### PR TITLE
Ports/mc: Remove `libtool` dependency

### DIFF
--- a/Ports/mc/package.sh
+++ b/Ports/mc/package.sh
@@ -7,14 +7,13 @@ files=(
 )
 depends=("gettext" "glib" "libtool" "ncurses" "vim")
 configopts=(
+    "--with-sysroot=${SERENITY_INSTALL_ROOT}"
     "--disable-largefile"
     "--disable-vfs"
     "--without-edit"
     "--without-x"
     "--with-homedir"
     "--with-screen=ncurses"
-    "--with-ncurses-includes=$SERENITY_BUILD_DIR/Root/usr/local/include/ncurses"
-    "--with-ncurses-libs=$SERENITY_BUILD_DIR/Root/usr/local/lib"
 )
 use_fresh_config_sub=true
 config_sub_paths=("config/config.sub")

--- a/Ports/mc/package.sh
+++ b/Ports/mc/package.sh
@@ -5,7 +5,12 @@ useconfigure=true
 files=(
     "http://ftp.midnight-commander.org/mc-${version}.tar.xz 01d8a3b94f58180cca5bf17257b5078d1fd6fd27a9b5c0e970ec767549540ad4"
 )
-depends=("gettext" "glib" "libtool" "ncurses" "vim")
+depends=(
+    'gettext'
+    'glib'
+    'ncurses'
+    'vim'
+)
 configopts=(
     "--with-sysroot=${SERENITY_INSTALL_ROOT}"
     "--disable-largefile"

--- a/Ports/mc/package.sh
+++ b/Ports/mc/package.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S bash ../.port_include.sh
-port=mc
-version=4.8.29
-useconfigure=true
+port='mc'
+version='4.8.29'
+useconfigure='true'
 files=(
     "http://ftp.midnight-commander.org/mc-${version}.tar.xz 01d8a3b94f58180cca5bf17257b5078d1fd6fd27a9b5c0e970ec767549540ad4"
 )
@@ -13,12 +13,14 @@ depends=(
 )
 configopts=(
     "--with-sysroot=${SERENITY_INSTALL_ROOT}"
-    "--disable-largefile"
-    "--disable-vfs"
-    "--without-edit"
-    "--without-x"
-    "--with-homedir"
-    "--with-screen=ncurses"
+    '--disable-largefile'
+    '--disable-vfs'
+    '--without-edit'
+    '--without-x'
+    '--with-homedir'
+    '--with-screen=ncurses'
 )
-use_fresh_config_sub=true
-config_sub_paths=("config/config.sub")
+use_fresh_config_sub='true'
+config_sub_paths=(
+    'config/config.sub'
+)


### PR DESCRIPTION
This PR removes `libtool` as a dependency for `mc` and adds `--with-sysroot` to `configopts`, to prevent any host libraries affecting the build.

These changes were made in an effort to solve what turned out to be an unrelated issue. My testing shows that these changes have no negative impact on the `mc` port, so I believe they are worth doing.