### PR TITLE
LibWeb: Update <use> visuals after changing the referenced element

### DIFF
--- a/Userland/Libraries/LibWeb/SVG/SVGUseElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGUseElement.cpp
@@ -57,6 +57,8 @@ void SVGUseElement::attribute_changed(DeprecatedFlyString const& name, Deprecate
     } else if (name == SVG::AttributeNames::href) {
         // FIXME: Support the xlink:href attribute as a fallback
         m_referenced_id = parse_id_from_href(value);
+
+        clone_element_tree_as_our_shadow_tree(referenced_element());
     }
 }
 


### PR DESCRIPTION
| Before | After |
| --- | --- |
| <video src="https://github.com/SerenityOS/serenity/assets/36564831/4de5cd10-7b80-4b55-af8c-7983ca1e4446"> | <video src="https://github.com/SerenityOS/serenity/assets/36564831/d42aea1e-ef07-47a9-984b-f6c5fd31693b"> |

Previously we would only update the shadow tree if the original \<symbol\> element or any of its children were changed or when the document was loaded. Coincidentally, there was an issue that if for some reason the document is already loaded when `initialize()` of the \<use\> element is called, or the document never finishes loading (due to a bug probably, I didn't figure out which option is actually occurring), the shadow tree is never populated. So this might be papering over some other issue... but either way, some SVGs on the https://www.jetbrains.com are appearing!

| Before | After |
| --- | --- |
| ![obraz](https://github.com/SerenityOS/serenity/assets/36564831/475ae388-407b-4f38-992a-92605ef46c4e) | ![obraz](https://github.com/SerenityOS/serenity/assets/36564831/ca838364-5d37-46ff-b067-8dad59466702) |