### PR TITLE
LibGUI: Add window remember state feature

### DIFF
--- a/Base/home/anon/.config/FileManager.ini
+++ b/Base/home/anon/.config/FileManager.ini
@@ -2,12 +2,6 @@
 ViewMode=Icon
 ShowDotFiles=false
 
-[Window]
-Left=150
-Top=75
-Width=640
-Height=480
-
 [Layout]
 ShowToolbar=true
 ShowStatusBar=true

--- a/Userland/Libraries/LibGUI/Window.h
+++ b/Userland/Libraries/LibGUI/Window.h
@@ -240,6 +240,10 @@ public:
 
     void propagate_shortcuts(KeyEvent& event, Widget* widget, ShortcutPropagationBoundary = ShortcutPropagationBoundary::Application);
 
+    void restore_size_and_position(StringView domain, StringView group = "Window"sv, Optional<Gfx::IntSize> fallback_size = {}, Optional<Gfx::IntPoint> fallback_position = {});
+    void save_size_and_position(StringView domain, StringView group = "Window"sv) const;
+    void save_size_and_position_on_close(StringView domain, StringView group = "Window"sv);
+
 protected:
     Window(Core::EventReceiver* parent = nullptr);
     virtual void wm_event(WMEvent&);
@@ -323,6 +327,9 @@ private:
     bool m_blocks_emoji_input { false };
     bool m_resizing { false };
     bool m_auto_shrink { false };
+    bool m_save_size_and_position_on_close { false };
+    StringView m_save_domain;
+    StringView m_save_group;
 };
 
 }


### PR DESCRIPTION
I have added the three functions to `LibGUI::Window`. You can use this function to easily save and restore the window state of your application:
```cpp
void restore_size_and_position(StringView domain, StringView group = "Window"sv, Optional<Gfx::IntSize> fallback_size = {}, Optional<Gfx::IntPoint> fallback_position = {});
void save_size_and_position(StringView domain, StringView group = "Window"sv) const;
void save_size_and_position_on_close(StringView domain, StringView group = "Window"sv);
```

You can use the `restore` and `save` functions to easily restore the window state from config. The `save_size_and_position_on_close` can be called when the window is initializing, it sets some state that when the window is closed the current window state is saved to config. This is a small example:
```cpp
auto window = TRY(GUI::Window::try_create());

// Load state from config if available use fallback when no config exists
window->restore_size_and_position("FileManager"sv, "Window"sv, { { 640, 480 } });
window->save_size_and_position_on_close("FileManager"sv, "Window"sv);

window->show();
app->exec();
// The current state is saved to config on close because we called save_size_and_position_on_close
```

Only the File Manager saves it window location at the moment but in the future more applications can use this feature.

When reading from config I use a small hack by loading `INT_MIN` to check if the value exists and is correct, but currently there is no API in LibConfig to check if a key exists and is valid.