### PR TITLE
Ports/ja2: Add launcher icon

### DIFF
--- a/Ports/ja2/package.sh
+++ b/Ports/ja2/package.sh
@@ -6,7 +6,9 @@ workdir="ja2-stracciatella-${version}"
 files=(
     "https://github.com/ja2-stracciatella/ja2-stracciatella/archive/refs/heads/${version}.zip 178375de4859d16a76276c781455bf48d3fa862841387c8aa6cfa4162f4f0ca4"
 )
-makeopts="SERENITY=1"
+makeopts+=(
+    'SERENITY=1'
+)
 launcher_name="Jagged Alliance 2"
 launcher_category=Games
 launcher_command="/opt/ja2/ja2"

--- a/Ports/ja2/package.sh
+++ b/Ports/ja2/package.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env -S bash ../.port_include.sh
-port=ja2
-version=0.15.x
-depends=("SDL2")
+port='ja2'
+version='0.15.x'
+depends=(
+    'SDL2'
+)
 workdir="ja2-stracciatella-${version}"
 files=(
     "https://github.com/ja2-stracciatella/ja2-stracciatella/archive/refs/heads/${version}.zip 178375de4859d16a76276c781455bf48d3fa862841387c8aa6cfa4162f4f0ca4"
@@ -9,9 +11,9 @@ files=(
 makeopts+=(
     'SERENITY=1'
 )
-launcher_name="Jagged Alliance 2"
-launcher_category=Games
-launcher_command="/opt/ja2/ja2"
+launcher_name='Jagged Alliance 2'
+launcher_category='Games'
+launcher_command='/opt/ja2/ja2'
 icon_file='Build/Res/jagged3.ico'
 
 install() {

--- a/Ports/ja2/package.sh
+++ b/Ports/ja2/package.sh
@@ -12,6 +12,7 @@ makeopts+=(
 launcher_name="Jagged Alliance 2"
 launcher_category=Games
 launcher_command="/opt/ja2/ja2"
+icon_file='Build/Res/jagged3.ico'
 
 install() {
     installdir="${SERENITY_INSTALL_ROOT}/opt/ja2"


### PR DESCRIPTION
This PR adds a launcher icon to the Jagged Alliance 2 port. It also ensures that the build is done in parallel by not overwriting the default `makeopts`.