### PR TITLE
LibWeb: Work towards making paint tree independent of layout tree

### DIFF
--- a/Tests/LibWeb/Layout/expected/abspos-box-with-replaced-element.txt
+++ b/Tests/LibWeb/Layout/expected/abspos-box-with-replaced-element.txt
@@ -6,7 +6,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           frag 0 from ImageBox start: 0, length: 0, rect: [262,12 248x26.46875]
         ImageBox <img> at (262,12) content-size 248x26.46875 children: not-inline
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x2] overflow: [9,9 502x102]
     PaintableWithLines (BlockContainer<BODY>) [9,9 502x102]
       PaintableWithLines (BlockContainer<DIV>.image-container) [260,10 250x30.46875] overflow: [261,11 249x28.46875]

--- a/Tests/LibWeb/Layout/expected/abspos-flex-container-with-auto-height.txt
+++ b/Tests/LibWeb/Layout/expected/abspos-flex-container-with-auto-height.txt
@@ -7,7 +7,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             "Diese Website nutzt Cookies und vergleichbare Funktionen zur"
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x2] overflow: [8,8 514.859375x21.46875]
     PaintableBox (Box<BODY>) [8,8 514.859375x21.46875]
       PaintableWithLines (BlockContainer<DIV>) [9,9 512.859375x19.46875]

--- a/Tests/LibWeb/Layout/expected/abspos-image-with-min-height-constraint.txt
+++ b/Tests/LibWeb/Layout/expected/abspos-image-with-min-height-constraint.txt
@@ -3,7 +3,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x0 children: not-inline
       ImageBox <img#zero-dimensions-but-min-percentages> at (8,8) content-size 800x600 positioned children: not-inline
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600] overflow: [0,0 808x608]
+ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 808x608]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x16] overflow: [0,0 808x608]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x0] overflow: [8,8 800x600]
       ImagePaintable (ImageBox<IMG>#zero-dimensions-but-min-percentages) [8,8 800x600]

--- a/Tests/LibWeb/Layout/expected/abspos-not-replaced-multiple-auto-variants.txt
+++ b/Tests/LibWeb/Layout/expected/abspos-not-replaced-multiple-auto-variants.txt
@@ -9,7 +9,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <div.both> at (11,11) content-size 10x10 positioned [BFC] children: not-inline
       TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x602]
+ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x602]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x602]
     PaintableWithLines (BlockContainer<BODY>) [9,9 782x2]
       PaintableWithLines (BlockContainer<DIV>.only-t-l) [5,5 12x12]

--- a/Tests/LibWeb/Layout/expected/abspos-with-percentage-insets.txt
+++ b/Tests/LibWeb/Layout/expected/abspos-with-percentage-insets.txt
@@ -13,7 +13,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
       TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x2] overflow: [9,9 502x402]
     PaintableWithLines (BlockContainer<BODY>) [9,9 502x402]
       PaintableWithLines (BlockContainer<DIV>.one) [310,210 30.6875x19.46875]

--- a/Tests/LibWeb/Layout/expected/acid1.txt
+++ b/Tests/LibWeb/Layout/expected/acid1.txt
@@ -134,7 +134,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (20,400) content-size 480x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x420]
     PaintableWithLines (BlockContainer(anonymous)) [0,0 800x0]
     PaintableWithLines (BlockContainer<BODY>) [15,15 490x390]

--- a/Tests/LibWeb/Layout/expected/anonymous-wrappers-continue-to-inherit-style-after-change.txt
+++ b/Tests/LibWeb/Layout/expected/anonymous-wrappers-continue-to-inherit-style-after-change.txt
@@ -12,7 +12,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             "anonymously wrapped text"
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x89.84375] overflow: [0,0 800x95.28125]
     PaintableWithLines (BlockContainer<BODY>) [8,21.4375 784x73.84375]
       PaintableWithLines (BlockContainer<H1>) [8,21.4375 784x34.9375]

--- a/Tests/LibWeb/Layout/expected/aspect-ratio-auto-and-ratio.txt
+++ b/Tests/LibWeb/Layout/expected/aspect-ratio-auto-and-ratio.txt
@@ -8,7 +8,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         ImageBox <img> at (9,111) content-size 200x200 children: not-inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x320]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x304]
       PaintableWithLines (BlockContainer<DIV>) [8,8 202x102]

--- a/Tests/LibWeb/Layout/expected/aspect-ratio-auto.txt
+++ b/Tests/LibWeb/Layout/expected/aspect-ratio-auto.txt
@@ -8,7 +8,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         ImageBox <img> at (9,11) content-size 200x200 children: not-inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x220]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x204]
       PaintableWithLines (BlockContainer<DIV>) [8,8 202x2]

--- a/Tests/LibWeb/Layout/expected/aspect-ratio-ratio.txt
+++ b/Tests/LibWeb/Layout/expected/aspect-ratio-ratio.txt
@@ -8,7 +8,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         ImageBox <img> at (9,111) content-size 200x100 children: not-inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x220]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x204]
       PaintableWithLines (BlockContainer<DIV>) [8,8 202x102]

--- a/Tests/LibWeb/Layout/expected/automatic-height-of-non-replaced-abspos-element-must-not-be-negative.txt
+++ b/Tests/LibWeb/Layout/expected/automatic-height-of-non-replaced-abspos-element-must-not-be-negative.txt
@@ -4,7 +4,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <div.inner> at (9,9) content-size 0x0 positioned [BFC] children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x0] overflow: [8,8 2x2]
     PaintableWithLines (BlockContainer<BODY>.outer) [8,8 0x0] overflow: [8,8 2x2]
       PaintableWithLines (BlockContainer<DIV>.inner) [8,8 2x2]

--- a/Tests/LibWeb/Layout/expected/automatic-width-of-non-replaced-abspos-element-must-not-be-negative.txt
+++ b/Tests/LibWeb/Layout/expected/automatic-width-of-non-replaced-abspos-element-must-not-be-negative.txt
@@ -3,7 +3,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body.outer> at (8,8) content-size 0x0 positioned [BFC] children: not-inline
       BlockContainer <div.inner> at (9,9) content-size 0x0 positioned [BFC] children: not-inline
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x0] overflow: [8,8 2x2]
     PaintableWithLines (BlockContainer<BODY>.outer) [8,8 0x0] overflow: [8,8 2x2]
       PaintableWithLines (BlockContainer<DIV>.inner) [8,8 2x2]

--- a/Tests/LibWeb/Layout/expected/blank.txt
+++ b/Tests/LibWeb/Layout/expected/blank.txt
@@ -5,7 +5,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x0 children: inline
       TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x16]
     PaintableWithLines (BlockContainer(anonymous)) [0,0 800x0]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x0]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/abspos-with-auto-margins-in-inline-axis.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/abspos-with-auto-margins-in-inline-axis.txt
@@ -5,7 +5,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <div#bar> at (699,101) content-size 100x100 positioned [BFC] children: not-inline
       BlockContainer <div#baz> at (1,201) content-size 100x100 positioned [BFC] children: not-inline
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x20] overflow: [0,0 800x302]
     PaintableWithLines (BlockContainer<BODY>) [9,9 782x2] overflow: [0,0 800x302]
       PaintableWithLines (BlockContainer<DIV>#foo) [349,0 102x102]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/abspos-with-percentage-height-resolved-against-padding-box-of-containing-block.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/abspos-with-percentage-height-resolved-against-padding-box-of-containing-block.txt
@@ -3,7 +3,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,248) content-size 784x0 positioned children: not-inline
       BlockContainer <div.abspos> at (8,8) content-size 784x240 positioned [BFC] children: not-inline
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x256]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x240]
       PaintableWithLines (BlockContainer<DIV>.abspos) [8,8 784x240]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/atomic-inline-with-percentage-vertical-align.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/atomic-inline-with-percentage-vertical-align.txt
@@ -9,7 +9,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BreakNode <br>
       BlockContainer <div.clump> at (3,35) content-size 30x30 inline-block [BFC] children: not-inline
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x64.5] overflow: [1,1 798x64]
     PaintableWithLines (BlockContainer<BODY>) [1,1 798x62.5] overflow: [2,2 796x63]
       PaintableWithLines (BlockContainer<DIV>.clump) [3,2 32x32]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/automatic-size-of-block-container-with-inline-children-and-nonempty-floating-child.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/automatic-size-of-block-container-with-inline-children-and-nonempty-floating-child.txt
@@ -5,7 +5,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <div.green> at (78,78) content-size 0x0 floating [BFC] children: not-inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x0] overflow: [8,8 140x100]
     PaintableWithLines (BlockContainer<BODY>) [8,8 140x100]
       PaintableWithLines (BlockContainer<DIV>.black) [8,8 140x100]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/bfc-consider-all-currently-stacked-floats.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/bfc-consider-all-currently-stacked-floats.txt
@@ -29,7 +29,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,42.9375) content-size 784x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x108]
     PaintableWithLines (BlockContainer(anonymous)) [0,0 800x0]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x34.9375]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/bfc-float-left-break-vertically-2.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/bfc-float-left-break-vertically-2.txt
@@ -9,7 +9,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (0,0) content-size 200x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x150]
     PaintableWithLines (BlockContainer<BODY>) [0,0 200x0] overflow: [0,0 200x150]
       PaintableWithLines (BlockContainer<UL>) [0,0 200x0]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/bfc-float-left-break-vertically.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/bfc-float-left-break-vertically.txt
@@ -16,7 +16,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <div.green> at (3,56) content-size 100x50 floating [BFC] children: not-inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x108]
     PaintableWithLines (BlockContainer(anonymous)) [1,1 798x0]
     PaintableWithLines (BlockContainer<BODY>) [1,1 402x4]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/block-with-fit-content-width-constraints.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/block-with-fit-content-width-constraints.txt
@@ -14,7 +14,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (10,48.9375) content-size 780x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x58.9375]
     PaintableWithLines (BlockContainer<BODY>) [9,9 782x40.9375]
       PaintableWithLines (BlockContainer<DIV>.box) [10,10 140.28125x19.46875]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/block-with-fit-content-width.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/block-with-fit-content-width.txt
@@ -9,7 +9,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (10,29.46875) content-size 780x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x39.46875]
     PaintableWithLines (BlockContainer<BODY>) [9,9 782x21.46875]
       PaintableWithLines (BlockContainer<DIV>.box) [10,10 140.28125x19.46875]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/block-with-hidden-overflow-after-float.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/block-with-hidden-overflow-after-float.txt
@@ -28,7 +28,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,25.46875) content-size 784x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x33.46875]
     PaintableWithLines (BlockContainer(anonymous)) [0,0 800x0]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x17.46875]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/block-with-hidden-overflow-after-sibling-float.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/block-with-hidden-overflow-after-sibling-float.txt
@@ -46,7 +46,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <(anonymous)> at (8,42.9375) content-size 784x0 children: inline
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x34.9375]
       PaintableWithLines (BlockContainer<DIV>) [8,8 784x34.9375]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/block-with-max-content-width.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/block-with-max-content-width.txt
@@ -23,7 +23,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (10,68.40625) content-size 780x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x78.40625]
     PaintableWithLines (BlockContainer<BODY>) [9,9 782x60.40625]
       PaintableWithLines (BlockContainer<DIV>.foo) [10,10 152.21875x19.46875]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/block-with-min-content-width.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/block-with-min-content-width.txt
@@ -32,7 +32,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (10,122.21875) content-size 780x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x132.21875]
     PaintableWithLines (BlockContainer<BODY>) [9,9 782x114.21875]
       PaintableWithLines (BlockContainer<DIV>.foo) [10,10 95.765625x37.40625]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/block-with-negative-margin-and-no-intruding-floats.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/block-with-negative-margin-and-no-intruding-floats.txt
@@ -10,7 +10,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             "intruding on this div"
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x57.40625]
     PaintableWithLines (BlockContainer<BODY>) [109,9 302x39.40625] overflow: [60,10 350x37.40625]
       PaintableWithLines (BlockContainer<DIV>) [60,10 202x37.40625]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/box-with-clearance-and-margin-top.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/box-with-clearance-and-margin-top.txt
@@ -6,7 +6,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <div.clearfix> at (8,108) content-size 10x10 children: not-inline
         BlockContainer <div.square.black> at (8,218) content-size 49x49 floating [BFC] children: not-inline
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x110] overflow: [8,8 784x259]
       PaintableWithLines (BlockContainer<DIV>) [8,8 784x110] overflow: [8,8 784x259]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/button-should-have-vertically-aligned-content.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/button-should-have-vertically-aligned-content.txt
@@ -26,7 +26,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 BlockContainer <(anonymous)> at (22,186.734375) content-size 48.6875x0 children: inline
                   TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x200]
       PaintableWithLines (BlockContainer<BUTTON>.button.border-black) [8,8 76.6875x200]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/button-with-multiple-words-text-node-label.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/button-with-multiple-words-text-node-label.txt
@@ -15,7 +15,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                     "A B C"
                 TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x21.46875]
       PaintableWithLines (BlockContainer<BUTTON>) [8,8 59.921875x21.46875]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/button-with-text-node-label-and-font-size.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/button-with-text-node-label-and-font-size.txt
@@ -15,7 +15,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                     "Test"
                 TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x56.40625]
       PaintableWithLines (BlockContainer<BUTTON>) [8,8 121.65625x56.40625]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/button-with-text-node-label.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/button-with-text-node-label.txt
@@ -15,7 +15,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                     "Test"
                 TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x21.46875]
       PaintableWithLines (BlockContainer<BUTTON>) [8,8 47.21875x21.46875]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/clear-both-from-inline-formatting-context.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/clear-both-from-inline-formatting-context.txt
@@ -22,7 +22,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x0]
       PaintableWithLines (BlockContainer<DIV>) [8,8 784x0]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/clear-both-without-introducing-clearance.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/clear-both-without-introducing-clearance.txt
@@ -13,7 +13,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             "lower"
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x125.9375]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x109.9375]
       PaintableWithLines (BlockContainer<DIV>.upper) [8,8 784x17.46875]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/clearfix.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/clearfix.txt
@@ -14,7 +14,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,108) content-size 784x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x100]
       PaintableWithLines (BlockContainer<DIV>) [8,8 784x100]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/float-1.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/float-1.txt
@@ -113,7 +113,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,340.34375) content-size 784x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x332.34375]
       PaintableWithLines (BlockContainer(anonymous)) [8,8 784x0]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/float-2.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/float-2.txt
@@ -15,7 +15,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,25.46875) content-size 784x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x60]
     PaintableWithLines (BlockContainer(anonymous)) [0,0 800x0]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x17.46875]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/float-3.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/float-3.txt
@@ -25,7 +25,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,127.46875) content-size 780x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 780x119.46875]
       PaintableWithLines (BlockContainer(anonymous)) [8,8 780x0]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/float-4.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/float-4.txt
@@ -29,7 +29,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
       TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x60]
     PaintableWithLines (BlockContainer(anonymous)) [0,0 800x0]
     PaintableWithLines (BlockContainer<BODY>) [8,8 780x0]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/float-clear-by-line-break.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/float-clear-by-line-break.txt
@@ -25,7 +25,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       InlineNode <span>
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x35.40625]
       PaintableWithLines (BlockContainer<SPAN>.a) [8,8 100x17.46875]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/float-left-and-right-with-justified-text-in-between.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/float-left-and-right-with-justified-text-in-between.txt
@@ -201,7 +201,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <div.right> at (489,213) content-size 300x200 floating [BFC] children: not-inline
       TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x602]
+ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x602]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x602]
     PaintableWithLines (BlockContainer<BODY>) [251,9 540x401.53125] overflow: [252,10 538.34375x399.53125]
       PaintableWithLines (BlockContainer<DIV>.left) [252,10 302x202]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/float-left-and-right-with-text-in-between.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/float-left-and-right-with-text-in-between.txt
@@ -61,7 +61,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <div.right> at (489,213) content-size 300x200 floating [BFC] children: not-inline
       TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x602]
+ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x602]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x602]
     PaintableWithLines (BlockContainer<BODY>) [251,9 540x401.53125]
       PaintableWithLines (BlockContainer<DIV>.left) [252,10 302x202]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/float-max-content-containing-block-flex-display.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/float-max-content-containing-block-flex-display.txt
@@ -15,7 +15,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                   "B"
               TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x0] overflow: [8,8 23.609375x17.46875]
       PaintableBox (Box<DIV>.display_flex) [8,8 23.609375x17.46875]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/float-max-content-containing-block.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/float-max-content-containing-block.txt
@@ -13,7 +13,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               "B"
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x0] overflow: [8,8 23.609375x17.46875]
       PaintableWithLines (BlockContainer<DIV>) [8,8 23.609375x17.46875]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/float-stress-1.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/float-stress-1.txt
@@ -76,7 +76,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <div.righty> at (278,190) content-size 30x30 floating [BFC] children: not-inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x268] overflow: [0,0 800x285]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x252] overflow: [8,8 784x277]
       PaintableWithLines (BlockContainer(anonymous)) [8,8 784x0]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/float-stress-2.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/float-stress-2.txt
@@ -17,7 +17,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (0,50) content-size 800x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>.js) [0,0 800x200]
     PaintableWithLines (BlockContainer<BODY>) [0,0 800x50] overflow: [0,0 800x200]
       PaintableWithLines (BlockContainer<DIV>#page) [0,0 800x50] overflow: [0,0 800x200]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/float-stress-3.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/float-stress-3.txt
@@ -15,7 +15,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <div.two> at (108,78) content-size 200x50 floating [BFC] children: not-inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x268]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x252]
       PaintableWithLines (BlockContainer(anonymous)) [8,8 784x0]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/floats-and-negative-margins.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/floats-and-negative-margins.txt
@@ -15,7 +15,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [100,8 200x200] overflow: [50,8 250x200]
       PaintableWithLines (BlockContainer<DIV>.row) [50,8 250x200]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/ifc-float-left-and-sibling-with-margin-left.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/ifc-float-left-and-sibling-with-margin-left.txt
@@ -8,7 +8,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             "Chrono Trigger"
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x63]
     PaintableWithLines (BlockContainer<BODY>) [9,9 782x21.46875] overflow: [10,10 780x52]
       PaintableWithLines (BlockContainer<DIV>.thumbnail) [10,10 52x52]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/inline-block-baseline-1.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/inline-block-baseline-1.txt
@@ -21,7 +21,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <(anonymous)> at (114,101.9375) content-size 202x0 children: inline
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x602]
+ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x602]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x602]
     PaintableWithLines (BlockContainer<BODY>) [9,9 782x94.9375]
       TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/block-and-inline/inline-block-baseline-2.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/inline-block-baseline-2.txt
@@ -25,7 +25,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <(anonymous)> at (114,49.9375) content-size 39.234375x0 children: inline
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x602]
+ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x602]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x602]
     PaintableWithLines (BlockContainer<BODY>) [9,9 782x62.40625]
       TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/block-and-inline/inline-block-percentage-max-width.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/inline-block-percentage-max-width.txt
@@ -9,7 +9,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             "New UI"
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x113.46875]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x97.46875]
       PaintableWithLines (BlockContainer<DIV>) [8,8 134.109375x97.46875]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/inline-block-with-max-width-fit-content.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/inline-block-with-max-width-fit-content.txt
@@ -9,7 +9,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             "hello friends"
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x35.46875]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x19.46875]
       PaintableWithLines (BlockContainer<SPAN>) [8,8 102.203125x19.46875]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/inline-block-with-percentage-height-and-auto-height-of-containing-block.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/inline-block-with-percentage-height-and-auto-height-of-containing-block.txt
@@ -10,7 +10,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               "docs"
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x33.46875]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x17.46875]
       PaintableWithLines (BlockContainer<DIV>.pure-menu-list) [8,8 784x17.46875]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/inline-box-positioned-with-top-left.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/inline-box-positioned-with-top-left.txt
@@ -15,7 +15,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
       TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x20]
       TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/block-and-inline/inline-box-with-vertical-margins-vertical-align-top.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/inline-box-with-vertical-margins-vertical-align-top.txt
@@ -11,7 +11,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <div#inline-box> at (51,58) content-size 100x100 inline-block [BFC] children: not-inline
       TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x175]
       TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/block-and-inline/inline-box-with-vertical-margins.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/inline-box-with-vertical-margins.txt
@@ -11,7 +11,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <div#inline-box> at (51,58) content-size 100x100 inline-block [BFC] children: not-inline
       TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x178.46875]
       TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/block-and-inline/intrinsic-sizing-with-min-width-specified.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/intrinsic-sizing-with-min-width-specified.txt
@@ -4,7 +4,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <div.outer> at (11,11) content-size 102x32 children: not-inline
         BlockContainer <div.inner> at (12,12) content-size 100x30 children: not-inline
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x54]
     PaintableWithLines (BlockContainer<BODY>) [9,9 106x36]
       PaintableWithLines (BlockContainer<DIV>.outer) [10,10 104x34]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/join-out-of-flow-box-with-previous-sibling-if-wrapped-in-anonymous-box.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/join-out-of-flow-box-with-previous-sibling-if-wrapped-in-anonymous-box.txt
@@ -8,7 +8,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <div.tab> at (8,38) content-size 200x30 inline-block [BFC] children: not-inline
         BlockContainer <div.timeline> at (592,38) content-size 200x30 floating [BFC] children: not-inline
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x76]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x60]
       PaintableWithLines (BlockContainer<DIV>.banner) [8,8 200x30]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/margin-collapse-1.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/margin-collapse-1.txt
@@ -16,7 +16,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,279) content-size 784x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,25 784x229] overflow: [8,25 784x254]
       PaintableWithLines (BlockContainer<DIV>#foo) [33,25 102x102]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/margin-collapse-2.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/margin-collapse-2.txt
@@ -23,7 +23,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,344) content-size 784x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x336]
       PaintableWithLines (BlockContainer<DIV>#foo) [8,8 102x102]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/margin-collapse-3.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/margin-collapse-3.txt
@@ -9,7 +9,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,358) content-size 784x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x350]
       PaintableWithLines (BlockContainer<DIV>#foo) [8,8 100x100]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/margin-collapse-4.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/margin-collapse-4.txt
@@ -9,7 +9,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,158) content-size 784x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x150]
       PaintableWithLines (BlockContainer<DIV>#foo) [8,8 100x50]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/margin-collapse-5.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/margin-collapse-5.txt
@@ -11,7 +11,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (2,121.46875) content-size 168.96875x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x123.46875]
     PaintableWithLines (BlockContainer<BODY>) [1,1 170.96875x121.46875]
       PaintableWithLines (BlockContainer<DIV>.hmm) [2,2 168.96875x19.46875]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/margin-collapse-6.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/margin-collapse-6.txt
@@ -5,7 +5,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <div.bfc> at (8,78) content-size 784x20 [BFC] children: not-inline
         BlockContainer <div.inner> at (8,78) content-size 20x20 children: not-inline
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x106]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x90]
       PaintableWithLines (BlockContainer<DIV>.upper) [8,8 784x20]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/margin-must-not-collapse-across-nested-bfc.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/margin-must-not-collapse-across-nested-bfc.txt
@@ -5,7 +5,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <div.bfc> at (8,80) content-size 784x0 [BFC] children: not-inline
       BlockContainer <div.not-bfc> at (8,110) content-size 784x20 children: not-inline
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x116] overflow: [0,0 800x130]
     PaintableWithLines (BlockContainer<BODY>) [8,30 784x100]
       PaintableWithLines (BlockContainer<DIV>.not-bfc) [8,30 784x20]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/margin-padding-block-inline-start.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/margin-padding-block-inline-start.txt
@@ -9,7 +9,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           InlineNode <span>
             TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x101.46875]
     PaintableWithLines (BlockContainer<BODY>) [9,9 502x83.46875]
       PaintableWithLines (BlockContainer<DIV>.a) [10,10 500x81.46875]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/margin-padding-block-inline.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/margin-padding-block-inline.txt
