### PR TITLE
AK: Use arc4random_buf() for Random on all BSDs

### DIFF
--- a/AK/Random.h
+++ b/AK/Random.h
@@ -16,15 +16,11 @@
 #    include <unistd.h>
 #endif
 
-#if defined(AK_OS_MACOS)
-#    include <sys/random.h>
-#endif
-
 namespace AK {
 
 inline void fill_with_random([[maybe_unused]] Bytes bytes)
 {
-#if defined(AK_OS_SERENITY) || defined(AK_OS_ANDROID)
+#if defined(AK_OS_SERENITY) || defined(AK_OS_ANDROID) || defined(AK_OS_BSD_GENERIC)
     arc4random_buf(bytes.data(), bytes.size());
 #elif defined(OSS_FUZZ)
 #else
@@ -33,7 +29,7 @@ inline void fill_with_random([[maybe_unused]] Bytes bytes)
             byte = rand();
     };
 
-#    if defined(__unix__) or defined(AK_OS_MACOS)
+#    if defined(__unix__)
     // The maximum permitted value for the getentropy length argument.
     static constexpr size_t getentropy_length_limit = 256;
     auto iterations = bytes.size() / getentropy_length_limit;


### PR DESCRIPTION
All BSD/Unix-derived operating systems, including Solaris and MacOS, support the arc4random_buf() function.
When doing my big Haiku pull request (#20808), it was suggested that this is the preferred way to get random data, since the other way with getentropy() is called a "fallback" in the code.
I tested this change on Solaris and FreeBSD and it works as expected here.
I can't test on MacOS but the documentation says that it works the same way there.
I also can't test OpenBSD and NetBSD as building is currently broken on them (Clang 13 on OpenBSD is too old and NetBSD lacks the qt6-qtmultimedia package), but again the documentation says that it works the same way there.