### PR TITLE
LibWeb: Implement `outline` and its related properties

### DIFF
--- a/Base/res/html/misc/inline-node.html
+++ b/Base/res/html/misc/inline-node.html
@@ -42,8 +42,13 @@
         }
         .outline3 {
             outline: 2px solid green;
+            outline-offset: 5px;
             border-radius: 10px;
             border: 2px solid black;
+        }
+        .outline4 {
+            outline: 1px solid red;
+            outline-offset: -20px;
         }
     </style>
 </head>
@@ -57,7 +62,7 @@
     </div>
     <div style="background-color:red;width:3px">This text should only have a strip of red on the left</div>
     <div class="box">
-        <span class="outline">This text has an outline</span> and <span class="outline2">this text has an outline with a border radius,</span> and <span class="outline3">this also has a border.</span>
+        <span class="outline">This text has an outline</span> and <span class="outline2">this text has an outline with a border radius,</span> and <span class="outline3">this also has a border.</span> <span class="outline4">This outline is a strikethrough.</span>
     </div>
 </body>
 </html>

--- a/Base/res/html/misc/inline-node.html
+++ b/Base/res/html/misc/inline-node.html
@@ -32,6 +32,19 @@
             border-radius: 6px;
             box-shadow: 4px 4px 4px darkgreen;
         }
+
+        .outline {
+            outline: 3px dotted magenta;
+        }
+        .outline2 {
+            outline: 1px solid red;
+            border-radius: 10px;
+        }
+        .outline3 {
+            outline: 2px solid green;
+            border-radius: 10px;
+            border: 2px solid black;
+        }
     </style>
 </head>
 <body>
@@ -43,5 +56,8 @@
         Hello world <span class="highlight">this is some text</span> in a box. <span class="bg-highlight">This text has a background</span> and <span class="br-highlight">this text has a shadow!</span>
     </div>
     <div style="background-color:red;width:3px">This text should only have a strip of red on the left</div>
+    <div class="box">
+        <span class="outline">This text has an outline</span> and <span class="outline2">this text has an outline with a border radius,</span> and <span class="outline3">this also has a border.</span>
+    </div>
 </body>
 </html>

--- a/Base/res/html/misc/outline.html
+++ b/Base/res/html/misc/outline.html
@@ -6,6 +6,7 @@
         p {
             padding: 5px;
             border: 2px solid black;
+            margin: 1em;
         }
         .outline-default {
             outline: auto;
@@ -21,6 +22,14 @@
             color: saddlebrown;
             outline: 5px dotted currentcolor;
         }
+        .outline-offset {
+            outline: 5px solid blue;
+            outline-offset: 0.5em;
+        }
+        .outline-inset {
+            outline: 1px solid red;
+            outline-offset: -10em;
+        }
     </style>
 </head>
 <body>
@@ -29,5 +38,7 @@
 <p class="outline-1">I have an outline!</p>
 <p class="outline-2">I have an outline and a radius!</p>
 <p class="outline-currentcolor">My outline is dotted and brown!</p>
+<p class="outline-offset">My outline is blue and away from my border!</p>
+<p class="outline-inset">My outline is a very thin red line in the middle of this box!</p>
 </body>
 </html>

--- a/Base/res/html/misc/outline.html
+++ b/Base/res/html/misc/outline.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html>
+<head>
+    <title>Outlines</title>
+    <style>
+        p {
+            padding: 5px;
+            border: 2px solid black;
+        }
+        .outline-default {
+            outline: auto;
+        }
+        .outline-1 {
+            outline: 5px dashed magenta;
+        }
+        .outline-2 {
+            outline: 5px solid green;
+            border-radius: 10px;
+        }
+        .outline-currentcolor {
+            color: saddlebrown;
+            outline: 5px dotted currentcolor;
+        }
+    </style>
+</head>
+<body>
+<h1>Outlines</h1>
+<p class="outline-default">I have the default outline!</p>
+<p class="outline-1">I have an outline!</p>
+<p class="outline-2">I have an outline and a radius!</p>
+<p class="outline-currentcolor">My outline is dotted and brown!</p>
+</body>
+</html>

--- a/Base/res/html/misc/welcome.html
+++ b/Base/res/html/misc/welcome.html
@@ -126,6 +126,7 @@
             <li><a href="fonts.html">Fonts</a></li>
             <li><a href="borders.html">Borders</a></li>
             <li><a href="border-radius.html">Border-Radius</a></li>
+            <li><a href="outline.html">Outlines</a></li>
             <li><a href="lists.html">Lists</a></li>
             <li><a href="flex.html">Flexboxes</a></li>
             <li><a href="flex-order.html">Flexbox order</a></li>

--- a/Userland/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Userland/Libraries/LibWeb/CSS/ComputedValues.h
@@ -108,6 +108,7 @@ public:
     static CSS::Time transition_delay() { return CSS::Time::make_seconds(0); }
     static CSS::ObjectFit object_fit() { return CSS::ObjectFit::Fill; }
     static Color outline_color() { return Color::Black; }
+    static CSS::Length outline_offset() { return CSS::Length::make_px(0); }
     static CSS::OutlineStyle outline_style() { return CSS::OutlineStyle::None; }
     static CSS::Length outline_width() { return CSS::Length::make_px(3); }
 };
@@ -328,6 +329,7 @@ public:
     CSS::Time transition_delay() const { return m_noninherited.transition_delay; }
 
     Color outline_color() const { return m_noninherited.outline_color; }
+    CSS::Length outline_offset() const { return m_noninherited.outline_offset; }
     CSS::OutlineStyle outline_style() const { return m_noninherited.outline_style; }
     CSS::Length outline_width() const { return m_noninherited.outline_width; }
 
@@ -442,6 +444,7 @@ protected:
         float stop_opacity { InitialValues::stop_opacity() };
         CSS::Time transition_delay { InitialValues::transition_delay() };
         Color outline_color { InitialValues::outline_color() };
+        CSS::Length outline_offset { InitialValues::outline_offset() };
         CSS::OutlineStyle outline_style { InitialValues::outline_style() };
         CSS::Length outline_width { InitialValues::outline_width() };
     } m_noninherited;
@@ -554,6 +557,7 @@ public:
     void set_stop_opacity(float value) { m_noninherited.stop_opacity = value; }
     void set_text_anchor(CSS::TextAnchor value) { m_inherited.text_anchor = value; }
     void set_outline_color(Color value) { m_noninherited.outline_color = value; }
+    void set_outline_offset(CSS::Length value) { m_noninherited.outline_offset = value; }
     void set_outline_style(CSS::OutlineStyle value) { m_noninherited.outline_style = value; }
     void set_outline_width(CSS::Length value) { m_noninherited.outline_width = value; }
 };

--- a/Userland/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Userland/Libraries/LibWeb/CSS/ComputedValues.h
@@ -107,6 +107,9 @@ public:
     static Vector<Vector<String>> grid_template_areas() { return {}; }
     static CSS::Time transition_delay() { return CSS::Time::make_seconds(0); }
     static CSS::ObjectFit object_fit() { return CSS::ObjectFit::Fill; }
+    static Color outline_color() { return Color::Black; }
+    static CSS::OutlineStyle outline_style() { return CSS::OutlineStyle::None; }
+    static CSS::Length outline_width() { return CSS::Length::make_px(3); }
 };
 
 enum class BackgroundSize {
@@ -324,6 +327,10 @@ public:
     CSS::FontVariant font_variant() const { return m_inherited.font_variant; }
     CSS::Time transition_delay() const { return m_noninherited.transition_delay; }
 
+    Color outline_color() const { return m_noninherited.outline_color; }
+    CSS::OutlineStyle outline_style() const { return m_noninherited.outline_style; }
+    CSS::Length outline_width() const { return m_noninherited.outline_width; }
+
     ComputedValues clone_inherited_values() const
     {
         ComputedValues clone;
@@ -434,6 +441,9 @@ protected:
         Gfx::Color stop_color { InitialValues::stop_color() };
         float stop_opacity { InitialValues::stop_opacity() };
         CSS::Time transition_delay { InitialValues::transition_delay() };
+        Color outline_color { InitialValues::outline_color() };
+        CSS::OutlineStyle outline_style { InitialValues::outline_style() };
+        CSS::Length outline_width { InitialValues::outline_width() };
     } m_noninherited;
 };
 