@@ -9,7 +9,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           InlineNode <span>
             TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x121.46875]
     PaintableWithLines (BlockContainer<BODY>) [9,9 502x103.46875]
       PaintableWithLines (BlockContainer<DIV>.a) [10,10 500x101.46875]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/max-width-for-box-with-inline-children.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/max-width-for-box-with-inline-children.txt
@@ -14,7 +14,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               "friends"
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x187.96875]
     PaintableWithLines (BlockContainer<BODY>) [9,9 206x169.96875]
       PaintableWithLines (BlockContainer<DIV>.outer) [10,10 204x167.96875]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/max-width-must-not-expand-element.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/max-width-must-not-expand-element.txt
@@ -4,7 +4,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <div.outer> at (11,11) content-size 2x52 children: not-inline
         BlockContainer <div.inner> at (12,12) content-size 0x50 children: not-inline
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x2] overflow: [9,9 6x56]
     PaintableWithLines (BlockContainer<BODY>) [9,9 6x56]
       PaintableWithLines (BlockContainer<DIV>.outer) [10,10 4x54]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/max-width-on-child-block-with-width-auto-contributes-to-intrinsic-size-of-parent.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/max-width-on-child-block-with-width-auto-contributes-to-intrinsic-size-of-parent.txt
@@ -8,7 +8,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               "OPEN"
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x41.46875]
     PaintableBox (Box<BODY>.outer) [9,9 782x23.46875]
       PaintableWithLines (BlockContainer<DIV>.middle) [10,10 204x21.46875]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/max-width-percentage-100-border-box.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/max-width-percentage-100-border-box.txt
@@ -7,7 +7,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             "border box"
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x2] overflow: [9,9 95.59375x21.46875]
     PaintableWithLines (BlockContainer<BODY>) [9,9 95.59375x21.46875]
       PaintableWithLines (BlockContainer<NAV>) [10,10 93.59375x19.46875]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/max-width-percentage-100.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/max-width-percentage-100.txt
@@ -7,7 +7,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             "well hello friends"
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x2] overflow: [9,9 140.609375x21.46875]
     PaintableWithLines (BlockContainer<BODY>) [9,9 140.609375x21.46875]
       PaintableWithLines (BlockContainer<DIV>) [10,10 138.609375x19.46875]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/min-width-for-box-with-inline-children.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/min-width-for-box-with-inline-children.txt
@@ -8,7 +8,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               "well hello friends"
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x78.59375]
     PaintableWithLines (BlockContainer<BODY>) [9,9 606x60.59375]
       PaintableWithLines (BlockContainer<DIV>.outer) [10,10 604x58.59375]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/narrow-bfc-width-to-avoid-overlap-with-floats.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/narrow-bfc-width-to-avoid-overlap-with-floats.txt
@@ -21,7 +21,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               "pulvinar ipsum eget nulla dapibus, ac varius mi eleifend."
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x1008]
+ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x1008]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x1008]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x108.21875] overflow: [8,8 784x1000]
       PaintableWithLines (BlockContainer<DIV>.wrapper) [8,8 784x108.21875] overflow: [8,8 784x1000]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/percentage-min-height-with-containing-block-padding.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/percentage-min-height-with-containing-block-padding.txt
@@ -8,7 +8,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               "hello"
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x616]
+ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x616]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x616]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x600]
       PaintableWithLines (BlockContainer<DIV>.container) [8,8 784x600]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/percentage-min-height.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/percentage-min-height.txt
@@ -7,7 +7,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             "hello"
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x53.46875]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x37.46875]
       PaintableWithLines (BlockContainer<DIV>.hmm) [8,8 784x37.46875]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/percentage-min-width-with-max-content-containing-block-width.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/percentage-min-width-with-max-content-containing-block-width.txt
@@ -7,7 +7,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             "hello"
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x33.46875]
     PaintableWithLines (BlockContainer<BODY>) [8,8 200x17.46875]
       PaintableWithLines (BlockContainer<DIV>) [8,8 200x17.46875]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/percentage-padding-on-inline-block-with-indefinite-containing-block-size.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/percentage-padding-on-inline-block-with-indefinite-containing-block-size.txt
@@ -5,7 +5,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         frag 0 from BlockContainer start: 0, length: 0, rect: [8,21 0x0]
       BlockContainer <div> at (8,21) content-size 0x0 inline-block [BFC] children: not-inline
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x33.46875]
     PaintableWithLines (BlockContainer<BODY>) [8,8 0x17.46875]
       PaintableWithLines (BlockContainer<DIV>) [8,21 0x0]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/relpos-block.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/relpos-block.txt
@@ -12,7 +12,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             "athena"
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x66.9375]
     PaintableWithLines (BlockContainer<BODY>) [10,10 604x46.9375]
       PaintableWithLines (BlockContainer<DIV>.exekiller) [12,12 204x21.46875]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/relpos-float.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/relpos-float.txt
@@ -12,7 +12,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             "athena"
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x35.46875] overflow: [2,2 796x35.46875]
     PaintableWithLines (BlockContainer<BODY>) [10,10 604x4] overflow: [12,12 208x25.46875]
       PaintableWithLines (BlockContainer<DIV>.exekiller) [12,12 204x21.46875]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/relpos-inline-element-js-offsets.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/relpos-inline-element-js-offsets.txt
@@ -41,7 +41,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x156.6875] overflow: [8,8 784x172.6875]
       PaintableWithLines (BlockContainer(anonymous)) [8,8 784x17.46875] overflow: [8,8 784x67.46875]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/relpos-inline-elements.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/relpos-inline-elements.txt
@@ -19,7 +19,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
       TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x17.46875] overflow: [8,8 784x67.46875]
       TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/block-and-inline/single-br-inline-layout.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/single-br-inline-layout.txt
@@ -7,7 +7,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BreakNode <br>
       BlockContainer <div#end> at (8,27.46875) content-size 784x2 children: not-inline
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x21.46875]
       PaintableWithLines (BlockContainer<DIV>#begin) [8,8 784x2]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/width-auto-margins-set-zero-if-containing-size-smaller.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/width-auto-margins-set-zero-if-containing-size-smaller.txt
@@ -14,7 +14,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               "friends"
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x2] overflow: [9,9 174x59.34375]
     PaintableWithLines (BlockContainer<BODY>) [9,9 104x59.34375] overflow: [10,10 173x57.34375]
       PaintableWithLines (BlockContainer<DIV>#container) [10,10 102x57.34375] overflow: [11,11 172x55.34375]

--- a/Tests/LibWeb/Layout/expected/blockify-layout-internal-box-without-crashing.txt
+++ b/Tests/LibWeb/Layout/expected/blockify-layout-internal-box-without-crashing.txt
@@ -8,7 +8,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> at (10,10) content-size 0x0 table-cell [BFC] children: not-inline
                 BlockContainer <td> at (9,9) content-size 0x0 positioned [BFC] children: not-inline
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x20]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x4]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 4x4]

--- a/Tests/LibWeb/Layout/expected/box-sizing-border-box-for-definite-sizes-without-layout.txt
+++ b/Tests/LibWeb/Layout/expected/box-sizing-border-box-for-definite-sizes-without-layout.txt
@@ -10,7 +10,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               "Hello"
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x66]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x50]
       PaintableBox (Box<DIV>.button) [8,18 89.71875x40]

--- a/Tests/LibWeb/Layout/expected/calc-negate-length.txt
+++ b/Tests/LibWeb/Layout/expected/calc-negate-length.txt
@@ -4,7 +4,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <div.container> at (8,8) content-size 100x50 children: not-inline
         BlockContainer <div.foo> at (8,8) content-size 99x50 children: not-inline
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x66]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x50]
       PaintableWithLines (BlockContainer<DIV>.container) [8,8 100x50]

--- a/Tests/LibWeb/Layout/expected/css-all-unset.txt
+++ b/Tests/LibWeb/Layout/expected/css-all-unset.txt
@@ -11,7 +11,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: inline
     InlineNode <body>
       TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   InlinePaintable (InlineNode<HTML>)
     InlinePaintable (InlineNode<HEAD>)
       InlinePaintable (InlineNode<STYLE>)

--- a/Tests/LibWeb/Layout/expected/css-calc-border-width.txt
+++ b/Tests/LibWeb/Layout/expected/css-calc-border-width.txt
@@ -3,7 +3,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x120 children: not-inline
       BlockContainer <div> at (18,18) content-size 100x100 children: not-inline
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x120]
       PaintableWithLines (BlockContainer<DIV>) [8,8 120x120]

--- a/Tests/LibWeb/Layout/expected/css-ex-unit.txt
+++ b/Tests/LibWeb/Layout/expected/css-ex-unit.txt
@@ -3,7 +3,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x161.25 children: not-inline
       BlockContainer <div> at (8,8) content-size 107.5x161.25 children: not-inline
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x177.25]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x161.25]
       PaintableWithLines (BlockContainer<DIV>) [8,8 107.5x161.25]

--- a/Tests/LibWeb/Layout/expected/css-font-size-calc.txt
+++ b/Tests/LibWeb/Layout/expected/css-font-size-calc.txt
@@ -6,7 +6,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           "Hello friends"
       TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x125.1875]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x109.1875]
       TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/css-host-selector-gets-parsed.txt
+++ b/Tests/LibWeb/Layout/expected/css-host-selector-gets-parsed.txt
@@ -7,7 +7,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             "whf"
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x100]
       PaintableWithLines (BlockContainer<DIV>) [8,8 100x100]

--- a/Tests/LibWeb/Layout/expected/css-import-rule.txt
+++ b/Tests/LibWeb/Layout/expected/css-import-rule.txt
@@ -6,7 +6,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           "Crazy"
       TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x54.59375]
       TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/css-imported-sheet-with-media-rule.txt
+++ b/Tests/LibWeb/Layout/expected/css-imported-sheet-with-media-rule.txt
@@ -6,7 +6,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           "Crazy"
       TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x109.1875]
       TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/css-invalid-psuedo-compound-selector.txt
+++ b/Tests/LibWeb/Layout/expected/css-invalid-psuedo-compound-selector.txt
@@ -5,7 +5,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x0]
       PaintableWithLines (BlockContainer<DIV>) [8,8 784x0]

--- a/Tests/LibWeb/Layout/expected/css-line-height-percentage-inheritance.txt
+++ b/Tests/LibWeb/Layout/expected/css-line-height-percentage-inheritance.txt
@@ -7,7 +7,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             "The Linux Kernel Archives"
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x54]
     PaintableWithLines (BlockContainer<BODY>) [9,9 782x36]
       PaintableWithLines (BlockContainer<DIV>) [10,10 780x34]

--- a/Tests/LibWeb/Layout/expected/css-logical-inset-properties.txt
+++ b/Tests/LibWeb/Layout/expected/css-logical-inset-properties.txt
@@ -5,7 +5,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <div.four-props> at (110,210) content-size 248x148 positioned [BFC] children: not-inline
       TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x2] overflow: [8,8 502x402]
     PaintableWithLines (BlockContainer<BODY>) [8,8 502x402]
       PaintableWithLines (BlockContainer<DIV>.two-props) [59,109 400x200]

--- a/Tests/LibWeb/Layout/expected/css-namespace-rule-matches.txt
+++ b/Tests/LibWeb/Layout/expected/css-namespace-rule-matches.txt
@@ -12,7 +12,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,61.84375) content-size 784x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,20 784x21.84375] overflow: [8,20 784x41.84375]
       PaintableWithLines (BlockContainer<P>) [8,20 784x21.84375]

--- a/Tests/LibWeb/Layout/expected/css-namespace-rule-no-match.txt
+++ b/Tests/LibWeb/Layout/expected/css-namespace-rule-no-match.txt
@@ -12,7 +12,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,61.84375) content-size 784x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,20 784x21.84375] overflow: [8,20 784x41.84375]
       PaintableWithLines (BlockContainer<P>) [8,20 784x21.84375]

--- a/Tests/LibWeb/Layout/expected/css-namespace-tag-name-selector.txt
+++ b/Tests/LibWeb/Layout/expected/css-namespace-tag-name-selector.txt
@@ -26,7 +26,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,307.65625) content-size 784x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x299.65625]
       PaintableWithLines (BlockContainer(anonymous)) [8,8 784x152]

--- a/Tests/LibWeb/Layout/expected/css-namespace-universal-selector.txt
+++ b/Tests/LibWeb/Layout/expected/css-namespace-universal-selector.txt
@@ -11,7 +11,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,332) content-size 784x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x324]
       SVGSVGPaintable (SVGSVGBox<svg>) [8,8 120x120]

--- a/Tests/LibWeb/Layout/expected/css-pseudo-element-blockification.txt
+++ b/Tests/LibWeb/Layout/expected/css-pseudo-element-blockification.txt
@@ -18,7 +18,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               "friends"
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x17.46875]
       PaintableBox (Box<DIV>.foo) [8,8 784x17.46875]

--- a/Tests/LibWeb/Layout/expected/css-pseudo-element-should-not-be-affected-by-inline-style.txt
+++ b/Tests/LibWeb/Layout/expected/css-pseudo-element-should-not-be-affected-by-inline-style.txt
@@ -7,7 +7,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <div.inner> at (12,64) content-size 98x0 children: inline
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x122]
     PaintableWithLines (BlockContainer<BODY>) [9,9 782x104]
       PaintableWithLines (BlockContainer<DIV>.outer) [10,10 102x102]

--- a/Tests/LibWeb/Layout/expected/css-pseudo-element-should-not-be-affected-by-presentational-hints.txt
+++ b/Tests/LibWeb/Layout/expected/css-pseudo-element-should-not-be-affected-by-presentational-hints.txt
@@ -9,7 +9,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 BlockContainer <(anonymous)> at (16,63) content-size 98x0 children: inline
                   TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x126]
     PaintableWithLines (BlockContainer<BODY>) [9,9 782x108]
       PaintableWithLines (TableWrapper(anonymous)) [10,10 110x106]

--- a/Tests/LibWeb/Layout/expected/css-revert.txt
+++ b/Tests/LibWeb/Layout/expected/css-revert.txt
@@ -6,7 +6,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           "Hello friends"
       TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x17.46875]
     PaintableWithLines (BlockContainer<BODY>) [0,0 800x17.46875]
       TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/css-snap-a-length-as-a-border-width.txt
+++ b/Tests/LibWeb/Layout/expected/css-snap-a-length-as-a-border-width.txt
@@ -4,7 +4,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <div.a> at (9,9) content-size 100x100 children: not-inline
       BlockContainer <div.b> at (9,111) content-size 100x100 children: not-inline
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x204]
       PaintableWithLines (BlockContainer<DIV>.a) [8,8 102x102]

--- a/Tests/LibWeb/Layout/expected/css-values/comparison-functions.txt
+++ b/Tests/LibWeb/Layout/expected/css-values/comparison-functions.txt
@@ -6,7 +6,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           BlockContainer <div.clamp> at (8,8) content-size 120x300 children: inline
             TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 0x0] overflow: [8,8 120x300]
     PaintableWithLines (BlockContainer<BODY>) [8,8 0x0] overflow: [8,8 120x300]
       PaintableWithLines (BlockContainer<DIV>.min) [8,8 80x0] overflow: [8,8 120x300]

--- a/Tests/LibWeb/Layout/expected/css-values/exponential-functions.txt
+++ b/Tests/LibWeb/Layout/expected/css-values/exponential-functions.txt
@@ -8,7 +8,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <div.exp> at (8,8) content-size 160x0 children: inline
                 TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 0x0] overflow: [8,8 160x0]
     PaintableWithLines (BlockContainer<BODY>) [8,8 0x0] overflow: [8,8 160x0]
       PaintableWithLines (BlockContainer<DIV>.pow) [8,8 80x0] overflow: [8,8 160x0]

--- a/Tests/LibWeb/Layout/expected/css-values/numeric-constants.txt
+++ b/Tests/LibWeb/Layout/expected/css-values/numeric-constants.txt
@@ -5,7 +5,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <div.e> at (8,8) content-size 100x0 children: inline
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 0x0] overflow: [8,8 100x0]
     PaintableWithLines (BlockContainer<BODY>) [8,8 0x0] overflow: [8,8 100x0]
       PaintableWithLines (BlockContainer<DIV>.pi) [8,8 80x0] overflow: [8,8 100x0]

--- a/Tests/LibWeb/Layout/expected/css-values/sign-related-functions.txt
+++ b/Tests/LibWeb/Layout/expected/css-values/sign-related-functions.txt
@@ -5,7 +5,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <div.sign> at (8,8) content-size 100x0 children: inline
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 0x0] overflow: [8,8 100x0]
     PaintableWithLines (BlockContainer<BODY>) [8,8 0x0] overflow: [8,8 100x0]
       PaintableWithLines (BlockContainer<DIV>.abs) [8,8 80x0] overflow: [8,8 100x0]

--- a/Tests/LibWeb/Layout/expected/css-values/stepped-value-functions.txt
+++ b/Tests/LibWeb/Layout/expected/css-values/stepped-value-functions.txt
@@ -6,7 +6,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           BlockContainer <div.rem> at (8,8) content-size 120x0 children: inline
             TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 0x0] overflow: [8,8 120x0]
     PaintableWithLines (BlockContainer<BODY>) [8,8 0x0] overflow: [8,8 120x0]
       PaintableWithLines (BlockContainer<DIV>.round) [8,8 80x0] overflow: [8,8 120x0]

--- a/Tests/LibWeb/Layout/expected/css-values/trigonometric-functions.txt
+++ b/Tests/LibWeb/Layout/expected/css-values/trigonometric-functions.txt
@@ -11,7 +11,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,988) content-size 784x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x996]
+ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x996]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x996]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x980]
       PaintableWithLines (BlockContainer<DIV>.sin) [8,8 80x100]

--- a/Tests/LibWeb/Layout/expected/css-var-in-calc-block.txt
+++ b/Tests/LibWeb/Layout/expected/css-var-in-calc-block.txt
@@ -3,7 +3,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (10,10) content-size 780x252 children: not-inline
       BlockContainer <div> at (11,11) content-size 250x250 children: not-inline
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x272]
     PaintableWithLines (BlockContainer<BODY>) [9,9 782x254]
       PaintableWithLines (BlockContainer<DIV>) [10,10 252x252]

--- a/Tests/LibWeb/Layout/expected/display-table-inline-children.txt
+++ b/Tests/LibWeb/Layout/expected/display-table-inline-children.txt
@@ -20,7 +20,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,608) content-size 784x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600] overflow: [0,0 1208x616]
+ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 1208x616]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x616] overflow: [0,0 1208x616]
     PaintableWithLines (BlockContainer(anonymous)) [0,0 800x0]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x600] overflow: [8,8 1200x600]

--- a/Tests/LibWeb/Layout/expected/div_align.txt
+++ b/Tests/LibWeb/Layout/expected/div_align.txt
@@ -78,7 +78,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,637.875) content-size 784x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x637.875]
+ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x637.875]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x637.875]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x609.875] overflow: [8,8 784.484375x629.875]
       PaintableWithLines (BlockContainer<DIV>) [8,8 784x137.46875]

--- a/Tests/LibWeb/Layout/expected/div_align_nested.txt
+++ b/Tests/LibWeb/Layout/expected/div_align_nested.txt
@@ -26,7 +26,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <(anonymous)> at (8,260.875) content-size 784x0 children: inline
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x252.875] overflow: [8,8 784.484375x252.875]
       PaintableWithLines (BlockContainer<DIV>) [8,8 784x252.875] overflow: [8,8 784.484375x252.875]

--- a/Tests/LibWeb/Layout/expected/flex-abspos-item-with-preceding-whitespace.txt
+++ b/Tests/LibWeb/Layout/expected/flex-abspos-item-with-preceding-whitespace.txt
@@ -7,7 +7,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <div.orange> at (48,-12) content-size 100x100 positioned [BFC] children: inline
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600] overflow: [0,-22 800x622]
+ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,-22 800x622]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x76] overflow: [10,-22 780x120]
     PaintableWithLines (BlockContainer<BODY>) [18,18 764x40] overflow: [28,-22 744x120]
       PaintableBox (Box<DIV>.pink) [28,28 744x20] overflow: [38,-22 120x120]

--- a/Tests/LibWeb/Layout/expected/flex-auto.txt
+++ b/Tests/LibWeb/Layout/expected/flex-auto.txt
@@ -28,7 +28,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,112) content-size 784x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x104]
       PaintableBox (Box<DIV>.container) [8,8 502x104] overflow: [9,9 500.015625x102]

--- a/Tests/LibWeb/Layout/expected/flex-column-constained-wrap.txt
+++ b/Tests/LibWeb/Layout/expected/flex-column-constained-wrap.txt
@@ -28,7 +28,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,260) content-size 784x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x252]
       PaintableBox (Box<DIV>.container.column) [8,8 252x252]

--- a/Tests/LibWeb/Layout/expected/flex-column-constrained-nowrap.txt
+++ b/Tests/LibWeb/Layout/expected/flex-column-constrained-nowrap.txt
@@ -28,7 +28,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,260) content-size 784x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x252]
       PaintableBox (Box<DIV>.container.column) [8,8 784x252]

--- a/Tests/LibWeb/Layout/expected/flex-column-height-constrained-width-constrained.txt
+++ b/Tests/LibWeb/Layout/expected/flex-column-height-constrained-width-constrained.txt
@@ -28,7 +28,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,260) content-size 784x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x252]
       PaintableBox (Box<DIV>.container.column) [8,8 252x252]

--- a/Tests/LibWeb/Layout/expected/flex-column-height-constrained.txt
+++ b/Tests/LibWeb/Layout/expected/flex-column-height-constrained.txt
@@ -28,7 +28,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,260) content-size 784x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x252]
       PaintableBox (Box<DIV>.container) [8,8 784x252]

--- a/Tests/LibWeb/Layout/expected/flex-column-height-unconstrained.txt
+++ b/Tests/LibWeb/Layout/expected/flex-column-height-unconstrained.txt
@@ -28,7 +28,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,316) content-size 784x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x308]
       PaintableBox (Box<DIV>.my-container.column) [8,8 784x308]

--- a/Tests/LibWeb/Layout/expected/flex-column-item-with-auto-height-and-max-width.txt
+++ b/Tests/LibWeb/Layout/expected/flex-column-item-with-auto-height-and-max-width.txt
@@ -19,7 +19,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             "Software Engineer at"
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x94.21875]
     PaintableBox (Box<BODY>) [1,1 798x92.21875]
       PaintableWithLines (BlockContainer<MAIN>) [2,2 402x90.21875]

--- a/Tests/LibWeb/Layout/expected/flex-column-item-with-auto-height-depending-auto-width-with-max-width-constraint.txt
+++ b/Tests/LibWeb/Layout/expected/flex-column-item-with-auto-height-depending-auto-width-with-max-width-constraint.txt
@@ -19,7 +19,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             "background."
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x333.5]
     PaintableBox (Box<BODY>.hero) [1,1 602x331.5]
       PaintableWithLines (BlockContainer<DIV>.header) [101,2 402x329.5]

--- a/Tests/LibWeb/Layout/expected/flex-column-item-with-auto-height-depending-on-auto-width.txt
+++ b/Tests/LibWeb/Layout/expected/flex-column-item-with-auto-height-depending-on-auto-width.txt
@@ -21,7 +21,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> (not painted) [BFC] children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x459.09375]
     PaintableBox (Box<BODY>.hero) [9,9 502x441.09375] overflow: [9,10 502x439.09375]
       PaintableWithLines (BlockContainer<DIV>.upper) [9,10 502x439.09375]

--- a/Tests/LibWeb/Layout/expected/flex-container-constrained-nowrap.txt
+++ b/Tests/LibWeb/Layout/expected/flex-container-constrained-nowrap.txt
@@ -28,7 +28,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,112) content-size 784x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x104]
       PaintableBox (Box<DIV>.container) [8,8 252x104]

--- a/Tests/LibWeb/Layout/expected/flex-container-constrained-wrap.txt
+++ b/Tests/LibWeb/Layout/expected/flex-container-constrained-wrap.txt
@@ -28,7 +28,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,214) content-size 784x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x206]
       PaintableBox (Box<DIV>.container) [8,8 252x206]

