### PR TITLE
Ports/poppler: Explicitly exclude optional dependencies

### DIFF
--- a/Ports/poppler/package.sh
+++ b/Ports/poppler/package.sh
@@ -31,6 +31,8 @@ configopts=(
     '-DENABLE_GOBJECT_INTROSPECTION=OFF'
     '-DENABLE_GTK_DOC=OFF'
     '-DENABLE_LIBOPENJPEG=unmaintained'
+    '-DWITH_Gpgmepp=OFF'
+    '-DWITH_NSS3=OFF'
 )
 
 configure() {


### PR DESCRIPTION
Previously, the optional `gpgme` and `nss3` dependencies could be unintentionally included if they were present on the host machine.

The build was failing on my machine due to `gpgme` being detected somewhere.