### PR TITLE
Ladybird: Fix silly tiny back/forward/reload icons in context menu

### DIFF
--- a/Ladybird/TVGIconEngine.cpp
+++ b/Ladybird/TVGIconEngine.cpp
@@ -33,14 +33,7 @@ QPixmap TVGIconEngine::pixmap(QSize const& size, QIcon::Mode mode, QIcon::State 
         return pixmap;
     auto bitmap = MUST(Gfx::Bitmap::create(Gfx::BitmapFormat::BGRA8888, { size.width(), size.height() }));
     Gfx::Painter painter { *bitmap };
-    auto icon_rect = m_image_data->rect().to_type<float>();
-    auto scale = min(size.width() / icon_rect.width(), size.height() / icon_rect.height()) * m_scale;
-    auto centered = Gfx::FloatRect { {}, icon_rect.size().scaled_by(scale) }
-                        .centered_within(Gfx::FloatRect { {}, { size.width(), size.height() } });
-    auto transform = Gfx::AffineTransform {}
-                         .translate(centered.location())
-                         .multiply(Gfx::AffineTransform {}.scale(scale, scale));
-    m_image_data->draw_transformed(painter, transform);
+    m_image_data->draw_into(painter, bitmap->rect());
     for (auto const& filter : m_filters) {
         if (filter->mode() == mode) {
             painter.blit_filtered({}, *bitmap, bitmap->rect(), filter->function(), false);

--- a/Ladybird/TVGIconEngine.h
+++ b/Ladybird/TVGIconEngine.h
@@ -29,12 +29,6 @@ public:
 
     void add_filter(QIcon::Mode mode, Function<Color(Color)> filter);
 
-    void set_scale(float scale)
-    {
-        m_scale = scale;
-        invalidate_cache();
-    }
-
 private:
     static unsigned next_cache_id()
     {
@@ -64,7 +58,6 @@ private:
 
     QString pixmap_cache_key(QSize const& size, QIcon::Mode mode, QIcon::State state);
 
-    float m_scale { 1 };
     Vector<NonnullRefPtr<Filter>> m_filters;
     NonnullRefPtr<Gfx::TinyVGDecodedImageData> m_image_data;
     unsigned m_cache_id { next_cache_id() };

--- a/Ladybird/Tab.cpp
+++ b/Ladybird/Tab.cpp
@@ -44,7 +44,6 @@ static QIcon create_tvg_icon_with_theme_colors(QString name, QPalette const& pal
     };
     icon_engine->add_filter(QIcon::Mode::Normal, icon_filter(palette.color(QPalette::ColorGroup::Normal, QPalette::ColorRole::ButtonText)));
     icon_engine->add_filter(QIcon::Mode::Disabled, icon_filter(palette.color(QPalette::ColorGroup::Disabled, QPalette::ColorRole::ButtonText)));
-    icon_engine->set_scale(0.66f);
     return QIcon(icon_engine);
 }
 
@@ -59,7 +58,6 @@ Tab::Tab(BrowserWindow* window, StringView webdriver_content_ipc_path, WebView::
     m_view = new WebContentView(webdriver_content_ipc_path, enable_callgrind_profiling, use_javascript_bytecode);
     m_toolbar = new QToolBar(this);
     m_location_edit = new LocationEdit(this);
-    m_reset_zoom_button = new QToolButton(m_toolbar);
 
     m_hover_label = new QLabel(this);
     m_hover_label->hide();
@@ -79,6 +77,13 @@ Tab::Tab(BrowserWindow* window, StringView webdriver_content_ipc_path, WebView::
     m_toolbar->addAction(&m_window->go_forward_action());
     m_toolbar->addAction(&m_window->reload_action());
     m_toolbar->addWidget(m_location_edit);
+    m_toolbar->setIconSize({ 16, 16 });
+    // This is a little awkward, but without this Qt shrinks the button to the size of the icon.
+    // Note: toolButtonStyle="0" -> ToolButtonIconOnly.
+    m_toolbar->setStyleSheet("QToolButton[toolButtonStyle=\"0\"]{width:24px;height:24px}");
+
+    m_reset_zoom_button = new QToolButton(m_toolbar);
+    m_reset_zoom_button->setToolButtonStyle(Qt::ToolButtonTextOnly);
     m_reset_zoom_button->setToolTip("Reset zoom level");
     m_reset_zoom_button_action = m_toolbar->addWidget(m_reset_zoom_button);
     m_reset_zoom_button_action->setVisible(false);


### PR DESCRIPTION
Rather than set a hacky scale factor on our QIconEngine, just set the icon size for the toolbar icons. This avoids the icons being unnecessarily scaled in other places (i.e. the context menu).

**Before:**
![Screenshot from 2023-07-31 00-19-22](https://github.com/SerenityOS/serenity/assets/11597044/20902b37-eaf9-4b02-a9d5-4f4bb3563b9a)
**After:**
![Screenshot from 2023-07-31 00-19-57](https://github.com/SerenityOS/serenity/assets/11597044/239263cc-32aa-4cf2-abca-a6fef0698ea1)
