### PR TITLE
Ladybird: Copy cacert.pem into the expected build-time path on macOS

### DIFF
--- a/Ladybird/CMakeLists.txt
+++ b/Ladybird/CMakeLists.txt
@@ -162,6 +162,7 @@ if (APPLE)
         COMMAND "${CMAKE_COMMAND}" -E copy_if_different "$<TARGET_FILE:headless-browser>" "${app_dir}"
         COMMAND "mkdir" -p "${bundle_dir}/Contents/Resources"
         COMMAND "iconutil" --convert icns "${CMAKE_CURRENT_SOURCE_DIR}/Icons/macos/app_icon.iconset" --output "${bundle_dir}/Contents/Resources/app_icon.icns"
+        COMMAND "${CMAKE_COMMAND}" -E copy_if_different "${Lagom_BINARY_DIR}/cacert.pem" "${bundle_dir}/Contents"
     )
 endif()
 


### PR DESCRIPTION
With the CMake build, the ladybird binary ends up in $build/bin/ladybird.app/Contents/MacOS. Which is a bit unfortunate for a few reasons, but the main one is that --enable-lagom-networking doesn't work with ./Meta/serenity.sh run lagom ladybird.

Let's copy the file to the expected location. There's very likely better solutions we can use in the future.