### PR TITLE
LibWeb: Add namespace support to CSS selectors

### DIFF
--- a/Tests/LibWeb/Layout/expected/css-namespace-tag-name-selector.txt
+++ b/Tests/LibWeb/Layout/expected/css-namespace-tag-name-selector.txt
@@ -1,0 +1,41 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x207.3125 children: not-inline
+      BlockContainer <(anonymous)> at (8,8) content-size 784x161.65625 children: inline
+        line 0 width: 413.453125, height: 161.65625, bottom: 161.65625, baseline: 152
+          frag 0 from SVGSVGBox start: 0, length: 0, rect: [9,9 300x150]
+          frag 1 from TextNode start: 0, length: 1, rect: [310,146 8x17.46875]
+            " "
+          frag 2 from TextNode start: 0, length: 5, rect: [320,126 99.453125x43.671875]
+            "Hello"
+        SVGSVGBox <svg> at (9,9) content-size 300x150 [SVG] children: inline
+          InlineNode <a>
+            SVGTextBox <text> at (9,9) content-size 0x0 children: inline
+              TextNode <#text>
+        TextNode <#text>
+        InlineNode <math>
+          InlineNode <a>
+            TextNode <#text>
+        TextNode <#text>
+      BlockContainer <div> at (9,170.65625) content-size 782x43.65625 children: inline
+        line 0 width: 101.453125, height: 43.65625, bottom: 43.65625, baseline: 33.828125
+          frag 0 from TextNode start: 0, length: 5, rect: [10,170.65625 99.453125x43.671875]
+            "Hello"
+        InlineNode <a>
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (8,215.3125) content-size 784x0 children: inline
+        TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x207.3125]
+      PaintableWithLines (BlockContainer(anonymous)) [8,8 784x161.65625] overflow: [8,8 784x161.671875]
+        SVGSVGPaintable (SVGSVGBox<svg>) [8,8 302x152]
+        TextPaintable (TextNode<#text>)
+        InlinePaintable (InlineNode<math>)
+          InlinePaintable (InlineNode<a>)
+            TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer<DIV>) [8,169.65625 784x45.65625] overflow: [9,170.65625 782x43.671875]
+        InlinePaintable (InlineNode<A>)
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,215.3125 784x0]

--- a/Tests/LibWeb/Layout/expected/css-namespace-universal-selector.txt
+++ b/Tests/LibWeb/Layout/expected/css-namespace-universal-selector.txt
@@ -1,0 +1,22 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x324 children: not-inline
+      SVGSVGBox <svg> at (18,18) content-size 100x100 [SVG] children: not-inline
+      BlockContainer <(anonymous)> at (8,128) content-size 784x0 children: inline
+        TextNode <#text>
+      BlockContainer <math> at (9,129) content-size 100x100 children: not-inline
+      BlockContainer <(anonymous)> at (8,230) content-size 784x0 children: inline
+        TextNode <#text>
+      BlockContainer <div> at (9,231) content-size 100x100 children: not-inline
+      BlockContainer <(anonymous)> at (8,332) content-size 784x0 children: inline
+        TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x324]
+      SVGSVGPaintable (SVGSVGBox<svg>) [8,8 120x120]
+      PaintableWithLines (BlockContainer(anonymous)) [8,128 784x0]
+      PaintableWithLines (BlockContainer<math>) [8,128 102x102]
+      PaintableWithLines (BlockContainer(anonymous)) [8,230 784x0]
+      PaintableWithLines (BlockContainer<DIV>) [8,230 102x102]
+      PaintableWithLines (BlockContainer(anonymous)) [8,332 784x0]

--- a/Tests/LibWeb/Layout/input/css-namespace-tag-name-selector.html
+++ b/Tests/LibWeb/Layout/input/css-namespace-tag-name-selector.html
@@ -1,0 +1,23 @@
+<style>
+@namespace s "http://www.w3.org/2000/svg";
+
+body * {
+    border: 1px solid black;
+}
+a {
+    width: 100px;
+}
+|a {
+    width: 200px !important;
+}
+*|a {
+    height: 100px;
+    font-size: 40px;
+}
+s|a {
+    font-size: 80px;
+}
+</style>
+<svg><a><text x="20" y="80">Hello</text></a></svg>
+<math><a>Hello</a></math>
+<div><a>Hello</a></div>

