### PR TITLE
AK+Userland: Parse 'data:' URLs like every other URL and decode them (when needed) to a separate class

### DIFF
--- a/AK/URL.h
+++ b/AK/URL.h
@@ -128,14 +128,16 @@ public:
 
     URL complete_url(StringView) const;
 
-    bool data_payload_is_base64() const { return m_data_payload_is_base64; }
-    DeprecatedString const& data_mime_type() const { return m_data_mime_type; }
-    DeprecatedString const& data_payload() const { return m_data_payload; }
+    struct DataURL {
+        String mime_type;
+        ByteBuffer body;
+    };
+    ErrorOr<DataURL> process_data_url() const;
 
     static URL create_with_url_or_path(DeprecatedString const&);
     static URL create_with_file_scheme(DeprecatedString const& path, DeprecatedString const& fragment = {}, DeprecatedString const& hostname = {});
     static URL create_with_help_scheme(DeprecatedString const& path, DeprecatedString const& fragment = {}, DeprecatedString const& hostname = {});
-    static URL create_with_data(DeprecatedString mime_type, DeprecatedString payload, bool is_base64 = false) { return URL(move(mime_type), move(payload), is_base64); }
+    static URL create_with_data(StringView mime_type, StringView payload, bool is_base64 = false);
 
     static u16 default_port_for_scheme(StringView);
     static bool is_special_scheme(StringView);
@@ -152,17 +154,7 @@ public:
     static bool code_point_is_in_percent_encode_set(u32 code_point, URL::PercentEncodeSet);
 
 private:
-    URL(DeprecatedString&& data_mime_type, DeprecatedString&& data_payload, bool payload_is_base64)
-        : m_valid(true)
-        , m_scheme("data")
-        , m_data_payload_is_base64(payload_is_base64)
-        , m_data_mime_type(move(data_mime_type))
-        , m_data_payload(move(data_payload))
-    {
-    }
-
     bool compute_validity() const;
-    DeprecatedString serialize_data_url() const;
 
     static void append_percent_encoded_if_necessary(StringBuilder&, u32 code_point, PercentEncodeSet set = PercentEncodeSet::Userinfo);
     static void append_percent_encoded(StringBuilder&, u32 code_point);
@@ -196,10 +188,6 @@ private:
     DeprecatedString m_fragment;
 
     bool m_cannot_be_a_base_url { false };
-
-    bool m_data_payload_is_base64 { false };
-    DeprecatedString m_data_mime_type;
-    DeprecatedString m_data_payload;
 };
 
 template<>

--- a/AK/URLParser.h
+++ b/AK/URLParser.h
@@ -63,9 +63,6 @@ public:
 
     // https://url.spec.whatwg.org/#concept-host-serializer
     static ErrorOr<String> serialize_host(URL::Host const&);
-
-private:
-    static Optional<URL> parse_data_url(StringView raw_input);
 };
 
 #undef ENUMERATE_STATES

--- a/Tests/AK/TestURL.cpp
+++ b/Tests/AK/TestURL.cpp
@@ -7,7 +7,6 @@
 
 #include <LibTest/TestCase.h>
 
-#include <AK/Base64.h>
 #include <AK/URL.h>
 #include <AK/URLParser.h>
 
@@ -111,7 +110,6 @@ TEST_CASE(some_bad_urls)
     EXPECT_EQ(URL("http://serenityos.org:abc"sv).is_valid(), false);
     EXPECT_EQ(URL("http://serenityos.org:abc:80"sv).is_valid(), false);
     EXPECT_EQ(URL("http://serenityos.org:abc:80/"sv).is_valid(), false);
-    EXPECT_EQ(URL("data:"sv).is_valid(), false);
 }
 
 TEST_CASE(serialization)
@@ -232,10 +230,11 @@ TEST_CASE(data_url)
     EXPECT(url.is_valid());
     EXPECT_EQ(url.scheme(), "data");
     EXPECT(url.host().has<Empty>());
-    EXPECT_EQ(url.data_mime_type(), "text/html");
-    EXPECT_EQ(url.data_payload(), "test");
-    EXPECT(!url.data_payload_is_base64());
     EXPECT_EQ(url.serialize(), "data:text/html,test");
