### PR TITLE
Kernel: Stop overeagerly adding a Keypad modifier + add it to the numpad Enter key

### DIFF
--- a/Kernel/Devices/HID/KeyboardDevice.cpp
+++ b/Kernel/Devices/HID/KeyboardDevice.cpp
@@ -244,6 +244,9 @@ void KeyboardDevice::handle_scan_code_input_event(ScanCodeEvent event)
         update_modifier(Mod_Shift, m_left_shift_pressed || m_right_shift_pressed);
         break;
     case 0x35:
+        if (event.e0_prefix)
+            update_modifier(Mod_Keypad, event.pressed);
+        break;
     case 0x37:
     case 0x47:
     case 0x48:
@@ -259,7 +262,8 @@ void KeyboardDevice::handle_scan_code_input_event(ScanCodeEvent event)
     case 0x52:
     case 0x53:
         // FIXME: This should also include the keypad "enter" key, but that has the same scan code as the return key (0x1c).
-        update_modifier(Mod_Keypad, event.pressed);
+        if (!event.e0_prefix)
+            update_modifier(Mod_Keypad, event.pressed);
         break;
     }
 

--- a/Kernel/Devices/HID/KeyboardDevice.cpp
+++ b/Kernel/Devices/HID/KeyboardDevice.cpp
@@ -243,6 +243,7 @@ void KeyboardDevice::handle_scan_code_input_event(ScanCodeEvent event)
         m_right_shift_pressed = event.pressed;
         update_modifier(Mod_Shift, m_left_shift_pressed || m_right_shift_pressed);
         break;
+    case 0x1c:
     case 0x35:
         if (event.e0_prefix)
             update_modifier(Mod_Keypad, event.pressed);
@@ -261,7 +262,6 @@ void KeyboardDevice::handle_scan_code_input_event(ScanCodeEvent event)
     case 0x51:
     case 0x52:
     case 0x53:
-        // FIXME: This should also include the keypad "enter" key, but that has the same scan code as the return key (0x1c).
         if (!event.e0_prefix)
             update_modifier(Mod_Keypad, event.pressed);
         break;


### PR DESCRIPTION
https://github.com/SerenityOS/serenity/pull/19892/commits/afc572a19eb7206a020a3bc4b86ca3fa8859d791 caused several keys that have the same scan codes as keys on the numpad to be considered _on_ the numpad, which broke shortcuts that include those keys.
The difference in scan codes is the presence of the e0 prefix. Note that numpad's `/` and `Enter` have the e0 prefix, but other numpad keys don't.

Comparison of the detected keys, by the html page added in the PR that included https://github.com/SerenityOS/serenity/pull/19892/commits/afc572a19eb7206a020a3bc4b86ca3fa8859d791. Keys pressed in bottom to top order:
`Numpad 0`, `Numpad .`, `Numpad Enter`, `Numpad 1`, `Numpad 2`, `Numpad 3`, `Numpad 4`, `Numpad 5`, `Numpad 6`, `Numpad 7`, `Numpad 8`, `Numpad 9`, `Numpad +`, `Numpad -`, `Numpad *`, `Numpad /`, `Num Lock`, `Pg Down`, `Pg Up`, `End`, `Home`, `Delete`, `PrtSc`, `Insert` (+ left Control, left Alt to leave Qemu).
| Before b81d7f745926db767179c964f85de6ef38b727b1: | After b81d7f745926db767179c964f85de6ef38b727b1: |
| --- | --- |
| ![obraz](https://github.com/SerenityOS/serenity/assets/36564831/7e05036d-9730-49a9-b23d-a9c28100aa99) | ![obraz](https://github.com/SerenityOS/serenity/assets/36564831/08be8f9b-6f77-4554-bda1-d028ff8838f8) |

Notable changes:
Non-numpad `Pg Down`, `Pg Up`, `End`, `Home`, `Delete`, `Insert` are now NOT considered to be on the numpad.
`PrtSc` was before detected as `ShiftLeft` + `NumpadAsterisk`, now it is detected as `ShiftLeft` + `Digit8`. I don't know what the actual code should be, as the opened page in Firefox doesn't even detect the `PrtSc` button on my machine.

Shortcuts that include those keys, that were not working before, are now working (ex. the `Delete` action). Some actions that include those keys (ex. `Page Down`) were mostly handled manually, so they worked anyway.

| Before b81d7f745926db767179c964f85de6ef38b727b1: | After b81d7f745926db767179c964f85de6ef38b727b1: |
| --- | --- |
| <video src="https://github.com/SerenityOS/serenity/assets/36564831/e867bafe-d061-406c-990a-8b15c5b41b52"> | <video src="https://github.com/SerenityOS/serenity/assets/36564831/8312b7c7-22d2-417a-9198-860c2bcfc2e2"> |

---

After 4f8fd64b980f0ddd4bf961a2bc5112e5ddf89871:

![obraz](https://github.com/SerenityOS/serenity/assets/36564831/66ee854f-2ca4-447a-ada5-a70d46fa0512)

