### PR TITLE
LibWeb: Convert divisor to double in TableFormattingContext

### DIFF
--- a/Tests/LibWeb/Layout/expected/table/basic.txt
+++ b/Tests/LibWeb/Layout/expected/table/basic.txt
@@ -17,15 +17,15 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             TextNode <#text>
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <thead> at (8,10) content-size 95.171875x19.15625 table-header-group children: not-inline
+          Box <thead> at (8,10) content-size 95.171875x19.46875 table-header-group children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (10,29.46875) content-size 95.171875x19.15625 table-row children: not-inline
+            Box <tr> at (10,29.46875) content-size 95.171875x19.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,30.3125) content-size 93.171875x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (11,30.46875) content-size 93.171875x17.46875 table-cell [BFC] children: inline
                 line 0 width: 73.65625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 9, rect: [11,30.3125 73.65625x17.46875]
+                  frag 0 from TextNode start: 0, length: 9, rect: [11,30.46875 73.65625x17.46875]
                     "Head Cell"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -34,15 +34,15 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               TextNode <#text>
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tbody> at (8,29.15625) content-size 95.171875x19.15625 table-row-group children: not-inline
+          Box <tbody> at (8,29.46875) content-size 95.171875x19.46875 table-row-group children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (10,50.625) content-size 95.171875x19.15625 table-row children: not-inline
+            Box <tr> at (10,50.9375) content-size 95.171875x19.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,51.46875) content-size 93.171875x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (11,51.9375) content-size 93.171875x17.46875 table-cell [BFC] children: inline
                 line 0 width: 70.234375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 9, rect: [11,51.46875 70.234375x17.46875]
+                  frag 0 from TextNode start: 0, length: 9, rect: [11,51.9375 70.234375x17.46875]
                     "Body Cell"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -51,15 +51,15 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               TextNode <#text>
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tfoot> at (8,48.3125) content-size 95.171875x19.15625 table-footer-group children: not-inline
+          Box <tfoot> at (8,48.9375) content-size 95.171875x19.46875 table-footer-group children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (10,71.78125) content-size 95.171875x19.15625 table-row children: not-inline
+            Box <tr> at (10,72.40625) content-size 95.171875x19.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,72.625) content-size 93.171875x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (11,73.40625) content-size 93.171875x17.46875 table-cell [BFC] children: inline
                 line 0 width: 93.171875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 11, rect: [11,72.625 93.171875x17.46875]
+                  frag 0 from TextNode start: 0, length: 11, rect: [11,73.40625 93.171875x17.46875]
                     "Footer Cell"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline

--- a/Tests/LibWeb/Layout/expected/table/border-collapse-is-inherited.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-collapse-is-inherited.txt
@@ -14,133 +14,133 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             TextNode <#text>
           TableWrapper <(anonymous)> at (9,22.53125) content-size 158.90625x192.34375 inline-block [BFC] children: not-inline
             Box <(anonymous)> at (9,22.53125) content-size 158.90625x192.34375 inline-table table-box [TFC] children: not-inline
-              Box <tbody> at (9,22.53125) content-size 158.90625x180.3125 table-row-group children: not-inline
+              Box <tbody> at (9,22.53125) content-size 158.90625x192.34375 table-row-group children: not-inline
                 BlockContainer <(anonymous)> (not painted) children: inline
                   TextNode <#text>
-                Box <tr> at (9,22.53125) content-size 158.90625x36.0625 table-row children: not-inline
+                Box <tr> at (9,22.53125) content-size 158.90625x38.46875 table-row children: not-inline
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
-                  BlockContainer <td> at (29.5,31.828125) content-size 14.265625x17.46875 table-cell [BFC] children: inline
+                  BlockContainer <td> at (29.5,33.03125) content-size 14.265625x17.46875 table-cell [BFC] children: inline
                     line 0 width: 14.265625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                      frag 0 from TextNode start: 0, length: 1, rect: [29.5,31.828125 14.265625x17.46875]
+                      frag 0 from TextNode start: 0, length: 1, rect: [29.5,33.03125 14.265625x17.46875]
                         "A"
                     TextNode <#text>
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
-                  BlockContainer <td> at (84.765625,31.828125) content-size 12.546875x17.46875 table-cell [BFC] children: inline
+                  BlockContainer <td> at (84.765625,33.03125) content-size 12.546875x17.46875 table-cell [BFC] children: inline
                     line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                      frag 0 from TextNode start: 0, length: 1, rect: [86.359375,31.828125 9.34375x17.46875]
+                      frag 0 from TextNode start: 0, length: 1, rect: [86.359375,33.03125 9.34375x17.46875]
                         "B"
                     TextNode <#text>
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
-                  BlockContainer <td> at (138.3125,31.828125) content-size 9.09375x17.46875 table-cell [BFC] children: inline
+                  BlockContainer <td> at (138.3125,33.03125) content-size 9.09375x17.46875 table-cell [BFC] children: inline
                     line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                      frag 0 from TextNode start: 0, length: 1, rect: [139.6875,31.828125 6.34375x17.46875]
+                      frag 0 from TextNode start: 0, length: 1, rect: [139.6875,33.03125 6.34375x17.46875]
                         "1"
                     TextNode <#text>
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
                 BlockContainer <(anonymous)> (not painted) children: inline
                   TextNode <#text>
-                Box <tr> at (9,58.59375) content-size 158.90625x36.0625 table-row children: not-inline
+                Box <tr> at (9,61) content-size 158.90625x38.46875 table-row children: not-inline
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
-                  BlockContainer <td> at (29.5,67.890625) content-size 14.265625x17.46875 table-cell [BFC] children: inline
+                  BlockContainer <td> at (29.5,71.5) content-size 14.265625x17.46875 table-cell [BFC] children: inline
                     line 0 width: 10.3125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                      frag 0 from TextNode start: 0, length: 1, rect: [31.46875,67.890625 10.3125x17.46875]
+                      frag 0 from TextNode start: 0, length: 1, rect: [31.46875,71.5 10.3125x17.46875]
                         "C"
                     TextNode <#text>
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
-                  BlockContainer <td> at (84.765625,67.890625) content-size 12.546875x17.46875 table-cell [BFC] children: inline
+                  BlockContainer <td> at (84.765625,71.5) content-size 12.546875x17.46875 table-cell [BFC] children: inline
                     line 0 width: 11.140625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                      frag 0 from TextNode start: 0, length: 1, rect: [85.46875,67.890625 11.140625x17.46875]
+                      frag 0 from TextNode start: 0, length: 1, rect: [85.46875,71.5 11.140625x17.46875]
                         "D"
                     TextNode <#text>
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
-                  BlockContainer <td> at (138.3125,67.890625) content-size 9.09375x17.46875 table-cell [BFC] children: inline
+                  BlockContainer <td> at (138.3125,71.5) content-size 9.09375x17.46875 table-cell [BFC] children: inline
                     line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                      frag 0 from TextNode start: 0, length: 1, rect: [138.453125,67.890625 8.8125x17.46875]
+                      frag 0 from TextNode start: 0, length: 1, rect: [138.453125,71.5 8.8125x17.46875]
                         "2"
                     TextNode <#text>
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
                 BlockContainer <(anonymous)> (not painted) children: inline
                   TextNode <#text>
-                Box <tr> at (9,94.65625) content-size 158.90625x36.0625 table-row children: not-inline
+                Box <tr> at (9,99.46875) content-size 158.90625x38.46875 table-row children: not-inline
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
-                  BlockContainer <td> at (29.5,103.953125) content-size 14.265625x17.46875 table-cell [BFC] children: inline
+                  BlockContainer <td> at (29.5,109.96875) content-size 14.265625x17.46875 table-cell [BFC] children: inline
                     line 0 width: 11.859375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                      frag 0 from TextNode start: 0, length: 1, rect: [30.703125,103.953125 11.859375x17.46875]
+                      frag 0 from TextNode start: 0, length: 1, rect: [30.703125,109.96875 11.859375x17.46875]
                         "E"
                     TextNode <#text>
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
-                  BlockContainer <td> at (84.765625,103.953125) content-size 12.546875x17.46875 table-cell [BFC] children: inline
+                  BlockContainer <td> at (84.765625,109.96875) content-size 12.546875x17.46875 table-cell [BFC] children: inline
                     line 0 width: 12.546875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                      frag 0 from TextNode start: 0, length: 1, rect: [84.765625,103.953125 12.546875x17.46875]
+                      frag 0 from TextNode start: 0, length: 1, rect: [84.765625,109.96875 12.546875x17.46875]
                         "F"
                     TextNode <#text>
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
-                  BlockContainer <td> at (138.3125,103.953125) content-size 9.09375x17.46875 table-cell [BFC] children: inline
+                  BlockContainer <td> at (138.3125,109.96875) content-size 9.09375x17.46875 table-cell [BFC] children: inline
                     line 0 width: 9.09375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                      frag 0 from TextNode start: 0, length: 1, rect: [138.3125,103.953125 9.09375x17.46875]
