### PR TITLE
LibELF: Cache consecutive lookups for the same symbol

### DIFF
--- a/Userland/Libraries/LibELF/DynamicLoader.h
+++ b/Userland/Libraries/LibELF/DynamicLoader.h
@@ -143,7 +143,11 @@ private:
         ResolveLater = 2,
         CallIfuncResolver = 3,
     };
-    RelocationResult do_direct_relocation(DynamicObject::Relocation const&, ShouldInitializeWeak, ShouldCallIfuncResolver);
+    struct CachedLookupResult {
+        DynamicObject::Symbol symbol;
+        Optional<DynamicObject::SymbolLookupResult> result;
+    };
+    RelocationResult do_direct_relocation(DynamicObject::Relocation const&, Optional<CachedLookupResult>&, ShouldInitializeWeak, ShouldCallIfuncResolver);
     // Will be called from _fixup_plt_entry, as part of the PLT trampoline
     static RelocationResult do_plt_relocation(DynamicObject::Relocation const&, ShouldCallIfuncResolver);
     void do_relr_relocations();

--- a/Userland/Libraries/LibELF/DynamicObject.h
+++ b/Userland/Libraries/LibELF/DynamicObject.h
@@ -84,6 +84,12 @@ public:
         }
         DynamicObject const& object() const { return m_dynamic; }
 
+        // This might return false even if the two Symbol objects resolve to the same thing.
+        bool definitely_equals(Symbol const& other) const
+        {
+            return &m_dynamic == &other.m_dynamic && &m_sym == &other.m_sym && m_index == other.m_index;
+        }
+
     private:
         DynamicObject const& m_dynamic;
         const ElfW(Sym) & m_sym;


### PR DESCRIPTION
This reduces the startup time of LibWeb by 10%, and eliminates 156'000 of the total 481'000 global symbol lookups during a self-test run.