--- a/Tests/LibWeb/Layout/expected/flex-container-width-constrained.txt
+++ b/Tests/LibWeb/Layout/expected/flex-container-width-constrained.txt
@@ -28,7 +28,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,112) content-size 784x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x104]
       PaintableBox (Box<DIV>.container.width-constrained) [8,8 252x104]

--- a/Tests/LibWeb/Layout/expected/flex-frozen-items-should-be-respected.txt
+++ b/Tests/LibWeb/Layout/expected/flex-frozen-items-should-be-respected.txt
@@ -28,7 +28,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               "LongPieceOfText"
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x72]
     PaintableWithLines (BlockContainer<BODY>) [9,9 782x54]
       PaintableBox (Box<DIV>.flexbox) [10,10 780x52]

--- a/Tests/LibWeb/Layout/expected/flex-grow-0-column.txt
+++ b/Tests/LibWeb/Layout/expected/flex-grow-0-column.txt
@@ -28,7 +28,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,68.40625) content-size 784x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x60.40625]
       PaintableBox (Box<DIV>.container) [8,8 502x60.40625]

--- a/Tests/LibWeb/Layout/expected/flex-grow-1.txt
+++ b/Tests/LibWeb/Layout/expected/flex-grow-1.txt
@@ -28,7 +28,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,112) content-size 784x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x104]
       PaintableBox (Box<DIV>.container) [8,8 502x104]

--- a/Tests/LibWeb/Layout/expected/flex-grow-2.txt
+++ b/Tests/LibWeb/Layout/expected/flex-grow-2.txt
@@ -28,7 +28,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,112) content-size 784x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x104]
       PaintableBox (Box<DIV>.container) [8,8 502x104]

--- a/Tests/LibWeb/Layout/expected/flex-item-auto-height-with-wrap.txt
+++ b/Tests/LibWeb/Layout/expected/flex-item-auto-height-with-wrap.txt
@@ -10,7 +10,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> (not painted) [BFC] children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x116]
     PaintableBox (Box<BODY>.outer) [8,8 400x100]
       PaintableBox (Box<DIV>.inner) [8,8 400x17.46875]

--- a/Tests/LibWeb/Layout/expected/flex-item-on-row-with-intrinsic-aspect-ratio.txt
+++ b/Tests/LibWeb/Layout/expected/flex-item-on-row-with-intrinsic-aspect-ratio.txt
@@ -3,7 +3,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     Box <body> at (0,0) content-size 800x200 flex-container(row) [FFC] children: not-inline
       ImageBox <img> at (0,0) content-size 400x200 flex-item children: not-inline
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x200]
     PaintableBox (Box<BODY>) [0,0 800x200]
       ImagePaintable (ImageBox<IMG>) [0,0 400x200]

--- a/Tests/LibWeb/Layout/expected/flex-item-vertical-padding-relative-to-flex-container-width.txt
+++ b/Tests/LibWeb/Layout/expected/flex-item-vertical-padding-relative-to-flex-container-width.txt
@@ -14,7 +14,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x602]
+ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x602]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x602]
     PaintableWithLines (BlockContainer<BODY>) [9,9 782x14] overflow: [10,10 780x201]
       PaintableWithLines (BlockContainer(anonymous)) [10,10 780x0]

--- a/Tests/LibWeb/Layout/expected/flex-item-with-cyclic-percentage-height.txt
+++ b/Tests/LibWeb/Layout/expected/flex-item-with-cyclic-percentage-height.txt
@@ -9,7 +9,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 "pillow"
             TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x41.46875]
     PaintableWithLines (BlockContainer<BODY>) [9,9 782x23.46875]
       PaintableBox (Box<DIV>.flexrow) [10,10 780x21.46875]

--- a/Tests/LibWeb/Layout/expected/flex-item-with-intrinsic-aspect-ratio.txt
+++ b/Tests/LibWeb/Layout/expected/flex-item-with-intrinsic-aspect-ratio.txt
@@ -3,7 +3,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     Box <body> at (0,0) content-size 400x200 flex-container(column) [FFC] children: not-inline
       ImageBox <img> at (0,0) content-size 400x200 flex-item children: not-inline
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x200]
     PaintableBox (Box<BODY>) [0,0 400x200]
       ImagePaintable (ImageBox<IMG>) [0,0 400x200]

--- a/Tests/LibWeb/Layout/expected/flex-margin-auto-justify-content.txt
+++ b/Tests/LibWeb/Layout/expected/flex-margin-auto-justify-content.txt
@@ -20,7 +20,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,62) content-size 784x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x54]
       PaintableBox (Box<DIV>.container) [8,8 602x54]

--- a/Tests/LibWeb/Layout/expected/flex-row.txt
+++ b/Tests/LibWeb/Layout/expected/flex-row.txt
@@ -28,7 +28,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,112) content-size 784x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x104]
       PaintableBox (Box<DIV>.container) [8,8 784x104]

--- a/Tests/LibWeb/Layout/expected/flex-shrink-1.txt
+++ b/Tests/LibWeb/Layout/expected/flex-shrink-1.txt
@@ -37,7 +37,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,112) content-size 784x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x104]
       PaintableBox (Box<DIV>.container) [8,8 252x104]

--- a/Tests/LibWeb/Layout/expected/flex-shrink-2.txt
+++ b/Tests/LibWeb/Layout/expected/flex-shrink-2.txt
@@ -28,7 +28,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,112) content-size 784x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x104]
       PaintableBox (Box<DIV>.container) [8,8 502x104]

--- a/Tests/LibWeb/Layout/expected/flex-shrink-3.txt
+++ b/Tests/LibWeb/Layout/expected/flex-shrink-3.txt
@@ -28,7 +28,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,112) content-size 784x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x104]
       PaintableBox (Box<DIV>.container) [8,8 502x104]

--- a/Tests/LibWeb/Layout/expected/flex/abspos-flex-child-static-position-with-align-items.txt
+++ b/Tests/LibWeb/Layout/expected/flex/abspos-flex-child-static-position-with-align-items.txt
@@ -76,7 +76,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> (not painted) [BFC] children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x566]
     PaintableBox (Box<BODY>) [18,18 764x530]
       PaintableBox (Box<DIV>.outer.normal) [28,28 170x170] overflow: [38,38 170x150]

--- a/Tests/LibWeb/Layout/expected/flex/abspos-flex-child-static-position-with-justify-content.txt
+++ b/Tests/LibWeb/Layout/expected/flex/abspos-flex-child-static-position-with-justify-content.txt
@@ -260,7 +260,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (38,2918) content-size 724x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x2956]
+ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x2956]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x2956]
     PaintableWithLines (BlockContainer<BODY>) [23,23 754x2910]
       PaintableWithLines (BlockContainer(anonymous)) [38,38 724x0]

--- a/Tests/LibWeb/Layout/expected/flex/align-keywords-start-and-end.txt
+++ b/Tests/LibWeb/Layout/expected/flex/align-keywords-start-and-end.txt
@@ -30,7 +30,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (10,276.40625) content-size 780x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x286.40625]
     PaintableWithLines (BlockContainer<BODY>) [9,9 782x268.40625]
       PaintableBox (Box<DIV>.flex.row.align-start) [10,10 502x202]

--- a/Tests/LibWeb/Layout/expected/flex/align-self-end-crash.txt
+++ b/Tests/LibWeb/Layout/expected/flex/align-self-end-crash.txt
@@ -3,7 +3,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     Box <body> at (8,8) content-size 784x0 flex-container(row) [FFC] children: not-inline
       BlockContainer <div> at (8,8) content-size 0x0 flex-item [BFC] children: not-inline
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x16]
     PaintableBox (Box<BODY>) [8,8 784x0]
       PaintableWithLines (BlockContainer<DIV>) [8,8 0x0]

--- a/Tests/LibWeb/Layout/expected/flex/automatic-minimum-size-with-explicit-flex-basis-and-flex-container-with-max-content-main-size.txt
+++ b/Tests/LibWeb/Layout/expected/flex/automatic-minimum-size-with-explicit-flex-basis-and-flex-container-with-max-content-main-size.txt
@@ -7,7 +7,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             "hello"
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x70]
     PaintableBox (Box<BODY>.flex) [9,9 40.84375x52]
       PaintableWithLines (BlockContainer<DIV>.item) [10,10 38.84375x50]

--- a/Tests/LibWeb/Layout/expected/flex/box-baseline-with-inline-flex-empty-child.txt
+++ b/Tests/LibWeb/Layout/expected/flex/box-baseline-with-inline-flex-empty-child.txt
@@ -8,7 +8,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           BlockContainer <(anonymous)> at (22,22) content-size 0x0 [BFC] children: inline
             TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x44]
     PaintableWithLines (BlockContainer<BODY>) [9,9 782x26]
       PaintableWithLines (BlockContainer<DIV>.first) [10,10 780x24]

--- a/Tests/LibWeb/Layout/expected/flex/calc-flex-basis.txt
+++ b/Tests/LibWeb/Layout/expected/flex/calc-flex-basis.txt
@@ -23,7 +23,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               "Item 4"
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x82]
     PaintableWithLines (BlockContainer<BODY>) [9,9 782x64]
       PaintableBox (Box<DIV>.flex-container) [10,10 780x62]

--- a/Tests/LibWeb/Layout/expected/flex/cross-size-of-item-with-box-sizing-border-box-and-nonzero-padding.txt
+++ b/Tests/LibWeb/Layout/expected/flex/cross-size-of-item-with-box-sizing-border-box-and-nonzero-padding.txt
@@ -26,7 +26,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               "Pellentesque eget justo nulla. Duis consectetur imperdiet nisi, ac tincidunt urna blandit quis."
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x247.09375]
     PaintableWithLines (BlockContainer<BODY>) [9,9 782x229.09375]
       PaintableBox (Box<DIV>.outer.flex.flex-wrap) [10,10 780x227.09375]

--- a/Tests/LibWeb/Layout/expected/flex/flex-column-container-with-max-width-max-content.txt
+++ b/Tests/LibWeb/Layout/expected/flex/flex-column-container-with-max-width-max-content.txt
@@ -2,6 +2,6 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x16 [BFC] children: not-inline
     Box <body> at (8,8) content-size 0x0 flex-container(column) [FFC] children: not-inline
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x16]
     PaintableBox (Box<BODY>) [8,8 0x0]

--- a/Tests/LibWeb/Layout/expected/flex/flex-column-item-with-intrinsic-aspect-ratio-and-percentage-max-width.txt
+++ b/Tests/LibWeb/Layout/expected/flex/flex-column-item-with-intrinsic-aspect-ratio-and-percentage-max-width.txt
@@ -3,7 +3,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     Box <body> at (10,10) content-size 780x102 flex-container(column) [FFC] children: not-inline
       ImageBox <img> at (11,11) content-size 100x100 flex-item children: not-inline
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x122]
     PaintableBox (Box<BODY>) [9,9 782x104]
       ImagePaintable (ImageBox<IMG>) [10,10 102x102]

--- a/Tests/LibWeb/Layout/expected/flex/flex-column-item-with-natural-aspect-ratio-and-automatic-cross-size.txt
+++ b/Tests/LibWeb/Layout/expected/flex/flex-column-item-with-natural-aspect-ratio-and-automatic-cross-size.txt
@@ -4,7 +4,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       SVGSVGBox <svg> at (0,0) content-size 200x100 flex-item [SVG] children: not-inline
         SVGGeometryBox <rect> at (0,0) content-size 200x100 children: not-inline
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x100]
     PaintableBox (Box<BODY>) [0,0 800x100]
       SVGSVGPaintable (SVGSVGBox<svg>) [0,0 200x100]

--- a/Tests/LibWeb/Layout/expected/flex/flex-column-item-with-percentage-max-width.txt
+++ b/Tests/LibWeb/Layout/expected/flex/flex-column-item-with-percentage-max-width.txt
@@ -10,7 +10,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x122]
     PaintableWithLines (BlockContainer<BODY>) [9,9 56x104]
       PaintableBox (Box<DIV>.flex) [10,10 54x102]

--- a/Tests/LibWeb/Layout/expected/flex/flex-container-intrinsic-cross-size-with-max-content-main-size.txt
+++ b/Tests/LibWeb/Layout/expected/flex/flex-container-intrinsic-cross-size-with-max-content-main-size.txt
@@ -8,7 +8,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               "this text should be all on one line"
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x53.46875]
     PaintableWithLines (BlockContainer<BODY>.outer) [8,8 300.84375x37.46875]
       PaintableBox (Box<DIV>.inner) [18,18 280.84375x17.46875]

--- a/Tests/LibWeb/Layout/expected/flex/flex-container-with-max-width-and-negative-margin-in-same-axis.txt
+++ b/Tests/LibWeb/Layout/expected/flex/flex-container-with-max-width-and-negative-margin-in-same-axis.txt
@@ -6,7 +6,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           BlockContainer <(anonymous)> (not painted) [BFC] children: inline
             TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600] overflow: [-92,0 892x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [-92,0 892x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x116] overflow: [-92,0 892x116]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x100] overflow: [-92,8 884x100]
       PaintableWithLines (BlockContainer<DIV>#container-of-flex) [8,8 100x100] overflow: [-92,8 200x100]

--- a/Tests/LibWeb/Layout/expected/flex/flex-gap-between-items-and-lines.txt
+++ b/Tests/LibWeb/Layout/expected/flex/flex-gap-between-items-and-lines.txt
@@ -11,7 +11,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <div> at (12,228) content-size 30x30 flex-item [BFC] children: not-inline
         BlockContainer <div> at (64,228) content-size 30x30 flex-item [BFC] children: not-inline
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x602]
+ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x602]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x602]
     PaintableWithLines (BlockContainer<BODY>) [9,9 782x252]
       PaintableBox (Box<DIV>.flexbox) [10,10 102x250]

--- a/Tests/LibWeb/Layout/expected/flex/flex-item-min-width-fit-content.txt
+++ b/Tests/LibWeb/Layout/expected/flex/flex-item-min-width-fit-content.txt
@@ -21,7 +21,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               "Reject"
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x72]
     PaintableBox (Box<BODY>) [9,9 502x54]
       PaintableWithLines (BlockContainer<DIV>.big) [10,10 383.625x52]

--- a/Tests/LibWeb/Layout/expected/flex/flex-item-with-calc-main-size-and-layout-dependent-containing-block-size.txt
+++ b/Tests/LibWeb/Layout/expected/flex/flex-item-with-calc-main-size-and-layout-dependent-containing-block-size.txt
@@ -14,7 +14,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               "text"
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x69.34375]
     PaintableBox (Box<BODY>.pink) [8,8 784x53.34375]
       PaintableBox (Box<DIV>.orange) [8,8 194.71875x53.34375]

--- a/Tests/LibWeb/Layout/expected/flex/flex-item-with-intrinsic-aspect-ratio-and-max-height.txt
+++ b/Tests/LibWeb/Layout/expected/flex/flex-item-with-intrinsic-aspect-ratio-and-max-height.txt
@@ -5,7 +5,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> (not painted) [BFC] children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x72]
     PaintableBox (Box<BODY>) [9,9 782x54]
       ImagePaintable (ImageBox<IMG>) [10,10 68.671875x52]

--- a/Tests/LibWeb/Layout/expected/flex/flex-row-reverse-with-centered-content.txt
+++ b/Tests/LibWeb/Layout/expected/flex/flex-row-reverse-with-centered-content.txt
@@ -18,7 +18,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               "3"
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x66]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x50]
       PaintableBox (Box<DIV>.flex) [8,8 784x50]

--- a/Tests/LibWeb/Layout/expected/flex/flex-shorthand-flex-basis-zero-percent.txt
+++ b/Tests/LibWeb/Layout/expected/flex/flex-shorthand-flex-basis-zero-percent.txt
@@ -28,7 +28,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 "friends"
             TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x128]
     PaintableWithLines (BlockContainer<BODY>) [9,9 782x110]
       PaintableBox (Box<DIV>.flex) [10,10 502x54]

--- a/Tests/LibWeb/Layout/expected/flex/inf-available-space-with-auto-margins.txt
+++ b/Tests/LibWeb/Layout/expected/flex/inf-available-space-with-auto-margins.txt
@@ -7,7 +7,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             "hmmMMMMmmmmmm"
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x33.46875]
     PaintableBox (Box<BODY>) [8,8 784x17.46875]
       PaintableWithLines (BlockContainer<MAIN>) [8,8 784x17.46875]

--- a/Tests/LibWeb/Layout/expected/flex/inline-flex-with-main-axis-margin-on-flex-container.txt
+++ b/Tests/LibWeb/Layout/expected/flex/inline-flex-with-main-axis-margin-on-flex-container.txt
@@ -9,7 +9,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             "Immobilie inserieren"
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 502x39.46875]
     PaintableBox (Box<BODY>) [9,9 164.40625x21.46875]
       PaintableWithLines (BlockContainer<DIV>) [10,10 162.40625x19.46875]

--- a/Tests/LibWeb/Layout/expected/flex/intrinsic-height-of-column-items-with-different-kinds-of-width.txt
+++ b/Tests/LibWeb/Layout/expected/flex/intrinsic-height-of-column-items-with-different-kinds-of-width.txt
@@ -52,7 +52,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> (not painted) [BFC] children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x145.28125]
     PaintableBox (Box<BODY>) [9,9 782x127.28125]
       PaintableWithLines (BlockContainer<DIV>.px) [10,10 202x21.46875]

--- a/Tests/LibWeb/Layout/expected/flex/intrinsic-height-of-flex-container-with-svg-item-that-only-has-natural-aspect-ratio.txt
+++ b/Tests/LibWeb/Layout/expected/flex/intrinsic-height-of-flex-container-with-svg-item-that-only-has-natural-aspect-ratio.txt
@@ -4,7 +4,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       SVGSVGBox <svg> at (400,8) content-size 0x0 flex-item [SVG] children: not-inline
         SVGGeometryBox <rect> at (400,8) content-size 0x0 children: not-inline
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x16]
     PaintableBox (Box<BODY>) [8,8 784x0]
       SVGSVGPaintable (SVGSVGBox<svg>) [400,8 0x0]

--- a/Tests/LibWeb/Layout/expected/flex/justify-content-1.txt
+++ b/Tests/LibWeb/Layout/expected/flex/justify-content-1.txt
@@ -580,7 +580,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (10,5834) content-size 780x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x5844]
+ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x5844]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x5844]
     PaintableWithLines (BlockContainer<BODY>) [9,9 782x5826]
       PaintableWithLines (BlockContainer(anonymous)) [10,10 780x0]

--- a/Tests/LibWeb/Layout/expected/flex/justify-content-space-between-single-item.txt
+++ b/Tests/LibWeb/Layout/expected/flex/justify-content-space-between-single-item.txt
@@ -8,7 +8,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               "A"
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x17.46875]
       PaintableBox (Box<DIV>.container) [8,8 784x17.46875]

--- a/Tests/LibWeb/Layout/expected/flex/justify-content-with-margin-auto-child.txt
+++ b/Tests/LibWeb/Layout/expected/flex/justify-content-with-margin-auto-child.txt
@@ -292,7 +292,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (10,2922) content-size 780x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x2932]
+ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x2932]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x2932]
     PaintableWithLines (BlockContainer<BODY>) [9,9 782x2914]
       PaintableWithLines (BlockContainer(anonymous)) [10,10 780x0]

--- a/Tests/LibWeb/Layout/expected/flex/list-container-display-contents.txt
+++ b/Tests/LibWeb/Layout/expected/flex/list-container-display-contents.txt
@@ -13,7 +13,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               "Mac"
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x41.46875]
     PaintableWithLines (BlockContainer<BODY>) [8,16 784x17.46875]
       PaintableBox (Box<UL>.globalnav-list) [8,16 784x17.46875]

--- a/Tests/LibWeb/Layout/expected/flex/multi-line-column-container-with-automatic-height.txt
+++ b/Tests/LibWeb/Layout/expected/flex/multi-line-column-container-with-automatic-height.txt
@@ -6,7 +6,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <div> at (12,64) content-size 50x50 flex-item [BFC] children: not-inline
         BlockContainer <div> at (12,116) content-size 50x50 flex-item [BFC] children: not-inline
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x178]
     PaintableWithLines (BlockContainer<BODY>) [9,9 782x160]
       PaintableBox (Box<DIV>.flexbox) [10,10 202x158]

--- a/Tests/LibWeb/Layout/expected/flex/percentage-flex-basis-with-indefinite-flex-container-size.txt
+++ b/Tests/LibWeb/Layout/expected/flex/percentage-flex-basis-with-indefinite-flex-container-size.txt
@@ -8,7 +8,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               "percentages are hard"
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x33.46875]
     PaintableBox (Box<BODY>.outer) [8,8 200x17.46875]
       PaintableWithLines (BlockContainer<DIV>.middle) [8,8 200x17.46875]

--- a/Tests/LibWeb/Layout/expected/flex/relpos-flex-item.txt
+++ b/Tests/LibWeb/Layout/expected/flex/relpos-flex-item.txt
@@ -12,7 +12,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             "athena"
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x45.46875]
     PaintableBox (Box<BODY>) [10,10 604x25.46875] overflow: [12,12 600x25.46875]
       PaintableWithLines (BlockContainer<DIV>.exekiller) [12,12 204x21.46875]

--- a/Tests/LibWeb/Layout/expected/flex/reverse-flex-layout-with-space-between-and-space-around.txt
+++ b/Tests/LibWeb/Layout/expected/flex/reverse-flex-layout-with-space-between-and-space-around.txt
@@ -72,7 +72,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               "friends"
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x616]
+ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x616]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x616]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x600]
       PaintableBox (Box<DIV>.outer.row) [8,8 150x150]

--- a/Tests/LibWeb/Layout/expected/flex/specified-size-suggestion-with-box-sizing-border-box.txt
+++ b/Tests/LibWeb/Layout/expected/flex/specified-size-suggestion-with-box-sizing-border-box.txt
@@ -4,7 +4,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       ImageBox <img> at (0,0) content-size 400x100 flex-item children: not-inline
       ImageBox <img.padded> at (600,0) content-size 200x100 flex-item children: not-inline
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x100]
     PaintableBox (Box<BODY>) [0,0 800x100]
       ImagePaintable (ImageBox<IMG>) [0,0 400x100]

--- a/Tests/LibWeb/Layout/expected/flex/stretch-alignment-with-cross-gap.txt
+++ b/Tests/LibWeb/Layout/expected/flex/stretch-alignment-with-cross-gap.txt
@@ -9,7 +9,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <div> at (12,178.65625) content-size 100x20 flex-item [BFC] children: not-inline
         BlockContainer <div> at (114,178.65625) content-size 100x20 flex-item [BFC] children: not-inline
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x222]
     PaintableWithLines (BlockContainer<BODY>) [9,9 782x204]
       PaintableBox (Box<DIV>.flex) [10,10 302x202]

--- a/Tests/LibWeb/Layout/expected/floating-non-replaced-element-percentage-padding-against-indefinite-width.txt
+++ b/Tests/LibWeb/Layout/expected/floating-non-replaced-element-percentage-padding-against-indefinite-width.txt
@@ -5,7 +5,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <div> at (8,8) content-size 0x0 flex-item [BFC] children: not-inline
           Box <div#box2> at (8,8) content-size 0x0 floating flex-container(row) [FFC] children: not-inline
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x16]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x0]
       PaintableBox (Box<DIV>#box1) [8,8 784x0]

--- a/Tests/LibWeb/Layout/expected/floating-replaced-element-percentage-padding-against-indefinite-width.txt
+++ b/Tests/LibWeb/Layout/expected/floating-replaced-element-percentage-padding-against-indefinite-width.txt
@@ -5,7 +5,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <div> at (8,8) content-size 16x64 flex-item [BFC] children: not-inline
           ImageBox <img#box2> at (24,24) content-size 16x32 floating flex-container(row) children: not-inline
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x80]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x64]
       PaintableBox (Box<DIV>#box1) [8,8 784x64]

--- a/Tests/LibWeb/Layout/expected/font-with-many-normal-values.txt
+++ b/Tests/LibWeb/Layout/expected/font-with-many-normal-values.txt
@@ -29,7 +29,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
       TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x216]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x200]
       InlinePaintable (InlineNode<SPAN>.one)

