### PR TITLE
Ports/dtc: Specify `NO_PYTHON` when running `make install`

### DIFF
--- a/Ports/dtc/package.sh
+++ b/Ports/dtc/package.sh
@@ -12,5 +12,5 @@ build() {
 }
 
 install() {
-    run make PREFIX="${DESTDIR}" BINDIR="${DESTDIR}/usr/bin" install
+    run make NO_PYTHON=1 PREFIX="${DESTDIR}" BINDIR="${DESTDIR}/usr/bin" install
 }


### PR DESCRIPTION
Previously, the install step was failing on my machine when the `python3` port was installed.