### PR TITLE
Ladybird: Fix JS console crash when history is empty

### DIFF
--- a/Ladybird/ConsoleWidget.cpp
+++ b/Ladybird/ConsoleWidget.cpp
@@ -175,6 +175,8 @@ void ConsoleInputEdit::keyPressEvent(QKeyEvent* event)
 {
     switch (event->key()) {
     case Qt::Key_Down: {
+        if (m_history.is_empty())
+            break;
         auto last_index = m_history.size() - 1;
         if (m_history_index < last_index) {
             m_history_index++;


### PR DESCRIPTION
Do not try to navigate JS console history forward when it is empty. A crash was occurring because of size_t underflow.