### PR TITLE
LibWeb: Stub out contenteditable plaintext-only state

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/HTMLElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLElement.h
@@ -80,9 +80,11 @@ private:
     // ^HTML::GlobalEventHandlers
     virtual DOM::EventTarget& global_event_handlers_to_event_target(FlyString const&) override { return *this; }
 
+    // https://html.spec.whatwg.org/multipage/interaction.html#attr-contenteditable
     enum class ContentEditableState {
         True,
         False,
+        PlaintextOnly,
         Inherit,
     };
     ContentEditableState m_content_editable_state { ContentEditableState::Inherit };


### PR DESCRIPTION
I was looking at trying to get readonly attribute working for the HTMLInputElement, and happened to stumble across that this was not present for the contenteditable attribute.

After digging into this some more, it only seems semi-standardized, and the main reference I can spot for it is here:

https://w3c.github.io/editing/docs/execCommand/#editable

By that stage, I had already stubbed out support for it. For now, just allow this state to be set, but don't do anything with it yet.