### PR TITLE
LibWeb: Use cell width instead available width to compute height

### DIFF
--- a/Tests/LibWeb/Layout/expected/table/inline-table-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/inline-table-width.txt
@@ -1,12 +1,12 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
-    BlockContainer <body> at (8,8) content-size 784x64.875 children: inline
-      line 0 width: 137.984375, height: 64.875, bottom: 64.875, baseline: 64.875
-        frag 0 from BlockContainer start: 0, length: 0, rect: [9,9 135.984375x62.875]
-      BlockContainer <table> at (9,9) content-size 135.984375x62.875 inline-block [BFC] children: not-inline
-        TableWrapper <(anonymous)> at (9,9) content-size 135.984375x62.875 inline-block [BFC] children: not-inline
-          Box <(anonymous)> at (9,9) content-size 135.984375x62.875 inline-table table-box [TFC] children: not-inline
-            Box <tbody> at (9,9) content-size 129.984375x56.875 table-row-group children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x46.9375 children: inline
+      line 0 width: 137.984375, height: 46.9375, bottom: 46.9375, baseline: 46.9375
+        frag 0 from BlockContainer start: 0, length: 0, rect: [9,9 135.984375x44.9375]
+      BlockContainer <table> at (9,9) content-size 135.984375x44.9375 inline-block [BFC] children: not-inline
+        TableWrapper <(anonymous)> at (9,9) content-size 135.984375x44.9375 inline-block [BFC] children: not-inline
+          Box <(anonymous)> at (9,9) content-size 135.984375x44.9375 inline-table table-box [TFC] children: not-inline
+            Box <tbody> at (9,9) content-size 129.984375x38.9375 table-row-group children: not-inline
               Box <tr> at (11,11) content-size 129.984375x19.46875 table-row children: not-inline
                 BlockContainer <td> at (12,12) content-size 87.90625x17.46875 table-cell [BFC] children: inline
                   line 0 width: 15.734375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
@@ -18,32 +18,32 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                     frag 0 from TextNode start: 0, length: 4, rect: [103.90625,12 27.84375x17.46875]
                       "null"
                   TextNode <#text>
-              Box <tr> at (11,32.46875) content-size 129.984375x37.40625 table-row children: not-inline
-                BlockContainer <td> at (12,42.4375) content-size 87.90625x17.46875 table-cell [BFC] children: inline
+              Box <tr> at (11,32.46875) content-size 129.984375x19.46875 table-row children: not-inline
+                BlockContainer <td> at (12,33.46875) content-size 87.90625x17.46875 table-cell [BFC] children: inline
                   line 0 width: 87.90625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                    frag 0 from TextNode start: 0, length: 11, rect: [12,42.4375 87.90625x17.46875]
+                    frag 0 from TextNode start: 0, length: 11, rect: [12,33.46875 87.90625x17.46875]
                       "Is Selected"
                   TextNode <#text>
-                BlockContainer <td> at (103.90625,42.4375) content-size 38.078125x17.46875 table-cell [BFC] children: inline
+                BlockContainer <td> at (103.90625,33.46875) content-size 38.078125x17.46875 table-cell [BFC] children: inline
                   line 0 width: 38.078125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                    frag 0 from TextNode start: 0, length: 5, rect: [103.90625,42.4375 38.078125x17.46875]
