### PR TITLE
useradd: Allow group name or number to be used with the `-g`option

### DIFF
--- a/Base/usr/share/man/man8/useradd.md
+++ b/Base/usr/share/man/man8/useradd.md
@@ -19,7 +19,7 @@ This program must be run as root.
 ## Options
 
 * `-u`, `--uid` _uid_: The user identifier for the new user. If not specified, an unused UID above `1000` will be auto-generated.
-* `-g`, `--gid` _gid_: The group identifier for the new user. If not specified, it will default to 100 (the **users** group).
+* `-g`, `--gid` _group_: The group name or identifier for the new user. If not specified, it will default to 100 (the **users** group).
 * `-p`, `--password` _password_: The encrypted password for the new user. If not specified, it will default to blank.
 * `-s`, `--shell` _path-to-shell_: The shell binary for this login. The default is `/bin/Shell`.
 * `-m`, `--create-home`: Create the specified home directory for this new user.

--- a/Userland/Utilities/useradd.cpp
+++ b/Userland/Utilities/useradd.cpp
@@ -55,7 +55,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::pledge("stdio wpath rpath cpath chown"));
 
     StringView home_path;
-    int uid = 0;
+    uid_t uid = 0;
     gid_t gid = USERS_GID;
     bool create_home_dir = false;
     DeprecatedString password = "";
@@ -107,11 +107,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     if (passwd.has_value()) {
         warnln("user {} already exists!", username);
         return 1;
-    }
-
-    if (uid < 0) {
-        warnln("invalid uid {}!", uid);
-        return 3;
     }
 
     // First, let's sort out the uid for the user


### PR DESCRIPTION
Previously, only the group number could be used.

Example usage:

![useradd_group_by_name](https://github.com/SerenityOS/serenity/assets/2817754/f58b0144-d205-45cd-84c3-9cacc267835f)
