### PR TITLE
LibWeb: Port some more IDL interfaces to new AK String

### DIFF
--- a/Userland/Applications/Browser/StorageModel.cpp
+++ b/Userland/Applications/Browser/StorageModel.cpp
@@ -10,10 +10,10 @@
 
 namespace Browser {
 
-void StorageModel::set_items(OrderedHashMap<DeprecatedString, DeprecatedString> map)
+void StorageModel::set_items(OrderedHashMap<String, String> map)
 {
     begin_insert_rows({}, m_local_storage_entries.size(), m_local_storage_entries.size());
-    m_local_storage_entries = map;
+    m_local_storage_entries = move(map);
     end_insert_rows();
 
     did_update(DontInvalidateIndices);

--- a/Userland/Applications/Browser/StorageModel.h
+++ b/Userland/Applications/Browser/StorageModel.h
@@ -18,7 +18,7 @@ public:
         __Count,
     };
 
-    void set_items(OrderedHashMap<DeprecatedString, DeprecatedString> map);
+    void set_items(OrderedHashMap<String, String> map);
     void clear_items();
     virtual int row_count(GUI::ModelIndex const&) const override;
     virtual int column_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override { return Column::__Count; }
@@ -28,7 +28,7 @@ public:
     virtual GUI::Model::MatchResult data_matches(GUI::ModelIndex const& index, GUI::Variant const& term) const override;
 
 private:
-    OrderedHashMap<DeprecatedString, DeprecatedString> m_local_storage_entries;
+    OrderedHashMap<String, String> m_local_storage_entries;
 };
 
 }

--- a/Userland/Applications/Browser/StorageWidget.cpp
+++ b/Userland/Applications/Browser/StorageWidget.cpp
@@ -107,7 +107,7 @@ void StorageWidget::clear_cookies()
     m_cookies_model->clear_items();
 }
 
-void StorageWidget::set_local_storage_entries(OrderedHashMap<DeprecatedString, DeprecatedString> entries)
+void StorageWidget::set_local_storage_entries(OrderedHashMap<String, String> entries)
 {
     m_local_storage_model->set_items(move(entries));
 }
@@ -117,7 +117,7 @@ void StorageWidget::clear_local_storage_entries()
     m_local_storage_model->clear_items();
 }
 
-void StorageWidget::set_session_storage_entries(OrderedHashMap<DeprecatedString, DeprecatedString> entries)
+void StorageWidget::set_session_storage_entries(OrderedHashMap<String, String> entries)
 {
     m_session_storage_model->set_items(move(entries));
 }

--- a/Userland/Applications/Browser/StorageWidget.h
+++ b/Userland/Applications/Browser/StorageWidget.h
@@ -26,10 +26,10 @@ public:
 
     Function<void(Web::Cookie::Cookie)> on_update_cookie;
 
-    void set_local_storage_entries(OrderedHashMap<DeprecatedString, DeprecatedString> entries);
+    void set_local_storage_entries(OrderedHashMap<String, String> entries);
     void clear_local_storage_entries();
 
-    void set_session_storage_entries(OrderedHashMap<DeprecatedString, DeprecatedString> entries);
+    void set_session_storage_entries(OrderedHashMap<String, String> entries);
     void clear_session_storage_entries();
 
 private:

--- a/Userland/Applications/Browser/Tab.h
+++ b/Userland/Applications/Browser/Tab.h
@@ -76,8 +76,8 @@ public:
     Function<void()> on_dump_cookies;
     Function<void(Web::Cookie::Cookie)> on_update_cookie;
     Function<Vector<Web::Cookie::Cookie>()> on_get_cookies_entries;
-    Function<OrderedHashMap<DeprecatedString, DeprecatedString>()> on_get_local_storage_entries;
-    Function<OrderedHashMap<DeprecatedString, DeprecatedString>()> on_get_session_storage_entries;
+    Function<OrderedHashMap<String, String>()> on_get_local_storage_entries;
+    Function<OrderedHashMap<String, String>()> on_get_session_storage_entries;
 
     void enable_webdriver_mode();
 

