### PR TITLE
Ladybird: Use plain QCoreApplication in WebContent process

### DIFF
--- a/Ladybird/WebContent/CMakeLists.txt
+++ b/Ladybird/WebContent/CMakeLists.txt
@@ -27,7 +27,7 @@ qt_add_executable(WebContent ${WEBCONTENT_SOURCES})
 
 target_include_directories(WebContent PRIVATE ${SERENITY_SOURCE_DIR}/Userland/Services/)
 target_include_directories(WebContent PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/..)
-target_link_libraries(WebContent PRIVATE Qt::Core Qt::Gui Qt::Network Qt::Multimedia LibAudio LibCore LibFileSystem LibGfx LibIPC LibJS LibMain LibWeb LibWebSocket)
+target_link_libraries(WebContent PRIVATE Qt::Core Qt::Network Qt::Multimedia LibAudio LibCore LibFileSystem LibGfx LibIPC LibJS LibMain LibWeb LibWebSocket)
 if (ANDROID)
     link_android_libs(WebContent)
 endif()

--- a/Ladybird/WebContent/main.cpp
+++ b/Ladybird/WebContent/main.cpp
@@ -29,7 +29,7 @@
 #include <LibWeb/PermissionsPolicy/AutoplayAllowlist.h>
 #include <LibWeb/Platform/EventLoopPluginSerenity.h>
 #include <LibWeb/WebSockets/WebSocket.h>
-#include <QGuiApplication>
+#include <QCoreApplication>
 #include <QTimer>
 #include <WebContent/ConnectionFromClient.h>
 #include <WebContent/PageHost.h>
@@ -46,7 +46,7 @@ extern DeprecatedString s_serenity_resource_root;
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    QGuiApplication app(arguments.argc, arguments.argv);
+    QCoreApplication app(arguments.argc, arguments.argv);
 
 #if defined(AK_OS_MACOS)
     prohibit_interaction();


### PR DESCRIPTION
Now that we no longer use QFont from LibWeb, we can also stop using QGuiApplication in the WebContent process entirely.

This removes a whole bunch of unnecessary work from the event loop, and also allows nice things like running headless-browser while *actually* headless. :^)