### PR TITLE
Kernel: Implement scrolling for critical messages in `VGATextConsole` and `GenericFramebufferConsole`

### DIFF
--- a/Kernel/Devices/GPU/Console/Console.h
+++ b/Kernel/Devices/GPU/Console/Console.h
@@ -63,6 +63,8 @@ protected:
     virtual void hide_cursor() = 0;
     virtual void show_cursor() = 0;
 
+    virtual void scroll_up() = 0;
+
     Console(size_t width, size_t height)
         : m_width(width)
         , m_height(height)

--- a/Kernel/Devices/GPU/Console/GenericFramebufferConsole.h
+++ b/Kernel/Devices/GPU/Console/GenericFramebufferConsole.h
@@ -39,6 +39,8 @@ protected:
     virtual void hide_cursor() override;
     virtual void show_cursor() override;
 
+    virtual void scroll_up() override;
+
     GenericFramebufferConsoleImpl(size_t width, size_t height, size_t pitch)
         : Console(width, height)
         , m_pitch(pitch)

--- a/Kernel/Devices/GPU/Console/VGATextModeConsole.cpp
+++ b/Kernel/Devices/GPU/Console/VGATextModeConsole.cpp
@@ -112,6 +112,11 @@ void VGATextModeConsole::clear(size_t x, size_t y, size_t length)
         buf[index] = 0x0720;
     }
 }
+
+void VGATextModeConsole::scroll_up()
+{
+}
+
 void VGATextModeConsole::write(size_t x, size_t y, char ch, bool critical)
 {
     write(x, y, ch, m_default_background_color, m_default_foreground_color, critical);

--- a/Kernel/Devices/GPU/Console/VGATextModeConsole.h
+++ b/Kernel/Devices/GPU/Console/VGATextModeConsole.h
@@ -34,6 +34,8 @@ private:
     virtual void hide_cursor() override;
     virtual void show_cursor() override;
 
+    virtual void scroll_up() override;
+
     void clear_vga_row(u16 row);
 
     explicit VGATextModeConsole(NonnullOwnPtr<Memory::Region>);


### PR DESCRIPTION
The current implementation handles newlines but simply wraps back up to the top if it reaches the bottom end of the console, creating some very unreadable messages if we get a panic while booting and looking at the debug console, like this:
![Untitled](https://github.com/SerenityOS/serenity/assets/93552013/29047163-e275-4ffb-b085-b7f94ffa7010)

I choose to move the new line handling and  handle the scrolling in `write(char ch, bool critical)` because:
1. Currently it's the only overload that's ever called with `critical = true` and
2. I don't think that anything that writes to a specific x and y would want the console to potentially scroll