### PR TITLE
LibWeb: Two CSS font-size fixes for varberg.se

### DIFF
--- a/Tests/LibWeb/Layout/expected/font-size-zero.txt
+++ b/Tests/LibWeb/Layout/expected/font-size-zero.txt
@@ -1,0 +1,14 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x16 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x0 children: not-inline
+      BlockContainer <div> at (8,8) content-size 784x0 children: inline
+        line 0 width: 0, height: 0, bottom: 0, baseline: 0
+          frag 0 from TextNode start: 0, length: 21, rect: [8,8 0x0]
+            "should not be visible"
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x16]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x0]
+      PaintableWithLines (BlockContainer<DIV>) [8,8 784x0]
+        TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/table-fixup-font-size-and-line-height.txt
+++ b/Tests/LibWeb/Layout/expected/table/table-fixup-font-size-and-line-height.txt
@@ -1,0 +1,20 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x116 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x100 children: not-inline
+      TableWrapper <(anonymous)> at (8,8) content-size 69.078125x100 [BFC] children: not-inline
+        Box <div> at (8,8) content-size 69.078125x100 table-box [TFC] children: inline
+          Box <(anonymous)> at (8,8) content-size 69.078125x100 table-row children: inline
+            BlockContainer <(anonymous)> at (8,8) content-size 69.078125x100 table-cell [BFC] children: inline
+              line 0 width: 69.078125, height: 100, bottom: 100, baseline: 59
+                frag 0 from TextNode start: 0, length: 5, rect: [8,8 69.078125x100]
+                  "hello"
+              TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x116]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x100]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 69.078125x100]
+        PaintableBox (Box<DIV>) [8,8 69.078125x100]
+          PaintableBox (Box(anonymous)) [8,8 69.078125x100]
+            PaintableWithLines (BlockContainer(anonymous)) [8,8 69.078125x100]
+              TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/input/font-size-zero.html
+++ b/Tests/LibWeb/Layout/input/font-size-zero.html
@@ -1,0 +1,5 @@
+<!doctype html><style>
+div {
+    font-size: 0px;
+}
+</style><div>should not be visible

--- a/Tests/LibWeb/Layout/input/table/table-fixup-font-size-and-line-height.html
+++ b/Tests/LibWeb/Layout/input/table/table-fixup-font-size-and-line-height.html
@@ -1,0 +1,8 @@
+<!doctype html><style>
+* { outline: 1px solid black; }
+div { display: table; }
+body {
+    font-size: 30px;
+    line-height: 100px;
+}
+</style><body><div>hello

--- a/Userland/Libraries/LibGfx/Font/Typeface.cpp
+++ b/Userland/Libraries/LibGfx/Font/Typeface.cpp
@@ -61,7 +61,7 @@ void Typeface::set_vector_font(RefPtr<VectorFont> font)
 
 RefPtr<Font> Typeface::get_font(float point_size, Font::AllowInexactSizeMatch allow_inexact_size_match) const
 {
-    VERIFY(point_size > 0);
+    VERIFY(point_size >= 0);
 
     if (m_vector_font)
         return adopt_ref(*new Gfx::ScaledFont(*m_vector_font, point_size, point_size));

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -2223,8 +2223,7 @@ RefPtr<Gfx::Font const> StyleComputer::compute_font_for_style_values(DOM::Elemen
         }
         if (maybe_length.has_value()) {
             auto px = maybe_length.value().to_px(length_resolution_context).to_int();
-            if (px != 0)
-                font_size_in_px = px;
+            font_size_in_px = px;
         }
     }
 


### PR DESCRIPTION
- Allow `font-size: 0px` since that's a valid value.
- Propagate `font-size` (and `line-height` too!) to generated table boxes.

Visual progression on https://varberg.se/

Before:
![Screenshot at 2023-09-05 12-07-24](https://github.com/SerenityOS/serenity/assets/5954907/14b218c1-bd0f-4040-96f9-dcd56b860213)

After:
![Screenshot at 2023-09-05 12-06-00](https://github.com/SerenityOS/serenity/assets/5954907/66a126a6-037f-42d6-8dab-563852ec6f7d)