+                    frag 0 from TextNode start: 0, length: 5, rect: [103.90625,33.46875 38.078125x17.46875]
                       "false"
                   TextNode <#text>
 
 PaintableWithLines (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
-    PaintableWithLines (BlockContainer<BODY>) [8,8 784x64.875]
-      PaintableWithLines (BlockContainer<TABLE>) [8,8 137.984375x64.875]
-        PaintableWithLines (TableWrapper(anonymous)) [9,9 135.984375x62.875]
-          PaintableBox (Box(anonymous)) [9,9 135.984375x62.875]
-            PaintableBox (Box<TBODY>) [9,9 129.984375x56.875] overflow: [9,9 133.984375x60.875]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x46.9375]
+      PaintableWithLines (BlockContainer<TABLE>) [8,8 137.984375x46.9375]
+        PaintableWithLines (TableWrapper(anonymous)) [9,9 135.984375x44.9375]
+          PaintableBox (Box(anonymous)) [9,9 135.984375x44.9375]
+            PaintableBox (Box<TBODY>) [9,9 129.984375x38.9375] overflow: [9,9 133.984375x42.9375]
               PaintableBox (Box<TR>) [11,11 129.984375x19.46875] overflow: [11,11 131.984375x19.46875]
                 PaintableWithLines (BlockContainer<TD>) [11,11 89.90625x19.46875]
                   TextPaintable (TextNode<#text>)
                 PaintableWithLines (BlockContainer<TD>) [102.90625,11 40.078125x19.46875]
                   TextPaintable (TextNode<#text>)
-              PaintableBox (Box<TR>) [11,32.46875 129.984375x37.40625] overflow: [11,32.46875 131.984375x37.40625]
-                PaintableWithLines (BlockContainer<TD>) [11,32.46875 89.90625x37.40625]
+              PaintableBox (Box<TR>) [11,32.46875 129.984375x19.46875] overflow: [11,32.46875 131.984375x19.46875]
+                PaintableWithLines (BlockContainer<TD>) [11,32.46875 89.90625x19.46875]
                   TextPaintable (TextNode<#text>)
-                PaintableWithLines (BlockContainer<TD>) [102.90625,32.46875 40.078125x37.40625]
+                PaintableWithLines (BlockContainer<TD>) [102.90625,32.46875 40.078125x19.46875]
                   TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/multi-line-cell.txt
+++ b/Tests/LibWeb/Layout/expected/table/multi-line-cell.txt
@@ -1,11 +1,11 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
-    BlockContainer <body> at (8,8) content-size 784x86.8125 children: not-inline
-      TableWrapper <(anonymous)> at (8,8) content-size 81.4375x86.8125 [BFC] children: not-inline
-        Box <table> at (9,9) content-size 79.4375x84.8125 table-box [TFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x68.875 children: not-inline
+      TableWrapper <(anonymous)> at (8,8) content-size 81.4375x68.875 [BFC] children: not-inline
+        Box <table> at (9,9) content-size 79.4375x66.875 table-box [TFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tbody> at (9,9) content-size 75.4375x78.8125 table-row-group children: not-inline
+          Box <tbody> at (9,9) content-size 75.4375x60.875 table-row-group children: not-inline
             Box <tr> at (11,11) content-size 75.4375x21.46875 table-row children: not-inline
               BlockContainer <td> at (13,13) content-size 71.4375x17.46875 table-cell [BFC] children: inline
                 line 0 width: 7.9375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
@@ -14,30 +14,30 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (11,34.46875) content-size 75.4375x57.34375 table-row children: not-inline
-              BlockContainer <td> at (13,45.4375) content-size 71.4375x35.40625 table-cell [BFC] children: inline
+            Box <tr> at (11,34.46875) content-size 75.4375x39.40625 table-row children: not-inline
+              BlockContainer <td> at (13,36.46875) content-size 71.4375x35.40625 table-cell [BFC] children: inline
                 line 0 width: 71.4375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 9, rect: [13,45.4375 71.4375x17.46875]
+                  frag 0 from TextNode start: 0, length: 9, rect: [13,36.46875 71.4375x17.46875]
                     "*********"
                 line 1 width: 63.5625, height: 17.9375, bottom: 35.40625, baseline: 13.53125
-                  frag 0 from TextNode start: 10, length: 8, rect: [13,62.4375 63.5625x17.46875]
+                  frag 0 from TextNode start: 10, length: 8, rect: [13,53.46875 63.5625x17.46875]
                     "***** **"
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-      BlockContainer <(anonymous)> at (8,94.8125) content-size 784x0 children: inline
+      BlockContainer <(anonymous)> at (8,76.875) content-size 784x0 children: inline
         TextNode <#text>
 
 PaintableWithLines (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
-    PaintableWithLines (BlockContainer<BODY>) [8,8 784x86.8125]
-      PaintableWithLines (TableWrapper(anonymous)) [8,8 81.4375x86.8125]
-        PaintableBox (Box<TABLE>) [8,8 81.4375x86.8125]
-          PaintableBox (Box<TBODY>) [9,9 75.4375x78.8125] overflow: [9,9 77.4375x82.8125]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x68.875]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 81.4375x68.875]
+        PaintableBox (Box<TABLE>) [8,8 81.4375x68.875]
+          PaintableBox (Box<TBODY>) [9,9 75.4375x60.875] overflow: [9,9 77.4375x64.875]
             PaintableBox (Box<TR>) [11,11 75.4375x21.46875]
               PaintableWithLines (BlockContainer<TD>) [11,11 75.4375x21.46875]
                 TextPaintable (TextNode<#text>)
-            PaintableBox (Box<TR>) [11,34.46875 75.4375x57.34375]
-              PaintableWithLines (BlockContainer<TD>) [11,34.46875 75.4375x57.34375]
+            PaintableBox (Box<TR>) [11,34.46875 75.4375x39.40625]
+              PaintableWithLines (BlockContainer<TD>) [11,34.46875 75.4375x39.40625]
                 TextPaintable (TextNode<#text>)
-      PaintableWithLines (BlockContainer(anonymous)) [8,94.8125 784x0]
+      PaintableWithLines (BlockContainer(anonymous)) [8,76.875 784x0]

--- a/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -219,7 +219,7 @@ void TableFormattingContext::compute_constrainedness()
     }
 }
 
-void TableFormattingContext::compute_cell_measures(AvailableSpace const& available_space)
+void TableFormattingContext::compute_cell_measures()
 {
     // Implements https://www.w3.org/TR/css-tables-3/#computing-cell-measures.
     auto const& containing_block = m_state.get(*table_wrapper().containing_block());
@@ -241,10 +241,10 @@ void TableFormattingContext::compute_cell_measures(AvailableSpace const& availab
         CSSPixels border_left = use_collapsing_borders_model ? round(cell_state.border_left / 2) : computed_values.border_left().width;
         CSSPixels border_right = use_collapsing_borders_model ? round(cell_state.border_right / 2) : computed_values.border_right().width;
 
-        auto min_content_height = calculate_min_content_height(cell.box, available_space.width.to_px_or_zero());
-        auto max_content_height = calculate_max_content_height(cell.box, available_space.width.to_px_or_zero());
         auto min_content_width = calculate_min_content_width(cell.box);
         auto max_content_width = calculate_max_content_width(cell.box);
+        auto min_content_height = calculate_min_content_height(cell.box, max_content_width);
+        auto max_content_height = calculate_max_content_height(cell.box, min_content_width);
 
         // The outer min-content height of a table-cell is max(min-height, min-content height) adjusted by the cell intrinsic offsets.
         auto min_height = computed_values.min_height().to_px(cell.box, containing_block.content_height());
@@ -1673,7 +1673,7 @@ void TableFormattingContext::run(Box const& box, LayoutMode layout_mode, Availab
     border_conflict_resolution();
 
     // Compute the minimum width of each column.
-    compute_cell_measures(available_space);
+    compute_cell_measures();
     compute_outer_content_sizes();
     compute_table_measures<Column>();
 

--- a/Userland/Libraries/LibWeb/Layout/TableFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/TableFormattingContext.h
@@ -39,7 +39,7 @@ private:
     CSSPixels compute_capmin();
     void calculate_row_column_grid(Box const&);
     void compute_constrainedness();
-    void compute_cell_measures(AvailableSpace const& available_space);
+    void compute_cell_measures();
     void compute_outer_content_sizes();
     template<class RowOrColumn>
     void initialize_table_measures();


### PR DESCRIPTION
Overall available width should only affect later stages of the table layout algorithm and have no impact on cell measures.