### PR TITLE
LibWeb: Don't send audio time updates until audio is playing

### DIFF
--- a/Userland/Libraries/LibWeb/Platform/AudioCodecPluginAgnostic.cpp
+++ b/Userland/Libraries/LibWeb/Platform/AudioCodecPluginAgnostic.cpp
@@ -78,7 +78,6 @@ AudioCodecPluginAgnostic::AudioCodecPluginAgnostic(NonnullRefPtr<Audio::Loader> 
     m_update_timer->on_timeout = [this]() {
         update_timestamp();
     };
-    m_update_timer->start();
 }
 
 void AudioCodecPluginAgnostic::resume_playback()


### PR DESCRIPTION
We would start the timer to send playback time updates to the element before playback had started, so in cases where the `HTMLMediaElement` (incorrectly) creates both an `AudioTrack` and `VideoTrack`, it will not cause the seek bar to flicker between the current video position and zero.