### PR TITLE
Shell: Allow the user to set the prompt using PROMPT()

### DIFF
--- a/Userland/Shell/Builtin.cpp
+++ b/Userland/Shell/Builtin.cpp
@@ -1967,6 +1967,28 @@ ErrorOr<int> Shell::builtin_run_with_env(Main::Arguments arguments)
     return exit_code;
 }
 
+ErrorOr<int> Shell::builtin_shell_set_active_prompt(Main::Arguments arguments)
+{
+    StringView new_prompt;
+
+    Core::ArgsParser parser;
+    parser.add_positional_argument(new_prompt, "New prompt text", "prompt", Core::ArgsParser::Required::Yes);
+
+    if (!parser.parse(arguments, Core::ArgsParser::FailureBehavior::Ignore))
+        return 1;
+
+    if (!m_editor) {
+        warnln("shell_set_active_prompt: No active prompt");
+        return 1;
+    }
+
+    if (m_editor->is_editing())
+        m_editor->set_prompt(new_prompt);
+    else
+        m_next_scheduled_prompt_text = new_prompt;
+    return 0;
+}
+
 bool Shell::has_builtin(StringView name) const
 {
     if (name == ":"sv || (m_in_posix_mode && name == "."sv))

--- a/Userland/Shell/Shell.h
+++ b/Userland/Shell/Shell.h
@@ -60,7 +60,8 @@
     __ENUMERATE_SHELL_BUILTIN(continue, OnlyInPOSIXMode)     \
     __ENUMERATE_SHELL_BUILTIN(read, OnlyInPOSIXMode)         \
     __ENUMERATE_SHELL_BUILTIN(run_with_env, OnlyInPOSIXMode) \
-    __ENUMERATE_SHELL_BUILTIN(argsparser_parse, InAllModes)
+    __ENUMERATE_SHELL_BUILTIN(argsparser_parse, InAllModes)  \
+    __ENUMERATE_SHELL_BUILTIN(shell_set_active_prompt, InAllModes)
 
 #define ENUMERATE_SHELL_OPTIONS()                                                                                    \
     __ENUMERATE_SHELL_OPTION(inline_exec_keep_empty_segments, false, "Keep empty segments in inline execute $(...)") \
@@ -422,6 +423,8 @@ private:
 
     void timer_event(Core::TimerEvent&) override;
 
+    void set_user_prompt();
+
     bool is_allowed_to_modify_termios(const AST::Command&) const;
 
     void bring_cursor_to_beginning_of_a_line() const;
@@ -510,6 +513,9 @@ private:
     Optional<size_t> m_history_autosave_time;
 
     StackInfo m_completion_stack_info;
+
+    RefPtr<AST::Node> m_prompt_command_node;
+    mutable Optional<DeprecatedString> m_next_scheduled_prompt_text;
 };
 
 [[maybe_unused]] static constexpr bool is_word_character(char c)


### PR DESCRIPTION
This allows the prompt to be dynamically configurable, making it possible to display various bits of information in the prompt.

I'm personally quite fond of this now:
<details><summary>Expand for demo</summary>

```sh

blue="\x1b[34m"
green="\x1b[32m"
purple="\x1b[35m"
red="\x1b[31m"
bold="\x1b[1m"
reset="\x1b[0m"

gitq() {
    if [ "$(git rev-parse --is-inside-work-tree 2>/dev/null)" = true ] {
        x='@'
        if not git diff --quiet {
            x='*'
        }
        echo -n " $x$purple$(git branch --show-current)$reset on $blue$(git rev-parse --show-toplevel)$reset"
    }
}
PROMPT() {
    echo -n <<~PROMPT
        $bold$green-- prompt at $(date +%H:%M:%S)$reset$(gitq)
        [$blue$(whoami)$reset@$green$(hostname)$reset] $purple$(pwd)$reset
        $blue❯ $reset
    PROMPT
}
```
which looks something like this:
![image](https://github.com/SerenityOS/serenity/assets/14001776/3146e4f2-f5d9-4004-a4d6-68d4922ffe48)

</details>