### PR TITLE
JSSpecCompiler: Add our first two passes :^)

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/JSSpecCompiler/AST/AST.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/JSSpecCompiler/AST/AST.cpp
@@ -71,6 +71,18 @@ Vector<NodeSubtreePointer> ElseIfBranch::subtrees()
     return { { &m_branch } };
 }
 
+Vector<NodeSubtreePointer> IfElseIfChain::subtrees()
+{
+    Vector<NodeSubtreePointer> result;
+    for (size_t i = 0; i < branches_count(); ++i) {
+        result.append({ &m_conditions[i] });
+        result.append({ &m_branches[i] });
+    }
+    if (m_else_branch)
+        result.append({ &m_else_branch });
+    return result;
+}
+
 Vector<NodeSubtreePointer> TreeList::subtrees()
 {
     Vector<NodeSubtreePointer> result;

--- a/Meta/Lagom/Tools/CodeGenerators/JSSpecCompiler/AST/AST.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/JSSpecCompiler/AST/AST.cpp
@@ -8,6 +8,29 @@
 
 namespace JSSpecCompiler {
 
+Tree NodeSubtreePointer::get(Badge<RecursiveASTVisitor>)
+{
+    return m_tree_ptr.visit(
+        [&](NullableTree* nullable_tree) -> Tree {
+            NullableTree copy = *nullable_tree;
+            return copy.release_nonnull();
+        },
+        [&](Tree* tree) -> Tree {
+            return *tree;
+        });
+}
+
+void NodeSubtreePointer::replace_subtree(Badge<RecursiveASTVisitor>, NullableTree replacement)
+{
+    m_tree_ptr.visit(
+        [&](NullableTree* nullable_tree) {
+            *nullable_tree = replacement;
+        },
+        [&](Tree* tree) {
+            *tree = replacement.release_nonnull();
+        });
+}
+
 Vector<NodeSubtreePointer> BinaryOperation::subtrees()
 {
     return { { &m_left }, { &m_right } };
@@ -43,8 +66,8 @@ Vector<NodeSubtreePointer> IfBranch::subtrees()
 
 Vector<NodeSubtreePointer> ElseIfBranch::subtrees()
 {
-    if (m_condition.has_value())
-        return { { &m_condition.value() }, { &m_branch } };
+    if (m_condition)
+        return { { &m_condition }, { &m_branch } };
     return { { &m_branch } };
 }
 

--- a/Meta/Lagom/Tools/CodeGenerators/JSSpecCompiler/AST/AST.h
+++ b/Meta/Lagom/Tools/CodeGenerators/JSSpecCompiler/AST/AST.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Badge.h>
 #include <AK/RefCounted.h>
 #include <AK/RefPtr.h>
 #include <AK/Vector.h>
@@ -27,9 +28,9 @@ public:
     {
     }
 
-    Tree& get() { return *m_tree_ptr; }
+    Tree& get(Badge<RecursiveASTVisitor>) { return *m_tree_ptr; }
 
-    void replace_subtree(Tree tree) { *m_tree_ptr = move(tree); }
+    void replace_subtree(Badge<RecursiveASTVisitor>, Tree tree) { *m_tree_ptr = move(tree); }
 
 private:
     Tree* m_tree_ptr;

--- a/Meta/Lagom/Tools/CodeGenerators/JSSpecCompiler/AST/AST.h
+++ b/Meta/Lagom/Tools/CodeGenerators/JSSpecCompiler/AST/AST.h
@@ -28,12 +28,16 @@ public:
     {
     }
 
-    Tree& get(Badge<RecursiveASTVisitor>) { return *m_tree_ptr; }
+    NodeSubtreePointer(NullableTree* tree_ptr)
+        : m_tree_ptr(tree_ptr)
+    {
+    }
 
-    void replace_subtree(Badge<RecursiveASTVisitor>, Tree tree) { *m_tree_ptr = move(tree); }
+    Tree get(Badge<RecursiveASTVisitor>);
+    void replace_subtree(Badge<RecursiveASTVisitor>, NullableTree replacement);
 
 private:
-    Tree* m_tree_ptr;
+    Variant<Tree*, NullableTree*> m_tree_ptr;
 };
 
 // ===== Generic nodes =====
@@ -258,7 +262,7 @@ protected:
 
 class ElseIfBranch : public Node {
 public:
-    ElseIfBranch(Optional<Tree> condition, Tree branch)
+    ElseIfBranch(NullableTree condition, Tree branch)
         : m_condition(condition)
         , m_branch(branch)
     {
@@ -266,7 +270,7 @@ public:
 
     Vector<NodeSubtreePointer> subtrees() override;
 
-    Optional<Tree> m_condition;
+    NullableTree m_condition;
     Tree m_branch;
 
 protected:

--- a/Meta/Lagom/Tools/CodeGenerators/JSSpecCompiler/AST/AST.h
+++ b/Meta/Lagom/Tools/CodeGenerators/JSSpecCompiler/AST/AST.h
@@ -57,7 +57,12 @@ protected:
 
 class ErrorNode : public Node {
 public:
-    ErrorNode() { }
+    ErrorNode(StringView error = ""sv)
+        : m_error(error)
+    {
+    }
+
+    StringView m_error;
 
 protected:
     void dump_tree(StringBuilder& builder) override;

--- a/Meta/Lagom/Tools/CodeGenerators/JSSpecCompiler/AST/AST.h
+++ b/Meta/Lagom/Tools/CodeGenerators/JSSpecCompiler/AST/AST.h
@@ -277,6 +277,29 @@ protected:
     void dump_tree(StringBuilder& builder) override;
 };
 
+class IfElseIfChain : public Node {
+public:
+    IfElseIfChain(Vector<Tree>&& conditions, Vector<Tree>&& branches, NullableTree else_branch)
+        : m_conditions(move(conditions))
+        , m_branches(move(branches))
+        , m_else_branch(else_branch)
+    {
+        VERIFY(m_branches.size() == m_conditions.size());
+    }
+
+    Vector<NodeSubtreePointer> subtrees() override;
+
+    // Excluding else branch, if one is present
+    size_t branches_count() { return m_branches.size(); }
+
+    Vector<Tree> m_conditions;
+    Vector<Tree> m_branches;
+    NullableTree m_else_branch;
+
+protected:
+    void dump_tree(StringBuilder& builder) override;
+};
+
 class TreeList : public Node {
 public:
     TreeList(Vector<Tree>&& expressions_)

--- a/Meta/Lagom/Tools/CodeGenerators/JSSpecCompiler/AST/ASTPrinting.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/JSSpecCompiler/AST/ASTPrinting.cpp
@@ -31,7 +31,7 @@ void Node::dump_node(StringBuilder& builder, AK::CheckedFormatString<Parameters.
 
 void ErrorNode::dump_tree(StringBuilder& builder)
 {
-    dump_node(builder, "Error");
+    dump_node(builder, "Error \"{}\"", m_error);
 }
 
 void MathematicalConstant::dump_tree(StringBuilder& builder)

--- a/Meta/Lagom/Tools/CodeGenerators/JSSpecCompiler/AST/ASTPrinting.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/JSSpecCompiler/AST/ASTPrinting.cpp
@@ -97,6 +97,18 @@ void ElseIfBranch::dump_tree(StringBuilder& builder)
     m_branch->format_tree(builder);
 }
 
+void IfElseIfChain::dump_tree(StringBuilder& builder)
+{
+    dump_node(builder, "IfElseIfChain");
+
+    for (size_t i = 0; i < branches_count(); ++i) {
+        m_conditions[i]->format_tree(builder);
+        m_branches[i]->format_tree(builder);
+    }
+    if (m_else_branch)
+        m_else_branch->format_tree(builder);
+}
+
 void TreeList::dump_tree(StringBuilder& builder)
 {
     dump_node(builder, "TreeList");

--- a/Meta/Lagom/Tools/CodeGenerators/JSSpecCompiler/AST/ASTPrinting.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/JSSpecCompiler/AST/ASTPrinting.cpp
@@ -91,9 +91,9 @@ void IfBranch::dump_tree(StringBuilder& builder)
 
 void ElseIfBranch::dump_tree(StringBuilder& builder)
 {
-    dump_node(builder, "ElseIfBranch {}", m_condition.has_value() ? "ElseIf" : "Else");
-    if (m_condition.has_value())
-        (*m_condition)->format_tree(builder);
+    dump_node(builder, "ElseIfBranch {}", m_condition ? "ElseIf" : "Else");
+    if (m_condition)
+        m_condition->format_tree(builder);
     m_branch->format_tree(builder);
 }
 

--- a/Meta/Lagom/Tools/CodeGenerators/JSSpecCompiler/CMakeLists.txt
+++ b/Meta/Lagom/Tools/CodeGenerators/JSSpecCompiler/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(SOURCES
     AST/AST.cpp
     AST/ASTPrinting.cpp
+    Compiler/FunctionCallCanonicalizationPass.cpp
     Compiler/GenericASTPass.cpp
     Parser/Lexer.cpp
     Parser/ParseError.cpp

--- a/Meta/Lagom/Tools/CodeGenerators/JSSpecCompiler/CMakeLists.txt
+++ b/Meta/Lagom/Tools/CodeGenerators/JSSpecCompiler/CMakeLists.txt
@@ -3,6 +3,7 @@ set(SOURCES
     AST/ASTPrinting.cpp
     Compiler/FunctionCallCanonicalizationPass.cpp
     Compiler/GenericASTPass.cpp
+    Compiler/IfBranchMergingPass.cpp
     Parser/Lexer.cpp
     Parser/ParseError.cpp
     Parser/SpecParser.cpp

--- a/Meta/Lagom/Tools/CodeGenerators/JSSpecCompiler/Compiler/FunctionCallCanonicalizationPass.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/JSSpecCompiler/Compiler/FunctionCallCanonicalizationPass.cpp
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2023, Dan Klishch <danilklishch@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "Compiler/FunctionCallCanonicalizationPass.h"
+#include "AST/AST.h"
+
+namespace JSSpecCompiler {
+
+RecursionDecision FunctionCallCanonicalizationPass::on_entry(Tree tree)
+{
+    if (auto binary_operation = as<BinaryOperation>(tree); binary_operation) {
+        if (binary_operation->m_operation == BinaryOperator::FunctionCall) {
+            Vector<Tree> arguments;
+
+            auto current_tree = binary_operation->m_right;
+            while (true) {
+                auto argument_tree = as<BinaryOperation>(current_tree);
+                if (!argument_tree || argument_tree->m_operation != BinaryOperator::Comma)
+                    break;
+                arguments.append(argument_tree->m_left);
+                current_tree = argument_tree->m_right;
+            }
+            arguments.append(current_tree);
+
+            replace_current_node_with(make_ref_counted<FunctionCall>(binary_operation->m_left, move(arguments)));
+        }
+    }
+    return RecursionDecision::Recurse;
+}
+
+}

--- a/Meta/Lagom/Tools/CodeGenerators/JSSpecCompiler/Compiler/FunctionCallCanonicalizationPass.h
+++ b/Meta/Lagom/Tools/CodeGenerators/JSSpecCompiler/Compiler/FunctionCallCanonicalizationPass.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2023, Dan Klishch <danilklishch@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include "Compiler/GenericASTPass.h"
+
+namespace JSSpecCompiler {
+
+// FunctionCallCanonicalizationPass simplifies ladders of BinaryOperators nodes in the function call
+// arguments into nice and neat FunctionCall nodes.
+//
+// Ladders initially appear since I do not want to complicate expression parser, so it interprets
+// `f(a, b, c, d)` as `f "function_call_operator" (a, (b, (c, d))))`.
+class FunctionCallCanonicalizationPass : public GenericASTPass {
+public:
+    using GenericASTPass::GenericASTPass;
+
+protected:
+    RecursionDecision on_entry(Tree tree) override;
+};
+
+}

--- a/Meta/Lagom/Tools/CodeGenerators/JSSpecCompiler/Compiler/GenericASTPass.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/JSSpecCompiler/Compiler/GenericASTPass.cpp
@@ -10,13 +10,24 @@
 
 namespace JSSpecCompiler {
 
+void RecursiveASTVisitor::run_in_const_subtree(NullableTree nullable_tree)
+{
+    if (nullable_tree) {
+        auto tree = nullable_tree.release_nonnull();
+        auto tree_copy = tree;
+        NodeSubtreePointer pointer { &tree };
+        recurse(tree, pointer);
+        VERIFY(tree == tree_copy);
+    }
+}
+
 void RecursiveASTVisitor::run_in_subtree(Tree& tree)
 {
     NodeSubtreePointer pointer { &tree };
     recurse(tree, pointer);
 }
 
-void RecursiveASTVisitor::replace_current_node_with(Tree tree)
+void RecursiveASTVisitor::replace_current_node_with(NullableTree tree)
 {
     m_current_subtree_pointer->replace_subtree({}, move(tree));
 }

--- a/Meta/Lagom/Tools/CodeGenerators/JSSpecCompiler/Compiler/GenericASTPass.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/JSSpecCompiler/Compiler/GenericASTPass.cpp
@@ -18,7 +18,7 @@ void RecursiveASTVisitor::run_in_subtree(Tree& tree)
 
 void RecursiveASTVisitor::replace_current_node_with(Tree tree)
 {
-    m_current_subtree_pointer->replace_subtree(move(tree));
+    m_current_subtree_pointer->replace_subtree({}, move(tree));
 }
 
 RecursionDecision RecursiveASTVisitor::recurse(Tree root, NodeSubtreePointer& pointer)
@@ -30,7 +30,7 @@ RecursionDecision RecursiveASTVisitor::recurse(Tree root, NodeSubtreePointer& po
 
     if (decision == RecursionDecision::Recurse) {
         for (auto& child : root->subtrees()) {
-            if (recurse(child.get(), child) == RecursionDecision::Break)
+            if (recurse(child.get({}), child) == RecursionDecision::Break)
                 return RecursionDecision::Break;
         }
     }

--- a/Meta/Lagom/Tools/CodeGenerators/JSSpecCompiler/Compiler/GenericASTPass.h
+++ b/Meta/Lagom/Tools/CodeGenerators/JSSpecCompiler/Compiler/GenericASTPass.h
@@ -17,13 +17,14 @@ class RecursiveASTVisitor {
 public:
     virtual ~RecursiveASTVisitor() = default;
 
+    void run_in_const_subtree(NullableTree tree);
     void run_in_subtree(Tree& tree);
 
 protected:
     virtual RecursionDecision on_entry(Tree) { return RecursionDecision::Recurse; }
     virtual void on_leave(Tree) { }
 
-    void replace_current_node_with(Tree tree);
+    void replace_current_node_with(NullableTree tree);
 
 private:
     RecursionDecision recurse(Tree root, NodeSubtreePointer& pointer);

--- a/Meta/Lagom/Tools/CodeGenerators/JSSpecCompiler/Compiler/IfBranchMergingPass.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/JSSpecCompiler/Compiler/IfBranchMergingPass.cpp
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2023, Dan Klishch <danilklishch@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/TypeCasts.h>
+
+#include "AST/AST.h"
+#include "Compiler/IfBranchMergingPass.h"
+
+namespace JSSpecCompiler {
+
+RecursionDecision IfBranchMergingPass::on_entry(Tree tree)
+{
+    if (auto list = as<TreeList>(tree); list) {
+        Vector<Tree> result;
+        Vector<Tree> unmerged_branches;
+
+        auto merge_if_needed = [&] {
+            if (!unmerged_branches.is_empty()) {
+                result.append(merge_branches(unmerged_branches));
+                unmerged_branches.clear();
+            }
+        };
+
+        for (auto const& node : list->m_expressions) {
+            if (is<IfBranch>(node.ptr())) {
+                merge_if_needed();
+                unmerged_branches.append(node);
+            } else if (is<ElseIfBranch>(node.ptr())) {
+                unmerged_branches.append(node);
+            } else {
+                merge_if_needed();
+                result.append(node);
+            }
+        }
+        merge_if_needed();
+
+        list->m_expressions = move(result);
+    }
+    return RecursionDecision::Recurse;
+}
+
+Tree IfBranchMergingPass::merge_branches(Vector<Tree> const& unmerged_branches)
+{
+    static const Tree error = make_ref_counted<ErrorNode>("Cannot make sense of if-elseif-else chain"sv);
+
+    VERIFY(unmerged_branches.size() >= 1);
+
+    Vector<Tree> conditions;
+    Vector<Tree> branches;
+    NullableTree else_branch;
+
+    if (auto if_branch = as<IfBranch>(unmerged_branches[0]); if_branch) {
+        conditions.append(if_branch->m_condition);
+        branches.append(if_branch->m_branch);
+    } else {
+        return error;
+    }
+
+    for (size_t i = 1; i < unmerged_branches.size(); ++i) {
+        auto branch = as<ElseIfBranch>(unmerged_branches[i]);
+
+        if (!branch)
+            return error;
+
+        if (!branch->m_condition) {
+            // There might be situation like:
+            //   1. If <condition>, then
+            //      ...
+            //   2. Else,
+            //      a. If <condition>, then
+            //         ...
+            //   3. Else,
+            //      ...
+            auto substep_list = as<TreeList>(branch->m_branch);
+            if (substep_list && substep_list->m_expressions.size() == 1) {
+                if (auto nested_if = as<IfBranch>(substep_list->m_expressions[0]); nested_if)
+                    branch = make_ref_counted<ElseIfBranch>(nested_if->m_condition, nested_if->m_branch);
+            }
+        }
+
+        if (branch->m_condition) {
+            conditions.append(branch->m_condition.release_nonnull());
+            branches.append(branch->m_branch);
+        } else {
+            if (i + 1 != unmerged_branches.size())
+                return error;
+            else_branch = branch->m_branch;
+        }
+    }
+
+    return make_ref_counted<IfElseIfChain>(move(conditions), move(branches), else_branch);
+}
+
+}

--- a/Meta/Lagom/Tools/CodeGenerators/JSSpecCompiler/Compiler/IfBranchMergingPass.h
+++ b/Meta/Lagom/Tools/CodeGenerators/JSSpecCompiler/Compiler/IfBranchMergingPass.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2023, Dan Klishch <danilklishch@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include "Compiler/GenericASTPass.h"
+
+namespace JSSpecCompiler {
+
+// IfBranchMergingPass, unsurprisingly, merges if-elseif-else chains, represented as a separate
+// nodes after parsing, into one IfElseIfChain node. It also deals with the following nonsense from
+// the spec:
+// ```
+//   1. If <condition>, then
+//      ...
+//   2. Else,
+//      a. If <condition>, then
+//         ...
+//   3. Else,
+//      ...
+// ```
+class IfBranchMergingPass : public GenericASTPass {
+public:
+    using GenericASTPass::GenericASTPass;
+
+protected:
+    RecursionDecision on_entry(Tree tree) override;
+
+private:
+    static Tree merge_branches(Vector<Tree> const& unmerged_branches);
+};
+
+}

--- a/Meta/Lagom/Tools/CodeGenerators/JSSpecCompiler/Forward.h
+++ b/Meta/Lagom/Tools/CodeGenerators/JSSpecCompiler/Forward.h
@@ -29,6 +29,7 @@ class ReturnExpression;
 class AssertExpression;
 class IfBranch;
 class ElseIfBranch;
+class IfElseIfChain;
 class TreeList;
 class RecordDirectListInitialization;
 class FunctionCall;

--- a/Meta/Lagom/Tools/CodeGenerators/JSSpecCompiler/Forward.h
+++ b/Meta/Lagom/Tools/CodeGenerators/JSSpecCompiler/Forward.h
@@ -37,6 +37,9 @@ class Variable;
 class FunctionPointer;
 using FunctionPointerRef = NonnullRefPtr<FunctionPointer>;
 
+// Compiler/GenericASTPass.h
+class RecursiveASTVisitor;
+
 // Parser/SpecParser.h
 class AlgorithmStep;
 class AlgorithmStepList;

--- a/Meta/Lagom/Tools/CodeGenerators/JSSpecCompiler/Parser/TextParser.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/JSSpecCompiler/Parser/TextParser.cpp
@@ -382,7 +382,7 @@ ParseErrorOr<TextParser::IfConditionParseResult> TextParser::parse_if_beginning(
     auto rollback = rollback_point();
 
     bool is_if_branch = !consume_word("if"sv).is_error();
-    Optional<Tree> condition;
+    NullableTree condition = nullptr;
     if (is_if_branch) {
         condition = TRY(parse_condition());
     } else {
@@ -406,9 +406,8 @@ ParseErrorOr<Tree> TextParser::parse_inline_if_else()
 
     rollback.disarm();
     if (is_if_branch)
-        return make_ref_counted<IfBranch>(*condition, then_branch);
-    else
-        return make_ref_counted<ElseIfBranch>(condition, then_branch);
+        return make_ref_counted<IfBranch>(condition.release_nonnull(), then_branch);
+    return make_ref_counted<ElseIfBranch>(condition, then_branch);
 }
 
 // <if> :== <if_condition> then$ <substeps>
@@ -437,7 +436,7 @@ ParseErrorOr<Tree> TextParser::parse_else(Tree else_branch)
     TRY(expect_eof());
 
     rollback.disarm();
-    return make_ref_counted<ElseIfBranch>(Optional<Tree> {}, else_branch);
+    return make_ref_counted<ElseIfBranch>(nullptr, else_branch);
 }
 
 // <simple_step> | <inline_if>

--- a/Meta/Lagom/Tools/CodeGenerators/JSSpecCompiler/Parser/TextParser.h
+++ b/Meta/Lagom/Tools/CodeGenerators/JSSpecCompiler/Parser/TextParser.h
@@ -33,7 +33,7 @@ public:
 private:
     struct IfConditionParseResult {
         bool is_if_branch;
-        Optional<Tree> condition;
+        NullableTree condition;
     };
 
     void retreat();

--- a/Meta/Lagom/Tools/CodeGenerators/JSSpecCompiler/main.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/JSSpecCompiler/main.cpp
@@ -10,6 +10,7 @@
 #include <LibXML/Parser/Parser.h>
 
 #include "Compiler/FunctionCallCanonicalizationPass.h"
+#include "Compiler/IfBranchMergingPass.h"
 #include "Function.h"
 #include "Parser/SpecParser.h"
 
@@ -39,6 +40,7 @@ ErrorOr<int> serenity_main(Main::Arguments)
     auto function = make_ref_counted<JSSpecCompiler::Function>(&context, spec_function.m_name, spec_function.m_algorithm.m_tree);
 
     FunctionCallCanonicalizationPass(function).run();
+    IfBranchMergingPass(function).run();
 
     out("{}", function->m_ast);
     return 0;


### PR DESCRIPTION
I don't want to overcomplicate already complicated enough expression parser, so there is some cleanup needed to make function calls nice to work with. Additionally, if-elseif-else chains also need some love after parsing.