### PR TITLE
LibWeb: Reset planned_increase while distributing space to "fr" tracks

### DIFF
--- a/Tests/LibWeb/Layout/expected/grid/two-items-spanning-one-1fr-row.txt
+++ b/Tests/LibWeb/Layout/expected/grid/two-items-spanning-one-1fr-row.txt
@@ -1,0 +1,21 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (1,1) content-size 798x120 [BFC] children: not-inline
+    Box <body> at (10,10) content-size 780x102 [GFC] children: not-inline
+      BlockContainer <div.foo> at (11,11) content-size 100x100 [BFC] children: inline
+        line 0 width: 27.15625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+          frag 0 from TextNode start: 0, length: 3, rect: [11,11 27.15625x17.46875]
+            "foo"
+        TextNode <#text>
+      BlockContainer <div.bar> at (11,11) content-size 778x100 [BFC] children: inline
+        line 0 width: 27.640625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+          frag 0 from TextNode start: 0, length: 3, rect: [11,11 27.640625x17.46875]
+            "bar"
+        TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x122]
+    PaintableBox (Box<BODY>) [9,9 782x104]
+      PaintableWithLines (BlockContainer<DIV>.foo) [10,10 102x102]
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer<DIV>.bar) [10,10 780x102]
+        TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/input/grid/two-items-spanning-one-1fr-row.html
+++ b/Tests/LibWeb/Layout/input/grid/two-items-spanning-one-1fr-row.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html><style>
+* {
+    border: 1px solid black;
+}
+body {
+    display: grid;
+    grid-template-rows: 1fr;
+}
+.foo {
+    width: 100px;
+    height: 100px;
+    grid-row: 1;
+    grid-column: 1;
+}
+.bar {
+    grid-row: 1;
+    grid-column: 1;
+}
+</style><body><div class="foo">foo</div><div class="bar">bar</div></div>

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -1057,6 +1057,7 @@ void GridFormattingContext::increase_sizes_to_accommodate_spanning_items_crossin
 
         for (auto& track : spanned_tracks) {
             track.base_size += track.planned_increase;
+            track.planned_increase = 0;
         }
 
         // 4. If at this point any track’s growth limit is now less than its base size, increase its growth limit to


### PR DESCRIPTION
Fixes bug when planned_increase is not reset after adding it to base_size.