### PR TITLE
Flood: Modernization

### DIFF
--- a/Userland/Games/Flood/CMakeLists.txt
+++ b/Userland/Games/Flood/CMakeLists.txt
@@ -4,19 +4,16 @@ serenity_component(
     TARGETS Flood
 )
 
-stringify_gml(FloodWindow.gml FloodWindowGML.h flood_window_gml)
-stringify_gml(SettingsDialog.gml SettingsDialogGML.h settings_dialog_gml)
+compile_gml(FloodWindow.gml FloodWindowGML.cpp)
+compile_gml(SettingsWidget.gml SettingsWidgetGML.cpp)
 
 set(SOURCES
     Board.cpp
     BoardWidget.cpp
+    FloodWindowGML.cpp
     SettingsDialog.cpp
+    SettingsWidgetGML.cpp
     main.cpp
-)
-
-set(GENERATED_SOURCES
-    FloodWindowGML.h
-    SettingsDialogGML.h
 )
 
 serenity_app(Flood ICON app-flood)

--- a/Userland/Games/Flood/FloodWindow.gml
+++ b/Userland/Games/Flood/FloodWindow.gml
@@ -1,4 +1,4 @@
-@GUI::Frame {
+@Flood::MainWidget {
     fill_with_background_color: true
     layout: @GUI::VerticalBoxLayout {}
 

--- a/Userland/Games/Flood/MainWidget.h
+++ b/Userland/Games/Flood/MainWidget.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2023, the SerenityOS developers
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibGUI/Widget.h>
+
+namespace Flood {
+
+class MainWidget : public GUI::Widget {
+    C_OBJECT_ABSTRACT(MainWidget)
+public:
+    static ErrorOr<NonnullRefPtr<MainWidget>> try_create();
+    virtual ~MainWidget() override = default;
+
+private:
+    MainWidget() = default;
+};
+
+}

--- a/Userland/Games/Flood/SettingsDialog.cpp
+++ b/Userland/Games/Flood/SettingsDialog.cpp
@@ -7,7 +7,6 @@
 #include "SettingsDialog.h"
 #include <AK/IntegralMath.h>
 #include <AK/QuickSort.h>
-#include <Games/Flood/SettingsDialogGML.h>
 #include <LibCore/DirIterator.h>
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/Button.h>
@@ -19,13 +18,12 @@
 
 ErrorOr<NonnullRefPtr<SettingsDialog>> SettingsDialog::try_create(GUI::Window* parent, size_t board_rows, size_t board_columns)
 {
-    auto settings_widget = GUI::Widget::construct();
-    TRY(settings_widget->load_from_gml(settings_dialog_gml));
+    auto settings_widget = TRY(Flood::SettingsWidget::try_create());
     auto settings_dialog = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) SettingsDialog(move(settings_widget), move(parent), move(board_rows), move(board_columns))));
     return settings_dialog;
 }
 
-SettingsDialog::SettingsDialog(NonnullRefPtr<GUI::Widget> settings_widget, GUI::Window* parent, size_t board_rows, size_t board_columns)
+SettingsDialog::SettingsDialog(NonnullRefPtr<Flood::SettingsWidget> settings_widget, GUI::Window* parent, size_t board_rows, size_t board_columns)
     : GUI::Dialog(parent)
     , m_board_rows(board_rows)
     , m_board_columns(board_columns)

--- a/Userland/Games/Flood/SettingsDialog.cpp
+++ b/Userland/Games/Flood/SettingsDialog.cpp
@@ -17,7 +17,15 @@
 #include <LibGUI/Label.h>
 #include <LibGUI/SpinBox.h>
 
-SettingsDialog::SettingsDialog(GUI::Window* parent, size_t board_rows, size_t board_columns)
+ErrorOr<NonnullRefPtr<SettingsDialog>> SettingsDialog::try_create(GUI::Window* parent, size_t board_rows, size_t board_columns)
+{
+    auto settings_widget = GUI::Widget::construct();
+    TRY(settings_widget->load_from_gml(settings_dialog_gml));
+    auto settings_dialog = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) SettingsDialog(move(settings_widget), move(parent), move(board_rows), move(board_columns))));
+    return settings_dialog;
+}
+
+SettingsDialog::SettingsDialog(NonnullRefPtr<GUI::Widget> settings_widget, GUI::Window* parent, size_t board_rows, size_t board_columns)
     : GUI::Dialog(parent)
     , m_board_rows(board_rows)
     , m_board_columns(board_columns)
