### PR TITLE
LibWeb: Add Canvas Context2D basic text align and text baseline support

### DIFF
--- a/Base/res/html/misc/canvas-text.html
+++ b/Base/res/html/misc/canvas-text.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Canvas Text Examples</title>
+</head>
+<body>
+
+<h1>Canvas Text Examples</h1>
+
+<em>Canvas text-align</em><br>
+<canvas id="canvas0" style="border: 1px solid black;"></canvas><br><br>
+
+<script>
+(function () {
+    const canvas = document.getElementById('canvas0');
+    const ctx = canvas.getContext('2d');
+
+    ctx.strokeStyle = 'red';
+    ctx.beginPath();
+    ctx.moveTo(canvas.width / 2, 0);
+    ctx.lineTo(canvas.width / 2, canvas.height);
+    ctx.stroke();
+
+    ctx.font = '16px sans-serif';
+    ctx.textBaseline = 'top';
+
+    const alignments = ['left', 'center', 'right', 'start', 'end'];
+    let y = 8;
+    for (const alignment of alignments) {
+        ctx.textAlign = alignment;
+        ctx.fillText(`Text align: ${alignment}`, canvas.width / 2, y);
+        y += 16 + 8;
+    }
+})();
+</script>
+
+<em>Canvas text-baseline</em><br>
+<canvas id="canvas1" width="1000" style="border: 1px solid black;"></canvas><br><br>
+
+<script>
+(function () {
+    const canvas = document.getElementById('canvas1');
+    const ctx = canvas.getContext('2d');
+
+    ctx.strokeStyle = 'red';
+    ctx.beginPath();
+    ctx.moveTo(0, canvas.height / 2);
+    ctx.lineTo(canvas.width, canvas.height / 2);
+    ctx.stroke();
+
+    ctx.font = '12px sans-serif';
+    ctx.textAlign = 'left';
+
+    const baselines = ['top', 'hanging', 'middle', 'alphabetic', 'ideographic', 'bottom'];
+    let x = 8;
+    for (const baseline of baselines) {
+        ctx.textBaseline = baseline;
+        ctx.fillText(`Baseline: ${baseline}`, x, canvas.height / 2);
+        x += canvas.width / baselines.length;
+    }
+})();
+</script>
+
+</body>
+</html>

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -36,6 +36,8 @@ class OptionConstructor;
 enum class AudioContextLatencyCategory;
 enum class CanPlayTypeResult;
 enum class CanvasFillRule;
+enum class CanvasTextAlign;
+enum class CanvasTextBaseline;
 enum class DOMParserSupportedType;
 enum class EndingType;
 enum class ImageSmoothingQuality;

--- a/Userland/Libraries/LibWeb/HTML/Canvas/CanvasPathDrawingStyles.idl
+++ b/Userland/Libraries/LibWeb/HTML/Canvas/CanvasPathDrawingStyles.idl
@@ -1,13 +1,6 @@
 // https://html.spec.whatwg.org/multipage/canvas.html#canvaslinecap
 enum CanvasLineCap { "butt", "round", "square" };
 enum CanvasLineJoin { "round", "bevel", "miter" };
-enum CanvasTextAlign { "start", "end", "left", "right", "center" };
-enum CanvasTextBaseline { "top", "hanging", "middle", "alphabetic", "ideographic", "bottom" };
-enum CanvasDirection { "ltr", "rtl", "inherit" };
-enum CanvasFontKerning { "auto", "normal", "none" };
-enum CanvasFontStretch { "ultra-condensed", "extra-condensed", "condensed", "semi-condensed", "normal", "semi-expanded", "expanded", "extra-expanded", "ultra-expanded" };
-enum CanvasFontVariantCaps { "normal", "small-caps", "all-small-caps", "petite-caps", "all-petite-caps", "unicase", "titling-caps" };
-enum CanvasTextRendering { "auto", "optimizeSpeed", "optimizeLegibility", "geometricPrecision" };
 
 // https://html.spec.whatwg.org/multipage/canvas.html#canvaspathdrawingstyles
 interface mixin CanvasPathDrawingStyles {

--- a/Userland/Libraries/LibWeb/HTML/Canvas/CanvasState.h
+++ b/Userland/Libraries/LibWeb/HTML/Canvas/CanvasState.h
@@ -80,6 +80,8 @@ public:
         Bindings::ImageSmoothingQuality image_smoothing_quality { Bindings::ImageSmoothingQuality::Low };
         float global_alpha = { 1 };
         Optional<CanvasClip> clip;
+        Bindings::CanvasTextAlign text_align { Bindings::CanvasTextAlign::Start };
+        Bindings::CanvasTextBaseline text_baseline { Bindings::CanvasTextBaseline::Alphabetic };
     };
     DrawingState& drawing_state() { return m_drawing_state; }
     DrawingState const& drawing_state() const { return m_drawing_state; }

