### PR TITLE
Kernel/Net: Don't allocate memory for adapters' names 

### DIFF
--- a/AK/StringBuilder.h
+++ b/AK/StringBuilder.h
@@ -16,11 +16,19 @@ namespace AK {
 
 class StringBuilder {
 public:
+    static constexpr size_t inline_capacity = 256;
+
     using OutputType = DeprecatedString;
 
     static ErrorOr<StringBuilder> create(size_t initial_capacity = inline_capacity);
 
     explicit StringBuilder(size_t initial_capacity = inline_capacity);
+
+    enum class UseInlineCapacityOnly {
+        Yes,
+        No,
+    };
+    explicit StringBuilder(UseInlineCapacityOnly use_inline_capacity_only);
     ~StringBuilder() = default;
 
     ErrorOr<void> try_append(StringView);
@@ -73,9 +81,9 @@ public:
     [[nodiscard]] StringView string_view() const;
     void clear();
 
-    [[nodiscard]] size_t length() const { return m_buffer.size(); }
-    [[nodiscard]] bool is_empty() const { return m_buffer.is_empty(); }
-    void trim(size_t count) { m_buffer.resize(m_buffer.size() - count); }
+    [[nodiscard]] size_t length() const;
+    [[nodiscard]] bool is_empty() const;
+    void trim(size_t count);
 
     template<class SeparatorType, class CollectionType>
     void join(SeparatorType const& separator, CollectionType const& collection, StringView fmtstr = "{}"sv)
@@ -98,10 +106,10 @@ public:
 
 private:
     ErrorOr<void> will_append(size_t);
-    u8* data() { return m_buffer.data(); }
-    u8 const* data() const { return m_buffer.data(); }
+    u8* data();
+    u8 const* data() const;
 
-    static constexpr size_t inline_capacity = 256;
+    UseInlineCapacityOnly m_use_inline_capacity_only { UseInlineCapacityOnly::No };
     Detail::ByteBuffer<inline_capacity> m_buffer;
 };
 

--- a/Kernel/Net/Intel/E1000ENetworkAdapter.cpp
+++ b/Kernel/Net/Intel/E1000ENetworkAdapter.cpp
@@ -199,13 +199,13 @@ UNMAP_AFTER_INIT ErrorOr<NonnullRefPtr<NetworkAdapter>> E1000ENetworkAdapter::cr
     auto rx_descriptors_region = TRY(MM.allocate_contiguous_kernel_region(TRY(Memory::page_round_up(sizeof(e1000_rx_desc) * number_of_rx_descriptors)), "E1000 RX Descriptors"sv, Memory::Region::Access::ReadWrite));
     auto tx_descriptors_region = TRY(MM.allocate_contiguous_kernel_region(TRY(Memory::page_round_up(sizeof(e1000_tx_desc) * number_of_tx_descriptors)), "E1000 TX Descriptors"sv, Memory::Region::Access::ReadWrite));
 
-    return TRY(adopt_nonnull_ref_or_enomem(new (nothrow) E1000ENetworkAdapter(pci_device_identifier,
+    return TRY(adopt_nonnull_ref_or_enomem(new (nothrow) E1000ENetworkAdapter(interface_name.representable_view(),
+        pci_device_identifier,
         irq, move(registers_io_window),
         move(rx_buffer_region),
         move(tx_buffer_region),
         move(rx_descriptors_region),
-        move(tx_descriptors_region),
-        move(interface_name))));
+        move(tx_descriptors_region))));
 }
 
 UNMAP_AFTER_INIT ErrorOr<void> E1000ENetworkAdapter::initialize(Badge<NetworkingManagement>)
@@ -229,16 +229,16 @@ UNMAP_AFTER_INIT ErrorOr<void> E1000ENetworkAdapter::initialize(Badge<Networking
     return {};
 }
 
