### PR TITLE
Ladybird: Use AK::Url rather than prefix list to check if URL is valid

### DIFF
--- a/Ladybird/Tab.cpp
+++ b/Ladybird/Tab.cpp
@@ -513,14 +513,15 @@ void Tab::focus_location_editor()
     m_location_edit->selectAll();
 }
 
-void Tab::navigate(QString url, LoadType load_type)
+void Tab::navigate(QString url_qstring, LoadType load_type)
 {
-    if (url.startsWith("/"))
-        url = "file://" + url;
-    else if (!url.startsWith("http://", Qt::CaseInsensitive) && !url.startsWith("https://", Qt::CaseInsensitive) && !url.startsWith("file://", Qt::CaseInsensitive) && !url.startsWith("about:", Qt::CaseInsensitive) && !url.startsWith("data:", Qt::CaseInsensitive))
-        url = "https://" + url;
+    auto url_string = ak_deprecated_string_from_qstring(url_qstring);
+    if (url_string.starts_with('/'))
+        url_string = DeprecatedString::formatted("file://{}", url_string);
+    else if (URL url = url_string; !url.is_valid())
+        url_string = DeprecatedString::formatted("https://{}", url_string);
     m_is_history_navigation = (load_type == LoadType::HistoryNavigation);
-    view().load(ak_deprecated_string_from_qstring(url));
+    view().load(url_string);
 }
 
 void Tab::back()


### PR DESCRIPTION
If a URL is not valid we try navigating to https:// + the url. It's better to ask AK::Url if it thinks the url is valid than put a big list of prefixes here, with this obscure protocols like Gemini are now recognised and with `--enable-lagom-networking` can be viewed in Ladybird (thanks to #2218).

[gemini://mozz.us](https://gemini.circumlunar.space/x/mozz.us) in Ladybird (which happened to be the first site we have a cipher suite implemented for :smile:):
![Screenshot from 2023-08-02 22-27-05](https://github.com/SerenityOS/serenity/assets/11597044/99bd890d-6d36-4b95-834e-90fb7b87e108)
