### PR TITLE
AK+LibWeb: Serialize URL hosts with 'concept-host-serializer'

### DIFF
--- a/AK/URL.cpp
+++ b/AK/URL.cpp
@@ -152,6 +152,14 @@ void URL::set_fragment(DeprecatedString fragment, ApplyPercentEncoding apply_per
     m_fragment = move(fragment);
 }
 
+// https://url.spec.whatwg.org/#cannot-have-a-username-password-port
+bool URL::cannot_have_a_username_or_password_or_port() const
+{
+    // A URL cannot have a username/password/port if its host is null or the empty string, or its scheme is "file".
+    // FIXME: The spec does not mention anything to do with 'cannot be a base URL'.
+    return m_host.is_null() || m_host.is_empty() || m_cannot_be_a_base_url || m_scheme == "file"sv;
+}
+
 // FIXME: This is by no means complete.
 // NOTE: This relies on some assumptions about how the spec-defined URL parser works that may turn out to be wrong.
 bool URL::compute_validity() const

--- a/AK/URL.h
+++ b/AK/URL.h
@@ -54,6 +54,22 @@ public:
     {
     }
 
+    // https://url.spec.whatwg.org/#concept-ipv4
+    // An IPv4 address is a 32-bit unsigned integer that identifies a network address. [RFC791]
+    // FIXME: It would be nice if this were an AK::IPv4Address
+    using IPv4Address = u32;
+
+    // https://url.spec.whatwg.org/#concept-ipv6
+    // An IPv6 address is a 128-bit unsigned integer that identifies a network address. For the purposes of this standard
+    // it is represented as a list of eight 16-bit unsigned integers, also known as IPv6 pieces. [RFC4291]
+    // FIXME: It would be nice if this were an AK::IPv6Address
+    using IPv6Address = Array<u16, 8>;
+
+    // https://url.spec.whatwg.org/#concept-host
+    // A host is a domain, an IP address, an opaque host, or an empty host. Typically a host serves as a network address,
+    // but it is sometimes used as opaque identifier in URLs where a network address is not necessary.
+    using Host = Variant<IPv4Address, IPv6Address, String, Empty>;
+
     bool is_valid() const { return m_valid; }
 
     enum class ApplyPercentDecoding {

--- a/AK/URL.h
+++ b/AK/URL.h
@@ -79,7 +79,8 @@ public:
     DeprecatedString const& scheme() const { return m_scheme; }
     DeprecatedString username(ApplyPercentDecoding = ApplyPercentDecoding::Yes) const;
     DeprecatedString password(ApplyPercentDecoding = ApplyPercentDecoding::Yes) const;
-    DeprecatedString const& host() const { return m_host; }
+    Host const& host() const { return m_host; }
+    ErrorOr<String> serialized_host() const;
     DeprecatedString basename(ApplyPercentDecoding = ApplyPercentDecoding::Yes) const;
     DeprecatedString query(ApplyPercentDecoding = ApplyPercentDecoding::No) const;
     DeprecatedString fragment(ApplyPercentDecoding = ApplyPercentDecoding::Yes) const;
@@ -101,7 +102,7 @@ public:
     void set_scheme(DeprecatedString);
     void set_username(DeprecatedString, ApplyPercentEncoding = ApplyPercentEncoding::Yes);
     void set_password(DeprecatedString, ApplyPercentEncoding = ApplyPercentEncoding::Yes);
-    void set_host(DeprecatedString);
+    void set_host(Host);
     void set_port(Optional<u16>);
     void set_paths(Vector<DeprecatedString>, ApplyPercentEncoding = ApplyPercentEncoding::Yes);
     void set_query(DeprecatedString, ApplyPercentEncoding = ApplyPercentEncoding::Yes);
@@ -178,7 +179,7 @@ private:
     DeprecatedString m_password;
 
     // A URL’s host is null or a host. It is initially null.
-    DeprecatedString m_host;
+    Host m_host;
 
     // A URL’s port is either null or a 16-bit unsigned integer that identifies a networking port. It is initially null.
     Optional<u16> m_port;

--- a/AK/URL.h
+++ b/AK/URL.h
@@ -89,7 +89,7 @@ public:
 
     u16 port_or_default() const { return m_port.value_or(default_port_for_scheme(m_scheme)); }
     bool cannot_be_a_base_url() const { return m_cannot_be_a_base_url; }
-    bool cannot_have_a_username_or_password_or_port() const { return m_host.is_null() || m_host.is_empty() || m_cannot_be_a_base_url || m_scheme == "file"sv; }
+    bool cannot_have_a_username_or_password_or_port() const;
 
     bool includes_credentials() const { return !m_username.is_empty() || !m_password.is_empty(); }
     bool is_special() const { return is_special_scheme(m_scheme); }

--- a/AK/URLParser.cpp
+++ b/AK/URLParser.cpp
@@ -121,7 +121,7 @@ static Optional<ParsedIPv4Number> parse_ipv4_number(StringView input)
 }
 
 // https://url.spec.whatwg.org/#concept-ipv4-parser
-static Optional<u32> parse_ipv4_address(StringView input)
+static Optional<URL::IPv4Address> parse_ipv4_address(StringView input)
 {
     // 1. Let parts be the result of strictly splitting input on U+002E (.).
     auto parts = input.split_view("."sv, SplitBehavior::KeepEmpty);
@@ -201,7 +201,7 @@ static Optional<u32> parse_ipv4_address(StringView input)
 }
 
 // https://url.spec.whatwg.org/#concept-ipv4-serializer
-static ErrorOr<String> serialize_ipv4_address(u32 address)
+static ErrorOr<String> serialize_ipv4_address(URL::IPv4Address address)
 {
     // 1. Let output be the empty string.
     // NOTE: Array to avoid prepend.
@@ -227,7 +227,7 @@ static ErrorOr<String> serialize_ipv4_address(u32 address)
 }
 
 // https://url.spec.whatwg.org/#concept-ipv6-serializer
-static ErrorOr<String> serialize_ipv6_address(Array<u16, 8> const& address)
+static ErrorOr<String> serialize_ipv6_address(URL::IPv6Address const& address)
 {
     // 1. Let output be the empty string.
     StringBuilder output;
@@ -290,7 +290,7 @@ static ErrorOr<String> serialize_ipv6_address(Array<u16, 8> const& address)
 }
 
 // https://url.spec.whatwg.org/#concept-ipv6-parser
-static Optional<Array<u16, 8>> parse_ipv6_address(StringView input)
+static Optional<URL::IPv6Address> parse_ipv6_address(StringView input)
 {
     // 1. Let address be a new IPv6 address whose IPv6 pieces are all 0.
     Array<u16, 8> address {};

--- a/AK/URLParser.cpp
+++ b/AK/URLParser.cpp
@@ -227,10 +227,9 @@ static ErrorOr<String> serialize_ipv4_address(URL::IPv4Address address)
 }
 
 // https://url.spec.whatwg.org/#concept-ipv6-serializer
