### PR TITLE
LibJS: Only update EC instruction pointer when pushing to EC stack

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -201,7 +201,6 @@ Interpreter::ValueAndFrame Interpreter::run_and_return_frame(Realm& realm, Execu
     for (;;) {
         auto pc = InstructionStreamIterator { m_current_block->instruction_stream(), m_current_executable };
         TemporaryChange temp_change { m_pc, Optional<InstructionStreamIterator&>(pc) };
-        TemporaryChange context_change { vm().running_execution_context().instruction_stream_iterator, Optional<InstructionStreamIterator&>(pc) };
 
         // FIXME: This is getting kinda spaghetti-y
         bool will_jump = false;

--- a/Userland/Libraries/LibJS/Runtime/ExecutionContext.h
+++ b/Userland/Libraries/LibJS/Runtime/ExecutionContext.h
@@ -44,7 +44,7 @@ public:
     // Non-standard: This points at something that owns this ExecutionContext, in case it needs to be protected from GC.
     GCPtr<Cell> context_owner;
 
-    Optional<Bytecode::InstructionStreamIterator&> instruction_stream_iterator;
+    Optional<Bytecode::InstructionStreamIterator> instruction_stream_iterator;
     DeprecatedFlyString function_name;
     Value this_value;
     MarkedVector<Value> arguments;

--- a/Userland/Libraries/LibJS/Runtime/VM.h
+++ b/Userland/Libraries/LibJS/Runtime/VM.h
@@ -93,11 +93,6 @@ public:
         return m_stack_info.size_free() < 32 * KiB;
     }
 
-    void push_execution_context(ExecutionContext& context)
-    {
-        m_execution_context_stack.append(&context);
-    }
-
     // TODO: Rename this function instead of providing a second argument, now that the global object is no longer passed in.
     struct CheckStackSpaceLimitTag { };
 
@@ -106,16 +101,12 @@ public:
         // Ensure we got some stack space left, so the next function call doesn't kill us.
         if (did_reach_stack_space_limit())
             return throw_completion<InternalError>(ErrorType::CallStackSizeExceeded);
-        m_execution_context_stack.append(&context);
+        push_execution_context(context);
         return {};
     }
 
-    void pop_execution_context()
-    {
-        m_execution_context_stack.take_last();
-        if (m_execution_context_stack.is_empty() && on_call_stack_emptied)
-            on_call_stack_emptied();
-    }
+    void push_execution_context(ExecutionContext&);
+    void pop_execution_context();
 
     // https://tc39.es/ecma262/#running-execution-context
     // At any point in time, there is at most one execution context per agent that is actually executing code.


### PR DESCRIPTION
Instead of trying to keep a live reference to the bytecode interpreter's current instruction stream iterator, we now simply copy the current iterator whenever pushing to the ExecutionContext stack.

This fixes a stack-use-after-return issue reported by ASAN.