### PR TITLE
LibGUI+LibCore: Move GML property system from LibCore to LibGUI

### DIFF
--- a/Userland/Libraries/LibCore/CMakeLists.txt
+++ b/Userland/Libraries/LibCore/CMakeLists.txt
@@ -21,7 +21,6 @@ set(SOURCES
     Object.cpp
     Process.cpp
     ProcessStatisticsReader.cpp
-    Property.cpp
     SecretString.cpp
     SessionManagement.cpp
     Socket.cpp

--- a/Userland/Libraries/LibCore/Object.cpp
+++ b/Userland/Libraries/LibCore/Object.cpp
@@ -136,22 +136,6 @@ void Object::stop_timer()
     m_timer_id = 0;
 }
 
-void Object::dump_tree(int indent)
-{
-    for (int i = 0; i < indent; ++i) {
-        out(" ");
-    }
-    out("{}{{{:p}}}", class_name(), this);
-    if (!name().is_null())
-        out(" {}", name());
-    outln();
-
-    for_each_child([&](auto& child) {
-        child.dump_tree(indent + 2);
-        return IterationDecision::Continue;
-    });
-}
-
 void Object::deferred_invoke(Function<void()> invokee)
 {
     Core::deferred_invoke([invokee = move(invokee), strong_this = NonnullRefPtr(*this)] { invokee(); });

--- a/Userland/Libraries/LibCore/Object.cpp
+++ b/Userland/Libraries/LibCore/Object.cpp
@@ -192,20 +192,6 @@ bool Object::is_visible_for_timer_purposes() const
     return true;
 }
 
