### PR TITLE
LibWeb: Don't assume opacity values are CSS numbers

### DIFF
--- a/Tests/LibWeb/Text/expected/css/element-opacity-change-invalidation.txt
+++ b/Tests/LibWeb/Text/expected/css/element-opacity-change-invalidation.txt
@@ -1,0 +1,1 @@
+Didn't crash :^)

--- a/Tests/LibWeb/Text/input/css/element-opacity-change-invalidation.html
+++ b/Tests/LibWeb/Text/input/css/element-opacity-change-invalidation.html
@@ -1,0 +1,12 @@
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        document.body.style.opacity = '0.5';
+        document.body.offsetWidth
+        document.body.style.opacity = '100.0%';
+        document.body.offsetWidth
+        document.body.style.opacity = '0.5';
+        document.body.offsetWidth
+        println("Didn't crash :^)");
+    });
+</script>

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -425,8 +425,8 @@ static Element::RequiredInvalidationAfterStyleChange compute_required_invalidati
             // OPTIMIZATION: An element creates a stacking context when its opacity changes from 1 to less than 1
             //               and stops to create one when opacity returns to 1. So stacking context tree rebuild is
             //               not required for opacity changes within the range below 1.
-            auto old_value_opacity = old_value.has_value() ? old_value->style->as_number().number() : 1;
-            auto new_value_opacity = new_value.has_value() ? new_value->style->as_number().number() : 1;
+            auto old_value_opacity = old_style.opacity();
+            auto new_value_opacity = new_style.opacity();
             if (old_value_opacity != new_value_opacity && (old_value_opacity == 1 || new_value_opacity == 1)) {
                 invalidation.rebuild_stacking_context_tree = true;
             }


### PR DESCRIPTION
...since they can also be percentages. Better to resolve them to a pair of absolute values, and then compare those. :^)

Regressed in 921aee8c666fbab2dcdba27cbefc942f1a144180.