### PR TITLE
LibWeb: Size SVG G container according to its children

### DIFF
--- a/Tests/LibWeb/Layout/expected/svg-transforms-and-viewboxes.txt
+++ b/Tests/LibWeb/Layout/expected/svg-transforms-and-viewboxes.txt
@@ -21,12 +21,12 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         frag 0 from SVGSVGBox start: 0, length: 0, rect: [50,450 200x200]
       SVGSVGBox <svg> at (50,150) content-size 200x100 [SVG] children: inline
         TextNode <#text>
-        SVGGraphicsBox <g> at (50,150) content-size 0x0 children: inline
+        SVGGraphicsBox <g> at (45.6875,199.828125) content-size 118.78125x47.453125 children: inline
           TextNode <#text>
           SVGGeometryBox <path> at (45.6875,199.828125) content-size 118.78125x47.453125 children: not-inline
           TextNode <#text>
         TextNode <#text>
-        SVGGraphicsBox <g> at (50,150) content-size 0x0 children: inline
+        SVGGraphicsBox <g> at (84.5,159.5) content-size 81x81 children: inline
           TextNode <#text>
           SVGGeometryBox <path> at (84.5,159.5) content-size 81x81 children: not-inline
           TextNode <#text>
@@ -99,9 +99,9 @@ PaintableWithLines (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x700]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x700]
     PaintableWithLines (BlockContainer<BODY>) [50,50 700x600]
       SVGSVGPaintable (SVGSVGBox<svg>) [50,150 200x100]
-        SVGGraphicsPaintable (SVGGraphicsBox<g>) [50,150 0x0]
+        SVGGraphicsPaintable (SVGGraphicsBox<g>) [45.6875,199.828125 118.78125x47.453125]
           SVGGeometryPaintable (SVGGeometryBox<path>) [45.6875,199.828125 118.78125x47.453125]
-        SVGGraphicsPaintable (SVGGraphicsBox<g>) [50,150 0x0]
+        SVGGraphicsPaintable (SVGGraphicsBox<g>) [84.5,159.5 81x81]
           SVGGeometryPaintable (SVGGeometryBox<path>) [84.5,159.5 81x81]
       TextPaintable (TextNode<#text>)
       SVGSVGPaintable (SVGSVGBox<svg>) [258,50 200x200]

--- a/Tests/LibWeb/Layout/expected/svg/svg-different-types-of-opacity.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-different-types-of-opacity.txt
@@ -1,0 +1,16 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x800 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x784 children: inline
+      line 0 width: 784, height: 784, bottom: 784, baseline: 784
+        frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,8 784x784]
+      SVGSVGBox <svg> at (8,8) content-size 784x784 [SVG] children: inline
+        TextNode <#text>
+        SVGGeometryBox <circle> at (47.203125,47.203125) content-size 548.796875x548.796875 children: not-inline
+        TextNode <#text>
+      TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x800]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x800]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x784]
+      SVGSVGPaintable (SVGSVGBox<svg>) [8,8 784x784]
+        SVGGeometryPaintable (SVGGeometryBox<circle>) [47.203125,47.203125 548.796875x548.796875]

--- a/Tests/LibWeb/Layout/expected/svg/svg-g-with-opacity.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-g-with-opacity.txt
@@ -1,0 +1,23 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x800 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x784 children: inline
+      line 0 width: 784, height: 784, bottom: 784, baseline: 784
+        frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,8 784x784]
+      SVGSVGBox <svg> at (8,8) content-size 784x784 [SVG] children: inline
+        TextNode <#text>
+        SVGGraphicsBox <g> at (121.671875,121.671875) content-size 556.65625x556.65625 children: inline
+          TextNode <#text>
+          SVGGeometryBox <circle> at (121.671875,121.671875) content-size 399.84375x399.84375 children: not-inline
+          TextNode <#text>
+          SVGGeometryBox <circle> at (278.484375,278.484375) content-size 399.84375x399.84375 children: not-inline
+          TextNode <#text>
+        TextNode <#text>
+      TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x800]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x800]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x784]
+      SVGSVGPaintable (SVGSVGBox<svg>) [8,8 784x784]
+        SVGGraphicsPaintable (SVGGraphicsBox<g>) [121.671875,121.671875 556.65625x556.65625]
+          SVGGeometryPaintable (SVGGeometryBox<circle>) [121.671875,121.671875 399.84375x399.84375]
+          SVGGeometryPaintable (SVGGeometryBox<circle>) [278.484375,278.484375 399.84375x399.84375]

