### PR TITLE
LibCore: Don't print class_name() from EventReceiver::stop_timer()

### DIFF
--- a/Userland/Libraries/LibCore/EventReceiver.cpp
+++ b/Userland/Libraries/LibCore/EventReceiver.cpp
@@ -131,7 +131,7 @@ void EventReceiver::stop_timer()
         return;
     bool success = Core::EventLoop::unregister_timer(m_timer_id);
     if (!success) {
-        dbgln("{} {:p} could not unregister timer {}", class_name(), this, m_timer_id);
+        dbgln("{:p} could not unregister timer {}", this, m_timer_id);
     }
     m_timer_id = 0;
 }


### PR DESCRIPTION
If stop_timer() is called from ~EventReceiver(), then the virtual functions will end up calling the overload from the base class. As EventReceiver::class_name() is pure virtual, this calls __cxa_pure_virtual and crashes. We should not be calling virtual functions from the destructor, and especially not pure virtual ones.

This "fixes" a crash in Piano, but the root cause of the problem is still unfixed.

Related to #20513

The root cause in Piano is not this virtual though. As I noted in the issue, we start a Core::Timer in the AudioPlayerLoop's secondary thread, and stop it in the main thread. This doesn't actually work because timers are registered per-thread.

We should probably add some asserts to make sure you don't try to do this, and figure out why we are starting a timer but not stopping it from that secondary thread.