--- a/Tests/LibWeb/Layout/input/css-namespace-universal-selector.html
+++ b/Tests/LibWeb/Layout/input/css-namespace-universal-selector.html
@@ -1,0 +1,21 @@
+<style>
+@namespace s "http://www.w3.org/2000/svg";
+
+body * {
+    display: block;
+    width: 100px;
+    border: 1px solid black;
+}
+body |* {
+    width: 200px !important;
+}
+body *|* {
+    height: 100px;
+}
+body s|* {
+    border-width: 10px;
+}
+</style>
+<svg></svg>
+<math></math>
+<div></div>

--- a/Userland/Libraries/LibWeb/CSS/CSSNamespaceRule.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSNamespaceRule.cpp
@@ -14,14 +14,14 @@
 
 namespace Web::CSS {
 
-CSSNamespaceRule::CSSNamespaceRule(JS::Realm& realm, Optional<StringView> prefix, StringView namespace_uri)
+CSSNamespaceRule::CSSNamespaceRule(JS::Realm& realm, Optional<DeprecatedString> prefix, StringView namespace_uri)
     : CSSRule(realm)
     , m_namespace_uri(namespace_uri)
-    , m_prefix(prefix.has_value() ? prefix.value() : ""sv)
+    , m_prefix(prefix.value_or(""sv))
 {
 }
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<CSSNamespaceRule>> CSSNamespaceRule::create(JS::Realm& realm, Optional<AK::StringView> prefix, AK::StringView namespace_uri)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<CSSNamespaceRule>> CSSNamespaceRule::create(JS::Realm& realm, Optional<DeprecatedString> prefix, AK::StringView namespace_uri)
 {
     return MUST_OR_THROW_OOM(realm.heap().allocate<CSSNamespaceRule>(realm, realm, prefix, namespace_uri));
 }

--- a/Userland/Libraries/LibWeb/CSS/CSSNamespaceRule.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSNamespaceRule.cpp
@@ -9,6 +9,7 @@
 #include <LibWeb/Bindings/CSSNamespaceRulePrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/CSS/CSSNamespaceRule.h>
+#include <LibWeb/CSS/Serialize.h>
 #include <LibWeb/WebIDL/ExceptionOr.h>
 
 namespace Web::CSS {
@@ -40,13 +41,13 @@ DeprecatedString CSSNamespaceRule::serialized() const
 
     // followed by the serialization as an identifier of the prefix attribute (if any),
     if (!m_prefix.is_empty() && !m_prefix.is_null()) {
-        builder.append(m_prefix);
+        serialize_an_identifier(builder, m_prefix).release_value_but_fixme_should_propagate_errors();
         // followed by a single SPACE (U+0020) if there is a prefix,
         builder.append(" "sv);
     }
 
     //  followed by the serialization as URL of the namespaceURI attribute,
-    builder.append(m_namespace_uri);
+    serialize_a_url(builder, m_namespace_uri).release_value_but_fixme_should_propagate_errors();
 
     // followed the character ";" (U+003B).
     builder.append(";"sv);

--- a/Userland/Libraries/LibWeb/CSS/CSSNamespaceRule.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSNamespaceRule.h
@@ -14,7 +14,7 @@ class CSSNamespaceRule final : public CSSRule {
     WEB_PLATFORM_OBJECT(CSSNamespaceRule, CSSRule);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<CSSNamespaceRule>> create(JS::Realm&, Optional<StringView> prefix, StringView namespace_uri);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<CSSNamespaceRule>> create(JS::Realm&, Optional<DeprecatedString> prefix, StringView namespace_uri);
 
     virtual ~CSSNamespaceRule() = default;
 
@@ -25,7 +25,7 @@ public:
     virtual Type type() const override { return Type::Namespace; }
 
 private:
-    CSSNamespaceRule(JS::Realm&, Optional<StringView> prefix, StringView namespace_uri);
+    CSSNamespaceRule(JS::Realm&, Optional<DeprecatedString> prefix, StringView namespace_uri);
 
     virtual void initialize(JS::Realm&) override;
 

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.h
@@ -50,6 +50,7 @@ public:
     void set_style_sheet_list(Badge<StyleSheetList>, StyleSheetList*);
 
     Optional<StringView> default_namespace() const;
+    Optional<StringView> namespace_uri(StringView namespace_prefix) const;
 
 private:
     CSSStyleSheet(JS::Realm&, CSSRuleList&, MediaList&, Optional<AK::URL> location);
@@ -61,6 +62,7 @@ private:
 
     JS::GCPtr<CSSRuleList> m_rules;
     JS::GCPtr<CSSNamespaceRule> m_default_namespace_rule;
+    HashMap<FlyString, JS::GCPtr<CSSNamespaceRule>> m_namespace_rules;
 
     JS::GCPtr<StyleSheetList> m_style_sheet_list;
     JS::GCPtr<CSSRule> m_owner_css_rule;

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -370,10 +370,9 @@ Parser::ParseErrorOr<Selector::SimpleSelector> Parser::parse_attribute_simple_se
         return ParseError::SyntaxError;
     }
 
-    // FIXME: Handle namespace prefix for attribute name.
-    auto const& attribute_part = attribute_tokens.next_token();
-    if (!attribute_part.is(Token::Type::Ident)) {
-        dbgln_if(CSS_PARSER_DEBUG, "Expected ident for attribute name, got: '{}'", attribute_part.to_debug_string());
+    auto maybe_qualified_name = parse_selector_qualified_name(attribute_tokens, AllowWildcardName::No);
+    if (!maybe_qualified_name.has_value()) {
+        dbgln_if(CSS_PARSER_DEBUG, "Expected qualified-name for attribute name, got: '{}'", attribute_tokens.peek_token().to_debug_string());
         return ParseError::SyntaxError;
     }
 
@@ -386,7 +385,7 @@ Parser::ParseErrorOr<Selector::SimpleSelector> Parser::parse_attribute_simple_se
             // they are converted to lowercase, so we do that here too. If we want to be
             // correct with XML later, we'll need to keep the original case and then do
             // a case-insensitive compare later.
-            .name = FlyString::from_deprecated_fly_string(attribute_part.token().ident().to_lowercase_string()).release_value_but_fixme_should_propagate_errors(),
+            .qualified_name = maybe_qualified_name.release_value(),
             .case_type = Selector::SimpleSelector::Attribute::CaseType::DefaultMatch,
         }
     };

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -3331,7 +3331,7 @@ CSSRule* Parser::convert_to_rule(NonnullRefPtr<Rule> rule)
             token_stream.skip_whitespace();
 
             auto token = token_stream.next_token();
-            Optional<StringView> prefix = {};
+            Optional<DeprecatedString> prefix = {};
             if (token.is(Token::Type::Ident)) {
                 prefix = token.token().ident();
                 token_stream.skip_whitespace();

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -349,7 +349,11 @@ private:
     ParseErrorOr<NonnullRefPtr<Selector>> parse_complex_selector(TokenStream<ComponentValue>&, SelectorType);
     ParseErrorOr<Optional<Selector::CompoundSelector>> parse_compound_selector(TokenStream<ComponentValue>&);
     Optional<Selector::Combinator> parse_selector_combinator(TokenStream<ComponentValue>&);
-
+    enum class AllowWildcardName {
+        No,
+        Yes,
+    };
+    Optional<Selector::SimpleSelector::QualifiedName> parse_selector_qualified_name(TokenStream<ComponentValue>&, AllowWildcardName);
     ParseErrorOr<Selector::SimpleSelector> parse_attribute_simple_selector(ComponentValue const&);
     ParseErrorOr<Selector::SimpleSelector> parse_pseudo_simple_selector(TokenStream<ComponentValue>&);
     ParseErrorOr<Optional<Selector::SimpleSelector>> parse_simple_selector(TokenStream<ComponentValue>&);

--- a/Userland/Libraries/LibWeb/CSS/Selector.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Selector.cpp
@@ -155,10 +155,15 @@ ErrorOr<String> Selector::SimpleSelector::serialize() const
         // 1. Append "[" (U+005B) to s.
         TRY(s.try_append('['));
 
-        // FIXME: 2. If the namespace prefix maps to a namespace that is not the null namespace (not in a namespace) append the serialization of the namespace prefix as an identifier, followed by a "|" (U+007C) to s.
+        // 2. If the namespace prefix maps to a namespace that is not the null namespace (not in a namespace)
+        //    append the serialization of the namespace prefix as an identifier, followed by a "|" (U+007C) to s.
+        if (attribute.qualified_name.namespace_type == QualifiedName::NamespaceType::Named) {
+            TRY(serialize_an_identifier(s, attribute.qualified_name.namespace_));
+            TRY(s.try_append('|'));
+        }
 
         // 3. Append the serialization of the attribute name as an identifier to s.
-        TRY(serialize_an_identifier(s, attribute.name));
+        TRY(serialize_an_identifier(s, attribute.qualified_name.name.name));
 
         // 4. If there is an attribute value specified, append "=", "~=", "|=", "^=", "$=", or "*=" as appropriate (depending on the type of attribute selector),
         //    followed by the serialization of the attribute value as a string, to s.

--- a/Userland/Libraries/LibWeb/CSS/Selector.h
+++ b/Userland/Libraries/LibWeb/CSS/Selector.h
@@ -177,7 +177,7 @@ public:
                 CaseInsensitiveMatch,
             };
             MatchType match_type;
-            FlyString name {};
+            QualifiedName qualified_name;
             String value {};
             CaseType case_type;
         };

