### PR TITLE
LibWeb: Stop collecting lookahead items on forced break

### DIFF
--- a/Tests/LibWeb/Layout/expected/table/forced-break-stops-non-whitespace-sequence.txt
+++ b/Tests/LibWeb/Layout/expected/table/forced-break-stops-non-whitespace-sequence.txt
@@ -1,0 +1,17 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,16) content-size 784x19.46875 children: not-inline
+      BlockContainer <pre> at (9,17) content-size 782x17.46875 children: inline
+        line 0 width: 8, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+          frag 0 from TextNode start: 0, length: 1, rect: [9,17 8x17.46875]
+            " "
+        InlineNode <span>
+          TextNode <#text>
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,16 784x19.46875]
+      PaintableWithLines (BlockContainer<PRE>) [8,16 784x19.46875]
+        InlinePaintable (InlineNode<SPAN>)
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/input/table/forced-break-stops-non-whitespace-sequence.html
+++ b/Tests/LibWeb/Layout/input/table/forced-break-stops-non-whitespace-sequence.html
@@ -1,0 +1,3 @@
+<pre style="border: 1px solid black">
+<span> </span>
+</pre>

--- a/Userland/Libraries/LibWeb/Layout/InlineLevelIterator.cpp
+++ b/Userland/Libraries/LibWeb/Layout/InlineLevelIterator.cpp
@@ -140,6 +140,8 @@ CSSPixels InlineLevelIterator::next_non_whitespace_sequence_width()
             break;
         m_lookahead_items.enqueue(next_item_opt.release_value());
         auto& next_item = m_lookahead_items.tail();
+        if (next_item.type == InlineLevelIterator::Item::Type::ForcedBreak)
+            break;
         if (next_item.node->computed_values().white_space() != CSS::WhiteSpace::Nowrap) {
             if (next_item.type != InlineLevelIterator::Item::Type::Text)
                 break;


### PR DESCRIPTION
This avoids a crash since such items don't have a node nor CSS properties. Fixes crashes on Wikipedia pages which contain preformatted code.