### PR TITLE
Ladybird: Fix the include of use_linker in CMakeLists.txt

### DIFF
--- a/Ladybird/CMakeLists.txt
+++ b/Ladybird/CMakeLists.txt
@@ -27,8 +27,6 @@ set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-include(use_linker)
-
 if (ENABLE_ADDRESS_SANITIZER)
     add_compile_options(-fsanitize=address -fno-omit-frame-pointer)
     add_link_options(-fsanitize=address)
@@ -63,6 +61,7 @@ if (LADYBIRD_IS_TOP_LEVEL)
     )
     list(APPEND CMAKE_MODULE_PATH "${SERENITY_SOURCE_DIR}/Meta/CMake")
     include(cmake/EnableLagom.cmake)
+    include(use_linker)
     include(lagom_compile_options)
     include(lagom_install_options)
 else()


### PR DESCRIPTION
Building Ladybird is currently broken on Solaris and FreeBSD (both confirmed) and probably also all other platforms (not confirmed) due to #20955 adding a include(use_linker) into the CMakeLists.txt above configuring the include directories.
This change moves the line after setting the CMAKE_MODULE_PATH and fixes the Cmake error message for me on both Solaris and FreeBSD.