### PR TITLE
LibWeb: Add ref test for opacity (stacking context) paint order

### DIFF
--- a/Tests/LibWeb/Ref/opacity-stacking-ref.html
+++ b/Tests/LibWeb/Ref/opacity-stacking-ref.html
@@ -1,0 +1,4 @@
+<svg width="600" viewBox="0 0 150 100" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="100" cy="50" r="40" fill="#b3b3b3" />
+  <circle cx="50" cy="50" r="40" fill="blue" />
+</svg>

--- a/Tests/LibWeb/Ref/opacity-stacking.html
+++ b/Tests/LibWeb/Ref/opacity-stacking.html
@@ -1,0 +1,4 @@
+<svg width="600" viewBox="0 0 150 100" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="100" cy="50" r="40" fill="black" opacity="0.3" />
+  <circle cx="50" cy="50" r="40" fill="blue" />
+</svg>


### PR DESCRIPTION
Now that we can test this, let's add a test, as mentioned in: https://github.com/SerenityOS/serenity/pull/20559#issuecomment-1677126697

(I confirmed this test failed before #20559)