### PR TITLE
LibGUI: Replace DeprecatedString usage in Widget

### DIFF
--- a/Userland/Applets/Audio/main.cpp
+++ b/Userland/Applets/Audio/main.cpp
@@ -87,7 +87,7 @@ private:
         m_root_container->set_frame_style(Gfx::FrameStyle::Window);
 
         m_percent_box = m_root_container->add<GUI::CheckBox>("\xE2\x84\xB9"_string);
-        m_percent_box->set_tooltip(show_percent() ? "Hide percent" : "Show percent");
+        m_percent_box->set_tooltip_deprecated(show_percent() ? "Hide percent" : "Show percent");
         m_percent_box->set_checked(show_percent());
         m_percent_box->on_checked = [&](bool show_percent) {
             set_show_percent(show_percent);
@@ -111,9 +111,9 @@ private:
 
         m_mute_box = m_root_container->add<GUI::CheckBox>("\xE2\x9D\x8C"_string);
         m_mute_box->set_checked(m_audio_muted);
-        m_mute_box->set_tooltip(m_audio_muted ? "Unmute" : "Mute");
+        m_mute_box->set_tooltip_deprecated(m_audio_muted ? "Unmute" : "Mute");
         m_mute_box->on_checked = [&](bool is_muted) {
-            m_mute_box->set_tooltip(is_muted ? "Unmute" : "Mute");
+            m_mute_box->set_tooltip_deprecated(is_muted ? "Unmute" : "Mute");
             m_audio_client->set_main_mix_muted(is_muted);
             GUI::Application::the()->hide_tooltip();
         };
@@ -129,7 +129,7 @@ public:
     {
         m_show_percent = show_percent;
         m_percent_box->set_checked(show_percent);
-        m_percent_box->set_tooltip(show_percent ? "Hide percent" : "Show percent");
+        m_percent_box->set_tooltip_deprecated(show_percent ? "Hide percent" : "Show percent");
         if (show_percent)
             window()->resize(44, 16);
         else

--- a/Userland/Applets/ClipboardHistory/main.cpp
+++ b/Userland/Applets/ClipboardHistory/main.cpp
@@ -101,7 +101,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     applet_window->set_window_type(GUI::WindowType::Applet);
     applet_window->set_has_alpha_channel(true);
     auto icon_widget = TRY(applet_window->set_main_widget<GUI::ImageWidget>());
-    icon_widget->set_tooltip("Clipboard History");
+    icon_widget->set_tooltip_deprecated("Clipboard History");
     icon_widget->load_from_file("/res/icons/16x16/edit-copy.png"sv);
     icon_widget->on_click = [&main_window = *main_window] {
         main_window.show();

--- a/Userland/Applets/Keymap/KeymapStatusWidget.cpp
+++ b/Userland/Applets/Keymap/KeymapStatusWidget.cpp
@@ -66,7 +66,7 @@ ErrorOr<void> KeymapStatusWidget::refresh_menu()
 void KeymapStatusWidget::set_current_keymap(DeprecatedString const& keymap)
 {
     m_current_keymap = keymap;
-    set_tooltip(keymap);
+    set_tooltip_deprecated(keymap);
     update();
 }
 

--- a/Userland/Applets/Network/main.cpp
+++ b/Userland/Applets/Network/main.cpp
@@ -62,7 +62,7 @@ private:
             m_adapter_info = adapter_info;
         }
 
-        set_tooltip(m_adapter_info);
+        set_tooltip_deprecated(m_adapter_info);
 
         if (m_connected)
             NetworkWidget::set_bitmap(m_connected_icon);

--- a/Userland/Applets/ResourceGraph/main.cpp
+++ b/Userland/Applets/ResourceGraph/main.cpp
@@ -107,7 +107,7 @@ private:
         default:
             VERIFY_NOT_REACHED();
         }
-        set_tooltip(m_tooltip);
+        set_tooltip_deprecated(m_tooltip);
         update();
     }
 

--- a/Userland/Applications/Assistant/main.cpp
+++ b/Userland/Applications/Assistant/main.cpp
@@ -250,7 +250,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             auto& match = results_container.add<Assistant::ResultRow>();
             match.set_icon(result->bitmap());
             match.set_text(String::from_deprecated_string(result->title()).release_value_but_fixme_should_propagate_errors());
