### PR TITLE
LibWeb: Reduce `CSSPixels` -> `float` round trips

### DIFF
--- a/Userland/Libraries/LibGfx/Point.h
+++ b/Userland/Libraries/LibGfx/Point.h
@@ -42,8 +42,8 @@ public:
     {
     }
 
-    [[nodiscard]] ALWAYS_INLINE T x() const { return m_x; }
-    [[nodiscard]] ALWAYS_INLINE T y() const { return m_y; }
+    [[nodiscard]] constexpr ALWAYS_INLINE T x() const { return m_x; }
+    [[nodiscard]] constexpr ALWAYS_INLINE T y() const { return m_y; }
 
     ALWAYS_INLINE void set_x(T x) { m_x = x; }
     ALWAYS_INLINE void set_y(T y) { m_y = y; }

--- a/Userland/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Userland/Libraries/LibWeb/CSS/ComputedValues.h
@@ -41,7 +41,7 @@ struct GridAutoFlow {
 class InitialValues {
 public:
     static AspectRatio aspect_ratio() { return AspectRatio { true, {} }; }
-    static float font_size() { return 16; }
+    static CSSPixels font_size() { return 16; }
     static int font_weight() { return 400; }
     static CSS::FontVariant font_variant() { return CSS::FontVariant::Normal; }
     static CSS::Float float_() { return CSS::Float::None; }
@@ -334,7 +334,7 @@ public:
     Vector<CSS::Transformation> const& transformations() const { return m_noninherited.transformations; }
     CSS::TransformOrigin const& transform_origin() const { return m_noninherited.transform_origin; }
 
-    float font_size() const { return m_inherited.font_size; }
+    CSSPixels font_size() const { return m_inherited.font_size; }
     int font_weight() const { return m_inherited.font_weight; }
     CSS::FontVariant font_variant() const { return m_inherited.font_variant; }
     CSS::Time transition_delay() const { return m_noninherited.transition_delay; }
@@ -355,7 +355,7 @@ public:
 
 protected:
     struct {
-        float font_size { InitialValues::font_size() };
+        CSSPixels font_size { InitialValues::font_size() };
         int font_weight { InitialValues::font_weight() };
         CSS::FontVariant font_variant { InitialValues::font_variant() };
         CSS::BorderCollapse border_collapse { InitialValues::border_collapse() };
@@ -477,7 +477,7 @@ public:
     }
 
     void set_aspect_ratio(AspectRatio aspect_ratio) { m_noninherited.aspect_ratio = aspect_ratio; }
-    void set_font_size(float font_size) { m_inherited.font_size = font_size; }
+    void set_font_size(CSSPixels font_size) { m_inherited.font_size = font_size; }
     void set_font_weight(int font_weight) { m_inherited.font_weight = font_weight; }
     void set_font_variant(CSS::FontVariant font_variant) { m_inherited.font_variant = font_variant; }
     void set_border_spacing_horizontal(CSS::Length border_spacing_horizontal) { m_inherited.border_spacing_horizontal = border_spacing_horizontal; }

--- a/Userland/Libraries/LibWeb/CSS/Length.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Length.cpp
@@ -98,34 +98,34 @@ CSSPixels Length::viewport_relative_length_to_px(CSSPixelRect const& viewport_re
     case Type::Svw:
     case Type::Lvw:
     case Type::Dvw:
-        return CSSPixels::nearest_value_for(viewport_rect.width() * (m_value / 100));
+        return viewport_rect.width() * (CSSPixels::nearest_value_for(m_value) / 100);
     case Type::Vh:
     case Type::Svh:
     case Type::Lvh:
     case Type::Dvh:
-        return CSSPixels::nearest_value_for(viewport_rect.height() * (m_value / 100));
+        return viewport_rect.height() * (CSSPixels::nearest_value_for(m_value) / 100);
     case Type::Vi:
     case Type::Svi:
     case Type::Lvi:
     case Type::Dvi:
         // FIXME: Select the width or height based on which is the inline axis.
-        return CSSPixels::nearest_value_for(viewport_rect.width() * (m_value / 100));
+        return viewport_rect.width() * (CSSPixels::nearest_value_for(m_value) / 100);
     case Type::Vb:
     case Type::Svb:
     case Type::Lvb:
     case Type::Dvb:
         // FIXME: Select the width or height based on which is the block axis.
-        return CSSPixels::nearest_value_for(viewport_rect.height() * (m_value / 100));
+        return viewport_rect.height() * (CSSPixels::nearest_value_for(m_value) / 100);
     case Type::Vmin:
     case Type::Svmin:
     case Type::Lvmin:
     case Type::Dvmin:
-        return CSSPixels::nearest_value_for(min(viewport_rect.width(), viewport_rect.height()) * (m_value / 100));
+        return min(viewport_rect.width(), viewport_rect.height()) * (CSSPixels::nearest_value_for(m_value) / 100);
     case Type::Vmax:
     case Type::Svmax:
     case Type::Lvmax:
     case Type::Dvmax:
-        return CSSPixels::nearest_value_for(max(viewport_rect.width(), viewport_rect.height()) * (m_value / 100));
+        return max(viewport_rect.width(), viewport_rect.height()) * (CSSPixels::nearest_value_for(m_value) / 100);
     default:
         VERIFY_NOT_REACHED();
     }

--- a/Userland/Libraries/LibWeb/CSS/Length.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Length.cpp
@@ -138,8 +138,8 @@ Length::ResolutionContext Length::ResolutionContext::for_layout_node(Layout::Nod
     VERIFY(root_element->layout_node());
     return Length::ResolutionContext {
         .viewport_rect = node.browsing_context().viewport_rect(),
-        .font_metrics = { CSSPixels::nearest_value_for(node.computed_values().font_size()), node.font().pixel_metrics(), node.line_height() },
-        .root_font_metrics = { CSSPixels::nearest_value_for(root_element->layout_node()->computed_values().font_size()), root_element->layout_node()->font().pixel_metrics(), root_element->layout_node()->line_height() },
+        .font_metrics = { node.computed_values().font_size(), node.font().pixel_metrics(), node.line_height() },
+        .root_font_metrics = { root_element->layout_node()->computed_values().font_size(), root_element->layout_node()->font().pixel_metrics(), root_element->layout_node()->line_height() },
     };
 }
 
@@ -168,12 +168,12 @@ CSSPixels Length::to_px(Layout::Node const& layout_node) const
             return 0;
 
         FontMetrics font_metrics {
-            CSSPixels::nearest_value_for(layout_node.computed_values().font_size()),
+            layout_node.computed_values().font_size(),
             layout_node.font().pixel_metrics(),
             layout_node.line_height()
         };
         FontMetrics root_font_metrics {
-            CSSPixels::nearest_value_for(root_element->layout_node()->computed_values().font_size()),
+            root_element->layout_node()->computed_values().font_size(),
             root_element->layout_node()->font().pixel_metrics(),
             root_element->layout_node()->line_height()
         };

--- a/Userland/Libraries/LibWeb/CSS/Position.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Position.cpp
@@ -15,36 +15,32 @@ CSSPixelPoint PositionValue::resolved(Layout::Node const& node, CSSPixelRect con
     // Note: A preset + a none default x/y_relative_to is impossible in the syntax (and makes little sense)
     CSSPixels x = horizontal_position.visit(
         [&](HorizontalPreset preset) -> CSSPixels {
-            return rect.width() * [&] {
-                switch (preset) {
-                case HorizontalPreset::Left:
-                    return CSSPixels(0.0);
-                case HorizontalPreset::Center:
-                    return CSSPixels(0.5);
-                case HorizontalPreset::Right:
-                    return CSSPixels(1.0);
-                default:
-                    VERIFY_NOT_REACHED();
-                }
-            }();
+            switch (preset) {
+            case HorizontalPreset::Left:
+                return 0;
+            case HorizontalPreset::Center:
+                return rect.width() / 2;
+            case HorizontalPreset::Right:
+                return rect.width();
+            default:
+                VERIFY_NOT_REACHED();
+            }
         },
         [&](LengthPercentage length_percentage) -> CSSPixels {
             return length_percentage.to_px(node, rect.width());
         });
     CSSPixels y = vertical_position.visit(
         [&](VerticalPreset preset) -> CSSPixels {
-            return rect.height() * [&] {
-                switch (preset) {
-                case VerticalPreset::Top:
-                    return CSSPixels(0.0);
-                case VerticalPreset::Center:
-                    return CSSPixels(0.5);
-                case VerticalPreset::Bottom:
-                    return CSSPixels(1.0);
-                default:
-                    VERIFY_NOT_REACHED();
-                }
-            }();
+            switch (preset) {
+            case VerticalPreset::Top:
+                return 0;
+            case VerticalPreset::Center:
+                return rect.height() / 2;
+            case VerticalPreset::Bottom:
+                return rect.height();
+            default:
+                VERIFY_NOT_REACHED();
+            }
         },
         [&](LengthPercentage length_percentage) -> CSSPixels {
             return length_percentage.to_px(node, rect.height());

--- a/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
@@ -598,7 +598,7 @@ RefPtr<StyleValue const> ResolvedCSSStyleDeclaration::style_value_for_property(L
     case PropertyID::Float:
         return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().float_()));
     case PropertyID::FontSize:
-        return LengthStyleValue::create(Length::make_px(CSSPixels::nearest_value_for(layout_node.computed_values().font_size())));
+        return LengthStyleValue::create(Length::make_px(layout_node.computed_values().font_size()));
     case PropertyID::FontVariant: {
         auto font_variant = layout_node.computed_values().font_variant();
         switch (font_variant) {

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -1941,17 +1941,31 @@ RefPtr<Gfx::Font const> StyleComputer::compute_font_for_style_values(DOM::Elemen
 
     if (font_size.is_identifier()) {
         // https://w3c.github.io/csswg-drafts/css-fonts/#absolute-size-mapping
-        AK::HashMap<Web::CSS::ValueID, float> absolute_size_mapping = {
-            { CSS::ValueID::XxSmall, 0.6 },
-            { CSS::ValueID::XSmall, 0.75 },
-            { CSS::ValueID::Small, 8.0 / 9.0 },
-            { CSS::ValueID::Medium, 1.0 },
-            { CSS::ValueID::Large, 1.2 },
-            { CSS::ValueID::XLarge, 1.5 },
-            { CSS::ValueID::XxLarge, 2.0 },
-            { CSS::ValueID::XxxLarge, 3.0 },
-            { CSS::ValueID::Smaller, 0.8 },
-            { CSS::ValueID::Larger, 1.25 },
+        constexpr auto get_absolute_size_mapping = [](Web::CSS::ValueID identifier) {
+            switch (identifier) {
+            case CSS::ValueID::XxSmall:
+                return 0.6f;
+            case CSS::ValueID::XSmall:
+                return 0.75f;
+            case CSS::ValueID::Small:
+                return 8.0f / 9.0f;
+            case CSS::ValueID::Medium:
+                return 1.0f;
+            case CSS::ValueID::Large:
+                return 1.2f;
+            case CSS::ValueID::XLarge:
+                return 1.5f;
+            case CSS::ValueID::XxLarge:
+                return 2.0f;
+            case CSS::ValueID::XxxLarge:
+                return 3.0f;
+            case CSS::ValueID::Smaller:
+                return 0.8f;
+            case CSS::ValueID::Larger:
+                return 1.25f;
+            default:
+                return 1.0f;
+            }
         };
 
         auto const identifier = static_cast<IdentifierStyleValue const&>(font_size).id();
@@ -1965,8 +1979,7 @@ RefPtr<Gfx::Font const> StyleComputer::compute_font_for_style_values(DOM::Elemen
                 font_size_in_px = CSSPixels::nearest_value_for(parent_element->computed_css_values()->computed_font().pixel_metrics().size);
             }
         }
-        auto const multiplier = absolute_size_mapping.get(identifier).value_or(1.0);
-        font_size_in_px.scale_by(multiplier);
+        font_size_in_px.scale_by(get_absolute_size_mapping(identifier));
 
     } else {
         Length::ResolutionContext const length_resolution_context {

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -1941,30 +1941,30 @@ RefPtr<Gfx::Font const> StyleComputer::compute_font_for_style_values(DOM::Elemen
 
     if (font_size.is_identifier()) {
         // https://w3c.github.io/csswg-drafts/css-fonts/#absolute-size-mapping
-        constexpr auto get_absolute_size_mapping = [](Web::CSS::ValueID identifier) {
+        auto get_absolute_size_mapping = [](Web::CSS::ValueID identifier) -> CSSPixelFraction {
             switch (identifier) {
             case CSS::ValueID::XxSmall:
-                return 0.6f;
+                return CSSPixels(3) / 5;
             case CSS::ValueID::XSmall:
-                return 0.75f;
+                return CSSPixels(3) / 4;
             case CSS::ValueID::Small:
-                return 8.0f / 9.0f;
+                return CSSPixels(8) / 9;
             case CSS::ValueID::Medium:
-                return 1.0f;
+                return 1;
             case CSS::ValueID::Large:
-                return 1.2f;
+                return CSSPixels(6) / 5;
             case CSS::ValueID::XLarge:
-                return 1.5f;
+                return CSSPixels(3) / 2;
             case CSS::ValueID::XxLarge:
-                return 2.0f;
+                return 2;
             case CSS::ValueID::XxxLarge:
-                return 3.0f;
+                return 3;
             case CSS::ValueID::Smaller:
-                return 0.8f;
+                return CSSPixels(4) / 5;
             case CSS::ValueID::Larger:
-                return 1.25f;
+                return CSSPixels(5) / 4;
             default:
-                return 1.0f;
+                return 1;
             }
         };
 
@@ -1979,8 +1979,7 @@ RefPtr<Gfx::Font const> StyleComputer::compute_font_for_style_values(DOM::Elemen
                 font_size_in_px = CSSPixels::nearest_value_for(parent_element->computed_css_values()->computed_font().pixel_metrics().size);
             }
         }
-        font_size_in_px.scale_by(get_absolute_size_mapping(identifier));
-
+        font_size_in_px *= get_absolute_size_mapping(identifier);
     } else {
         Length::ResolutionContext const length_resolution_context {
             .viewport_rect = viewport_rect(),

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/RadialGradientStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/RadialGradientStyleValue.cpp
@@ -85,16 +85,17 @@ Gfx::FloatSize RadialGradientStyleValue::resolve_size(Layout::Node const& node, 
         auto bottom_right_distance = size.bottom_right().distance_from(center);
         auto bottom_left_distance = size.bottom_left().distance_from(center);
         auto distance = top_left_distance;
+        corner = size.top_left();
         if (distance_compare(top_right_distance, distance)) {
             corner = size.top_right();
             distance = top_right_distance;
         }
         if (distance_compare(bottom_right_distance, distance)) {
-            corner = size.top_right();
+            corner = size.bottom_right();
             distance = bottom_right_distance;
         }
         if (distance_compare(bottom_left_distance, distance)) {
-            corner = size.top_right();
+            corner = size.bottom_left();
             distance = bottom_left_distance;
         }
         return distance;

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/RadialGradientStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/RadialGradientStyleValue.h
@@ -65,7 +65,7 @@ public:
 
     void resolve_for_size(Layout::NodeWithStyleAndBoxModelMetrics const&, CSSPixelSize) const override;
 
-    Gfx::FloatSize resolve_size(Layout::Node const&, Gfx::FloatPoint, Gfx::FloatRect const&) const;
+    CSSPixelSize resolve_size(Layout::Node const&, CSSPixelPoint, CSSPixelRect const&) const;
 
     bool is_repeating() const { return m_properties.repeating == GradientRepeating::Yes; }
 
@@ -89,8 +89,8 @@ private:
 
     struct ResolvedData {
         Painting::RadialGradientData data;
-        Gfx::FloatSize gradient_size;
-        Gfx::FloatPoint center;
+        CSSPixelSize gradient_size;
+        CSSPixelPoint center;
     };
 
     mutable Optional<ResolvedData> m_resolved;

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -1712,7 +1712,7 @@ CSSPixels FormattingContext::box_baseline(Box const& box) const
             return box_state.content_height() + box_state.margin_box_top();
         case CSS::VerticalAlign::TextTop:
             // TextTop: Align the top of the box with the top of the parent's content area (see 10.6.1).
-            return CSSPixels::nearest_value_for(box.computed_values().font_size());
+            return box.computed_values().font_size();
         case CSS::VerticalAlign::TextBottom:
             // TextTop: Align the bottom of the box with the bottom of the parent's content area (see 10.6.1).
             return box_state.content_height() - CSSPixels::nearest_value_for(box.containing_block()->font().pixel_metrics().descent * 2);

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -849,7 +849,7 @@ void GridFormattingContext::distribute_extra_space_across_spanned_tracks_base_si
         // Find the item-incurred increase for each spanned track with an affected size by: distributing the space
         // equally among such tracks, freezing a track’s item-incurred increase as its affected size + item-incurred
         // increase reaches its limit
-        CSSPixels increase_per_track = max(extra_space / affected_tracks.size(), CSSPixels::smallest_positive_value());
+        CSSPixels increase_per_track = max(CSSPixels::smallest_positive_value(), extra_space / affected_tracks.size());
         for (auto& track : affected_tracks) {
             if (track.base_size_frozen)
                 continue;

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -321,7 +321,7 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& computed_style)
     //       m_font is used by Length::to_px() when resolving sizes against this layout node.
     //       That's why it has to be set before everything else.
     m_font = computed_style.computed_font();
-    computed_values.set_font_size(computed_style.property(CSS::PropertyID::FontSize)->as_length().length().to_px(*this).to_double());
+    computed_values.set_font_size(computed_style.property(CSS::PropertyID::FontSize)->as_length().length().to_px(*this));
     computed_values.set_font_weight(round_to<int>(computed_style.property(CSS::PropertyID::FontWeight)->as_number().number()));
     m_line_height = computed_style.line_height(*this);
 

--- a/Userland/Libraries/LibWeb/PixelUnits.h
+++ b/Userland/Libraries/LibWeb/PixelUnits.h
@@ -324,6 +324,20 @@ public:
         return CSSPixels::from_raw(AK::clamp_to_int(wide_value));
     }
 
+    constexpr CSSPixels operator-(CSSPixels const& other) const
+    {
+        return CSSPixels(*this) - other;
+    }
+    constexpr CSSPixels operator+(CSSPixels const& other) const
+    {
+        return CSSPixels(*this) + other;
+    }
+
+    constexpr CSSPixelFraction operator-() const
+    {
+        return CSSPixelFraction(-numerator(), denominator());
+    }
+
     constexpr int operator<=>(CSSPixelFraction const& other) const
     {
         auto left = static_cast<i64>(m_numerator.raw_value()) * other.m_denominator.raw_value();
@@ -375,7 +389,7 @@ constexpr CSSPixels CSSPixels::operator/(CSSPixelFraction const& other) const
 }
 
 template<Integral T>
-constexpr CSSPixels operator/(CSSPixels left, T right) { return left / CSSPixels(right); }
+constexpr CSSPixelFraction operator/(CSSPixels left, T right) { return left / CSSPixels(right); }
 inline float operator/(CSSPixels left, float right) { return left.to_float() / right; }
 inline double operator/(CSSPixels left, double right) { return left.to_double() / right; }
 

--- a/Userland/Libraries/LibWeb/PixelUnits.h
+++ b/Userland/Libraries/LibWeb/PixelUnits.h
@@ -262,27 +262,28 @@ private:
     i32 m_value { 0 };
 };
 
-constexpr bool operator==(CSSPixels left, int right) { return left == CSSPixels(right); }
+template<Integral T>
+constexpr bool operator==(CSSPixels left, T right) { return left == CSSPixels(right); }
 inline bool operator==(CSSPixels left, float right) { return left.to_float() == right; }
 inline bool operator==(CSSPixels left, double right) { return left.to_double() == right; }
 
-constexpr bool operator>(CSSPixels left, int right) { return left > CSSPixels(right); }
+template<Integral T>
+constexpr bool operator>(CSSPixels left, T right) { return left > CSSPixels(right); }
 inline bool operator>(CSSPixels left, float right) { return left.to_float() > right; }
 inline bool operator>(CSSPixels left, double right) { return left.to_double() > right; }
 
-constexpr bool operator<(CSSPixels left, int right) { return left < CSSPixels(right); }
+template<Integral T>
+constexpr bool operator<(CSSPixels left, T right) { return left < CSSPixels(right); }
 inline bool operator<(CSSPixels left, float right) { return left.to_float() < right; }
 inline bool operator<(CSSPixels left, double right) { return left.to_double() < right; }
 
-constexpr CSSPixels operator*(CSSPixels left, int right) { return left * CSSPixels(right); }
-constexpr CSSPixels operator*(CSSPixels left, unsigned int right) { return left * CSSPixels(right); }
-constexpr CSSPixels operator*(CSSPixels left, unsigned long right) { return left * CSSPixels(right); }
+template<Integral T>
+constexpr CSSPixels operator*(CSSPixels left, T right) { return left * CSSPixels(right); }
 inline float operator*(CSSPixels left, float right) { return left.to_float() * right; }
 inline double operator*(CSSPixels left, double right) { return left.to_double() * right; }
 
-constexpr CSSPixels operator*(int left, CSSPixels right) { return right * CSSPixels(left); }
-constexpr CSSPixels operator*(unsigned int left, CSSPixels right) { return right * CSSPixels(left); }
-constexpr CSSPixels operator*(unsigned long left, CSSPixels right) { return right * CSSPixels(left); }
+template<Integral T>
+constexpr CSSPixels operator*(T left, CSSPixels right) { return CSSPixels(left) * right; }
 inline float operator*(float left, CSSPixels right) { return right.to_float() * left; }
 inline double operator*(double left, CSSPixels right) { return right.to_double() * left; }
 
@@ -373,9 +374,8 @@ constexpr CSSPixels CSSPixels::operator/(CSSPixelFraction const& other) const
     return CSSPixels::from_raw(AK::clamp_to_int(wide_value));
 }
 
-constexpr CSSPixels operator/(CSSPixels left, int right) { return left / CSSPixels(right); }
-constexpr CSSPixels operator/(CSSPixels left, unsigned int right) { return left / CSSPixels(right); }
-constexpr CSSPixels operator/(CSSPixels left, unsigned long right) { return left / CSSPixels(right); }
+template<Integral T>
+constexpr CSSPixels operator/(CSSPixels left, T right) { return left / CSSPixels(right); }
 inline float operator/(CSSPixels left, float right) { return left.to_float() / right; }
 inline double operator/(CSSPixels left, double right) { return left.to_double() / right; }
 

--- a/Userland/Libraries/LibWeb/PixelUnits.h
+++ b/Userland/Libraries/LibWeb/PixelUnits.h
@@ -405,7 +405,7 @@ using DevicePixelSize = Gfx::Size<DevicePixels>;
 
 }
 
-inline Web::CSSPixels abs(Web::CSSPixels const& value)
+constexpr Web::CSSPixels abs(Web::CSSPixels const& value)
 {
     return value.abs();
 }
@@ -430,9 +430,21 @@ constexpr Web::CSSPixels round(Web::CSSPixels const& value)
     return ceil(value - Web::CSSPixels::from_raw(Web::CSSPixels::fixed_point_denominator >> 1 /* 0.5 */));
 }
 
+inline Web::CSSPixels sqrt(Web::CSSPixels const& value)
+{
+    return Web::CSSPixels::nearest_value_for(AK::sqrt(value.to_float()));
+}
+
 constexpr Web::DevicePixels abs(Web::DevicePixels const& value)
 {
     return AK::abs(value.value());
+}
+
+constexpr Web::CSSPixels square_distance_between(Web::CSSPixelPoint const& a, Web::CSSPixelPoint const& b)
+{
+    auto delta_x = abs(a.x() - b.x());
+    auto delta_y = abs(a.y() - b.y());
+    return delta_x * delta_x + delta_y * delta_y;
 }
 
 template<>


### PR DESCRIPTION
This is the first in a possible series of PRs to remove unnecessary usages of things like `CSSPixels(float)` and `CSSPixels::nearest_value_for()`. Thus far, I haven't observed any actual changes in test pages that I've examined with these changes applied.

As an extra little change, calculating a radial gradient's size should call `sqrt()` less often, since it was previously using actual distances instead of squared distances to compare.