### PR TITLE
Ladybird+LibWebView: Implement the Ladybird "View Source" action with generated HTML in a separate web view

### DIFF
--- a/Ladybird/AppKit/Application/ApplicationDelegate.h
+++ b/Ladybird/AppKit/Application/ApplicationDelegate.h
@@ -28,6 +28,11 @@
                                fromTab:(nullable Tab*)tab
                            activateTab:(Web::HTML::ActivateTab)activate_tab;
 
+- (nonnull TabController*)createNewTab:(StringView)html
+                                   url:(URL const&)url
+                               fromTab:(nullable Tab*)tab
+                           activateTab:(Web::HTML::ActivateTab)activate_tab;
+
 - (void)removeTab:(nonnull TabController*)controller;
 
 - (Browser::CookieJar&)cookieJar;

--- a/Ladybird/AppKit/Application/ApplicationDelegate.h
+++ b/Ladybird/AppKit/Application/ApplicationDelegate.h
@@ -24,8 +24,8 @@
                 withCookieJar:(Browser::CookieJar)cookie_jar
       webdriverContentIPCPath:(StringView)webdriver_content_ipc_path;
 
-- (nonnull TabController*)createNewTab:(Optional<URL> const&)url;
 - (nonnull TabController*)createNewTab:(Optional<URL> const&)url
+                               fromTab:(nullable Tab*)tab
                            activateTab:(Web::HTML::ActivateTab)activate_tab;
 
 - (void)removeTab:(nonnull TabController*)controller;

--- a/Ladybird/AppKit/Application/ApplicationDelegate.mm
+++ b/Ladybird/AppKit/Application/ApplicationDelegate.mm
@@ -86,19 +86,20 @@
                        fromTab:(Tab*)tab
                    activateTab:(Web::HTML::ActivateTab)activate_tab
 {
-    auto* controller = [[TabController alloc] init:url.value_or(m_new_tab_page_url)];
-    [controller showWindow:nil];
+    auto* controller = [self createNewTab:activate_tab fromTab:tab];
+    [controller loadURL:url.value_or(m_new_tab_page_url)];
 
-    if (tab) {
-        [[tab tabGroup] addWindow:controller.window];
+    return controller;
+}
 
-        // FIXME: Can we create the tabbed window above without it becoming active in the first place?
-        if (activate_tab == Web::HTML::ActivateTab::No) {
-            [tab orderFront:nil];
-        }
-    }
+- (nonnull TabController*)createNewTab:(StringView)html
+                                   url:(URL const&)url
+                               fromTab:(nullable Tab*)tab
+                           activateTab:(Web::HTML::ActivateTab)activate_tab
+{
+    auto* controller = [self createNewTab:activate_tab fromTab:tab];
+    [controller loadHTML:html url:url];
 
-    [self.managed_tabs addObject:controller];
     return controller;
 }
 
@@ -123,6 +124,25 @@
 }
 
 #pragma mark - Private methods
