### PR TITLE
LibGfx/WOFF2: Align all reconstructed glyf entries to 4 bytes

### DIFF
--- a/Userland/Libraries/LibGfx/Font/WOFF2/Font.cpp
+++ b/Userland/Libraries/LibGfx/Font/WOFF2/Font.cpp
@@ -818,12 +818,12 @@ static ErrorOr<GlyfAndLocaTableBuffers> create_glyf_and_loca_tables_from_transfo
                     TRY(append_i16(point.y));
                 }
             }
+        }
 
-            // NOTE: Make sure each glyph starts on a 4-byte boundary.
-            //       I haven't found the spec text for this, but it matches other implementations.
-            while (reconstructed_glyf_table.size() % 4 != 0) {
-                TRY(reconstructed_glyf_table.try_append(0));
-            }
+        // NOTE: Make sure each glyph starts on a 4-byte boundary.
+        //       I haven't found the spec text for this, but it matches other implementations.
+        while (reconstructed_glyf_table.size() % 4 != 0) {
+            TRY(reconstructed_glyf_table.try_append(0));
         }
 
         TRY(loca_indexes.try_append(starting_glyf_table_size));


### PR DESCRIPTION
It wasn't enough to do it only for simple glyphs, we need to do it for composite glyphs as well.

Fixes an issue where some glyph data was misaligned in the output and thus ended up rendered incorrectly or not at all.

Visual progression on https://twinings.co.uk/

Before:
![Screenshot at 2023-08-16 13-13-00](https://github.com/SerenityOS/serenity/assets/5954907/1e6ba9e2-df8d-42f0-8487-e09073a5c0ac)

After:
![Screenshot at 2023-08-16 13-07-16](https://github.com/SerenityOS/serenity/assets/5954907/38a33a0f-9aa4-434c-b2c3-59b7ffe1bf85)

