### PR TITLE
Ladybird+LibWebView: Continue work to reduce duplcation betwen browser implementations

### DIFF
--- a/Ladybird/AppKit/UI/LadybirdWebView.mm
+++ b/Ladybird/AppKit/UI/LadybirdWebView.mm
@@ -416,7 +416,7 @@ struct HideCursor {
         [NSMenu popUpContextMenu:self.video_context_menu withEvent:event forView:self];
     };
 
-    m_web_view_bridge->on_alert = [self](auto const& message) {
+    m_web_view_bridge->on_request_alert = [self](auto const& message) {
         auto* ns_message = Ladybird::string_to_ns_string(message);
 
         self.dialog = [[NSAlert alloc] init];
@@ -429,7 +429,7 @@ struct HideCursor {
                             }];
     };
 
-    m_web_view_bridge->on_confirm = [self](auto const& message) {
+    m_web_view_bridge->on_request_confirm = [self](auto const& message) {
         auto* ns_message = Ladybird::string_to_ns_string(message);
 
         self.dialog = [[NSAlert alloc] init];
@@ -444,7 +444,7 @@ struct HideCursor {
                             }];
     };
 
-    m_web_view_bridge->on_prompt = [self](auto const& message, auto const& default_) {
+    m_web_view_bridge->on_request_prompt = [self](auto const& message, auto const& default_) {
         auto* ns_message = Ladybird::string_to_ns_string(message);
         auto* ns_default = Ladybird::string_to_ns_string(default_);
 
@@ -472,7 +472,7 @@ struct HideCursor {
                             }];
     };
 
