### PR TITLE
LibJS: Behave like major engines when substituting missing capture group

### DIFF
--- a/Userland/Libraries/LibJS/Tests/builtins/String/String.prototype.replace.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/String/String.prototype.replace.js
@@ -248,3 +248,9 @@ test("UTF-16", () => {
 
     expect("".replace("", "😀")).toBe("😀");
 });
+
+test("substitution with capture group", () => {
+    expect("A".replace(/(A)/, "$1")).toBe("A");
+    expect("A".replace(/(A)/, "$10")).toBe("A0");
+    expect("A".replace(/(A)/, "$2")).toBe("$2");
+});


### PR DESCRIPTION
When a substitution refers to a 2-digit capture group that doesn't exist we need to check if the first digit refers to an existing capture group. In other words, '$10' should be treated as capture group #1, followed by the literal '0' if 1 is a valid capture group but 10 is not.

This makes the Dromaeo "dom-query" subtest run to completion.