### PR TITLE
LibWeb: Implement `<meta http-equiv="Refresh">`

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -495,6 +495,8 @@ public:
 
     void start_intersection_observing_a_lazy_loading_element(Element& element);
 
+    void shared_declarative_refresh_steps(StringView input, JS::GCPtr<HTML::HTMLMetaElement const> meta_element = nullptr);
+
 protected:
     virtual JS::ThrowCompletionOr<void> initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
@@ -676,6 +678,12 @@ private:
     // https://html.spec.whatwg.org/multipage/urls-and-fetching.html#lazy-load-intersection-observer
     // Each Document has a lazy load intersection observer, initially set to null but can be set to an IntersectionObserver instance.
     JS::GCPtr<IntersectionObserver::IntersectionObserver> m_lazy_load_intersection_observer;
+
+    // https://html.spec.whatwg.org/multipage/semantics.html#will-declaratively-refresh
+    // A Document object has an associated will declaratively refresh (a boolean). It is initially false.
+    bool m_will_declaratively_refresh { false };
+
+    RefPtr<Core::Timer> m_active_refresh_timer;
 };
 
 template<>

--- a/Userland/Libraries/LibWeb/HTML/HTMLMetaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMetaElement.cpp
@@ -1,10 +1,12 @@
 /*
  * Copyright (c) 2020, the SerenityOS developers.
+ * Copyright (c) 2023, Luke Wilde <lukew@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/HTMLMetaElement.h>
 
 namespace Web::HTML {
@@ -22,6 +24,52 @@ JS::ThrowCompletionOr<void> HTMLMetaElement::initialize(JS::Realm& realm)
     set_prototype(&Bindings::ensure_web_prototype<Bindings::HTMLMetaElementPrototype>(realm, "HTMLMetaElement"));
 
     return {};
+}
+
+Optional<HTMLMetaElement::HttpEquivAttributeState> HTMLMetaElement::http_equiv_state() const
+{
+    auto value = attribute(HTML::AttributeNames::http_equiv);
+
+#define __ENUMERATE_HTML_META_HTTP_EQUIV_ATTRIBUTE(keyword, state) \
+    if (value.equals_ignoring_ascii_case(#keyword##sv))            \
+        return HTMLMetaElement::HttpEquivAttributeState::state;
+    ENUMERATE_HTML_META_HTTP_EQUIV_ATTRIBUTES
+#undef __ENUMERATE_HTML_META_HTTP_EQUIV_ATTRIBUTE
+
+    return OptionalNone {};
+}
+
+void HTMLMetaElement::inserted()
+{
+    Base::inserted();
+
+    // https://html.spec.whatwg.org/multipage/semantics.html#pragma-directives
+    // When a meta element is inserted into the document, if its http-equiv attribute is present and represents one of
+    // the above states, then the user agent must run the algorithm appropriate for that state, as described in the
+    // following list:
+    auto http_equiv = http_equiv_state();
+    if (http_equiv.has_value()) {
+        switch (http_equiv.value()) {
+        case HttpEquivAttributeState::Refresh: {
+            // https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv-refresh
+            // 1. If the meta element has no content attribute, or if that attribute's value is the empty string, then return.
+            // 2. Let input be the value of the element's content attribute.
+            if (!has_attribute(AttributeNames::content))
+                break;
+
+            auto input = attribute(AttributeNames::content);
+            if (input.is_empty())
+                break;
+
+            // 3. Run the shared declarative refresh steps with the meta element's node document, input, and the meta element.
+            document().shared_declarative_refresh_steps(input, this);
+            break;
+        }
+        default:
+            dbgln("FIXME: Implement '{}' http-equiv state", attribute(AttributeNames::http_equiv));
+            break;
+        }
+    }
 }
 
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLMetaElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMetaElement.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020, the SerenityOS developers.
+ * Copyright (c) 2023, Luke Wilde <lukew@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -10,16 +11,37 @@
 
 namespace Web::HTML {
 
+// https://html.spec.whatwg.org/multipage/semantics.html#pragma-directives
+#define ENUMERATE_HTML_META_HTTP_EQUIV_ATTRIBUTES                                   \
+    __ENUMERATE_HTML_META_HTTP_EQUIV_ATTRIBUTE("content-language", ContentLanguage) \
+    __ENUMERATE_HTML_META_HTTP_EQUIV_ATTRIBUTE("content-type", EncodingDeclaration) \
+    __ENUMERATE_HTML_META_HTTP_EQUIV_ATTRIBUTE("default-style", DefaultStyle)       \
+    __ENUMERATE_HTML_META_HTTP_EQUIV_ATTRIBUTE(refresh, Refresh)                    \
+    __ENUMERATE_HTML_META_HTTP_EQUIV_ATTRIBUTE("set-cookie", SetCookie)             \
+    __ENUMERATE_HTML_META_HTTP_EQUIV_ATTRIBUTE("x-ua-compatible", XUACompatible)    \
+    __ENUMERATE_HTML_META_HTTP_EQUIV_ATTRIBUTE("content-security-policy", ContentSecurityPolicy)
+
 class HTMLMetaElement final : public HTMLElement {
     WEB_PLATFORM_OBJECT(HTMLMetaElement, HTMLElement);
 
 public:
     virtual ~HTMLMetaElement() override;
 
+    enum class HttpEquivAttributeState {
+#define __ENUMERATE_HTML_META_HTTP_EQUIV_ATTRIBUTE(_, state) state,
+        ENUMERATE_HTML_META_HTTP_EQUIV_ATTRIBUTES
+#undef __ENUMERATE_HTML_META_HTTP_EQUIV_ATTRIBUTE
+    };
+
+    Optional<HttpEquivAttributeState> http_equiv_state() const;
+
 private:
     HTMLMetaElement(DOM::Document&, DOM::QualifiedName);
 
     virtual JS::ThrowCompletionOr<void> initialize(JS::Realm&) override;
+
+    // ^DOM::Element
+    virtual void inserted() override;
 };
 
 }


### PR DESCRIPTION
Required by Atlassian to continue to their authorization process. Also used by the SerenityOS FAQ redirect on the website, the Bootstrap documentation for going to older versions from the dropdown and likely several other sites.

Demo:

https://github.com/SerenityOS/serenity/assets/25595356/f235e524-d6bf-4ed6-ad55-a8ebd03196e1

To try out Atlassian for yourself, you'll have to apply this patch. Note that it isn't a proper solution, it's only to make progress on Atlassian.
```patch
diff --git a/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp b/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
index 2b370ea4de..a2e3ece7a2 100644
--- a/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
@@ -1235,6 +1235,7 @@ WebIDL::ExceptionOr<void> BrowsingContext::navigate(
             request.set_header("Content-Length", DeprecatedString::number(0));
         }
     }
+    request.set_header("Referer", source_browsing_context.active_document()->origin().serialize());
     loader().load(request, FrameLoader::Type::Navigation);
     return {};
 }
diff --git a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
index 3a30bfd92d..0b877e14f5 100644
--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -420,7 +420,6 @@ CSSPixels BlockFormattingContext::compute_table_box_width_inside_table_wrapper(B
     else if (available_space.width.is_min_content())
         throwaway_state.get_mutable(box).set_min_content_width();
     else {
-        VERIFY(available_space.width.is_max_content());
         throwaway_state.get_mutable(box).set_max_content_width();
     }
     auto context = create_independent_formatting_context_if_needed(throwaway_state, box);
```