### PR TITLE
Mail: Allow sorting columns (plus some cleanup)

### DIFF
--- a/Userland/Applications/Mail/InboxModel.cpp
+++ b/Userland/Applications/Mail/InboxModel.cpp
@@ -57,5 +57,7 @@ GUI::Variant InboxModel::data(GUI::ModelIndex const& index, GUI::ModelRole role)
         if (!value.seen)
             return Gfx::FontDatabase::default_font().bold_variant();
     }
+    if (role == static_cast<GUI::ModelRole>(InboxModelCustomRole::Sequence))
+        return value.sequence_number;
     return {};
 }

--- a/Userland/Applications/Mail/InboxModel.cpp
+++ b/Userland/Applications/Mail/InboxModel.cpp
@@ -27,12 +27,12 @@ int InboxModel::row_count(GUI::ModelIndex const&) const
 ErrorOr<String> InboxModel::column_name(int column_index) const
 {
     switch (column_index) {
+    case Date:
+        return "Date"_string;
     case Column::From:
         return "From"_string;
     case Subject:
         return "Subject"_string;
-    case Date:
-        return "Date"_string;
     default:
         VERIFY_NOT_REACHED();
     }
@@ -42,12 +42,12 @@ GUI::Variant InboxModel::data(GUI::ModelIndex const& index, GUI::ModelRole role)
 {
     auto& value = m_entries[index.row()];
     if (role == GUI::ModelRole::Display) {
+        if (index.column() == Column::Date)
+            return value.date;
         if (index.column() == Column::From)
             return value.from;
         if (index.column() == Column::Subject)
             return value.subject;
-        if (index.column() == Column::Date)
-            return value.date;
     }
     if (role == GUI::ModelRole::TextAlignment) {
         if (index.column() == Column::Date)

--- a/Userland/Applications/Mail/InboxModel.h
+++ b/Userland/Applications/Mail/InboxModel.h
@@ -11,10 +11,16 @@
 #include <LibIMAP/Objects.h>
 
 struct InboxEntry {
+    u32 sequence_number;
     DeprecatedString from;
     DeprecatedString subject;
     DeprecatedString date;
     bool seen;
+};
+
+enum class InboxModelCustomRole {
+    __DONOTUSE = (int)GUI::ModelRole::Custom,
+    Sequence,
 };
 
 class InboxModel final : public GUI::Model {

--- a/Userland/Applications/Mail/InboxModel.h
+++ b/Userland/Applications/Mail/InboxModel.h
@@ -12,9 +12,9 @@
 
 struct InboxEntry {
     u32 sequence_number;
+    DeprecatedString date;
     DeprecatedString from;
     DeprecatedString subject;
-    DeprecatedString date;
     bool seen;
 };
 
@@ -26,9 +26,9 @@ enum class InboxModelCustomRole {
 class InboxModel final : public GUI::Model {
 public:
     enum Column {
+        Date,
         From,
         Subject,
-        Date,
         __Count
     };
 

--- a/Userland/Applications/Mail/MailWidget.cpp
+++ b/Userland/Applications/Mail/MailWidget.cpp
@@ -310,6 +310,7 @@ void MailWidget::selected_mailbox()
 
     int i = 0;
     for (auto& fetch_data : fetch_response.data().fetch_data()) {
+        auto sequence_number = fetch_data.get<unsigned>();
         auto& response_data = fetch_data.get<IMAP::FetchResponseData>();
         auto& body_data = response_data.body_data();
 
@@ -421,7 +422,7 @@ void MailWidget::selected_mailbox()
         if (from.is_empty())
             from = "(Unknown sender)";
 
-        InboxEntry inbox_entry { from, subject, date, seen };
+        InboxEntry inbox_entry { sequence_number, from, subject, date, seen };
         m_statusbar->set_text(String::formatted("[{}]: Loading entry {}", mailbox.name, ++i).release_value_but_fixme_should_propagate_errors());
 
         active_inbox_entries.append(inbox_entry);
@@ -439,8 +440,7 @@ void MailWidget::selected_email_to_load()
     if (!index.is_valid())
         return;
 
-    // IMAP is 1-based.
-    int id_of_email_to_load = index.row() + 1;
+    int id_of_email_to_load = index.data(static_cast<GUI::ModelRole>(InboxModelCustomRole::Sequence)).as_u32();
 
     m_statusbar->set_text("Fetching message..."_string);
 

--- a/Userland/Applications/Mail/MailWidget.cpp
+++ b/Userland/Applications/Mail/MailWidget.cpp
@@ -286,11 +286,7 @@ void MailWidget::selected_mailbox(GUI::ModelIndex const& index)
         .sequence_set = { { 1, (int)response.data().exists() } },
         .data_items = {
             IMAP::FetchCommand::DataItem {
-                .type = IMAP::FetchCommand::DataItemType::PeekBody,
-                .section = IMAP::FetchCommand::DataItem::Section {
-                    .type = IMAP::FetchCommand::DataItem::SectionType::HeaderFields,
-                    .headers = { { "Subject", "From" } },
-                },
+                .type = IMAP::FetchCommand::DataItemType::Envelope,
             },
             IMAP::FetchCommand::DataItem {
                 .type = IMAP::FetchCommand::DataItemType::InternalDate,
@@ -316,98 +312,43 @@ void MailWidget::selected_mailbox(GUI::ModelIndex const& index)
     for (auto& fetch_data : fetch_response.data().fetch_data()) {
         auto sequence_number = fetch_data.get<unsigned>();
         auto& response_data = fetch_data.get<IMAP::FetchResponseData>();
-        auto& body_data = response_data.body_data();
-        auto& internal_date = response_data.internal_date();
+        auto const& envelope = response_data.envelope();
+        auto const& internal_date = response_data.internal_date();
 
         auto seen = !response_data.flags().find_if([](StringView value) { return value.equals_ignoring_ascii_case("\\Seen"sv); }).is_end();
 
-        auto data_item_has_header = [](IMAP::FetchCommand::DataItem const& data_item, DeprecatedString const& search_header) {
-            if (!data_item.section.has_value())
-                return false;
-            if (data_item.section->type != IMAP::FetchCommand::DataItem::SectionType::HeaderFields)
-                return false;
-            if (!data_item.section->headers.has_value())
-                return false;
-            auto header_iterator = data_item.section->headers->find_if([&search_header](auto& header) {
-                return header.equals_ignoring_ascii_case(search_header);
-            });
-            return header_iterator != data_item.section->headers->end();
-        };
-
-        auto subject_iterator = body_data.find_if([&data_item_has_header](Tuple<IMAP::FetchCommand::DataItem, Optional<DeprecatedString>>& data) {
-            auto const data_item = data.get<0>();
-            return data_item_has_header(data_item, "Subject");
-        });
-
-        VERIFY(subject_iterator != body_data.end());
-
-        auto from_iterator = body_data.find_if([&data_item_has_header](Tuple<IMAP::FetchCommand::DataItem, Optional<DeprecatedString>>& data) {
-            auto const data_item = data.get<0>();
-            return data_item_has_header(data_item, "From");
-        });
-
-        VERIFY(from_iterator != body_data.end());
-
-        // FIXME: All of the following doesn't really follow RFC 2822: https://datatracker.ietf.org/doc/html/rfc2822
-
-        auto parse_and_unfold = [](DeprecatedString const& value) {
-            GenericLexer lexer(value);
-            StringBuilder builder;
-
-            // There will be a space at the start of the value, which should be ignored.
-            VERIFY(lexer.consume_specific(' '));
-
-            while (!lexer.is_eof()) {
-                auto current_line = lexer.consume_while([](char c) {
-                    return c != '\r';
-                });
-
-                builder.append(current_line);
-
-                bool consumed_end_of_line = lexer.consume_specific("\r\n");
-                VERIFY(consumed_end_of_line);
-
-                // If CRLF are immediately followed by WSP (which is either ' ' or '\t'), then it is not the end of the header and is instead just a wrap.
-                // If it's not followed by WSP, then it is the end of the header.
-                // https://datatracker.ietf.org/doc/html/rfc2822#section-2.2.3
-                if (lexer.is_eof() || (lexer.peek() != ' ' && lexer.peek() != '\t'))
-                    break;
-            }
-
-            return builder.to_deprecated_string();
-        };
-
         DeprecatedString date = internal_date.to_deprecated_string();
-
-        auto& subject_iterator_value = subject_iterator->get<1>().value();
-        auto subject_index = subject_iterator_value.find("Subject:"sv);
-        DeprecatedString subject;
-        if (subject_index.has_value()) {
-            auto potential_subject = subject_iterator_value.substring(subject_index.value());
-            auto subject_parts = potential_subject.split_limit(':', 2);
-            subject = parse_and_unfold(subject_parts.last());
-        }
-
-        if (subject.is_empty())
-            subject = "(No subject)";
-
+        DeprecatedString subject = envelope.subject.value_or("(No subject)");
         if (subject.contains("=?"sv) && subject.contains("?="sv)) {
             subject = MUST(IMAP::decode_rfc2047_encoded_words(subject));
         }
 
-        auto& from_iterator_value = from_iterator->get<1>().value();
-        auto from_index = from_iterator_value.find("From:"sv);
-        if (!from_index.has_value())
-            from_index = from_iterator_value.find("from:"sv);
-        DeprecatedString from;
-        if (from_index.has_value()) {
-            auto potential_from = from_iterator_value.substring(from_index.value());
-            auto from_parts = potential_from.split_limit(':', 2);
-            from = parse_and_unfold(from_parts.last());
-        }
+        StringBuilder sender_builder;
+        if (envelope.from.has_value()) {
+            bool first { true };
+            for (auto const& address : *envelope.from) {
+                if (!first)
+                    sender_builder.append(", "sv);
 
-        if (from.is_empty())
-            from = "(Unknown sender)";
+                if (address.name.has_value()) {
+                    if (address.name->contains("=?"sv) && address.name->contains("?="sv))
+                        sender_builder.append(MUST(IMAP::decode_rfc2047_encoded_words(*address.name)));
+                    else
+                        sender_builder.append(*address.name);
+
+                    sender_builder.append(" <"sv);
+                    sender_builder.append(address.mailbox.value_or({}));
+                    sender_builder.append('@');
+                    sender_builder.append(address.host.value_or({}));
+                    sender_builder.append('>');
+                } else {
+                    sender_builder.append(address.mailbox.value_or({}));
+                    sender_builder.append('@');
+                    sender_builder.append(address.host.value_or({}));
+                }
+            }
+        }
+        DeprecatedString from = sender_builder.to_deprecated_string();
 
         InboxEntry inbox_entry { sequence_number, date, from, subject, seen };
         m_statusbar->set_text(String::formatted("[{}]: Loading entry {}", mailbox.name, ++i).release_value_but_fixme_should_propagate_errors());

--- a/Userland/Applications/Mail/MailWidget.cpp
+++ b/Userland/Applications/Mail/MailWidget.cpp
@@ -408,7 +408,7 @@ void MailWidget::selected_mailbox()
         if (from.is_empty())
             from = "(Unknown sender)";
 
-        InboxEntry inbox_entry { sequence_number, from, subject, date, seen };
+        InboxEntry inbox_entry { sequence_number, date, from, subject, seen };
         m_statusbar->set_text(String::formatted("[{}]: Loading entry {}", mailbox.name, ++i).release_value_but_fixme_should_propagate_errors());
 
         active_inbox_entries.append(inbox_entry);

--- a/Userland/Applications/Mail/MailWidget.cpp
+++ b/Userland/Applications/Mail/MailWidget.cpp
@@ -17,6 +17,7 @@
 #include <LibGUI/Menu.h>
 #include <LibGUI/MessageBox.h>
 #include <LibGUI/PasswordInputDialog.h>
+#include <LibGUI/SortingProxyModel.h>
 #include <LibGUI/Statusbar.h>
 #include <LibGUI/TableView.h>
 #include <LibGUI/TreeView.h>
@@ -39,7 +40,7 @@ MailWidget::MailWidget()
 
     m_individual_mailbox_view->set_activates_on_selection(true);
     m_individual_mailbox_view->on_activation = [this](auto& index) {
-        selected_email_to_load(index);
+        selected_email_to_load(m_mailbox_sorting_model->map_to_source(index));
     };
 
     m_web_view->on_link_click = [this](auto& url, auto&, unsigned) {
@@ -245,8 +246,8 @@ bool MailWidget::is_supported_alternative(Alternative const& alternative) const
 
 void MailWidget::selected_mailbox(GUI::ModelIndex const& index)
 {
-    m_individual_mailbox_model = InboxModel::create({});
-    m_individual_mailbox_view->set_model(m_individual_mailbox_model);
+    m_mailbox_model = InboxModel::create({});
+    m_individual_mailbox_view->set_model(m_mailbox_model);
 
     if (!index.is_valid())
         return;
@@ -415,8 +416,11 @@ void MailWidget::selected_mailbox(GUI::ModelIndex const& index)
     }
 
     m_statusbar->set_text(String::formatted("[{}]: Loaded {} entries", mailbox.name, i).release_value_but_fixme_should_propagate_errors());
-    m_individual_mailbox_model = InboxModel::create(move(active_inbox_entries));
-    m_individual_mailbox_view->set_model(m_individual_mailbox_model);
+    m_mailbox_model = InboxModel::create(move(active_inbox_entries));
+    m_mailbox_sorting_model = MUST(GUI::SortingProxyModel::create(*m_mailbox_model));
+    m_mailbox_sorting_model->set_sort_role(GUI::ModelRole::Display);
+    m_individual_mailbox_view->set_model(m_mailbox_sorting_model);
+    m_individual_mailbox_view->set_key_column_and_sort_order(InboxModel::Date, GUI::SortOrder::Descending);
 }
 
 void MailWidget::selected_email_to_load(GUI::ModelIndex const& index)
@@ -522,7 +526,7 @@ void MailWidget::selected_email_to_load(GUI::ModelIndex const& index)
     auto& fetch_response_data = fetch_data.last().get<IMAP::FetchResponseData>();
 
     auto seen = !fetch_response_data.flags().find_if([](StringView value) { return value.equals_ignoring_ascii_case("\\Seen"sv); }).is_end();
-    m_individual_mailbox_model->set_seen(index.row(), seen);
+    m_mailbox_model->set_seen(index.row(), seen);
 
     if (!fetch_response_data.contains_response_type(IMAP::FetchResponseType::Body)) {
         GUI::MessageBox::show_error(window(), "The server sent no body."sv);

--- a/Userland/Applications/Mail/MailWidget.cpp
+++ b/Userland/Applications/Mail/MailWidget.cpp
@@ -288,8 +288,11 @@ void MailWidget::selected_mailbox()
                 .type = IMAP::FetchCommand::DataItemType::PeekBody,
                 .section = IMAP::FetchCommand::DataItem::Section {
                     .type = IMAP::FetchCommand::DataItem::SectionType::HeaderFields,
-                    .headers = { { "Date", "Subject", "From" } },
+                    .headers = { { "Subject", "From" } },
                 },
+            },
+            IMAP::FetchCommand::DataItem {
+                .type = IMAP::FetchCommand::DataItemType::InternalDate,
             },
             IMAP::FetchCommand::DataItem {
                 .type = IMAP::FetchCommand::DataItemType::Flags,
@@ -313,6 +316,7 @@ void MailWidget::selected_mailbox()
         auto sequence_number = fetch_data.get<unsigned>();
         auto& response_data = fetch_data.get<IMAP::FetchResponseData>();
         auto& body_data = response_data.body_data();
+        auto& internal_date = response_data.internal_date();
 
         auto seen = !response_data.flags().find_if([](StringView value) { return value.equals_ignoring_ascii_case("\\Seen"sv); }).is_end();
 
@@ -328,13 +332,6 @@ void MailWidget::selected_mailbox()
             });
             return header_iterator != data_item.section->headers->end();
         };
-
-        auto date_iterator = body_data.find_if([&data_item_has_header](Tuple<IMAP::FetchCommand::DataItem, Optional<DeprecatedString>>& data) {
-            auto const data_item = data.get<0>();
-            return data_item_has_header(data_item, "Date");
-        });
-
-        VERIFY(date_iterator != body_data.end());
 
         auto subject_iterator = body_data.find_if([&data_item_has_header](Tuple<IMAP::FetchCommand::DataItem, Optional<DeprecatedString>>& data) {
             auto const data_item = data.get<0>();
@@ -379,18 +376,7 @@ void MailWidget::selected_mailbox()
             return builder.to_deprecated_string();
         };
 
-        auto& date_iterator_value = date_iterator->get<1>().value();
-        auto date_index = date_iterator_value.find("Date:"sv);
-        DeprecatedString date;
-        if (date_index.has_value()) {
-            auto potential_date = date_iterator_value.substring(date_index.value());
-            auto date_parts = potential_date.split_limit(':', 2);
-            date = parse_and_unfold(date_parts.last());
-        }
-
-        if (date.is_empty()) {
-            date = "(Unknown date)";
-        }
+        DeprecatedString date = internal_date.to_deprecated_string();
 
         auto& subject_iterator_value = subject_iterator->get<1>().value();
         auto subject_index = subject_iterator_value.find("Subject:"sv);

--- a/Userland/Applications/Mail/MailWidget.cpp
+++ b/Userland/Applications/Mail/MailWidget.cpp
@@ -32,12 +32,14 @@ MailWidget::MailWidget()
     m_web_view = *find_descendant_of_type_named<WebView::OutOfProcessWebView>("web_view");
     m_statusbar = *find_descendant_of_type_named<GUI::Statusbar>("statusbar");
 
-    m_mailbox_list->on_selection_change = [this] {
-        selected_mailbox();
+    m_mailbox_list->set_activates_on_selection(true);
+    m_mailbox_list->on_activation = [this](auto& index) {
+        selected_mailbox(index);
     };
 
-    m_individual_mailbox_view->on_selection_change = [this] {
-        selected_email_to_load();
+    m_individual_mailbox_view->set_activates_on_selection(true);
+    m_individual_mailbox_view->on_activation = [this](auto& index) {
+        selected_email_to_load(index);
     };
 
     m_web_view->on_link_click = [this](auto& url, auto&, unsigned) {
@@ -241,12 +243,10 @@ bool MailWidget::is_supported_alternative(Alternative const& alternative) const
     return alternative.body_structure.type.equals_ignoring_ascii_case("text"sv) && (alternative.body_structure.subtype.equals_ignoring_ascii_case("plain"sv) || alternative.body_structure.subtype.equals_ignoring_ascii_case("html"sv));
 }
 
-void MailWidget::selected_mailbox()
+void MailWidget::selected_mailbox(GUI::ModelIndex const& index)
 {
     m_individual_mailbox_model = InboxModel::create({});
     m_individual_mailbox_view->set_model(m_individual_mailbox_model);
-
-    auto const& index = m_mailbox_list->selection().first();
 
     if (!index.is_valid())
         return;
@@ -419,10 +419,8 @@ void MailWidget::selected_mailbox()
     m_individual_mailbox_view->set_model(m_individual_mailbox_model);
 }
 
-void MailWidget::selected_email_to_load()
+void MailWidget::selected_email_to_load(GUI::ModelIndex const& index)
 {
-    auto const& index = m_individual_mailbox_view->selection().first();
-
     if (!index.is_valid())
         return;
 

--- a/Userland/Applications/Mail/MailWidget.h
+++ b/Userland/Applications/Mail/MailWidget.h
@@ -41,7 +41,8 @@ private:
     OwnPtr<IMAP::Client> m_imap_client;
 
     RefPtr<GUI::TreeView> m_mailbox_list;
-    RefPtr<InboxModel> m_individual_mailbox_model;
+    RefPtr<InboxModel> m_mailbox_model;
+    RefPtr<GUI::SortingProxyModel> m_mailbox_sorting_model;
     RefPtr<GUI::TableView> m_individual_mailbox_view;
     RefPtr<WebView::OutOfProcessWebView> m_web_view;
     RefPtr<GUI::Statusbar> m_statusbar;

--- a/Userland/Applications/Mail/MailWidget.h
+++ b/Userland/Applications/Mail/MailWidget.h
@@ -26,8 +26,8 @@ public:
 private:
     MailWidget();
 
-    void selected_mailbox();
-    void selected_email_to_load();
+    void selected_mailbox(GUI::ModelIndex const&);
+    void selected_email_to_load(GUI::ModelIndex const&);
 
     struct Alternative {
         IMAP::BodyStructureData const& body_structure;


### PR DESCRIPTION
- **Mail: Fetch mails with their sequence number**

  The FETCH response doesn't have return the sequence in order, or at very least one of my mail providers doesn't do it.

- **Mail: Get message date using INTERNALDATE**

  Parsing mail headers and its date format is a rather tedious task, especially if you want to support the obsolete syntax <sup>([trust me](https://gist.github.com/krkk/4621cff3522e842643eb75874ab67477))</sup>, so let's ask the server to do it for us!

  This will convert the date to our local time and display it in a sortable and fixed-width format "%Y-%m-%d %H:%M:%S".

- **Mail: Make Date the first column**
- **Mail: Use set_activates_on_selection and on_activation callback**

  Preparation for a sortable mailbox. Otherwise the model would resort itself and select mail again forever.

  Arrow keys will no longer load mail automatically, now you also need to hit Enter.

- **Mail: Allow sorting columns**
- **Mail: Simplify reading message headers by issuing ENVELOPE items**

    `BODY[HEADER.FIELDS (...)]` gives us a part of a message that we have to parse ourselves. Looking at the FIXME, we didn't do much good job doing it, so let's better replace it with much simpler and probably preferred way (FETCH command has ALL and FULL macro types that also include it.)
    
    The tradeoff is that we get more data than we use currently (CC, BCC, unparsed date format, message id, etc.).
    
    Additionally this commit will try to decode 'encoded-words' in sender names, because they are here more common.
