### PR TITLE
Ladybird: Keep toolbar icons crisp on high-DPI displays 

### DIFF
--- a/Ladybird/CMakeLists.txt
+++ b/Ladybird/CMakeLists.txt
@@ -91,6 +91,7 @@ set(SOURCES
     Settings.cpp
     SettingsDialog.cpp
     Tab.cpp
+    TVGIconEngine.cpp
     Utilities.cpp
     WebContentView.cpp
     ladybird.qrc

--- a/Ladybird/TVGIconEngine.cpp
+++ b/Ladybird/TVGIconEngine.cpp
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2023, MacDue <macdue@dueutil.tech>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/MemoryStream.h>
+#include <AK/String.h>
+#include <LibGfx/Painter.h>
+#include <QFile>
+#include <QImage>
+#include <QPainter>
+#include <QPixmapCache>
+
+#include "TVGIconEngine.h"
+#include "Utilities.h"
+
+void TVGIconEngine::paint(QPainter* qpainter, QRect const& rect, QIcon::Mode mode, QIcon::State state)
+{
+    qpainter->drawPixmap(rect, pixmap(rect.size(), mode, state));
+}
+
+QIconEngine* TVGIconEngine::clone() const
+{
+    return new TVGIconEngine(*this);
+}
+
+QPixmap TVGIconEngine::pixmap(QSize const& size, QIcon::Mode mode, QIcon::State state)
+{
+    QPixmap pixmap;
+    auto key = pixmap_cache_key(size, mode, state);
+    if (QPixmapCache::find(key, &pixmap))
+        return pixmap;
+    auto bitmap = MUST(Gfx::Bitmap::create(Gfx::BitmapFormat::BGRA8888, { size.width(), size.height() }));
+    Gfx::Painter painter { *bitmap };
+    auto icon_rect = m_image_data->rect().to_type<float>();
+    auto scale = min(size.width() / icon_rect.width(), size.height() / icon_rect.height()) * m_scale;
+    auto centered = Gfx::FloatRect { {}, icon_rect.size().scaled_by(scale) }
+                        .centered_within(Gfx::FloatRect { {}, { size.width(), size.height() } });
+    auto transform = Gfx::AffineTransform {}
+                         .translate(centered.location())
+                         .multiply(Gfx::AffineTransform {}.scale(scale, scale));
+    m_image_data->draw_transformed(painter, transform);
+    for (auto const& filter : m_filters) {
+        if (filter->mode() == mode) {
+            painter.blit_filtered({}, *bitmap, bitmap->rect(), filter->function(), false);
+            break;
+        }
+    }
+    QImage qimage { bitmap->scanline_u8(0), bitmap->width(), bitmap->height(), QImage::Format::Format_ARGB32 };
+    pixmap = QPixmap::fromImage(qimage);
+    if (!pixmap.isNull())
+        QPixmapCache::insert(key, pixmap);
+    return pixmap;
+}
+
+QString TVGIconEngine::pixmap_cache_key(QSize const& size, QIcon::Mode mode, QIcon::State state)
+{
+    return qstring_from_ak_string(
+        MUST(String::formatted("$sernity_tvgicon_{}_{}x{}_{}_{}", m_cache_id, size.width(), size.height(), to_underlying(mode), to_underlying(state))));
+}
+
+void TVGIconEngine::add_filter(QIcon::Mode mode, Function<Color(Color)> filter)
+{
+    m_filters.empend(adopt_ref(*new Filter(mode, move(filter))));
+    invalidate_cache();
+}
+
+TVGIconEngine* TVGIconEngine::from_file(QString const& path)
+{
+    QFile icon_resource(path);
+    if (!icon_resource.open(QIODeviceBase::ReadOnly))
+        return nullptr;
+    auto icon_data = icon_resource.readAll();
+    FixedMemoryStream icon_bytes { ReadonlyBytes { icon_data.data(), static_cast<size_t>(icon_data.size()) } };
+    if (auto tvg = Gfx::TinyVGDecodedImageData::decode(icon_bytes); !tvg.is_error())
+        return new TVGIconEngine(tvg.release_value());
+    return nullptr;
+}

--- a/Ladybird/TVGIconEngine.h
+++ b/Ladybird/TVGIconEngine.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2023, MacDue <macdue@dueutil.tech>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Function.h>
+#include <AK/RefCounted.h>
+#include <AK/Vector.h>
+#include <LibGfx/ImageFormats/TinyVGLoader.h>
+#include <QIconEngine>
+
+class TVGIconEngine : public QIconEngine {
+public:
+    TVGIconEngine(Gfx::TinyVGDecodedImageData const& image_data)
+        : m_image_data(image_data)
+    {
+    }
+
+    static TVGIconEngine* from_file(QString const& path);
+
+    void paint(QPainter* painter, QRect const& rect, QIcon::Mode mode,
+        QIcon::State state) override;
+    QIconEngine* clone() const override;
+    QPixmap pixmap(QSize const& size, QIcon::Mode mode,
+        QIcon::State state) override;
+
+    void add_filter(QIcon::Mode mode, Function<Color(Color)> filter);
+
+    void set_scale(float scale)
+    {
+        m_scale = scale;
+        invalidate_cache();
+    }
+
+private:
+    static unsigned next_cache_id()
+    {
+        static unsigned cache_id = 0;
+        return cache_id++;
+    }
+
+    void invalidate_cache()
+    {
+        m_cache_id = next_cache_id();
+    }
+
+    class Filter : public RefCounted<Filter> {
+    public:
+        Filter(QIcon::Mode mode, Function<Color(Color)> function)
+            : m_mode(mode)
+            , m_function(move(function))
+        {
+        }
+        QIcon::Mode mode() const { return m_mode; }
+        Function<Color(Color)> const& function() const { return m_function; }
+
+    private:
+        QIcon::Mode m_mode;
+        Function<Color(Color)> m_function;
+    };
+
+    QString pixmap_cache_key(QSize const& size, QIcon::Mode mode, QIcon::State state);
+
+    float m_scale { 1 };
+    Vector<NonnullRefPtr<Filter>> m_filters;
+    NonnullRefPtr<Gfx::TinyVGDecodedImageData> m_image_data;
+    unsigned m_cache_id { next_cache_id() };
+};

--- a/Ladybird/Tab.h
+++ b/Ladybird/Tab.h
@@ -68,7 +68,7 @@ private:
     virtual void resizeEvent(QResizeEvent*) override;
     virtual bool event(QEvent*) override;
 
-    void rerender_toolbar_icons();
+    void recreate_toolbar_icons();
     void update_hover_label();
 
     void open_link(URL const&);

--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -934,7 +934,7 @@ void Painter::blit_with_opacity(IntPoint position, Gfx::Bitmap const& source, In
     }
 }
 
