### PR TITLE
Ports/glm: Create `/usr/local/include` if it doesn't exist

### DIFF
--- a/Ports/glm/package.sh
+++ b/Ports/glm/package.sh
@@ -12,5 +12,7 @@ configure() {
 }
 
 install() {
-    run cp -R glm "${SERENITY_BUILD_DIR}/Root/usr/local/include/"
+    target_dir="${SERENITY_INSTALL_ROOT}/usr/local/include/"
+    run_nocd mkdir -p "${target_dir}"
+    run cp -R glm "${target_dir}"
 }


### PR DESCRIPTION
Previously, the `glm` port would not build from a clean state, as this directory does not exist by default.