### PR TITLE
LibWeb: Reformat inconsistent CSS JSON files

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Enums.json
+++ b/Userland/Libraries/LibWeb/CSS/Enums.json
@@ -1,350 +1,350 @@
 {
-    "align-content": [
-        "flex-start",
-        "flex-end",
-        "center",
-        "space-between",
-        "space-around",
-        "space-evenly",
-        "stretch"
-    ],
-    "align-items": [
-        "baseline",
-        "center",
-        "end",
-        "flex-end",
-        "flex-start",
-        "normal",
-        "safe",
-        "self-end",
-        "self-start",
-        "start",
-        "stretch",
-        "unsafe"
-    ],
-    "align-self": [
-        "auto",
-        "baseline",
-        "center",
-        "end",
-        "flex-end",
-        "flex-start",
-        "normal",
-        "safe",
-        "self-end",
-        "self-start",
-        "start",
-        "stretch",
-        "unsafe"
-    ],
-    "animation-fill-mode": [
-        "backwards",
-        "both",
-        "forwards",
-        "none"
-    ],
-    "animation-direction": [
-        "alternate",
-        "alternate-reverse",
-        "normal",
-        "reverse"
-    ],
-    "appearance": [
-        "auto",
-        "button",
-        "checkbox",
-        "listbox",
-        "menulist",
-        "meter",
-        "menulist-button",
-        "none",
-        "push-button",
-        "progress-bar",
-        "radio",
-        "searchfield",
-        "slider-horizontal",
-        "square-button",
-        "textarea",
-        "textfield"
-    ],
-    "background-attachment": [
-        "fixed",
-        "local",
-        "scroll"
-    ],
-    "background-box": [
-        "border-box",
-        "content-box",
-        "padding-box"
-    ],
-    "border-collapse": [
-      "separate",
-      "collapse"
-    ],
-    "box-sizing": [
-        "border-box",
-        "content-box"
-    ],
-    "caption-side": [
-        "top",
-        "bottom"
-    ],
-    "clear": [
-        "none",
-        "left",
-        "right",
-        "both"
-    ],
-    "cursor": [
-        "auto",
-        "default",
-        "none",
-        "context-menu",
-        "help",
-        "pointer",
-        "progress",
-        "wait",
-        "cell",
-        "crosshair",
-        "text",
-        "vertical-text",
-        "alias",
-        "copy",
-        "move",
-        "no-drop",
-        "not-allowed",
-        "grab",
-        "grabbing",
-        "e-resize",
-        "n-resize",
-        "ne-resize",
-        "nw-resize",
-        "s-resize",
-        "se-resize",
-        "sw-resize",
-        "w-resize",
-        "ew-resize",
-        "ns-resize",
-        "nesw-resize",
-        "nwse-resize",
-        "col-resize",
-        "row-resize",
-        "all-scroll",
-        "zoom-in",
-        "zoom-out"
-    ],
-    "fill-rule": [
-        "nonzero",
-        "evenodd"
-    ],
-    "flex-direction": [
-        "row",
-        "row-reverse",
-        "column",
-        "column-reverse"
-    ],
-    "flex-wrap": [
-        "nowrap",
-        "wrap",
-        "wrap-reverse"
-    ],
-    "float": [
-        "none",
-        "left",
-        "right"
-    ],
-    "font-variant": [
-        "normal",
-        "small-caps"
-    ],
-    "image-rendering": [
-        "auto",
-        "crisp-edges",
-        "high-quality",
-        "pixelated",
-        "smooth",
-        "optimizespeed=pixelated",
-        "optimizequality=smooth"
-    ],
-    "justify-content": [
-        "start",
-        "end",
-        "flex-start",
-        "flex-end",
-        "center",
-        "space-between",
-        "space-around",
-        "space-evenly"
-    ],
-    "justify-items": [
-        "baseline",
-        "center",
-        "end",
-        "flex-end",
-        "flex-start",
-        "legacy",
-        "normal",
-        "safe",
-        "self-end",
-        "self-start",
-        "start",
-        "stretch",
-        "unsafe"
-    ],
-    "justify-self": [
-        "auto",
-        "baseline",
-        "center",
-        "end",
-        "flex-end",
-        "flex-start",
-        "normal",
-        "safe",
-        "self-end",
-        "self-start",
-        "start",
-        "stretch",
-        "unsafe"
-    ],
-    "line-style": [
-        "none",
-        "hidden",
-        "dotted",
-        "dashed",
-        "solid",
-        "double",
-        "groove",
-        "ridge",
-        "inset",
-        "outset"
-    ],
-    "list-style-type": [
-        "circle",
-        "decimal",
-        "decimal-leading-zero",
-        "disc",
-        "disclosure-closed",
-        "disclosure-open",
-        "lower-alpha",
-        "lower-latin",
-        "lower-roman",
-        "none",
-        "square",
-        "upper-alpha",
-        "upper-latin",
-        "upper-roman"
-    ],
-    "list-style-position": [
-        "inside",
-        "outside"
-    ],
-    "object-fit": [
-      "fill",
-      "contain",
-      "cover",
-      "none",
-      "scale-down"
-    ],
-    "overflow": [
-        "auto",
-        "clip",
-        "hidden",
-        "scroll",
-        "visible"
-    ],
-    "pointer-events": [
-        "auto",
-        "all",
-        "none"
-    ],
-    "position": [
-        "absolute",
-        "fixed",
-        "relative",
-        "static",
-        "sticky"
-    ],
-    "position-edge": [
-        "left",
-        "right",
-        "top",
-        "bottom"
-    ],
-    "repeat": [
-        "no-repeat",
-        "repeat",
-        "round",
-        "space"
-    ],
-    "rounding-strategy": [
-        "down",
-        "nearest",
-        "to-zero",
-        "up"
-    ],
-    "text-anchor": [
-        "start",
-        "middle",
-        "end"
-    ],
-    "text-align": [
-        "center",
-        "justify",
-        "left",
-        "right",
-        "-libweb-center",
-        "-libweb-left",
-        "-libweb-right"
-    ],
-    "text-decoration-line": [
-        "blink",
-        "line-through",
-        "none",
-        "overline",
-        "underline"
-    ],
-    "text-decoration-style": [
-        "dashed",
-        "dotted",
-        "double",
-        "solid",
-        "wavy"
-    ],
-    "text-justify": [
-        "auto",
-        "none",
-        "inter-word",
-        "inter-character",
-        "distribute=inter-character"
-    ],
-    "text-transform": [
-        "capitalize",
-        "full-size-kana",
-        "full-width",
-        "lowercase",
-        "none",
-        "uppercase"
-    ],
-    "vertical-align": [
-        "baseline",
-        "bottom",
-        "middle",
-        "sub",
-        "super",
-        "text-bottom",
-        "text-top",
-        "top"
-    ],
-    "visibility": [
-        "collapse",
-        "hidden",
-        "visible"
-    ],
-    "white-space": [
-        "normal",
-        "nowrap",
-        "pre",
-        "pre-line",
-        "pre-wrap"
-    ]
+  "align-content": [
+    "flex-start",
+    "flex-end",
+    "center",
+    "space-between",
+    "space-around",
+    "space-evenly",
+    "stretch"
+  ],
+  "align-items": [
+    "baseline",
+    "center",
+    "end",
+    "flex-end",
+    "flex-start",
+    "normal",
+    "safe",
+    "self-end",
+    "self-start",
+    "start",
+    "stretch",
+    "unsafe"
+  ],
+  "align-self": [
+    "auto",
+    "baseline",
+    "center",
+    "end",
+    "flex-end",
+    "flex-start",
+    "normal",
+    "safe",
+    "self-end",
+    "self-start",
+    "start",
+    "stretch",
+    "unsafe"
+  ],
+  "animation-fill-mode": [
+    "backwards",
+    "both",
+    "forwards",
+    "none"
+  ],
+  "animation-direction": [
+    "alternate",
+    "alternate-reverse",
+    "normal",
+    "reverse"
+  ],
+  "appearance": [
+    "auto",
+    "button",
+    "checkbox",
+    "listbox",
+    "menulist",
+    "meter",
+    "menulist-button",
+    "none",
+    "push-button",
+    "progress-bar",
+    "radio",
+    "searchfield",
+    "slider-horizontal",
+    "square-button",
+    "textarea",
+    "textfield"
+  ],
+  "background-attachment": [
+    "fixed",
+    "local",
+    "scroll"
+  ],
+  "background-box": [
+    "border-box",
+    "content-box",
+    "padding-box"
+  ],
+  "border-collapse": [
+    "separate",
+    "collapse"
+  ],
+  "box-sizing": [
+    "border-box",
+    "content-box"
+  ],
+  "caption-side": [
+    "top",
+    "bottom"
+  ],
+  "clear": [
+    "none",
+    "left",
+    "right",
+    "both"
+  ],
+  "cursor": [
+    "auto",
+    "default",
+    "none",
+    "context-menu",
+    "help",
+    "pointer",
+    "progress",
+    "wait",
+    "cell",
+    "crosshair",
+    "text",
+    "vertical-text",
+    "alias",
+    "copy",
+    "move",
+    "no-drop",
+    "not-allowed",
+    "grab",
+    "grabbing",
+    "e-resize",
+    "n-resize",
+    "ne-resize",
+    "nw-resize",
+    "s-resize",
+    "se-resize",
+    "sw-resize",
+    "w-resize",
+    "ew-resize",
+    "ns-resize",
+    "nesw-resize",
+    "nwse-resize",
+    "col-resize",
+    "row-resize",
+    "all-scroll",
+    "zoom-in",
+    "zoom-out"
+  ],
+  "fill-rule": [
+    "nonzero",
+    "evenodd"
+  ],
+  "flex-direction": [
+    "row",
+    "row-reverse",
+    "column",
+    "column-reverse"
+  ],
+  "flex-wrap": [
+    "nowrap",
+    "wrap",
+    "wrap-reverse"
+  ],
+  "float": [
+    "none",
+    "left",
+    "right"
+  ],
+  "font-variant": [
+    "normal",
+    "small-caps"
+  ],
+  "image-rendering": [
+    "auto",
+    "crisp-edges",
+    "high-quality",
+    "pixelated",
+    "smooth",
+    "optimizespeed=pixelated",
+    "optimizequality=smooth"
+  ],
+  "justify-content": [
+    "start",
+    "end",
+    "flex-start",
+    "flex-end",
+    "center",
+    "space-between",
+    "space-around",
+    "space-evenly"
+  ],
+  "justify-items": [
+    "baseline",
+    "center",
+    "end",
+    "flex-end",
+    "flex-start",
+    "legacy",
+    "normal",
+    "safe",
+    "self-end",
+    "self-start",
+    "start",
+    "stretch",
+    "unsafe"
+  ],
+  "justify-self": [
+    "auto",
+    "baseline",
+    "center",
+    "end",
+    "flex-end",
+    "flex-start",
+    "normal",
+    "safe",
+    "self-end",
+    "self-start",
+    "start",
+    "stretch",
+    "unsafe"
+  ],
+  "line-style": [
+    "none",
+    "hidden",
+    "dotted",
+    "dashed",
+    "solid",
+    "double",
+    "groove",
+    "ridge",
+    "inset",
+    "outset"
+  ],
+  "list-style-type": [
+    "circle",
+    "decimal",
+    "decimal-leading-zero",
+    "disc",
+    "disclosure-closed",
+    "disclosure-open",
+    "lower-alpha",
+    "lower-latin",
+    "lower-roman",
+    "none",
+    "square",
+    "upper-alpha",
+    "upper-latin",
+    "upper-roman"
+  ],
+  "list-style-position": [
+    "inside",
+    "outside"
+  ],
+  "object-fit": [
+    "fill",
+    "contain",
+    "cover",
+    "none",
+    "scale-down"
+  ],
+  "overflow": [
+    "auto",
+    "clip",
+    "hidden",
+    "scroll",
+    "visible"
+  ],
+  "pointer-events": [
+    "auto",
+    "all",
+    "none"
+  ],
+  "position": [
+    "absolute",
+    "fixed",
+    "relative",
+    "static",
+    "sticky"
+  ],
+  "position-edge": [
+    "left",
+    "right",
+    "top",
+    "bottom"
+  ],
+  "repeat": [
+    "no-repeat",
+    "repeat",
+    "round",
+    "space"
+  ],
+  "rounding-strategy": [
+    "down",
+    "nearest",
+    "to-zero",
+    "up"
+  ],
+  "text-anchor": [
+    "start",
+    "middle",
+    "end"
+  ],
+  "text-align": [
+    "center",
+    "justify",
+    "left",
+    "right",
+    "-libweb-center",
+    "-libweb-left",
+    "-libweb-right"
+  ],
+  "text-decoration-line": [
+    "blink",
+    "line-through",
+    "none",
+    "overline",
+    "underline"
+  ],
+  "text-decoration-style": [
+    "dashed",
+    "dotted",
+    "double",
+    "solid",
+    "wavy"
+  ],
+  "text-justify": [
+    "auto",
+    "none",
+    "inter-word",
+    "inter-character",
+    "distribute=inter-character"
+  ],
+  "text-transform": [
+    "capitalize",
+    "full-size-kana",
+    "full-width",
+    "lowercase",
+    "none",
+    "uppercase"
+  ],
+  "vertical-align": [
+    "baseline",
+    "bottom",
+    "middle",
+    "sub",
+    "super",
+    "text-bottom",
+    "text-top",
+    "top"
+  ],
+  "visibility": [
+    "collapse",
+    "hidden",
+    "visible"
+  ],
+  "white-space": [
+    "normal",
+    "nowrap",
+    "pre",
+    "pre-line",
+    "pre-wrap"
+  ]
 }