--- a/Userland/Libraries/LibWeb/CSS/Selector.h
+++ b/Userland/Libraries/LibWeb/CSS/Selector.h
@@ -136,6 +136,31 @@ public:
             Vector<FlyString> languages {};
         };
 
+        struct Name {
+            Name(FlyString n)
+                : name(move(n))
+                , lowercase_name(name.to_string().to_lowercase().release_value_but_fixme_should_propagate_errors())
+            {
+            }
+
+            FlyString name;
+            FlyString lowercase_name;
+        };
+
+        // Equivalent to `<wq-name>`
+        // https://www.w3.org/TR/selectors-4/#typedef-wq-name
+        struct QualifiedName {
+            enum class NamespaceType {
+                Default, // `E`
+                None,    // `|E`
+                Any,     // `*|E`
+                Named,   // `ns|E`
+            };
+            NamespaceType namespace_type { NamespaceType::Default };
+            FlyString namespace_ {};
+            Name name;
+        };
+
         struct Attribute {
             enum class MatchType {
                 HasAttribute,
@@ -155,17 +180,6 @@ public:
             FlyString name {};
             String value {};
             CaseType case_type;
-        };
-
-        struct Name {
-            Name(FlyString n)
-                : name(move(n))
-                , lowercase_name(name.to_string().to_lowercase().release_value_but_fixme_should_propagate_errors())
-            {
-            }
-
-            FlyString name;
-            FlyString lowercase_name;
         };
 
         Type type;

--- a/Userland/Libraries/LibWeb/CSS/Selector.h
+++ b/Userland/Libraries/LibWeb/CSS/Selector.h
@@ -183,7 +183,7 @@ public:
         };
 
         Type type;
