### PR TITLE
Meta: Add dark theme support to serenityos.org

### DIFF
--- a/Meta/Websites/serenityos.org/github-sponsors/index.html
+++ b/Meta/Websites/serenityos.org/github-sponsors/index.html
@@ -1,6 +1,7 @@
 <html>
 <head>
 	<title>Sponsor SerenityOS on GitHub!</title>
+<meta name="color-scheme" content="dark light"/>
 <style>
 .pinkbar {
     padding: 4;

--- a/Meta/Websites/serenityos.org/index.html
+++ b/Meta/Websites/serenityos.org/index.html
@@ -2,9 +2,10 @@
 <html>
 <head>
     <title>SerenityOS</title>
+    <meta name="color-scheme" content="dark light"/>
     <style>
         body { font-family: sans-serif; }
-    </style>	
+    </style>
 </head>
 <body>
 <img src="banner2.png" alt="SerenityOS">


### PR DESCRIPTION
By using the `meta name="color-scheme"` tag, which Ladybird doesn't support yet.