-            match.set_tooltip(result->tooltip());
+            match.set_tooltip_deprecated(result->tooltip());
             match.on_click = [&result](auto) {
                 result->activate();
                 GUI::Application::the()->quit();

--- a/Userland/Applications/Browser/BookmarksBarWidget.cpp
+++ b/Userland/Applications/Browser/BookmarksBarWidget.cpp
@@ -117,7 +117,7 @@ BookmarksBarWidget::BookmarksBarWidget(DeprecatedString const& bookmarks_file, b
         set_visible(false);
 
     m_additional = GUI::Button::construct();
-    m_additional->set_tooltip("Show hidden bookmarks");
+    m_additional->set_tooltip_deprecated("Show hidden bookmarks");
     m_additional->set_menu(m_additional_menu);
     auto bitmap_or_error = Gfx::Bitmap::load_from_file("/res/icons/16x16/overflow-menu.png"sv);
     if (!bitmap_or_error.is_error())
@@ -216,7 +216,7 @@ void BookmarksBarWidget::model_did_update(unsigned)
         button.set_fixed_size(font().width(title) + 32, 20);
         button.set_relative_rect(rect);
         button.set_focus_policy(GUI::FocusPolicy::TabFocus);
-        button.set_tooltip(url);
+        button.set_tooltip_deprecated(url);
         button.set_allowed_mouse_buttons_for_pressing(GUI::MouseButton::Primary | GUI::MouseButton::Middle);
 
         button.on_click = [title, url, this](auto) {

--- a/Userland/Applications/Browser/ConsoleWidget.cpp
+++ b/Userland/Applications/Browser/ConsoleWidget.cpp
@@ -62,7 +62,7 @@ ConsoleWidget::ConsoleWidget()
     auto& clear_button = bottom_container.add<GUI::Button>();
     clear_button.set_fixed_size(22, 22);
     clear_button.set_icon(g_icon_bag.delete_icon);
-    clear_button.set_tooltip("Clear the console output");
+    clear_button.set_tooltip_deprecated("Clear the console output");
     clear_button.on_click = [this](auto) {
         clear_output();
     };

--- a/Userland/Applications/Browser/Tab.cpp
+++ b/Userland/Applications/Browser/Tab.cpp
@@ -202,7 +202,7 @@ Tab::Tab(BrowserWindow& window)
         this);
 
     m_reset_zoom_button = toolbar.add<GUI::Button>();
-    m_reset_zoom_button->set_tooltip("Reset zoom level");
+    m_reset_zoom_button->set_tooltip_deprecated("Reset zoom level");
     m_reset_zoom_button->on_click = [&](auto) {
         view().reset_zoom();
         update_reset_zoom_button();
@@ -724,10 +724,10 @@ void Tab::update_bookmark_button(StringView url)
 {
     if (BookmarksBarWidget::the().contains_bookmark(url)) {
         m_bookmark_button->set_icon(g_icon_bag.bookmark_filled);
-        m_bookmark_button->set_tooltip("Remove Bookmark");
+        m_bookmark_button->set_tooltip_deprecated("Remove Bookmark");
     } else {
         m_bookmark_button->set_icon(g_icon_bag.bookmark_contour);
-        m_bookmark_button->set_tooltip("Add Bookmark");
+        m_bookmark_button->set_tooltip_deprecated("Add Bookmark");
     }
 }
 

--- a/Userland/Applications/DisplaySettings/MonitorSettingsWidget.cpp
+++ b/Userland/Applications/DisplaySettings/MonitorSettingsWidget.cpp
@@ -216,7 +216,7 @@ ErrorOr<void> MonitorSettingsWidget::selected_screen_index_or_resolution_changed
 
     if (screen_dpi.has_value()) {
         auto dpi_label_value = TRY(String::formatted("{} dpi", screen_dpi.value()));
-        m_dpi_label->set_tooltip(screen_dpi_tooltip.to_deprecated_string());
+        m_dpi_label->set_tooltip_deprecated(screen_dpi_tooltip.to_deprecated_string());
         m_dpi_label->set_text(move(dpi_label_value));
         m_dpi_label->set_visible(true);
     } else {

--- a/Userland/Applications/Piano/MainWidget.cpp
+++ b/Userland/Applications/Piano/MainWidget.cpp
@@ -69,7 +69,7 @@ ErrorOr<void> MainWidget::initialize()
     // FIXME: Implement vertical flipping in GUI::Slider, not here.
     m_octave_knob = TRY(m_octave_container->try_add<GUI::VerticalSlider>());
     m_octave_knob->set_preferred_width(GUI::SpecialDimension::Fit);
-    m_octave_knob->set_tooltip("Z: octave down, X: octave up");
+    m_octave_knob->set_tooltip_deprecated("Z: octave down, X: octave up");
     m_octave_knob->set_range(octave_min - 1, octave_max - 1);
     m_octave_knob->set_value((octave_max - 1) - (m_track_manager.keyboard()->virtual_keyboard_octave() - 1));
     m_octave_knob->set_step(1);

--- a/Userland/Applications/Piano/PlayerWidget.cpp
+++ b/Userland/Applications/Piano/PlayerWidget.cpp
@@ -62,7 +62,7 @@ ErrorOr<void> PlayerWidget::initialize()
     m_add_track_button = TRY(try_add<GUI::Button>());
     m_add_track_button->set_icon(*m_add_track_icon);
     m_add_track_button->set_fixed_width(30);
-    m_add_track_button->set_tooltip("Add Track");
+    m_add_track_button->set_tooltip_deprecated("Add Track");
     m_add_track_button->set_focus_policy(GUI::FocusPolicy::NoFocus);
     m_add_track_button->on_click = [this](unsigned) {
         add_track();
@@ -71,7 +71,7 @@ ErrorOr<void> PlayerWidget::initialize()
     m_next_track_button = TRY(try_add<GUI::Button>());
     m_next_track_button->set_icon(*m_next_track_icon);
     m_next_track_button->set_fixed_width(30);
-    m_next_track_button->set_tooltip("Next Track");
+    m_next_track_button->set_tooltip_deprecated("Next Track");
     m_next_track_button->set_focus_policy(GUI::FocusPolicy::NoFocus);
     m_next_track_button->on_click = [this](unsigned) {
         next_track();
@@ -80,7 +80,7 @@ ErrorOr<void> PlayerWidget::initialize()
     m_play_button = TRY(try_add<GUI::Button>());
     m_play_button->set_icon(*m_pause_icon);
     m_play_button->set_fixed_width(30);
-    m_play_button->set_tooltip("Play/Pause playback");
+    m_play_button->set_tooltip_deprecated("Play/Pause playback");
     m_play_button->set_focus_policy(GUI::FocusPolicy::NoFocus);
     m_play_button->on_click = [this](unsigned) {
         m_audio_loop.toggle_paused();
@@ -95,7 +95,7 @@ ErrorOr<void> PlayerWidget::initialize()
     m_back_button = TRY(try_add<GUI::Button>());
     m_back_button->set_icon(*m_back_icon);
     m_back_button->set_fixed_width(30);
-    m_back_button->set_tooltip("Previous Note");
+    m_back_button->set_tooltip_deprecated("Previous Note");
     m_back_button->set_focus_policy(GUI::FocusPolicy::NoFocus);
     m_back_button->on_click = [this](unsigned) {
         m_track_manager.time_forward(-(sample_rate / (beats_per_minute / 60) / notes_per_beat));
@@ -104,7 +104,7 @@ ErrorOr<void> PlayerWidget::initialize()
     m_next_button = TRY(try_add<GUI::Button>());
     m_next_button->set_icon(*m_next_icon);
     m_next_button->set_fixed_width(30);
-    m_next_button->set_tooltip("Next Note");
+    m_next_button->set_tooltip_deprecated("Next Note");
     m_next_button->set_focus_policy(GUI::FocusPolicy::NoFocus);
     m_next_button->on_click = [this](unsigned) {
         m_track_manager.time_forward((sample_rate / (beats_per_minute / 60) / notes_per_beat));

--- a/Userland/Applications/Piano/ProcessorParameterWidget/Slider.cpp
+++ b/Userland/Applications/Piano/ProcessorParameterWidget/Slider.cpp
@@ -26,7 +26,7 @@ ProcessorParameterSlider::ProcessorParameterSlider(Orientation orientation, DSP:
         set_value(value_log);
         set_step((min_log - max_log) / slider_steps);
     }
-    set_tooltip(m_parameter.name().to_deprecated_string());
+    set_tooltip_deprecated(m_parameter.name().to_deprecated_string());
     if (m_value_label != nullptr)
         m_value_label->set_text(String::formatted("{:.2f}", static_cast<double>(m_parameter)).release_value_but_fixme_should_propagate_errors());
 

--- a/Userland/Applications/PixelPaint/Filters/FastBoxBlur.cpp
+++ b/Userland/Applications/PixelPaint/Filters/FastBoxBlur.cpp
@@ -180,7 +180,7 @@ ErrorOr<RefPtr<GUI::Widget>> FastBoxBlur::get_settings_widget()
 
         m_gaussian_checkbox = TRY(gaussian_container->try_add<GUI::CheckBox>("Approximate Gaussian Blur"_string));
         m_gaussian_checkbox->set_checked(m_approximate_gauss);
-        m_gaussian_checkbox->set_tooltip("A real gaussian blur can be approximated by running the box blur multiple times with different weights.");
+        m_gaussian_checkbox->set_tooltip_deprecated("A real gaussian blur can be approximated by running the box blur multiple times with different weights.");
         m_gaussian_checkbox->on_checked = [this](bool checked) {
             m_approximate_gauss = checked;
             update_preview();

--- a/Userland/Applications/PixelPaint/Tools/GuideTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/GuideTool.cpp
@@ -189,7 +189,7 @@ ErrorOr<GUI::Widget*> GuideTool::get_properties_widget()
         auto snapping_label = TRY(snapping_container->try_add<GUI::Label>("Snap offset:"_string));
         snapping_label->set_text_alignment(Gfx::TextAlignment::CenterLeft);
         snapping_label->set_fixed_size(80, 20);
-        snapping_label->set_tooltip("Press Shift to snap");
+        snapping_label->set_tooltip_deprecated("Press Shift to snap");
 
         auto snapping_slider = TRY(snapping_container->try_add<GUI::ValueSlider>(Orientation::Horizontal, "px"_string));
         snapping_slider->set_range(0, 50);

--- a/Userland/Applications/SpaceAnalyzer/TreeMapWidget.cpp
+++ b/Userland/Applications/SpaceAnalyzer/TreeMapWidget.cpp
@@ -282,7 +282,7 @@ void TreeMapWidget::mousemove_event(GUI::MouseEvent& event)
 {
     auto* node = path_node(m_viewpoint);
     if (!node) {
-        set_tooltip({});
+        set_tooltip_deprecated({});
         return;
     }
 
@@ -293,7 +293,7 @@ void TreeMapWidget::mousemove_event(GUI::MouseEvent& event)
         }
     });
 
-    set_tooltip(DeprecatedString::formatted("{}\n{}", hovered_node->name(), human_readable_size(hovered_node->area())));
+    set_tooltip_deprecated(DeprecatedString::formatted("{}\n{}", hovered_node->name(), human_readable_size(hovered_node->area())));
 }
 
 void TreeMapWidget::mousedown_event(GUI::MouseEvent& event)

--- a/Userland/Applications/Spreadsheet/CellTypeDialog.cpp
+++ b/Userland/Applications/Spreadsheet/CellTypeDialog.cpp
@@ -153,7 +153,7 @@ void CellTypeDialog::setup_tabs(GUI::TabWidget& tabs, Vector<Position> const& po
 
             m_type = CellType::get_by_name(g_types.at(index.row()));
             if (auto* editor = right_side.find_descendant_of_type_named<GUI::TextEditor>("format_editor"))
-                editor->set_tooltip(m_type->metadata_hint(MetadataName::Format));
+                editor->set_tooltip_deprecated(m_type->metadata_hint(MetadataName::Format));
         };
 
         {

--- a/Userland/Applications/Spreadsheet/SpreadsheetView.cpp
+++ b/Userland/Applications/Spreadsheet/SpreadsheetView.cpp
@@ -80,10 +80,10 @@ void InfinitelyScrollableTableView::mousemove_event(GUI::MouseEvent& event)
         if (!is_dragging()) {
             auto tooltip = model->data(index, static_cast<GUI::ModelRole>(SheetModel::Role::Tooltip));
             if (tooltip.is_string()) {
-                set_tooltip(tooltip.as_string());
+                set_tooltip_deprecated(tooltip.as_string());
                 show_or_hide_tooltip();
             } else {
-                set_tooltip({});
+                set_tooltip_deprecated({});
             }
         }
 

--- a/Userland/Applications/Spreadsheet/SpreadsheetWidget.cpp
+++ b/Userland/Applications/Spreadsheet/SpreadsheetWidget.cpp
@@ -46,7 +46,7 @@ SpreadsheetWidget::SpreadsheetWidget(GUI::Window& parent_window, Vector<NonnullR
 
     auto& help_button = top_bar.add<GUI::Button>();
     help_button.set_icon(Gfx::Bitmap::load_from_file("/res/icons/16x16/app-help.png"sv).release_value_but_fixme_should_propagate_errors());
-    help_button.set_tooltip("Functions Help");
+    help_button.set_tooltip_deprecated("Functions Help");
     help_button.set_fixed_size(20, 20);
     help_button.on_click = [&](auto) {
         if (!current_view()) {

--- a/Userland/DevTools/GMLPlayground/MainWidget.cpp
+++ b/Userland/DevTools/GMLPlayground/MainWidget.cpp
@@ -90,7 +90,7 @@ ErrorOr<NonnullRefPtr<MainWidget>> MainWidget::try_create(GUI::Icon const& icon)
     main_widget->m_editor->on_change = [main_widget = main_widget.ptr()] {
         main_widget->m_preview->remove_all_children();
         // FIXME: Parsing errors happen while the user is typing. What should we do about them?
-        (void)main_widget->m_preview->load_from_gml(main_widget->m_editor->text(), [](DeprecatedString const& class_name) -> ErrorOr<NonnullRefPtr<Core::EventReceiver>> {
+        (void)main_widget->m_preview->load_from_gml(main_widget->m_editor->text(), [](StringView class_name) -> ErrorOr<NonnullRefPtr<Core::EventReceiver>> {
             return UnregisteredWidget::try_create(class_name);
         });
     };

--- a/Userland/DevTools/HackStudio/GMLPreviewWidget.cpp
+++ b/Userland/DevTools/HackStudio/GMLPreviewWidget.cpp
@@ -28,7 +28,7 @@ void GMLPreviewWidget::load_gml(DeprecatedString const& gml)
     }
 
     // FIXME: Parsing errors happen while the user is typing. What should we do about them?
-    (void)load_from_gml(gml, [](DeprecatedString const& name) -> ErrorOr<NonnullRefPtr<Core::EventReceiver>> {
+    (void)load_from_gml(gml, [](StringView name) -> ErrorOr<NonnullRefPtr<Core::EventReceiver>> {
         return GUI::Label::try_create(TRY(String::formatted("{} is not registered as a GML element!", name)));
     });
 

--- a/Userland/DevTools/HackStudio/Git/GitWidget.cpp
+++ b/Userland/DevTools/HackStudio/Git/GitWidget.cpp
@@ -32,7 +32,7 @@ GitWidget::GitWidget()
     auto& refresh_button = unstaged_header.add<GUI::Button>();
     refresh_button.set_icon(Gfx::Bitmap::load_from_file("/res/icons/16x16/reload.png"sv).release_value_but_fixme_should_propagate_errors());
     refresh_button.set_fixed_size(16, 16);
-    refresh_button.set_tooltip("refresh");
+    refresh_button.set_tooltip_deprecated("refresh");
     refresh_button.on_click = [this](int) { refresh(); };
 
     auto& unstaged_label = unstaged_header.add<GUI::Label>();
@@ -60,7 +60,7 @@ GitWidget::GitWidget()
     auto& commit_button = staged_header.add<GUI::Button>();
     commit_button.set_icon(Gfx::Bitmap::load_from_file("/res/icons/16x16/commit.png"sv).release_value_but_fixme_should_propagate_errors());
     commit_button.set_fixed_size(16, 16);
-    commit_button.set_tooltip("commit");
+    commit_button.set_tooltip_deprecated("commit");
     commit_button.on_click = [this](int) { commit(); };
 
     auto& staged_label = staged_header.add<GUI::Label>();

--- a/Userland/DevTools/Profiler/FlameGraphView.cpp
+++ b/Userland/DevTools/Profiler/FlameGraphView.cpp
@@ -93,7 +93,7 @@ void FlameGraphView::mousemove_event(GUI::MouseEvent& event)
     if (m_hovered_bar != nullptr && m_hovered_bar->index.is_valid()) {
         label = bar_label(*m_hovered_bar);
     }
-    set_tooltip(label);
+    set_tooltip_deprecated(label);
     show_or_hide_tooltip();
 
     update();

--- a/Userland/Libraries/LibGUI/Action.cpp
+++ b/Userland/Libraries/LibGUI/Action.cpp
@@ -308,7 +308,7 @@ void Action::set_tooltip(DeprecatedString tooltip)
         return;
     m_tooltip = move(tooltip);
     for_each_toolbar_button([&](auto& button) {
-        button.set_tooltip(*m_tooltip);
+        button.set_tooltip_deprecated(*m_tooltip);
     });
     for_each_menu_item([&](auto& menu_item) {
         menu_item.update_from_action({});

--- a/Userland/Libraries/LibGUI/Breadcrumbbar.cpp
+++ b/Userland/Libraries/LibGUI/Breadcrumbbar.cpp
@@ -76,7 +76,7 @@ void Breadcrumbbar::append_segment(DeprecatedString text, Gfx::Bitmap const* ico
     button.set_button_style(Gfx::ButtonStyle::Coolbar);
     button.set_text(String::from_deprecated_string(text).release_value_but_fixme_should_propagate_errors());
     button.set_icon(icon);
-    button.set_tooltip(move(tooltip));
+    button.set_tooltip_deprecated(move(tooltip));
     button.set_focus_policy(FocusPolicy::TabFocus);
     button.set_checkable(true);
     button.set_exclusive(true);

--- a/Userland/Libraries/LibGUI/EmojiInputDialog.cpp
+++ b/Userland/Libraries/LibGUI/EmojiInputDialog.cpp
@@ -144,7 +144,7 @@ auto EmojiInputDialog::supported_emoji() -> Vector<Emoji>
         };
 
         if (!emoji->name.is_empty())
-            button->set_tooltip(emoji->name);
+            button->set_tooltip_deprecated(emoji->name);
 
         emojis.empend(move(button), emoji.release_value(), move(text));
     }

--- a/Userland/Libraries/LibGUI/LinkLabel.cpp
+++ b/Userland/Libraries/LibGUI/LinkLabel.cpp
@@ -119,9 +119,9 @@ void LinkLabel::did_change_text()
 void LinkLabel::update_tooltip_if_needed()
 {
     if (width() < font().width(text())) {
-        set_tooltip(text().to_deprecated_string());
+        set_tooltip_deprecated(text().to_deprecated_string());
     } else {
-        set_tooltip({});
+        set_tooltip_deprecated({});
     }
 }
 

--- a/Userland/Libraries/LibGUI/Toolbar.cpp
+++ b/Userland/Libraries/LibGUI/Toolbar.cpp
@@ -49,7 +49,7 @@ private:
         if (action.group() && action.group()->is_exclusive())
             set_exclusive(true);
         set_action(action);
-        set_tooltip(tooltip(action));
+        set_tooltip_deprecated(tooltip(action));
         set_focus_policy(FocusPolicy::NoFocus);
         if (action.icon())
             set_icon(action.icon());
@@ -63,7 +63,7 @@ private:
         auto const* action = this->action();
         VERIFY(action);
 
-        set_tooltip(tooltip(*action));
+        set_tooltip_deprecated(tooltip(*action));
         if (!action->icon())
             Button::set_text(move(text));
     }

--- a/Userland/Libraries/LibGUI/Widget.cpp
+++ b/Userland/Libraries/LibGUI/Widget.cpp
@@ -57,7 +57,7 @@ Widget::Widget()
     REGISTER_BOOL_PROPERTY("visible", is_visible, set_visible);
     REGISTER_BOOL_PROPERTY("focused", is_focused, set_focus);
     REGISTER_BOOL_PROPERTY("enabled", is_enabled, set_enabled);
-    REGISTER_DEPRECATED_STRING_PROPERTY("tooltip", tooltip, set_tooltip);
+    REGISTER_DEPRECATED_STRING_PROPERTY("tooltip", tooltip_deprecated, set_tooltip_deprecated);
 
     REGISTER_UI_SIZE_PROPERTY("min_size", min_size, set_min_size);
     REGISTER_READONLY_UI_SIZE_PROPERTY("effective_min_size", effective_min_size);
@@ -1101,7 +1101,7 @@ Gfx::IntRect Widget::relative_non_grabbable_rect() const
     return rect;
 }
 
-void Widget::set_tooltip(DeprecatedString tooltip)
+void Widget::set_tooltip_deprecated(DeprecatedString tooltip)
 {
     m_tooltip = move(tooltip);
     if (Application::the()->tooltip_source_widget() == this)

--- a/Userland/Libraries/LibGUI/Widget.cpp
+++ b/Userland/Libraries/LibGUI/Widget.cpp
@@ -57,7 +57,7 @@ Widget::Widget()
     REGISTER_BOOL_PROPERTY("visible", is_visible, set_visible);
     REGISTER_BOOL_PROPERTY("focused", is_focused, set_focus);
     REGISTER_BOOL_PROPERTY("enabled", is_enabled, set_enabled);
-    REGISTER_DEPRECATED_STRING_PROPERTY("tooltip", tooltip_deprecated, set_tooltip_deprecated);
+    REGISTER_STRING_PROPERTY("tooltip", tooltip, set_tooltip);
 
     REGISTER_UI_SIZE_PROPERTY("min_size", min_size, set_min_size);
     REGISTER_READONLY_UI_SIZE_PROPERTY("effective_min_size", effective_min_size);
@@ -82,7 +82,7 @@ Widget::Widget()
     REGISTER_INT_PROPERTY("x", x, set_x);
     REGISTER_INT_PROPERTY("y", y, set_y);
 
-    REGISTER_DEPRECATED_STRING_PROPERTY("font", m_font->family, set_font_family);
+    REGISTER_STRING_PROPERTY("font", font_family, set_font_family);
     REGISTER_INT_PROPERTY("font_size", m_font->presentation_size, set_font_size);
     REGISTER_FONT_WEIGHT_PROPERTY("font_weight", m_font->weight, set_font_weight);
 
@@ -818,9 +818,9 @@ void Widget::set_font(Gfx::Font const* font)
     update();
 }
 
-void Widget::set_font_family(DeprecatedString const& family)
+void Widget::set_font_family(String const& family)
 {
-    set_font(Gfx::FontDatabase::the().get(family, m_font->presentation_size(), m_font->weight(), m_font->width(), m_font->slope()));
+    set_font(Gfx::FontDatabase::the().get(family.to_deprecated_string(), m_font->presentation_size(), m_font->weight(), m_font->width(), m_font->slope()));
 }
 
 void Widget::set_font_size(unsigned size)
@@ -1103,6 +1103,11 @@ Gfx::IntRect Widget::relative_non_grabbable_rect() const
 
 void Widget::set_tooltip_deprecated(DeprecatedString tooltip)
 {
+    set_tooltip(String::from_deprecated_string(move(tooltip)).release_value_but_fixme_should_propagate_errors());
+}
+
+void Widget::set_tooltip(String tooltip)
+{
     m_tooltip = move(tooltip);
     if (Application::the()->tooltip_source_widget() == this)
         show_or_hide_tooltip();
@@ -1111,7 +1116,7 @@ void Widget::set_tooltip_deprecated(DeprecatedString tooltip)
 void Widget::show_or_hide_tooltip()
 {
     if (has_tooltip())
-        Application::the()->show_tooltip(m_tooltip, this);
+        Application::the()->show_tooltip(m_tooltip.to_deprecated_string(), this);
     else
         Application::the()->hide_tooltip();
 }
@@ -1134,7 +1139,7 @@ void Widget::set_override_cursor(AK::Variant<Gfx::StandardCursor, NonnullRefPtr<
 
 ErrorOr<void> Widget::load_from_gml(StringView gml_string)
 {
-    return load_from_gml(gml_string, [](DeprecatedString const& class_name) -> ErrorOr<NonnullRefPtr<Core::EventReceiver>> {
+    return load_from_gml(gml_string, [](StringView class_name) -> ErrorOr<NonnullRefPtr<Core::EventReceiver>> {
         dbgln("Class '{}' not registered", class_name);
         return Error::from_string_literal("Class not registered");
     });
@@ -1257,6 +1262,11 @@ ErrorOr<void> Widget::add_spacer()
 {
     VERIFY(layout());
     return layout()->try_add_spacer();
+}
+
+String Widget::font_family() const
+{
+    return String::from_deprecated_string(m_font->family()).release_value_but_fixme_should_propagate_errors();
 }
 
 }

--- a/Userland/Libraries/LibGUI/Widget.h
+++ b/Userland/Libraries/LibGUI/Widget.h
@@ -169,7 +169,9 @@ public:
     virtual bool is_visible_for_timer_purposes() const override;
 
     bool has_tooltip() const { return !m_tooltip.is_empty(); }
-    DeprecatedString tooltip_deprecated() const { return m_tooltip; }
+    String tooltip() const { return m_tooltip; }
+    void set_tooltip(String tooltip);
+    DeprecatedString tooltip_deprecated() const { return tooltip().to_deprecated_string(); }
     void set_tooltip_deprecated(DeprecatedString);
 
     bool is_auto_focusable() const { return m_auto_focusable; }
@@ -291,7 +293,7 @@ public:
     void set_font(Gfx::Font const*);
     void set_font(Gfx::Font const& font) { set_font(&font); }
 
-    void set_font_family(DeprecatedString const&);
+    void set_font_family(String const&);
     void set_font_size(unsigned);
     void set_font_weight(unsigned);
     void set_font_fixed_width(bool);
@@ -350,7 +352,7 @@ public:
     AK::Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap const>> const& override_cursor() const { return m_override_cursor; }
     void set_override_cursor(AK::Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap const>>);
 
-    using UnregisteredChildHandler = ErrorOr<NonnullRefPtr<Core::EventReceiver>>(DeprecatedString const&);
+    using UnregisteredChildHandler = ErrorOr<NonnullRefPtr<Core::EventReceiver>>(StringView);
     ErrorOr<void> load_from_gml(StringView);
     ErrorOr<void> load_from_gml(StringView, UnregisteredChildHandler);
 
@@ -428,6 +430,9 @@ private:
     int dummy_fixed_height() { return 0; }
     Gfx::IntSize dummy_fixed_size() { return {}; }
 
+    // HACK: Used as property getter for the font_family property, can be removed when Font is migrated from DeprecatedString.
+    String font_family() const;
+
     Window* m_window { nullptr };
     RefPtr<Layout> m_layout;
 
@@ -435,7 +440,7 @@ private:
     Gfx::ColorRole m_background_role;
     Gfx::ColorRole m_foreground_role;
     NonnullRefPtr<Gfx::Font const> m_font;
-    DeprecatedString m_tooltip;
+    String m_tooltip;
 
     UISize m_min_size { SpecialDimension::Shrink };
     UISize m_max_size { SpecialDimension::Grow };

--- a/Userland/Libraries/LibGUI/Widget.h
+++ b/Userland/Libraries/LibGUI/Widget.h
@@ -169,8 +169,8 @@ public:
     virtual bool is_visible_for_timer_purposes() const override;
 
     bool has_tooltip() const { return !m_tooltip.is_empty(); }
-    DeprecatedString tooltip() const { return m_tooltip; }
-    void set_tooltip(DeprecatedString);
+    DeprecatedString tooltip_deprecated() const { return m_tooltip; }
+    void set_tooltip_deprecated(DeprecatedString);
 
     bool is_auto_focusable() const { return m_auto_focusable; }
     void set_auto_focusable(bool auto_focusable) { m_auto_focusable = auto_focusable; }

--- a/Userland/Libraries/LibVT/TerminalWidget.cpp
+++ b/Userland/Libraries/LibVT/TerminalWidget.cpp
@@ -878,18 +878,18 @@ void TerminalWidget::mousemove_event(GUI::MouseEvent& event)
                     auto file_name = LexicalPath::basename(path);
 
                     if (path == handlers[0]) {
-                        set_tooltip(DeprecatedString::formatted("Execute {}", app_name));
+                        set_tooltip_deprecated(DeprecatedString::formatted("Execute {}", app_name));
                     } else {
-                        set_tooltip(DeprecatedString::formatted("Open {} with {}", file_name, app_name));
+                        set_tooltip_deprecated(DeprecatedString::formatted("Open {} with {}", file_name, app_name));
                     }
                 } else {
-                    set_tooltip(DeprecatedString::formatted("Open {} with {}", attribute.href, app_name));
+                    set_tooltip_deprecated(DeprecatedString::formatted("Open {} with {}", attribute.href, app_name));
                 }
             }
         } else {
             m_hovered_href_id = {};
             m_hovered_href = {};
-            set_tooltip({});
+            set_tooltip_deprecated({});
         }
         show_or_hide_tooltip();
         if (!m_hovered_href.is_empty())
@@ -957,7 +957,7 @@ void TerminalWidget::leave_event(Core::Event&)
     bool should_update = !m_hovered_href.is_empty();
     m_hovered_href = {};
     m_hovered_href_id = {};
-    set_tooltip(m_hovered_href);
+    set_tooltip_deprecated(m_hovered_href);
     set_override_cursor(Gfx::StandardCursor::IBeam);
     if (should_update)
         update();

--- a/Userland/Services/Taskbar/ClockWidget.cpp
+++ b/Userland/Services/Taskbar/ClockWidget.cpp
@@ -30,7 +30,7 @@ ClockWidget::ClockWidget()
         if (now != last_update_time) {
             tick_clock();
             last_update_time = now;
-            set_tooltip(Core::DateTime::now().to_deprecated_string("%Y-%m-%d"sv));
+            set_tooltip_deprecated(Core::DateTime::now().to_deprecated_string("%Y-%m-%d"sv));
         }
     });
     m_timer->start();
@@ -107,7 +107,7 @@ ClockWidget::ClockWidget()
     m_jump_to_button->set_button_style(Gfx::ButtonStyle::Coolbar);
     m_jump_to_button->set_fixed_size(24, 24);
     m_jump_to_button->set_icon(Gfx::Bitmap::load_from_file("/res/icons/16x16/calendar-date.png"sv).release_value_but_fixme_should_propagate_errors());
-    m_jump_to_button->set_tooltip("Jump to today");
+    m_jump_to_button->set_tooltip_deprecated("Jump to today");
     m_jump_to_button->on_click = [this](auto) {
         jump_to_current_date();
     };
@@ -116,7 +116,7 @@ ClockWidget::ClockWidget()
     m_calendar_launcher->set_button_style(Gfx::ButtonStyle::Coolbar);
     m_calendar_launcher->set_fixed_size(24, 24);
     m_calendar_launcher->set_icon(Gfx::Bitmap::load_from_file("/res/icons/16x16/app-calendar.png"sv).release_value_but_fixme_should_propagate_errors());
-    m_calendar_launcher->set_tooltip("Calendar");
+    m_calendar_launcher->set_tooltip_deprecated("Calendar");
     m_calendar_launcher->on_click = [this](auto) {
         GUI::Process::spawn_or_show_error(window(), "/bin/Calendar"sv);
     };

--- a/Userland/Services/Taskbar/QuickLaunchWidget.cpp
+++ b/Userland/Services/Taskbar/QuickLaunchWidget.cpp
@@ -191,7 +191,7 @@ ErrorOr<void> QuickLaunchWidget::add_or_adjust_button(DeprecatedString const& bu
     button->set_button_style(Gfx::ButtonStyle::Coolbar);
     auto icon = entry->icon();
     button->set_icon(icon.bitmap_for_size(16));
-    button->set_tooltip(entry->name());
+    button->set_tooltip_deprecated(entry->name());
     button->set_name(button_name);
     button->on_click = [entry = move(entry), this](auto) {
         auto result = entry->launch();

--- a/Userland/Services/Taskbar/TaskbarWindow.cpp
+++ b/Userland/Services/Taskbar/TaskbarWindow.cpp
@@ -89,7 +89,7 @@ ErrorOr<void> TaskbarWindow::populate_taskbar()
     m_clock_widget = TRY(main_widget->try_add<Taskbar::ClockWidget>());
 
     m_show_desktop_button = TRY(main_widget->try_add<GUI::Button>());
-    m_show_desktop_button->set_tooltip("Show Desktop");
+    m_show_desktop_button->set_tooltip_deprecated("Show Desktop");
     m_show_desktop_button->set_icon(TRY(GUI::Icon::try_create_default_icon("desktop"sv)).bitmap_for_size(16));
     m_show_desktop_button->set_button_style(Gfx::ButtonStyle::Coolbar);
     m_show_desktop_button->set_fixed_size(24, 24);
@@ -199,7 +199,7 @@ void TaskbarWindow::update_window_button(::Window& window, bool show_as_active)
     if (!button)
         return;
     button->set_text(String::from_deprecated_string(window.title()).release_value_but_fixme_should_propagate_errors());
-    button->set_tooltip(window.title());
+    button->set_tooltip_deprecated(window.title());
     button->set_checked(show_as_active);
     button->set_visible(is_window_on_current_workspace(window));
 }


### PR DESCRIPTION
This PR adds a `_deprecated` suffix to the `{set_,}tooltip` methods and calls which use `DeprecatedString` and replaces the other uses of `DeprecatedString` within `Widget`.

Changes:
- LibGUI: `DeprecatedString` usage replaced with `String` or `StringView`
- Userland: All calls to `set_tooltip` renamed to `set_tooltip_deprecated`

Contributes to: #17128 