### PR TITLE
LibWeb: Make boxes with "overflow: scroll" actually scrollable

### DIFF
--- a/Tests/LibWeb/Layout/expected/misc/scroll.txt
+++ b/Tests/LibWeb/Layout/expected/misc/scroll.txt
@@ -1,0 +1,11 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x202 children: not-inline
+      BlockContainer <div#scrollbox> at (9,9) content-size 200x200 [BFC] children: not-inline
+        BlockContainer <div#content> at (9,9) content-size 200x1000 children: not-inline
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x202]
+      PaintableWithLines (BlockContainer<DIV>#scrollbox) [8,8 202x202] overflow: [9,9 200x1000] scroll-offset: [0,100]
+        PaintableWithLines (BlockContainer<DIV>#content) [9,9 200x1000]

--- a/Tests/LibWeb/Layout/input/misc/scroll.html
+++ b/Tests/LibWeb/Layout/input/misc/scroll.html
@@ -1,0 +1,22 @@
+<style>
+    #scrollbox {
+        width: 200px;
+        height: 200px;
+        overflow: scroll;
+        border: 1px solid black;
+    }
+
+    #content {
+        height: 1000px;
+    }
+</style>
+<script>
+    document.addEventListener(
+        "DOMContentLoaded",
+        function () {
+            document.getElementById("scrollbox").scroll(0, 100);
+        },
+        false
+    );
+</script>
+<div id="scrollbox"><div id="content"></div></div>

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -2230,7 +2230,7 @@ void Document::decrement_number_of_things_delaying_the_load_event(Badge<Document
 void Document::invalidate_stacking_context_tree()
 {
     if (auto* paintable_box = this->paintable_box())
-        const_cast<Painting::PaintableBox*>(paintable_box)->invalidate_stacking_context();
+        paintable_box->invalidate_stacking_context();
 }
 
 void Document::check_favicon_after_loading_link_resource()

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -1779,7 +1779,8 @@ HashMap<DeprecatedFlyString, CSS::StyleProperty> const& Element::custom_properti
 // https://drafts.csswg.org/cssom-view/#dom-element-scroll
 void Element::scroll(double x, double y)
 {
-    dbgln("FIXME: Implement Element::scroll(x: {}, y: {}", x, y);
+    // AD-HOC:
+    const_cast<Painting::PaintableBox*>(paintable_box())->scroll_by(x, y);
 }
 
 // https://drafts.csswg.org/cssom-view/#dom-element-scroll

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -1054,7 +1054,7 @@ void Element::set_scroll_left(double x)
     // FIXME: Implement this in terms of calling "scroll the element".
     auto scroll_offset = paintable_box()->scroll_offset();
     scroll_offset.set_x(static_cast<float>(x));
-    const_cast<Painting::PaintableBox*>(paintable_box())->set_scroll_offset(scroll_offset);
+    paintable_box()->set_scroll_offset(scroll_offset);
 }
 
 void Element::set_scroll_top(double y)
@@ -1122,7 +1122,7 @@ void Element::set_scroll_top(double y)
     // FIXME: Implement this in terms of calling "scroll the element".
     auto scroll_offset = paintable_box()->scroll_offset();
     scroll_offset.set_y(static_cast<float>(y));
-    const_cast<Painting::PaintableBox*>(paintable_box())->set_scroll_offset(scroll_offset);
+    paintable_box()->set_scroll_offset(scroll_offset);
 }
 
 // https://drafts.csswg.org/cssom-view/#dom-element-scrollwidth
@@ -1780,7 +1780,7 @@ HashMap<DeprecatedFlyString, CSS::StyleProperty> const& Element::custom_properti
 void Element::scroll(double x, double y)
 {
     // AD-HOC:
-    const_cast<Painting::PaintableBox*>(paintable_box())->scroll_by(x, y);
+    paintable_box()->scroll_by(x, y);
 }
 
 // https://drafts.csswg.org/cssom-view/#dom-element-scroll

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -1054,7 +1054,7 @@ void Element::set_scroll_left(double x)
     // FIXME: Implement this in terms of calling "scroll the element".
     auto scroll_offset = paintable_box()->scroll_offset();
     scroll_offset.set_x(static_cast<float>(x));
