### PR TITLE
LibWeb: Parse :host() selector

### DIFF
--- a/Tests/LibWeb/Layout/expected/css-host-selector-gets-parsed.txt
+++ b/Tests/LibWeb/Layout/expected/css-host-selector-gets-parsed.txt
@@ -1,0 +1,14 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x100 children: not-inline
+      BlockContainer <div> at (8,8) content-size 100x100 children: inline
+        line 0 width: 26.953125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+          frag 0 from TextNode start: 0, length: 3, rect: [8,8 26.953125x17.46875]
+            "whf"
+        TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x100]
+      PaintableWithLines (BlockContainer<DIV>) [8,8 100x100]
+        TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/input/css-host-selector-gets-parsed.html
+++ b/Tests/LibWeb/Layout/input/css-host-selector-gets-parsed.html
@@ -1,0 +1,9 @@
+<style>
+:host, div { 
+    width: 100px;
+}
+:host(span), div { 
+    height: 100px;
+    background: green;
+}
+</style><div>whf

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -613,6 +613,17 @@ Parser::ParseErrorOr<Selector::SimpleSelector> Parser::parse_pseudo_simple_selec
                     .argument_selector_list = move(not_selector) }
             };
         }
+        if (pseudo_function.name().equals_ignoring_ascii_case("host"sv)) {
+            auto function_token_stream = TokenStream(pseudo_function.values());
+            auto host_selector = TRY(parse_a_selector_list(function_token_stream, SelectorType::Standalone));
+
+            return Selector::SimpleSelector {
+                .type = Selector::SimpleSelector::Type::PseudoClass,
+                .value = Selector::SimpleSelector::PseudoClass {
+                    .type = Selector::SimpleSelector::PseudoClass::Type::Host,
+                    .argument_selector_list = move(host_selector) }
+            };
+        }
         if (pseudo_function.name().equals_ignoring_ascii_case("lang"sv)) {
             if (pseudo_function.values().is_empty()) {
                 dbgln_if(CSS_PARSER_DEBUG, "Empty :lang() selector");

--- a/Userland/Libraries/LibWeb/Dump.cpp
+++ b/Userland/Libraries/LibWeb/Dump.cpp
@@ -574,6 +574,7 @@ void dump_selector(StringBuilder& builder, CSS::Selector const& selector)
                     builder.join(',', pseudo_class.languages);
                     builder.append(')');
                 } else if (pseudo_class.type == CSS::Selector::SimpleSelector::PseudoClass::Type::Not
+                    || pseudo_class.type == CSS::Selector::SimpleSelector::PseudoClass::Type::Host
                     || pseudo_class.type == CSS::Selector::SimpleSelector::PseudoClass::Type::Is
                     || pseudo_class.type == CSS::Selector::SimpleSelector::PseudoClass::Type::Where) {
                     builder.append("(["sv);


### PR DESCRIPTION
We were already parsing non-function-syntax `:host`, so let's also do the `:host(...)` variant. Note that we don't have matching for these yet.

This fixes many issues on sites generated by Wix, as they often have selector lists that include some `:host()` selector, and we'd reject the entire rule after failing to parse it.

This makes it much easier to contact my local pizza place!

Before:
![Screenshot at 2023-08-05 12-13-36](https://github.com/SerenityOS/serenity/assets/5954907/2301e19e-7bdd-47a8-9f64-35bd439b2c4e)

After:
![Screenshot at 2023-08-05 12-13-44](https://github.com/SerenityOS/serenity/assets/5954907/ab83ae1f-72ff-4829-9ec1-74771c06c69d)

