### PR TITLE
LibWeb: Apply the color for inset and outset border styles

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/HTMLTableElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableElement.cpp
@@ -75,15 +75,16 @@ void HTMLTableElement::apply_presentational_hints(CSS::StyleProperties& style) c
             auto border = parse_border(value);
             if (!border)
                 return;
-            auto apply_border_style = [&](CSS::PropertyID style_property, CSS::PropertyID width_property) {
+            auto apply_border_style = [&](CSS::PropertyID style_property, CSS::PropertyID width_property, CSS::PropertyID color_property) {
                 auto legacy_line_style = CSS::IdentifierStyleValue::create(CSS::ValueID::Outset);
                 style.set_property(style_property, legacy_line_style);
                 style.set_property(width_property, CSS::LengthStyleValue::create(CSS::Length::make_px(border)));
+                style.set_property(color_property, CSS::ColorStyleValue::create(Color(128, 128, 128)));
             };
-            apply_border_style(CSS::PropertyID::BorderLeftStyle, CSS::PropertyID::BorderLeftWidth);
-            apply_border_style(CSS::PropertyID::BorderTopStyle, CSS::PropertyID::BorderTopWidth);
-            apply_border_style(CSS::PropertyID::BorderRightStyle, CSS::PropertyID::BorderRightWidth);
-            apply_border_style(CSS::PropertyID::BorderBottomStyle, CSS::PropertyID::BorderBottomWidth);
+            apply_border_style(CSS::PropertyID::BorderLeftStyle, CSS::PropertyID::BorderLeftWidth, CSS::PropertyID::BorderLeftColor);
+            apply_border_style(CSS::PropertyID::BorderTopStyle, CSS::PropertyID::BorderTopWidth, CSS::PropertyID::BorderTopColor);
+            apply_border_style(CSS::PropertyID::BorderRightStyle, CSS::PropertyID::BorderRightWidth, CSS::PropertyID::BorderRightColor);
+            apply_border_style(CSS::PropertyID::BorderBottomStyle, CSS::PropertyID::BorderBottomWidth, CSS::PropertyID::BorderBottomColor);
         }
     });
 }

--- a/Userland/Libraries/LibWeb/Painting/BorderPainting.cpp
+++ b/Userland/Libraries/LibWeb/Painting/BorderPainting.cpp
@@ -57,6 +57,24 @@ BorderRadiiData normalized_border_radii_data(Layout::Node const& node, CSSPixelR
     return BorderRadiiData { top_left_radius_px, top_right_radius_px, bottom_right_radius_px, bottom_left_radius_px };
 }
 
+static constexpr double dark_light_absolute_value_difference = 1. / 3;
+
+static Color light_color_for_inset_and_outset(Color const& color)
+{
+    auto hsv = color.to_hsv();
+    if (hsv.value >= dark_light_absolute_value_difference)
+        return Color::from_hsv(hsv);
+    return Color::from_hsv({ hsv.hue, hsv.saturation, hsv.value + dark_light_absolute_value_difference });
+}
+
+static Color dark_color_for_inset_and_outset(Color const& color)
+{
+    auto hsv = color.to_hsv();
+    if (hsv.value < dark_light_absolute_value_difference)
+        return Color::from_hsv(hsv);
+    return Color::from_hsv({ hsv.hue, hsv.saturation, hsv.value - dark_light_absolute_value_difference });
+}
+
 Gfx::Color border_color(BorderEdge edge, BordersData const& borders_data)
 {
     auto const& border_data = [&] {
@@ -75,12 +93,12 @@ Gfx::Color border_color(BorderEdge edge, BordersData const& borders_data)
     }();
 
     if (border_data.line_style == CSS::LineStyle::Inset) {
-        auto top_left_color = Color::from_rgb(0x5a5a5a);
-        auto bottom_right_color = Color::from_rgb(0x888888);
+        auto top_left_color = dark_color_for_inset_and_outset(border_data.color);
+        auto bottom_right_color = light_color_for_inset_and_outset(border_data.color);
         return (edge == BorderEdge::Left || edge == BorderEdge::Top) ? top_left_color : bottom_right_color;
     } else if (border_data.line_style == CSS::LineStyle::Outset) {
-        auto top_left_color = Color::from_rgb(0x888888);
-        auto bottom_right_color = Color::from_rgb(0x5a5a5a);
+        auto top_left_color = light_color_for_inset_and_outset(border_data.color);
+        auto bottom_right_color = dark_color_for_inset_and_outset(border_data.color);
         return (edge == BorderEdge::Left || edge == BorderEdge::Top) ? top_left_color : bottom_right_color;
     }
 


### PR DESCRIPTION
There's no specification for what the dark and light colors should be, match the behavior of other browsers instead.