### PR TITLE
Shell: A couple tiny POSIX fixes

### DIFF
--- a/Userland/Shell/PosixParser.h
+++ b/Userland/Shell/PosixParser.h
@@ -71,7 +71,7 @@ private:
     ErrorOr<RefPtr<AST::Node>> parse_list();
     ErrorOr<RefPtr<AST::Node>> parse_and_or();
     ErrorOr<RefPtr<AST::Node>> parse_pipeline();
-    ErrorOr<RefPtr<AST::Node>> parse_pipe_sequence();
+    ErrorOr<RefPtr<AST::Node>> parse_pipe_sequence(bool is_negated);
     ErrorOr<RefPtr<AST::Node>> parse_command();
     ErrorOr<RefPtr<AST::Node>> parse_compound_command();
     ErrorOr<RefPtr<AST::Node>> parse_subshell();


### PR DESCRIPTION
Previously any expansion closing sequence would've caused the entire
expansion chain to be terminated, fix this by keeping track of active
expansions and running the parser in 'skip' mode.

Fixes #19110.