### PR TITLE
LibWeb: Add the `:dir()` selector pseudo-class

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPseudoClass.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPseudoClass.cpp
@@ -73,6 +73,7 @@ struct PseudoClassMetadata {
         ANPlusBOf,
         CompoundSelector,
         ForgivingSelectorList,
+        Ident,
         LanguageRanges,
         SelectorList,
     } parameter_type;
@@ -169,6 +170,8 @@ PseudoClassMetadata pseudo_class_metadata(PseudoClass pseudo_class)
                 parameter_type = "CompoundSelector"_string;
             } else if (argument_string == "<forgiving-selector-list>"sv) {
                 parameter_type = "ForgivingSelectorList"_string;
+            } else if (argument_string == "<ident>"sv) {
+                parameter_type = "Ident"_string;
             } else if (argument_string == "<language-ranges>"sv) {
                 parameter_type = "LanguageRanges"_string;
             } else if (argument_string == "<selector-list>"sv) {

--- a/Tests/LibWeb/Layout/expected/css-dir-selector.txt
+++ b/Tests/LibWeb/Layout/expected/css-dir-selector.txt
@@ -1,0 +1,111 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (100,0) content-size 700x832 [BFC] children: not-inline
+    BlockContainer <body> at (200,8) content-size 592x816 children: not-inline
+      BlockContainer <div> at (301,9) content-size 100x100 children: inline
+        line 0 width: 79.96875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+          frag 0 from TextNode start: 0, length: 11, rect: [301,9 79.96875x17.46875]
+            "Well, hello"
+        line 1 width: 59.21875, height: 17.9375, bottom: 35.40625, baseline: 13.53125
+          frag 0 from TextNode start: 12, length: 8, rect: [301,26 59.21875x17.46875]
+            "friends!"
+        TextNode <#text>
+      BlockContainer <(anonymous)> at (200,110) content-size 592x0 children: inline
+        TextNode <#text>
+      BlockContainer <div> at (301,111) content-size 100x100 children: inline
+        line 0 width: 79.96875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+          frag 0 from TextNode start: 0, length: 11, rect: [301,111 79.96875x17.46875]
+            "Well, hello"
+        line 1 width: 59.21875, height: 17.9375, bottom: 35.40625, baseline: 13.53125
+          frag 0 from TextNode start: 12, length: 8, rect: [301,128 59.21875x17.46875]
+            "friends!"
+        TextNode <#text>
+      BlockContainer <(anonymous)> at (200,212) content-size 592x0 children: inline
+        TextNode <#text>
+      BlockContainer <div> at (401,213) content-size 100x100 children: inline
+        line 0 width: 79.96875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+          frag 0 from TextNode start: 0, length: 11, rect: [401,213 79.96875x17.46875]
+            "Well, hello"
+        line 1 width: 59.21875, height: 17.9375, bottom: 35.40625, baseline: 13.53125
+          frag 0 from TextNode start: 12, length: 8, rect: [401,230 59.21875x17.46875]
+            "friends!"
+        TextNode <#text>
+      BlockContainer <(anonymous)> at (200,314) content-size 592x0 children: inline
+        TextNode <#text>
+      BlockContainer <div> at (301,315) content-size 100x100 children: inline
+        line 0 width: 79.96875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+          frag 0 from TextNode start: 0, length: 11, rect: [301,315 79.96875x17.46875]
+            "Well, hello"
+        line 1 width: 59.21875, height: 17.9375, bottom: 35.40625, baseline: 13.53125
+          frag 0 from TextNode start: 12, length: 8, rect: [301,332 59.21875x17.46875]
+            "friends!"
+        TextNode <#text>
+      BlockContainer <(anonymous)> at (200,416) content-size 592x0 children: inline
+        TextNode <#text>
+      BlockContainer <div> at (301,417) content-size 100x100 children: inline
+        line 0 width: 86.125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+          frag 0 from TextNode start: 0, length: 26, rect: [301,417 86.125x17.46875]
+            "حسنًا ، مرحباً"
+        line 1 width: 78.125, height: 17.9375, bottom: 35.40625, baseline: 13.53125
+          frag 0 from TextNode start: 27, length: 25, rect: [301,434 78.125x17.46875]
+            "أيها الأصدقاء"
+        TextNode <#text>
+      BlockContainer <(anonymous)> at (200,518) content-size 592x0 children: inline
+        TextNode <#text>
+      BlockContainer <div> at (301,519) content-size 100x100 children: inline
+        line 0 width: 86.125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+          frag 0 from TextNode start: 0, length: 26, rect: [301,519 86.125x17.46875]
+            "حسنًا ، مرحباً"
+        line 1 width: 78.125, height: 17.9375, bottom: 35.40625, baseline: 13.53125
+          frag 0 from TextNode start: 27, length: 25, rect: [301,536 78.125x17.46875]
+            "أيها الأصدقاء"
+        TextNode <#text>
+      BlockContainer <(anonymous)> at (200,620) content-size 592x0 children: inline
+        TextNode <#text>
+      BlockContainer <div> at (401,621) content-size 100x100 children: inline
+        line 0 width: 86.125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+          frag 0 from TextNode start: 0, length: 26, rect: [401,621 86.125x17.46875]
+            "حسنًا ، مرحباً"
+        line 1 width: 78.125, height: 17.9375, bottom: 35.40625, baseline: 13.53125
+          frag 0 from TextNode start: 27, length: 25, rect: [401,638 78.125x17.46875]
+            "أيها الأصدقاء"
+        TextNode <#text>
+      BlockContainer <(anonymous)> at (200,722) content-size 592x0 children: inline
+        TextNode <#text>
+      BlockContainer <div> at (401,723) content-size 100x100 children: inline
+        line 0 width: 86.125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+          frag 0 from TextNode start: 0, length: 26, rect: [401,723 86.125x17.46875]
+            "حسنًا ، مرحباً"
+        line 1 width: 78.125, height: 17.9375, bottom: 35.40625, baseline: 13.53125
+          frag 0 from TextNode start: 27, length: 25, rect: [401,740 78.125x17.46875]
+            "أيها الأصدقاء"
+        TextNode <#text>
+      BlockContainer <(anonymous)> at (200,824) content-size 592x0 children: inline
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x832]
+  PaintableWithLines (BlockContainer<HTML>) [100,0 700x832]
+    PaintableWithLines (BlockContainer<BODY>) [200,8 592x816]
+      PaintableWithLines (BlockContainer<DIV>) [300,8 102x102]
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [200,110 592x0]
+      PaintableWithLines (BlockContainer<DIV>) [300,110 102x102]
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [200,212 592x0]
+      PaintableWithLines (BlockContainer<DIV>) [400,212 102x102]
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [200,314 592x0]
+      PaintableWithLines (BlockContainer<DIV>) [300,314 102x102]
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [200,416 592x0]
+      PaintableWithLines (BlockContainer<DIV>) [300,416 102x102]
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [200,518 592x0]
+      PaintableWithLines (BlockContainer<DIV>) [300,518 102x102]
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [200,620 592x0]
+      PaintableWithLines (BlockContainer<DIV>) [400,620 102x102]
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [200,722 592x0]
+      PaintableWithLines (BlockContainer<DIV>) [400,722 102x102]
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [200,824 592x0]

