### PR TITLE
LibWeb: Unregister IntersectionObserver in finalize, not the destructor

### DIFF
--- a/Userland/Libraries/LibWeb/IntersectionObserver/IntersectionObserver.cpp
+++ b/Userland/Libraries/LibWeb/IntersectionObserver/IntersectionObserver.cpp
@@ -53,7 +53,9 @@ IntersectionObserver::IntersectionObserver(JS::Realm& realm, JS::GCPtr<WebIDL::C
     });
 }
 
-IntersectionObserver::~IntersectionObserver()
+IntersectionObserver::~IntersectionObserver() = default;
+
+void IntersectionObserver::finalize()
 {
     intersection_root().visit([this](auto& node) {
         node->document().unregister_intersection_observer({}, *this);

--- a/Userland/Libraries/LibWeb/IntersectionObserver/IntersectionObserver.h
+++ b/Userland/Libraries/LibWeb/IntersectionObserver/IntersectionObserver.h
@@ -66,6 +66,7 @@ private:
 
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(JS::Cell::Visitor&) override;
+    virtual void finalize() override;
 
     // https://www.w3.org/TR/intersection-observer/#dom-intersectionobserver-callback-slot
     JS::GCPtr<WebIDL::CallbackType> m_callback;


### PR DESCRIPTION
Otherwise it UAFs the intersection root. Not sure how this didn't cause a lot of crashes!