### PR TITLE
 LibWeb: Support Access-Control-Expose-Headers in Fetch

### DIFF
--- a/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
@@ -1814,38 +1814,6 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<PendingResponse>> cors_preflight_fetch(JS::
             // NOTE: We treat "header_names_or_failure" being `Empty` as empty Vector here.
             auto header_names = header_names_or_failure.has<Vector<ByteBuffer>>() ? header_names_or_failure.get<Vector<ByteBuffer>>() : Vector<ByteBuffer> {};
 
-            // FIXME: Remove this once extract_header_list_values validates the header and returns multiple values.
-            if (!methods.is_empty()) {
-                VERIFY(methods.size() == 1);
-
-                auto split_methods = StringView { methods.first() }.split_view(',');
-                Vector<ByteBuffer> trimmed_methods;
-
-                for (auto const& method : split_methods) {
-                    auto trimmed_method = method.trim(" \t"sv);
-                    auto trimmed_method_as_byte_buffer = TRY_OR_IGNORE(ByteBuffer::copy(trimmed_method.bytes()));
-                    TRY_OR_IGNORE(trimmed_methods.try_append(move(trimmed_method_as_byte_buffer)));
-                }
-
-                methods = move(trimmed_methods);
-            }
-
-            // FIXME: Remove this once extract_header_list_values validates the header and returns multiple values.
-            if (!header_names.is_empty()) {
-                VERIFY(header_names.size() == 1);
-
-                auto split_header_names = StringView { header_names.first() }.split_view(',');
-                Vector<ByteBuffer> trimmed_header_names;
-
-                for (auto const& header_name : split_header_names) {
-                    auto trimmed_header_name = header_name.trim(" \t"sv);
-                    auto trimmed_header_name_as_byte_buffer = TRY_OR_IGNORE(ByteBuffer::copy(trimmed_header_name.bytes()));
-                    TRY_OR_IGNORE(trimmed_header_names.try_append(move(trimmed_header_name_as_byte_buffer)));
-                }
-
-                header_names = move(trimmed_header_names);
-            }
-
             // 4. If methods is null and request’s use-CORS-preflight flag is set, then set methods to a new list containing request’s method.
             // NOTE: This ensures that a CORS-preflight fetch that happened due to request’s use-CORS-preflight flag being set is cached.
             if (methods.is_empty() && request.use_cors_preflight())

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Headers.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Headers.cpp
@@ -776,6 +776,26 @@ ErrorOr<Optional<Vector<ByteBuffer>>> extract_header_values(Header const& header
 {
     // FIXME: 1. If parsing header’s value, per the ABNF for header’s name, fails, then return failure.
     // FIXME: 2. Return one or more values resulting from parsing header’s value, per the ABNF for header’s name.
+
+    // For now we only parse some headers that are of the ABNF list form "#something"
+    if (StringView { header.name }.is_one_of_ignoring_ascii_case(
+            "Access-Control-Request-Headers"sv,
+            "Access-Control-Expose-Headers"sv,
+            "Access-Control-Allow-Headers"sv,
+            "Access-Control-Allow-Methods"sv)
+        && !header.value.is_empty()) {
+        auto split_values = StringView { header.value }.split_view(',');
+        Vector<ByteBuffer> trimmed_values;
+
+        for (auto const& value : split_values) {
+            auto trimmed_value = value.trim(" \t"sv);
+            auto trimmed_value_as_byte_buffer = TRY(ByteBuffer::copy(trimmed_value.bytes()));
+            TRY(trimmed_values.try_append(move(trimmed_value_as_byte_buffer)));
+        }
+
+        return trimmed_values;
+    }
+
     // This always ignores the ABNF rules for now and returns the header value as a single list item.
     return Vector { TRY(ByteBuffer::copy(header.value)) };
 }

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Headers.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Headers.cpp
@@ -53,6 +53,23 @@ JS::NonnullGCPtr<HeaderList> HeaderList::create(JS::VM& vm)
     return vm.heap().allocate_without_realm<HeaderList>();
 }
 
+// Non-standard
+ErrorOr<Vector<ByteBuffer>> HeaderList::unique_names() const
+{
+    Vector<ByteBuffer> header_names_set;
+    HashTable<ReadonlyBytes, CaseInsensitiveBytesTraits<u8 const>> header_names_seen;
+
+    for (auto const& header : *this) {
+        if (header_names_seen.contains(header.name))
+            continue;
+        auto bytes = TRY(ByteBuffer::copy(header.name));
+        TRY(header_names_seen.try_set(header.name));
+        TRY(header_names_set.try_append(move(bytes)));
+    }
+
+    return header_names_set;
+}
+
 // https://fetch.spec.whatwg.org/#header-list-contains
 bool HeaderList::contains(ReadonlyBytes name) const
 {

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Headers.h
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Headers.h
@@ -61,6 +61,8 @@ public:
     [[nodiscard]] ErrorOr<ExtractLengthResult> extract_length() const;
 
     [[nodiscard]] ErrorOr<Optional<MimeSniff::MimeType>> extract_mime_type() const;
+
+    ErrorOr<Vector<ByteBuffer>> unique_names() const;
 };
 
 struct RangeHeaderValue {


### PR DESCRIPTION
This allows JS access in fetch CORS requests to headers listed in Access-Control-Expose-Headers. 

Also moved some of the existing header-value list parsing into extract_header_values. This part isn't a full implementation, but works for the headers we currently use and tidies up the existing parsing into once place.

Resolves #18626

