### PR TITLE
LibWeb: Snap table grid to device pixels in separate borders mode

### DIFF
--- a/Userland/Libraries/LibWeb/Painting/BorderPainting.cpp
+++ b/Userland/Libraries/LibWeb/Painting/BorderPainting.cpp
@@ -544,12 +544,10 @@ RefPtr<Gfx::Bitmap> get_cached_corner_bitmap(DevicePixelSize corners_size)
     return corner_bitmap;
 }
 
-void paint_all_borders(PaintContext& context, CSSPixelRect const& bordered_rect, BorderRadiiData const& border_radii_data, BordersData const& borders_data)
+void paint_all_borders(PaintContext& context, DevicePixelRect const& border_rect, BorderRadiiData const& border_radii_data, BordersData const& borders_data)
 {
     if (borders_data.top.width <= 0 && borders_data.right.width <= 0 && borders_data.left.width <= 0 && borders_data.bottom.width <= 0)
         return;
-
-    auto border_rect = context.rounded_device_rect(bordered_rect);
 
     auto top_left = border_radii_data.top_left.as_corner(context);
     auto top_right = border_radii_data.top_right.as_corner(context);

--- a/Userland/Libraries/LibWeb/Painting/BorderPainting.h
+++ b/Userland/Libraries/LibWeb/Painting/BorderPainting.h
@@ -84,7 +84,7 @@ Optional<BordersData> borders_data_for_outline(Layout::Node const&, Color outlin
 RefPtr<Gfx::Bitmap> get_cached_corner_bitmap(DevicePixelSize corners_size);
 
 void paint_border(PaintContext& context, BorderEdge edge, DevicePixelRect const& rect, Gfx::AntiAliasingPainter::CornerRadius const& radius, Gfx::AntiAliasingPainter::CornerRadius const& opposite_radius, BordersData const& borders_data, Gfx::Path& path, bool last);
-void paint_all_borders(PaintContext& context, CSSPixelRect const& bordered_rect, BorderRadiiData const& border_radii_data, BordersData const&);
+void paint_all_borders(PaintContext& context, DevicePixelRect const& border_rect, BorderRadiiData const& border_radii_data, BordersData const&);
 
 Gfx::Color border_color(BorderEdge edge, BordersData const& borders_data);
 

--- a/Userland/Libraries/LibWeb/Painting/InlinePaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/InlinePaintable.cpp
@@ -134,9 +134,9 @@ void InlinePaintable::paint(PaintContext& context, PaintPhase phase) const
 
                 border_radii_data.inflate(outline_data->top.width + outline_offset_y, outline_data->right.width + outline_offset_x, outline_data->bottom.width + outline_offset_y, outline_data->left.width + outline_offset_x);
                 borders_rect.inflate(outline_data->top.width + outline_offset_y, outline_data->right.width + outline_offset_x, outline_data->bottom.width + outline_offset_y, outline_data->left.width + outline_offset_x);
-                paint_all_borders(context, borders_rect, border_radii_data, *outline_data);
+                paint_all_borders(context, context.rounded_device_rect(borders_rect), border_radii_data, *outline_data);
             } else {
-                paint_all_borders(context, borders_rect, border_radii_data, borders_data);
+                paint_all_borders(context, context.rounded_device_rect(borders_rect), border_radii_data, borders_data);
             }
 
             return IterationDecision::Continue;

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -241,7 +241,7 @@ void PaintableBox::paint(PaintContext& context, PaintPhase phase) const
             border_radius_data.inflate(outline_width + outline_offset_y, outline_width + outline_offset_x, outline_width + outline_offset_y, outline_width + outline_offset_x);
             borders_rect.inflate(outline_width + outline_offset_y, outline_width + outline_offset_x, outline_width + outline_offset_y, outline_width + outline_offset_x);
 
-            paint_all_borders(context, borders_rect, border_radius_data, borders_data.value());
+            paint_all_borders(context, context.rounded_device_rect(borders_rect), border_radius_data, borders_data.value());
         }
     }
 
@@ -311,7 +311,7 @@ void PaintableBox::paint_border(PaintContext& context) const
         .bottom = box_model().border.bottom == 0 ? CSS::BorderData() : computed_values().border_bottom(),
         .left = box_model().border.left == 0 ? CSS::BorderData() : computed_values().border_left(),
     };
-    paint_all_borders(context, absolute_border_box_rect(), normalized_border_radii_data(), borders_data);
+    paint_all_borders(context, context.rounded_device_rect(absolute_border_box_rect()), normalized_border_radii_data(), borders_data);
 }
 
 void PaintableBox::paint_backdrop_filter(PaintContext& context) const

--- a/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -104,11 +104,13 @@ void StackingContext::paint_descendants(PaintContext& context, Layout::Node cons
         case StackingContextPaintPhase::BackgroundAndBorders:
             if (!child_is_inline_or_replaced && !child.is_floating()) {
                 paint_node(child, context, PaintPhase::Background);
-                if ((!child.display().is_table_cell() && !child.display().is_table_inside()) || child.computed_values().border_collapse() == CSS::BorderCollapse::Separate)
+                bool is_table_with_collapsed_borders = child.display().is_table_inside() && child.computed_values().border_collapse() == CSS::BorderCollapse::Collapse;
+                if (!child.display().is_table_cell() && !is_table_with_collapsed_borders)
                     paint_node(child, context, PaintPhase::Border);
                 paint_descendants(context, child, phase);
-                if (child.computed_values().border_collapse() == CSS::BorderCollapse::Collapse)
-                    paint_table_collapsed_borders(context, child);
+                if (child.display().is_table_inside() || child.computed_values().border_collapse() == CSS::BorderCollapse::Collapse) {
+                    paint_table_borders(context, child);
+                }
             }
             break;
         case StackingContextPaintPhase::Floats:

--- a/Userland/Libraries/LibWeb/Painting/TableBordersPainting.h
+++ b/Userland/Libraries/LibWeb/Painting/TableBordersPainting.h
@@ -10,6 +10,6 @@
 
 namespace Web::Painting {
 
-void paint_table_collapsed_borders(PaintContext&, Layout::Node const&);
+void paint_table_borders(PaintContext&, Layout::Node const&);
 
 }


### PR DESCRIPTION
Build a grid snapped to device pixels and use it to construct the rectangles for the cell edges, same as for collapsed borders. This is especially important when border-spacing is set to 0 since it avoids gaps between adjacent cells which have borders set.