### PR TITLE
AudioServer: A few cleanups

### DIFF
--- a/Userland/Services/AudioServer/CMakeLists.txt
+++ b/Userland/Services/AudioServer/CMakeLists.txt
@@ -10,6 +10,7 @@ compile_ipc(AudioManagerClient.ipc AudioManagerClientEndpoint.h)
 compile_ipc(AudioManagerServer.ipc AudioManagerServerEndpoint.h)
 
 set(SOURCES
+    ClientAudioStream.cpp
     ConnectionFromClient.cpp
     ConnectionFromManagerClient.cpp
     Mixer.cpp

--- a/Userland/Services/AudioServer/ClientAudioStream.cpp
+++ b/Userland/Services/AudioServer/ClientAudioStream.cpp
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2018-2022, the SerenityOS developers.
+ * Copyright (c) 2021-2023, kleines Filmröllchen <filmroellchen@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "ClientAudioStream.h"
+#include <LibAudio/Resampler.h>
+
+namespace AudioServer {
+
+ClientAudioStream::ClientAudioStream(ConnectionFromClient& client)
+    : m_client(client)
+{
+}
+
+ConnectionFromClient* ClientAudioStream::client()
+{
+    return m_client.ptr();
+}
+
+bool ClientAudioStream::is_connected() const
+{
+    return m_client && m_client->is_open();
+}
+
+bool ClientAudioStream::get_next_sample(Audio::Sample& sample, u32 audiodevice_sample_rate)
+{
+    // Note: Even though we only check client state here, we will probably close the client much earlier.
+    if (!is_connected())
+        return false;
+
+    if (m_paused)
+        return false;
+
+    if (m_in_chunk_location >= m_current_audio_chunk.size()) {
+        auto result = m_buffer->dequeue();
+        if (result.is_error()) {
+            if (result.error() == Audio::AudioQueue::QueueStatus::Empty) {
+                dbgln_if(AUDIO_DEBUG, "Audio client {} can't keep up!", m_client->client_id());
+            }
+
+            return false;
+        }
+        // FIXME: Our resampler and the way we resample here are bad.
+        //        Ideally, we should both do perfect band-corrected resampling,
+        //        as well as carry resampling state over between buffers.
+        auto attempted_resample = Audio::ResampleHelper<Audio::Sample> {
+            m_sample_rate == 0 ? audiodevice_sample_rate : m_sample_rate, audiodevice_sample_rate
+        }
+                                      .try_resample(result.release_value());
+        if (attempted_resample.is_error())
+            return false;
+
+        // If the sample rate changes underneath us, we will still play the existing buffer unchanged until we're done.
+        // This is not a significant problem since the buffers are very small (~100 samples or less).
+        m_current_audio_chunk = attempted_resample.release_value();
+        m_in_chunk_location = 0;
+    }
+
+    sample = m_current_audio_chunk[m_in_chunk_location++];
+
+    return true;
+}
+
+void ClientAudioStream::set_buffer(OwnPtr<Audio::AudioQueue> buffer)
+{
+    m_buffer = move(buffer);
+}
+
+void ClientAudioStream::clear()
+{
+    ErrorOr<Array<Audio::Sample, Audio::AUDIO_BUFFER_SIZE>, Audio::AudioQueue::QueueStatus> result = Audio::AudioQueue::QueueStatus::Invalid;
+    do {
+        result = m_buffer->dequeue();
+    } while (!result.is_error() || result.error() != Audio::AudioQueue::QueueStatus::Empty);
+}
+
+void ClientAudioStream::set_paused(bool paused)
+{
+    m_paused = paused;
+}
+
+FadingProperty<double>& ClientAudioStream::volume()
+{
+    return m_volume;
+}
+
+double ClientAudioStream::volume() const
+{
+    return m_volume;
+}
+
+void ClientAudioStream::set_volume(double const volume)
+{
+    m_volume = volume;
+}
+
+bool ClientAudioStream::is_muted() const
+{
+    return m_muted;
+}
+
+void ClientAudioStream::set_muted(bool muted)
+{
+    m_muted = muted;
+}
+
+u32 ClientAudioStream::sample_rate() const
+{
+    return m_sample_rate;
+}
+
+void ClientAudioStream::set_sample_rate(u32 sample_rate)
+{
+    dbgln_if(AUDIO_DEBUG, "queue {} got sample rate {} Hz", m_client->client_id(), sample_rate);
+    m_sample_rate = sample_rate;
+}
+
+}

--- a/Userland/Services/AudioServer/ClientAudioStream.h
+++ b/Userland/Services/AudioServer/ClientAudioStream.h
@@ -10,7 +10,6 @@
 #include "ConnectionFromClient.h"
 #include "FadingProperty.h"
 #include <AK/Atomic.h>
-#include <AK/Badge.h>
 #include <AK/Debug.h>
 #include <AK/RefCounted.h>
 #include <AK/WeakPtr.h>
@@ -20,22 +19,29 @@ namespace AudioServer {
 
 class ClientAudioStream : public RefCounted<ClientAudioStream> {
 public:
+    enum class ErrorState {
+        ClientDisconnected,
+        ClientPaused,
+        ClientUnderrun,
+        ResamplingError,
+    };
+
     explicit ClientAudioStream(ConnectionFromClient&);
     ~ClientAudioStream() = default;
 
-    bool get_next_sample(Audio::Sample& sample, u32 audiodevice_sample_rate);
+    ErrorOr<Audio::Sample, ErrorState> get_next_sample(u32 audiodevice_sample_rate);
     void clear();
 
     bool is_connected() const;
 
-    ConnectionFromClient* client();
+    Optional<ConnectionFromClient&> client();
 
-    void set_buffer(OwnPtr<Audio::AudioQueue> buffer);
+    void set_buffer(NonnullOwnPtr<Audio::AudioQueue> buffer);
 
     void set_paused(bool paused);
     FadingProperty<double>& volume();
     double volume() const;
-    void set_volume(double const volume);
+    void set_volume(double volume);
     bool is_muted() const;
     void set_muted(bool muted);
     u32 sample_rate() const;

--- a/Userland/Services/AudioServer/ClientAudioStream.h
+++ b/Userland/Services/AudioServer/ClientAudioStream.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2018-2022, the SerenityOS developers.
+ * Copyright (c) 2021-2023, kleines Filmröllchen <filmroellchen@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include "ConnectionFromClient.h"
+#include "FadingProperty.h"
+#include <AK/Atomic.h>
+#include <AK/Badge.h>
+#include <AK/Debug.h>
+#include <AK/RefCounted.h>
+#include <AK/WeakPtr.h>
+#include <LibAudio/Queue.h>
+
+namespace AudioServer {
+
+class ClientAudioStream : public RefCounted<ClientAudioStream> {
+public:
+    explicit ClientAudioStream(ConnectionFromClient&);
+    ~ClientAudioStream() = default;
+
+    bool get_next_sample(Audio::Sample& sample, u32 audiodevice_sample_rate);
+    void clear();
+
+    bool is_connected() const;
+
+    ConnectionFromClient* client();
+
+    void set_buffer(OwnPtr<Audio::AudioQueue> buffer);
+
+    void set_paused(bool paused);
+    FadingProperty<double>& volume();
+    double volume() const;
+    void set_volume(double const volume);
+    bool is_muted() const;
+    void set_muted(bool muted);
+    u32 sample_rate() const;
+    void set_sample_rate(u32 sample_rate);
+
+private:
+    OwnPtr<Audio::AudioQueue> m_buffer;
+    Vector<Audio::Sample> m_current_audio_chunk;
+    size_t m_in_chunk_location;
+
+    bool m_paused { true };
+    bool m_muted { false };
+    u32 m_sample_rate;
+
+    WeakPtr<ConnectionFromClient> m_client;
+    FadingProperty<double> m_volume { 1 };
+};
+
+}

--- a/Userland/Services/AudioServer/FadingProperty.h
+++ b/Userland/Services/AudioServer/FadingProperty.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include "Mixer.h"
 namespace AudioServer {
 
 // This is in buffer counts.

--- a/Userland/Services/AudioServer/Mixer.cpp
+++ b/Userland/Services/AudioServer/Mixer.cpp
@@ -187,9 +187,4 @@ void Mixer::request_setting_sync()
     }
 }
 
-ClientAudioStream::ClientAudioStream(ConnectionFromClient& client)
-    : m_client(client)
-{
-}
-
 }

--- a/Userland/Services/AudioServer/Mixer.cpp
+++ b/Userland/Services/AudioServer/Mixer.cpp
@@ -73,18 +73,20 @@ void Mixer::mix()
 
         // Mix the buffers together into the output
         for (auto& queue : active_mix_queues) {
-            if (!queue->client()) {
+            if (!queue->client().has_value()) {
                 queue->clear();
                 continue;
             }
             queue->volume().advance_time();
 
+            // FIXME: Perform sample extraction and mixing in two separate loops so they can be more easily vectorized.
             for (auto& mixed_sample : mixed_buffer) {
-                Audio::Sample sample;
-                if (!queue->get_next_sample(sample, audiodevice_get_sample_rate()))
+                auto sample_or_error = queue->get_next_sample(audiodevice_get_sample_rate());
+                if (sample_or_error.is_error())
                     break;
                 if (queue->is_muted())
                     continue;
+                auto sample = sample_or_error.release_value();
                 sample.log_multiply(SAMPLE_HEADROOM);
                 sample.log_multiply(static_cast<float>(queue->volume()));
                 mixed_sample += sample;

--- a/Userland/Services/AudioServer/Mixer.h
+++ b/Userland/Services/AudioServer/Mixer.h
@@ -1,12 +1,13 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
- * Copyright (c) 2021-2022, kleines Filmröllchen <filmroellchen@serenityos.org>
+ * Copyright (c) 2021-2023, kleines Filmröllchen <filmroellchen@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #pragma once
 
+#include "ClientAudioStream.h"
 #include "ConnectionFromClient.h"
 #include "FadingProperty.h"
 #include <AK/Atomic.h>
@@ -24,7 +25,6 @@
 #include <LibThreading/ConditionVariable.h>
 #include <LibThreading/Mutex.h>
 #include <LibThreading/Thread.h>
-#include <sys/types.h>
 
 namespace AudioServer {
 
@@ -35,93 +35,6 @@ constexpr double SAMPLE_HEADROOM = 0.95;
 constexpr size_t HARDWARE_BUFFER_SIZE = 512;
 // The hardware buffer size in bytes; there's two channels of 16-bit samples.
 constexpr size_t HARDWARE_BUFFER_SIZE_BYTES = HARDWARE_BUFFER_SIZE * 2 * sizeof(i16);
-
-class ConnectionFromClient;
-
-class ClientAudioStream : public RefCounted<ClientAudioStream> {
-public:
-    explicit ClientAudioStream(ConnectionFromClient&);
-    ~ClientAudioStream() = default;
-
-    bool get_next_sample(Audio::Sample& sample, u32 audiodevice_sample_rate)
-    {
-        // Note: Even though we only check client state here, we will probably close the client much earlier.
-        if (!is_connected())
-            return false;
-
-        if (m_paused)
-            return false;
-
-        if (m_in_chunk_location >= m_current_audio_chunk.size()) {
-            auto result = m_buffer->dequeue();
-            if (result.is_error()) {
-                if (result.error() == Audio::AudioQueue::QueueStatus::Empty) {
-                    dbgln_if(AUDIO_DEBUG, "Audio client {} can't keep up!", m_client->client_id());
-                }
-
-                return false;
-            }
-            // FIXME: Our resampler and the way we resample here are bad.
-            //        Ideally, we should both do perfect band-corrected resampling,
-            //        as well as carry resampling state over between buffers.
-            auto attempted_resample = Audio::ResampleHelper<Audio::Sample> {
-                m_sample_rate == 0 ? audiodevice_sample_rate : m_sample_rate, audiodevice_sample_rate
-            }
-                                          .try_resample(result.release_value());
-            if (attempted_resample.is_error())
-                return false;
-
-            // If the sample rate changes underneath us, we will still play the existing buffer unchanged until we're done.
-            // This is not a significant problem since the buffers are very small (~100 samples or less).
-            m_current_audio_chunk = attempted_resample.release_value();
-            m_in_chunk_location = 0;
-        }
-
-        sample = m_current_audio_chunk[m_in_chunk_location++];
-
-        return true;
-    }
-
-    bool is_connected() const { return m_client && m_client->is_open(); }
-
-    ConnectionFromClient* client() { return m_client.ptr(); }
-
-    void set_buffer(OwnPtr<Audio::AudioQueue> buffer) { m_buffer = move(buffer); }
-
-    void clear()
-    {
-        ErrorOr<Array<Audio::Sample, Audio::AUDIO_BUFFER_SIZE>, Audio::AudioQueue::QueueStatus> result = Audio::AudioQueue::QueueStatus::Invalid;
-        do {
-            result = m_buffer->dequeue();
-        } while (!result.is_error() || result.error() != Audio::AudioQueue::QueueStatus::Empty);
-    }
-
-    void set_paused(bool paused) { m_paused = paused; }
-
-    FadingProperty<double>& volume() { return m_volume; }
-    double volume() const { return m_volume; }
-    void set_volume(double const volume) { m_volume = volume; }
-    bool is_muted() const { return m_muted; }
-    void set_muted(bool muted) { m_muted = muted; }
-    u32 sample_rate() const { return m_sample_rate; }
-    void set_sample_rate(u32 sample_rate)
-    {
-        dbgln_if(AUDIO_DEBUG, "queue {} got sample rate {} Hz", m_client->client_id(), sample_rate);
-        m_sample_rate = sample_rate;
-    }
-
-private:
-    OwnPtr<Audio::AudioQueue> m_buffer;
-    Vector<Audio::Sample> m_current_audio_chunk;
-    size_t m_in_chunk_location;
-
-    bool m_paused { true };
-    bool m_muted { false };
-    u32 m_sample_rate;
-
-    WeakPtr<ConnectionFromClient> m_client;
-    FadingProperty<double> m_volume { 1 };
-};
 
 class Mixer : public Core::EventReceiver {
     C_OBJECT_ABSTRACT(Mixer)


### PR DESCRIPTION
Preparation for more resampling / GUI mixer work.
### AudioServer: Move ClientAudioStream to own files

This class will only grow, and it should really have its own files.

### AudioServer: Clean up ClientAudioStream APIs

- Use Optional references instead of pointers
- Clean up some const and nullability weirdness
- Use proper error return value for get_next_sample

