### PR TITLE
LibAudio: A few fixes for MP3Loader to play The Changelog podcast

### DIFF
--- a/Userland/Libraries/LibAudio/MP3Loader.cpp
+++ b/Userland/Libraries/LibAudio/MP3Loader.cpp
@@ -146,7 +146,6 @@ MaybeLoaderError MP3LoaderPlugin::build_seek_table()
     int sample_count = 0;
     size_t frame_count = 0;
     m_seek_table = {};
-    TRY(m_seek_table.insert_seek_point({ 0, 0 }));
 
     m_bitstream->align_to_byte_boundary();
 
@@ -157,11 +156,12 @@ MaybeLoaderError MP3LoaderPlugin::build_seek_table()
         if (error_or_header.is_error() || error_or_header.value().id != 1 || error_or_header.value().layer != 3) {
             continue;
         }
-        frame_count++;
-        sample_count += MP3::frame_size;
 
         if (frame_count % 10 == 0)
             TRY(m_seek_table.insert_seek_point({ static_cast<u64>(sample_count), frame_pos }));
+
+        frame_count++;
+        sample_count += MP3::frame_size;
 
         TRY(m_stream->seek(error_or_header.value().frame_size - 6, SeekMode::FromCurrentPosition));
 

--- a/Userland/Libraries/LibAudio/MP3Loader.h
+++ b/Userland/Libraries/LibAudio/MP3Loader.h
@@ -72,7 +72,6 @@ private:
     int m_total_samples { 0 };
     size_t m_loaded_samples { 0 };
 
-    OwnPtr<BigEndianInputBitStream> m_bitstream;
     AllocatingMemoryStream m_bit_reservoir;
 };
 

--- a/Userland/Libraries/LibAudio/MP3Loader.h
+++ b/Userland/Libraries/LibAudio/MP3Loader.h
@@ -43,9 +43,9 @@ private:
     MaybeLoaderError initialize();
     static MaybeLoaderError skip_id3(SeekableStream& stream);
     static MaybeLoaderError synchronize(BigEndianInputBitStream& stream, size_t sample_index);
+    static ErrorOr<MP3::Header, LoaderError> read_header(BigEndianInputBitStream& stream, size_t sample_index);
     MaybeLoaderError synchronize();
     MaybeLoaderError build_seek_table();
-    ErrorOr<MP3::Header, LoaderError> read_header();
     ErrorOr<MP3::MP3Frame, LoaderError> read_next_frame();
     ErrorOr<MP3::MP3Frame, LoaderError> read_frame_data(MP3::Header const&);
     MaybeLoaderError read_side_information(MP3::MP3Frame&);

--- a/Userland/Libraries/LibAudio/MP3Loader.h
+++ b/Userland/Libraries/LibAudio/MP3Loader.h
@@ -44,7 +44,8 @@ private:
     static MaybeLoaderError skip_id3(SeekableStream& stream);
     static MaybeLoaderError synchronize(SeekableStream& stream, size_t sample_index);
     static ErrorOr<MP3::Header, LoaderError> read_header(SeekableStream& stream, size_t sample_index);
-    MaybeLoaderError synchronize();
+    static ErrorOr<MP3::Header, LoaderError> synchronize_and_read_header(SeekableStream& stream, size_t sample_index);
+    ErrorOr<MP3::Header, LoaderError> synchronize_and_read_header();
     MaybeLoaderError build_seek_table();
     ErrorOr<MP3::MP3Frame, LoaderError> read_next_frame();
     ErrorOr<MP3::MP3Frame, LoaderError> read_frame_data(MP3::Header const&);

--- a/Userland/Libraries/LibAudio/MP3Loader.h
+++ b/Userland/Libraries/LibAudio/MP3Loader.h
@@ -72,7 +72,6 @@ private:
     int m_total_samples { 0 };
     size_t m_loaded_samples { 0 };
 
-    AK::Optional<MP3::MP3Frame> m_current_frame;
     OwnPtr<BigEndianInputBitStream> m_bitstream;
     AllocatingMemoryStream m_bit_reservoir;
 };

--- a/Userland/Libraries/LibAudio/MP3Loader.h
+++ b/Userland/Libraries/LibAudio/MP3Loader.h
@@ -42,8 +42,8 @@ public:
 private:
     MaybeLoaderError initialize();
     static MaybeLoaderError skip_id3(SeekableStream& stream);
-    static MaybeLoaderError synchronize(BigEndianInputBitStream& stream, size_t sample_index);
-    static ErrorOr<MP3::Header, LoaderError> read_header(BigEndianInputBitStream& stream, size_t sample_index);
+    static MaybeLoaderError synchronize(SeekableStream& stream, size_t sample_index);
+    static ErrorOr<MP3::Header, LoaderError> read_header(SeekableStream& stream, size_t sample_index);
     MaybeLoaderError synchronize();
     MaybeLoaderError build_seek_table();
     ErrorOr<MP3::MP3Frame, LoaderError> read_next_frame();

