### PR TITLE
LibWeb: A big dollop of do-ErrorOr-ing CSS stuff

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPropertyID.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPropertyID.cpp
@@ -156,7 +156,7 @@ Optional<PropertyID> property_id_from_camel_case_string(StringView);
 Optional<PropertyID> property_id_from_string(StringView);
 StringView string_from_property_id(PropertyID);
 bool is_inherited_property(PropertyID);
-ErrorOr<NonnullRefPtr<StyleValue>> property_initial_value(JS::Realm&, PropertyID);
+NonnullRefPtr<StyleValue> property_initial_value(JS::Realm&, PropertyID);
 
 enum class ValueType {
     Angle,
@@ -496,7 +496,7 @@ bool property_affects_stacking_context(PropertyID property_id)
     }
 }
 
-ErrorOr<NonnullRefPtr<StyleValue>> property_initial_value(JS::Realm& context_realm, PropertyID property_id)
+NonnullRefPtr<StyleValue> property_initial_value(JS::Realm& context_realm, PropertyID property_id)
 {
     static Array<RefPtr<StyleValue>, to_underlying(last_property_id) + 1> initial_values;
     if (auto initial_value = initial_values[to_underlying(property_id)])
@@ -525,7 +525,7 @@ ErrorOr<NonnullRefPtr<StyleValue>> property_initial_value(JS::Realm& context_rea
         TRY(member_generator.try_append(
             R"~~~(        case PropertyID::@name:titlecase@:
         {
-            auto parsed_value = TRY(parse_css_value(parsing_context, "@initial_value_string@"sv, PropertyID::@name:titlecase@));
+            auto parsed_value = parse_css_value(parsing_context, "@initial_value_string@"sv, PropertyID::@name:titlecase@);
             VERIFY(!parsed_value.is_null());
             auto initial_value = parsed_value.release_nonnull();
             initial_values[to_underlying(PropertyID::@name:titlecase@)] = initial_value;

--- a/Userland/Libraries/LibWeb/CSS/CSS.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSS.cpp
@@ -28,7 +28,7 @@ bool supports(JS::VM& vm, StringView property, StringView value)
     // 1. If property is an ASCII case-insensitive match for any defined CSS property that the UA supports,
     //    and value successfully parses according to that property’s grammar, return true.
     if (auto property_id = property_id_from_string(property); property_id.has_value()) {
-        if (parse_css_value(Parser::ParsingContext { realm }, value, property_id.value()).release_value_but_fixme_should_propagate_errors())
+        if (parse_css_value(Parser::ParsingContext { realm }, value, property_id.value()))
             return true;
     }
 

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleDeclaration.cpp
@@ -100,8 +100,8 @@ WebIDL::ExceptionOr<void> PropertyOwningCSSStyleDeclaration::set_property(Proper
 
     // 5. Let component value list be the result of parsing value for property property.
     auto component_value_list = is<ElementInlineCSSStyleDeclaration>(this)
-        ? MUST(parse_css_value(CSS::Parser::ParsingContext { static_cast<ElementInlineCSSStyleDeclaration&>(*this).element()->document() }, value, property_id))
-        : MUST(parse_css_value(CSS::Parser::ParsingContext { realm() }, value, property_id));
+        ? parse_css_value(CSS::Parser::ParsingContext { static_cast<ElementInlineCSSStyleDeclaration&>(*this).element()->document() }, value, property_id)
+        : parse_css_value(CSS::Parser::ParsingContext { realm() }, value, property_id);
 
     // 6. If component value list is null, then return.
     if (!component_value_list)

--- a/Userland/Libraries/LibWeb/CSS/Parser/GradientParsing.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/GradientParsing.cpp
@@ -46,15 +46,15 @@ static Optional<Vector<TElement>> parse_color_stop_list(auto& tokens, auto is_po
             }
             // <T-percentage> <color>
             auto maybe_color = parse_color(tokens.next_token());
-            if (maybe_color.is_error() || maybe_color.value() == nullptr)
+            if (!maybe_color)
                 return ElementType::Garbage;
-            color = maybe_color.release_value();
+            color = maybe_color.release_nonnull();
         } else {
             // [<color> <T-percentage>?]
             auto maybe_color = parse_color(token);
-            if (maybe_color.is_error() || maybe_color.value() == nullptr)
+            if (!maybe_color)
                 return ElementType::Garbage;
-            color = maybe_color.release_value();
+            color = maybe_color.release_nonnull();
             tokens.skip_whitespace();
             // Allow up to [<color> <T-percentage> <T-percentage>] (double-position color stops)
             // Note: Double-position color stops only appear to be valid in this order.
@@ -140,7 +140,7 @@ Optional<Vector<AngularColorStopListElement>> Parser::parse_angular_color_stop_l
         [&](auto& token) { return parse_dimension(token); });
 }
 
-ErrorOr<RefPtr<StyleValue>> Parser::parse_linear_gradient_function(ComponentValue const& component_value)
+RefPtr<StyleValue> Parser::parse_linear_gradient_function(ComponentValue const& component_value)
 {
     using GradientType = LinearGradientStyleValue::GradientType;
 
@@ -268,7 +268,7 @@ ErrorOr<RefPtr<StyleValue>> Parser::parse_linear_gradient_function(ComponentValu
     return LinearGradientStyleValue::create(gradient_direction, move(*color_stops), gradient_type, repeating_gradient);
 }
 
-ErrorOr<RefPtr<StyleValue>> Parser::parse_conic_gradient_function(ComponentValue const& component_value)
+RefPtr<StyleValue> Parser::parse_conic_gradient_function(ComponentValue const& component_value)
 {
     if (!component_value.is_function())
         return nullptr;
@@ -365,7 +365,7 @@ ErrorOr<RefPtr<StyleValue>> Parser::parse_conic_gradient_function(ComponentValue
     return ConicGradientStyleValue::create(from_angle, at_position, move(*color_stops), repeating_gradient);
 }
 
-ErrorOr<RefPtr<StyleValue>> Parser::parse_radial_gradient_function(ComponentValue const& component_value)
+RefPtr<StyleValue> Parser::parse_radial_gradient_function(ComponentValue const& component_value)
 {
     using EndingShape = RadialGradientStyleValue::EndingShape;
     using Extent = RadialGradientStyleValue::Extent;

--- a/Userland/Libraries/LibWeb/CSS/Parser/Helpers.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Helpers.cpp
@@ -34,11 +34,11 @@ CSS::ElementInlineCSSStyleDeclaration* parse_css_style_attribute(CSS::Parser::Pa
     return parser.parse_as_style_attribute(element);
 }
 
-ErrorOr<RefPtr<CSS::StyleValue>> parse_css_value(CSS::Parser::ParsingContext const& context, StringView string, CSS::PropertyID property_id)
+RefPtr<CSS::StyleValue> parse_css_value(CSS::Parser::ParsingContext const& context, StringView string, CSS::PropertyID property_id)
 {
     if (string.is_empty())
         return nullptr;
-    auto parser = TRY(CSS::Parser::Parser::create(context, string));
+    auto parser = MUST(CSS::Parser::Parser::create(context, string));
     return parser.parse_as_css_value(property_id);
 }
 

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -2717,14 +2717,14 @@ RefPtr<StyleValue> Parser::parse_background_value(Vector<ComponentValue> const& 
     StyleValueVector background_origins;
     RefPtr<StyleValue> background_color;
 
-    auto initial_background_image = MUST(property_initial_value(m_context.realm(), PropertyID::BackgroundImage));
-    auto initial_background_position = MUST(property_initial_value(m_context.realm(), PropertyID::BackgroundPosition));
-    auto initial_background_size = MUST(property_initial_value(m_context.realm(), PropertyID::BackgroundSize));
-    auto initial_background_repeat = MUST(property_initial_value(m_context.realm(), PropertyID::BackgroundRepeat));
-    auto initial_background_attachment = MUST(property_initial_value(m_context.realm(), PropertyID::BackgroundAttachment));
-    auto initial_background_clip = MUST(property_initial_value(m_context.realm(), PropertyID::BackgroundClip));
-    auto initial_background_origin = MUST(property_initial_value(m_context.realm(), PropertyID::BackgroundOrigin));
-    auto initial_background_color = MUST(property_initial_value(m_context.realm(), PropertyID::BackgroundColor));
+    auto initial_background_image = property_initial_value(m_context.realm(), PropertyID::BackgroundImage);
+    auto initial_background_position = property_initial_value(m_context.realm(), PropertyID::BackgroundPosition);
+    auto initial_background_size = property_initial_value(m_context.realm(), PropertyID::BackgroundSize);
+    auto initial_background_repeat = property_initial_value(m_context.realm(), PropertyID::BackgroundRepeat);
+    auto initial_background_attachment = property_initial_value(m_context.realm(), PropertyID::BackgroundAttachment);
+    auto initial_background_clip = property_initial_value(m_context.realm(), PropertyID::BackgroundClip);
+    auto initial_background_origin = property_initial_value(m_context.realm(), PropertyID::BackgroundOrigin);
+    auto initial_background_color = property_initial_value(m_context.realm(), PropertyID::BackgroundColor);
 
     // Per-layer values
     RefPtr<StyleValue> background_image;
@@ -3297,11 +3297,11 @@ RefPtr<StyleValue> Parser::parse_border_value(Vector<ComponentValue> const& comp
     }
 
     if (!border_width)
-        border_width = MUST(property_initial_value(m_context.realm(), PropertyID::BorderWidth));
+        border_width = property_initial_value(m_context.realm(), PropertyID::BorderWidth);
     if (!border_style)
-        border_style = MUST(property_initial_value(m_context.realm(), PropertyID::BorderStyle));
+        border_style = property_initial_value(m_context.realm(), PropertyID::BorderStyle);
     if (!border_color)
-        border_color = MUST(property_initial_value(m_context.realm(), PropertyID::BorderColor));
+        border_color = property_initial_value(m_context.realm(), PropertyID::BorderColor);
 
     return BorderStyleValue::create(border_width.release_nonnull(), border_style.release_nonnull(), border_color.release_nonnull());
 }
@@ -4006,9 +4006,9 @@ RefPtr<StyleValue> Parser::parse_flex_value(Vector<ComponentValue> const& compon
     }
 
     if (!flex_grow)
-        flex_grow = MUST(property_initial_value(m_context.realm(), PropertyID::FlexGrow));
+        flex_grow = property_initial_value(m_context.realm(), PropertyID::FlexGrow);
     if (!flex_shrink)
-        flex_shrink = MUST(property_initial_value(m_context.realm(), PropertyID::FlexShrink));
+        flex_shrink = property_initial_value(m_context.realm(), PropertyID::FlexShrink);
     if (!flex_basis) {
         // NOTE: The spec says that flex-basis should be 0 here, but other engines currently use 0%.
         // https://github.com/w3c/csswg-drafts/issues/5742
@@ -4050,9 +4050,9 @@ RefPtr<StyleValue> Parser::parse_flex_flow_value(Vector<ComponentValue> const& c
     }
 
     if (!flex_direction)
-        flex_direction = MUST(property_initial_value(m_context.realm(), PropertyID::FlexDirection));
+        flex_direction = property_initial_value(m_context.realm(), PropertyID::FlexDirection);
     if (!flex_wrap)
-        flex_wrap = MUST(property_initial_value(m_context.realm(), PropertyID::FlexWrap));
+        flex_wrap = property_initial_value(m_context.realm(), PropertyID::FlexWrap);
 
     return FlexFlowStyleValue::create(flex_direction.release_nonnull(), flex_wrap.release_nonnull());
 }
@@ -4169,13 +4169,13 @@ RefPtr<StyleValue> Parser::parse_font_value(Vector<ComponentValue> const& compon
         return nullptr;
 
     if (!font_stretch)
-        font_stretch = MUST(property_initial_value(m_context.realm(), PropertyID::FontStretch));
+        font_stretch = property_initial_value(m_context.realm(), PropertyID::FontStretch);
     if (!font_style)
-        font_style = MUST(property_initial_value(m_context.realm(), PropertyID::FontStyle));
+        font_style = property_initial_value(m_context.realm(), PropertyID::FontStyle);
     if (!font_weight)
-        font_weight = MUST(property_initial_value(m_context.realm(), PropertyID::FontWeight));
+        font_weight = property_initial_value(m_context.realm(), PropertyID::FontWeight);
     if (!line_height)
-        line_height = MUST(property_initial_value(m_context.realm(), PropertyID::LineHeight));
+        line_height = property_initial_value(m_context.realm(), PropertyID::LineHeight);
 
     return FontStyleValue::create(font_stretch.release_nonnull(), font_style.release_nonnull(), font_weight.release_nonnull(), font_size.release_nonnull(), line_height.release_nonnull(), font_families.release_nonnull());
 }
@@ -4528,11 +4528,11 @@ RefPtr<StyleValue> Parser::parse_list_style_value(Vector<ComponentValue> const& 
     }
 
     if (!list_position)
-        list_position = MUST(property_initial_value(m_context.realm(), PropertyID::ListStylePosition));
+        list_position = property_initial_value(m_context.realm(), PropertyID::ListStylePosition);
     if (!list_image)
-        list_image = MUST(property_initial_value(m_context.realm(), PropertyID::ListStyleImage));
+        list_image = property_initial_value(m_context.realm(), PropertyID::ListStyleImage);
     if (!list_type)
-        list_type = MUST(property_initial_value(m_context.realm(), PropertyID::ListStyleType));
+        list_type = property_initial_value(m_context.realm(), PropertyID::ListStyleType);
 
     return ListStyleStyleValue::create(list_position.release_nonnull(), list_image.release_nonnull(), list_type.release_nonnull());
 }
@@ -4666,13 +4666,13 @@ RefPtr<StyleValue> Parser::parse_text_decoration_value(Vector<ComponentValue> co
     }
 
     if (!decoration_line)
-        decoration_line = MUST(property_initial_value(m_context.realm(), PropertyID::TextDecorationLine));
+        decoration_line = property_initial_value(m_context.realm(), PropertyID::TextDecorationLine);
     if (!decoration_thickness)
-        decoration_thickness = MUST(property_initial_value(m_context.realm(), PropertyID::TextDecorationThickness));
+        decoration_thickness = property_initial_value(m_context.realm(), PropertyID::TextDecorationThickness);
     if (!decoration_style)
-        decoration_style = MUST(property_initial_value(m_context.realm(), PropertyID::TextDecorationStyle));
+        decoration_style = property_initial_value(m_context.realm(), PropertyID::TextDecorationStyle);
     if (!decoration_color)
-        decoration_color = MUST(property_initial_value(m_context.realm(), PropertyID::TextDecorationColor));
+        decoration_color = property_initial_value(m_context.realm(), PropertyID::TextDecorationColor);
 
     return TextDecorationStyleValue::create(decoration_line.release_nonnull(), decoration_thickness.release_nonnull(), decoration_style.release_nonnull(), decoration_color.release_nonnull());
 }
@@ -5923,7 +5923,7 @@ Parser::ParseErrorOr<NonnullRefPtr<StyleValue>> Parser::parse_css_value(Property
     }
 
     for (auto& property : unassigned_properties)
-        assigned_values.ensure(to_underlying(property)).append(MUST(property_initial_value(m_context.realm(), property)));
+        assigned_values.ensure(to_underlying(property)).append(property_initial_value(m_context.realm(), property));
 
     stream.skip_whitespace();
     if (stream.has_next_token())
@@ -6486,18 +6486,18 @@ bool Parser::is_builtin(StringView name)
         || name.equals_ignoring_ascii_case("unset"sv);
 }
 
-ErrorOr<RefPtr<CalculatedStyleValue>> Parser::parse_calculated_value(Badge<StyleComputer>, ParsingContext const& context, ComponentValue const& token)
+RefPtr<CalculatedStyleValue> Parser::parse_calculated_value(Badge<StyleComputer>, ParsingContext const& context, ComponentValue const& token)
 {
-    auto parser = TRY(Parser::create(context, ""sv));
+    auto parser = MUST(Parser::create(context, ""sv));
     return parser.parse_calculated_value(token);
 }
 
-ErrorOr<RefPtr<StyleValue>> Parser::parse_css_value(Badge<StyleComputer>, ParsingContext const& context, PropertyID property_id, Vector<ComponentValue> const& tokens)
+RefPtr<StyleValue> Parser::parse_css_value(Badge<StyleComputer>, ParsingContext const& context, PropertyID property_id, Vector<ComponentValue> const& tokens)
 {
     if (tokens.is_empty() || property_id == CSS::PropertyID::Invalid || property_id == CSS::PropertyID::Custom)
         return nullptr;
 
-    auto parser = TRY(Parser::create(context, ""sv));
+    auto parser = MUST(Parser::create(context, ""sv));
     TokenStream<ComponentValue> token_stream { tokens };
     auto result = parser.parse_css_value(property_id, token_stream);
     if (result.is_error())

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -2804,12 +2804,12 @@ RefPtr<StyleValue> Parser::parse_background_value(Vector<ComponentValue> const& 
         }
 
         auto value_and_property = parse_css_value_for_properties(remaining_layer_properties, tokens);
-        if (!value_and_property.style_value)
+        if (!value_and_property.has_value())
             return nullptr;
-        auto& value = value_and_property.style_value;
-        remove_property(remaining_layer_properties, value_and_property.property);
+        auto& value = value_and_property->style_value;
+        remove_property(remaining_layer_properties, value_and_property->property);
 
-        switch (value_and_property.property) {
+        switch (value_and_property->property) {
         case PropertyID::BackgroundAttachment:
             VERIFY(!background_attachment);
             background_attachment = value.release_nonnull();
@@ -3270,12 +3270,12 @@ RefPtr<StyleValue> Parser::parse_border_value(Vector<ComponentValue> const& comp
     auto tokens = TokenStream { component_values };
     while (tokens.has_next_token()) {
         auto property_and_value = parse_css_value_for_properties(remaining_longhands, tokens);
-        if (!property_and_value.style_value)
+        if (!property_and_value.has_value())
             return nullptr;
-        auto& value = property_and_value.style_value;
-        remove_property(remaining_longhands, property_and_value.property);
+        auto& value = property_and_value->style_value;
+        remove_property(remaining_longhands, property_and_value->property);
 
-        switch (property_and_value.property) {
+        switch (property_and_value->property) {
         case PropertyID::BorderWidth: {
             VERIFY(!border_width);
             border_width = value.release_nonnull();
@@ -3939,11 +3939,11 @@ RefPtr<StyleValue> Parser::parse_flex_value(Vector<ComponentValue> const& compon
         // One-value syntax: <flex-grow> | <flex-basis> | none
         auto properties = Array { PropertyID::FlexGrow, PropertyID::FlexBasis, PropertyID::Flex };
         auto property_and_value = parse_css_value_for_properties(properties, tokens);
-        if (!property_and_value.style_value)
+        if (!property_and_value.has_value())
             return nullptr;
 
-        auto& value = property_and_value.style_value;
-        switch (property_and_value.property) {
+        auto& value = property_and_value->style_value;
+        switch (property_and_value->property) {
         case PropertyID::FlexGrow: {
             // NOTE: The spec says that flex-basis should be 0 here, but other engines currently use 0%.
             // https://github.com/w3c/csswg-drafts/issues/5742
@@ -3979,12 +3979,12 @@ RefPtr<StyleValue> Parser::parse_flex_value(Vector<ComponentValue> const& compon
 
     while (tokens.has_next_token()) {
         auto property_and_value = parse_css_value_for_properties(remaining_longhands, tokens);
-        if (!property_and_value.style_value)
+        if (!property_and_value.has_value())
             return nullptr;
-        auto& value = property_and_value.style_value;
-        remove_property(remaining_longhands, property_and_value.property);
+        auto& value = property_and_value->style_value;
+        remove_property(remaining_longhands, property_and_value->property);
 
-        switch (property_and_value.property) {
+        switch (property_and_value->property) {
         case PropertyID::FlexGrow: {
             VERIFY(!flex_grow);
             flex_grow = value.release_nonnull();
@@ -4030,12 +4030,12 @@ RefPtr<StyleValue> Parser::parse_flex_flow_value(Vector<ComponentValue> const& c
     auto tokens = TokenStream { component_values };
     while (tokens.has_next_token()) {
         auto property_and_value = parse_css_value_for_properties(remaining_longhands, tokens);
-        if (!property_and_value.style_value)
+        if (!property_and_value.has_value())
             return nullptr;
-        auto& value = property_and_value.style_value;
-        remove_property(remaining_longhands, property_and_value.property);
+        auto& value = property_and_value->style_value;
+        remove_property(remaining_longhands, property_and_value->property);
 
-        switch (property_and_value.property) {
+        switch (property_and_value->property) {
         case PropertyID::FlexDirection:
             VERIFY(!flex_direction);
             flex_direction = value.release_nonnull();
@@ -4103,12 +4103,12 @@ RefPtr<StyleValue> Parser::parse_font_value(Vector<ComponentValue> const& compon
         }
 
         auto property_and_value = parse_css_value_for_properties(remaining_longhands, tokens);
-        if (!property_and_value.style_value)
+        if (!property_and_value.has_value())
             return nullptr;
-        auto& value = property_and_value.style_value;
-        remove_property(remaining_longhands, property_and_value.property);
+        auto& value = property_and_value->style_value;
+        remove_property(remaining_longhands, property_and_value->property);
 
-        switch (property_and_value.property) {
+        switch (property_and_value->property) {
         case PropertyID::FontSize: {
             VERIFY(!font_size);
             font_size = value.release_nonnull();
@@ -4481,12 +4481,12 @@ RefPtr<StyleValue> Parser::parse_list_style_value(Vector<ComponentValue> const& 
         }
 
         auto property_and_value = parse_css_value_for_properties(remaining_longhands, tokens);
-        if (!property_and_value.style_value)
+        if (!property_and_value.has_value())
             return nullptr;
-        auto& value = property_and_value.style_value;
-        remove_property(remaining_longhands, property_and_value.property);
+        auto& value = property_and_value->style_value;
+        remove_property(remaining_longhands, property_and_value->property);
 
-        switch (property_and_value.property) {
+        switch (property_and_value->property) {
         case PropertyID::ListStylePosition: {
             VERIFY(!list_position);
             list_position = value.release_nonnull();
@@ -4630,12 +4630,12 @@ RefPtr<StyleValue> Parser::parse_text_decoration_value(Vector<ComponentValue> co
     auto tokens = TokenStream { component_values };
     while (tokens.has_next_token()) {
         auto property_and_value = parse_css_value_for_properties(remaining_longhands, tokens);
-        if (!property_and_value.style_value)
+        if (!property_and_value.has_value())
             return nullptr;
-        auto& value = property_and_value.style_value;
-        remove_property(remaining_longhands, property_and_value.property);
+        auto& value = property_and_value->style_value;
+        remove_property(remaining_longhands, property_and_value->property);
 
-        switch (property_and_value.property) {
+        switch (property_and_value->property) {
         case PropertyID::TextDecorationColor: {
             VERIFY(!decoration_color);
             decoration_color = value.release_nonnull();
@@ -5902,9 +5902,9 @@ Parser::ParseErrorOr<NonnullRefPtr<StyleValue>> Parser::parse_css_value(Property
 
     while (stream.has_next_token() && !unassigned_properties.is_empty()) {
         auto property_and_value = parse_css_value_for_properties(unassigned_properties, stream);
-        if (property_and_value.style_value) {
-            auto property = property_and_value.property;
-            auto value = property_and_value.style_value;
+        if (property_and_value.has_value()) {
+            auto property = property_and_value->property;
+            auto value = property_and_value->style_value;
             auto& values = assigned_values.ensure(to_underlying(property));
             if (values.size() + 1 == property_maximum_value_count(property)) {
                 // We're done with this property, move on to the next one.
@@ -5948,10 +5948,12 @@ Parser::ParseErrorOr<NonnullRefPtr<StyleValue>> Parser::parse_css_value(Property
 
 RefPtr<StyleValue> Parser::parse_css_value_for_property(PropertyID property_id, TokenStream<ComponentValue>& tokens)
 {
-    return parse_css_value_for_properties({ &property_id, 1 }, tokens).style_value;
+    return parse_css_value_for_properties({ &property_id, 1 }, tokens)
+        .map([](auto& it) { return it.style_value; })
+        .value_or(nullptr);
 }
 
-Parser::PropertyAndValue Parser::parse_css_value_for_properties(ReadonlySpan<PropertyID> property_ids, TokenStream<ComponentValue>& tokens)
+Optional<Parser::PropertyAndValue> Parser::parse_css_value_for_properties(ReadonlySpan<PropertyID> property_ids, TokenStream<ComponentValue>& tokens)
 {
     auto any_property_accepts_type = [](ReadonlySpan<PropertyID> property_ids, ValueType value_type) -> Optional<PropertyID> {
         for (auto const& property : property_ids) {
@@ -6167,7 +6169,7 @@ Parser::PropertyAndValue Parser::parse_css_value_for_properties(ReadonlySpan<Pro
             return PropertyAndValue { *property, value.release_nonnull() };
     }
 
-    return PropertyAndValue { property_ids.first(), nullptr };
+    return OptionalNone {};
 }
 
 class UnparsedCalculationNode final : public CalculationNode {

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -2692,9 +2692,9 @@ ErrorOr<RefPtr<StyleValue>> Parser::parse_aspect_ratio_value(Vector<ComponentVal
     }
 
     if (auto_value && ratio_value) {
-        return TRY(StyleValueList::create(
+        return StyleValueList::create(
             StyleValueVector { auto_value.release_nonnull(), ratio_value.release_nonnull() },
-            StyleValueList::Separator::Space));
+            StyleValueList::Separator::Space);
     }
 
     if (ratio_value)
@@ -2890,13 +2890,13 @@ ErrorOr<RefPtr<StyleValue>> Parser::parse_background_value(Vector<ComponentValue
             background_color = initial_background_color;
         return BackgroundStyleValue::create(
             background_color.release_nonnull(),
-            TRY(StyleValueList::create(move(background_images), StyleValueList::Separator::Comma)),
-            TRY(StyleValueList::create(move(background_positions), StyleValueList::Separator::Comma)),
-            TRY(StyleValueList::create(move(background_sizes), StyleValueList::Separator::Comma)),
-            TRY(StyleValueList::create(move(background_repeats), StyleValueList::Separator::Comma)),
-            TRY(StyleValueList::create(move(background_attachments), StyleValueList::Separator::Comma)),
-            TRY(StyleValueList::create(move(background_origins), StyleValueList::Separator::Comma)),
-            TRY(StyleValueList::create(move(background_clips), StyleValueList::Separator::Comma)));
+            StyleValueList::create(move(background_images), StyleValueList::Separator::Comma),
+            StyleValueList::create(move(background_positions), StyleValueList::Separator::Comma),
+            StyleValueList::create(move(background_sizes), StyleValueList::Separator::Comma),
+            StyleValueList::create(move(background_repeats), StyleValueList::Separator::Comma),
+            StyleValueList::create(move(background_attachments), StyleValueList::Separator::Comma),
+            StyleValueList::create(move(background_origins), StyleValueList::Separator::Comma),
+            StyleValueList::create(move(background_clips), StyleValueList::Separator::Comma));
     }
 
     if (!background_color)
@@ -3096,8 +3096,8 @@ ErrorOr<RefPtr<StyleValue>> Parser::parse_single_background_position_value(Token
 
     transaction.commit();
     return PositionStyleValue::create(
-        TRY(EdgeStyleValue::create(horizontal->edge, horizontal->offset)),
-        TRY(EdgeStyleValue::create(vertical->edge, vertical->offset)));
+        EdgeStyleValue::create(horizontal->edge, horizontal->offset),
+        EdgeStyleValue::create(vertical->edge, vertical->offset));
 }
 
 ErrorOr<RefPtr<StyleValue>> Parser::parse_single_background_position_x_or_y_value(TokenStream<ComponentValue>& tokens, PropertyID property)
@@ -3398,14 +3398,14 @@ ErrorOr<RefPtr<StyleValue>> Parser::parse_border_radius_shorthand_value(Vector<C
         || (reading_vertical && vertical_radii.is_empty()))
         return nullptr;
 
-    auto top_left_radius = TRY(BorderRadiusStyleValue::create(top_left(horizontal_radii),
-        vertical_radii.is_empty() ? top_left(horizontal_radii) : top_left(vertical_radii)));
-    auto top_right_radius = TRY(BorderRadiusStyleValue::create(top_right(horizontal_radii),
-        vertical_radii.is_empty() ? top_right(horizontal_radii) : top_right(vertical_radii)));
-    auto bottom_right_radius = TRY(BorderRadiusStyleValue::create(bottom_right(horizontal_radii),
-        vertical_radii.is_empty() ? bottom_right(horizontal_radii) : bottom_right(vertical_radii)));
-    auto bottom_left_radius = TRY(BorderRadiusStyleValue::create(bottom_left(horizontal_radii),
-        vertical_radii.is_empty() ? bottom_left(horizontal_radii) : bottom_left(vertical_radii)));
+    auto top_left_radius = BorderRadiusStyleValue::create(top_left(horizontal_radii),
+        vertical_radii.is_empty() ? top_left(horizontal_radii) : top_left(vertical_radii));
+    auto top_right_radius = BorderRadiusStyleValue::create(top_right(horizontal_radii),
+        vertical_radii.is_empty() ? top_right(horizontal_radii) : top_right(vertical_radii));
+    auto bottom_right_radius = BorderRadiusStyleValue::create(bottom_right(horizontal_radii),
+        vertical_radii.is_empty() ? bottom_right(horizontal_radii) : bottom_right(vertical_radii));
+    auto bottom_left_radius = BorderRadiusStyleValue::create(bottom_left(horizontal_radii),
+        vertical_radii.is_empty() ? bottom_left(horizontal_radii) : bottom_left(vertical_radii));
 
     return BorderRadiusShorthandStyleValue::create(move(top_left_radius), move(top_right_radius), move(bottom_right_radius), move(bottom_left_radius));
 }
@@ -3520,9 +3520,9 @@ ErrorOr<RefPtr<StyleValue>> Parser::parse_single_shadow_value(TokenStream<Compon
 
     // Other lengths default to 0
     if (!blur_radius)
-        blur_radius = TRY(LengthStyleValue::create(Length::make_px(0)));
+        blur_radius = LengthStyleValue::create(Length::make_px(0));
     if (!spread_distance)
-        spread_distance = TRY(LengthStyleValue::create(Length::make_px(0)));
+        spread_distance = LengthStyleValue::create(Length::make_px(0));
 
     // Placement is outer by default
     if (!placement.has_value())
@@ -3590,9 +3590,9 @@ ErrorOr<RefPtr<StyleValue>> Parser::parse_content_value(Vector<ComponentValue> c
 
     RefPtr<StyleValueList> alt_text;
     if (!alt_text_values.is_empty())
-        alt_text = TRY(StyleValueList::create(move(alt_text_values), StyleValueList::Separator::Space));
+        alt_text = StyleValueList::create(move(alt_text_values), StyleValueList::Separator::Space);
 
-    return ContentStyleValue::create(TRY(StyleValueList::create(move(content_values), StyleValueList::Separator::Space)), move(alt_text));
+    return ContentStyleValue::create(StyleValueList::create(move(content_values), StyleValueList::Separator::Space), move(alt_text));
 }
 
 // https://www.w3.org/TR/css-display-3/#the-display-properties
@@ -3949,18 +3949,18 @@ ErrorOr<RefPtr<StyleValue>> Parser::parse_flex_value(Vector<ComponentValue> cons
         case PropertyID::FlexGrow: {
             // NOTE: The spec says that flex-basis should be 0 here, but other engines currently use 0%.
             // https://github.com/w3c/csswg-drafts/issues/5742
-            auto flex_basis = TRY(PercentageStyleValue::create(Percentage(0)));
-            auto one = TRY(NumberStyleValue::create(1));
+            auto flex_basis = PercentageStyleValue::create(Percentage(0));
+            auto one = NumberStyleValue::create(1);
             return FlexStyleValue::create(*value, one, flex_basis);
         }
         case PropertyID::FlexBasis: {
-            auto one = TRY(NumberStyleValue::create(1));
+            auto one = NumberStyleValue::create(1);
             return FlexStyleValue::create(one, one, *value);
         }
         case PropertyID::Flex: {
             if (value->is_identifier() && value->to_identifier() == ValueID::None) {
-                auto zero = TRY(NumberStyleValue::create(0));
-                return FlexStyleValue::create(zero, zero, TRY(IdentifierStyleValue::create(ValueID::Auto)));
+                auto zero = NumberStyleValue::create(0);
+                return FlexStyleValue::create(zero, zero, IdentifierStyleValue::create(ValueID::Auto));
             }
             break;
         }
@@ -4014,7 +4014,7 @@ ErrorOr<RefPtr<StyleValue>> Parser::parse_flex_value(Vector<ComponentValue> cons
     if (!flex_basis) {
         // NOTE: The spec says that flex-basis should be 0 here, but other engines currently use 0%.
         // https://github.com/w3c/csswg-drafts/issues/5742
-        flex_basis = TRY(PercentageStyleValue::create(Percentage(0)));
+        flex_basis = PercentageStyleValue::create(Percentage(0));
     }
 
     return FlexStyleValue::create(flex_grow.release_nonnull(), flex_shrink.release_nonnull(), flex_basis.release_nonnull());
@@ -4204,7 +4204,7 @@ ErrorOr<RefPtr<StyleValue>> Parser::parse_font_family_value(TokenStream<Componen
             (void)tokens.next_token(); // String
             if (!next_is_comma_or_eof())
                 return nullptr;
-            TRY(font_families.try_append(TRY(StringStyleValue::create(TRY(String::from_utf8(peek.token().string()))))));
+            TRY(font_families.try_append(StringStyleValue::create(TRY(String::from_utf8(peek.token().string())))));
             (void)tokens.next_token(); // Comma
             continue;
         }
@@ -4224,7 +4224,7 @@ ErrorOr<RefPtr<StyleValue>> Parser::parse_font_family_value(TokenStream<Componen
                 (void)tokens.next_token(); // Ident
                 if (!next_is_comma_or_eof())
                     return nullptr;
-                TRY(font_families.try_append(TRY(IdentifierStyleValue::create(maybe_ident.value()))));
+                TRY(font_families.try_append(IdentifierStyleValue::create(maybe_ident.value())));
                 (void)tokens.next_token(); // Comma
                 continue;
             }
@@ -4236,7 +4236,7 @@ ErrorOr<RefPtr<StyleValue>> Parser::parse_font_family_value(TokenStream<Componen
             if (current_name_parts.is_empty())
                 return nullptr;
             (void)tokens.next_token(); // Comma
-            TRY(font_families.try_append(TRY(StringStyleValue::create(TRY(String::join(' ', current_name_parts))))));
+            TRY(font_families.try_append(StringStyleValue::create(TRY(String::join(' ', current_name_parts)))));
             current_name_parts.clear();
             // Can't have a trailing comma
             if (!tokens.has_next_token())
@@ -4248,7 +4248,7 @@ ErrorOr<RefPtr<StyleValue>> Parser::parse_font_family_value(TokenStream<Componen
     }
 
     if (!current_name_parts.is_empty()) {
-        TRY(font_families.try_append(TRY(StringStyleValue::create(TRY(String::join(' ', current_name_parts))))));
+        TRY(font_families.try_append(StringStyleValue::create(TRY(String::join(' ', current_name_parts)))));
         current_name_parts.clear();
     }
 
@@ -4515,14 +4515,14 @@ ErrorOr<RefPtr<StyleValue>> Parser::parse_list_style_value(Vector<ComponentValue
     if (found_nones == 2) {
         if (list_image || list_type)
             return nullptr;
-        auto none = TRY(IdentifierStyleValue::create(ValueID::None));
+        auto none = IdentifierStyleValue::create(ValueID::None);
         list_image = none;
         list_type = none;
 
     } else if (found_nones == 1) {
         if (list_image && list_type)
             return nullptr;
-        auto none = TRY(IdentifierStyleValue::create(ValueID::None));
+        auto none = IdentifierStyleValue::create(ValueID::None);
         if (!list_image)
             list_image = none;
         if (!list_type)
@@ -4762,21 +4762,21 @@ ErrorOr<RefPtr<StyleValue>> Parser::parse_easing_value(TokenStream<ComponentValu
             switch (function_metadata.parameters[argument_index].type) {
             case EasingFunctionParameterType::Number: {
                 if (value.is(Token::Type::Number))
-                    values.append(TRY(NumberStyleValue::create(value.token().number().value())));
+                    values.append(NumberStyleValue::create(value.token().number().value()));
                 else
                     return nullptr;
                 break;
             }
             case EasingFunctionParameterType::NumberZeroToOne: {
                 if (value.is(Token::Type::Number) && value.token().number_value() >= 0 && value.token().number_value() <= 1)
-                    values.append(TRY(NumberStyleValue::create(value.token().number().value())));
+                    values.append(NumberStyleValue::create(value.token().number().value()));
                 else
                     return nullptr;
                 break;
             }
             case EasingFunctionParameterType::Integer: {
                 if (value.is(Token::Type::Number) && value.token().number().is_integer())
-                    values.append(TRY(IntegerStyleValue::create(value.token().number().integer_value())));
+                    values.append(IntegerStyleValue::create(value.token().number().integer_value()));
                 else
                     return nullptr;
                 break;
@@ -4860,7 +4860,7 @@ ErrorOr<RefPtr<StyleValue>> Parser::parse_transform_value(Vector<ComponentValue>
                 if (maybe_calc_value && maybe_calc_value->resolves_to_angle()) {
                     values.append(maybe_calc_value.release_nonnull());
                 } else if (value.is(Token::Type::Number) && value.token().number_value() == 0) {
-                    values.append(TRY(AngleStyleValue::create(Angle::make_degrees(0))));
+                    values.append(AngleStyleValue::create(Angle::make_degrees(0)));
                 } else {
                     auto dimension_value = TRY(parse_dimension_value(value));
                     if (!dimension_value || !dimension_value->is_angle())
@@ -4934,7 +4934,7 @@ ErrorOr<RefPtr<StyleValue>> Parser::parse_transform_value(Vector<ComponentValue>
             return nullptr;
         }
 
-        transformations.append(TRY(TransformationStyleValue::create(function, move(values))));
+        transformations.append(TransformationStyleValue::create(function, move(values)));
     }
     return StyleValueList::create(move(transformations), StyleValueList::Separator::Space);
 }
@@ -4954,7 +4954,7 @@ ErrorOr<RefPtr<StyleValue>> Parser::parse_transform_origin_value(Vector<Componen
         NonnullRefPtr<StyleValue> offset;
     };
 
-    auto to_axis_offset = [](RefPtr<StyleValue> value) -> ErrorOr<Optional<AxisOffset>> {
+    auto to_axis_offset = [](RefPtr<StyleValue> value) -> Optional<AxisOffset> {
         if (value->is_percentage())
             return AxisOffset { Axis::None, value->as_percentage() };
         if (value->is_length())
@@ -4962,15 +4962,15 @@ ErrorOr<RefPtr<StyleValue>> Parser::parse_transform_origin_value(Vector<Componen
         if (value->is_identifier()) {
             switch (value->to_identifier()) {
             case ValueID::Top:
-                return AxisOffset { Axis::Y, TRY(PercentageStyleValue::create(Percentage(0))) };
+                return AxisOffset { Axis::Y, PercentageStyleValue::create(Percentage(0)) };
             case ValueID::Left:
-                return AxisOffset { Axis::X, TRY(PercentageStyleValue::create(Percentage(0))) };
+                return AxisOffset { Axis::X, PercentageStyleValue::create(Percentage(0)) };
             case ValueID::Center:
-                return AxisOffset { Axis::None, TRY(PercentageStyleValue::create(Percentage(50))) };
+                return AxisOffset { Axis::None, PercentageStyleValue::create(Percentage(50)) };
             case ValueID::Bottom:
-                return AxisOffset { Axis::Y, TRY(PercentageStyleValue::create(Percentage(100))) };
+                return AxisOffset { Axis::Y, PercentageStyleValue::create(Percentage(100)) };
             case ValueID::Right:
-                return AxisOffset { Axis::X, TRY(PercentageStyleValue::create(Percentage(100))) };
+                return AxisOffset { Axis::X, PercentageStyleValue::create(Percentage(100)) };
             default:
                 return OptionalNone {};
             }
@@ -4978,7 +4978,7 @@ ErrorOr<RefPtr<StyleValue>> Parser::parse_transform_origin_value(Vector<Componen
         return OptionalNone {};
     };
 
-    auto make_list = [](NonnullRefPtr<StyleValue> const& x_value, NonnullRefPtr<StyleValue> const& y_value) -> ErrorOr<NonnullRefPtr<StyleValueList>> {
+    auto make_list = [](NonnullRefPtr<StyleValue> const& x_value, NonnullRefPtr<StyleValue> const& y_value) -> NonnullRefPtr<StyleValueList> {
         StyleValueVector values;
         values.append(x_value);
         values.append(y_value);
@@ -4988,7 +4988,7 @@ ErrorOr<RefPtr<StyleValue>> Parser::parse_transform_origin_value(Vector<Componen
     auto tokens = TokenStream { component_values };
     switch (component_values.size()) {
     case 1: {
-        auto single_value = TRY(to_axis_offset(TRY(parse_css_value_for_property(PropertyID::TransformOrigin, tokens))));
+        auto single_value = to_axis_offset(TRY(parse_css_value_for_property(PropertyID::TransformOrigin, tokens)));
         if (!single_value.has_value())
             return nullptr;
         // If only one value is specified, the second value is assumed to be center.
@@ -4996,15 +4996,15 @@ ErrorOr<RefPtr<StyleValue>> Parser::parse_transform_origin_value(Vector<Componen
         switch (single_value->axis) {
         case Axis::None:
         case Axis::X:
-            return make_list(single_value->offset, TRY(PercentageStyleValue::create(Percentage(50))));
+            return make_list(single_value->offset, PercentageStyleValue::create(Percentage(50)));
         case Axis::Y:
-            return make_list(TRY(PercentageStyleValue::create(Percentage(50))), single_value->offset);
+            return make_list(PercentageStyleValue::create(Percentage(50)), single_value->offset);
         }
         VERIFY_NOT_REACHED();
     }
     case 2: {
-        auto first_value = TRY(to_axis_offset(TRY(parse_css_value_for_property(PropertyID::TransformOrigin, tokens))));
-        auto second_value = TRY(to_axis_offset(TRY(parse_css_value_for_property(PropertyID::TransformOrigin, tokens))));
+        auto first_value = to_axis_offset(TRY(parse_css_value_for_property(PropertyID::TransformOrigin, tokens)));
+        auto second_value = to_axis_offset(TRY(parse_css_value_for_property(PropertyID::TransformOrigin, tokens)));
         if (!first_value.has_value() || !second_value.has_value())
             return nullptr;
 
@@ -5685,7 +5685,7 @@ Parser::ParseErrorOr<NonnullRefPtr<StyleValue>> Parser::parse_css_value(Property
     }
 
     if (property_id == PropertyID::Custom || contains_var_or_attr)
-        return FIXME_TRY(UnresolvedStyleValue::create(move(component_values), contains_var_or_attr));
+        return UnresolvedStyleValue::create(move(component_values), contains_var_or_attr);
 
     if (component_values.is_empty())
         return ParseError::SyntaxError;
@@ -5904,7 +5904,7 @@ Parser::ParseErrorOr<NonnullRefPtr<StyleValue>> Parser::parse_css_value(Property
             return *parsed_values.take_first();
 
         if (!parsed_values.is_empty() && parsed_values.size() <= property_maximum_value_count(property_id))
-            return FIXME_TRY(StyleValueList::create(move(parsed_values), StyleValueList::Separator::Space));
+            return StyleValueList::create(move(parsed_values), StyleValueList::Separator::Space);
     }
 
     // We have multiple values, but the property claims to accept only a single one, check if it's a shorthand property.
@@ -5956,10 +5956,10 @@ Parser::ParseErrorOr<NonnullRefPtr<StyleValue>> Parser::parse_css_value(Property
         if (it.value.size() == 1)
             longhand_values.unchecked_append(it.value.take_first());
         else
-            longhand_values.unchecked_append(FIXME_TRY(StyleValueList::create(move(it.value), StyleValueList::Separator::Space)));
+            longhand_values.unchecked_append(StyleValueList::create(move(it.value), StyleValueList::Separator::Space));
     }
 
-    return { FIXME_TRY(CompositeStyleValue::create(move(longhand_properties), move(longhand_values))) };
+    return { CompositeStyleValue::create(move(longhand_properties), move(longhand_values)) };
 #undef FIXME_TRY
 }
 
@@ -6009,14 +6009,14 @@ ErrorOr<Parser::PropertyAndValue> Parser::parse_css_value_for_properties(Readonl
         if (ident.has_value()) {
             if (auto property = any_property_accepts_identifier(property_ids, ident.value()); property.has_value()) {
                 (void)tokens.next_token();
-                return PropertyAndValue { *property, TRY(IdentifierStyleValue::create(ident.value())) };
+                return PropertyAndValue { *property, IdentifierStyleValue::create(ident.value()) };
             }
         }
 
         // Custom idents
         if (auto property = any_property_accepts_type(property_ids, ValueType::CustomIdent); property.has_value()) {
             (void)tokens.next_token();
-            return PropertyAndValue { *property, TRY(CustomIdentStyleValue::create(TRY(FlyString::from_utf8(peek_token.token().ident())))) };
+            return PropertyAndValue { *property, CustomIdentStyleValue::create(TRY(FlyString::from_utf8(peek_token.token().ident()))) };
         }
     }
 
@@ -6064,7 +6064,7 @@ ErrorOr<Parser::PropertyAndValue> Parser::parse_css_value_for_properties(Readonl
         auto percentage = Percentage(peek_token.token().percentage());
         if (auto property = any_property_accepts_type(property_ids, ValueType::Percentage); property.has_value() && property_accepts_percentage(*property, percentage)) {
             (void)tokens.next_token();
-            return PropertyAndValue { *property, TRY(PercentageStyleValue::create(percentage)) };
+            return PropertyAndValue { *property, PercentageStyleValue::create(percentage) };
         }
     }
 
@@ -6077,7 +6077,7 @@ ErrorOr<Parser::PropertyAndValue> Parser::parse_css_value_for_properties(Readonl
 
     if (peek_token.is(Token::Type::String)) {
         if (auto property = any_property_accepts_type(property_ids, ValueType::String); property.has_value())
-            return PropertyAndValue { *property, TRY(StringStyleValue::create(TRY(String::from_utf8(tokens.next_token().token().string())))) };
+            return PropertyAndValue { *property, StringStyleValue::create(TRY(String::from_utf8(tokens.next_token().token().string()))) };
     }
 
     if (auto property = any_property_accepts_type(property_ids, ValueType::Url); property.has_value()) {
@@ -6102,35 +6102,35 @@ ErrorOr<Parser::PropertyAndValue> Parser::parse_css_value_for_properties(Readonl
                 auto angle = dimension.angle();
                 if (auto property = any_property_accepts_type(property_ids, ValueType::Angle); property.has_value() && property_accepts_angle(*property, angle)) {
                     transaction.commit();
-                    return PropertyAndValue { *property, TRY(AngleStyleValue::create(angle)) };
+                    return PropertyAndValue { *property, AngleStyleValue::create(angle) };
                 }
             }
             if (dimension.is_frequency()) {
                 auto frequency = dimension.frequency();
                 if (auto property = any_property_accepts_type(property_ids, ValueType::Frequency); property.has_value() && property_accepts_frequency(*property, frequency)) {
                     transaction.commit();
-                    return PropertyAndValue { *property, TRY(FrequencyStyleValue::create(frequency)) };
+                    return PropertyAndValue { *property, FrequencyStyleValue::create(frequency) };
                 }
             }
             if (dimension.is_length()) {
                 auto length = dimension.length();
                 if (auto property = any_property_accepts_type(property_ids, ValueType::Length); property.has_value() && property_accepts_length(*property, length)) {
                     transaction.commit();
-                    return PropertyAndValue { *property, TRY(LengthStyleValue::create(length)) };
+                    return PropertyAndValue { *property, LengthStyleValue::create(length) };
                 }
             }
             if (dimension.is_resolution()) {
                 auto resolution = dimension.resolution();
                 if (auto property = any_property_accepts_type(property_ids, ValueType::Resolution); property.has_value() && property_accepts_resolution(*property, resolution)) {
                     transaction.commit();
-                    return PropertyAndValue { *property, TRY(ResolutionStyleValue::create(resolution)) };
+                    return PropertyAndValue { *property, ResolutionStyleValue::create(resolution) };
                 }
             }
             if (dimension.is_time()) {
                 auto time = dimension.time();
                 if (auto property = any_property_accepts_type(property_ids, ValueType::Time); property.has_value() && property_accepts_time(*property, time)) {
                     transaction.commit();
-                    return PropertyAndValue { *property, TRY(TimeStyleValue::create(time)) };
+                    return PropertyAndValue { *property, TimeStyleValue::create(time) };
                 }
             }
         }

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -66,8 +66,8 @@ public:
 
     RefPtr<StyleValue> parse_as_css_value(PropertyID);
 
-    static ErrorOr<RefPtr<StyleValue>> parse_css_value(Badge<StyleComputer>, ParsingContext const&, PropertyID, Vector<ComponentValue> const&);
-    static ErrorOr<RefPtr<CalculatedStyleValue>> parse_calculated_value(Badge<StyleComputer>, ParsingContext const&, ComponentValue const&);
+    static RefPtr<StyleValue> parse_css_value(Badge<StyleComputer>, ParsingContext const&, PropertyID, Vector<ComponentValue> const&);
+    static RefPtr<CalculatedStyleValue> parse_calculated_value(Badge<StyleComputer>, ParsingContext const&, ComponentValue const&);
 
     [[nodiscard]] LengthOrCalculated parse_as_sizes_attribute();
 
@@ -306,7 +306,7 @@ namespace Web {
 
 CSS::CSSStyleSheet* parse_css_stylesheet(CSS::Parser::ParsingContext const&, StringView, Optional<AK::URL> location = {});
 CSS::ElementInlineCSSStyleDeclaration* parse_css_style_attribute(CSS::Parser::ParsingContext const&, StringView, DOM::Element&);
-ErrorOr<RefPtr<CSS::StyleValue>> parse_css_value(CSS::Parser::ParsingContext const&, StringView, CSS::PropertyID property_id = CSS::PropertyID::Invalid);
+RefPtr<CSS::StyleValue> parse_css_value(CSS::Parser::ParsingContext const&, StringView, CSS::PropertyID property_id = CSS::PropertyID::Invalid);
 Optional<CSS::SelectorList> parse_selector(CSS::Parser::ParsingContext const&, StringView);
 CSS::CSSRule* parse_css_rule(CSS::Parser::ParsingContext const&, StringView);
 RefPtr<CSS::MediaQuery> parse_media_query(CSS::Parser::ParsingContext const&, StringView);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -64,7 +64,7 @@ public:
 
     RefPtr<Supports> parse_as_supports();
 
-    ErrorOr<RefPtr<StyleValue>> parse_as_css_value(PropertyID);
+    RefPtr<StyleValue> parse_as_css_value(PropertyID);
 
     static ErrorOr<RefPtr<StyleValue>> parse_css_value(Badge<StyleComputer>, ParsingContext const&, PropertyID, Vector<ComponentValue> const&);
     static ErrorOr<RefPtr<CalculatedStyleValue>> parse_calculated_value(Badge<StyleComputer>, ParsingContext const&, ComponentValue const&);
@@ -183,81 +183,81 @@ private:
     Optional<PositionValue> parse_position(TokenStream<ComponentValue>&, PositionValue initial_value = PositionValue::center());
 
     Optional<AK::URL> parse_url_function(ComponentValue const&);
-    ErrorOr<RefPtr<StyleValue>> parse_url_value(ComponentValue const&);
+    RefPtr<StyleValue> parse_url_value(ComponentValue const&);
 
     Optional<Vector<LinearColorStopListElement>> parse_linear_color_stop_list(TokenStream<ComponentValue>&);
     Optional<Vector<AngularColorStopListElement>> parse_angular_color_stop_list(TokenStream<ComponentValue>&);
 
-    ErrorOr<RefPtr<StyleValue>> parse_linear_gradient_function(ComponentValue const&);
-    ErrorOr<RefPtr<StyleValue>> parse_conic_gradient_function(ComponentValue const&);
-    ErrorOr<RefPtr<StyleValue>> parse_radial_gradient_function(ComponentValue const&);
+    RefPtr<StyleValue> parse_linear_gradient_function(ComponentValue const&);
+    RefPtr<StyleValue> parse_conic_gradient_function(ComponentValue const&);
+    RefPtr<StyleValue> parse_radial_gradient_function(ComponentValue const&);
 
     ParseErrorOr<NonnullRefPtr<StyleValue>> parse_css_value(PropertyID, TokenStream<ComponentValue>&);
-    ErrorOr<RefPtr<StyleValue>> parse_css_value_for_property(PropertyID, TokenStream<ComponentValue>&);
+    RefPtr<StyleValue> parse_css_value_for_property(PropertyID, TokenStream<ComponentValue>&);
     struct PropertyAndValue {
         PropertyID property;
         RefPtr<StyleValue> style_value;
     };
-    ErrorOr<PropertyAndValue> parse_css_value_for_properties(ReadonlySpan<PropertyID>, TokenStream<ComponentValue>&);
-    ErrorOr<RefPtr<StyleValue>> parse_builtin_value(ComponentValue const&);
-    ErrorOr<RefPtr<CalculatedStyleValue>> parse_calculated_value(ComponentValue const&);
+    PropertyAndValue parse_css_value_for_properties(ReadonlySpan<PropertyID>, TokenStream<ComponentValue>&);
+    RefPtr<StyleValue> parse_builtin_value(ComponentValue const&);
+    RefPtr<CalculatedStyleValue> parse_calculated_value(ComponentValue const&);
     // NOTE: Implemented in generated code. (GenerateCSSMathFunctions.cpp)
     ErrorOr<OwnPtr<CalculationNode>> parse_math_function(PropertyID, Function const&);
-    ErrorOr<OwnPtr<CalculationNode>> parse_a_calc_function_node(Function const&);
-    ErrorOr<RefPtr<StyleValue>> parse_dimension_value(ComponentValue const&);
-    ErrorOr<RefPtr<StyleValue>> parse_integer_value(TokenStream<ComponentValue>&);
-    ErrorOr<RefPtr<StyleValue>> parse_number_value(TokenStream<ComponentValue>&);
-    ErrorOr<RefPtr<StyleValue>> parse_identifier_value(ComponentValue const&);
-    ErrorOr<RefPtr<StyleValue>> parse_color_value(ComponentValue const&);
-    ErrorOr<RefPtr<StyleValue>> parse_rect_value(ComponentValue const&);
-    ErrorOr<RefPtr<StyleValue>> parse_ratio_value(TokenStream<ComponentValue>&);
-    ErrorOr<RefPtr<StyleValue>> parse_string_value(ComponentValue const&);
-    ErrorOr<RefPtr<StyleValue>> parse_image_value(ComponentValue const&);
-    ErrorOr<RefPtr<StyleValue>> parse_paint_value(TokenStream<ComponentValue>&);
+    OwnPtr<CalculationNode> parse_a_calc_function_node(Function const&);
+    RefPtr<StyleValue> parse_dimension_value(ComponentValue const&);
+    RefPtr<StyleValue> parse_integer_value(TokenStream<ComponentValue>&);
+    RefPtr<StyleValue> parse_number_value(TokenStream<ComponentValue>&);
+    RefPtr<StyleValue> parse_identifier_value(ComponentValue const&);
+    RefPtr<StyleValue> parse_color_value(ComponentValue const&);
+    RefPtr<StyleValue> parse_rect_value(ComponentValue const&);
+    RefPtr<StyleValue> parse_ratio_value(TokenStream<ComponentValue>&);
+    RefPtr<StyleValue> parse_string_value(ComponentValue const&);
+    RefPtr<StyleValue> parse_image_value(ComponentValue const&);
+    RefPtr<StyleValue> parse_paint_value(TokenStream<ComponentValue>&);
     template<typename ParseFunction>
-    ErrorOr<RefPtr<StyleValue>> parse_comma_separated_value_list(Vector<ComponentValue> const&, ParseFunction);
-    ErrorOr<RefPtr<StyleValue>> parse_simple_comma_separated_value_list(PropertyID, Vector<ComponentValue> const&);
+    RefPtr<StyleValue> parse_comma_separated_value_list(Vector<ComponentValue> const&, ParseFunction);
+    RefPtr<StyleValue> parse_simple_comma_separated_value_list(PropertyID, Vector<ComponentValue> const&);
 
-    ErrorOr<RefPtr<StyleValue>> parse_filter_value_list_value(Vector<ComponentValue> const&);
-    ErrorOr<RefPtr<StyleValue>> parse_aspect_ratio_value(Vector<ComponentValue> const&);
-    ErrorOr<RefPtr<StyleValue>> parse_background_value(Vector<ComponentValue> const&);
-    ErrorOr<RefPtr<StyleValue>> parse_single_background_position_value(TokenStream<ComponentValue>&);
-    ErrorOr<RefPtr<StyleValue>> parse_single_background_position_x_or_y_value(TokenStream<ComponentValue>&, PropertyID);
-    ErrorOr<RefPtr<StyleValue>> parse_single_background_repeat_value(TokenStream<ComponentValue>&);
-    ErrorOr<RefPtr<StyleValue>> parse_single_background_size_value(TokenStream<ComponentValue>&);
-    ErrorOr<RefPtr<StyleValue>> parse_border_value(Vector<ComponentValue> const&);
-    ErrorOr<RefPtr<StyleValue>> parse_border_radius_value(Vector<ComponentValue> const&);
-    ErrorOr<RefPtr<StyleValue>> parse_border_radius_shorthand_value(Vector<ComponentValue> const&);
-    ErrorOr<RefPtr<StyleValue>> parse_content_value(Vector<ComponentValue> const&);
-    ErrorOr<RefPtr<StyleValue>> parse_display_value(Vector<ComponentValue> const&);
-    ErrorOr<RefPtr<StyleValue>> parse_flex_value(Vector<ComponentValue> const&);
-    ErrorOr<RefPtr<StyleValue>> parse_flex_flow_value(Vector<ComponentValue> const&);
-    ErrorOr<RefPtr<StyleValue>> parse_font_value(Vector<ComponentValue> const&);
-    ErrorOr<RefPtr<StyleValue>> parse_font_family_value(TokenStream<ComponentValue>&);
-    ErrorOr<RefPtr<StyleValue>> parse_list_style_value(Vector<ComponentValue> const&);
-    ErrorOr<RefPtr<StyleValue>> parse_overflow_value(Vector<ComponentValue> const&);
-    ErrorOr<RefPtr<StyleValue>> parse_place_content_value(Vector<ComponentValue> const&);
-    ErrorOr<RefPtr<StyleValue>> parse_place_items_value(Vector<ComponentValue> const&);
-    ErrorOr<RefPtr<StyleValue>> parse_place_self_value(Vector<ComponentValue> const&);
+    RefPtr<StyleValue> parse_filter_value_list_value(Vector<ComponentValue> const&);
+    RefPtr<StyleValue> parse_aspect_ratio_value(Vector<ComponentValue> const&);
+    RefPtr<StyleValue> parse_background_value(Vector<ComponentValue> const&);
+    RefPtr<StyleValue> parse_single_background_position_value(TokenStream<ComponentValue>&);
+    RefPtr<StyleValue> parse_single_background_position_x_or_y_value(TokenStream<ComponentValue>&, PropertyID);
+    RefPtr<StyleValue> parse_single_background_repeat_value(TokenStream<ComponentValue>&);
+    RefPtr<StyleValue> parse_single_background_size_value(TokenStream<ComponentValue>&);
+    RefPtr<StyleValue> parse_border_value(Vector<ComponentValue> const&);
+    RefPtr<StyleValue> parse_border_radius_value(Vector<ComponentValue> const&);
+    RefPtr<StyleValue> parse_border_radius_shorthand_value(Vector<ComponentValue> const&);
+    RefPtr<StyleValue> parse_content_value(Vector<ComponentValue> const&);
+    RefPtr<StyleValue> parse_display_value(Vector<ComponentValue> const&);
+    RefPtr<StyleValue> parse_flex_value(Vector<ComponentValue> const&);
+    RefPtr<StyleValue> parse_flex_flow_value(Vector<ComponentValue> const&);
+    RefPtr<StyleValue> parse_font_value(Vector<ComponentValue> const&);
+    RefPtr<StyleValue> parse_font_family_value(TokenStream<ComponentValue>&);
+    RefPtr<StyleValue> parse_list_style_value(Vector<ComponentValue> const&);
+    RefPtr<StyleValue> parse_overflow_value(Vector<ComponentValue> const&);
+    RefPtr<StyleValue> parse_place_content_value(Vector<ComponentValue> const&);
+    RefPtr<StyleValue> parse_place_items_value(Vector<ComponentValue> const&);
+    RefPtr<StyleValue> parse_place_self_value(Vector<ComponentValue> const&);
     enum class AllowInsetKeyword {
         No,
         Yes,
     };
-    ErrorOr<RefPtr<StyleValue>> parse_shadow_value(Vector<ComponentValue> const&, AllowInsetKeyword);
-    ErrorOr<RefPtr<StyleValue>> parse_single_shadow_value(TokenStream<ComponentValue>&, AllowInsetKeyword);
-    ErrorOr<RefPtr<StyleValue>> parse_text_decoration_value(Vector<ComponentValue> const&);
-    ErrorOr<RefPtr<StyleValue>> parse_text_decoration_line_value(TokenStream<ComponentValue>&);
-    ErrorOr<RefPtr<StyleValue>> parse_easing_value(TokenStream<ComponentValue>&);
-    ErrorOr<RefPtr<StyleValue>> parse_transform_value(Vector<ComponentValue> const&);
-    ErrorOr<RefPtr<StyleValue>> parse_transform_origin_value(Vector<ComponentValue> const&);
-    ErrorOr<RefPtr<StyleValue>> parse_grid_track_size_list(Vector<ComponentValue> const&, bool allow_separate_line_name_blocks = false);
-    ErrorOr<RefPtr<StyleValue>> parse_grid_auto_track_sizes(Vector<ComponentValue> const&);
-    ErrorOr<RefPtr<StyleValue>> parse_grid_track_size_list_shorthand_value(Vector<ComponentValue> const&);
-    ErrorOr<RefPtr<StyleValue>> parse_grid_track_placement(Vector<ComponentValue> const&);
-    ErrorOr<RefPtr<StyleValue>> parse_grid_track_placement_shorthand_value(Vector<ComponentValue> const&);
-    ErrorOr<RefPtr<StyleValue>> parse_grid_template_areas_value(Vector<ComponentValue> const&);
-    ErrorOr<RefPtr<StyleValue>> parse_grid_area_shorthand_value(Vector<ComponentValue> const&);
-    ErrorOr<RefPtr<StyleValue>> parse_grid_shorthand_value(Vector<ComponentValue> const&);
+    RefPtr<StyleValue> parse_shadow_value(Vector<ComponentValue> const&, AllowInsetKeyword);
+    RefPtr<StyleValue> parse_single_shadow_value(TokenStream<ComponentValue>&, AllowInsetKeyword);
+    RefPtr<StyleValue> parse_text_decoration_value(Vector<ComponentValue> const&);
+    RefPtr<StyleValue> parse_text_decoration_line_value(TokenStream<ComponentValue>&);
+    RefPtr<StyleValue> parse_easing_value(TokenStream<ComponentValue>&);
+    RefPtr<StyleValue> parse_transform_value(Vector<ComponentValue> const&);
+    RefPtr<StyleValue> parse_transform_origin_value(Vector<ComponentValue> const&);
+    RefPtr<StyleValue> parse_grid_track_size_list(Vector<ComponentValue> const&, bool allow_separate_line_name_blocks = false);
+    RefPtr<StyleValue> parse_grid_auto_track_sizes(Vector<ComponentValue> const&);
+    RefPtr<StyleValue> parse_grid_track_size_list_shorthand_value(Vector<ComponentValue> const&);
+    RefPtr<StyleValue> parse_grid_track_placement(Vector<ComponentValue> const&);
+    RefPtr<StyleValue> parse_grid_track_placement_shorthand_value(Vector<ComponentValue> const&);
+    RefPtr<StyleValue> parse_grid_template_areas_value(Vector<ComponentValue> const&);
+    RefPtr<StyleValue> parse_grid_area_shorthand_value(Vector<ComponentValue> const&);
+    RefPtr<StyleValue> parse_grid_shorthand_value(Vector<ComponentValue> const&);
 
     ErrorOr<OwnPtr<CalculationNode>> parse_a_calculation(Vector<ComponentValue> const&);
 

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -198,7 +198,7 @@ private:
         PropertyID property;
         RefPtr<StyleValue> style_value;
     };
-    PropertyAndValue parse_css_value_for_properties(ReadonlySpan<PropertyID>, TokenStream<ComponentValue>&);
+    Optional<PropertyAndValue> parse_css_value_for_properties(ReadonlySpan<PropertyID>, TokenStream<ComponentValue>&);
     RefPtr<StyleValue> parse_builtin_value(ComponentValue const&);
     RefPtr<CalculatedStyleValue> parse_calculated_value(ComponentValue const&);
     // NOTE: Implemented in generated code. (GenerateCSSMathFunctions.cpp)

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -202,7 +202,7 @@ private:
     RefPtr<StyleValue> parse_builtin_value(ComponentValue const&);
     RefPtr<CalculatedStyleValue> parse_calculated_value(ComponentValue const&);
     // NOTE: Implemented in generated code. (GenerateCSSMathFunctions.cpp)
-    ErrorOr<OwnPtr<CalculationNode>> parse_math_function(PropertyID, Function const&);
+    OwnPtr<CalculationNode> parse_math_function(PropertyID, Function const&);
     OwnPtr<CalculationNode> parse_a_calc_function_node(Function const&);
     RefPtr<StyleValue> parse_dimension_value(ComponentValue const&);
     RefPtr<StyleValue> parse_integer_value(TokenStream<ComponentValue>&);
@@ -259,7 +259,7 @@ private:
     RefPtr<StyleValue> parse_grid_area_shorthand_value(Vector<ComponentValue> const&);
     RefPtr<StyleValue> parse_grid_shorthand_value(Vector<ComponentValue> const&);
 
-    ErrorOr<OwnPtr<CalculationNode>> parse_a_calculation(Vector<ComponentValue> const&);
+    OwnPtr<CalculationNode> parse_a_calculation(Vector<ComponentValue> const&);
 
     ParseErrorOr<NonnullRefPtr<Selector>> parse_complex_selector(TokenStream<ComponentValue>&, SelectorType);
     ParseErrorOr<Optional<Selector::CompoundSelector>> parse_compound_selector(TokenStream<ComponentValue>&);

--- a/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
@@ -129,33 +129,33 @@ static ErrorOr<RefPtr<StyleValue>> style_value_for_display(Display display)
         StyleValueVector values;
         switch (display.outside()) {
         case Display::Outside::Inline:
-            TRY(values.try_append(TRY(IdentifierStyleValue::create(ValueID::Inline))));
+            TRY(values.try_append(IdentifierStyleValue::create(ValueID::Inline)));
             break;
         case Display::Outside::Block:
-            TRY(values.try_append(TRY(IdentifierStyleValue::create(ValueID::Block))));
+            TRY(values.try_append(IdentifierStyleValue::create(ValueID::Block)));
             break;
         case Display::Outside::RunIn:
-            TRY(values.try_append(TRY(IdentifierStyleValue::create(ValueID::RunIn))));
+            TRY(values.try_append(IdentifierStyleValue::create(ValueID::RunIn)));
             break;
         }
         switch (display.inside()) {
         case Display::Inside::Flow:
-            TRY(values.try_append(TRY(IdentifierStyleValue::create(ValueID::Flow))));
+            TRY(values.try_append(IdentifierStyleValue::create(ValueID::Flow)));
             break;
         case Display::Inside::FlowRoot:
-            TRY(values.try_append(TRY(IdentifierStyleValue::create(ValueID::FlowRoot))));
+            TRY(values.try_append(IdentifierStyleValue::create(ValueID::FlowRoot)));
             break;
         case Display::Inside::Table:
-            TRY(values.try_append(TRY(IdentifierStyleValue::create(ValueID::Table))));
+            TRY(values.try_append(IdentifierStyleValue::create(ValueID::Table)));
             break;
         case Display::Inside::Flex:
-            TRY(values.try_append(TRY(IdentifierStyleValue::create(ValueID::Flex))));
+            TRY(values.try_append(IdentifierStyleValue::create(ValueID::Flex)));
             break;
         case Display::Inside::Grid:
-            TRY(values.try_append(TRY(IdentifierStyleValue::create(ValueID::Grid))));
+            TRY(values.try_append(IdentifierStyleValue::create(ValueID::Grid)));
             break;
         case Display::Inside::Ruby:
-            TRY(values.try_append(TRY(IdentifierStyleValue::create(ValueID::Ruby))));
+            TRY(values.try_append(IdentifierStyleValue::create(ValueID::Ruby)));
             break;
         }
 
@@ -201,7 +201,7 @@ static NonnullRefPtr<StyleValue const> value_or_default(Optional<StyleProperty> 
     return default_style;
 }
 
-static ErrorOr<NonnullRefPtr<StyleValue const>> style_value_for_length_percentage(LengthPercentage const& length_percentage)
+static NonnullRefPtr<StyleValue const> style_value_for_length_percentage(LengthPercentage const& length_percentage)
 {
     if (length_percentage.is_auto())
         return IdentifierStyleValue::create(ValueID::Auto);
@@ -212,7 +212,7 @@ static ErrorOr<NonnullRefPtr<StyleValue const>> style_value_for_length_percentag
     return length_percentage.calculated();
 }
 
-static ErrorOr<NonnullRefPtr<StyleValue const>> style_value_for_size(Size const& size)
+static NonnullRefPtr<StyleValue const> style_value_for_size(Size const& size)
 {
     if (size.is_none())
         return IdentifierStyleValue::create(ValueID::None);
@@ -232,7 +232,7 @@ static ErrorOr<NonnullRefPtr<StyleValue const>> style_value_for_size(Size const&
     TODO();
 }
 
-static ErrorOr<NonnullRefPtr<StyleValue const>> style_value_for_sided_shorthand(ValueComparingNonnullRefPtr<StyleValue const> top, ValueComparingNonnullRefPtr<StyleValue const> right, ValueComparingNonnullRefPtr<StyleValue const> bottom, ValueComparingNonnullRefPtr<StyleValue const> left)
+static NonnullRefPtr<StyleValue const> style_value_for_sided_shorthand(ValueComparingNonnullRefPtr<StyleValue const> top, ValueComparingNonnullRefPtr<StyleValue const> right, ValueComparingNonnullRefPtr<StyleValue const> bottom, ValueComparingNonnullRefPtr<StyleValue const> left)
 {
     bool top_and_bottom_same = top == bottom;
     bool left_and_right_same = left == right;
@@ -249,7 +249,7 @@ static ErrorOr<NonnullRefPtr<StyleValue const>> style_value_for_sided_shorthand(
     return StyleValueList::create(StyleValueVector { move(top), move(right), move(bottom), move(left) }, StyleValueList::Separator::Space);
 }
 
-static ErrorOr<NonnullRefPtr<StyleValue const>> style_value_for_svg_paint(Optional<SVGPaint> const& maybe_paint)
+static NonnullRefPtr<StyleValue const> style_value_for_svg_paint(Optional<SVGPaint> const& maybe_paint)
 {
     if (!maybe_paint.has_value())
         return IdentifierStyleValue::create(ValueID::None);
@@ -269,29 +269,29 @@ ErrorOr<RefPtr<StyleValue const>> ResolvedCSSStyleDeclaration::style_value_for_p
     case PropertyID::AccentColor: {
         auto accent_color = layout_node.computed_values().accent_color();
         if (accent_color.has_value())
-            return TRY(ColorStyleValue::create(accent_color.value()));
-        return TRY(IdentifierStyleValue::create(ValueID::Auto));
+            return ColorStyleValue::create(accent_color.value());
+        return IdentifierStyleValue::create(ValueID::Auto);
     }
     case PropertyID::AlignContent:
-        return TRY(IdentifierStyleValue::create(to_value_id(layout_node.computed_values().align_content())));
+        return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().align_content()));
     case PropertyID::AlignItems:
-        return TRY(IdentifierStyleValue::create(to_value_id(layout_node.computed_values().align_items())));
+        return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().align_items()));
     case PropertyID::AlignSelf:
-        return TRY(IdentifierStyleValue::create(to_value_id(layout_node.computed_values().align_self())));
+        return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().align_self()));
     case PropertyID::Appearance:
-        return TRY(IdentifierStyleValue::create(to_value_id(layout_node.computed_values().appearance())));
+        return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().appearance()));
     case PropertyID::AspectRatio: {
         auto aspect_ratio = layout_node.computed_values().aspect_ratio();
         if (aspect_ratio.use_natural_aspect_ratio_if_available && aspect_ratio.preferred_ratio.has_value()) {
-            return TRY(StyleValueList::create(
+            return StyleValueList::create(
                 StyleValueVector {
-                    TRY(IdentifierStyleValue::create(ValueID::Auto)),
-                    TRY(RatioStyleValue::create(aspect_ratio.preferred_ratio.value())) },
-                StyleValueList::Separator::Space));
+                    IdentifierStyleValue::create(ValueID::Auto),
+                    RatioStyleValue::create(aspect_ratio.preferred_ratio.value()) },
+                StyleValueList::Separator::Space);
         }
         if (aspect_ratio.preferred_ratio.has_value())
-            return TRY(RatioStyleValue::create(aspect_ratio.preferred_ratio.value()));
-        return TRY(IdentifierStyleValue::create(ValueID::Auto));
+            return RatioStyleValue::create(aspect_ratio.preferred_ratio.value());
+        return IdentifierStyleValue::create(ValueID::Auto);
     }
     case PropertyID::Background: {
         auto maybe_background_color = property(PropertyID::BackgroundColor);
@@ -304,14 +304,14 @@ ErrorOr<RefPtr<StyleValue const>> ResolvedCSSStyleDeclaration::style_value_for_p
         auto maybe_background_clip = property(PropertyID::BackgroundClip);
 
         return BackgroundStyleValue::create(
-            value_or_default(maybe_background_color, TRY(InitialStyleValue::the())),
-            value_or_default(maybe_background_image, TRY(IdentifierStyleValue::create(ValueID::None))),
-            value_or_default(maybe_background_position, TRY(PositionStyleValue::create(TRY(EdgeStyleValue::create(PositionEdge::Left, Length::make_px(0))), TRY(EdgeStyleValue::create(PositionEdge::Top, Length::make_px(0)))))),
-            value_or_default(maybe_background_size, TRY(IdentifierStyleValue::create(ValueID::Auto))),
-            value_or_default(maybe_background_repeat, TRY(BackgroundRepeatStyleValue::create(Repeat::Repeat, Repeat::Repeat))),
-            value_or_default(maybe_background_attachment, TRY(IdentifierStyleValue::create(ValueID::Scroll))),
-            value_or_default(maybe_background_origin, TRY(IdentifierStyleValue::create(ValueID::PaddingBox))),
-            value_or_default(maybe_background_clip, TRY(IdentifierStyleValue::create(ValueID::BorderBox))));
+            value_or_default(maybe_background_color, InitialStyleValue::the()),
+            value_or_default(maybe_background_image, IdentifierStyleValue::create(ValueID::None)),
+            value_or_default(maybe_background_position, PositionStyleValue::create(EdgeStyleValue::create(PositionEdge::Left, Length::make_px(0)), EdgeStyleValue::create(PositionEdge::Top, Length::make_px(0)))),
+            value_or_default(maybe_background_size, IdentifierStyleValue::create(ValueID::Auto)),
+            value_or_default(maybe_background_repeat, BackgroundRepeatStyleValue::create(Repeat::Repeat, Repeat::Repeat)),
+            value_or_default(maybe_background_attachment, IdentifierStyleValue::create(ValueID::Scroll)),
+            value_or_default(maybe_background_origin, IdentifierStyleValue::create(ValueID::PaddingBox)),
+            value_or_default(maybe_background_clip, IdentifierStyleValue::create(ValueID::BorderBox)));
     }
     case PropertyID::BackgroundAttachment:
         return style_value_for_background_property(
@@ -344,13 +344,13 @@ ErrorOr<RefPtr<StyleValue const>> ResolvedCSSStyleDeclaration::style_value_for_p
             layout_node,
             [](auto& layer) -> ErrorOr<NonnullRefPtr<StyleValue>> {
                 return PositionStyleValue::create(
-                    TRY(EdgeStyleValue::create(layer.position_edge_x, layer.position_offset_x)),
-                    TRY(EdgeStyleValue::create(layer.position_edge_y, layer.position_offset_y)));
+                    EdgeStyleValue::create(layer.position_edge_x, layer.position_offset_x),
+                    EdgeStyleValue::create(layer.position_edge_y, layer.position_offset_y));
             },
             []() -> ErrorOr<NonnullRefPtr<StyleValue>> {
                 return PositionStyleValue::create(
-                    TRY(EdgeStyleValue::create(PositionEdge::Left, Percentage(0))),
-                    TRY(EdgeStyleValue::create(PositionEdge::Top, Percentage(0))));
+                    EdgeStyleValue::create(PositionEdge::Left, Percentage(0)),
+                    EdgeStyleValue::create(PositionEdge::Top, Percentage(0)));
             });
     case PropertyID::BackgroundPositionX:
         return style_value_for_background_property(
@@ -367,8 +367,8 @@ ErrorOr<RefPtr<StyleValue const>> ResolvedCSSStyleDeclaration::style_value_for_p
             layout_node,
             [](auto& layer) -> ErrorOr<NonnullRefPtr<StyleValue const>> {
                 StyleValueVector repeat {
-                    TRY(IdentifierStyleValue::create(to_value_id(layer.repeat_x))),
-                    TRY(IdentifierStyleValue::create(to_value_id(layer.repeat_y))),
+                    IdentifierStyleValue::create(to_value_id(layer.repeat_x)),
+                    IdentifierStyleValue::create(to_value_id(layer.repeat_y)),
                 };
                 return StyleValueList::create(move(repeat), StyleValueList::Separator::Space);
             },
@@ -396,16 +396,16 @@ ErrorOr<RefPtr<StyleValue const>> ResolvedCSSStyleDeclaration::style_value_for_p
         // `border` only has a reasonable value if all four sides are the same.
         if (top != right || top != bottom || top != left)
             return nullptr;
-        auto width = TRY(LengthStyleValue::create(Length::make_px(top.width)));
-        auto style = TRY(IdentifierStyleValue::create(to_value_id(top.line_style)));
-        auto color = TRY(ColorStyleValue::create(top.color));
+        auto width = LengthStyleValue::create(Length::make_px(top.width));
+        auto style = IdentifierStyleValue::create(to_value_id(top.line_style));
+        auto color = ColorStyleValue::create(top.color);
         return BorderStyleValue::create(width, style, color);
     }
     case PropertyID::BorderBottom: {
         auto border = layout_node.computed_values().border_bottom();
-        auto width = TRY(LengthStyleValue::create(Length::make_px(border.width)));
-        auto style = TRY(IdentifierStyleValue::create(to_value_id(border.line_style)));
-        auto color = TRY(ColorStyleValue::create(border.color));
+        auto width = LengthStyleValue::create(Length::make_px(border.width));
+        auto style = IdentifierStyleValue::create(to_value_id(border.line_style));
+        auto color = ColorStyleValue::create(border.color);
         return BorderStyleValue::create(width, style, color);
     }
     case PropertyID::BorderBottomColor:
@@ -423,19 +423,19 @@ ErrorOr<RefPtr<StyleValue const>> ResolvedCSSStyleDeclaration::style_value_for_p
     case PropertyID::BorderBottomWidth:
         return LengthStyleValue::create(Length::make_px(layout_node.computed_values().border_bottom().width));
     case PropertyID::BorderColor: {
-        auto top = TRY(ColorStyleValue::create(layout_node.computed_values().border_top().color));
-        auto right = TRY(ColorStyleValue::create(layout_node.computed_values().border_right().color));
-        auto bottom = TRY(ColorStyleValue::create(layout_node.computed_values().border_bottom().color));
-        auto left = TRY(ColorStyleValue::create(layout_node.computed_values().border_left().color));
+        auto top = ColorStyleValue::create(layout_node.computed_values().border_top().color);
+        auto right = ColorStyleValue::create(layout_node.computed_values().border_right().color);
+        auto bottom = ColorStyleValue::create(layout_node.computed_values().border_bottom().color);
+        auto left = ColorStyleValue::create(layout_node.computed_values().border_left().color);
         return style_value_for_sided_shorthand(top, right, bottom, left);
     }
     case PropertyID::BorderCollapse:
         return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().border_collapse()));
     case PropertyID::BorderLeft: {
         auto border = layout_node.computed_values().border_left();
-        auto width = TRY(LengthStyleValue::create(Length::make_px(border.width)));
-        auto style = TRY(IdentifierStyleValue::create(to_value_id(border.line_style)));
-        auto color = TRY(ColorStyleValue::create(border.color));
+        auto width = LengthStyleValue::create(Length::make_px(border.width));
+        auto style = IdentifierStyleValue::create(to_value_id(border.line_style));
+        auto color = ColorStyleValue::create(border.color);
         return BorderStyleValue::create(width, style, color);
     }
     case PropertyID::BorderLeftColor:
@@ -471,9 +471,9 @@ ErrorOr<RefPtr<StyleValue const>> ResolvedCSSStyleDeclaration::style_value_for_p
     }
     case PropertyID::BorderRight: {
         auto border = layout_node.computed_values().border_right();
-        auto width = TRY(LengthStyleValue::create(Length::make_px(border.width)));
-        auto style = TRY(IdentifierStyleValue::create(to_value_id(border.line_style)));
-        auto color = TRY(ColorStyleValue::create(border.color));
+        auto width = LengthStyleValue::create(Length::make_px(border.width));
+        auto style = IdentifierStyleValue::create(to_value_id(border.line_style));
+        auto color = ColorStyleValue::create(border.color);
         return BorderStyleValue::create(width, style, color);
     }
     case PropertyID::BorderRightColor:
@@ -489,23 +489,23 @@ ErrorOr<RefPtr<StyleValue const>> ResolvedCSSStyleDeclaration::style_value_for_p
             return LengthStyleValue::create(horizontal);
         return StyleValueList::create(
             {
-                TRY(LengthStyleValue::create(horizontal)),
-                TRY(LengthStyleValue::create(vertical)),
+                LengthStyleValue::create(horizontal),
+                LengthStyleValue::create(vertical),
             },
             StyleValueList::Separator::Space);
     }
     case PropertyID::BorderStyle: {
-        auto top = TRY(IdentifierStyleValue::create(to_value_id(layout_node.computed_values().border_top().line_style)));
-        auto right = TRY(IdentifierStyleValue::create(to_value_id(layout_node.computed_values().border_right().line_style)));
-        auto bottom = TRY(IdentifierStyleValue::create(to_value_id(layout_node.computed_values().border_bottom().line_style)));
-        auto left = TRY(IdentifierStyleValue::create(to_value_id(layout_node.computed_values().border_left().line_style)));
+        auto top = IdentifierStyleValue::create(to_value_id(layout_node.computed_values().border_top().line_style));
+        auto right = IdentifierStyleValue::create(to_value_id(layout_node.computed_values().border_right().line_style));
+        auto bottom = IdentifierStyleValue::create(to_value_id(layout_node.computed_values().border_bottom().line_style));
+        auto left = IdentifierStyleValue::create(to_value_id(layout_node.computed_values().border_left().line_style));
         return style_value_for_sided_shorthand(top, right, bottom, left);
     }
     case PropertyID::BorderTop: {
         auto border = layout_node.computed_values().border_top();
-        auto width = TRY(LengthStyleValue::create(Length::make_px(border.width)));
-        auto style = TRY(IdentifierStyleValue::create(to_value_id(border.line_style)));
-        auto color = TRY(ColorStyleValue::create(border.color));
+        auto width = LengthStyleValue::create(Length::make_px(border.width));
+        auto style = IdentifierStyleValue::create(to_value_id(border.line_style));
+        auto color = ColorStyleValue::create(border.color);
         return BorderStyleValue::create(width, style, color);
     }
     case PropertyID::BorderTopColor:
@@ -523,10 +523,10 @@ ErrorOr<RefPtr<StyleValue const>> ResolvedCSSStyleDeclaration::style_value_for_p
     case PropertyID::BorderTopWidth:
         return LengthStyleValue::create(Length::make_px(layout_node.computed_values().border_top().width));
     case PropertyID::BorderWidth: {
-        auto top = TRY(LengthStyleValue::create(Length::make_px(layout_node.computed_values().border_top().width)));
-        auto right = TRY(LengthStyleValue::create(Length::make_px(layout_node.computed_values().border_right().width)));
-        auto bottom = TRY(LengthStyleValue::create(Length::make_px(layout_node.computed_values().border_bottom().width)));
-        auto left = TRY(LengthStyleValue::create(Length::make_px(layout_node.computed_values().border_left().width)));
+        auto top = LengthStyleValue::create(Length::make_px(layout_node.computed_values().border_top().width));
+        auto right = LengthStyleValue::create(Length::make_px(layout_node.computed_values().border_right().width));
+        auto bottom = LengthStyleValue::create(Length::make_px(layout_node.computed_values().border_bottom().width));
+        auto left = LengthStyleValue::create(Length::make_px(layout_node.computed_values().border_left().width));
         return style_value_for_sided_shorthand(top, right, bottom, left);
     }
     case PropertyID::Bottom:
@@ -537,10 +537,10 @@ ErrorOr<RefPtr<StyleValue const>> ResolvedCSSStyleDeclaration::style_value_for_p
             return nullptr;
 
         auto make_box_shadow_style_value = [](ShadowData const& data) -> ErrorOr<NonnullRefPtr<ShadowStyleValue>> {
-            auto offset_x = TRY(LengthStyleValue::create(data.offset_x));
-            auto offset_y = TRY(LengthStyleValue::create(data.offset_y));
-            auto blur_radius = TRY(LengthStyleValue::create(data.blur_radius));
-            auto spread_distance = TRY(LengthStyleValue::create(data.spread_distance));
+            auto offset_x = LengthStyleValue::create(data.offset_x);
+            auto offset_y = LengthStyleValue::create(data.offset_y);
+            auto blur_radius = LengthStyleValue::create(data.blur_radius);
+            auto spread_distance = LengthStyleValue::create(data.spread_distance);
             return ShadowStyleValue::create(data.color, offset_x, offset_y, blur_radius, spread_distance, data.placement);
         };
 
@@ -705,9 +705,9 @@ ErrorOr<RefPtr<StyleValue const>> ResolvedCSSStyleDeclaration::style_value_for_p
     case PropertyID::JustifyContent:
         return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().justify_content()));
     case PropertyID::JustifyItems:
-        return TRY(IdentifierStyleValue::create(to_value_id(layout_node.computed_values().justify_items())));
+        return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().justify_items()));
     case PropertyID::JustifySelf:
-        return TRY(IdentifierStyleValue::create(to_value_id(layout_node.computed_values().justify_self())));
+        return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().justify_self()));
     case PropertyID::Left:
         return style_value_for_length_percentage(layout_node.computed_values().inset().left());
     case PropertyID::LineHeight:
@@ -716,10 +716,10 @@ ErrorOr<RefPtr<StyleValue const>> ResolvedCSSStyleDeclaration::style_value_for_p
         return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().list_style_type()));
     case PropertyID::Margin: {
         auto margin = layout_node.computed_values().margin();
-        auto top = TRY(style_value_for_length_percentage(margin.top()));
-        auto right = TRY(style_value_for_length_percentage(margin.right()));
-        auto bottom = TRY(style_value_for_length_percentage(margin.bottom()));
-        auto left = TRY(style_value_for_length_percentage(margin.left()));
+        auto top = style_value_for_length_percentage(margin.top());
+        auto right = style_value_for_length_percentage(margin.right());
+        auto bottom = style_value_for_length_percentage(margin.bottom());
+        auto left = style_value_for_length_percentage(margin.left());
         return style_value_for_sided_shorthand(move(top), move(right), move(bottom), move(left));
     }
     case PropertyID::MarginBottom:
@@ -763,10 +763,10 @@ ErrorOr<RefPtr<StyleValue const>> ResolvedCSSStyleDeclaration::style_value_for_p
         return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().overflow_y()));
     case PropertyID::Padding: {
         auto padding = layout_node.computed_values().padding();
-        auto top = TRY(style_value_for_length_percentage(padding.top()));
-        auto right = TRY(style_value_for_length_percentage(padding.right()));
-        auto bottom = TRY(style_value_for_length_percentage(padding.bottom()));
-        auto left = TRY(style_value_for_length_percentage(padding.left()));
+        auto top = style_value_for_length_percentage(padding.top());
+        auto right = style_value_for_length_percentage(padding.right());
+        auto bottom = style_value_for_length_percentage(padding.bottom());
+        auto left = style_value_for_length_percentage(padding.left());
         return style_value_for_sided_shorthand(move(top), move(right), move(bottom), move(left));
     }
     case PropertyID::PaddingBottom:
@@ -809,7 +809,7 @@ ErrorOr<RefPtr<StyleValue const>> ResolvedCSSStyleDeclaration::style_value_for_p
         StyleValueVector style_values;
         TRY(style_values.try_ensure_capacity(text_decoration_lines.size()));
         for (auto const& line : text_decoration_lines) {
-            style_values.unchecked_append(TRY(IdentifierStyleValue::create(to_value_id(line))));
+            style_values.unchecked_append(IdentifierStyleValue::create(to_value_id(line)));
         }
         return StyleValueList::create(move(style_values), StyleValueList::Separator::Space);
     }
@@ -848,14 +848,14 @@ ErrorOr<RefPtr<StyleValue const>> ResolvedCSSStyleDeclaration::style_value_for_p
 
         StyleValueVector parameters;
         TRY(parameters.try_ensure_capacity(6));
-        parameters.unchecked_append(TRY(NumberStyleValue::create(affine_matrix.a())));
-        parameters.unchecked_append(TRY(NumberStyleValue::create(affine_matrix.b())));
-        parameters.unchecked_append(TRY(NumberStyleValue::create(affine_matrix.c())));
-        parameters.unchecked_append(TRY(NumberStyleValue::create(affine_matrix.d())));
-        parameters.unchecked_append(TRY(NumberStyleValue::create(affine_matrix.e())));
-        parameters.unchecked_append(TRY(NumberStyleValue::create(affine_matrix.f())));
+        parameters.unchecked_append(NumberStyleValue::create(affine_matrix.a()));
+        parameters.unchecked_append(NumberStyleValue::create(affine_matrix.b()));
+        parameters.unchecked_append(NumberStyleValue::create(affine_matrix.c()));
+        parameters.unchecked_append(NumberStyleValue::create(affine_matrix.d()));
+        parameters.unchecked_append(NumberStyleValue::create(affine_matrix.e()));
+        parameters.unchecked_append(NumberStyleValue::create(affine_matrix.f()));
 
-        NonnullRefPtr<StyleValue> matrix_function = TRY(TransformationStyleValue::create(TransformFunction::Matrix, move(parameters)));
+        NonnullRefPtr<StyleValue> matrix_function = TransformationStyleValue::create(TransformFunction::Matrix, move(parameters));
         // Elsewhere we always store the transform property's value as a StyleValueList of TransformationStyleValues,
         // so this is just for consistency.
         StyleValueVector matrix_functions { matrix_function };

--- a/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
@@ -77,7 +77,7 @@ DeprecatedString ResolvedCSSStyleDeclaration::item(size_t index) const
     return {};
 }
 
-static ErrorOr<NonnullRefPtr<StyleValue const>> style_value_for_background_property(Layout::NodeWithStyle const& layout_node, Function<ErrorOr<NonnullRefPtr<StyleValue const>>(BackgroundLayerData const&)> callback, Function<ErrorOr<NonnullRefPtr<StyleValue const>>()> default_value)
+static NonnullRefPtr<StyleValue const> style_value_for_background_property(Layout::NodeWithStyle const& layout_node, Function<NonnullRefPtr<StyleValue const>(BackgroundLayerData const&)> callback, Function<NonnullRefPtr<StyleValue const>()> default_value)
 {
     auto const& background_layers = layout_node.background_layers();
     if (background_layers.is_empty())
@@ -85,13 +85,13 @@ static ErrorOr<NonnullRefPtr<StyleValue const>> style_value_for_background_prope
     if (background_layers.size() == 1)
         return callback(background_layers.first());
     StyleValueVector values;
-    TRY(values.try_ensure_capacity(background_layers.size()));
+    values.ensure_capacity(background_layers.size());
     for (auto const& layer : background_layers)
-        values.unchecked_append(TRY(callback(layer)));
+        values.unchecked_append(callback(layer));
     return StyleValueList::create(move(values), StyleValueList::Separator::Comma);
 }
 
-static ErrorOr<RefPtr<StyleValue>> style_value_for_display(Display display)
+static RefPtr<StyleValue> style_value_for_display(Display display)
 {
     if (display.is_none())
         return IdentifierStyleValue::create(ValueID::None);
@@ -129,33 +129,33 @@ static ErrorOr<RefPtr<StyleValue>> style_value_for_display(Display display)
         StyleValueVector values;
         switch (display.outside()) {
         case Display::Outside::Inline:
-            TRY(values.try_append(IdentifierStyleValue::create(ValueID::Inline)));
+            values.append(IdentifierStyleValue::create(ValueID::Inline));
             break;
         case Display::Outside::Block:
-            TRY(values.try_append(IdentifierStyleValue::create(ValueID::Block)));
+            values.append(IdentifierStyleValue::create(ValueID::Block));
             break;
         case Display::Outside::RunIn:
-            TRY(values.try_append(IdentifierStyleValue::create(ValueID::RunIn)));
+            values.append(IdentifierStyleValue::create(ValueID::RunIn));
             break;
         }
         switch (display.inside()) {
         case Display::Inside::Flow:
-            TRY(values.try_append(IdentifierStyleValue::create(ValueID::Flow)));
+            values.append(IdentifierStyleValue::create(ValueID::Flow));
             break;
         case Display::Inside::FlowRoot:
-            TRY(values.try_append(IdentifierStyleValue::create(ValueID::FlowRoot)));
+            values.append(IdentifierStyleValue::create(ValueID::FlowRoot));
             break;
         case Display::Inside::Table:
-            TRY(values.try_append(IdentifierStyleValue::create(ValueID::Table)));
+            values.append(IdentifierStyleValue::create(ValueID::Table));
             break;
         case Display::Inside::Flex:
-            TRY(values.try_append(IdentifierStyleValue::create(ValueID::Flex)));
+            values.append(IdentifierStyleValue::create(ValueID::Flex));
             break;
         case Display::Inside::Grid:
-            TRY(values.try_append(IdentifierStyleValue::create(ValueID::Grid)));
+            values.append(IdentifierStyleValue::create(ValueID::Grid));
             break;
         case Display::Inside::Ruby:
-            TRY(values.try_append(IdentifierStyleValue::create(ValueID::Ruby)));
+            values.append(IdentifierStyleValue::create(ValueID::Ruby));
             break;
         }
 
@@ -263,7 +263,7 @@ static NonnullRefPtr<StyleValue const> style_value_for_svg_paint(Optional<SVGPai
     VERIFY_NOT_REACHED();
 }
 
-ErrorOr<RefPtr<StyleValue const>> ResolvedCSSStyleDeclaration::style_value_for_property(Layout::NodeWithStyle const& layout_node, PropertyID property_id) const
+RefPtr<StyleValue const> ResolvedCSSStyleDeclaration::style_value_for_property(Layout::NodeWithStyle const& layout_node, PropertyID property_id) const
 {
     switch (property_id) {
     case PropertyID::AccentColor: {
@@ -328,7 +328,7 @@ ErrorOr<RefPtr<StyleValue const>> ResolvedCSSStyleDeclaration::style_value_for_p
     case PropertyID::BackgroundImage:
         return style_value_for_background_property(
             layout_node,
-            [](auto& layer) -> ErrorOr<NonnullRefPtr<StyleValue const>> {
+            [](auto& layer) -> NonnullRefPtr<StyleValue const> {
                 if (layer.background_image)
                     return *layer.background_image;
                 return IdentifierStyleValue::create(ValueID::None);
@@ -342,12 +342,12 @@ ErrorOr<RefPtr<StyleValue const>> ResolvedCSSStyleDeclaration::style_value_for_p
     case PropertyID::BackgroundPosition:
         return style_value_for_background_property(
             layout_node,
-            [](auto& layer) -> ErrorOr<NonnullRefPtr<StyleValue>> {
+            [](auto& layer) -> NonnullRefPtr<StyleValue> {
                 return PositionStyleValue::create(
                     EdgeStyleValue::create(layer.position_edge_x, layer.position_offset_x),
                     EdgeStyleValue::create(layer.position_edge_y, layer.position_offset_y));
             },
-            []() -> ErrorOr<NonnullRefPtr<StyleValue>> {
+            []() -> NonnullRefPtr<StyleValue> {
                 return PositionStyleValue::create(
                     EdgeStyleValue::create(PositionEdge::Left, Percentage(0)),
                     EdgeStyleValue::create(PositionEdge::Top, Percentage(0)));
@@ -365,7 +365,7 @@ ErrorOr<RefPtr<StyleValue const>> ResolvedCSSStyleDeclaration::style_value_for_p
     case PropertyID::BackgroundRepeat:
         return style_value_for_background_property(
             layout_node,
-            [](auto& layer) -> ErrorOr<NonnullRefPtr<StyleValue const>> {
+            [](auto& layer) -> NonnullRefPtr<StyleValue const> {
                 StyleValueVector repeat {
                     IdentifierStyleValue::create(to_value_id(layer.repeat_x)),
                     IdentifierStyleValue::create(to_value_id(layer.repeat_y)),
@@ -376,7 +376,7 @@ ErrorOr<RefPtr<StyleValue const>> ResolvedCSSStyleDeclaration::style_value_for_p
     case PropertyID::BackgroundSize:
         return style_value_for_background_property(
             layout_node,
-            [](auto& layer) -> ErrorOr<NonnullRefPtr<StyleValue>> {
+            [](auto& layer) -> NonnullRefPtr<StyleValue> {
                 switch (layer.size_type) {
                 case BackgroundSize::Contain:
                     return IdentifierStyleValue::create(ValueID::Contain);
@@ -536,7 +536,7 @@ ErrorOr<RefPtr<StyleValue const>> ResolvedCSSStyleDeclaration::style_value_for_p
         if (box_shadow_layers.is_empty())
             return nullptr;
 
-        auto make_box_shadow_style_value = [](ShadowData const& data) -> ErrorOr<NonnullRefPtr<ShadowStyleValue>> {
+        auto make_box_shadow_style_value = [](ShadowData const& data) -> NonnullRefPtr<ShadowStyleValue> {
             auto offset_x = LengthStyleValue::create(data.offset_x);
             auto offset_y = LengthStyleValue::create(data.offset_y);
             auto blur_radius = LengthStyleValue::create(data.blur_radius);
@@ -548,9 +548,9 @@ ErrorOr<RefPtr<StyleValue const>> ResolvedCSSStyleDeclaration::style_value_for_p
             return make_box_shadow_style_value(box_shadow_layers.first());
 
         StyleValueVector box_shadow;
-        TRY(box_shadow.try_ensure_capacity(box_shadow_layers.size()));
+        box_shadow.ensure_capacity(box_shadow_layers.size());
         for (auto const& layer : box_shadow_layers)
-            box_shadow.unchecked_append(TRY(make_box_shadow_style_value(layer)));
+            box_shadow.unchecked_append(make_box_shadow_style_value(layer));
         return StyleValueList::create(move(box_shadow), StyleValueList::Separator::Comma);
     }
     case PropertyID::BoxSizing:
@@ -578,10 +578,10 @@ ErrorOr<RefPtr<StyleValue const>> ResolvedCSSStyleDeclaration::style_value_for_p
         return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().fill_rule()));
     case PropertyID::FlexBasis:
         return layout_node.computed_values().flex_basis().visit(
-            [](CSS::FlexBasisContent const&) -> ErrorOr<RefPtr<StyleValue const>> {
+            [](CSS::FlexBasisContent const&) -> RefPtr<StyleValue const> {
                 return IdentifierStyleValue::create(ValueID::Content);
             },
-            [&](CSS::Size const& size) -> ErrorOr<RefPtr<StyleValue const>> {
+            [&](CSS::Size const& size) -> RefPtr<StyleValue const> {
                 return style_value_for_size(size);
             });
     case PropertyID::FlexDirection:
@@ -744,9 +744,9 @@ ErrorOr<RefPtr<StyleValue const>> ResolvedCSSStyleDeclaration::style_value_for_p
         return IntegerStyleValue::create(layout_node.computed_values().order());
     case PropertyID::Outline: {
         return StyleValueList::create(
-            { TRY(style_value_for_property(layout_node, PropertyID::OutlineColor)).release_nonnull(),
-                TRY(style_value_for_property(layout_node, PropertyID::OutlineStyle)).release_nonnull(),
-                TRY(style_value_for_property(layout_node, PropertyID::OutlineWidth)).release_nonnull() },
+            { style_value_for_property(layout_node, PropertyID::OutlineColor).release_nonnull(),
+                style_value_for_property(layout_node, PropertyID::OutlineStyle).release_nonnull(),
+                style_value_for_property(layout_node, PropertyID::OutlineWidth).release_nonnull() },
             StyleValueList::Separator::Space);
     }
     case PropertyID::OutlineColor:
@@ -794,10 +794,10 @@ ErrorOr<RefPtr<StyleValue const>> ResolvedCSSStyleDeclaration::style_value_for_p
     case PropertyID::TextAlign:
         return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().text_align()));
     case PropertyID::TextDecoration: {
-        auto line = TRY(style_value_for_property(layout_node, PropertyID::TextDecorationLine));
-        auto thickness = TRY(style_value_for_property(layout_node, PropertyID::TextDecorationThickness));
-        auto style = TRY(style_value_for_property(layout_node, PropertyID::TextDecorationStyle));
-        auto color = TRY(style_value_for_property(layout_node, PropertyID::TextDecorationColor));
+        auto line = style_value_for_property(layout_node, PropertyID::TextDecorationLine);
+        auto thickness = style_value_for_property(layout_node, PropertyID::TextDecorationThickness);
+        auto style = style_value_for_property(layout_node, PropertyID::TextDecorationStyle);
+        auto color = style_value_for_property(layout_node, PropertyID::TextDecorationColor);
         return TextDecorationStyleValue::create(*line, *thickness, *style, *color);
     }
     case PropertyID::TextDecorationColor:
@@ -807,7 +807,7 @@ ErrorOr<RefPtr<StyleValue const>> ResolvedCSSStyleDeclaration::style_value_for_p
         if (text_decoration_lines.is_empty())
             return IdentifierStyleValue::create(ValueID::None);
         StyleValueVector style_values;
-        TRY(style_values.try_ensure_capacity(text_decoration_lines.size()));
+        style_values.ensure_capacity(text_decoration_lines.size());
         for (auto const& line : text_decoration_lines) {
             style_values.unchecked_append(IdentifierStyleValue::create(to_value_id(line)));
         }
@@ -847,7 +847,7 @@ ErrorOr<RefPtr<StyleValue const>> ResolvedCSSStyleDeclaration::style_value_for_p
         auto affine_matrix = paintable_box->stacking_context()->affine_transform_matrix();
 
         StyleValueVector parameters;
-        TRY(parameters.try_ensure_capacity(6));
+        parameters.ensure_capacity(6);
         parameters.unchecked_append(NumberStyleValue::create(affine_matrix.a()));
         parameters.unchecked_append(NumberStyleValue::create(affine_matrix.b()));
         parameters.unchecked_append(NumberStyleValue::create(affine_matrix.c()));
@@ -924,7 +924,7 @@ Optional<StyleProperty> ResolvedCSSStyleDeclaration::property(PropertyID propert
     }
 
     auto& layout_node = *m_element->layout_node();
-    auto value = style_value_for_property(layout_node, property_id).release_value_but_fixme_should_propagate_errors();
+    auto value = style_value_for_property(layout_node, property_id);
     if (!value)
         return {};
     return StyleProperty {

--- a/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.h
+++ b/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.h
@@ -32,7 +32,7 @@ private:
 
     virtual void visit_edges(Cell::Visitor&) override;
 
-    ErrorOr<RefPtr<StyleValue const>> style_value_for_property(Layout::NodeWithStyle const&, PropertyID) const;
+    RefPtr<StyleValue const> style_value_for_property(Layout::NodeWithStyle const&, PropertyID) const;
 
     JS::NonnullGCPtr<DOM::Element> m_element;
 };

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -2353,7 +2353,7 @@ CSSPixels StyleComputer::parent_or_root_element_line_height(DOM::Element const* 
     return computed_values->line_height(viewport_rect(), parent_font_metrics, m_root_element_font_metrics);
 }
 
-ErrorOr<void> StyleComputer::absolutize_values(StyleProperties& style, DOM::Element const* element, Optional<CSS::Selector::PseudoElement> pseudo_element) const
+void StyleComputer::absolutize_values(StyleProperties& style, DOM::Element const* element, Optional<CSS::Selector::PseudoElement> pseudo_element) const
 {
     auto parent_or_root_line_height = parent_or_root_element_line_height(element, pseudo_element);
 
@@ -2385,9 +2385,8 @@ ErrorOr<void> StyleComputer::absolutize_values(StyleProperties& style, DOM::Elem
         auto& value_slot = style.m_property_values[i];
         if (!value_slot.has_value())
             continue;
-        value_slot->style = TRY(value_slot->style->absolutized(viewport_rect(), font_metrics, m_root_element_font_metrics));
+        value_slot->style = value_slot->style->absolutized(viewport_rect(), font_metrics, m_root_element_font_metrics);
     }
-    return {};
 }
 
 enum class BoxTypeTransformation {
@@ -2487,7 +2486,7 @@ NonnullRefPtr<StyleProperties> StyleComputer::create_document_style() const
     auto style = StyleProperties::create();
     compute_font(style, nullptr, {});
     compute_defaulted_values(style, nullptr, {});
-    absolutize_values(style, nullptr, {}).release_value_but_fixme_should_propagate_errors();
+    absolutize_values(style, nullptr, {});
     style->set_property(CSS::PropertyID::Width, CSS::LengthStyleValue::create(CSS::Length::make_px(viewport_rect().width())), nullptr);
     style->set_property(CSS::PropertyID::Height, CSS::LengthStyleValue::create(CSS::Length::make_px(viewport_rect().height())), nullptr);
     style->set_property(CSS::PropertyID::Display, CSS::DisplayStyleValue::create(CSS::Display::from_short(CSS::Display::Short::Block)), nullptr);
@@ -2521,7 +2520,7 @@ ErrorOr<RefPtr<StyleProperties>> StyleComputer::compute_style_impl(DOM::Element&
     compute_font(style, &element, pseudo_element);
 
     // 3. Absolutize values, turning font/viewport relative lengths into absolute lengths
-    TRY(absolutize_values(style, &element, pseudo_element));
+    absolutize_values(style, &element, pseudo_element);
 
     // 4. Default the values, applying inheritance and 'initial' as needed
     compute_defaulted_values(style, &element, pseudo_element);

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -921,7 +921,7 @@ void StyleComputer::set_all_properties(DOM::Element& element, Optional<CSS::Sele
             if (is_inherited_property(property_id))
                 style.m_property_values[to_underlying(property_id)] = { { get_inherit_value(document.realm(), property_id, &element, pseudo_element), nullptr } };
             else
-                style.m_property_values[to_underlying(property_id)] = { { property_initial_value(document.realm(), property_id).release_value_but_fixme_should_propagate_errors(), nullptr } };
+                style.m_property_values[to_underlying(property_id)] = { { property_initial_value(document.realm(), property_id), nullptr } };
             continue;
         }
 
@@ -1087,7 +1087,7 @@ bool StyleComputer::expand_unresolved_values(DOM::Element& element, StringView p
                 return false;
             }
 
-            if (auto maybe_calc_value = Parser::Parser::parse_calculated_value({}, Parser::ParsingContext { document() }, value).release_value_but_fixme_should_propagate_errors(); maybe_calc_value && maybe_calc_value->is_calculated()) {
+            if (auto maybe_calc_value = Parser::Parser::parse_calculated_value({}, Parser::ParsingContext { document() }, value); maybe_calc_value && maybe_calc_value->is_calculated()) {
                 auto& calc_value = maybe_calc_value->as_calculated();
                 if (calc_value.resolves_to_number()) {
                     auto resolved_value = calc_value.resolve_number();
@@ -1146,7 +1146,7 @@ RefPtr<StyleValue> StyleComputer::resolve_unresolved_style_value(DOM::Element& e
     if (!expand_unresolved_values(element, string_from_property_id(property_id), unresolved_values_with_variables_expanded, expanded_values))
         return {};
 
-    if (auto parsed_value = Parser::Parser::parse_css_value({}, Parser::ParsingContext { document() }, property_id, expanded_values).release_value_but_fixme_should_propagate_errors())
+    if (auto parsed_value = Parser::Parser::parse_css_value({}, Parser::ParsingContext { document() }, property_id, expanded_values))
         return parsed_value.release_nonnull();
 
     return {};
@@ -1939,7 +1939,7 @@ NonnullRefPtr<StyleValue const> get_inherit_value(JS::Realm& initial_value_conte
     auto* parent_element = element_to_inherit_style_from(element, pseudo_element);
 
     if (!parent_element || !parent_element->computed_css_values())
-        return property_initial_value(initial_value_context_realm, property_id).release_value_but_fixme_should_propagate_errors();
+        return property_initial_value(initial_value_context_realm, property_id);
     return parent_element->computed_css_values()->property(property_id);
 }
 
@@ -1952,12 +1952,12 @@ void StyleComputer::compute_defaulted_property_value(StyleProperties& style, DOM
         if (is_inherited_property(property_id))
             style.m_property_values[to_underlying(property_id)] = { { get_inherit_value(document().realm(), property_id, element, pseudo_element), nullptr } };
         else
-            style.m_property_values[to_underlying(property_id)] = { { property_initial_value(document().realm(), property_id).release_value_but_fixme_should_propagate_errors(), nullptr } };
+            style.m_property_values[to_underlying(property_id)] = { { property_initial_value(document().realm(), property_id), nullptr } };
         return;
     }
 
     if (value_slot->style->is_initial()) {
-        value_slot->style = property_initial_value(document().realm(), property_id).release_value_but_fixme_should_propagate_errors();
+        value_slot->style = property_initial_value(document().realm(), property_id);
         return;
     }
 
@@ -1974,7 +1974,7 @@ void StyleComputer::compute_defaulted_property_value(StyleProperties& style, DOM
             value_slot->style = get_inherit_value(document().realm(), property_id, element, pseudo_element);
         } else {
             // and if it is not, this is treated as initial.
-            value_slot->style = property_initial_value(document().realm(), property_id).release_value_but_fixme_should_propagate_errors();
+            value_slot->style = property_initial_value(document().realm(), property_id);
         }
     }
 }

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -688,8 +688,8 @@ static void set_property_expanding_shorthands(StyleProperties& style, CSS::Prope
                     y_positions.unchecked_append(layer);
                 }
             }
-            set_longhand_property(CSS::PropertyID::BackgroundPositionX, StyleValueList::create(move(x_positions), values_list.separator()).release_value_but_fixme_should_propagate_errors());
-            set_longhand_property(CSS::PropertyID::BackgroundPositionY, StyleValueList::create(move(y_positions), values_list.separator()).release_value_but_fixme_should_propagate_errors());
+            set_longhand_property(CSS::PropertyID::BackgroundPositionX, StyleValueList::create(move(x_positions), values_list.separator()));
+            set_longhand_property(CSS::PropertyID::BackgroundPositionY, StyleValueList::create(move(y_positions), values_list.separator()));
         } else {
             set_longhand_property(CSS::PropertyID::BackgroundPositionX, value);
             set_longhand_property(CSS::PropertyID::BackgroundPositionY, value);
@@ -2320,8 +2320,8 @@ void StyleComputer::compute_font(StyleProperties& style, DOM::Element const* ele
 
     auto found_font = compute_font_for_style_values(element, pseudo_element, font_family, font_size, font_style, font_weight, font_stretch);
 
-    style.set_property(CSS::PropertyID::FontSize, LengthStyleValue::create(CSS::Length::make_px(found_font->pixel_size())).release_value_but_fixme_should_propagate_errors(), nullptr);
-    style.set_property(CSS::PropertyID::FontWeight, NumberStyleValue::create(font_weight->to_font_weight()).release_value_but_fixme_should_propagate_errors());
+    style.set_property(CSS::PropertyID::FontSize, LengthStyleValue::create(CSS::Length::make_px(found_font->pixel_size())), nullptr);
+    style.set_property(CSS::PropertyID::FontWeight, NumberStyleValue::create(font_weight->to_font_weight()));
 
     style.set_computed_font(found_font.release_nonnull());
 
@@ -2370,8 +2370,8 @@ ErrorOr<void> StyleComputer::absolutize_values(StyleProperties& style, DOM::Elem
     //       because most percentages are relative to containing block metrics.
     auto line_height_value_slot = style.m_property_values[to_underlying(CSS::PropertyID::LineHeight)].map([](auto& x) -> auto& { return x.style; });
     if (line_height_value_slot.has_value() && (*line_height_value_slot)->is_percentage()) {
-        *line_height_value_slot = TRY(LengthStyleValue::create(
-            Length::make_px(font_size * static_cast<double>((*line_height_value_slot)->as_percentage().percentage().as_fraction()))));
+        *line_height_value_slot = LengthStyleValue::create(
+            Length::make_px(font_size * static_cast<double>((*line_height_value_slot)->as_percentage().percentage().as_fraction())));
     }
 
     auto line_height = style.line_height(viewport_rect(), font_metrics, m_root_element_font_metrics);
@@ -2379,7 +2379,7 @@ ErrorOr<void> StyleComputer::absolutize_values(StyleProperties& style, DOM::Elem
 
     // NOTE: line-height might be using lh which should be resolved against the parent line height (like we did here already)
     if (line_height_value_slot.has_value() && (*line_height_value_slot)->is_length())
-        (*line_height_value_slot) = TRY(LengthStyleValue::create(Length::make_px(line_height)));
+        (*line_height_value_slot) = LengthStyleValue::create(Length::make_px(line_height));
 
     for (size_t i = 0; i < style.m_property_values.size(); ++i) {
         auto& value_slot = style.m_property_values[i];
@@ -2479,7 +2479,7 @@ void StyleComputer::transform_box_type_if_needed(StyleProperties& style, DOM::El
     }
 
     if (new_display != display)
-        style.set_property(CSS::PropertyID::Display, DisplayStyleValue::create(new_display).release_value_but_fixme_should_propagate_errors(), style.property_source_declaration(CSS::PropertyID::Display));
+        style.set_property(CSS::PropertyID::Display, DisplayStyleValue::create(new_display), style.property_source_declaration(CSS::PropertyID::Display));
 }
 
 NonnullRefPtr<StyleProperties> StyleComputer::create_document_style() const
@@ -2488,9 +2488,9 @@ NonnullRefPtr<StyleProperties> StyleComputer::create_document_style() const
     compute_font(style, nullptr, {});
     compute_defaulted_values(style, nullptr, {});
     absolutize_values(style, nullptr, {}).release_value_but_fixme_should_propagate_errors();
-    style->set_property(CSS::PropertyID::Width, CSS::LengthStyleValue::create(CSS::Length::make_px(viewport_rect().width())).release_value_but_fixme_should_propagate_errors(), nullptr);
-    style->set_property(CSS::PropertyID::Height, CSS::LengthStyleValue::create(CSS::Length::make_px(viewport_rect().height())).release_value_but_fixme_should_propagate_errors(), nullptr);
-    style->set_property(CSS::PropertyID::Display, CSS::DisplayStyleValue::create(CSS::Display::from_short(CSS::Display::Short::Block)).release_value_but_fixme_should_propagate_errors(), nullptr);
+    style->set_property(CSS::PropertyID::Width, CSS::LengthStyleValue::create(CSS::Length::make_px(viewport_rect().width())), nullptr);
+    style->set_property(CSS::PropertyID::Height, CSS::LengthStyleValue::create(CSS::Length::make_px(viewport_rect().height())), nullptr);
+    style->set_property(CSS::PropertyID::Display, CSS::DisplayStyleValue::create(CSS::Display::from_short(CSS::Display::Short::Block)), nullptr);
     return style;
 }
 

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.h
@@ -148,7 +148,7 @@ private:
     RefPtr<Gfx::Font const> font_matching_algorithm(FontFaceKey const& key, float font_size_in_pt) const;
     void compute_font(StyleProperties&, DOM::Element const*, Optional<CSS::Selector::PseudoElement>) const;
     void compute_defaulted_values(StyleProperties&, DOM::Element const*, Optional<CSS::Selector::PseudoElement>) const;
-    ErrorOr<void> absolutize_values(StyleProperties&, DOM::Element const*, Optional<CSS::Selector::PseudoElement>) const;
+    void absolutize_values(StyleProperties&, DOM::Element const*, Optional<CSS::Selector::PseudoElement>) const;
     void transform_box_type_if_needed(StyleProperties&, DOM::Element const&, Optional<CSS::Selector::PseudoElement>) const;
 
     void compute_defaulted_property_value(StyleProperties&, DOM::Element const*, CSS::PropertyID, Optional<CSS::Selector::PseudoElement>) const;

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
@@ -410,7 +410,7 @@ StyleValueList const& StyleValue::as_value_list() const
     return static_cast<StyleValueList const&>(*this);
 }
 
-ErrorOr<ValueComparingNonnullRefPtr<StyleValue const>> StyleValue::absolutized(CSSPixelRect const&, Length::FontMetrics const&, Length::FontMetrics const&) const
+ValueComparingNonnullRefPtr<StyleValue const> StyleValue::absolutized(CSSPixelRect const&, Length::FontMetrics const&, Length::FontMetrics const&) const
 {
     return *this;
 }

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -323,7 +323,7 @@ public:
     bool has_auto() const;
     virtual bool has_color() const { return false; }
 
-    virtual ErrorOr<ValueComparingNonnullRefPtr<StyleValue const>> absolutized(CSSPixelRect const& viewport_rect, Length::FontMetrics const& font_metrics, Length::FontMetrics const& root_font_metrics) const;
+    virtual ValueComparingNonnullRefPtr<StyleValue const> absolutized(CSSPixelRect const& viewport_rect, Length::FontMetrics const& font_metrics, Length::FontMetrics const& root_font_metrics) const;
 
     virtual Color to_color(Optional<Layout::NodeWithStyle const&>) const { return {}; }
     ValueID to_identifier() const;

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/AngleStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/AngleStyleValue.h
@@ -16,9 +16,9 @@ namespace Web::CSS {
 
 class AngleStyleValue : public StyleValueWithDefaultOperators<AngleStyleValue> {
 public:
-    static ErrorOr<ValueComparingNonnullRefPtr<AngleStyleValue>> create(Angle angle)
+    static ValueComparingNonnullRefPtr<AngleStyleValue> create(Angle angle)
     {
-        return adopt_nonnull_ref_or_enomem(new (nothrow) AngleStyleValue(move(angle)));
+        return adopt_ref(*new (nothrow) AngleStyleValue(move(angle)));
     }
     virtual ~AngleStyleValue() override;
 

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/BackgroundRepeatStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/BackgroundRepeatStyleValue.h
@@ -16,9 +16,9 @@ namespace Web::CSS {
 
 class BackgroundRepeatStyleValue final : public StyleValueWithDefaultOperators<BackgroundRepeatStyleValue> {
 public:
-    static ErrorOr<ValueComparingNonnullRefPtr<BackgroundRepeatStyleValue>> create(Repeat repeat_x, Repeat repeat_y)
+    static ValueComparingNonnullRefPtr<BackgroundRepeatStyleValue> create(Repeat repeat_x, Repeat repeat_y)
     {
-        return adopt_nonnull_ref_or_enomem(new (nothrow) BackgroundRepeatStyleValue(repeat_x, repeat_y));
+        return adopt_ref(*new (nothrow) BackgroundRepeatStyleValue(repeat_x, repeat_y));
     }
     virtual ~BackgroundRepeatStyleValue() override;
 

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/BackgroundSizeStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/BackgroundSizeStyleValue.h
@@ -18,9 +18,9 @@ namespace Web::CSS {
 // NOTE: This is not used for identifier sizes, like `cover` and `contain`.
 class BackgroundSizeStyleValue final : public StyleValueWithDefaultOperators<BackgroundSizeStyleValue> {
 public:
-    static ErrorOr<ValueComparingNonnullRefPtr<BackgroundSizeStyleValue>> create(LengthPercentage size_x, LengthPercentage size_y)
+    static ValueComparingNonnullRefPtr<BackgroundSizeStyleValue> create(LengthPercentage size_x, LengthPercentage size_y)
     {
-        return adopt_nonnull_ref_or_enomem(new (nothrow) BackgroundSizeStyleValue(size_x, size_y));
+        return adopt_ref(*new (nothrow) BackgroundSizeStyleValue(size_x, size_y));
     }
     virtual ~BackgroundSizeStyleValue() override;
 

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/BackgroundStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/BackgroundStyleValue.h
@@ -15,7 +15,7 @@ namespace Web::CSS {
 
 class BackgroundStyleValue final : public StyleValueWithDefaultOperators<BackgroundStyleValue> {
 public:
-    static ErrorOr<ValueComparingNonnullRefPtr<BackgroundStyleValue>> create(
+    static ValueComparingNonnullRefPtr<BackgroundStyleValue> create(
         ValueComparingNonnullRefPtr<StyleValue const> color,
         ValueComparingNonnullRefPtr<StyleValue const> image,
         ValueComparingNonnullRefPtr<StyleValue const> position,
@@ -25,7 +25,7 @@ public:
         ValueComparingNonnullRefPtr<StyleValue const> origin,
         ValueComparingNonnullRefPtr<StyleValue const> clip)
     {
-        return adopt_nonnull_ref_or_enomem(new (nothrow) BackgroundStyleValue(move(color), move(image), move(position), move(size), move(repeat), move(attachment), move(origin), move(clip)));
+        return adopt_ref(*new (nothrow) BackgroundStyleValue(move(color), move(image), move(position), move(size), move(repeat), move(attachment), move(origin), move(clip)));
     }
     virtual ~BackgroundStyleValue() override;
 

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/BorderRadiusShorthandStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/BorderRadiusShorthandStyleValue.h
@@ -16,13 +16,13 @@ namespace Web::CSS {
 
 class BorderRadiusShorthandStyleValue final : public StyleValueWithDefaultOperators<BorderRadiusShorthandStyleValue> {
 public:
-    static ErrorOr<ValueComparingNonnullRefPtr<BorderRadiusShorthandStyleValue>> create(
+    static ValueComparingNonnullRefPtr<BorderRadiusShorthandStyleValue> create(
         ValueComparingNonnullRefPtr<BorderRadiusStyleValue const> top_left,
         ValueComparingNonnullRefPtr<BorderRadiusStyleValue const> top_right,
         ValueComparingNonnullRefPtr<BorderRadiusStyleValue const> bottom_right,
         ValueComparingNonnullRefPtr<BorderRadiusStyleValue const> bottom_left)
     {
-        return adopt_nonnull_ref_or_enomem(new (nothrow) BorderRadiusShorthandStyleValue(move(top_left), move(top_right), move(bottom_right), move(bottom_left)));
+        return adopt_ref(*new (nothrow) BorderRadiusShorthandStyleValue(move(top_left), move(top_right), move(bottom_right), move(bottom_left)));
     }
     virtual ~BorderRadiusShorthandStyleValue() override = default;
 

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/BorderRadiusStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/BorderRadiusStyleValue.cpp
@@ -18,7 +18,7 @@ ErrorOr<String> BorderRadiusStyleValue::to_string() const
     return String::formatted("{} / {}", TRY(m_properties.horizontal_radius.to_string()), TRY(m_properties.vertical_radius.to_string()));
 }
 
-ErrorOr<ValueComparingNonnullRefPtr<StyleValue const>> BorderRadiusStyleValue::absolutized(CSSPixelRect const& viewport_rect, Length::FontMetrics const& font_metrics, Length::FontMetrics const& root_font_metrics) const
+ValueComparingNonnullRefPtr<StyleValue const> BorderRadiusStyleValue::absolutized(CSSPixelRect const& viewport_rect, Length::FontMetrics const& font_metrics, Length::FontMetrics const& root_font_metrics) const
 {
     if (m_properties.horizontal_radius.is_percentage() && m_properties.vertical_radius.is_percentage())
         return *this;

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/BorderRadiusStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/BorderRadiusStyleValue.h
@@ -38,7 +38,7 @@ private:
     {
     }
 
-    virtual ErrorOr<ValueComparingNonnullRefPtr<StyleValue const>> absolutized(CSSPixelRect const& viewport_rect, Length::FontMetrics const& font_metrics, Length::FontMetrics const& root_font_metrics) const override;
+    virtual ValueComparingNonnullRefPtr<StyleValue const> absolutized(CSSPixelRect const& viewport_rect, Length::FontMetrics const& font_metrics, Length::FontMetrics const& root_font_metrics) const override;
 
     struct Properties {
         bool is_elliptical;

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/BorderRadiusStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/BorderRadiusStyleValue.h
@@ -17,9 +17,9 @@ namespace Web::CSS {
 
 class BorderRadiusStyleValue final : public StyleValueWithDefaultOperators<BorderRadiusStyleValue> {
 public:
-    static ErrorOr<ValueComparingNonnullRefPtr<BorderRadiusStyleValue>> create(LengthPercentage const& horizontal_radius, LengthPercentage const& vertical_radius)
+    static ValueComparingNonnullRefPtr<BorderRadiusStyleValue> create(LengthPercentage const& horizontal_radius, LengthPercentage const& vertical_radius)
     {
-        return adopt_nonnull_ref_or_enomem(new (nothrow) BorderRadiusStyleValue(horizontal_radius, vertical_radius));
+        return adopt_ref(*new (nothrow) BorderRadiusStyleValue(horizontal_radius, vertical_radius));
     }
     virtual ~BorderRadiusStyleValue() override = default;
 

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/BorderStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/BorderStyleValue.h
@@ -15,12 +15,12 @@ namespace Web::CSS {
 
 class BorderStyleValue final : public StyleValueWithDefaultOperators<BorderStyleValue> {
 public:
-    static ErrorOr<ValueComparingNonnullRefPtr<BorderStyleValue>> create(
+    static ValueComparingNonnullRefPtr<BorderStyleValue> create(
         ValueComparingNonnullRefPtr<StyleValue> border_width,
         ValueComparingNonnullRefPtr<StyleValue> border_style,
         ValueComparingNonnullRefPtr<StyleValue> border_color)
     {
-        return adopt_nonnull_ref_or_enomem(new (nothrow) BorderStyleValue(move(border_width), move(border_style), move(border_color)));
+        return adopt_ref(*new (nothrow) BorderStyleValue(move(border_width), move(border_style), move(border_color)));
     }
     virtual ~BorderStyleValue() override;
 

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.cpp
@@ -114,9 +114,9 @@ CalculationNode::CalculationNode(Type type)
 
 CalculationNode::~CalculationNode() = default;
 
-ErrorOr<NonnullOwnPtr<NumericCalculationNode>> NumericCalculationNode::create(NumericValue value)
+NonnullOwnPtr<NumericCalculationNode> NumericCalculationNode::create(NumericValue value)
 {
-    return adopt_nonnull_own_or_enomem(new (nothrow) NumericCalculationNode(move(value)));
+    return adopt_own(*new (nothrow) NumericCalculationNode(move(value)));
 }
 
 NumericCalculationNode::NumericCalculationNode(NumericValue value)
@@ -211,9 +211,9 @@ ErrorOr<void> NumericCalculationNode::dump(StringBuilder& builder, int indent) c
     return builder.try_appendff("{: >{}}NUMERIC({})\n", "", indent, TRY(m_value.visit([](auto& it) { return it.to_string(); })));
 }
 
-ErrorOr<NonnullOwnPtr<SumCalculationNode>> SumCalculationNode::create(Vector<NonnullOwnPtr<CalculationNode>> values)
+NonnullOwnPtr<SumCalculationNode> SumCalculationNode::create(Vector<NonnullOwnPtr<CalculationNode>> values)
 {
-    return adopt_nonnull_own_or_enomem(new (nothrow) SumCalculationNode(move(values)));
+    return adopt_own(*new (nothrow) SumCalculationNode(move(values)));
 }
 
 SumCalculationNode::SumCalculationNode(Vector<NonnullOwnPtr<CalculationNode>> values)
@@ -314,14 +314,12 @@ CalculatedStyleValue::CalculationResult SumCalculationNode::resolve(Optional<Len
     return total.value();
 }
 
-ErrorOr<void> SumCalculationNode::for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const& callback)
+void SumCalculationNode::for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const& callback)
 {
     for (auto& item : m_values) {
-        TRY(item->for_each_child_node(callback));
-        TRY(callback(item));
+        item->for_each_child_node(callback);
+        callback(item);
     }
-
-    return {};
 }
 
 ErrorOr<void> SumCalculationNode::dump(StringBuilder& builder, int indent) const
@@ -332,9 +330,9 @@ ErrorOr<void> SumCalculationNode::dump(StringBuilder& builder, int indent) const
     return {};
 }
 
-ErrorOr<NonnullOwnPtr<ProductCalculationNode>> ProductCalculationNode::create(Vector<NonnullOwnPtr<CalculationNode>> values)
+NonnullOwnPtr<ProductCalculationNode> ProductCalculationNode::create(Vector<NonnullOwnPtr<CalculationNode>> values)
 {
-    return adopt_nonnull_own_or_enomem(new (nothrow) ProductCalculationNode(move(values)));
+    return adopt_own(*new (nothrow) ProductCalculationNode(move(values)));
 }
 
 ProductCalculationNode::ProductCalculationNode(Vector<NonnullOwnPtr<CalculationNode>> values)
@@ -440,14 +438,12 @@ CalculatedStyleValue::CalculationResult ProductCalculationNode::resolve(Optional
     return total.value();
 }
 
-ErrorOr<void> ProductCalculationNode::for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const& callback)
+void ProductCalculationNode::for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const& callback)
 {
     for (auto& item : m_values) {
-        TRY(item->for_each_child_node(callback));
-        TRY(callback(item));
+        item->for_each_child_node(callback);
+        callback(item);
     }
-
-    return {};
 }
 
 ErrorOr<void> ProductCalculationNode::dump(StringBuilder& builder, int indent) const
@@ -458,9 +454,9 @@ ErrorOr<void> ProductCalculationNode::dump(StringBuilder& builder, int indent) c
     return {};
 }
 
-ErrorOr<NonnullOwnPtr<NegateCalculationNode>> NegateCalculationNode::create(NonnullOwnPtr<Web::CSS::CalculationNode> value)
+NonnullOwnPtr<NegateCalculationNode> NegateCalculationNode::create(NonnullOwnPtr<Web::CSS::CalculationNode> value)
 {
-    return adopt_nonnull_own_or_enomem(new (nothrow) NegateCalculationNode(move(value)));
+    return adopt_own(*new (nothrow) NegateCalculationNode(move(value)));
 }
 
 NegateCalculationNode::NegateCalculationNode(NonnullOwnPtr<CalculationNode> value)
@@ -500,11 +496,10 @@ CalculatedStyleValue::CalculationResult NegateCalculationNode::resolve(Optional<
     return child_value;
 }
 
-ErrorOr<void> NegateCalculationNode::for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const& callback)
+void NegateCalculationNode::for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const& callback)
 {
-    TRY(m_value->for_each_child_node(callback));
-    TRY(callback(m_value));
-    return {};
+    m_value->for_each_child_node(callback);
+    callback(m_value);
 }
 
 ErrorOr<void> NegateCalculationNode::dump(StringBuilder& builder, int indent) const
@@ -514,9 +509,9 @@ ErrorOr<void> NegateCalculationNode::dump(StringBuilder& builder, int indent) co
     return {};
 }
 
-ErrorOr<NonnullOwnPtr<InvertCalculationNode>> InvertCalculationNode::create(NonnullOwnPtr<Web::CSS::CalculationNode> value)
+NonnullOwnPtr<InvertCalculationNode> InvertCalculationNode::create(NonnullOwnPtr<Web::CSS::CalculationNode> value)
 {
-    return adopt_nonnull_own_or_enomem(new (nothrow) InvertCalculationNode(move(value)));
+    return adopt_own(*new (nothrow) InvertCalculationNode(move(value)));
 }
 
 InvertCalculationNode::InvertCalculationNode(NonnullOwnPtr<CalculationNode> value)
@@ -563,11 +558,10 @@ CalculatedStyleValue::CalculationResult InvertCalculationNode::resolve(Optional<
     return child_value;
 }
 
-ErrorOr<void> InvertCalculationNode::for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const& callback)
+void InvertCalculationNode::for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const& callback)
 {
-    TRY(m_value->for_each_child_node(callback));
-    TRY(callback(m_value));
-    return {};
+    m_value->for_each_child_node(callback);
+    callback(m_value);
 }
 
 ErrorOr<void> InvertCalculationNode::dump(StringBuilder& builder, int indent) const
@@ -577,9 +571,9 @@ ErrorOr<void> InvertCalculationNode::dump(StringBuilder& builder, int indent) co
     return {};
 }
 
-ErrorOr<NonnullOwnPtr<MinCalculationNode>> MinCalculationNode::create(Vector<NonnullOwnPtr<Web::CSS::CalculationNode>> values)
+NonnullOwnPtr<MinCalculationNode> MinCalculationNode::create(Vector<NonnullOwnPtr<Web::CSS::CalculationNode>> values)
 {
-    return adopt_nonnull_own_or_enomem(new (nothrow) MinCalculationNode(move(values)));
+    return adopt_own(*new (nothrow) MinCalculationNode(move(values)));
 }
 
 MinCalculationNode::MinCalculationNode(Vector<NonnullOwnPtr<CalculationNode>> values)
@@ -644,14 +638,12 @@ CalculatedStyleValue::CalculationResult MinCalculationNode::resolve(Optional<Len
     return smallest_node;
 }
 
-ErrorOr<void> MinCalculationNode::for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const& callback)
+void MinCalculationNode::for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const& callback)
 {
     for (auto& value : m_values) {
-        TRY(value->for_each_child_node(callback));
-        TRY(callback(value));
+        value->for_each_child_node(callback);
+        callback(value);
     }
-
-    return {};
 }
 
 ErrorOr<void> MinCalculationNode::dump(StringBuilder& builder, int indent) const
@@ -662,9 +654,9 @@ ErrorOr<void> MinCalculationNode::dump(StringBuilder& builder, int indent) const
     return {};
 }
 
-ErrorOr<NonnullOwnPtr<MaxCalculationNode>> MaxCalculationNode::create(Vector<NonnullOwnPtr<Web::CSS::CalculationNode>> values)
+NonnullOwnPtr<MaxCalculationNode> MaxCalculationNode::create(Vector<NonnullOwnPtr<Web::CSS::CalculationNode>> values)
 {
-    return adopt_nonnull_own_or_enomem(new (nothrow) MaxCalculationNode(move(values)));
+    return adopt_own(*new (nothrow) MaxCalculationNode(move(values)));
 }
 
 MaxCalculationNode::MaxCalculationNode(Vector<NonnullOwnPtr<CalculationNode>> values)
@@ -729,14 +721,12 @@ CalculatedStyleValue::CalculationResult MaxCalculationNode::resolve(Optional<Len
     return largest_node;
 }
 
-ErrorOr<void> MaxCalculationNode::for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const& callback)
+void MaxCalculationNode::for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const& callback)
 {
     for (auto& value : m_values) {
-        TRY(value->for_each_child_node(callback));
-        TRY(callback(value));
+        value->for_each_child_node(callback);
+        callback(value);
     }
-
-    return {};
 }
 
 ErrorOr<void> MaxCalculationNode::dump(StringBuilder& builder, int indent) const
@@ -747,9 +737,9 @@ ErrorOr<void> MaxCalculationNode::dump(StringBuilder& builder, int indent) const
     return {};
 }
 
-ErrorOr<NonnullOwnPtr<ClampCalculationNode>> ClampCalculationNode::create(NonnullOwnPtr<CalculationNode> min, NonnullOwnPtr<CalculationNode> center, NonnullOwnPtr<CalculationNode> max)
+NonnullOwnPtr<ClampCalculationNode> ClampCalculationNode::create(NonnullOwnPtr<CalculationNode> min, NonnullOwnPtr<CalculationNode> center, NonnullOwnPtr<CalculationNode> max)
 {
-    return adopt_nonnull_own_or_enomem(new (nothrow) ClampCalculationNode(move(min), move(center), move(max)));
+    return adopt_own(*new (nothrow) ClampCalculationNode(move(min), move(center), move(max)));
 }
 
 ClampCalculationNode::ClampCalculationNode(NonnullOwnPtr<CalculationNode> min, NonnullOwnPtr<CalculationNode> center, NonnullOwnPtr<CalculationNode> max)
@@ -825,16 +815,14 @@ CalculatedStyleValue::CalculationResult ClampCalculationNode::resolve(Optional<L
     VERIFY_NOT_REACHED();
 }
 
-ErrorOr<void> ClampCalculationNode::for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const& callback)
+void ClampCalculationNode::for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const& callback)
 {
-    TRY(m_min_value->for_each_child_node(callback));
-    TRY(m_center_value->for_each_child_node(callback));
-    TRY(m_max_value->for_each_child_node(callback));
-    TRY(callback(m_min_value));
-    TRY(callback(m_center_value));
-    TRY(callback(m_max_value));
-
-    return {};
+    m_min_value->for_each_child_node(callback);
+    m_center_value->for_each_child_node(callback);
+    m_max_value->for_each_child_node(callback);
+    callback(m_min_value);
+    callback(m_center_value);
+    callback(m_max_value);
 }
 
 ErrorOr<void> ClampCalculationNode::dump(StringBuilder& builder, int indent) const
@@ -846,9 +834,9 @@ ErrorOr<void> ClampCalculationNode::dump(StringBuilder& builder, int indent) con
     return {};
 }
 
-ErrorOr<NonnullOwnPtr<AbsCalculationNode>> AbsCalculationNode::create(NonnullOwnPtr<CalculationNode> value)
+NonnullOwnPtr<AbsCalculationNode> AbsCalculationNode::create(NonnullOwnPtr<CalculationNode> value)
 {
-    return adopt_nonnull_own_or_enomem(new (nothrow) AbsCalculationNode(move(value)));
+    return adopt_own(*new (nothrow) AbsCalculationNode(move(value)));
 }
 
 AbsCalculationNode::AbsCalculationNode(NonnullOwnPtr<CalculationNode> value)
@@ -897,11 +885,10 @@ CalculatedStyleValue::CalculationResult AbsCalculationNode::resolve(Optional<Len
     return node_a;
 }
 
-ErrorOr<void> AbsCalculationNode::for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const& callback)
+void AbsCalculationNode::for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const& callback)
 {
-    TRY(m_value->for_each_child_node(callback));
-    TRY(callback(m_value));
-    return {};
+    m_value->for_each_child_node(callback);
+    callback(m_value);
 }
 
 ErrorOr<void> AbsCalculationNode::dump(StringBuilder& builder, int indent) const
@@ -910,9 +897,9 @@ ErrorOr<void> AbsCalculationNode::dump(StringBuilder& builder, int indent) const
     return {};
 }
 
-ErrorOr<NonnullOwnPtr<SignCalculationNode>> SignCalculationNode::create(NonnullOwnPtr<CalculationNode> value)
+NonnullOwnPtr<SignCalculationNode> SignCalculationNode::create(NonnullOwnPtr<CalculationNode> value)
 {
-    return adopt_nonnull_own_or_enomem(new (nothrow) SignCalculationNode(move(value)));
+    return adopt_own(*new (nothrow) SignCalculationNode(move(value)));
 }
 
 SignCalculationNode::SignCalculationNode(NonnullOwnPtr<CalculationNode> value)
@@ -963,11 +950,10 @@ CalculatedStyleValue::CalculationResult SignCalculationNode::resolve(Optional<Le
     return { Number(Number::Type::Integer, 0) };
 }
 
-ErrorOr<void> SignCalculationNode::for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const& callback)
+void SignCalculationNode::for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const& callback)
 {
-    TRY(m_value->for_each_child_node(callback));
-    TRY(callback(m_value));
-    return {};
+    m_value->for_each_child_node(callback);
+    callback(m_value);
 }
 
 ErrorOr<void> SignCalculationNode::dump(StringBuilder& builder, int indent) const
@@ -976,9 +962,9 @@ ErrorOr<void> SignCalculationNode::dump(StringBuilder& builder, int indent) cons
     return {};
 }
 
-ErrorOr<NonnullOwnPtr<ConstantCalculationNode>> ConstantCalculationNode::create(ConstantType constant)
+NonnullOwnPtr<ConstantCalculationNode> ConstantCalculationNode::create(ConstantType constant)
 {
-    return adopt_nonnull_own_or_enomem(new (nothrow) ConstantCalculationNode(constant));
+    return adopt_own(*new (nothrow) ConstantCalculationNode(constant));
 }
 
 ConstantCalculationNode::ConstantCalculationNode(ConstantType constant)
@@ -1039,20 +1025,15 @@ CalculatedStyleValue::CalculationResult ConstantCalculationNode::resolve([[maybe
     VERIFY_NOT_REACHED();
 }
 
-ErrorOr<void> ConstantCalculationNode::for_each_child_node([[maybe_unused]] Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const& callback)
-{
-    return {};
-}
-
 ErrorOr<void> ConstantCalculationNode::dump(StringBuilder& builder, int indent) const
 {
     TRY(builder.try_appendff("{: >{}}CONSTANT: {}\n", "", indent, TRY(to_string())));
     return {};
 }
 
-ErrorOr<NonnullOwnPtr<SinCalculationNode>> SinCalculationNode::create(NonnullOwnPtr<CalculationNode> value)
+NonnullOwnPtr<SinCalculationNode> SinCalculationNode::create(NonnullOwnPtr<CalculationNode> value)
 {
-    return adopt_nonnull_own_or_enomem(new (nothrow) SinCalculationNode(move(value)));
+    return adopt_own(*new (nothrow) SinCalculationNode(move(value)));
 }
 
 SinCalculationNode::SinCalculationNode(NonnullOwnPtr<CalculationNode> value)
@@ -1098,11 +1079,10 @@ CalculatedStyleValue::CalculationResult SinCalculationNode::resolve(Optional<Len
     return { Number(Number::Type::Number, result) };
 }
 
-ErrorOr<void> SinCalculationNode::for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const& callback)
+void SinCalculationNode::for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const& callback)
 {
-    TRY(m_value->for_each_child_node(callback));
-    TRY(callback(m_value));
-    return {};
+    m_value->for_each_child_node(callback);
+    callback(m_value);
 }
 
 ErrorOr<void> SinCalculationNode::dump(StringBuilder& builder, int indent) const
@@ -1111,9 +1091,9 @@ ErrorOr<void> SinCalculationNode::dump(StringBuilder& builder, int indent) const
     return {};
 }
 
-ErrorOr<NonnullOwnPtr<CosCalculationNode>> CosCalculationNode::create(NonnullOwnPtr<CalculationNode> value)
+NonnullOwnPtr<CosCalculationNode> CosCalculationNode::create(NonnullOwnPtr<CalculationNode> value)
 {
-    return adopt_nonnull_own_or_enomem(new (nothrow) CosCalculationNode(move(value)));
+    return adopt_own(*new (nothrow) CosCalculationNode(move(value)));
 }
 
 CosCalculationNode::CosCalculationNode(NonnullOwnPtr<CalculationNode> value)
@@ -1159,11 +1139,10 @@ CalculatedStyleValue::CalculationResult CosCalculationNode::resolve(Optional<Len
     return { Number(Number::Type::Number, result) };
 }
 
-ErrorOr<void> CosCalculationNode::for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const& callback)
+void CosCalculationNode::for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const& callback)
 {
-    TRY(m_value->for_each_child_node(callback));
-    TRY(callback(m_value));
-    return {};
+    m_value->for_each_child_node(callback);
+    callback(m_value);
 }
 
 ErrorOr<void> CosCalculationNode::dump(StringBuilder& builder, int indent) const
@@ -1172,9 +1151,9 @@ ErrorOr<void> CosCalculationNode::dump(StringBuilder& builder, int indent) const
     return {};
 }
 
-ErrorOr<NonnullOwnPtr<TanCalculationNode>> TanCalculationNode::create(NonnullOwnPtr<CalculationNode> value)
+NonnullOwnPtr<TanCalculationNode> TanCalculationNode::create(NonnullOwnPtr<CalculationNode> value)
 {
-    return adopt_nonnull_own_or_enomem(new (nothrow) TanCalculationNode(move(value)));
+    return adopt_own(*new (nothrow) TanCalculationNode(move(value)));
 }
 
 TanCalculationNode::TanCalculationNode(NonnullOwnPtr<CalculationNode> value)
@@ -1220,11 +1199,10 @@ CalculatedStyleValue::CalculationResult TanCalculationNode::resolve(Optional<Len
     return { Number(Number::Type::Number, result) };
 }
 
-ErrorOr<void> TanCalculationNode::for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const& callback)
+void TanCalculationNode::for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const& callback)
 {
-    TRY(m_value->for_each_child_node(callback));
-    TRY(callback(m_value));
-    return {};
+    m_value->for_each_child_node(callback);
+    callback(m_value);
 }
 
 ErrorOr<void> TanCalculationNode::dump(StringBuilder& builder, int indent) const
@@ -1233,9 +1211,9 @@ ErrorOr<void> TanCalculationNode::dump(StringBuilder& builder, int indent) const
     return {};
 }
 
-ErrorOr<NonnullOwnPtr<AsinCalculationNode>> AsinCalculationNode::create(NonnullOwnPtr<CalculationNode> value)
+NonnullOwnPtr<AsinCalculationNode> AsinCalculationNode::create(NonnullOwnPtr<CalculationNode> value)
 {
-    return adopt_nonnull_own_or_enomem(new (nothrow) AsinCalculationNode(move(value)));
+    return adopt_own(*new (nothrow) AsinCalculationNode(move(value)));
 }
 
 AsinCalculationNode::AsinCalculationNode(NonnullOwnPtr<CalculationNode> value)
@@ -1281,11 +1259,10 @@ CalculatedStyleValue::CalculationResult AsinCalculationNode::resolve(Optional<Le
     return { Angle(result, Angle::Type::Rad) };
 }
 
-ErrorOr<void> AsinCalculationNode::for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const& callback)
+void AsinCalculationNode::for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const& callback)
 {
-    TRY(m_value->for_each_child_node(callback));
-    TRY(callback(m_value));
-    return {};
+    m_value->for_each_child_node(callback);
+    callback(m_value);
 }
 
 ErrorOr<void> AsinCalculationNode::dump(StringBuilder& builder, int indent) const
@@ -1294,9 +1271,9 @@ ErrorOr<void> AsinCalculationNode::dump(StringBuilder& builder, int indent) cons
     return {};
 }
 
-ErrorOr<NonnullOwnPtr<AcosCalculationNode>> AcosCalculationNode::create(NonnullOwnPtr<CalculationNode> value)
+NonnullOwnPtr<AcosCalculationNode> AcosCalculationNode::create(NonnullOwnPtr<CalculationNode> value)
 {
-    return adopt_nonnull_own_or_enomem(new (nothrow) AcosCalculationNode(move(value)));
+    return adopt_own(*new (nothrow) AcosCalculationNode(move(value)));
 }
 
 AcosCalculationNode::AcosCalculationNode(NonnullOwnPtr<CalculationNode> value)
@@ -1342,11 +1319,10 @@ CalculatedStyleValue::CalculationResult AcosCalculationNode::resolve(Optional<Le
     return { Angle(result, Angle::Type::Rad) };
 }
 
-ErrorOr<void> AcosCalculationNode::for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const& callback)
+void AcosCalculationNode::for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const& callback)
 {
-    TRY(m_value->for_each_child_node(callback));
-    TRY(callback(m_value));
-    return {};
+    m_value->for_each_child_node(callback);
+    callback(m_value);
 }
 
 ErrorOr<void> AcosCalculationNode::dump(StringBuilder& builder, int indent) const
@@ -1355,9 +1331,9 @@ ErrorOr<void> AcosCalculationNode::dump(StringBuilder& builder, int indent) cons
     return {};
 }
 
-ErrorOr<NonnullOwnPtr<AtanCalculationNode>> AtanCalculationNode::create(NonnullOwnPtr<CalculationNode> value)
+NonnullOwnPtr<AtanCalculationNode> AtanCalculationNode::create(NonnullOwnPtr<CalculationNode> value)
 {
-    return adopt_nonnull_own_or_enomem(new (nothrow) AtanCalculationNode(move(value)));
+    return adopt_own(*new (nothrow) AtanCalculationNode(move(value)));
 }
 
 AtanCalculationNode::AtanCalculationNode(NonnullOwnPtr<CalculationNode> value)
@@ -1403,11 +1379,10 @@ CalculatedStyleValue::CalculationResult AtanCalculationNode::resolve(Optional<Le
     return { Angle(result, Angle::Type::Rad) };
 }
 
-ErrorOr<void> AtanCalculationNode::for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const& callback)
+void AtanCalculationNode::for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const& callback)
 {
-    TRY(m_value->for_each_child_node(callback));
-    TRY(callback(m_value));
-    return {};
+    m_value->for_each_child_node(callback);
+    callback(m_value);
 }
 
 ErrorOr<void> AtanCalculationNode::dump(StringBuilder& builder, int indent) const
@@ -1416,9 +1391,9 @@ ErrorOr<void> AtanCalculationNode::dump(StringBuilder& builder, int indent) cons
     return {};
 }
 
-ErrorOr<NonnullOwnPtr<Atan2CalculationNode>> Atan2CalculationNode::create(NonnullOwnPtr<CalculationNode> y, NonnullOwnPtr<CalculationNode> x)
+NonnullOwnPtr<Atan2CalculationNode> Atan2CalculationNode::create(NonnullOwnPtr<CalculationNode> y, NonnullOwnPtr<CalculationNode> x)
 {
-    return adopt_nonnull_own_or_enomem(new (nothrow) Atan2CalculationNode(move(y), move(x)));
+    return adopt_own(*new (nothrow) Atan2CalculationNode(move(y), move(x)));
 }
 
 Atan2CalculationNode::Atan2CalculationNode(NonnullOwnPtr<CalculationNode> y, NonnullOwnPtr<CalculationNode> x)
@@ -1471,13 +1446,12 @@ CalculatedStyleValue::CalculationResult Atan2CalculationNode::resolve(Optional<L
     return { Angle(result, Angle::Type::Rad) };
 }
 
-ErrorOr<void> Atan2CalculationNode::for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const& callback)
+void Atan2CalculationNode::for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const& callback)
 {
-    TRY(m_y->for_each_child_node(callback));
-    TRY(m_x->for_each_child_node(callback));
-    TRY(callback(m_y));
-    TRY(callback(m_x));
-    return {};
+    m_y->for_each_child_node(callback);
+    m_x->for_each_child_node(callback);
+    callback(m_y);
+    callback(m_x);
 }
 
 ErrorOr<void> Atan2CalculationNode::dump(StringBuilder& builder, int indent) const
@@ -1486,9 +1460,9 @@ ErrorOr<void> Atan2CalculationNode::dump(StringBuilder& builder, int indent) con
     return {};
 }
 
-ErrorOr<NonnullOwnPtr<PowCalculationNode>> PowCalculationNode::create(NonnullOwnPtr<CalculationNode> x, NonnullOwnPtr<CalculationNode> y)
+NonnullOwnPtr<PowCalculationNode> PowCalculationNode::create(NonnullOwnPtr<CalculationNode> x, NonnullOwnPtr<CalculationNode> y)
 {
-    return adopt_nonnull_own_or_enomem(new (nothrow) PowCalculationNode(move(x), move(y)));
+    return adopt_own(*new (nothrow) PowCalculationNode(move(x), move(y)));
 }
 
 PowCalculationNode::PowCalculationNode(NonnullOwnPtr<CalculationNode> x, NonnullOwnPtr<CalculationNode> y)
@@ -1536,13 +1510,12 @@ CalculatedStyleValue::CalculationResult PowCalculationNode::resolve(Optional<Len
     return { Number(Number::Type::Number, result) };
 }
 
-ErrorOr<void> PowCalculationNode::for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const& callback)
+void PowCalculationNode::for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const& callback)
 {
-    TRY(m_x->for_each_child_node(callback));
-    TRY(m_y->for_each_child_node(callback));
-    TRY(callback(m_x));
-    TRY(callback(m_y));
-    return {};
+    m_x->for_each_child_node(callback);
+    m_y->for_each_child_node(callback);
+    callback(m_x);
+    callback(m_y);
 }
 
 ErrorOr<void> PowCalculationNode::dump(StringBuilder& builder, int indent) const
@@ -1551,9 +1524,9 @@ ErrorOr<void> PowCalculationNode::dump(StringBuilder& builder, int indent) const
     return {};
 }
 
-ErrorOr<NonnullOwnPtr<SqrtCalculationNode>> SqrtCalculationNode::create(NonnullOwnPtr<CalculationNode> value)
+NonnullOwnPtr<SqrtCalculationNode> SqrtCalculationNode::create(NonnullOwnPtr<CalculationNode> value)
 {
-    return adopt_nonnull_own_or_enomem(new (nothrow) SqrtCalculationNode(move(value)));
+    return adopt_own(*new (nothrow) SqrtCalculationNode(move(value)));
 }
 
 SqrtCalculationNode::SqrtCalculationNode(NonnullOwnPtr<CalculationNode> value)
@@ -1594,11 +1567,10 @@ CalculatedStyleValue::CalculationResult SqrtCalculationNode::resolve(Optional<Le
     return { Number(Number::Type::Number, result) };
 }
 
-ErrorOr<void> SqrtCalculationNode::for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const& callback)
+void SqrtCalculationNode::for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const& callback)
 {
-    TRY(m_value->for_each_child_node(callback));
-    TRY(callback(m_value));
-    return {};
+    m_value->for_each_child_node(callback);
+    callback(m_value);
 }
 
 ErrorOr<void> SqrtCalculationNode::dump(StringBuilder& builder, int indent) const
@@ -1607,9 +1579,9 @@ ErrorOr<void> SqrtCalculationNode::dump(StringBuilder& builder, int indent) cons
     return {};
 }
 
-ErrorOr<NonnullOwnPtr<HypotCalculationNode>> HypotCalculationNode::create(Vector<NonnullOwnPtr<Web::CSS::CalculationNode>> values)
+NonnullOwnPtr<HypotCalculationNode> HypotCalculationNode::create(Vector<NonnullOwnPtr<Web::CSS::CalculationNode>> values)
 {
-    return adopt_nonnull_own_or_enomem(new (nothrow) HypotCalculationNode(move(values)));
+    return adopt_own(*new (nothrow) HypotCalculationNode(move(values)));
 }
 
 HypotCalculationNode::HypotCalculationNode(Vector<NonnullOwnPtr<CalculationNode>> values)
@@ -1672,14 +1644,12 @@ CalculatedStyleValue::CalculationResult HypotCalculationNode::resolve(Optional<L
     return to_resolved_type(resolved_type().value(), result);
 }
 
-ErrorOr<void> HypotCalculationNode::for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const& callback)
+void HypotCalculationNode::for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const& callback)
 {
     for (auto& value : m_values) {
-        TRY(value->for_each_child_node(callback));
-        TRY(callback(value));
+        value->for_each_child_node(callback);
+        callback(value);
     }
-
-    return {};
 }
 
 ErrorOr<void> HypotCalculationNode::dump(StringBuilder& builder, int indent) const
@@ -1690,9 +1660,9 @@ ErrorOr<void> HypotCalculationNode::dump(StringBuilder& builder, int indent) con
     return {};
 }
 
-ErrorOr<NonnullOwnPtr<LogCalculationNode>> LogCalculationNode::create(NonnullOwnPtr<CalculationNode> x, NonnullOwnPtr<CalculationNode> y)
+NonnullOwnPtr<LogCalculationNode> LogCalculationNode::create(NonnullOwnPtr<CalculationNode> x, NonnullOwnPtr<CalculationNode> y)
 {
-    return adopt_nonnull_own_or_enomem(new (nothrow) LogCalculationNode(move(x), move(y)));
+    return adopt_own(*new (nothrow) LogCalculationNode(move(x), move(y)));
 }
 
 LogCalculationNode::LogCalculationNode(NonnullOwnPtr<CalculationNode> x, NonnullOwnPtr<CalculationNode> y)
@@ -1740,13 +1710,12 @@ CalculatedStyleValue::CalculationResult LogCalculationNode::resolve(Optional<Len
     return { Number(Number::Type::Number, result) };
 }
 
-ErrorOr<void> LogCalculationNode::for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const& callback)
+void LogCalculationNode::for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const& callback)
 {
-    TRY(m_x->for_each_child_node(callback));
-    TRY(m_y->for_each_child_node(callback));
-    TRY(callback(m_x));
-    TRY(callback(m_y));
-    return {};
+    m_x->for_each_child_node(callback);
+    m_y->for_each_child_node(callback);
+    callback(m_x);
+    callback(m_y);
 }
 
 ErrorOr<void> LogCalculationNode::dump(StringBuilder& builder, int indent) const
@@ -1755,9 +1724,9 @@ ErrorOr<void> LogCalculationNode::dump(StringBuilder& builder, int indent) const
     return {};
 }
 
-ErrorOr<NonnullOwnPtr<ExpCalculationNode>> ExpCalculationNode::create(NonnullOwnPtr<CalculationNode> value)
+NonnullOwnPtr<ExpCalculationNode> ExpCalculationNode::create(NonnullOwnPtr<CalculationNode> value)
 {
-    return adopt_nonnull_own_or_enomem(new (nothrow) ExpCalculationNode(move(value)));
+    return adopt_own(*new (nothrow) ExpCalculationNode(move(value)));
 }
 
 ExpCalculationNode::ExpCalculationNode(NonnullOwnPtr<CalculationNode> value)
@@ -1798,11 +1767,10 @@ CalculatedStyleValue::CalculationResult ExpCalculationNode::resolve(Optional<Len
     return { Number(Number::Type::Number, result) };
 }
 
-ErrorOr<void> ExpCalculationNode::for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const& callback)
+void ExpCalculationNode::for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const& callback)
 {
-    TRY(m_value->for_each_child_node(callback));
-    TRY(callback(m_value));
-    return {};
+    m_value->for_each_child_node(callback);
+    callback(m_value);
 }
 
 ErrorOr<void> ExpCalculationNode::dump(StringBuilder& builder, int indent) const
@@ -1811,9 +1779,9 @@ ErrorOr<void> ExpCalculationNode::dump(StringBuilder& builder, int indent) const
     return {};
 }
 
-ErrorOr<NonnullOwnPtr<RoundCalculationNode>> RoundCalculationNode::create(RoundingStrategy strategy, NonnullOwnPtr<CalculationNode> x, NonnullOwnPtr<CalculationNode> y)
+NonnullOwnPtr<RoundCalculationNode> RoundCalculationNode::create(RoundingStrategy strategy, NonnullOwnPtr<CalculationNode> x, NonnullOwnPtr<CalculationNode> y)
 {
-    return adopt_nonnull_own_or_enomem(new (nothrow) RoundCalculationNode(strategy, move(x), move(y)));
+    return adopt_own(*new (nothrow) RoundCalculationNode(strategy, move(x), move(y)));
 }
 
 RoundCalculationNode::RoundCalculationNode(RoundingStrategy mode, NonnullOwnPtr<CalculationNode> x, NonnullOwnPtr<CalculationNode> y)
@@ -1900,13 +1868,12 @@ CalculatedStyleValue::CalculationResult RoundCalculationNode::resolve(Optional<L
     VERIFY_NOT_REACHED();
 }
 
-ErrorOr<void> RoundCalculationNode::for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const& callback)
+void RoundCalculationNode::for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const& callback)
 {
-    TRY(m_x->for_each_child_node(callback));
-    TRY(m_y->for_each_child_node(callback));
-    TRY(callback(m_x));
-    TRY(callback(m_y));
-    return {};
+    m_x->for_each_child_node(callback);
+    m_y->for_each_child_node(callback);
+    callback(m_x);
+    callback(m_y);
 }
 
 ErrorOr<void> RoundCalculationNode::dump(StringBuilder& builder, int indent) const
@@ -1915,9 +1882,9 @@ ErrorOr<void> RoundCalculationNode::dump(StringBuilder& builder, int indent) con
     return {};
 }
 
-ErrorOr<NonnullOwnPtr<ModCalculationNode>> ModCalculationNode::create(NonnullOwnPtr<CalculationNode> x, NonnullOwnPtr<CalculationNode> y)
+NonnullOwnPtr<ModCalculationNode> ModCalculationNode::create(NonnullOwnPtr<CalculationNode> x, NonnullOwnPtr<CalculationNode> y)
 {
-    return adopt_nonnull_own_or_enomem(new (nothrow) ModCalculationNode(move(x), move(y)));
+    return adopt_own(*new (nothrow) ModCalculationNode(move(x), move(y)));
 }
 
 ModCalculationNode::ModCalculationNode(NonnullOwnPtr<CalculationNode> x, NonnullOwnPtr<CalculationNode> y)
@@ -1978,13 +1945,12 @@ CalculatedStyleValue::CalculationResult ModCalculationNode::resolve(Optional<Len
     return to_resolved_type(resolved_type, value);
 }
 
-ErrorOr<void> ModCalculationNode::for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const& callback)
+void ModCalculationNode::for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const& callback)
 {
-    TRY(m_x->for_each_child_node(callback));
-    TRY(m_y->for_each_child_node(callback));
-    TRY(callback(m_x));
-    TRY(callback(m_y));
-    return {};
+    m_x->for_each_child_node(callback);
+    m_y->for_each_child_node(callback);
+    callback(m_x);
+    callback(m_y);
 }
 
 ErrorOr<void> ModCalculationNode::dump(StringBuilder& builder, int indent) const
@@ -1993,9 +1959,9 @@ ErrorOr<void> ModCalculationNode::dump(StringBuilder& builder, int indent) const
     return {};
 }
 
-ErrorOr<NonnullOwnPtr<RemCalculationNode>> RemCalculationNode::create(NonnullOwnPtr<CalculationNode> x, NonnullOwnPtr<CalculationNode> y)
+NonnullOwnPtr<RemCalculationNode> RemCalculationNode::create(NonnullOwnPtr<CalculationNode> x, NonnullOwnPtr<CalculationNode> y)
 {
-    return adopt_nonnull_own_or_enomem(new (nothrow) RemCalculationNode(move(x), move(y)));
+    return adopt_own(*new (nothrow) RemCalculationNode(move(x), move(y)));
 }
 
 RemCalculationNode::RemCalculationNode(NonnullOwnPtr<CalculationNode> x, NonnullOwnPtr<CalculationNode> y)
@@ -2055,13 +2021,12 @@ CalculatedStyleValue::CalculationResult RemCalculationNode::resolve(Optional<Len
     return to_resolved_type(resolved_type, value);
 }
 
-ErrorOr<void> RemCalculationNode::for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const& callback)
+void RemCalculationNode::for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const& callback)
 {
-    TRY(m_x->for_each_child_node(callback));
-    TRY(m_y->for_each_child_node(callback));
-    TRY(callback(m_x));
-    TRY(callback(m_y));
-    return {};
+    m_x->for_each_child_node(callback);
+    m_y->for_each_child_node(callback);
+    callback(m_x);
+    callback(m_y);
 }
 
 ErrorOr<void> RemCalculationNode::dump(StringBuilder& builder, int indent) const

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
@@ -66,9 +66,9 @@ public:
         Value m_value;
     };
 
-    static ErrorOr<ValueComparingNonnullRefPtr<CalculatedStyleValue>> create(NonnullOwnPtr<CalculationNode> calculation, CSSNumericType resolved_type)
+    static ValueComparingNonnullRefPtr<CalculatedStyleValue> create(NonnullOwnPtr<CalculationNode> calculation, CSSNumericType resolved_type)
     {
-        return adopt_nonnull_ref_or_enomem(new (nothrow) CalculatedStyleValue(move(calculation), resolved_type));
+        return adopt_ref(*new (nothrow) CalculatedStyleValue(move(calculation), resolved_type));
     }
 
     ErrorOr<String> to_string() const override;

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
@@ -238,7 +238,7 @@ public:
     virtual Optional<CSSNumericType> determine_type(PropertyID) const = 0;
     virtual bool contains_percentage() const = 0;
     virtual CalculatedStyleValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CalculatedStyleValue::PercentageBasis const&) const = 0;
-    virtual ErrorOr<void> for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const&) { return {}; }
+    virtual void for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const&) = 0;
 
     virtual ErrorOr<void> dump(StringBuilder&, int indent) const = 0;
 
@@ -251,7 +251,7 @@ private:
 
 class NumericCalculationNode final : public CalculationNode {
 public:
-    static ErrorOr<NonnullOwnPtr<NumericCalculationNode>> create(NumericValue);
+    static NonnullOwnPtr<NumericCalculationNode> create(NumericValue);
     ~NumericCalculationNode();
 
     virtual ErrorOr<String> to_string() const override;
@@ -259,6 +259,7 @@ public:
     virtual Optional<CSSNumericType> determine_type(PropertyID) const override;
     virtual bool contains_percentage() const override;
     virtual CalculatedStyleValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CalculatedStyleValue::PercentageBasis const&) const override;
+    virtual void for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const&) override { }
 
     virtual ErrorOr<void> dump(StringBuilder&, int indent) const override;
 
@@ -269,7 +270,7 @@ private:
 
 class SumCalculationNode final : public CalculationNode {
 public:
-    static ErrorOr<NonnullOwnPtr<SumCalculationNode>> create(Vector<NonnullOwnPtr<CalculationNode>>);
+    static NonnullOwnPtr<SumCalculationNode> create(Vector<NonnullOwnPtr<CalculationNode>>);
     ~SumCalculationNode();
 
     virtual ErrorOr<String> to_string() const override;
@@ -277,7 +278,7 @@ public:
     virtual Optional<CSSNumericType> determine_type(PropertyID) const override;
     virtual bool contains_percentage() const override;
     virtual CalculatedStyleValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CalculatedStyleValue::PercentageBasis const&) const override;
-    virtual ErrorOr<void> for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const&) override;
+    virtual void for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const&) override;
 
     virtual ErrorOr<void> dump(StringBuilder&, int indent) const override;
 
