### PR TITLE
Ports: Fix `acpica-tools` compilation on Clang toolchain

### DIFF
--- a/Ports/acpica-tools/package.sh
+++ b/Ports/acpica-tools/package.sh
@@ -6,12 +6,17 @@ files=(
     "https://github.com/acpica/acpica/archive/refs/tags/${version}.tar.gz 2248799b7ca08a7711ac87d31924354ed49047507607d033bd327ba861ec4d31"
 )
 
+makeopts+=(
+    'iasl'
+    'acpixtract'
+    # FIXME: Add "acpiexec" to work
+    'acpihelp'
+    'acpisrc'
+    'acpibin'
+)
 
-build() {
-    run make iasl
-    run make acpixtract
-    # FIXME: Make "run make acpiexec" to work
-    run make acpihelp
-    run make acpisrc
-    run make acpibin
-}
+if [[ "$SERENITY_TOOLCHAIN" == "GNU" ]]; then
+    makeopts+=(
+        CWARNINGFLAGS='-Wlogical-op -Wmissing-parameter-type -Wold-style-declaration'
+    )
+fi

--- a/Ports/acpica-tools/patches/0004-Remove-unsupported-warning-flags-for-cross-compile.patch
+++ b/Ports/acpica-tools/patches/0004-Remove-unsupported-warning-flags-for-cross-compile.patch
@@ -1,0 +1,59 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Gurkirat Singh <tbhaxor@gmail.com>
+Date: Mon, 28 Aug 2023 21:21:37 +0530
+Subject: [PATCH] Remove unsupported warning flags for cross-compile
+
+* -Wlogical-op
+* -Wmissing-parameter-type
+* -Wold-style-declaration
+---
+ generate/efi/Makefile.config  | 5 +----
+ generate/unix/Makefile.config | 5 +----
+ 2 files changed, 2 insertions(+), 8 deletions(-)
+
+diff --git a/generate/efi/Makefile.config b/generate/efi/Makefile.config
+index da49657bd1779cf1b45f019c05d98d4214d05487..57b04d8e0268aff6a172abbd2dfe833874c1df5b 100644
+--- a/generate/efi/Makefile.config
++++ b/generate/efi/Makefile.config
+@@ -146,7 +146,7 @@ endif
+ # Common compiler warning flags. The warning flags in addition
+ # to -Wall are not automatically included in -Wall.
+ #
+-CWARNINGFLAGS = \
++override CWARNINGFLAGS += \
+ 	-Wall\
+ 	-Wbad-function-cast\
+ 	-Wdeclaration-after-statement\
+@@ -157,9 +157,6 @@ CWARNINGFLAGS = \
+ 	-Wswitch-default\
+ 	-Wpointer-arith\
+ 	-Wempty-body\
+-	-Wlogical-op\
+-	-Wmissing-parameter-type\
+-	-Wold-style-declaration\
+ 	-Wtype-limits
+ 
+ ifneq ($(NOWERROR),TRUE)
+diff --git a/generate/unix/Makefile.config b/generate/unix/Makefile.config
+index 0374e09d880f0ecec165acc32e7b30a4dbb0c8cc..89d0d2d0a3f4c5c4032363a8afb58c9ba350ef65 100644
+--- a/generate/unix/Makefile.config
++++ b/generate/unix/Makefile.config
+@@ -198,7 +198,7 @@ endif
+ # Common compiler warning flags. The warning flags in addition
+ # to -Wall are not automatically included in -Wall.
+ #
+-CWARNINGFLAGS = \
++override CWARNINGFLAGS += \
+     -std=c99\
+     -Wall\
+     -Wbad-function-cast\
+@@ -241,9 +241,6 @@ ifneq ($(ACPI_HOST), _FreeBSD)
+     ifneq ($(ACPI_HOST), _APPLE)
+         CWARNINGFLAGS += \
+             -Woverride-init\
+-            -Wlogical-op\
+-            -Wmissing-parameter-type\
+-            -Wold-style-declaration\
+             -Wtype-limits
+     endif
+ endif

--- a/Ports/acpica-tools/patches/ReadMe.md
+++ b/Ports/acpica-tools/patches/ReadMe.md
@@ -16,3 +16,11 @@ We use the netbsd "acnetbsd.h" file here as a template.
 Disable warnings for Werror=bad-function-cast
 
 
+## `0004-Remove-unsupported-warning-flags-for-cross-compile.patch`
+
+Remove unsupported warning flags for cross-compile
+
+* -Wlogical-op
+* -Wmissing-parameter-type
+* -Wold-style-declaration
+


### PR DESCRIPTION
The clang toolchain was broken because of unknown warning flags in the Makefiles.

* -Wlogical-op
* -Wmissing-parameter-type
* -Wold-style-declaration