--- a/Userland/Libraries/LibWeb/CSS/CSSConditionRule.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSConditionRule.h
@@ -18,8 +18,8 @@ class CSSConditionRule : public CSSGroupingRule {
 public:
     virtual ~CSSConditionRule() = default;
 
-    virtual DeprecatedString condition_text() const = 0;
-    virtual void set_condition_text(DeprecatedString) = 0;
+    virtual String condition_text() const = 0;
+    virtual void set_condition_text(String const&) = 0;
     virtual bool condition_matches() const = 0;
 
     virtual void for_each_effective_style_rule(Function<void(CSSStyleRule const&)> const& callback) const override;

--- a/Userland/Libraries/LibWeb/CSS/CSSConditionRule.idl
+++ b/Userland/Libraries/LibWeb/CSS/CSSConditionRule.idl
@@ -1,6 +1,6 @@
 #import <CSS/CSSGroupingRule.idl>
 
-[Exposed=Window]
+[Exposed=Window, UseNewAKString]
 interface CSSConditionRule : CSSGroupingRule {
     attribute CSSOMString conditionText;
 };

--- a/Userland/Libraries/LibWeb/CSS/CSSKeyframeRule.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSKeyframeRule.h
@@ -29,12 +29,12 @@ public:
     CSS::Percentage key() const { return m_key; }
     JS::NonnullGCPtr<CSSStyleDeclaration> style() const { return m_declarations; }
 
-    DeprecatedString key_text() const
+    String key_text() const
     {
-        return m_key.to_string().to_deprecated_string();
+        return m_key.to_string();
     }
 
-    void set_key_text(DeprecatedString const& key_text)
+    void set_key_text(String const& key_text)
     {
         dbgln("FIXME: CSSKeyframeRule::set_key_text is not implemented: {}", key_text);
     }

--- a/Userland/Libraries/LibWeb/CSS/CSSKeyframeRule.idl
+++ b/Userland/Libraries/LibWeb/CSS/CSSKeyframeRule.idl
@@ -1,6 +1,6 @@
 #import <CSS/CSSRule.idl>
 
-[Exposed=Window]
+[Exposed=Window, UseNewAKString]
 interface CSSKeyframeRule : CSSRule {
     attribute CSSOMString keyText;
     [SameObject, PutForwards=cssText] readonly attribute CSSStyleDeclaration style;

--- a/Userland/Libraries/LibWeb/CSS/CSSKeyframesRule.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSKeyframesRule.h
@@ -31,10 +31,7 @@ public:
     FlyString const& name() const { return m_name; }
     size_t length() { return m_keyframes.size(); }
 
-    void set_name(DeprecatedString const& name)
-    {
-        m_name = FlyString::from_utf8(name.view()).release_value_but_fixme_should_propagate_errors();
-    }
+    void set_name(String const& name) { m_name = name; }
 
 private:
     CSSKeyframesRule(JS::Realm& realm, FlyString name, Vector<JS::NonnullGCPtr<CSSKeyframeRule>> keyframes)

--- a/Userland/Libraries/LibWeb/CSS/CSSKeyframesRule.idl
+++ b/Userland/Libraries/LibWeb/CSS/CSSKeyframesRule.idl
@@ -1,6 +1,6 @@
 #import <CSS/CSSRule.idl>
 
-[Exposed=Window]
+[Exposed=Window, UseNewAKString]
 interface CSSKeyframesRule : CSSRule {
     attribute CSSOMString name;
     readonly attribute unsigned long length;

--- a/Userland/Libraries/LibWeb/CSS/CSSMediaRule.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSMediaRule.cpp
@@ -37,7 +37,7 @@ void CSSMediaRule::visit_edges(Cell::Visitor& visitor)
 
 DeprecatedString CSSMediaRule::condition_text() const
 {
-    return m_media->media_text();
+    return m_media->media_text().to_deprecated_string();
 }
 
 void CSSMediaRule::set_condition_text(DeprecatedString text)

--- a/Userland/Libraries/LibWeb/CSS/CSSMediaRule.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSMediaRule.cpp
@@ -35,12 +35,12 @@ void CSSMediaRule::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_media);
 }
 
-DeprecatedString CSSMediaRule::condition_text() const
+String CSSMediaRule::condition_text() const
 {
-    return m_media->media_text().to_deprecated_string();
+    return String::from_deprecated_string(m_media->media_text().to_deprecated_string()).release_value();
 }
 
-void CSSMediaRule::set_condition_text(DeprecatedString text)
+void CSSMediaRule::set_condition_text(String const& text)
 {
     m_media->set_media_text(text);
 }

--- a/Userland/Libraries/LibWeb/CSS/CSSMediaRule.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSMediaRule.h
@@ -24,8 +24,8 @@ public:
 
     virtual Type type() const override { return Type::Media; }
 
-    virtual DeprecatedString condition_text() const override;
-    virtual void set_condition_text(DeprecatedString) override;
+    virtual String condition_text() const override;
+    virtual void set_condition_text(String const&) override;
     virtual bool condition_matches() const override { return m_media->matches(); }
 
     MediaList* media() const { return m_media; }

--- a/Userland/Libraries/LibWeb/CSS/CSSSupportsRule.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSSupportsRule.cpp
@@ -28,12 +28,12 @@ void CSSSupportsRule::initialize(JS::Realm& realm)
     set_prototype(&Bindings::ensure_web_prototype<Bindings::CSSSupportsRulePrototype>(realm, "CSSSupportsRule"));
 }
 
