### PR TITLE
LibJS+LibWeb: Make `JS::GCPtr` cheaper

### DIFF
--- a/Userland/Libraries/LibJS/Heap/GCPtr.h
+++ b/Userland/Libraries/LibJS/Heap/GCPtr.h
@@ -31,22 +31,11 @@ public:
     {
     }
 
-    NonnullGCPtr(NonnullGCPtr const& other)
-        : m_ptr(other.ptr())
-    {
-    }
-
     template<typename U>
     NonnullGCPtr(NonnullGCPtr<U> const& other)
     requires(IsConvertible<U*, T*>)
         : m_ptr(other.ptr())
     {
-    }
-
-    NonnullGCPtr& operator=(NonnullGCPtr const& other)
-    {
-        m_ptr = other.ptr();
-        return *this;
     }
 
     template<typename U>
@@ -88,7 +77,7 @@ private:
 template<typename T>
 class GCPtr {
 public:
-    GCPtr() = default;
+    constexpr GCPtr() = default;
 
     GCPtr(T& ptr)
         : m_ptr(&ptr)
@@ -97,11 +86,6 @@ public:
 
     GCPtr(T* ptr)
         : m_ptr(ptr)
-    {
-    }
-
-    GCPtr(GCPtr<T> const& other)
-        : m_ptr(other.ptr())
     {
     }
 
@@ -128,8 +112,6 @@ public:
         : m_ptr(nullptr)
     {
     }
-
-    GCPtr& operator=(GCPtr const&) = default;
 
     template<typename U>
     GCPtr& operator=(GCPtr<U> const& other)

--- a/Userland/Libraries/LibJS/Heap/GCPtr.h
+++ b/Userland/Libraries/LibJS/Heap/GCPtr.h
@@ -60,13 +60,13 @@ public:
         return *this;
     }
 
-    T* operator->() const { return m_ptr; }
+    RETURNS_NONNULL T* operator->() const { return m_ptr; }
 
     T& operator*() const { return *m_ptr; }
 
-    T* ptr() const { return m_ptr; }
+    RETURNS_NONNULL T* ptr() const { return m_ptr; }
 
