### PR TITLE
Ports/libgd: Explicitly specify which dependencies to include

### DIFF
--- a/Ports/libgd/package.sh
+++ b/Ports/libgd/package.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env -S bash ../.port_include.sh
-port=libgd
-version=2.3.3
-useconfigure=true
-use_fresh_config_sub=true
+port='libgd'
+version='2.3.3'
+useconfigure='true'
+use_fresh_config_sub='true'
 configopts=(
     "--with-sysroot=${SERENITY_INSTALL_ROOT}"
     '--without-avif'
@@ -13,7 +13,9 @@ configopts=(
     '--without-x'
     '--without-xpm'
 )
-config_sub_paths=("config/config.sub")
+config_sub_paths=(
+    'config/config.sub'
+)
 files=(
     "https://github.com/libgd/libgd/releases/download/gd-${version}/libgd-${version}.tar.gz dd3f1f0bb016edcc0b2d082e8229c822ad1d02223511997c80461481759b1ed2"
 )

--- a/Ports/libgd/package.sh
+++ b/Ports/libgd/package.sh
@@ -3,9 +3,25 @@ port=libgd
 version=2.3.3
 useconfigure=true
 use_fresh_config_sub=true
-configopts=("--without-x")
+configopts=(
+    "--with-sysroot=${SERENITY_INSTALL_ROOT}"
+    '--without-avif'
+    '--without-heif'
+    '--without-liq'
+    '--without-raqm'
+    '--without-webp'
+    '--without-x'
+    '--without-xpm'
+)
 config_sub_paths=("config/config.sub")
 files=(
     "https://github.com/libgd/libgd/releases/download/gd-${version}/libgd-${version}.tar.gz dd3f1f0bb016edcc0b2d082e8229c822ad1d02223511997c80461481759b1ed2"
 )
-depends=("libpng")
+depends=(
+    'fontconfig'
+    'freetype'
+    'libjpeg'
+    'libpng'
+    'libtiff'
+    'zlib'
+)


### PR DESCRIPTION
Previously, building `libgd` with `fontconfig` already installed would cause the build to fail.

~~Currently, we are building `libgd` without JPEG and TIFF support. These could be included, but currently the only port that makes use of this library (`npiet`) doesn't use this functionality.~~