### PR TITLE
LibWeb: Support `readonly` attribute for HTMLInputElement

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -179,7 +179,9 @@ static void show_the_picker_if_applicable(HTMLInputElement& element)
     if (!is<HTML::Window>(global_object) || !static_cast<HTML::Window&>(global_object).has_transient_activation())
         return;
 
-    // FIXME: 2. If element is not mutable, then return.
+    // 2. If element is not mutable, then return.
+    if (!element.is_mutable())
+        return;
 
     // 3. If element's type attribute is in the File Upload state, then run these steps in parallel:
     if (element.type_state() == HTMLInputElement::TypeAttributeState::FileUpload) {
@@ -219,7 +221,9 @@ WebIDL::ExceptionOr<void> HTMLInputElement::show_picker()
 {
     // The showPicker() method steps are:
 
-    // FIXME: 1. If this is not mutable, then throw an "InvalidStateError" DOMException.
+    // 1. If this is not mutable, then throw an "InvalidStateError" DOMException.
+    if (!m_is_mutable)
+        return WebIDL::InvalidStateError::create(realm(), "Element is not mutable"sv);
 
     // 2. If this's relevant settings object's origin is not same origin with this's relevant settings object's top-level origin,
     // and this's type attribute is not in the File Upload state or Color state, then throw a "SecurityError" DOMException.

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -162,6 +162,8 @@ private:
     WebIDL::ExceptionOr<void> run_input_activation_behavior();
     void set_checked_within_group();
 
+    void handle_readonly_attribute(DeprecatedFlyString const& value);
+
     // https://html.spec.whatwg.org/multipage/input.html#value-sanitization-algorithm
     DeprecatedString value_sanitization_algorithm(DeprecatedString) const;
 
@@ -181,6 +183,9 @@ private:
 
     // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#concept-fe-dirty
     bool m_dirty_value { false };
+
+    // https://html.spec.whatwg.org/multipage/input.html#the-input-element:concept-fe-mutable
+    bool m_is_mutable { true };
 
     // https://html.spec.whatwg.org/multipage/input.html#the-input-element:legacy-pre-activation-behavior
     bool m_before_legacy_pre_activation_behavior_checked { false };

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -81,6 +81,8 @@ public:
     bool indeterminate() const { return m_indeterminate; }
     void set_indeterminate(bool);
 
+    bool is_mutable() const { return m_is_mutable; }
+
     void did_edit_text_node(Badge<BrowsingContext>);
 
     JS::GCPtr<FileAPI::FileList> files();


### PR DESCRIPTION
I am not sure on how to write tests for this given that this requires user interaction, ideas on how to do this welcome!