-DeprecatedString CSSSupportsRule::condition_text() const
+String CSSSupportsRule::condition_text() const
 {
-    return m_supports->to_string().to_deprecated_string();
+    return m_supports->to_string();
 }
 
-void CSSSupportsRule::set_condition_text(DeprecatedString text)
+void CSSSupportsRule::set_condition_text(String const& text)
 {
     if (auto new_supports = parse_css_supports(Parser::ParsingContext { realm() }, text))
         m_supports = new_supports.release_nonnull();

--- a/Userland/Libraries/LibWeb/CSS/CSSSupportsRule.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSSupportsRule.h
@@ -25,8 +25,8 @@ public:
 
     virtual Type type() const override { return Type::Supports; }
 
-    DeprecatedString condition_text() const override;
-    void set_condition_text(DeprecatedString) override;
+    String condition_text() const override;
+    void set_condition_text(String const&) override;
     virtual bool condition_matches() const override { return m_supports->matches(); }
 
 private:

--- a/Userland/Libraries/LibWeb/CSS/MediaList.cpp
+++ b/Userland/Libraries/LibWeb/CSS/MediaList.cpp
@@ -31,13 +31,13 @@ void MediaList::initialize(JS::Realm& realm)
 }
 
 // https://www.w3.org/TR/cssom-1/#dom-medialist-mediatext
-DeprecatedString MediaList::media_text() const
+String MediaList::media_text() const
 {
-    return serialize_a_media_query_list(m_media).to_deprecated_string();
+    return serialize_a_media_query_list(m_media);
 }
 
 // https://www.w3.org/TR/cssom-1/#dom-medialist-mediatext
-void MediaList::set_media_text(DeprecatedString const& text)
+void MediaList::set_media_text(StringView text)
 {
     m_media.clear();
     if (text.is_empty())
@@ -51,16 +51,16 @@ bool MediaList::is_supported_property_index(u32 index) const
 }
 
 // https://www.w3.org/TR/cssom-1/#dom-medialist-item
-DeprecatedString MediaList::item(u32 index) const
+Optional<String> MediaList::item(u32 index) const
 {
     if (!is_supported_property_index(index))
         return {};
 
-    return m_media[index]->to_string().to_deprecated_string();
+    return m_media[index]->to_string();
 }
 
 // https://www.w3.org/TR/cssom-1/#dom-medialist-appendmedium
-void MediaList::append_medium(DeprecatedString medium)
+void MediaList::append_medium(StringView medium)
 {
     // 1. Let m be the result of parsing the given value.
     auto m = parse_media_query(Parser::ParsingContext { realm() }, medium);
@@ -81,7 +81,7 @@ void MediaList::append_medium(DeprecatedString medium)
 }
 
 // https://www.w3.org/TR/cssom-1/#dom-medialist-deletemedium
