### PR TITLE
LibWeb: Reject `nullptr` StyleValues as invalid ColorStops

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -2454,13 +2454,13 @@ static Optional<Vector<TElement>> parse_color_stop_list(auto& tokens, auto is_po
             }
             // <T-percentage> <color>
             auto maybe_color = parse_color(tokens.next_token());
-            if (maybe_color.is_error())
+            if (maybe_color.is_error() || maybe_color.value() == nullptr)
                 return ElementType::Garbage;
             color = maybe_color.release_value();
         } else {
             // [<color> <T-percentage>?]
             auto maybe_color = parse_color(token);
-            if (maybe_color.is_error())
+            if (maybe_color.is_error() || maybe_color.value() == nullptr)
                 return ElementType::Garbage;
             color = maybe_color.release_value();
             tokens.skip_whitespace();


### PR DESCRIPTION
This would cause a nullptr-deref during painting of invalid linear-gradients, such as `linear-gradient(top, #f8f9fa, #ececec)` found in googles sign-in button

---
Fixes #20599