### PR TITLE
HackStudio: Change fg color of staged/unstaged file list in Git tab

### DIFF
--- a/Userland/DevTools/HackStudio/Git/GitWidget.cpp
+++ b/Userland/DevTools/HackStudio/Git/GitWidget.cpp
@@ -51,6 +51,8 @@ GitWidget::GitWidget()
         show_diff(selected);
     };
 
+    m_unstaged_files->set_foreground_role(Gfx::ColorRole::Red);
+
     auto& staged = add<GUI::Widget>();
     staged.set_layout<GUI::VerticalBoxLayout>();
 
@@ -70,6 +72,7 @@ GitWidget::GitWidget()
     m_staged_files = staged.add<GitFilesView>(
         [this](auto const& file) { unstage_file(file); },
         Gfx::Bitmap::load_from_file("/res/icons/16x16/minus.png"sv).release_value_but_fixme_should_propagate_errors());
+    m_staged_files->set_foreground_role(Gfx::ColorRole::Green);
 }
 
 bool GitWidget::initialize()


### PR DESCRIPTION
Change the foreground color of staged and unstaged file list in the git tab to green and red respectively

<img width="1664" alt="image" src="https://github.com/SerenityOS/serenity/assets/15072510/8b5d0284-c4c9-425c-b726-c183d7a15c2c">