-void MediaList::delete_medium(DeprecatedString medium)
+void MediaList::delete_medium(StringView medium)
 {
     auto m = parse_media_query(Parser::ParsingContext { realm() }, medium);
     if (!m)

--- a/Userland/Libraries/LibWeb/CSS/MediaList.h
+++ b/Userland/Libraries/LibWeb/CSS/MediaList.h
@@ -23,12 +23,12 @@ public:
     [[nodiscard]] static JS::NonnullGCPtr<MediaList> create(JS::Realm&, Vector<NonnullRefPtr<MediaQuery>>&&);
     ~MediaList() = default;
 
-    DeprecatedString media_text() const;
-    void set_media_text(DeprecatedString const&);
+    String media_text() const;
+    void set_media_text(StringView);
     size_t length() const { return m_media.size(); }
-    DeprecatedString item(u32 index) const;
-    void append_medium(DeprecatedString);
-    void delete_medium(DeprecatedString);
+    Optional<String> item(u32 index) const;
+    void append_medium(StringView);
+    void delete_medium(StringView);
 
     virtual bool is_supported_property_index(u32 index) const override;
     virtual WebIDL::ExceptionOr<JS::Value> item_value(size_t index) const override;

--- a/Userland/Libraries/LibWeb/CSS/MediaList.idl
+++ b/Userland/Libraries/LibWeb/CSS/MediaList.idl
@@ -1,4 +1,4 @@
-[Exposed=Window]
+[Exposed=Window, UseNewAKString]
 interface MediaList {
     [LegacyNullToEmptyString] stringifier attribute CSSOMString mediaText;
     readonly attribute unsigned long length;

--- a/Userland/Libraries/LibWeb/DOM/Range.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Range.cpp
@@ -551,7 +551,7 @@ WebIDL::ExceptionOr<i16> Range::compare_point(Node const& node, u32 offset) cons
 }
 
 // https://dom.spec.whatwg.org/#dom-range-stringifier
-DeprecatedString Range::to_deprecated_string() const
+String Range::to_string() const
 {
     // 1. Let s be the empty string.
     StringBuilder builder;
@@ -559,7 +559,7 @@ DeprecatedString Range::to_deprecated_string() const
     // 2. If this’s start node is this’s end node and it is a Text node,
     //    then return the substring of that Text node’s data beginning at this’s start offset and ending at this’s end offset.
     if (start_container() == end_container() && is<Text>(*start_container()))
-        return static_cast<Text const&>(*start_container()).data().substring(start_offset(), end_offset() - start_offset());
+        return String::from_deprecated_string(static_cast<Text const&>(*start_container()).data().substring(start_offset(), end_offset() - start_offset())).release_value();
 
     // 3. If this’s start node is a Text node, then append the substring of that node’s data from this’s start offset until the end to s.
     if (is<Text>(*start_container()))
@@ -576,7 +576,7 @@ DeprecatedString Range::to_deprecated_string() const
         builder.append(static_cast<Text const&>(*end_container()).data().substring_view(0, end_offset()));
 
     // 6. Return s.
-    return builder.to_deprecated_string();
+    return MUST(builder.to_string());
 }
 
 // https://dom.spec.whatwg.org/#dom-range-extractcontents
@@ -1145,7 +1145,7 @@ JS::NonnullGCPtr<Geometry::DOMRect> Range::get_bounding_client_rect() const
 }
 
 // https://w3c.github.io/DOM-Parsing/#dom-range-createcontextualfragment
-WebIDL::ExceptionOr<JS::NonnullGCPtr<DocumentFragment>> Range::create_contextual_fragment(DeprecatedString const& fragment)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<DocumentFragment>> Range::create_contextual_fragment(String const& fragment)
 {
     // 1. Let node be the context object's start node.
     JS::NonnullGCPtr<Node> node = *start_container();
@@ -1185,7 +1185,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<DocumentFragment>> Range::create_contextual
     }
 
     // 3. Let fragment node be the result of invoking the fragment parsing algorithm with fragment as markup, and element as the context element.
