### PR TITLE
LibWeb: Apply CSS `clip` property to an element as well as its children 

### DIFF
--- a/Tests/LibWeb/Ref/clip-ref.html
+++ b/Tests/LibWeb/Ref/clip-ref.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html><style type="text/css">
+    * {
+        background-color: white;
+    }
+    .clip {
+        width: 100px;
+        height: 50px;
+        overflow: hidden;
+    }
+</style><div class="clip">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.

--- a/Tests/LibWeb/Ref/clip.html
+++ b/Tests/LibWeb/Ref/clip.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html><style type="text/css">
+    * {
+        background-color: white;
+    }
+    .clip {
+        position: absolute;
+        width: 100px;
+        height: 100px;
+        clip: rect(auto, auto, 50px, auto);
+    }
+</style><div class="clip">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.

--- a/Tests/LibWeb/Ref/manifest.json
+++ b/Tests/LibWeb/Ref/manifest.json
@@ -1,4 +1,5 @@
 {
+    "clip.html": "clip-ref.html",
     "clip-abspos-children.html": "clip-abspos-children-ref.html",
     "css-any-link-selector.html": "css-any-link-selector-ref.html",
     "css-gradient-currentcolor.html": "css-gradient-currentcolor-ref.html",

--- a/Userland/Libraries/LibWeb/CSS/EdgeRect.cpp
+++ b/Userland/Libraries/LibWeb/CSS/EdgeRect.cpp
@@ -12,7 +12,7 @@
 namespace Web::CSS {
 
 // https://www.w3.org/TR/CSS2/visufx.html#value-def-shape
-Gfx::FloatRect EdgeRect::resolved(Layout::Node const& layout_node, Gfx::Rect<double> border_box) const
+CSSPixelRect EdgeRect::resolved(Layout::Node const& layout_node, CSSPixelRect border_box) const
 {
     // In CSS 2.1, the only valid <shape> value is: rect(<top>, <right>, <bottom>, <left>) where
     // <top> and <bottom> specify offsets from the top border edge of the box, and <right>, and
@@ -24,11 +24,11 @@ Gfx::FloatRect EdgeRect::resolved(Layout::Node const& layout_node, Gfx::Rect<dou
     // widths for <bottom>, and the same as the used value of the width plus the sum of the
     // horizontal padding and border widths for <right>, such that four 'auto' values result in the
     // clipping region being the same as the element's border box).
-    auto left = border_box.left() + (left_edge.is_auto() ? 0 : left_edge.to_px(layout_node).to_double());
-    auto top = border_box.top() + (top_edge.is_auto() ? 0 : top_edge.to_px(layout_node).to_double());
-    auto right = border_box.left() + (right_edge.is_auto() ? border_box.width() : right_edge.to_px(layout_node).to_double());
-    auto bottom = border_box.top() + (bottom_edge.is_auto() ? border_box.height() : bottom_edge.to_px(layout_node).to_double());
-    return Gfx::FloatRect {
+    auto left = border_box.left() + (left_edge.is_auto() ? 0 : left_edge.to_px(layout_node));
+    auto top = border_box.top() + (top_edge.is_auto() ? 0 : top_edge.to_px(layout_node));
+    auto right = border_box.left() + (right_edge.is_auto() ? border_box.width() : right_edge.to_px(layout_node));
+    auto bottom = border_box.top() + (bottom_edge.is_auto() ? border_box.height() : bottom_edge.to_px(layout_node));
+    return CSSPixelRect {
         left,
         top,
         right - left,

--- a/Userland/Libraries/LibWeb/CSS/EdgeRect.h
+++ b/Userland/Libraries/LibWeb/CSS/EdgeRect.h
@@ -19,7 +19,7 @@ struct EdgeRect {
     Length right_edge;
     Length bottom_edge;
     Length left_edge;
-    Gfx::FloatRect resolved(Layout::Node const&, Gfx::Rect<double>) const;
+    CSSPixelRect resolved(Layout::Node const&, CSSPixelRect) const;
     bool operator==(EdgeRect const&) const = default;
 };
 

--- a/Userland/Libraries/LibWeb/Painting/Paintable.h
+++ b/Userland/Libraries/LibWeb/Painting/Paintable.h
@@ -109,6 +109,9 @@ public:
         return TraversalDecision::Continue;
     }
 
+    virtual void before_paint(PaintContext&, PaintPhase) const { }
+    virtual void after_paint(PaintContext&, PaintPhase) const { }
+
     virtual void paint(PaintContext&, PaintPhase) const { }
 
     virtual void before_children_paint(PaintContext&, PaintPhase) const { }

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -181,7 +181,7 @@ Optional<CSSPixelRect> PaintableBox::get_clip_rect() const
     auto clip = computed_values().clip();
     if (clip.is_rect() && layout_box().is_absolutely_positioned()) {
         auto border_box = absolute_border_box_rect();
-        return clip.to_rect().resolved(layout_node(), border_box.to_type<double>()).to_type<CSSPixels>();
+        return clip.to_rect().resolved(layout_node(), border_box);
     }
     return {};
 }

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.h
@@ -20,6 +20,9 @@ public:
     static JS::NonnullGCPtr<PaintableBox> create(Layout::Box const&);
     virtual ~PaintableBox();
 
+    virtual void before_paint(PaintContext&, PaintPhase) const override;
+    virtual void after_paint(PaintContext&, PaintPhase) const override;
+
     virtual void paint(PaintContext&, PaintPhase) const override;
 
     bool is_visible() const { return layout_box().is_visible(); }
@@ -185,6 +188,8 @@ public:
 
 protected:
     explicit PaintableBox(Layout::Box const&);
+
+    Optional<CSSPixelRect> get_clip_rect() const;
 
     virtual void paint_border(PaintContext&) const;
     virtual void paint_backdrop_filter(PaintContext&) const;

--- a/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -26,7 +26,9 @@ namespace Web::Painting {
 
 static void paint_node(Paintable const& paintable, PaintContext& context, PaintPhase phase)
 {
+    paintable.before_paint(context, phase);
     paintable.paint(context, phase);
+    paintable.after_paint(context, phase);
 }
 
 StackingContext::StackingContext(PaintableBox& paintable_box, StackingContext* parent, size_t index_in_tree_order)


### PR DESCRIPTION
https://github.com/SerenityOS/serenity/commit/d06d4eb388bfeb8c20c14c23d9da78c8c43ce85f made the `clip` property apply to children of an absolute-positioned element, but caused it not to be applied to the element the property was applied to directly.

To fix this, apply the clip in new `before_paint()` and `after_paint()` functions. Doing so keeps painter state from leaking from `paint()`, but still allows subclasses of `PaintableBox` clip their contents correctly without repeating the application of the clip rectangle.

In addition to that change, I've made the CSS `rect` representation not convert to floating point so that we can avoid converting it back to CSSPixels again in the painter.