### PR TITLE
LibWeb: Define getting and setting an attribute value

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Attr.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Attr.cpp
@@ -71,16 +71,24 @@ void Attr::set_value(DeprecatedString value)
     // 1. If attribute’s element is null, then set attribute’s value to value.
     if (!owner_element()) {
         m_value = move(value);
-        return;
     }
-
     // 2. Otherwise, change attribute to value.
-    // https://dom.spec.whatwg.org/#concept-element-attributes-change
-    // 1. Handle attribute changes for attribute with attribute’s element, attribute’s value, and value.
-    handle_attribute_changes(*owner_element(), m_value, value);
+    else {
+        change_attribute(move(value));
+    }
+}
+
+// https://dom.spec.whatwg.org/#concept-element-attributes-change
+void Attr::change_attribute(DeprecatedString value)
+{
+    // 1. Let oldValue be attribute’s value.
+    auto old_value = move(m_value);
 
     // 2. Set attribute’s value to value.
     m_value = move(value);
+
+    // 3. Handle attribute changes for attribute with attribute’s element, oldValue, and value.
+    handle_attribute_changes(*owner_element(), old_value, m_value);
 }
 
 // https://dom.spec.whatwg.org/#handle-attribute-changes

--- a/Userland/Libraries/LibWeb/DOM/Attr.h
+++ b/Userland/Libraries/LibWeb/DOM/Attr.h
@@ -33,6 +33,7 @@ public:
 
     DeprecatedString const& value() const { return m_value; }
     void set_value(DeprecatedString value);
+    void change_attribute(DeprecatedString value);
 
     Element* owner_element();
     Element const* owner_element() const;

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -90,12 +90,17 @@ public:
     bool has_attribute(DeprecatedFlyString const& name) const;
     bool has_attribute_ns(DeprecatedFlyString namespace_, DeprecatedFlyString const& name) const;
     bool has_attributes() const;
+
     DeprecatedString attribute(DeprecatedFlyString const& name) const { return get_attribute(name); }
     DeprecatedString get_attribute(DeprecatedFlyString const& name) const;
+    DeprecatedString get_attribute_value(DeprecatedFlyString const& local_name, DeprecatedFlyString const& namespace_ = {}) const;
+
     virtual WebIDL::ExceptionOr<void> set_attribute(DeprecatedFlyString const& name, DeprecatedString const& value);
     WebIDL::ExceptionOr<void> set_attribute_ns(DeprecatedFlyString const& namespace_, DeprecatedFlyString const& qualified_name, DeprecatedString const& value);
+    void set_attribute_value(DeprecatedFlyString const& local_name, DeprecatedString const& value, DeprecatedFlyString const& prefix = {}, DeprecatedFlyString const& namespace_ = {});
     WebIDL::ExceptionOr<JS::GCPtr<Attr>> set_attribute_node(Attr&);
     WebIDL::ExceptionOr<JS::GCPtr<Attr>> set_attribute_node_ns(Attr&);
+
     virtual void remove_attribute(DeprecatedFlyString const& name);
     WebIDL::ExceptionOr<bool> toggle_attribute(DeprecatedFlyString const& name, Optional<bool> force);
     size_t attribute_list_size() const;


### PR DESCRIPTION
These are a bit different than the existing `get/set_attribute`, and are meant to be used by our `Reflect` implementation. These are not used here, but just making a PR for @alimpfard.