### PR TITLE
usermod: Don't exit immediately for non-root users

### DIFF
--- a/Userland/Utilities/usermod.cpp
+++ b/Userland/Utilities/usermod.cpp
@@ -118,7 +118,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto account_or_error = Core::Account::from_name(username);
 
     if (account_or_error.is_error()) {
-        warnln("Core::Account::from_name: {}", account_or_error.error());
+        warnln("usermod: {}", strerror(account_or_error.error().code()));
         return 1;
     }
 

--- a/Userland/Utilities/usermod.cpp
+++ b/Userland/Utilities/usermod.cpp
@@ -43,8 +43,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         return 1;
     }
 
-    TRY(Core::System::setegid(0));
-
     TRY(Core::System::pledge("stdio wpath rpath cpath fattr tty"));
     TRY(Core::System::unveil("/etc", "rwc"));
 

--- a/Userland/Utilities/usermod.cpp
+++ b/Userland/Utilities/usermod.cpp
@@ -38,11 +38,6 @@ static Optional<gid_t> group_string_to_gid(StringView group)
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    if (geteuid() != 0) {
-        warnln("Not running as root :^(");
-        return 1;
-    }
-
     TRY(Core::System::pledge("stdio wpath rpath cpath fattr tty"));
     TRY(Core::System::unveil("/etc", "rwc"));
 


### PR DESCRIPTION
This PR modifies `usermod` to not immediately exit if not run as root. This allows non-root users to run `--help` for example.

Rather than a "not running as root" message, a "Permission denied" message is now shown. This is similar to what is shown in Linux.

Example usage:

![usermod_root_check_after](https://github.com/SerenityOS/serenity/assets/2817754/d7b3dbe1-7ad0-41d8-a47e-19151c2c6e3d)
