### PR TITLE
LibWeb: Define if identifier represent area or line during layout [GFC]

### DIFF
--- a/Tests/LibWeb/Layout/expected/grid/placement-using-named-tracks-1.txt
+++ b/Tests/LibWeb/Layout/expected/grid/placement-using-named-tracks-1.txt
@@ -1,23 +1,23 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (1,1) content-size 798x600 [BFC] children: not-inline
-    BlockContainer <body> at (10,10) content-size 780x40.9375 children: not-inline
-      Box <div.grid-container> at (11,11) content-size 778x38.9375 [GFC] children: not-inline
+    BlockContainer <body> at (10,10) content-size 780x21.46875 children: not-inline
+      Box <div.grid-container> at (11,11) content-size 778x19.46875 [GFC] children: not-inline
         BlockContainer <div.a> at (12,12) content-size 387x17.46875 [BFC] children: inline
           line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [12,12 6.34375x17.46875]
               "1"
           TextNode <#text>
-        BlockContainer <div.b> at (12,31.46875) content-size 387x17.46875 [BFC] children: inline
+        BlockContainer <div.b> at (401,12) content-size 387x17.46875 [BFC] children: inline
           line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 1, rect: [12,31.46875 8.8125x17.46875]
+            frag 0 from TextNode start: 0, length: 1, rect: [401,12 8.8125x17.46875]
               "2"
           TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x602]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x602]
-    PaintableWithLines (BlockContainer<BODY>) [9,9 782x42.9375]
-      PaintableBox (Box<DIV>.grid-container) [10,10 780x40.9375]
+    PaintableWithLines (BlockContainer<BODY>) [9,9 782x23.46875]
+      PaintableBox (Box<DIV>.grid-container) [10,10 780x21.46875]
         PaintableWithLines (BlockContainer<DIV>.a) [11,11 389x19.46875]
           TextPaintable (TextNode<#text>)
-        PaintableWithLines (BlockContainer<DIV>.b) [11,30.46875 389x19.46875]
+        PaintableWithLines (BlockContainer<DIV>.b) [400,11 389x19.46875]
           TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/grid/placement-using-named-tracks-2.txt
+++ b/Tests/LibWeb/Layout/expected/grid/placement-using-named-tracks-2.txt
@@ -2,24 +2,24 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (1,1) content-size 798x600 [BFC] children: not-inline
     BlockContainer <body> at (10,10) content-size 780x77 children: not-inline
       Box <div.grid-container> at (11,11) content-size 778x75 [GFC] children: not-inline
-        BlockContainer <div.grid-item.a> at (12,12) content-size 257.328125x23 [BFC] children: inline
+        BlockContainer <div.grid-item.a> at (12,12) content-size 257.328125x73 [BFC] children: inline
           line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [12,12 6.34375x17.46875]
               "1"
           TextNode <#text>
-        BlockContainer <div.grid-item.b> at (12,12) content-size 257.328125x23 [BFC] children: inline
+        BlockContainer <div.grid-item.b> at (530.65625,12) content-size 257.328125x48 [BFC] children: inline
           line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 1, rect: [12,12 8.8125x17.46875]
+            frag 0 from TextNode start: 0, length: 1, rect: [530.65625,12 8.8125x17.46875]
               "2"
           TextNode <#text>
-        BlockContainer <div.grid-item.c> at (12,12) content-size 257.328125x23 [BFC] children: inline
+        BlockContainer <div.grid-item.c> at (271.328125,12) content-size 257.328125x23 [BFC] children: inline
           line 0 width: 9.09375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 1, rect: [12,12 9.09375x17.46875]
+            frag 0 from TextNode start: 0, length: 1, rect: [271.328125,12 9.09375x17.46875]
               "3"
           TextNode <#text>
-        BlockContainer <div.grid-item.d> at (12,12) content-size 257.328125x23 [BFC] children: inline
+        BlockContainer <div.grid-item.d> at (271.328125,62) content-size 516.65625x23 [BFC] children: inline
           line 0 width: 7.75, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 1, rect: [12,12 7.75x17.46875]
+            frag 0 from TextNode start: 0, length: 1, rect: [271.328125,62 7.75x17.46875]
               "4"
           TextNode <#text>
 
@@ -27,11 +27,11 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x602]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x602]
     PaintableWithLines (BlockContainer<BODY>) [9,9 782x79]
       PaintableBox (Box<DIV>.grid-container) [10,10 780x77]
