### PR TITLE
LibWeb: Fill in missing kinds of calc() expansion in StyleComputer

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Parser/Token.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Token.h
@@ -175,6 +175,15 @@ public:
         return token;
     }
 
+    static Token create_dimension(double value, FlyString unit)
+    {
+        Token token;
+        token.m_type = Type::Dimension;
+        token.m_number_value = Number(Number::Type::Number, value);
+        token.m_value = move(unit);
+        return token;
+    }
+
 private:
     Type m_type { Type::Invalid };
 


### PR DESCRIPTION
This is all of them currently, except Length, because we lack the needed
information to be able to expand font-relative lengths.

The whole way `expand_unresolved_values()` works is awkward, but at some
point we'll be able to run the simplification algorithm on the
calculation, which will either return a single value, or a new
calculation that's simplified as much as possible.

Mostly I just wanted that FIXME log message to go away, because it's
overwhelming on certain sites.