### PR TITLE
LibJS: Avoid ToPropertyKey for spreading in PutByValue(WithThis)

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/Op.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Op.cpp
@@ -1593,36 +1593,40 @@ DeprecatedString SetLocal::to_deprecated_string_impl(Bytecode::Executable const&
     return DeprecatedString::formatted("SetLocal {}", m_index);
 }
 
+static StringView property_kind_to_string(PropertyKind kind)
+{
+    switch (kind) {
+    case PropertyKind::Getter:
+        return "getter"sv;
+    case PropertyKind::Setter:
+        return "setter"sv;
+    case PropertyKind::KeyValue:
+        return "key-value"sv;
+    case PropertyKind::DirectKeyValue:
+        return "direct-key-value"sv;
+    case PropertyKind::Spread:
+        return "spread"sv;
+    case PropertyKind::ProtoSetter:
+        return "proto-setter"sv;
+    }
+    VERIFY_NOT_REACHED();
+}
+
 DeprecatedString PutById::to_deprecated_string_impl(Bytecode::Executable const& executable) const
 {
-    auto kind = m_kind == PropertyKind::Getter
-        ? "getter"
-        : m_kind == PropertyKind::Setter
-        ? "setter"
-        : "property";
-
+    auto kind = property_kind_to_string(m_kind);
     return DeprecatedString::formatted("PutById kind:{} base:{}, property:{} ({})", kind, m_base, m_property, executable.identifier_table->get(m_property));
 }
 
 DeprecatedString PutByIdWithThis::to_deprecated_string_impl(Bytecode::Executable const& executable) const
 {
-    auto kind = m_kind == PropertyKind::Getter
-        ? "getter"
-        : m_kind == PropertyKind::Setter
-        ? "setter"
-        : "property";
-
+    auto kind = property_kind_to_string(m_kind);
     return DeprecatedString::formatted("PutByIdWithThis kind:{} base:{}, property:{} ({}) this_value:{}", kind, m_base, m_property, executable.identifier_table->get(m_property), m_this_value);
 }
 
 DeprecatedString PutPrivateById::to_deprecated_string_impl(Bytecode::Executable const& executable) const
 {
-    auto kind = m_kind == PropertyKind::Getter
-        ? "getter"
-        : m_kind == PropertyKind::Setter
-        ? "setter"
-        : "property";
-
+    auto kind = property_kind_to_string(m_kind);
     return DeprecatedString::formatted("PutPrivateById kind:{} base:{}, property:{} ({})", kind, m_base, m_property, executable.identifier_table->get(m_property));
 }
 
@@ -1837,23 +1841,13 @@ DeprecatedString GetByValueWithThis::to_deprecated_string_impl(Bytecode::Executa
 
 DeprecatedString PutByValue::to_deprecated_string_impl(Bytecode::Executable const&) const
 {
-    auto kind = m_kind == PropertyKind::Getter
-        ? "getter"
-        : m_kind == PropertyKind::Setter
-        ? "setter"
-        : "property";
-
+    auto kind = property_kind_to_string(m_kind);
     return DeprecatedString::formatted("PutByValue kind:{} base:{}, property:{}", kind, m_base, m_property);
 }
 
 DeprecatedString PutByValueWithThis::to_deprecated_string_impl(Bytecode::Executable const&) const
 {
-    auto kind = m_kind == PropertyKind::Getter
-        ? "getter"
-        : m_kind == PropertyKind::Setter
-        ? "setter"
-        : "property";
-
+    auto kind = property_kind_to_string(m_kind);
     return DeprecatedString::formatted("PutByValueWithThis kind:{} base:{}, property:{} this_value:{}", kind, m_base, m_property, m_this_value);
 }
 

--- a/Userland/Libraries/LibJS/Bytecode/Op.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Op.cpp
@@ -1183,7 +1183,7 @@ ThrowCompletionOr<void> PutByValue::execute_impl(Bytecode::Interpreter& interpre
 
     auto base = interpreter.reg(m_base);
 
-    auto property_key = TRY(interpreter.reg(m_property).to_property_key(vm));
+    auto property_key = m_kind != PropertyKind::Spread ? TRY(interpreter.reg(m_property).to_property_key(vm)) : PropertyKey {};
     TRY(put_by_property_key(vm, base, base, value, property_key, m_kind));
     interpreter.accumulator() = value;
     return {};
@@ -1198,7 +1198,7 @@ ThrowCompletionOr<void> PutByValueWithThis::execute_impl(Bytecode::Interpreter& 
 
     auto base = interpreter.reg(m_base);
 
-    auto property_key = TRY(interpreter.reg(m_property).to_property_key(vm));
+    auto property_key = m_kind != PropertyKind::Spread ? TRY(interpreter.reg(m_property).to_property_key(vm)) : PropertyKey {};
     TRY(put_by_property_key(vm, base, interpreter.reg(m_this_value), value, property_key, m_kind));
     interpreter.accumulator() = value;
     return {};

--- a/Userland/Libraries/LibJS/Tests/object-spread.js
+++ b/Userland/Libraries/LibJS/Tests/object-spread.js
@@ -144,7 +144,7 @@ describe("modification of spreadable objects during spread", () => {
         expect(Object.getOwnPropertyNames(result)).toContain("bar");
     });
 
-    test.xfail("spreading array", () => {
+    test("spreading array", () => {
         const array = [0];
         array[2] = 2;
         array[999] = 999;
@@ -191,4 +191,24 @@ test("allows assignment expressions", () => {
     expect("({ ...a ||= 'hello' })").toEval();
     expect("({ ...a ??= 'hello' })").toEval();
     expect("function* test() { return ({ ...yield a }); }").toEval();
+});
+
+test("spreading null-proto objects", () => {
+    const obj = {
+        __proto__: null,
+        hello: "world",
+        friends: "well hello",
+        toString() {
+            expect().fail("called toString()");
+        },
+        valueOf() {
+            expect().fail("called valueOf()");
+        },
+    };
+    let res;
+    expect(() => {
+        res = { ...obj };
+    }).not.toThrow();
+    expect(res).toHaveProperty("hello", "world");
+    expect(res).toHaveProperty("friends", "well hello");
 });


### PR DESCRIPTION
This is not we're supposed to do according to https://tc39.es/ecma262/#sec-runtime-semantics-propertydefinitionevaluation
Furthermore, this was observable by ToPrimitive looking up toString and
valueOf and potentially calling them if they exist. The big ticket
issue however is that for objects without toString and valueOf, such as
null-proto objects, this would unexpectedly throw.