### PR TITLE
LibWeb: Use CSS text-indent property on input type="submit" elements text

### DIFF
--- a/Userland/Libraries/LibWeb/Painting/ButtonPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/ButtonPaintable.cpp
@@ -47,8 +47,10 @@ void ButtonPaintable::paint(PaintContext& context, PaintPhase phase) const
         auto text_rect = button_rect;
 
         // Apply CSS text-indent property to text rect
+        // FIXME: The second parameter to to_px() needs to be the block container’s own inline-axis inner size:
+        //        https://drafts.csswg.org/css-text-3/#propdef-text-indent
         auto text_indent = computed_values().text_indent().to_px(layout_box(), CSSPixels());
-        text_rect.translate_by(text_indent.to_int(), 0);
+        text_rect.translate_by(context.rounded_device_pixels(text_indent), 0);
 
         // Apply button pressed state offset
         if (being_pressed()) {

--- a/Userland/Libraries/LibWeb/Painting/ButtonPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/ButtonPaintable.cpp
@@ -43,17 +43,29 @@ void ButtonPaintable::paint(PaintContext& context, PaintPhase phase) const
 
     auto const& dom_node = layout_box().dom_node();
     if (is<HTML::HTMLInputElement>(dom_node) && phase == PaintPhase::Foreground) {
-        auto text_rect = context.enclosing_device_rect(absolute_rect());
+        auto button_rect = context.enclosing_device_rect(absolute_rect());
+        auto text_rect = button_rect;
+
+        // Apply CSS text-indent property to text rect
+        auto text_indent = computed_values().text_indent().to_px(layout_box(), CSSPixels());
+        text_rect.translate_by(text_indent.to_int(), 0);
+
+        // Apply button pressed state offset
         if (being_pressed()) {
             auto offset = context.rounded_device_pixels(1);
             text_rect.translate_by(offset, offset);
         }
-        context.painter().draw_text(
+
+        // Paint button text clipped to button rect
+        auto& painter = context.painter();
+        painter.add_clip_rect(button_rect.to_type<int>());
+        painter.draw_text(
             text_rect.to_type<int>(),
             static_cast<HTML::HTMLInputElement const&>(dom_node).value(),
             FontCache::the().scaled_font(layout_box().font(), context.device_pixels_per_css_pixel()),
             Gfx::TextAlignment::Center,
             computed_values().color());
+        painter.clear_clip_rect();
     }
 }
 

--- a/Userland/Libraries/LibWeb/Painting/ButtonPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/ButtonPaintable.cpp
@@ -60,6 +60,7 @@ void ButtonPaintable::paint(PaintContext& context, PaintPhase phase) const
 
         // Paint button text clipped to button rect
         auto& painter = context.painter();
+        painter.save();
         painter.add_clip_rect(button_rect.to_type<int>());
         painter.draw_text(
             text_rect.to_type<int>(),
@@ -67,7 +68,7 @@ void ButtonPaintable::paint(PaintContext& context, PaintPhase phase) const
             FontCache::the().scaled_font(layout_box().font(), context.device_pixels_per_css_pixel()),
             Gfx::TextAlignment::Center,
             computed_values().color());
-        painter.clear_clip_rect();
+        painter.restore();
     }
 }
 


### PR DESCRIPTION
I found a visual glitch on a Dutch tech website (https://tweakers.net/). In the search bar button the text label "Zoeken" = "Search" was visible over the search icon.

On the `input type="submit"` the CSS propeties `text-indent: -1000px` with `overflow: hidden` are used to move the text outside of the button. I have added the code to read the `text-indent` and move the text label inside the button in `ButtonPaintable.cpp`.

Before:
<img width="1202" alt="before" src="https://github.com/SerenityOS/serenity/assets/19894029/de1996fd-c5fa-4243-8c22-b8ef5b603073">

After:
<img width="1204" alt="after" src="https://github.com/SerenityOS/serenity/assets/19894029/937003b7-0adf-4771-a15f-035aff5f1691">

This is my first commit to SerenityOS so probably there is a lot wrong with my changes

I am looking forward to your feedback ;)