### PR TITLE
headless-browser: Add ref tests support

### DIFF
--- a/Tests/LibWeb/Ref/manifest.json
+++ b/Tests/LibWeb/Ref/manifest.json
@@ -1,0 +1,3 @@
+{
+    "square-flex.html": "square-ref.html"
+}

--- a/Tests/LibWeb/Ref/square-flex.html
+++ b/Tests/LibWeb/Ref/square-flex.html
@@ -1,0 +1,11 @@
+<style>
+    .box {
+        display: flex;
+    }
+
+    .item {
+        width: 100px;
+        height: 100px;
+        background-color: pink;
+    }
+</style><div class="box"><div class="item">

--- a/Tests/LibWeb/Ref/square-ref.html
+++ b/Tests/LibWeb/Ref/square-ref.html
@@ -1,0 +1,7 @@
+<style>
+    .box {
+        width: 100px;
+        height: 100px;
+        background-color: pink;
+    }
+</style><div class="box"></div>


### PR DESCRIPTION
The ref tests runner takes screenshots of both the input page and the expected page, then compares them. Ref testing allows us to catch painting bugs, which cannot be detected with the layout and text tests we already have.

With ref tests, we'll likely want to reuse the same expectation page for multiple inputs. Therefore, there's a `manifest.json` file that describes the relationship between inputs and expected outputs.