### PR TITLE
Ladybird: Implement a JavaScript console for the AppKit chrome

### DIFF
--- a/Ladybird/AppKit/Application/ApplicationDelegate.mm
+++ b/Ladybird/AppKit/Application/ApplicationDelegate.mm
@@ -342,6 +342,9 @@
     [submenu addItem:[[NSMenuItem alloc] initWithTitle:@"View Source"
                                                 action:@selector(viewSource:)
                                          keyEquivalent:@""]];
+    [submenu addItem:[[NSMenuItem alloc] initWithTitle:@"Open Console"
+                                                action:@selector(openConsole:)
+                                         keyEquivalent:@"J"]];
 
     [menu setSubmenu:submenu];
     return menu;

--- a/Ladybird/AppKit/UI/Console.h
+++ b/Ladybird/AppKit/UI/Console.h
@@ -9,13 +9,13 @@
 #import <System/Cocoa.h>
 
 @class LadybirdWebView;
+@class Tab;
 
-@interface Tab : NSWindow
+@interface Console : NSWindow
 
-- (void)tabWillClose;
+- (instancetype)init:(Tab*)tab;
 
-- (void)openConsole:(id)sender;
-- (void)onConsoleClosed;
+- (void)reset;
 
 @property (nonatomic, strong) LadybirdWebView* web_view;
 

--- a/Ladybird/AppKit/UI/Console.mm
+++ b/Ladybird/AppKit/UI/Console.mm
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2023, Tim Flynn <trflynn89@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/OwnPtr.h>
+#include <LibWebView/ConsoleClient.h>
+
+#import <UI/Console.h>
+#import <UI/LadybirdWebView.h>
+#import <UI/Tab.h>
+#import <Utilities/Conversions.h>
+
+#if !__has_feature(objc_arc)
+#    error "This project requires ARC"
+#endif
+
+static constexpr CGFloat const WINDOW_WIDTH = 520;
+static constexpr CGFloat const WINDOW_HEIGHT = 600;
+
+@interface Console () <NSTextFieldDelegate>
+{
+    OwnPtr<WebView::ConsoleClient> m_console_client;
+}
+
+@property (nonatomic, strong) Tab* tab;
+@property (nonatomic, strong) NSScrollView* scroll_view;
+
+@end
+
+@implementation Console
+
+@synthesize tab = _tab;
+
+- (instancetype)init:(Tab*)tab
+{
+    auto tab_rect = [tab frame];
+    auto position_x = tab_rect.origin.x + (tab_rect.size.width - WINDOW_WIDTH) / 2;
+    auto position_y = tab_rect.origin.y + (tab_rect.size.height - WINDOW_HEIGHT) / 2;
+
+    auto window_rect = NSMakeRect(position_x, position_y, WINDOW_WIDTH, WINDOW_HEIGHT);
+    auto style_mask = NSWindowStyleMaskTitled | NSWindowStyleMaskClosable | NSWindowStyleMaskMiniaturizable | NSWindowStyleMaskResizable;
+
+    self = [super initWithContentRect:window_rect
+                            styleMask:style_mask
+                              backing:NSBackingStoreBuffered
+                                defer:NO];
+
+    if (self) {
+        self.tab = tab;
+
+        self.web_view = [[LadybirdWebView alloc] init:nil];
+        [self.web_view setPostsBoundsChangedNotifications:YES];
+
+        m_console_client = make<WebView::ConsoleClient>([[tab web_view] view], [[self web_view] view]);
+
+        self.scroll_view = [[NSScrollView alloc] initWithFrame:[self frame]];
+        [self.scroll_view setHasVerticalScroller:YES];
+        [self.scroll_view setHasHorizontalScroller:YES];
+        [self.scroll_view setLineScroll:24];
+
+        [self.scroll_view setContentView:self.web_view];
+        [self.scroll_view setDocumentView:[[NSView alloc] init]];
+
+        auto* font = [NSFont monospacedSystemFontOfSize:12.0
+                                                 weight:NSFontWeightRegular];
+
+        auto* prompt_indicator_attributes = @{
+            NSForegroundColorAttributeName : [NSColor systemCyanColor],
+            NSFontAttributeName : font,
+        };
+        auto* prompt_indicator_attribute = [[NSAttributedString alloc] initWithString:@">>"
+                                                                           attributes:prompt_indicator_attributes];
+        auto* prompt_indicator = [NSTextField labelWithAttributedString:prompt_indicator_attribute];
+
+        auto* prompt_text = [[NSTextField alloc] init];
+        [prompt_text setPlaceholderString:@"Enter JavaScript statement"];
+        [prompt_text setDelegate:self];
+        [prompt_text setBordered:YES];
+        [prompt_text setBezeled:YES];
+        [prompt_text setFont:font];
+
+        auto* clear_button = [NSButton buttonWithImage:[NSImage imageNamed:NSImageNameStopProgressTemplate]
+                                                target:self
+                                                action:@selector(clearConsole:)];
+        [clear_button setToolTip:@"Clear the console output"];
+
+        auto* controls_stack_view = [NSStackView stackViewWithViews:@[ prompt_indicator, prompt_text, clear_button ]];
+        [controls_stack_view setOrientation:NSUserInterfaceLayoutOrientationHorizontal];
+        [controls_stack_view setEdgeInsets:NSEdgeInsetsMake(8, 8, 8, 8)];
+
+        auto* content_stack_view = [NSStackView stackViewWithViews:@[ self.scroll_view, controls_stack_view ]];
+        [content_stack_view setOrientation:NSUserInterfaceLayoutOrientationVertical];
+        [content_stack_view setSpacing:0];
+
+        [self setContentView:content_stack_view];
+        [self setTitle:@"Console"];
+        [self setIsVisible:YES];
+
+        [[NSNotificationCenter defaultCenter]
+            addObserver:self
+               selector:@selector(onContentScroll:)
+                   name:NSViewBoundsDidChangeNotification
+                 object:[self.scroll_view contentView]];
+    }
+
+    return self;
+}
+
+#pragma mark - Public methods
+
+- (void)reset
+{
+    m_console_client->reset();
+}
+
+#pragma mark - Private methods
+
+- (void)onContentScroll:(NSNotification*)notification
+{
+    [[self web_view] handleScroll];
+}
+
+- (void)clearConsole:(id)sender
+{
+    m_console_client->clear();
+}
+
+#pragma mark - NSTextFieldDelegate
+
+- (BOOL)control:(NSControl*)control
+               textView:(NSTextView*)text_view
+    doCommandBySelector:(SEL)selector
+{
+    if (selector != @selector(insertNewline:)) {
+        return NO;
+    }
+
+    auto* ns_script = [[text_view textStorage] string];
+    auto script = Ladybird::ns_string_to_string(ns_script);
+
+    if (!script.bytes_as_string_view().is_whitespace()) {
+        m_console_client->execute(script);
+        [text_view setString:@""];
+    }
+
+    return YES;
+}
+
+@end

