### PR TITLE
LibLocale+LibJS: Make locale APIs infallible

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibLocale/GenerateDateTimeFormatData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibLocale/GenerateDateTimeFormatData.cpp
@@ -2091,7 +2091,7 @@ Optional<@return_type@> get_regional_@lookup_type@(StringView region)
     append_regional_lookup("Weekday"sv, "weekend_end"sv);
 
     generator.append(R"~~~(
-static ErrorOr<CalendarData const*> find_calendar_data(StringView locale, StringView calendar)
+static CalendarData const* find_calendar_data(StringView locale, StringView calendar)
 {
     auto locale_value = locale_from_string(locale);
     if (!locale_value.has_value())
@@ -2118,7 +2118,7 @@ static ErrorOr<CalendarData const*> find_calendar_data(StringView locale, String
     if (auto const* calendar_data = lookup_calendar(calendar))
         return calendar_data;
 
-    auto default_calendar = TRY(get_preferred_keyword_value_for_locale(locale, "ca"sv));
+    auto default_calendar = get_preferred_keyword_value_for_locale(locale, "ca"sv);
     if (!default_calendar.has_value())
         return nullptr;
 
@@ -2127,7 +2127,7 @@ static ErrorOr<CalendarData const*> find_calendar_data(StringView locale, String
 
 ErrorOr<Optional<CalendarFormat>> get_calendar_date_format(StringView locale, StringView calendar)
 {
-    if (auto const* data = TRY(find_calendar_data(locale, calendar)); data != nullptr) {
+    if (auto const* data = find_calendar_data(locale, calendar); data != nullptr) {
         auto const& formats = s_calendar_formats.at(data->date_formats);
         return TRY(formats.to_unicode_calendar_format());
     }
@@ -2136,7 +2136,7 @@ ErrorOr<Optional<CalendarFormat>> get_calendar_date_format(StringView locale, St
 
 ErrorOr<Optional<CalendarFormat>> get_calendar_time_format(StringView locale, StringView calendar)
 {
-    if (auto const* data = TRY(find_calendar_data(locale, calendar)); data != nullptr) {
+    if (auto const* data = find_calendar_data(locale, calendar); data != nullptr) {
         auto const& formats = s_calendar_formats.at(data->time_formats);
         return TRY(formats.to_unicode_calendar_format());
     }
@@ -2145,7 +2145,7 @@ ErrorOr<Optional<CalendarFormat>> get_calendar_time_format(StringView locale, St
 
 ErrorOr<Optional<CalendarFormat>> get_calendar_date_time_format(StringView locale, StringView calendar)
 {
-    if (auto const* data = TRY(find_calendar_data(locale, calendar)); data != nullptr) {
+    if (auto const* data = find_calendar_data(locale, calendar); data != nullptr) {
         auto const& formats = s_calendar_formats.at(data->date_time_formats);
         return TRY(formats.to_unicode_calendar_format());
     }
@@ -2156,7 +2156,7 @@ ErrorOr<Vector<CalendarPattern>> get_calendar_available_formats(StringView local
 {
     Vector<CalendarPattern> result {};
 
-    if (auto const* data = TRY(find_calendar_data(locale, calendar)); data != nullptr) {
+    if (auto const* data = find_calendar_data(locale, calendar); data != nullptr) {
         auto const& available_formats = s_calendar_pattern_lists.at(data->available_formats);
         TRY(result.try_ensure_capacity(available_formats.size()));
 
@@ -2169,7 +2169,7 @@ ErrorOr<Vector<CalendarPattern>> get_calendar_available_formats(StringView local
 
 ErrorOr<Optional<CalendarRangePattern>> get_calendar_default_range_format(StringView locale, StringView calendar)
 {
-    if (auto const* data = TRY(find_calendar_data(locale, calendar)); data != nullptr) {
+    if (auto const* data = find_calendar_data(locale, calendar); data != nullptr) {
         auto const& pattern = s_calendar_range_patterns[data->default_range_format];
         return TRY(pattern.to_unicode_calendar_range_pattern());
     }
@@ -2181,7 +2181,7 @@ ErrorOr<Vector<CalendarRangePattern>> get_calendar_range_formats(StringView loca
 {
     Vector<CalendarRangePattern> result {};
 
-    if (auto const* data = TRY(find_calendar_data(locale, calendar)); data != nullptr) {
+    if (auto const* data = find_calendar_data(locale, calendar); data != nullptr) {
         auto const& range_formats = s_calendar_range_pattern_lists.at(data->range_formats);
 
         for (auto format : range_formats) {
@@ -2199,7 +2199,7 @@ ErrorOr<Vector<CalendarRangePattern>> get_calendar_range12_formats(StringView lo
 {
     Vector<CalendarRangePattern> result {};
 
-    if (auto const* data = TRY(find_calendar_data(locale, calendar)); data != nullptr) {
+    if (auto const* data = find_calendar_data(locale, calendar); data != nullptr) {
         auto const& range12_formats = s_calendar_range_pattern_lists.at(data->range12_formats);
 
         for (auto format : range12_formats) {
@@ -2215,7 +2215,7 @@ ErrorOr<Vector<CalendarRangePattern>> get_calendar_range12_formats(StringView lo
 
 static ErrorOr<ReadonlySpan<@string_index_type@>> find_calendar_symbols(StringView locale, StringView calendar, CalendarSymbol symbol, CalendarPatternStyle style)
 {
-    if (auto const* data = TRY(find_calendar_data(locale, calendar)); data != nullptr) {
+    if (auto const* data = find_calendar_data(locale, calendar); data != nullptr) {
         auto const& symbols_list = s_calendar_symbol_lists[data->symbols];
         auto symbol_index = to_underlying(symbol);
 

--- a/Meta/Lagom/Tools/CodeGenerators/LibLocale/GenerateLocaleData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibLocale/GenerateLocaleData.cpp
@@ -1680,7 +1680,7 @@ Optional<StringView> get_preferred_keyword_value_for_locale(StringView locale, S
     // FIXME: Calendar keywords are also region-based, and will need to be handled here when we support non-Gregorian calendars:
     //        https://github.com/unicode-org/cldr-json/blob/main/cldr-json/cldr-core/supplemental/calendarPreferenceData.json
     if (key == "hc"sv) {
-        auto hour_cycles = MUST(get_locale_hour_cycles(locale));
+        auto hour_cycles = get_locale_hour_cycles(locale);
         if (hour_cycles.is_empty())
             return OptionalNone {};
 
@@ -1709,7 +1709,7 @@ Vector<StringView> get_keywords_for_locale(StringView locale, StringView key)
     // FIXME: Calendar keywords are also region-based, and will need to be handled here when we support non-Gregorian calendars:
     //        https://github.com/unicode-org/cldr-json/blob/main/cldr-json/cldr-core/supplemental/calendarPreferenceData.json
     if (key == "hc"sv) {
-        auto hour_cycles = MUST(get_locale_hour_cycles(locale));
+        auto hour_cycles = get_locale_hour_cycles(locale);
 
         Vector<StringView> values;
         values.ensure_capacity(hour_cycles.size());

--- a/Meta/Lagom/Tools/CodeGenerators/LibLocale/GenerateNumberFormatData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibLocale/GenerateNumberFormatData.cpp
@@ -927,7 +927,7 @@ Optional<ReadonlySpan<u32>> get_digits_for_number_system(StringView system)
     return s_number_systems_digits[number_system_index];
 }
 
-static ErrorOr<NumberSystemData const*> find_number_system(StringView locale, StringView system)
+static NumberSystemData const* find_number_system(StringView locale, StringView system)
 {
     auto locale_value = locale_from_string(locale);
     if (!locale_value.has_value())
@@ -957,44 +957,44 @@ static ErrorOr<NumberSystemData const*> find_number_system(StringView locale, St
     if (auto const* number_system = lookup_number_system(system))
         return number_system;
 
-    auto default_number_system = TRY(get_preferred_keyword_value_for_locale(locale, "nu"sv));
+    auto default_number_system = get_preferred_keyword_value_for_locale(locale, "nu"sv);
     if (!default_number_system.has_value())
         return nullptr;
 
     return lookup_number_system(*default_number_system);
 }
 
-ErrorOr<Optional<StringView>> get_number_system_symbol(StringView locale, StringView system, NumericSymbol symbol)
+Optional<StringView> get_number_system_symbol(StringView locale, StringView system, NumericSymbol symbol)
 {
-    if (auto const* number_system = TRY(find_number_system(locale, system)); number_system != nullptr) {
+    if (auto const* number_system = find_number_system(locale, system); number_system != nullptr) {
         auto symbols = s_numeric_symbol_lists.at(number_system->symbols);
 
         auto symbol_index = to_underlying(symbol);
         if (symbol_index >= symbols.size())
-            return OptionalNone {};
+            return {};
 
-        return Optional<StringView> { decode_string(symbols[symbol_index]) };
+        return decode_string(symbols[symbol_index]);
     }
 
-    return OptionalNone {};
+    return {};
 }
 
-ErrorOr<Optional<NumberGroupings>> get_number_system_groupings(StringView locale, StringView system)
+Optional<NumberGroupings> get_number_system_groupings(StringView locale, StringView system)
 {
     auto locale_value = locale_from_string(locale);
     if (!locale_value.has_value())
-        return OptionalNone {};
+        return {};
 
     u8 minimum_grouping_digits = s_minimum_grouping_digits[to_underlying(*locale_value) - 1];
 
-    if (auto const* number_system = TRY(find_number_system(locale, system)); number_system != nullptr)
+    if (auto const* number_system = find_number_system(locale, system); number_system != nullptr)
         return NumberGroupings { minimum_grouping_digits, number_system->primary_grouping_size, number_system->secondary_grouping_size };
-    return OptionalNone {};
+    return {};
 }
 
 ErrorOr<Optional<NumberFormat>> get_standard_number_system_format(StringView locale, StringView system, StandardNumberFormatType type)
 {
-    if (auto const* number_system = TRY(find_number_system(locale, system)); number_system != nullptr) {
+    if (auto const* number_system = find_number_system(locale, system); number_system != nullptr) {
         @number_format_index_type@ format_index = 0;
 
         switch (type) {
@@ -1025,7 +1025,7 @@ ErrorOr<Vector<NumberFormat>> get_compact_number_system_formats(StringView local
 {
     Vector<NumberFormat> formats;
 
-    if (auto const* number_system = TRY(find_number_system(locale, system)); number_system != nullptr) {
+    if (auto const* number_system = find_number_system(locale, system); number_system != nullptr) {
         @number_format_list_index_type@ number_format_list_index { 0 };
 
         switch (type) {

--- a/Meta/Lagom/Tools/CodeGenerators/LibLocale/GenerateNumberFormatData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibLocale/GenerateNumberFormatData.cpp
@@ -796,7 +796,7 @@ namespace Locale {
 
     generator.append(R"~~~(
 struct NumberFormatImpl {
-    ErrorOr<NumberFormat> to_unicode_number_format() const {
+    NumberFormat to_unicode_number_format() const {
         NumberFormat number_format {};
 
         number_format.magnitude = magnitude;
@@ -806,7 +806,7 @@ struct NumberFormatImpl {
         number_format.positive_format = decode_string(positive_format);
         number_format.negative_format = decode_string(negative_format);
 
-        TRY(number_format.identifiers.try_ensure_capacity(identifiers.size()));
+        number_format.identifiers.ensure_capacity(identifiers.size());
         for (@string_index_type@ identifier : identifiers)
             number_format.identifiers.unchecked_append(decode_string(identifier));
 
@@ -992,7 +992,7 @@ Optional<NumberGroupings> get_number_system_groupings(StringView locale, StringV
     return {};
 }
 
-ErrorOr<Optional<NumberFormat>> get_standard_number_system_format(StringView locale, StringView system, StandardNumberFormatType type)
+Optional<NumberFormat> get_standard_number_system_format(StringView locale, StringView system, StandardNumberFormatType type)
 {
     if (auto const* number_system = find_number_system(locale, system); number_system != nullptr) {
         @number_format_index_type@ format_index = 0;
@@ -1015,13 +1015,13 @@ ErrorOr<Optional<NumberFormat>> get_standard_number_system_format(StringView loc
             break;
         }
 
-        return TRY(s_number_formats[format_index].to_unicode_number_format());
+        return s_number_formats[format_index].to_unicode_number_format();
     }
 
-    return OptionalNone {};
+    return {};
 }
 
-ErrorOr<Vector<NumberFormat>> get_compact_number_system_formats(StringView locale, StringView system, CompactNumberFormatType type)
+Vector<NumberFormat> get_compact_number_system_formats(StringView locale, StringView system, CompactNumberFormatType type)
 {
     Vector<NumberFormat> formats;
 
@@ -1044,10 +1044,10 @@ ErrorOr<Vector<NumberFormat>> get_compact_number_system_formats(StringView local
         }
 
         auto number_formats = s_number_format_lists.at(number_format_list_index);
-        TRY(formats.try_ensure_capacity(number_formats.size()));
+        formats.ensure_capacity(number_formats.size());
 
         for (auto number_format : number_formats)
-            formats.unchecked_append(TRY(s_number_formats[number_format].to_unicode_number_format()));
+            formats.unchecked_append(s_number_formats[number_format].to_unicode_number_format());
     }
 
     return formats;
@@ -1072,7 +1072,7 @@ static Unit const* find_units(StringView locale, StringView unit)
     return nullptr;
 }
 
-ErrorOr<Vector<NumberFormat>> get_unit_formats(StringView locale, StringView unit, Style style)
+Vector<NumberFormat> get_unit_formats(StringView locale, StringView unit, Style style)
 {
     Vector<NumberFormat> formats;
 
@@ -1094,10 +1094,10 @@ ErrorOr<Vector<NumberFormat>> get_unit_formats(StringView locale, StringView uni
         }
 
         auto number_formats = s_number_format_lists.at(number_format_list_index);
-        TRY(formats.try_ensure_capacity(number_formats.size()));
+        formats.ensure_capacity(number_formats.size());
 
         for (auto number_format : number_formats)
-            formats.unchecked_append(TRY(s_number_formats[number_format].to_unicode_number_format()));
+            formats.unchecked_append(s_number_formats[number_format].to_unicode_number_format());
     }
 
     return formats;

--- a/Meta/Lagom/Tools/CodeGenerators/LibLocale/GenerateRelativeTimeFormatData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibLocale/GenerateRelativeTimeFormatData.cpp
@@ -245,7 +245,7 @@ static constexpr Array<@relative_time_format_index_type@, @size@> @name@ { {)~~~
     generate_mapping(generator, cldr.locales, cldr.unique_formats.type_that_fits(), "s_locale_relative_time_formats"sv, "s_number_systems_digits_{}"sv, nullptr, [&](auto const& name, auto const& value) { append_list(name, value.time_units); });
 
     generator.append(R"~~~(
-ErrorOr<Vector<RelativeTimeFormat>> get_relative_time_format_patterns(StringView locale, TimeUnit time_unit, StringView tense_or_number, Style style)
+Vector<RelativeTimeFormat> get_relative_time_format_patterns(StringView locale, TimeUnit time_unit, StringView tense_or_number, Style style)
 {
     Vector<RelativeTimeFormat> formats;
 
@@ -266,7 +266,7 @@ ErrorOr<Vector<RelativeTimeFormat>> get_relative_time_format_patterns(StringView
         if (decode_string(locale_format.tense_or_number) != tense_or_number)
             continue;
 
-        TRY(formats.try_append(locale_format.to_relative_time_format()));
+        formats.append(locale_format.to_relative_time_format());
     }
 
     return formats;

--- a/Tests/LibLocale/TestDateTimeFormat.cpp
+++ b/Tests/LibLocale/TestDateTimeFormat.cpp
@@ -75,7 +75,7 @@ TEST_CASE(time_zone_name)
     constexpr auto jan_1_2022 = AK::UnixDateTime::from_seconds_since_epoch(1640995200); // Saturday, January 1, 2022 12:00:00 AM
 
     for (auto const& test : test_data) {
-        auto time_zone = MUST(Locale::format_time_zone(test.locale, test.time_zone, test.style, jan_1_2022));
+        auto time_zone = Locale::format_time_zone(test.locale, test.time_zone, test.style, jan_1_2022);
         EXPECT_EQ(time_zone, test.expected_result);
     }
 }
@@ -125,7 +125,7 @@ TEST_CASE(time_zone_name_dst)
     constexpr auto sep_19_2022 = AK::UnixDateTime::from_seconds_since_epoch(1663553728); // Monday, September 19, 2022 2:15:28 AM
 
     for (auto const& test : test_data) {
-        auto time_zone = MUST(Locale::format_time_zone(test.locale, test.time_zone, test.style, sep_19_2022));
+        auto time_zone = Locale::format_time_zone(test.locale, test.time_zone, test.style, sep_19_2022);
         EXPECT_EQ(time_zone, test.expected_result);
     }
 }
@@ -182,7 +182,7 @@ TEST_CASE(format_time_zone_offset)
     };
 
     for (auto const& test : test_data) {
-        auto time_zone = MUST(Locale::format_time_zone(test.locale, test.time_zone, test.style, test.time));
+        auto time_zone = Locale::format_time_zone(test.locale, test.time_zone, test.style, test.time);
         EXPECT_EQ(time_zone, test.expected_result);
     }
 }

--- a/Tests/LibLocale/TestLocale.cpp
+++ b/Tests/LibLocale/TestLocale.cpp
@@ -104,11 +104,11 @@ template<typename LHS, typename RHS>
 TEST_CASE(parse_unicode_locale_id)
 {
     auto fail = [](StringView locale) {
-        auto locale_id = MUST(Locale::parse_unicode_locale_id(locale));
+        auto locale_id = Locale::parse_unicode_locale_id(locale);
         EXPECT(!locale_id.has_value());
     };
     auto pass = [](StringView locale, Optional<StringView> expected_language, Optional<StringView> expected_script, Optional<StringView> expected_region, Vector<StringView> expected_variants) {
-        auto locale_id = MUST(Locale::parse_unicode_locale_id(locale));
+        auto locale_id = Locale::parse_unicode_locale_id(locale);
         VERIFY(locale_id.has_value());
 
         EXPECT_EQ(locale_id->language_id.language, expected_language);
@@ -145,11 +145,11 @@ TEST_CASE(parse_unicode_locale_id_with_unicode_locale_extension)
     };
 
     auto fail = [](StringView locale) {
-        auto locale_id = MUST(Locale::parse_unicode_locale_id(locale));
+        auto locale_id = Locale::parse_unicode_locale_id(locale);
         EXPECT(!locale_id.has_value());
     };
     auto pass = [](StringView locale, LocaleExtension const& expected_extension) {
-        auto locale_id = MUST(Locale::parse_unicode_locale_id(locale));
+        auto locale_id = Locale::parse_unicode_locale_id(locale);
         VERIFY(locale_id.has_value());
         EXPECT_EQ(locale_id->extensions.size(), 1u);
 
@@ -209,11 +209,11 @@ TEST_CASE(parse_unicode_locale_id_with_transformed_extension)
     };
 
     auto fail = [](StringView locale) {
-        auto locale_id = MUST(Locale::parse_unicode_locale_id(locale));
+        auto locale_id = Locale::parse_unicode_locale_id(locale);
         EXPECT(!locale_id.has_value());
     };
     auto pass = [](StringView locale, TransformedExtension const& expected_extension) {
-        auto locale_id = MUST(Locale::parse_unicode_locale_id(locale));
+        auto locale_id = Locale::parse_unicode_locale_id(locale);
         VERIFY(locale_id.has_value());
         EXPECT_EQ(locale_id->extensions.size(), 1u);
 
@@ -280,11 +280,11 @@ TEST_CASE(parse_unicode_locale_id_with_other_extension)
     };
 
     auto fail = [](StringView locale) {
-        auto locale_id = MUST(Locale::parse_unicode_locale_id(locale));
+        auto locale_id = Locale::parse_unicode_locale_id(locale);
         EXPECT(!locale_id.has_value());
     };
     auto pass = [](StringView locale, OtherExtension const& expected_extension) {
-        auto locale_id = MUST(Locale::parse_unicode_locale_id(locale));
+        auto locale_id = Locale::parse_unicode_locale_id(locale);
         VERIFY(locale_id.has_value());
         EXPECT_EQ(locale_id->extensions.size(), 1u);
 
@@ -314,11 +314,11 @@ TEST_CASE(parse_unicode_locale_id_with_other_extension)
 TEST_CASE(parse_unicode_locale_id_with_private_use_extension)
 {
     auto fail = [](StringView locale) {
-        auto locale_id = MUST(Locale::parse_unicode_locale_id(locale));
+        auto locale_id = Locale::parse_unicode_locale_id(locale);
         EXPECT(!locale_id.has_value());
     };
     auto pass = [](StringView locale, Vector<StringView> const& expected_extension) {
-        auto locale_id = MUST(Locale::parse_unicode_locale_id(locale));
+        auto locale_id = Locale::parse_unicode_locale_id(locale);
         VERIFY(locale_id.has_value());
         EXPECT(compare_vectors(locale_id->private_use_extensions, expected_extension));
     };
@@ -338,10 +338,10 @@ TEST_CASE(parse_unicode_locale_id_with_private_use_extension)
 TEST_CASE(canonicalize_unicode_locale_id)
 {
     auto test = [](StringView locale, StringView expected_canonical_locale) {
-        auto locale_id = MUST(Locale::parse_unicode_locale_id(locale));
+        auto locale_id = Locale::parse_unicode_locale_id(locale);
         VERIFY(locale_id.has_value());
 
-        auto canonical_locale = MUST(Locale::canonicalize_unicode_locale_id(*locale_id));
+        auto canonical_locale = Locale::canonicalize_unicode_locale_id(*locale_id);
         EXPECT_EQ(*canonical_locale, expected_canonical_locale);
     };
 

--- a/Userland/Applications/ClockSettings/TimeZoneSettingsWidget.cpp
+++ b/Userland/Applications/ClockSettings/TimeZoneSettingsWidget.cpp
@@ -135,8 +135,8 @@ void TimeZoneSettingsWidget::set_time_zone_location()
     auto locale = Locale::default_locale();
     auto now = AK::UnixDateTime::now();
 
-    auto name = Locale::format_time_zone(locale, m_time_zone, Locale::CalendarPatternStyle::Long, now).release_value_but_fixme_should_propagate_errors();
-    auto offset = Locale::format_time_zone(locale, m_time_zone, Locale::CalendarPatternStyle::LongOffset, now).release_value_but_fixme_should_propagate_errors();
+    auto name = Locale::format_time_zone(locale, m_time_zone, Locale::CalendarPatternStyle::Long, now);
+    auto offset = Locale::format_time_zone(locale, m_time_zone, Locale::CalendarPatternStyle::LongOffset, now);
 
     m_time_zone_text = DeprecatedString::formatted("{}\n({})", name, offset);
 }

--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.cpp
@@ -719,7 +719,7 @@ ThrowCompletionOr<Vector<PatternPartition>> format_date_time_pattern(VM& vm, Dat
         // Non-standard, TR-35 requires the decimal separator before injected {fractionalSecondDigits} partitions
         // to adhere to the selected locale. This depends on other generated data, so it is deferred to here.
         else if (part == "decimal"sv) {
-            auto decimal_symbol = TRY_OR_THROW_OOM(vm, ::Locale::get_number_system_symbol(data_locale, date_time_format.numbering_system(), ::Locale::NumericSymbol::Decimal)).value_or("."sv);
+            auto decimal_symbol = ::Locale::get_number_system_symbol(data_locale, date_time_format.numbering_system(), ::Locale::NumericSymbol::Decimal).value_or("."sv);
             TRY_OR_THROW_OOM(vm, result.try_append({ "literal"sv, TRY_OR_THROW_OOM(vm, String::from_utf8(decimal_symbol)) }));
         }
 

--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormatConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormatConstructor.cpp
@@ -166,7 +166,7 @@ ThrowCompletionOr<NonnullGCPtr<DateTimeFormat>> create_date_time_format(VM& vm, 
 
     // 24. Let dataLocaleData be localeData.[[<dataLocale>]].
     // 25. Let hcDefault be dataLocaleData.[[hourCycle]].
-    auto default_hour_cycle = TRY_OR_THROW_OOM(vm, ::Locale::get_default_regional_hour_cycle(data_locale));
+    auto default_hour_cycle = ::Locale::get_default_regional_hour_cycle(data_locale);
 
     // Non-standard, default_hour_cycle will be empty if Unicode data generation is disabled.
     if (!default_hour_cycle.has_value()) {
@@ -394,7 +394,7 @@ ThrowCompletionOr<NonnullGCPtr<DateTimeFormat>> create_date_time_format(VM& vm, 
         }
 
         // f. Let formats be dataLocaleData.[[formats]].[[<resolvedCalendar>]].
-        auto formats = TRY_OR_THROW_OOM(vm, ::Locale::get_calendar_available_formats(data_locale, date_time_format->calendar()));
+        auto formats = ::Locale::get_calendar_available_formats(data_locale, date_time_format->calendar());
 
         // g. If matcher is "basic", then
         if (matcher.as_string().utf8_string_view() == "basic"sv) {
@@ -440,7 +440,7 @@ ThrowCompletionOr<NonnullGCPtr<DateTimeFormat>> create_date_time_format(VM& vm, 
         }
 
         // b. Let rangePatterns be bestFormat.[[rangePatterns12]].
-        range_patterns = TRY_OR_THROW_OOM(vm, ::Locale::get_calendar_range12_formats(data_locale, date_time_format->calendar(), best_format->skeleton));
+        range_patterns = ::Locale::get_calendar_range12_formats(data_locale, date_time_format->calendar(), best_format->skeleton);
     }
     // 48. Else,
     else {
@@ -448,7 +448,7 @@ ThrowCompletionOr<NonnullGCPtr<DateTimeFormat>> create_date_time_format(VM& vm, 
         pattern = move(best_format->pattern);
 
         // b. Let rangePatterns be bestFormat.[[rangePatterns]].
-        range_patterns = TRY_OR_THROW_OOM(vm, ::Locale::get_calendar_range_formats(data_locale, date_time_format->calendar(), best_format->skeleton));
+        range_patterns = ::Locale::get_calendar_range_formats(data_locale, date_time_format->calendar(), best_format->skeleton);
     }
 
     // 49. Set dateTimeFormat.[[Pattern]] to pattern.

--- a/Userland/Libraries/LibJS/Runtime/Intl/DisplayNames.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DisplayNames.cpp
@@ -106,7 +106,7 @@ ThrowCompletionOr<Value> canonical_code_for_display_names(VM& vm, DisplayNames::
     // 1. If type is "language", then
     if (type == DisplayNames::Type::Language) {
         // a. If code does not match the unicode_language_id production, throw a RangeError exception.
-        if (!TRY_OR_THROW_OOM(vm, ::Locale::parse_unicode_language_id(code)).has_value())
+        if (!::Locale::parse_unicode_language_id(code).has_value())
             return vm.throw_completion<RangeError>(ErrorType::OptionIsNotValidValue, code, "language"sv);
 
         // b. If IsStructurallyValidLanguageTag(code) is false, throw a RangeError exception.

--- a/Userland/Libraries/LibJS/Runtime/Intl/DisplayNamesPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DisplayNamesPrototype.cpp
@@ -63,7 +63,7 @@ JS_DEFINE_NATIVE_FUNCTION(DisplayNamesPrototype::of)
         }
 
         if (auto locale = MUST_OR_THROW_OOM(is_structurally_valid_language_tag(vm, code_string)); locale.has_value())
-            formatted_result = TRY_OR_THROW_OOM(vm, ::Locale::format_locale_for_display(display_names->locale(), locale.release_value()));
+            formatted_result = ::Locale::format_locale_for_display(display_names->locale(), locale.release_value());
         break;
     case DisplayNames::Type::Region:
         result = ::Locale::get_locale_territory_mapping(display_names->locale(), code_string);

--- a/Userland/Libraries/LibJS/Runtime/Intl/DurationFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DurationFormat.cpp
@@ -482,7 +482,7 @@ ThrowCompletionOr<Vector<PatternPartition>> partition_duration_format_pattern(VM
                     // c. If nextValue is not 0 or nextDisplay is not "auto", then
                     if (next_value != 0.0 || next_display != DurationFormat::Display::Auto) {
                         // i. Let separator be dataLocaleData.[[formats]].[[digital]].[[separator]].
-                        auto separator = TRY_OR_THROW_OOM(vm, ::Locale::get_number_system_symbol(data_locale, duration_format.numbering_system(), ::Locale::NumericSymbol::TimeSeparator)).value_or(":"sv);
+                        auto separator = ::Locale::get_number_system_symbol(data_locale, duration_format.numbering_system(), ::Locale::NumericSymbol::TimeSeparator).value_or(":"sv);
 
                         // ii. Append the new Record { [[Type]]: "literal", [[Value]]: separator} to the end of result.
                         TRY_OR_THROW_OOM(vm, result.try_append({ "literal"sv, TRY_OR_THROW_OOM(vm, String::from_utf8(separator)) }));

--- a/Userland/Libraries/LibJS/Runtime/Intl/Locale.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/Locale.cpp
@@ -208,8 +208,8 @@ static u8 weekday_to_integer(Optional<::Locale::Weekday> weekday, ::Locale::Week
 
 static ThrowCompletionOr<Vector<u8>> weekend_of_locale(VM& vm, StringView locale)
 {
-    auto weekend_start = weekday_to_integer(TRY_OR_THROW_OOM(vm, ::Locale::get_locale_weekend_start(locale)), ::Locale::Weekday::Saturday);
-    auto weekend_end = weekday_to_integer(TRY_OR_THROW_OOM(vm, ::Locale::get_locale_weekend_end(locale)), ::Locale::Weekday::Sunday);
+    auto weekend_start = weekday_to_integer(::Locale::get_locale_weekend_start(locale), ::Locale::Weekday::Saturday);
+    auto weekend_end = weekday_to_integer(::Locale::get_locale_weekend_end(locale), ::Locale::Weekday::Sunday);
 
     // There currently aren't any regions in the CLDR which wrap around from Sunday (7) to Monday (1).
     // If this changes, this logic will need to be updated to handle that.
@@ -235,8 +235,8 @@ ThrowCompletionOr<WeekInfo> week_info_of_locale(VM& vm, Locale const& locale_obj
 
     // 3. Return a record whose fields are defined by Table 1, with values based on locale.
     WeekInfo week_info {};
-    week_info.minimal_days = TRY_OR_THROW_OOM(vm, ::Locale::get_locale_minimum_days(locale)).value_or(1);
-    week_info.first_day = weekday_to_integer(TRY_OR_THROW_OOM(vm, ::Locale::get_locale_first_day(locale)), ::Locale::Weekday::Monday);
+    week_info.minimal_days = ::Locale::get_locale_minimum_days(locale).value_or(1);
+    week_info.first_day = weekday_to_integer(::Locale::get_locale_first_day(locale), ::Locale::Weekday::Monday);
     week_info.weekend = MUST_OR_THROW_OOM(weekend_of_locale(vm, locale));
 
     return week_info;

--- a/Userland/Libraries/LibJS/Runtime/Intl/Locale.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/Locale.cpp
@@ -14,10 +14,10 @@
 
 namespace JS::Intl {
 
-ThrowCompletionOr<NonnullGCPtr<Locale>> Locale::create(Realm& realm, ::Locale::LocaleID locale_id)
+NonnullGCPtr<Locale> Locale::create(Realm& realm, ::Locale::LocaleID locale_id)
 {
     auto locale = realm.heap().allocate<Locale>(realm, realm.intrinsics().intl_locale_prototype());
-    locale->set_locale(TRY_OR_THROW_OOM(realm.vm(), locale_id.to_string()));
+    locale->set_locale(locale_id.to_string());
 
     for (auto& extension : locale_id.extensions) {
         if (!extension.has<::Locale::LocaleExtension>())
@@ -51,7 +51,7 @@ Locale::Locale(Object& prototype)
 }
 
 // 1.1.1 CreateArrayFromListOrRestricted ( list , restricted )
-static ThrowCompletionOr<NonnullGCPtr<Array>> create_array_from_list_or_restricted(VM& vm, Vector<StringView> list, Optional<String> restricted)
+static NonnullGCPtr<Array> create_array_from_list_or_restricted(VM& vm, Vector<StringView> list, Optional<String> restricted)
 {
     auto& realm = *vm.current_realm();
 
@@ -63,12 +63,12 @@ static ThrowCompletionOr<NonnullGCPtr<Array>> create_array_from_list_or_restrict
 
     // 2. Return ! CreateArrayFromList( list ).
     return Array::create_from<StringView>(realm, list, [&vm](auto value) {
-        return PrimitiveString::create(vm, String::from_utf8(value).release_value());
+        return PrimitiveString::create(vm, MUST(String::from_utf8(value)));
     });
 }
 
 // 1.1.2 CalendarsOfLocale ( loc ), https://tc39.es/proposal-intl-locale-info/#sec-calendars-of-locale
-ThrowCompletionOr<NonnullGCPtr<Array>> calendars_of_locale(VM& vm, Locale const& locale_object)
+NonnullGCPtr<Array> calendars_of_locale(VM& vm, Locale const& locale_object)
 {
     // 1. Let restricted be loc.[[Calendar]].
     Optional<String> restricted = locale_object.has_calendar() ? locale_object.calendar() : Optional<String> {};
@@ -77,17 +77,17 @@ ThrowCompletionOr<NonnullGCPtr<Array>> calendars_of_locale(VM& vm, Locale const&
     auto const& locale = locale_object.locale();
 
     // 3. Assert: locale matches the unicode_locale_id production.
-    VERIFY(TRY_OR_THROW_OOM(vm, ::Locale::parse_unicode_locale_id(locale)).has_value());
+    VERIFY(::Locale::parse_unicode_locale_id(locale).has_value());
 
     // 4. Let list be a List of 1 or more unique canonical calendar identifiers, which must be lower case String values conforming to the type sequence from UTS 35 Unicode Locale Identifier, section 3.2, sorted in descending preference of those in common use for date and time formatting in locale.
-    auto list = TRY_OR_THROW_OOM(vm, ::Locale::get_keywords_for_locale(locale, "ca"sv));
+    auto list = ::Locale::get_keywords_for_locale(locale, "ca"sv);
 
     // 5. Return ! CreateArrayFromListOrRestricted( list, restricted ).
     return create_array_from_list_or_restricted(vm, move(list), move(restricted));
 }
 
 // 1.1.3 CollationsOfLocale ( loc ), https://tc39.es/proposal-intl-locale-info/#sec-collations-of-locale
-ThrowCompletionOr<NonnullGCPtr<Array>> collations_of_locale(VM& vm, Locale const& locale_object)
+NonnullGCPtr<Array> collations_of_locale(VM& vm, Locale const& locale_object)
 {
     // 1. Let restricted be loc.[[Collation]].
     Optional<String> restricted = locale_object.has_collation() ? locale_object.collation() : Optional<String> {};
@@ -96,17 +96,17 @@ ThrowCompletionOr<NonnullGCPtr<Array>> collations_of_locale(VM& vm, Locale const
     auto const& locale = locale_object.locale();
 
     // 3. Assert: locale matches the unicode_locale_id production.
-    VERIFY(TRY_OR_THROW_OOM(vm, ::Locale::parse_unicode_locale_id(locale)).has_value());
+    VERIFY(::Locale::parse_unicode_locale_id(locale).has_value());
 
     // 4. Let list be a List of 1 or more unique canonical collation identifiers, which must be lower case String values conforming to the type sequence from UTS 35 Unicode Locale Identifier, section 3.2, ordered as if an Array of the same values had been sorted, using %Array.prototype.sort% using undefined as comparefn, of those in common use for string comparison in locale. The values "standard" and "search" must be excluded from list.
-    auto list = TRY_OR_THROW_OOM(vm, ::Locale::get_keywords_for_locale(locale, "co"sv));
+    auto list = ::Locale::get_keywords_for_locale(locale, "co"sv);
 
     // 5. Return ! CreateArrayFromListOrRestricted( list, restricted ).
     return create_array_from_list_or_restricted(vm, move(list), move(restricted));
 }
 
 // 1.1.4 HourCyclesOfLocale ( loc ), https://tc39.es/proposal-intl-locale-info/#sec-hour-cycles-of-locale
-ThrowCompletionOr<NonnullGCPtr<Array>> hour_cycles_of_locale(VM& vm, Locale const& locale_object)
+NonnullGCPtr<Array> hour_cycles_of_locale(VM& vm, Locale const& locale_object)
 {
     // 1. Let restricted be loc.[[HourCycle]].
     Optional<String> restricted = locale_object.has_hour_cycle() ? locale_object.hour_cycle() : Optional<String> {};
@@ -115,17 +115,17 @@ ThrowCompletionOr<NonnullGCPtr<Array>> hour_cycles_of_locale(VM& vm, Locale cons
     auto const& locale = locale_object.locale();
 
     // 3. Assert: locale matches the unicode_locale_id production.
-    VERIFY(TRY_OR_THROW_OOM(vm, ::Locale::parse_unicode_locale_id(locale)).has_value());
+    VERIFY(::Locale::parse_unicode_locale_id(locale).has_value());
 
     // 4. Let list be a List of 1 or more unique hour cycle identifiers, which must be lower case String values indicating either the 12-hour format ("h11", "h12") or the 24-hour format ("h23", "h24"), sorted in descending preference of those in common use for date and time formatting in locale.
-    auto list = TRY_OR_THROW_OOM(vm, ::Locale::get_keywords_for_locale(locale, "hc"sv));
+    auto list = ::Locale::get_keywords_for_locale(locale, "hc"sv);
 
     // 5. Return ! CreateArrayFromListOrRestricted( list, restricted ).
     return create_array_from_list_or_restricted(vm, move(list), move(restricted));
 }
 
 // 1.1.5 NumberingSystemsOfLocale ( loc ), https://tc39.es/proposal-intl-locale-info/#sec-numbering-systems-of-locale
-ThrowCompletionOr<NonnullGCPtr<Array>> numbering_systems_of_locale(VM& vm, Locale const& locale_object)
+NonnullGCPtr<Array> numbering_systems_of_locale(VM& vm, Locale const& locale_object)
 {
     // 1. Let restricted be loc.[[NumberingSystem]].
     Optional<String> restricted = locale_object.has_numbering_system() ? locale_object.numbering_system() : Optional<String> {};
@@ -134,10 +134,10 @@ ThrowCompletionOr<NonnullGCPtr<Array>> numbering_systems_of_locale(VM& vm, Local
     auto const& locale = locale_object.locale();
 
     // 3. Assert: locale matches the unicode_locale_id production.
-    VERIFY(TRY_OR_THROW_OOM(vm, ::Locale::parse_unicode_locale_id(locale)).has_value());
+    VERIFY(::Locale::parse_unicode_locale_id(locale).has_value());
 
     // 4. Let list be a List of 1 or more unique canonical numbering system identifiers, which must be lower case String values conforming to the type sequence from UTS 35 Unicode Locale Identifier, section 3.2, sorted in descending preference of those in common use for formatting numeric values in locale.
-    auto list = TRY_OR_THROW_OOM(vm, ::Locale::get_keywords_for_locale(locale, "nu"sv));
+    auto list = ::Locale::get_keywords_for_locale(locale, "nu"sv);
 
     // 5. Return ! CreateArrayFromListOrRestricted( list, restricted ).
     return create_array_from_list_or_restricted(vm, move(list), move(restricted));
@@ -145,7 +145,7 @@ ThrowCompletionOr<NonnullGCPtr<Array>> numbering_systems_of_locale(VM& vm, Local
 
 // 1.1.6 TimeZonesOfLocale ( loc ), https://tc39.es/proposal-intl-locale-info/#sec-time-zones-of-locale
 // NOTE: Our implementation takes a region rather than a Locale object to avoid needlessly parsing the locale twice.
-ThrowCompletionOr<NonnullGCPtr<Array>> time_zones_of_locale(VM& vm, StringView region)
+NonnullGCPtr<Array> time_zones_of_locale(VM& vm, StringView region)
 {
     auto& realm = *vm.current_realm();
 
@@ -164,13 +164,13 @@ ThrowCompletionOr<NonnullGCPtr<Array>> time_zones_of_locale(VM& vm, StringView r
 }
 
 // 1.1.7 CharacterDirectionOfLocale ( loc ), https://tc39.es/proposal-intl-locale-info/#sec-character-direction-of-locale
-ThrowCompletionOr<StringView> character_direction_of_locale(VM& vm, Locale const& locale_object)
+StringView character_direction_of_locale(Locale const& locale_object)
 {
     // 1. Let locale be loc.[[Locale]].
     auto const& locale = locale_object.locale();
 
     // 2. Assert: locale matches the unicode_locale_id production.
-    VERIFY(TRY_OR_THROW_OOM(vm, ::Locale::parse_unicode_locale_id(locale)).has_value());
+    VERIFY(::Locale::parse_unicode_locale_id(locale).has_value());
 
     // 3. If the default general ordering of characters (characterOrder) within a line in locale is right-to-left, return "rtl".
     // NOTE: LibUnicode handles both LTR and RTL character orders in this call, not just RTL. We then fallback to LTR
@@ -231,7 +231,7 @@ ThrowCompletionOr<WeekInfo> week_info_of_locale(VM& vm, Locale const& locale_obj
     auto const& locale = locale_object.locale();
 
     // 2. Assert: locale matches the unicode_locale_id production.
-    VERIFY(TRY_OR_THROW_OOM(vm, ::Locale::parse_unicode_locale_id(locale)).has_value());
+    VERIFY(::Locale::parse_unicode_locale_id(locale).has_value());
 
     // 3. Return a record whose fields are defined by Table 1, with values based on locale.
     WeekInfo week_info {};

--- a/Userland/Libraries/LibJS/Runtime/Intl/Locale.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/Locale.h
@@ -22,7 +22,7 @@ class Locale final : public Object {
     JS_OBJECT(Locale, Object);
 
 public:
-    static ThrowCompletionOr<NonnullGCPtr<Locale>> create(Realm&, ::Locale::LocaleID);
+    static NonnullGCPtr<Locale> create(Realm&, ::Locale::LocaleID);
 
     static constexpr auto relevant_extension_keys()
     {
@@ -82,12 +82,12 @@ struct WeekInfo {
     Vector<u8> weekend;    // [[Weekend]]
 };
 
-ThrowCompletionOr<NonnullGCPtr<Array>> calendars_of_locale(VM&, Locale const&);
-ThrowCompletionOr<NonnullGCPtr<Array>> collations_of_locale(VM&, Locale const& locale);
-ThrowCompletionOr<NonnullGCPtr<Array>> hour_cycles_of_locale(VM&, Locale const& locale);
-ThrowCompletionOr<NonnullGCPtr<Array>> numbering_systems_of_locale(VM&, Locale const&);
-ThrowCompletionOr<NonnullGCPtr<Array>> time_zones_of_locale(VM&, StringView region);
-ThrowCompletionOr<StringView> character_direction_of_locale(VM&, Locale const&);
+NonnullGCPtr<Array> calendars_of_locale(VM&, Locale const&);
+NonnullGCPtr<Array> collations_of_locale(VM&, Locale const& locale);
+NonnullGCPtr<Array> hour_cycles_of_locale(VM&, Locale const& locale);
+NonnullGCPtr<Array> numbering_systems_of_locale(VM&, Locale const&);
+NonnullGCPtr<Array> time_zones_of_locale(VM&, StringView region);
+StringView character_direction_of_locale(Locale const&);
 ThrowCompletionOr<WeekInfo> week_info_of_locale(VM&, Locale const&);
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Intl/LocaleConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/LocaleConstructor.cpp
@@ -69,7 +69,7 @@ static ThrowCompletionOr<String> apply_options_to_tag(VM& vm, StringView tag, Ob
     auto canonicalized_tag = MUST_OR_THROW_OOM(canonicalize_unicode_locale_id(vm, *locale_id));
 
     // 11. Assert: tag matches the unicode_locale_id production.
-    locale_id = TRY_OR_THROW_OOM(vm, ::Locale::parse_unicode_locale_id(canonicalized_tag));
+    locale_id = ::Locale::parse_unicode_locale_id(canonicalized_tag);
     VERIFY(locale_id.has_value());
 
     // 12. Let languageId be the substring of tag corresponding to the unicode_language_id production.
@@ -109,7 +109,7 @@ static ThrowCompletionOr<LocaleAndKeys> apply_unicode_extension_to_tag(VM& vm, S
 {
     // 1. Assert: Type(tag) is String.
     // 2. Assert: tag matches the unicode_locale_id production.
-    auto locale_id = TRY_OR_THROW_OOM(vm, ::Locale::parse_unicode_locale_id(tag));
+    auto locale_id = ::Locale::parse_unicode_locale_id(tag);
     VERIFY(locale_id.has_value());
 
     Vector<String> attributes;
@@ -198,7 +198,7 @@ static ThrowCompletionOr<LocaleAndKeys> apply_unicode_extension_to_tag(VM& vm, S
 
     // 7. Let locale be the String value that is tag with any Unicode locale extension sequences removed.
     locale_id->remove_extension_type<::Locale::LocaleExtension>();
-    auto locale = TRY_OR_THROW_OOM(vm, locale_id->to_string());
+    auto locale = locale_id->to_string();
 
     // 8. Let newExtension be a Unicode BCP 47 U Extension based on attributes and keywords.
     ::Locale::LocaleExtension new_extension { move(attributes), move(keywords) };

--- a/Userland/Libraries/LibJS/Runtime/Intl/LocalePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/LocalePrototype.cpp
@@ -61,15 +61,15 @@ JS_DEFINE_NATIVE_FUNCTION(LocalePrototype::maximize)
     // 2. Perform ? RequireInternalSlot(loc, [[InitializedLocale]]).
     auto locale_object = TRY(typed_this_object(vm));
 
-    auto locale = TRY_OR_THROW_OOM(vm, ::Locale::parse_unicode_locale_id(locale_object->locale()));
+    auto locale = ::Locale::parse_unicode_locale_id(locale_object->locale());
     VERIFY(locale.has_value());
 
     // 3. Let maximal be the result of the Add Likely Subtags algorithm applied to loc.[[Locale]]. If an error is signaled, set maximal to loc.[[Locale]].
-    if (auto maximal = TRY_OR_THROW_OOM(vm, ::Locale::add_likely_subtags(locale->language_id)); maximal.has_value())
+    if (auto maximal = ::Locale::add_likely_subtags(locale->language_id); maximal.has_value())
         locale->language_id = maximal.release_value();
 
     // 4. Return ! Construct(%Locale%, maximal).
-    return MUST_OR_THROW_OOM(Locale::create(realm, locale.release_value()));
+    return Locale::create(realm, locale.release_value());
 }
 
 // 14.3.4 Intl.Locale.prototype.minimize ( ), https://tc39.es/ecma402/#sec-Intl.Locale.prototype.minimize
@@ -81,15 +81,15 @@ JS_DEFINE_NATIVE_FUNCTION(LocalePrototype::minimize)
     // 2. Perform ? RequireInternalSlot(loc, [[InitializedLocale]]).
     auto locale_object = TRY(typed_this_object(vm));
 
-    auto locale = TRY_OR_THROW_OOM(vm, ::Locale::parse_unicode_locale_id(locale_object->locale()));
+    auto locale = ::Locale::parse_unicode_locale_id(locale_object->locale());
     VERIFY(locale.has_value());
 
     // 3. Let minimal be the result of the Remove Likely Subtags algorithm applied to loc.[[Locale]]. If an error is signaled, set minimal to loc.[[Locale]].
-    if (auto minimal = TRY_OR_THROW_OOM(vm, ::Locale::remove_likely_subtags(locale->language_id)); minimal.has_value())
+    if (auto minimal = ::Locale::remove_likely_subtags(locale->language_id); minimal.has_value())
         locale->language_id = minimal.release_value();
 
     // 4. Return ! Construct(%Locale%, minimal).
-    return MUST_OR_THROW_OOM(Locale::create(realm, locale.release_value()));
+    return Locale::create(realm, locale.release_value());
 }
 
 // 14.3.5 Intl.Locale.prototype.toString ( ), https://tc39.es/ecma402/#sec-Intl.Locale.prototype.toString
@@ -111,11 +111,11 @@ JS_DEFINE_NATIVE_FUNCTION(LocalePrototype::base_name)
     auto locale_object = TRY(typed_this_object(vm));
 
     // 3. Let locale be loc.[[Locale]].
-    auto locale = TRY_OR_THROW_OOM(vm, ::Locale::parse_unicode_locale_id(locale_object->locale()));
+    auto locale = ::Locale::parse_unicode_locale_id(locale_object->locale());
     VERIFY(locale.has_value());
 
     // 4. Return the substring of locale corresponding to the unicode_language_id production.
-    return PrimitiveString::create(vm, TRY_OR_THROW_OOM(vm, locale->language_id.to_string()));
+    return PrimitiveString::create(vm, locale->language_id.to_string());
 }
 
 #define JS_ENUMERATE_LOCALE_KEYWORD_PROPERTIES \
@@ -160,7 +160,7 @@ JS_DEFINE_NATIVE_FUNCTION(LocalePrototype::language)
     auto locale_object = TRY(typed_this_object(vm));
 
     // 3. Let locale be loc.[[Locale]].
-    auto locale = TRY_OR_THROW_OOM(vm, ::Locale::parse_unicode_locale_id(locale_object->locale()));
+    auto locale = ::Locale::parse_unicode_locale_id(locale_object->locale());
 
     // 4. Assert: locale matches the unicode_locale_id production.
     VERIFY(locale.has_value());
@@ -177,7 +177,7 @@ JS_DEFINE_NATIVE_FUNCTION(LocalePrototype::script)
     auto locale_object = TRY(typed_this_object(vm));
 
     // 3. Let locale be loc.[[Locale]].
-    auto locale = TRY_OR_THROW_OOM(vm, ::Locale::parse_unicode_locale_id(locale_object->locale()));
+    auto locale = ::Locale::parse_unicode_locale_id(locale_object->locale());
 
     // 4. Assert: locale matches the unicode_locale_id production.
     VERIFY(locale.has_value());
@@ -198,7 +198,7 @@ JS_DEFINE_NATIVE_FUNCTION(LocalePrototype::region)
     auto locale_object = TRY(typed_this_object(vm));
 
     // 3. Let locale be loc.[[Locale]].
-    auto locale = TRY_OR_THROW_OOM(vm, ::Locale::parse_unicode_locale_id(locale_object->locale()));
+    auto locale = ::Locale::parse_unicode_locale_id(locale_object->locale());
 
     // 4. Assert: locale matches the unicode_locale_id production.
     VERIFY(locale.has_value());
@@ -221,11 +221,11 @@ JS_DEFINE_NATIVE_FUNCTION(LocalePrototype::region)
 // 1.4.17 get Intl.Locale.prototype.collations, https://tc39.es/proposal-intl-locale-info/#sec-Intl.Locale.prototype.collations
 // 1.4.18 get Intl.Locale.prototype.hourCycles, https://tc39.es/proposal-intl-locale-info/#sec-Intl.Locale.prototype.hourCycles
 // 1.4.19 get Intl.Locale.prototype.numberingSystems, https://tc39.es/proposal-intl-locale-info/#sec-Intl.Locale.prototype.numberingSystems
-#define __JS_ENUMERATE(keyword)                                           \
-    JS_DEFINE_NATIVE_FUNCTION(LocalePrototype::keyword)                   \
-    {                                                                     \
-        auto locale_object = TRY(typed_this_object(vm));                  \
-        return MUST_OR_THROW_OOM(keyword##_of_locale(vm, locale_object)); \
+#define __JS_ENUMERATE(keyword)                          \
+    JS_DEFINE_NATIVE_FUNCTION(LocalePrototype::keyword)  \
+    {                                                    \
+        auto locale_object = TRY(typed_this_object(vm)); \
+        return keyword##_of_locale(vm, locale_object);   \
     }
 JS_ENUMERATE_LOCALE_INFO_PROPERTIES
 #undef __JS_ENUMERATE
@@ -238,14 +238,14 @@ JS_DEFINE_NATIVE_FUNCTION(LocalePrototype::time_zones)
     auto locale_object = TRY(typed_this_object(vm));
 
     // 3. Let locale be loc.[[Locale]].
-    auto locale = TRY_OR_THROW_OOM(vm, ::Locale::parse_unicode_locale_id(locale_object->locale()));
+    auto locale = ::Locale::parse_unicode_locale_id(locale_object->locale());
 
     // 4. If the unicode_language_id production of locale does not contain the ["-" unicode_region_subtag] sequence, return undefined.
     if (!locale.has_value() || !locale->language_id.region.has_value())
         return js_undefined();
 
     // 5. Return ! TimeZonesOfLocale(loc).
-    return MUST_OR_THROW_OOM(time_zones_of_locale(vm, locale->language_id.region.value()));
+    return time_zones_of_locale(vm, locale->language_id.region.value());
 }
 
 // 1.4.21 get Intl.Locale.prototype.textInfo, https://tc39.es/proposal-intl-locale-info/#sec-Intl.Locale.prototype.textInfo
@@ -261,7 +261,7 @@ JS_DEFINE_NATIVE_FUNCTION(LocalePrototype::text_info)
     auto info = Object::create(realm, realm.intrinsics().object_prototype());
 
     // 4. Let dir be ! CharacterDirectionOfLocale(loc).
-    auto direction = MUST_OR_THROW_OOM(character_direction_of_locale(vm, locale_object));
+    auto direction = character_direction_of_locale(locale_object);
 
     // 5. Perform ! CreateDataPropertyOrThrow(info, "direction", dir).
     MUST(info->create_data_property_or_throw(vm.names.direction, PrimitiveString::create(vm, direction)));

--- a/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.cpp
@@ -537,13 +537,13 @@ ThrowCompletionOr<Vector<PatternPartition>> partition_number_pattern(VM& vm, Num
     // 2. If x is not-a-number, then
     if (number.is_nan()) {
         // a. Let n be an implementation- and locale-dependent (ILD) String value indicating the NaN value.
-        auto symbol = TRY_OR_THROW_OOM(vm, ::Locale::get_number_system_symbol(number_format.data_locale(), number_format.numbering_system(), ::Locale::NumericSymbol::NaN)).value_or("NaN"sv);
+        auto symbol = ::Locale::get_number_system_symbol(number_format.data_locale(), number_format.numbering_system(), ::Locale::NumericSymbol::NaN).value_or("NaN"sv);
         formatted_string = TRY_OR_THROW_OOM(vm, String::from_utf8(symbol));
     }
     // 3. Else if x is positive-infinity, then
     else if (number.is_positive_infinity()) {
         // a. Let n be an ILD String value indicating positive infinity.
-        auto symbol = TRY_OR_THROW_OOM(vm, ::Locale::get_number_system_symbol(number_format.data_locale(), number_format.numbering_system(), ::Locale::NumericSymbol::Infinity)).value_or("infinity"sv);
+        auto symbol = ::Locale::get_number_system_symbol(number_format.data_locale(), number_format.numbering_system(), ::Locale::NumericSymbol::Infinity).value_or("infinity"sv);
         formatted_string = TRY_OR_THROW_OOM(vm, String::from_utf8(symbol));
     }
     // 4. Else if x is negative-infinity, then
@@ -551,7 +551,7 @@ ThrowCompletionOr<Vector<PatternPartition>> partition_number_pattern(VM& vm, Num
         // a. Let n be an ILD String value indicating negative infinity.
         // NOTE: The CLDR does not contain unique strings for negative infinity. The negative sign will
         //       be inserted by the pattern returned from GetNumberFormatPattern.
-        auto symbol = TRY_OR_THROW_OOM(vm, ::Locale::get_number_system_symbol(number_format.data_locale(), number_format.numbering_system(), ::Locale::NumericSymbol::Infinity)).value_or("infinity"sv);
+        auto symbol = ::Locale::get_number_system_symbol(number_format.data_locale(), number_format.numbering_system(), ::Locale::NumericSymbol::Infinity).value_or("infinity"sv);
         formatted_string = TRY_OR_THROW_OOM(vm, String::from_utf8(symbol));
     }
     // 5. Else,
@@ -617,7 +617,7 @@ ThrowCompletionOr<Vector<PatternPartition>> partition_number_pattern(VM& vm, Num
         // d. Else if p is equal to "plusSign", then
         else if (part == "plusSign"sv) {
             // i. Let plusSignSymbol be the ILND String representing the plus sign.
-            auto plus_sign_symbol = TRY_OR_THROW_OOM(vm, ::Locale::get_number_system_symbol(number_format.data_locale(), number_format.numbering_system(), ::Locale::NumericSymbol::PlusSign)).value_or("+"sv);
+            auto plus_sign_symbol = ::Locale::get_number_system_symbol(number_format.data_locale(), number_format.numbering_system(), ::Locale::NumericSymbol::PlusSign).value_or("+"sv);
             // ii. Append a new Record { [[Type]]: "plusSign", [[Value]]: plusSignSymbol } as the last element of result.
             TRY_OR_THROW_OOM(vm, result.try_append({ "plusSign"sv, TRY_OR_THROW_OOM(vm, String::from_utf8(plus_sign_symbol)) }));
         }
@@ -625,7 +625,7 @@ ThrowCompletionOr<Vector<PatternPartition>> partition_number_pattern(VM& vm, Num
         // e. Else if p is equal to "minusSign", then
         else if (part == "minusSign"sv) {
             // i. Let minusSignSymbol be the ILND String representing the minus sign.
-            auto minus_sign_symbol = TRY_OR_THROW_OOM(vm, ::Locale::get_number_system_symbol(number_format.data_locale(), number_format.numbering_system(), ::Locale::NumericSymbol::MinusSign)).value_or("-"sv);
+            auto minus_sign_symbol = ::Locale::get_number_system_symbol(number_format.data_locale(), number_format.numbering_system(), ::Locale::NumericSymbol::MinusSign).value_or("-"sv);
             // ii. Append a new Record { [[Type]]: "minusSign", [[Value]]: minusSignSymbol } as the last element of result.
             TRY_OR_THROW_OOM(vm, result.try_append({ "minusSign"sv, TRY_OR_THROW_OOM(vm, String::from_utf8(minus_sign_symbol)) }));
         }
@@ -633,7 +633,7 @@ ThrowCompletionOr<Vector<PatternPartition>> partition_number_pattern(VM& vm, Num
         // f. Else if p is equal to "percentSign" and numberFormat.[[Style]] is "percent", then
         else if ((part == "percentSign"sv) && (number_format.style() == NumberFormat::Style::Percent)) {
             // i. Let percentSignSymbol be the ILND String representing the percent sign.
-            auto percent_sign_symbol = TRY_OR_THROW_OOM(vm, ::Locale::get_number_system_symbol(number_format.data_locale(), number_format.numbering_system(), ::Locale::NumericSymbol::PercentSign)).value_or("%"sv);
+            auto percent_sign_symbol = ::Locale::get_number_system_symbol(number_format.data_locale(), number_format.numbering_system(), ::Locale::NumericSymbol::PercentSign).value_or("%"sv);
             // ii. Append a new Record { [[Type]]: "percentSign", [[Value]]: percentSignSymbol } as the last element of result.
             TRY_OR_THROW_OOM(vm, result.try_append({ "percentSign"sv, TRY_OR_THROW_OOM(vm, String::from_utf8(percent_sign_symbol)) }));
         }
@@ -744,7 +744,7 @@ ThrowCompletionOr<Vector<PatternPartition>> partition_notation_sub_pattern(VM& v
     // 1. Let result be a new empty List.
     Vector<PatternPartition> result;
 
-    auto grouping_sizes = TRY_OR_THROW_OOM(vm, ::Locale::get_number_system_groupings(number_format.data_locale(), number_format.numbering_system()));
+    auto grouping_sizes = ::Locale::get_number_system_groupings(number_format.data_locale(), number_format.numbering_system());
     if (!grouping_sizes.has_value())
         return Vector<PatternPartition> {};
 
@@ -827,7 +827,7 @@ ThrowCompletionOr<Vector<PatternPartition>> partition_notation_sub_pattern(VM& v
                 // 7. Else,
                 else {
                     // a. Let groupSepSymbol be the implementation-, locale-, and numbering system-dependent (ILND) String representing the grouping separator.
-                    auto group_sep_symbol = TRY_OR_THROW_OOM(vm, ::Locale::get_number_system_symbol(number_format.data_locale(), number_format.numbering_system(), ::Locale::NumericSymbol::Group)).value_or(","sv);
+                    auto group_sep_symbol = ::Locale::get_number_system_symbol(number_format.data_locale(), number_format.numbering_system(), ::Locale::NumericSymbol::Group).value_or(","sv);
 
                     // b. Let groups be a List whose elements are, in left to right order, the substrings defined by ILND set of locations within the integer, which may depend on the value of numberFormat.[[UseGrouping]].
                     auto groups = MUST_OR_THROW_OOM(separate_integer_into_groups(vm, *grouping_sizes, move(integer), number_format.use_grouping()));
@@ -854,7 +854,7 @@ ThrowCompletionOr<Vector<PatternPartition>> partition_notation_sub_pattern(VM& v
                 // 8. If fraction is not undefined, then
                 if (fraction.has_value()) {
                     // a. Let decimalSepSymbol be the ILND String representing the decimal separator.
-                    auto decimal_sep_symbol = TRY_OR_THROW_OOM(vm, ::Locale::get_number_system_symbol(number_format.data_locale(), number_format.numbering_system(), ::Locale::NumericSymbol::Decimal)).value_or("."sv);
+                    auto decimal_sep_symbol = ::Locale::get_number_system_symbol(number_format.data_locale(), number_format.numbering_system(), ::Locale::NumericSymbol::Decimal).value_or("."sv);
                     // b. Append a new Record { [[Type]]: "decimal", [[Value]]: decimalSepSymbol } as the last element of result.
                     TRY_OR_THROW_OOM(vm, result.try_append({ "decimal"sv, TRY_OR_THROW_OOM(vm, String::from_utf8(decimal_sep_symbol)) }));
                     // c. Append a new Record { [[Type]]: "fraction", [[Value]]: fraction } as the last element of result.
@@ -878,7 +878,7 @@ ThrowCompletionOr<Vector<PatternPartition>> partition_notation_sub_pattern(VM& v
             // vi. Else if p is equal to "scientificSeparator", then
             else if (part == "scientificSeparator"sv) {
                 // 1. Let scientificSeparator be the ILND String representing the exponent separator.
-                auto scientific_separator = TRY_OR_THROW_OOM(vm, ::Locale::get_number_system_symbol(number_format.data_locale(), number_format.numbering_system(), ::Locale::NumericSymbol::Exponential)).value_or("E"sv);
+                auto scientific_separator = ::Locale::get_number_system_symbol(number_format.data_locale(), number_format.numbering_system(), ::Locale::NumericSymbol::Exponential).value_or("E"sv);
                 // 2. Append a new Record { [[Type]]: "exponentSeparator", [[Value]]: scientificSeparator } as the last element of result.
                 TRY_OR_THROW_OOM(vm, result.try_append({ "exponentSeparator"sv, TRY_OR_THROW_OOM(vm, String::from_utf8(scientific_separator)) }));
             }
@@ -887,7 +887,7 @@ ThrowCompletionOr<Vector<PatternPartition>> partition_notation_sub_pattern(VM& v
                 // 1. If exponent < 0, then
                 if (exponent < 0) {
                     // a. Let minusSignSymbol be the ILND String representing the minus sign.
-                    auto minus_sign_symbol = TRY_OR_THROW_OOM(vm, ::Locale::get_number_system_symbol(number_format.data_locale(), number_format.numbering_system(), ::Locale::NumericSymbol::MinusSign)).value_or("-"sv);
+                    auto minus_sign_symbol = ::Locale::get_number_system_symbol(number_format.data_locale(), number_format.numbering_system(), ::Locale::NumericSymbol::MinusSign).value_or("-"sv);
 
                     // b. Append a new Record { [[Type]]: "exponentMinusSign", [[Value]]: minusSignSymbol } as the last element of result.
                     TRY_OR_THROW_OOM(vm, result.try_append({ "exponentMinusSign"sv, TRY_OR_THROW_OOM(vm, String::from_utf8(minus_sign_symbol)) }));
@@ -1854,7 +1854,7 @@ ThrowCompletionOr<Vector<PatternPartitionWithSource>> partition_number_range_pat
     }
 
     // 7. Let rangeSeparator be an ILND String value used to separate two numbers.
-    auto range_separator_symbol = TRY_OR_THROW_OOM(vm, ::Locale::get_number_system_symbol(number_format.data_locale(), number_format.numbering_system(), ::Locale::NumericSymbol::RangeSeparator)).value_or("-"sv);
+    auto range_separator_symbol = ::Locale::get_number_system_symbol(number_format.data_locale(), number_format.numbering_system(), ::Locale::NumericSymbol::RangeSeparator).value_or("-"sv);
     auto range_separator = TRY_OR_THROW_OOM(vm, ::Locale::augment_range_pattern(range_separator_symbol, result.last().value, end_result[0].value));
 
     // 8. Append a new Record { [[Type]]: "literal", [[Value]]: rangeSeparator, [[Source]]: "shared" } element to result.
@@ -1887,7 +1887,7 @@ ThrowCompletionOr<Vector<PatternPartitionWithSource>> partition_number_range_pat
 ThrowCompletionOr<Vector<PatternPartitionWithSource>> format_approximately(VM& vm, NumberFormat& number_format, Vector<PatternPartitionWithSource> result)
 {
     // 1. Let approximatelySign be an ILND String value used to signify that a number is approximate.
-    auto approximately_sign = TRY_OR_THROW_OOM(vm, ::Locale::get_number_system_symbol(number_format.data_locale(), number_format.numbering_system(), ::Locale::NumericSymbol::ApproximatelySign));
+    auto approximately_sign = ::Locale::get_number_system_symbol(number_format.data_locale(), number_format.numbering_system(), ::Locale::NumericSymbol::ApproximatelySign);
 
     // 2. If approximatelySign is not empty, insert a new Record { [[Type]]: "approximatelySign", [[Value]]: approximatelySign } at an ILND index in result. For example, if numberFormat has [[Locale]] "en-US" and [[NumberingSystem]] "latn" and [[Style]] "decimal", the new Record might be inserted before the first element of result.
     if (approximately_sign.has_value() && !approximately_sign->is_empty()) {

--- a/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.cpp
@@ -761,7 +761,7 @@ ThrowCompletionOr<Vector<PatternPartition>> partition_notation_sub_pattern(VM& v
     // 4. Else,
     else {
         // a. Let notationSubPattern be GetNotationSubPattern(numberFormat, exponent).
-        auto notation_sub_pattern = MUST_OR_THROW_OOM(get_notation_sub_pattern(vm, number_format, exponent));
+        auto notation_sub_pattern = get_notation_sub_pattern(number_format, exponent);
         if (!notation_sub_pattern.has_value())
             return Vector<PatternPartition> {};
 
@@ -796,7 +796,7 @@ ThrowCompletionOr<Vector<PatternPartition>> partition_notation_sub_pattern(VM& v
                 //         iv. Set position to position + 1.
                 //     g. Set n to transliterated.
                 // 2. Else use an implementation dependent algorithm to map n to the appropriate representation of n in the given numbering system.
-                formatted_string = TRY_OR_THROW_OOM(vm, ::Locale::replace_digits_for_number_system(number_format.numbering_system(), formatted_string));
+                formatted_string = ::Locale::replace_digits_for_number_system(number_format.numbering_system(), formatted_string);
 
                 // 3. Let decimalSepIndex be StringIndexOf(n, ".", 0).
                 auto decimal_sep_index = formatted_string.find_byte_offset('.');
@@ -902,7 +902,7 @@ ThrowCompletionOr<Vector<PatternPartition>> partition_notation_sub_pattern(VM& v
 
                 // FIXME: The spec does not say to do this, but all of major engines perform this replacement.
                 //        Without this, formatting with non-Latin numbering systems will produce non-localized results.
-                exponent_result.formatted_string = TRY_OR_THROW_OOM(vm, ::Locale::replace_digits_for_number_system(number_format.numbering_system(), exponent_result.formatted_string));
+                exponent_result.formatted_string = ::Locale::replace_digits_for_number_system(number_format.numbering_system(), exponent_result.formatted_string);
 
                 // 3. Append a new Record { [[Type]]: "exponentInteger", [[Value]]: exponentResult.[[FormattedString]] } as the last element of result.
                 TRY_OR_THROW_OOM(vm, result.try_append({ "exponentInteger"sv, move(exponent_result.formatted_string) }));
@@ -1315,7 +1315,7 @@ ThrowCompletionOr<Optional<Variant<StringView, String>>> get_number_format_patte
     // 7. If style is "percent", then
     case NumberFormat::Style::Percent:
         // a. Let patterns be patterns.[[percent]].
-        patterns = TRY_OR_THROW_OOM(vm, ::Locale::get_standard_number_system_format(number_format.data_locale(), number_format.numbering_system(), ::Locale::StandardNumberFormatType::Percent));
+        patterns = ::Locale::get_standard_number_system_format(number_format.data_locale(), number_format.numbering_system(), ::Locale::StandardNumberFormatType::Percent);
         break;
 
     // 8. Else if style is "unit", then
@@ -1327,7 +1327,7 @@ ThrowCompletionOr<Optional<Variant<StringView, String>>> get_number_format_patte
         //     i. Let unit be "fallback".
         // e. Let patterns be patterns.[[<unit>]].
         // f. Let patterns be patterns.[[<unitDisplay>]].
-        auto formats = TRY_OR_THROW_OOM(vm, ::Locale::get_unit_formats(number_format.data_locale(), number_format.unit(), number_format.unit_display()));
+        auto formats = ::Locale::get_unit_formats(number_format.data_locale(), number_format.unit(), number_format.unit_display());
         auto plurality = MUST_OR_THROW_OOM(resolve_plural(vm, number_format, ::Locale::PluralForm::Cardinal, number.to_value(vm)));
 
         if (auto it = formats.find_if([&](auto& p) { return p.plurality == plurality.plural_category; }); it != formats.end())
@@ -1350,7 +1350,7 @@ ThrowCompletionOr<Optional<Variant<StringView, String>>> get_number_format_patte
 
         // Handling of other [[CurrencyDisplay]] options will occur after [[SignDisplay]].
         if (number_format.currency_display() == NumberFormat::CurrencyDisplay::Name) {
-            auto formats = TRY_OR_THROW_OOM(vm, ::Locale::get_compact_number_system_formats(number_format.data_locale(), number_format.numbering_system(), ::Locale::CompactNumberFormatType::CurrencyUnit));
+            auto formats = ::Locale::get_compact_number_system_formats(number_format.data_locale(), number_format.numbering_system(), ::Locale::CompactNumberFormatType::CurrencyUnit);
             auto plurality = MUST_OR_THROW_OOM(resolve_plural(vm, number_format, ::Locale::PluralForm::Cardinal, number.to_value(vm)));
 
             if (auto it = formats.find_if([&](auto& p) { return p.plurality == plurality.plural_category; }); it != formats.end()) {
@@ -1361,10 +1361,10 @@ ThrowCompletionOr<Optional<Variant<StringView, String>>> get_number_format_patte
 
         switch (number_format.currency_sign()) {
         case NumberFormat::CurrencySign::Standard:
-            patterns = TRY_OR_THROW_OOM(vm, ::Locale::get_standard_number_system_format(number_format.data_locale(), number_format.numbering_system(), ::Locale::StandardNumberFormatType::Currency));
+            patterns = ::Locale::get_standard_number_system_format(number_format.data_locale(), number_format.numbering_system(), ::Locale::StandardNumberFormatType::Currency);
             break;
         case NumberFormat::CurrencySign::Accounting:
-            patterns = TRY_OR_THROW_OOM(vm, ::Locale::get_standard_number_system_format(number_format.data_locale(), number_format.numbering_system(), ::Locale::StandardNumberFormatType::Accounting));
+            patterns = ::Locale::get_standard_number_system_format(number_format.data_locale(), number_format.numbering_system(), ::Locale::StandardNumberFormatType::Accounting);
             break;
         }
 
@@ -1374,7 +1374,7 @@ ThrowCompletionOr<Optional<Variant<StringView, String>>> get_number_format_patte
     case NumberFormat::Style::Decimal:
         // a. Assert: style is "decimal".
         // b. Let patterns be patterns.[[decimal]].
-        patterns = TRY_OR_THROW_OOM(vm, ::Locale::get_standard_number_system_format(number_format.data_locale(), number_format.numbering_system(), ::Locale::StandardNumberFormatType::Decimal));
+        patterns = ::Locale::get_standard_number_system_format(number_format.data_locale(), number_format.numbering_system(), ::Locale::StandardNumberFormatType::Decimal);
         break;
 
     default:
@@ -1510,7 +1510,7 @@ ThrowCompletionOr<Optional<Variant<StringView, String>>> get_number_format_patte
     // we might need to mutate the format pattern to inject a space between the currency display and
     // the currency number.
     if (number_format.style() == NumberFormat::Style::Currency) {
-        auto modified_pattern = TRY_OR_THROW_OOM(vm, ::Locale::augment_currency_format_pattern(number_format.resolve_currency_display(), pattern));
+        auto modified_pattern = ::Locale::augment_currency_format_pattern(number_format.resolve_currency_display(), pattern);
         if (modified_pattern.has_value())
             return modified_pattern.release_value();
     }
@@ -1520,7 +1520,7 @@ ThrowCompletionOr<Optional<Variant<StringView, String>>> get_number_format_patte
 }
 
 // 15.5.12 GetNotationSubPattern ( numberFormat, exponent ), https://tc39.es/ecma402/#sec-getnotationsubpattern
-ThrowCompletionOr<Optional<StringView>> get_notation_sub_pattern(VM& vm, NumberFormat& number_format, int exponent)
+Optional<StringView> get_notation_sub_pattern(NumberFormat& number_format, int exponent)
 {
     // 1. Let localeData be %NumberFormat%.[[LocaleData]].
     // 2. Let dataLocale be numberFormat.[[DataLocale]].
@@ -1534,9 +1534,9 @@ ThrowCompletionOr<Optional<StringView>> get_notation_sub_pattern(VM& vm, NumberF
     // 7. If notation is "scientific" or notation is "engineering", then
     if ((notation == NumberFormat::Notation::Scientific) || (notation == NumberFormat::Notation::Engineering)) {
         // a. Return notationSubPatterns.[[scientific]].
-        auto notation_sub_patterns = TRY_OR_THROW_OOM(vm, ::Locale::get_standard_number_system_format(number_format.data_locale(), number_format.numbering_system(), ::Locale::StandardNumberFormatType::Scientific));
+        auto notation_sub_patterns = ::Locale::get_standard_number_system_format(number_format.data_locale(), number_format.numbering_system(), ::Locale::StandardNumberFormatType::Scientific);
         if (!notation_sub_patterns.has_value())
-            return OptionalNone {};
+            return {};
 
         return notation_sub_patterns->zero_format;
     }
@@ -1576,7 +1576,7 @@ ThrowCompletionOr<int> compute_exponent(VM& vm, NumberFormat& number_format, Mat
     int magnitude = MUST_OR_THROW_OOM(number.logarithmic_floor(vm));
 
     // 4. Let exponent be ComputeExponentForMagnitude(numberFormat, magnitude).
-    int exponent = MUST_OR_THROW_OOM(compute_exponent_for_magnitude(vm, number_format, magnitude));
+    int exponent = compute_exponent_for_magnitude(number_format, magnitude);
 
     // 5. Let x be x × 10^(-exponent).
     number = number.multiplied_by_power(-exponent);
@@ -1600,11 +1600,11 @@ ThrowCompletionOr<int> compute_exponent(VM& vm, NumberFormat& number_format, Mat
     }
 
     // 10. Return ComputeExponentForMagnitude(numberFormat, magnitude + 1).
-    return MUST_OR_THROW_OOM(compute_exponent_for_magnitude(vm, number_format, magnitude + 1));
+    return compute_exponent_for_magnitude(number_format, magnitude + 1);
 }
 
 // 15.5.14 ComputeExponentForMagnitude ( numberFormat, magnitude ), https://tc39.es/ecma402/#sec-computeexponentformagnitude
-ThrowCompletionOr<int> compute_exponent_for_magnitude(VM& vm, NumberFormat& number_format, int magnitude)
+int compute_exponent_for_magnitude(NumberFormat& number_format, int magnitude)
 {
     // 1. Let notation be numberFormat.[[Notation]].
     switch (number_format.notation()) {
@@ -1637,11 +1637,11 @@ ThrowCompletionOr<int> compute_exponent_for_magnitude(VM& vm, NumberFormat& numb
         Vector<::Locale::NumberFormat> format_rules;
 
         if (number_format.style() == NumberFormat::Style::Currency)
-            format_rules = TRY_OR_THROW_OOM(vm, ::Locale::get_compact_number_system_formats(number_format.data_locale(), number_format.numbering_system(), ::Locale::CompactNumberFormatType::CurrencyShort));
+            format_rules = ::Locale::get_compact_number_system_formats(number_format.data_locale(), number_format.numbering_system(), ::Locale::CompactNumberFormatType::CurrencyShort);
         else if (number_format.compact_display() == NumberFormat::CompactDisplay::Long)
-            format_rules = TRY_OR_THROW_OOM(vm, ::Locale::get_compact_number_system_formats(number_format.data_locale(), number_format.numbering_system(), ::Locale::CompactNumberFormatType::DecimalLong));
+            format_rules = ::Locale::get_compact_number_system_formats(number_format.data_locale(), number_format.numbering_system(), ::Locale::CompactNumberFormatType::DecimalLong);
         else
-            format_rules = TRY_OR_THROW_OOM(vm, ::Locale::get_compact_number_system_formats(number_format.data_locale(), number_format.numbering_system(), ::Locale::CompactNumberFormatType::DecimalShort));
+            format_rules = ::Locale::get_compact_number_system_formats(number_format.data_locale(), number_format.numbering_system(), ::Locale::CompactNumberFormatType::DecimalShort);
 
         ::Locale::NumberFormat const* best_number_format = nullptr;
 
@@ -1855,7 +1855,7 @@ ThrowCompletionOr<Vector<PatternPartitionWithSource>> partition_number_range_pat
 
     // 7. Let rangeSeparator be an ILND String value used to separate two numbers.
     auto range_separator_symbol = ::Locale::get_number_system_symbol(number_format.data_locale(), number_format.numbering_system(), ::Locale::NumericSymbol::RangeSeparator).value_or("-"sv);
-    auto range_separator = TRY_OR_THROW_OOM(vm, ::Locale::augment_range_pattern(range_separator_symbol, result.last().value, end_result[0].value));
+    auto range_separator = ::Locale::augment_range_pattern(range_separator_symbol, result.last().value, end_result[0].value);
 
     // 8. Append a new Record { [[Type]]: "literal", [[Value]]: rangeSeparator, [[Source]]: "shared" } element to result.
     PatternPartitionWithSource part;

--- a/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.h
@@ -296,9 +296,9 @@ ThrowCompletionOr<Array*> format_numeric_to_parts(VM&, NumberFormat&, Mathematic
 ThrowCompletionOr<RawFormatResult> to_raw_precision(VM&, MathematicalValue const& number, int min_precision, int max_precision, NumberFormat::UnsignedRoundingMode unsigned_rounding_mode);
 ThrowCompletionOr<RawFormatResult> to_raw_fixed(VM&, MathematicalValue const& number, int min_fraction, int max_fraction, int rounding_increment, NumberFormat::UnsignedRoundingMode unsigned_rounding_mode);
 ThrowCompletionOr<Optional<Variant<StringView, String>>> get_number_format_pattern(VM&, NumberFormat&, MathematicalValue const& number, ::Locale::NumberFormat& found_pattern);
-ThrowCompletionOr<Optional<StringView>> get_notation_sub_pattern(VM&, NumberFormat&, int exponent);
+Optional<StringView> get_notation_sub_pattern(NumberFormat&, int exponent);
 ThrowCompletionOr<int> compute_exponent(VM&, NumberFormat&, MathematicalValue number);
-ThrowCompletionOr<int> compute_exponent_for_magnitude(VM&, NumberFormat&, int magnitude);
+int compute_exponent_for_magnitude(NumberFormat&, int magnitude);
 ThrowCompletionOr<MathematicalValue> to_intl_mathematical_value(VM&, Value value);
 NumberFormat::UnsignedRoundingMode get_unsigned_rounding_mode(NumberFormat::RoundingMode, bool is_negative);
 RoundingDecision apply_unsigned_rounding_mode(MathematicalValue const& x, MathematicalValue const& r1, MathematicalValue const& r2, NumberFormat::UnsignedRoundingMode unsigned_rounding_mode);

--- a/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormat.cpp
@@ -117,20 +117,20 @@ ThrowCompletionOr<Vector<PatternPartitionWithUnit>> partition_relative_time_patt
     //       then filtering the large set of locale data down to the pattern we are looking for. Instead,
     //       LibUnicode expects the individual options as enumeration values, and returns the couple of
     //       patterns that match those options.
-    auto find_patterns_for_tense_or_number = [&](StringView tense_or_number) -> ThrowCompletionOr<Vector<::Locale::RelativeTimeFormat>> {
+    auto find_patterns_for_tense_or_number = [&](StringView tense_or_number) {
         // 10. If style is equal to "short", then
         //     a. Let entry be the string-concatenation of unit and "-short".
         // 11. Else if style is equal to "narrow", then
         //     a. Let entry be the string-concatenation of unit and "-narrow".
         // 12. Else,
         //     a. Let entry be unit.
-        auto patterns = TRY_OR_THROW_OOM(vm, ::Locale::get_relative_time_format_patterns(data_locale, time_unit, tense_or_number, style));
+        auto patterns = ::Locale::get_relative_time_format_patterns(data_locale, time_unit, tense_or_number, style);
 
         // 13. If fields doesn't have a field [[<entry>]], then
         if (patterns.is_empty()) {
             // a. Let entry be unit.
             // NOTE: In the CLDR, the lack of "short" or "narrow" in the key implies "long".
-            patterns = TRY_OR_THROW_OOM(vm, ::Locale::get_relative_time_format_patterns(data_locale, time_unit, tense_or_number, ::Locale::Style::Long));
+            patterns = ::Locale::get_relative_time_format_patterns(data_locale, time_unit, tense_or_number, ::Locale::Style::Long);
         }
 
         // 14. Let patterns be fields.[[<entry>]].
@@ -144,7 +144,7 @@ ThrowCompletionOr<Vector<PatternPartitionWithUnit>> partition_relative_time_patt
         auto value_string = MUST(Value(value).to_string(vm));
 
         // b. If patterns has a field [[<valueString>]], then
-        if (auto patterns = MUST_OR_THROW_OOM(find_patterns_for_tense_or_number(value_string)); !patterns.is_empty()) {
+        if (auto patterns = find_patterns_for_tense_or_number(value_string); !patterns.is_empty()) {
             VERIFY(patterns.size() == 1);
 
             // i. Let result be patterns.[[<valueString>]].
@@ -173,7 +173,7 @@ ThrowCompletionOr<Vector<PatternPartitionWithUnit>> partition_relative_time_patt
     }
 
     // 19. Let po be patterns.[[<tl>]].
-    auto patterns = MUST_OR_THROW_OOM(find_patterns_for_tense_or_number(tense));
+    auto patterns = find_patterns_for_tense_or_number(tense);
 
     // 20. Let fv be ! PartitionNumberPattern(relativeTimeFormat.[[NumberFormat]], value).
     auto value_partitions = MUST_OR_THROW_OOM(partition_number_pattern(vm, relative_time_format.number_format(), Value(value)));

--- a/Userland/Libraries/LibJS/Runtime/StringPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/StringPrototype.cpp
@@ -1262,18 +1262,18 @@ static ThrowCompletionOr<String> transform_case(VM& vm, String const& string, Va
     // 2. If requestedLocales is not an empty List, then
     if (!requested_locales.is_empty()) {
         // a. Let requestedLocale be requestedLocales[0].
-        requested_locale = TRY_OR_THROW_OOM(vm, Locale::parse_unicode_locale_id(requested_locales[0]));
+        requested_locale = Locale::parse_unicode_locale_id(requested_locales[0]);
     }
     // 3. Else,
     else {
         // a. Let requestedLocale be ! DefaultLocale().
-        requested_locale = TRY_OR_THROW_OOM(vm, Locale::parse_unicode_locale_id(Locale::default_locale()));
+        requested_locale = Locale::parse_unicode_locale_id(Locale::default_locale());
     }
     VERIFY(requested_locale.has_value());
 
     // 4. Let noExtensionsLocale be the String value that is requestedLocale with any Unicode locale extension sequences (6.2.1) removed.
     requested_locale->remove_extension_type<Locale::LocaleExtension>();
-    auto no_extensions_locale = TRY_OR_THROW_OOM(vm, requested_locale->to_string());
+    auto no_extensions_locale = requested_locale->to_string();
 
     // 5. Let availableLocales be a List with language tags that includes the languages for which the Unicode Character Database contains language sensitive case mappings. Implementations may add additional language tags if they support case mapping for additional locales.
     // 6. Let locale be ! BestAvailableLocale(availableLocales, noExtensionsLocale).

--- a/Userland/Libraries/LibLocale/DateTimeFormat.cpp
+++ b/Userland/Libraries/LibLocale/DateTimeFormat.cpp
@@ -109,12 +109,12 @@ static ErrorOr<T> find_regional_values_for_locale(StringView locale, GetRegional
 
     auto return_default_values = [&]() { return get_regional_values("001"sv); };
 
-    auto language = TRY(parse_unicode_language_id(locale));
+    auto language = parse_unicode_language_id(locale);
     if (!language.has_value())
         return return_default_values();
 
     if (!language->region.has_value())
-        language = TRY(add_likely_subtags(*language));
+        language = add_likely_subtags(*language);
     if (!language.has_value() || !language->region.has_value())
         return return_default_values();
 
@@ -253,7 +253,7 @@ static ErrorOr<Optional<String>> format_time_zone_offset(StringView locale, Cale
     if (!formats.has_value())
         return OptionalNone {};
 
-    auto number_system = TRY(get_preferred_keyword_value_for_locale(locale, "nu"sv));
+    auto number_system = get_preferred_keyword_value_for_locale(locale, "nu"sv);
     if (!number_system.has_value())
         return OptionalNone {};
 

--- a/Userland/Libraries/LibLocale/DateTimeFormat.cpp
+++ b/Userland/Libraries/LibLocale/DateTimeFormat.cpp
@@ -296,7 +296,7 @@ static ErrorOr<Optional<String>> format_time_zone_offset(StringView locale, Cale
     }
 
     // The digits used for hours, minutes and seconds fields in this format are the locale's default decimal digits.
-    auto result = TRY(replace_digits_for_number_system(*number_system, TRY(builder.to_string())));
+    auto result = replace_digits_for_number_system(*number_system, TRY(builder.to_string()));
     return TRY(String::from_utf8(formats->gmt_format)).replace("{0}"sv, result, ReplaceMode::FirstOnly);
 }
 

--- a/Userland/Libraries/LibLocale/DateTimeFormat.h
+++ b/Userland/Libraries/LibLocale/DateTimeFormat.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/Error.h>
 #include <AK/Optional.h>
 #include <AK/String.h>
 #include <AK/StringView.h>
@@ -189,44 +188,44 @@ CalendarPatternStyle calendar_pattern_style_from_string(StringView style);
 StringView calendar_pattern_style_to_string(CalendarPatternStyle style);
 
 Optional<HourCycleRegion> hour_cycle_region_from_string(StringView hour_cycle_region);
-ErrorOr<Vector<HourCycle>> get_regional_hour_cycles(StringView region);
-ErrorOr<Vector<HourCycle>> get_locale_hour_cycles(StringView locale);
-ErrorOr<Optional<HourCycle>> get_default_regional_hour_cycle(StringView locale);
+Vector<HourCycle> get_regional_hour_cycles(StringView region);
+Vector<HourCycle> get_locale_hour_cycles(StringView locale);
+Optional<HourCycle> get_default_regional_hour_cycle(StringView locale);
 
 Optional<MinimumDaysRegion> minimum_days_region_from_string(StringView minimum_days_region);
 Optional<u8> get_regional_minimum_days(StringView region);
-ErrorOr<Optional<u8>> get_locale_minimum_days(StringView locale);
+Optional<u8> get_locale_minimum_days(StringView locale);
 
 Optional<FirstDayRegion> first_day_region_from_string(StringView first_day_region);
 Optional<Weekday> get_regional_first_day(StringView region);
-ErrorOr<Optional<Weekday>> get_locale_first_day(StringView locale);
+Optional<Weekday> get_locale_first_day(StringView locale);
 
 Optional<WeekendStartRegion> weekend_start_region_from_string(StringView weekend_start_region);
 Optional<Weekday> get_regional_weekend_start(StringView region);
-ErrorOr<Optional<Weekday>> get_locale_weekend_start(StringView locale);
+Optional<Weekday> get_locale_weekend_start(StringView locale);
 
 Optional<WeekendEndRegion> weekend_end_region_from_string(StringView weekend_end_region);
 Optional<Weekday> get_regional_weekend_end(StringView region);
-ErrorOr<Optional<Weekday>> get_locale_weekend_end(StringView locale);
+Optional<Weekday> get_locale_weekend_end(StringView locale);
 
-ErrorOr<String> combine_skeletons(StringView first, StringView second);
+String combine_skeletons(StringView first, StringView second);
 
-ErrorOr<Optional<CalendarFormat>> get_calendar_date_format(StringView locale, StringView calendar);
-ErrorOr<Optional<CalendarFormat>> get_calendar_time_format(StringView locale, StringView calendar);
-ErrorOr<Optional<CalendarFormat>> get_calendar_date_time_format(StringView locale, StringView calendar);
-ErrorOr<Optional<CalendarFormat>> get_calendar_format(StringView locale, StringView calendar, CalendarFormatType type);
-ErrorOr<Vector<CalendarPattern>> get_calendar_available_formats(StringView locale, StringView calendar);
-ErrorOr<Optional<CalendarRangePattern>> get_calendar_default_range_format(StringView locale, StringView calendar);
-ErrorOr<Vector<CalendarRangePattern>> get_calendar_range_formats(StringView locale, StringView calendar, StringView skeleton);
-ErrorOr<Vector<CalendarRangePattern>> get_calendar_range12_formats(StringView locale, StringView calendar, StringView skeleton);
+Optional<CalendarFormat> get_calendar_date_format(StringView locale, StringView calendar);
+Optional<CalendarFormat> get_calendar_time_format(StringView locale, StringView calendar);
+Optional<CalendarFormat> get_calendar_date_time_format(StringView locale, StringView calendar);
+Optional<CalendarFormat> get_calendar_format(StringView locale, StringView calendar, CalendarFormatType type);
+Vector<CalendarPattern> get_calendar_available_formats(StringView locale, StringView calendar);
+Optional<CalendarRangePattern> get_calendar_default_range_format(StringView locale, StringView calendar);
+Vector<CalendarRangePattern> get_calendar_range_formats(StringView locale, StringView calendar, StringView skeleton);
+Vector<CalendarRangePattern> get_calendar_range12_formats(StringView locale, StringView calendar, StringView skeleton);
 
-ErrorOr<Optional<StringView>> get_calendar_era_symbol(StringView locale, StringView calendar, CalendarPatternStyle style, Era value);
-ErrorOr<Optional<StringView>> get_calendar_month_symbol(StringView locale, StringView calendar, CalendarPatternStyle style, Month value);
-ErrorOr<Optional<StringView>> get_calendar_weekday_symbol(StringView locale, StringView calendar, CalendarPatternStyle style, Weekday value);
-ErrorOr<Optional<StringView>> get_calendar_day_period_symbol(StringView locale, StringView calendar, CalendarPatternStyle style, DayPeriod value);
-ErrorOr<Optional<StringView>> get_calendar_day_period_symbol_for_hour(StringView locale, StringView calendar, CalendarPatternStyle style, u8 hour);
+Optional<StringView> get_calendar_era_symbol(StringView locale, StringView calendar, CalendarPatternStyle style, Era value);
+Optional<StringView> get_calendar_month_symbol(StringView locale, StringView calendar, CalendarPatternStyle style, Month value);
+Optional<StringView> get_calendar_weekday_symbol(StringView locale, StringView calendar, CalendarPatternStyle style, Weekday value);
+Optional<StringView> get_calendar_day_period_symbol(StringView locale, StringView calendar, CalendarPatternStyle style, DayPeriod value);
+Optional<StringView> get_calendar_day_period_symbol_for_hour(StringView locale, StringView calendar, CalendarPatternStyle style, u8 hour);
 
-ErrorOr<String> format_time_zone(StringView locale, StringView time_zone, CalendarPatternStyle style, AK::UnixDateTime time);
+String format_time_zone(StringView locale, StringView time_zone, CalendarPatternStyle style, AK::UnixDateTime time);
 Optional<StringView> get_time_zone_name(StringView locale, StringView time_zone, CalendarPatternStyle style, TimeZone::InDST in_dst);
 Optional<TimeZoneFormat> get_time_zone_format(StringView locale);
 

--- a/Userland/Libraries/LibLocale/Locale.h
+++ b/Userland/Libraries/LibLocale/Locale.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <AK/CharacterTypes.h>
-#include <AK/Error.h>
 #include <AK/Optional.h>
 #include <AK/String.h>
 #include <AK/StringView.h>
@@ -18,7 +17,7 @@
 namespace Locale {
 
 struct LanguageID {
-    ErrorOr<String> to_string() const;
+    String to_string() const;
     bool operator==(LanguageID const&) const = default;
 
     bool is_root { false };
@@ -56,7 +55,7 @@ struct OtherExtension {
 using Extension = AK::Variant<LocaleExtension, TransformedExtension, OtherExtension>;
 
 struct LocaleID {
-    ErrorOr<String> to_string() const;
+    String to_string() const;
 
     template<typename ExtensionType>
     Vector<Extension> remove_extension_type()
@@ -137,11 +136,11 @@ constexpr bool is_unicode_variant_subtag(StringView subtag)
 
 bool is_type_identifier(StringView);
 
-ErrorOr<Optional<LanguageID>> parse_unicode_language_id(StringView);
-ErrorOr<Optional<LocaleID>> parse_unicode_locale_id(StringView);
+Optional<LanguageID> parse_unicode_language_id(StringView);
+Optional<LocaleID> parse_unicode_locale_id(StringView);
 
-ErrorOr<void> canonicalize_unicode_extension_values(StringView key, String& value, bool remove_true);
-ErrorOr<Optional<String>> canonicalize_unicode_locale_id(LocaleID&);
+void canonicalize_unicode_extension_values(StringView key, String& value, bool remove_true);
+Optional<String> canonicalize_unicode_locale_id(LocaleID&);
 
 StringView default_locale();
 bool is_locale_available(StringView locale);
@@ -173,11 +172,11 @@ Optional<KeywordHours> keyword_hc_from_string(StringView hc);
 Optional<KeywordColCaseFirst> keyword_kf_from_string(StringView kf);
 Optional<KeywordColNumeric> keyword_kn_from_string(StringView kn);
 Optional<KeywordNumbers> keyword_nu_from_string(StringView nu);
-ErrorOr<Vector<StringView>> get_keywords_for_locale(StringView locale, StringView key);
-ErrorOr<Optional<StringView>> get_preferred_keyword_value_for_locale(StringView locale, StringView key);
+Vector<StringView> get_keywords_for_locale(StringView locale, StringView key);
+Optional<StringView> get_preferred_keyword_value_for_locale(StringView locale, StringView key);
 
 Optional<DisplayPattern> get_locale_display_patterns(StringView locale);
-ErrorOr<Optional<String>> format_locale_for_display(StringView locale, LocaleID locale_id);
+Optional<String> format_locale_for_display(StringView locale, LocaleID locale_id);
 
 Optional<StringView> get_locale_language_mapping(StringView locale, StringView language);
 Optional<StringView> get_locale_territory_mapping(StringView locale, StringView territory);
@@ -202,12 +201,12 @@ Optional<StringView> resolve_territory_alias(StringView territory);
 Optional<StringView> resolve_script_tag_alias(StringView script_tag);
 Optional<StringView> resolve_variant_alias(StringView variant);
 Optional<StringView> resolve_subdivision_alias(StringView subdivision);
-ErrorOr<void> resolve_complex_language_aliases(LanguageID& language_id);
+void resolve_complex_language_aliases(LanguageID& language_id);
 
-ErrorOr<Optional<LanguageID>> add_likely_subtags(LanguageID const& language_id);
-ErrorOr<Optional<LanguageID>> remove_likely_subtags(LanguageID const& language_id);
+Optional<LanguageID> add_likely_subtags(LanguageID const& language_id);
+Optional<LanguageID> remove_likely_subtags(LanguageID const& language_id);
 
-ErrorOr<Optional<String>> resolve_most_likely_territory(LanguageID const& language_id);
-ErrorOr<String> resolve_most_likely_territory_alias(LanguageID const& language_id, StringView territory_alias);
+Optional<String> resolve_most_likely_territory(LanguageID const& language_id);
+String resolve_most_likely_territory_alias(LanguageID const& language_id, StringView territory_alias);
 
 }

--- a/Userland/Libraries/LibLocale/NumberFormat.cpp
+++ b/Userland/Libraries/LibLocale/NumberFormat.cpp
@@ -16,8 +16,8 @@
 
 namespace Locale {
 
-ErrorOr<Optional<StringView>> __attribute__((weak)) get_number_system_symbol(StringView, StringView, NumericSymbol) { return OptionalNone {}; }
-ErrorOr<Optional<NumberGroupings>> __attribute__((weak)) get_number_system_groupings(StringView, StringView) { return OptionalNone {}; }
+Optional<StringView> __attribute__((weak)) get_number_system_symbol(StringView, StringView, NumericSymbol) { return {}; }
+Optional<NumberGroupings> __attribute__((weak)) get_number_system_groupings(StringView, StringView) { return {}; }
 ErrorOr<Optional<NumberFormat>> __attribute__((weak)) get_standard_number_system_format(StringView, StringView, StandardNumberFormatType) { return OptionalNone {}; }
 ErrorOr<Vector<NumberFormat>> __attribute__((weak)) get_compact_number_system_formats(StringView, StringView, CompactNumberFormatType) { return Vector<NumberFormat> {}; }
 ErrorOr<Vector<NumberFormat>> __attribute__((weak)) get_unit_formats(StringView, StringView, Style) { return Vector<NumberFormat> {}; }

--- a/Userland/Libraries/LibLocale/NumberFormat.cpp
+++ b/Userland/Libraries/LibLocale/NumberFormat.cpp
@@ -18,9 +18,9 @@ namespace Locale {
 
 Optional<StringView> __attribute__((weak)) get_number_system_symbol(StringView, StringView, NumericSymbol) { return {}; }
 Optional<NumberGroupings> __attribute__((weak)) get_number_system_groupings(StringView, StringView) { return {}; }
-ErrorOr<Optional<NumberFormat>> __attribute__((weak)) get_standard_number_system_format(StringView, StringView, StandardNumberFormatType) { return OptionalNone {}; }
-ErrorOr<Vector<NumberFormat>> __attribute__((weak)) get_compact_number_system_formats(StringView, StringView, CompactNumberFormatType) { return Vector<NumberFormat> {}; }
-ErrorOr<Vector<NumberFormat>> __attribute__((weak)) get_unit_formats(StringView, StringView, Style) { return Vector<NumberFormat> {}; }
+Optional<NumberFormat> __attribute__((weak)) get_standard_number_system_format(StringView, StringView, StandardNumberFormatType) { return {}; }
+Vector<NumberFormat> __attribute__((weak)) get_compact_number_system_formats(StringView, StringView, CompactNumberFormatType) { return {}; }
+Vector<NumberFormat> __attribute__((weak)) get_unit_formats(StringView, StringView, Style) { return {}; }
 
 Optional<ReadonlySpan<u32>> __attribute__((weak)) get_digits_for_number_system(StringView)
 {
@@ -29,7 +29,7 @@ Optional<ReadonlySpan<u32>> __attribute__((weak)) get_digits_for_number_system(S
     return digits.span();
 }
 
-ErrorOr<String> replace_digits_for_number_system(StringView system, StringView number)
+String replace_digits_for_number_system(StringView system, StringView number)
 {
     auto digits = get_digits_for_number_system(system);
     if (!digits.has_value())
@@ -41,13 +41,13 @@ ErrorOr<String> replace_digits_for_number_system(StringView system, StringView n
     for (auto ch : number) {
         if (is_ascii_digit(ch)) {
             u32 digit = digits->at(parse_ascii_digit(ch));
-            TRY(builder.try_append_code_point(digit));
+            builder.append_code_point(digit);
         } else {
-            TRY(builder.try_append(ch));
+            builder.append(ch);
         }
     }
 
-    return builder.to_string();
+    return MUST(builder.to_string());
 }
 
 #if ENABLE_UNICODE_DATA
@@ -64,7 +64,7 @@ static u32 last_code_point(StringView string)
 #endif
 
 // https://www.unicode.org/reports/tr35/tr35-numbers.html#Currencies
-ErrorOr<Optional<String>> augment_currency_format_pattern([[maybe_unused]] StringView currency_display, [[maybe_unused]] StringView base_pattern)
+Optional<String> augment_currency_format_pattern([[maybe_unused]] StringView currency_display, [[maybe_unused]] StringView base_pattern)
 {
 #if ENABLE_UNICODE_DATA
     constexpr auto number_key = "{number}"sv;
@@ -87,7 +87,7 @@ ErrorOr<Optional<String>> augment_currency_format_pattern([[maybe_unused]] Strin
             u32 first_currency_code_point = *utf8_currency_display.begin();
 
             if (!Unicode::code_point_has_general_category(first_currency_code_point, Unicode::GeneralCategory::Symbol))
-                currency_key_with_spacing = TRY(String::formatted("{}{}", spacing, currency_key));
+                currency_key_with_spacing = MUST(String::formatted("{}{}", spacing, currency_key));
         }
     } else {
         u32 last_pattern_code_point = last_code_point(base_pattern.substring_view(0, *number_index));
@@ -96,23 +96,23 @@ ErrorOr<Optional<String>> augment_currency_format_pattern([[maybe_unused]] Strin
             u32 last_currency_code_point = last_code_point(currency_display);
 
             if (!Unicode::code_point_has_general_category(last_currency_code_point, Unicode::GeneralCategory::Symbol))
-                currency_key_with_spacing = TRY(String::formatted("{}{}", currency_key, spacing));
+                currency_key_with_spacing = MUST(String::formatted("{}{}", currency_key, spacing));
         }
     }
 
     if (currency_key_with_spacing.has_value())
-        return TRY(TRY(String::from_utf8(base_pattern)).replace(currency_key, *currency_key_with_spacing, ReplaceMode::FirstOnly));
+        return MUST(MUST(String::from_utf8(base_pattern)).replace(currency_key, *currency_key_with_spacing, ReplaceMode::FirstOnly));
 #endif
 
-    return OptionalNone {};
+    return {};
 }
 
 // https://unicode.org/reports/tr35/tr35-numbers.html#83-range-pattern-processing
-ErrorOr<Optional<String>> augment_range_pattern([[maybe_unused]] StringView range_separator, [[maybe_unused]] StringView lower, [[maybe_unused]] StringView upper)
+Optional<String> augment_range_pattern([[maybe_unused]] StringView range_separator, [[maybe_unused]] StringView lower, [[maybe_unused]] StringView upper)
 {
 #if ENABLE_UNICODE_DATA
     auto range_pattern_with_spacing = [&]() {
-        return String::formatted(" {} ", range_separator);
+        return MUST(String::formatted(" {} ", range_separator));
     };
 
     Utf8View utf8_range_separator { range_separator };
@@ -124,7 +124,7 @@ ErrorOr<Optional<String>> augment_range_pattern([[maybe_unused]] StringView rang
     // 2. If the range pattern does not contain a character having the White_Space binary Unicode property after the {0} or before the {1} placeholders.
     for (auto it = utf8_range_separator.begin(); it != utf8_range_separator.end(); ++it) {
         if (Unicode::code_point_has_property(*it, Unicode::Property::White_Space))
-            return OptionalNone {};
+            return {};
     }
 
     // 1. If the lower string ends with a character other than a digit, or if the upper string begins with a character other than a digit.
@@ -137,7 +137,7 @@ ErrorOr<Optional<String>> augment_range_pattern([[maybe_unused]] StringView rang
         return range_pattern_with_spacing();
 #endif
 
-    return OptionalNone {};
+    return {};
 }
 
 }

--- a/Userland/Libraries/LibLocale/NumberFormat.h
+++ b/Userland/Libraries/LibLocale/NumberFormat.h
@@ -61,8 +61,8 @@ enum class NumericSymbol : u8 {
     TimeSeparator,
 };
 
-ErrorOr<Optional<StringView>> get_number_system_symbol(StringView locale, StringView system, NumericSymbol symbol);
-ErrorOr<Optional<NumberGroupings>> get_number_system_groupings(StringView locale, StringView system);
+Optional<StringView> get_number_system_symbol(StringView locale, StringView system, NumericSymbol symbol);
+Optional<NumberGroupings> get_number_system_groupings(StringView locale, StringView system);
 
 Optional<ReadonlySpan<u32>> get_digits_for_number_system(StringView system);
 ErrorOr<String> replace_digits_for_number_system(StringView system, StringView number);

--- a/Userland/Libraries/LibLocale/NumberFormat.h
+++ b/Userland/Libraries/LibLocale/NumberFormat.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/Error.h>
 #include <AK/Optional.h>
 #include <AK/String.h>
 #include <AK/StringView.h>
@@ -65,13 +64,13 @@ Optional<StringView> get_number_system_symbol(StringView locale, StringView syst
 Optional<NumberGroupings> get_number_system_groupings(StringView locale, StringView system);
 
 Optional<ReadonlySpan<u32>> get_digits_for_number_system(StringView system);
-ErrorOr<String> replace_digits_for_number_system(StringView system, StringView number);
+String replace_digits_for_number_system(StringView system, StringView number);
 
-ErrorOr<Optional<NumberFormat>> get_standard_number_system_format(StringView locale, StringView system, StandardNumberFormatType type);
-ErrorOr<Vector<NumberFormat>> get_compact_number_system_formats(StringView locale, StringView system, CompactNumberFormatType type);
-ErrorOr<Vector<NumberFormat>> get_unit_formats(StringView locale, StringView unit, Style style);
+Optional<NumberFormat> get_standard_number_system_format(StringView locale, StringView system, StandardNumberFormatType type);
+Vector<NumberFormat> get_compact_number_system_formats(StringView locale, StringView system, CompactNumberFormatType type);
+Vector<NumberFormat> get_unit_formats(StringView locale, StringView unit, Style style);
 
-ErrorOr<Optional<String>> augment_currency_format_pattern(StringView currency_display, StringView base_pattern);
-ErrorOr<Optional<String>> augment_range_pattern(StringView range_separator, StringView lower, StringView upper);
+Optional<String> augment_currency_format_pattern(StringView currency_display, StringView base_pattern);
+Optional<String> augment_range_pattern(StringView range_separator, StringView lower, StringView upper);
 
 }

--- a/Userland/Libraries/LibLocale/RelativeTimeFormat.cpp
+++ b/Userland/Libraries/LibLocale/RelativeTimeFormat.cpp
@@ -53,6 +53,6 @@ StringView time_unit_to_string(TimeUnit time_unit)
     }
 }
 
-ErrorOr<Vector<RelativeTimeFormat>> __attribute__((weak)) get_relative_time_format_patterns(StringView, TimeUnit, StringView, Style) { return Vector<RelativeTimeFormat> {}; }
+Vector<RelativeTimeFormat> __attribute__((weak)) get_relative_time_format_patterns(StringView, TimeUnit, StringView, Style) { return {}; }
 
 }

--- a/Userland/Libraries/LibLocale/RelativeTimeFormat.h
+++ b/Userland/Libraries/LibLocale/RelativeTimeFormat.h
@@ -34,6 +34,6 @@ struct RelativeTimeFormat {
 Optional<TimeUnit> time_unit_from_string(StringView time_unit);
 StringView time_unit_to_string(TimeUnit time_unit);
 
-ErrorOr<Vector<RelativeTimeFormat>> get_relative_time_format_patterns(StringView locale, TimeUnit time_unit, StringView tense_or_number, Style style);
+Vector<RelativeTimeFormat> get_relative_time_format_patterns(StringView locale, TimeUnit time_unit, StringView tense_or_number, Style style);
 
 }


### PR DESCRIPTION
These APIs only perform small allocations, and are only used by LibJS.
Callers which could only have failed from these APIs are also made to
be infallible here.

Work towards #20449.