### PR TITLE
Ladybird: Implement a basic View Source window for the AppKit chrome

### DIFF
--- a/Ladybird/AppKit/Application/ApplicationDelegate.h
+++ b/Ladybird/AppKit/Application/ApplicationDelegate.h
@@ -24,8 +24,8 @@
                 withCookieJar:(Browser::CookieJar)cookie_jar
       webdriverContentIPCPath:(StringView)webdriver_content_ipc_path;
 
-- (nonnull TabController*)createNewTab:(Optional<URL> const&)url;
 - (nonnull TabController*)createNewTab:(Optional<URL> const&)url
+                               fromTab:(nullable Tab*)tab
                            activateTab:(Web::HTML::ActivateTab)activate_tab;
 
 - (void)removeTab:(nonnull TabController*)controller;

--- a/Ladybird/AppKit/Application/ApplicationDelegate.mm
+++ b/Ladybird/AppKit/Application/ApplicationDelegate.mm
@@ -36,6 +36,7 @@
 - (NSMenuItem*)createEditMenu;
 - (NSMenuItem*)createViewMenu;
 - (NSMenuItem*)createHistoryMenu;
+- (NSMenuItem*)createInspectMenu;
 - (NSMenuItem*)createDebugMenu;
 - (NSMenuItem*)createWindowsMenu;
 - (NSMenuItem*)createHelpMenu;
@@ -56,6 +57,7 @@
         [[NSApp mainMenu] addItem:[self createEditMenu]];
         [[NSApp mainMenu] addItem:[self createViewMenu]];
         [[NSApp mainMenu] addItem:[self createHistoryMenu]];
+        [[NSApp mainMenu] addItem:[self createInspectMenu]];
         [[NSApp mainMenu] addItem:[self createDebugMenu]];
         [[NSApp mainMenu] addItem:[self createWindowsMenu]];
         [[NSApp mainMenu] addItem:[self createHelpMenu]];
