### PR TITLE
LibGfx+LibWeb: Avoid looping through every system font repeatedly during CSS font fallback

### DIFF
--- a/Userland/Libraries/LibGfx/Font/FontDatabase.cpp
+++ b/Userland/Libraries/LibGfx/Font/FontDatabase.cpp
@@ -260,4 +260,13 @@ void FontDatabase::for_each_typeface(Function<void(Typeface const&)> callback)
     }
 }
 
+void FontDatabase::for_each_typeface_with_family_name(String const& family_name, Function<void(Typeface const&)> callback)
+{
+    auto it = m_private->typefaces.find(family_name.bytes_as_string_view());
+    if (it == m_private->typefaces.end())
+        return;
+    for (auto const& typeface : it->value)
+        callback(*typeface);
+}
+
 }

--- a/Userland/Libraries/LibGfx/Font/FontDatabase.h
+++ b/Userland/Libraries/LibGfx/Font/FontDatabase.h
@@ -55,6 +55,7 @@ public:
     void for_each_fixed_width_font(Function<void(Gfx::Font const&)>);
 
     void for_each_typeface(Function<void(Typeface const&)>);
+    void for_each_typeface_with_family_name(String const& family_name, Function<void(Typeface const&)>);
 
     void load_all_fonts_from_path(DeprecatedString const&);
 

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -2077,16 +2077,14 @@ RefPtr<Gfx::Font const> StyleComputer::font_matching_algorithm(FontFaceKey const
         if (font_key_and_loader.key.family_name.equals_ignoring_ascii_case(key.family_name))
             matching_family_fonts.empend(font_key_and_loader.key, font_key_and_loader.value.ptr());
     }
-    Gfx::FontDatabase::the().for_each_typeface([&](Gfx::Typeface const& typeface) {
-        if (typeface.family().equals_ignoring_ascii_case(key.family_name)) {
-            matching_family_fonts.empend(
-                FontFaceKey {
-                    .family_name = MUST(FlyString::from_deprecated_fly_string(typeface.family())),
-                    .weight = static_cast<int>(typeface.weight()),
-                    .slope = typeface.slope(),
-                },
-                &typeface);
-        }
+    Gfx::FontDatabase::the().for_each_typeface_with_family_name(key.family_name.to_string(), [&](Gfx::Typeface const& typeface) {
+        matching_family_fonts.empend(
+            FontFaceKey {
+                .family_name = MUST(FlyString::from_deprecated_fly_string(typeface.family())),
+                .weight = static_cast<int>(typeface.weight()),
+                .slope = typeface.slope(),
+            },
+            &typeface);
     });
     quick_sort(matching_family_fonts, [](auto const& a, auto const& b) {
         return a.key.weight < b.key.weight;


### PR DESCRIPTION
See individual commits for details.

Fixes a performance regression from 69a81243f5a602e5994258bc10af132f008d5858.