### PR TITLE
Calendar: Use proper tile information when painting tiles after January

### DIFF
--- a/Userland/Libraries/LibGUI/Calendar.cpp
+++ b/Userland/Libraries/LibGUI/Calendar.cpp
@@ -588,7 +588,7 @@ void Calendar::paint_event(GUI::PaintEvent& event)
                         m_tiles[l][i].height);
                     m_tiles[l][i].rect = tile_rect.translated(frame_thickness(), frame_thickness());
 
-                    paint_tile(painter, m_tiles[0][i], tile_rect, x_offset, y_offset, k);
+                    paint_tile(painter, m_tiles[l][i], tile_rect, x_offset, y_offset, k);
 
                     i++;
                 }


### PR DESCRIPTION
| Before: | After: |
| --- | --- |
| <video src="https://github.com/SerenityOS/serenity/assets/36564831/b9133343-163a-4044-a1cd-6d3883f18a59"> | <video src="https://github.com/SerenityOS/serenity/assets/36564831/d0c360fa-460d-491d-8588-e9b8ab12260f"> |