### PR TITLE
LibWeb: Propagate overflow modes from <html> or <body> to viewport

### DIFF
--- a/Tests/LibWeb/Layout/expected/abspos-box-with-replaced-element.txt
+++ b/Tests/LibWeb/Layout/expected/abspos-box-with-replaced-element.txt
@@ -5,3 +5,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         line 0 width: 250, height: 25.25, bottom: 25.25, baseline: 25.25
           frag 0 from ImageBox start: 0, length: 0, rect: [262,12 248x23.25]
         ImageBox <img> at (262,12) content-size 248x23.25 children: not-inline
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x2] overflow: [9,9 502x102]
+    PaintableWithLines (BlockContainer<BODY>) [9,9 502x102]
+      PaintableWithLines (BlockContainer<DIV>.image-container) [260,10 250x27.25] overflow: [261,11 249x25.25]
+        ImagePaintable (ImageBox<IMG>) [261,11 250x25.25]

--- a/Tests/LibWeb/Layout/expected/abspos-flex-container-with-auto-height.txt
+++ b/Tests/LibWeb/Layout/expected/abspos-flex-container-with-auto-height.txt
@@ -6,3 +6,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           frag 0 from TextNode start: 0, length: 60, rect: [10,10 510.859375x17.46875]
             "Diese Website nutzt Cookies und vergleichbare Funktionen zur"
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x2] overflow: [8,8 514.859375x21.46875]
+    PaintableBox (Box<BODY>) [8,8 514.859375x21.46875]
+      PaintableWithLines (BlockContainer<DIV>) [9,9 512.859375x19.46875]
+        TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/abspos-image-with-min-height-constraint.txt
+++ b/Tests/LibWeb/Layout/expected/abspos-image-with-min-height-constraint.txt
@@ -2,3 +2,8 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x16 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x0 children: not-inline
       ImageBox <img#zero-dimensions-but-min-percentages> at (8,8) content-size 800x600 positioned children: not-inline
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600] overflow: [0,0 808x608]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x16] overflow: [0,0 808x608]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x0] overflow: [8,8 800x600]
+      ImagePaintable (ImageBox<IMG>#zero-dimensions-but-min-percentages) [8,8 800x600]

--- a/Tests/LibWeb/Layout/expected/abspos-not-replaced-multiple-auto-variants.txt
+++ b/Tests/LibWeb/Layout/expected/abspos-not-replaced-multiple-auto-variants.txt
@@ -8,3 +8,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       TextNode <#text>
       BlockContainer <div.both> at (11,11) content-size 10x10 positioned [BFC] children: not-inline
       TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x602]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x602]
+    PaintableWithLines (BlockContainer<BODY>) [9,9 782x2]
+      PaintableWithLines (BlockContainer<DIV>.only-t-l) [5,5 12x12]
+      PaintableWithLines (BlockContainer<DIV>.only-mt-ml) [15,15 12x12]
+      PaintableWithLines (BlockContainer<DIV>.both) [10,10 12x12]

--- a/Tests/LibWeb/Layout/expected/abspos-with-percentage-insets.txt
+++ b/Tests/LibWeb/Layout/expected/abspos-with-percentage-insets.txt
@@ -12,3 +12,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             "two"
         TextNode <#text>
       TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x2] overflow: [9,9 502x402]
+    PaintableWithLines (BlockContainer<BODY>) [9,9 502x402]
+      PaintableWithLines (BlockContainer<DIV>.one) [310,210 30.6875x19.46875]
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer<DIV>.two) [329.5625,350.53125 30.4375x19.46875]
+        TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/acid1.txt
+++ b/Tests/LibWeb/Layout/expected/acid1.txt
@@ -133,3 +133,52 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
       BlockContainer <(anonymous)> at (20,399.921875) content-size 480x0 children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x419.921875]
+    PaintableWithLines (BlockContainer(anonymous)) [0,0 800x0]
+    PaintableWithLines (BlockContainer<BODY>) [15,15 490x389.921875]
+      PaintableWithLines (BlockContainer(anonymous)) [20,20 480x0]
+      PaintableWithLines (BlockContainer<DL>) [20,20 480x10]
+        PaintableWithLines (BlockContainer<DT>) [25,25 79.984375x310]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DD>) [115,25 380x310]
+          PaintableWithLines (BlockContainer(anonymous)) [135,45 340x0]
+          PaintableWithLines (BlockContainer<UL>) [135,45 340x0]
+            PaintableWithLines (BlockContainer<LI>) [135,45 80x120]
+              TextPaintable (TextNode<#text>)
+            PaintableWithLines (BlockContainer<LI>#bar) [225,45 159.96875x110]
+              PaintableWithLines (BlockContainer(anonymous)) [235,55 139.96875x0]
+              PaintableWithLines (BlockContainer<P>) [235,55 139.96875x10]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer(anonymous)) [235,65 139.96875x0]
+                InlinePaintable (InlineNode<FORM>)
+              PaintableWithLines (BlockContainer<P>) [235,65 139.96875x18.984375]
+                TextPaintable (TextNode<#text>)
+                RadioButtonPaintable (RadioButton<INPUT>) [262.484375,65.46875 12x12]
+              PaintableWithLines (BlockContainer<P>) [235,83.984375 139.96875x18.984375]
+                TextPaintable (TextNode<#text>)
+                RadioButtonPaintable (RadioButton<INPUT>) [280.15625,84.453125 12x12]
+              PaintableWithLines (BlockContainer(anonymous)) [235,102.96875 139.96875x0]
+            PaintableWithLines (BlockContainer<LI>) [394.96875,45 80x120]
+              TextPaintable (TextNode<#text>)
+            PaintableWithLines (BlockContainer<LI>#baz) [135,175 120x120]
+              TextPaintable (TextNode<#text>)
+          PaintableWithLines (BlockContainer(anonymous)) [135,45 340x0]
+            PaintableWithLines (BlockContainer<BLOCKQUOTE>) [275,175 70x140]
+              PaintableWithLines (BlockContainer(anonymous)) [280,195 50x0]
+              PaintableWithLines (BlockContainer<ADDRESS>) [280,195 50x20]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer(anonymous)) [280,215 50x0]
+            PaintableWithLines (BlockContainer<H1>) [355,175 120x120]
+              TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [20,30 480x0]
+      PaintableWithLines (BlockContainer<P>) [20,335 480x64.921875]
+        TextPaintable (TextNode<#text>)
+        InlinePaintable (InlineNode<A>)
+          TextPaintable (TextNode<#text>)
+        TextPaintable (TextNode<#text>)
+        InlinePaintable (InlineNode<A>)
+          TextPaintable (TextNode<#text>)
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [20,399.921875 480x0]

--- a/Tests/LibWeb/Layout/expected/anonymous-wrappers-continue-to-inherit-style-after-change.txt
+++ b/Tests/LibWeb/Layout/expected/anonymous-wrappers-continue-to-inherit-style-after-change.txt
@@ -11,3 +11,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           frag 0 from TextNode start: 0, length: 24, rect: [8,77.8125 212.125x17.46875]
             "anonymously wrapped text"
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x89.84375] overflow: [0,0 800x95.28125]
+    PaintableWithLines (BlockContainer<BODY>) [8,21.4375 784x73.84375]
+      PaintableWithLines (BlockContainer<H1>) [8,21.4375 784x34.9375]
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,77.8125 784x17.46875]
+        TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/aspect-ratio-auto-and-ratio.txt
+++ b/Tests/LibWeb/Layout/expected/aspect-ratio-auto-and-ratio.txt
@@ -7,3 +7,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           frag 0 from ImageBox start: 0, length: 0, rect: [9,111 200x200]
         ImageBox <img> at (9,111) content-size 200x200 children: not-inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x320]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x304]
+      PaintableWithLines (BlockContainer<DIV>) [8,8 202x102]
+      PaintableWithLines (BlockContainer(anonymous)) [8,110 784x202]
+        ImagePaintable (ImageBox<IMG>) [8,110 202x202]

--- a/Tests/LibWeb/Layout/expected/aspect-ratio-auto.txt
+++ b/Tests/LibWeb/Layout/expected/aspect-ratio-auto.txt
@@ -7,3 +7,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           frag 0 from ImageBox start: 0, length: 0, rect: [9,11 200x200]
         ImageBox <img> at (9,11) content-size 200x200 children: not-inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x220]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x204]
+      PaintableWithLines (BlockContainer<DIV>) [8,8 202x2]
+      PaintableWithLines (BlockContainer(anonymous)) [8,10 784x202]
+        ImagePaintable (ImageBox<IMG>) [8,10 202x202]

--- a/Tests/LibWeb/Layout/expected/aspect-ratio-ratio.txt
+++ b/Tests/LibWeb/Layout/expected/aspect-ratio-ratio.txt
@@ -7,3 +7,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           frag 0 from ImageBox start: 0, length: 0, rect: [9,111 200x100]
         ImageBox <img> at (9,111) content-size 200x100 children: not-inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x220]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x204]
+      PaintableWithLines (BlockContainer<DIV>) [8,8 202x102]
+      PaintableWithLines (BlockContainer(anonymous)) [8,110 784x102]
+        ImagePaintable (ImageBox<IMG>) [8,110 202x102]

--- a/Tests/LibWeb/Layout/expected/automatic-height-of-non-replaced-abspos-element-must-not-be-negative.txt
+++ b/Tests/LibWeb/Layout/expected/automatic-height-of-non-replaced-abspos-element-must-not-be-negative.txt
@@ -3,3 +3,8 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body.outer> at (8,8) content-size 0x0 positioned [BFC] children: not-inline
       BlockContainer <div.inner> at (9,9) content-size 0x0 positioned [BFC] children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x0] overflow: [8,8 2x2]
+    PaintableWithLines (BlockContainer<BODY>.outer) [8,8 0x0] overflow: [8,8 2x2]
+      PaintableWithLines (BlockContainer<DIV>.inner) [8,8 2x2]

--- a/Tests/LibWeb/Layout/expected/automatic-width-of-non-replaced-abspos-element-must-not-be-negative.txt
+++ b/Tests/LibWeb/Layout/expected/automatic-width-of-non-replaced-abspos-element-must-not-be-negative.txt
@@ -2,3 +2,8 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x0 [BFC] children: not-inline
     BlockContainer <body.outer> at (8,8) content-size 0x0 positioned [BFC] children: not-inline
       BlockContainer <div.inner> at (9,9) content-size 0x0 positioned [BFC] children: not-inline
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x0] overflow: [8,8 2x2]
+    PaintableWithLines (BlockContainer<BODY>.outer) [8,8 0x0] overflow: [8,8 2x2]
+      PaintableWithLines (BlockContainer<DIV>.inner) [8,8 2x2]

--- a/Tests/LibWeb/Layout/expected/blank.txt
+++ b/Tests/LibWeb/Layout/expected/blank.txt
@@ -4,3 +4,8 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       TextNode <#text>
     BlockContainer <body> at (8,8) content-size 784x0 children: inline
       TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x16]
+    PaintableWithLines (BlockContainer(anonymous)) [0,0 800x0]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x0]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/abspos-with-auto-margins-in-inline-axis.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/abspos-with-auto-margins-in-inline-axis.txt
@@ -4,3 +4,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <div#foo> at (350,1) content-size 100x100 positioned [BFC] children: not-inline
       BlockContainer <div#bar> at (699,101) content-size 100x100 positioned [BFC] children: not-inline
       BlockContainer <div#baz> at (1,201) content-size 100x100 positioned [BFC] children: not-inline
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x20] overflow: [0,0 800x302]
+    PaintableWithLines (BlockContainer<BODY>) [9,9 782x2] overflow: [0,0 800x302]
+      PaintableWithLines (BlockContainer<DIV>#foo) [349,0 102x102]
+      PaintableWithLines (BlockContainer<DIV>#bar) [698,100 102x102]
+      PaintableWithLines (BlockContainer<DIV>#baz) [0,200 102x102]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/abspos-with-percentage-height-resolved-against-padding-box-of-containing-block.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/abspos-with-percentage-height-resolved-against-padding-box-of-containing-block.txt
@@ -2,3 +2,8 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x256 [BFC] children: not-inline
     BlockContainer <body> at (8,248) content-size 784x0 positioned children: not-inline
       BlockContainer <div.abspos> at (8,8) content-size 784x240 positioned [BFC] children: not-inline
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x256]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x240]
+      PaintableWithLines (BlockContainer<DIV>.abspos) [8,8 784x240]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/atomic-inline-with-percentage-vertical-align.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/atomic-inline-with-percentage-vertical-align.txt
@@ -8,3 +8,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <div.clump> at (4,3) content-size 30x30 inline-block [BFC] children: not-inline
       BreakNode <br>
       BlockContainer <div.clump> at (3,35) content-size 30x30 inline-block [BFC] children: not-inline
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x64.515625] overflow: [1,1 798x64]
+    PaintableWithLines (BlockContainer<BODY>) [1,1 798x62.515625] overflow: [2,2 796x63]
+      PaintableWithLines (BlockContainer<DIV>.clump) [3,2 32x32]
+      PaintableWithLines (BlockContainer<DIV>.clump) [2,34 32x32]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/automatic-size-of-block-container-with-inline-children-and-nonempty-floating-child.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/automatic-size-of-block-container-with-inline-children-and-nonempty-floating-child.txt
@@ -4,3 +4,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <div.black> at (58,58) content-size 40x0 children: inline
         BlockContainer <div.green> at (78,78) content-size 0x0 floating [BFC] children: not-inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x0] overflow: [8,8 140x100]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 140x100]
+      PaintableWithLines (BlockContainer<DIV>.black) [8,8 140x100]
+        PaintableWithLines (BlockContainer<DIV>.green) [58,58 40x40]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/bfc-consider-all-currently-stacked-floats.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/bfc-consider-all-currently-stacked-floats.txt
@@ -28,3 +28,18 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
       BlockContainer <(anonymous)> at (8,42.9375) content-size 784x0 children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x108]
+    PaintableWithLines (BlockContainer(anonymous)) [0,0 800x0]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x34.9375]
+      PaintableWithLines (BlockContainer(anonymous)) [8,8 784x17.46875]
+        PaintableWithLines (BlockContainer<DIV>.big-float) [8,8 100x100]
+        PaintableWithLines (BlockContainer<DIV>.xxx) [108,8 29.109375x17.46875]
+          TextPaintable (TextNode<#text>)
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer<DIV>) [8,25.46875 784x17.46875]
+        PaintableWithLines (BlockContainer<DIV>.yyy) [108,25.46875 21.515625x17.46875]
+          TextPaintable (TextNode<#text>)
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,42.9375 784x0]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/bfc-float-left-break-vertically-2.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/bfc-float-left-break-vertically-2.txt
@@ -8,3 +8,12 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <div.orange> at (0,100) content-size 150x50 floating [BFC] children: not-inline
       BlockContainer <(anonymous)> at (0,0) content-size 200x0 children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x150]
+    PaintableWithLines (BlockContainer<BODY>) [0,0 200x0] overflow: [0,0 200x150]
+      PaintableWithLines (BlockContainer<UL>) [0,0 200x0]
+        PaintableWithLines (BlockContainer<DIV>.red) [0,0 150x50]
+        PaintableWithLines (BlockContainer<DIV>.green) [0,50 150x50]
+      PaintableWithLines (BlockContainer<DIV>.orange) [0,100 150x50]
+      PaintableWithLines (BlockContainer(anonymous)) [0,0 200x0]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/bfc-float-left-break-vertically.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/bfc-float-left-break-vertically.txt
@@ -15,3 +15,14 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
         BlockContainer <div.green> at (3,56) content-size 100x50 floating [BFC] children: not-inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x108]
+    PaintableWithLines (BlockContainer(anonymous)) [1,1 798x0]
+    PaintableWithLines (BlockContainer<BODY>) [1,1 402x4]
+      PaintableWithLines (BlockContainer(anonymous)) [2,2 400x0]
+      PaintableWithLines (BlockContainer<DIV>.ul) [2,2 400x2]
+        PaintableWithLines (BlockContainer<DIV>.yellow) [3,3 62x52]
+        PaintableWithLines (BlockContainer<DIV>.orange) [65,3 252x52]
+      PaintableWithLines (BlockContainer(anonymous)) [2,4 400x0]
+        PaintableWithLines (BlockContainer<DIV>.green) [2,55 102x52]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/block-with-fit-content-width-constraints.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/block-with-fit-content-width-constraints.txt
@@ -13,3 +13,12 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
       BlockContainer <(anonymous)> at (10,48.9375) content-size 780x0 children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x58.9375]
+    PaintableWithLines (BlockContainer<BODY>) [9,9 782x40.9375]
+      PaintableWithLines (BlockContainer<DIV>.box) [10,10 140.28125x19.46875]
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer<DIV>.box2) [10,29.46875 140.28125x19.46875]
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [10,48.9375 780x0]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/block-with-fit-content-width.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/block-with-fit-content-width.txt
@@ -8,3 +8,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
       BlockContainer <(anonymous)> at (10,29.46875) content-size 780x0 children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x39.46875]
+    PaintableWithLines (BlockContainer<BODY>) [9,9 782x21.46875]
+      PaintableWithLines (BlockContainer<DIV>.box) [10,10 140.28125x19.46875]
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [10,29.46875 780x0]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/block-with-hidden-overflow-after-float.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/block-with-hidden-overflow-after-float.txt
@@ -27,3 +27,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,25.46875) content-size 784x0 children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x33.46875]
+    PaintableWithLines (BlockContainer(anonymous)) [0,0 800x0]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x17.46875]
+      PaintableWithLines (BlockContainer(anonymous)) [8,8 784x0]
+      PaintableWithLines (BlockContainer<DIV>.ab) [108,8 684x17.46875]
+        PaintableWithLines (BlockContainer(anonymous)) [108,8 684x0]
+        PaintableWithLines (BlockContainer<DIV>) [108,8 684x0]
+          PaintableWithLines (BlockContainer<DIV>.a) [108,8 14.265625x17.46875]
+            TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer(anonymous)) [108,8 684x0]
+        PaintableWithLines (BlockContainer<DIV>.b) [122.265625,8 669.734375x17.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer(anonymous)) [108,25.46875 684x0]
+      PaintableWithLines (BlockContainer(anonymous)) [8,25.46875 784x0]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/block-with-hidden-overflow-after-sibling-float.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/block-with-hidden-overflow-after-sibling-float.txt
@@ -45,3 +45,28 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             TextNode <#text>
         BlockContainer <(anonymous)> at (8,42.9375) content-size 784x0 children: inline
           TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x34.9375]
+      PaintableWithLines (BlockContainer<DIV>) [8,8 784x34.9375]
+        PaintableWithLines (BlockContainer(anonymous)) [8,8 784x0]
+        PaintableWithLines (BlockContainer<DIV>) [8,8 784x0]
+          PaintableWithLines (BlockContainer<DIV>.a) [8,8 57.0625x34.9375]
+            PaintableWithLines (BlockContainer(anonymous)) [8,8 57.0625x0]
+            PaintableWithLines (BlockContainer<DIV>.a4) [8,8 57.0625x17.46875]
+              TextPaintable (TextNode<#text>)
+            PaintableWithLines (BlockContainer(anonymous)) [8,25.46875 57.0625x0]
+            PaintableWithLines (BlockContainer<DIV>) [8,25.46875 57.0625x17.46875]
+              TextPaintable (TextNode<#text>)
+            PaintableWithLines (BlockContainer(anonymous)) [8,42.9375 57.0625x0]
+        PaintableWithLines (BlockContainer(anonymous)) [8,8 784x0]
+        PaintableWithLines (BlockContainer<DIV>) [108,8 684x34.9375]
+          PaintableWithLines (BlockContainer(anonymous)) [108,8 684x0]
+          PaintableWithLines (BlockContainer<DIV>) [108,8 684x17.46875]
+            TextPaintable (TextNode<#text>)
+          PaintableWithLines (BlockContainer(anonymous)) [108,25.46875 684x0]
+          PaintableWithLines (BlockContainer<DIV>.c) [108,25.46875 684x17.46875]
+            TextPaintable (TextNode<#text>)
+          PaintableWithLines (BlockContainer(anonymous)) [108,42.9375 684x0]
+        PaintableWithLines (BlockContainer(anonymous)) [8,42.9375 784x0]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/block-with-max-content-width.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/block-with-max-content-width.txt
@@ -22,3 +22,16 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
       BlockContainer <(anonymous)> at (10,68.40625) content-size 780x0 children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x78.40625]
+    PaintableWithLines (BlockContainer<BODY>) [9,9 782x60.40625]
+      PaintableWithLines (BlockContainer<DIV>.foo) [10,10 152.21875x19.46875]
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [10,29.46875 780x0]
+      PaintableWithLines (BlockContainer<DIV>.bar) [10,29.46875 189.953125x19.46875]
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [10,48.9375 780x0]
+      PaintableWithLines (BlockContainer<DIV>.baz) [10,48.9375 185.078125x19.46875]
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [10,68.40625 780x0]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/block-with-min-content-width.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/block-with-min-content-width.txt
@@ -31,3 +31,16 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
       BlockContainer <(anonymous)> at (10,120.8125) content-size 780x0 children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x130.8125]
+    PaintableWithLines (BlockContainer<BODY>) [9,9 782x112.8125]
+      PaintableWithLines (BlockContainer<DIV>.foo) [10,10 95.765625x36.9375]
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [10,46.9375 780x0]
+      PaintableWithLines (BlockContainer<DIV>.bar) [10,46.9375 95.765625x36.9375]
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [10,83.875 780x0]
+      PaintableWithLines (BlockContainer<DIV>.baz) [10,83.875 95.765625x36.9375]
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [10,120.8125 780x0]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/block-with-negative-margin-and-no-intruding-floats.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/block-with-negative-margin-and-no-intruding-floats.txt
@@ -9,3 +9,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           frag 0 from TextNode start: 20, length: 21, rect: [61,28.46875 163.875x17.46875]
             "intruding on this div"
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x56.9375]
+    PaintableWithLines (BlockContainer<BODY>) [109,9 302x38.9375] overflow: [60,10 350x36.9375]
+      PaintableWithLines (BlockContainer<DIV>) [60,10 202x36.9375]
+        TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/block-and-inline/box-with-clearance-and-margin-top.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/box-with-clearance-and-margin-top.txt
@@ -5,3 +5,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <div.square.white> at (8,8) content-size 100x100 floating [BFC] children: not-inline
         BlockContainer <div.clearfix> at (8,108) content-size 10x10 children: not-inline
         BlockContainer <div.square.black> at (8,218) content-size 49x49 floating [BFC] children: not-inline
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x110] overflow: [8,8 784x259]
+      PaintableWithLines (BlockContainer<DIV>) [8,8 784x110] overflow: [8,8 784x259]
+        PaintableWithLines (BlockContainer<DIV>.square.white) [8,8 100x100]
+        PaintableWithLines (BlockContainer<DIV>.clearfix) [8,108 10x10]
+        PaintableWithLines (BlockContainer<DIV>.square.black) [8,218 49x49]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/clear-both-from-inline-formatting-context.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/clear-both-from-inline-formatting-context.txt
@@ -21,3 +21,14 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               "X"
           TextNode <#text>
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x0]
+      PaintableWithLines (BlockContainer<DIV>) [8,8 784x0]
+        PaintableWithLines (BlockContainer<H1>.left) [8,29.4375 28.53125x34.9375]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<H1>.right) [773.3125,29.4375 18.6875x34.9375]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.c) [8,155.8125 11.5625x17.46875]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/block-and-inline/clear-both-without-introducing-clearance.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/clear-both-without-introducing-clearance.txt
@@ -12,3 +12,12 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           frag 0 from TextNode start: 0, length: 5, rect: [8,100.46875 43.359375x17.46875]
             "lower"
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x125.9375]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x109.9375]
+      PaintableWithLines (BlockContainer<DIV>.upper) [8,8 784x17.46875]
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer<DIV>.mystery) [8,100.46875 784x0]
+      PaintableWithLines (BlockContainer<DIV>.lower) [8,100.46875 784x17.46875]
+        TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/block-and-inline/clearfix.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/clearfix.txt
@@ -13,3 +13,14 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,108) content-size 784x0 children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x100]
+      PaintableWithLines (BlockContainer<DIV>) [8,8 784x100]
+        PaintableWithLines (BlockContainer(anonymous)) [8,8 784x0]
+          PaintableWithLines (BlockContainer<DIV>.square.white) [8,8 100x100]
+        PaintableWithLines (BlockContainer<DIV>.clearfix) [8,108 784x0]
+        PaintableWithLines (BlockContainer(anonymous)) [8,108 784x0]
+          PaintableWithLines (BlockContainer<DIV>.square.black) [8,108 49x49]
+      PaintableWithLines (BlockContainer(anonymous)) [8,108 784x0]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/float-1.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/float-1.txt
@@ -112,3 +112,29 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
       BlockContainer <(anonymous)> at (8,339.90625) content-size 784x0 children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x331.90625]
+      PaintableWithLines (BlockContainer(anonymous)) [8,8 784x0]
+      PaintableWithLines (BlockContainer<DIV>) [8,8 784x0]
+        PaintableWithLines (BlockContainer<DIV>#lefty) [8,8 100x100]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>#righty) [742,8 50x50]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,8 784x0]
+      PaintableWithLines (BlockContainer<DIV>) [8,8 784x0]
+        PaintableWithLines (BlockContainer<DIV>#lefty2) [108,8 80x80]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>#righty2) [712,8 30x30]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,8 784x0]
+      PaintableWithLines (BlockContainer<DIV>) [8,8 784x0]
+        PaintableWithLines (BlockContainer<DIV>#lefty3) [188,8 40x40]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>#righty3) [692,8 20x20] overflow: [692,8 22.78125x20]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,8 784x0]
+      PaintableWithLines (BlockContainer<DIV>) [8,8 784x331.90625]
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,339.90625 784x0]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/float-2.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/float-2.txt
@@ -14,3 +14,13 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
       BlockContainer <(anonymous)> at (8,25.46875) content-size 784x0 children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x60]
+    PaintableWithLines (BlockContainer(anonymous)) [0,0 800x0]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x17.46875]
+      PaintableWithLines (BlockContainer(anonymous)) [8,8 784x0]
+        PaintableWithLines (BlockContainer<DIV>#b) [8,8 52x52]
+      PaintableWithLines (BlockContainer<DIV>#a) [8,8 784x17.46875]
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,25.46875 784x0]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/float-3.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/float-3.txt
@@ -24,3 +24,18 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,127.46875) content-size 780x0 children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 780x119.46875]
+      PaintableWithLines (BlockContainer(anonymous)) [8,8 780x0]
+      PaintableWithLines (BlockContainer<DIV>#top) [8,8 780x100]
+        PaintableWithLines (BlockContainer<DIV>#top-left.box) [8,8 300x100]
+        PaintableWithLines (BlockContainer<DIV>#top-right.box) [488,8 300x100]
+      PaintableWithLines (BlockContainer(anonymous)) [8,108 780x0]
+      PaintableWithLines (BlockContainer<DIV>#bottom) [8,108 780x19.46875]
+        PaintableWithLines (BlockContainer(anonymous)) [9,109 778x0]
+        PaintableWithLines (BlockContainer<DIV>#text) [9,109 778x17.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer(anonymous)) [9,126.46875 778x0]
+      PaintableWithLines (BlockContainer(anonymous)) [8,127.46875 780x0]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/float-4.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/float-4.txt
@@ -28,3 +28,16 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             "Right2"
         TextNode <#text>
       TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x60]
+    PaintableWithLines (BlockContainer(anonymous)) [0,0 800x0]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 780x0]
+      PaintableWithLines (BlockContainer<DIV>.left) [8,8 52x52]
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer<DIV>.right) [736,8 52x52]
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer<DIV>.left) [60,8 52x52]
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer<DIV>.right) [684,8 52x52] overflow: [685,9 50.78125x50]
+        TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/block-and-inline/float-clear-by-line-break.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/float-clear-by-line-break.txt
@@ -24,3 +24,15 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
       InlineNode <span>
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x34.9375]
+      PaintableWithLines (BlockContainer<SPAN>.a) [8,8 100x17.46875]
+        TextPaintable (TextNode<#text>)
+      InlinePaintable (InlineNode<SPAN>)
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer<SPAN>.a) [8,25.46875 100x17.46875]
+        TextPaintable (TextNode<#text>)
+      InlinePaintable (InlineNode<SPAN>)
+        TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/block-and-inline/float-left-and-right-with-justified-text-in-between.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/float-left-and-right-with-justified-text-in-between.txt
@@ -200,3 +200,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       TextNode <#text>
       BlockContainer <div.right> at (489,213) content-size 300x200 floating [BFC] children: not-inline
       TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x602]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x602]
+    PaintableWithLines (BlockContainer<BODY>) [251,9 540x400.90625]
+      PaintableWithLines (BlockContainer<DIV>.left) [252,10 302x202]
+      PaintableWithLines (BlockContainer<DIV>.right) [488,212 302x202]
+      TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/block-and-inline/float-left-and-right-with-text-in-between.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/float-left-and-right-with-text-in-between.txt
@@ -60,3 +60,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       TextNode <#text>
       BlockContainer <div.right> at (489,213) content-size 300x200 floating [BFC] children: not-inline
       TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x602]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x602]
+    PaintableWithLines (BlockContainer<BODY>) [251,9 540x400.90625]
+      PaintableWithLines (BlockContainer<DIV>.left) [252,10 302x202]
+      PaintableWithLines (BlockContainer<DIV>.right) [488,212 302x202]
+      TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/block-and-inline/float-stress-1.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/float-stress-1.txt
@@ -75,3 +75,20 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
         BlockContainer <div.righty> at (278,190) content-size 30x30 floating [BFC] children: not-inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x268] overflow: [0,0 800x285]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x252] overflow: [8,8 784x277]
+      PaintableWithLines (BlockContainer(anonymous)) [8,8 784x0]
+      PaintableWithLines (BlockContainer<DIV>.outer) [8,8 302x252] overflow: [9,9 300x276]
+        TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.lefty) [9,9 52x52]
+        PaintableWithLines (BlockContainer<DIV>.one) [61,25 202x52]
+        PaintableWithLines (BlockContainer<DIV>.two) [107,77 202x52]
+        TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.righty) [277,141 32x32]
+        TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.lefty.shwifty) [9,173 52x52]
+        TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.righty) [277,189 32x32]
+        TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/block-and-inline/float-stress-2.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/float-stress-2.txt
@@ -16,3 +16,14 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (0,50) content-size 800x0 children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>.js) [0,0 800x200]
+    PaintableWithLines (BlockContainer<BODY>) [0,0 800x50] overflow: [0,0 800x200]
+      PaintableWithLines (BlockContainer<DIV>#page) [0,0 800x50] overflow: [0,0 800x200]
+        PaintableWithLines (BlockContainer<DIV>#content_box) [50,50 400x150]
+          PaintableWithLines (BlockContainer<ARTICLE>.first) [50,50 300x100]
+            TextPaintable (TextNode<#text>)
+          PaintableWithLines (BlockContainer<ARTICLE>.second) [50,150 200x50]
+            TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [0,50 800x0]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/float-stress-3.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/float-stress-3.txt
@@ -14,3 +14,13 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
         BlockContainer <div.two> at (108,78) content-size 200x50 floating [BFC] children: not-inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x268]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x252]
+      PaintableWithLines (BlockContainer(anonymous)) [8,8 784x0]
+      PaintableWithLines (BlockContainer<DIV>.outer) [8,8 302x252]
+        TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.lefty) [9,9 52x52]
+        PaintableWithLines (BlockContainer<DIV>.one) [61,25 202x52]
+        PaintableWithLines (BlockContainer<DIV>.two) [107,77 202x52]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/floats-and-negative-margins.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/floats-and-negative-margins.txt
@@ -14,3 +14,12 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               "b"
           TextNode <#text>
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [100,8 200x200] overflow: [50,8 250x200]
+      PaintableWithLines (BlockContainer<DIV>.row) [50,8 250x200]
+        PaintableWithLines (BlockContainer<DIV>.item) [50,8 125x17.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.item) [175,8 125x17.46875]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/block-and-inline/ifc-float-left-and-sibling-with-margin-left.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/ifc-float-left-and-sibling-with-margin-left.txt
@@ -7,3 +7,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           frag 0 from TextNode start: 0, length: 14, rect: [91,11 125.125x17.46875]
             "Chrono Trigger"
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x63]
+    PaintableWithLines (BlockContainer<BODY>) [9,9 782x21.46875] overflow: [10,10 780x52]
+      PaintableWithLines (BlockContainer<DIV>.thumbnail) [10,10 52x52]
+      PaintableWithLines (BlockContainer<DIV>.title) [90,10 700x19.46875]
+        TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/block-and-inline/inline-block-baseline-1.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/inline-block-baseline-1.txt
@@ -20,3 +20,15 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <div.whee> at (115.140625,50.9375) content-size 200x50 children: not-inline
         BlockContainer <(anonymous)> at (114.140625,101.9375) content-size 202x0 children: inline
           TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x602]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x602]
+    PaintableWithLines (BlockContainer<BODY>) [9,9 782x94.9375]
+      TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer<DIV>.ib) [113.140625,10 204x92.9375]
+        PaintableWithLines (BlockContainer<DIV>) [114.140625,11 202x19.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [114.140625,30.46875 202x19.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.whee) [114.140625,49.9375 202x52]
+        PaintableWithLines (BlockContainer(anonymous)) [114.140625,101.9375 202x0]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/inline-block-baseline-2.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/inline-block-baseline-2.txt
@@ -24,3 +24,16 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
         BlockContainer <(anonymous)> at (114.140625,49.9375) content-size 39.234375x0 children: inline
           TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x602]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x602]
+    PaintableWithLines (BlockContainer<BODY>) [9,9 782x62.40625]
+      TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer<DIV>.ib) [113.140625,10 41.234375x60.40625]
+        PaintableWithLines (BlockContainer<DIV>) [114.140625,11 39.234375x19.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [114.140625,30.46875 39.234375x19.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.float) [114.140625,49.9375 39.234375x19.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer(anonymous)) [114.140625,49.9375 39.234375x0]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/inline-block-with-max-width-fit-content.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/inline-block-with-max-width-fit-content.txt
@@ -8,3 +8,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           frag 0 from TextNode start: 0, length: 13, rect: [9,9 100.203125x17.46875]
             "hello friends"
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x35.46875]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x19.46875]
+      PaintableWithLines (BlockContainer<SPAN>) [8,8 102.203125x19.46875]
+        TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/block-and-inline/inline-block-with-percentage-height-and-auto-height-of-containing-block.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/inline-block-with-percentage-height-and-auto-height-of-containing-block.txt
@@ -9,3 +9,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             frag 0 from TextNode start: 0, length: 4, rect: [8,8 36.453125x17.46875]
               "docs"
           TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x33.46875]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x17.46875]
+      PaintableWithLines (BlockContainer<DIV>.pure-menu-list) [8,8 784x17.46875]
+        PaintableWithLines (BlockContainer<DIV>.pure-menu-item) [8,8 36.453125x17.46875]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/block-and-inline/inline-box-positioned-with-top-left.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/inline-box-positioned-with-top-left.txt
@@ -14,3 +14,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             "displaced text"
         TextNode <#text>
       TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x20]
+      TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer<SPAN>.displaced_text) [150.421875,48 110.375x20]
+        TextPaintable (TextNode<#text>)
+      TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/block-and-inline/inline-box-with-vertical-margins-vertical-align-top.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/inline-box-with-vertical-margins-vertical-align-top.txt
@@ -10,3 +10,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       TextNode <#text>
       BlockContainer <div#inline-box> at (51.125,58) content-size 100x100 inline-block [BFC] children: not-inline
       TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x175]
+      TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer<DIV>#inline-box) [51.125,58 100x100]
+      TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/block-and-inline/inline-box-with-vertical-margins.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/inline-box-with-vertical-margins.txt
@@ -10,3 +10,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       TextNode <#text>
       BlockContainer <div#inline-box> at (51.125,58) content-size 100x100 inline-block [BFC] children: not-inline
       TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x178.9375]