--- a/Tests/LibWeb/Layout/input/css-dir-selector.html
+++ b/Tests/LibWeb/Layout/input/css-dir-selector.html
@@ -1,0 +1,24 @@
+<style>
+    div {
+        width: 100px;
+        height: 100px;
+        border: 1px solid black;
+    }
+    :dir(rtl) {
+        margin-left: 200px;
+    }
+    :dir(ltr) {
+        margin-left: 100px;
+    }
+    :dir(wheeee) {
+        width: 1000px !important;
+    }
+</style>
+<div>Well, hello friends!</div>
+<div dir="ltr">Well, hello friends!</div>
+<div dir="rtl">Well, hello friends!</div>
+<div dir="auto">Well, hello friends!</div>
+<div>حسنًا ، مرحباً أيها الأصدقاء</div>
+<div dir="ltr">حسنًا ، مرحباً أيها الأصدقاء</div>
+<div dir="rtl">حسنًا ، مرحباً أيها الأصدقاء</div>
+<div dir="auto">حسنًا ، مرحباً أيها الأصدقاء</div>

--- a/Userland/Libraries/LibWeb/CSS/PseudoClasses.json
+++ b/Userland/Libraries/LibWeb/CSS/PseudoClasses.json
@@ -11,6 +11,9 @@
   "defined": {
     "argument": ""
   },
+  "dir": {
+    "argument": "<ident>"
+  },
   "disabled": {
     "argument": ""
   },

--- a/Userland/Libraries/LibWeb/CSS/Selector.h
+++ b/Userland/Libraries/LibWeb/CSS/Selector.h
@@ -12,6 +12,7 @@
 #include <AK/String.h>
 #include <AK/Vector.h>
 #include <LibWeb/CSS/PseudoClass.h>