-static ErrorOr<String> serialize_ipv6_address(URL::IPv6Address const& address)
+static void serialize_ipv6_address(URL::IPv6Address const& address, StringBuilder& output)
 {
     // 1. Let output be the empty string.
-    StringBuilder output;
 
     // 2. Let compress be an index to the first IPv6 piece in the first longest sequences of address’s IPv6 pieces that are 0.
     // 3. If there is no sequence of address’s IPv6 pieces that are 0 that is longer than 1, then set compress to null.
@@ -286,7 +285,6 @@ static ErrorOr<String> serialize_ipv6_address(URL::IPv6Address const& address)
     }
 
     // 6. Return output.
-    return output.to_string();
 }
 
 // https://url.spec.whatwg.org/#concept-ipv6-parser
@@ -566,10 +564,9 @@ static Optional<DeprecatedString> parse_host(StringView input, bool is_not_speci
         if (!address.has_value())
             return {};
 
-        auto result = serialize_ipv6_address(*address);
-        if (result.is_error())
-            return {};
-        return result.release_value().to_deprecated_string();
+        StringBuilder output;
+        serialize_ipv6_address(*address, output);
+        return output.to_deprecated_string();
     }
 
     // 2. If isNotSpecial is true, then return the result of opaque-host parsing input.

--- a/AK/URLParser.h
+++ b/AK/URLParser.h
@@ -61,6 +61,9 @@ public:
     // https://url.spec.whatwg.org/#string-percent-encode-after-encoding
     static DeprecatedString percent_encode_after_encoding(StringView input, URL::PercentEncodeSet percent_encode_set, bool space_as_plus = false);
 
+    // https://url.spec.whatwg.org/#concept-host-serializer
+    static ErrorOr<String> serialize_host(URL::Host const&);
+
 private:
     static Optional<URL> parse_data_url(StringView raw_input);
 };

