### PR TITLE
LibWeb: Fix calculation of bitmap size in BorderRadiusCornerClipper

### DIFF
--- a/Userland/Libraries/LibWeb/Painting/BorderRadiusCornerClipper.cpp
+++ b/Userland/Libraries/LibWeb/Painting/BorderRadiusCornerClipper.cpp
@@ -21,11 +21,19 @@ ErrorOr<BorderRadiusCornerClipper> BorderRadiusCornerClipper::create(PaintContex
 
     DevicePixelSize corners_bitmap_size {
         max(
-            top_left.horizontal_radius + top_right.horizontal_radius,
-            bottom_left.horizontal_radius + bottom_right.horizontal_radius),
+            max(
+                top_left.horizontal_radius + top_right.horizontal_radius,
+                top_left.horizontal_radius + bottom_right.horizontal_radius),
+            max(
+                bottom_left.horizontal_radius + top_right.horizontal_radius,
+                bottom_left.horizontal_radius + bottom_right.horizontal_radius)),
         max(
-            top_left.vertical_radius + bottom_left.vertical_radius,
-            top_right.vertical_radius + bottom_right.vertical_radius)
+            max(
+                top_left.vertical_radius + bottom_left.vertical_radius,
+                top_left.vertical_radius + bottom_right.vertical_radius),
+            max(
+                top_right.vertical_radius + bottom_left.vertical_radius,
+                top_right.vertical_radius + bottom_right.vertical_radius))
     };
 
     RefPtr<Gfx::Bitmap> corner_bitmap;

--- a/Userland/Libraries/LibWeb/Painting/ShadowPainting.cpp
+++ b/Userland/Libraries/LibWeb/Painting/ShadowPainting.cpp
@@ -172,13 +172,17 @@ static void paint_outer_box_shadow(PaintContext& context, CSSPixelRect const& co
 
     auto shadow_bitmap_rect = DevicePixelRect(
         0, 0,
-        max(
-            top_left_corner_size.width() + top_right_corner_size.width(),
-            bottom_left_corner_size.width() + bottom_right_corner_size.width())
+        max(max(
+                top_left_corner_size.width() + top_right_corner_size.width(),
+                bottom_left_corner_size.width() + bottom_right_corner_size.width()),
+            max(top_left_corner_size.width() + bottom_right_corner_size.width(),
+                bottom_left_corner_size.width() + top_right_corner_size.width()))
             + 1 + blurred_edge_thickness,
-        max(
-            top_left_corner_size.height() + bottom_left_corner_size.height(),
-            top_right_corner_size.height() + bottom_right_corner_size.height())
+        max(max(
+                top_left_corner_size.height() + bottom_left_corner_size.height(),
+                top_right_corner_size.height() + bottom_right_corner_size.height()),
+            max(top_left_corner_size.height() + bottom_right_corner_size.height(),
+                bottom_left_corner_size.height() + top_right_corner_size.height()))
             + 1 + blurred_edge_thickness);
 
     auto top_left_corner_rect = DevicePixelRect {


### PR DESCRIPTION
Correctly compute the maximum possible width and height for corners_bitmap_size by considering all pair combinations of corners.

Fixes issue https://github.com/SerenityOS/serenity/issues/20205