+#include <LibWeb/CSS/ValueID.h>
 
 namespace Web::CSS {
 
@@ -96,6 +97,9 @@ public:
 
             // Used for :lang(en-gb,dk)
             Vector<FlyString> languages {};
+
+            // Used by :dir()
+            Optional<ValueID> identifier {};
         };
 
         struct Name {

--- a/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
+++ b/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
@@ -7,6 +7,7 @@
 
 #include <LibWeb/CSS/Parser/Parser.h>
 #include <LibWeb/CSS/SelectorEngine.h>
+#include <LibWeb/CSS/ValueID.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Element.h>
 #include <LibWeb/DOM/Text.h>
@@ -428,6 +429,19 @@ static inline bool matches_pseudo_class(CSS::Selector::SimpleSelector::PseudoCla
     }
     case CSS::PseudoClass::Target:
         return element.is_target();
+    case CSS::PseudoClass::Dir: {
+        // "Values other than ltr and rtl are not invalid, but do not match anything."
+        // - https://www.w3.org/TR/selectors-4/#the-dir-pseudo
+        if (!first_is_one_of(pseudo_class.identifier, CSS::ValueID::Ltr, CSS::ValueID::Rtl))
+            return false;
+        switch (element.directionality()) {
+        case DOM::Element::Directionality::Ltr:
+            return pseudo_class.identifier == CSS::ValueID::Ltr;
+        case DOM::Element::Directionality::Rtl:
+            return pseudo_class.identifier == CSS::ValueID::Rtl;
+        }
+        VERIFY_NOT_REACHED();
+    }
     }
 
     return false;

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -639,6 +639,12 @@ bool Element::is_target() const
     return document().target_element() == this;
 }
 
+// https://dom.spec.whatwg.org/#document-element
+bool Element::is_document_element() const
+{
+    return document().document_element() == this;
+}
+
 JS::NonnullGCPtr<HTMLCollection> Element::get_elements_by_class_name(DeprecatedFlyString const& class_names)
 {
     Vector<FlyString> list_of_class_names;

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -325,6 +325,19 @@ public:
     CSSPixelPoint scroll_offset(ScrollOffsetFor type) const { return m_scroll_offset[to_underlying(type)]; }
     void set_scroll_offset(ScrollOffsetFor type, CSSPixelPoint offset) { m_scroll_offset[to_underlying(type)] = offset; }
 
+    enum class Dir {
+        Ltr,
+        Rtl,
+        Auto,
+    };
+    Optional<Dir> dir() const { return m_dir; }
+
+    enum class Directionality {
+        Ltr,
+        Rtl,
+    };
+    Directionality directionality() const;
+
 protected:
     Element(Document&, DOM::QualifiedName);
     virtual void initialize(JS::Realm&) override;
@@ -358,6 +371,7 @@ private:
     Array<HashMap<DeprecatedFlyString, CSS::StyleProperty>, to_underlying(CSS::Selector::PseudoElement::PseudoElementCount)> m_pseudo_element_custom_properties;
 
     Vector<FlyString> m_classes;
+    Optional<Dir> m_dir;
 
     Array<JS::GCPtr<Layout::Node>, to_underlying(CSS::Selector::PseudoElement::PseudoElementCount)> m_pseudo_element_nodes;
 

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -169,6 +169,7 @@ public:
     bool is_focused() const;
     bool is_active() const;
     bool is_target() const;
+    bool is_document_element() const;
 
     JS::NonnullGCPtr<HTMLCollection> get_elements_by_class_name(DeprecatedFlyString const&);
 

--- a/Userland/Libraries/LibWeb/Dump.cpp
+++ b/Userland/Libraries/LibWeb/Dump.cpp
@@ -505,6 +505,9 @@ void dump_selector(StringBuilder& builder, CSS::Selector const& selector)
                     builder.append("])"sv);
                     break;
                 }
+                case CSS::PseudoClassMetadata::ParameterType::Ident:
+                    builder.appendff("(ident={})", string_from_value_id(pseudo_class.identifier.value()));
+                    break;
                 case CSS::PseudoClassMetadata::ParameterType::LanguageRanges: {
                     builder.append('(');
                     builder.join(',', pseudo_class.languages);


### PR DESCRIPTION
~~Relies on #20532.~~

Obviously, we don't render RTL text properly, but we do now detect it! Here's a screenshot of the test file:

|Firefox|Ladybird|
|---|---|
| ![image](https://github.com/SerenityOS/serenity/assets/222642/27573125-99d4-4ff7-9127-0a92864624fc) | ![image](https://github.com/SerenityOS/serenity/assets/222642/044fe47f-918e-4d10-8186-ede95cac868d) |