### PR TITLE
Maps: Convert the main widget to a frame

### DIFF
--- a/Userland/Applications/Maps/MapWidget.cpp
+++ b/Userland/Applications/Maps/MapWidget.cpp
@@ -283,9 +283,14 @@ void MapWidget::paint_attribution(GUI::Painter& painter)
     painter.draw_text(attribution_text_rect, m_attribution_text, Gfx::TextAlignment::BottomRight, panel_foreground_color);
 }
 
-void MapWidget::paint_event(GUI::PaintEvent&)
+void MapWidget::paint_event(GUI::PaintEvent& event)
 {
+    GUI::Frame::paint_event(event);
+
     GUI::Painter painter(*this);
+    painter.add_clip_rect(frame_inner_rect());
+    painter.add_clip_rect(event.rect());
+
     painter.fill_rect(rect(), map_background_color);
 
     if (m_connection_failed) {

--- a/Userland/Applications/Maps/MapWidget.h
+++ b/Userland/Applications/Maps/MapWidget.h
@@ -6,12 +6,12 @@
 
 #pragma once
 
+#include <LibGUI/Frame.h>
 #include <LibGUI/Painter.h>
-#include <LibGUI/Widget.h>
 #include <LibProtocol/Request.h>
 #include <LibProtocol/RequestClient.h>
 
-class MapWidget final : public GUI::Widget {
+class MapWidget final : public GUI::Frame {
     C_OBJECT(MapWidget);
 
 public:


### PR DESCRIPTION
This gives the maps widget a nice inner bevel to match most of the other applications on the system.

![Screenshot_20230903_141802](https://github.com/SerenityOS/serenity/assets/5600524/25093c22-11ff-48e4-9d21-9aa856e7ee4b)
