### PR TITLE
find: Add the `-empty` option

### DIFF
--- a/Base/usr/share/man/man1/find.md
+++ b/Base/usr/share/man/man1/find.md
@@ -46,6 +46,8 @@ space rounded up to the nearest whole unit.
 
 * `-name pattern`: Checks if the file name matches the given global-style
   pattern (case sensitive).
+* `-empty`: File is either an empty regular file or a directory containing no
+  files.
 * `-iname pattern`: Checks if the file name matches the given global-style
   pattern (case insensitive).
 * `-readable`: Checks if the file is readable by the current user.


### PR DESCRIPTION
This returns true for empty regular files or directories.

Example usage:

![find_empty_option](https://github.com/SerenityOS/serenity/assets/2817754/6c9ef4e1-c5f6-490a-bd52-b20cef7c2d4c)