### PR TITLE
AK: Full C11 compliant PrintfImplementation

### DIFF
--- a/Tests/LibC/TestSnprintf.cpp
+++ b/Tests/LibC/TestSnprintf.cpp
@@ -471,6 +471,36 @@ TEST_CASE(hexponential)
     EXPECT(test_single<double>({ LITERAL("xxxxxxxxxxxxxx"), "|%.4a|", 0.01, 13, LITERAL("|0x1.47aep-7|\0") }));
 }
 
+TEST_CASE(char_values)
+{
+    // Regular chars.
+    EXPECT(test_single<char>({ LITERAL("xxxx"), "|%c|", 'a', 3, LITERAL("|a|\0") }));
+    EXPECT(test_single<char>({ LITERAL("xxxxxxx"), "|%4c|", 'a', 6, LITERAL("|   a|\0") }));
+    EXPECT(test_single<char>({ LITERAL("xxxxxxx"), "|%-4c|", 'a', 6, LITERAL("|a   |\0") }));
+
+    // Wide chars. (on serenity emoji are one character wide)
+    EXPECT(test_single<wchar_t>({ LITERAL("xxxxxxx"), "|%lc|", L'😀', 6, LITERAL("|😀|\0") }));
+    EXPECT(test_single<wchar_t>({ LITERAL("xxxxxxxxxx"), "|%4lc|", L'😀', 9, LITERAL("|   😀|\0") }));
+    EXPECT(test_single<wchar_t>({ LITERAL("xxxxxxxxxx"), "|%-4lc|", L'😀', 9, LITERAL("|😀   |\0") }));
+}
+
+TEST_CASE(strings)
+{
+    // Regular strings.
+    EXPECT(test_single<char const*>({ LITERAL("xxxxxx"), "|%s|", "abc", 5, LITERAL("|abc|\0") }));
+    EXPECT(test_single<char const*>({ LITERAL("xxxxx"), "|%.2s|", "abc", 4, LITERAL("|ab|\0") }));
+    EXPECT(test_single<char const*>({ LITERAL("xxxxxxxxx"), "|%6s|", "abc", 8, LITERAL("|   abc|\0") }));
+    EXPECT(test_single<char const*>({ LITERAL("xxxxxxxxx"), "|%-6s|", "abc", 8, LITERAL("|abc   |\0") }));
+
+    // Wide chars. (on serenity emoji are one character wide)
+    EXPECT(test_single<wchar_t const*>({ LITERAL("xxxxxxxxxx"), "|%ls|", L"😀abc", 9, LITERAL("|😀abc|\0") }));
+    EXPECT(test_single<wchar_t const*>({ LITERAL("xxx"), "|%.2ls|", L"😀abc", 2, LITERAL("||\0") }));
+    EXPECT(test_single<wchar_t const*>({ LITERAL("xxxxxxx"), "|%.4ls|", L"😀abc", 6, LITERAL("|😀|\0") }));
+    EXPECT(test_single<wchar_t const*>({ LITERAL("xxxxxxxxx"), "|%.6ls|", L"😀abc", 8, LITERAL("|😀ab|\0") }));
+    EXPECT(test_single<wchar_t const*>({ LITERAL("xxxxxxxxxxxxx"), "|%7ls|", L"😀abc", 12, LITERAL("|   😀abc|\0") }));
+    EXPECT(test_single<wchar_t const*>({ LITERAL("xxxxxxxxxxxxx"), "|%-7ls|", L"😀abc", 12, LITERAL("|😀abc   |\0") }));
+}
+
 TEST_CASE(truncation)
 {
     EXPECT(test_single<int>({ LITERAL("xxxxxxxxxxxxx"), "|%d|", INT_MAX, 12, LITERAL("|2147483647|\0") }));

--- a/Userland/Applications/Spreadsheet/CellType/Format.cpp
+++ b/Userland/Applications/Spreadsheet/CellType/Format.cpp
@@ -11,8 +11,17 @@
 
 namespace Spreadsheet {
 
+// This needs to exist but will never be called.
 template<typename T, typename V>
 struct SingleEntryListNext {
+    ALWAYS_INLINE T operator()(V) const
+    {
+        VERIFY_NOT_REACHED();
+    }
+};
+
+template<Arithmetic T, typename V>
+struct SingleEntryListNext<T, V> {
     ALWAYS_INLINE T operator()(V value) const
     {
         return (T)value;
@@ -27,13 +36,14 @@ struct PrintfImpl : public PrintfImplementation::PrintfImpl<PutChFunc, ArgumentL
     }
 
     // Disallow pointer formats.
-    ALWAYS_INLINE int format_n(PrintfImplementation::ModifierState const&, ArgumentListRefT&) const
+    ALWAYS_INLINE int format_n(PrintfImplementation::FormatSpecifier const& fmt, ArgumentListRefT& ap) const
     {
-        return 0;
+        return PrintfImplementation::PrintfImpl<PutChFunc, ArgumentListRefT, NextArgument>::format_unrecognized(fmt, ap);
     }
-    ALWAYS_INLINE int format_s(PrintfImplementation::ModifierState const&, ArgumentListRefT&) const
+
+    ALWAYS_INLINE int format_s(PrintfImplementation::FormatSpecifier const& fmt, ArgumentListRefT& ap) const
     {
-        return 0;
+        return PrintfImplementation::PrintfImpl<PutChFunc, ArgumentListRefT, NextArgument>::format_unrecognized(fmt, ap);
     }
 };
 


### PR DESCRIPTION
Because printf was breaking ports, I decided to make it fully posix/c11 compliant.

This PR adds:
- Adds full support for %e, %g, and %a, giving us support for every conversion specifier.
- Supports all length modifiers.
- Supports precisions that would overflow.
- Support wide chars in %c and %s.
- Refactors to share more code.
- Adds spec links.
- Add lots of tests.

as far as i know the only things that could be missing are float edge cases.