### PR TITLE
Shell: Color bareword yellow if it's a prefix of at least one command

### DIFF
--- a/Userland/Shell/AST.cpp
+++ b/Userland/Shell/AST.cpp
@@ -654,6 +654,8 @@ ErrorOr<void> BarewordLiteral::highlight_in_editor(Line::Editor& editor, Shell& 
 #endif
 
             editor.stylize({ m_position.start_offset, m_position.end_offset }, style);
+        } else if (auto suggestions = shell.complete_program_name(m_text, m_text.bytes().size()); !suggestions.is_empty()) {
+            editor.stylize({ m_position.start_offset, m_position.end_offset }, { Line::Style::Foreground(Line::Style::XtermColor::Yellow) });
         } else {
             editor.stylize({ m_position.start_offset, m_position.end_offset }, { Line::Style::Foreground(Line::Style::XtermColor::Red) });
         }


### PR DESCRIPTION
Before, if a bareword wasn't a runnable program's filename it got colored red and white otherwise. Now, additionally it will be checked if it is a "prefix" of a possible command and colored yellow if it is and red if not.

Coloring this way provides another "feedback" to the user: If while typing out a command name the color changes from yellow to red then a typo occurred :^)

To check if a bareword is a prefix the `Shell::complete_program_name()` function is utilized (if pressing tab gives you some suggestions then it is a prefix).

---

![yellow-prefix](https://github.com/SerenityOS/serenity/assets/70647861/53099f16-9bac-49ad-b89d-66faee8d1897)

"se" is a prefix of "sed" and "sep" is not a command.

---

But... is checking for completions for every letter typed worth it for this feature?

---

When i first used serenity's terminal i thought of this feature. After looking around at wrong places (`SyntaxHighlighter.cpp`) i found the right place and it turned out that i could make it work with just 2 insertions!