+
+- (nonnull TabController*)createNewTab:(Web::HTML::ActivateTab)activate_tab
+                               fromTab:(nullable Tab*)tab
+{
+    auto* controller = [[TabController alloc] init];
+    [controller showWindow:nil];
+
+    if (tab) {
+        [[tab tabGroup] addWindow:controller.window];
+
+        // FIXME: Can we create the tabbed window above without it becoming active in the first place?
+        if (activate_tab == Web::HTML::ActivateTab::No) {
+            [tab orderFront:nil];
+        }
+    }
+
+    [self.managed_tabs addObject:controller];
+    return controller;
+}
 
 - (void)closeCurrentTab:(id)sender
 {

--- a/Ladybird/AppKit/Application/ApplicationDelegate.mm
+++ b/Ladybird/AppKit/Application/ApplicationDelegate.mm
@@ -36,6 +36,7 @@
 - (NSMenuItem*)createEditMenu;
 - (NSMenuItem*)createViewMenu;
 - (NSMenuItem*)createHistoryMenu;
+- (NSMenuItem*)createInspectMenu;
 - (NSMenuItem*)createDebugMenu;
 - (NSMenuItem*)createWindowsMenu;
 - (NSMenuItem*)createHelpMenu;
@@ -56,6 +57,7 @@
         [[NSApp mainMenu] addItem:[self createEditMenu]];
         [[NSApp mainMenu] addItem:[self createViewMenu]];
         [[NSApp mainMenu] addItem:[self createHistoryMenu]];
+        [[NSApp mainMenu] addItem:[self createInspectMenu]];
         [[NSApp mainMenu] addItem:[self createDebugMenu]];
         [[NSApp mainMenu] addItem:[self createWindowsMenu]];
         [[NSApp mainMenu] addItem:[self createHelpMenu]];
@@ -326,6 +328,19 @@
 
     [submenu addItem:[[NSMenuItem alloc] initWithTitle:@"Clear History"
                                                 action:@selector(clearHistory:)
+                                         keyEquivalent:@""]];
+
+    [menu setSubmenu:submenu];
+    return menu;
+}
+
+- (NSMenuItem*)createInspectMenu
+{
+    auto* menu = [[NSMenuItem alloc] init];
+    auto* submenu = [[NSMenu alloc] initWithTitle:@"Inspect"];
+
+    [submenu addItem:[[NSMenuItem alloc] initWithTitle:@"View Source"
+                                                action:@selector(viewSource:)
                                          keyEquivalent:@""]];
 
     [menu setSubmenu:submenu];

--- a/Ladybird/AppKit/UI/LadybirdWebView.h
+++ b/Ladybird/AppKit/UI/LadybirdWebView.h
@@ -22,4 +22,6 @@
 
 - (void)setPreferredColorScheme:(Web::CSS::PreferredColorScheme)color_scheme;
 
+- (void)viewSource;
+
 @end

--- a/Ladybird/AppKit/UI/LadybirdWebView.h
+++ b/Ladybird/AppKit/UI/LadybirdWebView.h
@@ -13,7 +13,8 @@
 
 @interface LadybirdWebView : NSClipView
 
-- (void)load:(URL const&)url;
+- (void)loadURL:(URL const&)url;
+- (void)loadHTML:(StringView)html url:(URL const&)url;
 
 - (void)handleResize;
 - (void)handleScroll;

--- a/Ladybird/AppKit/UI/LadybirdWebView.mm
+++ b/Ladybird/AppKit/UI/LadybirdWebView.mm
@@ -100,9 +100,14 @@ struct HideCursor {
 
 #pragma mark - Public methods
 
-- (void)load:(URL const&)url
+- (void)loadURL:(URL const&)url
 {
     m_web_view_bridge->load(url);
+}
+
+- (void)loadHTML:(StringView)html url:(URL const&)url
+{
+    m_web_view_bridge->load_html(html, url);
 }
 
 - (void)handleResize
@@ -364,7 +369,7 @@ struct HideCursor {
                            fromTab:[self tab]
                        activateTab:Web::HTML::ActivateTab::Yes];
         } else {
-            [[self tabController] load:url];
+            [[self tabController] loadURL:url];
         }
     };
 

--- a/Ladybird/AppKit/UI/LadybirdWebView.mm
+++ b/Ladybird/AppKit/UI/LadybirdWebView.mm
@@ -178,9 +178,12 @@ struct HideCursor {
         [self setNeedsDisplay:YES];
     };
 
