### PR TITLE
Shell: Add builtin command to reset the internal state

### DIFF
--- a/Userland/Shell/Builtin.cpp
+++ b/Userland/Shell/Builtin.cpp
@@ -149,6 +149,17 @@ ErrorOr<int> Shell::builtin_where(Main::Arguments arguments)
     return at_least_one_succeded ? 0 : 1;
 }
 
+ErrorOr<int> Shell::builtin_reset(Main::Arguments)
+{
+    destroy();
+    initialize(m_is_interactive);
+
+    // NOTE: As the last step before returning, clear (flush) the shell text entirely.
+    fprintf(stderr, "\033[3J\033[H\033[2J");
+    fflush(stderr);
+    return 0;
+}
+
 ErrorOr<int> Shell::builtin_alias(Main::Arguments arguments)
 {
     Vector<DeprecatedString> aliases;

--- a/Userland/Shell/Shell.cpp
+++ b/Userland/Shell/Shell.cpp
@@ -2258,9 +2258,7 @@ Shell::Shell()
     cache_path();
 }
 
-Shell::Shell(Line::Editor& editor, bool attempt_interactive, bool posix_mode)
-    : m_in_posix_mode(posix_mode)
-    , m_editor(editor)
+void Shell::initialize(bool attempt_interactive)
 {
     uid = getuid();
     tcsetpgrp(0, getpgrp());
@@ -2305,11 +2303,22 @@ Shell::Shell(Line::Editor& editor, bool attempt_interactive, bool posix_mode)
         m_editor->load_history(get_history_path());
         cache_path();
     }
+}
 
+Shell::Shell(Line::Editor& editor, bool attempt_interactive, bool posix_mode)
+    : m_in_posix_mode(posix_mode)
+    , m_editor(editor)
+{
+    initialize(attempt_interactive);
     start_timer(3000);
 }
 
 Shell::~Shell()
+{
+    destroy();
+}
+
+void Shell::destroy()
 {
     if (m_default_constructed)
         return;

--- a/Userland/Shell/Shell.h
+++ b/Userland/Shell/Shell.h
@@ -54,6 +54,7 @@
     __ENUMERATE_SHELL_BUILTIN(wait, InAllModes)              \
     __ENUMERATE_SHELL_BUILTIN(dump, InAllModes)              \
     __ENUMERATE_SHELL_BUILTIN(kill, InAllModes)              \
+    __ENUMERATE_SHELL_BUILTIN(reset, InAllModes)             \
     __ENUMERATE_SHELL_BUILTIN(noop, InAllModes)              \
     __ENUMERATE_SHELL_BUILTIN(break, OnlyInPOSIXMode)        \
     __ENUMERATE_SHELL_BUILTIN(continue, OnlyInPOSIXMode)     \
@@ -413,6 +414,9 @@ private:
     Shell(Line::Editor&, bool attempt_interactive, bool posix_mode = false);
     Shell();
     virtual ~Shell() override;
+
+    void destroy();
+    void initialize(bool attempt_interactive);
 
     RefPtr<AST::Node> parse(StringView, bool interactive = false, bool as_command = true) const;
 


### PR DESCRIPTION
The new builtin command "reset" now resets the entire internal state by virtually destructing the Shell state and re-constructing it.

This helps for example when setting a new hostname and wanting to view it in the current Shell program.

cc @alimpfard 