### PR TITLE
Everywhere: Add support for the Haiku platform

### DIFF
--- a/AK/Platform.h
+++ b/AK/Platform.h
@@ -233,7 +233,7 @@
 #    define CLOCK_MONOTONIC_COARSE CLOCK_MONOTONIC
 #endif
 
-#if defined(AK_OS_BSD_GENERIC) && !defined(AK_OS_FREEBSD)
+#if defined(AK_OS_BSD_GENERIC) && !defined(AK_OS_FREEBSD) || defined(AK_OS_HAIKU)
 #    define CLOCK_MONOTONIC_COARSE CLOCK_MONOTONIC
 #    define CLOCK_REALTIME_COARSE CLOCK_REALTIME
 #endif

--- a/AK/Platform.h
+++ b/AK/Platform.h
@@ -98,6 +98,10 @@
 #    define AK_OS_SOLARIS
 #endif
 
+#if defined(__HAIKU__)
+#    define AK_OS_HAIKU
+#endif
+
 #if defined(__gnu_hurd__)
 #    define AK_OS_GNU_HURD
 #endif

--- a/AK/Random.h
+++ b/AK/Random.h
@@ -20,7 +20,7 @@ namespace AK {
 
 inline void fill_with_random([[maybe_unused]] Bytes bytes)
 {
-#if defined(AK_OS_SERENITY) || defined(AK_OS_ANDROID) || defined(AK_OS_BSD_GENERIC) || AK_LIBC_GLIBC_PREREQ(2, 36)
+#if defined(AK_OS_SERENITY) || defined(AK_OS_ANDROID) || defined(AK_OS_BSD_GENERIC) || defined(AK_OS_HAIKU) || AK_LIBC_GLIBC_PREREQ(2, 36)
     arc4random_buf(bytes.data(), bytes.size());
 #elif defined(OSS_FUZZ)
 #else

--- a/AK/StackInfo.cpp
+++ b/AK/StackInfo.cpp
@@ -12,7 +12,7 @@
 
 #ifdef AK_OS_SERENITY
 #    include <serenity.h>
-#elif defined(AK_OS_LINUX) or defined(AK_LIBC_GLIBC) or defined(AK_OS_MACOS) or defined(AK_OS_NETBSD) or defined(AK_OS_SOLARIS)
+#elif defined(AK_OS_LINUX) or defined(AK_LIBC_GLIBC) or defined(AK_OS_MACOS) or defined(AK_OS_NETBSD) or defined(AK_OS_SOLARIS) or defined(AK_OS_HAIKU)
 #    include <pthread.h>
 #elif defined(AK_OS_FREEBSD) or defined(AK_OS_OPENBSD)
 #    include <pthread.h>
@@ -32,12 +32,12 @@ StackInfo::StackInfo()
         perror("get_stack_bounds");
         VERIFY_NOT_REACHED();
     }
-#elif defined(AK_OS_LINUX) or defined(AK_LIBC_GLIBC) or defined(AK_OS_FREEBSD) or defined(AK_OS_NETBSD) or defined(AK_OS_SOLARIS)
+#elif defined(AK_OS_LINUX) or defined(AK_LIBC_GLIBC) or defined(AK_OS_FREEBSD) or defined(AK_OS_NETBSD) or defined(AK_OS_SOLARIS) or defined(AK_OS_HAIKU)
     int rc;
     pthread_attr_t attr;
     pthread_attr_init(&attr);
 
-#    if defined(AK_OS_LINUX) or defined(AK_LIBC_GLIBC)
+#    if defined(AK_OS_LINUX) or defined(AK_LIBC_GLIBC) or defined(AK_OS_HAIKU)
     if ((rc = pthread_getattr_np(pthread_self(), &attr)) != 0) {
         fprintf(stderr, "pthread_getattr_np: %s\n", strerror(rc));
         VERIFY_NOT_REACHED();

--- a/Documentation/BuildInstructionsLadybird.md
+++ b/Documentation/BuildInstructionsLadybird.md
@@ -54,6 +54,11 @@ Note that OpenIndiana's latest GCC port (GCC 11) is too old to build Ladybird, s
 pfexec pkg install cmake ninja clang-15 libglvnd qt6
 ```
 
+On Haiku:
+```
+pkgman install cmake ninja cmd:python3 qt6_base_devel qt6_multimedia_devel qt6_tools_devel openal_devel
+```
+
 On Windows:
 
 WSL2/WSLg are preferred, as they provide a linux environment that matches one of the above distributions.
@@ -186,4 +191,15 @@ doesn't find a writable directory for its sockets.
 CMAKE_PREFIX_PATH=/usr/lib/qt/6.2/lib/amd64/cmake cmake -GNinja -S Ladybird -B Build/ladybird -DCMAKE_C_COMPILER=/usr/bin/clang -DCMAKE_CXX_COMPILER=/usr/bin/clang++
 cmake --build Build/ladybird
 XDG_RUNTIME_DIR=/var/tmp ninja -C Build/ladybird run
+```
+
+### Building on Haiku
+
+Haiku is supported by Ladybird out of the box. The steps are the same as on OpenIndiana, but no
+additional environment variables are required.
+
+```
+cmake -GNinja -S Ladybird -B Build/ladybird
+cmake --build Build/ladybird
+ninja -C Build/ladybird run
 ```

--- a/Ladybird/CMakeLists.txt
+++ b/Ladybird/CMakeLists.txt
@@ -45,6 +45,13 @@ if (ENABLE_UNDEFINED_SANITIZER)
     add_link_options(-fsanitize=undefined)
 endif()
 
+if (HAIKU)
+    # Haiku needs some extra compile definitions to make important stuff in its headers available.
+    add_compile_definitions(_DEFAULT_SOURCE)
+    add_compile_definitions(_GNU_SOURCE)
+    add_compile_definitions(__USE_GNU)
+endif()
+
 # Lagom
 # FIXME: PROJECT_IS_TOP_LEVEL with CMake 3.21+
 set(LADYBIRD_IS_TOP_LEVEL FALSE)

--- a/Ladybird/RequestServer/CMakeLists.txt
+++ b/Ladybird/RequestServer/CMakeLists.txt
@@ -23,3 +23,7 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "SunOS")
     # Solaris has socket and networking related functions in two extra libraries
     target_link_libraries(RequestServer PRIVATE nsl socket)
 endif()
+if (HAIKU)
+    # Haiku has networking related functions in the network library
+    target_link_libraries(RequestServer PRIVATE network)
+endif()

--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -112,6 +112,13 @@ if (ENABLE_COMPILETIME_FORMAT_CHECK)
     add_compile_definitions(ENABLE_COMPILETIME_FORMAT_CHECK)
 endif()
 
+if (HAIKU)
+    # Haiku needs some extra compile definitions to make important stuff in its headers available.
+    add_compile_definitions(_DEFAULT_SOURCE)
+    add_compile_definitions(_GNU_SOURCE)
+    add_compile_definitions(__USE_GNU)
+endif()
+
 if (ENABLE_FUZZERS)
     add_compile_options(-fno-omit-frame-pointer)
 endif()

--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -344,6 +344,10 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "BSD$")
     # BSD Platforms have backtrace(3) in a separate library
     target_link_libraries(LibCore PRIVATE execinfo)
 endif()
