### PR TITLE
LibWeb: Perform rounding when dividing `CSSPixels`

### DIFF
--- a/Tests/LibWeb/Layout/expected/abspos-box-with-replaced-element.txt
+++ b/Tests/LibWeb/Layout/expected/abspos-box-with-replaced-element.txt
@@ -1,13 +1,13 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (1,1) content-size 798x0 [BFC] children: not-inline
     BlockContainer <body> at (10,10) content-size 500x100 positioned [BFC] children: not-inline
-      BlockContainer <div.image-container> at (261,11) content-size 248x28.46875 positioned [BFC] children: inline
-        line 0 width: 250, height: 28.46875, bottom: 28.46875, baseline: 28.46875
-          frag 0 from ImageBox start: 0, length: 0, rect: [262,12 248x26.46875]
-        ImageBox <img> at (262,12) content-size 248x26.46875 children: not-inline
+      BlockContainer <div.image-container> at (261,11) content-size 248x28.484375 positioned [BFC] children: inline
+        line 0 width: 250, height: 28.484375, bottom: 28.484375, baseline: 28.484375
+          frag 0 from ImageBox start: 0, length: 0, rect: [262,12 248x26.484375]
+        ImageBox <img> at (262,12) content-size 248x26.484375 children: not-inline
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x2] overflow: [9,9 502x102]
     PaintableWithLines (BlockContainer<BODY>) [9,9 502x102]
-      PaintableWithLines (BlockContainer<DIV>.image-container) [260,10 250x30.46875] overflow: [261,11 249x28.46875]
-        ImagePaintable (ImageBox<IMG>) [261,11 250x28.46875]
+      PaintableWithLines (BlockContainer<DIV>.image-container) [260,10 250x30.484375] overflow: [261,11 249x28.484375]
+        ImagePaintable (ImageBox<IMG>) [261,11 250x28.484375]

--- a/Tests/LibWeb/Layout/expected/acid1.txt
+++ b/Tests/LibWeb/Layout/expected/acid1.txt
@@ -7,7 +7,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
       BlockContainer <dl> at (25,25) content-size 470x0 children: inline
         TextNode <#text>
-        BlockContainer <dt> at (40,40) content-size 49.984375x280 floating [BFC] children: inline
+        BlockContainer <dt> at (40,40) content-size 50x280 floating [BFC] children: inline
           line 0 width: 28.3125, height: 10, bottom: 10, baseline: 8
             frag 0 from TextNode start: 0, length: 6, rect: [40,40 28.3125x10]
               "toggle"
@@ -24,21 +24,21 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                   "the way"
               TextNode <#text>
             TextNode <#text>
-            BlockContainer <li#bar> at (235,55) content-size 139.96875x90 floating [BFC] children: not-inline
-              BlockContainer <(anonymous)> at (235,55) content-size 139.96875x0 children: inline
+            BlockContainer <li#bar> at (235,55) content-size 139.984375x90 floating [BFC] children: not-inline
+              BlockContainer <(anonymous)> at (235,55) content-size 139.984375x0 children: inline
                 TextNode <#text>
-              BlockContainer <p> at (235,55) content-size 139.96875x10 children: inline
+              BlockContainer <p> at (235,55) content-size 139.984375x10 children: inline
                 line 0 width: 74.3125, height: 10, bottom: 10, baseline: 8
                   frag 0 from TextNode start: 0, length: 14, rect: [235,55 74.3125x10]
                     "the world ends"
                 TextNode <#text>
-              BlockContainer <(anonymous)> at (235,65) content-size 139.96875x0 children: inline
+              BlockContainer <(anonymous)> at (235,65) content-size 139.984375x0 children: inline
                 TextNode <#text>
                 InlineNode <form>
                   TextNode <#text>
                   TextNode <#text>
                   TextNode <#text>
-              BlockContainer <p> at (235,65) content-size 139.96875x19 children: inline
+              BlockContainer <p> at (235,65) content-size 139.984375x19 children: inline
                 line 0 width: 39.484375, height: 19, bottom: 19, baseline: 12.5
                   frag 0 from TextNode start: 1, length: 5, rect: [235,65 27.484375x19]
                     "bang "
@@ -46,7 +46,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 TextNode <#text>
                 RadioButton <input> at (262,65) content-size 12x12 inline-block children: not-inline
                 TextNode <#text>
-              BlockContainer <p> at (235,84) content-size 139.96875x19 children: inline
+              BlockContainer <p> at (235,84) content-size 139.984375x19 children: inline
                 line 0 width: 57.15625, height: 19, bottom: 19, baseline: 12.5
                   frag 0 from TextNode start: 1, length: 8, rect: [235,84 45.15625x19]
                     "whimper "
@@ -54,15 +54,15 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 TextNode <#text>
                 RadioButton <input> at (280,84) content-size 12x12 inline-block children: not-inline
                 TextNode <#text>
-              BlockContainer <(anonymous)> at (235,103) content-size 139.96875x0 children: inline
+              BlockContainer <(anonymous)> at (235,103) content-size 139.984375x0 children: inline
                 TextNode <#text>
             TextNode <#text>
-            BlockContainer <li> at (409.96875,60) content-size 50x90 floating [BFC] children: inline
+            BlockContainer <li> at (409.984375,60) content-size 50x90 floating [BFC] children: inline
               line 0 width: 31.578125, height: 10, bottom: 10, baseline: 8
-                frag 0 from TextNode start: 0, length: 6, rect: [409.96875,60 31.578125x10]
+                frag 0 from TextNode start: 0, length: 6, rect: [409.984375,60 31.578125x10]
                   "i grow"
               line 1 width: 14.03125, height: 10, bottom: 20, baseline: 8
-                frag 0 from TextNode start: 7, length: 3, rect: [409.96875,70 14.03125x10]
+                frag 0 from TextNode start: 7, length: 3, rect: [409.984375,70 14.03125x10]
                   "old"
               TextNode <#text>
             TextNode <#text>
@@ -140,27 +140,27 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [15,15 490x390]
       PaintableWithLines (BlockContainer(anonymous)) [20,20 480x0]
       PaintableWithLines (BlockContainer<DL>) [20,20 480x10]
