### PR TITLE
nohup: Make sure to return exit code 127 for any errors

### DIFF
--- a/Userland/Utilities/nohup.cpp
+++ b/Userland/Utilities/nohup.cpp
@@ -13,7 +13,7 @@
 
 namespace {
 
-void dup_out_file(int fd_to_redirect)
+ErrorOr<void> dup_out_file(int fd_to_redirect)
 {
     int fd = -1;
     DeprecatedString path = "nohup.out";
@@ -23,38 +23,42 @@ void dup_out_file(int fd_to_redirect)
 
     if (fd_or_error.is_error()) {
         auto* home_env = getenv("HOME");
-        if (!home_env) {
-            warnln("nohup: unable to open for appending as $HOME is not set");
-            exit(127);
-        }
+        if (!home_env)
+            return Error::from_string_view("unable to open for appending as $HOME is not set"sv);
 
         path = LexicalPath::join(LexicalPath::canonicalized_path(home_env), path).string();
-        fd_or_error = Core::System::open(path, options, mode);
-        if (fd_or_error.is_error()) {
-            warnln("nohup: unable to open {} for appending: {}", path, strerror(fd_or_error.error().code()));
-            exit(127);
-        }
+        fd = TRY(Core::System::open(path, options, mode));
+    } else {
+        fd = fd_or_error.value();
     }
 
-    fd = fd_or_error.value();
+    TRY(Core::System::dup2(fd, fd_to_redirect));
 
-    auto maybe_error = Core::System::dup2(fd, fd_to_redirect);
-    if (maybe_error.is_error()) {
-        warnln("nohup: redirection failed: {}", strerror(maybe_error.error().code()));
-        exit(127);
-    }
-
-    MUST(Core::System::close(fd));
+    TRY(Core::System::close(fd));
 
     if (fd_to_redirect != STDERR_FILENO)
         outln(stderr, "appending output to {}", path);
+
+    return {};
+}
+
+void exit_with_error(Error error)
+{
+    if (error.is_syscall())
+        warnln("nohup: error while calling {}: {}", error.string_literal(), strerror(error.code()));
+    else if (error.is_errno())
+        warnln("nohup: {}", strerror(error.code()));
+    else
+        warnln("nohup: {}", error.string_literal());
+    exit(127);
 }
 
 }
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio wpath cpath rpath exec sigaction"));
+    if (auto pledge_result = Core::System::pledge("stdio wpath cpath rpath exec sigaction"); pledge_result.is_error())
+        exit_with_error(pledge_result.release_error());
 
     StringView utility;
     Vector<StringView> args;
@@ -69,26 +73,22 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto stdout_is_a_tty = false;
     auto tty_or_error = Core::System::isatty(STDOUT_FILENO);
     if (tty_or_error.is_error()) {
-        auto error = tty_or_error.release_error();
-        if (error.code() != EBADF) {
-            warnln("nohup: error while performing tty check on stdout: {}", strerror(error.code()));
-            return 127;
-        }
+        if (tty_or_error.error().code() != EBADF)
+            exit_with_error(tty_or_error.release_error());
     } else {
         stdout_is_a_tty = tty_or_error.value();
     }
 
-    if (stdout_is_a_tty)
-        dup_out_file(STDOUT_FILENO);
+    if (stdout_is_a_tty) {
+        if (auto dup_result = dup_out_file(STDOUT_FILENO); dup_result.is_error())
+            exit_with_error(dup_result.release_error());
+    }
 
     auto stderr_is_a_tty = false;
     tty_or_error = Core::System::isatty(STDERR_FILENO);
     if (tty_or_error.is_error()) {
-        auto error = tty_or_error.release_error();
-        if (error.code() != EBADF) {
-            warnln("nohup: error while performing tty check on stderr: {}", strerror(error.code()));
-            return 127;
-        }
+        if (tty_or_error.error().code() != EBADF)
+            exit_with_error(tty_or_error.release_error());
     } else {
         stderr_is_a_tty = tty_or_error.value();
     }
@@ -96,24 +96,26 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     if (stderr_is_a_tty) {
         auto dup_or_error = Core::System::dup2(STDOUT_FILENO, STDERR_FILENO);
         if (dup_or_error.is_error()) {
-            auto error = dup_or_error.release_error();
-            if (error.code() != EBADF) {
-                warnln("nohup: error redirecting stderr to stdout: {}", strerror(error.code()));
-                return 127;
-            }
+            if (dup_or_error.error().code() != EBADF)
+                exit_with_error(dup_or_error.release_error());
+
             // NOTE: Standard output must be closed, so "...the same output shall
             //       instead be appended to the end of the nohup.out file..."
-            dup_out_file(STDERR_FILENO);
+            if (auto dup_result = dup_out_file(STDERR_FILENO); dup_result.is_error())
+                exit_with_error(dup_result.release_error());
         }
     }
 
-    TRY(Core::System::signal(SIGHUP, SIG_IGN));
+    if (auto ignore_hup_or_error = Core::System::signal(SIGHUP, SIG_IGN); ignore_hup_or_error.is_error())
+        exit_with_error(ignore_hup_or_error.release_error());
 
-    TRY(args.try_prepend(utility));
+    if (auto prepend_or_error = args.try_prepend(utility); prepend_or_error.is_error())
+        exit_with_error(prepend_or_error.release_error());
+
     auto exec_or_error = Core::System::exec(utility, args.span(), Core::System::SearchInPath::Yes);
     if (exec_or_error.is_error()) {
         auto error = exec_or_error.release_error();
-        warnln("nohup: error while calling exec: {}", strerror(error.code()));
+        warnln("nohup: error while executing {}: {}", utility, strerror(error.code()));
         return error.code() == ENOENT ? 127 : 126;
     }
 


### PR DESCRIPTION
Instead of using whatever error code was given, we should conform to the POSIX spec by using exit code 127 when errors occur during nohup's runtime.