-UNMAP_AFTER_INIT E1000ENetworkAdapter::E1000ENetworkAdapter(PCI::DeviceIdentifier const& device_identifier, u8 irq,
+UNMAP_AFTER_INIT E1000ENetworkAdapter::E1000ENetworkAdapter(StringView interface_name,
+    PCI::DeviceIdentifier const& device_identifier, u8 irq,
     NonnullOwnPtr<IOWindow> registers_io_window, NonnullOwnPtr<Memory::Region> rx_buffer_region,
     NonnullOwnPtr<Memory::Region> tx_buffer_region, NonnullOwnPtr<Memory::Region> rx_descriptors_region,
-    NonnullOwnPtr<Memory::Region> tx_descriptors_region, NonnullOwnPtr<KString> interface_name)
-    : E1000NetworkAdapter(device_identifier, irq, move(registers_io_window),
+    NonnullOwnPtr<Memory::Region> tx_descriptors_region)
+    : E1000NetworkAdapter(interface_name, device_identifier, irq, move(registers_io_window),
         move(rx_buffer_region),
         move(tx_buffer_region),
         move(rx_descriptors_region),
-        move(tx_descriptors_region),
-        move(interface_name))
+        move(tx_descriptors_region))
 {
 }
 

--- a/Kernel/Net/Intel/E1000ENetworkAdapter.h
+++ b/Kernel/Net/Intel/E1000ENetworkAdapter.h
@@ -29,10 +29,10 @@ public:
     virtual StringView purpose() const override { return class_name(); }
 
 private:
-    E1000ENetworkAdapter(PCI::DeviceIdentifier const&, u8 irq,
+    E1000ENetworkAdapter(StringView interface_name, PCI::DeviceIdentifier const&, u8 irq,
         NonnullOwnPtr<IOWindow> registers_io_window, NonnullOwnPtr<Memory::Region> rx_buffer_region,
         NonnullOwnPtr<Memory::Region> tx_buffer_region, NonnullOwnPtr<Memory::Region> rx_descriptors_region,
-        NonnullOwnPtr<Memory::Region> tx_descriptors_region, NonnullOwnPtr<KString>);
+        NonnullOwnPtr<Memory::Region> tx_descriptors_region);
 
     virtual StringView class_name() const override { return "E1000ENetworkAdapter"sv; }
 

--- a/Kernel/Net/Intel/E1000NetworkAdapter.cpp
+++ b/Kernel/Net/Intel/E1000NetworkAdapter.cpp
@@ -177,13 +177,13 @@ UNMAP_AFTER_INIT ErrorOr<NonnullRefPtr<NetworkAdapter>> E1000NetworkAdapter::cre
     auto rx_descriptors_region = TRY(MM.allocate_contiguous_kernel_region(TRY(Memory::page_round_up(sizeof(e1000_rx_desc) * number_of_rx_descriptors)), "E1000 RX Descriptors"sv, Memory::Region::Access::ReadWrite));
     auto tx_descriptors_region = TRY(MM.allocate_contiguous_kernel_region(TRY(Memory::page_round_up(sizeof(e1000_tx_desc) * number_of_tx_descriptors)), "E1000 TX Descriptors"sv, Memory::Region::Access::ReadWrite));
 
-    return TRY(adopt_nonnull_ref_or_enomem(new (nothrow) E1000NetworkAdapter(pci_device_identifier,
+    return TRY(adopt_nonnull_ref_or_enomem(new (nothrow) E1000NetworkAdapter(interface_name.representable_view(),
+        pci_device_identifier,
         irq, move(registers_io_window),
         move(rx_buffer_region),
         move(tx_buffer_region),
         move(rx_descriptors_region),
-        move(tx_descriptors_region),
-        move(interface_name))));
+        move(tx_descriptors_region))));
 }
 
 UNMAP_AFTER_INIT ErrorOr<void> E1000NetworkAdapter::initialize(Badge<NetworkingManagement>)
@@ -225,11 +225,12 @@ UNMAP_AFTER_INIT void E1000NetworkAdapter::setup_interrupts()
     enable_irq();
 }
 