-    auto fragment_node = TRY(DOMParsing::parse_fragment(fragment, *element));
+    auto fragment_node = TRY(DOMParsing::parse_fragment(fragment.to_deprecated_string(), *element));
 
     // 4. Unmark all scripts in fragment node as "already started" and as "parser-inserted".
     fragment_node->for_each_in_subtree_of_type<HTML::HTMLScriptElement>([&](HTML::HTMLScriptElement& script_element) {

--- a/Userland/Libraries/LibWeb/DOM/Range.h
+++ b/Userland/Libraries/LibWeb/DOM/Range.h
@@ -79,7 +79,7 @@ public:
     WebIDL::ExceptionOr<void> insert_node(JS::NonnullGCPtr<Node>);
     WebIDL::ExceptionOr<void> surround_contents(JS::NonnullGCPtr<Node> new_parent);
 
-    DeprecatedString to_deprecated_string() const;
+    String to_string() const;
 
     static HashTable<Range*>& live_ranges();
 
@@ -89,7 +89,7 @@ public:
 
     void set_associated_selection(Badge<Selection::Selection>, JS::GCPtr<Selection::Selection>);
 
-    WebIDL::ExceptionOr<JS::NonnullGCPtr<DocumentFragment>> create_contextual_fragment(DeprecatedString const& fragment);
+    WebIDL::ExceptionOr<JS::NonnullGCPtr<DocumentFragment>> create_contextual_fragment(String const& fragment);
 
 private:
     explicit Range(Document&);

--- a/Userland/Libraries/LibWeb/DOM/Range.idl
+++ b/Userland/Libraries/LibWeb/DOM/Range.idl
@@ -2,7 +2,7 @@
 #import <DOM/AbstractRange.idl>
 #import <Geometry/DOMRect.idl>
 
-[Exposed=Window]
+[Exposed=Window, UseNewAKString]
 interface Range : AbstractRange {
 
     constructor();

--- a/Userland/Libraries/LibWeb/HTML/History.cpp
+++ b/Userland/Libraries/LibWeb/HTML/History.cpp
@@ -37,14 +37,14 @@ void History::visit_edges(Cell::Visitor& visitor)
 }
 
 // https://html.spec.whatwg.org/multipage/history.html#dom-history-pushstate
-WebIDL::ExceptionOr<void> History::push_state(JS::Value data, DeprecatedString const&, DeprecatedString const& url)
+WebIDL::ExceptionOr<void> History::push_state(JS::Value data, String const&, Optional<String> const& url)
 {
     // NOTE: The second parameter of this function is intentionally unused.
     return shared_history_push_replace_state(data, url, IsPush::Yes);
 }
 
 // https://html.spec.whatwg.org/multipage/history.html#dom-history-replacestate
-WebIDL::ExceptionOr<void> History::replace_state(JS::Value data, DeprecatedString const&, DeprecatedString const& url)
+WebIDL::ExceptionOr<void> History::replace_state(JS::Value data, String const&, Optional<String> const& url)
 {
     // NOTE: The second parameter of this function is intentionally unused.
     return shared_history_push_replace_state(data, url, IsPush::No);
@@ -150,7 +150,7 @@ static bool can_have_its_url_rewritten(DOM::Document const& document, AK::URL co
 }
 
 // https://html.spec.whatwg.org/multipage/history.html#shared-history-push/replace-state-steps
-WebIDL::ExceptionOr<void> History::shared_history_push_replace_state(JS::Value value, DeprecatedString const& url, IsPush)
+WebIDL::ExceptionOr<void> History::shared_history_push_replace_state(JS::Value value, Optional<String> const& url, IsPush)
 {
     // 1. Let document be history's associated Document.
     auto& document = m_associated_document;
@@ -171,10 +171,10 @@ WebIDL::ExceptionOr<void> History::shared_history_push_replace_state(JS::Value v
     auto new_url = document->url();
 
     // 6. If url is not null or the empty string, then:
-    if (!url.is_empty() && !url.is_null()) {
+    if (url.has_value() && !url->is_empty()) {
 
         // 1. Parse url, relative to the relevant settings object of history.
-        auto parsed_url = relevant_settings_object(*this).parse_url(url);
+        auto parsed_url = relevant_settings_object(*this).parse_url(url->to_deprecated_string());
 
         // 2. If that fails, then throw a "SecurityError" DOMException.
         if (!parsed_url.is_valid())

--- a/Userland/Libraries/LibWeb/HTML/History.h
+++ b/Userland/Libraries/LibWeb/HTML/History.h
@@ -20,8 +20,8 @@ public:
 
     virtual ~History() override;
 
-    WebIDL::ExceptionOr<void> push_state(JS::Value data, DeprecatedString const& unused, DeprecatedString const& url);
-    WebIDL::ExceptionOr<void> replace_state(JS::Value data, DeprecatedString const& unused, DeprecatedString const& url);
+    WebIDL::ExceptionOr<void> push_state(JS::Value data, String const& unused, Optional<String> const& url = {});
+    WebIDL::ExceptionOr<void> replace_state(JS::Value data, String const& unused, Optional<String> const& url = {});
     WebIDL::ExceptionOr<void> go(long delta);
     WebIDL::ExceptionOr<void> back();
     WebIDL::ExceptionOr<void> forward();
@@ -37,7 +37,7 @@ private:
         No,
         Yes,
     };
-    WebIDL::ExceptionOr<void> shared_history_push_replace_state(JS::Value data, DeprecatedString const& url, IsPush is_push);
+    WebIDL::ExceptionOr<void> shared_history_push_replace_state(JS::Value data, Optional<String> const& url, IsPush is_push);
 
     JS::NonnullGCPtr<DOM::Document> m_associated_document;
 };

--- a/Userland/Libraries/LibWeb/HTML/History.idl
+++ b/Userland/Libraries/LibWeb/HTML/History.idl
@@ -1,5 +1,5 @@
 // https://html.spec.whatwg.org/multipage/history.html#the-history-interface
-[Exposed=Window]
+[Exposed=Window, UseNewAKString]
 interface History {
     readonly attribute unsigned long length;
     // FIXME: attribute ScrollRestoration scrollRestoration;

--- a/Userland/Libraries/LibWeb/HTML/Path2D.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Path2D.cpp
@@ -14,13 +14,13 @@
 
 namespace Web::HTML {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<Path2D>> Path2D::construct_impl(JS::Realm& realm, Optional<Variant<JS::Handle<Path2D>, DeprecatedString>> const& path)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<Path2D>> Path2D::construct_impl(JS::Realm& realm, Optional<Variant<JS::Handle<Path2D>, String>> const& path)
 {
     return realm.heap().allocate<Path2D>(realm, realm, path);
 }
 
 // https://html.spec.whatwg.org/multipage/canvas.html#dom-path2d
-Path2D::Path2D(JS::Realm& realm, Optional<Variant<JS::Handle<Path2D>, DeprecatedString>> const& path)
+Path2D::Path2D(JS::Realm& realm, Optional<Variant<JS::Handle<Path2D>, String>> const& path)
     : PlatformObject(realm)
     , CanvasPath(static_cast<Bindings::PlatformObject&>(*this))
 {
@@ -37,7 +37,7 @@ Path2D::Path2D(JS::Realm& realm, Optional<Variant<JS::Handle<Path2D>, Deprecated
     }
 
     // 4. Let svgPath be the result of parsing and interpreting path according to SVG 2's rules for path data. [SVG]
-    auto path_instructions = SVG::AttributeParser::parse_path_data(path->get<DeprecatedString>());
+    auto path_instructions = SVG::AttributeParser::parse_path_data(path->get<String>());
     auto svg_path = SVG::path_from_path_instructions(path_instructions);
 
     if (!svg_path.segments().is_empty()) {

--- a/Userland/Libraries/LibWeb/HTML/Path2D.h
+++ b/Userland/Libraries/LibWeb/HTML/Path2D.h
@@ -22,14 +22,14 @@ class Path2D final
     WEB_PLATFORM_OBJECT(Path2D, Bindings::PlatformObject);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<Path2D>> construct_impl(JS::Realm&, Optional<Variant<JS::Handle<Path2D>, DeprecatedString>> const& path);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<Path2D>> construct_impl(JS::Realm&, Optional<Variant<JS::Handle<Path2D>, String>> const& path);
 
     virtual ~Path2D() override;
 
     WebIDL::ExceptionOr<void> add_path(JS::NonnullGCPtr<Path2D> path, Geometry::DOMMatrix2DInit& transform);
 
 private:
-    Path2D(JS::Realm&, Optional<Variant<JS::Handle<Path2D>, DeprecatedString>> const&);
+    Path2D(JS::Realm&, Optional<Variant<JS::Handle<Path2D>, String>> const&);
 
     virtual void initialize(JS::Realm&) override;
 };

--- a/Userland/Libraries/LibWeb/HTML/Path2D.idl
+++ b/Userland/Libraries/LibWeb/HTML/Path2D.idl
@@ -2,7 +2,7 @@
 #import <HTML/Canvas/CanvasPath.idl>
 
 // https://html.spec.whatwg.org/multipage/canvas.html#path2d
-[Exposed=(Window,Worker)]
+[Exposed=(Window,Worker), UseNewAKString]
 interface Path2D {
     constructor(optional (Path2D or DOMString) path);
 

--- a/Userland/Libraries/LibWeb/HTML/Storage.h
+++ b/Userland/Libraries/LibWeb/HTML/Storage.h
@@ -21,10 +21,10 @@ public:
     ~Storage();
 
     size_t length() const;
-    DeprecatedString key(size_t index);
-    DeprecatedString get_item(DeprecatedString const& key) const;
-    WebIDL::ExceptionOr<void> set_item(DeprecatedString const& key, DeprecatedString const& value);
-    void remove_item(DeprecatedString const& key);
+    Optional<String> key(size_t index);
+    Optional<String> get_item(StringView key) const;
+    WebIDL::ExceptionOr<void> set_item(String const& key, String const& value);
+    void remove_item(StringView key);
     void clear();
 
     auto const& map() const { return m_map; }
@@ -55,9 +55,9 @@ private:
     virtual bool named_property_deleter_has_identifier() const override { return true; }
 
     void reorder();
-    void broadcast(DeprecatedString const& key, DeprecatedString const& old_value, DeprecatedString const& new_value);
+    void broadcast(StringView key, StringView old_value, StringView new_value);
 
-    OrderedHashMap<DeprecatedString, DeprecatedString> m_map;
+    OrderedHashMap<String, String> m_map;
 };
 
 }

--- a/Userland/Libraries/LibWeb/HTML/Storage.idl
+++ b/Userland/Libraries/LibWeb/HTML/Storage.idl
@@ -1,4 +1,4 @@
-[Exposed=Window]
+[Exposed=Window, UseNewAKString]
 interface Storage {
 
     readonly attribute unsigned long length;

--- a/Userland/Libraries/LibWeb/Selection/Selection.cpp
+++ b/Userland/Libraries/LibWeb/Selection/Selection.cpp
@@ -104,13 +104,13 @@ unsigned Selection::range_count() const
     return 0;
 }
 
-DeprecatedString Selection::type() const
+String Selection::type() const
 {
     if (!m_range)
-        return "None";
+        return "None"_string;
     if (m_range->collapsed())
-        return "Caret";
-    return "Range";
+        return "Caret"_string;
+    return "Range"_string;
 }
 
 // https://w3c.github.io/selection-api/#dom-selection-getrangeat
@@ -421,13 +421,13 @@ bool Selection::contains_node(JS::NonnullGCPtr<DOM::Node> node, bool allow_parti
         && (end_relative_position == DOM::RelativeBoundaryPointPosition::Equal || end_relative_position == DOM::RelativeBoundaryPointPosition::After);
 }
 
-DeprecatedString Selection::to_deprecated_string() const
+String Selection::to_string() const
 {
     // FIXME: This needs more work to be compatible with other engines.
     //        See https://www.w3.org/Bugs/Public/show_bug.cgi?id=10583
     if (!m_range)
-        return DeprecatedString::empty();
-    return m_range->to_deprecated_string();
+        return String {};
+    return String::from_deprecated_string(m_range->to_deprecated_string()).release_value();
 }
 
 JS::NonnullGCPtr<DOM::Document> Selection::document() const

--- a/Userland/Libraries/LibWeb/Selection/Selection.cpp
+++ b/Userland/Libraries/LibWeb/Selection/Selection.cpp
@@ -427,7 +427,7 @@ String Selection::to_string() const
     //        See https://www.w3.org/Bugs/Public/show_bug.cgi?id=10583
     if (!m_range)
         return String {};
-    return String::from_deprecated_string(m_range->to_deprecated_string()).release_value();
+    return m_range->to_string();
 }
 
 JS::NonnullGCPtr<DOM::Document> Selection::document() const

--- a/Userland/Libraries/LibWeb/Selection/Selection.h
+++ b/Userland/Libraries/LibWeb/Selection/Selection.h
@@ -31,7 +31,7 @@ public:
     unsigned focus_offset() const;
     bool is_collapsed() const;
     unsigned range_count() const;
-    DeprecatedString type() const;
+    String type() const;
     WebIDL::ExceptionOr<JS::GCPtr<DOM::Range>> get_range_at(unsigned index);
     void add_range(JS::NonnullGCPtr<DOM::Range>);
     WebIDL::ExceptionOr<void> remove_range(JS::NonnullGCPtr<DOM::Range>);
@@ -48,7 +48,7 @@ public:
     delete_from_document();
     bool contains_node(JS::NonnullGCPtr<DOM::Node>, bool allow_partial_containment) const;
 
-    DeprecatedString to_deprecated_string() const;
+    String to_string() const;
 
     // Non-standard convenience accessor for the selection's range.
     JS::GCPtr<DOM::Range> range() const;

--- a/Userland/Libraries/LibWeb/Selection/Selection.idl
+++ b/Userland/Libraries/LibWeb/Selection/Selection.idl
@@ -1,7 +1,7 @@
 #import <DOM/Node.idl>
 #import <DOM/Range.idl>
 
-[Exposed=Window]
+[Exposed=Window, UseNewAKString]
 interface Selection {
 
     readonly attribute Node? anchorNode;

--- a/Userland/Libraries/LibWeb/WebGL/WebGLRenderingContext.idl
+++ b/Userland/Libraries/LibWeb/WebGL/WebGLRenderingContext.idl
@@ -1,6 +1,6 @@
 #import <WebGL/WebGLRenderingContextBase.idl>
 
-[Exposed=(Window,Worker)]
+[Exposed=(Window,Worker), UseNewAKString]
 interface WebGLRenderingContext {
 };
 

--- a/Userland/Libraries/LibWeb/WebGL/WebGLRenderingContextBase.cpp
+++ b/Userland/Libraries/LibWeb/WebGL/WebGLRenderingContextBase.cpp
@@ -119,18 +119,18 @@ bool WebGLRenderingContextBase::is_context_lost() const
     return m_context_lost;
 }
 
-Optional<Vector<DeprecatedString>> WebGLRenderingContextBase::get_supported_extensions() const
+Optional<Vector<String>> WebGLRenderingContextBase::get_supported_extensions() const
 {
     if (m_context_lost)
-        return Optional<Vector<DeprecatedString>> {};
+        return Optional<Vector<String>> {};
 
     dbgln_if(WEBGL_CONTEXT_DEBUG, "WebGLRenderingContextBase::get_supported_extensions()");
 
     // FIXME: We don't currently support any extensions.
-    return Vector<DeprecatedString> {};
+    return Vector<String> {};
 }
 
-JS::Object* WebGLRenderingContextBase::get_extension(DeprecatedString const& name) const
+JS::Object* WebGLRenderingContextBase::get_extension(String const& name) const
 {
     if (m_context_lost)
         return nullptr;

--- a/Userland/Libraries/LibWeb/WebGL/WebGLRenderingContextBase.h
+++ b/Userland/Libraries/LibWeb/WebGL/WebGLRenderingContextBase.h
@@ -29,8 +29,8 @@ public:
 
     bool is_context_lost() const;
 
-    Optional<Vector<DeprecatedString>> get_supported_extensions() const;
-    JS::Object* get_extension(DeprecatedString const& name) const;
+    Optional<Vector<String>> get_supported_extensions() const;
+    JS::Object* get_extension(String const& name) const;
 
     void active_texture(GLenum texture);
 

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
@@ -224,12 +224,12 @@ DeprecatedString OutOfProcessWebView::dump_layout_tree()
     return client().dump_layout_tree();
 }
 
-OrderedHashMap<DeprecatedString, DeprecatedString> OutOfProcessWebView::get_local_storage_entries()
+OrderedHashMap<String, String> OutOfProcessWebView::get_local_storage_entries()
 {
     return client().get_local_storage_entries();
 }
 
-OrderedHashMap<DeprecatedString, DeprecatedString> OutOfProcessWebView::get_session_storage_entries()
+OrderedHashMap<String, String> OutOfProcessWebView::get_session_storage_entries()
 {
     return client().get_session_storage_entries();
 }

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.h
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.h
@@ -36,8 +36,8 @@ public:
 
     DeprecatedString dump_layout_tree();
 
-    OrderedHashMap<DeprecatedString, DeprecatedString> get_local_storage_entries();
-    OrderedHashMap<DeprecatedString, DeprecatedString> get_session_storage_entries();
+    OrderedHashMap<String, String> get_local_storage_entries();
+    OrderedHashMap<String, String> get_session_storage_entries();
 
     void set_content_filters(Vector<String>);
     void set_autoplay_allowed_on_all_websites();

--- a/Userland/Services/WebContent/WebContentServer.ipc
+++ b/Userland/Services/WebContent/WebContentServer.ipc
@@ -68,8 +68,8 @@ endpoint WebContentServer
     set_window_position(Gfx::IntPoint position) =|
     set_window_size(Gfx::IntSize size) =|
 
-    get_local_storage_entries() => (OrderedHashMap<DeprecatedString,DeprecatedString> entries)
-    get_session_storage_entries() => (OrderedHashMap<DeprecatedString,DeprecatedString> entries)
+    get_local_storage_entries() => (OrderedHashMap<String,String> entries)
+    get_session_storage_entries() => (OrderedHashMap<String,String> entries)
 
     handle_file_return(i32 error, Optional<IPC::File> file, i32 request_id) =|
 


### PR DESCRIPTION
Which equates to ~12% of the remaining interfaces that are using DeprecatedString