### PR TITLE
Userland: Open files for save in write-only mode

### DIFF
--- a/Userland/Libraries/LibAudio/WavWriter.cpp
+++ b/Userland/Libraries/LibAudio/WavWriter.cpp
@@ -33,7 +33,7 @@ WavWriter::~WavWriter()
 
 ErrorOr<void> WavWriter::set_file(StringView path)
 {
-    m_file = TRY(Core::File::open(path, Core::File::OpenMode::ReadWrite));
+    m_file = TRY(Core::File::open(path, Core::File::OpenMode::Write));
     TRY(m_file->seek(44, SeekMode::SetPosition));
     m_finalized = false;
     return {};

--- a/Userland/Utilities/shot.cpp
+++ b/Userland/Utilities/shot.cpp
@@ -160,7 +160,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     if (edit_image)
         output_path = Core::DateTime::now().to_deprecated_string("/tmp/screenshot-%Y-%m-%d-%H-%M-%S.png"sv);
 
-    auto file_or_error = Core::File::open(output_path, Core::File::OpenMode::ReadWrite);
+    auto file_or_error = Core::File::open(output_path, Core::File::OpenMode::Write);
     if (file_or_error.is_error()) {
         warnln("Could not open '{}' for writing: {}", output_path, file_or_error.error());
         return 1;


### PR DESCRIPTION
After not so successful https://github.com/SerenityOS/serenity/pull/20363 (🫣), I decided to look if we're using the `ReadWrite` mode correctly in other places of the system.

It turns out that WavWriter and the shot utility open files with this mode and never truncate the files, which might leave some contents of a previous file during overwriting.

It seems to me that changing the mode to just `Write` is correct, as these tools always write to files.