-        PaintableWithLines (BlockContainer<DT>) [25,25 79.984375x310]
+        PaintableWithLines (BlockContainer<DT>) [25,25 80x310]
           TextPaintable (TextNode<#text>)
         PaintableWithLines (BlockContainer<DD>) [115,25 380x310]
           PaintableWithLines (BlockContainer(anonymous)) [135,45 340x0]
           PaintableWithLines (BlockContainer<UL>) [135,45 340x0]
             PaintableWithLines (BlockContainer<LI>) [135,45 80x120]
               TextPaintable (TextNode<#text>)
-            PaintableWithLines (BlockContainer<LI>#bar) [225,45 159.96875x110]
-              PaintableWithLines (BlockContainer(anonymous)) [235,55 139.96875x0]
-              PaintableWithLines (BlockContainer<P>) [235,55 139.96875x10]
+            PaintableWithLines (BlockContainer<LI>#bar) [225,45 159.984375x110]
+              PaintableWithLines (BlockContainer(anonymous)) [235,55 139.984375x0]
+              PaintableWithLines (BlockContainer<P>) [235,55 139.984375x10]
                 TextPaintable (TextNode<#text>)
-              PaintableWithLines (BlockContainer(anonymous)) [235,65 139.96875x0]
+              PaintableWithLines (BlockContainer(anonymous)) [235,65 139.984375x0]
                 InlinePaintable (InlineNode<FORM>)
-              PaintableWithLines (BlockContainer<P>) [235,65 139.96875x19]
+              PaintableWithLines (BlockContainer<P>) [235,65 139.984375x19]
                 TextPaintable (TextNode<#text>)
                 RadioButtonPaintable (RadioButton<INPUT>) [262,65 12x12]
-              PaintableWithLines (BlockContainer<P>) [235,84 139.96875x19]
+              PaintableWithLines (BlockContainer<P>) [235,84 139.984375x19]
                 TextPaintable (TextNode<#text>)
                 RadioButtonPaintable (RadioButton<INPUT>) [280,84 12x12]
-              PaintableWithLines (BlockContainer(anonymous)) [235,103 139.96875x0]
-            PaintableWithLines (BlockContainer<LI>) [394.96875,45 80x120]
+              PaintableWithLines (BlockContainer(anonymous)) [235,103 139.984375x0]
+            PaintableWithLines (BlockContainer<LI>) [394.984375,45 80x120]
               TextPaintable (TextNode<#text>)
             PaintableWithLines (BlockContainer<LI>#baz) [135,175 120x120]
               TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/block-and-inline/button-baseline-align.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/button-baseline-align.txt
@@ -1,10 +1,10 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x47.671875 children: inline
-      line 0 width: 61.1875, height: 47.671875, bottom: 47.671875, baseline: 35.828125
+      line 0 width: 61.1875, height: 47.671875, bottom: 47.671875, baseline: 35.84375
         frag 0 from BlockContainer start: 0, length: 0, rect: [8,8 61.1875x47.671875]
       BlockContainer <div.ib> at (8,8) content-size 61.1875x47.671875 inline-block [BFC] children: inline
-        line 0 width: 61.1875, height: 47.671875, bottom: 47.671875, baseline: 35.828125
+        line 0 width: 61.1875, height: 47.671875, bottom: 47.671875, baseline: 35.84375
           frag 0 from BlockContainer start: 0, length: 0, rect: [9,26 17.828125x21.84375]
           frag 1 from TextNode start: 0, length: 1, rect: [28,30 8x17.46875]
             " "
@@ -17,11 +17,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
         TextNode <#text>
         BlockContainer <button> at (41,10) content-size 23.359375x43.671875 inline-block [BFC] children: inline
-          line 0 width: 23.359375, height: 43.671875, bottom: 43.671875, baseline: 33.828125
-            frag 0 from BlockContainer start: 0, length: 0, rect: [41,10 23.359375x43.671875]
-          BlockContainer <(anonymous)> at (41,10) content-size 23.359375x43.671875 flex-container(column) [FFC] children: not-inline
-            BlockContainer <(anonymous)> at (41,10) content-size 23.359375x43.671875 flex-item [BFC] children: inline
-              line 0 width: 23.359375, height: 43.671875, bottom: 43.671875, baseline: 33.828125
+          line 0 width: 23.359375, height: 43.671875, bottom: 43.671875, baseline: 33.84375
+            frag 0 from BlockContainer start: 0, length: 0, rect: [41,10 23.359375x43.6875]
+          BlockContainer <(anonymous)> at (41,10) content-size 23.359375x43.6875 flex-container(column) [FFC] children: not-inline
+            BlockContainer <(anonymous)> at (41,10) content-size 23.359375x43.6875 flex-item [BFC] children: inline
+              line 0 width: 23.359375, height: 43.6875, bottom: 43.6875, baseline: 33.84375
                 frag 0 from TextNode start: 0, length: 1, rect: [41,10 23.359375x43.671875]
                   "B"
               TextNode <#text>
@@ -35,6 +35,6 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           TextPaintable (TextNode<#text>)
         TextPaintable (TextNode<#text>)
         PaintableWithLines (BlockContainer<BUTTON>) [36,8 33.359375x47.671875]
-          PaintableWithLines (BlockContainer(anonymous)) [41,10 23.359375x43.671875]
-            PaintableWithLines (BlockContainer(anonymous)) [41,10 23.359375x43.671875]
+          PaintableWithLines (BlockContainer(anonymous)) [41,10 23.359375x43.6875]
+            PaintableWithLines (BlockContainer(anonymous)) [41,10 23.359375x43.6875]
               TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/block-and-inline/button-with-block-content-baseline-align.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/button-with-block-content-baseline-align.txt
@@ -1,14 +1,14 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
-    BlockContainer <body> at (8,8) content-size 784x47.671875 children: inline
-      line 0 width: 61.1875, height: 47.671875, bottom: 47.671875, baseline: 33.828125
-        frag 0 from BlockContainer start: 0, length: 0, rect: [8,8 61.1875x47.671875]
-      BlockContainer <div.ib> at (8,8) content-size 61.1875x47.671875 inline-block [BFC] children: inline
-        line 0 width: 61.1875, height: 47.671875, bottom: 47.671875, baseline: 33.828125
+    BlockContainer <body> at (8,8) content-size 784x47.6875 children: inline
+      line 0 width: 61.1875, height: 47.6875, bottom: 47.6875, baseline: 33.84375
+        frag 0 from BlockContainer start: 0, length: 0, rect: [8,8 61.1875x47.6875]
+      BlockContainer <div.ib> at (8,8) content-size 61.1875x47.6875 inline-block [BFC] children: inline
+        line 0 width: 61.1875, height: 47.6875, bottom: 47.6875, baseline: 33.84375
           frag 0 from BlockContainer start: 0, length: 0, rect: [9,24 17.828125x21.84375]
           frag 1 from TextNode start: 0, length: 1, rect: [28,28 8x17.46875]
             " "
-          frag 2 from BlockContainer start: 0, length: 0, rect: [41,10 23.359375x43.671875]
+          frag 2 from BlockContainer start: 0, length: 0, rect: [41,10 23.359375x43.6875]
         TextNode <#text>
         BlockContainer <div.label> at (9,24) content-size 17.828125x21.84375 inline-block [BFC] children: inline
           line 0 width: 17.828125, height: 21.84375, bottom: 21.84375, baseline: 16.921875
@@ -16,31 +16,31 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               "A"
           TextNode <#text>
         TextNode <#text>
-        BlockContainer <button> at (41,10) content-size 23.359375x43.671875 inline-block [BFC] children: not-inline
-          BlockContainer <(anonymous)> at (41,10) content-size 23.359375x43.671875 flex-container(column) [FFC] children: not-inline
-            BlockContainer <(anonymous)> at (41,10) content-size 23.359375x43.671875 flex-item [BFC] children: not-inline
+        BlockContainer <button> at (41,10) content-size 23.359375x43.6875 inline-block [BFC] children: not-inline
+          BlockContainer <(anonymous)> at (41,10) content-size 23.359375x43.6875 flex-container(column) [FFC] children: not-inline
+            BlockContainer <(anonymous)> at (41,10) content-size 23.359375x43.6875 flex-item [BFC] children: not-inline
               BlockContainer <(anonymous)> at (41,10) content-size 23.359375x0 children: inline
                 TextNode <#text>
-              BlockContainer <div> at (41,10) content-size 23.359375x43.671875 children: inline
-                line 0 width: 23.359375, height: 43.671875, bottom: 43.671875, baseline: 33.828125
+              BlockContainer <div> at (41,10) content-size 23.359375x43.6875 children: inline
+                line 0 width: 23.359375, height: 43.6875, bottom: 43.6875, baseline: 33.84375
                   frag 0 from TextNode start: 0, length: 1, rect: [41,10 23.359375x43.671875]
                     "B"
                 TextNode <#text>
-              BlockContainer <(anonymous)> at (41,53.671875) content-size 23.359375x0 children: inline
+              BlockContainer <(anonymous)> at (41,53.6875) content-size 23.359375x0 children: inline
                 TextNode <#text>
         TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
-    PaintableWithLines (BlockContainer<BODY>) [8,8 784x47.671875]
-      PaintableWithLines (BlockContainer<DIV>.ib) [8,8 61.1875x47.671875]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x47.6875]
+      PaintableWithLines (BlockContainer<DIV>.ib) [8,8 61.1875x47.6875]
         PaintableWithLines (BlockContainer<DIV>.label) [8,23 19.828125x23.84375]
           TextPaintable (TextNode<#text>)
         TextPaintable (TextNode<#text>)
-        PaintableWithLines (BlockContainer<BUTTON>) [36,8 33.359375x47.671875]
-          PaintableWithLines (BlockContainer(anonymous)) [41,10 23.359375x43.671875]
-            PaintableWithLines (BlockContainer(anonymous)) [41,10 23.359375x43.671875]
+        PaintableWithLines (BlockContainer<BUTTON>) [36,8 33.359375x47.6875]
+          PaintableWithLines (BlockContainer(anonymous)) [41,10 23.359375x43.6875]
+            PaintableWithLines (BlockContainer(anonymous)) [41,10 23.359375x43.6875]
               PaintableWithLines (BlockContainer(anonymous)) [41,10 23.359375x0]
-              PaintableWithLines (BlockContainer<DIV>) [41,10 23.359375x43.671875]
+              PaintableWithLines (BlockContainer<DIV>) [41,10 23.359375x43.6875]
                 TextPaintable (TextNode<#text>)
-              PaintableWithLines (BlockContainer(anonymous)) [41,53.671875 23.359375x0]
+              PaintableWithLines (BlockContainer(anonymous)) [41,53.6875 23.359375x0]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/float-left-and-right-with-justified-text-in-between.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/float-left-and-right-with-justified-text-in-between.txt
@@ -40,13 +40,13 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       line 4 width: 196.703125, height: 22.21875, bottom: 109.59375, baseline: 16.921875
         frag 0 from TextNode start: 72, length: 8, rect: [554,97 82.046875x21.84375]
           "placerat"
-        frag 1 from TextNode start: 80, length: 1, rect: [636,97 29.640625x21.84375]
+        frag 1 from TextNode start: 80, length: 1, rect: [636,97 29.65625x21.84375]
           " "
-        frag 2 from TextNode start: 81, length: 7, rect: [665.640625,97 73.875x21.84375]
+        frag 2 from TextNode start: 81, length: 7, rect: [665.65625,97 73.875x21.84375]
           "mauris,"
-        frag 3 from TextNode start: 88, length: 1, rect: [739.640625,97 29.640625x21.84375]
+        frag 3 from TextNode start: 88, length: 1, rect: [739.65625,97 29.65625x21.84375]
           " "
-        frag 4 from TextNode start: 89, length: 2, rect: [769.28125,97 20.78125x21.84375]
+        frag 4 from TextNode start: 89, length: 2, rect: [769.3125,97 20.78125x21.84375]
           "ut"
       line 5 width: 234.6875, height: 22.0625, bottom: 131.28125, baseline: 16.921875
         frag 0 from TextNode start: 92, length: 9, rect: [554,119 101.28125x21.84375]
@@ -88,29 +88,29 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       line 8 width: 202.96875, height: 22.59375, bottom: 197.34375, baseline: 16.921875
         frag 0 from TextNode start: 160, length: 6, rect: [554,184 70.3125x21.84375]
           "rutrum"
-        frag 1 from TextNode start: 166, length: 1, rect: [624,184 21x21.84375]
+        frag 1 from TextNode start: 166, length: 1, rect: [624,184 21.015625x21.84375]
           " "
-        frag 2 from TextNode start: 167, length: 4, rect: [645,184 35.09375x21.84375]
+        frag 2 from TextNode start: 167, length: 4, rect: [645.015625,184 35.09375x21.84375]
           "nisi"
-        frag 3 from TextNode start: 171, length: 1, rect: [680,184 21x21.84375]
+        frag 3 from TextNode start: 171, length: 1, rect: [680.015625,184 21.015625x21.84375]
           " "
-        frag 4 from TextNode start: 172, length: 4, rect: [701,184 39.828125x21.84375]
+        frag 4 from TextNode start: 172, length: 4, rect: [701.03125,184 39.828125x21.84375]
           "eget"
-        frag 5 from TextNode start: 176, length: 1, rect: [741,184 21x21.84375]
+        frag 5 from TextNode start: 176, length: 1, rect: [741.03125,184 21.015625x21.84375]
           " "
-        frag 6 from TextNode start: 177, length: 3, rect: [762,184 27.734375x21.84375]
+        frag 6 from TextNode start: 177, length: 3, rect: [762.046875,184 27.734375x21.84375]
           "dui"
       line 9 width: 0, height: 0, bottom: 0, baseline: 0
       line 10 width: 208.828125, height: 22.4375, bottom: 225.03125, baseline: 16.921875
         frag 0 from TextNode start: 181, length: 7, rect: [252,212 68.984375x21.84375]
           "dictum,"
-        frag 1 from TextNode start: 188, length: 1, rect: [321,212 23.578125x21.84375]
+        frag 1 from TextNode start: 188, length: 1, rect: [321,212 23.59375x21.84375]
           " "
-        frag 2 from TextNode start: 189, length: 2, rect: [344.578125,212 23.109375x21.84375]
+        frag 2 from TextNode start: 189, length: 2, rect: [344.59375,212 23.109375x21.84375]
           "eu"
-        frag 3 from TextNode start: 191, length: 1, rect: [367.578125,212 23.578125x21.84375]
+        frag 3 from TextNode start: 191, length: 1, rect: [367.59375,212 23.59375x21.84375]
           " "
-        frag 4 from TextNode start: 192, length: 8, rect: [391.15625,212 96.734375x21.84375]
+        frag 4 from TextNode start: 192, length: 8, rect: [391.1875,212 96.734375x21.84375]
           "accumsan"
       line 11 width: 180.1875, height: 22.28125, bottom: 246.71875, baseline: 16.921875
         frag 0 from TextNode start: 201, length: 4, rect: [252,234 43.875x21.84375]
@@ -137,13 +137,13 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       line 13 width: 222.921875, height: 21.96875, bottom: 290.09375, baseline: 16.921875
         frag 0 from TextNode start: 240, length: 3, rect: [252,278 31.15625x21.84375]
           "est"
-        frag 1 from TextNode start: 243, length: 1, rect: [283,278 16.53125x21.84375]
+        frag 1 from TextNode start: 243, length: 1, rect: [283,278 16.546875x21.84375]
           " "
-        frag 2 from TextNode start: 244, length: 9, rect: [299.53125,278 91.46875x21.84375]
+        frag 2 from TextNode start: 244, length: 9, rect: [299.546875,278 91.46875x21.84375]
           "vulputate"
-        frag 3 from TextNode start: 253, length: 1, rect: [391.53125,278 16.53125x21.84375]
+        frag 3 from TextNode start: 253, length: 1, rect: [391.546875,278 16.546875x21.84375]
           " "
-        frag 4 from TextNode start: 254, length: 8, rect: [408.0625,278 80.296875x21.84375]
+        frag 4 from TextNode start: 254, length: 8, rect: [408.09375,278 80.296875x21.84375]
           "egestas."
       line 14 width: 223.125, height: 22.8125, bottom: 312.78125, baseline: 16.921875
         frag 0 from TextNode start: 263, length: 7, rect: [252,299 68.609375x21.84375]
@@ -159,13 +159,13 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       line 15 width: 222.609375, height: 22.65625, bottom: 334.46875, baseline: 16.921875
         frag 0 from TextNode start: 287, length: 4, rect: [252,321 43.15625x21.84375]
           "ante"
-        frag 1 from TextNode start: 291, length: 1, rect: [295,321 16.6875x21.84375]
+        frag 1 from TextNode start: 291, length: 1, rect: [295,321 16.703125x21.84375]
           " "
-        frag 2 from TextNode start: 292, length: 7, rect: [311.6875,321 74x21.84375]
+        frag 2 from TextNode start: 292, length: 7, rect: [311.703125,321 74x21.84375]
           "sodales"
-        frag 3 from TextNode start: 299, length: 1, rect: [385.6875,321 16.6875x21.84375]
+        frag 3 from TextNode start: 299, length: 1, rect: [385.703125,321 16.703125x21.84375]
           " "
-        frag 4 from TextNode start: 300, length: 9, rect: [402.375,321 85.453125x21.84375]
+        frag 4 from TextNode start: 300, length: 9, rect: [402.40625,321 85.453125x21.84375]
           "lobortis."
       line 16 width: 178.3125, height: 22.5, bottom: 356.15625, baseline: 16.921875
         frag 0 from TextNode start: 310, length: 5, rect: [252,343 60.90625x21.84375]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/small-percentage-margin.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/small-percentage-margin.txt
@@ -1,35 +1,35 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x208 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x0 children: not-inline
-      BlockContainer <div> at (15.828125,8) content-size 376.3125x100 floating [BFC] children: inline
+      BlockContainer <div> at (15.84375,8) content-size 376.3125x100 floating [BFC] children: inline
         line 0 width: 27.703125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-          frag 0 from TextNode start: 0, length: 3, rect: [15.828125,8 27.703125x17.46875]
+          frag 0 from TextNode start: 0, length: 3, rect: [15.84375,8 27.703125x17.46875]
             "abc"
         TextNode <#text>
-      BlockContainer <div> at (407.796875,8) content-size 376.3125x100 floating [BFC] children: inline
+      BlockContainer <div> at (407.84375,8) content-size 376.3125x100 floating [BFC] children: inline
         line 0 width: 23.015625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-          frag 0 from TextNode start: 0, length: 3, rect: [407.796875,8 23.015625x17.46875]
+          frag 0 from TextNode start: 0, length: 3, rect: [407.84375,8 23.015625x17.46875]
             "def"
         TextNode <#text>
-      BlockContainer <div> at (15.828125,108) content-size 376.3125x100 floating [BFC] children: inline
+      BlockContainer <div> at (15.84375,108) content-size 376.3125x100 floating [BFC] children: inline
         line 0 width: 21.421875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-          frag 0 from TextNode start: 0, length: 3, rect: [15.828125,108 21.421875x17.46875]
+          frag 0 from TextNode start: 0, length: 3, rect: [15.84375,108 21.421875x17.46875]
             "ghi"
         TextNode <#text>
-      BlockContainer <div> at (407.796875,108) content-size 376.3125x100 floating [BFC] children: inline
+      BlockContainer <div> at (407.84375,108) content-size 376.3125x100 floating [BFC] children: inline
         line 0 width: 18.40625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-          frag 0 from TextNode start: 0, length: 3, rect: [407.796875,108 18.40625x17.46875]
+          frag 0 from TextNode start: 0, length: 3, rect: [407.84375,108 18.40625x17.46875]
             "jkl"
         TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x208]
-    PaintableWithLines (BlockContainer<BODY>) [8,8 784x0] overflow: [15.828125,8 768.28125x200]
-      PaintableWithLines (BlockContainer<DIV>) [15.828125,8 376.3125x100]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x0] overflow: [15.84375,8 768.3125x200]
+      PaintableWithLines (BlockContainer<DIV>) [15.84375,8 376.3125x100]
         TextPaintable (TextNode<#text>)
-      PaintableWithLines (BlockContainer<DIV>) [407.796875,8 376.3125x100]
+      PaintableWithLines (BlockContainer<DIV>) [407.84375,8 376.3125x100]
         TextPaintable (TextNode<#text>)
-      PaintableWithLines (BlockContainer<DIV>) [15.828125,108 376.3125x100]
+      PaintableWithLines (BlockContainer<DIV>) [15.84375,108 376.3125x100]
         TextPaintable (TextNode<#text>)
-      PaintableWithLines (BlockContainer<DIV>) [407.796875,108 376.3125x100]
+      PaintableWithLines (BlockContainer<DIV>) [407.84375,108 376.3125x100]
         TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/css-namespace-tag-name-selector.txt
+++ b/Tests/LibWeb/Layout/expected/css-namespace-tag-name-selector.txt
@@ -1,6 +1,6 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
-    BlockContainer <body> at (8,8) content-size 784x299.65625 children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x299.6875 children: not-inline
       BlockContainer <(anonymous)> at (8,8) content-size 784x152 children: inline
         line 0 width: 302, height: 152, bottom: 152, baseline: 152
           frag 0 from SVGSVGBox start: 0, length: 0, rect: [9,9 300x150]
@@ -11,31 +11,31 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
         InlineNode <math>
       BlockContainer <a> at (9,161) content-size 100x100 children: inline
-        line 0 width: 99.453125, height: 43.671875, bottom: 43.671875, baseline: 33.828125
+        line 0 width: 99.453125, height: 43.6875, bottom: 43.6875, baseline: 33.84375
           frag 0 from TextNode start: 0, length: 5, rect: [9,161 99.453125x43.671875]
             "Hello"
         TextNode <#text>
       BlockContainer <(anonymous)> at (8,262) content-size 784x0 children: inline
         TextNode <#text>
-      BlockContainer <div> at (9,263) content-size 782x43.65625 children: inline
-        line 0 width: 101.453125, height: 43.65625, bottom: 43.65625, baseline: 33.828125
+      BlockContainer <div> at (9,263) content-size 782x43.6875 children: inline
+        line 0 width: 101.453125, height: 43.6875, bottom: 43.6875, baseline: 33.84375
           frag 0 from TextNode start: 0, length: 5, rect: [10,263 99.453125x43.671875]
             "Hello"
         InlineNode <a>
           TextNode <#text>
-      BlockContainer <(anonymous)> at (8,307.65625) content-size 784x0 children: inline
+      BlockContainer <(anonymous)> at (8,307.6875) content-size 784x0 children: inline
         TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
-    PaintableWithLines (BlockContainer<BODY>) [8,8 784x299.65625]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x299.6875]
       PaintableWithLines (BlockContainer(anonymous)) [8,8 784x152]
         SVGSVGPaintable (SVGSVGBox<svg>) [8,8 302x152]
         InlinePaintable (InlineNode<math>)
       PaintableWithLines (BlockContainer<a>) [8,160 102x102]
         TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,262 784x0]
-      PaintableWithLines (BlockContainer<DIV>) [8,262 784x45.65625] overflow: [9,263 782x43.671875]
+      PaintableWithLines (BlockContainer<DIV>) [8,262 784x45.6875]
         InlinePaintable (InlineNode<A>)
           TextPaintable (TextNode<#text>)
-      PaintableWithLines (BlockContainer(anonymous)) [8,307.65625 784x0]
+      PaintableWithLines (BlockContainer(anonymous)) [8,307.6875 784x0]

--- a/Tests/LibWeb/Layout/expected/flex/flex-item-with-intrinsic-aspect-ratio-and-max-height.txt
+++ b/Tests/LibWeb/Layout/expected/flex/flex-item-with-intrinsic-aspect-ratio-and-max-height.txt
@@ -1,11 +1,11 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (1,1) content-size 798x69.96875 [BFC] children: not-inline
-    Box <body> at (10,10) content-size 780x51.96875 flex-container(row) [FFC] children: not-inline
-      ImageBox <img> at (11,11) content-size 66.65625x49.984375 flex-item children: not-inline
+  BlockContainer <html> at (1,1) content-size 798x70 [BFC] children: not-inline
+    Box <body> at (10,10) content-size 780x52 flex-container(row) [FFC] children: not-inline
+      ImageBox <img> at (11,11) content-size 66.671875x50 flex-item children: not-inline
       BlockContainer <(anonymous)> (not painted) [BFC] children: inline
         TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x71.96875]
-    PaintableBox (Box<BODY>) [9,9 782x53.96875] overflow: [10,10 780x51.984375]
-      ImagePaintable (ImageBox<IMG>) [10,10 68.65625x51.984375]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x72]
+    PaintableBox (Box<BODY>) [9,9 782x54]
+      ImagePaintable (ImageBox<IMG>) [10,10 68.671875x52]

--- a/Tests/LibWeb/Layout/expected/flex/reverse-flex-layout-with-space-between-and-space-around.txt
+++ b/Tests/LibWeb/Layout/expected/flex/reverse-flex-layout-with-space-between-and-space-around.txt
@@ -2,37 +2,37 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x616 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x600 children: not-inline
       Box <div.outer.row> at (8,8) content-size 150x150 flex-container(row) [FFC] children: not-inline
-        BlockContainer <div.inner> at (12.609375,8) content-size 30.078125x150 flex-item [BFC] children: inline
+        BlockContainer <div.inner> at (12.625,8) content-size 30.078125x150 flex-item [BFC] children: inline
           line 0 width: 30.078125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 4, rect: [12.609375,8 30.078125x17.46875]
+            frag 0 from TextNode start: 0, length: 4, rect: [12.625,8 30.078125x17.46875]
               "Well"
           TextNode <#text>
-        BlockContainer <div.inner> at (51.921875,8) content-size 36.84375x150 flex-item [BFC] children: inline
+        BlockContainer <div.inner> at (51.9375,8) content-size 36.84375x150 flex-item [BFC] children: inline
           line 0 width: 36.84375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 5, rect: [51.921875,8 36.84375x17.46875]
+            frag 0 from TextNode start: 0, length: 5, rect: [51.9375,8 36.84375x17.46875]
               "hello"
           TextNode <#text>
-        BlockContainer <div.inner> at (98,8) content-size 55.359375x150 flex-item [BFC] children: inline
+        BlockContainer <div.inner> at (98.015625,8) content-size 55.359375x150 flex-item [BFC] children: inline
           line 0 width: 55.359375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 7, rect: [98,8 55.359375x17.46875]
+            frag 0 from TextNode start: 0, length: 7, rect: [98.015625,8 55.359375x17.46875]
               "friends"
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,158) content-size 784x0 children: inline
         TextNode <#text>
       Box <div.outer.row-reverse> at (8,158) content-size 150x150 flex-container(row-reverse) [FFC] children: not-inline
-        BlockContainer <div.inner> at (123.3125,158) content-size 30.078125x150 flex-item [BFC] children: inline
+        BlockContainer <div.inner> at (123.296875,158) content-size 30.078125x150 flex-item [BFC] children: inline
           line 0 width: 30.078125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 4, rect: [123.3125,158 30.078125x17.46875]
+            frag 0 from TextNode start: 0, length: 4, rect: [123.296875,158 30.078125x17.46875]
               "Well"
           TextNode <#text>
-        BlockContainer <div.inner> at (77.234375,158) content-size 36.84375x150 flex-item [BFC] children: inline
+        BlockContainer <div.inner> at (77.21875,158) content-size 36.84375x150 flex-item [BFC] children: inline
           line 0 width: 36.84375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 5, rect: [77.234375,158 36.84375x17.46875]
+            frag 0 from TextNode start: 0, length: 5, rect: [77.21875,158 36.84375x17.46875]
               "hello"
           TextNode <#text>
-        BlockContainer <div.inner> at (12.640625,158) content-size 55.359375x150 flex-item [BFC] children: inline
+        BlockContainer <div.inner> at (12.625,158) content-size 55.359375x150 flex-item [BFC] children: inline
           line 0 width: 55.359375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 7, rect: [12.640625,158 55.359375x17.46875]
+            frag 0 from TextNode start: 0, length: 7, rect: [12.625,158 55.359375x17.46875]
               "friends"
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,308) content-size 784x0 children: inline
@@ -76,19 +76,19 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x616]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x616]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x600]
       PaintableBox (Box<DIV>.outer.row) [8,8 150x150]
-        PaintableWithLines (BlockContainer<DIV>.inner) [12.609375,8 30.078125x150]
+        PaintableWithLines (BlockContainer<DIV>.inner) [12.625,8 30.078125x150]
           TextPaintable (TextNode<#text>)
-        PaintableWithLines (BlockContainer<DIV>.inner) [51.921875,8 36.84375x150]
+        PaintableWithLines (BlockContainer<DIV>.inner) [51.9375,8 36.84375x150]
           TextPaintable (TextNode<#text>)
-        PaintableWithLines (BlockContainer<DIV>.inner) [98,8 55.359375x150]
+        PaintableWithLines (BlockContainer<DIV>.inner) [98.015625,8 55.359375x150]
           TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,158 784x0]
       PaintableBox (Box<DIV>.outer.row-reverse) [8,158 150x150]
-        PaintableWithLines (BlockContainer<DIV>.inner) [123.3125,158 30.078125x150]
+        PaintableWithLines (BlockContainer<DIV>.inner) [123.296875,158 30.078125x150]
           TextPaintable (TextNode<#text>)
-        PaintableWithLines (BlockContainer<DIV>.inner) [77.234375,158 36.84375x150]
+        PaintableWithLines (BlockContainer<DIV>.inner) [77.21875,158 36.84375x150]
           TextPaintable (TextNode<#text>)
-        PaintableWithLines (BlockContainer<DIV>.inner) [12.640625,158 55.359375x150]
+        PaintableWithLines (BlockContainer<DIV>.inner) [12.625,158 55.359375x150]
           TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,308 784x0]
       PaintableBox (Box<DIV>.outer.column) [8,308 150x150]

--- a/Tests/LibWeb/Layout/expected/grid/grid-item-horizontal-margins-auto.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-item-horizontal-margins-auto.txt
@@ -25,9 +25,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.left-margin-auto.right-margin-auto.fit-content-width> at (75.25,70.40625) content-size 371.484375x17.46875 [BFC] children: inline
+        BlockContainer <div.left-margin-auto.right-margin-auto.fit-content-width> at (75.265625,70.40625) content-size 371.484375x17.46875 [BFC] children: inline
           line 0 width: 371.484375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 45, rect: [75.25,70.40625 371.484375x17.46875]
+            frag 0 from TextNode start: 0, length: 45, rect: [75.265625,70.40625 371.484375x17.46875]
               "auto horizontal margins and fit-content width"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
@@ -125,7 +125,7 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           TextPaintable (TextNode<#text>)
         PaintableWithLines (BlockContainer<DIV>.right-margin-auto) [11,49.9375 270.484375x19.46875]
           TextPaintable (TextNode<#text>)
-        PaintableWithLines (BlockContainer<DIV>.left-margin-auto.right-margin-auto.fit-content-width) [74.25,69.40625 373.484375x19.46875]
+        PaintableWithLines (BlockContainer<DIV>.left-margin-auto.right-margin-auto.fit-content-width) [74.265625,69.40625 373.484375x19.46875]
           TextPaintable (TextNode<#text>)
         PaintableWithLines (BlockContainer<DIV>.left-margin-auto.fit-content-width) [202.453125,88.875 308.546875x19.46875]
           TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/grid/grid-span-4.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-span-4.txt
@@ -1,21 +1,21 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (1,1) content-size 798x65.65625 [BFC] children: not-inline
-    Box <body> at (10,10) content-size 780x47.65625 [GFC] children: not-inline
-      BlockContainer <div.foo> at (11,11) content-size 778x21.8125 [BFC] children: inline
+  BlockContainer <html> at (1,1) content-size 798x65.6875 [BFC] children: not-inline
+    Box <body> at (10,10) content-size 780x47.6875 [GFC] children: not-inline
+      BlockContainer <div.foo> at (11,11) content-size 778x21.84375 [BFC] children: inline
         line 0 width: 33.9375, height: 21.84375, bottom: 21.84375, baseline: 16.921875
           frag 0 from TextNode start: 0, length: 3, rect: [11,11 33.9375x21.84375]
             "foo"
         TextNode <#text>
-      BlockContainer <div.bar> at (11,34.8125) content-size 778x21.84375 [BFC] children: inline
+      BlockContainer <div.bar> at (11,34.84375) content-size 778x21.84375 [BFC] children: inline
         line 0 width: 34.546875, height: 21.84375, bottom: 21.84375, baseline: 16.921875
-          frag 0 from TextNode start: 0, length: 3, rect: [11,34.8125 34.546875x21.84375]
+          frag 0 from TextNode start: 0, length: 3, rect: [11,34.84375 34.546875x21.84375]
             "bar"
         TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x67.65625]
-    PaintableBox (Box<BODY>) [9,9 782x49.65625]
-      PaintableWithLines (BlockContainer<DIV>.foo) [10,10 780x23.8125] overflow: [11,11 778x21.84375]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x67.6875]
+    PaintableBox (Box<BODY>) [9,9 782x49.6875]
+      PaintableWithLines (BlockContainer<DIV>.foo) [10,10 780x23.84375]
         TextPaintable (TextNode<#text>)
-      PaintableWithLines (BlockContainer<DIV>.bar) [10,33.8125 780x23.84375]
+      PaintableWithLines (BlockContainer<DIV>.bar) [10,33.84375 780x23.84375]
         TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/grid/image-in-grid.txt
+++ b/Tests/LibWeb/Layout/expected/grid/image-in-grid.txt
@@ -4,11 +4,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       Box <div.grid-container> at (8,8) content-size 784x24 [GFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.wrapper> at (8,8) content-size 64.03125x24 [BFC] children: inline
-          line 0 width: 64.03125, height: 24, bottom: 24, baseline: 24
-            frag 0 from ImageBox start: 0, length: 0, rect: [8,8 64.03125x24]
+        BlockContainer <div.wrapper> at (8,8) content-size 64.015625x24 [BFC] children: inline
+          line 0 width: 64.015625, height: 24, bottom: 24, baseline: 24
+            frag 0 from ImageBox start: 0, length: 0, rect: [8,8 64.015625x24]
           TextNode <#text>
-          ImageBox <img> at (8,8) content-size 64.03125x24 children: not-inline
+          ImageBox <img> at (8,8) content-size 64.015625x24 children: not-inline
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
@@ -17,5 +17,5 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x24]
       PaintableBox (Box<DIV>.grid-container) [8,8 784x24]
-        PaintableWithLines (BlockContainer<DIV>.wrapper) [8,8 64.03125x24]
-          ImagePaintable (ImageBox<IMG>) [8,8 64.03125x24]
+        PaintableWithLines (BlockContainer<DIV>.wrapper) [8,8 64.015625x24]
+          ImagePaintable (ImageBox<IMG>) [8,8 64.015625x24]

--- a/Tests/LibWeb/Layout/expected/grid/item-column-span-2.txt
+++ b/Tests/LibWeb/Layout/expected/grid/item-column-span-2.txt
@@ -7,12 +7,12 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <div.item-left> at (8,8) content-size 100x35.40625 [BFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.item-right> at (108.03125,8) content-size 683.96875x35.40625 [BFC] children: inline
+        BlockContainer <div.item-right> at (108.015625,8) content-size 683.984375x35.40625 [BFC] children: inline
           line 0 width: 625.953125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 77, rect: [108.03125,8 625.953125x17.46875]
+            frag 0 from TextNode start: 0, length: 77, rect: [108.015625,8 625.953125x17.46875]
               "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut iaculis venenatis"
           line 1 width: 304.0625, height: 17.9375, bottom: 35.40625, baseline: 13.53125
-            frag 0 from TextNode start: 78, length: 39, rect: [108.03125,25 304.0625x17.46875]
+            frag 0 from TextNode start: 78, length: 39, rect: [108.015625,25 304.0625x17.46875]
               "purus, eget blandit velit venenatis at."
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
@@ -25,6 +25,6 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x35.40625]
       PaintableBox (Box<DIV>.container) [8,8 784x35.40625]
         PaintableWithLines (BlockContainer<DIV>.item-left) [8,8 100x35.40625]
-        PaintableWithLines (BlockContainer<DIV>.item-right) [108.03125,8 683.96875x35.40625]
+        PaintableWithLines (BlockContainer<DIV>.item-right) [108.015625,8 683.984375x35.40625]
           TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,43.40625 784x0]

--- a/Tests/LibWeb/Layout/expected/grid/justify-items.txt
+++ b/Tests/LibWeb/Layout/expected/grid/justify-items.txt
@@ -12,9 +12,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (10,31.46875) content-size 780x0 children: inline
         TextNode <#text>
       Box <div.grid.center> at (11,32.46875) content-size 778x19.46875 [GFC] children: not-inline
-        BlockContainer <div> at (373.46875,33.46875) content-size 53.046875x17.46875 [BFC] children: inline
+        BlockContainer <div> at (373.484375,33.46875) content-size 53.046875x17.46875 [BFC] children: inline
           line 0 width: 53.046875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 6, rect: [373.46875,33.46875 53.046875x17.46875]
+            frag 0 from TextNode start: 0, length: 6, rect: [373.484375,33.46875 53.046875x17.46875]
               "Center"
           TextNode <#text>
       BlockContainer <(anonymous)> at (10,52.9375) content-size 780x0 children: inline
@@ -35,7 +35,7 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [10,31.46875 780x0]
       PaintableBox (Box<DIV>.grid.center) [10,31.46875 780x21.46875]
-        PaintableWithLines (BlockContainer<DIV>) [372.46875,32.46875 55.046875x19.46875]
+        PaintableWithLines (BlockContainer<DIV>) [372.484375,32.46875 55.046875x19.46875]
           TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [10,52.9375 780x0]
       PaintableBox (Box<DIV>.grid.end) [10,52.9375 780x21.46875]

--- a/Tests/LibWeb/Layout/expected/grid/justify-self.txt
+++ b/Tests/LibWeb/Layout/expected/grid/justify-self.txt
@@ -10,9 +10,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
       BlockContainer <(anonymous)> (not painted) [BFC] children: inline
         TextNode <#text>
-      BlockContainer <div> at (373.46875,30.46875) content-size 53.046875x17.46875 [BFC] children: inline
+      BlockContainer <div> at (373.484375,30.46875) content-size 53.046875x17.46875 [BFC] children: inline
         line 0 width: 53.046875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-          frag 0 from TextNode start: 0, length: 6, rect: [373.46875,30.46875 53.046875x17.46875]
+          frag 0 from TextNode start: 0, length: 6, rect: [373.484375,30.46875 53.046875x17.46875]
             "Center"
         TextNode <#text>
       BlockContainer <(anonymous)> (not painted) [BFC] children: inline
@@ -30,7 +30,7 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
     PaintableBox (Box<BODY>) [9,9 782x60.40625]
       PaintableWithLines (BlockContainer<DIV>) [10,10 45.859375x19.46875]
         TextPaintable (TextNode<#text>)
-      PaintableWithLines (BlockContainer<DIV>) [372.46875,29.46875 55.046875x19.46875]
+      PaintableWithLines (BlockContainer<DIV>) [372.484375,29.46875 55.046875x19.46875]
         TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer<DIV>) [758.671875,48.9375 31.328125x19.46875]
         TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/grid/min-max-content.txt
+++ b/Tests/LibWeb/Layout/expected/grid/min-max-content.txt
@@ -4,23 +4,23 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       Box <div.grid-container> at (8,8) content-size 784x17.46875 [GFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (8,8) content-size 46.875x17.46875 [BFC] children: inline
+        BlockContainer <div.grid-item> at (8,8) content-size 46.890625x17.46875 [BFC] children: inline
           line 0 width: 93.765625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 11, rect: [8,8 93.765625x17.46875]
               "min-content"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (54.875,8) content-size 98.640625x17.46875 [BFC] children: inline
+        BlockContainer <div.grid-item> at (54.890625,8) content-size 98.640625x17.46875 [BFC] children: inline
           line 0 width: 98.640625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 11, rect: [54.875,8 98.640625x17.46875]
+            frag 0 from TextNode start: 0, length: 11, rect: [54.890625,8 98.640625x17.46875]
               "max-content"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item> at (153.515625,8) content-size 638.484375x17.46875 [BFC] children: inline
+        BlockContainer <div.grid-item> at (153.53125,8) content-size 638.46875x17.46875 [BFC] children: inline
           line 0 width: 21.609375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 3, rect: [153.515625,8 21.609375x17.46875]
+            frag 0 from TextNode start: 0, length: 3, rect: [153.53125,8 21.609375x17.46875]
               "1fr"
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
@@ -30,9 +30,9 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x17.46875]
       PaintableBox (Box<DIV>.grid-container) [8,8 784x17.46875]
-        PaintableWithLines (BlockContainer<DIV>.grid-item) [8,8 46.875x17.46875] overflow: [8,8 93.765625x17.46875]
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [8,8 46.890625x17.46875] overflow: [8,8 93.765625x17.46875]
           TextPaintable (TextNode<#text>)
-        PaintableWithLines (BlockContainer<DIV>.grid-item) [54.875,8 98.640625x17.46875]
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [54.890625,8 98.640625x17.46875]
           TextPaintable (TextNode<#text>)
-        PaintableWithLines (BlockContainer<DIV>.grid-item) [153.515625,8 638.484375x17.46875]
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [153.53125,8 638.46875x17.46875]
           TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/grid/place-self.txt
+++ b/Tests/LibWeb/Layout/expected/grid/place-self.txt
@@ -15,9 +15,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (10,91.46875) content-size 780x0 children: inline
         TextNode <#text>
       Box <div.grid> at (31,112.46875) content-size 738x39.46875 [GFC] children: not-inline
-        BlockContainer <div.center> at (185.796875,123.46875) content-size 59.390625x17.46875 [BFC] children: inline
+        BlockContainer <div.center> at (185.8125,123.46875) content-size 59.390625x17.46875 [BFC] children: inline
           line 0 width: 59.390625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 7, rect: [185.796875,123.46875 59.390625x17.46875]
+            frag 0 from TextNode start: 0, length: 7, rect: [185.8125,123.46875 59.390625x17.46875]
               "Center1"
           TextNode <#text>
         BlockContainer <div.item-padding> at (411,123.46875) content-size 347x17.46875 [BFC] children: inline
@@ -49,7 +49,7 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [10,91.46875 780x0]
       PaintableBox (Box<DIV>.grid) [10,91.46875 780x81.46875]
-        PaintableWithLines (BlockContainer<DIV>.center) [184.796875,122.46875 61.390625x19.46875]
+        PaintableWithLines (BlockContainer<DIV>.center) [184.8125,122.46875 61.390625x19.46875]
           TextPaintable (TextNode<#text>)
         PaintableWithLines (BlockContainer<DIV>.item-padding) [400,112.46875 369x39.46875]
           TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/grid/placement-1.txt
+++ b/Tests/LibWeb/Layout/expected/grid/placement-1.txt
@@ -2,22 +2,22 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (1,1) content-size 798x600 [BFC] children: not-inline
     BlockContainer <body> at (10,10) content-size 780x21.46875 children: not-inline
       Box <div.grid-container> at (11,11) content-size 778x19.46875 [GFC] children: not-inline
-        BlockContainer <div.a> at (12,12) content-size 516.125x17.46875 [BFC] children: inline
+        BlockContainer <div.a> at (12,12) content-size 516.75x17.46875 [BFC] children: inline
           line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [12,12 6.34375x17.46875]
               "1"
           TextNode <#text>
-        BlockContainer <div.b> at (530.125,12) content-size 257.0625x17.46875 [BFC] children: inline
+        BlockContainer <div.b> at (530.75,12) content-size 257.375x17.46875 [BFC] children: inline
           line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 1, rect: [530.125,12 8.8125x17.46875]
+            frag 0 from TextNode start: 0, length: 1, rect: [530.75,12 8.8125x17.46875]
               "2"
           TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x602]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x602]
     PaintableWithLines (BlockContainer<BODY>) [9,9 782x23.46875]
-      PaintableBox (Box<DIV>.grid-container) [10,10 780x21.46875]
-        PaintableWithLines (BlockContainer<DIV>.a) [11,11 518.125x19.46875]
+      PaintableBox (Box<DIV>.grid-container) [10,10 780x21.46875] overflow: [11,11 778.125x19.46875]
+        PaintableWithLines (BlockContainer<DIV>.a) [11,11 518.75x19.46875]
           TextPaintable (TextNode<#text>)
-        PaintableWithLines (BlockContainer<DIV>.b) [529.125,11 259.0625x19.46875]
+        PaintableWithLines (BlockContainer<DIV>.b) [529.75,11 259.375x19.46875]
           TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/grid/placement-2.txt
+++ b/Tests/LibWeb/Layout/expected/grid/placement-2.txt
@@ -2,22 +2,22 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (1,1) content-size 798x600 [BFC] children: not-inline
     BlockContainer <body> at (10,10) content-size 780x21.46875 children: not-inline
       Box <div.grid-container> at (11,11) content-size 778x19.46875 [GFC] children: not-inline
-        BlockContainer <div.grid-item.a> at (12,12) content-size 257.0625x17.46875 [BFC] children: inline
+        BlockContainer <div.grid-item.a> at (12,12) content-size 257.375x17.46875 [BFC] children: inline
           line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [12,12 6.34375x17.46875]
               "1"
           TextNode <#text>
-        BlockContainer <div.grid-item.b> at (271.0625,12) content-size 516.125x17.46875 [BFC] children: inline
+        BlockContainer <div.grid-item.b> at (271.375,12) content-size 516.75x17.46875 [BFC] children: inline
           line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 1, rect: [271.0625,12 8.8125x17.46875]
+            frag 0 from TextNode start: 0, length: 1, rect: [271.375,12 8.8125x17.46875]
               "2"
           TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x602]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x602]
     PaintableWithLines (BlockContainer<BODY>) [9,9 782x23.46875]
-      PaintableBox (Box<DIV>.grid-container) [10,10 780x21.46875]
-        PaintableWithLines (BlockContainer<DIV>.grid-item.a) [11,11 259.0625x19.46875]
+      PaintableBox (Box<DIV>.grid-container) [10,10 780x21.46875] overflow: [11,11 778.125x19.46875]
+        PaintableWithLines (BlockContainer<DIV>.grid-item.a) [11,11 259.375x19.46875]
           TextPaintable (TextNode<#text>)
-        PaintableWithLines (BlockContainer<DIV>.grid-item.b) [270.0625,11 518.125x19.46875]
+        PaintableWithLines (BlockContainer<DIV>.grid-item.b) [270.375,11 518.75x19.46875]
           TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/grid/row-span-2-with-gaps.txt
+++ b/Tests/LibWeb/Layout/expected/grid/row-span-2-with-gaps.txt
@@ -1,10 +1,10 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
-    BlockContainer <body> at (8,8) content-size 784x352.34375 children: not-inline
-      Box <div.grid-container> at (8,8) content-size 784x352.34375 [GFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x332.34375 children: not-inline
+      Box <div.grid-container> at (8,8) content-size 784x332.34375 [GFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item.item-span-one-one> at (411.46875,8) content-size 382x139.765625 [BFC] children: inline
+        BlockContainer <div.grid-item.item-span-one-one> at (411.46875,8) content-size 382x129.765625 [BFC] children: inline
           line 0 width: 319.171875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 1, length: 40, rect: [411.46875,8 319.171875x17.46875]
               "In a sollicitudin augue. Sed ante augue,"
@@ -20,32 +20,32 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item.item-span-one-two> at (411.46875,167.765625) content-size 382x192.578125 [BFC] children: inline
+        BlockContainer <div.grid-item.item-span-one-two> at (411.46875,157.765625) content-size 382x182.578125 [BFC] children: inline
           line 0 width: 359.15625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 1, length: 43, rect: [411.46875,167.765625 359.15625x17.46875]
+            frag 0 from TextNode start: 1, length: 43, rect: [411.46875,157.765625 359.15625x17.46875]
               "Suspendisse potenti. Pellentesque at varius"
           line 1 width: 318.5625, height: 17.9375, bottom: 35.40625, baseline: 13.53125
-            frag 0 from TextNode start: 45, length: 41, rect: [411.46875,184.765625 318.5625x17.46875]
+            frag 0 from TextNode start: 45, length: 41, rect: [411.46875,174.765625 318.5625x17.46875]
               "lacus, sed sollicitudin leo. Pellentesque"
           line 2 width: 377.640625, height: 18.40625, bottom: 53.34375, baseline: 13.53125
-            frag 0 from TextNode start: 87, length: 44, rect: [411.46875,201.765625 377.640625x17.46875]
+            frag 0 from TextNode start: 87, length: 44, rect: [411.46875,191.765625 377.640625x17.46875]
               "malesuada mi eget pellentesque tempor. Donec"
           line 3 width: 378.03125, height: 17.875, bottom: 70.28125, baseline: 13.53125
-            frag 0 from TextNode start: 132, length: 47, rect: [411.46875,219.765625 378.03125x17.46875]
+            frag 0 from TextNode start: 132, length: 47, rect: [411.46875,209.765625 378.03125x17.46875]
               "egestas mauris est, ut lobortis nisi luctus at."
           line 4 width: 345.953125, height: 18.34375, bottom: 88.21875, baseline: 13.53125
-            frag 0 from TextNode start: 180, length: 41, rect: [411.46875,236.765625 345.953125x17.46875]
+            frag 0 from TextNode start: 180, length: 41, rect: [411.46875,226.765625 345.953125x17.46875]
               "Vivamus eleifend, lorem vulputate maximus"
           line 5 width: 312.765625, height: 17.8125, bottom: 105.15625, baseline: 13.53125
-            frag 0 from TextNode start: 222, length: 37, rect: [411.46875,254.765625 312.765625x17.46875]
+            frag 0 from TextNode start: 222, length: 37, rect: [411.46875,244.765625 312.765625x17.46875]
               "porta, nunc metus porttitor nibh, nec"
           line 6 width: 242.921875, height: 18.28125, bottom: 123.09375, baseline: 13.53125
-            frag 0 from TextNode start: 260, length: 31, rect: [411.46875,271.765625 242.921875x17.46875]
+            frag 0 from TextNode start: 260, length: 31, rect: [411.46875,261.765625 242.921875x17.46875]
               "bibendum nulla lectus ut felis."
           TextNode <#text>
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text>
-        BlockContainer <div.grid-item.item-span-two> at (8,8) content-size 383.46875x352.34375 [BFC] children: inline
+        BlockContainer <div.grid-item.item-span-two> at (8,8) content-size 383.46875x332.34375 [BFC] children: inline
           line 0 width: 337.6875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 1, length: 39, rect: [8,8 337.6875x17.46875]
               "Lorem ipsum dolor sit amet, consectetur"
@@ -109,11 +109,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
-    PaintableWithLines (BlockContainer<BODY>) [8,8 784x352.34375] overflow: [8,8 785.46875x352.34375]
-      PaintableBox (Box<DIV>.grid-container) [8,8 784x352.34375] overflow: [8,8 785.46875x352.34375]
-        PaintableWithLines (BlockContainer<DIV>.grid-item.item-span-one-one) [411.46875,8 382x139.765625]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x332.34375] overflow: [8,8 785.46875x332.34375]
+      PaintableBox (Box<DIV>.grid-container) [8,8 784x332.34375] overflow: [8,8 785.46875x332.34375]
+        PaintableWithLines (BlockContainer<DIV>.grid-item.item-span-one-one) [411.46875,8 382x129.765625]
           TextPaintable (TextNode<#text>)
-        PaintableWithLines (BlockContainer<DIV>.grid-item.item-span-one-two) [411.46875,167.765625 382x192.578125]
+        PaintableWithLines (BlockContainer<DIV>.grid-item.item-span-one-two) [411.46875,157.765625 382x182.578125]
           TextPaintable (TextNode<#text>)
-        PaintableWithLines (BlockContainer<DIV>.grid-item.item-span-two) [8,8 383.46875x352.34375]
+        PaintableWithLines (BlockContainer<DIV>.grid-item.item-span-two) [8,8 383.46875x332.34375]
           TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/grid/should-not-cause-infinite-spinning-in-space-distribution.txt
+++ b/Tests/LibWeb/Layout/expected/grid/should-not-cause-infinite-spinning-in-space-distribution.txt
@@ -1,21 +1,21 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (1,1) content-size 798x56.90625 [BFC] children: not-inline
-    Box <body> at (10,10) content-size 780x38.90625 [GFC] children: not-inline
-      BlockContainer <div.foo> at (11,11) content-size 778x17.4375 [BFC] children: inline
+  BlockContainer <html> at (1,1) content-size 798x56.9375 [BFC] children: not-inline
+    Box <body> at (10,10) content-size 780x38.9375 [GFC] children: not-inline
+      BlockContainer <div.foo> at (11,11) content-size 778x17.46875 [BFC] children: inline
         line 0 width: 27.15625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
           frag 0 from TextNode start: 0, length: 3, rect: [11,11 27.15625x17.46875]
             "foo"
         TextNode <#text>
-      BlockContainer <div.bar> at (11,30.4375) content-size 778x17.46875 [BFC] children: inline
+      BlockContainer <div.bar> at (11,30.46875) content-size 778x17.46875 [BFC] children: inline
         line 0 width: 27.640625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-          frag 0 from TextNode start: 0, length: 3, rect: [11,30.4375 27.640625x17.46875]
+          frag 0 from TextNode start: 0, length: 3, rect: [11,30.46875 27.640625x17.46875]
             "bar"
         TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x58.90625]
-    PaintableBox (Box<BODY>) [9,9 782x40.90625]
-      PaintableWithLines (BlockContainer<DIV>.foo) [10,10 780x19.4375] overflow: [11,11 778x17.46875]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x58.9375]
+    PaintableBox (Box<BODY>) [9,9 782x40.9375]
+      PaintableWithLines (BlockContainer<DIV>.foo) [10,10 780x19.46875]
         TextPaintable (TextNode<#text>)
-      PaintableWithLines (BlockContainer<DIV>.bar) [10,29.4375 780x19.46875]
+      PaintableWithLines (BlockContainer<DIV>.bar) [10,29.46875 780x19.46875]
         TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/inline-size.txt
+++ b/Tests/LibWeb/Layout/expected/inline-size.txt
@@ -1,30 +1,30 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x570.84375 [BFC] children: not-inline
-    BlockContainer <body> at (8,70) content-size 784x492.84375 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x570.859375 [BFC] children: not-inline
+    BlockContainer <body> at (8,70) content-size 784x492.859375 children: not-inline
       BlockContainer <p.min-inline-test> at (8,70) content-size 784x200 children: inline
-        line 0 width: 85.859375, height: 76.421875, bottom: 76.421875, baseline: 59.1875
+        line 0 width: 85.859375, height: 76.4375, bottom: 76.4375, baseline: 59.203125
           frag 0 from TextNode start: 0, length: 2, rect: [8,70 85.859375x76.421875]
             "KK"
         TextNode <#text>
       BlockContainer <(anonymous)> at (8,340) content-size 784x76.421875 children: inline
-        line 0 width: 0, height: 76.421875, bottom: 76.421875, baseline: 59.1875
+        line 0 width: 0, height: 76.421875, bottom: 76.421875, baseline: 59.203125
         TextNode <#text>
         BreakNode <br>
         TextNode <#text>
-      BlockContainer <p.max-inline-test> at (8,486.421875) content-size 100x76.421875 children: inline
-        line 0 width: 85.859375, height: 76.421875, bottom: 76.421875, baseline: 59.1875
+      BlockContainer <p.max-inline-test> at (8,486.421875) content-size 100x76.4375 children: inline
+        line 0 width: 85.859375, height: 76.4375, bottom: 76.4375, baseline: 59.203125
           frag 0 from TextNode start: 0, length: 2, rect: [8,486.421875 85.859375x76.421875]
             "KK"
         TextNode <#text>
-      BlockContainer <(anonymous)> at (8,632.84375) content-size 784x0 children: inline
+      BlockContainer <(anonymous)> at (8,632.859375) content-size 784x0 children: inline
         TextNode <#text>
 
-ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x632.84375]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x570.84375] overflow: [0,0 800x632.84375]
-    PaintableWithLines (BlockContainer<BODY>) [8,70 784x492.84375] overflow: [8,70 784x562.84375]
+ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x632.859375]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x570.859375] overflow: [0,0 800x632.859375]
+    PaintableWithLines (BlockContainer<BODY>) [8,70 784x492.859375] overflow: [8,70 784x562.859375]
       PaintableWithLines (BlockContainer<P>.min-inline-test) [8,70 784x200]
         TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,340 784x76.421875]
-      PaintableWithLines (BlockContainer<P>.max-inline-test) [8,486.421875 100x76.421875]
+      PaintableWithLines (BlockContainer<P>.max-inline-test) [8,486.421875 100x76.4375]
         TextPaintable (TextNode<#text>)
-      PaintableWithLines (BlockContainer(anonymous)) [8,632.84375 784x0]
+      PaintableWithLines (BlockContainer(anonymous)) [8,632.859375 784x0]

--- a/Tests/LibWeb/Layout/expected/place-content-shorthand-property.txt
+++ b/Tests/LibWeb/Layout/expected/place-content-shorthand-property.txt
@@ -2,9 +2,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (1,1) content-size 798x37.46875 [BFC] children: not-inline
     BlockContainer <body> at (10,10) content-size 780x19.46875 children: not-inline
       Box <div.container> at (11,11) content-size 800x17.46875 flex-container(row) [FFC] children: not-inline
-        BlockContainer <(anonymous)> at (392.203125,11) content-size 37.578125x17.46875 flex-item [BFC] children: inline
+        BlockContainer <(anonymous)> at (392.21875,11) content-size 37.578125x17.46875 flex-item [BFC] children: inline
           line 0 width: 37.578125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 4, rect: [392.203125,11 37.578125x17.46875]
+            frag 0 from TextNode start: 0, length: 4, rect: [392.21875,11 37.578125x17.46875]
               "Text"
           TextNode <#text>
 
@@ -12,5 +12,5 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 812x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x39.46875] overflow: [1,1 811x37.46875]
     PaintableWithLines (BlockContainer<BODY>) [9,9 782x21.46875] overflow: [10,10 802x19.46875]
       PaintableBox (Box<DIV>.container) [10,10 802x19.46875]
-        PaintableWithLines (BlockContainer(anonymous)) [392.203125,11 37.578125x17.46875]
+        PaintableWithLines (BlockContainer(anonymous)) [392.21875,11 37.578125x17.46875]
           TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/svg-transforms-and-viewboxes.txt
+++ b/Tests/LibWeb/Layout/expected/svg-transforms-and-viewboxes.txt
@@ -48,13 +48,13 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       TextNode <#text>
       SVGSVGBox <svg> at (50,250) content-size 200x200 [SVG] children: inline
         TextNode <#text>
-        SVGGeometryBox <rect> at (120.59375,320.578125) content-size 58.828125x58.828125 children: not-inline
+        SVGGeometryBox <rect> at (120.59375,320.59375) content-size 58.828125x58.828125 children: not-inline
         TextNode <#text>
         TextNode <#text>
-        SVGGeometryBox <rect> at (52.4375,310.359375) content-size 68.140625x68.140625 children: not-inline
+        SVGGeometryBox <rect> at (52.4375,310.375) content-size 68.140625x68.140625 children: not-inline
         TextNode <#text>
         TextNode <#text>
-        SVGGeometryBox <rect> at (179.40625,321.46875) content-size 68.140625x68.140625 children: not-inline
+        SVGGeometryBox <rect> at (179.40625,321.484375) content-size 68.140625x68.140625 children: not-inline
         TextNode <#text>
       TextNode <#text>
       SVGSVGBox <svg> at (258,250) content-size 200x200 [SVG] children: inline
@@ -112,9 +112,9 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x700]
         SVGGeometryPaintable (SVGGeometryBox<rect>) [506,90 120x120]
         SVGGeometryPaintable (SVGGeometryBox<rect>) [471.359375,90 189.28125x120]
       SVGSVGPaintable (SVGSVGBox<svg>) [50,250 200x200]
-        SVGGeometryPaintable (SVGGeometryBox<rect>) [120.59375,320.578125 58.828125x58.828125]
-        SVGGeometryPaintable (SVGGeometryBox<rect>) [52.4375,310.359375 68.140625x68.140625]
-        SVGGeometryPaintable (SVGGeometryBox<rect>) [179.40625,321.46875 68.140625x68.140625]
+        SVGGeometryPaintable (SVGGeometryBox<rect>) [120.59375,320.59375 58.828125x58.828125]
+        SVGGeometryPaintable (SVGGeometryBox<rect>) [52.4375,310.375 68.140625x68.140625]
+        SVGGeometryPaintable (SVGGeometryBox<rect>) [179.40625,321.484375 68.140625x68.140625]
       TextPaintable (TextNode<#text>)
       SVGSVGPaintable (SVGSVGBox<svg>) [258,250 200x200]
         SVGGeometryPaintable (SVGGeometryBox<circle>) [278,270 160x160]

--- a/Tests/LibWeb/Layout/expected/svg/svg-different-types-of-opacity.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-different-types-of-opacity.txt
@@ -5,7 +5,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,8 784x784]
       SVGSVGBox <svg> at (8,8) content-size 784x784 [SVG] children: inline
         TextNode <#text>
-        SVGGeometryBox <circle> at (47.203125,47.203125) content-size 548.796875x548.796875 children: not-inline
+        SVGGeometryBox <circle> at (47.1875,47.1875) content-size 548.796875x548.796875 children: not-inline
         TextNode <#text>
       TextNode <#text>
 
@@ -13,4 +13,4 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x800]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x800]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x784]
       SVGSVGPaintable (SVGSVGBox<svg>) [8,8 784x784]
-        SVGGeometryPaintable (SVGGeometryBox<circle>) [47.203125,47.203125 548.796875x548.796875]
+        SVGGeometryPaintable (SVGGeometryBox<circle>) [47.1875,47.1875 548.796875x548.796875]

--- a/Tests/LibWeb/Layout/expected/table/fixed-layout-percentage-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/fixed-layout-percentage-width.txt
@@ -5,67 +5,67 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         Box <table> at (9,9) content-size 598x42.9375 table-box [TFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tbody> at (9,9) content-size 597.96875x42.9375 table-row-group children: not-inline
-            Box <tr> at (9,9) content-size 597.96875x21.46875 table-row children: not-inline
+          Box <tbody> at (9,9) content-size 598.015625x42.9375 table-row-group children: not-inline
+            Box <tr> at (9,9) content-size 598.015625x21.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,11) content-size 95.65625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (11,11) content-size 95.671875x17.46875 table-cell [BFC] children: inline
                 line 0 width: 26.078125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
                   frag 0 from TextNode start: 0, length: 4, rect: [11,11 26.078125x17.46875]
                     "cell"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (110.65625,11) content-size 95.65625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (110.671875,11) content-size 95.671875x17.46875 table-cell [BFC] children: inline
                 line 0 width: 26.078125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 4, rect: [110.65625,11 26.078125x17.46875]
+                  frag 0 from TextNode start: 0, length: 4, rect: [110.671875,11 26.078125x17.46875]
                     "cell"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (210.3125,11) content-size 95.65625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (210.34375,11) content-size 95.671875x17.46875 table-cell [BFC] children: inline
                 line 0 width: 94.96875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 12, rect: [210.3125,11 94.96875x17.46875]
+                  frag 0 from TextNode start: 0, length: 12, rect: [210.34375,11 94.96875x17.46875]
                     "A table cell"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (309.96875,11) content-size 295x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (310.015625,11) content-size 295x17.46875 table-cell [BFC] children: inline
                 line 0 width: 94.96875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 12, rect: [309.96875,11 94.96875x17.46875]
+                  frag 0 from TextNode start: 0, length: 12, rect: [310.015625,11 94.96875x17.46875]
                     "A table cell"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (9,30.46875) content-size 597.96875x21.46875 table-row children: not-inline
+            Box <tr> at (9,30.46875) content-size 598.015625x21.46875 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,32.46875) content-size 95.65625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (11,32.46875) content-size 95.671875x17.46875 table-cell [BFC] children: inline
                 line 0 width: 26.078125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
                   frag 0 from TextNode start: 0, length: 4, rect: [11,32.46875 26.078125x17.46875]
                     "cell"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (110.65625,32.46875) content-size 95.65625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (110.671875,32.46875) content-size 95.671875x17.46875 table-cell [BFC] children: inline
                 line 0 width: 26.078125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 4, rect: [110.65625,32.46875 26.078125x17.46875]
+                  frag 0 from TextNode start: 0, length: 4, rect: [110.671875,32.46875 26.078125x17.46875]
                     "cell"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (210.3125,32.46875) content-size 95.65625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (210.34375,32.46875) content-size 95.671875x17.46875 table-cell [BFC] children: inline
                 line 0 width: 94.96875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 12, rect: [210.3125,32.46875 94.96875x17.46875]
+                  frag 0 from TextNode start: 0, length: 12, rect: [210.34375,32.46875 94.96875x17.46875]
                     "A table cell"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (309.96875,32.46875) content-size 295x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (310.015625,32.46875) content-size 295x17.46875 table-cell [BFC] children: inline
                 line 0 width: 94.96875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 12, rect: [309.96875,32.46875 94.96875x17.46875]
+                  frag 0 from TextNode start: 0, length: 12, rect: [310.015625,32.46875 94.96875x17.46875]
                     "A table cell"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -77,23 +77,23 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x44.9375]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 600x44.9375]
