### PR TITLE
LibWeb/Layout: Get rid of `isinfinite()` and `INFINITY`

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/AvailableSpace.cpp
+++ b/Userland/Libraries/LibWeb/Layout/AvailableSpace.cpp
@@ -17,7 +17,7 @@ AvailableSize AvailableSize::make_definite(CSSPixels value)
 
 AvailableSize AvailableSize::make_indefinite()
 {
-    return AvailableSize { Type::Indefinite, INFINITY };
+    return AvailableSize { Type::Indefinite, CSSPixels::max() };
 }
 
 AvailableSize AvailableSize::make_min_content()
@@ -27,7 +27,7 @@ AvailableSize AvailableSize::make_min_content()
 
 AvailableSize AvailableSize::make_max_content()
 {
-    return AvailableSize { Type::MaxContent, INFINITY };
+    return AvailableSize { Type::MaxContent, CSSPixels::max() };
 }
 
 DeprecatedString AvailableSize::to_deprecated_string() const

--- a/Userland/Libraries/LibWeb/Layout/AvailableSpace.cpp
+++ b/Userland/Libraries/LibWeb/Layout/AvailableSpace.cpp
@@ -11,7 +11,7 @@ namespace Web::Layout {
 
 AvailableSize AvailableSize::make_definite(CSSPixels value)
 {
-    VERIFY(isfinite(value.to_double()));
+    VERIFY(!value.might_be_saturated());
     return AvailableSize { Type::Definite, value };
 }
 

--- a/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -97,7 +97,7 @@ void FlexFormattingContext::run(Box const& run_box, LayoutMode, AvailableSpace c
                 if (!flex_item_is_stretched(item))
                     continue;
                 auto item_min_cross_size = has_cross_min_size(item.box) ? specified_cross_min_size(item.box) : 0;
-                auto item_max_cross_size = has_cross_max_size(item.box) ? specified_cross_max_size(item.box) : INFINITY;
+                auto item_max_cross_size = has_cross_max_size(item.box) ? specified_cross_max_size(item.box) : CSSPixels::max();
                 auto item_preferred_outer_cross_size = css_clamp(flex_container_inner_cross_size, item_min_cross_size, item_max_cross_size);
                 auto item_inner_cross_size = item_preferred_outer_cross_size - item.margins.cross_before - item.margins.cross_after - item.padding.cross_before - item.padding.cross_after - item.borders.cross_before - item.borders.cross_after;
                 set_cross_size(item.box, item_inner_cross_size);
@@ -1233,7 +1233,7 @@ void FlexFormattingContext::calculate_cross_size_of_each_flex_line()
         auto const& computed_min_size = this->computed_cross_min_size(flex_container());
         auto const& computed_max_size = this->computed_cross_max_size(flex_container());
         auto cross_min_size = (!computed_min_size.is_auto() && !computed_min_size.contains_percentage()) ? specified_cross_min_size(flex_container()) : 0;
-        auto cross_max_size = (!computed_max_size.is_none() && !computed_max_size.contains_percentage()) ? specified_cross_max_size(flex_container()) : INFINITY;
+        auto cross_max_size = (!computed_max_size.is_none() && !computed_max_size.contains_percentage()) ? specified_cross_max_size(flex_container()) : CSSPixels::max();
         m_flex_lines[0].cross_size = css_clamp(m_flex_lines[0].cross_size, cross_min_size, cross_max_size);
     }
 }
@@ -1258,7 +1258,7 @@ void FlexFormattingContext::determine_used_cross_size_of_each_flex_item()
                 auto const& computed_min_size = computed_cross_min_size(item.box);
                 auto const& computed_max_size = computed_cross_max_size(item.box);
                 auto cross_min_size = (!computed_min_size.is_auto() && !computed_min_size.contains_percentage()) ? specified_cross_min_size(item.box) : 0;
