### PR TITLE
LibWeb: Call process_the_iframe_attributes if iframe attribute changed

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/HTMLIFrameElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLIFrameElement.cpp
@@ -35,8 +35,8 @@ JS::GCPtr<Layout::Node> HTMLIFrameElement::create_layout_node(NonnullRefPtr<CSS:
 void HTMLIFrameElement::attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value)
 {
     HTMLElement::attribute_changed(name, value);
-    if (name == HTML::AttributeNames::src)
-        load_src(value);
+    if (m_nested_browsing_context)
+        process_the_iframe_attributes();
 }
 
 // https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element:the-iframe-element-6
@@ -107,28 +107,6 @@ void HTMLIFrameElement::removed_from(DOM::Node* node)
         m_nested_browsing_context->discard();
         m_nested_browsing_context = nullptr;
     }
-}
-
-void HTMLIFrameElement::load_src(DeprecatedString const& value)
-{
-    if (!m_nested_browsing_context)
-        return;
-
-    if (value.is_null())
-        return;
-
-    auto url = document().parse_url(value);
-    if (!url.is_valid()) {
-        dbgln("iframe failed to load URL: Invalid URL: {}", value);
-        return;
-    }
-    if (url.scheme() == "file" && document().origin().scheme() != "file") {
-        dbgln("iframe failed to load URL: Security violation: {} may not load {}", document().url(), url);
-        return;
-    }
-
-    dbgln("Loading iframe document from {}", value);
-    m_nested_browsing_context->loader().load(url, FrameLoader::Type::IFrame);
 }
 
 // https://html.spec.whatwg.org/multipage/rendering.html#attributes-for-embedded-content-and-images

--- a/Userland/Libraries/LibWeb/HTML/HTMLIFrameElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLIFrameElement.h
@@ -39,8 +39,6 @@ private:
     // https://html.spec.whatwg.org/multipage/iframe-embed-object.html#process-the-iframe-attributes
     void process_the_iframe_attributes(bool initial_insertion = false);
 
-    void load_src(DeprecatedString const&);
-
     // https://html.spec.whatwg.org/multipage/iframe-embed-object.html#current-navigation-was-lazy-loaded
     bool m_current_navigation_was_lazy_loaded { false };
 };


### PR DESCRIPTION
Replaces `load_src()` with `process_the_iframe_attributes()`. Both load document of iframe but the latter is defined in spec.