### PR TITLE
LibWeb: Don't lay out light DOM children of elements with a shadow root 

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -288,11 +288,11 @@ ErrorOr<void> TreeBuilder::create_layout_tree(DOM::Node& dom_node, TreeBuilder::
             for (auto* node = shadow_root->first_child(); node; node = node->next_sibling()) {
                 TRY(create_layout_tree(*node, context));
             }
+        } else {
+            // This is the same as verify_cast<DOM::ParentNode>(dom_node).for_each_child
+            for (auto* node = verify_cast<DOM::ParentNode>(dom_node).first_child(); node; node = node->next_sibling())
+                TRY(create_layout_tree(*node, context));
         }
-
-        // This is the same as verify_cast<DOM::ParentNode>(dom_node).for_each_child
-        for (auto* node = verify_cast<DOM::ParentNode>(dom_node).first_child(); node; node = node->next_sibling())
-            TRY(create_layout_tree(*node, context));
         pop_parent();
     }
 


### PR DESCRIPTION
This fixes the "last changed" time for files on GitHub. Note that this appears to be in accordance with the shadow DOM specification, but I can't find a line that neatly says it. Though on Google's post about shadow DOM v1 it says:

> "the element's shadow DOM is rendered in place of its children."
https://web.dev/shadowdom-v1/#creating-shadow-dom-for-a-custom-element

Progression on GitHub:

**Before:**
![Screenshot from 2023-08-01 22-41-34](https://github.com/SerenityOS/serenity/assets/11597044/810d85ad-511f-4ee6-9573-31d82ac0ac6c)

**After:**
![Screenshot from 2023-08-01 22-52-47](https://github.com/SerenityOS/serenity/assets/11597044/9e492d32-a871-4bbb-91ff-2a102e66bf9d)
