### PR TITLE
LibWeb: Implement media-related pseudo-classes

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -465,6 +465,8 @@ Parser::ParseErrorOr<Selector::SimpleSelector> Parser::parse_pseudo_simple_selec
 
         if (pseudo_name.equals_ignoring_ascii_case("active"sv))
             return make_pseudo_class_selector(Selector::SimpleSelector::PseudoClass::Type::Active);
+        if (pseudo_name.equals_ignoring_ascii_case("buffering"sv))
+            return make_pseudo_class_selector(Selector::SimpleSelector::PseudoClass::Type::Buffering);
         if (pseudo_name.equals_ignoring_ascii_case("checked"sv))
             return make_pseudo_class_selector(Selector::SimpleSelector::PseudoClass::Type::Checked);
         if (pseudo_name.equals_ignoring_ascii_case("indeterminate"sv))
@@ -507,6 +509,8 @@ Parser::ParseErrorOr<Selector::SimpleSelector> Parser::parse_pseudo_simple_selec
             return make_pseudo_class_selector(Selector::SimpleSelector::PseudoClass::Type::Root);
         if (pseudo_name.equals_ignoring_ascii_case("seeking"sv))
             return make_pseudo_class_selector(Selector::SimpleSelector::PseudoClass::Type::Seeking);
+        if (pseudo_name.equals_ignoring_ascii_case("stalled"sv))
+            return make_pseudo_class_selector(Selector::SimpleSelector::PseudoClass::Type::Stalled);
         if (pseudo_name.equals_ignoring_ascii_case("host"sv))
             return make_pseudo_class_selector(Selector::SimpleSelector::PseudoClass::Type::Host);
         if (pseudo_name.equals_ignoring_ascii_case("visited"sv))

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -503,6 +503,8 @@ Parser::ParseErrorOr<Selector::SimpleSelector> Parser::parse_pseudo_simple_selec
             return make_pseudo_class_selector(Selector::SimpleSelector::PseudoClass::Type::Paused);
         if (pseudo_name.equals_ignoring_ascii_case("root"sv))
             return make_pseudo_class_selector(Selector::SimpleSelector::PseudoClass::Type::Root);
+        if (pseudo_name.equals_ignoring_ascii_case("seeking"sv))
+            return make_pseudo_class_selector(Selector::SimpleSelector::PseudoClass::Type::Seeking);
         if (pseudo_name.equals_ignoring_ascii_case("host"sv))
             return make_pseudo_class_selector(Selector::SimpleSelector::PseudoClass::Type::Host);
         if (pseudo_name.equals_ignoring_ascii_case("visited"sv))

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -511,6 +511,8 @@ Parser::ParseErrorOr<Selector::SimpleSelector> Parser::parse_pseudo_simple_selec
             return make_pseudo_class_selector(Selector::SimpleSelector::PseudoClass::Type::Host);
         if (pseudo_name.equals_ignoring_ascii_case("visited"sv))
             return make_pseudo_class_selector(Selector::SimpleSelector::PseudoClass::Type::Visited);
+        if (pseudo_name.equals_ignoring_ascii_case("volume-locked"sv))
+            return make_pseudo_class_selector(Selector::SimpleSelector::PseudoClass::Type::VolumeLocked);
         if (pseudo_name.equals_ignoring_ascii_case("scope"sv))
             return make_pseudo_class_selector(Selector::SimpleSelector::PseudoClass::Type::Scope);
 

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -493,6 +493,8 @@ Parser::ParseErrorOr<Selector::SimpleSelector> Parser::parse_pseudo_simple_selec
             return make_pseudo_class_selector(Selector::SimpleSelector::PseudoClass::Type::LastOfType);
         if (pseudo_name.equals_ignoring_ascii_case("link"sv))
             return make_pseudo_class_selector(Selector::SimpleSelector::PseudoClass::Type::Link);
