### PR TITLE
LibWeb: Allow (explicitly) converting CSSPixels to float and int

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/StyleValues/RadialGradientStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/RadialGradientStyleValue.cpp
@@ -187,8 +187,8 @@ Gfx::FloatSize RadialGradientStyleValue::resolve_size(Layout::Node const& node, 
 void RadialGradientStyleValue::resolve_for_size(Layout::Node const& node, CSSPixelSize paint_size) const
 {
     CSSPixelRect gradient_box { { 0, 0 }, paint_size };
-    auto center = m_properties.position.resolved(node, gradient_box).to_type<double>().to_type<float>();
-    auto gradient_size = resolve_size(node, center, gradient_box.to_type<double>().to_type<float>());
+    auto center = m_properties.position.resolved(node, gradient_box).to_type<float>();
+    auto gradient_size = resolve_size(node, center, gradient_box.to_type<float>());
     if (m_resolved.has_value() && m_resolved->gradient_size == gradient_size)
         return;
     m_resolved = ResolvedData {

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -1961,7 +1961,7 @@ void Document::run_the_resize_steps()
     if (!browsing_context())
         return;
 
-    auto viewport_size = browsing_context()->viewport_rect().size().to_type<double>().to_type<float>().to_type<int>();
+    auto viewport_size = browsing_context()->viewport_rect().size().to_type<int>();
     if (m_last_viewport_size == viewport_size)
         return;
     m_last_viewport_size = viewport_size;

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -711,7 +711,7 @@ JS::NonnullGCPtr<Geometry::DOMRect> Element::get_bounding_client_rect() const
     VERIFY(document().browsing_context());
     auto viewport_offset = document().browsing_context()->viewport_scroll_offset();
 
-    return Geometry::DOMRect::create(realm(), paintable_box->absolute_rect().translated(-viewport_offset.x(), -viewport_offset.y()).to_type<double>().to_type<float>()).release_value_but_fixme_should_propagate_errors();
+    return Geometry::DOMRect::create(realm(), paintable_box->absolute_rect().translated(-viewport_offset.x(), -viewport_offset.y()).to_type<float>()).release_value_but_fixme_should_propagate_errors();
 }
 
 // https://drafts.csswg.org/cssom-view/#dom-element-getclientrects

--- a/Userland/Libraries/LibWeb/HTML/Window.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Window.cpp
@@ -1163,7 +1163,7 @@ void Window::scroll(ScrollToOptions const& options)
     // 1. If invoked with one argument, follow these substeps:
 
     // 1. Let options be the argument.
-    auto viewport_rect = top_level_browsing_context.viewport_rect().to_type<double>().to_type<float>();
+    auto viewport_rect = top_level_browsing_context.viewport_rect().to_type<float>();
 
     // 2. Let x be the value of the left dictionary member of options, if present, or the viewport’s current scroll
     //    position on the x axis otherwise.

--- a/Userland/Libraries/LibWeb/Layout/SVGFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/SVGFormattingContext.cpp
@@ -174,7 +174,7 @@ void SVGFormattingContext::run(Box const& box, LayoutMode layout_mode, Available
                 // The initial value for preserveAspectRatio is xMidYMid meet.
                 auto preserve_aspect_ratio = svg_svg_element.preserve_aspect_ratio().value_or(SVG::PreserveAspectRatio {});
                 auto viewbox_transform = scale_and_align_viewbox_content(preserve_aspect_ratio, view_box, { scale_width, scale_height }, svg_box_state);
-                path_transform = Gfx::AffineTransform {}.translate(viewbox_transform.offset.to_type<double>().to_type<float>()).scale(viewbox_transform.scale_factor, viewbox_transform.scale_factor).translate({ -view_box.min_x, -view_box.min_y }).multiply(path_transform);
+                path_transform = Gfx::AffineTransform {}.translate(viewbox_transform.offset.to_type<float>()).scale(viewbox_transform.scale_factor, viewbox_transform.scale_factor).translate({ -view_box.min_x, -view_box.min_y }).multiply(path_transform);
                 viewbox_scale = viewbox_transform.scale_factor;
             }
 

--- a/Userland/Libraries/LibWeb/Layout/SVGGeometryBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/SVGGeometryBox.cpp
@@ -31,7 +31,7 @@ Optional<Gfx::AffineTransform> SVGGeometryBox::layout_transform() const
     auto transform = geometry_element.get_transform();
     auto* svg_box = geometry_element.shadow_including_first_ancestor_of_type<SVG::SVGSVGElement>();
     double scaling = 1;
-    auto origin = viewbox_origin().to_type<double>().to_type<float>();
+    auto origin = viewbox_origin().to_type<float>();
     Gfx::FloatPoint paint_offset = {};
     if (svg_box && geometry_element.view_box().has_value()) {
         // Note: SVGFormattingContext has already done the scaling based on the viewbox,
@@ -47,7 +47,7 @@ Optional<Gfx::AffineTransform> SVGGeometryBox::layout_transform() const
         auto scaled_height = paintable_box()->content_height().to_double();
         scaling = min(scaled_width / static_cast<double>(original_bounding_box.width()), scaled_height / static_cast<double>(original_bounding_box.height()));
         auto scaled_bounding_box = original_bounding_box.scaled(scaling, scaling);
-        paint_offset = (paintable_box()->absolute_rect().location() - svg_box->paintable_box()->absolute_rect().location()).to_type<double>().to_type<float>() - scaled_bounding_box.location();
+        paint_offset = (paintable_box()->absolute_rect().location() - svg_box->paintable_box()->absolute_rect().location()).to_type<float>() - scaled_bounding_box.location();
     }
     return Gfx::AffineTransform {}.translate(paint_offset).scale(scaling, scaling).translate(-origin).multiply(transform);
 }

--- a/Userland/Libraries/LibWeb/Layout/SVGTextBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/SVGTextBox.cpp
@@ -29,10 +29,10 @@ Optional<Gfx::AffineTransform> SVGTextBox::layout_transform() const
     auto& geometry_element = dom_node();
     auto transform = geometry_element.get_transform();
     auto* svg_box = geometry_element.first_ancestor_of_type<SVG::SVGSVGElement>();
-    auto origin = viewbox_origin().to_type<double>().to_type<float>();
+    auto origin = viewbox_origin().to_type<float>();
     Gfx::FloatPoint paint_offset = {};
     if (svg_box && svg_box->view_box().has_value())
-        paint_offset = svg_box->paintable_box()->absolute_rect().location().to_type<double>().to_type<float>();
+        paint_offset = svg_box->paintable_box()->absolute_rect().location().to_type<float>();
     return Gfx::AffineTransform {}.translate(paint_offset).translate(-origin).multiply(transform);
 }
 

