### PR TITLE
Kernel: Change the code point of numpad keys to 0, when Num Lock is off

### DIFF
--- a/Kernel/Devices/HID/KeyboardDevice.cpp
+++ b/Kernel/Devices/HID/KeyboardDevice.cpp
@@ -299,7 +299,7 @@ void KeyboardDevice::handle_scan_code_input_event(ScanCodeEvent event)
     queued_event.flags = m_modifiers;
     queued_event.e0_prefix = event.e0_prefix;
     queued_event.caps_lock_on = m_caps_lock_on;
-    queued_event.code_point = HIDManagement::the().get_char_from_character_map(queued_event);
+    queued_event.code_point = HIDManagement::the().get_char_from_character_map(queued_event, m_num_lock_on);
 
     // If using a non-QWERTY layout, queued_event.key needs to be updated to be the same as event.code_point
     KeyCode mapped_key = code_point_to_key_code(queued_event.code_point);

--- a/Kernel/Devices/HID/Management.cpp
+++ b/Kernel/Devices/HID/Management.cpp
@@ -174,7 +174,7 @@ HIDManagement& HIDManagement::the()
     return *s_the;
 }
 
-u32 HIDManagement::get_char_from_character_map(KeyEvent event) const
+u32 HIDManagement::get_char_from_character_map(KeyEvent event, bool num_lock_on) const
 {
     auto modifiers = event.modifiers();
     auto index = event.scancode & 0xFF; // Index is last byte of scan code.
@@ -207,6 +207,10 @@ u32 HIDManagement::get_char_from_character_map(KeyEvent event) const
     } else if (event.e0_prefix && event.key != Key_Return) {
         // Except for `keypad-/` and 'keypad-return', all e0 scan codes are not actually characters. i.e., `keypad-0` and
         // `Insert` have the same scancode except for the prefix, but insert should not have a code_point.
+        code_point = 0;
+    } else if (!num_lock_on && !event.e0_prefix && event.scancode >= 0x47 && event.scancode <= 0x53 && event.key != Key_Minus && event.key != Key_Plus) {
+        // When Num Lock is off, some numpad keys have the same function as some of the extended keys like Home, End, PgDown, arrows etc.
+        // These keys should have the code_point set to 0.
         code_point = 0;
     }
 

--- a/Kernel/Devices/HID/Management.h
+++ b/Kernel/Devices/HID/Management.h
@@ -46,7 +46,7 @@ public:
 
     SpinlockProtected<KeymapData, LockRank::None>& keymap_data() { return m_keymap_data; }
 
-    u32 get_char_from_character_map(KeyEvent) const;
+    u32 get_char_from_character_map(KeyEvent, bool) const;
 
     void set_client(KeyboardClient* client);
     void set_maps(NonnullOwnPtr<KString> character_map_name, Keyboard::CharacterMapData const& character_map);


### PR DESCRIPTION
Previously we would set the KeyCode correctly to the appropriate extended keys values, like `Home` and `End`, but keep the code point of the original keys, like `1`, `2`, `3`, etc. Because of this, the keys would just print the original keys, instead of behaving like the extended ones.

In the After video, at 0:19 you can see me turning the Num Lock off and then using numpad keys to navigate through the file (you can also use the `.` key as a `Delete` but I forgot to record that :P).
This is not possible in the Before video, the keys still print the numbers after turning Num Lock off.
| Before | After |
| --- | --- |
| <video src="https://github.com/SerenityOS/serenity/assets/36564831/f0b1b8bb-84d1-4b42-920f-97f8f05878d0"> | <video src="https://github.com/SerenityOS/serenity/assets/36564831/770479cc-8104-4e2c-b5ad-969880f4b223"> |