### PR TITLE
Ports: Simplify the output from `identify` when installing icons

### DIFF
--- a/Ports/.port_include.sh
+++ b/Ports/.port_include.sh
@@ -224,7 +224,7 @@ install_icon() {
     fi
 
     for icon_size in "16x16" "32x32"; do
-        index=$(run identify "$icon" | grep "$icon_size" | grep -oE "\[[0-9]+\]" | tr -d "[]" | head -n1)
+        index=$(run identify -format '%p;%wx%h\n' "$icon" | grep "$icon_size" | cut -d";" -f1 | head -n1)
         if [ -n "$index" ]; then
             run convert "${icon}[${index}]" "app-${icon_size}.png"
         else


### PR DESCRIPTION
This ensures that the correct index is always used when selecting an image of a particular size.

This fixes an issue with the `lite-xl` port where the wrong size icon was being used. This issue only affects users of ImageMagick 7.x. 

Before:
![lite-xl-icon-before](https://github.com/SerenityOS/serenity/assets/2817754/6b236b07-3052-49f7-9925-431a7809164a)

After:
![lite-xl_icon_after](https://github.com/SerenityOS/serenity/assets/2817754/ba875ecd-0bca-4d61-8c5e-849ba426b333)

