### PR TITLE
Ports/backward-cpp: Link against zstd if present

### DIFF
--- a/Ports/backward-cpp/patches/0002-backward-Pretend-to-be-Linux-with-some-modifications.patch
+++ b/Ports/backward-cpp/patches/0002-backward-Pretend-to-be-Linux-with-some-modifications.patch
@@ -8,7 +8,7 @@ Subject: [PATCH] backward: Pretend to be Linux, with some modifications
  1 file changed, 10 insertions(+), 3 deletions(-)
 
 diff --git a/backward.hpp b/backward.hpp
-index 670aa45853997c515974bb9411d7a9e72aeeee78..25e70cc6d0d1e508ac42e63ea3fa8b56992cfb27 100644
+index 670aa45853997c515974bb9411d7a9e72aeeee78..ff51271a9490d3f16520ca459849d384b3f2061a 100644
 --- a/backward.hpp
 +++ b/backward.hpp
 @@ -63,7 +63,7 @@

--- a/Ports/backward-cpp/patches/0003-Link-to-zstd-library.patch
+++ b/Ports/backward-cpp/patches/0003-Link-to-zstd-library.patch
@@ -1,0 +1,23 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tim Ledbetter <timledbetter@gmail.com>
+Date: Fri, 18 Aug 2023 06:36:54 +0100
+Subject: [PATCH] Link to zstd library
+
+---
+ BackwardConfig.cmake | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/BackwardConfig.cmake b/BackwardConfig.cmake
+index cda0568bf9eaf76e7a3e263c1bd1aa950d1308a3..cd93ee07af2daf32fa2f1b6f550fcc8844c7215e 100644
+--- a/BackwardConfig.cmake
++++ b/BackwardConfig.cmake
+@@ -156,6 +156,9 @@ if (${STACK_DETAILS_AUTO_DETECT})
+ 			if (LIBSFRAME_LIBRARY)
+ 				list(APPEND _BACKWARD_LIBRARIES ${LIBSFRAME_LIBRARY})
+ 			endif()
++			if (LIBZSTD_LIBRARY)
++				list(APPEND _BACKWARD_LIBRARIES ${LIBZSTD_LIBRARY})
++			endif()
+ 
+ 			list(APPEND _BACKWARD_LIBRARIES iberty z)
+ 		endif()

--- a/Ports/backward-cpp/patches/ReadMe.md
+++ b/Ports/backward-cpp/patches/ReadMe.md
@@ -10,3 +10,8 @@ test: Don't use program_invocation_name on Serenity
 backward: Pretend to be Linux, with some modifications
 
 
+## `0003-Link-to-zstd-library.patch`
+
+Link to zstd library
+
+

--- a/Ports/binutils/package.sh
+++ b/Ports/binutils/package.sh
@@ -15,7 +15,10 @@ configopts=(
 files=(
     "https://ftpmirror.gnu.org/gnu/binutils/binutils-${version}.tar.xz 0f8a4c272d7f17f369ded10a4aca28b8e304828e95526da482b0ccc4dfc9d8e1"
 )
-depends=("zlib")
+depends=(
+    'zlib'
+    'zstd'
+)
 
 export ac_cv_func_getrusage=no
 


### PR DESCRIPTION
This PR makes 2 separate, but related changes:

The first change ensures `backward-cpp` links against `zstd` if it is installed. This fixes an issue where `backward-cpp` previously wouldn't build when `zstd` was installed. This change could probably be upstreamed. The only reason that I'm hesitant to do so is that this only affects `backward-cpp` when using a static `libbfd` from `binutils` >= 2.4.0. I'm not sure how common this kind of setup is outside of what we're doing.

The second change includes `zstd` as a dependency of `binutils`. This ensures that `binutils` is built with `zstd` support, which it has had since version 2.4.0.

Making both of these changes at the same time means that `zstd` will always be linked against when we build `backward-cpp`.