### PR TITLE
Kernel: Move m_uid and m_gid from the Device class to SlavePTY

### DIFF
--- a/Kernel/Devices/Device.h
+++ b/Kernel/Devices/Device.h
@@ -45,9 +45,6 @@ public:
     virtual ErrorOr<NonnullOwnPtr<KString>> pseudo_path(OpenFileDescription const&) const override;
     virtual ErrorOr<NonnullRefPtr<OpenFileDescription>> open(int options) override;
 
-    UserID uid() const { return m_uid; }
-    GroupID gid() const { return m_gid; }
-
     virtual bool is_device() const override { return true; }
     virtual void will_be_destroyed() override;
     virtual ErrorOr<void> after_inserting();
@@ -68,8 +65,6 @@ public:
 
 protected:
     Device(MajorNumber major, MinorNumber minor);
-    void set_uid(UserID uid) { m_uid = uid; }
-    void set_gid(GroupID gid) { m_gid = gid; }
 
     void after_inserting_add_to_device_management();
     void before_will_be_destroyed_remove_from_device_management();
@@ -85,8 +80,6 @@ protected:
 private:
     MajorNumber const m_major { 0 };
     MinorNumber const m_minor { 0 };
-    UserID m_uid { 0 };
-    GroupID m_gid { 0 };
 
     State m_state { State::Normal };
 

--- a/Kernel/FileSystem/DevPtsFS/FileSystem.cpp
+++ b/Kernel/FileSystem/DevPtsFS/FileSystem.cpp
@@ -53,11 +53,12 @@ ErrorOr<NonnullRefPtr<Inode>> DevPtsFS::get_inode(InodeIdentifier inode_id) cons
     auto* device = DeviceManagement::the().get_device(201, pty_index);
     VERIFY(device);
 
-    auto inode = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) DevPtsFSInode(const_cast<DevPtsFS&>(*this), inode_id.index(), static_cast<SlavePTY*>(device))));
+    auto* pts_device = static_cast<SlavePTY*>(device);
+    auto inode = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) DevPtsFSInode(const_cast<DevPtsFS&>(*this), inode_id.index(), pts_device)));
     inode->m_metadata.inode = inode_id;
     inode->m_metadata.size = 0;
-    inode->m_metadata.uid = device->uid();
-    inode->m_metadata.gid = device->gid();
+    inode->m_metadata.uid = pts_device->uid();
+    inode->m_metadata.gid = pts_device->gid();
     inode->m_metadata.mode = 0020600;
     inode->m_metadata.major_device = device->major();
     inode->m_metadata.minor_device = device->minor();

--- a/Kernel/TTY/SlavePTY.cpp
+++ b/Kernel/TTY/SlavePTY.cpp
@@ -35,17 +35,14 @@ bool SlavePTY::unref() const
     return did_hit_zero;
 }
 
-SlavePTY::SlavePTY(NonnullRefPtr<MasterPTY> master, unsigned index)
+SlavePTY::SlavePTY(NonnullRefPtr<MasterPTY> master, UserID uid, GroupID gid, unsigned index)
     : TTY(201, index)
     , m_master(move(master))
     , m_index(index)
+    , m_uid(uid)
+    , m_gid(gid)
 {
-    auto& process = Process::current();
-    auto credentials = process.credentials();
-    set_uid(credentials->uid());
-    set_gid(credentials->gid());
     set_size(80, 25);
-
     SlavePTY::all_instances().with([&](auto& list) { list.append(*this); });
 }
 

--- a/Kernel/TTY/SlavePTY.h
+++ b/Kernel/TTY/SlavePTY.h
@@ -25,6 +25,9 @@ public:
 
     virtual FileBlockerSet& blocker_set() override;
 
+    UserID uid() const { return m_uid; }
+    GroupID gid() const { return m_gid; }
+
 private:
     // ^Device
     virtual bool is_openable_by_jailed_processes() const override { return true; }
@@ -42,11 +45,14 @@ private:
     virtual ErrorOr<void> close() override;
 
     friend class MasterPTY;
-    SlavePTY(NonnullRefPtr<MasterPTY>, unsigned index);
+    SlavePTY(NonnullRefPtr<MasterPTY>, UserID, GroupID, unsigned index);
 
     NonnullRefPtr<MasterPTY> const m_master;
     UnixDateTime m_time_of_last_write {};
     unsigned m_index { 0 };
+
+    UserID const m_uid { 0 };
+    GroupID const m_gid { 0 };
 
     mutable IntrusiveListNode<SlavePTY> m_list_node;
 


### PR DESCRIPTION
No other device needs to store the UID/GID of the process that created them, so only store these values within the SlavePTY class.