--- a/Tests/LibWeb/Layout/expected/getComputedStyle-on-unconnected-element.txt
+++ b/Tests/LibWeb/Layout/expected/getComputedStyle-on-unconnected-element.txt
@@ -6,7 +6,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           "This test passes if we don't crash."
       TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x37.84375]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x21.84375]
       TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/grid/abspos-item.txt
+++ b/Tests/LibWeb/Layout/expected/grid/abspos-item.txt
@@ -13,7 +13,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               "more text"
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x17.46875]
       PaintableBox (Box<DIV>.outer-grid) [8,8 784x17.46875]

--- a/Tests/LibWeb/Layout/expected/grid/align-items.txt
+++ b/Tests/LibWeb/Layout/expected/grid/align-items.txt
@@ -41,7 +41,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               "End2"
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x264.40625]
     PaintableWithLines (BlockContainer<BODY>) [9,9 782x246.40625]
       PaintableWithLines (BlockContainer(anonymous)) [10,10 780x0]

--- a/Tests/LibWeb/Layout/expected/grid/align-self.txt
+++ b/Tests/LibWeb/Layout/expected/grid/align-self.txt
@@ -41,7 +41,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               "End2"
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x264.40625]
     PaintableWithLines (BlockContainer<BODY>) [9,9 782x246.40625]
       PaintableWithLines (BlockContainer(anonymous)) [10,10 780x0]

--- a/Tests/LibWeb/Layout/expected/grid/all-implicit-rows.txt
+++ b/Tests/LibWeb/Layout/expected/grid/all-implicit-rows.txt
@@ -35,7 +35,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,208) content-size 784x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x200]
       PaintableBox (Box<DIV>.grid-container) [8,8 784x200]

--- a/Tests/LibWeb/Layout/expected/grid/anonymous-inline-child.txt
+++ b/Tests/LibWeb/Layout/expected/grid/anonymous-inline-child.txt
@@ -8,7 +8,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               "hello"
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x17.46875]
       PaintableBox (Box<DIV>.grid) [8,8 784x17.46875]

--- a/Tests/LibWeb/Layout/expected/grid/auto-fill.txt
+++ b/Tests/LibWeb/Layout/expected/grid/auto-fill.txt
@@ -26,7 +26,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x17.46875]
       PaintableBox (Box<DIV>.grid-container) [8,8 784x17.46875]

--- a/Tests/LibWeb/Layout/expected/grid/auto-fit-collapse-empty-tracks.txt
+++ b/Tests/LibWeb/Layout/expected/grid/auto-fit-collapse-empty-tracks.txt
@@ -8,7 +8,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               "1"
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x97.46875]
       PaintableBox (Box<DIV>.container) [8,8 784x97.46875]

--- a/Tests/LibWeb/Layout/expected/grid/auto-fit.txt
+++ b/Tests/LibWeb/Layout/expected/grid/auto-fit.txt
@@ -26,7 +26,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x17.46875]
       PaintableBox (Box<DIV>.grid-container) [8,8 784x17.46875]

--- a/Tests/LibWeb/Layout/expected/grid/auto-track-sizes.txt
+++ b/Tests/LibWeb/Layout/expected/grid/auto-track-sizes.txt
@@ -7,7 +7,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <div#c3> at (8,8) content-size 83x41 [BFC] children: not-inline
         BlockContainer <div#c4> at (8,8) content-size 120x60 [BFC] children: not-inline
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x60]
       PaintableBox (Box<DIV>.grid) [8,8 784x60]

--- a/Tests/LibWeb/Layout/expected/grid/basic-2.txt
+++ b/Tests/LibWeb/Layout/expected/grid/basic-2.txt
@@ -13,7 +13,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               "Board"
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x17.46875]
       PaintableBox (Box<DIV>#grid) [8,8 784x17.46875]

--- a/Tests/LibWeb/Layout/expected/grid/basic.txt
+++ b/Tests/LibWeb/Layout/expected/grid/basic.txt
@@ -33,7 +33,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x34.9375]
       PaintableBox (Box<DIV>.grid-container) [8,8 784x34.9375]

--- a/Tests/LibWeb/Layout/expected/grid/borders.txt
+++ b/Tests/LibWeb/Layout/expected/grid/borders.txt
@@ -163,7 +163,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x428.28125] overflow: [8,8 784x435.75]
       PaintableBox (Box<DIV>.grid-container) [8,8 784x74.9375]

--- a/Tests/LibWeb/Layout/expected/grid/calc-track-size.txt
+++ b/Tests/LibWeb/Layout/expected/grid/calc-track-size.txt
@@ -10,7 +10,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,25.46875) content-size 784x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x17.46875]
       PaintableBox (Box<DIV>.grid-container) [8,8 784x17.46875]

--- a/Tests/LibWeb/Layout/expected/grid/column-1fr-1fr.txt
+++ b/Tests/LibWeb/Layout/expected/grid/column-1fr-1fr.txt
@@ -5,7 +5,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <div.test> at (8,8) content-size 100x100 [BFC] children: not-inline
           BlockContainer <div.big-child> at (8,8) content-size 500x100 children: not-inline
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x100]
       PaintableBox (Box<DIV>.grid) [8,8 100x100] overflow: [8,8 500x100]

--- a/Tests/LibWeb/Layout/expected/grid/column-auto-auto.txt
+++ b/Tests/LibWeb/Layout/expected/grid/column-auto-auto.txt
@@ -5,7 +5,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <div.test> at (8,8) content-size 500x100 [BFC] children: not-inline
           BlockContainer <div.big-child> at (8,8) content-size 500x100 children: not-inline
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x100]
       PaintableBox (Box<DIV>.grid) [8,8 100x100] overflow: [8,8 500x100]

--- a/Tests/LibWeb/Layout/expected/grid/different-column-sizes.txt
+++ b/Tests/LibWeb/Layout/expected/grid/different-column-sizes.txt
@@ -33,7 +33,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x34.9375]
       PaintableBox (Box<DIV>.grid-container) [8,8 784x34.9375]

--- a/Tests/LibWeb/Layout/expected/grid/distribute-extra-space-across-spanned-tracks.txt
+++ b/Tests/LibWeb/Layout/expected/grid/distribute-extra-space-across-spanned-tracks.txt
@@ -26,7 +26,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,25.46875) content-size 784x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x17.46875]
       PaintableBox (Box<DIV>.grid) [8,8 784x17.46875]

--- a/Tests/LibWeb/Layout/expected/grid/float-container-columns-1fr-1fr.txt
+++ b/Tests/LibWeb/Layout/expected/grid/float-container-columns-1fr-1fr.txt
@@ -23,7 +23,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               "goes-there"
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x0] overflow: [8,8 203.28125x34.9375]
       PaintableBox (Box<DIV>.container) [8,8 203.28125x34.9375]

--- a/Tests/LibWeb/Layout/expected/grid/floating-table-wrapper-width.txt
+++ b/Tests/LibWeb/Layout/expected/grid/floating-table-wrapper-width.txt
@@ -30,7 +30,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,35.46875) content-size 784x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x27.46875]
       PaintableBox (Box<DIV>.grid) [8,8 784x27.46875]

--- a/Tests/LibWeb/Layout/expected/grid/grid-gap-1.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-gap-1.txt
@@ -23,7 +23,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               "4"
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x84.9375]
       PaintableBox (Box<DIV>.grid-container) [8,8 784x84.9375]

--- a/Tests/LibWeb/Layout/expected/grid/grid-gap-2.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-gap-2.txt
@@ -13,7 +13,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               "2"
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x50.9375]
       PaintableBox (Box<DIV>.container) [8,8 784x50.9375]

--- a/Tests/LibWeb/Layout/expected/grid/grid-gap-3.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-gap-3.txt
@@ -8,7 +8,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               "1"
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x17.46875]
       PaintableBox (Box<DIV>.container) [8,8 784x17.46875]

--- a/Tests/LibWeb/Layout/expected/grid/grid-item-fixed-paddings.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-item-fixed-paddings.txt
@@ -35,7 +35,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,363.5) content-size 784x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x355.5]
       PaintableBox (Box<DIV>.grid-container) [8,8 784x355.5]

--- a/Tests/LibWeb/Layout/expected/grid/grid-item-fixed-size.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-item-fixed-size.txt
@@ -8,7 +8,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               "First"
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x200]
       PaintableBox (Box<DIV>.grid-container) [8,8 784x200]

--- a/Tests/LibWeb/Layout/expected/grid/grid-item-horizontal-margins-auto.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-item-horizontal-margins-auto.txt
@@ -115,7 +115,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (10,450.28125) content-size 780x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x460.28125]
     PaintableWithLines (BlockContainer<BODY>) [9,9 782x442.28125]
       PaintableBox (Box<DIV>.grid) [10,10 502x440.28125] overflow: [11,11 501.109375x438.28125]

--- a/Tests/LibWeb/Layout/expected/grid/grid-item-min-size.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-item-min-size.txt
@@ -13,7 +13,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               "second"
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x0] overflow: [8,8 102x204]
       PaintableBox (Box<DIV>.grid) [8,8 102x204]

--- a/Tests/LibWeb/Layout/expected/grid/grid-item-percentage-margins.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-item-percentage-margins.txt
@@ -9,7 +9,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 "A filthy t-shirt"
             TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x17.46875]
       PaintableWithLines (BlockContainer<DIV>) [8,8 784x17.46875]

--- a/Tests/LibWeb/Layout/expected/grid/grid-item-percentage-width-2.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-item-percentage-width-2.txt
@@ -59,7 +59,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               "tellus."
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x0] overflow: [8,8 200x315.40625]
       PaintableBox (Box<DIV>.container) [8,8 200x315.40625]

--- a/Tests/LibWeb/Layout/expected/grid/grid-item-percentage-width.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-item-percentage-width.txt
@@ -13,7 +13,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               "Second"
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x17.46875]
       PaintableBox (Box<DIV>.grid-container) [8,8 784x17.46875]

--- a/Tests/LibWeb/Layout/expected/grid/grid-item-with-fit-content-width.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-item-with-fit-content-width.txt
@@ -7,7 +7,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             "Press and Media"
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x39.46875]
     PaintableBox (Box<BODY>) [9,9 782x21.46875]
       PaintableWithLines (BlockContainer<DIV>.inner) [10,10 134.828125x19.46875]

--- a/Tests/LibWeb/Layout/expected/grid/grid-row-height-affected-by-item-margins.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-row-height-affected-by-item-margins.txt
@@ -7,7 +7,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             "Null publishes fine indie games"
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x99.8125]
     PaintableBox (Box<BODY>) [9,9 782x81.8125]
       PaintableWithLines (BlockContainer<H1>) [54.5,31.4375 691x36.9375]

--- a/Tests/LibWeb/Layout/expected/grid/grid-shorthand-property.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-shorthand-property.txt
@@ -4,7 +4,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       Box <div.container> at (8,8) content-size 784x100 [GFC] children: not-inline
         BlockContainer <div.item> at (8,8) content-size 200x100 [BFC] children: not-inline
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x100]
       PaintableBox (Box<DIV>.container) [8,8 784x100]

--- a/Tests/LibWeb/Layout/expected/grid/grid-span-4.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-span-4.txt
@@ -12,7 +12,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             "bar"
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x67.65625]
     PaintableBox (Box<BODY>) [9,9 782x49.65625]
       PaintableWithLines (BlockContainer<DIV>.foo) [10,10 780x23.8125] overflow: [11,11 778x21.84375]

--- a/Tests/LibWeb/Layout/expected/grid/grid-template-areas-basics.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-template-areas-basics.txt
@@ -18,7 +18,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               "right-top"
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x34.9375]
       PaintableBox (Box<DIV>.container) [8,8 784x34.9375]

--- a/Tests/LibWeb/Layout/expected/grid/grid-template-columns-with-min-css-function.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-template-columns-with-min-css-function.txt
@@ -7,7 +7,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             "hello friends"
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x56.9375]
     PaintableBox (Box<BODY>) [9,9 782x38.9375]
       PaintableWithLines (BlockContainer<H1>) [54.5,10 691x36.9375]

--- a/Tests/LibWeb/Layout/expected/grid/grid-template.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-template.txt
@@ -53,7 +53,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,208) content-size 784x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x200]
       PaintableBox (Box<DIV>.mw-page-container-inner) [8,8 784x0]

--- a/Tests/LibWeb/Layout/expected/grid/grow-beyond-limits.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grow-beyond-limits.txt
@@ -8,7 +8,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               "one"
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x33.46875]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x17.46875]
       PaintableBox (Box<DIV>.container) [8,8 784x17.46875]

--- a/Tests/LibWeb/Layout/expected/grid/image-in-grid.txt
+++ b/Tests/LibWeb/Layout/expected/grid/image-in-grid.txt
@@ -13,7 +13,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x24.015625]
       PaintableBox (Box<DIV>.grid-container) [8,8 784x24.015625]

--- a/Tests/LibWeb/Layout/expected/grid/inline-grid-simple.txt
+++ b/Tests/LibWeb/Layout/expected/grid/inline-grid-simple.txt
@@ -9,7 +9,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             "whf"
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x33.46875]
     PaintableBox (Box<BODY>) [8,8 26.953125x17.46875]
       PaintableWithLines (BlockContainer(anonymous)) [8,8 26.953125x17.46875]

--- a/Tests/LibWeb/Layout/expected/grid/intrinsic-sized-column.txt
+++ b/Tests/LibWeb/Layout/expected/grid/intrinsic-sized-column.txt
@@ -13,7 +13,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               "whee"
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x35.46875]
     PaintableWithLines (BlockContainer<BODY>) [8,8 20x19.46875] overflow: [8,8 38.953125x19.46875]
       PaintableWithLines (BlockContainer(anonymous)) [8,8 20x0]

--- a/Tests/LibWeb/Layout/expected/grid/intrinsic-sized-grid-2.txt
+++ b/Tests/LibWeb/Layout/expected/grid/intrinsic-sized-grid-2.txt
@@ -13,7 +13,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               "yeehaw"
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x32.46875]
     PaintableWithLines (BlockContainer<BODY>) [9,9 782x2] overflow: [10,10 98.421875x21.46875]
       PaintableBox (Box<DIV>.grid) [10,10 98.421875x21.46875]

--- a/Tests/LibWeb/Layout/expected/grid/intrinsic-sized-grid.txt
+++ b/Tests/LibWeb/Layout/expected/grid/intrinsic-sized-grid.txt
@@ -8,7 +8,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               "whee"
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x41.46875]
     PaintableWithLines (BlockContainer<BODY>) [9,9 43.953125x23.46875]
       PaintableBox (Box<DIV>.grid) [10,10 41.953125x21.46875]

--- a/Tests/LibWeb/Layout/expected/grid/item-column-span-2.txt
+++ b/Tests/LibWeb/Layout/expected/grid/item-column-span-2.txt
@@ -20,7 +20,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,43.40625) content-size 784x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x35.40625]
       PaintableBox (Box<DIV>.container) [8,8 784x35.40625]

--- a/Tests/LibWeb/Layout/expected/grid/item-min-max-percentage-width.txt
+++ b/Tests/LibWeb/Layout/expected/grid/item-min-max-percentage-width.txt
@@ -8,7 +8,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               "mincontent"
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x602]
+ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x602]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x602]
     PaintableWithLines (BlockContainer<BODY>) [9,9 782x23.46875]
       PaintableBox (Box<DIV>.grid-container) [10,10 780x21.46875]

--- a/Tests/LibWeb/Layout/expected/grid/item-span-exceeds-columns-size.txt
+++ b/Tests/LibWeb/Layout/expected/grid/item-span-exceeds-columns-size.txt
@@ -4,7 +4,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       Box <div.container> at (8,8) content-size 300x100 [GFC] children: not-inline
         BlockContainer <div.item> at (8,8) content-size 300x100 [BFC] children: not-inline
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x100]
       PaintableBox (Box<DIV>.container) [8,8 300x100]

--- a/Tests/LibWeb/Layout/expected/grid/justify-items.txt
+++ b/Tests/LibWeb/Layout/expected/grid/justify-items.txt
@@ -26,7 +26,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               "End"
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x84.40625]
     PaintableWithLines (BlockContainer<BODY>) [9,9 782x66.40625]
       PaintableWithLines (BlockContainer(anonymous)) [10,10 780x0]

--- a/Tests/LibWeb/Layout/expected/grid/justify-self.txt
+++ b/Tests/LibWeb/Layout/expected/grid/justify-self.txt
@@ -25,7 +25,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> (not painted) [BFC] children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x78.40625]
     PaintableBox (Box<BODY>) [9,9 782x60.40625]
       PaintableWithLines (BlockContainer<DIV>) [10,10 45.859375x19.46875]

--- a/Tests/LibWeb/Layout/expected/grid/justify-start-min-width.txt
+++ b/Tests/LibWeb/Layout/expected/grid/justify-start-min-width.txt
@@ -8,7 +8,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               "Start Selling"
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x33.46875]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x17.46875]
       PaintableBox (Box<DIV>#grid) [8,8 784x17.46875]

--- a/Tests/LibWeb/Layout/expected/grid/min-max-content.txt
+++ b/Tests/LibWeb/Layout/expected/grid/min-max-content.txt
@@ -26,7 +26,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x17.46875]
       PaintableBox (Box<DIV>.grid-container) [8,8 784x17.46875]

--- a/Tests/LibWeb/Layout/expected/grid/minmax-1.txt
+++ b/Tests/LibWeb/Layout/expected/grid/minmax-1.txt
@@ -13,7 +13,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               "2"
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x17.46875]
       PaintableBox (Box<DIV>.container) [8,8 784x17.46875]

--- a/Tests/LibWeb/Layout/expected/grid/minmax-2.txt
+++ b/Tests/LibWeb/Layout/expected/grid/minmax-2.txt
@@ -13,7 +13,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               "2"
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x100]
       PaintableBox (Box<DIV>.container) [8,8 784x100]

--- a/Tests/LibWeb/Layout/expected/grid/minmax-3.txt
+++ b/Tests/LibWeb/Layout/expected/grid/minmax-3.txt
@@ -18,7 +18,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               "3"
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x17.46875]
       PaintableBox (Box<DIV>.container) [8,8 784x17.46875]

--- a/Tests/LibWeb/Layout/expected/grid/minmax-auto-track-definition.txt
+++ b/Tests/LibWeb/Layout/expected/grid/minmax-auto-track-definition.txt
@@ -4,7 +4,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       Box <div.grid> at (8,8) content-size 200x200 [GFC] children: not-inline
         BlockContainer <div.item> at (8,8) content-size 100x100 [BFC] children: not-inline
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x200]
       PaintableBox (Box<DIV>.grid) [8,8 200x200]

--- a/Tests/LibWeb/Layout/expected/grid/minmax-invalid-1.txt
+++ b/Tests/LibWeb/Layout/expected/grid/minmax-invalid-1.txt
@@ -13,7 +13,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               "2"
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x34.9375]
       PaintableBox (Box<DIV>.container) [8,8 784x34.9375]

--- a/Tests/LibWeb/Layout/expected/grid/minmax-with-max-function-inside.txt
+++ b/Tests/LibWeb/Layout/expected/grid/minmax-with-max-function-inside.txt
@@ -23,7 +23,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               "d"
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x34.9375]
       PaintableBox (Box<DIV>.grid) [8,8 784x34.9375]

--- a/Tests/LibWeb/Layout/expected/grid/named-tracks.txt
+++ b/Tests/LibWeb/Layout/expected/grid/named-tracks.txt
@@ -89,7 +89,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x127.40625]
       PaintableBox (Box<DIV>.grid-container) [8,8 784x17.46875]

--- a/Tests/LibWeb/Layout/expected/grid/negative-grid-item-column-index.txt
+++ b/Tests/LibWeb/Layout/expected/grid/negative-grid-item-column-index.txt
@@ -70,7 +70,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,77.875) content-size 784x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x69.875]
       PaintableBox (Box<DIV>.grid) [8,8 784x69.875]

--- a/Tests/LibWeb/Layout/expected/grid/order.txt
+++ b/Tests/LibWeb/Layout/expected/grid/order.txt
@@ -28,7 +28,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (10,114) content-size 780x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x602]
+ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x602]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x602]
     PaintableWithLines (BlockContainer<BODY>) [9,9 782x106]
       PaintableBox (Box<DIV>.grid-container) [10,10 780x104]

--- a/Tests/LibWeb/Layout/expected/grid/place-items-center.txt
+++ b/Tests/LibWeb/Layout/expected/grid/place-items-center.txt
@@ -7,7 +7,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             "Download"
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x39.46875]
     PaintableBox (Box<BODY>) [9,9 782x21.46875]
       PaintableWithLines (BlockContainer<DIV>) [361.9375,10 76.125x19.46875]

--- a/Tests/LibWeb/Layout/expected/grid/place-self.txt
+++ b/Tests/LibWeb/Layout/expected/grid/place-self.txt
@@ -39,7 +39,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               "End2"
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x264.40625]
     PaintableWithLines (BlockContainer<BODY>) [9,9 782x246.40625]
       PaintableBox (Box<DIV>.grid) [10,10 780x81.46875]

--- a/Tests/LibWeb/Layout/expected/grid/positions-and-spans.txt
+++ b/Tests/LibWeb/Layout/expected/grid/positions-and-spans.txt
@@ -82,7 +82,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x169.875]
       PaintableBox (Box<DIV>.grid-container) [8,8 784x17.46875]

--- a/Tests/LibWeb/Layout/expected/grid/relpos-grid-item.txt
+++ b/Tests/LibWeb/Layout/expected/grid/relpos-grid-item.txt
@@ -12,7 +12,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             "athena"
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x66.9375]
     PaintableBox (Box<BODY>) [10,10 604x46.9375]
       PaintableWithLines (BlockContainer<DIV>.exekiller) [12,12 204x21.46875]

--- a/Tests/LibWeb/Layout/expected/grid/repeat.txt
+++ b/Tests/LibWeb/Layout/expected/grid/repeat.txt
@@ -82,7 +82,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x217.46875]
       PaintableBox (Box<DIV>.grid-container) [8,8 784x200]

--- a/Tests/LibWeb/Layout/expected/grid/row-1fr.txt
+++ b/Tests/LibWeb/Layout/expected/grid/row-1fr.txt
@@ -3,7 +3,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     Box <body> at (10,10) content-size 200x52 [GFC] children: not-inline
       BlockContainer <div.item> at (11,11) content-size 100x50 [BFC] children: not-inline
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x72]
     PaintableBox (Box<BODY>) [9,9 202x54]
       PaintableWithLines (BlockContainer<DIV>.item) [10,10 102x52]

--- a/Tests/LibWeb/Layout/expected/grid/row-height.txt
+++ b/Tests/LibWeb/Layout/expected/grid/row-height.txt
@@ -33,7 +33,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x67.46875]
       PaintableBox (Box<DIV>.grid-container) [8,8 784x67.46875]

--- a/Tests/LibWeb/Layout/expected/grid/row-span-2-maxcontent.txt
+++ b/Tests/LibWeb/Layout/expected/grid/row-span-2-maxcontent.txt
@@ -104,7 +104,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x315.40625] overflow: [8,8 785.46875x315.40625]
       PaintableBox (Box<DIV>.grid-container) [8,8 784x315.40625] overflow: [8,8 785.46875x315.40625]

--- a/Tests/LibWeb/Layout/expected/grid/row-span-2-mincontent.txt
+++ b/Tests/LibWeb/Layout/expected/grid/row-span-2-mincontent.txt
@@ -185,7 +185,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x560.0625]
       PaintableBox (Box<DIV>.grid-container) [8,8 784x560.0625]

