### PR TITLE
LibWeb: Move the media volume slider 1:1 with the mouse cursor

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.h
@@ -124,6 +124,7 @@ public:
         Optional<CSSPixelRect> timeline_rect;
         Optional<CSSPixelRect> speaker_button_rect;
         Optional<CSSPixelRect> volume_rect;
+        Optional<CSSPixelRect> volume_scrub_rect;
     };
     CachedLayoutBoxes& cached_layout_boxes(Badge<Painting::MediaPaintable>) const { return m_layout_boxes; }
 

--- a/Userland/Libraries/LibWeb/Painting/MediaPaintable.h
+++ b/Userland/Libraries/LibWeb/Painting/MediaPaintable.h
@@ -38,6 +38,7 @@ private:
         DevicePixels speaker_button_size;
 
         DevicePixelRect volume_rect;
+        DevicePixelRect volume_scrub_rect;
         DevicePixels volume_button_size;
     };
 


### PR DESCRIPTION
The volume control's slider is drawn in a rectangle shrunken by its slider handle's size, so the handle did not move 1:1 with the user's mouse movement.

To fix this, it will now check for a mousedown in the volume control with a rectangle sized to fit any possible position of the handle, but the volume value result will be calculated based on the center of the handle instead. This allows it to move 1:1 with the mouse cursor.

Before:

https://github.com/SerenityOS/serenity/assets/3149592/0358b36a-965a-445b-90e9-f9854058265c

After:

https://github.com/SerenityOS/serenity/assets/3149592/7d854f38-4b0d-472f-8509-8d285770b198

cc @trflynn89 