### PR TITLE
LibAudio: Add metadata writing infrastructure + use it to write metadata to FLAC files

### DIFF
--- a/Userland/Libraries/LibAudio/Encoder.h
+++ b/Userland/Libraries/LibAudio/Encoder.h
@@ -24,6 +24,10 @@ public:
     // This method makes sure that all samples are encoded and written out.
     // This method is called in the destructor, but since this can error, you should call this function yourself before disposing of the decoder.
     virtual ErrorOr<void> finalize() = 0;
+
+    // Provides a hint about the total number of samples to the encoder, improving some encoder's performance in various aspects.
+    // Note that the hint does not have to be fully correct; wrong hints never cause errors, not even indirectly.
+    virtual void sample_count_hint([[maybe_unused]] size_t sample_count) { }
 };
 
 }

--- a/Userland/Libraries/LibAudio/Encoder.h
+++ b/Userland/Libraries/LibAudio/Encoder.h
@@ -8,6 +8,7 @@
 
 #include <AK/Error.h>
 #include <AK/Span.h>
+#include <LibAudio/Forward.h>
 #include <LibAudio/Sample.h>
 
 namespace Audio {
@@ -24,6 +25,10 @@ public:
     // This method makes sure that all samples are encoded and written out.
     // This method is called in the destructor, but since this can error, you should call this function yourself before disposing of the decoder.
     virtual ErrorOr<void> finalize() = 0;
+
+    // Sets the metadata for this audio file.
+    // Not all encoders support this, and metadata may not be writeable after starting to write samples.
+    virtual ErrorOr<void> set_metadata([[maybe_unused]] Metadata const& metadata) { return {}; }
 
     // Provides a hint about the total number of samples to the encoder, improving some encoder's performance in various aspects.
     // Note that the hint does not have to be fully correct; wrong hints never cause errors, not even indirectly.

--- a/Userland/Libraries/LibAudio/FlacWriter.h
+++ b/Userland/Libraries/LibAudio/FlacWriter.h
@@ -13,6 +13,8 @@
 #include <AK/StringView.h>
 #include <LibAudio/Encoder.h>
 #include <LibAudio/FlacTypes.h>
+#include <LibAudio/Forward.h>
+#include <LibAudio/GenericTypes.h>
 #include <LibAudio/Sample.h>
 #include <LibAudio/SampleFormats.h>
 #include <LibCore/Forward.h>
@@ -80,6 +82,9 @@ public:
     ErrorOr<void> set_num_channels(u8 num_channels);
     ErrorOr<void> set_sample_rate(u32 sample_rate);
     ErrorOr<void> set_bits_per_sample(u16 bits_per_sample);
+
+    virtual ErrorOr<void> set_metadata(Metadata const& metadata) override;
+
     ErrorOr<void> finalize_header_format();
 
 private:
@@ -98,6 +103,9 @@ private:
     // In this case, an empty Optional is returned.
     ErrorOr<Optional<FlacLPCEncodedSubframe>> encode_fixed_lpc(FlacFixedLPC order, ReadonlySpan<i64> subframe, size_t current_min_cost, u8 bits_per_sample);
 
+    ErrorOr<void> add_metadata_block(FlacRawMetadataBlock block, Optional<size_t> insertion_index = {});
+    ErrorOr<void> write_metadata_block(FlacRawMetadataBlock const& block);
+
     NonnullOwnPtr<SeekableStream> m_stream;
     WriteState m_state { WriteState::HeaderUnwritten };
 
@@ -114,6 +122,9 @@ private:
     size_t m_sample_count { 0 };
     // Remember where the STREAMINFO block was written in the stream.
     size_t m_streaminfo_start_index;
+
+    // Raw metadata blocks that will be written out before header finalization.
+    Vector<FlacRawMetadataBlock> m_cached_metadata_blocks;
 };
 
 }

