### PR TITLE
LibWeb: Fix `Request::visit_edges` to actually visit `m_body`

### DIFF
--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Requests.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Requests.cpp
@@ -24,7 +24,7 @@ void Request::visit_edges(JS::Cell::Visitor& visitor)
     visitor.visit(m_header_list);
     visitor.visit(m_client);
     m_body.visit(
-        [&](JS::GCPtr<Body>& body) { visitor.visit(body); },
+        [&](JS::NonnullGCPtr<Body>& body) { visitor.visit(body); },
         [](auto&) {});
     m_reserved_client.visit(
         [&](JS::GCPtr<HTML::EnvironmentSettingsObject> const& value) { visitor.visit(value); },


### PR DESCRIPTION
This fixes bug introduced in bdd3a16b16c99bd6342ad34b629b89a510942699 that `m_body` is not visited because `BodyType` variant has `JS::NonnullGCPtr` instead of `JS::GCPtr`.