### PR TITLE
LibWeb: Stub out HTMLDialogElement APIs

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/HTMLDialogElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLDialogElement.cpp
@@ -22,4 +22,34 @@ void HTMLDialogElement::initialize(JS::Realm& realm)
     set_prototype(&Bindings::ensure_web_prototype<Bindings::HTMLDialogElementPrototype>(realm, "HTMLDialogElement"));
 }
 
+// https://html.spec.whatwg.org/multipage/interactive-elements.html#dom-dialog-show
+void HTMLDialogElement::show()
+{
+    dbgln("(STUBBED) HTMLDialogElement::show()");
+}
+
+// https://html.spec.whatwg.org/multipage/interactive-elements.html#dom-dialog-showmodal
+void HTMLDialogElement::show_modal()
+{
+    dbgln("(STUBBED) HTMLDialogElement::show_modal()");
+}
+
+// https://html.spec.whatwg.org/multipage/interactive-elements.html#dom-dialog-close
+void HTMLDialogElement::close(Optional<String>)
+{
+    dbgln("(STUBBED) HTMLDialogElement::close()");
+}
+
+// https://html.spec.whatwg.org/multipage/interactive-elements.html#dom-dialog-returnvalue
+String HTMLDialogElement::return_value() const
+{
+    return m_return_value;
+}
+
+// https://html.spec.whatwg.org/multipage/interactive-elements.html#dom-dialog-returnvalue
+void HTMLDialogElement::set_return_value(String return_value)
+{
+    m_return_value = move(return_value);
+}
+
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLDialogElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLDialogElement.h
@@ -17,6 +17,13 @@ class HTMLDialogElement final : public HTMLElement {
 public:
     virtual ~HTMLDialogElement() override;
 
+    String return_value() const;
+    void set_return_value(String);
+
+    void show();
+    void show_modal();
+    void close(Optional<String> return_value);
+
     // https://www.w3.org/TR/html-aria/#el-dialog
     virtual Optional<ARIA::Role> default_role() const override { return ARIA::Role::dialog; }
 
@@ -24,6 +31,8 @@ private:
     HTMLDialogElement(DOM::Document&, DOM::QualifiedName);
 
     virtual void initialize(JS::Realm&) override;
+
+    String m_return_value;
 };
 
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLDialogElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLDialogElement.idl
@@ -7,5 +7,9 @@ interface HTMLDialogElement : HTMLElement {
     [HTMLConstructor] constructor();
 
     [CEReactions, Reflect] attribute boolean open;
+    attribute DOMString returnValue;
+    [CEReactions] undefined show();
+    [CEReactions] undefined showModal();
+    [CEReactions] undefined close(optional DOMString returnValue);
 
 };


### PR DESCRIPTION
This makes https://null.com/ load instead of throwing a React internal error and showing a black background.