### PR TITLE
Ports/cmatrix: Install binary to `/usr/local/bin`

### DIFF
--- a/Ports/cmatrix/package.sh
+++ b/Ports/cmatrix/package.sh
@@ -9,7 +9,7 @@ files=(
 )
 launcher_name=cmatrix
 launcher_category=Games
-launcher_command=cmatrix
+launcher_command='/usr/local/bin/cmatrix'
 launcher_run_in_terminal=true
 
 configure() {
@@ -17,5 +17,6 @@ configure() {
 }
 
 install() {
-    run cp cmatrix "${SERENITY_INSTALL_ROOT}/bin"
+    mkdir -p "${SERENITY_INSTALL_ROOT}/usr/local/bin"
+    run cp cmatrix "${SERENITY_INSTALL_ROOT}/usr/local/bin"
 }

--- a/Ports/cmatrix/package.sh
+++ b/Ports/cmatrix/package.sh
@@ -1,16 +1,20 @@
 #!/usr/bin/env -S bash ../.port_include.sh
-port=cmatrix
-useconfigure=true
-version=3112b127babe72d2222059edd2d7eb7fb8bddfb1
-depends=("ncurses")
-configopts=("-DCMAKE_TOOLCHAIN_FILE=${SERENITY_BUILD_DIR}/CMakeToolchain.txt")
+port='cmatrix'
+useconfigure='true'
+version='3112b127babe72d2222059edd2d7eb7fb8bddfb1'
+depends=(
+    'ncurses'
+)
+configopts=(
+    "-DCMAKE_TOOLCHAIN_FILE=${SERENITY_BUILD_DIR}/CMakeToolchain.txt"
+)
 files=(
     "https://github.com/abishekvashok/cmatrix/archive/${version}.tar.gz a1d313d49a39cb5ae3a1c675872712f9f871114a161c38cbe94ce78967825f87"
 )
-launcher_name=cmatrix
-launcher_category=Games
+launcher_name='cmatrix'
+launcher_category='Games'
 launcher_command='/usr/local/bin/cmatrix'
-launcher_run_in_terminal=true
+launcher_run_in_terminal='true'
 
 configure() {
     run cmake "${configopts[@]}"


### PR DESCRIPTION
This PR updates the `cmatrix` port to install the binary to `/usr/local/bin` and corrects the launcher command path.