### PR TITLE
LibWeb: Fix calculating the corner radius values for SVG <rect>

### DIFF
--- a/Userland/Libraries/LibWeb/SVG/SVGRectElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGRectElement.cpp
@@ -132,12 +132,12 @@ Gfx::FloatSize SVGRectElement::calculate_used_corner_radius_values() const
         ry = 0;
     }
     // 3. Otherwise, if a properly specified value is provided for ‘rx’, but not for ‘ry’, then set both rx and ry to the value of ‘rx’.
-    else if (m_radius_x.has_value()) {
+    else if (m_radius_x.has_value() && !m_radius_y.has_value()) {
         rx = m_radius_x.value();
         ry = m_radius_x.value();
     }
     // 4. Otherwise, if a properly specified value is provided for ‘ry’, but not for ‘rx’, then set both rx and ry to the value of ‘ry’.
-    else if (m_radius_y.has_value()) {
+    else if (m_radius_y.has_value() && !m_radius_x.has_value()) {
         rx = m_radius_y.value();
         ry = m_radius_y.value();
     }


### PR DESCRIPTION
Previously, this would treat having both rx and ry set as if just rx was set. The checks are now updated to match the spec comments above them :).

Small progression on Inkscape camera.svg:

**Before**
![image](https://github.com/SerenityOS/serenity/assets/11597044/40a0d041-d0c7-4832-8da5-397f51659e0b)

**After**
![image](https://github.com/SerenityOS/serenity/assets/11597044/daaae893-2c4d-4179-8120-c8031c5f544d)

