### PR TITLE
About: Display Application's Icon in File Manager

### DIFF
--- a/Userland/Applications/About/CMakeLists.txt
+++ b/Userland/Applications/About/CMakeLists.txt
@@ -14,5 +14,5 @@ execute_process(COMMAND "git diff-index --quiet HEAD -- && echo tracked || echo 
 
 add_definitions(-DGIT_COMMIT="${GIT_COMMIT}" -DGIT_BRANCH="${GIT_BRANCH}" -DGIT_CHANGES="${GIT_CHANGES}")
 
-serenity_bin(About)
+serenity_app(About ICON ladyball)
 target_link_libraries(About PRIVATE LibCore LibGfx LibGUI LibMain)


### PR DESCRIPTION
A tiny little change 🐭

Before, when looking in `/bin` in File Manager, the About application's icon was missing. Now that it's a `serenity_app` instead of `serenity_bin` the icon is visible!

**Before:**
<img width="322" alt="Before" src="https://github.com/SerenityOS/serenity/assets/7754483/23a54600-d3e1-4439-a425-7d12e59a51bc">

**After:**
<img width="325" alt="After" src="https://github.com/SerenityOS/serenity/assets/7754483/5ea553c5-1961-409a-85c1-b8b0065356b2">