### PR TITLE
Meta: Fully create the required /usr/local directory tree

### DIFF
--- a/Meta/build-root-filesystem.sh
+++ b/Meta/build-root-filesystem.sh
@@ -135,6 +135,12 @@ done
 chmod 700 mnt/boot
 chmod 700 mnt/mod
 chmod 1777 mnt/tmp
+
+# Filesystem Hierarchy Standard (Linux Standard Base) - 4.9. /usr/local:
+# "The following directories, or symbolic links to directories, must be in /usr/local:"
+for dir in bin etc games include lib man sbin share src; do
+    mkdir -p mnt/usr/local/${dir}
+done
 echo "done"
 
 printf "creating utmp file... "


### PR DESCRIPTION
This should hopefully cut down on the number of ports that require manual directory creation.

The main question is whether we _want_ to officially adhere to the LSB for this topic. Given how many Linux tools we are porting, I don't think it would be particularly bad.