-        PaintableBox (Box<TABLE>) [8,8 600x44.9375]
-          PaintableBox (Box<TBODY>) [9,9 597.96875x42.9375]
-            PaintableBox (Box<TR>) [9,9 597.96875x21.46875]
-              PaintableWithLines (BlockContainer<TD>) [9,9 99.65625x21.46875]
+        PaintableBox (Box<TABLE>) [8,8 600x44.9375] overflow: [9,9 598.015625x42.9375]
+          PaintableBox (Box<TBODY>) [9,9 598.015625x42.9375]
+            PaintableBox (Box<TR>) [9,9 598.015625x21.46875]
+              PaintableWithLines (BlockContainer<TD>) [9,9 99.671875x21.46875]
                 TextPaintable (TextNode<#text>)
-              PaintableWithLines (BlockContainer<TD>) [108.65625,9 99.65625x21.46875]
+              PaintableWithLines (BlockContainer<TD>) [108.671875,9 99.671875x21.46875]
                 TextPaintable (TextNode<#text>)
-              PaintableWithLines (BlockContainer<TD>) [208.3125,9 99.65625x21.46875]
+              PaintableWithLines (BlockContainer<TD>) [208.34375,9 99.671875x21.46875]
                 TextPaintable (TextNode<#text>)
-              PaintableWithLines (BlockContainer<TD>) [307.96875,9 299x21.46875]
+              PaintableWithLines (BlockContainer<TD>) [308.015625,9 299x21.46875]
                 TextPaintable (TextNode<#text>)
-            PaintableBox (Box<TR>) [9,30.46875 597.96875x21.46875]
-              PaintableWithLines (BlockContainer<TD>) [9,30.46875 99.65625x21.46875]
+            PaintableBox (Box<TR>) [9,30.46875 598.015625x21.46875]
+              PaintableWithLines (BlockContainer<TD>) [9,30.46875 99.671875x21.46875]
                 TextPaintable (TextNode<#text>)
-              PaintableWithLines (BlockContainer<TD>) [108.65625,30.46875 99.65625x21.46875]
+              PaintableWithLines (BlockContainer<TD>) [108.671875,30.46875 99.671875x21.46875]
                 TextPaintable (TextNode<#text>)
-              PaintableWithLines (BlockContainer<TD>) [208.3125,30.46875 99.65625x21.46875]
+              PaintableWithLines (BlockContainer<TD>) [208.34375,30.46875 99.671875x21.46875]
                 TextPaintable (TextNode<#text>)
-              PaintableWithLines (BlockContainer<TD>) [307.96875,30.46875 299x21.46875]
+              PaintableWithLines (BlockContainer<TD>) [308.015625,30.46875 299x21.46875]
                 TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/row-outer-size-with-computed-size.txt
+++ b/Tests/LibWeb/Layout/expected/table/row-outer-size-with-computed-size.txt
@@ -9,7 +9,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (10,10) content-size 43.21875x9.734375 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,14.859375) content-size 0x0 table-cell [BFC] children: not-inline
+              BlockContainer <td> at (11,14.875) content-size 0x0 table-cell [BFC] children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (16,12) content-size 37.21875x17.46875 table-cell [BFC] children: inline
@@ -27,7 +27,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (10,21.734375) content-size 43.21875x9.734375 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,26.59375) content-size 0x0 table-cell [BFC] children: not-inline
+              BlockContainer <td> at (11,26.609375) content-size 0x0 table-cell [BFC] children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -38,11 +38,11 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x25.46875]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 49.21875x25.46875]
         PaintableBox (Box<TABLE>) [8,8 49.21875x25.46875]
-          PaintableBox (Box<TBODY>) [8,8 43.21875x19.46875] overflow: [8,8 47.21875x23.46875]
+          PaintableBox (Box<TBODY>) [8,8 43.21875x19.46875] overflow: [8,8 47.21875x23.484375]
             PaintableBox (Box<TR>) [10,10 43.21875x9.734375] overflow: [10,10 45.21875x21.46875]
-              PaintableWithLines (BlockContainer<TD>) [10,10 2x9.71875]
+              PaintableWithLines (BlockContainer<TD>) [10,10 2x9.75]
               PaintableWithLines (BlockContainer<TD>) [14,10 41.21875x21.46875]
                 InlinePaintable (InlineNode<A>)
                   TextPaintable (TextNode<#text>)
-            PaintableBox (Box<TR>) [10,21.734375 43.21875x9.734375]
-              PaintableWithLines (BlockContainer<TD>) [10,21.734375 2x9.71875]
+            PaintableBox (Box<TR>) [10,21.734375 43.21875x9.734375] overflow: [10,21.734375 43.21875x9.75]
+              PaintableWithLines (BlockContainer<TD>) [10,21.734375 2x9.75]

--- a/Tests/LibWeb/Layout/expected/table/row-span-and-nested-tables.txt
+++ b/Tests/LibWeb/Layout/expected/table/row-span-and-nested-tables.txt
@@ -15,9 +15,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (11,11) content-size 67.828125x54.203125 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (17,29.359375) content-size 11.5625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (17,29.375) content-size 11.5625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 11.5625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [17,29.359375 11.5625x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [17,29.375 11.5625x17.46875]
                     "X"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -79,9 +79,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (11,67.203125) content-size 67.828125x54.203125 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (17,85.5625) content-size 11.5625x17.46875 table-cell [BFC] children: inline
+              BlockContainer <td> at (17,85.578125) content-size 11.5625x17.46875 table-cell [BFC] children: inline
                 line 0 width: 11.09375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-                  frag 0 from TextNode start: 0, length: 1, rect: [17,85.5625 11.09375x17.46875]
+                  frag 0 from TextNode start: 0, length: 1, rect: [17,85.578125 11.09375x17.46875]
                     "Y"
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -100,9 +100,9 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
       PaintableWithLines (BlockContainer(anonymous)) [8,8 784x0]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 75.828125x116.40625]
         PaintableBox (Box<TABLE>) [8,8 75.828125x116.40625]
-          PaintableBox (Box<TBODY>) [9,9 67.828125x108.40625] overflow: [9,9 71.828125x112.40625]
+          PaintableBox (Box<TBODY>) [9,9 67.828125x108.40625] overflow: [9,9 71.828125x112.421875]
             PaintableBox (Box<TR>) [11,11 67.828125x54.203125] overflow: [11,11 69.828125x110.40625]
-              PaintableWithLines (BlockContainer<TD>) [11,11 23.5625x54.1875]
+              PaintableWithLines (BlockContainer<TD>) [11,11 23.5625x54.21875]
                 TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [36.5625,11 44.265625x110.40625]
                 PaintableWithLines (BlockContainer(anonymous)) [42.5625,17 32.265625x0]
@@ -122,7 +122,7 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
                       PaintableWithLines (BlockContainer(anonymous)) [42.5625,17 0x0]
                     PaintableWithLines (BlockContainer(anonymous)) [42.5625,17 0x0]
                 PaintableWithLines (BlockContainer(anonymous)) [42.5625,115.40625 32.265625x0]
-            PaintableBox (Box<TR>) [11,67.203125 67.828125x54.203125]
-              PaintableWithLines (BlockContainer<TD>) [11,67.203125 23.5625x54.1875]
+            PaintableBox (Box<TR>) [11,67.203125 67.828125x54.203125] overflow: [11,67.203125 67.828125x54.21875]
+              PaintableWithLines (BlockContainer<TD>) [11,67.203125 23.5625x54.21875]
                 TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,124.40625 784x0]

--- a/Tests/LibWeb/TestCSSPixels.cpp
+++ b/Tests/LibWeb/TestCSSPixels.cpp
@@ -36,6 +36,15 @@ TEST_CASE(division1)
     b = CSSPixels(0.25);
     EXPECT(!a.might_be_saturated());
     EXPECT((a / b).might_be_saturated());
+
+    // Results should be rounded:
+    a = CSSPixels::smallest_positive_value() * 3;
+    b = 2;
+    EXPECT((a / b) == CSSPixels::smallest_positive_value() * 2);
+
+    a = CSSPixels::smallest_positive_value() * -5;
+    b = 3;
+    EXPECT((a / b) == CSSPixels::smallest_positive_value() * -2);
 }
 
 TEST_CASE(multiplication1)

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -856,14 +856,17 @@ void GridFormattingContext::distribute_extra_space_across_spanned_tracks_base_si
             if (track.base_size_frozen)
                 continue;
 
-            if (track.growth_limit.has_value() && increase_per_track >= track.growth_limit.value()) {
-                track.base_size_frozen = true;
-                track.item_incurred_increase = track.growth_limit.value();
-                extra_space -= track.growth_limit.value();
-            } else {
-                track.item_incurred_increase += increase_per_track;
-                extra_space -= increase_per_track;
+            if (track.growth_limit.has_value()) {
+                auto maximum_increase = track.growth_limit.value() - track.base_size;
+                if (track.item_incurred_increase + increase_per_track >= maximum_increase) {
+                    track.base_size_frozen = true;
+                    track.item_incurred_increase = maximum_increase;
+                    extra_space -= maximum_increase - track.item_incurred_increase;
+                    continue;
+                }
             }
+            track.item_incurred_increase += increase_per_track;
+            extra_space -= increase_per_track;
         }
     }
 

--- a/Userland/Libraries/LibWeb/PixelUnits.h
+++ b/Userland/Libraries/LibWeb/PixelUnits.h
@@ -123,6 +123,11 @@ public:
         return from_raw(NumericLimits<int>::max());
     }
 
