### PR TITLE
LibWeb: Implement attr() types :^)

### DIFF
--- a/AK/FlyString.cpp
+++ b/AK/FlyString.cpp
@@ -190,4 +190,9 @@ bool FlyString::equals_ignoring_ascii_case(FlyString const& other) const
     return StringUtils::equals_ignoring_ascii_case(bytes_as_string_view(), other.bytes_as_string_view());
 }
 
+bool FlyString::equals_ignoring_ascii_case(StringView other) const
+{
+    return StringUtils::equals_ignoring_ascii_case(bytes_as_string_view(), other);
+}
+
 }

--- a/AK/FlyString.h
+++ b/AK/FlyString.h
@@ -64,6 +64,7 @@ public:
 
     // Compare this FlyString against another string with ASCII caseless matching.
     [[nodiscard]] bool equals_ignoring_ascii_case(FlyString const&) const;
+    [[nodiscard]] bool equals_ignoring_ascii_case(StringView) const;
 
     template<typename... Ts>
     [[nodiscard]] ALWAYS_INLINE constexpr bool is_one_of(Ts... strings) const

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSValueID.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSValueID.cpp
@@ -70,6 +70,14 @@ enum class ValueID {
 Optional<ValueID> value_id_from_string(StringView);
 StringView string_from_value_id(ValueID);
 
+// https://www.w3.org/TR/css-values-4/#common-keywords
+inline bool is_css_wide_keyword(StringView name)
+{
+    return name.equals_ignoring_ascii_case("inherit"sv)
+        || name.equals_ignoring_ascii_case("initial"sv)
+        || name.equals_ignoring_ascii_case("unset"sv);
+}
+
 }
 
 )~~~");

--- a/Tests/LibWeb/Ref/css-attr-basic.html
+++ b/Tests/LibWeb/Ref/css-attr-basic.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<style>
+    .foo::before {
+        content: attr(bar);
+    }
+</style>
+<div class="foo" bar="Well, hello friends!"></div>

--- a/Tests/LibWeb/Ref/css-attr-fallback.html
+++ b/Tests/LibWeb/Ref/css-attr-fallback.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<style>
+    .foo::before {
+        content: attr(bar, "Well, hello friends!");
+    }
+</style>
+<div class="foo"></div>

--- a/Tests/LibWeb/Ref/css-attr-ref.html
+++ b/Tests/LibWeb/Ref/css-attr-ref.html
@@ -1,0 +1,2 @@
+<!doctype html>
+<div>Well, hello friends!</div>

--- a/Tests/LibWeb/Ref/css-attr-typed-fallback.html
+++ b/Tests/LibWeb/Ref/css-attr-typed-fallback.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<style>
+    div {
+        width: 100px;
+        height: 20px;
+        border: 1px solid black;
+    }
+    .string::before {
+        content: attr(foo string, "WHF!");
+    }
+    .length {
+        width: attr(foo length, 200px);
+    }
+    .px {
+        width: attr(foo px, 200px);
+    }
+    .color {
+        background-color: attr(foo color, lime);
+    }
+</style>
+<div class="string"></div>
+<div class="length" foo="90pizzas"></div>
+<div class="px" foo="twohundred"></div>
+<div class="color" foo="grunge"></div>
+<div class="color" foo="rgb(0,0,0)"></div>

--- a/Tests/LibWeb/Ref/css-attr-typed-ref.html
+++ b/Tests/LibWeb/Ref/css-attr-typed-ref.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<style>
+    div {
+        width: 100px;
+        height: 20px;
+        border: 1px solid black;
+    }
+    .length {
+        width: 200px;
+    }
+    .px {
+        width: 200px;
+    }
+    .color {
+        background-color: #00ff00;
+    }
+</style>
+<div>WHF!</div>
+<div class="length"></div>
+<div class="px"></div>
+<div class="color" foo="green"></div>
+<div class="color" foo="#00ff00"></div>

--- a/Tests/LibWeb/Ref/css-attr-typed.html
+++ b/Tests/LibWeb/Ref/css-attr-typed.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<style>
+    div {
+        width: 100px;
+        height: 20px;
+        border: 1px solid black;
+    }
+    .string::before {
+        content: attr(foo string);
+    }
+    .length {
+        width: attr(foo length);
+    }
+    .px {
+        width: attr(foo px);
+    }
+    .color {
+        background-color: attr(foo color);
+    }
+</style>
+<div class="string" foo="WHF!"></div>
+<div class="length" foo="200px"></div>
+<div class="px" foo="200"></div>
+<div class="color" foo="lime"></div>
+<div class="color" foo="#00ff00"></div>

