### PR TITLE
LibWeb: Verify that table cells have a paintable when collecting them

### DIFF
--- a/Tests/LibWeb/Layout/expected/table/table-cell-not-paintable.txt
+++ b/Tests/LibWeb/Layout/expected/table/table-cell-not-paintable.txt
@@ -1,0 +1,17 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x17.46875 children: inline
+      line 0 width: 10, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+        frag 0 from BlockContainer start: 0, length: 0, rect: [13,19 0x0]
+      BlockContainer <button> at (13,19) content-size 0x0 inline-block [BFC] children: inline
+        TextNode <#text>
+        TableWrapper <(anonymous)> (not painted) [BFC] children: not-inline
+          BlockContainer <(anonymous)> (not painted) table-box [TFC] children: not-inline
+            Box <(anonymous)> (not painted) table-row children: not-inline
+              BlockContainer <(anonymous)> (not painted) table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> (not painted) inline-block [BFC] children: not-inline
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x17.46875]
+      PaintableWithLines (BlockContainer<BUTTON>) [8,17 10x4]

--- a/Tests/LibWeb/Layout/input/table/table-cell-not-paintable.html
+++ b/Tests/LibWeb/Layout/input/table/table-cell-not-paintable.html
@@ -1,0 +1,2 @@
+<button type="button">
+</button>

--- a/Userland/Libraries/LibWeb/Painting/TableBordersPainting.cpp
+++ b/Userland/Libraries/LibWeb/Painting/TableBordersPainting.cpp
@@ -34,8 +34,9 @@ static void collect_cell_boxes(Vector<PaintableBox const*>& cell_boxes, Layout::
 {
     box.for_each_child([&](auto& child) {
         if (child.display().is_table_cell()) {
-            VERIFY(is<Layout::Box>(child) && child.paintable());
-            cell_boxes.append(static_cast<Layout::Box const&>(child).paintable_box());
+            VERIFY(is<Layout::Box>(child));
+            if (child.paintable())
+                cell_boxes.append(static_cast<Layout::Box const&>(child).paintable_box());
         } else {
             collect_cell_boxes(cell_boxes, child);
         }


### PR DESCRIPTION
Replicate the more conservative way it's done for other nodes, for which we verify whether they have a paintable before doing painting-related operations with it.

Fixes crash on https://www.haiku-os.org/.