### PR TITLE
Kernel: Add NVMe shadow doorbell support

### DIFF
--- a/Kernel/Devices/Storage/NVMe/NVMeController.h
+++ b/Kernel/Devices/Storage/NVMe/NVMeController.h
@@ -58,6 +58,7 @@ private:
     NVMeController(PCI::DeviceIdentifier const&, u32 hardware_relative_controller_id);
 
     ErrorOr<void> identify_and_init_namespaces();
+    ErrorOr<void> identify_and_init_controller();
     Tuple<u64, u8> get_ns_features(IdentifyNamespace& identify_data_struct);
     ErrorOr<void> create_admin_queue(QueueType queue_type);
     ErrorOr<void> create_io_queue(u8 qid, QueueType queue_type);
@@ -72,6 +73,8 @@ private:
     Vector<NonnullLockRefPtr<NVMeQueue>> m_queues;
     Vector<NonnullLockRefPtr<NVMeNameSpace>> m_namespaces;
     Memory::TypedMapping<ControllerRegister volatile> m_controller_regs;
+    RefPtr<Memory::PhysicalPage> m_dbbuf_shadow_page;
+    RefPtr<Memory::PhysicalPage> m_dbbuf_eventidx_page;
     bool m_admin_queue_ready { false };
     size_t m_device_count { 0 };
     AK::Duration m_ready_timeout;

--- a/Kernel/Devices/Storage/NVMe/NVMeDefinitions.h
+++ b/Kernel/Devices/Storage/NVMe/NVMeDefinitions.h
@@ -34,10 +34,21 @@ struct IdentifyNamespace {
     u64 rsvd3[488];
 };
 
+// FIXME: For now only one value is used. Once we start using
+// more values from id_ctrl command, use separate member variables
+// instead of using rsd array.
+struct IdentifyController {
+    u8 rsdv1[256];
+    u16 oacs;
+    u8 rsdv2[3838];
+};
+
 // DOORBELL
 static constexpr u32 REG_SQ0TDBL_START = 0x1000;
 static constexpr u32 REG_SQ0TDBL_END = 0x1003;
 static constexpr u8 DBL_REG_SIZE = 8;
+static constexpr u16 ID_CTRL_SHADOW_DBBUF_MASK = 0x0100;
+
 // CAP
 static constexpr u8 CAP_DBL_SHIFT = 32;
 static constexpr u8 CAP_DBL_MASK = 0xf;
@@ -99,8 +110,9 @@ static constexpr u16 IO_QUEUE_SIZE = 64; // TODO:Need to be configurable
 
 // IDENTIFY
 static constexpr u16 NVMe_IDENTIFY_SIZE = 4096;
-static constexpr u8 NVMe_CNS_ID_ACTIVE_NS = 0x2;
 static constexpr u8 NVMe_CNS_ID_NS = 0x0;
+static constexpr u8 NVMe_CNS_ID_CTRL = 0x1;
+static constexpr u8 NVMe_CNS_ID_ACTIVE_NS = 0x2;
 static constexpr u8 FLBA_SIZE_INDEX = 26;
 static constexpr u8 FLBA_SIZE_MASK = 0xf;
 static constexpr u8 LBA_FORMAT_SUPPORT_INDEX = 128;
@@ -112,6 +124,7 @@ enum AdminCommandOpCode {
     OP_ADMIN_CREATE_COMPLETION_QUEUE = 0x5,
     OP_ADMIN_CREATE_SUBMISSION_QUEUE = 0x1,
     OP_ADMIN_IDENTIFY = 0x6,
+    OP_ADMIN_DBBUF_CONFIG = 0x7C,
 };
 
 // IO opcodes
@@ -202,6 +215,12 @@ struct [[gnu::packed]] NVMeCreateSQCmd {
     u64 rsvd12[2];
 };
 
