### PR TITLE
Calendar: Save time of the event and display it in Calendar

### DIFF
--- a/Userland/Applications/Calendar/EventCalendar.cpp
+++ b/Userland/Applications/Calendar/EventCalendar.cpp
@@ -33,17 +33,18 @@ void EventCalendar::paint_tile(GUI::Painter& painter, GUI::Calendar::Tile& tile,
         events.for_each([&](JsonValue const& value) {
             auto const& event = value.as_object();
 
-            if (!event.has("start_date"sv) || !event.has("summary"sv))
+            if (!event.has("start_date"sv) || !event.has("start_date"sv) || !event.has("summary"sv))
                 return;
 
             auto start_date = event.get("start_date"sv).value().to_deprecated_string();
+            auto start_time = event.get("start_time"sv).value().to_deprecated_string();
             auto summary = event.get("summary"sv).value().to_deprecated_string();
+            auto combined_text = DeprecatedString::formatted("{} {}", start_time, summary);
 
             if (start_date == DeprecatedString::formatted("{}-{:0>2d}-{:0>2d}", tile.year, tile.month, tile.day)) {
 
-                auto text_rect = tile.rect.translated(4, 4 + (font_height + 8) * ++index);
-
-                painter.draw_text(text_rect, summary, Gfx::FontDatabase::default_font(), Gfx::TextAlignment::TopLeft, palette().base_text());
+                auto text_rect = tile.rect.translated(4, 4 + (font_height + 4) * ++index);
+                painter.draw_text(text_rect, combined_text, Gfx::FontDatabase::default_font(), Gfx::TextAlignment::TopLeft, palette().base_text(), Gfx::TextElision::Right);
             }
         });
     }


### PR DESCRIPTION
This PR introduces the ability to save calendar event time and adds functionality for displaying saved times in the calendar. Additionally, it addresses the issue where changes to the time value in the dropdown were not being saved.

![image](https://github.com/SerenityOS/serenity/assets/55016761/9cfb52e9-360f-4251-876a-f7b7530bcc2c)


