### PR TITLE
LibWeb: Null check fonts after parsing them in CRC2D.font assignment

### DIFF
--- a/Tests/LibWeb/Text/expected/canvas/basic.txt
+++ b/Tests/LibWeb/Text/expected/canvas/basic.txt
@@ -1,0 +1,2 @@
+normal normal 20px SerenitySans
+normal normal 20px SerenitySans

--- a/Tests/LibWeb/Text/input/canvas/basic.html
+++ b/Tests/LibWeb/Text/input/canvas/basic.html
@@ -1,0 +1,11 @@
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        let canvas = document.createElement("canvas");
+        let context = canvas.getContext("2d");
+        context.font = '20px SerenitySans';
+        println(context.font);
+        context.font = '!!!'; // Invalid value, should be ignored.
+        println(context.font);
+    });
+</script>

--- a/Userland/Libraries/LibWeb/HTML/Canvas/CanvasTextDrawingStyles.h
+++ b/Userland/Libraries/LibWeb/HTML/Canvas/CanvasTextDrawingStyles.h
@@ -45,7 +45,7 @@ public:
         auto font_style_value_result = parse_css_value(parsing_context, font, CSS::PropertyID::Font);
 
         // If the new value is syntactically incorrect (including using property-independent style sheet syntax like 'inherit' or 'initial'), then it must be ignored, without assigning a new font value.
-        if (font_style_value_result.is_error()) {
+        if (font_style_value_result.is_error() || !font_style_value_result.value()) {
             return;
         }
         my_drawing_state().font_style_value = font_style_value_result.value();


### PR DESCRIPTION
Fixes an issue where setting CRC2D.font to an unparseable value would assert due to a null dereference.