### PR TITLE
LibWeb: Add and use the "snap a length as a border width" algorithm

### DIFF
--- a/Tests/LibWeb/Layout/expected/css-snap-a-length-as-a-border-width.txt
+++ b/Tests/LibWeb/Layout/expected/css-snap-a-length-as-a-border-width.txt
@@ -1,0 +1,5 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x204 children: not-inline
+      BlockContainer <div.a> at (9,9) content-size 100x100 children: not-inline
+      BlockContainer <div.b> at (9,111) content-size 100x100 children: not-inline

--- a/Tests/LibWeb/Layout/input/css-snap-a-length-as-a-border-width.html
+++ b/Tests/LibWeb/Layout/input/css-snap-a-length-as-a-border-width.html
@@ -1,0 +1,14 @@
+<style>
+    div {
+        width: 100px;
+        height: 100px;
+    }
+
+    /* Both of these border-widths should snap to 1px. */
+    .a {
+        border: 1.8px solid black;
+    }
+    .b {
+        border: 0.2px solid black;
+    }
+</style><div class="a"></div><div class="b"></div>

--- a/Userland/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Userland/Libraries/LibWeb/CSS/ComputedValues.h
@@ -155,7 +155,7 @@ struct BorderData {
 public:
     Color color { Color::Transparent };
     CSS::LineStyle line_style { CSS::LineStyle::None };
-    double width { 0 };
+    CSSPixels width { 0 };
 
     bool operator==(BorderData const&) const = default;
 };

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -753,7 +753,7 @@ int Element::client_top() const
     // 2. Return the computed value of the border-top-width property
     //    plus the height of any scrollbar rendered between the top padding edge and the top border edge,
     //    ignoring any transforms that apply to the element and its ancestors.
-    return static_cast<Layout::Box const&>(*layout_node()).computed_values().border_top().width;
+    return static_cast<Layout::Box const&>(*layout_node()).computed_values().border_top().width.to_int();
 }
 
 // https://drafts.csswg.org/cssom-view/#dom-element-clientleft
@@ -769,7 +769,7 @@ int Element::client_left() const
     // 2. Return the computed value of the border-left-width property
     //    plus the width of any scrollbar rendered between the left padding edge and the left border edge,
     //    ignoring any transforms that apply to the element and its ancestors.
-    return static_cast<Layout::Box const&>(*layout_node()).computed_values().border_left().width;
+    return static_cast<Layout::Box const&>(*layout_node()).computed_values().border_left().width.to_int();
 }
 
 // https://drafts.csswg.org/cssom-view/#dom-element-clientwidth

