### PR TITLE
LibWeb: Add Base::apply_presentational_hints call to <symbol> element

### DIFF
--- a/Tests/LibWeb/Ref/manifest.json
+++ b/Tests/LibWeb/Ref/manifest.json
@@ -4,5 +4,6 @@
     "opacity-stacking.html": "opacity-stacking-ref.html",
     "css-gradient-currentcolor.html": "css-gradient-currentcolor-ref.html",
     "css-lang-selector.html": "css-lang-selector-ref.html",
-    "css-gradients.html": "css-gradients-ref.html"
+    "css-gradients.html": "css-gradients-ref.html",
+    "svg-symbol.html": "svg-symbol-ref.html"
 }

--- a/Tests/LibWeb/Ref/svg-symbol-ref.html
+++ b/Tests/LibWeb/Ref/svg-symbol-ref.html
@@ -1,0 +1,5 @@
+<svg><symbol fill="green" id="dot" width="500" height="500" viewBox="0 0 2 10">
+<circle cx="1" cy="1" r="1"/>
+<circle fill="blue" cx="1.5" cy="1" r="1"/>
+</symbol>
+<use href="#dot"/>

--- a/Tests/LibWeb/Ref/svg-symbol.html
+++ b/Tests/LibWeb/Ref/svg-symbol.html
@@ -1,0 +1,5 @@
+<svg><symbol id="dot" width="500" height="500" viewBox="0 0 2 10">
+<circle fill="green" cx="1" cy="1" r="1"/>
+<circle fill="blue" cx="1.5" cy="1" r="1"/>
+</symbol>
+<use href="#dot"/>

--- a/Userland/Libraries/LibWeb/SVG/SVGSymbolElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGSymbolElement.cpp
@@ -30,6 +30,8 @@ void SVGSymbolElement::initialize(JS::Realm& realm)
 // https://svgwg.org/svg2-draft/struct.html#SymbolNotes
 void SVGSymbolElement::apply_presentational_hints(CSS::StyleProperties& style) const
 {
+    Base::apply_presentational_hints(style);
+
     // The user agent style sheet sets the overflow property for ‘symbol’ elements to hidden.
     auto hidden = CSS::IdentifierStyleValue::create(CSS::ValueID::Hidden);
     style.set_property(CSS::PropertyID::Overflow, CSS::OverflowStyleValue::create(hidden, hidden));


### PR DESCRIPTION
Reopening of #20655 because I've removed the commit and the PR closed itself. A rookie mistake :^(

Fixes a couple SVGs on ex. https://www.jetbrains.com/clion/

| Before | After |
| --- | --- |
| ![obraz](https://github.com/SerenityOS/serenity/assets/36564831/ca0f2808-a8aa-4368-aa0e-8e49e7104fb5) | ![obraz](https://github.com/SerenityOS/serenity/assets/36564831/c7ce8f26-f942-4fbc-b376-373751b65426) |