### PR TITLE
LibAudio/LibThreading: Clean up PulseAudio API objects properly and add a test for PlaybackStream

### DIFF
--- a/Meta/Azure/Setup.yml
+++ b/Meta/Azure/Setup.yml
@@ -21,7 +21,7 @@ steps:
         wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
         sudo add-apt-repository 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main'
         sudo apt-get update
-        sudo apt-get install ccache gcc-12 g++-12 clang-15 libstdc++-12-dev ninja-build unzip qt6-base-dev qt6-tools-dev-tools libqt6svg6-dev qt6-multimedia-dev libgl1-mesa-dev
+        sudo apt-get install ccache gcc-12 g++-12 clang-15 libstdc++-12-dev ninja-build unzip qt6-base-dev qt6-tools-dev-tools libqt6svg6-dev qt6-multimedia-dev libgl1-mesa-dev libpulse-dev
 
         sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-15 100
         sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-15 100

--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -661,6 +661,11 @@ if (BUILD_LAGOM)
         # The FLAC tests need a special working directory to find the test files
         lagom_test(../../Tests/LibAudio/TestFLACSpec.cpp LIBS LibAudio WORKING_DIRECTORY "${FLAC_TEST_PATH}/..")
 
+        lagom_test(../../Tests/LibAudio/TestPlaybackStream.cpp LIBS LibAudio)
+        if (HAVE_PULSEAUDIO)
+            target_compile_definitions(TestPlaybackStream PRIVATE HAVE_PULSEAUDIO=1)
+        endif()
+
         # LibCore
         if ((LINUX OR APPLE) AND NOT EMSCRIPTEN)
             lagom_test(../../Tests/LibCore/TestLibCoreFileWatcher.cpp)

--- a/Tests/LibAudio/CMakeLists.txt
+++ b/Tests/LibAudio/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(TEST_SOURCES
     TestFLACSpec.cpp
+    TestPlaybackStream.cpp
 )
 
 foreach(source IN LISTS TEST_SOURCES)

--- a/Tests/LibAudio/TestPlaybackStream.cpp
+++ b/Tests/LibAudio/TestPlaybackStream.cpp
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2023, Gregory Bertilson <zaggy1024@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Math.h>
+#include <AK/MemoryStream.h>
+#include <AK/WeakPtr.h>
+#include <LibAudio/PlaybackStream.h>
+#include <LibTest/TestSuite.h>
+#include <unistd.h>
+
+#if defined(HAVE_PULSEAUDIO)
+#    include <LibAudio/PulseAudioWrappers.h>
+#endif
+
+TEST_CASE(create_and_destroy_playback_stream)
+{
+    bool has_implementation = false;
+#if defined(HAVE_PULSEAUDIO)
+    has_implementation = true;
+#endif
+
+    {
+        auto stream_result = Audio::PlaybackStream::create(Audio::OutputState::Playing, 44100, 2, 100, [](Bytes buffer, Audio::PcmSampleFormat format, size_t sample_count) -> ReadonlyBytes {
+            VERIFY(format == Audio::PcmSampleFormat::Float32);
+            FixedMemoryStream writing_stream { buffer };
+
+            for (size_t i = 0; i < sample_count; i++) {
+                MUST(writing_stream.write_value(0.0f));
+                MUST(writing_stream.write_value(0.0f));
+            }
+
+            return buffer.trim(writing_stream.offset());
+        });
+        EXPECT_EQ(!stream_result.is_error(), has_implementation);
+        usleep(10000);
+    }
+
+#if defined(HAVE_PULSEAUDIO)
+    VERIFY(!Audio::PulseAudioContext::weak_instance());
+#endif
+}

--- a/Userland/Libraries/LibAudio/PlaybackStreamPulseAudio.cpp
+++ b/Userland/Libraries/LibAudio/PlaybackStreamPulseAudio.cpp
@@ -45,7 +45,6 @@ ErrorOr<NonnullRefPtr<PlaybackStream>> PlaybackStreamPulseAudio::create(OutputSt
     },
         "Audio::PlaybackStream"sv));
 
