### PR TITLE
Ports/prboom-plus: Add `CMAKE_TOOLCHAIN_FILE` to `configopts`

### DIFF
--- a/Ports/prboom-plus/package.sh
+++ b/Ports/prboom-plus/package.sh
@@ -10,10 +10,7 @@ files=(
 workdir="prboom-plus-${version}/prboom2"
 depends=("glu" "libmad" "libvorbis" "SDL2" "SDL2_image" "SDL2_mixer" "SDL2_net")
 configopts=(
-    "-DCMAKE_C_FLAGS=-I${SERENITY_INSTALL_ROOT}/usr/include/LibGL"
-    "-DCMAKE_PREFIX_PATH=${SERENITY_INSTALL_ROOT}/usr/local"
-    "-DFORCE_CROSSCOMPILE=ON"
-    "-DOPENGL_gl_LIBRARY=${SERENITY_INSTALL_ROOT}/usr/lib/libgl.so"
+    "-DCMAKE_TOOLCHAIN_FILE=${SERENITY_BUILD_DIR}/CMakeToolchain.txt"
     "-DWITH_ALSA=OFF"
     "-DWITH_DUMB=OFF"
     "-DWITH_FLUIDSYNTH=OFF"
@@ -36,7 +33,7 @@ build() {
 }
 
 install() {
-    run make DESTDIR="${DESTDIR}" -C build install
+    run make -C build install
 
     wad_directory="${SERENITY_INSTALL_ROOT}/usr/local/share/games/doom"
     mkdir -p "${wad_directory}"

--- a/Ports/prboom-plus/package.sh
+++ b/Ports/prboom-plus/package.sh
@@ -2,21 +2,29 @@
 port='prboom-plus'
 version='2.6.2'
 useconfigure='true'
-squashed_version=$(echo "${version}" | tr -d '.')
+squashed_version="$(echo ${version} | tr -d '.')"
 files=(
     "https://github.com/coelckers/prboom-plus/archive/refs/tags/v${version}.tar.gz 5cfeec96fbfe4fc3bd5dbc2b8d581ff5f6617dd74b2799680ba5b1e2e38c4aff"
     "https://github.com/coelckers/prboom-plus/releases/download/v${version}/prboom-plus-${squashed_version}-w32.zip 20313e00d8841a618e23e7c671d65870194bee634468fecd2f3697ac05f21476"
 )
 workdir="prboom-plus-${version}/prboom2"
-depends=("glu" "libmad" "libvorbis" "SDL2" "SDL2_image" "SDL2_mixer" "SDL2_net")
+depends=(
+    'glu'
+    'libmad'
+    'libvorbis'
+    'SDL2'
+    'SDL2_image'
+    'SDL2_mixer'
+    'SDL2_net'
+)
 configopts=(
     "-DCMAKE_TOOLCHAIN_FILE=${SERENITY_BUILD_DIR}/CMakeToolchain.txt"
-    "-DWITH_ALSA=OFF"
-    "-DWITH_DUMB=OFF"
-    "-DWITH_FLUIDSYNTH=OFF"
-    "-DWITH_PCRE=OFF"
-    "-DWITH_PORTMIDI=OFF"
-    "-Wno-dev"
+    '-DWITH_ALSA=OFF'
+    '-DWITH_DUMB=OFF'
+    '-DWITH_FLUIDSYNTH=OFF'
+    '-DWITH_PCRE=OFF'
+    '-DWITH_PORTMIDI=OFF'
+    '-Wno-dev'
 )
 
 launcher_name='PrBoom+'


### PR DESCRIPTION
This fixes an issue where `prboom-plus` wouldn't build if the `make` port was installed. Including this also makes some manually specified paths unnecessary.