### PR TITLE
LibWeb: Consistently use doubles in CSS

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Angle.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Angle.cpp
@@ -10,12 +10,6 @@
 
 namespace Web::CSS {
 
-Angle::Angle(int value, Type type)
-    : m_type(type)
-    , m_value(value)
-{
-}
-
 Angle::Angle(double value, Type type)
     : m_type(type)
     , m_value(value)

--- a/Userland/Libraries/LibWeb/CSS/Angle.h
+++ b/Userland/Libraries/LibWeb/CSS/Angle.h
@@ -22,7 +22,6 @@ public:
 
     static Optional<Type> unit_from_name(StringView);
 
-    Angle(int value, Type type);
     Angle(double value, Type type);
     static Angle make_degrees(double);
     Angle percentage_of(Percentage const&) const;

--- a/Userland/Libraries/LibWeb/CSS/Frequency.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Frequency.cpp
@@ -9,12 +9,6 @@
 
 namespace Web::CSS {
 
-Frequency::Frequency(int value, Type type)
-    : m_type(type)
-    , m_value(value)
-{
-}
-
 Frequency::Frequency(double value, Type type)
     : m_type(type)
     , m_value(value)

--- a/Userland/Libraries/LibWeb/CSS/Frequency.h
+++ b/Userland/Libraries/LibWeb/CSS/Frequency.h
@@ -19,7 +19,6 @@ public:
 
     static Optional<Type> unit_from_name(StringView);
 
-    Frequency(int value, Type type);
     Frequency(double value, Type type);
     static Frequency make_hertz(double);
     Frequency percentage_of(Percentage const&) const;

--- a/Userland/Libraries/LibWeb/CSS/Length.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Length.cpp
@@ -30,11 +30,6 @@ Length::FontMetrics::FontMetrics(CSSPixels font_size, Gfx::FontPixelMetrics cons
 {
 }
 
-Length::Length(int value, Type type)
-    : m_type(type)
-    , m_value(value)
-{
-}
 Length::Length(double value, Type type)
     : m_type(type)
     , m_value(value)

--- a/Userland/Libraries/LibWeb/CSS/Length.h
+++ b/Userland/Libraries/LibWeb/CSS/Length.h
@@ -83,7 +83,6 @@ public:
 
     static Optional<Type> unit_from_name(StringView);
 
-    Length(int value, Type type);
     Length(double value, Type type);
     ~Length();
 

--- a/Userland/Libraries/LibWeb/CSS/Parser/GradientParsing.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/GradientParsing.cpp
@@ -200,7 +200,7 @@ RefPtr<StyleValue> Parser::parse_linear_gradient_function(ComponentValue const& 
     if (first_param.is(Token::Type::Dimension)) {
         // <angle>
         tokens.next_token();
-        float angle_value = first_param.token().dimension_value();
+        auto angle_value = first_param.token().dimension_value();
         auto unit_string = first_param.token().dimension_unit();
         auto angle_type = Angle::unit_from_name(unit_string);
 
@@ -320,7 +320,7 @@ RefPtr<StyleValue> Parser::parse_conic_gradient_function(ComponentValue const& c
             auto angle_token = tokens.next_token();
             if (!angle_token.is(Token::Type::Dimension))
                 return nullptr;
-            float angle = angle_token.token().dimension_value();
+            auto angle = angle_token.token().dimension_value();
             auto angle_unit = angle_token.token().dimension_unit();
             auto angle_type = Angle::unit_from_name(angle_unit);
             if (!angle_type.has_value())

--- a/Userland/Libraries/LibWeb/CSS/Parser/Token.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Token.h
@@ -111,7 +111,7 @@ public:
         VERIFY(m_type == Type::Number || m_type == Type::Dimension || m_type == Type::Percentage);
         return m_number_value;
     }
-    float number_value() const
+    double number_value() const
     {
         VERIFY(m_type == Type::Number);
         return m_number_value.value();
@@ -127,14 +127,14 @@ public:
         VERIFY(m_type == Type::Dimension);
         return m_value.bytes_as_string_view();
     }
-    float dimension_value() const
+    double dimension_value() const
     {
         VERIFY(m_type == Type::Dimension);
         return m_number_value.value();
     }
     i64 dimension_value_int() const { return m_number_value.integer_value(); }
 
-    float percentage() const
+    double percentage() const
     {
         VERIFY(m_type == Type::Percentage);
         return m_number_value.value();
@@ -159,7 +159,7 @@ public:
         return token;
     }
 
-    static Token create_number(float value)
+    static Token create_number(double value)
     {
         Token token;
         token.m_type = Type::Number;
@@ -167,7 +167,7 @@ public:
         return token;
     }
 
-    static Token create_percentage(float value)
+    static Token create_percentage(double value)
     {
         Token token;
         token.m_type = Type::Percentage;

--- a/Userland/Libraries/LibWeb/CSS/Parser/Tokenizer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Tokenizer.cpp
@@ -574,11 +574,11 @@ Number Tokenizer::consume_a_number()
 }
 
 // https://www.w3.org/TR/css-syntax-3/#convert-string-to-number
-float Tokenizer::convert_a_string_to_a_number(StringView string)
+double Tokenizer::convert_a_string_to_a_number(StringView string)
 {
     // FIXME: We already found the whole part, fraction part and exponent during
     //        validation, we could probably skip
-    return string.to_float(AK::TrimWhitespace::No).release_value();
+    return string.to_double(AK::TrimWhitespace::No).release_value();
 }
 
 // https://www.w3.org/TR/css-syntax-3/#consume-name

--- a/Userland/Libraries/LibWeb/CSS/Parser/Tokenizer.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Tokenizer.h
@@ -87,7 +87,7 @@ private:
     [[nodiscard]] ErrorOr<Token> consume_a_numeric_token();
     [[nodiscard]] ErrorOr<Token> consume_an_ident_like_token();
     [[nodiscard]] Number consume_a_number();
-    [[nodiscard]] float convert_a_string_to_a_number(StringView);
+    [[nodiscard]] double convert_a_string_to_a_number(StringView);
     [[nodiscard]] ErrorOr<FlyString> consume_an_ident_sequence();
     [[nodiscard]] u32 consume_escaped_code_point();
     [[nodiscard]] ErrorOr<Token> consume_a_url_token();

--- a/Userland/Libraries/LibWeb/CSS/Percentage.h
+++ b/Userland/Libraries/LibWeb/CSS/Percentage.h
@@ -18,11 +18,6 @@ namespace Web::CSS {
 
 class Percentage {
 public:
-    explicit Percentage(int value)
-        : m_value(value)
-    {
-    }
-
     explicit Percentage(double value)
         : m_value(value)
     {

--- a/Userland/Libraries/LibWeb/CSS/Ratio.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Ratio.cpp
@@ -9,7 +9,7 @@
 
 namespace Web::CSS {
 
-Ratio::Ratio(float first, float second)
+Ratio::Ratio(double first, double second)
     : m_first_value(first)
     , m_second_value(second)
 {

--- a/Userland/Libraries/LibWeb/CSS/Ratio.h
+++ b/Userland/Libraries/LibWeb/CSS/Ratio.h
@@ -13,8 +13,8 @@ namespace Web::CSS {
 // https://www.w3.org/TR/css-values-4/#ratios
 class Ratio {
 public:
-    Ratio(float first, float second = 1);
-    float value() const { return m_first_value / m_second_value; }
+    Ratio(double first, double second = 1);
+    double value() const { return m_first_value / m_second_value; }
     bool is_degenerate() const;
 
     ErrorOr<String> to_string() const;
@@ -37,8 +37,8 @@ public:
     }
 
 private:
-    float m_first_value { 0 };
-    float m_second_value { 1 };
+    double m_first_value { 0 };
+    double m_second_value { 1 };
 };
 
 }

--- a/Userland/Libraries/LibWeb/CSS/Resolution.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Resolution.cpp
@@ -8,13 +8,7 @@
 
 namespace Web::CSS {
 
-Resolution::Resolution(int value, Type type)
-    : m_type(type)
-    , m_value(value)
-{
-}
-
-Resolution::Resolution(float value, Type type)
+Resolution::Resolution(double value, Type type)
     : m_type(type)
     , m_value(value)
 {
@@ -25,13 +19,13 @@ ErrorOr<String> Resolution::to_string() const
     return String::formatted("{}dppx", to_dots_per_pixel());
 }
 
-float Resolution::to_dots_per_pixel() const
+double Resolution::to_dots_per_pixel() const
 {
     switch (m_type) {
     case Type::Dpi:
         return m_value * 96; // 1in = 2.54cm = 96px
     case Type::Dpcm:
-        return m_value * (96.0f / 2.54f); // 1cm = 96px/2.54
+        return m_value * (96.0 / 2.54); // 1cm = 96px/2.54
     case Type::Dppx:
         return m_value;
     }

--- a/Userland/Libraries/LibWeb/CSS/Resolution.h
+++ b/Userland/Libraries/LibWeb/CSS/Resolution.h
@@ -21,11 +21,10 @@ public:
 
     static Optional<Type> unit_from_name(StringView);
 
-    Resolution(int value, Type type);
-    Resolution(float value, Type type);
+    Resolution(double value, Type type);
 
     ErrorOr<String> to_string() const;
-    float to_dots_per_pixel() const;
+    double to_dots_per_pixel() const;
 
     bool operator==(Resolution const& other) const
     {
@@ -48,6 +47,6 @@ private:
     StringView unit_name() const;
 
     Type m_type;
-    float m_value { 0 };
+    double m_value { 0 };
 };
 }

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.cpp
@@ -1015,9 +1015,9 @@ CalculatedStyleValue::CalculationResult ConstantCalculationNode::resolve([[maybe
         return { Number(Number::Type::Number, M_PI) };
     // FIXME: We need to keep track of Infinity and NaN across all nodes, since they require special handling.
     case CalculationNode::ConstantType::Infinity:
-        return { Number(Number::Type::Number, NumericLimits<float>::max()) };
+        return { Number(Number::Type::Number, NumericLimits<double>::max()) };
     case CalculationNode::ConstantType::MinusInfinity:
-        return { Number(Number::Type::Number, NumericLimits<float>::lowest()) };
+        return { Number(Number::Type::Number, NumericLimits<double>::lowest()) };
     case CalculationNode::ConstantType::NaN:
         return { Number(Number::Type::Number, NAN) };
     }

--- a/Userland/Libraries/LibWeb/CSS/Time.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Time.cpp
@@ -9,12 +9,6 @@
 
 namespace Web::CSS {
 
-Time::Time(int value, Type type)
-    : m_type(type)
-    , m_value(value)
-{
-}
-
 Time::Time(double value, Type type)
     : m_type(type)
     , m_value(value)

--- a/Userland/Libraries/LibWeb/CSS/Time.h
+++ b/Userland/Libraries/LibWeb/CSS/Time.h
@@ -20,7 +20,6 @@ public:
 
     static Optional<Type> unit_from_name(StringView);
 
-    Time(int value, Type type);
     Time(double value, Type type);
     static Time make_seconds(double);
     Time percentage_of(Percentage const&) const;

--- a/Userland/Libraries/LibWeb/Layout/Box.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Box.cpp
@@ -92,7 +92,7 @@ Optional<float> Box::preferred_aspect_ratio() const
     auto computed_aspect_ratio = computed_values().aspect_ratio();
     if (computed_aspect_ratio.use_natural_aspect_ratio_if_available && natural_aspect_ratio().has_value())
         return natural_aspect_ratio();
-    return computed_aspect_ratio.preferred_ratio.map([](CSS::Ratio const& ratio) { return ratio.value(); });
+    return computed_aspect_ratio.preferred_ratio.map([](CSS::Ratio const& ratio) { return static_cast<float>(ratio.value()); });
 }
 
 }


### PR DESCRIPTION
The red wiggly underlines have been bothering me for ages, so let's actually fix the clangd warnings about float->double promotion by not downgrading to float only to later promote to double again.

Also, remove the integer constructors for dimension types, because we no longer need them.