+        if (pseudo_name.equals_ignoring_ascii_case("muted"sv))
+            return make_pseudo_class_selector(Selector::SimpleSelector::PseudoClass::Type::Muted);
         if (pseudo_name.equals_ignoring_ascii_case("only-child"sv))
             return make_pseudo_class_selector(Selector::SimpleSelector::PseudoClass::Type::OnlyChild);
         if (pseudo_name.equals_ignoring_ascii_case("only-of-type"sv))

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -497,6 +497,10 @@ Parser::ParseErrorOr<Selector::SimpleSelector> Parser::parse_pseudo_simple_selec
             return make_pseudo_class_selector(Selector::SimpleSelector::PseudoClass::Type::OnlyChild);
         if (pseudo_name.equals_ignoring_ascii_case("only-of-type"sv))
             return make_pseudo_class_selector(Selector::SimpleSelector::PseudoClass::Type::OnlyOfType);
+        if (pseudo_name.equals_ignoring_ascii_case("playing"sv))
+            return make_pseudo_class_selector(Selector::SimpleSelector::PseudoClass::Type::Playing);
+        if (pseudo_name.equals_ignoring_ascii_case("paused"sv))
+            return make_pseudo_class_selector(Selector::SimpleSelector::PseudoClass::Type::Paused);
         if (pseudo_name.equals_ignoring_ascii_case("root"sv))
             return make_pseudo_class_selector(Selector::SimpleSelector::PseudoClass::Type::Root);
         if (pseudo_name.equals_ignoring_ascii_case("host"sv))

--- a/Userland/Libraries/LibWeb/CSS/Selector.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Selector.cpp
@@ -233,6 +233,7 @@ ErrorOr<String> Selector::SimpleSelector::serialize() const
         case Selector::SimpleSelector::PseudoClass::Type::Defined:
         case Selector::SimpleSelector::PseudoClass::Type::Playing:
         case Selector::SimpleSelector::PseudoClass::Type::Paused:
+        case Selector::SimpleSelector::PseudoClass::Type::Seeking:
             // If the pseudo-class does not accept arguments append ":" (U+003A), followed by the name of the pseudo-class, to s.
             TRY(s.try_append(':'));
             TRY(s.try_append(pseudo_class_name(pseudo_class.type)));

--- a/Userland/Libraries/LibWeb/CSS/Selector.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Selector.cpp
@@ -235,6 +235,7 @@ ErrorOr<String> Selector::SimpleSelector::serialize() const
         case Selector::SimpleSelector::PseudoClass::Type::Paused:
         case Selector::SimpleSelector::PseudoClass::Type::Seeking:
         case Selector::SimpleSelector::PseudoClass::Type::Muted:
+        case Selector::SimpleSelector::PseudoClass::Type::VolumeLocked:
             // If the pseudo-class does not accept arguments append ":" (U+003A), followed by the name of the pseudo-class, to s.
             TRY(s.try_append(':'));
             TRY(s.try_append(pseudo_class_name(pseudo_class.type)));

--- a/Userland/Libraries/LibWeb/CSS/Selector.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Selector.cpp
@@ -234,6 +234,7 @@ ErrorOr<String> Selector::SimpleSelector::serialize() const
         case Selector::SimpleSelector::PseudoClass::Type::Playing:
         case Selector::SimpleSelector::PseudoClass::Type::Paused:
         case Selector::SimpleSelector::PseudoClass::Type::Seeking:
+        case Selector::SimpleSelector::PseudoClass::Type::Muted:
             // If the pseudo-class does not accept arguments append ":" (U+003A), followed by the name of the pseudo-class, to s.
             TRY(s.try_append(':'));
             TRY(s.try_append(pseudo_class_name(pseudo_class.type)));

--- a/Userland/Libraries/LibWeb/CSS/Selector.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Selector.cpp
@@ -236,6 +236,8 @@ ErrorOr<String> Selector::SimpleSelector::serialize() const
         case Selector::SimpleSelector::PseudoClass::Type::Seeking:
         case Selector::SimpleSelector::PseudoClass::Type::Muted:
         case Selector::SimpleSelector::PseudoClass::Type::VolumeLocked:
+        case Selector::SimpleSelector::PseudoClass::Type::Buffering:
+        case Selector::SimpleSelector::PseudoClass::Type::Stalled:
             // If the pseudo-class does not accept arguments append ":" (U+003A), followed by the name of the pseudo-class, to s.
             TRY(s.try_append(':'));
             TRY(s.try_append(pseudo_class_name(pseudo_class.type)));

--- a/Userland/Libraries/LibWeb/CSS/Selector.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Selector.cpp
@@ -231,6 +231,8 @@ ErrorOr<String> Selector::SimpleSelector::serialize() const
         case Selector::SimpleSelector::PseudoClass::Type::Active:
         case Selector::SimpleSelector::PseudoClass::Type::Scope:
         case Selector::SimpleSelector::PseudoClass::Type::Defined:
+        case Selector::SimpleSelector::PseudoClass::Type::Playing:
+        case Selector::SimpleSelector::PseudoClass::Type::Paused:
             // If the pseudo-class does not accept arguments append ":" (U+003A), followed by the name of the pseudo-class, to s.
             TRY(s.try_append(':'));
             TRY(s.try_append(pseudo_class_name(pseudo_class.type)));

--- a/Userland/Libraries/LibWeb/CSS/Selector.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Selector.cpp
@@ -227,6 +227,7 @@ ErrorOr<String> Selector::SimpleSelector::serialize() const
         case Selector::SimpleSelector::PseudoClass::Type::Disabled:
         case Selector::SimpleSelector::PseudoClass::Type::Enabled:
         case Selector::SimpleSelector::PseudoClass::Type::Checked:
+        case Selector::SimpleSelector::PseudoClass::Type::Indeterminate:
         case Selector::SimpleSelector::PseudoClass::Type::Active:
         case Selector::SimpleSelector::PseudoClass::Type::Scope:
         case Selector::SimpleSelector::PseudoClass::Type::Defined:
@@ -265,9 +266,6 @@ ErrorOr<String> Selector::SimpleSelector::serialize() const
             }
             TRY(s.try_append(')'));
             break;
-        default:
-            dbgln("FIXME: Unknown pseudo class type for serialization: {}", to_underlying(pseudo_class.type));
-            VERIFY_NOT_REACHED();
         }
         break;
     }

--- a/Userland/Libraries/LibWeb/CSS/Selector.h
+++ b/Userland/Libraries/LibWeb/CSS/Selector.h
@@ -120,6 +120,8 @@ public:
                 Seeking,
                 Muted,
                 VolumeLocked,
+                Buffering,
+                Stalled,
             };
             Type type;
 
@@ -319,6 +321,10 @@ constexpr StringView pseudo_class_name(Selector::SimpleSelector::PseudoClass::Ty
         return "muted"sv;
     case Selector::SimpleSelector::PseudoClass::Type::VolumeLocked:
         return "volume-locked"sv;
+    case Selector::SimpleSelector::PseudoClass::Type::Buffering:
+        return "buffering"sv;
+    case Selector::SimpleSelector::PseudoClass::Type::Stalled:
+        return "stalled"sv;
     }
     VERIFY_NOT_REACHED();
 }

--- a/Userland/Libraries/LibWeb/CSS/Selector.h
+++ b/Userland/Libraries/LibWeb/CSS/Selector.h
@@ -115,6 +115,8 @@ public:
                 Lang,
                 Scope,
                 Defined,
+                Playing,
+                Paused,
             };
             Type type;
 
@@ -304,6 +306,10 @@ constexpr StringView pseudo_class_name(Selector::SimpleSelector::PseudoClass::Ty
         return "scope"sv;
     case Selector::SimpleSelector::PseudoClass::Type::Defined:
         return "defined"sv;
+    case Selector::SimpleSelector::PseudoClass::Type::Playing:
+        return "playing"sv;
+    case Selector::SimpleSelector::PseudoClass::Type::Paused:
+        return "paused"sv;
     }
     VERIFY_NOT_REACHED();
 }

