### PR TITLE
LibCore: Prevent duplicate ArgsParser option names

### DIFF
--- a/Userland/Libraries/LibCore/ArgsParser.cpp
+++ b/Userland/Libraries/LibCore/ArgsParser.cpp
@@ -388,6 +388,18 @@ void ArgsParser::print_version(FILE* file)
 
 void ArgsParser::add_option(Option&& option)
 {
+    for (auto const& existing_option : m_options) {
+        if (option.long_name && existing_option.long_name == option.long_name) {
+            warnln("Error: Multiple options have the long name \"--{}\"", option.long_name);
+            dbgln("Error: Multiple options have the long name \"--{}\"", option.long_name);
+            VERIFY_NOT_REACHED();
+        }
+        if (option.short_name && existing_option.short_name == option.short_name) {
+            warnln("Error: Multiple options have the short name \"-{}\"", option.short_name);
+            dbgln("Error: Multiple options have the short name \"-{}\"", option.short_name);
+            VERIFY_NOT_REACHED();
+        }
+    }
     m_options.append(move(option));
 }
 


### PR DESCRIPTION
Inspired by #20641, detect when adding an option that its long and short names are both unique. If they are not, print a warning and crash.