### PR TITLE
Add AK::InvokeResult

### DIFF
--- a/AK/StdLibExtraDetails.h
+++ b/AK/StdLibExtraDetails.h
@@ -618,6 +618,24 @@ inline constexpr bool IsSameIgnoringCV = IsSame<RemoveCV<T>, RemoveCV<U>>;
 template<typename T, typename... Ts>
 inline constexpr bool IsOneOfIgnoringCV = (IsSameIgnoringCV<T, Ts> || ...);
 
+template<typename...>
+struct __InvokeResult { };
+
+template<typename MethodDefBaseType, typename MethodType, typename InstanceType, typename... Args>
+struct __InvokeResult<MethodType MethodDefBaseType::*, InstanceType, Args...> {
+    using type = decltype((
+        declval<InstanceType>()
+        .*declval<MethodType MethodDefBaseType::*>())(declval<Args>()...));
+};
+
+template<typename F, typename... Args>
+struct __InvokeResult<F, Args...> {
+    using type = decltype((declval<F>())(declval<Args>()...));
+};
+
+template<typename F, typename... Args>
+using InvokeResult = typename __InvokeResult<F, Args...>::type;
+
 }
 
 #if !USING_AK_GLOBALLY
@@ -637,6 +655,7 @@ using AK::Detail::FalseType;
 using AK::Detail::IdentityType;
 using AK::Detail::IndexSequence;
 using AK::Detail::IntegerSequence;
+using AK::Detail::InvokeResult;
 using AK::Detail::IsArithmetic;
 using AK::Detail::IsAssignable;
 using AK::Detail::IsBaseOf;


### PR DESCRIPTION
Someone requested this over on Discord.

This is a port of [`rstd::core::cxxstd::invoke_result_t`](https://github.com/bugaevc/rstd/blob/25d9f4a1fe4dbb5828334350e99243cb8df3ff9e/include/rstd/core/cxxstd.hpp#L56-L79), except it's simpler because it doesn't do the `forward`'ing. Based on a conversation with @alimpfard, this is because our `declval<T>()` returns `T`, not `T&&`. Based on some research, _that_ in turn is because returning `T` wouldn't work pre-C++17, which STL and rstd support, but AK does not have to.