-        Variant<Empty, Attribute, PseudoClass, PseudoElement, Name> value {};
+        Variant<Empty, Attribute, PseudoClass, PseudoElement, Name, QualifiedName> value {};
 
         Attribute const& attribute() const { return value.get<Attribute>(); }
         Attribute& attribute() { return value.get<Attribute>(); }
@@ -196,6 +196,8 @@ public:
         FlyString& name() { return value.get<Name>().name; }
         FlyString const& lowercase_name() const { return value.get<Name>().lowercase_name; }
         FlyString& lowercase_name() { return value.get<Name>().lowercase_name; }
+        QualifiedName const& qualified_name() const { return value.get<QualifiedName>(); }
+        QualifiedName& qualified_name() { return value.get<QualifiedName>(); }
 
         ErrorOr<String> serialize() const;
     };

--- a/Userland/Libraries/LibWeb/CSS/SelectorEngine.h
+++ b/Userland/Libraries/LibWeb/CSS/SelectorEngine.h
@@ -11,6 +11,6 @@
 
 namespace Web::SelectorEngine {
 
-bool matches(CSS::Selector const&, DOM::Element const&, Optional<CSS::Selector::PseudoElement> = {}, JS::GCPtr<DOM::ParentNode const> scope = {});
+bool matches(CSS::Selector const&, Optional<CSS::CSSStyleSheet const&> style_sheet_for_rule, DOM::Element const&, Optional<CSS::Selector::PseudoElement> = {}, JS::GCPtr<DOM::ParentNode const> scope = {});
 
 }

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -267,7 +267,7 @@ Vector<MatchingRule> StyleComputer::collect_matching_rules(DOM::Element const& e
     matching_rules.ensure_capacity(rules_to_run.size());
     for (auto const& rule_to_run : rules_to_run) {
         auto const& selector = rule_to_run.rule->selectors()[rule_to_run.selector_index];
-        if (SelectorEngine::matches(selector, element, pseudo_element))
+        if (SelectorEngine::matches(selector, *rule_to_run.sheet, element, pseudo_element))
             matching_rules.append(rule_to_run);
     }
     return matching_rules;
@@ -2614,7 +2614,7 @@ NonnullOwnPtr<StyleComputer::RuleCache> StyleComputer::make_rule_cache_for_casca
                         break;
                     }
                     if (simple_selector.type == CSS::Selector::SimpleSelector::Type::TagName) {
-                        rule_cache->rules_by_tag_name.ensure(simple_selector.name()).append(move(matching_rule));
+                        rule_cache->rules_by_tag_name.ensure(simple_selector.qualified_name().name.lowercase_name).append(move(matching_rule));
                         ++num_tag_name_rules;
                         added_to_bucket = true;
                         break;

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -562,7 +562,7 @@ WebIDL::ExceptionOr<bool> Element::matches(StringView selectors) const
     // 3. If the result of match a selector against an element, using s, this, and scoping root this, returns success, then return true; otherwise, return false.
     auto sel = maybe_selectors.value();
     for (auto& s : sel) {
-        if (SelectorEngine::matches(s, *this, {}, static_cast<ParentNode const*>(this)))
+        if (SelectorEngine::matches(s, {}, *this, {}, static_cast<ParentNode const*>(this)))
             return true;
     }
     return false;
@@ -581,7 +581,7 @@ WebIDL::ExceptionOr<DOM::Element const*> Element::closest(StringView selectors) 
     auto matches_selectors = [this](CSS::SelectorList const& selector_list, Element const* element) {
         // 4. For each element in elements, if match a selector against an element, using s, element, and scoping root this, returns success, return element.
         for (auto& selector : selector_list) {
-            if (!SelectorEngine::matches(selector, *element, {}, this))
+            if (!SelectorEngine::matches(selector, {}, *element, {}, this))
                 return false;
         }
         return true;

--- a/Userland/Libraries/LibWeb/DOM/ParentNode.cpp
+++ b/Userland/Libraries/LibWeb/DOM/ParentNode.cpp
@@ -39,7 +39,7 @@ WebIDL::ExceptionOr<JS::GCPtr<Element>> ParentNode::query_selector(StringView se
     // FIXME: This should be shadow-including. https://drafts.csswg.org/selectors-4/#match-a-selector-against-a-tree
     for_each_in_subtree_of_type<Element>([&](auto& element) {
         for (auto& selector : selectors) {
-            if (SelectorEngine::matches(selector, element, {}, this)) {
+            if (SelectorEngine::matches(selector, {}, element, {}, this)) {
                 result = &element;
                 return IterationDecision::Break;
             }
@@ -71,7 +71,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<NodeList>> ParentNode::query_selector_all(S
     // FIXME: This should be shadow-including. https://drafts.csswg.org/selectors-4/#match-a-selector-against-a-tree
     for_each_in_subtree_of_type<Element>([&](auto& element) {
         for (auto& selector : selectors) {
-            if (SelectorEngine::matches(selector, element, {}, this)) {
+            if (SelectorEngine::matches(selector, {}, element, {}, this)) {
                 elements.append(&element);
             }
         }

--- a/Userland/Libraries/LibWeb/Dump.cpp
+++ b/Userland/Libraries/LibWeb/Dump.cpp
@@ -447,8 +447,27 @@ void dump_selector(StringBuilder& builder, CSS::Selector const& selector)
 
             builder.appendff("{}:", type_description);
             // FIXME: This is goofy
-            if (simple_selector.value.has<CSS::Selector::SimpleSelector::Name>())
+            if (simple_selector.value.has<CSS::Selector::SimpleSelector::Name>()) {
                 builder.append(simple_selector.name());
+            } else if (simple_selector.value.has<CSS::Selector::SimpleSelector::QualifiedName>()) {
+                auto qualified_name = simple_selector.qualified_name();
+                StringView namespace_type;
+                switch (qualified_name.namespace_type) {
+                case CSS::Selector::SimpleSelector::QualifiedName::NamespaceType::Default:
+                    namespace_type = "Default"sv;
+                    break;
+                case CSS::Selector::SimpleSelector::QualifiedName::NamespaceType::None:
+                    namespace_type = "None"sv;
+                    break;
+                case CSS::Selector::SimpleSelector::QualifiedName::NamespaceType::Any:
+                    namespace_type = "Any"sv;
+                    break;
+                case CSS::Selector::SimpleSelector::QualifiedName::NamespaceType::Named:
+                    namespace_type = "Named"sv;
+                    break;
+                }
+                builder.appendff(" [NamespaceType={}, Namespace='{}', Name='{}']", namespace_type, qualified_name.namespace_, qualified_name.name.name);
+            }
 
             if (simple_selector.type == CSS::Selector::SimpleSelector::Type::PseudoClass) {
                 auto const& pseudo_class = simple_selector.pseudo_class();


### PR DESCRIPTION
Fully supported:
- Namespaces in universal selectors. (`*|*`, `foo|*`, `|*`)
- Namespaces in tag-name selectors. (`*|a`, `foo|a`, `|a`)

Parsed but not functional:
- Namespaces in attribute selectors. (`[*|bar]`, `[|bar]`)

Also fix a couple of bugs with `@namespace` rules that I ran into.