-        PaintableWithLines (BlockContainer<DIV>.grid-item.a) [11,11 259.328125x25]
+        PaintableWithLines (BlockContainer<DIV>.grid-item.a) [11,11 259.328125x75]
           TextPaintable (TextNode<#text>)
-        PaintableWithLines (BlockContainer<DIV>.grid-item.b) [11,11 259.328125x25]
+        PaintableWithLines (BlockContainer<DIV>.grid-item.b) [529.65625,11 259.328125x50]
           TextPaintable (TextNode<#text>)
-        PaintableWithLines (BlockContainer<DIV>.grid-item.c) [11,11 259.328125x25]
+        PaintableWithLines (BlockContainer<DIV>.grid-item.c) [270.328125,11 259.328125x25]
           TextPaintable (TextNode<#text>)
-        PaintableWithLines (BlockContainer<DIV>.grid-item.d) [11,11 259.328125x25]
+        PaintableWithLines (BlockContainer<DIV>.grid-item.d) [270.328125,61 518.65625x25]
           TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/grid/placement-using-named-tracks-3.txt
+++ b/Tests/LibWeb/Layout/expected/grid/placement-using-named-tracks-3.txt
@@ -1,37 +1,37 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (1,1) content-size 798x600 [BFC] children: not-inline
-    BlockContainer <body> at (10,10) content-size 780x21.46875 children: not-inline
-      Box <div.grid-container> at (11,11) content-size 778x19.46875 [GFC] children: not-inline
-        BlockContainer <div.a> at (12,12) content-size 48x17.46875 [BFC] children: inline
+    BlockContainer <body> at (10,10) content-size 780x40.9375 children: not-inline
+      Box <div.grid-container> at (11,11) content-size 778x38.9375 [GFC] children: not-inline
+        BlockContainer <div.a> at (62,12) content-size 98x17.46875 [BFC] children: inline
           line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 1, rect: [12,12 6.34375x17.46875]
+            frag 0 from TextNode start: 0, length: 1, rect: [62,12 6.34375x17.46875]
               "1"
           TextNode <#text>
-        BlockContainer <div> at (62,12) content-size 98x17.46875 [BFC] children: inline
+        BlockContainer <div> at (162,12) content-size 48x17.46875 [BFC] children: inline
           line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 1, rect: [62,12 8.8125x17.46875]
+            frag 0 from TextNode start: 0, length: 1, rect: [162,12 8.8125x17.46875]
               "2"
           TextNode <#text>
-        BlockContainer <div> at (162,12) content-size 48x17.46875 [BFC] children: inline
+        BlockContainer <div> at (212,12) content-size 98x17.46875 [BFC] children: inline
           line 0 width: 9.09375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 1, rect: [162,12 9.09375x17.46875]
+            frag 0 from TextNode start: 0, length: 1, rect: [212,12 9.09375x17.46875]
               "3"
           TextNode <#text>
-        BlockContainer <div> at (212,12) content-size 98x17.46875 [BFC] children: inline
+        BlockContainer <div> at (12,31.46875) content-size 48x17.46875 [BFC] children: inline
           line 0 width: 7.75, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 1, rect: [212,12 7.75x17.46875]
+            frag 0 from TextNode start: 0, length: 1, rect: [12,31.46875 7.75x17.46875]
               "4"
           TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x602]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x602]
-    PaintableWithLines (BlockContainer<BODY>) [9,9 782x23.46875]
-      PaintableBox (Box<DIV>.grid-container) [10,10 780x21.46875]
-        PaintableWithLines (BlockContainer<DIV>.a) [11,11 50x19.46875]
-          TextPaintable (TextNode<#text>)
-        PaintableWithLines (BlockContainer<DIV>) [61,11 100x19.46875]
+    PaintableWithLines (BlockContainer<BODY>) [9,9 782x42.9375]
+      PaintableBox (Box<DIV>.grid-container) [10,10 780x40.9375]
+        PaintableWithLines (BlockContainer<DIV>.a) [61,11 100x19.46875]
           TextPaintable (TextNode<#text>)
         PaintableWithLines (BlockContainer<DIV>) [161,11 50x19.46875]
           TextPaintable (TextNode<#text>)
         PaintableWithLines (BlockContainer<DIV>) [211,11 100x19.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [11,30.46875 50x19.46875]
           TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/input/grid/placement-using-named-tracks-1.html
+++ b/Tests/LibWeb/Layout/input/grid/placement-using-named-tracks-1.html
@@ -1,6 +1,4 @@
 <style>
-    /* FIXME: This test is not rendered correctly */
-
     * {
         border: 1px solid black;
     }

--- a/Tests/LibWeb/Layout/input/grid/placement-using-named-tracks-2.html
+++ b/Tests/LibWeb/Layout/input/grid/placement-using-named-tracks-2.html
@@ -1,6 +1,4 @@
 <style>
-    /* FIXME: This test is not rendered correctly */
-
     * {
         border: 1px solid black;
     }

--- a/Tests/LibWeb/Layout/input/grid/placement-using-named-tracks-3.html
+++ b/Tests/LibWeb/Layout/input/grid/placement-using-named-tracks-3.html
@@ -1,6 +1,4 @@
 <style>
-    /* FIXME: This test is not rendered correctly */
-
     * {
         border: 1px solid black;
     }

--- a/Userland/Libraries/LibWeb/CSS/GridTrackPlacement.cpp
+++ b/Userland/Libraries/LibWeb/CSS/GridTrackPlacement.cpp
@@ -17,13 +17,15 @@ String GridTrackPlacement::to_string() const
         [&](Auto const&) {
             builder.append("auto"sv);
         },
-        [&](Area const& area) {
-            builder.append(area.name);
-        },
-        [&](Line const& line) {
-            builder.appendff("{}", line.value);
-            if (line.name.has_value())
-                builder.appendff(" {}", line.name.value());
+        [&](AreaOrLine const& area_or_line) {
+            if (area_or_line.line_number.has_value() && area_or_line.name.has_value()) {
+                builder.appendff("{} {}", *area_or_line.line_number, *area_or_line.name);
+            } else if (area_or_line.line_number.has_value()) {
+                builder.appendff("{}", *area_or_line.line_number);
+            }
+            if (area_or_line.name.has_value()) {
+                builder.appendff("{}", *area_or_line.name);
+            }
         },
         [&](Span const& span) {
             builder.appendff("span {}", span.value);

--- a/Userland/Libraries/LibWeb/CSS/GridTrackPlacement.h
+++ b/Userland/Libraries/LibWeb/CSS/GridTrackPlacement.h
@@ -18,14 +18,9 @@ public:
         return GridTrackPlacement();
     }
 
-    static GridTrackPlacement make_area(String name)
+    static GridTrackPlacement make_line(Optional<int> line_number, Optional<String> name)
     {
-        return GridTrackPlacement(Area { .name = name });
-    }
-
-    static GridTrackPlacement make_line(int value, Optional<String> name)
-    {
-        return GridTrackPlacement(Line { .value = value, .name = name });
+        return GridTrackPlacement(AreaOrLine { .line_number = line_number, .name = name });
     }
 
     static GridTrackPlacement make_span(int value)
@@ -34,21 +29,25 @@ public:
     }
 
     bool is_auto() const { return m_value.has<Auto>(); }
-    bool is_area() const { return m_value.has<Area>(); }
-    bool is_line() const { return m_value.has<Line>(); }
     bool is_span() const { return m_value.has<Span>(); }
+    bool is_area_or_line() const { return m_value.has<AreaOrLine>(); }
 
     bool is_auto_positioned() const { return is_auto() || is_span(); }
     bool is_positioned() const { return !is_auto_positioned(); }
 
-    bool has_line_name() const
+    bool has_identifier() const
     {
-        return is_line() && m_value.get<Line>().name.has_value();
+        return is_area_or_line() && m_value.get<AreaOrLine>().name.has_value();
     }
 
-    String area_name() const { return m_value.get<Area>().name; }
-    String line_name() const { return m_value.get<Line>().name.value(); }
-    int line_number() const { return m_value.get<Line>().value; }
+    bool has_line_number() const
+    {
+        return is_area_or_line() && m_value.get<AreaOrLine>().line_number.has_value();
+    }
+
+    String identifier() const { return *m_value.get<AreaOrLine>().name; }
+
+    int line_number() const { return *m_value.get<AreaOrLine>().line_number; }
     int span() const { return m_value.get<Span>().value; }
 
     String to_string() const;
@@ -60,15 +59,10 @@ private:
         bool operator==(Auto const&) const = default;
     };
 
-    struct Area {
-        String name;
-        bool operator==(Area const& other) const = default;
-    };
-
-    struct Line {
-        int value;
+    struct AreaOrLine {
+        Optional<int> line_number;
         Optional<String> name;
-        bool operator==(Line const& other) const = default;
+        bool operator==(AreaOrLine const& other) const = default;
     };
 
     struct Span {
@@ -78,14 +72,12 @@ private:
 
     GridTrackPlacement()
         : m_value(Auto {}) {};
-    GridTrackPlacement(Area value)
-        : m_value(value) {};
-    GridTrackPlacement(Line value)
+    GridTrackPlacement(AreaOrLine value)
         : m_value(value) {};
     GridTrackPlacement(Span value)
         : m_value(value) {};
 
-    Variant<Auto, Area, Line, Span> m_value;
+    Variant<Auto, AreaOrLine, Span> m_value;
 };
 
 }

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -5371,7 +5371,7 @@ RefPtr<StyleValue> Parser::parse_grid_track_placement(Vector<ComponentValue> con
         if (is_identifier(current_token)) {
             auto maybe_string = String::from_utf8(current_token.ident());
             if (!maybe_string.is_error())
-                return GridTrackPlacementStyleValue::create(GridTrackPlacement::make_area(maybe_string.value()));
+                return GridTrackPlacementStyleValue::create(GridTrackPlacement::make_line({}, maybe_string.value()));
         }
         return nullptr;
     }

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -136,13 +136,13 @@ void GridFormattingContext::place_item_with_row_and_column_position(Box const& c
 
     int row_start = 0, row_end = 0, column_start = 0, column_end = 0;
 
-    if (grid_row_start.is_line())
+    if (grid_row_start.has_line_number())
         row_start = child_box.computed_values().grid_row_start().line_number() - 1;
-    if (grid_row_end.is_line())
+    if (grid_row_end.has_line_number())
         row_end = child_box.computed_values().grid_row_end().line_number() - 1;
-    if (grid_column_start.is_line())
+    if (grid_column_start.has_line_number())
         column_start = child_box.computed_values().grid_column_start().line_number() - 1;
-    if (grid_column_end.is_line())
+    if (grid_column_end.has_line_number())
         column_end = child_box.computed_values().grid_column_end().line_number() - 1;
 
     // https://www.w3.org/TR/css-grid-2/#line-placement
@@ -174,15 +174,15 @@ void GridFormattingContext::place_item_with_row_and_column_position(Box const& c
     // grid-column-start line.
     size_t row_span = 1;
     size_t column_span = 1;
-    if (grid_row_start.is_line() && grid_row_end.is_span())
+    if (grid_row_start.has_line_number() && grid_row_end.is_span())
         row_span = grid_row_end.span();
-    if (grid_column_start.is_line() && grid_column_end.is_span())
+    if (grid_column_start.has_line_number() && grid_column_end.is_span())
         column_span = grid_column_end.span();
-    if (grid_row_end.is_line() && child_box.computed_values().grid_row_start().is_span()) {
+    if (grid_row_end.has_line_number() && child_box.computed_values().grid_row_start().is_span()) {
         row_span = grid_row_start.span();
         row_start = row_end - row_span;
     }
-    if (grid_column_end.is_line() && grid_column_start.is_span()) {
+    if (grid_column_end.has_line_number() && grid_column_start.is_span()) {
         column_span = grid_column_start.span();
         column_start = column_end - column_span;
     }
@@ -200,54 +200,39 @@ void GridFormattingContext::place_item_with_row_and_column_position(Box const& c
     // https://www.w3.org/TR/css-grid-2/#common-uses-named-lines
     // 8.1.3. Named Lines and Spans
     // Instead of counting lines by number, lines can be referenced by their line name:
-    if (grid_column_end.is_area()) {
-        if (auto maybe_grid_area = m_grid_areas.get(grid_column_end.area_name()); maybe_grid_area.has_value())
+    if (grid_column_end.has_identifier()) {
+        if (auto maybe_grid_area = m_grid_areas.get(grid_column_end.identifier()); maybe_grid_area.has_value())
             column_end = maybe_grid_area->column_end;
-        else
-            column_end = 1;
-        column_start = column_end - 1;
-    } else if (grid_column_end.has_line_name()) {
-        if (auto line_name_index = get_line_index_by_line_name(grid_column_end.line_name(), grid_container().computed_values().grid_template_columns()); line_name_index > -1)
+        else if (auto line_name_index = get_line_index_by_line_name(grid_column_end.identifier(), grid_container().computed_values().grid_template_columns()); line_name_index > -1)
             column_end = line_name_index;
         else
             column_end = 1;
         column_start = column_end - 1;
     }
 
-    if (grid_column_start.is_area()) {
-        if (auto maybe_grid_area = m_grid_areas.get(grid_column_start.area_name()); maybe_grid_area.has_value())
+    if (grid_column_start.has_identifier()) {
+        if (auto maybe_grid_area = m_grid_areas.get(grid_column_start.identifier()); maybe_grid_area.has_value())
             column_start = maybe_grid_area->column_start;
-        else
-            column_start = 0;
-    }
-    if (grid_column_start.has_line_name()) {
-        if (auto line_name_index = get_line_index_by_line_name(grid_column_start.line_name(), grid_container().computed_values().grid_template_columns()); line_name_index > -1)
+        else if (auto line_name_index = get_line_index_by_line_name(grid_column_start.identifier(), grid_container().computed_values().grid_template_columns()); line_name_index > -1)
             column_start = line_name_index;
         else
             column_start = 0;
     }
 
-    if (grid_row_end.is_area()) {
-        if (auto maybe_grid_area = m_grid_areas.get(grid_row_end.area_name()); maybe_grid_area.has_value())
+    if (grid_row_end.has_identifier()) {
+        if (auto maybe_grid_area = m_grid_areas.get(grid_row_end.identifier()); maybe_grid_area.has_value())
             row_end = maybe_grid_area->row_end;
-        else
-            row_end = 1;
-        row_start = row_end - 1;
-    } else if (grid_row_end.has_line_name()) {
-        if (auto line_name_index = get_line_index_by_line_name(grid_row_end.line_name(), grid_container().computed_values().grid_template_rows()); line_name_index > -1)
+        else if (auto line_name_index = get_line_index_by_line_name(grid_row_end.identifier(), grid_container().computed_values().grid_template_rows()); line_name_index > -1)
             row_end = line_name_index;
         else
             row_end = 1;
         row_start = row_end - 1;
     }
 
-    if (grid_row_start.is_area()) {
-        if (auto maybe_grid_area = m_grid_areas.get(grid_row_start.area_name()); maybe_grid_area.has_value())
+    if (grid_row_start.has_identifier()) {
+        if (auto maybe_grid_area = m_grid_areas.get(grid_row_start.identifier()); maybe_grid_area.has_value())
             row_start = maybe_grid_area->row_start;
-        else
-            row_start = 0;
-    } else if (grid_row_start.has_line_name()) {
-        if (auto line_name_index = get_line_index_by_line_name(grid_row_start.line_name(), grid_container().computed_values().grid_template_rows()); line_name_index > -1)
+        else if (auto line_name_index = get_line_index_by_line_name(grid_row_start.identifier(), grid_container().computed_values().grid_template_rows()); line_name_index > -1)
             row_start = line_name_index;
         else
             row_start = 0;
@@ -301,9 +286,9 @@ void GridFormattingContext::place_item_with_row_position(Box const& child_box)
 
     int row_start = 0, row_end = 0;
 
-    if (grid_row_start.is_line())
+    if (grid_row_start.has_line_number())
         row_start = grid_row_start.line_number() - 1;
-    if (grid_row_end.is_line())
+    if (grid_row_end.has_line_number())
         row_end = grid_row_end.line_number() - 1;
 
     // https://www.w3.org/TR/css-grid-2/#line-placement
@@ -332,9 +317,9 @@ void GridFormattingContext::place_item_with_row_position(Box const& child_box)
     // grid-column-end: span 2 indicates the second grid line in the endward direction from the
     // grid-column-start line.
     size_t row_span = 1;
-    if (grid_row_start.is_line() && grid_row_end.is_span())
+    if (grid_row_start.has_line_number() && grid_row_end.is_span())
         row_span = grid_row_end.span();
-    if (grid_row_end.is_line() && grid_row_start.is_span()) {
+    if (grid_row_end.has_line_number() && grid_row_start.is_span()) {
         row_span = grid_row_start.span();
         row_start = row_end - row_span;
         // FIXME: Remove me once have implemented spans overflowing into negative indexes, e.g., grid-row: span 2 / 1
@@ -355,27 +340,20 @@ void GridFormattingContext::place_item_with_row_position(Box const& child_box)
     // https://www.w3.org/TR/css-grid-2/#common-uses-named-lines
     // 8.1.3. Named Lines and Spans
     // Instead of counting lines by number, lines can be referenced by their line name:
-    if (grid_row_end.is_area()) {
-        if (auto maybe_grid_area = m_grid_areas.get(grid_row_end.area_name()); maybe_grid_area.has_value())
+    if (grid_row_end.has_identifier()) {
+        if (auto maybe_grid_area = m_grid_areas.get(grid_row_end.identifier()); maybe_grid_area.has_value())
             row_end = maybe_grid_area->row_end;
-        else
-            row_end = 1;
-        row_start = row_end - 1;
-    } else if (grid_row_end.has_line_name()) {
-        if (auto line_name_index = get_line_index_by_line_name(grid_row_end.line_name(), grid_container().computed_values().grid_template_rows()); line_name_index > -1)
+        else if (auto line_name_index = get_line_index_by_line_name(grid_row_end.identifier(), grid_container().computed_values().grid_template_rows()); line_name_index > -1)
             row_end = line_name_index - 1;
         else
             row_end = 1;
         row_start = row_end - 1;
     }
 
-    if (grid_row_start.is_area()) {
-        if (auto maybe_grid_area = m_grid_areas.get(grid_row_start.area_name()); maybe_grid_area.has_value())
+    if (grid_row_start.has_identifier()) {
+        if (auto maybe_grid_area = m_grid_areas.get(grid_row_start.identifier()); maybe_grid_area.has_value())
             row_start = maybe_grid_area->row_start;
-        else
-            row_start = 0;
-    } else if (grid_row_start.has_line_name()) {
-        if (auto line_name_index = get_line_index_by_line_name(grid_row_start.line_name(), grid_container().computed_values().grid_template_rows()); line_name_index > -1)
+        else if (auto line_name_index = get_line_index_by_line_name(grid_row_start.identifier(), grid_container().computed_values().grid_template_rows()); line_name_index > -1)
             row_start = line_name_index;
         else
             row_start = 0;
@@ -436,15 +414,15 @@ void GridFormattingContext::place_item_with_column_position(Box const& child_box
     auto const& grid_column_end = child_box.computed_values().grid_column_end();
 
     int column_start = 0;
-    if (grid_column_start.is_line() && grid_column_start.line_number() > 0) {
+    if (grid_column_start.has_line_number() && grid_column_start.line_number() > 0) {
         column_start = grid_column_start.line_number() - 1;
-    } else if (grid_column_start.is_line()) {
+    } else if (grid_column_start.has_line_number()) {
         // NOTE: Negative indexes count from the end side of the explicit grid
         column_start = m_explicit_columns_line_count + grid_column_start.line_number();
     }
 
     int column_end = 0;
-    if (grid_column_end.is_line())
+    if (grid_column_end.has_line_number())
         column_end = grid_column_end.line_number() - 1;
 
     // https://www.w3.org/TR/css-grid-2/#line-placement
@@ -474,9 +452,9 @@ void GridFormattingContext::place_item_with_column_position(Box const& child_box
     // grid-column-start line.
     size_t column_span = 1;
     size_t row_span = grid_row_start.is_span() ? grid_row_start.span() : 1;
-    if (grid_column_start.is_line() && grid_column_end.is_span())
+    if (grid_column_start.has_line_number() && grid_column_end.is_span())
         column_span = grid_column_end.span();
-    if (grid_column_end.is_line() && grid_column_start.is_span()) {
+    if (grid_column_end.has_line_number() && grid_column_start.is_span()) {
         column_span = grid_column_start.span();
         column_start = column_end - column_span;
         // FIXME: Remove me once have implemented spans overflowing into negative indexes, e.g., grid-column: span 2 / 1
@@ -500,31 +478,24 @@ void GridFormattingContext::place_item_with_column_position(Box const& child_box
     // https://www.w3.org/TR/css-grid-2/#common-uses-named-lines
     // 8.1.3. Named Lines and Spans
     // Instead of counting lines by number, lines can be referenced by their line name:
-    if (grid_column_end.is_area()) {
-        if (auto maybe_grid_area = m_grid_areas.get(grid_column_end.area_name()); maybe_grid_area.has_value())
+    if (grid_column_end.has_identifier()) {
+        if (auto maybe_grid_area = m_grid_areas.get(grid_column_end.identifier()); maybe_grid_area.has_value())
             column_end = maybe_grid_area->column_end;
-        else
-            column_end = 1;
-        column_start = column_end - 1;
-    } else if (grid_column_end.has_line_name()) {
-        if (auto line_name_index = get_line_index_by_line_name(grid_column_end.line_name(), grid_container().computed_values().grid_template_columns()); line_name_index > -1)
+        else if (auto line_name_index = get_line_index_by_line_name(grid_column_end.identifier(), grid_container().computed_values().grid_template_columns()); line_name_index > -1)
             column_end = line_name_index;
         else
             column_end = 1;
         column_start = column_end - 1;
     }
 
-    if (grid_column_start.is_area()) {
-        if (auto maybe_grid_area = m_grid_areas.get(grid_column_start.area_name()); maybe_grid_area.has_value())
+    if (grid_column_start.has_identifier()) {
+        if (auto maybe_grid_area = m_grid_areas.get(grid_column_start.identifier()); maybe_grid_area.has_value())
             column_start = maybe_grid_area->column_start;
-        else
-            column_start = 0;
-    }
-    if (grid_column_start.has_line_name()) {
-        if (auto line_name_index = get_line_index_by_line_name(grid_column_start.line_name(), grid_container().computed_values().grid_template_columns()); line_name_index > -1)
+        else if (auto line_name_index = get_line_index_by_line_name(grid_column_start.identifier(), grid_container().computed_values().grid_template_columns()); line_name_index > -1) {
             column_start = line_name_index;
-        else
+        } else {
             column_start = 0;
+        }
     }
 
     // If there are multiple lines of the same name, they effectively establish a named set of grid


### PR DESCRIPTION
This fixes regression introduced in
c03e025a324d2c8582d3c675b49c61274b7ff0fb by assuming that it is possible to determine whether identifier stands for line or area during parsing.