--- a/Ladybird/LocationEdit.cpp
+++ b/Ladybird/LocationEdit.cpp
@@ -49,7 +49,7 @@ void LocationEdit::highlight_location()
     if (url.is_valid() && !hasFocus()) {
         if (url.scheme() == "http" || url.scheme() == "https" || url.scheme() == "gemini") {
             int host_start = (url.scheme().length() + 3) - cursorPosition();
-            auto host_length = url.host().length();
+            auto host_length = url.serialized_host().release_value_but_fixme_should_propagate_errors().bytes().size();
 
             // FIXME: Maybe add a generator to use https://publicsuffix.org/list/public_suffix_list.dat
             //        for now just highlight the whole host

--- a/Ladybird/WebSocketImplQt.cpp
+++ b/Ladybird/WebSocketImplQt.cpp
@@ -53,7 +53,7 @@ void WebSocketImplQt::connect(WebSocket::ConnectionInfo const& connection_info)
     if (connection_info.is_secure()) {
         auto ssl_socket = make<QSslSocket>();
         ssl_socket->connectToHostEncrypted(
-            qstring_from_ak_deprecated_string(connection_info.url().host()),
+            qstring_from_ak_string(connection_info.url().serialized_host().release_value_but_fixme_should_propagate_errors()),
             connection_info.url().port_or_default());
         QObject::connect(ssl_socket.ptr(), &QSslSocket::alertReceived, [this](QSsl::AlertLevel level, QSsl::AlertType, QString const&) {
             if (level == QSsl::AlertLevel::Fatal)
@@ -63,7 +63,7 @@ void WebSocketImplQt::connect(WebSocket::ConnectionInfo const& connection_info)
     } else {
         m_socket = make<QTcpSocket>();
         m_socket->connectToHost(
-            qstring_from_ak_deprecated_string(connection_info.url().host()),
+            qstring_from_ak_string(connection_info.url().serialized_host().release_value_but_fixme_should_propagate_errors()),
             connection_info.url().port_or_default());
     }
 

--- a/Tests/AK/TestURL.cpp
+++ b/Tests/AK/TestURL.cpp
@@ -22,7 +22,7 @@ TEST_CASE(basic)
         URL url("http://www.serenityos.org"sv);
         EXPECT_EQ(url.is_valid(), true);
         EXPECT_EQ(url.scheme(), "http");
-        EXPECT_EQ(url.host(), "www.serenityos.org");
+        EXPECT_EQ(MUST(url.serialized_host()), "www.serenityos.org");
         EXPECT_EQ(url.port_or_default(), 80);
         EXPECT_EQ(url.serialize_path(), "/");
         EXPECT(url.query().is_null());
@@ -32,7 +32,7 @@ TEST_CASE(basic)
         URL url("https://www.serenityos.org/index.html"sv);
         EXPECT_EQ(url.is_valid(), true);
         EXPECT_EQ(url.scheme(), "https");
-        EXPECT_EQ(url.host(), "www.serenityos.org");
+        EXPECT_EQ(MUST(url.serialized_host()), "www.serenityos.org");
         EXPECT_EQ(url.port_or_default(), 443);
         EXPECT_EQ(url.serialize_path(), "/index.html");
         EXPECT(url.query().is_null());
@@ -42,7 +42,7 @@ TEST_CASE(basic)
         URL url("https://www.serenityos.org1/index.html"sv);
         EXPECT_EQ(url.is_valid(), true);
         EXPECT_EQ(url.scheme(), "https");
-        EXPECT_EQ(url.host(), "www.serenityos.org1");
+        EXPECT_EQ(MUST(url.serialized_host()), "www.serenityos.org1");
         EXPECT_EQ(url.port_or_default(), 443);
         EXPECT_EQ(url.serialize_path(), "/index.html");
         EXPECT(url.query().is_null());
@@ -52,7 +52,7 @@ TEST_CASE(basic)
         URL url("https://localhost:1234/~anon/test/page.html"sv);
         EXPECT_EQ(url.is_valid(), true);
         EXPECT_EQ(url.scheme(), "https");
-        EXPECT_EQ(url.host(), "localhost");
+        EXPECT_EQ(MUST(url.serialized_host()), "localhost");
         EXPECT_EQ(url.port_or_default(), 1234);
         EXPECT_EQ(url.serialize_path(), "/~anon/test/page.html");
         EXPECT(url.query().is_null());
@@ -62,7 +62,7 @@ TEST_CASE(basic)
         URL url("http://www.serenityos.org/index.html?#"sv);
         EXPECT_EQ(url.is_valid(), true);
         EXPECT_EQ(url.scheme(), "http");
-        EXPECT_EQ(url.host(), "www.serenityos.org");
+        EXPECT_EQ(MUST(url.serialized_host()), "www.serenityos.org");
         EXPECT_EQ(url.port_or_default(), 80);
         EXPECT_EQ(url.serialize_path(), "/index.html");
         EXPECT_EQ(url.query(), "");
@@ -72,7 +72,7 @@ TEST_CASE(basic)
         URL url("http://www.serenityos.org/index.html?foo=1&bar=2"sv);
         EXPECT_EQ(url.is_valid(), true);
         EXPECT_EQ(url.scheme(), "http");
-        EXPECT_EQ(url.host(), "www.serenityos.org");
+        EXPECT_EQ(MUST(url.serialized_host()), "www.serenityos.org");
         EXPECT_EQ(url.port_or_default(), 80);
         EXPECT_EQ(url.serialize_path(), "/index.html");
         EXPECT_EQ(url.query(), "foo=1&bar=2");
@@ -82,7 +82,7 @@ TEST_CASE(basic)
         URL url("http://www.serenityos.org/index.html#fragment"sv);
         EXPECT_EQ(url.is_valid(), true);
         EXPECT_EQ(url.scheme(), "http");
-        EXPECT_EQ(url.host(), "www.serenityos.org");
+        EXPECT_EQ(MUST(url.serialized_host()), "www.serenityos.org");
         EXPECT_EQ(url.port_or_default(), 80);
         EXPECT_EQ(url.serialize_path(), "/index.html");
         EXPECT(url.query().is_null());
@@ -92,7 +92,7 @@ TEST_CASE(basic)
         URL url("http://www.serenityos.org/index.html?foo=1&bar=2&baz=/?#frag/ment?test#"sv);
         EXPECT_EQ(url.is_valid(), true);
         EXPECT_EQ(url.scheme(), "http");
-        EXPECT_EQ(url.host(), "www.serenityos.org");
+        EXPECT_EQ(MUST(url.serialized_host()), "www.serenityos.org");
         EXPECT_EQ(url.port_or_default(), 80);
         EXPECT_EQ(url.serialize_path(), "/index.html");
         EXPECT_EQ(url.query(), "foo=1&bar=2&baz=/?");
@@ -128,7 +128,7 @@ TEST_CASE(file_url_with_hostname)
     URL url("file://courage/my/file"sv);
     EXPECT(url.is_valid());
     EXPECT_EQ(url.scheme(), "file");
-    EXPECT_EQ(url.host(), "courage");
+    EXPECT_EQ(MUST(url.serialized_host()), "courage");
     EXPECT_EQ(url.port_or_default(), 0);
     EXPECT_EQ(url.serialize_path(), "/my/file");
     EXPECT_EQ(url.serialize(), "file://courage/my/file");
@@ -141,7 +141,7 @@ TEST_CASE(file_url_with_localhost)
     URL url("file://localhost/my/file"sv);
     EXPECT(url.is_valid());
     EXPECT_EQ(url.scheme(), "file");
-    EXPECT_EQ(url.host(), "");
+    EXPECT_EQ(MUST(url.serialized_host()), "");
     EXPECT_EQ(url.serialize_path(), "/my/file");
     EXPECT_EQ(url.serialize(), "file:///my/file");
 }
@@ -151,7 +151,7 @@ TEST_CASE(file_url_without_hostname)
     URL url("file:///my/file"sv);
     EXPECT(url.is_valid());
     EXPECT_EQ(url.scheme(), "file");
-    EXPECT_EQ(url.host(), "");
+    EXPECT_EQ(MUST(url.serialized_host()), "");
     EXPECT_EQ(url.serialize_path(), "/my/file");
     EXPECT_EQ(url.serialize(), "file:///my/file");
 }
@@ -205,7 +205,7 @@ TEST_CASE(about_url)
     URL url("about:blank"sv);
     EXPECT(url.is_valid());
     EXPECT_EQ(url.scheme(), "about");
-    EXPECT(url.host().is_null());
+    EXPECT(url.host().has<Empty>());
     EXPECT_EQ(url.serialize_path(), "blank");
     EXPECT(url.query().is_null());
     EXPECT(url.fragment().is_null());
@@ -217,7 +217,7 @@ TEST_CASE(mailto_url)
     URL url("mailto:mail@example.com"sv);
     EXPECT(url.is_valid());
     EXPECT_EQ(url.scheme(), "mailto");
-    EXPECT(url.host().is_null());
+    EXPECT(url.host().has<Empty>());
     EXPECT_EQ(url.port_or_default(), 0);
     EXPECT_EQ(url.path_segment_count(), 1u);
     EXPECT_EQ(url.path_segment_at_index(0), "mail@example.com");
@@ -231,7 +231,7 @@ TEST_CASE(data_url)
     URL url("data:text/html,test"sv);
     EXPECT(url.is_valid());
     EXPECT_EQ(url.scheme(), "data");
-    EXPECT(url.host().is_null());
+    EXPECT(url.host().has<Empty>());
     EXPECT_EQ(url.data_mime_type(), "text/html");
     EXPECT_EQ(url.data_payload(), "test");
     EXPECT(!url.data_payload_is_base64());
@@ -243,7 +243,7 @@ TEST_CASE(data_url_default_mime_type)
     URL url("data:,test"sv);
     EXPECT(url.is_valid());
     EXPECT_EQ(url.scheme(), "data");
-    EXPECT(url.host().is_null());
+    EXPECT(url.host().has<Empty>());
     EXPECT_EQ(url.data_mime_type(), "text/plain");
     EXPECT_EQ(url.data_payload(), "test");
     EXPECT(!url.data_payload_is_base64());
@@ -255,7 +255,7 @@ TEST_CASE(data_url_encoded)
     URL url("data:text/html,Hello%20friends%2C%0X%X0"sv);
     EXPECT(url.is_valid());
     EXPECT_EQ(url.scheme(), "data");
-    EXPECT(url.host().is_null());
+    EXPECT(url.host().has<Empty>());
     EXPECT_EQ(url.data_mime_type(), "text/html");
     EXPECT_EQ(url.data_payload(), "Hello friends,%0X%X0");
     EXPECT(!url.data_payload_is_base64());
@@ -267,7 +267,7 @@ TEST_CASE(data_url_base64_encoded)
     URL url("data:text/html;base64,test"sv);
     EXPECT(url.is_valid());
     EXPECT_EQ(url.scheme(), "data");
-    EXPECT(url.host().is_null());
+    EXPECT(url.host().has<Empty>());
     EXPECT_EQ(url.data_mime_type(), "text/html");
     EXPECT_EQ(url.data_payload(), "test");
     EXPECT(url.data_payload_is_base64());
@@ -279,7 +279,7 @@ TEST_CASE(data_url_base64_encoded_default_mime_type)
     URL url("data:;base64,test"sv);
     EXPECT(url.is_valid());
     EXPECT_EQ(url.scheme(), "data");
-    EXPECT(url.host().is_null());
+    EXPECT(url.host().has<Empty>());
     EXPECT_EQ(url.data_mime_type(), "text/plain");
     EXPECT_EQ(url.data_payload(), "test");
     EXPECT(url.data_payload_is_base64());
@@ -291,7 +291,7 @@ TEST_CASE(data_url_base64_encoded_with_whitespace)
     URL url("data: text/html ;     bAsE64 , test with whitespace "sv);
     EXPECT(url.is_valid());
     EXPECT_EQ(url.scheme(), "data");
-    EXPECT(url.host().is_null());
+    EXPECT(url.host().has<Empty>());
     EXPECT_EQ(url.data_mime_type(), "text/html");
     EXPECT_EQ(url.data_payload(), " test with whitespace ");
     EXPECT(url.data_payload_is_base64());
@@ -303,7 +303,7 @@ TEST_CASE(data_url_base64_encoded_with_inline_whitespace)
     URL url("data:text/javascript;base64,%20ZD%20Qg%0D%0APS%20An%20Zm91cic%0D%0A%207%20"sv);
     EXPECT(url.is_valid());
     EXPECT_EQ(url.scheme(), "data");
-    EXPECT(url.host().is_null());
+    EXPECT(url.host().has<Empty>());
     EXPECT_EQ(url.data_mime_type(), "text/javascript");
     EXPECT(url.data_payload_is_base64());
     EXPECT_EQ(url.data_payload(), " ZD Qg\r\nPS An Zm91cic\r\n 7 "sv);
@@ -371,7 +371,7 @@ TEST_CASE(complete_url)
     URL url = base_url.complete_url("test.html"sv);
     EXPECT(url.is_valid());
     EXPECT_EQ(url.scheme(), "http");
-    EXPECT_EQ(url.host(), "serenityos.org");
+    EXPECT_EQ(MUST(url.serialized_host()), "serenityos.org");
     EXPECT_EQ(url.serialize_path(), "/test.html");
     EXPECT(url.query().is_null());
     EXPECT(url.query().is_null());
@@ -445,6 +445,7 @@ TEST_CASE(ipv6_address)
         constexpr auto ipv6_url = "http://[::1]/index.html"sv;
         URL url(ipv6_url);
         EXPECT(url.is_valid());
+        EXPECT_EQ(MUST(url.serialized_host()), "[::1]"sv);
         EXPECT_EQ(url, ipv6_url);
     }
 
@@ -452,6 +453,7 @@ TEST_CASE(ipv6_address)
         constexpr auto ipv6_url = "http://[0:f:0:0:f:f:0:0]/index.html"sv;
         URL url(ipv6_url);
         EXPECT(url.is_valid());
+        EXPECT_EQ(MUST(url.serialized_host()), "[0:f::f:f:0:0]"sv);
         EXPECT_EQ(url, ipv6_url);
     }
 
