### PR TITLE
LibWeb: Fix a rounding issue on CSSPixels multiplication

### DIFF
--- a/Tests/LibWeb/TestCSSPixels.cpp
+++ b/Tests/LibWeb/TestCSSPixels.cpp
@@ -55,6 +55,13 @@ TEST_CASE(multiplication1)
     b = CSSPixels::from_raw(0b01'100000);
     EXPECT_EQ(a * b, CSSPixels(a.to_double() * b.to_double()));
     EXPECT_EQ(a * -b, CSSPixels(a.to_double() * -b.to_double()));
+
+    EXPECT_EQ(
+        CSSPixels::from_raw(0b01'0000011) * CSSPixels::from_raw(0b00'010000),
+        CSSPixels::from_raw(0b00'0100001));
+    EXPECT_EQ(
+        CSSPixels::from_raw(0b01'0000111) * CSSPixels::from_raw(0b00'010000),
+        CSSPixels::from_raw(0b00'0100010));
 }
 
 TEST_CASE(addition2)

--- a/Userland/Libraries/LibWeb/PixelUnits.h
+++ b/Userland/Libraries/LibWeb/PixelUnits.h
@@ -170,8 +170,8 @@ public:
         // Rounding:
         // If last bit cut off was 1:
         if (value & (1u << (fractional_bits - 1))) {
-            // If the bit after was 1 as well
-            if (value & (radix_mask >> 2u)) {
+            // If any bit after was 1 as well
+            if (value & (radix_mask >> 1u)) {
                 // We need to round away from 0
                 int_value = Checked<int>::saturating_add(int_value, 1);
             } else {


### PR DESCRIPTION
We had the same issue as discovered in #20529 in CSSPixels aswell....

CC @ronak69