@@ -288,7 +289,7 @@ private:
 
 class ProductCalculationNode final : public CalculationNode {
 public:
-    static ErrorOr<NonnullOwnPtr<ProductCalculationNode>> create(Vector<NonnullOwnPtr<CalculationNode>>);
+    static NonnullOwnPtr<ProductCalculationNode> create(Vector<NonnullOwnPtr<CalculationNode>>);
     ~ProductCalculationNode();
 
     virtual ErrorOr<String> to_string() const override;
@@ -296,7 +297,7 @@ public:
     virtual Optional<CSSNumericType> determine_type(PropertyID) const override;
     virtual bool contains_percentage() const override;
     virtual CalculatedStyleValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CalculatedStyleValue::PercentageBasis const&) const override;
-    virtual ErrorOr<void> for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const&) override;
+    virtual void for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const&) override;
 
     virtual ErrorOr<void> dump(StringBuilder&, int indent) const override;
 
@@ -307,7 +308,7 @@ private:
 
 class NegateCalculationNode final : public CalculationNode {
 public:
-    static ErrorOr<NonnullOwnPtr<NegateCalculationNode>> create(NonnullOwnPtr<CalculationNode>);
+    static NonnullOwnPtr<NegateCalculationNode> create(NonnullOwnPtr<CalculationNode>);
     ~NegateCalculationNode();
 
     virtual ErrorOr<String> to_string() const override;
@@ -315,7 +316,7 @@ public:
     virtual Optional<CSSNumericType> determine_type(PropertyID) const override;
     virtual bool contains_percentage() const override;
     virtual CalculatedStyleValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CalculatedStyleValue::PercentageBasis const&) const override;
