### PR TITLE
Mail+LibIMAP: Don't set the whole mailbox as read

### DIFF
--- a/Userland/Applications/Mail/MailWidget.cpp
+++ b/Userland/Applications/Mail/MailWidget.cpp
@@ -271,7 +271,7 @@ void MailWidget::selected_mailbox()
         .sequence_set = { { 1, (int)response.data().exists() } },
         .data_items = {
             IMAP::FetchCommand::DataItem {
-                .type = IMAP::FetchCommand::DataItemType::BodySection,
+                .type = IMAP::FetchCommand::DataItemType::PeekBody,
                 .section = IMAP::FetchCommand::DataItem::Section {
                     .type = IMAP::FetchCommand::DataItem::SectionType::HeaderFields,
                     .headers = { { "Subject", "From" } },

--- a/Userland/Libraries/LibIMAP/Objects.cpp
+++ b/Userland/Libraries/LibIMAP/Objects.cpp
@@ -74,10 +74,12 @@ DeprecatedString FetchCommand::DataItem::serialize() const
     case DataItemType::UID:
         return "UID";
     case DataItemType::PeekBody:
-        TODO();
     case DataItemType::BodySection: {
         StringBuilder sb;
-        sb.appendff("BODY[{}]", section.value().serialize());
+        if (type == DataItemType::BodySection)
+            sb.appendff("BODY[{}]", section.value().serialize());
+        else
+            sb.appendff("BODY.PEEK[{}]", section.value().serialize());
         if (partial_fetch) {
             sb.appendff("<{}.{}>", start, octets);
         }


### PR DESCRIPTION
> [6.4.5. ](https://www.rfc-editor.org/rfc/rfc9051#section-6.4.5)[FETCH Command](https://www.rfc-editor.org/rfc/rfc9051#name-fetch-command)
>
> <dl>
> <dt>BODY[&lt;section&gt;]&lt;&lt;partial&gt;&gt;
> <dd> [...]<br>
>    The \Seen flag is implicitly set; if this causes the flags to change, they SHOULD be included as part of the FETCH responses.
> <dt>BODY.PEEK[&lt;section&gt;]&lt;&lt;partial&gt;&gt;
> <dd>An alternate form of BODY[&lt;section&gt;] that does not implicitly set the \Seen flag.
> </dl>

:p