-void Painter::blit_filtered(IntPoint position, Gfx::Bitmap const& source, IntRect const& src_rect, Function<Color(Color)> const& filter)
+void Painter::blit_filtered(IntPoint position, Gfx::Bitmap const& source, IntRect const& src_rect, Function<Color(Color)> const& filter, bool apply_alpha)
 {
     VERIFY((source.scale() == 1 || source.scale() == scale()) && "blit_filtered only supports integer upsampling");
 
@@ -969,7 +969,7 @@ void Painter::blit_filtered(IntPoint position, Gfx::Bitmap const& source, IntRec
                 if (source_color.alpha() == 0)
                     continue;
                 auto filtered_color = filter(source_color);
-                if (filtered_color.alpha() == 0xff)
+                if (!apply_alpha || filtered_color.alpha() == 0xff)
                     dst[x] = filtered_color.value();
                 else
                     dst[x] = color_for_format(dst_format, dst[x]).blend(filtered_color).value();
@@ -985,7 +985,7 @@ void Painter::blit_filtered(IntPoint position, Gfx::Bitmap const& source, IntRec
                 if (source_color.alpha() == 0)
                     continue;
                 auto filtered_color = filter(source_color);
-                if (filtered_color.alpha() == 0xff)
+                if (!apply_alpha || filtered_color.alpha() == 0xff)
                     dst[x] = filtered_color.value();
                 else
                     dst[x] = color_for_format(dst_format, dst[x]).blend(filtered_color).value();

--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -934,7 +934,7 @@ void Painter::blit_with_opacity(IntPoint position, Gfx::Bitmap const& source, In
     }
 }
 
-void Painter::blit_filtered(IntPoint position, Gfx::Bitmap const& source, IntRect const& src_rect, Function<Color(Color)> filter)
+void Painter::blit_filtered(IntPoint position, Gfx::Bitmap const& source, IntRect const& src_rect, Function<Color(Color)> const& filter)
 {
     VERIFY((source.scale() == 1 || source.scale() == scale()) && "blit_filtered only supports integer upsampling");
 

--- a/Userland/Libraries/LibGfx/Painter.h
+++ b/Userland/Libraries/LibGfx/Painter.h
@@ -84,7 +84,7 @@ public:
     void blit(IntPoint, Gfx::Bitmap const&, IntRect const& src_rect, float opacity = 1.0f, bool apply_alpha = true);
     void blit_dimmed(IntPoint, Gfx::Bitmap const&, IntRect const& src_rect);
     void blit_brightened(IntPoint, Gfx::Bitmap const&, IntRect const& src_rect);
-    void blit_filtered(IntPoint, Gfx::Bitmap const&, IntRect const& src_rect, Function<Color(Color)>);
+    void blit_filtered(IntPoint, Gfx::Bitmap const&, IntRect const& src_rect, Function<Color(Color)> const&);
     void draw_tiled_bitmap(IntRect const& dst_rect, Gfx::Bitmap const&);
     void blit_offset(IntPoint, Gfx::Bitmap const&, IntRect const& src_rect, IntPoint);
     void blit_disabled(IntPoint, Gfx::Bitmap const&, IntRect const&, Palette const&);

--- a/Userland/Libraries/LibGfx/Painter.h
+++ b/Userland/Libraries/LibGfx/Painter.h
@@ -84,7 +84,7 @@ public:
     void blit(IntPoint, Gfx::Bitmap const&, IntRect const& src_rect, float opacity = 1.0f, bool apply_alpha = true);
     void blit_dimmed(IntPoint, Gfx::Bitmap const&, IntRect const& src_rect);
     void blit_brightened(IntPoint, Gfx::Bitmap const&, IntRect const& src_rect);
-    void blit_filtered(IntPoint, Gfx::Bitmap const&, IntRect const& src_rect, Function<Color(Color)> const&);
+    void blit_filtered(IntPoint, Gfx::Bitmap const&, IntRect const& src_rect, Function<Color(Color)> const&, bool apply_alpha = true);
     void draw_tiled_bitmap(IntRect const& dst_rect, Gfx::Bitmap const&);
     void blit_offset(IntPoint, Gfx::Bitmap const&, IntRect const& src_rect, IntPoint);
     void blit_disabled(IntPoint, Gfx::Bitmap const&, IntRect const&, Palette const&);


### PR DESCRIPTION
Rather than blit the icons to 16x16 bitmaps use a custom `QIconEngine` that keeps them as vector graphics.

**Before (2x)**
![Screenshot from 2023-07-29 19-53-28](https://github.com/SerenityOS/serenity/assets/11597044/5d1b2a58-7e03-4a61-a594-8cb0eb803f73)
**After (2x)**
![Screenshot from 2023-07-29 19-52-22](https://github.com/SerenityOS/serenity/assets/11597044/c12c965d-8fda-4396-b3da-33368c75d97e)