-    virtual ErrorOr<void> for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const&) override;
+    virtual void for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const&) override;
 
     virtual ErrorOr<void> dump(StringBuilder&, int indent) const override;
 
@@ -326,7 +327,7 @@ private:
 
 class InvertCalculationNode final : public CalculationNode {
 public:
-    static ErrorOr<NonnullOwnPtr<InvertCalculationNode>> create(NonnullOwnPtr<CalculationNode>);
+    static NonnullOwnPtr<InvertCalculationNode> create(NonnullOwnPtr<CalculationNode>);
     ~InvertCalculationNode();
 
     virtual ErrorOr<String> to_string() const override;
@@ -334,7 +335,7 @@ public:
     virtual Optional<CSSNumericType> determine_type(PropertyID) const override;
     virtual bool contains_percentage() const override;
     virtual CalculatedStyleValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CalculatedStyleValue::PercentageBasis const&) const override;
-    virtual ErrorOr<void> for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const&) override;
+    virtual void for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const&) override;
 
     virtual ErrorOr<void> dump(StringBuilder&, int indent) const override;
 
@@ -345,7 +346,7 @@ private:
 
 class MinCalculationNode final : public CalculationNode {
 public:
-    static ErrorOr<NonnullOwnPtr<MinCalculationNode>> create(Vector<NonnullOwnPtr<CalculationNode>>);
+    static NonnullOwnPtr<MinCalculationNode> create(Vector<NonnullOwnPtr<CalculationNode>>);
     ~MinCalculationNode();
 
     virtual ErrorOr<String> to_string() const override;
@@ -353,7 +354,7 @@ public:
     virtual Optional<CSSNumericType> determine_type(PropertyID) const override;
     virtual bool contains_percentage() const override;
     virtual CalculatedStyleValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CalculatedStyleValue::PercentageBasis const&) const override;
