### PR TITLE
Ladybird: Use pixelDelta() on supported platforms for better scrolling

### DIFF
--- a/Ladybird/Qt/WebContentView.cpp
+++ b/Ladybird/Qt/WebContentView.cpp
@@ -285,10 +285,10 @@ void WebContentView::wheelEvent(QWheelEvent* event)
         auto num_degrees = -event->angleDelta();
         float delta_x = -num_degrees.x() / 120;
         float delta_y = num_degrees.y() / 120;
-        // Note: This does not use the QScrollBar's step size as LibWeb multiples this by a step size internally.
         auto step_x = delta_x * QApplication::wheelScrollLines() * devicePixelRatio();
         auto step_y = delta_y * QApplication::wheelScrollLines() * devicePixelRatio();
-        client().async_mouse_wheel(to_content_position(position), button, buttons, modifiers, step_x, step_y);
+        constexpr int scroll_step_size = 24;
+        client().async_mouse_wheel(to_content_position(position), button, buttons, modifiers, step_x * scroll_step_size, step_y * scroll_step_size);
         event->accept();
         return;
     }

--- a/Ladybird/Qt/WebContentView.cpp
+++ b/Ladybird/Qt/WebContentView.cpp
@@ -282,13 +282,19 @@ void WebContentView::wheelEvent(QWheelEvent* event)
         auto button = get_button_from_qt_event(*event);
         auto buttons = get_buttons_from_qt_event(*event);
         auto modifiers = get_modifiers_from_qt_mouse_event(*event);
-        auto num_degrees = -event->angleDelta();
-        float delta_x = -num_degrees.x() / 120;
-        float delta_y = num_degrees.y() / 120;
-        auto step_x = delta_x * QApplication::wheelScrollLines() * devicePixelRatio();
-        auto step_y = delta_y * QApplication::wheelScrollLines() * devicePixelRatio();
-        constexpr int scroll_step_size = 24;
-        client().async_mouse_wheel(to_content_position(position), button, buttons, modifiers, step_x * scroll_step_size, step_y * scroll_step_size);
+
+        auto num_pixels = -event->pixelDelta();
+        if (!num_pixels.isNull()) {
+            client().async_mouse_wheel(to_content_position(position), button, buttons, modifiers, num_pixels.x(), num_pixels.y());
+        } else {
+            auto num_degrees = -event->angleDelta();
+            float delta_x = -num_degrees.x() / 120;
+            float delta_y = num_degrees.y() / 120;
+            auto step_x = delta_x * QApplication::wheelScrollLines() * devicePixelRatio();
+            auto step_y = delta_y * QApplication::wheelScrollLines() * devicePixelRatio();
+            int scroll_step_size = verticalScrollBar()->singleStep();
+            client().async_mouse_wheel(to_content_position(position), button, buttons, modifiers, step_x * scroll_step_size, step_y * scroll_step_size);
+        }
         event->accept();
         return;
     }

--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -146,8 +146,6 @@ Painting::PaintableBox const* EventHandler::paint_root() const
 
 bool EventHandler::handle_mousewheel(CSSPixelPoint position, unsigned button, unsigned buttons, unsigned int modifiers, int wheel_delta_x, int wheel_delta_y)
 {
-    constexpr int scroll_step_size = 24;
-
     if (m_browsing_context->active_document())
         m_browsing_context->active_document()->update_layout();
 
@@ -167,7 +165,7 @@ bool EventHandler::handle_mousewheel(CSSPixelPoint position, unsigned button, un
         auto* containing_block = paintable->containing_block();
         while (containing_block) {
             if (containing_block->is_user_scrollable()) {
-                const_cast<Painting::PaintableBox*>(containing_block->paintable_box())->handle_mousewheel({}, position, buttons, modifiers, wheel_delta_x * scroll_step_size, wheel_delta_y * scroll_step_size);
+                const_cast<Painting::PaintableBox*>(containing_block->paintable_box())->handle_mousewheel({}, position, buttons, modifiers, wheel_delta_x, wheel_delta_y);
                 break;
             }
             containing_block = containing_block->containing_block();
@@ -192,7 +190,7 @@ bool EventHandler::handle_mousewheel(CSSPixelPoint position, unsigned button, un
             if (node->dispatch_event(UIEvents::WheelEvent::create_from_platform_event(node->realm(), UIEvents::EventNames::wheel, offset.x(), offset.y(), position.x(), position.y(), wheel_delta_x, wheel_delta_y, buttons, button).release_value_but_fixme_should_propagate_errors())) {
                 if (auto* page = m_browsing_context->page()) {
                     if (m_browsing_context == &page->top_level_browsing_context())
-                        page->client().page_did_request_scroll(wheel_delta_x * scroll_step_size, wheel_delta_y * scroll_step_size);
+                        page->client().page_did_request_scroll(wheel_delta_x, wheel_delta_y);
                 }
             }
 

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
@@ -423,9 +423,12 @@ void OutOfProcessWebView::process_next_input_event()
             case GUI::Event::Type::MouseMove:
                 client().async_mouse_move(to_content_position(event.position()), event.button(), event.buttons(), event.modifiers());
                 break;
-            case GUI::Event::Type::MouseWheel:
-                client().async_mouse_wheel(to_content_position(event.position()), event.button(), event.buttons(), event.modifiers(), event.wheel_delta_x(), event.wheel_delta_y());
+            case GUI::Event::Type::MouseWheel: {
+                // FIXME: This wheel delta step size multiplier is used to remain the old scroll behaviour, in future use system step size.
+                constexpr int scroll_step_size = 24;
+                client().async_mouse_wheel(to_content_position(event.position()), event.button(), event.buttons(), event.modifiers(), event.wheel_delta_x() * scroll_step_size, event.wheel_delta_y() * scroll_step_size);
                 break;
+            }
             case GUI::Event::Type::MouseDoubleClick:
                 client().async_doubleclick(to_content_position(event.position()), event.button(), event.buttons(), event.modifiers());
                 break;


### PR DESCRIPTION
Since #20380 and #20383 the scrolling in Ladybird on macOS is very slow and its kind of broken. You need to scroll super far to scroll a little bit on the web page. This change uses the Qt `pixelData()` function on macOS because that is uses the systems pixel scroll offsets. This fixes most scroll issues for me. But I love to here from others that have macOS if this works for them.