### PR TITLE
LibWeb/Streams: Fix GC related crashes seen on CI

### DIFF
--- a/Userland/Libraries/LibWeb/Streams/AbstractOperations.cpp
+++ b/Userland/Libraries/LibWeb/Streams/AbstractOperations.cpp
@@ -320,7 +320,7 @@ void readable_stream_error(ReadableStream& stream, JS::Value error)
 }
 
 // https://streams.spec.whatwg.org/#readable-stream-add-read-request
-void readable_stream_add_read_request(ReadableStream& stream, ReadRequest const& read_request)
+void readable_stream_add_read_request(ReadableStream& stream, ReadRequest& read_request)
 {
     // 1. Assert: stream.[[reader]] implements ReadableStreamDefaultReader.
     VERIFY(stream.reader().has_value() && stream.reader()->has<JS::NonnullGCPtr<ReadableStreamDefaultReader>>());
@@ -1032,7 +1032,7 @@ void readable_byte_stream_controller_error(ReadableByteStreamController& control
 }
 
 // https://streams.spec.whatwg.org/#abstract-opdef-readablebytestreamcontrollerfillreadrequestfromqueue
-WebIDL::ExceptionOr<void> readable_byte_stream_controller_fill_read_request_from_queue(ReadableByteStreamController& controller, NonnullRefPtr<ReadRequest> read_request)
+WebIDL::ExceptionOr<void> readable_byte_stream_controller_fill_read_request_from_queue(ReadableByteStreamController& controller, JS::NonnullGCPtr<ReadRequest> read_request)
 {
     auto& vm = controller.vm();
     auto& realm = controller.realm();

--- a/Userland/Libraries/LibWeb/Streams/AbstractOperations.h
+++ b/Userland/Libraries/LibWeb/Streams/AbstractOperations.h
@@ -37,7 +37,7 @@ WebIDL::ExceptionOr<double> extract_high_water_mark(QueuingStrategy const&, doub
 
 void readable_stream_close(ReadableStream&);
 void readable_stream_error(ReadableStream&, JS::Value error);
-void readable_stream_add_read_request(ReadableStream&, ReadRequest const&);
+void readable_stream_add_read_request(ReadableStream&, ReadRequest&);
 WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>> readable_stream_cancel(ReadableStream&, JS::Value reason);
 void readable_stream_fulfill_read_request(ReadableStream&, JS::Value chunk, bool done);
 size_t readable_stream_get_num_read_into_requests(ReadableStream const&);
@@ -84,7 +84,7 @@ void readable_byte_stream_controller_clear_algorithms(ReadableByteStreamControll
 void readable_byte_stream_controller_clear_pending_pull_intos(ReadableByteStreamController&);
 WebIDL::ExceptionOr<void> readable_byte_stream_controller_close(ReadableByteStreamController&);
 void readable_byte_stream_controller_error(ReadableByteStreamController&, JS::Value error);
-WebIDL::ExceptionOr<void> readable_byte_stream_controller_fill_read_request_from_queue(ReadableByteStreamController&, NonnullRefPtr<ReadRequest>);
+WebIDL::ExceptionOr<void> readable_byte_stream_controller_fill_read_request_from_queue(ReadableByteStreamController&, JS::NonnullGCPtr<ReadRequest>);
 Optional<double> readable_byte_stream_controller_get_desired_size(ReadableByteStreamController const&);
 WebIDL::ExceptionOr<void> readable_byte_stream_controller_handle_queue_drain(ReadableByteStreamController&);
 void readable_byte_stream_controller_invalidate_byob_request(ReadableByteStreamController&);

--- a/Userland/Libraries/LibWeb/Streams/ReadableByteStreamController.cpp
+++ b/Userland/Libraries/LibWeb/Streams/ReadableByteStreamController.cpp
@@ -69,7 +69,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>> ReadableByteStreamControl
 }
 
 // https://streams.spec.whatwg.org/#rbs-controller-private-pull
-WebIDL::ExceptionOr<void> ReadableByteStreamController::pull_steps(NonnullRefPtr<ReadRequest> read_request)
+WebIDL::ExceptionOr<void> ReadableByteStreamController::pull_steps(JS::NonnullGCPtr<ReadRequest> read_request)
 {
     auto& vm = this->vm();
     auto& realm = this->realm();
@@ -86,7 +86,6 @@ WebIDL::ExceptionOr<void> ReadableByteStreamController::pull_steps(NonnullRefPtr
 
         // 2. Perform ! ReadableByteStreamControllerFillReadRequestFromQueue(this, readRequest).
         TRY(readable_byte_stream_controller_fill_read_request_from_queue(*this, read_request));
-
         // 3. Return.
         return {};
     }

--- a/Userland/Libraries/LibWeb/Streams/ReadableByteStreamController.h
+++ b/Userland/Libraries/LibWeb/Streams/ReadableByteStreamController.h
@@ -119,7 +119,7 @@ public:
     void set_stream(JS::GCPtr<ReadableStream> stream) { m_stream = stream; }
 
     WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>> cancel_steps(JS::Value reason);
-    WebIDL::ExceptionOr<void> pull_steps(NonnullRefPtr<ReadRequest>);
+    WebIDL::ExceptionOr<void> pull_steps(JS::NonnullGCPtr<ReadRequest>);
     WebIDL::ExceptionOr<void> release_steps();
 
 private:

--- a/Userland/Libraries/LibWeb/Streams/ReadableStreamDefaultReader.h
+++ b/Userland/Libraries/LibWeb/Streams/ReadableStreamDefaultReader.h
@@ -20,7 +20,9 @@ struct ReadableStreamReadResult {
     bool done;
 };
 
-class ReadRequest : public RefCounted<ReadRequest> {
+class ReadRequest : public JS::Cell {
+    JS_CELL(ReadRequest, JS::Cell);
+
 public:
     virtual ~ReadRequest() = default;
 
@@ -29,7 +31,9 @@ public:
     virtual void on_error(JS::Value error) = 0;
 };
 
-class ReadLoopReadRequest : public ReadRequest {
+class ReadLoopReadRequest final : public ReadRequest {
+    JS_CELL(ReadLoopReadRequest, JS::Cell);
+
 public:
     // successSteps, which is an algorithm accepting a byte sequence
     using SuccessSteps = JS::SafeFunction<void(ByteBuffer)>;
@@ -46,6 +50,8 @@ public:
     virtual void on_error(JS::Value error) override;
 
 private:
+    virtual void visit_edges(Visitor&) override;
+
     JS::VM& m_vm;
     JS::Realm& m_realm;
     ReadableStreamDefaultReader& m_reader;
@@ -72,7 +78,7 @@ public:
 
     WebIDL::ExceptionOr<void> release_lock();
 
-    SinglyLinkedList<NonnullRefPtr<ReadRequest>>& read_requests() { return m_read_requests; }
+    SinglyLinkedList<JS::NonnullGCPtr<ReadRequest>>& read_requests() { return m_read_requests; }
 
 private:
     explicit ReadableStreamDefaultReader(JS::Realm&);
@@ -81,7 +87,7 @@ private:
 
     virtual void visit_edges(Cell::Visitor&) override;
 
-    SinglyLinkedList<NonnullRefPtr<ReadRequest>> m_read_requests;
+    SinglyLinkedList<JS::NonnullGCPtr<ReadRequest>> m_read_requests;
 };
 
 }

--- a/Userland/Libraries/LibWeb/Streams/ReadableStreamGenericReader.cpp
+++ b/Userland/Libraries/LibWeb/Streams/ReadableStreamGenericReader.cpp
@@ -45,6 +45,7 @@ void ReadableStreamGenericReaderMixin::visit_edges(JS::Cell::Visitor& visitor)
 {
     visitor.visit(m_closed_promise);
     visitor.visit(m_stream);
+    visitor.visit(m_realm);
 }
 
 }

--- a/Userland/Libraries/LibWeb/Streams/WritableStreamDefaultController.cpp
+++ b/Userland/Libraries/LibWeb/Streams/WritableStreamDefaultController.cpp
@@ -4,10 +4,20 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/DOM/AbortSignal.h>
 #include <LibWeb/Streams/WritableStream.h>
 #include <LibWeb/Streams/WritableStreamDefaultController.h>
 
 namespace Web::Streams {
+
+void WritableStreamDefaultController::visit_edges(Visitor& visitor)
+{
+    Base::visit_edges(visitor);
+    visitor.visit(m_signal);
+    for (auto& value : m_queue)
+        visitor.visit(value.value);
+    visitor.visit(m_stream);
+}
 
 // https://streams.spec.whatwg.org/#ws-default-controller-error
 WebIDL::ExceptionOr<void> WritableStreamDefaultController::error(JS::Value error)

--- a/Userland/Libraries/LibWeb/Streams/WritableStreamDefaultController.h
+++ b/Userland/Libraries/LibWeb/Streams/WritableStreamDefaultController.h
@@ -55,6 +55,8 @@ public:
 private:
     explicit WritableStreamDefaultController(JS::Realm&);
 
+    virtual void visit_edges(Visitor&) override;
+
     // https://streams.spec.whatwg.org/#writablestreamdefaultcontroller-abortalgorithm
     // A promise-returning algorithm, taking one argument (the abort reason), which communicates a requested abort to the underlying sink
     Optional<AbortAlgorithm> m_abort_algorithm;


### PR DESCRIPTION
Three little fixes to stop the intermittent CI flaking on streams-related tests :^)