-    virtual ErrorOr<void> for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const&) override;
+    virtual void for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const&) override;
 
     virtual ErrorOr<void> dump(StringBuilder&, int indent) const override;
 
@@ -364,7 +365,7 @@ private:
 
 class MaxCalculationNode final : public CalculationNode {
 public:
-    static ErrorOr<NonnullOwnPtr<MaxCalculationNode>> create(Vector<NonnullOwnPtr<CalculationNode>>);
+    static NonnullOwnPtr<MaxCalculationNode> create(Vector<NonnullOwnPtr<CalculationNode>>);
     ~MaxCalculationNode();
 
     virtual ErrorOr<String> to_string() const override;
@@ -372,7 +373,7 @@ public:
     virtual Optional<CSSNumericType> determine_type(PropertyID) const override;
     virtual bool contains_percentage() const override;
     virtual CalculatedStyleValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CalculatedStyleValue::PercentageBasis const&) const override;
-    virtual ErrorOr<void> for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const&) override;
+    virtual void for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const&) override;
 
     virtual ErrorOr<void> dump(StringBuilder&, int indent) const override;
 
@@ -383,7 +384,7 @@ private:
 
 class ClampCalculationNode final : public CalculationNode {
 public:
-    static ErrorOr<NonnullOwnPtr<ClampCalculationNode>> create(NonnullOwnPtr<CalculationNode>, NonnullOwnPtr<CalculationNode>, NonnullOwnPtr<CalculationNode>);
+    static NonnullOwnPtr<ClampCalculationNode> create(NonnullOwnPtr<CalculationNode>, NonnullOwnPtr<CalculationNode>, NonnullOwnPtr<CalculationNode>);
     ~ClampCalculationNode();
 
     virtual ErrorOr<String> to_string() const override;
@@ -391,7 +392,7 @@ public:
     virtual Optional<CSSNumericType> determine_type(PropertyID) const override;
     virtual bool contains_percentage() const override;
     virtual CalculatedStyleValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CalculatedStyleValue::PercentageBasis const&) const override;