+
+    auto data_url = TRY_OR_FAIL(url.process_data_url());
+    EXPECT_EQ(data_url.mime_type, "text/html");
+    EXPECT_EQ(StringView(data_url.body.bytes()), "test"sv);
 }
 
 TEST_CASE(data_url_default_mime_type)
@@ -244,10 +243,11 @@ TEST_CASE(data_url_default_mime_type)
     EXPECT(url.is_valid());
     EXPECT_EQ(url.scheme(), "data");
     EXPECT(url.host().has<Empty>());
-    EXPECT_EQ(url.data_mime_type(), "text/plain");
-    EXPECT_EQ(url.data_payload(), "test");
-    EXPECT(!url.data_payload_is_base64());
-    EXPECT_EQ(url.serialize(), "data:text/plain,test");
+    EXPECT_EQ(url.serialize(), "data:,test");
+
+    auto data_url = TRY_OR_FAIL(url.process_data_url());
+    EXPECT_EQ(data_url.mime_type, "text/plain;charset=US-ASCII");
+    EXPECT_EQ(StringView(data_url.body.bytes()), "test"sv);
 }
 
 TEST_CASE(data_url_encoded)
@@ -256,46 +256,50 @@ TEST_CASE(data_url_encoded)
     EXPECT(url.is_valid());
     EXPECT_EQ(url.scheme(), "data");
     EXPECT(url.host().has<Empty>());
-    EXPECT_EQ(url.data_mime_type(), "text/html");
-    EXPECT_EQ(url.data_payload(), "Hello friends,%0X%X0");
-    EXPECT(!url.data_payload_is_base64());
-    EXPECT_EQ(url.serialize(), "data:text/html,Hello friends,%0X%X0");
+    EXPECT_EQ(url.serialize(), "data:text/html,Hello%20friends%2C%0X%X0");
+
+    auto data_url = TRY_OR_FAIL(url.process_data_url());
+    EXPECT_EQ(data_url.mime_type, "text/html");
+    EXPECT_EQ(StringView(data_url.body.bytes()), "Hello friends,%0X%X0"sv);
 }
 
 TEST_CASE(data_url_base64_encoded)
 {
-    URL url("data:text/html;base64,test"sv);
+    URL url("data:text/html;base64,dGVzdA=="sv);
     EXPECT(url.is_valid());
     EXPECT_EQ(url.scheme(), "data");
     EXPECT(url.host().has<Empty>());
-    EXPECT_EQ(url.data_mime_type(), "text/html");
-    EXPECT_EQ(url.data_payload(), "test");
-    EXPECT(url.data_payload_is_base64());
-    EXPECT_EQ(url.serialize(), "data:text/html;base64,test");
+    EXPECT_EQ(url.serialize(), "data:text/html;base64,dGVzdA==");
+
+    auto data_url = TRY_OR_FAIL(url.process_data_url());
+    EXPECT_EQ(data_url.mime_type, "text/html");
+    EXPECT_EQ(StringView(data_url.body.bytes()), "test"sv);
 }
 
 TEST_CASE(data_url_base64_encoded_default_mime_type)
 {
-    URL url("data:;base64,test"sv);
+    URL url("data:;base64,dGVzdA=="sv);
     EXPECT(url.is_valid());
     EXPECT_EQ(url.scheme(), "data");
     EXPECT(url.host().has<Empty>());
-    EXPECT_EQ(url.data_mime_type(), "text/plain");
-    EXPECT_EQ(url.data_payload(), "test");
-    EXPECT(url.data_payload_is_base64());
-    EXPECT_EQ(url.serialize(), "data:text/plain;base64,test");
+    EXPECT_EQ(url.serialize(), "data:;base64,dGVzdA==");
+
+    auto data_url = TRY_OR_FAIL(url.process_data_url());
+    EXPECT_EQ(data_url.mime_type, "text/plain;charset=US-ASCII");
+    EXPECT_EQ(StringView(data_url.body.bytes()), "test"sv);
 }
 
 TEST_CASE(data_url_base64_encoded_with_whitespace)
 {
-    URL url("data: text/html ;     bAsE64 , test with whitespace "sv);
+    URL url("data: text/html ;     bAsE64 , dGVz dA== "sv);
     EXPECT(url.is_valid());
     EXPECT_EQ(url.scheme(), "data");
     EXPECT(url.host().has<Empty>());
-    EXPECT_EQ(url.data_mime_type(), "text/html");
-    EXPECT_EQ(url.data_payload(), " test with whitespace ");
-    EXPECT(url.data_payload_is_base64());
-    EXPECT_EQ(url.serialize(), "data:text/html;base64, test with whitespace ");
+    EXPECT_EQ(url.serialize(), "data: text/html ;     bAsE64 , dGVz dA==");
+
+    auto data_url = TRY_OR_FAIL(url.process_data_url());
+    EXPECT_EQ(data_url.mime_type, "text/html");
+    EXPECT_EQ(StringView(data_url.body.bytes()), "test");
 }
 
 TEST_CASE(data_url_base64_encoded_with_inline_whitespace)
