### PR TITLE
LibJS: Mark classes and virtual functions `final` where possible

### DIFF
--- a/Userland/Libraries/LibJS/AST.h
+++ b/Userland/Libraries/LibJS/AST.h
@@ -156,7 +156,7 @@ public:
 };
 
 // 14.13 Labelled Statements, https://tc39.es/ecma262/#sec-labelled-statements
-class LabelledStatement : public Statement {
+class LabelledStatement final : public Statement {
 public:
     LabelledStatement(SourceRange source_range, DeprecatedFlyString label, NonnullRefPtr<Statement const> labelled_item)
         : Statement(move(source_range))

--- a/Userland/Libraries/LibJS/CyclicModule.h
+++ b/Userland/Libraries/LibJS/CyclicModule.h
@@ -27,8 +27,8 @@ class CyclicModule : public Module {
 public:
     // Note: Do not call these methods directly unless you are HostResolveImportedModule.
     //       Badges cannot be used because other hosts must be able to call this (and it is called recursively)
-    virtual ThrowCompletionOr<void> link(VM& vm) override;
-    virtual ThrowCompletionOr<Promise*> evaluate(VM& vm) override;
+    virtual ThrowCompletionOr<void> link(VM& vm) override final;
+    virtual ThrowCompletionOr<Promise*> evaluate(VM& vm) override final;
 
     Vector<ModuleRequest> const& requested_modules() const { return m_requested_modules; }
 
@@ -37,8 +37,8 @@ protected:
 
     virtual void visit_edges(Cell::Visitor&) override;
 
-    virtual ThrowCompletionOr<u32> inner_module_linking(VM& vm, Vector<Module*>& stack, u32 index) override;
-    virtual ThrowCompletionOr<u32> inner_module_evaluation(VM& vm, Vector<Module*>& stack, u32 index) override;
+    virtual ThrowCompletionOr<u32> inner_module_linking(VM& vm, Vector<Module*>& stack, u32 index) override final;
+    virtual ThrowCompletionOr<u32> inner_module_evaluation(VM& vm, Vector<Module*>& stack, u32 index) override final;
 
     virtual ThrowCompletionOr<void> initialize_environment(VM& vm);
     virtual ThrowCompletionOr<void> execute_module(VM& vm, GCPtr<PromiseCapability> capability = {});

--- a/Userland/Libraries/LibJS/Heap/Cell.h
+++ b/Userland/Libraries/LibJS/Heap/Cell.h
@@ -87,7 +87,6 @@ public:
         virtual ~Visitor() = default;
     };
 
-    virtual bool is_environment() const { return false; }
     virtual void visit_edges(Visitor&) { }
 
     // This will be called on unmarked objects by the garbage collector in a separate pass before destruction.

--- a/Userland/Libraries/LibJS/Heap/MarkedVector.h
+++ b/Userland/Libraries/LibJS/Heap/MarkedVector.h
@@ -33,7 +33,7 @@ public:
 };
 
 template<typename T, size_t inline_capacity>
-class MarkedVector
+class MarkedVector final
     : public MarkedVectorBase
     , public Vector<T, inline_capacity> {
 

--- a/Userland/Libraries/LibJS/Runtime/Array.h
+++ b/Userland/Libraries/LibJS/Runtime/Array.h
@@ -40,10 +40,10 @@ public:
 
     virtual ~Array() override = default;
 
-    virtual ThrowCompletionOr<Optional<PropertyDescriptor>> internal_get_own_property(PropertyKey const&) const override;
-    virtual ThrowCompletionOr<bool> internal_define_own_property(PropertyKey const&, PropertyDescriptor const&) override;
-    virtual ThrowCompletionOr<bool> internal_delete(PropertyKey const&) override;
-    virtual ThrowCompletionOr<MarkedVector<Value>> internal_own_property_keys() const override;
+    virtual ThrowCompletionOr<Optional<PropertyDescriptor>> internal_get_own_property(PropertyKey const&) const override final;
+    virtual ThrowCompletionOr<bool> internal_define_own_property(PropertyKey const&, PropertyDescriptor const&) override final;
+    virtual ThrowCompletionOr<bool> internal_delete(PropertyKey const&) override final;
+    virtual ThrowCompletionOr<MarkedVector<Value>> internal_own_property_keys() const override final;
 
     [[nodiscard]] bool length_is_writable() const { return m_length_writable; }
 

--- a/Userland/Libraries/LibJS/Runtime/DeclarativeEnvironment.h
+++ b/Userland/Libraries/LibJS/Runtime/DeclarativeEnvironment.h
@@ -32,11 +32,11 @@ public:
 
     virtual ~DeclarativeEnvironment() override = default;
 
-    virtual ThrowCompletionOr<bool> has_binding(DeprecatedFlyString const& name, Optional<size_t>* = nullptr) const override;
-    virtual ThrowCompletionOr<void> create_mutable_binding(VM&, DeprecatedFlyString const& name, bool can_be_deleted) override;
-    virtual ThrowCompletionOr<void> create_immutable_binding(VM&, DeprecatedFlyString const& name, bool strict) override;
-    virtual ThrowCompletionOr<void> initialize_binding(VM&, DeprecatedFlyString const& name, Value, InitializeBindingHint) override;
-    virtual ThrowCompletionOr<void> set_mutable_binding(VM&, DeprecatedFlyString const& name, Value, bool strict) override;
+    virtual ThrowCompletionOr<bool> has_binding(DeprecatedFlyString const& name, Optional<size_t>* = nullptr) const override final;
+    virtual ThrowCompletionOr<void> create_mutable_binding(VM&, DeprecatedFlyString const& name, bool can_be_deleted) override final;
+    virtual ThrowCompletionOr<void> create_immutable_binding(VM&, DeprecatedFlyString const& name, bool strict) override final;
+    virtual ThrowCompletionOr<void> initialize_binding(VM&, DeprecatedFlyString const& name, Value, InitializeBindingHint) override final;
+    virtual ThrowCompletionOr<void> set_mutable_binding(VM&, DeprecatedFlyString const& name, Value, bool strict) override final;
     virtual ThrowCompletionOr<Value> get_binding_value(VM&, DeprecatedFlyString const& name, bool strict) override;
     virtual ThrowCompletionOr<bool> delete_binding(VM&, DeprecatedFlyString const& name) override;
 

--- a/Userland/Libraries/LibJS/Runtime/Environment.h
+++ b/Userland/Libraries/LibJS/Runtime/Environment.h
@@ -63,8 +63,6 @@ protected:
     virtual void visit_edges(Visitor&) override;
 
 private:
-    virtual bool is_environment() const final { return true; }
-
     bool m_permanently_screwed_by_eval { false };
 
     GCPtr<Environment> m_outer_environment;

--- a/Userland/Libraries/LibJS/Runtime/Object.h
+++ b/Userland/Libraries/LibJS/Runtime/Object.h
@@ -164,7 +164,7 @@ public:
     void define_direct_accessor(PropertyKey const&, FunctionObject* getter, FunctionObject* setter, PropertyAttributes attributes);
 
     using IntrinsicAccessor = Value (*)(Realm&);
-    virtual void define_intrinsic_accessor(PropertyKey const&, PropertyAttributes attributes, IntrinsicAccessor accessor);
+    void define_intrinsic_accessor(PropertyKey const&, PropertyAttributes attributes, IntrinsicAccessor accessor);
 
     void define_native_function(Realm&, PropertyKey const&, SafeFunction<ThrowCompletionOr<Value>(VM&)>, i32 length, PropertyAttributes attributes);
     void define_native_accessor(Realm&, PropertyKey const&, SafeFunction<ThrowCompletionOr<Value>(VM&)> getter, SafeFunction<ThrowCompletionOr<Value>(VM&)> setter, PropertyAttributes attributes);

--- a/Userland/Libraries/LibJS/Runtime/ObjectEnvironment.h
+++ b/Userland/Libraries/LibJS/Runtime/ObjectEnvironment.h
@@ -10,7 +10,7 @@
 
 namespace JS {
 
-class ObjectEnvironment : public Environment {
+class ObjectEnvironment final : public Environment {
     JS_ENVIRONMENT(ObjectEnvironment, Environment);
 
 public:


### PR DESCRIPTION
These cases were found with GCC's `-Wsuggest-final-{types,methods}` warnings, which catch calls that could have been devirtualized had we declared the functions `final` in the source.

To reproduce, Link Time Optimization needs to be enabled. The easiest way to achieve this is to set the `CMAKE_INTERPROCEDURAL_OPTIMIZATION` cache variable to `ON`. The `.incbin` directive in LibCompress' Brotli decompressor might needs to be changed to an absolute path for this to work.

This commit also removes a pair of unused virtual functions.