### PR TITLE
LibWeb: Improve spec alignment around integer parsing

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -71,6 +71,7 @@
 #include <LibWeb/HTML/MessageEvent.h>
 #include <LibWeb/HTML/Navigable.h>
 #include <LibWeb/HTML/NavigationParams.h>
+#include <LibWeb/HTML/Numbers.h>
 #include <LibWeb/HTML/Origin.h>
 #include <LibWeb/HTML/Parser/HTMLParser.h>
 #include <LibWeb/HTML/Scripting/ClassicScript.h>
@@ -3371,8 +3372,7 @@ void Document::shared_declarative_refresh_steps(StringView input, JS::GCPtr<HTML
     }
 
     // 7. Otherwise, set time to the result of parsing timeString using the rules for parsing non-negative integers.
-    // FIXME: Not sure if this exactly matches the spec's "rules for parsing non-negative integers".
-    auto maybe_time = time_string.to_uint<u32>();
+    auto maybe_time = Web::HTML::parse_non_negative_integer(time_string);
 
     // FIXME: Since we only collected ASCII digits, this can only fail because of overflow. What do we do when that happens? For now, default to 0.
     if (maybe_time.has_value() && maybe_time.value() < NumericLimits<int>::max() && !Checked<int>::multiplication_would_overflow(static_cast<int>(maybe_time.value()), 1000)) {

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -47,6 +47,7 @@
 #include <LibWeb/HTML/HTMLSelectElement.h>
 #include <LibWeb/HTML/HTMLStyleElement.h>
 #include <LibWeb/HTML/HTMLTextAreaElement.h>
+#include <LibWeb/HTML/Numbers.h>
 #include <LibWeb/HTML/Parser/HTMLParser.h>
 #include <LibWeb/HTML/Window.h>
 #include <LibWeb/Infra/CharacterTypes.h>
@@ -903,8 +904,8 @@ i32 Element::default_tab_index_value() const
 // https://html.spec.whatwg.org/multipage/interaction.html#dom-tabindex
 i32 Element::tab_index() const
 {
-    // FIXME: I'm not sure if "to_int" exactly matches the specs "rules for parsing integers"
-    auto maybe_table_index = attribute(HTML::AttributeNames::tabindex).to_int<i32>();
+    auto maybe_table_index = Web::HTML::parse_integer(attribute(HTML::AttributeNames::tabindex));
+
     if (!maybe_table_index.has_value())
         return default_tab_index_value();
     return maybe_table_index.value();


### PR DESCRIPTION
We now have functions for parsing integers in an HTML spec-compliant way. This PR gets rid of two FIXME comments.