### PR TITLE
LibWeb: Improve the line breaking algorithm

### DIFF
--- a/Tests/LibWeb/Layout/expected/nowrap-and-no-line-break-opportunity.txt
+++ b/Tests/LibWeb/Layout/expected/nowrap-and-no-line-break-opportunity.txt
@@ -1,0 +1,30 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x19.46875 children: not-inline
+      BlockContainer <div.fixed_width> at (9,9) content-size 50x17.46875 children: inline
+        line 0 width: 79.40625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+          frag 0 from TextNode start: 0, length: 3, rect: [9,9 33.921875x17.46875]
+            "ABC"
+          frag 1 from TextNode start: 0, length: 1, rect: [43,9 11.5625x17.46875]
+            "X"
+          frag 2 from TextNode start: 0, length: 3, rect: [54,9 33.921875x17.46875]
+            "ABC"
+        TextNode <#text>
+        InlineNode <span.nowrap>
+          TextNode <#text>
+        InlineNode <span>
+          TextNode <#text>
+        InlineNode <span.nowrap>
+          TextNode <#text>
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x19.46875]
+      PaintableWithLines (BlockContainer<DIV>.fixed_width) [8,8 52x19.46875] overflow: [9,9 78.921875x17.46875]
+        InlinePaintable (InlineNode<SPAN>.nowrap)
+          TextPaintable (TextNode<#text>)
+        InlinePaintable (InlineNode<SPAN>)
+          TextPaintable (TextNode<#text>)
+        InlinePaintable (InlineNode<SPAN>.nowrap)
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/space-is-soft-line-break-opportunity.txt
+++ b/Tests/LibWeb/Layout/expected/space-is-soft-line-break-opportunity.txt
@@ -1,0 +1,28 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x37.40625 children: not-inline
+      BlockContainer <div.fixed_width> at (9,9) content-size 50x35.40625 children: inline
+        line 0 width: 33.921875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+          frag 0 from TextNode start: 0, length: 3, rect: [9,9 33.921875x17.46875]
+            "ABC"
+        line 1 width: 33.921875, height: 17.9375, bottom: 35.40625, baseline: 13.53125
+          frag 0 from TextNode start: 0, length: 3, rect: [9,26 33.921875x17.46875]
+            "ABC"
+        TextNode <#text>
+        InlineNode <span.nowrap>
+          TextNode <#text>
+        InlineNode <span>
+          TextNode <#text>
+        InlineNode <span.nowrap>
+          TextNode <#text>
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x37.40625]
+      PaintableWithLines (BlockContainer<DIV>.fixed_width) [8,8 52x37.40625]
+        InlinePaintable (InlineNode<SPAN>.nowrap)
+          TextPaintable (TextNode<#text>)
+        InlinePaintable (InlineNode<SPAN>)
+        InlinePaintable (InlineNode<SPAN>.nowrap)
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/line-breaking-in-cells.txt
+++ b/Tests/LibWeb/Layout/expected/table/line-breaking-in-cells.txt
@@ -1,0 +1,58 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x39.40625 children: not-inline
+      TableWrapper <(anonymous)> at (8,8) content-size 61x39.40625 [BFC] children: not-inline
+        Box <table> at (8,8) content-size 61x39.40625 table-box [TFC] children: not-inline
+          BlockContainer <(anonymous)> (not painted) children: inline
+            TextNode <#text>
+          Box <tbody> at (8,8) content-size 61x39.40625 table-row-group children: not-inline
+            BlockContainer <(anonymous)> (not painted) children: inline
+              TextNode <#text>
+            Box <tr> at (8,8) content-size 61x39.40625 table-row children: not-inline
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+              BlockContainer <td> at (10,18.96875) content-size 14.296875x17.46875 table-cell [BFC] children: inline
+                line 0 width: 14.265625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                  frag 0 from TextNode start: 0, length: 1, rect: [10,18.96875 14.265625x17.46875]
+                    "A"
+                TextNode <#text>
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+              BlockContainer <td> at (28.296875,10) content-size 20.40625x35.40625 table-cell [BFC] children: inline
+                line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                  frag 0 from TextNode start: 1, length: 1, rect: [28.296875,10 9.34375x17.46875]
+                    "B"
+                line 1 width: 10.3125, height: 17.9375, bottom: 35.40625, baseline: 13.53125
+                  frag 0 from TextNode start: 0, length: 1, rect: [28.296875,27 10.3125x17.46875]
+                    "C"
+                TextNode <#text>
+                BreakNode <br>
+                TextNode <#text>
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+              BlockContainer <td> at (52.703125,18.96875) content-size 14.296875x17.46875 table-cell [BFC] children: inline
+                line 0 width: 11.140625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                  frag 0 from TextNode start: 1, length: 1, rect: [52.703125,18.96875 11.140625x17.46875]
+                    "D"
+                TextNode <#text>
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+            BlockContainer <(anonymous)> (not painted) children: inline
+              TextNode <#text>
+          BlockContainer <(anonymous)> (not painted) children: inline
+            TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x39.40625]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 61x39.40625]
+        PaintableBox (Box<TABLE>) [8,8 61x39.40625]
+          PaintableBox (Box<TBODY>) [8,8 61x39.40625]
+            PaintableBox (Box<TR>) [8,8 61x39.40625]
+              PaintableWithLines (BlockContainer<TD>) [8,8 18.296875x39.40625]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [26.296875,8 24.40625x39.40625]
+                TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [50.703125,8 18.296875x39.40625]
+                TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/input/nowrap-and-no-line-break-opportunity.html
+++ b/Tests/LibWeb/Layout/input/nowrap-and-no-line-break-opportunity.html
@@ -1,0 +1,13 @@
+<style>
+	.fixed_width {
+		max-width: 50px;
+		border: 1px solid black;
+	}
+
+	.nowrap {
+		white-space: nowrap;
+	}
+</style>
+<div class="fixed_width">
+	<span class="nowrap">ABC</span><span>X</span><span class="nowrap">ABC</span>
+</div>