-    internal_state->set_thread(thread);
     thread->start();
     thread->detach();
     return playback_stream;
@@ -136,12 +135,6 @@ ErrorOr<void> PlaybackStreamPulseAudio::InternalState::check_is_running()
     return {};
 }
 
-void PlaybackStreamPulseAudio::InternalState::set_thread(NonnullRefPtr<Threading::Thread> const& thread)
-{
-    Threading::MutexLocker locker { m_mutex };
-    m_thread = thread;
-}
-
 void PlaybackStreamPulseAudio::InternalState::set_stream(NonnullRefPtr<PulseAudioStream> const& stream)
 {
     m_stream = stream;
@@ -177,10 +170,6 @@ void PlaybackStreamPulseAudio::InternalState::thread_loop()
         }
         task();
     }
-
-    // Stop holding onto our thread so it can be deleted.
-    Threading::MutexLocker locker { m_mutex };
-    m_thread = nullptr;
 }
 
 void PlaybackStreamPulseAudio::InternalState::exit()

--- a/Userland/Libraries/LibAudio/PlaybackStreamPulseAudio.h
+++ b/Userland/Libraries/LibAudio/PlaybackStreamPulseAudio.h
@@ -31,8 +31,6 @@ private:
     // the UI thread.
     class InternalState : public AtomicRefCounted<InternalState> {
     public:
-        void set_thread(NonnullRefPtr<Threading::Thread> const&);
-
         void set_stream(NonnullRefPtr<PulseAudioStream> const&);
         RefPtr<PulseAudioStream> stream();
 
@@ -49,8 +47,6 @@ private:
         Threading::ConditionVariable m_wake_condition { m_mutex };
 
         Atomic<bool> m_exit { false };
-
-        RefPtr<Threading::Thread> m_thread { nullptr };
     };
 
     PlaybackStreamPulseAudio(NonnullRefPtr<InternalState>);

--- a/Userland/Libraries/LibAudio/PulseAudioWrappers.cpp
+++ b/Userland/Libraries/LibAudio/PulseAudioWrappers.cpp
@@ -105,8 +105,11 @@ PulseAudioContext::PulseAudioContext(pa_threaded_mainloop* main_loop, pa_mainloo
 
 PulseAudioContext::~PulseAudioContext()
 {
-    pa_context_disconnect(m_context);
-    pa_context_unref(m_context);
+    {
+        auto locker = main_loop_locker();
+        pa_context_disconnect(m_context);
+        pa_context_unref(m_context);
+    }
     pa_threaded_mainloop_stop(m_main_loop);
     pa_threaded_mainloop_free(m_main_loop);
 }

--- a/Userland/Libraries/LibAudio/PulseAudioWrappers.cpp
+++ b/Userland/Libraries/LibAudio/PulseAudioWrappers.cpp
@@ -266,11 +266,18 @@ ErrorOr<NonnullRefPtr<PulseAudioStream>> PulseAudioContext::create_stream(Output
         wait_for_signal();
     }
 
+    pa_stream_set_state_callback(stream, nullptr, nullptr);
+
     return stream_wrapper;
 }
 
 PulseAudioStream::~PulseAudioStream()
 {
+    auto locker = m_context->main_loop_locker();
+    pa_stream_set_write_callback(m_stream, nullptr, nullptr);
+    pa_stream_set_underflow_callback(m_stream, nullptr, nullptr);
+    pa_stream_set_started_callback(m_stream, nullptr, nullptr);
+    pa_stream_disconnect(m_stream);
     pa_stream_unref(m_stream);
 }
 

