### PR TITLE
Userland: Don't use buffered output when writing to stdout in echo(1), propagate errors on failed writing flush on FILE*

### DIFF
--- a/AK/Format.h
+++ b/AK/Format.h
@@ -574,15 +574,11 @@ void outln(FILE* file, CheckedFormatString<Parameters...>&& fmtstr, Parameters c
     vout(file, fmtstr.view(), variadic_format_params, true);
 }
 
-inline void outln(FILE* file) { fputc('\n', file); }
-
 template<typename... Parameters>
 void out(CheckedFormatString<Parameters...>&& fmtstr, Parameters const&... parameters) { out(stdout, move(fmtstr), parameters...); }
 
 template<typename... Parameters>
 void outln(CheckedFormatString<Parameters...>&& fmtstr, Parameters const&... parameters) { outln(stdout, move(fmtstr), parameters...); }
-
-inline void outln() { outln(stdout); }
 
 #    define outln_if(flag, fmt, ...)       \
         do {                               \
@@ -598,8 +594,6 @@ void warn(CheckedFormatString<Parameters...>&& fmtstr, Parameters const&... para
 
 template<typename... Parameters>
 void warnln(CheckedFormatString<Parameters...>&& fmtstr, Parameters const&... parameters) { outln(stderr, move(fmtstr), parameters...); }
-
-inline void warnln() { outln(stderr); }
 
 #    define warnln_if(flag, fmt, ...)       \
         do {                                \
@@ -625,7 +619,27 @@ void dbgln(CheckedFormatString<Parameters...>&& fmtstr, Parameters const&... par
     vdbg(fmtstr.view(), variadic_format_params, true);
 }
 
-inline void dbgln() { dbgln(""); }
+#ifndef KERNEL
+
+inline void outln(FILE* file)
+{
+    int rc = fputc('\n', file);
+    if (rc < 0) {
+        auto error = ferror(file);
+        dbgln("vout() failed, error was {} ({})", error, strerror(error));
+    }
+}
+
+inline void outln() { outln(stdout); }
+
+inline void warnln() { outln(stderr); }
+
+#endif
+
+inline void dbgln()
+{
+    dbgln("");
+}
 
 void set_debug_enabled(bool);
 

--- a/Userland/Libraries/LibC/stdio.cpp
+++ b/Userland/Libraries/LibC/stdio.cpp
@@ -217,7 +217,7 @@ size_t FILE::write(u8 const* data, size_t size)
     m_flags |= Flags::LastWrite;
 
     while (size > 0) {
-        size_t actual_size;
+        size_t actual_size = 0;
 
         if (m_buffer.may_use()) {
             m_buffer.realize(m_fd);
@@ -239,8 +239,10 @@ size_t FILE::write(u8 const* data, size_t size)
             // See if we have to flush it.
             if (m_buffer.mode() == _IOLBF) {
                 bool includes_newline = memchr(data, '\n', actual_size);
-                if (includes_newline)
-                    flush();
+                if (includes_newline) {
+                    if (!flush())
+                        return total_written;
+                }
             }
         } else {
             // Write directly from the user buffer.

--- a/Userland/Utilities/echo.cpp
+++ b/Userland/Utilities/echo.cpp
@@ -112,6 +112,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.set_stop_on_first_non_option(true);
     args_parser.parse(arguments);
 
+    setvbuf(stdout, nullptr, _IONBF, 0);
+
     if (text.is_empty()) {
         if (!no_trailing_newline)
             outln();
@@ -121,8 +123,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto output = DeprecatedString::join(' ', text);
     if (should_interpret_backslash_escapes)
         output = interpret_backslash_escapes(output, no_trailing_newline);
-    out("{}", output);
     if (!no_trailing_newline)
-        outln();
+        outln("{}", output);
+    else
+        out("{}", output);
     return 0;
 }


### PR DESCRIPTION
When I tested the changes on #20111, I saw that I couldn't get an debug print error when writing to the sysfs `hostname` node. Also, I tried to write `echo "test" > /dev/full` and this appeared to print nothing to the debug console as well.

Therefore I decided we should try to fix this with some small patches :)