### PR TITLE
Ports/vim: Override `uname` output to fix compilation on macOS

### DIFF
--- a/Ports/vim/package.sh
+++ b/Ports/vim/package.sh
@@ -14,6 +14,9 @@ export vim_cv_tgetent=zero
 export vim_cv_terminfo=yes
 export vim_cv_toupper_broken=no
 export vim_cv_tty_group=world
+export vim_cv_uname_output='SerenityOS'
+export vim_cv_uname_r_output='1.0-dev'
+export vim_cv_uname_m_output="${SERENITY_ARCH}"
 
 post_install() {
     run ln -sf vim "${SERENITY_INSTALL_ROOT}/usr/local/bin/vi"


### PR DESCRIPTION
`vim` does not use a mechanism like `config.sub` for determining the canonical system name from the `--target` triple passed to `configure`. Instead, it directly executes the `uname` executable on the host. This leads to it trying to build macOS-specific files on Mac hosts even if we are compiling for a different platform. To make cross-compilation possible, developers added a way to override `uname`'s output with environment variables. Let's set these.

See vim/vim#9338
Obsoletes #11426