+if (HAIKU)
+    # Haiku has networking related functions in the network library
+    target_link_libraries(LibCore PRIVATE network)
+endif()
 target_sources(LibCore PRIVATE ${AK_SOURCES})
 
 # LibMain

--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -315,7 +315,7 @@ endif()
 add_library(LibC INTERFACE)
 add_library(LibCrypt INTERFACE)
 add_library(LibSystem INTERFACE)
-if (NOT APPLE AND NOT ANDROID AND NOT EMSCRIPTEN AND NOT ${CMAKE_SYSTEM_NAME} MATCHES "OpenBSD")
+if (NOT APPLE AND NOT ANDROID AND NOT EMSCRIPTEN AND NOT ${CMAKE_SYSTEM_NAME} MATCHES "OpenBSD" AND NOT HAIKU)
     target_link_libraries(LibCrypt INTERFACE crypt) # LibCore::Account uses crypt() but it's not in libcrypt on macOS
 endif()
 if (SERENITYOS)

--- a/Userland/Libraries/LibCore/Account.cpp
+++ b/Userland/Libraries/LibCore/Account.cpp
@@ -16,7 +16,7 @@
 #include <errno.h>
 #include <grp.h>
 #include <pwd.h>
-#ifndef AK_OS_BSD_GENERIC
+#if !defined(AK_OS_BSD_GENERIC) && !defined(AK_OS_HAIKU)
 #    include <crypt.h>
 #    include <shadow.h>
 #endif

--- a/Userland/Libraries/LibCore/DirIterator.cpp
+++ b/Userland/Libraries/LibCore/DirIterator.cpp
@@ -56,7 +56,7 @@ bool DirIterator::advance_next()
             return false;
         }
 