--- a/Tests/LibWeb/Layout/input/space-is-soft-line-break-opportunity.html
+++ b/Tests/LibWeb/Layout/input/space-is-soft-line-break-opportunity.html
@@ -1,0 +1,13 @@
+<style>
+	.fixed_width {
+		max-width: 50px;
+		border: 1px solid black;
+	}
+
+	.nowrap {
+		white-space: nowrap;
+	}
+</style>
+<div class="fixed_width">
+	<span class="nowrap">ABC</span><span> </span><span class="nowrap">ABC</span>
+</div>

--- a/Tests/LibWeb/Layout/input/table/line-breaking-in-cells.html
+++ b/Tests/LibWeb/Layout/input/table/line-breaking-in-cells.html
@@ -1,0 +1,25 @@
+<style>
+	table {
+		border-collapse: collapse
+	}
+
+	td {
+		border: 1px solid black;
+	}
+</style>
+
+<table>
+	<tbody>
+		<tr>
+			<td style="width: 30%;">A
+			</td>
+			<td style="width: 40%;">
+				B
+				<br>C
+			</td>
+			<td style="width: 30%;">
+				D
+			</td>
+		</tr>
+	</tbody>
+</table>

--- a/Userland/Libraries/LibWeb/Layout/InlineLevelIterator.h
+++ b/Userland/Libraries/LibWeb/Layout/InlineLevelIterator.h
@@ -52,8 +52,10 @@ public:
     InlineLevelIterator(Layout::InlineFormattingContext&, LayoutState&, Layout::BlockContainer const&, LayoutMode);
 
     Optional<Item> next();
+    CSSPixels next_non_whitespace_sequence_width();
 
 private:
+    Optional<Item> next_without_lookahead();
     void skip_to_next();
     void compute_next();
 
@@ -96,6 +98,7 @@ private:
     Optional<ExtraBoxMetrics> m_extra_trailing_metrics;
 
     Vector<JS::NonnullGCPtr<NodeWithStyleAndBoxModelMetrics const>> m_box_model_node_stack;
+    Queue<InlineLevelIterator::Item> m_lookahead_items;
 };
 
 }


### PR DESCRIPTION
Check the width of the next token after white space to decide line breaks. The next width can also be the total width of multiple tokens. This better follows the CSS Text specification and matches behavior of other browsers.

Fixes #20388.