### PR TITLE
LibWeb: Bring html element height calculation closer to the spec

### DIFF
--- a/Tests/LibWeb/Layout/expected/block-and-inline/html-element-height-quirks-mode-off.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/html-element-height-quirks-mode-off.txt
@@ -1,0 +1,9 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x136 [BFC] children: not-inline
+    BlockContainer <body> at (18,18) content-size 764x100 children: not-inline
+      BlockContainer <div.box> at (18,18) content-size 100x100 children: not-inline
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x136]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x120]
+      PaintableWithLines (BlockContainer<DIV>.box) [18,18 100x100]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/html-element-height-quirks-mode-on.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/html-element-height-quirks-mode-on.txt
@@ -1,0 +1,9 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (18,18) content-size 764x300 children: not-inline
+      BlockContainer <div.box> at (18,18) content-size 100x100 children: not-inline
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x320]
+      PaintableWithLines (BlockContainer<DIV>.box) [18,18 100x100]

--- a/Tests/LibWeb/Layout/expected/viewport-overflow-propagation-2.txt
+++ b/Tests/LibWeb/Layout/expected/viewport-overflow-propagation-2.txt
@@ -1,10 +1,10 @@
 Viewport <#document> at (0,0) content-size 800x600 [BFC] children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x616 [BFC] children: not-inline
-    BlockContainer <body> at (8,8) content-size 784x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x2016 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x2000 children: not-inline
       BlockContainer <div.long> at (8,8) content-size 784x2000 children: inline
         TextNode <#text>
 
-ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x2008]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x616] overflow: [0,0 800x2008]
-    PaintableWithLines (BlockContainer<BODY>) [8,8 784x600] overflow: [8,8 784x2000]
+ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x2016]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x2016]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x2000]
       PaintableWithLines (BlockContainer<DIV>.long) [8,8 784x2000]

--- a/Tests/LibWeb/Layout/input/block-and-inline/html-element-height-quirks-mode-off.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/html-element-height-quirks-mode-off.html
@@ -1,0 +1,15 @@
+<!doctype html><style>
+    * {
+        outline: 1px solid black !important;
+    }
+    body {
+        border: 10px solid purple;
+        display: block;
+        height: 50%;
+    }
+    .box {
+        background-color: palevioletred;
+        height: 100px;
+        width: 100px;
+    }
+</style><body><div class="box"></div>

--- a/Tests/LibWeb/Layout/input/block-and-inline/html-element-height-quirks-mode-on.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/html-element-height-quirks-mode-on.html
@@ -1,0 +1,15 @@
+<style>
+    * {
+        outline: 1px solid black !important;
+    }
+    body {
+        border: 10px solid purple;
+        display: block;
+        height: 50%;
+    }
+    .box {
+        background-color: palevioletred;
+        height: 100px;
+        width: 100px;
+    }
+</style><body><div class="box"></div>

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -996,7 +996,6 @@ void Document::update_layout()
             VERIFY(document_element->layout_node());
             auto& icb_state = layout_state.get_mutable(verify_cast<Layout::NodeWithStyleAndBoxModelMetrics>(*document_element->layout_node()));
             icb_state.set_content_width(viewport_rect.width());
-            icb_state.set_content_height(viewport_rect.height());
         }
 
         root_formatting_context.run(


### PR DESCRIPTION
Previously we always set the height of the HTML element equal to the viewport height but now this will only happen in quirks mode as it is intended. Otherwise the html element height will be computed as auto.