### PR TITLE
Ladybird: Remove unused spawn helper

### DIFF
--- a/Ladybird/HelperProcess.cpp
+++ b/Ladybird/HelperProcess.cpp
@@ -6,22 +6,7 @@
 
 #include "HelperProcess.h"
 #include "Utilities.h"
-#include <AK/String.h>
 #include <QCoreApplication>
-
-ErrorOr<void> spawn_helper_process(StringView process_name, ReadonlySpan<StringView> arguments, Core::System::SearchInPath search_in_path, Optional<ReadonlySpan<StringView>> environment)
-{
-    auto paths = TRY(get_paths_for_helper_process(process_name));
-    VERIFY(!paths.is_empty());
-    ErrorOr<void> result;
-    for (auto const& path : paths) {
-        result = Core::System::exec(path, arguments, search_in_path, environment);
-        if (!result.is_error())
-            break;
-    }
-
-    return result;
-}
 
 ErrorOr<Vector<String>> get_paths_for_helper_process(StringView process_name)
 {

--- a/Ladybird/HelperProcess.h
+++ b/Ladybird/HelperProcess.h
@@ -12,5 +12,4 @@
 #include <AK/StringView.h>
 #include <LibCore/System.h>
 
-ErrorOr<void> spawn_helper_process(StringView process_name, ReadonlySpan<StringView> arguments, Core::System::SearchInPath, Optional<ReadonlySpan<StringView>> environment = {});
 ErrorOr<Vector<String>> get_paths_for_helper_process(StringView process_name);


### PR DESCRIPTION
The spawn_helper_process method was introduced together with get_paths_for_helper_process but was only ever used briefly to spawn WebContent. Other helper processes (SqlServer, headless_browser etc) are either execed or spawned with their own helpers & custom arguments.