### PR TITLE
Ports/sqlite: Add zlib dependency

### DIFF
--- a/Ports/sqlite/package.sh
+++ b/Ports/sqlite/package.sh
@@ -5,3 +5,4 @@ files="https://www.sqlite.org/2023/sqlite-autoconf-${version}.tar.gz sqlite-auto
 useconfigure='true'
 use_fresh_config_sub='true'
 workdir="sqlite-autoconf-${version}"
+depends=('zlib')


### PR DESCRIPTION
This allows the `sqlite` port to build from a clean state.