### PR TITLE
LibDiff+patch: Support creating a file, and parsing multiple patches in a patch file

### DIFF
--- a/Tests/Utilities/TestPatch.cpp
+++ b/Tests/Utilities/TestPatch.cpp
@@ -149,3 +149,19 @@ TEST_CASE(strip_path_partially)
 
     EXPECT_FILE_EQ(MUST(String::formatted("{}/to/basename", s_test_dir)), "Hello, friends!\n");
 }
+
+TEST_CASE(add_file_from_scratch)
+{
+    PatchSetup setup;
+
+    auto patch = R"(
+--- /dev/null
++++ a/file_to_add
+@@ -0,0 +1 @@
++Hello, friends!
+)"sv;
+
+    run_patch({}, patch, "patching file file_to_add\n"sv);
+
+    EXPECT_FILE_EQ(MUST(String::formatted("{}/file_to_add", s_test_dir)), "Hello, friends!\n");
+}

--- a/Tests/Utilities/TestPatch.cpp
+++ b/Tests/Utilities/TestPatch.cpp
@@ -165,3 +165,25 @@ TEST_CASE(add_file_from_scratch)
 
     EXPECT_FILE_EQ(MUST(String::formatted("{}/file_to_add", s_test_dir)), "Hello, friends!\n");
 }
+
+TEST_CASE(two_patches_in_single_patch_file)
+{
+    PatchSetup setup;
+
+    auto patch = R"(
+--- /dev/null
++++ a/first_file_to_add
+@@ -0,0 +1 @@
++Hello, friends!
+--- /dev/null
++++ a/second_file_to_add
+@@ -0,0 +1 @@
++Hello, friends!
+)"sv;
+
+    run_patch({}, patch, "patching file first_file_to_add\n"
+                         "patching file second_file_to_add\n"sv);
+
+    EXPECT_FILE_EQ(MUST(String::formatted("{}/first_file_to_add", s_test_dir)), "Hello, friends!\n");
+    EXPECT_FILE_EQ(MUST(String::formatted("{}/second_file_to_add", s_test_dir)), "Hello, friends!\n");
+}

--- a/Userland/Libraries/LibDiff/Hunks.h
+++ b/Userland/Libraries/LibDiff/Hunks.h
@@ -80,11 +80,13 @@ class Parser : public GenericLexer {
 public:
     using GenericLexer::GenericLexer;
 
+    ErrorOr<Patch> parse_patch(Optional<size_t> const& strip_count = {});
+
     ErrorOr<Vector<Hunk>> parse_hunks();
 
+private:
     ErrorOr<Header> parse_header(Optional<size_t> const& strip_count);
 
-private:
     ErrorOr<String> parse_file_line(Optional<size_t> const& strip_count);
     Optional<HunkLocation> consume_unified_location();
     bool consume_line_number(size_t& number);

--- a/Userland/Utilities/patch.cpp
+++ b/Userland/Utilities/patch.cpp
@@ -12,10 +12,31 @@
 #include <LibFileSystem/FileSystem.h>
 #include <LibMain/Main.h>
 
+static bool is_adding_file(Diff::Patch const& patch)
+{
+    return patch.hunks[0].location.old_range.start_line == 0;
+}
+
+static ErrorOr<ByteBuffer> read_content(StringView path_of_file_to_patch, Diff::Patch const& patch)
+{
+    auto file_to_patch_or_error = Core::File::open(path_of_file_to_patch, Core::File::OpenMode::Read);
+
+    // Trivial case - no error reading the file.
+    if (!file_to_patch_or_error.is_error())
+        return TRY(file_to_patch_or_error.release_value()->read_until_eof());
+
+    auto const& error = file_to_patch_or_error.error();
+
+    // If the patch is adding a file then it is fine for opening the file to error out if it did not exist.
+    if (!is_adding_file(patch) || !error.is_errno() || error.code() != ENOENT)
+        return file_to_patch_or_error.release_error();
+
+    return ByteBuffer {};
+}
+
 static ErrorOr<void> do_patch(StringView path_of_file_to_patch, Diff::Patch const& patch)
 {
-    auto file_to_patch = TRY(Core::File::open(path_of_file_to_patch, Core::File::OpenMode::Read));
-    auto content = TRY(file_to_patch->read_until_eof());
+    ByteBuffer content = TRY(read_content(path_of_file_to_patch, patch));
     auto lines = StringView(content).lines();
 
     // Apply patch to a temporary file in case one or more of the hunks fails.
@@ -54,7 +75,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     StringView to_patch;
     if (FileSystem::is_regular_file(patch.header.old_file_path)) {
         to_patch = patch.header.old_file_path;
-    } else if (FileSystem::is_regular_file(patch.header.new_file_path)) {
+    } else if (is_adding_file(patch) || FileSystem::is_regular_file(patch.header.new_file_path)) {
         to_patch = patch.header.new_file_path;
     } else {
         warnln("Unable to determine file to patch");

--- a/Userland/Utilities/run-tests.cpp
+++ b/Userland/Utilities/run-tests.cpp
@@ -121,10 +121,10 @@ void TestRunner::do_run_single_test(DeprecatedString const& test_path, size_t cu
         ++m_counts.tests_passed;
         break;
     case Test::Result::ExpectedFail:
-        ++m_counts.tests_passed;
+        ++m_counts.tests_expected_failed;
         break;
     case Test::Result::Skip:
-        ++m_counts.tests_expected_failed;
+        ++m_counts.tests_skipped;
         break;
     case Test::Result::Fail:
         ++m_counts.tests_failed;


### PR DESCRIPTION
![image](https://github.com/SerenityOS/serenity/assets/35911232/0b3431e0-a819-4d56-8e8c-1f569213b534)

And a small bug fix for `run-tests` I noticed while testing this.