-UNMAP_AFTER_INIT E1000NetworkAdapter::E1000NetworkAdapter(PCI::DeviceIdentifier const& device_identifier, u8 irq,
+UNMAP_AFTER_INIT E1000NetworkAdapter::E1000NetworkAdapter(StringView interface_name,
+    PCI::DeviceIdentifier const& device_identifier, u8 irq,
     NonnullOwnPtr<IOWindow> registers_io_window, NonnullOwnPtr<Memory::Region> rx_buffer_region,
     NonnullOwnPtr<Memory::Region> tx_buffer_region, NonnullOwnPtr<Memory::Region> rx_descriptors_region,
-    NonnullOwnPtr<Memory::Region> tx_descriptors_region, NonnullOwnPtr<KString> interface_name)
-    : NetworkAdapter(move(interface_name))
+    NonnullOwnPtr<Memory::Region> tx_descriptors_region)
+    : NetworkAdapter(interface_name)
     , PCI::Device(device_identifier)
     , IRQHandler(irq)
     , m_registers_io_window(move(registers_io_window))

--- a/Kernel/Net/Intel/E1000NetworkAdapter.h
+++ b/Kernel/Net/Intel/E1000NetworkAdapter.h
@@ -42,10 +42,10 @@ protected:
     void setup_interrupts();
     void setup_link();
 
-    E1000NetworkAdapter(PCI::DeviceIdentifier const&, u8 irq,
+    E1000NetworkAdapter(StringView, PCI::DeviceIdentifier const&, u8 irq,
         NonnullOwnPtr<IOWindow> registers_io_window, NonnullOwnPtr<Memory::Region> rx_buffer_region,
         NonnullOwnPtr<Memory::Region> tx_buffer_region, NonnullOwnPtr<Memory::Region> rx_descriptors_region,
-        NonnullOwnPtr<Memory::Region> tx_descriptors_region, NonnullOwnPtr<KString>);
+        NonnullOwnPtr<Memory::Region> tx_descriptors_region);
 
     virtual bool handle_irq(RegisterState const&) override;
     virtual StringView class_name() const override { return "E1000NetworkAdapter"sv; }

--- a/Kernel/Net/LoopbackAdapter.cpp
+++ b/Kernel/Net/LoopbackAdapter.cpp
@@ -13,12 +13,11 @@ static bool s_loopback_initialized = false;
 
 ErrorOr<NonnullRefPtr<LoopbackAdapter>> LoopbackAdapter::try_create()
 {
-    auto interface_name = TRY(KString::try_create("loop"sv));
-    return TRY(adopt_nonnull_ref_or_enomem(new (nothrow) LoopbackAdapter(move(interface_name))));
+    return TRY(adopt_nonnull_ref_or_enomem(new (nothrow) LoopbackAdapter("loop"sv)));
 }
 
