### PR TITLE
LibWeb: Use item minimum contribution while sizing "fr" track in GFC

### DIFF
--- a/Tests/LibWeb/Layout/expected/grid/row-1fr.txt
+++ b/Tests/LibWeb/Layout/expected/grid/row-1fr.txt
@@ -1,0 +1,4 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (1,1) content-size 798x70 [BFC] children: not-inline
+    Box <body> at (10,10) content-size 200x52 [GFC] children: not-inline
+      BlockContainer <div.item> at (11,11) content-size 100x50 [BFC] children: not-inline

--- a/Tests/LibWeb/Layout/input/grid/row-1fr.html
+++ b/Tests/LibWeb/Layout/input/grid/row-1fr.html
@@ -1,0 +1,15 @@
+<!doctype html><style>
+    * {
+        border: 1px solid black;
+    }
+    body {
+        display: grid;
+        grid-template-rows: 1fr;
+        width: 200px;
+    }
+    .item {
+        width: 100px;
+        height: 50px;
+        background: orange;
+    }
+</style><body><div class="item"></div>

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -1049,7 +1049,7 @@ void GridFormattingContext::increase_sizes_to_accommodate_spanning_items_crossin
 
         // 1. For intrinsic minimums: First increase the base size of tracks with an intrinsic min track sizing
         //    function by distributing extra space as needed to accommodate these items’ minimum contributions.
-        auto item_minimum_contribution = automatic_minimum_size(item, dimension);
+        auto item_minimum_contribution = calculate_minimum_contribution(item, dimension);
         distribute_extra_space_across_spanned_tracks_base_size(dimension,
             item_minimum_contribution, SpaceDistributionPhase::AccommodateMinimumContribution, spanned_tracks, [&](GridTrack const& track) {
                 return track.min_track_sizing_function.is_flexible_length();


### PR DESCRIPTION
Fixes the issue that before "automatic minimum size" were used to size flexible tracks even though specification says is should be "minimum contribution"