--- a/Ladybird/AppKit/UI/ConsoleController.h
+++ b/Ladybird/AppKit/UI/ConsoleController.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2023, Tim Flynn <trflynn89@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#import <System/Cocoa.h>
+
+@class Tab;
+
+@interface ConsoleController : NSWindowController
+
+- (instancetype)init:(Tab*)tab;
+
+@end

--- a/Ladybird/AppKit/UI/ConsoleController.mm
+++ b/Ladybird/AppKit/UI/ConsoleController.mm
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2023, Tim Flynn <trflynn89@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#import <UI/Console.h>
+#import <UI/ConsoleController.h>
+#import <UI/LadybirdWebView.h>
+#import <UI/Tab.h>
+
+#if !__has_feature(objc_arc)
+#    error "This project requires ARC"
+#endif
+
+@interface ConsoleController () <NSWindowDelegate>
+
+@property (nonatomic, strong) Tab* tab;
+
+@end
+
+@implementation ConsoleController
+
+- (instancetype)init:(Tab*)tab
+{
+    if (self = [super init]) {
+        self.tab = tab;
+    }
+
+    return self;
+}
+
+#pragma mark - Private methods
+
+- (Console*)console
+{
+    return (Console*)[self window];
+}
+
+#pragma mark - NSWindowController
+
+- (IBAction)showWindow:(id)sender
+{
+    self.window = [[Console alloc] init:self.tab];
+    [self.window setDelegate:self];
+    [self.window makeKeyAndOrderFront:sender];
+}
+
+#pragma mark - NSWindowDelegate
+
+- (void)windowWillClose:(NSNotification*)notification
+{
+    [self.tab onConsoleClosed];
+}
+
+- (void)windowDidResize:(NSNotification*)notification
+{
+    if (![[self window] inLiveResize]) {
+        [[[self console] web_view] handleResize];
+    }
+}
+
+@end

--- a/Ladybird/AppKit/UI/LadybirdWebView.h
+++ b/Ladybird/AppKit/UI/LadybirdWebView.h
@@ -10,6 +10,7 @@
 #include <LibGfx/Forward.h>
 #include <LibWeb/CSS/PreferredColorScheme.h>
 #include <LibWeb/HTML/ActivateTab.h>
+#include <LibWebView/Forward.h>
 
 #import <System/Cocoa.h>
 
@@ -41,6 +42,7 @@
 - (void)loadURL:(URL const&)url;
 - (void)loadHTML:(StringView)html url:(URL const&)url;
 
+- (WebView::ViewImplementation&)view;
 - (String const&)handle;
 
 - (void)handleResize;

--- a/Ladybird/AppKit/UI/LadybirdWebView.h
+++ b/Ladybird/AppKit/UI/LadybirdWebView.h
@@ -7,14 +7,41 @@
 #pragma once
 
 #include <AK/Forward.h>
+#include <LibGfx/Forward.h>
 #include <LibWeb/CSS/PreferredColorScheme.h>
+#include <LibWeb/HTML/ActivateTab.h>
 
 #import <System/Cocoa.h>
 
+@protocol LadybirdWebViewObserver <NSObject>
+
+- (String const&)onCreateNewTab:(URL const&)url
+                    activateTab:(Web::HTML::ActivateTab)activate_tab;
+
+- (String const&)onCreateNewTab:(StringView)html
+                            url:(URL const&)url
+                    activateTab:(Web::HTML::ActivateTab)activate_tab;
+
+- (void)loadURL:(URL const&)url;
+- (void)onLoadStart:(URL const&)url isRedirect:(BOOL)is_redirect;
+
+- (void)onTitleChange:(DeprecatedString const&)title;
+- (void)onFaviconChange:(Gfx::Bitmap const&)bitmap;
+
+- (void)onNavigateBack;
+- (void)onNavigateForward;
+- (void)onReload;
+
+@end
+
 @interface LadybirdWebView : NSClipView
+
+- (instancetype)init:(id<LadybirdWebViewObserver>)observer;
 
 - (void)loadURL:(URL const&)url;
 - (void)loadHTML:(StringView)html url:(URL const&)url;
+
+- (String const&)handle;
 
 - (void)handleResize;
 - (void)handleScroll;

--- a/Ladybird/AppKit/UI/LadybirdWebView.mm
+++ b/Ladybird/AppKit/UI/LadybirdWebView.mm
@@ -907,6 +907,12 @@ static void copy_text_to_clipboard(StringView text)
     [super drawRect:rect];
 }
 
+- (void)viewDidMoveToWindow
+{
+    [super viewDidMoveToWindow];
+    [self handleResize];
+}
+
 - (void)viewDidEndLiveResize
 {
     [super viewDidEndLiveResize];

--- a/Ladybird/AppKit/UI/LadybirdWebView.mm
+++ b/Ladybird/AppKit/UI/LadybirdWebView.mm
@@ -244,7 +244,17 @@ struct HideCursor {
     };
 
     m_web_view_bridge->on_scroll_to_point = [self](auto position) {
-        [self scrollToPoint:Ladybird::gfx_point_to_ns_point(position)];
+        auto content_rect = [self frame];
+        auto document_rect = [[self documentView] frame];
+        auto ns_position = Ladybird::gfx_point_to_ns_point(position);
+
+        ns_position.x = max(ns_position.x, document_rect.origin.x);
+        ns_position.x = min(ns_position.x, document_rect.size.width - content_rect.size.width);
+
+        ns_position.y = max(ns_position.y, document_rect.origin.y);
+        ns_position.y = min(ns_position.y, document_rect.size.height - content_rect.size.height);
+
+        [self scrollToPoint:ns_position];
         [[self scrollView] reflectScrolledClipView:self];
         [self updateViewportRect:Ladybird::WebViewBridge::ForResize::No];
     };

--- a/Ladybird/AppKit/UI/LadybirdWebView.mm
+++ b/Ladybird/AppKit/UI/LadybirdWebView.mm
@@ -112,6 +112,11 @@ struct HideCursor {
     m_web_view_bridge->load_html(html, url);
 }
 
+- (WebView::ViewImplementation&)view
+{
+    return *m_web_view_bridge;
+}
+
 - (String const&)handle
 {
     return m_web_view_bridge->handle();

--- a/Ladybird/AppKit/UI/Tab.h
+++ b/Ladybird/AppKit/UI/Tab.h
@@ -6,17 +6,11 @@
 
 #pragma once
 
-#include <AK/URL.h>
-
 #import <System/Cocoa.h>
 
 @class LadybirdWebView;
 
 @interface Tab : NSWindow
-
-- (void)onLoadStart:(URL const&)url;
-- (void)onTitleChange:(NSString*)title;
-- (void)onFaviconChange:(NSImage*)favicon;
 
 @property (nonatomic, strong) LadybirdWebView* web_view;
 

--- a/Ladybird/AppKit/UI/Tab.mm
+++ b/Ladybird/AppKit/UI/Tab.mm
@@ -12,6 +12,8 @@
 #include <LibGfx/ShareableBitmap.h>
 
 #import <Application/ApplicationDelegate.h>
+#import <UI/Console.h>
+#import <UI/ConsoleController.h>
 #import <UI/LadybirdWebView.h>
 #import <UI/Tab.h>
 #import <UI/TabController.h>
@@ -28,6 +30,8 @@ static constexpr CGFloat const WINDOW_HEIGHT = 800;
 
 @property (nonatomic, strong) NSString* title;
 @property (nonatomic, strong) NSImage* favicon;
+
+@property (nonatomic, strong) ConsoleController* console_controller;
 
 @end
 
@@ -93,6 +97,31 @@ static constexpr CGFloat const WINDOW_HEIGHT = 800;
     }
 
     return self;
+}
+
+#pragma mark - Public methods
+
+- (void)tabWillClose
+{
+    if (self.console_controller != nil) {
+        [self.console_controller.window close];
+    }
+}
+
+- (void)openConsole:(id)sender
+{
+    if (self.console_controller != nil) {
+        [self.console_controller.window makeKeyAndOrderFront:sender];
+        return;
+    }
+
+    self.console_controller = [[ConsoleController alloc] init:self];
+    [self.console_controller showWindow:nil];
+}
+
+- (void)onConsoleClosed
+{
+    self.console_controller = nil;
 }
 
 #pragma mark - Private methods
