### PR TITLE
HackStudio: Add git logs view in Git tab

### DIFF
--- a/Userland/DevTools/HackStudio/CMakeLists.txt
+++ b/Userland/DevTools/HackStudio/CMakeLists.txt
@@ -28,6 +28,8 @@ set(SOURCES
     EditorWrapper.cpp
     FindInFilesWidget.cpp
     Git/DiffViewer.cpp
+    Git/GitLogModel.cpp
+    Git/GitLogView.cpp
     Git/GitFilesModel.cpp
     Git/GitFilesView.cpp
     Git/GitRepo.cpp

--- a/Userland/DevTools/HackStudio/Git/GitLogModel.cpp
+++ b/Userland/DevTools/HackStudio/Git/GitLogModel.cpp
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2023, Abhishek R. <raturiabhi1000@gmail.com>
+ * Copyright (c) 2023, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "GitLogModel.h"
+
+namespace HackStudio {
+NonnullRefPtr<GitLogModel> GitLogModel::create(Vector<DeprecatedString>&& commits)
+{
+    return adopt_ref(*new GitLogModel(move(commits)));
+}
+
+GitLogModel::GitLogModel(Vector<DeprecatedString>&& commits)
+    : m_logs(move(commits))
+{
+}
+
+GUI::Variant GitLogModel::data(const GUI::ModelIndex& index, GUI::ModelRole role) const
+{
+    if (role == GUI::ModelRole::Display) {
+        return m_logs.at(index.row());
+    }
+    return {};
+}
+
+GUI::ModelIndex GitLogModel::index(int row, int column, const GUI::ModelIndex&) const
+{
+    if (row < 0 || row >= static_cast<int>(m_logs.size()))
+        return {};
+    return create_index(row, column, &m_logs.at(row));
+}
+}

--- a/Userland/DevTools/HackStudio/Git/GitLogModel.h
+++ b/Userland/DevTools/HackStudio/Git/GitLogModel.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2023, Abhishek R. <raturiabhi1000@gmail.com>
+ * Copyright (c) 2023, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include "GitFilesView.h"
+#include "GitRepo.h"
+
+namespace HackStudio {
+
+class GitLogModel final : public GUI::Model {
+public:
+    static NonnullRefPtr<GitLogModel> create(Vector<DeprecatedString>&& logs);
+
+    virtual int row_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override { return m_logs.size(); }
+    virtual int column_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override { return 1; }
+
+    virtual GUI::Variant data(const GUI::ModelIndex&, GUI::ModelRole) const override;
+
+    virtual GUI::ModelIndex index(int row, int column, const GUI::ModelIndex&) const override;
+
+private:
+    explicit GitLogModel(Vector<DeprecatedString>&& logs);
+    Vector<DeprecatedString> m_logs;
+};
+
+}

--- a/Userland/DevTools/HackStudio/Git/GitLogView.cpp
+++ b/Userland/DevTools/HackStudio/Git/GitLogView.cpp
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2023, Abhishek Raturi <raturiabhi1000@gmail.com>
+ * Copyright (c) 2023, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "GitLogView.h"
+#include <LibGUI/BoxLayout.h>
+
+namespace HackStudio {
+
+void GitLogView::paint_list_item(GUI::Painter& painter, int row_index, int painted_item_index)
+{
+    ListView::paint_list_item(painter, row_index, painted_item_index);
+}
+
+GitLogView::GitLogView(GitLogActionCallback)
+{
+    set_alternating_row_colors(true);
+}
+}

--- a/Userland/DevTools/HackStudio/Git/GitLogView.h
+++ b/Userland/DevTools/HackStudio/Git/GitLogView.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2023, Abhishek Raturi <raturiabhi1000@gmail.com>
+ * Copyright (c) 2023, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include "GitFilesView.h"
+#include "GitRepo.h"
+#include <AK/Function.h>
+#include <LibGUI/Forward.h>
+#include <LibGUI/TableView.h>
+
+namespace HackStudio {
+
+using GitLogActionCallback = Function<void(void)>;
+class GitLogView : public GUI::ListView {
+    C_OBJECT(GitLogView)
+public:
+    virtual ~GitLogView() override = default;
+
+protected:
+    GitLogView(GitLogActionCallback);
+
+private:
+    virtual void paint_list_item(GUI::Painter& painter, int row_index, int painted_item_index) override;
+    GitFileActionCallback m_action_callback;
+};
+
+}

--- a/Userland/DevTools/HackStudio/Git/GitRepo.cpp
+++ b/Userland/DevTools/HackStudio/Git/GitRepo.cpp
@@ -47,6 +47,14 @@ Vector<DeprecatedString> GitRepo::staged_files() const
     return parse_files_list(raw_result);
 }
 
