### PR TITLE
LibWeb: Two layout fixes for MDN

### DIFF
--- a/Tests/LibWeb/Layout/expected/flex/align-items-normal.txt
+++ b/Tests/LibWeb/Layout/expected/flex/align-items-normal.txt
@@ -1,0 +1,9 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x116 [BFC] children: not-inline
+    Box <body> at (8,8) content-size 784x100 flex-container(column) [FFC] children: not-inline
+      BlockContainer <div> at (8,8) content-size 100x100 flex-item [BFC] children: not-inline
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x116]
+    PaintableBox (Box<BODY>) [8,8 784x100]
+      PaintableWithLines (BlockContainer<DIV>) [8,8 100x100]

--- a/Tests/LibWeb/Layout/expected/height-min-max-fit-content.txt
+++ b/Tests/LibWeb/Layout/expected/height-min-max-fit-content.txt
@@ -1,0 +1,26 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x139.46875 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x123.46875 children: inline
+      line 0 width: 376, height: 123.46875, bottom: 123.46875, baseline: 120
+        frag 0 from ImageBox start: 0, length: 0, rect: [8,8 120x120]
+        frag 1 from TextNode start: 0, length: 1, rect: [128,114 8x17.46875]
+          " "
+        frag 2 from ImageBox start: 0, length: 0, rect: [136,8 120x120]
+        frag 3 from TextNode start: 0, length: 1, rect: [256,114 8x17.46875]
+          " "
+        frag 4 from ImageBox start: 0, length: 0, rect: [264,8 120x120]
+      ImageBox <img.min> at (8,8) content-size 120x120 children: not-inline
+      TextNode <#text>
+      ImageBox <img.max> at (136,8) content-size 120x120 children: not-inline
+      TextNode <#text>
+      ImageBox <img.fit> at (264,8) content-size 120x120 children: not-inline
+      TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x139.46875]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x123.46875]
+      ImagePaintable (ImageBox<IMG>.min) [8,8 120x120]
+      TextPaintable (TextNode<#text>)
+      ImagePaintable (ImageBox<IMG>.max) [136,8 120x120]
+      TextPaintable (TextNode<#text>)
+      ImagePaintable (ImageBox<IMG>.fit) [264,8 120x120]

--- a/Tests/LibWeb/Layout/input/flex/align-items-normal.html
+++ b/Tests/LibWeb/Layout/input/flex/align-items-normal.html
@@ -1,0 +1,12 @@
+<!doctype html><style>
+  body {
+    display: flex;
+    flex-direction: column;
+    align-items: normal;
+  }
+  div {
+    width: 100px;
+    height: 100px;
+    background: orange;
+  }
+</style><body><div></div>

--- a/Tests/LibWeb/Layout/input/height-min-max-fit-content.html
+++ b/Tests/LibWeb/Layout/input/height-min-max-fit-content.html
@@ -1,0 +1,8 @@
+<!doctype html><style>
+.min{ height: min-content; }
+.max { height: max-content; }
+.fit { height: fit-content; }
+</style>
+<img class="min" src="120.png" width="120" height="60" />
+<img class="max" src="120.png" width="120" height="60" />
+<img class="fit" src="120.png" width="120" height="60" />

--- a/Userland/Libraries/LibWeb/CSS/Properties.json
+++ b/Userland/Libraries/LibWeb/CSS/Properties.json
@@ -1182,7 +1182,10 @@
       "percentage [0,∞]"
     ],
     "valid-identifiers": [
-      "auto"
+      "auto",
+      "fit-content",
+      "max-content",
+      "min-content"
     ],
     "percentages-resolve-to": "length",
     "quirks": [

--- a/Userland/Libraries/LibWeb/CSS/Properties.json
+++ b/Userland/Libraries/LibWeb/CSS/Properties.json
@@ -18,7 +18,7 @@
   },
   "align-items": {
     "inherited": false,
-    "initial": "stretch",
+    "initial": "normal",
     "valid-types": [
       "align-items"
     ]

--- a/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -1246,7 +1246,8 @@ void FlexFormattingContext::determine_used_cross_size_of_each_flex_item()
             //  If a flex item has align-self: stretch, its computed cross size property is auto,
             //  and neither of its cross-axis margins are auto, the used outer cross size is the used cross size of its flex line,
             //  clamped according to the item’s used min and max cross sizes.
-            if (alignment_for_item(item.box) == CSS::AlignItems::Stretch
+            auto flex_item_alignment = alignment_for_item(item.box);
+            if ((flex_item_alignment == CSS::AlignItems::Stretch || flex_item_alignment == CSS::AlignItems::Normal)
                 && is_cross_auto(item.box)
                 && !item.margins.cross_before_is_auto
                 && !item.margins.cross_after_is_auto) {
@@ -1503,6 +1504,7 @@ void FlexFormattingContext::align_all_flex_items_along_the_cross_axis()
             case CSS::AlignItems::Start:
             case CSS::AlignItems::FlexStart:
             case CSS::AlignItems::Stretch:
+            case CSS::AlignItems::Normal:
                 item.cross_offset = -half_line_size + item.margins.cross_before + item.borders.cross_before + item.padding.cross_before;
                 break;
             case CSS::AlignItems::End:
@@ -2069,7 +2071,7 @@ CSSPixels FlexFormattingContext::calculate_max_content_cross_size(FlexItem const
 bool FlexFormattingContext::flex_item_is_stretched(FlexItem const& item) const
 {
     auto alignment = alignment_for_item(item.box);
-    if (alignment != CSS::AlignItems::Stretch)
+    if (alignment != CSS::AlignItems::Stretch && alignment != CSS::AlignItems::Normal)
         return false;
     // If the cross size property of the flex item computes to auto, and neither of the cross-axis margins are auto, the flex item is stretched.
     auto const& computed_cross_size = is_row_layout() ? item.box->computed_values().height() : item.box->computed_values().width();

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -1627,8 +1627,18 @@ bool FormattingContext::should_treat_width_as_auto(Box const& box, AvailableSpac
 
 bool FormattingContext::should_treat_height_as_auto(Box const& box, AvailableSpace const& available_space)
 {
-    if (box.computed_values().height().is_auto())
+    auto computed_height = box.computed_values().height();
+    if (computed_height.is_auto())
         return true;
+
+    // https://www.w3.org/TR/css-sizing-3/#valdef-width-min-content
+    // https://www.w3.org/TR/css-sizing-3/#valdef-width-max-content
+    // https://www.w3.org/TR/css-sizing-3/#valdef-width-fit-content
+    // For a box’s block size, unless otherwise specified, this is equivalent to its automatic size.
+    // FIXME: If height is not the block axis size, then we should be concerned with the width instead.
+    if (computed_height.is_min_content() || computed_height.is_max_content() || computed_height.is_fit_content())
+        return true;
+
     if (box.computed_values().height().contains_percentage()) {
         if (available_space.height.is_max_content())
             return true;


### PR DESCRIPTION
See individual commits for details.

Visual progression on https://developer.mozilla.org/en-US/

Before:
![Screenshot at 2023-08-20 18-30-42](https://github.com/SerenityOS/serenity/assets/5954907/745f2277-4039-4e0c-9959-8e430222a7bc)

After:
![Screenshot at 2023-08-20 18-29-57](https://github.com/SerenityOS/serenity/assets/5954907/4cea0b05-9a2d-4812-a2f6-daca90491f2c)