@@ -185,6 +214,11 @@ static constexpr CGFloat const WINDOW_HEIGHT = 800;
     self.title = Ladybird::string_to_ns_string(url.serialize());
     self.favicon = [Tab defaultFavicon];
     [self updateTabTitleAndFavicon];
+
+    if (self.console_controller != nil) {
+        auto* console = (Console*)[self.console_controller window];
+        [console reset];
+    }
 }
 
 - (void)onTitleChange:(DeprecatedString const&)title

--- a/Ladybird/AppKit/UI/Tab.mm
+++ b/Ladybird/AppKit/UI/Tab.mm
@@ -4,12 +4,18 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/DeprecatedString.h>
+#include <AK/String.h>
+#include <AK/URL.h>
+#include <Ladybird/Utilities.h>
+#include <LibGfx/ImageFormats/PNGWriter.h>
+#include <LibGfx/ShareableBitmap.h>
+
+#import <Application/ApplicationDelegate.h>
 #import <UI/LadybirdWebView.h>
 #import <UI/Tab.h>
 #import <UI/TabController.h>
 #import <Utilities/Conversions.h>
-
-#include <Ladybird/Utilities.h>
 
 #if !__has_feature(objc_arc)
 #    error "This project requires ARC"
@@ -18,7 +24,7 @@
 static constexpr CGFloat const WINDOW_WIDTH = 1000;
 static constexpr CGFloat const WINDOW_HEIGHT = 800;
 
-@interface Tab ()
+@interface Tab () <LadybirdWebViewObserver>
 
 @property (nonatomic, strong) NSString* title;
 @property (nonatomic, strong) NSImage* favicon;
@@ -59,7 +65,7 @@ static constexpr CGFloat const WINDOW_HEIGHT = 800;
                                 defer:NO];
 
     if (self) {
-        self.web_view = [[LadybirdWebView alloc] init];
+        self.web_view = [[LadybirdWebView alloc] init:self];
         [self.web_view setPostsBoundsChangedNotifications:YES];
 
         self.favicon = [Tab defaultFavicon];
@@ -89,28 +95,12 @@ static constexpr CGFloat const WINDOW_HEIGHT = 800;
     return self;
 }
 
-#pragma mark - Public methods
-
-- (void)onLoadStart:(URL const&)url
-{
-    self.title = Ladybird::string_to_ns_string(url.serialize());
-    self.favicon = [Tab defaultFavicon];
-    [self updateTabTitleAndFavicon];
-}
-
-- (void)onTitleChange:(NSString*)title
-{
-    self.title = title;
-    [self updateTabTitleAndFavicon];
-}
-
-- (void)onFaviconChange:(NSImage*)favicon
-{
-    self.favicon = favicon;
-    [self updateTabTitleAndFavicon];
-}
-
 #pragma mark - Private methods
