### PR TITLE
Utilities: Fix title formatting in `man`

### DIFF
--- a/Userland/Utilities/man.cpp
+++ b/Userland/Utilities/man.cpp
@@ -98,7 +98,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto const title = TRY("SerenityOS manual"_string);
 
     int spaces = max(view_width / 2 - page_name.code_points().length() - section_number.code_points().length() - title.code_points().length() / 2 - 4, 0);
-    outln("{}({}){}{}", page_name, section_number, String::repeated(' ', spaces), title);
+    outln("{}({}){}{}", page_name, section_number, TRY(String::repeated(' ', spaces)), title);
 
     auto document = Markdown::Document::parse(buffer);
     VERIFY(document);


### PR DESCRIPTION
`String::repeated()` returns a `ErrorOr<String>`, so wrap it in `TRY()`.

This fixes a glitch in the title formatting (`{}` not removed if `ErrorOr<String>` is directly passed to `outln()`).

Before:
![man_bad](https://github.com/SerenityOS/serenity/assets/70647861/0eda7805-7ea1-4e5f-8ea5-b623f4c956e2)

After:
![man_good](https://github.com/SerenityOS/serenity/assets/70647861/85d1107e-3125-45a6-9482-2c6db49e47b8)

Regressed in #19382.

Discovered while working on #20348.