### PR TITLE
LibUnicode: Generate data for bidirectional character types

### DIFF
--- a/Tests/LibUnicode/TestUnicodeCharacterTypes.cpp
+++ b/Tests/LibUnicode/TestUnicodeCharacterTypes.cpp
@@ -848,3 +848,28 @@ TEST_CASE(code_point_display_name)
     EXPECT_EQ(code_point_display_name(0x2f802), "CJK COMPATIBILITY IDEOGRAPH-2F802"sv);
     EXPECT_EQ(code_point_display_name(0x2fa1d), "CJK COMPATIBILITY IDEOGRAPH-2FA1D"sv);
 }
+
+TEST_CASE(code_point_bidirectional_character_type)
+{
+    auto code_point_bidi_class = [](u32 code_point) {
+        auto bidi_class = Unicode::bidirectional_class(code_point);
+        VERIFY(bidi_class.has_value());
+        return bidi_class.release_value();
+    };
+
+    auto bidi_class_from_string = [](StringView name) {
+        auto result = Unicode::bidirectional_class_from_string(name);
+        VERIFY(result.has_value());
+        return result.release_value();
+    };
+
+    // Left-to-right
+    EXPECT_EQ(code_point_bidi_class('A'), bidi_class_from_string("L"sv));
+    EXPECT_EQ(code_point_bidi_class('z'), bidi_class_from_string("L"sv));
+    // European number
+    EXPECT_EQ(code_point_bidi_class('7'), bidi_class_from_string("EN"sv));
+    // Whitespace
+    EXPECT_EQ(code_point_bidi_class(' '), bidi_class_from_string("WS"sv));
+    // Arabic right-to-left (U+FEB4 ARABIC LETTER SEEN MEDIAL FORM)
+    EXPECT_EQ(code_point_bidi_class(0xFEB4), bidi_class_from_string("AL"sv));
+}

--- a/Userland/Libraries/LibUnicode/CharacterTypes.cpp
+++ b/Userland/Libraries/LibUnicode/CharacterTypes.cpp
@@ -147,4 +147,7 @@ bool __attribute__((weak)) code_point_has_grapheme_break_property(u32, GraphemeB
 bool __attribute__((weak)) code_point_has_word_break_property(u32, WordBreakProperty) { return {}; }
 bool __attribute__((weak)) code_point_has_sentence_break_property(u32, SentenceBreakProperty) { return {}; }
 
+Optional<BidirectionalClass> __attribute__((weak)) bidirectional_class_from_string(StringView) { return {}; }
+Optional<BidirectionalClass> __attribute__((weak)) bidirectional_class(u32) { return {}; }
+
 }

--- a/Userland/Libraries/LibUnicode/CharacterTypes.h
+++ b/Userland/Libraries/LibUnicode/CharacterTypes.h
@@ -68,4 +68,7 @@ bool code_point_has_grapheme_break_property(u32 code_point, GraphemeBreakPropert
 bool code_point_has_word_break_property(u32 code_point, WordBreakProperty property);
 bool code_point_has_sentence_break_property(u32 code_point, SentenceBreakProperty property);
 
+Optional<BidirectionalClass> bidirectional_class_from_string(StringView);
+Optional<BidirectionalClass> bidirectional_class(u32 code_point);
+
 }

--- a/Userland/Libraries/LibUnicode/Forward.h
+++ b/Userland/Libraries/LibUnicode/Forward.h
@@ -10,6 +10,7 @@
 
 namespace Unicode {
 
+enum class BidirectionalClass : u8;
 enum class Block : u16;
 enum class EmojiGroup : u8;
 enum class GeneralCategory : u8;


### PR DESCRIPTION
This will let us examine code points to determine the rtl/ltr direction of a piece of text.