### PR TITLE
Calendar: Promote view_type ActionGroup to CalendarWidget's member

### DIFF
--- a/Userland/Applications/Calendar/CalendarWidget.cpp
+++ b/Userland/Applications/Calendar/CalendarWidget.cpp
@@ -49,11 +49,12 @@ ErrorOr<NonnullRefPtr<CalendarWidget>> CalendarWidget::create(GUI::Window* paren
     view_month_action->set_checked(true);
 
     auto view_year_action = TRY(widget->create_view_year_action());
-    auto view_type_action_group = make<GUI::ActionGroup>();
 
-    view_type_action_group->set_exclusive(true);
-    view_type_action_group->add_action(*view_month_action);
-    view_type_action_group->add_action(*view_year_action);
+    widget->m_view_type_action_group = make<GUI::ActionGroup>();
+    widget->m_view_type_action_group->set_exclusive(true);
+    widget->m_view_type_action_group->add_action(*view_month_action);
+    widget->m_view_type_action_group->add_action(*view_year_action);
+
     auto default_view = Config::read_string("Calendar"sv, "View"sv, "DefaultView"sv, "Month"sv);
     if (default_view == "Year")
         view_year_action->set_checked(true);

--- a/Userland/Applications/Calendar/CalendarWidget.h
+++ b/Userland/Applications/Calendar/CalendarWidget.h
@@ -42,6 +42,8 @@ private:
     ErrorOr<NonnullRefPtr<GUI::Action>> create_view_year_action();
     ErrorOr<NonnullRefPtr<GUI::Action>> create_open_settings_action();
 
+    OwnPtr<GUI::ActionGroup> m_view_type_action_group;
+
     RefPtr<EventCalendar> m_event_calendar;
 };
 


### PR DESCRIPTION
Otherwise, it would get destroyed after exiting the create() function.

| Before: | After: |
| --- | --- |
| <video src="https://github.com/SerenityOS/serenity/assets/36564831/48e7e2ff-160c-45d8-b801-90740af3f061"> | <video src="https://github.com/SerenityOS/serenity/assets/36564831/bee6adfd-d707-4353-82f9-19d93fcff556"> |

