### PR TITLE
LibCore: Implement a helper that waits for a debugger then breaks

### DIFF
--- a/Userland/Libraries/LibCore/Process.cpp
+++ b/Userland/Libraries/LibCore/Process.cpp
@@ -114,6 +114,11 @@ ErrorOr<String> Process::get_name()
     if (rc != 0)
         return Error::from_syscall("get_process_name"sv, -rc);
     return String::from_utf8(StringView { buffer, strlen(buffer) });
+#elif defined(AK_OS_LINUX)
+    return String::from_utf8(StringView { program_invocation_name, strlen(program_invocation_name) });
+#elif defined(AK_OS_BSD_GENERIC)
+    auto const* progname = getprogname();
+    return String::from_utf8(StringView { progname, strlen(progname) });
 #else
     // FIXME: Implement Process::get_name() for other platforms.
     return "???"_short_string;

--- a/Userland/Libraries/LibCore/Process.h
+++ b/Userland/Libraries/LibCore/Process.h
@@ -31,6 +31,7 @@ public:
     };
     static ErrorOr<void> set_name(StringView, SetThreadName = SetThreadName::No);
 
+    static void wait_for_debugger_and_break();
     static ErrorOr<bool> is_being_debugged();
 };
 

--- a/Userland/Libraries/LibCore/Process.h
+++ b/Userland/Libraries/LibCore/Process.h
@@ -30,6 +30,8 @@ public:
         Yes,
     };
     static ErrorOr<void> set_name(StringView, SetThreadName = SetThreadName::No);
+
+    static ErrorOr<bool> is_being_debugged();
 };
 
 }


### PR DESCRIPTION
The helper method can be used to force the current process to sleep, waiting for a debugger to attach. On attach, the debugger breaks at the callsite
 directly.

[Clion debugging demo gif](https://github.com/SerenityOS/serenity/assets/74406/2df2f1f6-d520-441a-8cf2-f3df90d86a58)

[Gdb in the terminal (lldb works too on macOS)](https://github.com/SerenityOS/serenity/assets/74406/4e070d63-4576-487d-bac6-6ffbb48a7d5e)
