### PR TITLE
LibWeb: Serialize strings into a more storage efficient format

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/StructuredSerialize.cpp
+++ b/Userland/Libraries/LibWeb/HTML/StructuredSerialize.cpp
@@ -6,13 +6,11 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/HashTable.h>
 #include <AK/StdLibExtras.h>
 #include <AK/String.h>
 #include <AK/Vector.h>
 #include <LibJS/Forward.h>
 #include <LibJS/Runtime/BigInt.h>
-#include <LibJS/Runtime/BigIntObject.h>
 #include <LibJS/Runtime/BooleanObject.h>
 #include <LibJS/Runtime/Date.h>
 #include <LibJS/Runtime/NumberObject.h>


### PR DESCRIPTION
This patch changes the way StructuredSerializeInternal() serialize strings by storing four bytes into a 32-bit entry, instead of one code point per 32-bit entry.

StructuredDeserialize() has also been changed to deserialize strings by the same ruleset.