### PR TITLE
LibWeb and friends: Add support for the color picker input

### DIFF
--- a/Ladybird/Qt/Tab.cpp
+++ b/Ladybird/Qt/Tab.cpp
@@ -15,6 +15,7 @@
 #include <LibGfx/Painter.h>
 #include <LibWebView/SourceHighlighter.h>
 #include <QClipboard>
+#include <QColorDialog>
 #include <QCoreApplication>
 #include <QCursor>
 #include <QFileDialog>
@@ -211,6 +212,21 @@ Tab::Tab(BrowserWindow* window, StringView webdriver_content_ipc_path, WebView::
     view().on_request_dismiss_dialog = [this]() {
         if (m_dialog)
             m_dialog->reject();
+    };
+
+    view().on_request_color_picker = [this](Color current_color) {
+        m_dialog = new QColorDialog(QColor(current_color.red(), current_color.green(), current_color.blue()), &view());
+        auto& dialog = static_cast<QColorDialog&>(*m_dialog);
+
+        dialog.setWindowTitle("Ladybird");
+        dialog.setOption(QColorDialog::ShowAlphaChannel, false);
+
+        if (dialog.exec() == QDialog::Accepted)
+            view().color_picker_closed(Color(dialog.selectedColor().red(), dialog.selectedColor().green(), dialog.selectedColor().blue()));
+        else
+            view().color_picker_closed({});
+
+        m_dialog = nullptr;
     };
 
     QObject::connect(focus_location_editor_action, &QAction::triggered, this, &Tab::focus_location_editor);

--- a/Userland/Applications/Browser/Tab.cpp
+++ b/Userland/Applications/Browser/Tab.cpp
@@ -28,6 +28,7 @@
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/Button.h>
 #include <LibGUI/Clipboard.h>
+#include <LibGUI/ColorPicker.h>
 #include <LibGUI/Dialog.h>
 #include <LibGUI/InputBox.h>
 #include <LibGUI/Menu.h>
@@ -564,6 +565,23 @@ Tab::Tab(BrowserWindow& window)
     view().on_request_dismiss_dialog = [this]() {
         if (m_dialog)
             m_dialog->done(GUI::Dialog::ExecResult::Cancel);
+    };
+
+    view().on_request_color_picker = [this](Color current_color) {
+        auto& window = this->window();
+
+        m_dialog = GUI::ColorPicker::construct(current_color, &window);
+        auto& dialog = static_cast<GUI::ColorPicker&>(*m_dialog);
+
+        dialog.set_icon(window.icon());
+        dialog.set_color_has_alpha_channel(false);
+
+        if (dialog.exec() == GUI::ColorPicker::ExecResult::OK)
+            view().color_picker_closed(dialog.color());
+        else
+            view().color_picker_closed({});
+
+        m_dialog = nullptr;
     };
 
     view().on_received_source = [this](auto& url, auto& source) {

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -85,6 +85,8 @@ public:
 
     bool is_mutable() const { return m_is_mutable; }
 
+    void did_pick_color(Optional<Color> picked_color);
+
     JS::GCPtr<FileAPI::FileList> files();
     void set_files(JS::GCPtr<FileAPI::FileList>);
 

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -120,6 +120,14 @@ public:
     void dismiss_dialog();
     void accept_dialog();
 
+    void did_request_color_picker(WeakPtr<HTML::HTMLInputElement> target, Color current_color);
+    void color_picker_closed(Optional<Color> picked_color);
+
+    enum class PendingNonBlockingDialog {
+        None,
+        ColorPicker,
+    };
+
     struct MediaContextMenu {
         AK::URL media_url;
         bool is_video { false };
@@ -167,6 +175,9 @@ private:
     Optional<Empty> m_pending_alert_response;
     Optional<bool> m_pending_confirm_response;
     Optional<Optional<String>> m_pending_prompt_response;
+
+    PendingNonBlockingDialog m_pending_non_blocking_dialog { PendingNonBlockingDialog::None };
+    WeakPtr<HTML::HTMLInputElement> m_pending_non_blocking_dialog_target;
 
     Optional<int> m_media_context_menu_element_id;
 
@@ -241,6 +252,7 @@ public:
 
     // https://html.spec.whatwg.org/multipage/input.html#show-the-picker,-if-applicable
     virtual void page_did_request_file_picker(WeakPtr<DOM::EventTarget>, [[maybe_unused]] bool multiple) {};
+    virtual void page_did_request_color_picker([[maybe_unused]] Color current_color) {};
 
     virtual void page_did_finish_text_test() {};
 

--- a/Userland/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Userland/Libraries/LibWebView/ViewImplementation.cpp
@@ -207,6 +207,11 @@ void ViewImplementation::prompt_closed(Optional<String> response)
     client().async_prompt_closed(move(response));
 }
 
+void ViewImplementation::color_picker_closed(Optional<Color> picked_color)
+{
+    client().async_color_picker_closed(picked_color);
+}
+
 void ViewImplementation::toggle_media_play_state()
 {
     client().async_toggle_media_play_state();

--- a/Userland/Libraries/LibWebView/ViewImplementation.h
+++ b/Userland/Libraries/LibWebView/ViewImplementation.h
@@ -82,6 +82,7 @@ public:
     void alert_closed();
     void confirm_closed(bool accepted);
     void prompt_closed(Optional<String> response);
+    void color_picker_closed(Optional<Color> picked_color);
 
     void toggle_media_play_state();
     void toggle_media_mute_state();
@@ -150,6 +151,7 @@ public:
     Function<Gfx::IntRect()> on_maximize_window;
     Function<Gfx::IntRect()> on_minimize_window;
     Function<Gfx::IntRect()> on_fullscreen_window;
+    Function<void(Color current_color)> on_request_color_picker;
     Function<void(bool)> on_finish_handling_input_event;
     Function<void()> on_text_test_finish;
 

--- a/Userland/Libraries/LibWebView/WebContentClient.cpp
+++ b/Userland/Libraries/LibWebView/WebContentClient.cpp
@@ -384,6 +384,12 @@ void WebContentClient::did_request_file(DeprecatedString const& path, i32 reques
         m_view.on_request_file(path, request_id);
 }
 
+void WebContentClient::did_request_color_picker(Color const& current_color)
+{
+    if (m_view.on_request_color_picker)
+        m_view.on_request_color_picker(current_color);
+}
+
 void WebContentClient::did_finish_handling_input_event(bool event_was_accepted)
 {
     if (m_view.on_finish_handling_input_event)

--- a/Userland/Libraries/LibWebView/WebContentClient.h
+++ b/Userland/Libraries/LibWebView/WebContentClient.h
@@ -82,6 +82,7 @@ private:
     virtual Messages::WebContentClient::DidRequestMinimizeWindowResponse did_request_minimize_window() override;
     virtual Messages::WebContentClient::DidRequestFullscreenWindowResponse did_request_fullscreen_window() override;
     virtual void did_request_file(DeprecatedString const& path, i32) override;
+    virtual void did_request_color_picker(Color const& current_color) override;
     virtual void did_finish_handling_input_event(bool event_was_accepted) override;
     virtual void did_finish_text_test() override;
 

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -892,6 +892,11 @@ void ConnectionFromClient::prompt_closed(Optional<String> const& response)
     m_page_host->prompt_closed(response);
 }
 
+void ConnectionFromClient::color_picker_closed(Optional<Color> const& picked_color)
+{
+    m_page_host->color_picker_closed(picked_color);
+}
+
 void ConnectionFromClient::toggle_media_play_state()
 {
     m_page_host->toggle_media_play_state().release_value_but_fixme_should_propagate_errors();

--- a/Userland/Services/WebContent/ConnectionFromClient.h
+++ b/Userland/Services/WebContent/ConnectionFromClient.h
@@ -97,6 +97,7 @@ private:
     virtual void alert_closed() override;
     virtual void confirm_closed(bool accepted) override;
     virtual void prompt_closed(Optional<String> const& response) override;
+    virtual void color_picker_closed(Optional<Color> const& picked_color) override;
 
     virtual void toggle_media_play_state() override;
     virtual void toggle_media_mute_state() override;

--- a/Userland/Services/WebContent/PageHost.cpp
+++ b/Userland/Services/WebContent/PageHost.cpp
@@ -358,6 +358,11 @@ void PageHost::prompt_closed(Optional<String> response)
     page().prompt_closed(move(response));
 }
 
+void PageHost::color_picker_closed(Optional<Color> picked_color)
+{
+    page().color_picker_closed(picked_color);
+}
+
 Web::WebIDL::ExceptionOr<void> PageHost::toggle_media_play_state()
 {
     return page().toggle_media_play_state();
@@ -451,6 +456,11 @@ void PageHost::page_did_close_browsing_context(Web::HTML::BrowsingContext const&
 void PageHost::request_file(Web::FileRequest file_request)
 {
     m_client.request_file(move(file_request));
+}
+
+void PageHost::page_did_request_color_picker(Color current_color)
+{
+    m_client.async_did_request_color_picker(current_color);
 }
 
 }

--- a/Userland/Services/WebContent/PageHost.h
+++ b/Userland/Services/WebContent/PageHost.h
@@ -48,6 +48,7 @@ public:
     void alert_closed();
     void confirm_closed(bool accepted);
     void prompt_closed(Optional<String> response);
+    void color_picker_closed(Optional<Color> picked_color);
 
     Web::WebIDL::ExceptionOr<void> toggle_media_play_state();
     void toggle_media_mute_state();
@@ -113,6 +114,7 @@ private:
     virtual void page_did_request_activate_tab() override;
     virtual void page_did_close_browsing_context(Web::HTML::BrowsingContext const&) override;
     virtual void request_file(Web::FileRequest) override;
+    virtual void page_did_request_color_picker(Color current_color) override;
     virtual void page_did_finish_text_test() override;
 
     explicit PageHost(ConnectionFromClient&);

--- a/Userland/Services/WebContent/WebContentClient.ipc
+++ b/Userland/Services/WebContent/WebContentClient.ipc
@@ -59,6 +59,7 @@ endpoint WebContentClient
     did_request_minimize_window() => (Gfx::IntRect window_rect)
     did_request_fullscreen_window() => (Gfx::IntRect window_rect)
     did_request_file(DeprecatedString path, i32 request_id) =|
+    did_request_color_picker(Color current_color) =|
     did_finish_handling_input_event(bool event_was_accepted) =|
 
     did_output_js_console_message(i32 message_index) =|

--- a/Userland/Services/WebContent/WebContentServer.ipc
+++ b/Userland/Services/WebContent/WebContentServer.ipc
@@ -78,6 +78,7 @@ endpoint WebContentServer
     alert_closed() =|
     confirm_closed(bool accepted) =|
     prompt_closed(Optional<String> response) =|
+    color_picker_closed(Optional<Color> picked_color) =|
 
     toggle_media_play_state() =|
     toggle_media_mute_state() =|


### PR DESCRIPTION
This adds support for color picker input elements. Currently it is primitively shown as a button, the visuals I plan to improve later. On frontends that support it, which are currently Browser LibGUI and Ladybird Qt, pressing it will open the system color picker, it is modeled after the behavior of Firefox, where the changes are only committed after confirming the selection.

HTMLInputElement has a new function did_pick_color which is called by the relevant logic in Page.cpp, where a new type of "non-blocking dialog" is handled by keeping track of the target HTMLInputElement and functions did_request_color_picker and color_picker_closed (This is meant to be expandable for implementing a file picker). In current implementations in Browser and Ladybird, the color dialog is modal, however there is support for a non-modal color picker, as no event loops are blocked by the dialog being open. There can be only one of this type of dialog open at once, which is a bit arbitrary.

Reviews and suggestions are very welcome, especially regarding pointer usage and memory safety errors, as this is the first time I implement such functionality. A potential architectural issue is the logic being present in Page and calling the HTMLInputElement directly, I am not sure if this belong in Page.cpp and should be done this way.