+
+- (TabController*)tabController
+{
+    return (TabController*)[self windowController];
+}
 
 - (void)updateTabTitleAndFavicon
 {
@@ -151,6 +141,93 @@ static constexpr CGFloat const WINDOW_HEIGHT = 800;
 - (void)onContentScroll:(NSNotification*)notification
 {
     [[self web_view] handleScroll];
+}
+
+#pragma mark - LadybirdWebViewObserver
+
+- (String const&)onCreateNewTab:(URL const&)url
+                    activateTab:(Web::HTML::ActivateTab)activate_tab
+{
+    auto* delegate = (ApplicationDelegate*)[NSApp delegate];
+
+    auto* controller = [delegate createNewTab:url
+                                      fromTab:self
+                                  activateTab:activate_tab];
+
+    auto* tab = (Tab*)[controller window];
+    return [[tab web_view] handle];
+}
+
+- (String const&)onCreateNewTab:(StringView)html
+                            url:(URL const&)url
+                    activateTab:(Web::HTML::ActivateTab)activate_tab
+{
+    auto* delegate = (ApplicationDelegate*)[NSApp delegate];
+
+    auto* controller = [delegate createNewTab:html
+                                          url:url
+                                      fromTab:self
+                                  activateTab:activate_tab];
+
+    auto* tab = (Tab*)[controller window];
+    return [[tab web_view] handle];
+}
+
+- (void)loadURL:(URL const&)url
+{
+    [[self tabController] loadURL:url];
+}
+
+- (void)onLoadStart:(URL const&)url isRedirect:(BOOL)is_redirect
+{
+    [[self tabController] onLoadStart:url isRedirect:is_redirect];
+
+    self.title = Ladybird::string_to_ns_string(url.serialize());
+    self.favicon = [Tab defaultFavicon];
+    [self updateTabTitleAndFavicon];
+}
+
+- (void)onTitleChange:(DeprecatedString const&)title
+{
+    [[self tabController] onTitleChange:title];
+
+    self.title = Ladybird::string_to_ns_string(title);
+    [self updateTabTitleAndFavicon];
+}
+
+- (void)onFaviconChange:(Gfx::Bitmap const&)bitmap
+{
+    static constexpr size_t FAVICON_SIZE = 16;
+
+    auto png = Gfx::PNGWriter::encode(bitmap);
+    if (png.is_error()) {
+        return;
+    }
+
+    auto* data = [NSData dataWithBytes:png.value().data()
+                                length:png.value().size()];
+
+    auto* favicon = [[NSImage alloc] initWithData:data];
+    [favicon setResizingMode:NSImageResizingModeStretch];
+    [favicon setSize:NSMakeSize(FAVICON_SIZE, FAVICON_SIZE)];
+
+    self.favicon = favicon;
+    [self updateTabTitleAndFavicon];
+}
+
+- (void)onNavigateBack
+{
+    [[self tabController] navigateBack:nil];
+}
+
+- (void)onNavigateForward
+{
+    [[self tabController] navigateForward:nil];
+}
+
+- (void)onReload
+{
+    [[self tabController] reload:nil];
 }
 
 #pragma mark - NSWindow

--- a/Ladybird/AppKit/UI/TabController.mm
+++ b/Ladybird/AppKit/UI/TabController.mm
@@ -334,6 +334,8 @@ enum class IsHistoryNavigation {
 
 - (void)windowWillClose:(NSNotification*)notification
 {
+    [[self tab] tabWillClose];
+
     auto* delegate = (ApplicationDelegate*)[NSApp delegate];
     [delegate removeTab:self];
 }

--- a/Ladybird/CMakeLists.txt
+++ b/Ladybird/CMakeLists.txt
@@ -133,6 +133,8 @@ elseif (APPLE)
         AppKit/Application/Application.mm
         AppKit/Application/ApplicationDelegate.mm
         AppKit/Application/EventLoopImplementation.mm
+        AppKit/UI/Console.mm
+        AppKit/UI/ConsoleController.mm
         AppKit/UI/Event.mm
         AppKit/UI/LadybirdWebView.mm
         AppKit/UI/LadybirdWebViewBridge.cpp

--- a/Ladybird/Qt/ConsoleWidget.cpp
+++ b/Ladybird/Qt/ConsoleWidget.cpp
@@ -10,35 +10,26 @@
 #include "ConsoleWidget.h"
 #include "StringUtils.h"
 #include "WebContentView.h"
-#include <AK/StringBuilder.h>
-#include <LibJS/MarkupGenerator.h>
+#include <LibWebView/ConsoleClient.h>
 #include <QFontDatabase>
 #include <QKeyEvent>
 #include <QLineEdit>
-#include <QPalette>
 #include <QPushButton>
-#include <QTextEdit>
 #include <QVBoxLayout>
 
 namespace Ladybird {
 
 bool is_using_dark_system_theme(QWidget&);
 
-ConsoleWidget::ConsoleWidget()
+ConsoleWidget::ConsoleWidget(WebContentView& content_view)
 {
     setLayout(new QVBoxLayout);
 
     m_output_view = new WebContentView({}, WebView::EnableCallgrindProfiling::No, UseLagomNetworking::No);
-    m_output_view->use_native_user_style_sheet();
     if (is_using_dark_system_theme(*this))
         m_output_view->update_palette(WebContentView::PaletteMode::Dark);
 
-    m_output_view->load("data:text/html,<html style=\"font: 10pt monospace;\"></html>"sv);
-    // Wait until our output WebView is loaded, and then request any messages that occurred before we existed
-    m_output_view->on_load_finish = [this](auto&) {
-        if (on_request_messages)
-            on_request_messages(0);
-    };
+    m_console_client = make<WebView::ConsoleClient>(content_view, *m_output_view);
 
     layout()->addWidget(m_output_view);
 
@@ -59,117 +50,17 @@ ConsoleWidget::ConsoleWidget()
     clear_button->setText("X");
     clear_button->setToolTip("Clear the console output");
     QObject::connect(clear_button, &QPushButton::pressed, [this] {
-        clear_output();
+        client().clear();
     });
 
     m_input->setFocus();
 }
 
-void ConsoleWidget::request_console_messages()
-{
-    VERIFY(!m_waiting_for_messages);
-    VERIFY(on_request_messages);
-    on_request_messages(m_highest_received_message_index + 1);
-    m_waiting_for_messages = true;
-}
-
-void ConsoleWidget::notify_about_new_console_message(i32 message_index)
-{
-    if (message_index <= m_highest_received_message_index) {
-        dbgln("Notified about console message we already have");
-        return;
-    }
-    if (message_index <= m_highest_notified_message_index) {
-        dbgln("Notified about console message we're already aware of");
-        return;
-    }
-
-    m_highest_notified_message_index = message_index;
-    if (!m_waiting_for_messages)
-        request_console_messages();
-}
-
-void ConsoleWidget::handle_console_messages(i32 start_index, Vector<DeprecatedString> const& message_types, Vector<DeprecatedString> const& messages)
-{
-    i32 end_index = start_index + message_types.size() - 1;
-    if (end_index <= m_highest_received_message_index) {
-        dbgln("Received old console messages");
-        return;
-    }
-
-    for (size_t i = 0; i < message_types.size(); i++) {
-        auto& type = message_types[i];
-        auto& message = messages[i];
-
-        if (type == "html") {
-            print_html(message);
-        } else if (type == "clear") {
-            clear_output();
-        } else if (type == "group") {
-            // FIXME: Implement.
-        } else if (type == "groupCollapsed") {
-            // FIXME: Implement.
-        } else if (type == "groupEnd") {
-            // FIXME: Implement.
-        } else {
-            VERIFY_NOT_REACHED();
-        }
-    }
-
-    m_highest_received_message_index = end_index;
-    m_waiting_for_messages = false;
-
-    if (m_highest_received_message_index < m_highest_notified_message_index)
-        request_console_messages();
-}
-
-void ConsoleWidget::print_source_line(StringView source)
-{
-    StringBuilder html;
-    html.append("<span class=\"repl-indicator\">"sv);
-    html.append("&gt; "sv);
-    html.append("</span>"sv);
-
-    html.append(JS::MarkupGenerator::html_from_source(source).release_value_but_fixme_should_propagate_errors());
-
-    print_html(html.string_view());
-}
-
-void ConsoleWidget::print_html(StringView line)
-{
-    StringBuilder builder;
-
-    builder.append(R"~~~(
-        var p = document.createElement("p");
-        p.innerHTML = ")~~~"sv);
-    builder.append_escaped_for_json(line);
-    builder.append(R"~~~("
-        document.body.appendChild(p);
-)~~~"sv);
-
-    // FIXME: It should be sufficient to scrollTo a y value of document.documentElement.offsetHeight,
-    // but due to an unknown bug offsetHeight seems to not be properly updated after spamming
-    // a lot of document changes.
-    //
-    // The setTimeout makes the scrollTo async and allows the DOM to be updated.
-    builder.append("setTimeout(function() { window.scrollTo(0, 1_000_000_000); }, 0);"sv);
-
-    m_output_view->run_javascript(builder.string_view());
-}
-
-void ConsoleWidget::clear_output()
-{
-    m_output_view->run_javascript(R"~~~(
-        document.body.innerHTML = "";
-    )~~~"sv);
-}
+ConsoleWidget::~ConsoleWidget() = default;
 
 void ConsoleWidget::reset()
 {
-    clear_output();
-    m_highest_notified_message_index = -1;
-    m_highest_received_message_index = -1;
-    m_waiting_for_messages = false;
+    m_console_client->reset();
 }
 
 void ConsoleInputEdit::keyPressEvent(QKeyEvent* event)
@@ -188,12 +79,14 @@ void ConsoleInputEdit::keyPressEvent(QKeyEvent* event)
         }
         break;
     }
+
     case Qt::Key_Up:
         if (m_history_index > 0) {
             m_history_index--;
             setText(qstring_from_ak_deprecated_string(m_history.at(m_history_index)));
         }
         break;
+
     case Qt::Key_Return: {
         auto js_source = ak_deprecated_string_from_qstring(text());
         if (js_source.is_whitespace())
@@ -204,15 +97,12 @@ void ConsoleInputEdit::keyPressEvent(QKeyEvent* event)
             m_history_index = m_history.size();
         }
 
+        m_console_widget.client().execute(js_source);
         clear();
-
-        m_console_widget.print_source_line(js_source);
-
-        if (m_console_widget.on_js_input)
-            m_console_widget.on_js_input(js_source);
 
         break;
     }
