### PR TITLE
LibWeb: Clear callbacks in `SharedImageRequest` after request is done

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/SharedImageRequest.cpp
+++ b/Userland/Libraries/LibWeb/HTML/SharedImageRequest.cpp
@@ -160,6 +160,7 @@ void SharedImageRequest::handle_successful_fetch(AK::URL const& url_string, Stri
         if (callback.on_finish)
             callback.on_finish();
     }
+    m_callbacks.clear();
 }
 
 void SharedImageRequest::handle_failed_fetch()
@@ -169,6 +170,7 @@ void SharedImageRequest::handle_failed_fetch()
         if (callback.on_fail)
             callback.on_fail();
     }
+    m_callbacks.clear();
 }
 
 bool SharedImageRequest::needs_fetching() const


### PR DESCRIPTION
Callbacks registered within the SharedImageRequest can be removed after the request has been completed. This resolves the GC memory leak issue that occurs due to a cyclic dependency, where the callback captures the image request while being owned by the image request at the same time.