### PR TITLE
LibGfx/JPEGXL: Add support for complex distribution clustering

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/JPEGXLLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEGXLLoader.cpp
@@ -1201,8 +1201,12 @@ private:
     ErrorOr<void> read_pre_clustered_distributions(LittleEndianInputBitStream& stream, u8 num_distrib)
     {
         // C.2.2  Distribution clustering
-        if (num_distrib == 1)
-            TODO();
+        if (num_distrib == 1) {
+            // If num_dist == 1, then num_clusters = 1 and clusters[0] = 0, and the remainder of this subclause is skipped.
+            m_clusters = { 0 };
+            TRY(m_configs.try_resize(1));
+            return {};
+        };
 
         TRY(m_clusters.try_resize(num_distrib));
 


### PR DESCRIPTION
**LibGfx/JPEGXL: Support clusters with a single distribution**

This type of cluster is an exception and has specific rules (but
simpler) to be read. This is a requirement to support complex
distributions as they use a symbol decoder initialized with a single
distribution.

**LibGfx/JPEGXL: Add support for complex distribution clustering**

Complex distribution - distributions that are encoded using an internal
symbol decoder with a single distribution, are very often used for lz77
compressed images. This is a requirement for the lz77_flower test case.


---

Again, this is not useful on its own, but a requirement for lz77_flower and probably many other images.