--- a/Tests/LibWeb/Layout/expected/grid/row-span-2-with-gaps.txt
+++ b/Tests/LibWeb/Layout/expected/grid/row-span-2-with-gaps.txt
@@ -107,7 +107,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x352.34375] overflow: [8,8 785.46875x352.34375]
       PaintableBox (Box<DIV>.grid-container) [8,8 784x352.34375] overflow: [8,8 785.46875x352.34375]

--- a/Tests/LibWeb/Layout/expected/grid/row-span-2.txt
+++ b/Tests/LibWeb/Layout/expected/grid/row-span-2.txt
@@ -104,7 +104,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x315.40625] overflow: [8,8 785.46875x315.40625]
       PaintableBox (Box<DIV>.grid-container) [8,8 784x315.40625] overflow: [8,8 785.46875x315.40625]

--- a/Tests/LibWeb/Layout/expected/grid/rows-1fr-1fr.txt
+++ b/Tests/LibWeb/Layout/expected/grid/rows-1fr-1fr.txt
@@ -10,7 +10,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,42.9375) content-size 784x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x34.9375]
       PaintableBox (Box<DIV>.container) [8,8 784x34.9375]

--- a/Tests/LibWeb/Layout/expected/grid/should-not-cause-infinite-spinning-in-space-distribution.txt
+++ b/Tests/LibWeb/Layout/expected/grid/should-not-cause-infinite-spinning-in-space-distribution.txt
@@ -12,7 +12,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             "bar"
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x58.90625]
     PaintableBox (Box<BODY>) [9,9 782x40.90625]
       PaintableWithLines (BlockContainer<DIV>.foo) [10,10 780x19.4375] overflow: [11,11 778x17.46875]

--- a/Tests/LibWeb/Layout/expected/grid/template-lines-and-areas.txt
+++ b/Tests/LibWeb/Layout/expected/grid/template-lines-and-areas.txt
@@ -13,7 +13,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               "1fr"
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x17.46875]
       PaintableBox (Box<DIV>.grid) [8,8 784x17.46875]

--- a/Tests/LibWeb/Layout/expected/grid/track-size-calc-with-percentage.txt
+++ b/Tests/LibWeb/Layout/expected/grid/track-size-calc-with-percentage.txt
@@ -9,7 +9,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 "The 10 Most Anticipated Summer Movies of 2023"
             TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x17.46875]
       PaintableBox (Box<DIV>.ipc-page-grid) [8,8 784x17.46875]

--- a/Tests/LibWeb/Layout/expected/grid/two-items-spanning-one-1fr-row.txt
+++ b/Tests/LibWeb/Layout/expected/grid/two-items-spanning-one-1fr-row.txt
@@ -12,7 +12,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             "bar"
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x122]
     PaintableBox (Box<BODY>) [9,9 782x104]
       PaintableWithLines (BlockContainer<DIV>.foo) [10,10 102x102]

--- a/Tests/LibWeb/Layout/expected/grid/unresolvable-percentage-track.txt
+++ b/Tests/LibWeb/Layout/expected/grid/unresolvable-percentage-track.txt
@@ -9,7 +9,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 "hello"
             TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x17.46875]
       PaintableBox (Box<DIV>.ipc-page-grid) [8,8 784x17.46875]

--- a/Tests/LibWeb/Layout/expected/grid/valid-grid-areas-1.txt
+++ b/Tests/LibWeb/Layout/expected/grid/valid-grid-areas-1.txt
@@ -8,7 +8,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               "1fr"
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x17.46875]
       PaintableBox (Box<DIV>.grid-container) [8,8 784x17.46875]

--- a/Tests/LibWeb/Layout/expected/grid/vertical-margins-auto.txt
+++ b/Tests/LibWeb/Layout/expected/grid/vertical-margins-auto.txt
@@ -8,7 +8,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               "item"
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x522]
     PaintableWithLines (BlockContainer<BODY>) [9,9 782x504]
       PaintableBox (Box<DIV>.container) [10,10 502x502]

--- a/Tests/LibWeb/Layout/expected/height-of-absolute-position-box-with-padding.txt
+++ b/Tests/LibWeb/Layout/expected/height-of-absolute-position-box-with-padding.txt
@@ -11,7 +11,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
       TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x16]
     PaintableWithLines (BlockContainer(anonymous)) [0,0 800x0]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x0]

--- a/Tests/LibWeb/Layout/expected/image-display-block-margin-auto.txt
+++ b/Tests/LibWeb/Layout/expected/image-display-block-margin-auto.txt
@@ -3,7 +3,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 400x100 children: not-inline
       ImageBox <img> at (158,8) content-size 100x100 children: not-inline
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x116]
     PaintableWithLines (BlockContainer<BODY>) [8,8 400x100]
       ImagePaintable (ImageBox<IMG>) [158,8 100x100]

--- a/Tests/LibWeb/Layout/expected/image-with-multiple-constraint-violations.txt
+++ b/Tests/LibWeb/Layout/expected/image-with-multiple-constraint-violations.txt
@@ -5,7 +5,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         frag 0 from ImageBox start: 0, length: 0, rect: [11,11 80x60]
       ImageBox <img> at (11,11) content-size 80x60 children: not-inline
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x82]
     PaintableWithLines (BlockContainer<BODY>) [9,9 782x64]
       ImagePaintable (ImageBox<IMG>) [10,10 82x62]

--- a/Tests/LibWeb/Layout/expected/img-with-box-sizing-border-box-and-padding.txt
+++ b/Tests/LibWeb/Layout/expected/img-with-box-sizing-border-box-and-padding.txt
@@ -8,7 +8,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       ImageBox <img.with-width> at (129,29) content-size 58x58 children: not-inline
       TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x116]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x100]
       ImagePaintable (ImageBox<IMG>.with-height) [8,8 100x100]

--- a/Tests/LibWeb/Layout/expected/img-with-percentage-max-width-and-indefinite-containing-block-width.txt
+++ b/Tests/LibWeb/Layout/expected/img-with-percentage-max-width-and-indefinite-containing-block-width.txt
@@ -6,7 +6,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           frag 0 from ImageBox start: 0, length: 0, rect: [8,8 120x120]
         ImageBox <img> at (8,8) content-size 120x120 children: not-inline
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x136]
     PaintableWithLines (BlockContainer<BODY>) [8,8 120x120]
       PaintableWithLines (BlockContainer<DIV>) [8,8 120x120]

--- a/Tests/LibWeb/Layout/expected/img-with-percentage-max-width-and-min-content-containing-block-width.txt
+++ b/Tests/LibWeb/Layout/expected/img-with-percentage-max-width-and-min-content-containing-block-width.txt
@@ -5,7 +5,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         frag 0 from ImageBox start: 0, length: 0, rect: [8,21 0x0]
       ImageBox <img> at (8,21) content-size 0x0 children: not-inline
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x33.46875]
     PaintableWithLines (BlockContainer<BODY>) [8,8 0x17.46875]
       ImagePaintable (ImageBox<IMG>) [8,21 0x0]

--- a/Tests/LibWeb/Layout/expected/inline-size.txt
+++ b/Tests/LibWeb/Layout/expected/inline-size.txt
@@ -19,7 +19,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,632.84375) content-size 784x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x632.84375]
+ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x632.84375]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x570.84375] overflow: [0,0 800x632.84375]
     PaintableWithLines (BlockContainer<BODY>) [8,70 784x492.84375] overflow: [8,70 784x562.84375]
       PaintableWithLines (BlockContainer<P>.min-inline-test) [8,70 784x200]

--- a/Tests/LibWeb/Layout/expected/input-element-with-display-inline.txt
+++ b/Tests/LibWeb/Layout/expected/input-element-with-display-inline.txt
@@ -8,7 +8,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           BlockContainer <div> at (14,13) content-size 0x21.84375 flex-item [BFC] children: inline
             TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x47.84375]
     PaintableWithLines (BlockContainer<BODY>) [9,9 782x29.84375]
       PaintableWithLines (BlockContainer<INPUT>) [10,10 202x27.84375]

--- a/Tests/LibWeb/Layout/expected/input-text-node-invalidation-on-value-change.txt
+++ b/Tests/LibWeb/Layout/expected/input-text-node-invalidation-on-value-change.txt
@@ -13,7 +13,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       TextNode <#text>
       TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x21.46875]
       PaintableWithLines (BlockContainer<INPUT>#foo) [8,8 120x21.46875]

--- a/Tests/LibWeb/Layout/expected/inset-shorthand-property.txt
+++ b/Tests/LibWeb/Layout/expected/inset-shorthand-property.txt
@@ -14,7 +14,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,208) content-size 784x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x216]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x200]
       PaintableWithLines (BlockContainer<DIV>.parent) [8,8 200x200]

--- a/Tests/LibWeb/Layout/expected/lh-1.txt
+++ b/Tests/LibWeb/Layout/expected/lh-1.txt
@@ -5,7 +5,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <div#b> at (8,8) content-size 100x100 children: inline
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x116]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x100]
       PaintableWithLines (BlockContainer<DIV>#a) [8,8 100x100]

--- a/Tests/LibWeb/Layout/expected/lh-2.txt
+++ b/Tests/LibWeb/Layout/expected/lh-2.txt
@@ -5,7 +5,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <div#b> at (8,8) content-size 100x100 children: inline
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x116]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x100]
       PaintableWithLines (BlockContainer<DIV>#a) [8,8 100x100]

--- a/Tests/LibWeb/Layout/expected/line-height-calc-number.txt
+++ b/Tests/LibWeb/Layout/expected/line-height-calc-number.txt
@@ -7,7 +7,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             "hello friends"
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x80]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x64]
       PaintableWithLines (BlockContainer<DIV>) [8,8 784x64]

--- a/Tests/LibWeb/Layout/expected/link-sheet.txt
+++ b/Tests/LibWeb/Layout/expected/link-sheet.txt
@@ -3,7 +3,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x0 children: not-inline
       BlockContainer <div#foo> at (0,0) content-size 123x456 positioned [BFC] children: not-inline
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x16] overflow: [0,0 800x456]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x0] overflow: [0,0 123x456]
       PaintableWithLines (BlockContainer<DIV>#foo) [0,0 123x456]

--- a/Tests/LibWeb/Layout/expected/misc/grid-template-block-components-whitespace-crash.txt
+++ b/Tests/LibWeb/Layout/expected/misc/grid-template-block-components-whitespace-crash.txt
@@ -2,6 +2,6 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x0 children: not-inline
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x0]

--- a/Tests/LibWeb/Layout/expected/misc/percentage-stroke-width-crash.txt
+++ b/Tests/LibWeb/Layout/expected/misc/percentage-stroke-width-crash.txt
@@ -2,6 +2,6 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x16 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x0 children: not-inline
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x16]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x0]

--- a/Tests/LibWeb/Layout/expected/misc/scroll.txt
+++ b/Tests/LibWeb/Layout/expected/misc/scroll.txt
@@ -4,7 +4,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <div#scrollbox> at (9,9) content-size 200x200 [BFC] children: not-inline
         BlockContainer <div#content> at (9,9) content-size 200x1000 children: not-inline
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x202]
       PaintableWithLines (BlockContainer<DIV>#scrollbox) [8,8 202x202] overflow: [9,9 200x1000] scroll-offset: [0,100]

--- a/Tests/LibWeb/Layout/expected/negative-max-size.txt
+++ b/Tests/LibWeb/Layout/expected/negative-max-size.txt
@@ -7,7 +7,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             "Well, hello friends!"
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x35.46875]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x19.46875]
       PaintableWithLines (BlockContainer<DIV>) [8,8 784x19.46875]

--- a/Tests/LibWeb/Layout/expected/non-floating-non-replaced-element-percentage-padding-against-indefinite-width.txt
+++ b/Tests/LibWeb/Layout/expected/non-floating-non-replaced-element-percentage-padding-against-indefinite-width.txt
@@ -5,7 +5,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <div> at (8,8) content-size 0x0 flex-item [BFC] children: not-inline
           Box <div#box2> at (8,8) content-size 0x0 flex-container(row) [FFC] children: not-inline
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x16]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x0]
       PaintableBox (Box<DIV>#box1) [8,8 784x0]

--- a/Tests/LibWeb/Layout/expected/overflow-x-hidden-with-border-radius.txt
+++ b/Tests/LibWeb/Layout/expected/overflow-x-hidden-with-border-radius.txt
@@ -5,7 +5,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,110) content-size 784x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x102]
       PaintableWithLines (BlockContainer<DIV>.box) [8,8 102x102]

--- a/Tests/LibWeb/Layout/expected/percentage-max-height-when-containing-block-has-indefinite-height.txt
+++ b/Tests/LibWeb/Layout/expected/percentage-max-height-when-containing-block-has-indefinite-height.txt
@@ -45,7 +45,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (10,115.34375) content-size 780x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x125.34375]
     PaintableWithLines (BlockContainer<BODY>) [9,9 782x107.34375]
       PaintableWithLines (BlockContainer<DIV>.block.formatting-context) [10,10 780x21.46875]

--- a/Tests/LibWeb/Layout/expected/picture-source-media-query.txt
+++ b/Tests/LibWeb/Layout/expected/picture-source-media-query.txt
@@ -12,7 +12,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
       TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x416]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x400]
       InlinePaintable (InlineNode<PICTURE>)

--- a/Tests/LibWeb/Layout/expected/place-content-shorthand-property.txt
+++ b/Tests/LibWeb/Layout/expected/place-content-shorthand-property.txt
@@ -8,7 +8,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               "Text"
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600] overflow: [0,0 812x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 812x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x39.46875] overflow: [1,1 811x37.46875]
     PaintableWithLines (BlockContainer<BODY>) [9,9 782x21.46875] overflow: [10,10 802x19.46875]
       PaintableBox (Box<DIV>.container) [10,10 802x19.46875]

--- a/Tests/LibWeb/Layout/expected/position-absolute-from-edges.txt
+++ b/Tests/LibWeb/Layout/expected/position-absolute-from-edges.txt
@@ -13,7 +13,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
       TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x0]
       PaintableWithLines (BlockContainer<DIV>#container) [8,8 540x440]

--- a/Tests/LibWeb/Layout/expected/position-absolute-ignores-padding-of-position-relative-floating-parent.txt
+++ b/Tests/LibWeb/Layout/expected/position-absolute-ignores-padding-of-position-relative-floating-parent.txt
@@ -5,7 +5,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <div#container> at (18,18) content-size 0x0 positioned floating [BFC] children: not-inline
           BlockContainer <div#box> at (8,8) content-size 100x100 positioned [BFC] children: not-inline
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x216]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x200]
       PaintableWithLines (BlockContainer<DIV>#guide) [8,8 200x200]

--- a/Tests/LibWeb/Layout/expected/position-absolute-top-left.txt
+++ b/Tests/LibWeb/Layout/expected/position-absolute-top-left.txt
@@ -35,7 +35,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,608) content-size 784x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x616]
+ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x616]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x616]
     PaintableWithLines (BlockContainer(anonymous)) [0,0 800x0]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x600]

--- a/Tests/LibWeb/Layout/expected/position-empty-pseudo-elements.txt
+++ b/Tests/LibWeb/Layout/expected/position-empty-pseudo-elements.txt
@@ -10,7 +10,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,175) content-size 784x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x158] overflow: [0,0 800x175]
     PaintableWithLines (BlockContainer<BODY>) [8,25 784x125] overflow: [8,25 784x150]
       PaintableWithLines (BlockContainer<DIV>.empty_content) [33,25 50x50]

--- a/Tests/LibWeb/Layout/expected/pre.txt
+++ b/Tests/LibWeb/Layout/expected/pre.txt
@@ -8,7 +8,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
       TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x17.46875]
       InlinePaintable (InlineNode<PRE>)

--- a/Tests/LibWeb/Layout/expected/pseudo-element-with-custom-properties-2.txt
+++ b/Tests/LibWeb/Layout/expected/pseudo-element-with-custom-properties-2.txt
@@ -50,7 +50,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,462.28125) content-size 784x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x470.28125]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x454.28125]
       PaintableWithLines (BlockContainer(anonymous)) [8,8 784x21.84375]

--- a/Tests/LibWeb/Layout/expected/pseudo-element-with-custom-properties.txt
+++ b/Tests/LibWeb/Layout/expected/pseudo-element-with-custom-properties.txt
@@ -5,7 +5,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <(anonymous)> at (8,8) content-size 500x100 positioned [BFC] children: inline
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x16] overflow: [0,0 800x108]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x0] overflow: [8,8 784x100]
       PaintableWithLines (BlockContainer<DIV>.hello) [8,8 784x0] overflow: [8,8 500x100]

--- a/Tests/LibWeb/Layout/expected/replaced-box-with-vertical-margins.txt
+++ b/Tests/LibWeb/Layout/expected/replaced-box-with-vertical-margins.txt
@@ -11,7 +11,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       ImageBox <img#image> at (51,33) content-size 64x138 children: not-inline
       TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x216.46875]
       TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/resolve-cyclic-percentage-against-zero-when-available-size-is-min-content.txt
+++ b/Tests/LibWeb/Layout/expected/resolve-cyclic-percentage-against-zero-when-available-size-is-min-content.txt
@@ -26,7 +26,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (10,1243.46875) content-size 780x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x1253.46875]
+ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x1253.46875]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x1253.46875]
     PaintableWithLines (BlockContainer<BODY>) [9,9 782x1235.46875]
       PaintableWithLines (BlockContainer<DIV>.w.min) [10,10 4x19.46875] overflow: [11,11 3x17.46875]

--- a/Tests/LibWeb/Layout/expected/resolve-height-of-containing-block.txt
+++ b/Tests/LibWeb/Layout/expected/resolve-height-of-containing-block.txt
@@ -25,7 +25,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,816) content-size 784x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600] overflow: [0,0 1288x824]
+ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 1288x824]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x824] overflow: [0,0 1288x824]
     PaintableWithLines (BlockContainer(anonymous)) [0,0 800x0]
     PaintableWithLines (BlockContainer<BODY>) [8,16 784x800] overflow: [8,16 1280x800]

--- a/Tests/LibWeb/Layout/expected/set-margin-of-floating-box.txt
+++ b/Tests/LibWeb/Layout/expected/set-margin-of-floating-box.txt
@@ -15,7 +15,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,49.46875) content-size 784x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x116]
     PaintableWithLines (BlockContainer(anonymous)) [0,0 800x0]
     PaintableWithLines (BlockContainer<BODY>) [8,16 784x17.46875] overflow: [8,16 784x33.46875]

--- a/Tests/LibWeb/Layout/expected/svg-preserve-aspect-ratio.txt
+++ b/Tests/LibWeb/Layout/expected/svg-preserve-aspect-ratio.txt
@@ -104,7 +104,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
       TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x257.46875]
       SVGSVGPaintable (SVGSVGBox<svg>) [8,83 102x52]

--- a/Tests/LibWeb/Layout/expected/svg-transforms-and-viewboxes.txt
+++ b/Tests/LibWeb/Layout/expected/svg-transforms-and-viewboxes.txt
@@ -95,7 +95,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
       TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x700]
+ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x700]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x700]
     PaintableWithLines (BlockContainer<BODY>) [50,50 700x600]
       SVGSVGPaintable (SVGSVGBox<svg>) [50,150 200x100]

--- a/Tests/LibWeb/Layout/expected/svg/dont-stretch-fit-svg-with-indefinite-containing-block-width.txt
+++ b/Tests/LibWeb/Layout/expected/svg/dont-stretch-fit-svg-with-indefinite-containing-block-width.txt
@@ -5,7 +5,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,21 0x0]
       SVGSVGBox <svg> at (8,21) content-size 0x0 [SVG] children: not-inline
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x33.46875]
     PaintableWithLines (BlockContainer<BODY>) [8,8 0x17.46875]
       SVGSVGPaintable (SVGSVGBox<svg>) [8,21 0x0]

--- a/Tests/LibWeb/Layout/expected/svg/mask-element-should-not-participate-in-layout.txt
+++ b/Tests/LibWeb/Layout/expected/svg/mask-element-should-not-participate-in-layout.txt
@@ -10,7 +10,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
       TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x116]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x100]
       SVGSVGPaintable (SVGSVGBox<svg>) [8,8 100x100]

--- a/Tests/LibWeb/Layout/expected/svg/svg-as-image-implicit-viewbox.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-as-image-implicit-viewbox.txt
@@ -7,7 +7,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           SVGSVGBox <svg> at (0,0) content-size 50x100 [SVG] children: not-inline
             SVGGeometryBox <rect> at (0,0) content-size 50x100 children: not-inline
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x116]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x100]
       ImagePaintable (ImageBox<IMG>) [8,8 50x100]

--- a/Tests/LibWeb/Layout/expected/svg/svg-as-image-invalid.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-as-image-invalid.txt
@@ -3,7 +3,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x32 children: not-inline
       ImageBox <img> at (8,8) content-size 16x32 children: not-inline
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x48]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x32]
       ImagePaintable (ImageBox<IMG>) [8,8 16x32]

--- a/Tests/LibWeb/Layout/expected/svg/svg-as-image.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-as-image.txt
@@ -9,7 +9,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             SVGGeometryBox <rect> at (0,0) content-size 784x1568 children: not-inline
             TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x1584]
+ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x1584]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x1584]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x1568]
       ImagePaintable (ImageBox<IMG>) [8,8 784x1568]

--- a/Tests/LibWeb/Layout/expected/svg/svg-different-types-of-opacity.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-different-types-of-opacity.txt
@@ -9,7 +9,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
       TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x800]
+ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x800]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x800]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x784]
       SVGSVGPaintable (SVGSVGBox<svg>) [8,8 784x784]

--- a/Tests/LibWeb/Layout/expected/svg/svg-fill-with-bogus-url.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-fill-with-bogus-url.txt
@@ -6,7 +6,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       SVGSVGBox <svg> at (8,8) content-size 784x784 [SVG] children: not-inline
         SVGGeometryBox <rect> at (8,8) content-size 784x784 children: not-inline
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x800]
+ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x800]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x800]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x784]
       SVGSVGPaintable (SVGSVGBox<svg>) [8,8 784x784]

--- a/Tests/LibWeb/Layout/expected/svg/svg-g-with-opacity.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-g-with-opacity.txt
@@ -14,7 +14,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
       TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x800]
+ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x800]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x800]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x784]
       SVGSVGPaintable (SVGSVGBox<svg>) [8,8 784x784]

--- a/Tests/LibWeb/Layout/expected/svg/svg-inside-svg.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-inside-svg.txt
@@ -9,7 +9,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             SVGGeometryBox <rect> at (8,8) content-size 24x24 children: not-inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x40]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x24]
       SVGSVGPaintable (SVGSVGBox<svg>) [8,8 24x24]

--- a/Tests/LibWeb/Layout/expected/svg/svg-intrinsic-size-in-one-dimension.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-intrinsic-size-in-one-dimension.txt
@@ -6,7 +6,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       SVGSVGBox <svg> at (9,61) content-size 200x100 [SVG] children: not-inline
         SVGGeometryBox <rect> at (34,86) content-size 150x50 children: not-inline
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x170]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x154]
       SVGSVGPaintable (SVGSVGBox<svg>) [8,8 102x52]

--- a/Tests/LibWeb/Layout/expected/svg/svg-negative-elliptical-arg-number.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-negative-elliptical-arg-number.txt
@@ -6,7 +6,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       SVGSVGBox <svg> at (8,8) content-size 100x100 [SVG] children: not-inline
         SVGGeometryBox <path> at (8,10) content-size 100x48 children: not-inline
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x116]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x100]
       SVGSVGPaintable (SVGSVGBox<svg>) [8,8 100x100]

--- a/Tests/LibWeb/Layout/expected/svg/svg-path-with-implicit-lineto.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-path-with-implicit-lineto.txt
@@ -6,7 +6,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       SVGSVGBox <svg> at (8,8) content-size 100x100 [SVG] children: not-inline
         SVGGeometryBox <path> at (28,28) content-size 60x60 children: not-inline
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x116]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x100]
       SVGSVGPaintable (SVGSVGBox<svg>) [8,8 100x100]