--- a/Userland/Libraries/LibWeb/CSS/Selector.h
+++ b/Userland/Libraries/LibWeb/CSS/Selector.h
@@ -117,6 +117,7 @@ public:
                 Defined,
                 Playing,
                 Paused,
+                Seeking,
             };
             Type type;
 
@@ -310,6 +311,8 @@ constexpr StringView pseudo_class_name(Selector::SimpleSelector::PseudoClass::Ty
         return "playing"sv;
     case Selector::SimpleSelector::PseudoClass::Type::Paused:
         return "paused"sv;
+    case Selector::SimpleSelector::PseudoClass::Type::Seeking:
+        return "seeking"sv;
     }
     VERIFY_NOT_REACHED();
 }

--- a/Userland/Libraries/LibWeb/CSS/Selector.h
+++ b/Userland/Libraries/LibWeb/CSS/Selector.h
@@ -119,6 +119,7 @@ public:
                 Paused,
                 Seeking,
                 Muted,
+                VolumeLocked,
             };
             Type type;
 
@@ -316,6 +317,8 @@ constexpr StringView pseudo_class_name(Selector::SimpleSelector::PseudoClass::Ty
         return "seeking"sv;
     case Selector::SimpleSelector::PseudoClass::Type::Muted:
         return "muted"sv;
+    case Selector::SimpleSelector::PseudoClass::Type::VolumeLocked:
+        return "volume-locked"sv;
     }
     VERIFY_NOT_REACHED();
 }

--- a/Userland/Libraries/LibWeb/CSS/Selector.h
+++ b/Userland/Libraries/LibWeb/CSS/Selector.h
@@ -118,6 +118,7 @@ public:
                 Playing,
                 Paused,
                 Seeking,
+                Muted,
             };
             Type type;
 
@@ -313,6 +314,8 @@ constexpr StringView pseudo_class_name(Selector::SimpleSelector::PseudoClass::Ty
         return "paused"sv;
     case Selector::SimpleSelector::PseudoClass::Type::Seeking:
         return "seeking"sv;
+    case Selector::SimpleSelector::PseudoClass::Type::Muted:
+        return "muted"sv;
     }
     VERIFY_NOT_REACHED();
 }

--- a/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
+++ b/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
@@ -17,6 +17,7 @@
 #include <LibWeb/HTML/HTMLFieldSetElement.h>
 #include <LibWeb/HTML/HTMLHtmlElement.h>
 #include <LibWeb/HTML/HTMLInputElement.h>
+#include <LibWeb/HTML/HTMLMediaElement.h>
 #include <LibWeb/HTML/HTMLOptGroupElement.h>
 #include <LibWeb/HTML/HTMLOptionElement.h>
 #include <LibWeb/HTML/HTMLProgressElement.h>