@@ -27,29 +35,28 @@ SettingsDialog::SettingsDialog(GUI::Window* parent, size_t board_rows, size_t bo
     set_icon(parent->icon());
     set_resizable(false);
 
-    auto main_widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
-    main_widget->load_from_gml(settings_dialog_gml).release_value_but_fixme_should_propagate_errors();
+    set_main_widget(settings_widget);
 
-    auto board_rows_spinbox = main_widget->find_descendant_of_type_named<GUI::SpinBox>("board_rows_spinbox");
+    auto board_rows_spinbox = settings_widget->find_descendant_of_type_named<GUI::SpinBox>("board_rows_spinbox");
     board_rows_spinbox->set_value(m_board_rows);
 
     board_rows_spinbox->on_change = [&](auto value) {
         m_board_rows = value;
     };
 
-    auto board_columns_spinbox = main_widget->find_descendant_of_type_named<GUI::SpinBox>("board_columns_spinbox");
+    auto board_columns_spinbox = settings_widget->find_descendant_of_type_named<GUI::SpinBox>("board_columns_spinbox");
     board_columns_spinbox->set_value(m_board_columns);
 
     board_columns_spinbox->on_change = [&](auto value) {
         m_board_columns = value;
     };
 
-    auto cancel_button = main_widget->find_descendant_of_type_named<GUI::Button>("cancel_button");
+    auto cancel_button = settings_widget->find_descendant_of_type_named<GUI::Button>("cancel_button");
     cancel_button->on_click = [this](auto) {
         done(ExecResult::Cancel);
     };
 
-    auto ok_button = main_widget->find_descendant_of_type_named<GUI::Button>("ok_button");
+    auto ok_button = settings_widget->find_descendant_of_type_named<GUI::Button>("ok_button");
     ok_button->on_click = [this](auto) {
         done(ExecResult::OK);
     };

--- a/Userland/Games/Flood/SettingsDialog.h
+++ b/Userland/Games/Flood/SettingsDialog.h
@@ -10,13 +10,14 @@
 #include <LibGUI/Dialog.h>
 
 class SettingsDialog : public GUI::Dialog {
-    C_OBJECT(SettingsDialog)
+    C_OBJECT_ABSTRACT(SettingsDialog)
 public:
+    static ErrorOr<NonnullRefPtr<SettingsDialog>> try_create(GUI::Window* parent, size_t board_rows, size_t board_columns);
     size_t board_rows() const { return m_board_rows; }
     size_t board_columns() const { return m_board_columns; }
 
 private:
-    SettingsDialog(GUI::Window* parent, size_t board_rows, size_t board_columns);
+    SettingsDialog(NonnullRefPtr<GUI::Widget> settings_widget, GUI::Window* parent, size_t board_rows, size_t board_columns);
 
     size_t m_board_rows;
     size_t m_board_columns;

--- a/Userland/Games/Flood/SettingsDialog.h
+++ b/Userland/Games/Flood/SettingsDialog.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include "SettingsWidget.h"
 #include <AK/Types.h>
 #include <LibGUI/Dialog.h>
 
@@ -17,7 +18,7 @@ public:
     size_t board_columns() const { return m_board_columns; }
 
 private:
-    SettingsDialog(NonnullRefPtr<GUI::Widget> settings_widget, GUI::Window* parent, size_t board_rows, size_t board_columns);
+    SettingsDialog(NonnullRefPtr<Flood::SettingsWidget> settings_widget, GUI::Window* parent, size_t board_rows, size_t board_columns);
 
     size_t m_board_rows;
     size_t m_board_columns;

--- a/Userland/Games/Flood/SettingsWidget.gml
+++ b/Userland/Games/Flood/SettingsWidget.gml
@@ -1,4 +1,4 @@
-@GUI::Frame {
+@Flood::SettingsWidget {
     fill_with_background_color: true
     layout: @GUI::VerticalBoxLayout {
         margins: [4]

--- a/Userland/Games/Flood/SettingsWidget.h
+++ b/Userland/Games/Flood/SettingsWidget.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2023, the SerenityOS developers
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibGUI/Widget.h>
+
+namespace Flood {
+
+class SettingsWidget : public GUI::Widget {
+    C_OBJECT_ABSTRACT(SettingsWidget)
+public:
+    static ErrorOr<NonnullRefPtr<SettingsWidget>> try_create();
+    virtual ~SettingsWidget() override = default;
+
+private:
+    SettingsWidget() = default;
+};
+
+}

--- a/Userland/Games/Flood/main.cpp
+++ b/Userland/Games/Flood/main.cpp
@@ -7,6 +7,7 @@
 #include "BoardWidget.h"
 #include "MainWidget.h"
 #include "SettingsDialog.h"
+#include <AK/String.h>
 #include <AK/URL.h>
 #include <LibConfig/Client.h>
 #include <LibCore/System.h>
@@ -145,12 +146,12 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             board_widget->board()->update_values();
             update();
             if (board_widget->board()->is_flooded()) {
-                DeprecatedString dialog_text("You have tied with the AI."sv);
+                auto dialog_text = "You have tied with the AI."_string;
                 auto dialog_title("Congratulations!"sv);
                 if (ai_moves - moves_made == 1)
-                    dialog_text = "You defeated the AI by 1 move."sv;
+                    dialog_text = "You defeated the AI by 1 move."_string;
                 else if (ai_moves - moves_made > 1)
-                    dialog_text = DeprecatedString::formatted("You defeated the AI by {} moves.", ai_moves - moves_made);
+                    dialog_text = String::formatted("You defeated the AI by {} moves.", ai_moves - moves_made).release_value_but_fixme_should_propagate_errors();
                 else
                     dialog_title = "Game over!"sv;
                 GUI::MessageBox::show(window,

--- a/Userland/Games/Flood/main.cpp
+++ b/Userland/Games/Flood/main.cpp
@@ -108,7 +108,13 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     update();
 
     auto change_settings = [&] {
-        auto settings_dialog = SettingsDialog::construct(window, board_rows, board_columns);
+        auto settings_dialog_or_error = SettingsDialog::try_create(window, board_rows, board_columns);
+        if (settings_dialog_or_error.is_error()) {
+            GUI::MessageBox::show(window, "Failed to load the settings window"sv, "Unable to Open Settings"sv, GUI::MessageBox::Type::Error);
+            return;
+        }
+
+        auto settings_dialog = settings_dialog_or_error.release_value();
         if (settings_dialog->exec() != GUI::Dialog::ExecResult::OK)
             return;
 

--- a/Userland/Games/Flood/main.cpp
+++ b/Userland/Games/Flood/main.cpp
@@ -5,9 +5,9 @@
  */
 
 #include "BoardWidget.h"
+#include "MainWidget.h"
 #include "SettingsDialog.h"
 #include <AK/URL.h>
-#include <Games/Flood/FloodWindowGML.h>
 #include <LibConfig/Client.h>
 #include <LibCore/System.h>
 #include <LibDesktop/Launcher.h>
@@ -82,8 +82,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_title("Flood");
     window->resize(304, 325);
 
-    auto main_widget = TRY(window->set_main_widget<GUI::Widget>());
-    TRY(main_widget->load_from_gml(flood_window_gml));
+    auto main_widget = TRY(Flood::MainWidget::try_create());
+    window->set_main_widget(main_widget);
 
     auto board_widget = TRY(main_widget->find_descendant_of_type_named<GUI::Widget>("board_widget_container")->try_add<BoardWidget>(board_rows, board_columns));
     board_widget->board()->randomize();


### PR DESCRIPTION
- Flood: Propagate errors when creating SettingsDialog
- Flood: Use the new GML compiler
- Flood: Replace usage of DeprecatedString

Contributes to #17128 and #20518. 