### PR TITLE
LibWeb: Fetch CSS @font-face fonts in @import'ed style sheets

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/CSSImportRule.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSImportRule.cpp
@@ -107,6 +107,7 @@ void CSSImportRule::resource_did_load()
     m_style_sheet = sheet;
 
     m_document->style_computer().invalidate_rule_cache();
+    m_document->style_computer().load_fonts_from_sheet(*m_style_sheet);
     m_document->invalidate_style();
 }
 


### PR DESCRIPTION
This makes importing Google Fonts via @import rule actually work. :^)