+struct [[gnu::packed]] NVMeDBBUFCmd {
+    u32 rsvd1[5];
+    struct DataPtr data_ptr;
+    u32 rsvd12[6];
+};
+
 struct [[gnu::packed]] NVMeSubmission {
     u8 op;
     u8 flags;
@@ -212,5 +231,6 @@ struct [[gnu::packed]] NVMeSubmission {
         NVMeRWCmd rw;
         NVMeCreateCQCmd create_cq;
         NVMeCreateSQCmd create_sq;
+        NVMeDBBUFCmd dbbuf_cmd;
     };
 };

--- a/Kernel/Devices/Storage/NVMe/NVMeInterruptQueue.cpp
+++ b/Kernel/Devices/Storage/NVMe/NVMeInterruptQueue.cpp
@@ -11,14 +11,14 @@
 
 namespace Kernel {
 
-ErrorOr<NonnullLockRefPtr<NVMeInterruptQueue>> NVMeInterruptQueue::try_create(PCI::Device& device, NonnullOwnPtr<Memory::Region> rw_dma_region, NonnullRefPtr<Memory::PhysicalPage> rw_dma_page, u16 qid, u8 irq, u32 q_depth, OwnPtr<Memory::Region> cq_dma_region, OwnPtr<Memory::Region> sq_dma_region, Memory::TypedMapping<DoorbellRegister volatile> db_regs)
+ErrorOr<NonnullLockRefPtr<NVMeInterruptQueue>> NVMeInterruptQueue::try_create(PCI::Device& device, NonnullOwnPtr<Memory::Region> rw_dma_region, NonnullRefPtr<Memory::PhysicalPage> rw_dma_page, u16 qid, u8 irq, u32 q_depth, OwnPtr<Memory::Region> cq_dma_region, OwnPtr<Memory::Region> sq_dma_region, Doorbell db_regs)
 {
     auto queue = TRY(adopt_nonnull_lock_ref_or_enomem(new (nothrow) NVMeInterruptQueue(device, move(rw_dma_region), rw_dma_page, qid, irq, q_depth, move(cq_dma_region), move(sq_dma_region), move(db_regs))));
     queue->initialize_interrupt_queue();
     return queue;
 }
 
-UNMAP_AFTER_INIT NVMeInterruptQueue::NVMeInterruptQueue(PCI::Device& device, NonnullOwnPtr<Memory::Region> rw_dma_region, NonnullRefPtr<Memory::PhysicalPage> rw_dma_page, u16 qid, u8 irq, u32 q_depth, OwnPtr<Memory::Region> cq_dma_region, OwnPtr<Memory::Region> sq_dma_region, Memory::TypedMapping<DoorbellRegister volatile> db_regs)
+UNMAP_AFTER_INIT NVMeInterruptQueue::NVMeInterruptQueue(PCI::Device& device, NonnullOwnPtr<Memory::Region> rw_dma_region, NonnullRefPtr<Memory::PhysicalPage> rw_dma_page, u16 qid, u8 irq, u32 q_depth, OwnPtr<Memory::Region> cq_dma_region, OwnPtr<Memory::Region> sq_dma_region, Doorbell db_regs)
     : NVMeQueue(move(rw_dma_region), rw_dma_page, qid, q_depth, move(cq_dma_region), move(sq_dma_region), move(db_regs))
     , PCIIRQHandler(device, irq)
 {

--- a/Kernel/Devices/Storage/NVMe/NVMeInterruptQueue.h
+++ b/Kernel/Devices/Storage/NVMe/NVMeInterruptQueue.h
@@ -14,14 +14,14 @@ namespace Kernel {
 class NVMeInterruptQueue : public NVMeQueue
     , public PCIIRQHandler {
 public:
-    static ErrorOr<NonnullLockRefPtr<NVMeInterruptQueue>> try_create(PCI::Device& device, NonnullOwnPtr<Memory::Region> rw_dma_region, NonnullRefPtr<Memory::PhysicalPage> rw_dma_page, u16 qid, u8 irq, u32 q_depth, OwnPtr<Memory::Region> cq_dma_region, OwnPtr<Memory::Region> sq_dma_region, Memory::TypedMapping<DoorbellRegister volatile> db_regs);
+    static ErrorOr<NonnullLockRefPtr<NVMeInterruptQueue>> try_create(PCI::Device& device, NonnullOwnPtr<Memory::Region> rw_dma_region, NonnullRefPtr<Memory::PhysicalPage> rw_dma_page, u16 qid, u8 irq, u32 q_depth, OwnPtr<Memory::Region> cq_dma_region, OwnPtr<Memory::Region> sq_dma_region, Doorbell db_regs);
     void submit_sqe(NVMeSubmission& submission) override;
     virtual ~NVMeInterruptQueue() override {};
     virtual StringView purpose() const override { return "NVMe"sv; }
     void initialize_interrupt_queue();
 
 protected:
-    NVMeInterruptQueue(PCI::Device& device, NonnullOwnPtr<Memory::Region> rw_dma_region, NonnullRefPtr<Memory::PhysicalPage> rw_dma_page, u16 qid, u8 irq, u32 q_depth, OwnPtr<Memory::Region> cq_dma_region, OwnPtr<Memory::Region> sq_dma_region, Memory::TypedMapping<DoorbellRegister volatile> db_regs);
+    NVMeInterruptQueue(PCI::Device& device, NonnullOwnPtr<Memory::Region> rw_dma_region, NonnullRefPtr<Memory::PhysicalPage> rw_dma_page, u16 qid, u8 irq, u32 q_depth, OwnPtr<Memory::Region> cq_dma_region, OwnPtr<Memory::Region> sq_dma_region, Doorbell db_regs);
 
 private:
     virtual void complete_current_request(u16 cmdid, u16 status) override;

--- a/Kernel/Devices/Storage/NVMe/NVMePollQueue.cpp
+++ b/Kernel/Devices/Storage/NVMe/NVMePollQueue.cpp
@@ -11,12 +11,12 @@
 
 namespace Kernel {
 
-ErrorOr<NonnullLockRefPtr<NVMePollQueue>> NVMePollQueue::try_create(NonnullOwnPtr<Memory::Region> rw_dma_region, NonnullRefPtr<Memory::PhysicalPage> rw_dma_page, u16 qid, u32 q_depth, OwnPtr<Memory::Region> cq_dma_region, OwnPtr<Memory::Region> sq_dma_region, Memory::TypedMapping<DoorbellRegister volatile> db_regs)
+ErrorOr<NonnullLockRefPtr<NVMePollQueue>> NVMePollQueue::try_create(NonnullOwnPtr<Memory::Region> rw_dma_region, NonnullRefPtr<Memory::PhysicalPage> rw_dma_page, u16 qid, u32 q_depth, OwnPtr<Memory::Region> cq_dma_region, OwnPtr<Memory::Region> sq_dma_region, Doorbell db_regs)
 {
     return TRY(adopt_nonnull_lock_ref_or_enomem(new (nothrow) NVMePollQueue(move(rw_dma_region), rw_dma_page, qid, q_depth, move(cq_dma_region), move(sq_dma_region), move(db_regs))));
 }
 
-UNMAP_AFTER_INIT NVMePollQueue::NVMePollQueue(NonnullOwnPtr<Memory::Region> rw_dma_region, NonnullRefPtr<Memory::PhysicalPage> rw_dma_page, u16 qid, u32 q_depth, OwnPtr<Memory::Region> cq_dma_region, OwnPtr<Memory::Region> sq_dma_region, Memory::TypedMapping<DoorbellRegister volatile> db_regs)
+UNMAP_AFTER_INIT NVMePollQueue::NVMePollQueue(NonnullOwnPtr<Memory::Region> rw_dma_region, NonnullRefPtr<Memory::PhysicalPage> rw_dma_page, u16 qid, u32 q_depth, OwnPtr<Memory::Region> cq_dma_region, OwnPtr<Memory::Region> sq_dma_region, Doorbell db_regs)
     : NVMeQueue(move(rw_dma_region), rw_dma_page, qid, q_depth, move(cq_dma_region), move(sq_dma_region), move(db_regs))
 {
 }

--- a/Kernel/Devices/Storage/NVMe/NVMePollQueue.h
+++ b/Kernel/Devices/Storage/NVMe/NVMePollQueue.h
@@ -12,12 +12,12 @@ namespace Kernel {
 
 class NVMePollQueue : public NVMeQueue {
 public:
-    static ErrorOr<NonnullLockRefPtr<NVMePollQueue>> try_create(NonnullOwnPtr<Memory::Region> rw_dma_region, NonnullRefPtr<Memory::PhysicalPage> rw_dma_page, u16 qid, u32 q_depth, OwnPtr<Memory::Region> cq_dma_region, OwnPtr<Memory::Region> sq_dma_region, Memory::TypedMapping<DoorbellRegister volatile> db_regs);
+    static ErrorOr<NonnullLockRefPtr<NVMePollQueue>> try_create(NonnullOwnPtr<Memory::Region> rw_dma_region, NonnullRefPtr<Memory::PhysicalPage> rw_dma_page, u16 qid, u32 q_depth, OwnPtr<Memory::Region> cq_dma_region, OwnPtr<Memory::Region> sq_dma_region, Doorbell db_regs);
     void submit_sqe(NVMeSubmission& submission) override;
     virtual ~NVMePollQueue() override {};
 
 protected:
-    NVMePollQueue(NonnullOwnPtr<Memory::Region> rw_dma_region, NonnullRefPtr<Memory::PhysicalPage> rw_dma_page, u16 qid, u32 q_depth, OwnPtr<Memory::Region> cq_dma_region, OwnPtr<Memory::Region> sq_dma_region, Memory::TypedMapping<DoorbellRegister volatile> db_regs);
+    NVMePollQueue(NonnullOwnPtr<Memory::Region> rw_dma_region, NonnullRefPtr<Memory::PhysicalPage> rw_dma_page, u16 qid, u32 q_depth, OwnPtr<Memory::Region> cq_dma_region, OwnPtr<Memory::Region> sq_dma_region, Doorbell db_regs);
 
 private:
     virtual void complete_current_request(u16 cmdid, u16 status) override;

--- a/Kernel/Devices/Storage/NVMe/NVMeQueue.cpp
+++ b/Kernel/Devices/Storage/NVMe/NVMeQueue.cpp
@@ -101,7 +101,6 @@ void NVMeQueue::submit_sqe(NVMeSubmission& sub)
     }
 
     dbgln_if(NVME_DEBUG, "NVMe: Submission with command identifier {}. SQ_TAIL: {}", sub.cmdid, m_sq_tail);
-    full_memory_barrier();
     update_sq_doorbell();
 }
 

--- a/Kernel/Devices/Storage/NVMe/NVMeQueue.cpp
+++ b/Kernel/Devices/Storage/NVMe/NVMeQueue.cpp
@@ -12,7 +12,7 @@
 #include <Kernel/Library/StdLib.h>
 
 namespace Kernel {
-ErrorOr<NonnullLockRefPtr<NVMeQueue>> NVMeQueue::try_create(NVMeController& device, u16 qid, u8 irq, u32 q_depth, OwnPtr<Memory::Region> cq_dma_region, OwnPtr<Memory::Region> sq_dma_region, Memory::TypedMapping<DoorbellRegister volatile> db_regs, QueueType queue_type)
+ErrorOr<NonnullLockRefPtr<NVMeQueue>> NVMeQueue::try_create(NVMeController& device, u16 qid, u8 irq, u32 q_depth, OwnPtr<Memory::Region> cq_dma_region, OwnPtr<Memory::Region> sq_dma_region, Doorbell db_regs, QueueType queue_type)
 {
     // Note: Allocate DMA region for RW operation. For now the requests don't exceed more than 4096 bytes (Storage device takes care of it)
     RefPtr<Memory::PhysicalPage> rw_dma_page;
@@ -30,7 +30,7 @@ ErrorOr<NonnullLockRefPtr<NVMeQueue>> NVMeQueue::try_create(NVMeController& devi
     return queue;
 }
 
-UNMAP_AFTER_INIT NVMeQueue::NVMeQueue(NonnullOwnPtr<Memory::Region> rw_dma_region, Memory::PhysicalPage const& rw_dma_page, u16 qid, u32 q_depth, OwnPtr<Memory::Region> cq_dma_region, OwnPtr<Memory::Region> sq_dma_region, Memory::TypedMapping<DoorbellRegister volatile> db_regs)
+UNMAP_AFTER_INIT NVMeQueue::NVMeQueue(NonnullOwnPtr<Memory::Region> rw_dma_region, Memory::PhysicalPage const& rw_dma_page, u16 qid, u32 q_depth, OwnPtr<Memory::Region> cq_dma_region, OwnPtr<Memory::Region> sq_dma_region, Doorbell db_regs)
     : m_rw_dma_region(move(rw_dma_region))
     , m_qid(qid)
     , m_admin_queue(qid == 0)

--- a/Kernel/Devices/Storage/NVMe/NVMeQueue.h
+++ b/Kernel/Devices/Storage/NVMe/NVMeQueue.h
@@ -26,6 +26,10 @@ struct DoorbellRegister {
     u32 cq_head;
 };
 
+struct Doorbell {
+    Memory::TypedMapping<DoorbellRegister volatile> mmio_reg;
+};
+
 enum class QueueType {
     Polled,
     IRQ
@@ -42,7 +46,7 @@ struct NVMeIO {
 class NVMeController;
 class NVMeQueue : public AtomicRefCounted<NVMeQueue> {
 public:
-    static ErrorOr<NonnullLockRefPtr<NVMeQueue>> try_create(NVMeController& device, u16 qid, u8 irq, u32 q_depth, OwnPtr<Memory::Region> cq_dma_region, OwnPtr<Memory::Region> sq_dma_region, Memory::TypedMapping<DoorbellRegister volatile> db_regs, QueueType queue_type);
+    static ErrorOr<NonnullLockRefPtr<NVMeQueue>> try_create(NVMeController& device, u16 qid, u8 irq, u32 q_depth, OwnPtr<Memory::Region> cq_dma_region, OwnPtr<Memory::Region> sq_dma_region, Doorbell db_regs, QueueType queue_type);
     bool is_admin_queue() { return m_admin_queue; }
     u16 submit_sync_sqe(NVMeSubmission&);
     void read(AsyncBlockDeviceRequest& request, u16 nsid, u64 index, u32 count);
@@ -54,9 +58,10 @@ protected:
     u32 process_cq();
     void update_sq_doorbell()
     {
-        m_db_regs->sq_tail = m_sq_tail;
+        m_db_regs.mmio_reg->sq_tail = m_sq_tail;
     }
-    NVMeQueue(NonnullOwnPtr<Memory::Region> rw_dma_region, Memory::PhysicalPage const& rw_dma_page, u16 qid, u32 q_depth, OwnPtr<Memory::Region> cq_dma_region, OwnPtr<Memory::Region> sq_dma_region, Memory::TypedMapping<DoorbellRegister volatile> db_regs);
+
+    NVMeQueue(NonnullOwnPtr<Memory::Region> rw_dma_region, Memory::PhysicalPage const& rw_dma_page, u16 qid, u32 q_depth, OwnPtr<Memory::Region> cq_dma_region, OwnPtr<Memory::Region> sq_dma_region, Doorbell db_regs);
 
     [[nodiscard]] u32 get_request_cid()
     {
@@ -77,7 +82,7 @@ private:
     virtual void complete_current_request(u16 cmdid, u16 status) = 0;
     void update_cq_doorbell()
     {
-        m_db_regs->cq_head = m_cq_head;
+        m_db_regs.mmio_reg->cq_head = m_cq_head;
     }
 
 protected:
@@ -100,7 +105,7 @@ private:
     OwnPtr<Memory::Region> m_sq_dma_region;
     Span<NVMeCompletion> m_cqe_array;
     WaitQueue m_sync_wait_queue;
-    Memory::TypedMapping<DoorbellRegister volatile> m_db_regs;
+    Doorbell m_db_regs;
     NonnullRefPtr<Memory::PhysicalPage const> const m_rw_dma_page;
 };
 }

--- a/Kernel/Devices/Storage/NVMe/NVMeQueue.h
+++ b/Kernel/Devices/Storage/NVMe/NVMeQueue.h
@@ -28,6 +28,8 @@ struct DoorbellRegister {
 
 struct Doorbell {
     Memory::TypedMapping<DoorbellRegister volatile> mmio_reg;
+    Memory::TypedMapping<DoorbellRegister> dbbuf_shadow;
+    Memory::TypedMapping<DoorbellRegister> dbbuf_eventidx;
 };
 
 enum class QueueType {
@@ -56,9 +58,25 @@ public:
 
 protected:
     u32 process_cq();
+
+    // Updates the shadow buffer and returns if mmio is needed
+    bool update_shadow_buf(u16 new_value, u32* dbbuf, u32* ei)
+    {
+        u32 const old = *dbbuf;
+
+        *dbbuf = new_value;
+        AK::full_memory_barrier();
+
+        bool need_mmio = static_cast<u16>(new_value - *ei - 1) < static_cast<u16>(new_value - old);
+        return need_mmio;
+    }
+
     void update_sq_doorbell()
     {
-        m_db_regs.mmio_reg->sq_tail = m_sq_tail;
+        full_memory_barrier();
+        if (m_db_regs.dbbuf_shadow.paddr.is_null()
+            || update_shadow_buf(m_sq_tail, &m_db_regs.dbbuf_shadow->sq_tail, &m_db_regs.dbbuf_eventidx->sq_tail))
+            m_db_regs.mmio_reg->sq_tail = m_sq_tail;
     }
 
     NVMeQueue(NonnullOwnPtr<Memory::Region> rw_dma_region, Memory::PhysicalPage const& rw_dma_page, u16 qid, u32 q_depth, OwnPtr<Memory::Region> cq_dma_region, OwnPtr<Memory::Region> sq_dma_region, Doorbell db_regs);
@@ -82,7 +100,10 @@ private:
     virtual void complete_current_request(u16 cmdid, u16 status) = 0;
     void update_cq_doorbell()
     {
-        m_db_regs.mmio_reg->cq_head = m_cq_head;
+        full_memory_barrier();
+        if (m_db_regs.dbbuf_shadow.paddr.is_null()
+            || update_shadow_buf(m_cq_head, &m_db_regs.dbbuf_shadow->cq_head, &m_db_regs.dbbuf_eventidx->cq_head))
+            m_db_regs.mmio_reg->cq_head = m_cq_head;
     }
 
 protected:


### PR DESCRIPTION
Shadow doorbell feature was added in the NVMe spec to improve
the performance of virtual NVMe devices. [1]

Typically, ringing a doorbell involves writing to an MMIO register in
QEMU, which can be expensive as there will be a trap for the VM.

Shadow doorbell mechanism was added for the VM to communicate with the guest OS
when it needs to do an MMIO write, thereby avoiding it when it is not
necessary.

There is **no performance improvement** with this support in Serenity
**at the moment** because of the block layer constraint of not batching
multiple IOs. Once the **command batching** support is added to the block
layer, **shadow doorbell support can improve performance** by avoiding many
MMIO writes.

[1] https://www.collabora.com/news-and-blog/blog/2016/08/23/increased-performance-of-emulated-nvme-devices/