### PR TITLE
AK: Add riscv64 support

### DIFF
--- a/AK/Assertions.h
+++ b/AK/Assertions.h
@@ -25,4 +25,5 @@ extern "C" __attribute__((noreturn)) void ak_verification_failed(char const*);
 static constexpr bool TODO = false;
 #    define TODO() VERIFY(TODO)                /* NOLINT(cert-dcl03-c,misc-static-assert) No, this can't be static_assert, it's a runtime check */
 #    define TODO_AARCH64() VERIFY(TODO)        /* NOLINT(cert-dcl03-c,misc-static-assert) No, this can't be static_assert, it's a runtime check */
+#    define TODO_RISCV64() VERIFY(TODO)        /* NOLINT(cert-dcl03-c,misc-static-assert) No, this can't be static_assert, it's a runtime check */
 #endif

--- a/AK/BuiltinWrappers.h
+++ b/AK/BuiltinWrappers.h
@@ -134,7 +134,7 @@ inline constexpr int count_leading_zeroes_safe(IntType value)
 template<Integral IntType>
 inline constexpr int bit_scan_forward(IntType value)
 {
-#if defined(AK_COMPILER_CLANG) || defined(AK_COMPILER_GCC)
+#if defined(AK_COMPILER_CLANG) || (defined(AK_COMPILER_GCC) && (!ARCH(RISCV64) || defined(__riscv_zbb)))
     static_assert(sizeof(IntType) <= sizeof(unsigned long long));
     if constexpr (sizeof(IntType) <= sizeof(unsigned int))
         return __builtin_ffs(value);

--- a/AK/Platform.h
+++ b/AK/Platform.h
@@ -23,6 +23,12 @@
 #    define AK_IS_ARCH_AARCH64() 0
 #endif
 
+#if defined(__riscv) && __riscv_xlen == 64
+#    define AK_IS_ARCH_RISCV64() 1
+#else
+#    define AK_IS_ARCH_RISCV64() 0
+#endif
+
 #ifdef __wasm32__
 #    define AK_IS_ARCH_WASM32() 1
 #else
@@ -111,6 +117,12 @@
 #    define VALIDATE_IS_AARCH64()
 #else
 #    define VALIDATE_IS_AARCH64() static_assert(false, "Trying to include aarch64 only header on non aarch64 platform");
+#endif
+
+#if ARCH(RISCV64)
+#    define VALIDATE_IS_RISCV64()
+#else
+#    define VALIDATE_IS_RISCV64() static_assert(false, "Trying to include riscv64 only header on non riscv64 platform");
 #endif
 
 #if !defined(AK_COMPILER_CLANG)


### PR DESCRIPTION
This PR adds the necessary macros to AK for riscv64 support for further riscv64 serenity patches.
The second commit of this PR makes `bit_scan_forward` not use `__builtin_ffs` on GCC without the Zbb "Basic bit-manipulation" extension. Otherwise it would redirect it to `ffs`, causing a linker error.
