### PR TITLE
LibWeb: Allow direct rouding of CSSPixelRects to CSSPixelRects

### DIFF
--- a/Userland/Libraries/LibGfx/Rect.h
+++ b/Userland/Libraries/LibGfx/Rect.h
@@ -976,6 +976,10 @@ public:
         return Rect<U>(*this);
     }
 
+    // For extern specialization, like CSSPixels
+    template<typename U>
+    [[nodiscard]] Rect<U> to_rounded() const = delete;
+
     template<FloatingPoint U>
     [[nodiscard]] ALWAYS_INLINE Rect<U> to_rounded() const
     {

--- a/Userland/Libraries/LibWeb/Painting/MarkerPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/MarkerPaintable.cpp
@@ -36,8 +36,7 @@ void MarkerPaintable::paint(PaintContext& context, PaintPhase phase) const
     if (phase != PaintPhase::Foreground)
         return;
 
-    // FIXME: All this does is round to the nearest whole CSS pixel, but it's goofy.
-    CSSPixelRect enclosing = absolute_rect().to_type<float>().to_rounded<float>().to_type<CSSPixels>();
+    CSSPixelRect enclosing = absolute_rect().to_rounded<CSSPixels>();
     auto device_enclosing = context.enclosing_device_rect(enclosing);
 
     CSSPixels marker_width = enclosing.height() / 2.0;

--- a/Userland/Libraries/LibWeb/PixelUnits.h
+++ b/Userland/Libraries/LibWeb/PixelUnits.h
@@ -13,6 +13,7 @@
 #include <AK/Math.h>
 #include <AK/Traits.h>
 #include <LibGfx/Forward.h>
+#include <LibGfx/Rect.h>
 #include <math.h>
 
 namespace Web {
@@ -277,6 +278,18 @@ constexpr Web::CSSPixels round(Web::CSSPixels const& value)
 constexpr Web::DevicePixels abs(Web::DevicePixels const& value)
 {
     return AK::abs(value.value());
+}
+
+template<>
+template<>
+[[nodiscard]] ALWAYS_INLINE Web::CSSPixelRect Web::CSSPixelRect::to_rounded<Web::CSSPixels>() const
+{
+    return {
+        round(x()),
+        round(y()),
+        round(width()),
+        round(height()),
+    };
 }
 
 namespace AK {


### PR DESCRIPTION
### LibGfx: Allow outside specilization of Rect::to_rounded


### LibWeb: Allow direct rouding of CSSPixelRects to CSSPixelRects

Preciously we were casting to float, round and cast back, which actually
might loose precision and was quite ugly.

----

@MacDue
