### PR TITLE
Utilities/gzip: Compress from stdin to stdout if no files are specified

### DIFF
--- a/Userland/Libraries/LibCore/File.cpp
+++ b/Userland/Libraries/LibCore/File.cpp
@@ -12,6 +12,11 @@
 
 namespace Core {
 
+bool File::valid_regular_filename_for_opening(StringView filename)
+{
+    return !filename.is_empty() && filename != "-"sv;
+}
+
 ErrorOr<NonnullOwnPtr<File>> File::open(StringView filename, OpenMode mode, mode_t permissions)
 {
     auto file = TRY(adopt_nonnull_own_or_enomem(new (nothrow) File(mode)));
@@ -50,7 +55,7 @@ ErrorOr<NonnullOwnPtr<File>> File::standard_error()
 
 ErrorOr<NonnullOwnPtr<File>> File::open_file_or_standard_stream(StringView filename, OpenMode mode)
 {
-    if (!filename.is_empty() && filename != "-"sv)
+    if (valid_regular_filename_for_opening(filename))
         return File::open(filename, mode);
 
     switch (mode) {

--- a/Userland/Libraries/LibCore/File.h
+++ b/Userland/Libraries/LibCore/File.h
@@ -39,6 +39,7 @@ public:
         No,
     };
 
+    static bool valid_regular_filename_for_opening(StringView filename);
     static ErrorOr<NonnullOwnPtr<File>> open(StringView filename, OpenMode, mode_t = 0644);
     static ErrorOr<NonnullOwnPtr<File>> adopt_fd(int fd, OpenMode, ShouldCloseFileDescriptor = ShouldCloseFileDescriptor::Yes);
 

--- a/Userland/Utilities/gzip.cpp
+++ b/Userland/Utilities/gzip.cpp
@@ -23,8 +23,17 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_option(keep_input_files, "Keep (don't delete) input files", "keep", 'k');
     args_parser.add_option(write_to_stdout, "Write to stdout, keep original files unchanged", "stdout", 'c');
     args_parser.add_option(decompress, "Decompress", "decompress", 'd');
-    args_parser.add_positional_argument(filenames, "Files", "FILES");
+    args_parser.add_positional_argument(filenames, "Files", "FILES", Core::ArgsParser::Required::No);
     args_parser.parse(arguments);
+
+    if (filenames.is_empty()) {
+        auto output_stream = TRY(Core::File::standard_output());
+        if (decompress)
+            TRY(Compress::GzipDecompressor::decompress_file("-"sv, move(output_stream)));
+        else
+            TRY(Compress::GzipCompressor::compress_file("-"sv, move(output_stream)));
+        return 0;
+    }
 
     if (write_to_stdout)
         keep_input_files = true;


### PR DESCRIPTION
The inspiration is from #20875, so let's ensure we can use `gzip` in similar fashion to what was proposed in that PR :)