### PR TITLE
LibGfx: Remove maximum size limit for decoded images 

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/BMPLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/BMPLoader.cpp
@@ -550,11 +550,6 @@ static bool decode_bmp_core_dib(BMPLoadingContext& context, InputStreamer& strea
         return false;
     }
 
-    if (static_cast<size_t>(core.width) > maximum_width_for_decoded_images || static_cast<size_t>(abs(core.height)) > maximum_height_for_decoded_images) {
-        dbgln("This BMP is too large for comfort: {}x{}", core.width, abs(core.height));
-        return false;
-    }
-
     auto color_planes = streamer.read_u16();
     if (color_planes != 1) {
         dbgln("BMP has an invalid number of color planes: {}", color_planes);

--- a/Userland/Libraries/LibGfx/ImageFormats/GIFLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/GIFLoader.cpp
@@ -391,11 +391,6 @@ static ErrorOr<void> load_header_and_logical_screen(GIFLoadingContext& context)
     context.logical_screen.width = TRY(context.stream.read_value<LittleEndian<u16>>());
     context.logical_screen.height = TRY(context.stream.read_value<LittleEndian<u16>>());
 
-    if (context.logical_screen.width > maximum_width_for_decoded_images || context.logical_screen.height > maximum_height_for_decoded_images) {
-        dbgln("This GIF is too large for comfort: {}x{}", context.logical_screen.width, context.logical_screen.height);
-        return Error::from_string_literal("This GIF is too large for comfort");
-    }
-
     auto gcm_info = TRY(context.stream.read_value<u8>());
     context.background_color_index = TRY(context.stream.read_value<u8>());
     [[maybe_unused]] auto pixel_aspect_ratio = TRY(context.stream.read_value<u8>());

--- a/Userland/Libraries/LibGfx/ImageFormats/ImageDecoder.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/ImageDecoder.h
@@ -18,9 +18,6 @@ namespace Gfx {
 
 class Bitmap;
 
-static constexpr size_t maximum_width_for_decoded_images = 16384;
-static constexpr size_t maximum_height_for_decoded_images = 16384;
-
 struct ImageFrameDescriptor {
     RefPtr<Bitmap> image;
     int duration { 0 };

--- a/Userland/Libraries/LibGfx/ImageFormats/JPEGLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEGLoader.cpp
@@ -1245,11 +1245,6 @@ static ErrorOr<void> read_start_of_frame(JPEGStream& stream, JPEGLoadingContext&
         return Error::from_string_literal("Image frame height of width null");
     }
 
-    if (context.frame.width > maximum_width_for_decoded_images || context.frame.height > maximum_height_for_decoded_images) {
-        dbgln("This JPEG is too large for comfort: {}x{}", context.frame.width, context.frame.height);
-        return Error::from_string_literal("JPEG too large for comfort");
-    }
-
     set_macroblock_metadata(context);
 
     auto component_count = TRY(stream.read_u8());

--- a/Userland/Libraries/LibGfx/ImageFormats/PNGLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/PNGLoader.cpp
@@ -933,11 +933,6 @@ static ErrorOr<void> process_IHDR(ReadonlyBytes data, PNGLoadingContext& context
 
     auto const& ihdr = *(const PNG_IHDR*)data.data();
 
-    if (ihdr.width > maximum_width_for_decoded_images || ihdr.height > maximum_height_for_decoded_images) {
-        dbgln("This PNG is too large for comfort: {}x{}", (u32)ihdr.width, (u32)ihdr.height);
-        return Error::from_string_literal("This PNG is too large for comfort");
-    }
-
     if (!is_valid_compression_method(ihdr.compression_method)) {
         dbgln("PNG has invalid compression method {}", ihdr.compression_method);
         return Error::from_string_literal("Unsupported compression method");

--- a/Userland/Libraries/LibGfx/ImageFormats/PortableImageLoaderCommon.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/PortableImageLoaderCommon.h
@@ -175,11 +175,6 @@ static ErrorOr<void> read_header(Context& context)
     TRY(read_whitespace(context));
     TRY(read_height(context));
 
-    if (context.width > maximum_width_for_decoded_images || context.height > maximum_height_for_decoded_images) {
-        dbgln("This portable network image is too large for comfort: {}x{}", context.width, context.height);
-        return Error::from_string_literal("This portable network image is too large.");
-    }
-
     TRY(read_whitespace(context));
 
     if constexpr (requires { context.format_details.max_val; }) {


### PR DESCRIPTION
Fixes #20872