### PR TITLE
Browser: Prevent moving a Database callback while it is executing

### DIFF
--- a/Userland/Applications/Browser/Database.h
+++ b/Userland/Applications/Browser/Database.h
@@ -81,9 +81,9 @@ private:
     void execute_statement(SQL::StatementID statement_id, Vector<SQL::Value> placeholder_values, PendingExecution pending_execution);
 
     template<typename ResultData>
-    auto find_pending_execution(ResultData const& result_data)
+    auto take_pending_execution(ResultData const& result_data)
     {
-        return m_pending_executions.find({ result_data.statement_id, result_data.execution_id });
+        return m_pending_executions.take({ result_data.statement_id, result_data.execution_id });
     }
 
     NonnullRefPtr<SQL::SQLClient> m_sql_client;


### PR DESCRIPTION
All SQL callbacks here were already moving the to-be-executed callback out of its storage before executing it, except for on_next_result(). This makes on_next_result() do the same move to ensure we do not later attempt to move it while the callback is executing.