@@ -304,12 +308,23 @@ TEST_CASE(data_url_base64_encoded_with_inline_whitespace)
     EXPECT(url.is_valid());
     EXPECT_EQ(url.scheme(), "data");
     EXPECT(url.host().has<Empty>());
-    EXPECT_EQ(url.data_mime_type(), "text/javascript");
-    EXPECT(url.data_payload_is_base64());
-    EXPECT_EQ(url.data_payload(), " ZD Qg\r\nPS An Zm91cic\r\n 7 "sv);
-    auto decode_result = decode_base64(url.data_payload());
-    EXPECT_EQ(decode_result.is_error(), false);
-    EXPECT_EQ(StringView(decode_result.value()), "d4 = 'four';"sv);
+
+    auto data_url = TRY_OR_FAIL(url.process_data_url());
+    EXPECT_EQ(data_url.mime_type, "text/javascript");
+    EXPECT_EQ(StringView(data_url.body.bytes()), "d4 = 'four';"sv);
+}
+
+TEST_CASE(data_url_completed_with_fragment)
+{
+    auto url = URL("data:text/plain,test"sv).complete_url("#a"sv);
+    EXPECT(url.is_valid());
+    EXPECT_EQ(url.scheme(), "data");
+    EXPECT_EQ(url.fragment(), "a");
+    EXPECT(url.host().has<Empty>());
+
+    auto data_url = TRY_OR_FAIL(url.process_data_url());
+    EXPECT_EQ(data_url.mime_type, "text/plain");
+    EXPECT_EQ(StringView(data_url.body.bytes()), "test"sv);
 }
 
 TEST_CASE(trailing_slash_with_complete_url)

--- a/Userland/Applications/Spreadsheet/HelpWindow.cpp
+++ b/Userland/Applications/Spreadsheet/HelpWindow.cpp
@@ -124,7 +124,7 @@ HelpWindow::HelpWindow(GUI::Window* parent)
             window->show();
         } else if (url.host() == String::from_utf8_short_string("doc"sv)) {
             auto entry = LexicalPath::basename(url.serialize_path());
-            m_webview->load(URL::create_with_data("text/html", render(entry)));
+            m_webview->load(URL::create_with_data("text/html"sv, render(entry)));
         } else {
             dbgln("Invalid spreadsheet action domain '{}'", url.serialized_host().release_value_but_fixme_should_propagate_errors());
         }
@@ -135,7 +135,7 @@ HelpWindow::HelpWindow(GUI::Window* parent)
             return;
 
         auto key = static_cast<HelpListModel*>(m_listview->model())->key(index);
-        m_webview->load(URL::create_with_data("text/html", render(key)));
+        m_webview->load(URL::create_with_data("text/html"sv, render(key)));
     };
 }
 

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -266,13 +266,8 @@ private:
     Optional<ExplicitGridTrack> parse_track_sizing_function(ComponentValue const&);
     Optional<PositionValue> parse_position(TokenStream<ComponentValue>&, PositionValue initial_value = PositionValue::center());
 
-    enum class AllowedDataUrlType {
-        None,
-        Image,
-        Font,
-    };
-    Optional<AK::URL> parse_url_function(ComponentValue const&, AllowedDataUrlType = AllowedDataUrlType::None);
-    ErrorOr<RefPtr<StyleValue>> parse_url_value(ComponentValue const&, AllowedDataUrlType = AllowedDataUrlType::None);
+    Optional<AK::URL> parse_url_function(ComponentValue const&);
+    ErrorOr<RefPtr<StyleValue>> parse_url_value(ComponentValue const&);
 
     Optional<Vector<LinearColorStopListElement>> parse_linear_color_stop_list(TokenStream<ComponentValue>&);
     Optional<Vector<AngularColorStopListElement>> parse_angular_color_stop_list(TokenStream<ComponentValue>&);

