### PR TITLE
LibWeb: Handle overlapping floating box and left margin

### DIFF
--- a/Tests/LibWeb/Layout/expected/block-and-inline/block-with-hidden-overflow-after-float.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/block-with-hidden-overflow-after-float.txt
@@ -8,11 +8,15 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <div.ab> at (108,8) content-size 684x17.46875 children: not-inline
         BlockContainer <(anonymous)> at (108,8) content-size 684x0 children: inline
           TextNode <#text>
+        BlockContainer <div> at (108,8) content-size 684x0 children: inline
+          TextNode <#text>
           BlockContainer <div.a> at (108,8) content-size 14.265625x17.46875 floating [BFC] children: inline
             line 0 width: 14.265625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
               frag 0 from TextNode start: 0, length: 1, rect: [108,8 14.265625x17.46875]
                 "A"
             TextNode <#text>
+          TextNode <#text>
+        BlockContainer <(anonymous)> at (108,8) content-size 684x0 children: inline
           TextNode <#text>
         BlockContainer <div.b> at (122.265625,8) content-size 669.734375x17.46875 [BFC] children: inline
           line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125

--- a/Tests/LibWeb/Layout/expected/block-and-inline/block-with-hidden-overflow-after-sibling-float.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/block-with-hidden-overflow-after-sibling-float.txt
@@ -1,0 +1,47 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x34.9375 children: not-inline
+      BlockContainer <div> at (8,8) content-size 784x34.9375 children: not-inline
+        BlockContainer <(anonymous)> at (8,8) content-size 784x0 children: inline
+          TextNode <#text>
+        BlockContainer <div> at (8,8) content-size 784x0 children: inline
+          TextNode <#text>
+          BlockContainer <div.a> at (8,8) content-size 57.0625x34.9375 floating [BFC] children: not-inline
+            BlockContainer <(anonymous)> at (8,8) content-size 57.0625x0 children: inline
+              TextNode <#text>
+            BlockContainer <div.a4> at (8,8) content-size 57.0625x17.46875 children: inline
+              line 0 width: 57.0625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                frag 0 from TextNode start: 0, length: 4, rect: [8,8 57.0625x17.46875]
+                  "AAAA"
+              TextNode <#text>
+            BlockContainer <(anonymous)> at (8,25.46875) content-size 57.0625x0 children: inline
+              TextNode <#text>
+            BlockContainer <div> at (8,25.46875) content-size 57.0625x17.46875 children: inline
+              line 0 width: 14.265625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                frag 0 from TextNode start: 0, length: 1, rect: [8,25.46875 14.265625x17.46875]
+                  "A"
+              TextNode <#text>
+            BlockContainer <(anonymous)> at (8,42.9375) content-size 57.0625x0 children: inline
+              TextNode <#text>
+          TextNode <#text>
+        BlockContainer <(anonymous)> at (8,8) content-size 784x0 children: inline
+          TextNode <#text>
+        BlockContainer <div> at (108,8) content-size 684x34.9375 children: not-inline
+          BlockContainer <(anonymous)> at (108,8) content-size 684x0 children: inline
+            TextNode <#text>
+          BlockContainer <div> at (108,8) content-size 684x17.46875 children: inline
+            line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+              frag 0 from TextNode start: 0, length: 1, rect: [108,8 9.34375x17.46875]
+                "B"
+            TextNode <#text>
+          BlockContainer <(anonymous)> at (108,25.46875) content-size 684x0 children: inline
+            TextNode <#text>
+          BlockContainer <div.c> at (108,25.46875) content-size 684x17.46875 [BFC] children: inline
+            line 0 width: 10.3125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+              frag 0 from TextNode start: 0, length: 1, rect: [108,25.46875 10.3125x17.46875]
+                "C"
+            TextNode <#text>
+          BlockContainer <(anonymous)> at (108,42.9375) content-size 684x0 children: inline
+            TextNode <#text>
+        BlockContainer <(anonymous)> at (8,42.9375) content-size 784x0 children: inline
+          TextNode <#text>

--- a/Tests/LibWeb/Layout/input/block-and-inline/block-with-hidden-overflow-after-float.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/block-with-hidden-overflow-after-float.html
@@ -20,7 +20,9 @@
 
 <body>
     <div class="ab">
-        <div class="a">A</div>
+        <div>
+            <div class="a">A</div>
+        </div>
         <div class="b">B</div>
     </div>
 

--- a/Tests/LibWeb/Layout/input/block-and-inline/block-with-hidden-overflow-after-sibling-float.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/block-with-hidden-overflow-after-sibling-float.html
@@ -1,0 +1,26 @@
+<style>
+    .a {
+        float: left;
+    }
+
+    .a4 {
+        display: block;
+    }
+
+    .c {
+        overflow: hidden;
+    }
+</style>
+
+<div>
+    <div>
+        <div class="a">
+            <div class="a4">AAAA</div>
+            <div>A</div>
+        </div>
+    </div>
+    <div style="margin-left: 100px">
+        <div>B</div>
+        <div class="c">C</div>
+    </div>
+</div>

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.h
@@ -121,6 +121,7 @@ protected:
         // Each block in the containing chain adds its own margin and we store the total here.
         CSSPixels left_total_containing_margin;
         CSSPixels right_total_containing_margin;
+        Box const* matching_left_float_box { nullptr };
     };
 
     struct ShrinkToFitResult {


### PR DESCRIPTION
Allow the left margin of a box which creates a block formatting context to overlap with left floating boxes which are siblings in the document tree.

Fixes #20233 and the comment layout on https://lobste.rs.