+      TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer<DIV>#inline-box) [51.125,58 100x100]
+      TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/block-and-inline/intrinsic-sizing-with-min-width-specified.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/intrinsic-sizing-with-min-width-specified.txt
@@ -3,3 +3,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (10,10) content-size 104x34 floating [BFC] children: not-inline
       BlockContainer <div.outer> at (11,11) content-size 102x32 children: not-inline
         BlockContainer <div.inner> at (12,12) content-size 100x30 children: not-inline
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x54]
+    PaintableWithLines (BlockContainer<BODY>) [9,9 106x36]
+      PaintableWithLines (BlockContainer<DIV>.outer) [10,10 104x34]
+        PaintableWithLines (BlockContainer<DIV>.inner) [11,11 102x32]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/join-out-of-flow-box-with-previous-sibling-if-wrapped-in-anonymous-box.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/join-out-of-flow-box-with-previous-sibling-if-wrapped-in-anonymous-box.txt
@@ -7,3 +7,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           frag 0 from BlockContainer start: 0, length: 0, rect: [8,38 200x30]
         BlockContainer <div.tab> at (8,38) content-size 200x30 inline-block [BFC] children: not-inline
         BlockContainer <div.timeline> at (592,38) content-size 200x30 floating [BFC] children: not-inline
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x76]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x60]
+      PaintableWithLines (BlockContainer<DIV>.banner) [8,8 200x30]
+      PaintableWithLines (BlockContainer(anonymous)) [8,38 784x30]
+        PaintableWithLines (BlockContainer<DIV>.tab) [8,38 200x30]
+        PaintableWithLines (BlockContainer<DIV>.timeline) [592,38 200x30]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/margin-collapse-1.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/margin-collapse-1.txt
@@ -15,3 +15,13 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
       BlockContainer <(anonymous)> at (8,279) content-size 784x0 children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,25 784x229] overflow: [8,25 784x254]
+      PaintableWithLines (BlockContainer<DIV>#foo) [33,25 102x102]
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,152 784x0]
+      PaintableWithLines (BlockContainer<DIV>#bar) [33,152 102x102]
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,279 784x0]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/margin-collapse-2.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/margin-collapse-2.txt
@@ -22,3 +22,16 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
       BlockContainer <(anonymous)> at (8,344) content-size 784x0 children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x336]
+      PaintableWithLines (BlockContainer<DIV>#foo) [8,8 102x102]
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,135 784x0]
+      PaintableWithLines (BlockContainer<DIV>#bar) [8,135 102x102]
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,262 784x0]
+      PaintableWithLines (BlockContainer<DIV>#baz) [8,242 102x102]
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,344 784x0]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/margin-collapse-3.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/margin-collapse-3.txt
@@ -8,3 +8,12 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <div#baz> at (8,158) content-size 100x100 children: not-inline
       BlockContainer <(anonymous)> at (8,358) content-size 784x0 children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x350]
+      PaintableWithLines (BlockContainer<DIV>#foo) [8,8 100x100]
+      PaintableWithLines (BlockContainer(anonymous)) [8,133 784x0]
+      PaintableWithLines (BlockContainer<DIV>#bar) [8,158 200x200]
+        PaintableWithLines (BlockContainer<DIV>#baz) [8,158 100x100]
+      PaintableWithLines (BlockContainer(anonymous)) [8,358 784x0]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/margin-collapse-4.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/margin-collapse-4.txt
@@ -8,3 +8,12 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <div#bar> at (8,108) content-size 50x50 children: not-inline
       BlockContainer <(anonymous)> at (8,158) content-size 784x0 children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x150]
+      PaintableWithLines (BlockContainer<DIV>#foo) [8,8 100x50]
+        PaintableWithLines (BlockContainer<DIV>#baz) [8,8 50x50]
+      PaintableWithLines (BlockContainer(anonymous)) [8,158 784x0]
+      PaintableWithLines (BlockContainer<DIV>#bar) [8,108 50x50]
+      PaintableWithLines (BlockContainer(anonymous)) [8,158 784x0]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/margin-collapse-5.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/margin-collapse-5.txt
@@ -10,3 +10,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
       BlockContainer <(anonymous)> at (2,121.46875) content-size 168.96875x0 children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x123.46875]
+    PaintableWithLines (BlockContainer<BODY>) [1,1 170.96875x121.46875]
+      PaintableWithLines (BlockContainer<DIV>.hmm) [2,2 168.96875x19.46875]
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [2,121.46875 168.96875x0]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/margin-collapse-6.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/margin-collapse-6.txt
@@ -4,3 +4,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <div.upper> at (8,8) content-size 784x20 children: not-inline
       BlockContainer <div.bfc> at (8,78) content-size 784x20 [BFC] children: not-inline
         BlockContainer <div.inner> at (8,78) content-size 20x20 children: not-inline
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x106]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x90]
+      PaintableWithLines (BlockContainer<DIV>.upper) [8,8 784x20]
+      PaintableWithLines (BlockContainer<DIV>.bfc) [8,78 784x20]
+        PaintableWithLines (BlockContainer<DIV>.inner) [8,78 20x20]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/margin-must-not-collapse-across-nested-bfc.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/margin-must-not-collapse-across-nested-bfc.txt
@@ -4,3 +4,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <div.not-bfc> at (8,30) content-size 784x20 children: not-inline
       BlockContainer <div.bfc> at (8,80) content-size 784x0 [BFC] children: not-inline
       BlockContainer <div.not-bfc> at (8,110) content-size 784x20 children: not-inline
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x116] overflow: [0,0 800x130]
+    PaintableWithLines (BlockContainer<BODY>) [8,30 784x100]
+      PaintableWithLines (BlockContainer<DIV>.not-bfc) [8,30 784x20]
+      PaintableWithLines (BlockContainer<DIV>.bfc) [8,80 784x0]
+      PaintableWithLines (BlockContainer<DIV>.not-bfc) [8,110 784x20]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/margin-padding-block-inline-start.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/margin-padding-block-inline-start.txt
@@ -8,3 +8,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               "Hello"
           InlineNode <span>
             TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x101.46875]
+    PaintableWithLines (BlockContainer<BODY>) [9,9 502x83.46875]
+      PaintableWithLines (BlockContainer<DIV>.a) [10,10 500x81.46875]
+        PaintableWithLines (BlockContainer<DIV>.b) [91,31 328x19.46875]
+          InlinePaintable (InlineNode<SPAN>)
+            TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/block-and-inline/margin-padding-block-inline.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/margin-padding-block-inline.txt
@@ -8,3 +8,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               "Hello"
           InlineNode <span>
             TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x121.46875]
+    PaintableWithLines (BlockContainer<BODY>) [9,9 502x103.46875]
+      PaintableWithLines (BlockContainer<DIV>.a) [10,10 500x101.46875]
+        PaintableWithLines (BlockContainer<DIV>.b) [71,51 378x19.46875]
+          InlinePaintable (InlineNode<SPAN>)
+            TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/block-and-inline/max-width-for-box-with-inline-children.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/max-width-for-box-with-inline-children.txt
@@ -13,3 +13,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             frag 0 from TextNode start: 11, length: 7, rect: [12,121.15625 172.984375x54.578125]
               "friends"
           TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x187.734375]
+    PaintableWithLines (BlockContainer<BODY>) [9,9 206x169.734375]
+      PaintableWithLines (BlockContainer<DIV>.outer) [10,10 204x167.734375]
+        PaintableWithLines (BlockContainer<DIV>.inner) [11,11 202x165.734375]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/block-and-inline/max-width-must-not-expand-element.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/max-width-must-not-expand-element.txt
@@ -3,3 +3,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (10,10) content-size 4x54 positioned [BFC] children: not-inline
       BlockContainer <div.outer> at (11,11) content-size 2x52 children: not-inline
         BlockContainer <div.inner> at (12,12) content-size 0x50 children: not-inline
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x2] overflow: [9,9 6x56]
+    PaintableWithLines (BlockContainer<BODY>) [9,9 6x56]
+      PaintableWithLines (BlockContainer<DIV>.outer) [10,10 4x54]
+        PaintableWithLines (BlockContainer<DIV>.inner) [11,11 2x52]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/max-width-on-child-block-with-width-auto-contributes-to-intrinsic-size-of-parent.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/max-width-on-child-block-with-width-auto-contributes-to-intrinsic-size-of-parent.txt
@@ -7,3 +7,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             frag 0 from TextNode start: 0, length: 4, rect: [12,12 45.15625x17.46875]
               "OPEN"
           TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x41.46875]
+    PaintableBox (Box<BODY>.outer) [9,9 782x23.46875]
+      PaintableWithLines (BlockContainer<DIV>.middle) [10,10 204x21.46875]
+        PaintableWithLines (BlockContainer<DIV>.inner) [11,11 202x19.46875]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/block-and-inline/max-width-percentage-100-border-box.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/max-width-percentage-100-border-box.txt
@@ -6,3 +6,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           frag 0 from TextNode start: 0, length: 10, rect: [11,11 91.59375x17.46875]
             "border box"
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x2] overflow: [9,9 95.59375x21.46875]
+    PaintableWithLines (BlockContainer<BODY>) [9,9 95.59375x21.46875]
+      PaintableWithLines (BlockContainer<NAV>) [10,10 93.59375x19.46875]
+        TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/block-and-inline/max-width-percentage-100.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/max-width-percentage-100.txt
@@ -6,3 +6,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           frag 0 from TextNode start: 0, length: 18, rect: [11,11 136.609375x17.46875]
             "well hello friends"
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x2] overflow: [9,9 140.609375x21.46875]
+    PaintableWithLines (BlockContainer<BODY>) [9,9 140.609375x21.46875]
+      PaintableWithLines (BlockContainer<DIV>) [10,10 138.609375x19.46875]
+        TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/block-and-inline/narrow-bfc-width-to-avoid-overlap-with-floats.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/narrow-bfc-width-to-avoid-overlap-with-floats.txt
@@ -20,3 +20,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             frag 0 from TextNode start: 252, length: 57, rect: [18,87.875 455.375x17.46875]
               "pulvinar ipsum eget nulla dapibus, ac varius mi eleifend."
           TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x1008]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x1008]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x107.34375] overflow: [8,8 784x1000]
+      PaintableWithLines (BlockContainer<DIV>.wrapper) [8,8 784x107.34375] overflow: [8,8 784x1000]
+        PaintableWithLines (BlockContainer<DIV>.float) [592,8 200x1000]
+        PaintableWithLines (BlockContainer<DIV>.bfc) [8,8 584x107.34375]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/block-and-inline/percentage-min-height-with-containing-block-padding.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/percentage-min-height-with-containing-block-padding.txt
@@ -7,3 +7,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             frag 0 from TextNode start: 0, length: 5, rect: [18,118 36.84375x17.46875]
               "hello"
           TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x616]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x616]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x600]
+      PaintableWithLines (BlockContainer<DIV>.container) [8,8 784x600]
+        PaintableWithLines (BlockContainer<DIV>.hmm) [8,108 784x270]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/block-and-inline/percentage-min-height.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/percentage-min-height.txt
@@ -6,3 +6,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           frag 0 from TextNode start: 0, length: 5, rect: [18,18 36.84375x17.46875]
             "hello"
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x53.46875]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x37.46875]
+      PaintableWithLines (BlockContainer<DIV>.hmm) [8,8 784x37.46875]
+        TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/block-and-inline/percentage-min-width-with-max-content-containing-block-width.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/percentage-min-width-with-max-content-containing-block-width.txt
@@ -6,3 +6,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           frag 0 from TextNode start: 0, length: 5, rect: [8,8 36.84375x17.46875]
             "hello"
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x33.46875]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 200x17.46875]
+      PaintableWithLines (BlockContainer<DIV>) [8,8 200x17.46875]
+        TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/block-and-inline/percentage-padding-on-inline-block-with-indefinite-containing-block-size.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/percentage-padding-on-inline-block-with-indefinite-containing-block-size.txt
@@ -4,3 +4,8 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       line 0 width: 0, height: 17.46875, bottom: 17.46875, baseline: 13.53125
         frag 0 from BlockContainer start: 0, length: 0, rect: [8,21.53125 0x0]
       BlockContainer <div> at (8,21.53125) content-size 0x0 inline-block [BFC] children: not-inline
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x33.46875]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 0x17.46875]
+      PaintableWithLines (BlockContainer<DIV>) [8,21.53125 0x0]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/relpos-block.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/relpos-block.txt
@@ -11,3 +11,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           frag 0 from TextNode start: 0, length: 6, rect: [24,25.46875 53.171875x17.46875]
             "athena"
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x66.9375]
+    PaintableWithLines (BlockContainer<BODY>) [10,10 604x46.9375]
+      PaintableWithLines (BlockContainer<DIV>.exekiller) [12,12 204x21.46875]
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer<DIV>.athena) [22,23.46875 204x21.46875]
+        TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/block-and-inline/relpos-float.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/relpos-float.txt
@@ -11,3 +11,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           frag 0 from TextNode start: 0, length: 6, rect: [18,18 53.171875x17.46875]
             "athena"
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x35.46875] overflow: [2,2 796x35.46875]
+    PaintableWithLines (BlockContainer<BODY>) [10,10 604x4] overflow: [12,12 208x25.46875]
+      PaintableWithLines (BlockContainer<DIV>.exekiller) [12,12 204x21.46875]
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer<DIV>.athena) [16,16 204x21.46875]
+        TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/block-and-inline/single-br-inline-layout.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/single-br-inline-layout.txt
@@ -6,3 +6,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         line 0 width: 0, height: 17.46875, bottom: 17.46875, baseline: 13.53125
         BreakNode <br>
       BlockContainer <div#end> at (8,27.46875) content-size 784x2 children: not-inline
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x21.46875]
+      PaintableWithLines (BlockContainer<DIV>#begin) [8,8 784x2]
+      PaintableWithLines (BlockContainer(anonymous)) [8,10 784x17.46875]
+      PaintableWithLines (BlockContainer<DIV>#end) [8,27.46875 784x2]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/width-auto-margins-set-zero-if-containing-size-smaller.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/width-auto-margins-set-zero-if-containing-size-smaller.txt
@@ -13,3 +13,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             frag 0 from TextNode start: 11, length: 7, rect: [72,46.9375 55.359375x17.46875]
               "friends"
           TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x2] overflow: [9,9 174x58.40625]
+    PaintableWithLines (BlockContainer<BODY>) [9,9 104x58.40625] overflow: [10,10 173x56.40625]
+      PaintableWithLines (BlockContainer<DIV>#container) [10,10 102x56.40625] overflow: [11,11 172x54.40625]
+        PaintableWithLines (BlockContainer<DIV>#child) [11,11 172x54.40625]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/blockify-layout-internal-box-without-crashing.txt
+++ b/Tests/LibWeb/Layout/expected/blockify-layout-internal-box-without-crashing.txt
@@ -7,3 +7,13 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (10,10) content-size 0x0 table-row children: not-inline
               BlockContainer <(anonymous)> at (10,10) content-size 0x0 table-cell [BFC] children: not-inline
                 BlockContainer <td> at (9,9) content-size 0x0 positioned [BFC] children: not-inline
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x20]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x4]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 4x4]
+        PaintableBox (Box<TABLE>) [8,8 4x4]
+          PaintableBox (Box<TBODY>) [8,8 0x0] overflow: [8,8 2x2]
+            PaintableBox (Box<TR>) [10,10 0x0] overflow: [8,8 2x2]
+              PaintableWithLines (BlockContainer(anonymous)) [10,10 0x0] overflow: [8,8 2x2]
+                PaintableWithLines (BlockContainer<TD>) [8,8 2x2]

--- a/Tests/LibWeb/Layout/expected/box-sizing-border-box-for-definite-sizes-without-layout.txt
+++ b/Tests/LibWeb/Layout/expected/box-sizing-border-box-for-definite-sizes-without-layout.txt
@@ -9,3 +9,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             frag 0 from TextNode start: 0, length: 5, rect: [28,28 49.71875x21.828125]
               "Hello"
           TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x66.90625]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x50.90625]
+      PaintableBox (Box<DIV>.button) [8,18.90625 89.71875x40]
+        PaintableWithLines (BlockContainer(anonymous)) [28,28 49.71875x21.828125]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/calc-negate-length.txt
+++ b/Tests/LibWeb/Layout/expected/calc-negate-length.txt
@@ -3,3 +3,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x50 children: not-inline
       BlockContainer <div.container> at (8,8) content-size 100x50 children: not-inline
         BlockContainer <div.foo> at (8,8) content-size 99x50 children: not-inline
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x66]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x50]
+      PaintableWithLines (BlockContainer<DIV>.container) [8,8 100x50]
+        PaintableWithLines (BlockContainer<DIV>.foo) [8,8 99x50]

--- a/Tests/LibWeb/Layout/expected/css-all-unset.txt
+++ b/Tests/LibWeb/Layout/expected/css-all-unset.txt
@@ -10,3 +10,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: inline
         TextNode <#text>
     InlineNode <body>
       TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  InlinePaintable (InlineNode<HTML>)
+    InlinePaintable (InlineNode<HEAD>)
+      InlinePaintable (InlineNode<STYLE>)
+        TextPaintable (TextNode<#text>)
+    InlinePaintable (InlineNode<BODY>)
+      TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/css-calc-border-width.txt
+++ b/Tests/LibWeb/Layout/expected/css-calc-border-width.txt
@@ -2,3 +2,8 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x120 children: not-inline
       BlockContainer <div> at (18,18) content-size 100x100 children: not-inline
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x120]
+      PaintableWithLines (BlockContainer<DIV>) [8,8 120x120]

--- a/Tests/LibWeb/Layout/expected/css-ex-unit.txt
+++ b/Tests/LibWeb/Layout/expected/css-ex-unit.txt
@@ -2,3 +2,8 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x177.015625 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x161.015625 children: not-inline
       BlockContainer <div> at (8,8) content-size 107.34375x161.015625 children: not-inline
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x177.015625]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x161.015625]
+      PaintableWithLines (BlockContainer<DIV>) [8,8 107.34375x161.015625]

--- a/Tests/LibWeb/Layout/expected/css-font-size-calc.txt
+++ b/Tests/LibWeb/Layout/expected/css-font-size-calc.txt
@@ -5,3 +5,8 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         frag 0 from TextNode start: 0, length: 13, rect: [8,8 644.609375x109.171875]
           "Hello friends"
       TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x125.171875]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x109.171875]
+      TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/css-import-rule.txt
+++ b/Tests/LibWeb/Layout/expected/css-import-rule.txt
@@ -5,3 +5,8 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         frag 0 from TextNode start: 0, length: 5, rect: [8,8 137.640625x54.578125]
           "Crazy"
       TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x54.578125]
+      TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/css-imported-sheet-with-media-rule.txt
+++ b/Tests/LibWeb/Layout/expected/css-imported-sheet-with-media-rule.txt
@@ -5,3 +5,8 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         frag 0 from TextNode start: 0, length: 5, rect: [8,8 275.28125x109.171875]
           "Crazy"
       TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x109.171875]
+      TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/css-line-height-percentage-inheritance.txt
+++ b/Tests/LibWeb/Layout/expected/css-line-height-percentage-inheritance.txt
@@ -6,3 +6,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           frag 0 from TextNode start: 0, length: 25, rect: [11,11 552.09375x32]
             "The Linux Kernel Archives"
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x54]
+    PaintableWithLines (BlockContainer<BODY>) [9,9 782x36]
+      PaintableWithLines (BlockContainer<DIV>) [10,10 780x34]
+        TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/css-logical-inset-properties.txt
+++ b/Tests/LibWeb/Layout/expected/css-logical-inset-properties.txt
@@ -4,3 +4,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <div.two-props> at (60,110) content-size 398x198 positioned [BFC] children: not-inline
       BlockContainer <div.four-props> at (110,210) content-size 248x148 positioned [BFC] children: not-inline
       TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x2] overflow: [8,8 502x402]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 502x402]
+      PaintableWithLines (BlockContainer<DIV>.two-props) [59,109 400x200]
+      PaintableWithLines (BlockContainer<DIV>.four-props) [109,209 250x150]

--- a/Tests/LibWeb/Layout/expected/css-namespace-rule-matches.txt
+++ b/Tests/LibWeb/Layout/expected/css-namespace-rule-matches.txt
@@ -11,3 +11,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
       BlockContainer <(anonymous)> at (8,61.828125) content-size 784x0 children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,20 784x21.828125] overflow: [8,20 784x41.828125]
+      PaintableWithLines (BlockContainer<P>) [8,20 784x21.828125]
+        InlinePaintable (InlineNode<A>)
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,61.828125 784x0]

--- a/Tests/LibWeb/Layout/expected/css-namespace-rule-no-match.txt
+++ b/Tests/LibWeb/Layout/expected/css-namespace-rule-no-match.txt
@@ -11,3 +11,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
       BlockContainer <(anonymous)> at (8,61.828125) content-size 784x0 children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,20 784x21.828125] overflow: [8,20 784x41.828125]
+      PaintableWithLines (BlockContainer<P>) [8,20 784x21.828125]
+        InlinePaintable (InlineNode<A>)
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,61.828125 784x0]

--- a/Tests/LibWeb/Layout/expected/css-pseudo-element-blockification.txt
+++ b/Tests/LibWeb/Layout/expected/css-pseudo-element-blockification.txt
@@ -17,3 +17,14 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             frag 0 from TextNode start: 0, length: 7, rect: [92.4375,8 55.359375x17.46875]
               "friends"
           TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x17.46875]
+      PaintableBox (Box<DIV>.foo) [8,8 784x17.46875]
+        PaintableWithLines (BlockContainer(anonymous)) [8,8 28.40625x17.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer(anonymous)) [46,8 36.84375x17.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer(anonymous)) [92.4375,8 55.359375x17.46875]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/css-pseudo-element-should-not-be-affected-by-inline-style.txt
+++ b/Tests/LibWeb/Layout/expected/css-pseudo-element-should-not-be-affected-by-inline-style.txt
@@ -6,3 +6,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
         BlockContainer <div.inner> at (12,64) content-size 98x0 children: inline
           TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x122]
+    PaintableWithLines (BlockContainer<BODY>) [9,9 782x104]
+      PaintableWithLines (BlockContainer<DIV>.outer) [10,10 102x102]
+        PaintableWithLines (BlockContainer(anonymous)) [11,11 52x52]
+        PaintableWithLines (BlockContainer<DIV>.inner) [11,63 100x2]

--- a/Tests/LibWeb/Layout/expected/css-pseudo-element-should-not-be-affected-by-presentational-hints.txt
+++ b/Tests/LibWeb/Layout/expected/css-pseudo-element-should-not-be-affected-by-presentational-hints.txt
@@ -8,3 +8,13 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <td> at (15,62) content-size 100x2 table-cell [BFC] children: not-inline
                 BlockContainer <(anonymous)> at (16,63) content-size 98x0 children: inline
                   TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x126]
+    PaintableWithLines (BlockContainer<BODY>) [9,9 782x108]
+      PaintableWithLines (TableWrapper(anonymous)) [10,10 110x106]
+        PaintableBox (Box<TABLE>) [10,10 110x106]
+          PaintableBox (Box<TBODY>) [11,11 104x100] overflow: [11,11 106x102]
+            PaintableBox (Box<TR>) [13,13 104x100]
+              PaintableWithLines (BlockContainer<TD>) [13,13 104x100]
+                PaintableWithLines (BlockContainer(anonymous)) [15,62 100x2]

--- a/Tests/LibWeb/Layout/expected/css-revert.txt
+++ b/Tests/LibWeb/Layout/expected/css-revert.txt
@@ -5,3 +5,8 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         frag 0 from TextNode start: 0, length: 13, rect: [0,0 103.140625x17.46875]
           "Hello friends"
       TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x17.46875]
+    PaintableWithLines (BlockContainer<BODY>) [0,0 800x17.46875]
+      TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/css-snap-a-length-as-a-border-width.txt
+++ b/Tests/LibWeb/Layout/expected/css-snap-a-length-as-a-border-width.txt
@@ -3,3 +3,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x204 children: not-inline
       BlockContainer <div.a> at (9,9) content-size 100x100 children: not-inline
       BlockContainer <div.b> at (9,111) content-size 100x100 children: not-inline
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x204]
+      PaintableWithLines (BlockContainer<DIV>.a) [8,8 102x102]
+      PaintableWithLines (BlockContainer<DIV>.b) [8,110 102x102]

--- a/Tests/LibWeb/Layout/expected/css-values/comparison-functions.txt
+++ b/Tests/LibWeb/Layout/expected/css-values/comparison-functions.txt
@@ -5,3 +5,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <div.max> at (8,8) content-size 100x0 children: not-inline
           BlockContainer <div.clamp> at (8,8) content-size 120x300 children: inline
             TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 0x0] overflow: [8,8 120x300]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 0x0] overflow: [8,8 120x300]
+      PaintableWithLines (BlockContainer<DIV>.min) [8,8 80x0] overflow: [8,8 120x300]
+        PaintableWithLines (BlockContainer<DIV>.max) [8,8 100x0] overflow: [8,8 120x300]
+          PaintableWithLines (BlockContainer<DIV>.clamp) [8,8 120x300]

--- a/Tests/LibWeb/Layout/expected/css-values/exponential-functions.txt
+++ b/Tests/LibWeb/Layout/expected/css-values/exponential-functions.txt
@@ -7,3 +7,12 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             BlockContainer <div.log> at (8,8) content-size 140x0 children: not-inline
               BlockContainer <div.exp> at (8,8) content-size 160x0 children: inline
                 TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 0x0] overflow: [8,8 160x0]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 0x0] overflow: [8,8 160x0]
+      PaintableWithLines (BlockContainer<DIV>.pow) [8,8 80x0] overflow: [8,8 160x0]
+        PaintableWithLines (BlockContainer<DIV>.sqrt) [8,8 100x0] overflow: [8,8 160x0]
+          PaintableWithLines (BlockContainer<DIV>.hypot) [8,8 120x0] overflow: [8,8 160x0]
+            PaintableWithLines (BlockContainer<DIV>.log) [8,8 140x0] overflow: [8,8 160x0]
+              PaintableWithLines (BlockContainer<DIV>.exp) [8,8 160x0]

--- a/Tests/LibWeb/Layout/expected/css-values/numeric-constants.txt
+++ b/Tests/LibWeb/Layout/expected/css-values/numeric-constants.txt
@@ -4,3 +4,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <div.pi> at (8,8) content-size 80x0 children: not-inline
         BlockContainer <div.e> at (8,8) content-size 100x0 children: inline
           TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 0x0] overflow: [8,8 100x0]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 0x0] overflow: [8,8 100x0]
+      PaintableWithLines (BlockContainer<DIV>.pi) [8,8 80x0] overflow: [8,8 100x0]
+        PaintableWithLines (BlockContainer<DIV>.e) [8,8 100x0]

--- a/Tests/LibWeb/Layout/expected/css-values/sign-related-functions.txt
+++ b/Tests/LibWeb/Layout/expected/css-values/sign-related-functions.txt
@@ -4,3 +4,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <div.abs> at (8,8) content-size 80x0 children: not-inline
         BlockContainer <div.sign> at (8,8) content-size 100x0 children: inline
           TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 0x0] overflow: [8,8 100x0]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 0x0] overflow: [8,8 100x0]
+      PaintableWithLines (BlockContainer<DIV>.abs) [8,8 80x0] overflow: [8,8 100x0]
+        PaintableWithLines (BlockContainer<DIV>.sign) [8,8 100x0]

--- a/Tests/LibWeb/Layout/expected/css-values/stepped-value-functions.txt
+++ b/Tests/LibWeb/Layout/expected/css-values/stepped-value-functions.txt
@@ -5,3 +5,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <div.mod> at (8,8) content-size 100x0 children: not-inline
           BlockContainer <div.rem> at (8,8) content-size 120x0 children: inline
             TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 0x0] overflow: [8,8 120x0]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 0x0] overflow: [8,8 120x0]
+      PaintableWithLines (BlockContainer<DIV>.round) [8,8 80x0] overflow: [8,8 120x0]
+        PaintableWithLines (BlockContainer<DIV>.mod) [8,8 100x0] overflow: [8,8 120x0]
+          PaintableWithLines (BlockContainer<DIV>.rem) [8,8 120x0]

--- a/Tests/LibWeb/Layout/expected/css-values/trigonometric-functions.txt
+++ b/Tests/LibWeb/Layout/expected/css-values/trigonometric-functions.txt
@@ -10,3 +10,15 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <div.atan2> at (8,788) content-size 100x200 positioned children: not-inline
       BlockContainer <(anonymous)> at (8,988) content-size 784x0 children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x996]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x996]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x980]
+      PaintableWithLines (BlockContainer<DIV>.sin) [8,8 79.984375x100]
+      PaintableWithLines (BlockContainer<DIV>.cos) [8,108 99.984375x100]
+      PaintableWithLines (BlockContainer<DIV>.tan) [8,208 119.984375x100]
+      PaintableWithLines (BlockContainer<DIV>.asin) [8,308 100x140]
+      PaintableWithLines (BlockContainer<DIV>.acos) [8,448 100x160]
+      PaintableWithLines (BlockContainer<DIV>.atan) [8,608 100x180]
+      PaintableWithLines (BlockContainer<DIV>.atan2) [8,788 100x200]
+      PaintableWithLines (BlockContainer(anonymous)) [8,988 784x0]

--- a/Tests/LibWeb/Layout/expected/css-var-in-calc-block.txt
+++ b/Tests/LibWeb/Layout/expected/css-var-in-calc-block.txt
@@ -2,3 +2,8 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (1,1) content-size 798x270 [BFC] children: not-inline
     BlockContainer <body> at (10,10) content-size 780x252 children: not-inline
       BlockContainer <div> at (11,11) content-size 250x250 children: not-inline
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x272]
+    PaintableWithLines (BlockContainer<BODY>) [9,9 782x254]
+      PaintableWithLines (BlockContainer<DIV>) [10,10 252x252]

--- a/Tests/LibWeb/Layout/expected/display-table-inline-children.txt
+++ b/Tests/LibWeb/Layout/expected/display-table-inline-children.txt
@@ -19,3 +19,16 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               TextNode <#text>
       BlockContainer <(anonymous)> at (8,608) content-size 784x0 children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600] overflow: [0,0 1208x616]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x616] overflow: [0,0 1208x616]
+    PaintableWithLines (BlockContainer(anonymous)) [0,0 800x0]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x600] overflow: [8,8 1200x600]
+      PaintableWithLines (BlockContainer(anonymous)) [8,8 784x0]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 784x600] overflow: [8,8 1200x600]
+        PaintableBox (Box<DIV>.aligncenter.block-image) [8,8 1200x600]
+          PaintableBox (Box(anonymous)) [8,8 1200x600]
+            PaintableWithLines (BlockContainer(anonymous)) [8,8 1200x600]
+              InlinePaintable (InlineNode<A>)
+                ImagePaintable (ImageBox<IMG>) [8,8 1200x600]
+      PaintableWithLines (BlockContainer(anonymous)) [8,608 784x0]

--- a/Tests/LibWeb/Layout/expected/div_align.txt
+++ b/Tests/LibWeb/Layout/expected/div_align.txt
@@ -77,3 +77,27 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <div.square> at (28,517.875) content-size 100x100 children: not-inline
       BlockContainer <(anonymous)> at (8,637.875) content-size 784x0 children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x637.875]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x637.875]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x609.875] overflow: [8,8 784x629.875]
+      PaintableWithLines (BlockContainer<DIV>) [8,8 784x137.46875]
+        PaintableWithLines (BlockContainer(anonymous)) [8,8 784x17.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.square) [28,45.46875 100x100]
+      PaintableWithLines (BlockContainer(anonymous)) [8,165.46875 784x0]
+      PaintableWithLines (BlockContainer<DIV>) [8,165.46875 784x137.46875]
+        PaintableWithLines (BlockContainer(anonymous)) [8,165.46875 784x17.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.square) [350,202.9375 100x100]
+      PaintableWithLines (BlockContainer(anonymous)) [8,322.9375 784x0]
+      PaintableWithLines (BlockContainer<DIV>) [8,322.9375 784x137.46875]
+        PaintableWithLines (BlockContainer(anonymous)) [8,322.9375 784x17.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.square) [672,360.40625 100x100]
+      PaintableWithLines (BlockContainer(anonymous)) [8,480.40625 784x0]
+      PaintableWithLines (BlockContainer<DIV>) [8,480.40625 784x137.46875]
+        PaintableWithLines (BlockContainer(anonymous)) [8,480.40625 784x17.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.square) [28,517.875 100x100]
+      PaintableWithLines (BlockContainer(anonymous)) [8,637.875 784x0]

--- a/Tests/LibWeb/Layout/expected/div_align_nested.txt
+++ b/Tests/LibWeb/Layout/expected/div_align_nested.txt
@@ -25,3 +25,18 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             TextNode <#text>
         BlockContainer <(anonymous)> at (8,260.40625) content-size 784x0 children: inline
           TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x252.40625]
+      PaintableWithLines (BlockContainer<DIV>) [8,8 784x252.40625]
+        PaintableWithLines (BlockContainer(anonymous)) [8,8 784x17.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.square) [692,25.46875 100x100]
+        PaintableWithLines (BlockContainer(anonymous)) [8,125.46875 784x0]
+        PaintableWithLines (BlockContainer<DIV>) [8,125.46875 784x134.9375]
+          PaintableWithLines (BlockContainer(anonymous)) [8,125.46875 784x34.9375]
+            TextPaintable (TextNode<#text>)
+          PaintableWithLines (BlockContainer<DIV>.square) [8,160.40625 100x100]
+          PaintableWithLines (BlockContainer(anonymous)) [8,260.40625 784x0]
+        PaintableWithLines (BlockContainer(anonymous)) [8,260.40625 784x0]

--- a/Tests/LibWeb/Layout/expected/flex-abspos-item-with-preceding-whitespace.txt
+++ b/Tests/LibWeb/Layout/expected/flex-abspos-item-with-preceding-whitespace.txt
@@ -6,3 +6,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
         BlockContainer <div.orange> at (48,-12) content-size 100x100 positioned [BFC] children: inline
           TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600] overflow: [0,-22 800x622]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x76] overflow: [10,-22 780x120]
+    PaintableWithLines (BlockContainer<BODY>) [18,18 764x40] overflow: [28,-22 744x120]
+      PaintableBox (Box<DIV>.pink) [28,28 744x20] overflow: [38,-22 120x120]
+        PaintableWithLines (BlockContainer<DIV>.orange) [38,-22 120x120]

--- a/Tests/LibWeb/Layout/expected/flex-auto.txt
+++ b/Tests/LibWeb/Layout/expected/flex-auto.txt
@@ -27,3 +27,15 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,112) content-size 784x0 children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x104]
+      PaintableBox (Box<DIV>.container) [8,8 502x104]
+        PaintableWithLines (BlockContainer<DIV>.box) [9,9 166.65625x102]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.box) [175.65625,9 166.65625x102]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.box) [342.3125,9 166.65625x102]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,112 784x0]

--- a/Tests/LibWeb/Layout/expected/flex-column-constained-wrap.txt
+++ b/Tests/LibWeb/Layout/expected/flex-column-constained-wrap.txt
@@ -27,3 +27,15 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,260) content-size 784x0 children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x252]
+      PaintableBox (Box<DIV>.container.column) [8,8 252x252]
+        PaintableWithLines (BlockContainer<DIV>.box) [9,9 102x102]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.box) [9,111 102x102]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.box) [134,9 102x102]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,260 784x0]

--- a/Tests/LibWeb/Layout/expected/flex-column-constrained-nowrap.txt
+++ b/Tests/LibWeb/Layout/expected/flex-column-constrained-nowrap.txt
@@ -27,3 +27,15 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,260) content-size 784x0 children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x252]
+      PaintableBox (Box<DIV>.container.column) [8,8 784x252] overflow: [9,9 782x250.03125]
+        PaintableWithLines (BlockContainer<DIV>.box) [9,9 102x83.34375]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.box) [9,92.34375 102x83.34375]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.box) [9,175.6875 102x83.34375]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,260 784x0]

--- a/Tests/LibWeb/Layout/expected/flex-column-height-constrained-width-constrained.txt
+++ b/Tests/LibWeb/Layout/expected/flex-column-height-constrained-width-constrained.txt
@@ -27,3 +27,15 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,260) content-size 784x0 children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x252]
+      PaintableBox (Box<DIV>.container.column) [8,8 252x252] overflow: [9,9 250x250.03125]
+        PaintableWithLines (BlockContainer<DIV>.box) [9,9 102x83.34375]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.box) [9,92.34375 102x83.34375]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.box) [9,175.6875 102x83.34375]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,260 784x0]

--- a/Tests/LibWeb/Layout/expected/flex-column-height-constrained.txt
+++ b/Tests/LibWeb/Layout/expected/flex-column-height-constrained.txt
@@ -27,3 +27,15 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,260) content-size 784x0 children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x252]
+      PaintableBox (Box<DIV>.container) [8,8 784x252] overflow: [9,9 782x250.03125]
+        PaintableWithLines (BlockContainer<DIV>.box) [9,9 102x83.34375]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.box) [9,92.34375 102x83.34375]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.box) [9,175.6875 102x83.34375]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,260 784x0]

--- a/Tests/LibWeb/Layout/expected/flex-column-height-unconstrained.txt
+++ b/Tests/LibWeb/Layout/expected/flex-column-height-unconstrained.txt
@@ -27,3 +27,15 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,316) content-size 784x0 children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x308]
+      PaintableBox (Box<DIV>.my-container.column) [8,8 784x308]
+        PaintableWithLines (BlockContainer<DIV>.box) [9,9 102x102]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.box) [9,111 102x102]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.box) [9,213 102x102]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,316 784x0]

