### PR TITLE
Ladybird: Remember window position and size on close

### DIFF
--- a/Ladybird/Qt/BrowserWindow.cpp
+++ b/Ladybird/Qt/BrowserWindow.cpp
@@ -695,4 +695,13 @@ bool BrowserWindow::eventFilter(QObject* obj, QEvent* event)
     return QMainWindow::eventFilter(obj, event);
 }
 
+void BrowserWindow::closeEvent(QCloseEvent* event)
+{
+    s_settings->set_last_position(pos());
+    s_settings->set_last_size(size());
+    s_settings->set_is_maximized(isMaximized());
+
+    QMainWindow::closeEvent(event);
+}
+
 }

--- a/Ladybird/Qt/BrowserWindow.h
+++ b/Ladybird/Qt/BrowserWindow.h
@@ -96,6 +96,7 @@ private:
     virtual void resizeEvent(QResizeEvent*) override;
     virtual void moveEvent(QMoveEvent*) override;
     virtual void wheelEvent(QWheelEvent*) override;
+    virtual void closeEvent(QCloseEvent*) override;
 
     void debug_request(DeprecatedString const& request, DeprecatedString const& argument = "");
 

--- a/Ladybird/Qt/Settings.cpp
+++ b/Ladybird/Qt/Settings.cpp
@@ -33,6 +33,38 @@ Settings::Settings()
     m_qsettings = new QSettings("Serenity", "Ladybird", this);
 }
 
+Optional<QPoint> Settings::last_position()
+{
+    if (m_qsettings->contains("last_position"))
+        return m_qsettings->value("last_position", QPoint()).toPoint();
+    return {};
+}
+
+void Settings::set_last_position(QPoint const& last_position)
+{
+    m_qsettings->setValue("last_position", last_position);
+}
+
+QSize Settings::last_size()
+{
+    return m_qsettings->value("last_size", QSize(800, 600)).toSize();
+}
+
+void Settings::set_last_size(QSize const& last_size)
+{
+    m_qsettings->setValue("last_size", last_size);
+}
+
+bool Settings::is_maximized()
+{
+    return m_qsettings->value("is_maximized", QVariant(false)).toBool();
+}
+
+void Settings::set_is_maximized(bool is_maximized)
+{
+    m_qsettings->setValue("is_maximized", is_maximized);
+}
+
 QString Settings::new_tab_page()
 {
     static auto const default_new_tab_url = rebase_default_url_on_serenity_resource_root(Browser::default_new_tab_url);

--- a/Ladybird/Qt/Settings.h
+++ b/Ladybird/Qt/Settings.h
@@ -7,13 +7,24 @@
 #pragma once
 
 #include <AK/DeprecatedString.h>
+#include <QPoint>
 #include <QSettings>
+#include <QSize>
 
 namespace Ladybird {
 
 class Settings : public QObject {
 public:
     Settings();
+
+    Optional<QPoint> last_position();
+    void set_last_position(QPoint const& last_position);
+
+    QSize last_size();
+    void set_last_size(QSize const& last_size);
+
+    bool is_maximized();
+    void set_is_maximized(bool is_maximized);
 
     QString new_tab_page();
     void set_new_tab_page(QString const& page);

--- a/Ladybird/Qt/main.cpp
+++ b/Ladybird/Qt/main.cpp
@@ -114,7 +114,16 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     Ladybird::s_settings = adopt_own_if_nonnull(new Ladybird::Settings());
     Ladybird::BrowserWindow window(initial_url, cookie_jar, webdriver_content_ipc_path, enable_callgrind_profiling ? WebView::EnableCallgrindProfiling::Yes : WebView::EnableCallgrindProfiling::No, use_lagom_networking ? Ladybird::UseLagomNetworking::Yes : Ladybird::UseLagomNetworking::No);
     window.setWindowTitle("Ladybird");
-    window.resize(800, 600);
+
+    if (Ladybird::s_settings->is_maximized()) {
+        window.showMaximized();
+    } else {
+        auto last_position = Ladybird::s_settings->last_position();
+        if (last_position.has_value())
+            window.move(last_position.value());
+        window.resize(Ladybird::s_settings->last_size());
+    }
+
     window.show();
 
     return event_loop.exec();


### PR DESCRIPTION
Currently the Ladybird browser window always opens with the small window size of 800x600. So every time I resize the window to something larger to open the website I want to test. This is annoying so I have added the code that the window remembers it's last position and size on close so that it can be restored when the browser is restarted.

I have not test this code with multi monitor setup so it may not work with that for now.