### PR TITLE
LibJS: Implement await properly for async functions

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/AsyncFunctionDriverWrapper.h
+++ b/Userland/Libraries/LibJS/Runtime/AsyncFunctionDriverWrapper.h
@@ -18,23 +18,27 @@ class AsyncFunctionDriverWrapper final : public Promise {
     JS_OBJECT(AsyncFunctionDriverWrapper, Promise);
 
 public:
+    enum class IsInitialExecution {
+        No,
+        Yes,
+    };
+
     static ThrowCompletionOr<Value> create(Realm&, GeneratorObject*);
 
     virtual ~AsyncFunctionDriverWrapper() override = default;
     void visit_edges(Cell::Visitor&) override;
 
-    void continue_async_execution(VM&, Value, bool is_successful);
+    void continue_async_execution(VM&, Value, bool is_successful, IsInitialExecution is_initial_execution = IsInitialExecution::No);
 
 private:
     AsyncFunctionDriverWrapper(Realm&, NonnullGCPtr<GeneratorObject>, NonnullGCPtr<Promise> top_level_promise);
+    ThrowCompletionOr<void> await(Value);
 
-    bool m_expect_promise { false };
     NonnullGCPtr<GeneratorObject> m_generator_object;
-    NonnullGCPtr<NativeFunction> m_on_fulfillment;
-    NonnullGCPtr<NativeFunction> m_on_rejection;
     NonnullGCPtr<Promise> m_top_level_promise;
     GCPtr<Promise> m_current_promise { nullptr };
     Handle<AsyncFunctionDriverWrapper> m_self_handle;
+    Optional<ExecutionContext> m_suspended_execution_context;
 };
 
 }

--- a/Userland/Libraries/LibJS/Tests/builtins/AsyncGenerator/AsyncGenerator.prototype.next.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/AsyncGenerator/AsyncGenerator.prototype.next.js
@@ -7,7 +7,7 @@ describe("correct behaviour", () => {
         yield b + 1;
         yield Promise.resolve(b + 2);
         yield* [Promise.resolve(b + 3), Promise.resolve(b + 4), Promise.resolve(b + 5)];
-        return b + 6;
+        return Promise.resolve(b + 6);
     }
 
     test("length is 1", () => {
@@ -64,7 +64,7 @@ describe("correct behaviour", () => {
         expect(seventhRunResult).toBe(9);
     });
 
-    test("can return a value", () => {
+    test("can return a value and return implicitly awaits", () => {
         const eighthRunResult = runGenerator("bad7", false);
         expect(eighthRunResult.value).toBe(10);
         expect(eighthRunResult.done).toBeTrue();


### PR DESCRIPTION
Fixes #20275

```
Summary:
    Diff Tests:
        +4 ✅    -4 ❌   

Diff Tests:
    test/built-ins/Array/fromAsync/non-iterable-input-with-thenable-async-mapped-awaits-callback-result-once.js ❌ -> ✅
    test/language/expressions/await/async-await-interleaved.js                                                  ❌ -> ✅
    test/language/expressions/await/await-awaits-thenables-that-throw.js                                        ❌ -> ✅
    test/language/expressions/await/await-awaits-thenables.js                                                   ❌ -> ✅
```