### PR TITLE
Ports/vitetris: Use correct launcher command path

### DIFF
--- a/Ports/vitetris/package.sh
+++ b/Ports/vitetris/package.sh
@@ -8,7 +8,7 @@ files=(
 configopts=("--without-xlib" "--without-joystick" "--without-network")
 launcher_name=vitetris
 launcher_category=Games
-launcher_command=tetris
+launcher_command='/usr/local/bin/tetris'
 launcher_run_in_terminal=true
 
 configure() {

--- a/Ports/vitetris/package.sh
+++ b/Ports/vitetris/package.sh
@@ -1,17 +1,21 @@
 #!/usr/bin/env -S bash ../.port_include.sh
-port=vitetris
-useconfigure="true"
-version="0.59.1"
+port='vitetris'
+useconfigure='true'
+version='0.59.1'
 files=(
     "https://github.com/vicgeralds/vitetris/archive/refs/tags/v${version}.tar.gz 699443df03c8d4bf2051838c1015da72039bbbdd0ab0eede891c59c840bdf58d"
 )
-configopts=("--without-xlib" "--without-joystick" "--without-network")
-launcher_name=vitetris
-launcher_category=Games
+configopts=(
+    '--without-xlib'
+    '--without-joystick'
+    '--without-network'
+)
+launcher_name='vitetris'
+launcher_category='Games'
 launcher_command='/usr/local/bin/tetris'
-launcher_run_in_terminal=true
+launcher_run_in_terminal='true'
 
 configure() {
-    run chmod +x "$configscript"
-    run ./"$configscript" "${configopts[@]}"
+    run chmod +x "${configscript}"
+    run "./${configscript}" "${configopts[@]}"
 }


### PR DESCRIPTION
There is an icon in the `vitetris` repository, but I decided against using it. It's an odd size, which results in our resized icon looking a little :yakid2:.