### PR TITLE
LibWeb: Add back undistributable space when adjusting table width

### DIFF
--- a/Tests/LibWeb/Layout/expected/table/sum-of-percentage-column-widths-less-than-100.txt
+++ b/Tests/LibWeb/Layout/expected/table/sum-of-percentage-column-widths-less-than-100.txt
@@ -1,31 +1,31 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x27.46875 children: not-inline
-      TableWrapper <(anonymous)> at (8,8) content-size 94x27.46875 [BFC] children: not-inline
-        Box <table> at (9,9) content-size 92x25.46875 table-box [TFC] children: not-inline
+      TableWrapper <(anonymous)> at (8,8) content-size 102x27.46875 [BFC] children: not-inline
+        Box <table> at (9,9) content-size 100x25.46875 table-box [TFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tbody> at (9,9) content-size 84.015625x21.46875 table-row-group children: not-inline
-            Box <tr> at (11,11) content-size 84.015625x21.46875 table-row children: not-inline
+          Box <tbody> at (9,9) content-size 91.984375x21.46875 table-row-group children: not-inline
+            Box <tr> at (11,11) content-size 91.984375x21.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (13,13) content-size 18.109375x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (13,13) content-size 19x17.46875 table-cell [BFC] children: inline
                 line 0 width: 14.265625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
                   frag 0 from TextNode start: 0, length: 1, rect: [13,13 14.265625x17.46875]
                     "A"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (37.109375,13) content-size 37.265625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (38,13) content-size 41.984375x17.46875 table-cell [BFC] children: inline
                 line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [37.109375,13 9.34375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [38,13 9.34375x17.46875]
                     "B"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (80.375,13) content-size 16.640625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (85.984375,13) content-size 19x17.46875 table-cell [BFC] children: inline
                 line 0 width: 10.3125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [80.375,13 10.3125x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [85.984375,13 10.3125x17.46875]
                     "C"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -36,13 +36,13 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x27.46875]
-      PaintableWithLines (TableWrapper(anonymous)) [8,8 94x27.46875]
-        PaintableBox (Box<TABLE>) [8,8 94x27.46875]
-          PaintableBox (Box<TBODY>) [9,9 84.015625x21.46875] overflow: [9,9 90.015625x23.46875]
-            PaintableBox (Box<TR>) [11,11 84.015625x21.46875] overflow: [11,11 88.015625x21.46875]
-              PaintableWithLines (BlockContainer<TD>) [11,11 22.109375x21.46875]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 102x27.46875]
+        PaintableBox (Box<TABLE>) [8,8 102x27.46875]
+          PaintableBox (Box<TBODY>) [9,9 91.984375x21.46875] overflow: [9,9 97.984375x23.46875]
+            PaintableBox (Box<TR>) [11,11 91.984375x21.46875] overflow: [11,11 95.984375x21.46875]
+              PaintableWithLines (BlockContainer<TD>) [11,11 23x21.46875]
                 TextPaintable (TextNode<#text>)
-              PaintableWithLines (BlockContainer<TD>) [35.109375,11 41.265625x21.46875]
+              PaintableWithLines (BlockContainer<TD>) [36,11 45.984375x21.46875]
                 TextPaintable (TextNode<#text>)
-              PaintableWithLines (BlockContainer<TD>) [78.375,11 20.640625x21.46875]
+              PaintableWithLines (BlockContainer<TD>) [83.984375,11 23x21.46875]
                 TextPaintable (TextNode<#text>)

--- a/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -496,7 +496,7 @@ void TableFormattingContext::compute_table_width()
         for (auto& cell : m_cells) {
             auto const& cell_width = cell.box->computed_values().width();
             if (cell_width.is_percentage()) {
-                adjusted_used_width = CSSPixels::nearest_value_for(ceil(100 / cell_width.percentage().value() * cell.outer_max_width.to_double()));
+                adjusted_used_width = CSSPixels::nearest_value_for(ceil(100 / cell_width.percentage().value() * cell.outer_max_width.to_double())) + undistributable_space;
                 if (width_of_table_containing_block.is_definite())
                     used_width = min(max(used_width, adjusted_used_width), width_of_table_containing_block.to_px_or_zero());
                 else


### PR DESCRIPTION
If the table used width has to be adjusted because of a cell with percentage width, add back the undistributable space due to border spacing. This is consistent with the width distribution algorithm, which sets aside the undistributable space and the behavior of other browsers.