### PR TITLE
LibWeb: Throw on attempt to create a Worker for now

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/Worker.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Worker.cpp
@@ -49,6 +49,10 @@ void Worker::visit_edges(Cell::Visitor& visitor)
 // https://html.spec.whatwg.org/multipage/workers.html#dom-worker
 WebIDL::ExceptionOr<JS::NonnullGCPtr<Worker>> Worker::create(String const& script_url, WorkerOptions const options, DOM::Document& document)
 {
+    // NOTE: We don't start a worker because they're not properly implemented yet and would likely crash.
+    dbgln("FIXME: Implement web workers");
+    return WebIDL::NotSupportedError::create(document.realm(), "Web workers not supported yet");
+
     dbgln_if(WEB_WORKER_DEBUG, "WebWorker: Creating worker with script_url = {}", script_url);
 
     // Returns a new Worker object. scriptURL will be fetched and executed in the background,


### PR DESCRIPTION
Trying to run a worker right now just results in the WebContent process asserting down the road, so let's throw and log a FIXME instead. This makes it easier to see what's failing. We'll obviously remove this once we get workers working correctly. :^)