### PR TITLE
LibWeb: Move viewport subscriptions from BrowsingContext to Document

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -1007,7 +1007,7 @@ void Document::update_layout()
     layout_state.commit(*m_layout_root);
 
     // Broadcast the current viewport rect to any new paintables, so they know whether they're visible or not.
-    browsing_context()->inform_all_viewport_clients_about_the_current_viewport_rect();
+    inform_all_viewport_clients_about_the_current_viewport_rect();
 
     browsing_context()->set_needs_display();
 
@@ -2996,6 +2996,24 @@ JS::NonnullGCPtr<CSS::VisualViewport> Document::visual_viewport()
     if (!m_visual_viewport)
         m_visual_viewport = CSS::VisualViewport::create(*this);
     return *m_visual_viewport;
+}
+
+void Document::register_viewport_client(ViewportClient& client)
+{
+    auto result = m_viewport_clients.set(&client);
+    VERIFY(result == AK::HashSetResult::InsertedNewEntry);
+}
+
+void Document::unregister_viewport_client(ViewportClient& client)
+{
+    bool was_removed = m_viewport_clients.remove(&client);
+    VERIFY(was_removed);
+}
+
+void Document::inform_all_viewport_clients_about_the_current_viewport_rect()
+{
+    for (auto* client : m_viewport_clients)
+        client->did_set_viewport_rect(viewport_rect());
 }
 
 void Document::register_intersection_observer(Badge<IntersectionObserver::IntersectionObserver>, IntersectionObserver::IntersectionObserver& observer)

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -392,6 +392,15 @@ public:
     JS::NonnullGCPtr<CSS::VisualViewport> visual_viewport();
     [[nodiscard]] CSSPixelRect viewport_rect() const;
 
+    class ViewportClient {
+    public:
+        virtual ~ViewportClient() = default;
+        virtual void did_set_viewport_rect(CSSPixelRect const&) = 0;
+    };
+    void register_viewport_client(ViewportClient&);
+    void unregister_viewport_client(ViewportClient&);
+    void inform_all_viewport_clients_about_the_current_viewport_rect();
+
     bool has_focus() const;
 
     void set_parser(Badge<HTML::HTMLParser>, HTML::HTMLParser&);
@@ -622,6 +631,8 @@ private:
 
     // Used by run_the_resize_steps().
     Gfx::IntSize m_last_viewport_size;
+
+    HashTable<ViewportClient*> m_viewport_clients;
 
     // https://w3c.github.io/csswg-drafts/cssom-view-1/#document-pending-scroll-event-targets
     Vector<JS::NonnullGCPtr<EventTarget>> m_pending_scroll_event_targets;

--- a/Userland/Libraries/LibWeb/HTML/BrowsingContext.h
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContext.h
@@ -118,14 +118,6 @@ public:
         return IterationDecision::Continue;
     }
 
-    class ViewportClient {
-    public:
-        virtual ~ViewportClient() = default;
-        virtual void browsing_context_did_set_viewport_rect(CSSPixelRect const&) = 0;
-    };
-    void register_viewport_client(ViewportClient&);
-    void unregister_viewport_client(ViewportClient&);
-
     bool is_top_level() const;
     bool is_focused_context() const;
 
@@ -277,8 +269,6 @@ public:
     virtual String const& window_handle() const override { return m_window_handle; }
     virtual void set_window_handle(String handle) override { m_window_handle = move(handle); }
 
-    void inform_all_viewport_clients_about_the_current_viewport_rect();
-
 private:
     explicit BrowsingContext(Page&, HTML::NavigableContainer*);
 
@@ -323,8 +313,6 @@ private:
     DOM::Position m_cursor_position;
     RefPtr<Core::Timer> m_cursor_blink_timer;
     bool m_cursor_blink_state { false };
-
-    HashTable<ViewportClient*> m_viewport_clients;
 
     HashMap<AK::URL, size_t> m_frame_nesting_levels;
     DeprecatedString m_name;

--- a/Userland/Libraries/LibWeb/HTML/HTMLImageElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLImageElement.h
@@ -9,6 +9,7 @@
 #include <AK/ByteBuffer.h>
 #include <AK/OwnPtr.h>
 #include <LibGfx/Forward.h>
+#include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/DocumentLoadEventDelayer.h>
 #include <LibWeb/HTML/BrowsingContext.h>
 #include <LibWeb/HTML/CORSSettingAttribute.h>
@@ -23,7 +24,7 @@ class HTMLImageElement final
     : public HTMLElement
     , public FormAssociatedElement
     , public Layout::ImageProvider
