### PR TITLE
Ports/nyancat: Use the correct launcher command path

### DIFF
--- a/Ports/nyancat/package.sh
+++ b/Ports/nyancat/package.sh
@@ -8,5 +8,5 @@ files=(
 )
 launcher_name=Nyancat
 launcher_category=Games
-launcher_command=nyancat
+launcher_command='/usr/local/bin/nyancat'
 launcher_run_in_terminal=true

--- a/Ports/nyancat/package.sh
+++ b/Ports/nyancat/package.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env -S bash ../.port_include.sh
 port=nyancat
 version=git
-workdir=nyancat-master
+commit_hash='5ffb6c5c03d0e9156db8f360599d4f0449bb16b9'
+workdir="nyancat-${commit_hash}"
 files=(
-    "https://github.com/klange/nyancat/archive/master.tar.gz cfd6c817f25adcecc9490321991ecb571bfdfe0d8c249663843d3df4194f935d"
+    "https://github.com/klange/nyancat/archive/${commit_hash}.tar.gz d9c3ea82ce59f0d7db86db9e8a626f8f8fa2fbd9544104557e4c59a31893ca31"
 )
 launcher_name=Nyancat
 launcher_category=Games

--- a/Ports/nyancat/package.sh
+++ b/Ports/nyancat/package.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env -S bash ../.port_include.sh
-port=nyancat
-version=git
+port='nyancat'
+version='git'
 commit_hash='5ffb6c5c03d0e9156db8f360599d4f0449bb16b9'
 workdir="nyancat-${commit_hash}"
 files=(
     "https://github.com/klange/nyancat/archive/${commit_hash}.tar.gz d9c3ea82ce59f0d7db86db9e8a626f8f8fa2fbd9544104557e4c59a31893ca31"
 )
-launcher_name=Nyancat
-launcher_category=Games
+launcher_name='Nyancat'
+launcher_category='Games'
 launcher_command='/usr/local/bin/nyancat'
-launcher_run_in_terminal=true
+launcher_run_in_terminal='true'


### PR DESCRIPTION
This PR updates the `nyancat` port to use the correct `launcher_command` path. It also now fetches from a specific commit (the latest) rather than the `master` branch` to avoid potential future sha256 mismatches.