### PR TITLE
LibWeb: Flesh out HTMLTextAreaElement

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Default.css
+++ b/Userland/Libraries/LibWeb/CSS/Default.css
@@ -38,7 +38,10 @@ input, textarea {
 textarea {
     padding: 2px;
     display: inline-block;
-    overflow: scroll;
+    overflow: auto;
+    font-family: monospace;
+    width: attr(cols ch, 20ch);
+    height: attr(rows lh, 2lh);
 }
 
 input[type=submit], input[type=button], input[type=reset], input[type=checkbox], input[type=radio] {

--- a/Userland/Libraries/LibWeb/DOM/Text.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Text.cpp
@@ -7,7 +7,6 @@
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/DOM/Range.h>
 #include <LibWeb/DOM/Text.h>
-#include <LibWeb/HTML/HTMLInputElement.h>
 #include <LibWeb/HTML/Scripting/Environments.h>
 #include <LibWeb/HTML/Window.h>
 #include <LibWeb/Layout/TextNode.h>
@@ -33,7 +32,7 @@ void Text::initialize(JS::Realm& realm)
 void Text::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(m_owner_input_element.ptr());
+    visitor.visit(dynamic_cast<JS::Cell*>(m_owner.ptr()));
 }
 
 // https://dom.spec.whatwg.org/#dom-text-text
@@ -42,11 +41,6 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Text>> Text::construct_impl(JS::Realm& real
     // The new Text(data) constructor steps are to set this’s data to data and this’s node document to current global object’s associated Document.
     auto& window = verify_cast<HTML::Window>(HTML::current_global_object());
     return realm.heap().allocate<Text>(realm, window.associated_document(), data);
-}
-
-void Text::set_owner_input_element(Badge<HTML::HTMLInputElement>, HTML::HTMLInputElement& input_element)
-{
-    m_owner_input_element = &input_element;
 }
 
 // https://dom.spec.whatwg.org/#dom-text-splittext

--- a/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
@@ -483,8 +483,8 @@ void BrowsingContext::did_edit(Badge<EditEventHandler>)
 
     if (m_cursor_position.node() && is<DOM::Text>(*m_cursor_position.node())) {
         auto& text_node = static_cast<DOM::Text&>(*m_cursor_position.node());
-        if (auto* input_element = text_node.owner_input_element())
-            input_element->did_edit_text_node({});
+        if (auto* text_node_owner = text_node.editable_text_node_owner())
+            text_node_owner->did_edit_text_node({});
     }
 }
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -13,7 +13,6 @@
 #include <LibWeb/DOM/ElementFactory.h>
 #include <LibWeb/DOM/Event.h>
 #include <LibWeb/DOM/ShadowRoot.h>
-#include <LibWeb/DOM/Text.h>
 #include <LibWeb/HTML/BrowsingContext.h>
 #include <LibWeb/HTML/EventNames.h>
 #include <LibWeb/HTML/HTMLDivElement.h>
@@ -504,7 +503,7 @@ void HTMLInputElement::create_shadow_tree_if_needed()
 
     m_placeholder_text_node = heap().allocate<DOM::Text>(realm(), document(), MUST(String::from_deprecated_string(initial_value)));
     m_placeholder_text_node->set_data(deprecated_attribute(HTML::AttributeNames::placeholder));
-    m_placeholder_text_node->set_owner_input_element({}, *this);
+    m_placeholder_text_node->set_editable_text_node_owner(Badge<HTMLInputElement> {}, *this);
     MUST(m_placeholder_element->append_child(*m_placeholder_text_node));
     MUST(element->append_child(*m_placeholder_element));
 
@@ -519,7 +518,7 @@ void HTMLInputElement::create_shadow_tree_if_needed()
         handle_readonly_attribute(deprecated_attribute(HTML::AttributeNames::readonly));
     }
 
-    m_text_node->set_owner_input_element({}, *this);
+    m_text_node->set_editable_text_node_owner(Badge<HTMLInputElement> {}, *this);
 
     if (m_type == TypeAttributeState::Password)
         m_text_node->set_is_password_input({}, true);

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <LibWeb/DOM/Text.h>
 #include <LibWeb/FileAPI/FileList.h>
 #include <LibWeb/HTML/FormAssociatedElement.h>
 #include <LibWeb/HTML/HTMLElement.h>
