### PR TITLE
LibWeb: Comment out invalid `display-outside` rules from Default.css

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Default.css
+++ b/Userland/Libraries/LibWeb/CSS/Default.css
@@ -290,18 +290,24 @@ q::after {
     content: close-quote;
 }
 
+/*
+NOTE: This isn't a real property and value. See https://github.com/whatwg/html/issues/2291
 br {
     display-outside: newline;
 }
+*/
 
 /* this also has bidi implications */
 nobr {
     white-space: nowrap;
 }
 
+/*
+NOTE: This isn't a real property and value. See https://github.com/whatwg/html/issues/2291
 wbr {
     display-outside: break-opportunity;
 }
+*/
 
 /* this also has bidi implications */
 nobr wbr {


### PR DESCRIPTION
This property was removed from the CSS specs, and efforts to correct the HTML spec have stalled. For now, let's comment them out so that I don't get spammed with the meaningless log warnings that they didn't parse, every time I launch Ladybird. :^)