### PR TITLE
Ladybird+WebDriver: Only load a single URL at launch

### DIFF
--- a/AK/URLParser.cpp
+++ b/AK/URLParser.cpp
@@ -632,7 +632,9 @@ ErrorOr<String> URLParser::serialize_host(URL::Host const& host)
     }
 
     // 3. Otherwise, host is a domain, opaque host, or empty host, return host.
-    return host.get<String>();
+    if (host.has<String>())
+        return host.get<String>();
+    return String {};
 }
 
 // https://url.spec.whatwg.org/#start-with-a-windows-drive-letter

--- a/Base/res/html/misc/new-tab.html
+++ b/Base/res/html/misc/new-tab.html
@@ -46,7 +46,6 @@
             <div id="search-buttons">
                 <button type="button" onclick="search('bing')">Bing</button>
                 <button type="button" onclick="search('duckduckgo')">DuckDuckGo</button>
-                <button type="button" onclick="search('frogfind')">FrogFind</button>
                 <button type="button" onclick="search('github')">GitHub</button>
                 <button type="button" onclick="search('google')">Google</button>
                 <button type="button" onclick="search('wiby')">Wiby</button>
@@ -77,9 +76,6 @@
                 url.searchParams.set("q", query);
             } else if (searchEngine == "duckduckgo") {
                 url = new URL("https://duckduckgo.com");
-                url.searchParams.set("q", query);
-            } else if (searchEngine == "frogfind") {
-                url = new URL("https://frogfind.com");
                 url.searchParams.set("q", query);
             } else if (searchEngine == "github") {
                 url = new URL("https://github.com/search");

--- a/Ladybird/Qt/BrowserWindow.cpp
+++ b/Ladybird/Qt/BrowserWindow.cpp
@@ -495,12 +495,8 @@ Tab& BrowserWindow::new_tab(QString const& url, Web::HTML::ActivateTab activate_
 
     tab_ptr->focus_location_editor();
 
-    // We *don't* load the initial page if we are connected to a WebDriver, as the Set URL command may come in very
-    // quickly, and become replaced by this load.
-    if (m_webdriver_content_ipc_path.is_empty()) {
-        // We make it HistoryNavigation so that the initial page doesn't get added to the history.
-        tab_ptr->navigate(url, Tab::LoadType::HistoryNavigation);
-    }
+    // We make it HistoryNavigation so that the initial page doesn't get added to the history.
+    tab_ptr->navigate(url, Tab::LoadType::HistoryNavigation);
 
     return *tab_ptr;
 }

--- a/Ladybird/Qt/BrowserWindow.cpp
+++ b/Ladybird/Qt/BrowserWindow.cpp
@@ -40,7 +40,7 @@ static QIcon const& app_icon()
     return icon;
 }
 
-BrowserWindow::BrowserWindow(Browser::CookieJar& cookie_jar, StringView webdriver_content_ipc_path, WebView::EnableCallgrindProfiling enable_callgrind_profiling, UseLagomNetworking use_lagom_networking)
+BrowserWindow::BrowserWindow(Optional<URL> const& initial_url, Browser::CookieJar& cookie_jar, StringView webdriver_content_ipc_path, WebView::EnableCallgrindProfiling enable_callgrind_profiling, UseLagomNetworking use_lagom_networking)
     : m_cookie_jar(cookie_jar)
     , m_webdriver_content_ipc_path(webdriver_content_ipc_path)
     , m_enable_callgrind_profiling(enable_callgrind_profiling)