+                      frag 0 from TextNode start: 0, length: 1, rect: [138.3125,109.96875 9.09375x17.46875]
                         "3"
                     TextNode <#text>
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
                 BlockContainer <(anonymous)> (not painted) children: inline
                   TextNode <#text>
-                Box <tr> at (9,130.71875) content-size 158.90625x36.0625 table-row children: not-inline
+                Box <tr> at (9,137.9375) content-size 158.90625x38.46875 table-row children: not-inline
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
-                  BlockContainer <td> at (29.5,140.015625) content-size 14.265625x17.46875 table-cell [BFC] children: inline
+                  BlockContainer <td> at (29.5,148.4375) content-size 14.265625x17.46875 table-cell [BFC] children: inline
                     line 0 width: 13.234375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                      frag 0 from TextNode start: 0, length: 1, rect: [30.015625,140.015625 13.234375x17.46875]
+                      frag 0 from TextNode start: 0, length: 1, rect: [30.015625,148.4375 13.234375x17.46875]
                         "G"
                     TextNode <#text>
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
-                  BlockContainer <td> at (84.765625,140.015625) content-size 12.546875x17.46875 table-cell [BFC] children: inline
+                  BlockContainer <td> at (84.765625,148.4375) content-size 12.546875x17.46875 table-cell [BFC] children: inline
                     line 0 width: 12.234375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                      frag 0 from TextNode start: 0, length: 1, rect: [84.921875,140.015625 12.234375x17.46875]
+                      frag 0 from TextNode start: 0, length: 1, rect: [84.921875,148.4375 12.234375x17.46875]
                         "H"
                     TextNode <#text>
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
-                  BlockContainer <td> at (138.3125,140.015625) content-size 9.09375x17.46875 table-cell [BFC] children: inline
+                  BlockContainer <td> at (138.3125,148.4375) content-size 9.09375x17.46875 table-cell [BFC] children: inline
                     line 0 width: 7.75, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                      frag 0 from TextNode start: 0, length: 1, rect: [138.984375,140.015625 7.75x17.46875]
+                      frag 0 from TextNode start: 0, length: 1, rect: [138.984375,148.4375 7.75x17.46875]
                         "4"
                     TextNode <#text>
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
                 BlockContainer <(anonymous)> (not painted) children: inline
                   TextNode <#text>
-                Box <tr> at (9,166.78125) content-size 158.90625x36.0625 table-row children: not-inline
+                Box <tr> at (9,176.40625) content-size 158.90625x38.46875 table-row children: not-inline
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
-                  BlockContainer <td> at (29.5,176.078125) content-size 14.265625x17.46875 table-cell [BFC] children: inline
+                  BlockContainer <td> at (29.5,186.90625) content-size 14.265625x17.46875 table-cell [BFC] children: inline
                     line 0 width: 4.59375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                      frag 0 from TextNode start: 0, length: 1, rect: [34.328125,176.078125 4.59375x17.46875]
+                      frag 0 from TextNode start: 0, length: 1, rect: [34.328125,186.90625 4.59375x17.46875]
                         "I"
                     TextNode <#text>
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
-                  BlockContainer <td> at (84.765625,176.078125) content-size 12.546875x17.46875 table-cell [BFC] children: inline
+                  BlockContainer <td> at (84.765625,186.90625) content-size 12.546875x17.46875 table-cell [BFC] children: inline
                     line 0 width: 8.90625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                      frag 0 from TextNode start: 0, length: 1, rect: [86.578125,176.078125 8.90625x17.46875]
+                      frag 0 from TextNode start: 0, length: 1, rect: [86.578125,186.90625 8.90625x17.46875]
                         "J"
                     TextNode <#text>
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
-                  BlockContainer <td> at (138.3125,176.078125) content-size 9.09375x17.46875 table-cell [BFC] children: inline
+                  BlockContainer <td> at (138.3125,186.90625) content-size 9.09375x17.46875 table-cell [BFC] children: inline
                     line 0 width: 8.453125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                      frag 0 from TextNode start: 0, length: 1, rect: [138.625,176.078125 8.453125x17.46875]
+                      frag 0 from TextNode start: 0, length: 1, rect: [138.625,186.90625 8.453125x17.46875]
                         "5"
                     TextNode <#text>
                   BlockContainer <(anonymous)> (not painted) children: inline

