### PR TITLE
LibWeb: Adjust ref-tests to reduce flakiness

### DIFF
--- a/Tests/LibWeb/Ref/grid-items-painting-order-ref.html
+++ b/Tests/LibWeb/Ref/grid-items-painting-order-ref.html
@@ -1,7 +1,7 @@
 <!doctype html><style type="text/css">
-* { outline: 1px solid black; }
 body { display: grid; }
 .bar {
+    outline: 1px solid black;
     grid-area: 1 / 1 / auto / auto;
     background: orange;
 }

--- a/Tests/LibWeb/Ref/grid-items-painting-order.html
+++ b/Tests/LibWeb/Ref/grid-items-painting-order.html
@@ -1,11 +1,11 @@
 <!doctype html><style type="text/css">
-* { outline: 1px solid black; }
 body { display: grid; }
 .foo {
     grid-area: 1 / 1 / auto / auto;
     background: pink;
 }
 .bar {
+    outline: 1px solid black;
     grid-area: 1 / 1 / auto / auto;
     background: orange;
 }

--- a/Tests/LibWeb/Ref/item-with-negative-z-index-ref.html
+++ b/Tests/LibWeb/Ref/item-with-negative-z-index-ref.html
@@ -1,7 +1,7 @@
 <!doctype html><style type="text/css">
-* { outline: 1px solid black; }
 body { display: grid; }
 .foo {
+    outline: 1px solid black;
     grid-area: 1 / 1 / auto / auto;
     background: pink;
 }

--- a/Tests/LibWeb/Ref/item-with-negative-z-index.html
+++ b/Tests/LibWeb/Ref/item-with-negative-z-index.html
@@ -1,7 +1,7 @@
 <!doctype html><style type="text/css">
-* { outline: 1px solid black; }
 body { display: grid; }
 .foo {
+    outline: 1px solid black;
     grid-area: 1 / 1 / auto / auto;
     background: pink;
 }


### PR DESCRIPTION
These two ref-tests involve two boxes positioned in the same place, with outlines. Outlines always have a border-radius, meaning that the corner pixels are not 100% opaque. (It seems to be 254 instead of 255.) With the test files painting two outlines, and the ref test only painting one, slight changes in the background color of the page would make that slight variation visible sometimes. So, let's avoid that inconsistency by always painting one outline instead of two.