### PR TITLE
LibWeb: Use current platform for navigator.platform

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/NavigatorID.cpp
+++ b/Userland/Libraries/LibWeb/HTML/NavigatorID.cpp
@@ -40,7 +40,7 @@ DeprecatedString NavigatorIDMixin::platform() const
     // platform.
 
     // FIXME: Use some portion of the user agent string to make spoofing work 100%
-    return "SerenityOS";
+    return ResourceLoader::the().platform();
 }
 
 // https://html.spec.whatwg.org/multipage/system-state.html#dom-navigator-useragent

--- a/Userland/Libraries/LibWeb/Loader/ResourceLoader.cpp
+++ b/Userland/Libraries/LibWeb/Loader/ResourceLoader.cpp
@@ -58,6 +58,7 @@ ErrorOr<NonnullRefPtr<ResourceLoader>> ResourceLoader::try_create(NonnullRefPtr<
 ResourceLoader::ResourceLoader(NonnullRefPtr<ResourceLoaderConnector> connector)
     : m_connector(move(connector))
     , m_user_agent(default_user_agent)
+    , m_platform(default_platform)
 {
 }
 

--- a/Userland/Libraries/LibWeb/Loader/ResourceLoader.h
+++ b/Userland/Libraries/LibWeb/Loader/ResourceLoader.h
@@ -50,6 +50,7 @@ namespace Web {
 #define BROWSER_VERSION "1.0"
 
 constexpr auto default_user_agent = "Mozilla/5.0 (" OS_STRING "; " CPU_STRING ") LibWeb+LibJS/1.0 " BROWSER_NAME "/" BROWSER_VERSION ""sv;
+constexpr auto default_platform = OS_STRING " " CPU_STRING ""sv;
 
 class ResourceLoaderConnectorRequest : public RefCounted<ResourceLoaderConnectorRequest> {
 public:
@@ -110,6 +111,9 @@ public:
     DeprecatedString const& user_agent() const { return m_user_agent; }
     void set_user_agent(DeprecatedString const& user_agent) { m_user_agent = user_agent; }
 
+    DeprecatedString const& platform() const { return m_platform; }
+    void set_platform(DeprecatedString const& platform) { m_platform = platform; }
+
     void clear_cache();
     void evict_from_cache(LoadRequest const&);
 
@@ -124,6 +128,7 @@ private:
     HashTable<NonnullRefPtr<ResourceLoaderConnectorRequest>> m_active_requests;
     NonnullRefPtr<ResourceLoaderConnector> m_connector;
     DeprecatedString m_user_agent;
+    DeprecatedString m_platform;
     Optional<Page&> m_page {};
 };
 


### PR DESCRIPTION
Before, `navigator.platform` would always report the platform as "SerenityOS", regardless of whether or not that was true. It also did not include the architecture, which Firefox and Chrome both do. Now, it can report either "Linux x86_64" or "SerenityOS AArch64".