### PR TITLE
Meta: Implement support for the new String in the gdb formatter

### DIFF
--- a/Meta/serenity_gdb.py
+++ b/Meta/serenity_gdb.py
@@ -189,9 +189,7 @@ class AKStringView:
         if int(self.val["m_length"]) == 0:
             return '""'
         else:
-            characters = self.val["m_characters"]
-            str_type = characters.type.target().array(self.val["m_length"]).pointer()
-            return str(characters.cast(str_type).dereference())
+            return self.val["m_characters"].string(length=self.val["m_length"])
 
     @classmethod
     def prettyprint_type(cls, type):
@@ -213,8 +211,7 @@ class AKStringImpl:
         if int(self.val["m_length"]) == 0:
             return '""'
         else:
-            str_type = gdb.lookup_type("char").array(self.val["m_length"])
-            return get_field_unalloced(self.val, "m_inline_buffer", str_type)
+            return self.val["m_inline_buffer"].string(length=self.val["m_length"])
 
     @classmethod
     def prettyprint_type(cls, type):


### PR DESCRIPTION
The pretty-print gdb helpers were not updated since the DeprecatedString change. This commit introduces a new printer for String and renames the old one to DeprecatedString.

StringImpl and StringView were also displayed character-by-character in the pretty printer. This is now changed to properly show the full "concatenated" string.