--- a/Tests/LibWeb/Layout/expected/svg/svg-inside-svg.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-inside-svg.txt
@@ -4,7 +4,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       line 0 width: 24, height: 24, bottom: 24, baseline: 24
         frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,8 24x24]
       SVGSVGBox <svg> at (8,8) content-size 24x24 [SVG] children: inline
-        SVGGraphicsBox <g> at (8,8) content-size 0x0 children: inline
+        SVGGraphicsBox <g> at (8,8) content-size 24x24 children: inline
           SVGSVGBox <svg> at (8,8) content-size 24x24 [SVG] children: not-inline
             SVGGeometryBox <rect> at (8,8) content-size 24x24 children: not-inline
         TextNode <#text>
@@ -13,6 +13,6 @@ PaintableWithLines (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x40]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x24]
       SVGSVGPaintable (SVGSVGBox<svg>) [8,8 24x24]
-        SVGGraphicsPaintable (SVGGraphicsBox<g>) [8,8 0x0]
+        SVGGraphicsPaintable (SVGGraphicsBox<g>) [8,8 24x24]
           SVGSVGPaintable (SVGSVGBox<svg>) [8,8 24x24]
             SVGGeometryPaintable (SVGGeometryBox<rect>) [8,8 24x24]

--- a/Tests/LibWeb/Layout/input/svg/svg-different-types-of-opacity.html
+++ b/Tests/LibWeb/Layout/input/svg/svg-different-types-of-opacity.html
@@ -1,0 +1,11 @@
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <circle
+    cx="40"
+    cy="40"
+    r="25"
+    stroke-opacity="50%"
+    fill-opacity="20%"
+    stroke="green"
+    opacity="90%"
+    stroke-width="20" />
+</svg>

--- a/Tests/LibWeb/Layout/input/svg/svg-g-with-opacity.html
+++ b/Tests/LibWeb/Layout/input/svg/svg-g-with-opacity.html
@@ -1,0 +1,6 @@
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <g fill="white" stroke="green" opacity="0.6">
+      <circle cx="40" cy="40" r="25" />
+      <circle cx="60" cy="60" r="25" />
+  </g>
+</svg>

--- a/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
@@ -141,11 +141,11 @@ void SVGGraphicsElement::apply_presentational_hints(CSS::StyleProperties& style)
             if (auto fill_opacity_value = parse_css_value(parsing_context, value, CSS::PropertyID::FillOpacity).release_value_but_fixme_should_propagate_errors())
                 style.set_property(CSS::PropertyID::FillOpacity, fill_opacity_value.release_nonnull());
         } else if (name.equals_ignoring_ascii_case("stroke-opacity"sv)) {
-            if (auto stroke_opacity_value = parse_css_value(parsing_context, value, CSS::PropertyID::FillOpacity).release_value_but_fixme_should_propagate_errors())
+            if (auto stroke_opacity_value = parse_css_value(parsing_context, value, CSS::PropertyID::StrokeOpacity).release_value_but_fixme_should_propagate_errors())
                 style.set_property(CSS::PropertyID::StrokeOpacity, stroke_opacity_value.release_nonnull());
         } else if (name.equals_ignoring_ascii_case(SVG::AttributeNames::opacity)) {
-            if (auto stroke_opacity_value = parse_css_value(parsing_context, value, CSS::PropertyID::Opacity).release_value_but_fixme_should_propagate_errors())
-                style.set_property(CSS::PropertyID::Opacity, stroke_opacity_value.release_nonnull());
+            if (auto opacity_value = parse_css_value(parsing_context, value, CSS::PropertyID::Opacity).release_value_but_fixme_should_propagate_errors())
+                style.set_property(CSS::PropertyID::Opacity, opacity_value.release_nonnull());
         } else if (name.equals_ignoring_ascii_case("text-anchor"sv)) {
             if (auto text_anchor_value = parse_css_value(parsing_context, value, CSS::PropertyID::TextAnchor).release_value_but_fixme_should_propagate_errors())
                 style.set_property(CSS::PropertyID::TextAnchor, text_anchor_value.release_nonnull());


### PR DESCRIPTION
Set the size of the SVG G container and its offset based on the size of its children. This fixes a bug with the duckduckgo logo.

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td><img src="https://github.com/SerenityOS/serenity/assets/45781926/a6feb7b0-ce84-4ebd-888d-3b17b9956097"></td>
<td><img src="https://github.com/SerenityOS/serenity/assets/45781926/2cda96ff-431c-440b-8f23-34943f4b4cb2"></td>
</tr>
</table>