### PR TITLE
LibWeb: Fix border-radius shrink algorithm for zero sized boxes (and avoid errors in CSSPixels assignment ops, *=, /=, +=, -=)

### DIFF
--- a/Tests/LibWeb/Layout/expected/table/sum-of-percentage-column-widths-less-than-100.txt
+++ b/Tests/LibWeb/Layout/expected/table/sum-of-percentage-column-widths-less-than-100.txt
@@ -5,27 +5,27 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         Box <table> at (9,9) content-size 92x25.46875 table-box [TFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tbody> at (9,9) content-size 84.015625x21.46875 table-row-group children: not-inline
-            Box <tr> at (11,11) content-size 84.015625x21.46875 table-row children: not-inline
+          Box <tbody> at (9,9) content-size 83.984375x21.46875 table-row-group children: not-inline
+            Box <tr> at (11,11) content-size 83.984375x21.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (13,13) content-size 18.109375x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (13,13) content-size 18.09375x17.46875 table-cell [BFC] children: inline
                 line 0 width: 14.265625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
                   frag 0 from TextNode start: 0, length: 1, rect: [13,13 14.265625x17.46875]
                     "A"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (37.109375,13) content-size 37.265625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (37.09375,13) content-size 37.265625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [37.109375,13 9.34375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [37.09375,13 9.34375x17.46875]
                     "B"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (80.375,13) content-size 16.640625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (80.359375,13) content-size 16.625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 10.3125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [80.375,13 10.3125x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [80.359375,13 10.3125x17.46875]
                     "C"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -38,11 +38,11 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x27.46875]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 94x27.46875]
         PaintableBox (Box<TABLE>) [8,8 94x27.46875]
-          PaintableBox (Box<TBODY>) [9,9 84.015625x21.46875] overflow: [9,9 90.015625x23.46875]
-            PaintableBox (Box<TR>) [11,11 84.015625x21.46875] overflow: [11,11 88.015625x21.46875]
-              PaintableWithLines (BlockContainer<TD>) [11,11 22.109375x21.46875]
+          PaintableBox (Box<TBODY>) [9,9 83.984375x21.46875] overflow: [9,9 89.984375x23.46875]
+            PaintableBox (Box<TR>) [11,11 83.984375x21.46875] overflow: [11,11 87.984375x21.46875]
+              PaintableWithLines (BlockContainer<TD>) [11,11 22.09375x21.46875]
                 TextPaintable (TextNode<#text>)
-              PaintableWithLines (BlockContainer<TD>) [35.109375,11 41.265625x21.46875]
+              PaintableWithLines (BlockContainer<TD>) [35.09375,11 41.265625x21.46875]
                 TextPaintable (TextNode<#text>)
-              PaintableWithLines (BlockContainer<TD>) [78.375,11 20.640625x21.46875]
+              PaintableWithLines (BlockContainer<TD>) [78.359375,11 20.625x21.46875]
                 TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Ref/border-radius-shrink-zero-sized-box-ref.html
+++ b/Tests/LibWeb/Ref/border-radius-shrink-zero-sized-box-ref.html
@@ -1,0 +1,1 @@
+<!-- This page is intentionally left blank. -->

--- a/Tests/LibWeb/Ref/border-radius-shrink-zero-sized-box.html
+++ b/Tests/LibWeb/Ref/border-radius-shrink-zero-sized-box.html
@@ -1,0 +1,10 @@
+<style>
+  #test {
+    background-color: red;
+    border-radius: 10px;
+    width: 0px;
+    height: 0px;
+  }
+</style>
+<div id="test">
+</div>

--- a/Tests/LibWeb/Ref/manifest.json
+++ b/Tests/LibWeb/Ref/manifest.json
@@ -15,5 +15,6 @@
     "css-read-only-read-write-selectors.html": "css-read-only-read-write-selectors-ref.html",
     "svg-symbol.html": "svg-symbol-ref.html",
     "svg-gradient-spreadMethod.html": "svg-gradient-spreadMethod-ref.html",
-    "svg-radialGradient.html": "svg-radialGradient-ref.html"
+    "svg-radialGradient.html": "svg-radialGradient-ref.html",
+    "border-radius-shrink-zero-sized-box.html": "border-radius-shrink-zero-sized-box-ref.html"
 }

--- a/Userland/Libraries/LibWeb/Painting/BorderPainting.cpp
+++ b/Userland/Libraries/LibWeb/Painting/BorderPainting.cpp
@@ -35,24 +35,34 @@ BorderRadiiData normalized_border_radii_data(Layout::Node const& node, CSSPixelR
     top_right_radius_px.vertical_radius = top_right_radius.vertical_radius.to_px(node, rect.height());
 
     // Scale overlapping curves according to https://www.w3.org/TR/css-backgrounds-3/#corner-overlap
-    CSSPixels f = 1;
-    if (rect.width() > 0) {
-        f = max(f, (top_left_radius_px.horizontal_radius + top_right_radius_px.horizontal_radius) / rect.width());
-        f = max(f, (bottom_left_radius_px.horizontal_radius + bottom_right_radius_px.horizontal_radius) / rect.width());
-    }
-    if (rect.height() > 0) {
-        f = max(f, (top_right_radius_px.vertical_radius + bottom_right_radius_px.vertical_radius) / rect.height());
-        f = max(f, (top_left_radius_px.vertical_radius + bottom_left_radius_px.vertical_radius) / rect.height());
-    }
+    // Let f = min(Li/Si), where i ∈ {top, right, bottom, left},
+    // Si is the sum of the two corresponding radii of the corners on side i,
+    // and Ltop = Lbottom = the width of the box, and Lleft = Lright = the height of the box.
+    auto l_top = rect.width().to_float();
+    auto l_bottom = l_top;
+    auto l_left = rect.height().to_float();
+    auto l_right = l_left;
+    auto s_top = (top_left_radius_px.horizontal_radius + top_right_radius_px.horizontal_radius).to_float();
+    auto s_right = (top_right_radius_px.vertical_radius + bottom_right_radius_px.vertical_radius).to_float();
+    auto s_bottom = (bottom_left_radius_px.horizontal_radius + bottom_right_radius_px.horizontal_radius).to_float();
+    auto s_left = (top_left_radius_px.vertical_radius + bottom_left_radius_px.vertical_radius).to_float();
+    float f = 1;
+    f = min(f, l_top / s_top);
+    f = min(f, l_right / s_right);
+    f = min(f, l_bottom / s_bottom);
+    f = min(f, l_left / s_left);
 
-    top_left_radius_px.horizontal_radius /= f;
-    top_left_radius_px.vertical_radius /= f;
-    top_right_radius_px.horizontal_radius /= f;
-    top_right_radius_px.vertical_radius /= f;
-    bottom_right_radius_px.horizontal_radius /= f;
-    bottom_right_radius_px.vertical_radius /= f;
-    bottom_left_radius_px.horizontal_radius /= f;
-    bottom_left_radius_px.vertical_radius /= f;
+    // If f < 1, then all corner radii are reduced by multiplying them by f.
+    if (f < 1) {
+        top_left_radius_px.horizontal_radius *= f;
+        top_left_radius_px.vertical_radius *= f;
+        top_right_radius_px.horizontal_radius *= f;
+        top_right_radius_px.vertical_radius *= f;
+        bottom_right_radius_px.horizontal_radius *= f;
+        bottom_right_radius_px.vertical_radius *= f;
+        bottom_left_radius_px.horizontal_radius *= f;
+        bottom_left_radius_px.vertical_radius *= f;
+    }
 
     return BorderRadiiData { top_left_radius_px, top_right_radius_px, bottom_right_radius_px, bottom_left_radius_px };
 }

--- a/Userland/Libraries/LibWeb/PixelUnits.h
+++ b/Userland/Libraries/LibWeb/PixelUnits.h
@@ -248,6 +248,86 @@ constexpr CSSPixels operator/(CSSPixels left, unsigned long right) { return left
 inline float operator/(CSSPixels left, float right) { return left.to_float() / right; }
 inline double operator/(CSSPixels left, double right) { return left.to_double() / right; }
 
+inline CSSPixels& operator*=(CSSPixels& left, float right)
+{
+    left = left.to_float() * right;
+    return left;
+}
+inline CSSPixels& operator*=(CSSPixels& left, double right)
+{
+    left = left.to_double() * right;
+    return left;
+}
+
+inline CSSPixels& operator/=(CSSPixels& left, float right)
+{
+    left = left.to_float() / right;
+    return left;
+}
+inline CSSPixels& operator/=(CSSPixels& left, double right)
+{
+    left = left.to_double() / right;
+    return left;
+}
+
+inline CSSPixels& operator+=(CSSPixels& left, float right)
+{
+    left = left.to_float() + right;
+    return left;
+}
+inline CSSPixels& operator+=(CSSPixels& left, double right)
+{
+    left = left.to_double() + right;
+    return left;
+}
+
+inline CSSPixels& operator-=(CSSPixels& left, float right)
+{
+    left = left.to_float() - right;
+    return left;
+}
+inline CSSPixels& operator-=(CSSPixels& left, double right)
+{
+    left = left.to_double() - right;
+    return left;
+}
+
+constexpr CSSPixels& operator*=(CSSPixels& left, int right)
+{
+    return left *= CSSPixels(right);
+}
+constexpr CSSPixels& operator*=(CSSPixels& left, unsigned long right)
+{
+    return left *= CSSPixels(right);
+}
+
+constexpr CSSPixels& operator/=(CSSPixels& left, int right)
+{
+    return left /= CSSPixels(right);
+}
+constexpr CSSPixels& operator/=(CSSPixels& left, unsigned long right)
+{
+    return left /= CSSPixels(right);
+}
+
+constexpr CSSPixels& operator+=(CSSPixels& left, int right)
+{
+    return left += CSSPixels(right);
+}
+constexpr CSSPixels& operator+=(CSSPixels& left, unsigned long right)
+{
+    return left += CSSPixels(right);
+}
+
+constexpr CSSPixels& operator-=(CSSPixels& left, int right)
+{
+    return left -= CSSPixels(right);
+}
+constexpr CSSPixels& operator-=(CSSPixels& left, unsigned long right)
+{
+    return left -= CSSPixels(right);
+}
+
 using CSSPixelLine = Gfx::Line<CSSPixels>;
 using CSSPixelPoint = Gfx::Point<CSSPixels>;
 using CSSPixelRect = Gfx::Rect<CSSPixels>;


### PR DESCRIPTION
```
<style>
  #test {
    background-color: red;
    border-radius: 10px;
    width: 0px;
    height: 0px;
  }
</style>
<div id="test">
</div>
```
Previously, the above little test case resulted in this: 
![image](https://github.com/SerenityOS/serenity/assets/11597044/b619a922-8a02-4d9f-be86-ee59c00c9665)
As the border radii would not shrink for a zero sized box. The shrink algorithm has now been updated to exactly match the steps in the spec (which naturally handles this case).

---

I originally spotted this as it broke custom `<progress>` element styles when the position was at 0 (all these bars should be empty): 
![Screenshot from 2023-08-25 01-13-29](https://github.com/SerenityOS/serenity/assets/11597044/498dccd1-91f3-40f7-945a-58a5bc319ab0)
 
