### PR TITLE
Kernel/Storage: Properly free unused NVMeIO AsyncBlockDeviceRequest

### DIFF
--- a/Kernel/Devices/Storage/NVMe/NVMeInterruptQueue.cpp
+++ b/Kernel/Devices/Storage/NVMe/NVMeInterruptQueue.cpp
@@ -57,7 +57,7 @@ void NVMeInterruptQueue::complete_current_request(u16 cmdid, u16 status)
                 request_pdu.request->complete(req_result);
             if (request_pdu.end_io_handler)
                 request_pdu.end_io_handler(status);
-            request_pdu.used = false;
+            request_pdu.clear();
         };
 
         // There can be submission without any request associated with it such as with
@@ -87,7 +87,7 @@ void NVMeInterruptQueue::complete_current_request(u16 cmdid, u16 status)
         current_request->complete(AsyncDeviceRequest::OutOfMemory);
         if (request_pdu.end_io_handler)
             request_pdu.end_io_handler(status);
-        request_pdu.used = false;
+        request_pdu.clear();
     }
 }
 }

--- a/Kernel/Devices/Storage/NVMe/NVMePollQueue.cpp
+++ b/Kernel/Devices/Storage/NVMe/NVMePollQueue.cpp
@@ -42,7 +42,7 @@ void NVMePollQueue::complete_current_request(u16 cmdid, u16 status)
             request_pdu.request->complete(req_result);
         if (request_pdu.end_io_handler)
             request_pdu.end_io_handler(status);
-        request_pdu.used = false;
+        request_pdu.clear();
     };
 
     // There can be submission without any request associated with it such as with

--- a/Kernel/Devices/Storage/NVMe/NVMeQueue.h
+++ b/Kernel/Devices/Storage/NVMe/NVMeQueue.h
@@ -34,6 +34,12 @@ enum class QueueType {
 class AsyncBlockDeviceRequest;
 
 struct NVMeIO {
+    void clear()
+    {
+        used = false;
+        request = nullptr;
+        end_io_handler = nullptr;
+    }
     RefPtr<AsyncBlockDeviceRequest> request;
     bool used = false;
     Function<void(u16 status)> end_io_handler;


### PR DESCRIPTION
This was the root cause of zombie processes showing up randomly and disappearing after some disk activity, such as running shell commands - The NVMeIO AsyncBlockDeviceRequest member simply held a pointer to a Process object, therefore it could keep it alive a for a long time after it ceased to actually function at all.

This has to be merged before #20588 could be merged.