### PR TITLE
LibJS: Remove usage of bytecode_interpreter_if_exists()

### DIFF
--- a/Meta/Lagom/Wasm/js_repl.cpp
+++ b/Meta/Lagom/Wasm/js_repl.cpp
@@ -117,11 +117,7 @@ static ErrorOr<bool> parse_and_run(JS::Interpreter& interpreter, StringView sour
         if (s_dump_ast)
             script_or_module->parse_node().dump(0);
 
-        if (auto* bytecode_interpreter = g_vm->bytecode_interpreter_if_exists()) {
-            result = bytecode_interpreter->run(*script_or_module);
-        } else {
-            result = interpreter.run(*script_or_module);
-        }
+        result = interpreter.run(*script_or_module);
 
         return ReturnEarly::No;
     };

--- a/Userland/Libraries/LibJS/AST.cpp
+++ b/Userland/Libraries/LibJS/AST.cpp
@@ -1627,7 +1627,7 @@ void ScopeNode::block_declaration_instantiation(VM& vm, Environment* environment
         // NOTE: Due to the use of MUST with `create_immutable_binding` and `create_mutable_binding` below,
         //       an exception should not result from `for_each_bound_name`.
         MUST(declaration.for_each_bound_identifier([&](auto const& identifier) {
-            if (vm.bytecode_interpreter_if_exists() && identifier.is_local()) {
+            if (identifier.is_local()) {
                 // NOTE: No need to create bindings for local variables as their values are not stored in an environment.
                 return;
             }
@@ -1644,7 +1644,7 @@ void ScopeNode::block_declaration_instantiation(VM& vm, Environment* environment
         if (is<FunctionDeclaration>(declaration)) {
             auto& function_declaration = static_cast<FunctionDeclaration const&>(declaration);
             auto function = ECMAScriptFunctionObject::create(realm, function_declaration.name(), function_declaration.source_text(), function_declaration.body(), function_declaration.parameters(), function_declaration.function_length(), function_declaration.local_variables_names(), environment, private_environment, function_declaration.kind(), function_declaration.is_strict_mode(), function_declaration.might_need_arguments_object(), function_declaration.contains_direct_call_to_eval());
-            if (vm.bytecode_interpreter_if_exists() && function_declaration.name_identifier()->is_local()) {
+            if (function_declaration.name_identifier()->is_local()) {
                 vm.running_execution_context().local_variables[function_declaration.name_identifier()->local_variable_index()] = function;
             } else {
                 VERIFY(is<DeclarativeEnvironment>(*environment));

--- a/Userland/Libraries/LibJS/Heap/Heap.cpp
+++ b/Userland/Libraries/LibJS/Heap/Heap.cpp
@@ -271,8 +271,7 @@ void Heap::mark_live_cells(HashTable<Cell*> const& roots)
 
     MarkingVisitor visitor(roots);
 
-    if (auto* bytecode_interpreter = vm().bytecode_interpreter_if_exists())
-        bytecode_interpreter->visit_edges(visitor);
+    vm().bytecode_interpreter().visit_edges(visitor);
 
     visitor.mark_all_live_cells();
 

--- a/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
@@ -610,7 +610,7 @@ ThrowCompletionOr<void> ECMAScriptFunctionObject::function_declaration_instantia
 
                     // 2. Perform ! env.CreateMutableBinding(n, false).
                     // 3. Perform ! env.InitializeBinding(n, undefined).
-                    if (vm.bytecode_interpreter_if_exists() && id.is_local()) {
+                    if (id.is_local()) {
                         callee_context.local_variables[id.local_variable_index()] = js_undefined();
                     } else {
                         MUST(environment->create_mutable_binding(vm, id.string(), false));
@@ -663,7 +663,7 @@ ThrowCompletionOr<void> ECMAScriptFunctionObject::function_declaration_instantia
                     }
 
                     // 5. Perform ! varEnv.InitializeBinding(n, initialValue).
-                    if (vm.bytecode_interpreter_if_exists() && id.is_local()) {
+                    if (id.is_local()) {
                         // NOTE: Local variables are supported only in bytecode interpreter
                         callee_context.local_variables[id.local_variable_index()] = initial_value;
                     } else {
@@ -738,7 +738,7 @@ ThrowCompletionOr<void> ECMAScriptFunctionObject::function_declaration_instantia
 
         // b. For each element dn of the BoundNames of d, do
         MUST(declaration.for_each_bound_identifier([&](auto const& id) {
-            if (vm.bytecode_interpreter_if_exists() && id.is_local()) {
+            if (id.is_local()) {
                 // NOTE: Local variables are supported only in bytecode interpreter
                 return;
             }
@@ -766,7 +766,7 @@ ThrowCompletionOr<void> ECMAScriptFunctionObject::function_declaration_instantia
         auto function = ECMAScriptFunctionObject::create(realm, declaration.name(), declaration.source_text(), declaration.body(), declaration.parameters(), declaration.function_length(), declaration.local_variables_names(), lex_environment, private_environment, declaration.kind(), declaration.is_strict_mode(), declaration.might_need_arguments_object(), declaration.contains_direct_call_to_eval());
 
         // c. Perform ! varEnv.SetMutableBinding(fn, fo, false).
-        if ((vm.bytecode_interpreter_if_exists() || kind() == FunctionKind::Generator || kind() == FunctionKind::AsyncGenerator) && declaration.name_identifier()->is_local()) {
+        if (declaration.name_identifier()->is_local()) {
             callee_context.local_variables[declaration.name_identifier()->local_variable_index()] = function;
         } else {
             MUST(var_environment->set_mutable_binding(vm, declaration.name(), function, false));

--- a/Userland/Libraries/LibJS/Runtime/VM.cpp
+++ b/Userland/Libraries/LibJS/Runtime/VM.cpp
@@ -192,11 +192,6 @@ Bytecode::Interpreter& VM::bytecode_interpreter()
     return *m_bytecode_interpreter;
 }
 
-Bytecode::Interpreter* VM::bytecode_interpreter_if_exists()
-{
-    return m_bytecode_interpreter;
-}
-
 void VM::gather_roots(HashTable<Cell*>& roots)
 {
     roots.set(m_empty_string);

--- a/Userland/Libraries/LibJS/Runtime/VM.h
+++ b/Userland/Libraries/LibJS/Runtime/VM.h
@@ -44,7 +44,6 @@ public:
     Heap const& heap() const { return m_heap; }
 
     Bytecode::Interpreter& bytecode_interpreter();
-    Bytecode::Interpreter* bytecode_interpreter_if_exists();
 
     void dump_backtrace() const;
 


### PR DESCRIPTION
There is no need to check if bytecode interpreter exists after we
switched away from AST interpreter.