### PR TITLE
watch: Use alternate buffer to display output

### DIFF
--- a/Userland/Utilities/watch.cpp
+++ b/Userland/Utilities/watch.cpp
@@ -132,19 +132,19 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto watch_callback = [&] {
         // Clear the screen, then reset the cursor position to the top left.
-        warn("\033[H\033[2J");
+        out("\033[H\033[2J");
         // Print the header.
         if (!flag_noheader) {
-            warnln("{}", header);
-            warnln();
+            outln("{}", header);
+            outln();
         } else {
-            fflush(stderr);
+            fflush(stdout);
         }
         if (run_command(command) != 0) {
             exit_code = 1;
             if (flag_beep_on_fail) {
-                warnln("\a");
-                fflush(stderr);
+                out("\a");
+                fflush(stdout);
             }
         }
     };


### PR DESCRIPTION
This matches the behavior of watch on Linux.

Example usage:

https://github.com/SerenityOS/serenity/assets/2817754/ea93e3c9-0d54-4de5-b5b4-6a428a069c72