-                auto cross_max_size = (!computed_max_size.is_none() && !computed_max_size.contains_percentage()) ? specified_cross_max_size(item.box) : INFINITY;
+                auto cross_max_size = (!computed_max_size.is_none() && !computed_max_size.contains_percentage()) ? specified_cross_max_size(item.box) : CSSPixels::max();
 
                 item.cross_size = css_clamp(unclamped_cross_size, cross_min_size, cross_max_size);
             } else {
@@ -1551,7 +1551,7 @@ void FlexFormattingContext::determine_flex_container_used_cross_size()
         auto const& computed_min_size = this->computed_cross_min_size(flex_container());
         auto const& computed_max_size = this->computed_cross_max_size(flex_container());
         auto cross_min_size = (!computed_min_size.is_auto() && !computed_min_size.contains_percentage()) ? specified_cross_min_size(flex_container()) : 0;
-        auto cross_max_size = (!computed_max_size.is_none() && !computed_max_size.contains_percentage()) ? specified_cross_max_size(flex_container()) : INFINITY;
+        auto cross_max_size = (!computed_max_size.is_none() && !computed_max_size.contains_percentage()) ? specified_cross_max_size(flex_container()) : CSSPixels::max();
         set_cross_size(flex_container(), css_clamp(cross_size, cross_min_size, cross_max_size));
     } else {
         set_cross_size(flex_container(), cross_size);
@@ -1736,7 +1736,7 @@ CSSPixels FlexFormattingContext::calculate_intrinsic_main_size_of_flex_container
             }
         } else if (result < 0) {
             if (item.scaled_flex_shrink_factor == 0)
-                result = -INFINITY;
+                result = CSSPixels::min();
             else
                 result /= item.scaled_flex_shrink_factor;
         }

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -1307,7 +1307,7 @@ CSSPixels FormattingContext::calculate_min_content_width(Layout::Box const& box)
 
     cache.min_content_width = context->automatic_content_width();
 
