### PR TITLE
Kernel: Introduce the new ProcessManagement singleton

### DIFF
--- a/Kernel/Arch/init.cpp
+++ b/Kernel/Arch/init.cpp
@@ -50,6 +50,7 @@
 #include <Kernel/TTY/VirtualConsole.h>
 #include <Kernel/Tasks/FinalizerTask.h>
 #include <Kernel/Tasks/Process.h>
+#include <Kernel/Tasks/ProcessManagement.h>
 #include <Kernel/Tasks/Scheduler.h>
 #include <Kernel/Tasks/SyncTask.h>
 #include <Kernel/Tasks/WorkQueue.h>
@@ -285,6 +286,7 @@ extern "C" [[noreturn]] UNMAP_AFTER_INIT void init([[maybe_unused]] BootInfo con
     __stack_chk_guard = get_fast_random<uintptr_t>();
 
     Process::initialize();
+    ProcessManagement::initialize();
 
     Scheduler::initialize();
 
@@ -340,11 +342,6 @@ extern "C" UNMAP_AFTER_INIT void init_finished(u32 cpu)
 
 void init_stage2(void*)
 {
-    // This is a little bit of a hack. We can't register our process at the time we're
-    // creating it, but we need to be registered otherwise finalization won't be happy.
-    // The colonel process gets away without having to do this because it never exits.
-    Process::register_new(Process::current());
-
     WorkQueue::initialize();
 
 #if ARCH(X86_64)

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -355,6 +355,7 @@ set(KERNEL_SOURCES
     Tasks/Process.cpp
     Tasks/ProcessGroup.cpp
     Tasks/ProcessList.cpp
+    Tasks/ProcessManagement.cpp
     Tasks/Scheduler.cpp
     Tasks/SyncTask.cpp
     Tasks/Thread.cpp

--- a/Kernel/FileSystem/ProcFS/Inode.cpp
+++ b/Kernel/FileSystem/ProcFS/Inode.cpp
@@ -8,6 +8,7 @@
 
 #include <Kernel/FileSystem/ProcFS/Inode.h>
 #include <Kernel/Tasks/Process.h>
+#include <Kernel/Tasks/ProcessManagement.h>
 #include <Kernel/Time/TimeManagement.h>
 
 namespace Kernel {
@@ -112,7 +113,7 @@ ErrorOr<void> ProcFSInode::traverse_as_root_directory(Function<ErrorOr<void>(Fil
     TRY(callback({ ".."sv, { fsid(), 0 }, 0 }));
     TRY(callback({ "self"sv, { fsid(), 2 }, 0 }));
 
-    return Process::for_each_in_same_jail([&](Process& process) -> ErrorOr<void> {
+    return ProcessManagement::the().for_each_in_same_jail_with_current_process([&](Process& process) -> ErrorOr<void> {
         VERIFY(!(process.pid() < 0));
         u64 process_id = (u64)process.pid().value();
         InodeIdentifier identifier = { fsid(), static_cast<InodeIndex>(process_id << 36) };
@@ -126,7 +127,7 @@ ErrorOr<void> ProcFSInode::traverse_as_directory(Function<ErrorOr<void>(FileSyst
 {
     if (m_type == Type::ProcessSubdirectory) {
         VERIFY(m_associated_pid.has_value());
-        auto process = Process::from_pid_in_same_jail(m_associated_pid.value());
+        auto process = ProcessManagement::the().from_pid_in_same_jail_with_current_process(m_associated_pid.value());
         if (!process)
             return EINVAL;
         switch (m_subdirectory) {
@@ -148,7 +149,7 @@ ErrorOr<void> ProcFSInode::traverse_as_directory(Function<ErrorOr<void>(FileSyst
 
     VERIFY(m_type == Type::ProcessDirectory);
     VERIFY(m_associated_pid.has_value());
-    auto process = Process::from_pid_in_same_jail(m_associated_pid.value());
+    auto process = ProcessManagement::the().from_pid_in_same_jail_with_current_process(m_associated_pid.value());
     if (!process)
         return EINVAL;
     return process->traverse_as_directory(procfs().fsid(), move(callback));
@@ -164,7 +165,7 @@ ErrorOr<NonnullRefPtr<Inode>> ProcFSInode::lookup_as_root_directory(StringView n
         return ESRCH;
     auto actual_pid = pid.value();
 
-    if (auto maybe_process = Process::from_pid_in_same_jail(actual_pid)) {
+    if (auto maybe_process = ProcessManagement::the().from_pid_in_same_jail_with_current_process(actual_pid)) {
         InodeIndex id = (static_cast<u64>(maybe_process->pid().value()) + 1) << 36;
         return procfs().get_inode({ fsid(), id });
     }
@@ -175,7 +176,7 @@ ErrorOr<NonnullRefPtr<Inode>> ProcFSInode::lookup(StringView name)
 {
     if (m_type == Type::ProcessSubdirectory) {
         VERIFY(m_associated_pid.has_value());
-        auto process = Process::from_pid_in_same_jail(m_associated_pid.value());
+        auto process = ProcessManagement::the().from_pid_in_same_jail_with_current_process(m_associated_pid.value());
         if (!process)
             return ESRCH;
         switch (m_subdirectory) {
@@ -197,7 +198,7 @@ ErrorOr<NonnullRefPtr<Inode>> ProcFSInode::lookup(StringView name)
 
     VERIFY(m_type == Type::ProcessDirectory);
     VERIFY(m_associated_pid.has_value());
-    auto process = Process::from_pid_in_same_jail(m_associated_pid.value());
+    auto process = ProcessManagement::the().from_pid_in_same_jail_with_current_process(m_associated_pid.value());
     if (!process)
         return ESRCH;
     return process->lookup_as_directory(procfs(), name);
@@ -246,7 +247,7 @@ ErrorOr<size_t> ProcFSInode::read_bytes_locked(off_t offset, size_t count, UserO
     if (!description) {
         auto builder = TRY(KBufferBuilder::try_create());
         VERIFY(m_associated_pid.has_value());
-        auto process = Process::from_pid_in_same_jail(m_associated_pid.value());
+        auto process = ProcessManagement::the().from_pid_in_same_jail_with_current_process(m_associated_pid.value());
         if (!process)
             return Error::from_errno(ESRCH);
         TRY(try_fetch_process_property_data(*process, builder));
@@ -338,7 +339,7 @@ ErrorOr<void> ProcFSInode::refresh_process_property_data(OpenFileDescription& de
     // Without this, files opened before a process went non-dumpable could still be used for dumping.
     VERIFY(m_type == Type::ProcessProperty);
     VERIFY(m_associated_pid.has_value());
-    auto process = Process::from_pid_in_same_jail(m_associated_pid.value());
+    auto process = ProcessManagement::the().from_pid_in_same_jail_with_current_process(m_associated_pid.value());
     if (!process)
         return Error::from_errno(ESRCH);
     process->ptrace_lock().lock();
@@ -385,7 +386,7 @@ InodeMetadata ProcFSInode::metadata() const
     }
     case Type::ProcessProperty: {
         VERIFY(m_associated_pid.has_value());
-        auto process = Process::from_pid_in_same_jail(m_associated_pid.value());
+        auto process = ProcessManagement::the().from_pid_in_same_jail_with_current_process(m_associated_pid.value());
         if (!process)
             return {};
         metadata.inode = identifier();
@@ -402,7 +403,7 @@ InodeMetadata ProcFSInode::metadata() const
     }
     case Type::ProcessDirectory: {
         VERIFY(m_associated_pid.has_value());
-        auto process = Process::from_pid_in_same_jail(m_associated_pid.value());
+        auto process = ProcessManagement::the().from_pid_in_same_jail_with_current_process(m_associated_pid.value());
         if (!process)
             return {};
         metadata.inode = identifier();
@@ -419,7 +420,7 @@ InodeMetadata ProcFSInode::metadata() const
     }
     case Type::ProcessSubdirectory: {
         VERIFY(m_associated_pid.has_value());
-        auto process = Process::from_pid_in_same_jail(m_associated_pid.value());
+        auto process = ProcessManagement::the().from_pid_in_same_jail_with_current_process(m_associated_pid.value());
         if (!process)
             return {};
         metadata.inode = identifier();

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/Processes.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/Processes.cpp
@@ -10,6 +10,7 @@
 #include <Kernel/Sections.h>
 #include <Kernel/TTY/TTY.h>
 #include <Kernel/Tasks/Process.h>
+#include <Kernel/Tasks/ProcessManagement.h>
 #include <Kernel/Tasks/Scheduler.h>
 
 namespace Kernel {
@@ -151,7 +152,7 @@ ErrorOr<void> SysFSOverallProcesses::try_generate(KBufferBuilder& builder)
         auto array = TRY(json.add_array("processes"sv));
         // FIXME: Do we actually want to expose the colonel process in a Jail environment?
         TRY(build_process(array, *Scheduler::colonel()));
-        TRY(Process::for_each_in_same_jail([&](Process& process) -> ErrorOr<void> {
+        TRY(ProcessManagement::the().for_each_in_same_jail_with_current_process([&](Process& process) -> ErrorOr<void> {
             TRY(build_process(array, process));
             return {};
         }));

--- a/Kernel/Forward.h
+++ b/Kernel/Forward.h
@@ -43,6 +43,7 @@ class PerformanceEventBuffer;
 class ProcFS;
 class ProcFSInode;
 class Process;
+class ProcessManagement;
 class ProcessGroup;
 class RAMFS;
 template<LockRank Rank>

--- a/Kernel/Memory/MemoryManager.cpp
+++ b/Kernel/Memory/MemoryManager.cpp
@@ -25,6 +25,7 @@
 #include <Kernel/Prekernel/Prekernel.h>
 #include <Kernel/Sections.h>
 #include <Kernel/Tasks/Process.h>
+#include <Kernel/Tasks/ProcessManagement.h>
 
 extern u8 start_of_kernel_image[];
 extern u8 end_of_kernel_image[];
@@ -893,7 +894,7 @@ ErrorOr<CommittedPhysicalPageSet> MemoryManager::commit_physical_pages(size_t pa
         return CommittedPhysicalPageSet { {}, page_count };
     });
     if (result.is_error()) {
-        Process::for_each_ignoring_jails([&](Process const& process) {
+        ProcessManagement::the().for_each_ignoring_jails([&](Process const& process) {
             size_t amount_resident = 0;
             size_t amount_shared = 0;
             size_t amount_virtual = 0;

--- a/Kernel/Security/Jail.h
+++ b/Kernel/Security/Jail.h
@@ -18,6 +18,7 @@
 #include <Kernel/Library/KString.h>
 #include <Kernel/Locking/SpinlockProtected.h>
 #include <Kernel/Tasks/Process.h>
+#include <Kernel/Tasks/ProcessList.h>
 
 namespace Kernel {
 

--- a/Kernel/Syscalls/disown.cpp
+++ b/Kernel/Syscalls/disown.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <Kernel/Tasks/Process.h>
+#include <Kernel/Tasks/ProcessManagement.h>
 
 namespace Kernel {
 
@@ -12,7 +13,7 @@ ErrorOr<FlatPtr> Process::sys$disown(ProcessID pid)
 {
     VERIFY_NO_PROCESS_BIG_LOCK(this);
     TRY(require_promise(Pledge::proc));
-    auto process = Process::from_pid_in_same_jail(pid);
+    auto process = ProcessManagement::the().from_pid_in_same_jail_with_current_process(pid);
     if (!process)
         return ESRCH;
     TRY(process->with_mutable_protected_data([this](auto& protected_data) -> ErrorOr<void> {

--- a/Kernel/Syscalls/execve.cpp
+++ b/Kernel/Syscalls/execve.cpp
@@ -16,9 +16,11 @@
 #include <Kernel/Memory/MemoryManager.h>
 #include <Kernel/Memory/Region.h>
 #include <Kernel/Memory/SharedInodeVMObject.h>
+#include <Kernel/Security/Jail.h>
 #include <Kernel/Security/Random.h>
 #include <Kernel/Tasks/PerformanceManager.h>
 #include <Kernel/Tasks/Process.h>
+#include <Kernel/Tasks/ProcessList.h>
 #include <Kernel/Tasks/Scheduler.h>
 #include <Kernel/Time/TimeManagement.h>
 #include <LibELF/AuxiliaryVector.h>

--- a/Kernel/Syscalls/profiling.cpp
+++ b/Kernel/Syscalls/profiling.cpp
@@ -7,6 +7,7 @@
 #include <Kernel/Tasks/Coredump.h>
 #include <Kernel/Tasks/PerformanceManager.h>
 #include <Kernel/Tasks/Process.h>
+#include <Kernel/Tasks/ProcessManagement.h>
 #include <Kernel/Tasks/Scheduler.h>
 #include <Kernel/Time/TimeManagement.h>
 
@@ -50,7 +51,7 @@ ErrorOr<FlatPtr> Process::profiling_enable(pid_t pid, u64 event_mask)
             return ENOTSUP;
         g_profiling_all_threads = true;
         PerformanceManager::add_process_created_event(*Scheduler::colonel());
-        TRY(Process::for_each_in_same_jail([](auto& process) -> ErrorOr<void> {
+        TRY(ProcessManagement::the().for_each_in_same_jail_with_current_process([](auto& process) -> ErrorOr<void> {
             PerformanceManager::add_process_created_event(process);
             return {};
         }));
@@ -58,7 +59,7 @@ ErrorOr<FlatPtr> Process::profiling_enable(pid_t pid, u64 event_mask)
         return 0;
     }
 
-    auto process = Process::from_pid_in_same_jail(pid);
+    auto process = ProcessManagement::the().from_pid_in_same_jail_with_current_process(pid);
     if (!process)
         return ESRCH;
     if (process->is_dead())
@@ -98,7 +99,7 @@ ErrorOr<FlatPtr> Process::sys$profiling_disable(pid_t pid)
         return 0;
     }
 
-    auto process = Process::from_pid_in_same_jail(pid);
+    auto process = ProcessManagement::the().from_pid_in_same_jail_with_current_process(pid);
     if (!process)
         return ESRCH;
     auto credentials = this->credentials();
@@ -137,7 +138,7 @@ ErrorOr<FlatPtr> Process::sys$profiling_free_buffer(pid_t pid)
         return 0;
     }
 
-    auto process = Process::from_pid_in_same_jail(pid);
+    auto process = ProcessManagement::the().from_pid_in_same_jail_with_current_process(pid);
     if (!process)
         return ESRCH;
     auto credentials = this->credentials();

--- a/Kernel/Syscalls/sched.cpp
+++ b/Kernel/Syscalls/sched.cpp
@@ -7,6 +7,7 @@
 
 #include <Kernel/API/Syscall.h>
 #include <Kernel/Tasks/Process.h>
+#include <Kernel/Tasks/ProcessManagement.h>
 #include <Kernel/Tasks/Scheduler.h>
 
 namespace Kernel {
@@ -38,7 +39,7 @@ ErrorOr<NonnullRefPtr<Thread>> Process::get_thread_from_pid_or_tid(pid_t pid_or_
     case Syscall::SchedulerParametersMode::Process: {
         auto* searched_process = this;
         if (pid_or_tid != 0)
-            searched_process = Process::from_pid_in_same_jail(pid_or_tid);
+            searched_process = ProcessManagement::the().from_pid_in_same_jail_with_current_process(pid_or_tid);
 
         if (searched_process == nullptr)
             return ESRCH;

--- a/Kernel/Syscalls/waitid.cpp
+++ b/Kernel/Syscalls/waitid.cpp
@@ -7,6 +7,7 @@
 #include <AK/Variant.h>
 #include <Kernel/Debug.h>
 #include <Kernel/Tasks/Process.h>
+#include <Kernel/Tasks/ProcessManagement.h>
 
 namespace Kernel {
 
@@ -30,7 +31,7 @@ ErrorOr<FlatPtr> Process::sys$waitid(Userspace<Syscall::SC_waitid_params const*>
     case P_ALL:
         break;
     case P_PID: {
-        auto waitee_process = Process::from_pid_in_same_jail(params.id);
+        auto waitee_process = ProcessManagement::the().from_pid_in_same_jail_with_current_process(params.id);
         if (!waitee_process)
             return ECHILD;
         bool waitee_is_child = waitee_process->ppid() == Process::current().pid();

--- a/Kernel/Tasks/FinalizerTask.cpp
+++ b/Kernel/Tasks/FinalizerTask.cpp
@@ -7,6 +7,7 @@
 #include <Kernel/Sections.h>
 #include <Kernel/Tasks/FinalizerTask.h>
 #include <Kernel/Tasks/Process.h>
+#include <Kernel/Tasks/ProcessManagement.h>
 #include <Kernel/Tasks/Scheduler.h>
 
 namespace Kernel {
@@ -30,7 +31,8 @@ static void finalizer_task(void*)
 
 UNMAP_AFTER_INIT void FinalizerTask::spawn()
 {
-    auto [_, finalizer_thread] = MUST(Process::create_kernel_process(finalizer_task_name, finalizer_task, nullptr));
+    auto [finalizer_process, finalizer_thread] = MUST(Process::create_kernel_process(finalizer_task_name, finalizer_task, nullptr));
+    ProcessManagement::the().attach_finalizer_process({}, finalizer_process);
     g_finalizer = move(finalizer_thread);
 }
 

--- a/Kernel/Tasks/PowerStateSwitchTask.h
+++ b/Kernel/Tasks/PowerStateSwitchTask.h
@@ -31,12 +31,6 @@ private:
     static void power_state_switch_task(void* raw_entry_data);
     static ErrorOr<void> perform_reboot();
     static ErrorOr<void> perform_shutdown();
-
-    enum class ProcessKind {
-        User,
-        Kernel,
-    };
-    static ErrorOr<void> kill_processes(ProcessKind, ProcessID finalizer_pid);
 };
 
 }

--- a/Kernel/Tasks/ProcessList.cpp
+++ b/Kernel/Tasks/ProcessList.cpp
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <Kernel/Tasks/Process.h>
+#include <Kernel/Tasks/ProcessList.h>
 
 namespace Kernel {
 

--- a/Kernel/Tasks/ProcessList.h
+++ b/Kernel/Tasks/ProcessList.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2023, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <Kernel/Tasks/Process.h>
+
+namespace Kernel {
+
+class ProcessList : public RefCounted<ProcessList> {
+public:
+    static ErrorOr<NonnullRefPtr<ProcessList>> create();
+    SpinlockProtected<Process::JailProcessList, LockRank::None>& attached_processes() { return m_attached_processes; }
+    SpinlockProtected<Process::JailProcessList, LockRank::None> const& attached_processes() const { return m_attached_processes; }
+
+private:
+    ProcessList() = default;
+    SpinlockProtected<Process::JailProcessList, LockRank::None> m_attached_processes;
+};
+
+}

--- a/Kernel/Tasks/ProcessManagement.cpp
+++ b/Kernel/Tasks/ProcessManagement.cpp
@@ -1,0 +1,257 @@
+/*
+ * Copyright (c) 2023, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Atomic.h>
+#include <AK/HashTable.h>
+#include <AK/Singleton.h>
+#include <Kernel/Sections.h>
+#include <Kernel/Tasks/ProcessList.h>
+#include <Kernel/Tasks/ProcessManagement.h>
+#include <Kernel/Tasks/Scheduler.h>
+
+namespace Kernel {
+
+static Singleton<ProcessManagement> s_the;
+static Atomic<pid_t> next_pid;
+
+ProcessManagement& ProcessManagement::the()
+{
+    VERIFY(s_the.is_initialized());
+    return *s_the;
+}
+
+void ProcessManagement::initialize()
+{
+    VERIFY(!s_the.is_initialized());
+    next_pid.store(0, AK::MemoryOrder::memory_order_release);
+    s_the.ensure_instance();
+}
+
+RefPtr<Process> ProcessManagement::from_pid_in_same_jail_with_current_process(ProcessID pid)
+{
+    return Process::current().m_jail_process_list.with([&](auto const& list_ptr) -> RefPtr<Process> {
+        if (list_ptr) {
+            return list_ptr->attached_processes().with([&](auto const& list) -> RefPtr<Process> {
+                for (auto& process : list) {
+                    if (process.pid() == pid) {
+                        return process;
+                    }
+                }
+                return {};
+            });
+        }
+        return m_all_instances.with([&](auto const& list) -> RefPtr<Process> {
+            for (auto& process : list) {
+                if (process.pid() == pid) {
+                    return process;
+                }
+            }
+            return {};
+        });
+    });
+}
+
+RefPtr<Process> ProcessManagement::from_pid_ignoring_jails(ProcessID pid)
+{
+    return m_all_instances.with([&](auto const& list) -> RefPtr<Process> {
+        for (auto const& process : list) {
+            if (process.pid() == pid)
+                return &process;
+        }
+        return {};
+    });
+}
+
+ErrorOr<void> ProcessManagement::for_each_in_same_jail_with_current_process(Function<ErrorOr<void>(Process&)> callback)
+{
+    return Process::current().m_jail_process_list.with([&](auto const& list_ptr) -> ErrorOr<void> {
+        ErrorOr<void> result {};
+        if (list_ptr) {
+            list_ptr->attached_processes().with([&](auto const& list) {
+                for (auto& process : list) {
+                    result = callback(process);
+                    if (result.is_error())
+                        break;
+                }
+            });
+            return result;
+        }
+        m_all_instances.with([&](auto const& list) {
+            for (auto& process : list) {
+                result = callback(process);
+                if (result.is_error())
+                    break;
+            }
+        });
+        return result;
+    });
+}
+
+ErrorOr<void> ProcessManagement::for_each_child_in_same_jail_with_current_process(Function<ErrorOr<void>(Process&)> callback)
+{
+    ProcessID my_pid = Process::current().pid();
+    return Process::current().m_jail_process_list.with([&](auto const& list_ptr) -> ErrorOr<void> {
+        ErrorOr<void> result {};
+        if (list_ptr) {
+            list_ptr->attached_processes().with([&](auto const& list) {
+                for (auto& process : list) {
+                    if (process.ppid() == my_pid || process.has_tracee_thread(my_pid))
+                        result = callback(process);
+                    if (result.is_error())
+                        break;
+                }
+            });
+            return result;
+        }
+        m_all_instances.with([&](auto const& list) {
+            for (auto& process : list) {
+                if (process.ppid() == my_pid || process.has_tracee_thread(my_pid))
+                    result = callback(process);
+                if (result.is_error())
+                    break;
+            }
+        });
+        return result;
+    });
+}
+
+void ProcessManagement::kill_finalizer_process(Badge<PowerStateSwitchTask>)
+{
+    m_finalizer_process->die();
+    m_finalizer_process->finalize();
+    m_finalizer_process.clear();
+}
+
+size_t ProcessManagement::alive_processes_count() const
+{
+    size_t alive_process_count = 0;
+    m_all_instances.for_each([&](Process& process) {
+        if (process.pid() != Process::current().pid() && !process.is_dead())
+            alive_process_count++;
+    });
+    return alive_process_count;
+}
+
+void ProcessManagement::attach_finalizer_process(Badge<FinalizerTask>, Process& process)
+{
+    m_finalizer_process = process;
+}
+
+ErrorOr<void> ProcessManagement::kill_processes(ProcessKind kind)
+{
+    bool kill_kernel_processes = kind == ProcessKind::Kernel;
+    auto finalizer_pid = m_finalizer_process->pid();
+
+    m_all_instances.for_each([&](Process& process) {
+        if (process.pid() != Process::current().pid() && process.pid() != finalizer_pid && process.is_kernel_process() == kill_kernel_processes) {
+            process.die();
+        }
+    });
+
+    // Although we *could* finalize processes ourselves (g_in_system_shutdown allows this),
+    // we're nice citizens and let the finalizer task perform final duties before we kill it.
+    Scheduler::notify_finalizer();
+    int alive_process_count = 1;
+    MonotonicTime last_status_time = TimeManagement::the().monotonic_time();
+    while (alive_process_count > 0) {
+        Scheduler::yield();
+        alive_process_count = 0;
+        m_all_instances.for_each([&](Process& process) {
+            if (process.pid() != Process::current().pid() && !process.is_dead() && process.pid() != finalizer_pid && process.is_kernel_process() == kill_kernel_processes)
+                alive_process_count++;
+        });
+
+        if (TimeManagement::the().monotonic_time() - last_status_time > Duration::from_seconds(2)) {
+            last_status_time = TimeManagement::the().monotonic_time();
+            dmesgln("Waiting on {} processes to exit...", alive_process_count);
+
+            if constexpr (PROCESS_DEBUG) {
+                m_all_instances.for_each_const([&](Process const& process) {
+                    if (process.pid() != Process::current().pid() && !process.is_dead() && process.pid() != finalizer_pid && process.is_kernel_process() == kill_kernel_processes) {
+                        dbgln("Process {:2} kernel={} dead={} dying={} ({})",
+                            process.pid(), process.is_kernel_process(), process.is_dead(), process.is_dying(),
+                            process.name().with([](auto& name) { return name.representable_view(); }));
+                    }
+                });
+            }
+        }
+    }
+
+    return {};
+}
+
+void ProcessManagement::after_creating_process(Process& process)
+{
+    NonnullRefPtr<Process> const new_process = process;
+    m_all_instances.with([&](auto& list) {
+        list.prepend(process);
+    });
+}
+
+void ProcessManagement::after_set_wait_result(Process& process)
+{
+    NonnullRefPtr<Process> const old_process = process;
+    old_process->m_jail_process_list.with([&](auto& list_ptr) {
+        if (list_ptr) {
+            list_ptr->attached_processes().with([&](auto& list) {
+                list.remove(process);
+            });
+        }
+        list_ptr.clear();
+    });
+    m_all_instances.with([&](auto& list) {
+        list.remove(process);
+    });
+}
+
+ErrorOr<void> ProcessManagement::for_each_in_pgrp_in_same_jail_with_current_process(ProcessGroupID pgid, Function<ErrorOr<void>(Process&)> callback)
+{
+    return Process::current().m_jail_process_list.with([&](auto const& list_ptr) -> ErrorOr<void> {
+        ErrorOr<void> result {};
+        if (list_ptr) {
+            list_ptr->attached_processes().with([&](auto const& list) {
+                for (auto& process : list) {
+                    if (!process.is_dead() && process.pgid() == pgid)
+                        result = callback(process);
+                    if (result.is_error())
+                        break;
+                }
+            });
+            return result;
+        }
+        m_all_instances.with([&](auto const& list) {
+            for (auto& process : list) {
+                if (!process.is_dead() && process.pgid() == pgid)
+                    result = callback(process);
+                if (result.is_error())
+                    break;
+            }
+        });
+        return result;
+    });
+}
+
+ProcessID ProcessManagement::allocate_pid()
+{
+    // Overflow is UB, and negative PIDs wreck havoc.
+    // TODO: Handle PID overflow
+    // For example: Use an Atomic<u32>, mask the most significant bit,
+    // retry if PID is already taken as a PID, taken as a TID,
+    // takes as a PGID, taken as a SID, or zero.
+    return next_pid.fetch_add(1, AK::MemoryOrder::memory_order_acq_rel);
+}
+
+ProcessID ProcessManagement::allocate_pid_for_new_thread(Badge<Thread>)
+{
+    return allocate_pid();
+}
+
+ProcessID ProcessManagement::allocate_pid_for_new_process(Badge<Process>)
+{
+    return allocate_pid();
+}
+
+}

--- a/Kernel/Tasks/ProcessManagement.h
+++ b/Kernel/Tasks/ProcessManagement.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2023, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Badge.h>
+#include <AK/Error.h>
+#include <AK/OwnPtr.h>
+#include <AK/Types.h>
+#include <Kernel/Locking/SpinlockProtected.h>
+#include <Kernel/Tasks/FinalizerTask.h>
+#include <Kernel/Tasks/PowerStateSwitchTask.h>
+#include <Kernel/Tasks/Process.h>
+#include <Kernel/Tasks/Thread.h>
+
+namespace Kernel {
+
+class ProcessManagement {
+
+public:
+    ProcessManagement() {};
+    static void initialize();
+    static ProcessManagement& the();
+
+    void after_creating_process(Process&);
+    void after_set_wait_result(Process&);
+
+    SpinlockProtected<Process::AllProcessesList, LockRank::None>& all_instances(Badge<Process>) { return m_all_instances; }
+
+    template<IteratorFunction<Process&> Callback>
+    void for_each_ignoring_jails(Callback callback)
+    {
+        m_all_instances.with([&](auto const& list) {
+            for (auto it = list.begin(); it != list.end();) {
+                auto& process = *it;
+                ++it;
+                if (callback(process) == IterationDecision::Break)
+                    break;
+            }
+        });
+    }
+
+    enum class ProcessKind {
+        User,
+        Kernel,
+    };
+    ErrorOr<void> kill_processes(ProcessKind kind);
+
+    size_t alive_processes_count() const;
+
+    RefPtr<Process> from_pid_ignoring_jails(ProcessID pid);
+    RefPtr<Process> from_pid_in_same_jail_with_current_process(ProcessID pid);
+    ErrorOr<void> for_each_child_in_same_jail_with_current_process(Function<ErrorOr<void>(Process&)> callback);
+    ErrorOr<void> for_each_in_pgrp_in_same_jail_with_current_process(ProcessGroupID pgid, Function<ErrorOr<void>(Process&)> callback);
+    ErrorOr<void> for_each_in_same_jail_with_current_process(Function<ErrorOr<void>(Process&)>);
+
+    ProcessID allocate_pid_for_new_process(Badge<Process>);
+    ProcessID allocate_pid_for_new_thread(Badge<Thread>);
+
+    void attach_finalizer_process(Badge<FinalizerTask>, Process&);
+    void kill_finalizer_process(Badge<PowerStateSwitchTask>);
+
+private:
+    ProcessID allocate_pid();
+    mutable SpinlockProtected<Process::AllProcessesList, LockRank::None> m_all_instances;
+
+    RefPtr<Process> m_finalizer_process;
+};
+
+}

--- a/Kernel/Tasks/Thread.h
+++ b/Kernel/Tasks/Thread.h
@@ -659,7 +659,7 @@ public:
 
     private:
         void do_was_disowned();
-        void do_set_result(siginfo_t const&);
+        void do_set_result(Process&, siginfo_t const&);
 
         int const m_wait_options;
         ErrorOr<siginfo_t>& m_result;


### PR DESCRIPTION
This new singleton takes over a few responsibilities from the Process class.

This change introduces the following features:
1. There's no need to leak a ref on a new user Process object. The new singleton has "all instances" list that holds a reference to all Process objects thus making it possible to not use the ListedRefCounted template anymore. The last reference to a Process object is released immediately upon the WaitBlocker::do_set_result method, which matches the expected behavior in such cases.
2. It simplifies the PowerStateSwitchTask code to great extent, because the new singleton makes it clear on the tear-down sequence during shutdown, without letting the PowerStateSwitchTask code to get into the small details.
3. It improves the Process-Jail relationship semantics, by creating a much more straighforward API semantics (for example by adding the phrase of "_with_current_process" to some functions).