### PR TITLE
LibC: Set `(U)LONG_WIDTH` correctly for 64-bit

### DIFF
--- a/Userland/Libraries/LibC/limits.h
+++ b/Userland/Libraries/LibC/limits.h
@@ -56,8 +56,8 @@
 #define INT_WIDTH 32
 #define UINT_WIDTH 32
 
-#define LONG_WIDTH 32
-#define ULONG_WIDTH 32
+#define LONG_WIDTH 64
+#define ULONG_WIDTH 64
 
 #define LLONG_WIDTH 64
 #define ULLONG_WIDTH 64


### PR DESCRIPTION
All supported targets use an LP64 ABI, where both `long` and `long long` are 64 bits wide.

We might consider using built-in macros to avoid such issues in the future.