### PR TITLE
Kernel: Allow acquiring the same LockRank multiple times

### DIFF
--- a/Kernel/Devices/Storage/NVMe/NVMeQueue.h
+++ b/Kernel/Devices/Storage/NVMe/NVMeQueue.h
@@ -18,6 +18,7 @@
 #include <Kernel/Locking/Spinlock.h>
 #include <Kernel/Memory/MemoryManager.h>
 #include <Kernel/Memory/TypedMapping.h>
+#include <Kernel/Tasks/WaitQueue.h>
 
 namespace Kernel {
 

--- a/Kernel/Locking/LockRank.cpp
+++ b/Kernel/Locking/LockRank.cpp
@@ -12,21 +12,22 @@
 
 namespace Kernel {
 
-void track_lock_acquire(LockRank rank)
+bool track_lock_acquire(LockRank rank)
 {
     if constexpr (LOCK_RANK_ENFORCEMENT) {
         auto* thread = Thread::current();
         if (thread && !thread->is_crashing())
-            thread->track_lock_acquire(rank);
+            return thread->track_lock_acquire(rank);
     }
+    return false;
 }
 
-void track_lock_release(LockRank rank)
+void track_lock_release(LockRank rank, bool change_state)
 {
     if constexpr (LOCK_RANK_ENFORCEMENT) {
         auto* thread = Thread::current();
         if (thread && !thread->is_crashing())
-            thread->track_lock_release(rank);
+            thread->track_lock_release(rank, change_state);
     }
 }
 

--- a/Kernel/Locking/LockRank.h
+++ b/Kernel/Locking/LockRank.h
@@ -38,6 +38,6 @@ enum class LockRank : int {
 
 AK_ENUM_BITWISE_OPERATORS(LockRank);
 
-void track_lock_acquire(LockRank);
-void track_lock_release(LockRank);
+[[nodiscard]] bool track_lock_acquire(LockRank);
+void track_lock_release(LockRank, bool change_state);
 }

--- a/Kernel/Locking/LockRank.h
+++ b/Kernel/Locking/LockRank.h
@@ -34,6 +34,9 @@ enum class LockRank : int {
     // Process locks are the highest rank, as they normally are taken
     // first thing when processing syscalls.
     Process = 0x010,
+
+    // Mutexes need to be taken before spinlocks, so they get their own lock-rank
+    Mutex = 0x020,
 };
 
 AK_ENUM_BITWISE_OPERATORS(LockRank);

--- a/Kernel/Locking/Mutex.cpp
+++ b/Kernel/Locking/Mutex.cpp
@@ -207,7 +207,7 @@ void Mutex::unlock()
     }
 }
 