--- a/Userland/Libraries/LibWeb/HTML/HTMLCanvasElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLCanvasElement.cpp
@@ -195,7 +195,7 @@ DeprecatedString HTMLCanvasElement::to_data_url(DeprecatedString const& type, [[
         // FIXME: propagate error
         return {};
     }
-    return AK::URL::create_with_data(type, base64_encoded_or_error.release_value().to_deprecated_string(), true).to_deprecated_string();
+    return AK::URL::create_with_data(type, base64_encoded_or_error.release_value(), true).to_deprecated_string();
 }
 
 void HTMLCanvasElement::present()

--- a/Userland/Libraries/LibWeb/Loader/Resource.cpp
+++ b/Userland/Libraries/LibWeb/Loader/Resource.cpp
@@ -102,9 +102,6 @@ void Resource::did_load(Badge<ResourceLoader>, ReadonlyBytes data, HashMap<Depre
         //        Let's use image/x-qoi for now, which is also what our Core::MimeData uses & would guess.
         if (m_mime_type == "application/octet-stream" && url().serialize_path().ends_with(".qoi"sv))
             m_mime_type = "image/x-qoi";
-    } else if (url().scheme() == "data" && !url().data_mime_type().is_empty()) {
-        dbgln_if(RESOURCE_DEBUG, "This is a data URL with mime-type _{}_", url().data_mime_type());
-        m_mime_type = url().data_mime_type();
     } else {
         auto content_type_options = headers.get("X-Content-Type-Options");
         if (content_type_options.value_or("").equals_ignoring_ascii_case("nosniff"sv)) {

--- a/Userland/Libraries/LibWeb/Loader/ResourceLoader.cpp
+++ b/Userland/Libraries/LibWeb/Loader/ResourceLoader.cpp
@@ -223,9 +223,12 @@ void ResourceLoader::load(LoadRequest& request, Function<void(ReadonlyBytes, Has
             data = url.data_payload().to_byte_buffer();
         }
 
+        HashMap<DeprecatedString, DeprecatedString, CaseInsensitiveStringTraits> response_headers;
+        response_headers.set("Content-Type", url.data_mime_type());
+
         log_success(request);
-        Platform::EventLoopPlugin::the().deferred_invoke([data = move(data), success_callback = move(success_callback)] {
-            success_callback(data, {}, {});
+        Platform::EventLoopPlugin::the().deferred_invoke([data = move(data), response_headers = move(response_headers), success_callback = move(success_callback)] {
+            success_callback(data, response_headers, {});
         });
         return;
     }


### PR DESCRIPTION
as hinted in https://github.com/SerenityOS/serenity/pull/19850 :)

first, remove unnecessary calls to specific data: url functions, where calling process_data_url() would be inefficient:

- **LibWeb: Remove checking for AllowedDataUrlType**

  CSS shouldn't probably check if a MIME type in the 'data:' URL is correct or not. Every URL gets sent to a ResourceLoader so a client can just validate if got file with correct media type.

  This also makes loading 'data:' URLs in @​import work now, as we didn't have AllowedDataUrlType for stylesheets.

- **LibWeb: Set Content-Type for data: URLs instead of checking MIME on load**

  This makes the loader more agnostic.

  Additionally, this allows us to load tab in Ladybird with a 'data:' URL containing parameters, as a Resource will now call `mime_type_from_content_type` to extract the content type from MIME. :^)

## AK: Decode data URLs to separate class (and parse like every other URL)

Parsing 'data:' URLs took it's own route. It never set standard URL fields like path, query or fragment (except for scheme) and instead gave us separate methods called `data_payload()`, `data_mime_type()`, and `data_payload_is_base64()`.

Because parsing 'data:' didn't use standard fields, running the following JS code:

```js
new URL('#a', 'data:text/plain,hello').toString()
```

not only cleared the path as URLParser doesn't check for data from data_payload() function (making the result be 'data:#a'), but it also crashes the program because we forbid having an empty MIME type when we serialize to string.

With this change, 'data:' URLs will be parsed like every other URLs. To decode the 'data:' URL contents, one needs to call process_data_url() on a URL, which will return a struct containing MIME type with already decoded data! :^)

*this also fixes crash when visiting https://tekstowo.pl for some reason lmao*
