### PR TITLE
LibCompress: Port `ZlibDecompressor` to `AK::Stream` (and other small changes)

### DIFF
--- a/Meta/Lagom/Fuzzers/FuzzBrotli.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzBrotli.cpp
@@ -12,7 +12,7 @@ extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
     FixedMemoryStream bufstream { { data, size } };
 
-    auto brotli_stream = Compress::BrotliDecompressionStream { bufstream };
+    auto brotli_stream = Compress::BrotliDecompressionStream { MaybeOwned<Stream> { bufstream } };
 
     (void)brotli_stream.read_until_eof();
     return 0;

--- a/Tests/LibCompress/TestBrotli.cpp
+++ b/Tests/LibCompress/TestBrotli.cpp
@@ -24,7 +24,7 @@ static void run_test(StringView const file_name)
     DeprecatedString path_compressed = DeprecatedString::formatted("{}.br", path);
 
     auto file = MUST(Core::File::open(path_compressed, Core::File::OpenMode::Read));
-    auto brotli_stream = Compress::BrotliDecompressionStream { *file };
+    auto brotli_stream = Compress::BrotliDecompressionStream { MaybeOwned<Stream> { *file } };
     auto data = MUST(brotli_stream.read_until_eof());
 
     EXPECT_EQ(data, cmp_data);
@@ -97,7 +97,7 @@ TEST_CASE(brotli_decompress_zero_one_bin)
     DeprecatedString path_compressed = DeprecatedString::formatted("{}.br", path);
 
     auto file = MUST(Core::File::open(path_compressed, Core::File::OpenMode::Read));
-    auto brotli_stream = Compress::BrotliDecompressionStream { *file };
+    auto brotli_stream = Compress::BrotliDecompressionStream { MaybeOwned<Stream> { *file } };
 
     u8 buffer_raw[4096];
     Bytes buffer { buffer_raw, 4096 };

--- a/Userland/Libraries/LibCompress/Brotli.cpp
+++ b/Userland/Libraries/LibCompress/Brotli.cpp
@@ -28,8 +28,8 @@ ErrorOr<size_t> Brotli::CanonicalCode::read_symbol(LittleEndianInputBitStream& i
     return Error::from_string_literal("no matching code found");
 }
 
-BrotliDecompressionStream::BrotliDecompressionStream(Stream& stream)
-    : m_input_stream(MaybeOwned(stream))
+BrotliDecompressionStream::BrotliDecompressionStream(MaybeOwned<Stream> stream)
+    : m_input_stream(move(stream))
 {
 }
 

--- a/Userland/Libraries/LibCompress/Brotli.h
+++ b/Userland/Libraries/LibCompress/Brotli.h
@@ -111,7 +111,7 @@ public:
     };
 
 public:
-    BrotliDecompressionStream(Stream&);
+    BrotliDecompressionStream(MaybeOwned<Stream>);
 
     ErrorOr<Bytes> read_some(Bytes output_buffer) override;
     ErrorOr<size_t> write_some(ReadonlyBytes bytes) override { return m_input_stream.write_some(bytes); }