@@ -397,7 +397,12 @@ BrowserWindow::BrowserWindow(Browser::CookieJar& cookie_jar, StringView webdrive
     m_go_back_action->setEnabled(false);
     m_go_forward_action->setEnabled(false);
 
-    new_tab(s_settings->new_tab_page(), Web::HTML::ActivateTab::Yes);
+    if (initial_url.has_value()) {
+        auto initial_url_string = qstring_from_ak_deprecated_string(initial_url->serialize());
+        new_tab(initial_url_string, Web::HTML::ActivateTab::Yes);
+    } else {
+        new_tab(s_settings->new_tab_page(), Web::HTML::ActivateTab::Yes);
+    }
 
     setCentralWidget(m_tabs_container);
     setContextMenuPolicy(Qt::PreventContextMenu);

--- a/Ladybird/Qt/BrowserWindow.h
+++ b/Ladybird/Qt/BrowserWindow.h
@@ -28,7 +28,7 @@ class WebContentView;
 class BrowserWindow : public QMainWindow {
     Q_OBJECT
 public:
-    explicit BrowserWindow(Browser::CookieJar&, StringView webdriver_content_ipc_path, WebView::EnableCallgrindProfiling, UseLagomNetworking);
+    explicit BrowserWindow(Optional<URL> const& initial_url, Browser::CookieJar&, StringView webdriver_content_ipc_path, WebView::EnableCallgrindProfiling, UseLagomNetworking);
 
     WebContentView& view() const { return m_current_tab->view(); }
 

--- a/Ladybird/Qt/main.cpp
+++ b/Ladybird/Qt/main.cpp
@@ -107,17 +107,15 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto cookie_jar = database ? TRY(Browser::CookieJar::create(*database)) : Browser::CookieJar::create();
 
+    Optional<URL> initial_url;
+    if (auto url = TRY(get_formatted_url(raw_url)); url.is_valid())
+        initial_url = move(url);
+
     Ladybird::s_settings = adopt_own_if_nonnull(new Ladybird::Settings());
-    Ladybird::BrowserWindow window(cookie_jar, webdriver_content_ipc_path, enable_callgrind_profiling ? WebView::EnableCallgrindProfiling::Yes : WebView::EnableCallgrindProfiling::No, use_lagom_networking ? Ladybird::UseLagomNetworking::Yes : Ladybird::UseLagomNetworking::No);
+    Ladybird::BrowserWindow window(initial_url, cookie_jar, webdriver_content_ipc_path, enable_callgrind_profiling ? WebView::EnableCallgrindProfiling::Yes : WebView::EnableCallgrindProfiling::No, use_lagom_networking ? Ladybird::UseLagomNetworking::Yes : Ladybird::UseLagomNetworking::No);
     window.setWindowTitle("Ladybird");
     window.resize(800, 600);
     window.show();
-
-    if (auto url = TRY(get_formatted_url(raw_url)); url.is_valid()) {
-        window.view().load(url);
-    } else {
-        window.view().load("about:blank"sv);
-    }
 
     return event_loop.exec();
 }

--- a/Ladybird/WebDriver/main.cpp
+++ b/Ladybird/WebDriver/main.cpp
@@ -36,6 +36,7 @@ static ErrorOr<pid_t> launch_browser(DeprecatedString const& socket_path)
         Array {
             "--webdriver-content-path",
             socket_path.characters(),
+            "about:blank",
         });
 }
 

--- a/Userland/Applications/Browser/main.cpp
+++ b/Userland/Applications/Browser/main.cpp
@@ -114,9 +114,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Desktop::Launcher::add_allowed_url(URL::create_with_file_scheme(Core::StandardPaths::downloads_directory())));
     TRY(Desktop::Launcher::seal_allowlist());
 
-    if (!Browser::g_webdriver_content_ipc_path.is_empty())
-        specified_urls.empend("about:blank");
-
     TRY(Core::System::unveil("/tmp/session/%sid/portal/filesystemaccess", "rw"));
     TRY(Core::System::unveil("/tmp/session/%sid/portal/filesystemaccess", "rw"));
     TRY(Core::System::unveil("/tmp/session/%sid/portal/image", "rw"));

--- a/Userland/Services/WebDriver/main.cpp
+++ b/Userland/Services/WebDriver/main.cpp
@@ -20,6 +20,7 @@ static ErrorOr<pid_t> launch_browser(DeprecatedString const& socket_path)
         Array {
             "--webdriver-content-path",
             socket_path.characters(),
+            "about:blank",
         });
 }
 


### PR DESCRIPTION
When we launch Ladybird, we currently:

1. Create a BrowserWindow, whose constructor navigates to the configured
   new tab page URL.
2. Then navigate to either "about:blank" or whatever URL is provided via
   the command line.

This patch removes step 2 and forwards the URL from the command line (if
any) to BrowserWindow. BrowserWindow's constructor then either navigates
to that URL or the new tab page URL.