### PR TITLE
Ports/glib: Specify `pcre2` as a dependency instead of `pcre`

### DIFF
--- a/Ports/glib/package.sh
+++ b/Ports/glib/package.sh
@@ -12,7 +12,7 @@ depends=(
     'gettext'
     'libffi'
     'libiconv'
-    'pcre'
+    'pcre2'
     'zlib'
 )
 


### PR DESCRIPTION
Previously, if `pcre2` was not installed before `glib`, the meson script would download its own version and use that.