### PR TITLE
AK+Libraries: Remove `FixedMemoryStream::[readonly_]bytes()`

### DIFF
--- a/AK/MemoryStream.cpp
+++ b/AK/MemoryStream.cpp
@@ -109,16 +109,6 @@ ErrorOr<void> FixedMemoryStream::write_until_depleted(ReadonlyBytes bytes)
     return {};
 }
 
-Bytes FixedMemoryStream::bytes()
-{
-    VERIFY(m_writing_enabled);
-    return m_bytes;
-}
-ReadonlyBytes FixedMemoryStream::readonly_bytes() const
-{
-    return m_bytes;
-}
-
 size_t FixedMemoryStream::offset() const
 {
     return m_offset;

--- a/AK/MemoryStream.h
+++ b/AK/MemoryStream.h
@@ -31,8 +31,6 @@ public:
     virtual ErrorOr<size_t> write_some(ReadonlyBytes bytes) override;
     virtual ErrorOr<void> write_until_depleted(ReadonlyBytes bytes) override;
 
-    Bytes bytes();
-    ReadonlyBytes readonly_bytes() const;
     size_t offset() const;
     size_t remaining() const;
 


### PR DESCRIPTION
These methods are slightly more convenient than storing the Bytes separately. However, it it feels unsanitary to reach in and access this data directly. Both of the users of these already have the [Readonly]Bytes available in their constructors, and can easily avoid using these methods, so let's remove them entirely.