### PR TITLE
LibWeb: Use `Core::Timer` for cursor blink timer in `BrowsingContext`

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
@@ -439,14 +439,14 @@ BrowsingContext::BrowsingContext(Page& page, HTML::NavigableContainer* container
     , m_event_handler({}, *this)
     , m_container(container)
 {
-    m_cursor_blink_timer = Platform::Timer::create_repeating(500, [this] {
+    m_cursor_blink_timer = Core::Timer::create_repeating(500, [this] {
         if (!is_focused_context())
             return;
         if (m_cursor_position.node() && m_cursor_position.node()->layout_node()) {
             m_cursor_blink_state = !m_cursor_blink_state;
             m_cursor_position.node()->layout_node()->set_needs_display();
         }
-    });
+    }).release_value_but_fixme_should_propagate_errors();
 }
 
 BrowsingContext::~BrowsingContext() = default;

--- a/Userland/Libraries/LibWeb/HTML/BrowsingContext.h
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContext.h
@@ -321,7 +321,7 @@ private:
     JS::GCPtr<HTML::WindowProxy> m_window_proxy;
 
     DOM::Position m_cursor_position;
-    RefPtr<Platform::Timer> m_cursor_blink_timer;
+    RefPtr<Core::Timer> m_cursor_blink_timer;
     bool m_cursor_blink_state { false };
 
     HashTable<ViewportClient*> m_viewport_clients;


### PR DESCRIPTION
Using `Core::Timer` that doesn't implicitly convert callback to `JS::SafeFunction` fixes the bug when `BrowsingContext` is never destroyed because of cyclic dependency between callback and `BrowsingContext`.