### PR TITLE
sed: Keep correct owner and permissions with `sed -i`

### DIFF
--- a/Userland/Utilities/sed.cpp
+++ b/Userland/Utilities/sed.cpp
@@ -690,10 +690,9 @@ public:
         VERIFY(m_output->is_open());
 
         TRY(m_output->seek(0, SeekMode::SetPosition));
-        auto source_stat = TRY(Core::System::stat(m_output_temp_file->path()));
+        auto source_stat = TRY(Core::System::stat(m_input_file_path.string()));
         return FileSystem::copy_file(
-            m_input_file_path.string(), m_output_temp_file->path(), source_stat, *m_output,
-            FileSystem::PreserveMode::Ownership | FileSystem::PreserveMode::Permissions);
+            m_input_file_path.string(), m_output_temp_file->path(), source_stat, *m_output);
     }
 
 private:


### PR DESCRIPTION
This solves an issue where user and permissions where lost after using `pls sed -i s/foo/bar/g` on a file.

Permissions of 777 still get mangled to 755, but that seems to be an issue with `FileSystem::copy_file()`.

CC @ADKaster @kleinesfilmroellchen 