### PR TITLE
LibWeb: Ignore % max-width if box is sized under max-content constraint

### DIFF
--- a/Tests/LibWeb/Layout/expected/block-and-inline/inline-block-percentage-max-width.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/inline-block-percentage-max-width.txt
@@ -1,0 +1,16 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x113.46875 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x97.46875 children: inline
+      line 0 width: 134.109375, height: 97.46875, bottom: 97.46875, baseline: 53.53125
+        frag 0 from BlockContainer start: 0, length: 0, rect: [48,48 54.109375x17.46875]
+      BlockContainer <div> at (48,48) content-size 54.109375x17.46875 inline-block [BFC] children: inline
+        line 0 width: 54.109375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+          frag 0 from TextNode start: 0, length: 6, rect: [48,48 54.109375x17.46875]
+            "New UI"
+        TextNode <#text>
+
+PaintableWithLines (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x113.46875]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x97.46875]
+      PaintableWithLines (BlockContainer<DIV>) [8,8 134.109375x97.46875]
+        TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/input/block-and-inline/inline-block-percentage-max-width.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/inline-block-percentage-max-width.html
@@ -1,0 +1,11 @@
+<!doctype html><style>
+    * {
+        outline: 1px solid black;
+    }
+    div {
+        display: inline-block;
+        max-width: 100%;
+        box-sizing: border-box;
+        padding: 40px;
+    }
+</style><body><div>New UI

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -1810,6 +1810,8 @@ bool FormattingContext::should_treat_max_width_as_none(Box const& box, Available
     if (box.is_absolutely_positioned())
         return false;
     if (max_width.contains_percentage()) {
+        if (available_width.is_max_content())
+            return true;
         if (available_width.is_min_content())
             return false;
         if (!m_state.get(*box.non_anonymous_containing_block()).has_definite_width())


### PR DESCRIPTION
When a box is sized under max-content constraint, any percentage value set for max-width should be considered as if it were infinite. In other words, it should have no effect on restricting the box's width.