### PR TITLE
AK+LibXML: Quality of life changes

### DIFF
--- a/AK/RecursionDecision.h
+++ b/AK/RecursionDecision.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <AK/Platform.h>
+
 namespace AK {
 
 enum class RecursionDecision {

--- a/AK/StringUtils.cpp
+++ b/AK/StringUtils.cpp
@@ -593,6 +593,16 @@ size_t count(StringView str, StringView needle)
     return count;
 }
 
+size_t count(StringView str, char needle)
+{
+    size_t count = 0;
+    for (size_t i = 0; i < str.length(); ++i) {
+        if (str[i] == needle)
+            count++;
+    }
+    return count;
+}
+
 }
 
 }

--- a/AK/StringUtils.h
+++ b/AK/StringUtils.h
@@ -107,6 +107,7 @@ DeprecatedString replace(StringView, StringView needle, StringView replacement, 
 ErrorOr<String> replace(String const&, StringView needle, StringView replacement, ReplaceMode);
 
 size_t count(StringView, StringView needle);
+size_t count(StringView, char needle);
 
 }
 

--- a/AK/StringView.h
+++ b/AK/StringView.h
@@ -330,6 +330,11 @@ public:
         return StringUtils::count(*this, needle);
     }
 
+    [[nodiscard]] size_t count(char needle) const
+    {
+        return StringUtils::count(*this, needle);
+    }
+
     template<typename... Ts>
     [[nodiscard]] ALWAYS_INLINE constexpr bool is_one_of(Ts&&... strings) const
     {

--- a/Userland/Libraries/LibXML/DOM/Node.h
+++ b/Userland/Libraries/LibXML/DOM/Node.h
@@ -36,5 +36,14 @@ struct Node {
 
     Variant<Text, Comment, Element> content;
     Node* parent { nullptr };
+
+    bool is_text() const { return content.has<Text>(); }
+    Text const& as_text() const { return content.get<Text>(); }
+
+    bool is_comment() const { return content.has<Comment>(); }
+    Comment const& as_comment() const { return content.get<Comment>(); }
+
+    bool is_element() const { return content.has<Element>(); }
+    Element const& as_element() const { return content.get<Element>(); }
 };
 }

--- a/Userland/Libraries/LibXML/DOM/Node.h
+++ b/Userland/Libraries/LibXML/DOM/Node.h
@@ -19,6 +19,12 @@ struct Attribute {
     DeprecatedString value;
 };
 
+struct Offset {
+    size_t offset { 0 };
+    size_t line { 0 };
+    size_t column { 0 };
+};
+
 struct Node {
     struct Text {
         StringBuilder builder;
@@ -34,6 +40,7 @@ struct Node {
 
     bool operator==(Node const&) const;
 
+    Offset offset;
     Variant<Text, Comment, Element> content;
     Node* parent { nullptr };
 

--- a/Userland/Libraries/LibXML/Parser/Parser.cpp
+++ b/Userland/Libraries/LibXML/Parser/Parser.cpp
@@ -130,7 +130,7 @@ void Parser::append_text(StringView text, Offset offset)
             }
             Node::Text text_node;
             text_node.builder.append(text);
-            node.children.append(make<Node>(offset, move(text_node)));
+            node.children.append(make<Node>(offset, move(text_node), m_entered_node));
         },
         [&](auto&) {
             // Can't enter a text or comment node.
@@ -152,7 +152,7 @@ void Parser::append_comment(StringView text, Offset offset)
 
     m_entered_node->content.visit(
         [&](Node::Element& node) {
-            node.children.append(make<Node>(offset, Node::Comment { text }));
+            node.children.append(make<Node>(offset, Node::Comment { text }, m_entered_node));
         },
         [&](auto&) {
             // Can't enter a text or comment node.


### PR DESCRIPTION
These are (hopefully) noncontroversial changes I needed to make while working on `JSSpecCompiler`. They will be used in the future initial `JSSpecCompiler` PR. Feel free to ask me to add tests (however, note that LibXML mostly doesn't have tests).

## LibXML: Add helpers for extracting node contents if its type is known

This allows to get rid of a lot of `Variant::visit` calls, thus makes interaction with LibXML much nicer.

## LibXML: Record source location for nodes

Recording nodes' location makes possible to generate nice error "stacktraces" when one parses information from XML-like format.

## LibXML: Set parents for text and comment nodes

Looks like an oversight, but pinging @alimpfard if this is intentional.