### PR TITLE
Utilities: Add zcat

### DIFF
--- a/Userland/Utilities/CMakeLists.txt
+++ b/Userland/Utilities/CMakeLists.txt
@@ -2,12 +2,12 @@ file(GLOB CMD_SOURCES  CONFIGURE_DEPENDS "*.cpp")
 list(APPEND SPECIAL_TARGETS test install)
 list(APPEND REQUIRED_TARGETS
     arp base64 basename cat chmod chown clear comm cp cut date dd df diff dirname dmesg du echo env expr false
-    file find grep groups head host hostname id ifconfig kill killall ln logout ls mkdir mount mv network-settings nproc
+    file find grep groups gunzip head host hostname id ifconfig kill killall ln logout ls mkdir mount mv network-settings nproc
     patch pgrep pidof ping pkill pmap ps readlink realpath reboot rm rmdir sed route seq shutdown sleep sort stat stty su tail test
     touch tr true umount uname uniq uptime w wc which whoami xargs yes
 )
 list(APPEND RECOMMENDED_TARGETS
-    aconv adjtime aplay abench asctl bt checksum chres cksum copy fortune gunzip gzip init install keymap lsirq lsof lspci lzcat man mknod mktemp
+    aconv adjtime aplay abench asctl bt checksum chres cksum copy fortune gzip init install keymap lsirq lsof lspci lzcat man mknod mktemp
     nc netstat notify ntpquery open passwd pixelflut pls printf pro shot strings tar tt unzip wallpaper xzcat zip
 )
 
@@ -70,6 +70,7 @@ endif()
 install(CODE "file(CREATE_LINK grep ${CMAKE_INSTALL_PREFIX}/bin/egrep SYMBOLIC)")
 install(CODE "file(CREATE_LINK grep ${CMAKE_INSTALL_PREFIX}/bin/fgrep SYMBOLIC)")
 install(CODE "file(CREATE_LINK grep ${CMAKE_INSTALL_PREFIX}/bin/rgrep SYMBOLIC)")
+install(CODE "file(CREATE_LINK gunzip ${CMAKE_INSTALL_PREFIX}/bin/zcat SYMBOLIC)")
 
 target_link_libraries(abench PRIVATE LibAudio LibFileSystem)
 target_link_libraries(aconv PRIVATE LibAudio LibFileSystem)

--- a/Userland/Utilities/gunzip.cpp
+++ b/Userland/Utilities/gunzip.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020, the SerenityOS developers.
+ * Copyright (c) 2023, Liav A. <liavalb@hotmail.co.il>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -18,8 +19,14 @@ ErrorOr<int> serenity_main(Main::Arguments args)
     bool write_to_stdout { false };
 
     Core::ArgsParser args_parser;
-    args_parser.add_option(keep_input_files, "Keep (don't delete) input files", "keep", 'k');
-    args_parser.add_option(write_to_stdout, "Write to stdout, keep original files unchanged", "stdout", 'c');
+    // NOTE: If the user run this program via the /bin/zcat symlink,
+    // then emulate gzip decompression to stdout.
+    if (args.argc > 0 && args.strings[0] == "zcat"sv) {
+        write_to_stdout = true;
+    } else {
+        args_parser.add_option(keep_input_files, "Keep (don't delete) input files", "keep", 'k');
+        args_parser.add_option(write_to_stdout, "Write to stdout, keep original files unchanged", "stdout", 'c');
+    }
     args_parser.add_positional_argument(filenames, "File to decompress", "FILE");
     args_parser.parse(args);
 


### PR DESCRIPTION
This utility is actually a symlink to the gunzip utility. The gunzip utility is modified to enable writing to stdout when running through the zcat symlink, to emulate the same behavior on other OSes.

In addition to that, the gunzip utility is now required on a default installation as it could be a vital utility under some conditions (for example, downloading source code in a tar.gz file).