### PR TITLE
Ports: Fix `clean_dist` function in .port_include.sh

### DIFF
--- a/Ports/.port_include.sh
+++ b/Ports/.port_include.sh
@@ -422,7 +422,8 @@ clean() {
 }
 clean_dist() {
     for f in "${files[@]}"; do
-        read url filename hash <<< $(echo "$f")
+        read url hash <<< "$f"
+        filename=$(basename "$url")
         rm -f "${PORT_META_DIR}/${filename}"
     done
 }


### PR DESCRIPTION
A bug was introduced in commit #20413, where the `clean_dist` function was missed from refactoring to the new "files" format. This PR aims to fix this issue.