### PR TITLE
CMake: Clean up some flags related to the AArch64 build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -223,12 +223,11 @@ if (ENABLE_MOLD_LINKER)
     add_link_options(-fuse-ld=mold)
 endif()
 
-if(NOT "${SERENITY_ARCH}" STREQUAL "aarch64")
-    if (CMAKE_CXX_COMPILER_ID MATCHES "Clang$" OR ENABLE_MOLD_LINKER)
-        add_link_options(LINKER:--pack-dyn-relocs=relr)
-    else()
-        add_link_options(LINKER:-z,pack-relative-relocs)
-    endif()
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang$" OR ENABLE_MOLD_LINKER)
+    add_link_options(LINKER:--pack-dyn-relocs=relr)
+elseif("${SERENITY_ARCH}" STREQUAL "x86_64")
+    # The BFD linker only supports RELR relocations on x86 and POWER.
+    add_link_options(LINKER:-z,pack-relative-relocs)
 endif()
 
 add_subdirectory(Userland)

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -611,7 +611,10 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     set_source_files_properties(Library/MiniStdLib.cpp
         PROPERTIES COMPILE_FLAGS "-fno-tree-loop-distribution -fno-tree-loop-distribute-patterns")
 
-    add_link_options(LINKER:-z,pack-relative-relocs)
+    if ("${SERENITY_ARCH}" STREQUAL "x86_64")
+        # The BFD linker only supports RELR relocations on x86 and POWER.
+        add_link_options(LINKER:-z,pack-relative-relocs)
+    endif()
 else() # Assume Clang
     add_compile_options(-Waddress-of-packed-member)
     add_compile_options(-faligned-allocation)

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -490,10 +490,7 @@ elseif("${SERENITY_ARCH}" STREQUAL "aarch64")
     )
 
     # Otherwise linker errors e.g undefined reference to `__aarch64_cas8_acq_rel'
-    add_compile_options(-mno-outline-atomics -latomic)
-
-    # FIXME: Remove this once compiling MemoryManager.cpp doesn't give the nonnull error anymore.
-    add_compile_options(-Wno-nonnull)
+    add_compile_options(-mno-outline-atomics)
 
     # NOTE: These files cannot use a stack protector and sanitizers, as these will cause accesses to global variables to be inserted
     #       by the compiler. The CPU cannot access global variables without the MMU as the kernel is linked for a virtual address in high memory.

--- a/Meta/CMake/serenity_compile_options.cmake
+++ b/Meta/CMake/serenity_compile_options.cmake
@@ -40,9 +40,3 @@ elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang$")
     link_directories(${TOOLCHAIN_ROOT}/lib/clang/${LLVM_MAJOR_VERSION}/lib/${SERENITY_ARCH}-pc-serenity/)
 endif()
 
-if ("${SERENITY_ARCH}" STREQUAL "aarch64")
-    # Unaligned memory access will cause a trap, so to make sure the compiler doesn't generate
-    # those unaligned accesses, the strict-align flag is added.
-    # FIXME: Remove -Wno-cast-align when we are able to build everything without this warning turned on.
-    add_compile_options(-mstrict-align -Wno-cast-align)
-endif()


### PR DESCRIPTION
Two non-functional changes:
- Remove pointless `-latomic` flag. It was specified via
  `add_compile_options`, which only affects compilation and not linking,
  so the library was never actually linked into the kernel. In fact, we
  do not even build `libatomic` for our toolchain.
- Do not disable `-Wnonnull`. The warning-causing code was fixed at some
  point.

This commit also removes `-mstrict-align` from the userland. Our target
AArch64 hardware natively supports unaligned accesses without a
significant performance penalty. Allowing the compiler to insert
unaligned accesses into aligned-as-written code allows for some
performance optimizations in fact. We keep this option turned on in the
kernel to preserve correctness for MMIO, as that might be sensitive to
alignment.

---

While LLD and mold support RELR "packed" relocations on all
architectures, the BFD linker currently only implements them on x86-64
and POWER.

This fixes two issues:
- The Kernel had it enabled even for AArch64 + GCC, which led to the
  following being printed: `warning: -z pack-relative-relocs ignored`.
- The userland always had it disabled, even in the supported AArch64 +
  Clang/mold scenarios.