### PR TITLE
LibWeb: Implement getting "ancestor navigables" of a document

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -2561,6 +2561,29 @@ Vector<JS::Handle<HTML::Navigable>> Document::inclusive_descendant_navigables()
     return navigables;
 }
 
+// https://html.spec.whatwg.org/multipage/document-sequences.html#ancestor-navigables
+Vector<JS::Handle<HTML::Navigable>> Document::ancestor_navigables()
+{
+    // 1. Let navigable be document's node navigable's parent.
+    VERIFY(navigable());
+    auto navigable = this->navigable()->parent();
+
+    // 2. Let ancestors be an empty list.
+    Vector<JS::Handle<HTML::Navigable>> ancestors;
+
+    // 3. While navigable is not null:
+    while (navigable) {
+        // 1. Prepend navigable to ancestors.
+        ancestors.prepend(*navigable);
+
+        // 2. Set navigable to navigable's parent.
+        navigable = navigable->parent();
+    }
+
+    // 4. Return ancestors.
+    return ancestors;
+}
+
 // https://html.spec.whatwg.org/multipage/browsers.html#list-of-the-descendant-browsing-contexts
 Vector<JS::Handle<HTML::BrowsingContext>> Document::list_of_descendant_browsing_contexts() const
 {

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -2584,6 +2584,19 @@ Vector<JS::Handle<HTML::Navigable>> Document::ancestor_navigables()
     return ancestors;
 }
 
+// https://html.spec.whatwg.org/multipage/document-sequences.html#inclusive-ancestor-navigables
+Vector<JS::Handle<HTML::Navigable>> Document::inclusive_ancestor_navigables()
+{
+    // 1. Let navigables be document's ancestor navigables.
+    auto navigables = ancestor_navigables();
+
+    // 2. Append document's node navigable to navigables.
+    navigables.append(*navigable());
+
+    // 3. Return navigables.
+    return navigables;
+}
+
 // https://html.spec.whatwg.org/multipage/browsers.html#list-of-the-descendant-browsing-contexts
 Vector<JS::Handle<HTML::BrowsingContext>> Document::list_of_descendant_browsing_contexts() const
 {

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -463,6 +463,7 @@ public:
     Vector<JS::Handle<HTML::Navigable>> descendant_navigables();
     Vector<JS::Handle<HTML::Navigable>> inclusive_descendant_navigables();
     Vector<JS::Handle<HTML::Navigable>> ancestor_navigables();
+    Vector<JS::Handle<HTML::Navigable>> inclusive_ancestor_navigables();
 
     void destroy();
 

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -462,6 +462,7 @@ public:
 
     Vector<JS::Handle<HTML::Navigable>> descendant_navigables();
     Vector<JS::Handle<HTML::Navigable>> inclusive_descendant_navigables();
+    Vector<JS::Handle<HTML::Navigable>> ancestor_navigables();
 
     void destroy();
 


### PR DESCRIPTION
A part of #18219 