### PR TITLE
LibSanitizer+CMake+CI: Add non-recoverable UBSan support and use it on CI

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -204,6 +204,7 @@ jobs:
             -DCMAKE_C_COMPILER=gcc-12 \
             -DCMAKE_CXX_COMPILER=g++-12 \
             -DENABLE_UNDEFINED_SANITIZER=ON \
+            -DUNDEFINED_BEHAVIOR_IS_FATAL=ON \
             -DDUMP_REGIONS_ON_CRASH=ON \
             -DENABLE_PCI_IDS_DOWNLOAD=OFF \
             -DENABLE_USB_IDS_DOWNLOAD=OFF

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,13 +192,6 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR}/Userland/Services)
 include_directories(${CMAKE_CURRENT_BINARY_DIR}/Userland/Libraries)
 include_directories(${CMAKE_CURRENT_BINARY_DIR}/Userland)
 
-# FIXME: vptr sanitizing requires.. intense ABI wrangling of std::type_info
-#     And would be better served by porting ubsan_type_hash_itanium.cpp from compiler-rt
-if (ENABLE_UNDEFINED_SANITIZER)
-    add_compile_options(-fsanitize=undefined -fno-sanitize=vptr)
-    add_link_options(-fsanitize=undefined -fno-sanitize=vptr)
-endif()
-
 add_custom_target(components ALL)
 option(BUILD_EVERYTHING "Build all optional components" ON)
 
@@ -218,6 +211,17 @@ endif()
 
 add_subdirectory(AK)
 add_subdirectory(Kernel)
+
+# FIXME: vptr sanitizing requires.. intense ABI wrangling of std::type_info
+#        And would be better served by porting ubsan_type_hash_itanium.cpp from compiler-rt
+if (ENABLE_UNDEFINED_SANITIZER)
+    add_compile_options(-fsanitize=undefined -fno-sanitize=vptr)
+    add_link_options(-fsanitize=undefined -fno-sanitize=vptr)
+
+    if (UNDEFINED_BEHAVIOR_IS_FATAL)
+        add_compile_options(-fno-sanitize-recover=undefined)
+    endif()
+endif()
 
 if (ENABLE_MOLD_LINKER)
     add_link_options(-fuse-ld=mold)

--- a/Documentation/AdvancedBuildInstructions.md
+++ b/Documentation/AdvancedBuildInstructions.md
@@ -46,7 +46,8 @@ There are some optional features that can be enabled during compilation that are
 - `ENABLE_KERNEL_COVERAGE_COLLECTION`: enables the KCOV API and kernel coverage collection instrumentation. Only useful for coverage guided kernel fuzzing.
 - `ENABLE_USERSPACE_COVERAGE_COLLECTION`: enables coverage collection instrumentation for userspace. Currently only works with a Clang build.
 - `ENABLE_MEMORY_SANITIZER`: enables runtime checks for uninitialized memory accesses in Lagom test cases.
