### PR TITLE
LibJS: Add GC graph dumper

### DIFF
--- a/Ladybird/Qt/BrowserWindow.cpp
+++ b/Ladybird/Qt/BrowserWindow.cpp
@@ -279,6 +279,12 @@ BrowserWindow::BrowserWindow(Optional<URL> const& initial_url, Browser::CookieJa
         debug_request("collect-garbage");
     });
 
+    auto* dump_gc_graph_action = new QAction("Dump GC graph", this);
+    debug_menu->addAction(dump_gc_graph_action);
+    QObject::connect(dump_gc_graph_action, &QAction::triggered, this, [this] {
+        debug_request("dump-gc-graph");
+    });
+
     auto* clear_cache_action = new QAction("Clear &Cache", this);
     clear_cache_action->setShortcut(QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_C));
     clear_cache_action->setIcon(QIcon(QString("%1/res/icons/browser/clear-cache.png").arg(s_serenity_resource_root.characters())));

--- a/Userland/Libraries/LibJS/Heap/Heap.h
+++ b/Userland/Libraries/LibJS/Heap/Heap.h
@@ -19,6 +19,7 @@
 #include <LibJS/Heap/Cell.h>
 #include <LibJS/Heap/CellAllocator.h>
 #include <LibJS/Heap/Handle.h>
+#include <LibJS/Heap/HeapRootTypeOrLocation.h>
 #include <LibJS/Heap/Internals.h>
 #include <LibJS/Heap/MarkedVector.h>
 #include <LibJS/Runtime/Completion.h>
@@ -58,6 +59,7 @@ public:
     };
 
     void collect_garbage(CollectionType = CollectionType::CollectGarbage, bool print_report = false);
+    void dump_graph();
 
     bool should_collect_on_every_allocation() const { return m_should_collect_on_every_allocation; }
     void set_should_collect_on_every_allocation(bool b) { m_should_collect_on_every_allocation = b; }
@@ -83,10 +85,10 @@ private:
 
     Cell* allocate_cell(size_t);
 
-    void gather_roots(HashTable<Cell*>&);
-    void gather_conservative_roots(HashTable<Cell*>&);
-    void gather_asan_fake_stack_roots(HashTable<FlatPtr>&, FlatPtr);
-    void mark_live_cells(HashTable<Cell*> const& live_cells);
+    void gather_roots(HashMap<Cell*, HeapRootTypeOrLocation>&);
+    void gather_conservative_roots(HashMap<Cell*, HeapRootTypeOrLocation>&);
+    void gather_asan_fake_stack_roots(HashMap<FlatPtr, HeapRootTypeOrLocation>&, FlatPtr);
+    void mark_live_cells(HashMap<Cell*, HeapRootTypeOrLocation> const& live_cells);
     void finalize_unmarked_cells();
     void sweep_dead_cells(bool print_report, Core::ElapsedTimer const&);
 

--- a/Userland/Libraries/LibJS/Heap/HeapRootTypeOrLocation.h
+++ b/Userland/Libraries/LibJS/Heap/HeapRootTypeOrLocation.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2023, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/SourceLocation.h>
+
+namespace JS {
+
+enum class HeapRootType {
+    Handle,
+    MarkedVector,
+    RegisterPointer,
+    StackPointer,
+    VM,
+};
+
+using HeapRootTypeOrLocation = Variant<HeapRootType, SourceLocation*>;
+
+}

--- a/Userland/Libraries/LibJS/Heap/MarkedVector.h
+++ b/Userland/Libraries/LibJS/Heap/MarkedVector.h
@@ -7,17 +7,18 @@
 
 #pragma once
 
-#include <AK/HashTable.h>
+#include <AK/HashMap.h>
 #include <AK/IntrusiveList.h>
 #include <AK/Vector.h>
 #include <LibJS/Forward.h>
 #include <LibJS/Heap/Cell.h>