--- a/Tests/LibWeb/Layout/expected/flex-column-item-with-auto-height-and-max-width.txt
+++ b/Tests/LibWeb/Layout/expected/flex-column-item-with-auto-height-and-max-width.txt
@@ -18,3 +18,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           frag 0 from TextNode start: 168, length: 20, rect: [3,72.875 175.40625x17.46875]
             "Software Engineer at"
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x93.34375]
+    PaintableBox (Box<BODY>) [1,1 798x91.34375]
+      PaintableWithLines (BlockContainer<MAIN>) [2,2 402x89.34375]
+        TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/flex-column-item-with-auto-height-depending-auto-width-with-max-width-constraint.txt
+++ b/Tests/LibWeb/Layout/expected/flex-column-item-with-auto-height-depending-auto-width-with-max-width-constraint.txt
@@ -18,3 +18,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           frag 0 from TextNode start: 40, length: 11, rect: [102,265 351.5625x65.5]
             "background."
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x333.5]
+    PaintableBox (Box<BODY>.hero) [1,1 602x331.5]
+      PaintableWithLines (BlockContainer<DIV>.header) [101,2 402x329.5]
+        TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/flex-column-item-with-auto-height-depending-on-auto-width.txt
+++ b/Tests/LibWeb/Layout/expected/flex-column-item-with-auto-height-depending-on-auto-width.txt
@@ -20,3 +20,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
       BlockContainer <(anonymous)> (not painted) [BFC] children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x458.71875]
+    PaintableBox (Box<BODY>.hero) [9,9 502x440.71875] overflow: [9,10 502x438.71875]
+      PaintableWithLines (BlockContainer<DIV>.upper) [9,10 502x438.71875]
+        TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/flex-container-constrained-nowrap.txt
+++ b/Tests/LibWeb/Layout/expected/flex-container-constrained-nowrap.txt
@@ -27,3 +27,15 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,112) content-size 784x0 children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x104]
+      PaintableBox (Box<DIV>.container) [8,8 252x104] overflow: [9,9 250.03125x102]
+        PaintableWithLines (BlockContainer<DIV>.box) [9,9 83.34375x102]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.box) [92.34375,9 83.34375x102]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.box) [175.6875,9 83.34375x102]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,112 784x0]

--- a/Tests/LibWeb/Layout/expected/flex-container-constrained-wrap.txt
+++ b/Tests/LibWeb/Layout/expected/flex-container-constrained-wrap.txt
@@ -27,3 +27,15 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,214) content-size 784x0 children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x206]
+      PaintableBox (Box<DIV>.container) [8,8 252x206]
+        PaintableWithLines (BlockContainer<DIV>.box) [9,9 102x102]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.box) [111,9 102x102]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.box) [9,111 102x102]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,214 784x0]

--- a/Tests/LibWeb/Layout/expected/flex-container-width-constrained.txt
+++ b/Tests/LibWeb/Layout/expected/flex-container-width-constrained.txt
@@ -27,3 +27,15 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,112) content-size 784x0 children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x104]
+      PaintableBox (Box<DIV>.container.width-constrained) [8,8 252x104] overflow: [9,9 250.03125x102]
+        PaintableWithLines (BlockContainer<DIV>.box) [9,9 83.34375x102]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.box) [92.34375,9 83.34375x102]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.box) [175.6875,9 83.34375x102]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,112 784x0]

--- a/Tests/LibWeb/Layout/expected/flex-frozen-items-should-be-respected.txt
+++ b/Tests/LibWeb/Layout/expected/flex-frozen-items-should-be-respected.txt
@@ -27,3 +27,18 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             frag 0 from TextNode start: 0, length: 15, rect: [565.25,12 136.3125x17.46875]
               "LongPieceOfText"
           TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x72]
+    PaintableWithLines (BlockContainer<BODY>) [9,9 782x54]
+      PaintableBox (Box<DIV>.flexbox) [10,10 780x52]
+        PaintableWithLines (BlockContainer<DIV>) [11,11 138.3125x50]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [149.3125,11 138.3125x50]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [287.625,11 138.3125x50]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [425.9375,11 138.3125x50]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.last.item) [564.25,11 224.75x50]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/flex-grow-0-column.txt
+++ b/Tests/LibWeb/Layout/expected/flex-grow-0-column.txt
@@ -27,3 +27,15 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,68.40625) content-size 784x0 children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x60.40625]
+      PaintableBox (Box<DIV>.container) [8,8 502x60.40625]
+        PaintableWithLines (BlockContainer<DIV>.box) [9,9 102x19.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.box) [9,28.46875 102x19.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.box) [9,47.9375 102x19.46875]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,68.40625 784x0]

--- a/Tests/LibWeb/Layout/expected/flex-grow-1.txt
+++ b/Tests/LibWeb/Layout/expected/flex-grow-1.txt
@@ -27,3 +27,15 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,112) content-size 784x0 children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x104]
+      PaintableBox (Box<DIV>.container) [8,8 502x104]
+        PaintableWithLines (BlockContainer<DIV>.box) [9,9 231.328125x102]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.box) [240.328125,9 166.65625x102]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.box) [406.984375,9 102x102]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,112 784x0]

--- a/Tests/LibWeb/Layout/expected/flex-grow-2.txt
+++ b/Tests/LibWeb/Layout/expected/flex-grow-2.txt
@@ -27,3 +27,15 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,112) content-size 784x0 children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x104]
+      PaintableBox (Box<DIV>.container) [8,8 502x104]
+        PaintableWithLines (BlockContainer<DIV>.box) [9,9 84.328125x102]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.box) [93.328125,9 166.65625x102]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.box) [259.984375,9 249x102]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,112 784x0]

--- a/Tests/LibWeb/Layout/expected/flex-item-auto-height-with-wrap.txt
+++ b/Tests/LibWeb/Layout/expected/flex-item-auto-height-with-wrap.txt
@@ -9,3 +9,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
       BlockContainer <(anonymous)> (not painted) [BFC] children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x116]
+    PaintableBox (Box<BODY>.outer) [8,8 400x100]
+      PaintableBox (Box<DIV>.inner) [8,8 400x17.46875]
+        PaintableWithLines (BlockContainer(anonymous)) [8,8 348.609375x17.46875]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/flex-item-on-row-with-intrinsic-aspect-ratio.txt
+++ b/Tests/LibWeb/Layout/expected/flex-item-on-row-with-intrinsic-aspect-ratio.txt
@@ -2,3 +2,8 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x200 [BFC] children: not-inline
     Box <body> at (0,0) content-size 800x200 flex-container(row) [FFC] children: not-inline
       ImageBox <img> at (0,0) content-size 400x200 flex-item children: not-inline
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x200]
+    PaintableBox (Box<BODY>) [0,0 800x200]
+      ImagePaintable (ImageBox<IMG>) [0,0 400x200]

--- a/Tests/LibWeb/Layout/expected/flex-item-vertical-padding-relative-to-flex-container-width.txt
+++ b/Tests/LibWeb/Layout/expected/flex-item-vertical-padding-relative-to-flex-container-width.txt
@@ -13,3 +13,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x602]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x602]
+    PaintableWithLines (BlockContainer<BODY>) [9,9 782x14] overflow: [10,10 780x201]
+      PaintableWithLines (BlockContainer(anonymous)) [10,10 780x0]
+      PaintableBox (Box<DIV>.flex-container) [10,10 602x12] overflow: [11,11 600x200]
+        PaintableWithLines (BlockContainer<DIV>.flex-item) [11,11 29.15625x200]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/flex-item-with-cyclic-percentage-height.txt
+++ b/Tests/LibWeb/Layout/expected/flex-item-with-cyclic-percentage-height.txt
@@ -8,3 +8,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               frag 0 from TextNode start: 0, length: 6, rect: [12,12 44.03125x17.46875]
                 "pillow"
             TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x41.46875]
+    PaintableWithLines (BlockContainer<BODY>) [9,9 782x23.46875]
+      PaintableBox (Box<DIV>.flexrow) [10,10 780x21.46875]
+        PaintableBox (Box<DIV>.project) [11,11 46.03125x19.46875]
+          PaintableWithLines (BlockContainer(anonymous)) [12,12 44.03125x17.46875]
+            TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/flex-item-with-intrinsic-aspect-ratio.txt
+++ b/Tests/LibWeb/Layout/expected/flex-item-with-intrinsic-aspect-ratio.txt
@@ -2,3 +2,8 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x200 [BFC] children: not-inline
     Box <body> at (0,0) content-size 400x200 flex-container(column) [FFC] children: not-inline
       ImageBox <img> at (0,0) content-size 400x200 flex-item children: not-inline
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x200]
+    PaintableBox (Box<BODY>) [0,0 400x200]
+      ImagePaintable (ImageBox<IMG>) [0,0 400x200]

--- a/Tests/LibWeb/Layout/expected/flex-margin-auto-justify-content.txt
+++ b/Tests/LibWeb/Layout/expected/flex-margin-auto-justify-content.txt
@@ -19,3 +19,15 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,62) content-size 784x0 children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x54]
+      PaintableBox (Box<DIV>.container) [8,8 602x54]
+        PaintableWithLines (BlockContainer<DIV>.box) [19,9 152x52]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.box) [171,9 152x52]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.box) [457,9 152x52]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,62 784x0]

--- a/Tests/LibWeb/Layout/expected/flex-row.txt
+++ b/Tests/LibWeb/Layout/expected/flex-row.txt
@@ -27,3 +27,15 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,112) content-size 784x0 children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x104]
+      PaintableBox (Box<DIV>.container) [8,8 784x104]
+        PaintableWithLines (BlockContainer<DIV>.box) [9,9 102x102]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.box) [111,9 102x102]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.box) [213,9 102x102]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,112 784x0]

--- a/Tests/LibWeb/Layout/expected/flex-shrink-1.txt
+++ b/Tests/LibWeb/Layout/expected/flex-shrink-1.txt
@@ -36,3 +36,15 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,112) content-size 784x0 children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x104]
+      PaintableBox (Box<DIV>.container) [8,8 252x104] overflow: [9,9 250.015625x102]
+        PaintableWithLines (BlockContainer<DIV>.box) [9,9 64.671875x102]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.box) [73.671875,9 83.34375x102]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.box) [157.015625,9 102x102]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,112 784x0]

--- a/Tests/LibWeb/Layout/expected/flex-shrink-2.txt
+++ b/Tests/LibWeb/Layout/expected/flex-shrink-2.txt
@@ -27,3 +27,15 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,112) content-size 784x0 children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x104]
+      PaintableBox (Box<DIV>.container) [8,8 502x104] overflow: [9,9 500.015625x102]
+        PaintableWithLines (BlockContainer<DIV>.box) [9,9 49x102]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.box) [58,9 166.671875x102]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.box) [224.671875,9 284.34375x102]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,112 784x0]

--- a/Tests/LibWeb/Layout/expected/flex-shrink-3.txt
+++ b/Tests/LibWeb/Layout/expected/flex-shrink-3.txt
@@ -27,3 +27,15 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,112) content-size 784x0 children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x104]
+      PaintableBox (Box<DIV>.container) [8,8 502x104]
+        PaintableWithLines (BlockContainer<DIV>.box) [9,9 102x102]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.box) [111,9 102x102]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.box) [213,9 102x102]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,112 784x0]

--- a/Tests/LibWeb/Layout/expected/flex/abspos-flex-child-static-position-with-align-items.txt
+++ b/Tests/LibWeb/Layout/expected/flex/abspos-flex-child-static-position-with-align-items.txt
@@ -75,3 +75,34 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
       BlockContainer <(anonymous)> (not painted) [BFC] children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x566]
+    PaintableBox (Box<BODY>) [18,18 764x530]
+      PaintableBox (Box<DIV>.outer.normal) [28,28 170x170] overflow: [38,38 170x150]
+        PaintableWithLines (BlockContainer<DIV>) [38,38 170x70]
+          TextPaintable (TextNode<#text>)
+      PaintableBox (Box<DIV>.outer.stretch) [198,28 170x170] overflow: [208,38 170x150]
+        PaintableWithLines (BlockContainer<DIV>) [208,38 170x70]
+          TextPaintable (TextNode<#text>)
+      PaintableBox (Box<DIV>.outer.start) [368,28 170x170] overflow: [378,38 170x150]
+        PaintableWithLines (BlockContainer<DIV>) [378,38 170x70]
+          TextPaintable (TextNode<#text>)
+      PaintableBox (Box<DIV>.outer.flex-start) [538,28 170x170] overflow: [548,38 170x150]
+        PaintableWithLines (BlockContainer<DIV>) [548,38 170x70]
+          TextPaintable (TextNode<#text>)
+      PaintableBox (Box<DIV>.outer.end) [28,198 170x170] overflow: [38,208 170x160]
+        PaintableWithLines (BlockContainer<DIV>) [38,298 170x70]
+          TextPaintable (TextNode<#text>)
+      PaintableBox (Box<DIV>.outer.flex-end) [198,198 170x170] overflow: [208,208 170x160]
+        PaintableWithLines (BlockContainer<DIV>) [208,298 170x70]
+          TextPaintable (TextNode<#text>)
+      PaintableBox (Box<DIV>.outer.center) [368,198 170x170] overflow: [378,208 170x150]
+        PaintableWithLines (BlockContainer<DIV>) [378,248 170x70]
+          TextPaintable (TextNode<#text>)
+      PaintableBox (Box<DIV>.outer.self-start) [538,198 170x170] overflow: [548,208 170x150]
+        PaintableWithLines (BlockContainer<DIV>) [548,208 170x70]
+          TextPaintable (TextNode<#text>)
+      PaintableBox (Box<DIV>.outer.self-end) [28,368 170x170] overflow: [38,378 170x160]
+        PaintableWithLines (BlockContainer<DIV>) [38,468 170x70]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/flex/abspos-flex-child-static-position-with-justify-content.txt
+++ b/Tests/LibWeb/Layout/expected/flex/abspos-flex-child-static-position-with-justify-content.txt
@@ -259,3 +259,136 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (38,2918) content-size 724x0 children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x2956]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x2956]
+    PaintableWithLines (BlockContainer<BODY>) [23,23 754x2910]
+      PaintableWithLines (BlockContainer(anonymous)) [38,38 724x0]
+      PaintableBox (Box<DIV>.row.outer.start) [38,38 330x90] overflow: [53,53 300x80]
+        PaintableWithLines (BlockContainer<DIV>) [53,53 180x80]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [38,128 724x0]
+      PaintableBox (Box<DIV>.row.outer.flex-start) [38,128 330x90] overflow: [53,143 300x80]
+        PaintableWithLines (BlockContainer<DIV>) [53,143 180x80]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [38,218 724x0]
+      PaintableBox (Box<DIV>.row.outer.end) [38,218 330x90] overflow: [53,233 300x80]
+        PaintableWithLines (BlockContainer<DIV>) [173,233 180x80]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [38,308 724x0]
+      PaintableBox (Box<DIV>.row.outer.flex-end) [38,308 330x90] overflow: [53,323 300x80]
+        PaintableWithLines (BlockContainer<DIV>) [173,323 180x80]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [38,398 724x0]
+      PaintableBox (Box<DIV>.row.outer.center) [38,398 330x90] overflow: [53,413 300x80]
+        PaintableWithLines (BlockContainer<DIV>) [113,413 180x80]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [38,488 724x0]
+      PaintableBox (Box<DIV>.row.outer.space-around) [38,488 330x90] overflow: [53,503 300x80]
+        PaintableWithLines (BlockContainer<DIV>) [113,503 180x80]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [38,578 724x0]
+      PaintableBox (Box<DIV>.row.outer.space-between) [38,578 330x90] overflow: [53,593 300x80]
+        PaintableWithLines (BlockContainer<DIV>) [53,593 180x80]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [38,668 724x0]
+      PaintableBox (Box<DIV>.row.outer.space-evenly) [38,668 330x90] overflow: [53,683 300x80]
+        PaintableWithLines (BlockContainer<DIV>) [113,683 180x80]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [38,758 724x0]
+      PaintableBox (Box<DIV>.row.reverse.outer.start) [38,758 330x90] overflow: [53,773 300x80]
+        PaintableWithLines (BlockContainer<DIV>) [53,773 180x80]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [38,848 724x0]
+      PaintableBox (Box<DIV>.row.reverse.outer.flex-start) [38,848 330x90] overflow: [53,863 300x80]
+        PaintableWithLines (BlockContainer<DIV>) [173,863 180x80]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [38,938 724x0]
+      PaintableBox (Box<DIV>.row.reverse.outer.end) [38,938 330x90] overflow: [53,953 300x80]
+        PaintableWithLines (BlockContainer<DIV>) [173,953 180x80]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [38,1028 724x0]
+      PaintableBox (Box<DIV>.row.reverse.outer.flex-end) [38,1028 330x90] overflow: [53,1043 300x80]
+        PaintableWithLines (BlockContainer<DIV>) [53,1043 180x80]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [38,1118 724x0]
+      PaintableBox (Box<DIV>.row.reverse.outer.center) [38,1118 330x90] overflow: [53,1133 300x80]
+        PaintableWithLines (BlockContainer<DIV>) [113,1133 180x80]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [38,1208 724x0]
+      PaintableBox (Box<DIV>.row.reverse.outer.space-around) [38,1208 330x90] overflow: [53,1223 300x80]
+        PaintableWithLines (BlockContainer<DIV>) [113,1223 180x80]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [38,1298 724x0]
+      PaintableBox (Box<DIV>.row.reverse.outer.space-between) [38,1298 330x90] overflow: [53,1313 300x80]
+        PaintableWithLines (BlockContainer<DIV>) [173,1313 180x80]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [38,1388 724x0]
+      PaintableBox (Box<DIV>.row.reverse.outer.space-evenly) [38,1388 330x90] overflow: [53,1403 300x80]
+        PaintableWithLines (BlockContainer<DIV>) [113,1403 180x80]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [38,1478 724x0]
+      PaintableBox (Box<DIV>.column.outer.start) [38,1478 330x90] overflow: [53,1493 300x80]
+        PaintableWithLines (BlockContainer<DIV>) [53,1493 180x80]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [38,1568 724x0]
+      PaintableBox (Box<DIV>.column.outer.flex-start) [38,1568 330x90] overflow: [53,1583 300x80]
+        PaintableWithLines (BlockContainer<DIV>) [53,1583 180x80]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [38,1658 724x0]
+      PaintableBox (Box<DIV>.column.outer.end) [38,1658 330x90] overflow: [53,1653 300x80]
+        PaintableWithLines (BlockContainer<DIV>) [53,1653 180x80]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [38,1748 724x0]
+      PaintableBox (Box<DIV>.column.outer.flex-end) [38,1748 330x90] overflow: [53,1743 300x80]
+        PaintableWithLines (BlockContainer<DIV>) [53,1743 180x80]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [38,1838 724x0]
+      PaintableBox (Box<DIV>.column.outer.center) [38,1838 330x90] overflow: [53,1843 300x80]
+        PaintableWithLines (BlockContainer<DIV>) [53,1843 180x80]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [38,1928 724x0]
+      PaintableBox (Box<DIV>.column.outer.space-around) [38,1928 330x90] overflow: [53,1933 300x80]
+        PaintableWithLines (BlockContainer<DIV>) [53,1933 180x80]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [38,2018 724x0]
+      PaintableBox (Box<DIV>.column.outer.space-between) [38,2018 330x90] overflow: [53,2033 300x80]
+        PaintableWithLines (BlockContainer<DIV>) [53,2033 180x80]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [38,2108 724x0]
+      PaintableBox (Box<DIV>.column.outer.space-evenly) [38,2108 330x90] overflow: [53,2113 300x80]
+        PaintableWithLines (BlockContainer<DIV>) [53,2113 180x80]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [38,2198 724x0]
+      PaintableBox (Box<DIV>.column.reverse.outer.start) [38,2198 330x90] overflow: [53,2213 300x80]
+        PaintableWithLines (BlockContainer<DIV>) [53,2213 180x80]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [38,2288 724x0]
+      PaintableBox (Box<DIV>.column.reverse.outer.flex-start) [38,2288 330x90] overflow: [53,2283 300x80]
+        PaintableWithLines (BlockContainer<DIV>) [53,2283 180x80]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [38,2378 724x0]
+      PaintableBox (Box<DIV>.column.reverse.outer.end) [38,2378 330x90] overflow: [53,2373 300x80]
+        PaintableWithLines (BlockContainer<DIV>) [53,2373 180x80]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [38,2468 724x0]
+      PaintableBox (Box<DIV>.column.reverse.outer.flex-end) [38,2468 330x90] overflow: [53,2483 300x80]
+        PaintableWithLines (BlockContainer<DIV>) [53,2483 180x80]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [38,2558 724x0]
+      PaintableBox (Box<DIV>.column.reverse.outer.center) [38,2558 330x90] overflow: [53,2563 300x80]
+        PaintableWithLines (BlockContainer<DIV>) [53,2563 180x80]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [38,2648 724x0]
+      PaintableBox (Box<DIV>.column.reverse.outer.space-around) [38,2648 330x90] overflow: [53,2653 300x80]
+        PaintableWithLines (BlockContainer<DIV>) [53,2653 180x80]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [38,2738 724x0]
+      PaintableBox (Box<DIV>.column.reverse.outer.space-between) [38,2738 330x90] overflow: [53,2733 300x80]
+        PaintableWithLines (BlockContainer<DIV>) [53,2733 180x80]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [38,2828 724x0]
+      PaintableBox (Box<DIV>.column.reverse.outer.space-evenly) [38,2828 330x90] overflow: [53,2833 300x80]
+        PaintableWithLines (BlockContainer<DIV>) [53,2833 180x80]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [38,2918 724x0]

--- a/Tests/LibWeb/Layout/expected/flex/align-keywords-start-and-end.txt
+++ b/Tests/LibWeb/Layout/expected/flex/align-keywords-start-and-end.txt
@@ -29,3 +29,21 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,276.40625) content-size 780x0 children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x286.40625]
+    PaintableWithLines (BlockContainer<BODY>) [9,9 782x268.40625]
+      PaintableBox (Box<DIV>.flex.row.align-start) [10,10 502x202]
+        PaintableWithLines (BlockContainer<DIV>) [11,11 138.5x19.46875]
+          TextPaintable (TextNode<#text>)
+      PaintableBox (Box<DIV>.flex.align-end) [10,212 502x21.46875]
+        PaintableWithLines (BlockContainer<DIV>) [11,213 123.453125x19.46875]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [10,233.46875 780x0]
+      PaintableBox (Box<DIV>.flex.align-start) [10,233.46875 502x21.46875]
+        PaintableWithLines (BlockContainer<DIV>) [11,234.46875 138.5x19.46875]
+          TextPaintable (TextNode<#text>)
+      PaintableBox (Box<DIV>.flex.column.align-end) [10,254.9375 502x21.46875]
+        PaintableWithLines (BlockContainer<DIV>) [387.546875,255.9375 123.453125x19.46875]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [10,276.40625 780x0]

--- a/Tests/LibWeb/Layout/expected/flex/align-self-end-crash.txt
+++ b/Tests/LibWeb/Layout/expected/flex/align-self-end-crash.txt
@@ -2,3 +2,8 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x16 [BFC] children: not-inline
     Box <body> at (8,8) content-size 784x0 flex-container(row) [FFC] children: not-inline
       BlockContainer <div> at (8,8) content-size 0x0 flex-item [BFC] children: not-inline
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x16]
+    PaintableBox (Box<BODY>) [8,8 784x0]
+      PaintableWithLines (BlockContainer<DIV>) [8,8 0x0]

--- a/Tests/LibWeb/Layout/expected/flex/automatic-minimum-size-with-explicit-flex-basis-and-flex-container-with-max-content-main-size.txt
+++ b/Tests/LibWeb/Layout/expected/flex/automatic-minimum-size-with-explicit-flex-basis-and-flex-container-with-max-content-main-size.txt
@@ -6,3 +6,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           frag 0 from TextNode start: 0, length: 5, rect: [11,11 36.84375x17.46875]
             "hello"
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x70]
+    PaintableBox (Box<BODY>.flex) [9,9 40.84375x52]
+      PaintableWithLines (BlockContainer<DIV>.item) [10,10 38.84375x50]
+        TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/flex/box-baseline-with-inline-flex-empty-child.txt
+++ b/Tests/LibWeb/Layout/expected/flex/box-baseline-with-inline-flex-empty-child.txt
@@ -7,3 +7,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         Box <span.second> at (22,22) content-size 0x0 flex-container(row) [FFC] children: not-inline
           BlockContainer <(anonymous)> at (22,22) content-size 0x0 [BFC] children: inline
             TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x44]
+    PaintableWithLines (BlockContainer<BODY>) [9,9 782x26]
+      PaintableWithLines (BlockContainer<DIV>.first) [10,10 780x24]
+        PaintableBox (Box<SPAN>.second) [11,11 22x22]
+          PaintableWithLines (BlockContainer(anonymous)) [22,22 0x0]

--- a/Tests/LibWeb/Layout/expected/flex/calc-flex-basis.txt
+++ b/Tests/LibWeb/Layout/expected/flex/calc-flex-basis.txt
@@ -22,3 +22,16 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             frag 0 from TextNode start: 0, length: 6, rect: [401,42 60.15625x21.828125]
               "Item 4"
           TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x82]
+    PaintableWithLines (BlockContainer<BODY>) [9,9 782x64]
+      PaintableBox (Box<DIV>.flex-container) [10,10 780x62]
+        PaintableWithLines (BlockContainer<DIV>.flex-item) [11,11 388x30]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.flex-item) [400,11 388x30]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.flex-item) [11,41 388x30]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.flex-item) [400,41 388x30]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/flex/cross-size-of-item-with-box-sizing-border-box-and-nonzero-padding.txt
+++ b/Tests/LibWeb/Layout/expected/flex/cross-size-of-item-with-box-sizing-border-box-and-nonzero-padding.txt
@@ -25,3 +25,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             frag 0 from TextNode start: 560, length: 95, rect: [12,166.8125 765.578125x17.46875]
               "Pellentesque eget justo nulla. Duis consectetur imperdiet nisi, ac tincidunt urna blandit quis."
           TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x246.28125]
+    PaintableWithLines (BlockContainer<BODY>) [9,9 782x228.28125]
+      PaintableBox (Box<DIV>.outer.flex.flex-wrap) [10,10 780x226.28125]
+        PaintableWithLines (BlockContainer<DIV>.inner) [11,11 778x224.28125]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/flex/flex-column-container-with-max-width-max-content.txt
+++ b/Tests/LibWeb/Layout/expected/flex/flex-column-container-with-max-width-max-content.txt
@@ -1,3 +1,7 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x16 [BFC] children: not-inline
     Box <body> at (8,8) content-size 0x0 flex-container(column) [FFC] children: not-inline
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x16]
+    PaintableBox (Box<BODY>) [8,8 0x0]

--- a/Tests/LibWeb/Layout/expected/flex/flex-column-item-with-intrinsic-aspect-ratio-and-percentage-max-width.txt
+++ b/Tests/LibWeb/Layout/expected/flex/flex-column-item-with-intrinsic-aspect-ratio-and-percentage-max-width.txt
@@ -2,3 +2,8 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (1,1) content-size 798x120 [BFC] children: not-inline
     Box <body> at (10,10) content-size 780x102 flex-container(column) [FFC] children: not-inline
       ImageBox <img> at (11,11) content-size 100x100 flex-item children: not-inline
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x122]
+    PaintableBox (Box<BODY>) [9,9 782x104]
+      ImagePaintable (ImageBox<IMG>) [10,10 102x102]

--- a/Tests/LibWeb/Layout/expected/flex/flex-column-item-with-natural-aspect-ratio-and-automatic-cross-size.txt
+++ b/Tests/LibWeb/Layout/expected/flex/flex-column-item-with-natural-aspect-ratio-and-automatic-cross-size.txt
@@ -3,3 +3,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     Box <body> at (0,0) content-size 800x100 flex-container(column) [FFC] children: not-inline
       SVGSVGBox <svg> at (0,0) content-size 200x100 flex-item [SVG] children: not-inline
         SVGGeometryBox <rect> at (0,0) content-size 200x100 children: not-inline
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x100]
+    PaintableBox (Box<BODY>) [0,0 800x100]
+      SVGSVGPaintable (SVGSVGBox<svg>) [0,0 200x100]
+        SVGGeometryPaintable (SVGGeometryBox<rect>) [0,0 200x100]

--- a/Tests/LibWeb/Layout/expected/flex/flex-column-item-with-percentage-max-width.txt
+++ b/Tests/LibWeb/Layout/expected/flex/flex-column-item-with-percentage-max-width.txt
@@ -9,3 +9,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x122]
+    PaintableWithLines (BlockContainer<BODY>) [9,9 56x104]
+      PaintableBox (Box<DIV>.flex) [10,10 54x102]
+        PaintableWithLines (BlockContainer<DIV>.hmm) [11,11 52x19.46875]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/flex/flex-container-intrinsic-cross-size-with-max-content-main-size.txt
+++ b/Tests/LibWeb/Layout/expected/flex/flex-container-intrinsic-cross-size-with-max-content-main-size.txt
@@ -7,3 +7,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             frag 0 from TextNode start: 0, length: 35, rect: [18,18 280.84375x17.46875]
               "this text should be all on one line"
           TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x53.46875]
+    PaintableWithLines (BlockContainer<BODY>.outer) [8,8 300.84375x37.46875]
+      PaintableBox (Box<DIV>.inner) [18,18 280.84375x17.46875]
+        PaintableWithLines (BlockContainer(anonymous)) [18,18 280.84375x17.46875]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/flex/flex-container-with-max-width-and-negative-margin-in-same-axis.txt
+++ b/Tests/LibWeb/Layout/expected/flex/flex-container-with-max-width-and-negative-margin-in-same-axis.txt
@@ -5,3 +5,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         Box <div#flex> at (-92,8) content-size 200x100 flex-container(row) [FFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) [BFC] children: inline
             TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600] overflow: [-92,0 892x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x116] overflow: [-92,0 892x116]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x100] overflow: [-92,8 884x100]
+      PaintableWithLines (BlockContainer<DIV>#container-of-flex) [8,8 100x100] overflow: [-92,8 200x100]
+        PaintableBox (Box<DIV>#flex) [-92,8 200x100]

--- a/Tests/LibWeb/Layout/expected/flex/flex-gap-between-items-and-lines.txt
+++ b/Tests/LibWeb/Layout/expected/flex/flex-gap-between-items-and-lines.txt
@@ -10,3 +10,16 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <div> at (64,156) content-size 30x30 flex-item [BFC] children: not-inline
         BlockContainer <div> at (12,228) content-size 30x30 flex-item [BFC] children: not-inline
         BlockContainer <div> at (64,228) content-size 30x30 flex-item [BFC] children: not-inline
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x602]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x602]
+    PaintableWithLines (BlockContainer<BODY>) [9,9 782x252]
+      PaintableBox (Box<DIV>.flexbox) [10,10 102x250]
+        PaintableWithLines (BlockContainer<DIV>) [11,11 32x32]
+        PaintableWithLines (BlockContainer<DIV>) [63,11 32x32]
+        PaintableWithLines (BlockContainer<DIV>) [11,83 32x32]
+        PaintableWithLines (BlockContainer<DIV>) [63,83 32x32]
+        PaintableWithLines (BlockContainer<DIV>) [11,155 32x32]
+        PaintableWithLines (BlockContainer<DIV>) [63,155 32x32]
+        PaintableWithLines (BlockContainer<DIV>) [11,227 32x32]
+        PaintableWithLines (BlockContainer<DIV>) [63,227 32x32]

--- a/Tests/LibWeb/Layout/expected/flex/flex-item-min-width-fit-content.txt
+++ b/Tests/LibWeb/Layout/expected/flex/flex-item-min-width-fit-content.txt
@@ -20,3 +20,13 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             frag 0 from TextNode start: 0, length: 6, rect: [454.671875,12 53.328125x17.46875]
               "Reject"
           TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x72]
+    PaintableBox (Box<BODY>) [9,9 502x54]
+      PaintableWithLines (BlockContainer<DIV>.big) [10,10 383.625x52]
+      PaintableWithLines (BlockContainer<DIV>.buttons) [393.625,10 116.375x52]
+        PaintableWithLines (BlockContainer<DIV>.button) [394.625,11 59.046875x19.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.button) [453.671875,11 55.328125x19.46875]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/flex/flex-item-with-calc-main-size-and-layout-dependent-containing-block-size.txt
+++ b/Tests/LibWeb/Layout/expected/flex/flex-item-with-calc-main-size-and-layout-dependent-containing-block-size.txt
@@ -13,3 +13,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             frag 0 from TextNode start: 19, length: 4, rect: [8,42.9375 32.140625x17.46875]
               "text"
           TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x68.40625]
+    PaintableBox (Box<BODY>.pink) [8,8 784x52.40625]
+      PaintableBox (Box<DIV>.orange) [8,8 194.71875x52.40625]
+        PaintableWithLines (BlockContainer<DIV>.lime) [8,8 87.34375x52.40625]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/flex/flex-item-with-intrinsic-aspect-ratio-and-max-height.txt
+++ b/Tests/LibWeb/Layout/expected/flex/flex-item-with-intrinsic-aspect-ratio-and-max-height.txt
@@ -4,3 +4,8 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       ImageBox <img> at (11,11) content-size 66.65625x49.984375 flex-item children: not-inline
       BlockContainer <(anonymous)> (not painted) [BFC] children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x71.96875]
+    PaintableBox (Box<BODY>) [9,9 782x53.96875] overflow: [10,10 780x51.984375]
+      ImagePaintable (ImageBox<IMG>) [10,10 68.65625x51.984375]

--- a/Tests/LibWeb/Layout/expected/flex/flex-row-reverse-with-centered-content.txt
+++ b/Tests/LibWeb/Layout/expected/flex/flex-row-reverse-with-centered-content.txt
@@ -17,3 +17,14 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             frag 0 from TextNode start: 0, length: 1, rect: [325,8 9.09375x17.46875]
               "3"
           TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x66]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x50]
+      PaintableBox (Box<DIV>.flex) [8,8 784x50]
+        PaintableWithLines (BlockContainer<DIV>) [425,8 50x50]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [375,8 50x50]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [325,8 50x50]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/flex/flex-shorthand-flex-basis-zero-percent.txt
+++ b/Tests/LibWeb/Layout/expected/flex/flex-shorthand-flex-basis-zero-percent.txt
@@ -27,3 +27,20 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               frag 0 from TextNode start: 0, length: 7, rect: [48.84375,66 55.359375x17.46875]
                 "friends"
             TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x128]
+    PaintableWithLines (BlockContainer<BODY>) [9,9 782x110]
+      PaintableBox (Box<DIV>.flex) [10,10 502x54]
+        PaintableWithLines (BlockContainer(anonymous)) [11,11 36.84375x52]
+          TextPaintable (TextNode<#text>)
+        PaintableBox (Box<DIV>.item.one) [47.84375,11 463.15625x52]
+          PaintableWithLines (BlockContainer(anonymous)) [48.84375,12 55.359375x50]
+            TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [10,64 780x0]
+      PaintableBox (Box<DIV>.flex) [10,64 502x54]
+        PaintableWithLines (BlockContainer(anonymous)) [11,65 36.84375x52]
+          TextPaintable (TextNode<#text>)
+        PaintableBox (Box<DIV>.item.two) [47.84375,65 463.15625x52]
+          PaintableWithLines (BlockContainer(anonymous)) [48.84375,66 55.359375x50]
+            TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/flex/inf-available-space-with-auto-margins.txt
+++ b/Tests/LibWeb/Layout/expected/flex/inf-available-space-with-auto-margins.txt
@@ -6,3 +6,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           frag 0 from TextNode start: 0, length: 13, rect: [8,8 153.984375x17.46875]
             "hmmMMMMmmmmmm"
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x33.46875]
+    PaintableBox (Box<BODY>) [8,8 784x17.46875]
+      PaintableWithLines (BlockContainer<MAIN>) [8,8 784x17.46875]
+        TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/flex/inline-flex-with-main-axis-margin-on-flex-container.txt
+++ b/Tests/LibWeb/Layout/expected/flex/inline-flex-with-main-axis-margin-on-flex-container.txt
@@ -8,3 +8,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           frag 0 from TextNode start: 0, length: 20, rect: [11,11 160.40625x17.46875]
             "Immobilie inserieren"
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 502x39.46875]
+    PaintableBox (Box<BODY>) [9,9 164.40625x21.46875]
+      PaintableWithLines (BlockContainer<DIV>) [10,10 162.40625x19.46875]
+        TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/flex/intrinsic-height-of-flex-container-with-svg-item-that-only-has-natural-aspect-ratio.txt
+++ b/Tests/LibWeb/Layout/expected/flex/intrinsic-height-of-flex-container-with-svg-item-that-only-has-natural-aspect-ratio.txt
@@ -3,3 +3,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     Box <body> at (8,8) content-size 784x0 flex-container(column) [FFC] children: not-inline
       SVGSVGBox <svg> at (400,8) content-size 0x0 flex-item [SVG] children: not-inline
         SVGGeometryBox <rect> at (400,8) content-size 0x0 children: not-inline
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x16]
+    PaintableBox (Box<BODY>) [8,8 784x0]
+      SVGSVGPaintable (SVGSVGBox<svg>) [400,8 0x0]
+        SVGGeometryPaintable (SVGGeometryBox<rect>) [400,8 0x0]

