### PR TITLE
sort: Add `-z` option to handle null terminated input

### DIFF
--- a/Base/usr/share/man/man1/sort.md
+++ b/Base/usr/share/man/man1/sort.md
@@ -19,6 +19,7 @@ Sort each lines of INPUT (or standard input). A quick sort algorithm is used.
 * `-n`, `--numeric`: Treat the key field as a number
 * `-t char`, `--sep char`: The separator to split fields by
 * `-r`, `--reverse`: Sort in reverse order
+* `-z`, `--zero-terminated`: Use `\0` as the line delimiter instead of a newline
 
 ## Examples
 

--- a/Userland/Utilities/sort.cpp
+++ b/Userland/Utilities/sort.cpp
@@ -57,7 +57,7 @@ struct Options {
     bool numeric { false };
     bool reverse { false };
     bool zero_terminated { false };
-    StringView separator { "\0", 1 };
+    StringView separator {};
     Vector<DeprecatedString> files;
 };
 
@@ -72,9 +72,9 @@ static ErrorOr<void> load_file(Options const& options, StringView filename, Stri
         DeprecatedString line { TRY(file->read_until(buffer, line_delimiter)) };
         StringView key = line;
         if (options.key_field != 0) {
-            auto split = (options.separator[0])
-                ? line.split_view(options.separator[0])
-                : line.split_view(is_ascii_space);
+            auto split = (!options.separator.is_empty())
+                ? key.split_view(options.separator)
+                : key.split_view_if(is_ascii_space);
             if (options.key_field - 1 >= split.size()) {
                 key = ""sv;
             } else {


### PR DESCRIPTION
This PR does two separate but related things: 
* Add the `-z` option for sorting null terminated input
* Allow multi-character separators to be used with the `-t` option

Example usage:

![sort_separators](https://github.com/SerenityOS/serenity/assets/2817754/7276dc28-d96c-40d8-9a13-5c25f2795e54)