--- a/Userland/Libraries/LibWeb/HTML/Canvas/CanvasTextDrawingStyles.h
+++ b/Userland/Libraries/LibWeb/HTML/Canvas/CanvasTextDrawingStyles.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2023, Bastiaan van der Plaat <bastiaan.v.d.plaat@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibWeb/HTML/Canvas/CanvasState.h>
+
+namespace Web::HTML {
+
+// https://html.spec.whatwg.org/multipage/canvas.html#canvastextdrawingstyles
+template<typename IncludingClass>
+class CanvasTextDrawingStyles {
+public:
+    ~CanvasTextDrawingStyles() = default;
+
+    void set_text_align(Bindings::CanvasTextAlign text_align) { my_drawing_state().text_align = text_align; }
+    Bindings::CanvasTextAlign text_align() const { return my_drawing_state().text_align; }
+
+    void set_text_baseline(Bindings::CanvasTextBaseline text_baseline) { my_drawing_state().text_baseline = text_baseline; }
+    Bindings::CanvasTextBaseline text_baseline() const { return my_drawing_state().text_baseline; }
+
+protected:
+    CanvasTextDrawingStyles() = default;
+
+private:
+    CanvasState::DrawingState& my_drawing_state() { return reinterpret_cast<IncludingClass&>(*this).drawing_state(); }
+    CanvasState::DrawingState const& my_drawing_state() const { return reinterpret_cast<IncludingClass const&>(*this).drawing_state(); }
+};
+
+}

--- a/Userland/Libraries/LibWeb/HTML/Canvas/CanvasTextDrawingStyles.idl
+++ b/Userland/Libraries/LibWeb/HTML/Canvas/CanvasTextDrawingStyles.idl
@@ -1,0 +1,22 @@
+// https://html.spec.whatwg.org/multipage/canvas.html#canvastextalign
+// enum CanvasTextAlign { "start", "end", "left", "right", "center" };
+// enum CanvasTextBaseline { "top", "hanging", "middle", "alphabetic", "ideographic", "bottom" };
+enum CanvasDirection { "ltr", "rtl", "inherit" };
+enum CanvasFontKerning { "auto", "normal", "none" };
+enum CanvasFontStretch { "ultra-condensed", "extra-condensed", "condensed", "semi-condensed", "normal", "semi-expanded", "expanded", "extra-expanded", "ultra-expanded" };
+enum CanvasFontVariantCaps { "normal", "small-caps", "all-small-caps", "petite-caps", "all-petite-caps", "unicase", "titling-caps" };
+enum CanvasTextRendering { "auto", "optimizeSpeed", "optimizeLegibility", "geometricPrecision" };
+
+// https://html.spec.whatwg.org/multipage/canvas.html#canvastextdrawingstyles
+interface mixin CanvasTextDrawingStyles {
+    // FIXME: attribute DOMString font; // (default 10px sans-serif)
+    attribute CanvasTextAlign textAlign; // (default: "start")
+    attribute CanvasTextBaseline textBaseline; // (default: "alphabetic")
+    // FIXME: attribute CanvasDirection direction; // (default: "inherit")
+    // FIXME: attribute DOMString letterSpacing; // (default: "0px")
+    // FIXME: attribute CanvasFontKerning fontKerning; // (default: "auto")
+    // FIXME: attribute CanvasFontStretch fontStretch; // (default: "normal")
+    // FIXME: attribute CanvasFontVariantCaps fontVariantCaps; // (default: "normal")
+    // FIXME: attribute CanvasTextRendering textRendering; // (default: "auto")
+    // FIXME: attribute DOMString wordSpacing; // (default: "0px")
+};

