### PR TITLE
Ports/mgba: Explicitly exclude optional dependencies

### DIFF
--- a/Ports/mgba/package.sh
+++ b/Ports/mgba/package.sh
@@ -5,7 +5,11 @@ files=(
     "https://github.com/mgba-emu/mgba/archive/refs/tags/${version}.tar.gz 692ff0ac50e18380df0ff3ee83071f9926715200d0dceedd9d16a028a59537a0"
 )
 configopts=(
+    '-DBUILD_QT=OFF'
     "-DCMAKE_TOOLCHAIN_FILE=${SERENITY_BUILD_DIR}/CMakeToolchain.txt"
+    '-DUSE_EDITLINE=OFF'
+    '-DUSE_ELF=OFF'
+    '-DUSE_EPOXY=OFF'
 )
 useconfigure=true
 depends=(

--- a/Ports/mgba/package.sh
+++ b/Ports/mgba/package.sh
@@ -1,12 +1,20 @@
 #!/usr/bin/env -S bash ../.port_include.sh
-port=mgba
-version=0.9.3
+port='mgba'
+version='0.9.3'
 files=(
     "https://github.com/mgba-emu/mgba/archive/refs/tags/${version}.tar.gz 692ff0ac50e18380df0ff3ee83071f9926715200d0dceedd9d16a028a59537a0"
 )
-configopts=("-DCMAKE_TOOLCHAIN_FILE=${SERENITY_BUILD_DIR}/CMakeToolchain.txt")
+configopts=(
+    "-DCMAKE_TOOLCHAIN_FILE=${SERENITY_BUILD_DIR}/CMakeToolchain.txt"
+)
 useconfigure=true
-depends=("SDL2" "zlib" "sqlite" "libpng" "libzip")
+depends=(
+    'libpng'
+    'libzip'
+    'SDL2'
+    'sqlite'
+    'zlib'
+)
 
 configure() {
     run cmake "${configopts[@]}"


### PR DESCRIPTION
Previously, some optional dependencies could be unintentionally included if they were present on the host machine.

The build was previously failing on my machine, as it was attempting to build the QT frontend as well as the SDL one.