### PR TITLE
LibJS: Add file & line number to bytecode VM stack traces :^)

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/Executable.h
+++ b/Userland/Libraries/LibJS/Bytecode/Executable.h
@@ -26,6 +26,11 @@ struct GlobalVariableCache : public PropertyLookupCache {
     u64 environment_serial_number { 0 };
 };
 
+struct SourceRecord {
+    u32 source_start_offset {};
+    u32 source_end_offset {};
+};
+
 struct Executable {
     DeprecatedFlyString name;
     Vector<PropertyLookupCache> property_lookup_caches;
@@ -34,6 +39,7 @@ struct Executable {
     NonnullOwnPtr<StringTable> string_table;
     NonnullOwnPtr<IdentifierTable> identifier_table;
     NonnullOwnPtr<RegexTable> regex_table;
+    NonnullRefPtr<SourceCode const> source_code;
     size_t number_of_registers { 0 };
     bool is_strict_mode { false };
 

--- a/Userland/Libraries/LibJS/Bytecode/Instruction.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Instruction.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibJS/Bytecode/Executable.h>
 #include <LibJS/Bytecode/Instruction.h>
 #include <LibJS/Bytecode/Op.h>
 
@@ -23,6 +24,22 @@ void Instruction::destroy(Instruction& instruction)
     }
 
 #undef __BYTECODE_OP
+}
+
+UnrealizedSourceRange InstructionStreamIterator::source_range() const
+{
+    VERIFY(m_executable);
+    auto record = dereference().source_record();
+    return {
+        .source_code = m_executable->source_code,
+        .start_offset = record.source_start_offset,
+        .end_offset = record.source_end_offset,
+    };
+}
+
+RefPtr<SourceCode> InstructionStreamIterator::source_code() const
+{
+    return m_executable ? m_executable->source_code.ptr() : nullptr;
 }
 
 }

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.h
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.h
@@ -87,7 +87,7 @@ public:
     Executable& current_executable() { return *m_current_executable; }
     Executable const& current_executable() const { return *m_current_executable; }
     BasicBlock const& current_block() const { return *m_current_block; }
-    size_t pc() const;
+    auto& instruction_stream_iterator() const { return m_pc; }
     DeprecatedString debug_position() const;
 
     Optional<Value>& this_value() { return m_this_value; }
@@ -121,7 +121,7 @@ private:
     Optional<Value> m_saved_exception;
     Executable* m_current_executable { nullptr };
     BasicBlock const* m_current_block { nullptr };
-    InstructionStreamIterator* m_pc { nullptr };
+    Optional<InstructionStreamIterator&> m_pc {};
 };
 
 extern bool g_dump_bytecode;

