### PR TITLE
LibGUI: Use set_text() for ReplaceAllTextCommand

### DIFF
--- a/Userland/DevTools/GMLPlayground/MainWidget.cpp
+++ b/Userland/DevTools/GMLPlayground/MainWidget.cpp
@@ -221,7 +221,7 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
     auto format_gml_action = GUI::Action::create("&Format GML", { Mod_Ctrl | Mod_Shift, Key_I }, TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/reformat.png"sv)), [&](auto&) {
         auto formatted_gml_or_error = GUI::GML::format_gml(m_editor->text());
         if (!formatted_gml_or_error.is_error()) {
-            m_editor->replace_all_text_without_resetting_undo_stack(formatted_gml_or_error.release_value());
+            m_editor->replace_all_text_without_resetting_undo_stack(formatted_gml_or_error.release_value(), "Format GML"sv);
         } else {
             GUI::MessageBox::show(
                 &window,

--- a/Userland/Libraries/LibGUI/TextDocument.h
+++ b/Userland/Libraries/LibGUI/TextDocument.h
@@ -74,7 +74,11 @@ public:
 
     void set_spans(u32 span_collection_index, Vector<TextDocumentSpan> spans);
 
-    bool set_text(StringView, AllowCallback = AllowCallback::Yes);
+    enum class IsNewDocument {
+        No,
+        Yes,
+    };
+    bool set_text(StringView, AllowCallback = AllowCallback::Yes, IsNewDocument = IsNewDocument::Yes);
 
     Vector<NonnullOwnPtr<TextDocumentLine>> const& lines() const { return m_lines; }
     Vector<NonnullOwnPtr<TextDocumentLine>>& lines() { return m_lines; }
@@ -290,19 +294,17 @@ private:
 class ReplaceAllTextCommand final : public GUI::TextDocumentUndoCommand {
 
 public:
-    ReplaceAllTextCommand(GUI::TextDocument& document, DeprecatedString const& new_text, GUI::TextRange const& range, DeprecatedString const& action_text);
+    ReplaceAllTextCommand(GUI::TextDocument& document, DeprecatedString const& new_text, DeprecatedString const& action_text);
     virtual ~ReplaceAllTextCommand() = default;
     void redo() override;
     void undo() override;
     bool merge_with(GUI::Command const&) override;
     DeprecatedString action_text() const override;
     DeprecatedString const& text() const { return m_new_text; }
-    TextRange const& range() const { return m_range; }
 
 private:
     DeprecatedString m_original_text;
     DeprecatedString m_new_text;
-    GUI::TextRange m_range;
     DeprecatedString m_action_text;
 };
 

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -1798,9 +1798,9 @@ void TextEditor::insert_at_cursor_or_replace_selection(StringView text)
     }
 }
 
-void TextEditor::replace_all_text_without_resetting_undo_stack(StringView text)
+void TextEditor::replace_all_text_without_resetting_undo_stack(StringView text, StringView action_text)
 {
-    execute<ReplaceAllTextCommand>(text, "GML Playground Format Text");
+    execute<ReplaceAllTextCommand>(text, action_text);
     did_change();
     update();
 }

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -1800,14 +1800,8 @@ void TextEditor::insert_at_cursor_or_replace_selection(StringView text)
 
 void TextEditor::replace_all_text_without_resetting_undo_stack(StringView text)
 {
-    auto start = GUI::TextPosition(0, 0);
-    auto last_line_index = line_count() - 1;
-    auto end = GUI::TextPosition(last_line_index, line(last_line_index).length());
-    auto range = GUI::TextRange(start, end);
-    auto normalized_range = range.normalized();
-    execute<ReplaceAllTextCommand>(text, range, "GML Playground Format Text");
+    execute<ReplaceAllTextCommand>(text, "GML Playground Format Text");
     did_change();
-    set_cursor(normalized_range.start());
     update();
 }
 

--- a/Userland/Libraries/LibGUI/TextEditor.h
+++ b/Userland/Libraries/LibGUI/TextEditor.h
@@ -138,7 +138,7 @@ public:
     TextRange normalized_selection() const { return m_selection.normalized(); }
 
     void insert_at_cursor_or_replace_selection(StringView);
-    void replace_all_text_without_resetting_undo_stack(StringView text);
+    void replace_all_text_without_resetting_undo_stack(StringView text, StringView action_text);
     ErrorOr<void> write_to_file(StringView path);
     ErrorOr<void> write_to_file(Core::File&);
     bool has_selection() const { return m_selection.is_valid(); }


### PR DESCRIPTION
Previously, this was reimplementing the same thing by removing all the
document text and then inserting the new text - which internally would
insert each code-point individually and fire change notifications for
each one. This made the "Reformat GML" button very slow, since it not
only had to recalculate the visual lines of the document each time, but
also rebuild the preview GUI.

The reason not to use `set_text()` is that it would throw away the undo
stack, since it always behaved as if the text is a new document. So,
let's add a parameter to disable that behaviour.

This takes the time for reformatting a ~200 line GML file from several
seconds, to basically instantaneous. :^)