--- a/Tests/LibWeb/Layout/expected/svg/svg-symbol-with-viewbox.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-symbol-with-viewbox.txt
@@ -19,7 +19,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x150]
       PaintableWithLines (BlockContainer(anonymous)) [8,8 784x0]

--- a/Tests/LibWeb/Layout/expected/svg/svg-symbol-with-viewbox.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-symbol-with-viewbox.txt
@@ -10,8 +10,8 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
         SVGSVGBox <svg> at (8,8) content-size 300x150 [SVG] children: inline
           TextNode <#text>
-          InlineNode <use>
-            InlineNode <symbol#braces>
+          Box <use> at (8,8) content-size 0x0 children: inline
+            Box <symbol#braces> at (8,8) content-size 0x0 children: inline
               TextNode <#text>
               SVGGeometryBox <path> at (92.375,26.75) content-size 131.25x112.15625 children: inline
                 TextNode <#text>
@@ -25,3 +25,6 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
       PaintableWithLines (BlockContainer(anonymous)) [8,8 784x0]
       PaintableWithLines (BlockContainer<DIV>) [8,8 784x150]
         SVGSVGPaintable (SVGSVGBox<svg>) [8,8 300x150]
+          PaintableBox (Box<use>) [8,8 0x0]
+            PaintableBox (Box<symbol>#braces) [8,8 0x0]
+              SVGGeometryPaintable (SVGGeometryBox<path>) [92.375,26.75 131.25x112.15625]

--- a/Tests/LibWeb/Layout/expected/svg/svg-with-css-variable-in-presentation-hint.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-with-css-variable-in-presentation-hint.txt
@@ -6,7 +6,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       SVGSVGBox <svg> at (9,9) content-size 100x100 [SVG] children: not-inline
         SVGGeometryBox <rect> at (29,29) content-size 60x60 children: not-inline
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x118]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x102]
       SVGSVGPaintable (SVGSVGBox<svg>) [8,8 102x102]

--- a/Tests/LibWeb/Layout/expected/svg/svg-with-display-block.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-with-display-block.txt
@@ -4,7 +4,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       SVGSVGBox <svg> at (8,8) content-size 784x784 [SVG] children: not-inline
         SVGGeometryBox <rect> at (8,8) content-size 784x784 children: not-inline
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x800]
+ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x800]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x800]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x784]
       SVGSVGPaintable (SVGSVGBox<svg>) [8,8 784x784]

--- a/Tests/LibWeb/Layout/expected/svg/svg-with-zero-intrinsic-size-and-no-viewbox.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-with-zero-intrinsic-size-and-no-viewbox.txt
@@ -20,7 +20,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
       TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x17.46875]
       ImagePaintable (ImageBox<IMG>) [8,21 0x0]

--- a/Tests/LibWeb/Layout/expected/svg/text-fill-none.txt
+++ b/Tests/LibWeb/Layout/expected/svg/text-fill-none.txt
@@ -7,7 +7,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         SVGTextBox <text> at (8,8) content-size 0x0 children: not-inline
       TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x150]
       SVGSVGPaintable (SVGSVGBox<svg>) [8,8 300x150]

--- a/Tests/LibWeb/Layout/expected/table/align-top-and-bottom.txt
+++ b/Tests/LibWeb/Layout/expected/table/align-top-and-bottom.txt
@@ -45,7 +45,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x100.9375]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 200.328125x100.9375]

--- a/Tests/LibWeb/Layout/expected/table/auto-height.txt
+++ b/Tests/LibWeb/Layout/expected/table/auto-height.txt
@@ -22,7 +22,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (10,52.9375) content-size 780x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x62.9375]
     PaintableWithLines (BlockContainer<BODY>) [9,9 782x44.9375]
       PaintableWithLines (BlockContainer<DIV>) [10,10 780x21.46875]

--- a/Tests/LibWeb/Layout/expected/table/auto-margins.txt
+++ b/Tests/LibWeb/Layout/expected/table/auto-margins.txt
@@ -11,7 +11,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                     "DaTa DisplaYiNg CSS WeBpaGE ScReEn"
                 TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x17.46875]
       PaintableWithLines (BlockContainer<DIV>.wrapper) [8,8 784x17.46875]

--- a/Tests/LibWeb/Layout/expected/table/avoid-div-by-zero-in-table-measures.txt
+++ b/Tests/LibWeb/Layout/expected/table/avoid-div-by-zero-in-table-measures.txt
@@ -23,7 +23,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x23.46875]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 6x23.46875] overflow: [8,8 17.265625x23.46875]

--- a/Tests/LibWeb/Layout/expected/table/basic.txt
+++ b/Tests/LibWeb/Layout/expected/table/basic.txt
@@ -71,7 +71,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,93.875) content-size 784x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x85.875]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 2x2]

--- a/Tests/LibWeb/Layout/expected/table/border-collapse-is-inherited.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-collapse-is-inherited.txt
@@ -153,7 +153,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,207.34375) content-size 784x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x215.34375]
     PaintableWithLines (BlockContainer(anonymous)) [0,0 800x0]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x199.34375]

--- a/Tests/LibWeb/Layout/expected/table/border-conflict-resolution-with-cell.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-conflict-resolution-with-cell.txt
@@ -63,7 +63,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x86.9375]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 172.671875x86.9375]

--- a/Tests/LibWeb/Layout/expected/table/border-conflict-resolution-with-col.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-conflict-resolution-with-col.txt
@@ -69,7 +69,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,169.875) content-size 784x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x177.875]
     PaintableWithLines (BlockContainer(anonymous)) [0,0 800x0]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x161.875]

--- a/Tests/LibWeb/Layout/expected/table/border-conflict-resolution-with-row.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-conflict-resolution-with-row.txt
@@ -68,7 +68,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x130.40625]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 114.8125x130.40625]

--- a/Tests/LibWeb/Layout/expected/table/border-conflict-resolution-with-rowgroup.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-conflict-resolution-with-rowgroup.txt
@@ -69,7 +69,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x124.40625]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 113.40625x124.40625]

--- a/Tests/LibWeb/Layout/expected/table/border-spacing-and-borders-table-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-spacing-and-borders-table-width.txt
@@ -26,7 +26,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x77.46875]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 143.609375x77.46875]

--- a/Tests/LibWeb/Layout/expected/table/border-spacing-colspan.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-spacing-colspan.txt
@@ -140,7 +140,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,267.34375) content-size 784x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x275.34375]
     PaintableWithLines (BlockContainer(anonymous)) [0,0 800x0]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x259.34375]

--- a/Tests/LibWeb/Layout/expected/table/border-spacing-rowspan.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-spacing-rowspan.txt
@@ -140,7 +140,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,267.34375) content-size 784x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x275.34375]
     PaintableWithLines (BlockContainer(anonymous)) [0,0 800x0]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x259.34375]

--- a/Tests/LibWeb/Layout/expected/table/border-spacing-with-percentage-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-spacing-with-percentage-width.txt
@@ -35,7 +35,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             "C"
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x0]
       PaintableWithLines (BlockContainer<DIV>.left) [8,8 117.59375x17.46875]

--- a/Tests/LibWeb/Layout/expected/table/border-spacing.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-spacing.txt
@@ -147,7 +147,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,267.34375) content-size 784x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x275.34375]
     PaintableWithLines (BlockContainer(anonymous)) [0,0 800x0]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x259.34375]

--- a/Tests/LibWeb/Layout/expected/table/borders.txt
+++ b/Tests/LibWeb/Layout/expected/table/borders.txt
@@ -259,7 +259,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,273.625) content-size 784x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x265.625]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 174.296875x74.40625]

--- a/Tests/LibWeb/Layout/expected/table/bottom-caption.txt
+++ b/Tests/LibWeb/Layout/expected/table/bottom-caption.txt
@@ -68,7 +68,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,91.875) content-size 784x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x99.875]
     PaintableWithLines (BlockContainer(anonymous)) [0,0 800x0]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x83.875]

--- a/Tests/LibWeb/Layout/expected/table/cell-auto-max-width-table-percentage-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/cell-auto-max-width-table-percentage-width.txt
@@ -42,7 +42,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <(anonymous)> at (8,31.46875) content-size 80x0 children: inline
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x23.46875]
       PaintableWithLines (BlockContainer<DIV>#container) [8,8 80x23.46875]

--- a/Tests/LibWeb/Layout/expected/table/cell-px-height.txt
+++ b/Tests/LibWeb/Layout/expected/table/cell-px-height.txt
@@ -5,7 +5,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         Box <div.row> at (8,8) content-size 102x100 table-row children: not-inline
           BlockContainer <div.cell> at (9,9) content-size 100x0 table-cell [BFC] children: not-inline
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (TableWrapper(anonymous)) [8,8 102x100]
       PaintableBox (Box<BODY>) [8,8 102x100]

--- a/Tests/LibWeb/Layout/expected/table/cell-relative-to-specified-table-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/cell-relative-to-specified-table-width.txt
@@ -63,7 +63,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x44.9375]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 784x44.9375]

--- a/Tests/LibWeb/Layout/expected/table/clip-spans-to-table-end.txt
+++ b/Tests/LibWeb/Layout/expected/table/clip-spans-to-table-end.txt
@@ -64,7 +64,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x118.40625]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 92.359375x118.40625]

--- a/Tests/LibWeb/Layout/expected/table/colspan-percentage-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/colspan-percentage-width.txt
@@ -52,7 +52,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x44.9375]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 420x44.9375]

--- a/Tests/LibWeb/Layout/expected/table/colspan-weighted-width-distribution.txt
+++ b/Tests/LibWeb/Layout/expected/table/colspan-weighted-width-distribution.txt
@@ -38,7 +38,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x44.9375]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 210x44.9375]

--- a/Tests/LibWeb/Layout/expected/table/colspan-width-distribution.txt
+++ b/Tests/LibWeb/Layout/expected/table/colspan-width-distribution.txt
@@ -44,7 +44,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,52.9375) content-size 784x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x60.9375]
     PaintableWithLines (BlockContainer(anonymous)) [0,0 800x0]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x44.9375]

--- a/Tests/LibWeb/Layout/expected/table/columns-width-distribution-1.txt
+++ b/Tests/LibWeb/Layout/expected/table/columns-width-distribution-1.txt
@@ -30,7 +30,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                     "client."
                 TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x113.15625]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 784x113.15625]

--- a/Tests/LibWeb/Layout/expected/table/fixed-layout-percentage-width-all-columns.txt
+++ b/Tests/LibWeb/Layout/expected/table/fixed-layout-percentage-width-all-columns.txt
@@ -73,7 +73,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x44.9375]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 600x44.9375]

--- a/Tests/LibWeb/Layout/expected/table/fixed-layout-percentage-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/fixed-layout-percentage-width.txt
@@ -73,7 +73,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x44.9375]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 600x44.9375]

--- a/Tests/LibWeb/Layout/expected/table/fixed-layout-pixel-width-all-columns.txt
+++ b/Tests/LibWeb/Layout/expected/table/fixed-layout-pixel-width-all-columns.txt
@@ -73,7 +73,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x44.9375]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 600x44.9375]

--- a/Tests/LibWeb/Layout/expected/table/fixed-layout-pixel-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/fixed-layout-pixel-width.txt
@@ -79,7 +79,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x80.8125]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 600x80.8125]

--- a/Tests/LibWeb/Layout/expected/table/fixed-layout.txt
+++ b/Tests/LibWeb/Layout/expected/table/fixed-layout.txt
@@ -73,7 +73,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x44.9375]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 600x44.9375]

--- a/Tests/LibWeb/Layout/expected/table/fixed-margins.txt
+++ b/Tests/LibWeb/Layout/expected/table/fixed-margins.txt
@@ -14,7 +14,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                     "To AdJuSt PRiCiNG sTYLiNG ceLL oF TAbLeS"
                 TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x35.40625]
       PaintableWithLines (BlockContainer<DIV>.wrapper) [8,8 784x35.40625]

--- a/Tests/LibWeb/Layout/expected/table/in-auto-height-flex-item.txt
+++ b/Tests/LibWeb/Layout/expected/table/in-auto-height-flex-item.txt
@@ -11,7 +11,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                     "Hello"
                 TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x41.46875]
     PaintableBox (Box<BODY>) [9,9 782x23.46875]
       PaintableWithLines (BlockContainer<DIV>.upper) [10,10 43.78125x21.46875]

--- a/Tests/LibWeb/Layout/expected/table/infinite-padding.txt
+++ b/Tests/LibWeb/Layout/expected/table/infinite-padding.txt
@@ -9,7 +9,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 TableWrapper <(anonymous)> at (8,8) content-size 0x0 [BFC] children: not-inline
                   Box <div#box2> at (8,8) content-size 0x0 table-box [TFC] children: not-inline
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x16]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x0]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 0x0]

--- a/Tests/LibWeb/Layout/expected/table/inline-table-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/inline-table-width.txt
@@ -30,7 +30,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                       "false"
                   TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x46.9375]
       PaintableWithLines (BlockContainer<TABLE>) [8,8 137.984375x46.9375]

--- a/Tests/LibWeb/Layout/expected/table/long-caption-increases-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/long-caption-increases-width.txt
@@ -92,7 +92,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,119.8125) content-size 784x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x127.8125]
     PaintableWithLines (BlockContainer(anonymous)) [0,0 800x0]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x111.8125]

--- a/Tests/LibWeb/Layout/expected/table/multi-line-cell.txt
+++ b/Tests/LibWeb/Layout/expected/table/multi-line-cell.txt
@@ -28,7 +28,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,76.875) content-size 784x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x68.875]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 81.4375x68.875]

--- a/Tests/LibWeb/Layout/expected/table/nested-table-box-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/nested-table-box-width.txt
@@ -81,7 +81,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,132.9375) content-size 784x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x140.9375]
     PaintableWithLines (BlockContainer(anonymous)) [0,0 800x0]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x124.9375]

--- a/Tests/LibWeb/Layout/expected/table/percentage-width-columns.txt
+++ b/Tests/LibWeb/Layout/expected/table/percentage-width-columns.txt
@@ -37,7 +37,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x23.46875]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 94x23.46875]

--- a/Tests/LibWeb/Layout/expected/table/percentage-width-for-nested-table-is-like-auto.txt
+++ b/Tests/LibWeb/Layout/expected/table/percentage-width-for-nested-table-is-like-auto.txt
@@ -18,7 +18,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                                   "A A"
                               TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x31.46875]
       PaintableBox (Box<DIV>.grid_layout) [8,8 784x31.46875]

--- a/Tests/LibWeb/Layout/expected/table/percentage-width-max-width-columns.txt
+++ b/Tests/LibWeb/Layout/expected/table/percentage-width-max-width-columns.txt
@@ -33,7 +33,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x21.46875]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 119x21.46875]

--- a/Tests/LibWeb/Layout/expected/table/propagate-style-update-to-wrapper.txt
+++ b/Tests/LibWeb/Layout/expected/table/propagate-style-update-to-wrapper.txt
@@ -15,7 +15,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x0] overflow: [8,8 6x6]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 6x6]

--- a/Tests/LibWeb/Layout/expected/table/row-outer-size-with-computed-size.txt
+++ b/Tests/LibWeb/Layout/expected/table/row-outer-size-with-computed-size.txt
@@ -33,7 +33,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x25.46875]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 49.21875x25.46875]

--- a/Tests/LibWeb/Layout/expected/table/row-px-height.txt
+++ b/Tests/LibWeb/Layout/expected/table/row-px-height.txt
@@ -5,7 +5,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         Box <div.row> at (8,8) content-size 102x100 table-row children: not-inline
           BlockContainer <div.cell> at (9,9) content-size 100x0 table-cell [BFC] children: not-inline
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (TableWrapper(anonymous)) [8,8 102x100]
       PaintableBox (Box<BODY>) [8,8 102x100]

--- a/Tests/LibWeb/Layout/expected/table/row-span-and-nested-tables.txt
+++ b/Tests/LibWeb/Layout/expected/table/row-span-and-nested-tables.txt
@@ -93,7 +93,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,124.40625) content-size 784x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x132.40625]
     PaintableWithLines (BlockContainer(anonymous)) [0,0 800x0]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x116.40625]

--- a/Tests/LibWeb/Layout/expected/table/rows-height-distribution-1.txt
+++ b/Tests/LibWeb/Layout/expected/table/rows-height-distribution-1.txt
@@ -8,7 +8,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           Box <div.row.b> at (8,58) content-size 200x100 table-row children: not-inline
             BlockContainer <div.cell> at (8,58) content-size 200x0 table-cell [BFC] children: not-inline
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x150]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 200x150]

--- a/Tests/LibWeb/Layout/expected/table/rows-height-distribution-2.txt
+++ b/Tests/LibWeb/Layout/expected/table/rows-height-distribution-2.txt
@@ -8,7 +8,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           Box <div.row.b> at (8,158) content-size 200x150 table-row children: not-inline
             BlockContainer <div.cell> at (8,158) content-size 200x0 table-cell [BFC] children: not-inline
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x300]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 200x300]

--- a/Tests/LibWeb/Layout/expected/table/rows-height-distribution-3.txt
+++ b/Tests/LibWeb/Layout/expected/table/rows-height-distribution-3.txt
@@ -16,7 +16,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                   "b"
               TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x300]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 200x300]

--- a/Tests/LibWeb/Layout/expected/table/rows-height-distribution-4.txt
+++ b/Tests/LibWeb/Layout/expected/table/rows-height-distribution-4.txt
@@ -16,7 +16,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                   "b"
               TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x300]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 200x300]

--- a/Tests/LibWeb/Layout/expected/table/rowspan.txt
+++ b/Tests/LibWeb/Layout/expected/table/rowspan.txt
@@ -110,7 +110,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,95.875) content-size 784x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x103.875]
     PaintableWithLines (BlockContainer(anonymous)) [0,0 800x0]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x87.875]

--- a/Tests/LibWeb/Layout/expected/table/size.txt
+++ b/Tests/LibWeb/Layout/expected/table/size.txt
@@ -15,7 +15,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> at (350,25.46875) content-size 100x0 children: inline
                 TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600] overflow: [0,0 2350x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 2350x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600] overflow: [0,0 2350x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x17.46875] overflow: [8,8 2342x17.46875]
       PaintableWithLines (TableWrapper(anonymous)) [350,8 100x17.46875] overflow: [350,8 2000x17.46875]

--- a/Tests/LibWeb/Layout/expected/table/stretch-to-fixed-height.txt
+++ b/Tests/LibWeb/Layout/expected/table/stretch-to-fixed-height.txt
@@ -10,7 +10,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x100]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 24x100]

--- a/Tests/LibWeb/Layout/expected/table/sum-of-percentage-column-widths-less-than-100.txt
+++ b/Tests/LibWeb/Layout/expected/table/sum-of-percentage-column-widths-less-than-100.txt
@@ -33,7 +33,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x27.46875]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 94x27.46875]

--- a/Tests/LibWeb/Layout/expected/table/table-cell-not-paintable.txt
+++ b/Tests/LibWeb/Layout/expected/table/table-cell-not-paintable.txt
@@ -9,7 +9,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <(anonymous)> at (13,19) content-size 0x0 table-row children: not-inline
               BlockContainer <(anonymous)> at (13,19) content-size 0x0 table-cell [BFC] children: not-inline
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x17.46875]
       PaintableWithLines (BlockContainer<BUTTON>) [8,17 10x4]

--- a/Tests/LibWeb/Layout/expected/table/table-formation-with-rowspan-in-the-middle.txt
+++ b/Tests/LibWeb/Layout/expected/table/table-formation-with-rowspan-in-the-middle.txt
@@ -85,7 +85,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,167.875) content-size 784x0 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x159.875]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 103.421875x159.875]

--- a/Tests/LibWeb/Layout/expected/table/table-header-and-footer-groups.txt
+++ b/Tests/LibWeb/Layout/expected/table/table-header-and-footer-groups.txt
@@ -17,7 +17,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                   "top"
               TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x218]
     PaintableWithLines (TableWrapper(anonymous)) [9,9 300x200]
       PaintableBox (Box<BODY>.table) [9,9 300x200]

--- a/Tests/LibWeb/Layout/expected/table/table-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/table-width.txt
@@ -7,7 +7,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (110,110) content-size 580x10 table-row children: not-inline
               BlockContainer <td.cell> at (111,115) content-size 578x0 table-cell [BFC] children: not-inline
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x214]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 784x214]

--- a/Tests/LibWeb/Layout/expected/table/td-valign.txt
+++ b/Tests/LibWeb/Layout/expected/table/td-valign.txt
@@ -23,7 +23,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x220]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x204]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 144.1875x204]

--- a/Tests/LibWeb/Layout/expected/table/top-caption-with-padding.txt
+++ b/Tests/LibWeb/Layout/expected/table/top-caption-with-padding.txt
@@ -26,7 +26,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600] overflow: [0,-2 800x602]
+ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,-2 800x602]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600] overflow: [0,-2 800x602]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x60.9375] overflow: [8,-2 784x70.9375]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 60.46875x60.9375] overflow: [8,-2 60.46875x70.9375]

--- a/Tests/LibWeb/Layout/expected/table/width-distribution-and-constrained-columns-increased-size-on-col.txt
+++ b/Tests/LibWeb/Layout/expected/table/width-distribution-and-constrained-columns-increased-size-on-col.txt
@@ -31,7 +31,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x27.46875]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 420x27.46875]

--- a/Tests/LibWeb/Layout/expected/table/width-distribution-and-constrained-columns-size-on-col.txt
+++ b/Tests/LibWeb/Layout/expected/table/width-distribution-and-constrained-columns-size-on-col.txt
@@ -31,7 +31,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x27.46875]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 420x27.46875]

--- a/Tests/LibWeb/Layout/expected/table/width-distribution-and-constrained-columns.txt
+++ b/Tests/LibWeb/Layout/expected/table/width-distribution-and-constrained-columns.txt
@@ -26,7 +26,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x27.46875]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 420x27.46875]

--- a/Tests/LibWeb/Layout/expected/table/width-distribution-of-max-width-increment.txt
+++ b/Tests/LibWeb/Layout/expected/table/width-distribution-of-max-width-increment.txt
@@ -37,7 +37,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x21.46875]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 784x21.46875]

--- a/Tests/LibWeb/Layout/expected/table/zero-columns-gridmax.txt
+++ b/Tests/LibWeb/Layout/expected/table/zero-columns-gridmax.txt
@@ -6,7 +6,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           Box <div.row> at (8,8) content-size 200x0 table-row children: not-inline
             BlockContainer <div.cell> at (8,8) content-size 200x0 table-cell [BFC] children: not-inline
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x0]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 200x0]

--- a/Tests/LibWeb/Layout/expected/text-align-justify-with-forced-break.txt
+++ b/Tests/LibWeb/Layout/expected/text-align-justify-with-forced-break.txt
@@ -74,7 +74,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BreakNode <br>
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x118]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x102] overflow: [8,8 784x105.46875]
       PaintableWithLines (BlockContainer<DIV>) [8,8 102x102] overflow: [9,9 100.203125x104.46875]

--- a/Tests/LibWeb/Layout/expected/text-align-overflow.txt
+++ b/Tests/LibWeb/Layout/expected/text-align-overflow.txt
@@ -8,7 +8,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               "My super long message!"
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x33.46875]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x17.46875]
       PaintableWithLines (BlockContainer<DIV>.outer) [18,8 80x17.46875]

--- a/Tests/LibWeb/Layout/expected/text-indent.txt
+++ b/Tests/LibWeb/Layout/expected/text-indent.txt
@@ -27,7 +27,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             "snab"
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x163.21875]
     PaintableWithLines (BlockContainer<BODY>) [9,9 782x145.21875]
       PaintableWithLines (BlockContainer<DIV>.px-indent) [10,10 780x70.9375]