+#include <LibJS/Heap/HeapRootTypeOrLocation.h>
 
 namespace JS {
 
 class MarkedVectorBase {
 public:
-    virtual void gather_roots(HashTable<Cell*>&) const = 0;
+    virtual void gather_roots(HashMap<Cell*, JS::HeapRootTypeOrLocation>&) const = 0;
 
 protected:
     explicit MarkedVectorBase(Heap&);
@@ -64,14 +65,14 @@ public:
         return *this;
     }
 
-    virtual void gather_roots(HashTable<Cell*>& roots) const override
+    virtual void gather_roots(HashMap<Cell*, JS::HeapRootTypeOrLocation>& roots) const override
     {
         for (auto& value : *this) {
             if constexpr (IsSame<Value, T>) {
                 if (value.is_cell())
-                    roots.set(&const_cast<T&>(value).as_cell());
+                    roots.set(&const_cast<T&>(value).as_cell(), HeapRootType::MarkedVector);
             } else {
-                roots.set(value);
+                roots.set(value, HeapRootType::MarkedVector);
             }
         }
     }

--- a/Userland/Libraries/LibJS/Runtime/VM.h
+++ b/Userland/Libraries/LibJS/Runtime/VM.h
@@ -47,7 +47,7 @@ public:
 
     void dump_backtrace() const;
 
-    void gather_roots(HashTable<Cell*>&);
+    void gather_roots(HashMap<Cell*, HeapRootTypeOrLocation>&);
 
 #define __JS_ENUMERATE(SymbolName, snake_name)                  \
     NonnullGCPtr<Symbol> well_known_symbol_##snake_name() const \

--- a/Userland/Libraries/LibJS/SafeFunction.h
+++ b/Userland/Libraries/LibJS/SafeFunction.h
@@ -83,25 +83,6 @@ public:
 
     explicit operator bool() const { return !!callable_wrapper(); }
 
-    template<typename CallableType>
-    SafeFunction& operator=(CallableType&& callable)
-    requires((AK::IsFunctionObject<CallableType> && IsCallableWithArguments<CallableType, Out, In...>))
-    {
-        clear();
-        init_with_callable(forward<CallableType>(callable), CallableKind::FunctionObject);
-        return *this;
-    }
-
-    template<typename FunctionType>
-    SafeFunction& operator=(FunctionType f)
-    requires((AK::IsFunctionPointer<FunctionType> && IsCallableWithArguments<RemovePointer<FunctionType>, Out, In...>))
-    {
-        clear();
-        if (f)
-            init_with_callable(move(f), CallableKind::FunctionPointer);
-        return *this;
-    }
-
     SafeFunction& operator=(nullptr_t)
     {
         clear();

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -410,6 +410,10 @@ void ConnectionFromClient::debug_request(DeprecatedString const& request, Deprec
         Web::Bindings::main_thread_vm().heap().collect_garbage(JS::Heap::CollectionType::CollectGarbage, true);
     }
 
+    if (request == "dump-gc-graph") {
+        Web::Bindings::main_thread_vm().heap().dump_graph();
+    }
+
     if (request == "set-line-box-borders") {
         bool state = argument == "on";
         m_page_host->set_should_show_line_box_borders(state);


### PR DESCRIPTION
This change introduces a very basic GC graph dumper. The `dump_graph()`
function outputs JSON data that contains information about all nodes in
the graph, including their class types and edges.

Root nodes will have a property indicating their root type or source
location if the root is captured by a SafeFunction. It would be useful
to add source location for other types of roots in the future.

Outout JSON dump have following format:
```json
    "4908721208": {
        "class_name": "Accessor",
        "edges": [
            "4909298232",
            "4909297976"
        ]
    },
    "4907520440": {
        "root": "SafeFunction Optional Optional.h:137",
        "class_name": "Realm",
        "edges": [
            "4908269624",
            "4924821560",
            "4908409240",
            "4908483960",
            "4924527672"
        ]
    },
    "4908251320": {
        "class_name": "CSSStyleRule",
        "edges": [
            "4908302648",
            "4925101656",
            "4908251192"
        ]
    },
```