@@ -289,7 +290,7 @@ static inline bool matches_pseudo_class(CSS::Selector::SimpleSelector::PseudoCla
     case CSS::Selector::SimpleSelector::PseudoClass::Type::NthChild:
     case CSS::Selector::SimpleSelector::PseudoClass::Type::NthLastChild:
     case CSS::Selector::SimpleSelector::PseudoClass::Type::NthOfType:
-    case CSS::Selector::SimpleSelector::PseudoClass::Type::NthLastOfType:
+    case CSS::Selector::SimpleSelector::PseudoClass::Type::NthLastOfType: {
         auto const step_size = pseudo_class.nth_child_pattern.step_size;
         auto const offset = pseudo_class.nth_child_pattern.offset;
         if (step_size == 0 && offset == 0)
@@ -375,6 +376,19 @@ static inline bool matches_pseudo_class(CSS::Selector::SimpleSelector::PseudoCla
 
         // Otherwise, we start at "offset" and count forwards.
         return index >= offset && canonical_modulo(index - offset, step_size) == 0;
+    }
+    case CSS::Selector::SimpleSelector::PseudoClass::Type::Playing: {
+        if (!is<HTML::HTMLMediaElement>(element))
+            return false;
+        auto const& media_element = static_cast<HTML::HTMLMediaElement const&>(element);
+        return !media_element.paused();
+    }
+    case CSS::Selector::SimpleSelector::PseudoClass::Type::Paused: {
+        if (!is<HTML::HTMLMediaElement>(element))
+            return false;
+        auto const& media_element = static_cast<HTML::HTMLMediaElement const&>(element);
+        return media_element.paused();
+    }
     }
 
     return false;

--- a/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
+++ b/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
@@ -406,6 +406,18 @@ static inline bool matches_pseudo_class(CSS::Selector::SimpleSelector::PseudoCla
         //        Once we do, implement this!
         return false;
     }
+    case CSS::Selector::SimpleSelector::PseudoClass::Type::Buffering: {
+        if (!is<HTML::HTMLMediaElement>(element))
+            return false;
+        auto const& media_element = static_cast<HTML::HTMLMediaElement const&>(element);
+        return media_element.blocked();
+    }
+    case CSS::Selector::SimpleSelector::PseudoClass::Type::Stalled: {
+        if (!is<HTML::HTMLMediaElement>(element))
+            return false;
+        auto const& media_element = static_cast<HTML::HTMLMediaElement const&>(element);
+        return media_element.stalled();
+    }
     }
 
     return false;

--- a/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
+++ b/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
@@ -395,6 +395,12 @@ static inline bool matches_pseudo_class(CSS::Selector::SimpleSelector::PseudoCla
         auto const& media_element = static_cast<HTML::HTMLMediaElement const&>(element);
         return media_element.seeking();
     }
+    case CSS::Selector::SimpleSelector::PseudoClass::Type::Muted: {
+        if (!is<HTML::HTMLMediaElement>(element))
+            return false;
+        auto const& media_element = static_cast<HTML::HTMLMediaElement const&>(element);
+        return media_element.muted();
+    }
     }
 
     return false;

--- a/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
+++ b/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
@@ -389,6 +389,12 @@ static inline bool matches_pseudo_class(CSS::Selector::SimpleSelector::PseudoCla
         auto const& media_element = static_cast<HTML::HTMLMediaElement const&>(element);
         return media_element.paused();
     }
+    case CSS::Selector::SimpleSelector::PseudoClass::Type::Seeking: {
+        if (!is<HTML::HTMLMediaElement>(element))
+            return false;
+        auto const& media_element = static_cast<HTML::HTMLMediaElement const&>(element);
+        return media_element.seeking();
+    }
     }
 
     return false;

--- a/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
+++ b/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
@@ -401,6 +401,11 @@ static inline bool matches_pseudo_class(CSS::Selector::SimpleSelector::PseudoCla
         auto const& media_element = static_cast<HTML::HTMLMediaElement const&>(element);
         return media_element.muted();
     }
+    case CSS::Selector::SimpleSelector::PseudoClass::Type::VolumeLocked: {
+        // FIXME: Currently we don't allow the user to specify an override volume, so this is always false.
+        //        Once we do, implement this!
+        return false;
+    }
     }
 
     return false;

--- a/Userland/Libraries/LibWeb/Dump.cpp
+++ b/Userland/Libraries/LibWeb/Dump.cpp
@@ -542,6 +542,12 @@ void dump_selector(StringBuilder& builder, CSS::Selector const& selector)
                 case CSS::Selector::SimpleSelector::PseudoClass::Type::Defined:
                     pseudo_class_description = "Defined";
                     break;
+                case CSS::Selector::SimpleSelector::PseudoClass::Type::Playing:
+                    pseudo_class_description = "Playing";
+                    break;
+                case CSS::Selector::SimpleSelector::PseudoClass::Type::Paused:
+                    pseudo_class_description = "Paused";
+                    break;
                 }
 
                 builder.appendff(" pseudo_class={}", pseudo_class_description);

