### PR TITLE
Userland+Tests: Don't use MAP_FILE when mmap-ing

### DIFF
--- a/Tests/Kernel/TestEmptyPrivateInodeVMObject.cpp
+++ b/Tests/Kernel/TestEmptyPrivateInodeVMObject.cpp
@@ -32,7 +32,7 @@ TEST_CASE(private_zero_length_inode_vmobject_sync)
     }
     int fd = open("/tmp/private_msync_test", O_RDWR | O_CREAT, 0644);
     VERIFY(fd >= 0);
-    private_ptr = (u8*)mmap(nullptr, 0x1000, PROT_READ | PROT_WRITE, MAP_FILE | MAP_PRIVATE, fd, 0);
+    private_ptr = (u8*)mmap(nullptr, 0x1000, PROT_READ | PROT_WRITE, MAP_PRIVATE, fd, 0);
     EXPECT(private_ptr != MAP_FAILED);
     private_ptr[0] = 0x1;
     VERIFY_NOT_REACHED();

--- a/Tests/Kernel/TestEmptySharedInodeVMObject.cpp
+++ b/Tests/Kernel/TestEmptySharedInodeVMObject.cpp
@@ -32,7 +32,7 @@ TEST_CASE(shared_zero_length_inode_vmobject_sync)
     }
     int fd = open("/tmp/shared_msync_test", O_RDWR | O_CREAT, 0644);
     VERIFY(fd >= 0);
-    shared_ptr = (u8*)mmap(nullptr, 0x1000, PROT_READ | PROT_WRITE, MAP_FILE | MAP_SHARED, fd, 0);
+    shared_ptr = (u8*)mmap(nullptr, 0x1000, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
     EXPECT(shared_ptr != MAP_FAILED);
     shared_ptr[0] = 0x1;
     VERIFY_NOT_REACHED();

--- a/Tests/Kernel/TestPrivateInodeVMObject.cpp
+++ b/Tests/Kernel/TestPrivateInodeVMObject.cpp
@@ -40,7 +40,7 @@ TEST_CASE(private_non_empty_inode_vmobject_sync)
     VERIFY(fd >= 0);
     auto rc = write(fd, buf, sizeof(buf));
     VERIFY(rc == sizeof(buf));
-    private_ptr = (u8*)mmap(nullptr, 0x2000, PROT_READ | PROT_WRITE, MAP_FILE | MAP_PRIVATE, fd, 0);
+    private_ptr = (u8*)mmap(nullptr, 0x2000, PROT_READ | PROT_WRITE, MAP_PRIVATE, fd, 0);
     EXPECT(private_ptr != MAP_FAILED);
     rc = msync(private_ptr, 0x2000, MS_ASYNC);
     EXPECT(rc == 0);

--- a/Tests/Kernel/TestSharedInodeVMObject.cpp
+++ b/Tests/Kernel/TestSharedInodeVMObject.cpp
@@ -40,7 +40,7 @@ TEST_CASE(shared_non_empty_inode_vmobject_sync)
     VERIFY(fd >= 0);
     auto rc = write(fd, buf, sizeof(buf));
     VERIFY(rc == sizeof(buf));
-    shared_ptr = (u8*)mmap(nullptr, 0x2000, PROT_READ | PROT_WRITE, MAP_FILE | MAP_SHARED, fd, 0);
+    shared_ptr = (u8*)mmap(nullptr, 0x2000, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
     EXPECT(shared_ptr != MAP_FAILED);
     rc = msync(shared_ptr, 0x2000, MS_ASYNC);
     EXPECT(rc == 0);

--- a/Tests/Kernel/elf-execve-mmap-race.cpp
+++ b/Tests/Kernel/elf-execve-mmap-race.cpp
@@ -98,7 +98,7 @@ int main()
 
     sync();
 
-    auto* mapped = (u8*)mmap(nullptr, sizeof(buffer), PROT_READ | PROT_WRITE, MAP_FILE | MAP_SHARED, fd, 0);
+    auto* mapped = (u8*)mmap(nullptr, sizeof(buffer), PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
     if (mapped == MAP_FAILED) {
         perror("mmap");
         return 1;

--- a/Tests/Kernel/mmap-write-into-running-programs-executable-file.cpp
+++ b/Tests/Kernel/mmap-write-into-running-programs-executable-file.cpp
@@ -18,7 +18,7 @@ int main()
         perror("open");
         return 1;
     }
-    u8* ptr = (u8*)mmap(nullptr, 16384, PROT_READ, MAP_FILE | MAP_SHARED, fd, 0);
+    u8* ptr = (u8*)mmap(nullptr, 16384, PROT_READ, MAP_SHARED, fd, 0);
     if (ptr == MAP_FAILED) {
         perror("mmap");
         return 1;

--- a/Tests/LibC/TestIo.cpp
+++ b/Tests/LibC/TestIo.cpp
@@ -136,7 +136,7 @@ TEST_CASE(mmap_directory)
 {
     int fd = open("/tmp", O_RDONLY | O_DIRECTORY);
     VERIFY(fd >= 0);
-    auto* ptr = mmap(nullptr, 4096, PROT_READ, MAP_FILE | MAP_SHARED, fd, 0);
+    auto* ptr = mmap(nullptr, 4096, PROT_READ, MAP_SHARED, fd, 0);
     EXPECT_EQ(ptr, MAP_FAILED);
     if (ptr != MAP_FAILED) {
         warnln("Boo! mmap() of a directory succeeded!");

--- a/Userland/Libraries/LibCore/AnonymousBuffer.cpp
+++ b/Userland/Libraries/LibCore/AnonymousBuffer.cpp
@@ -21,7 +21,7 @@ ErrorOr<AnonymousBuffer> AnonymousBuffer::create_with_size(size_t size)
 
 ErrorOr<NonnullRefPtr<AnonymousBufferImpl>> AnonymousBufferImpl::create(int fd, size_t size)
 {
-    auto* data = mmap(nullptr, round_up_to_power_of_two(size, PAGE_SIZE), PROT_READ | PROT_WRITE, MAP_FILE | MAP_SHARED, fd, 0);
+    auto* data = mmap(nullptr, round_up_to_power_of_two(size, PAGE_SIZE), PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
     if (data == MAP_FAILED)
         return Error::from_errno(errno);
     return AK::adopt_nonnull_ref_or_enomem(new (nothrow) AnonymousBufferImpl(fd, size, data));

--- a/Userland/Libraries/LibELF/DynamicLoader.cpp
+++ b/Userland/Libraries/LibELF/DynamicLoader.cpp
@@ -465,7 +465,7 @@ void DynamicLoader::load_program_headers()
             (u8*)reservation + ph_base - ph_load_base,
             ph_desired_base - ph_base + region.size_in_image(),
             PROT_READ,
-            MAP_FILE | MAP_SHARED | MAP_FIXED,
+            MAP_SHARED | MAP_FIXED,
             m_image_fd,
             VirtualAddress { region.offset() }.page_base().get(),
             builder.to_deprecated_string().characters());


### PR DESCRIPTION
MAP_FILE is not in POSIX, and is simply in most LibCs as a "default" mode. Our own LibC defines it as 0, meaning "no flags". It is also not defined in some OS's, such as Haiku. Let's be more portable and not use the unnecessary flag.