@@ -459,6 +461,7 @@ TEST_CASE(ipv6_address)
         constexpr auto ipv6_url = "https://[2001:0db8:85a3:0000:0000:8a2e:0370:7334]/index.html"sv;
         URL url(ipv6_url);
         EXPECT(url.is_valid());
+        EXPECT_EQ(MUST(url.serialized_host()), "[2001:db8:85a3::8a2e:370:7334]"sv);
         EXPECT_EQ(url, ipv6_url);
     }
 
@@ -475,14 +478,14 @@ TEST_CASE(ipv4_address)
         constexpr auto ipv4_url = "http://127.0.0.1/index.html"sv;
         URL url(ipv4_url);
         EXPECT(url.is_valid());
-        EXPECT_EQ(url.host(), "127.0.0.1"sv);
+        EXPECT_EQ(MUST(url.serialized_host()), "127.0.0.1"sv);
     }
 
     {
         constexpr auto ipv4_url = "http://0x.0x.0"sv;
         URL url(ipv4_url);
         EXPECT(url.is_valid());
-        EXPECT_EQ(url.host(), "0.0.0.0"sv);
+        EXPECT_EQ(MUST(url.serialized_host()), "0.0.0.0"sv);
     }
 
     {
@@ -495,13 +498,13 @@ TEST_CASE(ipv4_address)
         constexpr auto ipv4_url = "http://256"sv;
         URL url(ipv4_url);
         EXPECT(url.is_valid());
-        EXPECT_EQ(url.host(), "0.0.1.0"sv);
+        EXPECT_EQ(MUST(url.serialized_host()), "0.0.1.0"sv);
     }
 
     {
         constexpr auto ipv4_url = "http://888888888"sv;
         URL url(ipv4_url);
         EXPECT(url.is_valid());
-        EXPECT_EQ(url.host(), "52.251.94.56"sv);
+        EXPECT_EQ(MUST(url.serialized_host()), "52.251.94.56"sv);
     }
 }

--- a/Userland/Applications/Assistant/Providers.cpp
+++ b/Userland/Applications/Assistant/Providers.cpp
@@ -248,8 +248,8 @@ void URLProvider::query(DeprecatedString const& query, Function<void(Vector<Nonn
 
     if (url.scheme().is_empty())
         url.set_scheme("http");
-    if (url.host().is_empty())
-        url.set_host(query);
+    if (url.host().has<Empty>() || url.host() == String {})
+        url.set_host(String::from_deprecated_string(query).release_value_but_fixme_should_propagate_errors());
     if (url.path_segment_count() == 0)
         url.set_paths({ "" });
 

--- a/Userland/Applications/Browser/CookieJar.cpp
+++ b/Userland/Applications/Browser/CookieJar.cpp
@@ -208,7 +208,10 @@ Optional<DeprecatedString> CookieJar::canonicalize_domain(const URL& url)
         return {};
 
     // FIXME: Implement RFC 5890 to "Convert each label that is not a Non-Reserved LDH (NR-LDH) label to an A-label".
-    return url.host().to_lowercase();
+    if (url.host().has<Empty>())
+        return {};
+
+    return url.serialized_host().release_value_but_fixme_should_propagate_errors().to_deprecated_string().to_lowercase();
 }
 
 bool CookieJar::domain_matches(DeprecatedString const& string, DeprecatedString const& domain_string)

--- a/Userland/Applications/Browser/Tab.cpp
+++ b/Userland/Applications/Browser/Tab.cpp
@@ -107,10 +107,10 @@ void Tab::update_status(Optional<String> text_override, i32 count_waiting)
 
     if (count_waiting == 0) {
         // ex: "Loading google.com"
-        m_statusbar->set_text(String::formatted("Loading {}", m_navigating_url->host()).release_value_but_fixme_should_propagate_errors());
+        m_statusbar->set_text(String::formatted("Loading {}", m_navigating_url->serialized_host().release_value_but_fixme_should_propagate_errors()).release_value_but_fixme_should_propagate_errors());
     } else {
         // ex: "google.com is waiting on 5 resources"
-        m_statusbar->set_text(String::formatted("{} is waiting on {} resource{}", m_navigating_url->host(), count_waiting, count_waiting == 1 ? ""sv : "s"sv).release_value_but_fixme_should_propagate_errors());
+        m_statusbar->set_text(String::formatted("{} is waiting on {} resource{}", m_navigating_url->serialized_host().release_value_but_fixme_should_propagate_errors(), count_waiting, count_waiting == 1 ? ""sv : "s"sv).release_value_but_fixme_should_propagate_errors());
     }
 }
 