--- a/Tests/LibWeb/Layout/expected/flex/justify-content-1.txt
+++ b/Tests/LibWeb/Layout/expected/flex/justify-content-1.txt
@@ -579,3 +579,264 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,5834) content-size 780x0 children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x5844]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x5844]
+    PaintableWithLines (BlockContainer<BODY>) [9,9 782x5826]
+      PaintableWithLines (BlockContainer(anonymous)) [10,10 780x0]
+      PaintableBox (Box<DIV>.row.outer.start) [10,10 302x62]
+        PaintableWithLines (BlockContainer<DIV>) [11,11 52x52]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [63,11 52x52]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [115,11 52x52]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [10,72 780x0]
+      PaintableBox (Box<DIV>.row.outer.flex-start) [10,72 302x62]
+        PaintableWithLines (BlockContainer<DIV>) [11,73 52x52] overflow: [12,74 76.8125x50]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [63,73 52x52]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [115,73 52x52]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [10,134 780x0]
+      PaintableBox (Box<DIV>.row.outer.end) [10,134 302x62]
+        PaintableWithLines (BlockContainer<DIV>) [155,135 52x52]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [207,135 52x52]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [259,135 52x52]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [10,196 780x0]
+      PaintableBox (Box<DIV>.row.outer.flex-end) [10,196 302x62]
+        PaintableWithLines (BlockContainer<DIV>) [155,197 52x52] overflow: [156,198 61.765625x50]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [207,197 52x52]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [259,197 52x52]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [10,258 780x0]
+      PaintableBox (Box<DIV>.row.outer.center) [10,258 302x62]
+        PaintableWithLines (BlockContainer<DIV>) [83,259 52x52] overflow: [84,260 51.625x50]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [135,259 52x52]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [187,259 52x52]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [10,320 780x0]
+      PaintableBox (Box<DIV>.row.outer.space-around) [10,320 302x62]
+        PaintableWithLines (BlockContainer<DIV>) [35,321 52x52] overflow: [36,322 107.96875x50]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [135,321 52x52]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [235,321 52x52]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [10,382 780x0]
+      PaintableBox (Box<DIV>.row.outer.space-between) [10,382 302x62]
+        PaintableWithLines (BlockContainer<DIV>) [11,383 52x52] overflow: [12,384 115.515625x50]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [135,383 52x52]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [259,383 52x52]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [10,444 780x0]
+      PaintableBox (Box<DIV>.row.outer.space-evenly) [10,444 302x62]
+        PaintableWithLines (BlockContainer<DIV>) [47,445 52x52] overflow: [48,446 98.859375x50]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [135,445 52x52]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [223,445 52x52]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [10,506 780x0]
+      PaintableBox (Box<DIV>.row.reverse.outer.start) [10,506 302x62]
+        PaintableWithLines (BlockContainer<DIV>) [115,507 52x52]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [63,507 52x52]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [11,507 52x52]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [10,568 780x0]
+      PaintableBox (Box<DIV>.row.reverse.outer.flex-start) [10,568 302x62] overflow: [11,569 325.8125x60]
+        PaintableWithLines (BlockContainer<DIV>) [259,569 52x52] overflow: [260,570 76.8125x50]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [207,569 52x52]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [155,569 52x52]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [10,630 780x0]
+      PaintableBox (Box<DIV>.row.reverse.outer.end) [10,630 302x62]
+        PaintableWithLines (BlockContainer<DIV>) [259,631 52x52]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [207,631 52x52]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [155,631 52x52]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [10,692 780x0]
+      PaintableBox (Box<DIV>.row.reverse.outer.flex-end) [10,692 302x62]
+        PaintableWithLines (BlockContainer<DIV>) [115,693 52x52] overflow: [116,694 61.765625x50]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [63,693 52x52]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [11,693 52x52]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [10,754 780x0]
+      PaintableBox (Box<DIV>.row.reverse.outer.center) [10,754 302x62]
+        PaintableWithLines (BlockContainer<DIV>) [187,755 52x52] overflow: [188,756 51.625x50]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [135,755 52x52]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [83,755 52x52]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [10,816 780x0]
+      PaintableBox (Box<DIV>.row.reverse.outer.space-around) [10,816 302x62] overflow: [11,817 332.96875x60]
+        PaintableWithLines (BlockContainer<DIV>) [235,817 52x52] overflow: [236,818 107.96875x50]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [135,817 52x52]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [35,817 52x52]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [10,878 780x0]
+      PaintableBox (Box<DIV>.row.reverse.outer.space-between) [10,878 302x62] overflow: [11,879 364.515625x60]
+        PaintableWithLines (BlockContainer<DIV>) [259,879 52x52] overflow: [260,880 115.515625x50]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [135,879 52x52]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [11,879 52x52]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [10,940 780x0]
+      PaintableBox (Box<DIV>.row.reverse.outer.space-evenly) [10,940 302x62] overflow: [11,941 311.859375x60]
+        PaintableWithLines (BlockContainer<DIV>) [223,941 52x52] overflow: [224,942 98.859375x50]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [135,941 52x52]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [47,941 52x52]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [10,1002 780x0]
+      PaintableBox (Box<DIV>.column.outer.start) [10,1002 62x302]
+        PaintableWithLines (BlockContainer<DIV>) [11,1003 52x52]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [11,1055 52x52]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [11,1107 52x52]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [10,1304 780x0]
+      PaintableBox (Box<DIV>.column.outer.flex-start) [10,1304 62x302] overflow: [11,1305 77.8125x300]
+        PaintableWithLines (BlockContainer<DIV>) [11,1305 52x52] overflow: [12,1306 76.8125x50]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [11,1357 52x52]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [11,1409 52x52]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [10,1606 780x0]
+      PaintableBox (Box<DIV>.column.outer.end) [10,1606 62x302]
+        PaintableWithLines (BlockContainer<DIV>) [11,1751 52x52]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [11,1803 52x52]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [11,1855 52x52]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [10,1908 780x0]
+      PaintableBox (Box<DIV>.column.outer.flex-end) [10,1908 62x302] overflow: [11,1909 62.765625x300]
+        PaintableWithLines (BlockContainer<DIV>) [11,2053 52x52] overflow: [12,2054 61.765625x50]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [11,2105 52x52]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [11,2157 52x52]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [10,2210 780x0]
+      PaintableBox (Box<DIV>.column.outer.center) [10,2210 62x302]
+        PaintableWithLines (BlockContainer<DIV>) [11,2283 52x52] overflow: [12,2284 51.625x50]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [11,2335 52x52]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [11,2387 52x52]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [10,2512 780x0]
+      PaintableBox (Box<DIV>.column.outer.space-around) [10,2512 62x302] overflow: [11,2513 108.96875x300]
+        PaintableWithLines (BlockContainer<DIV>) [11,2537 52x52] overflow: [12,2538 107.96875x50]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [11,2637 52x52]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [11,2737 52x52]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [10,2814 780x0]
+      PaintableBox (Box<DIV>.column.outer.space-between) [10,2814 62x302] overflow: [11,2815 116.515625x300]
+        PaintableWithLines (BlockContainer<DIV>) [11,2815 52x52] overflow: [12,2816 115.515625x50]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [11,2939 52x52]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [11,3063 52x52]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [10,3116 780x0]
+      PaintableBox (Box<DIV>.column.outer.space-evenly) [10,3116 62x302] overflow: [11,3117 99.859375x300]
+        PaintableWithLines (BlockContainer<DIV>) [11,3153 52x52] overflow: [12,3154 98.859375x50]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [11,3241 52x52]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [11,3329 52x52]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [10,3418 780x0]
+      PaintableBox (Box<DIV>.column.reverse.outer.start) [10,3418 62x302]
+        PaintableWithLines (BlockContainer<DIV>) [11,3523 52x52]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [11,3471 52x52]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [11,3419 52x52]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [10,3720 780x0]
+      PaintableBox (Box<DIV>.column.reverse.outer.flex-start) [10,3720 62x302] overflow: [11,3721 77.8125x300]
+        PaintableWithLines (BlockContainer<DIV>) [11,3969 52x52] overflow: [12,3970 76.8125x50]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [11,3917 52x52]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [11,3865 52x52]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [10,4022 780x0]
+      PaintableBox (Box<DIV>.column.reverse.outer.end) [10,4022 62x302]
+        PaintableWithLines (BlockContainer<DIV>) [11,4271 52x52]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [11,4219 52x52]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [11,4167 52x52]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [10,4324 780x0]
+      PaintableBox (Box<DIV>.column.reverse.outer.flex-end) [10,4324 62x302] overflow: [11,4325 62.765625x300]
+        PaintableWithLines (BlockContainer<DIV>) [11,4429 52x52] overflow: [12,4430 61.765625x50]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [11,4377 52x52]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [11,4325 52x52]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [10,4626 780x0]
+      PaintableBox (Box<DIV>.column.reverse.outer.center) [10,4626 62x302]
+        PaintableWithLines (BlockContainer<DIV>) [11,4803 52x52] overflow: [12,4804 51.625x50]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [11,4751 52x52]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [11,4699 52x52]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [10,4928 780x0]
+      PaintableBox (Box<DIV>.column.reverse.outer.space-around) [10,4928 62x302] overflow: [11,4929 108.96875x300]
+        PaintableWithLines (BlockContainer<DIV>) [11,5153 52x52] overflow: [12,5154 107.96875x50]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [11,5053 52x52]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [11,4953 52x52]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [10,5230 780x0]
+      PaintableBox (Box<DIV>.column.reverse.outer.space-between) [10,5230 62x302] overflow: [11,5231 116.515625x300]
+        PaintableWithLines (BlockContainer<DIV>) [11,5479 52x52] overflow: [12,5480 115.515625x50]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [11,5355 52x52]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [11,5231 52x52]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [10,5532 780x0]
+      PaintableBox (Box<DIV>.column.reverse.outer.space-evenly) [10,5532 62x302] overflow: [11,5533 99.859375x300]
+        PaintableWithLines (BlockContainer<DIV>) [11,5745 52x52] overflow: [12,5746 98.859375x50]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [11,5657 52x52]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [11,5569 52x52]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [10,5834 780x0]

--- a/Tests/LibWeb/Layout/expected/flex/justify-content-space-between-single-item.txt
+++ b/Tests/LibWeb/Layout/expected/flex/justify-content-space-between-single-item.txt
@@ -7,3 +7,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             frag 0 from TextNode start: 0, length: 1, rect: [8,8 14.265625x17.46875]
               "A"
           TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x17.46875]
+      PaintableBox (Box<DIV>.container) [8,8 784x17.46875]
+        PaintableWithLines (BlockContainer<DIV>) [8,8 14.265625x17.46875]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/flex/justify-content-with-margin-auto-child.txt
+++ b/Tests/LibWeb/Layout/expected/flex/justify-content-with-margin-auto-child.txt
@@ -291,3 +291,136 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,2922) content-size 780x0 children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x2932]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x2932]
+    PaintableWithLines (BlockContainer<BODY>) [9,9 782x2914]
+      PaintableWithLines (BlockContainer(anonymous)) [10,10 780x0]
+      PaintableBox (Box<DIV>.row.outer.start) [10,10 302x62]
+        PaintableWithLines (BlockContainer<DIV>) [59,11 52x52]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [159,11 52x52]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [259,11 52x52]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [10,72 780x0]
+      PaintableBox (Box<DIV>.row.outer.flex-start) [10,72 302x62]
+        PaintableWithLines (BlockContainer<DIV>) [59,73 52x52] overflow: [60,74 76.8125x50]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [159,73 52x52]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [259,73 52x52]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [10,134 780x0]
+      PaintableBox (Box<DIV>.row.outer.end) [10,134 302x62]
+        PaintableWithLines (BlockContainer<DIV>) [11,135 52x52]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [111,135 52x52]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [211,135 52x52]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [10,196 780x0]
+      PaintableBox (Box<DIV>.row.outer.flex-end) [10,196 302x62]
+        PaintableWithLines (BlockContainer<DIV>) [11,197 52x52] overflow: [12,198 61.765625x50]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [111,197 52x52]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [211,197 52x52]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [10,258 780x0]
+      PaintableBox (Box<DIV>.row.reverse.outer.start) [10,258 302x62]
+        PaintableWithLines (BlockContainer<DIV>) [259,259 52x52]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [159,259 52x52]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [59,259 52x52]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [10,320 780x0]
+      PaintableBox (Box<DIV>.row.reverse.outer.flex-start) [10,320 302x62] overflow: [11,321 325.8125x60]
+        PaintableWithLines (BlockContainer<DIV>) [259,321 52x52] overflow: [260,322 76.8125x50]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [159,321 52x52]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [59,321 52x52]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [10,382 780x0]
+      PaintableBox (Box<DIV>.row.reverse.outer.end) [10,382 302x62]
+        PaintableWithLines (BlockContainer<DIV>) [211,383 52x52]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [111,383 52x52]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [11,383 52x52]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [10,444 780x0]
+      PaintableBox (Box<DIV>.row.reverse.outer.flex-end) [10,444 302x62]
+        PaintableWithLines (BlockContainer<DIV>) [211,445 52x52] overflow: [212,446 61.765625x50]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [111,445 52x52]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [11,445 52x52]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [10,506 780x0]
+      PaintableBox (Box<DIV>.column.outer.start) [10,506 62x302]
+        PaintableWithLines (BlockContainer<DIV>) [19,507 52x52]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [19,559 52x52]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [19,611 52x52]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [10,808 780x0]
+      PaintableBox (Box<DIV>.column.outer.flex-start) [10,808 62x302] overflow: [11,809 85.8125x300]
+        PaintableWithLines (BlockContainer<DIV>) [19,809 52x52] overflow: [20,810 76.8125x50]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [19,861 52x52]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [19,913 52x52]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [10,1110 780x0]
+      PaintableBox (Box<DIV>.column.outer.end) [10,1110 62x302]
+        PaintableWithLines (BlockContainer<DIV>) [11,1255 52x52]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [11,1307 52x52]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [11,1359 52x52]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [10,1412 780x0]
+      PaintableBox (Box<DIV>.column.outer.flex-end) [10,1412 62x302] overflow: [11,1413 62.765625x300]
+        PaintableWithLines (BlockContainer<DIV>) [11,1557 52x52] overflow: [12,1558 61.765625x50]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [11,1609 52x52]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [11,1661 52x52]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [10,1714 780x0]
+      PaintableBox (Box<DIV>.column.reverse.outer.start) [10,1714 62x302]
+        PaintableWithLines (BlockContainer<DIV>) [19,1819 52x52]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [19,1767 52x52]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [19,1715 52x52]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [10,2016 780x0]
+      PaintableBox (Box<DIV>.column.reverse.outer.flex-start) [10,2016 62x302] overflow: [11,2017 85.8125x300]
+        PaintableWithLines (BlockContainer<DIV>) [19,2265 52x52] overflow: [20,2266 76.8125x50]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [19,2213 52x52]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [19,2161 52x52]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [10,2318 780x0]
+      PaintableBox (Box<DIV>.column.reverse.outer.end) [10,2318 62x302]
+        PaintableWithLines (BlockContainer<DIV>) [11,2567 52x52]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [11,2515 52x52]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [11,2463 52x52]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [10,2620 780x0]
+      PaintableBox (Box<DIV>.column.reverse.outer.flex-end) [10,2620 62x302] overflow: [11,2621 62.765625x300]
+        PaintableWithLines (BlockContainer<DIV>) [11,2725 52x52] overflow: [12,2726 61.765625x50]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [11,2673 52x52]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [11,2621 52x52]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [10,2922 780x0]

--- a/Tests/LibWeb/Layout/expected/flex/list-container-display-contents.txt
+++ b/Tests/LibWeb/Layout/expected/flex/list-container-display-contents.txt
@@ -12,3 +12,12 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             frag 0 from TextNode start: 0, length: 3, rect: [762,16 30x17.46875]
               "Mac"
           TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x41.46875]
+    PaintableWithLines (BlockContainer<BODY>) [8,16 784x17.46875]
+      PaintableBox (Box<UL>.globalnav-list) [8,16 784x17.46875]
+        PaintableWithLines (BlockContainer<DIV>#item-1) [48,16 46.734375x17.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>#item-2) [762,16 30x17.46875]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/flex/multi-line-column-container-with-automatic-height.txt
+++ b/Tests/LibWeb/Layout/expected/flex/multi-line-column-container-with-automatic-height.txt
@@ -5,3 +5,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <div> at (12,12) content-size 50x50 flex-item [BFC] children: not-inline
         BlockContainer <div> at (12,64) content-size 50x50 flex-item [BFC] children: not-inline
         BlockContainer <div> at (12,116) content-size 50x50 flex-item [BFC] children: not-inline
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x178]
+    PaintableWithLines (BlockContainer<BODY>) [9,9 782x160]
+      PaintableBox (Box<DIV>.flexbox) [10,10 202x158]
+        PaintableWithLines (BlockContainer<DIV>) [11,11 52x52]
+        PaintableWithLines (BlockContainer<DIV>) [11,63 52x52]
+        PaintableWithLines (BlockContainer<DIV>) [11,115 52x52]

--- a/Tests/LibWeb/Layout/expected/flex/percentage-flex-basis-with-indefinite-flex-container-size.txt
+++ b/Tests/LibWeb/Layout/expected/flex/percentage-flex-basis-with-indefinite-flex-container-size.txt
@@ -7,3 +7,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             frag 0 from TextNode start: 0, length: 20, rect: [8,8 174.234375x17.46875]
               "percentages are hard"
           TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x33.46875]
+    PaintableBox (Box<BODY>.outer) [8,8 200x17.46875]
+      PaintableWithLines (BlockContainer<DIV>.middle) [8,8 200x17.46875]
+        PaintableWithLines (BlockContainer<DIV>.inner) [8,8 200x17.46875]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/flex/relpos-flex-item.txt
+++ b/Tests/LibWeb/Layout/expected/flex/relpos-flex-item.txt
@@ -11,3 +11,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           frag 0 from TextNode start: 0, length: 6, rect: [18,18 53.171875x17.46875]
             "athena"
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x45.46875]
+    PaintableBox (Box<BODY>) [10,10 604x25.46875] overflow: [12,12 600x25.46875]
+      PaintableWithLines (BlockContainer<DIV>.exekiller) [12,12 204x21.46875]
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer<DIV>.athena) [16,16 204x21.46875]
+        TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/flex/reverse-flex-layout-with-space-between-and-space-around.txt
+++ b/Tests/LibWeb/Layout/expected/flex/reverse-flex-layout-with-space-between-and-space-around.txt
@@ -71,3 +71,38 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             frag 0 from TextNode start: 0, length: 7, rect: [8,474.265625 55.359375x17.46875]
               "friends"
           TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x616]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x616]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x600]
+      PaintableBox (Box<DIV>.outer.row) [8,8 150x150]
+        PaintableWithLines (BlockContainer<DIV>.inner) [12.609375,8 30.078125x150]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.inner) [51.921875,8 36.84375x150]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.inner) [98,8 55.359375x150]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,158 784x0]
+      PaintableBox (Box<DIV>.outer.row-reverse) [8,158 150x150]
+        PaintableWithLines (BlockContainer<DIV>.inner) [123.3125,158 30.078125x150]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.inner) [77.234375,158 36.84375x150]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.inner) [12.640625,158 55.359375x150]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,308 784x0]
+      PaintableBox (Box<DIV>.outer.column) [8,308 150x150]
+        PaintableWithLines (BlockContainer<DIV>.inner) [8,324.265625 150x17.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.inner) [8,374.265625 150x17.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.inner) [8,424.265625 150x17.46875]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,458 784x0]
+      PaintableBox (Box<DIV>.outer.column-reverse) [8,458 150x150]
+        PaintableWithLines (BlockContainer<DIV>.inner) [8,574.265625 150x17.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.inner) [8,524.265625 150x17.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.inner) [8,474.265625 150x17.46875]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/flex/specified-size-suggestion-with-box-sizing-border-box.txt
+++ b/Tests/LibWeb/Layout/expected/flex/specified-size-suggestion-with-box-sizing-border-box.txt
@@ -3,3 +3,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     Box <body> at (0,0) content-size 800x100 flex-container(row) [FFC] children: not-inline
       ImageBox <img> at (0,0) content-size 400x100 flex-item children: not-inline
       ImageBox <img.padded> at (600,0) content-size 200x100 flex-item children: not-inline
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x100]
+    PaintableBox (Box<BODY>) [0,0 800x100]
+      ImagePaintable (ImageBox<IMG>) [0,0 400x100]
+      ImagePaintable (ImageBox<IMG>.padded) [400,0 400x100]

--- a/Tests/LibWeb/Layout/expected/flex/stretch-alignment-with-cross-gap.txt
+++ b/Tests/LibWeb/Layout/expected/flex/stretch-alignment-with-cross-gap.txt
@@ -8,3 +8,14 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <div> at (114,95.328125) content-size 100x20 flex-item [BFC] children: not-inline
         BlockContainer <div> at (12,178.65625) content-size 100x20 flex-item [BFC] children: not-inline
         BlockContainer <div> at (114,178.65625) content-size 100x20 flex-item [BFC] children: not-inline
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x222]
+    PaintableWithLines (BlockContainer<BODY>) [9,9 782x204]
+      PaintableBox (Box<DIV>.flex) [10,10 302x202]
+        PaintableWithLines (BlockContainer<DIV>) [11,11 102x22]
+        PaintableWithLines (BlockContainer<DIV>) [113,11 102x22]
+        PaintableWithLines (BlockContainer<DIV>) [11,94.328125 102x22]
+        PaintableWithLines (BlockContainer<DIV>) [113,94.328125 102x22]
+        PaintableWithLines (BlockContainer<DIV>) [11,177.65625 102x22]
+        PaintableWithLines (BlockContainer<DIV>) [113,177.65625 102x22]

--- a/Tests/LibWeb/Layout/expected/floating-non-replaced-element-percentage-padding-against-indefinite-width.txt
+++ b/Tests/LibWeb/Layout/expected/floating-non-replaced-element-percentage-padding-against-indefinite-width.txt
@@ -4,3 +4,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       Box <div#box1> at (8,8) content-size 784x0 flex-container(row) [FFC] children: not-inline
         BlockContainer <div> at (8,8) content-size 0x0 flex-item [BFC] children: not-inline
           Box <div#box2> at (8,8) content-size 0x0 floating flex-container(row) [FFC] children: not-inline
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x16]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x0]
+      PaintableBox (Box<DIV>#box1) [8,8 784x0]
+        PaintableWithLines (BlockContainer<DIV>) [8,8 0x0]
+          PaintableBox (Box<DIV>#box2) [8,8 0x0]

--- a/Tests/LibWeb/Layout/expected/floating-replaced-element-percentage-padding-against-indefinite-width.txt
+++ b/Tests/LibWeb/Layout/expected/floating-replaced-element-percentage-padding-against-indefinite-width.txt
@@ -4,3 +4,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       Box <div#box1> at (8,8) content-size 784x64 flex-container(row) [FFC] children: not-inline
         BlockContainer <div> at (8,8) content-size 16x64 flex-item [BFC] children: not-inline
           ImageBox <img#box2> at (24,24) content-size 16x32 floating flex-container(row) children: not-inline
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x80]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x64]
+      PaintableBox (Box<DIV>#box1) [8,8 784x64]
+        PaintableWithLines (BlockContainer<DIV>) [8,8 16x64] overflow: [8,8 48x64]
+          ImagePaintable (ImageBox<IMG>#box2) [8,8 48x64]

--- a/Tests/LibWeb/Layout/expected/font-with-many-normal-values.txt
+++ b/Tests/LibWeb/Layout/expected/font-with-many-normal-values.txt
@@ -28,3 +28,18 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       InlineNode <span.four>
         TextNode <#text>
       TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x215.984375]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x199.984375] overflow: [8,8 784x200]
+      InlinePaintable (InlineNode<SPAN>.one)
+        TextPaintable (TextNode<#text>)
+      TextPaintable (TextNode<#text>)
+      InlinePaintable (InlineNode<SPAN>.two)
+        TextPaintable (TextNode<#text>)
+      TextPaintable (TextNode<#text>)
+      InlinePaintable (InlineNode<SPAN>.three)
+        TextPaintable (TextNode<#text>)
+      TextPaintable (TextNode<#text>)
+      InlinePaintable (InlineNode<SPAN>.four)
+        TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/getComputedStyle-on-unconnected-element.txt
+++ b/Tests/LibWeb/Layout/expected/getComputedStyle-on-unconnected-element.txt
@@ -5,3 +5,8 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         frag 0 from TextNode start: 0, length: 35, rect: [8,8 362.59375x21.828125]
           "This test passes if we don't crash."
       TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x37.828125]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x21.828125]
+      TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/grid/align-items.txt
+++ b/Tests/LibWeb/Layout/expected/grid/align-items.txt
@@ -40,3 +40,25 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             frag 0 from TextNode start: 0, length: 4, rect: [411,204.9375 38.140625x17.46875]
               "End2"
           TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x264.40625]
+    PaintableWithLines (BlockContainer<BODY>) [9,9 782x246.40625]
+      PaintableWithLines (BlockContainer(anonymous)) [10,10 780x0]
+      PaintableBox (Box<DIV>.grid.start) [10,10 780x81.46875]
+        PaintableWithLines (BlockContainer<DIV>) [31,31 369x19.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.item-padding) [400,31 369x39.46875]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [10,91.46875 780x0]
+      PaintableBox (Box<DIV>.grid.center) [10,91.46875 780x81.46875]
+        PaintableWithLines (BlockContainer<DIV>) [31,122.46875 369x19.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.item-padding) [400,112.46875 369x39.46875]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [10,172.9375 780x0]
+      PaintableBox (Box<DIV>.grid.end) [10,172.9375 780x81.46875]
+        PaintableWithLines (BlockContainer<DIV>) [31,213.9375 369x19.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.item-padding) [400,193.9375 369x39.46875]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/grid/align-self.txt
+++ b/Tests/LibWeb/Layout/expected/grid/align-self.txt
@@ -40,3 +40,25 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             frag 0 from TextNode start: 0, length: 4, rect: [411,204.9375 38.140625x17.46875]
               "End2"
           TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x264.40625]
+    PaintableWithLines (BlockContainer<BODY>) [9,9 782x246.40625]
+      PaintableWithLines (BlockContainer(anonymous)) [10,10 780x0]
+      PaintableBox (Box<DIV>.grid) [10,10 780x81.46875]
+        PaintableWithLines (BlockContainer<DIV>.start) [31,31 369x19.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.item-padding) [400,31 369x39.46875]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [10,91.46875 780x0]
+      PaintableBox (Box<DIV>.grid) [10,91.46875 780x81.46875]
+        PaintableWithLines (BlockContainer<DIV>.center) [31,122.46875 369x19.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.item-padding) [400,112.46875 369x39.46875]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [10,172.9375 780x0]
+      PaintableBox (Box<DIV>.grid) [10,172.9375 780x81.46875]
+        PaintableWithLines (BlockContainer<DIV>.end) [31,213.9375 369x19.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.item-padding) [400,193.9375 369x39.46875]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/grid/all-implicit-rows.txt
+++ b/Tests/LibWeb/Layout/expected/grid/all-implicit-rows.txt
@@ -34,3 +34,17 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,208) content-size 784x0 children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x200]
+      PaintableBox (Box<DIV>.grid-container) [8,8 784x200]
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [8,8 392x100]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [400,8 392x100]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [8,108 392x100]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [400,108 392x100]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,208 784x0]

--- a/Tests/LibWeb/Layout/expected/grid/anonymous-inline-child.txt
+++ b/Tests/LibWeb/Layout/expected/grid/anonymous-inline-child.txt
@@ -7,3 +7,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             frag 0 from TextNode start: 0, length: 5, rect: [8,8 36.84375x17.46875]
               "hello"
           TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x17.46875]
+      PaintableBox (Box<DIV>.grid) [8,8 784x17.46875]
+        PaintableWithLines (BlockContainer(anonymous)) [8,8 784x17.46875]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/grid/auto-fill.txt
+++ b/Tests/LibWeb/Layout/expected/grid/auto-fill.txt
@@ -25,3 +25,14 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x17.46875]
+      PaintableBox (Box<DIV>.grid-container) [8,8 784x17.46875]
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [8,8 261.328125x17.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [269.328125,8 261.328125x17.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [530.65625,8 261.328125x17.46875]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/grid/auto-fit-collapse-empty-tracks.txt
+++ b/Tests/LibWeb/Layout/expected/grid/auto-fit-collapse-empty-tracks.txt
@@ -7,3 +7,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             frag 0 from TextNode start: 0, length: 1, rect: [48,48 6.34375x17.46875]
               "1"
           TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x97.46875]
+      PaintableBox (Box<DIV>.container) [8,8 784x97.46875]
+        PaintableWithLines (BlockContainer<DIV>.item) [18,18 764x77.46875]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/grid/auto-fit.txt
+++ b/Tests/LibWeb/Layout/expected/grid/auto-fit.txt
@@ -25,3 +25,14 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x17.46875]
+      PaintableBox (Box<DIV>.grid-container) [8,8 784x17.46875]
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [8,8 261.328125x17.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [269.328125,8 261.328125x17.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [530.65625,8 261.328125x17.46875]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/grid/auto-track-sizes.txt
+++ b/Tests/LibWeb/Layout/expected/grid/auto-track-sizes.txt
@@ -6,3 +6,12 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <div#c2> at (8,8) content-size 52x24 [BFC] children: not-inline
         BlockContainer <div#c3> at (8,8) content-size 83x41 [BFC] children: not-inline
         BlockContainer <div#c4> at (8,8) content-size 120x60 [BFC] children: not-inline
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x60]
+      PaintableBox (Box<DIV>.grid) [8,8 784x60]
+        PaintableWithLines (BlockContainer<DIV>#c1) [8,8 23x11]
+        PaintableWithLines (BlockContainer<DIV>#c2) [8,8 52x24]
+        PaintableWithLines (BlockContainer<DIV>#c3) [8,8 83x41]
+        PaintableWithLines (BlockContainer<DIV>#c4) [8,8 120x60]

--- a/Tests/LibWeb/Layout/expected/grid/basic-2.txt
+++ b/Tests/LibWeb/Layout/expected/grid/basic-2.txt
@@ -12,3 +12,12 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             frag 0 from TextNode start: 0, length: 5, rect: [96.171875,8 45.734375x17.46875]
               "Board"
           TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x17.46875]
+      PaintableBox (Box<DIV>#grid) [8,8 784x17.46875]
+        PaintableWithLines (BlockContainer<DIV>#title) [8,8 88.171875x17.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>#board) [96.171875,8 695.828125x17.46875]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/grid/basic.txt
+++ b/Tests/LibWeb/Layout/expected/grid/basic.txt
@@ -32,3 +32,16 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x34.9375]
+      PaintableBox (Box<DIV>.grid-container) [8,8 784x34.9375]
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [8,8 392x17.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [400,8 392x17.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [8,25.46875 392x17.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [400,25.46875 392x17.46875]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/grid/borders.txt
+++ b/Tests/LibWeb/Layout/expected/grid/borders.txt
@@ -162,3 +162,56 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x428.28125] overflow: [8,8 784x435.75]
+      PaintableBox (Box<DIV>.grid-container) [8,8 784x74.9375]
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [8,8 392x37.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [400,8 392x37.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [8,45.46875 392x37.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [400,45.46875 392x37.46875]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,82.9375 784x0]
+      PaintableBox (Box<DIV>.grid-container) [8,82.9375 784x107.46875]
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [8,82.9375 392x70]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [400,82.9375 392x70]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [8,152.9375 392x37.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [400,152.9375 392x37.46875]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,190.40625 784x0]
+      PaintableBox (Box<DIV>.grid-container) [8,190.40625 784x84.9375]
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [8,190.40625 367x37.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [425,190.40625 367x37.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [8,237.875 367x37.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [425,237.875 367x37.46875]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,275.34375 784x0]
+      PaintableBox (Box<DIV>.grid-container) [8,275.34375 784x90.9375]
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [434.1875,275.34375 357.796875x37.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [8,328.8125 357.796875x37.46875]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,366.28125 784x0]
+      PaintableBox (Box<DIV>.grid-container) [8,366.28125 784x50] overflow: [8,366.28125 784x52.46875]
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [8,366.28125 300x25] overflow: [18,376.28125 280x17.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [308,366.28125 300x25] overflow: [318,376.28125 280x17.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [8,391.28125 300x25] overflow: [18,401.28125 280x17.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [308,391.28125 300x25] overflow: [318,401.28125 280x17.46875]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,416.28125 784x0]
+      PaintableBox (Box<DIV>.grid-container) [8,416.28125 784x20] overflow: [8,416.28125 784x27.46875]
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [8,416.28125 784x20] overflow: [18,426.28125 6.34375x17.46875]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/grid/calc-track-size.txt
+++ b/Tests/LibWeb/Layout/expected/grid/calc-track-size.txt
@@ -9,3 +9,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,25.46875) content-size 784x0 children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x17.46875]
+      PaintableBox (Box<DIV>.grid-container) [8,8 784x17.46875]
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [8,8 200x17.46875]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,25.46875 784x0]

--- a/Tests/LibWeb/Layout/expected/grid/column-1fr-1fr.txt
+++ b/Tests/LibWeb/Layout/expected/grid/column-1fr-1fr.txt
@@ -4,3 +4,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       Box <div.grid> at (8,8) content-size 100x100 [GFC] children: not-inline
         BlockContainer <div.test> at (8,8) content-size 100x100 [BFC] children: not-inline
           BlockContainer <div.big-child> at (8,8) content-size 500x100 children: not-inline
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x100]
+      PaintableBox (Box<DIV>.grid) [8,8 100x100] overflow: [8,8 500x100]
+        PaintableWithLines (BlockContainer<DIV>.test) [8,8 100x100] overflow: [8,8 500x100]
+          PaintableWithLines (BlockContainer<DIV>.big-child) [8,8 500x100]

--- a/Tests/LibWeb/Layout/expected/grid/column-auto-auto.txt
+++ b/Tests/LibWeb/Layout/expected/grid/column-auto-auto.txt
@@ -4,3 +4,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       Box <div.grid> at (8,8) content-size 100x100 [GFC] children: not-inline
         BlockContainer <div.test> at (8,8) content-size 500x100 [BFC] children: not-inline
           BlockContainer <div.big-child> at (8,8) content-size 500x100 children: not-inline
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x100]
+      PaintableBox (Box<DIV>.grid) [8,8 100x100] overflow: [8,8 500x100]
+        PaintableWithLines (BlockContainer<DIV>.test) [8,8 500x100]
+          PaintableWithLines (BlockContainer<DIV>.big-child) [8,8 500x100]

--- a/Tests/LibWeb/Layout/expected/grid/different-column-sizes.txt
+++ b/Tests/LibWeb/Layout/expected/grid/different-column-sizes.txt
@@ -32,3 +32,16 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x34.9375]
+      PaintableBox (Box<DIV>.grid-container) [8,8 784x34.9375]
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [8,8 50x17.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [58,8 392x17.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [8,25.46875 50x17.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [58,25.46875 392x17.46875]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/grid/distribute-extra-space-across-spanned-tracks.txt
+++ b/Tests/LibWeb/Layout/expected/grid/distribute-extra-space-across-spanned-tracks.txt
@@ -25,3 +25,16 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,25.46875) content-size 784x0 children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x17.46875]
+      PaintableBox (Box<DIV>.grid) [8,8 784x17.46875]
+        PaintableWithLines (BlockContainer<DIV>.right) [400,8 392x17.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.left) [8,8 392x17.46875]
+          PaintableWithLines (BlockContainer(anonymous)) [8,8 392x0]
+          PaintableWithLines (BlockContainer<DIV>.inner) [8,8 392x17.46875]
+            TextPaintable (TextNode<#text>)
+          PaintableWithLines (BlockContainer(anonymous)) [8,25.46875 392x0]
+      PaintableWithLines (BlockContainer(anonymous)) [8,25.46875 784x0]

--- a/Tests/LibWeb/Layout/expected/grid/float-container-columns-1fr-1fr.txt
+++ b/Tests/LibWeb/Layout/expected/grid/float-container-columns-1fr-1fr.txt
@@ -22,3 +22,16 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             frag 0 from TextNode start: 0, length: 10, rect: [109.640625,25.46875 84.890625x17.46875]
               "goes-there"
           TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x0] overflow: [8,8 203.28125x34.9375]
+      PaintableBox (Box<DIV>.container) [8,8 203.28125x34.9375]
+        PaintableWithLines (BlockContainer<DIV>.item) [8,8 101.640625x17.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.item) [109.640625,8 101.640625x17.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.item) [8,25.46875 101.640625x17.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.item) [109.640625,25.46875 101.640625x17.46875]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/grid/grid-gap-1.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-gap-1.txt
@@ -22,3 +22,16 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             frag 0 from TextNode start: 0, length: 1, rect: [450,75.46875 7.75x17.46875]
               "4"
           TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x84.9375]
+      PaintableBox (Box<DIV>.grid-container) [8,8 784x84.9375]
+        PaintableWithLines (BlockContainer<DIV>.one) [8,8 342x17.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.two) [450,8 342x17.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.three) [8,75.46875 342x17.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.four) [450,75.46875 342x17.46875]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/grid/grid-gap-2.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-gap-2.txt
@@ -12,3 +12,12 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             frag 0 from TextNode start: 0, length: 1, rect: [8,41.46875 8.8125x17.46875]
               "2"
           TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x50.9375]
+      PaintableBox (Box<DIV>.container) [8,8 784x50.9375]
+        PaintableWithLines (BlockContainer<DIV>.item) [434.1875,8 357.796875x17.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.item) [8,41.46875 357.796875x17.46875]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/grid/grid-gap-3.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-gap-3.txt
@@ -7,3 +7,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             frag 0 from TextNode start: 0, length: 1, rect: [410,8 6.34375x17.46875]
               "1"
           TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x17.46875]
+      PaintableBox (Box<DIV>.container) [8,8 784x17.46875]
+        PaintableWithLines (BlockContainer<DIV>.item) [410,8 382x17.46875]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/grid/grid-item-fixed-paddings.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-item-fixed-paddings.txt
@@ -34,3 +34,17 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,363.5) content-size 784x0 children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x355.5]
+      PaintableBox (Box<DIV>.grid-container) [8,8 784x355.5]
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [8,8 137.046875x152.75]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [195.046875,8 136.515625x152.75]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [8,210.75 137.046875x152.75]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [195.046875,210.75 136.515625x152.75]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,363.5 784x0]

--- a/Tests/LibWeb/Layout/expected/grid/grid-item-fixed-size.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-item-fixed-size.txt
@@ -7,3 +7,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             frag 0 from TextNode start: 0, length: 5, rect: [8,8 42.140625x17.46875]
               "First"
           TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x200]
+      PaintableBox (Box<DIV>.grid-container) [8,8 784x200]
+        PaintableWithLines (BlockContainer<DIV>.first) [8,8 100x200]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/grid/grid-item-horizontal-margins-auto.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-item-horizontal-margins-auto.txt
@@ -114,3 +114,27 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,449.25) content-size 780x0 children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x459.25]
+    PaintableWithLines (BlockContainer<BODY>) [9,9 782x441.25]
+      PaintableBox (Box<DIV>.grid) [10,10 502x439.25] overflow: [11,11 501.109375x437.25]
+        PaintableWithLines (BlockContainer<DIV>.left-margin-auto.right-margin-auto) [98.71875,11 324.5625x19.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.left-margin-auto) [251.375,30.46875 259.625x19.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.right-margin-auto) [11,49.9375 270.484375x19.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.left-margin-auto.right-margin-auto.fit-content-width) [74.25,69.40625 373.484375x19.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.left-margin-auto.fit-content-width) [202.453125,88.875 308.546875x19.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.right-margin-auto.fit-content-width) [11,108.34375 319.40625x19.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.left-margin-auto.right-margin-auto.fixed-width) [235,127.8125 52x106.8125] overflow: [236,128.8125 81.84375x104.8125]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.left-margin-auto.fixed-width) [459,234.625 52x106.8125] overflow: [460,235.625 52.109375x104.8125]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.right-margin-auto.fixed-width) [11,341.4375 52x106.8125] overflow: [12,342.4375 52.109375x104.8125]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [10,449.25 780x0]

