### PR TITLE
Meta: Truncate generated IDL source files

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/main.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/main.cpp
@@ -128,7 +128,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto write_if_changed = [&](auto generator_function, StringView file_path) -> ErrorOr<void> {
         (*generator_function)(interface, output_builder);
 
-        auto output_file = TRY(Core::File::open(file_path, Core::File::OpenMode::ReadWrite));
+        auto output_file = TRY(Core::File::open(file_path, Core::File::OpenMode::ReadWrite | Core::File::OpenMode::Truncate));
 
         // Only write to disk if contents have changed
         auto previous_contents = TRY(output_file->read_until_eof());


### PR DESCRIPTION
3dd3120a8a15bdafc3d884878b52de37f3b60ec5 changed open mode from Write to ReadWrite, which stopped truncating files.

This could be noticed by building a slightly older branch, as compiling it gave compile errors.