-    box->set_scroll_offset(scroll_offset);
+    const_cast<Painting::PaintableBox*>(paintable_box())->set_scroll_offset(scroll_offset);
 }
 
 void Element::set_scroll_top(double y)
@@ -1122,7 +1122,7 @@ void Element::set_scroll_top(double y)
     // FIXME: Implement this in terms of calling "scroll the element".
     auto scroll_offset = paintable_box()->scroll_offset();
     scroll_offset.set_y(static_cast<float>(y));
-    box->set_scroll_offset(scroll_offset);
+    const_cast<Painting::PaintableBox*>(paintable_box())->set_scroll_offset(scroll_offset);
 }
 
 // https://drafts.csswg.org/cssom-view/#dom-element-scrollwidth

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -943,11 +943,9 @@ double Element::scroll_top() const
     if (!layout_node() || !is<Layout::Box>(layout_node()))
         return 0.0;
 
-    auto const* box = static_cast<Layout::Box const*>(layout_node());
-
     // 9. Return the y-coordinate of the scrolling area at the alignment point with the top of the padding edge of the element.
     // FIXME: Is this correct?
-    return box->scroll_offset().y().to_double();
+    return paintable_box()->scroll_offset().y().to_double();
 }
 
 double Element::scroll_left() const
@@ -985,11 +983,9 @@ double Element::scroll_left() const
     if (!layout_node() || !is<Layout::Box>(layout_node()))
         return 0.0;
 
-    auto const* box = static_cast<Layout::Box const*>(layout_node());
-
     // 9. Return the x-coordinate of the scrolling area at the alignment point with the left of the padding edge of the element.
     // FIXME: Is this correct?
-    return box->scroll_offset().x().to_double();
+    return paintable_box()->scroll_offset().x().to_double();
 }
 
 // https://drafts.csswg.org/cssom-view/#dom-element-scrollleft
@@ -1056,7 +1052,7 @@ void Element::set_scroll_left(double x)
 
     // 11. Scroll the element to x,scrollTop, with the scroll behavior being "auto".
     // FIXME: Implement this in terms of calling "scroll the element".
-    auto scroll_offset = box->scroll_offset();
+    auto scroll_offset = paintable_box()->scroll_offset();
     scroll_offset.set_x(static_cast<float>(x));
     box->set_scroll_offset(scroll_offset);
 }
@@ -1124,7 +1120,7 @@ void Element::set_scroll_top(double y)
 
     // 11. Scroll the element to scrollLeft,y, with the scroll behavior being "auto".
     // FIXME: Implement this in terms of calling "scroll the element".
-    auto scroll_offset = box->scroll_offset();
+    auto scroll_offset = paintable_box()->scroll_offset();
     scroll_offset.set_y(static_cast<float>(y));
     box->set_scroll_offset(scroll_offset);
 }

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -314,6 +314,14 @@ public:
     void unregister_intersection_observer(Badge<IntersectionObserver::IntersectionObserver>, JS::NonnullGCPtr<IntersectionObserver::IntersectionObserver>);
     IntersectionObserver::IntersectionObserverRegistration& get_intersection_observer_registration(Badge<DOM::Document>, IntersectionObserver::IntersectionObserver const&);
 
+    enum class ScrollOffsetFor {
+        Self,
+        PseudoBefore,
+        PseudoAfter
+    };
+    CSSPixelPoint scroll_offset(ScrollOffsetFor type) const { return m_scroll_offset[to_underlying(type)]; }
+    void set_scroll_offset(ScrollOffsetFor type, CSSPixelPoint offset) { m_scroll_offset[to_underlying(type)] = offset; }
+
 protected:
     Element(Document&, DOM::QualifiedName);
     virtual JS::ThrowCompletionOr<void> initialize(JS::Realm&) override;
@@ -367,6 +375,8 @@ private:
     // https://www.w3.org/TR/intersection-observer/#dom-element-registeredintersectionobservers-slot
     // Element objects have an internal [[RegisteredIntersectionObservers]] slot, which is initialized to an empty list.
     Vector<IntersectionObserver::IntersectionObserverRegistration> m_registered_intersection_observers;
