### PR TITLE
LibWeb: Some more porting of IDL interfaces from DeprecatedString

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -2450,9 +2450,22 @@ static void collect_attribute_values_of_an_inheritance_stack(SourceGenerator& fu
 
             if (attribute.extended_attributes.contains("Reflect")) {
                 if (attribute.type->name() != "boolean") {
-                    attribute_generator.append(R"~~~(
+                    if (interface_in_chain.extended_attributes.contains("UseDeprecatedAKString")) {
+                        attribute_generator.append(R"~~~(
     auto @attribute.return_value_name@ = impl->deprecated_attribute(HTML::AttributeNames::@attribute.reflect_name@);
 )~~~");
+                    } else {
+                        // FIXME: This should be calling Element::get_attribute_value: https://dom.spec.whatwg.org/#concept-element-attributes-get-value
+                        if (attribute.type->is_nullable()) {
+                            attribute_generator.append(R"~~~(
+    auto @attribute.return_value_name@ = impl->attribute(HTML::AttributeNames::@attribute.reflect_name@);
+)~~~");
+                        } else {
+                            attribute_generator.append(R"~~~(
+    auto @attribute.return_value_name@ = impl->attribute(HTML::AttributeNames::@attribute.reflect_name@).value_or(String {});
+)~~~");
+                        }
+                    }
                 } else {
                     attribute_generator.append(R"~~~(
     auto @attribute.return_value_name@ = impl->has_attribute(HTML::AttributeNames::@attribute.reflect_name@);
@@ -2776,9 +2789,22 @@ JS_DEFINE_NATIVE_FUNCTION(@class_name@::@attribute.getter_callback@)
 
         if (attribute.extended_attributes.contains("Reflect")) {
             if (attribute.type->name() != "boolean") {
-                attribute_generator.append(R"~~~(
+                if (interface.extended_attributes.contains("UseDeprecatedAKString")) {
+                    attribute_generator.append(R"~~~(
     auto retval = impl->deprecated_attribute(HTML::AttributeNames::@attribute.reflect_name@);
 )~~~");
+                } else {
+                    // FIXME: This should be calling Element::get_attribute_value: https://dom.spec.whatwg.org/#concept-element-attributes-get-value
+                    if (attribute.type->is_nullable()) {
+                        attribute_generator.append(R"~~~(
+    auto retval = impl->attribute(HTML::AttributeNames::@attribute.reflect_name@);
+)~~~");
+                    } else {
+                        attribute_generator.append(R"~~~(
+    auto retval = impl->attribute(HTML::AttributeNames::@attribute.reflect_name@).value_or(String {});
+)~~~");
+                    }
+                }
             } else {
                 attribute_generator.append(R"~~~(
     auto retval = impl->has_attribute(HTML::AttributeNames::@attribute.reflect_name@);

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -2451,7 +2451,7 @@ static void collect_attribute_values_of_an_inheritance_stack(SourceGenerator& fu
             if (attribute.extended_attributes.contains("Reflect")) {
                 if (attribute.type->name() != "boolean") {
                     attribute_generator.append(R"~~~(
-    auto @attribute.return_value_name@ = impl->attribute(HTML::AttributeNames::@attribute.reflect_name@);
+    auto @attribute.return_value_name@ = impl->deprecated_attribute(HTML::AttributeNames::@attribute.reflect_name@);
 )~~~");
                 } else {
                     attribute_generator.append(R"~~~(
@@ -2777,7 +2777,7 @@ JS_DEFINE_NATIVE_FUNCTION(@class_name@::@attribute.getter_callback@)
         if (attribute.extended_attributes.contains("Reflect")) {
             if (attribute.type->name() != "boolean") {
                 attribute_generator.append(R"~~~(
-    auto retval = impl->attribute(HTML::AttributeNames::@attribute.reflect_name@);
+    auto retval = impl->deprecated_attribute(HTML::AttributeNames::@attribute.reflect_name@);
 )~~~");
             } else {
                 attribute_generator.append(R"~~~(

--- a/Tests/LibWeb/Text/expected/idl-handling-of-null-attribute.txt
+++ b/Tests/LibWeb/Text/expected/idl-handling-of-null-attribute.txt
@@ -1,0 +1,2 @@
+initial type = ''
+after setting to null = 'null'

--- a/Tests/LibWeb/Text/input/idl-handling-of-null-attribute.html
+++ b/Tests/LibWeb/Text/input/idl-handling-of-null-attribute.html
@@ -1,0 +1,9 @@
+<script src="include.js"></script>
+<script id="script-element">
+    test(() => {
+        let s = document.getElementById("script-element");
+        println(`initial type = '${s.type}'`);
+        s.type = null;
+        println(`after setting to null = '${s.type}'`);
+    });
+</script>

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
@@ -25,7 +25,7 @@ CSSStyleSheet::CSSStyleSheet(JS::Realm& realm, CSSRuleList& rules, MediaList& me
     , m_rules(&rules)
 {
     if (location.has_value())
-        set_location(location->to_deprecated_string());
+        set_location(MUST(location->to_string()));
 
     for (auto& rule : *m_rules)
         rule->set_parent_style_sheet(this);

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.h
@@ -29,7 +29,7 @@ public:
 
     void set_owner_css_rule(CSSRule* rule) { m_owner_css_rule = rule; }
 
-    virtual DeprecatedString type() const override { return "text/css"; }
+    virtual String type() const override { return "text/css"_string; }
 
     CSSRuleList const& rules() const { return *m_rules; }
     CSSRuleList& rules() { return *m_rules; }

--- a/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
+++ b/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
@@ -34,7 +34,7 @@ static inline bool matches_lang_pseudo_class(DOM::Element const& element, Vector
 {
     FlyString element_language;
     for (auto const* e = &element; e; e = e->parent_element()) {
-        auto lang = e->attribute(HTML::AttributeNames::lang);
+        auto lang = e->deprecated_attribute(HTML::AttributeNames::lang);
         if (!lang.is_null()) {
             element_language = FlyString::from_deprecated_fly_string(lang).release_value_but_fixme_should_propagate_errors();
             break;
@@ -142,14 +142,14 @@ static inline bool matches_attribute(CSS::Selector::SimpleSelector::Attribute co
     switch (attribute.match_type) {
     case CSS::Selector::SimpleSelector::Attribute::MatchType::ExactValueMatch:
         return case_insensitive_match
-            ? Infra::is_ascii_case_insensitive_match(element.attribute(attribute_name), attribute.value)
-            : element.attribute(attribute_name) == attribute.value.to_deprecated_string();
+            ? Infra::is_ascii_case_insensitive_match(element.deprecated_attribute(attribute_name), attribute.value)
+            : element.deprecated_attribute(attribute_name) == attribute.value.to_deprecated_string();
     case CSS::Selector::SimpleSelector::Attribute::MatchType::ContainsWord: {
         if (attribute.value.is_empty()) {
             // This selector is always false is match value is empty.
             return false;
         }
-        auto const view = element.attribute(attribute_name).split_view(' ');
+        auto const view = element.deprecated_attribute(attribute_name).split_view(' ');
         auto const size = view.size();
         for (size_t i = 0; i < size; ++i) {
             auto const value = view.at(i);
@@ -163,9 +163,9 @@ static inline bool matches_attribute(CSS::Selector::SimpleSelector::Attribute co
     }
     case CSS::Selector::SimpleSelector::Attribute::MatchType::ContainsString:
         return !attribute.value.is_empty()
-            && element.attribute(attribute_name).contains(attribute.value, case_sensitivity);
+            && element.deprecated_attribute(attribute_name).contains(attribute.value, case_sensitivity);
     case CSS::Selector::SimpleSelector::Attribute::MatchType::StartsWithSegment: {
-        auto const element_attr_value = element.attribute(attribute_name);
+        auto const element_attr_value = element.deprecated_attribute(attribute_name);
         if (element_attr_value.is_empty()) {
             // If the attribute value on element is empty, the selector is true
             // if the match value is also empty and false otherwise.
@@ -181,10 +181,10 @@ static inline bool matches_attribute(CSS::Selector::SimpleSelector::Attribute co
     }
     case CSS::Selector::SimpleSelector::Attribute::MatchType::StartsWithString:
         return !attribute.value.is_empty()
-            && element.attribute(attribute_name).starts_with(attribute.value, case_sensitivity);
+            && element.deprecated_attribute(attribute_name).starts_with(attribute.value, case_sensitivity);
     case CSS::Selector::SimpleSelector::Attribute::MatchType::EndsWithString:
         return !attribute.value.is_empty()
-            && element.attribute(attribute_name).ends_with(attribute.value, case_sensitivity);
+            && element.deprecated_attribute(attribute_name).ends_with(attribute.value, case_sensitivity);
     default:
         break;
     }
@@ -255,7 +255,7 @@ static inline bool matches_pseudo_class(CSS::Selector::SimpleSelector::PseudoCla
         if (!matches_link_pseudo_class(element))
             return false;
         auto document_url = element.document().url();
-        AK::URL target_url = element.document().parse_url(element.attribute(HTML::AttributeNames::href));
+        AK::URL target_url = element.document().parse_url(element.deprecated_attribute(HTML::AttributeNames::href));
         if (target_url.fragment().has_value())
             return document_url.equals(target_url, AK::URL::ExcludeFragment::No);
         return document_url.equals(target_url, AK::URL::ExcludeFragment::Yes);
@@ -560,7 +560,7 @@ static inline bool matches(CSS::Selector::SimpleSelector const& component, Optio
         VERIFY_NOT_REACHED();
     }
     case CSS::Selector::SimpleSelector::Type::Id:
-        return component.name() == element.attribute(HTML::AttributeNames::id).view();
+        return component.name() == element.deprecated_attribute(HTML::AttributeNames::id).view();
     case CSS::Selector::SimpleSelector::Type::Class:
         return element.has_class(component.name());
     case CSS::Selector::SimpleSelector::Type::Attribute:

--- a/Userland/Libraries/LibWeb/CSS/StyleSheet.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleSheet.h
@@ -19,20 +19,20 @@ class StyleSheet : public Bindings::PlatformObject {
 public:
     virtual ~StyleSheet() = default;
 
-    virtual DeprecatedString type() const = 0;
+    virtual String type() const = 0;
 
     DOM::Element* owner_node() { return m_owner_node; }
     void set_owner_node(DOM::Element*);
 
-    DeprecatedString href() const { return m_location; }
+    Optional<String> href() const { return m_location; }
 
-    DeprecatedString location() const { return m_location; }
-    void set_location(DeprecatedString location) { m_location = move(location); }
+    Optional<String> location() const { return m_location; }
+    void set_location(Optional<String> location) { m_location = move(location); }
 
-    DeprecatedString title() const { return m_title; }
-    void set_title(DeprecatedString title) { m_title = move(title); }
+    Optional<String> title() const { return m_title; }
+    void set_title(Optional<String> title) { m_title = move(title); }
 
-    void set_type(DeprecatedString type) { m_type_string = move(type); }
+    void set_type(String type) { m_type_string = move(type); }
 
     MediaList* media() const
     {
@@ -65,9 +65,9 @@ private:
     JS::GCPtr<DOM::Element> m_owner_node;
     JS::GCPtr<CSSStyleSheet> m_parent_style_sheet;
 
-    DeprecatedString m_location;
-    DeprecatedString m_title;
-    DeprecatedString m_type_string;
+    Optional<String> m_location;
+    Optional<String> m_title;
+    String m_type_string;
 
     bool m_disabled { false };
     bool m_alternate { false };

--- a/Userland/Libraries/LibWeb/CSS/StyleSheet.idl
+++ b/Userland/Libraries/LibWeb/CSS/StyleSheet.idl
@@ -3,7 +3,7 @@
 #import <DOM/Element.idl>
 
 // https://drafts.csswg.org/cssom/#stylesheet
-[Exposed=Window, UseDeprecatedAKString]
+[Exposed=Window]
 interface StyleSheet {
 
     readonly attribute Element? ownerNode;

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -943,7 +943,7 @@ i32 Element::default_tab_index_value() const
 // https://html.spec.whatwg.org/multipage/interaction.html#dom-tabindex
 i32 Element::tab_index() const
 {
-    auto maybe_table_index = Web::HTML::parse_integer(attribute(HTML::AttributeNames::tabindex));
+    auto maybe_table_index = Web::HTML::parse_integer(deprecated_attribute(HTML::AttributeNames::tabindex));
 
     if (!maybe_table_index.has_value())
         return default_tab_index_value();

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -92,6 +92,14 @@ public:
     bool has_attributes() const;
 
     DeprecatedString deprecated_attribute(DeprecatedFlyString const& name) const { return get_attribute(name); }
+    Optional<String> attribute(DeprecatedFlyString const& name) const
+    {
+        auto ret = deprecated_attribute(name);
+        if (ret.is_null())
+            return {};
+        return String::from_deprecated_string(ret).release_value();
+    }
+
     DeprecatedString get_attribute(DeprecatedFlyString const& name) const;
     DeprecatedString get_attribute_value(DeprecatedFlyString const& local_name, DeprecatedFlyString const& namespace_ = {}) const;
 

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -91,7 +91,7 @@ public:
     bool has_attribute_ns(DeprecatedFlyString namespace_, DeprecatedFlyString const& name) const;
     bool has_attributes() const;
 
-    DeprecatedString attribute(DeprecatedFlyString const& name) const { return get_attribute(name); }
+    DeprecatedString deprecated_attribute(DeprecatedFlyString const& name) const { return get_attribute(name); }
     DeprecatedString get_attribute(DeprecatedFlyString const& name) const;
     DeprecatedString get_attribute_value(DeprecatedFlyString const& local_name, DeprecatedFlyString const& namespace_ = {}) const;
 
@@ -158,7 +158,7 @@ public:
     Layout::NodeWithStyle* layout_node();
     Layout::NodeWithStyle const* layout_node() const;
 
-    DeprecatedString name() const { return attribute(HTML::AttributeNames::name); }
+    DeprecatedString name() const { return deprecated_attribute(HTML::AttributeNames::name); }
 
     CSS::StyleProperties* computed_css_values() { return m_computed_css_values.ptr(); }
     CSS::StyleProperties const* computed_css_values() const { return m_computed_css_values.ptr(); }

--- a/Userland/Libraries/LibWeb/DOM/HTMLCollection.cpp
+++ b/Userland/Libraries/LibWeb/DOM/HTMLCollection.cpp
@@ -87,7 +87,7 @@ Element* HTMLCollection::named_item(FlyString const& name_) const
     auto elements = collect_matching_elements();
     // 2. Return the first element in the collection for which at least one of the following is true:
     //      - it has an ID which is key;
-    if (auto it = elements.find_if([&](auto& entry) { return entry->attribute(HTML::AttributeNames::id) == name; }); it != elements.end())
+    if (auto it = elements.find_if([&](auto& entry) { return entry->deprecated_attribute(HTML::AttributeNames::id) == name; }); it != elements.end())
         return *it;
     //      - it is in the HTML namespace and has a name attribute whose value is key;
     if (auto it = elements.find_if([&](auto& entry) { return entry->namespace_() == Namespace::HTML && entry->name() == name; }); it != elements.end())
@@ -108,7 +108,7 @@ Vector<DeprecatedString> HTMLCollection::supported_property_names() const
     for (auto& element : elements) {
         // 1. If element has an ID which is not in result, append element’s ID to result.
         if (element->has_attribute(HTML::AttributeNames::id)) {
-            auto id = element->attribute(HTML::AttributeNames::id);
+            auto id = element->deprecated_attribute(HTML::AttributeNames::id);
 
             if (!result.contains_slow(id))
                 result.append(id);
@@ -116,7 +116,7 @@ Vector<DeprecatedString> HTMLCollection::supported_property_names() const
 
         // 2. If element is in the HTML namespace and has a name attribute whose value is neither the empty string nor is in result, append element’s name attribute value to result.
         if (element->namespace_() == Namespace::HTML && element->has_attribute(HTML::AttributeNames::name)) {
-            auto name = element->attribute(HTML::AttributeNames::name);
+            auto name = element->deprecated_attribute(HTML::AttributeNames::name);
 
             if (!name.is_empty() && !result.contains_slow(name))
                 result.append(name);

--- a/Userland/Libraries/LibWeb/DOM/HTMLFormControlsCollection.cpp
+++ b/Userland/Libraries/LibWeb/DOM/HTMLFormControlsCollection.cpp
@@ -46,7 +46,7 @@ Variant<Empty, Element*, JS::Handle<RadioNodeList>> HTMLFormControlsCollection::
 
     auto collection = collect_matching_elements();
     for (auto const& element : collection) {
-        if (element->attribute(HTML::AttributeNames::id) != deprecated_name && element->name() != deprecated_name)
+        if (element->deprecated_attribute(HTML::AttributeNames::id) != deprecated_name && element->name() != deprecated_name)
             continue;
 
         if (matching_element) {
@@ -71,7 +71,7 @@ Variant<Empty, Element*, JS::Handle<RadioNodeList>> HTMLFormControlsCollection::
             return false;
 
         auto const& element = verify_cast<Element>(node);
-        return element.attribute(HTML::AttributeNames::id) == deprecated_name || element.name() == deprecated_name;
+        return element.deprecated_attribute(HTML::AttributeNames::id) == deprecated_name || element.name() == deprecated_name;
     }));
 }
 

--- a/Userland/Libraries/LibWeb/DOM/NonElementParentNode.h
+++ b/Userland/Libraries/LibWeb/DOM/NonElementParentNode.h
@@ -21,7 +21,7 @@ public:
     {
         JS::GCPtr<Element const> found_element;
         static_cast<NodeType const*>(this)->template for_each_in_inclusive_subtree_of_type<Element>([&](auto& element) {
-            if (element.attribute(HTML::AttributeNames::id) == id) {
+            if (element.deprecated_attribute(HTML::AttributeNames::id) == id) {
                 found_element = &element;
                 return IterationDecision::Break;
             }
@@ -34,7 +34,7 @@ public:
     {
         JS::GCPtr<Element> found_element;
         static_cast<NodeType*>(this)->template for_each_in_inclusive_subtree_of_type<Element>([&](auto& element) {
-            if (element.attribute(HTML::AttributeNames::id) == id) {
+            if (element.deprecated_attribute(HTML::AttributeNames::id) == id) {
                 found_element = &element;
                 return IterationDecision::Break;
             }

--- a/Userland/Libraries/LibWeb/DOM/StyleElementUtils.cpp
+++ b/Userland/Libraries/LibWeb/DOM/StyleElementUtils.cpp
@@ -94,12 +94,18 @@ void StyleElementUtils::create_a_css_style_sheet(DOM::Document& document, Deprec
     sheet.set_parent_css_style_sheet(parent_style_sheet);
     sheet.set_owner_css_rule(owner_rule);
     sheet.set_owner_node(owner_node);
-    sheet.set_type(move(type));
+    sheet.set_type(MUST(String::from_deprecated_string(type)));
     sheet.set_media(move(media));
-    sheet.set_title(move(title));
+    if (title.is_null())
+        sheet.set_title({});
+    else
+        sheet.set_title(MUST(String::from_deprecated_string(title)));
     sheet.set_alternate(alternate);
     sheet.set_origin_clean(origin_clean);
-    sheet.set_location(move(location));
+    if (location.is_null())
+        sheet.set_location({});
+    else
+        sheet.set_location(MUST(String::from_deprecated_string(location)));
 
     // 2. Then run the add a CSS style sheet steps for the newly created CSS style sheet.
     add_a_css_style_sheet(document, sheet);

--- a/Userland/Libraries/LibWeb/DOM/StyleElementUtils.cpp
+++ b/Userland/Libraries/LibWeb/DOM/StyleElementUtils.cpp
@@ -43,7 +43,7 @@ void StyleElementUtils::update_a_style_block(DOM::Element& style_element)
         return;
 
     // 4. If element's type attribute is present and its value is neither the empty string nor an ASCII case-insensitive match for "text/css", then return.
-    auto type_attribute = style_element.attribute(HTML::AttributeNames::type);
+    auto type_attribute = style_element.deprecated_attribute(HTML::AttributeNames::type);
     if (!type_attribute.is_null() && !type_attribute.is_empty() && !Infra::is_ascii_case_insensitive_match(type_attribute, "text/css"sv))
         return;
 
@@ -63,8 +63,8 @@ void StyleElementUtils::update_a_style_block(DOM::Element& style_element)
         style_element.document(),
         "text/css"sv,
         &style_element,
-        style_element.attribute(HTML::AttributeNames::media),
-        style_element.in_a_document_tree() ? style_element.attribute(HTML::AttributeNames::title) : DeprecatedString::empty(),
+        style_element.deprecated_attribute(HTML::AttributeNames::media),
+        style_element.in_a_document_tree() ? style_element.deprecated_attribute(HTML::AttributeNames::title) : DeprecatedString::empty(),
         false,
         true,
         {},

--- a/Userland/Libraries/LibWeb/Dump.cpp
+++ b/Userland/Libraries/LibWeb/Dump.cpp
@@ -126,7 +126,7 @@ void dump_tree(StringBuilder& builder, Layout::Node const& layout_node, bool sho
     if (layout_node.dom_node() && is<DOM::Element>(*layout_node.dom_node())) {
         auto& element = verify_cast<DOM::Element>(*layout_node.dom_node());
         StringBuilder builder;
-        auto id = element.attribute(HTML::AttributeNames::id);
+        auto id = element.deprecated_attribute(HTML::AttributeNames::id);
         if (!id.is_empty()) {
             builder.append('#');
             builder.append(id);

--- a/Userland/Libraries/LibWeb/HTML/CanvasGradient.cpp
+++ b/Userland/Libraries/LibWeb/HTML/CanvasGradient.cpp
@@ -54,7 +54,7 @@ void CanvasGradient::initialize(JS::Realm& realm)
 }
 
 // https://html.spec.whatwg.org/multipage/canvas.html#dom-canvasgradient-addcolorstop
-WebIDL::ExceptionOr<void> CanvasGradient::add_color_stop(double offset, DeprecatedString const& color)
+WebIDL::ExceptionOr<void> CanvasGradient::add_color_stop(double offset, StringView color)
 {
     // 1. If the offset is less than 0 or greater than 1, then throw an "IndexSizeError" DOMException.
     if (offset < 0 || offset > 1)

--- a/Userland/Libraries/LibWeb/HTML/CanvasGradient.h
+++ b/Userland/Libraries/LibWeb/HTML/CanvasGradient.h
@@ -20,7 +20,7 @@ public:
     static WebIDL::ExceptionOr<JS::NonnullGCPtr<CanvasGradient>> create_linear(JS::Realm&, double x0, double y0, double x1, double y1);
     static WebIDL::ExceptionOr<JS::NonnullGCPtr<CanvasGradient>> create_conic(JS::Realm&, double start_angle, double x, double y);
 
-    WebIDL::ExceptionOr<void> add_color_stop(double offset, DeprecatedString const& color);
+    WebIDL::ExceptionOr<void> add_color_stop(double offset, StringView color);
 
     ~CanvasGradient();
 

--- a/Userland/Libraries/LibWeb/HTML/CanvasGradient.idl
+++ b/Userland/Libraries/LibWeb/HTML/CanvasGradient.idl
@@ -1,4 +1,4 @@
-[Exposed=(Window,Worker), UseDeprecatedAKString]
+[Exposed=(Window,Worker)]
 interface CanvasGradient {
     // opaque object
     undefined addColorStop(double offset, DOMString color);

--- a/Userland/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
@@ -102,9 +102,9 @@ void FormAssociatedElement::reset_form_owner()
     // 4. If element is listed, has a form content attribute, and is connected, then:
     if (is_listed() && html_element.has_attribute(HTML::AttributeNames::form) && html_element.is_connected()) {
         // 1. If the first element in element's tree, in tree order, to have an ID that is identical to element's form content attribute's value, is a form element, then associate the element with that form element.
-        auto form_value = html_element.attribute(HTML::AttributeNames::form);
+        auto form_value = html_element.deprecated_attribute(HTML::AttributeNames::form);
         html_element.root().for_each_in_inclusive_subtree_of_type<HTMLFormElement>([this, &form_value](HTMLFormElement& form_element) {
-            if (form_element.attribute(HTML::AttributeNames::id) == form_value) {
+            if (form_element.deprecated_attribute(HTML::AttributeNames::id) == form_value) {
                 set_form(&form_element);
                 return IterationDecision::Break;
             }

--- a/Userland/Libraries/LibWeb/HTML/FormControlInfrastructure.cpp
+++ b/Userland/Libraries/LibWeb/HTML/FormControlInfrastructure.cpp
@@ -114,7 +114,7 @@ WebIDL::ExceptionOr<Optional<Vector<XHR::FormDataEntry>>> construct_entry_list(J
             for (auto const& option_element : select_element->list_of_options()) {
                 if (option_element->selected() && !option_element->disabled()) {
                     auto option_name = TRY_OR_THROW_OOM(vm, String::from_deprecated_string(option_element->name()));
-                    auto option_value = TRY_OR_THROW_OOM(vm, String::from_deprecated_string(option_element->value()));
+                    auto option_value = option_element->value();
                     TRY_OR_THROW_OOM(vm, entry_list.try_append(XHR::FormDataEntry { .name = move(option_name), .value = move(option_value) }));
                 }
             }

--- a/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.cpp
@@ -37,7 +37,7 @@ void HTMLAnchorElement::attribute_changed(DeprecatedFlyString const& name, Depre
 
 DeprecatedString HTMLAnchorElement::hyperlink_element_utils_href() const
 {
-    return attribute(HTML::AttributeNames::href);
+    return deprecated_attribute(HTML::AttributeNames::href);
 }
 
 WebIDL::ExceptionOr<void> HTMLAnchorElement::set_hyperlink_element_utils_href(DeprecatedString href)
@@ -122,7 +122,7 @@ void HTMLAnchorElement::set_text(DeprecatedString const& text)
 DeprecatedString HTMLAnchorElement::referrer_policy() const
 {
     // The IDL attribute referrerPolicy must reflect the referrerpolicy content attribute, limited to only known values.
-    auto policy_string = attribute(HTML::AttributeNames::referrerpolicy);
+    auto policy_string = deprecated_attribute(HTML::AttributeNames::referrerpolicy);
     auto maybe_policy = ReferrerPolicy::from_string(policy_string);
     if (maybe_policy.has_value())
         return ReferrerPolicy::to_string(maybe_policy.value());

--- a/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.cpp
@@ -105,32 +105,37 @@ Optional<ARIA::Role> HTMLAnchorElement::default_role() const
 }
 
 // https://html.spec.whatwg.org/multipage/text-level-semantics.html#dom-a-text
-DeprecatedString HTMLAnchorElement::text() const
+String HTMLAnchorElement::text() const
 {
     // The text attribute's getter must return this element's descendant text content.
-    return descendant_text_content();
+    return MUST(String::from_deprecated_string(descendant_text_content()));
 }
 
 // https://html.spec.whatwg.org/multipage/text-level-semantics.html#dom-a-text
-void HTMLAnchorElement::set_text(DeprecatedString const& text)
+void HTMLAnchorElement::set_text(String const& text)
 {
     // The text attribute's setter must string replace all with the given value within this element.
-    string_replace_all(text);
+    string_replace_all(text.to_deprecated_string());
 }
 
 // https://html.spec.whatwg.org/multipage/text-level-semantics.html#dom-a-referrerpolicy
-DeprecatedString HTMLAnchorElement::referrer_policy() const
+StringView HTMLAnchorElement::referrer_policy() const
 {
+    // FIXME: This should probably be `Reflect` in the IDL.
     // The IDL attribute referrerPolicy must reflect the referrerpolicy content attribute, limited to only known values.
-    auto policy_string = deprecated_attribute(HTML::AttributeNames::referrerpolicy);
-    auto maybe_policy = ReferrerPolicy::from_string(policy_string);
-    if (maybe_policy.has_value())
-        return ReferrerPolicy::to_string(maybe_policy.value());
-    return "";
+    auto maybe_policy_string = attribute(HTML::AttributeNames::referrerpolicy);
+    if (!maybe_policy_string.has_value())
+        return ""sv;
+
+    auto maybe_policy = ReferrerPolicy::from_string(maybe_policy_string.value());
+    if (!maybe_policy.has_value())
+        return ""sv;
+
+    return ReferrerPolicy::to_string(maybe_policy.value());
 }
 
 // https://html.spec.whatwg.org/multipage/text-level-semantics.html#dom-a-referrerpolicy
-WebIDL::ExceptionOr<void> HTMLAnchorElement::set_referrer_policy(DeprecatedString const& referrer_policy)
+WebIDL::ExceptionOr<void> HTMLAnchorElement::set_referrer_policy(String const& referrer_policy)
 {
     // The IDL attribute referrerPolicy must reflect the referrerpolicy content attribute, limited to only known values.
     return set_attribute(HTML::AttributeNames::referrerpolicy, referrer_policy);

--- a/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.h
@@ -23,11 +23,11 @@ public:
     DeprecatedString target() const { return deprecated_attribute(HTML::AttributeNames::target); }
     DeprecatedString download() const { return deprecated_attribute(HTML::AttributeNames::download); }
 
-    DeprecatedString text() const;
-    void set_text(DeprecatedString const&);
+    String text() const;
+    void set_text(String const&);
 
-    DeprecatedString referrer_policy() const;
-    WebIDL::ExceptionOr<void> set_referrer_policy(DeprecatedString const&);
+    StringView referrer_policy() const;
+    WebIDL::ExceptionOr<void> set_referrer_policy(String const&);
 
     // ^EventTarget
     // https://html.spec.whatwg.org/multipage/interaction.html#the-tabindex-attribute:the-a-element

--- a/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.h
@@ -19,9 +19,9 @@ class HTMLAnchorElement final
 public:
     virtual ~HTMLAnchorElement() override;
 
-    DeprecatedString rel() const { return attribute(HTML::AttributeNames::rel); }
-    DeprecatedString target() const { return attribute(HTML::AttributeNames::target); }
-    DeprecatedString download() const { return attribute(HTML::AttributeNames::download); }
+    DeprecatedString rel() const { return deprecated_attribute(HTML::AttributeNames::rel); }
+    DeprecatedString target() const { return deprecated_attribute(HTML::AttributeNames::target); }
+    DeprecatedString download() const { return deprecated_attribute(HTML::AttributeNames::download); }
 
     DeprecatedString text() const;
     void set_text(DeprecatedString const&);

--- a/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.idl
@@ -2,7 +2,7 @@
 #import <HTML/HTMLHyperlinkElementUtils.idl>
 
 // https://html.spec.whatwg.org/multipage/text-level-semantics.html#htmlanchorelement
-[Exposed=Window, UseDeprecatedAKString]
+[Exposed=Window]
 interface HTMLAnchorElement : HTMLElement {
 
     [HTMLConstructor] constructor();

--- a/Userland/Libraries/LibWeb/HTML/HTMLAreaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLAreaElement.cpp
@@ -33,7 +33,7 @@ void HTMLAreaElement::attribute_changed(DeprecatedFlyString const& name, Depreca
 
 DeprecatedString HTMLAreaElement::hyperlink_element_utils_href() const
 {
-    return attribute(HTML::AttributeNames::href);
+    return deprecated_attribute(HTML::AttributeNames::href);
 }
 
 WebIDL::ExceptionOr<void> HTMLAreaElement::set_hyperlink_element_utils_href(DeprecatedString href)

--- a/Userland/Libraries/LibWeb/HTML/HTMLAreaElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLAreaElement.idl
@@ -2,7 +2,7 @@
 #import <HTML/HTMLHyperlinkElementUtils.idl>
 
 // https://html.spec.whatwg.org/multipage/image-maps.html#htmlareaelement
-[Exposed=Window, UseDeprecatedAKString]
+[Exposed=Window]
 interface HTMLAreaElement : HTMLElement {
 
     [HTMLConstructor] constructor();

--- a/Userland/Libraries/LibWeb/HTML/HTMLBaseElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLBaseElement.cpp
@@ -80,15 +80,13 @@ void HTMLBaseElement::set_the_frozen_base_url()
 }
 
 // https://html.spec.whatwg.org/multipage/semantics.html#dom-base-href
-DeprecatedString HTMLBaseElement::href() const
+String HTMLBaseElement::href() const
 {
     // 1. Let document be element's node document.
-    auto& document = this->document();
+    auto const& document = this->document();
 
     // 2. Let url be the value of the href attribute of this element, if it has one, and the empty string otherwise.
-    auto url = DeprecatedString::empty();
-    if (has_attribute(AttributeNames::href))
-        url = deprecated_attribute(AttributeNames::href);
+    auto url = attribute(AttributeNames::href).value_or(String {});
 
     // 3. Let urlRecord be the result of parsing url with document's fallback base URL, and document's character encoding. (Thus, the base element isn't affected by other base elements or itself.)
     // FIXME: Pass in document's character encoding.
@@ -99,11 +97,11 @@ DeprecatedString HTMLBaseElement::href() const
         return url;
 
     // 5. Return the serialization of urlRecord.
-    return url_record.to_deprecated_string();
+    return MUST(url_record.to_string());
 }
 
 // https://html.spec.whatwg.org/multipage/semantics.html#dom-base-href
-WebIDL::ExceptionOr<void> HTMLBaseElement::set_href(DeprecatedString const& href)
+WebIDL::ExceptionOr<void> HTMLBaseElement::set_href(String const& href)
 {
     // The href IDL attribute, on setting, must set the href content attribute to the given new value.
     return set_attribute(AttributeNames::href, href);

--- a/Userland/Libraries/LibWeb/HTML/HTMLBaseElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLBaseElement.cpp
@@ -66,7 +66,7 @@ void HTMLBaseElement::set_the_frozen_base_url()
     auto& document = this->document();
 
     // 2. Let urlRecord be the result of parsing the value of element's href content attribute with document's fallback base URL, and document's character encoding. (Thus, the base element isn't affected by itself.)
-    auto href = attribute(AttributeNames::href);
+    auto href = deprecated_attribute(AttributeNames::href);
     auto url_record = document.fallback_base_url().complete_url(href);
 
     // 3. Set element's frozen base URL to document's fallback base URL, if urlRecord is failure or running Is base allowed for Document? on the resulting URL record and document returns "Blocked", and to urlRecord otherwise.
@@ -88,7 +88,7 @@ DeprecatedString HTMLBaseElement::href() const
     // 2. Let url be the value of the href attribute of this element, if it has one, and the empty string otherwise.
     auto url = DeprecatedString::empty();
     if (has_attribute(AttributeNames::href))
-        url = attribute(AttributeNames::href);
+        url = deprecated_attribute(AttributeNames::href);
 
     // 3. Let urlRecord be the result of parsing url with document's fallback base URL, and document's character encoding. (Thus, the base element isn't affected by other base elements or itself.)
     // FIXME: Pass in document's character encoding.

--- a/Userland/Libraries/LibWeb/HTML/HTMLBaseElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLBaseElement.h
@@ -16,8 +16,8 @@ class HTMLBaseElement final : public HTMLElement {
 public:
     virtual ~HTMLBaseElement() override;
 
-    DeprecatedString href() const;
-    WebIDL::ExceptionOr<void> set_href(DeprecatedString const& href);
+    String href() const;
+    WebIDL::ExceptionOr<void> set_href(String const& href);
 
     AK::URL const& frozen_base_url() const { return m_frozen_base_url; }
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLBaseElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLBaseElement.idl
@@ -1,7 +1,7 @@
 #import <HTML/HTMLElement.idl>
 
 // https://html.spec.whatwg.org/multipage/semantics.html#htmlbaseelement
-[Exposed=Window, UseDeprecatedAKString]
+[Exposed=Window]
 interface HTMLBaseElement : HTMLElement {
 
     [HTMLConstructor] constructor();

--- a/Userland/Libraries/LibWeb/HTML/HTMLButtonElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLButtonElement.cpp
@@ -59,7 +59,7 @@ void HTMLButtonElement::initialize(JS::Realm& realm)
 
 DeprecatedString HTMLButtonElement::type() const
 {
-    auto value = attribute(HTML::AttributeNames::type);
+    auto value = deprecated_attribute(HTML::AttributeNames::type);
 
 #define __ENUMERATE_HTML_BUTTON_TYPE_ATTRIBUTE(keyword, _) \
     if (value.equals_ignoring_ascii_case(#keyword##sv))    \
@@ -73,7 +73,7 @@ DeprecatedString HTMLButtonElement::type() const
 
 HTMLButtonElement::TypeAttributeState HTMLButtonElement::type_state() const
 {
-    auto value = attribute(HTML::AttributeNames::type);
+    auto value = deprecated_attribute(HTML::AttributeNames::type);
 
 #define __ENUMERATE_HTML_BUTTON_TYPE_ATTRIBUTE(keyword, state) \
     if (value.equals_ignoring_ascii_case(#keyword##sv))        \
@@ -110,7 +110,7 @@ DeprecatedString HTMLButtonElement::value() const
 {
     if (!has_attribute(AttributeNames::value))
         return DeprecatedString::empty();
-    return attribute(AttributeNames::value);
+    return deprecated_attribute(AttributeNames::value);
 }
 
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLButtonElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLButtonElement.cpp
@@ -57,18 +57,18 @@ void HTMLButtonElement::initialize(JS::Realm& realm)
     set_prototype(&Bindings::ensure_web_prototype<Bindings::HTMLButtonElementPrototype>(realm, "HTMLButtonElement"));
 }
 
-DeprecatedString HTMLButtonElement::type() const
+StringView HTMLButtonElement::type() const
 {
     auto value = deprecated_attribute(HTML::AttributeNames::type);
 
 #define __ENUMERATE_HTML_BUTTON_TYPE_ATTRIBUTE(keyword, _) \
     if (value.equals_ignoring_ascii_case(#keyword##sv))    \
-        return #keyword;
+        return #keyword##sv;
     ENUMERATE_HTML_BUTTON_TYPE_ATTRIBUTES
 #undef __ENUMERATE_HTML_BUTTON_TYPE_ATTRIBUTE
 
     // The missing value default and invalid value default are the Submit Button state.
-    return "submit";
+    return "submit"sv;
 }
 
 HTMLButtonElement::TypeAttributeState HTMLButtonElement::type_state() const
@@ -85,7 +85,7 @@ HTMLButtonElement::TypeAttributeState HTMLButtonElement::type_state() const
     return HTMLButtonElement::TypeAttributeState::Submit;
 }
 
-WebIDL::ExceptionOr<void> HTMLButtonElement::set_type(DeprecatedString const& type)
+WebIDL::ExceptionOr<void> HTMLButtonElement::set_type(String const& type)
 {
     return set_attribute(HTML::AttributeNames::type, type);
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLButtonElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLButtonElement.h
@@ -34,9 +34,9 @@ public:
 #undef __ENUMERATE_HTML_BUTTON_TYPE_ATTRIBUTE
     };
 
-    DeprecatedString type() const;
+    StringView type() const;
     TypeAttributeState type_state() const;
-    WebIDL::ExceptionOr<void> set_type(DeprecatedString const&);
+    WebIDL::ExceptionOr<void> set_type(String const&);
 
     // ^EventTarget
     // https://html.spec.whatwg.org/multipage/interaction.html#the-tabindex-attribute:the-button-element

--- a/Userland/Libraries/LibWeb/HTML/HTMLButtonElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLButtonElement.idl
@@ -1,7 +1,7 @@
 #import <HTML/HTMLElement.idl>
 
 // https://html.spec.whatwg.org/multipage/semantics.html#htmlbuttonelement
-[Exposed=Window, UseDeprecatedAKString]
+[Exposed=Window]
 interface HTMLButtonElement : HTMLElement {
 
     [HTMLConstructor] constructor();

--- a/Userland/Libraries/LibWeb/HTML/HTMLCanvasElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLCanvasElement.cpp
@@ -153,7 +153,7 @@ JS::ThrowCompletionOr<HTMLCanvasElement::HasOrCreatedContext> HTMLCanvasElement:
 }
 
 // https://html.spec.whatwg.org/multipage/canvas.html#dom-canvas-getcontext
-JS::ThrowCompletionOr<HTMLCanvasElement::RenderingContext> HTMLCanvasElement::get_context(DeprecatedString const& type, JS::Value options)
+JS::ThrowCompletionOr<HTMLCanvasElement::RenderingContext> HTMLCanvasElement::get_context(String const& type, JS::Value options)
 {
     // 1. If options is not an object, then set options to null.
     if (!options.is_object())
@@ -246,14 +246,14 @@ static ErrorOr<SerializeBitmapResult> serialize_bitmap(Gfx::Bitmap const& bitmap
 }
 
 // https://html.spec.whatwg.org/multipage/canvas.html#dom-canvas-todataurl
-DeprecatedString HTMLCanvasElement::to_data_url(DeprecatedString const& type, Optional<double> quality) const
+String HTMLCanvasElement::to_data_url(StringView type, Optional<double> quality) const
 {
     // FIXME: 1. If this canvas element's bitmap's origin-clean flag is set to false, then throw a "SecurityError" DOMException.
 
     // 2. If this canvas element's bitmap has no pixels (i.e. either its horizontal dimension or its vertical dimension is zero)
     //    then return the string "data:,". (This is the shortest data: URL; it represents the empty string in a text/plain resource.)
     if (!m_bitmap)
-        return "data:,";
+        return "data:,"_string;
 
     // 3. Let file be a serialization of this canvas element's bitmap as a file, passing type and quality if given.
     auto file = serialize_bitmap(*m_bitmap, type, move(quality));
@@ -261,19 +261,19 @@ DeprecatedString HTMLCanvasElement::to_data_url(DeprecatedString const& type, Op
     // 4. If file is null then return "data:,".
     if (file.is_error()) {
         dbgln("HTMLCanvasElement: Failed to encode canvas bitmap to {}: {}", type, file.error());
-        return "data:,";
+        return "data:,"_string;
     }
 
     // 5. Return a data: URL representing file. [RFC2397]
     auto base64_encoded_or_error = encode_base64(file.value().buffer);
     if (base64_encoded_or_error.is_error()) {
-        return "data:,";
+        return "data:,"_string;
     }
-    return AK::URL::create_with_data(file.value().mime_type, base64_encoded_or_error.release_value(), true).to_deprecated_string();
+    return MUST(AK::URL::create_with_data(file.value().mime_type, base64_encoded_or_error.release_value(), true).to_string());
 }
 
 // https://html.spec.whatwg.org/multipage/canvas.html#dom-canvas-toblob
-WebIDL::ExceptionOr<void> HTMLCanvasElement::to_blob(JS::NonnullGCPtr<WebIDL::CallbackType> callback, DeprecatedString const& type, Optional<double> quality)
+WebIDL::ExceptionOr<void> HTMLCanvasElement::to_blob(JS::NonnullGCPtr<WebIDL::CallbackType> callback, StringView type, Optional<double> quality)
 {
     // FIXME: 1. If this canvas element's bitmap's origin-clean flag is set to false, then throw a "SecurityError" DOMException.
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLCanvasElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLCanvasElement.cpp
@@ -64,8 +64,8 @@ void HTMLCanvasElement::apply_presentational_hints(CSS::StyleProperties& style) 
 
     // https://html.spec.whatwg.org/multipage/rendering.html#map-to-the-aspect-ratio-property
     // if element has both attributes w and h, and parsing those attributes' values using the rules for parsing non-negative integers doesn't generate an error for either
-    auto w = parse_non_negative_integer(attribute(HTML::AttributeNames::width));
-    auto h = parse_non_negative_integer(attribute(HTML::AttributeNames::height));
+    auto w = parse_non_negative_integer(deprecated_attribute(HTML::AttributeNames::width));
+    auto h = parse_non_negative_integer(deprecated_attribute(HTML::AttributeNames::height));
 
     if (w.has_value() && h.has_value())
         // then the user agent is expected to use the parsed integers as a presentational hint for the 'aspect-ratio' property of the form auto w / h.
@@ -83,7 +83,7 @@ unsigned HTMLCanvasElement::width() const
     // The rules for parsing non-negative integers must be used to obtain their numeric values.
     // If an attribute is missing, or if parsing its value returns an error, then the default value must be used instead.
     // The width attribute defaults to 300
-    return parse_non_negative_integer(attribute(HTML::AttributeNames::width)).value_or(300);
+    return parse_non_negative_integer(deprecated_attribute(HTML::AttributeNames::width)).value_or(300);
 }
 
 unsigned HTMLCanvasElement::height() const
@@ -92,7 +92,7 @@ unsigned HTMLCanvasElement::height() const
     // The rules for parsing non-negative integers must be used to obtain their numeric values.
     // If an attribute is missing, or if parsing its value returns an error, then the default value must be used instead.
     // the height attribute defaults to 150
-    return parse_non_negative_integer(attribute(HTML::AttributeNames::height)).value_or(150);
+    return parse_non_negative_integer(deprecated_attribute(HTML::AttributeNames::height)).value_or(150);
 }
 
 void HTMLCanvasElement::reset_context_to_default_state()

--- a/Userland/Libraries/LibWeb/HTML/HTMLCanvasElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLCanvasElement.h
@@ -25,7 +25,7 @@ public:
     Gfx::Bitmap* bitmap() { return m_bitmap; }
     bool create_bitmap(size_t minimum_width = 0, size_t minimum_height = 0);
 
-    JS::ThrowCompletionOr<RenderingContext> get_context(DeprecatedString const& type, JS::Value options);
+    JS::ThrowCompletionOr<RenderingContext> get_context(String const& type, JS::Value options);
 
     unsigned width() const;
     unsigned height() const;
@@ -33,8 +33,8 @@ public:
     WebIDL::ExceptionOr<void> set_width(unsigned);
     WebIDL::ExceptionOr<void> set_height(unsigned);
 
-    DeprecatedString to_data_url(DeprecatedString const& type, Optional<double> quality) const;
-    WebIDL::ExceptionOr<void> to_blob(JS::NonnullGCPtr<WebIDL::CallbackType> callback, DeprecatedString const& type, Optional<double> quality);
+    String to_data_url(StringView type, Optional<double> quality) const;
+    WebIDL::ExceptionOr<void> to_blob(JS::NonnullGCPtr<WebIDL::CallbackType> callback, StringView type, Optional<double> quality);
 
     void present();
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLCanvasElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLCanvasElement.idl
@@ -5,7 +5,7 @@
 typedef (CanvasRenderingContext2D or WebGLRenderingContext) RenderingContext;
 
 // https://html.spec.whatwg.org/multipage/semantics.html#htmlcanvaselement
-[Exposed=Window, UseDeprecatedAKString]
+[Exposed=Window]
 interface HTMLCanvasElement : HTMLElement {
 
     [HTMLConstructor] constructor();

--- a/Userland/Libraries/LibWeb/HTML/HTMLElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLElement.cpp
@@ -60,7 +60,7 @@ void HTMLElement::visit_edges(Cell::Visitor& visitor)
 // https://html.spec.whatwg.org/multipage/dom.html#dom-dir
 DeprecatedString HTMLElement::dir() const
 {
-    auto dir = attribute(HTML::AttributeNames::dir);
+    auto dir = deprecated_attribute(HTML::AttributeNames::dir);
 #define __ENUMERATE_HTML_ELEMENT_DIR_ATTRIBUTE(keyword) \
     if (dir.equals_ignoring_ascii_case(#keyword##sv))   \
         return #keyword##sv;
@@ -427,7 +427,7 @@ DeprecatedString HTMLElement::get_an_elements_target() const
 
     // 1. If element has a target attribute, then return that attribute's value.
     if (has_attribute(AttributeNames::target))
-        return attribute(AttributeNames::target);
+        return deprecated_attribute(AttributeNames::target);
 
     // FIXME: 2. If element's node document contains a base element with a
     // target attribute, then return the value of the target attribute of the
@@ -441,7 +441,7 @@ DeprecatedString HTMLElement::get_an_elements_target() const
 TokenizedFeature::NoOpener HTMLElement::get_an_elements_noopener(StringView target) const
 {
     // To get an element's noopener, given an a, area, or form element element and a string target:
-    auto rel = attribute(HTML::AttributeNames::rel).to_lowercase();
+    auto rel = deprecated_attribute(HTML::AttributeNames::rel).to_lowercase();
     auto link_types = rel.view().split_view_if(Infra::is_ascii_whitespace);
 
     // 1. If element's link types include the noopener or noreferrer keyword, then return true.

--- a/Userland/Libraries/LibWeb/HTML/HTMLElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLElement.h
@@ -27,7 +27,7 @@ class HTMLElement
 public:
     virtual ~HTMLElement() override;
 
-    DeprecatedString title() const { return attribute(HTML::AttributeNames::title); }
+    DeprecatedString title() const { return deprecated_attribute(HTML::AttributeNames::title); }
 
     DeprecatedString dir() const;
     void set_dir(DeprecatedString const&);

--- a/Userland/Libraries/LibWeb/HTML/HTMLElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLElement.h
@@ -29,14 +29,14 @@ public:
 
     DeprecatedString title() const { return deprecated_attribute(HTML::AttributeNames::title); }
 
-    DeprecatedString dir() const;
-    void set_dir(DeprecatedString const&);
+    StringView dir() const;
+    void set_dir(String const&);
 
     virtual bool is_editable() const final;
-    DeprecatedString content_editable() const;
-    WebIDL::ExceptionOr<void> set_content_editable(DeprecatedString const&);
+    StringView content_editable() const;
+    WebIDL::ExceptionOr<void> set_content_editable(StringView);
 
-    DeprecatedString inner_text();
+    String inner_text();
     void set_inner_text(StringView);
 
     int offset_top() const;

--- a/Userland/Libraries/LibWeb/HTML/HTMLElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLElement.idl
@@ -3,7 +3,7 @@
 #import <DOM/EventHandler.idl>
 
 // https://html.spec.whatwg.org/multipage/semantics.html#htmlelement
-[Exposed=Window, UseDeprecatedAKString]
+[Exposed=Window]
 interface HTMLElement : Element {
 
     [HTMLConstructor] constructor();

--- a/Userland/Libraries/LibWeb/HTML/HTMLFormElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFormElement.cpp
@@ -185,7 +185,7 @@ WebIDL::ExceptionOr<void> HTMLFormElement::submit_form(JS::NonnullGCPtr<HTMLElem
     //     owner.
     DeprecatedString target;
     if (submitter->has_attribute(AttributeNames::formtarget))
-        target = submitter->attribute(AttributeNames::formtarget);
+        target = submitter->deprecated_attribute(AttributeNames::formtarget);
     else
         target = get_an_elements_target();
 
@@ -316,10 +316,10 @@ DeprecatedString HTMLFormElement::action_from_form_element(JS::NonnullGCPtr<HTML
     // string.
     if (auto const* form_associated_element = dynamic_cast<FormAssociatedElement const*>(element.ptr());
         form_associated_element && form_associated_element->is_submit_button() && element->has_attribute(AttributeNames::formaction))
-        return attribute(AttributeNames::formaction);
+        return deprecated_attribute(AttributeNames::formaction);
 
     if (this->has_attribute(AttributeNames::action))
-        return attribute(AttributeNames::action);
+        return deprecated_attribute(AttributeNames::action);
 
     return DeprecatedString::empty();
 }
@@ -346,13 +346,13 @@ HTMLFormElement::MethodAttributeState HTMLFormElement::method_state_from_form_el
         form_associated_element && form_associated_element->is_submit_button() && element->has_attribute(AttributeNames::formmethod)) {
         // NOTE: `formmethod` is the same as `method`, except that it has no missing value default.
         //       This is handled by not calling `method_attribute_to_method_state` in the first place if there is no `formmethod` attribute.
-        return method_attribute_to_method_state(element->attribute(AttributeNames::formmethod));
+        return method_attribute_to_method_state(element->deprecated_attribute(AttributeNames::formmethod));
     }
 
     if (!this->has_attribute(AttributeNames::method))
         return MethodAttributeState::GET;
 
-    return method_attribute_to_method_state(this->attribute(AttributeNames::method));
+    return method_attribute_to_method_state(this->deprecated_attribute(AttributeNames::method));
 }
 
 // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#form-submission-attributes:attr-fs-enctype-2
@@ -378,13 +378,13 @@ HTMLFormElement::EncodingTypeAttributeState HTMLFormElement::encoding_type_state
         // NOTE: `formenctype` is the same as `enctype`, except that it has no missing value default.
         //       This is handled by not calling `encoding_type_attribute_to_encoding_type_state` in the first place if there is no
         //       `formenctype` attribute.
-        return encoding_type_attribute_to_encoding_type_state(element->attribute(AttributeNames::formenctype));
+        return encoding_type_attribute_to_encoding_type_state(element->deprecated_attribute(AttributeNames::formenctype));
     }
 
     if (!this->has_attribute(AttributeNames::enctype))
         return EncodingTypeAttributeState::FormUrlEncoded;
 
-    return encoding_type_attribute_to_encoding_type_state(this->attribute(AttributeNames::enctype));
+    return encoding_type_attribute_to_encoding_type_state(this->deprecated_attribute(AttributeNames::enctype));
 }
 
 static bool is_form_control(DOM::Element const& element)
@@ -497,7 +497,7 @@ DeprecatedString HTMLFormElement::action() const
     if (!has_attribute(AttributeNames::action))
         return document().url_string();
 
-    auto action_attribute = attribute(AttributeNames::action);
+    auto action_attribute = deprecated_attribute(AttributeNames::action);
     if (action_attribute.is_empty())
         return document().url_string();
 
@@ -519,7 +519,7 @@ ErrorOr<String> HTMLFormElement::pick_an_encoding() const
     // 2. If the form element has an accept-charset attribute, set encoding to the return value of running these substeps:
     if (has_attribute(AttributeNames::accept_charset)) {
         // 1. Let input be the value of the form element's accept-charset attribute.
-        auto input = attribute(AttributeNames::accept_charset);
+        auto input = deprecated_attribute(AttributeNames::accept_charset);
 
         // 2. Let candidate encoding labels be the result of splitting input on ASCII whitespace.
         auto candidate_encoding_labels = input.split_view(Infra::is_ascii_whitespace);
@@ -785,7 +785,7 @@ void HTMLFormElement::plan_to_navigate_to(Variant<AK::URL, JS::NonnullGCPtr<Fetc
     Optional<ReferrerPolicy::ReferrerPolicy> referrer_policy;
 
     // 2. If the form element's link types include the noreferrer keyword, then set referrerPolicy to "no-referrer".
-    auto rel = attribute(HTML::AttributeNames::rel).to_lowercase();
+    auto rel = deprecated_attribute(HTML::AttributeNames::rel).to_lowercase();
     auto link_types = rel.view().split_view_if(Infra::is_ascii_whitespace);
     if (link_types.contains_slow("noreferrer"sv))
         referrer_policy = ReferrerPolicy::ReferrerPolicy::NoReferrer;

--- a/Userland/Libraries/LibWeb/HTML/HTMLFormElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFormElement.cpp
@@ -465,9 +465,10 @@ ErrorOr<void> HTMLFormElement::populate_vector_with_submittable_elements_in_tree
 }
 
 // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-fs-method
-DeprecatedString HTMLFormElement::method() const
+StringView HTMLFormElement::method() const
 {
     // The method and enctype IDL attributes must reflect the respective content attributes of the same name, limited to only known values.
+    // FIXME: This should probably be `Reflect` in the IDL.
     auto method_state = method_state_from_form_element(*this);
     switch (method_state) {
     case MethodAttributeState::GET:
@@ -476,36 +477,35 @@ DeprecatedString HTMLFormElement::method() const
         return "post"sv;
     case MethodAttributeState::Dialog:
         return "dialog"sv;
-    default:
-        VERIFY_NOT_REACHED();
     }
+    VERIFY_NOT_REACHED();
 }
 
 // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-fs-method
-WebIDL::ExceptionOr<void> HTMLFormElement::set_method(DeprecatedString const& method)
+WebIDL::ExceptionOr<void> HTMLFormElement::set_method(String const& method)
 {
     // The method and enctype IDL attributes must reflect the respective content attributes of the same name, limited to only known values.
     return set_attribute(AttributeNames::method, method);
 }
 
 // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-fs-action
-DeprecatedString HTMLFormElement::action() const
+String HTMLFormElement::action() const
 {
     // The action IDL attribute must reflect the content attribute of the same name, except that on getting, when the
     // content attribute is missing or its value is the empty string, the element's node document's URL must be returned
     // instead.
     if (!has_attribute(AttributeNames::action))
-        return document().url_string();
+        return MUST(document().url().to_string());
 
-    auto action_attribute = deprecated_attribute(AttributeNames::action);
-    if (action_attribute.is_empty())
-        return document().url_string();
+    auto action_attribute = attribute(AttributeNames::action);
+    if (!action_attribute.has_value() || action_attribute->is_empty())
+        return MUST(document().url().to_string());
 
-    return action_attribute;
+    return action_attribute.value();
 }
 
 // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-fs-action
-WebIDL::ExceptionOr<void> HTMLFormElement::set_action(DeprecatedString const& value)
+WebIDL::ExceptionOr<void> HTMLFormElement::set_action(String const& value)
 {
     return set_attribute(AttributeNames::action, value);
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLFormElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFormElement.h
@@ -80,11 +80,11 @@ public:
     bool constructing_entry_list() const { return m_constructing_entry_list; }
     void set_constructing_entry_list(bool value) { m_constructing_entry_list = value; }
 
-    DeprecatedString method() const;
-    WebIDL::ExceptionOr<void> set_method(DeprecatedString const&);
+    StringView method() const;
+    WebIDL::ExceptionOr<void> set_method(String const&);
 
-    DeprecatedString action() const;
-    WebIDL::ExceptionOr<void> set_action(DeprecatedString const&);
+    String action() const;
+    WebIDL::ExceptionOr<void> set_action(String const&);
 
 private:
     HTMLFormElement(DOM::Document&, DOM::QualifiedName);

--- a/Userland/Libraries/LibWeb/HTML/HTMLFormElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFormElement.idl
@@ -2,7 +2,7 @@
 #import <HTML/HTMLElement.idl>
 
 // https://html.spec.whatwg.org/multipage/semantics.html#htmlformelement
-[Exposed=Window, UseDeprecatedAKString]
+[Exposed=Window]
 interface HTMLFormElement : HTMLElement {
 
     [HTMLConstructor] constructor();

--- a/Userland/Libraries/LibWeb/HTML/HTMLHyperlinkElementUtils.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLHyperlinkElementUtils.cpp
@@ -68,7 +68,7 @@ DeprecatedString HTMLHyperlinkElementUtils::protocol() const
 }
 
 // https://html.spec.whatwg.org/multipage/links.html#dom-hyperlink-protocol
-void HTMLHyperlinkElementUtils::set_protocol(DeprecatedString protocol)
+void HTMLHyperlinkElementUtils::set_protocol(StringView protocol)
 {
     // 1. Reinitialize url.
     reinitialize_url();
@@ -101,7 +101,7 @@ DeprecatedString HTMLHyperlinkElementUtils::username() const
 }
 
 // https://html.spec.whatwg.org/multipage/links.html#dom-hyperlink-username
-void HTMLHyperlinkElementUtils::set_username(DeprecatedString username)
+void HTMLHyperlinkElementUtils::set_username(StringView username)
 {
     // 1. Reinitialize url.
     reinitialize_url();
@@ -138,7 +138,7 @@ DeprecatedString HTMLHyperlinkElementUtils::password() const
 }
 
 // https://html.spec.whatwg.org/multipage/links.html#dom-hyperlink-password
-void HTMLHyperlinkElementUtils::set_password(DeprecatedString password)
+void HTMLHyperlinkElementUtils::set_password(StringView password)
 {
     // 1. Reinitialize url.
     reinitialize_url();
@@ -179,7 +179,7 @@ DeprecatedString HTMLHyperlinkElementUtils::host() const
 }
 
 // https://html.spec.whatwg.org/multipage/links.html#dom-hyperlink-host
-void HTMLHyperlinkElementUtils::set_host(DeprecatedString host)
+void HTMLHyperlinkElementUtils::set_host(StringView host)
 {
     // 1. Reinitialize url.
     reinitialize_url();
@@ -215,7 +215,7 @@ DeprecatedString HTMLHyperlinkElementUtils::hostname() const
     return url.serialized_host().release_value_but_fixme_should_propagate_errors().to_deprecated_string();
 }
 
-void HTMLHyperlinkElementUtils::set_hostname(DeprecatedString hostname)
+void HTMLHyperlinkElementUtils::set_hostname(StringView hostname)
 {
     // 1. Reinitialize url.
     reinitialize_url();
@@ -254,7 +254,7 @@ DeprecatedString HTMLHyperlinkElementUtils::port() const
 }
 
 // https://html.spec.whatwg.org/multipage/links.html#dom-hyperlink-port
-void HTMLHyperlinkElementUtils::set_port(DeprecatedString port)
+void HTMLHyperlinkElementUtils::set_port(StringView port)
 {
     // 1. Reinitialize url.
     reinitialize_url();
@@ -298,7 +298,7 @@ DeprecatedString HTMLHyperlinkElementUtils::pathname() const
 }
 
 // https://html.spec.whatwg.org/multipage/links.html#dom-hyperlink-pathname
-void HTMLHyperlinkElementUtils::set_pathname(DeprecatedString pathname)
+void HTMLHyperlinkElementUtils::set_pathname(StringView pathname)
 {
     // 1. Reinitialize url.
     reinitialize_url();
@@ -337,7 +337,7 @@ DeprecatedString HTMLHyperlinkElementUtils::search() const
     return DeprecatedString::formatted("?{}", m_url->query());
 }
 
-void HTMLHyperlinkElementUtils::set_search(DeprecatedString search)
+void HTMLHyperlinkElementUtils::set_search(StringView search)
 {
     // 1. Reinitialize url.
     reinitialize_url();
@@ -385,7 +385,7 @@ DeprecatedString HTMLHyperlinkElementUtils::hash() const
     return DeprecatedString::formatted("#{}", *m_url->fragment());
 }
 
-void HTMLHyperlinkElementUtils::set_hash(DeprecatedString hash)
+void HTMLHyperlinkElementUtils::set_hash(StringView hash)
 {
     // 1. Reinitialize url.
     reinitialize_url();
@@ -441,10 +441,10 @@ DeprecatedString HTMLHyperlinkElementUtils::href() const
 }
 
 // https://html.spec.whatwg.org/multipage/links.html#dom-hyperlink-href
-WebIDL::ExceptionOr<void> HTMLHyperlinkElementUtils::set_href(DeprecatedString href)
+WebIDL::ExceptionOr<void> HTMLHyperlinkElementUtils::set_href(StringView href)
 {
     // The href attribute's setter must set this element's href content attribute's value to the given value.
-    return set_hyperlink_element_utils_href(move(href));
+    return set_hyperlink_element_utils_href(href);
 }
 
 // https://html.spec.whatwg.org/multipage/links.html#update-href

--- a/Userland/Libraries/LibWeb/HTML/HTMLHyperlinkElementUtils.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLHyperlinkElementUtils.h
@@ -20,34 +20,34 @@ public:
     DeprecatedString origin() const;
 
     DeprecatedString href() const;
-    WebIDL::ExceptionOr<void> set_href(DeprecatedString);
+    WebIDL::ExceptionOr<void> set_href(StringView);
 
     DeprecatedString protocol() const;
-    void set_protocol(DeprecatedString);
+    void set_protocol(StringView);
 
     DeprecatedString username() const;
-    void set_username(DeprecatedString);
+    void set_username(StringView);
 
     DeprecatedString password() const;
-    void set_password(DeprecatedString);
+    void set_password(StringView);
 
     DeprecatedString host() const;
-    void set_host(DeprecatedString);
+    void set_host(StringView);
 
     DeprecatedString hostname() const;
-    void set_hostname(DeprecatedString);
+    void set_hostname(StringView);
 
     DeprecatedString port() const;
-    void set_port(DeprecatedString);
+    void set_port(StringView);
 
     DeprecatedString pathname() const;
-    void set_pathname(DeprecatedString);
+    void set_pathname(StringView);
 
     DeprecatedString search() const;
-    void set_search(DeprecatedString);
+    void set_search(StringView);
 
     DeprecatedString hash() const;
-    void set_hash(DeprecatedString);
+    void set_hash(StringView);
 
 protected:
     virtual DOM::Document& hyperlink_element_utils_document() = 0;

--- a/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -249,7 +249,7 @@ bool HTMLImageElement::complete() const
         return true;
 
     // - The srcset attribute is omitted and the src attribute's value is the empty string.
-    if (!has_attribute(HTML::AttributeNames::srcset) && attribute(HTML::AttributeNames::src) == ""sv)
+    if (!has_attribute(HTML::AttributeNames::srcset) && deprecated_attribute(HTML::AttributeNames::src) == ""sv)
         return true;
 
     // - The img element's current request's state is completely available and its pending request is null.
@@ -342,8 +342,8 @@ ErrorOr<void> HTMLImageElement::update_the_image_data(bool restart_animations, b
     //    and it has a src attribute specified whose value is not the empty string,
     //    then set selected source to the value of the element's src attribute
     //    and set selected pixel density to 1.0.
-    if (!uses_srcset_or_picture() && has_attribute(HTML::AttributeNames::src) && !attribute(HTML::AttributeNames::src).is_empty()) {
-        selected_source = TRY(String::from_deprecated_string(attribute(HTML::AttributeNames::src)));
+    if (!uses_srcset_or_picture() && has_attribute(HTML::AttributeNames::src) && !deprecated_attribute(HTML::AttributeNames::src).is_empty()) {
+        selected_source = TRY(String::from_deprecated_string(deprecated_attribute(HTML::AttributeNames::src)));
         selected_pixel_density = 1.0f;
     }
 
@@ -542,7 +542,7 @@ after_step_7:
             request->set_initiator(Fetch::Infrastructure::Request::Initiator::ImageSet);
 
         // 21. Set request's referrer policy to the current state of the element's referrerpolicy attribute.
-        request->set_referrer_policy(ReferrerPolicy::from_string(attribute(HTML::AttributeNames::referrerpolicy)));
+        request->set_referrer_policy(ReferrerPolicy::from_string(deprecated_attribute(HTML::AttributeNames::referrerpolicy)));
 
         // FIXME: 22. Set request's priority to the current state of the element's fetchpriority attribute.
 
@@ -757,7 +757,7 @@ void HTMLImageElement::react_to_changes_in_the_environment()
         request->set_initiator(Fetch::Infrastructure::Request::Initiator::ImageSet);
 
         // 3. Set request's referrer policy to the current state of the element's referrerpolicy attribute.
-        request->set_referrer_policy(ReferrerPolicy::from_string(attribute(HTML::AttributeNames::referrerpolicy)));
+        request->set_referrer_policy(ReferrerPolicy::from_string(deprecated_attribute(HTML::AttributeNames::referrerpolicy)));
 
         // FIXME: 4. Set request's priority to the current state of the element's fetchpriority attribute.
 
@@ -864,37 +864,37 @@ static void update_the_source_set(DOM::Element& element)
 
             // 4. If el is an img element that has a srcset attribute, then set srcset to that attribute's value.
             if (is<HTMLImageElement>(element)) {
-                if (auto srcset_value = element.attribute(HTML::AttributeNames::srcset); !srcset_value.is_null())
+                if (auto srcset_value = element.deprecated_attribute(HTML::AttributeNames::srcset); !srcset_value.is_null())
                     srcset = String::from_deprecated_string(srcset_value).release_value_but_fixme_should_propagate_errors();
             }
 
             // 5. Otherwise, if el is a link element that has an imagesrcset attribute, then set srcset to that attribute's value.
             else if (is<HTMLLinkElement>(element)) {
-                if (auto imagesrcset_value = element.attribute(HTML::AttributeNames::imagesrcset); !imagesrcset_value.is_null())
+                if (auto imagesrcset_value = element.deprecated_attribute(HTML::AttributeNames::imagesrcset); !imagesrcset_value.is_null())
                     srcset = String::from_deprecated_string(imagesrcset_value).release_value_but_fixme_should_propagate_errors();
             }
 
             // 6. If el is an img element that has a sizes attribute, then set sizes to that attribute's value.
             if (is<HTMLImageElement>(element)) {
-                if (auto sizes_value = element.attribute(HTML::AttributeNames::sizes); !sizes_value.is_null())
+                if (auto sizes_value = element.deprecated_attribute(HTML::AttributeNames::sizes); !sizes_value.is_null())
                     sizes = String::from_deprecated_string(sizes_value).release_value_but_fixme_should_propagate_errors();
             }
 
             // 7. Otherwise, if el is a link element that has an imagesizes attribute, then set sizes to that attribute's value.
             else if (is<HTMLLinkElement>(element)) {
-                if (auto imagesizes_value = element.attribute(HTML::AttributeNames::imagesizes); !imagesizes_value.is_null())
+                if (auto imagesizes_value = element.deprecated_attribute(HTML::AttributeNames::imagesizes); !imagesizes_value.is_null())
                     sizes = String::from_deprecated_string(imagesizes_value).release_value_but_fixme_should_propagate_errors();
             }
 
             // 8. If el is an img element that has a src attribute, then set default source to that attribute's value.
             if (is<HTMLImageElement>(element)) {
-                if (auto src_value = element.attribute(HTML::AttributeNames::src); !src_value.is_null())
+                if (auto src_value = element.deprecated_attribute(HTML::AttributeNames::src); !src_value.is_null())
                     default_source = String::from_deprecated_string(src_value).release_value_but_fixme_should_propagate_errors();
             }
 
             // 9. Otherwise, if el is a link element that has an href attribute, then set default source to that attribute's value.
             else if (is<HTMLLinkElement>(element)) {
-                if (auto href_value = element.attribute(HTML::AttributeNames::href); !href_value.is_null())
+                if (auto href_value = element.deprecated_attribute(HTML::AttributeNames::href); !href_value.is_null())
                     default_source = String::from_deprecated_string(href_value).release_value_but_fixme_should_propagate_errors();
             }
 
@@ -914,7 +914,7 @@ static void update_the_source_set(DOM::Element& element)
             continue;
 
         // 4. Parse child's srcset attribute and let the returned source set be source set.
-        auto source_set = parse_a_srcset_attribute(child->attribute(HTML::AttributeNames::srcset));
+        auto source_set = parse_a_srcset_attribute(child->deprecated_attribute(HTML::AttributeNames::srcset));
 
         // 5. If source set has zero image sources, continue to the next child.
         if (source_set.is_empty())
@@ -923,14 +923,14 @@ static void update_the_source_set(DOM::Element& element)
         // 6. If child has a media attribute, and its value does not match the environment, continue to the next child.
         if (child->has_attribute(HTML::AttributeNames::media)) {
             auto media_query = parse_media_query(CSS::Parser::ParsingContext { element.document() },
-                child->attribute(HTML::AttributeNames::media));
+                child->deprecated_attribute(HTML::AttributeNames::media));
             if (!media_query || !media_query->evaluate(element.document().window())) {
                 continue;
             }
         }
 
         // 7. Parse child's sizes attribute, and let source set's source size be the returned value.
-        source_set.m_source_size = parse_a_sizes_attribute(element.document(), child->attribute(HTML::AttributeNames::sizes));
+        source_set.m_source_size = parse_a_sizes_attribute(element.document(), child->deprecated_attribute(HTML::AttributeNames::sizes));
 
         // FIXME: 8. If child has a type attribute, and its value is an unknown or unsupported MIME type, continue to the next child.
         if (child->has_attribute(HTML::AttributeNames::type)) {
@@ -1000,7 +1000,7 @@ void HTMLImageElement::animate()
 // https://html.spec.whatwg.org/multipage/urls-and-fetching.html#lazy-loading-attributes
 HTMLImageElement::LazyLoading HTMLImageElement::lazy_loading() const
 {
-    auto value = attribute(HTML::AttributeNames::loading);
+    auto value = deprecated_attribute(HTML::AttributeNames::loading);
     if (value.equals_ignoring_ascii_case("lazy"sv))
         return LazyLoading::Lazy;
     return LazyLoading::Eager;

--- a/Userland/Libraries/LibWeb/HTML/HTMLImageElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLImageElement.h
@@ -33,8 +33,8 @@ public:
 
     virtual void attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value) override;
 
-    DeprecatedString alt() const { return attribute(HTML::AttributeNames::alt); }
-    DeprecatedString src() const { return attribute(HTML::AttributeNames::src); }
+    DeprecatedString alt() const { return deprecated_attribute(HTML::AttributeNames::alt); }
+    DeprecatedString src() const { return deprecated_attribute(HTML::AttributeNames::src); }
 
     RefPtr<Gfx::Bitmap const> bitmap() const;
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -442,7 +442,7 @@ Optional<DeprecatedString> HTMLInputElement::placeholder_value() const
     if (!has_attribute(HTML::AttributeNames::placeholder))
         return {};
 
-    auto placeholder = attribute(HTML::AttributeNames::placeholder);
+    auto placeholder = deprecated_attribute(HTML::AttributeNames::placeholder);
 
     if (placeholder.contains('\r') || placeholder.contains('\n')) {
         StringBuilder builder;
@@ -503,7 +503,7 @@ void HTMLInputElement::create_shadow_tree_if_needed()
     MUST(m_placeholder_element->style_for_bindings()->set_property(CSS::PropertyID::Height, "1lh"sv));
 
     m_placeholder_text_node = heap().allocate<DOM::Text>(realm(), document(), initial_value);
-    m_placeholder_text_node->set_data(attribute(HTML::AttributeNames::placeholder));
+    m_placeholder_text_node->set_data(deprecated_attribute(HTML::AttributeNames::placeholder));
     m_placeholder_text_node->set_owner_input_element({}, *this);
     MUST(m_placeholder_element->append_child(*m_placeholder_text_node));
     MUST(element->append_child(*m_placeholder_element));
@@ -516,7 +516,7 @@ void HTMLInputElement::create_shadow_tree_if_needed()
         // NOTE: file upload state is mutable, but we don't allow the text node to be modifed
         m_text_node->set_always_editable(false);
     } else {
-        handle_readonly_attribute(attribute(HTML::AttributeNames::readonly));
+        handle_readonly_attribute(deprecated_attribute(HTML::AttributeNames::readonly));
     }
 
     m_text_node->set_owner_input_element({}, *this);
@@ -1087,7 +1087,7 @@ Optional<ARIA::Role> HTMLInputElement::default_role() const
     if (type_state() == TypeAttributeState::Checkbox)
         return ARIA::Role::checkbox;
     // https://www.w3.org/TR/html-aria/#el-input-email
-    if (type_state() == TypeAttributeState::Email && attribute("list").is_null())
+    if (type_state() == TypeAttributeState::Email && deprecated_attribute("list").is_null())
         return ARIA::Role::textbox;
     // https://www.w3.org/TR/html-aria/#el-input-image
     if (type_state() == TypeAttributeState::ImageButton)
@@ -1110,10 +1110,10 @@ Optional<ARIA::Role> HTMLInputElement::default_role() const
             || type_state() == TypeAttributeState::Telephone
             || type_state() == TypeAttributeState::URL
             || type_state() == TypeAttributeState::Email)
-        && !attribute("list").is_null())
+        && !deprecated_attribute("list").is_null())
         return ARIA::Role::combobox;
     // https://www.w3.org/TR/html-aria/#el-input-search
-    if (type_state() == TypeAttributeState::Search && attribute("list").is_null())
+    if (type_state() == TypeAttributeState::Search && deprecated_attribute("list").is_null())
         return ARIA::Role::textbox;
     // https://www.w3.org/TR/html-aria/#el-input-submit
     if (type_state() == TypeAttributeState::SubmitButton)
@@ -1122,10 +1122,10 @@ Optional<ARIA::Role> HTMLInputElement::default_role() const
     if (type_state() == TypeAttributeState::Telephone)
         return ARIA::Role::textbox;
     // https://www.w3.org/TR/html-aria/#el-input-text
-    if (type_state() == TypeAttributeState::Text && attribute("list").is_null())
+    if (type_state() == TypeAttributeState::Text && deprecated_attribute("list").is_null())
         return ARIA::Role::textbox;
     // https://www.w3.org/TR/html-aria/#el-input-url
-    if (type_state() == TypeAttributeState::URL && attribute("list").is_null())
+    if (type_state() == TypeAttributeState::URL && deprecated_attribute("list").is_null())
         return ARIA::Role::textbox;
 
     // https://www.w3.org/TR/html-aria/#el-input-color

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -336,12 +336,12 @@ DeprecatedString HTMLInputElement::value() const
     return m_value;
 }
 
-WebIDL::ExceptionOr<void> HTMLInputElement::set_value(DeprecatedString value)
+WebIDL::ExceptionOr<void> HTMLInputElement::set_value(String const& value)
 {
     // https://html.spec.whatwg.org/multipage/input.html#dom-input-value-filename
     if (type_state() == TypeAttributeState::FileUpload) {
         // On setting, if the new value is the empty string, empty the list of selected files; otherwise, throw an "InvalidStateError" DOMException.
-        if (value != DeprecatedString::empty())
+        if (!value.is_empty())
             return WebIDL::InvalidStateError::create(realm(), "Setting value of input type file to non-empty string"sv);
         m_selected_files = nullptr;
         return {};
@@ -358,7 +358,7 @@ WebIDL::ExceptionOr<void> HTMLInputElement::set_value(DeprecatedString value)
     m_dirty_value = true;
 
     // 4. Invoke the value sanitization algorithm, if the element's type attribute's current state defines one.
-    m_value = value_sanitization_algorithm(move(value));
+    m_value = value_sanitization_algorithm(value.to_deprecated_string());
 
     // 5. If the element's value (after applying the value sanitization algorithm) is different from oldValue,
     //    and the element has a text entry cursor position, move the text entry cursor position to the end of the
@@ -602,8 +602,9 @@ HTMLInputElement::TypeAttributeState HTMLInputElement::parse_type_attribute(Stri
     return HTMLInputElement::TypeAttributeState::Text;
 }
 
-DeprecatedString HTMLInputElement::type() const
+StringView HTMLInputElement::type() const
 {
+    // FIXME: This should probably be `Reflect` in the IDL.
     switch (m_type) {
 #define __ENUMERATE_HTML_INPUT_TYPE_ATTRIBUTE(keyword, state) \
     case TypeAttributeState::state:                           \
@@ -615,7 +616,7 @@ DeprecatedString HTMLInputElement::type() const
     VERIFY_NOT_REACHED();
 }
 
-WebIDL::ExceptionOr<void> HTMLInputElement::set_type(DeprecatedString const& type)
+WebIDL::ExceptionOr<void> HTMLInputElement::set_type(String const& type)
 {
     return set_attribute(HTML::AttributeNames::type, type);
 }
@@ -1058,7 +1059,7 @@ WebIDL::ExceptionOr<bool> HTMLInputElement::report_validity()
 }
 
 // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-setcustomvalidity
-void HTMLInputElement::set_custom_validity(DeprecatedString const& error)
+void HTMLInputElement::set_custom_validity(String const& error)
 {
     dbgln("(STUBBED) HTMLInputElement::set_custom_validity(error={}). Called on: {}", error, debug_description());
     return;
@@ -1072,7 +1073,7 @@ WebIDL::ExceptionOr<void> HTMLInputElement::select()
 }
 
 // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-textarea/input-setselectionrange
-WebIDL::ExceptionOr<void> HTMLInputElement::set_selection_range(u32 start, u32 end, DeprecatedString const& direction)
+WebIDL::ExceptionOr<void> HTMLInputElement::set_selection_range(u32 start, u32 end, Optional<String> const& direction)
 {
     dbgln("(STUBBED) HTMLInputElement::set_selection_range(start={}, end={}, direction='{}'). Called on: {}", start, end, direction, debug_description());
     return {};

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -56,15 +56,15 @@ public:
 #undef __ENUMERATE_HTML_INPUT_TYPE_ATTRIBUTE
     };
 
-    DeprecatedString type() const;
+    StringView type() const;
     TypeAttributeState type_state() const { return m_type; }
-    WebIDL::ExceptionOr<void> set_type(DeprecatedString const&);
+    WebIDL::ExceptionOr<void> set_type(String const&);
 
     DeprecatedString default_value() const { return deprecated_attribute(HTML::AttributeNames::value); }
     DeprecatedString name() const { return deprecated_attribute(HTML::AttributeNames::name); }
 
     virtual DeprecatedString value() const override;
-    WebIDL::ExceptionOr<void> set_value(DeprecatedString);
+    WebIDL::ExceptionOr<void> set_value(String const&);
 
     Optional<DeprecatedString> placeholder_value() const;
 
@@ -94,10 +94,10 @@ public:
 
     WebIDL::ExceptionOr<bool> check_validity();
     WebIDL::ExceptionOr<bool> report_validity();
-    void set_custom_validity(DeprecatedString const&);
+    void set_custom_validity(String const&);
 
     WebIDL::ExceptionOr<void> select();
-    WebIDL::ExceptionOr<void> set_selection_range(u32 start, u32 end, DeprecatedString const& direction);
+    WebIDL::ExceptionOr<void> set_selection_range(u32 start, u32 end, Optional<String> const& direction = {});
 
     WebIDL::ExceptionOr<void> show_picker();
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -60,8 +60,8 @@ public:
     TypeAttributeState type_state() const { return m_type; }
     WebIDL::ExceptionOr<void> set_type(DeprecatedString const&);
 
-    DeprecatedString default_value() const { return attribute(HTML::AttributeNames::value); }
-    DeprecatedString name() const { return attribute(HTML::AttributeNames::name); }
+    DeprecatedString default_value() const { return deprecated_attribute(HTML::AttributeNames::value); }
+    DeprecatedString name() const { return deprecated_attribute(HTML::AttributeNames::name); }
 
     virtual DeprecatedString value() const override;
     WebIDL::ExceptionOr<void> set_value(DeprecatedString);

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.idl
@@ -3,7 +3,7 @@
 #import <FileAPI/FileList.idl>
 
 // https://html.spec.whatwg.org/multipage/input.html#htmlinputelement
-[Exposed=Window, UseDeprecatedAKString]
+[Exposed=Window]
 interface HTMLInputElement : HTMLElement {
 
     [HTMLConstructor] constructor();

--- a/Userland/Libraries/LibWeb/HTML/HTMLLabelElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLLabelElement.h
@@ -18,7 +18,7 @@ public:
 
     virtual JS::GCPtr<Layout::Node> create_layout_node(NonnullRefPtr<CSS::StyleProperties>) override;
 
-    DeprecatedString for_() const { return attribute(HTML::AttributeNames::for_); }
+    DeprecatedString for_() const { return deprecated_attribute(HTML::AttributeNames::for_); }
 
 private:
     HTMLLabelElement(DOM::Document&, DOM::QualifiedName);

--- a/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
@@ -58,12 +58,12 @@ void HTMLLinkElement::inserted()
     if (m_relationship & Relationship::Preload) {
         // FIXME: Respect the "as" attribute.
         LoadRequest request;
-        request.set_url(document().parse_url(attribute(HTML::AttributeNames::href)));
+        request.set_url(document().parse_url(deprecated_attribute(HTML::AttributeNames::href)));
         set_resource(ResourceLoader::the().load_resource(Resource::Type::Generic, request));
     } else if (m_relationship & Relationship::DNSPrefetch) {
-        ResourceLoader::the().prefetch_dns(document().parse_url(attribute(HTML::AttributeNames::href)));
+        ResourceLoader::the().prefetch_dns(document().parse_url(deprecated_attribute(HTML::AttributeNames::href)));
     } else if (m_relationship & Relationship::Preconnect) {
-        ResourceLoader::the().preconnect(document().parse_url(attribute(HTML::AttributeNames::href)));
+        ResourceLoader::the().preconnect(document().parse_url(deprecated_attribute(HTML::AttributeNames::href)));
     } else if (m_relationship & Relationship::Icon) {
         auto favicon_url = document().parse_url(href());
         auto favicon_request = LoadRequest::create_for_url_on_page(favicon_url, document().page());
@@ -343,7 +343,7 @@ void HTMLLinkElement::process_stylesheet_resource(bool success, Fetch::Infrastru
         //     2. Otherwise, return the document's character encoding. [DOM]
 
         DeprecatedString encoding;
-        if (auto charset = attribute(HTML::AttributeNames::charset); !charset.is_null())
+        if (auto charset = deprecated_attribute(HTML::AttributeNames::charset); !charset.is_null())
             encoding = charset;
         else
             encoding = document().encoding_or_default();
@@ -366,7 +366,7 @@ void HTMLLinkElement::process_stylesheet_resource(bool success, Fetch::Infrastru
 
                 if (m_loaded_style_sheet) {
                     m_loaded_style_sheet->set_owner_node(this);
-                    m_loaded_style_sheet->set_media(attribute(HTML::AttributeNames::media));
+                    m_loaded_style_sheet->set_media(deprecated_attribute(HTML::AttributeNames::media));
                     document().style_sheets().add_sheet(*m_loaded_style_sheet);
                 } else {
                     dbgln_if(CSS_LOADER_DEBUG, "HTMLLinkElement: Failed to parse stylesheet: {}", resource()->url());

--- a/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.h
@@ -28,9 +28,9 @@ public:
 
     virtual void inserted() override;
 
-    DeprecatedString rel() const { return attribute(HTML::AttributeNames::rel); }
-    DeprecatedString type() const { return attribute(HTML::AttributeNames::type); }
-    DeprecatedString href() const { return attribute(HTML::AttributeNames::href); }
+    DeprecatedString rel() const { return deprecated_attribute(HTML::AttributeNames::rel); }
+    DeprecatedString type() const { return deprecated_attribute(HTML::AttributeNames::type); }
+    DeprecatedString href() const { return deprecated_attribute(HTML::AttributeNames::href); }
 
     bool has_loaded_icon() const;
     bool load_favicon_and_use_if_window_is_active();

--- a/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -580,7 +580,7 @@ public:
         //    empty string, then end the synchronous section, and jump down to the failed with elements step below.
         String candiate_src;
         if (m_candidate->has_attribute(HTML::AttributeNames::src))
-            candiate_src = TRY_OR_THROW_OOM(vm, String::from_deprecated_string(m_candidate->attribute(HTML::AttributeNames::src)));
+            candiate_src = TRY_OR_THROW_OOM(vm, String::from_deprecated_string(m_candidate->deprecated_attribute(HTML::AttributeNames::src)));
 
         if (candiate_src.is_empty()) {
             TRY(failed_with_elements());
@@ -825,7 +825,7 @@ WebIDL::ExceptionOr<void> HTMLMediaElement::select_resource()
         };
 
         // 1. ⌛ If the src attribute's value is the empty string, then end the synchronous section, and jump down to the failed with attribute step below.
-        auto source = attribute(HTML::AttributeNames::src);
+        auto source = deprecated_attribute(HTML::AttributeNames::src);
         if (source.is_empty()) {
             failed_with_attribute("The 'src' attribute is empty"_string);
             return {};

--- a/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -166,7 +166,7 @@ JS::NonnullGCPtr<TimeRanges> HTMLMediaElement::buffered() const
 }
 
 // https://html.spec.whatwg.org/multipage/media.html#dom-navigator-canplaytype
-WebIDL::ExceptionOr<Bindings::CanPlayTypeResult> HTMLMediaElement::can_play_type(DeprecatedString const& type) const
+WebIDL::ExceptionOr<Bindings::CanPlayTypeResult> HTMLMediaElement::can_play_type(StringView type) const
 {
     auto& vm = this->vm();
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.h
@@ -58,7 +58,7 @@ public:
 
     [[nodiscard]] JS::NonnullGCPtr<TimeRanges> buffered() const;
 
-    WebIDL::ExceptionOr<Bindings::CanPlayTypeResult> can_play_type(DeprecatedString const& type) const;
+    WebIDL::ExceptionOr<Bindings::CanPlayTypeResult> can_play_type(StringView type) const;
 
     enum class ReadyState : u16 {
         HaveNothing,

--- a/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.idl
@@ -11,7 +11,7 @@ enum CanPlayTypeResult {
 };
 
 // https://html.spec.whatwg.org/multipage/media.html#htmlmediaelement
-[Exposed=Window, UseDeprecatedAKString]
+[Exposed=Window]
 interface HTMLMediaElement : HTMLElement {
 
     // error state

--- a/Userland/Libraries/LibWeb/HTML/HTMLMetaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMetaElement.cpp
@@ -26,7 +26,7 @@ void HTMLMetaElement::initialize(JS::Realm& realm)
 
 Optional<HTMLMetaElement::HttpEquivAttributeState> HTMLMetaElement::http_equiv_state() const
 {
-    auto value = attribute(HTML::AttributeNames::http_equiv);
+    auto value = deprecated_attribute(HTML::AttributeNames::http_equiv);
 
 #define __ENUMERATE_HTML_META_HTTP_EQUIV_ATTRIBUTE(keyword, state) \
     if (value.equals_ignoring_ascii_case(#keyword##sv))            \
@@ -55,7 +55,7 @@ void HTMLMetaElement::inserted()
             if (!has_attribute(AttributeNames::content))
                 break;
 
-            auto input = attribute(AttributeNames::content);
+            auto input = deprecated_attribute(AttributeNames::content);
             if (input.is_empty())
                 break;
 
@@ -64,7 +64,7 @@ void HTMLMetaElement::inserted()
             break;
         }
         default:
-            dbgln("FIXME: Implement '{}' http-equiv state", attribute(AttributeNames::http_equiv));
+            dbgln("FIXME: Implement '{}' http-equiv state", deprecated_attribute(AttributeNames::http_equiv));
             break;
         }
     }

--- a/Userland/Libraries/LibWeb/HTML/HTMLObjectElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLObjectElement.cpp
@@ -69,7 +69,7 @@ void HTMLObjectElement::attribute_changed(DeprecatedFlyString const& name, Depre
 // https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-object-data
 DeprecatedString HTMLObjectElement::data() const
 {
-    auto data = attribute(HTML::AttributeNames::data);
+    auto data = deprecated_attribute(HTML::AttributeNames::data);
     return document().parse_url(data).to_deprecated_string();
 }
 
@@ -123,7 +123,7 @@ void HTMLObjectElement::queue_element_task_to_run_object_representation_steps()
         // FIXME: 3. If the classid attribute is present, and has a value that isn't the empty string, then: if the user agent can find a plugin suitable according to the value of the classid attribute, and plugins aren't being sandboxed, then that plugin should be used, and the value of the data attribute, if any, should be passed to the plugin. If no suitable plugin can be found, or if the plugin reports an error, jump to the step below labeled fallback.
 
         // 4. If the data attribute is present and its value is not the empty string, then:
-        if (auto data = attribute(HTML::AttributeNames::data); !data.is_empty()) {
+        if (auto data = deprecated_attribute(HTML::AttributeNames::data); !data.is_empty()) {
             // 1. If the type attribute is present and its value is not a type that the user agent supports, and is not a type that the user agent can find a plugin for, then the user agent may jump to the step below labeled fallback without fetching the content to examine its real type.
 
             // 2. Parse a URL given the data attribute, relative to the element's node document.
@@ -320,7 +320,7 @@ void HTMLObjectElement::run_object_representation_fallback_steps()
 void HTMLObjectElement::load_image()
 {
     // NOTE: This currently reloads the image instead of reusing the resource we've already downloaded.
-    auto data = attribute(HTML::AttributeNames::data);
+    auto data = deprecated_attribute(HTML::AttributeNames::data);
     auto url = document().parse_url(data);
     m_image_request = HTML::SharedImageRequest::get_or_create(realm(), *document().page(), url);
     m_image_request->add_callbacks(

--- a/Userland/Libraries/LibWeb/HTML/HTMLObjectElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLObjectElement.cpp
@@ -67,10 +67,10 @@ void HTMLObjectElement::attribute_changed(DeprecatedFlyString const& name, Depre
 }
 
 // https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-object-data
-DeprecatedString HTMLObjectElement::data() const
+String HTMLObjectElement::data() const
 {
     auto data = deprecated_attribute(HTML::AttributeNames::data);
-    return document().parse_url(data).to_deprecated_string();
+    return MUST(document().parse_url(data).to_string());
 }
 
 JS::GCPtr<Layout::Node> HTMLObjectElement::create_layout_node(NonnullRefPtr<CSS::StyleProperties> style)

--- a/Userland/Libraries/LibWeb/HTML/HTMLObjectElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLObjectElement.h
@@ -36,8 +36,8 @@ public:
 
     virtual void attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value) override;
 
-    DeprecatedString data() const;
-    void set_data(DeprecatedString const& data) { MUST(set_attribute(HTML::AttributeNames::data, data)); }
+    String data() const;
+    void set_data(String const& data) { MUST(set_attribute(HTML::AttributeNames::data, data)); }
 
     DeprecatedString type() const { return deprecated_attribute(HTML::AttributeNames::type); }
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLObjectElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLObjectElement.h
@@ -39,7 +39,7 @@ public:
     DeprecatedString data() const;
     void set_data(DeprecatedString const& data) { MUST(set_attribute(HTML::AttributeNames::data, data)); }
 
-    DeprecatedString type() const { return attribute(HTML::AttributeNames::type); }
+    DeprecatedString type() const { return deprecated_attribute(HTML::AttributeNames::type); }
 
     // ^FormAssociatedElement
     // https://html.spec.whatwg.org/multipage/forms.html#category-listed

--- a/Userland/Libraries/LibWeb/HTML/HTMLObjectElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLObjectElement.idl
@@ -2,7 +2,7 @@
 #import <HTML/HTMLElement.idl>
 
 // https://html.spec.whatwg.org/multipage/iframe-embed-object.html#htmlobjectelement
-[Exposed=Window, UseDeprecatedAKString]
+[Exposed=Window]
 interface HTMLObjectElement : HTMLElement {
 
     [HTMLConstructor] constructor();

--- a/Userland/Libraries/LibWeb/HTML/HTMLOptionElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLOptionElement.cpp
@@ -60,18 +60,15 @@ void HTMLOptionElement::set_selected(bool selected)
 }
 
 // https://html.spec.whatwg.org/multipage/form-elements.html#dom-option-value
-DeprecatedString HTMLOptionElement::value() const
+String HTMLOptionElement::value() const
 {
     // The value of an option element is the value of the value content attribute, if there is one.
-    if (auto value_attr = get_attribute(HTML::AttributeNames::value); !value_attr.is_null())
-        return value_attr;
-
     // ...or, if there is not, the value of the element's text IDL attribute.
-    return text();
+    return attribute(HTML::AttributeNames::value).value_or(text());
 }
 
 // https://html.spec.whatwg.org/multipage/form-elements.html#dom-option-value
-WebIDL::ExceptionOr<void> HTMLOptionElement::set_value(DeprecatedString value)
+WebIDL::ExceptionOr<void> HTMLOptionElement::set_value(String const& value)
 {
     return set_attribute(HTML::AttributeNames::value, value);
 }
@@ -89,7 +86,7 @@ static void concatenate_descendants_text_content(DOM::Node const* node, StringBu
 }
 
 // https://html.spec.whatwg.org/multipage/form-elements.html#dom-option-text
-DeprecatedString HTMLOptionElement::text() const
+String HTMLOptionElement::text() const
 {
     StringBuilder builder;
 
@@ -101,13 +98,13 @@ DeprecatedString HTMLOptionElement::text() const
     });
 
     // Return the result of stripping and collapsing ASCII whitespace from the above concatenation.
-    return Infra::strip_and_collapse_whitespace(builder.string_view()).release_value_but_fixme_should_propagate_errors().to_deprecated_string();
+    return MUST(Infra::strip_and_collapse_whitespace(builder.string_view()));
 }
 
 // https://html.spec.whatwg.org/multipage/form-elements.html#dom-option-text
-void HTMLOptionElement::set_text(DeprecatedString text)
+void HTMLOptionElement::set_text(String const& text)
 {
-    string_replace_all(text);
+    string_replace_all(text.to_deprecated_string());
 }
 
 // https://html.spec.whatwg.org/multipage/form-elements.html#concept-option-index

--- a/Userland/Libraries/LibWeb/HTML/HTMLOptionElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLOptionElement.h
@@ -20,11 +20,11 @@ public:
     bool selected() const { return m_selected; }
     void set_selected(bool);
 
-    DeprecatedString value() const;
-    WebIDL::ExceptionOr<void> set_value(DeprecatedString);
+    String value() const;
+    WebIDL::ExceptionOr<void> set_value(String const&);
 
-    DeprecatedString text() const;
-    void set_text(DeprecatedString);
+    String text() const;
+    void set_text(String const&);
 
     int index() const;
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLOptionElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLOptionElement.idl
@@ -1,7 +1,7 @@
 #import <HTML/HTMLElement.idl>
 
 // https://html.spec.whatwg.org/multipage/form-elements.html#htmloptionelement
-[Exposed=Window,  LegacyFactoryFunction=Option(optional DOMString text = "", optional DOMString value, optional boolean defaultSelected = false, optional boolean selected = false), UseDeprecatedAKString]
+[Exposed=Window,  LegacyFactoryFunction=Option(optional DOMString text = "", optional DOMString value, optional boolean defaultSelected = false, optional boolean selected = false)]
 interface HTMLOptionElement : HTMLElement {
 
     [HTMLConstructor] constructor();

--- a/Userland/Libraries/LibWeb/HTML/HTMLProgressElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLProgressElement.cpp
@@ -51,7 +51,7 @@ void HTMLProgressElement::progress_position_updated()
 
 double HTMLProgressElement::value() const
 {
-    auto const& value_characters = attribute(HTML::AttributeNames::value);
+    auto const& value_characters = deprecated_attribute(HTML::AttributeNames::value);
     if (value_characters == nullptr)
         return 0;
 
@@ -78,7 +78,7 @@ WebIDL::ExceptionOr<void> HTMLProgressElement::set_value(double value)
 
 double HTMLProgressElement::max() const
 {
-    auto const& max_characters = attribute(HTML::AttributeNames::max);
+    auto const& max_characters = deprecated_attribute(HTML::AttributeNames::max);
     if (max_characters == nullptr)
         return 1;
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
@@ -109,7 +109,7 @@ void HTMLScriptElement::execute_script()
             document->set_current_script({}, nullptr);
 
         if (m_from_an_external_file)
-            dbgln_if(HTML_SCRIPT_DEBUG, "HTMLScriptElement: Running script {}", attribute(HTML::AttributeNames::src));
+            dbgln_if(HTML_SCRIPT_DEBUG, "HTMLScriptElement: Running script {}", deprecated_attribute(HTML::AttributeNames::src));
         else
             dbgln_if(HTML_SCRIPT_DEBUG, "HTMLScriptElement: Running inline script");
 
@@ -181,8 +181,8 @@ void HTMLScriptElement::prepare_script()
     DeprecatedString script_block_type;
     bool has_type_attribute = has_attribute(HTML::AttributeNames::type);
     bool has_language_attribute = has_attribute(HTML::AttributeNames::language);
-    if ((has_type_attribute && attribute(HTML::AttributeNames::type).is_empty())
-        || (!has_type_attribute && has_language_attribute && attribute(HTML::AttributeNames::language).is_empty())
+    if ((has_type_attribute && deprecated_attribute(HTML::AttributeNames::type).is_empty())
+        || (!has_type_attribute && has_language_attribute && deprecated_attribute(HTML::AttributeNames::language).is_empty())
         || (!has_type_attribute && !has_language_attribute)) {
         // then let the script block's type string for this script element be "text/javascript".
         script_block_type = "text/javascript";
@@ -190,12 +190,12 @@ void HTMLScriptElement::prepare_script()
     // Otherwise, if el has a type attribute,
     else if (has_type_attribute) {
         // then let the script block's type string be the value of that attribute with leading and trailing ASCII whitespace stripped.
-        script_block_type = attribute(HTML::AttributeNames::type).trim(Infra::ASCII_WHITESPACE);
+        script_block_type = deprecated_attribute(HTML::AttributeNames::type).trim(Infra::ASCII_WHITESPACE);
     }
     // Otherwise, el has a non-empty language attribute;
-    else if (!attribute(HTML::AttributeNames::language).is_empty()) {
+    else if (!deprecated_attribute(HTML::AttributeNames::language).is_empty()) {
         // let the script block's type string be the concatenation of "text/" and the value of el's language attribute.
-        script_block_type = DeprecatedString::formatted("text/{}", attribute(HTML::AttributeNames::language));
+        script_block_type = DeprecatedString::formatted("text/{}", deprecated_attribute(HTML::AttributeNames::language));
     }
 
     // 9. If the script block's type string is a JavaScript MIME type essence match,
@@ -256,10 +256,10 @@ void HTMLScriptElement::prepare_script()
     // 20. If el has an event attribute and a for attribute, and el's type is "classic", then:
     if (m_script_type == ScriptType::Classic && has_attribute(HTML::AttributeNames::event) && has_attribute(HTML::AttributeNames::for_)) {
         // 1. Let for be the value of el's' for attribute.
-        auto for_ = attribute(HTML::AttributeNames::for_);
+        auto for_ = deprecated_attribute(HTML::AttributeNames::for_);
 
         // 2. Let event be the value of el's event attribute.
-        auto event = attribute(HTML::AttributeNames::event);
+        auto event = deprecated_attribute(HTML::AttributeNames::event);
 
         // 3. Strip leading and trailing ASCII whitespace from event and for.
         for_ = for_.trim(Infra::ASCII_WHITESPACE);
@@ -284,7 +284,7 @@ void HTMLScriptElement::prepare_script()
     Optional<String> encoding;
 
     if (has_attribute(HTML::AttributeNames::charset)) {
-        auto charset = TextCodec::get_standardized_encoding(attribute(HTML::AttributeNames::charset));
+        auto charset = TextCodec::get_standardized_encoding(deprecated_attribute(HTML::AttributeNames::charset));
         if (charset.has_value())
             encoding = String::from_utf8(*charset).release_value_but_fixme_should_propagate_errors();
     }
@@ -308,7 +308,7 @@ void HTMLScriptElement::prepare_script()
     //     Otherwise, let integrity metadata be the empty string.
     String integrity_metadata;
     if (has_attribute(HTML::AttributeNames::integrity)) {
-        auto integrity = attribute(HTML::AttributeNames::integrity);
+        auto integrity = deprecated_attribute(HTML::AttributeNames::integrity);
         integrity_metadata = String::from_deprecated_string(integrity).release_value_but_fixme_should_propagate_errors();
     }
 
@@ -346,7 +346,7 @@ void HTMLScriptElement::prepare_script()
         }
 
         // 2. Let src be the value of el's src attribute.
-        auto src = attribute(HTML::AttributeNames::src);
+        auto src = deprecated_attribute(HTML::AttributeNames::src);
 
         // 3. If src is the empty string, then queue an element task on the DOM manipulation task source given el to fire an event named error at el, and return.
         if (src.is_empty()) {

--- a/Userland/Libraries/LibWeb/HTML/HTMLScriptElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLScriptElement.h
@@ -44,9 +44,9 @@ public:
     virtual void inserted() override;
 
     // https://html.spec.whatwg.org/multipage/scripting.html#dom-script-supports
-    static bool supports(JS::VM&, DeprecatedString const& type)
+    static bool supports(JS::VM&, StringView type)
     {
-        return type.is_one_of("classic", "module");
+        return type.is_one_of("classic"sv, "module"sv);
     }
 
     void set_source_line_number(Badge<HTMLParser>, size_t source_line_number) { m_source_line_number = source_line_number; }

--- a/Userland/Libraries/LibWeb/HTML/HTMLScriptElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLScriptElement.idl
@@ -1,7 +1,7 @@
 #import <HTML/HTMLElement.idl>
 
 // https://html.spec.whatwg.org/multipage/scripting.html#htmlscriptelement
-[Exposed=Window, UseDeprecatedAKString]
+[Exposed=Window]
 interface HTMLScriptElement : HTMLElement {
 
     [HTMLConstructor] constructor();

--- a/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
@@ -167,7 +167,7 @@ Optional<ARIA::Role> HTMLSelectElement::default_role() const
     if (has_attribute("multiple"))
         return ARIA::Role::listbox;
     if (has_attribute("size")) {
-        auto size_attribute = attribute("size").to_int();
+        auto size_attribute = deprecated_attribute("size").to_int();
         if (size_attribute.has_value() && size_attribute.value() > 1)
             return ARIA::Role::listbox;
     }

--- a/Userland/Libraries/LibWeb/HTML/HTMLTableCellElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableCellElement.cpp
@@ -97,7 +97,7 @@ void HTMLTableCellElement::apply_presentational_hints(CSS::StyleProperties& styl
 // https://html.spec.whatwg.org/multipage/tables.html#algorithm-for-processing-rows
 unsigned int HTMLTableCellElement::col_span() const
 {
-    auto optional_value = Web::HTML::parse_non_negative_integer(attribute(HTML::AttributeNames::colspan));
+    auto optional_value = Web::HTML::parse_non_negative_integer(deprecated_attribute(HTML::AttributeNames::colspan));
 
     // If parsing that value failed, or returned zero, or if the attribute is absent, then let colspan be 1, instead.
     if (!optional_value.has_value() || optional_value.value() == 0) {
@@ -124,7 +124,7 @@ WebIDL::ExceptionOr<void> HTMLTableCellElement::set_col_span(unsigned int value)
 unsigned int HTMLTableCellElement::row_span() const
 {
     // If parsing that value failed or if the attribute is absent, then let rowspan be 1, instead.
-    auto value = Web::HTML::parse_non_negative_integer(attribute(HTML::AttributeNames::rowspan)).value_or(1);
+    auto value = Web::HTML::parse_non_negative_integer(deprecated_attribute(HTML::AttributeNames::rowspan)).value_or(1);
 
     // If rowspan is greater than 65534, let it be 65534 instead.
     if (value > 65534) {

--- a/Userland/Libraries/LibWeb/HTML/HTMLTableElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableElement.cpp
@@ -410,7 +410,7 @@ WebIDL::ExceptionOr<void> HTMLTableElement::delete_row(long index)
 
 unsigned int HTMLTableElement::border() const
 {
-    return parse_border(attribute(HTML::AttributeNames::border));
+    return parse_border(deprecated_attribute(HTML::AttributeNames::border));
 }
 
 }

--- a/Userland/Libraries/LibWeb/HTML/NavigableContainer.cpp
+++ b/Userland/Libraries/LibWeb/HTML/NavigableContainer.cpp
@@ -77,7 +77,7 @@ WebIDL::ExceptionOr<void> NavigableContainer::create_new_child_navigable()
     Optional<String> target_name;
 
     // 5. If element has a name content attribute, then set targetName to the value of that attribute.
-    if (auto value = attribute(HTML::AttributeNames::name); !value.is_null())
+    if (auto value = deprecated_attribute(HTML::AttributeNames::name); !value.is_null())
         target_name = String::from_deprecated_string(value).release_value_but_fixme_should_propagate_errors();
 
     // 6. Let documentState be a new document state, with
@@ -152,7 +152,7 @@ void NavigableContainer::create_new_nested_browsing_context()
     m_nested_browsing_context->register_frame_nesting(document().url());
 
     // 4. If element has a name attribute, then set browsingContext's name to the value of this attribute.
-    if (auto name = attribute(HTML::AttributeNames::name); !name.is_empty())
+    if (auto name = deprecated_attribute(HTML::AttributeNames::name); !name.is_empty())
         m_nested_browsing_context->set_name(String::from_deprecated_string(name).release_value_but_fixme_should_propagate_errors());
 }
 
@@ -220,7 +220,7 @@ void NavigableContainer::shared_attribute_processing_steps_for_iframe_and_frame(
     // 2. If element has a src attribute specified, and its value is not the empty string,
     //    then parse the value of that attribute relative to element's node document.
     //    If this is successful, then set url to the resulting URL record.
-    auto src_attribute_value = attribute(HTML::AttributeNames::src);
+    auto src_attribute_value = deprecated_attribute(HTML::AttributeNames::src);
     if (!src_attribute_value.is_null() && !src_attribute_value.is_empty()) {
         auto parsed_src = document().parse_url(src_attribute_value);
         if (parsed_src.is_valid())

--- a/Userland/Libraries/LibWeb/Layout/FrameBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FrameBox.cpp
@@ -24,8 +24,8 @@ void FrameBox::prepare_for_replaced_layout()
     VERIFY(dom_node().nested_browsing_context());
 
     // FIXME: Do proper error checking, etc.
-    set_natural_width(dom_node().attribute(HTML::AttributeNames::width).to_int().value_or(300));
-    set_natural_height(dom_node().attribute(HTML::AttributeNames::height).to_int().value_or(150));
+    set_natural_width(dom_node().deprecated_attribute(HTML::AttributeNames::width).to_int().value_or(300));
+    set_natural_height(dom_node().deprecated_attribute(HTML::AttributeNames::height).to_int().value_or(150));
 }
 
 void FrameBox::did_set_content_size()

--- a/Userland/Libraries/LibWeb/Layout/Label.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Label.cpp
@@ -93,7 +93,7 @@ Label const* Label::label_for_control_node(LabelableNode const& control)
     // same tree as the label element. If the attribute is specified and there is an element in the tree
     // whose ID is equal to the value of the for attribute, and the first such element in tree order is
     // a labelable element, then that element is the label element's labeled control.
-    if (auto id = control.dom_node().attribute(HTML::AttributeNames::id); !id.is_empty()) {
+    if (auto id = control.dom_node().deprecated_attribute(HTML::AttributeNames::id); !id.is_empty()) {
         Label const* label = nullptr;
 
         control.document().layout_node()->for_each_in_inclusive_subtree_of_type<Label>([&](auto& node) {
@@ -128,7 +128,7 @@ LabelableNode* Label::labeled_control()
     // a labelable element, then that element is the label element's labeled control.
     if (auto for_ = dom_node().for_(); !for_.is_null()) {
         document().layout_node()->for_each_in_inclusive_subtree_of_type<LabelableNode>([&](auto& node) {
-            if (node.dom_node().attribute(HTML::AttributeNames::id) == for_) {
+            if (node.dom_node().deprecated_attribute(HTML::AttributeNames::id) == for_) {
                 control = &node;
                 return IterationDecision::Break;
             }

--- a/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -72,7 +72,7 @@ void TableFormattingContext::compute_constrainedness()
                 m_columns[column_index].is_constrained = true;
             }
             auto const& col_node = static_cast<HTML::HTMLTableColElement const&>(*column_box.dom_node());
-            unsigned span = col_node.attribute(HTML::AttributeNames::span).to_uint().value_or(1);
+            unsigned span = col_node.deprecated_attribute(HTML::AttributeNames::span).to_uint().value_or(1);
             column_index += span;
         });
     });
@@ -189,7 +189,7 @@ void TableFormattingContext::compute_outer_content_sizes()
             // The outer max-content width of a table-column or table-column-group is max(min-width, min(max-width, width)).
             m_columns[column_index].max_size = max(min_width, min(max_width, width));
             auto const& col_node = static_cast<HTML::HTMLTableColElement const&>(*column_box.dom_node());
-            unsigned span = col_node.attribute(HTML::AttributeNames::span).to_uint().value_or(1);
+            unsigned span = col_node.deprecated_attribute(HTML::AttributeNames::span).to_uint().value_or(1);
             column_index += span;
         });
     });
@@ -1378,7 +1378,7 @@ void TableFormattingContext::BorderConflictFinder::collect_conflicting_col_eleme
         for (auto* child_of_column_group = child->first_child(); child_of_column_group; child_of_column_group = child_of_column_group->next_sibling()) {
             VERIFY(child_of_column_group->display().is_table_column());
             auto const& col_node = static_cast<HTML::HTMLTableColElement const&>(*child_of_column_group->dom_node());
-            unsigned span = col_node.attribute(HTML::AttributeNames::span).to_uint().value_or(1);
+            unsigned span = col_node.deprecated_attribute(HTML::AttributeNames::span).to_uint().value_or(1);
             for (size_t i = column_index; i < column_index + span; ++i) {
                 m_col_elements_by_index[i] = child_of_column_group;
             }
@@ -1742,7 +1742,7 @@ void TableFormattingContext::initialize_intrinsic_percentages_from_rows_or_colum
             m_columns[column_index].has_intrinsic_percentage = computed_values.max_width().is_percentage() || computed_values.width().is_percentage();
             m_columns[column_index].intrinsic_percentage = min(width_percentage, max_width_percentage);
             auto const& col_node = static_cast<HTML::HTMLTableColElement const&>(*column_box.dom_node());
-            unsigned span = col_node.attribute(HTML::AttributeNames::span).to_uint().value_or(1);
+            unsigned span = col_node.deprecated_attribute(HTML::AttributeNames::span).to_uint().value_or(1);
             column_index += span;
         });
     });

--- a/Userland/Libraries/LibWeb/SVG/SVGForeignObjectElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGForeignObjectElement.cpp
@@ -52,10 +52,10 @@ void SVGForeignObjectElement::apply_presentational_hints(CSS::StyleProperties& s
 {
     Base::apply_presentational_hints(style);
     auto parsing_context = CSS::Parser::ParsingContext { document() };
-    if (auto width_value = parse_css_value(parsing_context, attribute(Web::HTML::AttributeNames::width), CSS::PropertyID::Width))
+    if (auto width_value = parse_css_value(parsing_context, deprecated_attribute(Web::HTML::AttributeNames::width), CSS::PropertyID::Width))
         style.set_property(CSS::PropertyID::Width, width_value.release_nonnull());
 
-    if (auto height_value = parse_css_value(parsing_context, attribute(Web::HTML::AttributeNames::height), CSS::PropertyID::Height))
+    if (auto height_value = parse_css_value(parsing_context, deprecated_attribute(Web::HTML::AttributeNames::height), CSS::PropertyID::Height))
         style.set_property(CSS::PropertyID::Height, height_value.release_nonnull());
 }
 

--- a/Userland/Libraries/LibWeb/SVG/SVGSVGElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGSVGElement.cpp
@@ -41,9 +41,9 @@ void SVGSVGElement::apply_presentational_hints(CSS::StyleProperties& style) cons
     // NOTE: Hack to ensure SVG unitless widths/heights are parsed even with <!DOCTYPE html>
     FIXME::TemporarilyEnableQuirksMode enable_quirks(document());
 
-    auto width_attribute = attribute(SVG::AttributeNames::width);
+    auto width_attribute = deprecated_attribute(SVG::AttributeNames::width);
     auto parsing_context = CSS::Parser::ParsingContext { document() };
-    if (auto width_value = parse_css_value(parsing_context, attribute(Web::HTML::AttributeNames::width), CSS::PropertyID::Width)) {
+    if (auto width_value = parse_css_value(parsing_context, deprecated_attribute(Web::HTML::AttributeNames::width), CSS::PropertyID::Width)) {
         style.set_property(CSS::PropertyID::Width, width_value.release_nonnull());
     } else if (width_attribute == "") {
         // If the `width` attribute is an empty string, it defaults to 100%.
@@ -53,8 +53,8 @@ void SVGSVGElement::apply_presentational_hints(CSS::StyleProperties& style) cons
     }
 
     // Height defaults to 100%
-    auto height_attribute = attribute(SVG::AttributeNames::height);
-    if (auto height_value = parse_css_value(parsing_context, attribute(Web::HTML::AttributeNames::height), CSS::PropertyID::Height)) {
+    auto height_attribute = deprecated_attribute(SVG::AttributeNames::height);
+    if (auto height_value = parse_css_value(parsing_context, deprecated_attribute(Web::HTML::AttributeNames::height), CSS::PropertyID::Height)) {
         style.set_property(CSS::PropertyID::Height, height_value.release_nonnull());
     } else if (height_attribute == "") {
         // If the `height` attribute is an empty string, it defaults to 100%.
@@ -85,15 +85,15 @@ void SVGSVGElement::update_fallback_view_box_for_svg_as_image()
     Optional<double> width;
     Optional<double> height;
 
-    auto width_attribute = attribute(SVG::AttributeNames::width);
+    auto width_attribute = deprecated_attribute(SVG::AttributeNames::width);
     auto parsing_context = CSS::Parser::ParsingContext { document() };
-    if (auto width_value = parse_css_value(parsing_context, attribute(Web::HTML::AttributeNames::width), CSS::PropertyID::Width)) {
+    if (auto width_value = parse_css_value(parsing_context, deprecated_attribute(Web::HTML::AttributeNames::width), CSS::PropertyID::Width)) {
         if (width_value->is_length() && width_value->as_length().length().is_absolute())
             width = width_value->as_length().length().absolute_length_to_px().to_double();
     }
 
-    auto height_attribute = attribute(SVG::AttributeNames::height);
-    if (auto height_value = parse_css_value(parsing_context, attribute(Web::HTML::AttributeNames::height), CSS::PropertyID::Height)) {
+    auto height_attribute = deprecated_attribute(SVG::AttributeNames::height);
+    if (auto height_value = parse_css_value(parsing_context, deprecated_attribute(Web::HTML::AttributeNames::height), CSS::PropertyID::Height)) {
         if (height_value->is_length() && height_value->as_length().length().is_absolute())
             height = height_value->as_length().length().absolute_length_to_px().to_double();
     }

--- a/Userland/Libraries/LibWeb/SVG/SVGUseElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGUseElement.cpp
@@ -103,7 +103,7 @@ void SVGUseElement::svg_element_removed(SVGElement& svg_element)
         return;
     }
 
-    if (svg_element.attribute("id"sv).matches(m_referenced_id.value())) {
+    if (svg_element.deprecated_attribute("id"sv).matches(m_referenced_id.value())) {
         shadow_root()->remove_all_children();
     }
 }

--- a/Userland/Libraries/LibWeb/WebDriver/Screenshot.cpp
+++ b/Userland/Libraries/LibWeb/WebDriver/Screenshot.cpp
@@ -36,11 +36,11 @@ static Response encode_canvas_element(HTML::HTMLCanvasElement const& canvas)
     auto data_url = canvas.to_data_url("image/png"sv, {});
 
     // 5. Let index be the index of "," in data url.
-    auto index = data_url.find(',');
+    auto index = data_url.find_byte_offset(',');
     VERIFY(index.has_value());
 
     // 6. Let encoded string be a substring of data url using (index + 1) as the start argument.
-    auto encoded_string = data_url.substring(*index + 1);
+    auto encoded_string = MUST(data_url.substring_from_byte_offset(*index + 1));
 
     // 7. Return success with data encoded string.
     return JsonValue { move(encoded_string) };


### PR DESCRIPTION
After these changes, there are only 18 IDL files left which require `UseDeprecatedAKString`. 