--- a/Userland/Libraries/LibAudio/Forward.h
+++ b/Userland/Libraries/LibAudio/Forward.h
@@ -10,6 +10,9 @@ namespace Audio {
 
 class ConnectionToServer;
 class Loader;
+class Encoder;
+struct Person;
+struct Metadata;
 class PlaybackStream;
 struct Sample;
 

--- a/Userland/Libraries/LibAudio/VorbisComment.h
+++ b/Userland/Libraries/LibAudio/VorbisComment.h
@@ -14,5 +14,6 @@ namespace Audio {
 
 // https://www.xiph.org/vorbis/doc/v-comment.html
 ErrorOr<Metadata, LoaderError> load_vorbis_comment(ByteBuffer const& vorbis_comment);
+ErrorOr<void> write_vorbis_comment(Metadata const& metadata, Stream& target);
 
 }

--- a/Userland/Libraries/LibAudio/WavLoader.cpp
+++ b/Userland/Libraries/LibAudio/WavLoader.cpp
@@ -324,6 +324,8 @@ MaybeLoaderError WavLoaderPlugin::load_wav_info_block(Vector<RIFF::Chunk> info_c
             m_metadata.genre = TRY(String::from_utf8(metadata_text));
         } else if (metadata_name == "INAM"sv) {
             m_metadata.title = TRY(String::from_utf8(metadata_text));
+        } else if (metadata_name == "IPRD"sv) {
+            m_metadata.album = TRY(String::from_utf8(metadata_text));
         } else if (metadata_name == "ISFT"sv) {
             m_metadata.encoder = TRY(String::from_utf8(metadata_text));
         } else if (metadata_name == "ISRC"sv) {

--- a/Userland/Utilities/aconv.cpp
+++ b/Userland/Utilities/aconv.cpp
@@ -141,6 +141,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             return 1;
         }
 
+        if (writer.has_value())
+            (*writer)->sample_count_hint(input_loader->total_samples());
+
         if (output != "-"sv)
             out("Writing: \033[s");
 

--- a/Userland/Utilities/aconv.cpp
+++ b/Userland/Utilities/aconv.cpp
@@ -134,15 +134,20 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                 static_cast<int>(input_loader->sample_rate()),
                 input_loader->num_channels(),
                 Audio::pcm_bits_per_sample(parsed_output_sample_format)));
-            TRY(flac_writer->finalize_header_format());
             writer.emplace(move(flac_writer));
         } else {
             warnln("Codec {} is not supported for encoding", output_format);
             return 1;
         }
 
-        if (writer.has_value())
+        if (writer.has_value()) {
             (*writer)->sample_count_hint(input_loader->total_samples());
+            TRY((*writer)->set_metadata(input_loader->metadata()));
+        }
+
+        // FIXME: Maybe use a generalized interface for this as well if the need arises.
+        if (output_format == "flac"sv)
+            TRY(static_cast<Audio::FlacWriter*>(writer->ptr())->finalize_header_format());
 
         if (output != "-"sv)
             out("Writing: \033[s");

--- a/Userland/Utilities/aconv.cpp
+++ b/Userland/Utilities/aconv.cpp
@@ -142,7 +142,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
         if (writer.has_value()) {
             (*writer)->sample_count_hint(input_loader->total_samples());
-            TRY((*writer)->set_metadata(input_loader->metadata()));
+
+            auto metadata = input_loader->metadata();
+            metadata.replace_encoder_with_serenity();
+            TRY((*writer)->set_metadata(metadata));
         }
 
         // FIXME: Maybe use a generalized interface for this as well if the need arises.


### PR DESCRIPTION
This allows us to write arbitrary metadata in Vorbis comments to FLAC files. Right now, we copy input metadata and overwrite the encoder with the Serenity encoder signature.

### LibAudio: Add more common classes to the forward declare header


### LibAudio: Add a sample count hinting mechanism to audio encoding


### LibAudio: Allow adding metadata to encoders


### aconv: Copy metadata to output

This requires postponing FLAC header finalization, since FLAC cannot
write metadata after a finalized header.

### LibAudio: Understand album (IPRD) metadata in WAV

This is in common usage, just not present in the reference I looked at.

### aconv: Override encoder in output metadata

After all, we encoded this file :^)

### LibAudio: Allow writing Vorbis comments

The vorbis comment parsing code is slightly generalized to reuse
field-role associations for artists.

### LibAudio: Write FLAC metadata

This includes a generalization of the metadata block infrastructure, so
adding and writing blocks is handled in a generalized fashion.