--- a/Userland/Libraries/LibWeb/Painting/GradientPainting.cpp
+++ b/Userland/Libraries/LibWeb/Painting/GradientPainting.cpp
@@ -112,7 +112,7 @@ static ColorStopData resolve_color_stop_positions(auto const& color_stop_list, a
 LinearGradientData resolve_linear_gradient_data(Layout::Node const& node, CSSPixelSize gradient_size, CSS::LinearGradientStyleValue const& linear_gradient)
 {
     auto gradient_angle = linear_gradient.angle_degrees(gradient_size);
-    auto gradient_length_px = Gfx::calculate_gradient_length(gradient_size.to_type<double>().to_type<float>(), gradient_angle);
+    auto gradient_length_px = Gfx::calculate_gradient_length(gradient_size.to_type<float>(), gradient_angle);
 
     auto resolved_color_stops = resolve_color_stop_positions(
         linear_gradient.color_stop_list(), [&](auto const& length_percentage) {

--- a/Userland/Libraries/LibWeb/Painting/MarkerPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/MarkerPaintable.cpp
@@ -37,7 +37,7 @@ void MarkerPaintable::paint(PaintContext& context, PaintPhase phase) const
         return;
 
     // FIXME: All this does is round to the nearest whole CSS pixel, but it's goofy.
-    CSSPixelRect enclosing = absolute_rect().to_type<double>().to_type<float>().to_rounded<float>().to_type<CSSPixels>();
+    CSSPixelRect enclosing = absolute_rect().to_type<float>().to_rounded<float>().to_type<CSSPixels>();
     auto device_enclosing = context.enclosing_device_rect(enclosing);
 
     CSSPixels marker_width = enclosing.height() / 2.0;

--- a/Userland/Libraries/LibWeb/Painting/SVGGeometryPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/SVGGeometryPaintable.cpp
@@ -36,7 +36,7 @@ Optional<HitTestResult> SVGGeometryPaintable::hit_test(CSSPixelPoint position, H
     if (auto transform = layout_box().layout_transform(); transform.has_value()) {
         auto transformed_bounding_box = transform->map_to_quad(
             const_cast<SVG::SVGGeometryElement&>(geometry_element).get_path().bounding_box());
-        if (!transformed_bounding_box.contains(position.to_type<double>().to_type<float>()))
+        if (!transformed_bounding_box.contains(position.to_type<float>()))
             return {};
     }
     return result;
@@ -103,7 +103,7 @@ void SVGGeometryPaintable::paint(PaintContext& context, PaintPhase phase) const
     auto svg_viewport = [&] {
         if (maybe_view_box.has_value())
             return Gfx::FloatRect { maybe_view_box->min_x, maybe_view_box->min_y, maybe_view_box->width, maybe_view_box->height };
-        return Gfx::FloatRect { { 0, 0 }, svg_element_rect.size().to_type<double>().to_type<float>() };
+        return Gfx::FloatRect { { 0, 0 }, svg_element_rect.size().to_type<float>() };
     }();
 
     SVG::SVGPaintContext paint_context {

--- a/Userland/Libraries/LibWeb/PixelUnits.h
+++ b/Userland/Libraries/LibWeb/PixelUnits.h
@@ -113,6 +113,8 @@ public:
     constexpr bool operator==(CSSPixels const& other) const = default;
 
     explicit operator double() const { return to_double(); }
+    explicit operator float() const { return to_float(); }
+    explicit operator int() const { return to_int(); }
 
     constexpr CSSPixels& operator++()
     {


### PR DESCRIPTION
...and remove some unnecessary cast chains.