-    virtual ErrorOr<void> for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const&) override;
+    virtual void for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const&) override;
 
     virtual ErrorOr<void> dump(StringBuilder&, int indent) const override;
 
@@ -404,7 +405,7 @@ private:
 
 class AbsCalculationNode final : public CalculationNode {
 public:
-    static ErrorOr<NonnullOwnPtr<AbsCalculationNode>> create(NonnullOwnPtr<CalculationNode>);
+    static NonnullOwnPtr<AbsCalculationNode> create(NonnullOwnPtr<CalculationNode>);
     ~AbsCalculationNode();
 
     virtual ErrorOr<String> to_string() const override;
@@ -412,7 +413,7 @@ public:
     virtual Optional<CSSNumericType> determine_type(PropertyID) const override;
     virtual bool contains_percentage() const override;
     virtual CalculatedStyleValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CalculatedStyleValue::PercentageBasis const&) const override;
-    virtual ErrorOr<void> for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const&) override;
+    virtual void for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const&) override;
 
     virtual ErrorOr<void> dump(StringBuilder&, int indent) const override;
 
@@ -423,7 +424,7 @@ private:
 
 class SignCalculationNode final : public CalculationNode {
 public:
-    static ErrorOr<NonnullOwnPtr<SignCalculationNode>> create(NonnullOwnPtr<CalculationNode>);
+    static NonnullOwnPtr<SignCalculationNode> create(NonnullOwnPtr<CalculationNode>);
     ~SignCalculationNode();
 
     virtual ErrorOr<String> to_string() const override;
@@ -431,7 +432,7 @@ public:
     virtual Optional<CSSNumericType> determine_type(PropertyID) const override;
     virtual bool contains_percentage() const override;
     virtual CalculatedStyleValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CalculatedStyleValue::PercentageBasis const&) const override;
-    virtual ErrorOr<void> for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const&) override;
+    virtual void for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const&) override;
 
     virtual ErrorOr<void> dump(StringBuilder&, int indent) const override;
 
@@ -442,7 +443,7 @@ private:
 
 class ConstantCalculationNode final : public CalculationNode {
 public:
-    static ErrorOr<NonnullOwnPtr<ConstantCalculationNode>> create(CalculationNode::ConstantType);
+    static NonnullOwnPtr<ConstantCalculationNode> create(CalculationNode::ConstantType);
     ~ConstantCalculationNode();
 
     virtual ErrorOr<String> to_string() const override;
@@ -450,7 +451,7 @@ public:
     virtual Optional<CSSNumericType> determine_type(PropertyID) const override;
     virtual bool contains_percentage() const override { return false; }
     virtual CalculatedStyleValue::CalculationResult resolve(Optional<Length::ResolutionContext const&> context, CalculatedStyleValue::PercentageBasis const&) const override;
-    virtual ErrorOr<void> for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const&) override;
+    virtual void for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const&) override { }
 
     virtual ErrorOr<void> dump(StringBuilder&, int indent) const override;
 
@@ -461,7 +462,7 @@ private:
 
 class SinCalculationNode final : public CalculationNode {
 public:
-    static ErrorOr<NonnullOwnPtr<SinCalculationNode>> create(NonnullOwnPtr<CalculationNode>);
+    static NonnullOwnPtr<SinCalculationNode> create(NonnullOwnPtr<CalculationNode>);
     ~SinCalculationNode();
 
     virtual ErrorOr<String> to_string() const override;
@@ -469,7 +470,7 @@ public:
     virtual Optional<CSSNumericType> determine_type(PropertyID) const override;
     virtual bool contains_percentage() const override;
     virtual CalculatedStyleValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CalculatedStyleValue::PercentageBasis const&) const override;
-    virtual ErrorOr<void> for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const&) override;
+    virtual void for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const&) override;
 
     virtual ErrorOr<void> dump(StringBuilder&, int indent) const override;
 
