### PR TITLE
LibWeb: Implement navigation.navigate()

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -528,6 +528,8 @@ public:
     using IndicatedPart = Variant<Element*, TopOfTheDocument>;
     IndicatedPart determine_the_indicated_part() const;
 
+    u32 unload_counter() const { return m_unload_counter; }
+
 protected:
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;

--- a/Userland/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Navigable.cpp
@@ -1113,4 +1113,10 @@ void Navigable::reload()
     });
 }
 
+// https://html.spec.whatwg.org/multipage/browsing-the-web.html#the-navigation-must-be-a-replace
+bool navigation_must_be_a_replace(AK::URL const& url, DOM::Document const& document)
+{
+    return url.scheme() == "javascript"sv || document.is_initial_about_blank();
+}
+
 }

--- a/Userland/Libraries/LibWeb/HTML/Navigable.h
+++ b/Userland/Libraries/LibWeb/HTML/Navigable.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <AK/String.h>
 #include <LibJS/Heap/Cell.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/HTML/ActivateTab.h>
@@ -134,5 +135,7 @@ private:
     // Implied link between navigable and its container.
     JS::GCPtr<NavigableContainer> m_container;
 };
+
+bool navigation_must_be_a_replace(AK::URL const& url, DOM::Document const& document);
 
 }

--- a/Userland/Libraries/LibWeb/HTML/NavigateEvent.h
+++ b/Userland/Libraries/LibWeb/HTML/NavigateEvent.h
@@ -23,7 +23,7 @@ struct NavigateEventInit : public DOM::EventInit {
     JS::GCPtr<DOM::AbortSignal> signal;
     JS::GCPtr<XHR::FormData> form_data = nullptr;
     Optional<String> download_request = {};
-    JS::Value info;
+    Optional<JS::Value> info;
     bool has_ua_visual_transition = false;
 };
 
@@ -33,8 +33,8 @@ using NavigationInterceptHandler = JS::NonnullGCPtr<WebIDL::CallbackType>;
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#navigationinterceptoptions
 struct NavigationInterceptOptions {
     JS::GCPtr<WebIDL::CallbackType> handler;
-    Bindings::NavigationFocusReset focus_reset;
-    Bindings::NavigationScrollBehavior scroll;
+    Optional<Bindings::NavigationFocusReset> focus_reset;
+    Optional<Bindings::NavigationScrollBehavior> scroll;
 };
 
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#navigateevent
@@ -57,7 +57,7 @@ public:
     JS::Value info() const { return m_info; }
     bool has_ua_visual_transition() const { return m_has_ua_visual_transition; }
 
-    WebIDL::ExceptionOr<void> intercept(Optional<NavigationInterceptOptions> const& = {});
+    WebIDL::ExceptionOr<void> intercept(NavigationInterceptOptions const&);
     WebIDL::ExceptionOr<void> scroll();
 
     virtual ~NavigateEvent() override;

--- a/Userland/Libraries/LibWeb/HTML/Navigation.idl
+++ b/Userland/Libraries/LibWeb/HTML/Navigation.idl
@@ -4,7 +4,7 @@
 #import <HTML/NavigationTransition.idl>
 
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#navigation-interface
-[Exposed=Window]
+[Exposed=Window, UseNewAKString]
 interface Navigation : EventTarget {
   sequence<NavigationHistoryEntry> entries();
   readonly attribute NavigationHistoryEntry? currentEntry;
@@ -15,7 +15,7 @@ interface Navigation : EventTarget {
   readonly attribute boolean canGoForward;
 
   // TODO: Actually implement navigation algorithms
-  // NavigationResult navigate(USVString url, optional NavigationNavigateOptions options = {});
+  NavigationResult navigate(USVString url, optional NavigationNavigateOptions options = {});
   // NavigationResult reload(optional NavigationReloadOptions options = {});
 
   // NavigationResult traverseTo(DOMString key, optional NavigationOptions options = {});


### PR DESCRIPTION
First, fixup Navigate event. Every property in an IDL dictionary is implied to be optional, unless it
is marked as required. If a dictionary is passed to a method with
optional, but it has at least one required or defaulted member, the
bindings will skip the optionality of the parameter and always pass a
struct with the required parameters filled in.

Next, onto navigation.navigate()

The implementation is incomplete, because our Navigable::navigate
implementation is missing the navigationAPIState parameter.

It also cannot actually be called without crashing the browser, because
Navigables are not fully hooked up yet to all navigation. The node
navigable for most documents is nullptr, which breaks an assumption in
the algorithm.