### PR TITLE
Ladybird+LibWebView: Migrate remaining notifications to LibWebView callbacks

### DIFF
--- a/Ladybird/AppKit/UI/LadybirdWebView.mm
+++ b/Ladybird/AppKit/UI/LadybirdWebView.mm
@@ -224,7 +224,7 @@ struct HideCursor {
         [[self tab] onFaviconChange:favicon];
     };
 
-    m_web_view_bridge->on_scroll = [self](auto position) {
+    m_web_view_bridge->on_scroll_to_point = [self](auto position) {
         [self scrollToPoint:Ladybird::gfx_point_to_ns_point(position)];
         [[self scrollView] reflectScrolledClipView:self];
         [self updateViewportRect:Ladybird::WebViewBridge::ForResize::No];

--- a/Ladybird/AppKit/UI/LadybirdWebView.mm
+++ b/Ladybird/AppKit/UI/LadybirdWebView.mm
@@ -323,11 +323,11 @@ struct HideCursor {
         [[self tabController] reload:nil];
     };
 
-    m_web_view_bridge->on_tooltip_entered = [self](auto const& tooltip) {
+    m_web_view_bridge->on_enter_tooltip_area = [self](auto, auto const& tooltip) {
         self.toolTip = Ladybird::string_to_ns_string(tooltip);
     };
 
-    m_web_view_bridge->on_tooltip_left = [self]() {
+    m_web_view_bridge->on_leave_tooltip_area = [self]() {
         self.toolTip = nil;
     };
 

--- a/Ladybird/AppKit/UI/LadybirdWebView.mm
+++ b/Ladybird/AppKit/UI/LadybirdWebView.mm
@@ -164,9 +164,9 @@ struct HideCursor {
 
 - (void)setWebViewCallbacks
 {
-    m_web_view_bridge->on_layout = [self](auto content_size) {
-        auto ns_content_size = Ladybird::gfx_size_to_ns_size(content_size);
-        [[self documentView] setFrameSize:ns_content_size];
+    m_web_view_bridge->on_did_layout = [self](auto content_size) {
+        auto inverse_device_pixel_ratio = m_web_view_bridge->inverse_device_pixel_ratio();
+        [[self documentView] setFrameSize:NSMakeSize(content_size.width() * inverse_device_pixel_ratio, content_size.height() * inverse_device_pixel_ratio)];
     };
 
     m_web_view_bridge->on_ready_to_paint = [self]() {

--- a/Ladybird/AppKit/UI/LadybirdWebViewBridge.cpp
+++ b/Ladybird/AppKit/UI/LadybirdWebViewBridge.cpp
@@ -104,14 +104,6 @@ Optional<WebViewBridge::Paintable> WebViewBridge::paintable()
     return Paintable { *bitmap, bitmap_size };
 }
 
-void WebViewBridge::notify_server_did_layout(Badge<WebView::WebContentClient>, Gfx::IntSize content_size)
-{
-    if (on_layout) {
-        content_size = scale_for_device(content_size, m_inverse_device_pixel_ratio);
-        on_layout(content_size);
-    }
-}
-
 void WebViewBridge::notify_server_did_request_cursor_change(Badge<WebView::WebContentClient>, Gfx::StandardCursor cursor)
 {
     if (on_cursor_change)

--- a/Ladybird/AppKit/UI/LadybirdWebViewBridge.cpp
+++ b/Ladybird/AppKit/UI/LadybirdWebViewBridge.cpp
@@ -133,10 +133,6 @@ Optional<WebViewBridge::Paintable> WebViewBridge::paintable()
     return Paintable { *bitmap, bitmap_size };
 }
 
-void WebViewBridge::notify_server_did_finish_handling_input_event(bool)
-{
-}
-
 void WebViewBridge::update_zoom()
 {
 }

--- a/Ladybird/AppKit/UI/LadybirdWebViewBridge.cpp
+++ b/Ladybird/AppKit/UI/LadybirdWebViewBridge.cpp
@@ -133,18 +133,6 @@ Optional<WebViewBridge::Paintable> WebViewBridge::paintable()
     return Paintable { *bitmap, bitmap_size };
 }
 
-void WebViewBridge::notify_server_did_enter_tooltip_area(Badge<WebView::WebContentClient>, Gfx::IntPoint, DeprecatedString const& tooltip)
-{
-    if (on_tooltip_entered)
-        on_tooltip_entered(tooltip);
-}
-
-void WebViewBridge::notify_server_did_leave_tooltip_area(Badge<WebView::WebContentClient>)
-{
-    if (on_tooltip_left)
-        on_tooltip_left();
-}
-
 void WebViewBridge::notify_server_did_finish_handling_input_event(bool)
 {
 }

--- a/Ladybird/AppKit/UI/LadybirdWebViewBridge.cpp
+++ b/Ladybird/AppKit/UI/LadybirdWebViewBridge.cpp
@@ -104,12 +104,6 @@ Optional<WebViewBridge::Paintable> WebViewBridge::paintable()
     return Paintable { *bitmap, bitmap_size };
 }
 
-void WebViewBridge::notify_server_did_request_cursor_change(Badge<WebView::WebContentClient>, Gfx::StandardCursor cursor)
-{
-    if (on_cursor_change)
-        on_cursor_change(cursor);
-}
-
 void WebViewBridge::notify_server_did_request_scroll(Badge<WebView::WebContentClient>, i32 x_delta, i32 y_delta)
 {
     // FIXME: This currently isn't reached because we do not yet propagate mouse wheel events to WebContent.

--- a/Ladybird/AppKit/UI/LadybirdWebViewBridge.h
+++ b/Ladybird/AppKit/UI/LadybirdWebViewBridge.h
@@ -52,8 +52,6 @@ public:
 private:
     WebViewBridge(Vector<Gfx::IntRect> screen_rects, float device_pixel_ratio, Optional<StringView> webdriver_content_ipc_path);
 
-    virtual void notify_server_did_finish_handling_input_event(bool event_was_accepted) override;
-
     virtual void update_zoom() override;
     virtual Gfx::IntRect viewport_rect() const override;
     virtual Gfx::IntPoint to_content_position(Gfx::IntPoint widget_position) const override;

--- a/Ladybird/AppKit/UI/LadybirdWebViewBridge.h
+++ b/Ladybird/AppKit/UI/LadybirdWebViewBridge.h
@@ -49,17 +49,12 @@ public:
     };
     Optional<Paintable> paintable();
 
-    Function<void(Gfx::IntPoint)> on_scroll;
-
     Function<void(DeprecatedString const&)> on_tooltip_entered;
     Function<void()> on_tooltip_left;
 
 private:
     WebViewBridge(Vector<Gfx::IntRect> screen_rects, float device_pixel_ratio, Optional<StringView> webdriver_content_ipc_path);
 
-    virtual void notify_server_did_request_scroll(Badge<WebView::WebContentClient>, i32, i32) override;
-    virtual void notify_server_did_request_scroll_to(Badge<WebView::WebContentClient>, Gfx::IntPoint) override;
-    virtual void notify_server_did_request_scroll_into_view(Badge<WebView::WebContentClient>, Gfx::IntRect const&) override;
     virtual void notify_server_did_enter_tooltip_area(Badge<WebView::WebContentClient>, Gfx::IntPoint, DeprecatedString const&) override;
     virtual void notify_server_did_leave_tooltip_area(Badge<WebView::WebContentClient>) override;
     virtual void notify_server_did_finish_handling_input_event(bool event_was_accepted) override;

--- a/Ladybird/AppKit/UI/LadybirdWebViewBridge.h
+++ b/Ladybird/AppKit/UI/LadybirdWebViewBridge.h
@@ -51,15 +51,12 @@ public:
 
     Function<void(Gfx::IntPoint)> on_scroll;
 
-    Function<void(Gfx::StandardCursor)> on_cursor_change;
-
     Function<void(DeprecatedString const&)> on_tooltip_entered;
     Function<void()> on_tooltip_left;
 
 private:
     WebViewBridge(Vector<Gfx::IntRect> screen_rects, float device_pixel_ratio, Optional<StringView> webdriver_content_ipc_path);
 
-    virtual void notify_server_did_request_cursor_change(Badge<WebView::WebContentClient>, Gfx::StandardCursor cursor) override;
     virtual void notify_server_did_request_scroll(Badge<WebView::WebContentClient>, i32, i32) override;
     virtual void notify_server_did_request_scroll_to(Badge<WebView::WebContentClient>, Gfx::IntPoint) override;
     virtual void notify_server_did_request_scroll_into_view(Badge<WebView::WebContentClient>, Gfx::IntRect const&) override;

--- a/Ladybird/AppKit/UI/LadybirdWebViewBridge.h
+++ b/Ladybird/AppKit/UI/LadybirdWebViewBridge.h
@@ -49,8 +49,6 @@ public:
     };
     Optional<Paintable> paintable();
 
-    Function<void(Gfx::IntSize)> on_layout;
-
     Function<void(Gfx::IntPoint)> on_scroll;
 
     Function<void(Gfx::StandardCursor)> on_cursor_change;
@@ -61,7 +59,6 @@ public:
 private:
     WebViewBridge(Vector<Gfx::IntRect> screen_rects, float device_pixel_ratio, Optional<StringView> webdriver_content_ipc_path);
 
-    virtual void notify_server_did_layout(Badge<WebView::WebContentClient>, Gfx::IntSize content_size) override;
     virtual void notify_server_did_request_cursor_change(Badge<WebView::WebContentClient>, Gfx::StandardCursor cursor) override;
     virtual void notify_server_did_request_scroll(Badge<WebView::WebContentClient>, i32, i32) override;
     virtual void notify_server_did_request_scroll_to(Badge<WebView::WebContentClient>, Gfx::IntPoint) override;

--- a/Ladybird/AppKit/UI/LadybirdWebViewBridge.h
+++ b/Ladybird/AppKit/UI/LadybirdWebViewBridge.h
@@ -49,14 +49,9 @@ public:
     };
     Optional<Paintable> paintable();
 
-    Function<void(DeprecatedString const&)> on_tooltip_entered;
-    Function<void()> on_tooltip_left;
-
 private:
     WebViewBridge(Vector<Gfx::IntRect> screen_rects, float device_pixel_ratio, Optional<StringView> webdriver_content_ipc_path);
 
-    virtual void notify_server_did_enter_tooltip_area(Badge<WebView::WebContentClient>, Gfx::IntPoint, DeprecatedString const&) override;
-    virtual void notify_server_did_leave_tooltip_area(Badge<WebView::WebContentClient>) override;
     virtual void notify_server_did_finish_handling_input_event(bool event_was_accepted) override;
 
     virtual void update_zoom() override;

--- a/Ladybird/Qt/Tab.cpp
+++ b/Ladybird/Qt/Tab.cpp
@@ -215,7 +215,7 @@ Tab::Tab(BrowserWindow* window, StringView webdriver_content_ipc_path, WebView::
 
     QObject::connect(focus_location_editor_action, &QAction::triggered, this, &Tab::focus_location_editor);
 
-    view().on_get_source = [this](auto const& url, auto const& source) {
+    view().on_received_source = [this](auto const& url, auto const& source) {
         auto* text_edit = new QPlainTextEdit(this);
         text_edit->setWindowFlags(Qt::Window);
         text_edit->setFont(QFontDatabase::systemFont(QFontDatabase::SystemFont::FixedFont));
@@ -266,22 +266,22 @@ Tab::Tab(BrowserWindow* window, StringView webdriver_content_ipc_path, WebView::
         return Gfx::IntRect { m_window->x(), m_window->y(), m_window->width(), m_window->height() };
     };
 
-    view().on_get_dom_tree = [this](auto& dom_tree) {
+    view().on_received_dom_tree = [this](auto& dom_tree) {
         if (m_inspector_widget)
             m_inspector_widget->set_dom_json(dom_tree);
     };
 
-    view().on_get_accessibility_tree = [this](auto& accessibility_tree) {
+    view().on_received_accessibility_tree = [this](auto& accessibility_tree) {
         if (m_inspector_widget)
             m_inspector_widget->set_accessibility_json(accessibility_tree);
     };
 
-    view().on_js_console_new_message = [this](auto message_index) {
+    view().on_received_console_message = [this](auto message_index) {
         if (m_console_widget)
             m_console_widget->notify_about_new_console_message(message_index);
     };
 
-    view().on_get_js_console_messages = [this](auto start_index, auto& message_types, auto& messages) {
+    view().on_received_console_messages = [this](auto start_index, auto& message_types, auto& messages) {
         if (m_console_widget)
             m_console_widget->handle_console_messages(start_index, message_types, messages);
     };

--- a/Ladybird/Qt/WebContentView.cpp
+++ b/Ladybird/Qt/WebContentView.cpp
@@ -76,6 +76,15 @@ WebContentView::WebContentView(StringView webdriver_content_ipc_path, WebView::E
 
     create_client(enable_callgrind_profiling);
 
+    on_did_layout = [this](auto content_size) {
+        verticalScrollBar()->setMinimum(0);
+        verticalScrollBar()->setMaximum(content_size.height() - m_viewport_rect.height());
+        verticalScrollBar()->setPageStep(m_viewport_rect.height());
+        horizontalScrollBar()->setMinimum(0);
+        horizontalScrollBar()->setMaximum(content_size.width() - m_viewport_rect.width());
+        horizontalScrollBar()->setPageStep(m_viewport_rect.width());
+    };
+
     on_ready_to_paint = [this]() {
         viewport()->update();
     };
@@ -652,16 +661,6 @@ void WebContentView::notify_server_did_request_cursor_change(Badge<WebContentCli
         setCursor(Qt::ArrowCursor);
         break;
     }
-}
-
-void WebContentView::notify_server_did_layout(Badge<WebContentClient>, Gfx::IntSize content_size)
-{
-    verticalScrollBar()->setMinimum(0);
-    verticalScrollBar()->setMaximum(content_size.height() - m_viewport_rect.height());
-    verticalScrollBar()->setPageStep(m_viewport_rect.height());
-    horizontalScrollBar()->setMinimum(0);
-    horizontalScrollBar()->setMaximum(content_size.width() - m_viewport_rect.width());
-    horizontalScrollBar()->setPageStep(m_viewport_rect.width());
 }
 
 void WebContentView::notify_server_did_request_scroll(Badge<WebContentClient>, i32 x_delta, i32 y_delta)

--- a/Ladybird/Qt/WebContentView.cpp
+++ b/Ladybird/Qt/WebContentView.cpp
@@ -88,6 +88,10 @@ WebContentView::WebContentView(StringView webdriver_content_ipc_path, WebView::E
     on_ready_to_paint = [this]() {
         viewport()->update();
     };
+
+    on_cursor_change = [this](auto cursor) {
+        update_cursor(cursor);
+    };
 }
 
 WebContentView::~WebContentView() = default;
@@ -600,7 +604,7 @@ void WebContentView::create_client(WebView::EnableCallgrindProfiling enable_call
         client().async_connect_to_webdriver(m_webdriver_content_ipc_path);
 }
 
-void WebContentView::notify_server_did_request_cursor_change(Badge<WebContentClient>, Gfx::StandardCursor cursor)
+void WebContentView::update_cursor(Gfx::StandardCursor cursor)
 {
     switch (cursor) {
     case Gfx::StandardCursor::Hidden:

--- a/Ladybird/Qt/WebContentView.cpp
+++ b/Ladybird/Qt/WebContentView.cpp
@@ -112,6 +112,17 @@ WebContentView::WebContentView(StringView webdriver_content_ipc_path, WebView::E
     on_cursor_change = [this](auto cursor) {
         update_cursor(cursor);
     };
+
+    on_enter_tooltip_area = [this](auto position, auto tooltip) {
+        QToolTip::showText(
+            mapToGlobal(QPoint(position.x(), position.y())),
+            qstring_from_ak_deprecated_string(tooltip),
+            this);
+    };
+
+    on_leave_tooltip_area = []() {
+        QToolTip::hideText();
+    };
 }
 
 WebContentView::~WebContentView() = default;
@@ -685,20 +696,6 @@ void WebContentView::update_cursor(Gfx::StandardCursor cursor)
         setCursor(Qt::ArrowCursor);
         break;
     }
-}
-
-void WebContentView::notify_server_did_enter_tooltip_area(Badge<WebContentClient>, Gfx::IntPoint content_position, DeprecatedString const& tooltip)
-{
-    auto widget_position = to_widget_position(content_position);
-    QToolTip::showText(
-        mapToGlobal(QPoint(widget_position.x(), widget_position.y())),
-        qstring_from_ak_deprecated_string(tooltip),
-        this);
-}
-
-void WebContentView::notify_server_did_leave_tooltip_area(Badge<WebContentClient>)
-{
-    QToolTip::hideText();
 }
 
 Gfx::IntRect WebContentView::viewport_rect() const

--- a/Ladybird/Qt/WebContentView.cpp
+++ b/Ladybird/Qt/WebContentView.cpp
@@ -89,6 +89,26 @@ WebContentView::WebContentView(StringView webdriver_content_ipc_path, WebView::E
         viewport()->update();
     };
 
+    on_scroll_by_delta = [this](auto x_delta, auto y_delta) {
+        horizontalScrollBar()->setValue(max(0, horizontalScrollBar()->value() + x_delta));
+        verticalScrollBar()->setValue(max(0, verticalScrollBar()->value() + y_delta));
+    };
+
+    on_scroll_to_point = [this](auto position) {
+        horizontalScrollBar()->setValue(position.x());
+        verticalScrollBar()->setValue(position.y());
+    };
+
+    on_scroll_into_view = [this](auto rect) {
+        if (m_viewport_rect.contains(rect))
+            return;
+
+        if (rect.top() < m_viewport_rect.top())
+            verticalScrollBar()->setValue(rect.top());
+        else if (rect.top() > m_viewport_rect.top() && rect.bottom() > m_viewport_rect.bottom())
+            verticalScrollBar()->setValue(rect.bottom() - m_viewport_rect.height());
+    };
+
     on_cursor_change = [this](auto cursor) {
         update_cursor(cursor);
     };
@@ -665,29 +685,6 @@ void WebContentView::update_cursor(Gfx::StandardCursor cursor)
         setCursor(Qt::ArrowCursor);
         break;
     }
-}
-
-void WebContentView::notify_server_did_request_scroll(Badge<WebContentClient>, i32 x_delta, i32 y_delta)
-{
-    horizontalScrollBar()->setValue(max(0, horizontalScrollBar()->value() + x_delta));
-    verticalScrollBar()->setValue(max(0, verticalScrollBar()->value() + y_delta));
-}
-
-void WebContentView::notify_server_did_request_scroll_to(Badge<WebContentClient>, Gfx::IntPoint scroll_position)
-{
-    horizontalScrollBar()->setValue(scroll_position.x());
-    verticalScrollBar()->setValue(scroll_position.y());
-}
-
-void WebContentView::notify_server_did_request_scroll_into_view(Badge<WebContentClient>, Gfx::IntRect const& rect)
-{
-    if (m_viewport_rect.contains(rect))
-        return;
-
-    if (rect.top() < m_viewport_rect.top())
-        verticalScrollBar()->setValue(rect.top());
-    else if (rect.top() > m_viewport_rect.top() && rect.bottom() > m_viewport_rect.bottom())
-        verticalScrollBar()->setValue(rect.bottom() - m_viewport_rect.height());
 }
 
 void WebContentView::notify_server_did_enter_tooltip_area(Badge<WebContentClient>, Gfx::IntPoint content_position, DeprecatedString const& tooltip)

--- a/Ladybird/Qt/WebContentView.cpp
+++ b/Ladybird/Qt/WebContentView.cpp
@@ -736,13 +736,6 @@ bool WebContentView::event(QEvent* event)
     return QAbstractScrollArea::event(event);
 }
 
-void WebContentView::notify_server_did_finish_handling_input_event(bool event_was_accepted)
-{
-    // FIXME: Currently Ladybird handles the keyboard shortcuts before passing the event to web content, so
-    //        we don't need to do anything here. But we'll need to once we start asking web content first.
-    (void)event_was_accepted;
-}
-
 ErrorOr<String> WebContentView::dump_layout_tree()
 {
     return String::from_deprecated_string(client().dump_layout_tree());

--- a/Ladybird/Qt/WebContentView.h
+++ b/Ladybird/Qt/WebContentView.h
@@ -76,8 +76,6 @@ public:
     };
     void update_palette(PaletteMode = PaletteMode::Default);
 
-    virtual void notify_server_did_finish_handling_input_event(bool event_was_accepted) override;
-
 signals:
     void urls_dropped(QList<QUrl> const&);
 

--- a/Ladybird/Qt/WebContentView.h
+++ b/Ladybird/Qt/WebContentView.h
@@ -76,8 +76,6 @@ public:
     };
     void update_palette(PaletteMode = PaletteMode::Default);
 
-    virtual void notify_server_did_enter_tooltip_area(Badge<WebContentClient>, Gfx::IntPoint, DeprecatedString const&) override;
-    virtual void notify_server_did_leave_tooltip_area(Badge<WebContentClient>) override;
     virtual void notify_server_did_finish_handling_input_event(bool event_was_accepted) override;
 
 signals:

--- a/Ladybird/Qt/WebContentView.h
+++ b/Ladybird/Qt/WebContentView.h
@@ -76,9 +76,6 @@ public:
     };
     void update_palette(PaletteMode = PaletteMode::Default);
 
-    virtual void notify_server_did_request_scroll(Badge<WebContentClient>, i32, i32) override;
-    virtual void notify_server_did_request_scroll_to(Badge<WebContentClient>, Gfx::IntPoint) override;
-    virtual void notify_server_did_request_scroll_into_view(Badge<WebContentClient>, Gfx::IntRect const&) override;
     virtual void notify_server_did_enter_tooltip_area(Badge<WebContentClient>, Gfx::IntPoint, DeprecatedString const&) override;
     virtual void notify_server_did_leave_tooltip_area(Badge<WebContentClient>) override;
     virtual void notify_server_did_finish_handling_input_event(bool event_was_accepted) override;

--- a/Ladybird/Qt/WebContentView.h
+++ b/Ladybird/Qt/WebContentView.h
@@ -76,7 +76,6 @@ public:
     };
     void update_palette(PaletteMode = PaletteMode::Default);
 
-    virtual void notify_server_did_request_cursor_change(Badge<WebContentClient>, Gfx::StandardCursor cursor) override;
     virtual void notify_server_did_request_scroll(Badge<WebContentClient>, i32, i32) override;
     virtual void notify_server_did_request_scroll_to(Badge<WebContentClient>, Gfx::IntPoint) override;
     virtual void notify_server_did_request_scroll_into_view(Badge<WebContentClient>, Gfx::IntRect const&) override;
@@ -96,6 +95,7 @@ private:
     virtual Gfx::IntPoint to_widget_position(Gfx::IntPoint content_position) const override;
 
     void update_viewport_rect();
+    void update_cursor(Gfx::StandardCursor cursor);
 
     qreal m_inverse_pixel_scaling_ratio { 1.0 };
     bool m_should_show_line_box_borders { false };

--- a/Ladybird/Qt/WebContentView.h
+++ b/Ladybird/Qt/WebContentView.h
@@ -76,7 +76,6 @@ public:
     };
     void update_palette(PaletteMode = PaletteMode::Default);
 
-    virtual void notify_server_did_layout(Badge<WebContentClient>, Gfx::IntSize content_size) override;
     virtual void notify_server_did_request_cursor_change(Badge<WebContentClient>, Gfx::StandardCursor cursor) override;
     virtual void notify_server_did_request_scroll(Badge<WebContentClient>, i32, i32) override;
     virtual void notify_server_did_request_scroll_to(Badge<WebContentClient>, Gfx::IntPoint) override;

--- a/Userland/Applications/Browser/Tab.cpp
+++ b/Userland/Applications/Browser/Tab.cpp
@@ -565,30 +565,30 @@ Tab::Tab(BrowserWindow& window)
             m_dialog->done(GUI::Dialog::ExecResult::Cancel);
     };
 
-    view().on_get_source = [this](auto& url, auto& source) {
+    view().on_received_source = [this](auto& url, auto& source) {
         view_source(url, source);
     };
 
-    view().on_get_dom_tree = [this](auto& dom_tree) {
+    view().on_received_dom_tree = [this](auto& dom_tree) {
         if (m_dom_inspector_widget)
             m_dom_inspector_widget->set_dom_json(dom_tree);
     };
 
-    view().on_get_dom_node_properties = [this](auto node_id, auto& specified, auto& computed, auto& custom_properties, auto& node_box_sizing, auto& aria_properties_state) {
+    view().on_received_dom_node_properties = [this](auto node_id, auto& specified, auto& computed, auto& custom_properties, auto& node_box_sizing, auto& aria_properties_state) {
         m_dom_inspector_widget->set_dom_node_properties_json({ node_id }, specified, computed, custom_properties, node_box_sizing, aria_properties_state);
     };
 
-    view().on_get_accessibility_tree = [this](auto& accessibility_tree) {
+    view().on_received_accessibility_tree = [this](auto& accessibility_tree) {
         if (m_dom_inspector_widget)
             m_dom_inspector_widget->set_accessibility_json(accessibility_tree);
     };
 
-    view().on_js_console_new_message = [this](auto message_index) {
+    view().on_received_console_message = [this](auto message_index) {
         if (m_console_widget)
             m_console_widget->notify_about_new_console_message(message_index);
     };
 
-    view().on_get_js_console_messages = [this](auto start_index, auto& message_types, auto& messages) {
+    view().on_received_console_messages = [this](auto start_index, auto& message_types, auto& messages) {
         if (m_console_widget)
             m_console_widget->handle_console_messages(start_index, message_types, messages);
     };

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
@@ -71,6 +71,10 @@ OutOfProcessWebView::OutOfProcessWebView()
     on_leave_tooltip_area = []() {
         GUI::Application::the()->hide_tooltip();
     };
+
+    on_finish_handling_input_event = [this](auto event_was_accepted) {
+        did_finish_handling_input_event(event_was_accepted);
+    };
 }
 
 OutOfProcessWebView::~OutOfProcessWebView() = default;
@@ -350,7 +354,7 @@ void OutOfProcessWebView::process_next_input_event()
         });
 }
 
-void OutOfProcessWebView::notify_server_did_finish_handling_input_event(bool event_was_accepted)
+void OutOfProcessWebView::did_finish_handling_input_event(bool event_was_accepted)
 {
     VERIFY(m_is_awaiting_response_for_input_event);
 

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
@@ -63,6 +63,14 @@ OutOfProcessWebView::OutOfProcessWebView()
     on_cursor_change = [this](auto cursor) {
         set_override_cursor(cursor);
     };
+
+    on_enter_tooltip_area = [](auto, auto tooltip) {
+        GUI::Application::the()->show_tooltip(tooltip, nullptr);
+    };
+
+    on_leave_tooltip_area = []() {
+        GUI::Application::the()->hide_tooltip();
+    };
 }
 
 OutOfProcessWebView::~OutOfProcessWebView() = default;
@@ -199,16 +207,6 @@ void OutOfProcessWebView::theme_change_event(GUI::ThemeChangeEvent& event)
 void OutOfProcessWebView::screen_rects_change_event(GUI::ScreenRectsChangeEvent& event)
 {
     client().async_update_screen_rects(event.rects(), event.main_screen_index());
-}
-
-void OutOfProcessWebView::notify_server_did_enter_tooltip_area(Badge<WebContentClient>, Gfx::IntPoint, DeprecatedString const& title)
-{
-    GUI::Application::the()->show_tooltip(title, nullptr);
-}
-
-void OutOfProcessWebView::notify_server_did_leave_tooltip_area(Badge<WebContentClient>)
-{
-    GUI::Application::the()->hide_tooltip();
 }
 
 void OutOfProcessWebView::did_scroll()

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
@@ -45,6 +45,10 @@ OutOfProcessWebView::OutOfProcessWebView()
         else
             client().async_handle_file_return(0, IPC::File(file.value().stream()), request_id);
     };
+
+    on_cursor_change = [this](auto cursor) {
+        set_override_cursor(cursor);
+    };
 }
 
 OutOfProcessWebView::~OutOfProcessWebView() = default;
@@ -181,11 +185,6 @@ void OutOfProcessWebView::theme_change_event(GUI::ThemeChangeEvent& event)
 void OutOfProcessWebView::screen_rects_change_event(GUI::ScreenRectsChangeEvent& event)
 {
     client().async_update_screen_rects(event.rects(), event.main_screen_index());
-}
-
-void OutOfProcessWebView::notify_server_did_request_cursor_change(Badge<WebContentClient>, Gfx::StandardCursor cursor)
-{
-    set_override_cursor(cursor);
 }
 
 void OutOfProcessWebView::notify_server_did_request_scroll(Badge<WebContentClient>, i32 x_delta, i32 y_delta)

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
@@ -46,6 +46,20 @@ OutOfProcessWebView::OutOfProcessWebView()
             client().async_handle_file_return(0, IPC::File(file.value().stream()), request_id);
     };
 
+    on_scroll_by_delta = [this](auto x_delta, auto y_delta) {
+        horizontal_scrollbar().increase_slider_by(x_delta);
+        vertical_scrollbar().increase_slider_by(y_delta);
+    };
+
+    on_scroll_to_point = [this](auto position) {
+        horizontal_scrollbar().set_value(position.x());
+        vertical_scrollbar().set_value(position.y());
+    };
+
+    on_scroll_into_view = [this](auto rect) {
+        scroll_into_view(rect, true, true);
+    };
+
     on_cursor_change = [this](auto cursor) {
         set_override_cursor(cursor);
     };
@@ -185,23 +199,6 @@ void OutOfProcessWebView::theme_change_event(GUI::ThemeChangeEvent& event)
 void OutOfProcessWebView::screen_rects_change_event(GUI::ScreenRectsChangeEvent& event)
 {
     client().async_update_screen_rects(event.rects(), event.main_screen_index());
-}
-
-void OutOfProcessWebView::notify_server_did_request_scroll(Badge<WebContentClient>, i32 x_delta, i32 y_delta)
-{
-    horizontal_scrollbar().increase_slider_by(x_delta);
-    vertical_scrollbar().increase_slider_by(y_delta);
-}
-
-void OutOfProcessWebView::notify_server_did_request_scroll_to(Badge<WebContentClient>, Gfx::IntPoint scroll_position)
-{
-    horizontal_scrollbar().set_value(scroll_position.x());
-    vertical_scrollbar().set_value(scroll_position.y());
-}
-
-void OutOfProcessWebView::notify_server_did_request_scroll_into_view(Badge<WebContentClient>, Gfx::IntRect const& rect)
-{
-    scroll_into_view(rect, true, true);
 }
 
 void OutOfProcessWebView::notify_server_did_enter_tooltip_area(Badge<WebContentClient>, Gfx::IntPoint, DeprecatedString const& title)

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
@@ -29,6 +29,10 @@ OutOfProcessWebView::OutOfProcessWebView()
 
     create_client();
 
+    on_did_layout = [this](auto content_size) {
+        set_content_size(content_size);
+    };
+
     on_ready_to_paint = [this]() {
         update();
     };
@@ -182,11 +186,6 @@ void OutOfProcessWebView::screen_rects_change_event(GUI::ScreenRectsChangeEvent&
 void OutOfProcessWebView::notify_server_did_request_cursor_change(Badge<WebContentClient>, Gfx::StandardCursor cursor)
 {
     set_override_cursor(cursor);
-}
-
-void OutOfProcessWebView::notify_server_did_layout(Badge<WebContentClient>, Gfx::IntSize content_size)
-{
-    set_content_size(content_size);
 }
 
 void OutOfProcessWebView::notify_server_did_request_scroll(Badge<WebContentClient>, i32 x_delta, i32 y_delta)

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.h
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.h
@@ -82,9 +82,6 @@ private:
     // ^WebView::ViewImplementation
     virtual void create_client(EnableCallgrindProfiling = EnableCallgrindProfiling::No) override;
     virtual void update_zoom() override;
-    virtual void notify_server_did_request_scroll(Badge<WebContentClient>, i32, i32) override;
-    virtual void notify_server_did_request_scroll_to(Badge<WebContentClient>, Gfx::IntPoint) override;
-    virtual void notify_server_did_request_scroll_into_view(Badge<WebContentClient>, Gfx::IntRect const&) override;
     virtual void notify_server_did_enter_tooltip_area(Badge<WebContentClient>, Gfx::IntPoint, DeprecatedString const&) override;
     virtual void notify_server_did_leave_tooltip_area(Badge<WebContentClient>) override;
     virtual void notify_server_did_finish_handling_input_event(bool event_was_accepted) override;

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.h
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.h
@@ -82,7 +82,6 @@ private:
     // ^WebView::ViewImplementation
     virtual void create_client(EnableCallgrindProfiling = EnableCallgrindProfiling::No) override;
     virtual void update_zoom() override;
-    virtual void notify_server_did_layout(Badge<WebContentClient>, Gfx::IntSize content_size) override;
     virtual void notify_server_did_request_cursor_change(Badge<WebContentClient>, Gfx::StandardCursor cursor) override;
     virtual void notify_server_did_request_scroll(Badge<WebContentClient>, i32, i32) override;
     virtual void notify_server_did_request_scroll_to(Badge<WebContentClient>, Gfx::IntPoint) override;

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.h
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.h
@@ -82,7 +82,6 @@ private:
     // ^WebView::ViewImplementation
     virtual void create_client(EnableCallgrindProfiling = EnableCallgrindProfiling::No) override;
     virtual void update_zoom() override;
-    virtual void notify_server_did_finish_handling_input_event(bool event_was_accepted) override;
 
     virtual Gfx::IntRect viewport_rect() const override;
     virtual Gfx::IntPoint to_content_position(Gfx::IntPoint widget_position) const override;
@@ -91,6 +90,7 @@ private:
     using InputEvent = Variant<GUI::KeyEvent, GUI::MouseEvent>;
     void enqueue_input_event(InputEvent const&);
     void process_next_input_event();
+    void did_finish_handling_input_event(bool event_was_accepted);
 
     bool m_is_awaiting_response_for_input_event { false };
     Queue<InputEvent> m_pending_input_events;

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.h
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.h
@@ -82,8 +82,6 @@ private:
     // ^WebView::ViewImplementation
     virtual void create_client(EnableCallgrindProfiling = EnableCallgrindProfiling::No) override;
     virtual void update_zoom() override;
-    virtual void notify_server_did_enter_tooltip_area(Badge<WebContentClient>, Gfx::IntPoint, DeprecatedString const&) override;
-    virtual void notify_server_did_leave_tooltip_area(Badge<WebContentClient>) override;
     virtual void notify_server_did_finish_handling_input_event(bool event_was_accepted) override;
 
     virtual Gfx::IntRect viewport_rect() const override;

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.h
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.h
@@ -82,7 +82,6 @@ private:
     // ^WebView::ViewImplementation
     virtual void create_client(EnableCallgrindProfiling = EnableCallgrindProfiling::No) override;
     virtual void update_zoom() override;
-    virtual void notify_server_did_request_cursor_change(Badge<WebContentClient>, Gfx::StandardCursor cursor) override;
     virtual void notify_server_did_request_scroll(Badge<WebContentClient>, i32, i32) override;
     virtual void notify_server_did_request_scroll_to(Badge<WebContentClient>, Gfx::IntPoint) override;
     virtual void notify_server_did_request_scroll_into_view(Badge<WebContentClient>, Gfx::IntRect const&) override;

--- a/Userland/Libraries/LibWebView/ViewImplementation.h
+++ b/Userland/Libraries/LibWebView/ViewImplementation.h
@@ -115,6 +115,9 @@ public:
     Function<void()> on_navigate_forward;
     Function<void()> on_refresh;
     Function<void(Gfx::Bitmap const&)> on_favicon_change;
+    Function<void(i32, i32)> on_scroll_by_delta;
+    Function<void(Gfx::IntPoint)> on_scroll_to_point;
+    Function<void(Gfx::IntRect)> on_scroll_into_view;
     Function<void(Gfx::StandardCursor)> on_cursor_change;
     Function<void(String const& message)> on_request_alert;
     Function<void(String const& message)> on_request_confirm;
@@ -141,9 +144,6 @@ public:
     Function<Gfx::IntRect()> on_minimize_window;
     Function<Gfx::IntRect()> on_fullscreen_window;
 
-    virtual void notify_server_did_request_scroll(Badge<WebContentClient>, i32, i32) = 0;
-    virtual void notify_server_did_request_scroll_to(Badge<WebContentClient>, Gfx::IntPoint) = 0;
-    virtual void notify_server_did_request_scroll_into_view(Badge<WebContentClient>, Gfx::IntRect const&) = 0;
     virtual void notify_server_did_enter_tooltip_area(Badge<WebContentClient>, Gfx::IntPoint, DeprecatedString const&) = 0;
     virtual void notify_server_did_leave_tooltip_area(Badge<WebContentClient>) = 0;
     virtual void notify_server_did_finish_handling_input_event(bool event_was_accepted) = 0;

--- a/Userland/Libraries/LibWebView/ViewImplementation.h
+++ b/Userland/Libraries/LibWebView/ViewImplementation.h
@@ -94,6 +94,7 @@ public:
     };
     ErrorOr<void> take_screenshot(ScreenshotType);
 
+    Function<void(Gfx::IntSize)> on_did_layout;
     Function<void()> on_ready_to_paint;
     Function<String(Web::HTML::ActivateTab)> on_new_tab;
     Function<void()> on_activate_tab;
@@ -139,7 +140,6 @@ public:
     Function<Gfx::IntRect()> on_minimize_window;
     Function<Gfx::IntRect()> on_fullscreen_window;
 
-    virtual void notify_server_did_layout(Badge<WebContentClient>, Gfx::IntSize content_size) = 0;
     virtual void notify_server_did_request_cursor_change(Badge<WebContentClient>, Gfx::StandardCursor cursor) = 0;
     virtual void notify_server_did_request_scroll(Badge<WebContentClient>, i32, i32) = 0;
     virtual void notify_server_did_request_scroll_to(Badge<WebContentClient>, Gfx::IntPoint) = 0;

--- a/Userland/Libraries/LibWebView/ViewImplementation.h
+++ b/Userland/Libraries/LibWebView/ViewImplementation.h
@@ -119,6 +119,8 @@ public:
     Function<void(Gfx::IntPoint)> on_scroll_to_point;
     Function<void(Gfx::IntRect)> on_scroll_into_view;
     Function<void(Gfx::StandardCursor)> on_cursor_change;
+    Function<void(Gfx::IntPoint, DeprecatedString const&)> on_enter_tooltip_area;
+    Function<void()> on_leave_tooltip_area;
     Function<void(String const& message)> on_request_alert;
     Function<void(String const& message)> on_request_confirm;
     Function<void(String const& message, String const& default_)> on_request_prompt;
@@ -144,8 +146,6 @@ public:
     Function<Gfx::IntRect()> on_minimize_window;
     Function<Gfx::IntRect()> on_fullscreen_window;
 
-    virtual void notify_server_did_enter_tooltip_area(Badge<WebContentClient>, Gfx::IntPoint, DeprecatedString const&) = 0;
-    virtual void notify_server_did_leave_tooltip_area(Badge<WebContentClient>) = 0;
     virtual void notify_server_did_finish_handling_input_event(bool event_was_accepted) = 0;
 
     virtual Gfx::IntRect viewport_rect() const = 0;

--- a/Userland/Libraries/LibWebView/ViewImplementation.h
+++ b/Userland/Libraries/LibWebView/ViewImplementation.h
@@ -145,8 +145,7 @@ public:
     Function<Gfx::IntRect()> on_maximize_window;
     Function<Gfx::IntRect()> on_minimize_window;
     Function<Gfx::IntRect()> on_fullscreen_window;
-
-    virtual void notify_server_did_finish_handling_input_event(bool event_was_accepted) = 0;
+    Function<void(bool)> on_finish_handling_input_event;
 
     virtual Gfx::IntRect viewport_rect() const = 0;
     virtual Gfx::IntPoint to_content_position(Gfx::IntPoint widget_position) const = 0;

--- a/Userland/Libraries/LibWebView/ViewImplementation.h
+++ b/Userland/Libraries/LibWebView/ViewImplementation.h
@@ -115,6 +115,7 @@ public:
     Function<void()> on_navigate_forward;
     Function<void()> on_refresh;
     Function<void(Gfx::Bitmap const&)> on_favicon_change;
+    Function<void(Gfx::StandardCursor)> on_cursor_change;
     Function<void(String const& message)> on_request_alert;
     Function<void(String const& message)> on_request_confirm;
     Function<void(String const& message, String const& default_)> on_request_prompt;
@@ -140,7 +141,6 @@ public:
     Function<Gfx::IntRect()> on_minimize_window;
     Function<Gfx::IntRect()> on_fullscreen_window;
 
-    virtual void notify_server_did_request_cursor_change(Badge<WebContentClient>, Gfx::StandardCursor cursor) = 0;
     virtual void notify_server_did_request_scroll(Badge<WebContentClient>, i32, i32) = 0;
     virtual void notify_server_did_request_scroll_to(Badge<WebContentClient>, Gfx::IntPoint) = 0;
     virtual void notify_server_did_request_scroll_into_view(Badge<WebContentClient>, Gfx::IntRect const&) = 0;

--- a/Userland/Libraries/LibWebView/ViewImplementation.h
+++ b/Userland/Libraries/LibWebView/ViewImplementation.h
@@ -127,12 +127,12 @@ public:
     Function<void(String const& message)> on_request_set_prompt_text;
     Function<void()> on_request_accept_dialog;
     Function<void()> on_request_dismiss_dialog;
-    Function<void(const AK::URL&, DeprecatedString const&)> on_get_source;
-    Function<void(DeprecatedString const&)> on_get_dom_tree;
-    Function<void(i32 node_id, DeprecatedString const& computed_style, DeprecatedString const& resolved_style, DeprecatedString const& custom_properties, DeprecatedString const& node_box_sizing, DeprecatedString const& aria_properties_state)> on_get_dom_node_properties;
-    Function<void(DeprecatedString const&)> on_get_accessibility_tree;
-    Function<void(i32 message_id)> on_js_console_new_message;
-    Function<void(i32 start_index, Vector<DeprecatedString> const& message_types, Vector<DeprecatedString> const& messages)> on_get_js_console_messages;
+    Function<void(const AK::URL&, DeprecatedString const&)> on_received_source;
+    Function<void(DeprecatedString const&)> on_received_dom_tree;
+    Function<void(i32 node_id, DeprecatedString const& computed_style, DeprecatedString const& resolved_style, DeprecatedString const& custom_properties, DeprecatedString const& node_box_sizing, DeprecatedString const& aria_properties_state)> on_received_dom_node_properties;
+    Function<void(DeprecatedString const&)> on_received_accessibility_tree;
+    Function<void(i32 message_id)> on_received_console_message;
+    Function<void(i32 start_index, Vector<DeprecatedString> const& message_types, Vector<DeprecatedString> const& messages)> on_received_console_messages;
     Function<Vector<Web::Cookie::Cookie>(AK::URL const& url)> on_get_all_cookies;
     Function<Optional<Web::Cookie::Cookie>(AK::URL const& url, DeprecatedString const& name)> on_get_named_cookie;
     Function<DeprecatedString(const AK::URL& url, Web::Cookie::Source source)> on_get_cookie;

--- a/Userland/Libraries/LibWebView/WebContentClient.cpp
+++ b/Userland/Libraries/LibWebView/WebContentClient.cpp
@@ -109,18 +109,21 @@ void WebContentClient::did_change_title(DeprecatedString const& title)
 
 void WebContentClient::did_request_scroll(i32 x_delta, i32 y_delta)
 {
-    m_view.notify_server_did_request_scroll({}, x_delta, y_delta);
+    if (m_view.on_scroll_by_delta)
+        m_view.on_scroll_by_delta(x_delta, y_delta);
 }
 
 void WebContentClient::did_request_scroll_to(Gfx::IntPoint scroll_position)
 {
-    m_view.notify_server_did_request_scroll_to({}, scroll_position);
+    if (m_view.on_scroll_to_point)
+        m_view.on_scroll_to_point(scroll_position);
 }
 
 void WebContentClient::did_request_scroll_into_view(Gfx::IntRect const& rect)
 {
     dbgln_if(SPAM_DEBUG, "handle: WebContentClient::DidRequestScrollIntoView! rect={}", rect);
-    m_view.notify_server_did_request_scroll_into_view({}, rect);
+    if (m_view.on_scroll_into_view)
+        m_view.on_scroll_into_view(rect);
 }
 
 void WebContentClient::did_enter_tooltip_area(Gfx::IntPoint content_position, DeprecatedString const& title)

--- a/Userland/Libraries/LibWebView/WebContentClient.cpp
+++ b/Userland/Libraries/LibWebView/WebContentClient.cpp
@@ -192,38 +192,38 @@ void WebContentClient::did_request_media_context_menu(Gfx::IntPoint content_posi
 
 void WebContentClient::did_get_source(AK::URL const& url, DeprecatedString const& source)
 {
-    if (m_view.on_get_source)
-        m_view.on_get_source(url, source);
+    if (m_view.on_received_source)
+        m_view.on_received_source(url, source);
 }
 
 void WebContentClient::did_get_dom_tree(DeprecatedString const& dom_tree)
 {
-    if (m_view.on_get_dom_tree)
-        m_view.on_get_dom_tree(dom_tree);
+    if (m_view.on_received_dom_tree)
+        m_view.on_received_dom_tree(dom_tree);
 }
 
 void WebContentClient::did_get_dom_node_properties(i32 node_id, DeprecatedString const& computed_style, DeprecatedString const& resolved_style, DeprecatedString const& custom_properties, DeprecatedString const& node_box_sizing, DeprecatedString const& aria_properties_state)
 {
-    if (m_view.on_get_dom_node_properties)
-        m_view.on_get_dom_node_properties(node_id, computed_style, resolved_style, custom_properties, node_box_sizing, aria_properties_state);
+    if (m_view.on_received_dom_node_properties)
+        m_view.on_received_dom_node_properties(node_id, computed_style, resolved_style, custom_properties, node_box_sizing, aria_properties_state);
 }
 
 void WebContentClient::did_get_accessibility_tree(DeprecatedString const& accessibility_tree)
 {
-    if (m_view.on_get_accessibility_tree)
-        m_view.on_get_accessibility_tree(accessibility_tree);
+    if (m_view.on_received_accessibility_tree)
+        m_view.on_received_accessibility_tree(accessibility_tree);
 }
 
 void WebContentClient::did_output_js_console_message(i32 message_index)
 {
-    if (m_view.on_js_console_new_message)
-        m_view.on_js_console_new_message(message_index);
+    if (m_view.on_received_console_message)
+        m_view.on_received_console_message(message_index);
 }
 
 void WebContentClient::did_get_js_console_messages(i32 start_index, Vector<DeprecatedString> const& message_types, Vector<DeprecatedString> const& messages)
 {
-    if (m_view.on_get_js_console_messages)
-        m_view.on_get_js_console_messages(start_index, message_types, messages);
+    if (m_view.on_received_console_messages)
+        m_view.on_received_console_messages(start_index, message_types, messages);
 }
 
 void WebContentClient::did_request_alert(String const& message)

--- a/Userland/Libraries/LibWebView/WebContentClient.cpp
+++ b/Userland/Libraries/LibWebView/WebContentClient.cpp
@@ -128,12 +128,14 @@ void WebContentClient::did_request_scroll_into_view(Gfx::IntRect const& rect)
 
 void WebContentClient::did_enter_tooltip_area(Gfx::IntPoint content_position, DeprecatedString const& title)
 {
-    m_view.notify_server_did_enter_tooltip_area({}, content_position, title);
+    if (m_view.on_enter_tooltip_area)
+        m_view.on_enter_tooltip_area(m_view.to_widget_position(content_position), title);
 }
 
 void WebContentClient::did_leave_tooltip_area()
 {
-    m_view.notify_server_did_leave_tooltip_area({});
+    if (m_view.on_leave_tooltip_area)
+        m_view.on_leave_tooltip_area();
 }
 
 void WebContentClient::did_hover_link(AK::URL const& url)

--- a/Userland/Libraries/LibWebView/WebContentClient.cpp
+++ b/Userland/Libraries/LibWebView/WebContentClient.cpp
@@ -88,7 +88,8 @@ void WebContentClient::did_request_cursor_change(i32 cursor_type)
 void WebContentClient::did_layout(Gfx::IntSize content_size)
 {
     dbgln_if(SPAM_DEBUG, "handle: WebContentClient::DidLayout! content_size={}", content_size);
-    m_view.notify_server_did_layout({}, content_size);
+    if (m_view.on_did_layout)
+        m_view.on_did_layout(content_size);
 }
 
 void WebContentClient::did_change_title(DeprecatedString const& title)

--- a/Userland/Libraries/LibWebView/WebContentClient.cpp
+++ b/Userland/Libraries/LibWebView/WebContentClient.cpp
@@ -380,7 +380,8 @@ void WebContentClient::did_request_file(DeprecatedString const& path, i32 reques
 
 void WebContentClient::did_finish_handling_input_event(bool event_was_accepted)
 {
-    m_view.notify_server_did_finish_handling_input_event(event_was_accepted);
+    if (m_view.on_finish_handling_input_event)
+        m_view.on_finish_handling_input_event(event_was_accepted);
 }
 
 }

--- a/Userland/Libraries/LibWebView/WebContentClient.cpp
+++ b/Userland/Libraries/LibWebView/WebContentClient.cpp
@@ -82,7 +82,9 @@ void WebContentClient::did_request_cursor_change(i32 cursor_type)
         dbgln("DidRequestCursorChange: Bad cursor type");
         return;
     }
-    m_view.notify_server_did_request_cursor_change({}, (Gfx::StandardCursor)cursor_type);
+
+    if (m_view.on_cursor_change)
+        m_view.on_cursor_change(static_cast<Gfx::StandardCursor>(cursor_type));
 }
 
 void WebContentClient::did_layout(Gfx::IntSize content_size)

