### PR TITLE
Meta: Port GCC compile option from cmake to gn

### DIFF
--- a/Meta/gn/build/BUILD.gn
+++ b/Meta/gn/build/BUILD.gn
@@ -111,6 +111,8 @@ config("compiler_defaults") {
       # instead) on clang<=3.8. Clang also has a -Wredundant-move, but it
       # only fires when the types match exactly, so we can keep it here.
       "-Wno-redundant-move",
+
+      "-Wno-literal-suffix",
     ]
   }
 


### PR DESCRIPTION
The GCC build is extremely noisy without -Wno-literal-suffix. (Tested on GCC12)