### PR TITLE
Kernel: Add PCISerialDevice WCH CH351 IDs

### DIFF
--- a/Kernel/Devices/PCISerialDevice.h
+++ b/Kernel/Devices/PCISerialDevice.h
@@ -30,11 +30,12 @@ private:
         SerialDevice::Baud baud_rate { SerialDevice::Baud::Baud38400 };
     };
 
-    static constexpr BoardDefinition board_definitions[4] = {
-        { { PCI::VendorID::WCH, 0x3253 }, "WCH CH382 2S"sv, 2, 0, 0xC0, 8, SerialDevice::Baud::Baud115200 },
+    static constexpr BoardDefinition board_definitions[] = {
         { { PCI::VendorID::RedHat, 0x0002 }, "QEMU PCI 16550A"sv, 1, 0, 0, 8, SerialDevice::Baud::Baud115200 },
         { { PCI::VendorID::RedHat, 0x0003 }, "QEMU PCI Dual-port 16550A"sv, 2, 0, 0, 8, SerialDevice::Baud::Baud115200 },
-        { { PCI::VendorID::RedHat, 0x0004 }, "QEMU PCI Quad-port 16550A"sv, 4, 0, 0, 8, SerialDevice::Baud::Baud115200 }
+        { { PCI::VendorID::RedHat, 0x0004 }, "QEMU PCI Quad-port 16550A"sv, 4, 0, 0, 8, SerialDevice::Baud::Baud115200 },
+        { { PCI::VendorID::WCH, 0x2273 }, "WCH CH351"sv, 2, 0, 0, 8, SerialDevice::Baud::Baud115200 },
+        { { PCI::VendorID::WCH, 0x3253 }, "WCH CH382 2S"sv, 2, 0, 0xC0, 8, SerialDevice::Baud::Baud115200 }
     };
 };
 


### PR DESCRIPTION
Add the device ID for PCI serial port cards that use the WCH CH351
chip. This device has been tested with real hardware where the serial
debug output could succesfully be received.