--- a/Tests/LibWeb/Layout/expected/table/border-conflict-resolution-with-col.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-conflict-resolution-with-col.txt
@@ -13,51 +13,51 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             BlockContainer <col> (not painted) children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tbody> at (8,8) content-size 59.265625x152.9375 table-row-group children: not-inline
+          Box <tbody> at (8,8) content-size 59.265625x157.875 table-row-group children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (8,8) content-size 59.265625x39.46875 table-row children: not-inline
+            Box <tr> at (8,8) content-size 59.265625x40.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (30.5,20) content-size 14.265625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (30.5,20.5) content-size 14.265625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 14.265625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [30.5,20 14.265625x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [30.5,20.5 14.265625x17.46875]
                     "A"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (8,47.46875) content-size 59.265625x37 table-row children: not-inline
+            Box <tr> at (8,48.46875) content-size 59.265625x38.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (30.5,57.234375) content-size 14.265625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (30.5,58.96875) content-size 14.265625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [30.5,57.234375 9.34375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [30.5,58.96875 9.34375x17.46875]
                     "B"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (8,84.46875) content-size 59.265625x37 table-row children: not-inline
+            Box <tr> at (8,86.9375) content-size 59.265625x38.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (30.5,94.234375) content-size 14.265625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (30.5,97.4375) content-size 14.265625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 10.3125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [30.5,94.234375 10.3125x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [30.5,97.4375 10.3125x17.46875]
                     "C"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (8,121.46875) content-size 59.265625x39.46875 table-row children: not-inline
+            Box <tr> at (8,125.40625) content-size 59.265625x40.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (30.5,131.46875) content-size 14.265625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (30.5,135.90625) content-size 14.265625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 11.140625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [30.5,131.46875 11.140625x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [30.5,135.90625 11.140625x17.46875]
                     "D"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline

--- a/Tests/LibWeb/Layout/expected/table/border-conflict-resolution-with-row.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-conflict-resolution-with-row.txt
@@ -5,60 +5,60 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         Box <table> at (8,8) content-size 112.8125x127.40625 table-box [TFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tbody> at (8,8) content-size 112.8125x125.390625 table-row-group children: not-inline
+          Box <tbody> at (8,8) content-size 112.8125x127.40625 table-row-group children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr.td-thick-border> at (8,8) content-size 112.8125x41.796875 table-row children: not-inline
+            Box <tr.td-thick-border> at (8,8) content-size 112.8125x42.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (30.5,20.171875) content-size 14.265625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (30.5,20.5) content-size 14.265625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 14.265625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [30.5,20.171875 14.265625x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [30.5,20.5 14.265625x17.46875]
                     "A"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (85.765625,20.171875) content-size 12.546875x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (85.765625,20.5) content-size 12.546875x17.46875 table-cell [BFC] children: inline
                 line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [85.765625,20.171875 9.34375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [85.765625,20.5 9.34375x17.46875]
                     "B"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (8,49.796875) content-size 112.8125x41.796875 table-row children: not-inline
+            Box <tr> at (8,50.46875) content-size 112.8125x42.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (28.5,61.96875) content-size 16.265625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (28.5,62.96875) content-size 16.265625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 10.3125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [28.5,61.96875 10.3125x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [28.5,62.96875 10.3125x17.46875]
                     "C"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (85.765625,61.96875) content-size 14.546875x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (85.765625,62.96875) content-size 14.546875x17.46875 table-cell [BFC] children: inline
                 line 0 width: 11.140625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [85.765625,61.96875 11.140625x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [85.765625,62.96875 11.140625x17.46875]
                     "D"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr.td-thick-border> at (8,91.59375) content-size 112.8125x41.796875 table-row children: not-inline
+            Box <tr.td-thick-border> at (8,92.9375) content-size 112.8125x42.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (30.5,103.765625) content-size 14.265625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (30.5,105.4375) content-size 14.265625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 11.859375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [30.5,103.765625 11.859375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [30.5,105.4375 11.859375x17.46875]
                     "E"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (85.765625,103.765625) content-size 12.546875x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (85.765625,105.4375) content-size 12.546875x17.46875 table-cell [BFC] children: inline
                 line 0 width: 12.546875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [85.765625,103.765625 12.546875x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [85.765625,105.4375 12.546875x17.46875]
                     "F"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline

--- a/Tests/LibWeb/Layout/expected/table/border-conflict-resolution-with-rowgroup.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-conflict-resolution-with-rowgroup.txt
@@ -5,61 +5,61 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         Box <table> at (8,8) content-size 111.40625x121.40625 table-box [TFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <thead> at (8,8) content-size 111.40625x39.828125 table-header-group children: not-inline
+          Box <thead> at (8,8) content-size 111.40625x40.46875 table-header-group children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (8,8) content-size 111.40625x39.828125 table-row children: not-inline
-              BlockContainer <td> at (28.5,18.1875) content-size 16.265625x17.46875 table-cell [BFC] children: inline
+            Box <tr> at (8,8) content-size 111.40625x40.46875 table-row children: not-inline
+              BlockContainer <td> at (28.5,18.5) content-size 16.265625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 9.59375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [28.5,18.1875 9.59375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [28.5,18.5 9.59375x17.46875]
                     "0"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (85.765625,18.1875) content-size 13.140625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (85.765625,18.5) content-size 13.140625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [85.765625,18.1875 6.34375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [85.765625,18.5 6.34375x17.46875]
                     "1"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tbody.thick-border> at (8,47.828125) content-size 111.40625x79.65625 table-row-group children: not-inline
+          Box <tbody.thick-border> at (8,48.46875) content-size 111.40625x80.9375 table-row-group children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (8,47.828125) content-size 111.40625x39.828125 table-row children: not-inline
+            Box <tr> at (8,48.46875) content-size 111.40625x40.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (30.5,60.015625) content-size 14.265625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (30.5,60.96875) content-size 14.265625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 14.265625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [30.5,60.015625 14.265625x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [30.5,60.96875 14.265625x17.46875]
                     "A"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (85.765625,60.015625) content-size 11.140625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (85.765625,60.96875) content-size 11.140625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [85.765625,60.015625 9.34375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [85.765625,60.96875 9.34375x17.46875]
                     "B"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (8,87.65625) content-size 111.40625x39.828125 table-row children: not-inline
+            Box <tr> at (8,88.9375) content-size 111.40625x40.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (30.5,97.84375) content-size 14.265625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (30.5,99.4375) content-size 14.265625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 10.3125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [30.5,97.84375 10.3125x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [30.5,99.4375 10.3125x17.46875]
                     "C"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (85.765625,97.84375) content-size 11.140625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (85.765625,99.4375) content-size 11.140625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 11.140625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [85.765625,97.84375 11.140625x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [85.765625,99.4375 11.140625x17.46875]
                     "D"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline

--- a/Tests/LibWeb/Layout/expected/table/border-spacing-colspan.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-spacing-colspan.txt
@@ -9,126 +9,126 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         Box <table> at (9,9) content-size 241.90625x257.34375 table-box [TFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tbody> at (9,9) content-size 161.90625x185 table-row-group children: not-inline
+          Box <tbody> at (9,9) content-size 161.90625x197.34375 table-row-group children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (29,19) content-size 161.90625x37 table-row children: not-inline
+            Box <tr> at (29,19) content-size 161.90625x39.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (50,28.765625) content-size 14.265625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (50,30) content-size 14.265625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 14.265625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [50,28.765625 14.265625x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [50,30 14.265625x17.46875]
                     "A"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (126.265625,28.765625) content-size 12.546875x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (126.265625,30) content-size 12.546875x17.46875 table-cell [BFC] children: inline
                 line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [127.859375,28.765625 9.34375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [127.859375,30 9.34375x17.46875]
                     "B"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (200.8125,28.765625) content-size 9.09375x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (200.8125,30) content-size 9.09375x17.46875 table-cell [BFC] children: inline
                 line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [202.1875,28.765625 6.34375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [202.1875,30 6.34375x17.46875]
                     "1"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (29,66) content-size 161.90625x37 table-row children: not-inline
+            Box <tr> at (29,68.46875) content-size 161.90625x39.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (50,75.765625) content-size 88.8125x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (50,79.46875) content-size 88.8125x17.46875 table-cell [BFC] children: inline
                 line 0 width: 10.3125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [89.25,75.765625 10.3125x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [89.25,79.46875 10.3125x17.46875]
                     "C"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (200.8125,75.765625) content-size 9.09375x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (200.8125,79.46875) content-size 9.09375x17.46875 table-cell [BFC] children: inline
                 line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [200.953125,75.765625 8.8125x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [200.953125,79.46875 8.8125x17.46875]
                     "2"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (29,113) content-size 161.90625x37 table-row children: not-inline
+            Box <tr> at (29,117.9375) content-size 161.90625x39.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (50,122.765625) content-size 14.265625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (50,128.9375) content-size 14.265625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 11.859375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [51.203125,122.765625 11.859375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [51.203125,128.9375 11.859375x17.46875]
                     "E"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (126.265625,122.765625) content-size 12.546875x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (126.265625,128.9375) content-size 12.546875x17.46875 table-cell [BFC] children: inline
                 line 0 width: 12.546875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [126.265625,122.765625 12.546875x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [126.265625,128.9375 12.546875x17.46875]
                     "F"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (200.8125,122.765625) content-size 9.09375x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (200.8125,128.9375) content-size 9.09375x17.46875 table-cell [BFC] children: inline
                 line 0 width: 9.09375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [200.8125,122.765625 9.09375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [200.8125,128.9375 9.09375x17.46875]
                     "3"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (29,160) content-size 161.90625x37 table-row children: not-inline
+            Box <tr> at (29,167.40625) content-size 161.90625x39.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (50,169.765625) content-size 14.265625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (50,178.40625) content-size 14.265625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 13.234375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [50.515625,169.765625 13.234375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [50.515625,178.40625 13.234375x17.46875]
                     "G"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (126.265625,169.765625) content-size 12.546875x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (126.265625,178.40625) content-size 12.546875x17.46875 table-cell [BFC] children: inline
                 line 0 width: 12.234375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [126.421875,169.765625 12.234375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [126.421875,178.40625 12.234375x17.46875]
                     "H"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (200.8125,169.765625) content-size 9.09375x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (200.8125,178.40625) content-size 9.09375x17.46875 table-cell [BFC] children: inline
                 line 0 width: 7.75, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [201.484375,169.765625 7.75x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [201.484375,178.40625 7.75x17.46875]
                     "4"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (29,207) content-size 161.90625x37 table-row children: not-inline
+            Box <tr> at (29,216.875) content-size 161.90625x39.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (50,216.765625) content-size 14.265625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (50,227.875) content-size 14.265625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 4.59375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [54.828125,216.765625 4.59375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [54.828125,227.875 4.59375x17.46875]
                     "I"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (126.265625,216.765625) content-size 12.546875x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (126.265625,227.875) content-size 12.546875x17.46875 table-cell [BFC] children: inline
                 line 0 width: 8.90625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [128.078125,216.765625 8.90625x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [128.078125,227.875 8.90625x17.46875]
                     "J"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (200.8125,216.765625) content-size 9.09375x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (200.8125,227.875) content-size 9.09375x17.46875 table-cell [BFC] children: inline
                 line 0 width: 8.453125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [201.125,216.765625 8.453125x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [201.125,227.875 8.453125x17.46875]
                     "5"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline

--- a/Tests/LibWeb/Layout/expected/table/border-spacing-rowspan.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-spacing-rowspan.txt
@@ -9,126 +9,126 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         Box <table> at (9,9) content-size 241.90625x257.34375 table-box [TFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tbody> at (9,9) content-size 161.90625x185 table-row-group children: not-inline
+          Box <tbody> at (9,9) content-size 161.90625x197.34375 table-row-group children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (29,19) content-size 161.90625x37 table-row children: not-inline
+            Box <tr> at (29,19) content-size 161.90625x39.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (50,52.265625) content-size 14.265625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (50,54.734375) content-size 14.265625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 14.265625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [50,52.265625 14.265625x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [50,54.734375 14.265625x17.46875]
                     "A"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (126.265625,28.765625) content-size 12.546875x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (126.265625,30) content-size 12.546875x17.46875 table-cell [BFC] children: inline
                 line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [127.859375,28.765625 9.34375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [127.859375,30 9.34375x17.46875]
                     "B"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (200.8125,28.765625) content-size 9.09375x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (200.8125,30) content-size 9.09375x17.46875 table-cell [BFC] children: inline
                 line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [202.1875,28.765625 6.34375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [202.1875,30 6.34375x17.46875]
                     "1"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (29,66) content-size 161.90625x37 table-row children: not-inline
+            Box <tr> at (29,68.46875) content-size 161.90625x39.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (126.265625,75.765625) content-size 12.546875x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (126.265625,79.46875) content-size 12.546875x17.46875 table-cell [BFC] children: inline
                 line 0 width: 11.140625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [126.96875,75.765625 11.140625x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [126.96875,79.46875 11.140625x17.46875]
                     "D"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (200.8125,75.765625) content-size 9.09375x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (200.8125,79.46875) content-size 9.09375x17.46875 table-cell [BFC] children: inline
                 line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [200.953125,75.765625 8.8125x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [200.953125,79.46875 8.8125x17.46875]
                     "2"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (29,113) content-size 161.90625x37 table-row children: not-inline
+            Box <tr> at (29,117.9375) content-size 161.90625x39.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (50,122.765625) content-size 14.265625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (50,128.9375) content-size 14.265625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 11.859375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [51.203125,122.765625 11.859375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [51.203125,128.9375 11.859375x17.46875]
                     "E"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (126.265625,122.765625) content-size 12.546875x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (126.265625,128.9375) content-size 12.546875x17.46875 table-cell [BFC] children: inline
                 line 0 width: 12.546875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [126.265625,122.765625 12.546875x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [126.265625,128.9375 12.546875x17.46875]
                     "F"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (200.8125,122.765625) content-size 9.09375x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (200.8125,128.9375) content-size 9.09375x17.46875 table-cell [BFC] children: inline
                 line 0 width: 9.09375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [200.8125,122.765625 9.09375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [200.8125,128.9375 9.09375x17.46875]
                     "3"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (29,160) content-size 161.90625x37 table-row children: not-inline
+            Box <tr> at (29,167.40625) content-size 161.90625x39.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (50,169.765625) content-size 14.265625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (50,178.40625) content-size 14.265625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 13.234375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [50.515625,169.765625 13.234375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [50.515625,178.40625 13.234375x17.46875]
                     "G"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (126.265625,169.765625) content-size 12.546875x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (126.265625,178.40625) content-size 12.546875x17.46875 table-cell [BFC] children: inline
                 line 0 width: 12.234375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [126.421875,169.765625 12.234375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [126.421875,178.40625 12.234375x17.46875]
                     "H"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (200.8125,169.765625) content-size 9.09375x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (200.8125,178.40625) content-size 9.09375x17.46875 table-cell [BFC] children: inline
                 line 0 width: 7.75, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [201.484375,169.765625 7.75x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [201.484375,178.40625 7.75x17.46875]
                     "4"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (29,207) content-size 161.90625x37 table-row children: not-inline
+            Box <tr> at (29,216.875) content-size 161.90625x39.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (50,216.765625) content-size 14.265625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (50,227.875) content-size 14.265625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 4.59375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [54.828125,216.765625 4.59375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [54.828125,227.875 4.59375x17.46875]
                     "I"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (126.265625,216.765625) content-size 12.546875x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (126.265625,227.875) content-size 12.546875x17.46875 table-cell [BFC] children: inline
                 line 0 width: 8.90625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [128.078125,216.765625 8.90625x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [128.078125,227.875 8.90625x17.46875]
                     "J"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (200.8125,216.765625) content-size 9.09375x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (200.8125,227.875) content-size 9.09375x17.46875 table-cell [BFC] children: inline
                 line 0 width: 8.453125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [201.125,216.765625 8.453125x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [201.125,227.875 8.453125x17.46875]
                     "5"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline

--- a/Tests/LibWeb/Layout/expected/table/border-spacing.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-spacing.txt
@@ -9,133 +9,133 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         Box <table> at (9,9) content-size 241.90625x257.34375 table-box [TFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tbody> at (9,9) content-size 161.90625x185 table-row-group children: not-inline
+          Box <tbody> at (9,9) content-size 161.90625x197.34375 table-row-group children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (29,19) content-size 161.90625x37 table-row children: not-inline
+            Box <tr> at (29,19) content-size 161.90625x39.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (50,28.765625) content-size 14.265625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (50,30) content-size 14.265625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 14.265625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [50,28.765625 14.265625x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [50,30 14.265625x17.46875]
                     "A"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (126.265625,28.765625) content-size 12.546875x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (126.265625,30) content-size 12.546875x17.46875 table-cell [BFC] children: inline
                 line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [127.859375,28.765625 9.34375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [127.859375,30 9.34375x17.46875]
                     "B"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (200.8125,28.765625) content-size 9.09375x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (200.8125,30) content-size 9.09375x17.46875 table-cell [BFC] children: inline
                 line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [202.1875,28.765625 6.34375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [202.1875,30 6.34375x17.46875]
                     "1"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (29,66) content-size 161.90625x37 table-row children: not-inline
+            Box <tr> at (29,68.46875) content-size 161.90625x39.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (50,75.765625) content-size 14.265625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (50,79.46875) content-size 14.265625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 10.3125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [51.96875,75.765625 10.3125x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [51.96875,79.46875 10.3125x17.46875]
                     "C"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (126.265625,75.765625) content-size 12.546875x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (126.265625,79.46875) content-size 12.546875x17.46875 table-cell [BFC] children: inline
                 line 0 width: 11.140625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [126.96875,75.765625 11.140625x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [126.96875,79.46875 11.140625x17.46875]
                     "D"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (200.8125,75.765625) content-size 9.09375x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (200.8125,79.46875) content-size 9.09375x17.46875 table-cell [BFC] children: inline
                 line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [200.953125,75.765625 8.8125x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [200.953125,79.46875 8.8125x17.46875]
                     "2"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (29,113) content-size 161.90625x37 table-row children: not-inline
+            Box <tr> at (29,117.9375) content-size 161.90625x39.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (50,122.765625) content-size 14.265625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (50,128.9375) content-size 14.265625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 11.859375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [51.203125,122.765625 11.859375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [51.203125,128.9375 11.859375x17.46875]
                     "E"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (126.265625,122.765625) content-size 12.546875x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (126.265625,128.9375) content-size 12.546875x17.46875 table-cell [BFC] children: inline
                 line 0 width: 12.546875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [126.265625,122.765625 12.546875x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [126.265625,128.9375 12.546875x17.46875]
                     "F"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (200.8125,122.765625) content-size 9.09375x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (200.8125,128.9375) content-size 9.09375x17.46875 table-cell [BFC] children: inline
                 line 0 width: 9.09375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [200.8125,122.765625 9.09375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [200.8125,128.9375 9.09375x17.46875]
                     "3"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (29,160) content-size 161.90625x37 table-row children: not-inline
+            Box <tr> at (29,167.40625) content-size 161.90625x39.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (50,169.765625) content-size 14.265625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (50,178.40625) content-size 14.265625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 13.234375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [50.515625,169.765625 13.234375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [50.515625,178.40625 13.234375x17.46875]
                     "G"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (126.265625,169.765625) content-size 12.546875x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (126.265625,178.40625) content-size 12.546875x17.46875 table-cell [BFC] children: inline
                 line 0 width: 12.234375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [126.421875,169.765625 12.234375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [126.421875,178.40625 12.234375x17.46875]
                     "H"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (200.8125,169.765625) content-size 9.09375x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (200.8125,178.40625) content-size 9.09375x17.46875 table-cell [BFC] children: inline
                 line 0 width: 7.75, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [201.484375,169.765625 7.75x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [201.484375,178.40625 7.75x17.46875]
                     "4"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (29,207) content-size 161.90625x37 table-row children: not-inline
+            Box <tr> at (29,216.875) content-size 161.90625x39.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (50,216.765625) content-size 14.265625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (50,227.875) content-size 14.265625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 4.59375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [54.828125,216.765625 4.59375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [54.828125,227.875 4.59375x17.46875]
                     "I"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (126.265625,216.765625) content-size 12.546875x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (126.265625,227.875) content-size 12.546875x17.46875 table-cell [BFC] children: inline
                 line 0 width: 8.90625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [128.078125,216.765625 8.90625x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [128.078125,227.875 8.90625x17.46875]
                     "J"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (200.8125,216.765625) content-size 9.09375x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (200.8125,227.875) content-size 9.09375x17.46875 table-cell [BFC] children: inline
                 line 0 width: 8.453125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [201.125,216.765625 8.453125x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [201.125,227.875 8.453125x17.46875]
                     "5"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline

--- a/Tests/LibWeb/Layout/expected/table/borders.txt
+++ b/Tests/LibWeb/Layout/expected/table/borders.txt
@@ -5,58 +5,58 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         Box <table.table-border-black> at (9,9) content-size 172.296875x72.40625 table-box [TFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tbody> at (9,9) content-size 166.296875x63.375 table-row-group children: not-inline
-            Box <tr> at (11,11) content-size 166.296875x21.125 table-row children: not-inline
+          Box <tbody> at (9,9) content-size 166.296875x64.40625 table-row-group children: not-inline
+            Box <tr> at (11,11) content-size 166.296875x21.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (13,12.828125) content-size 82.015625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (13,13) content-size 82.015625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 82.015625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 9, rect: [13,12.828125 82.015625x17.46875]
+                  frag 0 from TextNode start: 0, length: 9, rect: [13,13 82.015625x17.46875]
                     "Firstname"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (101.015625,12.828125) content-size 76.28125x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (101.015625,13) content-size 76.28125x17.46875 table-cell [BFC] children: inline
                 line 0 width: 76.28125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 8, rect: [101.015625,12.828125 76.28125x17.46875]
+                  frag 0 from TextNode start: 0, length: 8, rect: [101.015625,13 76.28125x17.46875]
                     "Lastname"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (11,34.125) content-size 166.296875x21.125 table-row children: not-inline
+            Box <tr> at (11,34.46875) content-size 166.296875x21.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (13,35.953125) content-size 82.015625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (13,36.46875) content-size 82.015625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 44.65625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 5, rect: [13,35.953125 44.65625x17.46875]
+                  frag 0 from TextNode start: 0, length: 5, rect: [13,36.46875 44.65625x17.46875]
                     "Peter"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (101.015625,35.953125) content-size 76.28125x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (101.015625,36.46875) content-size 76.28125x17.46875 table-cell [BFC] children: inline
                 line 0 width: 53.671875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 7, rect: [101.015625,35.953125 53.671875x17.46875]
+                  frag 0 from TextNode start: 0, length: 7, rect: [101.015625,36.46875 53.671875x17.46875]
                     "Griffin"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (11,57.25) content-size 166.296875x21.125 table-row children: not-inline
+            Box <tr> at (11,57.9375) content-size 166.296875x21.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (13,59.078125) content-size 82.015625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (13,59.9375) content-size 82.015625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 35.125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 4, rect: [13,59.078125 35.125x17.46875]
+                  frag 0 from TextNode start: 0, length: 4, rect: [13,59.9375 35.125x17.46875]
                     "Lois"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (101.015625,59.078125) content-size 76.28125x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (101.015625,59.9375) content-size 76.28125x17.46875 table-cell [BFC] children: inline
                 line 0 width: 53.671875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 7, rect: [101.015625,59.078125 53.671875x17.46875]
+                  frag 0 from TextNode start: 0, length: 7, rect: [101.015625,59.9375 53.671875x17.46875]
                     "Griffin"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -70,58 +70,58 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         Box <table.table-border-black> at (8,82.40625) content-size 163.296875x60.40625 table-box [TFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tbody> at (8,82.40625) content-size 163.296875x59.4375 table-row-group children: not-inline
-            Box <tr> at (8,82.40625) content-size 163.296875x19.8125 table-row children: not-inline
+          Box <tbody> at (8,82.40625) content-size 163.296875x60.40625 table-row-group children: not-inline
+            Box <tr> at (8,82.40625) content-size 163.296875x19.96875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (9,83.328125) content-size 82.015625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (9,83.40625) content-size 82.015625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 82.015625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 9, rect: [9,83.328125 82.015625x17.46875]
+                  frag 0 from TextNode start: 0, length: 9, rect: [9,83.40625 82.015625x17.46875]
                     "Firstname"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (94.015625,83.328125) content-size 76.28125x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (94.015625,83.40625) content-size 76.28125x17.46875 table-cell [BFC] children: inline
                 line 0 width: 76.28125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 8, rect: [94.015625,83.328125 76.28125x17.46875]
+                  frag 0 from TextNode start: 0, length: 8, rect: [94.015625,83.40625 76.28125x17.46875]
                     "Lastname"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (8,102.21875) content-size 163.296875x19.8125 table-row children: not-inline
+            Box <tr> at (8,102.375) content-size 163.296875x20.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (9,103.390625) content-size 82.015625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (9,103.875) content-size 82.015625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 44.65625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 5, rect: [9,103.390625 44.65625x17.46875]
+                  frag 0 from TextNode start: 0, length: 5, rect: [9,103.875 44.65625x17.46875]
                     "Peter"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (94.015625,103.390625) content-size 76.28125x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (94.015625,103.875) content-size 76.28125x17.46875 table-cell [BFC] children: inline
                 line 0 width: 53.671875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 7, rect: [94.015625,103.390625 53.671875x17.46875]
+                  frag 0 from TextNode start: 0, length: 7, rect: [94.015625,103.875 53.671875x17.46875]
                     "Griffin"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (8,122.03125) content-size 163.296875x19.8125 table-row children: not-inline
+            Box <tr> at (8,122.84375) content-size 163.296875x19.96875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (9,123.453125) content-size 82.015625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (9,124.34375) content-size 82.015625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 35.125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 4, rect: [9,123.453125 35.125x17.46875]
+                  frag 0 from TextNode start: 0, length: 4, rect: [9,124.34375 35.125x17.46875]
                     "Lois"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (94.015625,123.453125) content-size 76.28125x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (94.015625,124.34375) content-size 76.28125x17.46875 table-cell [BFC] children: inline
                 line 0 width: 53.671875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 7, rect: [94.015625,123.453125 53.671875x17.46875]
+                  frag 0 from TextNode start: 0, length: 7, rect: [94.015625,124.34375 53.671875x17.46875]
                     "Griffin"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -135,7 +135,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         Box <div.table.border-black> at (8,142.8125) content-size 159.296875x54.40625 table-box [TFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <div.table-row.border-black> at (8,142.8125) content-size 159.296875x17.84375 table-row children: not-inline
+          Box <div.table-row.border-black> at (8,142.8125) content-size 159.296875x17.96875 table-row children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
             BlockContainer <div.table-cell.border-black> at (8,142.8125) content-size 82.015625x17.46875 table-cell [BFC] children: inline
@@ -154,38 +154,38 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               TextNode <#text>
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <div.table-row.border-black> at (8,160.65625) content-size 159.296875x17.84375 table-row children: not-inline
+          Box <div.table-row.border-black> at (8,160.78125) content-size 159.296875x18.46875 table-row children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            BlockContainer <div.table-cell.border-black> at (8,161.15625) content-size 82.015625x17.46875 table-cell [BFC] children: inline
+            BlockContainer <div.table-cell.border-black> at (8,161.28125) content-size 82.015625x17.46875 table-cell [BFC] children: inline
               line 0 width: 44.65625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                frag 0 from TextNode start: 0, length: 5, rect: [8,161.15625 44.65625x17.46875]
+                frag 0 from TextNode start: 0, length: 5, rect: [8,161.28125 44.65625x17.46875]
                   "Peter"
               TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            BlockContainer <div.table-cell.border-black> at (91.015625,161.15625) content-size 76.28125x17.46875 table-cell [BFC] children: inline
+            BlockContainer <div.table-cell.border-black> at (91.015625,161.28125) content-size 76.28125x17.46875 table-cell [BFC] children: inline
               line 0 width: 53.671875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                frag 0 from TextNode start: 0, length: 7, rect: [91.015625,161.15625 53.671875x17.46875]
+                frag 0 from TextNode start: 0, length: 7, rect: [91.015625,161.28125 53.671875x17.46875]
                   "Griffin"
               TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <div.table-row.border-black> at (8,178.5) content-size 159.296875x17.84375 table-row children: not-inline
+          Box <div.table-row.border-black> at (8,179.25) content-size 159.296875x17.96875 table-row children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            BlockContainer <div.table-cell.border-black> at (8,179) content-size 82.015625x17.46875 table-cell [BFC] children: inline
+            BlockContainer <div.table-cell.border-black> at (8,179.75) content-size 82.015625x17.46875 table-cell [BFC] children: inline
               line 0 width: 35.125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                frag 0 from TextNode start: 0, length: 4, rect: [8,179 35.125x17.46875]
+                frag 0 from TextNode start: 0, length: 4, rect: [8,179.75 35.125x17.46875]
                   "Lois"
               TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            BlockContainer <div.table-cell.border-black> at (91.015625,179) content-size 76.28125x17.46875 table-cell [BFC] children: inline
+            BlockContainer <div.table-cell.border-black> at (91.015625,179.75) content-size 76.28125x17.46875 table-cell [BFC] children: inline
               line 0 width: 53.671875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                frag 0 from TextNode start: 0, length: 7, rect: [91.015625,179 53.671875x17.46875]
+                frag 0 from TextNode start: 0, length: 7, rect: [91.015625,179.75 53.671875x17.46875]
                   "Griffin"
               TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -199,7 +199,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         Box <div.table.thick-border-black> at (8,197.21875) content-size 168.296875x72.40625 table-box [TFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <div.table-row.thick-border-black> at (8,197.21875) content-size 168.296875x21.484375 table-row children: not-inline
+          Box <div.table-row.thick-border-black> at (8,197.21875) content-size 168.296875x22.46875 table-row children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
             BlockContainer <div.table-cell.thick-border-black> at (8,197.21875) content-size 82.015625x17.46875 table-cell [BFC] children: inline
@@ -218,38 +218,38 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               TextNode <#text>
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <div.table-row.thick-border-black> at (8,218.703125) content-size 168.296875x27.140625 table-row children: not-inline
+          Box <div.table-row.thick-border-black> at (8,219.6875) content-size 168.296875x27.46875 table-row children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            BlockContainer <div.table-cell.thick-border-black> at (8,223.703125) content-size 82.015625x17.46875 table-cell [BFC] children: inline
+            BlockContainer <div.table-cell.thick-border-black> at (8,224.6875) content-size 82.015625x17.46875 table-cell [BFC] children: inline
               line 0 width: 44.65625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                frag 0 from TextNode start: 0, length: 5, rect: [8,223.703125 44.65625x17.46875]
+                frag 0 from TextNode start: 0, length: 5, rect: [8,224.6875 44.65625x17.46875]
                   "Peter"
               TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            BlockContainer <div.table-cell.thick-border-black> at (100.015625,223.703125) content-size 76.28125x17.46875 table-cell [BFC] children: inline
+            BlockContainer <div.table-cell.thick-border-black> at (100.015625,224.6875) content-size 76.28125x17.46875 table-cell [BFC] children: inline
               line 0 width: 53.671875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                frag 0 from TextNode start: 0, length: 7, rect: [100.015625,223.703125 53.671875x17.46875]
+                frag 0 from TextNode start: 0, length: 7, rect: [100.015625,224.6875 53.671875x17.46875]
                   "Griffin"
               TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <div.table-row.thick-border-black> at (8,245.84375) content-size 168.296875x21.484375 table-row children: not-inline
+          Box <div.table-row.thick-border-black> at (8,247.15625) content-size 168.296875x22.46875 table-row children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            BlockContainer <div.table-cell.thick-border-black> at (8,250.84375) content-size 82.015625x17.46875 table-cell [BFC] children: inline
+            BlockContainer <div.table-cell.thick-border-black> at (8,252.15625) content-size 82.015625x17.46875 table-cell [BFC] children: inline
               line 0 width: 35.125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                frag 0 from TextNode start: 0, length: 4, rect: [8,250.84375 35.125x17.46875]
+                frag 0 from TextNode start: 0, length: 4, rect: [8,252.15625 35.125x17.46875]
                   "Lois"
               TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            BlockContainer <div.table-cell.thick-border-black> at (100.015625,250.84375) content-size 76.28125x17.46875 table-cell [BFC] children: inline
+            BlockContainer <div.table-cell.thick-border-black> at (100.015625,252.15625) content-size 76.28125x17.46875 table-cell [BFC] children: inline
               line 0 width: 53.671875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                frag 0 from TextNode start: 0, length: 7, rect: [100.015625,250.84375 53.671875x17.46875]
+                frag 0 from TextNode start: 0, length: 7, rect: [100.015625,252.15625 53.671875x17.46875]
                   "Griffin"
               TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline

--- a/Tests/LibWeb/Layout/expected/table/bottom-caption.txt
+++ b/Tests/LibWeb/Layout/expected/table/bottom-caption.txt
@@ -14,15 +14,15 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             TextNode <#text>
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <thead> at (8,8) content-size 95.171875x19.15625 table-header-group children: not-inline
+          Box <thead> at (8,8) content-size 95.171875x19.46875 table-header-group children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (10,10) content-size 95.171875x19.15625 table-row children: not-inline
+            Box <tr> at (10,10) content-size 95.171875x19.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,10.84375) content-size 93.171875x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (11,11) content-size 93.171875x17.46875 table-cell [BFC] children: inline
                 line 0 width: 73.65625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 9, rect: [11,10.84375 73.65625x17.46875]
+                  frag 0 from TextNode start: 0, length: 9, rect: [11,11 73.65625x17.46875]
                     "Head Cell"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -31,15 +31,15 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               TextNode <#text>
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tbody> at (8,27.15625) content-size 95.171875x19.15625 table-row-group children: not-inline
+          Box <tbody> at (8,27.46875) content-size 95.171875x19.46875 table-row-group children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (10,31.15625) content-size 95.171875x19.15625 table-row children: not-inline
+            Box <tr> at (10,31.46875) content-size 95.171875x19.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,32) content-size 93.171875x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (11,32.46875) content-size 93.171875x17.46875 table-cell [BFC] children: inline
                 line 0 width: 70.234375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 9, rect: [11,32 70.234375x17.46875]
+                  frag 0 from TextNode start: 0, length: 9, rect: [11,32.46875 70.234375x17.46875]
                     "Body Cell"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -48,15 +48,15 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               TextNode <#text>
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tfoot> at (8,46.3125) content-size 95.171875x19.15625 table-footer-group children: not-inline
+          Box <tfoot> at (8,46.9375) content-size 95.171875x19.46875 table-footer-group children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (10,52.3125) content-size 95.171875x19.15625 table-row children: not-inline
+            Box <tr> at (10,52.9375) content-size 95.171875x19.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,53.15625) content-size 93.171875x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (11,53.9375) content-size 93.171875x17.46875 table-cell [BFC] children: inline
                 line 0 width: 93.171875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 11, rect: [11,53.15625 93.171875x17.46875]
+                  frag 0 from TextNode start: 0, length: 11, rect: [11,53.9375 93.171875x17.46875]
                     "Footer Cell"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline

--- a/Tests/LibWeb/Layout/expected/table/clip-spans-to-table-end.txt
+++ b/Tests/LibWeb/Layout/expected/table/clip-spans-to-table-end.txt
@@ -5,58 +5,58 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         Box <table> at (8,8) content-size 89.359375x115.40625 table-box [TFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tbody> at (8,8) content-size 89.359375x113.578125 table-row-group children: not-inline
-            Box <tr> at (8,8) content-size 89.359375x37.859375 table-row children: not-inline
+          Box <tbody> at (8,8) content-size 89.359375x115.40625 table-row-group children: not-inline
+            Box <tr> at (8,8) content-size 89.359375x38.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (18.5,18.203125) content-size 8.453125x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (18.5,18.5) content-size 8.453125x17.46875 table-cell [BFC] children: inline
                 line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [18.5,18.203125 6.34375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [18.5,18.5 6.34375x17.46875]
                     "1"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (47.953125,18.203125) content-size 8.8125x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (47.953125,18.5) content-size 8.8125x17.46875 table-cell [BFC] children: inline
                 line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [47.953125,18.203125 8.8125x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [47.953125,18.5 8.8125x17.46875]
                     "2"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (77.765625,18.203125) content-size 9.09375x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (77.765625,18.5) content-size 9.09375x17.46875 table-cell [BFC] children: inline
                 line 0 width: 9.09375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [77.765625,18.203125 9.09375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [77.765625,18.5 9.09375x17.46875]
                     "3"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (8,45.859375) content-size 89.359375x37.859375 table-row children: not-inline
+            Box <tr> at (8,46.46875) content-size 89.359375x38.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (18.5,56.0625) content-size 8.453125x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (18.5,56.96875) content-size 8.453125x17.46875 table-cell [BFC] children: inline
                 line 0 width: 7.75, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [18.5,56.0625 7.75x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [18.5,56.96875 7.75x17.46875]
                     "4"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (47.953125,74.984375) content-size 38.90625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (47.953125,76.203125) content-size 38.90625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 24.046875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 3, rect: [47.953125,74.984375 24.046875x17.46875]
+                  frag 0 from TextNode start: 0, length: 3, rect: [47.953125,76.203125 24.046875x17.46875]
                     "6-9"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (8,83.71875) content-size 89.359375x37.859375 table-row children: not-inline
+            Box <tr> at (8,84.9375) content-size 89.359375x38.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (18.5,93.921875) content-size 8.453125x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (18.5,95.4375) content-size 8.453125x17.46875 table-cell [BFC] children: inline
                 line 0 width: 8.453125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [18.5,93.921875 8.453125x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [18.5,95.4375 8.453125x17.46875]
                     "5"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline

--- a/Tests/LibWeb/Layout/expected/table/colspan-width-distribution.txt
+++ b/Tests/LibWeb/Layout/expected/table/colspan-width-distribution.txt
@@ -5,34 +5,34 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x44.9375 children: not-inline
       BlockContainer <(anonymous)> at (8,8) content-size 784x0 children: inline
         TextNode <#text>
-      TableWrapper <(anonymous)> at (8,8) content-size 39.203125x44.9375 [BFC] children: not-inline
-        Box <table> at (9,9) content-size 37.203125x42.9375 table-box [TFC] children: not-inline
+      TableWrapper <(anonymous)> at (8,8) content-size 39.296875x44.9375 [BFC] children: not-inline
+        Box <table> at (9,9) content-size 37.296875x42.9375 table-box [TFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tbody> at (9,9) content-size 37.203125x42.9375 table-row-group children: not-inline
-            Box <tr> at (9,9) content-size 37.203125x21.46875 table-row children: not-inline
+          Box <tbody> at (9,9) content-size 37.296875x42.9375 table-row-group children: not-inline
+            Box <tr> at (9,9) content-size 37.296875x21.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,11) content-size 17.46875x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (11,11) content-size 17.546875x17.46875 table-cell [BFC] children: inline
                 line 0 width: 14.265625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [12.59375,11 14.265625x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [12.640625,11 14.265625x17.46875]
                     "A"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (32.46875,11) content-size 11.734375x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (32.546875,11) content-size 11.75x17.46875 table-cell [BFC] children: inline
                 line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [33.65625,11 9.34375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [33.75,11 9.34375x17.46875]
                     "B"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (9,30.46875) content-size 37.203125x21.46875 table-row children: not-inline
+            Box <tr> at (9,30.46875) content-size 37.296875x21.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,32.46875) content-size 33.203125x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (11,32.46875) content-size 33.296875x17.46875 table-cell [BFC] children: inline
                 line 0 width: 33.3125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
                   frag 0 from TextNode start: 0, length: 3, rect: [11,32.46875 33.3125x17.46875]
                     "CDE"

--- a/Tests/LibWeb/Layout/expected/table/columns-width-distribution-1.txt
+++ b/Tests/LibWeb/Layout/expected/table/columns-width-distribution-1.txt
@@ -5,11 +5,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         Box <table.ambox> at (9,9) content-size 784x110.8125 table-box [TFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tbody> at (9,9) content-size 776.453125x106.8125 table-row-group children: not-inline
-            Box <tr> at (11,11) content-size 776.453125x106.8125 table-row children: not-inline
+          Box <tbody> at (9,9) content-size 778x106.8125 table-row-group children: not-inline
+            Box <tr> at (11,11) content-size 778x106.8125 table-row children: not-inline
               BlockContainer <td.mbox-image> at (12,39.40625) content-size 50x50 table-cell [BFC] children: not-inline
                 BlockContainer <div.mbox-image-div> at (12,39.40625) content-size 50x50 children: not-inline
-              BlockContainer <td.mbox-text> at (66,12) content-size 722.453125x104.8125 table-cell [BFC] children: inline
+              BlockContainer <td.mbox-text> at (66,12) content-size 724x104.8125 table-cell [BFC] children: inline
                 line 0 width: 689.640625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
                   frag 0 from TextNode start: 1, length: 84, rect: [66,12 689.640625x17.46875]
                     "In a scene set in a lawyer's office, the lawyer sits alone and bounces a rubber ball"

--- a/Tests/LibWeb/Layout/expected/table/fixed-margins.txt
+++ b/Tests/LibWeb/Layout/expected/table/fixed-margins.txt
@@ -4,8 +4,8 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <div.wrapper> at (8,8) content-size 784x34.9375 children: not-inline
         TableWrapper <(anonymous)> at (108,8) content-size 584x34.9375 [BFC] children: not-inline
           Box <div.box> at (108,8) content-size 584x34.9375 table-box [TFC] children: not-inline
-            Box <(anonymous)> at (108,8) content-size 575.171875x34.9375 table-row children: not-inline
-              BlockContainer <div.cell> at (108,8) content-size 575.171875x34.9375 table-cell [BFC] children: inline
+            Box <(anonymous)> at (108,8) content-size 584x34.9375 table-row children: not-inline
+              BlockContainer <div.cell> at (108,8) content-size 584x34.9375 table-cell [BFC] children: inline
                 line 0 width: 569.859375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
                   frag 0 from TextNode start: 0, length: 58, rect: [108,8 569.859375x17.46875]
                     "DaTa DisplaYiNg CSS WeBpaGE ScReEn OF aR AddITioN COmmOnLY"

--- a/Tests/LibWeb/Layout/expected/table/long-caption-increases-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/long-caption-increases-width.txt
@@ -17,22 +17,22 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             TextNode <#text>
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <thead> at (10,10) content-size 53.03125x21.125 table-header-group children: not-inline
+          Box <thead> at (10,10) content-size 53.03125x21.46875 table-header-group children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (12,44.9375) content-size 53.03125x21.125 table-row children: not-inline
+            Box <tr> at (12,44.9375) content-size 53.03125x21.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (14,46.765625) content-size 21.25x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (14,46.9375) content-size 21.25x17.46875 table-cell [BFC] children: inline
                 line 0 width: 20.609375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 2, rect: [14,46.765625 20.609375x17.46875]
+                  frag 0 from TextNode start: 0, length: 2, rect: [14,46.9375 20.609375x17.46875]
                     "A1"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (41.25,46.765625) content-size 23.78125x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (41.25,46.9375) content-size 23.78125x17.46875 table-cell [BFC] children: inline
                 line 0 width: 23.078125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 2, rect: [41.25,46.765625 23.078125x17.46875]
+                  frag 0 from TextNode start: 0, length: 2, rect: [41.25,46.9375 23.078125x17.46875]
                     "A2"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -41,22 +41,22 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               TextNode <#text>
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tbody> at (10,31.125) content-size 53.03125x21.125 table-row-group children: not-inline
+          Box <tbody> at (10,31.46875) content-size 53.03125x21.46875 table-row-group children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (12,68.0625) content-size 53.03125x21.125 table-row children: not-inline
+            Box <tr> at (12,68.40625) content-size 53.03125x21.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (14,69.890625) content-size 21.25x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (14,70.40625) content-size 21.25x17.46875 table-cell [BFC] children: inline
                 line 0 width: 15.6875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 2, rect: [14,69.890625 15.6875x17.46875]
+                  frag 0 from TextNode start: 0, length: 2, rect: [14,70.40625 15.6875x17.46875]
                     "B1"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (41.25,69.890625) content-size 23.78125x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (41.25,70.40625) content-size 23.78125x17.46875 table-cell [BFC] children: inline
                 line 0 width: 18.15625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 2, rect: [41.25,69.890625 18.15625x17.46875]
+                  frag 0 from TextNode start: 0, length: 2, rect: [41.25,70.40625 18.15625x17.46875]
                     "B2"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -65,22 +65,22 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               TextNode <#text>
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tfoot> at (10,52.25) content-size 53.03125x21.125 table-footer-group children: not-inline
+          Box <tfoot> at (10,52.9375) content-size 53.03125x21.46875 table-footer-group children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (12,91.1875) content-size 53.03125x21.125 table-row children: not-inline
+            Box <tr> at (12,91.875) content-size 53.03125x21.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (14,93.015625) content-size 21.25x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (14,93.875) content-size 21.25x17.46875 table-cell [BFC] children: inline
                 line 0 width: 18.890625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 2, rect: [14,93.015625 18.890625x17.46875]
+                  frag 0 from TextNode start: 0, length: 2, rect: [14,93.875 18.890625x17.46875]
                     "F1"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (41.25,93.015625) content-size 23.78125x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (41.25,93.875) content-size 23.78125x17.46875 table-cell [BFC] children: inline
                 line 0 width: 21.359375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 2, rect: [41.25,93.015625 21.359375x17.46875]
+                  frag 0 from TextNode start: 0, length: 2, rect: [41.25,93.875 21.359375x17.46875]
                     "F2"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline

--- a/Tests/LibWeb/Layout/expected/table/multi-line-cell.txt
+++ b/Tests/LibWeb/Layout/expected/table/multi-line-cell.txt
@@ -5,22 +5,22 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         Box <table> at (9,9) content-size 79.4375x83.875 table-box [TFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tbody> at (9,9) content-size 75.4375x76.640625 table-row-group children: not-inline
-            Box <tr> at (11,11) content-size 75.4375x20.671875 table-row children: not-inline
-              BlockContainer <td> at (13,12.609375) content-size 71.4375x17.46875 table-cell [BFC] children: inline
+          Box <tbody> at (9,9) content-size 75.4375x77.859375 table-row-group children: not-inline
+            Box <tr> at (11,11) content-size 75.4375x21.453125 table-row children: not-inline
+              BlockContainer <td> at (13,13) content-size 71.4375x17.46875 table-cell [BFC] children: inline
                 line 0 width: 7.9375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [13,12.609375 7.9375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [13,13 7.9375x17.46875]
                     "*"
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (11,33.671875) content-size 75.4375x55.96875 table-row children: not-inline
-              BlockContainer <td> at (13,44.1875) content-size 71.4375x34.9375 table-cell [BFC] children: inline
+            Box <tr> at (11,34.453125) content-size 75.4375x56.40625 table-row children: not-inline
+              BlockContainer <td> at (13,45.1875) content-size 71.4375x34.9375 table-cell [BFC] children: inline
                 line 0 width: 71.4375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 9, rect: [13,44.1875 71.4375x17.46875]
+                  frag 0 from TextNode start: 0, length: 9, rect: [13,45.1875 71.4375x17.46875]
                     "*********"
                 line 1 width: 63.5625, height: 17.46875, bottom: 34.9375, baseline: 13.53125
-                  frag 0 from TextNode start: 10, length: 8, rect: [13,61.65625 63.5625x17.46875]
+                  frag 0 from TextNode start: 10, length: 8, rect: [13,62.65625 63.5625x17.46875]
                     "***** **"
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline

--- a/Tests/LibWeb/Layout/expected/table/row-span-and-nested-tables.txt
+++ b/Tests/LibWeb/Layout/expected/table/row-span-and-nested-tables.txt
@@ -29,39 +29,39 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                   Box <table> at (43.5625,18) content-size 30.265625x96.40625 table-box [TFC] children: not-inline
                     BlockContainer <(anonymous)> (not painted) children: inline
                       TextNode <#text>
-                    Box <tbody> at (43.5625,18) content-size 26.265625x87 table-row-group children: not-inline
+                    Box <tbody> at (43.5625,18) content-size 26.265625x88.40625 table-row-group children: not-inline
                       BlockContainer <(anonymous)> (not painted) children: inline
                         TextNode <#text>
-                      Box <tr> at (45.5625,20) content-size 26.265625x29 table-row children: not-inline
+                      Box <tr> at (45.5625,20) content-size 26.265625x29.46875 table-row children: not-inline
                         BlockContainer <(anonymous)> (not painted) children: inline
                           TextNode <#text>
-                        BlockContainer <td> at (51.5625,25.765625) content-size 14.265625x17.46875 table-cell [BFC] children: inline
+                        BlockContainer <td> at (51.5625,26) content-size 14.265625x17.46875 table-cell [BFC] children: inline
                           line 0 width: 14.265625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                            frag 0 from TextNode start: 0, length: 1, rect: [51.5625,25.765625 14.265625x17.46875]
+                            frag 0 from TextNode start: 0, length: 1, rect: [51.5625,26 14.265625x17.46875]
                               "A"
                           TextNode <#text>
                         BlockContainer <(anonymous)> (not painted) children: inline
                           TextNode <#text>
                       BlockContainer <(anonymous)> (not painted) children: inline
                         TextNode <#text>
-                      Box <tr> at (45.5625,51) content-size 26.265625x29 table-row children: not-inline
+                      Box <tr> at (45.5625,51.46875) content-size 26.265625x29.46875 table-row children: not-inline
                         BlockContainer <(anonymous)> (not painted) children: inline
                           TextNode <#text>
-                        BlockContainer <td> at (51.5625,56.765625) content-size 14.265625x17.46875 table-cell [BFC] children: inline
+                        BlockContainer <td> at (51.5625,57.46875) content-size 14.265625x17.46875 table-cell [BFC] children: inline
                           line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                            frag 0 from TextNode start: 0, length: 1, rect: [51.5625,56.765625 9.34375x17.46875]
+                            frag 0 from TextNode start: 0, length: 1, rect: [51.5625,57.46875 9.34375x17.46875]
                               "B"
                           TextNode <#text>
                         BlockContainer <(anonymous)> (not painted) children: inline
                           TextNode <#text>
                       BlockContainer <(anonymous)> (not painted) children: inline
                         TextNode <#text>
-                      Box <tr> at (45.5625,82) content-size 26.265625x29 table-row children: not-inline
+                      Box <tr> at (45.5625,82.9375) content-size 26.265625x29.46875 table-row children: not-inline
                         BlockContainer <(anonymous)> (not painted) children: inline
                           TextNode <#text>
-                        BlockContainer <td> at (51.5625,87.765625) content-size 14.265625x17.46875 table-cell [BFC] children: inline
+                        BlockContainer <td> at (51.5625,88.9375) content-size 14.265625x17.46875 table-cell [BFC] children: inline
                           line 0 width: 10.3125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                            frag 0 from TextNode start: 0, length: 1, rect: [51.5625,87.765625 10.3125x17.46875]
+                            frag 0 from TextNode start: 0, length: 1, rect: [51.5625,88.9375 10.3125x17.46875]
                               "C"
                           TextNode <#text>
                         BlockContainer <(anonymous)> (not painted) children: inline

--- a/Tests/LibWeb/Layout/expected/table/rows-height-distribution-1.txt
+++ b/Tests/LibWeb/Layout/expected/table/rows-height-distribution-1.txt
@@ -3,7 +3,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x150 children: not-inline
       TableWrapper <(anonymous)> at (8,8) content-size 200x150 [BFC] children: not-inline
         Box <div.table> at (8,8) content-size 200x150 table-box [TFC] children: not-inline
-          Box <div.row.a> at (8,8) content-size 200x49.21875 table-row children: not-inline
+          Box <div.row.a> at (8,8) content-size 200x50 table-row children: not-inline
             BlockContainer <div.cell> at (8,8) content-size 200x0 table-cell [BFC] children: not-inline
-          Box <div.row.b> at (8,57.21875) content-size 200x98.4375 table-row children: not-inline
-            BlockContainer <div.cell> at (8,57.21875) content-size 200x0 table-cell [BFC] children: not-inline
+          Box <div.row.b> at (8,58) content-size 200x100 table-row children: not-inline
+            BlockContainer <div.cell> at (8,58) content-size 200x0 table-cell [BFC] children: not-inline

--- a/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -408,13 +408,13 @@ void TableFormattingContext::compute_intrinsic_percentage(size_t max_cell_span)
                 //    columns spanned by the cell that have an intrinsic percentage width of the column based on cells of span up to N-1 equal to 0%.
                 CSSPixels ajusted_cell_contribution;
                 if (width_sum_of_columns_with_zero_intrinsic_percentage != 0) {
-                    ajusted_cell_contribution = cell_contribution * rows_or_columns[rc_index].max_size / width_sum_of_columns_with_zero_intrinsic_percentage;
+                    ajusted_cell_contribution = cell_contribution * rows_or_columns[rc_index].max_size / static_cast<double>(width_sum_of_columns_with_zero_intrinsic_percentage);
                 } else {
                     // However, if this ratio is undefined because the denominator is zero, instead use the 1 divided by the number of columns
                     // spanned by the cell that have an intrinsic percentage width of the column based on cells of span up to N-1 equal to zero.
                     ajusted_cell_contribution = cell_contribution * 1 / number_of_columns_with_zero_intrinsic_percentage;
                 }
-                intrinsic_percentage_contribution_by_index[rc_index] = max(ajusted_cell_contribution.to_double(), intrinsic_percentage_contribution_by_index[rc_index]);
+                intrinsic_percentage_contribution_by_index[rc_index] = max(static_cast<double>(ajusted_cell_contribution), intrinsic_percentage_contribution_by_index[rc_index]);
             }
         }
         for (size_t rc_index = 0; rc_index < rows_or_columns.size(); ++rc_index) {
@@ -486,7 +486,7 @@ void TableFormattingContext::compute_table_measures()
                     // - the outer min-content size of the cell minus the baseline min-content size and the baseline border spacing, clamped
                     //   to be at least 0 and at most the difference between the baseline max-content size and the baseline min-content size
                     auto normalized_max_min_diff = baseline_max_content_size != baseline_min_content_size
-                        ? (rows_or_columns[rc_index].max_size - rows_or_columns[rc_index].min_size) / (baseline_max_content_size - baseline_min_content_size)
+                        ? (rows_or_columns[rc_index].max_size - rows_or_columns[rc_index].min_size) / static_cast<double>(baseline_max_content_size - baseline_min_content_size)
                         : 0;
                     auto clamped_diff_to_baseline_min = min(
                         max(cell_min_size<RowOrColumn>(cell) - baseline_min_content_size - baseline_border_spacing, 0),
@@ -495,7 +495,7 @@ void TableFormattingContext::compute_table_measures()
                     // the product of:
                     // - the ratio of the max-content size based on cells of span up to N-1 of the column to the baseline max-content size
                     // - the outer min-content size of the cell minus the baseline max-content size and baseline border spacing, or 0 if this is negative
-                    cell_min_contribution += (rows_or_columns[rc_index].max_size / baseline_max_content_size)
+                    cell_min_contribution += (rows_or_columns[rc_index].max_size / static_cast<double>(baseline_max_content_size))
                         * max(CSSPixels(0), cell_min_size<RowOrColumn>(cell) - baseline_max_content_size - baseline_border_spacing);
 
                     // The contribution of the cell is the sum of:
@@ -504,7 +504,7 @@ void TableFormattingContext::compute_table_measures()
                     // and the product of:
                     // - the ratio of the max-content size based on cells of span up to N-1 of the column to the baseline max-content size
                     // - the outer max-content size of the cell minus the baseline max-content size and the baseline border spacing, or 0 if this is negative
-                    cell_max_contribution += (rows_or_columns[rc_index].max_size / baseline_max_content_size)
+                    cell_max_contribution += (rows_or_columns[rc_index].max_size / static_cast<double>(baseline_max_content_size))
                         * max(CSSPixels(0), cell_max_size<RowOrColumn>(cell) - baseline_max_content_size - baseline_border_spacing);
                     cell_min_contributions_by_rc_index[rc_index].append(cell_min_contribution);
                     cell_max_contributions_by_rc_index[rc_index].append(cell_max_contribution);
@@ -645,7 +645,7 @@ void TableFormattingContext::assign_columns_width_linear_combination(Vector<CSSP
     if (columns_total_candidate_width == columns_total_used_width) {
         return;
     }
-    auto candidate_weight = ((available_width - columns_total_used_width) / (columns_total_candidate_width - columns_total_used_width)).to_double();
+    auto candidate_weight = (available_width - columns_total_used_width) / static_cast<double>(columns_total_candidate_width - columns_total_used_width);
     for (size_t i = 0; i < m_columns.size(); ++i) {
         auto& column = m_columns[i];
         column.used_width = candidate_weight * candidate_widths[i] + (1 - candidate_weight) * column.used_width;
@@ -669,7 +669,7 @@ bool TableFormattingContext::distribute_excess_width_proportionally_to_max_width
     VERIFY(total_max_width > 0);
     for (auto& column : m_columns) {
         if (column_filter(column)) {
-            column.used_width += excess_width * column.max_size / total_max_width;
+            column.used_width += excess_width * column.max_size / static_cast<double>(total_max_width);
         }
     }
     return true;
@@ -1048,7 +1048,7 @@ void TableFormattingContext::distribute_height_to_rows()
         // will be the weighted mean of the base and the reference size that yields the correct total height.
 
         for (auto& row : m_rows) {
-            auto weight = row.reference_height / sum_reference_height;
+            auto weight = row.reference_height / static_cast<double>(sum_reference_height);
             auto final_height = m_table_height * weight;
             row.final_height = final_height;
         }


### PR DESCRIPTION
Improves precision of height and width distribution.