### PR TITLE
LibAudio: Add a seek point at the first sample in MP3Loader

### DIFF
--- a/Userland/Libraries/LibAudio/MP3Loader.cpp
+++ b/Userland/Libraries/LibAudio/MP3Loader.cpp
@@ -146,6 +146,7 @@ MaybeLoaderError MP3LoaderPlugin::build_seek_table()
     int sample_count = 0;
     size_t frame_count = 0;
     m_seek_table = {};
+    TRY(m_seek_table.insert_seek_point({ 0, 0 }));
 
     m_bitstream->align_to_byte_boundary();
 


### PR DESCRIPTION
A previous commit made it so that SeekTable doesn't provide a seek point from `seek_point_before()` if there is not a seek point before the requested sample index. However, MP3Loader was only setting a seek point after the first 10 frames, meaning that it would do nothing when seeking back to 0.

To fix this, add a seek point at byte 0 for the first sample, so that `seek_point_before()` will never fail.