--- a/Tests/LibWeb/Layout/expected/tolerate-css-percentage-overshoot.txt
+++ b/Tests/LibWeb/Layout/expected/tolerate-css-percentage-overshoot.txt
@@ -5,7 +5,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <div.larg.green> at (216.328125,8) content-size 208.328125x100 floating [BFC] children: not-inline
       BlockContainer <div.smol.blue> at (424.65625,8) content-size 83.328125x100 floating [BFC] children: not-inline
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 500x0] overflow: [8,8 499.984375x100]
       PaintableWithLines (BlockContainer<DIV>.larg.red) [8,8 208.328125x100]

--- a/Tests/LibWeb/Layout/expected/transform-calc-length-values.txt
+++ b/Tests/LibWeb/Layout/expected/transform-calc-length-values.txt
@@ -2,6 +2,6 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (9,9) content-size 100x100 children: not-inline
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 102x102]

--- a/Tests/LibWeb/Layout/expected/vertical-padding-relative-to-cb-width.txt
+++ b/Tests/LibWeb/Layout/expected/vertical-padding-relative-to-cb-width.txt
@@ -17,7 +17,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               "bar"
           TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x602]
+ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x602]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x602]
     PaintableWithLines (BlockContainer<BODY>) [9,9 782x14] overflow: [10,10 780x218.46875]
       PaintableWithLines (BlockContainer(anonymous)) [10,10 780x0]

--- a/Tests/LibWeb/Layout/expected/viewport-overflow-propagation-1.txt
+++ b/Tests/LibWeb/Layout/expected/viewport-overflow-propagation-1.txt
@@ -4,7 +4,7 @@ Viewport <#document> at (0,0) content-size 800x600 [BFC] children: not-inline
       BlockContainer <div> at (8,8) content-size 100x2000 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x2016]
+ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x2016]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x2016]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x2000]
       PaintableWithLines (BlockContainer<DIV>) [8,8 100x2000]

--- a/Tests/LibWeb/Layout/expected/viewport-overflow-propagation-2.txt
+++ b/Tests/LibWeb/Layout/expected/viewport-overflow-propagation-2.txt
@@ -4,7 +4,7 @@ Viewport <#document> at (0,0) content-size 800x600 [BFC] children: not-inline
       BlockContainer <div.long> at (8,8) content-size 784x2000 children: inline
         TextNode <#text>
 
-PaintableWithLines (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x2008]
+ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x2008]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x616] overflow: [0,0 800x2008]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x600] overflow: [8,8 784x2000]
       PaintableWithLines (BlockContainer<DIV>.long) [8,8 784x2000]

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -493,6 +493,7 @@ set(SOURCES
     Painting/TableBordersPainting.cpp
     Painting/TextPaintable.cpp
     Painting/VideoPaintable.cpp
+    Painting/ViewportPaintable.cpp
     PerformanceTimeline/EntryTypes.cpp
     PerformanceTimeline/PerformanceEntry.cpp
     PermissionsPolicy/AutoplayAllowlist.cpp

--- a/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
@@ -46,6 +46,7 @@
 #include <LibWeb/Layout/Viewport.h>
 #include <LibWeb/Painting/PaintableBox.h>
 #include <LibWeb/Painting/StackingContext.h>
+#include <LibWeb/Painting/ViewportPaintable.h>
 
 namespace Web::CSS {
 
@@ -834,9 +835,9 @@ RefPtr<StyleValue const> ResolvedCSSStyleDeclaration::style_value_for_property(L
             return IdentifierStyleValue::create(ValueID::None);
 
         // The transform matrix is held by the StackingContext, so we need to make sure we have one first.
-        auto const* viewport = layout_node.document().layout_node();
+        auto const* viewport = layout_node.document().paintable_box();
         VERIFY(viewport);
-        const_cast<Layout::Viewport&>(*viewport).build_stacking_context_tree_if_needed();
+        const_cast<Painting::ViewportPaintable&>(verify_cast<Painting::ViewportPaintable>(*viewport)).build_stacking_context_tree_if_needed();
 
         VERIFY(layout_node.paintable());
         auto const& paintable_box = verify_cast<Painting::PaintableBox const>(layout_node.paintable());

--- a/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
@@ -835,9 +835,9 @@ RefPtr<StyleValue const> ResolvedCSSStyleDeclaration::style_value_for_property(L
             return IdentifierStyleValue::create(ValueID::None);
 
         // The transform matrix is held by the StackingContext, so we need to make sure we have one first.
-        auto const* viewport = layout_node.document().paintable_box();
+        auto const* viewport = layout_node.document().paintable();
         VERIFY(viewport);
-        const_cast<Painting::ViewportPaintable&>(verify_cast<Painting::ViewportPaintable>(*viewport)).build_stacking_context_tree_if_needed();
+        const_cast<Painting::ViewportPaintable&>(*viewport).build_stacking_context_tree_if_needed();
 
         VERIFY(layout_node.paintable());
         auto const& paintable_box = verify_cast<Painting::PaintableBox const>(layout_node.paintable());

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -1003,7 +1003,7 @@ void Document::update_layout()
                 Layout::AvailableSize::make_definite(viewport_rect.height())));
     }
 
-    layout_state.commit();
+    layout_state.commit(*m_layout_root);
 
     // Broadcast the current viewport rect to any new paintables, so they know whether they're visible or not.
     browsing_context()->inform_all_viewport_clients_about_the_current_viewport_rect();

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -87,6 +87,7 @@
 #include <LibWeb/Layout/Viewport.h>
 #include <LibWeb/Namespace.h>
 #include <LibWeb/Page/Page.h>
+#include <LibWeb/Painting/ViewportPaintable.h>
 #include <LibWeb/PermissionsPolicy/AutoplayAllowlist.h>
 #include <LibWeb/SVG/SVGElement.h>
 #include <LibWeb/SVG/SVGTitleElement.h>
@@ -3394,6 +3395,16 @@ void Document::shared_declarative_refresh_steps(StringView input, JS::GCPtr<HTML
     if (meta_element && m_completely_loaded_time.has_value()) {
         m_active_refresh_timer->start();
     }
+}
+
+Painting::ViewportPaintable const* Document::paintable() const
+{
+    return static_cast<Painting::ViewportPaintable const*>(Node::paintable());
+}
+
+Painting::ViewportPaintable* Document::paintable()
+{
+    return static_cast<Painting::ViewportPaintable*>(Node::paintable());
 }
 
 }

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -210,6 +210,9 @@ public:
     Layout::Viewport const* layout_node() const;
     Layout::Viewport* layout_node();
 
+    Painting::ViewportPaintable const* paintable() const;
+    Painting::ViewportPaintable* paintable();
+
     void schedule_style_update();
     void schedule_layout_update();
 

--- a/Userland/Libraries/LibWeb/DOM/Node.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Node.cpp
@@ -41,6 +41,7 @@
 #include <LibWeb/Layout/Node.h>
 #include <LibWeb/Layout/TextNode.h>
 #include <LibWeb/Layout/Viewport.h>
+#include <LibWeb/Painting/Paintable.h>
 
 namespace Web::DOM {
 
@@ -103,6 +104,7 @@ void Node::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_child_nodes);
 
     visitor.visit(m_layout_node);
+    visitor.visit(m_paintable);
 
     for (auto& registered_observer : m_registered_observer_list)
         visitor.visit(registered_observer);
@@ -1438,18 +1440,19 @@ size_t Node::length() const
     return child_count();
 }
 
+void Node::set_paintable(JS::GCPtr<Painting::Paintable> paintable)
+{
+    m_paintable = paintable;
+}
+
 Painting::Paintable const* Node::paintable() const
 {
-    if (!layout_node())
-        return nullptr;
-    return layout_node()->paintable();
+    return m_paintable;
 }
 
 Painting::Paintable* Node::paintable()
 {
-    if (!layout_node())
-        return nullptr;
-    return layout_node()->paintable();
+    return m_paintable;
 }
 
 Painting::PaintableBox const* Node::paintable_box() const

--- a/Userland/Libraries/LibWeb/DOM/Node.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Node.cpp
@@ -1445,6 +1445,13 @@ Painting::Paintable const* Node::paintable() const
     return layout_node()->paintable();
 }
 
