### PR TITLE
LibWeb: Prune old paintable pointers from layout tree after relayout

### DIFF
--- a/Tests/LibWeb/Layout/expected/dont-crash-on-relayout-that-rewraps-text.txt
+++ b/Tests/LibWeb/Layout/expected/dont-crash-on-relayout-that-rewraps-text.txt
@@ -1,0 +1,27 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (1,1) content-size 798x56.9375 [BFC] children: not-inline
+    BlockContainer <body> at (10,10) content-size 200x38.9375 children: inline
+      line 0 width: 196.0625, height: 19.46875, bottom: 19.46875, baseline: 14.53125
+        frag 0 from BlockContainer start: 0, length: 0, rect: [11,11 194.0625x17.46875]
+      line 1 width: 138.265625, height: 19.46875, bottom: 38.9375, baseline: 14.53125
+        frag 0 from BlockContainer start: 0, length: 0, rect: [11,30 136.265625x17.46875]
+      BlockContainer <div> at (11,11) content-size 194.0625x17.46875 inline-block [BFC] children: inline
+        line 0 width: 194.0625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+          frag 0 from TextNode start: 0, length: 20, rect: [11,11 194.0625x17.46875]
+            "xxxxxxxxxxxxxxxxxxxx"
+        TextNode <#text>
+      TextNode <#text>
+      BlockContainer <div> at (11,30) content-size 136.265625x17.46875 inline-block [BFC] children: inline
+        line 0 width: 136.265625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+          frag 0 from TextNode start: 0, length: 19, rect: [11,30 136.265625x17.46875]
+            "yyyyyyyyyyyyyyyyyyy"
+        TextNode <#text>
+      TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x58.9375]
+    PaintableWithLines (BlockContainer<BODY>) [9,9 202x40.9375]
+      PaintableWithLines (BlockContainer<DIV>) [10,10 196.0625x19.46875]
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer<DIV>) [10,29 138.265625x19.46875]
+        TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/input/dont-crash-on-relayout-that-rewraps-text.html
+++ b/Tests/LibWeb/Layout/input/dont-crash-on-relayout-that-rewraps-text.html
@@ -1,0 +1,13 @@
+<!doctype html><style>
+* {
+    border: 1px solid black;
+}
+    div { display: inline-block; }
+</style><body><div>xxxxxxxxxxxxxxxxxxxx</div> <div>yyyyyyyyyyyyyyyyyyy</div>
+<script>
+    document.body.offsetWidth
+    document.body.style.width = "500px";
+    document.body.offsetWidth
+    document.body.style.width = "200px";
+    document.body.offsetWidth
+</script>

--- a/Userland/Libraries/LibWeb/Layout/LayoutState.cpp
+++ b/Userland/Libraries/LibWeb/Layout/LayoutState.cpp
@@ -218,6 +218,14 @@ void LayoutState::commit(Box& root)
     // Only the top-level LayoutState should ever be committed.
     VERIFY(!m_parent);
 
+    // NOTE: In case this is a relayout of an existing tree, we start by detaching the old paint tree
+    //       from the layout tree. This is done to ensure that we don't end up with any old-tree pointers
+    //       when text paintables shift around in the tree.
+    root.for_each_in_inclusive_subtree_of_type<Layout::TextNode>([&](Layout::TextNode& text_node) {
+        text_node.set_paintable(nullptr);
+        return IterationDecision::Continue;
+    });
+
     HashTable<Layout::TextNode*> text_nodes;
 
     Vector<Painting::PaintableWithLines&> paintables_with_lines;


### PR DESCRIPTION
When text paintables shift around in the tree due to line wrapping, we may end up in a situation where some text node does not generate a paintable (due to being all whitespace, for example), even though in the previous layout pass, it *did* generate a paintable.

To prevent holding on to old paintables in such cases, we now do a pass in LayoutState::commit() where we explicitly detach all old paintables from the layout tree.