--- a/Userland/Libraries/LibCompress/Gzip.cpp
+++ b/Userland/Libraries/LibCompress/Gzip.cpp
@@ -54,7 +54,7 @@ GzipDecompressor::Member::Member(BlockHeader header, NonnullOwnPtr<DeflateDecomp
 {
 }
 
-GzipDecompressor::GzipDecompressor(NonnullOwnPtr<Stream> stream)
+GzipDecompressor::GzipDecompressor(MaybeOwned<Stream> stream)
     : m_input_stream(make<LittleEndianInputBitStream>(move(stream)))
 {
 }

--- a/Userland/Libraries/LibCompress/Gzip.h
+++ b/Userland/Libraries/LibCompress/Gzip.h
@@ -42,7 +42,7 @@ struct Flags {
 
 class GzipDecompressor final : public Stream {
 public:
-    GzipDecompressor(NonnullOwnPtr<Stream>);
+    GzipDecompressor(MaybeOwned<Stream>);
     ~GzipDecompressor();
 
     virtual ErrorOr<Bytes> read_some(Bytes) override;

--- a/Userland/Libraries/LibCompress/Zlib.h
+++ b/Userland/Libraries/LibCompress/Zlib.h
@@ -44,22 +44,21 @@ struct ZlibHeader {
 };
 static_assert(sizeof(ZlibHeader) == sizeof(u16));
 
-class ZlibDecompressor {
+class ZlibDecompressor : public Stream {
 public:
-    Optional<ByteBuffer> decompress();
-    u32 checksum();
+    static ErrorOr<NonnullOwnPtr<ZlibDecompressor>> create(MaybeOwned<Stream>);
 
-    static Optional<ZlibDecompressor> try_create(ReadonlyBytes data);
-    static Optional<ByteBuffer> decompress_all(ReadonlyBytes);
+    virtual ErrorOr<Bytes> read_some(Bytes) override;
+    virtual ErrorOr<size_t> write_some(ReadonlyBytes) override;
+    virtual bool is_eof() const override;
+    virtual bool is_open() const override;
+    virtual void close() override;
 
 private:
-    ZlibDecompressor(ZlibHeader, ReadonlyBytes data);
+    ZlibDecompressor(ZlibHeader, NonnullOwnPtr<Stream>);
 
     ZlibHeader m_header;
-
-    u32 m_checksum { 0 };
-    ReadonlyBytes m_input_data;
-    ReadonlyBytes m_data_bytes;
+    NonnullOwnPtr<Stream> m_stream;
 };
 
 class ZlibCompressor : public Stream {
@@ -87,3 +86,8 @@ private:
 };
 
 }
+
+template<>
+struct AK::Traits<Compress::ZlibHeader> : public AK::GenericTraits<Compress::ZlibHeader> {
+    static constexpr bool is_trivially_serializable() { return true; }
+};

--- a/Userland/Libraries/LibGfx/Font/WOFF/Font.cpp
+++ b/Userland/Libraries/LibGfx/Font/WOFF/Font.cpp
@@ -6,6 +6,7 @@
 
 #include <AK/ByteBuffer.h>
 #include <AK/IntegralMath.h>
+#include <AK/MemoryStream.h>
 #include <LibCompress/Zlib.h>
 #include <LibGfx/Font/OpenType/Font.h>
 #include <LibGfx/Font/WOFF/Font.h>
@@ -120,12 +121,12 @@ ErrorOr<NonnullRefPtr<Font>> Font::try_load_from_externally_owned_memory(Readonl
         if (font_buffer_offset + orig_length > font_buffer.size())
             return Error::from_string_literal("Uncompressed WOFF table too big");
         if (comp_length < orig_length) {
-            auto decompressed = Compress::ZlibDecompressor::decompress_all(buffer.slice(offset, comp_length));
-            if (!decompressed.has_value())
-                return Error::from_string_literal("Could not decompress WOFF table");
-            if (orig_length != decompressed->size())
+            auto compressed_data_stream = make<FixedMemoryStream>(buffer.slice(offset, comp_length));
+            auto decompressor = TRY(Compress::ZlibDecompressor::create(move(compressed_data_stream)));
+            auto decompressed = TRY(decompressor->read_until_eof());
+            if (orig_length != decompressed.size())
                 return Error::from_string_literal("Invalid decompressed WOFF table length");
-            font_buffer.overwrite(font_buffer_offset, decompressed->data(), orig_length);
+            font_buffer.overwrite(font_buffer_offset, decompressed.data(), orig_length);
         } else {
             if (comp_length != orig_length)
                 return Error::from_string_literal("Invalid uncompressed WOFF table length");

--- a/Userland/Libraries/LibGfx/Font/WOFF2/Font.cpp
+++ b/Userland/Libraries/LibGfx/Font/WOFF2/Font.cpp
@@ -1000,7 +1000,7 @@ ErrorOr<NonnullRefPtr<Font>> Font::try_load_from_externally_owned_memory(Seekabl
         return Error::from_string_literal("Not enough data to read in the reported size of the compressed data");
 
     auto compressed_stream = FixedMemoryStream(compressed_bytes);
-    auto brotli_stream = Compress::BrotliDecompressionStream { compressed_stream };
+    auto brotli_stream = Compress::BrotliDecompressionStream { MaybeOwned<Stream>(compressed_stream) };
     auto decompressed_table_data = TRY(brotli_stream.read_until_eof());
     if (decompressed_table_data.size() != total_length_of_all_tables)
         return Error::from_string_literal("Size of the decompressed data is not equal to the total of the reported lengths of each table");

--- a/Userland/Libraries/LibHTTP/Job.cpp
+++ b/Userland/Libraries/LibHTTP/Job.cpp
@@ -75,7 +75,7 @@ static ErrorOr<ByteBuffer> handle_content_encoding(ByteBuffer const& buf, Deprec
         dbgln_if(JOB_DEBUG, "Job::handle_content_encoding: buf is brotli compressed!");
 
         FixedMemoryStream bufstream { buf };
-        auto brotli_stream = Compress::BrotliDecompressionStream { bufstream };
+        auto brotli_stream = Compress::BrotliDecompressionStream { MaybeOwned<Stream>(bufstream) };
 
         auto uncompressed = TRY(brotli_stream.read_until_eof());
         if constexpr (JOB_DEBUG) {

--- a/Userland/Libraries/LibHTTP/Job.cpp
+++ b/Userland/Libraries/LibHTTP/Job.cpp
@@ -51,13 +51,17 @@ static ErrorOr<ByteBuffer> handle_content_encoding(ByteBuffer const& buf, Deprec
 
         // Even though the content encoding is "deflate", it's actually deflate with the zlib wrapper.
         // https://tools.ietf.org/html/rfc7230#section-4.2.2
-        auto uncompressed = Compress::ZlibDecompressor::decompress_all(buf);
-        if (!uncompressed.has_value()) {
+        auto memory_stream = make<FixedMemoryStream>(buf);
+        auto zlib_decompressor = Compress::ZlibDecompressor::create(move(memory_stream));
+        Optional<ByteBuffer> uncompressed;
+        if (zlib_decompressor.is_error()) {
             // From the RFC:
             // "Note: Some non-conformant implementations send the "deflate"
             //        compressed data without the zlib wrapper."
             dbgln_if(JOB_DEBUG, "Job::handle_content_encoding: ZlibDecompressor::decompress_all() failed. Trying DeflateDecompressor::decompress_all()");
             uncompressed = TRY(Compress::DeflateDecompressor::decompress_all(buf));
+        } else {
+            uncompressed = TRY(zlib_decompressor.value()->read_until_eof());
         }
 
         if constexpr (JOB_DEBUG) {


### PR DESCRIPTION
These I had made when starting to try and untangle LibHTTP's decompressor setup, but that ultimately got nowhere. Still, these three commits are useful on their own.