--- a/Userland/Applications/Spreadsheet/HelpWindow.cpp
+++ b/Userland/Applications/Spreadsheet/HelpWindow.cpp
@@ -83,7 +83,7 @@ HelpWindow::HelpWindow(GUI::Window* parent)
     m_webview = splitter.add<WebView::OutOfProcessWebView>();
     m_webview->on_link_click = [this](auto& url, auto&, auto&&) {
         VERIFY(url.scheme() == "spreadsheet");
-        if (url.host() == "example") {
+        if (url.host().template has<String>() && url.host().template get<String>() == "example"sv) {
             auto example_path = url.serialize_path();
             auto entry = LexicalPath::basename(example_path);
             auto doc_option = m_docs.get_object(entry);
@@ -122,11 +122,11 @@ HelpWindow::HelpWindow(GUI::Window* parent)
 
             widget->add_sheet(sheet.release_nonnull());
             window->show();
-        } else if (url.host() == "doc") {
+        } else if (url.host() == String::from_utf8_short_string("doc"sv)) {
             auto entry = LexicalPath::basename(url.serialize_path());
             m_webview->load(URL::create_with_data("text/html", render(entry)));
         } else {
-            dbgln("Invalid spreadsheet action domain '{}'", url.host());
+            dbgln("Invalid spreadsheet action domain '{}'", url.serialized_host().release_value_but_fixme_should_propagate_errors());
         }
     };
 

--- a/Userland/Applications/Spreadsheet/Spreadsheet.cpp
+++ b/Userland/Applications/Spreadsheet/Spreadsheet.cpp
@@ -264,7 +264,7 @@ Optional<Position> Sheet::position_from_url(const URL& url) const
         return {};
     }
 
