### PR TITLE
LibWeb: Don't assert when calling navigation properties

### DIFF
--- a/Tests/LibWeb/Text/expected/HTML/Navigation-object-properties.txt
+++ b/Tests/LibWeb/Text/expected/HTML/Navigation-object-properties.txt
@@ -1,0 +1,5 @@
+entries is empty: true
+currentEntry is null: true
+transition is null: true
+canGoBack: false
+canGoForward: false

--- a/Tests/LibWeb/Text/input/HTML/Navigation-object-properties.html
+++ b/Tests/LibWeb/Text/input/HTML/Navigation-object-properties.html
@@ -1,0 +1,15 @@
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        let n = window.navigation;
+
+        // FIXME: Once we set up the interaction between Navigables and Navigation,
+        //        These two should become 1 and [object NavigationHistoryEntry], respectively
+        println(`entries is empty: ${n.entries().length == 0}`);
+        println(`currentEntry is null: ${n.currentEntry == null}`);
+
+        println(`transition is null: ${n.transition == null}`);
+        println(`canGoBack: ${n.canGoBack}`);
+        println(`canGoForward: ${n.canGoForward}`);       
+    });
+</script>

--- a/Userland/Libraries/LibWeb/HTML/Navigation.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Navigation.cpp
@@ -105,8 +105,10 @@ JS::GCPtr<NavigationHistoryEntry> Navigation::current_entry() const
     if (has_entries_and_events_disabled())
         return nullptr;
 
-    // 2. Assert: navigation's current entry index is not −1.
-    VERIFY(m_current_entry_index != -1);
+    // FIXME 2. Assert: navigation's current entry index is not −1.
+    // FIXME: This should not happen once Navigable's algorithms properly set up NHEs.
+    if (m_current_entry_index == -1)
+        return nullptr;
 
     // 3. Return navigation's entry list[navigation's current entry index].
     return m_entry_list[m_current_entry_index];
@@ -149,8 +151,10 @@ bool Navigation::can_go_back() const
     if (has_entries_and_events_disabled())
         return false;
 
-    // 2. Assert: this's current entry index is not −1.
-    VERIFY(m_current_entry_index != -1);
+    // FIXME 2. Assert: navigation's current entry index is not −1.
+    // FIXME: This should not happen once Navigable's algorithms properly set up NHEs.
+    if (m_current_entry_index == -1)
+        return false;
 
     // 3. If this's current entry index is 0, then return false.
     // 4. Return true.
@@ -166,8 +170,10 @@ bool Navigation::can_go_forward() const
     if (has_entries_and_events_disabled())
         return false;
 
-    // 2. Assert: this's current entry index is not −1.
-    VERIFY(m_current_entry_index != -1);
+    // FIXME 2. Assert: navigation's current entry index is not −1.
+    // FIXME: This should not happen once Navigable's algorithms properly set up NHEs.
+    if (m_current_entry_index == -1)
+        return false;
 
     // 3. If this's current entry index is equal to this's entry list's size, then return false.
     // 4. Return true.


### PR DESCRIPTION
The invariants for these property getters are supposed to be checked by the has_entries_and_events_disabled AO, but we don't have all the plumbing hooked up between Navigables and Navigation yet.

Add a test to make sure that these methods don't assert when calling them on a fresh page.

Fixes #20778