+
     default:
         QLineEdit::keyPressEvent(event);
     }

--- a/Ladybird/Qt/ConsoleWidget.h
+++ b/Ladybird/Qt/ConsoleWidget.h
@@ -10,12 +10,12 @@
 #pragma once
 
 #include <AK/DeprecatedString.h>
-#include <AK/Function.h>
+#include <AK/OwnPtr.h>
 #include <AK/Vector.h>
+#include <LibWebView/Forward.h>
 #include <QLineEdit>
 #include <QWidget>
 
-class QLineEdit;
 namespace Ladybird {
 
 class WebContentView;
@@ -23,30 +23,19 @@ class WebContentView;
 class ConsoleWidget final : public QWidget {
     Q_OBJECT
 public:
-    ConsoleWidget();
-    virtual ~ConsoleWidget() = default;
+    explicit ConsoleWidget(WebContentView& content_view);
+    virtual ~ConsoleWidget();
 
-    void notify_about_new_console_message(i32 message_index);
-    void handle_console_messages(i32 start_index, Vector<DeprecatedString> const& message_types, Vector<DeprecatedString> const& messages);
-    void print_source_line(StringView);
-    void print_html(StringView);
-    void reset();
-
+    WebView::ConsoleClient& client() { return *m_console_client; }
     WebContentView& view() { return *m_output_view; }
 
-    Function<void(DeprecatedString const&)> on_js_input;
-    Function<void(i32)> on_request_messages;
+    void reset();
 
 private:
-    void request_console_messages();
-    void clear_output();
+    OwnPtr<WebView::ConsoleClient> m_console_client;
 
     WebContentView* m_output_view { nullptr };
     QLineEdit* m_input { nullptr };
-
-    i32 m_highest_notified_message_index { -1 };
-    i32 m_highest_received_message_index { -1 };
-    bool m_waiting_for_messages { false };
 };
 
 class ConsoleInputEdit final : public QLineEdit {

--- a/Ladybird/Qt/Tab.cpp
+++ b/Ladybird/Qt/Tab.cpp
@@ -272,16 +272,6 @@ Tab::Tab(BrowserWindow* window, StringView webdriver_content_ipc_path, WebView::
             m_inspector_widget->set_accessibility_json(accessibility_tree);
     };
 
-    view().on_received_console_message = [this](auto message_index) {
-        if (m_console_widget)
-            m_console_widget->notify_about_new_console_message(message_index);
-    };
-
-    view().on_received_console_messages = [this](auto start_index, auto& message_types, auto& messages) {
-        if (m_console_widget)
-            m_console_widget->handle_console_messages(start_index, message_types, messages);
-    };
-
     auto* take_visible_screenshot_action = new QAction("Take &Visible Screenshot", this);
     take_visible_screenshot_action->setIcon(QIcon(QString("%1/res/icons/16x16/filetype-image.png").arg(s_serenity_resource_root.characters())));
     QObject::connect(take_visible_screenshot_action, &QAction::triggered, this, [this]() {
@@ -702,7 +692,7 @@ void Tab::show_inspector_window(InspectorTarget inspector_target)
 void Tab::show_console_window()
 {
     if (!m_console_widget) {
-        m_console_widget = new Ladybird::ConsoleWidget;
+        m_console_widget = new Ladybird::ConsoleWidget(view());
         m_console_widget->setWindowTitle("JS Console");
         m_console_widget->resize(640, 480);
 
@@ -718,12 +708,6 @@ void Tab::show_console_window()
         m_console_widget->view().on_context_menu_request = [this](Gfx::IntPoint) {
             auto screen_position = QCursor::pos();
             m_console_context_menu->exec(screen_position);
-        };
-        m_console_widget->on_js_input = [this](auto js_source) {
-            view().js_console_input(js_source);
-        };
-        m_console_widget->on_request_messages = [this](i32 start_index) {
-            view().js_console_request_messages(start_index);
         };
     }
 

--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -430,6 +430,7 @@ if (BUILD_LAGOM)
 
         # WebView
         list(APPEND LIBWEBVIEW_SOURCES "../../Userland/Libraries/LibWebView/AccessibilityTreeModel.cpp")
+        list(APPEND LIBWEBVIEW_SOURCES "../../Userland/Libraries/LibWebView/ConsoleClient.cpp")
         list(APPEND LIBWEBVIEW_SOURCES "../../Userland/Libraries/LibWebView/DOMTreeModel.cpp")
         list(APPEND LIBWEBVIEW_SOURCES "../../Userland/Libraries/LibWebView/RequestServerAdapter.cpp")
         list(APPEND LIBWEBVIEW_SOURCES "../../Userland/Libraries/LibWebView/SourceHighlighter.cpp")
@@ -463,7 +464,7 @@ if (BUILD_LAGOM)
 
         lagom_lib(LibWebView webview
             SOURCES ${LIBWEBVIEW_SOURCES} ${LIBWEBVIEW_GENERATED_SOURCES}
-            LIBS LibGfx LibGUI LibIPC LibWeb LibProtocol)
+            LIBS LibGfx LibGUI LibIPC LibJS LibWeb LibProtocol)
         foreach(header ${LIBWEBVIEW_GENERATED_SOURCES})
             get_filename_component(subdirectory ${header} DIRECTORY)
             install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${header}" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${subdirectory}")

--- a/Userland/Applications/Browser/ConsoleWidget.cpp
+++ b/Userland/Applications/Browser/ConsoleWidget.cpp
@@ -16,22 +16,18 @@
 #include <LibGfx/Font/FontDatabase.h>
 #include <LibJS/MarkupGenerator.h>
 #include <LibJS/SyntaxHighlighter.h>
+#include <LibWebView/ConsoleClient.h>
+#include <LibWebView/OutOfProcessWebView.h>
 
 namespace Browser {
 
-ConsoleWidget::ConsoleWidget()
+ConsoleWidget::ConsoleWidget(WebView::OutOfProcessWebView& content_view)
 {
     set_layout<GUI::VerticalBoxLayout>();
     set_fill_with_background_color(true);
 
     m_output_view = add<WebView::OutOfProcessWebView>();
-    m_output_view->use_native_user_style_sheet();
-    m_output_view->load("data:text/html,<html style=\"font: 10pt monospace;\"></html>"sv);
-    // Wait until our output WebView is loaded, and then request any messages that occurred before we existed
-    m_output_view->on_load_finish = [this](auto&) {
-        if (on_request_messages)
-            on_request_messages(0);
-    };
+    m_console_client = make<WebView::ConsoleClient>(content_view, *m_output_view);
 
     auto& bottom_container = add<GUI::Widget>();
     bottom_container.set_layout<GUI::HorizontalBoxLayout>();
@@ -52,10 +48,7 @@ ConsoleWidget::ConsoleWidget()
         m_input->add_current_text_to_history();
         m_input->clear();
 
-        print_source_line(js_source);
-
-        if (on_js_input)
-            on_js_input(js_source);
+        m_console_client->execute(js_source);
     };
 
     set_focus_proxy(m_input);
@@ -65,168 +58,15 @@ ConsoleWidget::ConsoleWidget()
     clear_button.set_icon(g_icon_bag.delete_icon);
     clear_button.set_tooltip_deprecated("Clear the console output");
     clear_button.on_click = [this](auto) {
-        clear_output();
+        m_console_client->clear();
     };
 }
 
-void ConsoleWidget::request_console_messages()
-{
-    VERIFY(!m_waiting_for_messages);
-    VERIFY(on_request_messages);
-    on_request_messages(m_highest_received_message_index + 1);
-    m_waiting_for_messages = true;
-}
-
-void ConsoleWidget::notify_about_new_console_message(i32 message_index)
-{
-    if (message_index <= m_highest_received_message_index) {
-        dbgln("Notified about console message we already have");
-        return;
-    }
-    if (message_index <= m_highest_notified_message_index) {
-        dbgln("Notified about console message we're already aware of");
-        return;
-    }
-
-    m_highest_notified_message_index = message_index;
-    if (!m_waiting_for_messages)
-        request_console_messages();
-}
-
-void ConsoleWidget::handle_console_messages(i32 start_index, Vector<DeprecatedString> const& message_types, Vector<DeprecatedString> const& messages)
-{
-    i32 end_index = start_index + message_types.size() - 1;
-    if (end_index <= m_highest_received_message_index) {
-        dbgln("Received old console messages");
-        return;
-    }
-
-    for (size_t i = 0; i < message_types.size(); i++) {
-        auto& type = message_types[i];
-        auto& message = messages[i];
-
-        if (type == "html") {
-            print_html(message);
-        } else if (type == "clear") {
-            clear_output();
-        } else if (type == "group") {
-            begin_group(message, true);
-        } else if (type == "groupCollapsed") {
-            begin_group(message, false);
-        } else if (type == "groupEnd") {
-            end_group();
-        } else {
-            VERIFY_NOT_REACHED();
-        }
-    }
-
-    m_highest_received_message_index = end_index;
-    m_waiting_for_messages = false;
-
-    if (m_highest_received_message_index < m_highest_notified_message_index)
-        request_console_messages();
-}
-
-void ConsoleWidget::print_source_line(StringView source)
-{
-    StringBuilder html;
-    html.append("<span class=\"repl-indicator\">"sv);
-    html.append("&gt; "sv);
-    html.append("</span>"sv);
-
-    html.append(JS::MarkupGenerator::html_from_source(source).release_value_but_fixme_should_propagate_errors());
-
-    print_html(html.string_view());
-}
-
-void ConsoleWidget::print_html(StringView line)
-{
-    StringBuilder builder;
-
-    int parent_id = m_group_stack.is_empty() ? 0 : m_group_stack.last().id;
-    if (parent_id == 0) {
-        builder.append(R"~~~(
-        var parentGroup = document.body;
-)~~~"sv);
-    } else {
-        builder.appendff(R"~~~(
-        var parentGroup = document.getElementById("group_{}");
-)~~~",
-            parent_id);
-    }
-
-    builder.append(R"~~~(
-        var p = document.createElement("p");
-        p.innerHTML = ")~~~"sv);
-    builder.append_escaped_for_json(line);
-    builder.append(R"~~~("
-        parentGroup.appendChild(p);
-)~~~"sv);
-    m_output_view->run_javascript(builder.string_view());
-    // FIXME: Make it scroll to the bottom, using `window.scrollTo()` in the JS above.
-    //        We used to call `m_output_view->scroll_to_bottom();` here, but that does not work because
-    //        it runs synchronously, meaning it happens before the HTML is output via IPC above.
-    //        (See also: begin_group())
-}
-
-void ConsoleWidget::clear_output()
-{
-    m_group_stack.clear();
-    m_output_view->run_javascript(R"~~~(
-        document.body.innerHTML = "";
-    )~~~"sv);
-}
-
-void ConsoleWidget::begin_group(StringView label, bool start_expanded)
-{
-    StringBuilder builder;
-    int parent_id = m_group_stack.is_empty() ? 0 : m_group_stack.last().id;
-    if (parent_id == 0) {
-        builder.append(R"~~~(
-        var parentGroup = document.body;
-)~~~"sv);
-    } else {
-        builder.appendff(R"~~~(
-        var parentGroup = document.getElementById("group_{}");
-)~~~",
-            parent_id);
-    }
-
-    Group group;
-    group.id = m_next_group_id++;
-    group.label = label;
-
-    builder.appendff(R"~~~(
-        var group = document.createElement("details");
-        group.id = "group_{}";
-        var label = document.createElement("summary");
-        label.innerHTML = ")~~~",
-        group.id);
-    builder.append_escaped_for_json(label);
-    builder.append(R"~~~(";
-        group.appendChild(label);
-        parentGroup.appendChild(group);
-)~~~"sv);
-
-    if (start_expanded)
-        builder.append("group.open = true;"sv);
-
-    m_output_view->run_javascript(builder.string_view());
-    // FIXME: Scroll console to bottom - see note in print_html()
-    m_group_stack.append(group);
-}
-
-void ConsoleWidget::end_group()
-{
-    m_group_stack.take_last();
-}
+ConsoleWidget::~ConsoleWidget() = default;
 
 void ConsoleWidget::reset()
 {
-    clear_output();
-    m_highest_notified_message_index = -1;
-    m_highest_received_message_index = -1;
-    m_waiting_for_messages = false;
+    m_console_client->reset();
 }
 
 }

