### PR TITLE
LibGfx/OpenType: Return metrics from hmtx even if there is no glyf entry

### DIFF
--- a/Userland/Libraries/LibGfx/Font/OpenType/Font.cpp
+++ b/Userland/Libraries/LibGfx/Font/OpenType/Font.cpp
@@ -671,11 +671,9 @@ Gfx::ScaledGlyphMetrics Font::glyph_metrics(u32 glyph_id, float x_scale, float y
     auto horizontal_metrics = m_hmtx.get_glyph_horizontal_metrics(glyph_id);
     auto glyph_offset = m_loca->get_glyph_offset(glyph_id);
     auto glyph = m_glyf->glyph(glyph_offset);
-    if (!glyph.has_value())
-        return {};
     return Gfx::ScaledGlyphMetrics {
-        .ascender = static_cast<float>(glyph->ascender()) * y_scale,
-        .descender = static_cast<float>(glyph->descender()) * y_scale,
+        .ascender = glyph.has_value() ? static_cast<float>(glyph->ascender()) * y_scale : 0,
+        .descender = glyph.has_value() ? static_cast<float>(glyph->descender()) * y_scale : 0,
         .advance_width = static_cast<float>(horizontal_metrics.advance_width) * x_scale,
         .left_side_bearing = static_cast<float>(horizontal_metrics.left_side_bearing) * x_scale,
     };


### PR DESCRIPTION
This fixes an issue with some typefaces where the space character has an advance width, but no glyf entry (and thus no ascent/descent). Before this change, we'd render whitespace with zero advance in such cases.

Visual progression on a website that uses DIN fonts:

Before:
![Screenshot at 2023-08-02 18-30-32](https://github.com/SerenityOS/serenity/assets/5954907/a797993a-ac41-4b54-b3d4-760feda26ff9)

After:
![Screenshot at 2023-08-02 18-31-55](https://github.com/SerenityOS/serenity/assets/5954907/105223d1-9790-4b26-83c5-e6da85b66058)
