### PR TITLE
LibIMAP: Don't crash on mails with attachments

### DIFF
--- a/Userland/Applications/Mail/MailWidget.cpp
+++ b/Userland/Applications/Mail/MailWidget.cpp
@@ -185,7 +185,7 @@ void MailWidget::on_window_close()
 
 IMAP::MultiPartBodyStructureData const* MailWidget::look_for_alternative_body_structure(IMAP::MultiPartBodyStructureData const& current_body_structure, Vector<u32>& position_stack) const
 {
-    if (current_body_structure.media_type.equals_ignoring_ascii_case("ALTERNATIVE"sv))
+    if (current_body_structure.multipart_subtype.equals_ignoring_ascii_case("ALTERNATIVE"sv))
         return &current_body_structure;
 
     u32 structure_index = 1;

--- a/Userland/Libraries/LibIMAP/Objects.h
+++ b/Userland/Libraries/LibIMAP/Objects.h
@@ -213,7 +213,7 @@ struct BodyStructureData {
     HashMap<DeprecatedString, DeprecatedString> fields;
     unsigned bytes { 0 };
     unsigned lines { 0 };
-    Optional<Envelope> envelope;
+    Optional<Tuple<Envelope, NonnullOwnPtr<BodyStructure>>> contanied_message;
 
     Optional<DeprecatedString> md5 {};
     Optional<Tuple<DeprecatedString, HashMap<DeprecatedString, DeprecatedString>>> disposition {};

--- a/Userland/Libraries/LibIMAP/Objects.h
+++ b/Userland/Libraries/LibIMAP/Objects.h
@@ -198,7 +198,7 @@ struct MultiPartBodyStructureData {
     Optional<Tuple<DeprecatedString, HashMap<DeprecatedString, DeprecatedString>>> disposition;
     Vector<OwnPtr<BodyStructure>> bodies;
     Vector<DeprecatedString> langs;
-    DeprecatedString media_type;
+    DeprecatedString multipart_subtype;
     Optional<HashMap<DeprecatedString, DeprecatedString>> params;
     Optional<DeprecatedString> location;
     Optional<Vector<BodyExtension>> extensions;

--- a/Userland/Libraries/LibIMAP/Parser.cpp
+++ b/Userland/Libraries/LibIMAP/Parser.cpp
@@ -384,7 +384,7 @@ BodyStructure Parser::parse_body_structure()
             data.bodies.append(make<BodyStructure>(move(child)));
         }
         consume(" "sv);
-        data.media_type = parse_string();
+        data.multipart_subtype = parse_string();
 
         if (!try_consume(")"sv)) {
             consume(" "sv);

--- a/Userland/Libraries/LibIMAP/Parser.cpp
+++ b/Userland/Libraries/LibIMAP/Parser.cpp
@@ -453,11 +453,18 @@ BodyStructure Parser::parse_one_part_body()
         // NOTE: "media-text SP body-fields" part is already parsed.
         consume(" "sv);
         data.lines = MUST(parse_number());
-    } else if (data.type.equals_ignoring_ascii_case("MESSAGE"sv) && data.subtype.equals_ignoring_ascii_case("RFC822"sv)) {
+    } else if (data.type.equals_ignoring_ascii_case("MESSAGE"sv) && data.subtype.is_one_of_ignoring_ascii_case("RFC822"sv, "GLOBAL"sv)) {
         // body-type-msg
         // NOTE: "media-message SP body-fields" part is already parsed.
         consume(" "sv);
-        data.envelope = parse_envelope();
+        auto envelope = parse_envelope();
+
+        consume(" ("sv);
+        auto body = parse_body_structure();
+        data.contanied_message = Tuple { move(envelope), make<BodyStructure>(move(body)) };
+
+        consume(" "sv);
+        data.lines = MUST(parse_number());
     } else {
         // body-type-basic
         // NOTE: "media-basic SP body-fields" is already parsed.

--- a/Userland/Libraries/LibIMAP/Parser.cpp
+++ b/Userland/Libraries/LibIMAP/Parser.cpp
@@ -299,6 +299,7 @@ FetchResponseData Parser::parse_fetch_response()
             break;
         }
         case FetchCommand::DataItemType::Envelope: {
+            consume(" "sv);
             fetch_response.set_envelope(parse_envelope());
             break;
         }
@@ -339,7 +340,7 @@ FetchResponseData Parser::parse_fetch_response()
 }
 Envelope Parser::parse_envelope()
 {
-    consume(" ("sv);
+    consume("("sv);
     auto date = parse_nstring();
     consume(" "sv);
     auto subject = parse_nstring();


### PR DESCRIPTION
Overall we weren't parsing `body-ext-1part` for any mime type but `text/`, and parsing steps for `message/rfc822` were incomplete.

---

Mail no longer crashes when trying to view following emails:

<table><tr><td>

```eml
MIME-Version: 1.0
Date: Sun, 3 Sep 2023 00:00:00 +0200
Subject: transparent png
Content-Type: image/png
Content-Transfer-Encoding: base64

iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAA
AABJRU5ErkJggg==
```

<td>

```eml
MIME-Version: 1.0
Date: Sun, 3 Sep 2023 01:32:21 +0200
Subject: email in email what!!
Content-Type: message/rfc822

Date: Sun, 3 Sep 2023 00:00:00 +0200
Subject: Subject Subject

:^)
```

</table>