### PR TITLE
LibWeb: Clip rect fixes for media elements

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/VideoBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/VideoBox.cpp
@@ -35,16 +35,6 @@ HTML::HTMLVideoElement const& VideoBox::dom_node() const
     return static_cast<HTML::HTMLVideoElement const&>(ReplacedBox::dom_node());
 }
 
-int VideoBox::preferred_width() const
-{
-    return dom_node().attribute(HTML::AttributeNames::width).to_int().value_or(dom_node().video_width());
-}
-
-int VideoBox::preferred_height() const
-{
-    return dom_node().attribute(HTML::AttributeNames::height).to_int().value_or(dom_node().video_height());
-}
-
 void VideoBox::prepare_for_replaced_layout()
 {
     auto width = static_cast<float>(dom_node().video_width());

--- a/Userland/Libraries/LibWeb/Layout/VideoBox.h
+++ b/Userland/Libraries/LibWeb/Layout/VideoBox.h
@@ -33,9 +33,6 @@ private:
 
     // ^JS::Cell
     virtual void finalize() override;
-
-    int preferred_width() const;
-    int preferred_height() const;
 };
 
 }

--- a/Userland/Libraries/LibWeb/Painting/AudioPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/AudioPaintable.cpp
@@ -52,7 +52,11 @@ void AudioPaintable::paint(PaintContext& context, PaintPhase phase) const
     if (phase != PaintPhase::Foreground)
         return;
 
+    Gfx::PainterStateSaver saver { context.painter() };
+
     auto audio_rect = context.rounded_device_rect(absolute_rect());
+    context.painter().add_clip_rect(audio_rect.to_type<int>());
+
     ScopedCornerRadiusClip corner_clip { context, context.painter(), audio_rect, normalized_border_radii_data(ShrinkRadiiForBorders::Yes) };
 
     auto const& audio_element = layout_box().dom_node();

--- a/Userland/Libraries/LibWeb/Painting/VideoPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/VideoPaintable.cpp
@@ -61,6 +61,8 @@ void VideoPaintable::paint(PaintContext& context, PaintPhase phase) const
     if (phase != PaintPhase::Foreground)
         return;
 
+    Gfx::PainterStateSaver saver { context.painter() };
+
     auto video_rect = context.rounded_device_rect(absolute_rect());
     context.painter().add_clip_rect(video_rect.to_type<int>());
 


### PR DESCRIPTION
This lets us go wild and have a video and audio element on one page:


https://github.com/SerenityOS/serenity/assets/5600524/bc9f4333-97ae-45e6-93b3-86c0bd0bb91f

