### PR TITLE
LibWeb: Reset auto_placement_cursor_x after adding new column in GFC

### DIFF
--- a/Tests/LibWeb/Layout/expected/grid/auto-flow-column-spanning-item.txt
+++ b/Tests/LibWeb/Layout/expected/grid/auto-flow-column-spanning-item.txt
@@ -1,0 +1,16 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x33.46875 [BFC] children: not-inline
+    Box <body> at (8,8) content-size 784x17.46875 [GFC] children: not-inline
+      BlockContainer <div> at (8,8) content-size 156.796875x17.46875 [BFC] children: not-inline
+      BlockContainer <div.item> at (164.796875,8) content-size 627.1875x17.46875 [BFC] children: inline
+        line 0 width: 27.15625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+          frag 0 from TextNode start: 0, length: 3, rect: [164.796875,8 27.15625x17.46875]
+            "foo"
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x33.46875]
+    PaintableBox (Box<BODY>) [8,8 784x17.46875]
+      PaintableWithLines (BlockContainer<DIV>) [8,8 156.796875x17.46875]
+      PaintableWithLines (BlockContainer<DIV>.item) [164.796875,8 627.1875x17.46875]
+        TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/input/grid/auto-flow-column-spanning-item.html
+++ b/Tests/LibWeb/Layout/input/grid/auto-flow-column-spanning-item.html
@@ -1,0 +1,9 @@
+<!doctype html><style>
+body {
+    display: grid;
+    grid-auto-flow: column;
+}
+.item {
+    grid-column: span 4 / auto;
+}
+</style><body><div></div><div class="item">foo</div>

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -606,6 +606,7 @@ void GridFormattingContext::place_item_with_no_declared_position(Box const& chil
                 auto_placement_cursor_y++;
             } else {
                 m_occupation_grid.set_max_column_index(auto_placement_cursor_x);
+                auto_placement_cursor_x = 0;
                 auto_placement_cursor_y = m_occupation_grid.min_row_index();
             }
         }


### PR DESCRIPTION
We need to start looking from the beginning of current row if adding new implicit column track made enough space to accomodate spanning item

This fixes placement for spanning grid items when `grid-auto-flow` is specified to `column`.