### PR TITLE
LibCore: Add default version for Lagom applications

### DIFF
--- a/Userland/Libraries/LibCore/ArgsParser.cpp
+++ b/Userland/Libraries/LibCore/ArgsParser.cpp
@@ -383,6 +383,8 @@ void ArgsParser::print_usage_markdown(FILE* file, StringView argv0)
 
 void ArgsParser::print_version(FILE* file)
 {
+    // FIXME: Allow applications to override version string for --version.
+    //        Especially useful for Lagom applications
     outln(file, Core::Version::read_long_version_string().release_value_but_fixme_should_propagate_errors());
 }
 

--- a/Userland/Libraries/LibCore/Version.cpp
+++ b/Userland/Libraries/LibCore/Version.cpp
@@ -12,12 +12,16 @@ namespace Core::Version {
 
 ErrorOr<String> read_long_version_string()
 {
+#ifdef AK_OS_SERENITY
     auto uname = TRY(Core::System::uname());
 
     auto const* version = uname.release;
     auto const* git_hash = uname.version;
 
     return String::formatted("Version {} revision {}", version, git_hash);
+#else
+    return String::from_utf8("Version 1.0"sv);
+#endif
 }
 
 }


### PR DESCRIPTION
Instead of grabbing `uname -vr` on non-Serenity platforms, let's just hardcode a version. This prevents Lagom builds of applications like Shell or Ladybird from reporting their version as that of the host OS.

cc @kleinesfilmroellchen 