--- a/Userland/Libraries/LibWeb/CSS/MediaFeatures.json
+++ b/Userland/Libraries/LibWeb/CSS/MediaFeatures.json
@@ -1,261 +1,261 @@
 {
-    "any-hover": {
-        "type": "discrete",
-        "values": [
-            "none",
-            "hover"
-        ]
-    },
-    "any-pointer": {
-        "type": "discrete",
-        "values": [
-            "none",
-            "coarse",
-            "fine"
-        ]
-    },
-    "aspect-ratio": {
-        "type": "range",
-        "values": [
-            "<ratio>"
-        ]
-    },
-    "color": {
-        "type": "range",
-        "values": [
-            "<integer>"
-        ]
-    },
-    "color-gamut": {
-        "type": "discrete",
-        "values": [
-            "srgb",
-            "p3",
-            "rec2020"
-        ]
-    },
-    "color-index": {
-        "type": "range",
-        "values": [
-            "<integer>"
-        ]
-    },
-    "device-aspect-ratio": {
-        "type": "range",
-        "values": [
-            "<ratio>"
-        ]
-    },
-    "device-height": {
-        "type": "range",
-        "values": [
-            "<length>"
-        ]
-    },
-    "device-width": {
-        "type": "range",
-        "values": [
-            "<length>"
-        ]
-    },
-    "display-mode": {
-        "type": "discrete",
-        "values": [
-            "fullscreen",
-            "standalone",
-            "minimal-ui",
-            "browser"
-        ]
-    },
-    "dynamic-range": {
-        "type": "discrete",
-        "values": [
-            "standard",
-            "high"
-        ]
-    },
-    "environment-blending": {
-        "type": "discrete",
-        "values": [
-            "opaque",
-            "additive",
-            "subtractive"
-        ]
-    },
-    "forced-colors": {
-        "type": "discrete",
-        "values": [
-            "none",
-            "active"
-        ]
-    },
-    "grid": {
-        "type": "discrete",
-        "values": [
-            "<mq-boolean>"
-        ]
-    },
-    "height": {
-        "type": "range",
-        "values": [
-            "<length>"
-        ]
-    },
-    "horizontal-viewport-segments": {
-        "type": "range",
-        "values": [
-            "<integer>"
-        ]
-    },
-    "hover": {
-        "type": "discrete",
-        "values": [
-            "none",
-            "hover"
-        ]
-    },
-    "inverted-colors": {
-        "type": "discrete",
-        "values": [
-            "none",
-            "inverted"
-        ]
-    },
-    "monochrome": {
-        "type": "range",
-        "values": [
-            "<integer>"
-        ]
-    },
-    "nav-controls": {
-        "type": "discrete",
-        "values": [
-            "none",
-            "back"
-        ]
-    },
-    "orientation": {
-        "type": "discrete",
-        "values": [
-            "portrait",
-            "landscape"
-        ]
-    },
-    "overflow-block": {
-        "type": "discrete",
-        "values": [
-            "none",
-            "scroll",
-            "paged"
-        ]
-    },
-    "overflow-inline": {
-        "type": "discrete",
-        "values": [
-            "none",
-            "scroll"
-        ]
-    },
-    "pointer": {
-        "type": "discrete",
-        "values": [
-            "none",
-            "coarse",
-            "fine"
-        ]
-    },
-    "prefers-color-scheme": {
-        "type": "discrete",
-        "values": [
-            "light",
-            "dark"
-        ]
-    },
-    "prefers-contrast": {
-        "type": "discrete",
-        "values": [
-            "no-preference",
-            "less",
-            "more",
-            "custom"
-        ]
-    },
-    "prefers-reduced-data": {
-        "type": "discrete",
-        "values": [
-            "no-preference",
-            "reduce"
-        ]
-    },
-    "prefers-reduced-motion": {
-        "type": "discrete",
-        "values": [
-            "no-preference",
-            "reduce"
-        ]
-    },
-    "prefers-reduced-transparency": {
-        "type": "discrete",
-        "values": [
-            "no-preference",
-            "reduce"
-        ]
-    },
-    "resolution": {
-        "type": "range",
-        "values": [
-            "<resolution>",
-            "infinite"
-        ]
-    },
-    "scan": {
-        "type": "discrete",
-        "values": [
-            "interlace",
-            "progressive"
-        ]
-    },
-    "scripting": {
-        "type": "discrete",
-        "values": [
-            "none",
-            "initial-only",
-            "enabled"
-        ]
-    },
-    "update": {
-        "type": "discrete",
-        "values": [
-            "none",
-            "slow",
-            "fast"
-        ]
-    },
-    "vertical-viewport-segments": {
-        "type": "range",
-        "values": [
-            "<integer>"
-        ]
-    },
-    "video-color-gamut": {
-        "type": "discrete",
-        "values": [
-            "srgb",
-            "p3",
-            "rec2020"
-        ]
-    },
-    "video-dynamic-range": {
-        "type": "discrete",
-        "values": [
-            "standard",
-            "high"
-        ]
-    },
-    "width": {
-        "type": "range",
-        "values": [
-            "<length>"
-        ]
-    }
+  "any-hover": {
+    "type": "discrete",
+    "values": [
+      "none",
+      "hover"
+    ]
+  },
+  "any-pointer": {
+    "type": "discrete",
+    "values": [
+      "none",
+      "coarse",
+      "fine"
+    ]
+  },
+  "aspect-ratio": {
+    "type": "range",
+    "values": [
+      "<ratio>"
+    ]
+  },
+  "color": {
+    "type": "range",
+    "values": [
+      "<integer>"
+    ]
+  },
+  "color-gamut": {
+    "type": "discrete",
+    "values": [
+      "srgb",
+      "p3",
+      "rec2020"
+    ]
+  },
+  "color-index": {
+    "type": "range",
+    "values": [
+      "<integer>"
+    ]
+  },
+  "device-aspect-ratio": {
+    "type": "range",
+    "values": [
+      "<ratio>"
+    ]
+  },
+  "device-height": {
+    "type": "range",
+    "values": [
+      "<length>"
+    ]
+  },
+  "device-width": {
+    "type": "range",
+    "values": [
+      "<length>"
+    ]
+  },
+  "display-mode": {
+    "type": "discrete",
+    "values": [
+      "fullscreen",
+      "standalone",
+      "minimal-ui",
+      "browser"
+    ]
+  },
+  "dynamic-range": {
+    "type": "discrete",
+    "values": [
+      "standard",
+      "high"
+    ]
+  },
+  "environment-blending": {
+    "type": "discrete",
+    "values": [
+      "opaque",
+      "additive",
+      "subtractive"
+    ]
+  },
+  "forced-colors": {
+    "type": "discrete",
+    "values": [
+      "none",
+      "active"
+    ]
+  },
+  "grid": {
+    "type": "discrete",
+    "values": [
+      "<mq-boolean>"
+    ]
+  },
+  "height": {
+    "type": "range",
+    "values": [
+      "<length>"
+    ]
+  },
+  "horizontal-viewport-segments": {
+    "type": "range",
+    "values": [
+      "<integer>"
+    ]
+  },
+  "hover": {
+    "type": "discrete",
+    "values": [
+      "none",
+      "hover"
+    ]
+  },
+  "inverted-colors": {
+    "type": "discrete",
+    "values": [
+      "none",
+      "inverted"
+    ]
+  },
+  "monochrome": {
+    "type": "range",
+    "values": [
+      "<integer>"
+    ]
+  },
+  "nav-controls": {
+    "type": "discrete",
+    "values": [
+      "none",
+      "back"
+    ]
+  },
+  "orientation": {
+    "type": "discrete",
+    "values": [
+      "portrait",
+      "landscape"
+    ]
+  },
+  "overflow-block": {
+    "type": "discrete",
+    "values": [
+      "none",
+      "scroll",
+      "paged"
+    ]
+  },
+  "overflow-inline": {
+    "type": "discrete",
+    "values": [
+      "none",
+      "scroll"
+    ]
+  },
+  "pointer": {
+    "type": "discrete",
+    "values": [
+      "none",
+      "coarse",
+      "fine"
+    ]
+  },
+  "prefers-color-scheme": {
+    "type": "discrete",
+    "values": [
+      "light",
+      "dark"
+    ]
+  },
+  "prefers-contrast": {
+    "type": "discrete",
+    "values": [
+      "no-preference",
+      "less",
+      "more",
+      "custom"
+    ]
+  },
+  "prefers-reduced-data": {
+    "type": "discrete",
+    "values": [
+      "no-preference",
+      "reduce"
+    ]
+  },
+  "prefers-reduced-motion": {
+    "type": "discrete",
+    "values": [
+      "no-preference",
+      "reduce"
+    ]
+  },
+  "prefers-reduced-transparency": {
+    "type": "discrete",
+    "values": [
+      "no-preference",
+      "reduce"
+    ]
+  },
+  "resolution": {
+    "type": "range",
+    "values": [
+      "<resolution>",
+      "infinite"
+    ]
+  },
+  "scan": {
+    "type": "discrete",
+    "values": [
+      "interlace",
+      "progressive"
+    ]
+  },
+  "scripting": {
+    "type": "discrete",
+    "values": [
+      "none",
+      "initial-only",
+      "enabled"
+    ]
+  },
+  "update": {
+    "type": "discrete",
+    "values": [
+      "none",
+      "slow",
+      "fast"
+    ]
+  },
+  "vertical-viewport-segments": {
+    "type": "range",
+    "values": [
+      "<integer>"
+    ]
+  },
+  "video-color-gamut": {
+    "type": "discrete",
+    "values": [
+      "srgb",
+      "p3",
+      "rec2020"
+    ]
+  },
+  "video-dynamic-range": {
+    "type": "discrete",
+    "values": [
+      "standard",
+      "high"
+    ]
+  },
+  "width": {
+    "type": "range",
+    "values": [
+      "<length>"
+    ]
+  }
 }

