### PR TITLE
LibWeb: Allow any valid `<color>` in CSS gradients

### DIFF
--- a/Tests/LibWeb/Ref/css-gradient-currentcolor-ref.html
+++ b/Tests/LibWeb/Ref/css-gradient-currentcolor-ref.html
@@ -1,0 +1,10 @@
+<html>
+<style>
+    div {
+        width: 200px;
+        height: 200px;
+        background: linear-gradient(green, white);
+    }
+</style>
+<div></div>
+</html>

--- a/Tests/LibWeb/Ref/css-gradient-currentcolor.html
+++ b/Tests/LibWeb/Ref/css-gradient-currentcolor.html
@@ -1,0 +1,11 @@
+<html>
+<style>
+    div {
+        color: green;
+        width: 200px;
+        height: 200px;
+        background: linear-gradient(currentColor, white);
+    }
+</style>
+<div></div>
+</html>

--- a/Tests/LibWeb/Ref/manifest.json
+++ b/Tests/LibWeb/Ref/manifest.json
@@ -1,5 +1,6 @@
 {
     "square-flex.html": "square-ref.html",
     "separate-borders-inline-table.html": "separate-borders-ref.html",
-    "opacity-stacking.html": "opacity-stacking-ref.html"
+    "opacity-stacking.html": "opacity-stacking-ref.html",
+    "css-gradient-currentcolor.html": "css-gradient-currentcolor-ref.html"
 }

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -2419,7 +2419,7 @@ static Optional<Vector<TElement>> parse_color_stop_list(auto& tokens, auto is_po
             return ElementType::Garbage;
         auto const& token = tokens.next_token();
 
-        Gfx::Color color;
+        RefPtr<StyleValue> color;
         Optional<typename TElement::PositionType> position;
         Optional<typename TElement::PositionType> second_position;
         auto dimension = parse_dimension(token);
@@ -2434,15 +2434,15 @@ static Optional<Vector<TElement>> parse_color_stop_list(auto& tokens, auto is_po
             }
             // <T-percentage> <color>
             auto maybe_color = parse_color(tokens.next_token());
-            if (!maybe_color.has_value())
+            if (maybe_color.is_error())
                 return ElementType::Garbage;
-            color = *maybe_color;
+            color = maybe_color.release_value();
         } else {
             // [<color> <T-percentage>?]
             auto maybe_color = parse_color(token);
-            if (!maybe_color.has_value())
+            if (maybe_color.is_error())
                 return ElementType::Garbage;
-            color = *maybe_color;
+            color = maybe_color.release_value();
             tokens.skip_whitespace();
             // Allow up to [<color> <T-percentage> <T-percentage>] (double-position color stops)
             // Note: Double-position color stops only appear to be valid in this order.
@@ -2503,7 +2503,7 @@ Optional<Vector<LinearColorStopListElement>> Parser::parse_linear_color_stop_lis
         tokens,
         [](Dimension& dimension) { return dimension.is_length_percentage(); },
         [](Dimension& dimension) { return dimension.length_percentage(); },
-        [&](auto& token) { return parse_color(token); },
+        [&](auto& token) { return parse_color_value(token); },
         [&](auto& token) { return parse_dimension(token); });
 }
 
@@ -2515,7 +2515,7 @@ Optional<Vector<AngularColorStopListElement>> Parser::parse_angular_color_stop_l
         tokens,
         [](Dimension& dimension) { return dimension.is_angle_percentage(); },
         [](Dimension& dimension) { return dimension.angle_percentage(); },
-        [&](auto& token) { return parse_color(token); },
+        [&](auto& token) { return parse_color_value(token); },
         [&](auto& token) { return parse_dimension(token); });
 }
 

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/AbstractImageStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/AbstractImageStyleValue.h
@@ -24,7 +24,7 @@ public:
     virtual Optional<CSSPixels> natural_height() const { return {}; }
 
     virtual void load_any_resources(DOM::Document&) {};
-    virtual void resolve_for_size(Layout::Node const&, CSSPixelSize) const {};
+    virtual void resolve_for_size(Layout::NodeWithStyleAndBoxModelMetrics const&, CSSPixelSize) const {};
 
     virtual bool is_paintable() const = 0;
     virtual void paint(PaintContext& context, DevicePixelRect const& dest_rect, ImageRendering) const = 0;