-void Mutex::block(Thread& current_thread, Mode mode, SpinlockLocker<Spinlock<LockRank::None>>& lock, u32 requested_locks)
+void Mutex::block(Thread& current_thread, Mode mode, SpinlockLocker<Spinlock<Rank>>& lock, u32 requested_locks)
 {
     if constexpr (LOCK_IN_CRITICAL_DEBUG) {
         // There are no interrupts enabled in early boot.

--- a/Kernel/Locking/Spinlock.h
+++ b/Kernel/Locking/Spinlock.h
@@ -13,6 +13,11 @@
 
 namespace Kernel {
 
+struct [[nodiscard]] SpinLockKey {
+    InterruptsState interrupts_state { InterruptsState::Disabled };
+    bool affect_lock_rank { false };
+};
+
 template<LockRank Rank>
 class Spinlock {
     AK_MAKE_NONCOPYABLE(Spinlock);
@@ -21,25 +26,24 @@ class Spinlock {
 public:
     Spinlock() = default;
 
-    InterruptsState lock()
+    SpinLockKey lock()
     {
         InterruptsState previous_interrupts_state = Processor::interrupts_state();
         Processor::enter_critical();
         Processor::disable_interrupts();
         while (m_lock.exchange(1, AK::memory_order_acquire) != 0)
             Processor::wait_check();
-        track_lock_acquire(m_rank);
-        return previous_interrupts_state;
+        return { previous_interrupts_state, track_lock_acquire(m_rank) };
     }
 
-    void unlock(InterruptsState previous_interrupts_state)
+    void unlock(SpinLockKey key)
     {
         VERIFY(is_locked());
-        track_lock_release(m_rank);
+        track_lock_release(m_rank, key.affect_lock_rank);
         m_lock.store(0, AK::memory_order_release);
 
         Processor::leave_critical();
-        Processor::restore_interrupts_state(previous_interrupts_state);
+        Processor::restore_interrupts_state(key.interrupts_state);
     }
 
     [[nodiscard]] ALWAYS_INLINE bool is_locked() const
@@ -51,6 +55,8 @@ public:
     {
         m_lock.store(0, AK::memory_order_relaxed);
     }
+
+    constexpr LockRank rank() { return Rank; }
 
 private:
     Atomic<u8> m_lock { 0 };
@@ -65,7 +71,7 @@ class RecursiveSpinlock {
 public:
     RecursiveSpinlock() = default;
 
-    InterruptsState lock()
+    SpinLockKey lock()
     {
         InterruptsState previous_interrupts_state = Processor::interrupts_state();
         Processor::disable_interrupts();
@@ -79,24 +85,25 @@ public:
             Processor::wait_check();
             expected = 0;
         }
+        bool did_affect_lock_rank = false;
         if (m_recursions == 0)
-            track_lock_acquire(m_rank);
+            did_affect_lock_rank = track_lock_acquire(m_rank);
         m_recursions++;
-        return previous_interrupts_state;
+        return { previous_interrupts_state, did_affect_lock_rank };
     }
 
-    void unlock(InterruptsState previous_interrupts_state)
+    void unlock(SpinLockKey key)
     {
         VERIFY_INTERRUPTS_DISABLED();
         VERIFY(m_recursions > 0);
         VERIFY(m_lock.load(AK::memory_order_relaxed) == FlatPtr(&Processor::current()));
         if (--m_recursions == 0) {
-            track_lock_release(m_rank);
+            track_lock_release(m_rank, key.affect_lock_rank);
             m_lock.store(0, AK::memory_order_release);
         }
 
         Processor::leave_critical();
-        Processor::restore_interrupts_state(previous_interrupts_state);
+        Processor::restore_interrupts_state(key.interrupts_state);
     }
 
     [[nodiscard]] ALWAYS_INLINE bool is_locked() const
@@ -113,6 +120,8 @@ public:
     {
         m_lock.store(0, AK::memory_order_relaxed);
     }
+
+    constexpr LockRank rank() { return Rank; }
 
 private:
     Atomic<FlatPtr> m_lock { 0 };
@@ -132,24 +141,24 @@ public:
         : m_lock(&lock)
     {
         VERIFY(m_lock);
-        m_previous_interrupts_state = m_lock->lock();
+        m_key = m_lock->lock();
         m_have_lock = true;
     }
 
     SpinlockLocker(SpinlockLocker&& from)
         : m_lock(from.m_lock)
-        , m_previous_interrupts_state(from.m_previous_interrupts_state)
+        , m_key(from.m_key)
         , m_have_lock(from.m_have_lock)
     {
         from.m_lock = nullptr;
-        from.m_previous_interrupts_state = InterruptsState::Disabled;
+        from.m_key = {};
         from.m_have_lock = false;
     }
 
     ~SpinlockLocker()
     {
         if (m_lock && m_have_lock) {
-            m_lock->unlock(m_previous_interrupts_state);
+            m_lock->unlock(m_key);
         }
     }
 
@@ -157,7 +166,7 @@ public:
     {
         VERIFY(m_lock);
         VERIFY(!m_have_lock);
-        m_previous_interrupts_state = m_lock->lock();
+        m_key = m_lock->lock();
         m_have_lock = true;
     }
 
@@ -165,8 +174,8 @@ public:
     {
         VERIFY(m_lock);
         VERIFY(m_have_lock);
-        m_lock->unlock(m_previous_interrupts_state);
-        m_previous_interrupts_state = InterruptsState::Disabled;
+        m_lock->unlock(m_key);
+        m_key = {};
         m_have_lock = false;
     }
 
@@ -177,7 +186,7 @@ public:
 
 private:
     LockType* m_lock { nullptr };
-    InterruptsState m_previous_interrupts_state { InterruptsState::Disabled };
+    SpinLockKey m_key {};
     bool m_have_lock { false };
 };
 

--- a/Kernel/Memory/MemoryManager.cpp
+++ b/Kernel/Memory/MemoryManager.cpp
@@ -1155,7 +1155,7 @@ u8* MemoryManager::quickmap_page(PhysicalAddress const& physical_address)
 {
     VERIFY_INTERRUPTS_DISABLED();
     auto& mm_data = get_data();
-    mm_data.m_quickmap_previous_interrupts_state = mm_data.m_quickmap_in_use.lock();
+    mm_data.m_quickmap_lock_key = mm_data.m_quickmap_in_use.lock();
 
     VirtualAddress vaddr(KERNEL_QUICKMAP_PER_CPU_BASE + Processor::current_id() * PAGE_SIZE);
     u32 pte_idx = (vaddr.get() - KERNEL_PT1024_BASE) / PAGE_SIZE;
@@ -1181,7 +1181,7 @@ void MemoryManager::unquickmap_page()
     auto& pte = ((PageTableEntry*)boot_pd_kernel_pt1023)[pte_idx];
     pte.clear();
     flush_tlb_local(vaddr);
-    mm_data.m_quickmap_in_use.unlock(mm_data.m_quickmap_previous_interrupts_state);
+    mm_data.m_quickmap_in_use.unlock(mm_data.m_quickmap_lock_key);
 }
 
 bool MemoryManager::validate_user_stack(AddressSpace& space, VirtualAddress vaddr) const

--- a/Kernel/Memory/MemoryManager.h
+++ b/Kernel/Memory/MemoryManager.h
@@ -87,7 +87,7 @@ struct MemoryManagerData {
     static ProcessorSpecificDataID processor_specific_data_id() { return ProcessorSpecificDataID::MemoryManager; }
 
     Spinlock<LockRank::None> m_quickmap_in_use {};
-    InterruptsState m_quickmap_previous_interrupts_state;
+    SpinLockKey m_quickmap_lock_key;
 };
 
 // This class represents a set of committed physical pages.

--- a/Kernel/Security/Random.h
+++ b/Kernel/Security/Random.h
@@ -13,6 +13,7 @@
 #include <Kernel/Arch/Processor.h>
 #include <Kernel/Library/StdLib.h>
 #include <Kernel/Locking/Mutex.h>
+#include <Kernel/Tasks/WaitQueue.h>
 #include <LibCrypto/Cipher/AES.h>
 #include <LibCrypto/Cipher/Cipher.h>
 #include <LibCrypto/Hash/SHA2.h>

--- a/Kernel/Syscalls/execve.cpp
+++ b/Kernel/Syscalls/execve.cpp
@@ -989,7 +989,12 @@ ErrorOr<FlatPtr> Process::sys$execve(Userspace<Syscall::SC_execve_params const*>
         // thread. We should also still be in our critical section
         VERIFY(!g_scheduler_lock.is_locked_by_current_processor());
         VERIFY(Processor::in_critical() == 1);
-        g_scheduler_lock.lock();
+
+        auto key = g_scheduler_lock.lock();
+        VERIFY(key.interrupts_state == InterruptsState::Disabled);
+        // FIXME: Remove the None check
+        VERIFY(key.affect_lock_rank || g_scheduler_lock.rank() == LockRank::None);
+
         current_thread->set_state(Thread::State::Running);
         Processor::assume_context(*current_thread, previous_interrupts_state);
         VERIFY_NOT_REACHED();

--- a/Kernel/Tasks/Thread.cpp
+++ b/Kernel/Tasks/Thread.cpp
@@ -220,7 +220,7 @@ Thread::BlockResult Thread::block_impl(BlockTimeout const& timeout, Blocker& blo
     return result;
 }
 
-void Thread::block(Kernel::Mutex& lock, SpinlockLocker<Spinlock<LockRank::None>>& lock_lock, u32 lock_count)
+void Thread::block(Kernel::Mutex& lock, SpinlockLocker<Spinlock<Kernel::Mutex::Rank>>& lock_lock, u32 lock_count)
 {
     VERIFY(!Processor::current_in_irq());
     VERIFY(this == Thread::current());

--- a/Kernel/Tasks/Thread.h
+++ b/Kernel/Tasks/Thread.h
@@ -472,7 +472,7 @@ public:
         void begin_requeue()
         {
             // We need to hold the lock until we moved it over
-            m_previous_interrupts_state = m_lock.lock();
+            m_lock_key = m_lock.lock();
         }
         void finish_requeue(FutexQueue&);
 
@@ -482,7 +482,7 @@ public:
     protected:
         FutexQueue& m_futex_queue;
         u32 m_bitset { 0 };
-        InterruptsState m_previous_interrupts_state { InterruptsState::Disabled };
+        SpinLockKey m_lock_key {};
         bool m_did_unblock { false };
     };
 
@@ -944,8 +944,8 @@ public:
     u32 saved_critical() const { return m_saved_critical; }
     void save_critical(u32 critical) { m_saved_critical = critical; }
 
-    void track_lock_acquire(LockRank rank);
-    void track_lock_release(LockRank rank);
+    [[nodiscard]] bool track_lock_acquire(LockRank rank);
+    void track_lock_release(LockRank rank, bool change_state);
 
     [[nodiscard]] bool is_active() const { return m_is_active; }
 

--- a/Kernel/Tasks/Thread.h
+++ b/Kernel/Tasks/Thread.h
@@ -808,7 +808,7 @@ public:
         }
     }
 
-    void block(Kernel::Mutex&, SpinlockLocker<Spinlock<LockRank::None>>&, u32);
+    void block(Kernel::Mutex&, SpinlockLocker<Spinlock<LockRank::Mutex>>&, u32);
 
     template<typename BlockerType, class... Args>
     BlockResult block(BlockTimeout const& timeout, Args&&... args)

--- a/Kernel/Tasks/ThreadBlockers.cpp
+++ b/Kernel/Tasks/ThreadBlockers.cpp
@@ -164,7 +164,7 @@ void Thread::FutexBlocker::finish_requeue(FutexQueue& futex_queue)
     VERIFY(m_lock.is_locked_by_current_processor());
     set_blocker_set_raw_locked(&futex_queue);
     // We can now release the lock
-    m_lock.unlock(m_previous_interrupts_state);
+    m_lock.unlock(m_lock_key);
 }
 
 bool Thread::FutexBlocker::unblock_bitset(u32 bitset)


### PR DESCRIPTION
Otherwise we'd fail on acquiring the process level lockrank twice during jail propagation in `sys$fork`.

Also while we are at it, make the VERIFYs neat little PANICs with good debug messages.

---
CC: @kleinesfilmroellchen @bgianfo 