@@ -41,7 +42,8 @@ namespace Web::HTML {
 
 class HTMLInputElement final
     : public HTMLElement
-    , public FormAssociatedElement {
+    , public FormAssociatedElement
+    , public DOM::EditableTextNodeOwner {
     WEB_PLATFORM_OBJECT(HTMLInputElement, HTMLElement);
     FORM_ASSOCIATED_ELEMENT(HTMLElement, HTMLInputElement)
 
@@ -83,8 +85,6 @@ public:
 
     bool is_mutable() const { return m_is_mutable; }
 
-    void did_edit_text_node(Badge<BrowsingContext>);
-
     JS::GCPtr<FileAPI::FileList> files();
     void set_files(JS::GCPtr<FileAPI::FileList>);
 
@@ -100,6 +100,9 @@ public:
     WebIDL::ExceptionOr<void> set_selection_range(u32 start, u32 end, Optional<String> const& direction = {});
 
     WebIDL::ExceptionOr<void> show_picker();
+
+    // ^DOM::EditableTextNodeOwner
+    virtual void did_edit_text_node(Badge<BrowsingContext>) override;
 
     // ^EventTarget
     // https://html.spec.whatwg.org/multipage/interaction.html#the-tabindex-attribute:the-input-element

--- a/Userland/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
@@ -1,25 +1,73 @@
 /*
  * Copyright (c) 2020, the SerenityOS developers.
+ * Copyright (c) 2023, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/CSS/StyleProperties.h>
+#include <LibWeb/CSS/StyleValues/DisplayStyleValue.h>
+#include <LibWeb/DOM/Document.h>
+#include <LibWeb/DOM/ElementFactory.h>
+#include <LibWeb/DOM/Event.h>
+#include <LibWeb/DOM/ShadowRoot.h>
+#include <LibWeb/DOM/Text.h>
 #include <LibWeb/HTML/HTMLTextAreaElement.h>
+#include <LibWeb/Namespace.h>
 
 namespace Web::HTML {
 
 HTMLTextAreaElement::HTMLTextAreaElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : HTMLElement(document, move(qualified_name))
+    , m_raw_value(DeprecatedString::empty())
 {
 }
 
 HTMLTextAreaElement::~HTMLTextAreaElement() = default;
 
+JS::GCPtr<Layout::Node> HTMLTextAreaElement::create_layout_node(NonnullRefPtr<CSS::StyleProperties> style)
+{
+    // AD-HOC: We rewrite `display: inline` to `display: inline-block`.
+    //         This is required for the internal shadow tree to work correctly in layout.
+    if (style->display().is_inline_outside() && style->display().is_flow_inside())
+        style->set_property(CSS::PropertyID::Display, CSS::DisplayStyleValue::create(CSS::Display::from_short(CSS::Display::Short::InlineBlock)));
+
+    return Element::create_layout_node_for_display_type(document(), style->display(), style, this);
+}
+
 void HTMLTextAreaElement::initialize(JS::Realm& realm)
 {
     Base::initialize(realm);
     set_prototype(&Bindings::ensure_web_prototype<Bindings::HTMLTextAreaElementPrototype>(realm, "HTMLTextAreaElement"));
+}
+
+void HTMLTextAreaElement::visit_edges(Cell::Visitor& visitor)
+{
+    Base::visit_edges(visitor);
+    visitor.visit(m_inner_text_element);
+    visitor.visit(m_text_node);
+}
+
+void HTMLTextAreaElement::did_receive_focus()
+{
+    auto* browsing_context = document().browsing_context();
+    if (!browsing_context)
+        return;
+    if (!m_text_node)
+        return;
+    browsing_context->set_cursor_position(DOM::Position { *m_text_node, 0 });
+}
+
+void HTMLTextAreaElement::did_lose_focus()
+{
+    // The change event fires when the value is committed, if that makes sense for the control,
+    // or else when the control loses focus
+    queue_an_element_task(HTML::Task::Source::UserInteraction, [this] {
+        auto change_event = DOM::Event::create(realm(), HTML::EventNames::change);
+        change_event->set_bubbles(true);
+        dispatch_event(change_event);
+    });
 }
 
 // https://html.spec.whatwg.org/multipage/interaction.html#dom-tabindex
@@ -32,7 +80,54 @@ i32 HTMLTextAreaElement::default_tab_index_value() const
 // https://html.spec.whatwg.org/multipage/form-elements.html#the-textarea-element:concept-form-reset-control
 void HTMLTextAreaElement::reset_algorithm()
 {
-    // FIXME: The reset algorithm for textarea elements is to set the dirty value flag back to false, and set the raw value of element to its child text content.
+    // The reset algorithm for textarea elements is to set the dirty value flag back to false,
+    m_dirty = false;
+    // and set the raw value of element to its child text content.
+    m_raw_value = child_text_content();
+}
+
+void HTMLTextAreaElement::form_associated_element_was_inserted()
+{
+    create_shadow_tree_if_needed();
+}
+
+void HTMLTextAreaElement::create_shadow_tree_if_needed()
+{
+    if (shadow_root_internal())
+        return;
+
+    auto shadow_root = heap().allocate<DOM::ShadowRoot>(realm(), document(), *this, Bindings::ShadowRootMode::Closed);
+    auto element = MUST(DOM::create_element(document(), HTML::TagNames::div, Namespace::HTML));
+
+    m_inner_text_element = MUST(DOM::create_element(document(), HTML::TagNames::div, Namespace::HTML));
+
+    // NOTE: The text content of the <textarea> element is not available to us yet.
+    //       It gets filled in by `children_changed()`.
+    m_text_node = heap().allocate<DOM::Text>(realm(), document(), String {});
+    m_text_node->set_always_editable(true);
+    m_text_node->set_editable_text_node_owner(Badge<HTMLTextAreaElement> {}, *this);
+
+    MUST(m_inner_text_element->append_child(*m_text_node));
+    MUST(element->append_child(*m_inner_text_element));
+    MUST(shadow_root->append_child(element));
+    set_shadow_root(shadow_root);
+}
+
+// https://html.spec.whatwg.org/multipage/form-elements.html#the-textarea-element:children-changed-steps
+void HTMLTextAreaElement::children_changed()
+{
+    // The children changed steps for textarea elements must, if the element's dirty value flag is false,
+    // set the element's raw value to its child text content.
+    if (!m_dirty) {
+        m_raw_value = child_text_content();
+        m_text_node->set_text_content(m_raw_value);
+    }
+}
+
+void HTMLTextAreaElement::did_edit_text_node(Badge<Web::HTML::BrowsingContext>)
+{
+    // A textarea element's dirty value flag must be set to true whenever the user interacts with the control in a way that changes the raw value.
+    m_dirty = true;
 }
 
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLTextAreaElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTextAreaElement.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <LibWeb/ARIA/Roles.h>
+#include <LibWeb/DOM/Text.h>
 #include <LibWeb/HTML/FormAssociatedElement.h>
 #include <LibWeb/HTML/HTMLElement.h>
 
@@ -15,12 +16,15 @@ namespace Web::HTML {
 
 class HTMLTextAreaElement final
     : public HTMLElement
-    , public FormAssociatedElement {
+    , public FormAssociatedElement
+    , public DOM::EditableTextNodeOwner {
     WEB_PLATFORM_OBJECT(HTMLTextAreaElement, HTMLElement);
     FORM_ASSOCIATED_ELEMENT(HTMLElement, HTMLTextAreaElement)
 
 public:
     virtual ~HTMLTextAreaElement() override;
+
+    virtual JS::GCPtr<Layout::Node> create_layout_node(NonnullRefPtr<CSS::StyleProperties>) override;
 
     DeprecatedString const& type() const
     {
@@ -28,9 +32,14 @@ public:
         return textarea;
     }
 
+    // ^DOM::EditableTextNodeOwner
+    virtual void did_edit_text_node(Badge<BrowsingContext>) override;
+
     // ^EventTarget
     // https://html.spec.whatwg.org/multipage/interaction.html#the-tabindex-attribute:the-textarea-element
     virtual bool is_focusable() const override { return true; }
+    virtual void did_lose_focus() override;
+    virtual void did_receive_focus() override;
 
     // ^FormAssociatedElement
     // https://html.spec.whatwg.org/multipage/forms.html#category-listed
@@ -51,6 +60,10 @@ public:
 
     virtual void reset_algorithm() override;
 
+    virtual void form_associated_element_was_inserted() override;
+
+    virtual void children_changed() override;
+
     // https://www.w3.org/TR/html-aria/#el-textarea
     virtual Optional<ARIA::Role> default_role() const override { return ARIA::Role::textbox; }
 
@@ -58,9 +71,18 @@ private:
     HTMLTextAreaElement(DOM::Document&, DOM::QualifiedName);
 
     virtual void initialize(JS::Realm&) override;
+    virtual void visit_edges(Cell::Visitor&) override;
 
     // ^DOM::Element
     virtual i32 default_tab_index_value() const override;
+
+    void create_shadow_tree_if_needed();
+
+    JS::GCPtr<DOM::Element> m_inner_text_element;
+    JS::GCPtr<DOM::Text> m_text_node;
+
+    bool m_dirty { false };
+    DeprecatedString m_raw_value;
 };
 
 }


### PR DESCRIPTION
This makes `<textarea>` actually editable by giving it a shadow tree. It's still lacking a lot but it's still a step forward and I've just been distracted by a CSS feature that would make the `rows` and `cols` attributes a lot nicer to implement, so submitting this now.