### PR TITLE
LibGfx/JPEGXL: Enough things to handle the header of one of the image of the compliance testsuite

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/JPEGXLLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEGXLLoader.cpp
@@ -582,7 +582,7 @@ struct FrameHeader {
 
     Array<u8, 3> jpeg_upsampling {};
     u8 upsampling {};
-    Vector<u8> ec_upsampling {};
+    FixedArray<u8> ec_upsampling {};
 
     u8 group_size_shift { 1 };
     Passes passes {};
@@ -591,6 +591,7 @@ struct FrameHeader {
     bool have_crop { false };
 
     BlendingInfo blending_info {};
+    FixedArray<BlendingInfo> ec_blending_info {};
 
     u32 duration {};
 
@@ -631,8 +632,9 @@ static ErrorOr<FrameHeader> read_frame_header(LittleEndianInputBitStream& stream
 
             frame_header.upsampling = U32(1, 2, 4, 8);
 
+            frame_header.ec_upsampling = TRY(FixedArray<u8>::create(metadata.num_extra_channels));
             for (u16 i {}; i < metadata.num_extra_channels; ++i)
-                TODO();
+                frame_header.ec_upsampling[i] = U32(1, 2, 4, 8);
         }
 
         if (frame_header.encoding == FrameHeader::Encoding::kModular)
@@ -663,8 +665,9 @@ static ErrorOr<FrameHeader> read_frame_header(LittleEndianInputBitStream& stream
         if (normal_frame) {
             frame_header.blending_info = TRY(read_blending_info(stream, metadata, full_frame));
 
+            frame_header.ec_blending_info = TRY(FixedArray<BlendingInfo>::create(metadata.num_extra_channels));
             for (u16 i {}; i < metadata.num_extra_channels; ++i)
-                TODO();
+                frame_header.ec_blending_info[i] = TRY(read_blending_info(stream, metadata, full_frame));
 
             if (metadata.animation.has_value())
                 TODO();

--- a/Userland/Libraries/LibGfx/ImageFormats/JPEGXLLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEGXLLoader.cpp
@@ -468,7 +468,7 @@ struct BlendingInfo {
 
     BlendMode mode {};
     u8 alpha_channel {};
-    u8 clamp {};
+    bool clamp { false };
     u8 source {};
 };
 
@@ -481,7 +481,14 @@ static ErrorOr<BlendingInfo> read_blending_info(LittleEndianInputBitStream& stre
     bool const extra = metadata.num_extra_channels > 0;
 
     if (extra) {
-        TODO();
+        auto const blend_or_mul_add = blending_info.mode == BlendingInfo::BlendMode::kBlend
+            || blending_info.mode == BlendingInfo::BlendMode::kMulAdd;
+
+        if (blend_or_mul_add)
+            blending_info.alpha_channel = U32(0, 1, 2, 3 + TRY(stream.read_bits(3)));
+
+        if (blend_or_mul_add || blending_info.mode == BlendingInfo::BlendMode::kMul)
+            blending_info.clamp = TRY(stream.read_bit());
     }
 
     if (blending_info.mode != BlendingInfo::BlendMode::kReplace

--- a/Userland/Libraries/LibGfx/ImageFormats/JPEGXLLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEGXLLoader.cpp
@@ -652,17 +652,11 @@ struct TOC {
 
 static u64 num_toc_entries(FrameHeader const& frame_header, u64 num_groups, u64 num_lf_groups)
 {
+    // F.3.1 - General
     if (num_groups == 1 && frame_header.passes.num_passes == 1)
         return 1;
 
-    // Otherwise, there is one entry for each of the following sections,
-    // in the order they are listed: LfGlobal, one per LfGroup in raster
-    // order, one for HfGlobal followed by HfPass data for all the passes,
-    // and num_groups * frame_header.passes.num_passes for the PassGroup sections.
-
-    auto const hf_contribution = frame_header.encoding == FrameHeader::Encoding::kVarDCT ? (1 + frame_header.passes.num_passes) : 0;
-
-    return 1 + num_lf_groups + hf_contribution + num_groups * frame_header.passes.num_passes;
+    return 1 + num_lf_groups + 1 + num_groups * frame_header.passes.num_passes;
 }
 
 static ErrorOr<TOC> read_toc(LittleEndianInputBitStream& stream, FrameHeader const& frame_header, u64 num_groups, u64 num_lf_groups)

--- a/Userland/Libraries/LibGfx/ImageFormats/JPEGXLLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEGXLLoader.cpp
@@ -1561,8 +1561,8 @@ static ErrorOr<Frame> read_frame(LittleEndianInputBitStream& stream,
     }
 
     if (frame.frame_header.upsampling > 1) {
-        frame.width = ceil(frame.width / frame.frame_header.upsampling);
-        frame.height = ceil(frame.height / frame.frame_header.upsampling);
+        frame.width = ceil(static_cast<double>(frame.width) / frame.frame_header.upsampling);
+        frame.height = ceil(static_cast<double>(frame.height) / frame.frame_header.upsampling);
     }
 
     if (frame.frame_header.lf_level > 0)
@@ -1571,8 +1571,10 @@ static ErrorOr<Frame> read_frame(LittleEndianInputBitStream& stream,
     // F.2 - FrameHeader
     auto const group_dim = 128 << frame.frame_header.group_size_shift;
 
-    frame.num_groups = ceil(frame.width / group_dim) * ceil(frame.height / group_dim);
-    frame.num_lf_groups = ceil(frame.width / (group_dim * 8)) * ceil(frame.height / (group_dim * 8));
+    auto const frame_width = static_cast<double>(frame.width);
+    auto const frame_height = static_cast<double>(frame.height);
+    frame.num_groups = ceil(frame_width / group_dim) * ceil(frame_height / group_dim);
+    frame.num_lf_groups = ceil(frame_width / (group_dim * 8)) * ceil(frame_height / (group_dim * 8));
 
     frame.toc = TRY(read_toc(stream, frame.frame_header, frame.num_groups, frame.num_lf_groups));
 


### PR DESCRIPTION
The three first commits are bugfixes and the last four are enhancements.
We are now failing at the image composition with the file [alpha_nonpremultiplied](https://github.com/libjxl/conformance/tree/master/testcases/alpha_nonpremultiplied).

---

**LibGfx/JPEGXL: Use the correct condition to read `save_before_ct`**

During the original implementation, I mixed the condition for
`save_before_ct` and the one for `save_before_ct`, resulting in a bogus
code. That's fixed now!

**LibGfx/JPEGXL: Perform size computation in a floating point type**

The computation was copied from the spec, but I forgot that they mention
that every "/" should be performed without truncation or rounding. Let's
use `double`s instead of integers.

**LibGfx/JPEGXL: Consider the HfGlobal section of the TOC**

There is always a section for HfGlobal, even if it's empty like with
Modular images.

I also removed the outdated (and misinterpreted) spec comment and
replace it with the name of the section.

**LibGfx/JPEGXL: Move code to read a string in a utility function**

This was only used for the name of the `Frame`, but this code will soon
be used to read `ExtraChannelInfo`'s name. So let's factorize it!

**LibGfx/JPEGXL: Start parsing the `ExtraChannelInfo` bundle**

This implementation is not feature complete yet as it only supports
channels with a type different of `ExtraChannelType::kAlpha`.

This patch also introduces the `read_enum` function.

**LibGfx/JPEGXL: Handle parsing `BlendingInfo` for extra channels**

Extra channels have more parameters than basic one. This patch allows us
to read all these parameters.

**LibGfx/JPEGXL: Read data related to extra channels in `FrameHeader`**

Thanks to previous patches, everything used in `read_frame_header`
supports extra channels. The last element to achieve the read of headers
of frame with extra channels is to add support in the function itself
and the `FrameHeader` struct, which that patch does.