### PR TITLE
Mandelbrot: Pledge `unix` to enable image export

### DIFF
--- a/Userland/Demos/Mandelbrot/Mandelbrot.cpp
+++ b/Userland/Demos/Mandelbrot/Mandelbrot.cpp
@@ -398,7 +398,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     auto app = TRY(GUI::Application::create(arguments));
 
-    TRY(Core::System::pledge("stdio thread recvfd sendfd rpath wpath cpath"));
+    TRY(Core::System::pledge("stdio thread recvfd sendfd rpath unix wpath cpath"));
 
 #if 0
     TRY(Core::System::unveil("/res", "r"));


### PR DESCRIPTION
Crash Reporter was very helpful.

<img width="1028" alt="Screenshot 2023-08-16 at 20 47 50" src="https://github.com/SerenityOS/serenity/assets/6179932/57c620b7-6ba2-42e5-b505-40f2d06fc117">
