### PR TITLE
Meta: Add `-fno-omit-frame-pointer` flag

### DIFF
--- a/Meta/CMake/serenity_compile_options.cmake
+++ b/Meta/CMake/serenity_compile_options.cmake
@@ -1,6 +1,7 @@
 include(${CMAKE_CURRENT_LIST_DIR}/common_compile_options.cmake)
 
-# The following warnings are sorted by the "base" name (the part excluding the initial Wno or W).
+# The following options are sorted by the "base" name (the part excluding the initial Wno/fno or W/f).
+
 add_compile_options(-Wno-address-of-packed-member)
 add_compile_options(-Wcast-qual)
 add_compile_options(-Wdeprecated-copy)
@@ -18,6 +19,7 @@ add_compile_options(-Wwrite-strings)
 
 add_compile_options(-fno-delete-null-pointer-checks)
 add_compile_options(-ffile-prefix-map=${SerenityOS_SOURCE_DIR}=.)
+add_compile_options(-fno-omit-frame-pointer)
 add_compile_options(-fsized-deallocation)
 add_compile_options(-fstack-clash-protection)
 add_compile_options(-fstack-protector-strong)


### PR DESCRIPTION
We currently only use frame pointer-based backtrace generation.
This option is necessary for RISC-V as otherwise the compiler doesn't save `fp` most of the time.
I made this flag not riscv64 exclusive, as we should do everything to make that kind of backtrace generation work.
See [this discussion](https://discord.com/channels/830522505605283862/1139481927594803260/1148020960499351643) for reference.