### PR TITLE
LibWeb: Cache and return the height computed when computing cell width

### DIFF
--- a/Tests/LibWeb/Layout/expected/table/cell-height-with-line-breaks-and-trailing-whitespace.txt
+++ b/Tests/LibWeb/Layout/expected/table/cell-height-with-line-breaks-and-trailing-whitespace.txt
@@ -1,0 +1,45 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x39.40625 children: not-inline
+      TableWrapper <(anonymous)> at (8,8) content-size 61x39.40625 [BFC] children: not-inline
+        Box <table> at (8,8) content-size 61x39.40625 table-box [TFC] children: not-inline
+          Box <tbody> at (8,8) content-size 61x39.40625 table-row-group children: not-inline
+            Box <tr> at (8,8) content-size 61x39.40625 table-row children: not-inline
+              BlockContainer <td> at (10,18.96875) content-size 14.296875x17.46875 table-cell [BFC] children: inline
+                line 0 width: 14.265625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                  frag 0 from TextNode start: 0, length: 1, rect: [10,18.96875 14.265625x17.46875]
+                    "A"
+                TextNode <#text>
+              BlockContainer <td> at (28.296875,10) content-size 20.40625x35.40625 table-cell [BFC] children: inline
+                line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                  frag 0 from TextNode start: 0, length: 1, rect: [28.296875,10 9.34375x17.46875]
+                    "B"
+                line 1 width: 10.3125, height: 17.9375, bottom: 35.40625, baseline: 13.53125
+                  frag 0 from TextNode start: 0, length: 1, rect: [28.296875,27 10.3125x17.46875]
+                    "C"
+                TextNode <#text>
+                BreakNode <br>
+                TextNode <#text>
+              BlockContainer <td> at (52.703125,18.96875) content-size 14.296875x17.46875 table-cell [BFC] children: inline
+                line 0 width: 11.140625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                  frag 0 from TextNode start: 0, length: 1, rect: [52.703125,18.96875 11.140625x17.46875]
+                    "D"
+                TextNode <#text>
+      BlockContainer <(anonymous)> at (8,47.40625) content-size 784x0 children: inline
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x39.40625]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 61x39.40625]
+        PaintableBox (Box<TABLE>) [8,8 61x39.40625]
+          PaintableBox (Box<TBODY>) [8,8 61x39.40625]
+            PaintableBox (Box<TR>) [8,8 61x39.40625]
+              PaintableWithLines (BlockContainer<TD>) [8,8 18.296875x39.40625]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [26.296875,8 24.40625x39.40625]
+                TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [50.703125,8 18.296875x39.40625]
+                TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,47.40625 784x0]

--- a/Tests/LibWeb/Layout/input/table/cell-height-with-line-breaks-and-trailing-whitespace.html
+++ b/Tests/LibWeb/Layout/input/table/cell-height-with-line-breaks-and-trailing-whitespace.html
@@ -1,0 +1,10 @@
+<style>
+    table {
+        border-collapse: collapse
+    }
+
+    td {
+        border: 1px solid black;
+    }
+</style><table><tbody><tr><td style="width: 30%;">A</td><td style="width: 40%;">B
+    <br>C</td><td style="width: 30%;">D</td></tr></tbody></table>

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -1286,8 +1286,8 @@ CSSPixels FormattingContext::calculate_min_content_width(Layout::Box const& box)
     auto& root_state = m_state.m_root;
 
     auto& cache = *root_state.intrinsic_sizes.ensure(&box, [] { return adopt_own(*new LayoutState::IntrinsicSizes); });
-    if (cache.min_content_width.has_value())
-        return *cache.min_content_width;
+    if (cache.sizes_for_min_content_width.has_value())
+        return cache.sizes_for_min_content_width->width();
 
     LayoutState throwaway_state(&m_state);
 
@@ -1305,15 +1305,15 @@ CSSPixels FormattingContext::calculate_min_content_width(Layout::Box const& box)
     auto available_height = AvailableSize::make_indefinite();
     context->run(box, LayoutMode::IntrinsicSizing, AvailableSpace(available_width, available_height));
 
