### PR TITLE
LibWeb: Ensure layout/text/ref tests run with the desired default theme

### DIFF
--- a/Ladybird/CMakeLists.txt
+++ b/Ladybird/CMakeLists.txt
@@ -239,7 +239,7 @@ include(CTest)
 if (BUILD_TESTING)
     add_test(
         NAME LibWeb
-        COMMAND ${CMAKE_CURRENT_BINARY_DIR}/../bin/headless-browser --run-tests ${SERENITY_SOURCE_DIR}/Tests/LibWeb
+        COMMAND ${CMAKE_CURRENT_BINARY_DIR}/../bin/headless-browser --resources "${SERENITY_SOURCE_DIR}/Base/res" --run-tests ${SERENITY_SOURCE_DIR}/Tests/LibWeb
     )
     add_test(
         NAME WPT


### PR DESCRIPTION
Without setting the --resources flag, headless-browser defaults to /res for all resources it tries to find, including the theme. It will not find this path on Lagom, so our attempt to load the default theme does not accomplish anything.