--- a/Userland/Applications/Browser/ConsoleWidget.h
+++ b/Userland/Applications/Browser/ConsoleWidget.h
@@ -9,47 +9,29 @@
 
 #pragma once
 
-#include "History.h"
+#include <AK/OwnPtr.h>
 #include <LibGUI/Widget.h>
-#include <LibWebView/OutOfProcessWebView.h>
+#include <LibWebView/Forward.h>
 
 namespace Browser {
 
 class ConsoleWidget final : public GUI::Widget {
     C_OBJECT(ConsoleWidget)
 public:
-    virtual ~ConsoleWidget() = default;
+    virtual ~ConsoleWidget();
 
-    void notify_about_new_console_message(i32 message_index);
-    void handle_console_messages(i32 start_index, Vector<DeprecatedString> const& message_types, Vector<DeprecatedString> const& messages);
-    void print_source_line(StringView);
-    void print_html(StringView);
     void reset();
 
-    Function<void(DeprecatedString const&)> on_js_input;
-    Function<void(i32)> on_request_messages;
-
 private:
-    ConsoleWidget();
+    explicit ConsoleWidget(WebView::OutOfProcessWebView& content_view);
 
     void request_console_messages();
     void clear_output();
-    void begin_group(StringView label, bool start_expanded);
-    void end_group();
+
+    OwnPtr<WebView::ConsoleClient> m_console_client;
 
     RefPtr<GUI::TextBox> m_input;
     RefPtr<WebView::OutOfProcessWebView> m_output_view;
-
-    i32 m_highest_notified_message_index { -1 };
-    i32 m_highest_received_message_index { -1 };
-    bool m_waiting_for_messages { false };
-
-    struct Group {
-        int id { 0 };
-        DeprecatedString label;
-    };
-    Vector<Group> m_group_stack;
-    int m_next_group_id { 1 };
 };
 
 }

