### PR TITLE
AK: Fix Clang 18 `-Wdeprecated-literal-operator` warning

### DIFF
--- a/AK/StringView.h
+++ b/AK/StringView.h
@@ -388,7 +388,7 @@ struct CaseInsensitiveASCIIStringViewTraits : public Traits<StringView> {
 #    define AK_STRING_VIEW_LITERAL_CONSTEVAL consteval
 #endif
 
-[[nodiscard]] ALWAYS_INLINE AK_STRING_VIEW_LITERAL_CONSTEVAL AK::StringView operator"" sv(char const* cstring, size_t length)
+[[nodiscard]] ALWAYS_INLINE AK_STRING_VIEW_LITERAL_CONSTEVAL AK::StringView operator""sv(char const* cstring, size_t length)
 {
     return AK::StringView(cstring, length);
 }

--- a/Documentation/Patterns.md
+++ b/Documentation/Patterns.md
@@ -242,11 +242,11 @@ static_assert(AssertSize<Empty, 1>());
 
 ## String View Literals
 
-`AK::StringView` support for `operator"" sv` which is a special string literal operator that was added as of
+`AK::StringView` support for `operator""sv` which is a special string literal operator that was added as of
 [C++17 to enable `std::string_view` literals](https://en.cppreference.com/w/cpp/string/basic_string_view/operator%22%22sv).
 
 ```cpp
-[[nodiscard]] ALWAYS_INLINE constexpr AK::StringView operator"" sv(const char* cstring, size_t length)
+[[nodiscard]] ALWAYS_INLINE constexpr AK::StringView operator""sv(const char* cstring, size_t length)
 {
     return AK::StringView(cstring, length);
 }

--- a/Meta/Lagom/ReadMe.md
+++ b/Meta/Lagom/ReadMe.md
@@ -33,7 +33,7 @@ To implement this yourself:
   ```
 - In addition, you will need to also add some compile options that Serenity uses to ensure no warnings or errors:
   ```cmake
-  add_compile_options(-Wno-literal-suffix) # AK::StringView defines operator"" sv, which GCC complains does not have an underscore.
+  add_compile_options(-Wno-literal-suffix) # AK::StringView defines operator""sv, which GCC complains does not have an underscore.
   add_compile_options(-fno-gnu-keywords)   # JS::Value has a method named typeof, which also happens to be a GNU keyword.
   ```
 


### PR DESCRIPTION
The proper syntax for defining user-defined literals does not require a space between the `operator""` token and the operator name:

> error: identifier 'sv' preceded by whitespace in a literal operator
>        declaration is deprecated

---

Please wait for CI to pass, I don't know how older Clang/GCC versions will react to this change.