### PR TITLE
Port Lagom to GNU/Hurd :^)

### DIFF
--- a/AK/Platform.h
+++ b/AK/Platform.h
@@ -92,6 +92,10 @@
 #    define AK_OS_SOLARIS
 #endif
 
+#if defined(__gnu_hurd__)
+#    define AK_OS_GNU_HURD
+#endif
+
 #if defined(_WIN32) || defined(_WIN64)
 #    define AK_OS_WINDOWS
 #endif

--- a/Tests/LibJS/test262-runner.cpp
+++ b/Tests/LibJS/test262-runner.cpp
@@ -25,7 +25,7 @@
 #include <signal.h>
 #include <unistd.h>
 
-#if !defined(AK_OS_MACOS) && !defined(AK_OS_EMSCRIPTEN)
+#if !defined(AK_OS_MACOS) && !defined(AK_OS_EMSCRIPTEN) && !defined(AK_OS_GNU_HURD)
 // Only used to disable core dumps
 #    include <sys/prctl.h>
 #endif
@@ -573,7 +573,10 @@ int main(int argc, char** argv)
     args_parser.add_option(disable_core_dumping, "Disable core dumping", "disable-core-dump", 0);
     args_parser.parse(arguments);
 
-#if !defined(AK_OS_MACOS) && !defined(AK_OS_EMSCRIPTEN)
+#ifdef AK_OS_GNU_HURD
+    if (disable_core_dumping)
+        setenv("CRASHSERVER", "/servers/crash-kill", true);
+#elif !defined(AK_OS_MACOS) && !defined(AK_OS_EMSCRIPTEN)
     if (disable_core_dumping && prctl(PR_SET_DUMPABLE, 0, 0, 0) < 0) {
         perror("prctl(PR_SET_DUMPABLE)");
         return exit_wrong_arguments;

--- a/Userland/Libraries/LibCore/Socket.cpp
+++ b/Userland/Libraries/LibCore/Socket.cpp
@@ -282,7 +282,7 @@ ErrorOr<int> LocalSocket::receive_fd(int flags)
 {
 #if defined(AK_OS_SERENITY)
     return Core::System::recvfd(m_helper.fd(), flags);
-#elif defined(AK_OS_LINUX) || defined(AK_OS_BSD_GENERIC)
+#elif defined(AK_OS_LINUX) || defined(AK_OS_GNU_HURD) || defined(AK_OS_BSD_GENERIC)
     union {
         struct cmsghdr cmsghdr;
         char control[CMSG_SPACE(sizeof(int))];
@@ -323,7 +323,7 @@ ErrorOr<void> LocalSocket::send_fd(int fd)
 {
 #if defined(AK_OS_SERENITY)
     return Core::System::sendfd(m_helper.fd(), fd);
-#elif defined(AK_OS_LINUX) || defined(AK_OS_BSD_GENERIC)
+#elif defined(AK_OS_LINUX) || defined(AK_OS_GNU_HURD) || defined(AK_OS_BSD_GENERIC)
     char c = 'F';
     struct iovec iov {
         .iov_base = &c,
@@ -373,6 +373,8 @@ ErrorOr<pid_t> LocalSocket::peer_pid() const
 #elif defined(AK_OS_SOLARIS)
     ucred_t* creds = NULL;
     socklen_t creds_size = sizeof(creds);
+#elif defined(AK_OS_GNU_HURD)
+    return Error::from_errno(ENOTSUP);
 #else
     struct ucred creds = {};
     socklen_t creds_size = sizeof(creds);
@@ -390,7 +392,7 @@ ErrorOr<pid_t> LocalSocket::peer_pid() const
 #elif defined(AK_OS_SOLARIS)
     TRY(System::getsockopt(m_helper.fd(), SOL_SOCKET, SO_RECVUCRED, &creds, &creds_size));
     return ucred_getpid(creds);
-#else
+#elif !defined(AK_OS_GNU_HURD)
     TRY(System::getsockopt(m_helper.fd(), SOL_SOCKET, SO_PEERCRED, &creds, &creds_size));
     return creds.pid;
 #endif

--- a/Userland/Libraries/LibCore/System.cpp
+++ b/Userland/Libraries/LibCore/System.cpp
@@ -479,6 +479,15 @@ ErrorOr<int> anon_create([[maybe_unused]] size_t size, [[maybe_unused]] int opti
         TRY(close(fd));
         return Error::from_errno(saved_errno);
     }
+#elif defined(SHM_ANON)
+    fd = shm_open(SHM_ANON, O_RDWR | O_CREAT | options, 0600);
+    if (fd < 0)
+        return Error::from_errno(errno);
+    if (::ftruncate(fd, size) < 0) {
+        auto saved_errno = errno;
+        TRY(close(fd));
+        return Error::from_errno(saved_errno);
+    }
 #elif defined(AK_OS_BSD_GENERIC) || defined(AK_OS_EMSCRIPTEN)
     struct timespec time;
     clock_gettime(CLOCK_REALTIME, &time);

--- a/Userland/Libraries/LibDNS/Answer.cpp
+++ b/Userland/Libraries/LibDNS/Answer.cpp
@@ -24,7 +24,7 @@ Answer::Answer(Name const& name, RecordType type, RecordClass class_code, u32 tt
 
 bool Answer::has_expired() const
 {
-    return time(nullptr) >= m_received_time + m_ttl;
+    return time(nullptr) >= static_cast<time_t>(m_received_time + m_ttl);
 }
 
 unsigned Answer::hash() const

--- a/Userland/Libraries/LibTest/CrashTest.cpp
+++ b/Userland/Libraries/LibTest/CrashTest.cpp
@@ -12,7 +12,7 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
-#if !defined(AK_OS_MACOS) && !defined(AK_OS_EMSCRIPTEN)
+#if !defined(AK_OS_MACOS) && !defined(AK_OS_EMSCRIPTEN) && !defined(AK_OS_GNU_HURD)
 #    include <sys/prctl.h>
 #endif
 
@@ -38,7 +38,10 @@ bool Crash::run(RunType run_type)
             perror("fork");
             VERIFY_NOT_REACHED();
         } else if (pid == 0) {
-#if !defined(AK_OS_MACOS) && !defined(AK_OS_EMSCRIPTEN)
+#if defined(AK_OS_GNU_HURD)
+            // When we crash, just kill the program, don't dump core.
+            setenv("CRASHSERVER", "/servers/crash-kill", true);
+#elif !defined(AK_OS_MACOS) && !defined(AK_OS_EMSCRIPTEN)
             if (prctl(PR_SET_DUMPABLE, 0, 0, 0) < 0)
                 perror("prctl(PR_SET_DUMPABLE)");
 #endif

--- a/Userland/Libraries/LibTest/JavaScriptTestRunnerMain.cpp
+++ b/Userland/Libraries/LibTest/JavaScriptTestRunnerMain.cpp
@@ -42,7 +42,7 @@ static void handle_sigabrt(int)
     Test::cleanup();
     struct sigaction act;
     memset(&act, 0, sizeof(act));
-    act.sa_flags = SA_NOCLDWAIT;
+    act.sa_flags = 0;
     act.sa_handler = SIG_DFL;
     int rc = sigaction(SIGABRT, &act, nullptr);
     if (rc < 0) {
@@ -66,7 +66,7 @@ int main(int argc, char** argv)
 
     struct sigaction act;
     memset(&act, 0, sizeof(act));
-    act.sa_flags = SA_NOCLDWAIT;
+    act.sa_flags = 0;
     act.sa_handler = handle_sigabrt;
     int rc = sigaction(SIGABRT, &act, nullptr);
     if (rc < 0) {

--- a/Userland/Libraries/LibWeb/Loader/ResourceLoader.h
+++ b/Userland/Libraries/LibWeb/Loader/ResourceLoader.h
@@ -42,6 +42,8 @@ namespace Web {
 #    define OS_STRING "DragonFly"
 #elif defined(AK_OS_SOLARIS)
 #    define OS_STRING "SunOS"
+#elif defined(AK_OS_GNU_HURD)
+#    define OS_STRING "GNU/Hurd"
 #else
 #    error Unknown OS
 #endif

--- a/Userland/Services/LookupServer/MulticastDNS.h
+++ b/Userland/Services/LookupServer/MulticastDNS.h
@@ -36,8 +36,11 @@ private:
 
     Name m_hostname;
 
+    // https://github.com/llvm/llvm-project/issues/56685
+    // https://github.com/llvm/llvm-project/pull/65409
+    // clang-format off
     static constexpr sockaddr_in mdns_addr {
-#ifdef AK_OS_BSD_GENERIC
+#if defined(AK_OS_BSD_GENERIC) || defined(AK_OS_GNU_HURD)
         .sin_len = sizeof(struct sockaddr_in),
 #endif
         .sin_family = AF_INET,
@@ -47,6 +50,7 @@ private:
         .sin_addr = { 0xfb0000e0 },
         .sin_zero = { 0 }
     };
+    // clang-format on
 };
 
 }


### PR DESCRIPTION
[GNU Hurd](https://www.gnu.org/software/hurd/) is the GNU project's kernel (actually a microkernel system on top of Mach). Contrary to the popular belief, the Hurd is not dead, not a failure, and works very well 😄

GNU/Hurd is the GNU operating system using Hurd as its kernel (just like GNU/Linux and GNU/kFreeBSD). It is the very same system as GNU/Linux, except for the kernel which is Hurd and not Linux. In particular GNU/Hurd is too built with the GNU toolchain (GCC & binutils), is too using glibc (everyone's favorite libc!), Bash, Nano, and all the other GNU (and non-GNU) software.

So, since Lagom has already been ported to GNU/Linux and doesn't really do much of kernel-specific things such as direct syscalls, one would think that it would just build & work on the Hurd. That is true to an extent, but also some things, mostly in LibCore/System, are kernel-specific, so those needed porting. Also the Hurd is mixing some things compared to Linux, specifically `SO_TIMESTAMP`, `SA_NOCLDWAIT`, and any form of `ucred`/`PEERCRED` (a downstream patch adding `SCM_CREDS` exists in Debian GNU/Hurd, but it is [very broken](https://mail.gnu.org/archive/html/bug-hurd/2023-02/msg00054.html)).

Of course, the best thing about the Hurd is the principal stance that they/we have taken on `PATH_MAX`: the Hurd does not have `PATH_MAX` at all (which is absolutely allowed by POSIX), and does not limit path lengths. This makes all the broken programs that (unconditionally) use `PATH_MAX` instantly apparent :^)

While x86_64 builds of the Hurd (and Debian GNU/Hurd) [exist](https://www.gnu.org/software/hurd/open_issues/64-bit_port.html) (that page is outdated, too: it was written back in May, when I only got `/bin/sh` to run; we've made a lot of progress since then), they are heavily WIP, so I used a i686 Hurd system to do the port. This uncovered a bunch of issues that are unrelated to the Hurd, see https://github.com/SerenityOS/serenity/pull/20957.

The port depends on https://github.com/SerenityOS/serenity/pull/20958 for fixes/improvements that are glibc-related, but not Hurd-specific.

Here's a screenshot of the Shell and the JS REPL running on my Hurd box, 100% `PATH_MAX`-free 😄:

![Screenshot from 2023-09-05 17-36-31](https://github.com/SerenityOS/serenity/assets/10091584/fbc2ef63-9cff-490b-9731-e265fc94306b)

I'd like to get Ladybird building & running, but that depends on the squashing the remaining issues with https://github.com/SerenityOS/serenity/pull/20957