--- a/Userland/Applications/Browser/Tab.cpp
+++ b/Userland/Applications/Browser/Tab.cpp
@@ -584,16 +584,6 @@ Tab::Tab(BrowserWindow& window)
             m_dom_inspector_widget->set_accessibility_json(accessibility_tree);
     };
 
-    view().on_received_console_message = [this](auto message_index) {
-        if (m_console_widget)
-            m_console_widget->notify_about_new_console_message(message_index);
-    };
-
-    view().on_received_console_messages = [this](auto start_index, auto& message_types, auto& messages) {
-        if (m_console_widget)
-            m_console_widget->handle_console_messages(start_index, message_types, messages);
-    };
-
     auto focus_location_box_action = GUI::Action::create(
         "Focus location box", { Mod_Ctrl, Key_L }, Key_F6, [this](auto&) {
             m_location_box->set_focus(true);
@@ -927,13 +917,8 @@ void Tab::show_console_window()
         console_window->resize(500, 300);
         console_window->set_title("JS Console");
         console_window->set_icon(g_icon_bag.filetype_javascript);
-        m_console_widget = console_window->set_main_widget<ConsoleWidget>().release_value_but_fixme_should_propagate_errors();
-        m_console_widget->on_js_input = [this](DeprecatedString const& js_source) {
-            m_web_content_view->js_console_input(js_source);
-        };
-        m_console_widget->on_request_messages = [this](i32 start_index) {
-            m_web_content_view->js_console_request_messages(start_index);
-        };
+
+        m_console_widget = MUST(console_window->set_main_widget<ConsoleWidget>(view()));
     }
 
     auto* window = m_console_widget->window();

--- a/Userland/Libraries/LibWebView/CMakeLists.txt
+++ b/Userland/Libraries/LibWebView/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(SOURCES
     AccessibilityTreeModel.cpp
     AriaPropertiesStateModel.cpp
+    ConsoleClient.cpp
     DOMTreeModel.cpp
     OutOfProcessWebView.cpp
     RequestServerAdapter.cpp
@@ -28,4 +29,4 @@ set(GENERATED_SOURCES
 )
 
 serenity_lib(LibWebView webview)
-target_link_libraries(LibWebView PRIVATE LibCore LibFileSystemAccessClient LibGfx LibGUI LibIPC LibProtocol LibWeb)
+target_link_libraries(LibWebView PRIVATE LibCore LibFileSystemAccessClient LibGfx LibGUI LibIPC LibProtocol LibJS LibWeb)

--- a/Userland/Libraries/LibWebView/ConsoleClient.cpp
+++ b/Userland/Libraries/LibWebView/ConsoleClient.cpp
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2023, Tim Flynn <trflynn89@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/StringBuilder.h>
+#include <LibJS/MarkupGenerator.h>
+#include <LibWebView/ConsoleClient.h>
+#include <LibWebView/ViewImplementation.h>
+
+namespace WebView {
+
+static constexpr auto CONSOLE_HTML = "data:text/html,<html style=\"font: 10pt monospace;\"></html>"sv;
+
+// FIXME: It should be sufficient to scrollTo a y value of document.documentElement.offsetHeight,
+//        but due to an unknown bug offsetHeight seems to not be properly updated after spamming
+//        a lot of document changes.
+//
+// The setTimeout makes the scrollTo async and allows the DOM to be updated.
+static constexpr auto SCROLL_TO_BOTTOM = "setTimeout(function() { window.scrollTo(0, 1_000_000_000); }, 0);"sv;
+
+ConsoleClient::ConsoleClient(ViewImplementation& content_web_view, ViewImplementation& console_web_view)
+    : m_content_web_view(content_web_view)
+    , m_console_web_view(console_web_view)
+{
+    m_content_web_view.on_received_console_message = [this](auto message_index) {
+        handle_console_message(message_index);
+    };
+
+    m_content_web_view.on_received_console_messages = [this](auto start_index, auto const& message_types, auto const& messages) {
+        handle_console_messages(start_index, message_types, messages);
+    };
+
+    // Wait until our output WebView is loaded, and then request any messages that occurred before we existed.
+    m_console_web_view.on_load_finish = [this](auto const&) {
+        request_console_messages(0);
+    };
+
+    m_console_web_view.use_native_user_style_sheet();
+    m_console_web_view.load(CONSOLE_HTML);
+}
+
+ConsoleClient::~ConsoleClient()
+{
+    m_content_web_view.on_received_console_message = nullptr;
+    m_content_web_view.on_received_console_messages = nullptr;
+}
+
+void ConsoleClient::execute(StringView script)
+{
+    print_source(script);
+    m_content_web_view.js_console_input(script);
+}
+
+void ConsoleClient::clear()
+{
+    m_console_web_view.js_console_input("document.body.innerHTML = \"\";"sv);
+    m_group_stack.clear();
+}
+
+void ConsoleClient::reset()
+{
+    clear();
+
+    m_highest_notified_message_index = -1;
+    m_highest_received_message_index = -1;
+    m_waiting_for_messages = false;
+}
+
+void ConsoleClient::handle_console_message(i32 message_index)
+{
+    if (message_index <= m_highest_received_message_index) {
+        dbgln("Notified about console message we already have");
+        return;
+    }
+    if (message_index <= m_highest_notified_message_index) {
+        dbgln("Notified about console message we're already aware of");
+        return;
+    }
+
+    m_highest_notified_message_index = message_index;
+
+    if (!m_waiting_for_messages)
+        request_console_messages();
+}
+
+void ConsoleClient::handle_console_messages(i32 start_index, ReadonlySpan<DeprecatedString> message_types, ReadonlySpan<DeprecatedString> messages)
+{
+    auto end_index = start_index + static_cast<i32>(message_types.size()) - 1;
+    if (end_index <= m_highest_received_message_index) {
+        dbgln("Received old console messages");
+        return;
+    }
+
+    for (size_t i = 0; i < message_types.size(); ++i) {
+        auto const& type = message_types[i];
+        auto const& message = messages[i];
+
+        if (type == "html"sv)
+            print_html(message);
+        else if (type == "clear"sv)
+            clear();
+        else if (type == "group"sv)
+            begin_group(message, true);
+        else if (type == "groupCollapsed"sv)
+            begin_group(message, false);
+        else if (type == "groupEnd"sv)
+            end_group();
+        else
+            VERIFY_NOT_REACHED();
+    }
+
+    m_highest_received_message_index = end_index;
+    m_waiting_for_messages = false;
+
+    if (m_highest_received_message_index < m_highest_notified_message_index)
+        request_console_messages();
+}
+
+void ConsoleClient::print_source(StringView source)
+{
+    StringBuilder builder;
+
+    builder.append("<span class=\"repl-indicator\">&gt; </span>"sv);
+    builder.append(MUST(JS::MarkupGenerator::html_from_source(source)));
+
+    print_html(builder.string_view());
+}
+
+void ConsoleClient::print_html(StringView html)
+{
+    StringBuilder builder;
+
+    if (m_group_stack.is_empty())
+        builder.append("var parentGroup = document.body;"sv);
+    else
+        builder.appendff("var parentGroup = document.getElementById(\"group_{}\");", m_group_stack.last().id);
+
+    builder.append(R"~~~(
+        var p = document.createElement("p");
+        p.innerHTML = ")~~~"sv);
+    builder.append_escaped_for_json(html);
+    builder.append(R"~~~("
+        parentGroup.appendChild(p);
+)~~~"sv);
+
+    builder.append(SCROLL_TO_BOTTOM);
+
+    m_console_web_view.run_javascript(builder.string_view());
+}
+
+void ConsoleClient::request_console_messages()
+{
+    request_console_messages(m_highest_received_message_index + 1);
+}
+
+void ConsoleClient::request_console_messages(i32 start_index)
+{
+    VERIFY(!m_waiting_for_messages);
+
+    m_content_web_view.js_console_request_messages(start_index);
+    m_waiting_for_messages = true;
+}
+
+void ConsoleClient::begin_group(StringView label, bool start_expanded)
+{
+    StringBuilder builder;
+
+    if (m_group_stack.is_empty())
+        builder.append("var parentGroup = document.body;"sv);
+    else
+        builder.appendff("var parentGroup = document.getElementById(\"group_{}\");", m_group_stack.last().id);
+
+    Group group;
+    group.id = m_next_group_id++;
+    group.label = label;
+
+    builder.appendff(R"~~~(
+        var group = document.createElement("details");
+        group.id = "group_{}";
+        var label = document.createElement("summary");
+        label.innerHTML = ")~~~",
+        group.id);
+    builder.append_escaped_for_json(label);
+    builder.append(R"~~~(";
+        group.appendChild(label);
+        parentGroup.appendChild(group);
+)~~~"sv);
+
+    if (start_expanded)
+        builder.append("group.open = true;"sv);
+
+    builder.append(SCROLL_TO_BOTTOM);
+
+    m_console_web_view.run_javascript(builder.string_view());
+    m_group_stack.append(group);
+}
+
+void ConsoleClient::end_group()
+{
+    m_group_stack.take_last();
+}
+
+}

--- a/Userland/Libraries/LibWebView/ConsoleClient.h
+++ b/Userland/Libraries/LibWebView/ConsoleClient.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2023, Tim Flynn <trflynn89@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/DeprecatedString.h>
+#include <AK/Function.h>
+#include <AK/Span.h>
+#include <AK/StringView.h>
+#include <AK/Vector.h>
+#include <LibWebView/Forward.h>
+
+namespace WebView {
+
+class ConsoleClient {
+public:
+    explicit ConsoleClient(ViewImplementation& content_web_view, ViewImplementation& console_web_view);
+    ~ConsoleClient();
+
+    void execute(StringView);
+
+    void clear();
+    void reset();
+
+private:
+    void handle_console_message(i32 message_index);
+    void handle_console_messages(i32 start_index, ReadonlySpan<DeprecatedString> message_types, ReadonlySpan<DeprecatedString> messages);
+
+    void print_source(StringView);
+    void print_html(StringView);
+
+    void request_console_messages();
+    void request_console_messages(i32 start_index);
+
+    void begin_group(StringView label, bool start_expanded);
+    void end_group();
+
+    ViewImplementation& m_content_web_view;
+    ViewImplementation& m_console_web_view;
+
+    i32 m_highest_notified_message_index { -1 };
+    i32 m_highest_received_message_index { -1 };
+    bool m_waiting_for_messages { false };
+
+    struct Group {
+        int id { 0 };
+        DeprecatedString label;
+    };
+    Vector<Group> m_group_stack;
+    int m_next_group_id { 1 };
+};
+
+}

--- a/Userland/Libraries/LibWebView/Forward.h
+++ b/Userland/Libraries/LibWebView/Forward.h
@@ -8,6 +8,7 @@
 
 namespace WebView {
 
+class ConsoleClient;
 class OutOfProcessWebView;
 class ViewImplementation;
 class WebContentClient;


### PR DESCRIPTION
This extracts the console functionality that is currently doubly implemented in the Serenity and Qt chromes (some of which the Qt chrome is missing) into a `WebView::ConsoleClient` class. This class handles all of the JS execution and message receiving, letting the chromes focus solely on their UI.

Then this adds such a UI to the AppKit chrome :^)

<img width="989" alt="Screenshot 2023-08-29 at 12 55 31 PM" src="https://github.com/SerenityOS/serenity/assets/5600524/31bf2702-fb13-4efb-b343-c5b2dc040f16">

<img width="993" alt="Screenshot 2023-08-29 at 1 02 03 PM" src="https://github.com/SerenityOS/serenity/assets/5600524/90127a8d-9f70-4a6f-bcb3-20fbb7d20223">
