### PR TITLE
Maps: Fix a hang, use cached tiles from other zoom levels, and zoom on doubleclick

### DIFF
--- a/Userland/Applications/Maps/MapWidget.cpp
+++ b/Userland/Applications/Maps/MapWidget.cpp
@@ -77,6 +77,12 @@ void MapWidget::set_zoom(int zoom)
     update();
 }
 
+void MapWidget::doubleclick_event(GUI::MouseEvent& event)
+{
+    int new_zoom = event.shift() ? m_zoom - 1 : m_zoom + 1;
+    set_zoom_for_mouse_event(new_zoom, event);
+}
+
 void MapWidget::mousedown_event(GUI::MouseEvent& event)
 {
     if (m_connection_failed)
@@ -149,16 +155,21 @@ void MapWidget::mousewheel_event(GUI::MouseEvent& event)
         return;
 
     int new_zoom = event.wheel_delta_y() > 0 ? m_zoom - 1 : m_zoom + 1;
-    if (new_zoom < ZOOM_MIN || new_zoom > ZOOM_MAX)
+    set_zoom_for_mouse_event(new_zoom, event);
+}
+
+void MapWidget::set_zoom_for_mouse_event(int zoom, GUI::MouseEvent& event)
+{
+    if (zoom == m_zoom || zoom < ZOOM_MIN || zoom > ZOOM_MAX)
         return;
-    if (event.wheel_delta_y() > 0) {
+    if (zoom < m_zoom) {
         set_center({ tile_y_to_latitude(latitude_to_tile_y(m_center.latitude, m_zoom) - static_cast<double>(event.y() - height() / 2) / TILE_SIZE, m_zoom),
             tile_x_to_longitude(longitude_to_tile_x(m_center.longitude, m_zoom) - static_cast<double>(event.x() - width() / 2) / TILE_SIZE, m_zoom) });
     } else {
-        set_center({ tile_y_to_latitude(latitude_to_tile_y(m_center.latitude, new_zoom) + static_cast<double>(event.y() - height() / 2) / TILE_SIZE, new_zoom),
-            tile_x_to_longitude(longitude_to_tile_x(m_center.longitude, new_zoom) + static_cast<double>(event.x() - width() / 2) / TILE_SIZE, new_zoom) });
+        set_center({ tile_y_to_latitude(latitude_to_tile_y(m_center.latitude, zoom) + static_cast<double>(event.y() - height() / 2) / TILE_SIZE, zoom),
+            tile_x_to_longitude(longitude_to_tile_x(m_center.longitude, zoom) + static_cast<double>(event.x() - width() / 2) / TILE_SIZE, zoom) });
     }
-    set_zoom(new_zoom);
+    set_zoom(zoom);
 }
 
 Optional<RefPtr<Gfx::Bitmap>> MapWidget::get_tile_image(int x, int y, int zoom, TileDownloadBehavior download_behavior)

--- a/Userland/Applications/Maps/MapWidget.cpp
+++ b/Userland/Applications/Maps/MapWidget.cpp
@@ -161,15 +161,17 @@ void MapWidget::mousewheel_event(GUI::MouseEvent& event)
     set_zoom(new_zoom);
 }
 
