### PR TITLE
Ports: Add cmake option for configscript

### DIFF
--- a/Ports/.port_include.sh
+++ b/Ports/.port_include.sh
@@ -86,7 +86,6 @@ makeopts=("-j${MAKEJOBS}")
 installopts=()
 configscript=configure
 configopts=()
-generator="make"
 useconfigure=false
 config_sub_paths=("config.sub")
 config_guess_paths=("config.guess")

--- a/Ports/.port_include.sh
+++ b/Ports/.port_include.sh
@@ -429,7 +429,7 @@ func_defined pre_configure || pre_configure() {
     :
 }
 func_defined configure || configure() {
-    if [[ -n "$(run find -maxdepth 1 -iname cmakelists.txt)" ]]; then
+    if [[ -f "${workdir}/CMakeLists.txt" ]]; then
         run cmake -B "$CMAKE_BINARY_DIR"  \
             -DCMAKE_TOOLCHAIN_FILE="${SERENITY_BUILD_DIR}/CMakeToolchain.txt" \
             "${configopts[@]}"
@@ -447,14 +447,14 @@ func_defined post_configure || post_configure() {
     :
 }
 func_defined build || build() {
-    if [[ -n "$(run find -maxdepth 1 -iname cmakelists.txt)" ]]; then
+    if [[ -f "${workdir}/CMakeLists.txt" ]]; then
         run cmake --build "$CMAKE_BINARY_DIR" -- "${makeopts[@]}"
         return
     fi
     run make "${makeopts[@]}"
 }
 func_defined install || install() {
-    if [[ -n "$(run find -maxdepth 1 -iname cmakelists.txt)" ]]; then
+    if [[ -f "${workdir}/CMakeLists.txt" ]]; then
         run cmake --build "$CMAKE_BINARY_DIR" --target install -- "${makeopts[@]}"
         return
     fi

--- a/Ports/.port_include.sh
+++ b/Ports/.port_include.sh
@@ -412,6 +412,11 @@ func_defined pre_configure || pre_configure() {
     :
 }
 func_defined configure || configure() {
+    if [[ "$configscript" == "cmake" ]]; then
+        run cmake "${configopts[@]}"
+        return
+    fi
+
     chmod +x "${workdir}"/"$configscript"
     if [[ -n "${SERENITY_SOURCE_DIR:-}" ]]; then
         run ./"$configscript" --host="${SERENITY_ARCH}-pc-serenity" "${configopts[@]}"

--- a/Ports/curl/package.sh
+++ b/Ports/curl/package.sh
@@ -21,4 +21,3 @@ configopts=(
     -DCURL_HIDDEN_SYMBOLS=OFF
 )
 configscript=cmake
-generator=ninja

--- a/Ports/curl/package.sh
+++ b/Ports/curl/package.sh
@@ -10,7 +10,6 @@ depends=(
   'zstd'
 )
 configopts=(
-    -Bbuild
     -DCURL_USE_OPENSSL=ON 
     -DCURL_ZSTD=ON 
     -DCURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
@@ -20,4 +19,3 @@ configopts=(
     -DCURL_DISABLE_TESTS=ON
     -DCURL_HIDDEN_SYMBOLS=OFF
 )
-configscript=cmake

--- a/Ports/curl/package.sh
+++ b/Ports/curl/package.sh
@@ -9,28 +9,16 @@ depends=(
   'zlib'
   'zstd'
 )
-configopts=("-DCMAKE_TOOLCHAIN_FILE=${SERENITY_BUILD_DIR}/CMakeToolchain.txt")
-
-configure() {
-    mkdir -p curl-build
-    cmake -G Ninja \
-    -S curl-${version} \
-    -B curl-build \
-    "${configopts[@]}" \
-    -DCURL_USE_OPENSSL=ON \
-    -DCURL_ZSTD=ON \
-    -DCURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt \
-    -DCURL_CA_PATH=none \
-    -DCURL_DISABLE_NTLM=ON \
-    -DCURL_DISABLE_SOCKETPAIR=ON \
-    -DCURL_DISABLE_TESTS=ON \
+configopts=(
+    -Bbuild
+    -DCURL_USE_OPENSSL=ON 
+    -DCURL_ZSTD=ON 
+    -DCURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
+    -DCURL_CA_PATH=none
+    -DCURL_DISABLE_NTLM=ON
+    -DCURL_DISABLE_SOCKETPAIR=ON
+    -DCURL_DISABLE_TESTS=ON
     -DCURL_HIDDEN_SYMBOLS=OFF
-}
-
-build() {
-    ninja -C curl-build
-}
-
-install() {
-    ninja -C curl-build install
-}
+)
+configscript=cmake
+generator=ninja


### PR DESCRIPTION
If the configscript is set to "cmake", run the cmake tool with configpopts in the configure() function in the "workdir" directory.