--- a/Tests/LibWeb/Ref/manifest.json
+++ b/Tests/LibWeb/Ref/manifest.json
@@ -2,6 +2,8 @@
     "clip.html": "clip-ref.html",
     "clip-abspos-children.html": "clip-abspos-children-ref.html",
     "css-any-link-selector.html": "css-any-link-selector-ref.html",
+    "css-attr-basic.html": "css-attr-ref.html",
+    "css-attr-fallback.html": "css-attr-ref.html",
     "css-gradient-currentcolor.html": "css-gradient-currentcolor-ref.html",
     "css-gradients.html": "css-gradients-ref.html",
     "css-invalid-var.html": "css-invalid-var-ref.html",

--- a/Tests/LibWeb/Ref/manifest.json
+++ b/Tests/LibWeb/Ref/manifest.json
@@ -4,6 +4,8 @@
     "css-any-link-selector.html": "css-any-link-selector-ref.html",
     "css-attr-basic.html": "css-attr-ref.html",
     "css-attr-fallback.html": "css-attr-ref.html",
+    "css-attr-typed.html": "css-attr-typed-ref.html",
+    "css-attr-typed-fallback.html": "css-attr-typed-ref.html",
     "css-gradient-currentcolor.html": "css-gradient-currentcolor-ref.html",
     "css-gradients.html": "css-gradients-ref.html",
     "css-invalid-var.html": "css-invalid-var-ref.html",

--- a/Userland/Libraries/LibWeb/CSS/Parser/Function.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Function.h
@@ -25,7 +25,7 @@ public:
 
     ~Function();
 
-    StringView name() const { return m_name; }
+    FlyString const& name() const { return m_name; }
     Vector<ComponentValue> const& values() const { return m_values; }
 
     String to_string() const;