-    if (!isfinite(cache.min_content_width->to_double())) {
+    if (cache.min_content_width->might_be_saturated()) {
         // HACK: If layout calculates a non-finite result, something went wrong. Force it to zero and log a little whine.
         dbgln("FIXME: Calculated non-finite min-content width for {}", box.debug_description());
         cache.min_content_width = 0;
@@ -1345,7 +1345,7 @@ CSSPixels FormattingContext::calculate_max_content_width(Layout::Box const& box)
 
     cache.max_content_width = context->automatic_content_width();
 
-    if (!isfinite(cache.max_content_width->to_double())) {
+    if (cache.max_content_width->might_be_saturated()) {
         // HACK: If layout calculates a non-finite result, something went wrong. Force it to zero and log a little whine.
         dbgln("FIXME: Calculated non-finite max-content width for {}", box.debug_description());
         cache.max_content_width = 0;
@@ -1388,7 +1388,7 @@ CSSPixels FormattingContext::calculate_min_content_height(Layout::Box const& box
     context->run(box, LayoutMode::IntrinsicSizing, AvailableSpace(AvailableSize::make_definite(width), AvailableSize::make_min_content()));
 
     auto min_content_height = context->automatic_content_height();
-    if (!isfinite(min_content_height.to_double())) {
+    if (min_content_height.might_be_saturated()) {
         // HACK: If layout calculates a non-finite result, something went wrong. Force it to zero and log a little whine.
         dbgln("FIXME: Calculated non-finite min-content height for {}", box.debug_description());
         min_content_height = 0;
@@ -1433,7 +1433,7 @@ CSSPixels FormattingContext::calculate_max_content_height(Layout::Box const& box
 
     auto max_content_height = context->automatic_content_height();
 
-    if (!isfinite(max_content_height.to_double())) {
+    if (max_content_height.might_be_saturated()) {
         // HACK: If layout calculates a non-finite result, something went wrong. Force it to zero and log a little whine.
         dbgln("FIXME: Calculated non-finite max-content height for {}", box.debug_description());
         max_content_height = 0;

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -1521,7 +1521,7 @@ CSSPixels FormattingContext::containing_block_width_for(NodeWithStyleAndBoxModel
     case SizeConstraint::MinContent:
         return 0;
     case SizeConstraint::MaxContent:
-        return INFINITY;
+        return CSSPixels::max();
     case SizeConstraint::None:
         return containing_block_state.content_width();
     }
@@ -1537,7 +1537,7 @@ CSSPixels FormattingContext::containing_block_height_for(NodeWithStyleAndBoxMode
     case SizeConstraint::MinContent:
         return 0;
     case SizeConstraint::MaxContent:
-        return INFINITY;
+        return CSSPixels::max();
     case SizeConstraint::None:
         return containing_block_state.content_height();
     }

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -1080,7 +1080,7 @@ void GridFormattingContext::maximize_tracks(AvailableSpace const& available_spac
         // free space is infinite; if sizing under a min-content constraint, the free space is zero.
         auto free_space = get_free_space(available_space, dimension);
         if (free_space.is_max_content() || free_space.is_indefinite()) {
-            return INFINITY;
+            return CSSPixels::max();
         } else if (free_space.is_min_content()) {
             return 0;
         } else {

--- a/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -265,7 +265,7 @@ void TableFormattingContext::compute_cell_measures()
         // However, during this early phase we don't have enough information to resolve percentage sizes yet and the formulas for outer sizes
         // in the specification give enough clues to pick defaults in a way that makes sense.
         auto height = computed_values.height().is_length() ? computed_values.height().to_px(cell.box, containing_block.content_height()) : 0;
-        auto max_height = computed_values.max_height().is_length() ? computed_values.max_height().to_px(cell.box, containing_block.content_height()) : INFINITY;
+        auto max_height = computed_values.max_height().is_length() ? computed_values.max_height().to_px(cell.box, containing_block.content_height()) : CSSPixels::max();
         if (m_rows[cell.row_index].is_constrained) {
             // The outer max-content height of a table-cell in a constrained row is
             // max(min-height, height, min-content height, min(max-height, height)) adjusted by the cell intrinsic offsets.
@@ -279,7 +279,7 @@ void TableFormattingContext::compute_cell_measures()
 
         // See the explanation for height and max_height above.
         auto width = computed_values.width().is_length() ? computed_values.width().to_px(cell.box, containing_block.content_width()) : 0;
-        auto max_width = computed_values.max_width().is_length() ? computed_values.max_width().to_px(cell.box, containing_block.content_width()) : INFINITY;
+        auto max_width = computed_values.max_width().is_length() ? computed_values.max_width().to_px(cell.box, containing_block.content_width()) : CSSPixels::max();
         if (use_fixed_mode_layout() && !width_is_specified_length_or_percentage) {
             continue;
         }
@@ -305,7 +305,7 @@ void TableFormattingContext::compute_outer_content_sizes()
         for_each_child_box_matching(column_group_box, is_table_column, [&](auto& column_box) {
             auto const& computed_values = column_box.computed_values();
             auto min_width = computed_values.min_width().to_px(column_box, containing_block.content_width());
-            auto max_width = computed_values.max_width().is_length() ? computed_values.max_width().to_px(column_box, containing_block.content_width()) : INFINITY;
+            auto max_width = computed_values.max_width().is_length() ? computed_values.max_width().to_px(column_box, containing_block.content_width()) : CSSPixels::max();
             auto width = computed_values.width().to_px(column_box, containing_block.content_width());
             // The outer min-content width of a table-column or table-column-group is max(min-width, width).
             m_columns[column_index].min_size = max(min_width, width);
@@ -320,7 +320,7 @@ void TableFormattingContext::compute_outer_content_sizes()
     for (auto& row : m_rows) {
         auto const& computed_values = row.box->computed_values();
         auto min_height = computed_values.min_height().to_px(row.box, containing_block.content_height());
-        auto max_height = computed_values.max_height().is_length() ? computed_values.max_height().to_px(row.box, containing_block.content_height()) : INFINITY;
+        auto max_height = computed_values.max_height().is_length() ? computed_values.max_height().to_px(row.box, containing_block.content_height()) : CSSPixels::max();
         auto height = computed_values.height().to_px(row.box, containing_block.content_height());
         // The outer min-content height of a table-row or table-row-group is max(min-height, height).
         row.min_size = max(min_height, height);

--- a/Userland/Libraries/LibWeb/PixelUnits.h
+++ b/Userland/Libraries/LibWeb/PixelUnits.h
@@ -102,6 +102,16 @@ public:
         return res;
     }
 
+    static constexpr CSSPixels min()
+    {
+        return from_raw(NumericLimits<int>::min());
+    }
+
+    static constexpr CSSPixels max()
+    {
+        return from_raw(NumericLimits<int>::max());
+    }
+
     float to_float() const;
     double to_double() const;
     int to_int() const;


### PR DESCRIPTION
Small refactoring to remove floating-point things from the layout code, which became irrelevant after switching to fixed-point math.