### PR TITLE
LibWeb: Use root content width as automatic width if children inline

### DIFF
--- a/Tests/LibWeb/Layout/expected/grid/item-min-max-percentage-width.txt
+++ b/Tests/LibWeb/Layout/expected/grid/item-min-max-percentage-width.txt
@@ -1,0 +1,16 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (1,1) content-size 798x600 [BFC] children: not-inline
+    BlockContainer <body> at (10,10) content-size 780x21.46875 children: not-inline
+      Box <div.grid-container> at (11,11) content-size 778x19.46875 [GFC] children: not-inline
+        BlockContainer <div.grid-item> at (12,12) content-size 43.640625x17.46875 [BFC] children: inline
+          line 0 width: 87.28125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 10, rect: [12,12 87.28125x17.46875]
+              "mincontent"
+          TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x602]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x602]
+    PaintableWithLines (BlockContainer<BODY>) [9,9 782x23.46875]
+      PaintableBox (Box<DIV>.grid-container) [10,10 780x21.46875]
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [11,11 45.640625x19.46875] overflow: [12,12 87.28125x17.46875]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/grid/justify-start-min-width.txt
+++ b/Tests/LibWeb/Layout/expected/grid/justify-start-min-width.txt
@@ -1,0 +1,16 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x33.46875 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x17.46875 children: not-inline
+      Box <div#grid> at (8,8) content-size 784x17.46875 [GFC] children: not-inline
+        BlockContainer <a#box> at (8,8) content-size 288x17.46875 [BFC] children: inline
+          line 0 width: 102.75, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 13, rect: [8,8 102.75x17.46875]
+              "Start Selling"
+          TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x33.46875]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x17.46875]
+      PaintableBox (Box<DIV>#grid) [8,8 784x17.46875]
+        PaintableWithLines (BlockContainer<A>#box) [8,8 288x17.46875]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/grid/min-max-content.txt
+++ b/Tests/LibWeb/Layout/expected/grid/min-max-content.txt
@@ -4,23 +4,23 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       Box <div.grid-container> at (8,8) content-size 784x17.46875 [GFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (8,8) content-size 0x17.46875 [BFC] children: inline
+        BlockContainer <div.grid-item> at (8,8) content-size 46.890625x17.46875 [BFC] children: inline
           line 0 width: 93.765625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 11, rect: [8,8 93.765625x17.46875]
               "min-content"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (8,8) content-size 98.640625x17.46875 [BFC] children: inline
+        BlockContainer <div.grid-item> at (54.890625,8) content-size 98.640625x17.46875 [BFC] children: inline
           line 0 width: 98.640625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 11, rect: [8,8 98.640625x17.46875]
+            frag 0 from TextNode start: 0, length: 11, rect: [54.890625,8 98.640625x17.46875]
               "max-content"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (106.640625,8) content-size 685.359375x17.46875 [BFC] children: inline
+        BlockContainer <div.grid-item> at (153.53125,8) content-size 638.46875x17.46875 [BFC] children: inline
           line 0 width: 21.609375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 3, rect: [106.640625,8 21.609375x17.46875]
+            frag 0 from TextNode start: 0, length: 3, rect: [153.53125,8 21.609375x17.46875]
               "1fr"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
@@ -30,9 +30,9 @@ PaintableWithLines (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x17.46875]
       PaintableBox (Box<DIV>.grid-container) [8,8 784x17.46875]
-        PaintableWithLines (BlockContainer<DIV>.grid-item) [8,8 0x17.46875] overflow: [8,8 93.765625x17.46875]
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [8,8 46.890625x17.46875] overflow: [8,8 93.765625x17.46875]
           TextPaintable (TextNode<#text>)
-        PaintableWithLines (BlockContainer<DIV>.grid-item) [8,8 98.640625x17.46875]
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [54.890625,8 98.640625x17.46875]
           TextPaintable (TextNode<#text>)
-        PaintableWithLines (BlockContainer<DIV>.grid-item) [106.640625,8 685.359375x17.46875]
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [153.53125,8 638.46875x17.46875]
           TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/grid/min-max-content.txt
+++ b/Tests/LibWeb/Layout/expected/grid/min-max-content.txt
@@ -4,23 +4,23 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       Box <div.grid-container> at (8,8) content-size 784x17.46875 [GFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (8,8) content-size 93.765625x17.46875 [BFC] children: inline
+        BlockContainer <div.grid-item> at (8,8) content-size 0x17.46875 [BFC] children: inline
           line 0 width: 93.765625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 11, rect: [8,8 93.765625x17.46875]
               "min-content"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (101.765625,8) content-size 98.640625x17.46875 [BFC] children: inline
+        BlockContainer <div.grid-item> at (8,8) content-size 98.640625x17.46875 [BFC] children: inline
           line 0 width: 98.640625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 11, rect: [101.765625,8 98.640625x17.46875]
+            frag 0 from TextNode start: 0, length: 11, rect: [8,8 98.640625x17.46875]
               "max-content"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (200.40625,8) content-size 591.59375x17.46875 [BFC] children: inline
+        BlockContainer <div.grid-item> at (106.640625,8) content-size 685.359375x17.46875 [BFC] children: inline
           line 0 width: 21.609375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 3, rect: [200.40625,8 21.609375x17.46875]
+            frag 0 from TextNode start: 0, length: 3, rect: [106.640625,8 21.609375x17.46875]
               "1fr"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
@@ -30,9 +30,9 @@ PaintableWithLines (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x17.46875]
       PaintableBox (Box<DIV>.grid-container) [8,8 784x17.46875]
-        PaintableWithLines (BlockContainer<DIV>.grid-item) [8,8 93.765625x17.46875]
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [8,8 0x17.46875] overflow: [8,8 93.765625x17.46875]
           TextPaintable (TextNode<#text>)
-        PaintableWithLines (BlockContainer<DIV>.grid-item) [101.765625,8 98.640625x17.46875]
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [8,8 98.640625x17.46875]
           TextPaintable (TextNode<#text>)
-        PaintableWithLines (BlockContainer<DIV>.grid-item) [200.40625,8 591.59375x17.46875]
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [106.640625,8 685.359375x17.46875]
           TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/input/grid/item-min-max-percentage-width.html
+++ b/Tests/LibWeb/Layout/input/grid/item-min-max-percentage-width.html
@@ -1,0 +1,15 @@
+<style>
+* {
+    border: 1px solid black;
+}
+
+.grid-container {
+    display: grid;
+    grid-template-columns: min-content;
+}
+
+.grid-item {
+    min-width: 25%;
+    max-width: 50%;
+}
+</style><div class="grid-container"><div class="grid-item">mincontent</div></div>

--- a/Tests/LibWeb/Layout/input/grid/justify-start-min-width.html
+++ b/Tests/LibWeb/Layout/input/grid/justify-start-min-width.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html><html><head><style>
+#grid {
+    display: grid;
+}
+
+#box {
+    justify-self: start;
+    min-width: 18rem;
+    background-color: orange;
+}
+</style></head><body><div id="grid"><a id="box">Start Selling

--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -40,6 +40,8 @@ BlockFormattingContext::~BlockFormattingContext()
 
 CSSPixels BlockFormattingContext::automatic_content_width() const
 {
+    if (root().children_are_inline())
+        return m_state.get(root()).content_width();
     return greatest_child_width(root());
 }
 

--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -515,8 +515,9 @@ void BlockFormattingContext::layout_inline_children(BlockContainer const& block_
         // NOTE: min-width or max-width for boxes with inline children can only be applied after inside layout
         //       is done and width of box content is known
         auto used_width_px = context.automatic_content_width();
+        auto available_width = AvailableSize::make_definite(used_width_px);
         if (!should_treat_max_width_as_none(block_container, available_space.width)) {
-            auto max_width_px = calculate_inner_width(block_container, available_space.width, block_container.computed_values().max_width()).to_px(block_container);
+            auto max_width_px = calculate_inner_width(block_container, available_width, block_container.computed_values().max_width()).to_px(block_container);
             if (used_width_px > max_width_px)
                 used_width_px = max_width_px;
         }
@@ -535,7 +536,7 @@ void BlockFormattingContext::layout_inline_children(BlockContainer const& block_
             return false;
         }();
         if (!should_treat_min_width_as_auto) {
-            auto min_width_px = calculate_inner_width(block_container, available_space.width, block_container.computed_values().min_width()).to_px(block_container);
+            auto min_width_px = calculate_inner_width(block_container, available_width, block_container.computed_values().min_width()).to_px(block_container);
             if (used_width_px < min_width_px)
                 used_width_px = min_width_px;
         }


### PR DESCRIPTION
Closes https://github.com/SerenityOS/serenity/issues/20432