### PR TITLE
LibWeb: Implement `:target` selector and some backing infrastructure

### DIFF
--- a/AK/URL.cpp
+++ b/AK/URL.cpp
@@ -72,6 +72,11 @@ DeprecatedString URL::fragment() const
     return percent_decode(m_fragment);
 }
 
+DeprecatedString URL::raw_fragment() const
+{
+    return m_fragment;
+}
+
 // NOTE: This only exists for compatibility with the existing URL tests which check for both .is_null() and .is_empty().
 static DeprecatedString deprecated_string_percent_encode(DeprecatedString const& input, URL::PercentEncodeSet set = URL::PercentEncodeSet::Userinfo, URL::SpaceAsPlus space_as_plus = URL::SpaceAsPlus::No)
 {

--- a/AK/URL.h
+++ b/AK/URL.h
@@ -83,7 +83,9 @@ public:
     ErrorOr<String> serialized_host() const;
     DeprecatedString basename() const;
     DeprecatedString query() const;
+    // NOTE: fragment() is percent-decoded, raw_fragment() is not.
     DeprecatedString fragment() const;
+    DeprecatedString raw_fragment() const;
     Optional<u16> port() const { return m_port; }
     DeprecatedString path_segment_at_index(size_t index) const;
     size_t path_segment_count() const { return m_paths.size(); }

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -587,6 +587,8 @@ Parser::ParseErrorOr<Selector::SimpleSelector> Parser::parse_pseudo_simple_selec
             return make_pseudo_class_selector(Selector::SimpleSelector::PseudoClass::Type::Seeking);
         if (pseudo_name.equals_ignoring_ascii_case("stalled"sv))
             return make_pseudo_class_selector(Selector::SimpleSelector::PseudoClass::Type::Stalled);
+        if (pseudo_name.equals_ignoring_ascii_case("target"sv))
+            return make_pseudo_class_selector(Selector::SimpleSelector::PseudoClass::Type::Target);
         if (pseudo_name.equals_ignoring_ascii_case("host"sv))
             return make_pseudo_class_selector(Selector::SimpleSelector::PseudoClass::Type::Host);
         if (pseudo_name.equals_ignoring_ascii_case("visited"sv))

--- a/Userland/Libraries/LibWeb/CSS/Selector.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Selector.cpp
@@ -258,6 +258,7 @@ ErrorOr<String> Selector::SimpleSelector::serialize() const
         case Selector::SimpleSelector::PseudoClass::Type::VolumeLocked:
         case Selector::SimpleSelector::PseudoClass::Type::Buffering:
         case Selector::SimpleSelector::PseudoClass::Type::Stalled:
+        case Selector::SimpleSelector::PseudoClass::Type::Target:
             // If the pseudo-class does not accept arguments append ":" (U+003A), followed by the name of the pseudo-class, to s.
             TRY(s.try_append(':'));
             TRY(s.try_append(pseudo_class_name(pseudo_class.type)));

--- a/Userland/Libraries/LibWeb/CSS/Selector.h
+++ b/Userland/Libraries/LibWeb/CSS/Selector.h
@@ -123,6 +123,7 @@ public:
                 VolumeLocked,
                 Buffering,
                 Stalled,
+                Target,
             };
             Type type;
 
@@ -344,6 +345,8 @@ constexpr StringView pseudo_class_name(Selector::SimpleSelector::PseudoClass::Ty
         return "buffering"sv;
     case Selector::SimpleSelector::PseudoClass::Type::Stalled:
         return "stalled"sv;
+    case Selector::SimpleSelector::PseudoClass::Type::Target:
+        return "target"sv;
     }
     VERIFY_NOT_REACHED();
 }

--- a/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
+++ b/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
@@ -425,6 +425,8 @@ static inline bool matches_pseudo_class(CSS::Selector::SimpleSelector::PseudoCla
         auto const& media_element = static_cast<HTML::HTMLMediaElement const&>(element);
         return media_element.stalled();
     }
+    case CSS::Selector::SimpleSelector::PseudoClass::Type::Target:
+        return element.is_target();
     }
 
     return false;

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -2,7 +2,7 @@
  * Copyright (c) 2018-2023, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2021-2023, Linus Groh <linusg@serenityos.org>
  * Copyright (c) 2021-2023, Luke Wilde <lukew@serenityos.org>