-    operator T*() const { return m_ptr; }
+    RETURNS_NONNULL operator T*() const { return m_ptr; }
 
     operator T&() const { return *m_ptr; }
 

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Fetching.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Fetching.cpp
@@ -256,7 +256,7 @@ WebIDL::ExceptionOr<void> fetch_classic_script(JS::NonnullGCPtr<HTMLScriptElemen
     // 5. Fetch request with the following processResponseConsumeBody steps given response response and null, failure,
     //    or a byte sequence bodyBytes:
     Fetch::Infrastructure::FetchAlgorithms::Input fetch_algorithms_input {};
-    fetch_algorithms_input.process_response_consume_body = [element, &settings_object, options = move(options), character_encoding = move(character_encoding), on_complete = move(on_complete)](auto response, auto body_bytes) {
+    fetch_algorithms_input.process_response_consume_body = [&settings_object, options = move(options), character_encoding = move(character_encoding), on_complete = move(on_complete)](auto response, auto body_bytes) {
         // 1. Set response to response's unsafe response.
         response = response->unsafe_response();
 

--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -682,7 +682,7 @@ constexpr bool should_ignore_keydown_event(u32 code_point)
 
 bool EventHandler::fire_keyboard_event(FlyString const& event_name, HTML::BrowsingContext& browsing_context, KeyCode key, unsigned int modifiers, u32 code_point)
 {
-    JS::NonnullGCPtr<DOM::Document> document = *browsing_context.active_document();
+    JS::GCPtr<DOM::Document> document = browsing_context.active_document();
     if (!document)
         return false;
 

--- a/Userland/Libraries/LibWeb/Streams/AbstractOperations.cpp
+++ b/Userland/Libraries/LibWeb/Streams/AbstractOperations.cpp
@@ -868,7 +868,7 @@ WebIDL::ExceptionOr<void> set_up_readable_stream_default_controller_from_underly
 
     // 7. If underlyingSourceDict["cancel"] exists, then set cancelAlgorithm to an algorithm which takes an argument reason and returns the result of invoking underlyingSourceDict["cancel"] with argument list « reason » and callback this value underlyingSource.
     if (underlying_source.cancel) {
-        cancel_algorithm = [&realm, controller, underlying_source_value, callback = underlying_source.cancel](auto const& reason) -> WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>> {
+        cancel_algorithm = [&realm, underlying_source_value, callback = underlying_source.cancel](auto const& reason) -> WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>> {
             // Note: callback return a promise, so invoke_callback will never return an abrupt completion
             auto result = MUST_OR_THROW_OOM(WebIDL::invoke_callback(*callback, underlying_source_value, reason)).release_value();
             return WebIDL::create_resolved_promise(realm, result);
@@ -2528,7 +2528,7 @@ WebIDL::ExceptionOr<void> set_up_writable_stream_default_controller_from_underly
 
     // 8. If underlyingSinkDict["close"] exists, then set closeAlgorithm to an algorithm which returns the result of invoking underlyingSinkDict["close"] with argument list «» and callback this value underlyingSink.
     if (underlying_sink.close) {
-        close_algorithm = [&realm, controller, underlying_sink_value, callback = underlying_sink.close]() -> WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>> {
+        close_algorithm = [&realm, underlying_sink_value, callback = underlying_sink.close]() -> WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>> {
             // Note: callback return a promise, so invoke_callback will never return an abrupt completion
             auto result = MUST_OR_THROW_OOM(WebIDL::invoke_callback(*callback, underlying_sink_value)).release_value();
             return WebIDL::create_resolved_promise(realm, result);
@@ -2537,7 +2537,7 @@ WebIDL::ExceptionOr<void> set_up_writable_stream_default_controller_from_underly
 
     // 9. If underlyingSinkDict["abort"] exists, then set abortAlgorithm to an algorithm which takes an argument reason and returns the result of invoking underlyingSinkDict["abort"] with argument list « reason » and callback this value underlyingSink.
     if (underlying_sink.abort) {
-        abort_algorithm = [&realm, controller, underlying_sink_value, callback = underlying_sink.abort](JS::Value reason) -> WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>> {
+        abort_algorithm = [&realm, underlying_sink_value, callback = underlying_sink.abort](JS::Value reason) -> WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>> {
             // Note: callback return a promise, so invoke_callback will never return an abrupt completion
             auto result = MUST_OR_THROW_OOM(WebIDL::invoke_callback(*callback, underlying_sink_value, reason)).release_value();
             return WebIDL::create_resolved_promise(realm, result);
@@ -3342,7 +3342,7 @@ WebIDL::ExceptionOr<void> set_up_readable_byte_stream_controller_from_underlying
 
     // 7. If underlyingSourceDict["cancel"] exists, then set cancelAlgorithm to an algorithm which takes an argument reason and returns the result of invoking underlyingSourceDict["cancel"] with argument list « reason » and callback this value underlyingSource.
     if (underlying_source_dict.cancel) {
-        cancel_algorithm = [&realm, controller, underlying_source, callback = underlying_source_dict.cancel](auto const& reason) -> WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>> {
+        cancel_algorithm = [&realm, underlying_source, callback = underlying_source_dict.cancel](auto const& reason) -> WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>> {
             // Note: callback return a promise, so invoke_callback will never return an abrupt completion
             auto result = MUST_OR_THROW_OOM(WebIDL::invoke_callback(*callback, underlying_source, reason)).release_value();
             return WebIDL::create_resolved_promise(realm, result);

--- a/Userland/Libraries/LibWeb/Streams/ReadableStream.cpp
+++ b/Userland/Libraries/LibWeb/Streams/ReadableStream.cpp
@@ -97,13 +97,13 @@ WebIDL::ExceptionOr<ReadableStreamReader> ReadableStream::get_reader(ReadableStr
 {
     // 1. If options["mode"] does not exist, return ? AcquireReadableStreamDefaultReader(this).
     if (!options.mode.has_value())
-        return TRY(acquire_readable_stream_default_reader(*this));
+        return ReadableStreamReader { TRY(acquire_readable_stream_default_reader(*this)) };
 
     // 2. Assert: options["mode"] is "byob".
     VERIFY(*options.mode == Bindings::ReadableStreamReaderMode::Byob);
 
     // 3. Return ? AcquireReadableStreamBYOBReader(this).
-    return TRY(acquire_readable_stream_byob_reader(*this));
+    return ReadableStreamReader { TRY(acquire_readable_stream_byob_reader(*this)) };
 }
 
 JS::ThrowCompletionOr<void> ReadableStream::initialize(JS::Realm& realm)


### PR DESCRIPTION
**LibJS+LibWeb: Apply the Rule of Zero to `{Nonnull,}GCPtr<T>`**

The compiler-generated copy constructor and copy assignment operator
already do the right thing (which is to simply copy the underlying
pointer).

The [Itanium C++ ABI][1] treats any class with non-trivial copy/move
constructors and destructors as non-trivial for the purposes of calls --
even if they are functionally identical to the compiler-generated ones.
If a class is non-trivial, it cannot be passed or returned in registers,
only via an invisible reference, which is worse for codegen. This commit
makes `{Nonnull,}GCPtr` trivial.

As the compiler can be sure that capturing a `GCPtr` by value has no
side effects, a few `-Wunused-lambda-capture` warnings had to be
addressed in LibWeb.

**LibJS+LibWeb: Mark `NonnullGCPtr::ptr()` as `returns_nonnull`**

This invariant is enforced by the fact that `NonnullGCPtr` can only be
constructed from references.

This commit fixes an instance where we compared a pointer to null after
we have already dereferenced it

[1]: https://itanium-cxx-abi.github.io/cxx-abi/abi.html#non-trivial