### PR TITLE
LibWeb: Handle case where abspos flex child position depends on height

### DIFF
--- a/Tests/LibWeb/Layout/expected/flex/abspos-flex-child-with-auto-height.txt
+++ b/Tests/LibWeb/Layout/expected/flex/abspos-flex-child-with-auto-height.txt
@@ -1,0 +1,12 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x16 [BFC] children: not-inline
+    Box <body> at (8,8) content-size 784x0 positioned flex-container(row) [FFC] children: not-inline
+      BlockContainer <div.abspos> at (8,-42) content-size 100x100 positioned [BFC] children: not-inline
+        BlockContainer <div.green> at (8,-42) content-size 100x200 children: inline
+          TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,-42 800x642]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x16] overflow: [0,-42 800x200]
+    PaintableBox (Box<BODY>) [8,8 784x0] overflow: [8,-42 100x200]
+      PaintableWithLines (BlockContainer<DIV>.abspos) [8,-42 100x100] overflow: [8,-42 100x200]
+        PaintableWithLines (BlockContainer<DIV>.green) [8,-42 100x200]

--- a/Tests/LibWeb/Layout/input/flex/abspos-flex-child-with-auto-height.html
+++ b/Tests/LibWeb/Layout/input/flex/abspos-flex-child-with-auto-height.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html><style>
+  * { outline: black solid 1px; }
+  body {
+    position: relative;
+    display: flex;
+    align-items: center;
+  }
+  .abspos {
+    position: absolute;
+    max-height: 100px;
+  }
+  .green {
+    display: block;
+    width: 100px;
+    height: 200px;
+    background: green;
+  }
+</style><body><div class="abspos"><div class="green">

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -880,7 +880,7 @@ void FormattingContext::compute_height_for_absolutely_positioned_non_replaced_el
     };
 
     // If all three of top, height, and bottom are auto:
-    if (top.is_auto() && height.is_auto() && bottom.is_auto()) {
+    if (top.is_auto() && should_treat_height_as_auto(box, available_space) && bottom.is_auto()) {
         // First set any auto values for margin-top and margin-bottom to 0,
         if (margin_top.is_auto())
             margin_top = CSS::Length::make_px(0);
@@ -900,7 +900,7 @@ void FormattingContext::compute_height_for_absolutely_positioned_non_replaced_el
     }
 
     // If none of the three are auto:
-    else if (!top.is_auto() && !height.is_auto() && !bottom.is_auto()) {
+    else if (!top.is_auto() && !should_treat_height_as_auto(box, available_space) && !bottom.is_auto()) {
         // If both margin-top and margin-bottom are auto,
         if (margin_top.is_auto() && margin_bottom.is_auto()) {
             // solve the equation under the extra constraint that the two margins get equal values.
@@ -934,7 +934,7 @@ void FormattingContext::compute_height_for_absolutely_positioned_non_replaced_el
         // and pick one of the following six rules that apply.
 
         // 1. If top and height are auto and bottom is not auto,
-        if (top.is_auto() && height.is_auto() && !bottom.is_auto()) {
+        if (top.is_auto() && should_treat_height_as_auto(box, available_space) && !bottom.is_auto()) {
             // then the height is based on the Auto heights for block formatting context roots,
             auto maybe_height = compute_auto_height_for_absolutely_positioned_element(box, available_space, before_or_after_inside_layout);
             if (!maybe_height.has_value())
@@ -946,7 +946,7 @@ void FormattingContext::compute_height_for_absolutely_positioned_non_replaced_el
         }
 
         // 2. If top and bottom are auto and height is not auto,
-        else if (top.is_auto() && bottom.is_auto() && !height.is_auto()) {
+        else if (top.is_auto() && bottom.is_auto() && !should_treat_height_as_auto(box, available_space)) {
             // then set top to the static position,
             top = CSS::Length::make_px(calculate_static_position(box).y());
 
@@ -955,7 +955,7 @@ void FormattingContext::compute_height_for_absolutely_positioned_non_replaced_el
         }
 
         // 3. If height and bottom are auto and top is not auto,
-        else if (height.is_auto() && bottom.is_auto() && !top.is_auto()) {
+        else if (should_treat_height_as_auto(box, available_space) && bottom.is_auto() && !top.is_auto()) {
             // then the height is based on the Auto heights for block formatting context roots,
             auto maybe_height = compute_auto_height_for_absolutely_positioned_element(box, available_space, before_or_after_inside_layout);
             if (!maybe_height.has_value())
@@ -967,19 +967,19 @@ void FormattingContext::compute_height_for_absolutely_positioned_non_replaced_el
         }
 
         // 4. If top is auto, height and bottom are not auto,
-        else if (top.is_auto() && !height.is_auto() && !bottom.is_auto()) {
+        else if (top.is_auto() && !should_treat_height_as_auto(box, available_space) && !bottom.is_auto()) {
             // then solve for top.
             solve_for_top();
         }
 
         // 5. If height is auto, top and bottom are not auto,
-        else if (height.is_auto() && !top.is_auto() && !bottom.is_auto()) {
+        else if (should_treat_height_as_auto(box, available_space) && !top.is_auto() && !bottom.is_auto()) {
             // then solve for height.
             solve_for_height();
         }
 
         // 6. If bottom is auto, top and height are not auto,
-        else if (bottom.is_auto() && !top.is_auto() && !height.is_auto()) {
+        else if (bottom.is_auto() && !top.is_auto() && !should_treat_height_as_auto(box, available_space)) {
             // then solve for bottom.
             solve_for_bottom();
         }


### PR DESCRIPTION
There's a particularly awkward case where the static position of an abspos child of a flex container is dependent on its height. This can happen when `align-items: center` is in effect, as we have to adjust the abspos child's Y position by half of its height.
    
This patch solves the issue by reordering operations in the abspos height resolution algorithm, to make sure that height is resolved before the static position is calculated.

Visual progression on https://null.com/

Before:
![Screenshot at 2023-09-03 14-29-11](https://github.com/SerenityOS/serenity/assets/5954907/96104940-d01f-4e39-b04a-c2d41a30eefa)


After:
![Screenshot at 2023-09-03 14-28-05](https://github.com/SerenityOS/serenity/assets/5954907/aace17ff-d5a0-42c8-ae09-6db592ec6e2f)
