### PR TITLE
Ladybird: Ensure RequestServer depends on its generated sources

### DIFF
--- a/Ladybird/RequestServer/CMakeLists.txt
+++ b/Ladybird/RequestServer/CMakeLists.txt
@@ -19,7 +19,7 @@ qt_add_executable(RequestServer ${REQUESTSERVER_SOURCES})
 
 target_include_directories(RequestServer PRIVATE ${SERENITY_SOURCE_DIR}/Userland/Services/)
 target_include_directories(RequestServer PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/..)
-target_link_libraries(RequestServer PRIVATE Qt::Core LibCore LibMain LibCrypto LibFileSystem LibGemini LibHTTP LibIPC LibMain LibTLS)
+target_link_libraries(RequestServer PRIVATE Qt::Core LibCore LibMain LibCrypto LibFileSystem LibGemini LibHTTP LibIPC LibMain LibTLS LibWebView)
 if (ANDROID)
     link_android_libs(RequestServer)
 endif()


### PR DESCRIPTION
Ladybird's RequestServer needs to depend on its generated IPC header files to ensure they are generated before RequestServer is compiled. We currently bundle the IPC headers into LibWebView, so the easiest method would be to make RequestServer depend on LibWebView. This would be a bit awkward though, because there's no reason for RequestServer to depend on all other things in LibWebView just for these headers.

So this breaks the RequestServer IPC headers into an INTERFACE library, and makes Ladybird's RequestServer depend on it. This can be changed to a normal library if any .cpp sources are added in the future.