-Optional<RefPtr<Gfx::Bitmap>> MapWidget::get_tile_image(int x, int y)
+Optional<RefPtr<Gfx::Bitmap>> MapWidget::get_tile_image(int x, int y, int zoom, TileDownloadBehavior download_behavior)
 {
     // Get the tile from tiles cache
-    TileKey const key = { x, y, m_zoom };
+    TileKey const key = { x, y, zoom };
     if (auto it = m_tiles.find(key); it != m_tiles.end()) {
         if (it->value)
             return it->value;
         return {};
     }
+    if (download_behavior == TileDownloadBehavior::DoNotDownload)
+        return {};
 
     // Register an empty tile so we don't send requests multiple times
     if (m_tiles.size() >= TILES_CACHE_MAX)
@@ -262,10 +264,62 @@ void MapWidget::paint_tiles(GUI::Painter& painter)
             if (tile_x < 0 || tile_y < 0 || tile_x > pow(2, m_zoom) - 1 || tile_y > pow(2, m_zoom) - 1)
                 continue;
 
+            auto tile_rect = Gfx::IntRect {
+                static_cast<int>(width() / 2 + dx * TILE_SIZE - offset_x),
+                static_cast<int>(height() / 2 + dy * TILE_SIZE - offset_y),
+                TILE_SIZE,
+                TILE_SIZE,
+            };
+            if (!painter.clip_rect().intersects(tile_rect))
+                continue;
+
             // Get tile, when it has a loaded image draw it at the right position
-            auto tile_image = get_tile_image(tile_x, tile_y);
-            if (tile_image.has_value())
-                painter.blit({ static_cast<int>(width() / 2 + dx * TILE_SIZE - offset_x), static_cast<int>(height() / 2 + dy * TILE_SIZE - offset_y) }, *tile_image.release_value(), { 0, 0, TILE_SIZE, TILE_SIZE }, 1);
+            auto tile_image = get_tile_image(tile_x, tile_y, m_zoom, TileDownloadBehavior::Download);
+            auto const tile_source = Gfx::IntRect { 0, 0, TILE_SIZE, TILE_SIZE };
+            if (tile_image.has_value()) {
+                painter.blit(tile_rect.location(), *tile_image.release_value(), tile_source, 1);
+                continue;
+            }
+
+            // Fallback: try to compose the tile from already cached tiles from a higher zoom level
+            auto cached_tiles_used = 0;
+            if (m_zoom < ZOOM_MAX) {
+                auto const child_top_left_tile_x = tile_x * 2;
+                auto const child_top_left_tile_y = tile_y * 2;
+                for (auto child_tile_x = child_top_left_tile_x; child_tile_x <= child_top_left_tile_x + 1; ++child_tile_x) {
+                    for (auto child_tile_y = child_top_left_tile_y; child_tile_y <= child_top_left_tile_y + 1; ++child_tile_y) {
+                        auto child_tile = get_tile_image(child_tile_x, child_tile_y, m_zoom + 1, TileDownloadBehavior::DoNotDownload);
+                        if (!child_tile.has_value())
+                            continue;
+
+                        auto target_rect = tile_rect;
+                        target_rect.set_size(TILE_SIZE / 2, TILE_SIZE / 2);
+                        if ((child_tile_x & 1) > 0)
+                            target_rect.translate_by(TILE_SIZE / 2, 0);
+                        if ((child_tile_y & 1) > 0)
+                            target_rect.translate_by(0, TILE_SIZE / 2);
+
+                        painter.draw_scaled_bitmap(target_rect, *child_tile.release_value(), tile_source, 1.f, Gfx::Painter::ScalingMode::BoxSampling);
+                        ++cached_tiles_used;
+                    }
+                }
+            }
+
+            // Fallback: try to use an already cached tile from a lower zoom level
+            // Note: we only want to try this if we did not find exactly 4 cached child tiles in the previous fallback (i.e. there are gaps)
+            if (m_zoom > ZOOM_MIN && cached_tiles_used < 4) {
+                auto const parent_tile_x = tile_x / 2;
+                auto const parent_tile_y = tile_y / 2;
+                auto larger_tile = get_tile_image(parent_tile_x, parent_tile_y, m_zoom - 1, TileDownloadBehavior::DoNotDownload);
+                if (larger_tile.has_value()) {
+                    auto source_rect = Gfx::IntRect { 0, 0, TILE_SIZE / 2, TILE_SIZE / 2 };
+                    if ((tile_x & 1) > 0)
+                        source_rect.translate_by(TILE_SIZE / 2, 0);
+                    if ((tile_y & 1) > 0)
+                        source_rect.translate_by(0, TILE_SIZE / 2);
+                    painter.draw_scaled_bitmap(tile_rect, *larger_tile.release_value(), source_rect, 1.f, Gfx::Painter::ScalingMode::BilinearBlend);
+                }
+            }
         }
     }
 }

--- a/Userland/Applications/Maps/MapWidget.cpp
+++ b/Userland/Applications/Maps/MapWidget.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2023, Bastiaan van der Plaat <bastiaan.v.d.plaat@gmail.com>
+ * Copyright (c) 2023, Jelle Raaijmakers <jelle@gmta.nl>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -67,6 +68,13 @@ MapWidget::MapWidget(Options const& options)
     , m_attribution_url(options.attribution_url)
 {
     m_request_client = Protocol::RequestClient::try_create().release_value_but_fixme_should_propagate_errors();
+}
+
+void MapWidget::set_zoom(int zoom)
+{
+    m_zoom = min(max(zoom, ZOOM_MIN), ZOOM_MAX);
+    clear_tile_queue();
+    update();
 }
 
 void MapWidget::mousedown_event(GUI::MouseEvent& event)
