### PR TITLE
Kernel/USB: Add a crude USB MassStorage driver :^)

### DIFF
--- a/Kernel/Bus/USB/Drivers/MassStorage/MassStorageDriver.cpp
+++ b/Kernel/Bus/USB/Drivers/MassStorage/MassStorageDriver.cpp
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2023, Leon Albrecht <leon.a@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Find.h>
+#include <Kernel/Bus/USB/Drivers/MassStorage/MassStorageDriver.h>
+#include <Kernel/Bus/USB/USBClasses.h>
+#include <Kernel/Bus/USB/USBEndpoint.h>
+#include <Kernel/Bus/USB/USBRequest.h>
+#include <Kernel/Devices/DeviceManagement.h>
+#include <Kernel/Devices/Storage/StorageManagement.h>
+#include <Kernel/Devices/Storage/USB/BulkSCSIInterface.h>
+#include <Kernel/Devices/Storage/USB/Codes.h>
+#include <Kernel/Devices/Storage/USB/SCSIComands.h>
+
+namespace Kernel::USB {
+
+using namespace MassStorage;
+
+USB_DEVICE_DRIVER(MassStorageDriver);
+
+void MassStorageDriver::init()
+{
+    auto driver = MUST(adopt_nonnull_lock_ref_or_enomem(new MassStorageDriver()));
+    USBManagement::the().register_driver(driver);
+}
+
+ErrorOr<void> MassStorageDriver::checkout_interface(USB::Device& device, USBInterface const& interface)
+{
+    auto const& descriptor = interface.descriptor();
+
+    if (descriptor.interface_class_code != USB_CLASS_MASS_STORAGE)
+        return ENOTSUP;
+
+    dmesgln("USB MassStorage Interface for device {}:{} found:", device.device_descriptor().vendor_id, device.device_descriptor().product_id);
+    dmesgln("    Subclass: {} [{:#02x}]", MassStorage::subclass_string((SubclassCode)descriptor.interface_sub_class_code), descriptor.interface_sub_class_code);
+    dmesgln("    Protocol: {} [{:#02x}]", MassStorage::transport_protocol_string((TransportProtocol)descriptor.interface_protocol), descriptor.interface_protocol);
+
+    // FIXME: Find a nice way of handling multiple device subclasses and protocols
+    if (descriptor.interface_protocol == to_underlying(TransportProtocol::BBB))
+        return initialise_bulk_only_device(device, interface);
+
+    return ENOTSUP;
+}
+
+ErrorOr<void> MassStorageDriver::probe(USB::Device& device)
+{
+    // USB massbulk Table 4.1:
+    if (device.device_descriptor().device_class != USB_CLASS_DEVICE
+        || device.device_descriptor().device_sub_class != 0x00
+        || device.device_descriptor().device_protocol != 0x00)
+        return ENOTSUP;
+
+    for (auto const& config : device.configurations()) {
+        // FIXME: There might be multiple MassStorage configs present,
+        //        figure out how to decide which one to take,
+        //        although that's very unlikely
+        bool has_accepted_an_interface = false;
+        for (auto const& interface : config.interfaces()) {
+            // FIXME: Handle multiple interfaces
+            //        Interface may coexist at the same time,
+            //        but having multiple handles on the same data storage seems like a bad idea,
+            //        so:
+            // FIXME: Choose the best supported interface
+            //        UAS for example is supposed to be better than BBB, but BBB will always
+            //        be the first listed interface of them, when both are supported
+            auto result = checkout_interface(device, interface);
+            if (result.is_error())
+                continue;
+
+            has_accepted_an_interface = true;
+        }
+
+        if (has_accepted_an_interface)
+            return {};
+    }
+
+    return ENOTSUP;
+}
+
+ErrorOr<void> MassStorageDriver::initialise_bulk_only_device(USB::Device& device, USBInterface const& interface)
+{
+    auto const& descriptor = interface.descriptor();
+    auto const& configuration = interface.configuration();
+
+    if (descriptor.interface_sub_class_code != to_underlying(MassStorage::SubclassCode::SCSI_transparent))
+        return ENOTSUP;
+
+    TRY(device.control_transfer(
+        USB_REQUEST_RECIPIENT_DEVICE | USB_REQUEST_TYPE_STANDARD | USB_REQUEST_TRANSFER_DIRECTION_HOST_TO_DEVICE,
+        USB_REQUEST_SET_CONFIGURATION, configuration.configuration_id(), 0, 0, nullptr));
+
+    u8 max_luns;
+    TRY(device.control_transfer(
+        USB_REQUEST_TYPE_CLASS | USB_REQUEST_RECIPIENT_INTERFACE | USB_REQUEST_TRANSFER_DIRECTION_DEVICE_TO_HOST,
+        to_underlying(MassStorage::RequestCodes::GetMaxLun), 0, interface.descriptor().interface_id, 1, &max_luns));
+    // FIXME: Devices that do not support multiple LUNs may STALL this command
+    // FIXME: Support multiple LUNs
+    if (max_luns != 0)
+        dmesgln("SCSI/BBB: WARNING: USB Mass Storage Device supports multiple LUNs ({}) only targetting first LUN", max_luns);
+
+    u8 in_pipe_address = 0xff;
+    u8 in_max_packet_size;
+    u8 out_pipe_address = 0xff;
+    u8 out_max_packet_size;
+
+    if (interface.descriptor().number_of_endpoints < 2) {
+        dmesgln("SCSI/BBB: Interface does not provide enough endpoints for advertised Bulk-only transfer protocol; Rejecting");
+        return ENOTSUP;
+    }
+
+    for (auto const& endpoint : interface.endpoints()) {
+        if (endpoint.endpoint_attributes_bitmap != USBEndpoint::ENDPOINT_ATTRIBUTES_TRANSFER_TYPE_BULK)
+            continue;
+        // The upper bit of the Endpoint address is set to 1, iff it is the Bulk-In Endpoint
+        if (endpoint.endpoint_address & 0x80) {
+            in_pipe_address = endpoint.endpoint_address & 0b1111;
+            in_max_packet_size = endpoint.max_packet_size;
+        } else {
+            out_pipe_address = endpoint.endpoint_address & 0b1111;
+            out_max_packet_size = endpoint.max_packet_size;
+        }
+    }
+    if (in_pipe_address == 0xff || out_pipe_address == 0xff) {
+        dmesgln("SCSI/BBB: Interface did not advertise two Bulk Endpoints; Rejecting");
+        return ENOTSUP;
+    }
+
+    auto in_pipe = TRY(BulkInPipe::create(device.controller(), in_pipe_address, in_max_packet_size, device.address()));
+    auto out_pipe = TRY(BulkOutPipe::create(device.controller(), out_pipe_address, out_max_packet_size, device.address()));
+
+    CommandBlockWrapper command_block {};
+    command_block.set_command(SCSI::ReadCapacity10 {});
+    command_block.transfer_length = sizeof(SCSI::ReadCapacity10Parameters);
+    command_block.direction = CBWDirection::DataIn;
+    TRY(out_pipe->submit_bulk_out_transfer(31, &command_block));
+
+    SCSI::ReadCapacity10Parameters capacity;
+    TRY(in_pipe->submit_bulk_in_transfer(sizeof(capacity), &capacity));
+    // FIXME: Handle Stalling
+    CommandStatusWrapper status;
+    TRY(in_pipe->submit_bulk_in_transfer(sizeof(status), &status));
+    if (status.status != CSWStatus::Passed) {
+        dmesgln("SCSI/BBB: Failed to query USB Drive capacity; Rejecting");
+        return ENOTSUP;
+    }
+
+    dmesgln("    Block Size: {}B", capacity.block_size);
+    dmesgln("    Block Count: {}", capacity.block_count);
+    dmesgln("    Total Size: {}MiB", (u64)capacity.block_size * capacity.block_count / MiB);
+
+    StorageDevice::LUNAddress lun = {
+        device.controller().storage_controller_id(),
+        device.address(),
+        // FIXME: Again, support multiple LUNs per device
+        0
+    };
+
+    auto bulk_scsi_interface = TRY(DeviceManagement::try_create_device<BulkSCSIInterface>(
+        lun,
+        device.address(), // FIXME: Figure out a better ID to put here
+        capacity.block_size,
+        capacity.block_count,
+        device,
+        move(in_pipe),
+        move(out_pipe)));
+
+    m_interfaces.append(bulk_scsi_interface);
+    StorageManagement::the().add_device(bulk_scsi_interface);
+
+    return {};
+}
+
+void MassStorageDriver::detach(USB::Device& device)
+{
+    auto&& interface = AK::find_if(m_interfaces.begin(), m_interfaces.end(), [&device](auto& interface) { return &interface.device() == &device; });
+
+    StorageManagement::the().remove_device(*interface);
+    m_interfaces.remove(*interface);
+}
+
+}

--- a/Kernel/Bus/USB/Drivers/MassStorage/MassStorageDriver.h
+++ b/Kernel/Bus/USB/Drivers/MassStorage/MassStorageDriver.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2023, Leon Albrecht <leon.a@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <Kernel/Bus/USB/Drivers/USBDriver.h>
+#include <Kernel/Bus/USB/USBInterface.h>
+#include <Kernel/Bus/USB/USBManagement.h>
+#include <Kernel/Devices/Storage/USB/BulkSCSIInterface.h>
+
+namespace Kernel::USB {
+
+class MassStorageDriver final : public Driver {
+public:
+    MassStorageDriver()
+        : Driver("USB MassStorage"sv)
+    {
+    }
+
+    static void init();
+
+    virtual ~MassStorageDriver() override = default;
+
+    virtual ErrorOr<void> probe(USB::Device&) override;
+    virtual void detach(USB::Device&) override;
+
+private:
+    BulkSCSIInterface::List m_interfaces;
+
+    ErrorOr<void> checkout_interface(USB::Device&, USBInterface const&);
+
+    ErrorOr<void> initialise_bulk_only_device(USB::Device&, USBInterface const&);
+};
+
+}

--- a/Kernel/Bus/USB/USBClasses.h
+++ b/Kernel/Bus/USB/USBClasses.h
@@ -11,6 +11,7 @@
 namespace Kernel::USB {
 
 // https://www.usb.org/defined-class-codes
+static constexpr u8 USB_CLASS_DEVICE = 0x00;
 static constexpr u8 USB_CLASS_AUDIO = 0x01;
 static constexpr u8 USB_CLASS_COMMUNICATIONS_AND_CDC_CONTROL = 0x02;
 static constexpr u8 USB_CLASS_HID = 0x03;

--- a/Kernel/Bus/USB/USBController.cpp
+++ b/Kernel/Bus/USB/USBController.cpp
@@ -5,8 +5,14 @@
  */
 
 #include <Kernel/Bus/USB/USBController.h>
+#include <Kernel/Devices/Storage/StorageManagement.h>
 
 namespace Kernel::USB {
+
+USBController::USBController()
+    : m_storage_controller_id(StorageManagement::generate_controller_id())
+{
+}
 
 u8 USBController::allocate_address()
 {

--- a/Kernel/Bus/USB/USBController.h
+++ b/Kernel/Bus/USB/USBController.h
@@ -28,9 +28,18 @@ public:
     virtual ErrorOr<size_t> submit_bulk_transfer(Transfer& transfer) = 0;
     virtual ErrorOr<void> submit_async_interrupt_transfer(NonnullLockRefPtr<Transfer> transfer, u16 ms_interval) = 0;
 
+    u32 storage_controller_id() const { return m_storage_controller_id; }
     u8 allocate_address();
 
+protected:
+    USBController();
+
 private:
+    // Note: We are pseudo storage controller for the sake of generating LUNs
+    //       And do not follow a hardware_relative_controller_id for the controller class "USB",
+    //       as we also have to follow the device id and its internal LUN, leaving no room for that
+    u32 m_storage_controller_id { 0 };
+
     u8 m_next_device_index { 1 };
 
     IntrusiveListNode<USBController, NonnullLockRefPtr<USBController>> m_controller_list_node;

--- a/Kernel/Bus/USB/USBDevice.cpp
+++ b/Kernel/Bus/USB/USBDevice.cpp
@@ -69,6 +69,7 @@ Device::Device(Device const& device, NonnullOwnPtr<ControlPipe> default_pipe)
     , m_device_speed(device.speed())
     , m_address(device.address())
     , m_device_descriptor(device.device_descriptor())
+    , m_configurations(device.configurations())
     , m_controller(device.controller())
     , m_default_pipe(move(default_pipe))
 {

--- a/Kernel/Bus/USB/USBHub.cpp
+++ b/Kernel/Bus/USB/USBHub.cpp
@@ -72,7 +72,7 @@ ErrorOr<void> Hub::enumerate_and_power_on_hub()
     if constexpr (USB_DEBUG) {
         dbgln("USB Hub Descriptor for {:04x}:{:04x}", m_vendor_id, m_product_id);
         dbgln("Number of Downstream Ports: {}", descriptor.number_of_downstream_ports);
-        dbgln("Hub Characteristics: 0x{:04x}", descriptor.hub_characteristics);
+        dbgln("Hub Characteristics: 0x{:04x}", static_cast<u16>(descriptor.hub_characteristics));
         dbgln("Power On to Power Good Time: {} ms ({} * 2ms)", descriptor.power_on_to_power_good_time * 2, descriptor.power_on_to_power_good_time);
         dbgln("Hub Controller Current: {} mA", descriptor.hub_controller_current);
     }

--- a/Kernel/Bus/USB/USBInterface.h
+++ b/Kernel/Bus/USB/USBInterface.h
@@ -16,10 +16,10 @@ class USBConfiguration;
 class USBInterface final {
 public:
     USBInterface() = delete;
-    USBInterface(USBConfiguration const& configuration, USBInterfaceDescriptor const descriptor, Vector<USBEndpointDescriptor> const& endpoint_descriptors)
+    USBInterface(USBConfiguration const& configuration, USBInterfaceDescriptor const descriptor, Vector<USBEndpointDescriptor> endpoint_descriptors)
         : m_configuration(configuration)
         , m_descriptor(descriptor)
-        , m_endpoint_descriptors(endpoint_descriptors)
+        , m_endpoint_descriptors(move(endpoint_descriptors))
     {
         m_endpoint_descriptors.ensure_capacity(descriptor.number_of_endpoints);
     }

--- a/Kernel/Bus/USB/USBInterface.h
+++ b/Kernel/Bus/USB/USBInterface.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/Vector.h>
+#include <Kernel/Bus/USB/USBDescriptors.h>
 
 namespace Kernel::USB {
 

--- a/Kernel/Bus/USB/USBPipe.h
+++ b/Kernel/Bus/USB/USBPipe.h
@@ -94,6 +94,7 @@ public:
     static ErrorOr<NonnullOwnPtr<BulkInPipe>> create(USBController const& controller, u8 endpoint_address, u16 max_packet_size, i8 device_address, size_t buffer_size = PAGE_SIZE);
 
     ErrorOr<size_t> submit_bulk_in_transfer(size_t length, void* data);
+    ErrorOr<size_t> submit_bulk_in_transfer(size_t length, UserOrKernelBuffer data);
 
 private:
     BulkInPipe(USBController const& controller, u8 endpoint_address, u16 max_packet_size, i8 device_address, NonnullOwnPtr<Memory::Region> dma_buffer);
@@ -104,6 +105,7 @@ public:
     static ErrorOr<NonnullOwnPtr<BulkOutPipe>> create(USBController const& controller, u8 endpoint_address, u16 max_packet_size, i8 device_address, size_t buffer_size = PAGE_SIZE);
 
     ErrorOr<size_t> submit_bulk_out_transfer(size_t length, void* data);
+    ErrorOr<size_t> submit_bulk_out_transfer(size_t length, UserOrKernelBuffer data);
 
 private:
     BulkOutPipe(USBController const& controller, u8 endpoint_address, u16 max_packet_size, i8 device_address, NonnullOwnPtr<Memory::Region> dma_buffer);

--- a/Kernel/Bus/USB/USBTransfer.cpp
+++ b/Kernel/Bus/USB/USBTransfer.cpp
@@ -6,6 +6,7 @@
 
 #include <Kernel/Bus/USB/USBTransfer.h>
 #include <Kernel/Library/StdLib.h>
+#include <Kernel/Library/UserOrKernelBuffer.h>
 #include <Kernel/Memory/MemoryManager.h>
 
 namespace Kernel::USB {
@@ -49,6 +50,13 @@ ErrorOr<void> Transfer::write_buffer(u16 len, void* data)
     memcpy(buffer().as_ptr(), data, len);
 
     return {};
+}
+
+ErrorOr<void> Transfer::write_buffer(u16 len, UserOrKernelBuffer data)
+{
+    VERIFY(len <= m_dma_buffer.size());
+    m_transfer_data_size = len;
+    return data.read(buffer().as_ptr(), len);
 }
 
 void Transfer::invoke_async_callback()

--- a/Kernel/Bus/USB/USBTransfer.h
+++ b/Kernel/Bus/USB/USBTransfer.h
@@ -30,6 +30,7 @@ public:
     void set_error_occurred() { m_error_occurred = true; }
 
     ErrorOr<void> write_buffer(u16 len, void* data);
+    ErrorOr<void> write_buffer(u16 len, UserOrKernelBuffer data);
 
     // `const` here makes sure we don't blow up by writing to a physical address
     USBRequestData const& request() const { return m_request; }

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -31,6 +31,7 @@ set(KERNEL_SOURCES
     Bus/PCI/DeviceIdentifier.cpp
     Bus/USB/UHCI/UHCIController.cpp
     Bus/USB/UHCI/UHCIRootHub.cpp
+    Bus/USB/Drivers/MassStorage/MassStorageDriver.cpp
     Bus/USB/USBConfiguration.cpp
     Bus/USB/USBController.cpp
     Bus/USB/USBDevice.cpp
@@ -120,6 +121,7 @@ set(KERNEL_SOURCES
     Devices/Storage/SD/PCISDHostController.cpp
     Devices/Storage/SD/SDHostController.cpp
     Devices/Storage/SD/SDMemoryCard.cpp
+    Devices/Storage/USB/BulkSCSIInterface.cpp
     Devices/Storage/DiskPartition.cpp
     Devices/Storage/StorageController.cpp
     Devices/Storage/StorageDevice.cpp

--- a/Kernel/Devices/Storage/StorageManagement.h
+++ b/Kernel/Devices/Storage/StorageManagement.h
@@ -40,11 +40,13 @@ public:
     static u32 generate_relative_ata_controller_id(Badge<ATAController>);
     static u32 generate_relative_sd_controller_id(Badge<SDHostController>);
 
+    void add_device(StorageDevice&);
     void remove_device(StorageDevice&);
 
 private:
     void enumerate_pci_controllers(bool force_pio, bool nvme_poll);
     void enumerate_storage_devices();
+    ErrorOr<void> enumerate_device_partitions(StorageDevice&);
     void enumerate_disk_partitions();
 
     void determine_boot_device();

--- a/Kernel/Devices/Storage/USB/BulkSCSIInterface.cpp
+++ b/Kernel/Devices/Storage/USB/BulkSCSIInterface.cpp
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2023, Leon Albrecht <leon.a@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/Bus/USB/USBController.h>
+#include <Kernel/Devices/Storage/USB/BulkSCSIInterface.h>
+#include <Kernel/Devices/Storage/USB/SCSIComands.h>
+
+namespace Kernel::USB {
+
+BulkSCSIInterface::BulkSCSIInterface(LUNAddress logical_unit_number_address, u32 hardware_relative_controller_id, size_t sector_size, u64 max_addressable_block, USB::Device& device, NonnullOwnPtr<BulkInPipe> in_pipe, NonnullOwnPtr<BulkOutPipe> out_pipe)
+    : StorageDevice(logical_unit_number_address, hardware_relative_controller_id, sector_size, max_addressable_block)
+    , m_device(device)
+    , m_in_pipe(move(in_pipe))
+    , m_out_pipe(move(out_pipe))
+{
+}
+
+void BulkSCSIInterface::start_request(AsyncBlockDeviceRequest& request)
+{
+    if (request.request_type() == AsyncBlockDeviceRequest::RequestType::Read) {
+        if (do_read(request.block_index(), request.block_count(), request.buffer(), request.buffer_size()).is_error()) {
+            request.complete(AsyncDeviceRequest::RequestResult::Failure);
+        } else {
+            request.complete(AsyncDeviceRequest::RequestResult::Success);
+        }
+    } else {
+        if (do_write(request.block_index(), request.block_count(), request.buffer(), request.buffer_size()).is_error()) {
+            request.complete(AsyncDeviceRequest::RequestResult::Failure);
+        } else {
+            request.complete(AsyncDeviceRequest::RequestResult::Success);
+        }
+    }
+}
+
+ErrorOr<void> BulkSCSIInterface::do_read(u32 block_index, u32 block_count, UserOrKernelBuffer& buffer, size_t)
+{
+    // FIXME: Error Handling and proper device reset on exit
+    CommandBlockWrapper command;
+    SCSI::Read10 read_command;
+
+    u32 block_index_to_read = block_index;
+    u32 blocks_read = 0;
+    UserOrKernelBuffer destination_buffer = buffer;
+    while (blocks_read < block_count) {
+        read_command.logical_block_address = block_index_to_read;
+
+        u16 transfer_length_bytes = min((block_count - blocks_read) * block_size(), AK::NumericLimits<u16>::max());
+
+        read_command.transfer_length = transfer_length_bytes / block_size();
+
+        command.transfer_length = transfer_length_bytes;
+        command.direction = CBWDirection::DataIn;
+        command.set_command(read_command);
+
+        TRY(m_out_pipe->submit_bulk_out_transfer(sizeof(command), &command));
+
+        TRY(m_in_pipe->submit_bulk_in_transfer(transfer_length_bytes, destination_buffer));
+
+        CommandStatusWrapper status;
+        TRY(m_in_pipe->submit_bulk_in_transfer(sizeof(status), &status));
+
+        if (status.status != CSWStatus::Passed) {
+            // FIXME: Actually handle the error
+            //        See usbmassbulk 5.3, 6.4 and 6.5
+            dmesgln("SCSI/BBB: Read failed with code {}", to_underlying(status.status));
+            return EIO;
+        }
+
+        u32 bytes_transferred = transfer_length_bytes - status.data_residue;
+        u32 blocks_read_in_transfer = bytes_transferred / block_size();
+
+        blocks_read += blocks_read_in_transfer;
+        block_index_to_read += blocks_read_in_transfer;
+    }
+
+    return {};
+}
+
+ErrorOr<void> BulkSCSIInterface::do_write(u32 block_index, u32 block_count, UserOrKernelBuffer& buffer, size_t)
+{
+    // FIXME: Error Handling and proper device reset on exit
+
+    CommandBlockWrapper command;
+    SCSI::Write10 read_command;
+
+    u32 block_index_to_read = block_index;
+    u32 blocks_read = 0;
+    UserOrKernelBuffer destination_buffer = buffer;
+    while (blocks_read < block_count) {
+        read_command.logical_block_address = block_index_to_read;
+
+        u16 transfer_length_bytes = min((block_count - blocks_read) * block_size(), AK::NumericLimits<u16>::max());
+
+        read_command.transfer_length = transfer_length_bytes / block_size();
+
+        command.transfer_length = transfer_length_bytes;
+        command.direction = CBWDirection::DataOut;
+        command.set_command(read_command);
+
+        TRY(m_out_pipe->submit_bulk_out_transfer(sizeof(command), &command));
+
+        TRY(m_out_pipe->submit_bulk_out_transfer(transfer_length_bytes, destination_buffer));
+
+        CommandStatusWrapper status;
+        TRY(m_in_pipe->submit_bulk_in_transfer(sizeof(status), &status));
+
+        if (status.status != CSWStatus::Passed) {
+            // FIXME: Actually handle the error
+            //        See usbmassbulk 5.3, 6.4 and 6.5
+            dmesgln("SCSI/BBB: Write failed with code {}", to_underlying(status.status));
+            return EIO;
+        }
+
+        u32 bytes_transferred = transfer_length_bytes - status.data_residue;
+        u32 blocks_read_in_transfer = bytes_transferred / block_size();
+        blocks_read += blocks_read_in_transfer;
+        block_index_to_read += blocks_read_in_transfer;
+    }
+
+    return {};
+}
+}

--- a/Kernel/Devices/Storage/USB/BulkSCSIInterface.h
+++ b/Kernel/Devices/Storage/USB/BulkSCSIInterface.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2023, Leon Albrecht <leon.a@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/IntrusiveList.h>
+#include <Kernel/Bus/USB/USBDevice.h>
+#include <Kernel/Bus/USB/USBPipe.h>
+#include <Kernel/Devices/Storage/StorageDevice.h>
+
+namespace Kernel::USB {
+
+enum class CBWDirection : u8 {
+    DataOut = 0,
+    DataIn = 1
+};
+
+struct CommandBlockWrapper {
+    LittleEndian<u32> signature { 0x43425355 };
+    LittleEndian<u32> tag { 0 };
+    LittleEndian<u32> transfer_length { 0 };
+    union {
+        u8 flags { 0 };
+        struct {
+            u8 flag_reserved : 6;
+            u8 flag_obsolete : 1;
+            CBWDirection direction : 1;
+        };
+    };
+    u8 lun { 0 };            // only 4 bits
+    u8 command_length { 0 }; // 5 bits, range 1-16
+    u8 command_block[16] { 0 };
+
+    template<typename T>
+    requires(sizeof(T) <= 16)
+    void set_command(T const& command)
+    {
+        command_length = sizeof(command);
+        memcpy(&command_block, &command, sizeof(command));
+    }
+};
+static_assert(AssertSize<CommandBlockWrapper, 31>());
+
+enum class CSWStatus : u8 {
+    Passed = 0x00,
+    Failed = 0x01,
+    PhaseError = 0x02
+};
+
+struct CommandStatusWrapper {
+    LittleEndian<u32> signature;
+    LittleEndian<u32> tag;
+    LittleEndian<u32> data_residue;
+    CSWStatus status;
+};
+static_assert(AssertSize<CommandStatusWrapper, 13>());
+
+class BulkSCSIInterface : public StorageDevice {
+    // https://www.usb.org/sites/default/files/usbmassbulk_10.pdf
+public:
+    BulkSCSIInterface(LUNAddress logical_unit_number_address, u32 hardware_relative_controller_id, size_t sector_size, u64 max_addressable_block, USB::Device& device, NonnullOwnPtr<BulkInPipe> in_pipe, NonnullOwnPtr<BulkOutPipe> out_pipe);
+
+    USB::Device const& device() const { return m_device; }
+
+    virtual void start_request(AsyncBlockDeviceRequest&) override;
+    virtual CommandSet command_set() const override { return CommandSet::SCSI; }
+
+private:
+    USB::Device& m_device;
+    NonnullOwnPtr<BulkInPipe> m_in_pipe;
+    NonnullOwnPtr<BulkOutPipe> m_out_pipe;
+
+    ErrorOr<void> do_read(u32 block_index, u32 block_count, UserOrKernelBuffer& buffer, size_t buffer_size);
+    ErrorOr<void> do_write(u32 block_index, u32 block_count, UserOrKernelBuffer& buffer, size_t buffer_size);
+
+    IntrusiveListNode<BulkSCSIInterface, NonnullLockRefPtr<BulkSCSIInterface>> m_list_node;
+
+public:
+    using List = IntrusiveList<&BulkSCSIInterface::m_list_node>;
+};
+
+}

--- a/Kernel/Devices/Storage/USB/Codes.h
+++ b/Kernel/Devices/Storage/USB/Codes.h
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2023, Leon Albrecht <leon.a@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/StringView.h>
+#include <AK/Types.h>
+
+namespace Kernel::USB::MassStorage {
+// https://www.usb.org/sites/default/files/Mass_Storage_Specification_Overview_v1.4_2-19-2010.pdf
+// 2
+enum class SubclassCode : u8 {
+    NotReported = 0x00,
+    RBC = 0x01,
+    MMC5 = 0x02, // ATAPI
+    Obsolete_QIC157 = 0x03,
+    UFI = 0x04, // Floppy
+    Obsolete_SFF8070i = 0x05,
+    SCSI_transparent = 0x06,
+    LSD_FS = 0x07,
+    IEEE1667 = 0x08,
+    // Reserved: 0x09 - 0xFE
+    VendorSpecific = 0xFF
+};
+
+constexpr StringView subclass_string(SubclassCode code)
+{
+    switch (code) {
+    case SubclassCode::NotReported:
+        return "Not Reported"sv;
+    case SubclassCode::RBC:
+        return "RBC"sv;
+    case SubclassCode::MMC5:
+        return "MMC-5 (ATAPI)"sv;
+    case SubclassCode::Obsolete_QIC157:
+        return "QIC157 (Obsolete)"sv;
+    case SubclassCode::UFI:
+        return "UFI"sv;
+    case SubclassCode::Obsolete_SFF8070i:
+        return "SFF8070i (Obsolete)"sv;
+    case SubclassCode::SCSI_transparent:
+        return "SCSI-transparent"sv;
+    case SubclassCode::LSD_FS:
+        return "LSD FS"sv;
+    case SubclassCode::IEEE1667:
+        return "IEEE1667"sv;
+    case SubclassCode::VendorSpecific:
+        return "Vendor Specific"sv;
+    }
+
+    return "Reserved"sv;
+}
+
+// 3
+enum class TransportProtocol : u8 {
+    CBI_completion_interrupt = 0x00,    // Control/Bulk/Interrupt
+    CBI_no_completion_interrupt = 0x01, // Control/Bulk/Interrupt
+    Obsolete = 0x02,
+    // Reserved: 0x03 - 0x4F
+    BBB = 0x50, // Bulk-only
+    // Reserved: 0x51 - 0x61
+    UAS = 0x62,
+    // Reserved: 0x63 - 0xFE
+    VendorSpecific = 0xFF
+};
+
+constexpr StringView transport_protocol_string(TransportProtocol protocol)
+{
+    switch (protocol) {
+    case TransportProtocol::CBI_completion_interrupt:
+        return "Control/Bulk/Interrupt with completion interrupt"sv;
+    case TransportProtocol::CBI_no_completion_interrupt:
+        return "Control/Bulk/Interrupt without completion interrupt"sv;
+    case TransportProtocol::Obsolete:
+        return "Obsolete"sv;
+    case TransportProtocol::BBB:
+        return "Bulk only"sv;
+    case TransportProtocol::UAS:
+        return "UAS"sv;
+    case TransportProtocol::VendorSpecific:
+        return "Vendor Specific"sv;
+    }
+
+    return "Reserved"sv;
+}
+
+// 4
+enum class RequestCodes : u8 {
+    ADSC = 0x00, // Accept Device Specific Command (CBI) - also alias USB-request 00h Get Status
+    // Reserved/alias USB-bRequest: 0x01 - 0x0D
+    // Reserved: 0x0E - 0XFB
+    GetRequest = 0xFC,
+    PutRequest = 0xFD,
+    GetMaxLun = 0xFE,               // GML (BBB)
+    BulkOnlyMassStorageReset = 0xFF // BOMSR (BBB)
+};
+
+// 5
+enum class ClassSpecificDescriptorCodes : u8 {
+    // Undefined by Mass Storage: 0x00 - 0x23
+    PipeUsageClassSpecific = 0x24 // UAS
+    // Undefined by Mass Storage: 0x25 - 0xFF
+};
+
+}

--- a/Kernel/Devices/Storage/USB/SCSIComands.h
+++ b/Kernel/Devices/Storage/USB/SCSIComands.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2023, Leon Albrecht <leon.a@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Endian.h>
+#include <AK/StdLibExtraDetails.h>
+#include <AK/Types.h>
+
+// https://www.seagate.com/files/staticfiles/support/docs/manual/Interface%20manuals/100293068j.pdf
+
+namespace Kernel::SCSI {
+// 3.22.1
+struct ReadCapacity10 {
+    u8 opcode { 0x25 };
+    u8 reserved1 { 0 };
+    BigEndian<u32> oboslete_logical_block_address { 0 };
+    u16 reserved2 { 0 };
+    u8 reserved3 { 0 };
+    u8 control { 0 };
+};
+static_assert(AssertSize<ReadCapacity10, 10>());
+// 3.22.2
+struct ReadCapacity10Parameters {
+    BigEndian<u32> block_count;
+    BigEndian<u32> block_size;
+};
+static_assert(AssertSize<ReadCapacity10Parameters, 8>());
+
+// 3.16
+struct Read10 {
+    u8 operation_code { 0x28 };
+    union {
+        u8 settings { 0 };
+        struct {
+            u8 obsolete : 2;
+            u8 rarc : 1;
+            u8 fua : 1;
+            u8 dpo : 1;
+            u8 rdprotect : 3;
+        };
+    };
+    BigEndian<u32> logical_block_address;
+    u8 group_number { 0 }; // only bottom 5 bits
+    BigEndian<u16> transfer_length;
+    u8 control { 0 };
+};
+static_assert(AssertSize<Read10, 10>());
+
+// 3.60
+struct Write10 {
+    u8 operation_code { 0x2A };
+    union {
+        u8 settings { 0 };
+        struct {
+            u8 obsolete : 2;
+            u8 reserved : 1;
+            u8 fua : 1;
+            u8 dpo : 1;
+            u8 wrprotect : 3;
+        };
+    };
+    BigEndian<u32> logical_block_address;
+    u8 group_number { 0 }; // only bottom 5 bits
+    BigEndian<u16> transfer_length;
+    u8 control { 0 };
+};
+static_assert(AssertSize<Read10, 10>());
+}

--- a/Kernel/FileSystem/SysFS/Subsystems/Devices/Storage/DeviceDirectory.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Devices/Storage/DeviceDirectory.cpp
@@ -18,7 +18,7 @@ StorageDevice const& StorageDeviceSysFSDirectory::device(Badge<StorageDeviceAttr
     return *m_device;
 }
 
-UNMAP_AFTER_INIT NonnullRefPtr<StorageDeviceSysFSDirectory> StorageDeviceSysFSDirectory::create(SysFSDirectory const& parent_directory, StorageDevice const& device)
+NonnullRefPtr<StorageDeviceSysFSDirectory> StorageDeviceSysFSDirectory::create(SysFSDirectory const& parent_directory, StorageDevice const& device)
 {
     // FIXME: Handle allocation failure gracefully
     auto lun_address = device.logical_unit_number_address();
@@ -33,7 +33,7 @@ UNMAP_AFTER_INIT NonnullRefPtr<StorageDeviceSysFSDirectory> StorageDeviceSysFSDi
     return directory;
 }
 
-UNMAP_AFTER_INIT StorageDeviceSysFSDirectory::StorageDeviceSysFSDirectory(NonnullOwnPtr<KString> device_directory_name, SysFSDirectory const& parent_directory, StorageDevice const& device)
+StorageDeviceSysFSDirectory::StorageDeviceSysFSDirectory(NonnullOwnPtr<KString> device_directory_name, SysFSDirectory const& parent_directory, StorageDevice const& device)
     : SysFSDirectory(parent_directory)
     , m_device(device)
     , m_device_directory_name(move(device_directory_name))


### PR DESCRIPTION
### Kernel: Remove UNMAP_ATER_INIT from StorageDeviceSysFSDirectory

We will need these when plugging in USB drives

### Kernel: Allow adding storage devices after init


### Kernel/USB: Copy device configurations when copying devices


### Kernel/USB: Add missing inlcude in USBInterface.h


### Kernel/USB: Explicitely copy descriptor.hub_characteristics for printing

This field is in a packed struct, which makes it possibly misaligned.
This knowledge is lost when invoking `dbgln` triggering an unaligned
access to it, aka UB. By explicitely copying it we avoid this issue.

### Kernel/USB: Add KernelOrUserBuffer overloads to certain BulkPipe and…

Transfers functions

These will be useful for directly accessing the destination buffer,
without going through a third buffer first.

### Kernel/USB: Add a crude USB MassStorage driver :^)


---

The only interface supported right now is BulkOnly with SCSI

to test this I booted the q35 mashine with the following adjustments to the run script and mounted the newly appearing `hdb` drive
```diff
diff --git a/Meta/run.sh b/Meta/run.sh
index a2dd7308be..fad557014e 100755
--- a/Meta/run.sh
+++ b/Meta/run.sh
@@ -398,7 +398,7 @@ $SERENITY_EXTRA_QEMU_ARGS
 -device vmware-svga
 -device ich9-usb-ehci1,bus=pcie.0,multifunction=on,addr=0x5.0x0
 -device ich9-usb-ehci2,bus=pcie.0,addr=0x5.0x2
--device ich9-usb-uhci1,bus=pcie.0,multifunction=on,addr=0x7.0x0
+-device ich9-usb-uhci1,bus=pcie.0,multifunction=on,addr=0x7.0x0,id=uhci1
 -device ich9-usb-uhci2,bus=pcie.0,addr=0x7.0x1
 -device ich9-usb-uhci3,bus=pcie.0,addr=0x7.0x2
 -device ich9-usb-uhci4,bus=pcie.0,addr=0x7.0x3
@@ -426,6 +426,8 @@ $SERENITY_EXTRA_QEMU_ARGS
 $SERENITY_AUDIO_BACKEND
 $SERENITY_AUDIO_PC_SPEAKER
 $SERENITY_BOOT_DRIVE
+-device usb-storage,drive=usbstick,bus=uhci1.0
+-drive if=none,id=usbstick,format=raw,file=${SERENITY_DISK_IMAGE}
 "
 
 export SDL_VIDEO_X11_DGAMOUSE=0
```

---
CC: @Quaker762 @supercomputer7 