--- a/Userland/Utilities/headless-browser.cpp
+++ b/Userland/Utilities/headless-browser.cpp
@@ -102,7 +102,6 @@ public:
 private:
     HeadlessWebContentView() = default;
 
-    void notify_server_did_finish_handling_input_event(bool) override { }
     void update_zoom() override { }
     void create_client(WebView::EnableCallgrindProfiling) override { }
 

--- a/Userland/Utilities/headless-browser.cpp
+++ b/Userland/Utilities/headless-browser.cpp
@@ -102,7 +102,6 @@ public:
 private:
     HeadlessWebContentView() = default;
 
-    void notify_server_did_layout(Badge<WebView::WebContentClient>, Gfx::IntSize) override { }
     void notify_server_did_request_cursor_change(Badge<WebView::WebContentClient>, Gfx::StandardCursor) override { }
     void notify_server_did_request_scroll(Badge<WebView::WebContentClient>, i32, i32) override { }
     void notify_server_did_request_scroll_to(Badge<WebView::WebContentClient>, Gfx::IntPoint) override { }

--- a/Userland/Utilities/headless-browser.cpp
+++ b/Userland/Utilities/headless-browser.cpp
@@ -102,7 +102,6 @@ public:
 private:
     HeadlessWebContentView() = default;
 
