### PR TITLE
LibWeb: Enable running WPT testharness

### DIFF
--- a/Userland/Libraries/LibWeb/WebDriver/Client.cpp
+++ b/Userland/Libraries/LibWeb/WebDriver/Client.cpp
@@ -96,6 +96,7 @@ static constexpr auto s_webdriver_endpoints = Array {
     ROUTE(POST, "/session/:session_id/cookie"sv, add_cookie),
     ROUTE(DELETE, "/session/:session_id/cookie/:name"sv, delete_cookie),
     ROUTE(DELETE, "/session/:session_id/cookie"sv, delete_all_cookies),
+    ROUTE(DELETE, "/session/:session_id/actions"sv, release_actions),
     ROUTE(POST, "/session/:session_id/alert/dismiss"sv, dismiss_alert),
     ROUTE(POST, "/session/:session_id/alert/accept"sv, accept_alert),
     ROUTE(GET, "/session/:session_id/alert/text"sv, get_alert_text),

--- a/Userland/Libraries/LibWeb/WebDriver/Client.h
+++ b/Userland/Libraries/LibWeb/WebDriver/Client.h
@@ -92,6 +92,9 @@ public:
     virtual Response delete_cookie(Parameters parameters, JsonValue payload) = 0;
     virtual Response delete_all_cookies(Parameters parameters, JsonValue payload) = 0;
 
+    // 15. Actions, https://w3c.github.io/webdriver/#actions
+    virtual Response release_actions(Parameters parameters, JsonValue payload) = 0;
+
     // 16. User prompts, https://w3c.github.io/webdriver/#user-prompts
     virtual Response dismiss_alert(Parameters parameters, JsonValue payload) = 0;
     virtual Response accept_alert(Parameters parameters, JsonValue payload) = 0;

--- a/Userland/Libraries/LibWeb/WebDriver/ExecuteScript.cpp
+++ b/Userland/Libraries/LibWeb/WebDriver/ExecuteScript.cpp
@@ -331,6 +331,10 @@ ExecuteScriptResultSerialized execute_async_script(Web::Page& page, DeprecatedSt
     auto& vm = window->vm();
     auto start = MonotonicTime::now();
 
+    auto has_timed_out = [&] {
+        return timeout.has_value() && (MonotonicTime::now() - start) > Duration::from_seconds(static_cast<i64>(*timeout));
+    };
+
     // AD-HOC: An execution context is required for Promise creation hooks.
     HTML::TemporaryExecutionContext execution_context { document->relevant_settings_object() };
 
@@ -381,7 +385,7 @@ ExecuteScriptResultSerialized execute_async_script(Web::Page& page, DeprecatedSt
         vm.custom_data()->spin_event_loop_until([&] {
             if (script_promise.state() != JS::Promise::State::Pending)
                 return true;
-            if (timeout.has_value() && (MonotonicTime::now() - start) > Duration::from_seconds(static_cast<i64>(*timeout)))
+            if (has_timed_out())
                 return true;
             return false;
         });
@@ -395,11 +399,21 @@ ExecuteScriptResultSerialized execute_async_script(Web::Page& page, DeprecatedSt
             WebIDL::reject_promise(realm, promise_capability, script_promise.result());
     }();
 
-    // FIXME: 6. If promise is still pending and session script timeout milliseconds is reached, return error with error code script timeout.
-
+    // 6. If promise is still pending and session script timeout milliseconds is reached, return error with error code script timeout.
     vm.custom_data()->spin_event_loop_until([&] {
+        if (has_timed_out()) {
+            return true;
+        }
+
         return promise->state() != JS::Promise::State::Pending;
     });
+
+    if (has_timed_out()) {
+        auto error_object = JsonObject {};
+        error_object.set("name", "Error");
+        error_object.set("message", "script timeout");
+        return { ExecuteScriptResultType::Timeout, move(error_object) };
+    }
 
     auto json_value_or_error = json_clone(realm, promise->result());
     if (json_value_or_error.is_error()) {

--- a/Userland/Libraries/LibWeb/WebDriver/ExecuteScript.cpp
+++ b/Userland/Libraries/LibWeb/WebDriver/ExecuteScript.cpp
@@ -358,8 +358,10 @@ ExecuteScriptResultSerialized execute_async_script(Web::Page& page, DeprecatedSt
         // NOTE: Prior revisions of this specification did not recognize the return value of the provided script.
         //       In order to preserve legacy behavior, the return value only influences the command if it is a
         //       "thenable"  object or if determining this produces an exception.
-        if (script_result.is_throw_completion())
+        if (script_result.is_throw_completion()) {
+            promise->reject(*script_result.throw_completion().value());
             return;
+        }
 
         // 5. If Type(scriptResult.[[Value]]) is not Object, then abort these steps.
         if (!script_result.value().is_object())
@@ -369,8 +371,10 @@ ExecuteScriptResultSerialized execute_async_script(Web::Page& page, DeprecatedSt
         auto then = script_result.value().as_object().get(vm.names.then);
 
         // 7. If then.[[Type]] is not normal, then reject promise with value then.[[Value]], and abort these steps.
-        if (then.is_throw_completion())
+        if (then.is_throw_completion()) {
+            promise->reject(*then.throw_completion().value());
             return;
+        }
 
         // 8. If IsCallable(then.[[Type]]) is false, then abort these steps.
         if (!then.value().is_function())

--- a/Userland/Services/WebContent/WebDriverClient.ipc
+++ b/Userland/Services/WebContent/WebDriverClient.ipc
@@ -51,6 +51,7 @@ endpoint WebDriverClient {
     add_cookie(JsonValue payload) => (Web::WebDriver::Response response)
     delete_cookie(String name) => (Web::WebDriver::Response response)
     delete_all_cookies() => (Web::WebDriver::Response response)
+    release_actions() => (Web::WebDriver::Response response)
     dismiss_alert() => (Web::WebDriver::Response response)
     accept_alert() => (Web::WebDriver::Response response)
     get_alert_text() => (Web::WebDriver::Response response)

--- a/Userland/Services/WebContent/WebDriverConnection.cpp
+++ b/Userland/Services/WebContent/WebDriverConnection.cpp
@@ -1654,6 +1654,26 @@ Messages::WebDriverClient::DeleteAllCookiesResponse WebDriverConnection::delete_
     return JsonValue {};
 }
 
+// 15.8 Release Actions, https://w3c.github.io/webdriver/#release-actions
+Messages::WebDriverClient::ReleaseActionsResponse WebDriverConnection::release_actions()
+{
+    // 1. If the current browsing context is no longer open, return error with error code no such window.
+    TRY(ensure_open_top_level_browsing_context());
+
+    // FIXME: 2. Let input state be the result of get the input state with current session and current top-level browsing context.
+
+    // FIXME: 3. Let actions options be a new actions options with the is element origin steps set to represents a web element, and the get element origin steps set to get a WebElement origin.
+
+    // FIXME: 4. Let undo actions be input state’s input cancel list in reverse order.
+
+    // FIXME: 5. Try to dispatch tick actions with arguments undo actions, 0, current browsing context, and actions options.
+
+    // FIXME: 6. Reset the input state with current session and current top-level browsing context.
+
+    // 7. Return success with data null.
+    return JsonValue {};
+}
+
 // 16.1 Dismiss Alert, https://w3c.github.io/webdriver/#dismiss-alert
 Messages::WebDriverClient::DismissAlertResponse WebDriverConnection::dismiss_alert()
 {

--- a/Userland/Services/WebContent/WebDriverConnection.h
+++ b/Userland/Services/WebContent/WebDriverConnection.h
@@ -88,6 +88,7 @@ private:
     virtual Messages::WebDriverClient::AddCookieResponse add_cookie(JsonValue const& payload) override;
     virtual Messages::WebDriverClient::DeleteCookieResponse delete_cookie(String const& name) override;
     virtual Messages::WebDriverClient::DeleteAllCookiesResponse delete_all_cookies() override;
+    virtual Messages::WebDriverClient::ReleaseActionsResponse release_actions() override;
     virtual Messages::WebDriverClient::DismissAlertResponse dismiss_alert() override;
     virtual Messages::WebDriverClient::AcceptAlertResponse accept_alert() override;
     virtual Messages::WebDriverClient::GetAlertTextResponse get_alert_text() override;

--- a/Userland/Services/WebDriver/Client.cpp
+++ b/Userland/Services/WebDriver/Client.cpp
@@ -632,6 +632,15 @@ Web::WebDriver::Response Client::delete_all_cookies(Web::WebDriver::Parameters p
     return session->web_content_connection().delete_all_cookies();
 }
 
+// 15.8 Release Actions, https://w3c.github.io/webdriver/#release-actions
+// DELETE /session/{session id}/actions
+Web::WebDriver::Response Client::release_actions(Web::WebDriver::Parameters parameters, JsonValue)
+{
+    dbgln_if(WEBDRIVER_DEBUG, "Handling DELETE /session/<session_id>/actions");
+    auto session = TRY(find_session_with_id(parameters[0]));
+    return session->web_content_connection().release_actions();
+}
+
 // 16.1 Dismiss Alert, https://w3c.github.io/webdriver/#dismiss-alert
 // POST /session/{session id}/alert/dismiss
 Web::WebDriver::Response Client::dismiss_alert(Web::WebDriver::Parameters parameters, JsonValue)

--- a/Userland/Services/WebDriver/Client.h
+++ b/Userland/Services/WebDriver/Client.h
@@ -85,6 +85,7 @@ private:
     virtual Web::WebDriver::Response add_cookie(Web::WebDriver::Parameters parameters, JsonValue payload) override;
     virtual Web::WebDriver::Response delete_cookie(Web::WebDriver::Parameters parameters, JsonValue payload) override;
     virtual Web::WebDriver::Response delete_all_cookies(Web::WebDriver::Parameters parameters, JsonValue payload) override;
+    virtual Web::WebDriver::Response release_actions(Web::WebDriver::Parameters parameters, JsonValue payload) override;
     virtual Web::WebDriver::Response dismiss_alert(Web::WebDriver::Parameters parameters, JsonValue payload) override;
     virtual Web::WebDriver::Response accept_alert(Web::WebDriver::Parameters parameters, JsonValue payload) override;
     virtual Web::WebDriver::Response get_alert_text(Web::WebDriver::Parameters parameters, JsonValue payload) override;


### PR DESCRIPTION
Cherry-picked the non-CSS commits from #19448

This lets 
```
 SERENITY_SOURCE_DIR=/home/andrew/serenity \
               python3 ./wpt/wpt run \
                    --webdriver-binary /home/andrew/serenity/Build/lagom/bin/WebDriver \
                    --no-fail-on-unexpected \
                    --no-fail-on-unexpected-pass  \
                    --skip-timeout \
                    --log-raw-level DEBUG --log-raw wpt.log \
                    ladybird   xhr/xmlhttprequest-eventtarget.htm
 ```
 actually open the test, but it doesn't actually close the browser at the end of the test (for reasons?)
 
 
 EDIT: Oh, all you need is `--no-pause-after-test` and we complete the test run :grimacing: 