-LoopbackAdapter::LoopbackAdapter(NonnullOwnPtr<KString> interface_name)
-    : NetworkAdapter(move(interface_name))
+LoopbackAdapter::LoopbackAdapter(StringView interface_name)
+    : NetworkAdapter(interface_name)
 {
     VERIFY(!s_loopback_initialized);
     s_loopback_initialized = true;

--- a/Kernel/Net/LoopbackAdapter.h
+++ b/Kernel/Net/LoopbackAdapter.h
@@ -12,7 +12,7 @@ namespace Kernel {
 
 class LoopbackAdapter final : public NetworkAdapter {
 private:
-    LoopbackAdapter(NonnullOwnPtr<KString>);
+    LoopbackAdapter(StringView);
 
 public:
     static ErrorOr<NonnullRefPtr<LoopbackAdapter>> try_create();

--- a/Kernel/Net/NetworkAdapter.cpp
+++ b/Kernel/Net/NetworkAdapter.cpp
@@ -14,9 +14,9 @@
 
 namespace Kernel {
 
-NetworkAdapter::NetworkAdapter(NonnullOwnPtr<KString> interface_name)
-    : m_name(move(interface_name))
+NetworkAdapter::NetworkAdapter(StringView interface_name)
 {
+    m_name.store_characters(interface_name);
 }
 
 NetworkAdapter::~NetworkAdapter() = default;

--- a/Kernel/Net/NetworkAdapter.h
+++ b/Kernel/Net/NetworkAdapter.h
@@ -60,7 +60,7 @@ public:
     virtual Type adapter_type() const = 0;
     virtual ErrorOr<void> initialize(Badge<NetworkingManagement>) = 0;
 
-    StringView name() const { return m_name->view(); }
+    StringView name() const { return m_name.representable_view(); }
     MACAddress mac_address() { return m_mac_address; }
     IPv4Address ipv4_address() const { return m_ipv4_address; }
     IPv4Address ipv4_netmask() const { return m_ipv4_netmask; }
@@ -102,7 +102,7 @@ public:
     void send_packet(ReadonlyBytes);
 
 protected:
-    NetworkAdapter(NonnullOwnPtr<KString>);
+    NetworkAdapter(StringView);
     void set_mac_address(MACAddress const& mac_address) { m_mac_address = mac_address; }
     void did_receive(ReadonlyBytes);
     virtual void send_raw(ReadonlyBytes) = 0;
@@ -120,7 +120,7 @@ private:
     PacketList m_packet_queue;
     size_t m_packet_queue_size { 0 };
     SpinlockProtected<PacketList, LockRank::None> m_unused_packets {};
-    NonnullOwnPtr<KString> m_name;
+    FixedStringBuffer<IFNAMSIZ> m_name;
     u32 m_packets_in { 0 };
     u32 m_bytes_in { 0 };
     u32 m_packets_out { 0 };

--- a/Kernel/Net/NetworkingManagement.cpp
+++ b/Kernel/Net/NetworkingManagement.cpp
@@ -83,12 +83,12 @@ RefPtr<NetworkAdapter> NetworkingManagement::lookup_by_name(StringView name) con
     });
 }
 
-ErrorOr<NonnullOwnPtr<KString>> NetworkingManagement::generate_interface_name_from_pci_address(PCI::DeviceIdentifier const& device_identifier)
+ErrorOr<FixedStringBuffer<IFNAMSIZ>> NetworkingManagement::generate_interface_name_from_pci_address(PCI::DeviceIdentifier const& device_identifier)
 {
     VERIFY(device_identifier.class_code().value() == 0x2);
     // Note: This stands for e - "Ethernet", p - "Port" as for PCI bus, "s" for slot as for PCI slot
-    auto name = TRY(KString::formatted("ep{}s{}", device_identifier.address().bus(), device_identifier.address().device()));
-    VERIFY(!NetworkingManagement::the().lookup_by_name(name->view()));
+    auto name = TRY(FixedStringBuffer<IFNAMSIZ>::formatted("ep{}s{}", device_identifier.address().bus(), device_identifier.address().device()));
+    VERIFY(!NetworkingManagement::the().lookup_by_name(name.representable_view()));
     return name;
 }
 

--- a/Kernel/Net/NetworkingManagement.h
+++ b/Kernel/Net/NetworkingManagement.h
@@ -26,7 +26,7 @@ public:
     static bool is_initialized();
     bool initialize();
 
-    static ErrorOr<NonnullOwnPtr<KString>> generate_interface_name_from_pci_address(PCI::DeviceIdentifier const&);
+    static ErrorOr<FixedStringBuffer<IFNAMSIZ>> generate_interface_name_from_pci_address(PCI::DeviceIdentifier const&);
 
     NetworkingManagement();
 

--- a/Kernel/Net/Realtek/RTL8168NetworkAdapter.cpp
+++ b/Kernel/Net/Realtek/RTL8168NetworkAdapter.cpp
@@ -196,7 +196,7 @@ UNMAP_AFTER_INIT ErrorOr<NonnullRefPtr<NetworkAdapter>> RTL8168NetworkAdapter::c
     u8 irq = pci_device_identifier.interrupt_line().value();
     auto interface_name = TRY(NetworkingManagement::generate_interface_name_from_pci_address(pci_device_identifier));
     auto registers_io_window = TRY(IOWindow::create_for_pci_device_bar(pci_device_identifier, PCI::HeaderType0BaseRegister::BAR0));
-    return TRY(adopt_nonnull_ref_or_enomem(new (nothrow) RTL8168NetworkAdapter(pci_device_identifier, irq, move(registers_io_window), move(interface_name))));
+    return TRY(adopt_nonnull_ref_or_enomem(new (nothrow) RTL8168NetworkAdapter(interface_name.representable_view(), pci_device_identifier, irq, move(registers_io_window))));
 }
 
 bool RTL8168NetworkAdapter::determine_supported_version() const
