### PR TITLE
LibWeb: Invoke our internal attribute change handler from Attr

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Attr.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Attr.cpp
@@ -110,7 +110,8 @@ void Attr::handle_attribute_changes(Element& element, DeprecatedString const& ol
         element.enqueue_a_custom_element_callback_reaction(HTML::CustomElementReactionNames::attributeChangedCallback, move(arguments));
     }
 
-    // FIXME: 3. Run the attribute change steps with element, attribute’s local name, oldValue, newValue, and attribute’s namespace.
+    // 3. Run the attribute change steps with element, attribute’s local name, oldValue, newValue, and attribute’s namespace.
+    element.run_attribute_change_steps(local_name(), old_value, new_value, namespace_uri());
 }
 
 }

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -324,6 +324,8 @@ WebIDL::ExceptionOr<bool> Element::toggle_attribute(DeprecatedFlyString const& n
         m_attributes->remove_attribute(name);
         attribute_changed(name, {});
         invalidate_style_after_attribute_change(name);
+
+        return false;
     }
 
     // 6. Return true.

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -209,10 +209,10 @@ WebIDL::ExceptionOr<void> Element::set_attribute_ns(DeprecatedFlyString const& n
     // 1. Let namespace, prefix, and localName be the result of passing namespace and qualifiedName to validate and extract.
     auto extracted_qualified_name = TRY(validate_and_extract(realm(), namespace_, qualified_name));
 
-    // FIXME: 2. Set an attribute value for this using localName, value, and also prefix and namespace.
+    // 2. Set an attribute value for this using localName, value, and also prefix and namespace.
+    set_attribute_value(extracted_qualified_name.local_name(), value, extracted_qualified_name.prefix(), extracted_qualified_name.namespace_());
 
-    // FIXME: Don't just call through to setAttribute() here.
-    return set_attribute(extracted_qualified_name.local_name(), value);
+    return {};
 }
 
 // https://dom.spec.whatwg.org/#concept-element-attributes-set-value

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -158,7 +158,7 @@ WebIDL::ExceptionOr<void> Element::set_attribute(DeprecatedFlyString const& name
     // 5. Change attribute to value.
     else {
         old_value = attribute->value();
-        attribute->set_value(value);
+        attribute->change_attribute(value);
     }
 
     attribute_changed(attribute->local_name(), value);

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -128,6 +128,8 @@ public:
     Vector<FlyString> const& class_names() const { return m_classes; }
 
     virtual void apply_presentational_hints(CSS::StyleProperties&) const { }
+
+    void run_attribute_change_steps(DeprecatedFlyString const& local_name, DeprecatedString const& old_value, DeprecatedString const& value, DeprecatedFlyString const& namespace_);
     virtual void attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value);
 
     struct [[nodiscard]] RequiredInvalidationAfterStyleChange {


### PR DESCRIPTION
The goal here is to consolidate all attribute change handling in a single location, as doing so was missed when adding a new attribute setter method in 720f7ba7463c67fe205cedfce7bde6a6ba3b14c8. To actually work though, this brings in a normative DOM spec change to ensure we fire the change handlers *after* the attribute is actually changed. This also lets us implement some attribute setters closer to the spec overall.