@@ -155,30 +163,51 @@ void MapWidget::mousewheel_event(GUI::MouseEvent& event)
 
 Optional<RefPtr<Gfx::Bitmap>> MapWidget::get_tile_image(int x, int y)
 {
-    // Get the right tile from tiles cache
-    TileKey key = { x, y, m_zoom };
+    // Get the tile from tiles cache
+    TileKey const key = { x, y, m_zoom };
     if (auto it = m_tiles.find(key); it != m_tiles.end()) {
         if (it->value)
             return it->value;
         return {};
     }
 
-    // Add tile when not in tiles
+    // Register an empty tile so we don't send requests multiple times
     if (m_tiles.size() >= TILES_CACHE_MAX)
         m_tiles.remove(m_tiles.begin());
     m_tiles.set(key, nullptr);
+
+    // Schedule the tile download
+    m_tile_queue.enqueue(key);
+    process_tile_queue();
+    return {};
+}
+
+void MapWidget::process_tile_queue()
+{
+    if (m_active_requests.size() >= TILES_DOWNLOAD_PARALLEL_MAX)
+        return;
+    if (m_tile_queue.is_empty())
+        return;
+
+    auto tile_key = m_tile_queue.dequeue();
 
     // Start HTTP GET request to load image
     HashMap<DeprecatedString, DeprecatedString> headers;
     headers.set("User-Agent", "SerenityOS Maps");
     headers.set("Accept", "image/png");
-    URL url(MUST(String::formatted(m_tile_layer_url, m_zoom, x, y)));
+    URL url(MUST(String::formatted(m_tile_layer_url, tile_key.zoom, tile_key.x, tile_key.y)));
     auto request = m_request_client->start_request("GET", url, headers, {});
+    VERIFY(!request.is_null());
+
     m_active_requests.append(request);
-    request->on_buffered_request_finish = [this, request, url, key](bool success, auto, auto&, auto, ReadonlyBytes payload) {
-        m_active_requests.remove_all_matching([request](auto const& other_request) { return other_request->id() == request->id(); });
+    request->on_buffered_request_finish = [this, request, url, tile_key](bool success, auto, auto&, auto, ReadonlyBytes payload) {
+        auto was_active = m_active_requests.remove_first_matching([request](auto const& other_request) { return other_request->id() == request->id(); });
+        if (!was_active)
+            return;
+        deferred_invoke([this]() { this->process_tile_queue(); });
+
+        // When first image load fails set connection failed
         if (!success) {
-            // When first image load fails set connection failed
             if (!m_first_image_loaded) {
                 m_first_image_loaded = true;
                 m_connection_failed = true;
@@ -194,14 +223,24 @@ Optional<RefPtr<Gfx::Bitmap>> MapWidget::get_tile_image(int x, int y)
             dbgln("Maps: Can't decode image: {}", url);
             return;
         }
-        m_tiles.set(key, decoder->frame(0).release_value_but_fixme_should_propagate_errors().image);
+        m_tiles.set(tile_key, decoder->frame(0).release_value_but_fixme_should_propagate_errors().image);
+
+        // FIXME: only update the part of the screen that this tile covers
         update();
     };
     request->set_should_buffer_all_input(true);
     request->on_certificate_requested = []() -> Protocol::Request::CertificateAndKey { return {}; };
+}
 
-    // Return no image for now
-    return {};
+void MapWidget::clear_tile_queue()
+{
+    m_tile_queue.clear();
+
+    // FIXME: ideally we would like to abort all active requests here, but invoking `->stop()`
+    //        often causes hangs for me for some reason.
+    m_active_requests.clear_with_capacity();
+
+    m_tiles.remove_all_matching([](auto, auto const& value) -> bool { return !value; });
 }
 
 void MapWidget::paint_tiles(GUI::Painter& painter)

--- a/Userland/Applications/Maps/MapWidget.h
+++ b/Userland/Applications/Maps/MapWidget.h
@@ -72,26 +72,22 @@ public:
 private:
     MapWidget(Options const&);
 
+    virtual void doubleclick_event(GUI::MouseEvent&) override;
     virtual void mousemove_event(GUI::MouseEvent&) override;
-
     virtual void mousedown_event(GUI::MouseEvent&) override;
-
     virtual void mouseup_event(GUI::MouseEvent&) override;
-
     virtual void mousewheel_event(GUI::MouseEvent&) override;
-
     virtual void paint_event(GUI::PaintEvent&) override;
+
+    void set_zoom_for_mouse_event(int zoom, GUI::MouseEvent&);
 
     Optional<RefPtr<Gfx::Bitmap>> get_tile_image(int x, int y, int zoom, TileDownloadBehavior);
     void process_tile_queue();
     void clear_tile_queue();
 
     void paint_tiles(GUI::Painter&);
-
     void paint_scale_line(GUI::Painter&, String label, Gfx::IntRect rect);
-
     void paint_scale(GUI::Painter&);
-
     void paint_attribution(GUI::Painter&);
 
     static int constexpr TILE_SIZE = 256;

--- a/Userland/Applications/Maps/MapWidget.h
+++ b/Userland/Applications/Maps/MapWidget.h
@@ -64,6 +64,11 @@ public:
         }
     };
 
+    enum class TileDownloadBehavior {
+        DoNotDownload,
+        Download,
+    };
+
 private:
     MapWidget(Options const&);
 
@@ -77,7 +82,7 @@ private:
 
     virtual void paint_event(GUI::PaintEvent&) override;
 
-    Optional<RefPtr<Gfx::Bitmap>> get_tile_image(int x, int y);
+    Optional<RefPtr<Gfx::Bitmap>> get_tile_image(int x, int y, int zoom, TileDownloadBehavior);
     void process_tile_queue();
     void clear_tile_queue();
 


### PR DESCRIPTION
**Maps**

- Tiles were downloaded in parallel, but without any limit. This implements a tile queue and limits the parallel downloads to 8 and by doing so, prevents hanging because of a file descriptor shortage.
- During zooming in and out, if we do not yet have a cached tile available, we composite a tile preview using cached tiles from higher and/or lower zoom levels.
- Double clicking anywhere on the map zooms in or out on that location.

_Demo_

https://github.com/SerenityOS/serenity/assets/3210731/42df8f36-d0e4-46d6-81eb-676186c80468

Note: those gray tiles in the demo seem to be caused by some peculiarities in RequestServer / our TCP stack.

CC @bplaat 