@@ -307,6 +309,19 @@
 
     [submenu addItem:[[NSMenuItem alloc] initWithTitle:@"Clear History"
                                                 action:@selector(clearHistory:)
+                                         keyEquivalent:@""]];
+
+    [menu setSubmenu:submenu];
+    return menu;
+}
+
+- (NSMenuItem*)createInspectMenu
+{
+    auto* menu = [[NSMenuItem alloc] init];
+    auto* submenu = [[NSMenu alloc] initWithTitle:@"Inspect"];
+
+    [submenu addItem:[[NSMenuItem alloc] initWithTitle:@"View Source"
+                                                action:@selector(viewSource:)
                                          keyEquivalent:@""]];
 
     [menu setSubmenu:submenu];

--- a/Ladybird/AppKit/Application/ApplicationDelegate.mm
+++ b/Ladybird/AppKit/Application/ApplicationDelegate.mm
@@ -83,25 +83,19 @@
 #pragma mark - Public methods
 
 - (TabController*)createNewTab:(Optional<URL> const&)url
-{
-    return [self createNewTab:url activateTab:Web::HTML::ActivateTab::Yes];
-}
-
-- (TabController*)createNewTab:(Optional<URL> const&)url
+                       fromTab:(Tab*)tab
                    activateTab:(Web::HTML::ActivateTab)activate_tab
 {
     // This handle must be acquired before creating the new tab.
-    auto* current_tab = (Tab*)[NSApp keyWindow];
-
     auto* controller = [[TabController alloc] init:url.value_or(m_new_tab_page_url)];
     [controller showWindow:nil];
 
-    if (current_tab) {
-        [[current_tab tabGroup] addWindow:controller.window];
+    if (tab) {
+        [[tab tabGroup] addWindow:controller.window];
 
         // FIXME: Can we create the tabbed window above without it becoming active in the first place?
         if (activate_tab == Web::HTML::ActivateTab::No) {
-            [current_tab orderFront:nil];
+            [tab orderFront:nil];
         }
     }
 
@@ -133,13 +127,18 @@
 
 - (void)closeCurrentTab:(id)sender
 {
-    auto* current_tab = (Tab*)[NSApp keyWindow];
-    [current_tab close];
+    auto* current_window = [NSApp keyWindow];
+    [current_window close];
 }
 
 - (void)openLocation:(id)sender
 {
-    auto* current_tab = (Tab*)[NSApp keyWindow];
+    auto* current_tab = [NSApp keyWindow];
+
+    if (![current_tab isKindOfClass:[Tab class]]) {
+        return;
+    }
+
     auto* controller = (TabController*)[current_tab windowController];
     [controller focusLocationToolbarItem];
 }
@@ -353,7 +352,9 @@
 
 - (void)applicationDidFinishLaunching:(NSNotification*)notification
 {
-    [self createNewTab:m_initial_url];
+    [self createNewTab:m_initial_url
+               fromTab:nil
+           activateTab:Web::HTML::ActivateTab::Yes];
 }
 
 - (void)applicationWillTerminate:(NSNotification*)notification

--- a/Ladybird/AppKit/UI/LadybirdWebView.h
+++ b/Ladybird/AppKit/UI/LadybirdWebView.h
@@ -21,4 +21,6 @@
 
 - (void)setPreferredColorScheme:(Web::CSS::PreferredColorScheme)color_scheme;
 
+- (void)viewSource;
+
 @end

--- a/Ladybird/AppKit/UI/LadybirdWebView.mm
+++ b/Ladybird/AppKit/UI/LadybirdWebView.mm
@@ -178,9 +178,12 @@ struct HideCursor {
         [self setNeedsDisplay:YES];
     };
 
-    m_web_view_bridge->on_new_tab = [](auto activate_tab) {
+    m_web_view_bridge->on_new_tab = [self](auto activate_tab) {
         auto* delegate = (ApplicationDelegate*)[NSApp delegate];
-        auto* controller = [delegate createNewTab:"about:blank"sv activateTab:activate_tab];
+
+        auto* controller = [delegate createNewTab:"about:blank"sv
+                                          fromTab:[self tab]
+                                      activateTab:activate_tab];
 
         auto* tab = (Tab*)[controller window];
         auto* web_view = [tab web_view];
@@ -353,17 +356,24 @@ struct HideCursor {
         auto* delegate = (ApplicationDelegate*)[NSApp delegate];
 
         if (modifiers == Mod_Super) {
-            [delegate createNewTab:url activateTab:Web::HTML::ActivateTab::No];
+            [delegate createNewTab:url
+                           fromTab:[self tab]
+                       activateTab:Web::HTML::ActivateTab::No];
         } else if (target == "_blank"sv) {
-            [delegate createNewTab:url activateTab:Web::HTML::ActivateTab::Yes];
+            [delegate createNewTab:url
+                           fromTab:[self tab]
+                       activateTab:Web::HTML::ActivateTab::Yes];
         } else {
             [[self tabController] load:url];
         }
     };
 
-    m_web_view_bridge->on_link_middle_click = [](auto url, auto, unsigned) {
+    m_web_view_bridge->on_link_middle_click = [self](auto url, auto, unsigned) {
         auto* delegate = (ApplicationDelegate*)[NSApp delegate];
-        [delegate createNewTab:url activateTab:Web::HTML::ActivateTab::No];
+
+        [delegate createNewTab:url
+                       fromTab:[self tab]
+                   activateTab:Web::HTML::ActivateTab::No];
     };
 
     m_web_view_bridge->on_context_menu_request = [self](auto position) {

--- a/Ladybird/AppKit/UI/LadybirdWebView.mm
+++ b/Ladybird/AppKit/UI/LadybirdWebView.mm
@@ -127,6 +127,11 @@ struct HideCursor {
     m_web_view_bridge->set_preferred_color_scheme(color_scheme);
 }
 
+- (void)viewSource
+{
+    m_web_view_bridge->get_source();
+}
+
 #pragma mark - Private methods
 
 - (void)updateViewportRect:(Ladybird::WebViewBridge::ForResize)for_resize
@@ -582,6 +587,10 @@ struct HideCursor {
 
         return Ladybird::ns_rect_to_gfx_rect([[self window] frame]);
     };
+
+    m_web_view_bridge->on_received_source = [self](auto const& url, auto const& source) {
+        [[self tabController] onReceivedSource:url source:source];
+    };
 }
 
 - (Tab*)tab
@@ -715,6 +724,11 @@ static void copy_text_to_clipboard(StringView text)
                                                         keyEquivalent:@""]];
         [_page_context_menu addItem:[[NSMenuItem alloc] initWithTitle:@"Take Full Screenshot"
                                                                action:@selector(takeFullScreenshot:)
+                                                        keyEquivalent:@""]];
+        [_page_context_menu addItem:[NSMenuItem separatorItem]];
+
+        [_page_context_menu addItem:[[NSMenuItem alloc] initWithTitle:@"View Source"
+                                                               action:@selector(viewSource:)
                                                         keyEquivalent:@""]];
     }
 

--- a/Ladybird/AppKit/UI/SourceView.h
+++ b/Ladybird/AppKit/UI/SourceView.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2023, Tim Flynn <trflynn89@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/StringView.h>
+#include <AK/URL.h>
+
+#import <System/Cocoa.h>
+
+@class Tab;
+
+@interface SourceView : NSWindow
+
+- (instancetype)init:(Tab*)tab
+                 url:(URL const&)url
+              source:(StringView)source;
+
+@end

--- a/Ladybird/AppKit/UI/SourceView.mm
+++ b/Ladybird/AppKit/UI/SourceView.mm
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2023, Tim Flynn <trflynn89@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWeb/HTML/Parser/HTMLTokenizer.h>
+
+#import <UI/SourceView.h>
+#import <UI/Tab.h>
+#import <Utilities/Conversions.h>
+
+#if !__has_feature(objc_arc)
+#    error "This project requires ARC"
+#endif
+
+static constexpr CGFloat const WINDOW_WIDTH = 800;
+static constexpr CGFloat const WINDOW_HEIGHT = 600;
+
+@interface SourceView ()
+@end
+
+@implementation SourceView
+
+- (instancetype)init:(Tab*)tab
+                 url:(URL const&)url
+              source:(StringView)source
+{
+    auto tab_rect = [tab frame];
+    auto position_x = tab_rect.origin.x + (tab_rect.size.width - WINDOW_WIDTH) / 2;
+    auto position_y = tab_rect.origin.y + (tab_rect.size.height - WINDOW_HEIGHT) / 2;
+
+    auto window_rect = NSMakeRect(position_x, position_y, WINDOW_WIDTH, WINDOW_HEIGHT);
+    auto style_mask = NSWindowStyleMaskTitled | NSWindowStyleMaskClosable | NSWindowStyleMaskMiniaturizable | NSWindowStyleMaskResizable;
+
+    self = [super initWithContentRect:window_rect
+                            styleMask:style_mask
+                              backing:NSBackingStoreBuffered
+                                defer:NO];
+
+    if (self) {
+        auto* scroll_view = [[NSScrollView alloc] initWithFrame:[[self contentView] frame]];
+        [scroll_view setAutoresizingMask:NSViewWidthSizable | NSViewHeightSizable];
+        [scroll_view setHasHorizontalScroller:NO];
+        [scroll_view setHasVerticalScroller:YES];
+
+        auto* font = [NSFont monospacedSystemFontOfSize:12.0
+                                                 weight:NSFontWeightRegular];
+
+        auto* text_view = [[NSTextView alloc] initWithFrame:[[scroll_view contentView] frame]];
+        [text_view setAutoresizingMask:NSViewWidthSizable];
+        [text_view setHorizontallyResizable:NO];
+        [text_view setVerticallyResizable:YES];
+        [text_view setEditable:NO];
+        [text_view setFont:font];
+
+        auto* ns_source = Ladybird::string_to_ns_string(source);
+        [text_view setString:ns_source];
+
+        [scroll_view setDocumentView:text_view];
+        [self setContentView:scroll_view];
+
+        auto title = MUST(String::formatted("View Source - {}", url));
+        auto* ns_title = Ladybird::string_to_ns_string(title);
+        [self setTitle:ns_title];
+
+        [self highlightHTML:source textStorage:[text_view textStorage]];
+        [self setIsVisible:YES];
+    }
+
+    return self;
+}
+
+#pragma mark - Private methods
+
+- (void)highlightHTML:(StringView)source
+          textStorage:(NSTextStorage*)storage
+{
+    Web::HTML::HTMLTokenizer tokenizer { source, "utf-8"sv };
+
+    auto* bold_font = [NSFont monospacedSystemFontOfSize:12.0
+                                                  weight:NSFontWeightBold];
+
+    auto highlight = [&](auto* color, auto start, auto end) {
+        if (end >= [storage length])
+            return;
+
+        [storage addAttribute:NSForegroundColorAttributeName
+                        value:color
+                        range:NSMakeRange(start, end - start)];
+    };
+
+    auto bolden = [&](auto start, auto end) {
+        if (end >= [storage length])
+            return;
+
+        [storage addAttribute:NSFontAttributeName
+                        value:bold_font
+                        range:NSMakeRange(start, end - start)];
+    };
+
+    for (auto token = tokenizer.next_token(); token.has_value(); token = tokenizer.next_token()) {
+        if (token->is_end_of_file())
+            break;
+
+        if (token->is_comment()) {
+            auto start_offset = token->start_position().byte_offset;
+            auto end_offset = token->end_position().byte_offset;
+
+            highlight([NSColor systemGreenColor], start_offset, end_offset);
+        } else if (token->is_start_tag() || token->is_end_tag()) {
+            auto start_offset = token->start_position().byte_offset;
+            auto end_offset = start_offset + token->tag_name().length();
+
+            highlight([NSColor systemPinkColor], start_offset, end_offset);
+            bolden(start_offset, end_offset);
+
+            token->for_each_attribute([&](auto const& attribute) {
+                start_offset = attribute.name_start_position.byte_offset;
+                end_offset = attribute.name_end_position.byte_offset;
+                highlight([NSColor systemOrangeColor], start_offset, end_offset);
+
+                start_offset = attribute.value_start_position.byte_offset;
+                end_offset = attribute.value_end_position.byte_offset;
+                highlight([NSColor systemCyanColor], start_offset, end_offset);
+
+                return IterationDecision::Continue;
+            });
+        }
+    }
+}
+
+@end

--- a/Ladybird/AppKit/UI/SourceViewController.h
+++ b/Ladybird/AppKit/UI/SourceViewController.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2023, Tim Flynn <trflynn89@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/DeprecatedString.h>
+#include <AK/URL.h>
+
+#import <System/Cocoa.h>
+
+@class TabController;
+
+@interface SourceViewController : NSWindowController <NSWindowDelegate>
+
+- (instancetype)init:(TabController*)tab_controller
+                 url:(URL)url
+              source:(DeprecatedString)source;
+
+@end

--- a/Ladybird/AppKit/UI/SourceViewController.mm
+++ b/Ladybird/AppKit/UI/SourceViewController.mm
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2023, Tim Flynn <trflynn89@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#import <UI/SourceView.h>
+#import <UI/SourceViewController.h>
+#import <UI/Tab.h>
+#import <UI/TabController.h>
+
+#if !__has_feature(objc_arc)
+#    error "This project requires ARC"
+#endif
+
+@interface SourceViewController ()
+{
+    URL m_url;
+    DeprecatedString m_source;
+}
+
+@property (nonatomic, strong) TabController* tab_controller;
+
+@end
+
+@implementation SourceViewController
+
+- (instancetype)init:(TabController*)tab_controller
+                 url:(URL)url
+              source:(DeprecatedString)source
+{
+    if (self = [super init]) {
+        self.tab_controller = tab_controller;
+
+        m_url = move(url);
+        m_source = move(source);
+    }
+
+    return self;
+}
+
+#pragma mark - NSWindowController
+
+- (IBAction)showWindow:(id)sender
+{
+    auto* tab = (Tab*)[self.tab_controller window];
+
+    self.window = [[SourceView alloc] init:tab
+                                       url:m_url
+                                    source:m_source];
+
+    [self.window setDelegate:self];
+    [self.window makeKeyAndOrderFront:sender];
+}
+
+#pragma mark - NSWindowDelegate
+
+- (void)windowWillClose:(NSNotification*)notification
+{
+    [self.tab_controller onSourceViewClosed];
+}
+
+@end

--- a/Ladybird/AppKit/UI/TabController.h
+++ b/Ladybird/AppKit/UI/TabController.h
@@ -25,6 +25,10 @@
 - (void)reload:(id)sender;
 - (void)clearHistory;
 
+- (void)viewSource:(id)sender;
+- (void)onReceivedSource:(URL const&)url source:(DeprecatedString const&)source;
+- (void)onSourceViewClosed;
+
 - (void)focusLocationToolbarItem;
 
 @end

--- a/Ladybird/AppKit/UI/TabController.mm
+++ b/Ladybird/AppKit/UI/TabController.mm
@@ -166,7 +166,10 @@ enum class IsHistoryNavigation {
 - (void)createNewTab:(id)sender
 {
     auto* delegate = (ApplicationDelegate*)[NSApp delegate];
-    [delegate createNewTab:OptionalNone {}];
+
+    [delegate createNewTab:OptionalNone {}
+                   fromTab:[self tab]
+               activateTab:Web::HTML::ActivateTab::Yes];
 }
 
 - (void)updateNavigationButtonStates

--- a/Ladybird/AppKit/UI/TabController.mm
+++ b/Ladybird/AppKit/UI/TabController.mm
@@ -8,6 +8,7 @@
 
 #import <Application/ApplicationDelegate.h>
 #import <UI/LadybirdWebView.h>
+#import <UI/SourceViewController.h>
 #import <UI/Tab.h>
 #import <UI/TabController.h>
 #import <Utilities/Conversions.h>
@@ -50,6 +51,8 @@ enum class IsHistoryNavigation {
 @property (nonatomic, strong) NSToolbarItem* tab_overview_toolbar_item;
 
 @property (nonatomic, assign) NSLayoutConstraint* location_toolbar_item_width;
+
+@property (nonatomic, strong) SourceViewController* source_view_controller;
 
 @end
 
@@ -149,6 +152,30 @@ enum class IsHistoryNavigation {
 {
     m_history.clear();
     [self updateNavigationButtonStates];
+}
+
+- (void)viewSource:(id)sender
+{
+    if (self.source_view_controller != nil) {
+        [self.source_view_controller.window makeKeyAndOrderFront:sender];
+        return;
+    }
+
+    [[[self tab] web_view] viewSource];
+}
+
+- (void)onReceivedSource:(URL const&)url
+                  source:(DeprecatedString const&)source
+{
+    self.source_view_controller = [[SourceViewController alloc] init:self
+                                                                 url:url
+                                                              source:source];
+    [self.source_view_controller showWindow:nil];
+}
+
+- (void)onSourceViewClosed
+{
+    self.source_view_controller = nil;
 }
 
 - (void)focusLocationToolbarItem
@@ -320,6 +347,10 @@ enum class IsHistoryNavigation {
 
 - (void)windowWillClose:(NSNotification*)notification
 {
+    if (self.source_view_controller != nil) {
+        [self.source_view_controller.window close];
+    }
+
     auto* delegate = (ApplicationDelegate*)[NSApp delegate];
     [delegate removeTab:self];
 }

--- a/Ladybird/CMakeLists.txt
+++ b/Ladybird/CMakeLists.txt
@@ -137,6 +137,8 @@ elseif (APPLE)
         AppKit/UI/LadybirdWebView.mm
         AppKit/UI/LadybirdWebViewBridge.cpp
         AppKit/UI/Palette.mm
+        AppKit/UI/SourceView.mm
+        AppKit/UI/SourceViewController.mm
         AppKit/UI/Tab.mm
         AppKit/UI/TabController.mm
         AppKit/Utilities/Conversions.mm

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.h
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.h
@@ -39,6 +39,7 @@ public:
 
         size_t line { 0 };
         size_t column { 0 };
+        size_t byte_offset { 0 };
     };
 
     struct Attribute {

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.h
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.h
@@ -35,6 +35,8 @@ public:
     };
 
     struct Position {
+        constexpr bool operator==(Position const&) const = default;
+
         size_t line { 0 };
         size_t column { 0 };
     };

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
@@ -223,6 +223,7 @@ void HTMLTokenizer::skip(size_t count)
             } else {
                 m_source_positions.last().column++;
             }
+            m_source_positions.last().byte_offset += m_utf8_iterator.underlying_code_point_length_in_bytes();
         }
         ++m_utf8_iterator;
     }


### PR DESCRIPTION
In the long run, it'd actually be much nicer if we implemented View Source in a way that made LibWeb/LibWebView generate an HTML file with the contents of the source styled with CSS. Then all chromes would be able to display the source as a web view in a tab. Doing this will require some more extensive `HTMLTokenizer` features though, such as being able to reconstruct the original source from a token (including whitespace). So for now, this is a small UI with a bit of syntax highlighting.

<img width="912" alt="Screenshot 2023-08-25 at 8 25 35 AM" src="https://github.com/SerenityOS/serenity/assets/5600524/82e732ca-252b-4270-98f8-80f324b3ccd2">
<img width="868" alt="Screenshot 2023-08-25 at 8 25 46 AM" src="https://github.com/SerenityOS/serenity/assets/5600524/c8e89a0f-0970-4054-a1f6-3044a6d1ab7c">
