### PR TITLE
LibJS: Improve garbage collection trigger condition

### DIFF
--- a/Userland/Libraries/LibJS/Heap/Heap.h
+++ b/Userland/Libraries/LibJS/Heap/Heap.h
@@ -101,8 +101,9 @@ private:
         }
     }
 
-    size_t m_max_allocations_between_gc { 100000 };
-    size_t m_allocations_since_last_gc { 0 };
+    static constexpr size_t GC_MIN_BYTES_THRESHOLD { 4 * 1024 * 1024 };
+    size_t m_gc_bytes_threshold { GC_MIN_BYTES_THRESHOLD };
+    size_t m_allocated_bytes_since_last_gc { 0 };
 
     bool m_should_collect_on_every_allocation { false };
 


### PR DESCRIPTION
## Approach
This patch now triggers a collection when the memory usage doubles (since the last collection) instead of every 100k allocations. 

This dynamic approach is inspired by some other GCs like [Golang's](https://tip.golang.org/doc/gc-guide#GOGC) and [Lua's](https://www.lua.org/wshop18/Ierusalimschy.pdf) and improves performance in memory heavy applications because  marking must visit old objects which will dominate the marking phase if the GC is invoked too often.

## Case Study: Google Maps
Loading the page in ladybird, we can almost half (reduce by ~48%) the time spent on collection.

| Loading Google Maps | before | after |
|--------|--------|--------|
| Number of Collections | 76 | 28 |
| Total time spent collecting | 2034 ms | 1061 ms |
| Mean pause times | 26 ms | 37 ms |

<details><summary>How to measure latency</summary>
<p>

I calculated the latency by forceing GC reports in Heap.h by changing the default of `collect_garbage` to `bool print_report = true`.
Than you can run:  `js test.js |& python3 gcprof.py`

`gcprof.py`: https://gist.github.com/flofriday/3c7744104ab54b22fe4fed6de6fc3bce

</p>
</details> 

## Case Study: Octane 2.0
This commit also improves some Octane memory specific benchmarks and almost doubles the Splay one :^)
![image](https://github.com/SerenityOS/serenity/assets/21206831/c7599fdc-faa6-4491-91d6-ff20f0571e26)
(The benchmarks are not run to completion because zlib takes forever) 

## Drawbacks
- This approach, while more infrequent, results in somewhat longer pause times.
- It _can_ also use more memory, though in real web usage I didn't notice much of a difference.
- I think it _should_ reduce the efficiency of the block caching in the `BlockAllocator` because of the larger memory differences between collections. All attempts of modifying the `BlockAllocator` to a larger cache size or to dynamically adjusting the cache size didn't result in any measurable differences so I left them out of this PR.