### PR TITLE
LibWeb: A couple of HTMLTokenizerFixes

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.h
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.h
@@ -247,6 +247,13 @@ public:
 
     StringView attribute(DeprecatedFlyString const& attribute_name) const
     {
+        if (auto result = raw_attribute(attribute_name); result.has_value())
+            return result->value;
+        return {};
+    }
+
+    Optional<Attribute const&> raw_attribute(DeprecatedFlyString const& attribute_name) const
+    {
         VERIFY(is_start_tag() || is_end_tag());
 
         auto* ptr = tag_attributes();
@@ -254,7 +261,7 @@ public:
             return {};
         for (auto& attribute : *ptr) {
             if (attribute_name == attribute.local_name)
-                return attribute.value;
+                return attribute;
         }
         return {};
     }

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
@@ -347,7 +347,6 @@ _StartOfFunction:
                 ON('>')
                 {
                     m_current_token.set_tag_name(consume_current_builder());
-                    m_current_token.set_end_position({}, nth_last_position(1));
                     SWITCH_TO_AND_EMIT_CURRENT_TOKEN(Data);
                 }
                 ON_ASCII_UPPER_ALPHA
@@ -366,7 +365,6 @@ _StartOfFunction:
                 ON_EOF
                 {
                     log_parse_error();
-                    m_current_token.set_end_position({}, nth_last_position(0));
                     EMIT_EOF;
                 }
                 ANYTHING_ELSE
@@ -2773,19 +2771,9 @@ bool HTMLTokenizer::consume_next_if_match(StringView string, CaseSensitivity cas
 void HTMLTokenizer::create_new_token(HTMLToken::Type type)
 {
     m_current_token = { type };
-    size_t offset = 0;
-    switch (type) {
-    case HTMLToken::Type::StartTag:
-        offset = 1;
-        break;
-    case HTMLToken::Type::EndTag:
-        offset = 2;
-        break;
-    default:
-        break;
-    }
 
-    m_current_token.set_start_position({}, nth_last_position(offset));
+    auto is_start_or_end_tag = type == HTMLToken::Type::StartTag || type == HTMLToken::Type::EndTag;
+    m_current_token.set_start_position({}, nth_last_position(is_start_or_end_tag ? 1 : 0));
 }
 
 HTMLTokenizer::HTMLTokenizer()
@@ -2855,7 +2843,9 @@ void HTMLTokenizer::will_emit(HTMLToken& token)
 {
     if (token.is_start_tag())
         m_last_emitted_start_tag_name = token.tag_name();
-    token.set_end_position({}, nth_last_position(0));
+
+    auto is_start_or_end_tag = token.type() == HTMLToken::Type::StartTag || token.type() == HTMLToken::Type::EndTag;
+    token.set_end_position({}, nth_last_position(is_start_or_end_tag ? 1 : 0));
 }
 
 bool HTMLTokenizer::current_end_tag_token_is_appropriate() const

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
@@ -1051,8 +1051,6 @@ _StartOfFunction:
                 }
                 ON('/')
                 {
-                    if (m_current_token.has_attributes())
-                        m_current_token.last_attribute().name_end_position = nth_last_position(1);
                     RECONSUME_IN(AfterAttributeName);
                 }
                 ON('>')
