### PR TITLE
LibWeb: Add directory entries page when visiting a local directory

### DIFF
--- a/Base/res/html/directory.html
+++ b/Base/res/html/directory.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="UTF-8">
+        <title>Index of @path@</title>
+        <style>
+            header {
+                margin-bottom: 10px;
+            }
+            h1 {
+                display: inline;
+            }
+            a {
+                text-decoration: none;
+            }
+            a:focus, a:hover {
+                text-decoration: underline;
+            }
+            table {
+                font-family: monospace;
+            }
+
+            .folder, .file, .open-parent {
+                display: inline-block;
+                width: 16px;
+                height: 16px;
+                margin-right: 5px;
+                background-size: contain;
+            }
+            .folder {
+                background-image: url('@resource_directory_url@/icons/32x32/filetype-folder.png');
+            }
+            .file {
+                background-image: url('@resource_directory_url@/icons/32x32/filetype-unknown.png');
+            }
+            .open-parent {
+                background-image: url('@resource_directory_url@/icons/16x16/open-parent-directory.png');
+            }
+        </style>
+    </head>
+    <body>
+        <header>
+            <span class="folder" style="width: 24px; height: 24px;"></span>
+            <h1>Index of @path@</h1>
+        </header>
+        <p><a href="file://@parent_path@"><span class="open-parent"></span>Open Parent Directory</a></p>
+        <hr>
+        @contents@
+        <hr>
+    </body>
+</html>

--- a/Base/res/html/error.html
+++ b/Base/res/html/error.html
@@ -9,11 +9,14 @@
             header {
                 margin-bottom: 10px;
             }
+            img {
+                margin-right: 5px;
+            }
         </style>
     </head>
     <body>
         <header>
-            <img src="../icons/32x32/msgbox-warning.png" alt="Warning" width="24" height="24">
+            <img src="@resource_directory_url@/icons/32x32/msgbox-warning.png" alt="Warning" width="24" height="24">
             <h1>Failed to load @failed_url@</h1>
         </header>
         <p>Error: @error@</p>

--- a/Ladybird/WebContent/main.cpp
+++ b/Ladybird/WebContent/main.cpp
@@ -98,6 +98,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     Web::Platform::FontPlugin::install(*new Ladybird::FontPlugin(is_layout_test_mode));
 
+    Web::FrameLoader::set_resource_directory_url(DeprecatedString::formatted("file://{}/res", s_serenity_resource_root));
     Web::FrameLoader::set_error_page_url(DeprecatedString::formatted("file://{}/res/html/error.html", s_serenity_resource_root));
 
     TRY(Web::Bindings::initialize_main_thread_vm());

--- a/Ladybird/WebContent/main.cpp
+++ b/Ladybird/WebContent/main.cpp
@@ -100,6 +100,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     Web::FrameLoader::set_resource_directory_url(DeprecatedString::formatted("file://{}/res", s_serenity_resource_root));
     Web::FrameLoader::set_error_page_url(DeprecatedString::formatted("file://{}/res/html/error.html", s_serenity_resource_root));
+    Web::FrameLoader::set_directory_page_url(DeprecatedString::formatted("file://{}/res/html/directory.html", s_serenity_resource_root));
 
     TRY(Web::Bindings::initialize_main_thread_vm());
 