-void Object::increment_inspector_count(Badge<InspectorServerConnection>)
-{
-    ++m_inspector_count;
-    if (m_inspector_count == 1)
-        did_begin_inspection();
-}
-
-void Object::decrement_inspector_count(Badge<InspectorServerConnection>)
-{
-    --m_inspector_count;
-    if (!m_inspector_count)
-        did_end_inspection();
-}
-
 void Object::set_event_filter(Function<bool(Core::Event&)> filter)
 {
     m_event_filter = move(filter);

--- a/Userland/Libraries/LibCore/Object.cpp
+++ b/Userland/Libraries/LibCore/Object.cpp
@@ -15,16 +15,9 @@
 
 namespace Core {
 
-IntrusiveList<&Object::m_all_objects_list_node>& Object::all_objects()
-{
-    static IntrusiveList<&Object::m_all_objects_list_node> objects;
-    return objects;
-}
-
 Object::Object(Object* parent)
     : m_parent(parent)
 {
-    all_objects().append(*this);
     if (m_parent)
         m_parent->add_child(*this);
 }
@@ -39,7 +32,6 @@ Object::~Object()
     for (auto& child : children)
         child->m_parent = nullptr;
 
-    all_objects().remove(*this);
     stop_timer();
     if (m_parent)
         m_parent->remove_child(*this);

--- a/Userland/Libraries/LibCore/Object.h
+++ b/Userland/Libraries/LibCore/Object.h
@@ -11,7 +11,6 @@
 #include <AK/Forward.h>
 #include <AK/Function.h>
 #include <AK/HashMap.h>
-#include <AK/IntrusiveList.h>
 #include <AK/Noncopyable.h>
 #include <AK/OwnPtr.h>
 #include <AK/StringView.h>
@@ -59,8 +58,6 @@ class Object
 
     AK_MAKE_NONCOPYABLE(Object);
     AK_MAKE_NONMOVABLE(Object);
-
-    IntrusiveListNode<Object> m_all_objects_list_node;
 
 public:
     virtual ~Object();
@@ -134,8 +131,6 @@ public:
     void dump_tree(int indent = 0);
 
     void deferred_invoke(Function<void()>);
-
-    static IntrusiveList<&Object::m_all_objects_list_node>& all_objects();
 
     void dispatch_event(Core::Event&, Object* stay_within = nullptr);
 

--- a/Userland/Libraries/LibCore/Object.h
+++ b/Userland/Libraries/LibCore/Object.h
@@ -20,8 +20,6 @@
 
 namespace Core {
 
-class InspectorServerConnection;
-
 enum class TimerShouldFireWhenNotVisible {
     No = 0,
     Yes
@@ -158,11 +156,6 @@ public:
 
     virtual bool is_visible_for_timer_purposes() const;
 
-    bool is_being_inspected() const { return m_inspector_count; }
-
-    void increment_inspector_count(Badge<InspectorServerConnection>);
-    void decrement_inspector_count(Badge<InspectorServerConnection>);
-
 protected:
     explicit Object(Object* parent = nullptr);
 
@@ -174,14 +167,10 @@ protected:
     // NOTE: You may get child events for children that are not yet fully constructed!
     virtual void child_event(ChildEvent&);
 
-    virtual void did_begin_inspection() { }
-    virtual void did_end_inspection() { }
-
 private:
     Object* m_parent { nullptr };
     DeprecatedString m_name;
     int m_timer_id { 0 };
-    unsigned m_inspector_count { 0 };
     Vector<NonnullRefPtr<Object>> m_children;
     Function<bool(Core::Event&)> m_event_filter;
 };

--- a/Userland/Libraries/LibCore/Object.h
+++ b/Userland/Libraries/LibCore/Object.h
@@ -126,8 +126,6 @@ public:
 
     void set_event_filter(Function<bool(Core::Event&)>);
 
-    void dump_tree(int indent = 0);
-
     void deferred_invoke(Function<void()>);
 
     void dispatch_event(Core::Event&, Object* stay_within = nullptr);

--- a/Userland/Libraries/LibCore/Object.h
+++ b/Userland/Libraries/LibCore/Object.h
@@ -9,6 +9,7 @@
 
 #include <AK/DeprecatedString.h>
 #include <AK/Forward.h>
+#include <AK/Function.h>
 #include <AK/HashMap.h>
 #include <AK/IntrusiveList.h>
 #include <AK/Noncopyable.h>
@@ -17,45 +18,8 @@
 #include <AK/TypeCasts.h>
 #include <AK/Weakable.h>
 #include <LibCore/Forward.h>
-#include <LibCore/Property.h>
 
 namespace Core {
-
-#define REGISTER_ABSTRACT_CORE_OBJECT(namespace_, class_name)                                                                                                                             \
-    namespace Core {                                                                                                                                                                      \
-    namespace Registration {                                                                                                                                                              \
-    Core::ObjectClassRegistration registration_##class_name(#namespace_ "::" #class_name##sv, []() { return Error::from_string_literal("Attempted to construct an abstract object."); }); \
-    }                                                                                                                                                                                     \
-    }
-
-#define REGISTER_CORE_OBJECT(namespace_, class_name)                                                                                                  \
-    namespace Core {                                                                                                                                  \
-    namespace Registration {                                                                                                                          \
-    Core::ObjectClassRegistration registration_##class_name(#namespace_ "::" #class_name##sv, []() { return namespace_::class_name::try_create(); }); \
-    }                                                                                                                                                 \
-    }
-
-class ObjectClassRegistration {
-    AK_MAKE_NONCOPYABLE(ObjectClassRegistration);
-    AK_MAKE_NONMOVABLE(ObjectClassRegistration);
-
-public:
-    ObjectClassRegistration(StringView class_name, Function<ErrorOr<NonnullRefPtr<Object>>()> factory, ObjectClassRegistration* parent_class = nullptr);
-    ~ObjectClassRegistration() = default;
-
-    StringView class_name() const { return m_class_name; }
-    ObjectClassRegistration const* parent_class() const { return m_parent_class; }
-    ErrorOr<NonnullRefPtr<Object>> construct() const { return m_factory(); }
-    bool is_derived_from(ObjectClassRegistration const& base_class) const;
-
-    static void for_each(Function<void(ObjectClassRegistration const&)>);
-    static ObjectClassRegistration const* find(StringView class_name);
-
-private:
-    StringView m_class_name;
-    Function<ErrorOr<NonnullRefPtr<Object>>()> m_factory;
-    ObjectClassRegistration* m_parent_class { nullptr };
-};
 
 class InspectorServerConnection;
 
@@ -171,10 +135,6 @@ public:
 
     void deferred_invoke(Function<void()>);
 
-    bool set_property(DeprecatedString const& name, JsonValue const& value);
-    JsonValue property(DeprecatedString const& name) const;
-    HashMap<DeprecatedString, NonnullOwnPtr<Property>> const& properties() const { return m_properties; }
-
     static IntrusiveList<&Object::m_all_objects_list_node>& all_objects();
 
     void dispatch_event(Core::Event&, Object* stay_within = nullptr);
@@ -211,8 +171,6 @@ public:
 protected:
     explicit Object(Object* parent = nullptr);
 
-    void register_property(DeprecatedString const& name, Function<JsonValue()> getter, Function<bool(JsonValue const&)> setter = nullptr);
-
     virtual void event(Core::Event&);
 
     virtual void timer_event(TimerEvent&);
@@ -229,7 +187,6 @@ private:
     DeprecatedString m_name;
     int m_timer_id { 0 };
     unsigned m_inspector_count { 0 };
-    HashMap<DeprecatedString, NonnullOwnPtr<Property>> m_properties;
     Vector<NonnullRefPtr<Object>> m_children;
     Function<bool(Core::Event&)> m_event_filter;
 };
@@ -289,186 +246,4 @@ requires IsBaseOf<Object, T>
     return found_child;
 }
 
-#define REGISTER_INT_PROPERTY(property_name, getter, setter) \
-    register_property(                                       \
-        property_name,                                       \
-        [this] { return this->getter(); },                   \
-        [this](auto& value) {                                \
-            this->setter(value.template to_number<int>());   \
-            return true;                                     \
-        });
-
-#define REGISTER_BOOL_PROPERTY(property_name, getter, setter) \
-    register_property(                                        \
-        property_name,                                        \
-        [this] { return this->getter(); },                    \
-        [this](auto& value) {                                 \
-            this->setter(value.to_bool());                    \
-            return true;                                      \
-        });
-
-// FIXME: Port JsonValue to the new String class.
-#define REGISTER_STRING_PROPERTY(property_name, getter, setter)                                                                           \
-    register_property(                                                                                                                    \
-        property_name,                                                                                                                    \
-        [this]() { return this->getter().to_deprecated_string(); },                                                                       \
-        [this](auto& value) {                                                                                                             \
-            this->setter(String::from_deprecated_string(value.to_deprecated_string()).release_value_but_fixme_should_propagate_errors()); \
-            return true;                                                                                                                  \
-        });
-
-#define REGISTER_DEPRECATED_STRING_PROPERTY(property_name, getter, setter) \
-    register_property(                                                     \
-        property_name,                                                     \
-        [this] { return this->getter(); },                                 \
-        [this](auto& value) {                                              \
-            this->setter(value.to_deprecated_string());                    \
-            return true;                                                   \
-        });
-
-#define REGISTER_READONLY_STRING_PROPERTY(property_name, getter) \
-    register_property(                                           \
-        property_name,                                           \
-        [this] { return this->getter(); },                       \
-        {});
-
-#define REGISTER_WRITE_ONLY_STRING_PROPERTY(property_name, setter) \
-    register_property(                                             \
-        property_name,                                             \
-        {},                                                        \
-        [this](auto& value) {                                      \
-            this->setter(value.to_deprecated_string());            \
-            return true;                                           \
-        });
-
-#define REGISTER_READONLY_SIZE_PROPERTY(property_name, getter) \
-    register_property(                                         \
-        property_name,                                         \
-        [this] {                                               \
-            auto size = this->getter();                        \
-            JsonArray size_array;                              \
-            size_array.must_append(size.width());              \
-            size_array.must_append(size.height());             \
-            return size_array;                                 \
-        },                                                     \
-        {});
-
-#define REGISTER_RECT_PROPERTY(property_name, getter, setter)                       \
-    register_property(                                                              \
-        property_name,                                                              \
-        [this] {                                                                    \
-            auto rect = this->getter();                                             \
-            JsonObject rect_object;                                                 \
-            rect_object.set("x"sv, rect.x());                                       \
-            rect_object.set("y"sv, rect.y());                                       \
-            rect_object.set("width"sv, rect.width());                               \
-            rect_object.set("height"sv, rect.height());                             \
-            return rect_object;                                                     \
-        },                                                                          \
-        [this](auto& value) {                                                       \
-            Gfx::IntRect rect;                                                      \
-            if (value.is_object()) {                                                \
-                rect.set_x(value.as_object().get_i32("x"sv).value_or(0));           \
-                rect.set_y(value.as_object().get_i32("y"sv).value_or(0));           \
-                rect.set_width(value.as_object().get_i32("width"sv).value_or(0));   \
-                rect.set_height(value.as_object().get_i32("height"sv).value_or(0)); \
-            } else if (value.is_array() && value.as_array().size() == 4) {          \
-                rect.set_x(value.as_array()[0].to_i32());                           \
-                rect.set_y(value.as_array()[1].to_i32());                           \
-                rect.set_width(value.as_array()[2].to_i32());                       \
-                rect.set_height(value.as_array()[3].to_i32());                      \
-            } else {                                                                \
-                return false;                                                       \
-            }                                                                       \
-            setter(rect);                                                           \
-                                                                                    \
-            return true;                                                            \
-        });
-
-#define REGISTER_SIZE_PROPERTY(property_name, getter, setter) \
-    register_property(                                        \
-        property_name,                                        \
-        [this] {                                              \
-            auto size = this->getter();                       \
-            JsonArray size_array;                             \
-            size_array.must_append(size.width());             \
-            size_array.must_append(size.height());            \
-            return size_array;                                \
-        },                                                    \
-        [this](auto& value) {                                 \
-            if (!value.is_array())                            \
-                return false;                                 \
-            Gfx::IntSize size;                                \
-            size.set_width(value.as_array()[0].to_i32());     \
-            size.set_height(value.as_array()[1].to_i32());    \
-            setter(size);                                     \
-            return true;                                      \
-        });
-
-#define REGISTER_ENUM_PROPERTY(property_name, getter, setter, EnumType, ...) \
-    register_property(                                                       \
-        property_name,                                                       \
-        [this]() -> JsonValue {                                              \
-            struct {                                                         \
-                EnumType enum_value;                                         \
-                DeprecatedString string_value;                               \
-            } options[] = { __VA_ARGS__ };                                   \
-            auto enum_value = getter();                                      \
-            for (size_t i = 0; i < array_size(options); ++i) {               \
-                auto& option = options[i];                                   \
-                if (enum_value == option.enum_value)                         \
-                    return option.string_value;                              \
-            }                                                                \
-            return JsonValue();                                              \
-        },                                                                   \
-        [this](auto& value) {                                                \
-            struct {                                                         \
-                EnumType enum_value;                                         \
-                DeprecatedString string_value;                               \
-            } options[] = { __VA_ARGS__ };                                   \
-            if (!value.is_string())                                          \
-                return false;                                                \
-            auto string_value = value.as_string();                           \
-            for (size_t i = 0; i < array_size(options); ++i) {               \
-                auto& option = options[i];                                   \
-                if (string_value == option.string_value) {                   \
-                    setter(option.enum_value);                               \
-                    return true;                                             \
-                }                                                            \
-            }                                                                \
-            return false;                                                    \
-        })
-
-#define REGISTER_TEXT_ALIGNMENT_PROPERTY(property_name, getter, setter) \
-    REGISTER_ENUM_PROPERTY(                                             \
-        property_name, getter, setter, Gfx::TextAlignment,              \
-        { Gfx::TextAlignment::Center, "Center" },                       \
-        { Gfx::TextAlignment::CenterLeft, "CenterLeft" },               \
-        { Gfx::TextAlignment::CenterRight, "CenterRight" },             \
-        { Gfx::TextAlignment::TopCenter, "TopCenter" },                 \
-        { Gfx::TextAlignment::TopLeft, "TopLeft" },                     \
-        { Gfx::TextAlignment::TopRight, "TopRight" },                   \
-        { Gfx::TextAlignment::BottomCenter, "BottomCenter" },           \
-        { Gfx::TextAlignment::BottomLeft, "BottomLeft" },               \
-        { Gfx::TextAlignment::BottomRight, "BottomRight" })
-
-#define REGISTER_FONT_WEIGHT_PROPERTY(property_name, getter, setter) \
-    REGISTER_ENUM_PROPERTY(                                          \
-        property_name, getter, setter, unsigned,                     \
-        { Gfx::FontWeight::Thin, "Thin" },                           \
-        { Gfx::FontWeight::ExtraLight, "ExtraLight" },               \
-        { Gfx::FontWeight::Light, "Light" },                         \
-        { Gfx::FontWeight::Regular, "Regular" },                     \
-        { Gfx::FontWeight::Medium, "Medium" },                       \
-        { Gfx::FontWeight::SemiBold, "SemiBold" },                   \
-        { Gfx::FontWeight::Bold, "Bold" },                           \
-        { Gfx::FontWeight::ExtraBold, "ExtraBold" },                 \
-        { Gfx::FontWeight::Black, "Black" },                         \
-        { Gfx::FontWeight::ExtraBlack, "ExtraBlack" })
-
-#define REGISTER_TEXT_WRAPPING_PROPERTY(property_name, getter, setter) \
-    REGISTER_ENUM_PROPERTY(                                            \
-        property_name, getter, setter, Gfx::TextWrapping,              \
-        { Gfx::TextWrapping::Wrap, "Wrap" },                           \
-        { Gfx::TextWrapping::DontWrap, "DontWrap" })
 }

--- a/Userland/Libraries/LibGUI/CMakeLists.txt
+++ b/Userland/Libraries/LibGUI/CMakeLists.txt
@@ -79,6 +79,7 @@ set(SOURCES
     MouseTracker.cpp
     MultiView.cpp
     Notification.cpp
+    Object.cpp
     OpacitySlider.cpp
     Painter.cpp
     PasswordInputDialog.cpp
@@ -87,6 +88,7 @@ set(SOURCES
     Process.cpp
     ProcessChooser.cpp
     Progressbar.cpp
+    Property.cpp
     RadioButton.cpp
     RangeSlider.cpp
     RegularEditingEngine.cpp

--- a/Userland/Libraries/LibGUI/Forward.h
+++ b/Userland/Libraries/LibGUI/Forward.h
@@ -54,6 +54,7 @@ class ModelIndex;
 class MouseEvent;
 class MultiPaintEvent;
 class MultiView;
+class Object;
 class OpacitySlider;
 class PaintEvent;
 class Painter;

--- a/Userland/Libraries/LibGUI/GML/AutocompleteProvider.cpp
+++ b/Userland/Libraries/LibGUI/GML/AutocompleteProvider.cpp
@@ -107,8 +107,8 @@ void AutocompleteProvider::provide_completions(Function<void(Vector<CodeComprehe
         state = previous_states.take_last();
     }
 
-    auto& widget_class = *Core::ObjectClassRegistration::find("GUI::Widget"sv);
-    auto& layout_class = *Core::ObjectClassRegistration::find("GUI::Layout"sv);
+    auto& widget_class = *GUI::ObjectClassRegistration::find("GUI::Widget"sv);
+    auto& layout_class = *GUI::ObjectClassRegistration::find("GUI::Layout"sv);
 
     // FIXME: Can this be done without a StringBuilder?
     auto make_fuzzy = [](StringView str) {
@@ -124,14 +124,14 @@ void AutocompleteProvider::provide_completions(Function<void(Vector<CodeComprehe
     Vector<CodeComprehension::AutocompleteResultEntry> class_entries, identifier_entries;
 
     auto register_layouts_matching_pattern = [&](DeprecatedString pattern, size_t partial_input_length) {
-        Core::ObjectClassRegistration::for_each([&](const Core::ObjectClassRegistration& registration) {
+        GUI::ObjectClassRegistration::for_each([&](const GUI::ObjectClassRegistration& registration) {
             if (registration.is_derived_from(layout_class) && &registration != &layout_class && registration.class_name().matches(pattern))
                 class_entries.empend(DeprecatedString::formatted("@{}", registration.class_name()), partial_input_length);
         });
     };
 
     auto register_widgets_matching_pattern = [&](DeprecatedString pattern, size_t partial_input_length) {
-        Core::ObjectClassRegistration::for_each([&](const Core::ObjectClassRegistration& registration) {
+        GUI::ObjectClassRegistration::for_each([&](const GUI::ObjectClassRegistration& registration) {
             if (registration.is_derived_from(widget_class) && registration.class_name().matches(pattern))
                 class_entries.empend(DeprecatedString::formatted("@{}", registration.class_name()), partial_input_length);
         });
@@ -141,7 +141,7 @@ void AutocompleteProvider::provide_completions(Function<void(Vector<CodeComprehe
         auto class_name = class_names.last();
 
         // FIXME: Don't show properties that are already specified in the scope.
-        auto registration = Core::ObjectClassRegistration::find(class_name);
+        auto registration = GUI::ObjectClassRegistration::find(class_name);
         if (registration && (registration->is_derived_from(widget_class) || registration->is_derived_from(layout_class))) {
             if (auto instance = registration->construct(); !instance.is_error()) {
                 for (auto& it : instance.value()->properties()) {
@@ -161,7 +161,7 @@ void AutocompleteProvider::provide_completions(Function<void(Vector<CodeComprehe
         if (!class_names.is_empty()) {
             register_class_properties_matching_pattern(pattern, partial_input_length);
 
-            auto parent_registration = Core::ObjectClassRegistration::find(class_names.last());
+            auto parent_registration = GUI::ObjectClassRegistration::find(class_names.last());
             if (parent_registration && parent_registration->is_derived_from(layout_class)) {
                 // Layouts can't have child classes, so why suggest them?
                 return;

--- a/Userland/Libraries/LibGUI/Layout.cpp
+++ b/Userland/Libraries/LibGUI/Layout.cpp
@@ -10,7 +10,7 @@
 #include <LibGUI/Layout.h>
 #include <LibGUI/Widget.h>
 
-REGISTER_ABSTRACT_CORE_OBJECT(GUI, Layout)
+REGISTER_ABSTRACT_GUI_OBJECT(GUI, Layout)
 
 namespace GUI {
 

--- a/Userland/Libraries/LibGUI/Layout.h
+++ b/Userland/Libraries/LibGUI/Layout.h
@@ -9,25 +9,25 @@
 #include <AK/OwnPtr.h>
 #include <AK/Vector.h>
 #include <AK/WeakPtr.h>
-#include <LibCore/Object.h>
 #include <LibGUI/Forward.h>
 #include <LibGUI/Margins.h>
+#include <LibGUI/Object.h>
 #include <LibGUI/UIDimensions.h>
 #include <LibGfx/Forward.h>
 
-namespace Core::Registration {
-extern Core::ObjectClassRegistration registration_Layout;
+namespace GUI::Registration {
+extern GUI::ObjectClassRegistration registration_Layout;
 }
 
-#define REGISTER_LAYOUT(namespace_, class_name)                                                                                                       \
-    namespace Core::Registration {                                                                                                                    \
-    Core::ObjectClassRegistration registration_##class_name(                                                                                          \
-        #namespace_ "::" #class_name##sv, []() { return static_ptr_cast<Core::Object>(namespace_::class_name::construct()); }, &registration_Layout); \
+#define REGISTER_LAYOUT(namespace_, class_name)                                                                                                      \
+    namespace GUI::Registration {                                                                                                                    \
+    ::GUI::ObjectClassRegistration registration_##class_name(                                                                                        \
+        #namespace_ "::" #class_name##sv, []() { return static_ptr_cast<GUI::Object>(namespace_::class_name::construct()); }, &registration_Layout); \
     }
 
 namespace GUI {
 
-class Layout : public Core::Object {
+class Layout : public GUI::Object {
     C_OBJECT_ABSTRACT(Layout);
 
 public:

--- a/Userland/Libraries/LibGUI/Object.cpp
+++ b/Userland/Libraries/LibGUI/Object.cpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2023, Andreas Kling <kling@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibGUI/Object.h>
+
+namespace GUI {
+
+Object::Object(Core::Object* parent)
+    : Core::Object(parent)
+{
+}
+
+Object::~Object() = default;
+
+void Object::register_property(DeprecatedString const& name, Function<JsonValue()> getter, Function<bool(JsonValue const&)> setter)
+{
+    m_properties.set(name, make<Property>(name, move(getter), move(setter)));
+}
+
+JsonValue Object::property(DeprecatedString const& name) const
+{
+    auto it = m_properties.find(name);
+    if (it == m_properties.end())
+        return JsonValue();
+    return it->value->get();
+}
+
+bool Object::set_property(DeprecatedString const& name, JsonValue const& value)
+{
+    auto it = m_properties.find(name);
+    if (it == m_properties.end())
+        return false;
+    return it->value->set(value);
+}
+
+static HashMap<StringView, ObjectClassRegistration*>& object_classes()
+{
+    static HashMap<StringView, ObjectClassRegistration*> s_map;
+    return s_map;
+}
+
+ObjectClassRegistration::ObjectClassRegistration(StringView class_name, Function<ErrorOr<NonnullRefPtr<Object>>()> factory, ObjectClassRegistration* parent_class)
+    : m_class_name(class_name)
+    , m_factory(move(factory))
+    , m_parent_class(parent_class)
+{
+    object_classes().set(class_name, this);
+}
+
+bool ObjectClassRegistration::is_derived_from(ObjectClassRegistration const& base_class) const
+{
+    if (&base_class == this)
+        return true;
+    if (!m_parent_class)
+        return false;
+    return m_parent_class->is_derived_from(base_class);
+}
+
+void ObjectClassRegistration::for_each(Function<void(ObjectClassRegistration const&)> callback)
+{
+    for (auto& it : object_classes()) {
+        callback(*it.value);
+    }
+}
+
+ObjectClassRegistration const* ObjectClassRegistration::find(StringView class_name)
+{
+    return object_classes().get(class_name).value_or(nullptr);
+}
+
+}

--- a/Userland/Libraries/LibGUI/Object.h
+++ b/Userland/Libraries/LibGUI/Object.h
@@ -1,0 +1,249 @@
+/*
+ * Copyright (c) 2023, Andreas Kling <kling@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibCore/Object.h>
+#include <LibGUI/Forward.h>
+#include <LibGUI/Property.h>
+
+namespace GUI {
+
+#define REGISTER_ABSTRACT_GUI_OBJECT(namespace_, class_name)                                                                                                                               \
+    namespace GUI::Registration {                                                                                                                                                          \
+    ::GUI::ObjectClassRegistration registration_##class_name(#namespace_ "::" #class_name##sv, []() { return Error::from_string_literal("Attempted to construct an abstract object."); }); \
+    }
+
+#define REGISTER_GUI_OBJECT(namespace_, class_name)                                                                                                    \
+    namespace GUI::Registration {                                                                                                                      \
+    ::GUI::ObjectClassRegistration registration_##class_name(#namespace_ "::" #class_name##sv, []() { return namespace_::class_name::try_create(); }); \
+    }
+
+class ObjectClassRegistration {
+    AK_MAKE_NONCOPYABLE(ObjectClassRegistration);
+    AK_MAKE_NONMOVABLE(ObjectClassRegistration);
+
+public:
+    ObjectClassRegistration(StringView class_name, Function<ErrorOr<NonnullRefPtr<Object>>()> factory, ObjectClassRegistration* parent_class = nullptr);
+    ~ObjectClassRegistration() = default;
+
+    StringView class_name() const { return m_class_name; }
+    ObjectClassRegistration const* parent_class() const { return m_parent_class; }
+    ErrorOr<NonnullRefPtr<Object>> construct() const { return m_factory(); }
+    bool is_derived_from(ObjectClassRegistration const& base_class) const;
+
+    static void for_each(Function<void(ObjectClassRegistration const&)>);
+    static ObjectClassRegistration const* find(StringView class_name);
+
+private:
+    StringView m_class_name;
+    Function<ErrorOr<NonnullRefPtr<Object>>()> m_factory;
+    ObjectClassRegistration* m_parent_class { nullptr };
+};
+
+class Object : public Core::Object {
+    C_OBJECT_ABSTRACT(Object);
+
+public:
+    virtual ~Object() override;
+
+    bool set_property(DeprecatedString const& name, JsonValue const& value);
+    JsonValue property(DeprecatedString const& name) const;
+    HashMap<DeprecatedString, NonnullOwnPtr<Property>> const& properties() const { return m_properties; }
+
+protected:
+    explicit Object(Core::Object* parent = nullptr);
+
+    void register_property(DeprecatedString const& name, Function<JsonValue()> getter, Function<bool(JsonValue const&)> setter = nullptr);
+
+private:
+    HashMap<DeprecatedString, NonnullOwnPtr<Property>> m_properties;
+};
+
+}
+
+#define REGISTER_INT_PROPERTY(property_name, getter, setter) \
+    register_property(                                       \
+        property_name,                                       \
+        [this] { return this->getter(); },                   \
+        [this](auto& value) {                                \
+            this->setter(value.template to_number<int>());   \
+            return true;                                     \
+        });
+
+#define REGISTER_BOOL_PROPERTY(property_name, getter, setter) \
+    register_property(                                        \
+        property_name,                                        \
+        [this] { return this->getter(); },                    \
+        [this](auto& value) {                                 \
+            this->setter(value.to_bool());                    \
+            return true;                                      \
+        });
+
+// FIXME: Port JsonValue to the new String class.
+#define REGISTER_STRING_PROPERTY(property_name, getter, setter)                                                                           \
+    register_property(                                                                                                                    \
+        property_name,                                                                                                                    \
+        [this]() { return this->getter().to_deprecated_string(); },                                                                       \
+        [this](auto& value) {                                                                                                             \
+            this->setter(String::from_deprecated_string(value.to_deprecated_string()).release_value_but_fixme_should_propagate_errors()); \
+            return true;                                                                                                                  \
+        });
+
+#define REGISTER_DEPRECATED_STRING_PROPERTY(property_name, getter, setter) \
+    register_property(                                                     \
+        property_name,                                                     \
+        [this] { return this->getter(); },                                 \
+        [this](auto& value) {                                              \
+            this->setter(value.to_deprecated_string());                    \
+            return true;                                                   \
+        });
+
+#define REGISTER_READONLY_STRING_PROPERTY(property_name, getter) \
+    register_property(                                           \
+        property_name,                                           \
+        [this] { return this->getter(); },                       \
+        {});
+
+#define REGISTER_WRITE_ONLY_STRING_PROPERTY(property_name, setter) \
+    register_property(                                             \
+        property_name,                                             \
+        {},                                                        \
+        [this](auto& value) {                                      \
+            this->setter(value.to_deprecated_string());            \
+            return true;                                           \
+        });
+
+#define REGISTER_READONLY_SIZE_PROPERTY(property_name, getter) \
+    register_property(                                         \
+        property_name,                                         \
+        [this] {                                               \
+            auto size = this->getter();                        \
+            JsonArray size_array;                              \
+            size_array.must_append(size.width());              \
+            size_array.must_append(size.height());             \
+            return size_array;                                 \
+        },                                                     \
+        {});
+
+#define REGISTER_RECT_PROPERTY(property_name, getter, setter)                       \
+    register_property(                                                              \
+        property_name,                                                              \
+        [this] {                                                                    \
+            auto rect = this->getter();                                             \
+            JsonObject rect_object;                                                 \
+            rect_object.set("x"sv, rect.x());                                       \
+            rect_object.set("y"sv, rect.y());                                       \
+            rect_object.set("width"sv, rect.width());                               \
+            rect_object.set("height"sv, rect.height());                             \
+            return rect_object;                                                     \
+        },                                                                          \
+        [this](auto& value) {                                                       \
+            Gfx::IntRect rect;                                                      \
+            if (value.is_object()) {                                                \
+                rect.set_x(value.as_object().get_i32("x"sv).value_or(0));           \
+                rect.set_y(value.as_object().get_i32("y"sv).value_or(0));           \
+                rect.set_width(value.as_object().get_i32("width"sv).value_or(0));   \
+                rect.set_height(value.as_object().get_i32("height"sv).value_or(0)); \
+            } else if (value.is_array() && value.as_array().size() == 4) {          \
+                rect.set_x(value.as_array()[0].to_i32());                           \
+                rect.set_y(value.as_array()[1].to_i32());                           \
+                rect.set_width(value.as_array()[2].to_i32());                       \
+                rect.set_height(value.as_array()[3].to_i32());                      \
+            } else {                                                                \
+                return false;                                                       \
+            }                                                                       \
+            setter(rect);                                                           \
+                                                                                    \
+            return true;                                                            \
+        });
+
+#define REGISTER_SIZE_PROPERTY(property_name, getter, setter) \
+    register_property(                                        \
+        property_name,                                        \
+        [this] {                                              \
+            auto size = this->getter();                       \
+            JsonArray size_array;                             \
+            size_array.must_append(size.width());             \
+            size_array.must_append(size.height());            \
+            return size_array;                                \
+        },                                                    \
+        [this](auto& value) {                                 \
+            if (!value.is_array())                            \
+                return false;                                 \
+            Gfx::IntSize size;                                \
+            size.set_width(value.as_array()[0].to_i32());     \
+            size.set_height(value.as_array()[1].to_i32());    \
+            setter(size);                                     \
+            return true;                                      \
+        });
+
+#define REGISTER_ENUM_PROPERTY(property_name, getter, setter, EnumType, ...) \
+    register_property(                                                       \
+        property_name,                                                       \
+        [this]() -> JsonValue {                                              \
+            struct {                                                         \
+                EnumType enum_value;                                         \
+                DeprecatedString string_value;                               \
+            } options[] = { __VA_ARGS__ };                                   \
+            auto enum_value = getter();                                      \
+            for (size_t i = 0; i < array_size(options); ++i) {               \
+                auto& option = options[i];                                   \
+                if (enum_value == option.enum_value)                         \
+                    return option.string_value;                              \
+            }                                                                \
+            return JsonValue();                                              \
+        },                                                                   \
+        [this](auto& value) {                                                \
+            struct {                                                         \
+                EnumType enum_value;                                         \
+                DeprecatedString string_value;                               \
+            } options[] = { __VA_ARGS__ };                                   \
+            if (!value.is_string())                                          \
+                return false;                                                \
+            auto string_value = value.as_string();                           \
+            for (size_t i = 0; i < array_size(options); ++i) {               \
+                auto& option = options[i];                                   \
+                if (string_value == option.string_value) {                   \
+                    setter(option.enum_value);                               \
+                    return true;                                             \
+                }                                                            \
+            }                                                                \
+            return false;                                                    \
+        })
+
+#define REGISTER_TEXT_ALIGNMENT_PROPERTY(property_name, getter, setter) \
+    REGISTER_ENUM_PROPERTY(                                             \
+        property_name, getter, setter, Gfx::TextAlignment,              \
+        { Gfx::TextAlignment::Center, "Center" },                       \
+        { Gfx::TextAlignment::CenterLeft, "CenterLeft" },               \
+        { Gfx::TextAlignment::CenterRight, "CenterRight" },             \
+        { Gfx::TextAlignment::TopCenter, "TopCenter" },                 \
+        { Gfx::TextAlignment::TopLeft, "TopLeft" },                     \
+        { Gfx::TextAlignment::TopRight, "TopRight" },                   \
+        { Gfx::TextAlignment::BottomCenter, "BottomCenter" },           \
+        { Gfx::TextAlignment::BottomLeft, "BottomLeft" },               \
+        { Gfx::TextAlignment::BottomRight, "BottomRight" })
+
+#define REGISTER_FONT_WEIGHT_PROPERTY(property_name, getter, setter) \
+    REGISTER_ENUM_PROPERTY(                                          \
+        property_name, getter, setter, unsigned,                     \
+        { Gfx::FontWeight::Thin, "Thin" },                           \
+        { Gfx::FontWeight::ExtraLight, "ExtraLight" },               \
+        { Gfx::FontWeight::Light, "Light" },                         \
+        { Gfx::FontWeight::Regular, "Regular" },                     \
+        { Gfx::FontWeight::Medium, "Medium" },                       \
+        { Gfx::FontWeight::SemiBold, "SemiBold" },                   \
+        { Gfx::FontWeight::Bold, "Bold" },                           \
+        { Gfx::FontWeight::ExtraBold, "ExtraBold" },                 \
+        { Gfx::FontWeight::Black, "Black" },                         \
+        { Gfx::FontWeight::ExtraBlack, "ExtraBlack" })
+
+#define REGISTER_TEXT_WRAPPING_PROPERTY(property_name, getter, setter) \
+    REGISTER_ENUM_PROPERTY(                                            \
+        property_name, getter, setter, Gfx::TextWrapping,              \
+        { Gfx::TextWrapping::Wrap, "Wrap" },                           \
+        { Gfx::TextWrapping::DontWrap, "DontWrap" })

--- a/Userland/Libraries/LibGUI/Property.cpp
+++ b/Userland/Libraries/LibGUI/Property.cpp
@@ -5,9 +5,9 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <LibCore/Property.h>
+#include <LibGUI/Property.h>
 
-namespace Core {
+namespace GUI {
 
 Property::Property(DeprecatedString name, Function<JsonValue()> getter, Function<bool(JsonValue const&)> setter)
     : m_name(move(name))

--- a/Userland/Libraries/LibGUI/Property.h
+++ b/Userland/Libraries/LibGUI/Property.h
@@ -10,7 +10,7 @@
 #include <AK/Function.h>
 #include <AK/JsonValue.h>
 
-namespace Core {
+namespace GUI {
 
 class Property {
     AK_MAKE_NONCOPYABLE(Property);

--- a/Userland/Libraries/LibGUI/ScrollableContainerWidget.cpp
+++ b/Userland/Libraries/LibGUI/ScrollableContainerWidget.cpp
@@ -130,7 +130,7 @@ ErrorOr<void> ScrollableContainerWidget::load_from_gml_ast(NonnullRefPtr<GUI::GM
         auto class_name = content_widget.name();
 
         RefPtr<Core::Object> child;
-        if (auto* registration = Core::ObjectClassRegistration::find(class_name)) {
+        if (auto* registration = GUI::ObjectClassRegistration::find(class_name)) {
             child = TRY(registration->construct());
         } else {
             child = TRY(unregistered_child_handler(class_name));

--- a/Userland/Libraries/LibGUI/Widget.cpp
+++ b/Userland/Libraries/LibGUI/Widget.cpp
@@ -415,11 +415,6 @@ void Widget::handle_paint_event(PaintEvent& event)
         Painter painter(*this);
         painter.draw_rect(rect(), Color::Red);
     }
-
-    if (is_being_inspected()) {
-        Painter painter(*this);
-        painter.draw_rect(rect(), Color::Magenta);
-    }
 }
 
 void Widget::set_layout(NonnullRefPtr<Layout> layout)
@@ -1087,16 +1082,6 @@ void Widget::set_foreground_role(ColorRole role)
 Gfx::Palette Widget::palette() const
 {
     return Gfx::Palette(*m_palette);
-}
-
-void Widget::did_begin_inspection()
-{
-    update();
-}
-
-void Widget::did_end_inspection()
-{
-    update();
 }
 
 void Widget::set_grabbable_margins(Margins const& margins)

--- a/Userland/Libraries/LibGUI/Widget.h
+++ b/Userland/Libraries/LibGUI/Widget.h
@@ -404,9 +404,6 @@ protected:
     virtual void screen_rects_change_event(ScreenRectsChangeEvent&);
     virtual void applet_area_rect_change_event(AppletAreaRectChangeEvent&);
 
-    virtual void did_begin_inspection() override;
-    virtual void did_end_inspection() override;
-
     void show_or_hide_tooltip();
 
     void add_focus_delegator(Widget*);

--- a/Userland/Libraries/LibGUI/Widget.h
+++ b/Userland/Libraries/LibGUI/Widget.h
@@ -13,13 +13,14 @@
 #include <AK/Optional.h>
 #include <AK/String.h>
 #include <AK/Variant.h>
-#include <LibCore/Object.h>
 #include <LibCore/Timer.h>
 #include <LibGUI/Event.h>
 #include <LibGUI/FocusPolicy.h>
 #include <LibGUI/Forward.h>
 #include <LibGUI/GML/AST.h>
 #include <LibGUI/Margins.h>
+#include <LibGUI/Object.h>
+#include <LibGUI/Property.h>
 #include <LibGUI/UIDimensions.h>
 #include <LibGfx/Color.h>
 #include <LibGfx/Forward.h>
@@ -27,14 +28,14 @@
 #include <LibGfx/Rect.h>
 #include <LibGfx/StandardCursor.h>
 
-namespace Core::Registration {
-extern Core::ObjectClassRegistration registration_Widget;
+namespace GUI::Registration {
+extern GUI::ObjectClassRegistration registration_Widget;
 }
 
-#define REGISTER_WIDGET(namespace_, class_name)                                                                                                                                                     \
-    namespace Core::Registration {                                                                                                                                                                  \
-    Core::ObjectClassRegistration registration_##class_name(                                                                                                                                        \
-        #namespace_ "::" #class_name##sv, []() -> ErrorOr<NonnullRefPtr<Core::Object>> { return static_ptr_cast<Core::Object>(TRY(namespace_::class_name::try_create())); }, &registration_Widget); \
+#define REGISTER_WIDGET(namespace_, class_name)                                                                                                                                                   \
+    namespace GUI::Registration {                                                                                                                                                                 \
+    GUI::ObjectClassRegistration registration_##class_name(                                                                                                                                       \
+        #namespace_ "::" #class_name##sv, []() -> ErrorOr<NonnullRefPtr<GUI::Object>> { return static_ptr_cast<GUI::Object>(TRY(namespace_::class_name::try_create())); }, &registration_Widget); \
     }
 
 namespace GUI {
@@ -70,7 +71,7 @@ enum class AllowCallback {
     Yes
 };
 
-class Widget : public Core::Object {
+class Widget : public GUI::Object {
     C_OBJECT(Widget)
 public:
     virtual ~Widget() override;

--- a/Userland/Libraries/LibGUI/Window.cpp
+++ b/Userland/Libraries/LibGUI/Window.cpp
@@ -72,7 +72,7 @@ Window* Window::from_window_id(int window_id)
 }
 
 Window::Window(Core::Object* parent)
-    : Core::Object(parent)
+    : GUI::Object(parent)
     , m_menubar(Menubar::construct())
 {
     if (parent)

--- a/Userland/Libraries/LibGUI/Window.h
+++ b/Userland/Libraries/LibGUI/Window.h
@@ -13,9 +13,9 @@
 #include <AK/OwnPtr.h>
 #include <AK/Variant.h>
 #include <AK/WeakPtr.h>
-#include <LibCore/Object.h>
 #include <LibGUI/FocusSource.h>
 #include <LibGUI/Forward.h>
+#include <LibGUI/Object.h>
 #include <LibGUI/ResizeDirection.h>
 #include <LibGUI/WindowMode.h>
 #include <LibGUI/WindowType.h>
@@ -27,7 +27,7 @@ namespace GUI {
 
 class WindowBackingStore;
 
-class Window : public Core::Object {
+class Window : public GUI::Object {
     C_OBJECT(Window)
 public:
     virtual ~Window() override;

--- a/Userland/Libraries/LibThreading/Thread.cpp
+++ b/Userland/Libraries/LibThreading/Thread.cpp
@@ -16,11 +16,6 @@ Thread::Thread(Function<intptr_t()> action, StringView thread_name)
     , m_action(move(action))
     , m_thread_name(thread_name.is_null() ? ""sv : thread_name)
 {
-    register_property("thread_name", [&] { return JsonValue { m_thread_name }; });
-#if defined(AK_OS_SERENITY) || defined(AK_OS_LINUX)
-    // FIXME: Print out a pretty TID for BSD and macOS platforms, too
-    register_property("tid", [&] { return JsonValue { m_tid }; });
-#endif
 }
 
 Thread::~Thread()

--- a/Userland/Services/WindowServer/Window.h
+++ b/Userland/Services/WindowServer/Window.h
@@ -8,6 +8,7 @@
 
 #include "HitTestResult.h"
 #include <AK/DeprecatedString.h>
+#include <AK/IntrusiveList.h>
 #include <AK/WeakPtr.h>
 #include <LibCore/Object.h>
 #include <LibGfx/Bitmap.h>

--- a/Userland/Shell/Shell.h
+++ b/Userland/Shell/Shell.h
@@ -12,6 +12,7 @@
 #include <AK/CircularQueue.h>
 #include <AK/DeprecatedString.h>
 #include <AK/HashMap.h>
+#include <AK/IntrusiveList.h>
 #include <AK/StackInfo.h>
 #include <AK/StringBuilder.h>
 #include <AK/StringView.h>

--- a/Userland/Utilities/js.cpp
+++ b/Userland/Utilities/js.cpp
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/JsonValue.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/ConfigFile.h>
 #include <LibCore/StandardPaths.h>


### PR DESCRIPTION
Since Core::Object properties are really only used by GML now that the
Inspector is long gone, there's no need for these to pollute
Core::Object.

This patch adds a new GUI::Object class to hold properties, and makes
it the new base class of GUI::Window, GUI::Widget and GUI::Layout.
The "instantiate an object by name" mechanism that GML uses is also
hoisted into GUI::Object as well.

...and also some tangential removal of unused code. :^)