### PR TITLE
LibJS: Make Heap::allocate<T>() infallible

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -3473,7 +3473,7 @@ JS::ThrowCompletionOr<JS::NonnullGCPtr<JS::Object>> @constructor_class@::constru
         // 3. Set element's namespace to the HTML namespace.
         // 4. Set element's namespace prefix to null.
         // 5. Set element's local name to definition's local name.
-        auto element = realm.heap().allocate<@fully_qualified_name@>(realm, window.associated_document(), DOM::QualifiedName { definition->local_name().to_deprecated_string(), {}, Namespace::HTML }).release_allocated_value_but_fixme_should_propagate_errors();
+        auto element = realm.heap().allocate<@fully_qualified_name@>(realm, window.associated_document(), DOM::QualifiedName { definition->local_name().to_deprecated_string(), {}, Namespace::HTML });
 
         // https://webidl.spec.whatwg.org/#internally-create-a-new-object-implementing-the-interface
         // Important steps from "internally create a new object implementing the interface"

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateWindowOrWorkerInterfaces.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateWindowOrWorkerInterfaces.cpp
@@ -157,7 +157,7 @@ namespace Web::Bindings {
 template<>
 void Intrinsics::create_web_namespace<@namespace_class@>(JS::Realm& realm)
 {
-    auto namespace_object = heap().allocate<@namespace_class@>(realm, realm).release_allocated_value_but_fixme_should_propagate_errors();
+    auto namespace_object = heap().allocate<@namespace_class@>(realm, realm);
     m_namespaces.set("@interface_name@"sv, namespace_object);
 
     [[maybe_unused]] static constexpr u8 attr = JS::Attribute::Writable | JS::Attribute::Configurable;)~~~");
@@ -189,10 +189,10 @@ void Intrinsics::create_web_prototype_and_constructor<@prototype_class@>(JS::Rea
 {
     auto& vm = realm.vm();
 
-    auto prototype = heap().allocate<@prototype_class@>(realm, realm).release_allocated_value_but_fixme_should_propagate_errors();
+    auto prototype = heap().allocate<@prototype_class@>(realm, realm);
     m_prototypes.set("@interface_name@"sv, prototype);
 
-    auto constructor = heap().allocate<@constructor_class@>(realm, realm).release_allocated_value_but_fixme_should_propagate_errors();
+    auto constructor = heap().allocate<@constructor_class@>(realm, realm);
     m_constructors.set("@interface_name@"sv, constructor);
 
     prototype->define_direct_property(vm.names.constructor, constructor.ptr(), JS::Attribute::Writable | JS::Attribute::Configurable);
@@ -203,7 +203,7 @@ void Intrinsics::create_web_prototype_and_constructor<@prototype_class@>(JS::Rea
             gen.set("legacy_interface_name", legacy_constructor->name);
             gen.set("legacy_constructor_class", legacy_constructor->constructor_class);
             gen.append(R"~~~(
-    auto legacy_constructor = heap().allocate<@legacy_constructor_class@>(realm, realm).release_allocated_value_but_fixme_should_propagate_errors();
+    auto legacy_constructor = heap().allocate<@legacy_constructor_class@>(realm, realm);
     m_constructors.set("@legacy_interface_name@"sv, legacy_constructor);
 
     legacy_constructor->define_direct_property(vm.names.name, JS::PrimitiveString::create(vm, "@legacy_interface_name@"_string), JS::Attribute::Configurable);)~~~");

--- a/Tests/LibWasm/test-wasm.cpp
+++ b/Tests/LibWasm/test-wasm.cpp
@@ -56,7 +56,7 @@ public:
     static JS::ThrowCompletionOr<WebAssemblyModule*> create(JS::Realm& realm, Wasm::Module module, HashMap<Wasm::Linker::Name, Wasm::ExternValue> const& imports)
     {
         auto& vm = realm.vm();
-        auto instance = MUST_OR_THROW_OOM(realm.heap().allocate<WebAssemblyModule>(realm, realm.intrinsics().object_prototype()));
+        auto instance = realm.heap().allocate<WebAssemblyModule>(realm, realm.intrinsics().object_prototype());
         instance->m_module = move(module);
         Wasm::Linker linker(*instance->m_module);
         linker.link(imports);

--- a/Userland/Applications/Spreadsheet/Workbook.cpp
+++ b/Userland/Applications/Spreadsheet/Workbook.cpp
@@ -28,7 +28,7 @@ Workbook::Workbook(Vector<NonnullRefPtr<Sheet>>&& sheets, GUI::Window& parent_wi
 {
     auto& realm = *m_root_execution_context->realm;
     auto& vm = realm.vm();
-    m_workbook_object = vm.heap().allocate<WorkbookObject>(realm, realm, *this).release_allocated_value_but_fixme_should_propagate_errors();
+    m_workbook_object = vm.heap().allocate<WorkbookObject>(realm, realm, *this);
     realm.global_object().define_direct_property("workbook", workbook_object(), JS::default_attributes);
 
     m_main_execution_context.this_value = &realm.global_object();

--- a/Userland/Libraries/LibJS/Contrib/Test262/262Object.cpp
+++ b/Userland/Libraries/LibJS/Contrib/Test262/262Object.cpp
@@ -30,8 +30,8 @@ void $262Object::initialize(Realm& realm)
 {
     Base::initialize(realm);
 
-    m_agent = MUST(vm().heap().allocate<AgentObject>(realm, realm));
-    m_is_htmldda = MUST(vm().heap().allocate<IsHTMLDDA>(realm, realm));
+    m_agent = vm().heap().allocate<AgentObject>(realm, realm);
+    m_is_htmldda = vm().heap().allocate<IsHTMLDDA>(realm, realm);
 
     u8 attr = Attribute::Writable | Attribute::Configurable;
     define_native_function(realm, "clearKeptObjects", clear_kept_objects, 0, attr);

--- a/Userland/Libraries/LibJS/Contrib/Test262/GlobalObject.cpp
+++ b/Userland/Libraries/LibJS/Contrib/Test262/GlobalObject.cpp
@@ -18,7 +18,7 @@ void GlobalObject::initialize(Realm& realm)
 {
     Base::initialize(realm);
 
-    m_$262 = MUST(vm().heap().allocate<$262Object>(realm, realm));
+    m_$262 = vm().heap().allocate<$262Object>(realm, realm);
 
     // https://github.com/tc39/test262/blob/master/INTERPRETING.md#host-defined-functions
     u8 attr = Attribute::Writable | Attribute::Configurable;

--- a/Userland/Libraries/LibJS/Heap/Heap.h
+++ b/Userland/Libraries/LibJS/Heap/Heap.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2020-2023, Andreas Kling <kling@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -43,7 +43,7 @@ public:
     }
 
     template<typename T, typename... Args>
-    ThrowCompletionOr<NonnullGCPtr<T>> allocate(Realm& realm, Args&&... args)
+    NonnullGCPtr<T> allocate(Realm& realm, Args&&... args)
     {
         auto* memory = allocate_cell(sizeof(T));
         new (memory) T(forward<Args>(args)...);

--- a/Userland/Libraries/LibJS/Module.cpp
+++ b/Userland/Libraries/LibJS/Module.cpp
@@ -114,7 +114,7 @@ Object* Module::module_namespace_create(VM& vm, Vector<DeprecatedFlyString> unam
     // 6. Let sortedExports be a List whose elements are the elements of exports ordered as if an Array of the same values had been sorted using %Array.prototype.sort% using undefined as comparefn.
     // 7. Set M.[[Exports]] to sortedExports.
     // 8. Create own properties of M corresponding to the definitions in 28.3.
-    auto module_namespace = vm.heap().allocate<ModuleNamespaceObject>(realm, realm, this, move(unambiguous_names)).release_allocated_value_but_fixme_should_propagate_errors();
+    auto module_namespace = vm.heap().allocate<ModuleNamespaceObject>(realm, realm, this, move(unambiguous_names));
 
     // 9. Set module.[[Namespace]] to M.
     m_namespace = make_handle(module_namespace);

--- a/Userland/Libraries/LibJS/Runtime/AbstractOperations.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AbstractOperations.cpp
@@ -1103,7 +1103,7 @@ Object* create_mapped_arguments_object(VM& vm, FunctionObject& function, Vector<
     // 7. Set obj.[[Set]] as specified in 10.4.4.4.
     // 8. Set obj.[[Delete]] as specified in 10.4.4.5.
     // 9. Set obj.[[Prototype]] to %Object.prototype%.
-    auto object = vm.heap().allocate<ArgumentsObject>(realm, realm, environment).release_allocated_value_but_fixme_should_propagate_errors();
+    auto object = vm.heap().allocate<ArgumentsObject>(realm, realm, environment);
 
     // 14. Let index be 0.
     // 15. Repeat, while index < len,

--- a/Userland/Libraries/LibJS/Runtime/AbstractOperations.h
+++ b/Userland/Libraries/LibJS/Runtime/AbstractOperations.h
@@ -149,7 +149,7 @@ ThrowCompletionOr<NonnullGCPtr<T>> ordinary_create_from_constructor(VM& vm, Func
 {
     auto& realm = *vm.current_realm();
     auto* prototype = TRY(get_prototype_from_constructor(vm, constructor, intrinsic_default_prototype));
-    return MUST_OR_THROW_OOM(realm.heap().allocate<T>(realm, forward<Args>(args)..., *prototype));
+    return realm.heap().allocate<T>(realm, forward<Args>(args)..., *prototype);
 }
 
 // 14.1 MergeLists ( a, b ), https://tc39.es/proposal-temporal/#sec-temporal-mergelists

--- a/Userland/Libraries/LibJS/Runtime/AggregateError.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AggregateError.cpp
@@ -12,7 +12,7 @@ namespace JS {
 
 NonnullGCPtr<AggregateError> AggregateError::create(Realm& realm)
 {
-    return realm.heap().allocate<AggregateError>(realm, realm.intrinsics().aggregate_error_prototype()).release_allocated_value_but_fixme_should_propagate_errors();
+    return realm.heap().allocate<AggregateError>(realm, realm.intrinsics().aggregate_error_prototype());
 }
 
 AggregateError::AggregateError(Object& prototype)

--- a/Userland/Libraries/LibJS/Runtime/Array.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Array.cpp
@@ -32,7 +32,7 @@ ThrowCompletionOr<NonnullGCPtr<Array>> Array::create(Realm& realm, u64 length, O
     // 3. Let A be MakeBasicObject(« [[Prototype]], [[Extensible]] »).
     // 4. Set A.[[Prototype]] to proto.
     // 5. Set A.[[DefineOwnProperty]] as specified in 10.4.2.1.
-    auto array = MUST_OR_THROW_OOM(realm.heap().allocate<Array>(realm, *prototype));
+    auto array = realm.heap().allocate<Array>(realm, *prototype);
 
     // 6. Perform ! OrdinaryDefineOwnProperty(A, "length", PropertyDescriptor { [[Value]]: 𝔽(length), [[Writable]]: true, [[Enumerable]]: false, [[Configurable]]: false }).
     MUST(array->internal_define_own_property(vm.names.length, { .value = Value(length), .writable = true, .enumerable = false, .configurable = false }));

--- a/Userland/Libraries/LibJS/Runtime/ArrayBuffer.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayBuffer.cpp
@@ -17,17 +17,17 @@ ThrowCompletionOr<NonnullGCPtr<ArrayBuffer>> ArrayBuffer::create(Realm& realm, s
     if (buffer.is_error())
         return realm.vm().throw_completion<RangeError>(ErrorType::NotEnoughMemoryToAllocate, byte_length);
 
-    return MUST_OR_THROW_OOM(realm.heap().allocate<ArrayBuffer>(realm, buffer.release_value(), realm.intrinsics().array_buffer_prototype()));
+    return realm.heap().allocate<ArrayBuffer>(realm, buffer.release_value(), realm.intrinsics().array_buffer_prototype());
 }
 
 NonnullGCPtr<ArrayBuffer> ArrayBuffer::create(Realm& realm, ByteBuffer buffer)
 {
-    return realm.heap().allocate<ArrayBuffer>(realm, move(buffer), realm.intrinsics().array_buffer_prototype()).release_allocated_value_but_fixme_should_propagate_errors();
+    return realm.heap().allocate<ArrayBuffer>(realm, move(buffer), realm.intrinsics().array_buffer_prototype());
 }
 
 NonnullGCPtr<ArrayBuffer> ArrayBuffer::create(Realm& realm, ByteBuffer* buffer)
 {
-    return realm.heap().allocate<ArrayBuffer>(realm, buffer, realm.intrinsics().array_buffer_prototype()).release_allocated_value_but_fixme_should_propagate_errors();
+    return realm.heap().allocate<ArrayBuffer>(realm, buffer, realm.intrinsics().array_buffer_prototype());
 }
 
 ArrayBuffer::ArrayBuffer(ByteBuffer buffer, Object& prototype)

--- a/Userland/Libraries/LibJS/Runtime/ArrayIterator.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayIterator.cpp
@@ -11,7 +11,7 @@ namespace JS {
 
 NonnullGCPtr<ArrayIterator> ArrayIterator::create(Realm& realm, Value array, Object::PropertyKind iteration_kind)
 {
-    return realm.heap().allocate<ArrayIterator>(realm, array, iteration_kind, realm.intrinsics().array_iterator_prototype()).release_allocated_value_but_fixme_should_propagate_errors();
+    return realm.heap().allocate<ArrayIterator>(realm, array, iteration_kind, realm.intrinsics().array_iterator_prototype());
 }
 
 ArrayIterator::ArrayIterator(Value array, Object::PropertyKind iteration_kind, Object& prototype)

--- a/Userland/Libraries/LibJS/Runtime/AsyncFromSyncIterator.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AsyncFromSyncIterator.cpp
@@ -13,7 +13,7 @@ namespace JS {
 
 NonnullGCPtr<AsyncFromSyncIterator> AsyncFromSyncIterator::create(Realm& realm, IteratorRecord sync_iterator_record)
 {
-    return realm.heap().allocate<AsyncFromSyncIterator>(realm, realm, sync_iterator_record).release_allocated_value_but_fixme_should_propagate_errors();
+    return realm.heap().allocate<AsyncFromSyncIterator>(realm, realm, sync_iterator_record);
 }
 
 AsyncFromSyncIterator::AsyncFromSyncIterator(Realm& realm, IteratorRecord sync_iterator_record)

--- a/Userland/Libraries/LibJS/Runtime/AsyncFunctionDriverWrapper.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AsyncFunctionDriverWrapper.cpp
@@ -14,12 +14,12 @@
 
 namespace JS {
 
-ThrowCompletionOr<Value> AsyncFunctionDriverWrapper::create(Realm& realm, GeneratorObject* generator_object)
+NonnullGCPtr<Promise> AsyncFunctionDriverWrapper::create(Realm& realm, GeneratorObject* generator_object)
 {
     auto top_level_promise = Promise::create(realm);
     // Note: This generates a handle to itself, which it clears upon completing its execution
     //       The top_level_promise is also kept alive by this Wrapper
-    auto wrapper = MUST_OR_THROW_OOM(realm.heap().allocate<AsyncFunctionDriverWrapper>(realm, realm, *generator_object, *top_level_promise));
+    auto wrapper = realm.heap().allocate<AsyncFunctionDriverWrapper>(realm, realm, *generator_object, *top_level_promise);
     // Prime the generator:
     // This runs until the first `await value;`
     wrapper->continue_async_execution(realm.vm(), js_undefined(), true, IsInitialExecution::Yes);

--- a/Userland/Libraries/LibJS/Runtime/AsyncFunctionDriverWrapper.h
+++ b/Userland/Libraries/LibJS/Runtime/AsyncFunctionDriverWrapper.h
@@ -23,7 +23,7 @@ public:
         Yes,
     };
 
-    static ThrowCompletionOr<Value> create(Realm&, GeneratorObject*);
+    [[nodiscard]] static NonnullGCPtr<Promise> create(Realm&, GeneratorObject*);
 
     virtual ~AsyncFunctionDriverWrapper() override = default;
     void visit_edges(Cell::Visitor&) override;

--- a/Userland/Libraries/LibJS/Runtime/AsyncGenerator.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AsyncGenerator.cpp
@@ -20,7 +20,7 @@ ThrowCompletionOr<NonnullGCPtr<AsyncGenerator>> AsyncGenerator::create(Realm& re
     // This is "g1.prototype" in figure-2 (https://tc39.es/ecma262/img/figure-2.png)
     auto generating_function_prototype = TRY(generating_function->get(vm.names.prototype));
     auto generating_function_prototype_object = TRY(generating_function_prototype.to_object(vm));
-    auto object = MUST_OR_THROW_OOM(realm.heap().allocate<AsyncGenerator>(realm, realm, generating_function_prototype_object, move(execution_context)));
+    auto object = realm.heap().allocate<AsyncGenerator>(realm, realm, generating_function_prototype_object, move(execution_context));
     object->m_generating_function = generating_function;
     object->m_frame = move(frame);
     object->m_previous_value = initial_value;

--- a/Userland/Libraries/LibJS/Runtime/BigIntObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/BigIntObject.cpp
@@ -11,7 +11,7 @@ namespace JS {
 
 NonnullGCPtr<BigIntObject> BigIntObject::create(Realm& realm, BigInt& bigint)
 {
-    return realm.heap().allocate<BigIntObject>(realm, bigint, realm.intrinsics().bigint_prototype()).release_allocated_value_but_fixme_should_propagate_errors();
+    return realm.heap().allocate<BigIntObject>(realm, bigint, realm.intrinsics().bigint_prototype());
 }
 
 BigIntObject::BigIntObject(BigInt& bigint, Object& prototype)

--- a/Userland/Libraries/LibJS/Runtime/BooleanObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/BooleanObject.cpp
@@ -11,7 +11,7 @@ namespace JS {
 
 NonnullGCPtr<BooleanObject> BooleanObject::create(Realm& realm, bool value)
 {
-    return realm.heap().allocate<BooleanObject>(realm, value, realm.intrinsics().boolean_prototype()).release_allocated_value_but_fixme_should_propagate_errors();
+    return realm.heap().allocate<BooleanObject>(realm, value, realm.intrinsics().boolean_prototype());
 }
 
 BooleanObject::BooleanObject(bool value, Object& prototype)

--- a/Userland/Libraries/LibJS/Runtime/BoundFunction.cpp
+++ b/Userland/Libraries/LibJS/Runtime/BoundFunction.cpp
@@ -26,7 +26,7 @@ ThrowCompletionOr<NonnullGCPtr<BoundFunction>> BoundFunction::create(Realm& real
     // 7. Set obj.[[BoundTargetFunction]] to targetFunction.
     // 8. Set obj.[[BoundThis]] to boundThis.
     // 9. Set obj.[[BoundArguments]] to boundArgs.
-    auto object = MUST_OR_THROW_OOM(realm.heap().allocate<BoundFunction>(realm, realm, target_function, bound_this, move(bound_arguments), prototype));
+    auto object = realm.heap().allocate<BoundFunction>(realm, realm, target_function, bound_this, move(bound_arguments), prototype);
 
     // 10. Return obj.
     return object;

--- a/Userland/Libraries/LibJS/Runtime/DataView.cpp
+++ b/Userland/Libraries/LibJS/Runtime/DataView.cpp
@@ -10,7 +10,7 @@ namespace JS {
 
 NonnullGCPtr<DataView> DataView::create(Realm& realm, ArrayBuffer* viewed_buffer, size_t byte_length, size_t byte_offset)
 {
-    return realm.heap().allocate<DataView>(realm, viewed_buffer, byte_length, byte_offset, realm.intrinsics().data_view_prototype()).release_allocated_value_but_fixme_should_propagate_errors();
+    return realm.heap().allocate<DataView>(realm, viewed_buffer, byte_length, byte_offset, realm.intrinsics().data_view_prototype());
 }
 
 DataView::DataView(ArrayBuffer* viewed_buffer, size_t byte_length, size_t byte_offset, Object& prototype)

--- a/Userland/Libraries/LibJS/Runtime/Date.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Date.cpp
@@ -25,7 +25,7 @@ Crypto::SignedBigInteger const ns_per_day_bigint { static_cast<i64>(ns_per_day) 
 
 NonnullGCPtr<Date> Date::create(Realm& realm, double date_value)
 {
-    return realm.heap().allocate<Date>(realm, date_value, realm.intrinsics().date_prototype()).release_allocated_value_but_fixme_should_propagate_errors();
+    return realm.heap().allocate<Date>(realm, date_value, realm.intrinsics().date_prototype());
 }
 
 Date::Date(double date_value, Object& prototype)

--- a/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
@@ -48,12 +48,12 @@ NonnullGCPtr<ECMAScriptFunctionObject> ECMAScriptFunctionObject::create(Realm& r
         prototype = realm.intrinsics().async_generator_function_prototype();
         break;
     }
-    return realm.heap().allocate<ECMAScriptFunctionObject>(realm, move(name), move(source_text), ecmascript_code, move(parameters), m_function_length, move(local_variables_names), parent_environment, private_environment, *prototype, kind, is_strict, might_need_arguments_object, contains_direct_call_to_eval, is_arrow_function, move(class_field_initializer_name)).release_allocated_value_but_fixme_should_propagate_errors();
+    return realm.heap().allocate<ECMAScriptFunctionObject>(realm, move(name), move(source_text), ecmascript_code, move(parameters), m_function_length, move(local_variables_names), parent_environment, private_environment, *prototype, kind, is_strict, might_need_arguments_object, contains_direct_call_to_eval, is_arrow_function, move(class_field_initializer_name));
 }
 
 NonnullGCPtr<ECMAScriptFunctionObject> ECMAScriptFunctionObject::create(Realm& realm, DeprecatedFlyString name, Object& prototype, DeprecatedString source_text, Statement const& ecmascript_code, Vector<FunctionParameter> parameters, i32 m_function_length, Vector<DeprecatedFlyString> local_variables_names, Environment* parent_environment, PrivateEnvironment* private_environment, FunctionKind kind, bool is_strict, bool might_need_arguments_object, bool contains_direct_call_to_eval, bool is_arrow_function, Variant<PropertyKey, PrivateName, Empty> class_field_initializer_name)
 {
-    return realm.heap().allocate<ECMAScriptFunctionObject>(realm, move(name), move(source_text), ecmascript_code, move(parameters), m_function_length, move(local_variables_names), parent_environment, private_environment, prototype, kind, is_strict, might_need_arguments_object, contains_direct_call_to_eval, is_arrow_function, move(class_field_initializer_name)).release_allocated_value_but_fixme_should_propagate_errors();
+    return realm.heap().allocate<ECMAScriptFunctionObject>(realm, move(name), move(source_text), ecmascript_code, move(parameters), m_function_length, move(local_variables_names), parent_environment, private_environment, prototype, kind, is_strict, might_need_arguments_object, contains_direct_call_to_eval, is_arrow_function, move(class_field_initializer_name));
 }
 
 ECMAScriptFunctionObject::ECMAScriptFunctionObject(DeprecatedFlyString name, DeprecatedString source_text, Statement const& ecmascript_code, Vector<FunctionParameter> formal_parameters, i32 function_length, Vector<DeprecatedFlyString> local_variables_names, Environment* parent_environment, PrivateEnvironment* private_environment, Object& prototype, FunctionKind kind, bool strict, bool might_need_arguments_object, bool contains_direct_call_to_eval, bool is_arrow_function, Variant<PropertyKey, PrivateName, Empty> class_field_initializer_name)
@@ -118,7 +118,7 @@ void ECMAScriptFunctionObject::initialize(Realm& realm)
         Object* prototype = nullptr;
         switch (m_kind) {
         case FunctionKind::Normal:
-            prototype = MUST(vm.heap().allocate<Object>(realm, realm.intrinsics().new_ordinary_function_prototype_object_shape()));
+            prototype = vm.heap().allocate<Object>(realm, realm.intrinsics().new_ordinary_function_prototype_object_shape());
             MUST(prototype->define_property_or_throw(vm.names.constructor, { .value = this, .writable = true, .enumerable = false, .configurable = true }));
             break;
         case FunctionKind::Generator:
@@ -1088,7 +1088,7 @@ Completion ECMAScriptFunctionObject::ordinary_call_evaluate_body()
     // NOTE: Async functions are entirely transformed to generator functions, and wrapped in a custom driver that returns a promise
     //       See AwaitExpression::generate_bytecode() for the transformation.
     if (m_kind == FunctionKind::Async)
-        return { Completion::Type::Return, TRY(AsyncFunctionDriverWrapper::create(realm, generator_object)), {} };
+        return { Completion::Type::Return, AsyncFunctionDriverWrapper::create(realm, generator_object), {} };
 
     VERIFY(m_kind == FunctionKind::Generator);
     return { Completion::Type::Return, generator_object, {} };

--- a/Userland/Libraries/LibJS/Runtime/Error.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Error.cpp
@@ -32,7 +32,7 @@ SourceRange const& TracebackFrame::source_range() const
 
 NonnullGCPtr<Error> Error::create(Realm& realm)
 {
-    return realm.heap().allocate<Error>(realm, realm.intrinsics().error_prototype()).release_allocated_value_but_fixme_should_propagate_errors();
+    return realm.heap().allocate<Error>(realm, realm.intrinsics().error_prototype());
 }
 
 NonnullGCPtr<Error> Error::create(Realm& realm, String message)
@@ -119,29 +119,29 @@ ThrowCompletionOr<String> Error::stack_string(VM& vm) const
     return stack_string_builder.to_string();
 }
 
-#define __JS_ENUMERATE(ClassName, snake_name, PrototypeName, ConstructorName, ArrayType)                                                                         \
-    NonnullGCPtr<ClassName> ClassName::create(Realm& realm)                                                                                                      \
-    {                                                                                                                                                            \
-        return realm.heap().allocate<ClassName>(realm, realm.intrinsics().snake_name##_prototype()).release_allocated_value_but_fixme_should_propagate_errors(); \
-    }                                                                                                                                                            \
-                                                                                                                                                                 \
-    NonnullGCPtr<ClassName> ClassName::create(Realm& realm, String message)                                                                                      \
-    {                                                                                                                                                            \
-        auto& vm = realm.vm();                                                                                                                                   \
-        auto error = ClassName::create(realm);                                                                                                                   \
-        u8 attr = Attribute::Writable | Attribute::Configurable;                                                                                                 \
-        error->define_direct_property(vm.names.message, PrimitiveString::create(vm, move(message)), attr);                                                       \
-        return error;                                                                                                                                            \
-    }                                                                                                                                                            \
-                                                                                                                                                                 \
-    ThrowCompletionOr<NonnullGCPtr<ClassName>> ClassName::create(Realm& realm, StringView message)                                                               \
-    {                                                                                                                                                            \
-        return create(realm, TRY_OR_THROW_OOM(realm.vm(), String::from_utf8(message)));                                                                          \
-    }                                                                                                                                                            \
-                                                                                                                                                                 \
-    ClassName::ClassName(Object& prototype)                                                                                                                      \
-        : Error(prototype)                                                                                                                                       \
-    {                                                                                                                                                            \
+#define __JS_ENUMERATE(ClassName, snake_name, PrototypeName, ConstructorName, ArrayType)                   \
+    NonnullGCPtr<ClassName> ClassName::create(Realm& realm)                                                \
+    {                                                                                                      \
+        return realm.heap().allocate<ClassName>(realm, realm.intrinsics().snake_name##_prototype());       \
+    }                                                                                                      \
+                                                                                                           \
+    NonnullGCPtr<ClassName> ClassName::create(Realm& realm, String message)                                \
+    {                                                                                                      \
+        auto& vm = realm.vm();                                                                             \
+        auto error = ClassName::create(realm);                                                             \
+        u8 attr = Attribute::Writable | Attribute::Configurable;                                           \
+        error->define_direct_property(vm.names.message, PrimitiveString::create(vm, move(message)), attr); \
+        return error;                                                                                      \
+    }                                                                                                      \
+                                                                                                           \
+    ThrowCompletionOr<NonnullGCPtr<ClassName>> ClassName::create(Realm& realm, StringView message)         \
+    {                                                                                                      \
+        return create(realm, TRY_OR_THROW_OOM(realm.vm(), String::from_utf8(message)));                    \
+    }                                                                                                      \
+                                                                                                           \
+    ClassName::ClassName(Object& prototype)                                                                \
+        : Error(prototype)                                                                                 \
+    {                                                                                                      \
     }
 
 JS_ENUMERATE_NATIVE_ERRORS

--- a/Userland/Libraries/LibJS/Runtime/GeneratorObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/GeneratorObject.cpp
@@ -28,7 +28,7 @@ ThrowCompletionOr<NonnullGCPtr<GeneratorObject>> GeneratorObject::create(Realm& 
         generating_function_prototype = TRY(generating_function->get(vm.names.prototype));
     }
     auto generating_function_prototype_object = TRY(generating_function_prototype.to_object(vm));
-    auto object = MUST_OR_THROW_OOM(realm.heap().allocate<GeneratorObject>(realm, realm, generating_function_prototype_object, move(execution_context)));
+    auto object = realm.heap().allocate<GeneratorObject>(realm, realm, generating_function_prototype_object, move(execution_context));
     object->m_generating_function = generating_function;
     object->m_frame = move(frame);
     object->m_previous_value = initial_value;

--- a/Userland/Libraries/LibJS/Runtime/Intl/CollatorCompareFunction.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/CollatorCompareFunction.cpp
@@ -13,7 +13,7 @@ namespace JS::Intl {
 
 NonnullGCPtr<CollatorCompareFunction> CollatorCompareFunction::create(Realm& realm, Collator& collator)
 {
-    return realm.heap().allocate<CollatorCompareFunction>(realm, realm, collator).release_allocated_value_but_fixme_should_propagate_errors();
+    return realm.heap().allocate<CollatorCompareFunction>(realm, realm, collator);
 }
 
 CollatorCompareFunction::CollatorCompareFunction(Realm& realm, Collator& collator)

--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormatFunction.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormatFunction.cpp
@@ -16,7 +16,7 @@ namespace JS::Intl {
 // 11.5.4 DateTime Format Functions, https://tc39.es/ecma402/#sec-datetime-format-functions
 NonnullGCPtr<DateTimeFormatFunction> DateTimeFormatFunction::create(Realm& realm, DateTimeFormat& date_time_format)
 {
-    return realm.heap().allocate<DateTimeFormatFunction>(realm, date_time_format, realm.intrinsics().function_prototype()).release_allocated_value_but_fixme_should_propagate_errors();
+    return realm.heap().allocate<DateTimeFormatFunction>(realm, date_time_format, realm.intrinsics().function_prototype());
 }
 
 DateTimeFormatFunction::DateTimeFormatFunction(DateTimeFormat& date_time_format, Object& prototype)

--- a/Userland/Libraries/LibJS/Runtime/Intl/Locale.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/Locale.cpp
@@ -16,7 +16,7 @@ namespace JS::Intl {
 
 ThrowCompletionOr<NonnullGCPtr<Locale>> Locale::create(Realm& realm, ::Locale::LocaleID locale_id)
 {
-    auto locale = MUST_OR_THROW_OOM(realm.heap().allocate<Locale>(realm, realm.intrinsics().intl_locale_prototype()));
+    auto locale = realm.heap().allocate<Locale>(realm, realm.intrinsics().intl_locale_prototype());
     locale->set_locale(TRY_OR_THROW_OOM(realm.vm(), locale_id.to_string()));
 
     for (auto& extension : locale_id.extensions) {

--- a/Userland/Libraries/LibJS/Runtime/Intl/NumberFormatFunction.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/NumberFormatFunction.cpp
@@ -13,7 +13,7 @@ namespace JS::Intl {
 // 15.5.2 Number Format Functions, https://tc39.es/ecma402/#sec-number-format-functions
 NonnullGCPtr<NumberFormatFunction> NumberFormatFunction::create(Realm& realm, NumberFormat& number_format)
 {
-    return realm.heap().allocate<NumberFormatFunction>(realm, number_format, realm.intrinsics().function_prototype()).release_allocated_value_but_fixme_should_propagate_errors();
+    return realm.heap().allocate<NumberFormatFunction>(realm, number_format, realm.intrinsics().function_prototype());
 }
 
 NumberFormatFunction::NumberFormatFunction(NumberFormat& number_format, Object& prototype)

--- a/Userland/Libraries/LibJS/Runtime/Intl/SegmentIterator.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/SegmentIterator.cpp
@@ -19,7 +19,7 @@ NonnullGCPtr<SegmentIterator> SegmentIterator::create(Realm& realm, Segmenter& s
     // 4. Set iterator.[[IteratedString]] to string.
     // 5. Set iterator.[[IteratedStringNextSegmentCodeUnitIndex]] to 0.
     // 6. Return iterator.
-    return realm.heap().allocate<SegmentIterator>(realm, realm, segmenter, move(string), segments).release_allocated_value_but_fixme_should_propagate_errors();
+    return realm.heap().allocate<SegmentIterator>(realm, realm, segmenter, move(string), segments);
 }
 
 // 18.6 Segment Iterator Objects, https://tc39.es/ecma402/#sec-segment-iterator-objects

--- a/Userland/Libraries/LibJS/Runtime/Intl/Segments.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/Segments.cpp
@@ -18,7 +18,7 @@ NonnullGCPtr<Segments> Segments::create(Realm& realm, Segmenter& segmenter, Utf1
     // 3. Set segments.[[SegmentsSegmenter]] to segmenter.
     // 4. Set segments.[[SegmentsString]] to string.
     // 5. Return segments.
-    return realm.heap().allocate<Segments>(realm, realm, segmenter, move(string)).release_allocated_value_but_fixme_should_propagate_errors();
+    return realm.heap().allocate<Segments>(realm, realm, segmenter, move(string));
 }
 
 // 18.5 Segments Objects, https://tc39.es/ecma402/#sec-segments-objects

--- a/Userland/Libraries/LibJS/Runtime/Intrinsics.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intrinsics.cpp
@@ -194,27 +194,27 @@ ThrowCompletionOr<void> Intrinsics::initialize_intrinsics(Realm& realm)
 
 #define __JS_ENUMERATE(ClassName, snake_name) \
     VERIFY(!m_##snake_name##_prototype);      \
-    m_##snake_name##_prototype = heap().allocate<ClassName##Prototype>(realm, realm).release_allocated_value_but_fixme_should_propagate_errors();
+    m_##snake_name##_prototype = heap().allocate<ClassName##Prototype>(realm, realm);
     JS_ENUMERATE_ITERATOR_PROTOTYPES
 #undef __JS_ENUMERATE
 
     // These must be initialized separately as they have no companion constructor
-    m_async_from_sync_iterator_prototype = heap().allocate<AsyncFromSyncIteratorPrototype>(realm, realm).release_allocated_value_but_fixme_should_propagate_errors();
-    m_async_generator_prototype = heap().allocate<AsyncGeneratorPrototype>(realm, realm).release_allocated_value_but_fixme_should_propagate_errors();
-    m_generator_prototype = heap().allocate<GeneratorPrototype>(realm, realm).release_allocated_value_but_fixme_should_propagate_errors();
-    m_intl_segments_prototype = heap().allocate<Intl::SegmentsPrototype>(realm, realm).release_allocated_value_but_fixme_should_propagate_errors();
-    m_wrap_for_valid_iterator_prototype = heap().allocate<WrapForValidIteratorPrototype>(realm, realm).release_allocated_value_but_fixme_should_propagate_errors();
+    m_async_from_sync_iterator_prototype = heap().allocate<AsyncFromSyncIteratorPrototype>(realm, realm);
+    m_async_generator_prototype = heap().allocate<AsyncGeneratorPrototype>(realm, realm);
+    m_generator_prototype = heap().allocate<GeneratorPrototype>(realm, realm);
+    m_intl_segments_prototype = heap().allocate<Intl::SegmentsPrototype>(realm, realm);
+    m_wrap_for_valid_iterator_prototype = heap().allocate<WrapForValidIteratorPrototype>(realm, realm);
 
     // These must be initialized before allocating...
     // - AggregateErrorPrototype, which uses ErrorPrototype as its prototype
     // - AggregateErrorConstructor, which uses ErrorConstructor as its prototype
     // - AsyncFunctionConstructor, which uses FunctionConstructor as its prototype
-    m_error_prototype = heap().allocate<ErrorPrototype>(realm, realm).release_allocated_value_but_fixme_should_propagate_errors();
-    m_error_constructor = heap().allocate<ErrorConstructor>(realm, realm).release_allocated_value_but_fixme_should_propagate_errors();
-    m_function_constructor = heap().allocate<FunctionConstructor>(realm, realm).release_allocated_value_but_fixme_should_propagate_errors();
+    m_error_prototype = heap().allocate<ErrorPrototype>(realm, realm);
+    m_error_constructor = heap().allocate<ErrorConstructor>(realm, realm);
+    m_function_constructor = heap().allocate<FunctionConstructor>(realm, realm);
 
     // Not included in JS_ENUMERATE_NATIVE_OBJECTS due to missing distinct prototype
-    m_proxy_constructor = heap().allocate<ProxyConstructor>(realm, realm).release_allocated_value_but_fixme_should_propagate_errors();
+    m_proxy_constructor = heap().allocate<ProxyConstructor>(realm, realm);
 
     // Global object functions
     m_eval_function = NativeFunction::create(realm, GlobalObject::eval, 1, vm.names.eval, &realm);
@@ -229,7 +229,7 @@ ThrowCompletionOr<void> Intrinsics::initialize_intrinsics(Realm& realm)
     m_escape_function = NativeFunction::create(realm, GlobalObject::escape, 1, vm.names.escape, &realm);
     m_unescape_function = NativeFunction::create(realm, GlobalObject::unescape, 1, vm.names.unescape, &realm);
 
-    m_object_constructor = heap().allocate<ObjectConstructor>(realm, realm).release_allocated_value_but_fixme_should_propagate_errors();
+    m_object_constructor = heap().allocate<ObjectConstructor>(realm, realm);
 
     // 10.2.4.1 %ThrowTypeError% ( ), https://tc39.es/ecma262/#sec-%throwtypeerror%
     m_throw_type_error_function = NativeFunction::create(
@@ -274,52 +274,52 @@ constexpr inline bool IsTypedArrayConstructor = false;
 JS_ENUMERATE_TYPED_ARRAYS
 #undef __JS_ENUMERATE
 
-#define __JS_ENUMERATE_INNER(ClassName, snake_name, PrototypeName, ConstructorName, Namespace, snake_namespace)                                                                                                    \
-    void Intrinsics::initialize_##snake_namespace##snake_name()                                                                                                                                                    \
-    {                                                                                                                                                                                                              \
-        auto& vm = this->vm();                                                                                                                                                                                     \
-                                                                                                                                                                                                                   \
-        VERIFY(!m_##snake_namespace##snake_name##_prototype);                                                                                                                                                      \
-        VERIFY(!m_##snake_namespace##snake_name##_constructor);                                                                                                                                                    \
-        if constexpr (IsTypedArrayConstructor<Namespace::ConstructorName>) {                                                                                                                                       \
-            m_##snake_namespace##snake_name##_prototype = heap().allocate<Namespace::PrototypeName>(m_realm, *typed_array_prototype()).release_allocated_value_but_fixme_should_propagate_errors();                \
-            m_##snake_namespace##snake_name##_constructor = heap().allocate<Namespace::ConstructorName>(m_realm, m_realm, *typed_array_constructor()).release_allocated_value_but_fixme_should_propagate_errors(); \
-        } else {                                                                                                                                                                                                   \
-            m_##snake_namespace##snake_name##_prototype = heap().allocate<Namespace::PrototypeName>(m_realm, m_realm).release_allocated_value_but_fixme_should_propagate_errors();                                 \
-            m_##snake_namespace##snake_name##_constructor = heap().allocate<Namespace::ConstructorName>(m_realm, m_realm).release_allocated_value_but_fixme_should_propagate_errors();                             \
-        }                                                                                                                                                                                                          \
-                                                                                                                                                                                                                   \
-        /* FIXME: Add these special cases to JS_ENUMERATE_NATIVE_OBJECTS */                                                                                                                                        \
-        if constexpr (IsSame<Namespace::ConstructorName, BigIntConstructor>)                                                                                                                                       \
-            initialize_constructor(vm, vm.names.BigInt, *m_##snake_namespace##snake_name##_constructor, m_##snake_namespace##snake_name##_prototype);                                                              \
-        else if constexpr (IsSame<Namespace::ConstructorName, BooleanConstructor>)                                                                                                                                 \
-            initialize_constructor(vm, vm.names.Boolean, *m_##snake_namespace##snake_name##_constructor, m_##snake_namespace##snake_name##_prototype);                                                             \
-        else if constexpr (IsSame<Namespace::ConstructorName, FunctionConstructor>)                                                                                                                                \
-            initialize_constructor(vm, vm.names.Function, *m_##snake_namespace##snake_name##_constructor, m_##snake_namespace##snake_name##_prototype);                                                            \
-        else if constexpr (IsSame<Namespace::ConstructorName, NumberConstructor>)                                                                                                                                  \
-            initialize_constructor(vm, vm.names.Number, *m_##snake_namespace##snake_name##_constructor, m_##snake_namespace##snake_name##_prototype);                                                              \
-        else if constexpr (IsSame<Namespace::ConstructorName, RegExpConstructor>)                                                                                                                                  \
-            initialize_constructor(vm, vm.names.RegExp, *m_##snake_namespace##snake_name##_constructor, m_##snake_namespace##snake_name##_prototype);                                                              \
-        else if constexpr (IsSame<Namespace::ConstructorName, StringConstructor>)                                                                                                                                  \
-            initialize_constructor(vm, vm.names.String, *m_##snake_namespace##snake_name##_constructor, m_##snake_namespace##snake_name##_prototype);                                                              \
-        else if constexpr (IsSame<Namespace::ConstructorName, SymbolConstructor>)                                                                                                                                  \
-            initialize_constructor(vm, vm.names.Symbol, *m_##snake_namespace##snake_name##_constructor, m_##snake_namespace##snake_name##_prototype);                                                              \
-        else                                                                                                                                                                                                       \
-            initialize_constructor(vm, vm.names.ClassName, *m_##snake_namespace##snake_name##_constructor, m_##snake_namespace##snake_name##_prototype);                                                           \
-    }                                                                                                                                                                                                              \
-                                                                                                                                                                                                                   \
-    NonnullGCPtr<Namespace::ConstructorName> Intrinsics::snake_namespace##snake_name##_constructor()                                                                                                               \
-    {                                                                                                                                                                                                              \
-        if (!m_##snake_namespace##snake_name##_constructor)                                                                                                                                                        \
-            initialize_##snake_namespace##snake_name();                                                                                                                                                            \
-        return *m_##snake_namespace##snake_name##_constructor;                                                                                                                                                     \
-    }                                                                                                                                                                                                              \
-                                                                                                                                                                                                                   \
-    NonnullGCPtr<Object> Intrinsics::snake_namespace##snake_name##_prototype()                                                                                                                                     \
-    {                                                                                                                                                                                                              \
-        if (!m_##snake_namespace##snake_name##_prototype)                                                                                                                                                          \
-            initialize_##snake_namespace##snake_name();                                                                                                                                                            \
-        return *m_##snake_namespace##snake_name##_prototype;                                                                                                                                                       \
+#define __JS_ENUMERATE_INNER(ClassName, snake_name, PrototypeName, ConstructorName, Namespace, snake_namespace)                                          \
+    void Intrinsics::initialize_##snake_namespace##snake_name()                                                                                          \
+    {                                                                                                                                                    \
+        auto& vm = this->vm();                                                                                                                           \
+                                                                                                                                                         \
+        VERIFY(!m_##snake_namespace##snake_name##_prototype);                                                                                            \
+        VERIFY(!m_##snake_namespace##snake_name##_constructor);                                                                                          \
+        if constexpr (IsTypedArrayConstructor<Namespace::ConstructorName>) {                                                                             \
+            m_##snake_namespace##snake_name##_prototype = heap().allocate<Namespace::PrototypeName>(m_realm, *typed_array_prototype());                  \
+            m_##snake_namespace##snake_name##_constructor = heap().allocate<Namespace::ConstructorName>(m_realm, m_realm, *typed_array_constructor());   \
+        } else {                                                                                                                                         \
+            m_##snake_namespace##snake_name##_prototype = heap().allocate<Namespace::PrototypeName>(m_realm, m_realm);                                   \
+            m_##snake_namespace##snake_name##_constructor = heap().allocate<Namespace::ConstructorName>(m_realm, m_realm);                               \
+        }                                                                                                                                                \
+                                                                                                                                                         \
+        /* FIXME: Add these special cases to JS_ENUMERATE_NATIVE_OBJECTS */                                                                              \
+        if constexpr (IsSame<Namespace::ConstructorName, BigIntConstructor>)                                                                             \
+            initialize_constructor(vm, vm.names.BigInt, *m_##snake_namespace##snake_name##_constructor, m_##snake_namespace##snake_name##_prototype);    \
+        else if constexpr (IsSame<Namespace::ConstructorName, BooleanConstructor>)                                                                       \
+            initialize_constructor(vm, vm.names.Boolean, *m_##snake_namespace##snake_name##_constructor, m_##snake_namespace##snake_name##_prototype);   \
+        else if constexpr (IsSame<Namespace::ConstructorName, FunctionConstructor>)                                                                      \
+            initialize_constructor(vm, vm.names.Function, *m_##snake_namespace##snake_name##_constructor, m_##snake_namespace##snake_name##_prototype);  \
+        else if constexpr (IsSame<Namespace::ConstructorName, NumberConstructor>)                                                                        \
+            initialize_constructor(vm, vm.names.Number, *m_##snake_namespace##snake_name##_constructor, m_##snake_namespace##snake_name##_prototype);    \
+        else if constexpr (IsSame<Namespace::ConstructorName, RegExpConstructor>)                                                                        \
+            initialize_constructor(vm, vm.names.RegExp, *m_##snake_namespace##snake_name##_constructor, m_##snake_namespace##snake_name##_prototype);    \
+        else if constexpr (IsSame<Namespace::ConstructorName, StringConstructor>)                                                                        \
+            initialize_constructor(vm, vm.names.String, *m_##snake_namespace##snake_name##_constructor, m_##snake_namespace##snake_name##_prototype);    \
+        else if constexpr (IsSame<Namespace::ConstructorName, SymbolConstructor>)                                                                        \
+            initialize_constructor(vm, vm.names.Symbol, *m_##snake_namespace##snake_name##_constructor, m_##snake_namespace##snake_name##_prototype);    \
+        else                                                                                                                                             \
+            initialize_constructor(vm, vm.names.ClassName, *m_##snake_namespace##snake_name##_constructor, m_##snake_namespace##snake_name##_prototype); \
+    }                                                                                                                                                    \
+                                                                                                                                                         \
+    NonnullGCPtr<Namespace::ConstructorName> Intrinsics::snake_namespace##snake_name##_constructor()                                                     \
+    {                                                                                                                                                    \
+        if (!m_##snake_namespace##snake_name##_constructor)                                                                                              \
+            initialize_##snake_namespace##snake_name();                                                                                                  \
+        return *m_##snake_namespace##snake_name##_constructor;                                                                                           \
+    }                                                                                                                                                    \
+                                                                                                                                                         \
+    NonnullGCPtr<Object> Intrinsics::snake_namespace##snake_name##_prototype()                                                                           \
+    {                                                                                                                                                    \
+        if (!m_##snake_namespace##snake_name##_prototype)                                                                                                \
+            initialize_##snake_namespace##snake_name();                                                                                                  \
+        return *m_##snake_namespace##snake_name##_prototype;                                                                                             \
     }
 
 #define __JS_ENUMERATE(ClassName, snake_name, PrototypeName, ConstructorName, ArrayType) \
@@ -339,12 +339,12 @@ JS_ENUMERATE_TEMPORAL_OBJECTS
 
 #undef __JS_ENUMERATE_INNER
 
-#define __JS_ENUMERATE(ClassName, snake_name)                                                                                                   \
-    NonnullGCPtr<ClassName> Intrinsics::snake_name##_object()                                                                                   \
-    {                                                                                                                                           \
-        if (!m_##snake_name##_object)                                                                                                           \
-            m_##snake_name##_object = heap().allocate<ClassName>(m_realm, m_realm).release_allocated_value_but_fixme_should_propagate_errors(); \
-        return *m_##snake_name##_object;                                                                                                        \
+#define __JS_ENUMERATE(ClassName, snake_name)                                       \
+    NonnullGCPtr<ClassName> Intrinsics::snake_name##_object()                       \
+    {                                                                               \
+        if (!m_##snake_name##_object)                                               \
+            m_##snake_name##_object = heap().allocate<ClassName>(m_realm, m_realm); \
+        return *m_##snake_name##_object;                                            \
     }
 JS_ENUMERATE_BUILTIN_NAMESPACE_OBJECTS
 #undef __JS_ENUMERATE

--- a/Userland/Libraries/LibJS/Runtime/Iterator.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Iterator.cpp
@@ -15,9 +15,9 @@
 
 namespace JS {
 
-ThrowCompletionOr<NonnullGCPtr<Iterator>> Iterator::create(Realm& realm, Object& prototype, IteratorRecord iterated)
+NonnullGCPtr<Iterator> Iterator::create(Realm& realm, Object& prototype, IteratorRecord iterated)
 {
-    return MUST_OR_THROW_OOM(realm.heap().allocate<Iterator>(realm, prototype, move(iterated)));
+    return realm.heap().allocate<Iterator>(realm, prototype, move(iterated));
 }
 
 Iterator::Iterator(Object& prototype, IteratorRecord iterated)

--- a/Userland/Libraries/LibJS/Runtime/Iterator.h
+++ b/Userland/Libraries/LibJS/Runtime/Iterator.h
@@ -27,7 +27,7 @@ class Iterator : public Object {
     JS_OBJECT(Iterator, Object);
 
 public:
-    static ThrowCompletionOr<NonnullGCPtr<Iterator>> create(Realm&, Object& prototype, IteratorRecord iterated);
+    static NonnullGCPtr<Iterator> create(Realm&, Object& prototype, IteratorRecord iterated);
 
     IteratorRecord const& iterated() const { return m_iterated; }
 

--- a/Userland/Libraries/LibJS/Runtime/IteratorConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/IteratorConstructor.cpp
@@ -78,7 +78,7 @@ JS_DEFINE_NATIVE_FUNCTION(IteratorConstructor::from)
 
     // 4. Let wrapper be OrdinaryObjectCreate(%WrapForValidIteratorPrototype%, « [[Iterated]] »).
     // 5. Set wrapper.[[Iterated]] to iteratorRecord.
-    auto wrapper = MUST_OR_THROW_OOM(Iterator::create(realm, realm.intrinsics().wrap_for_valid_iterator_prototype(), move(iterator_record)));
+    auto wrapper = Iterator::create(realm, realm.intrinsics().wrap_for_valid_iterator_prototype(), move(iterator_record));
 
     // 6. Return wrapper.
     return wrapper;

--- a/Userland/Libraries/LibJS/Runtime/IteratorHelper.cpp
+++ b/Userland/Libraries/LibJS/Runtime/IteratorHelper.cpp
@@ -13,7 +13,7 @@ namespace JS {
 
 ThrowCompletionOr<NonnullGCPtr<IteratorHelper>> IteratorHelper::create(Realm& realm, IteratorRecord underlying_iterator, Closure closure, Optional<AbruptClosure> abrupt_closure)
 {
-    return TRY(realm.heap().allocate<IteratorHelper>(realm, realm, realm.intrinsics().iterator_helper_prototype(), move(underlying_iterator), move(closure), move(abrupt_closure)));
+    return realm.heap().allocate<IteratorHelper>(realm, realm, realm.intrinsics().iterator_helper_prototype(), move(underlying_iterator), move(closure), move(abrupt_closure));
 }
 
 IteratorHelper::IteratorHelper(Realm& realm, Object& prototype, IteratorRecord underlying_iterator, Closure closure, Optional<AbruptClosure> abrupt_closure)

--- a/Userland/Libraries/LibJS/Runtime/IteratorPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/IteratorPrototype.cpp
@@ -439,7 +439,7 @@ JS_DEFINE_NATIVE_FUNCTION(IteratorPrototype::flat_map)
     // 4. Let iterated be ? GetIteratorDirect(O).
     auto iterated = TRY(get_iterator_direct(vm, object));
 
-    auto flat_map_iterator = MUST_OR_THROW_OOM(vm.heap().allocate<FlatMapIterator>(realm));
+    auto flat_map_iterator = vm.heap().allocate<FlatMapIterator>(realm);
 
     // 5. Let closure be a new Abstract Closure with no parameters that captures iterated and mapper and performs the following steps when called:
     IteratorHelper::Closure closure = [flat_map_iterator, mapper = NonnullGCPtr { mapper.as_function() }](auto& vm, auto& iterator) mutable -> ThrowCompletionOr<Value> {

--- a/Userland/Libraries/LibJS/Runtime/Map.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Map.cpp
@@ -10,7 +10,7 @@ namespace JS {
 
 NonnullGCPtr<Map> Map::create(Realm& realm)
 {
-    return realm.heap().allocate<Map>(realm, realm.intrinsics().map_prototype()).release_allocated_value_but_fixme_should_propagate_errors();
+    return realm.heap().allocate<Map>(realm, realm.intrinsics().map_prototype());
 }
 
 Map::Map(Object& prototype)

--- a/Userland/Libraries/LibJS/Runtime/MapIterator.cpp
+++ b/Userland/Libraries/LibJS/Runtime/MapIterator.cpp
@@ -11,7 +11,7 @@ namespace JS {
 
 NonnullGCPtr<MapIterator> MapIterator::create(Realm& realm, Map& map, Object::PropertyKind iteration_kind)
 {
-    return realm.heap().allocate<MapIterator>(realm, map, iteration_kind, realm.intrinsics().map_iterator_prototype()).release_allocated_value_but_fixme_should_propagate_errors();
+    return realm.heap().allocate<MapIterator>(realm, map, iteration_kind, realm.intrinsics().map_iterator_prototype());
 }
 
 MapIterator::MapIterator(Map& map, Object::PropertyKind iteration_kind, Object& prototype)

--- a/Userland/Libraries/LibJS/Runtime/NativeFunction.cpp
+++ b/Userland/Libraries/LibJS/Runtime/NativeFunction.cpp
@@ -36,7 +36,7 @@ NonnullGCPtr<NativeFunction> NativeFunction::create(Realm& allocating_realm, Saf
     // 7. Set func.[[Extensible]] to true.
     // 8. Set func.[[Realm]] to realm.
     // 9. Set func.[[InitialName]] to null.
-    auto function = allocating_realm.heap().allocate<NativeFunction>(allocating_realm, move(behaviour), prototype.value(), *realm.value()).release_allocated_value_but_fixme_should_propagate_errors();
+    auto function = allocating_realm.heap().allocate<NativeFunction>(allocating_realm, move(behaviour), prototype.value(), *realm.value());
 
     // 10. Perform SetFunctionLength(func, length).
     function->set_function_length(length);
@@ -53,7 +53,7 @@ NonnullGCPtr<NativeFunction> NativeFunction::create(Realm& allocating_realm, Saf
 
 NonnullGCPtr<NativeFunction> NativeFunction::create(Realm& realm, DeprecatedFlyString const& name, SafeFunction<ThrowCompletionOr<Value>(VM&)> function)
 {
-    return realm.heap().allocate<NativeFunction>(realm, name, move(function), realm.intrinsics().function_prototype()).release_allocated_value_but_fixme_should_propagate_errors();
+    return realm.heap().allocate<NativeFunction>(realm, name, move(function), realm.intrinsics().function_prototype());
 }
 
 NativeFunction::NativeFunction(SafeFunction<ThrowCompletionOr<Value>(VM&)> native_function, Object* prototype, Realm& realm)

--- a/Userland/Libraries/LibJS/Runtime/NumberObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/NumberObject.cpp
@@ -11,7 +11,7 @@ namespace JS {
 
 NonnullGCPtr<NumberObject> NumberObject::create(Realm& realm, double value)
 {
-    return realm.heap().allocate<NumberObject>(realm, value, realm.intrinsics().number_prototype()).release_allocated_value_but_fixme_should_propagate_errors();
+    return realm.heap().allocate<NumberObject>(realm, value, realm.intrinsics().number_prototype());
 }
 
 NumberObject::NumberObject(double value, Object& prototype)

--- a/Userland/Libraries/LibJS/Runtime/Object.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Object.cpp
@@ -29,10 +29,10 @@ static HashMap<GCPtr<Object const>, HashMap<DeprecatedFlyString, Object::Intrins
 NonnullGCPtr<Object> Object::create(Realm& realm, Object* prototype)
 {
     if (!prototype)
-        return realm.heap().allocate<Object>(realm, realm.intrinsics().empty_object_shape()).release_allocated_value_but_fixme_should_propagate_errors();
+        return realm.heap().allocate<Object>(realm, realm.intrinsics().empty_object_shape());
     if (prototype == realm.intrinsics().object_prototype())
-        return realm.heap().allocate<Object>(realm, realm.intrinsics().new_object_shape()).release_allocated_value_but_fixme_should_propagate_errors();
-    return realm.heap().allocate<Object>(realm, ConstructWithPrototypeTag::Tag, *prototype).release_allocated_value_but_fixme_should_propagate_errors();
+        return realm.heap().allocate<Object>(realm, realm.intrinsics().new_object_shape());
+    return realm.heap().allocate<Object>(realm, ConstructWithPrototypeTag::Tag, *prototype);
 }
 
 Object::Object(GlobalObjectTag, Realm& realm)

--- a/Userland/Libraries/LibJS/Runtime/Promise.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Promise.cpp
@@ -44,7 +44,7 @@ ThrowCompletionOr<Object*> promise_resolve(VM& vm, Object& constructor, Value va
 
 NonnullGCPtr<Promise> Promise::create(Realm& realm)
 {
-    return realm.heap().allocate<Promise>(realm, realm.intrinsics().promise_prototype()).release_allocated_value_but_fixme_should_propagate_errors();
+    return realm.heap().allocate<Promise>(realm, realm.intrinsics().promise_prototype());
 }
 
 // 27.2 Promise Objects, https://tc39.es/ecma262/#sec-promise-objects

--- a/Userland/Libraries/LibJS/Runtime/PromiseCapability.cpp
+++ b/Userland/Libraries/LibJS/Runtime/PromiseCapability.cpp
@@ -59,7 +59,7 @@ ThrowCompletionOr<NonnullGCPtr<PromiseCapability>> new_promise_capability(VM& vm
     // 2. NOTE: C is assumed to be a constructor function that supports the parameter conventions of the Promise constructor (see 27.2.3.1).
 
     // 3. Let resolvingFunctions be the Record { [[Resolve]]: undefined, [[Reject]]: undefined }.
-    auto resolving_functions = TRY(vm.heap().allocate<ResolvingFunctions>(realm));
+    auto resolving_functions = vm.heap().allocate<ResolvingFunctions>(realm);
 
     // 4. Let executorClosure be a new Abstract Closure with parameters (resolve, reject) that captures resolvingFunctions and performs the following steps when called:
     auto executor_closure = [resolving_functions](auto& vm) -> ThrowCompletionOr<Value> {

--- a/Userland/Libraries/LibJS/Runtime/PromiseResolvingElementFunctions.cpp
+++ b/Userland/Libraries/LibJS/Runtime/PromiseResolvingElementFunctions.cpp
@@ -55,7 +55,7 @@ void PromiseResolvingElementFunction::visit_edges(Cell::Visitor& visitor)
 
 NonnullGCPtr<PromiseAllResolveElementFunction> PromiseAllResolveElementFunction::create(Realm& realm, size_t index, PromiseValueList& values, NonnullGCPtr<PromiseCapability const> capability, RemainingElements& remaining_elements)
 {
-    return realm.heap().allocate<PromiseAllResolveElementFunction>(realm, index, values, capability, remaining_elements, realm.intrinsics().function_prototype()).release_allocated_value_but_fixme_should_propagate_errors();
+    return realm.heap().allocate<PromiseAllResolveElementFunction>(realm, index, values, capability, remaining_elements, realm.intrinsics().function_prototype());
 }
 
 PromiseAllResolveElementFunction::PromiseAllResolveElementFunction(size_t index, PromiseValueList& values, NonnullGCPtr<PromiseCapability const> capability, RemainingElements& remaining_elements, Object& prototype)
@@ -87,7 +87,7 @@ ThrowCompletionOr<Value> PromiseAllResolveElementFunction::resolve_element()
 
 NonnullGCPtr<PromiseAllSettledResolveElementFunction> PromiseAllSettledResolveElementFunction::create(Realm& realm, size_t index, PromiseValueList& values, NonnullGCPtr<PromiseCapability const> capability, RemainingElements& remaining_elements)
 {
-    return realm.heap().allocate<PromiseAllSettledResolveElementFunction>(realm, index, values, capability, remaining_elements, realm.intrinsics().function_prototype()).release_allocated_value_but_fixme_should_propagate_errors();
+    return realm.heap().allocate<PromiseAllSettledResolveElementFunction>(realm, index, values, capability, remaining_elements, realm.intrinsics().function_prototype());
 }
 
 PromiseAllSettledResolveElementFunction::PromiseAllSettledResolveElementFunction(size_t index, PromiseValueList& values, NonnullGCPtr<PromiseCapability const> capability, RemainingElements& remaining_elements, Object& prototype)
@@ -128,7 +128,7 @@ ThrowCompletionOr<Value> PromiseAllSettledResolveElementFunction::resolve_elemen
 
 NonnullGCPtr<PromiseAllSettledRejectElementFunction> PromiseAllSettledRejectElementFunction::create(Realm& realm, size_t index, PromiseValueList& values, NonnullGCPtr<PromiseCapability const> capability, RemainingElements& remaining_elements)
 {
-    return realm.heap().allocate<PromiseAllSettledRejectElementFunction>(realm, index, values, capability, remaining_elements, realm.intrinsics().function_prototype()).release_allocated_value_but_fixme_should_propagate_errors();
+    return realm.heap().allocate<PromiseAllSettledRejectElementFunction>(realm, index, values, capability, remaining_elements, realm.intrinsics().function_prototype());
 }
 
 PromiseAllSettledRejectElementFunction::PromiseAllSettledRejectElementFunction(size_t index, PromiseValueList& values, NonnullGCPtr<PromiseCapability const> capability, RemainingElements& remaining_elements, Object& prototype)
@@ -169,7 +169,7 @@ ThrowCompletionOr<Value> PromiseAllSettledRejectElementFunction::resolve_element
 
 NonnullGCPtr<PromiseAnyRejectElementFunction> PromiseAnyRejectElementFunction::create(Realm& realm, size_t index, PromiseValueList& errors, NonnullGCPtr<PromiseCapability const> capability, RemainingElements& remaining_elements)
 {
-    return realm.heap().allocate<PromiseAnyRejectElementFunction>(realm, index, errors, capability, remaining_elements, realm.intrinsics().function_prototype()).release_allocated_value_but_fixme_should_propagate_errors();
+    return realm.heap().allocate<PromiseAnyRejectElementFunction>(realm, index, errors, capability, remaining_elements, realm.intrinsics().function_prototype());
 }
 
 PromiseAnyRejectElementFunction::PromiseAnyRejectElementFunction(size_t index, PromiseValueList& errors, NonnullGCPtr<PromiseCapability const> capability, RemainingElements& remaining_elements, Object& prototype)

--- a/Userland/Libraries/LibJS/Runtime/PromiseResolvingFunction.cpp
+++ b/Userland/Libraries/LibJS/Runtime/PromiseResolvingFunction.cpp
@@ -13,7 +13,7 @@ namespace JS {
 
 NonnullGCPtr<PromiseResolvingFunction> PromiseResolvingFunction::create(Realm& realm, Promise& promise, AlreadyResolved& already_resolved, FunctionType function)
 {
-    return realm.heap().allocate<PromiseResolvingFunction>(realm, promise, already_resolved, move(function), realm.intrinsics().function_prototype()).release_allocated_value_but_fixme_should_propagate_errors();
+    return realm.heap().allocate<PromiseResolvingFunction>(realm, promise, already_resolved, move(function), realm.intrinsics().function_prototype());
 }
 
 PromiseResolvingFunction::PromiseResolvingFunction(Promise& promise, AlreadyResolved& already_resolved, FunctionType native_function, Object& prototype)

--- a/Userland/Libraries/LibJS/Runtime/ProxyObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ProxyObject.cpp
@@ -17,7 +17,7 @@ namespace JS {
 
 NonnullGCPtr<ProxyObject> ProxyObject::create(Realm& realm, Object& target, Object& handler)
 {
-    return realm.heap().allocate<ProxyObject>(realm, target, handler, realm.intrinsics().object_prototype()).release_allocated_value_but_fixme_should_propagate_errors();
+    return realm.heap().allocate<ProxyObject>(realm, target, handler, realm.intrinsics().object_prototype());
 }
 
 ProxyObject::ProxyObject(Object& target, Object& handler, Object& prototype)

--- a/Userland/Libraries/LibJS/Runtime/RegExpObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/RegExpObject.cpp
@@ -132,12 +132,12 @@ ThrowCompletionOr<DeprecatedString> parse_regex_pattern(VM& vm, StringView patte
 
 NonnullGCPtr<RegExpObject> RegExpObject::create(Realm& realm)
 {
-    return realm.heap().allocate<RegExpObject>(realm, realm.intrinsics().regexp_prototype()).release_allocated_value_but_fixme_should_propagate_errors();
+    return realm.heap().allocate<RegExpObject>(realm, realm.intrinsics().regexp_prototype());
 }
 
 NonnullGCPtr<RegExpObject> RegExpObject::create(Realm& realm, Regex<ECMA262> regex, DeprecatedString pattern, DeprecatedString flags)
 {
-    return realm.heap().allocate<RegExpObject>(realm, move(regex), move(pattern), move(flags), realm.intrinsics().regexp_prototype()).release_allocated_value_but_fixme_should_propagate_errors();
+    return realm.heap().allocate<RegExpObject>(realm, move(regex), move(pattern), move(flags), realm.intrinsics().regexp_prototype());
 }
 
 RegExpObject::RegExpObject(Object& prototype)

--- a/Userland/Libraries/LibJS/Runtime/RegExpStringIterator.cpp
+++ b/Userland/Libraries/LibJS/Runtime/RegExpStringIterator.cpp
@@ -12,7 +12,7 @@ namespace JS {
 // 22.2.9.1 CreateRegExpStringIterator ( R, S, global, fullUnicode ), https://tc39.es/ecma262/#sec-createregexpstringiterator
 NonnullGCPtr<RegExpStringIterator> RegExpStringIterator::create(Realm& realm, Object& regexp_object, Utf16String string, bool global, bool unicode)
 {
-    return realm.heap().allocate<RegExpStringIterator>(realm, realm.intrinsics().regexp_string_iterator_prototype(), regexp_object, move(string), global, unicode).release_allocated_value_but_fixme_should_propagate_errors();
+    return realm.heap().allocate<RegExpStringIterator>(realm, realm.intrinsics().regexp_string_iterator_prototype(), regexp_object, move(string), global, unicode);
 }
 
 RegExpStringIterator::RegExpStringIterator(Object& prototype, Object& regexp_object, Utf16String string, bool global, bool unicode)

--- a/Userland/Libraries/LibJS/Runtime/Set.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Set.cpp
@@ -10,7 +10,7 @@ namespace JS {
 
 NonnullGCPtr<Set> Set::create(Realm& realm)
 {
-    return realm.heap().allocate<Set>(realm, realm.intrinsics().set_prototype()).release_allocated_value_but_fixme_should_propagate_errors();
+    return realm.heap().allocate<Set>(realm, realm.intrinsics().set_prototype());
 }
 
 Set::Set(Object& prototype)

--- a/Userland/Libraries/LibJS/Runtime/SetIterator.cpp
+++ b/Userland/Libraries/LibJS/Runtime/SetIterator.cpp
@@ -11,7 +11,7 @@ namespace JS {
 
 NonnullGCPtr<SetIterator> SetIterator::create(Realm& realm, Set& set, Object::PropertyKind iteration_kind)
 {
-    return realm.heap().allocate<SetIterator>(realm, set, iteration_kind, realm.intrinsics().set_iterator_prototype()).release_allocated_value_but_fixme_should_propagate_errors();
+    return realm.heap().allocate<SetIterator>(realm, set, iteration_kind, realm.intrinsics().set_iterator_prototype());
 }
 
 SetIterator::SetIterator(Set& set, Object::PropertyKind iteration_kind, Object& prototype)

--- a/Userland/Libraries/LibJS/Runtime/StringConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/StringConstructor.cpp
@@ -79,7 +79,7 @@ ThrowCompletionOr<NonnullGCPtr<Object>> StringConstructor::construct(FunctionObj
 
     // 4. Return StringCreate(s, ? GetPrototypeFromConstructor(NewTarget, "%String.prototype%")).
     auto* prototype = TRY(get_prototype_from_constructor(vm, new_target, &Intrinsics::string_prototype));
-    return MUST_OR_THROW_OOM(StringObject::create(realm, *primitive_string, *prototype));
+    return StringObject::create(realm, *primitive_string, *prototype);
 }
 
 // 22.1.2.1 String.fromCharCode ( ...codeUnits ), https://tc39.es/ecma262/#sec-string.fromcharcode

--- a/Userland/Libraries/LibJS/Runtime/StringIterator.cpp
+++ b/Userland/Libraries/LibJS/Runtime/StringIterator.cpp
@@ -12,7 +12,7 @@ namespace JS {
 
 NonnullGCPtr<StringIterator> StringIterator::create(Realm& realm, String string)
 {
-    return realm.heap().allocate<StringIterator>(realm, move(string), realm.intrinsics().string_iterator_prototype()).release_allocated_value_but_fixme_should_propagate_errors();
+    return realm.heap().allocate<StringIterator>(realm, move(string), realm.intrinsics().string_iterator_prototype());
 }
 
 StringIterator::StringIterator(String string, Object& prototype)

--- a/Userland/Libraries/LibJS/Runtime/StringObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/StringObject.cpp
@@ -15,7 +15,7 @@
 namespace JS {
 
 // 10.4.3.4 StringCreate ( value, prototype ), https://tc39.es/ecma262/#sec-stringcreate
-ThrowCompletionOr<NonnullGCPtr<StringObject>> StringObject::create(Realm& realm, PrimitiveString& primitive_string, Object& prototype)
+NonnullGCPtr<StringObject> StringObject::create(Realm& realm, PrimitiveString& primitive_string, Object& prototype)
 {
     // 1. Let S be MakeBasicObject(« [[Prototype]], [[Extensible]], [[StringData]] »).
     // 2. Set S.[[Prototype]] to prototype.
@@ -26,7 +26,7 @@ ThrowCompletionOr<NonnullGCPtr<StringObject>> StringObject::create(Realm& realm,
     // 7. Let length be the length of value.
     // 8. Perform ! DefinePropertyOrThrow(S, "length", PropertyDescriptor { [[Value]]: 𝔽(length), [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: false }).
     // 9. Return S.
-    return MUST_OR_THROW_OOM(realm.heap().allocate<StringObject>(realm, primitive_string, prototype));
+    return realm.heap().allocate<StringObject>(realm, primitive_string, prototype);
 }
 
 StringObject::StringObject(PrimitiveString& string, Object& prototype)

--- a/Userland/Libraries/LibJS/Runtime/StringObject.h
+++ b/Userland/Libraries/LibJS/Runtime/StringObject.h
@@ -14,7 +14,7 @@ class StringObject : public Object {
     JS_OBJECT(StringObject, Object);
 
 public:
-    static ThrowCompletionOr<NonnullGCPtr<StringObject>> create(Realm&, PrimitiveString&, Object& prototype);
+    [[nodiscard]] static NonnullGCPtr<StringObject> create(Realm&, PrimitiveString&, Object& prototype);
 
     virtual void initialize(Realm&) override;
     virtual ~StringObject() override = default;

--- a/Userland/Libraries/LibJS/Runtime/SuppressedError.cpp
+++ b/Userland/Libraries/LibJS/Runtime/SuppressedError.cpp
@@ -12,7 +12,7 @@ namespace JS {
 
 NonnullGCPtr<SuppressedError> SuppressedError::create(Realm& realm)
 {
-    return realm.heap().allocate<SuppressedError>(realm, realm.intrinsics().suppressed_error_prototype()).release_allocated_value_but_fixme_should_propagate_errors();
+    return realm.heap().allocate<SuppressedError>(realm, realm.intrinsics().suppressed_error_prototype());
 }
 
 SuppressedError::SuppressedError(Object& prototype)

--- a/Userland/Libraries/LibJS/Runtime/SymbolObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/SymbolObject.cpp
@@ -12,7 +12,7 @@ namespace JS {
 
 NonnullGCPtr<SymbolObject> SymbolObject::create(Realm& realm, Symbol& primitive_symbol)
 {
-    return realm.heap().allocate<SymbolObject>(realm, primitive_symbol, realm.intrinsics().symbol_prototype()).release_allocated_value_but_fixme_should_propagate_errors();
+    return realm.heap().allocate<SymbolObject>(realm, primitive_symbol, realm.intrinsics().symbol_prototype());
 }
 
 SymbolObject::SymbolObject(Symbol& symbol, Object& prototype)

--- a/Userland/Libraries/LibJS/Runtime/Temporal/Temporal.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/Temporal.cpp
@@ -36,7 +36,7 @@ void Temporal::initialize(Realm& realm)
     define_direct_property(vm.well_known_symbol_to_string_tag(), PrimitiveString::create(vm, "Temporal"_string), Attribute::Configurable);
 
     u8 attr = Attribute::Writable | Attribute::Configurable;
-    define_direct_property(vm.names.Now, MUST(heap().allocate<Now>(realm, realm)), attr);
+    define_direct_property(vm.names.Now, heap().allocate<Now>(realm, realm), attr);
     define_intrinsic_accessor(vm.names.Calendar, attr, [](auto& realm) -> Value { return realm.intrinsics().temporal_calendar_constructor(); });
     define_intrinsic_accessor(vm.names.Duration, attr, [](auto& realm) -> Value { return realm.intrinsics().temporal_duration_constructor(); });
     define_intrinsic_accessor(vm.names.Instant, attr, [](auto& realm) -> Value { return realm.intrinsics().temporal_instant_constructor(); });

--- a/Userland/Libraries/LibJS/Runtime/Value.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Value.cpp
@@ -566,7 +566,7 @@ ThrowCompletionOr<NonnullGCPtr<Object>> Value::to_object(VM& vm) const
     // String
     case STRING_TAG:
         // Return a new String object whose [[StringData]] internal slot is set to argument. See 22.1 for a description of String objects.
-        return MUST_OR_THROW_OOM(StringObject::create(realm, const_cast<JS::PrimitiveString&>(as_string()), realm.intrinsics().string_prototype()));
+        return StringObject::create(realm, const_cast<JS::PrimitiveString&>(as_string()), realm.intrinsics().string_prototype());
     // Symbol
     case SYMBOL_TAG:
         // Return a new Symbol object whose [[SymbolData]] internal slot is set to argument. See 20.4 for a description of Symbol objects.

--- a/Userland/Libraries/LibJS/Runtime/WeakMap.cpp
+++ b/Userland/Libraries/LibJS/Runtime/WeakMap.cpp
@@ -10,7 +10,7 @@ namespace JS {
 
 NonnullGCPtr<WeakMap> WeakMap::create(Realm& realm)
 {
-    return realm.heap().allocate<WeakMap>(realm, realm.intrinsics().weak_map_prototype()).release_allocated_value_but_fixme_should_propagate_errors();
+    return realm.heap().allocate<WeakMap>(realm, realm.intrinsics().weak_map_prototype());
 }
 
 WeakMap::WeakMap(Object& prototype)

--- a/Userland/Libraries/LibJS/Runtime/WeakRef.cpp
+++ b/Userland/Libraries/LibJS/Runtime/WeakRef.cpp
@@ -10,12 +10,12 @@ namespace JS {
 
 NonnullGCPtr<WeakRef> WeakRef::create(Realm& realm, Object& value)
 {
-    return realm.heap().allocate<WeakRef>(realm, value, realm.intrinsics().weak_ref_prototype()).release_allocated_value_but_fixme_should_propagate_errors();
+    return realm.heap().allocate<WeakRef>(realm, value, realm.intrinsics().weak_ref_prototype());
 }
 
 NonnullGCPtr<WeakRef> WeakRef::create(Realm& realm, Symbol& value)
 {
-    return realm.heap().allocate<WeakRef>(realm, value, realm.intrinsics().weak_ref_prototype()).release_allocated_value_but_fixme_should_propagate_errors();
+    return realm.heap().allocate<WeakRef>(realm, value, realm.intrinsics().weak_ref_prototype());
 }
 
 WeakRef::WeakRef(Object& value, Object& prototype)

--- a/Userland/Libraries/LibJS/Runtime/WeakSet.cpp
+++ b/Userland/Libraries/LibJS/Runtime/WeakSet.cpp
@@ -10,7 +10,7 @@ namespace JS {
 
 NonnullGCPtr<WeakSet> WeakSet::create(Realm& realm)
 {
-    return realm.heap().allocate<WeakSet>(realm, realm.intrinsics().weak_set_prototype()).release_allocated_value_but_fixme_should_propagate_errors();
+    return realm.heap().allocate<WeakSet>(realm, realm.intrinsics().weak_set_prototype());
 }
 
 WeakSet::WeakSet(Object& prototype)

--- a/Userland/Libraries/LibJS/Runtime/WrappedFunction.cpp
+++ b/Userland/Libraries/LibJS/Runtime/WrappedFunction.cpp
@@ -22,7 +22,7 @@ ThrowCompletionOr<NonnullGCPtr<WrappedFunction>> WrappedFunction::create(Realm& 
     // 5. Set wrapped.[[WrappedTargetFunction]] to Target.
     // 6. Set wrapped.[[Realm]] to callerRealm.
     auto& prototype = *caller_realm.intrinsics().function_prototype();
-    auto wrapped = MUST_OR_THROW_OOM(vm.heap().allocate<WrappedFunction>(realm, caller_realm, target, prototype));
+    auto wrapped = vm.heap().allocate<WrappedFunction>(realm, caller_realm, target, prototype);
 
     // 7. Let result be CopyNameAndLength(wrapped, Target).
     auto result = copy_name_and_length(vm, *wrapped, target);

--- a/Userland/Libraries/LibTest/JavaScriptTestRunner.h
+++ b/Userland/Libraries/LibTest/JavaScriptTestRunner.h
@@ -292,7 +292,7 @@ inline JSFileResult TestRunner::run_file_test(DeprecatedString const& test_path)
         *g_vm,
         [&](JS::Realm& realm_) -> JS::GlobalObject* {
             realm = &realm_;
-            global_object = g_vm->heap().allocate<TestRunnerGlobalObject>(*realm, *realm).release_allocated_value_but_fixme_should_propagate_errors();
+            global_object = g_vm->heap().allocate<TestRunnerGlobalObject>(*realm, *realm);
             return global_object;
         },
         nullptr));

--- a/Userland/Libraries/LibWeb/Bindings/MainThreadVM.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/MainThreadVM.cpp
@@ -174,7 +174,7 @@ ErrorOr<void> initialize_main_thread_vm()
                     /* .promise = */ promise,
                     /* .reason = */ promise.result(),
                 };
-                auto promise_rejection_event = HTML::PromiseRejectionEvent::create(HTML::relevant_realm(global), HTML::EventNames::rejectionhandled, event_init).release_value_but_fixme_should_propagate_errors();
+                auto promise_rejection_event = HTML::PromiseRejectionEvent::create(HTML::relevant_realm(global), HTML::EventNames::rejectionhandled, event_init);
                 window.dispatch_event(promise_rejection_event);
             });
             break;

--- a/Userland/Libraries/LibWeb/Bindings/OptionConstructor.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/OptionConstructor.cpp
@@ -53,7 +53,7 @@ JS::ThrowCompletionOr<JS::NonnullGCPtr<JS::Object>> OptionConstructor::construct
     if (vm.argument_count() > 0) {
         auto text = TRY(vm.argument(0).to_deprecated_string(vm));
         if (!text.is_empty()) {
-            auto new_text_node = MUST_OR_THROW_OOM(vm.heap().allocate<DOM::Text>(realm, document, text));
+            auto new_text_node = vm.heap().allocate<DOM::Text>(realm, document, text);
             MUST(option_element->append_child(*new_text_node));
         }
     }

--- a/Userland/Libraries/LibWeb/CSS/CSSFontFaceRule.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSFontFaceRule.cpp
@@ -14,9 +14,9 @@
 
 namespace Web::CSS {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<CSSFontFaceRule>> CSSFontFaceRule::create(JS::Realm& realm, FontFace&& font_face)
+JS::NonnullGCPtr<CSSFontFaceRule> CSSFontFaceRule::create(JS::Realm& realm, FontFace&& font_face)
 {
-    return MUST_OR_THROW_OOM(realm.heap().allocate<CSSFontFaceRule>(realm, realm, move(font_face)));
+    return realm.heap().allocate<CSSFontFaceRule>(realm, realm, move(font_face));
 }
 
 CSSFontFaceRule::CSSFontFaceRule(JS::Realm& realm, FontFace&& font_face)

--- a/Userland/Libraries/LibWeb/CSS/CSSFontFaceRule.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSFontFaceRule.h
@@ -16,7 +16,7 @@ class CSSFontFaceRule final : public CSSRule {
     WEB_PLATFORM_OBJECT(CSSFontFaceRule, CSSRule);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<CSSFontFaceRule>> create(JS::Realm&, FontFace&&);
+    [[nodiscard]] static JS::NonnullGCPtr<CSSFontFaceRule> create(JS::Realm&, FontFace&&);
 
     virtual ~CSSFontFaceRule() override = default;
 

--- a/Userland/Libraries/LibWeb/CSS/CSSImportRule.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSImportRule.cpp
@@ -19,10 +19,10 @@
 
 namespace Web::CSS {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<CSSImportRule>> CSSImportRule::create(AK::URL url, DOM::Document& document)
+JS::NonnullGCPtr<CSSImportRule> CSSImportRule::create(AK::URL url, DOM::Document& document)
 {
     auto& realm = document.realm();
-    return MUST_OR_THROW_OOM(realm.heap().allocate<CSSImportRule>(realm, move(url), document));
+    return realm.heap().allocate<CSSImportRule>(realm, move(url), document);
 }
 
 CSSImportRule::CSSImportRule(AK::URL url, DOM::Document& document)

--- a/Userland/Libraries/LibWeb/CSS/CSSImportRule.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSImportRule.h
@@ -22,7 +22,7 @@ class CSSImportRule final
     WEB_PLATFORM_OBJECT(CSSImportRule, CSSRule);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<CSSImportRule>> create(AK::URL, DOM::Document&);
+    [[nodiscard]] static JS::NonnullGCPtr<CSSImportRule> create(AK::URL, DOM::Document&);
 
     virtual ~CSSImportRule() = default;
 

--- a/Userland/Libraries/LibWeb/CSS/CSSKeyframeRule.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSKeyframeRule.cpp
@@ -11,9 +11,9 @@
 
 namespace Web::CSS {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<CSSKeyframeRule>> CSSKeyframeRule::create(JS::Realm& realm, CSS::Percentage key, Web::CSS::CSSStyleDeclaration& declarations)
+JS::NonnullGCPtr<CSSKeyframeRule> CSSKeyframeRule::create(JS::Realm& realm, CSS::Percentage key, Web::CSS::CSSStyleDeclaration& declarations)
 {
-    return MUST_OR_THROW_OOM(realm.heap().allocate<CSSKeyframeRule>(realm, realm, key, declarations));
+    return realm.heap().allocate<CSSKeyframeRule>(realm, realm, key, declarations);
 }
 
 void CSSKeyframeRule::visit_edges(Visitor& visitor)

--- a/Userland/Libraries/LibWeb/CSS/CSSKeyframeRule.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSKeyframeRule.h
@@ -20,7 +20,7 @@ class CSSKeyframeRule final : public CSSRule {
     WEB_PLATFORM_OBJECT(CSSKeyframeRule, CSSRule);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<CSSKeyframeRule>> create(JS::Realm& realm, CSS::Percentage key, CSSStyleDeclaration& declarations);
+    static JS::NonnullGCPtr<CSSKeyframeRule> create(JS::Realm&, CSS::Percentage key, CSSStyleDeclaration&);
 
     virtual ~CSSKeyframeRule() = default;
 

--- a/Userland/Libraries/LibWeb/CSS/CSSKeyframesRule.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSKeyframesRule.cpp
@@ -10,9 +10,9 @@
 
 namespace Web::CSS {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<CSSKeyframesRule>> CSSKeyframesRule::create(JS::Realm& realm, AK::FlyString name, Vector<JS::NonnullGCPtr<CSSKeyframeRule>> keyframes)
+JS::NonnullGCPtr<CSSKeyframesRule> CSSKeyframesRule::create(JS::Realm& realm, AK::FlyString name, Vector<JS::NonnullGCPtr<CSSKeyframeRule>> keyframes)
 {
-    return MUST_OR_THROW_OOM(realm.heap().allocate<CSSKeyframesRule>(realm, realm, move(name), move(keyframes)));
+    return realm.heap().allocate<CSSKeyframesRule>(realm, realm, move(name), move(keyframes));
 }
 
 void CSSKeyframesRule::visit_edges(Visitor& visitor)

--- a/Userland/Libraries/LibWeb/CSS/CSSKeyframesRule.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSKeyframesRule.h
@@ -21,7 +21,7 @@ class CSSKeyframesRule final : public CSSRule {
     WEB_PLATFORM_OBJECT(CSSKeyframesRule, CSSRule);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<CSSKeyframesRule>> create(JS::Realm& realm, FlyString name, Vector<JS::NonnullGCPtr<CSSKeyframeRule>> keyframes);
+    [[nodiscard]] static JS::NonnullGCPtr<CSSKeyframesRule> create(JS::Realm&, FlyString name, Vector<JS::NonnullGCPtr<CSSKeyframeRule>>);
 
     virtual ~CSSKeyframesRule() = default;
 

--- a/Userland/Libraries/LibWeb/CSS/CSSMediaRule.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSMediaRule.cpp
@@ -12,9 +12,9 @@
 
 namespace Web::CSS {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<CSSMediaRule>> CSSMediaRule::create(JS::Realm& realm, MediaList& media_queries, CSSRuleList& rules)
+JS::NonnullGCPtr<CSSMediaRule> CSSMediaRule::create(JS::Realm& realm, MediaList& media_queries, CSSRuleList& rules)
 {
-    return MUST_OR_THROW_OOM(realm.heap().allocate<CSSMediaRule>(realm, realm, media_queries, rules));
+    return realm.heap().allocate<CSSMediaRule>(realm, realm, media_queries, rules);
 }
 
 CSSMediaRule::CSSMediaRule(JS::Realm& realm, MediaList& media, CSSRuleList& rules)

--- a/Userland/Libraries/LibWeb/CSS/CSSMediaRule.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSMediaRule.h
@@ -18,7 +18,7 @@ class CSSMediaRule final : public CSSConditionRule {
     WEB_PLATFORM_OBJECT(CSSMediaRule, CSSConditionRule);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<CSSMediaRule>> create(JS::Realm&, MediaList& media_queries, CSSRuleList&);
+    [[nodiscard]] static JS::NonnullGCPtr<CSSMediaRule> create(JS::Realm&, MediaList& media_queries, CSSRuleList&);
 
     virtual ~CSSMediaRule() = default;
 

--- a/Userland/Libraries/LibWeb/CSS/CSSNamespaceRule.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSNamespaceRule.cpp
@@ -21,9 +21,9 @@ CSSNamespaceRule::CSSNamespaceRule(JS::Realm& realm, Optional<DeprecatedString> 
 {
 }
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<CSSNamespaceRule>> CSSNamespaceRule::create(JS::Realm& realm, Optional<DeprecatedString> prefix, AK::StringView namespace_uri)
+JS::NonnullGCPtr<CSSNamespaceRule> CSSNamespaceRule::create(JS::Realm& realm, Optional<DeprecatedString> prefix, AK::StringView namespace_uri)
 {
-    return MUST_OR_THROW_OOM(realm.heap().allocate<CSSNamespaceRule>(realm, realm, prefix, namespace_uri));
+    return realm.heap().allocate<CSSNamespaceRule>(realm, realm, prefix, namespace_uri);
 }
 
 void CSSNamespaceRule::initialize(JS::Realm& realm)

--- a/Userland/Libraries/LibWeb/CSS/CSSNamespaceRule.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSNamespaceRule.h
@@ -14,7 +14,7 @@ class CSSNamespaceRule final : public CSSRule {
     WEB_PLATFORM_OBJECT(CSSNamespaceRule, CSSRule);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<CSSNamespaceRule>> create(JS::Realm&, Optional<DeprecatedString> prefix, StringView namespace_uri);
+    [[nodiscard]] static JS::NonnullGCPtr<CSSNamespaceRule> create(JS::Realm&, Optional<DeprecatedString> prefix, StringView namespace_uri);
 
     virtual ~CSSNamespaceRule() = default;
 

--- a/Userland/Libraries/LibWeb/CSS/CSSRuleList.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSRuleList.cpp
@@ -18,9 +18,9 @@
 
 namespace Web::CSS {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<CSSRuleList>> CSSRuleList::create(JS::Realm& realm, JS::MarkedVector<CSSRule*> const& rules)
+JS::NonnullGCPtr<CSSRuleList> CSSRuleList::create(JS::Realm& realm, JS::MarkedVector<CSSRule*> const& rules)
 {
-    auto rule_list = MUST_OR_THROW_OOM(realm.heap().allocate<CSSRuleList>(realm, realm));
+    auto rule_list = realm.heap().allocate<CSSRuleList>(realm, realm);
     for (auto* rule : rules)
         rule_list->m_rules.append(*rule);
     return rule_list;
@@ -31,9 +31,9 @@ CSSRuleList::CSSRuleList(JS::Realm& realm)
 {
 }
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<CSSRuleList>> CSSRuleList::create_empty(JS::Realm& realm)
+JS::NonnullGCPtr<CSSRuleList> CSSRuleList::create_empty(JS::Realm& realm)
 {
-    return MUST_OR_THROW_OOM(realm.heap().allocate<CSSRuleList>(realm, realm));
+    return realm.heap().allocate<CSSRuleList>(realm, realm);
 }
 
 void CSSRuleList::initialize(JS::Realm& realm)

--- a/Userland/Libraries/LibWeb/CSS/CSSRuleList.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSRuleList.h
@@ -23,8 +23,8 @@ class CSSRuleList : public Bindings::LegacyPlatformObject {
     WEB_PLATFORM_OBJECT(CSSRuleList, Bindings::LegacyPlatformObject);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<CSSRuleList>> create(JS::Realm&, JS::MarkedVector<CSSRule*> const&);
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<CSSRuleList>> create_empty(JS::Realm&);
+    [[nodiscard]] static JS::NonnullGCPtr<CSSRuleList> create(JS::Realm&, JS::MarkedVector<CSSRule*> const&);
+    [[nodiscard]] static JS::NonnullGCPtr<CSSRuleList> create_empty(JS::Realm&);
 
     ~CSSRuleList() = default;
 

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleDeclaration.cpp
@@ -26,9 +26,9 @@ void CSSStyleDeclaration::initialize(JS::Realm& realm)
     set_prototype(&Bindings::ensure_web_prototype<Bindings::CSSStyleDeclarationPrototype>(realm, "CSSStyleDeclaration"));
 }
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<PropertyOwningCSSStyleDeclaration>> PropertyOwningCSSStyleDeclaration::create(JS::Realm& realm, Vector<StyleProperty> properties, HashMap<DeprecatedString, StyleProperty> custom_properties)
+JS::NonnullGCPtr<PropertyOwningCSSStyleDeclaration> PropertyOwningCSSStyleDeclaration::create(JS::Realm& realm, Vector<StyleProperty> properties, HashMap<DeprecatedString, StyleProperty> custom_properties)
 {
-    return MUST_OR_THROW_OOM(realm.heap().allocate<PropertyOwningCSSStyleDeclaration>(realm, realm, move(properties), move(custom_properties)));
+    return realm.heap().allocate<PropertyOwningCSSStyleDeclaration>(realm, realm, move(properties), move(custom_properties));
 }
 
 PropertyOwningCSSStyleDeclaration::PropertyOwningCSSStyleDeclaration(JS::Realm& realm, Vector<StyleProperty> properties, HashMap<DeprecatedString, StyleProperty> custom_properties)
@@ -45,10 +45,10 @@ DeprecatedString PropertyOwningCSSStyleDeclaration::item(size_t index) const
     return CSS::string_from_property_id(m_properties[index].property_id);
 }
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<ElementInlineCSSStyleDeclaration>> ElementInlineCSSStyleDeclaration::create(DOM::Element& element, Vector<StyleProperty> properties, HashMap<DeprecatedString, StyleProperty> custom_properties)
+JS::NonnullGCPtr<ElementInlineCSSStyleDeclaration> ElementInlineCSSStyleDeclaration::create(DOM::Element& element, Vector<StyleProperty> properties, HashMap<DeprecatedString, StyleProperty> custom_properties)
 {
     auto& realm = element.realm();
-    return MUST_OR_THROW_OOM(realm.heap().allocate<ElementInlineCSSStyleDeclaration>(realm, element, move(properties), move(custom_properties)));
+    return realm.heap().allocate<ElementInlineCSSStyleDeclaration>(realm, element, move(properties), move(custom_properties));
 }
 
 ElementInlineCSSStyleDeclaration::ElementInlineCSSStyleDeclaration(DOM::Element& element, Vector<StyleProperty> properties, HashMap<DeprecatedString, StyleProperty> custom_properties)

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleDeclaration.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleDeclaration.h
@@ -53,7 +53,7 @@ class PropertyOwningCSSStyleDeclaration : public CSSStyleDeclaration {
     friend class ElementInlineCSSStyleDeclaration;
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<PropertyOwningCSSStyleDeclaration>>
+    [[nodiscard]] static JS::NonnullGCPtr<PropertyOwningCSSStyleDeclaration>
     create(JS::Realm&, Vector<StyleProperty>, HashMap<DeprecatedString, StyleProperty> custom_properties);
 
     virtual ~PropertyOwningCSSStyleDeclaration() override = default;
@@ -93,7 +93,7 @@ class ElementInlineCSSStyleDeclaration final : public PropertyOwningCSSStyleDecl
     WEB_PLATFORM_OBJECT(ElementInlineCSSStyleDeclaration, PropertyOwningCSSStyleDeclaration);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<ElementInlineCSSStyleDeclaration>> create(DOM::Element&, Vector<StyleProperty> properties, HashMap<DeprecatedString, StyleProperty> custom_properties);
+    [[nodiscard]] static JS::NonnullGCPtr<ElementInlineCSSStyleDeclaration> create(DOM::Element&, Vector<StyleProperty>, HashMap<DeprecatedString, StyleProperty> custom_properties);
 
     virtual ~ElementInlineCSSStyleDeclaration() override = default;
 

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleRule.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleRule.cpp
@@ -12,9 +12,9 @@
 
 namespace Web::CSS {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<CSSStyleRule>> CSSStyleRule::create(JS::Realm& realm, Vector<NonnullRefPtr<Web::CSS::Selector>>&& selectors, CSSStyleDeclaration& declaration)
+JS::NonnullGCPtr<CSSStyleRule> CSSStyleRule::create(JS::Realm& realm, Vector<NonnullRefPtr<Web::CSS::Selector>>&& selectors, CSSStyleDeclaration& declaration)
 {
-    return MUST_OR_THROW_OOM(realm.heap().allocate<CSSStyleRule>(realm, realm, move(selectors), declaration));
+    return realm.heap().allocate<CSSStyleRule>(realm, realm, move(selectors), declaration);
 }
 
 CSSStyleRule::CSSStyleRule(JS::Realm& realm, Vector<NonnullRefPtr<Selector>>&& selectors, CSSStyleDeclaration& declaration)

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleRule.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleRule.h
@@ -18,7 +18,7 @@ class CSSStyleRule final : public CSSRule {
     WEB_PLATFORM_OBJECT(CSSStyleRule, CSSRule);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<CSSStyleRule>> create(JS::Realm&, Vector<NonnullRefPtr<Selector>>&&, CSSStyleDeclaration&);
+    [[nodiscard]] static JS::NonnullGCPtr<CSSStyleRule> create(JS::Realm&, Vector<NonnullRefPtr<Selector>>&&, CSSStyleDeclaration&);
 
     virtual ~CSSStyleRule() override = default;
 

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
@@ -15,9 +15,9 @@
 
 namespace Web::CSS {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<CSSStyleSheet>> CSSStyleSheet::create(JS::Realm& realm, CSSRuleList& rules, MediaList& media, Optional<AK::URL> location)
+JS::NonnullGCPtr<CSSStyleSheet> CSSStyleSheet::create(JS::Realm& realm, CSSRuleList& rules, MediaList& media, Optional<AK::URL> location)
 {
-    return MUST_OR_THROW_OOM(realm.heap().allocate<CSSStyleSheet>(realm, realm, rules, media, move(location)));
+    return realm.heap().allocate<CSSStyleSheet>(realm, realm, rules, media, move(location));
 }
 
 CSSStyleSheet::CSSStyleSheet(JS::Realm& realm, CSSRuleList& rules, MediaList& media, Optional<AK::URL> location)

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.h
@@ -23,7 +23,7 @@ class CSSStyleSheet final
     WEB_PLATFORM_OBJECT(CSSStyleSheet, StyleSheet);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<CSSStyleSheet>> create(JS::Realm&, CSSRuleList& rules, MediaList& media, Optional<AK::URL> location);
+    [[nodiscard]] static JS::NonnullGCPtr<CSSStyleSheet> create(JS::Realm&, CSSRuleList&, MediaList&, Optional<AK::URL> location);
 
     virtual ~CSSStyleSheet() override = default;
 

--- a/Userland/Libraries/LibWeb/CSS/CSSSupportsRule.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSSupportsRule.cpp
@@ -11,9 +11,9 @@
 
 namespace Web::CSS {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<CSSSupportsRule>> CSSSupportsRule::create(JS::Realm& realm, NonnullRefPtr<Supports>&& supports, CSSRuleList& rules)
+JS::NonnullGCPtr<CSSSupportsRule> CSSSupportsRule::create(JS::Realm& realm, NonnullRefPtr<Supports>&& supports, CSSRuleList& rules)
 {
-    return MUST_OR_THROW_OOM(realm.heap().allocate<CSSSupportsRule>(realm, realm, move(supports), rules));
+    return realm.heap().allocate<CSSSupportsRule>(realm, realm, move(supports), rules);
 }
 
 CSSSupportsRule::CSSSupportsRule(JS::Realm& realm, NonnullRefPtr<Supports>&& supports, CSSRuleList& rules)

--- a/Userland/Libraries/LibWeb/CSS/CSSSupportsRule.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSSupportsRule.h
@@ -19,7 +19,7 @@ class CSSSupportsRule final : public CSSConditionRule {
     WEB_PLATFORM_OBJECT(CSSSupportsRule, CSSConditionRule);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<CSSSupportsRule>> create(JS::Realm&, NonnullRefPtr<Supports>&&, CSSRuleList&);
+    static JS::NonnullGCPtr<CSSSupportsRule> create(JS::Realm&, NonnullRefPtr<Supports>&&, CSSRuleList&);
 
     virtual ~CSSSupportsRule() = default;
 

--- a/Userland/Libraries/LibWeb/CSS/MediaList.cpp
+++ b/Userland/Libraries/LibWeb/CSS/MediaList.cpp
@@ -13,9 +13,9 @@
 
 namespace Web::CSS {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<MediaList>> MediaList::create(JS::Realm& realm, Vector<NonnullRefPtr<MediaQuery>>&& media)
+JS::NonnullGCPtr<MediaList> MediaList::create(JS::Realm& realm, Vector<NonnullRefPtr<MediaQuery>>&& media)
 {
-    return MUST_OR_THROW_OOM(realm.heap().allocate<MediaList>(realm, realm, move(media)));
+    return realm.heap().allocate<MediaList>(realm, realm, move(media));
 }
 
 MediaList::MediaList(JS::Realm& realm, Vector<NonnullRefPtr<MediaQuery>>&& media)

--- a/Userland/Libraries/LibWeb/CSS/MediaList.h
+++ b/Userland/Libraries/LibWeb/CSS/MediaList.h
@@ -20,7 +20,7 @@ class MediaList final : public Bindings::LegacyPlatformObject {
     WEB_PLATFORM_OBJECT(MediaList, Bindings::LegacyPlatformObject);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<MediaList>> create(JS::Realm&, Vector<NonnullRefPtr<MediaQuery>>&& media);
+    [[nodiscard]] static JS::NonnullGCPtr<MediaList> create(JS::Realm&, Vector<NonnullRefPtr<MediaQuery>>&&);
     ~MediaList() = default;
 
     DeprecatedString media_text() const;

--- a/Userland/Libraries/LibWeb/CSS/MediaQueryList.cpp
+++ b/Userland/Libraries/LibWeb/CSS/MediaQueryList.cpp
@@ -15,9 +15,9 @@
 
 namespace Web::CSS {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<MediaQueryList>> MediaQueryList::create(DOM::Document& document, Vector<NonnullRefPtr<MediaQuery>>&& media)
+JS::NonnullGCPtr<MediaQueryList> MediaQueryList::create(DOM::Document& document, Vector<NonnullRefPtr<MediaQuery>>&& media)
 {
-    return MUST_OR_THROW_OOM(document.heap().allocate<MediaQueryList>(document.realm(), document, move(media)));
+    return document.heap().allocate<MediaQueryList>(document.realm(), document, move(media));
 }
 
 MediaQueryList::MediaQueryList(DOM::Document& document, Vector<NonnullRefPtr<MediaQuery>>&& media)

--- a/Userland/Libraries/LibWeb/CSS/MediaQueryList.h
+++ b/Userland/Libraries/LibWeb/CSS/MediaQueryList.h
@@ -17,7 +17,7 @@ class MediaQueryList final : public DOM::EventTarget {
     WEB_PLATFORM_OBJECT(MediaQueryList, DOM::EventTarget);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<MediaQueryList>> create(DOM::Document&, Vector<NonnullRefPtr<MediaQuery>>&&);
+    [[nodiscard]] static JS::NonnullGCPtr<MediaQueryList> create(DOM::Document&, Vector<NonnullRefPtr<MediaQuery>>&&);
 
     virtual ~MediaQueryList() override = default;
 

--- a/Userland/Libraries/LibWeb/CSS/MediaQueryListEvent.cpp
+++ b/Userland/Libraries/LibWeb/CSS/MediaQueryListEvent.cpp
@@ -10,9 +10,9 @@
 
 namespace Web::CSS {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<MediaQueryListEvent>> MediaQueryListEvent::construct_impl(JS::Realm& realm, FlyString const& event_name, MediaQueryListEventInit const& event_init)
+JS::NonnullGCPtr<MediaQueryListEvent> MediaQueryListEvent::construct_impl(JS::Realm& realm, FlyString const& event_name, MediaQueryListEventInit const& event_init)
 {
-    return MUST_OR_THROW_OOM(realm.heap().allocate<MediaQueryListEvent>(realm, realm, event_name, event_init));
+    return realm.heap().allocate<MediaQueryListEvent>(realm, realm, event_name, event_init);
 }
 
 MediaQueryListEvent::MediaQueryListEvent(JS::Realm& realm, FlyString const& event_name, MediaQueryListEventInit const& event_init)

--- a/Userland/Libraries/LibWeb/CSS/MediaQueryListEvent.h
+++ b/Userland/Libraries/LibWeb/CSS/MediaQueryListEvent.h
@@ -20,7 +20,7 @@ class MediaQueryListEvent final : public DOM::Event {
     WEB_PLATFORM_OBJECT(MediaQueryListEvent, DOM::Event);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<MediaQueryListEvent>> construct_impl(JS::Realm&, FlyString const& event_name, MediaQueryListEventInit const& event_init = {});
+    [[nodiscard]] static JS::NonnullGCPtr<MediaQueryListEvent> construct_impl(JS::Realm&, FlyString const& event_name, MediaQueryListEventInit const& = {});
 
     virtual ~MediaQueryListEvent() override;
 

--- a/Userland/Libraries/LibWeb/CSS/Parser/Helpers.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Helpers.cpp
@@ -18,9 +18,9 @@ namespace Web {
 CSS::CSSStyleSheet* parse_css_stylesheet(CSS::Parser::ParsingContext const& context, StringView css, Optional<AK::URL> location)
 {
     if (css.is_empty()) {
-        auto rule_list = CSS::CSSRuleList::create_empty(context.realm()).release_value_but_fixme_should_propagate_errors();
-        auto media_list = CSS::MediaList::create(context.realm(), {}).release_value_but_fixme_should_propagate_errors();
-        return CSS::CSSStyleSheet::create(context.realm(), rule_list, media_list, location).release_value_but_fixme_should_propagate_errors();
+        auto rule_list = CSS::CSSRuleList::create_empty(context.realm());
+        auto media_list = CSS::MediaList::create(context.realm(), {});
+        return CSS::CSSStyleSheet::create(context.realm(), rule_list, media_list, location);
     }
     auto parser = CSS::Parser::Parser::create(context, css).release_value_but_fixme_should_propagate_errors();
     return parser.parse_as_css_stylesheet(location);
@@ -29,7 +29,7 @@ CSS::CSSStyleSheet* parse_css_stylesheet(CSS::Parser::ParsingContext const& cont
 CSS::ElementInlineCSSStyleDeclaration* parse_css_style_attribute(CSS::Parser::ParsingContext const& context, StringView css, DOM::Element& element)
 {
     if (css.is_empty())
-        return CSS::ElementInlineCSSStyleDeclaration::create(element, {}, {}).release_value_but_fixme_should_propagate_errors();
+        return CSS::ElementInlineCSSStyleDeclaration::create(element, {}, {});
     auto parser = CSS::Parser::Parser::create(context, css).release_value_but_fixme_should_propagate_errors();
     return parser.parse_as_style_attribute(element);
 }

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -161,9 +161,9 @@ CSSStyleSheet* Parser::parse_as_css_stylesheet(Optional<AK::URL> location)
             rules.append(rule);
     }
 
-    auto rule_list = CSSRuleList::create(m_context.realm(), rules).release_value_but_fixme_should_propagate_errors();
-    auto media_list = MediaList::create(m_context.realm(), {}).release_value_but_fixme_should_propagate_errors();
-    return CSSStyleSheet::create(m_context.realm(), rule_list, media_list, move(location)).release_value_but_fixme_should_propagate_errors();
+    auto rule_list = CSSRuleList::create(m_context.realm(), rules);
+    auto media_list = MediaList::create(m_context.realm(), {});
+    return CSSStyleSheet::create(m_context.realm(), rule_list, media_list, move(location));
 }
 
 Optional<SelectorList> Parser::parse_as_selector(SelectorParsingMode parsing_mode)
@@ -2360,7 +2360,7 @@ ElementInlineCSSStyleDeclaration* Parser::parse_as_style_attribute(DOM::Element&
 {
     auto declarations_and_at_rules = parse_a_list_of_declarations(m_token_stream);
     auto [properties, custom_properties] = extract_properties(declarations_and_at_rules);
-    return ElementInlineCSSStyleDeclaration::create(element, move(properties), move(custom_properties)).release_value_but_fixme_should_propagate_errors();
+    return ElementInlineCSSStyleDeclaration::create(element, move(properties), move(custom_properties));
 }
 
 Optional<AK::URL> Parser::parse_url_function(ComponentValue const& component_value)
@@ -3149,7 +3149,7 @@ CSSRule* Parser::convert_to_rule(NonnullRefPtr<Rule> rule)
             }
 
             if (url.has_value())
-                return CSSImportRule::create(url.value(), const_cast<DOM::Document&>(*m_context.document())).release_value_but_fixme_should_propagate_errors();
+                return CSSImportRule::create(url.value(), const_cast<DOM::Document&>(*m_context.document()));
             dbgln_if(CSS_PARSER_DEBUG, "Unable to parse url from @import rule");
             return {};
         }
@@ -3166,9 +3166,9 @@ CSSRule* Parser::convert_to_rule(NonnullRefPtr<Rule> rule)
                 if (auto* child_rule = convert_to_rule(raw_rule))
                     child_rules.append(child_rule);
             }
-            auto media_list = MediaList::create(m_context.realm(), move(media_query_list)).release_value_but_fixme_should_propagate_errors();
-            auto rule_list = CSSRuleList::create(m_context.realm(), child_rules).release_value_but_fixme_should_propagate_errors();
-            return CSSMediaRule::create(m_context.realm(), media_list, rule_list).release_value_but_fixme_should_propagate_errors();
+            auto media_list = MediaList::create(m_context.realm(), move(media_query_list));
+            auto rule_list = CSSRuleList::create(m_context.realm(), child_rules);
+            return CSSMediaRule::create(m_context.realm(), media_list, rule_list);
         }
         if (rule->at_rule_name().equals_ignoring_ascii_case("supports"sv)) {
             auto supports_tokens = TokenStream { rule->prelude() };
@@ -3191,8 +3191,8 @@ CSSRule* Parser::convert_to_rule(NonnullRefPtr<Rule> rule)
                     child_rules.append(child_rule);
             }
 
-            auto rule_list = CSSRuleList::create(m_context.realm(), child_rules).release_value_but_fixme_should_propagate_errors();
-            return CSSSupportsRule::create(m_context.realm(), supports.release_nonnull(), rule_list).release_value_but_fixme_should_propagate_errors();
+            auto rule_list = CSSRuleList::create(m_context.realm(), child_rules);
+            return CSSSupportsRule::create(m_context.realm(), supports.release_nonnull(), rule_list);
         }
         if (rule->at_rule_name().equals_ignoring_ascii_case("keyframes"sv)) {
             auto prelude_stream = TokenStream { rule->prelude() };
@@ -3286,7 +3286,7 @@ CSSRule* Parser::convert_to_rule(NonnullRefPtr<Rule> rule)
                     auto block_declarations = parse_a_list_of_declarations(block_stream);
                     auto style = convert_to_style_declaration(block_declarations);
                     for (auto& selector : selectors) {
-                        auto keyframe_rule = CSSKeyframeRule::create(m_context.realm(), selector, *style).release_value_but_fixme_should_propagate_errors();
+                        auto keyframe_rule = CSSKeyframeRule::create(m_context.realm(), selector, *style);
                         keyframes.append(keyframe_rule);
                     }
                 } else {
@@ -3294,7 +3294,7 @@ CSSRule* Parser::convert_to_rule(NonnullRefPtr<Rule> rule)
                 }
             }
 
-            return CSSKeyframesRule::create(m_context.realm(), name, move(keyframes)).release_value_but_fixme_should_propagate_errors();
+            return CSSKeyframesRule::create(m_context.realm(), name, move(keyframes));
         }
         if (rule->at_rule_name().equals_ignoring_ascii_case("namespace"sv)) {
             // https://drafts.csswg.org/css-namespaces/#syntax
@@ -3325,7 +3325,7 @@ CSSRule* Parser::convert_to_rule(NonnullRefPtr<Rule> rule)
                 return {};
             }
 
-            return CSSNamespaceRule::create(m_context.realm(), prefix, namespace_uri).release_value_but_fixme_should_propagate_errors();
+            return CSSNamespaceRule::create(m_context.realm(), prefix, namespace_uri);
         }
 
         // FIXME: More at rules!
@@ -3363,7 +3363,7 @@ CSSRule* Parser::convert_to_rule(NonnullRefPtr<Rule> rule)
         return {};
     }
 
-    return CSSStyleRule::create(m_context.realm(), move(selectors.value()), *declaration).release_value_but_fixme_should_propagate_errors();
+    return CSSStyleRule::create(m_context.realm(), move(selectors.value()), *declaration);
 }
 
 auto Parser::extract_properties(Vector<DeclarationOrAtRule> const& declarations_and_at_rules) -> PropertiesAndCustomProperties
@@ -3392,7 +3392,7 @@ auto Parser::extract_properties(Vector<DeclarationOrAtRule> const& declarations_
 PropertyOwningCSSStyleDeclaration* Parser::convert_to_style_declaration(Vector<DeclarationOrAtRule> const& declarations_and_at_rules)
 {
     auto [properties, custom_properties] = extract_properties(declarations_and_at_rules);
-    return PropertyOwningCSSStyleDeclaration::create(m_context.realm(), move(properties), move(custom_properties)).release_value_but_fixme_should_propagate_errors();
+    return PropertyOwningCSSStyleDeclaration::create(m_context.realm(), move(properties), move(custom_properties));
 }
 
 Optional<StyleProperty> Parser::convert_to_style_property(Declaration const& declaration)
@@ -6133,7 +6133,7 @@ CSSRule* Parser::parse_font_face_rule(TokenStream<ComponentValue>& tokens)
         unicode_range.empend(0x0u, 0x10FFFFu);
     }
 
-    return CSSFontFaceRule::create(m_context.realm(), FontFace { font_family.release_value(), weight, slope, move(src), move(unicode_range) }).release_value_but_fixme_should_propagate_errors();
+    return CSSFontFaceRule::create(m_context.realm(), FontFace { font_family.release_value(), weight, slope, move(src), move(unicode_range) });
 }
 
 Vector<FontFace::Source> Parser::parse_font_face_src(TokenStream<ComponentValue>& component_values)

--- a/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
@@ -48,9 +48,9 @@
 
 namespace Web::CSS {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<ResolvedCSSStyleDeclaration>> ResolvedCSSStyleDeclaration::create(DOM::Element& element)
+JS::NonnullGCPtr<ResolvedCSSStyleDeclaration> ResolvedCSSStyleDeclaration::create(DOM::Element& element)
 {
-    return MUST_OR_THROW_OOM(element.realm().heap().allocate<ResolvedCSSStyleDeclaration>(element.realm(), element));
+    return element.realm().heap().allocate<ResolvedCSSStyleDeclaration>(element.realm(), element);
 }
 
 ResolvedCSSStyleDeclaration::ResolvedCSSStyleDeclaration(DOM::Element& element)

--- a/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.h
+++ b/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.h
@@ -14,7 +14,7 @@ class ResolvedCSSStyleDeclaration final : public CSSStyleDeclaration {
     WEB_PLATFORM_OBJECT(ResolvedCSSStyleDeclaration, CSSStyleDeclaration);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<ResolvedCSSStyleDeclaration>> create(DOM::Element& element);
+    [[nodiscard]] static JS::NonnullGCPtr<ResolvedCSSStyleDeclaration> create(DOM::Element&);
 
     virtual ~ResolvedCSSStyleDeclaration() override = default;
 

--- a/Userland/Libraries/LibWeb/CSS/Screen.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Screen.cpp
@@ -13,9 +13,9 @@
 
 namespace Web::CSS {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<Screen>> Screen::create(HTML::Window& window)
+JS::NonnullGCPtr<Screen> Screen::create(HTML::Window& window)
 {
-    return MUST_OR_THROW_OOM(window.heap().allocate<Screen>(window.realm(), window));
+    return window.heap().allocate<Screen>(window.realm(), window);
 }
 
 Screen::Screen(HTML::Window& window)

--- a/Userland/Libraries/LibWeb/CSS/Screen.h
+++ b/Userland/Libraries/LibWeb/CSS/Screen.h
@@ -17,7 +17,7 @@ class Screen final : public Bindings::PlatformObject {
     WEB_PLATFORM_OBJECT(Screen, Bindings::PlatformObject);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<Screen>> create(HTML::Window&);
+    [[nodiscard]] static JS::NonnullGCPtr<Screen> create(HTML::Window&);
 
     i32 width() const { return screen_rect().width(); }
     i32 height() const { return screen_rect().height(); }

--- a/Userland/Libraries/LibWeb/CSS/StyleSheetList.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleSheetList.cpp
@@ -62,10 +62,10 @@ void StyleSheetList::remove_sheet(CSSStyleSheet& sheet)
     m_document->invalidate_style();
 }
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<StyleSheetList>> StyleSheetList::create(DOM::Document& document)
+JS::NonnullGCPtr<StyleSheetList> StyleSheetList::create(DOM::Document& document)
 {
     auto& realm = document.realm();
-    return MUST_OR_THROW_OOM(realm.heap().allocate<StyleSheetList>(realm, document));
+    return realm.heap().allocate<StyleSheetList>(realm, document);
 }
 
 StyleSheetList::StyleSheetList(DOM::Document& document)

--- a/Userland/Libraries/LibWeb/CSS/StyleSheetList.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleSheetList.h
@@ -16,7 +16,7 @@ class StyleSheetList : public Bindings::LegacyPlatformObject {
     WEB_PLATFORM_OBJECT(StyleSheetList, Bindings::LegacyPlatformObject);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<StyleSheetList>> create(DOM::Document& document);
+    [[nodiscard]] static JS::NonnullGCPtr<StyleSheetList> create(DOM::Document&);
 
     void add_sheet(CSSStyleSheet&);
     void remove_sheet(CSSStyleSheet&);

--- a/Userland/Libraries/LibWeb/CSS/VisualViewport.cpp
+++ b/Userland/Libraries/LibWeb/CSS/VisualViewport.cpp
@@ -15,9 +15,9 @@
 
 namespace Web::CSS {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<VisualViewport>> VisualViewport::create(DOM::Document& document)
+JS::NonnullGCPtr<VisualViewport> VisualViewport::create(DOM::Document& document)
 {
-    return MUST_OR_THROW_OOM(document.heap().allocate<VisualViewport>(document.realm(), document));
+    return document.heap().allocate<VisualViewport>(document.realm(), document);
 }
 
 VisualViewport::VisualViewport(DOM::Document& document)

--- a/Userland/Libraries/LibWeb/CSS/VisualViewport.h
+++ b/Userland/Libraries/LibWeb/CSS/VisualViewport.h
@@ -15,7 +15,7 @@ class VisualViewport final : public DOM::EventTarget {
     WEB_PLATFORM_OBJECT(VisualViewport, DOM::EventTarget);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<VisualViewport>> create(DOM::Document&);
+    [[nodiscard]] static JS::NonnullGCPtr<VisualViewport> create(DOM::Document&);
 
     virtual ~VisualViewport() override = default;
 

--- a/Userland/Libraries/LibWeb/Crypto/Crypto.cpp
+++ b/Userland/Libraries/LibWeb/Crypto/Crypto.cpp
@@ -15,9 +15,9 @@
 
 namespace Web::Crypto {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<Crypto>> Crypto::create(JS::Realm& realm)
+JS::NonnullGCPtr<Crypto> Crypto::create(JS::Realm& realm)
 {
-    return MUST_OR_THROW_OOM(realm.heap().allocate<Crypto>(realm, realm));
+    return realm.heap().allocate<Crypto>(realm, realm);
 }
 
 Crypto::Crypto(JS::Realm& realm)
@@ -31,7 +31,7 @@ void Crypto::initialize(JS::Realm& realm)
 {
     Base::initialize(realm);
     set_prototype(&Bindings::ensure_web_prototype<Bindings::CryptoPrototype>(realm, "Crypto"));
-    m_subtle = MUST(SubtleCrypto::create(realm));
+    m_subtle = SubtleCrypto::create(realm);
 }
 
 JS::NonnullGCPtr<SubtleCrypto> Crypto::subtle() const

--- a/Userland/Libraries/LibWeb/Crypto/Crypto.h
+++ b/Userland/Libraries/LibWeb/Crypto/Crypto.h
@@ -16,7 +16,7 @@ class Crypto : public Bindings::PlatformObject {
     WEB_PLATFORM_OBJECT(Crypto, Bindings::PlatformObject);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<Crypto>> create(JS::Realm&);
+    [[nodiscard]] static JS::NonnullGCPtr<Crypto> create(JS::Realm&);
 
     virtual ~Crypto() override;
 

--- a/Userland/Libraries/LibWeb/Crypto/SubtleCrypto.cpp
+++ b/Userland/Libraries/LibWeb/Crypto/SubtleCrypto.cpp
@@ -14,9 +14,9 @@
 
 namespace Web::Crypto {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<SubtleCrypto>> SubtleCrypto::create(JS::Realm& realm)
+JS::NonnullGCPtr<SubtleCrypto> SubtleCrypto::create(JS::Realm& realm)
 {
-    return MUST_OR_THROW_OOM(realm.heap().allocate<SubtleCrypto>(realm, realm));
+    return realm.heap().allocate<SubtleCrypto>(realm, realm);
 }
 
 SubtleCrypto::SubtleCrypto(JS::Realm& realm)

--- a/Userland/Libraries/LibWeb/Crypto/SubtleCrypto.h
+++ b/Userland/Libraries/LibWeb/Crypto/SubtleCrypto.h
@@ -15,7 +15,7 @@ class SubtleCrypto final : public Bindings::PlatformObject {
     WEB_PLATFORM_OBJECT(SubtleCrypto, Bindings::PlatformObject);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<SubtleCrypto>> create(JS::Realm&);
+    [[nodiscard]] static JS::NonnullGCPtr<SubtleCrypto> create(JS::Realm&);
 
     virtual ~SubtleCrypto() override;
 

--- a/Userland/Libraries/LibWeb/DOM/AbortController.cpp
+++ b/Userland/Libraries/LibWeb/DOM/AbortController.cpp
@@ -13,7 +13,7 @@ namespace Web::DOM {
 WebIDL::ExceptionOr<JS::NonnullGCPtr<AbortController>> AbortController::construct_impl(JS::Realm& realm)
 {
     auto signal = TRY(AbortSignal::construct_impl(realm));
-    return MUST_OR_THROW_OOM(realm.heap().allocate<AbortController>(realm, realm, move(signal)));
+    return realm.heap().allocate<AbortController>(realm, realm, move(signal));
 }
 
 // https://dom.spec.whatwg.org/#dom-abortcontroller-abortcontroller

--- a/Userland/Libraries/LibWeb/DOM/AbortSignal.cpp
+++ b/Userland/Libraries/LibWeb/DOM/AbortSignal.cpp
@@ -14,7 +14,7 @@ namespace Web::DOM {
 
 WebIDL::ExceptionOr<JS::NonnullGCPtr<AbortSignal>> AbortSignal::construct_impl(JS::Realm& realm)
 {
-    return MUST_OR_THROW_OOM(realm.heap().allocate<AbortSignal>(realm, realm));
+    return realm.heap().allocate<AbortSignal>(realm, realm);
 }
 
 AbortSignal::AbortSignal(JS::Realm& realm)
@@ -60,7 +60,7 @@ void AbortSignal::signal_abort(JS::Value reason)
     m_abort_algorithms.clear();
 
     // 5. Fire an event named abort at signal.
-    dispatch_event(Event::create(realm(), HTML::EventNames::abort).release_value_but_fixme_should_propagate_errors());
+    dispatch_event(Event::create(realm(), HTML::EventNames::abort));
 }
 
 void AbortSignal::set_onabort(WebIDL::CallbackType* event_handler)

--- a/Userland/Libraries/LibWeb/DOM/AccessibilityTreeNode.cpp
+++ b/Userland/Libraries/LibWeb/DOM/AccessibilityTreeNode.cpp
@@ -13,9 +13,9 @@
 
 namespace Web::DOM {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<AccessibilityTreeNode>> AccessibilityTreeNode::create(Document* document, DOM::Node const* value)
+JS::NonnullGCPtr<AccessibilityTreeNode> AccessibilityTreeNode::create(Document* document, DOM::Node const* value)
 {
-    return MUST_OR_THROW_OOM(document->heap().allocate<AccessibilityTreeNode>(document->realm(), value));
+    return document->heap().allocate<AccessibilityTreeNode>(document->realm(), value);
 }
 
 AccessibilityTreeNode::AccessibilityTreeNode(JS::GCPtr<DOM::Node const> value)

--- a/Userland/Libraries/LibWeb/DOM/AccessibilityTreeNode.h
+++ b/Userland/Libraries/LibWeb/DOM/AccessibilityTreeNode.h
@@ -17,7 +17,7 @@ namespace Web::DOM {
 class AccessibilityTreeNode final : public JS::Cell {
     JS_CELL(AccessibilityTreeNode, JS::Cell)
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<AccessibilityTreeNode>> create(Document*, DOM::Node const*);
+    static JS::NonnullGCPtr<AccessibilityTreeNode> create(Document*, DOM::Node const*);
     virtual ~AccessibilityTreeNode() override = default;
 
     JS::GCPtr<DOM::Node const> value() const { return m_value; }

--- a/Userland/Libraries/LibWeb/DOM/Attr.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Attr.cpp
@@ -15,19 +15,19 @@
 
 namespace Web::DOM {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<Attr>> Attr::create(Document& document, DeprecatedFlyString local_name, DeprecatedString value, Element* owner_element)
+JS::NonnullGCPtr<Attr> Attr::create(Document& document, DeprecatedFlyString local_name, DeprecatedString value, Element* owner_element)
 {
-    return MUST_OR_THROW_OOM(document.heap().allocate<Attr>(document.realm(), document, QualifiedName(move(local_name), {}, {}), move(value), owner_element));
+    return document.heap().allocate<Attr>(document.realm(), document, QualifiedName(move(local_name), {}, {}), move(value), owner_element);
 }
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<Attr>> Attr::create(Document& document, QualifiedName qualified_name, DeprecatedString value, Element* owner_element)
+JS::NonnullGCPtr<Attr> Attr::create(Document& document, QualifiedName qualified_name, DeprecatedString value, Element* owner_element)
 {
-    return MUST_OR_THROW_OOM(document.heap().allocate<Attr>(document.realm(), document, move(qualified_name), move(value), owner_element));
+    return document.heap().allocate<Attr>(document.realm(), document, move(qualified_name), move(value), owner_element);
 }
 
 JS::NonnullGCPtr<Attr> Attr::clone(Document& document)
 {
-    return *heap().allocate<Attr>(realm(), document, m_qualified_name, m_value, nullptr).release_allocated_value_but_fixme_should_propagate_errors();
+    return *heap().allocate<Attr>(realm(), document, m_qualified_name, m_value, nullptr);
 }
 
 Attr::Attr(Document& document, QualifiedName qualified_name, DeprecatedString value, Element* owner_element)

--- a/Userland/Libraries/LibWeb/DOM/Attr.h
+++ b/Userland/Libraries/LibWeb/DOM/Attr.h
@@ -18,8 +18,8 @@ class Attr final : public Node {
     WEB_PLATFORM_OBJECT(Attr, Node);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<Attr>> create(Document&, QualifiedName, DeprecatedString value = "", Element* = nullptr);
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<Attr>> create(Document&, DeprecatedFlyString local_name, DeprecatedString value = "", Element* = nullptr);
+    [[nodiscard]] static JS::NonnullGCPtr<Attr> create(Document&, QualifiedName, DeprecatedString value = "", Element* = nullptr);
+    [[nodiscard]] static JS::NonnullGCPtr<Attr> create(Document&, DeprecatedFlyString local_name, DeprecatedString value = "", Element* = nullptr);
     JS::NonnullGCPtr<Attr> clone(Document&);
 
     virtual ~Attr() override = default;

--- a/Userland/Libraries/LibWeb/DOM/Comment.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Comment.cpp
@@ -20,7 +20,7 @@ Comment::Comment(Document& document, DeprecatedString const& data)
 WebIDL::ExceptionOr<JS::NonnullGCPtr<Comment>> Comment::construct_impl(JS::Realm& realm, DeprecatedString const& data)
 {
     auto& window = verify_cast<HTML::Window>(realm.global_object());
-    return MUST_OR_THROW_OOM(realm.heap().allocate<Comment>(realm, window.associated_document(), data));
+    return realm.heap().allocate<Comment>(realm, window.associated_document(), data);
 }
 
 void Comment::initialize(JS::Realm& realm)

--- a/Userland/Libraries/LibWeb/DOM/CustomEvent.cpp
+++ b/Userland/Libraries/LibWeb/DOM/CustomEvent.cpp
@@ -11,9 +11,9 @@
 
 namespace Web::DOM {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<CustomEvent>> CustomEvent::create(JS::Realm& realm, FlyString const& event_name, CustomEventInit const& event_init)
+JS::NonnullGCPtr<CustomEvent> CustomEvent::create(JS::Realm& realm, FlyString const& event_name, CustomEventInit const& event_init)
 {
-    return MUST_OR_THROW_OOM(realm.heap().allocate<CustomEvent>(realm, realm, event_name, event_init));
+    return realm.heap().allocate<CustomEvent>(realm, realm, event_name, event_init);
 }
 
 WebIDL::ExceptionOr<JS::NonnullGCPtr<CustomEvent>> CustomEvent::construct_impl(JS::Realm& realm, FlyString const& event_name, CustomEventInit const& event_init)

--- a/Userland/Libraries/LibWeb/DOM/CustomEvent.h
+++ b/Userland/Libraries/LibWeb/DOM/CustomEvent.h
@@ -21,8 +21,8 @@ class CustomEvent : public Event {
     WEB_PLATFORM_OBJECT(CustomEvent, Event);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<CustomEvent>> create(JS::Realm&, FlyString const& event_name, CustomEventInit const& event_init = {});
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<CustomEvent>> construct_impl(JS::Realm&, FlyString const& event_name, CustomEventInit const& event_init);
+    [[nodiscard]] static JS::NonnullGCPtr<CustomEvent> create(JS::Realm&, FlyString const& event_name, CustomEventInit const& = {});
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<CustomEvent>> construct_impl(JS::Realm&, FlyString const& event_name, CustomEventInit const&);
 
     virtual ~CustomEvent() override;
 

--- a/Userland/Libraries/LibWeb/DOM/DOMImplementation.cpp
+++ b/Userland/Libraries/LibWeb/DOM/DOMImplementation.cpp
@@ -17,10 +17,10 @@
 
 namespace Web::DOM {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<DOMImplementation>> DOMImplementation::create(Document& document)
+JS::NonnullGCPtr<DOMImplementation> DOMImplementation::create(Document& document)
 {
     auto& realm = document.realm();
-    return MUST_OR_THROW_OOM(realm.heap().allocate<DOMImplementation>(realm, document));
+    return realm.heap().allocate<DOMImplementation>(realm, document);
 }
 
 DOMImplementation::DOMImplementation(Document& document)
@@ -47,7 +47,7 @@ void DOMImplementation::visit_edges(Cell::Visitor& visitor)
 WebIDL::ExceptionOr<JS::NonnullGCPtr<Document>> DOMImplementation::create_document(DeprecatedString const& namespace_, DeprecatedString const& qualified_name, JS::GCPtr<DocumentType> doctype) const
 {
     // FIXME: This should specifically be an XML document.
-    auto xml_document = TRY(Document::create(realm()));
+    auto xml_document = Document::create(realm());
 
     xml_document->set_ready_for_post_load_tasks(true);
 
@@ -77,12 +77,12 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Document>> DOMImplementation::create_docume
 // https://dom.spec.whatwg.org/#dom-domimplementation-createhtmldocument
 JS::NonnullGCPtr<Document> DOMImplementation::create_html_document(DeprecatedString const& title) const
 {
-    auto html_document = Document::create(realm()).release_value_but_fixme_should_propagate_errors();
+    auto html_document = Document::create(realm());
 
     html_document->set_content_type("text/html");
     html_document->set_ready_for_post_load_tasks(true);
 
-    auto doctype = heap().allocate<DocumentType>(realm(), html_document).release_allocated_value_but_fixme_should_propagate_errors();
+    auto doctype = heap().allocate<DocumentType>(realm(), html_document);
     doctype->set_name("html");
     MUST(html_document->append_child(*doctype));
 
@@ -96,7 +96,7 @@ JS::NonnullGCPtr<Document> DOMImplementation::create_html_document(DeprecatedStr
         auto title_element = create_element(html_document, HTML::TagNames::title, Namespace::HTML).release_value_but_fixme_should_propagate_errors();
         MUST(head_element->append_child(title_element));
 
-        auto text_node = heap().allocate<Text>(realm(), html_document, title).release_allocated_value_but_fixme_should_propagate_errors();
+        auto text_node = heap().allocate<Text>(realm(), html_document, title);
         MUST(title_element->append_child(*text_node));
     }
 
@@ -112,7 +112,7 @@ JS::NonnullGCPtr<Document> DOMImplementation::create_html_document(DeprecatedStr
 WebIDL::ExceptionOr<JS::NonnullGCPtr<DocumentType>> DOMImplementation::create_document_type(DeprecatedString const& qualified_name, DeprecatedString const& public_id, DeprecatedString const& system_id)
 {
     TRY(Document::validate_qualified_name(realm(), qualified_name));
-    auto document_type = TRY(DocumentType::create(document()));
+    auto document_type = DocumentType::create(document());
     document_type->set_name(qualified_name);
     document_type->set_public_id(public_id);
     document_type->set_system_id(system_id);

--- a/Userland/Libraries/LibWeb/DOM/DOMImplementation.h
+++ b/Userland/Libraries/LibWeb/DOM/DOMImplementation.h
@@ -17,7 +17,7 @@ class DOMImplementation final : public Bindings::PlatformObject {
     WEB_PLATFORM_OBJECT(DOMImplementation, Bindings::PlatformObject);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<DOMImplementation>> create(Document&);
+    [[nodiscard]] static JS::NonnullGCPtr<DOMImplementation> create(Document&);
     virtual ~DOMImplementation();
 
     WebIDL::ExceptionOr<JS::NonnullGCPtr<Document>> create_document(DeprecatedString const&, DeprecatedString const&, JS::GCPtr<DocumentType>) const;

--- a/Userland/Libraries/LibWeb/DOM/DOMTokenList.cpp
+++ b/Userland/Libraries/LibWeb/DOM/DOMTokenList.cpp
@@ -52,10 +52,10 @@ inline void replace_in_ordered_set(Vector<DeprecatedString>& set, StringView ite
 
 namespace Web::DOM {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<DOMTokenList>> DOMTokenList::create(Element& associated_element, DeprecatedFlyString associated_attribute)
+JS::NonnullGCPtr<DOMTokenList> DOMTokenList::create(Element& associated_element, DeprecatedFlyString associated_attribute)
 {
     auto& realm = associated_element.realm();
-    return MUST_OR_THROW_OOM(realm.heap().allocate<DOMTokenList>(realm, associated_element, move(associated_attribute)));
+    return realm.heap().allocate<DOMTokenList>(realm, associated_element, move(associated_attribute));
 }
 
 // https://dom.spec.whatwg.org/#ref-for-domtokenlist%E2%91%A0%E2%91%A2

--- a/Userland/Libraries/LibWeb/DOM/DOMTokenList.h
+++ b/Userland/Libraries/LibWeb/DOM/DOMTokenList.h
@@ -24,7 +24,7 @@ class DOMTokenList final : public Bindings::LegacyPlatformObject {
     WEB_PLATFORM_OBJECT(DOMTokenList, Bindings::LegacyPlatformObject);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<DOMTokenList>> create(Element& associated_element, DeprecatedFlyString associated_attribute);
+    [[nodiscard]] static JS::NonnullGCPtr<DOMTokenList> create(Element& associated_element, DeprecatedFlyString associated_attribute);
     ~DOMTokenList() = default;
 
     void associated_attribute_changed(StringView value);

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -91,7 +91,7 @@ public:
 
     static WebIDL::ExceptionOr<JS::NonnullGCPtr<Document>> create_and_initialize(Type, DeprecatedString content_type, HTML::NavigationParams);
 
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<Document>> create(JS::Realm&, AK::URL const& url = "about:blank"sv);
+    [[nodiscard]] static JS::NonnullGCPtr<Document> create(JS::Realm&, AK::URL const& url = "about:blank"sv);
     static WebIDL::ExceptionOr<JS::NonnullGCPtr<Document>> construct_impl(JS::Realm&);
     virtual ~Document() override;
 
@@ -362,7 +362,7 @@ public:
     JS::NonnullGCPtr<HTML::History> history();
     JS::NonnullGCPtr<HTML::History> history() const;
 
-    WebIDL::ExceptionOr<JS::GCPtr<HTML::Location>> location();
+    [[nodiscard]] JS::GCPtr<HTML::Location> location();
 
     size_t number_of_things_delaying_the_load_event() { return m_number_of_things_delaying_the_load_event; }
     void increment_number_of_things_delaying_the_load_event(Badge<DocumentLoadEventDelayer>);

--- a/Userland/Libraries/LibWeb/DOM/DocumentFragment.cpp
+++ b/Userland/Libraries/LibWeb/DOM/DocumentFragment.cpp
@@ -35,7 +35,7 @@ void DocumentFragment::set_host(Web::DOM::Element* element)
 WebIDL::ExceptionOr<JS::NonnullGCPtr<DocumentFragment>> DocumentFragment::construct_impl(JS::Realm& realm)
 {
     auto& window = verify_cast<HTML::Window>(realm.global_object());
-    return MUST_OR_THROW_OOM(realm.heap().allocate<DocumentFragment>(realm, window.associated_document()));
+    return realm.heap().allocate<DocumentFragment>(realm, window.associated_document());
 }
 
 }

--- a/Userland/Libraries/LibWeb/DOM/DocumentLoading.cpp
+++ b/Userland/Libraries/LibWeb/DOM/DocumentLoading.cpp
@@ -119,7 +119,7 @@ static bool build_image_document(DOM::Document& document, ByteBuffer const& data
     MUST(head_element->append_child(title_element));
 
     auto basename = LexicalPath::basename(document.url().serialize_path());
-    auto title_text = document.heap().allocate<DOM::Text>(document.realm(), document, DeprecatedString::formatted("{} [{}x{}]", basename, bitmap->width(), bitmap->height())).release_allocated_value_but_fixme_should_propagate_errors();
+    auto title_text = document.heap().allocate<DOM::Text>(document.realm(), document, DeprecatedString::formatted("{} [{}x{}]", basename, bitmap->width(), bitmap->height()));
     MUST(title_element->append_child(*title_text));
 
     auto body_element = DOM::create_element(document, HTML::TagNames::body, Namespace::HTML).release_value_but_fixme_should_propagate_errors();

--- a/Userland/Libraries/LibWeb/DOM/DocumentType.cpp
+++ b/Userland/Libraries/LibWeb/DOM/DocumentType.cpp
@@ -9,9 +9,9 @@
 
 namespace Web::DOM {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<DocumentType>> DocumentType::create(Document& document)
+JS::NonnullGCPtr<DocumentType> DocumentType::create(Document& document)
 {
-    return MUST_OR_THROW_OOM(document.heap().allocate<DocumentType>(document.realm(), document));
+    return document.heap().allocate<DocumentType>(document.realm(), document);
 }
 
 DocumentType::DocumentType(Document& document)

--- a/Userland/Libraries/LibWeb/DOM/DocumentType.h
+++ b/Userland/Libraries/LibWeb/DOM/DocumentType.h
@@ -18,7 +18,7 @@ class DocumentType final
     WEB_PLATFORM_OBJECT(DocumentType, Node);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<DocumentType>> create(Document&);
+    [[nodiscard]] static JS::NonnullGCPtr<DocumentType> create(Document&);
 
     virtual ~DocumentType() override = default;
 

--- a/Userland/Libraries/LibWeb/DOM/ElementFactory.cpp
+++ b/Userland/Libraries/LibWeb/DOM/ElementFactory.cpp
@@ -270,221 +270,221 @@ bool is_unknown_html_element(DeprecatedFlyString const& tag_name)
 }
 
 // https://html.spec.whatwg.org/#elements-in-the-dom:element-interface
-static WebIDL::ExceptionOr<JS::NonnullGCPtr<Element>> create_html_element(JS::Realm& realm, Document& document, QualifiedName qualified_name)
+static JS::NonnullGCPtr<Element> create_html_element(JS::Realm& realm, Document& document, QualifiedName qualified_name)
 {
     auto lowercase_tag_name = qualified_name.local_name().to_lowercase();
 
     if (lowercase_tag_name == HTML::TagNames::a)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLAnchorElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<HTML::HTMLAnchorElement>(realm, document, move(qualified_name));
     if (lowercase_tag_name == HTML::TagNames::area)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLAreaElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<HTML::HTMLAreaElement>(realm, document, move(qualified_name));
     if (lowercase_tag_name == HTML::TagNames::audio)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLAudioElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<HTML::HTMLAudioElement>(realm, document, move(qualified_name));
     if (lowercase_tag_name == HTML::TagNames::base)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLBaseElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<HTML::HTMLBaseElement>(realm, document, move(qualified_name));
     if (lowercase_tag_name == HTML::TagNames::blink)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLBlinkElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<HTML::HTMLBlinkElement>(realm, document, move(qualified_name));
     if (lowercase_tag_name == HTML::TagNames::body)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLBodyElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<HTML::HTMLBodyElement>(realm, document, move(qualified_name));
     if (lowercase_tag_name == HTML::TagNames::br)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLBRElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<HTML::HTMLBRElement>(realm, document, move(qualified_name));
     if (lowercase_tag_name == HTML::TagNames::button)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLButtonElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<HTML::HTMLButtonElement>(realm, document, move(qualified_name));
     if (lowercase_tag_name == HTML::TagNames::canvas)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLCanvasElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<HTML::HTMLCanvasElement>(realm, document, move(qualified_name));
     if (lowercase_tag_name == HTML::TagNames::data)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLDataElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<HTML::HTMLDataElement>(realm, document, move(qualified_name));
     if (lowercase_tag_name == HTML::TagNames::datalist)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLDataListElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<HTML::HTMLDataListElement>(realm, document, move(qualified_name));
     if (lowercase_tag_name == HTML::TagNames::details)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLDetailsElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<HTML::HTMLDetailsElement>(realm, document, move(qualified_name));
     if (lowercase_tag_name == HTML::TagNames::dialog)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLDialogElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<HTML::HTMLDialogElement>(realm, document, move(qualified_name));
     if (lowercase_tag_name == HTML::TagNames::dir)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLDirectoryElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<HTML::HTMLDirectoryElement>(realm, document, move(qualified_name));
     if (lowercase_tag_name == HTML::TagNames::div)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLDivElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<HTML::HTMLDivElement>(realm, document, move(qualified_name));
     if (lowercase_tag_name == HTML::TagNames::dl)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLDListElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<HTML::HTMLDListElement>(realm, document, move(qualified_name));
     if (lowercase_tag_name == HTML::TagNames::embed)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLEmbedElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<HTML::HTMLEmbedElement>(realm, document, move(qualified_name));
     if (lowercase_tag_name == HTML::TagNames::fieldset)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLFieldSetElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<HTML::HTMLFieldSetElement>(realm, document, move(qualified_name));
     if (lowercase_tag_name == HTML::TagNames::font)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLFontElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<HTML::HTMLFontElement>(realm, document, move(qualified_name));
     if (lowercase_tag_name == HTML::TagNames::form)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLFormElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<HTML::HTMLFormElement>(realm, document, move(qualified_name));
     if (lowercase_tag_name == HTML::TagNames::frame)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLFrameElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<HTML::HTMLFrameElement>(realm, document, move(qualified_name));
     if (lowercase_tag_name == HTML::TagNames::frameset)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLFrameSetElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<HTML::HTMLFrameSetElement>(realm, document, move(qualified_name));
     if (lowercase_tag_name == HTML::TagNames::head)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLHeadElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<HTML::HTMLHeadElement>(realm, document, move(qualified_name));
     if (lowercase_tag_name.is_one_of(HTML::TagNames::h1, HTML::TagNames::h2, HTML::TagNames::h3, HTML::TagNames::h4, HTML::TagNames::h5, HTML::TagNames::h6))
-        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLHeadingElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<HTML::HTMLHeadingElement>(realm, document, move(qualified_name));
     if (lowercase_tag_name == HTML::TagNames::hr)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLHRElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<HTML::HTMLHRElement>(realm, document, move(qualified_name));
     if (lowercase_tag_name == HTML::TagNames::html)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLHtmlElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<HTML::HTMLHtmlElement>(realm, document, move(qualified_name));
     if (lowercase_tag_name == HTML::TagNames::iframe)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLIFrameElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<HTML::HTMLIFrameElement>(realm, document, move(qualified_name));
     if (lowercase_tag_name == HTML::TagNames::img)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLImageElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<HTML::HTMLImageElement>(realm, document, move(qualified_name));
     if (lowercase_tag_name == HTML::TagNames::input)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLInputElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<HTML::HTMLInputElement>(realm, document, move(qualified_name));
     if (lowercase_tag_name == HTML::TagNames::label)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLLabelElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<HTML::HTMLLabelElement>(realm, document, move(qualified_name));
     if (lowercase_tag_name == HTML::TagNames::legend)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLLegendElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<HTML::HTMLLegendElement>(realm, document, move(qualified_name));
     if (lowercase_tag_name == HTML::TagNames::li)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLLIElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<HTML::HTMLLIElement>(realm, document, move(qualified_name));
     if (lowercase_tag_name == HTML::TagNames::link)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLLinkElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<HTML::HTMLLinkElement>(realm, document, move(qualified_name));
     if (lowercase_tag_name == HTML::TagNames::map)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLMapElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<HTML::HTMLMapElement>(realm, document, move(qualified_name));
     if (lowercase_tag_name == HTML::TagNames::marquee)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLMarqueeElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<HTML::HTMLMarqueeElement>(realm, document, move(qualified_name));
     if (lowercase_tag_name == HTML::TagNames::menu)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLMenuElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<HTML::HTMLMenuElement>(realm, document, move(qualified_name));
     if (lowercase_tag_name == HTML::TagNames::meta)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLMetaElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<HTML::HTMLMetaElement>(realm, document, move(qualified_name));
     if (lowercase_tag_name == HTML::TagNames::meter)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLMeterElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<HTML::HTMLMeterElement>(realm, document, move(qualified_name));
     if (lowercase_tag_name.is_one_of(HTML::TagNames::ins, HTML::TagNames::del))
-        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLModElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<HTML::HTMLModElement>(realm, document, move(qualified_name));
     if (lowercase_tag_name == HTML::TagNames::object)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLObjectElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<HTML::HTMLObjectElement>(realm, document, move(qualified_name));
     if (lowercase_tag_name == HTML::TagNames::ol)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLOListElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<HTML::HTMLOListElement>(realm, document, move(qualified_name));
     if (lowercase_tag_name == HTML::TagNames::optgroup)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLOptGroupElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<HTML::HTMLOptGroupElement>(realm, document, move(qualified_name));
     if (lowercase_tag_name == HTML::TagNames::option)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLOptionElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<HTML::HTMLOptionElement>(realm, document, move(qualified_name));
     if (lowercase_tag_name == HTML::TagNames::output)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLOutputElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<HTML::HTMLOutputElement>(realm, document, move(qualified_name));
     if (lowercase_tag_name == HTML::TagNames::p)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLParagraphElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<HTML::HTMLParagraphElement>(realm, document, move(qualified_name));
     if (lowercase_tag_name == HTML::TagNames::param)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLParamElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<HTML::HTMLParamElement>(realm, document, move(qualified_name));
     if (lowercase_tag_name == HTML::TagNames::picture)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLPictureElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<HTML::HTMLPictureElement>(realm, document, move(qualified_name));
     // NOTE: The obsolete elements "listing" and "xmp" are explicitly mapped to HTMLPreElement in the specification.
     if (lowercase_tag_name.is_one_of(HTML::TagNames::pre, HTML::TagNames::listing, HTML::TagNames::xmp))
-        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLPreElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<HTML::HTMLPreElement>(realm, document, move(qualified_name));
     if (lowercase_tag_name == HTML::TagNames::progress)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLProgressElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<HTML::HTMLProgressElement>(realm, document, move(qualified_name));
     if (lowercase_tag_name.is_one_of(HTML::TagNames::blockquote, HTML::TagNames::q))
-        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLQuoteElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<HTML::HTMLQuoteElement>(realm, document, move(qualified_name));
     if (lowercase_tag_name == HTML::TagNames::script)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLScriptElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<HTML::HTMLScriptElement>(realm, document, move(qualified_name));
     if (lowercase_tag_name == HTML::TagNames::select)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLSelectElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<HTML::HTMLSelectElement>(realm, document, move(qualified_name));
     if (lowercase_tag_name == HTML::TagNames::slot)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLSlotElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<HTML::HTMLSlotElement>(realm, document, move(qualified_name));
     if (lowercase_tag_name == HTML::TagNames::source)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLSourceElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<HTML::HTMLSourceElement>(realm, document, move(qualified_name));
     if (lowercase_tag_name == HTML::TagNames::span)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLSpanElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<HTML::HTMLSpanElement>(realm, document, move(qualified_name));
     if (lowercase_tag_name == HTML::TagNames::style)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLStyleElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<HTML::HTMLStyleElement>(realm, document, move(qualified_name));
     if (lowercase_tag_name == HTML::TagNames::summary)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLSummaryElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<HTML::HTMLSummaryElement>(realm, document, move(qualified_name));
     if (lowercase_tag_name == HTML::TagNames::caption)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLTableCaptionElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<HTML::HTMLTableCaptionElement>(realm, document, move(qualified_name));
     if (lowercase_tag_name.is_one_of(Web::HTML::TagNames::td, Web::HTML::TagNames::th))
-        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLTableCellElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<HTML::HTMLTableCellElement>(realm, document, move(qualified_name));
     if (lowercase_tag_name.is_one_of(HTML::TagNames::colgroup, HTML::TagNames::col))
-        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLTableColElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<HTML::HTMLTableColElement>(realm, document, move(qualified_name));
     if (lowercase_tag_name == HTML::TagNames::table)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLTableElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<HTML::HTMLTableElement>(realm, document, move(qualified_name));
     if (lowercase_tag_name == HTML::TagNames::tr)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLTableRowElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<HTML::HTMLTableRowElement>(realm, document, move(qualified_name));
     if (lowercase_tag_name.is_one_of(HTML::TagNames::tbody, HTML::TagNames::thead, HTML::TagNames::tfoot))
-        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLTableSectionElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<HTML::HTMLTableSectionElement>(realm, document, move(qualified_name));
     if (lowercase_tag_name == HTML::TagNames::template_)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLTemplateElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<HTML::HTMLTemplateElement>(realm, document, move(qualified_name));
     if (lowercase_tag_name == HTML::TagNames::textarea)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLTextAreaElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<HTML::HTMLTextAreaElement>(realm, document, move(qualified_name));
     if (lowercase_tag_name == HTML::TagNames::time)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLTimeElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<HTML::HTMLTimeElement>(realm, document, move(qualified_name));
     if (lowercase_tag_name == HTML::TagNames::title)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLTitleElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<HTML::HTMLTitleElement>(realm, document, move(qualified_name));
     if (lowercase_tag_name == HTML::TagNames::track)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLTrackElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<HTML::HTMLTrackElement>(realm, document, move(qualified_name));
     if (lowercase_tag_name == HTML::TagNames::ul)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLUListElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<HTML::HTMLUListElement>(realm, document, move(qualified_name));
     if (lowercase_tag_name == HTML::TagNames::video)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLVideoElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<HTML::HTMLVideoElement>(realm, document, move(qualified_name));
     if (lowercase_tag_name.is_one_of(
             HTML::TagNames::article, HTML::TagNames::section, HTML::TagNames::nav, HTML::TagNames::aside, HTML::TagNames::hgroup, HTML::TagNames::header, HTML::TagNames::footer, HTML::TagNames::address, HTML::TagNames::dt, HTML::TagNames::dd, HTML::TagNames::figure, HTML::TagNames::figcaption, HTML::TagNames::main, HTML::TagNames::em, HTML::TagNames::strong, HTML::TagNames::small, HTML::TagNames::s, HTML::TagNames::cite, HTML::TagNames::dfn, HTML::TagNames::abbr, HTML::TagNames::ruby, HTML::TagNames::rt, HTML::TagNames::rp, HTML::TagNames::code, HTML::TagNames::var, HTML::TagNames::samp, HTML::TagNames::kbd, HTML::TagNames::sub, HTML::TagNames::sup, HTML::TagNames::i, HTML::TagNames::b, HTML::TagNames::u, HTML::TagNames::mark, HTML::TagNames::bdi, HTML::TagNames::bdo, HTML::TagNames::wbr, HTML::TagNames::noscript,
             // Obsolete
             HTML::TagNames::acronym, HTML::TagNames::basefont, HTML::TagNames::big, HTML::TagNames::center, HTML::TagNames::nobr, HTML::TagNames::noembed, HTML::TagNames::noframes, HTML::TagNames::plaintext, HTML::TagNames::rb, HTML::TagNames::rtc, HTML::TagNames::strike, HTML::TagNames::tt))
-        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<HTML::HTMLElement>(realm, document, move(qualified_name));
     if (HTML::is_valid_custom_element_name(qualified_name.local_name()))
-        return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<HTML::HTMLElement>(realm, document, move(qualified_name));
 
-    return MUST_OR_THROW_OOM(realm.heap().allocate<HTML::HTMLUnknownElement>(realm, document, move(qualified_name)));
+    return realm.heap().allocate<HTML::HTMLUnknownElement>(realm, document, move(qualified_name));
 }
 
-static WebIDL::ExceptionOr<JS::GCPtr<SVG::SVGElement>> create_svg_element(JS::Realm& realm, Document& document, QualifiedName qualified_name)
+static JS::GCPtr<SVG::SVGElement> create_svg_element(JS::Realm& realm, Document& document, QualifiedName qualified_name)
 {
     auto const& local_name = qualified_name.local_name();
 
     if (local_name == SVG::TagNames::svg)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<SVG::SVGSVGElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<SVG::SVGSVGElement>(realm, document, move(qualified_name));
     // FIXME: Support SVG's mixedCase tag names properly.
     if (local_name.equals_ignoring_ascii_case(SVG::TagNames::clipPath))
-        return MUST_OR_THROW_OOM(realm.heap().allocate<SVG::SVGClipPathElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<SVG::SVGClipPathElement>(realm, document, move(qualified_name));
     if (local_name == SVG::TagNames::circle)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<SVG::SVGCircleElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<SVG::SVGCircleElement>(realm, document, move(qualified_name));
     if (local_name.equals_ignoring_ascii_case(SVG::TagNames::defs))
-        return MUST_OR_THROW_OOM(realm.heap().allocate<SVG::SVGDefsElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<SVG::SVGDefsElement>(realm, document, move(qualified_name));
     if (local_name == SVG::TagNames::ellipse)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<SVG::SVGEllipseElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<SVG::SVGEllipseElement>(realm, document, move(qualified_name));
     if (local_name.equals_ignoring_ascii_case(SVG::TagNames::foreignObject))
-        return MUST_OR_THROW_OOM(realm.heap().allocate<SVG::SVGForeignObjectElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<SVG::SVGForeignObjectElement>(realm, document, move(qualified_name));
     if (local_name == SVG::TagNames::line)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<SVG::SVGLineElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<SVG::SVGLineElement>(realm, document, move(qualified_name));
     if (local_name == SVG::TagNames::linearGradient)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<SVG::SVGLinearGradientElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<SVG::SVGLinearGradientElement>(realm, document, move(qualified_name));
     if (local_name == SVG::TagNames::mask)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<SVG::SVGMaskElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<SVG::SVGMaskElement>(realm, document, move(qualified_name));
     if (local_name == SVG::TagNames::path)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<SVG::SVGPathElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<SVG::SVGPathElement>(realm, document, move(qualified_name));
     if (local_name == SVG::TagNames::polygon)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<SVG::SVGPolygonElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<SVG::SVGPolygonElement>(realm, document, move(qualified_name));
     if (local_name == SVG::TagNames::polyline)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<SVG::SVGPolylineElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<SVG::SVGPolylineElement>(realm, document, move(qualified_name));
     if (local_name == SVG::TagNames::radialGradient)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<SVG::SVGRadialGradientElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<SVG::SVGRadialGradientElement>(realm, document, move(qualified_name));
     if (local_name == SVG::TagNames::rect)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<SVG::SVGRectElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<SVG::SVGRectElement>(realm, document, move(qualified_name));
     if (local_name == SVG::TagNames::g)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<SVG::SVGGElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<SVG::SVGGElement>(realm, document, move(qualified_name));
     if (local_name == SVG::TagNames::stop)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<SVG::SVGStopElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<SVG::SVGStopElement>(realm, document, move(qualified_name));
     if (local_name == SVG::TagNames::style)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<SVG::SVGStyleElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<SVG::SVGStyleElement>(realm, document, move(qualified_name));
     if (local_name == SVG::TagNames::symbol)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<SVG::SVGSymbolElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<SVG::SVGSymbolElement>(realm, document, move(qualified_name));
     if (local_name == SVG::TagNames::text)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<SVG::SVGTextElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<SVG::SVGTextElement>(realm, document, move(qualified_name));
     if (local_name == SVG::TagNames::title)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<SVG::SVGTitleElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<SVG::SVGTitleElement>(realm, document, move(qualified_name));
     if (local_name == SVG::TagNames::tspan)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<SVG::SVGTSpanElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<SVG::SVGTSpanElement>(realm, document, move(qualified_name));
     if (local_name == SVG::TagNames::use)
-        return MUST_OR_THROW_OOM(realm.heap().allocate<SVG::SVGUseElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<SVG::SVGUseElement>(realm, document, move(qualified_name));
 
     return nullptr;
 }
 
-static WebIDL::ExceptionOr<JS::GCPtr<MathML::MathMLElement>> create_mathml_element(JS::Realm& realm, Document& document, QualifiedName qualified_name)
+static JS::GCPtr<MathML::MathMLElement> create_mathml_element(JS::Realm& realm, Document& document, QualifiedName qualified_name)
 {
-    auto const& local_name = TRY_OR_THROW_OOM(realm.vm(), FlyString::from_deprecated_fly_string(qualified_name.local_name()));
+    auto const& local_name = MUST(FlyString::from_deprecated_fly_string(qualified_name.local_name()));
 
     if (local_name.is_one_of(MathML::TagNames::annotation, MathML::TagNames::annotation_xml, MathML::TagNames::maction, MathML::TagNames::math, MathML::TagNames::merror, MathML::TagNames::mfrac, MathML::TagNames::mi, MathML::TagNames::mmultiscripts, MathML::TagNames::mn, MathML::TagNames::mo, MathML::TagNames::mover, MathML::TagNames::mpadded, MathML::TagNames::mphantom, MathML::TagNames::mprescripts, MathML::TagNames::mroot, MathML::TagNames::mrow, MathML::TagNames::ms, MathML::TagNames::mspace, MathML::TagNames::msqrt, MathML::TagNames::mstyle, MathML::TagNames::msub, MathML::TagNames::msubsup, MathML::TagNames::msup, MathML::TagNames::mtable, MathML::TagNames::mtd, MathML::TagNames::mtext, MathML::TagNames::mtr, MathML::TagNames::munder, MathML::TagNames::munderover, MathML::TagNames::semantics))
-        return MUST_OR_THROW_OOM(realm.heap().allocate<MathML::MathMLElement>(realm, document, move(qualified_name)));
+        return realm.heap().allocate<MathML::MathMLElement>(realm, document, move(qualified_name));
 
     return nullptr;
 }
@@ -511,7 +511,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Element>> create_element(Document& document
         // 2. Set result to a new element that implements interface, with no attributes, namespace set to the HTML namespace,
         //    namespace prefix set to prefix, local name set to localName, custom element state set to "undefined", custom element definition set to null,
         //    is value set to is, and node document set to document.
-        auto element = TRY(create_html_element(realm, document, QualifiedName { local_name, prefix, Namespace::HTML }));
+        auto element = create_html_element(realm, document, QualifiedName { local_name, prefix, Namespace::HTML });
 
         // 3. If the synchronous custom elements flag is set, then run this step while catching any exceptions:
         if (synchronous_custom_elements_flag) {
@@ -596,7 +596,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Element>> create_element(Document& document
 
                 // 2. Set result to a new element that implements the HTMLUnknownElement interface, with no attributes, namespace set to the HTML namespace, namespace prefix set to prefix,
                 //    local name set to localName, custom element state set to "failed", custom element definition set to null, is value set to null, and node document set to document.
-                JS::NonnullGCPtr<Element> element = realm.heap().allocate<HTML::HTMLUnknownElement>(realm, document, QualifiedName { local_name, prefix, Namespace::HTML }).release_allocated_value_but_fixme_should_propagate_errors();
+                JS::NonnullGCPtr<Element> element = realm.heap().allocate<HTML::HTMLUnknownElement>(realm, document, QualifiedName { local_name, prefix, Namespace::HTML });
                 element->set_custom_element_state(CustomElementState::Failed);
                 return element;
             }
@@ -607,7 +607,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Element>> create_element(Document& document
         // 2. Otherwise:
         // 1. Set result to a new element that implements the HTMLElement interface, with no attributes, namespace set to the HTML namespace, namespace prefix set to prefix,
         //    local name set to localName, custom element state set to "undefined", custom element definition set to null, is value set to null, and node document set to document.
-        JS::NonnullGCPtr<Element> element = realm.heap().allocate<HTML::HTMLElement>(realm, document, QualifiedName { local_name, prefix, Namespace::HTML }).release_allocated_value_but_fixme_should_propagate_errors();
+        auto element = realm.heap().allocate<HTML::HTMLElement>(realm, document, QualifiedName { local_name, prefix, Namespace::HTML });
         element->set_custom_element_state(CustomElementState::Undefined);
 
         // 2. Enqueue a custom element upgrade reaction given result and definition.
@@ -624,7 +624,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Element>> create_element(Document& document
     auto qualified_name = QualifiedName { local_name, prefix, namespace_ };
 
     if (namespace_ == Namespace::HTML) {
-        auto element = TRY(create_html_element(realm, document, move(qualified_name)));
+        auto element = create_html_element(realm, document, move(qualified_name));
         element->set_is_value(move(is_value));
         element->set_custom_element_state(CustomElementState::Uncustomized);
 
@@ -637,7 +637,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Element>> create_element(Document& document
     }
 
     if (namespace_ == Namespace::SVG) {
-        auto element = TRY(create_svg_element(realm, document, qualified_name));
+        auto element = create_svg_element(realm, document, qualified_name);
         if (element) {
             element->set_is_value(move(is_value));
             element->set_custom_element_state(CustomElementState::Uncustomized);
@@ -646,7 +646,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Element>> create_element(Document& document
     }
 
     if (namespace_ == Namespace::MathML) {
-        auto element = TRY(create_mathml_element(realm, document, qualified_name));
+        auto element = create_mathml_element(realm, document, qualified_name);
         if (element) {
             element->set_is_value(move(is_value));
             element->set_custom_element_state(CustomElementState::Uncustomized);
@@ -660,7 +660,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Element>> create_element(Document& document
     // https://dom.spec.whatwg.org/#concept-element-interface
     // The element interface for any name and namespace is Element, unless stated otherwise.
     dbgln("Potential FIXME: Creating unknown generic element '{}' in namespace '{}'", local_name, namespace_);
-    JS::NonnullGCPtr<Element> element = realm.heap().allocate<DOM::Element>(realm, document, move(qualified_name)).release_allocated_value_but_fixme_should_propagate_errors();
+    auto element = realm.heap().allocate<DOM::Element>(realm, document, move(qualified_name));
     element->set_is_value(move(is_value));
     element->set_custom_element_state(CustomElementState::Uncustomized);
     return element;

--- a/Userland/Libraries/LibWeb/DOM/Event.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Event.cpp
@@ -14,9 +14,9 @@
 
 namespace Web::DOM {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<Event>> Event::create(JS::Realm& realm, FlyString const& event_name, EventInit const& event_init)
+JS::NonnullGCPtr<Event> Event::create(JS::Realm& realm, FlyString const& event_name, EventInit const& event_init)
 {
-    return MUST_OR_THROW_OOM(realm.heap().allocate<Event>(realm, realm, event_name, event_init));
+    return realm.heap().allocate<Event>(realm, realm, event_name, event_init);
 }
 
 WebIDL::ExceptionOr<JS::NonnullGCPtr<Event>> Event::construct_impl(JS::Realm& realm, FlyString const& event_name, EventInit const& event_init)

--- a/Userland/Libraries/LibWeb/DOM/Event.h
+++ b/Userland/Libraries/LibWeb/DOM/Event.h
@@ -45,7 +45,7 @@ public:
 
     using Path = Vector<PathEntry>;
 
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<Event>> create(JS::Realm&, FlyString const& event_name, EventInit const& event_init = {});
+    [[nodiscard]] static JS::NonnullGCPtr<Event> create(JS::Realm&, FlyString const& event_name, EventInit const& event_init = {});
     static WebIDL::ExceptionOr<JS::NonnullGCPtr<Event>> construct_impl(JS::Realm&, FlyString const& event_name, EventInit const& event_init);
 
     Event(JS::Realm&, FlyString const& type);

--- a/Userland/Libraries/LibWeb/DOM/EventTarget.cpp
+++ b/Userland/Libraries/LibWeb/DOM/EventTarget.cpp
@@ -49,7 +49,7 @@ EventTarget::~EventTarget() = default;
 WebIDL::ExceptionOr<JS::NonnullGCPtr<EventTarget>> EventTarget::construct_impl(JS::Realm& realm)
 {
     // The new EventTarget() constructor steps are to do nothing.
-    return MUST_OR_THROW_OOM(realm.heap().allocate<EventTarget>(realm, realm));
+    return realm.heap().allocate<EventTarget>(realm, realm);
 }
 
 void EventTarget::initialize(JS::Realm& realm)
@@ -581,7 +581,7 @@ void EventTarget::activate_event_handler(FlyString const& name, HTML::EventHandl
     // 5. Let listener be a new event listener whose type is the event handler event type corresponding to eventHandler and callback is callback.
     auto listener = realm.heap().allocate_without_realm<DOMEventListener>();
     listener->type = name;
-    listener->callback = IDLEventListener::create(realm, *callback).release_value_but_fixme_should_propagate_errors();
+    listener->callback = IDLEventListener::create(realm, *callback);
 
     // 6. Add an event listener with eventTarget and listener.
     add_an_event_listener(*listener);

--- a/Userland/Libraries/LibWeb/DOM/HTMLCollection.cpp
+++ b/Userland/Libraries/LibWeb/DOM/HTMLCollection.cpp
@@ -13,9 +13,9 @@
 
 namespace Web::DOM {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<HTMLCollection>> HTMLCollection::create(ParentNode& root, Scope scope, Function<bool(Element const&)> filter)
+JS::NonnullGCPtr<HTMLCollection> HTMLCollection::create(ParentNode& root, Scope scope, Function<bool(Element const&)> filter)
 {
-    return MUST_OR_THROW_OOM(root.heap().allocate<HTMLCollection>(root.realm(), root, scope, move(filter)));
+    return root.heap().allocate<HTMLCollection>(root.realm(), root, scope, move(filter));
 }
 
 HTMLCollection::HTMLCollection(ParentNode& root, Scope scope, Function<bool(Element const&)> filter)

--- a/Userland/Libraries/LibWeb/DOM/HTMLCollection.h
+++ b/Userland/Libraries/LibWeb/DOM/HTMLCollection.h
@@ -34,7 +34,7 @@ public:
         Children,
         Descendants,
     };
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<HTMLCollection>> create(ParentNode& root, Scope, Function<bool(Element const&)> filter);
+    [[nodiscard]] static JS::NonnullGCPtr<HTMLCollection> create(ParentNode& root, Scope, Function<bool(Element const&)> filter);
 
     virtual ~HTMLCollection() override;
 

--- a/Userland/Libraries/LibWeb/DOM/IDLEventListener.cpp
+++ b/Userland/Libraries/LibWeb/DOM/IDLEventListener.cpp
@@ -10,9 +10,9 @@
 
 namespace Web::DOM {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<IDLEventListener>> IDLEventListener::create(JS::Realm& realm, JS::NonnullGCPtr<WebIDL::CallbackType> callback)
+JS::NonnullGCPtr<IDLEventListener> IDLEventListener::create(JS::Realm& realm, JS::NonnullGCPtr<WebIDL::CallbackType> callback)
 {
-    return MUST_OR_THROW_OOM(realm.heap().allocate<IDLEventListener>(realm, realm, move(callback)));
+    return realm.heap().allocate<IDLEventListener>(realm, realm, move(callback));
 }
 
 IDLEventListener::IDLEventListener(JS::Realm& realm, JS::NonnullGCPtr<WebIDL::CallbackType> callback)

--- a/Userland/Libraries/LibWeb/DOM/IDLEventListener.h
+++ b/Userland/Libraries/LibWeb/DOM/IDLEventListener.h
@@ -28,7 +28,7 @@ class IDLEventListener final : public JS::Object {
     JS_OBJECT(IDLEventListener, JS::Object);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<IDLEventListener>> create(JS::Realm&, JS::NonnullGCPtr<WebIDL::CallbackType>);
+    [[nodiscard]] static JS::NonnullGCPtr<IDLEventListener> create(JS::Realm&, JS::NonnullGCPtr<WebIDL::CallbackType>);
     IDLEventListener(JS::Realm&, JS::NonnullGCPtr<WebIDL::CallbackType>);
 
     virtual ~IDLEventListener() = default;

--- a/Userland/Libraries/LibWeb/DOM/LiveNodeList.cpp
+++ b/Userland/Libraries/LibWeb/DOM/LiveNodeList.cpp
@@ -12,9 +12,9 @@
 
 namespace Web::DOM {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<NodeList>> LiveNodeList::create(JS::Realm& realm, Node& root, Scope scope, Function<bool(Node const&)> filter)
+JS::NonnullGCPtr<NodeList> LiveNodeList::create(JS::Realm& realm, Node& root, Scope scope, Function<bool(Node const&)> filter)
 {
-    return MUST_OR_THROW_OOM(realm.heap().allocate<LiveNodeList>(realm, realm, root, scope, move(filter)));
+    return realm.heap().allocate<LiveNodeList>(realm, realm, root, scope, move(filter));
 }
 
 LiveNodeList::LiveNodeList(JS::Realm& realm, Node& root, Scope scope, Function<bool(Node const&)> filter)

--- a/Userland/Libraries/LibWeb/DOM/LiveNodeList.h
+++ b/Userland/Libraries/LibWeb/DOM/LiveNodeList.h
@@ -23,7 +23,7 @@ public:
         Descendants,
     };
 
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<NodeList>> create(JS::Realm&, Node& root, Scope, Function<bool(Node const&)> filter);
+    [[nodiscard]] static JS::NonnullGCPtr<NodeList> create(JS::Realm&, Node& root, Scope, Function<bool(Node const&)> filter);
     virtual ~LiveNodeList() override;
 
     virtual u32 length() const override;

--- a/Userland/Libraries/LibWeb/DOM/MutationObserver.cpp
+++ b/Userland/Libraries/LibWeb/DOM/MutationObserver.cpp
@@ -13,7 +13,7 @@ namespace Web::DOM {
 
 WebIDL::ExceptionOr<JS::NonnullGCPtr<MutationObserver>> MutationObserver::construct_impl(JS::Realm& realm, JS::GCPtr<WebIDL::CallbackType> callback)
 {
-    return MUST_OR_THROW_OOM(realm.heap().allocate<MutationObserver>(realm, realm, callback));
+    return realm.heap().allocate<MutationObserver>(realm, realm, callback);
 }
 
 // https://dom.spec.whatwg.org/#dom-mutationobserver-mutationobserver

--- a/Userland/Libraries/LibWeb/DOM/MutationRecord.cpp
+++ b/Userland/Libraries/LibWeb/DOM/MutationRecord.cpp
@@ -12,9 +12,9 @@
 
 namespace Web::DOM {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<MutationRecord>> MutationRecord::create(JS::Realm& realm, FlyString const& type, Node const& target, NodeList& added_nodes, NodeList& removed_nodes, Node* previous_sibling, Node* next_sibling, DeprecatedString const& attribute_name, DeprecatedString const& attribute_namespace, DeprecatedString const& old_value)
+JS::NonnullGCPtr<MutationRecord> MutationRecord::create(JS::Realm& realm, FlyString const& type, Node const& target, NodeList& added_nodes, NodeList& removed_nodes, Node* previous_sibling, Node* next_sibling, DeprecatedString const& attribute_name, DeprecatedString const& attribute_namespace, DeprecatedString const& old_value)
 {
-    return MUST_OR_THROW_OOM(realm.heap().allocate<MutationRecord>(realm, realm, type, target, added_nodes, removed_nodes, previous_sibling, next_sibling, attribute_name, attribute_namespace, old_value));
+    return realm.heap().allocate<MutationRecord>(realm, realm, type, target, added_nodes, removed_nodes, previous_sibling, next_sibling, attribute_name, attribute_namespace, old_value);
 }
 
 MutationRecord::MutationRecord(JS::Realm& realm, FlyString const& type, Node const& target, NodeList& added_nodes, NodeList& removed_nodes, Node* previous_sibling, Node* next_sibling, DeprecatedString const& attribute_name, DeprecatedString const& attribute_namespace, DeprecatedString const& old_value)

--- a/Userland/Libraries/LibWeb/DOM/MutationRecord.h
+++ b/Userland/Libraries/LibWeb/DOM/MutationRecord.h
@@ -16,7 +16,7 @@ class MutationRecord : public Bindings::PlatformObject {
     WEB_PLATFORM_OBJECT(MutationRecord, Bindings::PlatformObject);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<MutationRecord>> create(JS::Realm&, FlyString const& type, Node const& target, NodeList& added_nodes, NodeList& removed_nodes, Node* previous_sibling, Node* next_sibling, DeprecatedString const& attribute_name, DeprecatedString const& attribute_namespace, DeprecatedString const& old_value);
+    [[nodiscard]] static JS::NonnullGCPtr<MutationRecord> create(JS::Realm&, FlyString const& type, Node const& target, NodeList& added_nodes, NodeList& removed_nodes, Node* previous_sibling, Node* next_sibling, DeprecatedString const& attribute_name, DeprecatedString const& attribute_namespace, DeprecatedString const& old_value);
 
     virtual ~MutationRecord() override;
 

--- a/Userland/Libraries/LibWeb/DOM/NamedNodeMap.cpp
+++ b/Userland/Libraries/LibWeb/DOM/NamedNodeMap.cpp
@@ -13,10 +13,10 @@
 
 namespace Web::DOM {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<NamedNodeMap>> NamedNodeMap::create(Element& element)
+JS::NonnullGCPtr<NamedNodeMap> NamedNodeMap::create(Element& element)
 {
     auto& realm = element.realm();
-    return MUST_OR_THROW_OOM(realm.heap().allocate<NamedNodeMap>(realm, element));
+    return realm.heap().allocate<NamedNodeMap>(realm, element);
 }
 
 NamedNodeMap::NamedNodeMap(Element& element)

--- a/Userland/Libraries/LibWeb/DOM/NamedNodeMap.h
+++ b/Userland/Libraries/LibWeb/DOM/NamedNodeMap.h
@@ -22,7 +22,7 @@ class NamedNodeMap : public Bindings::LegacyPlatformObject {
     WEB_PLATFORM_OBJECT(NamedNodeMap, Bindings::LegacyPlatformObject);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<NamedNodeMap>> create(Element&);
+    [[nodiscard]] static JS::NonnullGCPtr<NamedNodeMap> create(Element&);
     ~NamedNodeMap() = default;
 
     virtual bool is_supported_property_index(u32 index) const override;

--- a/Userland/Libraries/LibWeb/DOM/Node.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Node.cpp
@@ -777,7 +777,7 @@ JS::NonnullGCPtr<Node> Node::clone_node(Document* document, bool clone_children)
     else if (is<Document>(this)) {
         // Document
         auto document_ = verify_cast<Document>(this);
-        auto document_copy = Document::create(this->realm(), document_->url()).release_value_but_fixme_should_propagate_errors();
+        auto document_copy = Document::create(this->realm(), document_->url());
 
         // Set copy’s encoding, content type, URL, origin, type, and mode to those of node.
         document_copy->set_encoding(document_->encoding());
@@ -790,7 +790,7 @@ JS::NonnullGCPtr<Node> Node::clone_node(Document* document, bool clone_children)
     } else if (is<DocumentType>(this)) {
         // DocumentType
         auto document_type = verify_cast<DocumentType>(this);
-        auto document_type_copy = heap().allocate<DocumentType>(realm(), *document).release_allocated_value_but_fixme_should_propagate_errors();
+        auto document_type_copy = heap().allocate<DocumentType>(realm(), *document);
 
         // Set copy’s name, public ID, and system ID to those of node.
         document_type_copy->set_name(document_type->name());
@@ -807,26 +807,26 @@ JS::NonnullGCPtr<Node> Node::clone_node(Document* document, bool clone_children)
         auto text = verify_cast<Text>(this);
 
         // Set copy’s data to that of node.
-        auto text_copy = heap().allocate<Text>(realm(), *document, text->data()).release_allocated_value_but_fixme_should_propagate_errors();
+        auto text_copy = heap().allocate<Text>(realm(), *document, text->data());
         copy = move(text_copy);
     } else if (is<Comment>(this)) {
         // Comment
         auto comment = verify_cast<Comment>(this);
 
         // Set copy’s data to that of node.
-        auto comment_copy = heap().allocate<Comment>(realm(), *document, comment->data()).release_allocated_value_but_fixme_should_propagate_errors();
+        auto comment_copy = heap().allocate<Comment>(realm(), *document, comment->data());
         copy = move(comment_copy);
     } else if (is<ProcessingInstruction>(this)) {
         // ProcessingInstruction
         auto processing_instruction = verify_cast<ProcessingInstruction>(this);
 
         // Set copy’s target and data to those of node.
-        auto processing_instruction_copy = heap().allocate<ProcessingInstruction>(realm(), *document, processing_instruction->data(), processing_instruction->target()).release_allocated_value_but_fixme_should_propagate_errors();
+        auto processing_instruction_copy = heap().allocate<ProcessingInstruction>(realm(), *document, processing_instruction->data(), processing_instruction->target());
         copy = processing_instruction_copy;
     }
     // Otherwise, Do nothing.
     else if (is<DocumentFragment>(this)) {
-        copy = heap().allocate<DocumentFragment>(realm(), *document).release_allocated_value_but_fixme_should_propagate_errors();
+        copy = heap().allocate<DocumentFragment>(realm(), *document);
     }
 
     // FIXME: 4. Set copy’s node document and document to copy, if copy is a document, and set copy’s node document to document otherwise.
@@ -937,7 +937,7 @@ JS::NonnullGCPtr<NodeList> Node::child_nodes()
     if (!m_child_nodes) {
         m_child_nodes = LiveNodeList::create(realm(), *this, LiveNodeList::Scope::Children, [](auto&) {
             return true;
-        }).release_value_but_fixme_should_propagate_errors();
+        });
     }
     return *m_child_nodes;
 }
@@ -1259,7 +1259,7 @@ void Node::string_replace_all(DeprecatedString const& string)
 
     // 2. If string is not the empty string, then set node to a new Text node whose data is string and node document is parent’s node document.
     if (!string.is_empty())
-        node = heap().allocate<Text>(realm(), document(), string).release_allocated_value_but_fixme_should_propagate_errors();
+        node = heap().allocate<Text>(realm(), document(), string);
 
     // 3. Replace all with node within parent.
     replace_all(node);
@@ -1517,14 +1517,14 @@ void Node::queue_mutation_record(FlyString const& type, DeprecatedString attribu
     if (interested_observers.is_empty())
         return;
 
-    auto added_nodes_list = StaticNodeList::create(realm(), move(added_nodes)).release_value_but_fixme_should_propagate_errors();
-    auto removed_nodes_list = StaticNodeList::create(realm(), move(removed_nodes)).release_value_but_fixme_should_propagate_errors();
+    auto added_nodes_list = StaticNodeList::create(realm(), move(added_nodes));
+    auto removed_nodes_list = StaticNodeList::create(realm(), move(removed_nodes));
 
     // 4. For each observer → mappedOldValue of interestedObservers:
     for (auto& interested_observer : interested_observers) {
         // 1. Let record be a new MutationRecord object with its type set to type, target set to target, attributeName set to name, attributeNamespace set to namespace, oldValue set to mappedOldValue,
         //    addedNodes set to addedNodes, removedNodes set to removedNodes, previousSibling set to previousSibling, and nextSibling set to nextSibling.
-        auto record = MutationRecord::create(realm(), type, *this, added_nodes_list, removed_nodes_list, previous_sibling, next_sibling, attribute_name, attribute_namespace, /* mappedOldValue */ interested_observer.value).release_value_but_fixme_should_propagate_errors();
+        auto record = MutationRecord::create(realm(), type, *this, added_nodes_list, removed_nodes_list, previous_sibling, next_sibling, attribute_name, attribute_namespace, /* mappedOldValue */ interested_observer.value);
 
         // 2. Enqueue record to observer’s record queue.
         interested_observer.key->enqueue_record({}, move(record));
@@ -1661,7 +1661,7 @@ void Node::build_accessibility_tree(AccessibilityTreeNode& parent)
             return;
 
         if (element->include_in_accessibility_tree()) {
-            auto current_node = AccessibilityTreeNode::create(&document(), this).release_value_but_fixme_should_propagate_errors();
+            auto current_node = AccessibilityTreeNode::create(&document(), this);
             parent.append_child(current_node);
             if (has_child_nodes()) {
                 for_each_child([&current_node](DOM::Node& child) {
@@ -1674,7 +1674,7 @@ void Node::build_accessibility_tree(AccessibilityTreeNode& parent)
             });
         }
     } else if (is_text()) {
-        parent.append_child(AccessibilityTreeNode::create(&document(), this).release_value_but_fixme_should_propagate_errors());
+        parent.append_child(AccessibilityTreeNode::create(&document(), this));
         if (has_child_nodes()) {
             for_each_child([&parent](DOM::Node& child) {
                 child.build_accessibility_tree(parent);

--- a/Userland/Libraries/LibWeb/DOM/NodeFilter.cpp
+++ b/Userland/Libraries/LibWeb/DOM/NodeFilter.cpp
@@ -10,9 +10,9 @@
 
 namespace Web::DOM {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<NodeFilter>> NodeFilter::create(JS::Realm& realm, WebIDL::CallbackType& callback)
+JS::NonnullGCPtr<NodeFilter> NodeFilter::create(JS::Realm& realm, WebIDL::CallbackType& callback)
 {
-    return MUST_OR_THROW_OOM(realm.heap().allocate<NodeFilter>(realm, realm, callback));
+    return realm.heap().allocate<NodeFilter>(realm, realm, callback);
 }
 
 NodeFilter::NodeFilter(JS::Realm& realm, WebIDL::CallbackType& callback)

--- a/Userland/Libraries/LibWeb/DOM/NodeFilter.h
+++ b/Userland/Libraries/LibWeb/DOM/NodeFilter.h
@@ -15,7 +15,7 @@ class NodeFilter final : public Bindings::PlatformObject {
     WEB_PLATFORM_OBJECT(NodeFilter, Bindings::PlatformObject);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<NodeFilter>> create(JS::Realm&, WebIDL::CallbackType&);
+    [[nodiscard]] static JS::NonnullGCPtr<NodeFilter> create(JS::Realm&, WebIDL::CallbackType&);
 
     virtual ~NodeFilter() = default;
 

--- a/Userland/Libraries/LibWeb/DOM/NodeIterator.cpp
+++ b/Userland/Libraries/LibWeb/DOM/NodeIterator.cpp
@@ -51,7 +51,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<NodeIterator>> NodeIterator::create(Node& r
     // 2. Set iterator’s root and iterator’s reference to root.
     // 3. Set iterator’s pointer before reference to true.
     auto& realm = root.realm();
-    auto iterator = MUST_OR_THROW_OOM(realm.heap().allocate<NodeIterator>(realm, root));
+    auto iterator = realm.heap().allocate<NodeIterator>(realm, root);
 
     // 4. Set iterator’s whatToShow to whatToShow.
     iterator->m_what_to_show = what_to_show;

--- a/Userland/Libraries/LibWeb/DOM/NodeOperations.cpp
+++ b/Userland/Libraries/LibWeb/DOM/NodeOperations.cpp
@@ -22,19 +22,19 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Node>> convert_nodes_to_single_node(Vector<
     // 4. Otherwise, set node to a new DocumentFragment node whose node document is document, and then append each node in nodes, if any, to it.
     // 5. Return node.
 
-    auto potentially_convert_string_to_text_node = [&document](Variant<JS::Handle<Node>, DeprecatedString> const& node) -> JS::ThrowCompletionOr<JS::NonnullGCPtr<Node>> {
+    auto potentially_convert_string_to_text_node = [&document](Variant<JS::Handle<Node>, DeprecatedString> const& node) -> JS::NonnullGCPtr<Node> {
         if (node.has<JS::Handle<Node>>())
             return *node.get<JS::Handle<Node>>();
 
-        return MUST_OR_THROW_OOM(document.heap().allocate<DOM::Text>(document.realm(), document, node.get<DeprecatedString>()));
+        return document.heap().allocate<DOM::Text>(document.realm(), document, node.get<DeprecatedString>());
     };
 
     if (nodes.size() == 1)
-        return TRY(potentially_convert_string_to_text_node(nodes.first()));
+        return potentially_convert_string_to_text_node(nodes.first());
 
-    auto document_fragment = MUST_OR_THROW_OOM(document.heap().allocate<DOM::DocumentFragment>(document.realm(), document));
+    auto document_fragment = document.heap().allocate<DOM::DocumentFragment>(document.realm(), document);
     for (auto& unconverted_node : nodes) {
-        auto node = TRY(potentially_convert_string_to_text_node(unconverted_node));
+        auto node = potentially_convert_string_to_text_node(unconverted_node);
         (void)TRY(document_fragment->append_child(node));
     }
 

--- a/Userland/Libraries/LibWeb/DOM/ParentNode.cpp
+++ b/Userland/Libraries/LibWeb/DOM/ParentNode.cpp
@@ -115,7 +115,7 @@ JS::NonnullGCPtr<HTMLCollection> ParentNode::children()
     if (!m_children) {
         m_children = HTMLCollection::create(*this, HTMLCollection::Scope::Children, [](Element const&) {
             return true;
-        }).release_value_but_fixme_should_propagate_errors();
+        });
     }
     return *m_children;
 }
@@ -128,7 +128,7 @@ JS::NonnullGCPtr<HTMLCollection> ParentNode::get_elements_by_tag_name(Deprecated
     if (qualified_name == "*") {
         return HTMLCollection::create(*this, HTMLCollection::Scope::Descendants, [](Element const&) {
             return true;
-        }).release_value_but_fixme_should_propagate_errors();
+        });
     }
 
     // 2. Otherwise, if root’s node document is an HTML document, return a HTMLCollection rooted at root, whose filter matches the following descendant elements:
@@ -140,13 +140,13 @@ JS::NonnullGCPtr<HTMLCollection> ParentNode::get_elements_by_tag_name(Deprecated
 
             // - Whose namespace is not the HTML namespace and whose qualified name is qualifiedName.
             return element.qualified_name() == qualified_name;
-        }).release_value_but_fixme_should_propagate_errors();
+        });
     }
 
     // 3. Otherwise, return a HTMLCollection rooted at root, whose filter matches descendant elements whose qualified name is qualifiedName.
     return HTMLCollection::create(*this, HTMLCollection::Scope::Descendants, [qualified_name](Element const& element) {
         return element.qualified_name() == qualified_name;
-    }).release_value_but_fixme_should_propagate_errors();
+    });
 }
 
 // https://dom.spec.whatwg.org/#concept-getelementsbytagnamens
@@ -162,27 +162,27 @@ JS::NonnullGCPtr<HTMLCollection> ParentNode::get_elements_by_tag_name_ns(Depreca
     if (namespace_ == "*" && local_name == "*") {
         return HTMLCollection::create(*this, HTMLCollection::Scope::Descendants, [](Element const&) {
             return true;
-        }).release_value_but_fixme_should_propagate_errors();
+        });
     }
 
     // 3. Otherwise, if namespace is "*" (U+002A), return a HTMLCollection rooted at root, whose filter matches descendant elements whose local name is localName.
     if (namespace_ == "*") {
         return HTMLCollection::create(*this, HTMLCollection::Scope::Descendants, [local_name](Element const& element) {
             return element.local_name() == local_name;
-        }).release_value_but_fixme_should_propagate_errors();
+        });
     }
 
     // 4. Otherwise, if localName is "*" (U+002A), return a HTMLCollection rooted at root, whose filter matches descendant elements whose namespace is namespace.
     if (local_name == "*") {
         return HTMLCollection::create(*this, HTMLCollection::Scope::Descendants, [namespace_](Element const& element) {
             return element.namespace_() == namespace_;
-        }).release_value_but_fixme_should_propagate_errors();
+        });
     }
 
     // 5. Otherwise, return a HTMLCollection rooted at root, whose filter matches descendant elements whose namespace is namespace and local name is localName.
     return HTMLCollection::create(*this, HTMLCollection::Scope::Descendants, [namespace_, local_name](Element const& element) {
         return element.namespace_() == namespace_ && element.local_name() == local_name;
-    }).release_value_but_fixme_should_propagate_errors();
+    });
 }
 
 // https://dom.spec.whatwg.org/#dom-parentnode-prepend

--- a/Userland/Libraries/LibWeb/DOM/Range.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Range.cpp
@@ -31,21 +31,21 @@ HashTable<Range*>& Range::live_ranges()
     return ranges;
 }
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<Range>> Range::create(HTML::Window& window)
+JS::NonnullGCPtr<Range> Range::create(HTML::Window& window)
 {
     return Range::create(window.associated_document());
 }
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<Range>> Range::create(Document& document)
+JS::NonnullGCPtr<Range> Range::create(Document& document)
 {
     auto& realm = document.realm();
-    return MUST_OR_THROW_OOM(realm.heap().allocate<Range>(realm, document));
+    return realm.heap().allocate<Range>(realm, document);
 }
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<Range>> Range::create(Node& start_container, u32 start_offset, Node& end_container, u32 end_offset)
+JS::NonnullGCPtr<Range> Range::create(Node& start_container, u32 start_offset, Node& end_container, u32 end_offset)
 {
     auto& realm = start_container.realm();
-    return MUST_OR_THROW_OOM(realm.heap().allocate<Range>(realm, start_container, start_offset, end_container, end_offset));
+    return realm.heap().allocate<Range>(realm, start_container, start_offset, end_container, end_offset);
 }
 
 WebIDL::ExceptionOr<JS::NonnullGCPtr<Range>> Range::construct_impl(JS::Realm& realm)
@@ -430,12 +430,12 @@ WebIDL::ExceptionOr<void> Range::select_node_contents(Node& node)
 
 JS::NonnullGCPtr<Range> Range::clone_range() const
 {
-    return heap().allocate<Range>(shape().realm(), const_cast<Node&>(*m_start_container), m_start_offset, const_cast<Node&>(*m_end_container), m_end_offset).release_allocated_value_but_fixme_should_propagate_errors();
+    return heap().allocate<Range>(shape().realm(), const_cast<Node&>(*m_start_container), m_start_offset, const_cast<Node&>(*m_end_container), m_end_offset);
 }
 
 JS::NonnullGCPtr<Range> Range::inverted() const
 {
-    return heap().allocate<Range>(shape().realm(), const_cast<Node&>(*m_end_container), m_end_offset, const_cast<Node&>(*m_start_container), m_start_offset).release_allocated_value_but_fixme_should_propagate_errors();
+    return heap().allocate<Range>(shape().realm(), const_cast<Node&>(*m_end_container), m_end_offset, const_cast<Node&>(*m_start_container), m_start_offset);
 }
 
 JS::NonnullGCPtr<Range> Range::normalized() const
@@ -589,7 +589,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<DocumentFragment>> Range::extract_contents(
 WebIDL::ExceptionOr<JS::NonnullGCPtr<DocumentFragment>> Range::extract()
 {
     // 1. Let fragment be a new DocumentFragment node whose node document is range’s start node’s node document.
-    auto fragment = MUST_OR_THROW_OOM(heap().allocate<DOM::DocumentFragment>(realm(), const_cast<Document&>(start_container()->document())));
+    auto fragment = heap().allocate<DOM::DocumentFragment>(realm(), const_cast<Document&>(start_container()->document()));
 
     // 2. If range is collapsed, then return fragment.
     if (collapsed())
@@ -717,7 +717,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<DocumentFragment>> Range::extract()
         TRY(fragment->append_child(clone));
 
         // 3. Let subrange be a new live range whose start is (original start node, original start offset) and whose end is (first partially contained child, first partially contained child’s length).
-        auto subrange = TRY(Range::create(original_start_node, original_start_offset, *first_partially_contained_child, first_partially_contained_child->length()));
+        auto subrange = Range::create(original_start_node, original_start_offset, *first_partially_contained_child, first_partially_contained_child->length());
 
         // 4. Let subfragment be the result of extracting subrange.
         auto subfragment = TRY(subrange->extract());
@@ -755,7 +755,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<DocumentFragment>> Range::extract()
         TRY(fragment->append_child(clone));
 
         // 3. Let subrange be a new live range whose start is (last partially contained child, 0) and whose end is (original end node, original end offset).
-        auto subrange = TRY(Range::create(*last_partially_contained_child, 0, original_end_node, original_end_offset));
+        auto subrange = Range::create(*last_partially_contained_child, 0, original_end_node, original_end_offset);
 
         // 4. Let subfragment be the result of extracting subrange.
         auto subfragment = TRY(subrange->extract());
@@ -918,7 +918,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<DocumentFragment>> Range::clone_contents()
 WebIDL::ExceptionOr<JS::NonnullGCPtr<DocumentFragment>> Range::clone_the_contents()
 {
     // 1. Let fragment be a new DocumentFragment node whose node document is range’s start node’s node document.
-    auto fragment = MUST_OR_THROW_OOM(heap().allocate<DOM::DocumentFragment>(realm(), const_cast<Document&>(start_container()->document())));
+    auto fragment = heap().allocate<DOM::DocumentFragment>(realm(), const_cast<Document&>(start_container()->document()));
 
     // 2. If range is collapsed, then return fragment.
     if (collapsed())
@@ -1018,7 +1018,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<DocumentFragment>> Range::clone_the_content
         TRY(fragment->append_child(clone));
 
         // 3. Let subrange be a new live range whose start is (original start node, original start offset) and whose end is (first partially contained child, first partially contained child’s length).
-        auto subrange = TRY(Range::create(original_start_node, original_start_offset, *first_partially_contained_child, first_partially_contained_child->length()));
+        auto subrange = Range::create(original_start_node, original_start_offset, *first_partially_contained_child, first_partially_contained_child->length());
 
         // 4. Let subfragment be the result of cloning the contents of subrange.
         auto subfragment = TRY(subrange->clone_the_contents());
@@ -1057,7 +1057,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<DocumentFragment>> Range::clone_the_content
         TRY(fragment->append_child(clone));
 
         // 3. Let subrange be a new live range whose start is (last partially contained child, 0) and whose end is (original end node, original end offset).
-        auto subrange = TRY(Range::create(*last_partially_contained_child, 0, original_end_node, original_end_offset));
+        auto subrange = Range::create(*last_partially_contained_child, 0, original_end_node, original_end_offset);
 
         // 4. Let subfragment be the result of cloning the contents of subrange.
         auto subfragment = TRY(subrange->clone_the_contents());

--- a/Userland/Libraries/LibWeb/DOM/Range.h
+++ b/Userland/Libraries/LibWeb/DOM/Range.h
@@ -26,9 +26,9 @@ class Range final : public AbstractRange {
     WEB_PLATFORM_OBJECT(Range, AbstractRange);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<Range>> create(Document&);
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<Range>> create(HTML::Window&);
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<Range>> create(Node& start_container, u32 start_offset, Node& end_container, u32 end_offset);
+    [[nodiscard]] static JS::NonnullGCPtr<Range> create(Document&);
+    [[nodiscard]] static JS::NonnullGCPtr<Range> create(HTML::Window&);
+    [[nodiscard]] static JS::NonnullGCPtr<Range> create(Node& start_container, u32 start_offset, Node& end_container, u32 end_offset);
     static WebIDL::ExceptionOr<JS::NonnullGCPtr<Range>> construct_impl(JS::Realm&);
 
     virtual ~Range() override;

--- a/Userland/Libraries/LibWeb/DOM/StaticNodeList.cpp
+++ b/Userland/Libraries/LibWeb/DOM/StaticNodeList.cpp
@@ -10,9 +10,9 @@
 
 namespace Web::DOM {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<NodeList>> StaticNodeList::create(JS::Realm& realm, Vector<JS::Handle<Node>> static_nodes)
+JS::NonnullGCPtr<NodeList> StaticNodeList::create(JS::Realm& realm, Vector<JS::Handle<Node>> static_nodes)
 {
-    return MUST_OR_THROW_OOM(realm.heap().allocate<StaticNodeList>(realm, realm, move(static_nodes)));
+    return realm.heap().allocate<StaticNodeList>(realm, realm, move(static_nodes));
 }
 
 StaticNodeList::StaticNodeList(JS::Realm& realm, Vector<JS::Handle<Node>> static_nodes)

--- a/Userland/Libraries/LibWeb/DOM/StaticNodeList.h
+++ b/Userland/Libraries/LibWeb/DOM/StaticNodeList.h
@@ -15,7 +15,7 @@ class StaticNodeList final : public NodeList {
     WEB_PLATFORM_OBJECT(StaticNodeList, NodeList);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<NodeList>> create(JS::Realm&, Vector<JS::Handle<Node>>);
+    [[nodiscard]] static JS::NonnullGCPtr<NodeList> create(JS::Realm&, Vector<JS::Handle<Node>>);
 
     virtual ~StaticNodeList() override;
 

--- a/Userland/Libraries/LibWeb/DOM/StaticRange.cpp
+++ b/Userland/Libraries/LibWeb/DOM/StaticRange.cpp
@@ -32,7 +32,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<StaticRange>> StaticRange::construct_impl(J
         return WebIDL::InvalidNodeTypeError::create(realm, "endContainer cannot be a DocumentType or Attribute node.");
 
     // 2. Set this’s start to (init["startContainer"], init["startOffset"]) and end to (init["endContainer"], init["endOffset"]).
-    return MUST_OR_THROW_OOM(realm.heap().allocate<StaticRange>(realm, *init.start_container, init.start_offset, *init.end_container, init.end_offset));
+    return realm.heap().allocate<StaticRange>(realm, *init.start_container, init.start_offset, *init.end_container, init.end_offset);
 }
 
 void StaticRange::initialize(JS::Realm& realm)

--- a/Userland/Libraries/LibWeb/DOM/Text.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Text.cpp
@@ -41,7 +41,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Text>> Text::construct_impl(JS::Realm& real
 {
     // The new Text(data) constructor steps are to set this’s data to data and this’s node document to current global object’s associated Document.
     auto& window = verify_cast<HTML::Window>(HTML::current_global_object());
-    return MUST_OR_THROW_OOM(realm.heap().allocate<Text>(realm, window.associated_document(), data));
+    return realm.heap().allocate<Text>(realm, window.associated_document(), data);
 }
 
 void Text::set_owner_input_element(Badge<HTML::HTMLInputElement>, HTML::HTMLInputElement& input_element)
@@ -67,7 +67,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Text>> Text::split_text(size_t offset)
     auto new_data = TRY(substring_data(offset, count));
 
     // 5. Let new node be a new Text node, with the same node document as node. Set new node’s data to new data.
-    auto new_node = MUST_OR_THROW_OOM(heap().allocate<Text>(realm(), document(), new_data));
+    auto new_node = heap().allocate<Text>(realm(), document(), new_data);
 
     // 6. Let parent be node’s parent.
     JS::GCPtr<Node> parent = this->parent();

--- a/Userland/Libraries/LibWeb/DOM/TreeWalker.cpp
+++ b/Userland/Libraries/LibWeb/DOM/TreeWalker.cpp
@@ -37,12 +37,12 @@ void TreeWalker::visit_edges(Cell::Visitor& visitor)
 }
 
 // https://dom.spec.whatwg.org/#dom-document-createtreewalker
-WebIDL::ExceptionOr<JS::NonnullGCPtr<TreeWalker>> TreeWalker::create(Node& root, unsigned what_to_show, JS::GCPtr<NodeFilter> filter)
+JS::NonnullGCPtr<TreeWalker> TreeWalker::create(Node& root, unsigned what_to_show, JS::GCPtr<NodeFilter> filter)
 {
     // 1. Let walker be a new TreeWalker object.
     // 2. Set walker’s root and walker’s current to root.
     auto& realm = root.realm();
-    auto walker = MUST_OR_THROW_OOM(realm.heap().allocate<TreeWalker>(realm, root));
+    auto walker = realm.heap().allocate<TreeWalker>(realm, root);
 
     // 3. Set walker’s whatToShow to whatToShow.
     walker->m_what_to_show = what_to_show;

--- a/Userland/Libraries/LibWeb/DOM/TreeWalker.h
+++ b/Userland/Libraries/LibWeb/DOM/TreeWalker.h
@@ -15,7 +15,7 @@ class TreeWalker final : public Bindings::PlatformObject {
     WEB_PLATFORM_OBJECT(TreeWalker, Bindings::PlatformObject);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<TreeWalker>> create(Node& root, unsigned what_to_show, JS::GCPtr<NodeFilter>);
+    [[nodiscard]] static JS::NonnullGCPtr<TreeWalker> create(Node& root, unsigned what_to_show, JS::GCPtr<NodeFilter>);
 
     virtual ~TreeWalker() override;
 

--- a/Userland/Libraries/LibWeb/DOMParsing/InnerHTML.cpp
+++ b/Userland/Libraries/LibWeb/DOMParsing/InnerHTML.cpp
@@ -21,7 +21,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<DOM::DocumentFragment>> parse_fragment(Depr
     auto& realm = context_element.realm();
 
     auto new_children = HTML::HTMLParser::parse_html_fragment(context_element, markup);
-    auto fragment = MUST_OR_THROW_OOM(realm.heap().allocate<DOM::DocumentFragment>(realm, context_element.document()));
+    auto fragment = realm.heap().allocate<DOM::DocumentFragment>(realm, context_element.document());
 
     for (auto& child : new_children) {
         // I don't know if this can throw here, but let's be safe.

--- a/Userland/Libraries/LibWeb/DOMParsing/XMLSerializer.cpp
+++ b/Userland/Libraries/LibWeb/DOMParsing/XMLSerializer.cpp
@@ -25,7 +25,7 @@ namespace Web::DOMParsing {
 
 WebIDL::ExceptionOr<JS::NonnullGCPtr<XMLSerializer>> XMLSerializer::construct_impl(JS::Realm& realm)
 {
-    return MUST_OR_THROW_OOM(realm.heap().allocate<XMLSerializer>(realm, realm));
+    return realm.heap().allocate<XMLSerializer>(realm, realm);
 }
 
 XMLSerializer::XMLSerializer(JS::Realm& realm)

--- a/Userland/Libraries/LibWeb/Encoding/TextDecoder.cpp
+++ b/Userland/Libraries/LibWeb/Encoding/TextDecoder.cpp
@@ -20,7 +20,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<TextDecoder>> TextDecoder::construct_impl(J
     if (!decoder.has_value())
         return WebIDL::SimpleException { WebIDL::SimpleExceptionType::TypeError, TRY_OR_THROW_OOM(vm, String::formatted("Invalid encoding {}", encoding)) };
 
-    return MUST_OR_THROW_OOM(realm.heap().allocate<TextDecoder>(realm, realm, *decoder, move(encoding), false, false));
+    return realm.heap().allocate<TextDecoder>(realm, realm, *decoder, move(encoding), false, false);
 }
 
 // https://encoding.spec.whatwg.org/#dom-textdecoder

--- a/Userland/Libraries/LibWeb/Encoding/TextEncoder.cpp
+++ b/Userland/Libraries/LibWeb/Encoding/TextEncoder.cpp
@@ -14,7 +14,7 @@ namespace Web::Encoding {
 
 WebIDL::ExceptionOr<JS::NonnullGCPtr<TextEncoder>> TextEncoder::construct_impl(JS::Realm& realm)
 {
-    return MUST_OR_THROW_OOM(realm.heap().allocate<TextEncoder>(realm, realm));
+    return realm.heap().allocate<TextEncoder>(realm, realm);
 }
 
 TextEncoder::TextEncoder(JS::Realm& realm)

--- a/Userland/Libraries/LibWeb/Fetch/Body.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Body.cpp
@@ -113,7 +113,7 @@ WebIDL::ExceptionOr<JS::Value> package_data(JS::Realm& realm, ByteBuffer bytes, 
         // Return a Blob whose contents are bytes and type attribute is mimeType.
         // NOTE: If extracting the mime type returns failure, other browsers set it to an empty string - not sure if that's spec'd.
         auto mime_type_string = mime_type.has_value() ? TRY_OR_THROW_OOM(vm, mime_type->serialized()) : String {};
-        return TRY(FileAPI::Blob::create(realm, move(bytes), move(mime_type_string)));
+        return FileAPI::Blob::create(realm, move(bytes), move(mime_type_string));
     }
     case PackageDataType::FormData:
         // If mimeType’s essence is "multipart/form-data", then:

--- a/Userland/Libraries/LibWeb/Fetch/BodyInit.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/BodyInit.cpp
@@ -45,12 +45,12 @@ WebIDL::ExceptionOr<Infrastructure::BodyWithType> extract_body(JS::Realm& realm,
     else if (auto const* blob_handle = object.get_pointer<JS::Handle<FileAPI::Blob>>()) {
         // FIXME: "set stream to the result of running object’s get stream"
         (void)blob_handle;
-        stream = MUST_OR_THROW_OOM(realm.heap().allocate<Streams::ReadableStream>(realm, realm));
+        stream = realm.heap().allocate<Streams::ReadableStream>(realm, realm);
     }
     // 4. Otherwise, set stream to a new ReadableStream object, and set up stream.
     else {
         // FIXME: "set up stream"
-        stream = MUST_OR_THROW_OOM(realm.heap().allocate<Streams::ReadableStream>(realm, realm));
+        stream = realm.heap().allocate<Streams::ReadableStream>(realm, realm);
     }
 
     // 5. Assert: stream is a ReadableStream object.

--- a/Userland/Libraries/LibWeb/Fetch/FetchMethod.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/FetchMethod.cpp
@@ -111,7 +111,7 @@ JS::NonnullGCPtr<JS::Promise> fetch(JS::VM& vm, RequestInfo const& input, Reques
 
         // 4. Set responseObject to the result of creating a Response object, given response, "immutable", and
         //    relevantRealm.
-        auto response_object = Response::create(relevant_realm, response, Headers::Guard::Immutable).release_value_but_fixme_should_propagate_errors();
+        auto response_object = Response::create(relevant_realm, response, Headers::Guard::Immutable);
         response_object_handle = JS::make_handle(response_object);
 
         // 5. Resolve p with responseObject.

--- a/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
@@ -859,7 +859,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<PendingResponse>> http_fetch(JS::Realm& rea
     // 4. If request’s service-workers mode is "all", then:
     if (request->service_workers_mode() == Infrastructure::Request::ServiceWorkersMode::All) {
         // 1. Let requestForServiceWorker be a clone of request.
-        auto request_for_service_worker = TRY(request->clone(realm));
+        auto request_for_service_worker = request->clone(realm);
 
         // 2. If requestForServiceWorker’s body is non-null, then:
         if (!request_for_service_worker->body().has<Empty>()) {
@@ -1262,7 +1262,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<PendingResponse>> http_network_or_cache_fet
             // NOTE: Implementations are encouraged to avoid teeing request’s body’s stream when request’s body’s
             //       source is null as only a single body is needed in that case. E.g., when request’s body’s source
             //       is null, redirects and authentication will end up failing the fetch.
-            http_request = TRY(request->clone(realm));
+            http_request = request->clone(realm);
 
             // 2. Set httpFetchParams to a copy of fetchParams.
             // 3. Set httpFetchParams’s request to httpRequest.

--- a/Userland/Libraries/LibWeb/Fetch/Headers.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Headers.cpp
@@ -17,7 +17,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Headers>> Headers::construct_impl(JS::Realm
     auto& vm = realm.vm();
 
     // The new Headers(init) constructor steps are:
-    auto headers = MUST_OR_THROW_OOM(realm.heap().allocate<Headers>(realm, realm, Infrastructure::HeaderList::create(vm)));
+    auto headers = realm.heap().allocate<Headers>(realm, realm, Infrastructure::HeaderList::create(vm));
 
     // 1. Set this’s guard to "none".
     headers->m_guard = Guard::None;

--- a/Userland/Libraries/LibWeb/Fetch/HeadersIterator.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/HeadersIterator.cpp
@@ -15,7 +15,7 @@ namespace Web::Bindings {
 template<>
 void Intrinsics::create_web_prototype_and_constructor<HeadersIteratorPrototype>(JS::Realm& realm)
 {
-    auto prototype = heap().allocate<HeadersIteratorPrototype>(realm, realm).release_allocated_value_but_fixme_should_propagate_errors();
+    auto prototype = heap().allocate<HeadersIteratorPrototype>(realm, realm);
     m_prototypes.set("HeadersIterator"sv, prototype);
 }
 
@@ -23,9 +23,9 @@ void Intrinsics::create_web_prototype_and_constructor<HeadersIteratorPrototype>(
 
 namespace Web::Fetch {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<HeadersIterator>> HeadersIterator::create(Headers const& headers, JS::Object::PropertyKind iteration_kind)
+JS::NonnullGCPtr<HeadersIterator> HeadersIterator::create(Headers const& headers, JS::Object::PropertyKind iteration_kind)
 {
-    return MUST_OR_THROW_OOM(headers.heap().allocate<HeadersIterator>(headers.realm(), headers, iteration_kind));
+    return headers.heap().allocate<HeadersIterator>(headers.realm(), headers, iteration_kind);
 }
 
 HeadersIterator::HeadersIterator(Headers const& headers, JS::Object::PropertyKind iteration_kind)

--- a/Userland/Libraries/LibWeb/Fetch/HeadersIterator.h
+++ b/Userland/Libraries/LibWeb/Fetch/HeadersIterator.h
@@ -16,7 +16,7 @@ class HeadersIterator final : public Bindings::PlatformObject {
     WEB_PLATFORM_OBJECT(HeadersIterator, Bindings::PlatformObject);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<HeadersIterator>> create(Headers const&, JS::Object::PropertyKind iteration_kind);
+    [[nodiscard]] static JS::NonnullGCPtr<HeadersIterator> create(Headers const&, JS::Object::PropertyKind iteration_kind);
 
     virtual ~HeadersIterator() override;
 

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Bodies.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Bodies.cpp
@@ -26,12 +26,12 @@ Body::Body(JS::Handle<Streams::ReadableStream> stream, SourceType source, Option
 }
 
 // https://fetch.spec.whatwg.org/#concept-body-clone
-WebIDL::ExceptionOr<Body> Body::clone(JS::Realm& realm) const
+Body Body::clone(JS::Realm& realm) const
 {
     // To clone a body body, run these steps:
     // FIXME: 1. Let « out1, out2 » be the result of teeing body’s stream.
     // FIXME: 2. Set body’s stream to out1.
-    auto out2 = MUST_OR_THROW_OOM(realm.heap().allocate<Streams::ReadableStream>(realm, realm));
+    auto out2 = realm.heap().allocate<Streams::ReadableStream>(realm, realm);
 
     // 3. Return a body whose stream is out2 and other members are copied from body.
     return Body { JS::make_handle(out2), m_source, m_length };

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Bodies.h
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Bodies.h
@@ -36,7 +36,7 @@ public:
     [[nodiscard]] SourceType const& source() const { return m_source; }
     [[nodiscard]] Optional<u64> const& length() const { return m_length; }
 
-    WebIDL::ExceptionOr<Body> clone(JS::Realm&) const;
+    [[nodiscard]] Body clone(JS::Realm&) const;
 
     WebIDL::ExceptionOr<void> fully_read(JS::Realm&, ProcessBodyCallback process_body, ProcessBodyErrorCallback process_body_error, TaskDestination task_destination) const;
 

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Requests.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Requests.cpp
@@ -202,7 +202,7 @@ ErrorOr<ByteBuffer> Request::byte_serialize_origin() const
 }
 
 // https://fetch.spec.whatwg.org/#concept-request-clone
-WebIDL::ExceptionOr<JS::NonnullGCPtr<Request>> Request::clone(JS::Realm& realm) const
+JS::NonnullGCPtr<Request> Request::clone(JS::Realm& realm) const
 {
     // To clone a request request, run these steps:
     auto& vm = realm.vm();
@@ -250,7 +250,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Request>> Request::clone(JS::Realm& realm) 
 
     // 2. If request’s body is non-null, set newRequest’s body to the result of cloning request’s body.
     if (auto const* body = m_body.get_pointer<Body>())
-        new_request->set_body(TRY(body->clone(realm)));
+        new_request->set_body(body->clone(realm));
 
     // 3. Return newRequest.
     return new_request;

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Requests.h
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Requests.h
@@ -297,7 +297,7 @@ public:
     [[nodiscard]] ErrorOr<String> serialize_origin() const;
     [[nodiscard]] ErrorOr<ByteBuffer> byte_serialize_origin() const;
 
-    [[nodiscard]] WebIDL::ExceptionOr<JS::NonnullGCPtr<Request>> clone(JS::Realm&) const;
+    [[nodiscard]] JS::NonnullGCPtr<Request> clone(JS::Realm&) const;
 
     [[nodiscard]] ErrorOr<void> add_range_header(u64 first, Optional<u64> const& last);
     [[nodiscard]] ErrorOr<void> add_origin_header();

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Responses.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Responses.cpp
@@ -164,7 +164,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Response>> Response::clone(JS::Realm& realm
 
     // 3. If response’s body is non-null, then set newResponse’s body to the result of cloning response’s body.
     if (m_body.has_value())
-        new_response->set_body(TRY(m_body->clone(realm)));
+        new_response->set_body(m_body->clone(realm));
 
     // 4. Return newResponse.
     return new_response;

--- a/Userland/Libraries/LibWeb/Fetch/Request.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Request.cpp
@@ -79,18 +79,18 @@ Optional<Infrastructure::Body&> Request::body_impl()
 }
 
 // https://fetch.spec.whatwg.org/#request-create
-WebIDL::ExceptionOr<JS::NonnullGCPtr<Request>> Request::create(JS::Realm& realm, JS::NonnullGCPtr<Infrastructure::Request> request, Headers::Guard guard)
+JS::NonnullGCPtr<Request> Request::create(JS::Realm& realm, JS::NonnullGCPtr<Infrastructure::Request> request, Headers::Guard guard)
 {
     // 1. Let requestObject be a new Request object with realm.
     // 2. Set requestObject’s request to request.
-    auto request_object = MUST_OR_THROW_OOM(realm.heap().allocate<Request>(realm, realm, request));
+    auto request_object = realm.heap().allocate<Request>(realm, realm, request);
 
     // 3. Set requestObject’s headers to a new Headers object with realm, whose headers list is request’s headers list and guard is guard.
-    request_object->m_headers = MUST_OR_THROW_OOM(realm.heap().allocate<Headers>(realm, realm, request->header_list()));
+    request_object->m_headers = realm.heap().allocate<Headers>(realm, realm, request->header_list());
     request_object->m_headers->set_guard(guard);
 
     // 4. Set requestObject’s signal to a new AbortSignal object with realm.
-    request_object->m_signal = MUST_OR_THROW_OOM(realm.heap().allocate<DOM::AbortSignal>(realm, realm));
+    request_object->m_signal = realm.heap().allocate<DOM::AbortSignal>(realm, realm);
 
     // 5. Return requestObject.
     return request_object;
@@ -102,7 +102,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Request>> Request::construct_impl(JS::Realm
     auto& vm = realm.vm();
 
     // Referred to as 'this' in the spec.
-    auto request_object = MUST_OR_THROW_OOM(realm.heap().allocate<Request>(realm, realm, Infrastructure::Request::create(vm)));
+    auto request_object = realm.heap().allocate<Request>(realm, realm, Infrastructure::Request::create(vm));
 
     // 1. Let request be null.
     JS::GCPtr<Infrastructure::Request> input_request;
@@ -387,14 +387,14 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Request>> Request::construct_impl(JS::Realm
 
     // 28. Set this’s signal to a new AbortSignal object with this’s relevant Realm.
     auto& this_relevant_realm = HTML::relevant_realm(*request_object);
-    request_object->m_signal = MUST_OR_THROW_OOM(realm.heap().allocate<DOM::AbortSignal>(this_relevant_realm, this_relevant_realm));
+    request_object->m_signal = realm.heap().allocate<DOM::AbortSignal>(this_relevant_realm, this_relevant_realm);
 
     // 29. If signal is not null, then make this’s signal follow signal.
     if (input_signal != nullptr)
         request_object->m_signal->follow(*input_signal);
 
     // 30. Set this’s headers to a new Headers object with this’s relevant Realm, whose header list is request’s header list and guard is "request".
-    request_object->m_headers = MUST_OR_THROW_OOM(realm.heap().allocate<Headers>(realm, realm, request->header_list()));
+    request_object->m_headers = realm.heap().allocate<Headers>(realm, realm, request->header_list());
     request_object->m_headers->set_guard(Headers::Guard::Request);
 
     // 31. If this’s request’s mode is "no-cors", then:
@@ -639,10 +639,10 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Request>> Request::clone() const
         return WebIDL::SimpleException { WebIDL::SimpleExceptionType::TypeError, "Request is unusable"sv };
 
     // 2. Let clonedRequest be the result of cloning this’s request.
-    auto cloned_request = TRY(m_request->clone(realm));
+    auto cloned_request = m_request->clone(realm);
 
     // 3. Let clonedRequestObject be the result of creating a Request object, given clonedRequest, this’s headers’s guard, and this’s relevant Realm.
-    auto cloned_request_object = TRY(Request::create(HTML::relevant_realm(*this), cloned_request, m_headers->guard()));
+    auto cloned_request_object = Request::create(HTML::relevant_realm(*this), cloned_request, m_headers->guard());
 
     // 4. Make clonedRequestObject’s signal follow this’s signal.
     cloned_request_object->m_signal->follow(*m_signal);

--- a/Userland/Libraries/LibWeb/Fetch/Request.h
+++ b/Userland/Libraries/LibWeb/Fetch/Request.h
@@ -66,7 +66,7 @@ class Request final
     WEB_PLATFORM_OBJECT(Request, Bindings::PlatformObject);
 
 public:
-    [[nodiscard]] static WebIDL::ExceptionOr<JS::NonnullGCPtr<Request>> create(JS::Realm&, JS::NonnullGCPtr<Infrastructure::Request>, Headers::Guard);
+    [[nodiscard]] static JS::NonnullGCPtr<Request> create(JS::Realm&, JS::NonnullGCPtr<Infrastructure::Request>, Headers::Guard);
     static WebIDL::ExceptionOr<JS::NonnullGCPtr<Request>> construct_impl(JS::Realm&, RequestInfo const& input, RequestInit const& init = {});
 
     virtual ~Request() override;

--- a/Userland/Libraries/LibWeb/Fetch/Response.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Response.cpp
@@ -71,14 +71,14 @@ Optional<Infrastructure::Body&> Response::body_impl()
 }
 
 // https://fetch.spec.whatwg.org/#response-create
-WebIDL::ExceptionOr<JS::NonnullGCPtr<Response>> Response::create(JS::Realm& realm, JS::NonnullGCPtr<Infrastructure::Response> response, Headers::Guard guard)
+JS::NonnullGCPtr<Response> Response::create(JS::Realm& realm, JS::NonnullGCPtr<Infrastructure::Response> response, Headers::Guard guard)
 {
     // 1. Let responseObject be a new Response object with realm.
     // 2. Set responseObject’s response to response.
-    auto response_object = MUST_OR_THROW_OOM(realm.heap().allocate<Response>(realm, realm, response));
+    auto response_object = realm.heap().allocate<Response>(realm, realm, response);
 
     // 3. Set responseObject’s headers to a new Headers object with realm, whose headers list is response’s headers list and guard is guard.
-    response_object->m_headers = MUST_OR_THROW_OOM(realm.heap().allocate<Headers>(realm, realm, response->header_list()));
+    response_object->m_headers = realm.heap().allocate<Headers>(realm, realm, response->header_list());
     response_object->m_headers->set_guard(guard);
 
     // 4. Return responseObject.
@@ -134,14 +134,14 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Response>> Response::construct_impl(JS::Rea
     auto& vm = realm.vm();
 
     // Referred to as 'this' in the spec.
-    auto response_object = MUST_OR_THROW_OOM(realm.heap().allocate<Response>(realm, realm, Infrastructure::Response::create(vm)));
+    auto response_object = realm.heap().allocate<Response>(realm, realm, Infrastructure::Response::create(vm));
 
     // 1. Set this’s response to a new response.
     // NOTE: This is done at the beginning as the 'this' value Response object
     //       cannot exist with a null Infrastructure::Response.
 
     // 2. Set this’s headers to a new Headers object with this’s relevant Realm, whose header list is this’s response’s header list and guard is "response".
-    response_object->m_headers = MUST_OR_THROW_OOM(realm.heap().allocate<Headers>(realm, realm, response_object->response()->header_list()));
+    response_object->m_headers = realm.heap().allocate<Headers>(realm, realm, response_object->response()->header_list());
     response_object->m_headers->set_guard(Headers::Guard::Response);
 
     // 3. Let bodyWithType be null.
@@ -158,7 +158,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Response>> Response::construct_impl(JS::Rea
 }
 
 // https://fetch.spec.whatwg.org/#dom-response-error
-WebIDL::ExceptionOr<JS::NonnullGCPtr<Response>> Response::error(JS::VM& vm)
+JS::NonnullGCPtr<Response> Response::error(JS::VM& vm)
 {
     // The static error() method steps are to return the result of creating a Response object, given a new network error, "immutable", and this’s relevant Realm.
     // FIXME: How can we reliably get 'this', i.e. the object the function was called on, in IDL-defined functions?
@@ -184,7 +184,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Response>> Response::redirect(JS::VM& vm, S
 
     // 4. Let responseObject be the result of creating a Response object, given a new response, "immutable", and this’s relevant Realm.
     // FIXME: How can we reliably get 'this', i.e. the object the function was called on, in IDL-defined functions?
-    auto response_object = TRY(Response::create(realm, Infrastructure::Response::create(vm), Headers::Guard::Immutable));
+    auto response_object = Response::create(realm, Infrastructure::Response::create(vm), Headers::Guard::Immutable);
 
     // 5. Set responseObject’s response’s status to status.
     response_object->response()->set_status(status);
@@ -213,7 +213,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Response>> Response::json(JS::VM& vm, JS::V
 
     // 3. Let responseObject be the result of creating a Response object, given a new response, "response", and this’s relevant Realm.
     // FIXME: How can we reliably get 'this', i.e. the object the function was called on, in IDL-defined functions?
-    auto response_object = TRY(Response::create(realm, Infrastructure::Response::create(vm), Headers::Guard::Response));
+    auto response_object = Response::create(realm, Infrastructure::Response::create(vm), Headers::Guard::Response);
 
     // 4. Perform initialize a response given responseObject, init, and (body, "application/json").
     auto body_with_type = Infrastructure::BodyWithType {
@@ -294,7 +294,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Response>> Response::clone() const
     auto cloned_response = TRY(m_response->clone(realm));
 
     // 3. Return the result of creating a Response object, given clonedResponse, this’s headers’s guard, and this’s relevant Realm.
-    return TRY(Response::create(HTML::relevant_realm(*this), cloned_response, m_headers->guard()));
+    return Response::create(HTML::relevant_realm(*this), cloned_response, m_headers->guard());
 }
 
 }

--- a/Userland/Libraries/LibWeb/Fetch/Response.h
+++ b/Userland/Libraries/LibWeb/Fetch/Response.h
@@ -33,7 +33,7 @@ class Response final
     WEB_PLATFORM_OBJECT(Response, Bindings::PlatformObject);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<Response>> create(JS::Realm&, JS::NonnullGCPtr<Infrastructure::Response>, Headers::Guard);
+    [[nodiscard]] static JS::NonnullGCPtr<Response> create(JS::Realm&, JS::NonnullGCPtr<Infrastructure::Response>, Headers::Guard);
     static WebIDL::ExceptionOr<JS::NonnullGCPtr<Response>> construct_impl(JS::Realm&, Optional<BodyInit> const& body = {}, ResponseInit const& init = {});
 
     virtual ~Response() override;
@@ -48,7 +48,7 @@ public:
     [[nodiscard]] JS::NonnullGCPtr<Infrastructure::Response> response() const { return m_response; }
 
     // JS API functions
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<Response>> error(JS::VM&);
+    [[nodiscard]] static JS::NonnullGCPtr<Response> error(JS::VM&);
     static WebIDL::ExceptionOr<JS::NonnullGCPtr<Response>> redirect(JS::VM&, String const& url, u16 status);
     static WebIDL::ExceptionOr<JS::NonnullGCPtr<Response>> json(JS::VM&, JS::Value data, ResponseInit const& init = {});
     [[nodiscard]] Bindings::ResponseType type() const;

--- a/Userland/Libraries/LibWeb/FileAPI/Blob.cpp
+++ b/Userland/Libraries/LibWeb/FileAPI/Blob.cpp
@@ -22,9 +22,9 @@
 
 namespace Web::FileAPI {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<Blob>> Blob::create(JS::Realm& realm, ByteBuffer byte_buffer, String type)
+JS::NonnullGCPtr<Blob> Blob::create(JS::Realm& realm, ByteBuffer byte_buffer, String type)
 {
-    return MUST_OR_THROW_OOM(realm.heap().allocate<Blob>(realm, realm, move(byte_buffer), move(type)));
+    return realm.heap().allocate<Blob>(realm, realm, move(byte_buffer), move(type));
 }
 
 // https://w3c.github.io/FileAPI/#convert-line-endings-to-native
@@ -146,18 +146,16 @@ void Blob::initialize(JS::Realm& realm)
 }
 
 // https://w3c.github.io/FileAPI/#ref-for-dom-blob-blob
-WebIDL::ExceptionOr<JS::NonnullGCPtr<Blob>> Blob::create(JS::Realm& realm, Optional<Vector<BlobPart>> const& blob_parts, Optional<BlobPropertyBag> const& options)
+JS::NonnullGCPtr<Blob> Blob::create(JS::Realm& realm, Optional<Vector<BlobPart>> const& blob_parts, Optional<BlobPropertyBag> const& options)
 {
-    auto& vm = realm.vm();
-
     // 1. If invoked with zero parameters, return a new Blob object consisting of 0 bytes, with size set to 0, and with type set to the empty string.
     if (!blob_parts.has_value() && !options.has_value())
-        return MUST_OR_THROW_OOM(realm.heap().allocate<Blob>(realm, realm));
+        return realm.heap().allocate<Blob>(realm, realm);
 
     ByteBuffer byte_buffer {};
     // 2. Let bytes be the result of processing blob parts given blobParts and options.
     if (blob_parts.has_value()) {
-        byte_buffer = TRY_OR_THROW_OOM(realm.vm(), process_blob_parts(blob_parts.value(), options));
+        byte_buffer = MUST(process_blob_parts(blob_parts.value(), options));
     }
 
     auto type = String {};
@@ -173,11 +171,11 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Blob>> Blob::create(JS::Realm& realm, Optio
 
         // 2. Convert every character in t to ASCII lowercase.
         if (!type.is_empty())
-            type = TRY_OR_THROW_OOM(vm, Infra::to_ascii_lowercase(type));
+            type = MUST(Infra::to_ascii_lowercase(type));
     }
 
     // 4. Return a Blob object referring to bytes as its associated byte sequence, with its size set to the length of bytes, and its type set to the value of t from the substeps above.
-    return MUST_OR_THROW_OOM(realm.heap().allocate<Blob>(realm, realm, move(byte_buffer), move(type)));
+    return realm.heap().allocate<Blob>(realm, realm, move(byte_buffer), move(type));
 }
 
 WebIDL::ExceptionOr<JS::NonnullGCPtr<Blob>> Blob::construct_impl(JS::Realm& realm, Optional<Vector<BlobPart>> const& blob_parts, Optional<BlobPropertyBag> const& options)
@@ -250,7 +248,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Blob>> Blob::slice(Optional<i64> start, Opt
     // b. S.size = span.
     // c. S.type = relativeContentType.
     auto byte_buffer = TRY_OR_THROW_OOM(vm, m_byte_buffer.slice(relative_start, span));
-    return MUST_OR_THROW_OOM(heap().allocate<Blob>(realm(), realm(), move(byte_buffer), move(relative_content_type)));
+    return heap().allocate<Blob>(realm(), realm(), move(byte_buffer), move(relative_content_type));
 }
 
 // https://w3c.github.io/FileAPI/#dom-blob-stream
@@ -266,7 +264,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Streams::ReadableStream>> Blob::get_stream(
     auto& realm = this->realm();
 
     // 1. Let stream be a new ReadableStream created in blob’s relevant Realm.
-    auto stream = MUST_OR_THROW_OOM(realm.heap().allocate<Streams::ReadableStream>(realm, realm));
+    auto stream = realm.heap().allocate<Streams::ReadableStream>(realm, realm);
 
     // 2. Set up stream with byte reading support.
     TRY(set_up_readable_stream_controller_with_byte_reading_support(stream));

--- a/Userland/Libraries/LibWeb/FileAPI/Blob.h
+++ b/Userland/Libraries/LibWeb/FileAPI/Blob.h
@@ -32,8 +32,8 @@ class Blob : public Bindings::PlatformObject {
 public:
     virtual ~Blob() override;
 
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<Blob>> create(JS::Realm&, ByteBuffer, String type);
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<Blob>> create(JS::Realm&, Optional<Vector<BlobPart>> const& blob_parts = {}, Optional<BlobPropertyBag> const& options = {});
+    [[nodiscard]] static JS::NonnullGCPtr<Blob> create(JS::Realm&, ByteBuffer, String type);
+    [[nodiscard]] static JS::NonnullGCPtr<Blob> create(JS::Realm&, Optional<Vector<BlobPart>> const& blob_parts = {}, Optional<BlobPropertyBag> const& options = {});
     static WebIDL::ExceptionOr<JS::NonnullGCPtr<Blob>> construct_impl(JS::Realm&, Optional<Vector<BlobPart>> const& blob_parts = {}, Optional<BlobPropertyBag> const& options = {});
 
     // https://w3c.github.io/FileAPI/#dfn-size

--- a/Userland/Libraries/LibWeb/FileAPI/File.cpp
+++ b/Userland/Libraries/LibWeb/FileAPI/File.cpp
@@ -67,7 +67,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<File>> File::create(JS::Realm& realm, Vecto
     //    4. F.name is set to n.
     //    5. F.type is set to t.
     //    6. F.lastModified is set to d.
-    return MUST_OR_THROW_OOM(realm.heap().allocate<File>(realm, realm, move(bytes), move(name), move(type), last_modified));
+    return realm.heap().allocate<File>(realm, realm, move(bytes), move(name), move(type), last_modified);
 }
 
 WebIDL::ExceptionOr<JS::NonnullGCPtr<File>> File::construct_impl(JS::Realm& realm, Vector<BlobPart> const& file_bits, String const& file_name, Optional<FilePropertyBag> const& options)

--- a/Userland/Libraries/LibWeb/FileAPI/FileList.cpp
+++ b/Userland/Libraries/LibWeb/FileAPI/FileList.cpp
@@ -11,9 +11,9 @@
 
 namespace Web::FileAPI {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<FileList>> FileList::create(JS::Realm& realm, Vector<JS::NonnullGCPtr<File>>&& files)
+JS::NonnullGCPtr<FileList> FileList::create(JS::Realm& realm, Vector<JS::NonnullGCPtr<File>>&& files)
 {
-    return MUST_OR_THROW_OOM(realm.heap().allocate<FileList>(realm, realm, move(files)));
+    return realm.heap().allocate<FileList>(realm, realm, move(files));
 }
 
 FileList::FileList(JS::Realm& realm, Vector<JS::NonnullGCPtr<File>>&& files)

--- a/Userland/Libraries/LibWeb/FileAPI/FileList.h
+++ b/Userland/Libraries/LibWeb/FileAPI/FileList.h
@@ -18,7 +18,7 @@ class FileList : public Bindings::LegacyPlatformObject {
     WEB_PLATFORM_OBJECT(FileList, Bindings::LegacyPlatformObject);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<FileList>> create(JS::Realm&, Vector<JS::NonnullGCPtr<File>>&&);
+    [[nodiscard]] static JS::NonnullGCPtr<FileList> create(JS::Realm&, Vector<JS::NonnullGCPtr<File>>&&);
     virtual ~FileList() override;
 
     // https://w3c.github.io/FileAPI/#dfn-length

--- a/Userland/Libraries/LibWeb/Geometry/DOMMatrix.cpp
+++ b/Userland/Libraries/LibWeb/Geometry/DOMMatrix.cpp
@@ -23,7 +23,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<DOMMatrix>> DOMMatrix::construct_impl(JS::R
             return WebIDL::SimpleException { WebIDL::SimpleExceptionType::TypeError, TRY_OR_THROW_OOM(vm, String::formatted("Sequence must contain exactly 6 or 16 elements, got {} element(s)", double_sequence->size())) };
     }
 
-    return realm.heap().allocate<DOMMatrix>(realm, realm, init).release_allocated_value_but_fixme_should_propagate_errors();
+    return realm.heap().allocate<DOMMatrix>(realm, realm, init);
 }
 
 // https://drafts.fxtf.org/geometry/#create-a-dommatrix-from-the-2d-dictionary
@@ -42,12 +42,12 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<DOMMatrix>> DOMMatrix::create_from_dom_matr
 
     // 2. Return the result of invoking create a 2d matrix of type DOMMatrixReadOnly or DOMMatrix as appropriate, with a sequence of numbers,
     //    the values being the 6 elements m11, m12, m21, m22, m41 and m42 of other in the given order.
-    return realm.heap().allocate<DOMMatrix>(realm, realm, init.m11.value(), init.m12.value(), init.m21.value(), init.m22.value(), init.m41.value(), init.m42.value()).release_allocated_value_but_fixme_should_propagate_errors();
+    return realm.heap().allocate<DOMMatrix>(realm, realm, init.m11.value(), init.m12.value(), init.m21.value(), init.m22.value(), init.m41.value(), init.m42.value());
 }
 
 JS::NonnullGCPtr<DOMMatrix> DOMMatrix::create_from_dom_matrix_read_only(JS::Realm& realm, DOMMatrixReadOnly const& read_only_matrix)
 {
-    return realm.heap().allocate<DOMMatrix>(realm, realm, read_only_matrix).release_allocated_value_but_fixme_should_propagate_errors();
+    return realm.heap().allocate<DOMMatrix>(realm, realm, read_only_matrix);
 }
 
 DOMMatrix::DOMMatrix(JS::Realm& realm, double m11, double m12, double m21, double m22, double m41, double m42)

--- a/Userland/Libraries/LibWeb/Geometry/DOMMatrixReadOnly.cpp
+++ b/Userland/Libraries/LibWeb/Geometry/DOMMatrixReadOnly.cpp
@@ -24,7 +24,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<DOMMatrixReadOnly>> DOMMatrixReadOnly::cons
             return WebIDL::SimpleException { WebIDL::SimpleExceptionType::TypeError, TRY_OR_THROW_OOM(vm, String::formatted("Sequence must contain exactly 6 or 16 elements, got {} element(s)", double_sequence->size())) };
     }
 
-    return realm.heap().allocate<DOMMatrixReadOnly>(realm, realm, init).release_allocated_value_but_fixme_should_propagate_errors();
+    return realm.heap().allocate<DOMMatrixReadOnly>(realm, realm, init);
 }
 
 // https://drafts.fxtf.org/geometry/#create-a-dommatrixreadonly-from-the-2d-dictionary
@@ -43,7 +43,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<DOMMatrixReadOnly>> DOMMatrixReadOnly::crea
 
     // 2. Return the result of invoking create a 2d matrix of type DOMMatrixReadOnly or DOMMatrix as appropriate, with a sequence of numbers,
     //    the values being the 6 elements m11, m12, m21, m22, m41 and m42 of other in the given order.
-    return realm.heap().allocate<DOMMatrixReadOnly>(realm, realm, init.m11.value(), init.m12.value(), init.m21.value(), init.m22.value(), init.m41.value(), init.m42.value()).release_allocated_value_but_fixme_should_propagate_errors();
+    return realm.heap().allocate<DOMMatrixReadOnly>(realm, realm, init.m11.value(), init.m12.value(), init.m21.value(), init.m22.value(), init.m41.value(), init.m42.value());
 }
 
 DOMMatrixReadOnly::DOMMatrixReadOnly(JS::Realm& realm, double m11, double m12, double m21, double m22, double m41, double m42)

--- a/Userland/Libraries/LibWeb/Geometry/DOMPoint.cpp
+++ b/Userland/Libraries/LibWeb/Geometry/DOMPoint.cpp
@@ -13,7 +13,7 @@ namespace Web::Geometry {
 
 WebIDL::ExceptionOr<JS::NonnullGCPtr<DOMPoint>> DOMPoint::construct_impl(JS::Realm& realm, double x, double y, double z, double w)
 {
-    return MUST_OR_THROW_OOM(realm.heap().allocate<DOMPoint>(realm, realm, x, y, z, w));
+    return realm.heap().allocate<DOMPoint>(realm, realm, x, y, z, w);
 }
 
 DOMPoint::DOMPoint(JS::Realm& realm, double x, double y, double z, double w)

--- a/Userland/Libraries/LibWeb/Geometry/DOMPointReadOnly.cpp
+++ b/Userland/Libraries/LibWeb/Geometry/DOMPointReadOnly.cpp
@@ -13,7 +13,7 @@ namespace Web::Geometry {
 
 WebIDL::ExceptionOr<JS::NonnullGCPtr<DOMPointReadOnly>> DOMPointReadOnly::construct_impl(JS::Realm& realm, double x, double y, double z, double w)
 {
-    return MUST_OR_THROW_OOM(realm.heap().allocate<DOMPointReadOnly>(realm, realm, x, y, z, w));
+    return realm.heap().allocate<DOMPointReadOnly>(realm, realm, x, y, z, w);
 }
 
 DOMPointReadOnly::DOMPointReadOnly(JS::Realm& realm, double x, double y, double z, double w)

--- a/Userland/Libraries/LibWeb/Geometry/DOMRect.cpp
+++ b/Userland/Libraries/LibWeb/Geometry/DOMRect.cpp
@@ -12,19 +12,19 @@ namespace Web::Geometry {
 
 WebIDL::ExceptionOr<JS::NonnullGCPtr<DOMRect>> DOMRect::construct_impl(JS::Realm& realm, double x, double y, double width, double height)
 {
-    return MUST_OR_THROW_OOM(realm.heap().allocate<DOMRect>(realm, realm, x, y, width, height));
+    return create(realm, Gfx::FloatRect { x, y, width, height });
 }
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<DOMRect>> DOMRect::create(JS::Realm& realm, Gfx::FloatRect const& rect)
+JS::NonnullGCPtr<DOMRect> DOMRect::create(JS::Realm& realm, Gfx::FloatRect const& rect)
 {
-    return construct_impl(realm, rect.x(), rect.y(), rect.width(), rect.height());
+    return realm.heap().allocate<DOMRect>(realm, realm, rect.x(), rect.y(), rect.width(), rect.height());
 }
 
 // https://drafts.fxtf.org/geometry/#create-a-domrect-from-the-dictionary
-WebIDL::ExceptionOr<JS::NonnullGCPtr<DOMRect>> DOMRect::from_rect(JS::VM& vm, Geometry::DOMRectInit const& other)
+JS::NonnullGCPtr<DOMRect> DOMRect::from_rect(JS::VM& vm, Geometry::DOMRectInit const& other)
 {
     auto& realm = *vm.current_realm();
-    return MUST_OR_THROW_OOM(realm.heap().allocate<DOMRect>(realm, realm, other.x, other.y, other.width, other.height));
+    return realm.heap().allocate<DOMRect>(realm, realm, other.x, other.y, other.width, other.height);
 }
 
 DOMRect::DOMRect(JS::Realm& realm, double x, double y, double width, double height)

--- a/Userland/Libraries/LibWeb/Geometry/DOMRect.h
+++ b/Userland/Libraries/LibWeb/Geometry/DOMRect.h
@@ -16,8 +16,8 @@ class DOMRect final : public DOMRectReadOnly {
 
 public:
     static WebIDL::ExceptionOr<JS::NonnullGCPtr<DOMRect>> construct_impl(JS::Realm&, double x = 0, double y = 0, double width = 0, double height = 0);
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<DOMRect>> create(JS::Realm&, Gfx::FloatRect const&);
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<DOMRect>> from_rect(JS::VM&, DOMRectInit const&);
+    [[nodiscard]] static JS::NonnullGCPtr<DOMRect> create(JS::Realm&, Gfx::FloatRect const&);
+    [[nodiscard]] static JS::NonnullGCPtr<DOMRect> from_rect(JS::VM&, DOMRectInit const&);
 
     virtual ~DOMRect() override;
 

--- a/Userland/Libraries/LibWeb/Geometry/DOMRectList.cpp
+++ b/Userland/Libraries/LibWeb/Geometry/DOMRectList.cpp
@@ -12,12 +12,12 @@
 
 namespace Web::Geometry {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<DOMRectList>> DOMRectList::create(JS::Realm& realm, Vector<JS::Handle<DOMRect>> rect_handles)
+JS::NonnullGCPtr<DOMRectList> DOMRectList::create(JS::Realm& realm, Vector<JS::Handle<DOMRect>> rect_handles)
 {
     Vector<JS::NonnullGCPtr<DOMRect>> rects;
     for (auto& rect : rect_handles)
         rects.append(*rect);
-    return MUST_OR_THROW_OOM(realm.heap().allocate<DOMRectList>(realm, realm, move(rects)));
+    return realm.heap().allocate<DOMRectList>(realm, realm, move(rects));
 }
 
 DOMRectList::DOMRectList(JS::Realm& realm, Vector<JS::NonnullGCPtr<DOMRect>> rects)

--- a/Userland/Libraries/LibWeb/Geometry/DOMRectList.h
+++ b/Userland/Libraries/LibWeb/Geometry/DOMRectList.h
@@ -18,7 +18,7 @@ class DOMRectList final : public Bindings::LegacyPlatformObject {
     WEB_PLATFORM_OBJECT(DOMRectList, Bindings::LegacyPlatformObject);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<DOMRectList>> create(JS::Realm&, Vector<JS::Handle<DOMRect>>);
+    [[nodiscard]] static JS::NonnullGCPtr<DOMRectList> create(JS::Realm&, Vector<JS::Handle<DOMRect>>);
 
     virtual ~DOMRectList() override;
 

--- a/Userland/Libraries/LibWeb/Geometry/DOMRectReadOnly.cpp
+++ b/Userland/Libraries/LibWeb/Geometry/DOMRectReadOnly.cpp
@@ -12,14 +12,14 @@ namespace Web::Geometry {
 
 WebIDL::ExceptionOr<JS::NonnullGCPtr<DOMRectReadOnly>> DOMRectReadOnly::construct_impl(JS::Realm& realm, double x, double y, double width, double height)
 {
-    return MUST_OR_THROW_OOM(realm.heap().allocate<DOMRectReadOnly>(realm, realm, x, y, width, height));
+    return realm.heap().allocate<DOMRectReadOnly>(realm, realm, x, y, width, height);
 }
 
 // https://drafts.fxtf.org/geometry/#create-a-domrect-from-the-dictionary
-WebIDL::ExceptionOr<JS::NonnullGCPtr<DOMRectReadOnly>> DOMRectReadOnly::from_rect(JS::VM& vm, Geometry::DOMRectInit const& other)
+JS::NonnullGCPtr<DOMRectReadOnly> DOMRectReadOnly::from_rect(JS::VM& vm, Geometry::DOMRectInit const& other)
 {
     auto& realm = *vm.current_realm();
-    return MUST_OR_THROW_OOM(realm.heap().allocate<DOMRectReadOnly>(realm, realm, other.x, other.y, other.width, other.height));
+    return realm.heap().allocate<DOMRectReadOnly>(realm, realm, other.x, other.y, other.width, other.height);
 }
 
 DOMRectReadOnly::DOMRectReadOnly(JS::Realm& realm, double x, double y, double width, double height)

--- a/Userland/Libraries/LibWeb/Geometry/DOMRectReadOnly.h
+++ b/Userland/Libraries/LibWeb/Geometry/DOMRectReadOnly.h
@@ -26,7 +26,7 @@ class DOMRectReadOnly : public Bindings::PlatformObject {
 
 public:
     static WebIDL::ExceptionOr<JS::NonnullGCPtr<DOMRectReadOnly>> construct_impl(JS::Realm&, double x = 0, double y = 0, double width = 0, double height = 0);
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<DOMRectReadOnly>> from_rect(JS::VM&, DOMRectInit const&);
+    [[nodiscard]] static JS::NonnullGCPtr<DOMRectReadOnly> from_rect(JS::VM&, DOMRectInit const&);
 
     virtual ~DOMRectReadOnly() override;
 

--- a/Userland/Libraries/LibWeb/HTML/AudioTrack.cpp
+++ b/Userland/Libraries/LibWeb/HTML/AudioTrack.cpp
@@ -102,7 +102,7 @@ void AudioTrack::set_enabled(bool enabled)
         // is disabled, the user agent must queue a media element task given the media element to fire an event named
         // change at the AudioTrackList object.
         m_media_element->queue_a_media_element_task([this]() {
-            m_audio_track_list->dispatch_event(DOM::Event::create(realm(), HTML::EventNames::change).release_value_but_fixme_should_propagate_errors());
+            m_audio_track_list->dispatch_event(DOM::Event::create(realm(), HTML::EventNames::change));
         });
     }
 

--- a/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
@@ -150,10 +150,10 @@ JS::NonnullGCPtr<BrowsingContext> BrowsingContext::create_a_new_browsing_context
     auto realm_execution_context = Bindings::create_a_new_javascript_realm(
         Bindings::main_thread_vm(),
         [&](JS::Realm& realm) -> JS::Object* {
-            browsing_context->m_window_proxy = realm.heap().allocate<WindowProxy>(realm, realm).release_allocated_value_but_fixme_should_propagate_errors();
+            browsing_context->m_window_proxy = realm.heap().allocate<WindowProxy>(realm, realm);
 
             // - For the global object, create a new Window object.
-            window = HTML::Window::create(realm).release_value_but_fixme_should_propagate_errors();
+            window = HTML::Window::create(realm);
             return window.ptr();
         },
         [&](JS::Realm&) -> JS::Object* {
@@ -173,8 +173,7 @@ JS::NonnullGCPtr<BrowsingContext> BrowsingContext::create_a_new_browsing_context
         move(realm_execution_context),
         {},
         top_level_creation_url,
-        top_level_origin)
-        .release_value_but_fixme_should_propagate_errors();
+        top_level_origin);
 
     // 12. Let loadTimingInfo be a new document load timing info with its navigation start time set to the result of calling
     //     coarsen time with unsafeContextCreationTime and the new environment settings object's cross-origin isolated capability.
@@ -204,7 +203,7 @@ JS::NonnullGCPtr<BrowsingContext> BrowsingContext::create_a_new_browsing_context
     //     load timing info is loadTimingInfo,
     //     FIXME: navigation id is null,
     //     and which is ready for post-load tasks.
-    auto document = HTML::HTMLDocument::create(window->realm()).release_value_but_fixme_should_propagate_errors();
+    auto document = HTML::HTMLDocument::create(window->realm());
 
     // Non-standard
     document->set_window(*window);
@@ -329,10 +328,10 @@ WebIDL::ExceptionOr<BrowsingContext::BrowsingContextAndDocument> BrowsingContext
         Bindings::main_thread_vm(),
         [&](JS::Realm& realm) -> JS::Object* {
             auto window_proxy = realm.heap().allocate<WindowProxy>(realm, realm);
-            browsing_context->set_window_proxy(window_proxy.release_allocated_value_but_fixme_should_propagate_errors());
+            browsing_context->set_window_proxy(window_proxy);
 
             // - For the global object, create a new Window object.
-            window = Window::create(realm).release_value_but_fixme_should_propagate_errors();
+            window = Window::create(realm);
             return window.ptr();
         },
         [&](JS::Realm&) -> JS::Object* {
@@ -347,12 +346,12 @@ WebIDL::ExceptionOr<BrowsingContext::BrowsingContextAndDocument> BrowsingContext
     auto top_level_origin = !embedder ? origin : relevant_settings_object(*embedder).origin();
 
     // 12. Set up a window environment settings object with about:blank, realm execution context, null, topLevelCreationURL, and topLevelOrigin.
-    TRY(WindowEnvironmentSettingsObject::setup(
+    WindowEnvironmentSettingsObject::setup(
         AK::URL("about:blank"),
         move(realm_execution_context),
         {},
         top_level_creation_url,
-        top_level_origin));
+        top_level_origin);
 
     // 13. Let loadTimingInfo be a new document load timing info with its navigation start time set to the result of calling
     //     coarsen time with unsafeContextCreationTime and the new environment settings object's cross-origin isolated capability.
@@ -362,7 +361,7 @@ WebIDL::ExceptionOr<BrowsingContext::BrowsingContextAndDocument> BrowsingContext
         verify_cast<WindowEnvironmentSettingsObject>(Bindings::host_defined_environment_settings_object(window->realm())).cross_origin_isolated_capability() == CanUseCrossOriginIsolatedAPIs::Yes);
 
     // 14. Let document be a new Document, with:
-    auto document = TRY(HTML::HTMLDocument::create(window->realm()));
+    auto document = HTML::HTMLDocument::create(window->realm());
 
     // Non-standard
     document->set_window(*window);
@@ -1435,7 +1434,7 @@ WebIDL::ExceptionOr<void> BrowsingContext::traverse_the_history(size_t entry_ind
             // and the newURL attribute initialized to newURL.
 
             // FIXME: Implement a proper HashChangeEvent class.
-            auto event = DOM::Event::create(verify_cast<HTML::Window>(relevant_global_object(*new_document)).realm(), HTML::EventNames::hashchange).release_value_but_fixme_should_propagate_errors();
+            auto event = DOM::Event::create(verify_cast<HTML::Window>(relevant_global_object(*new_document)).realm(), HTML::EventNames::hashchange);
             new_document->dispatch_event(event);
         });
     }

--- a/Userland/Libraries/LibWeb/HTML/CanvasGradient.cpp
+++ b/Userland/Libraries/LibWeb/HTML/CanvasGradient.cpp
@@ -22,21 +22,21 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<CanvasGradient>> CanvasGradient::create_rad
         return WebIDL::IndexSizeError::create(realm, "The r1 passed is less than 0");
 
     auto radial_gradient = TRY_OR_THROW_OOM(realm.vm(), Gfx::CanvasRadialGradientPaintStyle::create(Gfx::FloatPoint { x0, y0 }, r0, Gfx::FloatPoint { x1, y1 }, r1));
-    return MUST_OR_THROW_OOM(realm.heap().allocate<CanvasGradient>(realm, realm, *radial_gradient));
+    return realm.heap().allocate<CanvasGradient>(realm, realm, *radial_gradient);
 }
 
 // https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-createlineargradient
 WebIDL::ExceptionOr<JS::NonnullGCPtr<CanvasGradient>> CanvasGradient::create_linear(JS::Realm& realm, double x0, double y0, double x1, double y1)
 {
     auto linear_gradient = TRY_OR_THROW_OOM(realm.vm(), Gfx::CanvasLinearGradientPaintStyle::create(Gfx::FloatPoint { x0, y0 }, Gfx::FloatPoint { x1, y1 }));
-    return MUST_OR_THROW_OOM(realm.heap().allocate<CanvasGradient>(realm, realm, *linear_gradient));
+    return realm.heap().allocate<CanvasGradient>(realm, realm, *linear_gradient);
 }
 
 // https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-createconicgradient
 WebIDL::ExceptionOr<JS::NonnullGCPtr<CanvasGradient>> CanvasGradient::create_conic(JS::Realm& realm, double start_angle, double x, double y)
 {
     auto conic_gradient = TRY_OR_THROW_OOM(realm.vm(), Gfx::CanvasConicGradientPaintStyle::create(Gfx::FloatPoint { x, y }, start_angle));
-    return MUST_OR_THROW_OOM(realm.heap().allocate<CanvasGradient>(realm, realm, *conic_gradient));
+    return realm.heap().allocate<CanvasGradient>(realm, realm, *conic_gradient);
 }
 
 CanvasGradient::CanvasGradient(JS::Realm& realm, Gfx::GradientPaintStyle& gradient)

--- a/Userland/Libraries/LibWeb/HTML/CanvasPattern.cpp
+++ b/Userland/Libraries/LibWeb/HTML/CanvasPattern.cpp
@@ -130,7 +130,7 @@ WebIDL::ExceptionOr<JS::GCPtr<CanvasPattern>> CanvasPattern::create(JS::Realm& r
     // FIXME: 7. If image is not origin-clean, then mark pattern as not origin-clean.
 
     // 8. Return pattern.
-    return MUST_OR_THROW_OOM(realm.heap().allocate<CanvasPattern>(realm, realm, *pattern));
+    return realm.heap().allocate<CanvasPattern>(realm, realm, *pattern);
 }
 
 void CanvasPattern::initialize(JS::Realm& realm)

--- a/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
+++ b/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
@@ -26,9 +26,9 @@
 
 namespace Web::HTML {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<CanvasRenderingContext2D>> CanvasRenderingContext2D::create(JS::Realm& realm, HTMLCanvasElement& element)
+JS::NonnullGCPtr<CanvasRenderingContext2D> CanvasRenderingContext2D::create(JS::Realm& realm, HTMLCanvasElement& element)
 {
-    return MUST_OR_THROW_OOM(realm.heap().allocate<CanvasRenderingContext2D>(realm, realm, element));
+    return realm.heap().allocate<CanvasRenderingContext2D>(realm, realm, element);
 }
 
 CanvasRenderingContext2D::CanvasRenderingContext2D(JS::Realm& realm, HTMLCanvasElement& element)
@@ -394,7 +394,7 @@ JS::NonnullGCPtr<TextMetrics> CanvasRenderingContext2D::measure_text(DeprecatedS
     // TextMetrics object with members behaving as described in the following
     // list:
     auto prepared_text = prepare_text(text);
-    auto metrics = TextMetrics::create(realm()).release_value_but_fixme_should_propagate_errors();
+    auto metrics = TextMetrics::create(realm());
     // FIXME: Use the font that was used to create the glyphs in prepared_text.
     auto font = current_font();
 

--- a/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.h
+++ b/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.h
@@ -60,7 +60,7 @@ class CanvasRenderingContext2D
     WEB_PLATFORM_OBJECT(CanvasRenderingContext2D, Bindings::PlatformObject);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<CanvasRenderingContext2D>> create(JS::Realm&, HTMLCanvasElement&);
+    [[nodiscard]] static JS::NonnullGCPtr<CanvasRenderingContext2D> create(JS::Realm&, HTMLCanvasElement&);
     virtual ~CanvasRenderingContext2D() override;
 
     virtual void fill_rect(float x, float y, float width, float height) override;

--- a/Userland/Libraries/LibWeb/HTML/CloseEvent.cpp
+++ b/Userland/Libraries/LibWeb/HTML/CloseEvent.cpp
@@ -9,9 +9,9 @@
 
 namespace Web::HTML {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<CloseEvent>> CloseEvent::create(JS::Realm& realm, FlyString const& event_name, CloseEventInit const& event_init)
+JS::NonnullGCPtr<CloseEvent> CloseEvent::create(JS::Realm& realm, FlyString const& event_name, CloseEventInit const& event_init)
 {
-    return MUST_OR_THROW_OOM(realm.heap().allocate<CloseEvent>(realm, realm, event_name, event_init));
+    return realm.heap().allocate<CloseEvent>(realm, realm, event_name, event_init);
 }
 
 WebIDL::ExceptionOr<JS::NonnullGCPtr<CloseEvent>> CloseEvent::construct_impl(JS::Realm& realm, FlyString const& event_name, CloseEventInit const& event_init)

--- a/Userland/Libraries/LibWeb/HTML/CloseEvent.h
+++ b/Userland/Libraries/LibWeb/HTML/CloseEvent.h
@@ -22,7 +22,7 @@ class CloseEvent : public DOM::Event {
     WEB_PLATFORM_OBJECT(CloseEvent, DOM::Event);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<CloseEvent>> create(JS::Realm&, FlyString const& event_name, CloseEventInit const& event_init = {});
+    [[nodiscard]] static JS::NonnullGCPtr<CloseEvent> create(JS::Realm&, FlyString const& event_name, CloseEventInit const& event_init = {});
     static WebIDL::ExceptionOr<JS::NonnullGCPtr<CloseEvent>> construct_impl(JS::Realm&, FlyString const& event_name, CloseEventInit const& event_init);
 
     virtual ~CloseEvent() override;

--- a/Userland/Libraries/LibWeb/HTML/CustomElements/CustomElementDefinition.h
+++ b/Userland/Libraries/LibWeb/HTML/CustomElements/CustomElementDefinition.h
@@ -24,7 +24,7 @@ class CustomElementDefinition : public JS::Cell {
 
     static JS::NonnullGCPtr<CustomElementDefinition> create(JS::Realm& realm, String const& name, String const& local_name, WebIDL::CallbackType& constructor, Vector<String>&& observed_attributes, LifecycleCallbacksStorage&& lifecycle_callbacks, bool form_associated, bool disable_internals, bool disable_shadow)
     {
-        return realm.heap().allocate<CustomElementDefinition>(realm, name, local_name, constructor, move(observed_attributes), move(lifecycle_callbacks), form_associated, disable_internals, disable_shadow).release_allocated_value_but_fixme_should_propagate_errors();
+        return realm.heap().allocate<CustomElementDefinition>(realm, name, local_name, constructor, move(observed_attributes), move(lifecycle_callbacks), form_associated, disable_internals, disable_shadow);
     }
 
     ~CustomElementDefinition() = default;

--- a/Userland/Libraries/LibWeb/HTML/DOMParser.cpp
+++ b/Userland/Libraries/LibWeb/HTML/DOMParser.cpp
@@ -16,7 +16,7 @@ namespace Web::HTML {
 
 WebIDL::ExceptionOr<JS::NonnullGCPtr<DOMParser>> DOMParser::construct_impl(JS::Realm& realm)
 {
-    return MUST_OR_THROW_OOM(realm.heap().allocate<DOMParser>(realm, realm));
+    return realm.heap().allocate<DOMParser>(realm, realm);
 }
 
 DOMParser::DOMParser(JS::Realm& realm)
@@ -42,7 +42,7 @@ JS::NonnullGCPtr<DOM::Document> DOMParser::parse_from_string(DeprecatedString co
     if (type == Bindings::DOMParserSupportedType::Text_Html) {
         // -> "text/html"
         // 1. Set document's type to "html".
-        document = HTML::HTMLDocument::create(realm(), verify_cast<HTML::Window>(relevant_global_object(*this)).associated_document().url()).release_value_but_fixme_should_propagate_errors();
+        document = HTML::HTMLDocument::create(realm(), verify_cast<HTML::Window>(relevant_global_object(*this)).associated_document().url());
         document->set_content_type(Bindings::idl_enum_to_deprecated_string(type));
         document->set_document_type(DOM::Document::Type::HTML);
 
@@ -56,7 +56,7 @@ JS::NonnullGCPtr<DOM::Document> DOMParser::parse_from_string(DeprecatedString co
         parser->run("about:blank"sv);
     } else {
         // -> Otherwise
-        document = DOM::Document::create(realm(), verify_cast<HTML::Window>(relevant_global_object(*this)).associated_document().url()).release_value_but_fixme_should_propagate_errors();
+        document = DOM::Document::create(realm(), verify_cast<HTML::Window>(relevant_global_object(*this)).associated_document().url());
         document->set_content_type(Bindings::idl_enum_to_deprecated_string(type));
 
         // 1. Create an XML parser parse, associated with document, and with XML scripting support disabled.

--- a/Userland/Libraries/LibWeb/HTML/DOMStringMap.cpp
+++ b/Userland/Libraries/LibWeb/HTML/DOMStringMap.cpp
@@ -12,10 +12,10 @@
 
 namespace Web::HTML {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<DOMStringMap>> DOMStringMap::create(DOM::Element& element)
+JS::NonnullGCPtr<DOMStringMap> DOMStringMap::create(DOM::Element& element)
 {
     auto& realm = element.realm();
-    return MUST_OR_THROW_OOM(realm.heap().allocate<DOMStringMap>(realm, element));
+    return realm.heap().allocate<DOMStringMap>(realm, element);
 }
 
 DOMStringMap::DOMStringMap(DOM::Element& element)

--- a/Userland/Libraries/LibWeb/HTML/DOMStringMap.h
+++ b/Userland/Libraries/LibWeb/HTML/DOMStringMap.h
@@ -17,7 +17,7 @@ class DOMStringMap final : public Bindings::LegacyPlatformObject {
     WEB_PLATFORM_OBJECT(DOMStringMap, Bindings::LegacyPlatformObject);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<DOMStringMap>> create(DOM::Element&);
+    [[nodiscard]] static JS::NonnullGCPtr<DOMStringMap> create(DOM::Element&);
 
     virtual ~DOMStringMap() override;
 

--- a/Userland/Libraries/LibWeb/HTML/ErrorEvent.cpp
+++ b/Userland/Libraries/LibWeb/HTML/ErrorEvent.cpp
@@ -9,9 +9,9 @@
 
 namespace Web::HTML {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<ErrorEvent>> ErrorEvent::create(JS::Realm& realm, FlyString const& event_name, ErrorEventInit const& event_init)
+JS::NonnullGCPtr<ErrorEvent> ErrorEvent::create(JS::Realm& realm, FlyString const& event_name, ErrorEventInit const& event_init)
 {
-    return MUST_OR_THROW_OOM(realm.heap().allocate<ErrorEvent>(realm, realm, event_name, event_init));
+    return realm.heap().allocate<ErrorEvent>(realm, realm, event_name, event_init);
 }
 
 WebIDL::ExceptionOr<JS::NonnullGCPtr<ErrorEvent>> ErrorEvent::construct_impl(JS::Realm& realm, FlyString const& event_name, ErrorEventInit const& event_init)

--- a/Userland/Libraries/LibWeb/HTML/ErrorEvent.h
+++ b/Userland/Libraries/LibWeb/HTML/ErrorEvent.h
@@ -25,7 +25,7 @@ class ErrorEvent final : public DOM::Event {
     WEB_PLATFORM_OBJECT(ErrorEvent, DOM::Event);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<ErrorEvent>> create(JS::Realm&, FlyString const& event_name, ErrorEventInit const& event_init = {});
+    [[nodiscard]] static JS::NonnullGCPtr<ErrorEvent> create(JS::Realm&, FlyString const& event_name, ErrorEventInit const& = {});
     static WebIDL::ExceptionOr<JS::NonnullGCPtr<ErrorEvent>> construct_impl(JS::Realm&, FlyString const& event_name, ErrorEventInit const& event_init);
 
     virtual ~ErrorEvent() override;

--- a/Userland/Libraries/LibWeb/HTML/Focus.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Focus.cpp
@@ -65,7 +65,7 @@ static void run_focus_update_steps(Vector<JS::Handle<DOM::Node>> old_chain, Vect
         //    with related blur target as the related target.
         if (blur_event_target) {
             // FIXME: Implement the "fire a focus event" spec operation.
-            auto blur_event = UIEvents::FocusEvent::create(blur_event_target->realm(), HTML::EventNames::blur).release_value_but_fixme_should_propagate_errors();
+            auto blur_event = UIEvents::FocusEvent::create(blur_event_target->realm(), HTML::EventNames::blur);
             blur_event->set_related_target(related_blur_target);
             blur_event_target->dispatch_event(blur_event);
         }
@@ -108,7 +108,7 @@ static void run_focus_update_steps(Vector<JS::Handle<DOM::Node>> old_chain, Vect
         //    with related focus target as the related target.
         if (focus_event_target) {
             // FIXME: Implement the "fire a focus event" spec operation.
-            auto focus_event = UIEvents::FocusEvent::create(focus_event_target->realm(), HTML::EventNames::focus).release_value_but_fixme_should_propagate_errors();
+            auto focus_event = UIEvents::FocusEvent::create(focus_event_target->realm(), HTML::EventNames::focus);
             focus_event->set_related_target(related_focus_target);
             focus_event_target->dispatch_event(focus_event);
         }

--- a/Userland/Libraries/LibWeb/HTML/FormDataEvent.cpp
+++ b/Userland/Libraries/LibWeb/HTML/FormDataEvent.cpp
@@ -12,7 +12,7 @@ namespace Web::HTML {
 
 WebIDL::ExceptionOr<JS::NonnullGCPtr<FormDataEvent>> FormDataEvent::construct_impl(JS::Realm& realm, FlyString const& event_name, FormDataEventInit const& event_init)
 {
-    return MUST_OR_THROW_OOM(realm.heap().allocate<FormDataEvent>(realm, realm, event_name, event_init));
+    return realm.heap().allocate<FormDataEvent>(realm, realm, event_name, event_init);
 }
 
 FormDataEvent::FormDataEvent(JS::Realm& realm, FlyString const& event_name, FormDataEventInit const& event_init)

--- a/Userland/Libraries/LibWeb/HTML/HTMLCanvasElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLCanvasElement.cpp
@@ -101,7 +101,7 @@ HTMLCanvasElement::HasOrCreatedContext HTMLCanvasElement::create_2d_context()
     if (!m_context.has<Empty>())
         return m_context.has<JS::NonnullGCPtr<CanvasRenderingContext2D>>() ? HasOrCreatedContext::Yes : HasOrCreatedContext::No;
 
-    m_context = CanvasRenderingContext2D::create(realm(), *this).release_value_but_fixme_should_propagate_errors();
+    m_context = CanvasRenderingContext2D::create(realm(), *this);
     return HasOrCreatedContext::Yes;
 }
 
@@ -266,7 +266,7 @@ WebIDL::ExceptionOr<void> HTMLCanvasElement::to_blob(JS::NonnullGCPtr<WebIDL::Ca
                 // 1. If result is non-null, then set result to a new Blob object, created in the relevant realm of this canvas element, representing result. [FILEAPI]
                 JS::GCPtr<FileAPI::Blob> blob_result;
                 if (file_result.has_value())
-                    blob_result = TRY(FileAPI::Blob::create(realm(), file_result->buffer, TRY_OR_THROW_OOM(vm(), String::from_utf8(file_result->mime_type))));
+                    blob_result = FileAPI::Blob::create(realm(), file_result->buffer, TRY_OR_THROW_OOM(vm(), String::from_utf8(file_result->mime_type)));
 
                 // 2. Invoke callback with « result ».
                 TRY(WebIDL::invoke_callback(*callback, {}, move(blob_result)));

--- a/Userland/Libraries/LibWeb/HTML/HTMLDetailsElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLDetailsElement.cpp
@@ -48,7 +48,7 @@ void HTMLDetailsElement::run_details_notification_task_steps()
         // 1. FIXME: If another task has been queued to run the details notification task steps for this details element, then return.
 
         // 2. Fire an event named toggle at the details element.
-        dispatch_event(Web::DOM::Event::create(realm(), HTML::EventNames::toggle).release_value_but_fixme_should_propagate_errors());
+        dispatch_event(Web::DOM::Event::create(realm(), HTML::EventNames::toggle));
     });
 }
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLDocument.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLDocument.cpp
@@ -20,9 +20,9 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<HTMLDocument>> HTMLDocument::construct_impl
     return HTMLDocument::create(realm);
 }
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<HTMLDocument>> HTMLDocument::create(JS::Realm& realm, AK::URL const& url)
+JS::NonnullGCPtr<HTMLDocument> HTMLDocument::create(JS::Realm& realm, AK::URL const& url)
 {
-    return MUST_OR_THROW_OOM(realm.heap().allocate<HTMLDocument>(realm, realm, url));
+    return realm.heap().allocate<HTMLDocument>(realm, realm, url);
 }
 
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLDocument.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLDocument.h
@@ -20,7 +20,7 @@ class HTMLDocument final : public DOM::Document {
 public:
     virtual ~HTMLDocument() override;
 
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<HTMLDocument>> create(JS::Realm&, AK::URL const& url = "about:blank"sv);
+    [[nodiscard]] static JS::NonnullGCPtr<HTMLDocument> create(JS::Realm&, AK::URL const& url = "about:blank"sv);
     WebIDL::ExceptionOr<JS::NonnullGCPtr<HTMLDocument>> construct_impl(JS::Realm&);
 
 private:

--- a/Userland/Libraries/LibWeb/HTML/HTMLElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLElement.cpp
@@ -48,7 +48,7 @@ void HTMLElement::initialize(JS::Realm& realm)
     Base::initialize(realm);
     set_prototype(&Bindings::ensure_web_prototype<Bindings::HTMLElementPrototype>(realm, "HTMLElement"));
 
-    m_dataset = MUST(DOMStringMap::create(*this));
+    m_dataset = DOMStringMap::create(*this);
 }
 
 void HTMLElement::visit_edges(Cell::Visitor& visitor)
@@ -283,7 +283,7 @@ bool HTMLElement::fire_a_synthetic_pointer_event(FlyString const& type, DOM::Ele
     // 1. Let event be the result of creating an event using PointerEvent.
     // 2. Initialize event's type attribute to e.
     // FIXME: Actually create a PointerEvent!
-    auto event = UIEvents::MouseEvent::create(realm(), type).release_value_but_fixme_should_propagate_errors();
+    auto event = UIEvents::MouseEvent::create(realm(), type);
 
     // 3. Initialize event's bubbles and cancelable attributes to true.
     event->set_bubbles(true);

--- a/Userland/Libraries/LibWeb/HTML/HTMLFormElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFormElement.cpp
@@ -101,7 +101,7 @@ WebIDL::ExceptionOr<void> HTMLFormElement::submit_form(JS::NonnullGCPtr<HTMLElem
         //    cancelable attribute initialized to true.
         SubmitEventInit event_init {};
         event_init.submitter = submitter_button;
-        auto submit_event = SubmitEvent::create(realm, EventNames::submit, event_init).release_value_but_fixme_should_propagate_errors();
+        auto submit_event = SubmitEvent::create(realm, EventNames::submit, event_init);
         submit_event->set_bubbles(true);
         submit_event->set_cancelable(true);
         bool should_continue = dispatch_event(*submit_event);
@@ -258,7 +258,7 @@ WebIDL::ExceptionOr<void> HTMLFormElement::submit_form(JS::NonnullGCPtr<HTMLElem
 void HTMLFormElement::reset_form()
 {
     // 1. Let reset be the result of firing an event named reset at form, with the bubbles and cancelable attributes initialized to true.
-    auto reset_event = DOM::Event::create(realm(), HTML::EventNames::reset).release_value_but_fixme_should_propagate_errors();
+    auto reset_event = DOM::Event::create(realm(), HTML::EventNames::reset);
     reset_event->set_bubbles(true);
     reset_event->set_cancelable(true);
 
@@ -411,7 +411,7 @@ JS::NonnullGCPtr<DOM::HTMLCollection> HTMLFormElement::elements() const
     if (!m_elements) {
         m_elements = DOM::HTMLCollection::create(const_cast<HTMLFormElement&>(*this), DOM::HTMLCollection::Scope::Descendants, [](Element const& element) {
             return is_form_control(element);
-        }).release_value_but_fixme_should_propagate_errors();
+        });
     }
     return *m_elements;
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLIFrameElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLIFrameElement.cpp
@@ -163,7 +163,7 @@ void run_iframe_load_event_steps(HTML::HTMLIFrameElement& element)
     // FIXME: 4. Set childDocument's iframe load in progress flag.
 
     // 5. Fire an event named load at element.
-    element.dispatch_event(DOM::Event::create(element.realm(), HTML::EventNames::load).release_value_but_fixme_should_propagate_errors());
+    element.dispatch_event(DOM::Event::create(element.realm(), HTML::EventNames::load));
 
     // FIXME: 6. Unset childDocument's iframe load in progress flag.
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -391,7 +391,7 @@ ErrorOr<void> HTMLImageElement::update_the_image_data(bool restart_animations, b
 
                 // 3. If maybe omit events is not set or previousURL is not equal to urlString, then fire an event named load at the img element.
                 if (!maybe_omit_events || previous_url != url_string)
-                    dispatch_event(DOM::Event::create(realm(), HTML::EventNames::load).release_value_but_fixme_should_propagate_errors());
+                    dispatch_event(DOM::Event::create(realm(), HTML::EventNames::load));
             });
 
             // 8. Abort the update the image data algorithm.
@@ -434,7 +434,7 @@ after_step_7:
                 if (
                     (has_attribute(HTML::AttributeNames::src) || uses_srcset_or_picture())
                     && (!maybe_omit_events || m_current_request->current_url() != ""sv)) {
-                    dispatch_event(DOM::Event::create(realm(), HTML::EventNames::error).release_value_but_fixme_should_propagate_errors());
+                    dispatch_event(DOM::Event::create(realm(), HTML::EventNames::error));
                 }
             });
 
@@ -463,7 +463,7 @@ after_step_7:
 
                 // 2. If maybe omit events is not set or previousURL is not equal to selected source, then fire an event named error at the img element.
                 if (!maybe_omit_events || previous_url != selected_source.value().url)
-                    dispatch_event(DOM::Event::create(realm(), HTML::EventNames::error).release_value_but_fixme_should_propagate_errors());
+                    dispatch_event(DOM::Event::create(realm(), HTML::EventNames::error));
             });
 
             // 5. Return.
@@ -585,7 +585,7 @@ void HTMLImageElement::add_callbacks_to_image_request(NonnullRefPtr<ImageRequest
 
                 // 4. If maybe omit events is not set or previousURL is not equal to urlString, then fire an event named load at the img element.
                 if (!maybe_omit_events || previous_url != url_string)
-                    dispatch_event(DOM::Event::create(realm(), HTML::EventNames::load).release_value_but_fixme_should_propagate_errors());
+                    dispatch_event(DOM::Event::create(realm(), HTML::EventNames::load));
 
                 set_needs_style_update(true);
                 document().set_needs_layout();
@@ -617,7 +617,7 @@ void HTMLImageElement::add_callbacks_to_image_request(NonnullRefPtr<ImageRequest
             // queue an element task on the DOM manipulation task source given the img element
             // to fire an event named error at the img element.
             if (!maybe_omit_events || previous_url != url_string)
-                dispatch_event(DOM::Event::create(realm(), HTML::EventNames::error).release_value_but_fixme_should_propagate_errors());
+                dispatch_event(DOM::Event::create(realm(), HTML::EventNames::error));
 
             m_load_event_delayer.clear();
         });
@@ -726,7 +726,7 @@ void HTMLImageElement::react_to_changes_in_the_environment()
             document().set_needs_layout();
 
             // 7. Fire an event named load at the img element.
-            dispatch_event(DOM::Event::create(realm(), HTML::EventNames::load).release_value_but_fixme_should_propagate_errors());
+            dispatch_event(DOM::Event::create(realm(), HTML::EventNames::load));
         });
     };
 
@@ -803,7 +803,7 @@ void HTMLImageElement::upgrade_pending_request_to_current_request()
 void HTMLImageElement::handle_failed_fetch()
 {
     // AD-HOC
-    dispatch_event(DOM::Event::create(realm(), HTML::EventNames::error).release_value_but_fixme_should_propagate_errors());
+    dispatch_event(DOM::Event::create(realm(), HTML::EventNames::error));
 }
 
 // https://html.spec.whatwg.org/multipage/rendering.html#restart-the-animation

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -135,7 +135,7 @@ JS::GCPtr<FileAPI::FileList> HTMLInputElement::files()
         return nullptr;
 
     if (!m_selected_files)
-        m_selected_files = FileAPI::FileList::create(realm(), {}).release_value_but_fixme_should_propagate_errors();
+        m_selected_files = FileAPI::FileList::create(realm(), {});
     return m_selected_files;
 }
 
@@ -159,11 +159,11 @@ void HTMLInputElement::update_the_file_selection(JS::NonnullGCPtr<FileAPI::FileL
         this->set_files(files.ptr());
 
         // 2. Fire an event named input at the input element, with the bubbles and composed attributes initialized to true.
-        auto input_event = DOM::Event::create(this->realm(), EventNames::input, { .bubbles = true, .composed = true }).release_value_but_fixme_should_propagate_errors();
+        auto input_event = DOM::Event::create(this->realm(), EventNames::input, { .bubbles = true, .composed = true });
         this->dispatch_event(input_event);
 
         // 3. Fire an event named change at the input element, with the bubbles attribute initialized to true.
-        auto change_event = DOM::Event::create(this->realm(), EventNames::change, { .bubbles = true }).release_value_but_fixme_should_propagate_errors();
+        auto change_event = DOM::Event::create(this->realm(), EventNames::change, { .bubbles = true });
         this->dispatch_event(change_event);
     });
 }
@@ -250,13 +250,13 @@ WebIDL::ExceptionOr<void> HTMLInputElement::run_input_activation_behavior()
             return {};
 
         // 2. Fire an event named input at the element with the bubbles and composed attributes initialized to true.
-        auto input_event = DOM::Event::create(realm(), HTML::EventNames::input).release_value_but_fixme_should_propagate_errors();
+        auto input_event = DOM::Event::create(realm(), HTML::EventNames::input);
         input_event->set_bubbles(true);
         input_event->set_composed(true);
         dispatch_event(input_event);
 
         // 3. Fire an event named change at the element with the bubbles attribute initialized to true.
-        auto change_event = DOM::Event::create(realm(), HTML::EventNames::change).release_value_but_fixme_should_propagate_errors();
+        auto change_event = DOM::Event::create(realm(), HTML::EventNames::change);
         change_event->set_bubbles(true);
         dispatch_event(*change_event);
     } else if (type_state() == TypeAttributeState::SubmitButton) {
@@ -274,7 +274,7 @@ WebIDL::ExceptionOr<void> HTMLInputElement::run_input_activation_behavior()
     } else if (type_state() == TypeAttributeState::FileUpload) {
         show_the_picker_if_applicable(*this);
     } else {
-        dispatch_event(DOM::Event::create(realm(), EventNames::change).release_value_but_fixme_should_propagate_errors());
+        dispatch_event(DOM::Event::create(realm(), EventNames::change));
     }
 
     return {};
@@ -291,7 +291,7 @@ void HTMLInputElement::did_edit_text_node(Badge<BrowsingContext>)
     // NOTE: This is a bit ad-hoc, but basically implements part of "4.10.5.5 Common event behaviors"
     //       https://html.spec.whatwg.org/multipage/input.html#common-input-element-events
     queue_an_element_task(HTML::Task::Source::UserInteraction, [this] {
-        auto input_event = DOM::Event::create(realm(), HTML::EventNames::input).release_value_but_fixme_should_propagate_errors();
+        auto input_event = DOM::Event::create(realm(), HTML::EventNames::input);
         input_event->set_bubbles(true);
         input_event->set_composed(true);
         dispatch_event(*input_event);
@@ -431,7 +431,7 @@ void HTMLInputElement::create_shadow_tree_if_needed()
         break;
     }
 
-    auto shadow_root = heap().allocate<DOM::ShadowRoot>(realm(), document(), *this, Bindings::ShadowRootMode::Closed).release_allocated_value_but_fixme_should_propagate_errors();
+    auto shadow_root = heap().allocate<DOM::ShadowRoot>(realm(), document(), *this, Bindings::ShadowRootMode::Closed);
     auto initial_value = m_value;
     if (initial_value.is_null())
         initial_value = DeprecatedString::empty();
@@ -445,10 +445,10 @@ void HTMLInputElement::create_shadow_tree_if_needed()
         padding: 1px 2px;
 )~~~"));
 
-    m_placeholder_element = heap().allocate<PlaceholderElement>(realm(), document()).release_allocated_value_but_fixme_should_propagate_errors();
+    m_placeholder_element = heap().allocate<PlaceholderElement>(realm(), document());
     MUST(m_placeholder_element->style_for_bindings()->set_property(CSS::PropertyID::Height, "1lh"sv));
 
-    m_placeholder_text_node = heap().allocate<DOM::Text>(realm(), document(), initial_value).release_allocated_value_but_fixme_should_propagate_errors();
+    m_placeholder_text_node = heap().allocate<DOM::Text>(realm(), document(), initial_value);
     m_placeholder_text_node->set_data(attribute(HTML::AttributeNames::placeholder));
     m_placeholder_text_node->set_owner_input_element({}, *this);
     MUST(m_placeholder_element->append_child(*m_placeholder_text_node));
@@ -457,7 +457,7 @@ void HTMLInputElement::create_shadow_tree_if_needed()
     m_inner_text_element = DOM::create_element(document(), HTML::TagNames::div, Namespace::HTML).release_value_but_fixme_should_propagate_errors();
     MUST(m_inner_text_element->style_for_bindings()->set_property(CSS::PropertyID::Height, "1lh"sv));
 
-    m_text_node = heap().allocate<DOM::Text>(realm(), document(), initial_value).release_allocated_value_but_fixme_should_propagate_errors();
+    m_text_node = heap().allocate<DOM::Text>(realm(), document(), initial_value);
     m_text_node->set_always_editable(m_type != TypeAttributeState::FileUpload);
     m_text_node->set_owner_input_element({}, *this);
 
@@ -485,7 +485,7 @@ void HTMLInputElement::did_lose_focus()
     // The change event fires when the value is committed, if that makes sense for the control,
     // or else when the control loses focus
     queue_an_element_task(HTML::Task::Source::UserInteraction, [this] {
-        auto change_event = DOM::Event::create(realm(), HTML::EventNames::change).release_value_but_fixme_should_propagate_errors();
+        auto change_event = DOM::Event::create(realm(), HTML::EventNames::change);
         change_event->set_bubbles(true);
         dispatch_event(change_event);
     });
@@ -842,7 +842,7 @@ void HTMLInputElement::reset_algorithm()
     m_checked = has_attribute(AttributeNames::checked);
 
     // empty the list of selected files,
-    m_selected_files = FileAPI::FileList::create(realm(), {}).release_value_but_fixme_should_propagate_errors();
+    m_selected_files = FileAPI::FileList::create(realm(), {});
 
     // and then invoke the value sanitization algorithm, if the type attribute's current state defines one.
     m_value = value_sanitization_algorithm(m_value);

--- a/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
@@ -133,7 +133,7 @@ void HTMLLinkElement::resource_did_fail()
 {
     dbgln_if(CSS_LOADER_DEBUG, "HTMLLinkElement: Resource did fail. URL: {}", resource()->url());
     if (m_relationship & Relationship::Preload) {
-        dispatch_event(*DOM::Event::create(realm(), HTML::EventNames::error).release_value_but_fixme_should_propagate_errors());
+        dispatch_event(*DOM::Event::create(realm(), HTML::EventNames::error));
     }
 }
 
@@ -145,7 +145,7 @@ void HTMLLinkElement::resource_did_load()
         m_document_load_event_delayer.clear();
     }
     if (m_relationship & Relationship::Preload) {
-        dispatch_event(*DOM::Event::create(realm(), HTML::EventNames::load).release_value_but_fixme_should_propagate_errors());
+        dispatch_event(*DOM::Event::create(realm(), HTML::EventNames::load));
     }
 }
 
@@ -353,13 +353,13 @@ void HTMLLinkElement::process_stylesheet_resource(bool success, Fetch::Infrastru
         if (!decoder.has_value()) {
             // If we don't support the encoding yet, let's error out instead of trying to decode it as something it's most likely not.
             dbgln("FIXME: Style sheet encoding '{}' is not supported yet", encoding);
-            dispatch_event(*DOM::Event::create(realm(), HTML::EventNames::error).release_value_but_fixme_should_propagate_errors());
+            dispatch_event(*DOM::Event::create(realm(), HTML::EventNames::error));
         } else {
             auto const& encoded_string = body_bytes.get<ByteBuffer>();
             auto maybe_decoded_string = TextCodec::convert_input_to_utf8_using_given_decoder_unless_there_is_a_byte_order_mark(*decoder, encoded_string);
             if (maybe_decoded_string.is_error()) {
                 dbgln("Style sheet {} claimed to be '{}' but decoding failed", response.url().value_or(AK::URL()), encoding);
-                dispatch_event(*DOM::Event::create(realm(), HTML::EventNames::error).release_value_but_fixme_should_propagate_errors());
+                dispatch_event(*DOM::Event::create(realm(), HTML::EventNames::error));
             } else {
                 auto const decoded_string = maybe_decoded_string.release_value();
                 m_loaded_style_sheet = parse_css_stylesheet(CSS::Parser::ParsingContext(document(), *response.url()), decoded_string);
@@ -373,13 +373,13 @@ void HTMLLinkElement::process_stylesheet_resource(bool success, Fetch::Infrastru
                 }
 
                 // 2. Fire an event named load at el.
-                dispatch_event(*DOM::Event::create(realm(), HTML::EventNames::load).release_value_but_fixme_should_propagate_errors());
+                dispatch_event(*DOM::Event::create(realm(), HTML::EventNames::load));
             }
         }
     }
     // 5. Otherwise, fire an event named error at el.
     else {
-        dispatch_event(*DOM::Event::create(realm(), HTML::EventNames::error).release_value_but_fixme_should_propagate_errors());
+        dispatch_event(*DOM::Event::create(realm(), HTML::EventNames::error));
     }
 
     // FIXME: 6. If el contributes a script-blocking style sheet, then:

--- a/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.h
@@ -56,7 +56,7 @@ public:
     };
     NetworkState network_state() const { return m_network_state; }
 
-    WebIDL::ExceptionOr<JS::NonnullGCPtr<TimeRanges>> buffered() const;
+    [[nodiscard]] JS::NonnullGCPtr<TimeRanges> buffered() const;
 
     WebIDL::ExceptionOr<Bindings::CanPlayTypeResult> can_play_type(DeprecatedString const& type) const;
 
@@ -177,9 +177,9 @@ private:
 
     bool is_eligible_for_autoplay() const;
     bool has_ended_playback() const;
-    WebIDL::ExceptionOr<void> reached_end_of_media_playback();
+    void reached_end_of_media_playback();
 
-    WebIDL::ExceptionOr<void> dispatch_time_update_event();
+    void dispatch_time_update_event();
 
     enum class TimeMarchesOnReason {
         NormalPlayback,

--- a/Userland/Libraries/LibWeb/HTML/HTMLObjectElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLObjectElement.cpp
@@ -125,7 +125,7 @@ void HTMLObjectElement::queue_element_task_to_run_object_representation_steps()
 
             // 3. If that failed, fire an event named error at the element, then jump to the step below labeled fallback.
             if (!url.is_valid()) {
-                dispatch_event(DOM::Event::create(realm(), HTML::EventNames::error).release_value_but_fixme_should_propagate_errors());
+                dispatch_event(DOM::Event::create(realm(), HTML::EventNames::error));
                 return run_object_representation_fallback_steps();
             }
 
@@ -152,7 +152,7 @@ void HTMLObjectElement::queue_element_task_to_run_object_representation_steps()
 void HTMLObjectElement::resource_did_fail()
 {
     // 4.7. If the load failed (e.g. there was an HTTP 404 error, there was a DNS error), fire an event named error at the element, then jump to the step below labeled fallback.
-    dispatch_event(DOM::Event::create(realm(), HTML::EventNames::error).release_value_but_fixme_should_propagate_errors());
+    dispatch_event(DOM::Event::create(realm(), HTML::EventNames::error));
     run_object_representation_fallback_steps();
 }
 
@@ -290,7 +290,7 @@ void HTMLObjectElement::run_object_representation_completed_steps(Representation
     // 4.11. If the object element does not represent its nested browsing context, then once the resource is completely loaded, queue an element task on the DOM manipulation task source given the object element to fire an event named load at the element.
     if (representation != Representation::NestedBrowsingContext) {
         queue_an_element_task(HTML::Task::Source::DOMManipulation, [&]() {
-            dispatch_event(DOM::Event::create(realm(), HTML::EventNames::load).release_value_but_fixme_should_propagate_errors());
+            dispatch_event(DOM::Event::create(realm(), HTML::EventNames::load));
         });
     }
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLOptionsCollection.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLOptionsCollection.cpp
@@ -13,9 +13,9 @@
 
 namespace Web::HTML {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<HTMLOptionsCollection>> HTMLOptionsCollection::create(DOM::ParentNode& root, Function<bool(DOM::Element const&)> filter)
+JS::NonnullGCPtr<HTMLOptionsCollection> HTMLOptionsCollection::create(DOM::ParentNode& root, Function<bool(DOM::Element const&)> filter)
 {
-    return MUST_OR_THROW_OOM(root.heap().allocate<HTMLOptionsCollection>(root.realm(), root, move(filter)));
+    return root.heap().allocate<HTMLOptionsCollection>(root.realm(), root, move(filter));
 }
 
 HTMLOptionsCollection::HTMLOptionsCollection(DOM::ParentNode& root, Function<bool(DOM::Element const&)> filter)

--- a/Userland/Libraries/LibWeb/HTML/HTMLOptionsCollection.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLOptionsCollection.h
@@ -19,7 +19,7 @@ class HTMLOptionsCollection final : public DOM::HTMLCollection {
     WEB_PLATFORM_OBJECT(HTMLOptionsCollection, DOM::HTMLCollection);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<HTMLOptionsCollection>> create(DOM::ParentNode& root, Function<bool(DOM::Element const&)> filter);
+    [[nodiscard]] static JS::NonnullGCPtr<HTMLOptionsCollection> create(DOM::ParentNode& root, Function<bool(DOM::Element const&)> filter);
     virtual ~HTMLOptionsCollection() override;
 
     WebIDL::ExceptionOr<void> add(HTMLOptionOrOptGroupElement element, Optional<HTMLElementOrElementIndex> before = {});

--- a/Userland/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
@@ -86,7 +86,7 @@ void HTMLScriptElement::execute_script()
     // 3. If el's result is null, then fire an event named error at el, and return.
     if (m_result.has<ResultState::Null>()) {
         dbgln("HTMLScriptElement: Refusing to run script because the element's result is null.");
-        dispatch_event(DOM::Event::create(realm(), HTML::EventNames::error).release_value_but_fixme_should_propagate_errors());
+        dispatch_event(DOM::Event::create(realm(), HTML::EventNames::error));
         return;
     }
 
@@ -137,7 +137,7 @@ void HTMLScriptElement::execute_script()
 
     // 8. If el's from an external file is true, then fire an event named load at el.
     if (m_from_an_external_file)
-        dispatch_event(DOM::Event::create(realm(), HTML::EventNames::load).release_value_but_fixme_should_propagate_errors());
+        dispatch_event(DOM::Event::create(realm(), HTML::EventNames::load));
 }
 
 // https://html.spec.whatwg.org/multipage/scripting.html#prepare-a-script
@@ -340,7 +340,7 @@ void HTMLScriptElement::prepare_script()
         if (m_script_type == ScriptType::ImportMap) {
             // then queue an element task on the DOM manipulation task source given el to fire an event named error at el, and return.
             queue_an_element_task(HTML::Task::Source::DOMManipulation, [this] {
-                dispatch_event(DOM::Event::create(realm(), HTML::EventNames::error).release_value_but_fixme_should_propagate_errors());
+                dispatch_event(DOM::Event::create(realm(), HTML::EventNames::error));
             });
             return;
         }
@@ -352,7 +352,7 @@ void HTMLScriptElement::prepare_script()
         if (src.is_empty()) {
             dbgln("HTMLScriptElement: Refusing to run script because the src attribute is empty.");
             queue_an_element_task(HTML::Task::Source::DOMManipulation, [this] {
-                dispatch_event(DOM::Event::create(realm(), HTML::EventNames::error).release_value_but_fixme_should_propagate_errors());
+                dispatch_event(DOM::Event::create(realm(), HTML::EventNames::error));
             });
             return;
         }
@@ -367,7 +367,7 @@ void HTMLScriptElement::prepare_script()
         if (!url.is_valid()) {
             dbgln("HTMLScriptElement: Refusing to run script because the src URL '{}' is invalid.", url);
             queue_an_element_task(HTML::Task::Source::DOMManipulation, [this] {
-                dispatch_event(DOM::Event::create(realm(), HTML::EventNames::error).release_value_but_fixme_should_propagate_errors());
+                dispatch_event(DOM::Event::create(realm(), HTML::EventNames::error));
             });
             return;
         }

--- a/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
@@ -42,7 +42,7 @@ JS::GCPtr<HTMLOptionsCollection> const& HTMLSelectElement::options()
             // the select element, and all the option element children of all the optgroup element children
             // of the select element, in tree order.
             return is<HTMLOptionElement>(element);
-        }).release_value_but_fixme_should_propagate_errors();
+        });
     }
     return m_options;
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLTableElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableElement.cpp
@@ -272,7 +272,7 @@ JS::NonnullGCPtr<DOM::HTMLCollection> HTMLTableElement::t_bodies()
     if (!m_t_bodies) {
         m_t_bodies = DOM::HTMLCollection::create(*this, DOM::HTMLCollection::Scope::Children, [](DOM::Element const& element) {
             return element.local_name() == TagNames::tbody;
-        }).release_value_but_fixme_should_propagate_errors();
+        });
     }
     return *m_t_bodies;
 }
@@ -329,7 +329,7 @@ JS::NonnullGCPtr<DOM::HTMLCollection> HTMLTableElement::rows()
             }
 
             return false;
-        }).release_value_but_fixme_should_propagate_errors();
+        });
     }
     return *m_rows;
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLTableRowElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableRowElement.cpp
@@ -65,7 +65,7 @@ JS::NonnullGCPtr<DOM::HTMLCollection> HTMLTableRowElement::cells() const
     if (!m_cells) {
         m_cells = DOM::HTMLCollection::create(const_cast<HTMLTableRowElement&>(*this), DOM::HTMLCollection::Scope::Children, [](Element const& element) {
             return is<HTMLTableCellElement>(element);
-        }).release_value_but_fixme_should_propagate_errors();
+        });
     }
     return *m_cells;
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLTableSectionElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableSectionElement.cpp
@@ -41,7 +41,7 @@ JS::NonnullGCPtr<DOM::HTMLCollection> HTMLTableSectionElement::rows() const
     if (!m_rows) {
         m_rows = DOM::HTMLCollection::create(const_cast<HTMLTableSectionElement&>(*this), DOM::HTMLCollection::Scope::Children, [](Element const& element) {
             return is<HTMLTableRowElement>(element);
-        }).release_value_but_fixme_should_propagate_errors();
+        });
     }
     return *m_rows;
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLTemplateElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTemplateElement.cpp
@@ -22,7 +22,7 @@ void HTMLTemplateElement::initialize(JS::Realm& realm)
     Base::initialize(realm);
     set_prototype(&Bindings::ensure_web_prototype<Bindings::HTMLTemplateElementPrototype>(realm, "HTMLTemplateElement"));
 
-    m_content = MUST(heap().allocate<DOM::DocumentFragment>(realm, m_document->appropriate_template_contents_owner_document()));
+    m_content = heap().allocate<DOM::DocumentFragment>(realm, m_document->appropriate_template_contents_owner_document());
     m_content->set_host(this);
 }
 

--- a/Userland/Libraries/LibWeb/HTML/History.cpp
+++ b/Userland/Libraries/LibWeb/HTML/History.cpp
@@ -10,9 +10,9 @@
 
 namespace Web::HTML {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<History>> History::create(JS::Realm& realm, DOM::Document& document)
+JS::NonnullGCPtr<History> History::create(JS::Realm& realm, DOM::Document& document)
 {
-    return MUST_OR_THROW_OOM(realm.heap().allocate<History>(realm, realm, document));
+    return realm.heap().allocate<History>(realm, realm, document);
 }
 
 History::History(JS::Realm& realm, DOM::Document& document)

--- a/Userland/Libraries/LibWeb/HTML/History.h
+++ b/Userland/Libraries/LibWeb/HTML/History.h
@@ -16,7 +16,7 @@ class History final : public Bindings::PlatformObject {
     WEB_PLATFORM_OBJECT(History, Bindings::PlatformObject);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<History>> create(JS::Realm&, DOM::Document&);
+    [[nodiscard]] static JS::NonnullGCPtr<History> create(JS::Realm&, DOM::Document&);
 
     virtual ~History() override;
 

--- a/Userland/Libraries/LibWeb/HTML/ImageData.cpp
+++ b/Userland/Libraries/LibWeb/HTML/ImageData.cpp
@@ -28,7 +28,7 @@ JS::GCPtr<ImageData> ImageData::create_with_size(JS::Realm& realm, int width, in
     auto bitmap_or_error = Gfx::Bitmap::create_wrapper(Gfx::BitmapFormat::RGBA8888, Gfx::IntSize(width, height), 1, width * sizeof(u32), data->data().data());
     if (bitmap_or_error.is_error())
         return nullptr;
-    return realm.heap().allocate<ImageData>(realm, realm, bitmap_or_error.release_value(), move(data)).release_allocated_value_but_fixme_should_propagate_errors();
+    return realm.heap().allocate<ImageData>(realm, realm, bitmap_or_error.release_value(), move(data));
 }
 
 ImageData::ImageData(JS::Realm& realm, NonnullRefPtr<Gfx::Bitmap> bitmap, JS::NonnullGCPtr<JS::Uint8ClampedArray> data)

--- a/Userland/Libraries/LibWeb/HTML/MessageChannel.cpp
+++ b/Userland/Libraries/LibWeb/HTML/MessageChannel.cpp
@@ -13,17 +13,17 @@ namespace Web::HTML {
 
 WebIDL::ExceptionOr<JS::NonnullGCPtr<MessageChannel>> MessageChannel::construct_impl(JS::Realm& realm)
 {
-    return MUST_OR_THROW_OOM(realm.heap().allocate<MessageChannel>(realm, realm));
+    return realm.heap().allocate<MessageChannel>(realm, realm);
 }
 
 MessageChannel::MessageChannel(JS::Realm& realm)
     : PlatformObject(realm)
 {
     // 1. Set this's port 1 to a new MessagePort in this's relevant Realm.
-    m_port1 = MessagePort::create(realm).release_value_but_fixme_should_propagate_errors();
+    m_port1 = MessagePort::create(realm);
 
     // 2. Set this's port 2 to a new MessagePort in this's relevant Realm.
-    m_port2 = MessagePort::create(realm).release_value_but_fixme_should_propagate_errors();
+    m_port2 = MessagePort::create(realm);
 
     // 3. Entangle this's port 1 and this's port 2.
     m_port1->entangle_with(*m_port2);

--- a/Userland/Libraries/LibWeb/HTML/MessageEvent.cpp
+++ b/Userland/Libraries/LibWeb/HTML/MessageEvent.cpp
@@ -9,9 +9,9 @@
 
 namespace Web::HTML {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<MessageEvent>> MessageEvent::create(JS::Realm& realm, FlyString const& event_name, MessageEventInit const& event_init)
+JS::NonnullGCPtr<MessageEvent> MessageEvent::create(JS::Realm& realm, FlyString const& event_name, MessageEventInit const& event_init)
 {
-    return MUST_OR_THROW_OOM(realm.heap().allocate<MessageEvent>(realm, realm, event_name, event_init));
+    return realm.heap().allocate<MessageEvent>(realm, realm, event_name, event_init);
 }
 
 WebIDL::ExceptionOr<JS::NonnullGCPtr<MessageEvent>> MessageEvent::construct_impl(JS::Realm& realm, FlyString const& event_name, MessageEventInit const& event_init)

--- a/Userland/Libraries/LibWeb/HTML/MessageEvent.h
+++ b/Userland/Libraries/LibWeb/HTML/MessageEvent.h
@@ -22,8 +22,8 @@ class MessageEvent : public DOM::Event {
     WEB_PLATFORM_OBJECT(MessageEvent, DOM::Event);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<MessageEvent>> create(JS::Realm&, FlyString const& event_name, MessageEventInit const& event_init = {});
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<MessageEvent>> construct_impl(JS::Realm&, FlyString const& event_name, MessageEventInit const& event_init);
+    [[nodiscard]] static JS::NonnullGCPtr<MessageEvent> create(JS::Realm&, FlyString const& event_name, MessageEventInit const& = {});
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<MessageEvent>> construct_impl(JS::Realm&, FlyString const& event_name, MessageEventInit const&);
 
     MessageEvent(JS::Realm&, FlyString const& event_name, MessageEventInit const& event_init);
     virtual ~MessageEvent() override;

--- a/Userland/Libraries/LibWeb/HTML/MessagePort.cpp
+++ b/Userland/Libraries/LibWeb/HTML/MessagePort.cpp
@@ -14,9 +14,9 @@
 
 namespace Web::HTML {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<MessagePort>> MessagePort::create(JS::Realm& realm)
+JS::NonnullGCPtr<MessagePort> MessagePort::create(JS::Realm& realm)
 {
-    return MUST_OR_THROW_OOM(realm.heap().allocate<MessagePort>(realm, realm));
+    return realm.heap().allocate<MessagePort>(realm, realm);
 }
 
 MessagePort::MessagePort(JS::Realm& realm)
@@ -97,7 +97,7 @@ void MessagePort::post_message(JS::Value message)
         MessageEventInit event_init {};
         event_init.data = message;
         event_init.origin = "<origin>"_string;
-        target_port->dispatch_event(MessageEvent::create(target_port->realm(), HTML::EventNames::message, event_init).release_value_but_fixme_should_propagate_errors());
+        target_port->dispatch_event(MessageEvent::create(target_port->realm(), HTML::EventNames::message, event_init));
     }));
 }
 

--- a/Userland/Libraries/LibWeb/HTML/MessagePort.h
+++ b/Userland/Libraries/LibWeb/HTML/MessagePort.h
@@ -27,7 +27,7 @@ class MessagePort final : public DOM::EventTarget {
     WEB_PLATFORM_OBJECT(MessagePort, DOM::EventTarget);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<MessagePort>> create(JS::Realm&);
+    [[nodiscard]] static JS::NonnullGCPtr<MessagePort> create(JS::Realm&);
 
     virtual ~MessagePort() override;
 

--- a/Userland/Libraries/LibWeb/HTML/Navigator.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Navigator.cpp
@@ -15,9 +15,9 @@
 
 namespace Web::HTML {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<Navigator>> Navigator::create(JS::Realm& realm)
+JS::NonnullGCPtr<Navigator> Navigator::create(JS::Realm& realm)
 {
-    return MUST_OR_THROW_OOM(realm.heap().allocate<Navigator>(realm, realm));
+    return realm.heap().allocate<Navigator>(realm, realm);
 }
 
 Navigator::Navigator(JS::Realm& realm)
@@ -59,17 +59,17 @@ void Navigator::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_plugin_array);
 }
 
-JS::ThrowCompletionOr<JS::NonnullGCPtr<MimeTypeArray>> Navigator::mime_types()
+JS::NonnullGCPtr<MimeTypeArray> Navigator::mime_types()
 {
     if (!m_mime_type_array)
-        m_mime_type_array = TRY(heap().allocate<MimeTypeArray>(realm(), realm()));
+        m_mime_type_array = heap().allocate<MimeTypeArray>(realm(), realm());
     return *m_mime_type_array;
 }
 
-JS::ThrowCompletionOr<JS::NonnullGCPtr<PluginArray>> Navigator::plugins()
+JS::NonnullGCPtr<PluginArray> Navigator::plugins()
 {
     if (!m_plugin_array)
-        m_plugin_array = TRY(heap().allocate<PluginArray>(realm(), realm()));
+        m_plugin_array = heap().allocate<PluginArray>(realm(), realm());
     return *m_plugin_array;
 }
 

--- a/Userland/Libraries/LibWeb/HTML/Navigator.h
+++ b/Userland/Libraries/LibWeb/HTML/Navigator.h
@@ -24,7 +24,7 @@ class Navigator : public Bindings::PlatformObject
     WEB_PLATFORM_OBJECT(Navigator, Bindings::PlatformObject);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<Navigator>> create(JS::Realm&);
+    [[nodiscard]] static JS::NonnullGCPtr<Navigator> create(JS::Realm&);
 
     // FIXME: Implement NavigatorContentUtilsMixin
 
@@ -41,8 +41,8 @@ public:
 
     bool webdriver() const;
 
-    JS::ThrowCompletionOr<JS::NonnullGCPtr<MimeTypeArray>> mime_types();
-    JS::ThrowCompletionOr<JS::NonnullGCPtr<PluginArray>> plugins();
+    [[nodiscard]] JS::NonnullGCPtr<MimeTypeArray> mime_types();
+    [[nodiscard]] JS::NonnullGCPtr<PluginArray> plugins();
 
     virtual ~Navigator() override;
 

--- a/Userland/Libraries/LibWeb/HTML/PageTransitionEvent.cpp
+++ b/Userland/Libraries/LibWeb/HTML/PageTransitionEvent.cpp
@@ -9,9 +9,9 @@
 
 namespace Web::HTML {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<PageTransitionEvent>> PageTransitionEvent::create(JS::Realm& realm, FlyString const& event_name, PageTransitionEventInit const& event_init)
+JS::NonnullGCPtr<PageTransitionEvent> PageTransitionEvent::create(JS::Realm& realm, FlyString const& event_name, PageTransitionEventInit const& event_init)
 {
-    return MUST_OR_THROW_OOM(realm.heap().allocate<PageTransitionEvent>(realm, realm, event_name, event_init));
+    return realm.heap().allocate<PageTransitionEvent>(realm, realm, event_name, event_init);
 }
 
 WebIDL::ExceptionOr<JS::NonnullGCPtr<PageTransitionEvent>> PageTransitionEvent::construct_impl(JS::Realm& realm, FlyString const& event_name, PageTransitionEventInit const& event_init)

--- a/Userland/Libraries/LibWeb/HTML/PageTransitionEvent.h
+++ b/Userland/Libraries/LibWeb/HTML/PageTransitionEvent.h
@@ -19,8 +19,8 @@ class PageTransitionEvent final : public DOM::Event {
     WEB_PLATFORM_OBJECT(PageTransitionEvent, DOM::Event);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<PageTransitionEvent>> create(JS::Realm&, FlyString const& event_name, PageTransitionEventInit const& event_init);
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<PageTransitionEvent>> construct_impl(JS::Realm&, FlyString const& event_name, PageTransitionEventInit const& event_init);
+    [[nodiscard]] static JS::NonnullGCPtr<PageTransitionEvent> create(JS::Realm&, FlyString const& event_name, PageTransitionEventInit const&);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<PageTransitionEvent>> construct_impl(JS::Realm&, FlyString const& event_name, PageTransitionEventInit const&);
 
     PageTransitionEvent(JS::Realm&, FlyString const& event_name, PageTransitionEventInit const& event_init);
 

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLEncodingDetection.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLEncodingDetection.cpp
@@ -109,7 +109,7 @@ JS::GCPtr<DOM::Attr> prescan_get_attribute(DOM::Document& document, ByteBuffer c
         } else if (input[position] == '\t' || input[position] == '\n' || input[position] == '\f' || input[position] == '\r' || input[position] == ' ')
             goto spaces;
         else if (input[position] == '/' || input[position] == '>')
-            return *DOM::Attr::create(document, attribute_name.to_deprecated_string(), "").release_value_but_fixme_should_propagate_errors();
+            return *DOM::Attr::create(document, attribute_name.to_deprecated_string(), "");
         else
             attribute_name.append_as_lowercase(input[position]);
         ++position;
@@ -121,7 +121,7 @@ spaces:
     if (!prescan_skip_whitespace_and_slashes(input, position))
         return {};
     if (input[position] != '=')
-        return DOM::Attr::create(document, attribute_name.to_deprecated_string(), "").release_value_but_fixme_should_propagate_errors();
+        return DOM::Attr::create(document, attribute_name.to_deprecated_string(), "");
     ++position;
 
 value:
@@ -134,13 +134,13 @@ value:
         ++position;
         for (; !prescan_should_abort(input, position); ++position) {
             if (input[position] == quote_character)
-                return DOM::Attr::create(document, attribute_name.to_deprecated_string(), attribute_value.to_deprecated_string()).release_value_but_fixme_should_propagate_errors();
+                return DOM::Attr::create(document, attribute_name.to_deprecated_string(), attribute_value.to_deprecated_string());
             else
                 attribute_value.append_as_lowercase(input[position]);
         }
         return {};
     } else if (input[position] == '>')
-        return DOM::Attr::create(document, attribute_name.to_deprecated_string(), "").release_value_but_fixme_should_propagate_errors();
+        return DOM::Attr::create(document, attribute_name.to_deprecated_string(), "");
     else
         attribute_value.append_as_lowercase(input[position]);
 
@@ -150,7 +150,7 @@ value:
 
     for (; !prescan_should_abort(input, position); ++position) {
         if (input[position] == '\t' || input[position] == '\n' || input[position] == '\f' || input[position] == '\r' || input[position] == ' ' || input[position] == '>')
-            return DOM::Attr::create(document, attribute_name.to_deprecated_string(), attribute_value.to_deprecated_string()).release_value_but_fixme_should_propagate_errors();
+            return DOM::Attr::create(document, attribute_name.to_deprecated_string(), attribute_value.to_deprecated_string());
         else
             attribute_value.append_as_lowercase(input[position]);
     }

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
@@ -281,7 +281,7 @@ void HTMLParser::the_end()
         document->load_timing_info().dom_content_loaded_event_start_time = HighResolutionTime::unsafe_shared_current_time();
 
         // 2. Fire an event named DOMContentLoaded at the Document object, with its bubbles attribute initialized to true.
-        auto content_loaded_event = DOM::Event::create(document->realm(), HTML::EventNames::DOMContentLoaded).release_value_but_fixme_should_propagate_errors();
+        auto content_loaded_event = DOM::Event::create(document->realm(), HTML::EventNames::DOMContentLoaded);
         content_loaded_event->set_bubbles(true);
         document->dispatch_event(content_loaded_event);
 
@@ -322,7 +322,7 @@ void HTMLParser::the_end()
         // 5. Fire an event named load at window, with legacy target override flag set.
         // FIXME: The legacy target override flag is currently set by a virtual override of dispatch_event()
         //        We should reorganize this so that the flag appears explicitly here instead.
-        window->dispatch_event(DOM::Event::create(document->realm(), HTML::EventNames::load).release_value_but_fixme_should_propagate_errors());
+        window->dispatch_event(DOM::Event::create(document->realm(), HTML::EventNames::load));
 
         // FIXME: 6. Invoke WebDriver BiDi load complete with the Document's browsing context, and a new WebDriver BiDi navigation status whose id is the Document object's navigation id, status is "complete", and url is the Document object's URL.
 
@@ -490,13 +490,13 @@ void HTMLParser::handle_initial(HTMLToken& token)
     }
 
     if (token.is_comment()) {
-        auto comment = realm().heap().allocate<DOM::Comment>(realm(), document(), token.comment()).release_allocated_value_but_fixme_should_propagate_errors();
+        auto comment = realm().heap().allocate<DOM::Comment>(realm(), document(), token.comment());
         MUST(document().append_child(*comment));
         return;
     }
 
     if (token.is_doctype()) {
-        auto doctype = realm().heap().allocate<DOM::DocumentType>(realm(), document()).release_allocated_value_but_fixme_should_propagate_errors();
+        auto doctype = realm().heap().allocate<DOM::DocumentType>(realm(), document());
         doctype->set_name(token.doctype_data().name);
         doctype->set_public_id(token.doctype_data().public_identifier);
         doctype->set_system_id(token.doctype_data().system_identifier);
@@ -525,7 +525,7 @@ void HTMLParser::handle_before_html(HTMLToken& token)
     // -> A comment token
     if (token.is_comment()) {
         // Insert a comment as the last child of the Document object.
-        auto comment = realm().heap().allocate<DOM::Comment>(realm(), document(), token.comment()).release_allocated_value_but_fixme_should_propagate_errors();
+        auto comment = realm().heap().allocate<DOM::Comment>(realm(), document(), token.comment());
         MUST(document().append_child(*comment));
         return;
     }
@@ -822,7 +822,7 @@ AnythingElse:
 void HTMLParser::insert_comment(HTMLToken& token)
 {
     auto adjusted_insertion_location = find_appropriate_place_for_inserting_node();
-    adjusted_insertion_location.parent->insert_before(realm().heap().allocate<DOM::Comment>(realm(), document(), token.comment()).release_allocated_value_but_fixme_should_propagate_errors(), adjusted_insertion_location.insert_before_sibling);
+    adjusted_insertion_location.parent->insert_before(realm().heap().allocate<DOM::Comment>(realm(), document(), token.comment()), adjusted_insertion_location.insert_before_sibling);
 }
 
 void HTMLParser::handle_in_head(HTMLToken& token)
@@ -1004,7 +1004,7 @@ DOM::Text* HTMLParser::find_character_insertion_node()
     if (adjusted_insertion_location.insert_before_sibling) {
         if (adjusted_insertion_location.insert_before_sibling->previous_sibling() && adjusted_insertion_location.insert_before_sibling->previous_sibling()->is_text())
             return static_cast<DOM::Text*>(adjusted_insertion_location.insert_before_sibling->previous_sibling());
-        auto new_text_node = realm().heap().allocate<DOM::Text>(realm(), document(), "").release_allocated_value_but_fixme_should_propagate_errors();
+        auto new_text_node = realm().heap().allocate<DOM::Text>(realm(), document(), "");
         adjusted_insertion_location.parent->insert_before(*new_text_node, *adjusted_insertion_location.insert_before_sibling);
         return new_text_node;
     }
@@ -1012,7 +1012,7 @@ DOM::Text* HTMLParser::find_character_insertion_node()
         return nullptr;
     if (adjusted_insertion_location.parent->last_child() && adjusted_insertion_location.parent->last_child()->is_text())
         return verify_cast<DOM::Text>(adjusted_insertion_location.parent->last_child());
-    auto new_text_node = realm().heap().allocate<DOM::Text>(realm(), document(), "").release_allocated_value_but_fixme_should_propagate_errors();
+    auto new_text_node = realm().heap().allocate<DOM::Text>(realm(), document(), "");
     MUST(adjusted_insertion_location.parent->append_child(*new_text_node));
     return new_text_node;
 }
@@ -1137,7 +1137,7 @@ void HTMLParser::handle_after_body(HTMLToken& token)
 
     if (token.is_comment()) {
         auto& insertion_location = m_stack_of_open_elements.first();
-        MUST(insertion_location.append_child(realm().heap().allocate<DOM::Comment>(realm(), document(), token.comment()).release_allocated_value_but_fixme_should_propagate_errors()));
+        MUST(insertion_location.append_child(realm().heap().allocate<DOM::Comment>(realm(), document(), token.comment())));
         return;
     }
 
@@ -1173,7 +1173,7 @@ void HTMLParser::handle_after_body(HTMLToken& token)
 void HTMLParser::handle_after_after_body(HTMLToken& token)
 {
     if (token.is_comment()) {
-        auto comment = realm().heap().allocate<DOM::Comment>(realm(), document(), token.comment()).release_allocated_value_but_fixme_should_propagate_errors();
+        auto comment = realm().heap().allocate<DOM::Comment>(realm(), document(), token.comment());
         MUST(document().append_child(*comment));
         return;
     }
@@ -3402,7 +3402,7 @@ void HTMLParser::handle_after_frameset(HTMLToken& token)
 void HTMLParser::handle_after_after_frameset(HTMLToken& token)
 {
     if (token.is_comment()) {
-        auto comment = document().heap().allocate<DOM::Comment>(document().realm(), document(), token.comment()).release_allocated_value_but_fixme_should_propagate_errors();
+        auto comment = document().heap().allocate<DOM::Comment>(document().realm(), document(), token.comment());
         MUST(document().append_child(comment));
         return;
     }
@@ -3669,7 +3669,7 @@ DOM::Document& HTMLParser::document()
 Vector<JS::Handle<DOM::Node>> HTMLParser::parse_html_fragment(DOM::Element& context_element, StringView markup)
 {
     // 1. Create a new Document node, and mark it as being an HTML document.
-    auto temp_document = DOM::Document::create(context_element.realm()).release_value_but_fixme_should_propagate_errors();
+    auto temp_document = DOM::Document::create(context_element.realm());
     temp_document->set_document_type(DOM::Document::Type::HTML);
 
     temp_document->set_is_temporary_document_for_fragment_parsing({});

--- a/Userland/Libraries/LibWeb/HTML/Path2D.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Path2D.cpp
@@ -16,7 +16,7 @@ namespace Web::HTML {
 
 WebIDL::ExceptionOr<JS::NonnullGCPtr<Path2D>> Path2D::construct_impl(JS::Realm& realm, Optional<Variant<JS::Handle<Path2D>, DeprecatedString>> const& path)
 {
-    return MUST_OR_THROW_OOM(realm.heap().allocate<Path2D>(realm, realm, path));
+    return realm.heap().allocate<Path2D>(realm, realm, path);
 }
 
 // https://html.spec.whatwg.org/multipage/canvas.html#dom-path2d

--- a/Userland/Libraries/LibWeb/HTML/PromiseRejectionEvent.cpp
+++ b/Userland/Libraries/LibWeb/HTML/PromiseRejectionEvent.cpp
@@ -9,9 +9,9 @@
 
 namespace Web::HTML {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<PromiseRejectionEvent>> PromiseRejectionEvent::create(JS::Realm& realm, FlyString const& event_name, PromiseRejectionEventInit const& event_init)
+JS::NonnullGCPtr<PromiseRejectionEvent> PromiseRejectionEvent::create(JS::Realm& realm, FlyString const& event_name, PromiseRejectionEventInit const& event_init)
 {
-    return MUST_OR_THROW_OOM(realm.heap().allocate<PromiseRejectionEvent>(realm, realm, event_name, event_init));
+    return realm.heap().allocate<PromiseRejectionEvent>(realm, realm, event_name, event_init);
 }
 
 WebIDL::ExceptionOr<JS::NonnullGCPtr<PromiseRejectionEvent>> PromiseRejectionEvent::construct_impl(JS::Realm& realm, FlyString const& event_name, PromiseRejectionEventInit const& event_init)

--- a/Userland/Libraries/LibWeb/HTML/PromiseRejectionEvent.h
+++ b/Userland/Libraries/LibWeb/HTML/PromiseRejectionEvent.h
@@ -24,8 +24,8 @@ class PromiseRejectionEvent final : public DOM::Event {
     WEB_PLATFORM_OBJECT(PromiseRejectionEvent, DOM::Event);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<PromiseRejectionEvent>> create(JS::Realm&, FlyString const& event_name, PromiseRejectionEventInit const& event_init = {});
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<PromiseRejectionEvent>> construct_impl(JS::Realm&, FlyString const& event_name, PromiseRejectionEventInit const& event_init);
+    [[nodiscard]] static JS::NonnullGCPtr<PromiseRejectionEvent> create(JS::Realm&, FlyString const& event_name, PromiseRejectionEventInit const& = {});
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<PromiseRejectionEvent>> construct_impl(JS::Realm&, FlyString const& event_name, PromiseRejectionEventInit const&);
 
     virtual ~PromiseRejectionEvent() override;
 

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Environments.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Environments.cpp
@@ -259,7 +259,7 @@ void EnvironmentSettingsObject::notify_about_rejected_promises(Badge<EventLoop>)
             // FIXME: This currently assumes that global is a WindowObject.
             auto& window = verify_cast<HTML::Window>(global);
 
-            auto promise_rejection_event = PromiseRejectionEvent::create(window.realm(), HTML::EventNames::unhandledrejection, event_init).release_value_but_fixme_should_propagate_errors();
+            auto promise_rejection_event = PromiseRejectionEvent::create(window.realm(), HTML::EventNames::unhandledrejection, event_init);
 
             bool not_handled = window.dispatch_event(*promise_rejection_event);
 

--- a/Userland/Libraries/LibWeb/HTML/Scripting/ModuleScript.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/ModuleScript.cpp
@@ -37,7 +37,7 @@ WebIDL::ExceptionOr<JS::GCPtr<JavaScriptModuleScript>> JavaScriptModuleScript::c
     auto& realm = settings_object.realm();
 
     // 2. Let script be a new module script that this algorithm will subsequently initialize.
-    auto script = MUST_OR_THROW_OOM(realm.heap().allocate<JavaScriptModuleScript>(realm, move(base_url), filename, settings_object));
+    auto script = realm.heap().allocate<JavaScriptModuleScript>(realm, move(base_url), filename, settings_object);
 
     // 3. Set script's settings object to settings.
     // NOTE: This was already done when constructing.

--- a/Userland/Libraries/LibWeb/HTML/Scripting/WindowEnvironmentSettingsObject.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/WindowEnvironmentSettingsObject.cpp
@@ -27,7 +27,7 @@ void WindowEnvironmentSettingsObject::visit_edges(JS::Cell::Visitor& visitor)
 }
 
 // https://html.spec.whatwg.org/multipage/window-object.html#set-up-a-window-environment-settings-object
-WebIDL::ExceptionOr<void> WindowEnvironmentSettingsObject::setup(AK::URL const& creation_url, NonnullOwnPtr<JS::ExecutionContext> execution_context, Optional<Environment> reserved_environment, AK::URL top_level_creation_url, Origin top_level_origin)
+void WindowEnvironmentSettingsObject::setup(AK::URL const& creation_url, NonnullOwnPtr<JS::ExecutionContext> execution_context, Optional<Environment> reserved_environment, AK::URL top_level_creation_url, Origin top_level_origin)
 {
     // 1. Let realm be the value of execution context's Realm component.
     auto realm = execution_context->realm;
@@ -38,7 +38,7 @@ WebIDL::ExceptionOr<void> WindowEnvironmentSettingsObject::setup(AK::URL const& 
 
     // 3. Let settings object be a new environment settings object whose algorithms are defined as follows:
     // NOTE: See the functions defined for this class.
-    auto settings_object = MUST_OR_THROW_OOM(realm->heap().allocate<WindowEnvironmentSettingsObject>(*realm, window, move(execution_context)));
+    auto settings_object = realm->heap().allocate<WindowEnvironmentSettingsObject>(*realm, window, move(execution_context));
 
     // 4. If reservedEnvironment is non-null, then:
     if (reserved_environment.has_value()) {
@@ -71,15 +71,13 @@ WebIDL::ExceptionOr<void> WindowEnvironmentSettingsObject::setup(AK::URL const& 
 
     // 7. Set realm's [[HostDefined]] field to settings object.
     // Non-Standard: We store the ESO next to the web intrinsics in a custom HostDefined object
-    auto intrinsics = MUST_OR_THROW_OOM(realm->heap().allocate<Bindings::Intrinsics>(*realm, *realm));
+    auto intrinsics = realm->heap().allocate<Bindings::Intrinsics>(*realm, *realm);
     auto host_defined = make<Bindings::HostDefined>(settings_object, intrinsics);
     realm->set_host_defined(move(host_defined));
 
     // Non-Standard: We cannot fully initialize window object until *after* the we set up
     //    the realm's [[HostDefined]] internal slot as the internal slot contains the web platform intrinsics
-    TRY(window.initialize_web_interfaces({}));
-
-    return {};
+    MUST(window.initialize_web_interfaces({}));
 }
 
 // https://html.spec.whatwg.org/multipage/window-object.html#script-settings-for-window-objects:responsible-document

--- a/Userland/Libraries/LibWeb/HTML/Scripting/WindowEnvironmentSettingsObject.h
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/WindowEnvironmentSettingsObject.h
@@ -15,7 +15,7 @@ class WindowEnvironmentSettingsObject final : public EnvironmentSettingsObject {
     JS_CELL(WindowEnvironmentSettingsObject, EnvironmentSettingsObject);
 
 public:
-    static WebIDL::ExceptionOr<void> setup(AK::URL const& creation_url, NonnullOwnPtr<JS::ExecutionContext>, Optional<Environment>, AK::URL top_level_creation_url, Origin top_level_origin);
+    static void setup(AK::URL const& creation_url, NonnullOwnPtr<JS::ExecutionContext>, Optional<Environment>, AK::URL top_level_creation_url, Origin top_level_origin);
 
     virtual ~WindowEnvironmentSettingsObject() override;
 

--- a/Userland/Libraries/LibWeb/HTML/Scripting/WorkerEnvironmentSettingsObject.h
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/WorkerEnvironmentSettingsObject.h
@@ -27,10 +27,10 @@ public:
     {
         auto realm = execution_context->realm;
         VERIFY(realm);
-        auto settings_object = realm->heap().allocate<WorkerEnvironmentSettingsObject>(*realm, move(execution_context)).release_allocated_value_but_fixme_should_propagate_errors();
+        auto settings_object = realm->heap().allocate<WorkerEnvironmentSettingsObject>(*realm, move(execution_context));
         settings_object->target_browsing_context = nullptr;
 
-        auto intrinsics = realm->heap().allocate<Bindings::Intrinsics>(*realm, *realm).release_allocated_value_but_fixme_should_propagate_errors();
+        auto intrinsics = realm->heap().allocate<Bindings::Intrinsics>(*realm, *realm);
         auto host_defined = make<Bindings::HostDefined>(settings_object, intrinsics);
         realm->set_host_defined(move(host_defined));
 

--- a/Userland/Libraries/LibWeb/HTML/Storage.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Storage.cpp
@@ -11,9 +11,9 @@
 
 namespace Web::HTML {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<Storage>> Storage::create(JS::Realm& realm)
+JS::NonnullGCPtr<Storage> Storage::create(JS::Realm& realm)
 {
-    return MUST_OR_THROW_OOM(realm.heap().allocate<Storage>(realm, realm));
+    return realm.heap().allocate<Storage>(realm, realm);
 }
 
 Storage::Storage(JS::Realm& realm)

--- a/Userland/Libraries/LibWeb/HTML/Storage.h
+++ b/Userland/Libraries/LibWeb/HTML/Storage.h
@@ -17,7 +17,7 @@ class Storage : public Bindings::LegacyPlatformObject {
     WEB_PLATFORM_OBJECT(Storage, Bindings::LegacyPlatformObject);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<Storage>> create(JS::Realm&);
+    [[nodiscard]] static JS::NonnullGCPtr<Storage> create(JS::Realm&);
     ~Storage();
 
     size_t length() const;

--- a/Userland/Libraries/LibWeb/HTML/StructuredSerialize.cpp
+++ b/Userland/Libraries/LibWeb/HTML/StructuredSerialize.cpp
@@ -235,7 +235,7 @@ public:
             case ValueTag::StringObject: {
                 auto* realm = m_vm.current_realm();
                 auto string = TRY(deserialize_string_primitive(m_vm, m_vector, position));
-                m_memory.append(TRY(JS::StringObject::create(*realm, string, realm->intrinsics().string_prototype())));
+                m_memory.append(JS::StringObject::create(*realm, string, realm->intrinsics().string_prototype()));
                 break;
             }
             case ValueTag::DateObject: {

--- a/Userland/Libraries/LibWeb/HTML/SubmitEvent.cpp
+++ b/Userland/Libraries/LibWeb/HTML/SubmitEvent.cpp
@@ -9,9 +9,9 @@
 
 namespace Web::HTML {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<SubmitEvent>> SubmitEvent::create(JS::Realm& realm, FlyString const& event_name, SubmitEventInit const& event_init)
+JS::NonnullGCPtr<SubmitEvent> SubmitEvent::create(JS::Realm& realm, FlyString const& event_name, SubmitEventInit const& event_init)
 {
-    return MUST_OR_THROW_OOM(realm.heap().allocate<SubmitEvent>(realm, realm, event_name, event_init));
+    return realm.heap().allocate<SubmitEvent>(realm, realm, event_name, event_init);
 }
 
 WebIDL::ExceptionOr<JS::NonnullGCPtr<SubmitEvent>> SubmitEvent::construct_impl(JS::Realm& realm, FlyString const& event_name, SubmitEventInit const& event_init)

--- a/Userland/Libraries/LibWeb/HTML/SubmitEvent.h
+++ b/Userland/Libraries/LibWeb/HTML/SubmitEvent.h
@@ -19,7 +19,7 @@ class SubmitEvent final : public DOM::Event {
     WEB_PLATFORM_OBJECT(SubmitEvent, DOM::Event);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<SubmitEvent>> create(JS::Realm&, FlyString const& event_name, SubmitEventInit const& event_init);
+    [[nodiscard]] static JS::NonnullGCPtr<SubmitEvent> create(JS::Realm&, FlyString const& event_name, SubmitEventInit const& event_init);
     static WebIDL::ExceptionOr<JS::NonnullGCPtr<SubmitEvent>> construct_impl(JS::Realm&, FlyString const& event_name, SubmitEventInit const& event_init);
 
     virtual ~SubmitEvent() override;

--- a/Userland/Libraries/LibWeb/HTML/TextMetrics.cpp
+++ b/Userland/Libraries/LibWeb/HTML/TextMetrics.cpp
@@ -10,9 +10,9 @@
 
 namespace Web::HTML {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<TextMetrics>> TextMetrics::create(JS::Realm& realm)
+JS::NonnullGCPtr<TextMetrics> TextMetrics::create(JS::Realm& realm)
 {
-    return MUST_OR_THROW_OOM(realm.heap().allocate<TextMetrics>(realm, realm));
+    return realm.heap().allocate<TextMetrics>(realm, realm);
 }
 
 TextMetrics::TextMetrics(JS::Realm& realm)

--- a/Userland/Libraries/LibWeb/HTML/TextMetrics.h
+++ b/Userland/Libraries/LibWeb/HTML/TextMetrics.h
@@ -14,7 +14,7 @@ class TextMetrics : public Bindings::PlatformObject {
     WEB_PLATFORM_OBJECT(TextMetrics, Bindings::PlatformObject);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<TextMetrics>> create(JS::Realm&);
+    [[nodiscard]] static JS::NonnullGCPtr<TextMetrics> create(JS::Realm&);
 
     virtual ~TextMetrics() override;
 

--- a/Userland/Libraries/LibWeb/HTML/TrackEvent.cpp
+++ b/Userland/Libraries/LibWeb/HTML/TrackEvent.cpp
@@ -10,9 +10,9 @@
 
 namespace Web::HTML {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<TrackEvent>> TrackEvent::create(JS::Realm& realm, FlyString const& event_name, TrackEventInit event_init)
+JS::NonnullGCPtr<TrackEvent> TrackEvent::create(JS::Realm& realm, FlyString const& event_name, TrackEventInit event_init)
 {
-    return MUST_OR_THROW_OOM(realm.heap().allocate<TrackEvent>(realm, realm, event_name, move(event_init)));
+    return realm.heap().allocate<TrackEvent>(realm, realm, event_name, move(event_init));
 }
 
 WebIDL::ExceptionOr<JS::NonnullGCPtr<TrackEvent>> TrackEvent::construct_impl(JS::Realm& realm, FlyString const& event_name, TrackEventInit event_init)

--- a/Userland/Libraries/LibWeb/HTML/TrackEvent.h
+++ b/Userland/Libraries/LibWeb/HTML/TrackEvent.h
@@ -23,8 +23,8 @@ class TrackEvent : public DOM::Event {
     WEB_PLATFORM_OBJECT(TrackEvent, DOM::Event);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<TrackEvent>> create(JS::Realm&, FlyString const& event_name, TrackEventInit event_init = {});
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<TrackEvent>> construct_impl(JS::Realm&, FlyString const& event_name, TrackEventInit event_init);
+    [[nodiscard]] static JS::NonnullGCPtr<TrackEvent> create(JS::Realm&, FlyString const& event_name, TrackEventInit = {});
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<TrackEvent>> construct_impl(JS::Realm&, FlyString const& event_name, TrackEventInit);
 
     // https://html.spec.whatwg.org/multipage/media.html#dom-trackevent-track
     Variant<Empty, JS::Handle<VideoTrack>, JS::Handle<AudioTrack>> track() const;

--- a/Userland/Libraries/LibWeb/HTML/VideoTrack.cpp
+++ b/Userland/Libraries/LibWeb/HTML/VideoTrack.cpp
@@ -153,7 +153,7 @@ void VideoTrack::set_selected(bool selected)
 
         if (previously_unselected_track_is_selected || selected_track_was_unselected_without_another_selection) {
             m_media_element->queue_a_media_element_task([this]() {
-                m_video_track_list->dispatch_event(DOM::Event::create(realm(), HTML::EventNames::change).release_value_but_fixme_should_propagate_errors());
+                m_video_track_list->dispatch_event(DOM::Event::create(realm(), HTML::EventNames::change));
             });
         }
     }

--- a/Userland/Libraries/LibWeb/HTML/Window.h
+++ b/Userland/Libraries/LibWeb/HTML/Window.h
@@ -46,7 +46,7 @@ class Window final
     WEB_PLATFORM_OBJECT(Window, DOM::EventTarget);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<Window>> create(JS::Realm&);
+    [[nodiscard]] static JS::NonnullGCPtr<Window> create(JS::Realm&);
 
     ~Window();
 
@@ -131,7 +131,7 @@ public:
     JS::NonnullGCPtr<DOM::Document const> document() const;
     String name() const;
     void set_name(String const&);
-    WebIDL::ExceptionOr<JS::NonnullGCPtr<Location>> location();
+    [[nodiscard]] JS::NonnullGCPtr<Location> location();
     JS::NonnullGCPtr<History> history() const;
     void focus();
 
@@ -142,7 +142,7 @@ public:
     JS::GCPtr<DOM::Element const> frame_element() const;
     WebIDL::ExceptionOr<JS::GCPtr<WindowProxy>> open(Optional<String> const& url, Optional<String> const& target, Optional<String> const& features);
 
-    WebIDL::ExceptionOr<JS::NonnullGCPtr<Navigator>> navigator();
+    [[nodiscard]] JS::NonnullGCPtr<Navigator> navigator();
 
     void alert(String const& message = {});
     bool confirm(Optional<String> const& message);
@@ -152,11 +152,11 @@ public:
 
     Variant<JS::Handle<DOM::Event>, JS::Value> event() const;
 
-    WebIDL::ExceptionOr<JS::NonnullGCPtr<CSS::CSSStyleDeclaration>> get_computed_style(DOM::Element&, Optional<String> const& pseudo_element) const;
+    [[nodiscard]] JS::NonnullGCPtr<CSS::CSSStyleDeclaration> get_computed_style(DOM::Element&, Optional<String> const& pseudo_element) const;
 
     WebIDL::ExceptionOr<JS::NonnullGCPtr<CSS::MediaQueryList>> match_media(String const& query);
-    WebIDL::ExceptionOr<JS::NonnullGCPtr<CSS::Screen>> screen();
-    WebIDL::ExceptionOr<JS::GCPtr<CSS::VisualViewport>> visual_viewport();
+    [[nodiscard]] JS::NonnullGCPtr<CSS::Screen> screen();
+    [[nodiscard]] JS::GCPtr<CSS::VisualViewport> visual_viewport();
 
     i32 inner_width() const;
     i32 inner_height() const;
@@ -182,11 +182,11 @@ public:
 
     JS::GCPtr<Selection::Selection> get_selection() const;
 
-    WebIDL::ExceptionOr<JS::NonnullGCPtr<HighResolutionTime::Performance>> performance();
+    [[nodiscard]] JS::NonnullGCPtr<HighResolutionTime::Performance> performance();
 
-    WebIDL::ExceptionOr<JS::NonnullGCPtr<Crypto::Crypto>> crypto();
+    [[nodiscard]] JS::NonnullGCPtr<Crypto::Crypto> crypto();
 
-    WebIDL::ExceptionOr<JS::NonnullGCPtr<CustomElementRegistry>> custom_elements();
+    [[nodiscard]] JS::NonnullGCPtr<CustomElementRegistry> custom_elements();
 
     HighResolutionTime::DOMHighResTimeStamp get_last_activation_timestamp() const { return m_last_activation_timestamp; }
     void set_last_activation_timestamp(HighResolutionTime::DOMHighResTimeStamp timestamp) { m_last_activation_timestamp = timestamp; }

--- a/Userland/Libraries/LibWeb/HTML/Worker.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Worker.cpp
@@ -23,7 +23,7 @@ Worker::Worker(String const& script_url, WorkerOptions const options, DOM::Docum
     , m_document(&document)
     , m_custom_data()
     , m_worker_vm(JS::VM::create(adopt_own(m_custom_data)).release_value_but_fixme_should_propagate_errors())
-    , m_implicit_port(MessagePort::create(document.realm()).release_value_but_fixme_should_propagate_errors())
+    , m_implicit_port(MessagePort::create(document.realm()))
 {
 }
 
@@ -77,10 +77,10 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Worker>> Worker::create(String const& scrip
     // 5. Let worker URL be the resulting URL record.
 
     // 6. Let worker be a new Worker object.
-    auto worker = MUST_OR_THROW_OOM(document.heap().allocate<Worker>(document.realm(), script_url, options, document));
+    auto worker = document.heap().allocate<Worker>(document.realm(), script_url, options, document);
 
     // 7. Let outside port be a new MessagePort in outside settings's Realm.
-    auto outside_port = TRY(MessagePort::create(outside_settings.realm()));
+    auto outside_port = MessagePort::create(outside_settings.realm());
 
     // 8. Associate the outside port with worker
     worker->m_outside_port = outside_port;
@@ -166,7 +166,7 @@ void Worker::run_a_worker(AK::URL& url, EnvironmentSettingsObject& outside_setti
                 MessageEventInit event_init {};
                 event_init.data = message;
                 event_init.origin = "<origin>"_string;
-                dispatch_event(MessageEvent::create(*m_worker_realm, HTML::EventNames::message, event_init).release_value_but_fixme_should_propagate_errors());
+                dispatch_event(MessageEvent::create(*m_worker_realm, HTML::EventNames::message, event_init));
             }));
 
             return JS::js_undefined();
@@ -263,7 +263,7 @@ void Worker::run_a_worker(AK::URL& url, EnvironmentSettingsObject& outside_setti
             // FIXME: Global scope association
 
             // 16. Let inside port be a new MessagePort object in inside settings's Realm.
-            auto inside_port = MessagePort::create(m_inner_settings->realm()).release_value_but_fixme_should_propagate_errors();
+            auto inside_port = MessagePort::create(m_inner_settings->realm());
 
             // 17. Associate inside port with worker global scope.
             // FIXME: Global scope association

--- a/Userland/Libraries/LibWeb/HTML/WorkerGlobalScope.cpp
+++ b/Userland/Libraries/LibWeb/HTML/WorkerGlobalScope.cpp
@@ -27,7 +27,7 @@ WorkerGlobalScope::~WorkerGlobalScope() = default;
 void WorkerGlobalScope::initialize(JS::Realm& realm)
 {
     Base::initialize(realm);
-    m_navigator = MUST(WorkerNavigator::create(*this));
+    m_navigator = WorkerNavigator::create(*this);
 }
 
 void WorkerGlobalScope::visit_edges(Cell::Visitor& visitor)

--- a/Userland/Libraries/LibWeb/HTML/WorkerNavigator.cpp
+++ b/Userland/Libraries/LibWeb/HTML/WorkerNavigator.cpp
@@ -11,9 +11,9 @@
 
 namespace Web::HTML {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<WorkerNavigator>> WorkerNavigator::create(WorkerGlobalScope& global_scope)
+JS::NonnullGCPtr<WorkerNavigator> WorkerNavigator::create(WorkerGlobalScope& global_scope)
 {
-    return MUST_OR_THROW_OOM(global_scope.heap().allocate<WorkerNavigator>(global_scope.realm(), global_scope));
+    return global_scope.heap().allocate<WorkerNavigator>(global_scope.realm(), global_scope);
 }
 
 WorkerNavigator::WorkerNavigator(WorkerGlobalScope& global_scope)

--- a/Userland/Libraries/LibWeb/HTML/WorkerNavigator.h
+++ b/Userland/Libraries/LibWeb/HTML/WorkerNavigator.h
@@ -22,7 +22,7 @@ class WorkerNavigator : public Bindings::PlatformObject
     WEB_PLATFORM_OBJECT(WorkerNavigator, Bindings::PlatformObject);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<WorkerNavigator>> create(WorkerGlobalScope&);
+    [[nodiscard]] static JS::NonnullGCPtr<WorkerNavigator> create(WorkerGlobalScope&);
 
     virtual ~WorkerNavigator() override;
 

--- a/Userland/Libraries/LibWeb/HighResolutionTime/Performance.cpp
+++ b/Userland/Libraries/LibWeb/HighResolutionTime/Performance.cpp
@@ -43,7 +43,7 @@ void Performance::visit_edges(Cell::Visitor& visitor)
 JS::GCPtr<NavigationTiming::PerformanceTiming> Performance::timing()
 {
     if (!m_timing)
-        m_timing = heap().allocate<NavigationTiming::PerformanceTiming>(realm(), *m_window).release_allocated_value_but_fixme_should_propagate_errors();
+        m_timing = heap().allocate<NavigationTiming::PerformanceTiming>(realm(), *m_window);
     return m_timing;
 }
 
@@ -290,7 +290,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<UserTiming::PerformanceMeasure>> Performanc
     // NOTE: Already the default value of `detail`.
 
     // 4. Create a new PerformanceMeasure object (entry) with this's relevant realm.
-    auto entry = MUST_OR_THROW_OOM(realm.heap().allocate<UserTiming::PerformanceMeasure>(realm, realm, measure_name, start_time, duration, detail));
+    auto entry = realm.heap().allocate<UserTiming::PerformanceMeasure>(realm, realm, measure_name, start_time, duration, detail);
 
     // 10. Queue entry.
     TRY(window_or_worker->queue_performance_entry(entry));

--- a/Userland/Libraries/LibWeb/IntersectionObserver/IntersectionObserver.cpp
+++ b/Userland/Libraries/LibWeb/IntersectionObserver/IntersectionObserver.cpp
@@ -39,7 +39,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<IntersectionObserver>> IntersectionObserver
     // 2. Set this’s internal [[callback]] slot to callback.
     // 8. The thresholds attribute getter will return this sorted thresholds list.
     // 9. Return this.
-    return MUST_OR_THROW_OOM(realm.heap().allocate<IntersectionObserver>(realm, realm, callback, options.root, move(thresholds)));
+    return realm.heap().allocate<IntersectionObserver>(realm, realm, callback, options.root, move(thresholds));
 }
 
 IntersectionObserver::IntersectionObserver(JS::Realm& realm, JS::GCPtr<WebIDL::CallbackType> callback, Optional<Variant<JS::Handle<DOM::Element>, JS::Handle<DOM::Document>>> const& root, Vector<double>&& thresholds)

--- a/Userland/Libraries/LibWeb/IntersectionObserver/IntersectionObserverEntry.cpp
+++ b/Userland/Libraries/LibWeb/IntersectionObserver/IntersectionObserverEntry.cpp
@@ -16,11 +16,11 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<IntersectionObserverEntry>> IntersectionObs
 
     JS::GCPtr<Geometry::DOMRectReadOnly> root_bounds;
     if (options.root_bounds.has_value())
-        root_bounds = TRY(Geometry::DOMRectReadOnly::from_rect(vm, options.root_bounds.value()));
+        root_bounds = Geometry::DOMRectReadOnly::from_rect(vm, options.root_bounds.value());
 
-    auto bounding_client_rect = TRY(Geometry::DOMRectReadOnly::from_rect(vm, options.bounding_client_rect));
-    auto intersection_rect = TRY(Geometry::DOMRectReadOnly::from_rect(vm, options.intersection_rect));
-    return MUST_OR_THROW_OOM(realm.heap().allocate<IntersectionObserverEntry>(realm, realm, options.time, root_bounds, bounding_client_rect, intersection_rect, options.is_intersecting, options.intersection_ratio, *options.target));
+    auto bounding_client_rect = Geometry::DOMRectReadOnly::from_rect(vm, options.bounding_client_rect);
+    auto intersection_rect = Geometry::DOMRectReadOnly::from_rect(vm, options.intersection_rect);
+    return realm.heap().allocate<IntersectionObserverEntry>(realm, realm, options.time, root_bounds, bounding_client_rect, intersection_rect, options.is_intersecting, options.intersection_ratio, *options.target);
 }
 
 IntersectionObserverEntry::IntersectionObserverEntry(JS::Realm& realm, HighResolutionTime::DOMHighResTimeStamp time, JS::GCPtr<Geometry::DOMRectReadOnly> root_bounds, JS::NonnullGCPtr<Geometry::DOMRectReadOnly> bounding_client_rect, JS::NonnullGCPtr<Geometry::DOMRectReadOnly> intersection_rect, bool is_intersecting, double intersection_ratio, JS::NonnullGCPtr<DOM::Element> target)

--- a/Userland/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -203,7 +203,7 @@ ErrorOr<void> TreeBuilder::create_pseudo_element_if_needed(DOM::Element& element
 
     // FIXME: Handle images, and multiple values
     if (pseudo_element_content.type == CSS::ContentData::Type::String) {
-        auto text = document.heap().allocate<DOM::Text>(document.realm(), document, pseudo_element_content.data.to_deprecated_string()).release_allocated_value_but_fixme_should_propagate_errors();
+        auto text = document.heap().allocate<DOM::Text>(document.realm(), document, pseudo_element_content.data.to_deprecated_string());
         auto text_node = document.heap().allocate_without_realm<Layout::TextNode>(document, *text);
         text_node->set_generated_for(generated_for, element);
 

--- a/Userland/Libraries/LibWeb/MathML/MathMLElement.cpp
+++ b/Userland/Libraries/LibWeb/MathML/MathMLElement.cpp
@@ -22,7 +22,7 @@ void MathMLElement::initialize(JS::Realm& realm)
     Base::initialize(realm);
     set_prototype(&Bindings::ensure_web_prototype<Bindings::MathMLElementPrototype>(realm, "MathMLElement"));
 
-    m_dataset = MUST(HTML::DOMStringMap::create(*this));
+    m_dataset = HTML::DOMStringMap::create(*this);
 }
 
 Optional<ARIA::Role> MathMLElement::default_role() const

--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -693,12 +693,12 @@ bool EventHandler::fire_keyboard_event(FlyString const& event_name, HTML::Browsi
                 return fire_keyboard_event(event_name, *navigable_container.nested_browsing_context(), key, modifiers, code_point);
         }
 
-        auto event = UIEvents::KeyboardEvent::create_from_platform_event(document->realm(), event_name, key, modifiers, code_point).release_value_but_fixme_should_propagate_errors();
+        auto event = UIEvents::KeyboardEvent::create_from_platform_event(document->realm(), event_name, key, modifiers, code_point);
         return !focused_element->dispatch_event(event);
     }
 
     // FIXME: De-duplicate this. This is just to prevent wasting a KeyboardEvent allocation when recursing into an (i)frame.
-    auto event = UIEvents::KeyboardEvent::create_from_platform_event(document->realm(), event_name, key, modifiers, code_point).release_value_but_fixme_should_propagate_errors();
+    auto event = UIEvents::KeyboardEvent::create_from_platform_event(document->realm(), event_name, key, modifiers, code_point);
 
     if (JS::GCPtr<HTML::HTMLElement> body = document->body())
         return !body->dispatch_event(event);

--- a/Userland/Libraries/LibWeb/RequestIdleCallback/IdleDeadline.cpp
+++ b/Userland/Libraries/LibWeb/RequestIdleCallback/IdleDeadline.cpp
@@ -12,9 +12,9 @@
 
 namespace Web::RequestIdleCallback {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<IdleDeadline>> IdleDeadline::create(JS::Realm& realm, bool did_timeout)
+JS::NonnullGCPtr<IdleDeadline> IdleDeadline::create(JS::Realm& realm, bool did_timeout)
 {
-    return MUST_OR_THROW_OOM(realm.heap().allocate<IdleDeadline>(realm, realm, did_timeout));
+    return realm.heap().allocate<IdleDeadline>(realm, realm, did_timeout);
 }
 
 IdleDeadline::IdleDeadline(JS::Realm& realm, bool did_timeout)

--- a/Userland/Libraries/LibWeb/RequestIdleCallback/IdleDeadline.h
+++ b/Userland/Libraries/LibWeb/RequestIdleCallback/IdleDeadline.h
@@ -15,7 +15,7 @@ class IdleDeadline final : public Bindings::PlatformObject {
     WEB_PLATFORM_OBJECT(IdleDeadline, Bindings::PlatformObject);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<IdleDeadline>> create(JS::Realm&, bool did_timeout = false);
+    [[nodiscard]] static JS::NonnullGCPtr<IdleDeadline> create(JS::Realm&, bool did_timeout = false);
     virtual ~IdleDeadline() override;
 
     double time_remaining() const;

--- a/Userland/Libraries/LibWeb/ResizeObserver/ResizeObserver.cpp
+++ b/Userland/Libraries/LibWeb/ResizeObserver/ResizeObserver.cpp
@@ -15,7 +15,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<ResizeObserver>> ResizeObserver::construct_
 {
     // FIXME: Implement
     (void)callback;
-    return MUST_OR_THROW_OOM(realm.heap().allocate<ResizeObserver>(realm, realm));
+    return realm.heap().allocate<ResizeObserver>(realm, realm);
 }
 
 ResizeObserver::ResizeObserver(JS::Realm& realm)

--- a/Userland/Libraries/LibWeb/SVG/SVGAnimatedLength.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGAnimatedLength.cpp
@@ -9,9 +9,9 @@
 
 namespace Web::SVG {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<SVGAnimatedLength>> SVGAnimatedLength::create(JS::Realm& realm, JS::NonnullGCPtr<SVGLength> base_val, JS::NonnullGCPtr<SVGLength> anim_val)
+JS::NonnullGCPtr<SVGAnimatedLength> SVGAnimatedLength::create(JS::Realm& realm, JS::NonnullGCPtr<SVGLength> base_val, JS::NonnullGCPtr<SVGLength> anim_val)
 {
-    return MUST_OR_THROW_OOM(realm.heap().allocate<SVGAnimatedLength>(realm, realm, move(base_val), move(anim_val)));
+    return realm.heap().allocate<SVGAnimatedLength>(realm, realm, move(base_val), move(anim_val));
 }
 
 SVGAnimatedLength::SVGAnimatedLength(JS::Realm& realm, JS::NonnullGCPtr<SVGLength> base_val, JS::NonnullGCPtr<SVGLength> anim_val)

--- a/Userland/Libraries/LibWeb/SVG/SVGAnimatedLength.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGAnimatedLength.h
@@ -16,7 +16,7 @@ class SVGAnimatedLength final : public Bindings::PlatformObject {
     WEB_PLATFORM_OBJECT(SVGAnimatedLength, Bindings::PlatformObject);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<SVGAnimatedLength>> create(JS::Realm&, JS::NonnullGCPtr<SVGLength> base_val, JS::NonnullGCPtr<SVGLength> anim_val);
+    [[nodiscard]] static JS::NonnullGCPtr<SVGAnimatedLength> create(JS::Realm&, JS::NonnullGCPtr<SVGLength> base_val, JS::NonnullGCPtr<SVGLength> anim_val);
     virtual ~SVGAnimatedLength() override;
 
     JS::NonnullGCPtr<SVGLength> base_val() const { return m_base_val; }

--- a/Userland/Libraries/LibWeb/SVG/SVGAnimatedNumber.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGAnimatedNumber.cpp
@@ -9,9 +9,9 @@
 
 namespace Web::SVG {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<SVGAnimatedNumber>> SVGAnimatedNumber::create(JS::Realm& realm, float base_val, float anim_val)
+JS::NonnullGCPtr<SVGAnimatedNumber> SVGAnimatedNumber::create(JS::Realm& realm, float base_val, float anim_val)
 {
-    return MUST_OR_THROW_OOM(realm.heap().allocate<SVGAnimatedNumber>(realm, realm, base_val, anim_val));
+    return realm.heap().allocate<SVGAnimatedNumber>(realm, realm, base_val, anim_val);
 }
 
 SVGAnimatedNumber::SVGAnimatedNumber(JS::Realm& realm, float base_val, float anim_val)

--- a/Userland/Libraries/LibWeb/SVG/SVGAnimatedNumber.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGAnimatedNumber.h
@@ -16,7 +16,7 @@ class SVGAnimatedNumber final : public Bindings::PlatformObject {
     WEB_PLATFORM_OBJECT(SVGAnimatedNumber, Bindings::PlatformObject);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<SVGAnimatedNumber>> create(JS::Realm&, float base_val, float anim_val);
+    [[nodiscard]] static JS::NonnullGCPtr<SVGAnimatedNumber> create(JS::Realm&, float base_val, float anim_val);
     virtual ~SVGAnimatedNumber() override;
 
     float base_val() const { return m_base_val; }

--- a/Userland/Libraries/LibWeb/SVG/SVGCircleElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGCircleElement.cpp
@@ -82,9 +82,9 @@ JS::NonnullGCPtr<SVGAnimatedLength> SVGCircleElement::cx() const
 {
     // FIXME: Populate the unit type when it is parsed (0 here is "unknown").
     // FIXME: Create a proper animated value when animations are supported.
-    auto base_length = SVGLength::create(realm(), 0, m_center_x.value_or(0)).release_value_but_fixme_should_propagate_errors();
-    auto anim_length = SVGLength::create(realm(), 0, m_center_x.value_or(0)).release_value_but_fixme_should_propagate_errors();
-    return SVGAnimatedLength::create(realm(), move(base_length), move(anim_length)).release_value_but_fixme_should_propagate_errors();
+    auto base_length = SVGLength::create(realm(), 0, m_center_x.value_or(0));
+    auto anim_length = SVGLength::create(realm(), 0, m_center_x.value_or(0));
+    return SVGAnimatedLength::create(realm(), move(base_length), move(anim_length));
 }
 
 // https://www.w3.org/TR/SVG11/shapes.html#CircleElementCYAttribute
@@ -92,9 +92,9 @@ JS::NonnullGCPtr<SVGAnimatedLength> SVGCircleElement::cy() const
 {
     // FIXME: Populate the unit type when it is parsed (0 here is "unknown").
     // FIXME: Create a proper animated value when animations are supported.
-    auto base_length = SVGLength::create(realm(), 0, m_center_y.value_or(0)).release_value_but_fixme_should_propagate_errors();
-    auto anim_length = SVGLength::create(realm(), 0, m_center_y.value_or(0)).release_value_but_fixme_should_propagate_errors();
-    return SVGAnimatedLength::create(realm(), move(base_length), move(anim_length)).release_value_but_fixme_should_propagate_errors();
+    auto base_length = SVGLength::create(realm(), 0, m_center_y.value_or(0));
+    auto anim_length = SVGLength::create(realm(), 0, m_center_y.value_or(0));
+    return SVGAnimatedLength::create(realm(), move(base_length), move(anim_length));
 }
 
 // https://www.w3.org/TR/SVG11/shapes.html#CircleElementRAttribute
@@ -102,9 +102,9 @@ JS::NonnullGCPtr<SVGAnimatedLength> SVGCircleElement::r() const
 {
     // FIXME: Populate the unit type when it is parsed (0 here is "unknown").
     // FIXME: Create a proper animated value when animations are supported.
-    auto base_length = SVGLength::create(realm(), 0, m_radius.value_or(0)).release_value_but_fixme_should_propagate_errors();
-    auto anim_length = SVGLength::create(realm(), 0, m_radius.value_or(0)).release_value_but_fixme_should_propagate_errors();
-    return SVGAnimatedLength::create(realm(), move(base_length), move(anim_length)).release_value_but_fixme_should_propagate_errors();
+    auto base_length = SVGLength::create(realm(), 0, m_radius.value_or(0));
+    auto anim_length = SVGLength::create(realm(), 0, m_radius.value_or(0));
+    return SVGAnimatedLength::create(realm(), move(base_length), move(anim_length));
 }
 
 }

--- a/Userland/Libraries/LibWeb/SVG/SVGElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGElement.cpp
@@ -25,7 +25,7 @@ void SVGElement::initialize(JS::Realm& realm)
     Base::initialize(realm);
     set_prototype(&Bindings::ensure_web_prototype<Bindings::SVGElementPrototype>(realm, "SVGElement"));
 
-    m_dataset = MUST(HTML::DOMStringMap::create(*this));
+    m_dataset = HTML::DOMStringMap::create(*this);
 }
 
 void SVGElement::visit_edges(Cell::Visitor& visitor)

--- a/Userland/Libraries/LibWeb/SVG/SVGEllipseElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGEllipseElement.cpp
@@ -87,9 +87,9 @@ JS::NonnullGCPtr<SVGAnimatedLength> SVGEllipseElement::cx() const
 {
     // FIXME: Populate the unit type when it is parsed (0 here is "unknown").
     // FIXME: Create a proper animated value when animations are supported.
-    auto base_length = SVGLength::create(realm(), 0, m_center_x.value_or(0)).release_value_but_fixme_should_propagate_errors();
-    auto anim_length = SVGLength::create(realm(), 0, m_center_x.value_or(0)).release_value_but_fixme_should_propagate_errors();
-    return SVGAnimatedLength::create(realm(), move(base_length), move(anim_length)).release_value_but_fixme_should_propagate_errors();
+    auto base_length = SVGLength::create(realm(), 0, m_center_x.value_or(0));
+    auto anim_length = SVGLength::create(realm(), 0, m_center_x.value_or(0));
+    return SVGAnimatedLength::create(realm(), move(base_length), move(anim_length));
 }
 
 // https://www.w3.org/TR/SVG11/shapes.html#EllipseElementCYAttribute
@@ -97,9 +97,9 @@ JS::NonnullGCPtr<SVGAnimatedLength> SVGEllipseElement::cy() const
 {
     // FIXME: Populate the unit type when it is parsed (0 here is "unknown").
     // FIXME: Create a proper animated value when animations are supported.
-    auto base_length = SVGLength::create(realm(), 0, m_center_y.value_or(0)).release_value_but_fixme_should_propagate_errors();
-    auto anim_length = SVGLength::create(realm(), 0, m_center_y.value_or(0)).release_value_but_fixme_should_propagate_errors();
-    return SVGAnimatedLength::create(realm(), move(base_length), move(anim_length)).release_value_but_fixme_should_propagate_errors();
+    auto base_length = SVGLength::create(realm(), 0, m_center_y.value_or(0));
+    auto anim_length = SVGLength::create(realm(), 0, m_center_y.value_or(0));
+    return SVGAnimatedLength::create(realm(), move(base_length), move(anim_length));
 }
 
 // https://www.w3.org/TR/SVG11/shapes.html#EllipseElementRXAttribute
@@ -107,9 +107,9 @@ JS::NonnullGCPtr<SVGAnimatedLength> SVGEllipseElement::rx() const
 {
     // FIXME: Populate the unit type when it is parsed (0 here is "unknown").
     // FIXME: Create a proper animated value when animations are supported.
-    auto base_length = SVGLength::create(realm(), 0, m_radius_x.value_or(0)).release_value_but_fixme_should_propagate_errors();
-    auto anim_length = SVGLength::create(realm(), 0, m_radius_x.value_or(0)).release_value_but_fixme_should_propagate_errors();
-    return SVGAnimatedLength::create(realm(), move(base_length), move(anim_length)).release_value_but_fixme_should_propagate_errors();
+    auto base_length = SVGLength::create(realm(), 0, m_radius_x.value_or(0));
+    auto anim_length = SVGLength::create(realm(), 0, m_radius_x.value_or(0));
+    return SVGAnimatedLength::create(realm(), move(base_length), move(anim_length));
 }
 
 // https://www.w3.org/TR/SVG11/shapes.html#EllipseElementRYAttribute
@@ -117,9 +117,9 @@ JS::NonnullGCPtr<SVGAnimatedLength> SVGEllipseElement::ry() const
 {
     // FIXME: Populate the unit type when it is parsed (0 here is "unknown").
     // FIXME: Create a proper animated value when animations are supported.
-    auto base_length = SVGLength::create(realm(), 0, m_radius_y.value_or(0)).release_value_but_fixme_should_propagate_errors();
-    auto anim_length = SVGLength::create(realm(), 0, m_radius_y.value_or(0)).release_value_but_fixme_should_propagate_errors();
-    return SVGAnimatedLength::create(realm(), move(base_length), move(anim_length)).release_value_but_fixme_should_propagate_errors();
+    auto base_length = SVGLength::create(realm(), 0, m_radius_y.value_or(0));
+    auto anim_length = SVGLength::create(realm(), 0, m_radius_y.value_or(0));
+    return SVGAnimatedLength::create(realm(), move(base_length), move(anim_length));
 }
 
 }

--- a/Userland/Libraries/LibWeb/SVG/SVGForeignObjectElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGForeignObjectElement.cpp
@@ -28,10 +28,10 @@ void SVGForeignObjectElement::initialize(JS::Realm& realm)
     set_prototype(&Bindings::ensure_web_prototype<Bindings::SVGForeignObjectElementPrototype>(realm, "SVGForeignObjectElement"));
 
     // FIXME: These never actually get updated!
-    m_x = MUST(SVGAnimatedLength::create(realm, MUST(SVGLength::create(realm, 0, 0)), MUST(SVGLength::create(realm, 0, 0))));
-    m_y = MUST(SVGAnimatedLength::create(realm, MUST(SVGLength::create(realm, 0, 0)), MUST(SVGLength::create(realm, 0, 0))));
-    m_width = MUST(SVGAnimatedLength::create(realm, MUST(SVGLength::create(realm, 0, 0)), MUST(SVGLength::create(realm, 0, 0))));
-    m_height = MUST(SVGAnimatedLength::create(realm, MUST(SVGLength::create(realm, 0, 0)), MUST(SVGLength::create(realm, 0, 0))));
+    m_x = SVGAnimatedLength::create(realm, SVGLength::create(realm, 0, 0), SVGLength::create(realm, 0, 0));
+    m_y = SVGAnimatedLength::create(realm, SVGLength::create(realm, 0, 0), SVGLength::create(realm, 0, 0));
+    m_width = SVGAnimatedLength::create(realm, SVGLength::create(realm, 0, 0), SVGLength::create(realm, 0, 0));
+    m_height = SVGAnimatedLength::create(realm, SVGLength::create(realm, 0, 0), SVGLength::create(realm, 0, 0));
 }
 
 void SVGForeignObjectElement::visit_edges(Cell::Visitor& visitor)

--- a/Userland/Libraries/LibWeb/SVG/SVGLength.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGLength.cpp
@@ -9,9 +9,9 @@
 
 namespace Web::SVG {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<SVGLength>> SVGLength::create(JS::Realm& realm, u8 unit_type, float value)
+JS::NonnullGCPtr<SVGLength> SVGLength::create(JS::Realm& realm, u8 unit_type, float value)
 {
-    return MUST_OR_THROW_OOM(realm.heap().allocate<SVGLength>(realm, realm, unit_type, value));
+    return realm.heap().allocate<SVGLength>(realm, realm, unit_type, value);
 }
 
 SVGLength::SVGLength(JS::Realm& realm, u8 unit_type, float value)

--- a/Userland/Libraries/LibWeb/SVG/SVGLength.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGLength.h
@@ -16,7 +16,7 @@ class SVGLength : public Bindings::PlatformObject {
     WEB_PLATFORM_OBJECT(SVGLength, Bindings::PlatformObject);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<SVGLength>> create(JS::Realm&, u8 unit_type, float value);
+    [[nodiscard]] static JS::NonnullGCPtr<SVGLength> create(JS::Realm&, u8 unit_type, float value);
     virtual ~SVGLength() override;
 
     u8 unit_type() const { return m_unit_type; }

--- a/Userland/Libraries/LibWeb/SVG/SVGLineElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGLineElement.cpp
@@ -67,9 +67,9 @@ JS::NonnullGCPtr<SVGAnimatedLength> SVGLineElement::x1() const
 {
     // FIXME: Populate the unit type when it is parsed (0 here is "unknown").
     // FIXME: Create a proper animated value when animations are supported.
-    auto base_length = SVGLength::create(realm(), 0, m_x1.value_or(0)).release_value_but_fixme_should_propagate_errors();
-    auto anim_length = SVGLength::create(realm(), 0, m_x1.value_or(0)).release_value_but_fixme_should_propagate_errors();
-    return SVGAnimatedLength::create(realm(), move(base_length), move(anim_length)).release_value_but_fixme_should_propagate_errors();
+    auto base_length = SVGLength::create(realm(), 0, m_x1.value_or(0));
+    auto anim_length = SVGLength::create(realm(), 0, m_x1.value_or(0));
+    return SVGAnimatedLength::create(realm(), move(base_length), move(anim_length));
 }
 
 // https://www.w3.org/TR/SVG11/shapes.html#LineElementY1Attribute
@@ -77,9 +77,9 @@ JS::NonnullGCPtr<SVGAnimatedLength> SVGLineElement::y1() const
 {
     // FIXME: Populate the unit type when it is parsed (0 here is "unknown").
     // FIXME: Create a proper animated value when animations are supported.
-    auto base_length = SVGLength::create(realm(), 0, m_y1.value_or(0)).release_value_but_fixme_should_propagate_errors();
-    auto anim_length = SVGLength::create(realm(), 0, m_y1.value_or(0)).release_value_but_fixme_should_propagate_errors();
-    return SVGAnimatedLength::create(realm(), move(base_length), move(anim_length)).release_value_but_fixme_should_propagate_errors();
+    auto base_length = SVGLength::create(realm(), 0, m_y1.value_or(0));
+    auto anim_length = SVGLength::create(realm(), 0, m_y1.value_or(0));
+    return SVGAnimatedLength::create(realm(), move(base_length), move(anim_length));
 }
 
 // https://www.w3.org/TR/SVG11/shapes.html#LineElementX2Attribute
@@ -87,9 +87,9 @@ JS::NonnullGCPtr<SVGAnimatedLength> SVGLineElement::x2() const
 {
     // FIXME: Populate the unit type when it is parsed (0 here is "unknown").
     // FIXME: Create a proper animated value when animations are supported.
-    auto base_length = SVGLength::create(realm(), 0, m_x2.value_or(0)).release_value_but_fixme_should_propagate_errors();
-    auto anim_length = SVGLength::create(realm(), 0, m_x2.value_or(0)).release_value_but_fixme_should_propagate_errors();
-    return SVGAnimatedLength::create(realm(), move(base_length), move(anim_length)).release_value_but_fixme_should_propagate_errors();
+    auto base_length = SVGLength::create(realm(), 0, m_x2.value_or(0));
+    auto anim_length = SVGLength::create(realm(), 0, m_x2.value_or(0));
+    return SVGAnimatedLength::create(realm(), move(base_length), move(anim_length));
 }
 
 // https://www.w3.org/TR/SVG11/shapes.html#LineElementY2Attribute
@@ -97,9 +97,9 @@ JS::NonnullGCPtr<SVGAnimatedLength> SVGLineElement::y2() const
 {
     // FIXME: Populate the unit type when it is parsed (0 here is "unknown").
     // FIXME: Create a proper animated value when animations are supported.
-    auto base_length = SVGLength::create(realm(), 0, m_y2.value_or(0)).release_value_but_fixme_should_propagate_errors();
-    auto anim_length = SVGLength::create(realm(), 0, m_y2.value_or(0)).release_value_but_fixme_should_propagate_errors();
-    return SVGAnimatedLength::create(realm(), move(base_length), move(anim_length)).release_value_but_fixme_should_propagate_errors();
+    auto base_length = SVGLength::create(realm(), 0, m_y2.value_or(0));
+    auto anim_length = SVGLength::create(realm(), 0, m_y2.value_or(0));
+    return SVGAnimatedLength::create(realm(), move(base_length), move(anim_length));
 }
 
 }

--- a/Userland/Libraries/LibWeb/SVG/SVGRectElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGRectElement.cpp
@@ -164,9 +164,9 @@ JS::NonnullGCPtr<SVGAnimatedLength> SVGRectElement::x() const
 {
     // FIXME: Populate the unit type when it is parsed (0 here is "unknown").
     // FIXME: Create a proper animated value when animations are supported.
-    auto base_length = SVGLength::create(realm(), 0, m_x.value_or(0)).release_value_but_fixme_should_propagate_errors();
-    auto anim_length = SVGLength::create(realm(), 0, m_x.value_or(0)).release_value_but_fixme_should_propagate_errors();
-    return SVGAnimatedLength::create(realm(), move(base_length), move(anim_length)).release_value_but_fixme_should_propagate_errors();
+    auto base_length = SVGLength::create(realm(), 0, m_x.value_or(0));
+    auto anim_length = SVGLength::create(realm(), 0, m_x.value_or(0));
+    return SVGAnimatedLength::create(realm(), move(base_length), move(anim_length));
 }
 
 // https://www.w3.org/TR/SVG11/shapes.html#RectElementYAttribute
@@ -174,9 +174,9 @@ JS::NonnullGCPtr<SVGAnimatedLength> SVGRectElement::y() const
 {
     // FIXME: Populate the unit type when it is parsed (0 here is "unknown").
     // FIXME: Create a proper animated value when animations are supported.
-    auto base_length = SVGLength::create(realm(), 0, m_y.value_or(0)).release_value_but_fixme_should_propagate_errors();
-    auto anim_length = SVGLength::create(realm(), 0, m_y.value_or(0)).release_value_but_fixme_should_propagate_errors();
-    return SVGAnimatedLength::create(realm(), move(base_length), move(anim_length)).release_value_but_fixme_should_propagate_errors();
+    auto base_length = SVGLength::create(realm(), 0, m_y.value_or(0));
+    auto anim_length = SVGLength::create(realm(), 0, m_y.value_or(0));
+    return SVGAnimatedLength::create(realm(), move(base_length), move(anim_length));
 }
 
 // https://www.w3.org/TR/SVG11/shapes.html#RectElementWidthAttribute
@@ -184,9 +184,9 @@ JS::NonnullGCPtr<SVGAnimatedLength> SVGRectElement::width() const
 {
     // FIXME: Populate the unit type when it is parsed (0 here is "unknown").
     // FIXME: Create a proper animated value when animations are supported.
-    auto base_length = SVGLength::create(realm(), 0, m_width.value_or(0)).release_value_but_fixme_should_propagate_errors();
-    auto anim_length = SVGLength::create(realm(), 0, m_width.value_or(0)).release_value_but_fixme_should_propagate_errors();
-    return SVGAnimatedLength::create(realm(), move(base_length), move(anim_length)).release_value_but_fixme_should_propagate_errors();
+    auto base_length = SVGLength::create(realm(), 0, m_width.value_or(0));
+    auto anim_length = SVGLength::create(realm(), 0, m_width.value_or(0));
+    return SVGAnimatedLength::create(realm(), move(base_length), move(anim_length));
 }
 
 // https://www.w3.org/TR/SVG11/shapes.html#RectElementHeightAttribute
@@ -194,9 +194,9 @@ JS::NonnullGCPtr<SVGAnimatedLength> SVGRectElement::height() const
 {
     // FIXME: Populate the unit type when it is parsed (0 here is "unknown").
     // FIXME: Create a proper animated value when animations are supported.
-    auto base_length = SVGLength::create(realm(), 0, m_height.value_or(0)).release_value_but_fixme_should_propagate_errors();
-    auto anim_length = SVGLength::create(realm(), 0, m_height.value_or(0)).release_value_but_fixme_should_propagate_errors();
-    return SVGAnimatedLength::create(realm(), move(base_length), move(anim_length)).release_value_but_fixme_should_propagate_errors();
+    auto base_length = SVGLength::create(realm(), 0, m_height.value_or(0));
+    auto anim_length = SVGLength::create(realm(), 0, m_height.value_or(0));
+    return SVGAnimatedLength::create(realm(), move(base_length), move(anim_length));
 }
 
 // https://www.w3.org/TR/SVG11/shapes.html#RectElementRXAttribute
@@ -204,9 +204,9 @@ JS::NonnullGCPtr<SVGAnimatedLength> SVGRectElement::rx() const
 {
     // FIXME: Populate the unit type when it is parsed (0 here is "unknown").
     // FIXME: Create a proper animated value when animations are supported.
-    auto base_length = SVGLength::create(realm(), 0, m_radius_x.value_or(0)).release_value_but_fixme_should_propagate_errors();
-    auto anim_length = SVGLength::create(realm(), 0, m_radius_x.value_or(0)).release_value_but_fixme_should_propagate_errors();
-    return SVGAnimatedLength::create(realm(), move(base_length), move(anim_length)).release_value_but_fixme_should_propagate_errors();
+    auto base_length = SVGLength::create(realm(), 0, m_radius_x.value_or(0));
+    auto anim_length = SVGLength::create(realm(), 0, m_radius_x.value_or(0));
+    return SVGAnimatedLength::create(realm(), move(base_length), move(anim_length));
 }
 
 // https://www.w3.org/TR/SVG11/shapes.html#RectElementRYAttribute
@@ -214,9 +214,9 @@ JS::NonnullGCPtr<SVGAnimatedLength> SVGRectElement::ry() const
 {
     // FIXME: Populate the unit type when it is parsed (0 here is "unknown").
     // FIXME: Create a proper animated value when animations are supported.
-    auto base_length = SVGLength::create(realm(), 0, m_radius_y.value_or(0)).release_value_but_fixme_should_propagate_errors();
-    auto anim_length = SVGLength::create(realm(), 0, m_radius_y.value_or(0)).release_value_but_fixme_should_propagate_errors();
-    return SVGAnimatedLength::create(realm(), move(base_length), move(anim_length)).release_value_but_fixme_should_propagate_errors();
+    auto base_length = SVGLength::create(realm(), 0, m_radius_y.value_or(0));
+    auto anim_length = SVGLength::create(realm(), 0, m_radius_y.value_or(0));
+    return SVGAnimatedLength::create(realm(), move(base_length), move(anim_length));
 }
 
 }

--- a/Userland/Libraries/LibWeb/SVG/SVGUseElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGUseElement.cpp
@@ -27,12 +27,12 @@ void SVGUseElement::initialize(JS::Realm& realm)
     set_prototype(&Bindings::ensure_web_prototype<Bindings::SVGUseElementPrototype>(realm, "SVGUseElement"));
 
     // The shadow tree is open (inspectable by script), but read-only.
-    auto shadow_root = MUST(heap().allocate<DOM::ShadowRoot>(realm, document(), *this, Bindings::ShadowRootMode::Open));
+    auto shadow_root = heap().allocate<DOM::ShadowRoot>(realm, document(), *this, Bindings::ShadowRootMode::Open);
 
     // The user agent must create a use-element shadow tree whose host is the ‘use’ element itself
     set_shadow_root(shadow_root);
 
-    m_document_observer = MUST(realm.heap().allocate<DOM::DocumentObserver>(realm, realm, document()));
+    m_document_observer = realm.heap().allocate<DOM::DocumentObserver>(realm, realm, document());
     m_document_observer->document_completely_loaded = [this]() {
         clone_element_tree_as_our_shadow_tree(referenced_element());
     };
@@ -136,9 +136,9 @@ JS::NonnullGCPtr<SVGAnimatedLength> SVGUseElement::x() const
 {
     // FIXME: Populate the unit type when it is parsed (0 here is "unknown").
     // FIXME: Create a proper animated value when animations are supported.
-    auto base_length = SVGLength::create(realm(), 0, m_x.value_or(0)).release_value_but_fixme_should_propagate_errors();
-    auto anim_length = SVGLength::create(realm(), 0, m_x.value_or(0)).release_value_but_fixme_should_propagate_errors();
-    return SVGAnimatedLength::create(realm(), move(base_length), move(anim_length)).release_value_but_fixme_should_propagate_errors();
+    auto base_length = SVGLength::create(realm(), 0, m_x.value_or(0));
+    auto anim_length = SVGLength::create(realm(), 0, m_x.value_or(0));
+    return SVGAnimatedLength::create(realm(), move(base_length), move(anim_length));
 }
 
 // https://www.w3.org/TR/SVG11/shapes.html#RectElementYAttribute
@@ -146,9 +146,9 @@ JS::NonnullGCPtr<SVGAnimatedLength> SVGUseElement::y() const
 {
     // FIXME: Populate the unit type when it is parsed (0 here is "unknown").
     // FIXME: Create a proper animated value when animations are supported.
-    auto base_length = SVGLength::create(realm(), 0, m_y.value_or(0)).release_value_but_fixme_should_propagate_errors();
-    auto anim_length = SVGLength::create(realm(), 0, m_y.value_or(0)).release_value_but_fixme_should_propagate_errors();
-    return SVGAnimatedLength::create(realm(), move(base_length), move(anim_length)).release_value_but_fixme_should_propagate_errors();
+    auto base_length = SVGLength::create(realm(), 0, m_y.value_or(0));
+    auto anim_length = SVGLength::create(realm(), 0, m_y.value_or(0));
+    return SVGAnimatedLength::create(realm(), move(base_length), move(anim_length));
 }
 
 JS::NonnullGCPtr<SVGAnimatedLength> SVGUseElement::width() const

--- a/Userland/Libraries/LibWeb/Selection/Selection.cpp
+++ b/Userland/Libraries/LibWeb/Selection/Selection.cpp
@@ -11,9 +11,9 @@
 
 namespace Web::Selection {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<Selection>> Selection::create(JS::NonnullGCPtr<JS::Realm> realm, JS::NonnullGCPtr<DOM::Document> document)
+JS::NonnullGCPtr<Selection> Selection::create(JS::NonnullGCPtr<JS::Realm> realm, JS::NonnullGCPtr<DOM::Document> document)
 {
-    return MUST_OR_THROW_OOM(realm->heap().allocate<Selection>(realm, realm, document));
+    return realm->heap().allocate<Selection>(realm, realm, document);
 }
 
 Selection::Selection(JS::NonnullGCPtr<JS::Realm> realm, JS::NonnullGCPtr<DOM::Document> document)
@@ -185,7 +185,7 @@ WebIDL::ExceptionOr<void> Selection::collapse(JS::GCPtr<DOM::Node> node, unsigne
         return {};
 
     // 4. Otherwise, let newRange be a new range.
-    auto new_range = TRY(DOM::Range::create(*m_document));
+    auto new_range = DOM::Range::create(*m_document);
 
     // 5. Set the start the start and the end of newRange to (node, offset).
     TRY(new_range->set_start(*node, offset));
@@ -212,7 +212,7 @@ WebIDL::ExceptionOr<void> Selection::collapse_to_start()
     }
 
     // 2. Otherwise, it must create a new range
-    auto new_range = TRY(DOM::Range::create(*m_document));
+    auto new_range = DOM::Range::create(*m_document);
 
     // 3. Set the start both its start and end to the start of this's range
     TRY(new_range->set_start(*anchor_node(), m_range->start_offset()));
@@ -232,7 +232,7 @@ WebIDL::ExceptionOr<void> Selection::collapse_to_end()
     }
 
     // 2. Otherwise, it must create a new range
-    auto new_range = TRY(DOM::Range::create(*m_document));
+    auto new_range = DOM::Range::create(*m_document);
 
     // 3. Set the start both its start and end to the start of this's range
     TRY(new_range->set_start(*anchor_node(), m_range->end_offset()));
@@ -264,7 +264,7 @@ WebIDL::ExceptionOr<void> Selection::extend(JS::NonnullGCPtr<DOM::Node> node, un
     auto new_focus_offset = offset;
 
     // 4. Let newRange be a new range.
-    auto new_range = TRY(DOM::Range::create(*m_document));
+    auto new_range = DOM::Range::create(*m_document);
 
     // 5. If node's root is not the same as the this's range's root, set the start newRange's start and end to newFocus.
     if (&node->root() != &m_range->start_container()->root()) {
@@ -313,7 +313,7 @@ WebIDL::ExceptionOr<void> Selection::set_base_and_extent(JS::NonnullGCPtr<DOM::N
     // 3. Let anchor be the boundary point (anchorNode, anchorOffset) and let focus be the boundary point (focusNode, focusOffset).
 
     // 4. Let newRange be a new range.
-    auto new_range = TRY(DOM::Range::create(*m_document));
+    auto new_range = DOM::Range::create(*m_document);
 
     // 5. If anchor is before focus, set the start the newRange's start to anchor and its end to focus. Otherwise, set the start them to focus and anchor respectively.
     auto position_of_anchor_relative_to_focus = DOM::position_of_boundary_point_relative_to_other_boundary_point(anchor_node, anchor_offset, focus_node, focus_offset);
@@ -346,7 +346,7 @@ WebIDL::ExceptionOr<void> Selection::select_all_children(JS::NonnullGCPtr<DOM::N
         return {};
 
     // 2. Let newRange be a new range and childCount be the number of children of node.
-    auto new_range = TRY(DOM::Range::create(*m_document));
+    auto new_range = DOM::Range::create(*m_document);
     auto child_count = node->child_count();
 
     // 3. Set newRange's start to (node, 0).

--- a/Userland/Libraries/LibWeb/Selection/Selection.h
+++ b/Userland/Libraries/LibWeb/Selection/Selection.h
@@ -15,7 +15,7 @@ class Selection final : public Bindings::PlatformObject {
     WEB_PLATFORM_OBJECT(Selection, Bindings::PlatformObject);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<Selection>> create(JS::NonnullGCPtr<JS::Realm>, JS::NonnullGCPtr<DOM::Document>);
+    [[nodiscard]] static JS::NonnullGCPtr<Selection> create(JS::NonnullGCPtr<JS::Realm>, JS::NonnullGCPtr<DOM::Document>);
 
     virtual ~Selection() override;
 

--- a/Userland/Libraries/LibWeb/Streams/AbstractOperations.cpp
+++ b/Userland/Libraries/LibWeb/Streams/AbstractOperations.cpp
@@ -41,7 +41,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<ReadableStreamDefaultReader>> acquire_reada
     auto& realm = stream.realm();
 
     // 1. Let reader be a new ReadableStreamDefaultReader.
-    auto reader = TRY(realm.heap().allocate<ReadableStreamDefaultReader>(realm, realm));
+    auto reader = realm.heap().allocate<ReadableStreamDefaultReader>(realm, realm);
 
     // 2. Perform ? SetUpReadableStreamDefaultReader(reader, stream).
     TRY(set_up_readable_stream_default_reader(reader, stream));
@@ -56,7 +56,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<ReadableStreamBYOBReader>> acquire_readable
     auto& realm = stream.realm();
 
     // 1. Let reader be a new ReadableStreamBYOBReader.
-    auto reader = TRY(realm.heap().allocate<ReadableStreamBYOBReader>(realm, realm));
+    auto reader = realm.heap().allocate<ReadableStreamBYOBReader>(realm, realm);
 
     // 2. Perform ? SetUpReadableStreamBYOBReader(reader, stream).
     TRY(set_up_readable_stream_byob_reader(reader, stream));
@@ -834,7 +834,7 @@ WebIDL::ExceptionOr<void> set_up_readable_stream_default_controller_from_underly
     auto& realm = stream.realm();
 
     // 1. Let controller be a new ReadableStreamDefaultController.
-    auto controller = MUST_OR_THROW_OOM(stream.heap().allocate<ReadableStreamDefaultController>(realm, realm));
+    auto controller = stream.heap().allocate<ReadableStreamDefaultController>(realm, realm);
 
     // 2. Let startAlgorithm be an algorithm that returns undefined.
     StartAlgorithm start_algorithm = [] { return JS::js_undefined(); };
@@ -1172,13 +1172,13 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<ReadableStream>> create_readable_stream(JS:
     VERIFY(is_non_negative_number(JS::Value { *high_water_mark }));
 
     // 4. Let stream be a new ReadableStream.
-    auto stream = MUST_OR_THROW_OOM(realm.heap().allocate<ReadableStream>(realm, realm));
+    auto stream = realm.heap().allocate<ReadableStream>(realm, realm);
 
     // 5. Perform ! InitializeReadableStream(stream).
     initialize_readable_stream(*stream);
 
     // 6. Let controller be a new ReadableStreamDefaultController.
-    auto controller = MUST_OR_THROW_OOM(realm.heap().allocate<ReadableStreamDefaultController>(realm, realm));
+    auto controller = realm.heap().allocate<ReadableStreamDefaultController>(realm, realm);
 
     // 7. Perform ? SetUpReadableStreamDefaultController(stream, controller, startAlgorithm, pullAlgorithm, cancelAlgorithm, highWaterMark, sizeAlgorithm).
     TRY(set_up_readable_stream_default_controller(*stream, *controller, move(start_algorithm), move(pull_algorithm), move(cancel_algorithm), *high_water_mark, move(*size_algorithm)));
@@ -1194,13 +1194,13 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<WritableStream>> create_writable_stream(JS:
     VERIFY(is_non_negative_number(JS::Value { high_water_mark }));
 
     // 2. Let stream be a new WritableStream.
-    auto stream = MUST_OR_THROW_OOM(realm.heap().allocate<WritableStream>(realm, realm));
+    auto stream = realm.heap().allocate<WritableStream>(realm, realm);
 
     // 3. Perform ! InitializeWritableStream(stream).
     initialize_writable_stream(*stream);
 
     // 4. Let controller be a new WritableStreamDefaultController.
-    auto controller = MUST_OR_THROW_OOM(realm.heap().allocate<WritableStreamDefaultController>(realm, realm));
+    auto controller = realm.heap().allocate<WritableStreamDefaultController>(realm, realm);
 
     // 5. Perform ? SetUpWritableStreamDefaultController(stream, controller, startAlgorithm, writeAlgorithm, closeAlgorithm, abortAlgorithm, highWaterMark, sizeAlgorithm).
     TRY(set_up_writable_stream_default_controller(*stream, *controller, move(start_algorithm), move(write_algorithm), move(close_algorithm), move(abort_algorithm), high_water_mark, move(size_algorithm)));
@@ -1252,7 +1252,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<WritableStreamDefaultWriter>> acquire_writa
     auto& realm = stream.realm();
 
     // 1. Let writer be a new WritableStreamDefaultWriter.
-    auto writer = MUST_OR_THROW_OOM(stream.heap().allocate<WritableStreamDefaultWriter>(realm, realm));
+    auto writer = stream.heap().allocate<WritableStreamDefaultWriter>(realm, realm);
 
     // 2. Perform ? SetUpWritableStreamDefaultWriter(writer, stream).
     TRY(set_up_writable_stream_default_writer(*writer, stream));
@@ -1730,7 +1730,7 @@ WebIDL::ExceptionOr<void> set_up_readable_stream_controller_with_byte_reading_su
 
     // 4. Perform ! InitializeReadableStream(stream).
     // 5. Let controller be a new ReadableByteStreamController.
-    auto controller = MUST_OR_THROW_OOM(stream.heap().allocate<ReadableByteStreamController>(realm, realm));
+    auto controller = stream.heap().allocate<ReadableByteStreamController>(realm, realm);
 
     // 6. Perform ! SetUpReadableByteStreamController(stream, controller, startAlgorithm, pullAlgorithmWrapper, cancelAlgorithmWrapper, highWaterMark, undefined).
     TRY(set_up_readable_byte_stream_controller(stream, controller, move(start_algorithm), move(pull_algorithm_wrapper), move(cancel_algorithm_wrapper), high_water_mark, JS::js_undefined()));
@@ -2418,7 +2418,7 @@ WebIDL::ExceptionOr<void> set_up_writable_stream_default_controller(WritableStre
     reset_queue(controller);
 
     // 6. Set controller.[[signal]] to a new AbortSignal.
-    controller.set_signal(MUST_OR_THROW_OOM(realm.heap().allocate<DOM::AbortSignal>(realm, realm)));
+    controller.set_signal(realm.heap().allocate<DOM::AbortSignal>(realm, realm));
 
     // 7. Set controller.[[started]] to false.
     controller.set_started(false);
@@ -2489,7 +2489,7 @@ WebIDL::ExceptionOr<void> set_up_writable_stream_default_controller_from_underly
     auto& realm = stream.realm();
 
     // 1. Let controller be a new WritableStreamDefaultController.
-    auto controller = MUST_OR_THROW_OOM(realm.heap().allocate<WritableStreamDefaultController>(realm, realm));
+    auto controller = realm.heap().allocate<WritableStreamDefaultController>(realm, realm);
 
     // 2. Let startAlgorithm be an algorithm that returns undefined.
     StartAlgorithm start_algorithm = [] { return JS::js_undefined(); };
@@ -2916,7 +2916,7 @@ WebIDL::ExceptionOr<void> set_up_transform_stream_default_controller_from_transf
     auto& vm = realm.vm();
 
     // 1. Let controller be a new TransformStreamDefaultController.
-    auto controller = MUST_OR_THROW_OOM(realm.heap().allocate<TransformStreamDefaultController>(realm, realm));
+    auto controller = realm.heap().allocate<TransformStreamDefaultController>(realm, realm);
 
     // 2. Let transformAlgorithm be the following steps, taking a chunk argument:
     TransformAlgorithm transform_algorithm = [controller, &realm, &vm](JS::Value chunk) {
@@ -3308,7 +3308,7 @@ WebIDL::ExceptionOr<void> set_up_readable_byte_stream_controller_from_underlying
     auto& realm = stream.realm();
 
     // 1. Let controller be a new ReadableByteStreamController.
-    auto controller = MUST_OR_THROW_OOM(stream.heap().allocate<ReadableByteStreamController>(realm, realm));
+    auto controller = stream.heap().allocate<ReadableByteStreamController>(realm, realm);
 
     // 2. Let startAlgorithm be an algorithm that returns undefined.
     StartAlgorithm start_algorithm = [] { return JS::js_undefined(); };

--- a/Userland/Libraries/LibWeb/Streams/ByteLengthQueuingStrategy.cpp
+++ b/Userland/Libraries/LibWeb/Streams/ByteLengthQueuingStrategy.cpp
@@ -18,7 +18,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<ByteLengthQueuingStrategy>> ByteLengthQueui
 {
     // The new ByteLengthQueuingStrategy(init) constructor steps are:
     // 1. Set this.[[highWaterMark]] to init["highWaterMark"].
-    return MUST_OR_THROW_OOM(realm.heap().allocate<ByteLengthQueuingStrategy>(realm, realm, init.high_water_mark));
+    return realm.heap().allocate<ByteLengthQueuingStrategy>(realm, realm, init.high_water_mark);
 }
 
 ByteLengthQueuingStrategy::ByteLengthQueuingStrategy(JS::Realm& realm, double high_water_mark)

--- a/Userland/Libraries/LibWeb/Streams/CountQueuingStrategy.cpp
+++ b/Userland/Libraries/LibWeb/Streams/CountQueuingStrategy.cpp
@@ -18,7 +18,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<CountQueuingStrategy>> CountQueuingStrategy
 {
     // The new CountQueuingStrategy(init) constructor steps are:
     // 1. Set this.[[highWaterMark]] to init["highWaterMark"].
-    return MUST_OR_THROW_OOM(realm.heap().allocate<CountQueuingStrategy>(realm, realm, init.high_water_mark));
+    return realm.heap().allocate<CountQueuingStrategy>(realm, realm, init.high_water_mark);
 }
 
 CountQueuingStrategy::CountQueuingStrategy(JS::Realm& realm, double high_water_mark)

--- a/Userland/Libraries/LibWeb/Streams/ReadableStream.cpp
+++ b/Userland/Libraries/LibWeb/Streams/ReadableStream.cpp
@@ -23,7 +23,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<ReadableStream>> ReadableStream::construct_
 {
     auto& vm = realm.vm();
 
-    auto readable_stream = MUST_OR_THROW_OOM(realm.heap().allocate<ReadableStream>(realm, realm));
+    auto readable_stream = realm.heap().allocate<ReadableStream>(realm, realm);
 
     // 1. If underlyingSource is missing, set it to null.
     auto underlying_source = underlying_source_object.has_value() ? JS::Value(underlying_source_object.value().ptr()) : JS::js_null();

--- a/Userland/Libraries/LibWeb/Streams/ReadableStreamDefaultReader.cpp
+++ b/Userland/Libraries/LibWeb/Streams/ReadableStreamDefaultReader.cpp
@@ -33,7 +33,7 @@ void ReadLoopReadRequest::visit_edges(Visitor& visitor)
 // https://streams.spec.whatwg.org/#default-reader-constructor
 WebIDL::ExceptionOr<JS::NonnullGCPtr<ReadableStreamDefaultReader>> ReadableStreamDefaultReader::construct_impl(JS::Realm& realm, JS::NonnullGCPtr<ReadableStream> stream)
 {
-    auto reader = TRY(realm.heap().allocate<ReadableStreamDefaultReader>(realm, realm));
+    auto reader = realm.heap().allocate<ReadableStreamDefaultReader>(realm, realm);
 
     // 1. Perform ? SetUpReadableStreamDefaultReader(this, stream);
     TRY(set_up_readable_stream_default_reader(reader, *stream));

--- a/Userland/Libraries/LibWeb/Streams/TransformStream.cpp
+++ b/Userland/Libraries/LibWeb/Streams/TransformStream.cpp
@@ -20,7 +20,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<TransformStream>> TransformStream::construc
 {
     auto& vm = realm.vm();
 
-    auto stream = MUST_OR_THROW_OOM(realm.heap().allocate<TransformStream>(realm, realm));
+    auto stream = realm.heap().allocate<TransformStream>(realm, realm);
 
     // 1. If transformer is missing, set it to null.
     auto transformer = transformer_object.has_value() ? JS::Value { transformer_object.value().ptr() } : JS::js_null();

--- a/Userland/Libraries/LibWeb/Streams/WritableStream.cpp
+++ b/Userland/Libraries/LibWeb/Streams/WritableStream.cpp
@@ -21,7 +21,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<WritableStream>> WritableStream::construct_
 {
     auto& vm = realm.vm();
 
-    auto writable_stream = MUST_OR_THROW_OOM(realm.heap().allocate<WritableStream>(realm, realm));
+    auto writable_stream = realm.heap().allocate<WritableStream>(realm, realm);
 
     // 1. If underlyingSink is missing, set it to null.
     auto underlying_sink = underlying_sink_object.has_value() ? JS::Value(underlying_sink_object.value().ptr()) : JS::js_null();

--- a/Userland/Libraries/LibWeb/Streams/WritableStreamDefaultWriter.cpp
+++ b/Userland/Libraries/LibWeb/Streams/WritableStreamDefaultWriter.cpp
@@ -16,7 +16,7 @@ namespace Web::Streams {
 
 WebIDL::ExceptionOr<JS::NonnullGCPtr<WritableStreamDefaultWriter>> WritableStreamDefaultWriter::construct_impl(JS::Realm& realm, JS::NonnullGCPtr<WritableStream> stream)
 {
-    auto writer = MUST_OR_THROW_OOM(realm.heap().allocate<WritableStreamDefaultWriter>(realm, realm));
+    auto writer = realm.heap().allocate<WritableStreamDefaultWriter>(realm, realm);
 
     // 1. Perform ? SetUpWritableStreamDefaultWriter(this, stream).
     TRY(set_up_writable_stream_default_writer(*writer, stream));

--- a/Userland/Libraries/LibWeb/UIEvents/FocusEvent.cpp
+++ b/Userland/Libraries/LibWeb/UIEvents/FocusEvent.cpp
@@ -11,7 +11,7 @@ namespace Web::UIEvents {
 
 WebIDL::ExceptionOr<JS::NonnullGCPtr<FocusEvent>> FocusEvent::construct_impl(JS::Realm& realm, FlyString const& event_name, FocusEventInit const& event_init)
 {
-    return MUST_OR_THROW_OOM(realm.heap().allocate<FocusEvent>(realm, realm, event_name, event_init));
+    return realm.heap().allocate<FocusEvent>(realm, realm, event_name, event_init);
 }
 
 FocusEvent::FocusEvent(JS::Realm& realm, FlyString const& event_name, FocusEventInit const& event_init)

--- a/Userland/Libraries/LibWeb/UIEvents/KeyboardEvent.cpp
+++ b/Userland/Libraries/LibWeb/UIEvents/KeyboardEvent.cpp
@@ -503,12 +503,10 @@ static DOMKeyLocation get_event_location(KeyCode platform_key, unsigned modifier
     return DOMKeyLocation::Standard;
 }
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<KeyboardEvent>> KeyboardEvent::create_from_platform_event(JS::Realm& realm, FlyString const& event_name, KeyCode platform_key, unsigned modifiers, u32 code_point)
+JS::NonnullGCPtr<KeyboardEvent> KeyboardEvent::create_from_platform_event(JS::Realm& realm, FlyString const& event_name, KeyCode platform_key, unsigned modifiers, u32 code_point)
 {
-    auto& vm = realm.vm();
-
-    auto event_key = TRY_OR_THROW_OOM(vm, get_event_key(platform_key, code_point));
-    auto event_code = TRY_OR_THROW_OOM(vm, get_event_code(platform_key, modifiers));
+    auto event_key = MUST(get_event_key(platform_key, code_point));
+    auto event_code = MUST(get_event_code(platform_key, modifiers));
 
     auto key_code = determine_key_code(platform_key, code_point);
     KeyboardEventInit event_init {};
@@ -542,9 +540,9 @@ bool KeyboardEvent::get_modifier_state(String const& key_arg)
     return false;
 }
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<KeyboardEvent>> KeyboardEvent::create(JS::Realm& realm, FlyString const& event_name, KeyboardEventInit const& event_init)
+JS::NonnullGCPtr<KeyboardEvent> KeyboardEvent::create(JS::Realm& realm, FlyString const& event_name, KeyboardEventInit const& event_init)
 {
-    return MUST_OR_THROW_OOM(realm.heap().allocate<KeyboardEvent>(realm, realm, event_name, event_init));
+    return realm.heap().allocate<KeyboardEvent>(realm, realm, event_name, event_init);
 }
 
 WebIDL::ExceptionOr<JS::NonnullGCPtr<KeyboardEvent>> KeyboardEvent::construct_impl(JS::Realm& realm, FlyString const& event_name, KeyboardEventInit const& event_init)

--- a/Userland/Libraries/LibWeb/UIEvents/KeyboardEvent.h
+++ b/Userland/Libraries/LibWeb/UIEvents/KeyboardEvent.h
@@ -36,9 +36,9 @@ class KeyboardEvent final : public UIEvent {
     WEB_PLATFORM_OBJECT(KeyboardEvent, UIEvent);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<KeyboardEvent>> create(JS::Realm&, FlyString const& event_name, KeyboardEventInit const& event_init = {});
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<KeyboardEvent>> construct_impl(JS::Realm&, FlyString const& event_name, KeyboardEventInit const& event_init);
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<KeyboardEvent>> create_from_platform_event(JS::Realm&, FlyString const& event_name, KeyCode, unsigned modifiers, u32 code_point);
+    [[nodiscard]] static JS::NonnullGCPtr<KeyboardEvent> create(JS::Realm&, FlyString const& event_name, KeyboardEventInit const& = {});
+    [[nodiscard]] static JS::NonnullGCPtr<KeyboardEvent> create_from_platform_event(JS::Realm&, FlyString const& event_name, KeyCode, unsigned modifiers, u32 code_point);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<KeyboardEvent>> construct_impl(JS::Realm&, FlyString const& event_name, KeyboardEventInit const&);
 
     virtual ~KeyboardEvent() override;
 

--- a/Userland/Libraries/LibWeb/UIEvents/MouseEvent.cpp
+++ b/Userland/Libraries/LibWeb/UIEvents/MouseEvent.cpp
@@ -54,9 +54,9 @@ static i16 determine_button(unsigned mouse_button)
     }
 }
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<MouseEvent>> MouseEvent::create(JS::Realm& realm, FlyString const& event_name, MouseEventInit const& event_init)
+JS::NonnullGCPtr<MouseEvent> MouseEvent::create(JS::Realm& realm, FlyString const& event_name, MouseEventInit const& event_init)
 {
-    return MUST_OR_THROW_OOM(realm.heap().allocate<MouseEvent>(realm, realm, event_name, event_init));
+    return realm.heap().allocate<MouseEvent>(realm, realm, event_name, event_init);
 }
 
 WebIDL::ExceptionOr<JS::NonnullGCPtr<MouseEvent>> MouseEvent::create_from_platform_event(JS::Realm& realm, FlyString const& event_name, CSSPixelPoint offset, CSSPixelPoint client_offset, CSSPixelPoint page_offset, unsigned buttons, unsigned mouse_button)

--- a/Userland/Libraries/LibWeb/UIEvents/MouseEvent.h
+++ b/Userland/Libraries/LibWeb/UIEvents/MouseEvent.h
@@ -29,7 +29,7 @@ class MouseEvent : public UIEvent {
     WEB_PLATFORM_OBJECT(MouseEvent, UIEvent);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<MouseEvent>> create(JS::Realm&, FlyString const& event_name, MouseEventInit const& event_init = {});
+    [[nodiscard]] static JS::NonnullGCPtr<MouseEvent> create(JS::Realm&, FlyString const& event_name, MouseEventInit const& = {});
     static WebIDL::ExceptionOr<JS::NonnullGCPtr<MouseEvent>> create_from_platform_event(JS::Realm&, FlyString const& event_name, CSSPixelPoint offset, CSSPixelPoint client_offset, CSSPixelPoint page_offset, unsigned buttons, unsigned mouse_button = 1);
 
     virtual ~MouseEvent() override;

--- a/Userland/Libraries/LibWeb/UIEvents/UIEvent.cpp
+++ b/Userland/Libraries/LibWeb/UIEvents/UIEvent.cpp
@@ -9,14 +9,14 @@
 
 namespace Web::UIEvents {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<UIEvent>> UIEvent::create(JS::Realm& realm, FlyString const& event_name)
+JS::NonnullGCPtr<UIEvent> UIEvent::create(JS::Realm& realm, FlyString const& event_name)
 {
-    return MUST_OR_THROW_OOM(realm.heap().allocate<UIEvent>(realm, realm, event_name));
+    return realm.heap().allocate<UIEvent>(realm, realm, event_name);
 }
 
 WebIDL::ExceptionOr<JS::NonnullGCPtr<UIEvent>> UIEvent::construct_impl(JS::Realm& realm, FlyString const& event_name, UIEventInit const& event_init)
 {
-    return MUST_OR_THROW_OOM(realm.heap().allocate<UIEvent>(realm, realm, event_name, event_init));
+    return realm.heap().allocate<UIEvent>(realm, realm, event_name, event_init);
 }
 
 UIEvent::UIEvent(JS::Realm& realm, FlyString const& event_name)

--- a/Userland/Libraries/LibWeb/UIEvents/UIEvent.h
+++ b/Userland/Libraries/LibWeb/UIEvents/UIEvent.h
@@ -21,7 +21,7 @@ class UIEvent : public DOM::Event {
     WEB_PLATFORM_OBJECT(UIEvent, DOM::Event);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<UIEvent>> create(JS::Realm&, FlyString const& type);
+    [[nodiscard]] static JS::NonnullGCPtr<UIEvent> create(JS::Realm&, FlyString const& type);
     static WebIDL::ExceptionOr<JS::NonnullGCPtr<UIEvent>> construct_impl(JS::Realm&, FlyString const& event_name, UIEventInit const& event_init);
 
     virtual ~UIEvent() override;

--- a/Userland/Libraries/LibWeb/UIEvents/WheelEvent.cpp
+++ b/Userland/Libraries/LibWeb/UIEvents/WheelEvent.cpp
@@ -29,9 +29,9 @@ void WheelEvent::initialize(JS::Realm& realm)
     set_prototype(&Bindings::ensure_web_prototype<Bindings::WheelEventPrototype>(realm, "WheelEvent"));
 }
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<WheelEvent>> WheelEvent::create(JS::Realm& realm, FlyString const& event_name, WheelEventInit const& event_init)
+JS::NonnullGCPtr<WheelEvent> WheelEvent::create(JS::Realm& realm, FlyString const& event_name, WheelEventInit const& event_init)
 {
-    return MUST_OR_THROW_OOM(realm.heap().allocate<WheelEvent>(realm, realm, event_name, event_init));
+    return realm.heap().allocate<WheelEvent>(realm, realm, event_name, event_init);
 }
 
 WebIDL::ExceptionOr<JS::NonnullGCPtr<WheelEvent>> WheelEvent::create_from_platform_event(JS::Realm& realm, FlyString const& event_name, CSSPixels offset_x, CSSPixels offset_y, CSSPixels client_x, CSSPixels client_y, double delta_x, double delta_y, unsigned buttons, unsigned button)

--- a/Userland/Libraries/LibWeb/UIEvents/WheelEvent.h
+++ b/Userland/Libraries/LibWeb/UIEvents/WheelEvent.h
@@ -29,7 +29,7 @@ class WheelEvent final : public MouseEvent {
     WEB_PLATFORM_OBJECT(WheelEvent, MouseEvent);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<WheelEvent>> create(JS::Realm&, FlyString const& event_name, WheelEventInit const& event_init = {});
+    [[nodiscard]] static JS::NonnullGCPtr<WheelEvent> create(JS::Realm&, FlyString const& event_name, WheelEventInit const& event_init = {});
     static WebIDL::ExceptionOr<JS::NonnullGCPtr<WheelEvent>> create_from_platform_event(JS::Realm&, FlyString const& event_name, CSSPixels offset_x, CSSPixels offset_y, CSSPixels client_x, CSSPixels client_y, double delta_x, double delta_y, unsigned buttons, unsigned button);
 
     virtual ~WheelEvent() override;

--- a/Userland/Libraries/LibWeb/URL/URL.cpp
+++ b/Userland/Libraries/LibWeb/URL/URL.cpp
@@ -16,9 +16,9 @@
 
 namespace Web::URL {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<URL>> URL::create(JS::Realm& realm, AK::URL url, JS::NonnullGCPtr<URLSearchParams> query)
+JS::NonnullGCPtr<URL> URL::create(JS::Realm& realm, AK::URL url, JS::NonnullGCPtr<URLSearchParams> query)
 {
-    return MUST_OR_THROW_OOM(realm.heap().allocate<URL>(realm, realm, move(url), move(query)));
+    return realm.heap().allocate<URL>(realm, realm, move(url), move(query));
 }
 
 // https://url.spec.whatwg.org/#api-url-parser
@@ -67,7 +67,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<URL>> URL::construct_impl(JS::Realm& realm,
     auto query_object = MUST(URLSearchParams::construct_impl(realm, query));
 
     // 6. Initialize this’s query object with query.
-    auto result_url = TRY(URL::create(realm, parsed_url.release_value(), move(query_object)));
+    auto result_url = URL::create(realm, parsed_url.release_value(), move(query_object));
 
     // 7. Set this’s query object’s URL object to this.
     result_url->m_query->m_url = result_url;

--- a/Userland/Libraries/LibWeb/URL/URL.h
+++ b/Userland/Libraries/LibWeb/URL/URL.h
@@ -19,7 +19,7 @@ class URL : public Bindings::PlatformObject {
     WEB_PLATFORM_OBJECT(URL, Bindings::PlatformObject);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<URL>> create(JS::Realm&, AK::URL url, JS::NonnullGCPtr<URLSearchParams> query);
+    [[nodiscard]] static JS::NonnullGCPtr<URL> create(JS::Realm&, AK::URL, JS::NonnullGCPtr<URLSearchParams> query);
     static WebIDL::ExceptionOr<JS::NonnullGCPtr<URL>> construct_impl(JS::Realm&, String const& url, Optional<String> const& base = {});
 
     virtual ~URL() override;

--- a/Userland/Libraries/LibWeb/URL/URLSearchParams.cpp
+++ b/Userland/Libraries/LibWeb/URL/URLSearchParams.cpp
@@ -118,7 +118,7 @@ ErrorOr<Vector<QueryParam>> url_decode(StringView input)
 
 WebIDL::ExceptionOr<JS::NonnullGCPtr<URLSearchParams>> URLSearchParams::create(JS::Realm& realm, Vector<QueryParam> list)
 {
-    return MUST_OR_THROW_OOM(realm.heap().allocate<URLSearchParams>(realm, realm, move(list)));
+    return realm.heap().allocate<URLSearchParams>(realm, realm, move(list));
 }
 
 // https://url.spec.whatwg.org/#dom-urlsearchparams-urlsearchparams

--- a/Userland/Libraries/LibWeb/URL/URLSearchParamsIterator.cpp
+++ b/Userland/Libraries/LibWeb/URL/URLSearchParamsIterator.cpp
@@ -15,7 +15,7 @@ namespace Web::Bindings {
 template<>
 void Intrinsics::create_web_prototype_and_constructor<URLSearchParamsIteratorPrototype>(JS::Realm& realm)
 {
-    auto prototype = heap().allocate<URLSearchParamsIteratorPrototype>(realm, realm).release_allocated_value_but_fixme_should_propagate_errors();
+    auto prototype = heap().allocate<URLSearchParamsIteratorPrototype>(realm, realm);
     m_prototypes.set("URLSearchParamsIterator"sv, prototype);
 }
 
@@ -25,7 +25,7 @@ namespace Web::URL {
 
 WebIDL::ExceptionOr<JS::NonnullGCPtr<URLSearchParamsIterator>> URLSearchParamsIterator::create(URLSearchParams const& url_search_params, JS::Object::PropertyKind iteration_kind)
 {
-    return MUST_OR_THROW_OOM(url_search_params.heap().allocate<URLSearchParamsIterator>(url_search_params.realm(), url_search_params, iteration_kind));
+    return url_search_params.heap().allocate<URLSearchParamsIterator>(url_search_params.realm(), url_search_params, iteration_kind);
 }
 
 URLSearchParamsIterator::URLSearchParamsIterator(URLSearchParams const& url_search_params, JS::Object::PropertyKind iteration_kind)

--- a/Userland/Libraries/LibWeb/UserTiming/PerformanceMark.cpp
+++ b/Userland/Libraries/LibWeb/UserTiming/PerformanceMark.cpp
@@ -88,7 +88,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<PerformanceMark>> PerformanceMark::construc
     }
 
     // 2. Create a new PerformanceMark object (entry) with the current global object's realm.
-    return MUST_OR_THROW_OOM(realm.heap().allocate<PerformanceMark>(realm, realm, name, start_time, duration, detail));
+    return realm.heap().allocate<PerformanceMark>(realm, realm, name, start_time, duration, detail);
 }
 
 FlyString const& PerformanceMark::entry_type() const

--- a/Userland/Libraries/LibWeb/UserTiming/PerformanceMeasure.cpp
+++ b/Userland/Libraries/LibWeb/UserTiming/PerformanceMeasure.cpp
@@ -24,9 +24,9 @@ PerformanceMeasure::PerformanceMeasure(JS::Realm& realm, String const& name, Hig
 
 PerformanceMeasure::~PerformanceMeasure() = default;
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<PerformanceMeasure>> PerformanceMeasure::create(JS::Realm& realm, String const& measure_name, HighResolutionTime::DOMHighResTimeStamp start_time, HighResolutionTime::DOMHighResTimeStamp duration, JS::Value detail)
+JS::NonnullGCPtr<PerformanceMeasure> PerformanceMeasure::create(JS::Realm& realm, String const& measure_name, HighResolutionTime::DOMHighResTimeStamp start_time, HighResolutionTime::DOMHighResTimeStamp duration, JS::Value detail)
 {
-    return MUST_OR_THROW_OOM(realm.heap().allocate<PerformanceMeasure>(realm, realm, measure_name, start_time, duration, detail));
+    return realm.heap().allocate<PerformanceMeasure>(realm, realm, measure_name, start_time, duration, detail);
 }
 
 FlyString const& PerformanceMeasure::entry_type() const

--- a/Userland/Libraries/LibWeb/UserTiming/PerformanceMeasure.h
+++ b/Userland/Libraries/LibWeb/UserTiming/PerformanceMeasure.h
@@ -25,7 +25,7 @@ class PerformanceMeasure final : public PerformanceTimeline::PerformanceEntry {
 public:
     virtual ~PerformanceMeasure();
 
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<PerformanceMeasure>> create(JS::Realm&, String const& measure_name, HighResolutionTime::DOMHighResTimeStamp start_time, HighResolutionTime::DOMHighResTimeStamp duration, JS::Value detail);
+    [[nodiscard]] static JS::NonnullGCPtr<PerformanceMeasure> create(JS::Realm&, String const& measure_name, HighResolutionTime::DOMHighResTimeStamp start_time, HighResolutionTime::DOMHighResTimeStamp duration, JS::Value detail);
 
     // NOTE: These three functions are answered by the registry for the given entry type.
     // https://w3c.github.io/timing-entrytypes-registry/#registry

--- a/Userland/Libraries/LibWeb/WebAssembly/Instance.cpp
+++ b/Userland/Libraries/LibWeb/WebAssembly/Instance.cpp
@@ -28,7 +28,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Instance>> Instance::construct_impl(JS::Rea
     auto& vm = realm.vm();
 
     auto index = TRY(Detail::instantiate_module(vm, module.module()));
-    return MUST_OR_THROW_OOM(vm.heap().allocate<Instance>(realm, realm, index));
+    return vm.heap().allocate<Instance>(realm, realm, index);
 }
 
 Instance::Instance(JS::Realm& realm, size_t index)
@@ -62,7 +62,7 @@ void Instance::initialize(JS::Realm& realm)
             [&](Wasm::MemoryAddress const& address) {
                 Optional<JS::GCPtr<Memory>> object = cache.memory_instances.get(address);
                 if (!object.has_value()) {
-                    object = MUST(heap().allocate<Memory>(realm, realm, address));
+                    object = heap().allocate<Memory>(realm, realm, address);
                     cache.memory_instances.set(address, *object);
                 }
 
@@ -71,7 +71,7 @@ void Instance::initialize(JS::Realm& realm)
             [&](Wasm::TableAddress const& address) {
                 Optional<JS::GCPtr<Table>> object = cache.table_instances.get(address);
                 if (!object.has_value()) {
-                    object = MUST(heap().allocate<Table>(realm, realm, address));
+                    object = heap().allocate<Table>(realm, realm, address);
                     cache.table_instances.set(address, *object);
                 }
 

--- a/Userland/Libraries/LibWeb/WebAssembly/Memory.cpp
+++ b/Userland/Libraries/LibWeb/WebAssembly/Memory.cpp
@@ -25,7 +25,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Memory>> Memory::construct_impl(JS::Realm& 
     if (!address.has_value())
         return vm.throw_completion<JS::TypeError>("Wasm Memory allocation failed"sv);
 
-    auto memory_object = MUST_OR_THROW_OOM(vm.heap().allocate<Memory>(realm, realm, *address));
+    auto memory_object = vm.heap().allocate<Memory>(realm, realm, *address);
     Detail::s_abstract_machine.store().get(*address)->successful_grow_hook = [memory_object] {
         MUST(memory_object->reset_the_memory_buffer());
     };

--- a/Userland/Libraries/LibWeb/WebAssembly/Module.cpp
+++ b/Userland/Libraries/LibWeb/WebAssembly/Module.cpp
@@ -19,7 +19,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Module>> Module::construct_impl(JS::Realm& 
     auto& vm = realm.vm();
 
     auto index = TRY(Detail::parse_module(vm, bytes.cell()));
-    return MUST_OR_THROW_OOM(vm.heap().allocate<Module>(realm, realm, index));
+    return vm.heap().allocate<Module>(realm, realm, index);
 }
 
 Module::Module(JS::Realm& realm, size_t index)

--- a/Userland/Libraries/LibWeb/WebAssembly/Table.cpp
+++ b/Userland/Libraries/LibWeb/WebAssembly/Table.cpp
@@ -52,7 +52,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Table>> Table::construct_impl(JS::Realm& re
     for (auto& element : table.elements())
         element = reference;
 
-    return MUST_OR_THROW_OOM(vm.heap().allocate<Table>(realm, realm, *address));
+    return vm.heap().allocate<Table>(realm, realm, *address);
 }
 
 Table::Table(JS::Realm& realm, Wasm::TableAddress address)

--- a/Userland/Libraries/LibWeb/WebAssembly/WebAssembly.cpp
+++ b/Userland/Libraries/LibWeb/WebAssembly/WebAssembly.cpp
@@ -88,7 +88,7 @@ WebIDL::ExceptionOr<JS::Value> compile(JS::VM& vm, JS::Handle<JS::Object>& bytes
     if (module.is_error()) {
         promise->reject(*module.release_error().value());
     } else {
-        auto module_object = MUST_OR_THROW_OOM(vm.heap().allocate<Module>(realm, realm, module.release_value()));
+        auto module_object = vm.heap().allocate<Module>(realm, realm, module.release_value());
         promise->fulfill(module_object);
     }
 
@@ -118,8 +118,8 @@ WebIDL::ExceptionOr<JS::Value> instantiate(JS::VM& vm, JS::Handle<JS::Object>& b
     if (result.is_error()) {
         promise->reject(*result.release_error().value());
     } else {
-        auto module_object = MUST_OR_THROW_OOM(vm.heap().allocate<Module>(realm, realm, Detail::s_compiled_modules.size() - 1));
-        auto instance_object = MUST_OR_THROW_OOM(vm.heap().allocate<Instance>(realm, realm, result.release_value()));
+        auto module_object = vm.heap().allocate<Module>(realm, realm, Detail::s_compiled_modules.size() - 1);
+        auto instance_object = vm.heap().allocate<Instance>(realm, realm, result.release_value());
 
         auto object = JS::Object::create(realm, nullptr);
         object->define_direct_property("module", module_object, JS::default_attributes);
@@ -145,7 +145,7 @@ WebIDL::ExceptionOr<JS::Value> instantiate(JS::VM& vm, Module const& module_obje
     if (result.is_error()) {
         promise->reject(*result.release_error().value());
     } else {
-        auto instance_object = MUST_OR_THROW_OOM(vm.heap().allocate<Instance>(realm, realm, result.release_value()));
+        auto instance_object = vm.heap().allocate<Instance>(realm, realm, result.release_value());
         promise->fulfill(instance_object);
     }
 
@@ -426,7 +426,7 @@ JS::Value to_js_value(JS::VM& vm, Wasm::Value& wasm_value)
     auto& realm = *vm.current_realm();
     switch (wasm_value.type().kind()) {
     case Wasm::ValueType::I64:
-        return realm.heap().allocate<JS::BigInt>(realm, ::Crypto::SignedBigInteger { wasm_value.to<i64>().value() }).release_allocated_value_but_fixme_should_propagate_errors();
+        return realm.heap().allocate<JS::BigInt>(realm, ::Crypto::SignedBigInteger { wasm_value.to<i64>().value() });
     case Wasm::ValueType::I32:
         return JS::Value(wasm_value.to<i32>().value());
     case Wasm::ValueType::F64:

--- a/Userland/Libraries/LibWeb/WebAudio/AudioContext.cpp
+++ b/Userland/Libraries/LibWeb/WebAudio/AudioContext.cpp
@@ -15,7 +15,7 @@ namespace Web::WebAudio {
 // https://webaudio.github.io/web-audio-api/#dom-audiocontext-audiocontext
 WebIDL::ExceptionOr<JS::NonnullGCPtr<AudioContext>> AudioContext::construct_impl(JS::Realm& realm, AudioContextOptions const& context_options)
 {
-    return MUST_OR_THROW_OOM(realm.heap().allocate<AudioContext>(realm, realm, context_options));
+    return realm.heap().allocate<AudioContext>(realm, realm, context_options);
 }
 
 AudioContext::AudioContext(JS::Realm& realm, AudioContextOptions const& context_options)
@@ -72,7 +72,7 @@ AudioContext::AudioContext(JS::Realm& realm, AudioContextOptions const& context_
             BaseAudioContext::set_control_state(Bindings::AudioContextState::Running);
 
             // 5.3.2: queue a media element task to fire an event named statechange at the AudioContext.
-            this->dispatch_event(DOM::Event::create(realm, HTML::EventNames::statechange).release_value_but_fixme_should_propagate_errors());
+            this->dispatch_event(DOM::Event::create(realm, HTML::EventNames::statechange));
         });
     }
 }
@@ -174,7 +174,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> AudioContext::resume()
 
             // 7.5.4.2: queue a media element task to fire an event named statechange at the AudioContext.
             queue_a_media_element_task([&realm, this]() {
-                this->dispatch_event(DOM::Event::create(realm, HTML::EventNames::statechange).release_value_but_fixme_should_propagate_errors());
+                this->dispatch_event(DOM::Event::create(realm, HTML::EventNames::statechange));
             });
         }
     });
@@ -229,7 +229,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> AudioContext::suspend()
 
             // 7.3.2.2: queue a media element task to fire an event named statechange at the AudioContext.
             queue_a_media_element_task([&realm, this]() {
-                this->dispatch_event(DOM::Event::create(realm, HTML::EventNames::statechange).release_value_but_fixme_should_propagate_errors());
+                this->dispatch_event(DOM::Event::create(realm, HTML::EventNames::statechange));
             });
         }
     });
@@ -280,7 +280,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> AudioContext::close()
 
         // 5.4.2.2: queue a media element task to fire an event named statechange at the AudioContext.
         // FIXME: Attempting to queue another task in here causes an assertion fail at Vector.h:148
-        this->dispatch_event(DOM::Event::create(realm, HTML::EventNames::statechange).release_value_but_fixme_should_propagate_errors());
+        this->dispatch_event(DOM::Event::create(realm, HTML::EventNames::statechange));
     });
 
     // 6. Return promise

--- a/Userland/Libraries/LibWeb/WebGL/WebGLContextEvent.cpp
+++ b/Userland/Libraries/LibWeb/WebGL/WebGLContextEvent.cpp
@@ -9,9 +9,9 @@
 
 namespace Web::WebGL {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<WebGLContextEvent>> WebGLContextEvent::create(JS::Realm& realm, FlyString const& event_name, WebGLContextEventInit const& event_init)
+JS::NonnullGCPtr<WebGLContextEvent> WebGLContextEvent::create(JS::Realm& realm, FlyString const& event_name, WebGLContextEventInit const& event_init)
 {
-    return MUST_OR_THROW_OOM(realm.heap().allocate<WebGLContextEvent>(realm, realm, event_name, event_init));
+    return realm.heap().allocate<WebGLContextEvent>(realm, realm, event_name, event_init);
 }
 
 WebIDL::ExceptionOr<JS::NonnullGCPtr<WebGLContextEvent>> WebGLContextEvent::construct_impl(JS::Realm& realm, FlyString const& event_name, WebGLContextEventInit const& event_init)

--- a/Userland/Libraries/LibWeb/WebGL/WebGLContextEvent.h
+++ b/Userland/Libraries/LibWeb/WebGL/WebGLContextEvent.h
@@ -20,8 +20,8 @@ class WebGLContextEvent final : public DOM::Event {
     WEB_PLATFORM_OBJECT(WebGLContextEvent, DOM::Event);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<WebGLContextEvent>> create(JS::Realm&, FlyString const& type, WebGLContextEventInit const& event_init);
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<WebGLContextEvent>> construct_impl(JS::Realm&, FlyString const& type, WebGLContextEventInit const& event_init);
+    [[nodiscard]] static JS::NonnullGCPtr<WebGLContextEvent> create(JS::Realm&, FlyString const& type, WebGLContextEventInit const&);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<WebGLContextEvent>> construct_impl(JS::Realm&, FlyString const& type, WebGLContextEventInit const&);
 
     virtual ~WebGLContextEvent() override;
 

--- a/Userland/Libraries/LibWeb/WebGL/WebGLRenderingContext.cpp
+++ b/Userland/Libraries/LibWeb/WebGL/WebGLRenderingContext.cpp
@@ -18,7 +18,7 @@ static void fire_webgl_context_event(HTML::HTMLCanvasElement& canvas_element, Fl
 {
     // To fire a WebGL context event named e means that an event using the WebGLContextEvent interface, with its type attribute [DOM4] initialized to e, its cancelable attribute initialized to true, and its isTrusted attribute [DOM4] initialized to true, is to be dispatched at the given object.
     // FIXME: Consider setting a status message.
-    auto event = WebGLContextEvent::create(canvas_element.realm(), type, WebGLContextEventInit {}).release_value_but_fixme_should_propagate_errors();
+    auto event = WebGLContextEvent::create(canvas_element.realm(), type, WebGLContextEventInit {});
     event->set_is_trusted(true);
     event->set_cancelable(true);
     canvas_element.dispatch_event(*event);
@@ -47,7 +47,7 @@ JS::ThrowCompletionOr<JS::GCPtr<WebGLRenderingContext>> WebGLRenderingContext::c
         fire_webgl_context_creation_error(canvas_element);
         return JS::GCPtr<WebGLRenderingContext> { nullptr };
     }
-    return MUST_OR_THROW_OOM(realm.heap().allocate<WebGLRenderingContext>(realm, realm, canvas_element, context_or_error.release_value(), context_attributes, context_attributes));
+    return realm.heap().allocate<WebGLRenderingContext>(realm, realm, canvas_element, context_or_error.release_value(), context_attributes, context_attributes);
 }
 
 WebGLRenderingContext::WebGLRenderingContext(JS::Realm& realm, HTML::HTMLCanvasElement& canvas_element, NonnullOwnPtr<GL::GLContext> context, WebGLContextAttributes context_creation_parameters, WebGLContextAttributes actual_context_parameters)

--- a/Userland/Libraries/LibWeb/WebIDL/DOMException.cpp
+++ b/Userland/Libraries/LibWeb/WebIDL/DOMException.cpp
@@ -11,12 +11,12 @@ namespace Web::WebIDL {
 
 JS::NonnullGCPtr<DOMException> DOMException::create(JS::Realm& realm, DeprecatedFlyString const& name, DeprecatedFlyString const& message)
 {
-    return realm.heap().allocate<DOMException>(realm, realm, name, message).release_allocated_value_but_fixme_should_propagate_errors();
+    return realm.heap().allocate<DOMException>(realm, realm, name, message);
 }
 
 JS::NonnullGCPtr<DOMException> DOMException::construct_impl(JS::Realm& realm, DeprecatedFlyString const& message, DeprecatedFlyString const& name)
 {
-    return realm.heap().allocate<DOMException>(realm, realm, name, message).release_allocated_value_but_fixme_should_propagate_errors();
+    return realm.heap().allocate<DOMException>(realm, realm, name, message);
 }
 
 DOMException::DOMException(JS::Realm& realm, DeprecatedFlyString const& name, DeprecatedFlyString const& message)

--- a/Userland/Libraries/LibWeb/WebSockets/WebSocket.cpp
+++ b/Userland/Libraries/LibWeb/WebSockets/WebSocket.cpp
@@ -53,7 +53,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<WebSocket>> WebSocket::construct_impl(JS::R
 {
     auto& vm = realm.vm();
 
-    auto web_socket = MUST_OR_THROW_OOM(realm.heap().allocate<WebSocket>(realm, realm));
+    auto web_socket = realm.heap().allocate<WebSocket>(realm, realm);
     auto& relevant_settings_object = HTML::relevant_settings_object(*web_socket);
 
     // 1. Let baseURL be this's relevant settings object's API base URL.
@@ -264,13 +264,13 @@ void WebSocket::on_open()
     // 1. Change the readyState attribute's value to OPEN (1).
     // 2. Change the extensions attribute's value to the extensions in use, if it is not the null value. [WSP]
     // 3. Change the protocol attribute's value to the subprotocol in use, if it is not the null value. [WSP]
-    dispatch_event(DOM::Event::create(realm(), HTML::EventNames::open).release_value_but_fixme_should_propagate_errors());
+    dispatch_event(DOM::Event::create(realm(), HTML::EventNames::open));
 }
 
 // https://websockets.spec.whatwg.org/#feedback-from-the-protocol
 void WebSocket::on_error()
 {
-    dispatch_event(DOM::Event::create(realm(), HTML::EventNames::error).release_value_but_fixme_should_propagate_errors());
+    dispatch_event(DOM::Event::create(realm(), HTML::EventNames::error));
 }
 
 // https://websockets.spec.whatwg.org/#feedback-from-the-protocol
@@ -282,7 +282,7 @@ void WebSocket::on_close(u16 code, String reason, bool was_clean)
     event_init.was_clean = was_clean;
     event_init.code = code;
     event_init.reason = reason;
-    dispatch_event(HTML::CloseEvent::create(realm(), HTML::EventNames::close, event_init).release_value_but_fixme_should_propagate_errors());
+    dispatch_event(HTML::CloseEvent::create(realm(), HTML::EventNames::close, event_init));
 }
 
 // https://websockets.spec.whatwg.org/#feedback-from-the-protocol
@@ -295,7 +295,7 @@ void WebSocket::on_message(ByteBuffer message, bool is_text)
         HTML::MessageEventInit event_init;
         event_init.data = JS::PrimitiveString::create(vm(), text_message);
         event_init.origin = url().release_value_but_fixme_should_propagate_errors();
-        dispatch_event(HTML::MessageEvent::create(realm(), HTML::EventNames::message, event_init).release_value_but_fixme_should_propagate_errors());
+        dispatch_event(HTML::MessageEvent::create(realm(), HTML::EventNames::message, event_init));
         return;
     }
 
@@ -307,7 +307,7 @@ void WebSocket::on_message(ByteBuffer message, bool is_text)
         HTML::MessageEventInit event_init;
         event_init.data = JS::ArrayBuffer::create(realm(), message);
         event_init.origin = url().release_value_but_fixme_should_propagate_errors();
-        dispatch_event(HTML::MessageEvent::create(realm(), HTML::EventNames::message, event_init).release_value_but_fixme_should_propagate_errors());
+        dispatch_event(HTML::MessageEvent::create(realm(), HTML::EventNames::message, event_init));
         return;
     }
 

--- a/Userland/Libraries/LibWeb/XHR/FormData.cpp
+++ b/Userland/Libraries/LibWeb/XHR/FormData.cpp
@@ -35,7 +35,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<FormData>> FormData::construct_impl(JS::Rea
 
 WebIDL::ExceptionOr<JS::NonnullGCPtr<FormData>> FormData::construct_impl(JS::Realm& realm, Vector<FormDataEntry> entry_list)
 {
-    return MUST_OR_THROW_OOM(realm.heap().allocate<FormData>(realm, realm, move(entry_list)));
+    return realm.heap().allocate<FormData>(realm, realm, move(entry_list));
 }
 
 FormData::FormData(JS::Realm& realm, Vector<FormDataEntry> entry_list)

--- a/Userland/Libraries/LibWeb/XHR/FormDataIterator.cpp
+++ b/Userland/Libraries/LibWeb/XHR/FormDataIterator.cpp
@@ -15,7 +15,7 @@ namespace Web::Bindings {
 template<>
 void Intrinsics::create_web_prototype_and_constructor<FormDataIteratorPrototype>(JS::Realm& realm)
 {
-    auto prototype = heap().allocate<FormDataIteratorPrototype>(realm, realm).release_allocated_value_but_fixme_should_propagate_errors();
+    auto prototype = heap().allocate<FormDataIteratorPrototype>(realm, realm);
     m_prototypes.set("FormDataIterator"sv, prototype);
 }
 
@@ -23,9 +23,9 @@ void Intrinsics::create_web_prototype_and_constructor<FormDataIteratorPrototype>
 
 namespace Web::XHR {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<FormDataIterator>> FormDataIterator::create(FormData const& form_data, JS::Object::PropertyKind iterator_kind)
+JS::NonnullGCPtr<FormDataIterator> FormDataIterator::create(FormData const& form_data, JS::Object::PropertyKind iterator_kind)
 {
-    return MUST_OR_THROW_OOM(form_data.heap().allocate<FormDataIterator>(form_data.realm(), form_data, iterator_kind));
+    return form_data.heap().allocate<FormDataIterator>(form_data.realm(), form_data, iterator_kind);
 }
 
 FormDataIterator::FormDataIterator(Web::XHR::FormData const& form_data, JS::Object::PropertyKind iterator_kind)

--- a/Userland/Libraries/LibWeb/XHR/FormDataIterator.h
+++ b/Userland/Libraries/LibWeb/XHR/FormDataIterator.h
@@ -15,7 +15,7 @@ class FormDataIterator : public Bindings::PlatformObject {
     WEB_PLATFORM_OBJECT(FormDataIterator, Bindings::PlatformObject);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<FormDataIterator>> create(FormData const&, JS::Object::PropertyKind iterator_kind);
+    [[nodiscard]] static JS::NonnullGCPtr<FormDataIterator> create(FormData const&, JS::Object::PropertyKind iterator_kind);
 
     virtual ~FormDataIterator() override;
 

--- a/Userland/Libraries/LibWeb/XHR/ProgressEvent.cpp
+++ b/Userland/Libraries/LibWeb/XHR/ProgressEvent.cpp
@@ -9,9 +9,9 @@
 
 namespace Web::XHR {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<ProgressEvent>> ProgressEvent::create(JS::Realm& realm, FlyString const& event_name, ProgressEventInit const& event_init)
+JS::NonnullGCPtr<ProgressEvent> ProgressEvent::create(JS::Realm& realm, FlyString const& event_name, ProgressEventInit const& event_init)
 {
-    return MUST_OR_THROW_OOM(realm.heap().allocate<ProgressEvent>(realm, realm, event_name, event_init));
+    return realm.heap().allocate<ProgressEvent>(realm, realm, event_name, event_init);
 }
 
 WebIDL::ExceptionOr<JS::NonnullGCPtr<ProgressEvent>> ProgressEvent::construct_impl(JS::Realm& realm, FlyString const& event_name, ProgressEventInit const& event_init)

--- a/Userland/Libraries/LibWeb/XHR/ProgressEvent.h
+++ b/Userland/Libraries/LibWeb/XHR/ProgressEvent.h
@@ -24,7 +24,7 @@ class ProgressEvent final : public DOM::Event {
     WEB_PLATFORM_OBJECT(ProgressEvent, DOM::Event);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<ProgressEvent>> create(JS::Realm&, FlyString const& event_name, ProgressEventInit const& event_init);
+    [[nodiscard]] static JS::NonnullGCPtr<ProgressEvent> create(JS::Realm&, FlyString const& event_name, ProgressEventInit const& event_init);
     static WebIDL::ExceptionOr<JS::NonnullGCPtr<ProgressEvent>> construct_impl(JS::Realm&, FlyString const& event_name, ProgressEventInit const& event_init);
 
     virtual ~ProgressEvent() override;

--- a/Userland/Libraries/LibWeb/XML/XMLDocumentBuilder.cpp
+++ b/Userland/Libraries/LibWeb/XML/XMLDocumentBuilder.cpp
@@ -197,7 +197,7 @@ void XMLDocumentBuilder::document_end()
         document->load_timing_info().dom_content_loaded_event_start_time = HighResolutionTime::unsafe_shared_current_time();
 
         // Fire an event named DOMContentLoaded at the Document object, with its bubbles attribute initialized to true.
-        auto content_loaded_event = DOM::Event::create(document->realm(), HTML::EventNames::DOMContentLoaded).release_value_but_fixme_should_propagate_errors();
+        auto content_loaded_event = DOM::Event::create(document->realm(), HTML::EventNames::DOMContentLoaded);
         content_loaded_event->set_bubbles(true);
         document->dispatch_event(content_loaded_event);
 
@@ -237,7 +237,7 @@ void XMLDocumentBuilder::document_end()
         // Fire an event named load at window, with legacy target override flag set.
         // FIXME: The legacy target override flag is currently set by a virtual override of dispatch_event()
         // We should reorganize this so that the flag appears explicitly here instead.
-        window->dispatch_event(DOM::Event::create(document->realm(), HTML::EventNames::load).release_value_but_fixme_should_propagate_errors());
+        window->dispatch_event(DOM::Event::create(document->realm(), HTML::EventNames::load));
 
         // FIXME: Invoke WebDriver BiDi load complete with the Document's browsing context, and a new WebDriver BiDi navigation status whose id is the Document object's navigation id, status is "complete", and url is the Document object's URL.
 

--- a/Userland/Services/WebContent/WebContentConsoleClient.cpp
+++ b/Userland/Services/WebContent/WebContentConsoleClient.cpp
@@ -28,7 +28,7 @@ WebContentConsoleClient::WebContentConsoleClient(JS::Console& console, JS::Realm
     , m_client(client)
 {
     auto& window = verify_cast<Web::HTML::Window>(realm.global_object());
-    m_console_global_environment_extensions = realm.heap().allocate<ConsoleGlobalEnvironmentExtensions>(realm, realm, window).release_allocated_value_but_fixme_should_propagate_errors().ptr();
+    m_console_global_environment_extensions = realm.heap().allocate<ConsoleGlobalEnvironmentExtensions>(realm, realm, window);
 }
 
 void WebContentConsoleClient::handle_input(DeprecatedString const& js_source)

--- a/Userland/Services/WebContent/WebDriverConnection.cpp
+++ b/Userland/Services/WebContent/WebDriverConnection.cpp
@@ -316,7 +316,7 @@ static bool fire_an_event(FlyString name, Optional<Web::DOM::Element&> target)
     if (!target.has_value())
         return false;
 
-    auto event = T::create(target->realm(), name).release_value_but_fixme_should_propagate_errors();
+    auto event = T::create(target->realm(), name);
     return target->dispatch_event(event);
 }
 


### PR DESCRIPTION
Stop worrying about tiny OOMs. Work towards #20449.

While going through these, I also changed the function signature in many places where returning ThrowCompletionOr<T> is no longer necessary.