### PR TITLE
LibWeb: When growing or shrinking a border-radius, ignore it if it's 0

### DIFF
--- a/Userland/Libraries/LibWeb/Painting/BorderPainting.h
+++ b/Userland/Libraries/LibWeb/Painting/BorderPainting.h
@@ -33,8 +33,10 @@ struct BorderRadiusData {
 
     inline void shrink(CSSPixels horizontal, CSSPixels vertical)
     {
-        horizontal_radius = max(CSSPixels(0), horizontal_radius - horizontal);
-        vertical_radius = max(CSSPixels(0), vertical_radius - vertical);
+        if (horizontal_radius != 0)
+            horizontal_radius = max(CSSPixels(0), horizontal_radius - horizontal);
+        if (vertical_radius != 0)
+            vertical_radius = max(CSSPixels(0), vertical_radius - vertical);
     }
 };
 


### PR DESCRIPTION
This function is used to calculate a matching radius that goes inside or outside of the border. For example, if the border-radius is 10px and we are 5px further out, the radius needs to be 15px to look right. However, if the radius is 0 it isn't rounded, and we want to keep the same sharp corner no matter how far we go.

This makes our outline rendering better match Chrome and Firefox.