--- a/Userland/Libraries/LibWeb/CSS/Parser/GradientParsing.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/GradientParsing.cpp
@@ -150,7 +150,7 @@ RefPtr<StyleValue> Parser::parse_linear_gradient_function(ComponentValue const& 
     GradientRepeating repeating_gradient = GradientRepeating::No;
     GradientType gradient_type { GradientType::Standard };
 
-    auto function_name = component_value.function().name();
+    auto function_name = component_value.function().name().bytes_as_string_view();
 
     function_name = consume_if_starts_with(function_name, "-webkit-"sv, [&] {
         gradient_type = GradientType::WebKit;
@@ -275,7 +275,7 @@ RefPtr<StyleValue> Parser::parse_conic_gradient_function(ComponentValue const& c
 
     GradientRepeating repeating_gradient = GradientRepeating::No;
 
-    auto function_name = component_value.function().name();
+    auto function_name = component_value.function().name().bytes_as_string_view();
 
     function_name = consume_if_starts_with(function_name, "repeating-"sv, [&] {
         repeating_gradient = GradientRepeating::Yes;
@@ -378,7 +378,7 @@ RefPtr<StyleValue> Parser::parse_radial_gradient_function(ComponentValue const& 
 
     auto repeating_gradient = GradientRepeating::No;
 
-    auto function_name = component_value.function().name();
+    auto function_name = component_value.function().name().bytes_as_string_view();
 
     function_name = consume_if_starts_with(function_name, "repeating-"sv, [&] {
         repeating_gradient = GradientRepeating::Yes;

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -1488,7 +1488,7 @@ CSSRule* Parser::convert_to_rule(NonnullRefPtr<Rule> rule)
                 return {};
             }
 
-            if (name_token.is(Token::Type::Ident) && (is_builtin(name_token.ident()) || name_token.ident().equals_ignoring_ascii_case("none"sv))) {
+            if (name_token.is(Token::Type::Ident) && (is_css_wide_keyword(name_token.ident()) || name_token.ident().equals_ignoring_ascii_case("none"sv))) {
                 dbgln_if(CSS_PARSER_DEBUG, "CSSParser: @keyframes rule name is invalid: {}; discarding.", name_token.ident());
                 return {};
             }
@@ -4246,7 +4246,7 @@ CSSRule* Parser::parse_font_face_rule(TokenStream<ComponentValue>& tokens)
                     continue;
                 }
                 if (part.is(Token::Type::Ident)) {
-                    if (is_builtin(part.token().ident())) {
+                    if (is_css_wide_keyword(part.token().ident())) {
                         dbgln_if(CSS_PARSER_DEBUG, "CSSParser: @font-face font-family format invalid; discarding.");
                         had_syntax_error = true;
                         break;
@@ -6481,13 +6481,6 @@ bool Parser::has_ignored_vendor_prefix(StringView string)
     if (string.starts_with("-libweb-"sv))
         return false;
     return true;
-}
-
-bool Parser::is_builtin(StringView name)
-{
-    return name.equals_ignoring_ascii_case("inherit"sv)
-        || name.equals_ignoring_ascii_case("initial"sv)
-        || name.equals_ignoring_ascii_case("unset"sv);
 }
 
 RefPtr<CalculatedStyleValue> Parser::parse_calculated_value(Badge<StyleComputer>, ParsingContext const& context, ComponentValue const& token)

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -68,6 +68,8 @@ public:
 
     RefPtr<StyleValue> parse_as_css_value(PropertyID);
 
+    Optional<ComponentValue> parse_as_component_value();
+
     static NonnullRefPtr<StyleValue> resolve_unresolved_style_value(Badge<StyleComputer>, ParsingContext const&, DOM::Element&, Optional<CSS::Selector::PseudoElement>, PropertyID, UnresolvedStyleValue const&);
 
     [[nodiscard]] LengthOrCalculated parse_as_sizes_attribute();

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -286,7 +286,6 @@ private:
     Optional<Supports::Feature> parse_supports_feature(TokenStream<ComponentValue>&);
 
     static bool has_ignored_vendor_prefix(StringView);
-    static bool is_builtin(StringView);
 
     struct PropertiesAndCustomProperties {
         Vector<StyleProperty> properties;

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -289,6 +289,7 @@ private:
     NonnullRefPtr<StyleValue> resolve_unresolved_style_value(DOM::Element&, Optional<Selector::PseudoElement>, PropertyID, UnresolvedStyleValue const&);
     bool expand_variables(DOM::Element&, Optional<Selector::PseudoElement>, StringView property_name, HashMap<FlyString, NonnullRefPtr<PropertyDependencyNode>>& dependencies, TokenStream<ComponentValue>& source, Vector<ComponentValue>& dest);
     bool expand_unresolved_values(DOM::Element&, StringView property_name, TokenStream<ComponentValue>& source, Vector<ComponentValue>& dest);
+    bool substitute_attr_function(DOM::Element& element, StringView property_name, Function const& attr_function, Vector<ComponentValue>& dest);
 
     static bool has_ignored_vendor_prefix(StringView);
 

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -37,6 +37,8 @@
 
 namespace Web::CSS::Parser {
 
+class PropertyDependencyNode;
+
 class Parser {
 public:
     static ErrorOr<Parser> create(ParsingContext const&, StringView input, StringView encoding = "utf-8"sv);
@@ -66,8 +68,7 @@ public:
 
     RefPtr<StyleValue> parse_as_css_value(PropertyID);
 
-    static RefPtr<StyleValue> parse_css_value(Badge<StyleComputer>, ParsingContext const&, PropertyID, Vector<ComponentValue> const&);
-    static RefPtr<CalculatedStyleValue> parse_calculated_value(Badge<StyleComputer>, ParsingContext const&, ComponentValue const&);
+    static NonnullRefPtr<StyleValue> resolve_unresolved_style_value(Badge<StyleComputer>, ParsingContext const&, DOM::Element&, Optional<CSS::Selector::PseudoElement>, PropertyID, UnresolvedStyleValue const&);
 
     [[nodiscard]] LengthOrCalculated parse_as_sizes_attribute();
 
@@ -284,6 +285,10 @@ private:
     OwnPtr<Supports::Condition> parse_supports_condition(TokenStream<ComponentValue>&);
     Optional<Supports::InParens> parse_supports_in_parens(TokenStream<ComponentValue>&);
     Optional<Supports::Feature> parse_supports_feature(TokenStream<ComponentValue>&);
+
+    NonnullRefPtr<StyleValue> resolve_unresolved_style_value(DOM::Element&, Optional<Selector::PseudoElement>, PropertyID, UnresolvedStyleValue const&);
+    bool expand_variables(DOM::Element&, Optional<Selector::PseudoElement>, StringView property_name, HashMap<FlyString, NonnullRefPtr<PropertyDependencyNode>>& dependencies, TokenStream<ComponentValue>& source, Vector<ComponentValue>& dest);
+    bool expand_unresolved_values(DOM::Element&, StringView property_name, TokenStream<ComponentValue>& source, Vector<ComponentValue>& dest);
 
     static bool has_ignored_vendor_prefix(StringView);
 

--- a/Userland/Libraries/LibWeb/CSS/Parser/Token.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Token.h
@@ -151,7 +151,7 @@ public:
     Position const& start_position() const { return m_start_position; }
     Position const& end_position() const { return m_end_position; }
 
-    static Token of_string(FlyString str)
+    static Token create_string(FlyString str)
     {
         Token token;
         token.m_type = Type::String;
@@ -181,6 +181,22 @@ public:
         token.m_type = Type::Dimension;
         token.m_number_value = Number(Number::Type::Number, value);
         token.m_value = move(unit);
+        return token;
+    }
+
+    static Token create_ident(FlyString ident)
+    {
+        Token token;
+        token.m_type = Type::Ident;
+        token.m_value = move(ident);
+        return token;
+    }
+
+    static Token create_url(FlyString url)
+    {
+        Token token;
+        token.m_type = Type::Url;
+        token.m_value = move(url);
         return token;
     }
 

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -1057,10 +1057,6 @@ bool StyleComputer::expand_variables(DOM::Element& element, Optional<CSS::Select
 
 bool StyleComputer::expand_unresolved_values(DOM::Element& element, StringView property_name, Parser::TokenStream<Parser::ComponentValue>& source, Vector<Parser::ComponentValue>& dest) const
 {
-    // FIXME: Do this better!
-    // We build a copy of the tree of ComponentValues, with all var()s and attr()s replaced with their contents.
-    // This is a very naive solution, and we could do better if the CSS Parser could accept tokens one at a time.
-
     while (source.has_next_token()) {
         auto const& value = source.next_token();
         if (value.is_function()) {
@@ -1167,6 +1163,10 @@ NonnullRefPtr<StyleValue> StyleComputer::resolve_unresolved_style_value(DOM::Ele
     VERIFY(unresolved.contains_var_or_attr());
 
     // If the value is invalid, we fall back to `unset`: https://www.w3.org/TR/css-variables-1/#invalid-at-computed-value-time
+
+    // FIXME: Do this better!
+    // We build a copy of the tree of ComponentValues, with all var()s and attr()s replaced with their contents.
+    // This is a very naive solution, and we could do better if the CSS Parser could accept tokens one at a time.
 
     Parser::TokenStream unresolved_values_without_variables_expanded { unresolved.values() };
     Vector<Parser::ComponentValue> values_with_variables_expanded;

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -1140,8 +1140,7 @@ bool StyleComputer::expand_unresolved_values(DOM::Element& element, StringView p
             Parser::TokenStream source_function_contents { source_function.values() };
             if (!expand_unresolved_values(element, property_name, source_function_contents, function_values))
                 return false;
-            // FIXME: This would be much nicer if we could access the source_function's FlyString value directly.
-            NonnullRefPtr<Parser::Function> function = Parser::Function::create(FlyString::from_utf8(source_function.name()).release_value_but_fixme_should_propagate_errors(), move(function_values));
+            NonnullRefPtr<Parser::Function> function = Parser::Function::create(source_function.name(), move(function_values));
             dest.empend(function);
             continue;
         }

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -943,247 +943,12 @@ void StyleComputer::set_all_properties(DOM::Element& element, Optional<CSS::Sele
 
         NonnullRefPtr<StyleValue> property_value = value;
         if (property_value->is_unresolved())
-            property_value = resolve_unresolved_style_value(element, pseudo_element, property_id, property_value->as_unresolved());
+            property_value = Parser::Parser::resolve_unresolved_style_value({}, Parser::ParsingContext { document }, element, pseudo_element, property_id, property_value->as_unresolved());
         if (!property_value->is_unresolved())
             set_property_expanding_shorthands(style, property_id, property_value, document, declaration, properties_for_revert);
 
         set_property_expanding_shorthands(style, property_id, value, document, declaration, properties_for_revert);
     }
-}
-
-static RefPtr<StyleValue const> get_custom_property(DOM::Element const& element, Optional<CSS::Selector::PseudoElement> pseudo_element, FlyString const& custom_property_name)
-{
-    if (pseudo_element.has_value()) {
-        if (auto it = element.custom_properties(pseudo_element).find(custom_property_name.to_string().to_deprecated_string()); it != element.custom_properties(pseudo_element).end())
-            return it->value.value;
-    }
-
-    for (auto const* current_element = &element; current_element; current_element = current_element->parent_element()) {
-        if (auto it = current_element->custom_properties({}).find(custom_property_name.to_string().to_deprecated_string()); it != current_element->custom_properties({}).end())
-            return it->value.value;
-    }
-    return nullptr;
-}
-
-bool StyleComputer::expand_variables(DOM::Element& element, Optional<CSS::Selector::PseudoElement> pseudo_element, StringView property_name, HashMap<FlyString, NonnullRefPtr<PropertyDependencyNode>>& dependencies, Parser::TokenStream<Parser::ComponentValue>& source, Vector<Parser::ComponentValue>& dest) const
-{
-    // Arbitrary large value chosen to avoid the billion-laughs attack.
-    // https://www.w3.org/TR/css-variables-1/#long-variables
-    size_t const MAX_VALUE_COUNT = 16384;
-    if (source.remaining_token_count() + dest.size() > MAX_VALUE_COUNT) {
-        dbgln("Stopped expanding CSS variables: maximum length reached.");
-        return false;
-    }
-
-    auto get_dependency_node = [&](FlyString name) -> NonnullRefPtr<PropertyDependencyNode> {
-        if (auto existing = dependencies.get(name); existing.has_value())
-            return *existing.value();
-        auto new_node = PropertyDependencyNode::create(name.to_string());
-        dependencies.set(name, new_node);
-        return new_node;
-    };
-
-    while (source.has_next_token()) {
-        auto const& value = source.next_token();
-        if (value.is_block()) {
-            auto const& source_block = value.block();
-            Vector<Parser::ComponentValue> block_values;
-            Parser::TokenStream source_block_contents { source_block.values() };
-            if (!expand_variables(element, pseudo_element, property_name, dependencies, source_block_contents, block_values))
-                return false;
-            NonnullRefPtr<Parser::Block> block = Parser::Block::create(source_block.token(), move(block_values));
-            dest.empend(block);
-            continue;
-        }
-        if (!value.is_function()) {
-            dest.empend(value);
-            continue;
-        }
-        if (!value.function().name().equals_ignoring_ascii_case("var"sv)) {
-            auto const& source_function = value.function();
-            Vector<Parser::ComponentValue> function_values;
-            Parser::TokenStream source_function_contents { source_function.values() };
-            if (!expand_variables(element, pseudo_element, property_name, dependencies, source_function_contents, function_values))
-                return false;
-            NonnullRefPtr<Parser::Function> function = Parser::Function::create(FlyString::from_utf8(source_function.name()).release_value_but_fixme_should_propagate_errors(), move(function_values));
-            dest.empend(function);
-            continue;
-        }
-
-        Parser::TokenStream var_contents { value.function().values() };
-        var_contents.skip_whitespace();
-        if (!var_contents.has_next_token())
-            return false;
-
-        auto const& custom_property_name_token = var_contents.next_token();
-        if (!custom_property_name_token.is(Parser::Token::Type::Ident))
-            return false;
-        auto custom_property_name = custom_property_name_token.token().ident();
-        if (!custom_property_name.starts_with("--"sv))
-            return false;
-
-        // Detect dependency cycles. https://www.w3.org/TR/css-variables-1/#cycles
-        // We do not do this by the spec, since we are not keeping a graph of var dependencies around,
-        // but rebuilding it every time.
-        if (custom_property_name == property_name)
-            return false;
-        auto parent = get_dependency_node(FlyString::from_utf8(property_name).release_value_but_fixme_should_propagate_errors());
-        auto child = get_dependency_node(FlyString::from_utf8(custom_property_name).release_value_but_fixme_should_propagate_errors());
-        parent->add_child(child);
-        if (parent->has_cycles())
-            return false;
-
-        if (auto custom_property_value = get_custom_property(element, pseudo_element, FlyString::from_utf8(custom_property_name).release_value_but_fixme_should_propagate_errors())) {
-            VERIFY(custom_property_value->is_unresolved());
-            Parser::TokenStream custom_property_tokens { custom_property_value->as_unresolved().values() };
-            if (!expand_variables(element, pseudo_element, custom_property_name, dependencies, custom_property_tokens, dest))
-                return false;
-            continue;
-        }
-
-        // Use the provided fallback value, if any.
-        var_contents.skip_whitespace();
-        if (var_contents.has_next_token()) {
-            auto const& comma_token = var_contents.next_token();
-            if (!comma_token.is(Parser::Token::Type::Comma))
-                return false;
-            var_contents.skip_whitespace();
-            if (!expand_variables(element, pseudo_element, property_name, dependencies, var_contents, dest))
-                return false;
-        }
-    }
-    return true;
-}
-
-bool StyleComputer::expand_unresolved_values(DOM::Element& element, StringView property_name, Parser::TokenStream<Parser::ComponentValue>& source, Vector<Parser::ComponentValue>& dest) const
-{
-    while (source.has_next_token()) {
-        auto const& value = source.next_token();
-        if (value.is_function()) {
-            if (value.function().name().equals_ignoring_ascii_case("attr"sv)) {
-                // https://drafts.csswg.org/css-values-5/#attr-substitution
-                Parser::TokenStream attr_contents { value.function().values() };
-                attr_contents.skip_whitespace();
-                if (!attr_contents.has_next_token())
-                    return false;
-
-                auto const& attr_name_token = attr_contents.next_token();
-                if (!attr_name_token.is(Parser::Token::Type::Ident))
-                    return false;
-                auto attr_name = attr_name_token.token().ident();
-
-                auto attr_value = element.get_attribute(attr_name);
-                // 1. If the attr() function has a substitution value, replace the attr() function by the substitution value.
-                if (!attr_value.is_null()) {
-                    // FIXME: attr() should also accept an optional type argument, not just strings.
-                    dest.empend(Parser::Token::of_string(FlyString::from_deprecated_fly_string(attr_value).release_value_but_fixme_should_propagate_errors()));
-                    continue;
-                }
-
-                // 2. Otherwise, if the attr() function has a fallback value as its last argument, replace the attr() function by the fallback value.
-                //    If there are any var() or attr() references in the fallback, substitute them as well.
-                attr_contents.skip_whitespace();
-                if (attr_contents.has_next_token()) {
-                    auto const& comma_token = attr_contents.next_token();
-                    if (!comma_token.is(Parser::Token::Type::Comma))
-                        return false;
-                    attr_contents.skip_whitespace();
-                    if (!expand_unresolved_values(element, property_name, attr_contents, dest))
-                        return false;
-                    continue;
-                }
-
-                // 3. Otherwise, the property containing the attr() function is invalid at computed-value time.
-                return false;
-            }
-
-            if (auto maybe_calc_value = Parser::Parser::parse_calculated_value({}, Parser::ParsingContext { document() }, value); maybe_calc_value && maybe_calc_value->is_calculated()) {
-                auto& calc_value = maybe_calc_value->as_calculated();
-                if (calc_value.resolves_to_angle()) {
-                    auto resolved_value = calc_value.resolve_angle();
-                    dest.empend(Parser::Token::create_dimension(resolved_value->to_degrees(), "deg"_fly_string));
-                    continue;
-                }
-                if (calc_value.resolves_to_frequency()) {
-                    auto resolved_value = calc_value.resolve_frequency();
-                    dest.empend(Parser::Token::create_dimension(resolved_value->to_hertz(), "hz"_fly_string));
-                    continue;
-                }
-                if (calc_value.resolves_to_length()) {
-                    // FIXME: In order to resolve lengths, we need to know the font metrics in case a font-relative unit
-                    //  is used. So... we can't do that until style is computed?
-                    //  This might be easier once we have calc-simplification implemented.
-                }
-                if (calc_value.resolves_to_percentage()) {
-                    auto resolved_value = calc_value.resolve_percentage();
-                    dest.empend(Parser::Token::create_percentage(resolved_value.value().value()));
-                    continue;
-                }
-                if (calc_value.resolves_to_time()) {
-                    auto resolved_value = calc_value.resolve_time();
-                    dest.empend(Parser::Token::create_dimension(resolved_value->to_seconds(), "s"_fly_string));
-                    continue;
-                }
-                if (calc_value.resolves_to_number()) {
-                    auto resolved_value = calc_value.resolve_number();
-                    dest.empend(Parser::Token::create_number(resolved_value.value()));
-                    continue;
-                }
-            }
-
-            auto const& source_function = value.function();
-            Vector<Parser::ComponentValue> function_values;
-            Parser::TokenStream source_function_contents { source_function.values() };
-            if (!expand_unresolved_values(element, property_name, source_function_contents, function_values))
-                return false;
-            NonnullRefPtr<Parser::Function> function = Parser::Function::create(source_function.name(), move(function_values));
-            dest.empend(function);
-            continue;
-        }
-        if (value.is_block()) {
-            auto const& source_block = value.block();
-            Parser::TokenStream source_block_values { source_block.values() };
-            Vector<Parser::ComponentValue> block_values;
-            if (!expand_unresolved_values(element, property_name, source_block_values, block_values))
-                return false;
-            NonnullRefPtr<Parser::Block> block = Parser::Block::create(source_block.token(), move(block_values));
-            dest.empend(move(block));
-            continue;
-        }
-        dest.empend(value.token());
-    }
-
-    return true;
-}
-
-NonnullRefPtr<StyleValue> StyleComputer::resolve_unresolved_style_value(DOM::Element& element, Optional<CSS::Selector::PseudoElement> pseudo_element, PropertyID property_id, UnresolvedStyleValue const& unresolved) const
-{
-    // Unresolved always contains a var() or attr(), unless it is a custom property's value, in which case we shouldn't be trying
-    // to produce a different StyleValue from it.
-    VERIFY(unresolved.contains_var_or_attr());
-
-    // If the value is invalid, we fall back to `unset`: https://www.w3.org/TR/css-variables-1/#invalid-at-computed-value-time
-
-    // FIXME: Do this better!
-    // We build a copy of the tree of ComponentValues, with all var()s and attr()s replaced with their contents.
-    // This is a very naive solution, and we could do better if the CSS Parser could accept tokens one at a time.
-
-    Parser::TokenStream unresolved_values_without_variables_expanded { unresolved.values() };
-    Vector<Parser::ComponentValue> values_with_variables_expanded;
-
-    HashMap<FlyString, NonnullRefPtr<PropertyDependencyNode>> dependencies;
-    if (!expand_variables(element, pseudo_element, string_from_property_id(property_id), dependencies, unresolved_values_without_variables_expanded, values_with_variables_expanded))
-        return UnsetStyleValue::the();
-
-    Parser::TokenStream unresolved_values_with_variables_expanded { values_with_variables_expanded };
-    Vector<Parser::ComponentValue> expanded_values;
-    if (!expand_unresolved_values(element, string_from_property_id(property_id), unresolved_values_with_variables_expanded, expanded_values))
-        return UnsetStyleValue::the();
-
-    if (auto parsed_value = Parser::Parser::parse_css_value({}, Parser::ParsingContext { document() }, property_id, expanded_values))
-        return parsed_value.release_nonnull();
-
-    return UnsetStyleValue::the();
 }
 
 void StyleComputer::cascade_declarations(StyleProperties& style, DOM::Element& element, Optional<CSS::Selector::PseudoElement> pseudo_element, Vector<MatchingRule> const& matching_rules, CascadeOrigin cascade_origin, Important important) const
@@ -1202,7 +967,7 @@ void StyleComputer::cascade_declarations(StyleProperties& style, DOM::Element& e
 
             auto property_value = property.value;
             if (property.value->is_unresolved())
-                property_value = resolve_unresolved_style_value(element, pseudo_element, property.property_id, property.value->as_unresolved());
+                property_value = Parser::Parser::resolve_unresolved_style_value({}, Parser::ParsingContext { document() }, element, pseudo_element, property.property_id, property.value->as_unresolved());
             if (!property_value->is_unresolved())
                 set_property_expanding_shorthands(style, property.property_id, property_value, m_document, &match.rule->declaration(), properties_for_revert);
         }
@@ -1221,7 +986,7 @@ void StyleComputer::cascade_declarations(StyleProperties& style, DOM::Element& e
 
                 auto property_value = property.value;
                 if (property.value->is_unresolved())
-                    property_value = resolve_unresolved_style_value(element, pseudo_element, property.property_id, property.value->as_unresolved());
+                    property_value = Parser::Parser::resolve_unresolved_style_value({}, Parser::ParsingContext { document() }, element, pseudo_element, property.property_id, property.value->as_unresolved());
                 if (!property_value->is_unresolved())
                     set_property_expanding_shorthands(style, property.property_id, property_value, m_document, inline_style, properties_for_revert);
             }
@@ -1767,7 +1532,7 @@ ErrorOr<void> StyleComputer::compute_cascaded_values(StyleProperties& style, DOM
                 auto property_id = (CSS::PropertyID)i;
                 auto& property = style.m_property_values[i];
                 if (property.has_value() && property->style->is_unresolved())
-                    property->style = resolve_unresolved_style_value(element, pseudo_element, property_id, property->style->as_unresolved());
+                    property->style = Parser::Parser::resolve_unresolved_style_value({}, Parser::ParsingContext { document() }, element, pseudo_element, property_id, property->style->as_unresolved());
             }
         }
     }
@@ -2565,36 +2330,6 @@ ErrorOr<RefPtr<StyleProperties>> StyleComputer::compute_style_impl(DOM::Element&
     transform_box_type_if_needed(style, element, pseudo_element);
 
     return style;
-}
-
-PropertyDependencyNode::PropertyDependencyNode(String name)
-    : m_name(move(name))
-{
-}
-
-void PropertyDependencyNode::add_child(NonnullRefPtr<PropertyDependencyNode> new_child)
-{
-    for (auto const& child : m_children) {
-        if (child->m_name == new_child->m_name)
-            return;
-    }
-
-    // We detect self-reference already.
-    VERIFY(new_child->m_name != m_name);
-    m_children.append(move(new_child));
-}
-
-bool PropertyDependencyNode::has_cycles()
-{
-    if (m_marked)
-        return true;
-
-    TemporaryChange change { m_marked, true };
-    for (auto& child : m_children) {
-        if (child->has_cycles())
-            return true;
-    }
-    return false;
 }
 
 void StyleComputer::build_rule_cache_if_needed() const

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.h
@@ -14,8 +14,6 @@
 #include <LibWeb/CSS/CSSFontFaceRule.h>
 #include <LibWeb/CSS/CSSKeyframesRule.h>
 #include <LibWeb/CSS/CSSStyleDeclaration.h>
-#include <LibWeb/CSS/Parser/ComponentValue.h>
-#include <LibWeb/CSS/Parser/TokenStream.h>
 #include <LibWeb/CSS/Selector.h>
 #include <LibWeb/CSS/StyleProperties.h>
 #include <LibWeb/FontCache.h>
@@ -31,24 +29,6 @@ struct MatchingRule {
     size_t selector_index { 0 };
     u32 specificity { 0 };
     bool contains_pseudo_element { false };
-};
-
-class PropertyDependencyNode : public RefCounted<PropertyDependencyNode> {
-public:
-    static NonnullRefPtr<PropertyDependencyNode> create(String name)
-    {
-        return adopt_ref(*new PropertyDependencyNode(move(name)));
-    }
-
-    void add_child(NonnullRefPtr<PropertyDependencyNode>);
-    bool has_cycles();
-
-private:
-    explicit PropertyDependencyNode(String name);
-
-    String m_name;
-    Vector<NonnullRefPtr<PropertyDependencyNode>> m_children;
-    bool m_marked { false };
 };
 
 struct FontFaceKey {
@@ -152,10 +132,6 @@ private:
     void transform_box_type_if_needed(StyleProperties&, DOM::Element const&, Optional<CSS::Selector::PseudoElement>) const;
 
     void compute_defaulted_property_value(StyleProperties&, DOM::Element const*, CSS::PropertyID, Optional<CSS::Selector::PseudoElement>) const;
-
-    NonnullRefPtr<StyleValue> resolve_unresolved_style_value(DOM::Element&, Optional<CSS::Selector::PseudoElement>, PropertyID, UnresolvedStyleValue const&) const;
-    bool expand_variables(DOM::Element&, Optional<CSS::Selector::PseudoElement>, StringView property_name, HashMap<FlyString, NonnullRefPtr<PropertyDependencyNode>>& dependencies, Parser::TokenStream<Parser::ComponentValue>& source, Vector<Parser::ComponentValue>& dest) const;
-    bool expand_unresolved_values(DOM::Element&, StringView property_name, Parser::TokenStream<Parser::ComponentValue>& source, Vector<Parser::ComponentValue>& dest) const;
 
     void set_all_properties(DOM::Element&, Optional<CSS::Selector::PseudoElement>, StyleProperties&, StyleValue const&, DOM::Document&, CSS::CSSStyleDeclaration const*, StyleProperties::PropertyValues const& properties_for_revert) const;
 


### PR DESCRIPTION
This lets you specify what type to parse the attribute's contents as. For example, this HTML (from a new test):

```html
<!doctype html>
<style>
    div {
        width: 100px;
        height: 20px;
        border: 1px solid black;
    }
    .string::before {
        content: attr(foo string);
    }
    .length {
        width: attr(foo length);
    }
    .px {
        width: attr(foo px);
    }
    .color {
        background-color: attr(foo color);
    }
</style>
<div class="string" foo="WHF!"></div>
<div class="length" foo="200px"></div>
<div class="px" foo="200"></div>
<div class="color" foo="lime"></div>
<div class="color" foo="#00ff00"></div>
```
...looks like this!

![image](https://github.com/SerenityOS/serenity/assets/222642/f86fa5d5-f647-4b22-bd16-04fe4bf6c499)

Can't currently compare this with any other browsers, because [they don't support it](https://caniuse.com/?search=attr()). :buffie: