### PR TITLE
LibWeb: Allow <svg> to act as a containing block

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -90,7 +90,8 @@ static Box const* nearest_ancestor_capable_of_forming_a_containing_block(Node co
     for (auto const* ancestor = node.parent(); ancestor; ancestor = ancestor->parent()) {
         if (ancestor->is_block_container()
             || ancestor->display().is_flex_inside()
-            || ancestor->display().is_grid_inside()) {
+            || ancestor->display().is_grid_inside()
+            || ancestor->is_svg_svg_box()) {
             return verify_cast<Box>(ancestor);
         }
     }


### PR DESCRIPTION
This change makes overflow clipping work correctly for children of svg element.

Fixes following example:
```html
<!doctype html><style>
    body {
        width: 300px;
        height: 300px;
        position: relative;
        overflow: hidden;
        border: 1px solid black;
    }
    svg {
        position: absolute;
        left: 50%;
        top: 50%;
        width: 100%;
        height: 100%;
        transform: translate(-50%, -50%);
    }
</style>
<body>
<svg viewBox="0 0 100 100">
   <g>
     <rect x="0" y="0" width="100" height="100" fill="green"></rect>
   </g>
</svg>
```