### PR TITLE
LibGfx: A bit of API symmetry for Rect, Point, and Size

### DIFF
--- a/Userland/Applications/DisplaySettings/MonitorWidget.cpp
+++ b/Userland/Applications/DisplaySettings/MonitorWidget.cpp
@@ -126,7 +126,7 @@ void MonitorWidget::redraw_desktop_if_needed()
     float sw = (float)m_desktop_bitmap->width() / (float)m_desktop_resolution.width();
     float sh = (float)m_desktop_bitmap->height() / (float)m_desktop_resolution.height();
 
-    auto scaled_size = m_wallpaper_bitmap->size().to_type<float>().scaled_by(sw, sh).to_type<int>();
+    auto scaled_size = m_wallpaper_bitmap->size().to_type<float>().scaled(sw, sh).to_type<int>();
     auto scaled_bitmap_or_error = m_wallpaper_bitmap->scaled(sw, sh);
     if (scaled_bitmap_or_error.is_error()) {
         GUI::MessageBox::show_error(window(), "There was an error updating the desktop preview"sv);

--- a/Userland/Libraries/LibGfx/Point.h
+++ b/Userland/Libraries/LibGfx/Point.h
@@ -91,6 +91,13 @@ public:
         return point;
     }
 
+    [[nodiscard]] Point<T> scaled(T dboth) const
+    {
+        Point<T> point = *this;
+        point.scale_by(dboth);
+        return point;
+    }
+
     [[nodiscard]] Point<T> scaled(Point<T> const& delta) const
     {
         Point<T> point = *this;

--- a/Userland/Libraries/LibGfx/Rect.h
+++ b/Userland/Libraries/LibGfx/Rect.h
@@ -177,6 +177,13 @@ public:
         return rect;
     }
 
+    [[nodiscard]] Rect<T> scaled(T dboth) const
+    {
+        Rect<T> rect = *this;
+        rect.scale_by(dboth);
+        return rect;
+    }
+
     [[nodiscard]] Rect<T> scaled(T sx, T sy) const
     {
         Rect<T> rect = *this;

--- a/Userland/Libraries/LibGfx/Size.h
+++ b/Userland/Libraries/LibGfx/Size.h
@@ -58,21 +58,21 @@ public:
     ALWAYS_INLINE constexpr void scale_by(T dboth) { scale_by(dboth, dboth); }
     ALWAYS_INLINE constexpr void scale_by(Point<T> const& s) { scale_by(s.x(), s.y()); }
 
-    [[nodiscard]] constexpr Size scaled_by(T dx, T dy) const
+    [[nodiscard]] constexpr Size scaled(T dx, T dy) const
     {
         Size<T> size = *this;
         size.scale_by(dx, dy);
         return size;
     }
 
-    [[nodiscard]] constexpr Size scaled_by(T dboth) const
+    [[nodiscard]] constexpr Size scaled(T dboth) const
     {
         Size<T> size = *this;
         size.scale_by(dboth);
         return size;
     }
 
-    [[nodiscard]] constexpr Size scaled_by(Point<T> const& s) const
+    [[nodiscard]] constexpr Size scaled(Point<T> const& s) const
     {
         Size<T> size = *this;
         size.scale_by(s);

--- a/Userland/Libraries/LibGfx/VectorGraphic.cpp
+++ b/Userland/Libraries/LibGfx/VectorGraphic.cpp
@@ -15,7 +15,7 @@ void VectorGraphic::draw_into(Painter& painter, IntRect const& dest, AffineTrans
     // This allows you to easily rotate or flip the image before painting.
     auto transformed_rect = transform.map(FloatRect { {}, size() });
     auto scale = min(float(dest.width()) / transformed_rect.width(), float(dest.height()) / transformed_rect.height());
-    auto centered = FloatRect { {}, transformed_rect.size().scaled_by(scale) }.centered_within(dest.to_type<float>());
+    auto centered = FloatRect { {}, transformed_rect.size().scaled(scale) }.centered_within(dest.to_type<float>());
     auto view_transform = AffineTransform {}
                               .translate(centered.location())
                               .multiply(AffineTransform {}.scale(scale, scale))

--- a/Userland/Libraries/LibVideo/VP9/Decoder.cpp
+++ b/Userland/Libraries/LibVideo/VP9/Decoder.cpp
@@ -787,10 +787,10 @@ DecoderErrorOr<void> Decoder::prepare_referenced_frame(Gfx::Size<u32> frame_size
     // − FrameHeight <= 16 * RefFrameHeight[ refIdx ]
     if (!reference_frame.is_valid())
         return DecoderError::format(DecoderErrorCategory::Corrupted, "Attempted to use reference frame {} that has not been saved", reference_frame_index);
-    auto double_frame_size = frame_size.scaled_by(2);
+    auto double_frame_size = frame_size.scaled(2);
     if (double_frame_size.width() < reference_frame.size.width() || double_frame_size.height() < reference_frame.size.height())
         return DecoderError::format(DecoderErrorCategory::Corrupted, "Inter frame size is too small relative to reference frame {}", reference_frame_index);
-    if (!reference_frame.size.scaled_by(16).contains(frame_size))
+    if (!reference_frame.size.scaled(16).contains(frame_size))
         return DecoderError::format(DecoderErrorCategory::Corrupted, "Inter frame size is too large relative to reference frame {}", reference_frame_index);
 
     // FIXME: Convert all the operations in this function to vector operations supported by


### PR DESCRIPTION
Ignoring Size for a second, we currently have:

    Rect::scale_by
    Rect::scaled

    Point::scale_by
    Point::scaled

In Size, before this patch, we have:

    Size::scale_by
    Size::scaled_by

This aligns Size to use the same method name as Rect and Point. While
subjectively providing API symmetry, this is mostly to allow using this
method in templated helpers without caring what the exact underlying type
is.