### PR TITLE
AK: Correctly handle signed types in `IntegralMath.h`

### DIFF
--- a/Tests/AK/TestIntegerMath.cpp
+++ b/Tests/AK/TestIntegerMath.cpp
@@ -7,7 +7,69 @@
 #include <LibTest/TestCase.h>
 
 #include <AK/IntegralMath.h>
+#include <AK/NumericLimits.h>
 #include <initializer_list>
+
+TEST_CASE(exp2)
+{
+    EXPECT_EQ(AK::exp2<u64>(0), 1llu);
+    EXPECT_EQ(AK::exp2<u64>(1), 2llu);
+    EXPECT_EQ(AK::exp2<u64>(2), 4llu);
+
+    // maximum
+    EXPECT_EQ(AK::exp2<u8>(7), 128u);
+    EXPECT_EQ(AK::exp2<u32>(31), 2147483648u);
+    EXPECT_EQ(AK::exp2<u64>(63), 9223372036854775808llu);
+    EXPECT_EQ(AK::exp2<i8>(6), 64);
+    EXPECT_EQ(AK::exp2<i32>(30), 1073741824);
+    EXPECT_EQ(AK::exp2<i64>(62), 4611686018427387904ll);
+
+    // overflow
+    EXPECT_EQ(AK::exp2<u8>(8), NumericLimits<u8>::max());
+    EXPECT_EQ(AK::exp2<u32>(32), NumericLimits<u32>::max());
+    EXPECT_EQ(AK::exp2<u64>(64), NumericLimits<u64>::max());
+    EXPECT_EQ(AK::exp2<i8>(7), NumericLimits<i8>::max());
+    EXPECT_EQ(AK::exp2<i32>(31), NumericLimits<i32>::max());
+    EXPECT_EQ(AK::exp2<i64>(63), NumericLimits<i64>::max());
+
+    EXPECT_EQ(AK::exp2<i64>(-1), 0ll);
+}
+
+TEST_CASE(log2)
+{
+    constexpr auto test_log2_for_type = []<typename IntType>() {
+        EXPECT_EQ(AK::log2<IntType>(0), static_cast<IntType>(0));
+        EXPECT_EQ(AK::ceil_log2<IntType>(0), static_cast<IntType>(0));
+
+        EXPECT_EQ(AK::log2<IntType>(1), static_cast<IntType>(0));
+        EXPECT_EQ(AK::ceil_log2<IntType>(1), static_cast<IntType>(0));
+
+        EXPECT_EQ(AK::log2<IntType>(2), static_cast<IntType>(1));
+        EXPECT_EQ(AK::ceil_log2<IntType>(2), static_cast<IntType>(1));
+
+        for (IntType power = 2; power < 8 * sizeof(IntType); ++power) {
+            IntType number = static_cast<IntType>(1) << power;
+
+            EXPECT_EQ(AK::log2<IntType>(number), power);
+            EXPECT_EQ(AK::ceil_log2<IntType>(number), power);
+
+            EXPECT_EQ(AK::log2<IntType>(number - 1), power - 1);
+            EXPECT_EQ(AK::ceil_log2<IntType>(number - 1), power);
+
+            EXPECT_EQ(AK::log2<IntType>(number + 1), power);
+            EXPECT_EQ(AK::ceil_log2<IntType>(number + 1), power + 1);
+        }
+    };
+
+    test_log2_for_type.operator()<u8>();
+    test_log2_for_type.operator()<u32>();
+    test_log2_for_type.operator()<u64>();
+
+    EXPECT_EQ(AK::log2<i32>(0), AK::NumericLimits<i32>::min());
+    EXPECT_EQ(AK::ceil_log2<i32>(0), AK::NumericLimits<i32>::min());
+    EXPECT_EQ(AK::log2<i32>(-1), AK::NumericLimits<i32>::min());
+    EXPECT_EQ(AK::ceil_log2<i32>(-1), AK::NumericLimits<i32>::min());
+}
 
 TEST_CASE(pow)
 {

--- a/Userland/Libraries/LibGfx/Font/OpenType/Hinting/Opcodes.cpp
+++ b/Userland/Libraries/LibGfx/Font/OpenType/Hinting/Opcodes.cpp
@@ -27,7 +27,7 @@ static constexpr u8 flag_bit_count(Opcode opcode)
     switch (to_underlying(opcode)) {
 #define __ENUMERATE_OPENTYPE_OPCODES(mnemonic, range_start, range_end) \
     case range_start ... range_end:                                    \
-        return AK::ceil_log2(range_end - range_start);
+        return AK::ceil_log2<u8>(range_end - range_start);
         ENUMERATE_OPENTYPE_OPCODES
 #undef __ENUMERATE_OPENTYPE_OPCODES
     }


### PR DESCRIPTION
The `exp2()`, `log2()` and `ceil_log2()` functions now behave as is expected for signed types, negative numbers and overflow conditions.

Logarithm of zero is equal to negative infinity, to represent -inf, a type's minimum value is used. Likewise if the correct answer of exponentiation is too large for a type its maximum value is returned instead.

The following expressions show the changes:

     Expression   Before  After
    ------------  ------  -----
    exp2<u8>(8)        0    255
    exp2<i8>(8)        0    127
    log2<i8>(0)        0   -128
    log2<i8>(-1)       7   -128

This patch also fixes incorrect output of few edge cases:

    ceil_log2(1)       1      0
    exp2<i8>(7)     -128    127
    exp2<u64>(63)      0   2^63

Tests for these functions in `TestIntegerMath.cpp` are added as well.

---

Separate implementations for signed and unsigned would be better or is this fine?

Tests are maybe too much. Which ones should i remove?

Is this how these functions are supposed to work? or have i missed something...
