### PR TITLE
LibWeb: Add a CSSPixelFraction class to allow comparison of fractions

### DIFF
--- a/Tests/LibWeb/Ref/border-radius-shrink-zero-sized-box-ref.html
+++ b/Tests/LibWeb/Ref/border-radius-shrink-zero-sized-box-ref.html
@@ -1,0 +1,1 @@
+<!-- This page is intentionally left blank. -->

--- a/Tests/LibWeb/Ref/border-radius-shrink-zero-sized-box.html
+++ b/Tests/LibWeb/Ref/border-radius-shrink-zero-sized-box.html
@@ -1,0 +1,10 @@
+<style>
+  #test {
+    background-color: red;
+    border-radius: 10px;
+    width: 0px;
+    height: 0px;
+  }
+</style>
+<div id="test">
+</div>

--- a/Tests/LibWeb/Ref/manifest.json
+++ b/Tests/LibWeb/Ref/manifest.json
@@ -16,5 +16,6 @@
     "square-flex.html": "square-ref.html",
     "svg-gradient-spreadMethod.html": "svg-gradient-spreadMethod-ref.html",
     "svg-radialGradient.html": "svg-radialGradient-ref.html",
-    "svg-symbol.html": "svg-symbol-ref.html"
+    "svg-symbol.html": "svg-symbol-ref.html",
+    "border-radius-shrink-zero-sized-box.html": "border-radius-shrink-zero-sized-box-ref.html"
 }

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -283,21 +283,21 @@ CSSPixelSize FormattingContext::solve_replaced_size_constraint(CSSPixels input_w
     auto& h = size.height;
 
     if (w > max_width)
-        size = { max_width, max(max_width * h / w, min_height) };
+        size = { max_width, max(max_width * (h / w), min_height) };
     if (w < min_width)
-        size = { min_width, min(min_width * h / w, max_height) };
+        size = { min_width, min(min_width * (h / w), max_height) };
     if (h > max_height)
-        size = { max(max_height * w / h, min_width), max_height };
+        size = { max(max_height * (w / h), min_width), max_height };
     if (h < min_height)
-        size = { min(min_height * w / h, max_width), min_height };
+        size = { min(min_height * (w / h), max_width), min_height };
     if ((w > max_width && h > max_height) && (max_width / w <= max_height / h))
-        size = { max_width, max(min_height, max_width * h / w) };
+        size = { max_width, max(min_height, max_width * (h / w)) };
     if ((w > max_width && h > max_height) && (max_width / w > max_height / h))
-        size = { max(min_width, max_height * w / h), max_height };
+        size = { max(min_width, max_height * (w / h)), max_height };
     if ((w < min_width && h < min_height) && (min_width / w <= min_height / h))
-        size = { min(max_width, min_height * w / h), min_height };
+        size = { min(max_width, min_height * (w / h)), min_height };
     if ((w < min_width && h < min_height) && (min_width / w > min_height / h))
-        size = { min_width, min(max_height, min_width * h / w) };
+        size = { min_width, min(max_height, min_width * (h / w)) };
     if (w < min_width && h > max_height)
         size = { min_width, max_height };
     if (w > max_width && h < min_height)


### PR DESCRIPTION
This class will allow us to compare the ratio of two `CSSPixels` values losslessly.

Not only that, but an operation like `a * (b / c)` should no longer be lossy, since the operation can be implicitly carried out as `(a * b) / c` instead. This part is demonstrated by adding parentheses to a calculation in `FormattingContext::solve_replaced_size_constraint()` to cause it to make use of the new `operator*(CSSPixels, CSSPixelFraction)`.

-------

This was created specifically to allow the changes that were initially implemented by @MacDue in the now-closed https://github.com/SerenityOS/serenity/pull/20759 to be done losslessly, rather than converting to and from floating point.

-------

Also included is a change to make `FormattingContext` use the new multiply-by-fraction mentioned above, meaning that if the compiler didn't already optimize them out, the unnecessary shifts done by the multiplication and division operators in that sequence of operations will no longer be done. This change has been verified to not break the page that was tested in https://github.com/SerenityOS/serenity/pull/20353, which would truncate if the division result was a single 32-bit value instead of a fraction.

cc @kalenikaliaksandr 