@@ -543,6 +553,9 @@ public:
     void set_stop_color(Color value) { m_noninherited.stop_color = value; }
     void set_stop_opacity(float value) { m_noninherited.stop_opacity = value; }
     void set_text_anchor(CSS::TextAnchor value) { m_inherited.text_anchor = value; }
+    void set_outline_color(Color value) { m_noninherited.outline_color = value; }
+    void set_outline_style(CSS::OutlineStyle value) { m_noninherited.outline_style = value; }
+    void set_outline_width(CSS::Length value) { m_noninherited.outline_width = value; }
 };
 
 }

--- a/Userland/Libraries/LibWeb/CSS/Enums.json
+++ b/Userland/Libraries/LibWeb/CSS/Enums.json
@@ -245,6 +245,18 @@
     "none",
     "scale-down"
   ],
+  "outline-style": [
+    "auto",
+    "none",
+    "dotted",
+    "dashed",
+    "solid",
+    "double",
+    "groove",
+    "ridge",
+    "inset",
+    "outset"
+  ],
   "overflow": [
     "auto",
     "clip",

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -485,6 +485,8 @@ Parser::ParseErrorOr<Selector::SimpleSelector> Parser::parse_pseudo_simple_selec
             return make_pseudo_class_selector(Selector::SimpleSelector::PseudoClass::Type::FirstOfType);
         if (pseudo_name.equals_ignoring_ascii_case("focus"sv))
             return make_pseudo_class_selector(Selector::SimpleSelector::PseudoClass::Type::Focus);
+        if (pseudo_name.equals_ignoring_ascii_case("focus-visible"sv))
+            return make_pseudo_class_selector(Selector::SimpleSelector::PseudoClass::Type::FocusVisible);
         if (pseudo_name.equals_ignoring_ascii_case("focus-within"sv))
             return make_pseudo_class_selector(Selector::SimpleSelector::PseudoClass::Type::FocusWithin);
         if (pseudo_name.equals_ignoring_ascii_case("hover"sv))

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -7576,12 +7576,7 @@ Parser::ParseErrorOr<NonnullRefPtr<StyleValue>> Parser::parse_css_value(Property
         auto stream = TokenStream { component_values };
         if (auto parsed_value = FIXME_TRY(parse_css_value_for_property(property_id, stream)))
             return parsed_value.release_nonnull();
-
-        return ParseError::SyntaxError;
-    }
-
-    // Multiple ComponentValues will usually produce multiple StyleValues, so make a StyleValueList.
-    {
+    } else {
         StyleValueVector parsed_values;
         auto stream = TokenStream { component_values };
         while (auto parsed_value = FIXME_TRY(parse_css_value_for_property(property_id, stream))) {

--- a/Userland/Libraries/LibWeb/CSS/Properties.json
+++ b/Userland/Libraries/LibWeb/CSS/Properties.json
@@ -1603,6 +1603,14 @@
       "color"
     ]
   },
+  "outline-offset": {
+    "affects-layout": false,
+    "inherited": false,
+    "initial": "0",
+    "valid-types": [
+      "length [-∞,∞]"
+    ]
+  },
   "outline-style": {
     "affects-layout": false,
     "inherited": false,

--- a/Userland/Libraries/LibWeb/CSS/Properties.json
+++ b/Userland/Libraries/LibWeb/CSS/Properties.json
@@ -1587,8 +1587,7 @@
   "outline": {
     "affects-layout": false,
     "inherited": false,
-    "__comment": "FIXME: Initial value is really `medium invert none` but we don't yet parse the outline shorthand.",
-    "initial": "none",
+    "initial": "medium currentColor none",
     "longhands": [
       "outline-color",
       "outline-style",
@@ -1598,12 +1597,10 @@
   "outline-color": {
     "affects-layout": false,
     "inherited": false,
-    "initial": "invert",
+    "__comment": "FIXME: We don't yet support `invert`. Until we do, the spec directs us to use `currentColor` as the default instead, and reject `invert`",
+    "initial": "currentColor",
     "valid-types": [
       "color"
-    ],
-    "valid-identifiers": [
-      "invert"
     ]
   },
   "outline-style": {
@@ -1611,7 +1608,7 @@
     "inherited": false,
     "initial": "none",
     "valid-types": [
-      "line-style"
+      "outline-style"
     ]
   },
   "outline-width": {

--- a/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
@@ -738,6 +738,8 @@ ErrorOr<RefPtr<StyleValue const>> ResolvedCSSStyleDeclaration::style_value_for_p
     }
     case PropertyID::OutlineColor:
         return ColorStyleValue::create(layout_node.computed_values().outline_color());
+    case PropertyID::OutlineOffset:
+        return LengthStyleValue::create(layout_node.computed_values().outline_offset());
     case PropertyID::OutlineStyle:
         return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().outline_style()));
     case PropertyID::OutlineWidth:

--- a/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
@@ -729,6 +729,19 @@ ErrorOr<RefPtr<StyleValue const>> ResolvedCSSStyleDeclaration::style_value_for_p
         return NumberStyleValue::create(layout_node.computed_values().opacity());
     case PropertyID::Order:
         return IntegerStyleValue::create(layout_node.computed_values().order());
+    case PropertyID::Outline: {
+        return StyleValueList::create(
+            { TRY(style_value_for_property(layout_node, PropertyID::OutlineColor)).release_nonnull(),
+                TRY(style_value_for_property(layout_node, PropertyID::OutlineStyle)).release_nonnull(),
+                TRY(style_value_for_property(layout_node, PropertyID::OutlineWidth)).release_nonnull() },
+            StyleValueList::Separator::Space);
+    }
+    case PropertyID::OutlineColor:
+        return ColorStyleValue::create(layout_node.computed_values().outline_color());
+    case PropertyID::OutlineStyle:
+        return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().outline_style()));
+    case PropertyID::OutlineWidth:
+        return LengthStyleValue::create(layout_node.computed_values().outline_width());
     case PropertyID::OverflowX:
         return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().overflow_x()));
     case PropertyID::OverflowY:

--- a/Userland/Libraries/LibWeb/CSS/Selector.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Selector.cpp
@@ -214,6 +214,7 @@ ErrorOr<String> Selector::SimpleSelector::serialize() const
         case Selector::SimpleSelector::PseudoClass::Type::Visited:
         case Selector::SimpleSelector::PseudoClass::Type::Hover:
         case Selector::SimpleSelector::PseudoClass::Type::Focus:
+        case Selector::SimpleSelector::PseudoClass::Type::FocusVisible:
         case Selector::SimpleSelector::PseudoClass::Type::FocusWithin:
         case Selector::SimpleSelector::PseudoClass::Type::FirstChild:
         case Selector::SimpleSelector::PseudoClass::Type::LastChild:

--- a/Userland/Libraries/LibWeb/CSS/Selector.h
+++ b/Userland/Libraries/LibWeb/CSS/Selector.h
@@ -90,6 +90,7 @@ public:
                 Visited,
                 Hover,
                 Focus,
+                FocusVisible,
                 FocusWithin,
                 FirstChild,
                 LastChild,
@@ -261,6 +262,8 @@ constexpr StringView pseudo_class_name(Selector::SimpleSelector::PseudoClass::Ty
         return "hover"sv;
     case Selector::SimpleSelector::PseudoClass::Type::Focus:
         return "focus"sv;
+    case Selector::SimpleSelector::PseudoClass::Type::FocusVisible:
+        return "focus-visible"sv;
     case Selector::SimpleSelector::PseudoClass::Type::FocusWithin:
         return "focus-within"sv;
     case Selector::SimpleSelector::PseudoClass::Type::FirstChild:

--- a/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
+++ b/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
@@ -217,6 +217,9 @@ static inline bool matches_pseudo_class(CSS::Selector::SimpleSelector::PseudoCla
         return matches_hover_pseudo_class(element);
     case CSS::Selector::SimpleSelector::PseudoClass::Type::Focus:
         return element.is_focused();
+    case CSS::Selector::SimpleSelector::PseudoClass::Type::FocusVisible:
+        // FIXME: We should only apply this when a visible focus is useful. Decide when that is!
+        return element.is_focused();
     case CSS::Selector::SimpleSelector::PseudoClass::Type::FocusWithin: {
         auto* focused_element = element.document().focused_element();
         return focused_element && element.is_inclusive_ancestor_of(*focused_element);

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -626,6 +626,12 @@ Optional<CSS::LineStyle> StyleProperties::line_style(CSS::PropertyID property_id
     return value_id_to_line_style(value->to_identifier());
 }
 
+Optional<CSS::OutlineStyle> StyleProperties::outline_style() const
+{
+    auto value = property(CSS::PropertyID::OutlineStyle);
+    return value_id_to_outline_style(value->to_identifier());
+}
+
 Optional<CSS::Float> StyleProperties::float_() const
 {
     auto value = property(CSS::PropertyID::Float);

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.h
@@ -68,6 +68,7 @@ public:
     Optional<CSS::Cursor> cursor() const;
     Optional<CSS::WhiteSpace> white_space() const;
     Optional<CSS::LineStyle> line_style(CSS::PropertyID) const;
+    Optional<CSS::OutlineStyle> outline_style() const;
     Vector<CSS::TextDecorationLine> text_decoration_line() const;
     Optional<CSS::TextDecorationStyle> text_decoration_style() const;
     Optional<CSS::TextTransform> text_transform() const;

--- a/Userland/Libraries/LibWeb/Dump.cpp
+++ b/Userland/Libraries/LibWeb/Dump.cpp
@@ -494,6 +494,9 @@ void dump_selector(StringBuilder& builder, CSS::Selector const& selector)
                 case CSS::Selector::SimpleSelector::PseudoClass::Type::Focus:
                     pseudo_class_description = "Focus";
                     break;
+                case CSS::Selector::SimpleSelector::PseudoClass::Type::FocusVisible:
+                    pseudo_class_description = "FocusVisible";
+                    break;
                 case CSS::Selector::SimpleSelector::PseudoClass::Type::FocusWithin:
                     pseudo_class_description = "FocusWithin";
                     break;

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -709,6 +709,8 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& computed_style)
 
     if (auto outline_color = computed_style.property(CSS::PropertyID::OutlineColor); outline_color->has_color())
         computed_values.set_outline_color(outline_color->to_color(*this));
+    if (auto outline_offset = computed_style.property(CSS::PropertyID::OutlineOffset); outline_offset->is_length())
+        computed_values.set_outline_offset(outline_offset->as_length().length());
     if (auto outline_style = computed_style.outline_style(); outline_style.has_value())
         computed_values.set_outline_style(outline_style.value());
     if (auto outline_width = computed_style.property(CSS::PropertyID::OutlineWidth); outline_width->is_length())

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -707,6 +707,13 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& computed_style)
     do_border_style(computed_values.border_right(), CSS::PropertyID::BorderRightWidth, CSS::PropertyID::BorderRightColor, CSS::PropertyID::BorderRightStyle);
     do_border_style(computed_values.border_bottom(), CSS::PropertyID::BorderBottomWidth, CSS::PropertyID::BorderBottomColor, CSS::PropertyID::BorderBottomStyle);
 
+    if (auto outline_color = computed_style.property(CSS::PropertyID::OutlineColor); outline_color->has_color())
+        computed_values.set_outline_color(outline_color->to_color(*this));
+    if (auto outline_style = computed_style.outline_style(); outline_style.has_value())
+        computed_values.set_outline_style(outline_style.value());
+    if (auto outline_width = computed_style.property(CSS::PropertyID::OutlineWidth); outline_width->is_length())
+        computed_values.set_outline_width(outline_width->as_length().length());
+
     computed_values.set_content(computed_style.content());
     computed_values.set_grid_auto_columns(computed_style.grid_auto_columns());
     computed_values.set_grid_auto_rows(computed_style.grid_auto_rows());

--- a/Userland/Libraries/LibWeb/Painting/BorderPainting.cpp
+++ b/Userland/Libraries/LibWeb/Painting/BorderPainting.cpp
@@ -127,10 +127,27 @@ void paint_border(PaintContext& context, BorderEdge edge, DevicePixelRect const&
     };
 
     auto gfx_line_style = Gfx::Painter::LineStyle::Solid;
-    if (border_style == CSS::LineStyle::Dotted)
+    switch (border_style) {
+    case CSS::LineStyle::None:
+    case CSS::LineStyle::Hidden:
+        return;
+    case CSS::LineStyle::Dotted:
         gfx_line_style = Gfx::Painter::LineStyle::Dotted;
-    if (border_style == CSS::LineStyle::Dashed)
+        break;
+    case CSS::LineStyle::Dashed:
         gfx_line_style = Gfx::Painter::LineStyle::Dashed;
+        break;
+    case CSS::LineStyle::Solid:
+        gfx_line_style = Gfx::Painter::LineStyle::Solid;
+        break;
+    case CSS::LineStyle::Double:
+    case CSS::LineStyle::Groove:
+    case CSS::LineStyle::Ridge:
+    case CSS::LineStyle::Inset:
+    case CSS::LineStyle::Outset:
+        // FIXME: Implement these
+        break;
+    }
 
     if (gfx_line_style != Gfx::Painter::LineStyle::Solid) {
         auto [p1, p2] = points_for_edge(edge, rect);

--- a/Userland/Libraries/LibWeb/Painting/BorderPainting.h
+++ b/Userland/Libraries/LibWeb/Painting/BorderPainting.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021-2023, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -55,6 +56,11 @@ struct BorderRadiiData {
         bottom_right.shrink(right, bottom);
         bottom_left.shrink(left, bottom);
     }
+
+    inline void inflate(CSSPixels top, CSSPixels right, CSSPixels bottom, CSSPixels left)
+    {
+        shrink(-top, -right, -bottom, -left);
+    }
 };
 
 BorderRadiiData normalized_border_radii_data(Layout::Node const&, CSSPixelRect const&, CSS::BorderRadiusData top_left_radius, CSS::BorderRadiusData top_right_radius, CSS::BorderRadiusData bottom_right_radius, CSS::BorderRadiusData bottom_left_radius);
@@ -71,6 +77,9 @@ struct BordersData {
     CSS::BorderData bottom;
     CSS::BorderData left;
 };
+
+// Returns OptionalNone if there is no outline to paint.
+Optional<BordersData> borders_data_for_outline(Layout::Node const&, Color outline_color, CSS::OutlineStyle outline_style, CSSPixels outline_width);
 
 RefPtr<Gfx::Bitmap> get_cached_corner_bitmap(DevicePixelSize corners_size);
 

--- a/Userland/Libraries/LibWeb/Painting/Paintable.h
+++ b/Userland/Libraries/LibWeb/Painting/Paintable.h
@@ -23,7 +23,7 @@ enum class PaintPhase {
     Background,
     Border,
     Foreground,
-    FocusOutline,
+    Outline,
     Overlay,
 };
 

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -217,7 +217,7 @@ void PaintableBox::paint(PaintContext& context, PaintPhase phase) const
         context.painter().draw_text(size_text_device_rect, size_text, font, Gfx::TextAlignment::Center, context.palette().color(Gfx::ColorRole::TooltipText));
     }
 
-    if (phase == PaintPhase::FocusOutline && layout_box().dom_node() && layout_box().dom_node()->is_element() && verify_cast<DOM::Element>(*layout_box().dom_node()).is_focused()) {
+    if (phase == PaintPhase::Outline && layout_box().dom_node() && layout_box().dom_node()->is_element() && verify_cast<DOM::Element>(*layout_box().dom_node()).is_focused()) {
         // FIXME: Implement this as `outline` using :focus-visible in the default UA stylesheet to make it possible to override/disable.
         auto focus_outline_rect = context.enclosing_device_rect(absolute_border_box_rect()).inflated(4, 4);
         context.painter().draw_focus_rect(focus_outline_rect.to_type<int>(), context.palette().focus_outline());
@@ -641,7 +641,7 @@ void PaintableWithLines::paint(PaintContext& context, PaintPhase phase) const
     }
 
     // FIXME: Merge this loop with the above somehow..
-    if (phase == PaintPhase::FocusOutline) {
+    if (phase == PaintPhase::Outline) {
         for (auto& line_box : m_line_boxes) {
             for (auto& fragment : line_box.fragments()) {
                 auto* node = fragment.layout_node().dom_node();

--- a/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -125,7 +125,7 @@ void StackingContext::paint_descendants(PaintContext& context, Layout::Node cons
             break;
         case StackingContextPaintPhase::FocusAndOverlay:
             if (context.has_focus()) {
-                paint_node(child, context, PaintPhase::FocusOutline);
+                paint_node(child, context, PaintPhase::Outline);
             }
             paint_node(child, context, PaintPhase::Overlay);
             paint_descendants(context, child, phase);
@@ -213,7 +213,7 @@ void StackingContext::paint_internal(PaintContext& context) const
         paint_descendants(context, layout_node, StackingContextPaintPhase::BackgroundAndBordersForInlineLevelAndReplaced);
         paint_node(layout_node, context, PaintPhase::Foreground);
         paint_descendants(context, layout_node, StackingContextPaintPhase::Foreground);
-        paint_node(layout_node, context, PaintPhase::FocusOutline);
+        paint_node(layout_node, context, PaintPhase::Outline);
         paint_node(layout_node, context, PaintPhase::Overlay);
         paint_descendants(context, layout_node, StackingContextPaintPhase::FocusAndOverlay);
         if (parent_paintable)
@@ -230,7 +230,7 @@ void StackingContext::paint_internal(PaintContext& context) const
             paint_child(child);
     }
 
-    paint_node(m_box, context, PaintPhase::FocusOutline);
+    paint_node(m_box, context, PaintPhase::Outline);
     paint_node(m_box, context, PaintPhase::Overlay);
     paint_descendants(context, m_box, StackingContextPaintPhase::FocusAndOverlay);
 }

--- a/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -124,9 +124,7 @@ void StackingContext::paint_descendants(PaintContext& context, Layout::Node cons
             paint_descendants(context, child, phase);
             break;
         case StackingContextPaintPhase::FocusAndOverlay:
-            if (context.has_focus()) {
-                paint_node(child, context, PaintPhase::Outline);
-            }
+            paint_node(child, context, PaintPhase::Outline);
             paint_node(child, context, PaintPhase::Overlay);
             paint_descendants(context, child, phase);
             break;


### PR DESCRIPTION
Chrome on the left, Ladybird on the right:
![image](https://github.com/SerenityOS/serenity/assets/222642/8cfb9d73-736c-4eec-8a3a-00bc57c0e304)

Chrome on the left, Ladybird on the right:
![image](https://github.com/SerenityOS/serenity/assets/222642/42d80566-ba02-4c51-80ce-158d9b55b330)
(They're really showing off with that waviness on the green outline!)