--- a/Userland/Libraries/LibWeb/CSS/TransformFunctions.json
+++ b/Userland/Libraries/LibWeb/CSS/TransformFunctions.json
@@ -1,87 +1,230 @@
 {
-    "matrix": {
-        "parameters": [
-            { "type": "<number>", "required": true },
-            { "type": "<number>", "required": true },
-            { "type": "<number>", "required": true },
-            { "type": "<number>", "required": true },
-            { "type": "<number>", "required": true },
-            { "type": "<number>", "required": true }
-        ]
-    },
-    "matrix3d": {
-        "parameters": [
-            { "type": "<number>", "required": true },
-            { "type": "<number>", "required": true },
-            { "type": "<number>", "required": true },
-            { "type": "<number>", "required": true },
-            { "type": "<number>", "required": true },
-            { "type": "<number>", "required": true },
-            { "type": "<number>", "required": true },
-            { "type": "<number>", "required": true },
-            { "type": "<number>", "required": true },
-            { "type": "<number>", "required": true },
-            { "type": "<number>", "required": true },
-            { "type": "<number>", "required": true },
-            { "type": "<number>", "required": true },
-            { "type": "<number>", "required": true },
-            { "type": "<number>", "required": true },
-            { "type": "<number>", "required": true }
-        ]
-    },
-    "translate": {
-        "parameters": [
-            { "type": "<length-percentage>", "required": true },
-            { "type": "<length-percentage>", "required": false }
-        ]
-    },
-    "translate3d": {
-        "parameters": [
-            { "type": "<length-percentage>", "required": true },
-            { "type": "<length-percentage>", "required": true },
-            { "type": "<length>", "required": true }
-        ]
-    },
-    "translateX": {
-        "parameters": [{ "type": "<length-percentage>", "required": true }]
-    },
-    "translateY": {
-        "parameters": [{ "type": "<length-percentage>", "required": true }]
-    },
-    "scale": {
-        "parameters": [
-            { "type": "<number>", "required": true },
-            { "type": "<number>", "required": false }
-        ]
-    },
-    "scaleX": {
-        "parameters": [{ "type": "<number>", "required": true }]
-    },
-    "scaleY": {
-        "parameters": [{ "type": "<number>", "required": true }]
-    },
-    "rotate": {
-        "parameters": [{ "type": "<angle>", "required": true }]
-    },
-    "rotateX": {
-        "parameters": [{ "type": "<angle>", "required": true }]
-    },
-    "rotateY": {
-        "parameters": [{ "type": "<angle>", "required": true }]
-    },
-    "rotateZ": {
-        "parameters": [{ "type": "<angle>", "required": true }]
-    },
-    "skew": {
-        "parameters": [
-            { "type": "<angle>", "required": true },
-            { "type": "<angle>", "required": false }
-        ]
-    },
-    "skewX": {
-        "parameters": [{ "type": "<angle>", "required": true }]
-    },
-    "skewY": {
-        "parameters": [{ "type": "<angle>", "required": true }]
-    }
+  "matrix": {
+    "parameters": [
+      {
+        "type": "<number>",
+        "required": true
+      },
+      {
+        "type": "<number>",
+        "required": true
+      },
+      {
+        "type": "<number>",
+        "required": true
+      },
+      {
+        "type": "<number>",
+        "required": true
+      },
+      {
+        "type": "<number>",
+        "required": true
+      },
+      {
+        "type": "<number>",
+        "required": true
+      }
+    ]
+  },
+  "matrix3d": {
+    "parameters": [
+      {
+        "type": "<number>",
+        "required": true
+      },
+      {
+        "type": "<number>",
+        "required": true
+      },
+      {
+        "type": "<number>",
+        "required": true
+      },
+      {
+        "type": "<number>",
+        "required": true
+      },
+      {
+        "type": "<number>",
+        "required": true
+      },
+      {
+        "type": "<number>",
+        "required": true
+      },
+      {
+        "type": "<number>",
+        "required": true
+      },
+      {
+        "type": "<number>",
+        "required": true
+      },
+      {
+        "type": "<number>",
+        "required": true
+      },
+      {
+        "type": "<number>",
+        "required": true
+      },
+      {
+        "type": "<number>",
+        "required": true
+      },
+      {
+        "type": "<number>",
+        "required": true
+      },
+      {
+        "type": "<number>",
+        "required": true
+      },
+      {
+        "type": "<number>",
+        "required": true
+      },
+      {
+        "type": "<number>",
+        "required": true
+      },
+      {
+        "type": "<number>",
+        "required": true
+      }
+    ]
+  },
+  "translate": {
+    "parameters": [
+      {
+        "type": "<length-percentage>",
+        "required": true
+      },
+      {
+        "type": "<length-percentage>",
+        "required": false
+      }
+    ]
+  },
+  "translate3d": {
+    "parameters": [
+      {
+        "type": "<length-percentage>",
+        "required": true
+      },
+      {
+        "type": "<length-percentage>",
+        "required": true
+      },
+      {
+        "type": "<length>",
+        "required": true
+      }
+    ]
+  },
+  "translateX": {
+    "parameters": [
+      {
+        "type": "<length-percentage>",
+        "required": true
+      }
+    ]
+  },
+  "translateY": {
+    "parameters": [
+      {
+        "type": "<length-percentage>",
+        "required": true
+      }
+    ]
+  },
+  "scale": {
+    "parameters": [
+      {
+        "type": "<number>",
+        "required": true
+      },
+      {
+        "type": "<number>",
+        "required": false
+      }
+    ]
+  },
+  "scaleX": {
+    "parameters": [
+      {
+        "type": "<number>",
+        "required": true
+      }
+    ]
+  },
+  "scaleY": {
+    "parameters": [
+      {
+        "type": "<number>",
+        "required": true
+      }
+    ]
+  },
+  "rotate": {
+    "parameters": [
+      {
+        "type": "<angle>",
+        "required": true
+      }
+    ]
+  },
+  "rotateX": {
+    "parameters": [
+      {
+        "type": "<angle>",
+        "required": true
+      }
+    ]
+  },
+  "rotateY": {
+    "parameters": [
+      {
+        "type": "<angle>",
+        "required": true
+      }
+    ]
+  },
+  "rotateZ": {
+    "parameters": [
+      {
+        "type": "<angle>",
+        "required": true
+      }
+    ]
+  },
+  "skew": {
+    "parameters": [
+      {
+        "type": "<angle>",
+        "required": true
+      },
+      {
+        "type": "<angle>",
+        "required": false
+      }
+    ]
+  },
+  "skewX": {
+    "parameters": [
+      {
+        "type": "<angle>",
+        "required": true
+      }
+    ]
+  },
+  "skewY": {
+    "parameters": [
+      {
+        "type": "<angle>",
+        "required": true
+      }
+    ]
+  }
 }


### PR DESCRIPTION
Mostly this is about 2-space indentation, but we now also only have one key:value pair per line.

As pointed out by @TobyAsE!

The transform function definitions ended up more verbose, but eh.