### PR TITLE
find: Add the `-newer`, `-anewer` and `-cnewer` options

### DIFF
--- a/Base/usr/share/man/man1/find.md
+++ b/Base/usr/share/man/man1/find.md
@@ -52,6 +52,18 @@ space rounded up to the nearest whole unit.
 * `-writable`: Checks if the file is writable by the current user.
 * `-executable`: Checks if the file is executable, or directory is searchable,
 by the current user.
+* `-newer file`: Checks if the file last modification time is greater than that
+  of the specified reference file. If `file` is a symbolic link and the `-L`
+  option is in use, then the last modification time of the file pointed to by
+  the symbolic link is used.
+* `-anewer file`: Checks if the file last access time is greater than that of
+  the specified reference file. If `file` is a symbolic link and the `-L`
+  option is in use, then the last access time of the file pointed to by the
+  symbolic link is used.
+* `-cnewer file`: Checks if the file creation time is greater than that of
+  the specified reference file. If `file` is a symbolic link and the `-L`
+  option is in use, then the creation time of the file pointed to by the
+  symbolic link is used.
 * `-print`: Outputs the file path, followed by a newline. Always evaluates to
   true.
 * `-print0`: Outputs the file path, followed by a zero byte. Always evaluates to


### PR DESCRIPTION
These return true if the last modification time, last access time or creation time of a file is greater than the given reference file.

If the `-L` option is in use and the given reference file is a symbolic link then the timestamp of the file pointed to by the symbolic link will be used.

Example usage:

![find_newer](https://github.com/SerenityOS/serenity/assets/2817754/055325d9-555d-4dbb-84b3-ec8f37158523)