--- a/Tests/LibWeb/Layout/expected/grid/grid-item-min-size.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-item-min-size.txt
@@ -12,3 +12,12 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             frag 0 from TextNode start: 0, length: 6, rect: [9,111 54.78125x17.46875]
               "second"
           TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x0] overflow: [8,8 102x204]
+      PaintableBox (Box<DIV>.grid) [8,8 102x204]
+        PaintableWithLines (BlockContainer<DIV>.first) [8,8 102x102]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.second) [8,110 102x102]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/grid/grid-item-percentage-margins.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-item-percentage-margins.txt
@@ -8,3 +8,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               frag 0 from TextNode start: 0, length: 16, rect: [243.1875,8 121.0625x17.46875]
                 "A filthy t-shirt"
             TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x17.46875]
+      PaintableWithLines (BlockContainer<DIV>) [8,8 784x17.46875]
+        PaintableBox (Box<DIV>.grid) [8,8 784x17.46875]
+          PaintableWithLines (BlockContainer<DIV>.item) [164.796875,8 470.40625x17.46875]
+            TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/grid/grid-item-percentage-width-2.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-item-percentage-width-2.txt
@@ -58,3 +58,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             frag 0 from TextNode start: 155, length: 7, rect: [8,304.96875 47.5x17.46875]
               "tellus."
           TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x0] overflow: [8,8 200x314.4375]
+      PaintableBox (Box<DIV>.container) [8,8 200x314.4375]
+        PaintableWithLines (BlockContainer<DIV>.item) [8,8 100x314.4375]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/grid/grid-item-percentage-width.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-item-percentage-width.txt
@@ -12,3 +12,12 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             frag 0 from TextNode start: 0, length: 6, rect: [400,8 57.40625x17.46875]
               "Second"
           TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x17.46875]
+      PaintableBox (Box<DIV>.grid-container) [8,8 784x17.46875]
+        PaintableWithLines (BlockContainer<DIV>.first) [8,8 313.59375x17.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.second) [400,8 78.390625x17.46875]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/grid/grid-item-with-fit-content-width.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-item-with-fit-content-width.txt
@@ -6,3 +6,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           frag 0 from TextNode start: 0, length: 15, rect: [11,11 132.828125x17.46875]
             "Press and Media"
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x39.46875]
+    PaintableBox (Box<BODY>) [9,9 782x21.46875]
+      PaintableWithLines (BlockContainer<DIV>.inner) [10,10 134.828125x19.46875]
+        TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/grid/grid-row-height-affected-by-item-margins.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-row-height-affected-by-item-margins.txt
@@ -6,3 +6,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           frag 0 from TextNode start: 0, length: 31, rect: [55.5,32.4375 492.96875x34.9375]
             "Null publishes fine indie games"
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x99.8125]
+    PaintableBox (Box<BODY>) [9,9 782x81.8125]
+      PaintableWithLines (BlockContainer<H1>) [54.5,31.4375 691x36.9375]
+        TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/grid/grid-shorthand-property.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-shorthand-property.txt
@@ -3,3 +3,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x100 children: not-inline
       Box <div.container> at (8,8) content-size 784x100 [GFC] children: not-inline
         BlockContainer <div.item> at (8,8) content-size 200x100 [BFC] children: not-inline
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x100]
+      PaintableBox (Box<DIV>.container) [8,8 784x100]
+        PaintableWithLines (BlockContainer<DIV>.item) [8,8 200x100]

--- a/Tests/LibWeb/Layout/expected/grid/grid-template-areas-basics.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-template-areas-basics.txt
@@ -17,3 +17,14 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             frag 0 from TextNode start: 0, length: 9, rect: [400,8 70.234375x17.46875]
               "right-top"
           TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x34.9375]
+      PaintableBox (Box<DIV>.container) [8,8 784x34.9375]
+        PaintableWithLines (BlockContainer<DIV>.item.right-bottom) [400,25.46875 392x17.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.item.left) [8,8 392x34.9375]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.item.right-top) [400,8 392x17.46875]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/grid/grid-template-columns-with-min-css-function.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-template-columns-with-min-css-function.txt
@@ -6,3 +6,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           frag 0 from TextNode start: 0, length: 13, rect: [55.5,11 200.40625x34.9375]
             "hello friends"
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x56.9375]
+    PaintableBox (Box<BODY>) [9,9 782x38.9375]
+      PaintableWithLines (BlockContainer<H1>) [54.5,10 691x36.9375]
+        TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/grid/grid-template.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-template.txt
@@ -52,3 +52,23 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,208) content-size 784x0 children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x200]
+      PaintableBox (Box<DIV>.mw-page-container-inner) [8,8 784x0]
+        PaintableWithLines (BlockContainer<DIV>.vector-main-menu-container) [8,8 196x0]
+        PaintableWithLines (BlockContainer<DIV>.vector-sitenotice-container) [8,8 784x0]
+        PaintableWithLines (BlockContainer<DIV>.mw-content-container) [204,8 588x0]
+        PaintableWithLines (BlockContainer<DIV>.mw-footer-container) [8,8 784x0]
+      PaintableWithLines (BlockContainer(anonymous)) [8,8 784x0]
+      PaintableBox (Box<SECTION>#page) [8,8 784x200]
+        PaintableWithLines (BlockContainer<HEADER>) [8,8 784x30]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<NAV>) [8,38 120x170]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<MAIN>) [128,38 664x140]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<FOOTER>) [128,178 664x30]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,208 784x0]

--- a/Tests/LibWeb/Layout/expected/grid/grow-beyond-limits.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grow-beyond-limits.txt
@@ -7,3 +7,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             frag 0 from TextNode start: 0, length: 3, rect: [8,8 28.6875x17.46875]
               "one"
           TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x33.46875]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x17.46875]
+      PaintableBox (Box<DIV>.container) [8,8 784x17.46875]
+        PaintableWithLines (BlockContainer<DIV>.item) [8,8 28.6875x17.46875]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/grid/image-in-grid.txt
+++ b/Tests/LibWeb/Layout/expected/grid/image-in-grid.txt
@@ -12,3 +12,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x24]
+      PaintableBox (Box<DIV>.grid-container) [8,8 784x24]
+        PaintableWithLines (BlockContainer<DIV>.wrapper) [8,8 64.015625x24]
+          ImagePaintable (ImageBox<IMG>) [8,8 64.015625x24]

--- a/Tests/LibWeb/Layout/expected/grid/inline-grid-simple.txt
+++ b/Tests/LibWeb/Layout/expected/grid/inline-grid-simple.txt
@@ -8,3 +8,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           frag 0 from TextNode start: 0, length: 3, rect: [8,8 26.953125x17.46875]
             "whf"
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x33.46875]
+    PaintableBox (Box<BODY>) [8,8 26.953125x17.46875]
+      PaintableWithLines (BlockContainer(anonymous)) [8,8 26.953125x17.46875]
+        TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/grid/intrinsic-sized-column.txt
+++ b/Tests/LibWeb/Layout/expected/grid/intrinsic-sized-column.txt
@@ -12,3 +12,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             frag 0 from TextNode start: 0, length: 4, rect: [9,9 37.953125x17.46875]
               "whee"
           TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x35.46875]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 20x19.46875] overflow: [8,8 38.953125x19.46875]
+      PaintableWithLines (BlockContainer(anonymous)) [8,8 20x0]
+      PaintableBox (Box<DIV>.grid) [8,8 20x19.46875] overflow: [8,8 38.953125x19.46875]
+        PaintableWithLines (BlockContainer<DIV>.whee) [8,8 20x19.46875] overflow: [9,9 37.953125x17.46875]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/grid/intrinsic-sized-grid-2.txt
+++ b/Tests/LibWeb/Layout/expected/grid/intrinsic-sized-grid-2.txt
@@ -12,3 +12,12 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             frag 0 from TextNode start: 0, length: 6, rect: [51.953125,12 54.46875x17.46875]
               "yeehaw"
           TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x32.46875]
+    PaintableWithLines (BlockContainer<BODY>) [9,9 782x2] overflow: [10,10 98.421875x21.46875]
+      PaintableBox (Box<DIV>.grid) [10,10 98.421875x21.46875]
+        PaintableWithLines (BlockContainer<DIV>.whee) [11,11 39.953125x19.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.yeehaw) [50.953125,11 56.46875x19.46875]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/grid/intrinsic-sized-grid.txt
+++ b/Tests/LibWeb/Layout/expected/grid/intrinsic-sized-grid.txt
@@ -7,3 +7,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             frag 0 from TextNode start: 0, length: 4, rect: [12,12 37.953125x17.46875]
               "whee"
           TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x41.46875]
+    PaintableWithLines (BlockContainer<BODY>) [9,9 43.953125x23.46875]
+      PaintableBox (Box<DIV>.grid) [10,10 41.953125x21.46875]
+        PaintableWithLines (BlockContainer<DIV>.whee) [11,11 39.953125x19.46875]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/grid/item-column-span-2.txt
+++ b/Tests/LibWeb/Layout/expected/grid/item-column-span-2.txt
@@ -19,3 +19,12 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,42.9375) content-size 784x0 children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x34.9375]
+      PaintableBox (Box<DIV>.container) [8,8 784x34.9375]
+        PaintableWithLines (BlockContainer<DIV>.item-left) [8,8 100x34.9375]
+        PaintableWithLines (BlockContainer<DIV>.item-right) [108.03125,8 683.96875x34.9375]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,42.9375 784x0]

--- a/Tests/LibWeb/Layout/expected/grid/item-span-exceeds-columns-size.txt
+++ b/Tests/LibWeb/Layout/expected/grid/item-span-exceeds-columns-size.txt
@@ -3,3 +3,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x100 children: not-inline
       Box <div.container> at (8,8) content-size 300x100 [GFC] children: not-inline
         BlockContainer <div.item> at (8,8) content-size 300x100 [BFC] children: not-inline
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x100]
+      PaintableBox (Box<DIV>.container) [8,8 300x100]
+        PaintableWithLines (BlockContainer<DIV>.item) [8,8 300x100]

--- a/Tests/LibWeb/Layout/expected/grid/justify-items.txt
+++ b/Tests/LibWeb/Layout/expected/grid/justify-items.txt
@@ -25,3 +25,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             frag 0 from TextNode start: 0, length: 3, rect: [758.671875,54.9375 29.328125x17.46875]
               "End"
           TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x84.40625]
+    PaintableWithLines (BlockContainer<BODY>) [9,9 782x66.40625]
+      PaintableWithLines (BlockContainer(anonymous)) [10,10 780x0]
+      PaintableBox (Box<DIV>.grid.start) [10,10 780x21.46875]
+        PaintableWithLines (BlockContainer<DIV>) [11,11 45.859375x19.46875]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [10,31.46875 780x0]
+      PaintableBox (Box<DIV>.grid.center) [10,31.46875 780x21.46875]
+        PaintableWithLines (BlockContainer<DIV>) [372.46875,32.46875 55.046875x19.46875]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [10,52.9375 780x0]
+      PaintableBox (Box<DIV>.grid.end) [10,52.9375 780x21.46875]
+        PaintableWithLines (BlockContainer<DIV>) [757.671875,53.9375 31.328125x19.46875]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/grid/justify-self.txt
+++ b/Tests/LibWeb/Layout/expected/grid/justify-self.txt
@@ -24,3 +24,13 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
       BlockContainer <(anonymous)> (not painted) [BFC] children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x78.40625]
+    PaintableBox (Box<BODY>) [9,9 782x60.40625]
+      PaintableWithLines (BlockContainer<DIV>) [10,10 45.859375x19.46875]
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer<DIV>) [372.46875,29.46875 55.046875x19.46875]
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer<DIV>) [758.671875,48.9375 31.328125x19.46875]
+        TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/grid/min-max-content.txt
+++ b/Tests/LibWeb/Layout/expected/grid/min-max-content.txt
@@ -25,3 +25,14 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x17.46875]
+      PaintableBox (Box<DIV>.grid-container) [8,8 784x17.46875]
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [8,8 93.765625x17.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [101.765625,8 98.640625x17.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [200.40625,8 591.59375x17.46875]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/grid/minmax-1.txt
+++ b/Tests/LibWeb/Layout/expected/grid/minmax-1.txt
@@ -12,3 +12,12 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             frag 0 from TextNode start: 0, length: 1, rect: [308,8 8.8125x17.46875]
               "2"
           TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x17.46875]
+      PaintableBox (Box<DIV>.container) [8,8 784x17.46875]
+        PaintableWithLines (BlockContainer<DIV>.one) [8,8 300x17.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.two) [308,8 300x17.46875]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/grid/minmax-2.txt
+++ b/Tests/LibWeb/Layout/expected/grid/minmax-2.txt
@@ -12,3 +12,12 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             frag 0 from TextNode start: 0, length: 1, rect: [308,8 8.8125x17.46875]
               "2"
           TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x100]
+      PaintableBox (Box<DIV>.container) [8,8 784x100]
+        PaintableWithLines (BlockContainer<DIV>.one) [8,8 300x50]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.two) [308,8 300x50]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/grid/minmax-3.txt
+++ b/Tests/LibWeb/Layout/expected/grid/minmax-3.txt
@@ -17,3 +17,14 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             frag 0 from TextNode start: 0, length: 1, rect: [500,8 9.09375x17.46875]
               "3"
           TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x17.46875]
+      PaintableBox (Box<DIV>.container) [8,8 784x17.46875]
+        PaintableWithLines (BlockContainer<DIV>.one) [8,8 292x17.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.two) [300,8 200x17.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.three) [500,8 292x17.46875]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/grid/minmax-auto-track-definition.txt
+++ b/Tests/LibWeb/Layout/expected/grid/minmax-auto-track-definition.txt
@@ -3,3 +3,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x200 children: not-inline
       Box <div.grid> at (8,8) content-size 200x200 [GFC] children: not-inline
         BlockContainer <div.item> at (8,8) content-size 100x100 [BFC] children: not-inline
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x200]
+      PaintableBox (Box<DIV>.grid) [8,8 200x200]
+        PaintableWithLines (BlockContainer<DIV>.item) [8,8 100x100]

--- a/Tests/LibWeb/Layout/expected/grid/minmax-invalid-1.txt
+++ b/Tests/LibWeb/Layout/expected/grid/minmax-invalid-1.txt
@@ -12,3 +12,12 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             frag 0 from TextNode start: 0, length: 1, rect: [8,25.46875 8.8125x17.46875]
               "2"
           TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x34.9375]
+      PaintableBox (Box<DIV>.container) [8,8 784x34.9375]
+        PaintableWithLines (BlockContainer<DIV>.one) [8,8 784x17.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.two) [8,25.46875 784x17.46875]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/grid/minmax-with-max-function-inside.txt
+++ b/Tests/LibWeb/Layout/expected/grid/minmax-with-max-function-inside.txt
@@ -22,3 +22,16 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             frag 0 from TextNode start: 0, length: 1, rect: [8,25.46875 7.859375x17.46875]
               "d"
           TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x34.9375]
+      PaintableBox (Box<DIV>.grid) [8,8 784x34.9375]
+        PaintableWithLines (BlockContainer<DIV>) [8,8 261.328125x17.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [269.328125,8 261.328125x17.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [530.65625,8 261.328125x17.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [8,25.46875 261.328125x17.46875]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/grid/named-tracks.txt
+++ b/Tests/LibWeb/Layout/expected/grid/named-tracks.txt
@@ -88,3 +88,32 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x127.40625]
+      PaintableBox (Box<DIV>.grid-container) [8,8 784x17.46875]
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [8,8 392x17.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [400,8 392x17.46875]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,25.46875 784x0]
+      PaintableBox (Box<DIV>.grid-container) [8,25.46875 784x75]
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [8,25.46875 261.328125x75]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [530.65625,25.46875 261.328125x50]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [269.328125,25.46875 261.328125x25]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [269.328125,75.46875 522.65625x25]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,100.46875 784x0]
+      PaintableBox (Box<DIV>.grid-container) [8,100.46875 784x34.9375]
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [58,100.46875 100x17.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [158,100.46875 50x17.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [208,100.46875 100x17.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [8,117.9375 50x17.46875]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/grid/negative-grid-item-column-index.txt
+++ b/Tests/LibWeb/Layout/expected/grid/negative-grid-item-column-index.txt
@@ -69,3 +69,27 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,77.875) content-size 784x0 children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x69.875]
+      PaintableBox (Box<DIV>.grid) [8,8 784x69.875]
+        PaintableWithLines (BlockContainer<DIV>.a) [8,8 196x17.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.c) [204,8 196x17.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.b) [400,8 196x17.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.b) [400,25.46875 196x17.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.d) [596,25.46875 196x17.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.c) [204,42.9375 196x17.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.d) [596,42.9375 196x17.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.e) [8,60.40625 196x17.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.f) [204,60.40625 196x17.46875]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,77.875 784x0]

--- a/Tests/LibWeb/Layout/expected/grid/place-items-center.txt
+++ b/Tests/LibWeb/Layout/expected/grid/place-items-center.txt
@@ -6,3 +6,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           frag 0 from TextNode start: 0, length: 8, rect: [362.9375,11 74.125x17.46875]
             "Download"
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x39.46875]
+    PaintableBox (Box<BODY>) [9,9 782x21.46875]
+      PaintableWithLines (BlockContainer<DIV>) [361.9375,10 76.125x19.46875]
+        TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/grid/positions-and-spans.txt
+++ b/Tests/LibWeb/Layout/expected/grid/positions-and-spans.txt
@@ -81,3 +81,30 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x169.875]
+      PaintableBox (Box<DIV>.grid-container) [8,8 784x17.46875]
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [8,8 522.5x17.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [530.5,8 261.25x17.46875]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,25.46875 784x0]
+      PaintableBox (Box<DIV>.grid-container) [8,25.46875 784x17.46875]
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [8,25.46875 261.25x17.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [269.25,25.46875 522.5x17.46875]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,42.9375 784x0]
+      PaintableBox (Box<DIV>.grid-container) [8,42.9375 784x100]
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [8,42.9375 784x40]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [8,82.9375 784x60]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,142.9375 784x0]
+      PaintableBox (Box<DIV>.grid-container) [8,142.9375 784x34.9375]
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [8,142.9375 784x17.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [8,160.40625 392x17.46875]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/grid/relpos-grid-item.txt
+++ b/Tests/LibWeb/Layout/expected/grid/relpos-grid-item.txt
@@ -11,3 +11,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           frag 0 from TextNode start: 0, length: 6, rect: [24,25.46875 53.171875x17.46875]
             "athena"
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x66.9375]
+    PaintableBox (Box<BODY>) [10,10 604x46.9375]
+      PaintableWithLines (BlockContainer<DIV>.exekiller) [12,12 204x21.46875]
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer<DIV>.athena) [22,23.46875 204x21.46875]
+        TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/grid/repeat.txt
+++ b/Tests/LibWeb/Layout/expected/grid/repeat.txt
@@ -81,3 +81,30 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x217.46875]
+      PaintableBox (Box<DIV>.grid-container) [8,8 784x200]
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [8,8 392x200]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [400,8 392x100]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [400,108 196x50]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [596,108 196x50]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [400,158 196x50]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [596,158 196x50]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,208 784x0]
+      PaintableBox (Box<DIV>.grid-container) [8,208 784x17.46875]
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [8,208 50x17.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [58,208 50x17.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [108,208 100x17.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [208,208 100x17.46875]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/grid/row-1fr.txt
+++ b/Tests/LibWeb/Layout/expected/grid/row-1fr.txt
@@ -2,3 +2,8 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (1,1) content-size 798x70 [BFC] children: not-inline
     Box <body> at (10,10) content-size 200x52 [GFC] children: not-inline
       BlockContainer <div.item> at (11,11) content-size 100x50 [BFC] children: not-inline
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x72]
+    PaintableBox (Box<BODY>) [9,9 202x54]
+      PaintableWithLines (BlockContainer<DIV>.item) [10,10 102x52]

--- a/Tests/LibWeb/Layout/expected/grid/row-height.txt
+++ b/Tests/LibWeb/Layout/expected/grid/row-height.txt
@@ -32,3 +32,16 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x67.46875]
+      PaintableBox (Box<DIV>.grid-container) [8,8 784x67.46875]
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [8,8 392x50]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [400,8 392x50]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [8,58 392x17.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [400,58 392x17.46875]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/grid/row-span-2-maxcontent.txt
+++ b/Tests/LibWeb/Layout/expected/grid/row-span-2-maxcontent.txt
@@ -103,3 +103,14 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x314.4375] overflow: [8,8 785.46875x314.4375]
+      PaintableBox (Box<DIV>.grid-container) [8,8 784x314.4375] overflow: [8,8 785.46875x314.4375]
+        PaintableWithLines (BlockContainer<DIV>.grid-item.item-span-one-one) [401.46875,8 392x131.015625]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item.item-span-one-two) [401.46875,139.015625 392x183.421875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item.item-span-two) [8,8 393.46875x314.4375]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/grid/row-span-2-mincontent.txt
+++ b/Tests/LibWeb/Layout/expected/grid/row-span-2-mincontent.txt
@@ -184,3 +184,14 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x559]
+      PaintableBox (Box<DIV>.grid-container) [8,8 784x559]
+        PaintableWithLines (BlockContainer<DIV>.grid-item.item-span-one-one) [108.640625,8 101.515625x244.5625]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item.item-span-one-two) [108.640625,252.5625 101.515625x314.4375]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item.item-span-two) [8,8 100.640625x559]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/grid/row-span-2-with-gaps.txt
+++ b/Tests/LibWeb/Layout/expected/grid/row-span-2-with-gaps.txt
@@ -106,3 +106,14 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x351.90625] overflow: [8,8 785.46875x351.90625]
+      PaintableBox (Box<DIV>.grid-container) [8,8 784x351.90625] overflow: [8,8 785.46875x351.90625]
+        PaintableWithLines (BlockContainer<DIV>.grid-item.item-span-one-one) [411.46875,8 382x139.75]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item.item-span-one-two) [411.46875,167.75 382x192.15625]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item.item-span-two) [8,8 383.46875x351.90625]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/grid/row-span-2.txt
+++ b/Tests/LibWeb/Layout/expected/grid/row-span-2.txt
@@ -103,3 +103,14 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x314.4375] overflow: [8,8 785.46875x314.4375]
+      PaintableBox (Box<DIV>.grid-container) [8,8 784x314.4375] overflow: [8,8 785.46875x314.4375]
+        PaintableWithLines (BlockContainer<DIV>.grid-item.item-span-one-one) [401.46875,8 392x131.015625]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item.item-span-one-two) [401.46875,139.015625 392x183.421875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item.item-span-two) [8,8 393.46875x314.4375]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/grid/rows-1fr-1fr.txt
+++ b/Tests/LibWeb/Layout/expected/grid/rows-1fr-1fr.txt
@@ -9,3 +9,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,42.9375) content-size 784x0 children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x34.9375]
+      PaintableBox (Box<DIV>.container) [8,8 784x34.9375]
+        PaintableWithLines (BlockContainer<DIV>.item) [8,8 784x17.46875]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,42.9375 784x0]

--- a/Tests/LibWeb/Layout/expected/grid/template-lines-and-areas.txt
+++ b/Tests/LibWeb/Layout/expected/grid/template-lines-and-areas.txt
@@ -12,3 +12,12 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             frag 0 from TextNode start: 0, length: 3, rect: [530.65625,8 21.609375x17.46875]
               "1fr"
           TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x17.46875]
+      PaintableBox (Box<DIV>.grid) [8,8 784x17.46875]
+        PaintableWithLines (BlockContainer<DIV>.item-left) [8,8 261.328125x17.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.item-right) [530.65625,8 261.328125x17.46875]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/grid/track-size-calc-with-percentage.txt
+++ b/Tests/LibWeb/Layout/expected/grid/track-size-calc-with-percentage.txt
@@ -11,3 +11,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               frag 0 from TextNode start: 41, length: 4, rect: [8,25.46875 36.3125x17.46875]
                 "2023"
             TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x34.9375]
+      PaintableBox (Box<DIV>.ipc-page-grid) [8,8 784x34.9375]
+        PaintableBox (Box<DIV>.ipc-sub-grid) [8,8 401.28125x34.9375]
+          PaintableWithLines (BlockContainer(anonymous)) [8,8 401.265625x34.9375]
+            TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/grid/unresolvable-percentage-track.txt
+++ b/Tests/LibWeb/Layout/expected/grid/unresolvable-percentage-track.txt
@@ -8,3 +8,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               frag 0 from TextNode start: 0, length: 5, rect: [8,8 36.84375x17.46875]
                 "hello"
             TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x17.46875]
+      PaintableBox (Box<DIV>.ipc-page-grid) [8,8 784x17.46875]
+        PaintableBox (Box<DIV>.ipc-sub-grid) [8,8 36.84375x17.46875]
+          PaintableWithLines (BlockContainer<DIV>) [8,8 36.84375x17.46875]
+            TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/grid/valid-grid-areas-1.txt
+++ b/Tests/LibWeb/Layout/expected/grid/valid-grid-areas-1.txt
@@ -7,3 +7,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             frag 0 from TextNode start: 0, length: 3, rect: [8,8 21.609375x17.46875]
               "1fr"
           TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x17.46875]
+      PaintableBox (Box<DIV>.grid-container) [8,8 784x17.46875]
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [8,8 392x17.46875]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/grid/vertical-margins-auto.txt
+++ b/Tests/LibWeb/Layout/expected/grid/vertical-margins-auto.txt
@@ -7,3 +7,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             frag 0 from TextNode start: 0, length: 4, rect: [244.828125,252.265625 32.34375x17.46875]
               "item"
           TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x522]
+    PaintableWithLines (BlockContainer<BODY>) [9,9 782x504]
+      PaintableBox (Box<DIV>.container) [10,10 502x502]
+        PaintableWithLines (BlockContainer<DIV>.item) [243.828125,251.265625 34.34375x19.46875]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/height-of-absolute-position-box-with-padding.txt
+++ b/Tests/LibWeb/Layout/expected/height-of-absolute-position-box-with-padding.txt
@@ -10,3 +10,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             "Test"
         TextNode <#text>
       TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x16]
+    PaintableWithLines (BlockContainer(anonymous)) [0,0 800x0]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x0]
+      PaintableWithLines (BlockContainer<H1>) [75.578125,58.734375 128x128]
+        TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/image-display-block-margin-auto.txt
+++ b/Tests/LibWeb/Layout/expected/image-display-block-margin-auto.txt
@@ -2,3 +2,8 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x116 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 400x100 children: not-inline
       ImageBox <img> at (158,8) content-size 100x100 children: not-inline
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x116]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 400x100]
+      ImagePaintable (ImageBox<IMG>) [158,8 100x100]

--- a/Tests/LibWeb/Layout/expected/image-with-multiple-constraint-violations.txt
+++ b/Tests/LibWeb/Layout/expected/image-with-multiple-constraint-violations.txt
@@ -4,3 +4,8 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       line 0 width: 81.6875, height: 62, bottom: 62, baseline: 62
         frag 0 from ImageBox start: 0, length: 0, rect: [11,11 79.6875x60]
       ImageBox <img> at (11,11) content-size 79.6875x60 children: not-inline
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x82]
+    PaintableWithLines (BlockContainer<BODY>) [9,9 782x64]
+      ImagePaintable (ImageBox<IMG>) [10,10 81.6875x62]

--- a/Tests/LibWeb/Layout/expected/img-with-box-sizing-border-box-and-padding.txt
+++ b/Tests/LibWeb/Layout/expected/img-with-box-sizing-border-box-and-padding.txt
@@ -7,3 +7,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       ImageBox <img.with-height> at (29,29) content-size 58x58 children: not-inline
       ImageBox <img.with-width> at (129,29) content-size 58x58 children: not-inline
       TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x116]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x100]
+      ImagePaintable (ImageBox<IMG>.with-height) [8,8 100x100]
+      ImagePaintable (ImageBox<IMG>.with-width) [108,8 100x100]

--- a/Tests/LibWeb/Layout/expected/img-with-percentage-max-width-and-indefinite-containing-block-width.txt
+++ b/Tests/LibWeb/Layout/expected/img-with-percentage-max-width-and-indefinite-containing-block-width.txt
@@ -5,3 +5,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         line 0 width: 120, height: 120, bottom: 120, baseline: 120
           frag 0 from ImageBox start: 0, length: 0, rect: [8,8 120x120]
         ImageBox <img> at (8,8) content-size 120x120 children: not-inline
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x136]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 120x120]
+      PaintableWithLines (BlockContainer<DIV>) [8,8 120x120]
+        ImagePaintable (ImageBox<IMG>) [8,8 120x120]

--- a/Tests/LibWeb/Layout/expected/img-with-percentage-max-width-and-min-content-containing-block-width.txt
+++ b/Tests/LibWeb/Layout/expected/img-with-percentage-max-width-and-min-content-containing-block-width.txt
@@ -4,3 +4,8 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       line 0 width: 0, height: 17.46875, bottom: 17.46875, baseline: 13.53125
         frag 0 from ImageBox start: 0, length: 0, rect: [8,21.53125 0x0]
       ImageBox <img> at (8,21.53125) content-size 0x0 children: not-inline
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x33.46875]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 0x17.46875]
+      ImagePaintable (ImageBox<IMG>) [8,21.53125 0x0]

--- a/Tests/LibWeb/Layout/expected/inline-size.txt
+++ b/Tests/LibWeb/Layout/expected/inline-size.txt
@@ -18,3 +18,13 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
       BlockContainer <(anonymous)> at (8,632.84375) content-size 784x0 children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x632.84375]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x570.84375] overflow: [0,0 800x632.84375]
+    PaintableWithLines (BlockContainer<BODY>) [8,70 784x492.84375] overflow: [8,70 784x562.84375]
+      PaintableWithLines (BlockContainer<P>.min-inline-test) [8,70 784x200]
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,340 784x76.421875]
+      PaintableWithLines (BlockContainer<P>.max-inline-test) [8,486.421875 100x76.421875]
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,632.84375 784x0]

--- a/Tests/LibWeb/Layout/expected/input-element-with-display-inline.txt
+++ b/Tests/LibWeb/Layout/expected/input-element-with-display-inline.txt
@@ -7,3 +7,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         Box <div> at (13,12) content-size 196x23.828125 flex-container(row) [FFC] children: not-inline
           BlockContainer <div> at (14,13) content-size 0x21.828125 flex-item [BFC] children: inline
             TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x47.828125]
+    PaintableWithLines (BlockContainer<BODY>) [9,9 782x29.828125]
+      PaintableWithLines (BlockContainer<INPUT>) [10,10 202x27.828125]
+        PaintableBox (Box<DIV>) [11,11 200x25.828125]
+          PaintableWithLines (BlockContainer<DIV>) [13,12 2x23.828125]

--- a/Tests/LibWeb/Layout/expected/inset-shorthand-property.txt
+++ b/Tests/LibWeb/Layout/expected/inset-shorthand-property.txt
@@ -13,3 +13,12 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
       BlockContainer <(anonymous)> at (8,208) content-size 784x0 children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x216]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x200]
+      PaintableWithLines (BlockContainer<DIV>.parent) [8,8 200x200]
+        PaintableWithLines (BlockContainer<DIV>.bad) [38,18 150x150]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.good) [38,18 150x150]
+      PaintableWithLines (BlockContainer(anonymous)) [8,208 784x0]

--- a/Tests/LibWeb/Layout/expected/lh-1.txt
+++ b/Tests/LibWeb/Layout/expected/lh-1.txt
@@ -4,3 +4,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <div#a> at (8,8) content-size 100x100 children: not-inline
         BlockContainer <div#b> at (8,8) content-size 100x100 children: inline
           TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x116]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x100]
+      PaintableWithLines (BlockContainer<DIV>#a) [8,8 100x100]
+        PaintableWithLines (BlockContainer<DIV>#b) [8,8 100x100]

--- a/Tests/LibWeb/Layout/expected/lh-2.txt
+++ b/Tests/LibWeb/Layout/expected/lh-2.txt
@@ -4,3 +4,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <div#a> at (8,8) content-size 100x100 children: not-inline
         BlockContainer <div#b> at (8,8) content-size 100x100 children: inline
           TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x116]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x100]
