### PR TITLE
LibWeb: Get rid of `AvailableSize::to_px()` usage

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/AvailableSpace.h
+++ b/Userland/Libraries/LibWeb/Layout/AvailableSpace.h
@@ -48,6 +48,7 @@ public:
     DeprecatedString to_deprecated_string() const;
 
     bool operator==(AvailableSize const& other) const = default;
+    bool operator<(AvailableSize const& other) const { return m_value < other.m_value; }
 
 private:
     AvailableSize(Type type, CSSPixels);

--- a/Userland/Libraries/LibWeb/Layout/AvailableSpace.h
+++ b/Userland/Libraries/LibWeb/Layout/AvailableSpace.h
@@ -57,6 +57,33 @@ private:
     CSSPixels m_value {};
 };
 
+inline bool operator>(CSSPixels left, AvailableSize const& right)
+{
+    if (right.is_max_content() || right.is_indefinite())
+        return false;
+    if (right.is_min_content())
+        return true;
+    return left > right.to_px_or_zero();
+}
+
+inline bool operator<(CSSPixels left, AvailableSize const& right)
+{
+    if (right.is_max_content() || right.is_indefinite())
+        return true;
+    if (right.is_min_content())
+        return false;
+    return left < right.to_px_or_zero();
+}
+
+inline bool operator<(AvailableSize const& left, CSSPixels right)
+{
+    if (left.is_min_content())
+        return true;
+    if (left.is_max_content() || left.is_indefinite())
+        return false;
+    return left.to_px_or_zero() < right;
+}
+
 class AvailableSpace {
 public:
     AvailableSpace(AvailableSize w, AvailableSize h)

--- a/Userland/Libraries/LibWeb/Layout/AvailableSpace.h
+++ b/Userland/Libraries/LibWeb/Layout/AvailableSpace.h
@@ -33,11 +33,6 @@ public:
     bool is_max_content() const { return m_type == Type::MaxContent; }
     bool is_intrinsic_sizing_constraint() const { return is_min_content() || is_max_content(); }
 
-    CSSPixels to_px() const
-    {
-        return m_value;
-    }
-
     CSSPixels to_px_or_zero() const
     {
         if (!is_definite())

--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -135,7 +135,7 @@ void BlockFormattingContext::compute_width(Box const& box, AvailableSpace const&
         // CSS2 does not define when a UA may put said element next to the float or by how much said element may
         // become narrower.
         auto intrusion = intrusion_by_floats_into_box(box, 0);
-        auto remaining_width = available_space.width.to_px() - intrusion.left - intrusion.right;
+        auto remaining_width = available_space.width.to_px_or_zero() - intrusion.left - intrusion.right;
         remaining_available_space.width = AvailableSize::make_definite(remaining_width);
     }
 
@@ -163,7 +163,7 @@ void BlockFormattingContext::compute_width(Box const& box, AvailableSpace const&
 
     auto const& computed_values = box.computed_values();
 
-    auto width_of_containing_block = remaining_available_space.width.to_px();
+    auto width_of_containing_block = remaining_available_space.width.to_px_or_zero();
     auto width_of_containing_block_as_length_for_resolve = remaining_available_space.width.is_definite() ? CSS::Length::make_px(width_of_containing_block) : CSS::Length::make_px(0);
 
     auto zero_value = CSS::Length::make_px(0);
@@ -271,7 +271,7 @@ void BlockFormattingContext::compute_width(Box const& box, AvailableSpace const&
     //    but this time using the value of 'min-width' as the computed value for 'width'.
     if (!computed_values.min_width().is_auto()) {
         auto min_width = calculate_inner_width(box, remaining_available_space.width, computed_values.min_width());
-        auto used_width_px = used_width.is_auto() ? remaining_available_space.width.to_px() : used_width.to_px(box);
+        auto used_width_px = used_width.is_auto() ? remaining_available_space.width : AvailableSize::make_definite(used_width.to_px(box));
         if (used_width_px < min_width.to_px(box)) {
             used_width = try_compute_width(min_width);
         }
@@ -290,7 +290,7 @@ void BlockFormattingContext::compute_width_for_floating_box(Box const& box, Avai
     auto& computed_values = box.computed_values();
 
     auto zero_value = CSS::Length::make_px(0);
-    auto width_of_containing_block = available_space.width.to_px();
+    auto width_of_containing_block = available_space.width.to_px_or_zero();
     auto width_of_containing_block_as_length_for_resolve = CSS::Length::make_px(width_of_containing_block);
     if (!available_space.width.is_definite())
         width_of_containing_block_as_length_for_resolve = CSS::Length::make_px(0);
@@ -367,7 +367,7 @@ void BlockFormattingContext::compute_width_for_block_level_replaced_element_in_n
     auto& computed_values = box.computed_values();
 
     auto zero_value = CSS::Length::make_px(0);
-    auto width_of_containing_block = available_space.width.to_px();
+    auto width_of_containing_block = available_space.width.to_px_or_zero();
     auto width_of_containing_block_as_length_for_resolve = CSS::Length::make_px(width_of_containing_block);
     if (!available_space.width.is_definite())
         width_of_containing_block_as_length_for_resolve = CSS::Length::make_px(0);
@@ -403,7 +403,7 @@ CSSPixels BlockFormattingContext::compute_table_box_width_inside_table_wrapper(B
 
     auto const& computed_values = box.computed_values();
 
-    auto width_of_containing_block = available_space.width.to_px();
+    auto width_of_containing_block = available_space.width.to_px_or_zero();
     auto width_of_containing_block_as_length_for_resolve = available_space.width.is_definite() ? CSS::Length::make_px(width_of_containing_block) : CSS::Length::make_px(0);
 
     auto zero_value = CSS::Length::make_px(0);
@@ -442,7 +442,7 @@ CSSPixels BlockFormattingContext::compute_table_box_width_inside_table_wrapper(B
 void BlockFormattingContext::compute_height(Box const& box, AvailableSpace const& available_space)
 {
     auto const& computed_values = box.computed_values();
-    auto containing_block_height = CSS::Length::make_px(available_space.height.to_px());
+    auto containing_block_height = CSS::Length::make_px(available_space.height.to_px_or_zero());
 
     // Then work out what the height is, based on box type and CSS properties.
     CSSPixels height = 0;
@@ -850,7 +850,7 @@ void BlockFormattingContext::place_block_level_element_in_normal_flow_horizontal
     auto& box_state = m_state.get_mutable(child_box);
 
     CSSPixels x = 0;
-    CSSPixels available_width_within_containing_block = available_space.width.to_px();
+    CSSPixels available_width_within_containing_block = available_space.width.to_px_or_zero();
 
     if ((!m_left_floats.current_boxes.is_empty() || !m_right_floats.current_boxes.is_empty())
         && creates_block_formatting_context(child_box)) {
@@ -899,7 +899,7 @@ void BlockFormattingContext::layout_floating_box(Box const& box, BlockContainer 
     VERIFY(box.is_floating());
 
     auto& box_state = m_state.get_mutable(box);
-    CSSPixels width_of_containing_block = available_space.width.to_px();
+    CSSPixels width_of_containing_block = available_space.width.to_px_or_zero();
 
     resolve_vertical_box_model_metrics(box);
 

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -450,7 +450,7 @@ CSSPixels FormattingContext::compute_width_for_replaced_element(Box const& box, 
     // 10.3.2 Inline, replaced elements
 
     auto zero_value = CSS::Length::make_px(0);
-    auto width_of_containing_block = available_space.width.to_px();
+    auto width_of_containing_block = available_space.width.to_px_or_zero();
     auto width_of_containing_block_as_length = CSS::Length::make_px(width_of_containing_block);
 
     auto computed_width = should_treat_width_as_auto(box, available_space) ? CSS::Size::make_auto() : box.computed_values().width();
@@ -564,7 +564,7 @@ CSSPixels FormattingContext::compute_height_for_replaced_element(Box const& box,
 
 void FormattingContext::compute_width_for_absolutely_positioned_non_replaced_element(Box const& box, AvailableSpace const& available_space)
 {
-    auto width_of_containing_block = available_space.width.to_px();
+    auto width_of_containing_block = available_space.width.to_px_or_zero();
     auto width_of_containing_block_as_length = CSS::Length::make_px(width_of_containing_block);
     auto& computed_values = box.computed_values();
     auto zero_value = CSS::Length::make_px(0);
@@ -744,7 +744,7 @@ void FormattingContext::compute_width_for_absolutely_positioned_replaced_element
     }
 
     auto width = compute_width_for_replaced_element(box, available_space);
-    auto width_of_containing_block = available_space.width.to_px();
+    auto width_of_containing_block = available_space.width.to_px_or_zero();
     auto available = width_of_containing_block - width;
     auto const& computed_values = box.computed_values();
     auto left = computed_values.inset().left();
@@ -834,7 +834,7 @@ void FormattingContext::compute_height_for_absolutely_positioned_non_replaced_el
 
     auto width_of_containing_block = containing_block_width_for(box);
     auto width_of_containing_block_as_length = CSS::Length::make_px(width_of_containing_block);
-    auto height_of_containing_block = available_space.height.to_px();
+    auto height_of_containing_block = available_space.height.to_px_or_zero();
     auto height_of_containing_block_as_length = CSS::Length::make_px(height_of_containing_block);
 
     enum class ClampToZero {
@@ -1093,8 +1093,8 @@ void FormattingContext::layout_absolutely_positioned_element(Box const& box, Ava
     auto& containing_block_state = m_state.get_mutable(*box.containing_block());
     auto& box_state = m_state.get_mutable(box);
 
-    auto width_of_containing_block = available_space.width.to_px();
-    auto height_of_containing_block = available_space.height.to_px();
+    auto width_of_containing_block = available_space.width.to_px_or_zero();
+    auto height_of_containing_block = available_space.height.to_px_or_zero();
     auto width_of_containing_block_as_length = CSS::Length::make_px(width_of_containing_block);
     auto height_of_containing_block_as_length = CSS::Length::make_px(height_of_containing_block);
 
@@ -1135,7 +1135,7 @@ void FormattingContext::compute_height_for_absolutely_positioned_replaced_elemen
     // The used value of 'height' is determined as for inline replaced elements.
     auto height = compute_height_for_replaced_element(box, available_space);
 
-    auto height_of_containing_block = available_space.height.to_px();
+    auto height_of_containing_block = available_space.height.to_px_or_zero();
     auto available = height_of_containing_block - height;
     auto const& computed_values = box.computed_values();
     auto top = computed_values.inset().top();
@@ -1587,7 +1587,7 @@ CSSPixels FormattingContext::calculate_stretch_fit_width(Box const& box, Availab
         return 0;
 
     auto const& box_state = m_state.get(box);
-    return available_width.to_px()
+    return available_width.to_px_or_zero()
         - box_state.margin_left
         - box_state.margin_right
         - box_state.padding_left
@@ -1603,7 +1603,7 @@ CSSPixels FormattingContext::calculate_stretch_fit_height(Box const& box, Availa
     // in other words, the stretch fit into the available space, if that is definite.
     // Undefined if the available space is indefinite.
     auto const& box_state = m_state.get(box);
-    return available_height.to_px()
+    return available_height.to_px_or_zero()
         - box_state.margin_top
         - box_state.margin_bottom
         - box_state.padding_top

--- a/Userland/Libraries/LibWeb/Layout/InlineFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/InlineFormattingContext.h
@@ -30,7 +30,7 @@ public:
     void dimension_box_on_line(Box const&, LayoutMode);
 
     CSSPixels leftmost_x_offset_at(CSSPixels y) const;
-    CSSPixels available_space_for_line(CSSPixels y) const;
+    AvailableSize available_space_for_line(CSSPixels y) const;
     bool any_floats_intrude_at_y(CSSPixels y) const;
     bool can_fit_new_line_at_y(CSSPixels y) const;
 

--- a/Userland/Libraries/LibWeb/Layout/InlineLevelIterator.cpp
+++ b/Userland/Libraries/LibWeb/Layout/InlineLevelIterator.cpp
@@ -121,7 +121,7 @@ void InlineLevelIterator::skip_to_next()
     compute_next();
 }
 
-Optional<InlineLevelIterator::Item> InlineLevelIterator::next(CSSPixels available_width)
+Optional<InlineLevelIterator::Item> InlineLevelIterator::next(AvailableSize available_width)
 {
     if (!m_current_node)
         return {};

--- a/Userland/Libraries/LibWeb/Layout/InlineLevelIterator.h
+++ b/Userland/Libraries/LibWeb/Layout/InlineLevelIterator.h
@@ -51,7 +51,7 @@ public:
 
     InlineLevelIterator(Layout::InlineFormattingContext&, LayoutState&, Layout::BlockContainer const&, LayoutMode);
 
-    Optional<Item> next(CSSPixels available_width);
+    Optional<Item> next(AvailableSize available_width);
 
 private:
     void skip_to_next();

--- a/Userland/Libraries/LibWeb/Layout/LineBox.h
+++ b/Userland/Libraries/LibWeb/Layout/LineBox.h
@@ -30,7 +30,7 @@ public:
     bool is_empty_or_ends_in_whitespace() const;
     bool is_empty() const { return m_fragments.is_empty() && !m_has_break; }
 
-    CSSPixels original_available_width() const { return m_original_available_width; }
+    AvailableSize original_available_width() const { return m_original_available_width; }
 
     CSSPixelRect const& absolute_rect() const { return m_absolute_rect; }
     void set_absolute_rect(CSSPixelRect const& rect) { m_absolute_rect = rect; }
@@ -49,7 +49,7 @@ private:
     CSSPixels m_baseline { 0 };
 
     // The amount of available width that was originally available when creating this line box. Used for text justification.
-    CSSPixels m_original_available_width { 0 };
+    AvailableSize m_original_available_width { AvailableSize::make_indefinite() };
 
     bool m_has_break { false };
     bool m_has_forced_break { false };

--- a/Userland/Libraries/LibWeb/Layout/LineBuilder.cpp
+++ b/Userland/Libraries/LibWeb/Layout/LineBuilder.cpp
@@ -136,7 +136,7 @@ CSSPixels LineBuilder::y_for_float_to_be_inserted_here(Box const& box)
 
 bool LineBuilder::should_break(CSSPixels next_item_width)
 {
-    if (!isfinite(m_available_width_for_current_line.to_double()))
+    if (m_available_width_for_current_line.is_max_content())
         return false;
 
     auto const& line_boxes = m_containing_block_state.line_boxes;
@@ -169,7 +169,7 @@ void LineBuilder::update_last_line()
     CSSPixels x_offset_bottom = m_context.leftmost_x_offset_at(m_current_y + current_line_height - 1);
     CSSPixels x_offset = max(x_offset_top, x_offset_bottom);
 
-    CSSPixels excess_horizontal_space = m_available_width_for_current_line - line_box.width();
+    CSSPixels excess_horizontal_space = m_available_width_for_current_line.to_px_or_zero() - line_box.width();
 
     // If (after justification, if any) the inline contents of a line box are too long to fit within it,
     // then the contents are start-aligned: any content that doesn't fit overflows the line box’s end edge.

--- a/Userland/Libraries/LibWeb/Layout/LineBuilder.h
+++ b/Userland/Libraries/LibWeb/Layout/LineBuilder.h
@@ -37,7 +37,7 @@ public:
         return false;
     }
 
-    CSSPixels available_width_for_current_line() const { return m_available_width_for_current_line; }
+    AvailableSize available_width_for_current_line() const { return m_available_width_for_current_line; }
 
     void update_last_line();
 
@@ -61,7 +61,7 @@ private:
     InlineFormattingContext& m_context;
     LayoutState& m_layout_state;
     LayoutState::UsedValues& m_containing_block_state;
-    CSSPixels m_available_width_for_current_line { 0 };
+    AvailableSize m_available_width_for_current_line { AvailableSize::make_indefinite() };
     CSSPixels m_current_y { 0 };
     CSSPixels m_max_height_on_current_line { 0 };
     CSSPixels m_text_indent { 0 };


### PR DESCRIPTION
This layout code refactoring replaces usage of `to_px()` with `to_px_or_zero()` that prevents leakage of saturated (infinite) values into layout calculations.