### PR TITLE
Kernel: Allow Ext2FS::flush_writes() to return ErrorOr<void>

### DIFF
--- a/Kernel/FileSystem/BlockBasedFileSystem.cpp
+++ b/Kernel/FileSystem/BlockBasedFileSystem.cpp
@@ -305,9 +305,10 @@ void BlockBasedFileSystem::flush_writes_impl()
     });
 }
 
-void BlockBasedFileSystem::flush_writes()
+ErrorOr<void> BlockBasedFileSystem::flush_writes()
 {
     flush_writes_impl();
+    return {};
 }
 
 }

--- a/Kernel/FileSystem/BlockBasedFileSystem.h
+++ b/Kernel/FileSystem/BlockBasedFileSystem.h
@@ -19,7 +19,7 @@ public:
 
     u64 device_block_size() const { return m_device_block_size; }
 
-    virtual void flush_writes() override;
+    virtual ErrorOr<void> flush_writes() override;
     void flush_writes_impl();
 
 protected:

--- a/Kernel/FileSystem/Ext2FS/FileSystem.h
+++ b/Kernel/FileSystem/Ext2FS/FileSystem.h
@@ -77,7 +77,7 @@ private:
     ErrorOr<NonnullRefPtr<Inode>> get_inode(InodeIdentifier) const;
     ErrorOr<NonnullRefPtr<Inode>> create_inode(Ext2FSInode& parent_inode, StringView name, mode_t, dev_t, UserID, GroupID);
     ErrorOr<NonnullRefPtr<Inode>> create_directory(Ext2FSInode& parent_inode, StringView name, mode_t, UserID, GroupID);
-    virtual void flush_writes() override;
+    virtual ErrorOr<void> flush_writes() override;
 
     BlockIndex first_block_index() const;
     BlockIndex first_block_of_block_group_descriptors() const;

--- a/Kernel/FileSystem/FileSystem.h
+++ b/Kernel/FileSystem/FileSystem.h
@@ -51,7 +51,7 @@ public:
         u8 file_type { 0 };
     };
 
-    virtual void flush_writes() { }
+    virtual ErrorOr<void> flush_writes() { return {}; }
 
     u64 logical_block_size() const { return m_logical_block_size; }
     size_t fragment_size() const { return m_fragment_size; }

--- a/Kernel/FileSystem/Inode.cpp
+++ b/Kernel/FileSystem/Inode.cpp
@@ -48,7 +48,11 @@ void Inode::sync()
 {
     if (is_metadata_dirty())
         (void)flush_metadata();
-    fs().flush_writes();
+    auto result = fs().flush_writes();
+    if (result.is_error()) {
+        // TODO: Figure out how to propagate error to a higher function.
+    }
+
 }
 
 ErrorOr<NonnullRefPtr<Custody>> Inode::resolve_as_link(Credentials const& credentials, Custody& base, RefPtr<Custody>* out_parent, int options, int symlink_recursion_level) const

--- a/Kernel/FileSystem/VirtualFileSystem.cpp
+++ b/Kernel/FileSystem/VirtualFileSystem.cpp
@@ -247,8 +247,12 @@ void VirtualFileSystem::sync_filesystems()
             file_systems.append(fs);
     });
 
-    for (auto& fs : file_systems)
-        fs->flush_writes();
+    for (auto& fs : file_systems) {
+        auto result = fs->flush_writes();
+        if (result.is_error()) {
+            //TODO: Figure out how to propagate error to a higher function.
+        }
+    }
 }
 
 void VirtualFileSystem::lock_all_filesystems()

--- a/Kernel/Tasks/PowerStateSwitchTask.cpp
+++ b/Kernel/Tasks/PowerStateSwitchTask.cpp
@@ -131,7 +131,7 @@ ErrorOr<void> PowerStateSwitchTask::perform_shutdown()
 
         while (!mounts.is_empty()) {
             auto& mount = mounts.take_last();
-            mount.guest_fs().flush_writes();
+            TRY(mount.guest_fs().flush_writes());
 
             auto mount_path = TRY(mount.absolute_path());
             auto& mount_inode = mount.guest();


### PR DESCRIPTION
Attempting to solve a FIXME which would allow flush_writes() to return ErrorOr<void>. Apologies for making a second pull request about this, deleted the previous one due to silly reasons. I also made the changes recommended by @ADKaster. For the changes I made in Inode.cpp and VirtualFileSystem.cpp I was unsure if it would be ok to add VERIFY_NOT_REACHED() macro as the if statement is currently empty and I was cautious about causing a kernel panic as I was warned about previously.