### PR TITLE
LibWeb: Invalidate font cache when web fonts are downloaded

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -2794,8 +2794,9 @@ CSSPixelRect StyleComputer::viewport_rect() const
     return {};
 }
 
-void StyleComputer::did_load_font([[maybe_unused]] FlyString const& family_name)
+void StyleComputer::did_load_font(FlyString const& family_name)
 {
+    m_font_cache.did_load_font({}, family_name);
     document().invalidate_style();
 }
 

--- a/Userland/Libraries/LibWeb/FontCache.cpp
+++ b/Userland/Libraries/LibWeb/FontCache.cpp
@@ -8,6 +8,8 @@
 #include <LibGfx/Font/Font.h>
 #include <LibWeb/FontCache.h>
 
+namespace Web {
+
 RefPtr<Gfx::Font const> FontCache::get(FontSelector const& font_selector) const
 {
     auto cached_font = m_fonts.get(font_selector);
@@ -35,4 +37,6 @@ NonnullRefPtr<Gfx::Font const> FontCache::scaled_font(Gfx::Font const& font, flo
 void FontCache::set(FontSelector const& font_selector, NonnullRefPtr<Gfx::Font const> font)
 {
     m_fonts.set(font_selector, move(font));
+}
+
 }

--- a/Userland/Libraries/LibWeb/FontCache.cpp
+++ b/Userland/Libraries/LibWeb/FontCache.cpp
@@ -39,4 +39,11 @@ void FontCache::set(FontSelector const& font_selector, NonnullRefPtr<Gfx::Font c
     m_fonts.set(font_selector, move(font));
 }
 
+void FontCache::did_load_font(Badge<CSS::StyleComputer>, FlyString const& family_name)
+{
+    m_fonts.remove_all_matching([&family_name](auto& key, auto&) -> bool {
+        return key.family == family_name;
+    });
+}
+
 }

--- a/Userland/Libraries/LibWeb/FontCache.h
+++ b/Userland/Libraries/LibWeb/FontCache.h
@@ -35,6 +35,8 @@ public:
 
     NonnullRefPtr<Gfx::Font const> scaled_font(Gfx::Font const&, float scale_factor);
 
+    void did_load_font(Badge<CSS::StyleComputer>, FlyString const& family_name);
+
 private:
     mutable HashMap<FontSelector, NonnullRefPtr<Gfx::Font const>> m_fonts;
 };

--- a/Userland/Libraries/LibWeb/FontCache.h
+++ b/Userland/Libraries/LibWeb/FontCache.h
@@ -10,6 +10,9 @@
 #include <AK/HashMap.h>
 #include <LibGfx/Font/Font.h>
 #include <LibGfx/Forward.h>
+#include <LibWeb/Forward.h>
+
+namespace Web {
 
 struct FontSelector {
     FlyString family;
@@ -24,13 +27,6 @@ struct FontSelector {
     }
 };
 
-namespace AK {
-template<>
-struct Traits<FontSelector> : public GenericTraits<FontSelector> {
-    static unsigned hash(FontSelector const& key) { return pair_int_hash(pair_int_hash(key.family.hash(), key.weight), key.point_size); }
-};
-}
-
 class FontCache {
 public:
     FontCache() = default;
@@ -42,3 +38,12 @@ public:
 private:
     mutable HashMap<FontSelector, NonnullRefPtr<Gfx::Font const>> m_fonts;
 };
+
+}
+
+namespace AK {
+template<>
+struct Traits<Web::FontSelector> : public GenericTraits<Web::FontSelector> {
+    static unsigned hash(Web::FontSelector const& key) { return pair_int_hash(pair_int_hash(key.family.hash(), key.weight), key.point_size); }
+};
+}


### PR DESCRIPTION
In case we've looked up the family name before and cached the result of font fallback, we now invalidate any cached entries with the same family name so that the next lookup may consider the newly downloaded font.