-    m_web_view_bridge->on_prompt_text_changed = [self](auto const& message) {
+    m_web_view_bridge->on_request_set_prompt_text = [self](auto const& message) {
         if (self.dialog == nil || [self.dialog accessoryView] == nil) {
             return;
         }
@@ -483,7 +483,7 @@ struct HideCursor {
         [input setStringValue:ns_message];
     };
 
-    m_web_view_bridge->on_dialog_accepted = [self]() {
+    m_web_view_bridge->on_request_accept_dialog = [self]() {
         if (self.dialog == nil) {
             return;
         }
@@ -492,7 +492,7 @@ struct HideCursor {
                      returnCode:NSModalResponseOK];
     };
 
-    m_web_view_bridge->on_dialog_dismissed = [self]() {
+    m_web_view_bridge->on_request_dismiss_dialog = [self]() {
         if (self.dialog == nil) {
             return;
         }

--- a/Ladybird/AppKit/UI/LadybirdWebViewBridge.cpp
+++ b/Ladybird/AppKit/UI/LadybirdWebViewBridge.cpp
@@ -112,26 +112,6 @@ void WebViewBridge::notify_server_did_layout(Badge<WebView::WebContentClient>, G
     }
 }
 
-void WebViewBridge::notify_server_did_paint(Badge<WebView::WebContentClient>, i32 bitmap_id, Gfx::IntSize size)
-{
-    if (m_client_state.back_bitmap.id == bitmap_id) {
-        m_client_state.has_usable_bitmap = true;
-        m_client_state.back_bitmap.pending_paints--;
-        m_client_state.back_bitmap.last_painted_size = size;
-        swap(m_client_state.back_bitmap, m_client_state.front_bitmap);
-        // We don't need the backup bitmap anymore, so drop it.
-        m_backup_bitmap = nullptr;
-
-        if (on_ready_to_paint)
-            on_ready_to_paint();
-
-        if (m_client_state.got_repaint_requests_while_painting) {
-            m_client_state.got_repaint_requests_while_painting = false;
-            request_repaint();
-        }
-    }
-}
-
 void WebViewBridge::notify_server_did_invalidate_content_rect(Badge<WebView::WebContentClient>, Gfx::IntRect const&)
 {
     request_repaint();

--- a/Ladybird/AppKit/UI/LadybirdWebViewBridge.cpp
+++ b/Ladybird/AppKit/UI/LadybirdWebViewBridge.cpp
@@ -112,16 +112,6 @@ void WebViewBridge::notify_server_did_layout(Badge<WebView::WebContentClient>, G
     }
 }
 
-void WebViewBridge::notify_server_did_invalidate_content_rect(Badge<WebView::WebContentClient>, Gfx::IntRect const&)
-{
-    request_repaint();
-}
-
-void WebViewBridge::notify_server_did_change_selection(Badge<WebView::WebContentClient>)
-{
-    request_repaint();
-}
-
 void WebViewBridge::notify_server_did_request_cursor_change(Badge<WebView::WebContentClient>, Gfx::StandardCursor cursor)
 {
     if (on_cursor_change)

--- a/Ladybird/AppKit/UI/LadybirdWebViewBridge.cpp
+++ b/Ladybird/AppKit/UI/LadybirdWebViewBridge.cpp
@@ -197,58 +197,6 @@ void WebViewBridge::notify_server_did_leave_tooltip_area(Badge<WebView::WebConte
     if (on_tooltip_left)
         on_tooltip_left();
 }
-
-void WebViewBridge::notify_server_did_request_alert(Badge<WebView::WebContentClient>, String const& message)
-{
-    if (on_alert)
-        on_alert(message);
-}
-
-void WebViewBridge::alert_closed()
-{
-    client().async_alert_closed();
-}
-
-void WebViewBridge::notify_server_did_request_confirm(Badge<WebView::WebContentClient>, String const& message)
-{
-    if (on_confirm)
-        on_confirm(message);
-}
-
-void WebViewBridge::confirm_closed(bool accepted)
-{
-    client().async_confirm_closed(accepted);
-}
-
-void WebViewBridge::notify_server_did_request_prompt(Badge<WebView::WebContentClient>, String const& message, String const& default_)
-{
-    if (on_prompt)
-        on_prompt(message, default_);
-}
-
-void WebViewBridge::prompt_closed(Optional<String> response)
-{
-    client().async_prompt_closed(move(response));
-}
-
-void WebViewBridge::notify_server_did_request_set_prompt_text(Badge<WebView::WebContentClient>, String const& message)
-{
-    if (on_prompt_text_changed)
-        on_prompt_text_changed(message);
-}
-
-void WebViewBridge::notify_server_did_request_accept_dialog(Badge<WebView::WebContentClient>)
-{
-    if (on_dialog_accepted)
-        on_dialog_accepted();
-}
-
-void WebViewBridge::notify_server_did_request_dismiss_dialog(Badge<WebView::WebContentClient>)
-{
-    if (on_dialog_dismissed)
-        on_dialog_dismissed();
-}
-
 void WebViewBridge::notify_server_did_request_file(Badge<WebView::WebContentClient>, DeprecatedString const& path, i32 request_id)
 {
     auto file = Core::File::open(path, Core::File::OpenMode::Read);

--- a/Ladybird/AppKit/UI/LadybirdWebViewBridge.cpp
+++ b/Ladybird/AppKit/UI/LadybirdWebViewBridge.cpp
@@ -7,7 +7,6 @@
 #include <Ladybird/HelperProcess.h>
 #include <Ladybird/Types.h>
 #include <Ladybird/Utilities.h>
-#include <LibCore/File.h>
 #include <LibGfx/Font/FontDatabase.h>
 #include <LibGfx/Rect.h>
 #include <LibIPC/File.h>
@@ -196,15 +195,6 @@ void WebViewBridge::notify_server_did_leave_tooltip_area(Badge<WebView::WebConte
 {
     if (on_tooltip_left)
         on_tooltip_left();
-}
-void WebViewBridge::notify_server_did_request_file(Badge<WebView::WebContentClient>, DeprecatedString const& path, i32 request_id)
-{
-    auto file = Core::File::open(path, Core::File::OpenMode::Read);
-
-    if (file.is_error())
-        client().async_handle_file_return(file.error().code(), {}, request_id);
-    else
-        client().async_handle_file_return(0, IPC::File(*file.value()), request_id);
 }
 
 void WebViewBridge::notify_server_did_finish_handling_input_event(bool)

--- a/Ladybird/AppKit/UI/LadybirdWebViewBridge.h
+++ b/Ladybird/AppKit/UI/LadybirdWebViewBridge.h
@@ -59,19 +59,6 @@ public:
     Function<void(DeprecatedString const&)> on_tooltip_entered;
     Function<void()> on_tooltip_left;
 
-    Function<void(String const&)> on_alert;
-    void alert_closed();
-
-    Function<void(String const&)> on_confirm;
-    void confirm_closed(bool);
-
-    Function<void(String const&, String const&)> on_prompt;
-    Function<void(String const&)> on_prompt_text_changed;
-    void prompt_closed(Optional<String>);
-
-    Function<void()> on_dialog_accepted;
-    Function<void()> on_dialog_dismissed;
-
 private:
     WebViewBridge(Vector<Gfx::IntRect> screen_rects, float device_pixel_ratio, Optional<StringView> webdriver_content_ipc_path);
 
@@ -85,12 +72,6 @@ private:
     virtual void notify_server_did_request_scroll_into_view(Badge<WebView::WebContentClient>, Gfx::IntRect const&) override;
     virtual void notify_server_did_enter_tooltip_area(Badge<WebView::WebContentClient>, Gfx::IntPoint, DeprecatedString const&) override;
     virtual void notify_server_did_leave_tooltip_area(Badge<WebView::WebContentClient>) override;
-    virtual void notify_server_did_request_alert(Badge<WebView::WebContentClient>, String const& message) override;
-    virtual void notify_server_did_request_confirm(Badge<WebView::WebContentClient>, String const& message) override;
-    virtual void notify_server_did_request_prompt(Badge<WebView::WebContentClient>, String const& message, String const& default_) override;
-    virtual void notify_server_did_request_set_prompt_text(Badge<WebView::WebContentClient>, String const& message) override;
-    virtual void notify_server_did_request_accept_dialog(Badge<WebView::WebContentClient>) override;
-    virtual void notify_server_did_request_dismiss_dialog(Badge<WebView::WebContentClient>) override;
     virtual void notify_server_did_request_file(Badge<WebView::WebContentClient>, DeprecatedString const& path, i32) override;
     virtual void notify_server_did_finish_handling_input_event(bool event_was_accepted) override;
 

--- a/Ladybird/AppKit/UI/LadybirdWebViewBridge.h
+++ b/Ladybird/AppKit/UI/LadybirdWebViewBridge.h
@@ -62,8 +62,6 @@ private:
     WebViewBridge(Vector<Gfx::IntRect> screen_rects, float device_pixel_ratio, Optional<StringView> webdriver_content_ipc_path);
 
     virtual void notify_server_did_layout(Badge<WebView::WebContentClient>, Gfx::IntSize content_size) override;
-    virtual void notify_server_did_invalidate_content_rect(Badge<WebView::WebContentClient>, Gfx::IntRect const&) override;
-    virtual void notify_server_did_change_selection(Badge<WebView::WebContentClient>) override;
     virtual void notify_server_did_request_cursor_change(Badge<WebView::WebContentClient>, Gfx::StandardCursor cursor) override;
     virtual void notify_server_did_request_scroll(Badge<WebView::WebContentClient>, i32, i32) override;
     virtual void notify_server_did_request_scroll_to(Badge<WebView::WebContentClient>, Gfx::IntPoint) override;

--- a/Ladybird/AppKit/UI/LadybirdWebViewBridge.h
+++ b/Ladybird/AppKit/UI/LadybirdWebViewBridge.h
@@ -50,7 +50,6 @@ public:
     Optional<Paintable> paintable();
 
     Function<void(Gfx::IntSize)> on_layout;
-    Function<void()> on_ready_to_paint;
 
     Function<void(Gfx::IntPoint)> on_scroll;
 
@@ -63,7 +62,6 @@ private:
     WebViewBridge(Vector<Gfx::IntRect> screen_rects, float device_pixel_ratio, Optional<StringView> webdriver_content_ipc_path);
 
     virtual void notify_server_did_layout(Badge<WebView::WebContentClient>, Gfx::IntSize content_size) override;
-    virtual void notify_server_did_paint(Badge<WebView::WebContentClient>, i32 bitmap_id, Gfx::IntSize) override;
     virtual void notify_server_did_invalidate_content_rect(Badge<WebView::WebContentClient>, Gfx::IntRect const&) override;
     virtual void notify_server_did_change_selection(Badge<WebView::WebContentClient>) override;
     virtual void notify_server_did_request_cursor_change(Badge<WebView::WebContentClient>, Gfx::StandardCursor cursor) override;

--- a/Ladybird/AppKit/UI/LadybirdWebViewBridge.h
+++ b/Ladybird/AppKit/UI/LadybirdWebViewBridge.h
@@ -72,7 +72,6 @@ private:
     virtual void notify_server_did_request_scroll_into_view(Badge<WebView::WebContentClient>, Gfx::IntRect const&) override;
     virtual void notify_server_did_enter_tooltip_area(Badge<WebView::WebContentClient>, Gfx::IntPoint, DeprecatedString const&) override;
     virtual void notify_server_did_leave_tooltip_area(Badge<WebView::WebContentClient>) override;
-    virtual void notify_server_did_request_file(Badge<WebView::WebContentClient>, DeprecatedString const& path, i32) override;
     virtual void notify_server_did_finish_handling_input_event(bool event_was_accepted) override;
 
     virtual void update_zoom() override;

--- a/Ladybird/Qt/Tab.h
+++ b/Ladybird/Qt/Tab.h
@@ -14,6 +14,7 @@
 #include <QLabel>
 #include <QLineEdit>
 #include <QMenu>
+#include <QPointer>
 #include <QToolBar>
 #include <QToolButton>
 #include <QWidget>
@@ -111,6 +112,8 @@ private:
     Ladybird::ConsoleWidget* m_console_widget { nullptr };
     OwnPtr<QMenu> m_console_context_menu;
     Ladybird::InspectorWidget* m_inspector_widget { nullptr };
+
+    QPointer<QDialog> m_dialog;
 };
 
 }

--- a/Ladybird/Qt/WebContentView.cpp
+++ b/Ladybird/Qt/WebContentView.cpp
@@ -725,15 +725,6 @@ void WebContentView::notify_server_did_leave_tooltip_area(Badge<WebContentClient
     QToolTip::hideText();
 }
 
-void WebContentView::notify_server_did_request_file(Badge<WebContentClient>, DeprecatedString const& path, i32 request_id)
-{
-    auto file = Core::File::open(path, Core::File::OpenMode::Read);
-    if (file.is_error())
-        client().async_handle_file_return(file.error().code(), {}, request_id);
-    else
-        client().async_handle_file_return(0, IPC::File(*file.value()), request_id);
-}
-
 Gfx::IntRect WebContentView::viewport_rect() const
 {
     return m_viewport_rect;

--- a/Ladybird/Qt/WebContentView.cpp
+++ b/Ladybird/Qt/WebContentView.cpp
@@ -37,9 +37,7 @@
 #include <QCursor>
 #include <QGuiApplication>
 #include <QIcon>
-#include <QInputDialog>
 #include <QLineEdit>
-#include <QMessageBox>
 #include <QMimeData>
 #include <QMouseEvent>
 #include <QPaintEvent>
@@ -725,59 +723,6 @@ void WebContentView::notify_server_did_enter_tooltip_area(Badge<WebContentClient
 void WebContentView::notify_server_did_leave_tooltip_area(Badge<WebContentClient>)
 {
     QToolTip::hideText();
-}
-
-void WebContentView::notify_server_did_request_alert(Badge<WebContentClient>, String const& message)
-{
-    m_dialog = new QMessageBox(QMessageBox::Icon::Warning, "Ladybird", qstring_from_ak_string(message), QMessageBox::StandardButton::Ok, this);
-    m_dialog->exec();
-
-    client().async_alert_closed();
-    m_dialog = nullptr;
-}
-
-void WebContentView::notify_server_did_request_confirm(Badge<WebContentClient>, String const& message)
-{
-    m_dialog = new QMessageBox(QMessageBox::Icon::Question, "Ladybird", qstring_from_ak_string(message), QMessageBox::StandardButton::Ok | QMessageBox::StandardButton::Cancel, this);
-    auto result = m_dialog->exec();
-
-    client().async_confirm_closed(result == QMessageBox::StandardButton::Ok || result == QDialog::Accepted);
-    m_dialog = nullptr;
-}
-
-void WebContentView::notify_server_did_request_prompt(Badge<WebContentClient>, String const& message, String const& default_)
-{
-    m_dialog = new QInputDialog(this);
-    auto& dialog = static_cast<QInputDialog&>(*m_dialog);
-
-    dialog.setWindowTitle("Ladybird");
-    dialog.setLabelText(qstring_from_ak_string(message));
-    dialog.setTextValue(qstring_from_ak_string(default_));
-
-    if (dialog.exec() == QDialog::Accepted)
-        client().async_prompt_closed(ak_string_from_qstring(dialog.textValue()).release_value_but_fixme_should_propagate_errors());
-    else
-        client().async_prompt_closed({});
-
-    m_dialog = nullptr;
-}
-
-void WebContentView::notify_server_did_request_set_prompt_text(Badge<WebContentClient>, String const& message)
-{
-    if (m_dialog && is<QInputDialog>(*m_dialog))
-        static_cast<QInputDialog&>(*m_dialog).setTextValue(qstring_from_ak_string(message));
-}
-
-void WebContentView::notify_server_did_request_accept_dialog(Badge<WebContentClient>)
-{
-    if (m_dialog)
-        m_dialog->accept();
-}
-
-void WebContentView::notify_server_did_request_dismiss_dialog(Badge<WebContentClient>)
-{
-    if (m_dialog)
-        m_dialog->reject();
 }
 
 void WebContentView::notify_server_did_request_file(Badge<WebContentClient>, DeprecatedString const& path, i32 request_id)

--- a/Ladybird/Qt/WebContentView.cpp
+++ b/Ladybird/Qt/WebContentView.cpp
@@ -591,16 +591,6 @@ void WebContentView::create_client(WebView::EnableCallgrindProfiling enable_call
         client().async_connect_to_webdriver(m_webdriver_content_ipc_path);
 }
 
-void WebContentView::notify_server_did_invalidate_content_rect(Badge<WebContentClient>, [[maybe_unused]] Gfx::IntRect const& content_rect)
-{
-    request_repaint();
-}
-
-void WebContentView::notify_server_did_change_selection(Badge<WebContentClient>)
-{
-    request_repaint();
-}
-
 void WebContentView::notify_server_did_request_cursor_change(Badge<WebContentClient>, Gfx::StandardCursor cursor)
 {
     switch (cursor) {

--- a/Ladybird/Qt/WebContentView.h
+++ b/Ladybird/Qt/WebContentView.h
@@ -77,7 +77,6 @@ public:
     void update_palette(PaletteMode = PaletteMode::Default);
 
     virtual void notify_server_did_layout(Badge<WebContentClient>, Gfx::IntSize content_size) override;
-    virtual void notify_server_did_paint(Badge<WebContentClient>, i32 bitmap_id, Gfx::IntSize) override;
     virtual void notify_server_did_invalidate_content_rect(Badge<WebContentClient>, Gfx::IntRect const&) override;
     virtual void notify_server_did_change_selection(Badge<WebContentClient>) override;
     virtual void notify_server_did_request_cursor_change(Badge<WebContentClient>, Gfx::StandardCursor cursor) override;

--- a/Ladybird/Qt/WebContentView.h
+++ b/Ladybird/Qt/WebContentView.h
@@ -86,7 +86,6 @@ public:
     virtual void notify_server_did_request_scroll_into_view(Badge<WebContentClient>, Gfx::IntRect const&) override;
     virtual void notify_server_did_enter_tooltip_area(Badge<WebContentClient>, Gfx::IntPoint, DeprecatedString const&) override;
     virtual void notify_server_did_leave_tooltip_area(Badge<WebContentClient>) override;
-    virtual void notify_server_did_request_file(Badge<WebContentClient>, DeprecatedString const& path, i32) override;
     virtual void notify_server_did_finish_handling_input_event(bool event_was_accepted) override;
 
 signals:

--- a/Ladybird/Qt/WebContentView.h
+++ b/Ladybird/Qt/WebContentView.h
@@ -22,7 +22,6 @@
 #include <LibWeb/HTML/ActivateTab.h>
 #include <LibWebView/ViewImplementation.h>
 #include <QAbstractScrollArea>
-#include <QPointer>
 #include <QUrl>
 
 class QTextEdit;
@@ -87,12 +86,6 @@ public:
     virtual void notify_server_did_request_scroll_into_view(Badge<WebContentClient>, Gfx::IntRect const&) override;
     virtual void notify_server_did_enter_tooltip_area(Badge<WebContentClient>, Gfx::IntPoint, DeprecatedString const&) override;
     virtual void notify_server_did_leave_tooltip_area(Badge<WebContentClient>) override;
-    virtual void notify_server_did_request_alert(Badge<WebContentClient>, String const& message) override;
-    virtual void notify_server_did_request_confirm(Badge<WebContentClient>, String const& message) override;
-    virtual void notify_server_did_request_prompt(Badge<WebContentClient>, String const& message, String const& default_) override;
-    virtual void notify_server_did_request_set_prompt_text(Badge<WebContentClient>, String const& message) override;
-    virtual void notify_server_did_request_accept_dialog(Badge<WebContentClient>) override;
-    virtual void notify_server_did_request_dismiss_dialog(Badge<WebContentClient>) override;
     virtual void notify_server_did_request_file(Badge<WebContentClient>, DeprecatedString const& path, i32) override;
     virtual void notify_server_did_finish_handling_input_event(bool event_was_accepted) override;
 
@@ -112,8 +105,6 @@ private:
     qreal m_inverse_pixel_scaling_ratio { 1.0 };
     bool m_should_show_line_box_borders { false };
     UseLagomNetworking m_use_lagom_networking {};
-
-    QPointer<QDialog> m_dialog;
 
     Gfx::IntRect m_viewport_rect;
 

--- a/Ladybird/Qt/WebContentView.h
+++ b/Ladybird/Qt/WebContentView.h
@@ -77,8 +77,6 @@ public:
     void update_palette(PaletteMode = PaletteMode::Default);
 
     virtual void notify_server_did_layout(Badge<WebContentClient>, Gfx::IntSize content_size) override;
-    virtual void notify_server_did_invalidate_content_rect(Badge<WebContentClient>, Gfx::IntRect const&) override;
-    virtual void notify_server_did_change_selection(Badge<WebContentClient>) override;
     virtual void notify_server_did_request_cursor_change(Badge<WebContentClient>, Gfx::StandardCursor cursor) override;
     virtual void notify_server_did_request_scroll(Badge<WebContentClient>, i32, i32) override;
     virtual void notify_server_did_request_scroll_to(Badge<WebContentClient>, Gfx::IntPoint) override;

--- a/Userland/Applications/Browser/Tab.h
+++ b/Userland/Applications/Browser/Tab.h
@@ -136,6 +136,8 @@ private:
     RefPtr<GUI::Statusbar> m_statusbar;
     RefPtr<GUI::ToolbarContainer> m_toolbar_container;
 
+    RefPtr<GUI::Dialog> m_dialog;
+
     RefPtr<GUI::Menu> m_link_context_menu;
     RefPtr<GUI::Action> m_link_context_menu_default_action;
     URL m_link_context_menu_url;

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
@@ -179,16 +179,6 @@ void OutOfProcessWebView::screen_rects_change_event(GUI::ScreenRectsChangeEvent&
     client().async_update_screen_rects(event.rects(), event.main_screen_index());
 }
 
-void OutOfProcessWebView::notify_server_did_invalidate_content_rect(Badge<WebContentClient>, [[maybe_unused]] Gfx::IntRect const& content_rect)
-{
-    request_repaint();
-}
-
-void OutOfProcessWebView::notify_server_did_change_selection(Badge<WebContentClient>)
-{
-    request_repaint();
-}
-
 void OutOfProcessWebView::notify_server_did_request_cursor_change(Badge<WebContentClient>, Gfx::StandardCursor cursor)
 {
     set_override_cursor(cursor);

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.h
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.h
@@ -83,7 +83,6 @@ private:
     virtual void create_client(EnableCallgrindProfiling = EnableCallgrindProfiling::No) override;
     virtual void update_zoom() override;
     virtual void notify_server_did_layout(Badge<WebContentClient>, Gfx::IntSize content_size) override;
-    virtual void notify_server_did_paint(Badge<WebContentClient>, i32 bitmap_id, Gfx::IntSize) override;
     virtual void notify_server_did_invalidate_content_rect(Badge<WebContentClient>, Gfx::IntRect const&) override;
     virtual void notify_server_did_change_selection(Badge<WebContentClient>) override;
     virtual void notify_server_did_request_cursor_change(Badge<WebContentClient>, Gfx::StandardCursor cursor) override;

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.h
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.h
@@ -92,12 +92,6 @@ private:
     virtual void notify_server_did_request_scroll_into_view(Badge<WebContentClient>, Gfx::IntRect const&) override;
     virtual void notify_server_did_enter_tooltip_area(Badge<WebContentClient>, Gfx::IntPoint, DeprecatedString const&) override;
     virtual void notify_server_did_leave_tooltip_area(Badge<WebContentClient>) override;
-    virtual void notify_server_did_request_alert(Badge<WebContentClient>, String const& message) override;
-    virtual void notify_server_did_request_confirm(Badge<WebContentClient>, String const& message) override;
-    virtual void notify_server_did_request_prompt(Badge<WebContentClient>, String const& message, String const& default_) override;
-    virtual void notify_server_did_request_set_prompt_text(Badge<WebContentClient>, String const& message) override;
-    virtual void notify_server_did_request_accept_dialog(Badge<WebContentClient>) override;
-    virtual void notify_server_did_request_dismiss_dialog(Badge<WebContentClient>) override;
     virtual void notify_server_did_request_file(Badge<WebContentClient>, DeprecatedString const& path, i32) override;
     virtual void notify_server_did_finish_handling_input_event(bool event_was_accepted) override;
 
@@ -108,8 +102,6 @@ private:
     using InputEvent = Variant<GUI::KeyEvent, GUI::MouseEvent>;
     void enqueue_input_event(InputEvent const&);
     void process_next_input_event();
-
-    RefPtr<GUI::Dialog> m_dialog;
 
     bool m_is_awaiting_response_for_input_event { false };
     Queue<InputEvent> m_pending_input_events;

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.h
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.h
@@ -92,7 +92,6 @@ private:
     virtual void notify_server_did_request_scroll_into_view(Badge<WebContentClient>, Gfx::IntRect const&) override;
     virtual void notify_server_did_enter_tooltip_area(Badge<WebContentClient>, Gfx::IntPoint, DeprecatedString const&) override;
     virtual void notify_server_did_leave_tooltip_area(Badge<WebContentClient>) override;
-    virtual void notify_server_did_request_file(Badge<WebContentClient>, DeprecatedString const& path, i32) override;
     virtual void notify_server_did_finish_handling_input_event(bool event_was_accepted) override;
 
     virtual Gfx::IntRect viewport_rect() const override;

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.h
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.h
@@ -83,8 +83,6 @@ private:
     virtual void create_client(EnableCallgrindProfiling = EnableCallgrindProfiling::No) override;
     virtual void update_zoom() override;
     virtual void notify_server_did_layout(Badge<WebContentClient>, Gfx::IntSize content_size) override;
-    virtual void notify_server_did_invalidate_content_rect(Badge<WebContentClient>, Gfx::IntRect const&) override;
-    virtual void notify_server_did_change_selection(Badge<WebContentClient>) override;
     virtual void notify_server_did_request_cursor_change(Badge<WebContentClient>, Gfx::StandardCursor cursor) override;
     virtual void notify_server_did_request_scroll(Badge<WebContentClient>, i32, i32) override;
     virtual void notify_server_did_request_scroll_to(Badge<WebContentClient>, Gfx::IntPoint) override;

--- a/Userland/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Userland/Libraries/LibWebView/ViewImplementation.cpp
@@ -25,6 +25,15 @@ ViewImplementation::ViewImplementation()
         // happen to be visiting crashy websites a lot.
         this->m_crash_count = 0;
     }).release_value_but_fixme_should_propagate_errors();
+
+    on_request_file = [this](auto const& path, auto request_id) {
+        auto file = Core::File::open(path, Core::File::OpenMode::Read);
+
+        if (file.is_error())
+            client().async_handle_file_return(file.error().code(), {}, request_id);
+        else
+            client().async_handle_file_return(0, IPC::File(*file.value()), request_id);
+    };
 }
 
 WebContentClient& ViewImplementation::client()

--- a/Userland/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Userland/Libraries/LibWebView/ViewImplementation.cpp
@@ -152,6 +152,21 @@ void ViewImplementation::js_console_request_messages(i32 start_index)
     client().async_js_console_request_messages(start_index);
 }
 
+void ViewImplementation::alert_closed()
+{
+    client().async_alert_closed();
+}
+
+void ViewImplementation::confirm_closed(bool accepted)
+{
+    client().async_confirm_closed(accepted);
+}
+
+void ViewImplementation::prompt_closed(Optional<String> response)
+{
+    client().async_prompt_closed(move(response));
+}
+
 void ViewImplementation::toggle_media_play_state()
 {
     client().async_toggle_media_play_state();

--- a/Userland/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Userland/Libraries/LibWebView/ViewImplementation.cpp
@@ -70,6 +70,16 @@ void ViewImplementation::server_did_paint(Badge<WebContentClient>, i32 bitmap_id
     }
 }
 
+void ViewImplementation::server_did_invalidate_content_rect(Badge<WebContentClient>, Gfx::IntRect)
+{
+    request_repaint();
+}
+
+void ViewImplementation::server_did_change_selection(Badge<WebContentClient>)
+{
+    request_repaint();
+}
+
 void ViewImplementation::load(AK::URL const& url)
 {
     m_url = url;

--- a/Userland/Libraries/LibWebView/ViewImplementation.h
+++ b/Userland/Libraries/LibWebView/ViewImplementation.h
@@ -48,6 +48,8 @@ public:
     String const& handle() const { return m_client_state.client_handle; }
 
     void server_did_paint(Badge<WebContentClient>, i32 bitmap_id, Gfx::IntSize size);
+    void server_did_invalidate_content_rect(Badge<WebContentClient>, Gfx::IntRect rect);
+    void server_did_change_selection(Badge<WebContentClient>);
 
     void load(AK::URL const&);
     void load_html(StringView, AK::URL const&);
@@ -138,8 +140,6 @@ public:
     Function<Gfx::IntRect()> on_fullscreen_window;
 
     virtual void notify_server_did_layout(Badge<WebContentClient>, Gfx::IntSize content_size) = 0;
-    virtual void notify_server_did_invalidate_content_rect(Badge<WebContentClient>, Gfx::IntRect const&) = 0;
-    virtual void notify_server_did_change_selection(Badge<WebContentClient>) = 0;
     virtual void notify_server_did_request_cursor_change(Badge<WebContentClient>, Gfx::StandardCursor cursor) = 0;
     virtual void notify_server_did_request_scroll(Badge<WebContentClient>, i32, i32) = 0;
     virtual void notify_server_did_request_scroll_to(Badge<WebContentClient>, Gfx::IntPoint) = 0;

--- a/Userland/Libraries/LibWebView/ViewImplementation.h
+++ b/Userland/Libraries/LibWebView/ViewImplementation.h
@@ -75,6 +75,10 @@ public:
     void js_console_input(DeprecatedString const& js_source);
     void js_console_request_messages(i32 start_index);
 
+    void alert_closed();
+    void confirm_closed(bool accepted);
+    void prompt_closed(Optional<String> response);
+
     void toggle_media_play_state();
     void toggle_media_mute_state();
     void toggle_media_loop_state();
@@ -104,6 +108,12 @@ public:
     Function<void()> on_navigate_forward;
     Function<void()> on_refresh;
     Function<void(Gfx::Bitmap const&)> on_favicon_change;
+    Function<void(String const& message)> on_request_alert;
+    Function<void(String const& message)> on_request_confirm;
+    Function<void(String const& message, String const& default_)> on_request_prompt;
+    Function<void(String const& message)> on_request_set_prompt_text;
+    Function<void()> on_request_accept_dialog;
+    Function<void()> on_request_dismiss_dialog;
     Function<void(const AK::URL&, DeprecatedString const&)> on_get_source;
     Function<void(DeprecatedString const&)> on_get_dom_tree;
     Function<void(i32 node_id, DeprecatedString const& computed_style, DeprecatedString const& resolved_style, DeprecatedString const& custom_properties, DeprecatedString const& node_box_sizing, DeprecatedString const& aria_properties_state)> on_get_dom_node_properties;
@@ -133,12 +143,6 @@ public:
     virtual void notify_server_did_request_scroll_into_view(Badge<WebContentClient>, Gfx::IntRect const&) = 0;
     virtual void notify_server_did_enter_tooltip_area(Badge<WebContentClient>, Gfx::IntPoint, DeprecatedString const&) = 0;
     virtual void notify_server_did_leave_tooltip_area(Badge<WebContentClient>) = 0;
-    virtual void notify_server_did_request_alert(Badge<WebContentClient>, String const& message) = 0;
-    virtual void notify_server_did_request_confirm(Badge<WebContentClient>, String const& message) = 0;
-    virtual void notify_server_did_request_prompt(Badge<WebContentClient>, String const& message, String const& default_) = 0;
-    virtual void notify_server_did_request_set_prompt_text(Badge<WebContentClient>, String const& message) = 0;
-    virtual void notify_server_did_request_accept_dialog(Badge<WebContentClient>) = 0;
-    virtual void notify_server_did_request_dismiss_dialog(Badge<WebContentClient>) = 0;
     virtual void notify_server_did_request_file(Badge<WebContentClient>, DeprecatedString const& path, i32) = 0;
     virtual void notify_server_did_finish_handling_input_event(bool event_was_accepted) = 0;
 

--- a/Userland/Libraries/LibWebView/ViewImplementation.h
+++ b/Userland/Libraries/LibWebView/ViewImplementation.h
@@ -104,6 +104,7 @@ public:
     Function<void(DeprecatedString const&)> on_title_change;
     Function<void(const AK::URL&, bool)> on_load_start;
     Function<void(const AK::URL&)> on_load_finish;
+    Function<void(DeprecatedString const& path, i32)> on_request_file;
     Function<void()> on_navigate_back;
     Function<void()> on_navigate_forward;
     Function<void()> on_refresh;
@@ -143,7 +144,6 @@ public:
     virtual void notify_server_did_request_scroll_into_view(Badge<WebContentClient>, Gfx::IntRect const&) = 0;
     virtual void notify_server_did_enter_tooltip_area(Badge<WebContentClient>, Gfx::IntPoint, DeprecatedString const&) = 0;
     virtual void notify_server_did_leave_tooltip_area(Badge<WebContentClient>) = 0;
-    virtual void notify_server_did_request_file(Badge<WebContentClient>, DeprecatedString const& path, i32) = 0;
     virtual void notify_server_did_finish_handling_input_event(bool event_was_accepted) = 0;
 
     virtual Gfx::IntRect viewport_rect() const = 0;

--- a/Userland/Libraries/LibWebView/ViewImplementation.h
+++ b/Userland/Libraries/LibWebView/ViewImplementation.h
@@ -47,6 +47,8 @@ public:
 
     String const& handle() const { return m_client_state.client_handle; }
 
+    void server_did_paint(Badge<WebContentClient>, i32 bitmap_id, Gfx::IntSize size);
+
     void load(AK::URL const&);
     void load_html(StringView, AK::URL const&);
     void load_empty_document();
@@ -90,6 +92,7 @@ public:
     };
     ErrorOr<void> take_screenshot(ScreenshotType);
 
+    Function<void()> on_ready_to_paint;
     Function<String(Web::HTML::ActivateTab)> on_new_tab;
     Function<void()> on_activate_tab;
     Function<void()> on_close;
@@ -135,7 +138,6 @@ public:
     Function<Gfx::IntRect()> on_fullscreen_window;
 
     virtual void notify_server_did_layout(Badge<WebContentClient>, Gfx::IntSize content_size) = 0;
-    virtual void notify_server_did_paint(Badge<WebContentClient>, i32 bitmap_id, Gfx::IntSize) = 0;
     virtual void notify_server_did_invalidate_content_rect(Badge<WebContentClient>, Gfx::IntRect const&) = 0;
     virtual void notify_server_did_change_selection(Badge<WebContentClient>) = 0;
     virtual void notify_server_did_request_cursor_change(Badge<WebContentClient>, Gfx::StandardCursor cursor) = 0;

--- a/Userland/Libraries/LibWebView/WebContentClient.cpp
+++ b/Userland/Libraries/LibWebView/WebContentClient.cpp
@@ -67,13 +67,13 @@ void WebContentClient::did_invalidate_content_rect(Gfx::IntRect const& content_r
     dbgln_if(SPAM_DEBUG, "handle: WebContentClient::DidInvalidateContentRect! content_rect={}", content_rect);
 
     // FIXME: Figure out a way to coalesce these messages to reduce unnecessary painting
-    m_view.notify_server_did_invalidate_content_rect({}, content_rect);
+    m_view.server_did_invalidate_content_rect({}, content_rect);
 }
 
 void WebContentClient::did_change_selection()
 {
     dbgln_if(SPAM_DEBUG, "handle: WebContentClient::DidChangeSelection!");
-    m_view.notify_server_did_change_selection({});
+    m_view.server_did_change_selection({});
 }
 
 void WebContentClient::did_request_cursor_change(i32 cursor_type)

--- a/Userland/Libraries/LibWebView/WebContentClient.cpp
+++ b/Userland/Libraries/LibWebView/WebContentClient.cpp
@@ -220,32 +220,38 @@ void WebContentClient::did_get_js_console_messages(i32 start_index, Vector<Depre
 
 void WebContentClient::did_request_alert(String const& message)
 {
-    m_view.notify_server_did_request_alert({}, message);
+    if (m_view.on_request_alert)
+        m_view.on_request_alert(message);
 }
 
 void WebContentClient::did_request_confirm(String const& message)
 {
-    m_view.notify_server_did_request_confirm({}, message);
+    if (m_view.on_request_confirm)
+        m_view.on_request_confirm(message);
 }
 
 void WebContentClient::did_request_prompt(String const& message, String const& default_)
 {
-    m_view.notify_server_did_request_prompt({}, message, default_);
+    if (m_view.on_request_prompt)
+        m_view.on_request_prompt(message, default_);
 }
 
 void WebContentClient::did_request_set_prompt_text(String const& message)
 {
-    m_view.notify_server_did_request_set_prompt_text({}, message);
+    if (m_view.on_request_set_prompt_text)
+        m_view.on_request_set_prompt_text(message);
 }
 
 void WebContentClient::did_request_accept_dialog()
 {
-    m_view.notify_server_did_request_accept_dialog({});
+    if (m_view.on_request_accept_dialog)
+        m_view.on_request_accept_dialog();
 }
 
 void WebContentClient::did_request_dismiss_dialog()
 {
-    m_view.notify_server_did_request_dismiss_dialog({});
+    if (m_view.on_request_dismiss_dialog)
+        m_view.on_request_dismiss_dialog();
 }
 
 void WebContentClient::did_change_favicon(Gfx::ShareableBitmap const& favicon)

--- a/Userland/Libraries/LibWebView/WebContentClient.cpp
+++ b/Userland/Libraries/LibWebView/WebContentClient.cpp
@@ -366,7 +366,8 @@ Messages::WebContentClient::DidRequestFullscreenWindowResponse WebContentClient:
 
 void WebContentClient::did_request_file(DeprecatedString const& path, i32 request_id)
 {
-    m_view.notify_server_did_request_file({}, path, request_id);
+    if (m_view.on_request_file)
+        m_view.on_request_file(path, request_id);
 }
 
 void WebContentClient::did_finish_handling_input_event(bool event_was_accepted)

--- a/Userland/Libraries/LibWebView/WebContentClient.cpp
+++ b/Userland/Libraries/LibWebView/WebContentClient.cpp
@@ -5,7 +5,7 @@
  */
 
 #include "WebContentClient.h"
-#include "OutOfProcessWebView.h"
+#include "ViewImplementation.h"
 #include <AK/Debug.h>
 #include <LibWeb/Cookie/ParsedCookie.h>
 

--- a/Userland/Libraries/LibWebView/WebContentClient.cpp
+++ b/Userland/Libraries/LibWebView/WebContentClient.cpp
@@ -25,7 +25,7 @@ void WebContentClient::die()
 
 void WebContentClient::did_paint(Gfx::IntRect const& rect, i32 bitmap_id)
 {
-    m_view.notify_server_did_paint({}, bitmap_id, rect.size());
+    m_view.server_did_paint({}, bitmap_id, rect.size());
 }
 
 void WebContentClient::did_start_loading(AK::URL const& url, bool is_redirect)

--- a/Userland/Utilities/headless-browser.cpp
+++ b/Userland/Utilities/headless-browser.cpp
@@ -112,12 +112,6 @@ private:
     void notify_server_did_request_scroll_into_view(Badge<WebView::WebContentClient>, Gfx::IntRect const&) override { }
     void notify_server_did_enter_tooltip_area(Badge<WebView::WebContentClient>, Gfx::IntPoint, DeprecatedString const&) override { }
     void notify_server_did_leave_tooltip_area(Badge<WebView::WebContentClient>) override { }
-    void notify_server_did_request_alert(Badge<WebView::WebContentClient>, String const&) override { }
-    void notify_server_did_request_confirm(Badge<WebView::WebContentClient>, String const&) override { }
-    void notify_server_did_request_prompt(Badge<WebView::WebContentClient>, String const&, String const&) override { }
-    void notify_server_did_request_set_prompt_text(Badge<WebView::WebContentClient>, String const&) override { }
-    void notify_server_did_request_accept_dialog(Badge<WebView::WebContentClient>) override { }
-    void notify_server_did_request_dismiss_dialog(Badge<WebView::WebContentClient>) override { }
 
     void notify_server_did_request_file(Badge<WebView::WebContentClient>, DeprecatedString const& path, i32 request_id) override
     {

--- a/Userland/Utilities/headless-browser.cpp
+++ b/Userland/Utilities/headless-browser.cpp
@@ -112,17 +112,6 @@ private:
     void notify_server_did_request_scroll_into_view(Badge<WebView::WebContentClient>, Gfx::IntRect const&) override { }
     void notify_server_did_enter_tooltip_area(Badge<WebView::WebContentClient>, Gfx::IntPoint, DeprecatedString const&) override { }
     void notify_server_did_leave_tooltip_area(Badge<WebView::WebContentClient>) override { }
-
-    void notify_server_did_request_file(Badge<WebView::WebContentClient>, DeprecatedString const& path, i32 request_id) override
-    {
-        auto file = Core::File::open(path, Core::File::OpenMode::Read);
-
-        if (file.is_error())
-            client().async_handle_file_return(file.error().code(), {}, request_id);
-        else
-            client().async_handle_file_return(0, IPC::File(*file.value()), request_id);
-    }
-
     void notify_server_did_finish_handling_input_event(bool) override { }
     void update_zoom() override { }
     void create_client(WebView::EnableCallgrindProfiling) override { }

--- a/Userland/Utilities/headless-browser.cpp
+++ b/Userland/Utilities/headless-browser.cpp
@@ -103,8 +103,6 @@ private:
     HeadlessWebContentView() = default;
 
     void notify_server_did_layout(Badge<WebView::WebContentClient>, Gfx::IntSize) override { }
-    void notify_server_did_invalidate_content_rect(Badge<WebView::WebContentClient>, Gfx::IntRect const&) override { }
-    void notify_server_did_change_selection(Badge<WebView::WebContentClient>) override { }
     void notify_server_did_request_cursor_change(Badge<WebView::WebContentClient>, Gfx::StandardCursor) override { }
     void notify_server_did_request_scroll(Badge<WebView::WebContentClient>, i32, i32) override { }
     void notify_server_did_request_scroll_to(Badge<WebView::WebContentClient>, Gfx::IntPoint) override { }

--- a/Userland/Utilities/headless-browser.cpp
+++ b/Userland/Utilities/headless-browser.cpp
@@ -103,7 +103,6 @@ private:
     HeadlessWebContentView() = default;
 
     void notify_server_did_layout(Badge<WebView::WebContentClient>, Gfx::IntSize) override { }
-    void notify_server_did_paint(Badge<WebView::WebContentClient>, i32, Gfx::IntSize) override { }
     void notify_server_did_invalidate_content_rect(Badge<WebView::WebContentClient>, Gfx::IntRect const&) override { }
     void notify_server_did_change_selection(Badge<WebView::WebContentClient>) override { }
     void notify_server_did_request_cursor_change(Badge<WebView::WebContentClient>, Gfx::StandardCursor) override { }


### PR DESCRIPTION
This continues the work started by #18893, with the goal of reducing the amount of copy-paste duplication across every `ViewImplementation`. The savings here aren't *as* huge as that PR, but the duplication did stick out to me nonetheless while bringing up the AppKit chrome.