### PR TITLE
Ladybird: Link libnsl and libsocket to RequestServer on Solaris

### DIFF
--- a/Ladybird/RequestServer/CMakeLists.txt
+++ b/Ladybird/RequestServer/CMakeLists.txt
@@ -22,3 +22,7 @@ target_link_libraries(RequestServer PRIVATE LibCore LibMain LibCrypto LibFileSys
 if (ANDROID)
     link_android_libs(RequestServer)
 endif()
+if (${CMAKE_SYSTEM_NAME} MATCHES "SunOS")
+    # Solaris has socket and networking related functions in two extra libraries
+    target_link_libraries(RequestServer PRIVATE nsl socket)
+endif()


### PR DESCRIPTION
Adding RequestServer to Ladybird broke building on Solaris as it wasn't linked to Solaris networking libraries (libnsl and libsocket) which resulted in "Undefined symbol gethostbyname errors"
This change links RequestServer to libnsl and libsocket on Solaris, making sure that gethostbyname and other networking-related functions are found here.