### PR TITLE
LibWeb: Implement an ephemeral `URL.createObjectURL`

### DIFF
--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -206,6 +206,7 @@ set(SOURCES
     Fetch/Request.cpp
     Fetch/Response.cpp
     FileAPI/Blob.cpp
+    FileAPI/BlobURLStore.cpp
     FileAPI/File.cpp
     FileAPI/FileList.cpp
     FontCache.cpp

--- a/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
@@ -31,6 +31,8 @@
 #include <LibWeb/Fetch/Infrastructure/PortBlocking.h>
 #include <LibWeb/Fetch/Infrastructure/Task.h>
 #include <LibWeb/Fetch/Infrastructure/URL.h>
+#include <LibWeb/FileAPI/Blob.h>
+#include <LibWeb/FileAPI/BlobURLStore.h>
 #include <LibWeb/HTML/EventLoop/EventLoop.h>
 #include <LibWeb/HTML/Scripting/Environments.h>
 #include <LibWeb/HTML/Window.h>
@@ -708,8 +710,83 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<PendingResponse>> scheme_fetch(JS::Realm& r
     }
     // -> "blob"
     else if (request->current_url().scheme() == "blob"sv) {
-        // FIXME: Support 'blob://' URLs
-        return PendingResponse::create(vm, request, Infrastructure::Response::network_error(vm, "Request has 'blob:' URL which is currently unsupported"sv));
+        auto const& store = FileAPI::blob_url_store();
+
+        // 1. Let blobURLEntry be request’s current URL’s blob URL entry.
+        auto blob_url_entry = store.get(TRY_OR_THROW_OOM(vm, request->current_url().to_string()));
+
+        // 2. If request’s method is not `GET`, blobURLEntry is null, or blobURLEntry’s object is not a Blob object,
+        //    then return a network error. [FILEAPI]
+        if (request->method() != "GET"sv.bytes() || !blob_url_entry.has_value()) {
+            // FIXME: Handle "blobURLEntry’s object is not a Blob object". It could be a MediaSource object, but we
+            //        have not yet implemented the Media Source Extensions spec.
+            return PendingResponse::create(vm, request, Infrastructure::Response::network_error(vm, "Request has an invalid 'blob:' URL"sv));
+        }
+
+        // 3. Let blob be blobURLEntry’s object.
+        auto const& blob = blob_url_entry->object;
+
+        // 4. Let response be a new response.
+        auto response = Infrastructure::Response::create(vm);
+
+        // 5. Let fullLength be blob’s size.
+        auto full_length = blob->size();
+
+        // 6. Let serializedFullLength be fullLength, serialized and isomorphic encoded.
+        auto serialized_full_length = TRY_OR_THROW_OOM(vm, String::number(full_length));
+
+        // 7. Let type be blob’s type.
+        auto const& type = blob->type();
+
+        // 8. If request’s header list does not contain `Range`:
+        if (!request->header_list()->contains("Range"sv.bytes())) {
+            // 1. Let bodyWithType be the result of safely extracting blob.
+            auto body_with_type = TRY(safely_extract_body(realm, blob));
+
+            // 2. Set response’s status message to `OK`.
+            response->set_status_message(MUST(ByteBuffer::copy("OK"sv.bytes())));
+
+            // 3. Set response’s body to bodyWithType’s body.
+            response->set_body(move(body_with_type.body));
+
+            // 4. Set response’s header list to « (`Content-Length`, serializedFullLength), (`Content-Type`, type) ».
+            auto content_length_header = TRY_OR_THROW_OOM(vm, Infrastructure::Header::from_string_pair("Content-Length"sv, serialized_full_length));
+            TRY_OR_THROW_OOM(vm, response->header_list()->append(move(content_length_header)));
+
+            auto content_type_header = TRY_OR_THROW_OOM(vm, Infrastructure::Header::from_string_pair("Content-Type"sv, type));
+            TRY_OR_THROW_OOM(vm, response->header_list()->append(move(content_type_header)));
+        }
+        // FIXME: 9. Otherwise:
+        else {
+            // 1. Set response’s range-requested flag.
+            // 2. Let rangeHeader be the result of getting `Range` from request’s header list.
+            // 3. Let rangeValue be the result of parsing a single range header value given rangeHeader and true.
+            // 4. If rangeValue is failure, then return a network error.
+            // 5. Let (rangeStart, rangeEnd) be rangeValue.
+            // 6. If rangeStart is null:
+            //     1. Set rangeStart to fullLength − rangeEnd.
+            //     2. Set rangeEnd to rangeStart + rangeEnd − 1.
+            // 7. Otherwise:
+            //     1. If rangeStart is greater than or equal to fullLength, then return a network error.
+            //     2. If rangeEnd is null or rangeEnd is greater than or equal to fullLength, then set rangeEnd to fullLength − 1.
+            // 8. Let slicedBlob be the result of invoking slice blob given blob, rangeStart, rangeEnd + 1, and type.
+            // 9. Let slicedBodyWithType be the result of safely extracting slicedBlob.
+            // 10. Set response’s body to slicedBodyWithType’s body.
+            // 11. Let serializedSlicedLength be slicedBlob’s size, serialized and isomorphic encoded.
+            // 12. Let contentRange be `bytes `.
+            // 13. Append rangeStart, serialized and isomorphic encoded, to contentRange.
+            // 14. Append 0x2D (-) to contentRange.
+            // 15. Append rangeEnd, serialized and isomorphic encoded to contentRange.
+            // 16. Append 0x2F (/) to contentRange.
+            // 17. Append serializedFullLength to contentRange.
+            // 18. Set response’s status to 206.
+            // 19. Set response’s status message to `Partial Content`.
+            // 20. Set response’s header list to « (`Content-Length`, serializedSlicedLength), (`Content-Type`, type), (`Content-Range`, contentRange) ».
+            return PendingResponse::create(vm, request, Infrastructure::Response::network_error(vm, "Request has a 'blob:' URL with a Content-Range header, which is currently unsupported"sv));
+        }
+
+        // 10. Return response.
+        return PendingResponse::create(vm, request, response);
     }
     // -> "data"
     else if (request->current_url().scheme() == "data"sv) {

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Bodies.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Bodies.cpp
@@ -69,6 +69,9 @@ WebIDL::ExceptionOr<void> Body::fully_read(JS::Realm& realm, Web::Fetch::Infrast
     // FIXME: Implement the streams spec - this is completely made up for now :^)
     if (auto const* byte_buffer = m_source.get_pointer<ByteBuffer>()) {
         TRY_OR_THROW_OOM(vm, success_steps(*byte_buffer));
+    } else if (auto const* blob_handle = m_source.get_pointer<JS::Handle<FileAPI::Blob>>()) {
+        auto byte_buffer = TRY_OR_THROW_OOM(vm, ByteBuffer::copy((*blob_handle)->bytes()));
+        TRY_OR_THROW_OOM(vm, success_steps(move(byte_buffer)));
     } else {
         // Empty, Blob, FormData
         error_steps(WebIDL::DOMException::create(realm, "DOMException", "Reading from Blob, FormData or null source is not yet implemented"sv));

--- a/Userland/Libraries/LibWeb/FileAPI/BlobURLStore.cpp
+++ b/Userland/Libraries/LibWeb/FileAPI/BlobURLStore.cpp
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2023, Tim Flynn <trflynn89@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/StringBuilder.h>
+#include <AK/URL.h>
+#include <LibWeb/Crypto/Crypto.h>
+#include <LibWeb/FileAPI/Blob.h>
+#include <LibWeb/FileAPI/BlobURLStore.h>
+#include <LibWeb/HTML/Origin.h>
+#include <LibWeb/HTML/Scripting/Environments.h>
+
+namespace Web::FileAPI {
+
+BlobURLStore& blob_url_store()
+{
+    static HashMap<String, BlobURLEntry> store;
+    return store;
+}
+
+// https://w3c.github.io/FileAPI/#unicodeBlobURL
+ErrorOr<String> generate_new_blob_url()
+{
+    // 1. Let result be the empty string.
+    StringBuilder result;
+
+    // 2. Append the string "blob:" to result.
+    TRY(result.try_append("blob:"sv));
+
+    // 3. Let settings be the current settings object
+    auto& settings = HTML::current_settings_object();
+
+    // 4. Let origin be settings’s origin.
+    auto origin = settings.origin();
+
+    // 5. Let serialized be the ASCII serialization of origin.
+    auto serialized = origin.serialize();
+
+    // 6. If serialized is "null", set it to an implementation-defined value.
+    if (serialized == "null"sv)
+        serialized = "ladybird"sv;
+
+    // 7. Append serialized to result.
+    TRY(result.try_append(serialized));
+
+    // 8. Append U+0024 SOLIDUS (/) to result.
+    TRY(result.try_append('/'));
+
+    // 9. Generate a UUID [RFC4122] as a string and append it to result.
+    auto uuid = TRY(Crypto::generate_random_uuid());
+    TRY(result.try_append(uuid));
+
+    // 10. Return result.
+    return result.to_string();
+}
+
+// https://w3c.github.io/FileAPI/#add-an-entry
+ErrorOr<String> add_entry_to_blob_url_store(JS::NonnullGCPtr<Blob> object)
+{
+    // 1. Let store be the user agent’s blob URL store.
+    auto& store = blob_url_store();
+
+    // 2. Let url be the result of generating a new blob URL.
+    auto url = TRY(generate_new_blob_url());
+
+    // 3. Let entry be a new blob URL entry consisting of object and the current settings object.
+    BlobURLEntry entry { object, HTML::current_settings_object() };
+
+    // 4. Set store[url] to entry.
+    TRY(store.try_set(url, move(entry)));
+
+    // 5. Return url.
+    return url;
+}
+
+// https://w3c.github.io/FileAPI/#removeTheEntry
+ErrorOr<void> remove_entry_from_blob_url_store(StringView url)
+{
+    // 1. Let store be the user agent’s blob URL store;
+    auto& store = blob_url_store();
+
+    // 2. Let url string be the result of serializing url.
+    auto url_string = TRY(AK::URL { url }.to_string());
+
+    // 3. Remove store[url string].
+    store.remove(url_string);
+    return {};
+}
+
+}

--- a/Userland/Libraries/LibWeb/FileAPI/BlobURLStore.h
+++ b/Userland/Libraries/LibWeb/FileAPI/BlobURLStore.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2023, Tim Flynn <trflynn89@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/HashMap.h>
+#include <AK/String.h>
+#include <LibJS/Heap/GCPtr.h>
+#include <LibJS/Heap/Handle.h>
+#include <LibWeb/Forward.h>
+
+namespace Web::FileAPI {
+
+// https://w3c.github.io/FileAPI/#blob-url-entry
+struct BlobURLEntry {
+    JS::Handle<Blob> object; // FIXME: This could also be a MediaSource after we implement MSE.
+    JS::Handle<HTML::EnvironmentSettingsObject> environment;
+};
+
+// https://w3c.github.io/FileAPI/#BlobURLStore
+using BlobURLStore = HashMap<String, BlobURLEntry>;
+
+BlobURLStore& blob_url_store();
+ErrorOr<String> generate_new_blob_url();
+ErrorOr<String> add_entry_to_blob_url_store(JS::NonnullGCPtr<Blob> object);
+ErrorOr<void> remove_entry_from_blob_url_store(StringView url);
+
+}

--- a/Userland/Libraries/LibWeb/URL/URL.h
+++ b/Userland/Libraries/LibWeb/URL/URL.h
@@ -24,6 +24,9 @@ public:
 
     virtual ~URL() override;
 
+    static WebIDL::ExceptionOr<String> create_object_url(JS::VM&, JS::NonnullGCPtr<FileAPI::Blob> object);
+    static WebIDL::ExceptionOr<void> revoke_object_url(JS::VM&, StringView url);
+
     static bool can_parse(JS::VM&, String const& url, Optional<String> const& base = {});
 
     WebIDL::ExceptionOr<String> href() const;

--- a/Userland/Libraries/LibWeb/URL/URL.idl
+++ b/Userland/Libraries/LibWeb/URL/URL.idl
@@ -1,3 +1,4 @@
+#import <FileAPI/Blob.idl>
 #import <URL/URLSearchParams.idl>
 
 // https://url.spec.whatwg.org/#url
@@ -21,4 +22,7 @@ interface URL {
     attribute USVString hash;
 
     USVString toJSON();
+
+    static DOMString createObjectURL(Blob obj); // FIXME: Should be (Blob or MediaSource).
+    static undefined revokeObjectURL(DOMString url);
 };


### PR DESCRIPTION
Tested with the following HTML running on a local server:
```html
<html>
<body>
<script type="text/javascript">
    async function test() {
        const response = await fetch('./90s-bg.png');
        const data = await response.blob();
        return URL.createObjectURL(data);
    }

    test().then(url => {
        let image = new Image(240, 240)
        image.src = url;
        image.onload = () => {
            URL.revokeObjectURL(image.src);
        };

        document.body.appendChild(image);
    });
</script>
</body>
</html>
```

This test isn't added in-tree because CORS prevents the `fetch` invocation from working on `file://` URLs.