### PR TITLE
LibWeb: Generate PseudoClass metadata

### DIFF
--- a/Meta/CMake/libweb_generators.cmake
+++ b/Meta/CMake/libweb_generators.cmake
@@ -46,6 +46,15 @@ function (generate_css_implementation)
     )
 
     invoke_generator(
+        "PseudoClass.cpp"
+        Lagom::GenerateCSSPseudoClass
+        "${LIBWEB_INPUT_FOLDER}/CSS/PseudoClasses.json"
+        "CSS/PseudoClass.h"
+        "CSS/PseudoClass.cpp"
+        arguments -j "${LIBWEB_INPUT_FOLDER}/CSS/PseudoClasses.json"
+    )
+
+    invoke_generator(
         "TransformFunctions.cpp"
         Lagom::GenerateCSSTransformFunctions
         "${LIBWEB_INPUT_FOLDER}/CSS/TransformFunctions.json"

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/CMakeLists.txt
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/CMakeLists.txt
@@ -5,6 +5,7 @@ lagom_tool(GenerateCSSEnums                 SOURCES GenerateCSSEnums.cpp LIBS Li
 lagom_tool(GenerateCSSMathFunctions         SOURCES GenerateCSSMathFunctions.cpp LIBS LibMain)
 lagom_tool(GenerateCSSMediaFeatureID        SOURCES GenerateCSSMediaFeatureID.cpp LIBS LibMain)
 lagom_tool(GenerateCSSPropertyID            SOURCES GenerateCSSPropertyID.cpp LIBS LibMain)
+lagom_tool(GenerateCSSPseudoClass           SOURCES GenerateCSSPseudoClass.cpp LIBS LibMain)
 lagom_tool(GenerateCSSTransformFunctions    SOURCES GenerateCSSTransformFunctions.cpp LIBS LibMain)
 lagom_tool(GenerateCSSValueID               SOURCES GenerateCSSValueID.cpp LIBS LibMain)
 lagom_tool(GenerateWindowOrWorkerInterfaces SOURCES GenerateWindowOrWorkerInterfaces.cpp LIBS LibMain LibIDL)

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPseudoClass.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPseudoClass.cpp
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2022-2023, Sam Atkins <atkinssj@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "GeneratorUtil.h"
+#include <AK/SourceGenerator.h>
+#include <LibCore/ArgsParser.h>
+#include <LibMain/Main.h>
+
+ErrorOr<void> generate_header_file(JsonObject& pseudo_classes_data, Core::File& file);
+ErrorOr<void> generate_implementation_file(JsonObject& pseudo_classes_data, Core::File& file);
+
+ErrorOr<int> serenity_main(Main::Arguments arguments)
+{
+    StringView generated_header_path;
+    StringView generated_implementation_path;
+    StringView identifiers_json_path;
+
+    Core::ArgsParser args_parser;
+    args_parser.add_option(generated_header_path, "Path to the PseudoClasses header file to generate", "generated-header-path", 'h', "generated-header-path");
+    args_parser.add_option(generated_implementation_path, "Path to the PseudoClasses implementation file to generate", "generated-implementation-path", 'c', "generated-implementation-path");
+    args_parser.add_option(identifiers_json_path, "Path to the JSON file to read from", "json-path", 'j', "json-path");
+    args_parser.parse(arguments);
+
+    auto json = TRY(read_entire_file_as_json(identifiers_json_path));
+    VERIFY(json.is_object());
+    auto data = json.as_object();
+
+    auto generated_header_file = TRY(Core::File::open(generated_header_path, Core::File::OpenMode::Write));
+    auto generated_implementation_file = TRY(Core::File::open(generated_implementation_path, Core::File::OpenMode::Write));
+
+    TRY(generate_header_file(data, *generated_header_file));
+    TRY(generate_implementation_file(data, *generated_implementation_file));
+
+    return 0;
+}
+
+ErrorOr<void> generate_header_file(JsonObject& pseudo_classes_data, Core::File& file)
+{
+    StringBuilder builder;
+    SourceGenerator generator { builder };
+
+    TRY(generator.try_append(R"~~~(
+#pragma once
+
+#include <AK/Optional.h>
+#include <AK/StringView.h>
+
+namespace Web::CSS {
+
+enum class PseudoClass {
+)~~~"));
+
+    TRY(pseudo_classes_data.try_for_each_member([&](auto& name, auto&) -> ErrorOr<void> {
+        auto member_generator = TRY(generator.fork());
+        TRY(member_generator.set("name:titlecase", TRY(title_casify(name))));
+
+        TRY(member_generator.try_appendln("    @name:titlecase@,"));
+        return {};
+    }));
+    TRY(generator.try_append(R"~~~(
+};
+
+Optional<PseudoClass> pseudo_class_from_string(StringView);
+StringView pseudo_class_name(PseudoClass);
+
+struct PseudoClassMetadata {
+    enum class ParameterType {
+        None,
+        ANPlusB,
+        ANPlusBOf,
+        ForgivingSelectorList,
+        LanguageRanges,
+        SelectorList,
+    } parameter_type;
+    bool is_valid_as_function;
+    bool is_valid_as_identifier;
+};
+PseudoClassMetadata pseudo_class_metadata(PseudoClass);
+
+}
+)~~~"));
+
+    TRY(file.write_until_depleted(generator.as_string_view().bytes()));
+    return {};
+}
+
+ErrorOr<void> generate_implementation_file(JsonObject& pseudo_classes_data, Core::File& file)
+{
+    StringBuilder builder;
+    SourceGenerator generator { builder };
+
+    TRY(generator.try_append(R"~~~(
+#include <LibWeb/CSS/PseudoClass.h>
+
+namespace Web::CSS {
+
+Optional<PseudoClass> pseudo_class_from_string(StringView string)
+{
+)~~~"));
+
+    TRY(pseudo_classes_data.try_for_each_member([&](auto& name, auto&) -> ErrorOr<void> {
+        auto member_generator = TRY(generator.fork());
+        TRY(member_generator.set("name", TRY(String::from_deprecated_string(name))));
+        TRY(member_generator.set("name:titlecase", TRY(title_casify(name))));
+
+        TRY(member_generator.try_append(R"~~~(
+    if (string.equals_ignoring_ascii_case("@name@"sv))
+        return PseudoClass::@name:titlecase@;
+)~~~"));
+        return {};
+    }));
+
+    TRY(generator.try_append(R"~~~(
+
+    return {};
+}
+
+StringView pseudo_class_name(PseudoClass pseudo_class)
+{
+    switch (pseudo_class) {
+)~~~"));
+
+    TRY(pseudo_classes_data.try_for_each_member([&](auto& name, auto&) -> ErrorOr<void> {
+        auto member_generator = TRY(generator.fork());
+        TRY(member_generator.set("name", TRY(String::from_deprecated_string(name))));
+        TRY(member_generator.set("name:titlecase", TRY(title_casify(name))));
+
+        TRY(member_generator.try_append(R"~~~(
+    case PseudoClass::@name:titlecase@:
+        return "@name@"sv;
+)~~~"));
+        return {};
+    }));
+
+    TRY(generator.try_append(R"~~~(
+    }
+    VERIFY_NOT_REACHED();
+}
+
+PseudoClassMetadata pseudo_class_metadata(PseudoClass pseudo_class)
+{
+    switch (pseudo_class) {
+)~~~"));
+
+    TRY(pseudo_classes_data.try_for_each_member([&](auto& name, JsonValue const& value) -> ErrorOr<void> {
+        auto member_generator = TRY(generator.fork());
+        auto& pseudo_class = value.as_object();
+        auto argument_string = pseudo_class.get_deprecated_string("argument"sv).value();
+
+        bool is_valid_as_identifier = argument_string.is_empty();
+        bool is_valid_as_function = !argument_string.is_empty();
+
+        if (argument_string.ends_with('?')) {
+            is_valid_as_identifier = true;
+            argument_string = argument_string.substring(0, argument_string.length() - 1);
+        }
+
+        String parameter_type = "None"_string;
+        if (is_valid_as_function) {
+            if (argument_string == "<an+b>"sv) {
+                parameter_type = "ANPlusB"_string;
+            } else if (argument_string == "<an+b-of>"sv) {
+                parameter_type = "ANPlusBOf"_string;
+            } else if (argument_string == "<forgiving-selector-list>"sv) {
+                parameter_type = "ForgivingSelectorList"_string;
+            } else if (argument_string == "<language-ranges>"sv) {
+                parameter_type = "LanguageRanges"_string;
+            } else if (argument_string == "<selector-list>"sv) {
+                parameter_type = "SelectorList"_string;
+            } else {
+                warnln("Unrecognized pseudo-class argument type: `{}`", argument_string);
+                VERIFY_NOT_REACHED();
+            }
+        }
+
+        TRY(member_generator.set("name:titlecase", TRY(title_casify(name))));
+        TRY(member_generator.set("parameter_type", parameter_type));
+        TRY(member_generator.set("is_valid_as_function", is_valid_as_function ? "true"_string : "false"_string));
+        TRY(member_generator.set("is_valid_as_identifier", is_valid_as_identifier ? "true"_string : "false"_string));
+
+        TRY(member_generator.try_append(R"~~~(
+    case PseudoClass::@name:titlecase@:
+        return {
+            .parameter_type = PseudoClassMetadata::ParameterType::@parameter_type@,
+            .is_valid_as_function = @is_valid_as_function@,
+            .is_valid_as_identifier = @is_valid_as_identifier@,
+        };
+)~~~"));
+        return {};
+    }));
+
+    TRY(generator.try_append(R"~~~(
+    }
+    VERIFY_NOT_REACHED();
+}
+
+}
+)~~~"));
+
+    TRY(file.write_until_depleted(generator.as_string_view().bytes()));
+    return {};
+}

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPseudoClass.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPseudoClass.cpp
@@ -71,6 +71,7 @@ struct PseudoClassMetadata {
         None,
         ANPlusB,
         ANPlusBOf,
+        CompoundSelector,
         ForgivingSelectorList,
         LanguageRanges,
         SelectorList,
@@ -164,6 +165,8 @@ PseudoClassMetadata pseudo_class_metadata(PseudoClass pseudo_class)
                 parameter_type = "ANPlusB"_string;
             } else if (argument_string == "<an+b-of>"sv) {
                 parameter_type = "ANPlusBOf"_string;
+            } else if (argument_string == "<compound-selector>"sv) {
+                parameter_type = "CompoundSelector"_string;
             } else if (argument_string == "<forgiving-selector-list>"sv) {
                 parameter_type = "ForgivingSelectorList"_string;
             } else if (argument_string == "<language-ranges>"sv) {

--- a/Meta/gn/secondary/Userland/Libraries/LibWeb/BUILD.gn
+++ b/Meta/gn/secondary/Userland/Libraries/LibWeb/BUILD.gn
@@ -164,6 +164,23 @@ compiled_action("generate_css_property_id") {
   ]
 }
 
+compiled_action("generate_css_pseudo_class") {
+  tool = "//Meta/Lagom/Tools/CodeGenerators/LibWeb:GenerateCSSPseudoClass"
+  inputs = [ "CSS/PseudoClasses.json" ]
+  outputs = [
+    "$target_gen_dir/CSS/PseudoClass.h",
+    "$target_gen_dir/CSS/PseudoClass.cpp",
+  ]
+  args = [
+    "-h",
+    rebase_path(outputs[0], root_build_dir),
+    "-c",
+    rebase_path(outputs[1], root_build_dir),
+    "-j",
+    rebase_path(inputs[0], root_build_dir),
+  ]
+}
+
 compiled_action("generate_css_transform_functions") {
   tool =
       "//Meta/Lagom/Tools/CodeGenerators/LibWeb:GenerateCSSTransformFunctions"
@@ -228,6 +245,7 @@ source_set("all_generated") {
     ":generate_css_math_functions",
     ":generate_css_media_feature_id",
     ":generate_css_property_id",
+    ":generate_css_pseudo_class",
     ":generate_css_transform_functions",
     ":generate_css_value_id",
     ":generate_default_stylesheet_source",

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -630,6 +630,7 @@ set(GENERATED_SOURCES
     CSS/MathFunctions.cpp
     CSS/MediaFeatureID.cpp
     CSS/PropertyID.cpp
+    CSS/PseudoClass.cpp
     CSS/QuirksModeStyleSheetSource.cpp
     CSS/TransformFunctions.cpp
     CSS/ValueID.cpp

--- a/Userland/Libraries/LibWeb/CSS/PseudoClasses.json
+++ b/Userland/Libraries/LibWeb/CSS/PseudoClasses.json
@@ -1,0 +1,116 @@
+{
+  "active": {
+    "argument": ""
+  },
+  "buffering": {
+    "argument": ""
+  },
+  "checked": {
+    "argument": ""
+  },
+  "defined": {
+    "argument": ""
+  },
+  "disabled": {
+    "argument": ""
+  },
+  "empty": {
+    "argument": ""
+  },
+  "enabled": {
+    "argument": ""
+  },
+  "first-child": {
+    "argument": ""
+  },
+  "first-of-type": {
+    "argument": ""
+  },
+  "focus": {
+    "argument": ""
+  },
+  "focus-visible": {
+    "argument": ""
+  },
+  "focus-within": {
+    "argument": ""
+  },
+  "host": {
+    "argument": "<selector-list>?"
+  },
+  "hover": {
+    "argument": ""
+  },
+  "indeterminate": {
+    "argument": ""
+  },
+  "is": {
+    "argument": "<forgiving-selector-list>"
+  },
+  "lang": {
+    "argument": "<language-ranges>"
+  },
+  "last-child": {
+    "argument": ""
+  },
+  "last-of-type": {
+    "argument": ""
+  },
+  "link": {
+    "argument": ""
+  },
+  "muted": {
+    "argument": ""
+  },
+  "not": {
+    "argument": "<selector-list>"
+  },
+  "nth-child": {
+    "argument": "<an+b-of>"
+  },
+  "nth-last-child": {
+    "argument": "<an+b-of>"
+  },
+  "nth-last-of-type": {
+    "argument": "<an+b>"
+  },
+  "nth-of-type": {
+    "argument": "<an+b>"
+  },
+  "only-child": {
+    "argument": ""
+  },
+  "only-of-type": {
+    "argument": ""
+  },
+  "paused": {
+    "argument": ""
+  },
+  "playing": {
+    "argument": ""
+  },
+  "root": {
+    "argument": ""
+  },
+  "scope": {
+    "argument": ""
+  },
+  "seeking": {
+    "argument": ""
+  },
+  "stalled": {
+    "argument": ""
+  },
+  "target": {
+    "argument": ""
+  },
+  "visited": {
+    "argument": ""
+  },
+  "volume-locked": {
+    "argument": ""
+  },
+  "where": {
+    "argument": "<forgiving-selector-list>"
+  }
+}

--- a/Userland/Libraries/LibWeb/CSS/PseudoClasses.json
+++ b/Userland/Libraries/LibWeb/CSS/PseudoClasses.json
@@ -36,7 +36,7 @@
     "argument": ""
   },
   "host": {
-    "argument": "<selector-list>?"
+    "argument": "<compound-selector>?"
   },
   "hover": {
     "argument": ""

--- a/Userland/Libraries/LibWeb/CSS/Selector.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Selector.cpp
@@ -228,51 +228,16 @@ ErrorOr<String> Selector::SimpleSelector::serialize() const
     case Selector::SimpleSelector::Type::PseudoClass: {
         auto& pseudo_class = this->pseudo_class();
 
-        switch (pseudo_class.type) {
-        case PseudoClass::Link:
-        case PseudoClass::Visited:
-        case PseudoClass::Hover:
-        case PseudoClass::Focus:
-        case PseudoClass::FocusVisible:
-        case PseudoClass::FocusWithin:
-        case PseudoClass::FirstChild:
-        case PseudoClass::LastChild:
-        case PseudoClass::OnlyChild:
-        case PseudoClass::Empty:
-        case PseudoClass::Root:
-        case PseudoClass::Host:
-        case PseudoClass::FirstOfType:
-        case PseudoClass::LastOfType:
-        case PseudoClass::OnlyOfType:
-        case PseudoClass::Disabled:
-        case PseudoClass::Enabled:
-        case PseudoClass::Checked:
-        case PseudoClass::Indeterminate:
-        case PseudoClass::Active:
-        case PseudoClass::Scope:
-        case PseudoClass::Defined:
-        case PseudoClass::Playing:
-        case PseudoClass::Paused:
-        case PseudoClass::Seeking:
-        case PseudoClass::Muted:
-        case PseudoClass::VolumeLocked:
-        case PseudoClass::Buffering:
-        case PseudoClass::Stalled:
-        case PseudoClass::Target:
-            // If the pseudo-class does not accept arguments append ":" (U+003A), followed by the name of the pseudo-class, to s.
+        auto metadata = pseudo_class_metadata(pseudo_class.type);
+
+        // If the pseudo-class does not accept arguments append ":" (U+003A), followed by the name of the pseudo-class, to s.
+        if (metadata.is_valid_as_identifier) {
             TRY(s.try_append(':'));
             TRY(s.try_append(pseudo_class_name(pseudo_class.type)));
-            break;
-        case PseudoClass::NthChild:
-        case PseudoClass::NthLastChild:
-        case PseudoClass::NthOfType:
-        case PseudoClass::NthLastOfType:
-        case PseudoClass::Not:
-        case PseudoClass::Is:
-        case PseudoClass::Where:
-        case PseudoClass::Lang:
-            // Otherwise, append ":" (U+003A), followed by the name of the pseudo-class, followed by "(" (U+0028),
-            // followed by the value of the pseudo-class argument(s) determined as per below, followed by ")" (U+0029), to s.
+        }
+        // Otherwise, append ":" (U+003A), followed by the name of the pseudo-class, followed by "(" (U+0028),
+        // followed by the value of the pseudo-class argument(s) determined as per below, followed by ")" (U+0029), to s.
+        else {
             TRY(s.try_append(':'));
             TRY(s.try_append(pseudo_class_name(pseudo_class.type)));
             TRY(s.try_append('('));
@@ -293,7 +258,6 @@ ErrorOr<String> Selector::SimpleSelector::serialize() const
                 s.join(", "sv, pseudo_class.languages);
             }
             TRY(s.try_append(')'));
-            break;
         }
         break;
     }

--- a/Userland/Libraries/LibWeb/CSS/Selector.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Selector.cpp
@@ -72,15 +72,15 @@ u32 Selector::specificity() const
             case SimpleSelector::Type::PseudoClass: {
                 auto& pseudo_class = simple_selector.pseudo_class();
                 switch (pseudo_class.type) {
-                case SimpleSelector::PseudoClass::Type::Is:
-                case SimpleSelector::PseudoClass::Type::Not: {
+                case PseudoClass::Is:
+                case PseudoClass::Not: {
                     // The specificity of an :is(), :not(), or :has() pseudo-class is replaced by the
                     // specificity of the most specific complex selector in its selector list argument.
                     count_specificity_of_most_complex_selector(pseudo_class.argument_selector_list);
                     break;
                 }
-                case SimpleSelector::PseudoClass::Type::NthChild:
-                case SimpleSelector::PseudoClass::Type::NthLastChild: {
+                case PseudoClass::NthChild:
+                case PseudoClass::NthLastChild: {
                     // Analogously, the specificity of an :nth-child() or :nth-last-child() selector
                     // is the specificity of the pseudo class itself (counting as one pseudo-class selector)
                     // plus the specificity of the most specific complex selector in its selector list argument (if any).
@@ -88,7 +88,7 @@ u32 Selector::specificity() const
                     count_specificity_of_most_complex_selector(pseudo_class.argument_selector_list);
                     break;
                 }
-                case SimpleSelector::PseudoClass::Type::Where:
+                case PseudoClass::Where:
                     // The specificity of a :where() pseudo-class is replaced by zero.
                     break;
                 default:
@@ -229,66 +229,66 @@ ErrorOr<String> Selector::SimpleSelector::serialize() const
         auto& pseudo_class = this->pseudo_class();
 
         switch (pseudo_class.type) {
-        case Selector::SimpleSelector::PseudoClass::Type::Link:
-        case Selector::SimpleSelector::PseudoClass::Type::Visited:
-        case Selector::SimpleSelector::PseudoClass::Type::Hover:
-        case Selector::SimpleSelector::PseudoClass::Type::Focus:
-        case Selector::SimpleSelector::PseudoClass::Type::FocusVisible:
-        case Selector::SimpleSelector::PseudoClass::Type::FocusWithin:
-        case Selector::SimpleSelector::PseudoClass::Type::FirstChild:
-        case Selector::SimpleSelector::PseudoClass::Type::LastChild:
-        case Selector::SimpleSelector::PseudoClass::Type::OnlyChild:
-        case Selector::SimpleSelector::PseudoClass::Type::Empty:
-        case Selector::SimpleSelector::PseudoClass::Type::Root:
-        case Selector::SimpleSelector::PseudoClass::Type::Host:
-        case Selector::SimpleSelector::PseudoClass::Type::FirstOfType:
-        case Selector::SimpleSelector::PseudoClass::Type::LastOfType:
-        case Selector::SimpleSelector::PseudoClass::Type::OnlyOfType:
-        case Selector::SimpleSelector::PseudoClass::Type::Disabled:
-        case Selector::SimpleSelector::PseudoClass::Type::Enabled:
-        case Selector::SimpleSelector::PseudoClass::Type::Checked:
-        case Selector::SimpleSelector::PseudoClass::Type::Indeterminate:
-        case Selector::SimpleSelector::PseudoClass::Type::Active:
-        case Selector::SimpleSelector::PseudoClass::Type::Scope:
-        case Selector::SimpleSelector::PseudoClass::Type::Defined:
-        case Selector::SimpleSelector::PseudoClass::Type::Playing:
-        case Selector::SimpleSelector::PseudoClass::Type::Paused:
-        case Selector::SimpleSelector::PseudoClass::Type::Seeking:
-        case Selector::SimpleSelector::PseudoClass::Type::Muted:
-        case Selector::SimpleSelector::PseudoClass::Type::VolumeLocked:
-        case Selector::SimpleSelector::PseudoClass::Type::Buffering:
-        case Selector::SimpleSelector::PseudoClass::Type::Stalled:
-        case Selector::SimpleSelector::PseudoClass::Type::Target:
+        case PseudoClass::Link:
+        case PseudoClass::Visited:
+        case PseudoClass::Hover:
+        case PseudoClass::Focus:
+        case PseudoClass::FocusVisible:
+        case PseudoClass::FocusWithin:
+        case PseudoClass::FirstChild:
+        case PseudoClass::LastChild:
+        case PseudoClass::OnlyChild:
+        case PseudoClass::Empty:
+        case PseudoClass::Root:
+        case PseudoClass::Host:
+        case PseudoClass::FirstOfType:
+        case PseudoClass::LastOfType:
+        case PseudoClass::OnlyOfType:
+        case PseudoClass::Disabled:
+        case PseudoClass::Enabled:
+        case PseudoClass::Checked:
+        case PseudoClass::Indeterminate:
+        case PseudoClass::Active:
+        case PseudoClass::Scope:
+        case PseudoClass::Defined:
+        case PseudoClass::Playing:
+        case PseudoClass::Paused:
+        case PseudoClass::Seeking:
+        case PseudoClass::Muted:
+        case PseudoClass::VolumeLocked:
+        case PseudoClass::Buffering:
+        case PseudoClass::Stalled:
+        case PseudoClass::Target:
             // If the pseudo-class does not accept arguments append ":" (U+003A), followed by the name of the pseudo-class, to s.
             TRY(s.try_append(':'));
             TRY(s.try_append(pseudo_class_name(pseudo_class.type)));
             break;
-        case Selector::SimpleSelector::PseudoClass::Type::NthChild:
-        case Selector::SimpleSelector::PseudoClass::Type::NthLastChild:
-        case Selector::SimpleSelector::PseudoClass::Type::NthOfType:
-        case Selector::SimpleSelector::PseudoClass::Type::NthLastOfType:
-        case Selector::SimpleSelector::PseudoClass::Type::Not:
-        case Selector::SimpleSelector::PseudoClass::Type::Is:
-        case Selector::SimpleSelector::PseudoClass::Type::Where:
-        case Selector::SimpleSelector::PseudoClass::Type::Lang:
+        case PseudoClass::NthChild:
+        case PseudoClass::NthLastChild:
+        case PseudoClass::NthOfType:
+        case PseudoClass::NthLastOfType:
+        case PseudoClass::Not:
+        case PseudoClass::Is:
+        case PseudoClass::Where:
+        case PseudoClass::Lang:
             // Otherwise, append ":" (U+003A), followed by the name of the pseudo-class, followed by "(" (U+0028),
             // followed by the value of the pseudo-class argument(s) determined as per below, followed by ")" (U+0029), to s.
             TRY(s.try_append(':'));
             TRY(s.try_append(pseudo_class_name(pseudo_class.type)));
             TRY(s.try_append('('));
-            if (pseudo_class.type == Selector::SimpleSelector::PseudoClass::Type::NthChild
-                || pseudo_class.type == Selector::SimpleSelector::PseudoClass::Type::NthLastChild
-                || pseudo_class.type == Selector::SimpleSelector::PseudoClass::Type::NthOfType
-                || pseudo_class.type == Selector::SimpleSelector::PseudoClass::Type::NthLastOfType) {
+            if (pseudo_class.type == PseudoClass::NthChild
+                || pseudo_class.type == PseudoClass::NthLastChild
+                || pseudo_class.type == PseudoClass::NthOfType
+                || pseudo_class.type == PseudoClass::NthLastOfType) {
                 // The result of serializing the value using the rules to serialize an <an+b> value.
                 TRY(s.try_append(TRY(pseudo_class.nth_child_pattern.serialize())));
-            } else if (pseudo_class.type == Selector::SimpleSelector::PseudoClass::Type::Not
-                || pseudo_class.type == Selector::SimpleSelector::PseudoClass::Type::Is
-                || pseudo_class.type == Selector::SimpleSelector::PseudoClass::Type::Where) {
+            } else if (pseudo_class.type == PseudoClass::Not
+                || pseudo_class.type == PseudoClass::Is
+                || pseudo_class.type == PseudoClass::Where) {
                 // The result of serializing the value using the rules for serializing a group of selectors.
                 // NOTE: `:is()` and `:where()` aren't in the spec for this yet, but it should be!
                 TRY(s.try_append(TRY(serialize_a_group_of_selectors(pseudo_class.argument_selector_list))));
-            } else if (pseudo_class.type == Selector::SimpleSelector::PseudoClass::Type::Lang) {
+            } else if (pseudo_class.type == PseudoClass::Lang) {
                 // The serialization of a comma-separated list of each argument’s serialization as a string, preserving relative order.
                 s.join(", "sv, pseudo_class.languages);
             }

--- a/Userland/Libraries/LibWeb/CSS/Selector.h
+++ b/Userland/Libraries/LibWeb/CSS/Selector.h
@@ -11,6 +11,7 @@
 #include <AK/RefCounted.h>
 #include <AK/String.h>
 #include <AK/Vector.h>
+#include <LibWeb/CSS/PseudoClass.h>
 
 namespace Web::CSS {
 
@@ -84,48 +85,8 @@ public:
             }
         };
 
-        struct PseudoClass {
-            enum class Type {
-                Link,
-                Visited,
-                Hover,
-                Focus,
-                FocusVisible,
-                FocusWithin,
-                FirstChild,
-                LastChild,
-                OnlyChild,
-                NthChild,
-                NthLastChild,
-                Empty,
-                Root,
-                Host,
-                FirstOfType,
-                LastOfType,
-                OnlyOfType,
-                NthOfType,
-                NthLastOfType,
-                Disabled,
-                Enabled,
-                Checked,
-                Indeterminate,
-                Is,
-                Not,
-                Where,
-                Active,
-                Lang,
-                Scope,
-                Defined,
-                Playing,
-                Paused,
-                Seeking,
-                Muted,
-                VolumeLocked,
-                Buffering,
-                Stalled,
-                Target,
-            };
-            Type type;
+        struct PseudoClassSelector {
+            PseudoClass type;
 
             // FIXME: We don't need this field on every single SimpleSelector, but it's also annoying to malloc it somewhere.
             // Only used when "pseudo_class" is "NthChild" or "NthLastChild".
@@ -184,12 +145,12 @@ public:
         };
 
         Type type;
-        Variant<Empty, Attribute, PseudoClass, PseudoElement, Name, QualifiedName> value {};
+        Variant<Empty, Attribute, PseudoClassSelector, PseudoElement, Name, QualifiedName> value {};
 
         Attribute const& attribute() const { return value.get<Attribute>(); }
         Attribute& attribute() { return value.get<Attribute>(); }
-        PseudoClass const& pseudo_class() const { return value.get<PseudoClass>(); }
-        PseudoClass& pseudo_class() { return value.get<PseudoClass>(); }
+        PseudoClassSelector const& pseudo_class() const { return value.get<PseudoClassSelector>(); }
+        PseudoClassSelector& pseudo_class() { return value.get<PseudoClassSelector>(); }
         PseudoElement const& pseudo_element() const { return value.get<PseudoElement>(); }
         PseudoElement& pseudo_element() { return value.get<PseudoElement>(); }
 
@@ -267,89 +228,6 @@ constexpr StringView pseudo_element_name(Selector::PseudoElement pseudo_element)
 }
 
 Optional<Selector::PseudoElement> pseudo_element_from_string(StringView);
-
-constexpr StringView pseudo_class_name(Selector::SimpleSelector::PseudoClass::Type pseudo_class)
-{
-    switch (pseudo_class) {
-    case Selector::SimpleSelector::PseudoClass::Type::Link:
-        return "link"sv;
-    case Selector::SimpleSelector::PseudoClass::Type::Visited:
-        return "visited"sv;
-    case Selector::SimpleSelector::PseudoClass::Type::Hover:
-        return "hover"sv;
-    case Selector::SimpleSelector::PseudoClass::Type::Focus:
-        return "focus"sv;
-    case Selector::SimpleSelector::PseudoClass::Type::FocusVisible:
-        return "focus-visible"sv;
-    case Selector::SimpleSelector::PseudoClass::Type::FocusWithin:
-        return "focus-within"sv;
-    case Selector::SimpleSelector::PseudoClass::Type::FirstChild:
-        return "first-child"sv;
-    case Selector::SimpleSelector::PseudoClass::Type::LastChild:
-        return "last-child"sv;
-    case Selector::SimpleSelector::PseudoClass::Type::OnlyChild:
-        return "only-child"sv;
-    case Selector::SimpleSelector::PseudoClass::Type::Empty:
-        return "empty"sv;
-    case Selector::SimpleSelector::PseudoClass::Type::Root:
-        return "root"sv;
-    case Selector::SimpleSelector::PseudoClass::Type::Host:
-        return "host"sv;
-    case Selector::SimpleSelector::PseudoClass::Type::FirstOfType:
-        return "first-of-type"sv;
-    case Selector::SimpleSelector::PseudoClass::Type::LastOfType:
-        return "last-of-type"sv;
-    case Selector::SimpleSelector::PseudoClass::Type::OnlyOfType:
-        return "only-of-type"sv;
-    case Selector::SimpleSelector::PseudoClass::Type::NthOfType:
-        return "nth-of-type"sv;
-    case Selector::SimpleSelector::PseudoClass::Type::NthLastOfType:
-        return "nth-last-of-type"sv;
-    case Selector::SimpleSelector::PseudoClass::Type::Disabled:
-        return "disabled"sv;
-    case Selector::SimpleSelector::PseudoClass::Type::Enabled:
-        return "enabled"sv;
-    case Selector::SimpleSelector::PseudoClass::Type::Checked:
-        return "checked"sv;
-    case Selector::SimpleSelector::PseudoClass::Type::Indeterminate:
-        return "indeterminate"sv;
-    case Selector::SimpleSelector::PseudoClass::Type::Active:
-        return "active"sv;
-    case Selector::SimpleSelector::PseudoClass::Type::NthChild:
-        return "nth-child"sv;
-    case Selector::SimpleSelector::PseudoClass::Type::NthLastChild:
-        return "nth-last-child"sv;
-    case Selector::SimpleSelector::PseudoClass::Type::Is:
-        return "is"sv;
-    case Selector::SimpleSelector::PseudoClass::Type::Not:
-        return "not"sv;
-    case Selector::SimpleSelector::PseudoClass::Type::Where:
-        return "where"sv;
-    case Selector::SimpleSelector::PseudoClass::Type::Lang:
-        return "lang"sv;
-    case Selector::SimpleSelector::PseudoClass::Type::Scope:
-        return "scope"sv;
-    case Selector::SimpleSelector::PseudoClass::Type::Defined:
-        return "defined"sv;
-    case Selector::SimpleSelector::PseudoClass::Type::Playing:
-        return "playing"sv;
-    case Selector::SimpleSelector::PseudoClass::Type::Paused:
-        return "paused"sv;
-    case Selector::SimpleSelector::PseudoClass::Type::Seeking:
-        return "seeking"sv;
-    case Selector::SimpleSelector::PseudoClass::Type::Muted:
-        return "muted"sv;
-    case Selector::SimpleSelector::PseudoClass::Type::VolumeLocked:
-        return "volume-locked"sv;
-    case Selector::SimpleSelector::PseudoClass::Type::Buffering:
-        return "buffering"sv;
-    case Selector::SimpleSelector::PseudoClass::Type::Stalled:
-        return "stalled"sv;
-    case Selector::SimpleSelector::PseudoClass::Type::Target:
-        return "target"sv;
-    }
-    VERIFY_NOT_REACHED();
-}
 
 ErrorOr<String> serialize_a_group_of_selectors(Vector<NonnullRefPtr<Selector>> const& selectors);
 

--- a/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
+++ b/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
@@ -207,34 +207,34 @@ static inline DOM::Element const* next_sibling_with_same_tag_name(DOM::Element c
     return nullptr;
 }
 
-static inline bool matches_pseudo_class(CSS::Selector::SimpleSelector::PseudoClass const& pseudo_class, Optional<CSS::CSSStyleSheet const&> style_sheet_for_rule, DOM::Element const& element, JS::GCPtr<DOM::ParentNode const> scope)
+static inline bool matches_pseudo_class(CSS::Selector::SimpleSelector::PseudoClassSelector const& pseudo_class, Optional<CSS::CSSStyleSheet const&> style_sheet_for_rule, DOM::Element const& element, JS::GCPtr<DOM::ParentNode const> scope)
 {
     switch (pseudo_class.type) {
-    case CSS::Selector::SimpleSelector::PseudoClass::Type::Link:
+    case CSS::PseudoClass::Link:
         return matches_link_pseudo_class(element);
-    case CSS::Selector::SimpleSelector::PseudoClass::Type::Visited:
+    case CSS::PseudoClass::Visited:
         // FIXME: Maybe match this selector sometimes?
         return false;
-    case CSS::Selector::SimpleSelector::PseudoClass::Type::Active:
+    case CSS::PseudoClass::Active:
         return element.is_active();
-    case CSS::Selector::SimpleSelector::PseudoClass::Type::Hover:
+    case CSS::PseudoClass::Hover:
         return matches_hover_pseudo_class(element);
-    case CSS::Selector::SimpleSelector::PseudoClass::Type::Focus:
+    case CSS::PseudoClass::Focus:
         return element.is_focused();
-    case CSS::Selector::SimpleSelector::PseudoClass::Type::FocusVisible:
+    case CSS::PseudoClass::FocusVisible:
         // FIXME: We should only apply this when a visible focus is useful. Decide when that is!
         return element.is_focused();
-    case CSS::Selector::SimpleSelector::PseudoClass::Type::FocusWithin: {
+    case CSS::PseudoClass::FocusWithin: {
         auto* focused_element = element.document().focused_element();
         return focused_element && element.is_inclusive_ancestor_of(*focused_element);
     }
-    case CSS::Selector::SimpleSelector::PseudoClass::Type::FirstChild:
+    case CSS::PseudoClass::FirstChild:
         return !element.previous_element_sibling();
-    case CSS::Selector::SimpleSelector::PseudoClass::Type::LastChild:
+    case CSS::PseudoClass::LastChild:
         return !element.next_element_sibling();
-    case CSS::Selector::SimpleSelector::PseudoClass::Type::OnlyChild:
+    case CSS::PseudoClass::OnlyChild:
         return !(element.previous_element_sibling() || element.next_element_sibling());
-    case CSS::Selector::SimpleSelector::PseudoClass::Type::Empty: {
+    case CSS::PseudoClass::Empty: {
         if (!element.has_children())
             return true;
         if (element.first_child_of_type<DOM::Element>())
@@ -251,53 +251,53 @@ static inline bool matches_pseudo_class(CSS::Selector::SimpleSelector::PseudoCla
         });
         return !has_nonempty_text_child;
     }
-    case CSS::Selector::SimpleSelector::PseudoClass::Type::Root:
+    case CSS::PseudoClass::Root:
         return is<HTML::HTMLHtmlElement>(element);
-    case CSS::Selector::SimpleSelector::PseudoClass::Type::Host:
+    case CSS::PseudoClass::Host:
         // FIXME: Implement :host selector.
         return false;
-    case CSS::Selector::SimpleSelector::PseudoClass::Type::Scope:
+    case CSS::PseudoClass::Scope:
         return scope ? &element == scope : is<HTML::HTMLHtmlElement>(element);
-    case CSS::Selector::SimpleSelector::PseudoClass::Type::FirstOfType:
+    case CSS::PseudoClass::FirstOfType:
         return !previous_sibling_with_same_tag_name(element);
-    case CSS::Selector::SimpleSelector::PseudoClass::Type::LastOfType:
+    case CSS::PseudoClass::LastOfType:
         return !next_sibling_with_same_tag_name(element);
-    case CSS::Selector::SimpleSelector::PseudoClass::Type::OnlyOfType:
+    case CSS::PseudoClass::OnlyOfType:
         return !previous_sibling_with_same_tag_name(element) && !next_sibling_with_same_tag_name(element);
-    case CSS::Selector::SimpleSelector::PseudoClass::Type::Lang:
+    case CSS::PseudoClass::Lang:
         return matches_lang_pseudo_class(element, pseudo_class.languages);
-    case CSS::Selector::SimpleSelector::PseudoClass::Type::Disabled:
+    case CSS::PseudoClass::Disabled:
         // https://html.spec.whatwg.org/multipage/semantics-other.html#selector-disabled
         // The :disabled pseudo-class must match any element that is actually disabled.
         return element.is_actually_disabled();
-    case CSS::Selector::SimpleSelector::PseudoClass::Type::Enabled:
+    case CSS::PseudoClass::Enabled:
         // https://html.spec.whatwg.org/multipage/semantics-other.html#selector-enabled
         // The :enabled pseudo-class must match any button, input, select, textarea, optgroup, option, fieldset element, or form-associated custom element that is not actually disabled.
         return (is<HTML::HTMLButtonElement>(element) || is<HTML::HTMLInputElement>(element) || is<HTML::HTMLSelectElement>(element) || is<HTML::HTMLTextAreaElement>(element) || is<HTML::HTMLOptGroupElement>(element) || is<HTML::HTMLOptionElement>(element) || is<HTML::HTMLFieldSetElement>(element))
             && !element.is_actually_disabled();
-    case CSS::Selector::SimpleSelector::PseudoClass::Type::Checked:
+    case CSS::PseudoClass::Checked:
         return matches_checked_pseudo_class(element);
-    case CSS::Selector::SimpleSelector::PseudoClass::Type::Indeterminate:
+    case CSS::PseudoClass::Indeterminate:
         return matches_indeterminate_pseudo_class(element);
-    case CSS::Selector::SimpleSelector::PseudoClass::Type::Defined:
+    case CSS::PseudoClass::Defined:
         return element.is_defined();
-    case CSS::Selector::SimpleSelector::PseudoClass::Type::Is:
-    case CSS::Selector::SimpleSelector::PseudoClass::Type::Where:
+    case CSS::PseudoClass::Is:
+    case CSS::PseudoClass::Where:
         for (auto& selector : pseudo_class.argument_selector_list) {
             if (matches(selector, style_sheet_for_rule, element))
                 return true;
         }
         return false;
-    case CSS::Selector::SimpleSelector::PseudoClass::Type::Not:
+    case CSS::PseudoClass::Not:
         for (auto& selector : pseudo_class.argument_selector_list) {
             if (matches(selector, style_sheet_for_rule, element))
                 return false;
         }
         return true;
-    case CSS::Selector::SimpleSelector::PseudoClass::Type::NthChild:
-    case CSS::Selector::SimpleSelector::PseudoClass::Type::NthLastChild:
-    case CSS::Selector::SimpleSelector::PseudoClass::Type::NthOfType:
-    case CSS::Selector::SimpleSelector::PseudoClass::Type::NthLastOfType: {
+    case CSS::PseudoClass::NthChild:
+    case CSS::PseudoClass::NthLastChild:
+    case CSS::PseudoClass::NthOfType:
+    case CSS::PseudoClass::NthLastOfType: {
         auto const step_size = pseudo_class.nth_child_pattern.step_size;
         auto const offset = pseudo_class.nth_child_pattern.offset;
         if (step_size == 0 && offset == 0)
@@ -320,7 +320,7 @@ static inline bool matches_pseudo_class(CSS::Selector::SimpleSelector::PseudoCla
 
         int index = 1;
         switch (pseudo_class.type) {
-        case CSS::Selector::SimpleSelector::PseudoClass::Type::NthChild: {
+        case CSS::PseudoClass::NthChild: {
             if (!matches_selector_list(pseudo_class.argument_selector_list, element))
                 return false;
             for (auto* child = parent->first_child_of_type<DOM::Element>(); child && child != &element; child = child->next_element_sibling()) {
@@ -329,7 +329,7 @@ static inline bool matches_pseudo_class(CSS::Selector::SimpleSelector::PseudoCla
             }
             break;
         }
-        case CSS::Selector::SimpleSelector::PseudoClass::Type::NthLastChild: {
+        case CSS::PseudoClass::NthLastChild: {
             if (!matches_selector_list(pseudo_class.argument_selector_list, element))
                 return false;
             for (auto* child = parent->last_child_of_type<DOM::Element>(); child && child != &element; child = child->previous_element_sibling()) {
@@ -338,12 +338,12 @@ static inline bool matches_pseudo_class(CSS::Selector::SimpleSelector::PseudoCla
             }
             break;
         }
-        case CSS::Selector::SimpleSelector::PseudoClass::Type::NthOfType: {
+        case CSS::PseudoClass::NthOfType: {
             for (auto* child = previous_sibling_with_same_tag_name(element); child; child = previous_sibling_with_same_tag_name(*child))
                 ++index;
             break;
         }
-        case CSS::Selector::SimpleSelector::PseudoClass::Type::NthLastOfType: {
+        case CSS::PseudoClass::NthLastOfType: {
             for (auto* child = next_sibling_with_same_tag_name(element); child; child = next_sibling_with_same_tag_name(*child))
                 ++index;
             break;
@@ -384,48 +384,48 @@ static inline bool matches_pseudo_class(CSS::Selector::SimpleSelector::PseudoCla
         // Otherwise, we start at "offset" and count forwards.
         return index >= offset && canonical_modulo(index - offset, step_size) == 0;
     }
-    case CSS::Selector::SimpleSelector::PseudoClass::Type::Playing: {
+    case CSS::PseudoClass::Playing: {
         if (!is<HTML::HTMLMediaElement>(element))
             return false;
         auto const& media_element = static_cast<HTML::HTMLMediaElement const&>(element);
         return !media_element.paused();
     }
-    case CSS::Selector::SimpleSelector::PseudoClass::Type::Paused: {
+    case CSS::PseudoClass::Paused: {
         if (!is<HTML::HTMLMediaElement>(element))
             return false;
         auto const& media_element = static_cast<HTML::HTMLMediaElement const&>(element);
         return media_element.paused();
     }
-    case CSS::Selector::SimpleSelector::PseudoClass::Type::Seeking: {
+    case CSS::PseudoClass::Seeking: {
         if (!is<HTML::HTMLMediaElement>(element))
             return false;
         auto const& media_element = static_cast<HTML::HTMLMediaElement const&>(element);
         return media_element.seeking();
     }
-    case CSS::Selector::SimpleSelector::PseudoClass::Type::Muted: {
+    case CSS::PseudoClass::Muted: {
         if (!is<HTML::HTMLMediaElement>(element))
             return false;
         auto const& media_element = static_cast<HTML::HTMLMediaElement const&>(element);
         return media_element.muted();
     }
-    case CSS::Selector::SimpleSelector::PseudoClass::Type::VolumeLocked: {
+    case CSS::PseudoClass::VolumeLocked: {
         // FIXME: Currently we don't allow the user to specify an override volume, so this is always false.
         //        Once we do, implement this!
         return false;
     }
-    case CSS::Selector::SimpleSelector::PseudoClass::Type::Buffering: {
+    case CSS::PseudoClass::Buffering: {
         if (!is<HTML::HTMLMediaElement>(element))
             return false;
         auto const& media_element = static_cast<HTML::HTMLMediaElement const&>(element);
         return media_element.blocked();
     }
-    case CSS::Selector::SimpleSelector::PseudoClass::Type::Stalled: {
+    case CSS::PseudoClass::Stalled: {
         if (!is<HTML::HTMLMediaElement>(element))
             return false;
         auto const& media_element = static_cast<HTML::HTMLMediaElement const&>(element);
         return media_element.stalled();
     }
-    case CSS::Selector::SimpleSelector::PseudoClass::Type::Target:
+    case CSS::PseudoClass::Target:
         return element.is_target();
     }
 

--- a/Userland/Libraries/LibWeb/Dump.cpp
+++ b/Userland/Libraries/LibWeb/Dump.cpp
@@ -16,6 +16,7 @@
 #include <LibWeb/CSS/CSSStyleSheet.h>
 #include <LibWeb/CSS/CSSSupportsRule.h>
 #include <LibWeb/CSS/PropertyID.h>
+#include <LibWeb/CSS/PseudoClass.h>
 #include <LibWeb/DOM/Comment.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Element.h>
@@ -458,7 +459,7 @@ void dump_selector(StringBuilder& builder, CSS::Selector const& selector)
                 type_description = "Attribute";
                 break;
             case CSS::Selector::SimpleSelector::Type::PseudoClass:
-                type_description = "PseudoClass";
+                type_description = "PseudoClassSelector";
                 break;
             case CSS::Selector::SimpleSelector::Type::PseudoElement:
                 type_description = "PseudoElement";
@@ -477,141 +478,14 @@ void dump_selector(StringBuilder& builder, CSS::Selector const& selector)
             if (simple_selector.type == CSS::Selector::SimpleSelector::Type::PseudoClass) {
                 auto const& pseudo_class = simple_selector.pseudo_class();
 
-                char const* pseudo_class_description = "";
-                switch (pseudo_class.type) {
-                case CSS::Selector::SimpleSelector::PseudoClass::Type::Link:
-                    pseudo_class_description = "Link";
-                    break;
-                case CSS::Selector::SimpleSelector::PseudoClass::Type::Visited:
-                    pseudo_class_description = "Visited";
-                    break;
-                case CSS::Selector::SimpleSelector::PseudoClass::Type::Active:
-                    pseudo_class_description = "Active";
-                    break;
-                case CSS::Selector::SimpleSelector::PseudoClass::Type::Root:
-                    pseudo_class_description = "Root";
-                    break;
-                case CSS::Selector::SimpleSelector::PseudoClass::Type::Host:
-                    pseudo_class_description = "Host";
-                    break;
-                case CSS::Selector::SimpleSelector::PseudoClass::Type::FirstOfType:
-                    pseudo_class_description = "FirstOfType";
-                    break;
-                case CSS::Selector::SimpleSelector::PseudoClass::Type::LastOfType:
-                    pseudo_class_description = "LastOfType";
-                    break;
-                case CSS::Selector::SimpleSelector::PseudoClass::Type::OnlyOfType:
-                    pseudo_class_description = "OnlyOfType";
-                    break;
-                case CSS::Selector::SimpleSelector::PseudoClass::Type::NthOfType:
-                    pseudo_class_description = "NthOfType";
-                    break;
-                case CSS::Selector::SimpleSelector::PseudoClass::Type::NthLastOfType:
-                    pseudo_class_description = "NthLastOfType";
-                    break;
-                case CSS::Selector::SimpleSelector::PseudoClass::Type::NthChild:
-                    pseudo_class_description = "NthChild";
-                    break;
-                case CSS::Selector::SimpleSelector::PseudoClass::Type::NthLastChild:
-                    pseudo_class_description = "NthLastChild";
-                    break;
-                case CSS::Selector::SimpleSelector::PseudoClass::Type::Focus:
-                    pseudo_class_description = "Focus";
-                    break;
-                case CSS::Selector::SimpleSelector::PseudoClass::Type::FocusVisible:
-                    pseudo_class_description = "FocusVisible";
-                    break;
-                case CSS::Selector::SimpleSelector::PseudoClass::Type::FocusWithin:
-                    pseudo_class_description = "FocusWithin";
-                    break;
-                case CSS::Selector::SimpleSelector::PseudoClass::Type::Empty:
-                    pseudo_class_description = "Empty";
-                    break;
-                case CSS::Selector::SimpleSelector::PseudoClass::Type::Hover:
-                    pseudo_class_description = "Hover";
-                    break;
-                case CSS::Selector::SimpleSelector::PseudoClass::Type::LastChild:
-                    pseudo_class_description = "LastChild";
-                    break;
-                case CSS::Selector::SimpleSelector::PseudoClass::Type::FirstChild:
-                    pseudo_class_description = "FirstChild";
-                    break;
-                case CSS::Selector::SimpleSelector::PseudoClass::Type::OnlyChild:
-                    pseudo_class_description = "OnlyChild";
-                    break;
-                case CSS::Selector::SimpleSelector::PseudoClass::Type::Disabled:
-                    pseudo_class_description = "Disabled";
-                    break;
-                case CSS::Selector::SimpleSelector::PseudoClass::Type::Enabled:
-                    pseudo_class_description = "Enabled";
-                    break;
-                case CSS::Selector::SimpleSelector::PseudoClass::Type::Checked:
-                    pseudo_class_description = "Checked";
-                    break;
-                case CSS::Selector::SimpleSelector::PseudoClass::Type::Indeterminate:
-                    pseudo_class_description = "Indeterminate";
-                    break;
-                case CSS::Selector::SimpleSelector::PseudoClass::Type::Not:
-                    pseudo_class_description = "Not";
-                    break;
-                case CSS::Selector::SimpleSelector::PseudoClass::Type::Is:
-                    pseudo_class_description = "Is";
-                    break;
-                case CSS::Selector::SimpleSelector::PseudoClass::Type::Where:
-                    pseudo_class_description = "Where";
-                    break;
-                case CSS::Selector::SimpleSelector::PseudoClass::Type::Lang:
-                    pseudo_class_description = "Lang";
-                    break;
-                case CSS::Selector::SimpleSelector::PseudoClass::Type::Scope:
-                    pseudo_class_description = "Scope";
-                    break;
-                case CSS::Selector::SimpleSelector::PseudoClass::Type::Defined:
-                    pseudo_class_description = "Defined";
-                    break;
-                case CSS::Selector::SimpleSelector::PseudoClass::Type::Playing:
-                    pseudo_class_description = "Playing";
-                    break;
-                case CSS::Selector::SimpleSelector::PseudoClass::Type::Paused:
-                    pseudo_class_description = "Paused";
-                    break;
-                case CSS::Selector::SimpleSelector::PseudoClass::Type::Seeking:
-                    pseudo_class_description = "Seeking";
-                    break;
-                case CSS::Selector::SimpleSelector::PseudoClass::Type::Muted:
-                    pseudo_class_description = "Muted";
-                    break;
-                case CSS::Selector::SimpleSelector::PseudoClass::Type::VolumeLocked:
-                    pseudo_class_description = "VolumeLocked";
-                    break;
-                case CSS::Selector::SimpleSelector::PseudoClass::Type::Buffering:
-                    pseudo_class_description = "Buffering";
-                    break;
-                case CSS::Selector::SimpleSelector::PseudoClass::Type::Stalled:
-                    pseudo_class_description = "Stalled";
-                    break;
-                case CSS::Selector::SimpleSelector::PseudoClass::Type::Target:
-                    pseudo_class_description = "Target";
-                    break;
-                }
+                builder.appendff(" pseudo_class={}", CSS::pseudo_class_name(pseudo_class.type));
+                auto pseudo_class_metadata = CSS::pseudo_class_metadata(pseudo_class.type);
 
-                builder.appendff(" pseudo_class={}", pseudo_class_description);
-                if (pseudo_class.type == CSS::Selector::SimpleSelector::PseudoClass::Type::Lang) {
-                    builder.append('(');
-                    builder.join(',', pseudo_class.languages);
-                    builder.append(')');
-                } else if (pseudo_class.type == CSS::Selector::SimpleSelector::PseudoClass::Type::Not
-                    || pseudo_class.type == CSS::Selector::SimpleSelector::PseudoClass::Type::Host
-                    || pseudo_class.type == CSS::Selector::SimpleSelector::PseudoClass::Type::Is
-                    || pseudo_class.type == CSS::Selector::SimpleSelector::PseudoClass::Type::Where) {
-                    builder.append("(["sv);
-                    for (auto& selector : pseudo_class.argument_selector_list)
-                        dump_selector(builder, selector);
-                    builder.append("])"sv);
-                } else if ((pseudo_class.type == CSS::Selector::SimpleSelector::PseudoClass::Type::NthChild)
-                    || (pseudo_class.type == CSS::Selector::SimpleSelector::PseudoClass::Type::NthLastChild)
-                    || (pseudo_class.type == CSS::Selector::SimpleSelector::PseudoClass::Type::NthOfType)
-                    || (pseudo_class.type == CSS::Selector::SimpleSelector::PseudoClass::Type::NthLastOfType)) {
+                switch (pseudo_class_metadata.parameter_type) {
+                case CSS::PseudoClassMetadata::ParameterType::None:
+                    break;
+                case CSS::PseudoClassMetadata::ParameterType::ANPlusB:
+                case CSS::PseudoClassMetadata::ParameterType::ANPlusBOf: {
                     builder.appendff("(step={}, offset={}", pseudo_class.nth_child_pattern.step_size, pseudo_class.nth_child_pattern.offset);
                     if (!pseudo_class.argument_selector_list.is_empty()) {
                         builder.append(", selectors=["sv);
@@ -620,6 +494,22 @@ void dump_selector(StringBuilder& builder, CSS::Selector const& selector)
                         builder.append("]"sv);
                     }
                     builder.append(")"sv);
+                    break;
+                }
+                case CSS::PseudoClassMetadata::ParameterType::ForgivingSelectorList:
+                case CSS::PseudoClassMetadata::ParameterType::SelectorList: {
+                    builder.append("(["sv);
+                    for (auto& selector : pseudo_class.argument_selector_list)
+                        dump_selector(builder, selector);
+                    builder.append("])"sv);
+                    break;
+                }
+                case CSS::PseudoClassMetadata::ParameterType::LanguageRanges: {
+                    builder.append('(');
+                    builder.join(',', pseudo_class.languages);
+                    builder.append(')');
+                    break;
+                }
                 }
             }
 

--- a/Userland/Libraries/LibWeb/Dump.cpp
+++ b/Userland/Libraries/LibWeb/Dump.cpp
@@ -496,6 +496,7 @@ void dump_selector(StringBuilder& builder, CSS::Selector const& selector)
                     builder.append(")"sv);
                     break;
                 }
+                case CSS::PseudoClassMetadata::ParameterType::CompoundSelector:
                 case CSS::PseudoClassMetadata::ParameterType::ForgivingSelectorList:
                 case CSS::PseudoClassMetadata::ParameterType::SelectorList: {
                     builder.append("(["sv);


### PR DESCRIPTION
I got fed up with having to remember to edit so many places to add a pseudo-class, so now we have a JSON file which the boilerplate is generated from. :^)

A couple of small functional changes related to `:host` / `:host()`:
- Make the parameter a `<compound-selector>`, instead of a `<selector-list>`.
- Hack it in to the "serialize a simple selector" algorithm.