@@ -480,7 +481,7 @@ private:
 
 class CosCalculationNode final : public CalculationNode {
 public:
-    static ErrorOr<NonnullOwnPtr<CosCalculationNode>> create(NonnullOwnPtr<CalculationNode>);
+    static NonnullOwnPtr<CosCalculationNode> create(NonnullOwnPtr<CalculationNode>);
     ~CosCalculationNode();
 
     virtual ErrorOr<String> to_string() const override;
@@ -488,7 +489,7 @@ public:
     virtual Optional<CSSNumericType> determine_type(PropertyID) const override;
     virtual bool contains_percentage() const override;
     virtual CalculatedStyleValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CalculatedStyleValue::PercentageBasis const&) const override;
-    virtual ErrorOr<void> for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const&) override;
+    virtual void for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const&) override;
 
     virtual ErrorOr<void> dump(StringBuilder&, int indent) const override;
 
@@ -499,7 +500,7 @@ private:
 
 class TanCalculationNode final : public CalculationNode {
 public:
-    static ErrorOr<NonnullOwnPtr<TanCalculationNode>> create(NonnullOwnPtr<CalculationNode>);
+    static NonnullOwnPtr<TanCalculationNode> create(NonnullOwnPtr<CalculationNode>);
     ~TanCalculationNode();
 
     virtual ErrorOr<String> to_string() const override;
@@ -507,7 +508,7 @@ public:
     virtual Optional<CSSNumericType> determine_type(PropertyID) const override;
     virtual bool contains_percentage() const override;
     virtual CalculatedStyleValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CalculatedStyleValue::PercentageBasis const&) const override;
-    virtual ErrorOr<void> for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const&) override;
+    virtual void for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const&) override;
 
     virtual ErrorOr<void> dump(StringBuilder&, int indent) const override;
 
@@ -518,7 +519,7 @@ private:
 
 class AsinCalculationNode final : public CalculationNode {
 public:
-    static ErrorOr<NonnullOwnPtr<AsinCalculationNode>> create(NonnullOwnPtr<CalculationNode>);
+    static NonnullOwnPtr<AsinCalculationNode> create(NonnullOwnPtr<CalculationNode>);
     ~AsinCalculationNode();
 
     virtual ErrorOr<String> to_string() const override;
@@ -526,7 +527,7 @@ public:
     virtual Optional<CSSNumericType> determine_type(PropertyID) const override;
     virtual bool contains_percentage() const override;
     virtual CalculatedStyleValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CalculatedStyleValue::PercentageBasis const&) const override;
-    virtual ErrorOr<void> for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const&) override;
+    virtual void for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const&) override;
 
     virtual ErrorOr<void> dump(StringBuilder&, int indent) const override;
 
@@ -537,7 +538,7 @@ private:
 
 class AcosCalculationNode final : public CalculationNode {
 public:
-    static ErrorOr<NonnullOwnPtr<AcosCalculationNode>> create(NonnullOwnPtr<CalculationNode>);
+    static NonnullOwnPtr<AcosCalculationNode> create(NonnullOwnPtr<CalculationNode>);
     ~AcosCalculationNode();
 
     virtual ErrorOr<String> to_string() const override;
@@ -545,7 +546,7 @@ public:
     virtual Optional<CSSNumericType> determine_type(PropertyID) const override;
     virtual bool contains_percentage() const override;
     virtual CalculatedStyleValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CalculatedStyleValue::PercentageBasis const&) const override;
-    virtual ErrorOr<void> for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const&) override;
+    virtual void for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const&) override;
 
     virtual ErrorOr<void> dump(StringBuilder&, int indent) const override;
 
@@ -556,7 +557,7 @@ private:
 
 class AtanCalculationNode final : public CalculationNode {
 public:
-    static ErrorOr<NonnullOwnPtr<AtanCalculationNode>> create(NonnullOwnPtr<CalculationNode>);
+    static NonnullOwnPtr<AtanCalculationNode> create(NonnullOwnPtr<CalculationNode>);
     ~AtanCalculationNode();
 
     virtual ErrorOr<String> to_string() const override;
@@ -564,7 +565,7 @@ public:
     virtual Optional<CSSNumericType> determine_type(PropertyID) const override;
     virtual bool contains_percentage() const override;
     virtual CalculatedStyleValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CalculatedStyleValue::PercentageBasis const&) const override;
-    virtual ErrorOr<void> for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const&) override;
+    virtual void for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const&) override;
 
     virtual ErrorOr<void> dump(StringBuilder&, int indent) const override;
 
@@ -575,7 +576,7 @@ private:
 
 class Atan2CalculationNode final : public CalculationNode {
 public:
-    static ErrorOr<NonnullOwnPtr<Atan2CalculationNode>> create(NonnullOwnPtr<CalculationNode>, NonnullOwnPtr<CalculationNode>);
+    static NonnullOwnPtr<Atan2CalculationNode> create(NonnullOwnPtr<CalculationNode>, NonnullOwnPtr<CalculationNode>);
     ~Atan2CalculationNode();
 
     virtual ErrorOr<String> to_string() const override;
@@ -583,7 +584,7 @@ public:
     virtual Optional<CSSNumericType> determine_type(PropertyID) const override;
     virtual bool contains_percentage() const override;
     virtual CalculatedStyleValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CalculatedStyleValue::PercentageBasis const&) const override;
-    virtual ErrorOr<void> for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const&) override;
+    virtual void for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const&) override;
 
     virtual ErrorOr<void> dump(StringBuilder&, int indent) const override;
 
@@ -595,7 +596,7 @@ private:
 
 class PowCalculationNode final : public CalculationNode {
 public:
-    static ErrorOr<NonnullOwnPtr<PowCalculationNode>> create(NonnullOwnPtr<CalculationNode>, NonnullOwnPtr<CalculationNode>);
+    static NonnullOwnPtr<PowCalculationNode> create(NonnullOwnPtr<CalculationNode>, NonnullOwnPtr<CalculationNode>);
     ~PowCalculationNode();
 
     virtual ErrorOr<String> to_string() const override;
@@ -603,7 +604,7 @@ public:
     virtual Optional<CSSNumericType> determine_type(PropertyID) const override;
     virtual bool contains_percentage() const override { return false; }
     virtual CalculatedStyleValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CalculatedStyleValue::PercentageBasis const&) const override;
-    virtual ErrorOr<void> for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const&) override;
+    virtual void for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const&) override;
 
     virtual ErrorOr<void> dump(StringBuilder&, int indent) const override;
 
@@ -615,7 +616,7 @@ private:
 
 class SqrtCalculationNode final : public CalculationNode {
 public:
-    static ErrorOr<NonnullOwnPtr<SqrtCalculationNode>> create(NonnullOwnPtr<CalculationNode>);
+    static NonnullOwnPtr<SqrtCalculationNode> create(NonnullOwnPtr<CalculationNode>);
     ~SqrtCalculationNode();
 
     virtual ErrorOr<String> to_string() const override;
@@ -623,7 +624,7 @@ public:
     virtual Optional<CSSNumericType> determine_type(PropertyID) const override;
     virtual bool contains_percentage() const override { return false; }
     virtual CalculatedStyleValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CalculatedStyleValue::PercentageBasis const&) const override;
-    virtual ErrorOr<void> for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const&) override;
+    virtual void for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const&) override;
 
     virtual ErrorOr<void> dump(StringBuilder&, int indent) const override;
 
@@ -634,7 +635,7 @@ private:
 
 class HypotCalculationNode final : public CalculationNode {
 public:
-    static ErrorOr<NonnullOwnPtr<HypotCalculationNode>> create(Vector<NonnullOwnPtr<CalculationNode>>);
+    static NonnullOwnPtr<HypotCalculationNode> create(Vector<NonnullOwnPtr<CalculationNode>>);
     ~HypotCalculationNode();
 
     virtual ErrorOr<String> to_string() const override;
@@ -642,7 +643,7 @@ public:
     virtual Optional<CSSNumericType> determine_type(PropertyID) const override;
     virtual bool contains_percentage() const override;
     virtual CalculatedStyleValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CalculatedStyleValue::PercentageBasis const&) const override;
-    virtual ErrorOr<void> for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const&) override;
+    virtual void for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const&) override;
 
     virtual ErrorOr<void> dump(StringBuilder&, int indent) const override;
 
@@ -653,7 +654,7 @@ private:
 
 class LogCalculationNode final : public CalculationNode {
 public:
-    static ErrorOr<NonnullOwnPtr<LogCalculationNode>> create(NonnullOwnPtr<CalculationNode>, NonnullOwnPtr<CalculationNode>);
+    static NonnullOwnPtr<LogCalculationNode> create(NonnullOwnPtr<CalculationNode>, NonnullOwnPtr<CalculationNode>);
     ~LogCalculationNode();
 
     virtual ErrorOr<String> to_string() const override;
@@ -661,7 +662,7 @@ public:
     virtual Optional<CSSNumericType> determine_type(PropertyID) const override;
     virtual bool contains_percentage() const override { return false; }
     virtual CalculatedStyleValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CalculatedStyleValue::PercentageBasis const&) const override;
-    virtual ErrorOr<void> for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const&) override;
+    virtual void for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const&) override;
 
     virtual ErrorOr<void> dump(StringBuilder&, int indent) const override;
 
@@ -673,7 +674,7 @@ private:
 
 class ExpCalculationNode final : public CalculationNode {
 public:
-    static ErrorOr<NonnullOwnPtr<ExpCalculationNode>> create(NonnullOwnPtr<CalculationNode>);
+    static NonnullOwnPtr<ExpCalculationNode> create(NonnullOwnPtr<CalculationNode>);
     ~ExpCalculationNode();
 
     virtual ErrorOr<String> to_string() const override;
@@ -681,7 +682,7 @@ public:
     virtual Optional<CSSNumericType> determine_type(PropertyID) const override;
     virtual bool contains_percentage() const override { return false; }
     virtual CalculatedStyleValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CalculatedStyleValue::PercentageBasis const&) const override;
-    virtual ErrorOr<void> for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const&) override;
+    virtual void for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const&) override;
 
     virtual ErrorOr<void> dump(StringBuilder&, int indent) const override;
 
@@ -692,7 +693,7 @@ private:
 
 class RoundCalculationNode final : public CalculationNode {
 public:
-    static ErrorOr<NonnullOwnPtr<RoundCalculationNode>> create(RoundingStrategy, NonnullOwnPtr<CalculationNode>, NonnullOwnPtr<CalculationNode>);
+    static NonnullOwnPtr<RoundCalculationNode> create(RoundingStrategy, NonnullOwnPtr<CalculationNode>, NonnullOwnPtr<CalculationNode>);
     ~RoundCalculationNode();
 
     virtual ErrorOr<String> to_string() const override;
@@ -700,7 +701,7 @@ public:
     virtual Optional<CSSNumericType> determine_type(PropertyID) const override;
     virtual bool contains_percentage() const override;
     virtual CalculatedStyleValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CalculatedStyleValue::PercentageBasis const&) const override;
-    virtual ErrorOr<void> for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const&) override;
+    virtual void for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const&) override;
 
     virtual ErrorOr<void> dump(StringBuilder&, int indent) const override;
 
@@ -713,7 +714,7 @@ private:
 
 class ModCalculationNode final : public CalculationNode {
 public:
-    static ErrorOr<NonnullOwnPtr<ModCalculationNode>> create(NonnullOwnPtr<CalculationNode>, NonnullOwnPtr<CalculationNode>);
+    static NonnullOwnPtr<ModCalculationNode> create(NonnullOwnPtr<CalculationNode>, NonnullOwnPtr<CalculationNode>);
     ~ModCalculationNode();
 
     virtual ErrorOr<String> to_string() const override;
@@ -721,7 +722,7 @@ public:
     virtual Optional<CSSNumericType> determine_type(PropertyID) const override;
     virtual bool contains_percentage() const override;
     virtual CalculatedStyleValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CalculatedStyleValue::PercentageBasis const&) const override;
-    virtual ErrorOr<void> for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const&) override;
+    virtual void for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const&) override;
 
     virtual ErrorOr<void> dump(StringBuilder&, int indent) const override;
 
@@ -733,7 +734,7 @@ private:
 
 class RemCalculationNode final : public CalculationNode {
 public:
-    static ErrorOr<NonnullOwnPtr<RemCalculationNode>> create(NonnullOwnPtr<CalculationNode>, NonnullOwnPtr<CalculationNode>);
+    static NonnullOwnPtr<RemCalculationNode> create(NonnullOwnPtr<CalculationNode>, NonnullOwnPtr<CalculationNode>);
     ~RemCalculationNode();
 
     virtual ErrorOr<String> to_string() const override;
@@ -741,7 +742,7 @@ public:
     virtual Optional<CSSNumericType> determine_type(PropertyID) const override;
     virtual bool contains_percentage() const override;
     virtual CalculatedStyleValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CalculatedStyleValue::PercentageBasis const&) const override;
-    virtual ErrorOr<void> for_each_child_node(Function<ErrorOr<void>(NonnullOwnPtr<CalculationNode>&)> const&) override;
+    virtual void for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const&) override;
 
     virtual ErrorOr<void> dump(StringBuilder&, int indent) const override;
 

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/ColorStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/ColorStyleValue.cpp
@@ -12,24 +12,24 @@
 
 namespace Web::CSS {
 
-ErrorOr<ValueComparingNonnullRefPtr<ColorStyleValue>> ColorStyleValue::create(Color color)
+ValueComparingNonnullRefPtr<ColorStyleValue> ColorStyleValue::create(Color color)
 {
     if (color.value() == 0) {
-        static auto transparent = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) ColorStyleValue(color)));
+        static auto transparent = adopt_ref(*new (nothrow) ColorStyleValue(color));
         return transparent;
     }
 
     if (color == Color::from_rgb(0x000000)) {
-        static auto black = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) ColorStyleValue(color)));
+        static auto black = adopt_ref(*new (nothrow) ColorStyleValue(color));
         return black;
     }
 
     if (color == Color::from_rgb(0xffffff)) {
-        static auto white = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) ColorStyleValue(color)));
+        static auto white = adopt_ref(*new (nothrow) ColorStyleValue(color));
         return white;
     }
 
