### PR TITLE
fortune: Use simple formatting when stdout isn't connected to a terminal

### DIFF
--- a/Base/usr/share/man/man1/fortune.md
+++ b/Base/usr/share/man/man1/fortune.md
@@ -5,12 +5,16 @@ fortune
 ## Synopsis
 
 ```sh
-$ fortune [path]
+$ fortune [--color when] [path]
 ```
 
 ## Description
 
 Open a fortune cookie, receive a free quote for the day!
+
+## Options
+
+* `--color when`: Chose when to color the output. Valid options are always, never and auto (default). When color is set to auto, color codes will be emitted when stdout is a terminal
 
 ## Arguments
 


### PR DESCRIPTION
This changes the default behavior, so that, by default, color codes, hyperlinks and additional spacing are only emitted when standard output is connected to a terminal.

The default coloring behavior can be overridden with the `--color` option. Valid arguments for this option are: 'always', 'never' and 'auto' (default).

My motivation for doing this was to improve the formatting of `fortune | cowsay`.

Before:
![fortune_telling_cow_before](https://github.com/SerenityOS/serenity/assets/2817754/b72ceb86-99b1-4bef-9fbd-35e7bdf37f87)


After:
![fortune_telling_cow_after](https://github.com/SerenityOS/serenity/assets/2817754/212d2f91-6f47-436f-8675-63dc2156c2f1)