--- a/Userland/Libraries/LibAudio/MP3Loader.h
+++ b/Userland/Libraries/LibAudio/MP3Loader.h
@@ -41,6 +41,7 @@ public:
 
 private:
     MaybeLoaderError initialize();
+    static MaybeLoaderError skip_id3(SeekableStream& stream);
     static MaybeLoaderError synchronize(BigEndianInputBitStream& stream, size_t sample_index);
     MaybeLoaderError synchronize();
     MaybeLoaderError build_seek_table();

--- a/Userland/Libraries/LibAudio/MP3Types.h
+++ b/Userland/Libraries/LibAudio/MP3Types.h
@@ -45,21 +45,21 @@ enum class BlockType {
 };
 
 struct Header {
-    i32 id;
-    i32 layer;
-    bool protection_bit;
-    i32 bitrate;
-    i32 samplerate;
-    bool padding_bit;
-    bool private_bit;
-    Mode mode;
-    ModeExtension mode_extension;
-    bool copyright_bit;
-    bool original_bit;
-    Emphasis emphasis;
-    u16 crc16;
-    size_t frame_size;
-    size_t slot_count;
+    i32 id { 0 };
+    i32 layer { 0 };
+    bool protection_bit { false };
+    i32 bitrate { 0 };
+    i32 samplerate { 0 };
+    bool padding_bit { false };
+    bool private_bit { false };
+    Mode mode { Mode::Stereo };
+    ModeExtension mode_extension { ModeExtension::Stereo };
+    bool copyright_bit { false };
+    bool original_bit { false };
+    Emphasis emphasis { Emphasis::None };
+    u16 crc16 { 0 };
+    size_t frame_size { 0 };
+    size_t slot_count { 0 };
 
     size_t channel_count() const { return mode == Mode::SingleChannel ? 1 : 2; }
 };
@@ -68,20 +68,20 @@ struct Granule {
     Array<float, MP3::granule_size> samples;
     Array<Array<float, 18>, 32> filter_bank_input;
     Array<Array<float, 32>, 18> pcm;
-    u32 part_2_3_length;
-    u32 big_values;
-    u32 global_gain;
-    u32 scalefac_compress;
-    bool window_switching_flag;
-    BlockType block_type;
-    bool mixed_block_flag;
+    u32 part_2_3_length { 0 };
+    u32 big_values { 0 };
+    u32 global_gain { 0 };
+    u32 scalefac_compress { 0 };
+    bool window_switching_flag { false };
+    BlockType block_type { BlockType::Normal };
+    bool mixed_block_flag { false };
     Array<int, 3> table_select;
     Array<int, 3> sub_block_gain;
-    u32 region0_count;
-    u32 region1_count;
-    bool preflag;
-    bool scalefac_scale;
-    bool count1table_select;
+    u32 region0_count { 0 };
+    u32 region1_count { 0 };
+    bool preflag { false };
+    bool scalefac_scale { false };
+    bool count1table_select { false };
 };
 
 struct Channel {
@@ -93,8 +93,8 @@ struct Channel {
 struct MP3Frame {
     Header header;
     FixedArray<Channel> channels;
-    off_t main_data_begin;
-    u32 private_bits;
+    off_t main_data_begin { 0 };
+    u32 private_bits { 0 };
 
     MP3Frame(Header header)
         : header(header)

--- a/Userland/Libraries/LibAudio/MP3Types.h
+++ b/Userland/Libraries/LibAudio/MP3Types.h
@@ -58,6 +58,7 @@ struct Header {
     bool original_bit { false };
     Emphasis emphasis { Emphasis::None };
     u16 crc16 { 0 };
+    size_t header_size { 0 };
     size_t frame_size { 0 };
     size_t slot_count { 0 };
 


### PR DESCRIPTION
To allow the recent [Changelog Interview with Andreas](https://changelog.com/podcast/554) to play in LibWeb, this implements a few fixes for `MP3Loader`:

- Parse the size of the ID3 tags from the header to skip past all the data before finding an MP3 frame sync code. Since the podcast MP3 file has a large PNG image for its album art, some of its data would be recognized as an MP3 frame, causing errors trying to play it back.
- Use the correct frame header size to skip the exact size of a frame when calculating the duration of audio and creating the seek table. Previously, it would skip to 2 bytes before the next frame when skipping a frame that has no CRC16 checksum, meaning that if it appears to have a sync code in those 2 bytes before the next frame, it will cause it to skip the frame since the field values were illegal.
- Use `read_header()` to check for valid frames when `sniff()`ing for an MP3 file. This _should_ have no effect except consolidating some duplicate conditions.
- Read the header when synchronizing to the next frame so that we can ensure that the frame it stops at will not immediately fail due to bad field values.
- Make synchronization work byte-by-byte instead of bit-by-bit. This should hopefully provide a slight performance improvement, especially in startup time.
- Remove some fields from `MP3Loader` that could just be stored in local variables instead.

Here it is playing back the podcast on their page!

https://github.com/SerenityOS/serenity/assets/3149592/a9ae90b8-a70a-4582-b082-af4839044737