+      PaintableWithLines (BlockContainer<DIV>#a) [8,8 100x100]
+        PaintableWithLines (BlockContainer<DIV>#b) [8,8 100x100]

--- a/Tests/LibWeb/Layout/expected/line-height-calc-number.txt
+++ b/Tests/LibWeb/Layout/expected/line-height-calc-number.txt
@@ -6,3 +6,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           frag 0 from TextNode start: 0, length: 13, rect: [8,8 100.203125x64]
             "hello friends"
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x80]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x64]
+      PaintableWithLines (BlockContainer<DIV>) [8,8 784x64]
+        TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/link-sheet.txt
+++ b/Tests/LibWeb/Layout/expected/link-sheet.txt
@@ -2,3 +2,8 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x16 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x0 children: not-inline
       BlockContainer <div#foo> at (0,0) content-size 123x456 positioned [BFC] children: not-inline
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x16] overflow: [0,0 800x456]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x0] overflow: [0,0 123x456]
+      PaintableWithLines (BlockContainer<DIV>#foo) [0,0 123x456]

--- a/Tests/LibWeb/Layout/expected/misc/grid-template-block-components-whitespace-crash.txt
+++ b/Tests/LibWeb/Layout/expected/misc/grid-template-block-components-whitespace-crash.txt
@@ -1,3 +1,7 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x0 children: not-inline
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x0]

--- a/Tests/LibWeb/Layout/expected/misc/percentage-stroke-width-crash.txt
+++ b/Tests/LibWeb/Layout/expected/misc/percentage-stroke-width-crash.txt
@@ -1,3 +1,7 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x16 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x0 children: not-inline
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x16]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x0]

--- a/Tests/LibWeb/Layout/expected/negative-max-size.txt
+++ b/Tests/LibWeb/Layout/expected/negative-max-size.txt
@@ -6,3 +6,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           frag 0 from TextNode start: 0, length: 20, rect: [9,9 147.1875x17.46875]
             "Well, hello friends!"
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x35.46875]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x19.46875]
+      PaintableWithLines (BlockContainer<DIV>) [8,8 784x19.46875]
+        TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/non-floating-non-replaced-element-percentage-padding-against-indefinite-width.txt
+++ b/Tests/LibWeb/Layout/expected/non-floating-non-replaced-element-percentage-padding-against-indefinite-width.txt
@@ -4,3 +4,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       Box <div#box1> at (8,8) content-size 784x0 flex-container(row) [FFC] children: not-inline
         BlockContainer <div> at (8,8) content-size 0x0 flex-item [BFC] children: not-inline
           Box <div#box2> at (8,8) content-size 0x0 flex-container(row) [FFC] children: not-inline
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x16]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x0]
+      PaintableBox (Box<DIV>#box1) [8,8 784x0]
+        PaintableWithLines (BlockContainer<DIV>) [8,8 0x0]
+          PaintableBox (Box<DIV>#box2) [8,8 0x0]

--- a/Tests/LibWeb/Layout/expected/overflow-x-hidden-with-border-radius.txt
+++ b/Tests/LibWeb/Layout/expected/overflow-x-hidden-with-border-radius.txt
@@ -4,3 +4,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <div.box> at (9,9) content-size 100x100 positioned [BFC] children: not-inline
       BlockContainer <(anonymous)> at (8,110) content-size 784x0 children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x102]
+      PaintableWithLines (BlockContainer<DIV>.box) [8,8 102x102]
+      PaintableWithLines (BlockContainer(anonymous)) [8,110 784x0]

--- a/Tests/LibWeb/Layout/expected/percentage-max-height-when-containing-block-has-indefinite-height.txt
+++ b/Tests/LibWeb/Layout/expected/percentage-max-height-when-containing-block-has-indefinite-height.txt
@@ -44,3 +44,30 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 TextNode <#text>
       BlockContainer <(anonymous)> at (10,115.34375) content-size 780x0 children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x125.34375]
+    PaintableWithLines (BlockContainer<BODY>) [9,9 782x107.34375]
+      PaintableWithLines (BlockContainer<DIV>.block.formatting-context) [10,10 780x21.46875]
+        PaintableWithLines (BlockContainer<DIV>) [11,11 778x19.46875]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [10,31.46875 780x0]
+      PaintableWithLines (BlockContainer<DIV>.inline.formatting-context) [10,31.46875 780x19.46875]
+        InlinePaintable (InlineNode<DIV>)
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [10,50.9375 780x0]
+      PaintableBox (Box<DIV>.flex.formatting-context) [10,50.9375 780x21.46875]
+        PaintableWithLines (BlockContainer<DIV>) [11,51.9375 31.09375x19.46875]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [10,72.40625 780x0]
+      PaintableBox (Box<DIV>.grid.formatting-context) [10,72.40625 780x21.46875]
+        PaintableWithLines (BlockContainer<DIV>) [11,73.40625 778x19.46875]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [10,93.875 780x0]
+      PaintableWithLines (TableWrapper(anonymous)) [10,93.875 42.625x21.46875]
+        PaintableBox (Box<DIV>.table.formatting-context) [10,93.875 42.625x21.46875]
+          PaintableBox (Box(anonymous)) [11,94.875 40.625x19.46875]
+            PaintableWithLines (BlockContainer(anonymous)) [11,94.875 40.625x19.46875]
+              PaintableWithLines (BlockContainer<DIV>) [11,94.875 40.625x19.46875]
+                TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [10,115.34375 780x0]

--- a/Tests/LibWeb/Layout/expected/picture-source-media-query.txt
+++ b/Tests/LibWeb/Layout/expected/picture-source-media-query.txt
@@ -11,3 +11,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         ImageBox <img> at (8,8) content-size 400x400 children: not-inline
         TextNode <#text>
       TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x416]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x400]
+      InlinePaintable (InlineNode<PICTURE>)
+        InlinePaintable (InlineNode<SOURCE>)
+        ImagePaintable (ImageBox<IMG>) [8,8 400x400]

--- a/Tests/LibWeb/Layout/expected/place-content-shorthand-property.txt
+++ b/Tests/LibWeb/Layout/expected/place-content-shorthand-property.txt
@@ -7,3 +7,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             frag 0 from TextNode start: 0, length: 4, rect: [392.203125,11 37.578125x17.46875]
               "Text"
           TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600] overflow: [0,0 812x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x39.46875] overflow: [1,1 811x37.46875]
+    PaintableWithLines (BlockContainer<BODY>) [9,9 782x21.46875] overflow: [10,10 802x19.46875]
+      PaintableBox (Box<DIV>.container) [10,10 802x19.46875]
+        PaintableWithLines (BlockContainer(anonymous)) [392.203125,11 37.578125x17.46875]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/position-absolute-from-edges.txt
+++ b/Tests/LibWeb/Layout/expected/position-absolute-from-edges.txt
@@ -12,3 +12,12 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <div#yellow> at (408,308) content-size 100x100 positioned [BFC] children: not-inline
         TextNode <#text>
       TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x0]
+      PaintableWithLines (BlockContainer<DIV>#container) [8,8 540x440]
+        PaintableWithLines (BlockContainer<DIV>#red) [48,48 120x120]
+        PaintableWithLines (BlockContainer<DIV>#green) [358,98 100x100]
+        PaintableWithLines (BlockContainer<DIV>#blue) [48,308 100x100]
+        PaintableWithLines (BlockContainer<DIV>#yellow) [408,308 100x100]

--- a/Tests/LibWeb/Layout/expected/position-absolute-ignores-padding-of-position-relative-floating-parent.txt
+++ b/Tests/LibWeb/Layout/expected/position-absolute-ignores-padding-of-position-relative-floating-parent.txt
@@ -4,3 +4,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <div#guide> at (8,8) content-size 200x200 children: not-inline
         BlockContainer <div#container> at (18,18) content-size 0x0 positioned floating [BFC] children: not-inline
           BlockContainer <div#box> at (8,8) content-size 100x100 positioned [BFC] children: not-inline
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x216]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x200]
+      PaintableWithLines (BlockContainer<DIV>#guide) [8,8 200x200]
+        PaintableWithLines (BlockContainer<DIV>#container) [8,8 20x20] overflow: [8,8 100x100]
+          PaintableWithLines (BlockContainer<DIV>#box) [8,8 100x100]

--- a/Tests/LibWeb/Layout/expected/position-absolute-top-left.txt
+++ b/Tests/LibWeb/Layout/expected/position-absolute-top-left.txt
@@ -34,3 +34,25 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <div.blue_margin> at (408,408) content-size 200x200 children: not-inline
       BlockContainer <(anonymous)> at (8,608) content-size 784x0 children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x616]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x616]
+    PaintableWithLines (BlockContainer(anonymous)) [0,0 800x0]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x600]
+      PaintableWithLines (BlockContainer(anonymous)) [8,8 784x0]
+        PaintableWithLines (BlockContainer<DIV>.blue.absolute) [208,208 200x200]
+          PaintableWithLines (BlockContainer<DIV>.red.absolute) [308,308 100x100]
+          PaintableWithLines (BlockContainer<DIV>.yellow.absolute) [258,258 100x100]
+            PaintableWithLines (BlockContainer<DIV>.black.absolute) [308,308 50x50]
+          PaintableWithLines (BlockContainer<DIV>.green.absolute) [508,508 100x100]
+      PaintableWithLines (BlockContainer<DIV>.blue) [8,8 200x200] overflow: [8,8 200x300]
+        PaintableWithLines (BlockContainer(anonymous)) [8,8 200x0]
+        PaintableWithLines (BlockContainer<DIV>.red) [8,8 100x100]
+        PaintableWithLines (BlockContainer(anonymous)) [8,108 200x0]
+        PaintableWithLines (BlockContainer<DIV>.yellow) [8,108 100x100]
+        PaintableWithLines (BlockContainer(anonymous)) [8,208 200x0]
+        PaintableWithLines (BlockContainer<DIV>.green) [8,208 100x100]
+        PaintableWithLines (BlockContainer(anonymous)) [8,308 200x0]
+      PaintableWithLines (BlockContainer(anonymous)) [8,208 784x0]
+      PaintableWithLines (BlockContainer<DIV>.blue_margin) [408,408 200x200]
+      PaintableWithLines (BlockContainer(anonymous)) [8,608 784x0]

--- a/Tests/LibWeb/Layout/expected/position-empty-pseudo-elements.txt
+++ b/Tests/LibWeb/Layout/expected/position-empty-pseudo-elements.txt
@@ -9,3 +9,12 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,175) content-size 784x0 children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x158] overflow: [0,0 800x175]
+    PaintableWithLines (BlockContainer<BODY>) [8,25 784x125] overflow: [8,25 784x150]
+      PaintableWithLines (BlockContainer<DIV>.empty_content) [33,25 50x50]
+        PaintableWithLines (BlockContainer(anonymous)) [33,25 50x50]
+      PaintableWithLines (BlockContainer<DIV>.content_with_space) [33,100 50x50]
+        PaintableWithLines (BlockContainer(anonymous)) [33,100 50x50]
+      PaintableWithLines (BlockContainer(anonymous)) [8,175 784x0]

--- a/Tests/LibWeb/Layout/expected/pre.txt
+++ b/Tests/LibWeb/Layout/expected/pre.txt
@@ -7,3 +7,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       InlineNode <pre>
         TextNode <#text>
       TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x17.46875]
+      InlinePaintable (InlineNode<PRE>)
+        TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/pseudo-element-with-custom-properties-2.txt
+++ b/Tests/LibWeb/Layout/expected/pseudo-element-with-custom-properties-2.txt
@@ -49,3 +49,20 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,460.796875) content-size 784x0 children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x468.796875]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x452.796875]
+      PaintableWithLines (BlockContainer(anonymous)) [8,8 784x21.828125]
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer<DIV>.a) [8,29.828125 784x100]
+        PaintableWithLines (BlockContainer(anonymous)) [8,29.828125 200x100]
+      PaintableWithLines (BlockContainer(anonymous)) [8,129.828125 784x65.484375]
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer<DIV>.b) [8,195.3125 784x100]
+        PaintableWithLines (BlockContainer(anonymous)) [8,195.3125 200x100]
+      PaintableWithLines (BlockContainer(anonymous)) [8,295.3125 784x65.484375]
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer<DIV>.c) [8,360.796875 784x100]
+        PaintableWithLines (BlockContainer(anonymous)) [8,360.796875 200x100]
+      PaintableWithLines (BlockContainer(anonymous)) [8,460.796875 784x0]

--- a/Tests/LibWeb/Layout/expected/pseudo-element-with-custom-properties.txt
+++ b/Tests/LibWeb/Layout/expected/pseudo-element-with-custom-properties.txt
@@ -4,3 +4,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <div.hello> at (8,8) content-size 784x0 children: not-inline
         BlockContainer <(anonymous)> at (8,8) content-size 500x100 positioned [BFC] children: inline
           TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x16] overflow: [0,0 800x108]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x0] overflow: [8,8 784x100]
+      PaintableWithLines (BlockContainer<DIV>.hello) [8,8 784x0] overflow: [8,8 500x100]
+        PaintableWithLines (BlockContainer(anonymous)) [8,8 500x100]

--- a/Tests/LibWeb/Layout/expected/replaced-box-with-vertical-margins.txt
+++ b/Tests/LibWeb/Layout/expected/replaced-box-with-vertical-margins.txt
@@ -10,3 +10,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       TextNode <#text>
       ImageBox <img#image> at (51.125,33) content-size 64x138 children: not-inline
       TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x216.9375]
+      TextPaintable (TextNode<#text>)
+      ImagePaintable (ImageBox<IMG>#image) [51.125,33 64x138]
+      TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/resolve-cyclic-percentage-against-zero-when-available-size-is-min-content.txt
+++ b/Tests/LibWeb/Layout/expected/resolve-cyclic-percentage-against-zero-when-available-size-is-min-content.txt
@@ -25,3 +25,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         ImageBox <img> at (12,841.46875) content-size 400x400 children: not-inline
       BlockContainer <(anonymous)> at (10,1243.46875) content-size 780x0 children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x1253.46875]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x1253.46875]
+    PaintableWithLines (BlockContainer<BODY>) [9,9 782x1235.46875]
+      PaintableWithLines (BlockContainer<DIV>.w.min) [10,10 4x19.46875] overflow: [11,11 3x17.46875]
+        ImagePaintable (ImageBox<IMG>) [11,20.53125 4x4]
+      PaintableWithLines (BlockContainer(anonymous)) [10,29.46875 780x0]
+      PaintableWithLines (BlockContainer<DIV>.w.max) [10,29.46875 404x406] overflow: [11,30.46875 403x404]
+        ImagePaintable (ImageBox<IMG>) [11,30.46875 404x404]
+      PaintableWithLines (BlockContainer(anonymous)) [10,435.46875 780x0]
+      PaintableWithLines (BlockContainer<DIV>.h.min) [10,435.46875 780x404]
+        ImagePaintable (ImageBox<IMG>) [11,436.46875 402x402]
+      PaintableWithLines (BlockContainer(anonymous)) [10,839.46875 780x0]
+      PaintableWithLines (BlockContainer<DIV>.h.max) [10,839.46875 780x404]
+        ImagePaintable (ImageBox<IMG>) [11,840.46875 402x402]
+      PaintableWithLines (BlockContainer(anonymous)) [10,1243.46875 780x0]

--- a/Tests/LibWeb/Layout/expected/resolve-height-of-containing-block.txt
+++ b/Tests/LibWeb/Layout/expected/resolve-height-of-containing-block.txt
@@ -24,3 +24,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,816) content-size 784x0 children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600] overflow: [0,0 1288x824]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x824] overflow: [0,0 1288x824]
+    PaintableWithLines (BlockContainer(anonymous)) [0,0 800x0]
+    PaintableWithLines (BlockContainer<BODY>) [8,16 784x800] overflow: [8,16 1280x800]
+      PaintableWithLines (BlockContainer(anonymous)) [8,16 784x0]
+      PaintableWithLines (BlockContainer<DIV>.foo) [8,16 1280x800]
+        PaintableWithLines (BlockContainer(anonymous)) [8,16 1280x0]
+        PaintableWithLines (BlockContainer<DIV>) [8,16 1280x400]
+          PaintableWithLines (BlockContainer(anonymous)) [8,16 1280x0]
+            ImagePaintable (ImageBox<IMG>) [488,16 800x400]
+          PaintableWithLines (BlockContainer<P>) [8,16 1280x17.46875]
+            TextPaintable (TextNode<#text>)
+          PaintableWithLines (BlockContainer(anonymous)) [8,49.46875 1280x0]
+        PaintableWithLines (BlockContainer(anonymous)) [8,416 1280x0]
+      PaintableWithLines (BlockContainer(anonymous)) [8,816 784x0]

--- a/Tests/LibWeb/Layout/expected/set-margin-of-floating-box.txt
+++ b/Tests/LibWeb/Layout/expected/set-margin-of-floating-box.txt
@@ -14,3 +14,13 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
       BlockContainer <(anonymous)> at (8,49.46875) content-size 784x0 children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x116]
+    PaintableWithLines (BlockContainer(anonymous)) [0,0 800x0]
+    PaintableWithLines (BlockContainer<BODY>) [8,16 784x17.46875] overflow: [8,16 784x33.46875]
+      PaintableWithLines (BlockContainer(anonymous)) [8,16 784x0]
+        ImagePaintable (ImageBox<IMG>) [8,16 200x100]
+      PaintableWithLines (BlockContainer<P>) [8,16 784x17.46875]
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,49.46875 784x0]

--- a/Tests/LibWeb/Layout/expected/svg-preserve-aspect-ratio.txt
+++ b/Tests/LibWeb/Layout/expected/svg-preserve-aspect-ratio.txt
@@ -103,3 +103,44 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         SVGGeometryBox <circle> at (299,201) content-size 60x60 children: not-inline
         TextNode <#text>
       TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x257.9375]
+      SVGSVGPaintable (SVGSVGBox<svg>) [8,83 102x52]
+        SVGGeometryPaintable (SVGGeometryBox<circle>) [34,84 50x50]
+      TextPaintable (TextNode<#text>)
+      SVGSVGPaintable (SVGSVGBox<svg>) [118,83 102x52]
+        SVGGeometryPaintable (SVGGeometryBox<circle>) [119,84 50x50]
+      TextPaintable (TextNode<#text>)
+      SVGSVGPaintable (SVGSVGBox<svg>) [228,83 102x52]
+        SVGGeometryPaintable (SVGGeometryBox<circle>) [279,84 50x50]
+      TextPaintable (TextNode<#text>)
+      SVGSVGPaintable (SVGSVGBox<svg>) [338,83 102x52]
+        SVGGeometryPaintable (SVGGeometryBox<circle>) [339,84 100x100]
+      TextPaintable (TextNode<#text>)
+      SVGSVGPaintable (SVGSVGBox<svg>) [448,83 102x52]
+        SVGGeometryPaintable (SVGGeometryBox<circle>) [449,59 100x100]
+      TextPaintable (TextNode<#text>)
+      SVGSVGPaintable (SVGSVGBox<svg>) [558,83 102x52]
+        SVGGeometryPaintable (SVGGeometryBox<circle>) [559,34 100x100]
+      TextPaintable (TextNode<#text>)
+      SVGSVGPaintable (SVGSVGBox<svg>) [668,8 52x127]
+        SVGGeometryPaintable (SVGGeometryBox<circle>) [669,9 50x50]
+      TextPaintable (TextNode<#text>)
+      SVGSVGPaintable (SVGSVGBox<svg>) [728,8 52x127]
+        SVGGeometryPaintable (SVGGeometryBox<circle>) [729,46.5 50x50]
+      SVGSVGPaintable (SVGSVGBox<svg>) [8,135 52x127]
+        SVGGeometryPaintable (SVGGeometryBox<circle>) [9,211 50x50]
+      TextPaintable (TextNode<#text>)
+      SVGSVGPaintable (SVGSVGBox<svg>) [68,135 52x127]
+        SVGGeometryPaintable (SVGGeometryBox<circle>) [69,136 125x125]
+      TextPaintable (TextNode<#text>)
+      SVGSVGPaintable (SVGSVGBox<svg>) [128,135 52x127]
+        SVGGeometryPaintable (SVGGeometryBox<circle>) [91.5,136 125x125]
+      TextPaintable (TextNode<#text>)
+      SVGSVGPaintable (SVGSVGBox<svg>) [188,135 52x127]
+        SVGGeometryPaintable (SVGGeometryBox<circle>) [114,136 125x125]
+      TextPaintable (TextNode<#text>)
+      SVGSVGPaintable (SVGSVGBox<svg>) [248,200 162x62]
+        SVGGeometryPaintable (SVGGeometryBox<circle>) [299,201 60x60]

--- a/Tests/LibWeb/Layout/expected/svg-transforms-and-viewboxes.txt
+++ b/Tests/LibWeb/Layout/expected/svg-transforms-and-viewboxes.txt
@@ -94,3 +94,39 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         SVGGeometryBox <rect> at (160,560) content-size 80x80 children: not-inline
         TextNode <#text>
       TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x700]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x700]
+    PaintableWithLines (BlockContainer<BODY>) [50,50 700x600]
+      SVGSVGPaintable (SVGSVGBox<svg>) [50,150 200x100]
+        SVGGraphicsPaintable (SVGGraphicsBox<g>) [50,150 0x0]
+          SVGGeometryPaintable (SVGGeometryBox<path>) [45.703125,199.828125 118.78125x47.453125]
+        SVGGraphicsPaintable (SVGGraphicsBox<g>) [50,150 0x0]
+          SVGGeometryPaintable (SVGGeometryBox<path>) [84.5,159.484375 81x81]
+      TextPaintable (TextNode<#text>)
+      SVGSVGPaintable (SVGSVGBox<svg>) [258,50 200x200]
+        SVGGeometryPaintable (SVGGeometryBox<rect>) [268,60 30x20]
+        SVGGeometryPaintable (SVGGeometryBox<rect>) [288,130 110x90]
+      TextPaintable (TextNode<#text>)
+      SVGSVGPaintable (SVGSVGBox<svg>) [466,50 200x200]
+        SVGGeometryPaintable (SVGGeometryBox<rect>) [506,90 120x120]
+        SVGGeometryPaintable (SVGGeometryBox<rect>) [471.34375,90 189.28125x120]
+      SVGSVGPaintable (SVGSVGBox<svg>) [50,250 200x200]
+        SVGGeometryPaintable (SVGGeometryBox<rect>) [120.578125,320.578125 58.8125x58.8125]
+        SVGGeometryPaintable (SVGGeometryBox<rect>) [52.4375,310.375 68.140625x68.140625]
+        SVGGeometryPaintable (SVGGeometryBox<rect>) [179.40625,321.484375 68.140625x68.140625]
+      TextPaintable (TextNode<#text>)
+      SVGSVGPaintable (SVGSVGBox<svg>) [258,250 200x200]
+        SVGGeometryPaintable (SVGGeometryBox<circle>) [278,270 160x160]
+        SVGGeometryPaintable (SVGGeometryBox<circle>) [338,270 40x160]
+        SVGGeometryPaintable (SVGGeometryBox<circle>) [278,330 160x40]
+        SVGGeometryPaintable (SVGGeometryBox<circle>) [338,330 40x40]
+      TextPaintable (TextNode<#text>)
+      SVGSVGPaintable (SVGSVGBox<svg>) [466,250 200x200]
+        SVGGeometryPaintable (SVGGeometryBox<rect>) [506,290 120x120]
+        SVGGeometryPaintable (SVGGeometryBox<rect>) [506,255.34375 120x189.28125]
+      SVGSVGPaintable (SVGSVGBox<svg>) [50,450 200x200]
+        SVGGeometryPaintable (SVGGeometryBox<rect>) [60,460 80x80]
+        SVGGeometryPaintable (SVGGeometryBox<rect>) [160,460 80x80]
+        SVGGeometryPaintable (SVGGeometryBox<rect>) [60,560 80x80]
+        SVGGeometryPaintable (SVGGeometryBox<rect>) [160,560 80x80]

--- a/Tests/LibWeb/Layout/expected/svg/dont-stretch-fit-svg-with-indefinite-containing-block-width.txt
+++ b/Tests/LibWeb/Layout/expected/svg/dont-stretch-fit-svg-with-indefinite-containing-block-width.txt
@@ -4,3 +4,8 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       line 0 width: 0, height: 17.46875, bottom: 17.46875, baseline: 13.53125
         frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,21.53125 0x0]
       SVGSVGBox <svg> at (8,21.53125) content-size 0x0 [SVG] children: not-inline
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x33.46875]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 0x17.46875]
+      SVGSVGPaintable (SVGSVGBox<svg>) [8,21.53125 0x0]

--- a/Tests/LibWeb/Layout/expected/svg/svg-as-image-implicit-viewbox.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-as-image-implicit-viewbox.txt
@@ -6,3 +6,8 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         Viewport <#document> at (0,0) content-size 50x100 children: inline
           SVGSVGBox <svg> at (0,0) content-size 50x100 [SVG] children: not-inline
             SVGGeometryBox <rect> at (0,0) content-size 50x100 children: not-inline
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x116]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x100]
+      ImagePaintable (ImageBox<IMG>) [8,8 50x100]

--- a/Tests/LibWeb/Layout/expected/svg/svg-as-image-invalid.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-as-image-invalid.txt
@@ -2,3 +2,8 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x48 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x32 children: not-inline
       ImageBox <img> at (8,8) content-size 16x32 children: not-inline
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x48]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x32]
+      ImagePaintable (ImageBox<IMG>) [8,8 16x32]

--- a/Tests/LibWeb/Layout/expected/svg/svg-as-image.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-as-image.txt
@@ -8,3 +8,8 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             TextNode <#text>
             SVGGeometryBox <rect> at (0,0) content-size 784x1568 children: not-inline
             TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x1584]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x1584]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x1568]
+      ImagePaintable (ImageBox<IMG>) [8,8 784x1568]

--- a/Tests/LibWeb/Layout/expected/svg/svg-fill-with-bogus-url.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-fill-with-bogus-url.txt
@@ -5,3 +5,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,8 784x784]
       SVGSVGBox <svg> at (8,8) content-size 784x784 [SVG] children: not-inline
         SVGGeometryBox <rect> at (8,8) content-size 784x784 children: not-inline
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x800]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x800]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x784]
+      SVGSVGPaintable (SVGSVGBox<svg>) [8,8 784x784]
+        SVGGeometryPaintable (SVGGeometryBox<rect>) [8,8 784x784]

--- a/Tests/LibWeb/Layout/expected/svg/svg-inside-svg.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-inside-svg.txt
@@ -8,3 +8,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           SVGSVGBox <svg> at (8,8) content-size 24x24 [SVG] children: not-inline
             SVGGeometryBox <rect> at (8,8) content-size 24x24 children: not-inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x40]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x24]
+      SVGSVGPaintable (SVGSVGBox<svg>) [8,8 24x24]
+        SVGGraphicsPaintable (SVGGraphicsBox<g>) [8,8 0x0]
+          SVGSVGPaintable (SVGSVGBox<svg>) [8,8 24x24]
+            SVGGeometryPaintable (SVGGeometryBox<rect>) [8,8 24x24]

--- a/Tests/LibWeb/Layout/expected/svg/svg-intrinsic-size-in-one-dimension.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-intrinsic-size-in-one-dimension.txt
@@ -5,3 +5,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         SVGGeometryBox <rect> at (21.5,21.5) content-size 75x25 children: not-inline
       SVGSVGBox <svg> at (9,61) content-size 200x100 [SVG] children: not-inline
         SVGGeometryBox <rect> at (34,86) content-size 150x50 children: not-inline
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x170]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x154]
+      SVGSVGPaintable (SVGSVGBox<svg>) [8,8 102x52]
+        SVGGeometryPaintable (SVGGeometryBox<rect>) [21.5,21.5 75x25]
+      SVGSVGPaintable (SVGSVGBox<svg>) [8,60 202x102]
+        SVGGeometryPaintable (SVGGeometryBox<rect>) [34,86 150x50]

--- a/Tests/LibWeb/Layout/expected/svg/svg-negative-elliptical-arg-number.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-negative-elliptical-arg-number.txt
@@ -5,3 +5,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,8 100x100]
       SVGSVGBox <svg> at (8,8) content-size 100x100 [SVG] children: not-inline
         SVGGeometryBox <path> at (8,9.984375) content-size 100x48 children: not-inline
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x116]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x100]
+      SVGSVGPaintable (SVGSVGBox<svg>) [8,8 100x100]
+        SVGGeometryPaintable (SVGGeometryBox<path>) [8,9.984375 100x48]

--- a/Tests/LibWeb/Layout/expected/svg/svg-path-with-implicit-lineto.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-path-with-implicit-lineto.txt
@@ -5,3 +5,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,8 100x100]
       SVGSVGBox <svg> at (8,8) content-size 100x100 [SVG] children: not-inline
         SVGGeometryBox <path> at (28,28) content-size 60x60 children: not-inline
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x116]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x100]
+      SVGSVGPaintable (SVGSVGBox<svg>) [8,8 100x100]
+        SVGGeometryPaintable (SVGGeometryBox<path>) [28,28 60x60]

--- a/Tests/LibWeb/Layout/expected/svg/svg-symbol-with-viewbox.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-symbol-with-viewbox.txt
@@ -18,3 +18,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               TextNode <#text>
           TextNode <#text>
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x150]
+      PaintableWithLines (BlockContainer(anonymous)) [8,8 784x0]
+      PaintableWithLines (BlockContainer<DIV>) [8,8 784x150]
+        SVGSVGPaintable (SVGSVGBox<svg>) [8,8 300x150]

--- a/Tests/LibWeb/Layout/expected/svg/svg-with-css-variable-in-presentation-hint.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-with-css-variable-in-presentation-hint.txt
@@ -5,3 +5,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         frag 0 from SVGSVGBox start: 0, length: 0, rect: [9,9 100x100]
       SVGSVGBox <svg> at (9,9) content-size 100x100 [SVG] children: not-inline
         SVGGeometryBox <rect> at (29,29) content-size 60x60 children: not-inline
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x118]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x102]
+      SVGSVGPaintable (SVGSVGBox<svg>) [8,8 102x102]
+        SVGGeometryPaintable (SVGGeometryBox<rect>) [29,29 60x60]

--- a/Tests/LibWeb/Layout/expected/svg/svg-with-display-block.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-with-display-block.txt
@@ -3,3 +3,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x784 children: not-inline
       SVGSVGBox <svg> at (8,8) content-size 784x784 [SVG] children: not-inline
         SVGGeometryBox <rect> at (8,8) content-size 784x784 children: not-inline
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x800]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x800]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x784]
+      SVGSVGPaintable (SVGSVGBox<svg>) [8,8 784x784]
+        SVGGeometryPaintable (SVGGeometryBox<rect>) [8,8 784x784]

--- a/Tests/LibWeb/Layout/expected/svg/svg-with-zero-intrinsic-size-and-no-viewbox.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-with-zero-intrinsic-size-and-no-viewbox.txt
@@ -19,3 +19,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         SVGGeometryBox <rect> at (16,21.53125) content-size 1x1 children: not-inline
         TextNode <#text>
       TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x17.46875]
+      ImagePaintable (ImageBox<IMG>) [8,21.53125 0x0]
+      TextPaintable (TextNode<#text>)
+      SVGSVGPaintable (SVGSVGBox<svg>) [16,21.53125 0x0]
+        SVGGeometryPaintable (SVGGeometryBox<rect>) [16,21.53125 1x1]

--- a/Tests/LibWeb/Layout/expected/svg/text-fill-none.txt
+++ b/Tests/LibWeb/Layout/expected/svg/text-fill-none.txt
@@ -6,3 +6,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       SVGSVGBox <svg> at (8,8) content-size 300x150 [SVG] children: not-inline
         SVGTextBox <text> at (8,8) content-size 0x0 children: not-inline
       TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x150]
+      SVGSVGPaintable (SVGSVGBox<svg>) [8,8 300x150]
+        SVGTextPaintable (SVGTextBox<text>) [8,8 0x0]

--- a/Tests/LibWeb/Layout/expected/table/align-top-and-bottom.txt
+++ b/Tests/LibWeb/Layout/expected/table/align-top-and-bottom.txt
@@ -44,3 +44,20 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x98.9375]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 197.328125x98.9375]
+        PaintableBox (Box<TABLE>) [8,8 197.328125x98.9375]
+          PaintableBox (Box<TBODY>) [9,9 195.328125x96.9375]
+            PaintableBox (Box<TR>) [9,9 195.328125x48.46875] overflow: [9,9 195.328125x96.9375]
+              PaintableWithLines (BlockContainer<TD>) [9,9 63.078125x96.9375]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [72.078125,9 86.984375x96.9375]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [159.0625,9 45.265625x48.46875]
+                TextPaintable (TextNode<#text>)
+            PaintableBox (Box<TR>) [9,57.46875 195.328125x48.46875]
+              PaintableWithLines (BlockContainer<TD>) [159.0625,57.46875 45.265625x48.46875]
+                TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/auto-height.txt
+++ b/Tests/LibWeb/Layout/expected/table/auto-height.txt
@@ -21,3 +21,20 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 TextNode <#text>
       BlockContainer <(anonymous)> at (10,52.9375) content-size 780x0 children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x62.9375]
+    PaintableWithLines (BlockContainer<BODY>) [9,9 782x44.9375]
+      PaintableWithLines (BlockContainer<DIV>) [10,10 780x21.46875]
+        PaintableWithLines (TableWrapper(anonymous)) [11,11 29.15625x19.46875]
+          PaintableBox (Box(anonymous)) [11,11 29.15625x19.46875]
+            PaintableBox (Box(anonymous)) [11,11 29.15625x19.46875]
+              PaintableWithLines (BlockContainer<SPAN>) [11,11 29.15625x19.46875]
+                TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer<DIV>) [10,31.46875 780x21.46875]
+        PaintableWithLines (TableWrapper(anonymous)) [11,32.46875 29.640625x19.46875]
+          PaintableBox (Box(anonymous)) [11,32.46875 29.640625x19.46875]
+            PaintableBox (Box(anonymous)) [11,32.46875 29.640625x19.46875]
+              PaintableWithLines (BlockContainer<SPAN>) [11,32.46875 29.640625x19.46875]
+                TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [10,52.9375 780x0]

--- a/Tests/LibWeb/Layout/expected/table/auto-margins.txt
+++ b/Tests/LibWeb/Layout/expected/table/auto-margins.txt
@@ -10,3 +10,13 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                   frag 0 from TextNode start: 0, length: 34, rect: [235.265625,8 329.46875x17.46875]
                     "DaTa DisplaYiNg CSS WeBpaGE ScReEn"
                 TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x17.46875]
+      PaintableWithLines (BlockContainer<DIV>.wrapper) [8,8 784x17.46875]
+        PaintableWithLines (TableWrapper(anonymous)) [235.265625,8 329.46875x17.46875]
+          PaintableBox (Box<DIV>.box) [235.265625,8 329.46875x17.46875]
+            PaintableBox (Box(anonymous)) [235.265625,8 329.46875x17.46875]
+              PaintableWithLines (BlockContainer<DIV>.cell) [235.265625,8 329.46875x17.46875]
+                TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/avoid-div-by-zero-in-table-measures.txt
+++ b/Tests/LibWeb/Layout/expected/table/avoid-div-by-zero-in-table-measures.txt
@@ -22,3 +22,13 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               TextNode <#text>
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x23.46875]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 6x23.46875] overflow: [8,8 17.265625x23.46875]
+        PaintableBox (Box<TABLE>) [8,8 6x23.46875] overflow: [8,8 17.265625x23.46875]
+          PaintableBox (Box<TBODY>) [8,8 0x19.46875] overflow: [10,10 15.265625x19.46875]
+            PaintableBox (Box<TR>) [10,10 0x19.46875] overflow: [10,10 15.265625x19.46875]
+              PaintableWithLines (BlockContainer<TD>) [10,10 2x19.46875] overflow: [10,10 15.265625x19.46875]
+                TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/basic.txt
+++ b/Tests/LibWeb/Layout/expected/table/basic.txt
@@ -70,3 +70,27 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             TextNode <#text>
       BlockContainer <(anonymous)> at (8,93.875) content-size 784x0 children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x85.875]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 2x2]
