### PR TITLE
LibAudio: Fix various fuzzer-found bugs

### DIFF
--- a/AK/Checked.h
+++ b/AK/Checked.h
@@ -234,6 +234,24 @@ public:
         m_overflow = false;
     }
 
+    constexpr void saturating_mul(T other)
+    {
+        // Figure out if the result is positive, negative or zero beforehand.
+        auto either_is_zero = this->m_value == 0 || other == 0;
+        auto result_is_positive = (this->m_value > 0) == (other > 0);
+
+        mul(other);
+        if (m_overflow) {
+            if (either_is_zero)
+                m_value = 0;
+            else if (result_is_positive)
+                m_value = NumericLimits<T>::max();
+            else
+                m_value = NumericLimits<T>::min();
+        }
+        m_overflow = false;
+    }
+
     constexpr Checked& operator+=(Checked const& other)
     {
         m_overflow |= other.m_overflow;
@@ -351,6 +369,14 @@ public:
     {
         Checked checked { a };
         checked.saturating_sub(b);
+        return checked.value();
+    }
+
+    template<typename U, typename V>
+    static constexpr T saturating_mul(U a, V b)
+    {
+        Checked checked { a };
+        checked.saturating_mul(b);
         return checked.value();
     }
 

--- a/Userland/Libraries/LibAudio/FlacLoader.cpp
+++ b/Userland/Libraries/LibAudio/FlacLoader.cpp
@@ -918,6 +918,10 @@ MaybeLoaderError FlacLoaderPlugin::decode_residual(Vector<i64>& decoded, FlacSub
 
     if (partitions > m_current_frame->sample_count)
         return LoaderError { LoaderError::Category::Format, static_cast<size_t>(m_current_sample_or_frame), "Too many Rice partitions, each partition must contain at least one sample" };
+    // “The partition order MUST be such that the block size is evenly divisible by the number of partitions.”
+    // FIXME: Check “The partition order also MUST be such that the (block size >> partition order) is larger than the predictor order.”
+    if (m_current_frame->sample_count % partitions != 0)
+        return LoaderError { LoaderError::Category::Format, TRY(m_stream->tell()), "Block size is not evenly divisible by number of partitions" };
 
     if (residual_mode == FlacResidualMode::Rice4Bit) {
         // 11.30.2. RESIDUAL_CODING_METHOD_PARTITIONED_EXP_GOLOMB

--- a/Userland/Libraries/LibAudio/FlacLoader.cpp
+++ b/Userland/Libraries/LibAudio/FlacLoader.cpp
@@ -746,7 +746,13 @@ ErrorOr<Vector<i64>, LoaderError> FlacLoaderPlugin::decode_verbatim(FlacSubframe
     Vector<i64> decoded;
     decoded.ensure_capacity(m_current_frame->sample_count);
 
-    VERIFY(subframe.bits_per_sample - subframe.wasted_bits_per_sample != 0);
+    if (subframe.bits_per_sample <= subframe.wasted_bits_per_sample) {
+        return LoaderError {
+            LoaderError::Category::Format,
+            TRY(m_stream->tell()),
+            "Effective verbatim bits per sample are zero"sv,
+        };
+    }
     for (size_t i = 0; i < m_current_frame->sample_count; ++i) {
         decoded.unchecked_append(sign_extend(
             TRY(bit_input.read_bits<u64>(subframe.bits_per_sample - subframe.wasted_bits_per_sample)),
@@ -766,7 +772,13 @@ ErrorOr<void, LoaderError> FlacLoaderPlugin::decode_custom_lpc(Vector<i64>& deco
 
     decoded.ensure_capacity(m_current_frame->sample_count);
 
-    VERIFY(subframe.bits_per_sample - subframe.wasted_bits_per_sample != 0);
+    if (subframe.bits_per_sample <= subframe.wasted_bits_per_sample) {
+        return LoaderError {
+            LoaderError::Category::Format,
+            TRY(m_stream->tell()),
+            "Effective verbatim bits per sample are zero"sv,
+        };
+    }
     // warm-up samples
     for (auto i = 0; i < subframe.order; ++i) {
         decoded.unchecked_append(sign_extend(
@@ -825,7 +837,13 @@ ErrorOr<Vector<i64>, LoaderError> FlacLoaderPlugin::decode_fixed_lpc(FlacSubfram
     Vector<i64> decoded;
     decoded.ensure_capacity(m_current_frame->sample_count);
 
-    VERIFY(subframe.bits_per_sample - subframe.wasted_bits_per_sample != 0);
+    if (subframe.bits_per_sample <= subframe.wasted_bits_per_sample) {
+        return LoaderError {
+            LoaderError::Category::Format,
+            TRY(m_stream->tell()),
+            "Effective verbatim bits per sample are zero"sv,
+        };
+    }
     // warm-up samples
     for (auto i = 0; i < subframe.order; ++i) {
         decoded.unchecked_append(sign_extend(

--- a/Userland/Libraries/LibAudio/FlacLoader.cpp
+++ b/Userland/Libraries/LibAudio/FlacLoader.cpp
@@ -460,7 +460,9 @@ LoaderSamples FlacLoaderPlugin::next_frame()
         auto& subframe_samples = m_subframe_buffers[i];
         subframe_samples.clear_with_capacity();
         TRY(parse_subframe(subframe_samples, new_subframe, bit_stream));
-        VERIFY(subframe_samples.size() == m_current_frame->sample_count);
+        // We only verify the sample count for the common case of a constant sample rate.
+        if (m_sample_rate == m_current_frame->sample_rate)
+            VERIFY(subframe_samples.size() == m_current_frame->sample_count);
     }
 
     // 11.2. Overview ("The audio data is composed of...")

--- a/Userland/Libraries/LibAudio/GenericTypes.cpp
+++ b/Userland/Libraries/LibAudio/GenericTypes.cpp
@@ -51,7 +51,12 @@ Optional<u64> SeekTable::seek_point_sample_distance_around(u64 sample_index) con
         return {};
     size_t nearby_seek_point_index = 0;
     AK::binary_search(m_seek_points, sample_index, &nearby_seek_point_index, [](auto const& sample_index, auto const& seekpoint_candidate) {
-        return static_cast<i64>(sample_index) - static_cast<i64>(seekpoint_candidate.sample_index);
+        // Subtraction with i64 cast may cause overflow.
+        if (sample_index > seekpoint_candidate.sample_index)
+            return 1;
+        if (sample_index == seekpoint_candidate.sample_index)
+            return 0;
+        return -1;
     });
 
     while (nearby_seek_point_index < m_seek_points.size() && m_seek_points[nearby_seek_point_index].sample_index <= sample_index)

--- a/Userland/Libraries/LibAudio/MP3Loader.cpp
+++ b/Userland/Libraries/LibAudio/MP3Loader.cpp
@@ -724,6 +724,9 @@ void MP3LoaderPlugin::process_stereo(MP3::MP3Frame& frame, size_t granule_index)
 
     auto process_intensity_stereo = [&](MP3::Tables::ScaleFactorBand const& band, float intensity_stereo_ratio) {
         for (size_t i = band.start; i <= band.end; i++) {
+            // Superflous empty scale factor band.
+            if (i >= MP3::granule_size)
+                continue;
             float const sample_left = granule_left.samples[i];
             float const coeff_l = intensity_stereo_ratio / (1 + intensity_stereo_ratio);
             float const coeff_r = 1 / (1 + intensity_stereo_ratio);

--- a/Userland/Libraries/LibAudio/QOATypes.cpp
+++ b/Userland/Libraries/LibAudio/QOATypes.cpp
@@ -38,10 +38,11 @@ LMSState::LMSState(u64 history_packed, u64 weights_packed)
 
 i32 LMSState::predict() const
 {
-    i32 prediction = 0;
+    // The spec specifies that overflows are not allowed, but we do a safe thing anyways.
+    Checked<i32> prediction = 0;
     for (size_t i = 0; i < lms_history; ++i)
-        prediction += history[i] * weights[i];
-    return prediction >> 13;
+        prediction.saturating_add(Checked<i32>::saturating_mul(history[i], weights[i]));
+    return prediction.value() >> 13;
 }
 
 void LMSState::update(i32 sample, i32 residual)


### PR DESCRIPTION
### LibAudio: Prevent overflows during prediction

Saturating arithmetic leads to less screwed up audio in these cases.

### LibAudio: Account for garbage shifts in several places in FLAC loader


### LibAudio: Perform all seekpoint binary searches with comparisons

One was missed in the previous fix

### LibAudio: Only check subframe size if sample rate is constant


### LibAudio: Treat FLAC bps <= wasted_bps as error instead of crash

This can happen with some weird inputs, so instead, return an error; we
need at least one “effective” bit per sample so the bits per sample
cannot be less than or equal to the wasted bits per sample.

### LibAudio: Check more FLAC partition order constraints as per the spec


### LibAudio: Prevent overflow in QOA LMS prediction


### LibAudio: Skip empty MP3 scale factor bands in stereo intensity process

These were intentionally set up to be at the end of the granule size,
but since the stereo intensity loop is intentionally using a <= end
comparison (that’s how the scale factor bands work), we must skip these
dummy bands which would otherwise cause an out-of-bounds index.
