### PR TITLE
LibWeb: Improve HTMLCanvasElement.toDataUrl(), implement .toBlob(), and support encoding to JPEG

### DIFF
--- a/Meta/gn/secondary/Userland/Libraries/LibGfx/BUILD.gn
+++ b/Meta/gn/secondary/Userland/Libraries/LibGfx/BUILD.gn
@@ -43,6 +43,7 @@ shared_library("LibGfx") {
     "ImageFormats/ICOLoader.cpp",
     "ImageFormats/ImageDecoder.cpp",
     "ImageFormats/JPEGLoader.cpp",
+    "ImageFormats/JPEGWriter.cpp",
     "ImageFormats/JPEGXLLoader.cpp",
     "ImageFormats/PBMLoader.cpp",
     "ImageFormats/PGMLoader.cpp",

--- a/Userland/Libraries/LibWeb/HTML/EventLoop/Task.h
+++ b/Userland/Libraries/LibWeb/HTML/EventLoop/Task.h
@@ -44,6 +44,9 @@ public:
         // Some elements, such as the HTMLMediaElement, must have a unique task source per instance.
         // Keep this field last, to serve as the base value of all unique task sources.
         UniqueTaskSourceStart,
+
+        // https://html.spec.whatwg.org/multipage/canvas.html#canvas-blob-serialisation-task-source
+        CanvasBlobSerializationTask,
     };
 
     static NonnullOwnPtr<Task> create(Source source, DOM::Document const* document, JS::SafeFunction<void()> steps)

--- a/Userland/Libraries/LibWeb/HTML/HTMLCanvasElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLCanvasElement.h
@@ -34,6 +34,7 @@ public:
     WebIDL::ExceptionOr<void> set_height(unsigned);
 
     DeprecatedString to_data_url(DeprecatedString const& type, Optional<double> quality) const;
+    WebIDL::ExceptionOr<void> to_blob(JS::NonnullGCPtr<WebIDL::CallbackType> callback, DeprecatedString const& type, Optional<double> quality);
 
     void present();
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLCanvasElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLCanvasElement.idl
@@ -15,5 +15,7 @@ interface HTMLCanvasElement : HTMLElement {
     [CEReactions] attribute unsigned long height;
 
     USVString toDataURL(optional DOMString type = "image/png", optional double quality);
-
+    undefined toBlob(BlobCallback _callback, optional DOMString type = "image/png", optional double quality);
 };
+
+callback BlobCallback = undefined (Blob? blob);


### PR DESCRIPTION
- **LibWeb: Implement HTMLCanvasElement.toDataUrl() closer to spec**

  - Requesting an unsupported image type will now fallback to PNG,
  - Errors should return 'data:,' instead of empty string,
  - Added spec comments

- **LibWeb: Implement HTMLCanvasElement.toBlob()**
- **LibWeb: Add support for encoding Canvas to JPEG**
- **Meta: Add ImageFormats/JPEGWriter.cpp to gn build**