### PR TITLE
Ports/wayland: Add `libffi` dependency

### DIFF
--- a/Ports/wayland/package.sh
+++ b/Ports/wayland/package.sh
@@ -12,6 +12,7 @@ configopts=(
 )
 depends=(
     'expat'
+    'libffi'
     'libxml2'
 )
 files=(


### PR DESCRIPTION
This allows `wayland` to build from a clean state.