+
+    Array<CSSPixelPoint, 3> m_scroll_offset;
 };
 
 template<>

--- a/Userland/Libraries/LibWeb/DOM/Node.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Node.cpp
@@ -1454,6 +1454,15 @@ Painting::PaintableBox const* Node::paintable_box() const
     return static_cast<Layout::Box const&>(*layout_node()).paintable_box();
 }
 
+Painting::PaintableBox* Node::paintable_box()
+{
+    if (!layout_node())
+        return nullptr;
+    if (!layout_node()->is_box())
+        return nullptr;
+    return static_cast<Layout::Box&>(*layout_node()).paintable_box();
+}
+
 // https://dom.spec.whatwg.org/#queue-a-mutation-record
 void Node::queue_mutation_record(FlyString const& type, DeprecatedString attribute_name, DeprecatedString attribute_namespace, DeprecatedString old_value, Vector<JS::Handle<Node>> added_nodes, Vector<JS::Handle<Node>> removed_nodes, Node* previous_sibling, Node* next_sibling) const
 {

--- a/Userland/Libraries/LibWeb/DOM/Node.h
+++ b/Userland/Libraries/LibWeb/DOM/Node.h
@@ -183,6 +183,7 @@ public:
     Layout::Node* layout_node() { return m_layout_node; }
 
     Painting::PaintableBox const* paintable_box() const;
+    Painting::PaintableBox* paintable_box();
     Painting::Paintable const* paintable() const;
 
     void set_layout_node(Badge<Layout::Node>, JS::NonnullGCPtr<Layout::Node>);

--- a/Userland/Libraries/LibWeb/Dump.cpp
+++ b/Userland/Libraries/LibWeb/Dump.cpp
@@ -856,6 +856,10 @@ void dump_tree(StringBuilder& builder, Painting::Paintable const& paintable, boo
         if (paintable_box.has_scrollable_overflow()) {
             builder.appendff(" overflow: {}", paintable_box.scrollable_overflow_rect());
         }
+
+        if (!paintable_box.scroll_offset().is_zero()) {
+            builder.appendff(" scroll-offset: {}", paintable_box.scroll_offset());
+        }
     }
     builder.append("\n"sv);
     for (auto const* child = paintable.first_child(); child; child = child->next_sibling()) {

--- a/Userland/Libraries/LibWeb/Layout/Box.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Box.cpp
@@ -61,23 +61,10 @@ bool Box::is_scrollable() const
     return computed_values().overflow_y() == CSS::Overflow::Scroll;
 }
 
-CSSPixelPoint Box::scroll_offset() const
-{
-    if (is_generated_for_before_pseudo_element())
-        return pseudo_element_generator()->scroll_offset(DOM::Element::ScrollOffsetFor::PseudoBefore);
-    if (is_generated_for_after_pseudo_element())
-        return pseudo_element_generator()->scroll_offset(DOM::Element::ScrollOffsetFor::PseudoAfter);
-
-    if (!is<DOM::Element>(*dom_node()))
-        return {};
-
-    return static_cast<DOM::Element const*>(dom_node())->scroll_offset(DOM::Element::ScrollOffsetFor::Self);
-}
-
 void Box::set_scroll_offset(CSSPixelPoint offset)
 {
     // FIXME: If there is horizontal and vertical scroll ignore only part of the new offset
-    if (offset.y() < 0 || scroll_offset() == offset)
+    if (offset.y() < 0 || paintable_box()->scroll_offset() == offset)
         return;
 
     if (is_generated_for_before_pseudo_element()) {

--- a/Userland/Libraries/LibWeb/Layout/Box.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Box.cpp
@@ -61,12 +61,35 @@ bool Box::is_scrollable() const
     return computed_values().overflow_y() == CSS::Overflow::Scroll;
 }
 
+CSSPixelPoint Box::scroll_offset() const
+{
+    if (is_generated_for_before_pseudo_element())
+        return pseudo_element_generator()->scroll_offset(DOM::Element::ScrollOffsetFor::PseudoBefore);
+    if (is_generated_for_after_pseudo_element())
+        return pseudo_element_generator()->scroll_offset(DOM::Element::ScrollOffsetFor::PseudoAfter);
+
+    if (!is<DOM::Element>(*dom_node()))
+        return {};
+
+    return static_cast<DOM::Element const*>(dom_node())->scroll_offset(DOM::Element::ScrollOffsetFor::Self);
+}
+
 void Box::set_scroll_offset(CSSPixelPoint offset)
 {
     // FIXME: If there is horizontal and vertical scroll ignore only part of the new offset
-    if (offset.y() < 0 || m_scroll_offset == offset)
+    if (offset.y() < 0 || scroll_offset() == offset)
         return;
-    m_scroll_offset = offset;
+
+    if (is_generated_for_before_pseudo_element()) {
+        pseudo_element_generator()->set_scroll_offset(DOM::Element::ScrollOffsetFor::PseudoBefore, offset);
+    } else if (is_generated_for_after_pseudo_element()) {
+        pseudo_element_generator()->set_scroll_offset(DOM::Element::ScrollOffsetFor::PseudoAfter, offset);
+    } else if (is<DOM::Element>(*dom_node())) {
+        static_cast<DOM::Element*>(dom_node())->set_scroll_offset(DOM::Element::ScrollOffsetFor::Self, offset);
+    } else {
+        return;
+    }
+
     set_needs_display();
 }
 

--- a/Userland/Libraries/LibWeb/Layout/Box.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Box.cpp
@@ -77,6 +77,11 @@ JS::GCPtr<Painting::Paintable> Box::create_paintable() const
     return Painting::PaintableBox::create(*this);
 }
 
+Painting::PaintableBox* Box::paintable_box()
+{
+    return static_cast<Painting::PaintableBox*>(Node::paintable());
+}
+
 Painting::PaintableBox const* Box::paintable_box() const
 {
     return static_cast<Painting::PaintableBox const*>(Node::paintable());

--- a/Userland/Libraries/LibWeb/Layout/Box.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Box.cpp
@@ -61,25 +61,6 @@ bool Box::is_scrollable() const
     return computed_values().overflow_y() == CSS::Overflow::Scroll;
 }
 
-void Box::set_scroll_offset(CSSPixelPoint offset)
-{
-    // FIXME: If there is horizontal and vertical scroll ignore only part of the new offset
-    if (offset.y() < 0 || paintable_box()->scroll_offset() == offset)
-        return;
-
-    if (is_generated_for_before_pseudo_element()) {
-        pseudo_element_generator()->set_scroll_offset(DOM::Element::ScrollOffsetFor::PseudoBefore, offset);
-    } else if (is_generated_for_after_pseudo_element()) {
-        pseudo_element_generator()->set_scroll_offset(DOM::Element::ScrollOffsetFor::PseudoAfter, offset);
-    } else if (is<DOM::Element>(*dom_node())) {
-        static_cast<DOM::Element*>(dom_node())->set_scroll_offset(DOM::Element::ScrollOffsetFor::Self, offset);
-    } else {
-        return;
-    }
-
-    set_needs_display();
-}
-
 void Box::set_needs_display()
 {
     if (paintable_box())

--- a/Userland/Libraries/LibWeb/Layout/Box.h
+++ b/Userland/Libraries/LibWeb/Layout/Box.h
@@ -54,7 +54,6 @@ public:
     bool is_scroll_container() const;
 
     bool is_scrollable() const;
-    CSSPixelPoint scroll_offset() const;
     void set_scroll_offset(CSSPixelPoint);
 
 protected:

--- a/Userland/Libraries/LibWeb/Layout/Box.h
+++ b/Userland/Libraries/LibWeb/Layout/Box.h
@@ -54,7 +54,7 @@ public:
     bool is_scroll_container() const;
 
     bool is_scrollable() const;
-    CSSPixelPoint scroll_offset() const { return m_scroll_offset; }
+    CSSPixelPoint scroll_offset() const;
     void set_scroll_offset(CSSPixelPoint);
 
 protected:
@@ -63,8 +63,6 @@ protected:
 
 private:
     virtual bool is_box() const final { return true; }
-
-    CSSPixelPoint m_scroll_offset;
 
     Optional<CSSPixels> m_natural_width;
     Optional<CSSPixels> m_natural_height;

--- a/Userland/Libraries/LibWeb/Layout/Box.h
+++ b/Userland/Libraries/LibWeb/Layout/Box.h
@@ -54,7 +54,6 @@ public:
     bool is_scroll_container() const;
 
     bool is_scrollable() const;
-    void set_scroll_offset(CSSPixelPoint);
 
 protected:
     Box(DOM::Document&, DOM::Node*, NonnullRefPtr<CSS::StyleProperties>);

--- a/Userland/Libraries/LibWeb/Layout/Box.h
+++ b/Userland/Libraries/LibWeb/Layout/Box.h
@@ -23,6 +23,7 @@ class Box : public NodeWithStyleAndBoxModelMetrics {
 
 public:
     Painting::PaintableBox const* paintable_box() const;
+    Painting::PaintableBox* paintable_box();
 
     virtual void set_needs_display() override;
 

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -915,6 +915,18 @@ DOM::Node* Node::dom_node()
     return m_dom_node.ptr();
 }
 
+DOM::Element const* Node::pseudo_element_generator() const
+{
+    VERIFY(m_generated_for != GeneratedFor::NotGenerated);
+    return m_pseudo_element_generator.ptr();
+}
+
+DOM::Element* Node::pseudo_element_generator()
+{
+    VERIFY(m_generated_for != GeneratedFor::NotGenerated);
+    return m_pseudo_element_generator.ptr();
+}
+
 DOM::Document& Node::document()
 {
     return m_dom_node->document();

--- a/Userland/Libraries/LibWeb/Layout/Node.h
+++ b/Userland/Libraries/LibWeb/Layout/Node.h
@@ -46,8 +46,22 @@ public:
     DOM::Node const* dom_node() const;
     DOM::Node* dom_node();
 
-    bool is_generated() const { return m_generated; }
-    void set_generated(bool b) { m_generated = b; }
+    DOM::Element const* pseudo_element_generator() const;
+    DOM::Element* pseudo_element_generator();
+
+    enum class GeneratedFor {
+        NotGenerated,
+        PseudoBefore,
+        PseudoAfter
+    };
+    bool is_generated() const { return m_generated_for != GeneratedFor::NotGenerated; }
+    bool is_generated_for_before_pseudo_element() const { return m_generated_for == GeneratedFor::PseudoBefore; }
+    bool is_generated_for_after_pseudo_element() const { return m_generated_for == GeneratedFor::PseudoAfter; }
+    void set_generated_for(GeneratedFor type, DOM::Element& element)
+    {
+        m_generated_for = type;
+        m_pseudo_element_generator = &element;
+    }
 
     Painting::Paintable* paintable() { return m_paintable; }
     Painting::Paintable const* paintable() const { return m_paintable; }
@@ -169,6 +183,8 @@ private:
 
     JS::NonnullGCPtr<HTML::BrowsingContext> m_browsing_context;
 
+    JS::GCPtr<DOM::Element> m_pseudo_element_generator;
+
     bool m_anonymous { false };
     bool m_has_style { false };
     bool m_visible { true };
@@ -176,7 +192,7 @@ private:
     SelectionState m_selection_state { SelectionState::None };
 
     bool m_is_flex_item { false };
-    bool m_generated { false };
+    GeneratedFor m_generated_for { GeneratedFor::NotGenerated };
 };
 
 class NodeWithStyle : public Node {

--- a/Userland/Libraries/LibWeb/Layout/Viewport.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Viewport.cpp
@@ -33,24 +33,24 @@ void Viewport::build_stacking_context_tree_if_needed()
 
 void Viewport::build_stacking_context_tree()
 {
-    const_cast<Painting::PaintableBox*>(paintable_box())->set_stacking_context(make<Painting::StackingContext>(*this, nullptr, 0));
+    paintable_box()->set_stacking_context(make<Painting::StackingContext>(*this, nullptr, 0));
 
     size_t index_in_tree_order = 1;
     for_each_in_subtree_of_type<Box>([&](Box& box) {
         if (!box.paintable_box())
             return IterationDecision::Continue;
-        const_cast<Painting::PaintableBox*>(box.paintable_box())->invalidate_stacking_context();
+        box.paintable_box()->invalidate_stacking_context();
         if (!box.establishes_stacking_context()) {
             VERIFY(!box.paintable_box()->stacking_context());
             return IterationDecision::Continue;
         }
-        auto* parent_context = const_cast<Painting::PaintableBox*>(box.paintable_box())->enclosing_stacking_context();
+        auto* parent_context = box.paintable_box()->enclosing_stacking_context();
         VERIFY(parent_context);
-        const_cast<Painting::PaintableBox*>(box.paintable_box())->set_stacking_context(make<Painting::StackingContext>(box, parent_context, index_in_tree_order++));
+        box.paintable_box()->set_stacking_context(make<Painting::StackingContext>(box, parent_context, index_in_tree_order++));
         return IterationDecision::Continue;
     });
 
-    const_cast<Painting::PaintableBox*>(paintable_box())->stacking_context()->sort();
+    paintable_box()->stacking_context()->sort();
 }
 
 void Viewport::paint_all_phases(PaintContext& context)

--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -134,14 +134,14 @@ Painting::PaintableBox* EventHandler::paint_root()
 {
     if (!m_browsing_context->active_document())
         return nullptr;
-    return const_cast<Painting::PaintableBox*>(m_browsing_context->active_document()->paintable_box());
+    return m_browsing_context->active_document()->paintable_box();
 }
 
 Painting::PaintableBox const* EventHandler::paint_root() const
 {
     if (!m_browsing_context->active_document())
         return nullptr;
-    return const_cast<Painting::PaintableBox*>(m_browsing_context->active_document()->paintable_box());
+    return m_browsing_context->active_document()->paintable_box();
 }
 
 bool EventHandler::handle_mousewheel(CSSPixelPoint position, unsigned button, unsigned buttons, unsigned int modifiers, int wheel_delta_x, int wheel_delta_y)

--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -163,6 +163,15 @@ bool EventHandler::handle_mousewheel(CSSPixelPoint position, unsigned button, un
     if (auto result = target_for_mouse_position(position); result.has_value())
         paintable = result->paintable;
 
+    auto* containing_block = paintable->containing_block();
+    while (containing_block) {
+        if (containing_block->is_scrollable()) {
+            const_cast<Painting::PaintableBox*>(containing_block->paintable_box())->handle_mousewheel({}, position, buttons, modifiers, wheel_delta_x * scroll_step_size, wheel_delta_y * scroll_step_size);
+            break;
+        }
+        containing_block = containing_block->containing_block();
+    }
+
     if (paintable) {
         paintable->handle_mousewheel({}, position, buttons, modifiers, wheel_delta_x, wheel_delta_y);
 

--- a/Userland/Libraries/LibWeb/Painting/Paintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/Paintable.cpp
@@ -34,19 +34,8 @@ Paintable::DispatchEventOfSameName Paintable::handle_mousemove(Badge<EventHandle
     return DispatchEventOfSameName::Yes;
 }
 
-bool Paintable::handle_mousewheel(Badge<EventHandler>, CSSPixelPoint, unsigned, unsigned, int wheel_delta_x, int wheel_delta_y)
+bool Paintable::handle_mousewheel(Badge<EventHandler>, CSSPixelPoint, unsigned, unsigned, int, int)
 {
-    if (auto const* containing_block = this->containing_block()) {
-        if (!containing_block->is_scrollable())
-            return false;
-        auto new_offset = containing_block->scroll_offset();
-        new_offset.translate_by(wheel_delta_x, wheel_delta_y);
-        // FIXME: This const_cast is gross.
-        // FIXME: Scroll offset shouldn't live in the layout tree.
-        const_cast<Layout::Box*>(containing_block)->set_scroll_offset(new_offset);
-        return true;
-    }
-
     return false;
 }
 

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -663,13 +663,16 @@ void PaintableWithLines::paint(PaintContext& context, PaintPhase phase) const
     }
 }
 
-bool PaintableWithLines::handle_mousewheel(Badge<EventHandler>, CSSPixelPoint, unsigned, unsigned, int wheel_delta_x, int wheel_delta_y)
+bool PaintableBox::handle_mousewheel(Badge<EventHandler>, CSSPixelPoint, unsigned, unsigned, int wheel_delta_x, int wheel_delta_y)
 {
     if (!layout_box().is_scrollable())
         return false;
-    auto new_offset = layout_box().scroll_offset();
-    new_offset.translate_by(wheel_delta_x, wheel_delta_y);
-    layout_box().set_scroll_offset(new_offset);
+    auto max_x_offset = scrollable_overflow_rect()->width() - content_size().width();
+    auto max_y_offset = scrollable_overflow_rect()->height() - content_size().height();
+    auto current_offset = layout_box().scroll_offset();
+    auto new_offset_x = clamp(current_offset.x() + wheel_delta_x, 0, max_x_offset);
+    auto new_offset_y = clamp(current_offset.y() + wheel_delta_y, 0, max_y_offset);
+    layout_box().set_scroll_offset({ new_offset_x, new_offset_y });
     return true;
 }
 

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -57,6 +57,19 @@ PaintableWithLines::~PaintableWithLines()
 {
 }
 
+void PaintableBox::scroll_by(int delta_x, int delta_y)
+{
+    auto scrollable_overflow_rect = this->scrollable_overflow_rect();
+    if (!scrollable_overflow_rect.has_value())
+        return;
+    auto max_x_offset = scrollable_overflow_rect->width() - content_size().width();
+    auto max_y_offset = scrollable_overflow_rect->height() - content_size().height();
+    auto current_offset = layout_box().scroll_offset();
+    auto new_offset_x = clamp(current_offset.x() + delta_x, 0, max_x_offset);
+    auto new_offset_y = clamp(current_offset.y() + delta_y, 0, max_y_offset);
+    layout_box().set_scroll_offset({ new_offset_x, new_offset_y });
+}
+
 void PaintableBox::set_offset(CSSPixelPoint offset)
 {
     m_offset = offset;
@@ -667,12 +680,7 @@ bool PaintableBox::handle_mousewheel(Badge<EventHandler>, CSSPixelPoint, unsigne
 {
     if (!layout_box().is_scrollable())
         return false;
-    auto max_x_offset = scrollable_overflow_rect()->width() - content_size().width();
-    auto max_y_offset = scrollable_overflow_rect()->height() - content_size().height();
-    auto current_offset = layout_box().scroll_offset();
-    auto new_offset_x = clamp(current_offset.x() + wheel_delta_x, 0, max_x_offset);
-    auto new_offset_y = clamp(current_offset.y() + wheel_delta_y, 0, max_y_offset);
-    layout_box().set_scroll_offset({ new_offset_x, new_offset_y });
+    scroll_by(wheel_delta_x, wheel_delta_y);
     return true;
 }
 

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -65,7 +65,7 @@ CSSPixelPoint PaintableBox::scroll_offset() const
     if (node.is_generated_for_after_pseudo_element())
         return node.pseudo_element_generator()->scroll_offset(DOM::Element::ScrollOffsetFor::PseudoAfter);
 
-    if (!is<DOM::Element>(*dom_node()))
+    if (!(dom_node() && is<DOM::Element>(*dom_node())))
         return {};
 
     return static_cast<DOM::Element const*>(dom_node())->scroll_offset(DOM::Element::ScrollOffsetFor::Self);

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.h
@@ -39,6 +39,7 @@ public:
     CSSPixelPoint effective_offset() const;
 
     CSSPixelPoint scroll_offset() const;
+    void set_scroll_offset(CSSPixelPoint);
     void scroll_by(int delta_x, int delta_y);
 
     void set_offset(CSSPixelPoint);

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.h
@@ -126,6 +126,8 @@ public:
 
     virtual Optional<HitTestResult> hit_test(CSSPixelPoint, HitTestType) const override;
 
+    virtual bool handle_mousewheel(Badge<EventHandler>, CSSPixelPoint, unsigned buttons, unsigned modifiers, int wheel_delta_x, int wheel_delta_y) override;
+
     void invalidate_stacking_context();
 
     bool is_out_of_view(PaintContext&) const;
@@ -235,7 +237,6 @@ public:
 
     virtual void paint(PaintContext&, PaintPhase) const override;
     virtual bool wants_mouse_events() const override { return false; }
-    virtual bool handle_mousewheel(Badge<EventHandler>, CSSPixelPoint, unsigned buttons, unsigned modifiers, int wheel_delta_x, int wheel_delta_y) override;
 
     virtual Optional<HitTestResult> hit_test(CSSPixelPoint, HitTestType) const override;
 

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.h
@@ -38,6 +38,7 @@ public:
     CSSPixelRect absolute_rect() const;
     CSSPixelPoint effective_offset() const;
 
+    CSSPixelPoint scroll_offset() const;
     void scroll_by(int delta_x, int delta_y);
 
     void set_offset(CSSPixelPoint);

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.h
@@ -38,6 +38,8 @@ public:
     CSSPixelRect absolute_rect() const;
     CSSPixelPoint effective_offset() const;
 
+    void scroll_by(int delta_x, int delta_y);
+
     void set_offset(CSSPixelPoint);
     void set_offset(float x, float y) { set_offset({ x, y }); }
 

--- a/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -29,7 +29,7 @@ static void paint_node(Layout::Node const& layout_node, PaintContext& context, P
     if (auto const* paintable = layout_node.paintable()) {
         if (paintable->containing_block() && paintable->containing_block()->is_scrollable()) {
             Gfx::PainterStateSaver saver(context.painter());
-            auto scroll_offset = -paintable->containing_block()->scroll_offset();
+            auto scroll_offset = -paintable->containing_block()->paintable_box()->scroll_offset();
             context.painter().translate({ context.enclosing_device_pixels(scroll_offset.x()), context.enclosing_device_pixels(scroll_offset.y()) });
             paintable->paint(context, phase);
         } else {

--- a/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -26,8 +26,16 @@ namespace Web::Painting {
 
 static void paint_node(Layout::Node const& layout_node, PaintContext& context, PaintPhase phase)
 {
-    if (auto const* paintable = layout_node.paintable())
-        paintable->paint(context, phase);
+    if (auto const* paintable = layout_node.paintable()) {
+        if (paintable->containing_block() && paintable->containing_block()->is_scrollable()) {
+            Gfx::PainterStateSaver saver(context.painter());
+            auto scroll_offset = -paintable->containing_block()->scroll_offset();
+            context.painter().translate({ context.enclosing_device_pixels(scroll_offset.x()), context.enclosing_device_pixels(scroll_offset.y()) });
+            paintable->paint(context, phase);
+        } else {
+            paintable->paint(context, phase);
+        }
+    }
 }
 
 StackingContext::StackingContext(Layout::Box& box, StackingContext* parent, size_t index_in_tree_order)


### PR DESCRIPTION
Implements very basic support for scrolling "overflow: scroll" boxes.

Following improvements are made:
- Painting takes in account scroll offset
- Scrollable overflow rectangle limits from `scrollable_overflow_rect()` are taken in account now.
- Scroll offset state is moved from layout tree to dom tree
- EventHandler does slightly better work at finding scrollable target to trigger wheel event handling

There still many things left to implement in the future:
- Layout tree nodes still have functions to get/set scroll offset although they should not
- Scroll offset doesn't behave right when resize happens
- Event handler works very naive when it comes to finding target for wheel events
- Many other things

Example that allows to test improvements made with these changes:
```html
<!DOCTYPE html>
<style>
  .container {
    width: 300px;
    height: 300px;
    overflow: scroll;
    border: 1px solid black;
    font-size: 30px;
  }
</style>
<div class="container">
  <p>
    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed aliquam sapien
    ut felis laoreet, et aliquam libero tincidunt. Donec vel eleifend odio. Duis
    euismod ex ut magna auctor tincidunt. Ut faucibus vestibulum enim, sit amet
    interdum dolor tristique quis. Fusce luctus massa ac nisl eleifend, ac
    ullamcorper purus convallis. Integer bibendum, turpis a posuere bibendum,
    ipsum velit commodo nisi, nec tincidunt odio justo nec elit. Duis pharetra
    eu erat ut dignissim. Sed eu erat eu libero vulputate sodales. Fusce eget
    massa vel metus feugiat rhoncus eget eget arcu.
  </p>
</div>
```