### PR TITLE
LibWeb+LibWebView+WebContent: Add support for "User" CascadeOrigin

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.h
@@ -168,6 +168,7 @@ private:
 
     struct MatchingRuleSet {
         Vector<MatchingRule> user_agent_rules;
+        Vector<MatchingRule> user_rules;
         Vector<MatchingRule> author_rules;
     };
 
@@ -202,7 +203,9 @@ private:
     void ensure_animation_timer() const;
 
     OwnPtr<RuleCache> m_author_rule_cache;
+    OwnPtr<RuleCache> m_user_rule_cache;
     OwnPtr<RuleCache> m_user_agent_rule_cache;
+    JS::Handle<CSSStyleSheet> m_user_style_sheet;
 
     mutable FontCache m_font_cache;
 

--- a/Userland/Libraries/LibWeb/Page/Page.cpp
+++ b/Userland/Libraries/LibWeb/Page/Page.cpp
@@ -9,6 +9,7 @@
 #include <AK/SourceLocation.h>
 #include <LibIPC/Decoder.h>
 #include <LibIPC/Encoder.h>
+#include <LibWeb/CSS/StyleComputer.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/BrowsingContext.h>
 #include <LibWeb/HTML/EventLoop/EventLoop.h>
@@ -370,6 +371,14 @@ JS::GCPtr<HTML::HTMLMediaElement> Page::media_context_menu_element()
         return nullptr;
 
     return static_cast<HTML::HTMLMediaElement*>(dom_node);
+}
+
+void Page::set_user_style(String source)
+{
+    m_user_style_sheet_source = source;
+    if (top_level_browsing_context_is_initialized() && top_level_browsing_context().active_document()) {
+        top_level_browsing_context().active_document()->style_computer().invalidate_rule_cache();
+    }
 }
 
 }

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -135,6 +135,9 @@ public:
     WebIDL::ExceptionOr<void> toggle_media_loop_state();
     WebIDL::ExceptionOr<void> toggle_media_controls_state();
 
+    Optional<String> const& user_style() const { return m_user_style_sheet_source; }
+    void set_user_style(String source);
+
     bool pdf_viewer_supported() const { return m_pdf_viewer_supported; }
 
 private:
@@ -166,6 +169,8 @@ private:
     Optional<Optional<String>> m_pending_prompt_response;
 
     Optional<int> m_media_context_menu_element_id;
+
+    Optional<String> m_user_style_sheet_source;
 
     // https://html.spec.whatwg.org/multipage/system-state.html#pdf-viewer-supported
     // Each user agent has a PDF viewer supported boolean, whose value is implementation-defined (and might vary according to user preferences).

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
@@ -516,4 +516,9 @@ void OutOfProcessWebView::set_content_scales_to_viewport(bool b)
     m_content_scales_to_viewport = b;
 }
 
+void OutOfProcessWebView::set_user_style_sheet(String source)
+{
+    client().async_set_user_style(source);
+}
+
 }

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.h
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.h
@@ -54,6 +54,8 @@ public:
     // In practice, this means that OOPWV may render scaled stale versions of the content while resizing.
     void set_content_scales_to_viewport(bool);
 
+    void set_user_style_sheet(String source);
+
 private:
     OutOfProcessWebView();
 

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020-2023, Andreas Kling <kling@serenityos.org>
- * Copyright (c) 2021, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2021-2023, Sam Atkins <atkinssj@serenityos.org>
  * Copyright (c) 2021-2023, Linus Groh <linusg@serenityos.org>
  * Copyright (c) 2022, Tobias Christiansen <tobyase@serenityos.org>
  * Copyright (c) 2022, Tim Flynn <trflynn89@serenityos.org>
@@ -857,6 +857,11 @@ void ConnectionFromClient::toggle_media_loop_state()
 void ConnectionFromClient::toggle_media_controls_state()
 {
     m_page_host->toggle_media_controls_state().release_value_but_fixme_should_propagate_errors();
+}
+
+void ConnectionFromClient::set_user_style(String const& source)
+{
+    m_page_host->set_user_style(source);
 }
 
 void ConnectionFromClient::inspect_accessibility_tree()

--- a/Userland/Services/WebContent/ConnectionFromClient.h
+++ b/Userland/Services/WebContent/ConnectionFromClient.h
@@ -102,6 +102,8 @@ private:
     virtual void toggle_media_loop_state() override;
     virtual void toggle_media_controls_state() override;
 
+    virtual void set_user_style(String const&) override;
+
     virtual Messages::WebContentServer::TakeDocumentScreenshotResponse take_document_screenshot() override;
 
     virtual Messages::WebContentServer::GetLocalStorageEntriesResponse get_local_storage_entries() override;

--- a/Userland/Services/WebContent/PageHost.cpp
+++ b/Userland/Services/WebContent/PageHost.cpp
@@ -366,6 +366,11 @@ Web::WebIDL::ExceptionOr<void> PageHost::toggle_media_controls_state()
     return page().toggle_media_controls_state();
 }
 
+void PageHost::set_user_style(String source)
+{
+    page().set_user_style(source);
+}
+
 void PageHost::page_did_request_accept_dialog()
 {
     m_client.async_did_request_accept_dialog();

--- a/Userland/Services/WebContent/PageHost.h
+++ b/Userland/Services/WebContent/PageHost.h
@@ -56,6 +56,8 @@ public:
 
     [[nodiscard]] Gfx::Color background_color() const;
 
+    void set_user_style(String source);
+
 private:
     // ^PageClient
     virtual bool is_connection_open() const override;

--- a/Userland/Services/WebContent/WebContentServer.ipc
+++ b/Userland/Services/WebContent/WebContentServer.ipc
@@ -83,4 +83,6 @@ endpoint WebContentServer
     toggle_media_mute_state() =|
     toggle_media_loop_state() =|
     toggle_media_controls_state() =|
+
+    set_user_style(String source) =|
 }


### PR DESCRIPTION
Right now we directly pass theme colours to web content, so that it matches native SerenityOS widgets. That's not quite what websites expect, and some websites (like example.com) are illegible when using dark themes.

Implementing the User CascadeOrigin is a first step to fixing this: We use more expected colours by default, and then let Help and other users of OOPWV manually set a user style-sheet that matches the desktop theme.

This PR just implements the User CascadeOrigin, and doesn't make anything use it.