### PR TITLE
LibWeb: Improvements to position:relative for inline-level elements

### DIFF
--- a/Tests/LibWeb/Layout/expected/block-and-inline/relpos-inline-element-js-offsets.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/relpos-inline-element-js-offsets.txt
@@ -1,0 +1,58 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x156.6875 children: not-inline
+      BlockContainer <(anonymous)> at (8,8) content-size 784x17.46875 children: inline
+        line 0 width: 136.609375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+          frag 0 from TextNode start: 0, length: 5, rect: [8,8 36.40625x17.46875]
+            "well "
+          frag 1 from TextNode start: 0, length: 6, rect: [44,33 44.84375x17.46875]
+            "hello "
+          frag 2 from TextNode start: 0, length: 7, rect: [89,58 55.359375x17.46875]
+            "friends"
+        InlineNode <span>
+          TextNode <#text>
+          InlineNode <b>
+            TextNode <#text>
+            InlineNode <i>
+              TextNode <#text>
+        TextNode <#text>
+      BlockContainer <div> at (8,25.46875) content-size 784x139.21875 children: not-inline
+        BlockContainer <(anonymous)> at (8,25.46875) content-size 784x69.875 children: inline
+          line 0 width: 0, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+          line 1 width: 0, height: 17.46875, bottom: 34.9375, baseline: 13.53125
+          line 2 width: 0, height: 17.46875, bottom: 52.40625, baseline: 13.53125
+          line 3 width: 0, height: 17.46875, bottom: 69.875, baseline: 13.53125
+          BreakNode <br>
+          BreakNode <br>
+          BreakNode <br>
+          BreakNode <br>
+        BlockContainer <pre#out> at (8,111.34375) content-size 784x53.34375 children: inline
+          line 0 width: 72.421875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 10, rect: [8,111.34375 72.421875x17.46875]
+              "well: 0, 0"
+          line 1 width: 96.765625, height: 17.9375, bottom: 35.40625, baseline: 13.53125
+            frag 0 from TextNode start: 11, length: 13, rect: [8,128.34375 96.765625x17.46875]
+              "hello: 36, 25"
+          line 2 width: 113.65625, height: 18.40625, bottom: 53.34375, baseline: 13.53125
+            frag 0 from TextNode start: 25, length: 15, rect: [8,145.34375 113.65625x17.46875]
+              "friends: 45, 25"
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (8,180.6875) content-size 784x0 children: inline
+        TextNode <#text>
+        TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x156.6875] overflow: [8,8 784x172.6875]
+      PaintableWithLines (BlockContainer(anonymous)) [8,8 784x17.46875] overflow: [8,8 784x67.46875]
+        InlinePaintable (InlineNode<SPAN>)
+          TextPaintable (TextNode<#text>)
+          InlinePaintable (InlineNode<B>)
+            TextPaintable (TextNode<#text>)
+            InlinePaintable (InlineNode<I>)
+              TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer<DIV>) [8,25.46875 784x139.21875]
+        PaintableWithLines (BlockContainer(anonymous)) [8,25.46875 784x69.875]
+        PaintableWithLines (BlockContainer<PRE>#out) [8,111.34375 784x53.34375]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,180.6875 784x0]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/relpos-inline-elements.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/relpos-inline-elements.txt
@@ -1,0 +1,31 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x17.46875 children: inline
+      line 0 width: 98, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+        frag 0 from TextNode start: 0, length: 4, rect: [8,8 35.15625x17.46875]
+          "foo "
+        frag 1 from TextNode start: 0, length: 3, rect: [43,33 27.640625x17.46875]
+          "bar"
+        frag 2 from TextNode start: 0, length: 1, rect: [71,8 8x17.46875]
+          " "
+        frag 3 from TextNode start: 0, length: 3, rect: [54,58 27.203125x17.46875]
+          "baz"
+      TextNode <#text>
+      InlineNode <b>
+        TextNode <#text>
+      TextNode <#text>
+      InlineNode <b>
+        InlineNode <i>
+          TextNode <#text>
+      TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x17.46875] overflow: [8,8 784x67.46875]
+      TextPaintable (TextNode<#text>)
+      InlinePaintable (InlineNode<B>)
+        TextPaintable (TextNode<#text>)
+      TextPaintable (TextNode<#text>)
+      InlinePaintable (InlineNode<B>)
+        InlinePaintable (InlineNode<I>)
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/input/block-and-inline/relpos-inline-element-js-offsets.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/relpos-inline-element-js-offsets.html
@@ -1,0 +1,20 @@
+<style>
+b, i {
+    position: relative;
+    top: 25px;
+}
+</style><span>well <b>hello <i>friends</i></b></span>
+<div><br><br><br><br><pre id=out></pre></div>
+
+<script>
+function println(s) {
+    let out = document.getElementById("out");
+    out.innerHTML += s + "\n";
+}
+let i = document.getElementsByTagName("i")[0]
+let b = document.getElementsByTagName("b")[0]
+let span = document.getElementsByTagName("span")[0]
+println("well: " + span.offsetLeft + ", " + span.offsetTop)
+println("hello: " + b.offsetLeft + ", " + b.offsetTop)
+println("friends: " + i.offsetLeft + ", " + i.offsetTop)
+</script>

--- a/Tests/LibWeb/Layout/input/block-and-inline/relpos-inline-elements.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/relpos-inline-elements.html
@@ -1,0 +1,12 @@
+<style>
+b {
+    position: relative;
+    top: 25px;
+}
+i {
+    position: relative;
+    top: 25px;
+    right: 25px;
+}
+</style>
+<body>foo <b>bar</b> <b><i>baz</i></b>

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -1199,7 +1199,7 @@ void FormattingContext::compute_height_for_absolutely_positioned_replaced_elemen
 }
 
 // https://www.w3.org/TR/css-position-3/#relpos-insets
-void FormattingContext::compute_inset(Box const& box)
+void FormattingContext::compute_inset(NodeWithStyleAndBoxModelMetrics const& box)
 {
     if (box.computed_values().position() != CSS::Position::Relative)
         return;
@@ -1512,12 +1512,12 @@ CSS::Length FormattingContext::calculate_inner_height(Layout::Box const& box, Av
     return height.resolved(box, height_of_containing_block_as_length_for_resolve);
 }
 
-CSSPixels FormattingContext::containing_block_width_for(Box const& box) const
+CSSPixels FormattingContext::containing_block_width_for(NodeWithStyleAndBoxModelMetrics const& node) const
 {
-    auto const& containing_block_state = m_state.get(*box.containing_block());
-    auto const& box_state = m_state.get(box);
+    auto const& containing_block_state = m_state.get(*node.containing_block());
+    auto const& node_state = m_state.get(node);
 
-    switch (box_state.width_constraint) {
+    switch (node_state.width_constraint) {
     case SizeConstraint::MinContent:
         return 0;
     case SizeConstraint::MaxContent:
@@ -1528,12 +1528,12 @@ CSSPixels FormattingContext::containing_block_width_for(Box const& box) const
     VERIFY_NOT_REACHED();
 }
 
-CSSPixels FormattingContext::containing_block_height_for(Box const& box) const
+CSSPixels FormattingContext::containing_block_height_for(NodeWithStyleAndBoxModelMetrics const& node) const
 {
-    auto const& containing_block_state = m_state.get(*box.containing_block());
-    auto const& box_state = m_state.get(box);
+    auto const& containing_block_state = m_state.get(*node.containing_block());
+    auto const& node_state = m_state.get(node);
 
-    switch (box_state.height_constraint) {
+    switch (node_state.height_constraint) {
     case SizeConstraint::MinContent:
         return 0;
     case SizeConstraint::MaxContent:
@@ -1544,12 +1544,12 @@ CSSPixels FormattingContext::containing_block_height_for(Box const& box) const
     VERIFY_NOT_REACHED();
 }
 
-AvailableSize FormattingContext::containing_block_width_as_available_size(Box const& box) const
+AvailableSize FormattingContext::containing_block_width_as_available_size(NodeWithStyleAndBoxModelMetrics const& node) const
 {
-    auto const& containing_block_state = m_state.get(*box.containing_block());
-    auto const& box_state = m_state.get(box);
+    auto const& containing_block_state = m_state.get(*node.containing_block());
+    auto const& node_state = m_state.get(node);
 
-    switch (box_state.width_constraint) {
+    switch (node_state.width_constraint) {
     case SizeConstraint::MinContent:
         return AvailableSize::make_min_content();
     case SizeConstraint::MaxContent:
@@ -1560,12 +1560,12 @@ AvailableSize FormattingContext::containing_block_width_as_available_size(Box co
     VERIFY_NOT_REACHED();
 }
 
-AvailableSize FormattingContext::containing_block_height_as_available_size(Box const& box) const
+AvailableSize FormattingContext::containing_block_height_as_available_size(NodeWithStyleAndBoxModelMetrics const& node) const
 {
-    auto const& containing_block_state = m_state.get(*box.containing_block());
-    auto const& box_state = m_state.get(box);
+    auto const& containing_block_state = m_state.get(*node.containing_block());
+    auto const& node_state = m_state.get(node);
 
-    switch (box_state.height_constraint) {
+    switch (node_state.height_constraint) {
     case SizeConstraint::MinContent:
         return AvailableSize::make_min_content();
     case SizeConstraint::MaxContent:

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.h
@@ -80,11 +80,11 @@ public:
     [[nodiscard]] CSSPixels box_baseline(Box const&) const;
     [[nodiscard]] CSSPixelRect content_box_rect_in_static_position_ancestor_coordinate_space(Box const&, Box const& ancestor_box) const;
 
-    [[nodiscard]] CSSPixels containing_block_width_for(Box const&) const;
-    [[nodiscard]] CSSPixels containing_block_height_for(Box const&) const;
+    [[nodiscard]] CSSPixels containing_block_width_for(NodeWithStyleAndBoxModelMetrics const&) const;
+    [[nodiscard]] CSSPixels containing_block_height_for(NodeWithStyleAndBoxModelMetrics const&) const;
 
-    [[nodiscard]] AvailableSize containing_block_width_as_available_size(Box const&) const;
-    [[nodiscard]] AvailableSize containing_block_height_as_available_size(Box const&) const;
+    [[nodiscard]] AvailableSize containing_block_width_as_available_size(NodeWithStyleAndBoxModelMetrics const&) const;
+    [[nodiscard]] AvailableSize containing_block_height_as_available_size(NodeWithStyleAndBoxModelMetrics const&) const;
 
     [[nodiscard]] CSSPixels calculate_stretch_fit_width(Box const&, AvailableSize const&) const;
     [[nodiscard]] CSSPixels calculate_stretch_fit_height(Box const&, AvailableSize const&) const;

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.h
@@ -96,6 +96,8 @@ public:
     virtual CSSPixelPoint calculate_static_position(Box const&) const;
     bool can_skip_is_anonymous_text_run(Box&);
 
+    void compute_inset(NodeWithStyleAndBoxModelMetrics const&);
+
 protected:
     FormattingContext(Type, LayoutState&, Box const&, FormattingContext* parent = nullptr);
 
@@ -106,7 +108,6 @@ protected:
     [[nodiscard]] bool should_treat_max_height_as_none(Box const&, AvailableSize const&) const;
 
     OwnPtr<FormattingContext> layout_inside(Box const&, LayoutMode, AvailableSpace const&);
-    void compute_inset(Box const& box);
 
     struct SpaceUsedByFloats {
         CSSPixels left { 0 };

--- a/Userland/Libraries/LibWeb/Layout/InlineLevelIterator.cpp
+++ b/Userland/Libraries/LibWeb/Layout/InlineLevelIterator.cpp
@@ -42,6 +42,9 @@ void InlineLevelIterator::enter_node_with_box_model_metrics(Layout::NodeWithStyl
     m_extra_leading_metrics->border += used_values.border_left;
     m_extra_leading_metrics->padding += used_values.padding_left;
 
+    // Now's our chance to resolve the inset properties for this node.
+    m_inline_formatting_context.compute_inset(node);
+
     m_box_model_node_stack.append(node);
 }
 

--- a/Userland/Libraries/LibWeb/Layout/LayoutState.h
+++ b/Userland/Libraries/LibWeb/Layout/LayoutState.h
@@ -172,6 +172,9 @@ struct LayoutState {
 
     LayoutState const* m_parent { nullptr };
     LayoutState const& m_root;
+
+private:
+    void resolve_relative_positions(Vector<Painting::PaintableWithLines&> const&);
 };
 
 }

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -229,16 +229,14 @@ CSSPixelPoint Node::box_type_agnostic_position() const
         return verify_cast<Box>(*this).paintable_box()->absolute_position();
     VERIFY(is_inline());
     CSSPixelPoint position;
-    if (auto* block = containing_block()) {
-        if (is<Painting::PaintableWithLines>(*block)) {
-            static_cast<Painting::PaintableWithLines const&>(*block->paintable_box()).for_each_fragment([&](auto& fragment) {
-                if (&fragment.layout_node() == this || is_ancestor_of(fragment.layout_node())) {
-                    position = fragment.absolute_rect().location();
-                    return IterationDecision::Break;
-                }
-                return IterationDecision::Continue;
-            });
-        }
+    if (auto* block = containing_block(); block && block->paintable() && is<Painting::PaintableWithLines>(*block->paintable())) {
+        static_cast<Painting::PaintableWithLines const&>(*block->paintable_box()).for_each_fragment([&](auto& fragment) {
+            if (&fragment.layout_node() == this || is_ancestor_of(fragment.layout_node())) {
+                position = fragment.absolute_rect().location();
+                return IterationDecision::Break;
+            }
+            return IterationDecision::Continue;
+        });
     }
     return position;
 }

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -115,16 +115,16 @@ void PaintableBox::set_content_size(CSSPixelSize size)
     layout_box().did_set_content_size();
 }
 
-CSSPixelPoint PaintableBox::effective_offset() const
+CSSPixelPoint PaintableBox::offset() const
 {
     return m_offset;
 }
 
 CSSPixelRect PaintableBox::compute_absolute_rect() const
 {
-    CSSPixelRect rect { effective_offset(), content_size() };
+    CSSPixelRect rect { offset(), content_size() };
     for (auto const* block = containing_block(); block && block->paintable(); block = block->paintable()->containing_block())
-        rect.translate_by(block->paintable_box()->effective_offset());
+        rect.translate_by(block->paintable_box()->offset());
     return rect;
 }
 

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -117,19 +117,7 @@ void PaintableBox::set_content_size(CSSPixelSize size)
 
 CSSPixelPoint PaintableBox::effective_offset() const
 {
-    CSSPixelPoint offset;
-    if (containing_block() && m_containing_line_box_fragment.has_value()) {
-        auto& paintable_with_lines = *verify_cast<PaintableWithLines>(containing_block()->paintable_box());
-        auto const& fragment = paintable_with_lines.line_boxes()[m_containing_line_box_fragment->line_box_index].fragments()[m_containing_line_box_fragment->fragment_index];
-        offset = fragment.offset();
-    } else {
-        offset = m_offset;
-    }
-    if (layout_box().computed_values().position() == CSS::Position::Relative) {
-        auto const& inset = layout_box().box_model().inset;
-        offset.translate_by(inset.left, inset.top);
-    }
-    return offset;
+    return m_offset;
 }
 
 CSSPixelRect PaintableBox::compute_absolute_rect() const
@@ -174,11 +162,6 @@ CSSPixelRect PaintableBox::absolute_paint_rect() const
     if (!m_absolute_paint_rect.has_value())
         m_absolute_paint_rect = compute_absolute_paint_rect();
     return *m_absolute_paint_rect;
-}
-
-void PaintableBox::set_containing_line_box_fragment(Optional<Layout::LineBoxFragmentCoordinate> fragment_coordinate)
-{
-    m_containing_line_box_fragment = move(fragment_coordinate);
 }
 
 StackingContext* PaintableBox::enclosing_stacking_context()

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.h
@@ -112,7 +112,6 @@ public:
     Optional<CSSPixelRect> calculate_overflow_clipped_rect() const;
 
     void set_overflow_data(OverflowData data) { m_overflow_data = move(data); }
-    void set_containing_line_box_fragment(Optional<Layout::LineBoxFragmentCoordinate>);
 
     StackingContext* stacking_context() { return m_stacking_context; }
     StackingContext const* stacking_context() const { return m_stacking_context; }
@@ -200,9 +199,6 @@ private:
 
     CSSPixelPoint m_offset;
     CSSPixelSize m_content_size;
-
-    // Some boxes hang off of line box fragments. (inline-block, inline-table, replaced, etc)
-    Optional<Layout::LineBoxFragmentCoordinate> m_containing_line_box_fragment;
 
     OwnPtr<StackingContext> m_stacking_context;
 

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.h
@@ -36,7 +36,9 @@ public:
     };
 
     CSSPixelRect absolute_rect() const;
-    CSSPixelPoint effective_offset() const;
+
+    // Offset from the top left of the containing block's content edge.
+    [[nodiscard]] CSSPixelPoint offset() const;
 
     CSSPixelPoint scroll_offset() const;
     void set_scroll_offset(CSSPixelPoint);

--- a/Userland/Libraries/LibWeb/Painting/SVGPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/SVGPaintable.cpp
@@ -23,9 +23,9 @@ Layout::SVGBox const& SVGPaintable::layout_box() const
 CSSPixelRect SVGPaintable::compute_absolute_rect() const
 {
     if (auto* svg_svg_box = layout_box().first_ancestor_of_type<Layout::SVGSVGBox>()) {
-        CSSPixelRect rect { effective_offset(), content_size() };
+        CSSPixelRect rect { offset(), content_size() };
         for (Layout::Box const* ancestor = svg_svg_box; ancestor && ancestor->paintable(); ancestor = ancestor->paintable()->containing_block())
-            rect.translate_by(ancestor->paintable_box()->effective_offset());
+            rect.translate_by(ancestor->paintable_box()->offset());
         return rect;
     }
     return PaintableBox::compute_absolute_rect();


### PR DESCRIPTION
See individual commits for details, but basically we can now do stuff like this:

```html
<span style="position: relative; top: 50px;">whee</span>
```