-- `ENABLE_UNDEFINED_SANITIZER`: builds in runtime checks for [undefined behavior](https://en.wikipedia.org/wiki/Undefined_behavior) (like null pointer dereferences and signed integer overflows) in Lagom test cases.
+- `ENABLE_UNDEFINED_SANITIZER`: builds in runtime checks for [undefined behavior](https://en.wikipedia.org/wiki/Undefined_behavior) (like null pointer dereferences and signed integer overflows) in Lagom and the SerenityOS userland.
+- `UNDEFINED_BEHAVIOR_IS_FATAL`: makes all undefined behavior sanitizer errors non-recoverable. This option reduces the performance overhead of `ENABLE_UNDEFINED_SANITIZER`.
 - `ENABLE_COMPILER_EXPLORER_BUILD`: Skip building non-library entities in Lagom (this only applies to Lagom).
 - `ENABLE_FUZZERS`: builds [fuzzers](../Meta/Lagom/ReadMe.md#fuzzing) for various parts of the system.
 - `ENABLE_FUZZERS_LIBFUZZER`: builds Clang libFuzzer-based [fuzzers](../Meta/Lagom/ReadMe.md#fuzzing) for various parts of the system.

--- a/Ladybird/CMakeLists.txt
+++ b/Ladybird/CMakeLists.txt
@@ -41,6 +41,9 @@ endif()
 
 if (ENABLE_UNDEFINED_SANITIZER)
     add_compile_options(-fsanitize=undefined -fno-omit-frame-pointer)
+    if (UNDEFINED_BEHAVIOR_IS_FATAL)
+        add_compile_options(-fno-sanitize-recover=undefined)
+    endif()
     add_link_options(-fsanitize=undefined)
 endif()
 

--- a/Meta/Azure/Serenity.yml
+++ b/Meta/Azure/Serenity.yml
@@ -47,6 +47,7 @@ jobs:
           -DSERENITY_ARCH=${{ parameters.arch }} \
           -DSERENITY_TOOLCHAIN=Clang \
           -DENABLE_UNDEFINED_SANITIZER=ON \
+          -DUNDEFINED_BEHAVIOR_IS_FATAL=ON \
           -DENABLE_USERSPACE_COVERAGE_COLLECTION=${{ parameters.coverage }} \
           -DDUMP_REGIONS_ON_CRASH=ON \
           -DENABLE_PCI_IDS_DOWNLOAD=OFF \

--- a/Meta/CMake/common_options.cmake
+++ b/Meta/CMake/common_options.cmake
@@ -9,6 +9,7 @@ endif()
 
 serenity_option(ENABLE_COMPILETIME_FORMAT_CHECK ON CACHE BOOL "Enable compiletime format string checks")
 serenity_option(ENABLE_UNDEFINED_SANITIZER OFF CACHE BOOL "Enable undefined behavior sanitizer testing in gcc/clang")
+serenity_option(UNDEFINED_BEHAVIOR_IS_FATAL OFF CACHE BOOL "Make undefined behavior sanitizer errors non-recoverable")
 
 serenity_option(ENABLE_ALL_THE_DEBUG_MACROS OFF CACHE BOOL "Enable all debug macros to validate they still compile")
 serenity_option(ENABLE_ALL_DEBUG_FACILITIES OFF CACHE BOOL "Enable all noisy debug symbols and options. Not recommended for normal developer use")

--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -119,6 +119,9 @@ endif()
 
 if (ENABLE_UNDEFINED_SANITIZER)
     add_compile_options(-fsanitize=undefined -fno-omit-frame-pointer)
+    if (UNDEFINED_BEHAVIOR_IS_FATAL)
+        add_compile_options(-fno-sanitize-recover=undefined)
+    endif()
     set(LINKER_FLAGS "${LINKER_FLAGS} -fsanitize=undefined")
 endif()
 


### PR DESCRIPTION
I tried to summarize most of the information in the commit messages, but see the "Making LibWeb less heavy on the linker" thread for more background.

~~I've yet to test this with GCC, waiting for results right now.~~

---

**LibSanitizer: Abort on unrecoverable UBSan errors**

There is no sensible recovery possible from non-void functions that
fail to return a value, or from `__builtin_unreachable()` being reached,
all bets are off once they happened. This is why LLVM's libsanitizer
treats these as always fatal, even if all other UBSan checks are made
recoverable with `-fsanitize-recover`. The codegen already assumes that
these handlers will not return.

**LibSanitizer: Add `_abort` variants of UBSan handlers**

These variants make the choice to terminate the process a compile-time
decision rather than a runtime-configurable setting through
`UBSAN_OPTIONS`. As the compiler can treat any code following these
UBSan handler calls as dead code, it allows for significant
optimizations, such as removing redundant UBSan checks and not needing
to worry about saving volatile registers before calling these.

Generation of this kind of instrumentation can be enabled with
`-fsanitize=undefined -fno-sanitize-recover=undefined`. Build system
support will come in a separate PR.

**CMake: Add `UNDEFINED_BEHAVIOR_IS_FATAL` configure option**

This is mainly intended for use on CI, as UBSan instrumentation results
in a serious load and execution time penalty there. See the previous
commit for more details.

With this enabled, the size of LibWeb, built for x86-64 with Clang 17 as
of https://github.com/SerenityOS/serenity/commit/0b91d36a1e640a5784ce2e17a7261b8fb15b34a6 is reduced as follows:
```
      FILE SIZE        VM SIZE
   --------------  --------------
     +18% +2.99Mi  [ = ]       0    .debug_info
     +14%  +758Ki  [ = ]       0    .debug_addr
    +2.6% +7.92Ki  [ = ]       0    .debug_abbrev
    +129% +2.66Ki  [ = ]       0    [Unmapped]
    -0.2%    -208  -0.2%    -208    .plt
    -0.2%    -312  -0.2%    -312    .rela.plt
    -0.1%    -336  -0.1%    -336    .dynsym
    -0.0%    -647  -0.0%    -513    [8 Others]
    -0.1% -1.14Ki  -0.1% -1.14Ki    .dynstr
   -20.1% -53.5Ki -20.1% -53.5Ki    .eh_frame_hdr
    -7.2% -56.8Ki  [ = ]       0    .debug_str_offsets
    -7.1%  -156Ki  [ = ]       0    .debug_str
   -15.0%  -160Ki  [ = ]       0    .symtab
   -63.6%  -245Ki -63.6%  -245Ki    .relr.dyn
   -25.4%  -357Ki -25.4%  -357Ki    .eh_frame
   -27.7% -1.09Mi  [ = ]       0    .strtab
   -59.3% -10.0Mi  [ = ]       0    .debug_rnglists
   -41.3% -11.0Mi  [ = ]       0    .debug_line
   -70.0% -12.0Mi -70.0% -12.0Mi    .rodata
   -65.2% -15.1Mi -65.2% -15.1Mi    .data
   -53.0% -15.7Mi -53.0% -15.7Mi    .text
   -41.7% -62.1Mi -57.7% -43.4Mi    TOTAL
```
**CI: Force UBSan errors to be fatal for Serenity tests**

The test runner script sets the `halt_on_error=1` `UBSAN_OPTIONS` flag
already, this just makes it a compile-time decision. This should
alleviate some of the slowness of running on-target tests without
hardware acceleration.