### PR TITLE
LibWeb: Disambiguate GridTrackPlacement API

### DIFF
--- a/Tests/LibWeb/Layout/expected/grid/named-tracks.txt
+++ b/Tests/LibWeb/Layout/expected/grid/named-tracks.txt
@@ -1,7 +1,7 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x127.40625 children: not-inline
-      Box <div.grid-container> at (8,8) content-size 784x17.46875 [GFC] children: not-inline
+      Box <div.grid-container> at (8,8) content-size 784x34.9375 [GFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
         BlockContainer <div.grid-item> at (8,8) content-size 392x17.46875 [BFC] children: inline
@@ -11,79 +11,79 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (400,8) content-size 392x17.46875 [BFC] children: inline
+        BlockContainer <div.grid-item> at (8,25.46875) content-size 392x17.46875 [BFC] children: inline
           line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 1, rect: [400,8 8.8125x17.46875]
+            frag 0 from TextNode start: 0, length: 1, rect: [8,25.46875 8.8125x17.46875]
               "2"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-      BlockContainer <(anonymous)> at (8,25.46875) content-size 784x0 children: inline
+      BlockContainer <(anonymous)> at (8,42.9375) content-size 784x0 children: inline
         TextNode <#text>
         TextNode <#text>
         TextNode <#text>
-      Box <div.grid-container> at (8,25.46875) content-size 784x75 [GFC] children: not-inline
+      Box <div.grid-container> at (8,42.9375) content-size 784x75 [GFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (8,25.46875) content-size 261.328125x75 [BFC] children: inline
+        BlockContainer <div.grid-item> at (8,42.9375) content-size 261.328125x25 [BFC] children: inline
           line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 1, rect: [8,25.46875 6.34375x17.46875]
+            frag 0 from TextNode start: 0, length: 1, rect: [8,42.9375 6.34375x17.46875]
               "1"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (530.65625,25.46875) content-size 261.328125x50 [BFC] children: inline
+        BlockContainer <div.grid-item> at (8,42.9375) content-size 261.328125x25 [BFC] children: inline
           line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 1, rect: [530.65625,25.46875 8.8125x17.46875]
+            frag 0 from TextNode start: 0, length: 1, rect: [8,42.9375 8.8125x17.46875]
               "2"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (269.328125,25.46875) content-size 261.328125x25 [BFC] children: inline
+        BlockContainer <div.grid-item> at (8,42.9375) content-size 261.328125x25 [BFC] children: inline
           line 0 width: 9.09375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 1, rect: [269.328125,25.46875 9.09375x17.46875]
+            frag 0 from TextNode start: 0, length: 1, rect: [8,42.9375 9.09375x17.46875]
               "3"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (269.328125,75.46875) content-size 522.65625x25 [BFC] children: inline
+        BlockContainer <div.grid-item> at (8,42.9375) content-size 261.328125x25 [BFC] children: inline
           line 0 width: 7.75, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 1, rect: [269.328125,75.46875 7.75x17.46875]
+            frag 0 from TextNode start: 0, length: 1, rect: [8,42.9375 7.75x17.46875]
               "4"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-      BlockContainer <(anonymous)> at (8,100.46875) content-size 784x0 children: inline
+      BlockContainer <(anonymous)> at (8,117.9375) content-size 784x0 children: inline
         TextNode <#text>
         TextNode <#text>
         TextNode <#text>
-      Box <div.grid-container> at (8,100.46875) content-size 784x34.9375 [GFC] children: not-inline
+      Box <div.grid-container> at (8,117.9375) content-size 784x17.46875 [GFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (58,100.46875) content-size 100x17.46875 [BFC] children: inline
+        BlockContainer <div.grid-item> at (8,117.9375) content-size 50x17.46875 [BFC] children: inline
           line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 1, rect: [58,100.46875 6.34375x17.46875]
+            frag 0 from TextNode start: 0, length: 1, rect: [8,117.9375 6.34375x17.46875]
               "1"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (158,100.46875) content-size 50x17.46875 [BFC] children: inline
+        BlockContainer <div.grid-item> at (58,117.9375) content-size 100x17.46875 [BFC] children: inline
           line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 1, rect: [158,100.46875 8.8125x17.46875]
+            frag 0 from TextNode start: 0, length: 1, rect: [58,117.9375 8.8125x17.46875]
               "2"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (208,100.46875) content-size 100x17.46875 [BFC] children: inline
+        BlockContainer <div.grid-item> at (158,117.9375) content-size 50x17.46875 [BFC] children: inline
           line 0 width: 9.09375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 1, rect: [208,100.46875 9.09375x17.46875]
+            frag 0 from TextNode start: 0, length: 1, rect: [158,117.9375 9.09375x17.46875]
               "3"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (8,117.9375) content-size 50x17.46875 [BFC] children: inline
+        BlockContainer <div.grid-item> at (208,117.9375) content-size 100x17.46875 [BFC] children: inline
           line 0 width: 7.75, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 1, rect: [8,117.9375 7.75x17.46875]
+            frag 0 from TextNode start: 0, length: 1, rect: [208,117.9375 7.75x17.46875]
               "4"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
@@ -92,28 +92,28 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x127.40625]
-      PaintableBox (Box<DIV>.grid-container) [8,8 784x17.46875]
+      PaintableBox (Box<DIV>.grid-container) [8,8 784x34.9375]
         PaintableWithLines (BlockContainer<DIV>.grid-item) [8,8 392x17.46875]
           TextPaintable (TextNode<#text>)
-        PaintableWithLines (BlockContainer<DIV>.grid-item) [400,8 392x17.46875]
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [8,25.46875 392x17.46875]
           TextPaintable (TextNode<#text>)
-      PaintableWithLines (BlockContainer(anonymous)) [8,25.46875 784x0]
-      PaintableBox (Box<DIV>.grid-container) [8,25.46875 784x75]
-        PaintableWithLines (BlockContainer<DIV>.grid-item) [8,25.46875 261.328125x75]
+      PaintableWithLines (BlockContainer(anonymous)) [8,42.9375 784x0]
+      PaintableBox (Box<DIV>.grid-container) [8,42.9375 784x75]
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [8,42.9375 261.328125x25]
           TextPaintable (TextNode<#text>)
-        PaintableWithLines (BlockContainer<DIV>.grid-item) [530.65625,25.46875 261.328125x50]
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [8,42.9375 261.328125x25]
           TextPaintable (TextNode<#text>)
-        PaintableWithLines (BlockContainer<DIV>.grid-item) [269.328125,25.46875 261.328125x25]
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [8,42.9375 261.328125x25]
           TextPaintable (TextNode<#text>)
-        PaintableWithLines (BlockContainer<DIV>.grid-item) [269.328125,75.46875 522.65625x25]
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [8,42.9375 261.328125x25]
           TextPaintable (TextNode<#text>)
-      PaintableWithLines (BlockContainer(anonymous)) [8,100.46875 784x0]
-      PaintableBox (Box<DIV>.grid-container) [8,100.46875 784x34.9375]
-        PaintableWithLines (BlockContainer<DIV>.grid-item) [58,100.46875 100x17.46875]
-          TextPaintable (TextNode<#text>)
-        PaintableWithLines (BlockContainer<DIV>.grid-item) [158,100.46875 50x17.46875]
-          TextPaintable (TextNode<#text>)
-        PaintableWithLines (BlockContainer<DIV>.grid-item) [208,100.46875 100x17.46875]
-          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,117.9375 784x0]
+      PaintableBox (Box<DIV>.grid-container) [8,117.9375 784x17.46875]
         PaintableWithLines (BlockContainer<DIV>.grid-item) [8,117.9375 50x17.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [58,117.9375 100x17.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [158,117.9375 50x17.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [208,117.9375 100x17.46875]
           TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/grid/template-lines-and-areas.txt
+++ b/Tests/LibWeb/Layout/expected/grid/template-lines-and-areas.txt
@@ -7,9 +7,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             frag 0 from TextNode start: 0, length: 3, rect: [8,8 21.609375x17.46875]
               "1fr"
           TextNode <#text>
-        BlockContainer <div.item-right> at (530.65625,8) content-size 261.328125x17.46875 [BFC] children: inline
+        BlockContainer <div.item-right> at (269.328125,8) content-size 522.65625x17.46875 [BFC] children: inline
           line 0 width: 21.609375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 3, rect: [530.65625,8 21.609375x17.46875]
+            frag 0 from TextNode start: 0, length: 3, rect: [269.328125,8 21.609375x17.46875]
               "1fr"
           TextNode <#text>
 
@@ -19,5 +19,5 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
       PaintableBox (Box<DIV>.grid) [8,8 784x17.46875]
         PaintableWithLines (BlockContainer<DIV>.item-left) [8,8 261.328125x17.46875]
           TextPaintable (TextNode<#text>)
-        PaintableWithLines (BlockContainer<DIV>.item-right) [530.65625,8 261.328125x17.46875]
+        PaintableWithLines (BlockContainer<DIV>.item-right) [269.328125,8 522.65625x17.46875]
           TextPaintable (TextNode<#text>)

--- a/Userland/Libraries/LibWeb/CSS/GridTrackPlacement.cpp
+++ b/Userland/Libraries/LibWeb/CSS/GridTrackPlacement.cpp
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2023, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
  * Copyright (c) 2022, Martin Falisse <mfalisse@outlook.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
@@ -9,48 +10,24 @@
 
 namespace Web::CSS {
 
-GridTrackPlacement::GridTrackPlacement(int span_count_or_position, bool has_span)
-    : m_type(has_span ? Type::Span : Type::Position)
-    , m_span_count_or_position(span_count_or_position)
-{
-}
-
-GridTrackPlacement::GridTrackPlacement(String line_name, int span_count_or_position, bool has_span)
-    : m_type(has_span ? Type::Span : Type::Position)
-    , m_span_count_or_position(span_count_or_position)
-    , m_line_name(line_name)
-{
-}
-
-GridTrackPlacement::GridTrackPlacement(String line_name, bool has_span)
-    : m_type(has_span ? Type::Span : Type::Position)
-    , m_line_name(line_name)
-{
-}
-
-GridTrackPlacement::GridTrackPlacement()
-    : m_type(Type::Auto)
-{
-}
-
 String GridTrackPlacement::to_string() const
 {
     StringBuilder builder;
-    if (is_auto()) {
-        builder.append("auto"sv);
-        return MUST(builder.to_string());
-    }
-    if (is_span()) {
-        builder.append("span"sv);
-        builder.append(" "sv);
-    }
-    if (m_span_count_or_position != 0) {
-        builder.append(MUST(String::number(m_span_count_or_position)));
-        builder.append(" "sv);
-    }
-    if (has_line_name()) {
-        builder.append(m_line_name);
-    }
+    m_value.visit(
+        [&](Auto const&) {
+            builder.append("auto"sv);
+        },
+        [&](Area const& area) {
+            builder.append(area.name);
+        },
+        [&](Line const& line) {
+            builder.appendff("{}", line.value);
+            if (line.name.has_value())
+                builder.appendff(" {}", line.name.value());
+        },
+        [&](Span const& span) {
+            builder.appendff("span {}", span.value);
+        });
     return MUST(builder.to_string());
 }
 

--- a/Userland/Libraries/LibWeb/CSS/GridTrackPlacement.h
+++ b/Userland/Libraries/LibWeb/CSS/GridTrackPlacement.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2023, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
  * Copyright (c) 2022, Martin Falisse <mfalisse@outlook.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
@@ -12,40 +13,79 @@ namespace Web::CSS {
 
 class GridTrackPlacement {
 public:
-    enum class Type {
-        Span,
-        Position,
-        Auto
-    };
-
-    GridTrackPlacement(String line_name, int span_count_or_position, bool has_span = false);
-    GridTrackPlacement(int span_count_or_position, bool has_span = false);
-    GridTrackPlacement(String line_name, bool has_span = false);
-    GridTrackPlacement();
-
-    static GridTrackPlacement make_auto() { return GridTrackPlacement(); }
-
-    bool is_span() const { return m_type == Type::Span; }
-    bool is_position() const { return m_type == Type::Position; }
-    bool is_auto() const { return m_type == Type::Auto; }
-    bool is_auto_positioned() const { return m_type == Type::Auto || (m_type == Type::Span && !has_line_name()); }
-
-    bool has_line_name() const { return !m_line_name.is_empty(); }
-
-    int raw_value() const { return m_span_count_or_position; }
-    Type type() const { return m_type; }
-    String line_name() const { return m_line_name; }
-
-    String to_string() const;
-    bool operator==(GridTrackPlacement const& other) const
+    static GridTrackPlacement make_auto()
     {
-        return m_type == other.type() && m_span_count_or_position == other.raw_value();
+        return GridTrackPlacement();
     }
 
+    static GridTrackPlacement make_area(String name)
+    {
+        return GridTrackPlacement(Area { .name = name });
+    }
+
+    static GridTrackPlacement make_line(int value, Optional<String> name)
+    {
+        return GridTrackPlacement(Line { .value = value, .name = name });
+    }
+
+    static GridTrackPlacement make_span(int value)
+    {
+        return GridTrackPlacement(Span { .value = value });
+    }
+
+    bool is_auto() const { return m_value.has<Auto>(); }
+    bool is_area() const { return m_value.has<Area>(); }
+    bool is_line() const { return m_value.has<Line>(); }
+    bool is_span() const { return m_value.has<Span>(); }
+
+    bool is_auto_positioned() const { return is_auto() || is_span(); }
+    bool is_positioned() const { return !is_auto_positioned(); }
+
+    bool has_line_name() const
+    {
+        return is_line() && m_value.get<Line>().name.has_value();
+    }
+
+    String area_name() const { return m_value.get<Area>().name; }
+    String line_name() const { return m_value.get<Line>().name.value(); }
+    int line_number() const { return m_value.get<Line>().value; }
+    int span() const { return m_value.get<Span>().value; }
+
+    String to_string() const;
+
+    bool operator==(GridTrackPlacement const& other) const = default;
+
 private:
-    Type m_type;
-    int m_span_count_or_position { 0 };
-    String m_line_name;
+    struct Auto {
+        bool operator==(Auto const&) const = default;
+    };
+
+    struct Area {
+        String name;
+        bool operator==(Area const& other) const = default;
+    };
+
+    struct Line {
+        int value;
+        Optional<String> name;
+        bool operator==(Line const& other) const = default;
+    };
+
+    struct Span {
+        int value;
+        bool operator==(Span const& other) const = default;
+    };
+
+    GridTrackPlacement()
+        : m_value(Auto {}) {};
+    GridTrackPlacement(Area value)
+        : m_value(value) {};
+    GridTrackPlacement(Line value)
+        : m_value(value) {};
+    GridTrackPlacement(Span value)
+        : m_value(value) {};
+
+    Variant<Auto, Area, Line, Span> m_value;
 };
 
 }

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2023, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
  * Copyright (c) 2022-2023, Martin Falisse <mfalisse@outlook.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause


### PR DESCRIPTION
- Ambiguous `raw_value()` method is replaced with `line_number()` and `span()`.
- `line_name()` that before returned either line name or area name is replaced with `line_name()` and `area_name()`.
- `Position` type is replaced with `Line` and `Area` type so we don't have to guess while doing layout.

Affected test expectations:
- `template-lines-and-areas` - improvement over what we had before.
- `named-tracks` - rebaseline a giant test. will have to split it into smaller tests in the future.