### PR TITLE
Ports: Remove the remaining instances of linking static libraries into shared libraries

### DIFF
--- a/Ports/freetype/package.sh
+++ b/Ports/freetype/package.sh
@@ -13,9 +13,3 @@ configopts=(
     "--with-harfbuzz=no"
     "--with-png=no"
 )
-
-install() {
-    run make DESTDIR="${SERENITY_INSTALL_ROOT}" "${installopts[@]}" install
-    ${CC} -shared -o "${SERENITY_INSTALL_ROOT}/usr/local/lib/libfreetype.so" -Wl,-soname,libfreetype.so -Wl,--whole-archive "${SERENITY_INSTALL_ROOT}/usr/local/lib/libfreetype.a" -Wl,--no-whole-archive
-    rm -f "${SERENITY_INSTALL_ROOT}/usr/local/lib/libfreetype.la"
-}

--- a/Ports/freetype/patches/0001-libtool-Enable-shared-library-support-for-SerenityOS.patch
+++ b/Ports/freetype/patches/0001-libtool-Enable-shared-library-support-for-SerenityOS.patch
@@ -1,0 +1,73 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tim Schumacher <timschumi@gmx.de>
+Date: Tue, 1 Aug 2023 20:34:42 +0200
+Subject: [PATCH] libtool: Enable shared library support for SerenityOS
+
+For some odd reason, libtool handles the configuration for shared
+libraries entirely statically and in its configure script. If no
+shared library support is "present", building shared libraries is
+disabled entirely.
+
+Fix that by just adding the appropriate configuration options for
+`serenity`. This allows us to finally create dynamic libraries
+automatically using libtool, without having to manually link the
+static library into a shared library.
+---
+ builds/unix/configure | 23 +++++++++++++++++++++++
+ 1 file changed, 23 insertions(+)
+
+diff --git a/builds/unix/configure b/builds/unix/configure
+index 99499ceebe1c715183610b374841de288552d3e3..e2fa5a60411fab7089aab5800c89abaeea985d36 100755
+--- a/builds/unix/configure
++++ b/builds/unix/configure
+@@ -5558,6 +5558,10 @@ tpf*)
+ os2*)
+   lt_cv_deplibs_check_method=pass_all
+   ;;
++
++serenity*)
++  lt_cv_deplibs_check_method=pass_all
++  ;;
+ esac
+ 
+ fi
+@@ -9108,6 +9112,10 @@ lt_prog_compiler_static=
+       lt_prog_compiler_static='-Bstatic'
+       ;;
+ 
++    serenity*)
++      lt_prog_compiler_can_build_shared=yes
++      ;;
++
+     *)
+       lt_prog_compiler_can_build_shared=no
+       ;;
+@@ -10640,6 +10648,10 @@ printf "%s\n" "$lt_cv_irix_exported_symbol" >&6; }
+       hardcode_shlibpath_var=no
+       ;;
+ 
++    serenity*)
++      ld_shlibs=yes
++      ;;
++
+     *)
+       ld_shlibs=no
+       ;;
+@@ -11712,6 +11724,17 @@ uts4*)
+   shlibpath_var=LD_LIBRARY_PATH
+   ;;
+ 
++serenity*)
++  version_type=linux
++  need_lib_prefix=no
++  need_version=no
++  library_names_spec='${libname}${release}${shared_ext}${versuffix} ${libname}${release}${shared_ext}${major} ${libname}${shared_ext}'
++  soname_spec='${libname}${release}${shared_ext}${major}'
++  shlibpath_var=LD_LIBRARY_PATH
++  shlibpath_overrides_runpath=no
++  dynamic_linker='SerenityOS LibELF'
++  ;;
++
+ *)
+   dynamic_linker=no
+   ;;

--- a/Ports/freetype/patches/ReadMe.md
+++ b/Ports/freetype/patches/ReadMe.md
@@ -1,0 +1,16 @@
+# Patches for freetype on SerenityOS
+
+## `0001-libtool-Enable-shared-library-support-for-SerenityOS.patch`
+
+libtool: Enable shared library support for SerenityOS
+
+For some odd reason, libtool handles the configuration for shared
+libraries entirely statically and in its configure script. If no
+shared library support is "present", building shared libraries is
+disabled entirely.
+
+Fix that by just adding the appropriate configuration options for
+`serenity`. This allows us to finally create dynamic libraries
+automatically using libtool, without having to manually link the
+static library into a shared library.
+