-    return adopt_nonnull_ref_or_enomem(new (nothrow) ColorStyleValue(color));
+    return adopt_ref(*new (nothrow) ColorStyleValue(color));
 }
 
 ErrorOr<String> ColorStyleValue::to_string() const

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/ColorStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/ColorStyleValue.h
@@ -16,7 +16,7 @@ namespace Web::CSS {
 
 class ColorStyleValue : public StyleValueWithDefaultOperators<ColorStyleValue> {
 public:
-    static ErrorOr<ValueComparingNonnullRefPtr<ColorStyleValue>> create(Color color);
+    static ValueComparingNonnullRefPtr<ColorStyleValue> create(Color color);
     virtual ~ColorStyleValue() override = default;
 
     Color color() const { return m_color; }

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/CompositeStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/CompositeStyleValue.h
@@ -12,9 +12,9 @@ namespace Web::CSS {
 
 class CompositeStyleValue final : public StyleValueWithDefaultOperators<CompositeStyleValue> {
 public:
-    static ErrorOr<ValueComparingNonnullRefPtr<CompositeStyleValue>> create(Vector<PropertyID> sub_properties, Vector<ValueComparingNonnullRefPtr<StyleValue const>> values)
+    static ValueComparingNonnullRefPtr<CompositeStyleValue> create(Vector<PropertyID> sub_properties, Vector<ValueComparingNonnullRefPtr<StyleValue const>> values)
     {
-        return adopt_nonnull_ref_or_enomem(new CompositeStyleValue(move(sub_properties), move(values)));
+        return adopt_ref(*new CompositeStyleValue(move(sub_properties), move(values)));
     }
     virtual ~CompositeStyleValue() override;
 

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/ConicGradientStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/ConicGradientStyleValue.h
@@ -18,10 +18,10 @@ namespace Web::CSS {
 
 class ConicGradientStyleValue final : public AbstractImageStyleValue {
 public:
-    static ErrorOr<ValueComparingNonnullRefPtr<ConicGradientStyleValue>> create(Angle from_angle, PositionValue position, Vector<AngularColorStopListElement> color_stop_list, GradientRepeating repeating)
+    static ValueComparingNonnullRefPtr<ConicGradientStyleValue> create(Angle from_angle, PositionValue position, Vector<AngularColorStopListElement> color_stop_list, GradientRepeating repeating)
     {
         VERIFY(color_stop_list.size() >= 2);
-        return adopt_nonnull_ref_or_enomem(new (nothrow) ConicGradientStyleValue(from_angle, position, move(color_stop_list), repeating));
+        return adopt_ref(*new (nothrow) ConicGradientStyleValue(from_angle, position, move(color_stop_list), repeating));
     }
 
     virtual ErrorOr<String> to_string() const override;

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/ContentStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/ContentStyleValue.h
@@ -15,9 +15,9 @@ namespace Web::CSS {
 
 class ContentStyleValue final : public StyleValueWithDefaultOperators<ContentStyleValue> {
 public:
-    static ErrorOr<ValueComparingNonnullRefPtr<ContentStyleValue>> create(ValueComparingNonnullRefPtr<StyleValueList> content, ValueComparingRefPtr<StyleValueList> alt_text)
+    static ValueComparingNonnullRefPtr<ContentStyleValue> create(ValueComparingNonnullRefPtr<StyleValueList> content, ValueComparingRefPtr<StyleValueList> alt_text)
     {
-        return adopt_nonnull_ref_or_enomem(new (nothrow) ContentStyleValue(move(content), move(alt_text)));
+        return adopt_ref(*new (nothrow) ContentStyleValue(move(content), move(alt_text)));
     }
     virtual ~ContentStyleValue() override = default;
 

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/CustomIdentStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/CustomIdentStyleValue.h
@@ -14,9 +14,9 @@ namespace Web::CSS {
 // https://www.w3.org/TR/css-values-4/#custom-idents
 class CustomIdentStyleValue final : public StyleValueWithDefaultOperators<CustomIdentStyleValue> {
 public:
-    static ErrorOr<ValueComparingNonnullRefPtr<CustomIdentStyleValue>> create(FlyString custom_ident)
+    static ValueComparingNonnullRefPtr<CustomIdentStyleValue> create(FlyString custom_ident)
     {
-        return adopt_nonnull_ref_or_enomem(new (nothrow) CustomIdentStyleValue(move(custom_ident)));
+        return adopt_ref(*new (nothrow) CustomIdentStyleValue(move(custom_ident)));
     }
     virtual ~CustomIdentStyleValue() override = default;
 

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/DisplayStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/DisplayStyleValue.cpp
@@ -8,9 +8,9 @@
 
 namespace Web::CSS {
 
-ErrorOr<ValueComparingNonnullRefPtr<DisplayStyleValue>> DisplayStyleValue::create(Display const& display)
+ValueComparingNonnullRefPtr<DisplayStyleValue> DisplayStyleValue::create(Display const& display)
 {
-    return adopt_nonnull_ref_or_enomem(new (nothrow) DisplayStyleValue(display));
+    return adopt_ref(*new (nothrow) DisplayStyleValue(display));
 }
 
 }

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/DisplayStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/DisplayStyleValue.h
@@ -13,7 +13,7 @@ namespace Web::CSS {
 
 class DisplayStyleValue : public StyleValueWithDefaultOperators<DisplayStyleValue> {
 public:
-    static ErrorOr<ValueComparingNonnullRefPtr<DisplayStyleValue>> create(Display const&);
+    static ValueComparingNonnullRefPtr<DisplayStyleValue> create(Display const&);
     virtual ~DisplayStyleValue() override = default;
 
     virtual ErrorOr<String> to_string() const override { return m_display.to_string(); }

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/EasingStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/EasingStyleValue.h
@@ -17,9 +17,9 @@ namespace Web::CSS {
 
 class EasingStyleValue final : public StyleValueWithDefaultOperators<EasingStyleValue> {
 public:
-    static ErrorOr<ValueComparingNonnullRefPtr<EasingStyleValue>> create(CSS::EasingFunction easing_function, StyleValueVector&& values)
+    static ValueComparingNonnullRefPtr<EasingStyleValue> create(CSS::EasingFunction easing_function, StyleValueVector&& values)
     {
-        return adopt_nonnull_ref_or_enomem(new (nothrow) EasingStyleValue(easing_function, move(values)));
+        return adopt_ref(*new (nothrow) EasingStyleValue(easing_function, move(values)));
     }
     virtual ~EasingStyleValue() override = default;
 

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/EdgeStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/EdgeStyleValue.h
@@ -14,9 +14,9 @@ namespace Web::CSS {
 
 class EdgeStyleValue final : public StyleValueWithDefaultOperators<EdgeStyleValue> {
 public:
-    static ErrorOr<ValueComparingNonnullRefPtr<EdgeStyleValue>> create(PositionEdge edge, LengthPercentage const& offset)
+    static ValueComparingNonnullRefPtr<EdgeStyleValue> create(PositionEdge edge, LengthPercentage const& offset)
     {
-        return adopt_nonnull_ref_or_enomem(new (nothrow) EdgeStyleValue(edge, offset));
+        return adopt_ref(*new (nothrow) EdgeStyleValue(edge, offset));
     }
     virtual ~EdgeStyleValue() override = default;
 

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/FilterValueListStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/FilterValueListStyleValue.h
@@ -70,11 +70,11 @@ using FilterFunction = Variant<Filter::Blur, Filter::DropShadow, Filter::HueRota
 
 class FilterValueListStyleValue final : public StyleValueWithDefaultOperators<FilterValueListStyleValue> {
 public:
-    static ErrorOr<ValueComparingNonnullRefPtr<FilterValueListStyleValue>> create(
+    static ValueComparingNonnullRefPtr<FilterValueListStyleValue> create(
         Vector<FilterFunction> filter_value_list)
     {
         VERIFY(filter_value_list.size() >= 1);
-        return adopt_nonnull_ref_or_enomem(new (nothrow) FilterValueListStyleValue(move(filter_value_list)));
+        return adopt_ref(*new (nothrow) FilterValueListStyleValue(move(filter_value_list)));
     }
 
     Vector<FilterFunction> const& filter_value_list() const { return m_filter_value_list; }

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/FlexFlowStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/FlexFlowStyleValue.h
@@ -15,9 +15,9 @@ namespace Web::CSS {
 
 class FlexFlowStyleValue final : public StyleValueWithDefaultOperators<FlexFlowStyleValue> {
 public:
-    static ErrorOr<ValueComparingNonnullRefPtr<FlexFlowStyleValue>> create(ValueComparingNonnullRefPtr<StyleValue> flex_direction, ValueComparingNonnullRefPtr<StyleValue> flex_wrap)
+    static ValueComparingNonnullRefPtr<FlexFlowStyleValue> create(ValueComparingNonnullRefPtr<StyleValue> flex_direction, ValueComparingNonnullRefPtr<StyleValue> flex_wrap)
     {
-        return adopt_nonnull_ref_or_enomem(new (nothrow) FlexFlowStyleValue(move(flex_direction), move(flex_wrap)));
+        return adopt_ref(*new (nothrow) FlexFlowStyleValue(move(flex_direction), move(flex_wrap)));
     }
     virtual ~FlexFlowStyleValue() override = default;
 

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/FlexStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/FlexStyleValue.h
@@ -15,12 +15,12 @@ namespace Web::CSS {
 
 class FlexStyleValue final : public StyleValueWithDefaultOperators<FlexStyleValue> {
 public:
-    static ErrorOr<ValueComparingNonnullRefPtr<FlexStyleValue>> create(
+    static ValueComparingNonnullRefPtr<FlexStyleValue> create(
         ValueComparingNonnullRefPtr<StyleValue> grow,
         ValueComparingNonnullRefPtr<StyleValue> shrink,
         ValueComparingNonnullRefPtr<StyleValue> basis)
     {
-        return adopt_nonnull_ref_or_enomem(new (nothrow) FlexStyleValue(move(grow), move(shrink), move(basis)));
+        return adopt_ref(*new (nothrow) FlexStyleValue(move(grow), move(shrink), move(basis)));
     }
     virtual ~FlexStyleValue() override = default;
 

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/FontStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/FontStyleValue.h
@@ -15,7 +15,7 @@ namespace Web::CSS {
 
 class FontStyleValue final : public StyleValueWithDefaultOperators<FontStyleValue> {
 public:
-    static ErrorOr<ValueComparingNonnullRefPtr<FontStyleValue>> create(
+    static ValueComparingNonnullRefPtr<FontStyleValue> create(
         ValueComparingNonnullRefPtr<StyleValue> font_stretch,
         ValueComparingNonnullRefPtr<StyleValue> font_style,
         ValueComparingNonnullRefPtr<StyleValue> font_weight,
@@ -23,7 +23,7 @@ public:
         ValueComparingNonnullRefPtr<StyleValue> line_height,
         ValueComparingNonnullRefPtr<StyleValue> font_families)
     {
-        return adopt_nonnull_ref_or_enomem(new (nothrow) FontStyleValue(move(font_stretch), move(font_style), move(font_weight), move(font_size), move(line_height), move(font_families)));
+        return adopt_ref(*new (nothrow) FontStyleValue(move(font_stretch), move(font_style), move(font_weight), move(font_size), move(line_height), move(font_families)));
     }
     virtual ~FontStyleValue() override = default;
 

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/FrequencyStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/FrequencyStyleValue.h
@@ -16,9 +16,9 @@ namespace Web::CSS {
 
 class FrequencyStyleValue : public StyleValueWithDefaultOperators<FrequencyStyleValue> {
 public:
-    static ErrorOr<ValueComparingNonnullRefPtr<FrequencyStyleValue>> create(Frequency frequency)
+    static ValueComparingNonnullRefPtr<FrequencyStyleValue> create(Frequency frequency)
     {
-        return adopt_nonnull_ref_or_enomem(new (nothrow) FrequencyStyleValue(move(frequency)));
+        return adopt_ref(*new (nothrow) FrequencyStyleValue(move(frequency)));
     }
     virtual ~FrequencyStyleValue() override = default;
 

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/GridAreaShorthandStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/GridAreaShorthandStyleValue.cpp
@@ -12,22 +12,22 @@
 
 namespace Web::CSS {
 
-ErrorOr<ValueComparingNonnullRefPtr<GridAreaShorthandStyleValue>> GridAreaShorthandStyleValue::create(
+ValueComparingNonnullRefPtr<GridAreaShorthandStyleValue> GridAreaShorthandStyleValue::create(
     ValueComparingNonnullRefPtr<GridTrackPlacementStyleValue const> row_start,
     ValueComparingNonnullRefPtr<GridTrackPlacementStyleValue const> column_start,
     ValueComparingNonnullRefPtr<GridTrackPlacementStyleValue const> row_end,
     ValueComparingNonnullRefPtr<GridTrackPlacementStyleValue const> column_end)
 {
-    return adopt_nonnull_ref_or_enomem(new (nothrow) GridAreaShorthandStyleValue(row_start, column_start, row_end, column_end));
+    return adopt_ref(*new (nothrow) GridAreaShorthandStyleValue(row_start, column_start, row_end, column_end));
 }
 
-ErrorOr<ValueComparingNonnullRefPtr<GridAreaShorthandStyleValue>> GridAreaShorthandStyleValue::create(GridTrackPlacement row_start, GridTrackPlacement column_start, GridTrackPlacement row_end, GridTrackPlacement column_end)
+ValueComparingNonnullRefPtr<GridAreaShorthandStyleValue> GridAreaShorthandStyleValue::create(GridTrackPlacement row_start, GridTrackPlacement column_start, GridTrackPlacement row_end, GridTrackPlacement column_end)
 {
-    return adopt_nonnull_ref_or_enomem(new (nothrow) GridAreaShorthandStyleValue(
-        TRY(GridTrackPlacementStyleValue::create(row_start)),
-        TRY(GridTrackPlacementStyleValue::create(column_start)),
-        TRY(GridTrackPlacementStyleValue::create(row_end)),
-        TRY(GridTrackPlacementStyleValue::create(column_end))));
+    return adopt_ref(*new (nothrow) GridAreaShorthandStyleValue(
+        GridTrackPlacementStyleValue::create(row_start),
+        GridTrackPlacementStyleValue::create(column_start),
+        GridTrackPlacementStyleValue::create(row_end),
+        GridTrackPlacementStyleValue::create(column_end)));
 }
 
 ErrorOr<String> GridAreaShorthandStyleValue::to_string() const

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/GridAreaShorthandStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/GridAreaShorthandStyleValue.h
@@ -15,12 +15,12 @@ namespace Web::CSS {
 
 class GridAreaShorthandStyleValue final : public StyleValueWithDefaultOperators<GridAreaShorthandStyleValue> {
 public:
-    static ErrorOr<ValueComparingNonnullRefPtr<GridAreaShorthandStyleValue>> create(
+    static ValueComparingNonnullRefPtr<GridAreaShorthandStyleValue> create(
         ValueComparingNonnullRefPtr<GridTrackPlacementStyleValue const> row_start,
         ValueComparingNonnullRefPtr<GridTrackPlacementStyleValue const> column_start,
         ValueComparingNonnullRefPtr<GridTrackPlacementStyleValue const> row_end,
         ValueComparingNonnullRefPtr<GridTrackPlacementStyleValue const> column_end);
-    static ErrorOr<ValueComparingNonnullRefPtr<GridAreaShorthandStyleValue>> create(GridTrackPlacement row_start, GridTrackPlacement column_start, GridTrackPlacement row_end, GridTrackPlacement column_end);
+    static ValueComparingNonnullRefPtr<GridAreaShorthandStyleValue> create(GridTrackPlacement row_start, GridTrackPlacement column_start, GridTrackPlacement row_end, GridTrackPlacement column_end);
     virtual ~GridAreaShorthandStyleValue() override = default;
 
     auto row_start() const { return m_properties.row_start; }

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/GridTemplateAreaStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/GridTemplateAreaStyleValue.cpp
@@ -11,9 +11,9 @@
 
 namespace Web::CSS {
 
-ErrorOr<ValueComparingNonnullRefPtr<GridTemplateAreaStyleValue>> GridTemplateAreaStyleValue::create(Vector<Vector<String>> grid_template_area)
+ValueComparingNonnullRefPtr<GridTemplateAreaStyleValue> GridTemplateAreaStyleValue::create(Vector<Vector<String>> grid_template_area)
 {
-    return adopt_nonnull_ref_or_enomem(new (nothrow) GridTemplateAreaStyleValue(grid_template_area));
+    return adopt_ref(*new (nothrow) GridTemplateAreaStyleValue(grid_template_area));
 }
 
 ErrorOr<String> GridTemplateAreaStyleValue::to_string() const

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/GridTemplateAreaStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/GridTemplateAreaStyleValue.h
@@ -15,7 +15,7 @@ namespace Web::CSS {
 
 class GridTemplateAreaStyleValue final : public StyleValueWithDefaultOperators<GridTemplateAreaStyleValue> {
 public:
-    static ErrorOr<ValueComparingNonnullRefPtr<GridTemplateAreaStyleValue>> create(Vector<Vector<String>> grid_template_area);
+    static ValueComparingNonnullRefPtr<GridTemplateAreaStyleValue> create(Vector<Vector<String>> grid_template_area);
     virtual ~GridTemplateAreaStyleValue() override = default;
 
     Vector<Vector<String>> const& grid_template_area() const { return m_grid_template_area; }

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/GridTrackPlacementShorthandStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/GridTrackPlacementShorthandStyleValue.cpp
@@ -12,16 +12,16 @@
 
 namespace Web::CSS {
 
-ErrorOr<ValueComparingNonnullRefPtr<GridTrackPlacementShorthandStyleValue>> GridTrackPlacementShorthandStyleValue::create(ValueComparingNonnullRefPtr<GridTrackPlacementStyleValue const> start, ValueComparingNonnullRefPtr<GridTrackPlacementStyleValue const> end)
+ValueComparingNonnullRefPtr<GridTrackPlacementShorthandStyleValue> GridTrackPlacementShorthandStyleValue::create(ValueComparingNonnullRefPtr<GridTrackPlacementStyleValue const> start, ValueComparingNonnullRefPtr<GridTrackPlacementStyleValue const> end)
 {
-    return adopt_nonnull_ref_or_enomem(new (nothrow) GridTrackPlacementShorthandStyleValue(move(start), move(end)));
+    return adopt_ref(*new (nothrow) GridTrackPlacementShorthandStyleValue(move(start), move(end)));
 }
 
-ErrorOr<ValueComparingNonnullRefPtr<GridTrackPlacementShorthandStyleValue>> GridTrackPlacementShorthandStyleValue::create(GridTrackPlacement start)
+ValueComparingNonnullRefPtr<GridTrackPlacementShorthandStyleValue> GridTrackPlacementShorthandStyleValue::create(GridTrackPlacement start)
 {
-    return adopt_nonnull_ref_or_enomem(new (nothrow) GridTrackPlacementShorthandStyleValue(
-        TRY(GridTrackPlacementStyleValue::create(start)),
-        TRY(GridTrackPlacementStyleValue::create(GridTrackPlacement::make_auto()))));
+    return adopt_ref(*new (nothrow) GridTrackPlacementShorthandStyleValue(
+        GridTrackPlacementStyleValue::create(start),
+        GridTrackPlacementStyleValue::create(GridTrackPlacement::make_auto())));
 }
 
 ErrorOr<String> GridTrackPlacementShorthandStyleValue::to_string() const

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/GridTrackPlacementShorthandStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/GridTrackPlacementShorthandStyleValue.h
@@ -15,8 +15,8 @@ namespace Web::CSS {
 
 class GridTrackPlacementShorthandStyleValue final : public StyleValueWithDefaultOperators<GridTrackPlacementShorthandStyleValue> {
 public:
-    static ErrorOr<ValueComparingNonnullRefPtr<GridTrackPlacementShorthandStyleValue>> create(ValueComparingNonnullRefPtr<GridTrackPlacementStyleValue const> start, ValueComparingNonnullRefPtr<GridTrackPlacementStyleValue const> end);
-    static ErrorOr<ValueComparingNonnullRefPtr<GridTrackPlacementShorthandStyleValue>> create(GridTrackPlacement start);
+    static ValueComparingNonnullRefPtr<GridTrackPlacementShorthandStyleValue> create(ValueComparingNonnullRefPtr<GridTrackPlacementStyleValue const> start, ValueComparingNonnullRefPtr<GridTrackPlacementStyleValue const> end);
+    static ValueComparingNonnullRefPtr<GridTrackPlacementShorthandStyleValue> create(GridTrackPlacement start);
     virtual ~GridTrackPlacementShorthandStyleValue() override = default;
 
     auto start() const { return m_properties.start; }

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/GridTrackPlacementStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/GridTrackPlacementStyleValue.cpp
@@ -11,9 +11,9 @@
 
 namespace Web::CSS {
 
-ErrorOr<ValueComparingNonnullRefPtr<GridTrackPlacementStyleValue>> GridTrackPlacementStyleValue::create(CSS::GridTrackPlacement grid_track_placement)
+ValueComparingNonnullRefPtr<GridTrackPlacementStyleValue> GridTrackPlacementStyleValue::create(CSS::GridTrackPlacement grid_track_placement)
 {
-    return adopt_nonnull_ref_or_enomem(new (nothrow) GridTrackPlacementStyleValue(grid_track_placement));
+    return adopt_ref(*new (nothrow) GridTrackPlacementStyleValue(grid_track_placement));
 }
 
 ErrorOr<String> GridTrackPlacementStyleValue::to_string() const

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/GridTrackPlacementStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/GridTrackPlacementStyleValue.h
@@ -16,7 +16,7 @@ namespace Web::CSS {
 
 class GridTrackPlacementStyleValue final : public StyleValueWithDefaultOperators<GridTrackPlacementStyleValue> {
 public:
-    static ErrorOr<ValueComparingNonnullRefPtr<GridTrackPlacementStyleValue>> create(GridTrackPlacement grid_track_placement);
+    static ValueComparingNonnullRefPtr<GridTrackPlacementStyleValue> create(GridTrackPlacement grid_track_placement);
     virtual ~GridTrackPlacementStyleValue() override = default;
 
     GridTrackPlacement const& grid_track_placement() const { return m_grid_track_placement; }

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/GridTrackSizeListShorthandStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/GridTrackSizeListShorthandStyleValue.cpp
@@ -9,12 +9,12 @@
 
 namespace Web::CSS {
 
-ErrorOr<ValueComparingNonnullRefPtr<GridTrackSizeListShorthandStyleValue>> GridTrackSizeListShorthandStyleValue::create(
+ValueComparingNonnullRefPtr<GridTrackSizeListShorthandStyleValue> GridTrackSizeListShorthandStyleValue::create(
     ValueComparingNonnullRefPtr<GridTemplateAreaStyleValue const> areas,
     ValueComparingNonnullRefPtr<GridTrackSizeListStyleValue const> rows,
     ValueComparingNonnullRefPtr<GridTrackSizeListStyleValue const> columns)
 {
-    return adopt_nonnull_ref_or_enomem(new (nothrow) GridTrackSizeListShorthandStyleValue(move(areas), move(rows), move(columns)));
+    return adopt_ref(*new (nothrow) GridTrackSizeListShorthandStyleValue(move(areas), move(rows), move(columns)));
 }
 
 ErrorOr<String> GridTrackSizeListShorthandStyleValue::to_string() const

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/GridTrackSizeListShorthandStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/GridTrackSizeListShorthandStyleValue.h
@@ -13,7 +13,7 @@ namespace Web::CSS {
 
 class GridTrackSizeListShorthandStyleValue final : public StyleValueWithDefaultOperators<GridTrackSizeListShorthandStyleValue> {
 public:
-    static ErrorOr<ValueComparingNonnullRefPtr<GridTrackSizeListShorthandStyleValue>> create(
+    static ValueComparingNonnullRefPtr<GridTrackSizeListShorthandStyleValue> create(
         ValueComparingNonnullRefPtr<GridTemplateAreaStyleValue const> areas,
         ValueComparingNonnullRefPtr<GridTrackSizeListStyleValue const> rows,
         ValueComparingNonnullRefPtr<GridTrackSizeListStyleValue const> columns);

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/GridTrackSizeListStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/GridTrackSizeListStyleValue.cpp
@@ -16,19 +16,19 @@ ErrorOr<String> GridTrackSizeListStyleValue::to_string() const
     return m_grid_track_size_list.to_string();
 }
 
-ErrorOr<ValueComparingNonnullRefPtr<GridTrackSizeListStyleValue>> GridTrackSizeListStyleValue::create(CSS::GridTrackSizeList grid_track_size_list)
+ValueComparingNonnullRefPtr<GridTrackSizeListStyleValue> GridTrackSizeListStyleValue::create(CSS::GridTrackSizeList grid_track_size_list)
 {
-    return adopt_nonnull_ref_or_enomem(new (nothrow) GridTrackSizeListStyleValue(grid_track_size_list));
+    return adopt_ref(*new (nothrow) GridTrackSizeListStyleValue(grid_track_size_list));
 }
 
-ErrorOr<ValueComparingNonnullRefPtr<GridTrackSizeListStyleValue>> GridTrackSizeListStyleValue::make_auto()
+ValueComparingNonnullRefPtr<GridTrackSizeListStyleValue> GridTrackSizeListStyleValue::make_auto()
 {
-    return adopt_nonnull_ref_or_enomem(new (nothrow) GridTrackSizeListStyleValue(CSS::GridTrackSizeList()));
+    return adopt_ref(*new (nothrow) GridTrackSizeListStyleValue(CSS::GridTrackSizeList()));
 }
 
-ErrorOr<ValueComparingNonnullRefPtr<GridTrackSizeListStyleValue>> GridTrackSizeListStyleValue::make_none()
+ValueComparingNonnullRefPtr<GridTrackSizeListStyleValue> GridTrackSizeListStyleValue::make_none()
 {
-    return adopt_nonnull_ref_or_enomem(new (nothrow) GridTrackSizeListStyleValue(CSS::GridTrackSizeList()));
+    return adopt_ref(*new (nothrow) GridTrackSizeListStyleValue(CSS::GridTrackSizeList()));
 }
 
 }

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/GridTrackSizeListStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/GridTrackSizeListStyleValue.h
@@ -16,11 +16,11 @@ namespace Web::CSS {
 
 class GridTrackSizeListStyleValue final : public StyleValueWithDefaultOperators<GridTrackSizeListStyleValue> {
 public:
-    static ErrorOr<ValueComparingNonnullRefPtr<GridTrackSizeListStyleValue>> create(CSS::GridTrackSizeList grid_track_size_list);
+    static ValueComparingNonnullRefPtr<GridTrackSizeListStyleValue> create(CSS::GridTrackSizeList grid_track_size_list);
     virtual ~GridTrackSizeListStyleValue() override = default;
 
-    static ErrorOr<ValueComparingNonnullRefPtr<GridTrackSizeListStyleValue>> make_auto();
-    static ErrorOr<ValueComparingNonnullRefPtr<GridTrackSizeListStyleValue>> make_none();
+    static ValueComparingNonnullRefPtr<GridTrackSizeListStyleValue> make_auto();
+    static ValueComparingNonnullRefPtr<GridTrackSizeListStyleValue> make_none();
 
     CSS::GridTrackSizeList grid_track_size_list() const { return m_grid_track_size_list; }
 

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/IdentifierStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/IdentifierStyleValue.h
@@ -16,9 +16,9 @@ namespace Web::CSS {
 
 class IdentifierStyleValue final : public StyleValueWithDefaultOperators<IdentifierStyleValue> {
 public:
-    static ErrorOr<ValueComparingNonnullRefPtr<IdentifierStyleValue>> create(ValueID id)
+    static ValueComparingNonnullRefPtr<IdentifierStyleValue> create(ValueID id)
     {
-        return adopt_nonnull_ref_or_enomem(new (nothrow) IdentifierStyleValue(id));
+        return adopt_ref(*new (nothrow) IdentifierStyleValue(id));
     }
     virtual ~IdentifierStyleValue() override = default;
 

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.h
@@ -20,9 +20,9 @@ class ImageStyleValue final
     : public AbstractImageStyleValue
     , public Weakable<ImageStyleValue> {
 public:
-    static ErrorOr<ValueComparingNonnullRefPtr<ImageStyleValue>> create(AK::URL const& url)
+    static ValueComparingNonnullRefPtr<ImageStyleValue> create(AK::URL const& url)
     {
-        return adopt_nonnull_ref_or_enomem(new (nothrow) ImageStyleValue(url));
+        return adopt_ref(*new (nothrow) ImageStyleValue(url));
     }
     virtual ~ImageStyleValue() override = default;
 

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/InheritStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/InheritStyleValue.h
@@ -12,9 +12,9 @@ namespace Web::CSS {
 
 class InheritStyleValue final : public StyleValueWithDefaultOperators<InheritStyleValue> {
 public:
-    static ErrorOr<ValueComparingNonnullRefPtr<InheritStyleValue>> the()
+    static ValueComparingNonnullRefPtr<InheritStyleValue> the()
     {
-        static ValueComparingNonnullRefPtr<InheritStyleValue> instance = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) InheritStyleValue));
+        static ValueComparingNonnullRefPtr<InheritStyleValue> instance = adopt_ref(*new (nothrow) InheritStyleValue);
         return instance;
     }
     virtual ~InheritStyleValue() override = default;

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/InitialStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/InitialStyleValue.h
@@ -12,9 +12,9 @@ namespace Web::CSS {
 
 class InitialStyleValue final : public StyleValueWithDefaultOperators<InitialStyleValue> {
 public:
-    static ErrorOr<ValueComparingNonnullRefPtr<InitialStyleValue>> the()
+    static ValueComparingNonnullRefPtr<InitialStyleValue> the()
     {
-        static ValueComparingNonnullRefPtr<InitialStyleValue> instance = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) InitialStyleValue));
+        static ValueComparingNonnullRefPtr<InitialStyleValue> instance = adopt_ref(*new (nothrow) InitialStyleValue);
         return instance;
     }
     virtual ~InitialStyleValue() override = default;

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/IntegerStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/IntegerStyleValue.h
@@ -12,9 +12,9 @@ namespace Web::CSS {
 
 class IntegerStyleValue : public StyleValueWithDefaultOperators<IntegerStyleValue> {
 public:
-    static ErrorOr<ValueComparingNonnullRefPtr<IntegerStyleValue>> create(i64 value)
+    static ValueComparingNonnullRefPtr<IntegerStyleValue> create(i64 value)
     {
-        return adopt_nonnull_ref_or_enomem(new (nothrow) IntegerStyleValue(value));
+        return adopt_ref(*new (nothrow) IntegerStyleValue(value));
     }
 
     i64 integer() const { return m_value; }

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/LengthStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/LengthStyleValue.cpp
@@ -11,20 +11,20 @@
 
 namespace Web::CSS {
 
-ErrorOr<ValueComparingNonnullRefPtr<LengthStyleValue>> LengthStyleValue::create(Length const& length)
+ValueComparingNonnullRefPtr<LengthStyleValue> LengthStyleValue::create(Length const& length)
 {
     VERIFY(!length.is_auto());
     if (length.is_px()) {
         if (length.raw_value() == 0) {
-            static auto value = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) LengthStyleValue(CSS::Length::make_px(0))));
+            static auto value = adopt_ref(*new (nothrow) LengthStyleValue(CSS::Length::make_px(0)));
             return value;
         }
         if (length.raw_value() == 1) {
-            static auto value = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) LengthStyleValue(CSS::Length::make_px(1))));
+            static auto value = adopt_ref(*new (nothrow) LengthStyleValue(CSS::Length::make_px(1)));
             return value;
         }
     }
-    return adopt_nonnull_ref_or_enomem(new (nothrow) LengthStyleValue(length));
+    return adopt_ref(*new (nothrow) LengthStyleValue(length));
 }
 
 ErrorOr<ValueComparingNonnullRefPtr<StyleValue const>> LengthStyleValue::absolutized(CSSPixelRect const& viewport_rect, Length::FontMetrics const& font_metrics, Length::FontMetrics const& root_font_metrics) const

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/LengthStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/LengthStyleValue.cpp
@@ -27,7 +27,7 @@ ValueComparingNonnullRefPtr<LengthStyleValue> LengthStyleValue::create(Length co
     return adopt_ref(*new (nothrow) LengthStyleValue(length));
 }
 
-ErrorOr<ValueComparingNonnullRefPtr<StyleValue const>> LengthStyleValue::absolutized(CSSPixelRect const& viewport_rect, Length::FontMetrics const& font_metrics, Length::FontMetrics const& root_font_metrics) const
+ValueComparingNonnullRefPtr<StyleValue const> LengthStyleValue::absolutized(CSSPixelRect const& viewport_rect, Length::FontMetrics const& font_metrics, Length::FontMetrics const& root_font_metrics) const
 {
     if (auto length = m_length.absolutize(viewport_rect, font_metrics, root_font_metrics); length.has_value())
         return LengthStyleValue::create(length.release_value());

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/LengthStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/LengthStyleValue.h
@@ -15,7 +15,7 @@ namespace Web::CSS {
 
 class LengthStyleValue : public StyleValueWithDefaultOperators<LengthStyleValue> {
 public:
-    static ErrorOr<ValueComparingNonnullRefPtr<LengthStyleValue>> create(Length const&);
+    static ValueComparingNonnullRefPtr<LengthStyleValue> create(Length const&);
     virtual ~LengthStyleValue() override = default;
 
     Length const& length() const { return m_length; }

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/LengthStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/LengthStyleValue.h
@@ -21,7 +21,7 @@ public:
     Length const& length() const { return m_length; }
 
     virtual ErrorOr<String> to_string() const override { return m_length.to_string(); }
-    virtual ErrorOr<ValueComparingNonnullRefPtr<StyleValue const>> absolutized(CSSPixelRect const& viewport_rect, Length::FontMetrics const& font_metrics, Length::FontMetrics const& root_font_metrics) const override;
+    virtual ValueComparingNonnullRefPtr<StyleValue const> absolutized(CSSPixelRect const& viewport_rect, Length::FontMetrics const& font_metrics, Length::FontMetrics const& root_font_metrics) const override;
 
     bool properties_equal(LengthStyleValue const& other) const { return m_length == other.m_length; }
 

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/LinearGradientStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/LinearGradientStyleValue.h
@@ -38,10 +38,10 @@ public:
         WebKit
     };
 
-    static ErrorOr<ValueComparingNonnullRefPtr<LinearGradientStyleValue>> create(GradientDirection direction, Vector<LinearColorStopListElement> color_stop_list, GradientType type, GradientRepeating repeating)
+    static ValueComparingNonnullRefPtr<LinearGradientStyleValue> create(GradientDirection direction, Vector<LinearColorStopListElement> color_stop_list, GradientType type, GradientRepeating repeating)
     {
         VERIFY(color_stop_list.size() >= 2);
-        return adopt_nonnull_ref_or_enomem(new (nothrow) LinearGradientStyleValue(direction, move(color_stop_list), type, repeating));
+        return adopt_ref(*new (nothrow) LinearGradientStyleValue(direction, move(color_stop_list), type, repeating));
     }
 
     virtual ErrorOr<String> to_string() const override;

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/ListStyleStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/ListStyleStyleValue.h
@@ -15,12 +15,12 @@ namespace Web::CSS {
 
 class ListStyleStyleValue final : public StyleValueWithDefaultOperators<ListStyleStyleValue> {
 public:
-    static ErrorOr<ValueComparingNonnullRefPtr<ListStyleStyleValue>> create(
+    static ValueComparingNonnullRefPtr<ListStyleStyleValue> create(
         ValueComparingNonnullRefPtr<StyleValue> position,
         ValueComparingNonnullRefPtr<StyleValue> image,
         ValueComparingNonnullRefPtr<StyleValue> style_type)
     {
-        return adopt_nonnull_ref_or_enomem(new (nothrow) ListStyleStyleValue(move(position), move(image), move(style_type)));
+        return adopt_ref(*new (nothrow) ListStyleStyleValue(move(position), move(image), move(style_type)));
     }
     virtual ~ListStyleStyleValue() override = default;
 

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/NumberStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/NumberStyleValue.h
@@ -15,9 +15,9 @@ namespace Web::CSS {
 
 class NumberStyleValue : public StyleValueWithDefaultOperators<NumberStyleValue> {
 public:
-    static ErrorOr<ValueComparingNonnullRefPtr<NumberStyleValue>> create(double value)
+    static ValueComparingNonnullRefPtr<NumberStyleValue> create(double value)
     {
-        return adopt_nonnull_ref_or_enomem(new (nothrow) NumberStyleValue(value));
+        return adopt_ref(*new (nothrow) NumberStyleValue(value));
     }
 
     double number() const { return m_value; }

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/OverflowStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/OverflowStyleValue.h
@@ -15,9 +15,9 @@ namespace Web::CSS {
 
 class OverflowStyleValue final : public StyleValueWithDefaultOperators<OverflowStyleValue> {
 public:
-    static ErrorOr<ValueComparingNonnullRefPtr<OverflowStyleValue>> create(ValueComparingNonnullRefPtr<StyleValue> overflow_x, ValueComparingNonnullRefPtr<StyleValue> overflow_y)
+    static ValueComparingNonnullRefPtr<OverflowStyleValue> create(ValueComparingNonnullRefPtr<StyleValue> overflow_x, ValueComparingNonnullRefPtr<StyleValue> overflow_y)
     {
-        return adopt_nonnull_ref_or_enomem(new (nothrow) OverflowStyleValue(move(overflow_x), move(overflow_y)));
+        return adopt_ref(*new (nothrow) OverflowStyleValue(move(overflow_x), move(overflow_y)));
     }
     virtual ~OverflowStyleValue() override = default;
 

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/PercentageStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/PercentageStyleValue.h
@@ -16,9 +16,9 @@ namespace Web::CSS {
 
 class PercentageStyleValue final : public StyleValueWithDefaultOperators<PercentageStyleValue> {
 public:
-    static ErrorOr<ValueComparingNonnullRefPtr<PercentageStyleValue>> create(Percentage percentage)
+    static ValueComparingNonnullRefPtr<PercentageStyleValue> create(Percentage percentage)
     {
-        return adopt_nonnull_ref_or_enomem(new (nothrow) PercentageStyleValue(move(percentage)));
+        return adopt_ref(*new (nothrow) PercentageStyleValue(move(percentage)));
     }
     virtual ~PercentageStyleValue() override = default;
 

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/PlaceContentStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/PlaceContentStyleValue.h
@@ -12,9 +12,9 @@ namespace Web::CSS {
 
 class PlaceContentStyleValue final : public StyleValueWithDefaultOperators<PlaceContentStyleValue> {
 public:
-    static ErrorOr<ValueComparingNonnullRefPtr<PlaceContentStyleValue>> create(ValueComparingNonnullRefPtr<StyleValue> align_content, ValueComparingNonnullRefPtr<StyleValue> justify_content)
+    static ValueComparingNonnullRefPtr<PlaceContentStyleValue> create(ValueComparingNonnullRefPtr<StyleValue> align_content, ValueComparingNonnullRefPtr<StyleValue> justify_content)
     {
-        return adopt_nonnull_ref_or_enomem(new (nothrow) PlaceContentStyleValue(move(align_content), move(justify_content)));
+        return adopt_ref(*new (nothrow) PlaceContentStyleValue(move(align_content), move(justify_content)));
     }
     virtual ~PlaceContentStyleValue() override = default;
 

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/PlaceItemsStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/PlaceItemsStyleValue.h
@@ -12,9 +12,9 @@ namespace Web::CSS {
 
 class PlaceItemsStyleValue final : public StyleValueWithDefaultOperators<PlaceItemsStyleValue> {
 public:
-    static ErrorOr<ValueComparingNonnullRefPtr<PlaceItemsStyleValue>> create(ValueComparingNonnullRefPtr<StyleValue> align_items, ValueComparingNonnullRefPtr<StyleValue> justify_items)
+    static ValueComparingNonnullRefPtr<PlaceItemsStyleValue> create(ValueComparingNonnullRefPtr<StyleValue> align_items, ValueComparingNonnullRefPtr<StyleValue> justify_items)
     {
-        return adopt_nonnull_ref_or_enomem(new (nothrow) PlaceItemsStyleValue(move(align_items), move(justify_items)));
+        return adopt_ref(*new (nothrow) PlaceItemsStyleValue(move(align_items), move(justify_items)));
     }
     virtual ~PlaceItemsStyleValue() override = default;
 

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/PlaceSelfStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/PlaceSelfStyleValue.h
@@ -12,9 +12,9 @@ namespace Web::CSS {
 
 class PlaceSelfStyleValue final : public StyleValueWithDefaultOperators<PlaceSelfStyleValue> {
 public:
-    static ErrorOr<ValueComparingNonnullRefPtr<PlaceSelfStyleValue>> create(ValueComparingNonnullRefPtr<StyleValue> align_self, ValueComparingNonnullRefPtr<StyleValue> justify_self)
+    static ValueComparingNonnullRefPtr<PlaceSelfStyleValue> create(ValueComparingNonnullRefPtr<StyleValue> align_self, ValueComparingNonnullRefPtr<StyleValue> justify_self)
     {
-        return adopt_nonnull_ref_or_enomem(new (nothrow) PlaceSelfStyleValue(move(align_self), move(justify_self)));
+        return adopt_ref(*new (nothrow) PlaceSelfStyleValue(move(align_self), move(justify_self)));
     }
     virtual ~PlaceSelfStyleValue() override = default;
 

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/PositionStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/PositionStyleValue.h
@@ -17,9 +17,9 @@ namespace Web::CSS {
 
 class PositionStyleValue final : public StyleValueWithDefaultOperators<PositionStyleValue> {
 public:
-    static ErrorOr<ValueComparingNonnullRefPtr<PositionStyleValue>> create(ValueComparingNonnullRefPtr<StyleValue> egde_x, ValueComparingNonnullRefPtr<StyleValue> edge_y)
+    static ValueComparingNonnullRefPtr<PositionStyleValue> create(ValueComparingNonnullRefPtr<StyleValue> egde_x, ValueComparingNonnullRefPtr<StyleValue> edge_y)
     {
-        return adopt_nonnull_ref_or_enomem(new (nothrow) PositionStyleValue(move(egde_x), move(edge_y)));
+        return adopt_ref(*new (nothrow) PositionStyleValue(move(egde_x), move(edge_y)));
     }
     virtual ~PositionStyleValue() override = default;
 

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/RadialGradientStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/RadialGradientStyleValue.h
@@ -44,10 +44,10 @@ public:
 
     using Size = Variant<Extent, CircleSize, EllipseSize>;
 
-    static ErrorOr<ValueComparingNonnullRefPtr<RadialGradientStyleValue>> create(EndingShape ending_shape, Size size, PositionValue position, Vector<LinearColorStopListElement> color_stop_list, GradientRepeating repeating)
+    static ValueComparingNonnullRefPtr<RadialGradientStyleValue> create(EndingShape ending_shape, Size size, PositionValue position, Vector<LinearColorStopListElement> color_stop_list, GradientRepeating repeating)
     {
         VERIFY(color_stop_list.size() >= 2);
-        return adopt_nonnull_ref_or_enomem(new (nothrow) RadialGradientStyleValue(ending_shape, size, position, move(color_stop_list), repeating));
+        return adopt_ref(*new (nothrow) RadialGradientStyleValue(ending_shape, size, position, move(color_stop_list), repeating));
     }
 
     virtual ErrorOr<String> to_string() const override;

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/RatioStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/RatioStyleValue.h
@@ -13,9 +13,9 @@ namespace Web::CSS {
 
 class RatioStyleValue final : public StyleValueWithDefaultOperators<RatioStyleValue> {
 public:
-    static ErrorOr<ValueComparingNonnullRefPtr<RatioStyleValue>> create(Ratio ratio)
+    static ValueComparingNonnullRefPtr<RatioStyleValue> create(Ratio ratio)
     {
-        return adopt_nonnull_ref_or_enomem(new (nothrow) RatioStyleValue(move(ratio)));
+        return adopt_ref(*new (nothrow) RatioStyleValue(move(ratio)));
     }
     virtual ~RatioStyleValue() override = default;
 

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/RectStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/RectStyleValue.cpp
@@ -11,9 +11,9 @@
 
 namespace Web::CSS {
 
-ErrorOr<ValueComparingNonnullRefPtr<RectStyleValue>> RectStyleValue::create(EdgeRect rect)
+ValueComparingNonnullRefPtr<RectStyleValue> RectStyleValue::create(EdgeRect rect)
 {
-    return adopt_nonnull_ref_or_enomem(new (nothrow) RectStyleValue(move(rect)));
+    return adopt_ref(*new (nothrow) RectStyleValue(move(rect)));
 }
 
 ErrorOr<String> RectStyleValue::to_string() const

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/RectStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/RectStyleValue.h
@@ -16,7 +16,7 @@ namespace Web::CSS {
 
 class RectStyleValue : public StyleValueWithDefaultOperators<RectStyleValue> {
 public:
-    static ErrorOr<ValueComparingNonnullRefPtr<RectStyleValue>> create(EdgeRect rect);
+    static ValueComparingNonnullRefPtr<RectStyleValue> create(EdgeRect rect);
     virtual ~RectStyleValue() override = default;
 
     EdgeRect rect() const { return m_rect; }

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/ResolutionStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/ResolutionStyleValue.h
@@ -13,9 +13,9 @@ namespace Web::CSS {
 
 class ResolutionStyleValue : public StyleValueWithDefaultOperators<ResolutionStyleValue> {
 public:
-    static ErrorOr<ValueComparingNonnullRefPtr<ResolutionStyleValue>> create(Resolution resolution)
+    static ValueComparingNonnullRefPtr<ResolutionStyleValue> create(Resolution resolution)
     {
-        return adopt_nonnull_ref_or_enomem(new (nothrow) ResolutionStyleValue(move(resolution)));
+        return adopt_ref(*new (nothrow) ResolutionStyleValue(move(resolution)));
     }
     virtual ~ResolutionStyleValue() override = default;
 

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/RevertStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/RevertStyleValue.h
@@ -12,9 +12,9 @@ namespace Web::CSS {
 
 class RevertStyleValue final : public StyleValueWithDefaultOperators<RevertStyleValue> {
 public:
-    static ErrorOr<ValueComparingNonnullRefPtr<RevertStyleValue>> the()
+    static ValueComparingNonnullRefPtr<RevertStyleValue> the()
     {
-        static ValueComparingNonnullRefPtr<RevertStyleValue> instance = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) RevertStyleValue));
+        static ValueComparingNonnullRefPtr<RevertStyleValue> instance = adopt_ref(*new (nothrow) RevertStyleValue);
         return instance;
     }
     virtual ~RevertStyleValue() override = default;

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/ShadowStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/ShadowStyleValue.cpp
@@ -20,12 +20,12 @@ ErrorOr<String> ShadowStyleValue::to_string() const
     return builder.to_string();
 }
 
-ErrorOr<ValueComparingNonnullRefPtr<StyleValue const>> ShadowStyleValue::absolutized(CSSPixelRect const& viewport_rect, Length::FontMetrics const& font_metrics, Length::FontMetrics const& root_font_metrics) const
+ValueComparingNonnullRefPtr<StyleValue const> ShadowStyleValue::absolutized(CSSPixelRect const& viewport_rect, Length::FontMetrics const& font_metrics, Length::FontMetrics const& root_font_metrics) const
 {
-    auto absolutized_offset_x = TRY(m_properties.offset_x->absolutized(viewport_rect, font_metrics, root_font_metrics));
-    auto absolutized_offset_y = TRY(m_properties.offset_y->absolutized(viewport_rect, font_metrics, root_font_metrics));
-    auto absolutized_blur_radius = TRY(m_properties.blur_radius->absolutized(viewport_rect, font_metrics, root_font_metrics));
-    auto absolutized_spread_distance = TRY(m_properties.spread_distance->absolutized(viewport_rect, font_metrics, root_font_metrics));
+    auto absolutized_offset_x = m_properties.offset_x->absolutized(viewport_rect, font_metrics, root_font_metrics);
+    auto absolutized_offset_y = m_properties.offset_y->absolutized(viewport_rect, font_metrics, root_font_metrics);
+    auto absolutized_blur_radius = m_properties.blur_radius->absolutized(viewport_rect, font_metrics, root_font_metrics);
+    auto absolutized_spread_distance = m_properties.spread_distance->absolutized(viewport_rect, font_metrics, root_font_metrics);
     return ShadowStyleValue::create(m_properties.color, absolutized_offset_x, absolutized_offset_y, absolutized_blur_radius, absolutized_spread_distance, m_properties.placement);
 }
 

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/ShadowStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/ShadowStyleValue.h
@@ -65,7 +65,7 @@ private:
     {
     }
 
-    virtual ErrorOr<ValueComparingNonnullRefPtr<StyleValue const>> absolutized(CSSPixelRect const& viewport_rect, Length::FontMetrics const& font_metrics, Length::FontMetrics const& root_font_metrics) const override;
+    virtual ValueComparingNonnullRefPtr<StyleValue const> absolutized(CSSPixelRect const& viewport_rect, Length::FontMetrics const& font_metrics, Length::FontMetrics const& root_font_metrics) const override;
 
     struct Properties {
         Color color;

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/ShadowStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/ShadowStyleValue.h
@@ -22,7 +22,7 @@ enum class ShadowPlacement {
 
 class ShadowStyleValue final : public StyleValueWithDefaultOperators<ShadowStyleValue> {
 public:
-    static ErrorOr<ValueComparingNonnullRefPtr<ShadowStyleValue>> create(
+    static ValueComparingNonnullRefPtr<ShadowStyleValue> create(
         Color color,
         ValueComparingNonnullRefPtr<StyleValue const> offset_x,
         ValueComparingNonnullRefPtr<StyleValue const> offset_y,
@@ -30,7 +30,7 @@ public:
         ValueComparingNonnullRefPtr<StyleValue const> spread_distance,
         ShadowPlacement placement)
     {
-        return adopt_nonnull_ref_or_enomem(new (nothrow) ShadowStyleValue(color, move(offset_x), move(offset_y), move(blur_radius), move(spread_distance), placement));
+        return adopt_ref(*new (nothrow) ShadowStyleValue(color, move(offset_x), move(offset_y), move(blur_radius), move(spread_distance), placement));
     }
     virtual ~ShadowStyleValue() override = default;
 

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/StringStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/StringStyleValue.h
@@ -13,9 +13,9 @@ namespace Web::CSS {
 
 class StringStyleValue : public StyleValueWithDefaultOperators<StringStyleValue> {
 public:
-    static ErrorOr<ValueComparingNonnullRefPtr<StringStyleValue>> create(String const& string)
+    static ValueComparingNonnullRefPtr<StringStyleValue> create(String const& string)
     {
-        return adopt_nonnull_ref_or_enomem(new (nothrow) StringStyleValue(string));
+        return adopt_ref(*new (nothrow) StringStyleValue(string));
     }
     virtual ~StringStyleValue() override = default;
 

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/StyleValueList.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/StyleValueList.h
@@ -19,9 +19,9 @@ public:
         Space,
         Comma,
     };
-    static ErrorOr<ValueComparingNonnullRefPtr<StyleValueList>> create(StyleValueVector&& values, Separator separator)
+    static ValueComparingNonnullRefPtr<StyleValueList> create(StyleValueVector&& values, Separator separator)
     {
-        return adopt_nonnull_ref_or_enomem(new (nothrow) StyleValueList(move(values), separator));
+        return adopt_ref(*new (nothrow) StyleValueList(move(values), separator));
     }
 
     size_t size() const { return m_properties.values.size(); }

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/TextDecorationStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/TextDecorationStyleValue.h
@@ -15,13 +15,13 @@ namespace Web::CSS {
 
 class TextDecorationStyleValue final : public StyleValueWithDefaultOperators<TextDecorationStyleValue> {
 public:
-    static ErrorOr<ValueComparingNonnullRefPtr<TextDecorationStyleValue>> create(
+    static ValueComparingNonnullRefPtr<TextDecorationStyleValue> create(
         ValueComparingNonnullRefPtr<StyleValue> line,
         ValueComparingNonnullRefPtr<StyleValue> thickness,
         ValueComparingNonnullRefPtr<StyleValue> style,
         ValueComparingNonnullRefPtr<StyleValue> color)
     {
-        return adopt_nonnull_ref_or_enomem(new (nothrow) TextDecorationStyleValue(move(line), move(thickness), move(style), move(color)));
+        return adopt_ref(*new (nothrow) TextDecorationStyleValue(move(line), move(thickness), move(style), move(color)));
     }
     virtual ~TextDecorationStyleValue() override = default;
 

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/TimeStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/TimeStyleValue.h
@@ -16,9 +16,9 @@ namespace Web::CSS {
 
 class TimeStyleValue : public StyleValueWithDefaultOperators<TimeStyleValue> {
 public:
-    static ErrorOr<ValueComparingNonnullRefPtr<TimeStyleValue>> create(Time time)
+    static ValueComparingNonnullRefPtr<TimeStyleValue> create(Time time)
     {
-        return adopt_nonnull_ref_or_enomem(new (nothrow) TimeStyleValue(move(time)));
+        return adopt_ref(*new (nothrow) TimeStyleValue(move(time)));
     }
     virtual ~TimeStyleValue() override = default;
 

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/TransformationStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/TransformationStyleValue.h
@@ -16,9 +16,9 @@ namespace Web::CSS {
 
 class TransformationStyleValue final : public StyleValueWithDefaultOperators<TransformationStyleValue> {
 public:
-    static ErrorOr<ValueComparingNonnullRefPtr<TransformationStyleValue>> create(CSS::TransformFunction transform_function, StyleValueVector&& values)
+    static ValueComparingNonnullRefPtr<TransformationStyleValue> create(CSS::TransformFunction transform_function, StyleValueVector&& values)
     {
-        return adopt_nonnull_ref_or_enomem(new (nothrow) TransformationStyleValue(transform_function, move(values)));
+        return adopt_ref(*new (nothrow) TransformationStyleValue(transform_function, move(values)));
     }
     virtual ~TransformationStyleValue() override = default;
 

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/URLStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/URLStyleValue.h
@@ -14,9 +14,9 @@ namespace Web::CSS {
 
 class URLStyleValue final : public StyleValueWithDefaultOperators<URLStyleValue> {
 public:
-    static ErrorOr<ValueComparingNonnullRefPtr<URLStyleValue>> create(AK::URL const& url)
+    static ValueComparingNonnullRefPtr<URLStyleValue> create(AK::URL const& url)
     {
-        return adopt_nonnull_ref_or_enomem(new (nothrow) URLStyleValue(url));
+        return adopt_ref(*new (nothrow) URLStyleValue(url));
     }
 
     virtual ~URLStyleValue() override = default;

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/UnresolvedStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/UnresolvedStyleValue.h
@@ -17,9 +17,9 @@ namespace Web::CSS {
 
 class UnresolvedStyleValue final : public StyleValue {
 public:
-    static ErrorOr<ValueComparingNonnullRefPtr<UnresolvedStyleValue>> create(Vector<Parser::ComponentValue>&& values, bool contains_var_or_attr)
+    static ValueComparingNonnullRefPtr<UnresolvedStyleValue> create(Vector<Parser::ComponentValue>&& values, bool contains_var_or_attr)
     {
-        return adopt_nonnull_ref_or_enomem(new (nothrow) UnresolvedStyleValue(move(values), contains_var_or_attr));
+        return adopt_ref(*new (nothrow) UnresolvedStyleValue(move(values), contains_var_or_attr));
     }
     virtual ~UnresolvedStyleValue() override = default;
 

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/UnsetStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/UnsetStyleValue.h
@@ -15,9 +15,9 @@ namespace Web::CSS {
 
 class UnsetStyleValue final : public StyleValueWithDefaultOperators<UnsetStyleValue> {
 public:
-    static ErrorOr<ValueComparingNonnullRefPtr<UnsetStyleValue>> the()
+    static ValueComparingNonnullRefPtr<UnsetStyleValue> the()
     {
-        static ValueComparingNonnullRefPtr<UnsetStyleValue> instance = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) UnsetStyleValue));
+        static ValueComparingNonnullRefPtr<UnsetStyleValue> instance = adopt_ref(*new (nothrow) UnsetStyleValue);
         return instance;
     }
     virtual ~UnsetStyleValue() override = default;

--- a/Userland/Libraries/LibWeb/HTML/Canvas/CanvasTextDrawingStyles.h
+++ b/Userland/Libraries/LibWeb/HTML/Canvas/CanvasTextDrawingStyles.h
@@ -45,10 +45,10 @@ public:
         auto font_style_value_result = parse_css_value(parsing_context, font, CSS::PropertyID::Font);
 
         // If the new value is syntactically incorrect (including using property-independent style sheet syntax like 'inherit' or 'initial'), then it must be ignored, without assigning a new font value.
-        if (font_style_value_result.is_error() || !font_style_value_result.value()) {
+        if (!font_style_value_result) {
             return;
         }
-        my_drawing_state().font_style_value = font_style_value_result.value();
+        my_drawing_state().font_style_value = font_style_value_result.release_nonnull();
 
         // Load font with font style value properties
         auto const& font_style_value = my_drawing_state().font_style_value->as_font();

--- a/Userland/Libraries/LibWeb/HTML/HTMLBodyElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLBodyElement.cpp
@@ -35,12 +35,12 @@ void HTMLBodyElement::apply_presentational_hints(CSS::StyleProperties& style) co
             // https://html.spec.whatwg.org/multipage/rendering.html#the-page:rules-for-parsing-a-legacy-colour-value
             auto color = parse_legacy_color_value(value);
             if (color.has_value())
-                style.set_property(CSS::PropertyID::BackgroundColor, CSS::ColorStyleValue::create(color.value()).release_value_but_fixme_should_propagate_errors(), nullptr);
+                style.set_property(CSS::PropertyID::BackgroundColor, CSS::ColorStyleValue::create(color.value()), nullptr);
         } else if (name.equals_ignoring_ascii_case("text"sv)) {
             // https://html.spec.whatwg.org/multipage/rendering.html#the-page:rules-for-parsing-a-legacy-colour-value-2
             auto color = parse_legacy_color_value(value);
             if (color.has_value())
-                style.set_property(CSS::PropertyID::Color, CSS::ColorStyleValue::create(color.value()).release_value_but_fixme_should_propagate_errors(), nullptr);
+                style.set_property(CSS::PropertyID::Color, CSS::ColorStyleValue::create(color.value()), nullptr);
         } else if (name.equals_ignoring_ascii_case("background"sv)) {
             VERIFY(m_background_style_value);
             style.set_property(CSS::PropertyID::BackgroundImage, *m_background_style_value, nullptr);
@@ -67,7 +67,7 @@ void HTMLBodyElement::attribute_changed(DeprecatedFlyString const& name, Depreca
         if (color.has_value())
             document().set_visited_link_color(color.value());
     } else if (name.equals_ignoring_ascii_case("background"sv)) {
-        m_background_style_value = CSS::ImageStyleValue::create(document().parse_url(value)).release_value_but_fixme_should_propagate_errors();
+        m_background_style_value = CSS::ImageStyleValue::create(document().parse_url(value));
         m_background_style_value->on_animate = [this] {
             if (layout_node()) {
                 layout_node()->set_needs_display();

--- a/Userland/Libraries/LibWeb/HTML/HTMLDivElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLDivElement.cpp
@@ -24,13 +24,13 @@ void HTMLDivElement::apply_presentational_hints(CSS::StyleProperties& style) con
     for_each_attribute([&](auto& name, auto& value) {
         if (name.equals_ignoring_ascii_case("align"sv)) {
             if (value.equals_ignoring_ascii_case("left"sv))
-                style.set_property(CSS::PropertyID::TextAlign, CSS::IdentifierStyleValue::create(CSS::ValueID::LibwebLeft).release_value_but_fixme_should_propagate_errors());
+                style.set_property(CSS::PropertyID::TextAlign, CSS::IdentifierStyleValue::create(CSS::ValueID::LibwebLeft));
             else if (value.equals_ignoring_ascii_case("right"sv))
-                style.set_property(CSS::PropertyID::TextAlign, CSS::IdentifierStyleValue::create(CSS::ValueID::LibwebRight).release_value_but_fixme_should_propagate_errors());
+                style.set_property(CSS::PropertyID::TextAlign, CSS::IdentifierStyleValue::create(CSS::ValueID::LibwebRight));
             else if (value.equals_ignoring_ascii_case("center"sv))
-                style.set_property(CSS::PropertyID::TextAlign, CSS::IdentifierStyleValue::create(CSS::ValueID::LibwebCenter).release_value_but_fixme_should_propagate_errors());
+                style.set_property(CSS::PropertyID::TextAlign, CSS::IdentifierStyleValue::create(CSS::ValueID::LibwebCenter));
             else if (value.equals_ignoring_ascii_case("justify"sv))
-                style.set_property(CSS::PropertyID::TextAlign, CSS::IdentifierStyleValue::create(CSS::ValueID::Justify).release_value_but_fixme_should_propagate_errors());
+                style.set_property(CSS::PropertyID::TextAlign, CSS::IdentifierStyleValue::create(CSS::ValueID::Justify));
         }
     });
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLFontElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFontElement.cpp
@@ -32,7 +32,7 @@ void HTMLFontElement::apply_presentational_hints(CSS::StyleProperties& style) co
             // https://html.spec.whatwg.org/multipage/rendering.html#phrasing-content-3:rules-for-parsing-a-legacy-colour-value
             auto color = parse_legacy_color_value(value);
             if (color.has_value())
-                style.set_property(CSS::PropertyID::Color, CSS::ColorStyleValue::create(color.value()).release_value_but_fixme_should_propagate_errors());
+                style.set_property(CSS::PropertyID::Color, CSS::ColorStyleValue::create(color.value()));
         }
     });
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLHeadingElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLHeadingElement.cpp
@@ -31,13 +31,13 @@ void HTMLHeadingElement::apply_presentational_hints(CSS::StyleProperties& style)
     for_each_attribute([&](auto& name, auto& value) {
         if (name.equals_ignoring_ascii_case("align"sv)) {
             if (value == "left"sv)
-                style.set_property(CSS::PropertyID::TextAlign, CSS::IdentifierStyleValue::create(CSS::ValueID::Left).release_value_but_fixme_should_propagate_errors());
+                style.set_property(CSS::PropertyID::TextAlign, CSS::IdentifierStyleValue::create(CSS::ValueID::Left));
             else if (value == "right"sv)
-                style.set_property(CSS::PropertyID::TextAlign, CSS::IdentifierStyleValue::create(CSS::ValueID::Right).release_value_but_fixme_should_propagate_errors());
+                style.set_property(CSS::PropertyID::TextAlign, CSS::IdentifierStyleValue::create(CSS::ValueID::Right));
             else if (value == "center"sv)
-                style.set_property(CSS::PropertyID::TextAlign, CSS::IdentifierStyleValue::create(CSS::ValueID::Center).release_value_but_fixme_should_propagate_errors());
+                style.set_property(CSS::PropertyID::TextAlign, CSS::IdentifierStyleValue::create(CSS::ValueID::Center));
             else if (value == "justify"sv)
-                style.set_property(CSS::PropertyID::TextAlign, CSS::IdentifierStyleValue::create(CSS::ValueID::Justify).release_value_but_fixme_should_propagate_errors());
+                style.set_property(CSS::PropertyID::TextAlign, CSS::IdentifierStyleValue::create(CSS::ValueID::Justify));
         }
     });
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -80,7 +80,7 @@ JS::GCPtr<Layout::Node> HTMLInputElement::create_layout_node(NonnullRefPtr<CSS::
     // AD-HOC: We rewrite `display: inline` to `display: inline-block`.
     //         This is required for the internal shadow tree to work correctly in layout.
     if (style->display().is_inline_outside() && style->display().is_flow_inside())
-        style->set_property(CSS::PropertyID::Display, CSS::DisplayStyleValue::create(CSS::Display::from_short(CSS::Display::Short::InlineBlock)).release_value_but_fixme_should_propagate_errors());
+        style->set_property(CSS::PropertyID::Display, CSS::DisplayStyleValue::create(CSS::Display::from_short(CSS::Display::Short::InlineBlock)));
 
     return Element::create_layout_node_for_display_type(document(), style->display(), style, this);
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLMarqueeElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMarqueeElement.cpp
@@ -33,7 +33,7 @@ void HTMLMarqueeElement::apply_presentational_hints(CSS::StyleProperties& style)
             // https://html.spec.whatwg.org/multipage/rendering.html#the-marquee-element-2:rules-for-parsing-a-legacy-colour-value
             auto color = parse_legacy_color_value(value);
             if (color.has_value())
-                style.set_property(CSS::PropertyID::BackgroundColor, CSS::ColorStyleValue::create(color.value()).release_value_but_fixme_should_propagate_errors());
+                style.set_property(CSS::PropertyID::BackgroundColor, CSS::ColorStyleValue::create(color.value()));
         }
     });
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLParagraphElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLParagraphElement.cpp
@@ -31,13 +31,13 @@ void HTMLParagraphElement::apply_presentational_hints(CSS::StyleProperties& styl
     for_each_attribute([&](auto& name, auto& value) {
         if (name.equals_ignoring_ascii_case("align"sv)) {
             if (value == "left"sv)
-                style.set_property(CSS::PropertyID::TextAlign, CSS::IdentifierStyleValue::create(CSS::ValueID::Left).release_value_but_fixme_should_propagate_errors());
+                style.set_property(CSS::PropertyID::TextAlign, CSS::IdentifierStyleValue::create(CSS::ValueID::Left));
             else if (value == "right"sv)
-                style.set_property(CSS::PropertyID::TextAlign, CSS::IdentifierStyleValue::create(CSS::ValueID::Right).release_value_but_fixme_should_propagate_errors());
+                style.set_property(CSS::PropertyID::TextAlign, CSS::IdentifierStyleValue::create(CSS::ValueID::Right));
             else if (value == "center"sv)
-                style.set_property(CSS::PropertyID::TextAlign, CSS::IdentifierStyleValue::create(CSS::ValueID::Center).release_value_but_fixme_should_propagate_errors());
+                style.set_property(CSS::PropertyID::TextAlign, CSS::IdentifierStyleValue::create(CSS::ValueID::Center));
             else if (value == "justify"sv)
-                style.set_property(CSS::PropertyID::TextAlign, CSS::IdentifierStyleValue::create(CSS::ValueID::Justify).release_value_but_fixme_should_propagate_errors());
+                style.set_property(CSS::PropertyID::TextAlign, CSS::IdentifierStyleValue::create(CSS::ValueID::Justify));
         }
     });
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLPreElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLPreElement.cpp
@@ -30,7 +30,7 @@ void HTMLPreElement::apply_presentational_hints(CSS::StyleProperties& style) con
 
     for_each_attribute([&](auto const& name, auto const&) {
         if (name.equals_ignoring_ascii_case(HTML::AttributeNames::wrap))
-            style.set_property(CSS::PropertyID::WhiteSpace, CSS::IdentifierStyleValue::create(CSS::ValueID::PreWrap).release_value_but_fixme_should_propagate_errors());
+            style.set_property(CSS::PropertyID::WhiteSpace, CSS::IdentifierStyleValue::create(CSS::ValueID::PreWrap));
     });
 }
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLTableCaptionElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableCaptionElement.cpp
@@ -31,7 +31,7 @@ void HTMLTableCaptionElement::apply_presentational_hints(CSS::StyleProperties& s
     for_each_attribute([&](auto& name, auto& value) {
         if (name.equals_ignoring_ascii_case("align"sv)) {
             if (value == "bottom"sv)
-                style.set_property(CSS::PropertyID::CaptionSide, CSS::IdentifierStyleValue::create(CSS::ValueID::Bottom).release_value_but_fixme_should_propagate_errors());
+                style.set_property(CSS::PropertyID::CaptionSide, CSS::IdentifierStyleValue::create(CSS::ValueID::Bottom));
         }
     });
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLTableCellElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableCellElement.cpp
@@ -40,7 +40,7 @@ void HTMLTableCellElement::apply_presentational_hints(CSS::StyleProperties& styl
             return;
         }
         if (name == HTML::AttributeNames::valign) {
-            if (auto parsed_value = parse_css_value(CSS::Parser::ParsingContext { document() }, value.view(), CSS::PropertyID::VerticalAlign).release_value_but_fixme_should_propagate_errors())
+            if (auto parsed_value = parse_css_value(CSS::Parser::ParsingContext { document() }, value.view(), CSS::PropertyID::VerticalAlign))
                 style.set_property(CSS::PropertyID::VerticalAlign, parsed_value.release_nonnull());
             return;
         }
@@ -48,7 +48,7 @@ void HTMLTableCellElement::apply_presentational_hints(CSS::StyleProperties& styl
             if (value.equals_ignoring_ascii_case("center"sv) || value.equals_ignoring_ascii_case("middle"sv)) {
                 style.set_property(CSS::PropertyID::TextAlign, CSS::IdentifierStyleValue::create(CSS::ValueID::LibwebCenter));
             } else {
-                if (auto parsed_value = parse_css_value(CSS::Parser::ParsingContext { document() }, value.view(), CSS::PropertyID::TextAlign).release_value_but_fixme_should_propagate_errors())
+                if (auto parsed_value = parse_css_value(CSS::Parser::ParsingContext { document() }, value.view(), CSS::PropertyID::TextAlign))
                     style.set_property(CSS::PropertyID::TextAlign, parsed_value.release_nonnull());
             }
             return;

--- a/Userland/Libraries/LibWeb/HTML/HTMLTableCellElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableCellElement.cpp
@@ -36,7 +36,7 @@ void HTMLTableCellElement::apply_presentational_hints(CSS::StyleProperties& styl
             // https://html.spec.whatwg.org/multipage/rendering.html#tables-2:rules-for-parsing-a-legacy-colour-value
             auto color = parse_legacy_color_value(value);
             if (color.has_value())
-                style.set_property(CSS::PropertyID::BackgroundColor, CSS::ColorStyleValue::create(color.value()).release_value_but_fixme_should_propagate_errors());
+                style.set_property(CSS::PropertyID::BackgroundColor, CSS::ColorStyleValue::create(color.value()));
             return;
         }
         if (name == HTML::AttributeNames::valign) {
@@ -46,7 +46,7 @@ void HTMLTableCellElement::apply_presentational_hints(CSS::StyleProperties& styl
         }
         if (name == HTML::AttributeNames::align) {
             if (value.equals_ignoring_ascii_case("center"sv) || value.equals_ignoring_ascii_case("middle"sv)) {
-                style.set_property(CSS::PropertyID::TextAlign, CSS::IdentifierStyleValue::create(CSS::ValueID::LibwebCenter).release_value_but_fixme_should_propagate_errors());
+                style.set_property(CSS::PropertyID::TextAlign, CSS::IdentifierStyleValue::create(CSS::ValueID::LibwebCenter));
             } else {
                 if (auto parsed_value = parse_css_value(CSS::Parser::ParsingContext { document() }, value.view(), CSS::PropertyID::TextAlign).release_value_but_fixme_should_propagate_errors())
                     style.set_property(CSS::PropertyID::TextAlign, parsed_value.release_nonnull());
@@ -63,7 +63,7 @@ void HTMLTableCellElement::apply_presentational_hints(CSS::StyleProperties& styl
             return;
         } else if (name == HTML::AttributeNames::background) {
             if (auto parsed_value = document().parse_url(value); parsed_value.is_valid())
-                style.set_property(CSS::PropertyID::BackgroundImage, CSS::ImageStyleValue::create(parsed_value).release_value_but_fixme_should_propagate_errors());
+                style.set_property(CSS::PropertyID::BackgroundImage, CSS::ImageStyleValue::create(parsed_value));
             return;
         }
     });

--- a/Userland/Libraries/LibWeb/HTML/HTMLTableElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableElement.cpp
@@ -56,7 +56,7 @@ void HTMLTableElement::apply_presentational_hints(CSS::StyleProperties& style) c
             // https://html.spec.whatwg.org/multipage/rendering.html#tables-2:rules-for-parsing-a-legacy-colour-value
             auto color = parse_legacy_color_value(value);
             if (color.has_value())
-                style.set_property(CSS::PropertyID::BackgroundColor, CSS::ColorStyleValue::create(color.value()).release_value_but_fixme_should_propagate_errors());
+                style.set_property(CSS::PropertyID::BackgroundColor, CSS::ColorStyleValue::create(color.value()));
             return;
         }
         if (name == HTML::AttributeNames::cellspacing) {

--- a/Userland/Libraries/LibWeb/HTML/HTMLTableRowElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableRowElement.cpp
@@ -41,11 +41,11 @@ void HTMLTableRowElement::apply_presentational_hints(CSS::StyleProperties& style
             // https://html.spec.whatwg.org/multipage/rendering.html#tables-2:rules-for-parsing-a-legacy-colour-value
             auto color = parse_legacy_color_value(value);
             if (color.has_value())
-                style.set_property(CSS::PropertyID::BackgroundColor, CSS::ColorStyleValue::create(color.value()).release_value_but_fixme_should_propagate_errors());
+                style.set_property(CSS::PropertyID::BackgroundColor, CSS::ColorStyleValue::create(color.value()));
             return;
         } else if (name == HTML::AttributeNames::background) {
             if (auto parsed_value = document().parse_url(value); parsed_value.is_valid())
-                style.set_property(CSS::PropertyID::BackgroundImage, CSS::ImageStyleValue::create(parsed_value).release_value_but_fixme_should_propagate_errors());
+                style.set_property(CSS::PropertyID::BackgroundImage, CSS::ImageStyleValue::create(parsed_value));
             return;
         }
     });

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
@@ -3993,14 +3993,14 @@ static RefPtr<CSS::StyleValue> parse_current_dimension_value(float value, Utf8Vi
 {
     // 1. If position is past the end of input, then return value as a length.
     if (position == input.end())
-        return CSS::LengthStyleValue::create(CSS::Length::make_px(value)).release_value_but_fixme_should_propagate_errors();
+        return CSS::LengthStyleValue::create(CSS::Length::make_px(value));
 
     // 2. If the code point at position within input is U+0025 (%), then return value as a percentage.
     if (*position == '%')
-        return CSS::PercentageStyleValue::create(CSS::Percentage(value)).release_value_but_fixme_should_propagate_errors();
+        return CSS::PercentageStyleValue::create(CSS::Percentage(value));
 
     // 3. Return value as a length.
-    return CSS::LengthStyleValue::create(CSS::Length::make_px(value)).release_value_but_fixme_should_propagate_errors();
+    return CSS::LengthStyleValue::create(CSS::Length::make_px(value));
 }
 
 // https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#rules-for-parsing-dimension-values
@@ -4034,7 +4034,7 @@ RefPtr<CSS::StyleValue> parse_dimension_value(StringView string)
 
     // 6. If position is past the end of input, then return value as a length.
     if (position == input.end())
-        return CSS::LengthStyleValue::create(CSS::Length::make_px(*integer_value)).release_value_but_fixme_should_propagate_errors();
+        return CSS::LengthStyleValue::create(CSS::Length::make_px(*integer_value));
 
     float value = *integer_value;
 
@@ -4065,7 +4065,7 @@ RefPtr<CSS::StyleValue> parse_dimension_value(StringView string)
 
             // 4. If position is past the end of input, then return value as a length.
             if (position == input.end())
-                return CSS::LengthStyleValue::create(CSS::Length::make_px(value)).release_value_but_fixme_should_propagate_errors();
+                return CSS::LengthStyleValue::create(CSS::Length::make_px(value));
 
             // 5. If the code point at position within input is not an ASCII digit, then break.
             if (!is_ascii_digit(*position))

--- a/Userland/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -352,11 +352,11 @@ ErrorOr<void> TreeBuilder::create_layout_tree(DOM::Node& dom_node, TreeBuilder::
         auto& progress = static_cast<HTML::HTMLProgressElement&>(dom_node);
         if (!progress.using_system_appearance()) {
             auto bar_style = TRY(style_computer.compute_style(progress, CSS::Selector::PseudoElement::ProgressBar));
-            bar_style->set_property(CSS::PropertyID::Display, CSS::DisplayStyleValue::create(CSS::Display::from_short(CSS::Display::Short::FlowRoot)).release_value_but_fixme_should_propagate_errors());
+            bar_style->set_property(CSS::PropertyID::Display, CSS::DisplayStyleValue::create(CSS::Display::from_short(CSS::Display::Short::FlowRoot)));
             auto value_style = TRY(style_computer.compute_style(progress, CSS::Selector::PseudoElement::ProgressValue));
-            value_style->set_property(CSS::PropertyID::Display, CSS::DisplayStyleValue::create(CSS::Display::from_short(CSS::Display::Short::Block)).release_value_but_fixme_should_propagate_errors());
+            value_style->set_property(CSS::PropertyID::Display, CSS::DisplayStyleValue::create(CSS::Display::from_short(CSS::Display::Short::Block)));
             auto position = progress.position();
-            value_style->set_property(CSS::PropertyID::Width, CSS::PercentageStyleValue::create(CSS::Percentage(position >= 0 ? round_to<int>(100 * position) : 0)).release_value_but_fixme_should_propagate_errors());
+            value_style->set_property(CSS::PropertyID::Width, CSS::PercentageStyleValue::create(CSS::Percentage(position >= 0 ? round_to<int>(100 * position) : 0)));
             auto bar_display = bar_style->display();
             auto value_display = value_style->display();
             auto progress_bar = DOM::Element::create_layout_node_for_display_type(document, bar_display, bar_style, nullptr);

--- a/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -396,7 +396,7 @@ Gfx::FloatMatrix4x4 StackingContext::get_transformation_matrix(CSS::Transformati
                 0, 0, 0, 1);
         break;
     default:
-        dbgln_if(LIBWEB_CSS_DEBUG, "FIXME: Unhandled transformation function {}", MUST(CSS::TransformationStyleValue::create(transformation.function, {}))->to_string());
+        dbgln_if(LIBWEB_CSS_DEBUG, "FIXME: Unhandled transformation function {}", CSS::TransformationStyleValue::create(transformation.function, {})->to_string());
     }
     return Gfx::FloatMatrix4x4::identity();
 }

--- a/Userland/Libraries/LibWeb/SVG/SVGForeignObjectElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGForeignObjectElement.cpp
@@ -52,10 +52,10 @@ void SVGForeignObjectElement::apply_presentational_hints(CSS::StyleProperties& s
 {
     Base::apply_presentational_hints(style);
     auto parsing_context = CSS::Parser::ParsingContext { document() };
-    if (auto width_value = parse_css_value(parsing_context, attribute(Web::HTML::AttributeNames::width), CSS::PropertyID::Width).release_value_but_fixme_should_propagate_errors())
+    if (auto width_value = parse_css_value(parsing_context, attribute(Web::HTML::AttributeNames::width), CSS::PropertyID::Width))
         style.set_property(CSS::PropertyID::Width, width_value.release_nonnull());
 
-    if (auto height_value = parse_css_value(parsing_context, attribute(Web::HTML::AttributeNames::height), CSS::PropertyID::Height).release_value_but_fixme_should_propagate_errors())
+    if (auto height_value = parse_css_value(parsing_context, attribute(Web::HTML::AttributeNames::height), CSS::PropertyID::Height))
         style.set_property(CSS::PropertyID::Height, height_value.release_nonnull());
 }
 

--- a/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
@@ -125,32 +125,32 @@ void SVGGraphicsElement::apply_presentational_hints(CSS::StyleProperties& style)
     for_each_attribute([&](auto& name, auto& value) {
         if (name.equals_ignoring_ascii_case("fill"sv)) {
             // FIXME: The `fill` attribute and CSS `fill` property are not the same! But our support is limited enough that they are equivalent for now.
-            if (auto fill_value = parse_css_value(parsing_context, value, CSS::PropertyID::Fill).release_value_but_fixme_should_propagate_errors())
+            if (auto fill_value = parse_css_value(parsing_context, value, CSS::PropertyID::Fill))
                 style.set_property(CSS::PropertyID::Fill, fill_value.release_nonnull());
         } else if (name.equals_ignoring_ascii_case("stroke"sv)) {
             // FIXME: The `stroke` attribute and CSS `stroke` property are not the same! But our support is limited enough that they are equivalent for now.
-            if (auto stroke_value = parse_css_value(parsing_context, value, CSS::PropertyID::Stroke).release_value_but_fixme_should_propagate_errors())
+            if (auto stroke_value = parse_css_value(parsing_context, value, CSS::PropertyID::Stroke))
                 style.set_property(CSS::PropertyID::Stroke, stroke_value.release_nonnull());
         } else if (name.equals_ignoring_ascii_case("stroke-width"sv)) {
-            if (auto stroke_width_value = parse_css_value(parsing_context, value, CSS::PropertyID::StrokeWidth).release_value_but_fixme_should_propagate_errors())
+            if (auto stroke_width_value = parse_css_value(parsing_context, value, CSS::PropertyID::StrokeWidth))
                 style.set_property(CSS::PropertyID::StrokeWidth, stroke_width_value.release_nonnull());
         } else if (name.equals_ignoring_ascii_case("fill-rule"sv)) {
-            if (auto fill_rule_value = parse_css_value(parsing_context, value, CSS::PropertyID::FillRule).release_value_but_fixme_should_propagate_errors())
+            if (auto fill_rule_value = parse_css_value(parsing_context, value, CSS::PropertyID::FillRule))
                 style.set_property(CSS::PropertyID::FillRule, fill_rule_value.release_nonnull());
         } else if (name.equals_ignoring_ascii_case("fill-opacity"sv)) {
-            if (auto fill_opacity_value = parse_css_value(parsing_context, value, CSS::PropertyID::FillOpacity).release_value_but_fixme_should_propagate_errors())
+            if (auto fill_opacity_value = parse_css_value(parsing_context, value, CSS::PropertyID::FillOpacity))
                 style.set_property(CSS::PropertyID::FillOpacity, fill_opacity_value.release_nonnull());
         } else if (name.equals_ignoring_ascii_case("stroke-opacity"sv)) {
-            if (auto stroke_opacity_value = parse_css_value(parsing_context, value, CSS::PropertyID::StrokeOpacity).release_value_but_fixme_should_propagate_errors())
+            if (auto stroke_opacity_value = parse_css_value(parsing_context, value, CSS::PropertyID::StrokeOpacity))
                 style.set_property(CSS::PropertyID::StrokeOpacity, stroke_opacity_value.release_nonnull());
         } else if (name.equals_ignoring_ascii_case(SVG::AttributeNames::opacity)) {
-            if (auto opacity_value = parse_css_value(parsing_context, value, CSS::PropertyID::Opacity).release_value_but_fixme_should_propagate_errors())
+            if (auto opacity_value = parse_css_value(parsing_context, value, CSS::PropertyID::Opacity))
                 style.set_property(CSS::PropertyID::Opacity, opacity_value.release_nonnull());
         } else if (name.equals_ignoring_ascii_case("text-anchor"sv)) {
-            if (auto text_anchor_value = parse_css_value(parsing_context, value, CSS::PropertyID::TextAnchor).release_value_but_fixme_should_propagate_errors())
+            if (auto text_anchor_value = parse_css_value(parsing_context, value, CSS::PropertyID::TextAnchor))
                 style.set_property(CSS::PropertyID::TextAnchor, text_anchor_value.release_nonnull());
         } else if (name.equals_ignoring_ascii_case("font-size"sv)) {
-            if (auto font_size_value = parse_css_value(parsing_context, value, CSS::PropertyID::FontSize).release_value_but_fixme_should_propagate_errors())
+            if (auto font_size_value = parse_css_value(parsing_context, value, CSS::PropertyID::FontSize))
                 style.set_property(CSS::PropertyID::FontSize, font_size_value.release_nonnull());
         }
     });

--- a/Userland/Libraries/LibWeb/SVG/SVGSVGElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGSVGElement.cpp
@@ -49,7 +49,7 @@ void SVGSVGElement::apply_presentational_hints(CSS::StyleProperties& style) cons
         // If the `width` attribute is an empty string, it defaults to 100%.
         // This matches WebKit and Blink, but not Firefox. The spec is unclear.
         // FIXME: Figure out what to do here.
-        style.set_property(CSS::PropertyID::Width, CSS::PercentageStyleValue::create(CSS::Percentage { 100 }).release_value_but_fixme_should_propagate_errors());
+        style.set_property(CSS::PropertyID::Width, CSS::PercentageStyleValue::create(CSS::Percentage { 100 }));
     }
 
     // Height defaults to 100%
@@ -60,7 +60,7 @@ void SVGSVGElement::apply_presentational_hints(CSS::StyleProperties& style) cons
         // If the `height` attribute is an empty string, it defaults to 100%.
         // This matches WebKit and Blink, but not Firefox. The spec is unclear.
         // FIXME: Figure out what to do here.
-        style.set_property(CSS::PropertyID::Height, CSS::PercentageStyleValue::create(CSS::Percentage { 100 }).release_value_but_fixme_should_propagate_errors());
+        style.set_property(CSS::PropertyID::Height, CSS::PercentageStyleValue::create(CSS::Percentage { 100 }));
     }
 }
 

--- a/Userland/Libraries/LibWeb/SVG/SVGSVGElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGSVGElement.cpp
@@ -43,7 +43,7 @@ void SVGSVGElement::apply_presentational_hints(CSS::StyleProperties& style) cons
 
     auto width_attribute = attribute(SVG::AttributeNames::width);
     auto parsing_context = CSS::Parser::ParsingContext { document() };
-    if (auto width_value = parse_css_value(parsing_context, attribute(Web::HTML::AttributeNames::width), CSS::PropertyID::Width).release_value_but_fixme_should_propagate_errors()) {
+    if (auto width_value = parse_css_value(parsing_context, attribute(Web::HTML::AttributeNames::width), CSS::PropertyID::Width)) {
         style.set_property(CSS::PropertyID::Width, width_value.release_nonnull());
     } else if (width_attribute == "") {
         // If the `width` attribute is an empty string, it defaults to 100%.
@@ -54,7 +54,7 @@ void SVGSVGElement::apply_presentational_hints(CSS::StyleProperties& style) cons
 
     // Height defaults to 100%
     auto height_attribute = attribute(SVG::AttributeNames::height);
-    if (auto height_value = parse_css_value(parsing_context, attribute(Web::HTML::AttributeNames::height), CSS::PropertyID::Height).release_value_but_fixme_should_propagate_errors()) {
+    if (auto height_value = parse_css_value(parsing_context, attribute(Web::HTML::AttributeNames::height), CSS::PropertyID::Height)) {
         style.set_property(CSS::PropertyID::Height, height_value.release_nonnull());
     } else if (height_attribute == "") {
         // If the `height` attribute is an empty string, it defaults to 100%.
@@ -87,13 +87,13 @@ void SVGSVGElement::update_fallback_view_box_for_svg_as_image()
 
     auto width_attribute = attribute(SVG::AttributeNames::width);
     auto parsing_context = CSS::Parser::ParsingContext { document() };
-    if (auto width_value = parse_css_value(parsing_context, attribute(Web::HTML::AttributeNames::width), CSS::PropertyID::Width).release_value_but_fixme_should_propagate_errors()) {
+    if (auto width_value = parse_css_value(parsing_context, attribute(Web::HTML::AttributeNames::width), CSS::PropertyID::Width)) {
         if (width_value->is_length() && width_value->as_length().length().is_absolute())
             width = width_value->as_length().length().absolute_length_to_px().to_double();
     }
 
     auto height_attribute = attribute(SVG::AttributeNames::height);
-    if (auto height_value = parse_css_value(parsing_context, attribute(Web::HTML::AttributeNames::height), CSS::PropertyID::Height).release_value_but_fixme_should_propagate_errors()) {
+    if (auto height_value = parse_css_value(parsing_context, attribute(Web::HTML::AttributeNames::height), CSS::PropertyID::Height)) {
         if (height_value->is_length() && height_value->as_length().length().is_absolute())
             height = height_value->as_length().length().absolute_length_to_px().to_double();
     }

--- a/Userland/Libraries/LibWeb/SVG/SVGStopElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGStopElement.cpp
@@ -33,11 +33,11 @@ void SVGStopElement::apply_presentational_hints(CSS::StyleProperties& style) con
     for_each_attribute([&](auto& name, auto& value) {
         CSS::Parser::ParsingContext parsing_context { document() };
         if (name.equals_ignoring_ascii_case("stop-color"sv)) {
-            if (auto stop_color = parse_css_value(parsing_context, value, CSS::PropertyID::StopColor).release_value_but_fixme_should_propagate_errors()) {
+            if (auto stop_color = parse_css_value(parsing_context, value, CSS::PropertyID::StopColor)) {
                 style.set_property(CSS::PropertyID::StopColor, stop_color.release_nonnull());
             }
         } else if (name.equals_ignoring_ascii_case("stop-opacity"sv)) {
-            if (auto stop_opacity = parse_css_value(parsing_context, value, CSS::PropertyID::StopOpacity).release_value_but_fixme_should_propagate_errors()) {
+            if (auto stop_opacity = parse_css_value(parsing_context, value, CSS::PropertyID::StopOpacity)) {
                 style.set_property(CSS::PropertyID::StopOpacity, stop_opacity.release_nonnull());
             }
         }

--- a/Userland/Libraries/LibWeb/SVG/SVGSymbolElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGSymbolElement.cpp
@@ -31,17 +31,17 @@ void SVGSymbolElement::initialize(JS::Realm& realm)
 void SVGSymbolElement::apply_presentational_hints(CSS::StyleProperties& style) const
 {
     // The user agent style sheet sets the overflow property for ‘symbol’ elements to hidden.
-    auto hidden = CSS::IdentifierStyleValue::create(CSS::ValueID::Hidden).release_value_but_fixme_should_propagate_errors();
-    style.set_property(CSS::PropertyID::Overflow, CSS::OverflowStyleValue::create(hidden, hidden).release_value_but_fixme_should_propagate_errors());
+    auto hidden = CSS::IdentifierStyleValue::create(CSS::ValueID::Hidden);
+    style.set_property(CSS::PropertyID::Overflow, CSS::OverflowStyleValue::create(hidden, hidden));
 
     if (is_direct_child_of_use_shadow_tree()) {
         // The generated instance of a ‘symbol’ that is the direct referenced element of a ‘use’ element must always have a computed value of inline for the display property.
-        style.set_property(CSS::PropertyID::Display, CSS::DisplayStyleValue::create(CSS::Display::from_short(CSS::Display::Short::Inline)).release_value_but_fixme_should_propagate_errors());
+        style.set_property(CSS::PropertyID::Display, CSS::DisplayStyleValue::create(CSS::Display::from_short(CSS::Display::Short::Inline)));
     } else {
         // FIXME: When we have a DefaultSVG.css then use https://svgwg.org/svg2-draft/styling.html#UAStyleSheet instead.
         // The user agent must set the display property on the ‘symbol’ element to none, as part of the user agent style sheet,
         // and this declaration must have importance over any other CSS rule or presentation attribute.
-        style.set_property(CSS::PropertyID::Display, CSS::DisplayStyleValue::create(CSS::Display::from_short(CSS::Display::Short::None)).release_value_but_fixme_should_propagate_errors());
+        style.set_property(CSS::PropertyID::Display, CSS::DisplayStyleValue::create(CSS::Display::from_short(CSS::Display::Short::None)));
     }
 }
 


### PR DESCRIPTION
Contributes to #20449.

I did also sneak in a little API change for `parse_css_value_for_properties()`, since the old way of returning failure was more obviously strange once the `ErrorOr` was gone.