### PR TITLE
Ports/SDL2: Avoid accumulation errors in resampler

### DIFF
--- a/Ports/SDL2/patches/0002-audio-Avoid-accumulation-errors-in-resampler.patch
+++ b/Ports/SDL2/patches/0002-audio-Avoid-accumulation-errors-in-resampler.patch
@@ -1,0 +1,23 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ryan C. Gordon <icculus@icculus.org>
+Date: Sat, 5 Nov 2022 10:38:33 -0400
+Subject: [PATCH] audio: Avoid accumulation errors in resampler.
+
+Fixes #6391.
+---
+ src/audio/SDL_audiocvt.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/audio/SDL_audiocvt.c b/src/audio/SDL_audiocvt.c
+index 85faa4b0b75a51c2121938d19a3303712ad13edf..841dd00d4b6a5c7d2789d5a655fd962cf014e3c6 100644
+--- a/src/audio/SDL_audiocvt.c
++++ b/src/audio/SDL_audiocvt.c
+@@ -247,7 +247,7 @@ SDL_ResampleAudio(const int chans, const int inrate, const int outrate,
+             *(dst++) = outsample;
+         }
+ 
+-        outtime += outtimeincr;
++        outtime = outtimeincr * i;
+     }
+ 
+     return outframes * chans * sizeof (float);

--- a/Ports/SDL2/patches/ReadMe.md
+++ b/Ports/SDL2/patches/ReadMe.md
@@ -5,3 +5,9 @@
 Add SerenityOS platform support
 
 
+## `0002-audio-Avoid-accumulation-errors-in-resampler.patch`
+
+audio: Avoid accumulation errors in resampler.
+
+Fixes #6391.
+


### PR DESCRIPTION
This adds a patch to the SDL2 port to fix a segfault which occurs in
the resampler.

Taken from this upstream commit:
https://github.com/libsdl-org/SDL/commit/78f9710

This fixes a crash we were seeing in the julius port.