### PR TITLE
LibWeb: Key calculate_{min, max}_content_width cache by parent width

### DIFF
--- a/Tests/LibWeb/Layout/expected/grid/invalidate-width-cache-when-parent-width-changes.txt
+++ b/Tests/LibWeb/Layout/expected/grid/invalidate-width-cache-when-parent-width-changes.txt
@@ -1,0 +1,50 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x27.46875 children: not-inline
+      Box <div.grid> at (8,8) content-size 784x27.46875 [GFC] children: not-inline
+        BlockContainer <div> at (8,8) content-size 784x27.46875 [BFC] children: not-inline
+          BlockContainer <div.left> at (8,8) content-size 6.34375x17.46875 floating [BFC] children: inline
+            line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+              frag 0 from TextNode start: 0, length: 1, rect: [8,8 6.34375x17.46875]
+                "1"
+            TextNode <#text>
+          TableWrapper <(anonymous)> at (14.34375,8) content-size 156.796875x27.46875 floating [BFC] children: not-inline
+            Box <table.middle> at (15.34375,9) content-size 154.796875x25.46875 table-box [TFC] children: not-inline
+              Box <tbody> at (15.34375,9) content-size 148.796875x21.46875 table-row-group children: not-inline
+                Box <tr> at (17.34375,11) content-size 148.796875x21.46875 table-row children: not-inline
+                  BlockContainer <td> at (19.34375,13) content-size 69.59375x17.46875 table-cell [BFC] children: inline
+                    line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                      frag 0 from TextNode start: 0, length: 1, rect: [19.34375,13 8.8125x17.46875]
+                        "2"
+                    TextNode <#text>
+                  BlockContainer <td> at (94.9375,13) content-size 71.203125x17.46875 table-cell [BFC] children: inline
+                    line 0 width: 9.09375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                      frag 0 from TextNode start: 0, length: 1, rect: [94.9375,13 9.09375x17.46875]
+                        "3"
+                    TextNode <#text>
+          BlockContainer <div.right> at (171.140625,8) content-size 7.75x17.46875 floating [BFC] children: inline
+            line 0 width: 7.75, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+              frag 0 from TextNode start: 0, length: 1, rect: [171.140625,8 7.75x17.46875]
+                "4"
+            TextNode <#text>
+      BlockContainer <(anonymous)> at (8,35.46875) content-size 784x0 children: inline
+        TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x27.46875]
+      PaintableBox (Box<DIV>.grid) [8,8 784x27.46875]
+        PaintableWithLines (BlockContainer<DIV>) [8,8 784x27.46875]
+          PaintableWithLines (BlockContainer<DIV>.left) [8,8 6.34375x17.46875]
+            TextPaintable (TextNode<#text>)
+          PaintableWithLines (TableWrapper(anonymous)) [14.34375,8 156.796875x27.46875]
+            PaintableBox (Box<TABLE>.middle) [14.34375,8 156.796875x27.46875]
+              PaintableBox (Box<TBODY>) [15.34375,9 148.796875x21.46875] overflow: [15.34375,9 152.796875x23.46875]
+                PaintableBox (Box<TR>) [17.34375,11 148.796875x21.46875] overflow: [17.34375,11 150.796875x21.46875]
+                  PaintableWithLines (BlockContainer<TD>) [17.34375,11 73.59375x21.46875]
+                    TextPaintable (TextNode<#text>)
+                  PaintableWithLines (BlockContainer<TD>) [92.9375,11 75.203125x21.46875]
+                    TextPaintable (TextNode<#text>)
+          PaintableWithLines (BlockContainer<DIV>.right) [171.140625,8 7.75x17.46875]
+            TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,35.46875 784x0]

--- a/Tests/LibWeb/Layout/input/grid/invalidate-width-cache-when-parent-width-changes.html
+++ b/Tests/LibWeb/Layout/input/grid/invalidate-width-cache-when-parent-width-changes.html
@@ -1,0 +1,23 @@
+<style>
+    .grid {
+        display: grid;
+    }
+
+    .left {
+        float: left;
+    }
+
+    .middle {
+        float: left;
+        width: 20%;
+    }
+
+    .right {
+        float: left;
+    }
+
+    table,
+    td {
+        border: 1px solid black;
+    }
+</style><div class="grid"><div><div class="left">1</div><table class="middle"><tr><td>2</td><td>3</td></tr></table><div class="right">4</div></div></div>

--- a/Userland/Libraries/LibWeb/Layout/LayoutState.h
+++ b/Userland/Libraries/LibWeb/Layout/LayoutState.h
@@ -161,8 +161,8 @@ struct LayoutState {
     // We cache intrinsic sizes once determined, as they will not change over the course of a full layout.
     // This avoids computing them several times while performing flex layout.
     struct IntrinsicSizes {
-        Optional<CSSPixels> min_content_width;
-        Optional<CSSPixels> max_content_width;
+        HashMap<CSSPixels, Optional<CSSPixels>> min_content_width;
+        HashMap<CSSPixels, Optional<CSSPixels>> max_content_width;
 
         HashMap<CSSPixels, Optional<CSSPixels>> min_content_height;
         HashMap<CSSPixels, Optional<CSSPixels>> max_content_height;


### PR DESCRIPTION
For tables, the width should change even if the box is the same if the parent width is adjusted.

Fixes #20385 and some Wikipedia pages, for example: https://en.wikipedia.org/wiki/2022%E2%80%9323_UEFA_Champions_League_knockout_phase