### PR TITLE
LibWeb: Make custom fonts load on apple.com

### DIFF
--- a/Tests/LibWeb/Text/expected/css/font-face-src-local-serialization.txt
+++ b/Tests/LibWeb/Text/expected/css/font-face-src-local-serialization.txt
@@ -1,0 +1,1 @@
+@font-face { font-family: "a1"; src: local("xyz"); unicode-range: "U+0-10ffff"; }

--- a/Tests/LibWeb/Text/input/css/font-face-src-local-serialization.html
+++ b/Tests/LibWeb/Text/input/css/font-face-src-local-serialization.html
@@ -1,0 +1,10 @@
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        let style = document.createElement("style");
+        style.innerText = "@font-face { font-family: 'a1'; src: local('xyz'); }";
+        document.head.appendChild(style);
+        let sheet = style.sheet;
+        println(sheet.cssRules[0].cssText);
+    });
+</script>

--- a/Userland/Libraries/LibWeb/CSS/CSSFontFaceRule.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSFontFaceRule.cpp
@@ -62,8 +62,11 @@ DeprecatedString CSSFontFaceRule::serialized() const
 
         // 2. The result of invoking serialize a comma-separated list on performing serialize a URL or serialize a LOCAL for each source on the source list.
         serialize_a_comma_separated_list(builder, m_font_face.sources(), [&](StringBuilder& builder, FontFace::Source source) -> void {
-            // FIXME: Serialize locals once we support those
-            serialize_a_url(builder, source.url.to_deprecated_string());
+            if (source.local_or_url.has<AK::URL>()) {
+                serialize_a_url(builder, source.local_or_url.get<AK::URL>().to_deprecated_string());
+            } else {
+                builder.appendff("local({})", source.local_or_url.get<String>());
+            }
 
             // NOTE: No spec currently exists for format()
             if (source.format.has_value()) {

--- a/Userland/Libraries/LibWeb/CSS/FontFace.h
+++ b/Userland/Libraries/LibWeb/CSS/FontFace.h
@@ -16,7 +16,7 @@ namespace Web::CSS {
 class FontFace {
 public:
     struct Source {
-        AK::URL url;
+        Variant<String, AK::URL> local_or_url;
         // FIXME: Do we need to keep this around, or is it only needed to discard unwanted formats during parsing?
         Optional<FlyString> format;
     };

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -4453,7 +4453,14 @@ Vector<FontFace::Source> Parser::parse_font_face_src(TokenStream<ComponentValue>
             continue;
         }
 
-        // FIXME: Implement `local()`.
+        if (first.is_function() && first.function().name().equals_ignoring_ascii_case("local"sv)) {
+            if (first.function().values().is_empty()) {
+                continue;
+            }
+            supported_sources.empend(first.function().values().first().to_string(), Optional<FlyString> {});
+            continue;
+        }
+
         dbgln_if(CSS_PARSER_DEBUG, "CSSParser: @font-face src invalid (failed to parse url from: {}); discarding.", first.to_debug_string());
         return {};
     }

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -71,6 +71,7 @@
 #include <LibWeb/Layout/Node.h>
 #include <LibWeb/Loader/ResourceLoader.h>
 #include <LibWeb/Platform/FontPlugin.h>
+#include <LibWeb/ReferrerPolicy/AbstractOperations.h>
 #include <stdio.h>
 
 namespace AK {
@@ -148,6 +149,13 @@ private:
             return;
         LoadRequest request;
         request.set_url(m_urls.take_first());
+
+        // HACK: We're crudely computing the referer value and shoving it into the
+        //       request until fetch infrastructure is used here.
+        auto referrer_url = ReferrerPolicy::strip_url_for_use_as_referrer(m_style_computer.document().url());
+        if (referrer_url.has_value() && !request.headers().contains("Referer"))
+            request.set_header("Referer", referrer_url->serialize());
+
         set_resource(ResourceLoader::the().load_resource(Resource::Type::Generic, request));
     }
 

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -2827,7 +2827,9 @@ void StyleComputer::load_fonts_from_sheet(CSSStyleSheet const& sheet)
         Vector<AK::URL> urls;
         for (auto& source : font_face.sources()) {
             // FIXME: These should be loaded relative to the stylesheet URL instead of the document URL.
-            urls.append(m_document->parse_url(source.url.to_deprecated_string()));
+            if (source.local_or_url.has<AK::URL>())
+                urls.append(m_document->parse_url(source.local_or_url.get<AK::URL>().to_deprecated_string()));
+            // FIXME: Handle local()
         }
 
         if (urls.is_empty())

--- a/Userland/Libraries/LibWeb/Dump.cpp
+++ b/Userland/Libraries/LibWeb/Dump.cpp
@@ -654,7 +654,10 @@ void dump_font_face_rule(StringBuilder& builder, CSS::CSSFontFaceRule const& rul
     builder.append("sources:\n"sv);
     for (auto const& source : font_face.sources()) {
         indent(builder, indent_levels + 2);
-        builder.appendff("url={}, format={}\n", source.url, source.format.value_or("???"_string));
+        if (source.local_or_url.has<AK::URL>())
+            builder.appendff("url={}, format={}\n", source.local_or_url.get<AK::URL>(), source.format.value_or("???"_string));
+        else
+            builder.appendff("local={}\n", source.local_or_url.get<AK::String>());
     }
 
     indent(builder, indent_levels + 1);


### PR DESCRIPTION
There were two issues here:
- We did not include a `Referer` header with CSS font HTTP requests. This made apple.com respond with 404 (wat)
- We rejected CSS `@font-face` rules with `src: local(...), ...` which they use for what appears to be some kind of compatibility hack.

Visual progression on https://apple.com/

Before:
![apple1](https://github.com/SerenityOS/serenity/assets/5954907/2b1597b3-b95c-4d51-9970-133ece1d50e1)

After:
![apple2](https://github.com/SerenityOS/serenity/assets/5954907/f630408b-fd3c-4119-96e2-18473f9fefb9)

