### PR TITLE
LibWeb: Support multiple values in `:lang()` selector

### DIFF
--- a/Tests/LibWeb/Ref/css-lang-selector-ref.html
+++ b/Tests/LibWeb/Ref/css-lang-selector-ref.html
@@ -1,0 +1,16 @@
+<html lang="en">
+<style>
+    div {
+        width: 100px;
+        height: 100px;
+        border: 1px solid black;
+        background-color: red;
+    }
+    #fr, #de {
+        background-color: blue;
+    }
+</style>
+<div>Red</div>
+<div id="fr">Blue</div>
+<div id="de">Blue</div>
+</html>

--- a/Tests/LibWeb/Ref/css-lang-selector.html
+++ b/Tests/LibWeb/Ref/css-lang-selector.html
@@ -1,0 +1,18 @@
+<html lang="en">
+<style>
+    div {
+        width: 100px;
+        height: 100px;
+        border: 1px solid black;
+    }
+    div:lang(en) {
+        background-color: red;
+    }
+    div:lang("fr",de) {
+        background-color: blue;
+    }
+</style>
+<div>Red</div>
+<div lang="fr">Blue</div>
+<div lang="de">Blue</div>
+</html>

--- a/Tests/LibWeb/Ref/manifest.json
+++ b/Tests/LibWeb/Ref/manifest.json
@@ -2,5 +2,6 @@
     "square-flex.html": "square-ref.html",
     "separate-borders-inline-table.html": "separate-borders-ref.html",
     "opacity-stacking.html": "opacity-stacking-ref.html",
-    "css-gradient-currentcolor.html": "css-gradient-currentcolor-ref.html"
+    "css-gradient-currentcolor.html": "css-gradient-currentcolor-ref.html",
+    "css-lang-selector.html": "css-lang-selector-ref.html"
 }

--- a/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
+++ b/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
@@ -44,13 +44,14 @@ static inline bool matches_lang_pseudo_class(DOM::Element const& element, Vector
     // FIXME: This is ad-hoc. Implement a proper language range matching algorithm as recommended by BCP47.
     for (auto const& language : languages) {
         if (language.is_empty())
-            return false;
+            continue;
         if (language == "*"sv)
             return true;
-        if (!element_language.to_string().contains('-'))
-            return Infra::is_ascii_case_insensitive_match(element_language, language);
+        if (!element_language.to_string().contains('-') && Infra::is_ascii_case_insensitive_match(element_language, language))
+            return true;
         auto parts = element_language.to_string().split_limit('-', 2).release_value_but_fixme_should_propagate_errors();
-        return Infra::is_ascii_case_insensitive_match(parts[0], language);
+        if (Infra::is_ascii_case_insensitive_match(parts[0], language))
+            return true;
     }
     return false;
 }


### PR DESCRIPTION
Parse them, and also don't give up completely if the first language listed doesn't match an element.

I haven't gone into proper matching because OH BOY that's a big can of worms. :sweat_smile: But our existing matching now supports checking all the listed languages.