--- a/Meta/gn/secondary/Userland/Libraries/LibWeb/Loader/BUILD.gn
+++ b/Meta/gn/secondary/Userland/Libraries/LibWeb/Loader/BUILD.gn
@@ -3,6 +3,7 @@ source_set("Loader") {
   deps = [ "//Userland/Libraries/LibWeb:all_generated" ]
   sources = [
     "ContentFilter.cpp",
+    "FileDirectoryLoader.cpp",
     "FileRequest.cpp",
     "FrameLoader.cpp",
     "LoadRequest.cpp",

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -444,6 +444,7 @@ set(SOURCES
     Layout/TreeBuilder.cpp
     Layout/VideoBox.cpp
     Loader/ContentFilter.cpp
+    Loader/FileDirectoryLoader.cpp
     Loader/FileRequest.cpp
     Loader/FrameLoader.cpp
     Loader/LoadRequest.cpp

--- a/Userland/Libraries/LibWeb/Loader/FileDirectoryLoader.cpp
+++ b/Userland/Libraries/LibWeb/Loader/FileDirectoryLoader.cpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2023, Bastiaan van der Plaat <bastiaan.v.d.plaat@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/QuickSort.h>
+#include <AK/SourceGenerator.h>
+#include <LibCore/DateTime.h>
+#include <LibCore/Directory.h>
+#include <LibCore/System.h>
+#include <LibWeb/Loader/FileDirectoryLoader.h>
+#include <LibWeb/Loader/FrameLoader.h>
+
+namespace Web {
+
+ErrorOr<DeprecatedString> load_file_directory_page(LoadRequest const& request)
+{
+    // Generate HTML contents entries table
+    auto lexical_path = LexicalPath(request.url().serialize_path());
+    Core::DirIterator dt(lexical_path.string(), Core::DirIterator::Flags::SkipParentAndBaseDir);
+    Vector<DeprecatedString> names;
+    while (dt.has_next())
+        names.append(dt.next_path());
+    quick_sort(names);
+
+    StringBuilder contents;
+    contents.append("<table>"sv);
+    for (auto& name : names) {
+        auto path = lexical_path.append(name);
+        auto maybe_st = Core::System::stat(path.string());
+        if (!maybe_st.is_error()) {
+            auto st = maybe_st.release_value();
+            contents.append("<tr>"sv);
+            contents.appendff("<td><span class=\"{}\"></span></td>", S_ISDIR(st.st_mode) ? "folder" : "file");
+            contents.appendff("<td><a href=\"file://{}\">{}</a></td><td>&nbsp;</td>"sv, path, name);
+            contents.appendff("<td>{:10}</td><td>&nbsp;</td>", st.st_size);
+            contents.appendff("<td>{}</td>"sv, Core::DateTime::from_timestamp(st.st_mtime).to_deprecated_string());
+            contents.append("</tr>\n"sv);
+        }
+    }
+    contents.append("</table>"sv);
+
+    // Generate HTML directory page from directory template file
+    // FIXME: Use an actual templating engine (our own one when it's built, preferably with a way to check these usages at compile time)
+    auto template_path = AK::URL::create_with_url_or_path(FrameLoader::directory_page_url()).serialize_path();
+    auto template_file = TRY(Core::File::open(template_path, Core::File::OpenMode::Read));
+    auto template_contents = TRY(template_file->read_until_eof());
+    StringBuilder builder;
+    SourceGenerator generator { builder };
+    generator.set("resource_directory_url", FrameLoader::resource_directory_url());
+    generator.set("path", escape_html_entities(lexical_path.string()));
+    generator.set("parent_path", escape_html_entities(lexical_path.parent().string()));
+    generator.set("contents", contents.to_deprecated_string());
+    generator.append(template_contents);
+    return generator.as_string_view().to_deprecated_string();
+}
+
+}

--- a/Userland/Libraries/LibWeb/Loader/FileDirectoryLoader.h
+++ b/Userland/Libraries/LibWeb/Loader/FileDirectoryLoader.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2023, Bastiaan van der Plaat <bastiaan.v.d.plaat@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibWeb/Loader/Resource.h>
+
+namespace Web {
+
+ErrorOr<DeprecatedString> load_file_directory_page(LoadRequest const&);
+
+}

--- a/Userland/Libraries/LibWeb/Loader/FrameLoader.cpp
+++ b/Userland/Libraries/LibWeb/Loader/FrameLoader.cpp
@@ -193,6 +193,18 @@ void FrameLoader::set_error_page_url(DeprecatedString error_page_url)
     s_error_page_url = error_page_url;
 }
 
+static DeprecatedString s_directory_page_url = "file:///res/html/directory.html";
+
+DeprecatedString FrameLoader::directory_page_url()
+{
+    return s_directory_page_url;
+}
+
+void FrameLoader::set_directory_page_url(DeprecatedString directory_page_url)
+{
+    s_directory_page_url = directory_page_url;
+}
+
 // FIXME: Use an actual templating engine (our own one when it's built, preferably
 // with a way to check these usages at compile time)
 

--- a/Userland/Libraries/LibWeb/Loader/FrameLoader.cpp
+++ b/Userland/Libraries/LibWeb/Loader/FrameLoader.cpp
@@ -169,7 +169,24 @@ void FrameLoader::load_html(StringView html, const AK::URL& url)
     parser->run(url);
 }
 
+static DeprecatedString s_resource_directory_url = "file:///res";
+
+DeprecatedString FrameLoader::resource_directory_url()
+{
+    return s_resource_directory_url;
+}
+
+void FrameLoader::set_resource_directory_url(DeprecatedString resource_directory_url)
+{
+    s_resource_directory_url = resource_directory_url;
+}
+
 static DeprecatedString s_error_page_url = "file:///res/html/error.html";
+
+DeprecatedString FrameLoader::error_page_url()
+{
+    return s_error_page_url;
+}
 
 void FrameLoader::set_error_page_url(DeprecatedString error_page_url)
 {
@@ -189,6 +206,7 @@ void FrameLoader::load_error_page(const AK::URL& failed_url, DeprecatedString co
             VERIFY(!data.is_null());
             StringBuilder builder;
             SourceGenerator generator { builder };
+            generator.set("resource_directory_url", resource_directory_url());
             generator.set("failed_url", escape_html_entities(failed_url.to_deprecated_string()));
             generator.set("error", escape_html_entities(error));
             generator.append(data);

--- a/Userland/Libraries/LibWeb/Loader/FrameLoader.h
+++ b/Userland/Libraries/LibWeb/Loader/FrameLoader.h
@@ -25,6 +25,9 @@ public:
     };
 
     static void set_default_favicon_path(DeprecatedString);
+    static DeprecatedString resource_directory_url();
+    static void set_resource_directory_url(DeprecatedString);
+    static DeprecatedString error_page_url();
     static void set_error_page_url(DeprecatedString);
 
     explicit FrameLoader(HTML::BrowsingContext&);

--- a/Userland/Libraries/LibWeb/Loader/FrameLoader.h
+++ b/Userland/Libraries/LibWeb/Loader/FrameLoader.h
@@ -29,6 +29,8 @@ public:
     static void set_resource_directory_url(DeprecatedString);
     static DeprecatedString error_page_url();
     static void set_error_page_url(DeprecatedString);
+    static DeprecatedString directory_page_url();
+    static void set_directory_page_url(DeprecatedString);
 
     explicit FrameLoader(HTML::BrowsingContext&);
     ~FrameLoader();


### PR DESCRIPTION
Currently when you visit a local directory with the file scheme you get an error. I have added some code that generates a basic directory listings page. So you can traverse your file system inside Ladybird. This feature exists in many other browsers like Firefox and Chrome.

I have added the `FrameLoader::set_resource_directory_url()` API where `Ladybird/main.cpp` can set the relative `file://` path URL to the `Base/res.` That variable is used in the internal HTML pages (`error.html`, `directory.html`) to point to the right image files.

| Before  | After |
| ------------- | ------------- |
| ![Screenshot 2023-08-09 at 10 24 39](https://github.com/SerenityOS/serenity/assets/19894029/c8b560d0-8180-4713-917c-85d52f6ef885) | ![Screenshot 2023-08-10 at 11 49 05](https://github.com/SerenityOS/serenity/assets/19894029/154d9ad9-d692-4e9c-b650-b7cb955f647e) |

Most of the styling and directory indexing I have copied from: `WebServer/Client.cpp:252`.

I'm looking forward to your feedback :)