### PR TITLE
glibc-related improvements

### DIFF
--- a/AK/Assertions.cpp
+++ b/AK/Assertions.cpp
@@ -9,7 +9,7 @@
 #include <AK/Platform.h>
 #include <AK/StringView.h>
 
-#if (defined(AK_OS_LINUX) && !defined(AK_OS_ANDROID)) || defined(AK_OS_BSD_GENERIC) || defined(AK_OS_SOLARIS)
+#if (defined(AK_OS_LINUX) && !defined(AK_OS_ANDROID)) || defined(AK_LIBC_GLIBC) || defined(AK_OS_BSD_GENERIC) || defined(AK_OS_SOLARIS)
 #    define EXECINFO_BACKTRACE
 #endif
 

--- a/AK/Platform.h
+++ b/AK/Platform.h
@@ -47,6 +47,13 @@
 #    define AK_COMPILER_GCC
 #endif
 
+#if defined(__GLIBC__)
+#    define AK_LIBC_GLIBC
+#    define AK_LIBC_GLIBC_PREREQ(maj, min) __GLIBC_PREREQ((maj), (min))
+#else
+#    define AK_LIBC_GLIBC_PREREQ(maj, min) 0
+#endif
+
 #if defined(__serenity__)
 #    define AK_OS_SERENITY
 #endif

--- a/AK/Random.h
+++ b/AK/Random.h
@@ -20,7 +20,7 @@ namespace AK {
 
 inline void fill_with_random([[maybe_unused]] Bytes bytes)
 {
-#if defined(AK_OS_SERENITY) || defined(AK_OS_ANDROID) || defined(AK_OS_BSD_GENERIC)
+#if defined(AK_OS_SERENITY) || defined(AK_OS_ANDROID) || defined(AK_OS_BSD_GENERIC) || AK_LIBC_GLIBC_PREREQ(2, 36)
     arc4random_buf(bytes.data(), bytes.size());
 #elif defined(OSS_FUZZ)
 #else

--- a/AK/StackInfo.cpp
+++ b/AK/StackInfo.cpp
@@ -12,7 +12,7 @@
 
 #ifdef AK_OS_SERENITY
 #    include <serenity.h>
-#elif defined(AK_OS_LINUX) or defined(AK_OS_MACOS) or defined(AK_OS_NETBSD) or defined(AK_OS_SOLARIS)
+#elif defined(AK_OS_LINUX) or defined(AK_LIBC_GLIBC) or defined(AK_OS_MACOS) or defined(AK_OS_NETBSD) or defined(AK_OS_SOLARIS)
 #    include <pthread.h>
 #elif defined(AK_OS_FREEBSD) or defined(AK_OS_OPENBSD)
 #    include <pthread.h>
@@ -32,12 +32,12 @@ StackInfo::StackInfo()
         perror("get_stack_bounds");
         VERIFY_NOT_REACHED();
     }
-#elif defined(AK_OS_LINUX) or defined(AK_OS_FREEBSD) or defined(AK_OS_NETBSD) or defined(AK_OS_SOLARIS)
+#elif defined(AK_OS_LINUX) or defined(AK_LIBC_GLIBC) or defined(AK_OS_FREEBSD) or defined(AK_OS_NETBSD) or defined(AK_OS_SOLARIS)
     int rc;
     pthread_attr_t attr;
     pthread_attr_init(&attr);
 
-#    ifdef AK_OS_LINUX
+#    if defined(AK_OS_LINUX) or defined(AK_LIBC_GLIBC)
     if ((rc = pthread_getattr_np(pthread_self(), &attr)) != 0) {
         fprintf(stderr, "pthread_getattr_np: %s\n", strerror(rc));
         VERIFY_NOT_REACHED();

--- a/Userland/Libraries/LibCore/Process.cpp
+++ b/Userland/Libraries/LibCore/Process.cpp
@@ -118,7 +118,7 @@ ErrorOr<String> Process::get_name()
     if (rc != 0)
         return Error::from_syscall("get_process_name"sv, -rc);
     return String::from_utf8(StringView { buffer, strlen(buffer) });
-#elif defined(AK_OS_LINUX) && !defined(AK_OS_ANDROID)
+#elif defined(AK_LIBC_GLIBC) || (defined(AK_OS_LINUX) && !defined(AK_OS_ANDROID))
     return String::from_utf8(StringView { program_invocation_name, strlen(program_invocation_name) });
 #elif defined(AK_OS_BSD_GENERIC)
     auto const* progname = getprogname();

--- a/Userland/Libraries/LibFileSystem/FileSystem.cpp
+++ b/Userland/Libraries/LibFileSystem/FileSystem.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <AK/LexicalPath.h>
+#include <AK/ScopeGuard.h>
 #include <LibCore/DirIterator.h>
 #include <LibCore/System.h>
 #include <LibFileSystem/FileSystem.h>
@@ -47,9 +48,9 @@ ErrorOr<String> real_path(StringView path)
     if (path.is_null())
         return Error::from_errno(ENOENT);
 
-    char buffer[PATH_MAX];
     DeprecatedString dep_path = path;
-    auto* real_path = realpath(dep_path.characters(), buffer);
+    char* real_path = realpath(dep_path.characters(), nullptr);
+    ScopeGuard free_path = [real_path]() { free(real_path); };
 
     if (!real_path)
         return Error::from_syscall("realpath"sv, -errno);


### PR DESCRIPTION
* get rid of not one, but two `PATH_MAX` usages 🎉
    * note: `realpath(..., nullptr)` used to be a glibc extension, but it's in POSIX now, so we should be able to just use it
* enable `arc4random_buf()` on recent glibc versions
* gate some things that are glibc-specific, not Linux-specific, on the new `AK_LIBC_GLIBC`

This is in preparation for adding support for a certain OS that uses glibc, but not Linux 😉