### PR TITLE
LibWeb: Some low-hanging performance fruit on the Discord web interface

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
@@ -51,6 +51,7 @@ void CSSStyleSheet::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_style_sheet_list.ptr());
     visitor.visit(m_rules);
     visitor.visit(m_owner_css_rule);
+    visitor.visit(m_default_namespace_rule);
 }
 
 // https://www.w3.org/TR/cssom/#dom-cssstylesheet-insertrule

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.h
@@ -174,8 +174,6 @@ private:
     void build_rule_cache();
     void build_rule_cache_if_needed() const;
 
-    Vector<MatchingRule> filter_namespace_rules(DOM::Element const&, Vector<MatchingRule> const&) const;
-
     JS::NonnullGCPtr<DOM::Document> m_document;
 
     struct AnimationKeyFrameSet {

--- a/Userland/Libraries/LibWeb/DOM/Node.h
+++ b/Userland/Libraries/LibWeb/DOM/Node.h
@@ -74,6 +74,7 @@ public:
     virtual bool requires_svg_container() const { return false; }
     virtual bool is_svg_container() const { return false; }
     virtual bool is_svg_element() const { return false; }
+    virtual bool is_svg_graphics_element() const { return false; }
     virtual bool is_svg_svg_element() const { return false; }
     virtual bool is_svg_use_element() const { return false; }
 

--- a/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.h
@@ -56,8 +56,18 @@ protected:
     Optional<Gfx::PaintStyle const&> svg_paint_computed_value_to_gfx_paint_style(SVGPaintContext const& paint_context, Optional<CSS::SVGPaint> const& paint_value) const;
 
     Gfx::AffineTransform m_transform = {};
+
+private:
+    virtual bool is_svg_graphics_element() const final { return true; }
 };
 
 Gfx::AffineTransform transform_from_transform_list(ReadonlySpan<Transform> transform_list);
+
+}
+
+namespace Web::DOM {
+
+template<>
+inline bool Node::fast_is<SVG::SVGGraphicsElement>() const { return is_svg_graphics_element(); }
 
 }


### PR DESCRIPTION
And fix a missing GC `visit_edges()` while we're passing through `CSSStyleSheet`.