### PR TITLE
LibMarkdown: Preserve blank lines in `CodeBlock`s

### DIFF
--- a/Userland/Libraries/LibMarkdown/CodeBlock.cpp
+++ b/Userland/Libraries/LibMarkdown/CodeBlock.cpp
@@ -66,9 +66,8 @@ Vector<DeprecatedString> CodeBlock::render_lines_for_terminal(size_t) const
             indentation = "  "sv;
     }
 
-    for (auto const& line : m_code.split('\n'))
+    for (auto const& line : m_code.split('\n', SplitBehavior::KeepEmpty))
         lines.append(DeprecatedString::formatted("{}{}", indentation, line));
-    lines.append("");
 
     return lines;
 }


### PR DESCRIPTION
Specifically, `CodeBlock::render_lines_for_terminal()` eats up blank lines because it uses `DeprecatedString::split()` without the `SplitBehavior::KeepEmpty` enum. Easy fix: use the enum.

Before:
![image](https://github.com/SerenityOS/serenity/assets/70647861/c9d2a150-e8ae-4c74-8139-4d46caec5c58)

After:
![md_good](https://github.com/SerenityOS/serenity/assets/70647861/cfef478b-a31e-409f-b0e9-ce6657589eb7)

Discovered while working on #20348.