### PR TITLE
LibJS: Add three more await thenable tests

### DIFF
--- a/Userland/Libraries/LibJS/Tests/syntax/async-await.js
+++ b/Userland/Libraries/LibJS/Tests/syntax/async-await.js
@@ -201,14 +201,71 @@ describe("await cannot be used in class static init blocks", () => {
     });
 });
 
-test.xfailIf(isBytecodeInterpreterEnabled(), "async returning a thenable", () => {
-    let isCalled = false;
-    const f = async () => ({
-        then() {
-            isCalled = true;
-        },
+describe("await thenables", () => {
+    // FIXME: This test crashes for AST, and fails for bytecode.
+    test.skip("async returning a thanable variable without fulfilling", () => {
+        let isCalled = false;
+        const obj = {
+            then() {
+                isCalled = true;
+            },
+        };
+
+        const f = async () => await obj;
+        f();
+        runQueuedPromiseJobs();
+        expect(isCalled).toBe(true);
     });
-    f();
-    runQueuedPromiseJobs();
-    expect(isCalled).toBe(true);
+
+    test.xfailIf(
+        isBytecodeInterpreterEnabled(),
+        "async returning a thanable variable that fulfills",
+        () => {
+            let isCalled = false;
+            const obj = {
+                then(fulfill) {
+                    isCalled = true;
+                    fulfill(isCalled);
+                },
+            };
+
+            const f = async () => await obj;
+            f();
+            runQueuedPromiseJobs();
+            expect(isCalled).toBe(true);
+        }
+    );
+
+    test.xfailIf(
+        isBytecodeInterpreterEnabled(),
+        "async returning a thenable directly without fulfilling",
+        () => {
+            let isCalled = false;
+            const f = async () => ({
+                then() {
+                    isCalled = true;
+                },
+            });
+            f();
+            runQueuedPromiseJobs();
+            expect(isCalled).toBe(true);
+        }
+    );
+
+    test.xfailIf(
+        isBytecodeInterpreterEnabled(),
+        "async returning a thenable directly that fulfills",
+        () => {
+            let isCalled = false;
+            const f = async () => ({
+                then(fulfill) {
+                    isCalled = true;
+                    fulfill(isCalled);
+                },
+            });
+            f();
+            runQueuedPromiseJobs();
+            expect(isCalled).toBe(true);
+        }
+    );
 });


### PR DESCRIPTION
The first test crashes in AST, and fails in bytecode, so the best thing which we can do here without complicated test setup logic is to just skip this test for now. Interestingly, this crashing test is very similar to the existing thenable test case, and only differs in the way that the thenable is given to the async function.

The next two tests are effectively the same as the above two mentioned tests, with the only different being that the thenable calls the fulfill function. For the test case that crashes in AST mode, doing that appears to fix the test case for AST mode (but both still fail in bytecode).