### PR TITLE
LibWeb: Use height when possible in calculate_min{max}_content_width()

### DIFF
--- a/Tests/LibWeb/Layout/expected/block-and-inline/inline-block-with-img-child-max-height.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/inline-block-with-img-child-max-height.txt
@@ -1,0 +1,11 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x66 [BFC] children: inline
+    line 0 width: 66, height: 66, bottom: 66, baseline: 66
+      frag 0 from BlockContainer start: 0, length: 0, rect: [8,8 50x50]
+    BlockContainer <body> at (8,8) content-size 50x50 inline-block [BFC] children: not-inline
+      ImageBox <img> at (8,8) content-size 50x50 children: not-inline
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x66]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 50x50]
+      ImagePaintable (ImageBox<IMG>) [8,8 50x50]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/inline-block-with-img-child-min-height.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/inline-block-with-img-child-min-height.txt
@@ -1,0 +1,11 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x166 [BFC] children: inline
+    line 0 width: 166, height: 166, bottom: 166, baseline: 166
+      frag 0 from BlockContainer start: 0, length: 0, rect: [8,8 150x150]
+    BlockContainer <body> at (8,8) content-size 150x150 inline-block [BFC] children: not-inline
+      ImageBox <img> at (8,8) content-size 150x150 children: not-inline
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x166]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 150x150]
+      ImagePaintable (ImageBox<IMG>) [8,8 150x150]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/inline-block-with-img-child.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/inline-block-with-img-child.txt
@@ -1,0 +1,11 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x116 [BFC] children: inline
+    line 0 width: 116, height: 116, bottom: 116, baseline: 116
+      frag 0 from BlockContainer start: 0, length: 0, rect: [8,8 100x100]
+    BlockContainer <body> at (8,8) content-size 100x100 inline-block [BFC] children: not-inline
+      ImageBox <img> at (8,8) content-size 100x100 children: not-inline
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x116]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 100x100]
+      ImagePaintable (ImageBox<IMG>) [8,8 100x100]

--- a/Tests/LibWeb/Layout/input/block-and-inline/inline-block-with-img-child-max-height.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/inline-block-with-img-child-max-height.html
@@ -1,0 +1,15 @@
+<!doctype html><style>
+    * {
+        outline: 1px solid black !important;
+    }
+    body {
+        display: inline-block;
+        height: 100px;
+        max-height: 50px;
+    }
+    img {
+        display: block;
+        height: 100%;
+        width: auto;
+    }
+</style><body><img src="../120.png" />

--- a/Tests/LibWeb/Layout/input/block-and-inline/inline-block-with-img-child-min-height.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/inline-block-with-img-child-min-height.html
@@ -1,0 +1,15 @@
+<!doctype html><style>
+    * {
+        outline: 1px solid black !important;
+    }
+    body {
+        display: inline-block;
+        height: 100px;
+        min-height: 150px;
+    }
+    img {
+        display: block;
+        height: 100%;
+        width: auto;
+    }
+</style><body><img src="../120.png" />

--- a/Tests/LibWeb/Layout/input/block-and-inline/inline-block-with-img-child.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/inline-block-with-img-child.html
@@ -1,0 +1,14 @@
+<!doctype html><style>
+    * {
+        outline: 1px solid black !important;
+    }
+    body {
+        display: inline-block;
+        height: 100px;
+    }
+    img {
+        display: block;
+        height: 100%;
+        width: auto;
+    }
+</style><body><img src="../120.png" />

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -1293,6 +1293,8 @@ CSSPixels FormattingContext::calculate_min_content_width(Layout::Box const& box)
 
     auto available_width = AvailableSize::make_min_content();
     auto available_height = AvailableSize::make_indefinite();
+    if (box.computed_values().height().is_length())
+        available_height = AvailableSize::make_definite(box.computed_values().height().length().to_px(box));
     context->run(box, LayoutMode::IntrinsicSizing, AvailableSpace(available_width, available_height));
 
     cache.min_content_width = context->automatic_content_width();
@@ -1331,6 +1333,9 @@ CSSPixels FormattingContext::calculate_max_content_width(Layout::Box const& box)
 
     auto available_width = AvailableSize::make_max_content();
     auto available_height = AvailableSize::make_indefinite();
+    if (box.computed_values().height().is_length())
+        available_height = AvailableSize::make_definite(box.computed_values().height().length().to_px(box));
+
     context->run(box, LayoutMode::IntrinsicSizing, AvailableSpace(available_width, available_height));
 
     cache.max_content_width = context->automatic_content_width();


### PR DESCRIPTION
If height is length it can be used as available space for determining
the min/max content width. Doing this allows to correctly resolve width
for replaced boxes with an aspect ratio while doing intrinsic sizing
layout.