-    if (url.scheme() != "spreadsheet" || url.host() != "cell") {
+    if (url.scheme() != "spreadsheet" || url.host() != String::from_utf8_short_string("cell"sv)) {
         dbgln("Bad url: {}", url.to_deprecated_string());
         return {};
     }
@@ -757,7 +757,7 @@ URL Position::to_url(Sheet const& sheet) const
 {
     URL url;
     url.set_scheme("spreadsheet");
-    url.set_host("cell");
+    url.set_host(String::from_utf8_short_string("cell"sv));
     url.set_paths({ DeprecatedString::number(getpid()) });
     url.set_fragment(to_cell_identifier(sheet));
     return url;

--- a/Userland/Libraries/LibCore/Proxy.h
+++ b/Userland/Libraries/LibCore/Proxy.h
@@ -36,10 +36,9 @@ struct ProxyData {
 
         proxy_data.type = ProxyData::Type::SOCKS5;
 
-        auto host_ipv4 = IPv4Address::from_string(url.host());
-        if (!host_ipv4.has_value())
+        if (!url.host().has<URL::IPv4Address>())
             return Error::from_string_literal("Invalid proxy host, must be an IPv4 address");
-        proxy_data.host_ipv4 = host_ipv4->to_u32();
+        proxy_data.host_ipv4 = url.host().get<URL::IPv4Address>();
 
         auto port = url.port();
         if (!port.has_value())

--- a/Userland/Libraries/LibGUI/TextBox.cpp
+++ b/Userland/Libraries/LibGUI/TextBox.cpp
@@ -179,8 +179,9 @@ void UrlBox::highlight_url()
 
     if (url.is_valid() && !is_focused()) {
         if (url.scheme() == "http" || url.scheme() == "https" || url.scheme() == "gemini") {
+            auto serialized_host = url.serialized_host().release_value_but_fixme_should_propagate_errors().to_deprecated_string();
             auto host_start = url.scheme().length() + 3;
-            auto host_length = url.host().length();
+            auto host_length = serialized_host.length();
 
             // FIXME: Maybe add a generator to use https://publicsuffix.org/list/public_suffix_list.dat
             //        for now just highlight the whole host

--- a/Userland/Libraries/LibHTTP/HttpRequest.cpp
+++ b/Userland/Libraries/LibHTTP/HttpRequest.cpp
@@ -7,6 +7,7 @@
 
 #include <AK/Base64.h>
 #include <AK/StringBuilder.h>
+#include <AK/URLParser.h>
 #include <LibHTTP/HttpRequest.h>
 #include <LibHTTP/Job.h>
 
@@ -57,7 +58,7 @@ ErrorOr<ByteBuffer> HttpRequest::to_raw_request() const
         TRY(builder.try_append(m_url.query()));
     }
     TRY(builder.try_append(" HTTP/1.1\r\nHost: "sv));
-    TRY(builder.try_append(m_url.host()));
+    TRY(builder.try_append(TRY(m_url.serialized_host())));
     if (m_url.port().has_value())
         TRY(builder.try_appendff(":{}", *m_url.port()));
     TRY(builder.try_append("\r\n"sv));

--- a/Userland/Libraries/LibManual/Node.cpp
+++ b/Userland/Libraries/LibManual/Node.cpp
@@ -82,7 +82,7 @@ ErrorOr<NonnullRefPtr<PageNode const>> Node::try_create_from_query(Vector<String
 
 ErrorOr<NonnullRefPtr<Node const>> Node::try_find_from_help_url(URL const& url)
 {
-    if (url.host() != "man")
+    if (url.host() != String::from_utf8_short_string("man"sv))
         return Error::from_string_view("Bad help operation"sv);
     if (url.path_segment_count() < 2)
         return Error::from_string_view("Bad help page URL"sv);

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -2316,8 +2316,7 @@ DeprecatedString Document::domain() const
         return DeprecatedString::empty();
 
     // 3. Return effectiveDomain, serialized.
-    // FIXME: Implement host serialization.
-    return effective_domain.release_value();
+    return URLParser::serialize_host(effective_domain.release_value()).release_value_but_fixme_should_propagate_errors().to_deprecated_string();
 }
 
 void Document::set_domain(DeprecatedString const& domain)

--- a/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
@@ -256,7 +256,7 @@ WebIDL::ExceptionOr<Optional<JS::NonnullGCPtr<PendingResponse>>> main_fetch(JS::
         // - request’s current URL’s scheme is "http"
         request->current_url().scheme() == "http"sv
         // - request’s current URL’s host is a domain
-        && URL::host_is_domain(request->current_url().serialized_host().release_value_but_fixme_should_propagate_errors())
+        && URL::host_is_domain(request->current_url().host())
         // FIXME: - Matching request’s current URL’s host per Known HSTS Host Domain Name Matching results in either a
         //          superdomain match with an asserted includeSubDomains directive or a congruent match (with or without an
         //          asserted includeSubDomains directive) [HSTS]; or DNS resolution for the request finds a matching HTTPS RR

--- a/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
@@ -256,7 +256,7 @@ WebIDL::ExceptionOr<Optional<JS::NonnullGCPtr<PendingResponse>>> main_fetch(JS::
         // - request’s current URL’s scheme is "http"
         request->current_url().scheme() == "http"sv
         // - request’s current URL’s host is a domain
-        && URL::host_is_domain(request->current_url().host())
+        && URL::host_is_domain(request->current_url().serialized_host().release_value_but_fixme_should_propagate_errors())
         // FIXME: - Matching request’s current URL’s host per Known HSTS Host Domain Name Matching results in either a
         //          superdomain match with an asserted includeSubDomains directive or a congruent match (with or without an
         //          asserted includeSubDomains directive) [HSTS]; or DNS resolution for the request finds a matching HTTPS RR

--- a/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
@@ -44,7 +44,7 @@ static bool url_matches_about_blank(AK::URL const& url)
         && url.serialize_path() == "blank"sv
         && url.username().is_empty()
         && url.password().is_empty()
-        && url.host().is_null();
+        && url.host().has<Empty>();
 }
 
 // FIXME: This is an outdated older version of "determining the origin" and should be removed.

--- a/Userland/Libraries/LibWeb/HTML/HTMLHyperlinkElementUtils.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLHyperlinkElementUtils.cpp
@@ -167,15 +167,15 @@ DeprecatedString HTMLHyperlinkElementUtils::host() const
     auto& url = m_url;
 
     // 3. If url or url's host is null, return the empty string.
-    if (!url.has_value() || url->host().is_null())
+    if (!url.has_value() || url->host().has<Empty>())
         return DeprecatedString::empty();
 
     // 4. If url's port is null, return url's host, serialized.
     if (!url->port().has_value())
-        return url->host();
+        return url->serialized_host().release_value_but_fixme_should_propagate_errors().to_deprecated_string();
 
     // 5. Return url's host, serialized, followed by ":" and url's port, serialized.
-    return DeprecatedString::formatted("{}:{}", url->host(), url->port().value());
+    return DeprecatedString::formatted("{}:{}", url->serialized_host().release_value_but_fixme_should_propagate_errors(), url->port().value());
 }
 
 // https://html.spec.whatwg.org/multipage/links.html#dom-hyperlink-host
@@ -205,11 +205,14 @@ DeprecatedString HTMLHyperlinkElementUtils::hostname() const
     // 1. Reinitialize url.
     //
     // 2. Let url be this element's url.
-    //
+    AK::URL url(href());
+
     // 3. If url or url's host is null, return the empty string.
-    //
+    if (url.host().has<Empty>())
+        return DeprecatedString::empty();
+
     // 4. Return url's host, serialized.
-    return AK::URL(href()).host();
+    return url.serialized_host().release_value_but_fixme_should_propagate_errors().to_deprecated_string();
 }
 
 void HTMLHyperlinkElementUtils::set_hostname(DeprecatedString hostname)

--- a/Userland/Libraries/LibWeb/HTML/Location.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Location.cpp
@@ -153,15 +153,15 @@ WebIDL::ExceptionOr<String> Location::host() const
     auto url = this->url();
 
     // 3. If url's host is null, return the empty string.
-    if (url.host().is_null())
+    if (url.host().has<Empty>())
         return String {};
 
     // 4. If url's port is null, return url's host, serialized.
     if (!url.port().has_value())
-        return TRY_OR_THROW_OOM(vm, String::from_deprecated_string(url.host()));
+        return TRY_OR_THROW_OOM(vm, url.serialized_host());
 
     // 5. Return url's host, serialized, followed by ":" and url's port, serialized.
-    return TRY_OR_THROW_OOM(vm, String::formatted("{}:{}", url.host(), *url.port()));
+    return TRY_OR_THROW_OOM(vm, String::formatted("{}:{}", TRY_OR_THROW_OOM(vm, url.serialized_host()), *url.port()));
 }
 
 WebIDL::ExceptionOr<void> Location::set_host(String const&)
@@ -183,11 +183,11 @@ WebIDL::ExceptionOr<String> Location::hostname() const
     auto url = this->url();
 
     // 2. If this's url's host is null, return the empty string.
-    if (url.host().is_null())
+    if (url.host().has<Empty>())
         return String {};
 
     // 3. Return this's url's host, serialized.
-    return TRY_OR_THROW_OOM(vm, String::from_deprecated_string(url.host()));
+    return TRY_OR_THROW_OOM(vm, url.serialized_host());
 }
 
 WebIDL::ExceptionOr<void> Location::set_hostname(String const&)

--- a/Userland/Libraries/LibWeb/HTML/NavigableContainer.cpp
+++ b/Userland/Libraries/LibWeb/HTML/NavigableContainer.cpp
@@ -217,7 +217,7 @@ static bool url_matches_about_blank(AK::URL const& url)
         && url.serialize_path() == "blank"sv
         && url.username().is_empty()
         && url.password().is_empty()
-        && url.host().is_null();
+        && url.host().has<Empty>();
 }
 
 // https://html.spec.whatwg.org/multipage/iframe-embed-object.html#shared-attribute-processing-steps-for-iframe-and-frame-elements

--- a/Userland/Libraries/LibWeb/HTML/WorkerLocation.cpp
+++ b/Userland/Libraries/LibWeb/HTML/WorkerLocation.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/URLParser.h>
 #include <LibWeb/HTML/WorkerGlobalScope.h>
 #include <LibWeb/HTML/WorkerLocation.h>
 
@@ -43,15 +44,15 @@ WebIDL::ExceptionOr<String> WorkerLocation::host() const
     auto const& url = m_global_scope->url();
 
     // 2. If url's host is null, return the empty string.
-    if (url.host().is_empty())
+    if (url.host().has<Empty>())
         return String {};
 
     // 3. If url's port is null, return url's host, serialized.
     if (!url.port().has_value())
-        return TRY_OR_THROW_OOM(vm, String::from_deprecated_string(url.host()));
+        return TRY_OR_THROW_OOM(vm, url.serialized_host());
 
     // 4. Return url's host, serialized, followed by ":" and url's port, serialized.
-    return TRY_OR_THROW_OOM(vm, String::formatted("{}:{}", url.host().view(), url.port().value()));
+    return TRY_OR_THROW_OOM(vm, String::formatted("{}:{}", TRY_OR_THROW_OOM(vm, url.serialized_host()), url.port().value()));
 }
 
 // https://html.spec.whatwg.org/multipage/workers.html#dom-workerlocation-hostname
@@ -64,11 +65,11 @@ WebIDL::ExceptionOr<String> WorkerLocation::hostname() const
     auto const& host = m_global_scope->url().host();
 
     // 2. If host is null, return the empty string.
-    if (host.is_empty())
+    if (host.has<Empty>())
         return String {};
 
     // 3. Return host, serialized.
-    return TRY_OR_THROW_OOM(vm, String::from_deprecated_string(host));
+    return TRY_OR_THROW_OOM(vm, URLParser::serialize_host(host));
 }
 
 // https://html.spec.whatwg.org/multipage/workers.html#dom-workerlocation-port

--- a/Userland/Libraries/LibWeb/URL/URL.cpp
+++ b/Userland/Libraries/LibWeb/URL/URL.cpp
@@ -235,15 +235,15 @@ WebIDL::ExceptionOr<String> URL::host() const
     auto& url = m_url;
 
     // 2. If url’s host is null, then return the empty string.
-    if (url.host().is_null())
+    if (url.host().has<Empty>())
         return String {};
 
     // 3. If url’s port is null, return url’s host, serialized.
     if (!url.port().has_value())
-        return TRY_OR_THROW_OOM(vm, String::from_deprecated_string(url.host()));
+        return TRY_OR_THROW_OOM(vm, url.serialized_host());
 
     // 4. Return url’s host, serialized, followed by U+003A (:) and url’s port, serialized.
