### PR TITLE
LibWeb: Fix typo in query of link elements search params

### DIFF
--- a/Tests/LibWeb/Text/expected/link-element-search.txt
+++ b/Tests/LibWeb/Text/expected/link-element-search.txt
@@ -1,0 +1,1 @@
+   ?q=some:query

--- a/Tests/LibWeb/Text/input/link-element-search.html
+++ b/Tests/LibWeb/Text/input/link-element-search.html
@@ -1,0 +1,7 @@
+<a id="link-with-query" rel="search" href="https://serenityos.org/search?q=some:query"</a>
+<script src="include.js"></script>
+<script>
+    window.onload = function() {
+        println(document.getElementById("link-with-query").search);
+    }
+</script>

--- a/Userland/Libraries/LibWeb/HTML/HTMLHyperlinkElementUtils.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLHyperlinkElementUtils.cpp
@@ -330,7 +330,7 @@ DeprecatedString HTMLHyperlinkElementUtils::search() const
     // 2. Let url be this element's url.
 
     // 3. If url is null, or url's query is either null or the empty string, return the empty string.
-    if (!m_url.has_value() || m_url->query().has_value() || m_url->query()->is_empty())
+    if (!m_url.has_value() || !m_url->query().has_value() || m_url->query()->is_empty())
         return DeprecatedString::empty();
 
     // 4. Return "?", followed by url's query.


### PR DESCRIPTION
Regressed in 21fe86d235845626383fc321d1125d4a2c6db98a

`is_null() != has_value()` - forgetting to add `!` in the port `DeprecatedString` to `Optional` :(