### PR TITLE
Browser: Do not visualize trailing whitespace in the source viewer

### DIFF
--- a/Userland/Applications/Browser/Tab.cpp
+++ b/Userland/Applications/Browser/Tab.cpp
@@ -83,6 +83,7 @@ void Tab::view_source(const URL& url, DeprecatedString const& source)
     editor->set_mode(GUI::TextEditor::ReadOnly);
     editor->set_syntax_highlighter(make<Web::HTML::SyntaxHighlighter>());
     editor->set_ruler_visible(true);
+    editor->set_visualize_trailing_whitespace(false);
     window->resize(640, 480);
     window->set_title(url.to_deprecated_string());
     window->set_icon(g_icon_bag.filetype_text);


### PR DESCRIPTION
Trailing whitespace in the source view is not actionable, so there's no benefit to showing it.

See here:
![before](https://github.com/SerenityOS/serenity/assets/5600524/fec557d9-a73a-4cad-ad85-e9fbd08e42c7)

Now:
![after](https://github.com/SerenityOS/serenity/assets/5600524/d84365c3-70fa-4201-8d96-06aba27fa402)
