### PR TITLE
LibWeb: Remove "LibWeb+LibJS/1.0" from the default User-Agent string

### DIFF
--- a/Userland/Libraries/LibWeb/Loader/ResourceLoader.h
+++ b/Userland/Libraries/LibWeb/Loader/ResourceLoader.h
@@ -49,7 +49,7 @@ namespace Web {
 #define BROWSER_NAME "Ladybird"
 #define BROWSER_VERSION "1.0"
 
-constexpr auto default_user_agent = "Mozilla/5.0 (" OS_STRING "; " CPU_STRING ") LibWeb+LibJS/1.0 " BROWSER_NAME "/" BROWSER_VERSION ""sv;
+constexpr auto default_user_agent = "Mozilla/5.0 (" OS_STRING "; " CPU_STRING ") " BROWSER_NAME "/" BROWSER_VERSION ""sv;
 constexpr auto default_platform = OS_STRING " " CPU_STRING ""sv;
 
 class ResourceLoaderConnectorRequest : public RefCounted<ResourceLoaderConnectorRequest> {


### PR DESCRIPTION
As it turns out, there are popular User-Agent blacklists out there with the string "LibWeb" in them. Such entries have been added long before our LibWeb existed, so "LibWeb" has presumably been used by some bot that people got tired of.

Trying to chase down everyone who has installed these blacklists is obviously a losing battle, so this patch simply removes the engine part of our default UA string.