### PR TITLE
LibWeb: Remove 3 decimal places rounding hack in Length::percentage_of

### DIFF
--- a/Tests/LibWeb/Layout/expected/grid/min-max-content.txt
+++ b/Tests/LibWeb/Layout/expected/grid/min-max-content.txt
@@ -4,23 +4,23 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       Box <div.grid-container> at (8,8) content-size 784x17.46875 [GFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (8,8) content-size 46.890625x17.46875 [BFC] children: inline
+        BlockContainer <div.grid-item> at (8,8) content-size 46.875x17.46875 [BFC] children: inline
           line 0 width: 93.765625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 11, rect: [8,8 93.765625x17.46875]
               "min-content"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (54.890625,8) content-size 98.640625x17.46875 [BFC] children: inline
+        BlockContainer <div.grid-item> at (54.875,8) content-size 98.640625x17.46875 [BFC] children: inline
           line 0 width: 98.640625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 11, rect: [54.890625,8 98.640625x17.46875]
+            frag 0 from TextNode start: 0, length: 11, rect: [54.875,8 98.640625x17.46875]
               "max-content"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (153.53125,8) content-size 638.46875x17.46875 [BFC] children: inline
+        BlockContainer <div.grid-item> at (153.515625,8) content-size 638.484375x17.46875 [BFC] children: inline
           line 0 width: 21.609375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 3, rect: [153.53125,8 21.609375x17.46875]
+            frag 0 from TextNode start: 0, length: 3, rect: [153.515625,8 21.609375x17.46875]
               "1fr"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
@@ -30,9 +30,9 @@ PaintableWithLines (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x17.46875]
       PaintableBox (Box<DIV>.grid-container) [8,8 784x17.46875]
-        PaintableWithLines (BlockContainer<DIV>.grid-item) [8,8 46.890625x17.46875] overflow: [8,8 93.765625x17.46875]
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [8,8 46.875x17.46875] overflow: [8,8 93.765625x17.46875]
           TextPaintable (TextNode<#text>)
-        PaintableWithLines (BlockContainer<DIV>.grid-item) [54.890625,8 98.640625x17.46875]
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [54.875,8 98.640625x17.46875]
           TextPaintable (TextNode<#text>)
-        PaintableWithLines (BlockContainer<DIV>.grid-item) [153.53125,8 638.46875x17.46875]
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [153.515625,8 638.484375x17.46875]
           TextPaintable (TextNode<#text>)

--- a/Userland/Libraries/LibWeb/CSS/Length.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Length.cpp
@@ -59,15 +59,7 @@ Length Length::percentage_of(Percentage const& percentage) const
         return *this;
     }
 
-    // HACK: We round to 3 decimal places to emulate what happens in browsers that used fixed point math.
-    // FIXME: Remove this when converting CSSPixels to a fixed-point type.
-    //        https://github.com/SerenityOS/serenity/issues/18566
-    auto value = percentage.as_fraction() * raw_value();
-    value *= 1000;
-    value = round(value);
-    value /= 1000;
-
-    return Length { value, m_type };
+    return Length { percentage.as_fraction() * raw_value(), m_type };
 }
 
 CSSPixels Length::font_relative_length_to_px(Length::FontMetrics const& font_metrics, Length::FontMetrics const& root_font_metrics) const


### PR DESCRIPTION
CSSPixels uses fixed point now.