@@ -1108,21 +1106,25 @@ _StartOfFunction:
             {
                 ON_WHITESPACE
                 {
+                    m_current_token.last_attribute().name_end_position = nth_last_position(1);
                     m_current_token.last_attribute().local_name = consume_current_builder();
                     RECONSUME_IN(AfterAttributeName);
                 }
                 ON('/')
                 {
+                    m_current_token.last_attribute().name_end_position = nth_last_position(1);
                     m_current_token.last_attribute().local_name = consume_current_builder();
                     RECONSUME_IN(AfterAttributeName);
                 }
                 ON('>')
                 {
+                    m_current_token.last_attribute().name_end_position = nth_last_position(1);
                     m_current_token.last_attribute().local_name = consume_current_builder();
                     RECONSUME_IN(AfterAttributeName);
                 }
                 ON_EOF
                 {
+                    m_current_token.last_attribute().name_end_position = nth_last_position(1);
                     m_current_token.last_attribute().local_name = consume_current_builder();
                     RECONSUME_IN(AfterAttributeName);
                 }
@@ -1196,7 +1198,7 @@ _StartOfFunction:
                 {
                     m_current_token.add_attribute({});
                     if (!m_source_positions.is_empty())
-                        m_current_token.last_attribute().name_start_position = m_source_positions.last();
+                        m_current_token.last_attribute().name_start_position = nth_last_position(1);
                     RECONSUME_IN(AttributeName);
                 }
             }

--- a/Userland/Libraries/LibWeb/HTML/SyntaxHighlighter/SyntaxHighlighter.cpp
+++ b/Userland/Libraries/LibWeb/HTML/SyntaxHighlighter/SyntaxHighlighter.cpp
@@ -132,8 +132,6 @@ void SyntaxHighlighter::rehighlight(Palette const& palette)
             continue;
         }
 
-        size_t token_start_offset = token->is_end_tag() ? 1 : 0;
-
         if (token->is_comment()) {
             highlight(
                 token->start_position().line,
@@ -150,25 +148,25 @@ void SyntaxHighlighter::rehighlight(Palette const& palette)
         } else if (token->is_start_tag() || token->is_end_tag()) {
             highlight(
                 token->start_position().line,
-                token->start_position().column + token_start_offset,
+                token->start_position().column,
                 token->start_position().line,
-                token->start_position().column + token_start_offset + token->tag_name().length(),
+                token->start_position().column + token->tag_name().length(),
                 { palette.syntax_keyword(), {}, true },
                 token->is_start_tag() ? AugmentedTokenKind::OpenTag : AugmentedTokenKind::CloseTag);
 
             token->for_each_attribute([&](auto& attribute) {
                 highlight(
                     attribute.name_start_position.line,
-                    attribute.name_start_position.column + token_start_offset,
+                    attribute.name_start_position.column,
                     attribute.name_end_position.line,
-                    attribute.name_end_position.column + token_start_offset,
+                    attribute.name_end_position.column,
                     { palette.syntax_identifier(), {} },
                     AugmentedTokenKind::AttributeName);
                 highlight(
                     attribute.value_start_position.line,
-                    attribute.value_start_position.column + token_start_offset,
+                    attribute.value_start_position.column,
                     attribute.value_end_position.line,
-                    attribute.value_end_position.column + token_start_offset,
+                    attribute.value_end_position.column,
                     { palette.syntax_string(), {} },
                     AugmentedTokenKind::AttributeValue);
                 return IterationDecision::Continue;


### PR DESCRIPTION
The details are in the commit messages, but a couple are easy to see with a theme that shows attributes/values clearly.

For example, in this self-closing `meta` tag, the attribute name `charset` (colored green) captures the attribute value as well:
![self-closing-before](https://github.com/SerenityOS/serenity/assets/5600524/2f335b20-e739-4d5e-8bd2-08ef93ef326f)

Now we properly set the attribute name's end position to not consume the attribute value:
![self-closing-after](https://github.com/SerenityOS/serenity/assets/5600524/dd56b433-732f-44f0-beff-92d5df87a56d)

Another example: Previously, we didn't highlight valueless attributes at all, and were off-by-one on the attribute name of any subsequent attribute:
![no-value-before](https://github.com/SerenityOS/serenity/assets/5600524/bd2fee37-a196-4148-a041-957c9d902411)

Now we detect the valueless attribute correctly:
![no-value-after](https://github.com/SerenityOS/serenity/assets/5600524/6ae3895a-50cc-4c8d-bd42-74a590429b56)

