### PR TITLE
Ports/libuuid: Disable natural language support

### DIFF
--- a/Ports/libuuid/package.sh
+++ b/Ports/libuuid/package.sh
@@ -1,12 +1,18 @@
 #!/usr/bin/env -S bash ../.port_include.sh
 
-port=libuuid
-version=2.38
+port='libuuid'
+version='2.38'
 workdir="util-linux-${version}"
-useconfigure=true
-configopts=("--prefix=/usr/local" "--disable-all-programs" "--enable-libuuid")
+useconfigure='true'
+configopts=(
+    '--disable-all-programs'
+    '--enable-libuuid'
+    '--prefix=/usr/local'
+)
 files=(
     "https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v${version}/util-linux-${version}.tar.gz c31d4e54f30b56b0f7ec8b342658c07de81378f2c067941c2b886da356f8ad42"
 )
-use_fresh_config_sub=true
-config_sub_paths=("config/config.sub")
+use_fresh_config_sub='true'
+config_sub_paths=(
+    'config/config.sub'
+)

--- a/Ports/libuuid/package.sh
+++ b/Ports/libuuid/package.sh
@@ -6,6 +6,7 @@ workdir="util-linux-${version}"
 useconfigure='true'
 configopts=(
     '--disable-all-programs'
+    '--disable-nls'
     '--enable-libuuid'
     '--prefix=/usr/local'
 )


### PR DESCRIPTION
Having this option enabled made `libuuid` link to `libintl` only when the `gettext` port was installed. This made the `taskwarrior` port fail to build when `gettext` was installed prior to `libuuid`.

The only ports which rely on `libuuid` are `taskwarrior` and `python3`. Both build and run fine after this change.