--- a/Userland/Libraries/LibWeb/Dump.cpp
+++ b/Userland/Libraries/LibWeb/Dump.cpp
@@ -551,6 +551,9 @@ void dump_selector(StringBuilder& builder, CSS::Selector const& selector)
                 case CSS::Selector::SimpleSelector::PseudoClass::Type::Seeking:
                     pseudo_class_description = "Seeking";
                     break;
+                case CSS::Selector::SimpleSelector::PseudoClass::Type::Muted:
+                    pseudo_class_description = "Muted";
+                    break;
                 }
 
                 builder.appendff(" pseudo_class={}", pseudo_class_description);

--- a/Userland/Libraries/LibWeb/Dump.cpp
+++ b/Userland/Libraries/LibWeb/Dump.cpp
@@ -554,6 +554,9 @@ void dump_selector(StringBuilder& builder, CSS::Selector const& selector)
                 case CSS::Selector::SimpleSelector::PseudoClass::Type::Muted:
                     pseudo_class_description = "Muted";
                     break;
+                case CSS::Selector::SimpleSelector::PseudoClass::Type::VolumeLocked:
+                    pseudo_class_description = "VolumeLocked";
+                    break;
                 }
 
                 builder.appendff(" pseudo_class={}", pseudo_class_description);

--- a/Userland/Libraries/LibWeb/Dump.cpp
+++ b/Userland/Libraries/LibWeb/Dump.cpp
@@ -557,6 +557,12 @@ void dump_selector(StringBuilder& builder, CSS::Selector const& selector)
                 case CSS::Selector::SimpleSelector::PseudoClass::Type::VolumeLocked:
                     pseudo_class_description = "VolumeLocked";
                     break;
+                case CSS::Selector::SimpleSelector::PseudoClass::Type::Buffering:
+                    pseudo_class_description = "Buffering";
+                    break;
+                case CSS::Selector::SimpleSelector::PseudoClass::Type::Stalled:
+                    pseudo_class_description = "Stalled";
+                    break;
                 }
 
                 builder.appendff(" pseudo_class={}", pseudo_class_description);

--- a/Userland/Libraries/LibWeb/Dump.cpp
+++ b/Userland/Libraries/LibWeb/Dump.cpp
@@ -548,6 +548,9 @@ void dump_selector(StringBuilder& builder, CSS::Selector const& selector)
                 case CSS::Selector::SimpleSelector::PseudoClass::Type::Paused:
                     pseudo_class_description = "Paused";
                     break;
+                case CSS::Selector::SimpleSelector::PseudoClass::Type::Seeking:
+                    pseudo_class_description = "Seeking";
+                    break;
                 }
 
                 builder.appendff(" pseudo_class={}", pseudo_class_description);

--- a/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -414,6 +414,7 @@ void HTMLMediaElement::set_muted(bool muted)
 
     m_muted = muted;
     volume_or_muted_attribute_changed();
+    set_needs_style_update(true);
 }
 
 // https://html.spec.whatwg.org/multipage/media.html#user-interface:dom-media-volume-3

--- a/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -212,6 +212,14 @@ WebIDL::ExceptionOr<Bindings::CanPlayTypeResult> HTMLMediaElement::can_play_type
     return Bindings::CanPlayTypeResult::Empty;
 }
 
+void HTMLMediaElement::set_seeking(bool seeking)
+{
+    if (m_seeking == seeking)
+        return;
+    m_seeking = seeking;
+    set_needs_style_update(true);
+}
+
 // https://html.spec.whatwg.org/multipage/media.html#dom-media-load
 WebIDL::ExceptionOr<void> HTMLMediaElement::load()
 {
@@ -505,7 +513,8 @@ WebIDL::ExceptionOr<void> HTMLMediaElement::load_element()
         }
 
         // 7. If seeking is true, set it to false.