+    static constexpr CSSPixels smallest_positive_value()
+    {
+        return from_raw(1);
+    }
+
     float to_float() const;
     double to_double() const;
     int to_int() const;

--- a/Userland/Libraries/LibWeb/PixelUnits.h
+++ b/Userland/Libraries/LibWeb/PixelUnits.h
@@ -284,6 +284,14 @@ constexpr CSSPixels operator*(unsigned long left, CSSPixels right) { return righ
 inline float operator*(float left, CSSPixels right) { return right.to_float() * left; }
 inline double operator*(double left, CSSPixels right) { return right.to_double() * left; }
 
+template<Integral T>
+constexpr static T rounding_divide(T dividend, T divisor)
+{
+    if ((dividend < 0) == (divisor < 0))
+        return (dividend + (divisor / 2)) / divisor;
+    return (dividend - (divisor / 2)) / divisor;
+}
+
 class CSSPixelFraction {
 public:
     constexpr CSSPixelFraction(CSSPixels numerator, CSSPixels denominator)
@@ -309,7 +317,7 @@ public:
     {
         i64 wide_value = m_numerator.raw_value();
         wide_value <<= CSSPixels::fractional_bits;
-        wide_value /= m_denominator.raw_value();
+        wide_value = rounding_divide<i64>(wide_value, m_denominator.raw_value());
         return CSSPixels::from_raw(AK::clamp_to_int(wide_value));
     }
 
@@ -347,7 +355,7 @@ constexpr CSSPixels CSSPixels::operator*(CSSPixelFraction const& other) const
 {
     i64 wide_value = raw_value();
     wide_value *= other.numerator().raw_value();
-    wide_value /= other.denominator().raw_value();
+    wide_value = rounding_divide<i64>(wide_value, other.denominator().raw_value());
     return CSSPixels::from_raw(AK::clamp_to_int(wide_value));
 }
 
@@ -359,7 +367,7 @@ constexpr CSSPixels CSSPixels::operator/(CSSPixelFraction const& other) const
 {
     i64 wide_value = raw_value();
     wide_value *= other.denominator().raw_value();
-    wide_value /= other.numerator().raw_value();
+    wide_value = rounding_divide<i64>(wide_value, other.numerator().raw_value());
     return CSSPixels::from_raw(AK::clamp_to_int(wide_value));
 }
 


### PR DESCRIPTION
Rounding when dividing `CSSPixels` should allow us to retain a little more accuracy in our layout, probably closer to what things were like when using doubles for layout instead.

These changes might break some assumptions in the layout though (like the one the first two commits prevent), so please do be critical of any odd layout test results you notice!

Note: This will conflict with https://github.com/SerenityOS/serenity/pull/20898.