### PR TITLE
Ports/aria2: Explicitly disable some optional dependencies

### DIFF
--- a/Ports/aria2/package.sh
+++ b/Ports/aria2/package.sh
@@ -17,4 +17,5 @@ config_sub_paths+=("deps/wslay/config.sub")
 configopts+=(
     "--with-libuv"
     "--with-sysroot=${SERENITY_INSTALL_ROOT}"
+    '--without-libcares'
 )

--- a/Ports/aria2/package.sh
+++ b/Ports/aria2/package.sh
@@ -5,17 +5,19 @@ files=(
     "https://github.com/aria2/aria2/releases/download/release-${version}/aria2-${version}.tar.xz 58d1e7608c12404f0229a3d9a4953d0d00c18040504498b483305bcb3de907a5"
 )
 depends=(
-    "libssh2"
-    "libxml2"
-    "openssl"
-    "zlib"
-    "libuv"
+    'libssh2'
+    'libuv'
+    'libxml2'
+    'openssl'
+    'zlib'
 )
 useconfigure='true'
 use_fresh_config_sub='true'
-config_sub_paths+=("deps/wslay/config.sub")
+config_sub_paths+=(
+    'deps/wslay/config.sub'
+)
 configopts+=(
-    "--with-libuv"
+    '--with-libuv'
     "--with-sysroot=${SERENITY_INSTALL_ROOT}"
     '--without-libcares'
     '--without-sqlite3'

--- a/Ports/aria2/package.sh
+++ b/Ports/aria2/package.sh
@@ -18,4 +18,5 @@ configopts+=(
     "--with-libuv"
     "--with-sysroot=${SERENITY_INSTALL_ROOT}"
     '--without-libcares'
+    '--without-sqlite3'
 )

--- a/Ports/libssh2/package.sh
+++ b/Ports/libssh2/package.sh
@@ -5,8 +5,16 @@ useconfigure=true
 files=(
     "https://www.libssh2.org/download/libssh2-${version}.tar.gz 2d64e90f3ded394b91d3a2e774ca203a4179f69aebee03003e5a6fa621e41d51"
 )
-depends=("libgcrypt")
-configopts=("-DCMAKE_TOOLCHAIN_FILE=${SERENITY_BUILD_DIR}/CMakeToolchain.txt" "-GNinja")
+depends=(
+    'openssl'
+    'zlib'
+)
+configopts=(
+    "-DCMAKE_TOOLCHAIN_FILE=${SERENITY_BUILD_DIR}/CMakeToolchain.txt" 
+    '-DCRYPTO_BACKEND=OpenSSL'
+    '-DENABLE_ZLIB_COMPRESSION=ON'
+    '-GNinja'
+)
 
 configure() {
     run cmake "${configopts[@]}" .

--- a/Ports/libssh2/package.sh
+++ b/Ports/libssh2/package.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S bash ../.port_include.sh
-port=libssh2
-version=1.10.0
-useconfigure=true
+port='libssh2'
+version='1.10.0'
+useconfigure='true'
 files=(
     "https://www.libssh2.org/download/libssh2-${version}.tar.gz 2d64e90f3ded394b91d3a2e774ca203a4179f69aebee03003e5a6fa621e41d51"
 )


### PR DESCRIPTION
This PR makes 3 separate, but related changes:
* Use OpenSSL instead of `libgcrypt` as the crypto backend for `libssh2`. Openssl takes precedence if both are found, so preferring it makes sense.
* Don't use `c-ares` in `aria2`: This was causing the build to fail if the `c-ares` port was installed prior to `aria2`
* Don't use `sqlite3` in `aria2`: This disables Firefox/Chromium cookie support in aria2, which isn't that useful in SerenityOS, but makes the build consistent, regardless of whether the `sqlite` port is installed or not.

I made the `libssh2` changes at the same time as `aria2` because `aria2` is the only thing that depends on `libssh2`.