### PR TITLE
Meta+LibWeb: Make WPT run script runnable anywhere, remove apt installs

### DIFF
--- a/Ladybird/CMakeLists.txt
+++ b/Ladybird/CMakeLists.txt
@@ -219,5 +219,14 @@ if (BUILD_TESTING)
         NAME LibWeb
         COMMAND ${CMAKE_CURRENT_BINARY_DIR}/../bin/headless-browser --run-tests ${SERENITY_SOURCE_DIR}/Tests/LibWeb
     )
-    set_tests_properties(LibWeb PROPERTIES ENVIRONMENT QT_QPA_PLATFORM=offscreen)
+    add_test(
+        NAME WPT
+        CONFIGURATIONS Integration
+        COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../Tests/LibWeb/WPT/run.sh
+    )
+    set_tests_properties(LibWeb WPT PROPERTIES
+        DEPENDS ladybird
+        ENVIRONMENT QT_QPA_PLATFORM=offscreen
+        ENVIRONMENT "SERENITY_SOURCE_DIR=${SERENITY_SOURCE_DIR}"
+    )
 endif()

--- a/Meta/Azure/Setup.yml
+++ b/Meta/Azure/Setup.yml
@@ -21,7 +21,7 @@ steps:
         wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
         sudo add-apt-repository 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main'
         sudo apt-get update
-        sudo apt-get install ccache gcc-12 g++-12 clang-15 libstdc++-12-dev ninja-build unzip qt6-base-dev qt6-tools-dev-tools libqt6svg6-dev qt6-multimedia-dev libgl1-mesa-dev libpulse-dev
+        sudo apt-get install ccache gcc-12 g++-12 clang-15 libstdc++-12-dev ninja-build unzip qt6-base-dev qt6-tools-dev-tools libqt6svg6-dev qt6-multimedia-dev libgl1-mesa-dev libpulse-dev libssl-dev
 
         sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-15 100
         sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-15 100

--- a/Meta/serenity.sh
+++ b/Meta/serenity.sh
@@ -256,12 +256,14 @@ ensure_target() {
 
 run_tests() {
     local TEST_NAME="$1"
-    export CTEST_OUTPUT_ON_FAILURE=1
+    local CTEST_ARGS=("--output-on-failure" "--test-dir" "$BUILD_DIR")
     if [ -n "$TEST_NAME" ]; then
-        ( cd "$BUILD_DIR" && ctest -R "$TEST_NAME" )
-    else
-        ( cd "$BUILD_DIR" && ctest )
+        if [ "$TEST_NAME" = "WPT" ]; then
+            CTEST_ARGS+=("-C" "Integration")
+        fi
+        CTEST_ARGS+=("-R" "$TEST_NAME")
     fi
+    ctest "${CTEST_ARGS[@]}"
 }
 
 build_target() {

--- a/Tests/LibWeb/WPT/run.sh
+++ b/Tests/LibWeb/WPT/run.sh
@@ -2,9 +2,12 @@
 
 set -eo pipefail
 
+SCRIPT_DIR="$(realpath "$(dirname "${BASH_SOURCE[0]}")")"
+
 if [ -z "$SERENITY_SOURCE_DIR" ]
 then
-    echo "SERENITY_SOURCE_DIR is not set. Exiting."
+    SERENITY_SOURCE_DIR="$(realpath "${SCRIPT_DIR}/../../../")"
+    export SERENITY_SOURCE_DIR
 fi
 
 if [[ "$1" == "--update-expectations-metadata" ]]; then
@@ -16,35 +19,36 @@ fi
 # NOTE: WPT runner assumes Ladybird, WebContent and WebDriver are available in $PATH.
 export PATH="${SERENITY_SOURCE_DIR}/Build/lagom/bin:${SERENITY_SOURCE_DIR}/Meta/Lagom/Build/bin:${PATH}"
 
-# Install dependencies.
-sudo apt-get install -y git python3 python3-pip python3-venv libssl-dev
+pushd "${SCRIPT_DIR}"
 
-# Ensure a `python` binary exists
-sudo apt-get install -y python-is-python3
+if [ ! -d "${SCRIPT_DIR}/wpt" ]; then
+    # Clone patched web-platform-tests repository
+    git clone --depth 10000 https://github.com/web-platform-tests/wpt.git
 
-# Clone patched web-platform-tests repository
-git clone --depth 10000 https://github.com/web-platform-tests/wpt.git
+    # Switch to the commit that was used to generate tests expectations. Requires periodic updates.
+    (cd wpt; git checkout 4434e91bd0801dfefff044b5b9a9744e30d255d3)
 
-# Switch to the commit that was used to generate tests expectations. Requires periodic updates.
-(cd wpt; git checkout 4434e91bd0801dfefff044b5b9a9744e30d255d3)
+    # Apply WPT patch with Ladybird runner
+    (cd wpt; git apply ../ladybird_runner.patch)
 
-# Apply WPT patch with Ladybird runner
-(cd wpt; git apply ../ladybird_runner.patch)
-
-# Update hosts file
-./wpt/wpt make-hosts-file | sudo tee -a /etc/hosts
+    # Update hosts file
+    # FIXME: Only do this if required. Otherwise your /etc/hosts gets crowded quickly
+    python3 "./wpt/wpt" make-hosts-file | sudo tee -a /etc/hosts
+fi
 
 # Extract metadata.txt into directory with expectation files expected by WPT runner
-./concat-extract-metadata.py --extract metadata.txt metadata
+python3 ./concat-extract-metadata.py --extract metadata.txt metadata
 
 # Generate name for file with wpt run log
 wpt_run_log_filename="$(mktemp).txt"
 
 # Run tests.
-./wpt/wpt run ladybird --no-fail-on-unexpected --no-fail-on-unexpected-pass --skip-timeout --include-manifest include.ini --metadata ./metadata --manifest ./MANIFEST.json --log-raw "${wpt_run_log_filename}"
+python3 ./wpt/wpt run ladybird --no-fail-on-unexpected --no-fail-on-unexpected-pass --skip-timeout --include-manifest include.ini --metadata ./metadata --manifest ./MANIFEST.json --log-raw "${wpt_run_log_filename}"
 
 # Update expectations metadata files if requested
 if [[ $update_expectations_metadata == true ]]; then
-    ./wpt/wpt update-expectations --product ladybird --metadata ./metadata --manifest ./MANIFEST.json "${wpt_run_log_filename}"
-    ./concat-extract-metadata.py --concat ./metadata > metadata.txt
+    python3 ./wpt/wpt update-expectations --product ladybird --metadata ./metadata --manifest ./MANIFEST.json "${wpt_run_log_filename}"
+    python3 ./concat-extract-metadata.py --concat ./metadata > metadata.txt
 fi
+
+popd


### PR DESCRIPTION
We should be documenting required pacakges elsewhere and installing them
in the setup step of CI.

This also fixes a problem where the run script would fail if you already
had a cloned wpt directory.