### PR TITLE
LibJS: Allow assignment expression in spreading property definition

### DIFF
--- a/Userland/Libraries/LibJS/Parser.cpp
+++ b/Userland/Libraries/LibJS/Parser.cpp
@@ -1926,7 +1926,7 @@ NonnullRefPtr<ObjectExpression const> Parser::parse_object_expression()
 
         if (match(TokenType::TripleDot)) {
             consume();
-            property_key = parse_expression(4);
+            property_key = parse_expression(2);
             properties.append(create_ast_node<ObjectProperty>({ m_source_code, rule_start.position(), position() }, *property_key, nullptr, ObjectProperty::Type::Spread, false));
             if (!match(TokenType::Comma))
                 break;

--- a/Userland/Libraries/LibJS/Tests/builtins/Array/array-spread.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Array/array-spread.js
@@ -23,3 +23,23 @@ test("basic functionality", () => {
 
     expect([...[], ...[...[1, 2, 3]], 4]).toEqual([1, 2, 3, 4]);
 });
+
+test("allows assignment expressions", () => {
+    expect("([ ...a = { hello: 'world' } ])").toEval();
+    expect("([ ...a += 'hello' ])").toEval();
+    expect("([ ...a -= 'hello' ])").toEval();
+    expect("([ ...a **= 'hello' ])").toEval();
+    expect("([ ...a *= 'hello' ])").toEval();
+    expect("([ ...a /= 'hello' ])").toEval();
+    expect("([ ...a %= 'hello' ])").toEval();
+    expect("([ ...a <<= 'hello' ])").toEval();
+    expect("([ ...a >>= 'hello' ])").toEval();
+    expect("([ ...a >>>= 'hello' ])").toEval();
+    expect("([ ...a &= 'hello' ])").toEval();
+    expect("([ ...a ^= 'hello' ])").toEval();
+    expect("([ ...a |= 'hello' ])").toEval();
+    expect("([ ...a &&= 'hello' ])").toEval();
+    expect("([ ...a ||= 'hello' ])").toEval();
+    expect("([ ...a ??= 'hello' ])").toEval();
+    expect("function* test() { return ([ ...yield a ]); }").toEval();
+});

--- a/Userland/Libraries/LibJS/Tests/object-spread.js
+++ b/Userland/Libraries/LibJS/Tests/object-spread.js
@@ -172,3 +172,23 @@ describe("modification of spreadable objects during spread", () => {
         expect(arrayResult).toHaveProperty("1000", 1000);
     });
 });
+
+test("allows assignment expressions", () => {
+    expect("({ ...a = { hello: 'world' } })").toEval();
+    expect("({ ...a += 'hello' })").toEval();
+    expect("({ ...a -= 'hello' })").toEval();
+    expect("({ ...a **= 'hello' })").toEval();
+    expect("({ ...a *= 'hello' })").toEval();
+    expect("({ ...a /= 'hello' })").toEval();
+    expect("({ ...a %= 'hello' })").toEval();
+    expect("({ ...a <<= 'hello' })").toEval();
+    expect("({ ...a >>= 'hello' })").toEval();
+    expect("({ ...a >>>= 'hello' })").toEval();
+    expect("({ ...a &= 'hello' })").toEval();
+    expect("({ ...a ^= 'hello' })").toEval();
+    expect("({ ...a |= 'hello' })").toEval();
+    expect("({ ...a &&= 'hello' })").toEval();
+    expect("({ ...a ||= 'hello' })").toEval();
+    expect("({ ...a ??= 'hello' })").toEval();
+    expect("function* test() { return ({ ...yield a }); }").toEval();
+});


### PR DESCRIPTION
See: https://tc39.es/ecma262/#sec-runtime-semantics-propertydefinitionevaluation
PropertyDefinition : ... AssignmentExpression
Also add a test for this in array spreading, which already had this in place.