-    void notify_server_did_request_cursor_change(Badge<WebView::WebContentClient>, Gfx::StandardCursor) override { }
     void notify_server_did_request_scroll(Badge<WebView::WebContentClient>, i32, i32) override { }
     void notify_server_did_request_scroll_to(Badge<WebView::WebContentClient>, Gfx::IntPoint) override { }
     void notify_server_did_request_scroll_into_view(Badge<WebView::WebContentClient>, Gfx::IntRect const&) override { }

--- a/Userland/Utilities/headless-browser.cpp
+++ b/Userland/Utilities/headless-browser.cpp
@@ -102,9 +102,6 @@ public:
 private:
     HeadlessWebContentView() = default;
 
-    void notify_server_did_request_scroll(Badge<WebView::WebContentClient>, i32, i32) override { }
-    void notify_server_did_request_scroll_to(Badge<WebView::WebContentClient>, Gfx::IntPoint) override { }
-    void notify_server_did_request_scroll_into_view(Badge<WebView::WebContentClient>, Gfx::IntRect const&) override { }
     void notify_server_did_enter_tooltip_area(Badge<WebView::WebContentClient>, Gfx::IntPoint, DeprecatedString const&) override { }
     void notify_server_did_leave_tooltip_area(Badge<WebView::WebContentClient>) override { }
     void notify_server_did_finish_handling_input_event(bool) override { }

--- a/Userland/Utilities/headless-browser.cpp
+++ b/Userland/Utilities/headless-browser.cpp
@@ -102,8 +102,6 @@ public:
 private:
     HeadlessWebContentView() = default;
 
-    void notify_server_did_enter_tooltip_area(Badge<WebView::WebContentClient>, Gfx::IntPoint, DeprecatedString const&) override { }
-    void notify_server_did_leave_tooltip_area(Badge<WebView::WebContentClient>) override { }
     void notify_server_did_finish_handling_input_event(bool) override { }
     void update_zoom() override { }
     void create_client(WebView::EnableCallgrindProfiling) override { }


### PR DESCRIPTION
Continuing #18893 and #20723. Again, the de-deduplication is not *as* large as the first PR, but now all GUI hooks are propagated in a uniform manner.