### PR TITLE
LibWebView+Ladybird: Remove duplicate WebContent callback

### DIFF
--- a/Ladybird/Qt/Tab.cpp
+++ b/Ladybird/Qt/Tab.cpp
@@ -113,14 +113,6 @@ Tab::Tab(BrowserWindow* window, StringView webdriver_content_ipc_path, WebView::
         m_hover_label->hide();
     };
 
-    view().on_back_button = [this] {
-        back();
-    };
-
-    view().on_forward_button = [this] {
-        forward();
-    };
-
     view().on_load_start = [this](const URL& url, bool is_redirect) {
         // If we are loading due to a redirect, we replace the current history entry
         // with the loaded URL

--- a/Ladybird/Qt/WebContentView.cpp
+++ b/Ladybird/Qt/WebContentView.cpp
@@ -324,11 +324,11 @@ void WebContentView::mouseReleaseEvent(QMouseEvent* event)
     auto button = get_button_from_qt_event(*event);
 
     if (event->button() & Qt::MouseButton::BackButton) {
-        if (on_back_button)
-            on_back_button();
+        if (on_navigate_back)
+            on_navigate_back();
     } else if (event->button() & Qt::MouseButton::ForwardButton) {
-        if (on_forward_button)
-            on_forward_button();
+        if (on_navigate_forward)
+            on_navigate_forward();
     }
 
     if (button == 0) {

--- a/Userland/Applications/Browser/Tab.cpp
+++ b/Userland/Applications/Browser/Tab.cpp
@@ -554,16 +554,6 @@ Tab::Tab(BrowserWindow& window)
         update_status();
     };
 
-    view().on_back_button = [this] {
-        if (m_history.can_go_back())
-            go_back();
-    };
-
-    view().on_forward_button = [this] {
-        if (m_history.can_go_forward())
-            go_forward();
-    };
-
     view().on_new_tab = [this](auto activate_tab) {
         auto& tab = this->window().create_new_tab(URL("about:blank"), activate_tab);
         return tab.view().handle();
@@ -689,6 +679,9 @@ void Tab::reload()
 
 void Tab::go_back(int steps)
 {
+    if (!m_history.can_go_back(steps))
+        return;
+
     m_history.go_back(steps);
     update_actions();
     load(m_history.current().url, LoadType::HistoryNavigation);
@@ -696,6 +689,9 @@ void Tab::go_back(int steps)
 
 void Tab::go_forward(int steps)
 {
+    if (!m_history.can_go_forward(steps))
+        return;
+
     m_history.go_forward(steps);
     update_actions();
     load(m_history.current().url, LoadType::HistoryNavigation);

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
@@ -134,11 +134,11 @@ void OutOfProcessWebView::mouseup_event(GUI::MouseEvent& event)
     enqueue_input_event(event);
 
     if (event.button() == GUI::MouseButton::Backward) {
-        if (on_back_button)
-            on_back_button();
+        if (on_navigate_back)
+            on_navigate_back();
     } else if (event.button() == GUI::MouseButton::Forward) {
-        if (on_forward_button)
-            on_forward_button();
+        if (on_navigate_forward)
+            on_navigate_forward();
     }
 }
 

--- a/Userland/Libraries/LibWebView/ViewImplementation.h
+++ b/Userland/Libraries/LibWebView/ViewImplementation.h
@@ -122,8 +122,6 @@ public:
     Function<Gfx::IntRect()> on_maximize_window;
     Function<Gfx::IntRect()> on_minimize_window;
     Function<Gfx::IntRect()> on_fullscreen_window;
-    Function<void()> on_back_button;
-    Function<void()> on_forward_button;
 
     virtual void notify_server_did_layout(Badge<WebContentClient>, Gfx::IntSize content_size) = 0;
     virtual void notify_server_did_paint(Badge<WebContentClient>, i32 bitmap_id, Gfx::IntSize) = 0;


### PR DESCRIPTION
We have `on_navigate_back` + `on_back_button` and `on_navigate_forward` + `on_forward_button`. Remove the `*_button variants`.