### PR TITLE
Ladybird: Add ladybird.nix to nix flake in Toolchain/

### DIFF
--- a/Documentation/BuildInstructionsLadybird.md
+++ b/Documentation/BuildInstructionsLadybird.md
@@ -36,6 +36,10 @@ On Nix/NixOS:
 ```
 nix-shell ladybird.nix
 ```
+You can also use the nix flake in `Toolchain`:
+```
+nix develop Toolchain/#ladybird
+```
 
 On macOS:
 

--- a/Toolchain/flake.nix
+++ b/Toolchain/flake.nix
@@ -13,6 +13,7 @@
         {
           formatter = pkgs.nixpkgs-fmt;
           devShells.default = import ./serenity.nix { inherit pkgs; };
+          devShells.ladybird = import ../Ladybird/ladybird.nix { inherit pkgs; };
         }
       );
 


### PR DESCRIPTION
Add another nix dev shell to `Toolchain/flake.nix` called `ladybird.nix` that pulls in the dependencies for building Ladybird.

Also update the documentation to mention building with a flake.

I've tested this and I am able to build and run Ladybird.