### PR TITLE
LibWeb: Remove outdated old_queue_global_event_with_document

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
+++ b/Userland/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
@@ -238,13 +238,6 @@ void EventLoop::process()
         schedule();
 }
 
-// FIXME: This is here to paper over an issue in the HTML parser where it'll create new interpreters (and thus ESOs) on temporary documents created for innerHTML if it uses Document::realm() to get the global object.
-//        Use queue_global_task instead.
-void old_queue_global_task_with_document(HTML::Task::Source source, DOM::Document& document, JS::SafeFunction<void()> steps)
-{
-    main_thread_event_loop().task_queue().add(HTML::Task::create(source, &document, move(steps)));
-}
-
 // https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-global-task
 void queue_global_task(HTML::Task::Source source, JS::Object& global_object, JS::SafeFunction<void()> steps)
 {

--- a/Userland/Libraries/LibWeb/HTML/EventLoop/EventLoop.h
+++ b/Userland/Libraries/LibWeb/HTML/EventLoop/EventLoop.h
@@ -113,7 +113,6 @@ private:
 };
 
 EventLoop& main_thread_event_loop();
-void old_queue_global_task_with_document(HTML::Task::Source, DOM::Document&, JS::SafeFunction<void()> steps);
 void queue_global_task(HTML::Task::Source, JS::Object&, JS::SafeFunction<void()> steps);
 void queue_a_microtask(DOM::Document const*, JS::SafeFunction<void()> steps);
 void perform_a_microtask_checkpoint();

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
@@ -276,7 +276,7 @@ void HTMLParser::the_end()
     }
 
     // 6. Queue a global task on the DOM manipulation task source given the Document's relevant global object to run the following substeps:
-    old_queue_global_task_with_document(HTML::Task::Source::DOMManipulation, *m_document, [document = m_document] {
+    queue_global_task(HTML::Task::Source::DOMManipulation, *m_document, [document = m_document] {
         // 1. Set the Document's load timing info's DOM content loaded event start time to the current high resolution time given the Document's relevant global object.
         document->load_timing_info().dom_content_loaded_event_start_time = HighResolutionTime::unsafe_shared_current_time();
 
@@ -305,7 +305,7 @@ void HTMLParser::the_end()
     });
 
     // 9. Queue a global task on the DOM manipulation task source given the Document's relevant global object to run the following steps:
-    old_queue_global_task_with_document(HTML::Task::Source::DOMManipulation, *m_document, [document = m_document] {
+    queue_global_task(HTML::Task::Source::DOMManipulation, *m_document, [document = m_document] {
         // 1. Update the current document readiness to "complete".
         document->update_readiness(HTML::DocumentReadyState::Complete);
 

--- a/Userland/Libraries/LibWeb/XML/XMLDocumentBuilder.cpp
+++ b/Userland/Libraries/LibWeb/XML/XMLDocumentBuilder.cpp
@@ -192,7 +192,7 @@ void XMLDocumentBuilder::document_end()
         (void)m_document->scripts_to_execute_when_parsing_has_finished().take_first();
     }
     // Queue a global task on the DOM manipulation task source given the Document's relevant global object to run the following substeps:
-    old_queue_global_task_with_document(HTML::Task::Source::DOMManipulation, m_document, [document = m_document] {
+    queue_global_task(HTML::Task::Source::DOMManipulation, m_document, [document = m_document] {
         // Set the Document's load timing info's DOM content loaded event start time to the current high resolution time given the Document's relevant global object.
         document->load_timing_info().dom_content_loaded_event_start_time = HighResolutionTime::unsafe_shared_current_time();
 
@@ -220,7 +220,7 @@ void XMLDocumentBuilder::document_end()
     });
 
     // Queue a global task on the DOM manipulation task source given the Document's relevant global object to run the following steps:
-    old_queue_global_task_with_document(HTML::Task::Source::DOMManipulation, m_document, [document = m_document] {
+    queue_global_task(HTML::Task::Source::DOMManipulation, m_document, [document = m_document] {
         // Update the current document readiness to "complete".
         document->update_readiness(HTML::DocumentReadyState::Complete);
 


### PR DESCRIPTION
The FIXME here describes an old constraint on JS Interpreters which no longer holds. It hails from a time when we had the global object and JS realm attached to the document.