-    cache.min_content_width = context->automatic_content_width();
+    cache.sizes_for_min_content_width = CSSPixelSize { context->automatic_content_width(), {} };
 
-    if (cache.min_content_width->might_be_saturated()) {
+    if (cache.sizes_for_min_content_width->width().might_be_saturated()) {
         // HACK: If layout calculates a non-finite result, something went wrong. Force it to zero and log a little whine.
         dbgln("FIXME: Calculated non-finite min-content width for {}", box.debug_description());
-        cache.min_content_width = 0;
+        cache.sizes_for_min_content_width->set_width(0);
     }
 
-    return *cache.min_content_width;
+    return cache.sizes_for_min_content_width->width();
 }
 
 CSSPixels FormattingContext::calculate_max_content_width(Layout::Box const& box) const
@@ -1324,8 +1324,8 @@ CSSPixels FormattingContext::calculate_max_content_width(Layout::Box const& box)
     auto& root_state = m_state.m_root;
 
     auto& cache = *root_state.intrinsic_sizes.ensure(&box, [] { return adopt_own(*new LayoutState::IntrinsicSizes); });
-    if (cache.max_content_width.has_value())
-        return *cache.max_content_width;
+    if (cache.sizes_for_max_content_width.has_value())
+        return cache.sizes_for_max_content_width->width();
 
     LayoutState throwaway_state(&m_state);
 
@@ -1343,15 +1343,15 @@ CSSPixels FormattingContext::calculate_max_content_width(Layout::Box const& box)
     auto available_height = AvailableSize::make_indefinite();
     context->run(box, LayoutMode::IntrinsicSizing, AvailableSpace(available_width, available_height));
 
-    cache.max_content_width = context->automatic_content_width();
+    cache.sizes_for_max_content_width = CSSPixelSize { context->automatic_content_width(), {} };
 
-    if (cache.max_content_width->might_be_saturated()) {
+    if (cache.sizes_for_max_content_width->width().might_be_saturated()) {
         // HACK: If layout calculates a non-finite result, something went wrong. Force it to zero and log a little whine.
         dbgln("FIXME: Calculated non-finite max-content width for {}", box.debug_description());
-        cache.max_content_width = 0;
+        cache.sizes_for_max_content_width->set_width(0);
     }
 
-    return *cache.max_content_width;
+    return cache.sizes_for_max_content_width->width();
 }
 
 // https://www.w3.org/TR/css-sizing-3/#min-content-block-size

--- a/Userland/Libraries/LibWeb/Layout/LayoutState.h
+++ b/Userland/Libraries/LibWeb/Layout/LayoutState.h
@@ -162,8 +162,8 @@ struct LayoutState {
     // We cache intrinsic sizes once determined, as they will not change over the course of a full layout.
     // This avoids computing them several times while performing flex layout.
     struct IntrinsicSizes {
-        Optional<CSSPixels> min_content_width;
-        Optional<CSSPixels> max_content_width;
+        Optional<CSSPixelSize> sizes_for_min_content_width;
+        Optional<CSSPixelSize> sizes_for_max_content_width;
 
         HashMap<CSSPixels, Optional<CSSPixels>> min_content_height;
         HashMap<CSSPixels, Optional<CSSPixels>> max_content_height;

--- a/Userland/Libraries/LibWeb/Layout/TableFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/TableFormattingContext.h
@@ -70,6 +70,14 @@ private:
     template<class ColumnFilter>
     bool distribute_excess_width_by_intrinsic_percentage(CSSPixels excess_width, ColumnFilter column_filter);
 
+    struct CalculatedBoxSizes {
+        CSSPixels width;
+        Optional<CSSPixels> height;
+    };
+
+    CalculatedBoxSizes calculate_sizes_for_min_content_width_box(Layout::Box const&) const;
+    CalculatedBoxSizes calculate_sizes_for_max_content_width_box(Layout::Box const&) const;
+
     bool use_fixed_mode_layout() const;
 
     CSSPixels m_table_height { 0 };


### PR DESCRIPTION
Retrieve and cache cell height alongside min- and max-width. This prevents using a width which is too small for the min-height computation, which happens when we trim trailing whitespace when we build the line boxes.