+        PaintableBox (Box<TABLE>#empty-table) [8,8 2x2]
+      PaintableWithLines (BlockContainer(anonymous)) [8,10 784x0]
+      PaintableWithLines (TableWrapper(anonymous)) [8,10 99.171875x83.875]
+        PaintableBox (Box<TABLE>#full-table) [8,27.46875 99.171875x66.40625] overflow: [8,10 99.171875x83.875]
+          PaintableWithLines (BlockContainer<CAPTION>) [8,10 82.734375x17.46875] overflow: [8,10 90.953125x17.46875]
+            TextPaintable (TextNode<#text>)
+          PaintableBox (Box<THEAD>) [8,10 95.171875x19.46875] overflow: [8,10 97.171875x38.9375]
+            PaintableBox (Box<TR>) [10,29.46875 95.171875x19.46875]
+              PaintableWithLines (BlockContainer<TD>) [10,29.46875 95.171875x19.46875]
+                TextPaintable (TextNode<#text>)
+          PaintableBox (Box<TBODY>) [8,29.46875 95.171875x19.46875] overflow: [8,29.46875 97.171875x40.9375]
+            PaintableBox (Box<TR>) [10,50.9375 95.171875x19.46875]
+              PaintableWithLines (BlockContainer<TD>) [10,50.9375 95.171875x19.46875]
+                TextPaintable (TextNode<#text>)
+          PaintableBox (Box<TFOOT>) [8,48.9375 95.171875x19.46875] overflow: [8,48.9375 97.171875x42.9375]
+            PaintableBox (Box<TR>) [10,72.40625 95.171875x19.46875]
+              PaintableWithLines (BlockContainer<TD>) [10,72.40625 95.171875x19.46875]
+                TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,93.875 784x0]

--- a/Tests/LibWeb/Layout/expected/table/border-collapse-is-inherited.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-collapse-is-inherited.txt
@@ -152,3 +152,51 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
       BlockContainer <(anonymous)> at (8,202.34375) content-size 784x0 children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x210.34375]
+    PaintableWithLines (BlockContainer(anonymous)) [0,0 800x0]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x194.34375]
+      PaintableWithLines (BlockContainer(anonymous)) [8,8 784x0]
+      PaintableWithLines (BlockContainer<DIV>.horizontal) [8,8 784x194.34375]
+        PaintableWithLines (BlockContainer<TABLE>) [8,8 160.90625x194.34375]
+          PaintableWithLines (BlockContainer(anonymous)) [9,9 158.90625x0]
+          PaintableWithLines (TableWrapper(anonymous)) [9,9 158.90625x192.34375]
+            PaintableBox (Box(anonymous)) [9,9 158.90625x192.34375]
+              PaintableBox (Box<TBODY>) [9,9 158.90625x192.34375]
+                PaintableBox (Box<TR>) [9,9 158.90625x38.46875]
+                  PaintableWithLines (BlockContainer<TD>) [9,9 55.265625x38.46875]
+                    TextPaintable (TextNode<#text>)
+                  PaintableWithLines (BlockContainer<TD>) [64.265625,9 53.546875x38.46875]
+                    TextPaintable (TextNode<#text>)
+                  PaintableWithLines (BlockContainer<TD>) [117.8125,9 50.09375x38.46875]
+                    TextPaintable (TextNode<#text>)
+                PaintableBox (Box<TR>) [9,47.46875 158.90625x38.46875]
+                  PaintableWithLines (BlockContainer<TD>) [9,47.46875 55.265625x38.46875]
+                    TextPaintable (TextNode<#text>)
+                  PaintableWithLines (BlockContainer<TD>) [64.265625,47.46875 53.546875x38.46875]
+                    TextPaintable (TextNode<#text>)
+                  PaintableWithLines (BlockContainer<TD>) [117.8125,47.46875 50.09375x38.46875]
+                    TextPaintable (TextNode<#text>)
+                PaintableBox (Box<TR>) [9,85.9375 158.90625x38.46875]
+                  PaintableWithLines (BlockContainer<TD>) [9,85.9375 55.265625x38.46875]
+                    TextPaintable (TextNode<#text>)
+                  PaintableWithLines (BlockContainer<TD>) [64.265625,85.9375 53.546875x38.46875]
+                    TextPaintable (TextNode<#text>)
+                  PaintableWithLines (BlockContainer<TD>) [117.8125,85.9375 50.09375x38.46875]
+                    TextPaintable (TextNode<#text>)
+                PaintableBox (Box<TR>) [9,124.40625 158.90625x38.46875]
+                  PaintableWithLines (BlockContainer<TD>) [9,124.40625 55.265625x38.46875]
+                    TextPaintable (TextNode<#text>)
+                  PaintableWithLines (BlockContainer<TD>) [64.265625,124.40625 53.546875x38.46875]
+                    TextPaintable (TextNode<#text>)
+                  PaintableWithLines (BlockContainer<TD>) [117.8125,124.40625 50.09375x38.46875]
+                    TextPaintable (TextNode<#text>)
+                PaintableBox (Box<TR>) [9,162.875 158.90625x38.46875]
+                  PaintableWithLines (BlockContainer<TD>) [9,162.875 55.265625x38.46875]
+                    TextPaintable (TextNode<#text>)
+                  PaintableWithLines (BlockContainer<TD>) [64.265625,162.875 53.546875x38.46875]
+                    TextPaintable (TextNode<#text>)
+                  PaintableWithLines (BlockContainer<TD>) [117.8125,162.875 50.09375x38.46875]
+                    TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,202.34375 784x0]

--- a/Tests/LibWeb/Layout/expected/table/border-conflict-resolution-with-cell.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-conflict-resolution-with-cell.txt
@@ -62,3 +62,24 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               TextNode <#text>
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x84.9375]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 169.671875x84.9375]
+        PaintableBox (Box<TABLE>) [8,8 169.671875x84.9375]
+          PaintableBox (Box<TBODY>) [8,8 169.671875x84.9375]
+            PaintableBox (Box<TR>) [8,8 169.671875x42.46875]
+              PaintableWithLines (BlockContainer<TD>) [8,8 57.265625x42.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>.td-thick-border) [65.265625,8 54.859375x42.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [120.125,8 57.546875x42.46875]
+                TextPaintable (TextNode<#text>)
+            PaintableBox (Box<TR>) [8,50.46875 169.671875x42.46875]
+              PaintableWithLines (BlockContainer<TD>) [8,50.46875 57.265625x42.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [65.265625,50.46875 54.859375x42.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>.td-thick-border) [120.125,50.46875 57.546875x42.46875]
+                TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/border-conflict-resolution-with-col.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-conflict-resolution-with-col.txt
@@ -68,3 +68,25 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             TextNode <#text>
       BlockContainer <(anonymous)> at (8,165.875) content-size 784x0 children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x173.875]
+    PaintableWithLines (BlockContainer(anonymous)) [0,0 800x0]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x157.875]
+      PaintableWithLines (BlockContainer(anonymous)) [8,8 784x0]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 59.265625x157.875]
+        PaintableBox (Box<TABLE>) [8,8 59.265625x157.875]
+          PaintableBox (Box<TBODY>) [8,8 59.265625x157.875]
+            PaintableBox (Box<TR>) [8,8 59.265625x40.46875]
+              PaintableWithLines (BlockContainer<TD>) [8,8 59.265625x40.46875]
+                TextPaintable (TextNode<#text>)
+            PaintableBox (Box<TR>) [8,48.46875 59.265625x38.46875]
+              PaintableWithLines (BlockContainer<TD>) [8,48.46875 59.265625x38.46875]
+                TextPaintable (TextNode<#text>)
+            PaintableBox (Box<TR>) [8,86.9375 59.265625x38.46875]
+              PaintableWithLines (BlockContainer<TD>) [8,86.9375 59.265625x38.46875]
+                TextPaintable (TextNode<#text>)
+            PaintableBox (Box<TR>) [8,125.40625 59.265625x40.46875]
+              PaintableWithLines (BlockContainer<TD>) [8,125.40625 59.265625x40.46875]
+                TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,165.875 784x0]

--- a/Tests/LibWeb/Layout/expected/table/border-conflict-resolution-with-row.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-conflict-resolution-with-row.txt
@@ -67,3 +67,25 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               TextNode <#text>
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x127.40625]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 112.8125x127.40625]
+        PaintableBox (Box<TABLE>) [8,8 112.8125x127.40625]
+          PaintableBox (Box<TBODY>) [8,8 112.8125x127.40625]
+            PaintableBox (Box<TR>.td-thick-border) [8,8 112.8125x42.46875]
+              PaintableWithLines (BlockContainer<TD>) [8,8 57.265625x42.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [65.265625,8 55.546875x42.46875]
+                TextPaintable (TextNode<#text>)
+            PaintableBox (Box<TR>) [8,50.46875 112.8125x42.46875]
+              PaintableWithLines (BlockContainer<TD>) [8,50.46875 57.265625x42.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [65.265625,50.46875 55.546875x42.46875]
+                TextPaintable (TextNode<#text>)
+            PaintableBox (Box<TR>.td-thick-border) [8,92.9375 112.8125x42.46875]
+              PaintableWithLines (BlockContainer<TD>) [8,92.9375 57.265625x42.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [65.265625,92.9375 55.546875x42.46875]
+                TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/border-conflict-resolution-with-rowgroup.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-conflict-resolution-with-rowgroup.txt
@@ -68,3 +68,26 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               TextNode <#text>
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x121.40625]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 111.40625x121.40625]
+        PaintableBox (Box<TABLE>) [8,8 111.40625x121.40625]
+          PaintableBox (Box<THEAD>) [8,8 111.40625x40.46875]
+            PaintableBox (Box<TR>) [8,8 111.40625x40.46875]
+              PaintableWithLines (BlockContainer<TD>) [8,8 57.265625x40.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [65.265625,8 54.140625x40.46875]
+                TextPaintable (TextNode<#text>)
+          PaintableBox (Box<TBODY>.thick-border) [8,48.46875 111.40625x80.9375]
+            PaintableBox (Box<TR>) [8,48.46875 111.40625x40.46875]
+              PaintableWithLines (BlockContainer<TD>) [8,48.46875 57.265625x40.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [65.265625,48.46875 54.140625x40.46875]
+                TextPaintable (TextNode<#text>)
+            PaintableBox (Box<TR>) [8,88.9375 111.40625x40.46875]
+              PaintableWithLines (BlockContainer<TD>) [8,88.9375 57.265625x40.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [65.265625,88.9375 54.140625x40.46875]
+                TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/border-spacing-and-borders-table-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-spacing-and-borders-table-width.txt
@@ -25,3 +25,15 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x77.46875]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 143.609375x77.46875]
+        PaintableBox (Box<TABLE>) [8,8 143.609375x77.46875]
+          PaintableBox (Box<TBODY>) [23,13 83.609375x47.46875] overflow: [23,13 103.609375x57.46875]
+            PaintableBox (Box<TR>) [33,23 83.609375x47.46875] overflow: [33,23 93.609375x47.46875]
+              PaintableWithLines (BlockContainer<TD>) [33,23 44.265625x47.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [87.265625,23 39.34375x47.46875]
+                TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/border-spacing-colspan.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-spacing-colspan.txt
@@ -139,3 +139,46 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             TextNode <#text>
       BlockContainer <(anonymous)> at (8,267.34375) content-size 784x0 children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x275.34375]
+    PaintableWithLines (BlockContainer(anonymous)) [0,0 800x0]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x259.34375]
+      PaintableWithLines (BlockContainer(anonymous)) [8,8 784x0]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 243.90625x259.34375]
+        PaintableBox (Box<TABLE>) [8,8 243.90625x259.34375]
+          PaintableBox (Box<TBODY>) [9,9 161.90625x197.34375] overflow: [9,9 221.90625x247.34375]
+            PaintableBox (Box<TR>) [29,19 161.90625x39.46875] overflow: [29,19 201.90625x39.46875]
+              PaintableWithLines (BlockContainer<TD>) [29,19 56.265625x39.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [105.265625,19 54.546875x39.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [179.8125,19 51.09375x39.46875]
+                TextPaintable (TextNode<#text>)
+            PaintableBox (Box<TR>) [29,68.46875 161.90625x39.46875] overflow: [29,68.46875 201.90625x39.46875]
+              PaintableWithLines (BlockContainer<TD>) [29,68.46875 130.8125x39.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [179.8125,68.46875 51.09375x39.46875]
+                TextPaintable (TextNode<#text>)
+            PaintableBox (Box<TR>) [29,117.9375 161.90625x39.46875] overflow: [29,117.9375 201.90625x39.46875]
+              PaintableWithLines (BlockContainer<TD>) [29,117.9375 56.265625x39.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [105.265625,117.9375 54.546875x39.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [179.8125,117.9375 51.09375x39.46875]
+                TextPaintable (TextNode<#text>)
+            PaintableBox (Box<TR>) [29,167.40625 161.90625x39.46875] overflow: [29,167.40625 201.90625x39.46875]
+              PaintableWithLines (BlockContainer<TD>) [29,167.40625 56.265625x39.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [105.265625,167.40625 54.546875x39.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [179.8125,167.40625 51.09375x39.46875]
+                TextPaintable (TextNode<#text>)
+            PaintableBox (Box<TR>) [29,216.875 161.90625x39.46875] overflow: [29,216.875 201.90625x39.46875]
+              PaintableWithLines (BlockContainer<TD>) [29,216.875 56.265625x39.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [105.265625,216.875 54.546875x39.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [179.8125,216.875 51.09375x39.46875]
+                TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,267.34375 784x0]

--- a/Tests/LibWeb/Layout/expected/table/border-spacing-rowspan.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-spacing-rowspan.txt
@@ -139,3 +139,46 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             TextNode <#text>
       BlockContainer <(anonymous)> at (8,267.34375) content-size 784x0 children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x275.34375]
+    PaintableWithLines (BlockContainer(anonymous)) [0,0 800x0]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x259.34375]
+      PaintableWithLines (BlockContainer(anonymous)) [8,8 784x0]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 243.90625x259.34375]
+        PaintableBox (Box<TABLE>) [8,8 243.90625x259.34375]
+          PaintableBox (Box<TBODY>) [9,9 161.90625x197.34375] overflow: [9,9 221.90625x247.34375]
+            PaintableBox (Box<TR>) [29,19 161.90625x39.46875] overflow: [29,19 201.90625x88.9375]
+              PaintableWithLines (BlockContainer<TD>) [29,19 56.265625x88.9375]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [105.265625,19 54.546875x39.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [179.8125,19 51.09375x39.46875]
+                TextPaintable (TextNode<#text>)
+            PaintableBox (Box<TR>) [29,68.46875 161.90625x39.46875] overflow: [29,68.46875 201.90625x39.46875]
+              PaintableWithLines (BlockContainer<TD>) [105.265625,68.46875 54.546875x39.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [179.8125,68.46875 51.09375x39.46875]
+                TextPaintable (TextNode<#text>)
+            PaintableBox (Box<TR>) [29,117.9375 161.90625x39.46875] overflow: [29,117.9375 201.90625x39.46875]
+              PaintableWithLines (BlockContainer<TD>) [29,117.9375 56.265625x39.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [105.265625,117.9375 54.546875x39.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [179.8125,117.9375 51.09375x39.46875]
+                TextPaintable (TextNode<#text>)
+            PaintableBox (Box<TR>) [29,167.40625 161.90625x39.46875] overflow: [29,167.40625 201.90625x39.46875]
+              PaintableWithLines (BlockContainer<TD>) [29,167.40625 56.265625x39.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [105.265625,167.40625 54.546875x39.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [179.8125,167.40625 51.09375x39.46875]
+                TextPaintable (TextNode<#text>)
+            PaintableBox (Box<TR>) [29,216.875 161.90625x39.46875] overflow: [29,216.875 201.90625x39.46875]
+              PaintableWithLines (BlockContainer<TD>) [29,216.875 56.265625x39.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [105.265625,216.875 54.546875x39.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [179.8125,216.875 51.09375x39.46875]
+                TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,267.34375 784x0]

--- a/Tests/LibWeb/Layout/expected/table/border-spacing-with-percentage-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-spacing-with-percentage-width.txt
@@ -34,3 +34,17 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           frag 0 from TextNode start: 1, length: 1, rect: [603.828125,8 10.3125x17.46875]
             "C"
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x0]
+      PaintableWithLines (BlockContainer<DIV>.left) [8,8 117.59375x17.46875]
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (TableWrapper(anonymous)) [125.59375,8 478.234375x23.46875]
+        PaintableBox (Box<TABLE>.middle) [125.59375,8 478.234375x23.46875]
+          PaintableBox (Box<TBODY>) [125.59375,8 474.234375x19.46875] overflow: [125.59375,8 476.234375x21.46875]
+            PaintableBox (Box<TR>) [127.59375,10 474.234375x19.46875]
+              PaintableWithLines (BlockContainer<TD>) [127.59375,10 474.234375x19.46875]
+                TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer<DIV>.right) [603.828125,8 188.15625x17.46875]
+        TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/border-spacing.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-spacing.txt
@@ -146,3 +146,48 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             TextNode <#text>
       BlockContainer <(anonymous)> at (8,267.34375) content-size 784x0 children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x275.34375]
+    PaintableWithLines (BlockContainer(anonymous)) [0,0 800x0]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x259.34375]
+      PaintableWithLines (BlockContainer(anonymous)) [8,8 784x0]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 243.90625x259.34375]
+        PaintableBox (Box<TABLE>) [8,8 243.90625x259.34375]
+          PaintableBox (Box<TBODY>) [9,9 161.90625x197.34375] overflow: [9,9 221.90625x247.34375]
+            PaintableBox (Box<TR>) [29,19 161.90625x39.46875] overflow: [29,19 201.90625x39.46875]
+              PaintableWithLines (BlockContainer<TD>) [29,19 56.265625x39.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [105.265625,19 54.546875x39.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [179.8125,19 51.09375x39.46875]
+                TextPaintable (TextNode<#text>)
+            PaintableBox (Box<TR>) [29,68.46875 161.90625x39.46875] overflow: [29,68.46875 201.90625x39.46875]
+              PaintableWithLines (BlockContainer<TD>) [29,68.46875 56.265625x39.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [105.265625,68.46875 54.546875x39.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [179.8125,68.46875 51.09375x39.46875]
+                TextPaintable (TextNode<#text>)
+            PaintableBox (Box<TR>) [29,117.9375 161.90625x39.46875] overflow: [29,117.9375 201.90625x39.46875]
+              PaintableWithLines (BlockContainer<TD>) [29,117.9375 56.265625x39.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [105.265625,117.9375 54.546875x39.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [179.8125,117.9375 51.09375x39.46875]
+                TextPaintable (TextNode<#text>)
+            PaintableBox (Box<TR>) [29,167.40625 161.90625x39.46875] overflow: [29,167.40625 201.90625x39.46875]
+              PaintableWithLines (BlockContainer<TD>) [29,167.40625 56.265625x39.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [105.265625,167.40625 54.546875x39.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [179.8125,167.40625 51.09375x39.46875]
+                TextPaintable (TextNode<#text>)
+            PaintableBox (Box<TR>) [29,216.875 161.90625x39.46875] overflow: [29,216.875 201.90625x39.46875]
+              PaintableWithLines (BlockContainer<TD>) [29,216.875 56.265625x39.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [105.265625,216.875 54.546875x39.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [179.8125,216.875 51.09375x39.46875]
+                TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,267.34375 784x0]

--- a/Tests/LibWeb/Layout/expected/table/borders.txt
+++ b/Tests/LibWeb/Layout/expected/table/borders.txt
@@ -258,3 +258,81 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             TextNode <#text>
       BlockContainer <(anonymous)> at (8,269.625) content-size 784x0 children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x261.625]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 174.296875x74.40625]
+        PaintableBox (Box<TABLE>.table-border-black) [8,8 174.296875x74.40625]
+          PaintableBox (Box<TBODY>) [9,9 166.296875x64.40625] overflow: [9,9 170.296875x70.40625]
+            PaintableBox (Box<TR>) [11,11 166.296875x21.46875] overflow: [11,11 168.296875x21.46875]
+              PaintableWithLines (BlockContainer<TD>) [11,11 86.015625x21.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [99.015625,11 80.28125x21.46875]
+                TextPaintable (TextNode<#text>)
+            PaintableBox (Box<TR>) [11,34.46875 166.296875x21.46875] overflow: [11,34.46875 168.296875x21.46875]
+              PaintableWithLines (BlockContainer<TD>) [11,34.46875 86.015625x21.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [99.015625,34.46875 80.28125x21.46875]
+                TextPaintable (TextNode<#text>)
+            PaintableBox (Box<TR>) [11,57.9375 166.296875x21.46875] overflow: [11,57.9375 168.296875x21.46875]
+              PaintableWithLines (BlockContainer<TD>) [11,57.9375 86.015625x21.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [99.015625,57.9375 80.28125x21.46875]
+                TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,82.40625 784x0]
+      PaintableWithLines (TableWrapper(anonymous)) [8,82.40625 163.296875x60.40625]
+        PaintableBox (Box<TABLE>.table-border-black) [8,82.40625 163.296875x60.40625]
+          PaintableBox (Box<TBODY>) [8,82.40625 163.296875x60.40625]
+            PaintableBox (Box<TR>) [8,82.40625 163.296875x19.96875]
+              PaintableWithLines (BlockContainer<TD>) [8,82.40625 84.515625x19.96875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [92.515625,82.40625 78.78125x19.96875]
+                TextPaintable (TextNode<#text>)
+            PaintableBox (Box<TR>) [8,102.375 163.296875x20.46875]
+              PaintableWithLines (BlockContainer<TD>) [8,102.375 84.515625x20.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [92.515625,102.375 78.78125x20.46875]
+                TextPaintable (TextNode<#text>)
+            PaintableBox (Box<TR>) [8,122.84375 163.296875x19.96875]
+              PaintableWithLines (BlockContainer<TD>) [8,122.84375 84.515625x19.96875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [92.515625,122.84375 78.78125x19.96875]
+                TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,142.8125 784x0]
+      PaintableWithLines (TableWrapper(anonymous)) [8,142.8125 159.296875x54.40625]
+        PaintableBox (Box<DIV>.table.border-black) [8,142.8125 159.296875x54.40625]
+          PaintableBox (Box<DIV>.table-row.border-black) [8,142.8125 159.296875x17.96875]
+            PaintableWithLines (BlockContainer<DIV>.table-cell.border-black) [8,142.8125 82.515625x17.96875]
+              TextPaintable (TextNode<#text>)
+            PaintableWithLines (BlockContainer<DIV>.table-cell.border-black) [90.515625,142.8125 76.78125x17.96875]
+              TextPaintable (TextNode<#text>)
+          PaintableBox (Box<DIV>.table-row.border-black) [8,160.78125 159.296875x18.46875]
+            PaintableWithLines (BlockContainer<DIV>.table-cell.border-black) [8,160.78125 82.515625x18.46875]
+              TextPaintable (TextNode<#text>)
+            PaintableWithLines (BlockContainer<DIV>.table-cell.border-black) [90.515625,160.78125 76.78125x18.46875]
+              TextPaintable (TextNode<#text>)
+          PaintableBox (Box<DIV>.table-row.border-black) [8,179.25 159.296875x17.96875]
+            PaintableWithLines (BlockContainer<DIV>.table-cell.border-black) [8,179.25 82.515625x17.96875]
+              TextPaintable (TextNode<#text>)
+            PaintableWithLines (BlockContainer<DIV>.table-cell.border-black) [90.515625,179.25 76.78125x17.96875]
+              TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,197.21875 784x0]
+      PaintableWithLines (TableWrapper(anonymous)) [8,197.21875 168.296875x72.40625]
+        PaintableBox (Box<DIV>.table.thick-border-black) [8,197.21875 168.296875x72.40625]
+          PaintableBox (Box<DIV>.table-row.thick-border-black) [8,197.21875 168.296875x22.46875]
+            PaintableWithLines (BlockContainer<DIV>.table-cell.thick-border-black) [8,197.21875 87.015625x22.46875]
+              TextPaintable (TextNode<#text>)
+            PaintableWithLines (BlockContainer<DIV>.table-cell.thick-border-black) [95.015625,197.21875 81.28125x22.46875]
+              TextPaintable (TextNode<#text>)
+          PaintableBox (Box<DIV>.table-row.thick-border-black) [8,219.6875 168.296875x27.46875]
+            PaintableWithLines (BlockContainer<DIV>.table-cell.thick-border-black) [8,219.6875 87.015625x27.46875]
+              TextPaintable (TextNode<#text>)
+            PaintableWithLines (BlockContainer<DIV>.table-cell.thick-border-black) [95.015625,219.6875 81.28125x27.46875]
+              TextPaintable (TextNode<#text>)
+          PaintableBox (Box<DIV>.table-row.thick-border-black) [8,247.15625 168.296875x22.46875]
+            PaintableWithLines (BlockContainer<DIV>.table-cell.thick-border-black) [8,247.15625 87.015625x22.46875]
+              TextPaintable (TextNode<#text>)
+            PaintableWithLines (BlockContainer<DIV>.table-cell.thick-border-black) [95.015625,247.15625 81.28125x22.46875]
+              TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,269.625 784x0]

--- a/Tests/LibWeb/Layout/expected/table/bottom-caption.txt
+++ b/Tests/LibWeb/Layout/expected/table/bottom-caption.txt
@@ -67,3 +67,25 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             TextNode <#text>
       BlockContainer <(anonymous)> at (8,91.875) content-size 784x0 children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x99.875]
+    PaintableWithLines (BlockContainer(anonymous)) [0,0 800x0]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x83.875]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 99.171875x83.875]
+        PaintableBox (Box<TABLE>#full-table) [8,8 99.171875x66.40625] overflow: [8,8 99.171875x83.875]
+          PaintableWithLines (BlockContainer<CAPTION>) [8,74.40625 82.734375x17.46875] overflow: [8,74.40625 90.953125x17.46875]
+            TextPaintable (TextNode<#text>)
+          PaintableBox (Box<THEAD>) [8,8 95.171875x19.46875] overflow: [8,8 97.171875x21.46875]
+            PaintableBox (Box<TR>) [10,10 95.171875x19.46875]
+              PaintableWithLines (BlockContainer<TD>) [10,10 95.171875x19.46875]
+                TextPaintable (TextNode<#text>)
+          PaintableBox (Box<TBODY>) [8,27.46875 95.171875x19.46875] overflow: [8,27.46875 97.171875x23.46875]
+            PaintableBox (Box<TR>) [10,31.46875 95.171875x19.46875]
+              PaintableWithLines (BlockContainer<TD>) [10,31.46875 95.171875x19.46875]
+                TextPaintable (TextNode<#text>)
+          PaintableBox (Box<TFOOT>) [8,46.9375 95.171875x19.46875] overflow: [8,46.9375 97.171875x25.46875]
+            PaintableBox (Box<TR>) [10,52.9375 95.171875x19.46875]
+              PaintableWithLines (BlockContainer<TD>) [10,52.9375 95.171875x19.46875]
+                TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,91.875 784x0]

--- a/Tests/LibWeb/Layout/expected/table/cell-auto-max-width-table-percentage-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/cell-auto-max-width-table-percentage-width.txt
@@ -41,3 +41,20 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               TextNode <#text>
         BlockContainer <(anonymous)> at (8,31.46875) content-size 80x0 children: inline
           TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x23.46875]
+      PaintableWithLines (BlockContainer<DIV>#container) [8,8 80x23.46875]
+        PaintableWithLines (BlockContainer(anonymous)) [8,8 80x0]
+        PaintableWithLines (TableWrapper(anonymous)) [8,8 80x23.46875]
+          PaintableBox (Box<TABLE>#table) [8,8 80x23.46875]
+            PaintableBox (Box<TBODY>) [8,8 71.984375x19.46875] overflow: [8,8 77.984375x21.46875]
+              PaintableBox (Box<TR>) [10,10 71.984375x19.46875] overflow: [10,10 75.984375x19.46875]
+                PaintableWithLines (BlockContainer<TD>) [10,10 19.828125x19.46875]
+                  TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer<TD>) [31.828125,10 13.828125x19.46875]
+                  TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer<TD>) [47.65625,10 38.328125x19.46875]
+                  TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer(anonymous)) [8,31.46875 80x0]

--- a/Tests/LibWeb/Layout/expected/table/cell-px-height.txt
+++ b/Tests/LibWeb/Layout/expected/table/cell-px-height.txt
@@ -4,3 +4,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       Box <body> at (8,8) content-size 102x100 table-box [TFC] children: not-inline
         Box <div.row> at (8,8) content-size 102x100 table-row children: not-inline
           BlockContainer <div.cell> at (9,9) content-size 100x0 table-cell [BFC] children: not-inline
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (TableWrapper(anonymous)) [8,8 102x100]
+      PaintableBox (Box<BODY>) [8,8 102x100]
+        PaintableBox (Box<DIV>.row) [8,8 102x100]
+          PaintableWithLines (BlockContainer<DIV>.cell) [8,8 102x100]

--- a/Tests/LibWeb/Layout/expected/table/cell-relative-to-specified-table-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/cell-relative-to-specified-table-width.txt
@@ -62,3 +62,24 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               TextNode <#text>
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x44.9375]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 784x44.9375]
+        PaintableBox (Box<TABLE>) [8,8 784x44.9375]
+          PaintableBox (Box<TBODY>) [8,8 775.96875x38.9375] overflow: [8,8 781.96875x42.9375]
+            PaintableBox (Box<TR>) [10,10 775.96875x19.46875] overflow: [10,10 779.96875x19.46875]
+              PaintableWithLines (BlockContainer<TH>) [10,10 302.625x19.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TH>) [314.625,10 170.71875x19.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TH>) [487.34375,10 302.625x19.46875]
+                TextPaintable (TextNode<#text>)
+            PaintableBox (Box<TR>) [10,31.46875 775.96875x19.46875] overflow: [10,31.46875 779.96875x19.46875]
+              PaintableWithLines (BlockContainer<TD>) [10,31.46875 302.625x19.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [314.625,31.46875 170.71875x19.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [487.34375,31.46875 302.625x19.46875]
+                TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/clip-spans-to-table-end.txt
+++ b/Tests/LibWeb/Layout/expected/table/clip-spans-to-table-end.txt
@@ -63,3 +63,25 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x115.40625]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 89.359375x115.40625]
+        PaintableBox (Box<TABLE>) [8,8 89.359375x115.40625]
+          PaintableBox (Box<TBODY>) [8,8 89.359375x115.40625]
+            PaintableBox (Box<TR>) [8,8 89.359375x38.46875]
+              PaintableWithLines (BlockContainer<TD>) [8,8 29.453125x38.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [37.453125,8 29.8125x38.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [67.265625,8 30.09375x38.46875]
+                TextPaintable (TextNode<#text>)
+            PaintableBox (Box<TR>) [8,46.46875 89.359375x38.46875] overflow: [8,46.46875 89.359375x76.9375]
+              PaintableWithLines (BlockContainer<TD>) [8,46.46875 29.453125x38.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [37.453125,46.46875 59.90625x76.9375]
+                TextPaintable (TextNode<#text>)
+            PaintableBox (Box<TR>) [8,84.9375 89.359375x38.46875]
+              PaintableWithLines (BlockContainer<TD>) [8,84.9375 29.453125x38.46875]
+                TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/colspan-percentage-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/colspan-percentage-width.txt
@@ -51,3 +51,22 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x44.9375]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 420x44.9375]
+        PaintableBox (Box<TABLE>) [8,8 420x44.9375]
+          PaintableBox (Box<TBODY>) [9,9 418x42.9375]
+            PaintableBox (Box<TR>) [9,9 418x21.46875]
+              PaintableWithLines (BlockContainer<TD>) [9,9 83.6875x21.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [92.6875,9 161.3125x21.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [254,9 173x21.46875]
+                TextPaintable (TextNode<#text>)
+            PaintableBox (Box<TR>) [9,30.46875 418x21.46875]
+              PaintableWithLines (BlockContainer<TD>) [9,30.46875 83.6875x21.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [92.6875,30.46875 334.3125x21.46875]
+                TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/colspan-weighted-width-distribution.txt
+++ b/Tests/LibWeb/Layout/expected/table/colspan-weighted-width-distribution.txt
@@ -37,3 +37,18 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x44.9375]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 210x44.9375]
+        PaintableBox (Box<TABLE>) [8,8 210x44.9375]
+          PaintableBox (Box<TBODY>) [9,9 208x42.9375]
+            PaintableBox (Box<TR>) [9,9 208x21.46875]
+              PaintableWithLines (BlockContainer<TD>) [9,9 184x21.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [193,9 24x21.46875]
+                TextPaintable (TextNode<#text>)
+            PaintableBox (Box<TR>) [9,30.46875 208x21.46875]
+              PaintableWithLines (BlockContainer<TD>) [9,30.46875 208x21.46875]
+                TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/colspan-width-distribution.txt
+++ b/Tests/LibWeb/Layout/expected/table/colspan-width-distribution.txt
@@ -43,3 +43,21 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               TextNode <#text>
       BlockContainer <(anonymous)> at (8,52.9375) content-size 784x0 children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x60.9375]
+    PaintableWithLines (BlockContainer(anonymous)) [0,0 800x0]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x44.9375]
+      PaintableWithLines (BlockContainer(anonymous)) [8,8 784x0]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 39.296875x44.9375]
+        PaintableBox (Box<TABLE>) [8,8 39.296875x44.9375]
+          PaintableBox (Box<TBODY>) [9,9 37.296875x42.9375]
+            PaintableBox (Box<TR>) [9,9 37.296875x21.46875]
+              PaintableWithLines (BlockContainer<TD>) [9,9 21.546875x21.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [30.546875,9 15.75x21.46875]
+                TextPaintable (TextNode<#text>)
+            PaintableBox (Box<TR>) [9,30.46875 37.296875x21.46875]
+              PaintableWithLines (BlockContainer<TD>) [9,30.46875 37.296875x21.46875]
+                TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,52.9375 784x0]

--- a/Tests/LibWeb/Layout/expected/table/columns-width-distribution-1.txt
+++ b/Tests/LibWeb/Layout/expected/table/columns-width-distribution-1.txt
@@ -29,3 +29,15 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                   frag 0 from TextNode start: 424, length: 7, rect: [66,99.34375 47.21875x17.46875]
                     "client."
                 TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x112.8125] overflow: [8,8 786x112.8125]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 784x112.8125] overflow: [8,8 786x112.8125]
+        PaintableBox (Box<TABLE>.ambox) [8,8 786x112.8125]
+          PaintableBox (Box<TBODY>) [9,9 778x106.8125] overflow: [9,9 782x108.8125]
+            PaintableBox (Box<TR>) [11,11 778x106.8125] overflow: [11,11 780x106.8125]
+              PaintableWithLines (BlockContainer<TD>.mbox-image) [11,11 52x106.8125]
+                PaintableWithLines (BlockContainer<DIV>.mbox-image-div) [12,39.40625 50x50]
+              PaintableWithLines (BlockContainer<TD>.mbox-text) [65,11 726x106.8125]
+                TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/fixed-margins.txt
+++ b/Tests/LibWeb/Layout/expected/table/fixed-margins.txt
@@ -13,3 +13,13 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                   frag 0 from TextNode start: 59, length: 40, rect: [108,25.46875 399.9375x17.46875]
                     "To AdJuSt PRiCiNG sTYLiNG ceLL oF TAbLeS"
                 TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x34.9375]
+      PaintableWithLines (BlockContainer<DIV>.wrapper) [8,8 784x34.9375]
+        PaintableWithLines (TableWrapper(anonymous)) [108,8 584x34.9375]
+          PaintableBox (Box<DIV>.box) [108,8 584x34.9375]
+            PaintableBox (Box(anonymous)) [108,8 584x34.9375]
+              PaintableWithLines (BlockContainer<DIV>.cell) [108,8 584x34.9375]
+                TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/in-auto-height-flex-item.txt
+++ b/Tests/LibWeb/Layout/expected/table/in-auto-height-flex-item.txt
@@ -10,3 +10,13 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                   frag 0 from TextNode start: 0, length: 5, rect: [12,12 39.78125x17.46875]
                     "Hello"
                 TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x41.46875]
+    PaintableBox (Box<BODY>) [9,9 782x23.46875]
+      PaintableWithLines (BlockContainer<DIV>.upper) [10,10 43.78125x21.46875]
+        PaintableWithLines (TableWrapper(anonymous)) [11,11 41.78125x19.46875]
+          PaintableBox (Box(anonymous)) [11,11 41.78125x19.46875]
+            PaintableBox (Box(anonymous)) [11,11 41.78125x19.46875]
+              PaintableWithLines (BlockContainer<DIV>.cell) [11,11 41.78125x19.46875]
+                TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/inline-table-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/inline-table-width.txt
@@ -29,3 +29,21 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                     frag 0 from TextNode start: 0, length: 5, rect: [103.90625,33.46875 38.078125x17.46875]
                       "false"
                   TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x46.9375]
+      PaintableWithLines (BlockContainer<TABLE>) [8,8 137.984375x46.9375]
+        PaintableWithLines (TableWrapper(anonymous)) [9,9 135.984375x44.9375]
+          PaintableBox (Box(anonymous)) [9,9 135.984375x44.9375]
+            PaintableBox (Box<TBODY>) [9,9 129.984375x38.9375] overflow: [9,9 133.984375x42.9375]
+              PaintableBox (Box<TR>) [11,11 129.984375x19.46875] overflow: [11,11 131.984375x19.46875]
+                PaintableWithLines (BlockContainer<TD>) [11,11 89.90625x19.46875]
+                  TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer<TD>) [102.90625,11 40.078125x19.46875]
+                  TextPaintable (TextNode<#text>)
+              PaintableBox (Box<TR>) [11,32.46875 129.984375x19.46875] overflow: [11,32.46875 131.984375x19.46875]
+                PaintableWithLines (BlockContainer<TD>) [11,32.46875 89.90625x19.46875]
+                  TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer<TD>) [102.90625,32.46875 40.078125x19.46875]
+                  TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/long-caption-increases-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/long-caption-increases-width.txt
@@ -91,3 +91,31 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             TextNode <#text>
       BlockContainer <(anonymous)> at (8,119.34375) content-size 784x0 children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x127.34375]
+    PaintableWithLines (BlockContainer(anonymous)) [0,0 800x0]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x111.34375]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 63.046875x111.34375]
+        PaintableBox (Box<TABLE>#full-table) [8,40.9375 63.046875x76.40625] overflow: [8,8 61.046875x107.34375]
+          PaintableWithLines (BlockContainer<CAPTION>) [8,8 59.046875x34.9375]
+            TextPaintable (TextNode<#text>)
+          PaintableBox (Box<THEAD>) [10,10 53.03125x21.46875] overflow: [10,10 57.03125x56.40625]
+            PaintableBox (Box<TR>) [12,44.9375 53.03125x21.46875] overflow: [12,44.9375 55.03125x21.46875]
+              PaintableWithLines (BlockContainer<TD>) [12,44.9375 25.25x21.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [39.25,44.9375 27.78125x21.46875]
+                TextPaintable (TextNode<#text>)
+          PaintableBox (Box<TBODY>) [10,31.46875 53.03125x21.46875] overflow: [10,31.46875 57.03125x58.40625]
+            PaintableBox (Box<TR>) [12,68.40625 53.03125x21.46875] overflow: [12,68.40625 55.03125x21.46875]
+              PaintableWithLines (BlockContainer<TD>) [12,68.40625 25.25x21.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [39.25,68.40625 27.78125x21.46875]
+                TextPaintable (TextNode<#text>)
+          PaintableBox (Box<TFOOT>) [10,52.9375 53.03125x21.46875] overflow: [10,52.9375 57.03125x60.40625]
+            PaintableBox (Box<TR>) [12,91.875 53.03125x21.46875] overflow: [12,91.875 55.03125x21.46875]
+              PaintableWithLines (BlockContainer<TD>) [12,91.875 25.25x21.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [39.25,91.875 27.78125x21.46875]
+                TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,119.34375 784x0]

--- a/Tests/LibWeb/Layout/expected/table/multi-line-cell.txt
+++ b/Tests/LibWeb/Layout/expected/table/multi-line-cell.txt
@@ -27,3 +27,17 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               TextNode <#text>
       BlockContainer <(anonymous)> at (8,93.875) content-size 784x0 children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x85.875]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 81.4375x85.875]
+        PaintableBox (Box<TABLE>) [8,8 81.4375x85.875]
+          PaintableBox (Box<TBODY>) [9,9 75.4375x77.859375] overflow: [9,9 77.4375x81.859375]
+            PaintableBox (Box<TR>) [11,11 75.4375x21.453125] overflow: [11,11 75.4375x21.46875]
+              PaintableWithLines (BlockContainer<TD>) [11,11 75.4375x21.46875]
+                TextPaintable (TextNode<#text>)
+            PaintableBox (Box<TR>) [11,34.453125 75.4375x56.40625]
+              PaintableWithLines (BlockContainer<TD>) [11,34.453125 75.4375x56.40625]
+                TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,93.875 784x0]

--- a/Tests/LibWeb/Layout/expected/table/nested-table-box-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/nested-table-box-width.txt
@@ -80,3 +80,31 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             TextNode <#text>
       BlockContainer <(anonymous)> at (8,132.9375) content-size 784x0 children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x140.9375]
+    PaintableWithLines (BlockContainer(anonymous)) [0,0 800x0]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x124.9375]
+      PaintableWithLines (BlockContainer(anonymous)) [8,8 784x0]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 115.828125x124.9375]
+        PaintableBox (Box<TABLE>) [8,8 115.828125x124.9375]
+          PaintableBox (Box<TBODY>) [13,13 99.828125x108.9375] overflow: [13,13 103.828125x112.9375]
+            PaintableBox (Box<TR>) [15,15 99.828125x54.46875] overflow: [15,15 101.828125x110.9375]
+              PaintableWithLines (BlockContainer<TD>) [15,15 31.5625x54.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [48.5625,15 68.265625x110.9375]
+                PaintableWithLines (BlockContainer(anonymous)) [58.5625,25 48.265625x0]
+                PaintableWithLines (TableWrapper(anonymous)) [58.5625,25 48.265625x90.9375]
+                  PaintableBox (Box<TABLE>) [58.5625,25 48.265625x90.9375]
+                    PaintableBox (Box<TBODY>) [63.5625,30 34.265625x74.9375] overflow: [63.5625,30 36.265625x78.9375]
+                      PaintableBox (Box<TR>) [65.5625,32 34.265625x37.46875]
+                        PaintableWithLines (BlockContainer<TD>) [65.5625,32 34.265625x37.46875]
+                          TextPaintable (TextNode<#text>)
+                      PaintableBox (Box<TR>) [65.5625,71.46875 34.265625x37.46875]
+                        PaintableWithLines (BlockContainer<TD>) [65.5625,71.46875 34.265625x37.46875]
+                          TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [58.5625,115.9375 48.265625x0]
+            PaintableBox (Box<TR>) [15,71.46875 99.828125x54.46875]
+              PaintableWithLines (BlockContainer<TD>) [15,71.46875 31.5625x54.46875]
+                TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,132.9375 784x0]

--- a/Tests/LibWeb/Layout/expected/table/percentage-width-columns.txt
+++ b/Tests/LibWeb/Layout/expected/table/percentage-width-columns.txt
@@ -36,3 +36,17 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               TextNode <#text>
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x22.46875]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 88.328125x22.46875]
+        PaintableBox (Box<TABLE>) [8,8 88.328125x22.46875]
+          PaintableBox (Box<TBODY>) [9,9 86.328125x20.46875]
+            PaintableBox (Box<TR>) [9,9 86.328125x20.46875]
+              PaintableWithLines (BlockContainer<TD>) [9,9 17.265625x20.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [26.265625,9 51.796875x20.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [78.0625,9 17.265625x20.46875]
+                TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/propagate-style-update-to-wrapper.txt
+++ b/Tests/LibWeb/Layout/expected/table/propagate-style-update-to-wrapper.txt
@@ -14,3 +14,12 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x0] overflow: [8,8 6x6]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 6x6]
+        PaintableBox (Box<TABLE>#t) [8,8 6x6]
+          PaintableBox (Box<TBODY>) [8,8 2x2] overflow: [8,8 4x4]
+            PaintableBox (Box<TR>) [10,10 2x2]
+              PaintableWithLines (BlockContainer<TD>) [10,10 2x2]

--- a/Tests/LibWeb/Layout/expected/table/row-outer-size-with-computed-size.txt
+++ b/Tests/LibWeb/Layout/expected/table/row-outer-size-with-computed-size.txt
@@ -32,3 +32,17 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x25.46875]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 49.21875x25.46875]
+        PaintableBox (Box<TABLE>) [8,8 49.21875x25.46875]
+          PaintableBox (Box<TBODY>) [8,8 43.21875x19.46875] overflow: [8,8 47.21875x23.46875]
+            PaintableBox (Box<TR>) [10,10 43.21875x9.734375] overflow: [10,10 45.21875x21.46875]
+              PaintableWithLines (BlockContainer<TD>) [10,10 2x9.71875]
+              PaintableWithLines (BlockContainer<TD>) [14,10 41.21875x21.46875]
+                InlinePaintable (InlineNode<A>)
+                  TextPaintable (TextNode<#text>)
+            PaintableBox (Box<TR>) [10,21.734375 43.21875x9.734375]
+              PaintableWithLines (BlockContainer<TD>) [10,21.734375 2x9.71875]

--- a/Tests/LibWeb/Layout/expected/table/row-px-height.txt
+++ b/Tests/LibWeb/Layout/expected/table/row-px-height.txt
@@ -4,3 +4,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       Box <body> at (8,8) content-size 102x100 table-box [TFC] children: not-inline
         Box <div.row> at (8,8) content-size 102x100 table-row children: not-inline
           BlockContainer <div.cell> at (9,9) content-size 100x0 table-cell [BFC] children: not-inline
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (TableWrapper(anonymous)) [8,8 102x100]
+      PaintableBox (Box<BODY>) [8,8 102x100]
+        PaintableBox (Box<DIV>.row) [8,8 102x100]
+          PaintableWithLines (BlockContainer<DIV>.cell) [8,8 102x100]

--- a/Tests/LibWeb/Layout/expected/table/row-span-and-nested-tables.txt
+++ b/Tests/LibWeb/Layout/expected/table/row-span-and-nested-tables.txt
@@ -92,3 +92,34 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             TextNode <#text>
       BlockContainer <(anonymous)> at (8,124.40625) content-size 784x0 children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x132.40625]
+    PaintableWithLines (BlockContainer(anonymous)) [0,0 800x0]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x116.40625]
+      PaintableWithLines (BlockContainer(anonymous)) [8,8 784x0]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 75.828125x116.40625]
+        PaintableBox (Box<TABLE>) [8,8 75.828125x116.40625]
+          PaintableBox (Box<TBODY>) [9,9 67.828125x108.40625] overflow: [9,9 71.828125x112.40625]
+            PaintableBox (Box<TR>) [11,11 67.828125x54.203125] overflow: [11,11 69.828125x110.40625]
+              PaintableWithLines (BlockContainer<TD>) [11,11 23.5625x54.1875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [36.5625,11 44.265625x110.40625]
+                PaintableWithLines (BlockContainer(anonymous)) [42.5625,17 32.265625x0]
+                PaintableWithLines (TableWrapper(anonymous)) [42.5625,17 32.265625x98.40625]
+                  PaintableBox (Box<TABLE>) [42.5625,17 32.265625x98.40625]
+                    PaintableBox (Box<TBODY>) [43.5625,18 26.265625x88.40625] overflow: [43.5625,18 28.265625x94.40625]
+                      PaintableBox (Box<TR>) [45.5625,20 26.265625x29.46875]
+                        PaintableWithLines (BlockContainer<TD>) [45.5625,20 26.265625x29.46875]
+                          TextPaintable (TextNode<#text>)
+                      PaintableBox (Box<TR>) [45.5625,51.46875 26.265625x29.46875]
+                        PaintableWithLines (BlockContainer<TD>) [45.5625,51.46875 26.265625x29.46875]
+                          TextPaintable (TextNode<#text>)
+                      PaintableBox (Box<TR>) [45.5625,82.9375 26.265625x29.46875]
+                        PaintableWithLines (BlockContainer<TD>) [45.5625,82.9375 26.265625x29.46875]
+                          TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [42.5625,115.40625 32.265625x0]
+            PaintableBox (Box<TR>) [11,67.203125 67.828125x54.203125]
+              PaintableWithLines (BlockContainer<TD>) [11,67.203125 23.5625x54.1875]
+                TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,124.40625 784x0]

--- a/Tests/LibWeb/Layout/expected/table/rows-height-distribution-1.txt
+++ b/Tests/LibWeb/Layout/expected/table/rows-height-distribution-1.txt
@@ -7,3 +7,13 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             BlockContainer <div.cell> at (8,8) content-size 200x0 table-cell [BFC] children: not-inline
           Box <div.row.b> at (8,58) content-size 200x100 table-row children: not-inline
             BlockContainer <div.cell> at (8,58) content-size 200x0 table-cell [BFC] children: not-inline
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x150]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 200x150]
+        PaintableBox (Box<DIV>.table) [8,8 200x150]
+          PaintableBox (Box<DIV>.row.a) [8,8 200x50]
+            PaintableWithLines (BlockContainer<DIV>.cell) [8,8 200x50]
+          PaintableBox (Box<DIV>.row.b) [8,58 200x100]
+            PaintableWithLines (BlockContainer<DIV>.cell) [8,58 200x100]

--- a/Tests/LibWeb/Layout/expected/table/rows-height-distribution-2.txt
+++ b/Tests/LibWeb/Layout/expected/table/rows-height-distribution-2.txt
@@ -7,3 +7,13 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             BlockContainer <div.cell> at (8,8) content-size 200x0 table-cell [BFC] children: not-inline
           Box <div.row.b> at (8,158) content-size 200x150 table-row children: not-inline
             BlockContainer <div.cell> at (8,158) content-size 200x0 table-cell [BFC] children: not-inline
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x300]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 200x300]
+        PaintableBox (Box<DIV>.table) [8,8 200x300]
+          PaintableBox (Box<DIV>.row.a) [8,8 200x150]
+            PaintableWithLines (BlockContainer<DIV>.cell) [8,8 200x150]
+          PaintableBox (Box<DIV>.row.b) [8,158 200x150]
+            PaintableWithLines (BlockContainer<DIV>.cell) [8,158 200x150]

--- a/Tests/LibWeb/Layout/expected/table/rows-height-distribution-3.txt
+++ b/Tests/LibWeb/Layout/expected/table/rows-height-distribution-3.txt
@@ -15,3 +15,15 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 frag 0 from TextNode start: 0, length: 1, rect: [8,158 9.46875x17.46875]
                   "b"
               TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x300]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 200x300]
+        PaintableBox (Box<DIV>.table) [8,8 200x300]
+          PaintableBox (Box<DIV>.row.a) [8,8 200x150]
+            PaintableWithLines (BlockContainer<DIV>.cell) [8,8 200x150]
+              TextPaintable (TextNode<#text>)
+          PaintableBox (Box<DIV>.row.b) [8,158 200x150]
+            PaintableWithLines (BlockContainer<DIV>.cell) [8,158 200x150]
+              TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/rows-height-distribution-4.txt
+++ b/Tests/LibWeb/Layout/expected/table/rows-height-distribution-4.txt
@@ -15,3 +15,15 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 frag 0 from TextNode start: 0, length: 1, rect: [8,108 9.46875x17.46875]
                   "b"
               TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x300]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 200x300]
+        PaintableBox (Box<DIV>.table) [8,8 200x300]
+          PaintableBox (Box<DIV>.row.a) [8,8 200x100]
+            PaintableWithLines (BlockContainer<DIV>.cell) [8,8 200x100]
+              TextPaintable (TextNode<#text>)
+          PaintableBox (Box<DIV>.row.b) [8,108 200x200]
+            PaintableWithLines (BlockContainer<DIV>.cell) [8,108 200x200]
+              TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/rowspan.txt
+++ b/Tests/LibWeb/Layout/expected/table/rowspan.txt
@@ -109,3 +109,39 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               TextNode <#text>
       BlockContainer <(anonymous)> at (8,95.875) content-size 784x0 children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x103.875]
+    PaintableWithLines (BlockContainer(anonymous)) [0,0 800x0]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x87.875]
+      PaintableWithLines (BlockContainer(anonymous)) [8,8 784x0]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 229.359375x87.875]
+        PaintableBox (Box<TABLE>) [8,8 229.359375x87.875]
+          PaintableBox (Box<TBODY>) [8,8 221.359375x77.875] overflow: [8,8 227.359375x85.875]
+            PaintableBox (Box<TR>) [10,10 221.359375x19.46875] overflow: [10,10 225.359375x19.46875]
+              PaintableWithLines (BlockContainer<TH>) [10,10 72.046875x19.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TH>) [84.046875,10 74.515625x19.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TH>) [160.5625,10 74.796875x19.46875]
+                TextPaintable (TextNode<#text>)
+            PaintableBox (Box<TR>) [10,31.46875 221.359375x19.46875] overflow: [10,31.46875 225.359375x40.9375]
+              PaintableWithLines (BlockContainer<TD>) [10,31.46875 72.046875x40.9375]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [84.046875,31.46875 74.515625x19.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [160.5625,31.46875 74.796875x19.46875]
+                TextPaintable (TextNode<#text>)
+            PaintableBox (Box<TR>) [10,52.9375 221.359375x19.46875] overflow: [10,52.9375 225.359375x19.46875]
+              PaintableWithLines (BlockContainer<TD>) [84.046875,52.9375 74.515625x19.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [160.5625,52.9375 74.796875x19.46875]
+                TextPaintable (TextNode<#text>)
+            PaintableBox (Box<TR>) [10,74.40625 221.359375x19.46875] overflow: [10,74.40625 225.359375x19.46875]
+              PaintableWithLines (BlockContainer<TD>) [10,74.40625 72.046875x19.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [84.046875,74.40625 74.515625x19.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [160.5625,74.40625 74.796875x19.46875]
+                TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,95.875 784x0]

--- a/Tests/LibWeb/Layout/expected/table/size.txt
+++ b/Tests/LibWeb/Layout/expected/table/size.txt
@@ -14,3 +14,15 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 TextNode <#text>
               BlockContainer <(anonymous)> at (350,25.46875) content-size 2000x0 children: inline
                 TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600] overflow: [0,0 2350x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600] overflow: [0,0 2350x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x17.46875] overflow: [8,8 2342x17.46875]
+      PaintableWithLines (TableWrapper(anonymous)) [350,8 100x17.46875] overflow: [350,8 2000x17.46875]
+        PaintableBox (Box<DIV>) [350,8 100x17.46875] overflow: [350,8 2000x17.46875]
+          PaintableBox (Box(anonymous)) [350,8 2000x17.46875]
+            PaintableWithLines (BlockContainer(anonymous)) [350,8 2000x17.46875]
+              PaintableWithLines (BlockContainer(anonymous)) [350,8 2000x0]
+              PaintableWithLines (BlockContainer<DIV>) [350,8 2000x17.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer(anonymous)) [350,25.46875 2000x0]

--- a/Tests/LibWeb/Layout/expected/table/stretch-to-fixed-height.txt
+++ b/Tests/LibWeb/Layout/expected/table/stretch-to-fixed-height.txt
@@ -9,3 +9,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (21,31) content-size 0x0 table-row children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x100]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 24x100]
+        PaintableBox (Box<TABLE>) [8,8 24x100]
+          PaintableBox (Box<TBODY>) [19,19 0x0] overflow: [21,31 0x0]
+            PaintableBox (Box<TR>) [21,31 0x0]

--- a/Tests/LibWeb/Layout/expected/table/sum-of-percentage-column-widths-less-than-100.txt
+++ b/Tests/LibWeb/Layout/expected/table/sum-of-percentage-column-widths-less-than-100.txt
@@ -32,3 +32,17 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x27.46875]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 93.328125x27.46875]
+        PaintableBox (Box<TABLE>) [8,8 93.328125x27.46875]
+          PaintableBox (Box<TBODY>) [9,9 83.3125x21.46875] overflow: [9,9 89.3125x23.46875]
+            PaintableBox (Box<TR>) [11,11 83.3125x21.46875] overflow: [11,11 87.3125x21.46875]
+              PaintableWithLines (BlockContainer<TD>) [11,11 22.03125x21.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [35.03125,11 40.859375x21.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [77.890625,11 20.421875x21.46875]
+                TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/table-formation-with-rowspan-in-the-middle.txt
+++ b/Tests/LibWeb/Layout/expected/table/table-formation-with-rowspan-in-the-middle.txt
@@ -84,3 +84,31 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               TextNode <#text>
       BlockContainer <(anonymous)> at (8,163.875) content-size 784x0 children: inline
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x155.875]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 100.421875x155.875]
+        PaintableBox (Box<TABLE>) [8,8 100.421875x155.875]
+          PaintableBox (Box<TBODY>) [9,9 98.421875x153.875]
+            PaintableBox (Box<TR>) [9,9 98.421875x38.46875] overflow: [9,9 98.421875x115.40625]
+              PaintableWithLines (BlockContainer<TD>) [9,9 30.59375x38.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [39.59375,9 35.265625x76.9375]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [74.859375,9 32.5625x115.40625]
+                TextPaintable (TextNode<#text>)
+            PaintableBox (Box<TR>) [9,47.46875 98.421875x38.46875]
+              PaintableWithLines (BlockContainer<TD>) [9,47.46875 30.59375x38.46875]
+                TextPaintable (TextNode<#text>)
+            PaintableBox (Box<TR>) [9,85.9375 98.421875x38.46875] overflow: [9,85.9375 98.421875x76.9375]
+              PaintableWithLines (BlockContainer<TD>) [9,85.9375 30.59375x38.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [39.59375,85.9375 35.265625x76.9375]
+                TextPaintable (TextNode<#text>)
+            PaintableBox (Box<TR>) [9,124.40625 98.421875x38.46875]
+              PaintableWithLines (BlockContainer<TD>) [9,124.40625 30.59375x38.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [74.859375,124.40625 32.5625x38.46875]
+                TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,163.875 784x0]

--- a/Tests/LibWeb/Layout/expected/table/table-header-and-footer-groups.txt
+++ b/Tests/LibWeb/Layout/expected/table/table-header-and-footer-groups.txt
@@ -16,3 +16,16 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 frag 0 from TextNode start: 0, length: 3, rect: [10,10 26.640625x0]
                   "top"
               TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x218]
+    PaintableWithLines (TableWrapper(anonymous)) [9,9 300x200]
+      PaintableBox (Box<BODY>.table) [9,9 300x200]
+        PaintableBox (Box<DIV>.bottom) [10,10 298x0]
+          PaintableBox (Box(anonymous)) [10,10 298x0]
+            PaintableWithLines (BlockContainer(anonymous)) [10,10 298x0]
+              TextPaintable (TextNode<#text>)
+        PaintableBox (Box<DIV>.top) [10,10 298x0]
+          PaintableBox (Box(anonymous)) [10,10 298x0]
+            PaintableWithLines (BlockContainer(anonymous)) [10,10 298x0]
+              TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/table-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/table-width.txt
@@ -6,3 +6,12 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           Box <tbody> at (108,108) content-size 580x10 table-row-group children: not-inline
             Box <tr> at (110,110) content-size 580x10 table-row children: not-inline
               BlockContainer <td.cell> at (111,115) content-size 578x0 table-cell [BFC] children: not-inline
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x214]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 784x214]
+        PaintableBox (Box<TABLE>.table) [8,8 784x214]
+          PaintableBox (Box<TBODY>) [108,108 580x10] overflow: [108,108 582x12]
+            PaintableBox (Box<TR>) [110,110 580x10]
+              PaintableWithLines (BlockContainer<TD>.cell) [110,110 580x10]

--- a/Tests/LibWeb/Layout/expected/table/td-valign.txt
+++ b/Tests/LibWeb/Layout/expected/table/td-valign.txt
@@ -22,3 +22,17 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x220]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x204]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 144.1875x204]
+        PaintableBox (Box<TABLE>) [8,8 144.1875x204]
+          PaintableBox (Box<TBODY>) [9,9 134.1875x198] overflow: [9,9 140.1875x200]
+            PaintableBox (Box<TR>) [11,11 134.1875x198] overflow: [11,11 138.1875x198]
+              PaintableWithLines (BlockContainer<TD>) [11,11 28.640625x198]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [41.640625,11 47.4375x198]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [91.078125,11 58.109375x198]
+                TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/top-caption-with-padding.txt
+++ b/Tests/LibWeb/Layout/expected/table/top-caption-with-padding.txt
@@ -25,3 +25,15 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600] overflow: [0,-2 800x602]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600] overflow: [0,-2 800x602]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x60.9375] overflow: [8,-2 784x70.9375]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 60.46875x60.9375] overflow: [8,-2 60.46875x70.9375]
+        PaintableBox (Box<TABLE>) [8,35.46875 60.46875x23.46875] overflow: [8,-2 60.46875x60.9375]
+          PaintableWithLines (BlockContainer<CAPTION>) [8,-2 60.46875x37.46875]
+            TextPaintable (TextNode<#text>)
+          PaintableBox (Box<TBODY>) [8,8 56.46875x19.46875] overflow: [8,8 58.46875x48.9375]
+            PaintableBox (Box<TR>) [10,37.46875 56.46875x19.46875]
+              PaintableWithLines (BlockContainer<TD>) [10,37.46875 56.46875x19.46875]
+                TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/width-distribution-and-constrained-columns-increased-size-on-col.txt
+++ b/Tests/LibWeb/Layout/expected/table/width-distribution-and-constrained-columns-increased-size-on-col.txt
@@ -30,3 +30,15 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x27.46875]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 420x27.46875]
+        PaintableBox (Box<TABLE>) [8,8 420x27.46875]
+          PaintableBox (Box<TBODY>) [9,9 412x21.46875] overflow: [9,9 416x23.46875]
+            PaintableBox (Box<TR>) [11,11 412x21.46875] overflow: [11,11 414x21.46875]
+              PaintableWithLines (BlockContainer<TD>) [11,11 50x21.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [63,11 362x21.46875]
+                TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/width-distribution-and-constrained-columns-size-on-col.txt
+++ b/Tests/LibWeb/Layout/expected/table/width-distribution-and-constrained-columns-size-on-col.txt
@@ -30,3 +30,15 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x27.46875]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 420x27.46875]
+        PaintableBox (Box<TABLE>) [8,8 420x27.46875]
+          PaintableBox (Box<TBODY>) [9,9 412x21.46875] overflow: [9,9 416x23.46875]
+            PaintableBox (Box<TR>) [11,11 412x21.46875] overflow: [11,11 414x21.46875]
+              PaintableWithLines (BlockContainer<TD>) [11,11 18.265625x21.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [31.265625,11 393.734375x21.46875]
+                TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/width-distribution-and-constrained-columns.txt
+++ b/Tests/LibWeb/Layout/expected/table/width-distribution-and-constrained-columns.txt
@@ -25,3 +25,15 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x27.46875]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 420x27.46875]
+        PaintableBox (Box<TABLE>) [8,8 420x27.46875]
+          PaintableBox (Box<TBODY>) [9,9 412x21.46875] overflow: [9,9 416x23.46875]
+            PaintableBox (Box<TR>) [11,11 412x21.46875] overflow: [11,11 414x21.46875]
+              PaintableWithLines (BlockContainer<TD>) [11,11 18.265625x21.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [31.265625,11 393.734375x21.46875]
+                TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/width-distribution-of-max-width-increment.txt
+++ b/Tests/LibWeb/Layout/expected/table/width-distribution-of-max-width-increment.txt
@@ -36,3 +36,17 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               TextNode <#text>
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x20.46875]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 784x20.46875]
+        PaintableBox (Box<TABLE>) [8,8 784x20.46875]
+          PaintableBox (Box<TBODY>) [8,8 783.96875x20.46875]
+            PaintableBox (Box<TR>) [8,8 783.96875x20.46875]
+              PaintableWithLines (BlockContainer<TD>) [8,8 218.09375x20.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [226.09375,8 155.921875x20.46875]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [382.015625,8 409.953125x20.46875]
+                TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/zero-columns-gridmax.txt
+++ b/Tests/LibWeb/Layout/expected/table/zero-columns-gridmax.txt
@@ -5,3 +5,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         Box <div.table> at (8,8) content-size 200x0 table-box [TFC] children: not-inline
           Box <div.row> at (8,8) content-size 200x0 table-row children: not-inline
             BlockContainer <div.cell> at (8,8) content-size 200x0 table-cell [BFC] children: not-inline
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x0]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 200x0]
+        PaintableBox (Box<DIV>.table) [8,8 200x0]
+          PaintableBox (Box<DIV>.row) [8,8 200x0]
+            PaintableWithLines (BlockContainer<DIV>.cell) [8,8 200x0]

--- a/Tests/LibWeb/Layout/expected/text-align-justify-with-forced-break.txt
+++ b/Tests/LibWeb/Layout/expected/text-align-justify-with-forced-break.txt
@@ -73,3 +73,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
         BreakNode <br>
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x118]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x102] overflow: [8,8 784x105.8125]
+      PaintableWithLines (BlockContainer<DIV>) [8,8 102x102] overflow: [9,9 100x104.8125]
+        TextPaintable (TextNode<#text>)
+        TextPaintable (TextNode<#text>)
+        TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/text-align-overflow.txt
+++ b/Tests/LibWeb/Layout/expected/text-align-overflow.txt
@@ -7,3 +7,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             frag 0 from TextNode start: 0, length: 22, rect: [18,8 189.875x17.46875]
               "My super long message!"
           TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x33.46875]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x17.46875]
+      PaintableWithLines (BlockContainer<DIV>.outer) [18,8 80x17.46875]
+        PaintableWithLines (BlockContainer<SPAN>.text) [18,8 80x17.46875] overflow: [18,8 189.875x17.46875]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/text-indent.txt
+++ b/Tests/LibWeb/Layout/expected/text-indent.txt
@@ -26,3 +26,14 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           frag 0 from TextNode start: 26, length: 4, rect: [11,134.34375 37.765625x17.46875]
             "snab"
         TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x162.8125]
+    PaintableWithLines (BlockContainer<BODY>) [9,9 782x144.8125]
+      PaintableWithLines (BlockContainer<DIV>.px-indent) [10,10 780x70.9375]
+        PaintableWithLines (BlockContainer(anonymous)) [11,11 778x17.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<P>) [11,44.46875 778x19.46875]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer<DIV>.pct-indent) [10,80.9375 102x71.875]
+        TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/tolerate-css-percentage-overshoot.txt
+++ b/Tests/LibWeb/Layout/expected/tolerate-css-percentage-overshoot.txt
@@ -4,3 +4,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <div.larg.red> at (8,8) content-size 208.328125x100 floating [BFC] children: not-inline
       BlockContainer <div.larg.green> at (216.328125,8) content-size 208.328125x100 floating [BFC] children: not-inline
       BlockContainer <div.smol.blue> at (424.65625,8) content-size 83.328125x100 floating [BFC] children: not-inline
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 500x0] overflow: [8,8 499.984375x100]
+      PaintableWithLines (BlockContainer<DIV>.larg.red) [8,8 208.328125x100]
+      PaintableWithLines (BlockContainer<DIV>.larg.green) [216.328125,8 208.328125x100]
+      PaintableWithLines (BlockContainer<DIV>.smol.blue) [424.65625,8 83.328125x100]

--- a/Tests/LibWeb/Layout/expected/transform-calc-length-values.txt
+++ b/Tests/LibWeb/Layout/expected/transform-calc-length-values.txt
@@ -1,3 +1,7 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (9,9) content-size 100x100 children: not-inline
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 102x102]

--- a/Tests/LibWeb/Layout/expected/vertical-padding-relative-to-cb-width.txt
+++ b/Tests/LibWeb/Layout/expected/vertical-padding-relative-to-cb-width.txt
@@ -16,3 +16,14 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             frag 0 from TextNode start: 1, length: 3, rect: [11,211 27.640625x17.46875]
               "bar"
           TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x602]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x602]
+    PaintableWithLines (BlockContainer<BODY>) [9,9 782x14] overflow: [10,10 780x218.46875]
+      PaintableWithLines (BlockContainer(anonymous)) [10,10 780x0]
+      PaintableWithLines (BlockContainer<DIV>.cb) [10,10 602x12] overflow: [11,11 600x217.46875]
+        PaintableWithLines (BlockContainer(anonymous)) [11,11 600x0]
+        PaintableWithLines (BlockContainer<DIV>.foo) [11,11 600x200]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer(anonymous)) [11,211 600x17.46875]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/viewport-overflow-propagation-1.txt
+++ b/Tests/LibWeb/Layout/expected/viewport-overflow-propagation-1.txt
@@ -1,0 +1,10 @@
+Viewport <#document> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x2016 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x2000 children: not-inline
+      BlockContainer <div> at (8,8) content-size 100x2000 children: inline
+        TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x2016]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x2016]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x2000]
+      PaintableWithLines (BlockContainer<DIV>) [8,8 100x2000]

--- a/Tests/LibWeb/Layout/expected/viewport-overflow-propagation-2.txt
+++ b/Tests/LibWeb/Layout/expected/viewport-overflow-propagation-2.txt
@@ -1,0 +1,10 @@
+Viewport <#document> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x616 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x600 children: not-inline
+      BlockContainer <div.long> at (8,8) content-size 784x2000 children: inline
+        TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x2008]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x616] overflow: [0,0 800x2008]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x600] overflow: [8,8 784x2000]
+      PaintableWithLines (BlockContainer<DIV>.long) [8,8 784x2000]

--- a/Tests/LibWeb/Layout/input/viewport-overflow-propagation-1.html
+++ b/Tests/LibWeb/Layout/input/viewport-overflow-propagation-1.html
@@ -1,0 +1,12 @@
+<!doctype html><style>
+html {
+    overflow: visible;
+}
+body {
+    overflow: scroll;
+}
+div {
+    width: 100px;
+    height: 2000px;
+}
+</style><body><div>

--- a/Tests/LibWeb/Layout/input/viewport-overflow-propagation-2.html
+++ b/Tests/LibWeb/Layout/input/viewport-overflow-propagation-2.html
@@ -1,0 +1,10 @@
+<!doctype html><style>
+    body {
+        height: 100%;
+        overflow: scroll;
+    }
+    .long {
+        height: 2000px;
+        background: orange;
+    }
+</style><body><div class="long">

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -678,6 +678,22 @@ Messages::WebContentServer::DumpLayoutTreeResponse ConnectionFromClient::dump_la
     return builder.to_deprecated_string();
 }
 
+Messages::WebContentServer::DumpPaintTreeResponse ConnectionFromClient::dump_paint_tree()
+{
+    auto* document = page().top_level_browsing_context().active_document();
+    if (!document)
+        return DeprecatedString { "(no DOM tree)" };
+    document->update_layout();
+    auto* layout_root = document->layout_node();
+    if (!layout_root)
+        return DeprecatedString { "(no layout tree)" };
+    if (!layout_root->paintable())
+        return DeprecatedString { "(no paint tree)" };
+    StringBuilder builder;
+    Web::dump_tree(builder, *layout_root->paintable());
+    return builder.to_deprecated_string();
+}
+
 Messages::WebContentServer::DumpTextResponse ConnectionFromClient::dump_text()
 {
     auto* document = page().top_level_browsing_context().active_document();

--- a/Userland/Services/WebContent/ConnectionFromClient.h
+++ b/Userland/Services/WebContent/ConnectionFromClient.h
@@ -75,6 +75,7 @@ private:
     virtual void inspect_accessibility_tree() override;
     virtual Messages::WebContentServer::GetHoveredNodeIdResponse get_hovered_node_id() override;
     virtual Messages::WebContentServer::DumpLayoutTreeResponse dump_layout_tree() override;
+    virtual Messages::WebContentServer::DumpPaintTreeResponse dump_paint_tree() override;
     virtual Messages::WebContentServer::DumpTextResponse dump_text() override;
     virtual void set_content_filters(Vector<String> const&) override;
     virtual void set_autoplay_allowed_on_all_websites() override;

--- a/Userland/Services/WebContent/WebContentServer.ipc
+++ b/Userland/Services/WebContent/WebContentServer.ipc
@@ -53,6 +53,7 @@ endpoint WebContentServer
     run_javascript(DeprecatedString js_source) =|
 
     dump_layout_tree() => (DeprecatedString dump)
+    dump_paint_tree() => (DeprecatedString dump)
     dump_text() => (DeprecatedString dump)
 
     get_selected_text() => (DeprecatedString selection)

--- a/Userland/Utilities/headless-browser.cpp
+++ b/Userland/Utilities/headless-browser.cpp
@@ -84,6 +84,11 @@ public:
         return String::from_deprecated_string(client().dump_layout_tree());
     }
 
+    ErrorOr<String> dump_paint_tree()
+    {
+        return String::from_deprecated_string(client().dump_paint_tree());
+    }
+
     ErrorOr<String> dump_text()
     {
         return String::from_deprecated_string(client().dump_text());
@@ -207,7 +212,11 @@ static ErrorOr<String> run_one_test(HeadlessWebContentView& view, StringView inp
             //       It also causes a lot more code to run, which is good for finding bugs. :^)
             (void)view.take_screenshot();
 
-            result = view.dump_layout_tree().release_value_but_fixme_should_propagate_errors();
+            StringBuilder builder;
+            builder.append(view.dump_layout_tree().release_value_but_fixme_should_propagate_errors());
+            builder.append("\n"sv);
+            builder.append(view.dump_paint_tree().release_value_but_fixme_should_propagate_errors());
+            result = builder.to_string().release_value_but_fixme_should_propagate_errors();
             loop.quit(0);
         };
     } else if (mode == TestMode::Text) {
@@ -422,8 +431,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         view->on_load_finish = [&](auto const&) {
             (void)view->take_screenshot();
             auto layout_tree = view->dump_layout_tree().release_value_but_fixme_should_propagate_errors();
+            auto paint_tree = view->dump_paint_tree().release_value_but_fixme_should_propagate_errors();
 
-            out("{}", layout_tree);
+            out("{}\n{}", layout_tree, paint_tree);
             fflush(stdout);
 
             event_loop.quit(0);


### PR DESCRIPTION
This patch implements [Overflow Viewport Propagation](https://drafts.csswg.org/css-overflow-3/#overflow-propagation) from CSS-OVERFLOW. It fixes an issue where many websites were not scrollable because they had `overflow: scroll` on the body element and we didn't propagate it.
