### PR TITLE
FileManager: Add file properties tabs for ZIP and PDF files

### DIFF
--- a/Userland/Applications/FileManager/CMakeLists.txt
+++ b/Userland/Applications/FileManager/CMakeLists.txt
@@ -12,6 +12,7 @@ compile_gml(PropertiesWindowAudioTab.gml PropertiesWindowAudioTabGML.h propertie
 compile_gml(PropertiesWindowFontTab.gml PropertiesWindowFontTabGML.h properties_window_font_tab_gml)
 compile_gml(PropertiesWindowGeneralTab.gml PropertiesWindowGeneralTabGML.h properties_window_general_tab_gml)
 compile_gml(PropertiesWindowImageTab.gml PropertiesWindowImageTabGML.h properties_window_image_tab_gml)
+compile_gml(PropertiesWindowPDFTab.gml PropertiesWindowPDFTabGML.h properties_window_pdf_tab_gml)
 
 set(SOURCES
     DesktopWidget.cpp
@@ -30,7 +31,8 @@ set(GENERATED_SOURCES
     PropertiesWindowFontTabGML.h
     PropertiesWindowGeneralTabGML.h
     PropertiesWindowImageTabGML.h
+    PropertiesWindowPDFTabGML.h
 )
 
 serenity_app(FileManager ICON app-file-manager)
-target_link_libraries(FileManager PRIVATE LibArchive LibAudio LibCore LibFileSystem LibGfx LibGUI LibDesktop LibConfig LibMain LibThreading)
+target_link_libraries(FileManager PRIVATE LibArchive LibAudio LibConfig LibCore LibDesktop LibFileSystem LibGfx LibGUI LibMain LibPDF LibThreading)

--- a/Userland/Applications/FileManager/CMakeLists.txt
+++ b/Userland/Applications/FileManager/CMakeLists.txt
@@ -7,6 +7,7 @@ serenity_component(
 
 compile_gml(FileManagerWindow.gml FileManagerWindowGML.h file_manager_window_gml)
 compile_gml(FileOperationProgress.gml FileOperationProgressGML.h file_operation_progress_gml)
+compile_gml(PropertiesWindowArchiveTab.gml PropertiesWindowArchiveTabGML.h properties_window_archive_tab_gml)
 compile_gml(PropertiesWindowAudioTab.gml PropertiesWindowAudioTabGML.h properties_window_audio_tab_gml)
 compile_gml(PropertiesWindowFontTab.gml PropertiesWindowFontTabGML.h properties_window_font_tab_gml)
 compile_gml(PropertiesWindowGeneralTab.gml PropertiesWindowGeneralTabGML.h properties_window_general_tab_gml)
@@ -24,6 +25,7 @@ set(SOURCES
 set(GENERATED_SOURCES
     FileManagerWindowGML.h
     FileOperationProgressGML.h
+    PropertiesWindowArchiveTabGML.h
     PropertiesWindowAudioTabGML.h
     PropertiesWindowFontTabGML.h
     PropertiesWindowGeneralTabGML.h
@@ -31,4 +33,4 @@ set(GENERATED_SOURCES
 )
 
 serenity_app(FileManager ICON app-file-manager)
-target_link_libraries(FileManager PRIVATE LibAudio LibCore LibFileSystem LibGfx LibGUI LibDesktop LibConfig LibMain LibThreading)
+target_link_libraries(FileManager PRIVATE LibArchive LibAudio LibCore LibFileSystem LibGfx LibGUI LibDesktop LibConfig LibMain LibThreading)

--- a/Userland/Applications/FileManager/PropertiesWindow.cpp
+++ b/Userland/Applications/FileManager/PropertiesWindow.cpp
@@ -16,6 +16,7 @@
 #include <Applications/FileManager/PropertiesWindowFontTabGML.h>
 #include <Applications/FileManager/PropertiesWindowGeneralTabGML.h>
 #include <Applications/FileManager/PropertiesWindowImageTabGML.h>
+#include <Applications/FileManager/PropertiesWindowPDFTabGML.h>
 #include <LibArchive/Zip.h>
 #include <LibAudio/Loader.h>
 #include <LibCore/Directory.h>
@@ -39,6 +40,7 @@
 #include <LibGfx/Font/WOFF/Font.h>
 #include <LibGfx/ICC/Profile.h>
 #include <LibGfx/ICC/Tags.h>
+#include <LibPDF/Document.h>
 #include <grp.h>
 #include <pwd.h>
 #include <stdio.h>
@@ -237,6 +239,9 @@ ErrorOr<void> PropertiesWindow::create_file_type_specific_tabs(GUI::TabWidget& t
 
     if (mime_type.starts_with("image/"sv))
         return create_image_tab(tab_widget, move(mapped_file), mime_type);
+
+    if (mime_type == "application/pdf"sv)
+        return create_pdf_tab(tab_widget, move(mapped_file));
 
     return {};
 }
@@ -446,6 +451,59 @@ ErrorOr<void> PropertiesWindow::create_image_tab(GUI::TabWidget& tab_widget, Non
 
     } else {
         hide_icc_group("None"_short_string);
+    }
+
+    return {};
+}
+
+ErrorOr<void> PropertiesWindow::create_pdf_tab(GUI::TabWidget& tab_widget, NonnullRefPtr<Core::MappedFile> mapped_file)
+{
+    auto maybe_document = PDF::Document::create(mapped_file->bytes());
+    if (maybe_document.is_error()) {
+        warnln("Failed to open '{}': {}", m_path, maybe_document.error().message());
+        return {};
+    }
+    auto document = maybe_document.release_value();
+
+    if (auto handler = document->security_handler(); handler && !handler->has_user_password()) {
+        // FIXME: Show a password dialog, once we've switched to lazy-loading
+        auto tab = TRY(tab_widget.try_add_tab<GUI::Label>("PDF"_short_string));
+        tab->set_text(TRY("PDF is password-protected."_string));
+        return {};
+    }
+
+    if (auto maybe_error = document->initialize(); maybe_error.is_error()) {
+        warnln("PDF '{}' seems to be invalid: {}", m_path, maybe_error.error().message());
+        return {};
+    }
+
+    auto tab = TRY(tab_widget.try_add_tab<GUI::Widget>("PDF"_short_string));
+    TRY(tab->load_from_gml(properties_window_pdf_tab_gml));
+
+    tab->find_descendant_of_type_named<GUI::Label>("pdf_version")->set_text(TRY(String::formatted("{}.{}", document->version().major, document->version().minor)));
+    tab->find_descendant_of_type_named<GUI::Label>("pdf_page_count")->set_text(TRY(String::number(document->get_page_count())));
+
+    auto maybe_info_dict = document->info_dict();
+    if (maybe_info_dict.is_error()) {
+        warnln("Failed to read InfoDict from '{}': {}", m_path, maybe_info_dict.error().message());
+    } else if (maybe_info_dict.value().has_value()) {
+        auto get_info_string = [](PDF::PDFErrorOr<Optional<DeprecatedString>> input) -> ErrorOr<String> {
+            if (input.is_error())
+                return String {};
+            if (!input.value().has_value())
+                return String {};
+            return String::from_deprecated_string(input.value().value());
+        };
+
+        auto info_dict = maybe_info_dict.release_value().release_value();
+        tab->find_descendant_of_type_named<GUI::Label>("pdf_title")->set_text(TRY(get_info_string(info_dict.title())));
+        tab->find_descendant_of_type_named<GUI::Label>("pdf_author")->set_text(TRY(get_info_string(info_dict.author())));
+        tab->find_descendant_of_type_named<GUI::Label>("pdf_subject")->set_text(TRY(get_info_string(info_dict.subject())));
+        tab->find_descendant_of_type_named<GUI::Label>("pdf_keywords")->set_text(TRY(get_info_string(info_dict.keywords())));
+        tab->find_descendant_of_type_named<GUI::Label>("pdf_creator")->set_text(TRY(get_info_string(info_dict.creator())));
+        tab->find_descendant_of_type_named<GUI::Label>("pdf_producer")->set_text(TRY(get_info_string(info_dict.producer())));
+        tab->find_descendant_of_type_named<GUI::Label>("pdf_creation_date")->set_text(TRY(get_info_string(info_dict.creation_date())));
+        tab->find_descendant_of_type_named<GUI::Label>("pdf_modification_date")->set_text(TRY(get_info_string(info_dict.modification_date())));
     }
 
     return {};

--- a/Userland/Applications/FileManager/PropertiesWindow.h
+++ b/Userland/Applications/FileManager/PropertiesWindow.h
@@ -30,6 +30,7 @@ private:
     ErrorOr<void> create_widgets(bool disable_rename);
     ErrorOr<void> create_general_tab(GUI::TabWidget&, bool disable_rename);
     ErrorOr<void> create_file_type_specific_tabs(GUI::TabWidget&);
+    ErrorOr<void> create_archive_tab(GUI::TabWidget&, NonnullRefPtr<Core::MappedFile>);
     ErrorOr<void> create_audio_tab(GUI::TabWidget&, NonnullRefPtr<Core::MappedFile>);
     ErrorOr<void> create_font_tab(GUI::TabWidget&, NonnullRefPtr<Core::MappedFile>, StringView mime_type);
     ErrorOr<void> create_image_tab(GUI::TabWidget&, NonnullRefPtr<Core::MappedFile>, StringView mime_type);

--- a/Userland/Applications/FileManager/PropertiesWindow.h
+++ b/Userland/Applications/FileManager/PropertiesWindow.h
@@ -34,6 +34,7 @@ private:
     ErrorOr<void> create_audio_tab(GUI::TabWidget&, NonnullRefPtr<Core::MappedFile>);
     ErrorOr<void> create_font_tab(GUI::TabWidget&, NonnullRefPtr<Core::MappedFile>, StringView mime_type);
     ErrorOr<void> create_image_tab(GUI::TabWidget&, NonnullRefPtr<Core::MappedFile>, StringView mime_type);
+    ErrorOr<void> create_pdf_tab(GUI::TabWidget&, NonnullRefPtr<Core::MappedFile>);
 
     struct PermissionMasks {
         mode_t read;

--- a/Userland/Applications/FileManager/PropertiesWindowArchiveTab.gml
+++ b/Userland/Applications/FileManager/PropertiesWindowArchiveTab.gml
@@ -1,0 +1,87 @@
+@GUI::Widget {
+    layout: @GUI::VerticalBoxLayout {
+        margins: [8]
+        spacing: 12
+    }
+
+    @GUI::GroupBox {
+        title: "Archive"
+        preferred_height: "shrink"
+        layout: @GUI::VerticalBoxLayout {
+            margins: [12, 8, 0]
+            spacing: 2
+        }
+
+        @GUI::Widget {
+            layout: @GUI::HorizontalBoxLayout {
+                spacing: 12
+            }
+
+            @GUI::Label {
+                text: "Format:"
+                text_alignment: "TopLeft"
+                fixed_width: 80
+            }
+
+            @GUI::Label {
+                name: "archive_format"
+                text: "ZIP"
+                text_alignment: "TopLeft"
+            }
+        }
+
+        @GUI::Widget {
+            layout: @GUI::HorizontalBoxLayout {
+                spacing: 12
+            }
+
+            @GUI::Label {
+                text: "Files:"
+                text_alignment: "TopLeft"
+                fixed_width: 80
+            }
+
+            @GUI::Label {
+                name: "archive_file_count"
+                text: "42"
+                text_alignment: "TopLeft"
+            }
+        }
+
+        @GUI::Widget {
+            layout: @GUI::HorizontalBoxLayout {
+                spacing: 12
+            }
+
+            @GUI::Label {
+                text: "Directories:"
+                text_alignment: "TopLeft"
+                fixed_width: 80
+            }
+
+            @GUI::Label {
+                name: "archive_directory_count"
+                text: "7"
+                text_alignment: "TopLeft"
+            }
+        }
+
+        @GUI::Widget {
+            layout: @GUI::HorizontalBoxLayout {
+                spacing: 12
+            }
+
+            @GUI::Label {
+                text: "Uncompressed:"
+                text_alignment: "TopLeft"
+                fixed_width: 80
+            }
+
+            @GUI::Label {
+                name: "archive_uncompressed_size"
+                text: "3.3 MiB"
+                text_alignment: "TopLeft"
+            }
+        }
+    }
+}

--- a/Userland/Applications/FileManager/PropertiesWindowPDFTab.gml
+++ b/Userland/Applications/FileManager/PropertiesWindowPDFTab.gml
@@ -1,0 +1,185 @@
+@GUI::Widget {
+    layout: @GUI::VerticalBoxLayout {
+        margins: [8]
+        spacing: 12
+    }
+
+    @GUI::GroupBox {
+        title: "PDF"
+        preferred_height: "shrink"
+        layout: @GUI::VerticalBoxLayout {
+            margins: [12, 8, 0]
+            spacing: 2
+        }
+
+        @GUI::Widget {
+            layout: @GUI::HorizontalBoxLayout {
+                spacing: 12
+            }
+
+            @GUI::Label {
+                text: "Version:"
+                text_alignment: "TopLeft"
+                fixed_width: 80
+            }
+
+            @GUI::Label {
+                name: "pdf_version"
+                text_alignment: "TopLeft"
+            }
+        }
+
+        @GUI::Widget {
+            layout: @GUI::HorizontalBoxLayout {
+                spacing: 12
+            }
+
+            @GUI::Label {
+                text: "Page count:"
+                text_alignment: "TopLeft"
+                fixed_width: 80
+            }
+
+            @GUI::Label {
+                name: "pdf_page_count"
+                text_alignment: "TopLeft"
+            }
+        }
+
+        @GUI::Widget {
+            layout: @GUI::HorizontalBoxLayout {
+                spacing: 12
+            }
+
+            @GUI::Label {
+                text: "Title:"
+                text_alignment: "TopLeft"
+                fixed_width: 80
+            }
+
+            @GUI::Label {
+                name: "pdf_title"
+                text_alignment: "TopLeft"
+            }
+        }
+
+        @GUI::Widget {
+            layout: @GUI::HorizontalBoxLayout {
+                spacing: 12
+            }
+
+            @GUI::Label {
+                text: "Author:"
+                text_alignment: "TopLeft"
+                fixed_width: 80
+            }
+
+            @GUI::Label {
+                name: "pdf_author"
+                text_alignment: "TopLeft"
+            }
+        }
+
+        @GUI::Widget {
+            layout: @GUI::HorizontalBoxLayout {
+                spacing: 12
+            }
+
+            @GUI::Label {
+                text: "Subject:"
+                text_alignment: "TopLeft"
+                fixed_width: 80
+            }
+
+            @GUI::Label {
+                name: "pdf_subject"
+                text_alignment: "TopLeft"
+            }
+        }
+
+        @GUI::Widget {
+            layout: @GUI::HorizontalBoxLayout {
+                spacing: 12
+            }
+
+            @GUI::Label {
+                text: "Keywords:"
+                text_alignment: "TopLeft"
+                fixed_width: 80
+            }
+
+            @GUI::Label {
+                name: "pdf_keywords"
+                text_alignment: "TopLeft"
+            }
+        }
+
+        @GUI::Widget {
+            layout: @GUI::HorizontalBoxLayout {
+                spacing: 12
+            }
+
+            @GUI::Label {
+                text: "Creator:"
+                text_alignment: "TopLeft"
+                fixed_width: 80
+            }
+
+            @GUI::Label {
+                name: "pdf_creator"
+                text_alignment: "TopLeft"
+            }
+        }
+
+        @GUI::Widget {
+            layout: @GUI::HorizontalBoxLayout {
+                spacing: 12
+            }
+
+            @GUI::Label {
+                text: "Producer:"
+                text_alignment: "TopLeft"
+                fixed_width: 80
+            }
+
+            @GUI::Label {
+                name: "pdf_producer"
+                text_alignment: "TopLeft"
+            }
+        }
+
+        @GUI::Widget {
+            layout: @GUI::HorizontalBoxLayout {
+                spacing: 12
+            }
+
+            @GUI::Label {
+                text: "Created:"
+                text_alignment: "TopLeft"
+                fixed_width: 80
+            }
+
+            @GUI::Label {
+                name: "pdf_creation_date"
+                text_alignment: "TopLeft"
+            }
+        }
+
+        @GUI::Widget {
+            layout: @GUI::HorizontalBoxLayout {
+                spacing: 12
+            }
+
+            @GUI::Label {
+                text: "Modified:"
+                text_alignment: "TopLeft"
+                fixed_width: 80
+            }
+
+            @GUI::Label {
+                name: "pdf_modification_date"
+                text_alignment: "TopLeft"
+            }
+        }
+    }
+}

--- a/Userland/Libraries/LibArchive/Statistics.h
+++ b/Userland/Libraries/LibArchive/Statistics.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2023, Sam Atkins <atkinssj@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Types.h>
+
+namespace Archive {
+
+class Statistics {
+public:
+    Statistics(size_t file_count, size_t directory_count, size_t total_uncompressed_bytes)
+        : m_file_count(file_count)
+        , m_directory_count(directory_count)
+        , m_total_uncompressed_bytes(total_uncompressed_bytes)
+    {
+    }
+
+    size_t file_count() const { return m_file_count; }
+    size_t directory_count() const { return m_directory_count; }
+    size_t member_count() const { return file_count() + directory_count(); }
+    size_t total_uncompressed_bytes() const { return m_total_uncompressed_bytes; }
+
+private:
+    size_t m_file_count { 0 };
+    size_t m_directory_count { 0 };
+    size_t m_total_uncompressed_bytes { 0 };
+};
+
+}

--- a/Userland/Libraries/LibArchive/Zip.h
+++ b/Userland/Libraries/LibArchive/Zip.h
@@ -15,6 +15,7 @@
 #include <AK/Stream.h>
 #include <AK/String.h>
 #include <AK/Vector.h>
+#include <LibArchive/Statistics.h>
 #include <LibCore/DateTime.h>
 #include <string.h>
 
@@ -254,7 +255,8 @@ struct ZipMember {
 class Zip {
 public:
     static Optional<Zip> try_create(ReadonlyBytes buffer);
-    ErrorOr<bool> for_each_member(Function<ErrorOr<IterationDecision>(ZipMember const&)>);
+    ErrorOr<bool> for_each_member(Function<ErrorOr<IterationDecision>(ZipMember const&)>) const;
+    ErrorOr<Statistics> calculate_statistics() const;
 
 private:
     static bool find_end_of_central_directory_offset(ReadonlyBytes, size_t& offset);

--- a/Userland/Utilities/unzip.cpp
+++ b/Userland/Utilities/unzip.cpp
@@ -146,22 +146,17 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     if (list_files) {
         outln("  Length     Date      Time     Name");
         outln("--------- ---------- --------   ----");
-        u32 members_count = 0;
-        u64 total_size = 0;
         TRY(zip_file->for_each_member([&](auto zip_member) -> ErrorOr<IterationDecision> {
-            members_count++;
-
             auto time = time_from_packed_dos(zip_member.modification_date, zip_member.modification_time);
             auto time_str = TRY(Core::DateTime::from_timestamp(time.seconds_since_epoch()).to_string());
-
-            total_size += zip_member.uncompressed_size;
 
             outln("{:>9} {}   {}", zip_member.uncompressed_size, time_str, zip_member.name);
 
             return IterationDecision::Continue;
         }));
+        auto statistics = TRY(zip_file->calculate_statistics());
         outln("---------                       ----");
-        outln("{:>9}                       {} files", total_size, members_count);
+        outln("{:>9}                       {} files", statistics.total_uncompressed_bytes(), statistics.member_count());
         return 0;
     }
 


### PR DESCRIPTION
![image](https://github.com/SerenityOS/serenity/assets/222642/40245051-a3bc-400b-8172-ff3b9fc2299d)

![image](https://github.com/SerenityOS/serenity/assets/222642/8cab1da4-6a2c-4589-a2ec-d18c9aa19c41)

A couple more file types you can now inspect. For ZIP, I left things so they could apply to other kinds of archive, we just don't have a convenient way to scan through them to get statistics yet.