### PR TITLE
Userland: Always call syscall(SC_prctl, ...) with 4 arguments

### DIFF
--- a/Userland/Libraries/LibC/assert.cpp
+++ b/Userland/Libraries/LibC/assert.cpp
@@ -30,7 +30,7 @@ void __assertion_failed(char const* msg)
         { "assertion", strlen("assertion") },
         { msg, strlen(msg) },
     };
-    syscall(SC_prctl, PR_SET_COREDUMP_METADATA_VALUE, &params, nullptr);
+    syscall(SC_prctl, PR_SET_COREDUMP_METADATA_VALUE, &params, nullptr, nullptr);
     abort();
 }
 }

--- a/Userland/Libraries/LibC/unistd.cpp
+++ b/Userland/Libraries/LibC/unistd.cpp
@@ -1012,13 +1012,13 @@ void dump_backtrace()
 
 int get_process_name(char* buffer, int buffer_size)
 {
-    int rc = syscall(SC_prctl, PR_GET_PROCESS_NAME, buffer, buffer_size);
+    int rc = syscall(SC_prctl, PR_GET_PROCESS_NAME, buffer, buffer_size, nullptr);
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
 
 int set_process_name(char const* name, size_t name_length)
 {
-    int rc = syscall(SC_prctl, PR_SET_PROCESS_NAME, name, name_length);
+    int rc = syscall(SC_prctl, PR_SET_PROCESS_NAME, name, name_length, nullptr);
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
 

--- a/Userland/Libraries/LibELF/DynamicLinker.cpp
+++ b/Userland/Libraries/LibELF/DynamicLinker.cpp
@@ -677,7 +677,7 @@ void ELF::DynamicLinker::linker_main(DeprecatedString&& main_program_path, int m
 
     s_loaders.clear();
 
-    int rc = syscall(SC_prctl, PR_SET_NO_NEW_SYSCALL_REGION_ANNOTATIONS, 1, 0);
+    int rc = syscall(SC_prctl, PR_SET_NO_NEW_SYSCALL_REGION_ANNOTATIONS, 1, 0, nullptr);
     if (rc < 0) {
         VERIFY_NOT_REACHED();
     }


### PR DESCRIPTION
The arguments are passed on registers, so if we pass only 3 defined arguments then the fourth argument for the prctl syscall could have garbage value within it.

To avoid possible bugs, always pass 3 arguments to a raw syscall prctl call in addition to the prctl option.

This was found after I looked on my patches in #20666 and realized that raw prctl calls are used in the codebase.