--- a/Ports/gettext/package.sh
+++ b/Ports/gettext/package.sh
@@ -6,9 +6,3 @@ files="https://ftpmirror.gnu.org/gettext/gettext-${version}.tar.gz gettext-${ver
 depends=("libiconv")
 use_fresh_config_sub='true'
 config_sub_paths=("build-aux/config.sub" "libtextstyle/build-aux/config.sub")
-
-install() {
-    run make DESTDIR=${SERENITY_INSTALL_ROOT} "${installopts[@]}" install
-    ${CC} -shared -pthread -o ${SERENITY_INSTALL_ROOT}/usr/local/lib/libintl.so -Wl,-soname,libintl.so -Wl,--whole-archive ${SERENITY_INSTALL_ROOT}/usr/local/lib/libintl.a -Wl,--no-whole-archive -liconv
-    rm -f ${SERENITY_INSTALL_ROOT}/usr/local/lib/libintl.la
-}

--- a/Ports/gettext/patches/0001-Stub-out-some-wctype-functions.patch
+++ b/Ports/gettext/patches/0001-Stub-out-some-wctype-functions.patch
@@ -8,10 +8,10 @@ Subject: [PATCH] Stub out some wctype functions
  1 file changed, 12 insertions(+)
 
 diff --git a/gettext-tools/gnulib-lib/fnmatch.c b/gettext-tools/gnulib-lib/fnmatch.c
-index 3937ce3..84aa6e6 100644
+index b33a127d9802be15eeafef4622e63aac709bef8e..87f1f7c218c1708f84f3e4394eaa219e1d7c5858 100644
 --- a/gettext-tools/gnulib-lib/fnmatch.c
 +++ b/gettext-tools/gnulib-lib/fnmatch.c
-@@ -106,6 +106,18 @@ extern int fnmatch (const char *pattern, const char *string, int flags);
+@@ -112,6 +112,18 @@ typedef ptrdiff_t idx_t;
  # define CHAR_CLASS_MAX_LENGTH 256
  #endif
  

--- a/Ports/gettext/patches/0002-libtool-Enable-shared-library-support-for-SerenityOS.patch
+++ b/Ports/gettext/patches/0002-libtool-Enable-shared-library-support-for-SerenityOS.patch
@@ -1,0 +1,108 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tim Schumacher <timschumi@gmx.de>
+Date: Tue, 1 Aug 2023 20:45:12 +0200
+Subject: [PATCH] libtool: Enable shared library support for SerenityOS
+
+For some odd reason, libtool handles the configuration for shared
+libraries entirely statically and in its configure script. If no
+shared library support is "present", building shared libraries is
+disabled entirely.
+
+Fix that by just adding the appropriate configuration options for
+`serenity`. This allows us to finally create dynamic libraries
+automatically using libtool, without having to manually link the
+static library into a shared library.
+
+This patch here is a bit more elaborate for other ports, as libintl's
+configure includes the code for detecting dynamic linker characteristics
+twice, and it also queries the C++ compiler for shared library support.
+
+Co-Authored-By: Daniel Bertalan <dani@danielbertalan.dev>
+---
+ gettext-runtime/configure | 38 ++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 38 insertions(+)
+
+diff --git a/gettext-runtime/configure b/gettext-runtime/configure
+index 56cc8e17be7ed390b4a692dde31434dceff45a94..268c7c572abde069814834be25d08175e51f195e 100755
+--- a/gettext-runtime/configure
++++ b/gettext-runtime/configure
+@@ -10219,6 +10219,10 @@ tpf*)
+ os2*)
+   lt_cv_deplibs_check_method=pass_all
+   ;;
++
++serenity*)
++  lt_cv_deplibs_check_method=pass_all
++  ;;
+ esac
+ 
+ fi
+@@ -13707,6 +13711,10 @@ lt_prog_compiler_static=
+       lt_prog_compiler_static='-Bstatic'
+       ;;
+ 
++    serenity*)
++      lt_prog_compiler_can_build_shared=yes
++      ;;
++
+     *)
+       lt_prog_compiler_can_build_shared=no
+       ;;
+@@ -15239,6 +15247,10 @@ printf "%s\n" "$lt_cv_irix_exported_symbol" >&6; }
+       hardcode_shlibpath_var=no
+       ;;
+ 
++    serenity*)
++      ld_shlibs=yes
++      ;;
++
+     *)
+       ld_shlibs=no
+       ;;
+@@ -16311,6 +16323,17 @@ uts4*)
+   shlibpath_var=LD_LIBRARY_PATH
+   ;;
+ 
++serenity*)
++  version_type=linux
++  need_lib_prefix=no
++  need_version=no
++  library_names_spec='${libname}${release}${shared_ext}${versuffix} ${libname}${release}${shared_ext}${major} ${libname}${shared_ext}'
++  soname_spec='${libname}${release}${shared_ext}${major}'
++  shlibpath_var=LD_LIBRARY_PATH
++  shlibpath_overrides_runpath=no
++  dynamic_linker='SerenityOS LibELF'
++  ;;
++
+ *)
+   dynamic_linker=no
+   ;;
+@@ -18601,6 +18624,10 @@ fi
+         ld_shlibs_CXX=no
+         ;;
+ 
++      serenity*)
++        ld_shlibs_CXX=yes
++        ;;
++
+       *)
+         # FIXME: insert proper C++ library support
+         ld_shlibs_CXX=no
+@@ -20300,6 +20327,17 @@ uts4*)
+   shlibpath_var=LD_LIBRARY_PATH
+   ;;
+ 
++serenity*)
++  version_type=linux
++  need_lib_prefix=no
++  need_version=no
++  library_names_spec='${libname}${release}${shared_ext}${versuffix} ${libname}${release}${shared_ext}${major} ${libname}${shared_ext}'
++  soname_spec='${libname}${release}${shared_ext}${major}'
++  shlibpath_var=LD_LIBRARY_PATH
++  shlibpath_overrides_runpath=no
++  dynamic_linker='SerenityOS LibELF'
++  ;;
++
+ *)
+   dynamic_linker=no
+   ;;