--- a/Userland/Libraries/LibWeb/Layout/LayoutState.cpp
+++ b/Userland/Libraries/LibWeb/Layout/LayoutState.cpp
@@ -224,14 +224,14 @@ void LayoutState::UsedValues::set_node(NodeWithStyleAndBoxModelMetrics& node, Us
         CSSPixels border_and_padding;
 
         if (width) {
-            border_and_padding = CSSPixels(computed_values.border_left().width)
+            border_and_padding = computed_values.border_left().width
                 + computed_values.padding().left().to_px(*m_node, containing_block_used_values->content_width())
-                + CSSPixels(computed_values.border_right().width)
+                + computed_values.border_right().width
                 + computed_values.padding().right().to_px(*m_node, containing_block_used_values->content_width());
         } else {
-            border_and_padding = CSSPixels(computed_values.border_top().width)
+            border_and_padding = computed_values.border_top().width
                 + computed_values.padding().top().to_px(*m_node, containing_block_used_values->content_width())
-                + CSSPixels(computed_values.border_bottom().width)
+                + computed_values.border_bottom().width
                 + computed_values.padding().bottom().to_px(*m_node, containing_block_used_values->content_width());
         }
 

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -654,12 +654,12 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& computed_style)
         if (border.line_style == CSS::LineStyle::None || border.line_style == CSS::LineStyle::Hidden) {
             border.width = 0;
         } else {
-            auto resolve_border_width = [&]() -> double {
+            auto resolve_border_width = [&]() -> CSSPixels {
                 auto value = computed_style.property(width_property);
                 if (value->is_calculated())
-                    return value->as_calculated().resolve_length(*this)->to_px(*this).to_double();
+                    return value->as_calculated().resolve_length(*this)->to_px(*this);
                 if (value->is_length())
-                    return value->as_length().length().to_px(*this).to_double();
+                    return value->as_length().length().to_px(*this);
                 if (value->is_identifier()) {
                     // https://www.w3.org/TR/css-backgrounds-3/#valdef-line-width-thin
                     switch (value->to_identifier()) {

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -289,6 +289,28 @@ NodeWithStyle::NodeWithStyle(DOM::Document& document, DOM::Node* node, CSS::Comp
     m_font = Platform::FontPlugin::the().default_font();
 }
 
+// https://www.w3.org/TR/css-values-4/#snap-a-length-as-a-border-width
+static CSSPixels snap_a_length_as_a_border_width(double device_pixels_per_css_pixel, CSSPixels length)
+{
+    // 1. Assert: len is non-negative.
+    VERIFY(length >= 0);
+
+    // 2. If len is an integer number of device pixels, do nothing.
+    auto device_pixels = length.to_double() * device_pixels_per_css_pixel;
+    if (device_pixels == trunc(device_pixels))
+        return length;
+
+    // 3. If len is greater than zero, but less than 1 device pixel, round len up to 1 device pixel.
+    if (device_pixels > 0 && device_pixels < 1)
+        return 1 / device_pixels_per_css_pixel;
+
+    // 4. If len is greater than 1 device pixel, round it down to the nearest integer number of device pixels.
+    if (device_pixels > 1)
+        return floor(device_pixels) / device_pixels_per_css_pixel;
+
+    return length;
+}
+
 void NodeWithStyle::apply_style(const CSS::StyleProperties& computed_style)
 {
     auto& computed_values = static_cast<CSS::MutableComputedValues&>(m_computed_values);
@@ -676,7 +698,7 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& computed_style)
                 VERIFY_NOT_REACHED();
             };
 
-            border.width = resolve_border_width();
+            border.width = snap_a_length_as_a_border_width(document().page()->client().device_pixels_per_css_pixel(), resolve_border_width());
         }
     };
 

--- a/Userland/Libraries/LibWeb/Painting/BackgroundPainting.cpp
+++ b/Userland/Libraries/LibWeb/Painting/BackgroundPainting.cpp
@@ -83,10 +83,10 @@ void paint_background(PaintContext& context, Layout::NodeWithStyleAndBoxModelMet
         return;
 
     struct {
-        int top { 0 };
-        int bottom { 0 };
-        int left { 0 };
-        int right { 0 };
+        DevicePixels top { 0 };
+        DevicePixels bottom { 0 };
+        DevicePixels left { 0 };
+        DevicePixels right { 0 };
     } clip_shrink;
 
     auto border_top = layout_node.computed_values().border_top();
@@ -96,10 +96,10 @@ void paint_background(PaintContext& context, Layout::NodeWithStyleAndBoxModelMet
 
     if (border_top.color.alpha() == 255 && border_bottom.color.alpha() == 255
         && border_left.color.alpha() == 255 && border_right.color.alpha() == 255) {
-        clip_shrink.top = border_top.width;
-        clip_shrink.bottom = border_bottom.width;
-        clip_shrink.left = border_left.width;
-        clip_shrink.right = border_right.width;
+        clip_shrink.top = context.rounded_device_pixels(border_top.width);
+        clip_shrink.bottom = context.rounded_device_pixels(border_bottom.width);
+        clip_shrink.left = context.rounded_device_pixels(border_left.width);
+        clip_shrink.right = context.rounded_device_pixels(border_right.width);
     }
 
     // Note: Background layers are ordered front-to-back, so we paint them in reverse

--- a/Userland/Libraries/LibWeb/Painting/BorderPainting.cpp
+++ b/Userland/Libraries/LibWeb/Painting/BorderPainting.cpp
@@ -106,7 +106,7 @@ void paint_border(PaintContext& context, BorderEdge edge, DevicePixelRect const&
 
     auto color = border_color(edge, borders_data);
     auto border_style = border_data.line_style;
-    auto device_pixel_width = context.enclosing_device_pixels(width);
+    auto device_pixel_width = context.rounded_device_pixels(width);
 
     struct Points {
         DevicePixelPoint p1;

--- a/Userland/Libraries/LibWeb/Painting/PaintContext.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintContext.cpp
@@ -29,68 +29,68 @@ CSSPixelRect PaintContext::css_viewport_rect() const
 
 DevicePixels PaintContext::rounded_device_pixels(CSSPixels css_pixels) const
 {
-    return roundf(css_pixels.to_double() * m_device_pixels_per_css_pixel);
+    return round(css_pixels.to_double() * m_device_pixels_per_css_pixel);
 }
 
 DevicePixels PaintContext::enclosing_device_pixels(CSSPixels css_pixels) const
 {
-    return ceilf(css_pixels.to_double() * m_device_pixels_per_css_pixel);
+    return ceil(css_pixels.to_double() * m_device_pixels_per_css_pixel);
 }
 
 DevicePixels PaintContext::floored_device_pixels(CSSPixels css_pixels) const
 {
-    return floorf(css_pixels.to_double() * m_device_pixels_per_css_pixel);
+    return floor(css_pixels.to_double() * m_device_pixels_per_css_pixel);
 }
 
 DevicePixelPoint PaintContext::rounded_device_point(CSSPixelPoint point) const
 {
     return {
-        roundf(point.x().to_double() * m_device_pixels_per_css_pixel),
-        roundf(point.y().to_double() * m_device_pixels_per_css_pixel)
+        round(point.x().to_double() * m_device_pixels_per_css_pixel),
+        round(point.y().to_double() * m_device_pixels_per_css_pixel)
     };
 }
 
 DevicePixelPoint PaintContext::floored_device_point(CSSPixelPoint point) const
 {
     return {
-        floorf(point.x().to_double() * m_device_pixels_per_css_pixel),
-        floorf(point.y().to_double() * m_device_pixels_per_css_pixel)
+        floor(point.x().to_double() * m_device_pixels_per_css_pixel),
+        floor(point.y().to_double() * m_device_pixels_per_css_pixel)
     };
 }
 
 DevicePixelRect PaintContext::enclosing_device_rect(CSSPixelRect rect) const
 {
     return {
-        floorf(rect.x().to_double() * m_device_pixels_per_css_pixel),
-        floorf(rect.y().to_double() * m_device_pixels_per_css_pixel),
-        ceilf(rect.width().to_double() * m_device_pixels_per_css_pixel),
-        ceilf(rect.height().to_double() * m_device_pixels_per_css_pixel)
+        floor(rect.x().to_double() * m_device_pixels_per_css_pixel),
+        floor(rect.y().to_double() * m_device_pixels_per_css_pixel),
+        ceil(rect.width().to_double() * m_device_pixels_per_css_pixel),
+        ceil(rect.height().to_double() * m_device_pixels_per_css_pixel)
     };
 }
 
 DevicePixelRect PaintContext::rounded_device_rect(CSSPixelRect rect) const
 {
     return {
-        roundf(rect.x().to_double() * m_device_pixels_per_css_pixel),
-        roundf(rect.y().to_double() * m_device_pixels_per_css_pixel),
-        roundf(rect.width().to_double() * m_device_pixels_per_css_pixel),
-        roundf(rect.height().to_double() * m_device_pixels_per_css_pixel)
+        round(rect.x().to_double() * m_device_pixels_per_css_pixel),
+        round(rect.y().to_double() * m_device_pixels_per_css_pixel),
+        round(rect.width().to_double() * m_device_pixels_per_css_pixel),
+        round(rect.height().to_double() * m_device_pixels_per_css_pixel)
     };
 }
 
 DevicePixelSize PaintContext::enclosing_device_size(CSSPixelSize size) const
 {
     return {
-        ceilf(size.width().to_double() * m_device_pixels_per_css_pixel),
-        ceilf(size.height().to_double() * m_device_pixels_per_css_pixel)
+        ceil(size.width().to_double() * m_device_pixels_per_css_pixel),
+        ceil(size.height().to_double() * m_device_pixels_per_css_pixel)
     };
 }
 
 DevicePixelSize PaintContext::rounded_device_size(CSSPixelSize size) const
 {
     return {
-        roundf(size.width().to_double() * m_device_pixels_per_css_pixel),
-        roundf(size.height().to_double() * m_device_pixels_per_css_pixel)
+        round(size.width().to_double() * m_device_pixels_per_css_pixel),
+        round(size.height().to_double() * m_device_pixels_per_css_pixel)
     };
 }
 

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -278,7 +278,7 @@ void PaintableBox::paint_background(PaintContext& context) const
 
     // HACK: If the Box has a border, use the bordered_rect to paint the background.
     //       This way if we have a border-radius there will be no gap between the filling and actual border.
-    if (computed_values().border_top().width || computed_values().border_right().width || computed_values().border_bottom().width || computed_values().border_left().width)
+    if (computed_values().border_top().width != 0 || computed_values().border_right().width != 0 || computed_values().border_bottom().width != 0 || computed_values().border_left().width != 0)
         background_rect = absolute_border_box_rect();
 
     Painting::paint_background(context, layout_box(), background_rect, background_color, computed_values().image_rendering(), background_layers, normalized_border_radii_data());


### PR DESCRIPTION
...and a couple of tweaks to the internals.

**Before:**
![image](https://github.com/SerenityOS/serenity/assets/222642/5a6d2c5d-9a07-439e-94c9-9a0f8bd8ea4c)

**After:**
![image](https://github.com/SerenityOS/serenity/assets/222642/9b028e5e-cdde-41cd-89e2-259434ad50db)

**Firefox:**
![image](https://github.com/SerenityOS/serenity/assets/222642/a4a69a49-a813-4332-bf40-92a51bab1f18)

