### PR TITLE
LibWeb: Resolve viewport-relative `<img sizes>` values

### DIFF
--- a/Tests/LibWeb/Ref/img-srcset-viewport-relative-sizes-ref.html
+++ b/Tests/LibWeb/Ref/img-srcset-viewport-relative-sizes-ref.html
@@ -1,0 +1,6 @@
+<!doctype html>
+<img
+    src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIW2NgaGD4DwAChAGAZM0bBgAAAABJRU5ErkJggg=="
+    width="400"
+    height="400"
+/>

--- a/Tests/LibWeb/Ref/img-srcset-viewport-relative-sizes.html
+++ b/Tests/LibWeb/Ref/img-srcset-viewport-relative-sizes.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<img
+    sizes="100vw"
+    srcset="
+        data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIW2P4z8DwHwAFAAH/F1FwBgAAAABJRU5ErkJggg== 100w,
+        data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIW2NgaGD4DwAChAGAZM0bBgAAAABJRU5ErkJggg== 200w
+    "
+    width="400"
+    height="400"
+/>

--- a/Tests/LibWeb/Ref/manifest.json
+++ b/Tests/LibWeb/Ref/manifest.json
@@ -1,4 +1,5 @@
 {
+    "img-srcset-viewport-relative-sizes.html": "img-srcset-viewport-relative-sizes-ref.html",
     "square-flex.html": "square-ref.html",
     "separate-borders-inline-table.html": "separate-borders-ref.html",
     "opacity-stacking.html": "opacity-stacking-ref.html",

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -968,7 +968,7 @@ void Document::update_layout()
     if (!browsing_context())
         return;
 
-    auto viewport_rect = browsing_context()->viewport_rect();
+    auto viewport_rect = this->viewport_rect();
 
     if (!m_layout_root) {
         Layout::TreeBuilder tree_builder;
@@ -2101,10 +2101,7 @@ void Document::run_the_resize_steps()
     //    or an iframe element’s dimensions are changed) since the last time these steps were run,
     //    fire an event named resize at the Window object associated with doc.
 
-    if (!browsing_context())
-        return;
-
-    auto viewport_size = browsing_context()->viewport_rect().size().to_type<int>();
+    auto viewport_size = viewport_rect().size().to_type<int>();
     if (m_last_viewport_size == viewport_size)
         return;
     m_last_viewport_size = viewport_size;
@@ -2985,6 +2982,13 @@ HTML::ListOfAvailableImages& Document::list_of_available_images()
 HTML::ListOfAvailableImages const& Document::list_of_available_images() const
 {
     return *m_list_of_available_images;
+}
+
+CSSPixelRect Document::viewport_rect() const
+{
+    if (auto* browsing_context = this->browsing_context())
+        return browsing_context->viewport_rect();
+    return CSSPixelRect {};
 }
 
 JS::NonnullGCPtr<CSS::VisualViewport> Document::visual_viewport()

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -390,6 +390,7 @@ public:
     void add_media_query_list(JS::NonnullGCPtr<CSS::MediaQueryList>);
 
     JS::NonnullGCPtr<CSS::VisualViewport> visual_viewport();
+    [[nodiscard]] CSSPixelRect viewport_rect() const;
 
     bool has_focus() const;
 

--- a/Userland/Libraries/LibWeb/HTML/SourceSet.cpp
+++ b/Userland/Libraries/LibWeb/HTML/SourceSet.cpp
@@ -388,8 +388,15 @@ void SourceSet::normalize_source_densities(DOM::Element const& element)
 {
     // 1. Let source size be source set's source size.
     auto source_size = [&] {
-        if (!m_source_size.is_calculated())
+        if (!m_source_size.is_calculated()) {
+            // If the source size is viewport-relative, resolve it against the viewport right now.
+            if (m_source_size.value().is_viewport_relative()) {
+                return CSS::Length::make_px(m_source_size.value().viewport_relative_length_to_px(element.document().viewport_rect()));
+            }
+
+            // FIXME: Resolve font-relative lengths against the relevant font size.
             return m_source_size.value();
+        }
 
         // HACK: Flush any pending layouts here so we get an up-to-date length resolution context.
         // FIXME: We should have a way to build a LengthResolutionContext for any DOM node without going through the layout tree.


### PR DESCRIPTION
We still don't know how to resolve font-relative lengths in `<img sizes>` since we don't always have font size information available at this stage in the pipeline, but we can at least handle viewport-relative lengths.
    
This fixes an issue on many websites where low-resolution images were loaded (appropriate for a small viewport) even when the viewport is big.

Visual progression on https://twinings.co.uk/ (note quality of background image!)

Before:
![Screenshot at 2023-08-21 13-01-50](https://github.com/SerenityOS/serenity/assets/5954907/f15201b3-038e-464e-95c9-e744ab719a2e)

After:
![Screenshot at 2023-08-21 13-01-24](https://github.com/SerenityOS/serenity/assets/5954907/28fa5cb9-b2f3-4c46-8d66-e9de7cab9905)