--- a/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.h
+++ b/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.h
@@ -28,6 +28,7 @@
 #include <LibWeb/HTML/Canvas/CanvasRect.h>
 #include <LibWeb/HTML/Canvas/CanvasState.h>
 #include <LibWeb/HTML/Canvas/CanvasText.h>
+#include <LibWeb/HTML/Canvas/CanvasTextDrawingStyles.h>
 #include <LibWeb/HTML/Canvas/CanvasTransform.h>
 #include <LibWeb/HTML/CanvasGradient.h>
 #include <LibWeb/Layout/InlineNode.h>
@@ -53,7 +54,8 @@ class CanvasRenderingContext2D
     , public CanvasImageData
     , public CanvasImageSmoothing
     , public CanvasCompositing
-    , public CanvasPathDrawingStyles<CanvasRenderingContext2D> {
+    , public CanvasPathDrawingStyles<CanvasRenderingContext2D>
+    , public CanvasTextDrawingStyles<CanvasRenderingContext2D> {
 
     WEB_PLATFORM_OBJECT(CanvasRenderingContext2D, Bindings::PlatformObject);
 

--- a/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.idl
+++ b/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.idl
@@ -7,12 +7,17 @@
 #import <HTML/Canvas/CanvasImageSmoothing.idl>
 #import <HTML/Canvas/CanvasPath.idl>
 #import <HTML/Canvas/CanvasPathDrawingStyles.idl>
+#import <HTML/Canvas/CanvasTextDrawingStyles.idl>
 #import <HTML/Canvas/CanvasRect.idl>
 #import <HTML/Canvas/CanvasState.idl>
 #import <HTML/Canvas/CanvasText.idl>
 #import <HTML/Canvas/CanvasTransform.idl>
 
 enum ImageSmoothingQuality { "low", "medium", "high" };
+
+// FIXME: This should be in CanvasTextDrawingStyles.idl but then it is not exported
+enum CanvasTextAlign { "start", "end", "left", "right", "center" };
+enum CanvasTextBaseline { "top", "hanging", "middle", "alphabetic", "ideographic", "bottom" };
 
 // https://html.spec.whatwg.org/multipage/canvas.html#canvasrenderingcontext2d
 [Exposed=Window]
@@ -34,5 +39,5 @@ CanvasRenderingContext2D includes CanvasText;
 CanvasRenderingContext2D includes CanvasDrawImage;
 CanvasRenderingContext2D includes CanvasImageData;
 CanvasRenderingContext2D includes CanvasPathDrawingStyles;
-// FIXME: CanvasRenderingContext2D includes CanvasTextDrawingStyles;
+CanvasRenderingContext2D includes CanvasTextDrawingStyles;
 CanvasRenderingContext2D includes CanvasPath;


### PR DESCRIPTION
I have added basic support for the Canvas Context2D text rendering text alignment and text baseline. I'm not really super familiar with the LibWeb source code yet but I did my best ;)

The only issue I have is that when I put the enum `CanvasTextAlign` in `CanvasTextDrawingStyles.idl` I can't use it or include it in C++, but for now I have put it in `CanvasRenderingContext2D.idl` like `ImageSmoothingQuality`.

I have only implemented top, middle and bottom for text baseline because to my knowledge the `draw_text` function in LibGfx doesn't support precise baseline positioning at the moment.

Right now only the `ctx.fillText()` function uses these new values we need to expand that in the future.

Before:
<img width="1019" alt="Screenshot 2023-08-03 at 16 58 56" src="https://github.com/SerenityOS/serenity/assets/19894029/252b768b-3b6e-4f36-8848-9db36647c32d">

After:
<img width="1030" alt="Screenshot 2023-08-03 at 16 37 59" src="https://github.com/SerenityOS/serenity/assets/19894029/f5afa0e0-d1a5-42ab-bfa1-eac8afd86a0e">


I'm looking forward to your feedback