### PR TITLE
Utilities+Base: Improve `cal` and its man page

### DIFF
--- a/Base/usr/share/man/man1/cal.md
+++ b/Base/usr/share/man/man1/cal.md
@@ -15,29 +15,39 @@ An overview of a whole year is displayed when a `year` is passed without a `mont
 
 The current day is always highlighted.
 
-Months and years are specified with numbers. Weeks start at what's configured in the Calendar system settings,
+Months and years are specified with numbers. Weeks start at what's configured in the Calendar system settings (Default is Sunday),
 unless the `--starting-day` option is passed.
 
-Days, months and years are specified with numbers. Week starts at Sunday.
+### Note on Calenders
+
+This program only supports "Gregorian" calendar.
+
+On "September 3, 1752" the Gregorian calendar was adopted by Britain, marking that day's date as "September 14, 1752."
+So, (unlike this program's output) "September 13, 1752" actually should be "September 2, 1752" for historical correctness.
+
+## Arguments
+
+* `year`:  Year as a number (0 to 2147483647). The current year is the default value.
+* `month`: Month as a number (1 to 12).
 
 ## Options
 
 * `-s`, `--starting-day`: Specify which day should start the week. Accepts either short or long weekday names or indexes (0 being Sunday).
-* `-3`, `--three-month-view`: Display the previous, current, and next months side-by-side.
-* `-y`, `--year`: Display an entire year by laying out months on a grid. If no year number is specified, the current year is used as a default.
+* `-3`, `--three-month-view`: Along with the month specified (by the `month` argument), display previous and next month as well.
+* `-y`, `--year`: Display the current year by laying out months on a grid. Short-hand for `cal $current_year`.
 
 ## Examples
 
 ```sh
-# Display the current month
+# Display the current month (August 2023)
 $ cal
-    March - 2023
+   August - 2023
 Su Mo Tu We Th Fr Sa
-          1  2  3  4
- 5  6  7  8  9 10 11
-12 13 14 15 16 17 18
-19 20 21 22 23 24 25
-26 27 28 29 30 31
+       1  2  3  4  5
+ 6  7  8  9 10 11 12
+13 14 15 16 17 18 19
+20 21 22 23 24 25 26
+27 28 29 30 31
 
 # Display any month
 $ cal 1 1999
@@ -48,17 +58,18 @@ Su Mo Tu We Th Fr Sa
 10 11 12 13 14 15 16
 17 18 19 20 21 22 23
 24 25 26 27 28 29 30
-31                  
+31
 
 # Display three months side-by-side
-$ cal -3 3 2023
-  February - 2023         March - 2023          April - 2023
+$ cal -3 12 2018
+  November - 2018       December - 2018        January - 2019
 Su Mo Tu We Th Fr Sa  Su Mo Tu We Th Fr Sa  Su Mo Tu We Th Fr Sa
-          1  2  3  4            1  2  3  4                     1
- 5  6  7  8  9 10 11   5  6  7  8  9 10 11   2  3  4  5  6  7  8
-12 13 14 15 16 17 18  12 13 14 15 16 17 18   9 10 11 12 13 14 15
-19 20 21 22 23 24 25  19 20 21 22 23 24 25  16 17 18 19 20 21 22
-26 27 28              26 27 28 29 30 31     23 24 25 26 27 28 29
+             1  2  3                     1         1  2  3  4  5
+ 4  5  6  7  8  9 10   2  3  4  5  6  7  8   6  7  8  9 10 11 12
+11 12 13 14 15 16 17   9 10 11 12 13 14 15  13 14 15 16 17 18 19
+18 19 20 21 22 23 24  16 17 18 19 20 21 22  20 21 22 23 24 25 26
+25 26 27 28 29 30     23 24 25 26 27 28 29  27 28 29 30 31
+                      30 31
 
 # Display an entire year
 $ cal 2023
@@ -102,4 +113,23 @@ Su Mo Tu We Th Fr Sa  Su Mo Tu We Th Fr Sa  Su Mo Tu We Th Fr Sa
 22 23 24 25 26 27 28  19 20 21 22 23 24 25  17 18 19 20 21 22 23
 29 30 31              26 27 28 29 30        24 25 26 27 28 29 30
 
+# Start the week with Friday
+# same as: `cal -s Fr`, `cal -s FRI`,  and `cal -s 5` (weekday names are case insensitive)
+$ cal -s friday
+   August - 2023
+Fr Sa Su Mo Tu We Th
+             1  2  3
+ 4  5  6  7  8  9 10
+11 12 13 14 15 16 17
+18 19 20 21 22 23 24
+25 26 27 28 29 30 31
+```
+
+## Errors and return values
+
+```sh
+# Incorrect usage of `-3` without specifying a `month`. Returns 1.
+# same error for `cal -3 -y`
+$ cal -3 1969
+cal: Cannot use --three-month-view when displaying a year.
 ```


### PR DESCRIPTION
Full commit-messages:

```
Utilities: Improve `cal`

* Pad years with leading zeros.
* Error when `year` is specified with the option `--three-month-view`.
* Add a FIXME for handling cases where zeros are passed to arguments.
* Change wording of the option's descriptions to match current behaviour.

Base: Update `cal` man page

* New "Arguments" section.
* New "Errors and Return values" section to show erroneous input and the
  resultant error messages.
* New "Note on Calenders" subsection to specify that `cal` only supports
  the "Gregorian" calender.
* Add an example of using the option `--starting-day`.
* Better wording in long option descriptions that matches the current
  behaviour more accurately.
```

Initially i just wanted to fix a typo in the error message but i ended up making
all these changes. :)

Before `cal -3 2020` would not produce an error. After rearranging the code it now does.

`--three-month-view` and `--year` are not the best names for what they do. Three month view has nothing to do with the year being displayed in a 4x**3** grid. And `--year` is just a short hand for the current year and not the option that takes a year as an argument.

Some faults i found in other areas while working on this:
* markdown render doesn't preserve newlines in code blocks. (workaround is to use multiple code blocks but not used as this will get fixed eventually)
* the `ArgsParser` is treating "negative numbers" as "short options". (cal shouldn't allow negatives in arguments)