- * Copyright (c) 2021, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2021-2023, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -1708,6 +1708,23 @@ void Document::set_active_element(Element* element)
         return;
 
     m_active_element = element;
+
+    if (m_layout_root)
+        m_layout_root->set_needs_display();
+}
+
+void Document::set_target_element(Element* element)
+{
+    if (m_target_element.ptr() == element)
+        return;
+
+    if (m_target_element)
+        m_target_element->set_needs_style_update(true);
+
+    m_target_element = element;
+
+    if (m_target_element)
+        m_target_element->set_needs_style_update(true);
 
     if (m_layout_root)
         m_layout_root->set_needs_display();

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -49,6 +49,7 @@
 #include <LibWeb/HTML/DocumentState.h>
 #include <LibWeb/HTML/EventLoop/EventLoop.h>
 #include <LibWeb/HTML/EventNames.h>
+#include <LibWeb/HTML/Focus.h>
 #include <LibWeb/HTML/HTMLAnchorElement.h>
 #include <LibWeb/HTML/HTMLAreaElement.h>
 #include <LibWeb/HTML/HTMLBaseElement.h>
@@ -1794,6 +1795,64 @@ Element* Document::find_a_potential_indicated_element(DeprecatedString fragment)
 
     // 3. Return null.
     return nullptr;
+}
+
+// https://html.spec.whatwg.org/multipage/browsing-the-web.html#scroll-to-the-fragment-identifier
+void Document::scroll_to_the_fragment()
+{
+    // To scroll to the fragment given a Document document:
+
+    // 1. If document's indicated part is null, then set document's target element to null.
+    auto indicated_part = determine_the_indicated_part();
+    if (indicated_part.has<Element*>() && indicated_part.get<Element*>() == nullptr) {
+        set_target_element(nullptr);
+    }
+
+    // 2. Otherwise, if document's indicated part is top of the document, then:
+    else if (indicated_part.has<TopOfTheDocument>()) {
+        // 1. Set document's target element to null.
+        set_target_element(nullptr);
+
+        // 2. Scroll to the beginning of the document for document. [CSSOMVIEW]
+        scroll_to_the_beginning_of_the_document();
+
+        // 3. Return.
+        return;
+    }
+
+    // 3. Otherwise:
+    else {
+        // 1. Assert: document's indicated part is an element.
+        VERIFY(indicated_part.has<Element*>());
+
+        // 2. Let target be document's indicated part.
+        auto target = indicated_part.get<Element*>();
+
+        // 3. Set document's target element to target.
+        set_target_element(target);
+
+        // FIXME: 4. Run the ancestor details revealing algorithm on target.
+
+        // FIXME: 5. Run the ancestor hidden-until-found revealing algorithm on target.
+
+        // 6. Scroll target into view, with behavior set to "auto", block set to "start", and inline set to "nearest". [CSSOMVIEW]
+        // FIXME: Do this properly!
+        (void)target->scroll_into_view();
+
+        // 7. Run the focusing steps for target, with the Document's viewport as the fallback target.
+        // FIXME: Pass the Document's viewport somehow.
+        HTML::run_focusing_steps(target);
+
+        // FIXME: 8. Move the sequential focus navigation starting point to target.
+    }
+}
+
+// https://drafts.csswg.org/cssom-view-1/#scroll-to-the-beginning-of-the-document
+void Document::scroll_to_the_beginning_of_the_document()
+{
+    // FIXME: Actually implement this algorithm
+    if (auto browsing_context = this->browsing_context())
+        browsing_context->scroll_to({ 0, 0 });
 }
 
 DeprecatedString Document::ready_state() const

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -295,6 +295,9 @@ public:
 
     void set_active_element(Element*);
 
+    Element const* target_element() const { return m_target_element.ptr(); }
+    void set_target_element(Element*);
+
     bool created_for_appropriate_template_contents() const { return m_created_for_appropriate_template_contents; }
 
     JS::NonnullGCPtr<Document> appropriate_template_contents_owner_document();
