### PR TITLE
LibLine: Fix case-change operations

### DIFF
--- a/Userland/Libraries/LibLine/InternalFunctions.cpp
+++ b/Userland/Libraries/LibLine/InternalFunctions.cpp
@@ -494,8 +494,10 @@ void Editor::case_change_word(Editor::CaseChangeOp change_op)
             m_buffer[m_cursor] = to_ascii_lowercase(m_buffer[m_cursor]);
         }
         ++m_cursor;
-        m_refresh_needed = true;
     }
+
+    m_refresh_needed = true;
+    m_chars_touched_in_the_middle = 1;
 }
 
 void Editor::capitalize_word()


### PR DESCRIPTION
Even though case-change operations set `m_refresh_needed` to `true`, `Editor::refresh_display()` doesn't redraw the line or a part of it. Setting `m_chars_touched_in_the_middle` to a non-zero value results in redrawing of the line; Fixing the issue of the line not being refreshed after a case-change operation.

---

I can't figure out what `m_chars_touched_in_the_middle` actually does (why is it an int if it is used as a bool?) but i am guessing it is for marking the index of the start of the line change. Starting from that index till the cursor is what got changed and *only that* part should be redrawn.

Was this (Meta+u, Meta+l, and Meta+c) broken for 2.5 years?? I think the delta refresh logic was forgotten and never got implemented. Missing FIXME? (in `Editor::refresh_display()`)

But other operations like `Editor::erase_character_backwards()` don't set `m_chars_touched_in_the_middle` and yet they aren't broken.

Regardless of any of the above, this patch makes case operations work again.