### PR TITLE
Ladybird: Ensure we release CoreFoundation references

### DIFF
--- a/Ladybird/AppKit/Application/EventLoopImplementation.mm
+++ b/Ladybird/AppKit/Application/EventLoopImplementation.mm
@@ -89,6 +89,7 @@ bool CFEventLoopManager::unregister_timer(int timer_id)
 
     if (auto timer = thread_data.timers.take(timer_id); timer.has_value()) {
         CFRunLoopTimerInvalidate(*timer);
+        CFRelease(*timer);
         return true;
     }
 
@@ -139,6 +140,8 @@ void CFEventLoopManager::register_notifier(Core::Notifier& notifier)
 
     auto* source = CFSocketCreateRunLoopSource(kCFAllocatorDefault, socket, 0);
     CFRunLoopAddSource(CFRunLoopGetCurrent(), source, kCFRunLoopDefaultMode);
+
+    CFRelease(socket);
 
     ThreadData::the().notifiers.set(&notifier, source);
 }

--- a/Ladybird/AppKit/UI/LadybirdWebView.mm
+++ b/Ladybird/AppKit/UI/LadybirdWebView.mm
@@ -860,6 +860,7 @@ static void copy_text_to_clipboard(StringView text)
     [image drawInRect:image_rect];
 
     CGContextRestoreGState(context);
+    CGDataProviderRelease(provider);
     CGImageRelease(bitmap_image);
 
     [super drawRect:rect];


### PR DESCRIPTION
Once we are done with our references to some CoreFoundation types, we must be sure to manually release those references.