### PR TITLE
Kernel: Run clang-format on a couple of FileSystem sources

### DIFF
--- a/Kernel/FileSystem/Inode.cpp
+++ b/Kernel/FileSystem/Inode.cpp
@@ -52,7 +52,6 @@ void Inode::sync()
     if (result.is_error()) {
         // TODO: Figure out how to propagate error to a higher function.
     }
-
 }
 
 ErrorOr<NonnullRefPtr<Custody>> Inode::resolve_as_link(Credentials const& credentials, Custody& base, RefPtr<Custody>* out_parent, int options, int symlink_recursion_level) const

--- a/Kernel/FileSystem/VirtualFileSystem.cpp
+++ b/Kernel/FileSystem/VirtualFileSystem.cpp
@@ -262,7 +262,7 @@ void VirtualFileSystem::sync_filesystems()
     for (auto& fs : file_systems) {
         auto result = fs->flush_writes();
         if (result.is_error()) {
-            //TODO: Figure out how to propagate error to a higher function.
+            // TODO: Figure out how to propagate error to a higher function.
         }
     }
 }


### PR DESCRIPTION
Fixes bad formatting in commit abcf05801ad259c06197b9ef54a76e58cf319509.