### PR TITLE
Kernel: Remove KDSETMODE and KDGETMODE ioctl options from the TTY class

### DIFF
--- a/Kernel/TTY/TTY.cpp
+++ b/Kernel/TTY/TTY.cpp
@@ -562,19 +562,6 @@ ErrorOr<void> TTY::ioctl(OpenFileDescription&, unsigned request, Userspace<void*
     case TIOCNOTTY:
         current_process.set_tty(nullptr);
         return {};
-    case KDSETMODE: {
-        auto mode = static_cast<unsigned int>(arg.ptr());
-        if (mode != KD_TEXT && mode != KD_GRAPHICS)
-            return EINVAL;
-
-        set_graphical(mode == KD_GRAPHICS);
-        return {};
-    }
-    case KDGETMODE: {
-        auto mode_ptr = static_ptr_cast<int*>(arg);
-        int mode = (is_graphical()) ? KD_GRAPHICS : KD_TEXT;
-        return copy_to_user(mode_ptr, &mode);
-    }
     }
     return EINVAL;
 }

--- a/Kernel/TTY/TTY.h
+++ b/Kernel/TTY/TTY.h
@@ -25,7 +25,7 @@ public:
     virtual ErrorOr<size_t> write(OpenFileDescription&, u64, UserOrKernelBuffer const&, size_t) override;
     virtual bool can_read(OpenFileDescription const&, u64) const override;
     virtual bool can_write(OpenFileDescription const&, u64) const override;
-    virtual ErrorOr<void> ioctl(OpenFileDescription&, unsigned request, Userspace<void*> arg) override final;
+    virtual ErrorOr<void> ioctl(OpenFileDescription&, unsigned request, Userspace<void*> arg) override;
 
     unsigned short rows() const { return m_rows; }
     unsigned short columns() const { return m_columns; }
@@ -47,9 +47,6 @@ public:
     void hang_up();
 
     virtual ErrorOr<NonnullOwnPtr<KString>> pseudo_name() const = 0;
-
-    virtual bool is_graphical() const { return false; }
-    virtual void set_graphical(bool) { }
 
 protected:
     virtual ErrorOr<size_t> on_tty_write(UserOrKernelBuffer const&, size_t) = 0;

--- a/Kernel/TTY/VirtualConsole.h
+++ b/Kernel/TTY/VirtualConsole.h
@@ -77,9 +77,8 @@ public:
 
     void refresh_after_resolution_change();
 
-    // ^TTY
-    virtual bool is_graphical() const override { return m_graphical; }
-    virtual void set_graphical(bool graphical) override;
+    bool is_graphical() const { return m_graphical; }
+    void set_graphical(bool graphical);
 
     void emit_char(char);
 
@@ -91,6 +90,7 @@ private:
     // ^TTY
     virtual ErrorOr<NonnullOwnPtr<KString>> pseudo_name() const override;
     virtual ErrorOr<size_t> on_tty_write(UserOrKernelBuffer const&, size_t) override;
+    virtual ErrorOr<void> ioctl(OpenFileDescription&, unsigned request, Userspace<void*> arg) override;
     virtual void echo(u8) override;
 
     // ^TerminalClient


### PR DESCRIPTION
These options are not relevant and are actually meaningless on pure TTY devices, as they are meant to be effective only for the VirtualConsole devices.

This also removes the virtual marking from two methods because they're no longer declared in the TTY class as well.

Taken originally from #20761.