-#ifdef AK_OS_SOLARIS
+#if defined(AK_OS_SOLARIS) || defined(AK_OS_HAIKU)
         m_next = DirectoryEntry::from_stat(m_dir, *de);
 #else
         m_next = DirectoryEntry::from_dirent(*de);

--- a/Userland/Libraries/LibCore/DirectoryEntry.cpp
+++ b/Userland/Libraries/LibCore/DirectoryEntry.cpp
@@ -32,7 +32,7 @@ static DirectoryEntry::Type directory_entry_type_from_stat(mode_t st_mode)
     VERIFY_NOT_REACHED();
 }
 
-#ifndef AK_OS_SOLARIS
+#if !defined(AK_OS_SOLARIS) && !defined(AK_OS_HAIKU)
 static DirectoryEntry::Type directory_entry_type_from_posix(unsigned char dt_constant)
 {
     switch (dt_constant) {
@@ -72,7 +72,7 @@ DirectoryEntry DirectoryEntry::from_stat(DIR* d, dirent const& de)
     };
 }
 
-#ifndef AK_OS_SOLARIS
+#if !defined(AK_OS_SOLARIS) && !defined(AK_OS_HAIKU)
 DirectoryEntry DirectoryEntry::from_dirent(dirent const& de)
 {
     return DirectoryEntry {

--- a/Userland/Libraries/LibCore/Group.cpp
+++ b/Userland/Libraries/LibCore/Group.cpp
@@ -67,7 +67,7 @@ ErrorOr<void> Group::sync()
     return {};
 }
 
-#if !defined(AK_OS_BSD_GENERIC) && !defined(AK_OS_ANDROID)
+#if !defined(AK_OS_BSD_GENERIC) && !defined(AK_OS_ANDROID) && !defined(AK_OS_HAIKU)
 ErrorOr<void> Group::add_group(Group& group)
 {
     if (group.name().is_empty())

--- a/Userland/Libraries/LibCore/Group.h
+++ b/Userland/Libraries/LibCore/Group.h
@@ -15,7 +15,7 @@ namespace Core {
 
 class Group {
 public:
-#if !defined(AK_OS_BSD_GENERIC) && !defined(AK_OS_ANDROID)
+#if !defined(AK_OS_BSD_GENERIC) && !defined(AK_OS_ANDROID) && !defined(AK_OS_HAIKU)
     static ErrorOr<void> add_group(Group& group);
 #endif
 

--- a/Userland/Libraries/LibCore/LocalServer.cpp
+++ b/Userland/Libraries/LibCore/LocalServer.cpp
@@ -118,7 +118,7 @@ ErrorOr<NonnullOwnPtr<LocalSocket>> LocalServer::accept()
     VERIFY(m_listening);
     sockaddr_un un;
     socklen_t un_size = sizeof(un);
-#ifndef AK_OS_MACOS
+#if !defined(AK_OS_MACOS) && !defined(AK_OS_HAIKU)
     int accepted_fd = ::accept4(m_fd, (sockaddr*)&un, &un_size, SOCK_NONBLOCK | SOCK_CLOEXEC);
 #else
     int accepted_fd = ::accept(m_fd, (sockaddr*)&un, &un_size);
@@ -127,7 +127,7 @@ ErrorOr<NonnullOwnPtr<LocalSocket>> LocalServer::accept()
         return Error::from_syscall("accept"sv, -errno);
     }
 
-#ifdef AK_OS_MACOS
+#if defined(AK_OS_MACOS) || defined(AK_OS_HAIKU)
     int option = 1;
     ioctl(m_fd, FIONBIO, &option);
     (void)fcntl(accepted_fd, F_SETFD, FD_CLOEXEC);

--- a/Userland/Libraries/LibCore/Process.cpp
+++ b/Userland/Libraries/LibCore/Process.cpp
@@ -124,7 +124,7 @@ ErrorOr<String> Process::get_name()
     return String::from_utf8(StringView { buffer, strlen(buffer) });
 #elif defined(AK_LIBC_GLIBC) || (defined(AK_OS_LINUX) && !defined(AK_OS_ANDROID))
     return String::from_utf8(StringView { program_invocation_name, strlen(program_invocation_name) });
-#elif defined(AK_OS_BSD_GENERIC)
+#elif defined(AK_OS_BSD_GENERIC) || defined(AK_OS_HAIKU)
     auto const* progname = getprogname();
     return String::from_utf8(StringView { progname, strlen(progname) });
 #else

--- a/Userland/Libraries/LibCore/Socket.cpp
+++ b/Userland/Libraries/LibCore/Socket.cpp
@@ -282,7 +282,7 @@ ErrorOr<int> LocalSocket::receive_fd(int flags)
 {
 #if defined(AK_OS_SERENITY)
     return Core::System::recvfd(m_helper.fd(), flags);
-#elif defined(AK_OS_LINUX) || defined(AK_OS_GNU_HURD) || defined(AK_OS_BSD_GENERIC)
+#elif defined(AK_OS_LINUX) || defined(AK_OS_GNU_HURD) || defined(AK_OS_BSD_GENERIC) || defined(AK_OS_HAIKU)
     union {
         struct cmsghdr cmsghdr;
         char control[CMSG_SPACE(sizeof(int))];
@@ -323,7 +323,7 @@ ErrorOr<void> LocalSocket::send_fd(int fd)
 {
 #if defined(AK_OS_SERENITY)
     return Core::System::sendfd(m_helper.fd(), fd);
-#elif defined(AK_OS_LINUX) || defined(AK_OS_GNU_HURD) || defined(AK_OS_BSD_GENERIC)
+#elif defined(AK_OS_LINUX) || defined(AK_OS_GNU_HURD) || defined(AK_OS_BSD_GENERIC) || defined(AK_OS_HAIKU)
     char c = 'F';
     struct iovec iov {
         .iov_base = &c,

--- a/Userland/Libraries/LibCore/System.cpp
+++ b/Userland/Libraries/LibCore/System.cpp
@@ -61,6 +61,10 @@ extern "C" {
 #    include <LibCore/File.h>
 #endif
 
+#if defined(AK_OS_HAIKU)
+#    include <image.h>
+#endif
+
 #define HANDLE_SYSCALL_RETURN_VALUE(syscall_name, rc, success_value) \
     if ((rc) < 0) {                                                  \
         return Error::from_syscall(syscall_name##sv, rc);            \
@@ -1795,6 +1799,15 @@ ErrorOr<String> current_executable_path()
     auto ret = _NSGetExecutablePath(path, &size);
     if (ret != 0)
         return Error::from_errno(ENAMETOOLONG);
+#elif defined(AK_OS_HAIKU)
+    image_info info = {};
+    for (int32 cookie { 0 }; get_next_image_info(B_CURRENT_TEAM, &cookie, &info) == B_OK && info.type != B_APP_IMAGE;)
+        ;
+    if (info.type != B_APP_IMAGE)
+        return Error::from_string_view("current_executable_path() failed"sv);
+    if (sizeof(info.name) > sizeof(path))
+        return Error::from_errno(ENAMETOOLONG);
+    strlcpy(path, info.name, sizeof(path) - 1);
 #elif defined(AK_OS_EMSCRIPTEN)
     return Error::from_string_view("current_executable_path() unknown on this platform"sv);
 #else

--- a/Userland/Libraries/LibCore/System.cpp
+++ b/Userland/Libraries/LibCore/System.cpp
@@ -695,7 +695,11 @@ ErrorOr<void> ioctl(int fd, unsigned request, ...)
 {
     va_list ap;
     va_start(ap, request);
+#ifdef AK_OS_HAIKU
+    void* arg = va_arg(ap, void*);
+#else
     FlatPtr arg = va_arg(ap, FlatPtr);
+#endif
     va_end(ap);
     if (::ioctl(fd, request, arg) < 0)
         return Error::from_syscall("ioctl"sv, -errno);

--- a/Userland/Libraries/LibCore/System.cpp
+++ b/Userland/Libraries/LibCore/System.cpp
@@ -499,7 +499,7 @@ ErrorOr<int> anon_create([[maybe_unused]] size_t size, [[maybe_unused]] int opti
         TRY(close(fd));
         return Error::from_errno(saved_errno);
     }
-#elif defined(AK_OS_BSD_GENERIC) || defined(AK_OS_EMSCRIPTEN)
+#elif defined(AK_OS_BSD_GENERIC) || defined(AK_OS_EMSCRIPTEN) || defined(AK_OS_HAIKU)
     struct timespec time;
     clock_gettime(CLOCK_REALTIME, &time);
     auto name = DeprecatedString::formatted("/shm-{}{}", (unsigned long)time.tv_sec, (unsigned long)time.tv_nsec);

--- a/Userland/Libraries/LibCore/System.cpp
+++ b/Userland/Libraries/LibCore/System.cpp
@@ -1226,7 +1226,7 @@ ErrorOr<struct utsname> uname()
     return uts;
 }
 
-#ifndef AK_OS_ANDROID
+#if !defined(AK_OS_ANDROID) && !defined(AK_OS_HAIKU)
 ErrorOr<void> adjtime(const struct timeval* delta, struct timeval* old_delta)
 {
 #    ifdef AK_OS_SERENITY

--- a/Userland/Libraries/LibCore/System.cpp
+++ b/Userland/Libraries/LibCore/System.cpp
@@ -378,7 +378,7 @@ ErrorOr<Optional<struct spwd>> getspnam(StringView name)
 }
 #endif
 
-#ifndef AK_OS_MACOS
+#if !defined(AK_OS_MACOS) && !defined(AK_OS_HAIKU)
 ErrorOr<int> accept4(int sockfd, sockaddr* address, socklen_t* address_length, int flags)
 {
     auto fd = ::accept4(sockfd, address, address_length, flags);

--- a/Userland/Libraries/LibCore/System.h
+++ b/Userland/Libraries/LibCore/System.h
@@ -105,7 +105,7 @@ ErrorOr<Optional<struct spwd>> getspent();
 ErrorOr<Optional<struct spwd>> getspnam(StringView name);
 #endif
 
-#ifndef AK_OS_MACOS
+#if !defined(AK_OS_MACOS) && !defined(AK_OS_HAIKU)
 ErrorOr<int> accept4(int sockfd, struct sockaddr*, socklen_t*, int flags);
 #endif
 

--- a/Userland/Libraries/LibCore/System.h
+++ b/Userland/Libraries/LibCore/System.h
@@ -188,7 +188,7 @@ ErrorOr<void> utime(StringView path, Optional<struct utimbuf>);
 ErrorOr<void> utimensat(int fd, StringView path, struct timespec const times[2], int flag);
 ErrorOr<struct utsname> uname();
 ErrorOr<Array<int, 2>> pipe2(int flags);
-#ifndef AK_OS_ANDROID
+#if !defined(AK_OS_ANDROID) && !defined(AK_OS_HAIKU)
 ErrorOr<void> adjtime(const struct timeval* delta, struct timeval* old_delta);
 #endif
 enum class SearchInPath {

--- a/Userland/Libraries/LibCore/TCPServer.cpp
+++ b/Userland/Libraries/LibCore/TCPServer.cpp
@@ -80,7 +80,7 @@ ErrorOr<NonnullOwnPtr<TCPSocket>> TCPServer::accept()
     VERIFY(m_listening);
     sockaddr_in in;
     socklen_t in_size = sizeof(in);
-#ifndef AK_OS_MACOS
+#if !defined(AK_OS_MACOS) && !defined(AK_OS_HAIKU)
     int accepted_fd = TRY(Core::System::accept4(m_fd, (sockaddr*)&in, &in_size, SOCK_NONBLOCK | SOCK_CLOEXEC));
 #else
     int accepted_fd = TRY(Core::System::accept(m_fd, (sockaddr*)&in, &in_size));
@@ -88,7 +88,7 @@ ErrorOr<NonnullOwnPtr<TCPSocket>> TCPServer::accept()
 
     auto socket = TRY(TCPSocket::adopt_fd(accepted_fd));
 
-#ifdef AK_OS_MACOS
+#if defined(AK_OS_MACOS) || defined(AK_OS_HAIKU)
     // FIXME: Ideally, we should let the caller decide whether it wants the
     //        socket to be nonblocking or not, but there are currently places
     //        which depend on this.

--- a/Userland/Libraries/LibWeb/Loader/ResourceLoader.h
+++ b/Userland/Libraries/LibWeb/Loader/ResourceLoader.h
@@ -44,6 +44,8 @@ namespace Web {
 #    define OS_STRING "DragonFly"
 #elif defined(AK_OS_SOLARIS)
 #    define OS_STRING "SunOS"
+#elif defined(AK_OS_HAIKU)
+#    define OS_STRING "Haiku"
 #elif defined(AK_OS_GNU_HURD)
 #    define OS_STRING "GNU/Hurd"
 #else


### PR DESCRIPTION
This set of patches makes Ladybird build (but not yet run) successful on Haiku, the open-source successor of BeOS.
Most fixes are at the same locations where patches were already required for the BSDs.
Additionally, I took a lot of inspiration from https://github.com/haikuports/haikuports/blob/897726483669e0f4f4df26f388b901d841ebf40d/www-client/ladybird/patches/serenity-pre20220728.patchset but also a lot has changed since that year.
Building Ladybird on Haiku was impossible for the last year due to the old compiler versions, GCC 13 has only become available here a few days ago which makes building Ladybird possible again.
This is currently work on progress, it builds successfully and the Ladybird window opens, but the WebContent process crashes immediately for an unknown reason.