### PR TITLE
Ports/SDL_sound: Specify which optional dependencies to include

### DIFF
--- a/Ports/SDL_sound/package.sh
+++ b/Ports/SDL_sound/package.sh
@@ -19,6 +19,6 @@ configopts=(
     '--enable-speex=no'
     "--with-sdl-prefix=${SERENITY_INSTALL_ROOT}/usr/local"
 )
-makeopts=(
+makeopts+=(
     'LDFLAGS=-lm'
 )


### PR DESCRIPTION
This fixes an issue where building `SDL_sound` with the `libphysfs` port installed would cause the build to fail.

Ogg support has also been enabled. This allows playback of the sound effects in GLTron.

Both FLAC and `libmodplug` support are currently disabled, even though the build succeeds with them enabled, as there is currently no way to test whether they would work or not (and given the age of the SDL library I wouldn't be confident in these working without testing them).