### PR TITLE
LibWeb: Deduplicate calc-parsing code

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -89,7 +89,7 @@ public:
     ErrorOr<RefPtr<StyleValue>> parse_as_css_value(PropertyID);
 
     static ErrorOr<RefPtr<StyleValue>> parse_css_value(Badge<StyleComputer>, ParsingContext const&, PropertyID, Vector<ComponentValue> const&);
-    static ErrorOr<RefPtr<CalculatedStyleValue>> parse_calculated_value(Badge<StyleComputer>, ParsingContext const&, Vector<ComponentValue> const&);
+    static ErrorOr<RefPtr<CalculatedStyleValue>> parse_calculated_value(Badge<StyleComputer>, ParsingContext const&, ComponentValue const&);
 
     [[nodiscard]] LengthOrCalculated parse_as_sizes_attribute();
 
@@ -284,8 +284,7 @@ private:
     };
     ErrorOr<PropertyAndValue> parse_css_value_for_properties(ReadonlySpan<PropertyID>, TokenStream<ComponentValue>&);
     ErrorOr<RefPtr<StyleValue>> parse_builtin_value(ComponentValue const&);
-    ErrorOr<RefPtr<StyleValue>> parse_dynamic_value(ComponentValue const&);
-    ErrorOr<RefPtr<CalculatedStyleValue>> parse_calculated_value(Vector<ComponentValue> const&);
+    ErrorOr<RefPtr<CalculatedStyleValue>> parse_calculated_value(ComponentValue const&);
     // NOTE: Implemented in generated code. (GenerateCSSMathFunctions.cpp)
     ErrorOr<OwnPtr<CalculationNode>> parse_math_function(PropertyID, Function const&);
     ErrorOr<OwnPtr<CalculationNode>> parse_a_calc_function_node(Function const&);

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -1074,21 +1074,18 @@ bool StyleComputer::expand_unresolved_values(DOM::Element& element, StringView p
                 return false;
             }
 
-            // FIXME: Handle all math functions.
-            if (value.function().name().equals_ignoring_ascii_case("calc"sv)) {
-                auto const& calc_function = value.function();
-                if (auto calc_value = Parser::Parser::parse_calculated_value({}, Parser::ParsingContext { document() }, calc_function.values()).release_value_but_fixme_should_propagate_errors()) {
-                    if (calc_value->resolves_to_number()) {
-                        auto resolved_value = calc_value->resolve_number();
-                        dest.empend(Parser::Token::create_number(resolved_value.value()));
-                        continue;
-                    } else if (calc_value->resolves_to_percentage()) {
-                        auto resolved_value = calc_value->resolve_percentage();
-                        dest.empend(Parser::Token::create_percentage(resolved_value.value().value()));
-                        continue;
-                    } else {
-                        dbgln_if(LIBWEB_CSS_DEBUG, "FIXME: Unimplemented calc() expansion: {}", calc_value->to_string());
-                    }
+            if (auto maybe_calc_value = Parser::Parser::parse_calculated_value({}, Parser::ParsingContext { document() }, value).release_value_but_fixme_should_propagate_errors(); maybe_calc_value && maybe_calc_value->is_calculated()) {
+                auto& calc_value = maybe_calc_value->as_calculated();
+                if (calc_value.resolves_to_number()) {
+                    auto resolved_value = calc_value.resolve_number();
+                    dest.empend(Parser::Token::create_number(resolved_value.value()));
+                    continue;
+                } else if (calc_value.resolves_to_percentage()) {
+                    auto resolved_value = calc_value.resolve_percentage();
+                    dest.empend(Parser::Token::create_percentage(resolved_value.value().value()));
+                    continue;
+                } else {
+                    dbgln_if(LIBWEB_CSS_DEBUG, "FIXME: Unimplemented calc() expansion: {}", calc_value.to_string());
                 }
             }
 


### PR DESCRIPTION
We had `parse_calculated_value()` which parsed the contents of `calc()`, and `parse_dynamic_value()` which parsed any math function, both of which produce a CalculatedStyleValue, but return a plain StyleValue. This was confusing, so let's combine them together, and return a CalculatedStyleValue.

This also makes the other math functions work in `StyleComputer::expand_unresolved_values()`.

And it's 49 fewer lines. Not much but it's something!