### PR TITLE
LibWeb: Two fixes for inline children of flex containers

### DIFF
--- a/Tests/LibWeb/Layout/expected/flex/br-element-does-not-get-blockified-by-itself.txt
+++ b/Tests/LibWeb/Layout/expected/flex/br-element-does-not-get-blockified-by-itself.txt
@@ -1,0 +1,28 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x53.34375 children: not-inline
+      Box <div> at (8,8) content-size 784x53.34375 flex-container(row) [FFC] children: not-inline
+        BlockContainer <(anonymous)> at (8,8) content-size 55.359375x53.34375 flex-item [BFC] children: inline
+          line 0 width: 28.40625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 1, length: 4, rect: [8,8 28.40625x17.46875]
+              "well"
+          line 1 width: 36.84375, height: 17.9375, bottom: 35.40625, baseline: 13.53125
+            frag 0 from TextNode start: 1, length: 5, rect: [8,25 36.84375x17.46875]
+              "hello"
+          line 2 width: 55.359375, height: 18.40625, bottom: 53.34375, baseline: 13.53125
+            frag 0 from TextNode start: 1, length: 7, rect: [8,42 55.359375x17.46875]
+              "friends"
+          TextNode <#text>
+          BreakNode <br>
+          TextNode <#text>
+          BreakNode <br>
+          TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x53.34375]
+      PaintableBox (Box<DIV>) [8,8 784x53.34375]
+        PaintableWithLines (BlockContainer(anonymous)) [8,8 55.359375x53.34375]
+          TextPaintable (TextNode<#text>)
+          TextPaintable (TextNode<#text>)
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/input/flex/br-element-does-not-get-blockified-by-itself.html
+++ b/Tests/LibWeb/Layout/input/flex/br-element-does-not-get-blockified-by-itself.html
@@ -1,0 +1,8 @@
+<!doctype><style>
+* { outline: 1px solid black; }
+div { display: flex; }
+</style>
+<div>
+well<br>
+hello<br>
+friends

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -68,6 +68,7 @@
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Element.h>
 #include <LibWeb/FontCache.h>
+#include <LibWeb/HTML/HTMLBRElement.h>
 #include <LibWeb/HTML/HTMLHtmlElement.h>
 #include <LibWeb/Layout/Node.h>
 #include <LibWeb/Loader/ResourceLoader.h>
@@ -2427,6 +2428,12 @@ enum class BoxTypeTransformation {
 
 static BoxTypeTransformation required_box_type_transformation(StyleProperties const& style, DOM::Element const& element, Optional<CSS::Selector::PseudoElement> const& pseudo_element)
 {
+    // NOTE: We never blockify <br> elements. They are always inline.
+    //       There is currently no way to express in CSS how a <br> element really behaves.
+    //       Spec issue: https://github.com/whatwg/html/issues/2291
+    if (is<HTML::HTMLBRElement>(element))
+        return BoxTypeTransformation::None;
+
     // Absolute positioning or floating an element blockifies the box’s display type. [CSS2]
     if (style.position() == CSS::Position::Absolute || style.position() == CSS::Position::Fixed || style.float_() != CSS::Float::None)
         return BoxTypeTransformation::Blockify;

--- a/Userland/Libraries/LibWeb/DOM/Node.h
+++ b/Userland/Libraries/LibWeb/DOM/Node.h
@@ -99,6 +99,7 @@ public:
     virtual bool is_html_table_section_element() const { return false; }
     virtual bool is_html_table_row_element() const { return false; }
     virtual bool is_html_table_cell_element() const { return false; }
+    virtual bool is_html_br_element() const { return false; }
     virtual bool is_navigable_container() const { return false; }
 
     WebIDL::ExceptionOr<JS::NonnullGCPtr<Node>> pre_insert(JS::NonnullGCPtr<Node>, JS::GCPtr<Node>);

--- a/Userland/Libraries/LibWeb/HTML/HTMLBRElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLBRElement.h
@@ -19,9 +19,16 @@ public:
     virtual JS::GCPtr<Layout::Node> create_layout_node(NonnullRefPtr<CSS::StyleProperties>) override;
 
 private:
+    virtual bool is_html_br_element() const override { return true; }
+
     HTMLBRElement(DOM::Document&, DOM::QualifiedName);
 
     virtual void initialize(JS::Realm&) override;
 };
 
+}
+
+namespace Web::DOM {
+template<>
+inline bool Node::fast_is<HTML::HTMLBRElement>() const { return is_html_br_element(); }
 }

--- a/Userland/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -69,6 +69,8 @@ static Layout::Node& insertion_parent_for_inline_node(Layout::NodeWithStyle& lay
         return layout_parent;
 
     if (layout_parent.display().is_flex_inside() || layout_parent.display().is_grid_inside()) {
+        if (layout_parent.last_child() && layout_parent.last_child()->is_anonymous() && layout_parent.last_child()->children_are_inline())
+            return *layout_parent.last_child();
         layout_parent.append_child(layout_parent.create_anonymous_wrapper());
         return *layout_parent.last_child();
     }


### PR DESCRIPTION
Two issues here:
- `<br>` elements should never be blockified.
- Multiple consecutive inline-level children of flex containers should be collected into a single anonymous wrapper.

Visual progression on https://lillanapoli.se/

Before:
![Screenshot at 2023-09-01 11-07-07](https://github.com/SerenityOS/serenity/assets/5954907/13bfcf07-4201-452b-b2e7-70f15d55456e)

After:
![Screenshot at 2023-09-01 11-06-44](https://github.com/SerenityOS/serenity/assets/5954907/2cd1bea4-ffdb-4d4c-9178-44444c40b2d8)
