### PR TITLE
Ports/stb: Create `/usr/local/include` if it doesn't exist

### DIFF
--- a/Ports/stb/package.sh
+++ b/Ports/stb/package.sh
@@ -8,5 +8,7 @@ build() {
 }
 
 install() {
-    run cp -r "./" "${SERENITY_INSTALL_ROOT}/usr/local/include/"
+    target_dir="${SERENITY_INSTALL_ROOT}/usr/local/include/"
+    run_nocd mkdir -p "${target_dir}"
+    run cp -r "./" "${target_dir}"
 }


### PR DESCRIPTION
Previously, the `stb` port would not build from a clean state, as this directory does not exist by default.