-    m_web_view_bridge->on_new_tab = [](auto activate_tab) {
+    m_web_view_bridge->on_new_tab = [self](auto activate_tab) {
         auto* delegate = (ApplicationDelegate*)[NSApp delegate];
-        auto* controller = [delegate createNewTab:"about:blank"sv activateTab:activate_tab];
+
+        auto* controller = [delegate createNewTab:"about:blank"sv
+                                          fromTab:[self tab]
+                                      activateTab:activate_tab];
 
         auto* tab = (Tab*)[controller window];
         auto* web_view = [tab web_view];
@@ -353,17 +356,24 @@ struct HideCursor {
         auto* delegate = (ApplicationDelegate*)[NSApp delegate];
 
         if (modifiers == Mod_Super) {
-            [delegate createNewTab:url activateTab:Web::HTML::ActivateTab::No];
+            [delegate createNewTab:url
+                           fromTab:[self tab]
+                       activateTab:Web::HTML::ActivateTab::No];
         } else if (target == "_blank"sv) {
-            [delegate createNewTab:url activateTab:Web::HTML::ActivateTab::Yes];
+            [delegate createNewTab:url
+                           fromTab:[self tab]
+                       activateTab:Web::HTML::ActivateTab::Yes];
         } else {
             [[self tabController] load:url];
         }
     };
 
-    m_web_view_bridge->on_link_middle_click = [](auto url, auto, unsigned) {
+    m_web_view_bridge->on_link_middle_click = [self](auto url, auto, unsigned) {
         auto* delegate = (ApplicationDelegate*)[NSApp delegate];
-        [delegate createNewTab:url activateTab:Web::HTML::ActivateTab::No];
+
+        [delegate createNewTab:url
+                       fromTab:[self tab]
+                   activateTab:Web::HTML::ActivateTab::No];
     };
 
     m_web_view_bridge->on_context_menu_request = [self](auto position) {

--- a/Ladybird/AppKit/UI/Palette.mm
+++ b/Ladybird/AppKit/UI/Palette.mm
@@ -30,7 +30,7 @@ Core::AnonymousBuffer create_system_palette()
 {
     auto is_dark = is_using_dark_system_theme();
 
-    auto theme_file = is_dark ? "Default"sv : "Dark"sv;
+    auto theme_file = is_dark ? "Dark"sv : "Default"sv;
     auto theme_path = DeprecatedString::formatted("{}/res/themes/{}.ini", s_serenity_resource_root, theme_file);
 
     auto theme = MUST(Gfx::load_system_theme(theme_path));

--- a/Ladybird/AppKit/UI/TabController.h
+++ b/Ladybird/AppKit/UI/TabController.h
@@ -13,9 +13,10 @@
 
 @interface TabController : NSWindowController <NSWindowDelegate>
 
-- (instancetype)init:(URL)url;
+- (instancetype)init;
 
-- (void)load:(URL const&)url;
+- (void)loadURL:(URL const&)url;
+- (void)loadHTML:(StringView)html url:(URL const&)url;
 
 - (void)onLoadStart:(URL const&)url isRedirect:(BOOL)isRedirect;
 - (void)onTitleChange:(DeprecatedString const&)title;

--- a/Ladybird/AppKit/UI/TabController.mm
+++ b/Ladybird/AppKit/UI/TabController.mm
@@ -139,6 +139,10 @@ enum class IsHistoryNavigation {
 
 - (void)reload:(id)sender
 {
+    if (m_history.is_empty()) {
+        return;
+    }
+
     m_is_history_navigation = IsHistoryNavigation::Yes;
 
     auto url = m_history.current().url;
@@ -179,6 +183,9 @@ enum class IsHistoryNavigation {
 
     auto* navigate_forward_button = (NSButton*)[[self navigate_forward_toolbar_item] view];
     [navigate_forward_button setEnabled:m_history.can_go_forward()];
+
+    auto* reload_button = (NSButton*)[[self reload_toolbar_item] view];
+    [reload_button setEnabled:!m_history.is_empty()];
 }
 
 - (void)showTabOverview:(id)sender
@@ -232,6 +239,7 @@ enum class IsHistoryNavigation {
     if (!_reload_toolbar_item) {
         auto* button = [self create_button:NSImageNameRefreshTemplate
                                with_action:@selector(reload:)];
+        [button setEnabled:NO];
 
         _reload_toolbar_item = [[NSToolbarItem alloc] initWithItemIdentifier:TOOLBAR_RELOAD_IDENTIFIER];
         [_reload_toolbar_item setView:button];

--- a/Ladybird/AppKit/UI/TabController.mm
+++ b/Ladybird/AppKit/UI/TabController.mm
@@ -158,6 +158,11 @@ enum class IsHistoryNavigation {
     [self updateNavigationButtonStates];
 }
 
+- (void)viewSource:(id)sender
+{
+    [[[self tab] web_view] viewSource];
+}
+
 - (void)focusLocationToolbarItem
 {
     [self.window makeFirstResponder:self.location_toolbar_item.view];

--- a/Ladybird/AppKit/UI/TabController.mm
+++ b/Ladybird/AppKit/UI/TabController.mm
@@ -32,7 +32,6 @@ enum class IsHistoryNavigation {
 
 @interface TabController () <NSToolbarDelegate, NSSearchFieldDelegate>
 {
-    URL m_url;
     DeprecatedString m_title;
 
     Browser::History m_history;
@@ -63,7 +62,7 @@ enum class IsHistoryNavigation {
 @synthesize new_tab_toolbar_item = _new_tab_toolbar_item;
 @synthesize tab_overview_toolbar_item = _tab_overview_toolbar_item;
 
-- (instancetype)init:(URL)url
+- (instancetype)init
 {
     if (self = [super init]) {
         self.toolbar = [[NSToolbar alloc] initWithIdentifier:TOOLBAR_IDENTIFIER];
@@ -72,7 +71,6 @@ enum class IsHistoryNavigation {
         [self.toolbar setAllowsUserCustomization:NO];
         [self.toolbar setSizeMode:NSToolbarSizeModeRegular];
 
-        m_url = move(url);
         m_is_history_navigation = IsHistoryNavigation::No;
     }
 
@@ -81,9 +79,14 @@ enum class IsHistoryNavigation {
 
 #pragma mark - Public methods
 
-- (void)load:(URL const&)url
+- (void)loadURL:(URL const&)url
 {
-    [[self tab].web_view load:url];
+    [[self tab].web_view loadURL:url];
+}
+
+- (void)loadHTML:(StringView)html url:(URL const&)url
+{
+    [[self tab].web_view loadHTML:html url:url];
 }
 
 - (void)onLoadStart:(URL const&)url isRedirect:(BOOL)isRedirect
@@ -121,7 +124,7 @@ enum class IsHistoryNavigation {
     m_history.go_back();
 
     auto url = m_history.current().url;
-    [self load:url];
+    [self loadURL:url];
 }
 
 - (void)navigateForward:(id)sender
@@ -134,7 +137,7 @@ enum class IsHistoryNavigation {
     m_history.go_forward();
 
     auto url = m_history.current().url;
-    [self load:url];
+    [self loadURL:url];
 }
 
 - (void)reload:(id)sender
@@ -146,7 +149,7 @@ enum class IsHistoryNavigation {
     m_is_history_navigation = IsHistoryNavigation::Yes;
 
     auto url = m_history.current().url;
-    [self load:url];
+    [self loadURL:url];
 }
 
 - (void)clearHistory
@@ -312,8 +315,6 @@ enum class IsHistoryNavigation {
 - (IBAction)showWindow:(id)sender
 {
     self.window = [[Tab alloc] init];
-    [self load:m_url];
-
     [self.window setDelegate:self];
 
     [self.window setToolbar:self.toolbar];
@@ -397,7 +398,7 @@ enum class IsHistoryNavigation {
 
     auto* url_string = [[text_view textStorage] string];
     auto url = Ladybird::sanitize_url(url_string);
-    [self load:url];
+    [self loadURL:url];
 
     [self.window makeFirstResponder:nil];
     return YES;

--- a/Ladybird/AppKit/UI/TabController.mm
+++ b/Ladybird/AppKit/UI/TabController.mm
@@ -166,7 +166,10 @@ enum class IsHistoryNavigation {
 - (void)createNewTab:(id)sender
 {
     auto* delegate = (ApplicationDelegate*)[NSApp delegate];
-    [delegate createNewTab:OptionalNone {}];
+
+    [delegate createNewTab:OptionalNone {}
+                   fromTab:[self tab]
+               activateTab:Web::HTML::ActivateTab::Yes];
 }
 
 - (void)updateNavigationButtonStates

--- a/Ladybird/Qt/BrowserWindow.cpp
+++ b/Ladybird/Qt/BrowserWindow.cpp
@@ -401,6 +401,7 @@ BrowserWindow::BrowserWindow(Optional<URL> const& initial_url, Browser::CookieJa
     m_reload_action->setShortcuts(QKeySequence::keyBindings(QKeySequence::StandardKey::Refresh));
     m_go_back_action->setEnabled(false);
     m_go_forward_action->setEnabled(false);
+    m_reload_action->setEnabled(false);
 
     if (initial_url.has_value()) {
         auto initial_url_string = qstring_from_ak_deprecated_string(initial_url->serialize());

--- a/Ladybird/Qt/BrowserWindow.cpp
+++ b/Ladybird/Qt/BrowserWindow.cpp
@@ -430,6 +430,20 @@ void BrowserWindow::debug_request(DeprecatedString const& request, DeprecatedStr
 
 Tab& BrowserWindow::new_tab(QString const& url, Web::HTML::ActivateTab activate_tab)
 {
+    auto& tab = create_new_tab(activate_tab);
+    tab.navigate(url);
+    return tab;
+}
+
+Tab& BrowserWindow::new_tab(StringView html, URL const& url, Web::HTML::ActivateTab activate_tab)
+{
+    auto& tab = create_new_tab(activate_tab);
+    tab.load_html(html, url);
+    return tab;
+}
+
+Tab& BrowserWindow::create_new_tab(Web::HTML::ActivateTab activate_tab)
+{
     auto tab = make<Tab>(this, m_webdriver_content_ipc_path, m_enable_callgrind_profiling, m_use_lagom_networking);
     auto tab_ptr = tab.ptr();
     m_tabs.append(std::move(tab));
@@ -500,9 +514,6 @@ Tab& BrowserWindow::new_tab(QString const& url, Web::HTML::ActivateTab activate_
     };
 
     tab_ptr->focus_location_editor();
-
-    tab_ptr->navigate(url);
-
     return *tab_ptr;
 }
 

--- a/Ladybird/Qt/BrowserWindow.h
+++ b/Ladybird/Qt/BrowserWindow.h
@@ -73,6 +73,7 @@ public slots:
     void tab_title_changed(int index, QString const&);
     void tab_favicon_changed(int index, QIcon const& icon);
     Tab& new_tab(QString const&, Web::HTML::ActivateTab);
+    Tab& new_tab(StringView html, URL const& url, Web::HTML::ActivateTab);
     void activate_tab(int index);
     void close_tab(int index);
     void close_current_tab();
@@ -97,6 +98,8 @@ private:
     virtual void moveEvent(QMoveEvent*) override;
     virtual void wheelEvent(QWheelEvent*) override;
     virtual void closeEvent(QCloseEvent*) override;
+
+    Tab& create_new_tab(Web::HTML::ActivateTab activate_tab);
 
     void debug_request(DeprecatedString const& request, DeprecatedString const& argument = "");
 

--- a/Ladybird/Qt/Tab.cpp
+++ b/Ladybird/Qt/Tab.cpp
@@ -132,6 +132,7 @@ Tab::Tab(BrowserWindow* window, StringView webdriver_content_ipc_path, WebView::
 
         m_window->go_back_action().setEnabled(m_history.can_go_back());
         m_window->go_forward_action().setEnabled(m_history.can_go_forward());
+        m_window->reload_action().setEnabled(!m_history.is_empty());
 
         if (m_inspector_widget)
             m_inspector_widget->clear_dom_json();
@@ -587,6 +588,9 @@ void Tab::forward()
 
 void Tab::reload()
 {
+    if (m_history.is_empty())
+        return;
+
     m_is_history_navigation = true;
     view().load(m_history.current().url.to_deprecated_string());
 }

--- a/Ladybird/Qt/Tab.cpp
+++ b/Ladybird/Qt/Tab.cpp
@@ -566,6 +566,11 @@ void Tab::navigate(QString url_qstring)
     view().load(url_string);
 }
 
+void Tab::load_html(StringView html, URL const& url)
+{
+    view().load_html(html, url);
+}
+
 void Tab::back()
 {
     if (!m_history.can_go_back())

--- a/Ladybird/Qt/Tab.cpp
+++ b/Ladybird/Qt/Tab.cpp
@@ -14,6 +14,7 @@
 #include <Browser/History.h>
 #include <LibGfx/ImageFormats/BMPWriter.h>
 #include <LibGfx/Painter.h>
+#include <LibWebView/SourceHighlighter.h>
 #include <QClipboard>
 #include <QCoreApplication>
 #include <QCursor>
@@ -26,7 +27,6 @@
 #include <QMenu>
 #include <QMessageBox>
 #include <QPainter>
-#include <QPlainTextEdit>
 #include <QPoint>
 #include <QResizeEvent>
 
@@ -217,13 +217,8 @@ Tab::Tab(BrowserWindow* window, StringView webdriver_content_ipc_path, WebView::
     QObject::connect(focus_location_editor_action, &QAction::triggered, this, &Tab::focus_location_editor);
 
     view().on_received_source = [this](auto const& url, auto const& source) {
-        auto* text_edit = new QPlainTextEdit(this);
-        text_edit->setWindowFlags(Qt::Window);
-        text_edit->setFont(QFontDatabase::systemFont(QFontDatabase::SystemFont::FixedFont));
-        text_edit->resize(800, 600);
-        text_edit->setWindowTitle(qstring_from_ak_deprecated_string(url.to_deprecated_string()));
-        text_edit->setPlainText(qstring_from_ak_deprecated_string(source));
-        text_edit->show();
+        auto html = WebView::highlight_source(url, source);
+        m_window->new_tab(html, url, Web::HTML::ActivateTab::Yes);
     };
 
     view().on_navigate_back = [this]() {

--- a/Ladybird/Qt/Tab.h
+++ b/Ladybird/Qt/Tab.h
@@ -34,6 +34,8 @@ public:
     WebContentView& view() { return *m_view; }
 
     void navigate(QString);
+    void load_html(StringView, URL const&);
+
     void back();
     void forward();
     void reload();

--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -431,10 +431,11 @@ if (BUILD_LAGOM)
         # WebView
         list(APPEND LIBWEBVIEW_SOURCES "../../Userland/Libraries/LibWebView/AccessibilityTreeModel.cpp")
         list(APPEND LIBWEBVIEW_SOURCES "../../Userland/Libraries/LibWebView/DOMTreeModel.cpp")
+        list(APPEND LIBWEBVIEW_SOURCES "../../Userland/Libraries/LibWebView/RequestServerAdapter.cpp")
+        list(APPEND LIBWEBVIEW_SOURCES "../../Userland/Libraries/LibWebView/SourceHighlighter.cpp")
         list(APPEND LIBWEBVIEW_SOURCES "../../Userland/Libraries/LibWebView/StylePropertiesModel.cpp")
         list(APPEND LIBWEBVIEW_SOURCES "../../Userland/Libraries/LibWebView/ViewImplementation.cpp")
         list(APPEND LIBWEBVIEW_SOURCES "../../Userland/Libraries/LibWebView/WebContentClient.cpp")
-        list(APPEND LIBWEBVIEW_SOURCES "../../Userland/Libraries/LibWebView/RequestServerAdapter.cpp")
         list(APPEND LIBWEBVIEW_SOURCES "../../Userland/Libraries/LibWebView/WebSocketClientAdapter.cpp")
 
         compile_ipc(${SERENITY_PROJECT_ROOT}/Userland/Services/WebContent/WebContentServer.ipc WebContent/WebContentServerEndpoint.h)

--- a/Userland/Applications/Browser/History.h
+++ b/Userland/Applications/Browser/History.h
@@ -35,6 +35,8 @@ public:
     bool can_go_forward(int steps = 1) { return (m_current + steps) < static_cast<int>(m_items.size()); }
     void clear();
 
+    bool is_empty() const { return m_items.is_empty(); }
+
 private:
     Vector<URLTitlePair> m_items;
     int m_current { -1 };

--- a/Userland/Applications/Browser/Tab.cpp
+++ b/Userland/Applications/Browser/Tab.cpp
@@ -732,6 +732,9 @@ URL Tab::url() const
 
 void Tab::reload()
 {
+    if (m_history.is_empty())
+        return;
+
     load(url());
 }
 
@@ -762,6 +765,7 @@ void Tab::update_actions()
         return;
     window.go_back_action().set_enabled(m_history.can_go_back());
     window.go_forward_action().set_enabled(m_history.can_go_forward());
+    window.reload_action().set_enabled(!m_history.is_empty());
 }
 
 ErrorOr<void> Tab::bookmark_current_url()

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.h
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.h
@@ -37,6 +37,7 @@ public:
     struct Position {
         size_t line { 0 };
         size_t column { 0 };
+        size_t byte_offset { 0 };
     };
 
     struct Attribute {

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
@@ -223,6 +223,7 @@ void HTMLTokenizer::skip(size_t count)
             } else {
                 m_source_positions.last().column++;
             }
+            m_source_positions.last().byte_offset += m_utf8_iterator.underlying_code_point_length_in_bytes();
         }
         ++m_utf8_iterator;
     }

--- a/Userland/Libraries/LibWebView/CMakeLists.txt
+++ b/Userland/Libraries/LibWebView/CMakeLists.txt
@@ -4,6 +4,7 @@ set(SOURCES
     DOMTreeModel.cpp
     OutOfProcessWebView.cpp
     RequestServerAdapter.cpp
+    SourceHighlighter.cpp
     StylePropertiesModel.cpp
     ViewImplementation.cpp
     WebContentClient.cpp

--- a/Userland/Libraries/LibWebView/SourceHighlighter.cpp
+++ b/Userland/Libraries/LibWebView/SourceHighlighter.cpp
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2023, Tim Flynn <trflynn89@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/StringBuilder.h>
+#include <AK/URL.h>
+#include <LibWeb/HTML/Parser/HTMLTokenizer.h>
+#include <LibWebView/SourceHighlighter.h>
+
+namespace WebView {
+
+String highlight_source(URL const& url, StringView source)
+{
+    Web::HTML::HTMLTokenizer tokenizer { source, "utf-8"sv };
+    StringBuilder builder;
+
+    builder.append(R"~~~(
+<!DOCTYPE html>
+<html>
+<head>
+    <meta name="color-scheme" content="dark light">)~~~"sv);
+
+    builder.appendff("<title>View Source - {}</title>", url);
+
+    builder.append(R"~~~(
+    <style type="text/css">
+        html {
+            font-size: 10pt;
+        }
+
+        @media (prefers-color-scheme: dark) {
+            /* FIXME: We should be able to remove the HTML style when "color-scheme" is supported */
+            html {
+                background-color: rgb(30, 30, 30);
+                color: white;
+            }
+            .comment {
+                color: lightgreen;
+            }
+            .tag {
+                color: orangered;
+            }
+            .attribute-name {
+                color: orange;
+            }
+            .attribute-value {
+                color: deepskyblue;
+            }
+        }
+
+        @media (prefers-color-scheme: light) {
+            .comment {
+                color: green;
+            }
+            .tag {
+                color: red;
+            }
+            .attribute-name {
+                color: darkorange;
+            }
+            .attribute-value {
+                color: blue;
+            }
+        }
+    </style>
+</head>
+<body>
+<pre>
+)~~~"sv);
+
+    size_t previous_position = 0;
+
+    auto append_source = [&](auto end_position, Optional<StringView> const& class_name = {}) {
+        if (end_position <= previous_position)
+            return;
+
+        auto segment = source.substring_view(previous_position, end_position - previous_position);
+
+        if (class_name.has_value())
+            builder.appendff("<span class=\"{}\">"sv, *class_name);
+
+        for (auto code_point : Utf8View { segment }) {
+            if (code_point == '&')
+                builder.append("&amp;"sv);
+            else if (code_point == 0xA0)
+                builder.append("&nbsp;"sv);
+            else if (code_point == '<')
+                builder.append("&lt;"sv);
+            else if (code_point == '>')
+                builder.append("&gt;"sv);
+            else
+                builder.append_code_point(code_point);
+        }
+
+        if (class_name.has_value())
+            builder.append("</span>"sv);
+
+        previous_position = end_position;
+    };
+
+    for (auto token = tokenizer.next_token(); token.has_value(); token = tokenizer.next_token()) {
+        if (token->is_comment()) {
+            append_source(token->start_position().byte_offset);
+            append_source(token->end_position().byte_offset, "comment"sv);
+        } else if (token->is_start_tag() || token->is_end_tag()) {
+            auto tag_name_start = token->start_position().byte_offset;
+
+            append_source(tag_name_start);
+            append_source(tag_name_start + token->tag_name().length(), "tag"sv);
+
+            token->for_each_attribute([&](auto const& attribute) {
+                append_source(attribute.name_start_position.byte_offset);
+                append_source(attribute.name_end_position.byte_offset, "attribute-name"sv);
+
+                append_source(attribute.value_start_position.byte_offset);
+                append_source(attribute.value_end_position.byte_offset, "attribute-value"sv);
+
+                return IterationDecision::Continue;
+            });
+
+            append_source(token->end_position().byte_offset);
+        } else {
+            append_source(token->end_position().byte_offset);
+        }
+    }
+
+    builder.append(R"~~~(
+</pre>
+</body>
+</html>
+)~~~"sv);
+
+    return MUST(builder.to_string());
+}
+
+}

--- a/Userland/Libraries/LibWebView/SourceHighlighter.h
+++ b/Userland/Libraries/LibWebView/SourceHighlighter.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2023, Tim Flynn <trflynn89@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/String.h>
+#include <AK/StringView.h>
+
+namespace WebView {
+
+String highlight_source(URL const&, StringView);
+
+}


### PR DESCRIPTION
This provides us with a couple of benefits:
* Syntax highlighting of the source being viewed (Qt's View Source window previously was not highlighted)
* A common implementation that all chromes can build on (generally just whatever platform-specific code is needed to hook up menu items, etc.)
* System theme support

This does not hook up Serenity's chrome yet as that chrome is still more featureful than this chrome. This does hook up the Qt and AppKit chromes as a start.

Qt:
<img width="1112" alt="qt-dark" src="https://github.com/SerenityOS/serenity/assets/5600524/5bfd2d77-7074-4882-ae54-b778fafda3af">
<img width="1112" alt="qt-light" src="https://github.com/SerenityOS/serenity/assets/5600524/0d2d875d-7637-4602-93fe-31d5589a4ed0">

AppKit:
<img width="1112" alt="app-dark" src="https://github.com/SerenityOS/serenity/assets/5600524/4e10e6ab-7bcc-4d21-9df5-a37cd8771227">
<img width="1112" alt="app-light" src="https://github.com/SerenityOS/serenity/assets/5600524/9fda62f2-f3d8-4174-b927-4a28e76af38f">