@@ -244,8 +244,8 @@ bool RTL8168NetworkAdapter::determine_supported_version() const
     }
 }
 
-UNMAP_AFTER_INIT RTL8168NetworkAdapter::RTL8168NetworkAdapter(PCI::DeviceIdentifier const& device_identifier, u8 irq, NonnullOwnPtr<IOWindow> registers_io_window, NonnullOwnPtr<KString> interface_name)
-    : NetworkAdapter(move(interface_name))
+UNMAP_AFTER_INIT RTL8168NetworkAdapter::RTL8168NetworkAdapter(StringView interface_name, PCI::DeviceIdentifier const& device_identifier, u8 irq, NonnullOwnPtr<IOWindow> registers_io_window)
+    : NetworkAdapter(interface_name)
     , PCI::Device(device_identifier)
     , IRQHandler(irq)
     , m_registers_io_window(move(registers_io_window))

--- a/Kernel/Net/Realtek/RTL8168NetworkAdapter.h
+++ b/Kernel/Net/Realtek/RTL8168NetworkAdapter.h
@@ -41,7 +41,7 @@ private:
     static constexpr size_t number_of_rx_descriptors = 64;
     static constexpr size_t number_of_tx_descriptors = 16;
 
-    RTL8168NetworkAdapter(PCI::DeviceIdentifier const&, u8 irq, NonnullOwnPtr<IOWindow> registers_io_window, NonnullOwnPtr<KString>);
+    RTL8168NetworkAdapter(StringView, PCI::DeviceIdentifier const&, u8 irq, NonnullOwnPtr<IOWindow> registers_io_window);
 
     virtual bool handle_irq(RegisterState const&) override;
     virtual StringView class_name() const override { return "RTL8168NetworkAdapter"sv; }

--- a/Kernel/Net/VirtIO/VirtIONetworkAdapter.cpp
+++ b/Kernel/Net/VirtIO/VirtIONetworkAdapter.cpp
@@ -102,12 +102,12 @@ UNMAP_AFTER_INIT ErrorOr<bool> VirtIONetworkAdapter::probe(PCI::DeviceIdentifier
 UNMAP_AFTER_INIT ErrorOr<NonnullRefPtr<NetworkAdapter>> VirtIONetworkAdapter::create(PCI::DeviceIdentifier const& pci_device_identifier)
 {
     auto interface_name = TRY(NetworkingManagement::generate_interface_name_from_pci_address(pci_device_identifier));
-    return TRY(adopt_nonnull_ref_or_enomem(new (nothrow) VirtIONetworkAdapter(pci_device_identifier, move(interface_name))));
+    return TRY(adopt_nonnull_ref_or_enomem(new (nothrow) VirtIONetworkAdapter(interface_name.representable_view(), pci_device_identifier)));
 }
 
-UNMAP_AFTER_INIT VirtIONetworkAdapter::VirtIONetworkAdapter(PCI::DeviceIdentifier const& pci_device_identifier, NonnullOwnPtr<KString> interface_name)
+UNMAP_AFTER_INIT VirtIONetworkAdapter::VirtIONetworkAdapter(StringView interface_name, PCI::DeviceIdentifier const& pci_device_identifier)
     : VirtIO::Device(pci_device_identifier)
-    , NetworkAdapter(move(interface_name))
+    , NetworkAdapter(interface_name)
 {
 }
 

--- a/Kernel/Net/VirtIO/VirtIONetworkAdapter.h
+++ b/Kernel/Net/VirtIO/VirtIONetworkAdapter.h
@@ -35,7 +35,7 @@ public:
     virtual i32 link_speed() override { return m_link_speed; }
 
 private:
-    explicit VirtIONetworkAdapter(PCI::DeviceIdentifier const&, NonnullOwnPtr<KString> interface_name);
+    explicit VirtIONetworkAdapter(StringView interface_name, PCI::DeviceIdentifier const&);
 
     // VirtIO::Device
     virtual bool handle_device_config_change() override;


### PR DESCRIPTION
The goal of this PR is to remove some extra heap allocations.
Instead, we could use a FixedStringBuffer to store a string with up to 16 chars for network adapters' names.