### PR TITLE
LibWeb: Reorder table row groups according to specification

### DIFF
--- a/Tests/LibWeb/Layout/expected/table/table-header-and-footer-groups.txt
+++ b/Tests/LibWeb/Layout/expected/table/table-header-and-footer-groups.txt
@@ -2,30 +2,30 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (1,1) content-size 798x216 [BFC] children: not-inline
     TableWrapper <(anonymous)> at (9,9) content-size 300x200 [BFC] children: not-inline
       Box <body.table> at (10,10) content-size 298x198 table-box [TFC] children: not-inline
-        Box <div.bottom> at (10,10) content-size 298x99 table-footer-group children: inline
+        Box <div.top> at (10,10) content-size 298x99 table-header-group children: inline
           Box <(anonymous)> at (10,10) content-size 298x99 table-row children: inline
             BlockContainer <(anonymous)> at (10,10) content-size 298x17.46875 table-cell [BFC] children: inline
-              line 0 width: 56.109375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                frag 0 from TextNode start: 0, length: 6, rect: [10,10 56.109375x17.46875]
-                  "bottom"
+              line 0 width: 26.640625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                frag 0 from TextNode start: 0, length: 3, rect: [10,10 26.640625x17.46875]
+                  "top"
               TextNode <#text>
-        Box <div.top> at (10,109) content-size 298x99 table-header-group children: inline
+        Box <div.bottom> at (10,109) content-size 298x99 table-footer-group children: inline
           Box <(anonymous)> at (10,109) content-size 298x99 table-row children: inline
             BlockContainer <(anonymous)> at (10,109) content-size 298x17.46875 table-cell [BFC] children: inline
-              line 0 width: 26.640625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                frag 0 from TextNode start: 0, length: 3, rect: [10,109 26.640625x17.46875]
-                  "top"
+              line 0 width: 56.109375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                frag 0 from TextNode start: 0, length: 6, rect: [10,109 56.109375x17.46875]
+                  "bottom"
               TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x218]
     PaintableWithLines (TableWrapper(anonymous)) [9,9 300x200]
       PaintableBox (Box<BODY>.table) [9,9 300x200]
-        PaintableBox (Box<DIV>.bottom) [10,10 298x99]
+        PaintableBox (Box<DIV>.top) [10,10 298x99]
           PaintableBox (Box(anonymous)) [10,10 298x99]
             PaintableWithLines (BlockContainer(anonymous)) [10,10 298x99]
               TextPaintable (TextNode<#text>)
-        PaintableBox (Box<DIV>.top) [10,109 298x99]
+        PaintableBox (Box<DIV>.bottom) [10,109 298x99]
           PaintableBox (Box(anonymous)) [10,109 298x99]
             PaintableWithLines (BlockContainer(anonymous)) [10,109 298x99]
               TextPaintable (TextNode<#text>)

--- a/Userland/Libraries/LibWeb/Layout/TreeBuilder.h
+++ b/Userland/Libraries/LibWeb/Layout/TreeBuilder.h
@@ -41,6 +41,7 @@ private:
     void generate_missing_child_wrappers(NodeWithStyle& root);
     Vector<JS::Handle<Box>> generate_missing_parents(NodeWithStyle& root);
     void missing_cells_fixup(Vector<JS::Handle<Box>> const&);
+    void reorder_row_groups(NodeWithStyle& root);
 
     enum class AppendOrPrepend {
         Append,


### PR DESCRIPTION
First table-header-group and table-footer-group have to be first and last, respectively, regardless of their order in the DOM.