### PR TITLE
Toolchian: Add nix flake; Fix nix build deps

### DIFF
--- a/Documentation/BuildInstructionsOther.md
+++ b/Documentation/BuildInstructionsOther.md
@@ -39,6 +39,18 @@ or you can use the nix flake [`Toolchain/flake.nix`](../Toolchain/serenity.nix) 
 nix develop Toolchain
 ```
 
+You can also save this environment to a profile:
+
+```
+nix develop Toolchain --profile Toolchain/nix-profiles/dev 
+```
+
+and resume later with:
+
+```
+nix develop Toolchain/nix-profiles/dev
+```
+
 ## Alpine Linux
 
 First, make sure you have enabled the `community` repository in `/etc/apk/repositories` and run `apk update`. It has been tested on `edge`, YMMV on `stable`.

--- a/Documentation/BuildInstructionsOther.md
+++ b/Documentation/BuildInstructionsOther.md
@@ -33,6 +33,12 @@ You can use the `nix-shell` script [`Toolchain/serenity.nix`](../Toolchain/seren
 nix-shell Toolchain/serenity.nix
 ```
 
+or you can use the nix flake [`Toolchain/flake.nix`](../Toolchain/serenity.nix) instead:
+
+```console
+nix develop Toolchain
+```
+
 ## Alpine Linux
 
 First, make sure you have enabled the `community` repository in `/etc/apk/repositories` and run `apk update`. It has been tested on `edge`, YMMV on `stable`.

--- a/Toolchain/.gitignore
+++ b/Toolchain/.gitignore
@@ -3,3 +3,5 @@ config-temp
 config.log
 # For caching the entire toolchain (useful on Travis)
 Cache/
+# Nix profiles can be stored here
+nix-profiles/

--- a/Toolchain/flake.lock
+++ b/Toolchain/flake.lock
@@ -1,0 +1,60 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1692799911,
+        "narHash": "sha256-3eihraek4qL744EvQXsK1Ha6C3CR7nnT8X2qWap4RNk=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "f9e7cf818399d17d347f847525c5a5a8032e4e44",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1693485768,
+        "narHash": "sha256-PxqYECiPBBbavaPjnf/v2rlzp2Xoe/JPA7rl1WxGe0A=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c106712dc7a447db0c8a654162c3a0557909dfd6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/Toolchain/flake.nix
+++ b/Toolchain/flake.nix
@@ -1,0 +1,20 @@
+{
+  description = "Serenity OS";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+  outputs = { self, flake-utils, nixpkgs }:
+
+    flake-utils.lib.eachDefaultSystem
+      (system:
+        let pkgs = nixpkgs.legacyPackages.${system}; in
+        {
+          formatter = pkgs.nixpkgs-fmt;
+          devShells.default = import ./serenity.nix { inherit pkgs; };
+        }
+      );
+
+
+}

--- a/Toolchain/serenity.nix
+++ b/Toolchain/serenity.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation {
     openssl
     parted
     qemu
-    xlibsWrapper
+    python3
   ];
 
   hardeningDisable = [ "format" "fortify" ];


### PR DESCRIPTION
Add a nix flake to `Toolchain/` that wraps the existing nix derivation
`Toolchain/serenity.nix`. This also comes with a lockfile making the nix
developer enviornment setup more reproducible.

We also update the documentation for "other builds" to mention the
flake.

xlibswrapper is removed from `Toolchain/serenity.nix` as it is a
wrapper package and has been deprecated. We don't use it in the build
anyway.

This fixes https://github.com/SerenityOS/serenity/issues/19286

During the build, python3 is required so we add `python3` as a build
dependency.