@@ -47,7 +47,7 @@ struct ColorStopListElement {
 
     Optional<ColorHint> transition_hint;
     struct ColorStop {
-        Color color;
+        RefPtr<StyleValue> color;
         Optional<TPosition> position;
         Optional<TPosition> second_position = {};
         inline bool operator==(ColorStop const&) const = default;
@@ -69,7 +69,7 @@ static ErrorOr<void> serialize_color_stop_list(StringBuilder& builder, auto cons
         if (element.transition_hint.has_value())
             TRY(builder.try_appendff("{}, "sv, TRY(element.transition_hint->value.to_string())));
 
-        TRY(serialize_a_srgb_value(builder, element.color_stop.color));
+        TRY(builder.try_append(TRY(element.color_stop.color->to_string())));
         for (auto position : Array { &element.color_stop.position, &element.color_stop.second_position }) {
             if (position->has_value())
                 TRY(builder.try_appendff(" {}"sv, TRY((*position)->to_string())));

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/ConicGradientStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/ConicGradientStyleValue.cpp
@@ -8,6 +8,7 @@
  */
 
 #include "ConicGradientStyleValue.h"
+#include <LibWeb/Layout/Node.h>
 
 namespace Web::CSS {
 
@@ -34,7 +35,7 @@ ErrorOr<String> ConicGradientStyleValue::to_string() const
     return builder.to_string();
 }
 
-void ConicGradientStyleValue::resolve_for_size(Layout::Node const& node, CSSPixelSize size) const
+void ConicGradientStyleValue::resolve_for_size(Layout::NodeWithStyleAndBoxModelMetrics const& node, CSSPixelSize size) const
 {
     if (!m_resolved.has_value())
         m_resolved = ResolvedData { Painting::resolve_conic_gradient_data(node, *this), {} };

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/ConicGradientStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/ConicGradientStyleValue.h
@@ -39,7 +39,7 @@ public:
 
     bool is_paintable() const override { return true; }
 
-    void resolve_for_size(Layout::Node const&, CSSPixelSize) const override;
+    void resolve_for_size(Layout::NodeWithStyleAndBoxModelMetrics const&, CSSPixelSize) const override;
 
     virtual ~ConicGradientStyleValue() override = default;
 

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/LinearGradientStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/LinearGradientStyleValue.cpp
@@ -102,7 +102,7 @@ float LinearGradientStyleValue::angle_degrees(CSSPixelSize gradient_size) const
         });
 }
 
-void LinearGradientStyleValue::resolve_for_size(Layout::Node const& node, CSSPixelSize size) const
+void LinearGradientStyleValue::resolve_for_size(Layout::NodeWithStyleAndBoxModelMetrics const& node, CSSPixelSize size) const
 {
     if (m_resolved.has_value() && m_resolved->size == size)
         return;

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/LinearGradientStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/LinearGradientStyleValue.h
@@ -57,7 +57,7 @@ public:
 
     float angle_degrees(CSSPixelSize gradient_size) const;
 
-    void resolve_for_size(Layout::Node const&, CSSPixelSize) const override;
+    void resolve_for_size(Layout::NodeWithStyleAndBoxModelMetrics const&, CSSPixelSize) const override;
 
     bool is_paintable() const override { return true; }
     void paint(PaintContext& context, DevicePixelRect const& dest_rect, CSS::ImageRendering image_rendering) const override;

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/RadialGradientStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/RadialGradientStyleValue.cpp
@@ -8,6 +8,7 @@
  */
 
 #include "RadialGradientStyleValue.h"
+#include <LibWeb/Layout/Node.h>
 
 namespace Web::CSS {
 
@@ -184,7 +185,7 @@ Gfx::FloatSize RadialGradientStyleValue::resolve_size(Layout::Node const& node, 
     return resolved_size;
 }
 
-void RadialGradientStyleValue::resolve_for_size(Layout::Node const& node, CSSPixelSize paint_size) const
+void RadialGradientStyleValue::resolve_for_size(Layout::NodeWithStyleAndBoxModelMetrics const& node, CSSPixelSize paint_size) const
 {
     CSSPixelRect gradient_box { { 0, 0 }, paint_size };
     auto center = m_properties.position.resolved(node, gradient_box).to_type<float>();

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/RadialGradientStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/RadialGradientStyleValue.h
@@ -63,7 +63,7 @@ public:
 
     bool is_paintable() const override { return true; }
 
-    void resolve_for_size(Layout::Node const&, CSSPixelSize) const override;
+    void resolve_for_size(Layout::NodeWithStyleAndBoxModelMetrics const&, CSSPixelSize) const override;
 
     Gfx::FloatSize resolve_size(Layout::Node const&, Gfx::FloatPoint, Gfx::FloatRect const&) const;
 

--- a/Userland/Libraries/LibWeb/Painting/GradientPainting.h
+++ b/Userland/Libraries/LibWeb/Painting/GradientPainting.h
@@ -36,9 +36,9 @@ struct RadialGradientData {
     ColorStopData color_stops;
 };
 
-LinearGradientData resolve_linear_gradient_data(Layout::Node const&, CSSPixelSize, CSS::LinearGradientStyleValue const&);
-ConicGradientData resolve_conic_gradient_data(Layout::Node const&, CSS::ConicGradientStyleValue const&);
-RadialGradientData resolve_radial_gradient_data(Layout::Node const&, CSSPixelSize, CSS::RadialGradientStyleValue const&);
+LinearGradientData resolve_linear_gradient_data(Layout::NodeWithStyleAndBoxModelMetrics const&, CSSPixelSize, CSS::LinearGradientStyleValue const&);
+ConicGradientData resolve_conic_gradient_data(Layout::NodeWithStyleAndBoxModelMetrics const&, CSS::ConicGradientStyleValue const&);
+RadialGradientData resolve_radial_gradient_data(Layout::NodeWithStyleAndBoxModelMetrics const&, CSSPixelSize, CSS::RadialGradientStyleValue const&);
 
 void paint_linear_gradient(PaintContext&, DevicePixelRect const&, LinearGradientData const&);
 void paint_conic_gradient(PaintContext&, DevicePixelRect const&, ConicGradientData const&, DevicePixelPoint position);


### PR DESCRIPTION
We now keep the color value as a StyleValue up until we go to paint the gradient, which makes `currentColor` work, along with any other color values that can't be immediately converted into a `Gfx::Color` while parsing.

With this test page:
```html
<html>
    <style>
        div {
            color: green;
            width: 200px;
            height: 200px;
            background: linear-gradient(currentColor, white);
        }
    </style>
    <div></div>
</html>
```

**Before:**
![image](https://github.com/SerenityOS/serenity/assets/222642/b56a5763-8a97-496d-bc5c-7de315cb03db)

**After:**
![image](https://github.com/SerenityOS/serenity/assets/222642/efccd7cd-3fb2-4e1a-8c82-d3f2b81a2a03)