@@ -565,6 +568,7 @@ private:
 
     JS::GCPtr<Element> m_focused_element;
     JS::GCPtr<Element> m_active_element;
+    JS::GCPtr<Element> m_target_element;
 
     bool m_created_for_appropriate_template_contents { false };
     JS::GCPtr<Document> m_associated_inert_template_document;

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -298,6 +298,9 @@ public:
     Element const* target_element() const { return m_target_element.ptr(); }
     void set_target_element(Element*);
 
+    void scroll_to_the_fragment();
+    void scroll_to_the_beginning_of_the_document();
+
     bool created_for_appropriate_template_contents() const { return m_created_for_appropriate_template_contents; }
 
     JS::NonnullGCPtr<Document> appropriate_template_contents_owner_document();

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -524,6 +524,11 @@ private:
     void queue_intersection_observer_task();
     void queue_an_intersection_observer_entry(IntersectionObserver::IntersectionObserver&, HighResolutionTime::DOMHighResTimeStamp time, JS::NonnullGCPtr<Geometry::DOMRectReadOnly> root_bounds, JS::NonnullGCPtr<Geometry::DOMRectReadOnly> bounding_client_rect, JS::NonnullGCPtr<Geometry::DOMRectReadOnly> intersection_rect, bool is_intersecting, double intersection_ratio, JS::NonnullGCPtr<Element> target);
 
+    struct TopOfTheDocument { };
+    using IndicatedPart = Variant<Element*, TopOfTheDocument>;
+    IndicatedPart determine_the_indicated_part() const;
+    Element* find_a_potential_indicated_element(DeprecatedString fragment) const;
+
     OwnPtr<CSS::StyleComputer> m_style_computer;
     JS::GCPtr<CSS::StyleSheetList> m_style_sheets;
     JS::GCPtr<Node> m_hovered_node;

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -634,6 +634,11 @@ bool Element::is_active() const
     return document().active_element() == this;
 }
 
+bool Element::is_target() const
+{
+    return document().target_element() == this;
+}
+
 JS::NonnullGCPtr<HTMLCollection> Element::get_elements_by_class_name(DeprecatedFlyString const& class_names)
 {
     Vector<FlyString> list_of_class_names;

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -168,6 +168,7 @@ public:
 
     bool is_focused() const;
     bool is_active() const;
+    bool is_target() const;
 
     JS::NonnullGCPtr<HTMLCollection> get_elements_by_class_name(DeprecatedFlyString const&);
 

--- a/Userland/Libraries/LibWeb/Dump.cpp
+++ b/Userland/Libraries/LibWeb/Dump.cpp
@@ -590,6 +590,9 @@ void dump_selector(StringBuilder& builder, CSS::Selector const& selector)
                 case CSS::Selector::SimpleSelector::PseudoClass::Type::Stalled:
                     pseudo_class_description = "Stalled";
                     break;
+                case CSS::Selector::SimpleSelector::PseudoClass::Type::Target:
+                    pseudo_class_description = "Target";
+                    break;
                 }
 
                 builder.appendff(" pseudo_class={}", pseudo_class_description);

--- a/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
@@ -1407,11 +1407,8 @@ WebIDL::ExceptionOr<void> BrowsingContext::traverse_the_history(size_t entry_ind
     }
 
     // 10. If entry's persisted user state is null, and its URL's fragment is non-null, then scroll to the fragment.
-    if (!entry->url.fragment().is_null()) {
-        // FIXME: Implement the full "scroll to the fragment" algorithm:
-        // https://html.spec.whatwg.org/multipage/browsing-the-web.html#scroll-to-the-fragment-identifier
-        scroll_to_anchor(entry->url.fragment());
-    }
+    if (!entry->url.fragment().is_null())
+        active_document()->scroll_to_the_fragment();
 
     // 11. Set the current entry to entry.
     m_session_history_index = entry_index;


### PR DESCRIPTION
...not *much* backing infrastructure, because I got very lost in the yaks, confused myself, and gave up. :sweat_smile: As such, we don't set the target element most of the time, and so this doesn't really function *yet*, but it will once we have a more complete Navigables implementation.