### PR TITLE
LibWeb: Add support for "display: contents"

### DIFF
--- a/Tests/LibWeb/Layout/expected/flex/list-container-display-contents.txt
+++ b/Tests/LibWeb/Layout/expected/flex/list-container-display-contents.txt
@@ -1,0 +1,14 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x41.46875 [BFC] children: not-inline
+    BlockContainer <body> at (8,16) content-size 784x17.46875 children: not-inline
+      Box <ul.globalnav-list> at (48,16) content-size 744x17.46875 flex-container(row) [FFC] children: not-inline
+        BlockContainer <div#item-1> at (48,16) content-size 46.734375x17.46875 flex-item [BFC] children: inline
+          line 0 width: 46.734375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 5, rect: [48,16 46.734375x17.46875]
+              "Store"
+          TextNode <#text>
+        BlockContainer <div#item-2> at (762,16) content-size 30x17.46875 flex-item [BFC] children: inline
+          line 0 width: 30, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 3, rect: [762,16 30x17.46875]
+              "Mac"
+          TextNode <#text>

--- a/Tests/LibWeb/Layout/input/flex/list-container-display-contents.html
+++ b/Tests/LibWeb/Layout/input/flex/list-container-display-contents.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<style type="text/css">
+  .globalnav-list {
+    display: flex;
+    justify-content: space-between;
+  }
+  .globalnav-menu {
+    display: contents;
+  }
+</style><ul class="globalnav-list"><li class="globalnav-menu"><div id="item-1">Store</div><div id="item-2">Mac</div>

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -5327,8 +5327,7 @@ ErrorOr<RefPtr<StyleValue>> Parser::parse_display_value(Vector<ComponentValue> c
 
             // display-box
             case ValueID::Contents:
-                // FIXME this should be Display::Short::Contents but contents is currently not implemented
-                return Display::from_short(Display::Short::Flow);
+                return Display::from_short(Display::Short::Contents);
             case ValueID::None:
                 return Display::from_short(Display::Short::None);
 

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -347,7 +347,7 @@ JS::GCPtr<Layout::Node> Element::create_layout_node_for_display_type(DOM::Docume
     if (display.is_flex_inside() || display.is_grid_inside())
         return document.heap().allocate_without_realm<Layout::Box>(document, element, move(style));
 
-    if (display.is_flow_inside() || display.is_flow_root_inside())
+    if (display.is_flow_inside() || display.is_flow_root_inside() || display.is_contents())
         return document.heap().allocate_without_realm<Layout::BlockContainer>(document, element, move(style));
 
     dbgln("FIXME: CSS display '{}' not implemented yet.", display.to_string().release_value_but_fixme_should_propagate_errors());

--- a/Userland/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -129,6 +129,9 @@ static Layout::Node& insertion_parent_for_block_node(Layout::NodeWithStyle& layo
 
 void TreeBuilder::insert_node_into_inline_or_block_ancestor(Layout::Node& node, CSS::Display display, AppendOrPrepend mode)
 {
+    if (node.display().is_contents())
+        return;
+
     if (display.is_inline_outside()) {
         // Inlines can be inserted into the nearest ancestor.
         auto& insertion_point = insertion_parent_for_inline_node(m_ancestor_stack.last());
@@ -141,6 +144,8 @@ void TreeBuilder::insert_node_into_inline_or_block_ancestor(Layout::Node& node, 
         // Non-inlines can't be inserted into an inline parent, so find the nearest non-inline ancestor.
         auto& nearest_non_inline_ancestor = [&]() -> Layout::NodeWithStyle& {
             for (auto& ancestor : m_ancestor_stack.in_reverse()) {
+                if (ancestor->display().is_contents())
+                    continue;
                 if (!ancestor->display().is_inline_outside())
                     return ancestor;
                 if (!ancestor->display().is_flow_inside())


### PR DESCRIPTION
This change makes tree builder omit elements with "display: contents" from the layout tree during construction. Their child elements are instead directly appended to the parent element in layout tree.

Visual progression on apple.com

Before:
<img width="844" alt="Screenshot 2023-07-27 at 23 39 13" src="https://github.com/SerenityOS/serenity/assets/45686940/33deb5bf-fbcb-4c77-b1ec-4e1185a3bba4">

After:
<img width="844" alt="Screenshot 2023-07-27 at 23 39 57" src="https://github.com/SerenityOS/serenity/assets/45686940/1c147dfc-7231-462f-82e8-2334a45a02d7">