-    return TRY_OR_THROW_OOM(vm, String::formatted("{}:{}", url.host(), *url.port()));
+    return TRY_OR_THROW_OOM(vm, String::formatted("{}:{}", TRY_OR_THROW_OOM(vm, url.serialized_host()), *url.port()));
 }
 
 // https://url.spec.whatwg.org/#dom-url-hostref-for-dom-url-host%E2%91%A0
@@ -265,11 +265,11 @@ WebIDL::ExceptionOr<String> URL::hostname() const
     auto& vm = realm().vm();
 
     // 1. If this’s URL’s host is null, then return the empty string.
-    if (m_url.host().is_null())
+    if (m_url.host().has<Empty>())
         return String {};
 
     // 2. Return this’s URL’s host, serialized.
-    return TRY_OR_THROW_OOM(vm, String::from_deprecated_string(m_url.host()));
+    return TRY_OR_THROW_OOM(vm, m_url.serialized_host());
 }
 
 // https://url.spec.whatwg.org/#ref-for-dom-url-hostname①
@@ -473,7 +473,7 @@ HTML::Origin url_origin(AK::URL const& url)
     if (url.scheme() == "file"sv) {
         // Unfortunate as it is, this is left as an exercise to the reader. When in doubt, return a new opaque origin.
         // Note: We must return an origin with the `file://' protocol for `file://' iframes to work from `file://' pages.
-        return HTML::Origin(url.scheme(), DeprecatedString(), 0);
+        return HTML::Origin(url.scheme(), String {}, 0);
     }
 
     // -> Otherwise

--- a/Userland/Libraries/LibWeb/URL/URL.cpp
+++ b/Userland/Libraries/LibWeb/URL/URL.cpp
@@ -482,12 +482,10 @@ HTML::Origin url_origin(AK::URL const& url)
 }
 
 // https://url.spec.whatwg.org/#concept-domain
-bool host_is_domain(StringView host)
+bool host_is_domain(AK::URL::Host const& host)
 {
     // A domain is a non-empty ASCII string that identifies a realm within a network.
-    return !host.is_empty()
-        && !IPv4Address::from_string(host).has_value()
-        && !IPv6Address::from_string(host).has_value();
+    return host.has<String>() && host.get<String>() != String {};
 }
 
 // https://url.spec.whatwg.org/#concept-url-parser

--- a/Userland/Libraries/LibWeb/URL/URL.h
+++ b/Userland/Libraries/LibWeb/URL/URL.h
@@ -75,7 +75,7 @@ private:
 };
 
 HTML::Origin url_origin(AK::URL const&);
-bool host_is_domain(StringView host);
+bool host_is_domain(AK::URL::Host const&);
 
 // https://url.spec.whatwg.org/#concept-url-parser
 AK::URL parse(StringView input, Optional<AK::URL> const& base_url = {});

