### PR TITLE
LibGfx/JPEGXL: Remove unused variables in `JPEGXLLoadingContext`

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/JPEGXLLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEGXLLoader.cpp
@@ -2600,9 +2600,6 @@ private:
 
     SizeHeader m_header;
     ImageMetadata m_metadata;
-
-    FrameHeader m_frame_header;
-    TOC m_toc;
 };
 
 JPEGXLImageDecoderPlugin::JPEGXLImageDecoderPlugin(NonnullOwnPtr<FixedMemoryStream> stream)


### PR DESCRIPTION
These two variables are already fields of `Frame`, they make no sense at the context scope.