### PR TITLE
LibWeb+Ladybird: Better looking text on Twinings :^)

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPropertyID.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPropertyID.cpp
@@ -105,6 +105,7 @@ namespace Web::CSS {
 enum class PropertyID {
     Invalid,
     Custom,
+    All,
 )~~~"));
 
     Vector<DeprecatedString> shorthand_property_ids;
@@ -361,6 +362,8 @@ Optional<PropertyID> property_id_from_camel_case_string(StringView string)
 
 Optional<PropertyID> property_id_from_string(StringView string)
 {
+    if (Infra::is_ascii_case_insensitive_match(string, "all"sv))
+        return PropertyID::All;
 )~~~"));
 
     TRY(properties.try_for_each_member([&](auto& name, auto& value) -> ErrorOr<void> {

--- a/Tests/LibWeb/Layout/expected/css-all-unset.txt
+++ b/Tests/LibWeb/Layout/expected/css-all-unset.txt
@@ -1,0 +1,12 @@
+Viewport <#document> at (0,0) content-size 800x600 children: inline
+  line 0 width: 238.125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+    frag 0 from TextNode start: 1, length: 18, rect: [0,0 134.984375x17.46875]
+      "* { all: unset; } "
+    frag 1 from TextNode start: 0, length: 13, rect: [134.984375,0 103.140625x17.46875]
+      "Hello friends"
+  InlineNode <html>
+    InlineNode <head>
+      InlineNode <style>
+        TextNode <#text>
+    InlineNode <body>
+      TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/css-revert.txt
+++ b/Tests/LibWeb/Layout/expected/css-revert.txt
@@ -1,0 +1,7 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x17.46875 [BFC] children: not-inline
+    BlockContainer <body> at (0,0) content-size 800x17.46875 children: inline
+      line 0 width: 103.140625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+        frag 0 from TextNode start: 0, length: 13, rect: [0,0 103.140625x17.46875]
+          "Hello friends"
+      TextNode <#text>

--- a/Tests/LibWeb/Layout/input/css-all-unset.html
+++ b/Tests/LibWeb/Layout/input/css-all-unset.html
@@ -1,0 +1,3 @@
+<!doctype html><style>
+* { all: unset; }
+</style>Hello friends

--- a/Tests/LibWeb/Layout/input/css-revert.html
+++ b/Tests/LibWeb/Layout/input/css-revert.html
@@ -1,0 +1,6 @@
+<!doctype html><style>
+* {
+    all: unset;
+    display: revert;
+}
+</style>Hello friends

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -76,6 +76,7 @@
 #include <LibWeb/CSS/StyleValues/RatioStyleValue.h>
 #include <LibWeb/CSS/StyleValues/RectStyleValue.h>
 #include <LibWeb/CSS/StyleValues/ResolutionStyleValue.h>
+#include <LibWeb/CSS/StyleValues/RevertStyleValue.h>
 #include <LibWeb/CSS/StyleValues/ShadowStyleValue.h>
 #include <LibWeb/CSS/StyleValues/StringStyleValue.h>
 #include <LibWeb/CSS/StyleValues/StyleValueList.h>
@@ -3352,7 +3353,9 @@ ErrorOr<RefPtr<StyleValue>> Parser::parse_builtin_value(ComponentValue const& co
             return InitialStyleValue::the();
         if (ident.equals_ignoring_ascii_case("unset"sv))
             return UnsetStyleValue::the();
-        // FIXME: Implement `revert` and `revert-layer` keywords, from Cascade4 and Cascade5 respectively
+        if (ident.equals_ignoring_ascii_case("revert"sv))
+            return RevertStyleValue::the();
+        // FIXME: Implement `revert-layer` from CSS-CASCADE-5.
     }
 
     return nullptr;

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.h
@@ -154,7 +154,7 @@ private:
     bool expand_variables(DOM::Element&, Optional<CSS::Selector::PseudoElement>, StringView property_name, HashMap<FlyString, NonnullRefPtr<PropertyDependencyNode>>& dependencies, Parser::TokenStream<Parser::ComponentValue>& source, Vector<Parser::ComponentValue>& dest) const;
     bool expand_unresolved_values(DOM::Element&, StringView property_name, Parser::TokenStream<Parser::ComponentValue>& source, Vector<Parser::ComponentValue>& dest) const;
 
-    void set_all_properties(DOM::Element&, Optional<CSS::Selector::PseudoElement>, StyleProperties&, StyleValue const&, DOM::Document&, CSS::CSSStyleDeclaration const*) const;
+    void set_all_properties(DOM::Element&, Optional<CSS::Selector::PseudoElement>, StyleProperties&, StyleValue const&, DOM::Document&, CSS::CSSStyleDeclaration const*, StyleProperties::PropertyValues const& properties_for_revert) const;
 
     template<typename Callback>
     void for_each_stylesheet(CascadeOrigin, Callback) const;

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.h
@@ -154,6 +154,8 @@ private:
     bool expand_variables(DOM::Element&, Optional<CSS::Selector::PseudoElement>, StringView property_name, HashMap<FlyString, NonnullRefPtr<PropertyDependencyNode>>& dependencies, Parser::TokenStream<Parser::ComponentValue>& source, Vector<Parser::ComponentValue>& dest) const;
     bool expand_unresolved_values(DOM::Element&, StringView property_name, Parser::TokenStream<Parser::ComponentValue>& source, Vector<Parser::ComponentValue>& dest) const;
 
+    void set_all_properties(DOM::Element&, Optional<CSS::Selector::PseudoElement>, StyleProperties&, StyleValue const&, DOM::Document&, CSS::CSSStyleDeclaration const*) const;
+
     template<typename Callback>
     void for_each_stylesheet(CascadeOrigin, Callback) const;
 

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.h
@@ -35,6 +35,12 @@ public:
         }
     }
 
+    struct StyleAndSourceDeclaration {
+        NonnullRefPtr<StyleValue const> style;
+        CSS::CSSStyleDeclaration const* declaration = nullptr;
+    };
+    using PropertyValues = Array<Optional<StyleAndSourceDeclaration>, to_underlying(CSS::last_property_id) + 1>;
+
     auto& properties() { return m_property_values; }
     auto const& properties() const { return m_property_values; }
 
@@ -138,11 +144,7 @@ public:
 private:
     friend class StyleComputer;
 
-    struct StyleAndSourceDeclaration {
-        NonnullRefPtr<StyleValue const> style;
-        CSS::CSSStyleDeclaration const* declaration = nullptr;
-    };
-    Array<Optional<StyleAndSourceDeclaration>, to_underlying(CSS::last_property_id) + 1> m_property_values;
+    PropertyValues m_property_values;
     Optional<CSS::Overflow> overflow(CSS::PropertyID) const;
     Vector<CSS::ShadowData> shadow(CSS::PropertyID, Layout::Node const&) const;
 

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -132,6 +132,7 @@ public:
         Ratio,
         Rect,
         Resolution,
+        Revert,
         Shadow,
         String,
         TextDecoration,
@@ -191,6 +192,7 @@ public:
     bool is_ratio() const { return type() == Type::Ratio; }
     bool is_rect() const { return type() == Type::Rect; }
     bool is_resolution() const { return type() == Type::Resolution; }
+    bool is_revert() const { return type() == Type::Revert; }
     bool is_shadow() const { return type() == Type::Shadow; }
     bool is_string() const { return type() == Type::String; }
     bool is_text_decoration() const { return type() == Type::TextDecoration; }

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/RevertStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/RevertStyleValue.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2023, Andreas Kling <kling@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibWeb/CSS/StyleValue.h>
+
+namespace Web::CSS {
+
+class RevertStyleValue final : public StyleValueWithDefaultOperators<RevertStyleValue> {
+public:
+    static ErrorOr<ValueComparingNonnullRefPtr<RevertStyleValue>> the()
+    {
+        static ValueComparingNonnullRefPtr<RevertStyleValue> instance = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) RevertStyleValue));
+        return instance;
+    }
+    virtual ~RevertStyleValue() override = default;
+
+    ErrorOr<String> to_string() const override { return "revert"_string; }
+
+    bool properties_equal(RevertStyleValue const&) const { return true; }
+
+private:
+    RevertStyleValue()
+        : StyleValueWithDefaultOperators(Type::Revert)
+    {
+    }
+};
+
+}


### PR DESCRIPTION
Three things:

- Stop asking Qt about default fonts since it gets most answers wrong anyway. We get better results by just using our default fallback lists.
- Implement CSS `all` property keyword
- Implement CSS `revert` value keyword

Before:
![Screenshot at 2023-07-29 17-45-01](https://github.com/SerenityOS/serenity/assets/5954907/c2a7de77-bfec-4b46-839e-16141d9a44ef)

After:
![Screenshot at 2023-07-29 17-40-34](https://github.com/SerenityOS/serenity/assets/5954907/acbbfd47-89f9-47de-9500-b8e60fb04a78)