-        m_seeking = false;
+        if (seeking())
+            set_seeking(false);
 
         // 8. Set the current playback position to 0.
         m_current_playback_position = 0;
@@ -1490,7 +1499,7 @@ void HTMLMediaElement::seek_element(double playback_position, MediaSeekMode seek
     }
 
     // 4. Set the seeking IDL attribute to true.
-    m_seeking = true;
+    set_seeking(true);
 
     // FIXME: 5. If the seek was in response to a DOM method call or setting of an IDL attribute, then continue the script. The
     //           remainder of these steps must be run in parallel. With the exception of the steps marked with ⌛, they could be
@@ -1534,7 +1543,7 @@ void HTMLMediaElement::seek_element(double playback_position, MediaSeekMode seek
     //            synchronous section are marked with ⌛.)
 
     // 14. ⌛ Set the seeking IDL attribute to false.
-    m_seeking = false;
+    set_seeking(false);
 
     // 15. ⌛ Run the time marches on steps.
     time_marches_on(TimeMarchesOnReason::Other);

--- a/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -1273,7 +1273,10 @@ void HTMLMediaElement::forget_media_resource_specific_tracks()
 // https://html.spec.whatwg.org/multipage/media.html#ready-states:media-element-3
 void HTMLMediaElement::set_ready_state(ReadyState ready_state)
 {
-    ScopeGuard guard { [&] { m_ready_state = ready_state; } };
+    ScopeGuard guard { [&] {
+        m_ready_state = ready_state;
+        set_needs_style_update(true);
+    } };
 
     // When the ready state of a media element whose networkState is not NETWORK_EMPTY changes, the user agent must
     // follow the steps given below:
@@ -1621,6 +1624,12 @@ bool HTMLMediaElement::blocked() const
     // FIXME: Implement "paused for user interaction" (namely "the user agent has reached a point in the media resource
     //        where the user has to make a selection for the resource to continue").
     // FIXME: Implement "paused for in-band content".
+    return false;
+}
+
+bool HTMLMediaElement::stalled() const
+{
+    // FIXME: Implement stall timeout. https://html.spec.whatwg.org/multipage/media.html#stall-timeout
     return false;
 }
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -1591,6 +1591,7 @@ void HTMLMediaElement::set_paused(bool paused)
 
     if (auto* layout_node = this->layout_node())
         layout_node->set_needs_display();
+    set_needs_style_update(true);
 }
 
 // https://html.spec.whatwg.org/multipage/media.html#blocked-media-element

--- a/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.h
@@ -70,6 +70,7 @@ public:
     ReadyState ready_state() const { return m_ready_state; }
 
     bool seeking() const { return m_seeking; }
+    void set_seeking(bool);
 
     WebIDL::ExceptionOr<void> load();
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.h
@@ -68,6 +68,8 @@ public:
         HaveEnoughData,
     };
     ReadyState ready_state() const { return m_ready_state; }
+    bool blocked() const;
+    bool stalled() const;
 
     bool seeking() const { return m_seeking; }
     void set_seeking(bool);
@@ -172,7 +174,6 @@ private:
 
     void volume_or_muted_attribute_changed();
 
-    bool blocked() const;
     bool is_eligible_for_autoplay() const;
     bool has_ended_playback() const;
     WebIDL::ExceptionOr<void> reached_end_of_media_playback();


### PR DESCRIPTION
These all affect `<video>` and `<audio>` elements. 

- `:playing`
- `:paused`
- `:seeking`
- `:muted`
- `:volume-locked` (This refers to a UA feature allowing the user to lock the volume on a media element so that nothing can modify it. We don't support that, so it's always false.)
- `:buffering`
- `:stalled` (We don't implement the stall timeout, so this is always false.)

The lack of WPT tests, and other-browser support for these means I'm not certain I'm doing things correctly for all of these pseudo-classes, but they seem right. :sweat_smile: 