### PR TITLE
LibWeb: Support positioning of abspos boxes inside grid container

### DIFF
--- a/Tests/LibWeb/Layout/expected/grid/abspos-item.txt
+++ b/Tests/LibWeb/Layout/expected/grid/abspos-item.txt
@@ -1,0 +1,23 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x17.46875 children: not-inline
+      Box <div.outer-grid> at (8,8) content-size 784x17.46875 [GFC] children: not-inline
+        BlockContainer <div.inner-absolute-block> at (8,8) content-size 80.765625x17.46875 positioned [BFC] children: inline
+          line 0 width: 80.765625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 9, rect: [8,8 80.765625x17.46875]
+              "some text"
+          TextNode <#text>
+        BlockContainer <div> at (8,8) content-size 784x17.46875 [BFC] children: inline
+          line 0 width: 80.25, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 9, rect: [8,8 80.25x17.46875]
+              "more text"
+          TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x17.46875]
+      PaintableBox (Box<DIV>.outer-grid) [8,8 784x17.46875]
+        PaintableWithLines (BlockContainer<DIV>.inner-absolute-block) [8,8 80.765625x17.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [8,8 784x17.46875]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/input/grid/abspos-item.html
+++ b/Tests/LibWeb/Layout/input/grid/abspos-item.html
@@ -1,0 +1,10 @@
+<style>
+.outer-grid {
+    display: grid;
+}
+.inner-absolute-block {
+    display: block;
+    position: absolute;
+}
+</style>
+<div class="outer-grid"><div class="inner-absolute-block">some text</div><div>more text</div></div>

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.h
@@ -223,6 +223,8 @@ private:
     void determine_grid_container_height();
     void determine_intrinsic_size_of_grid_container(AvailableSpace const& available_space);
 
+    virtual void parent_context_did_dimension_child_root_box() override;
+
     void resolve_grid_item_widths();
     void resolve_grid_item_heights();
 


### PR DESCRIPTION
- Out-of-flow items should not affect grid layout
- "The static position of an absolutely-positioned child of a grid container is determined as if it were the sole grid item in a grid area whose edges coincide with the content edges of the grid container."