### PR TITLE
LibWeb+AK: Load high resolution images on apple.com when running on high-DPI display

### DIFF
--- a/AK/NonnullOwnPtr.h
+++ b/AK/NonnullOwnPtr.h
@@ -196,7 +196,16 @@ inline void swap(NonnullOwnPtr<T>& a, NonnullOwnPtr<U>& b)
     a.swap(b);
 }
 
+template<Formattable T>
+struct Formatter<NonnullOwnPtr<T>> : Formatter<T> {
+    ErrorOr<void> format(FormatBuilder& builder, NonnullOwnPtr<T> const& value)
+    {
+        return Formatter<T>::format(builder, *value);
+    }
+};
+
 template<typename T>
+requires(!HasFormatter<T>)
 struct Formatter<NonnullOwnPtr<T>> : Formatter<T const*> {
     ErrorOr<void> format(FormatBuilder& builder, NonnullOwnPtr<T> const& value)
     {

--- a/Tests/AK/TestNonnullOwnPtr.cpp
+++ b/Tests/AK/TestNonnullOwnPtr.cpp
@@ -9,6 +9,7 @@
 #include <AK/DeprecatedString.h>
 #include <AK/NonnullOwnPtr.h>
 #include <AK/OwnPtr.h>
+#include <AK/String.h>
 
 TEST_CASE(destroy_self_owning_object)
 {
@@ -31,4 +32,20 @@ TEST_CASE(destroy_self_owning_object)
     auto* object_ptr = object.ptr();
     object_ptr->inner = make<SelfOwning::Inner>(object.release_nonnull());
     object_ptr->inner = nullptr;
+}
+
+struct Foo { };
+
+template<>
+struct AK::Formatter<Foo> : Formatter<StringView> {
+    ErrorOr<void> format(FormatBuilder& builder, Foo const&)
+    {
+        return Formatter<StringView>::format(builder, ":^)"sv);
+    }
+};
+
+TEST_CASE(formatter)
+{
+    auto foo = make<Foo>();
+    EXPECT_EQ(MUST(String::formatted("{}", foo)), ":^)"sv);
 }

--- a/Tests/LibWeb/Layout/expected/media-query-resolution.txt
+++ b/Tests/LibWeb/Layout/expected/media-query-resolution.txt
@@ -1,0 +1,31 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,16) content-size 784x68.875 children: not-inline
+      BlockContainer <p> at (8,16) content-size 784x35.40625 children: inline
+        line 0 width: 746.890625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+          frag 0 from TextNode start: 0, length: 88, rect: [8,16 746.890625x17.46875]
+            "NOTE: This test assumes that you're running with 1x pixels (which our test runner always"
+        line 1 width: 40.625, height: 17.9375, bottom: 35.40625, baseline: 13.53125
+          frag 0 from TextNode start: 89, length: 5, rect: [8,33 40.625x17.46875]
+            "does."
+        TextNode <#text>
+      BlockContainer <(anonymous)> at (8,67.40625) content-size 784x0 children: inline
+        TextNode <#text>
+      BlockContainer <div.pass> at (8,67.40625) content-size 784x17.46875 children: inline
+        line 0 width: 49.734375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+          frag 0 from TextNode start: 0, length: 4, rect: [8,67.40625 49.734375x17.46875]
+            "PASS"
+        TextNode <#text>
+      BlockContainer <(anonymous)> at (8,84.875) content-size 784x0 children: inline
+        TextNode <#text>
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,16 784x68.875]
+      PaintableWithLines (BlockContainer<P>) [8,16 784x35.40625]
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,67.40625 784x0]
+      PaintableWithLines (BlockContainer<DIV>.pass) [8,67.40625 784x17.46875]
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,84.875 784x0]

--- a/Tests/LibWeb/Layout/input/media-query-resolution.html
+++ b/Tests/LibWeb/Layout/input/media-query-resolution.html
@@ -1,0 +1,12 @@
+<style>
+div { display: none; }
+@media (min-resolution: 96dpi) {
+    div.pass { display: block; }
+}
+@media (min-resolution: 97dpi) {
+    div.fail { display: block; }
+}
+</style>
+<p>NOTE: This test assumes that you're running with 1x pixels (which our test runner always does.</p>
+<div class="pass">PASS</div>
+<div class="fail">FAIL</div>

--- a/Tests/LibWeb/Text/expected/css/media-query-serialization-basic.txt
+++ b/Tests/LibWeb/Text/expected/css/media-query-serialization-basic.txt
@@ -1,0 +1,15 @@
+@media screen {
+
+}
+@media screen and ((min-width:20px) and (max-width:40px)) {
+
+}
+@media screen and (min-resolution:1dppx) {
+
+}
+@media screen and (min-resolution:2dppx) {
+
+}
+@media screen and (min-resolution:2.54dppx) {
+
+}

--- a/Tests/LibWeb/Text/input/css/media-query-serialization-basic.html
+++ b/Tests/LibWeb/Text/input/css/media-query-serialization-basic.html
@@ -1,0 +1,16 @@
+<head><style>
+@media only screen { }
+@media only screen and (min-width: 20px) and (max-width: 40px) { }
+@media only screen and (min-resolution: 96dpi) { }
+@media only screen and (min-resolution: 2dppx) { }
+@media only screen and (min-resolution: 96dpcm) { }
+</style></head>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        let sheet = document.head.firstChild.sheet
+        for (rule of sheet.cssRules) {
+            println(rule.cssText);
+        }
+    });
+</script>

--- a/Userland/Libraries/LibWeb/CSS/Resolution.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Resolution.cpp
@@ -23,9 +23,9 @@ double Resolution::to_dots_per_pixel() const
 {
     switch (m_type) {
     case Type::Dpi:
-        return m_value * 96; // 1in = 2.54cm = 96px
+        return m_value / 96; // 1in = 2.54cm = 96px
     case Type::Dpcm:
-        return m_value * (96.0 / 2.54); // 1cm = 96px/2.54
+        return m_value / (96.0 / 2.54); // 1cm = 96px/2.54
     case Type::Dppx:
         return m_value;
     }

--- a/Userland/Libraries/LibWeb/HTML/Window.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Window.cpp
@@ -546,7 +546,8 @@ Optional<CSS::MediaFeatureValue> Window::query_media_feature(CSS::MediaFeatureID
     case CSS::MediaFeatureID::PrefersReducedTransparency:
         // FIXME: Make this a preference
         return CSS::MediaFeatureValue(CSS::ValueID::NoPreference);
-    // FIXME: resolution
+    case CSS::MediaFeatureID::Resolution:
+        return CSS::MediaFeatureValue(CSS::Resolution(device_pixel_ratio(), CSS::Resolution::Type::Dppx));
     case CSS::MediaFeatureID::Scan:
         return CSS::MediaFeatureValue(CSS::ValueID::Progressive);
     case CSS::MediaFeatureID::Scripting:


### PR DESCRIPTION
See individual commits for details.

Before:
![apple2](https://github.com/SerenityOS/serenity/assets/5954907/46b10e5a-5dab-4ab7-a443-f4f7bf62920e)

After:
![apple3](https://github.com/SerenityOS/serenity/assets/5954907/10ac6cfb-74e5-4e40-8af0-34ed6c9d3456)
