### PR TITLE
LibWeb: Update Navigable::navigate() to the current state of the spec

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -133,7 +133,7 @@ static JS::NonnullGCPtr<HTML::BrowsingContext> obtain_a_browsing_context_to_use_
     //           cross-origin isolation mode to either "logical" or "concrete". The choice of which is implementation-defined.
 
     // 5. If sandboxFlags is not empty, then:
-    if (!sandbox_flags.is_empty()) {
+    if (!is_empty(sandbox_flags)) {
         // 1. Assert navigationCOOP's value is "unsafe-none".
         VERIFY(navigation_coop.value == HTML::CrossOriginOpenerPolicyValue::UnsafeNone);
 
@@ -2533,7 +2533,7 @@ HTML::SourceSnapshotParams Document::snapshot_source_snapshot_params() const
     return HTML::SourceSnapshotParams {
         .has_transient_activation = verify_cast<HTML::Window>(HTML::relevant_global_object(*this)).has_transient_activation(),
         .sandboxing_flags = m_active_sandboxing_flag_set,
-        .allows_downloading = (m_active_sandboxing_flag_set.flags & HTML::SandboxingFlagSet::SandboxedDownloads) != HTML::SandboxingFlagSet::SandboxedDownloads,
+        .allows_downloading = !has_flag(m_active_sandboxing_flag_set, HTML::SandboxingFlagSet::SandboxedDownloads),
         .fetch_client = relevant_settings_object(),
         .source_policy_container = m_policy_container
     };
@@ -3473,7 +3473,7 @@ void Document::shared_declarative_refresh_steps(StringView input, JS::GCPtr<HTML
     //   flag set, then navigate document's node navigable to urlRecord using document, with historyHandling set to
     //   "replace".
     m_active_refresh_timer = Core::Timer::create_single_shot(time * 1000, [this, has_meta_element = !!meta_element, url_record = move(url_record)]() {
-        if (has_meta_element && active_sandboxing_flag_set().flags & HTML::SandboxingFlagSet::SandboxedAutomaticFeatures)
+        if (has_meta_element && has_flag(active_sandboxing_flag_set(), HTML::SandboxingFlagSet::SandboxedAutomaticFeatures))
             return;
 
         // FIXME: Use navigables when they're used for all navigation (otherwise, navigable() would be null in some cases)

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -457,7 +457,7 @@ struct EnvironmentSettingsObject;
 struct NavigationParams;
 struct POSTResource;
 struct PolicyContainer;
-struct SandboxingFlagSet;
+enum class SandboxingFlagSet;
 struct SerializedFormData;
 struct SessionHistoryEntry;
 }

--- a/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
@@ -37,7 +37,7 @@
 namespace Web::HTML {
 
 // https://html.spec.whatwg.org/multipage/urls-and-fetching.html#matches-about:blank
-static bool url_matches_about_blank(AK::URL const& url)
+bool url_matches_about_blank(AK::URL const& url)
 {
     // A URL matches about:blank if its scheme is "about", its path contains a single string "blank", its username and password are the empty string, and its host is null.
     return url.scheme() == "about"sv

--- a/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
@@ -1635,4 +1635,11 @@ bool BrowsingContext::is_ancestor_of(BrowsingContext const& other) const
     return false;
 }
 
+// https://html.spec.whatwg.org/multipage/browsing-the-web.html#snapshotting-target-snapshot-params
+SandboxingFlagSet determine_the_creation_sandboxing_flags(BrowsingContext const&, JS::GCPtr<DOM::Element>)
+{
+    // FIXME: Populate this once we have the proper flag sets on BrowsingContext
+    return {};
+}
+
 }

--- a/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
@@ -52,7 +52,7 @@ static bool url_matches_about_blank(AK::URL const& url)
 HTML::Origin determine_the_origin(BrowsingContext const& browsing_context, Optional<AK::URL> url, SandboxingFlagSet sandbox_flags, Optional<HTML::Origin> invocation_origin)
 {
     // 1. If sandboxFlags has its sandboxed origin browsing context flag set, then return a new opaque origin.
-    if (sandbox_flags.flags & SandboxingFlagSet::SandboxedOrigin) {
+    if (has_flag(sandbox_flags, SandboxingFlagSet::SandboxedOrigin)) {
         return HTML::Origin {};
     }
 
@@ -80,7 +80,7 @@ HTML::Origin determine_the_origin(BrowsingContext const& browsing_context, Optio
 HTML::Origin determine_the_origin(AK::URL const& url, SandboxingFlagSet sandbox_flags, Optional<HTML::Origin> source_origin, Optional<HTML::Origin> container_origin)
 {
     // 1. If sandboxFlags has its sandboxed origin browsing context flag set, then return a new opaque origin.
-    if (sandbox_flags.flags & SandboxingFlagSet::SandboxedOrigin) {
+    if (has_flag(sandbox_flags, SandboxingFlagSet::SandboxedOrigin)) {
         return HTML::Origin {};
     }
 
@@ -135,7 +135,7 @@ JS::NonnullGCPtr<BrowsingContext> BrowsingContext::create_a_new_browsing_context
     }
 
     // FIXME: 4. Let sandboxFlags be the result of determining the creation sandboxing flags given browsingContext and embedded.
-    SandboxingFlagSet sandbox_flags;
+    SandboxingFlagSet sandbox_flags = {};
 
     // 5. Let origin be the result of determining the origin given browsingContext, about:blank, sandboxFlags, and browsingContext's creator origin.
     auto origin = determine_the_origin(*browsing_context, AK::URL("about:blank"), sandbox_flags, browsing_context->m_creator_origin);
@@ -311,7 +311,7 @@ WebIDL::ExceptionOr<BrowsingContext::BrowsingContextAndDocument> BrowsingContext
     }
 
     // FIXME: 5. Let sandboxFlags be the result of determining the creation sandboxing flags given browsingContext and embedder.
-    SandboxingFlagSet sandbox_flags;
+    SandboxingFlagSet sandbox_flags = {};
 
     // 6. Let origin be the result of determining the origin given about:blank, sandboxFlags, creatorOrigin, and null.
     auto origin = determine_the_origin(AK::URL("about:blank"sv), sandbox_flags, creator_origin, {});
@@ -890,7 +890,7 @@ BrowsingContext::ChosenBrowsingContext BrowsingContext::choose_a_browsing_contex
         }
 
         // --> If sandboxingFlagSet has the sandboxed auxiliary navigation browsing context flag set
-        else if (sandboxing_flag_set.flags & SandboxingFlagSet::SandboxedAuxiliaryNavigation) {
+        else if (has_flag(sandboxing_flag_set, SandboxingFlagSet::SandboxedAuxiliaryNavigation)) {
             // FIXME: The user agent may report to a developer console that a popup has been blocked.
             dbgln("Pop-up blocked!");
         }
@@ -1445,7 +1445,7 @@ bool BrowsingContext::is_allowed_to_navigate(BrowsingContext const& other) const
         //    and A's active document's active sandboxing flag set has its sandboxed top-level navigation with user activation browsing context flag set,
         //    then return false.
         if (active_window()->has_transient_activation()
-            && active_document()->active_sandboxing_flag_set().flags & SandboxingFlagSet::SandboxedTopLevelNavigationWithUserActivation) {
+            && has_flag(active_document()->active_sandboxing_flag_set(), SandboxingFlagSet::SandboxedTopLevelNavigationWithUserActivation)) {
             return false;
         }
 
@@ -1453,7 +1453,7 @@ bool BrowsingContext::is_allowed_to_navigate(BrowsingContext const& other) const
         //    and A's active document's active sandboxing flag set has its sandboxed top-level navigation without user activation browsing context flag set,
         //    then return false.
         if (!active_window()->has_transient_activation()
-            && active_document()->active_sandboxing_flag_set().flags & SandboxingFlagSet::SandboxedTopLevelNavigationWithoutUserActivation) {
+            && has_flag(active_document()->active_sandboxing_flag_set(), SandboxingFlagSet::SandboxedTopLevelNavigationWithoutUserActivation)) {
             return false;
         }
     }
@@ -1466,7 +1466,7 @@ bool BrowsingContext::is_allowed_to_navigate(BrowsingContext const& other) const
     if (other.is_top_level()
         && &other != this
         && !other.is_ancestor_of(*this)
-        && active_document()->active_sandboxing_flag_set().flags & SandboxingFlagSet::SandboxedNavigation
+        && has_flag(active_document()->active_sandboxing_flag_set(), SandboxingFlagSet::SandboxedNavigation)
         && this != other.the_one_permitted_sandboxed_navigator()) {
         return false;
     }

--- a/Userland/Libraries/LibWeb/HTML/BrowsingContext.h
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContext.h
@@ -21,6 +21,7 @@
 #include <LibWeb/HTML/HistoryHandlingBehavior.h>
 #include <LibWeb/HTML/NavigableContainer.h>
 #include <LibWeb/HTML/Origin.h>
+#include <LibWeb/HTML/SandboxingFlagSet.h>
 #include <LibWeb/HTML/SessionHistoryEntry.h>
 #include <LibWeb/HTML/TokenizedFeatures.h>
 #include <LibWeb/HTML/VisibilityState.h>
@@ -336,5 +337,8 @@ private:
 HTML::Origin determine_the_origin(BrowsingContext const& browsing_context, Optional<AK::URL> url, SandboxingFlagSet sandbox_flags, Optional<HTML::Origin> invocation_origin);
 
 HTML::Origin determine_the_origin(AK::URL const& url, SandboxingFlagSet sandbox_flags, Optional<HTML::Origin> source_origin, Optional<HTML::Origin> container_origin);
+
+// FIXME: Find a better home for this
+bool url_matches_about_blank(AK::URL const& url);
 
 }

--- a/Userland/Libraries/LibWeb/HTML/BrowsingContext.h
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContext.h
@@ -338,6 +338,8 @@ HTML::Origin determine_the_origin(BrowsingContext const& browsing_context, Optio
 
 HTML::Origin determine_the_origin(AK::URL const& url, SandboxingFlagSet sandbox_flags, Optional<HTML::Origin> source_origin, Optional<HTML::Origin> container_origin);
 
+SandboxingFlagSet determine_the_creation_sandboxing_flags(BrowsingContext const&, JS::GCPtr<DOM::Element> embedder);
+
 // FIXME: Find a better home for this
 bool url_matches_about_blank(AK::URL const& url);
 

--- a/Userland/Libraries/LibWeb/HTML/DocumentState.h
+++ b/Userland/Libraries/LibWeb/HTML/DocumentState.h
@@ -52,6 +52,9 @@ public:
     [[nodiscard]] Optional<HTML::Origin> origin() const { return m_origin; }
     void set_origin(Optional<HTML::Origin> origin) { m_origin = move(origin); }
 
+    [[nodiscard]] Optional<AK::URL> const& about_base_url() const { return m_about_base_url; }
+    void set_about_base_url(Optional<AK::URL> url) { m_about_base_url = move(url); }
+
     [[nodiscard]] Vector<NestedHistory> const& nested_histories() const { return m_nested_histories; }
     [[nodiscard]] Vector<NestedHistory>& nested_histories() { return m_nested_histories; }
 
@@ -89,6 +92,9 @@ private:
 
     // https://html.spec.whatwg.org/multipage/browsing-the-web.html#document-state-origin
     Optional<HTML::Origin> m_origin;
+
+    // https://html.spec.whatwg.org/multipage/browsing-the-web.html#document-state-about-base-url
+    Optional<AK::URL> m_about_base_url = {};
 
     // https://html.spec.whatwg.org/multipage/browsing-the-web.html#document-state-nested-histories
     Vector<NestedHistory> m_nested_histories;

--- a/Userland/Libraries/LibWeb/HTML/HTMLFormElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFormElement.cpp
@@ -74,7 +74,7 @@ WebIDL::ExceptionOr<void> HTMLFormElement::submit_form(JS::NonnullGCPtr<HTMLElem
     auto* form_browsing_context = form_document->browsing_context();
 
     // 4. If form document's active sandboxing flag set has its sandboxed forms browsing context flag set, then return.
-    if (form_document->active_sandboxing_flag_set().flags & HTML::SandboxingFlagSet::Flag::SandboxedForms)
+    if (has_flag(form_document->active_sandboxing_flag_set(), HTML::SandboxingFlagSet::SandboxedForms))
         return {};
 
     // 5. If the submitted from submit() method flag is not set, then:

--- a/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -1655,7 +1655,7 @@ bool HTMLMediaElement::is_eligible_for_autoplay() const
         has_attribute(HTML::AttributeNames::autoplay) &&
 
         // Its node document's active sandboxing flag set does not have the sandboxed automatic features browsing context flag set.
-        (document().active_sandboxing_flag_set().flags & SandboxingFlagSet::SandboxedAutomaticFeatures) == 0 &&
+        !has_flag(document().active_sandboxing_flag_set(), SandboxingFlagSet::SandboxedAutomaticFeatures) &&
 
         // Its node document is allowed to use the "autoplay" feature.
         document().is_allowed_to_use_feature(DOM::PolicyControlledFeature::Autoplay));

--- a/Userland/Libraries/LibWeb/HTML/Location.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Location.cpp
@@ -16,6 +16,7 @@
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/CrossOrigin/AbstractOperations.h>
 #include <LibWeb/HTML/Location.h>
+#include <LibWeb/HTML/Navigation.h>
 #include <LibWeb/HTML/Window.h>
 #include <LibWeb/WebIDL/DOMException.h>
 
@@ -58,6 +59,18 @@ JS::GCPtr<DOM::Document> Location::relevant_document() const
     return browsing_context ? browsing_context->active_document() : nullptr;
 }
 
+static Bindings::NavigationHistoryBehavior to_navigation_history_behavior(HistoryHandlingBehavior b)
+{
+    switch (b) {
+    case HistoryHandlingBehavior::Push:
+        return Bindings::NavigationHistoryBehavior::Push;
+    case HistoryHandlingBehavior::Replace:
+        return Bindings::NavigationHistoryBehavior::Replace;
+    default:
+        return Bindings::NavigationHistoryBehavior::Auto;
+    }
+}
+
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#location-object-navigate
 WebIDL::ExceptionOr<void> Location::navigate(AK::URL url, HistoryHandlingBehavior history_handling)
 {
@@ -73,7 +86,7 @@ WebIDL::ExceptionOr<void> Location::navigate(AK::URL url, HistoryHandlingBehavio
     }
 
     // 4. Navigate navigable to url using sourceDocument, with exceptionsEnabled set to true and historyHandling set to historyHandling.
-    TRY(navigable->navigate(url, source_document, {}, nullptr, true, history_handling));
+    TRY(navigable->navigate(url, source_document, {}, nullptr, true, to_navigation_history_behavior(history_handling)));
 
     return {};
 }

--- a/Userland/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Navigable.cpp
@@ -490,7 +490,7 @@ static WebIDL::ExceptionOr<Optional<NavigationParams>> create_navigation_params_
     JS::GCPtr<Fetch::Infrastructure::FetchController> fetch_controller = nullptr;
 
     // 13. Let finalSandboxFlags be an empty sandboxing flag set.
-    SandboxingFlagSet final_sandbox_flags;
+    SandboxingFlagSet final_sandbox_flags = {};
 
     // 16. Let locationURL be null.
     ErrorOr<Optional<AK::URL>> location_url { OptionalNone {} };

--- a/Userland/Libraries/LibWeb/HTML/Navigable.h
+++ b/Userland/Libraries/LibWeb/HTML/Navigable.h
@@ -66,6 +66,8 @@ public:
     JS::GCPtr<TraversableNavigable> traversable_navigable() const;
     JS::GCPtr<TraversableNavigable> top_level_traversable();
 
+    virtual bool is_top_level_traversable() const { return false; }
+
     enum class WindowType {
         ExistingOrNone,
         NewAndUnrestricted,

--- a/Userland/Libraries/LibWeb/HTML/NavigableContainer.cpp
+++ b/Userland/Libraries/LibWeb/HTML/NavigableContainer.cpp
@@ -211,17 +211,6 @@ HTML::WindowProxy* NavigableContainer::content_window()
     return m_nested_browsing_context->window_proxy();
 }
 
-// https://html.spec.whatwg.org/multipage/urls-and-fetching.html#matches-about:blank
-static bool url_matches_about_blank(AK::URL const& url)
-{
-    // A URL matches about:blank if its scheme is "about", its path contains a single string "blank", its username and password are the empty string, and its host is null.
-    return url.scheme() == "about"sv
-        && url.serialize_path() == "blank"sv
-        && url.raw_username().is_empty()
-        && url.raw_password().is_empty()
-        && url.host().has<Empty>();
-}
-
 // https://html.spec.whatwg.org/multipage/iframe-embed-object.html#shared-attribute-processing-steps-for-iframe-and-frame-elements
 void NavigableContainer::shared_attribute_processing_steps_for_iframe_and_frame(bool initial_insertion)
 {

--- a/Userland/Libraries/LibWeb/HTML/Navigation.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Navigation.cpp
@@ -181,15 +181,19 @@ bool Navigation::can_go_forward() const
     return (m_current_entry_index != static_cast<i64>(m_entry_list.size()));
 }
 
-static HistoryHandlingBehavior to_history_handling_behavior(Bindings::NavigationHistoryBehavior b)
+HistoryHandlingBehavior to_history_handling_behavior(Bindings::NavigationHistoryBehavior b)
 {
+    // A history handling behavior is a NavigationHistoryBehavior that is either "push" or "replace",
+    // i.e., that has been resolved away from any initial "auto" value.
+    VERIFY(b != Bindings::NavigationHistoryBehavior::Auto);
+
     switch (b) {
-    case Bindings::NavigationHistoryBehavior::Auto:
-        return HistoryHandlingBehavior::Default;
     case Bindings::NavigationHistoryBehavior::Push:
         return HistoryHandlingBehavior::Push;
     case Bindings::NavigationHistoryBehavior::Replace:
         return HistoryHandlingBehavior::Replace;
+    case Bindings::NavigationHistoryBehavior::Auto:
+        VERIFY_NOT_REACHED();
     };
     VERIFY_NOT_REACHED();
 }

--- a/Userland/Libraries/LibWeb/HTML/Navigation.h
+++ b/Userland/Libraries/LibWeb/HTML/Navigation.h
@@ -9,6 +9,7 @@
 #include <LibJS/Runtime/Promise.h>
 #include <LibWeb/Bindings/NavigationPrototype.h>
 #include <LibWeb/DOM/EventTarget.h>
+#include <LibWeb/HTML/HistoryHandlingBehavior.h>
 #include <LibWeb/HTML/StructuredSerialize.h>
 
 namespace Web::HTML {
@@ -151,5 +152,7 @@ private:
     // https://html.spec.whatwg.org/multipage/nav-history-apis.html#upcoming-non-traverse-api-method-tracker
     HashMap<String, JS::NonnullGCPtr<NavigationAPIMethodTracker>> m_upcoming_traverse_api_method_trackers;
 };
+
+HistoryHandlingBehavior to_history_handling_behavior(Bindings::NavigationHistoryBehavior);
 
 }

--- a/Userland/Libraries/LibWeb/HTML/NavigationParams.h
+++ b/Userland/Libraries/LibWeb/HTML/NavigationParams.h
@@ -36,7 +36,7 @@ struct NavigationParams {
     PolicyContainer policy_container;
 
     // a sandboxing flag set to impose on the new Document
-    SandboxingFlagSet final_sandboxing_flag_set;
+    SandboxingFlagSet final_sandboxing_flag_set = {};
 
     // a cross-origin opener policy to use for the new Document
     CrossOriginOpenerPolicy cross_origin_opener_policy;

--- a/Userland/Libraries/LibWeb/HTML/SandboxingFlagSet.h
+++ b/Userland/Libraries/LibWeb/HTML/SandboxingFlagSet.h
@@ -6,35 +6,33 @@
 
 #pragma once
 
+#include <AK/EnumBits.h>
 #include <AK/Types.h>
 
 namespace Web::HTML {
 
 // https://html.spec.whatwg.org/multipage/origin.html#sandboxing-flag-set
-struct SandboxingFlagSet {
-    enum Flag {
-        SandboxedNavigation = 1u << 0u,
-        SandboxedAuxiliaryNavigation = 1u << 1u,
-        SandboxedTopLevelNavigationWithoutUserActivation = 1u << 2u,
-        SandboxedTopLevelNavigationWithUserActivation = 1u << 3u,
-        SandboxedPlugins = 1u << 4u,
-        SandboxedOrigin = 1u << 5u,
-        SandboxedForms = 1u << 6u,
-        SandboxedPointerLock = 1u << 7u,
-        SandboxedScripts = 1u << 8u,
-        SandboxedAutomaticFeatures = 1u << 9u,
-        SandboxedDocumentDomain = 1u << 10u,
-        SandboxPropagatesToAuxiliaryBrowsingContexts = 1u << 11u,
-        SandboxedModals = 1u << 12u,
-        SandboxedOrientationLock = 1u << 13u,
-        SandboxedPresentation = 1u << 14u,
-        SandboxedDownloads = 1u << 15u,
-        SandboxedCustomProtocols = 1u << 16u,
-    };
-
-    bool is_empty() const { return flags == 0; }
-
-    u32 flags { 0 };
+enum class SandboxingFlagSet {
+    SandboxedNavigation = 1u << 0u,
+    SandboxedAuxiliaryNavigation = 1u << 1u,
+    SandboxedTopLevelNavigationWithoutUserActivation = 1u << 2u,
+    SandboxedTopLevelNavigationWithUserActivation = 1u << 3u,
+    SandboxedPlugins = 1u << 4u,
+    SandboxedOrigin = 1u << 5u,
+    SandboxedForms = 1u << 6u,
+    SandboxedPointerLock = 1u << 7u,
+    SandboxedScripts = 1u << 8u,
+    SandboxedAutomaticFeatures = 1u << 9u,
+    SandboxedDocumentDomain = 1u << 10u,
+    SandboxPropagatesToAuxiliaryBrowsingContexts = 1u << 11u,
+    SandboxedModals = 1u << 12u,
+    SandboxedOrientationLock = 1u << 13u,
+    SandboxedPresentation = 1u << 14u,
+    SandboxedDownloads = 1u << 15u,
+    SandboxedCustomProtocols = 1u << 16u,
 };
+
+AK_ENUM_BITWISE_OPERATORS(SandboxingFlagSet);
+inline bool is_empty(SandboxingFlagSet s) { return (to_underlying(s) & 0x1FFU) == 0; }
 
 }

--- a/Userland/Libraries/LibWeb/HTML/SourceSnapshotParams.h
+++ b/Userland/Libraries/LibWeb/HTML/SourceSnapshotParams.h
@@ -17,7 +17,7 @@ struct SourceSnapshotParams {
     bool has_transient_activation;
 
     // a sandboxing flag set
-    SandboxingFlagSet sandboxing_flags;
+    SandboxingFlagSet sandboxing_flags = {};
 
     // a boolean
     bool allows_downloading;

--- a/Userland/Libraries/LibWeb/HTML/TraversableNavigable.h
+++ b/Userland/Libraries/LibWeb/HTML/TraversableNavigable.h
@@ -23,7 +23,7 @@ public:
 
     virtual ~TraversableNavigable() override;
 
-    bool is_top_level_traversable() const;
+    virtual bool is_top_level_traversable() const override;
 
     int current_session_history_step() const { return m_current_session_history_step; }
     Vector<JS::NonnullGCPtr<SessionHistoryEntry>>& session_history_entries() { return m_session_history_entries; }

--- a/Userland/Libraries/LibWeb/XHR/FormData.h
+++ b/Userland/Libraries/LibWeb/XHR/FormData.h
@@ -11,16 +11,9 @@
 #include <LibWeb/Forward.h>
 #include <LibWeb/HTML/HTMLFormElement.h>
 #include <LibWeb/WebIDL/ExceptionOr.h>
+#include <LibWeb/XHR/FormDataEntry.h>
 
 namespace Web::XHR {
-
-// https://xhr.spec.whatwg.org/#formdataentryvalue
-using FormDataEntryValue = Variant<JS::Handle<FileAPI::File>, String>;
-
-struct FormDataEntry {
-    String name;
-    FormDataEntryValue value;
-};
 
 // https://xhr.spec.whatwg.org/#interface-formdata
 class FormData : public Bindings::PlatformObject {

--- a/Userland/Libraries/LibWeb/XHR/FormDataEntry.h
+++ b/Userland/Libraries/LibWeb/XHR/FormDataEntry.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2023, Kenneth Myhra <kennethmyhra@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/String.h>
+#include <AK/Variant.h>
+#include <LibJS/Heap/Handle.h>
+#include <LibWeb/Forward.h>
+
+namespace Web::XHR {
+
+// https://xhr.spec.whatwg.org/#formdataentryvalue
+using FormDataEntryValue = Variant<JS::Handle<FileAPI::File>, String>;
+
+struct FormDataEntry {
+    String name;
+    FormDataEntryValue value;
+};
+
+}


### PR DESCRIPTION
A few parameters and step renumberings have happened since we first
implemented this algorithm.

Also add some scaffolding and cleanup to other classes to make the implementation easier.