### PR TITLE
find: Don't allow negative GIDs to be passed to the `-group` option

### DIFF
--- a/Userland/Utilities/find.cpp
+++ b/Userland/Utilities/find.cpp
@@ -181,7 +181,7 @@ public:
             m_uid = passwd->pw_uid;
         } else {
             // Attempt to parse it as decimal UID.
-            auto number = StringView { arg, strlen(arg) }.to_uint();
+            auto number = StringView { arg, strlen(arg) }.to_uint<uid_t>();
             if (!number.has_value())
                 fatal_error("Invalid user: \033[1m{}", arg);
             m_uid = number.value();

--- a/Userland/Utilities/find.cpp
+++ b/Userland/Utilities/find.cpp
@@ -205,7 +205,7 @@ public:
             m_gid = gr->gr_gid;
         } else {
             // Attempt to parse it as decimal GID.
-            auto number = StringView { arg, strlen(arg) }.to_int();
+            auto number = StringView { arg, strlen(arg) }.to_uint<gid_t>();
             if (!number.has_value())
                 fatal_error("Invalid group: \033[1m{}", arg);
             m_gid = number.value();


### PR DESCRIPTION
For example: `find . -group -1` will now result in an error being displayed. Previously the negative number was converted to unsigned and treated as valid.

Note: the above command would succeed in theory if you had a group called '-1', but the `groupadd` comand doesn't currently allow you to create such a group.