+Vector<DeprecatedString> GitRepo::git_logs() const
+{
+    auto logs = command({ "log", "--pretty=format:%h %s by <%cn>", "--abbrev-commit" });
+    if (logs.is_null())
+        return {};
+    return parse_files_list(logs);
+}
+
 Vector<DeprecatedString> GitRepo::modified_files() const
 {
     auto raw_result = command({ "ls-files", "--modified", "--exclude-standard" });
@@ -106,6 +114,11 @@ bool GitRepo::unstage(DeprecatedString const& file)
     return !command({ "reset", "HEAD", "--", file }).is_null();
 }
 
+bool GitRepo::git_log()
+{
+    return !command({ "log", "--abbrev-commit" }).is_null();
+}
+
 bool GitRepo::commit(DeprecatedString const& message)
 {
     return !command({ "commit", "-m", message }).is_null();
@@ -129,5 +142,4 @@ bool GitRepo::is_tracked(DeprecatedString const& file) const
 
     return !res.is_empty();
 }
-
 }

--- a/Userland/DevTools/HackStudio/Git/GitRepo.h
+++ b/Userland/DevTools/HackStudio/Git/GitRepo.h
@@ -33,11 +33,13 @@ public:
 
     bool stage(DeprecatedString const& file);
     bool unstage(DeprecatedString const& file);
+    bool git_log();
     bool commit(DeprecatedString const& message);
     bool is_tracked(DeprecatedString const& file) const;
 
     Vector<DeprecatedString> unstaged_files() const;
     Vector<DeprecatedString> staged_files() const;
+    Vector<DeprecatedString> git_logs() const;
     Optional<DeprecatedString> original_file_content(DeprecatedString const& file) const;
     Optional<DeprecatedString> unstaged_diff(DeprecatedString const& file) const;
 

--- a/Userland/DevTools/HackStudio/Git/GitWidget.cpp
+++ b/Userland/DevTools/HackStudio/Git/GitWidget.cpp
@@ -7,6 +7,7 @@
 #include "GitWidget.h"
 #include "../Dialogs/Git/GitCommitDialog.h"
 #include "GitFilesModel.h"
+#include "GitLogModel.h"
 #include <LibDiff/Format.h>
 #include <LibGUI/Application.h>
 #include <LibGUI/BoxLayout.h>
@@ -73,6 +74,12 @@ GitWidget::GitWidget()
         [this](auto const& file) { unstage_file(file); },
         Gfx::Bitmap::load_from_file("/res/icons/16x16/minus.png"sv).release_value_but_fixme_should_propagate_errors());
     m_staged_files->set_foreground_role(Gfx::ColorRole::Green);
+
+    auto& git_logs = add<GUI::Widget>();
+    git_logs.set_layout<GUI::VerticalBoxLayout>();
+    auto& git_log_label = git_logs.add<GUI::Label>();
+    git_log_label.set_text("Git Log"_string);
+    m_git_logs = git_logs.add<GitLogView>([this]() { git_log(); });
 }
 
 bool GitWidget::initialize()
@@ -116,6 +123,7 @@ void GitWidget::refresh()
 
     m_unstaged_files->set_model(GitFilesModel::create(m_git_repo->unstaged_files()));
     m_staged_files->set_model(GitFilesModel::create(m_git_repo->staged_files()));
+    m_git_logs->set_model(GitLogModel::create(m_git_repo->git_logs()));
 }
 
 void GitWidget::stage_file(DeprecatedString const& file)
@@ -130,6 +138,14 @@ void GitWidget::unstage_file(DeprecatedString const& file)
 {
     dbgln("unstaging: {}", file);
     bool rc = m_git_repo->unstage(file);
+    VERIFY(rc);
+    refresh();
+}
+
+void GitWidget::git_log()
+{
+    dbgln("Git logs : ");
+    bool rc = m_git_repo->git_log();
     VERIFY(rc);
     refresh();
 }

--- a/Userland/DevTools/HackStudio/Git/GitWidget.h
+++ b/Userland/DevTools/HackStudio/Git/GitWidget.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "GitFilesView.h"
+#include "GitLogView.h"
 #include "GitRepo.h"
 #include <AK/Function.h>
 #include <LibGUI/Forward.h>
@@ -33,12 +34,14 @@ private:
     bool initialize_if_needed();
     void stage_file(DeprecatedString const&);
     void unstage_file(DeprecatedString const&);
+    void git_log();
     void commit();
     void show_diff(DeprecatedString const&);
 
     DeprecatedString m_repo_root;
     RefPtr<GitFilesView> m_unstaged_files;
     RefPtr<GitFilesView> m_staged_files;
+    RefPtr<GitLogView> m_git_logs;
     RefPtr<GitRepo> m_git_repo;
     ViewDiffCallback m_view_diff_callback;
 };


### PR DESCRIPTION
Add Git Logs in the Git tab in HackStudio to view git history.

<img width="1664" alt="image" src="https://github.com/SerenityOS/serenity/assets/15072510/2d7df300-4a0f-4506-9a19-88c88dea34a1">
