### PR TITLE
LibUnicode: Perform code point case conversion lookups in constant time

### DIFF
--- a/Tests/LibUnicode/TestUnicodeCharacterTypes.cpp
+++ b/Tests/LibUnicode/TestUnicodeCharacterTypes.cpp
@@ -124,6 +124,16 @@ TEST_CASE(to_unicode_casefold)
     EXPECT_EQ(result, "\u03B1\u0342\u03B9"sv);
 }
 
+BENCHMARK_CASE(casing)
+{
+    for (size_t i = 0; i < 50'000; ++i) {
+        __test_to_unicode_lowercase();
+        __test_to_unicode_uppercase();
+        __test_to_unicode_titlecase();
+        __test_to_unicode_casefold();
+    }
+}
+
 TEST_CASE(to_unicode_lowercase_unconditional_special_casing)
 {
     // LATIN SMALL LETTER SHARP S


### PR DESCRIPTION
First commit is a compile-time performance improvement to cut the runtime of GenerateUnicodeData from
3.4 seconds to 1.2 seconds.

Next is replacing the lookup tables for case information (which we currently binary-search at runtime) with 2-stage, constant-time lookup tables. Not *as* much of a win as code point property tables, but still a measurable improvement, and it's nice to have these tables all behave the same:

In total, this change:

* Does not change the size of libunicode.so (which is nice because,
  generally, the 2-stage lookup tables are expected to trade a bit
  of size for performance).

* Reduces the runtime of the new benchmark test case added here from
  1.383s to 1.127s (about an 18.5% improvement).