-    , public BrowsingContext::ViewportClient {
+    , public DOM::Document::ViewportClient {
     WEB_PLATFORM_OBJECT(HTMLImageElement, HTMLElement);
     FORM_ASSOCIATED_ELEMENT(HTMLElement, HTMLImageElement)
 
@@ -99,11 +100,13 @@ private:
     virtual void initialize(JS::Realm&) override;
     virtual void finalize() override;
 
+    virtual void adopted_from(DOM::Document&) override;
+
     virtual void apply_presentational_hints(CSS::StyleProperties&) const override;
 
     virtual JS::GCPtr<Layout::Node> create_layout_node(NonnullRefPtr<CSS::StyleProperties>) override;
 
-    virtual void browsing_context_did_set_viewport_rect(CSSPixelRect const&) override;
+    virtual void did_set_viewport_rect(CSSPixelRect const&) override;
 
     void handle_successful_fetch(AK::URL const&, StringView mime_type, ImageRequest&, ByteBuffer, bool maybe_omit_events, AK::URL const& previous_url);
     void handle_failed_fetch();

--- a/Userland/Libraries/LibWeb/Layout/VideoBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/VideoBox.cpp
@@ -13,16 +13,16 @@ namespace Web::Layout {
 VideoBox::VideoBox(DOM::Document& document, DOM::Element& element, NonnullRefPtr<CSS::StyleProperties> style)
     : ReplacedBox(document, element, move(style))
 {
-    browsing_context().register_viewport_client(*this);
+    document.register_viewport_client(*this);
 }
 
 void VideoBox::finalize()
 {
     Base::finalize();
 
-    // NOTE: We unregister from the browsing context in finalize() to avoid trouble
-    //       in the scenario where our BrowsingContext has already been swept by GC.
-    browsing_context().unregister_viewport_client(*this);
+    // NOTE: We unregister from the document in finalize() to avoid trouble
+    //       in the scenario where our Document has already been swept by GC.
+    document().unregister_viewport_client(*this);
 }
 
 HTML::HTMLVideoElement& VideoBox::dom_node()
@@ -49,7 +49,7 @@ void VideoBox::prepare_for_replaced_layout()
         set_natural_aspect_ratio({});
 }
 
-void VideoBox::browsing_context_did_set_viewport_rect(CSSPixelRect const&)
+void VideoBox::did_set_viewport_rect(CSSPixelRect const&)
 {
     // FIXME: Several steps in HTMLMediaElement indicate we may optionally handle whether the media object
     //        is in view. Implement those steps.

--- a/Userland/Libraries/LibWeb/Layout/VideoBox.h
+++ b/Userland/Libraries/LibWeb/Layout/VideoBox.h
@@ -6,15 +6,15 @@
 
 #pragma once
 
+#include <LibWeb/DOM/Document.h>
 #include <LibWeb/Forward.h>
-#include <LibWeb/HTML/BrowsingContext.h>
 #include <LibWeb/Layout/ReplacedBox.h>
 
 namespace Web::Layout {
 
 class VideoBox final
     : public ReplacedBox
-    , public HTML::BrowsingContext::ViewportClient {
+    , public DOM::Document::ViewportClient {
     JS_CELL(VideoBox, ReplacedBox);
 
 public:
@@ -28,8 +28,8 @@ public:
 private:
     VideoBox(DOM::Document&, DOM::Element&, NonnullRefPtr<CSS::StyleProperties>);
 
-    // ^BrowsingContext::ViewportClient
-    virtual void browsing_context_did_set_viewport_rect(CSSPixelRect const&) final;
+    // ^Document::ViewportClient
+    virtual void did_set_viewport_rect(CSSPixelRect const&) final;
 
     // ^JS::Cell
     virtual void finalize() override;

--- a/Userland/Libraries/LibWeb/Painting/ImagePaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/ImagePaintable.cpp
@@ -23,16 +23,16 @@ JS::NonnullGCPtr<ImagePaintable> ImagePaintable::create(Layout::ImageBox const& 
 ImagePaintable::ImagePaintable(Layout::ImageBox const& layout_box)
     : PaintableBox(layout_box)
 {
-    browsing_context().register_viewport_client(*this);
+    const_cast<DOM::Document&>(layout_box.document()).register_viewport_client(*this);
 }
 
 void ImagePaintable::finalize()
 {
     Base::finalize();
 
-    // NOTE: We unregister from the browsing context in finalize() to avoid trouble
-    //       in the scenario where our BrowsingContext has already been swept by GC.
-    browsing_context().unregister_viewport_client(*this);
+    // NOTE: We unregister from the document in finalize() to avoid trouble
+    //       in the scenario where our Document has already been swept by GC.
+    document().unregister_viewport_client(*this);
 }
 
 Layout::ImageBox const& ImagePaintable::layout_box() const
@@ -133,7 +133,7 @@ void ImagePaintable::paint(PaintContext& context, PaintPhase phase) const
     }
 }
 
-void ImagePaintable::browsing_context_did_set_viewport_rect(CSSPixelRect const& viewport_rect)
+void ImagePaintable::did_set_viewport_rect(CSSPixelRect const& viewport_rect)
 {
     const_cast<Layout::ImageProvider&>(layout_box().image_provider()).set_visible_in_viewport(viewport_rect.intersects(absolute_rect()));
 }

--- a/Userland/Libraries/LibWeb/Painting/ImagePaintable.h
+++ b/Userland/Libraries/LibWeb/Painting/ImagePaintable.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <LibWeb/HTML/BrowsingContext.h>
 #include <LibWeb/Layout/ImageBox.h>
 #include <LibWeb/Painting/PaintableBox.h>
 
@@ -14,7 +13,7 @@ namespace Web::Painting {
 
 class ImagePaintable final
     : public PaintableBox
-    , public HTML::BrowsingContext::ViewportClient {
+    , public DOM::Document::ViewportClient {
     JS_CELL(ImagePaintable, PaintableBox);
 
 public:
@@ -28,8 +27,8 @@ private:
     // ^JS::Cell
     virtual void finalize() override;
 
-    // ^BrowsingContext::ViewportClient
-    virtual void browsing_context_did_set_viewport_rect(CSSPixelRect const&) final;
+    // ^Document::ViewportClient
+    virtual void did_set_viewport_rect(CSSPixelRect const&) final;
 
     ImagePaintable(Layout::ImageBox const&);
 };


### PR DESCRIPTION
With this change, elements that want to receive viewport rect updates will need to register on document instead of the browsing context.

This change solves the problem where a browsing context for a document is guaranteed to exist only while the document is active so browsing context might not exit by the time DOM node that want to register is constructed.

This is a part of preparation work before switching to navigables where this issue becomes more visible.