--- a/Ports/gettext/patches/ReadMe.md
+++ b/Ports/gettext/patches/ReadMe.md
@@ -5,3 +5,22 @@
 Stub out some wctype functions
 
 
+## `0002-libtool-Enable-shared-library-support-for-SerenityOS.patch`
+
+libtool: Enable shared library support for SerenityOS
+
+For some odd reason, libtool handles the configuration for shared
+libraries entirely statically and in its configure script. If no
+shared library support is "present", building shared libraries is
+disabled entirely.
+
+Fix that by just adding the appropriate configuration options for
+`serenity`. This allows us to finally create dynamic libraries
+automatically using libtool, without having to manually link the
+static library into a shared library.
+
+This patch here is a bit more elaborate for other ports, as libintl's
+configure includes the code for detecting dynamic linker characteristics
+twice, and it also queries the C++ compiler for shared library support.
+
+

--- a/Ports/zlib/package.sh
+++ b/Ports/zlib/package.sh
@@ -5,12 +5,9 @@ useconfigure=true
 files="https://www.zlib.net/zlib-${version}.tar.gz zlib-${version}.tar.gz b3a24de97a8fdbc835b9833169501030b8977031bcb54b3b3ac13740f846ab30"
 
 configure() {
-    # Set uname to linux to prevent it finding the host's `libtool` on e.g. Darwin
-    run ./configure --uname=linux
-}
-
-install() {
-    run make DESTDIR=${SERENITY_INSTALL_ROOT} "${installopts[@]}" install
-    ${CC} -shared -o ${SERENITY_INSTALL_ROOT}/usr/local/lib/libz.so -Wl,-soname,libz.so -Wl,--whole-archive ${SERENITY_INSTALL_ROOT}/usr/local/lib/libz.a -Wl,--no-whole-archive
-    rm -f ${SERENITY_INSTALL_ROOT}/usr/local/lib/libz.la
+    # No SONAME is set on unknown systems by default. Manually set it
+    # to an unversioned name to avoid needing to rebuild dependent
+    # ports after a minor version upgrade.
+    export LDSHARED="$CC -shared -Wl,-soname,libz.so"
+    run ./configure --uname=SerenityOS
 }


### PR DESCRIPTION
These just happen to work right now because our compilers default to compiling every object with `-fPIC`. I would like to change this to `-fPIE` in the next toolchain update, which only permits the object to be linked into an executable (and produces better code as a result). Libtool automatically adds the necessary compiler flags when building a shared object, we just need to tell it that we support those. See also #14178 and #6694.

**Ports/zlib: Do not manually link zlib into a shared library**

Instead, pass our system name to its (non-autotools) configure script.
Tell it to include a SONAME to avoid breaking dependent ports when
updating zlib.

**Ports: Replace manually linking freetype with a libtool patch**

**Ports/gettext: Replace manually linking libintl with a libtool patch**

The `gettext` port comprises of multiple libraries, however `libintl.so`
is the one most commonly used in external executables/libraries, so
porting the patches to this one is enough.