### PR TITLE
LibWeb: Remove GC allocations in FetchAlgorithms constructor

### DIFF
--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/FetchAlgorithms.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/FetchAlgorithms.cpp
@@ -12,16 +12,34 @@ namespace Web::Fetch::Infrastructure {
 
 JS::NonnullGCPtr<FetchAlgorithms> FetchAlgorithms::create(JS::VM& vm, Input input)
 {
-    return vm.heap().allocate_without_realm<FetchAlgorithms>(vm, move(input));
+    auto process_request_body_chunk_length = JS::create_heap_function(vm.heap(), move(input.process_request_body_chunk_length));
+    auto process_request_end_of_body = JS::create_heap_function(vm.heap(), move(input.process_request_end_of_body));
+    auto process_early_hints_response = JS::create_heap_function(vm.heap(), move(input.process_early_hints_response));
+    auto process_response = JS::create_heap_function(vm.heap(), move(input.process_response));
+    auto process_response_end_of_body = JS::create_heap_function(vm.heap(), move(input.process_response_end_of_body));
+    auto process_response_consume_body = JS::create_heap_function(vm.heap(), move(input.process_response_consume_body));
+    return vm.heap().allocate_without_realm<FetchAlgorithms>(
+        process_request_body_chunk_length,
+        process_request_end_of_body,
+        process_early_hints_response,
+        process_response,
+        process_response_end_of_body,
+        process_response_consume_body);
 }
 
-FetchAlgorithms::FetchAlgorithms(JS::VM& vm, Input input)
-    : m_process_request_body_chunk_length(JS::create_heap_function(vm.heap(), move(input.process_request_body_chunk_length)))
-    , m_process_request_end_of_body(JS::create_heap_function(vm.heap(), move(input.process_request_end_of_body)))
-    , m_process_early_hints_response(JS::create_heap_function(vm.heap(), move(input.process_early_hints_response)))
-    , m_process_response(JS::create_heap_function(vm.heap(), move(input.process_response)))
-    , m_process_response_end_of_body(JS::create_heap_function(vm.heap(), move(input.process_response_end_of_body)))
-    , m_process_response_consume_body(JS::create_heap_function(vm.heap(), move(input.process_response_consume_body)))
+FetchAlgorithms::FetchAlgorithms(
+    ProcessRequestBodyChunkLengthHeapFunction process_request_body_chunk_length,
+    ProcessRequestEndOfBodyHeapFunction process_request_end_of_body,
+    ProcessEarlyHintsResponseHeapFunction process_early_hints_response,
+    ProcessResponseHeapFunction process_response,
+    ProcessResponseEndOfBodyHeapFunction process_response_end_of_body,
+    ProcessResponseConsumeBodyHeapFunction process_response_consume_body)
+    : m_process_request_body_chunk_length(process_request_body_chunk_length)
+    , m_process_request_end_of_body(process_request_end_of_body)
+    , m_process_early_hints_response(process_early_hints_response)
+    , m_process_response(process_response)
+    , m_process_response_end_of_body(process_response_end_of_body)
+    , m_process_response_consume_body(process_response_consume_body)
 {
 }
 

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/FetchAlgorithms.h
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/FetchAlgorithms.h
@@ -30,6 +30,13 @@ public:
     using ProcessResponseEndOfBodyFunction = Function<void(JS::NonnullGCPtr<Infrastructure::Response>)>;
     using ProcessResponseConsumeBodyFunction = Function<void(JS::NonnullGCPtr<Infrastructure::Response>, BodyBytes)>;
 
+    using ProcessRequestBodyChunkLengthHeapFunction = JS::NonnullGCPtr<JS::HeapFunction<ProcessRequestBodyChunkLengthFunction::FunctionType>>;
+    using ProcessRequestEndOfBodyHeapFunction = JS::NonnullGCPtr<JS::HeapFunction<ProcessRequestEndOfBodyFunction::FunctionType>>;
+    using ProcessEarlyHintsResponseHeapFunction = JS::NonnullGCPtr<JS::HeapFunction<ProcessEarlyHintsResponseFunction::FunctionType>>;
+    using ProcessResponseHeapFunction = JS::NonnullGCPtr<JS::HeapFunction<ProcessResponseFunction::FunctionType>>;
+    using ProcessResponseEndOfBodyHeapFunction = JS::NonnullGCPtr<JS::HeapFunction<ProcessResponseEndOfBodyFunction::FunctionType>>;
+    using ProcessResponseConsumeBodyHeapFunction = JS::NonnullGCPtr<JS::HeapFunction<ProcessResponseConsumeBodyFunction::FunctionType>>;
+
     struct Input {
         ProcessRequestBodyChunkLengthFunction process_request_body_chunk_length;
         ProcessRequestEndOfBodyFunction process_request_end_of_body;
@@ -51,14 +58,20 @@ public:
     virtual void visit_edges(JS::Cell::Visitor&) override;
 
 private:
-    explicit FetchAlgorithms(JS::VM&, Input);
+    explicit FetchAlgorithms(
+        ProcessRequestBodyChunkLengthHeapFunction process_request_body_chunk_length,
+        ProcessRequestEndOfBodyHeapFunction process_request_end_of_body,
+        ProcessEarlyHintsResponseHeapFunction process_early_hints_response,
+        ProcessResponseHeapFunction process_response,
+        ProcessResponseEndOfBodyHeapFunction process_response_end_of_body,
+        ProcessResponseConsumeBodyHeapFunction process_response_consume_body);
 
-    JS::NonnullGCPtr<JS::HeapFunction<void(u64)>> m_process_request_body_chunk_length;
-    JS::NonnullGCPtr<JS::HeapFunction<void()>> m_process_request_end_of_body;
-    JS::NonnullGCPtr<JS::HeapFunction<void(JS::NonnullGCPtr<Infrastructure::Response>)>> m_process_early_hints_response;
-    JS::NonnullGCPtr<JS::HeapFunction<void(JS::NonnullGCPtr<Infrastructure::Response>)>> m_process_response;
-    JS::NonnullGCPtr<JS::HeapFunction<void(JS::NonnullGCPtr<Infrastructure::Response>)>> m_process_response_end_of_body;
-    JS::NonnullGCPtr<JS::HeapFunction<void(JS::NonnullGCPtr<Infrastructure::Response>, BodyBytes)>> m_process_response_consume_body;
+    ProcessRequestBodyChunkLengthHeapFunction m_process_request_body_chunk_length;
+    ProcessRequestEndOfBodyHeapFunction m_process_request_end_of_body;
+    ProcessEarlyHintsResponseHeapFunction m_process_early_hints_response;
+    ProcessResponseHeapFunction m_process_response;
+    ProcessResponseEndOfBodyHeapFunction m_process_response_end_of_body;
+    ProcessResponseConsumeBodyHeapFunction m_process_response_consume_body;
 };
 
 }


### PR DESCRIPTION
We should not GC allocate in the constructors of GC-allocated objects because a new allocation might trigger garbage collection, which in turn might access not fully initialized objects.