### PR TITLE
Userland: Fix absolute paths in man page links

### DIFF
--- a/Userland/Libraries/LibMarkdown/Text.cpp
+++ b/Userland/Libraries/LibMarkdown/Text.cpp
@@ -670,7 +670,14 @@ NonnullOwnPtr<Text::Node> Text::parse_link(Vector<Token>::ConstIterator& tokens)
 
         if (*iterator == ")"sv) {
             tokens = iterator;
-            return make<LinkNode>(is_image, move(link_text), address.to_deprecated_string().trim_whitespace(), image_width, image_height);
+
+            DeprecatedString href = address.to_deprecated_string().trim_whitespace();
+
+            // Add file:// if the link is an absolute path otherwise it will be assumed relative.
+            if (AK::StringUtils::starts_with(href, "/"sv, CaseSensitivity::CaseSensitive))
+                href = DeprecatedString::formatted("file://{}", href);
+
+            return make<LinkNode>(is_image, move(link_text), move(href), image_width, image_height);
         }
 
         address.append(iterator->data);


### PR DESCRIPTION
Absolute paths in man page links such as

```
[some link](/foo/bar)
```

Were being interpreted as relative paths when rendered in HTML. This issue was observed in #20889 and #20041.

The fix is to make sure we don't leave any absolute paths when parsing links. Instead we check if a directory is absolute (by checking for `/`) and add `file://` accordingly. This turns the above link into:

```
[some link](file:///foo/bar)
```

Which does get interpreted correctly when rendered as HTML.

- fixes #20889
- fixes #20041

Before this patch, opening the Help application would raise an error. Now all the pictures in the man pages render correctly.