--- a/Userland/Libraries/LibAudio/PulseAudioWrappers.cpp
+++ b/Userland/Libraries/LibAudio/PulseAudioWrappers.cpp
@@ -16,6 +16,13 @@ ErrorOr<NonnullRefPtr<PulseAudioContext>> PulseAudioContext::instance()
     // Use a weak pointer to allow the context to be shut down if we stop outputting audio.
     static WeakPtr<PulseAudioContext> the_instance;
     static Threading::Mutex instantiation_mutex;
+    // Lock and unlock the mutex to ensure that the mutex is fully unlocked at application
+    // exit.
+    atexit([]() {
+        instantiation_mutex.lock();
+        instantiation_mutex.unlock();
+    });
+
     auto instantiation_locker = Threading::MutexLocker(instantiation_mutex);
 
     RefPtr<PulseAudioContext> strong_instance_pointer = the_instance.strong_ref();

--- a/Userland/Libraries/LibAudio/PulseAudioWrappers.cpp
+++ b/Userland/Libraries/LibAudio/PulseAudioWrappers.cpp
@@ -11,10 +11,15 @@
 
 namespace Audio {
 
-ErrorOr<NonnullRefPtr<PulseAudioContext>> PulseAudioContext::instance()
+WeakPtr<PulseAudioContext> PulseAudioContext::weak_instance()
 {
     // Use a weak pointer to allow the context to be shut down if we stop outputting audio.
     static WeakPtr<PulseAudioContext> the_instance;
+    return the_instance;
+}
+
+ErrorOr<NonnullRefPtr<PulseAudioContext>> PulseAudioContext::instance()
+{
     static Threading::Mutex instantiation_mutex;
     // Lock and unlock the mutex to ensure that the mutex is fully unlocked at application
     // exit.
@@ -25,6 +30,7 @@ ErrorOr<NonnullRefPtr<PulseAudioContext>> PulseAudioContext::instance()
 
     auto instantiation_locker = Threading::MutexLocker(instantiation_mutex);
 
+    auto the_instance = weak_instance();
     RefPtr<PulseAudioContext> strong_instance_pointer = the_instance.strong_ref();
 
     if (strong_instance_pointer == nullptr) {

--- a/Userland/Libraries/LibAudio/PulseAudioWrappers.cpp
+++ b/Userland/Libraries/LibAudio/PulseAudioWrappers.cpp
@@ -234,7 +234,6 @@ ErrorOr<NonnullRefPtr<PulseAudioStream>> PulseAudioContext::create_stream(Output
         return Error::from_string_literal("Error while connecting the PulseAudio stream");
     }
 
-    // FIXME: This should be asynchronous if connection can take longer than a fraction of a second.
     while (true) {
         bool is_ready = false;
         switch (stream_wrapper->get_connection_state()) {

--- a/Userland/Libraries/LibAudio/PulseAudioWrappers.cpp
+++ b/Userland/Libraries/LibAudio/PulseAudioWrappers.cpp
@@ -230,7 +230,7 @@ ErrorOr<NonnullRefPtr<PulseAudioStream>> PulseAudioContext::create_stream(Output
         stream_wrapper.ptr());
 
     if (auto error = pa_stream_connect_playback(stream, nullptr, &buffer_attributes, flags, nullptr, nullptr); error != 0) {
-        warnln("PulseAudio stream connection failed with error: {}", pulse_audio_error_to_string(static_cast<PulseAudioErrorCode>(error)));
+        warnln("Failed to start PulseAudio stream connection with error: {}", pulse_audio_error_to_string(static_cast<PulseAudioErrorCode>(error)));
         return Error::from_string_literal("Error while connecting the PulseAudio stream");
     }
 
@@ -244,6 +244,7 @@ ErrorOr<NonnullRefPtr<PulseAudioStream>> PulseAudioContext::create_stream(Output
             is_ready = true;
             break;
         case PulseAudioStreamState::Failed:
+            warnln("PulseAudio stream connection failed with error: {}", pulse_audio_error_to_string(get_last_error()));
             return Error::from_string_literal("Failed to connect to PulseAudio daemon");
         case PulseAudioStreamState::Unconnected:
         case PulseAudioStreamState::Terminated:

--- a/Userland/Libraries/LibAudio/PulseAudioWrappers.h
+++ b/Userland/Libraries/LibAudio/PulseAudioWrappers.h
@@ -40,6 +40,7 @@ class PulseAudioContext
     : public AtomicRefCounted<PulseAudioContext>
     , public Weakable<PulseAudioContext> {
 public:
+    static AK::WeakPtr<PulseAudioContext> weak_instance();
     static ErrorOr<NonnullRefPtr<PulseAudioContext>> instance();
 
     explicit PulseAudioContext(pa_threaded_mainloop*, pa_mainloop_api*, pa_context*);

--- a/Userland/Libraries/LibThreading/BackgroundAction.h
+++ b/Userland/Libraries/LibThreading/BackgroundAction.h
@@ -55,8 +55,7 @@ public:
 
 private:
     BackgroundAction(Function<ErrorOr<Result>(BackgroundAction&)> action, Function<ErrorOr<void>(Result)> on_complete, Optional<Function<void(Error)>> on_error = {})
-        : Core::EventReceiver(&background_thread())
-        , m_promise(Promise::try_create().release_value_but_fixme_should_propagate_errors())
+        : m_promise(Promise::try_create().release_value_but_fixme_should_propagate_errors())
         , m_action(move(action))
         , m_on_complete(move(on_complete))
     {
@@ -75,21 +74,18 @@ private:
         if (on_error.has_value())
             m_on_error = on_error.release_value();
 
-        enqueue_work([this, origin_event_loop = &Core::EventLoop::current()] {
-            auto result = m_action(*this);
+        enqueue_work([self = NonnullRefPtr(*this), origin_event_loop = &Core::EventLoop::current()]() {
+            auto result = self->m_action(*self);
             // The event loop cancels the promise when it exits.
-            m_canceled |= m_promise->is_rejected();
-            auto callback_scheduled = false;
+            self->m_canceled |= self->m_promise->is_rejected();
             // All of our work was successful and we weren't cancelled; resolve the event loop's promise.
-            if (!m_canceled && !result.is_error()) {
-                m_result = result.release_value();
+            if (!self->m_canceled && !result.is_error()) {
+                self->m_result = result.release_value();
                 // If there is no completion callback, we don't rely on the user keeping around the event loop.
-                if (m_on_complete) {
-                    callback_scheduled = true;
-                    origin_event_loop->deferred_invoke([this] {
+                if (self->m_on_complete) {
+                    origin_event_loop->deferred_invoke([self] {
                         // Our promise's resolution function will never error.
-                        (void)m_promise->resolve(*this);
-                        remove_from_parent();
+                        (void)self->m_promise->resolve(*self);
                     });
                     origin_event_loop->wake();
                 }
@@ -99,21 +95,16 @@ private:
                 if (result.is_error())
                     error = result.release_error();
 
-                m_promise->reject(Error::from_errno(ECANCELED));
-                if (!m_canceled && m_on_error) {
-                    callback_scheduled = true;
-                    origin_event_loop->deferred_invoke([this, error = move(error)]() mutable {
-                        m_on_error(move(error));
-                        remove_from_parent();
+                self->m_promise->reject(Error::from_errno(ECANCELED));
+                if (!self->m_canceled && self->m_on_error) {
+                    origin_event_loop->deferred_invoke([self, error = move(error)]() mutable {
+                        self->m_on_error(move(error));
                     });
                     origin_event_loop->wake();
-                } else if (m_on_error) {
-                    m_on_error(move(error));
+                } else if (self->m_on_error) {
+                    self->m_on_error(move(error));
                 }
             }
-
-            if (!callback_scheduled)
-                remove_from_parent();
         });
     }
 

--- a/Userland/Libraries/LibThreading/Thread.cpp
+++ b/Userland/Libraries/LibThreading/Thread.cpp
@@ -23,8 +23,6 @@ Thread::~Thread()
         dbgln("Destroying {} while it is still running undetached!", *this);
         [[maybe_unused]] auto res = join();
     }
-    if (m_state == ThreadState::Detached)
-        dbgln("Bug! {} in state {} is being destroyed; AK/Function will crash shortly!", *this, m_state.load());
 }
 
 ErrorOr<void> Thread::set_priority(int priority)
@@ -80,7 +78,8 @@ void Thread::start()
         // FIXME: Use pthread_attr_t to start a thread detached if that was requested by the user before the call to start().
         nullptr,
         [](void* arg) -> void* {
-            Thread* self = static_cast<Thread*>(arg);
+            auto self = adopt_ref(*static_cast<Thread*>(arg));
+
             auto exit_code = self->m_action();
 
             auto expected = Threading::ThreadState::Running;
@@ -100,7 +99,7 @@ void Thread::start()
 
             return reinterpret_cast<void*>(exit_code);
         },
-        static_cast<void*>(this));
+        &NonnullRefPtr(*this).leak_ref());
 
     VERIFY(rc == 0);
 #ifdef AK_OS_SERENITY

--- a/Userland/Libraries/LibThreading/Thread.cpp
+++ b/Userland/Libraries/LibThreading/Thread.cpp
@@ -12,8 +12,7 @@
 namespace Threading {
 
 Thread::Thread(Function<intptr_t()> action, StringView thread_name)
-    : Core::EventReceiver(nullptr)
-    , m_action(move(action))
+    : m_action(move(action))
     , m_thread_name(thread_name.is_null() ? ""sv : thread_name)
 {
 }

--- a/Userland/Libraries/LibThreading/Thread.h
+++ b/Userland/Libraries/LibThreading/Thread.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <AK/Assertions.h>
+#include <AK/AtomicRefCounted.h>
 #include <AK/DeprecatedString.h>
 #include <AK/DistinctNumeric.h>
 #include <AK/Function.h>
@@ -42,7 +43,7 @@ enum class ThreadState : u8 {
 };
 
 class Thread final
-    : public RefCounted<Thread>
+    : public AtomicRefCounted<Thread>
     , public Weakable<Thread> {
 public:
     static NonnullRefPtr<Thread> construct(Function<intptr_t()> action, StringView thread_name = {})

--- a/Userland/Libraries/LibThreading/Thread.h
+++ b/Userland/Libraries/LibThreading/Thread.h
@@ -41,10 +41,19 @@ enum class ThreadState : u8 {
     Joined,
 };
 
-class Thread final : public Core::EventReceiver {
-    C_OBJECT(Thread);
-
+class Thread final
+    : public RefCounted<Thread>
+    , public Weakable<Thread> {
 public:
+    static NonnullRefPtr<Thread> construct(Function<intptr_t()> action, StringView thread_name = {})
+    {
+        return adopt_ref(*new Thread(move(action), thread_name));
+    }
+    static ErrorOr<NonnullRefPtr<Thread>> try_create(Function<intptr_t()> action, StringView thread_name = {})
+    {
+        return adopt_nonnull_ref_or_enomem(new (nothrow) Thread(move(action), thread_name));
+    }
+
     virtual ~Thread();
 
     ErrorOr<void> set_priority(int priority);


### PR DESCRIPTION
This PR does the following:

- Adds `libpulse-dev` to CI to allow PulseAudio classes in LibAudio to build on CI.
- Makes creating, detaching and then destructing a `RefPtr<Threading::Thread>` safe by keeping the `Thread` alive until its action completes.
- Fixes numerous issues with the `PulseAudioWrappers.cpp` classes and `PlaybackStreamPulseAudio` when destructing a stream. Streams will now successfully shut down and free all memory, and the PulseAudio context will successfully disconnect, be freed, and then when necessary it will be instantiated and connected again.