### PR TITLE
Ports/potrace: Add zlib dependency

### DIFF
--- a/Ports/potrace/package.sh
+++ b/Ports/potrace/package.sh
@@ -8,3 +8,6 @@ files="https://potrace.sourceforge.net/download/${version}/potrace-${version}.ta
 configopts=(
     "--with-libpotrace"
 )
+depends=(
+    'zlib'
+)


### PR DESCRIPTION
This allows the `potrace` port to build from a clean state.