--- a/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
@@ -152,6 +152,7 @@ ThrowCompletionOr<Value> ECMAScriptFunctionObject::internal_call(Value this_argu
 
     // Non-standard
     callee_context.arguments.extend(move(arguments_list));
+    callee_context.instruction_stream_iterator = vm.bytecode_interpreter().instruction_stream_iterator();
 
     // 2. Let calleeContext be PrepareForOrdinaryCall(F, undefined).
     // NOTE: We throw if the end of the native stack is reached, so unlike in the spec this _does_ need an exception check.
@@ -221,6 +222,7 @@ ThrowCompletionOr<NonnullGCPtr<Object>> ECMAScriptFunctionObject::internal_const
 
     // Non-standard
     callee_context.arguments.extend(move(arguments_list));
+    callee_context.instruction_stream_iterator = vm.bytecode_interpreter().instruction_stream_iterator();
 
     // 4. Let calleeContext be PrepareForOrdinaryCall(F, newTarget).
     // NOTE: We throw if the end of the native stack is reached, so unlike in the spec this _does_ need an exception check.

--- a/Userland/Libraries/LibJS/Runtime/Error.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Error.cpp
@@ -83,9 +83,12 @@ void Error::populate_stack()
         if (function_name.is_empty())
             function_name = "<unknown>"sv;
 
+        UnrealizedSourceRange range = {};
+        if (context->instruction_stream_iterator.has_value())
+            range = context->instruction_stream_iterator->source_range();
         TracebackFrame frame {
             .function_name = move(function_name),
-            .source_range_storage = context->source_range,
+            .source_range_storage = range,
         };
 
         m_traceback.append(move(frame));

--- a/Userland/Libraries/LibJS/Runtime/ExecutionContext.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ExecutionContext.cpp
@@ -33,7 +33,7 @@ ExecutionContext ExecutionContext::copy() const
     copy.lexical_environment = lexical_environment;
     copy.variable_environment = variable_environment;
     copy.private_environment = private_environment;
-    copy.source_range = source_range;
+    copy.instruction_stream_iterator = instruction_stream_iterator;
     copy.function_name = function_name;
     copy.this_value = this_value;
     copy.is_strict_mode = is_strict_mode;

--- a/Userland/Libraries/LibJS/Runtime/ExecutionContext.h
+++ b/Userland/Libraries/LibJS/Runtime/ExecutionContext.h
@@ -10,6 +10,7 @@
 
 #include <AK/DeprecatedFlyString.h>
 #include <AK/WeakPtr.h>
+#include <LibJS/Bytecode/Instruction.h>
 #include <LibJS/Forward.h>
 #include <LibJS/Heap/MarkedVector.h>
 #include <LibJS/Module.h>
@@ -43,7 +44,7 @@ public:
     // Non-standard: This points at something that owns this ExecutionContext, in case it needs to be protected from GC.
     GCPtr<Cell> context_owner;
 
-    UnrealizedSourceRange source_range;
+    Optional<Bytecode::InstructionStreamIterator&> instruction_stream_iterator;
     DeprecatedFlyString function_name;
     Value this_value;
     MarkedVector<Value> arguments;

--- a/Userland/Libraries/LibJS/Runtime/NativeFunction.cpp
+++ b/Userland/Libraries/LibJS/Runtime/NativeFunction.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <LibJS/AST.h>
+#include <LibJS/Bytecode/Interpreter.h>
 #include <LibJS/Runtime/FunctionEnvironment.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/NativeFunction.h>
@@ -128,9 +129,9 @@ ThrowCompletionOr<Value> NativeFunction::internal_call(Value this_argument, Mark
     // Note: This is already the default value.
 
     // 8. Perform any necessary implementation-defined initialization of calleeContext.
-
     callee_context.this_value = this_argument;
     callee_context.arguments.extend(move(arguments_list));
+    callee_context.instruction_stream_iterator = vm.bytecode_interpreter().instruction_stream_iterator();
 
     callee_context.lexical_environment = caller_context.lexical_environment;
     callee_context.variable_environment = caller_context.variable_environment;
@@ -192,8 +193,8 @@ ThrowCompletionOr<NonnullGCPtr<Object>> NativeFunction::internal_construct(Marke
     // Note: This is already the default value.
 
     // 8. Perform any necessary implementation-defined initialization of calleeContext.
-
     callee_context.arguments.extend(move(arguments_list));
+    callee_context.instruction_stream_iterator = vm.bytecode_interpreter().instruction_stream_iterator();
 
     callee_context.lexical_environment = caller_context.lexical_environment;
     callee_context.variable_environment = caller_context.variable_environment;

--- a/Userland/Libraries/LibJS/Runtime/VM.cpp
+++ b/Userland/Libraries/LibJS/Runtime/VM.cpp
@@ -746,8 +746,8 @@ void VM::dump_backtrace() const
 {
     for (ssize_t i = m_execution_context_stack.size() - 1; i >= 0; --i) {
         auto& frame = m_execution_context_stack[i];
-        if (frame->source_range.source_code) {
-            auto source_range = frame->source_range.realize();
+        if (frame->instruction_stream_iterator->source_code()) {
+            auto source_range = frame->instruction_stream_iterator->source_range().realize();
             dbgln("-> {} @ {}:{},{}", frame->function_name, source_range.filename(), source_range.start.line, source_range.start.column);
         } else {
             dbgln("-> {}", frame->function_name);

--- a/Userland/Libraries/LibJS/Tests/builtins/Error/Error.prototype.stack.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Error/Error.prototype.stack.js
@@ -3,15 +3,14 @@ const stackGetter = stackDescriptor.get;
 const stackSetter = stackDescriptor.set;
 
 describe("getter - normal behavior", () => {
-    test.xfail("basic functionality", () => {
+    test("basic functionality", () => {
         const stackFrames = [
             /^    at .*Error \(.*\/Error\.prototype\.stack\.js:\d+:\d+\)$/,
             /^    at .+\/Error\/Error\.prototype\.stack\.js:\d+:\d+$/,
             /^    at test \(.+\/test-common.js:\d+:\d+\)$/,
-            /^    at (.+\/test-common.js:\d+:\d+)/,
-            /^    at .+\/Error\/Error\.prototype\.stack\.js:6:73$/,
+            /^    at .+\/Error\/Error\.prototype\.stack\.js:6:9$/,
             /^    at describe \(.+\/test-common\.js:\d+:\d+\)$/,
-            /^    at .+\/Error\/Error\.prototype\.stack\.js:5:38$/,
+            /^    at .+\/Error\/Error\.prototype\.stack\.js:5:9$/,
         ];
         const values = [
             {

--- a/Userland/Utilities/js.cpp
+++ b/Userland/Utilities/js.cpp
@@ -268,8 +268,13 @@ static ErrorOr<bool> parse_and_run(JS::Realm& realm, StringView source, StringVi
                     warnln(" -> {}", traceback_frame.function_name);
                     warnln(" {} more calls", repetitions);
                 } else {
-                    for (size_t j = 0; j < repetitions + 1; ++j)
-                        warnln(" -> {}", traceback_frame.function_name);
+                    for (size_t j = 0; j < repetitions + 1; ++j) {
+                        warnln(" -> {} ({}:{},{})",
+                            traceback_frame.function_name,
+                            traceback_frame.source_range().code->filename(),
+                            traceback_frame.source_range().start.line,
+                            traceback_frame.source_range().start.column);
+                    }
                 }
                 repetitions = 0;
             }


### PR DESCRIPTION
This works by adding source start/end offset to every bytecode instruction. In the future we can make this more efficient by keeping a map of bytecode ranges to source ranges in the Executable instead, but let's just get traces working first.