### PR TITLE
LibCore: Don't include sys/sysctl.h on Solaris

### DIFF
--- a/Userland/Libraries/LibCore/Process.cpp
+++ b/Userland/Libraries/LibCore/Process.cpp
@@ -20,7 +20,7 @@
 #if defined(AK_OS_SERENITY)
 #    include <serenity.h>
 #    include <syscall.h>
-#elif defined(AK_OS_BSD_GENERIC)
+#elif defined(AK_OS_BSD_GENERIC) && !defined(AK_OS_SOLARIS)
 #    include <sys/sysctl.h>
 #endif
 

--- a/Userland/Libraries/LibCore/System.cpp
+++ b/Userland/Libraries/LibCore/System.cpp
@@ -50,7 +50,7 @@ static int memfd_create(char const* name, unsigned int flags)
 extern char** environ;
 #endif
 
-#if defined(AK_OS_BSD_GENERIC)
+#if defined(AK_OS_BSD_GENERIC) && !defined(AK_OS_SOLARIS)
 #    include <sys/sysctl.h>
 #endif
 


### PR DESCRIPTION
Solaris doesn't support the sysctl command and doesn't have a sys/syctl.h header file,which seems to be common on other Unix variants.
Trying to include this file for AK_OS_BSD_GENERIC makes the build fail on Solaris currently.
The current_executable_path function in System.cpp is already implemented in a way that doesn't need sysctl on Solaris.
The is_being_debugged function in Process.cpp is not yet implemented for Solaris,but will have to be done in a non-sysctl way as that simply doesn't exist on Solaris.