--- a/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
+++ b/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
@@ -388,7 +388,7 @@ WebIDL::ExceptionOr<void> XMLHttpRequest::open(String const& method_string, Stri
     // NOTE: This is handled in the overload lacking the async argument.
 
     // 8. If parsedURL’s host is non-null, then:
-    if (!parsed_url.host().is_null()) {
+    if (!parsed_url.host().has<Empty>()) {
         // 1. If the username argument is not null, set the username given parsedURL and username.
         if (username.has_value())
             parsed_url.set_username(username.value().to_deprecated_string());

--- a/Userland/Libraries/LibWebSocket/WebSocket.cpp
+++ b/Userland/Libraries/LibWebSocket/WebSocket.cpp
@@ -171,7 +171,7 @@ void WebSocket::send_client_handshake()
 
     // 4. Host
     auto url = m_connection.url();
-    builder.appendff("Host: {}", url.host());
+    builder.appendff("Host: {}", url.serialized_host().release_value_but_fixme_should_propagate_errors());
     if (!m_connection.is_secure() && url.port_or_default() != 80)
         builder.appendff(":{}", url.port_or_default());
     else if (m_connection.is_secure() && url.port_or_default() != 443)

--- a/Userland/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Userland/Libraries/LibWebView/ViewImplementation.cpp
@@ -344,8 +344,8 @@ void ViewImplementation::handle_web_content_process_crash()
     builder.append(escape_html_entities(m_url.to_deprecated_string()));
     builder.append("</title></head><body>"sv);
     builder.append("<h1>Web page crashed"sv);
-    if (!m_url.host().is_empty()) {
-        builder.appendff(" on {}", escape_html_entities(m_url.host()));
+    if (!m_url.host().has<Empty>()) {
+        builder.appendff(" on {}", escape_html_entities(m_url.serialized_host().release_value_but_fixme_should_propagate_errors()));
     }
     builder.append("</h1>"sv);
     auto escaped_url = escape_html_entities(m_url.to_deprecated_string());

--- a/Userland/Services/RequestServer/ConnectionCache.cpp
+++ b/Userland/Services/RequestServer/ConnectionCache.cpp
@@ -23,7 +23,7 @@ void request_did_finish(URL const& url, Core::Socket const* socket)
 
     dbgln_if(REQUESTSERVER_DEBUG, "Request for {} finished", url);
 
-    ConnectionKey partial_key { url.host(), url.port_or_default() };
+    ConnectionKey partial_key { url.serialized_host().release_value_but_fixme_should_propagate_errors().to_deprecated_string(), url.port_or_default() };
     auto fire_off_next_job = [&](auto& cache) {
         auto it = find_if(cache.begin(), cache.end(), [&](auto& connection) { return connection.key.hostname == partial_key.hostname && connection.key.port == partial_key.port; });
         if (it == cache.end()) {

--- a/Userland/Services/RequestServer/ConnectionCache.h
+++ b/Userland/Services/RequestServer/ConnectionCache.h
@@ -37,14 +37,14 @@ struct Proxy {
     ErrorOr<NonnullOwnPtr<StorageType>> tunnel(URL const& url, Args&&... args)
     {
         if (data.type == Core::ProxyData::Direct) {
-            return TRY(SocketType::connect(url.host(), url.port_or_default(), forward<Args>(args)...));
+            return TRY(SocketType::connect(url.serialized_host().release_value_but_fixme_should_propagate_errors().to_deprecated_string(), url.port_or_default(), forward<Args>(args)...));
         }
         if (data.type == Core::ProxyData::SOCKS5) {
             if constexpr (requires { SocketType::connect(declval<DeprecatedString>(), *proxy_client_storage, forward<Args>(args)...); }) {
-                proxy_client_storage = TRY(Core::SOCKSProxyClient::connect(data.host_ipv4, data.port, Core::SOCKSProxyClient::Version::V5, url.host(), url.port_or_default()));
-                return TRY(SocketType::connect(url.host(), *proxy_client_storage, forward<Args>(args)...));
+                proxy_client_storage = TRY(Core::SOCKSProxyClient::connect(data.host_ipv4, data.port, Core::SOCKSProxyClient::Version::V5, url.serialized_host().release_value_but_fixme_should_propagate_errors().to_deprecated_string(), url.port_or_default()));
+                return TRY(SocketType::connect(url.serialized_host().release_value_but_fixme_should_propagate_errors().to_deprecated_string(), *proxy_client_storage, forward<Args>(args)...));
             } else if constexpr (IsSame<SocketType, Core::TCPSocket>) {
-                return TRY(Core::SOCKSProxyClient::connect(data.host_ipv4, data.port, Core::SOCKSProxyClient::Version::V5, url.host(), url.port_or_default()));
+                return TRY(Core::SOCKSProxyClient::connect(data.host_ipv4, data.port, Core::SOCKSProxyClient::Version::V5, url.serialized_host().release_value_but_fixme_should_propagate_errors().to_deprecated_string(), url.port_or_default()));
             } else {
                 return Error::from_string_literal("SOCKS5 not supported for this socket type");
             }
@@ -173,7 +173,7 @@ ErrorOr<void> recreate_socket_if_needed(T& connection, URL const& url)
 decltype(auto) get_or_create_connection(auto& cache, URL const& url, auto& job, Core::ProxyData proxy_data = {})
 {
     using CacheEntryType = RemoveCVReference<decltype(*cache.begin()->value)>;
-    auto& sockets_for_url = *cache.ensure({ url.host(), url.port_or_default(), proxy_data }, [] { return make<CacheEntryType>(); });
+    auto& sockets_for_url = *cache.ensure({ url.serialized_host().release_value_but_fixme_should_propagate_errors().to_deprecated_string(), url.port_or_default(), proxy_data }, [] { return make<CacheEntryType>(); });
 
     Proxy proxy { proxy_data };
 

--- a/Userland/Services/RequestServer/ConnectionFromClient.cpp
+++ b/Userland/Services/RequestServer/ConnectionFromClient.cpp
@@ -147,7 +147,7 @@ void ConnectionFromClient::ensure_connection(URL const& url, ::RequestServer::Ca
     }
 
     if (cache_level == CacheLevel::ResolveOnly) {
-        return Core::deferred_invoke([host = url.host()] {
+        return Core::deferred_invoke([host = url.serialized_host().release_value_but_fixme_should_propagate_errors().to_deprecated_string()] {
             dbgln("EnsureConnection: DNS-preload for {}", host);
             (void)gethostbyname(host.characters());
         });
@@ -156,7 +156,8 @@ void ConnectionFromClient::ensure_connection(URL const& url, ::RequestServer::Ca
     auto& job = Job::ensure(url);
     dbgln("EnsureConnection: Pre-connect to {}", url);
     auto do_preconnect = [&](auto& cache) {
-        auto it = cache.find({ url.host(), url.port_or_default() });
+        auto serialized_host = url.serialized_host().release_value_but_fixme_should_propagate_errors().to_deprecated_string();
+        auto it = cache.find({ serialized_host, url.port_or_default() });
         if (it == cache.end() || it->value->is_empty())
             ConnectionCache::get_or_create_connection(cache, url, job);
     };

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -112,10 +112,10 @@ void ConnectionFromClient::load_url(const URL& url)
 
 #if defined(AK_OS_SERENITY)
     DeprecatedString process_name;
-    if (url.host().is_empty())
+    if (url.host().has<Empty>() || url.host() == String {})
         process_name = "WebContent";
     else
-        process_name = DeprecatedString::formatted("WebContent: {}", url.host());
+        process_name = DeprecatedString::formatted("WebContent: {}", url.serialized_host().release_value_but_fixme_should_propagate_errors());
 
     pthread_setname_np(pthread_self(), process_name.characters());
 #endif

--- a/Userland/Shell/AST.cpp
+++ b/Userland/Shell/AST.cpp
@@ -679,7 +679,7 @@ ErrorOr<void> BarewordLiteral::highlight_in_editor(Line::Editor& editor, Shell& 
     if (FileSystem::exists(m_text)) {
         auto realpath = shell.resolve_path(m_text.bytes_as_string_view());
         auto url = URL::create_with_file_scheme(realpath);
-        url.set_host(shell.hostname);
+        url.set_host(TRY(String::from_deprecated_string(shell.hostname)));
         editor.stylize({ m_position.start_offset, m_position.end_offset }, { Line::Style::Hyperlink(url.to_deprecated_string()) });
     }
     return {};
@@ -2620,7 +2620,7 @@ ErrorOr<void> PathRedirectionNode::highlight_in_editor(Line::Editor& editor, She
         if (!path.starts_with('/'))
             path = String::formatted("{}/{}", shell.cwd, path).release_value_but_fixme_should_propagate_errors();
         auto url = URL::create_with_file_scheme(path.to_deprecated_string());
-        url.set_host(shell.hostname);
+        url.set_host(TRY(String::from_deprecated_string(shell.hostname)));
         editor.stylize({ position.start_offset, position.end_offset }, { Line::Style::Hyperlink(url.to_deprecated_string()) });
     }
     return {};
@@ -3214,7 +3214,7 @@ ErrorOr<void> Juxtaposition::highlight_in_editor(Line::Editor& editor, Shell& sh
         if (FileSystem::exists(path)) {
             auto realpath = shell.resolve_path(path);
             auto url = URL::create_with_file_scheme(realpath);
-            url.set_host(shell.hostname);
+            url.set_host(TRY(String::from_deprecated_string(shell.hostname)));
             editor.stylize({ m_position.start_offset, m_position.end_offset }, { Line::Style::Hyperlink(url.to_deprecated_string()) });
         }
 

--- a/Userland/Utilities/markdown-check.cpp
+++ b/Userland/Utilities/markdown-check.cpp
@@ -191,7 +191,7 @@ RecursionDecision MarkdownLinkage::visit(Markdown::Text::LinkNode const& link_no
             return RecursionDecision::Recurse;
         }
         if (url.scheme() == "help") {
-            if (url.host() != "man") {
+            if (url.host() != String::from_utf8_short_string("man"sv)) {
                 warnln("help:// URL without 'man': {}", href);
                 m_has_invalid_link = true;
                 return RecursionDecision::Recurse;

--- a/Userland/Utilities/pro.cpp
+++ b/Userland/Utilities/pro.cpp
@@ -343,7 +343,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                 if (output_name.is_empty() || output_name == "/") {
                     int i = -1;
                     do {
-                        output_name = url.host();
+                        output_name = url.serialized_host().release_value_but_fixme_should_propagate_errors().to_deprecated_string();
                         if (i > -1)
                             output_name = DeprecatedString::formatted("{}.{}", output_name, i);
                         ++i;


### PR DESCRIPTION
In order to follow spec text to achieve this, we need to change the
underlying representation of a host in AK::URL in deserialized format
Before this, we were parsing the host and then immediately serializing
it again.

Making that change resulted in a whole bunch of fallout.

After this change, callers can access the serialized data through
this concept-host-serializer. The functional end result of this
change is that IPv6 hosts are now correctly serialized to be
surrounded with '[' and ']'.