### PR TITLE
LibWeb: Resolve currentColor when used for SVG gradient <stop>s

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -15,6 +15,7 @@
 #include <LibWeb/CSS/StyleValues/GridTemplateAreaStyleValue.h>
 #include <LibWeb/CSS/StyleValues/GridTrackPlacementStyleValue.h>
 #include <LibWeb/CSS/StyleValues/GridTrackSizeListStyleValue.h>
+#include <LibWeb/CSS/StyleValues/IdentifierStyleValue.h>
 #include <LibWeb/CSS/StyleValues/IntegerStyleValue.h>
 #include <LibWeb/CSS/StyleValues/LengthStyleValue.h>
 #include <LibWeb/CSS/StyleValues/NumberStyleValue.h>
@@ -939,9 +940,15 @@ String StyleProperties::grid_area() const
 Color StyleProperties::stop_color() const
 {
     auto value = property(CSS::PropertyID::StopColor);
+    if (value->is_identifier()) {
+        // Workaround lack of layout node to resolve current color.
+        auto& ident = value->as_identifier();
+        if (ident.id() == CSS::ValueID::Currentcolor)
+            value = property(CSS::PropertyID::Color);
+    }
     if (value->has_color()) {
         // FIXME: This is used by the SVGStopElement, which does not participate in layout,
-        // so can't pass a layout node (so can't resolve some colors, e.g. palette ones or currentColor)
+        // so can't pass a layout node (so can't resolve some colors, e.g. palette ones)
         return value->to_color({});
     }
     return Color::Black;


### PR DESCRIPTION
A small workaround is needed here as \<stop\> elements don't create a layout node, so we can't get the current color from value->to_color().  
                                                                        
This fixes the gradients in the Atlassian logo and icons. 

| Before                                                                                                                              | After                                                                                                                               |
|-------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------|
| ![Screenshot from 2023-07-28 22-23-21](https://github.com/SerenityOS/serenity/assets/11597044/39e42796-7475-4a39-9c40-a7d889c3a10c) | ![Screenshot from 2023-07-28 22-22-45](https://github.com/SerenityOS/serenity/assets/11597044/30686a72-86a0-4f5f-9d3e-7fcbb1149c0f) |