+Painting::Paintable* Node::paintable()
+{
+    if (!layout_node())
+        return nullptr;
+    return layout_node()->paintable();
+}
+
 Painting::PaintableBox const* Node::paintable_box() const
 {
     if (!layout_node())

--- a/Userland/Libraries/LibWeb/DOM/Node.h
+++ b/Userland/Libraries/LibWeb/DOM/Node.h
@@ -187,6 +187,8 @@ public:
     Painting::Paintable const* paintable() const;
     Painting::Paintable* paintable();
 
+    void set_paintable(JS::GCPtr<Painting::Paintable>);
+
     void set_layout_node(Badge<Layout::Node>, JS::NonnullGCPtr<Layout::Node>);
     void detach_layout_node(Badge<Layout::TreeBuilder>);
 
@@ -671,6 +673,7 @@ protected:
 
     JS::GCPtr<Document> m_document;
     JS::GCPtr<Layout::Node> m_layout_node;
+    JS::GCPtr<Painting::Paintable> m_paintable;
     NodeType m_type { NodeType::INVALID };
     bool m_needs_style_update { false };
     bool m_child_needs_style_update { false };

--- a/Userland/Libraries/LibWeb/DOM/Node.h
+++ b/Userland/Libraries/LibWeb/DOM/Node.h
@@ -185,6 +185,7 @@ public:
     Painting::PaintableBox const* paintable_box() const;
     Painting::PaintableBox* paintable_box();
     Painting::Paintable const* paintable() const;
+    Painting::Paintable* paintable();
 
     void set_layout_node(Badge<Layout::Node>, JS::NonnullGCPtr<Layout::Node>);
     void detach_layout_node(Badge<Layout::TreeBuilder>);

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -521,6 +521,7 @@ class PaintableWithLines;
 class StackingContext;
 class TextPaintable;
 class VideoPaintable;
+class ViewportPaintable;
 
 enum class PaintPhase;
 

--- a/Userland/Libraries/LibWeb/Layout/LayoutState.cpp
+++ b/Userland/Libraries/LibWeb/Layout/LayoutState.cpp
@@ -209,6 +209,8 @@ static void build_paint_tree(Node& node, Painting::Paintable* parent_paintable =
         parent_paintable->append_child(paintable);
     }
     paintable.set_dom_node(node.dom_node());
+    if (node.dom_node())
+        node.dom_node()->set_paintable(&paintable);
     for (auto* child = node.first_child(); child; child = child->next_sibling()) {
         build_paint_tree(*child, &paintable);
     }

--- a/Userland/Libraries/LibWeb/Layout/LayoutState.cpp
+++ b/Userland/Libraries/LibWeb/Layout/LayoutState.cpp
@@ -82,8 +82,8 @@ static CSSPixelRect measure_scrollable_overflow(Box const& box)
     auto scrollable_overflow_rect = paintable_box.absolute_padding_box_rect();
 
     // - All line boxes directly contained by the scroll container.
-    if (box.is_block_container() && box.children_are_inline()) {
-        auto const& line_boxes = verify_cast<Painting::PaintableWithLines>(*box.paintable_box()).line_boxes();
+    if (is<Painting::PaintableWithLines>(box.paintable())) {
+        auto const& line_boxes = static_cast<Painting::PaintableWithLines const&>(*box.paintable()).line_boxes();
         for (auto const& line_box : line_boxes) {
             scrollable_overflow_rect = scrollable_overflow_rect.united(line_box.absolute_rect());
         }
@@ -238,8 +238,7 @@ void LayoutState::commit(Box& root)
         node.set_paintable(paintable);
 
         // For boxes, transfer all the state needed for painting.
-        if (is<Layout::Box>(node)) {
-            auto& box = static_cast<Layout::Box const&>(node);
+        if (paintable && is<Painting::PaintableBox>(*paintable)) {
             auto& paintable_box = static_cast<Painting::PaintableBox&>(*paintable);
             paintable_box.set_offset(used_values.offset);
             paintable_box.set_content_size(used_values.content_width(), used_values.content_height());
@@ -250,7 +249,7 @@ void LayoutState::commit(Box& root)
                 paintable_box.set_table_cell_coordinates(used_values.table_cell_coordinates().value());
             }
 
-            if (is<Layout::BlockContainer>(box)) {
+            if (is<Painting::PaintableWithLines>(paintable_box)) {
                 auto& paintable_with_lines = static_cast<Painting::PaintableWithLines&>(paintable_box);
                 paintable_with_lines.set_line_boxes(move(used_values.line_boxes));
                 paintables_with_lines.append(paintable_with_lines);

--- a/Userland/Libraries/LibWeb/Layout/LayoutState.cpp
+++ b/Userland/Libraries/LibWeb/Layout/LayoutState.cpp
@@ -208,6 +208,7 @@ static void build_paint_tree(Node& node, Painting::Paintable* parent_paintable =
         }
         parent_paintable->append_child(paintable);
     }
+    paintable.set_dom_node(node.dom_node());
     for (auto* child = node.first_child(); child; child = child->next_sibling()) {
         build_paint_tree(*child, &paintable);
     }

--- a/Userland/Libraries/LibWeb/Layout/LayoutState.h
+++ b/Userland/Libraries/LibWeb/Layout/LayoutState.h
@@ -148,7 +148,8 @@ struct LayoutState {
         Optional<Painting::PaintableBox::TableCellCoordinates> m_table_cell_coordinates;
     };
 
-    void commit();
+    // Commits the used values produced by layout and builds a paintable tree.
+    void commit(Box& root);
 
     // NOTE: get_mutable() will CoW the UsedValues if it's inherited from an ancestor state;
     UsedValues& get_mutable(NodeWithStyleAndBoxModelMetrics const&);

--- a/Userland/Libraries/LibWeb/Layout/Viewport.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Viewport.cpp
@@ -9,6 +9,7 @@
 #include <LibWeb/Layout/Viewport.h>
 #include <LibWeb/Painting/PaintableBox.h>
 #include <LibWeb/Painting/StackingContext.h>
+#include <LibWeb/Painting/ViewportPaintable.h>
 
 namespace Web::Layout {
 
@@ -124,6 +125,11 @@ void Viewport::recompute_selection_states()
         if (auto* layout_node = node->layout_node())
             layout_node->set_selection_state(SelectionState::Full);
     }
+}
+
+JS::GCPtr<Painting::Paintable> Viewport::create_paintable() const
+{
+    return Painting::ViewportPaintable::create(*this);
 }
 
 }

--- a/Userland/Libraries/LibWeb/Layout/Viewport.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Viewport.cpp
@@ -25,42 +25,6 @@ JS::GCPtr<Selection::Selection> Viewport::selection() const
     return const_cast<DOM::Document&>(document()).get_selection();
 }
 
-void Viewport::build_stacking_context_tree_if_needed()
-{
-    if (paintable_box()->stacking_context())
-        return;
-    build_stacking_context_tree();
-}
-
-void Viewport::build_stacking_context_tree()
-{
-    paintable_box()->set_stacking_context(make<Painting::StackingContext>(*this, nullptr, 0));
-
-    size_t index_in_tree_order = 1;
-    for_each_in_subtree_of_type<Box>([&](Box& box) {
-        if (!box.paintable_box())
-            return IterationDecision::Continue;
-        box.paintable_box()->invalidate_stacking_context();
-        if (!box.establishes_stacking_context()) {
-            VERIFY(!box.paintable_box()->stacking_context());
-            return IterationDecision::Continue;
-        }
-        auto* parent_context = box.paintable_box()->enclosing_stacking_context();
-        VERIFY(parent_context);
-        box.paintable_box()->set_stacking_context(make<Painting::StackingContext>(box, parent_context, index_in_tree_order++));
-        return IterationDecision::Continue;
-    });
-
-    paintable_box()->stacking_context()->sort();
-}
-
-void Viewport::paint_all_phases(PaintContext& context)
-{
-    build_stacking_context_tree_if_needed();
-    context.painter().translate(-context.device_viewport_rect().location().to_type<int>());
-    paintable_box()->stacking_context()->paint(context);
-}
-
 void Viewport::recompute_selection_states()
 {
     // 1. Start by resetting the selection state of all layout nodes to None.

--- a/Userland/Libraries/LibWeb/Layout/Viewport.h
+++ b/Userland/Libraries/LibWeb/Layout/Viewport.h
@@ -29,6 +29,8 @@ public:
     void recompute_selection_states();
 
 private:
+    virtual JS::GCPtr<Painting::Paintable> create_paintable() const override;
+
     void build_stacking_context_tree();
     virtual bool is_viewport() const override { return true; }
 };

--- a/Userland/Libraries/LibWeb/Layout/Viewport.h
+++ b/Userland/Libraries/LibWeb/Layout/Viewport.h
@@ -21,17 +21,13 @@ public:
 
     const DOM::Document& dom_node() const { return static_cast<const DOM::Document&>(*Node::dom_node()); }
 
-    void paint_all_phases(PaintContext&);
-
     JS::GCPtr<Selection::Selection> selection() const;
 
-    void build_stacking_context_tree_if_needed();
     void recompute_selection_states();
 
 private:
     virtual JS::GCPtr<Painting::Paintable> create_paintable() const override;
 
-    void build_stacking_context_tree();
     virtual bool is_viewport() const override { return true; }
 };
 

--- a/Userland/Libraries/LibWeb/Painting/NestedBrowsingContextPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/NestedBrowsingContextPaintable.cpp
@@ -10,6 +10,7 @@
 #include <LibWeb/Layout/Viewport.h>
 #include <LibWeb/Painting/BorderRadiusCornerClipper.h>
 #include <LibWeb/Painting/NestedBrowsingContextPaintable.h>
+#include <LibWeb/Painting/ViewportPaintable.h>
 
 namespace Web::Painting {
 
@@ -43,8 +44,8 @@ void NestedBrowsingContextPaintable::paint(PaintContext& context, PaintPhase pha
         auto* hosted_document = layout_box().dom_node().content_document_without_origin_check();
         if (!hosted_document)
             return;
-        auto* hosted_layout_tree = hosted_document->layout_node();
-        if (!hosted_layout_tree)
+        auto* hosted_paint_tree = hosted_document->paintable_box();
+        if (!hosted_paint_tree)
             return;
 
         context.painter().save();
@@ -56,7 +57,7 @@ void NestedBrowsingContextPaintable::paint(PaintContext& context, PaintPhase pha
         context.painter().translate(absolute_device_rect.x().value(), absolute_device_rect.y().value());
 
         context.set_device_viewport_rect({ {}, context.enclosing_device_size(layout_box().dom_node().nested_browsing_context()->size()) });
-        const_cast<Layout::Viewport*>(hosted_layout_tree)->paint_all_phases(context);
+        const_cast<ViewportPaintable&>(verify_cast<ViewportPaintable>(*hosted_paint_tree)).paint_all_phases(context);
 
         context.set_device_viewport_rect(old_viewport_rect);
         context.painter().restore();

--- a/Userland/Libraries/LibWeb/Painting/NestedBrowsingContextPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/NestedBrowsingContextPaintable.cpp
@@ -44,7 +44,7 @@ void NestedBrowsingContextPaintable::paint(PaintContext& context, PaintPhase pha
         auto* hosted_document = layout_box().dom_node().content_document_without_origin_check();
         if (!hosted_document)
             return;
-        auto* hosted_paint_tree = hosted_document->paintable_box();
+        auto* hosted_paint_tree = hosted_document->paintable();
         if (!hosted_paint_tree)
             return;
 
@@ -57,7 +57,7 @@ void NestedBrowsingContextPaintable::paint(PaintContext& context, PaintPhase pha
         context.painter().translate(absolute_device_rect.x().value(), absolute_device_rect.y().value());
 
         context.set_device_viewport_rect({ {}, context.enclosing_device_size(layout_box().dom_node().nested_browsing_context()->size()) });
-        const_cast<ViewportPaintable&>(verify_cast<ViewportPaintable>(*hosted_paint_tree)).paint_all_phases(context);
+        const_cast<ViewportPaintable*>(hosted_paint_tree)->paint_all_phases(context);
 
         context.set_device_viewport_rect(old_viewport_rect);
         context.painter().restore();

--- a/Userland/Libraries/LibWeb/Painting/Paintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/Paintable.cpp
@@ -44,38 +44,6 @@ Optional<HitTestResult> Paintable::hit_test(CSSPixelPoint, HitTestType) const
     return {};
 }
 
-Paintable const* Paintable::first_child() const
-{
-    auto const* layout_child = m_layout_node->first_child();
-    for (; layout_child && !layout_child->paintable(); layout_child = layout_child->next_sibling())
-        ;
-    return layout_child ? layout_child->paintable() : nullptr;
-}
-
-Paintable const* Paintable::next_sibling() const
-{
-    auto const* layout_node = m_layout_node->next_sibling();
-    for (; layout_node && !layout_node->paintable(); layout_node = layout_node->next_sibling())
-        ;
-    return layout_node ? layout_node->paintable() : nullptr;
-}
-
-Paintable const* Paintable::last_child() const
-{
-    auto const* layout_child = m_layout_node->last_child();
-    for (; layout_child && !layout_child->paintable(); layout_child = layout_child->previous_sibling())
-        ;
-    return layout_child ? layout_child->paintable() : nullptr;
-}
-
-Paintable const* Paintable::previous_sibling() const
-{
-    auto const* layout_node = m_layout_node->previous_sibling();
-    for (; layout_node && !layout_node->paintable(); layout_node = layout_node->previous_sibling())
-        ;
-    return layout_node ? layout_node->paintable() : nullptr;
-}
-
 StackingContext const* Paintable::stacking_context_rooted_here() const
 {
     if (!layout_node().is_box())

--- a/Userland/Libraries/LibWeb/Painting/Paintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/Paintable.cpp
@@ -14,9 +14,25 @@ namespace Web::Painting {
 void Paintable::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
+    visitor.visit(m_dom_node);
     visitor.visit(m_layout_node);
     if (m_containing_block.has_value())
         visitor.visit(m_containing_block.value());
+}
+
+void Paintable::set_dom_node(JS::GCPtr<DOM::Node> dom_node)
+{
+    m_dom_node = dom_node;
+}
+
+JS::GCPtr<DOM::Node> Paintable::dom_node()
+{
+    return m_dom_node;
+}
+
+JS::GCPtr<DOM::Node const> Paintable::dom_node() const
+{
+    return m_dom_node;
 }
 
 Paintable::DispatchEventOfSameName Paintable::handle_mousedown(Badge<EventHandler>, CSSPixelPoint, unsigned, unsigned)

--- a/Userland/Libraries/LibWeb/Painting/Paintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/Paintable.cpp
@@ -79,7 +79,7 @@ Optional<HitTestResult> Paintable::hit_test(CSSPixelPoint, HitTestType) const
 
 StackingContext const* Paintable::stacking_context_rooted_here() const
 {
-    if (!layout_node().is_box())
+    if (!is<PaintableBox>(*this))
         return nullptr;
     return static_cast<PaintableBox const&>(*this).stacking_context();
 }

--- a/Userland/Libraries/LibWeb/Painting/Paintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/Paintable.cpp
@@ -11,11 +11,18 @@
 
 namespace Web::Painting {
 
+Paintable::Paintable(Layout::Node const& layout_node)
+    : m_layout_node(layout_node)
+    , m_browsing_context(const_cast<HTML::BrowsingContext&>(layout_node.browsing_context()))
+{
+}
+
 void Paintable::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
     visitor.visit(m_dom_node);
     visitor.visit(m_layout_node);
+    visitor.visit(m_browsing_context);
     if (m_containing_block.has_value())
         visitor.visit(m_containing_block.value());
 }
@@ -33,6 +40,16 @@ JS::GCPtr<DOM::Node> Paintable::dom_node()
 JS::GCPtr<DOM::Node const> Paintable::dom_node() const
 {
     return m_dom_node;
+}
+
+HTML::BrowsingContext const& Paintable::browsing_context() const
+{
+    return m_browsing_context;
+}
+
+HTML::BrowsingContext& Paintable::browsing_context()
+{
+    return m_browsing_context;
 }
 
 Paintable::DispatchEventOfSameName Paintable::handle_mousedown(Badge<EventHandler>, CSSPixelPoint, unsigned, unsigned)

--- a/Userland/Libraries/LibWeb/Painting/Paintable.h
+++ b/Userland/Libraries/LibWeb/Painting/Paintable.h
@@ -139,8 +139,8 @@ public:
 
     bool visible_for_hit_testing() const { return computed_values().pointer_events() != CSS::PointerEvents::None; }
 
-    HTML::BrowsingContext const& browsing_context() const { return m_layout_node->browsing_context(); }
-    HTML::BrowsingContext& browsing_context() { return layout_node().browsing_context(); }
+    [[nodiscard]] HTML::BrowsingContext const& browsing_context() const;
+    [[nodiscard]] HTML::BrowsingContext& browsing_context();
 
     void set_needs_display() const { const_cast<Layout::Node&>(*m_layout_node).set_needs_display(); }
 
@@ -157,16 +157,14 @@ public:
     StackingContext const* stacking_context_rooted_here() const;
 
 protected:
-    explicit Paintable(Layout::Node const& layout_node)
-        : m_layout_node(layout_node)
-    {
-    }
+    explicit Paintable(Layout::Node const&);
 
     virtual void visit_edges(Cell::Visitor&) override;
 
 private:
     JS::GCPtr<DOM::Node> m_dom_node;
     JS::NonnullGCPtr<Layout::Node const> m_layout_node;
+    JS::NonnullGCPtr<HTML::BrowsingContext> m_browsing_context;
     Optional<JS::GCPtr<Layout::Box const>> mutable m_containing_block;
 };
 

--- a/Userland/Libraries/LibWeb/Painting/Paintable.h
+++ b/Userland/Libraries/LibWeb/Painting/Paintable.h
@@ -154,6 +154,9 @@ public:
     template<typename T>
     bool fast_is() const = delete;
 
+    [[nodiscard]] virtual bool is_paintable_box() const { return false; }
+    [[nodiscard]] virtual bool is_paintable_with_lines() const { return false; }
+
     StackingContext const* stacking_context_rooted_here() const;
 
 protected:
@@ -179,6 +182,9 @@ inline DOM::Node const* HitTestResult::dom_node() const
 }
 
 template<>
-inline bool Paintable::fast_is<PaintableBox>() const { return m_layout_node->is_box(); }
+inline bool Paintable::fast_is<PaintableBox>() const { return is_paintable_box(); }
+
+template<>
+inline bool Paintable::fast_is<PaintableWithLines>() const { return is_paintable_with_lines(); }
 
 }

--- a/Userland/Libraries/LibWeb/Painting/Paintable.h
+++ b/Userland/Libraries/LibWeb/Painting/Paintable.h
@@ -131,8 +131,9 @@ public:
     Layout::Node const& layout_node() const { return m_layout_node; }
     Layout::Node& layout_node() { return const_cast<Layout::Node&>(*m_layout_node); }
 
-    DOM::Node* dom_node() { return layout_node().dom_node(); }
-    DOM::Node const* dom_node() const { return layout_node().dom_node(); }
+    [[nodiscard]] JS::GCPtr<DOM::Node> dom_node();
+    [[nodiscard]] JS::GCPtr<DOM::Node const> dom_node() const;
+    void set_dom_node(JS::GCPtr<DOM::Node>);
 
     auto const& computed_values() const { return m_layout_node->computed_values(); }
 
@@ -164,6 +165,7 @@ protected:
     virtual void visit_edges(Cell::Visitor&) override;
 
 private:
+    JS::GCPtr<DOM::Node> m_dom_node;
     JS::NonnullGCPtr<Layout::Node const> m_layout_node;
     Optional<JS::GCPtr<Layout::Box const>> mutable m_containing_block;
 };

--- a/Userland/Libraries/LibWeb/Painting/Paintable.h
+++ b/Userland/Libraries/LibWeb/Painting/Paintable.h
@@ -48,16 +48,13 @@ enum class HitTestType {
     TextCursor, // Clicking past the right/bottom edge of text will still hit the text
 };
 
-class Paintable : public JS::Cell {
+class Paintable
+    : public JS::Cell
+    , public TreeNode<Paintable> {
     JS_CELL(Paintable, Cell);
 
 public:
     virtual ~Paintable() = default;
-
-    Paintable const* first_child() const;
-    Paintable const* last_child() const;
-    Paintable const* next_sibling() const;
-    Paintable const* previous_sibling() const;
 
     template<typename U, typename Callback>
     TraversalDecision for_each_in_inclusive_subtree_of_type(Callback callback) const

--- a/Userland/Libraries/LibWeb/Painting/Paintable.h
+++ b/Userland/Libraries/LibWeb/Painting/Paintable.h
@@ -56,6 +56,13 @@ class Paintable
 public:
     virtual ~Paintable() = default;
 
+    [[nodiscard]] bool is_positioned() const { return layout_node().is_positioned(); }
+    [[nodiscard]] bool is_fixed_position() const { return layout_node().is_fixed_position(); }
+    [[nodiscard]] bool is_absolutely_positioned() const { return layout_node().is_absolutely_positioned(); }
+    [[nodiscard]] bool is_floating() const { return layout_node().is_floating(); }
+    [[nodiscard]] bool is_inline() const { return layout_node().is_inline(); }
+    [[nodiscard]] CSS::Display display() const { return layout_node().display(); }
+
     template<typename U, typename Callback>
     TraversalDecision for_each_in_inclusive_subtree_of_type(Callback callback) const
     {

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -15,6 +15,7 @@
 #include <LibWeb/Painting/FilterPainting.h>
 #include <LibWeb/Painting/PaintableBox.h>
 #include <LibWeb/Painting/StackingContext.h>
+#include <LibWeb/Painting/ViewportPaintable.h>
 #include <LibWeb/Platform/FontPlugin.h>
 
 namespace Web::Painting {
@@ -739,7 +740,7 @@ Optional<HitTestResult> PaintableBox::hit_test(CSSPixelPoint position, HitTestTy
         return {};
 
     if (layout_box().is_viewport()) {
-        const_cast<Layout::Viewport&>(static_cast<Layout::Viewport const&>(layout_box())).build_stacking_context_tree_if_needed();
+        const_cast<ViewportPaintable&>(static_cast<ViewportPaintable const&>(*this)).build_stacking_context_tree_if_needed();
         return stacking_context()->hit_test(position, type);
     }
 

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.h
@@ -218,7 +218,7 @@ private:
     Optional<TableCellCoordinates> m_table_cell_coordinates;
 };
 
-class PaintableWithLines final : public PaintableBox {
+class PaintableWithLines : public PaintableBox {
     JS_CELL(PaintableWithLines, PaintableBox);
 
 public:

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.h
@@ -197,6 +197,8 @@ protected:
     Vector<ShadowData> resolve_box_shadow_data() const;
 
 private:
+    [[nodiscard]] virtual bool is_paintable_box() const final { return true; }
+
     Optional<OverflowData> m_overflow_data;
 
     CSSPixelPoint m_offset;
@@ -249,6 +251,8 @@ protected:
     PaintableWithLines(Layout::BlockContainer const&);
 
 private:
+    [[nodiscard]] virtual bool is_paintable_with_lines() const final { return true; }
+
     Vector<Layout::LineBox> m_line_boxes;
 };
 

--- a/Userland/Libraries/LibWeb/Painting/StackingContext.h
+++ b/Userland/Libraries/LibWeb/Painting/StackingContext.h
@@ -8,19 +8,18 @@
 
 #include <AK/Vector.h>
 #include <LibGfx/Matrix4x4.h>
-#include <LibWeb/Layout/Node.h>
 #include <LibWeb/Painting/Paintable.h>
 
 namespace Web::Painting {
 
 class StackingContext {
 public:
-    StackingContext(Layout::Box&, StackingContext* parent, size_t index_in_tree_order);
+    StackingContext(PaintableBox&, StackingContext* parent, size_t index_in_tree_order);
 
     StackingContext* parent() { return m_parent; }
     StackingContext const* parent() const { return m_parent; }
 
-    PaintableBox const& paintable_box() const { return *m_box->paintable_box(); }
+    PaintableBox const& paintable_box() const { return *m_paintable_box; }
 
     enum class StackingContextPaintPhase {
         BackgroundAndBorders,
@@ -30,7 +29,7 @@ public:
         FocusAndOverlay,
     };
 
-    void paint_descendants(PaintContext&, Layout::Node const&, StackingContextPaintPhase) const;
+    void paint_descendants(PaintContext&, Paintable const&, StackingContextPaintPhase) const;
     void paint(PaintContext&) const;
     Optional<HitTestResult> hit_test(CSSPixelPoint, HitTestType) const;
 
@@ -42,7 +41,7 @@ public:
     void sort();
 
 private:
-    JS::NonnullGCPtr<Layout::Box> m_box;
+    JS::NonnullGCPtr<PaintableBox> m_paintable_box;
     Gfx::FloatMatrix4x4 m_transform;
     Gfx::FloatPoint m_transform_origin;
     StackingContext* const m_parent { nullptr };

--- a/Userland/Libraries/LibWeb/Painting/TableBordersPainting.h
+++ b/Userland/Libraries/LibWeb/Painting/TableBordersPainting.h
@@ -10,6 +10,6 @@
 
 namespace Web::Painting {
 
-void paint_table_borders(PaintContext&, Layout::Node const&);
+void paint_table_borders(PaintContext&, PaintableBox const& table_paintable);
 
 }

--- a/Userland/Libraries/LibWeb/Painting/ViewportPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/ViewportPaintable.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibWeb/Layout/Viewport.h>
+#include <LibWeb/Painting/StackingContext.h>
 #include <LibWeb/Painting/ViewportPaintable.h>
 
 namespace Web::Painting {
@@ -20,5 +21,40 @@ ViewportPaintable::ViewportPaintable(Layout::Viewport const& layout_viewport)
 }
 
 ViewportPaintable::~ViewportPaintable() = default;
+
+void ViewportPaintable::build_stacking_context_tree_if_needed()
+{
+    if (stacking_context())
+        return;
+    build_stacking_context_tree();
+}
+
+void ViewportPaintable::build_stacking_context_tree()
+{
+    set_stacking_context(make<StackingContext>(layout_box(), nullptr, 0));
+
+    size_t index_in_tree_order = 1;
+    for_each_in_subtree_of_type<PaintableBox>([&](PaintableBox const& paintable) {
+        auto& paintable_box = const_cast<PaintableBox&>(paintable);
+        paintable_box.invalidate_stacking_context();
+        if (!paintable_box.layout_box().establishes_stacking_context()) {
+            VERIFY(!paintable_box.stacking_context());
+            return TraversalDecision::Continue;
+        }
+        auto* parent_context = paintable_box.enclosing_stacking_context();
+        VERIFY(parent_context);
+        paintable_box.set_stacking_context(make<Painting::StackingContext>(paintable_box.layout_box(), parent_context, index_in_tree_order++));
+        return TraversalDecision::Continue;
+    });
+
+    stacking_context()->sort();
+}
+
+void ViewportPaintable::paint_all_phases(PaintContext& context)
+{
+    build_stacking_context_tree_if_needed();
+    context.painter().translate(-context.device_viewport_rect().location().to_type<int>());
+    stacking_context()->paint(context);
+}
 
 }

--- a/Userland/Libraries/LibWeb/Painting/ViewportPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/ViewportPaintable.cpp
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2023, Andreas Kling <kling@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWeb/Layout/Viewport.h>
+#include <LibWeb/Painting/ViewportPaintable.h>
+
+namespace Web::Painting {
+
+JS::NonnullGCPtr<ViewportPaintable> ViewportPaintable::create(Layout::Viewport const& layout_viewport)
+{
+    return layout_viewport.heap().allocate_without_realm<ViewportPaintable>(layout_viewport);
+}
+
+ViewportPaintable::ViewportPaintable(Layout::Viewport const& layout_viewport)
+    : PaintableWithLines(layout_viewport)
+{
+}
+
+ViewportPaintable::~ViewportPaintable() = default;
+
+}

--- a/Userland/Libraries/LibWeb/Painting/ViewportPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/ViewportPaintable.cpp
@@ -31,7 +31,7 @@ void ViewportPaintable::build_stacking_context_tree_if_needed()
 
 void ViewportPaintable::build_stacking_context_tree()
 {
-    set_stacking_context(make<StackingContext>(layout_box(), nullptr, 0));
+    set_stacking_context(make<StackingContext>(*this, nullptr, 0));
 
     size_t index_in_tree_order = 1;
     for_each_in_subtree_of_type<PaintableBox>([&](PaintableBox const& paintable) {
@@ -43,7 +43,7 @@ void ViewportPaintable::build_stacking_context_tree()
         }
         auto* parent_context = paintable_box.enclosing_stacking_context();
         VERIFY(parent_context);
-        paintable_box.set_stacking_context(make<Painting::StackingContext>(paintable_box.layout_box(), parent_context, index_in_tree_order++));
+        paintable_box.set_stacking_context(make<Painting::StackingContext>(paintable_box, parent_context, index_in_tree_order++));
         return TraversalDecision::Continue;
     });
 

--- a/Userland/Libraries/LibWeb/Painting/ViewportPaintable.h
+++ b/Userland/Libraries/LibWeb/Painting/ViewportPaintable.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2023, Andreas Kling <kling@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibWeb/Painting/PaintableBox.h>
+
+namespace Web::Painting {
+
+class ViewportPaintable final : public PaintableWithLines {
+    JS_CELL(ViewportPaintable, PaintableWithLines);
+
+public:
+    static JS::NonnullGCPtr<ViewportPaintable> create(Layout::Viewport const&);
+    virtual ~ViewportPaintable() override;
+
+private:
+    explicit ViewportPaintable(Layout::Viewport const&);
+};
+
+}

--- a/Userland/Libraries/LibWeb/Painting/ViewportPaintable.h
+++ b/Userland/Libraries/LibWeb/Painting/ViewportPaintable.h
@@ -17,7 +17,12 @@ public:
     static JS::NonnullGCPtr<ViewportPaintable> create(Layout::Viewport const&);
     virtual ~ViewportPaintable() override;
 
+    void paint_all_phases(PaintContext&);
+    void build_stacking_context_tree_if_needed();
+
 private:
+    void build_stacking_context_tree();
+
     explicit ViewportPaintable(Layout::Viewport const&);
 };
 

--- a/Userland/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
@@ -12,6 +12,7 @@
 #include <LibWeb/HTML/Parser/HTMLParser.h>
 #include <LibWeb/Layout/Viewport.h>
 #include <LibWeb/Painting/PaintContext.h>
+#include <LibWeb/Painting/ViewportPaintable.h>
 #include <LibWeb/SVG/SVGDecodedImageData.h>
 #include <LibWeb/SVG/SVGSVGElement.h>
 
@@ -99,7 +100,7 @@ void SVGDecodedImageData::render(Gfx::IntSize size) const
     Gfx::Painter painter(*m_bitmap);
     PaintContext context(painter, m_page_client->palette(), m_page_client->device_pixels_per_css_pixel());
 
-    m_document->layout_node()->paint_all_phases(context);
+    verify_cast<Painting::ViewportPaintable>(*m_document->paintable_box()).paint_all_phases(context);
 }
 
 RefPtr<Gfx::Bitmap const> SVGDecodedImageData::bitmap(size_t, Gfx::IntSize size) const

--- a/Userland/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
@@ -100,7 +100,7 @@ void SVGDecodedImageData::render(Gfx::IntSize size) const
     Gfx::Painter painter(*m_bitmap);
     PaintContext context(painter, m_page_client->palette(), m_page_client->device_pixels_per_css_pixel());
 
-    verify_cast<Painting::ViewportPaintable>(*m_document->paintable_box()).paint_all_phases(context);
+    m_document->paintable()->paint_all_phases(context);
 }
 
 RefPtr<Gfx::Bitmap const> SVGDecodedImageData::bitmap(size_t, Gfx::IntSize size) const

--- a/Userland/Libraries/LibWeb/SVG/SVGSymbolElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGSymbolElement.cpp
@@ -10,6 +10,7 @@
 #include <LibWeb/CSS/StyleValues/IdentifierStyleValue.h>
 #include <LibWeb/CSS/StyleValues/OverflowStyleValue.h>
 #include <LibWeb/DOM/ShadowRoot.h>
+#include <LibWeb/Layout/Box.h>
 #include <LibWeb/SVG/AttributeNames.h>
 #include <LibWeb/SVG/SVGSymbolElement.h>
 #include <LibWeb/SVG/SVGUseElement.h>
@@ -60,6 +61,11 @@ bool SVGSymbolElement::is_direct_child_of_use_shadow_tree() const
 
     auto host = static_cast<const DOM::ShadowRoot&>(*maybe_shadow_root).host();
     return is<SVGUseElement>(host);
+}
+
+JS::GCPtr<Layout::Node> SVGSymbolElement::create_layout_node(NonnullRefPtr<CSS::StyleProperties> style)
+{
+    return heap().allocate_without_realm<Layout::Box>(document(), this, move(style));
 }
 
 }

--- a/Userland/Libraries/LibWeb/SVG/SVGSymbolElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGSymbolElement.h
@@ -25,6 +25,8 @@ private:
 
     virtual void initialize(JS::Realm&) override;
 
+    virtual JS::GCPtr<Layout::Node> create_layout_node(NonnullRefPtr<CSS::StyleProperties>) override;
+
     bool is_direct_child_of_use_shadow_tree() const;
 
     virtual void attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value) override;

--- a/Userland/Libraries/LibWeb/SVG/SVGUseElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGUseElement.cpp
@@ -9,6 +9,7 @@
 #include <LibWeb/DOM/ElementFactory.h>
 #include <LibWeb/DOM/Event.h>
 #include <LibWeb/DOM/ShadowRoot.h>
+#include <LibWeb/Layout/Box.h>
 #include <LibWeb/Namespace.h>
 #include <LibWeb/SVG/AttributeNames.h>
 #include <LibWeb/SVG/SVGSVGElement.h>
@@ -170,6 +171,11 @@ JS::GCPtr<SVGElement> SVGUseElement::instance_root() const
 JS::GCPtr<SVGElement> SVGUseElement::animated_instance_root() const
 {
     return instance_root();
+}
+
+JS::GCPtr<Layout::Node> SVGUseElement::create_layout_node(NonnullRefPtr<CSS::StyleProperties> style)
+{
+    return heap().allocate_without_realm<Layout::Box>(document(), this, move(style));
 }
 
 }

--- a/Userland/Libraries/LibWeb/SVG/SVGUseElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGUseElement.h
@@ -42,6 +42,8 @@ private:
 
     virtual bool is_svg_use_element() const override { return true; }
 
+    virtual JS::GCPtr<Layout::Node> create_layout_node(NonnullRefPtr<CSS::StyleProperties>) override;
+
     Optional<StringView> parse_id_from_href(DeprecatedString const& href);
 
     JS::GCPtr<DOM::Element> referenced_element();

--- a/Userland/Libraries/LibWeb/TreeNode.h
+++ b/Userland/Libraries/LibWeb/TreeNode.h
@@ -109,8 +109,6 @@ public:
     void insert_before(JS::NonnullGCPtr<T> node, JS::GCPtr<T> child);
     void remove_child(JS::NonnullGCPtr<T> node);
 
-    bool is_child_allowed(T const&) const { return true; }
-
     T* next_in_pre_order()
     {
         if (first_child())
@@ -465,9 +463,6 @@ inline void TreeNode<T>::append_child(JS::NonnullGCPtr<T> node)
 {
     VERIFY(!node->m_parent);
 
-    if (!static_cast<T*>(this)->is_child_allowed(*node))
-        return;
-
     if (m_last_child)
         m_last_child->m_next_sibling = node.ptr();
     node->m_previous_sibling = m_last_child;
@@ -504,9 +499,6 @@ template<typename T>
 inline void TreeNode<T>::prepend_child(JS::NonnullGCPtr<T> node)
 {
     VERIFY(!node->m_parent);
-
-    if (!static_cast<T*>(this)->is_child_allowed(*node))
-        return;
 
     if (m_first_child)
         m_first_child->m_previous_sibling = node.ptr();

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -31,8 +31,8 @@
 #include <LibWeb/Loader/ContentFilter.h>
 #include <LibWeb/Loader/ProxyMappings.h>
 #include <LibWeb/Loader/ResourceLoader.h>
-#include <LibWeb/Painting/PaintableBox.h>
 #include <LibWeb/Painting/StackingContext.h>
+#include <LibWeb/Painting/ViewportPaintable.h>
 #include <LibWeb/PermissionsPolicy/AutoplayAllowlist.h>
 #include <LibWeb/Platform/EventLoopPlugin.h>
 #include <WebContent/ConnectionFromClient.h>

--- a/Userland/Services/WebContent/PageHost.cpp
+++ b/Userland/Services/WebContent/PageHost.cpp
@@ -122,8 +122,10 @@ void PageHost::paint(Web::DevicePixelRect const& content_rect, Gfx::Bitmap& targ
     Gfx::Painter painter(target);
     Gfx::IntRect bitmap_rect { {}, content_rect.size().to_type<int>() };
 
-    if (auto* document = page().top_level_browsing_context().active_document())
+    auto document = page().top_level_browsing_context().active_document();
+    if (document) {
         document->update_layout();
+    }
 
     auto background_color = this->background_color();
 
@@ -131,16 +133,14 @@ void PageHost::paint(Web::DevicePixelRect const& content_rect, Gfx::Bitmap& targ
         painter.clear_rect(bitmap_rect, palette().base());
     painter.fill_rect(bitmap_rect, background_color);
 
-    auto* layout_root = this->layout_root();
-    if (!layout_root) {
+    if (!document->paintable())
         return;
-    }
 
     Web::PaintContext context(painter, palette(), device_pixels_per_css_pixel());
     context.set_should_show_line_box_borders(m_should_show_line_box_borders);
     context.set_device_viewport_rect(content_rect);
     context.set_has_focus(m_has_focus);
-    verify_cast<Web::Painting::ViewportPaintable>(*layout_root->paintable_box()).paint_all_phases(context);
+    document->paintable()->paint_all_phases(context);
 }
 
 void PageHost::set_viewport_rect(Web::DevicePixelRect const& rect)

--- a/Userland/Services/WebContent/PageHost.cpp
+++ b/Userland/Services/WebContent/PageHost.cpp
@@ -14,6 +14,7 @@
 #include <LibWeb/HTML/BrowsingContext.h>
 #include <LibWeb/Layout/Viewport.h>
 #include <LibWeb/Painting/PaintableBox.h>
+#include <LibWeb/Painting/ViewportPaintable.h>
 #include <LibWeb/Platform/Timer.h>
 #include <WebContent/WebContentClientEndpoint.h>
 #include <WebContent/WebDriverConnection.h>
@@ -139,7 +140,7 @@ void PageHost::paint(Web::DevicePixelRect const& content_rect, Gfx::Bitmap& targ
     context.set_should_show_line_box_borders(m_should_show_line_box_borders);
     context.set_device_viewport_rect(content_rect);
     context.set_has_focus(m_has_focus);
-    layout_root->paint_all_phases(context);
+    verify_cast<Web::Painting::ViewportPaintable>(*layout_root->paintable_box()).paint_all_phases(context);
 }
 
 void PageHost::set_viewport_rect(Web::DevicePixelRect const& rect)


### PR DESCRIPTION
The paint tree (`Paintable` and pals) is eventually meant to be a completely separate tree, produced by layout.

Today, since the paint tree refactoring is not yet finished, it still piggybacks heavily on the layout tree, by reaching into the originating layout nodes for various functionality, including basic traversal.

This PR takes a bunch of pretty big steps towards paint tree independence, but there is still work remaining.

For this work to be truly finished, there should be no `to_px(layout_node)` calls anywhere in paint code, and no references to layout nodes whatsoever.