### PR TITLE
LibWeb: Some more porting of IDL interfaces from DeprecatedString

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -3567,7 +3567,7 @@ JS::ThrowCompletionOr<JS::NonnullGCPtr<JS::Object>> @constructor_class@::constru
 
     // 11. If element is an already constructed marker, then throw an "InvalidStateError" DOMException.
     if (element.has<HTML::AlreadyConstructedCustomElementMarker>())
-        return JS::throw_completion(WebIDL::InvalidStateError::create(realm, "Custom element has already been constructed"sv));
+        return JS::throw_completion(WebIDL::InvalidStateError::create(realm, "Custom element has already been constructed"_fly_string));
 
     // 12. Perform ? element.[[SetPrototypeOf]](prototype).
     auto actual_element = element.get<JS::Handle<DOM::Element>>();

--- a/Userland/Libraries/LibWeb/Bindings/OptionConstructor.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/OptionConstructor.cpp
@@ -51,7 +51,7 @@ JS::ThrowCompletionOr<JS::NonnullGCPtr<JS::Object>> OptionConstructor::construct
 
     // 3. If text is not the empty string, then append to option a new Text node whose data is text.
     if (vm.argument_count() > 0) {
-        auto text = TRY(vm.argument(0).to_deprecated_string(vm));
+        auto text = TRY(vm.argument(0).to_string(vm));
         if (!text.is_empty()) {
             auto new_text_node = vm.heap().allocate<DOM::Text>(realm, document, text);
             MUST(option_element->append_child(*new_text_node));

--- a/Userland/Libraries/LibWeb/CSS/CSSRuleList.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSRuleList.cpp
@@ -64,7 +64,7 @@ WebIDL::ExceptionOr<unsigned> CSSRuleList::insert_a_css_rule(Variant<StringView,
 
     // 2. If index is greater than length, then throw an IndexSizeError exception.
     if (index > length)
-        return WebIDL::IndexSizeError::create(realm(), "CSS rule index out of bounds.");
+        return WebIDL::IndexSizeError::create(realm(), "CSS rule index out of bounds."_fly_string);
 
     // 3. Set new rule to the results of performing parse a CSS rule on argument rule.
     // NOTE: The insert-a-css-rule spec expects `rule` to be a string, but the CSSStyleSheet.insertRule()
@@ -81,7 +81,7 @@ WebIDL::ExceptionOr<unsigned> CSSRuleList::insert_a_css_rule(Variant<StringView,
 
     // 4. If new rule is a syntax error, throw a SyntaxError exception.
     if (!new_rule)
-        return WebIDL::SyntaxError::create(realm(), "Unable to parse CSS rule.");
+        return WebIDL::SyntaxError::create(realm(), "Unable to parse CSS rule."_fly_string);
 
     // FIXME: 5. If new rule cannot be inserted into list at the zero-index position index due to constraints specified by CSS, then throw a HierarchyRequestError exception. [CSS21]
 
@@ -104,7 +104,7 @@ WebIDL::ExceptionOr<void> CSSRuleList::remove_a_css_rule(u32 index)
 
     // 2. If index is greater than or equal to length, then throw an IndexSizeError exception.
     if (index >= length)
-        return WebIDL::IndexSizeError::create(realm(), "CSS rule index out of bounds.");
+        return WebIDL::IndexSizeError::create(realm(), "CSS rule index out of bounds."_fly_string);
 
     // 3. Set old rule to the indexth item in list.
     CSSRule& old_rule = m_rules[index];

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
@@ -67,7 +67,7 @@ WebIDL::ExceptionOr<unsigned> CSSStyleSheet::insert_rule(StringView rule, unsign
 
     // 4. If parsed rule is a syntax error, return parsed rule.
     if (!parsed_rule)
-        return WebIDL::SyntaxError::create(realm(), "Unable to parse CSS rule.");
+        return WebIDL::SyntaxError::create(realm(), "Unable to parse CSS rule."_fly_string);
 
     // FIXME: 5. If parsed rule is an @import rule, and the constructed flag is set, throw a SyntaxError DOMException.
 

--- a/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
@@ -940,14 +940,14 @@ Optional<StyleProperty> ResolvedCSSStyleDeclaration::property(PropertyID propert
 WebIDL::ExceptionOr<void> ResolvedCSSStyleDeclaration::set_property(PropertyID, StringView, StringView)
 {
     // 1. If the computed flag is set, then throw a NoModificationAllowedError exception.
-    return WebIDL::NoModificationAllowedError::create(realm(), "Cannot modify properties in result of getComputedStyle()");
+    return WebIDL::NoModificationAllowedError::create(realm(), "Cannot modify properties in result of getComputedStyle()"_fly_string);
 }
 
 // https://drafts.csswg.org/cssom/#dom-cssstyledeclaration-removeproperty
 WebIDL::ExceptionOr<DeprecatedString> ResolvedCSSStyleDeclaration::remove_property(PropertyID)
 {
     // 1. If the computed flag is set, then throw a NoModificationAllowedError exception.
-    return WebIDL::NoModificationAllowedError::create(realm(), "Cannot remove properties from result of getComputedStyle()");
+    return WebIDL::NoModificationAllowedError::create(realm(), "Cannot remove properties from result of getComputedStyle()"_fly_string);
 }
 
 DeprecatedString ResolvedCSSStyleDeclaration::serialized() const
@@ -964,7 +964,7 @@ DeprecatedString ResolvedCSSStyleDeclaration::serialized() const
 WebIDL::ExceptionOr<void> ResolvedCSSStyleDeclaration::set_css_text(StringView)
 {
     // 1. If the computed flag is set, then throw a NoModificationAllowedError exception.
-    return WebIDL::NoModificationAllowedError::create(realm(), "Cannot modify properties in result of getComputedStyle()");
+    return WebIDL::NoModificationAllowedError::create(realm(), "Cannot modify properties in result of getComputedStyle()"_fly_string);
 }
 
 }

--- a/Userland/Libraries/LibWeb/Crypto/Crypto.cpp
+++ b/Userland/Libraries/LibWeb/Crypto/Crypto.cpp
@@ -44,16 +44,16 @@ WebIDL::ExceptionOr<JS::Value> Crypto::get_random_values(JS::Value array) const
 {
     // 1. If array is not an Int8Array, Uint8Array, Uint8ClampedArray, Int16Array, Uint16Array, Int32Array, Uint32Array, BigInt64Array, or BigUint64Array, then throw a TypeMismatchError and terminate the algorithm.
     if (!array.is_object() || !(is<JS::Int8Array>(array.as_object()) || is<JS::Uint8Array>(array.as_object()) || is<JS::Uint8ClampedArray>(array.as_object()) || is<JS::Int16Array>(array.as_object()) || is<JS::Uint16Array>(array.as_object()) || is<JS::Int32Array>(array.as_object()) || is<JS::Uint32Array>(array.as_object()) || is<JS::BigInt64Array>(array.as_object()) || is<JS::BigUint64Array>(array.as_object())))
-        return WebIDL::TypeMismatchError::create(realm(), "array must be one of Int8Array, Uint8Array, Uint8ClampedArray, Int16Array, Uint16Array, Int32Array, Uint32Array, BigInt64Array, or BigUint64Array");
+        return WebIDL::TypeMismatchError::create(realm(), "array must be one of Int8Array, Uint8Array, Uint8ClampedArray, Int16Array, Uint16Array, Int32Array, Uint32Array, BigInt64Array, or BigUint64Array"_fly_string);
     auto& typed_array = static_cast<JS::TypedArrayBase&>(array.as_object());
 
     // 2. If the byteLength of array is greater than 65536, throw a QuotaExceededError and terminate the algorithm.
     if (typed_array.byte_length() > 65536)
-        return WebIDL::QuotaExceededError::create(realm(), "array's byteLength may not be greater than 65536");
+        return WebIDL::QuotaExceededError::create(realm(), "array's byteLength may not be greater than 65536"_fly_string);
 
     // IMPLEMENTATION DEFINED: If the viewed array buffer is detached, throw a InvalidStateError and terminate the algorithm.
     if (typed_array.viewed_array_buffer()->is_detached())
-        return WebIDL::InvalidStateError::create(realm(), "array is detached");
+        return WebIDL::InvalidStateError::create(realm(), "array is detached"_fly_string);
     // FIXME: Handle SharedArrayBuffers
 
     // 3. Overwrite all elements of array with cryptographically strong random values of the appropriate type.

--- a/Userland/Libraries/LibWeb/Crypto/SubtleCrypto.cpp
+++ b/Userland/Libraries/LibWeb/Crypto/SubtleCrypto.cpp
@@ -42,7 +42,7 @@ JS::NonnullGCPtr<JS::Promise> SubtleCrypto::digest(String const& algorithm, JS::
     // 2. Let data be the result of getting a copy of the bytes held by the data parameter passed to the digest() method.
     auto data_buffer_or_error = WebIDL::get_buffer_source_copy(*data.cell());
     if (data_buffer_or_error.is_error()) {
-        auto error = WebIDL::OperationError::create(realm, "Failed to copy bytes from ArrayBuffer");
+        auto error = WebIDL::OperationError::create(realm, "Failed to copy bytes from ArrayBuffer"_fly_string);
         auto promise = JS::Promise::create(realm);
         promise->reject(error.ptr());
         return promise;
@@ -64,7 +64,7 @@ JS::NonnullGCPtr<JS::Promise> SubtleCrypto::digest(String const& algorithm, JS::
     }
     // 4. If an error occurred, return a Promise rejected with normalizedAlgorithm.
     else {
-        auto error = WebIDL::NotSupportedError::create(realm, DeprecatedString::formatted("Invalid hash function '{}'", algorithm));
+        auto error = WebIDL::NotSupportedError::create(realm, MUST(String::formatted("Invalid hash function '{}'", algorithm)));
         auto promise = JS::Promise::create(realm);
         promise->reject(error.ptr());
         return promise;
@@ -85,7 +85,7 @@ JS::NonnullGCPtr<JS::Promise> SubtleCrypto::digest(String const& algorithm, JS::
     auto digest = hash.digest();
     auto result_buffer = ByteBuffer::copy(digest.immutable_data(), hash.digest_size());
     if (result_buffer.is_error()) {
-        auto error = WebIDL::OperationError::create(realm, "Failed to create result buffer");
+        auto error = WebIDL::OperationError::create(realm, "Failed to create result buffer"_fly_string);
         promise->reject(error.ptr());
         return promise;
     }

--- a/Userland/Libraries/LibWeb/DOM/AbortSignal.cpp
+++ b/Userland/Libraries/LibWeb/DOM/AbortSignal.cpp
@@ -50,7 +50,7 @@ void AbortSignal::signal_abort(JS::Value reason)
     if (!reason.is_undefined())
         m_abort_reason = reason;
     else
-        m_abort_reason = WebIDL::AbortError::create(realm(), "Aborted without reason").ptr();
+        m_abort_reason = WebIDL::AbortError::create(realm(), "Aborted without reason"_fly_string).ptr();
 
     // 3. For each algorithm in signal’s abort algorithms: run algorithm.
     for (auto& algorithm : m_abort_algorithms)

--- a/Userland/Libraries/LibWeb/DOM/CDATASection.cpp
+++ b/Userland/Libraries/LibWeb/DOM/CDATASection.cpp
@@ -9,7 +9,7 @@
 
 namespace Web::DOM {
 
-CDATASection::CDATASection(Document& document, DeprecatedString const& data)
+CDATASection::CDATASection(Document& document, String const& data)
     : Text(document, NodeType::CDATA_SECTION_NODE, data)
 {
 }

--- a/Userland/Libraries/LibWeb/DOM/CDATASection.h
+++ b/Userland/Libraries/LibWeb/DOM/CDATASection.h
@@ -21,7 +21,7 @@ public:
     virtual DeprecatedFlyString node_name() const override { return "#cdata-section"; }
 
 private:
-    CDATASection(Document&, DeprecatedString const&);
+    CDATASection(Document&, String const&);
 
     virtual void initialize(JS::Realm&) override;
 };

--- a/Userland/Libraries/LibWeb/DOM/CharacterData.cpp
+++ b/Userland/Libraries/LibWeb/DOM/CharacterData.cpp
@@ -44,7 +44,7 @@ WebIDL::ExceptionOr<DeprecatedString> CharacterData::substring_data(size_t offse
 
     // 2. If offset is greater than length, then throw an "IndexSizeError" DOMException.
     if (offset > length)
-        return WebIDL::IndexSizeError::create(realm(), "Substring offset out of range.");
+        return WebIDL::IndexSizeError::create(realm(), "Substring offset out of range."_fly_string);
 
     // 3. If offset plus count is greater than length, return a string whose value is the code units from the offsetth code unit
     //    to the end of node’s data, and then return.
@@ -63,7 +63,7 @@ WebIDL::ExceptionOr<void> CharacterData::replace_data(size_t offset, size_t coun
 
     // 2. If offset is greater than length, then throw an "IndexSizeError" DOMException.
     if (offset > length)
-        return WebIDL::IndexSizeError::create(realm(), "Replacement offset out of range.");
+        return WebIDL::IndexSizeError::create(realm(), "Replacement offset out of range."_fly_string);
 
     // 3. If offset plus count is greater than length, then set count to length minus offset.
     if (offset + count > length)

--- a/Userland/Libraries/LibWeb/DOM/Comment.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Comment.cpp
@@ -11,13 +11,13 @@
 
 namespace Web::DOM {
 
-Comment::Comment(Document& document, DeprecatedString const& data)
-    : CharacterData(document, NodeType::COMMENT_NODE, data)
+Comment::Comment(Document& document, String const& data)
+    : CharacterData(document, NodeType::COMMENT_NODE, data.to_deprecated_string())
 {
 }
 
 // https://dom.spec.whatwg.org/#dom-comment-comment
-WebIDL::ExceptionOr<JS::NonnullGCPtr<Comment>> Comment::construct_impl(JS::Realm& realm, DeprecatedString const& data)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<Comment>> Comment::construct_impl(JS::Realm& realm, String const& data)
 {
     auto& window = verify_cast<HTML::Window>(realm.global_object());
     return realm.heap().allocate<Comment>(realm, window.associated_document(), data);

--- a/Userland/Libraries/LibWeb/DOM/Comment.h
+++ b/Userland/Libraries/LibWeb/DOM/Comment.h
@@ -15,13 +15,13 @@ class Comment final : public CharacterData {
     WEB_PLATFORM_OBJECT(Comment, CharacterData);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<Comment>> construct_impl(JS::Realm&, DeprecatedString const& data);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<Comment>> construct_impl(JS::Realm&, String const& data);
     virtual ~Comment() override = default;
 
     virtual DeprecatedFlyString node_name() const override { return "#comment"; }
 
 private:
-    Comment(Document&, DeprecatedString const&);
+    Comment(Document&, String const&);
 
     virtual void initialize(JS::Realm&) override;
 };

--- a/Userland/Libraries/LibWeb/DOM/Comment.idl
+++ b/Userland/Libraries/LibWeb/DOM/Comment.idl
@@ -1,7 +1,7 @@
 #import <DOM/CharacterData.idl>
 
 // https://dom.spec.whatwg.org/#comment
-[Exposed=Window, UseDeprecatedAKString]
+[Exposed=Window]
 interface Comment : CharacterData {
     constructor(optional DOMString data = "");
 };

--- a/Userland/Libraries/LibWeb/DOM/DOMImplementation.cpp
+++ b/Userland/Libraries/LibWeb/DOM/DOMImplementation.cpp
@@ -118,7 +118,7 @@ JS::NonnullGCPtr<Document> DOMImplementation::create_html_document(Optional<Stri
         MUST(head_element->append_child(title_element));
 
         // 2. Append a new Text node, with its data set to title (which could be the empty string) and its node document set to doc, to the title element created earlier.
-        auto text_node = heap().allocate<Text>(realm(), html_document, title->to_deprecated_string());
+        auto text_node = heap().allocate<Text>(realm(), html_document, title.value());
         MUST(title_element->append_child(*text_node));
     }
 

--- a/Userland/Libraries/LibWeb/DOM/DOMTokenList.cpp
+++ b/Userland/Libraries/LibWeb/DOM/DOMTokenList.cpp
@@ -240,9 +240,9 @@ void DOMTokenList::set_value(String const& value)
 WebIDL::ExceptionOr<void> DOMTokenList::validate_token(StringView token) const
 {
     if (token.is_empty())
-        return WebIDL::SyntaxError::create(realm(), "Non-empty DOM tokens are not allowed");
+        return WebIDL::SyntaxError::create(realm(), "Non-empty DOM tokens are not allowed"_fly_string);
     if (any_of(token, Infra::is_ascii_whitespace))
-        return WebIDL::InvalidCharacterError::create(realm(), "DOM tokens containing ASCII whitespace are not allowed");
+        return WebIDL::InvalidCharacterError::create(realm(), "DOM tokens containing ASCII whitespace are not allowed"_fly_string);
     return {};
 }
 

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -1427,7 +1427,7 @@ JS::NonnullGCPtr<Text> Document::create_text_node(DeprecatedString const& data)
 
 JS::NonnullGCPtr<Comment> Document::create_comment(DeprecatedString const& data)
 {
-    return heap().allocate<Comment>(realm(), *this, data);
+    return heap().allocate<Comment>(realm(), *this, MUST(String::from_deprecated_string(data)));
 }
 
 // https://dom.spec.whatwg.org/#dom-document-createprocessinginstruction

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -433,11 +433,11 @@ WebIDL::ExceptionOr<void> Document::run_the_document_write_steps(DeprecatedStrin
 {
     // 1. If document is an XML document, then throw an "InvalidStateError" DOMException.
     if (m_type == Type::XML)
-        return WebIDL::InvalidStateError::create(realm(), "write() called on XML document.");
+        return WebIDL::InvalidStateError::create(realm(), "write() called on XML document."_fly_string);
 
     // 2. If document's throw-on-dynamic-markup-insertion counter is greater than 0, then throw an "InvalidStateError" DOMException.
     if (m_throw_on_dynamic_markup_insertion_counter > 0)
-        return WebIDL::InvalidStateError::create(realm(), "throw-on-dynamic-markup-insertion-counter greater than zero.");
+        return WebIDL::InvalidStateError::create(realm(), "throw-on-dynamic-markup-insertion-counter greater than zero."_fly_string);
 
     // 3. If document's active parser was aborted is true, then return.
     if (m_active_parser_was_aborted)
@@ -468,18 +468,18 @@ WebIDL::ExceptionOr<Document*> Document::open(DeprecatedString const&, Deprecate
 {
     // 1. If document is an XML document, then throw an "InvalidStateError" DOMException exception.
     if (m_type == Type::XML)
-        return WebIDL::InvalidStateError::create(realm(), "open() called on XML document.");
+        return WebIDL::InvalidStateError::create(realm(), "open() called on XML document."_fly_string);
 
     // 2. If document's throw-on-dynamic-markup-insertion counter is greater than 0, then throw an "InvalidStateError" DOMException.
     if (m_throw_on_dynamic_markup_insertion_counter > 0)
-        return WebIDL::InvalidStateError::create(realm(), "throw-on-dynamic-markup-insertion-counter greater than zero.");
+        return WebIDL::InvalidStateError::create(realm(), "throw-on-dynamic-markup-insertion-counter greater than zero."_fly_string);
 
     // FIXME: 3. Let entryDocument be the entry global object's associated Document.
     auto& entry_document = *this;
 
     // 4. If document's origin is not same origin to entryDocument's origin, then throw a "SecurityError" DOMException.
     if (origin() != entry_document.origin())
-        return WebIDL::SecurityError::create(realm(), "Document.origin() not the same as entryDocument's.");
+        return WebIDL::SecurityError::create(realm(), "Document.origin() not the same as entryDocument's."_fly_string);
 
     // 5. If document has an active parser whose script nesting level is greater than 0, then return document.
     if (m_parser && m_parser->script_nesting_level() > 0)
@@ -539,7 +539,7 @@ WebIDL::ExceptionOr<JS::GCPtr<HTML::WindowProxy>> Document::open(DeprecatedStrin
 {
     // 1. If this is not fully active, then throw an "InvalidAccessError" DOMException exception.
     if (!is_fully_active())
-        return WebIDL::InvalidAccessError::create(realm(), "Cannot perform open on a document that isn't fully active."sv);
+        return WebIDL::InvalidAccessError::create(realm(), "Cannot perform open on a document that isn't fully active."_fly_string);
 
     // 2. Return the result of running the window open steps with url, name, and features.
     return window().open_impl(url, name, features);
@@ -550,11 +550,11 @@ WebIDL::ExceptionOr<void> Document::close()
 {
     // 1. If document is an XML document, then throw an "InvalidStateError" DOMException exception.
     if (m_type == Type::XML)
-        return WebIDL::InvalidStateError::create(realm(), "close() called on XML document.");
+        return WebIDL::InvalidStateError::create(realm(), "close() called on XML document."_fly_string);
 
     // 2. If document's throw-on-dynamic-markup-insertion counter is greater than 0, then throw an "InvalidStateError" DOMException.
     if (m_throw_on_dynamic_markup_insertion_counter > 0)
-        return WebIDL::InvalidStateError::create(realm(), "throw-on-dynamic-markup-insertion-counter greater than zero.");
+        return WebIDL::InvalidStateError::create(realm(), "throw-on-dynamic-markup-insertion-counter greater than zero."_fly_string);
 
     // 3. If there is no script-created parser associated with the document, then return.
     if (!m_parser)
@@ -678,7 +678,7 @@ HTML::HTMLElement* Document::body()
 WebIDL::ExceptionOr<void> Document::set_body(HTML::HTMLElement* new_body)
 {
     if (!is<HTML::HTMLBodyElement>(new_body) && !is<HTML::HTMLFrameSetElement>(new_body))
-        return WebIDL::HierarchyRequestError::create(realm(), "Invalid document body element, must be 'body' or 'frameset'");
+        return WebIDL::HierarchyRequestError::create(realm(), "Invalid document body element, must be 'body' or 'frameset'"_fly_string);
 
     auto* existing_body = body();
     if (existing_body) {
@@ -688,7 +688,7 @@ WebIDL::ExceptionOr<void> Document::set_body(HTML::HTMLElement* new_body)
 
     auto* document_element = this->document_element();
     if (!document_element)
-        return WebIDL::HierarchyRequestError::create(realm(), "Missing document element");
+        return WebIDL::HierarchyRequestError::create(realm(), "Missing document element"_fly_string);
 
     (void)TRY(document_element->append_child(*new_body));
     return {};
@@ -1367,7 +1367,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Element>> Document::create_element(Deprecat
 
     // 1. If localName does not match the Name production, then throw an "InvalidCharacterError" DOMException.
     if (!is_valid_name(local_name))
-        return WebIDL::InvalidCharacterError::create(realm(), "Invalid character in tag name.");
+        return WebIDL::InvalidCharacterError::create(realm(), "Invalid character in tag name."_fly_string);
 
     // 2. If this is an HTML document, then set localName to localName in ASCII lowercase.
     if (document_type() == Type::HTML)
@@ -1500,7 +1500,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Event>> Document::create_event(DeprecatedSt
 
     // 3. If constructor is null, then throw a "NotSupportedError" DOMException.
     if (!event) {
-        return WebIDL::NotSupportedError::create(realm, "No constructor for interface found");
+        return WebIDL::NotSupportedError::create(realm, "No constructor for interface found"_fly_string);
     }
 
     // FIXME: 4. If the interface indicated by constructor is not exposed on the relevant global object of this, then throw a "NotSupportedError" DOMException.
@@ -1570,7 +1570,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Node>> Document::import_node(JS::NonnullGCP
 {
     // 1. If node is a document or shadow root, then throw a "NotSupportedError" DOMException.
     if (is<Document>(*node) || is<ShadowRoot>(*node))
-        return WebIDL::NotSupportedError::create(realm(), "Cannot import a document or shadow root.");
+        return WebIDL::NotSupportedError::create(realm(), "Cannot import a document or shadow root."_fly_string);
 
     // 2. Return a clone of node, with this and the clone children flag set if deep is true.
     return node->clone_node(this, deep);
@@ -1644,10 +1644,10 @@ void Document::adopt_node(Node& node)
 WebIDL::ExceptionOr<JS::NonnullGCPtr<Node>> Document::adopt_node_binding(JS::NonnullGCPtr<Node> node)
 {
     if (is<Document>(*node))
-        return WebIDL::NotSupportedError::create(realm(), "Cannot adopt a document into a document");
+        return WebIDL::NotSupportedError::create(realm(), "Cannot adopt a document into a document"_fly_string);
 
     if (is<ShadowRoot>(*node))
-        return WebIDL::HierarchyRequestError::create(realm(), "Cannot adopt a shadow root into a document");
+        return WebIDL::HierarchyRequestError::create(realm(), "Cannot adopt a shadow root into a document"_fly_string);
 
     if (is<DocumentFragment>(*node) && verify_cast<DocumentFragment>(*node).host())
         return node;
@@ -2265,11 +2265,11 @@ bool Document::is_valid_name(DeprecatedString const& name)
 WebIDL::ExceptionOr<Document::PrefixAndTagName> Document::validate_qualified_name(JS::Realm& realm, DeprecatedString const& qualified_name)
 {
     if (qualified_name.is_empty())
-        return WebIDL::InvalidCharacterError::create(realm, "Empty string is not a valid qualified name.");
+        return WebIDL::InvalidCharacterError::create(realm, "Empty string is not a valid qualified name."_fly_string);
 
     Utf8View utf8view { qualified_name };
     if (!utf8view.validate())
-        return WebIDL::InvalidCharacterError::create(realm, "Invalid qualified name.");
+        return WebIDL::InvalidCharacterError::create(realm, "Invalid qualified name."_fly_string);
 
     Optional<size_t> colon_offset;
 
@@ -2279,19 +2279,19 @@ WebIDL::ExceptionOr<Document::PrefixAndTagName> Document::validate_qualified_nam
         auto code_point = *it;
         if (code_point == ':') {
             if (colon_offset.has_value())
-                return WebIDL::InvalidCharacterError::create(realm, "More than one colon (:) in qualified name.");
+                return WebIDL::InvalidCharacterError::create(realm, "More than one colon (:) in qualified name."_fly_string);
             colon_offset = utf8view.byte_offset_of(it);
             at_start_of_name = true;
             continue;
         }
         if (at_start_of_name) {
             if (!is_valid_name_start_character(code_point))
-                return WebIDL::InvalidCharacterError::create(realm, "Invalid start of qualified name.");
+                return WebIDL::InvalidCharacterError::create(realm, "Invalid start of qualified name."_fly_string);
             at_start_of_name = false;
             continue;
         }
         if (!is_valid_name_character(code_point))
-            return WebIDL::InvalidCharacterError::create(realm, "Invalid character in qualified name.");
+            return WebIDL::InvalidCharacterError::create(realm, "Invalid character in qualified name."_fly_string);
     }
 
     if (!colon_offset.has_value())
@@ -2301,10 +2301,10 @@ WebIDL::ExceptionOr<Document::PrefixAndTagName> Document::validate_qualified_nam
         };
 
     if (*colon_offset == 0)
-        return WebIDL::InvalidCharacterError::create(realm, "Qualified name can't start with colon (:).");
+        return WebIDL::InvalidCharacterError::create(realm, "Qualified name can't start with colon (:)."_fly_string);
 
     if (*colon_offset >= (qualified_name.length() - 1))
-        return WebIDL::InvalidCharacterError::create(realm, "Qualified name can't end with colon (:).");
+        return WebIDL::InvalidCharacterError::create(realm, "Qualified name can't end with colon (:)."_fly_string);
 
     return Document::PrefixAndTagName {
         .prefix = qualified_name.substring_view(0, *colon_offset),
@@ -2985,7 +2985,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Attr>> Document::create_attribute(Deprecate
 {
     // 1. If localName does not match the Name production in XML, then throw an "InvalidCharacterError" DOMException.
     if (!is_valid_name(local_name))
-        return WebIDL::InvalidCharacterError::create(realm(), "Invalid character in attribute name.");
+        return WebIDL::InvalidCharacterError::create(realm(), "Invalid character in attribute name."_fly_string);
 
     // 2. If this is an HTML document, then set localName to localName in ASCII lowercase.
     // 3. Return a new attribute whose local name is localName and node document is this.

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -1422,7 +1422,7 @@ JS::NonnullGCPtr<DocumentFragment> Document::create_document_fragment()
 
 JS::NonnullGCPtr<Text> Document::create_text_node(DeprecatedString const& data)
 {
-    return heap().allocate<Text>(realm(), *this, data);
+    return heap().allocate<Text>(realm(), *this, MUST(String::from_deprecated_string(data)));
 }
 
 JS::NonnullGCPtr<Comment> Document::create_comment(DeprecatedString const& data)

--- a/Userland/Libraries/LibWeb/DOM/DocumentLoading.cpp
+++ b/Userland/Libraries/LibWeb/DOM/DocumentLoading.cpp
@@ -119,7 +119,7 @@ static bool build_image_document(DOM::Document& document, ByteBuffer const& data
     MUST(head_element->append_child(title_element));
 
     auto basename = LexicalPath::basename(document.url().serialize_path());
-    auto title_text = document.heap().allocate<DOM::Text>(document.realm(), document, DeprecatedString::formatted("{} [{}x{}]", basename, bitmap->width(), bitmap->height()));
+    auto title_text = document.heap().allocate<DOM::Text>(document.realm(), document, MUST(String::formatted("{} [{}x{}]", basename, bitmap->width(), bitmap->height())));
     MUST(title_element->append_child(*title_text));
 
     auto body_element = DOM::create_element(document, HTML::TagNames::body, Namespace::HTML).release_value_but_fixme_should_propagate_errors();

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -136,7 +136,7 @@ WebIDL::ExceptionOr<void> Element::set_attribute(DeprecatedFlyString const& name
     // 1. If qualifiedName does not match the Name production in XML, then throw an "InvalidCharacterError" DOMException.
     // FIXME: Proper name validation
     if (name.is_empty())
-        return WebIDL::InvalidCharacterError::create(realm(), "Attribute name must not be empty");
+        return WebIDL::InvalidCharacterError::create(realm(), "Attribute name must not be empty"_fly_string);
 
     // 2. If this is in the HTML namespace and its node document is an HTML document, then set qualifiedName to qualifiedName in ASCII lowercase.
     // FIXME: Handle the second condition, assume it is an HTML document for now.
@@ -193,19 +193,19 @@ WebIDL::ExceptionOr<QualifiedName> validate_and_extract(JS::Realm& realm, Deprec
 
     // 6. If prefix is non-null and namespace is null, then throw a "NamespaceError" DOMException.
     if (!prefix.is_null() && namespace_.is_null())
-        return WebIDL::NamespaceError::create(realm, "Prefix is non-null and namespace is null.");
+        return WebIDL::NamespaceError::create(realm, "Prefix is non-null and namespace is null."_fly_string);
 
     // 7. If prefix is "xml" and namespace is not the XML namespace, then throw a "NamespaceError" DOMException.
     if (prefix == "xml"sv && namespace_ != Namespace::XML)
-        return WebIDL::NamespaceError::create(realm, "Prefix is 'xml' and namespace is not the XML namespace.");
+        return WebIDL::NamespaceError::create(realm, "Prefix is 'xml' and namespace is not the XML namespace."_fly_string);
 
     // 8. If either qualifiedName or prefix is "xmlns" and namespace is not the XMLNS namespace, then throw a "NamespaceError" DOMException.
     if ((qualified_name == "xmlns"sv || prefix == "xmlns"sv) && namespace_ != Namespace::XMLNS)
-        return WebIDL::NamespaceError::create(realm, "Either qualifiedName or prefix is 'xmlns' and namespace is not the XMLNS namespace.");
+        return WebIDL::NamespaceError::create(realm, "Either qualifiedName or prefix is 'xmlns' and namespace is not the XMLNS namespace."_fly_string);
 
     // 9. If namespace is the XMLNS namespace and neither qualifiedName nor prefix is "xmlns", then throw a "NamespaceError" DOMException.
     if (namespace_ == Namespace::XMLNS && !(qualified_name == "xmlns"sv || prefix == "xmlns"sv))
-        return WebIDL::NamespaceError::create(realm, "Namespace is the XMLNS namespace and neither qualifiedName nor prefix is 'xmlns'.");
+        return WebIDL::NamespaceError::create(realm, "Namespace is the XMLNS namespace and neither qualifiedName nor prefix is 'xmlns'."_fly_string);
 
     // 10. Return namespace, prefix, and localName.
     return QualifiedName { local_name, prefix, namespace_ };
@@ -289,7 +289,7 @@ WebIDL::ExceptionOr<bool> Element::toggle_attribute(DeprecatedFlyString const& n
     // 1. If qualifiedName does not match the Name production in XML, then throw an "InvalidCharacterError" DOMException.
     // FIXME: Proper name validation
     if (name.is_empty())
-        return WebIDL::InvalidCharacterError::create(realm(), "Attribute name must not be empty");
+        return WebIDL::InvalidCharacterError::create(realm(), "Attribute name must not be empty"_fly_string);
 
     // 2. If this is in the HTML namespace and its node document is an HTML document, then set qualifiedName to qualifiedName in ASCII lowercase.
     // FIXME: Handle the second condition, assume it is an HTML document for now.
@@ -556,7 +556,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<ShadowRoot>> Element::attach_shadow(ShadowR
 {
     // 1. If this’s namespace is not the HTML namespace, then throw a "NotSupportedError" DOMException.
     if (namespace_() != Namespace::HTML)
-        return WebIDL::NotSupportedError::create(realm(), "Element's namespace is not the HTML namespace"sv);
+        return WebIDL::NotSupportedError::create(realm(), "Element's namespace is not the HTML namespace"_fly_string);
 
     // 2. If this’s local name is not one of the following:
     //    - a valid custom element name
@@ -564,7 +564,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<ShadowRoot>> Element::attach_shadow(ShadowR
     if (!HTML::is_valid_custom_element_name(local_name())
         && !local_name().is_one_of("article", "aside", "blockquote", "body", "div", "footer", "h1", "h2", "h3", "h4", "h5", "h6", "header", "main", "nav", "p", "section", "span")) {
         // then throw a "NotSupportedError" DOMException.
-        return WebIDL::NotSupportedError::create(realm(), DeprecatedString::formatted("Element '{}' cannot be a shadow host", local_name()));
+        return WebIDL::NotSupportedError::create(realm(), MUST(String::formatted("Element '{}' cannot be a shadow host", local_name())));
     }
 
     // 3. If this’s local name is a valid custom element name, or this’s is value is not null, then:
@@ -574,12 +574,12 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<ShadowRoot>> Element::attach_shadow(ShadowR
 
         // 2. If definition is not null and definition’s disable shadow is true, then throw a "NotSupportedError" DOMException.
         if (definition && definition->disable_shadow())
-            return WebIDL::NotSupportedError::create(realm(), "Cannot attach a shadow root to a custom element that has disabled shadow roots"sv);
+            return WebIDL::NotSupportedError::create(realm(), "Cannot attach a shadow root to a custom element that has disabled shadow roots"_fly_string);
     }
 
     // 4. If this is a shadow host, then throw an "NotSupportedError" DOMException.
     if (is_shadow_host())
-        return WebIDL::NotSupportedError::create(realm(), "Element already is a shadow host");
+        return WebIDL::NotSupportedError::create(realm(), "Element already is a shadow host"_fly_string);
 
     // 5. Let shadow be a new shadow root whose node document is this’s node document, host is this, and mode is init["mode"].
     auto shadow = heap().allocate<ShadowRoot>(realm(), document(), *this, init.mode);
@@ -622,7 +622,7 @@ WebIDL::ExceptionOr<bool> Element::matches(StringView selectors) const
 
     // 2. If s is failure, then throw a "SyntaxError" DOMException.
     if (!maybe_selectors.has_value())
-        return WebIDL::SyntaxError::create(realm(), "Failed to parse selector");
+        return WebIDL::SyntaxError::create(realm(), "Failed to parse selector"_fly_string);
 
     // 3. If the result of match a selector against an element, using s, this, and scoping root this, returns success, then return true; otherwise, return false.
     auto sel = maybe_selectors.value();
@@ -641,7 +641,7 @@ WebIDL::ExceptionOr<DOM::Element const*> Element::closest(StringView selectors) 
 
     // 2. If s is failure, then throw a "SyntaxError" DOMException.
     if (!maybe_selectors.has_value())
-        return WebIDL::SyntaxError::create(realm(), "Failed to parse selector");
+        return WebIDL::SyntaxError::create(realm(), "Failed to parse selector"_fly_string);
 
     auto matches_selectors = [this](CSS::SelectorList const& selector_list, Element const* element) {
         // 4. For each element in elements, if match a selector against an element, using s, element, and scoping root this, returns success, return element.
@@ -1308,7 +1308,7 @@ WebIDL::ExceptionOr<void> Element::insert_adjacent_html(DeprecatedString positio
 
         // If context is null or a Document, throw a "NoModificationAllowedError" DOMException.
         if (!context || context->is_document())
-            return WebIDL::NoModificationAllowedError::create(realm(), "insertAdjacentHTML: context is null or a Document"sv);
+            return WebIDL::NoModificationAllowedError::create(realm(), "insertAdjacentHTML: context is null or a Document"_fly_string);
     }
     // - If position is an ASCII case-insensitive match for the string "afterbegin"
     // - If position is an ASCII case-insensitive match for the string "beforeend"
@@ -1320,7 +1320,7 @@ WebIDL::ExceptionOr<void> Element::insert_adjacent_html(DeprecatedString positio
     // Otherwise
     else {
         // Throw a "SyntaxError" DOMException.
-        return WebIDL::SyntaxError::create(realm(), "insertAdjacentHTML: invalid position argument"sv);
+        return WebIDL::SyntaxError::create(realm(), "insertAdjacentHTML: invalid position argument"_fly_string);
     }
 
     // 2. If context is not an Element or the following are all true:
@@ -1407,7 +1407,7 @@ WebIDL::ExceptionOr<JS::GCPtr<Node>> Element::insert_adjacent(DeprecatedString c
 
     // -> Otherwise
     // Throw a "SyntaxError" DOMException.
-    return WebIDL::SyntaxError::create(realm(), DeprecatedString::formatted("Unknown position '{}'. Must be one of 'beforebegin', 'afterbegin', 'beforeend' or 'afterend'"sv, where));
+    return WebIDL::SyntaxError::create(realm(), MUST(String::formatted("Unknown position '{}'. Must be one of 'beforebegin', 'afterbegin', 'beforeend' or 'afterend'"sv, where)));
 }
 
 // https://dom.spec.whatwg.org/#dom-element-insertadjacentelement
@@ -1711,7 +1711,7 @@ JS::ThrowCompletionOr<void> Element::upgrade_element(JS::NonnullGCPtr<HTML::Cust
     auto attempt_to_construct_custom_element = [&]() -> JS::ThrowCompletionOr<void> {
         // 1. If definition's disable shadow is true and element's shadow root is non-null, then throw a "NotSupportedError" DOMException.
         if (custom_element_definition->disable_shadow() && shadow_root())
-            return JS::throw_completion(WebIDL::NotSupportedError::create(realm, "Custom element definition disables shadow DOM and the custom element has a shadow root"sv));
+            return JS::throw_completion(WebIDL::NotSupportedError::create(realm, "Custom element definition disables shadow DOM and the custom element has a shadow root"_fly_string));
 
         // 2. Set element's custom element state to "precustomized".
         m_custom_element_state = CustomElementState::Precustomized;

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -1424,7 +1424,7 @@ WebIDL::ExceptionOr<JS::GCPtr<Element>> Element::insert_adjacent_element(Depreca
 WebIDL::ExceptionOr<void> Element::insert_adjacent_text(DeprecatedString const& where, DeprecatedString const& data)
 {
     // 1. Let text be a new Text node whose data is data and node document is this’s node document.
-    auto text = heap().allocate<DOM::Text>(realm(), document(), data);
+    auto text = heap().allocate<DOM::Text>(realm(), document(), MUST(String::from_deprecated_string(data)));
 
     // 2. Run insert adjacent, given this, where, and text.
     // Spec Note: This method returns nothing because it existed before we had a chance to design it.

--- a/Userland/Libraries/LibWeb/DOM/ElementFactory.cpp
+++ b/Userland/Libraries/LibWeb/DOM/ElementFactory.cpp
@@ -561,23 +561,23 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Element>> create_element(Document& document
 
                 // 5. If result’s attribute list is not empty, then throw a "NotSupportedError" DOMException.
                 if (element->has_attributes())
-                    return JS::throw_completion(WebIDL::NotSupportedError::create(realm, "Synchronously created custom element cannot have attributes"sv));
+                    return JS::throw_completion(WebIDL::NotSupportedError::create(realm, "Synchronously created custom element cannot have attributes"_fly_string));
 
                 // 6. If result has children, then throw a "NotSupportedError" DOMException.
                 if (element->has_children())
-                    return JS::throw_completion(WebIDL::NotSupportedError::create(realm, "Synchronously created custom element cannot have children"sv));
+                    return JS::throw_completion(WebIDL::NotSupportedError::create(realm, "Synchronously created custom element cannot have children"_fly_string));
 
                 // 7. If result’s parent is not null, then throw a "NotSupportedError" DOMException.
                 if (element->parent())
-                    return JS::throw_completion(WebIDL::NotSupportedError::create(realm, "Synchronously created custom element cannot have a parent"sv));
+                    return JS::throw_completion(WebIDL::NotSupportedError::create(realm, "Synchronously created custom element cannot have a parent"_fly_string));
 
                 // 8. If result’s node document is not document, then throw a "NotSupportedError" DOMException.
                 if (&element->document() != &document)
-                    return JS::throw_completion(WebIDL::NotSupportedError::create(realm, "Synchronously created custom element must be in the same document that element creation was invoked in"sv));
+                    return JS::throw_completion(WebIDL::NotSupportedError::create(realm, "Synchronously created custom element must be in the same document that element creation was invoked in"_fly_string));
 
                 // 9. If result’s local name is not equal to localName, then throw a "NotSupportedError" DOMException.
                 if (element->local_name() != local_name)
-                    return JS::throw_completion(WebIDL::NotSupportedError::create(realm, "Synchronously created custom element must have the same local name that element creation was invoked with"sv));
+                    return JS::throw_completion(WebIDL::NotSupportedError::create(realm, "Synchronously created custom element must have the same local name that element creation was invoked with"_fly_string));
 
                 // 10. Set result’s namespace prefix to prefix.
                 element->set_prefix(prefix);

--- a/Userland/Libraries/LibWeb/DOM/EventTarget.cpp
+++ b/Userland/Libraries/LibWeb/DOM/EventTarget.cpp
@@ -248,10 +248,10 @@ WebIDL::ExceptionOr<bool> EventTarget::dispatch_event_binding(Event& event)
 {
     // 1. If event’s dispatch flag is set, or if its initialized flag is not set, then throw an "InvalidStateError" DOMException.
     if (event.dispatched())
-        return WebIDL::InvalidStateError::create(realm(), "The event is already being dispatched.");
+        return WebIDL::InvalidStateError::create(realm(), "The event is already being dispatched."_fly_string);
 
     if (!event.initialized())
-        return WebIDL::InvalidStateError::create(realm(), "Cannot dispatch an uninitialized event.");
+        return WebIDL::InvalidStateError::create(realm(), "Cannot dispatch an uninitialized event."_fly_string);
 
     // 2. Initialize event’s isTrusted attribute to false.
     event.set_is_trusted(false);

--- a/Userland/Libraries/LibWeb/DOM/MutationObserver.h
+++ b/Userland/Libraries/LibWeb/DOM/MutationObserver.h
@@ -23,7 +23,7 @@ struct MutationObserverInit {
     bool subtree { false };
     Optional<bool> attribute_old_value;
     Optional<bool> character_data_old_value;
-    Optional<Vector<DeprecatedString>> attribute_filter;
+    Optional<Vector<String>> attribute_filter;
 };
 
 // https://dom.spec.whatwg.org/#mutationobserver

--- a/Userland/Libraries/LibWeb/DOM/MutationObserver.idl
+++ b/Userland/Libraries/LibWeb/DOM/MutationObserver.idl
@@ -1,7 +1,7 @@
 #import <DOM/MutationRecord.idl>
 #import <DOM/Node.idl>
 
-[Exposed=Window, UseDeprecatedAKString]
+[Exposed=Window]
 interface MutationObserver {
 
     constructor(MutationCallback callback);

--- a/Userland/Libraries/LibWeb/DOM/NamedNodeMap.cpp
+++ b/Userland/Libraries/LibWeb/DOM/NamedNodeMap.cpp
@@ -112,7 +112,7 @@ WebIDL::ExceptionOr<Attr const*> NamedNodeMap::remove_named_item(StringView qual
 
     // 2. If attr is null, then throw a "NotFoundError" DOMException.
     if (!attribute)
-        return WebIDL::NotFoundError::create(realm(), DeprecatedString::formatted("Attribute with name '{}' not found", qualified_name));
+        return WebIDL::NotFoundError::create(realm(), MUST(String::formatted("Attribute with name '{}' not found", qualified_name)));
 
     // 3. Return attr.
     return attribute;
@@ -126,7 +126,7 @@ WebIDL::ExceptionOr<Attr const*> NamedNodeMap::remove_named_item_ns(StringView n
 
     // 2. If attr is null, then throw a "NotFoundError" DOMException.
     if (!attribute)
-        return WebIDL::NotFoundError::create(realm(), DeprecatedString::formatted("Attribute with namespace '{}' and local name '{}' not found", namespace_, local_name));
+        return WebIDL::NotFoundError::create(realm(), MUST(String::formatted("Attribute with namespace '{}' and local name '{}' not found", namespace_, local_name)));
 
     // 3. Return attr.
     return attribute;
@@ -197,7 +197,7 @@ WebIDL::ExceptionOr<JS::GCPtr<Attr>> NamedNodeMap::set_attribute(Attr& attribute
 {
     // 1. If attr’s element is neither null nor element, throw an "InUseAttributeError" DOMException.
     if ((attribute.owner_element() != nullptr) && (attribute.owner_element() != &associated_element()))
-        return WebIDL::InUseAttributeError::create(realm(), "Attribute must not already be in use"sv);
+        return WebIDL::InUseAttributeError::create(realm(), "Attribute must not already be in use"_fly_string);
 
     // 2. Let oldAttr be the result of getting an attribute given attr’s namespace, attr’s local name, and element.
     size_t old_attribute_index = 0;

--- a/Userland/Libraries/LibWeb/DOM/Node.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Node.cpp
@@ -334,24 +334,24 @@ WebIDL::ExceptionOr<void> Node::ensure_pre_insertion_validity(JS::NonnullGCPtr<N
 {
     // 1. If parent is not a Document, DocumentFragment, or Element node, then throw a "HierarchyRequestError" DOMException.
     if (!is<Document>(this) && !is<DocumentFragment>(this) && !is<Element>(this))
-        return WebIDL::HierarchyRequestError::create(realm(), "Can only insert into a document, document fragment or element");
+        return WebIDL::HierarchyRequestError::create(realm(), "Can only insert into a document, document fragment or element"_fly_string);
 
     // 2. If node is a host-including inclusive ancestor of parent, then throw a "HierarchyRequestError" DOMException.
     if (node->is_host_including_inclusive_ancestor_of(*this))
-        return WebIDL::HierarchyRequestError::create(realm(), "New node is an ancestor of this node");
+        return WebIDL::HierarchyRequestError::create(realm(), "New node is an ancestor of this node"_fly_string);
 
     // 3. If child is non-null and its parent is not parent, then throw a "NotFoundError" DOMException.
     if (child && child->parent() != this)
-        return WebIDL::NotFoundError::create(realm(), "This node is not the parent of the given child");
+        return WebIDL::NotFoundError::create(realm(), "This node is not the parent of the given child"_fly_string);
 
     // FIXME: All the following "Invalid node type for insertion" messages could be more descriptive.
     // 4. If node is not a DocumentFragment, DocumentType, Element, or CharacterData node, then throw a "HierarchyRequestError" DOMException.
     if (!is<DocumentFragment>(*node) && !is<DocumentType>(*node) && !is<Element>(*node) && !is<Text>(*node) && !is<Comment>(*node) && !is<ProcessingInstruction>(*node))
-        return WebIDL::HierarchyRequestError::create(realm(), "Invalid node type for insertion");
+        return WebIDL::HierarchyRequestError::create(realm(), "Invalid node type for insertion"_fly_string);
 
     // 5. If either node is a Text node and parent is a document, or node is a doctype and parent is not a document, then throw a "HierarchyRequestError" DOMException.
     if ((is<Text>(*node) && is<Document>(this)) || (is<DocumentType>(*node) && !is<Document>(this)))
-        return WebIDL::HierarchyRequestError::create(realm(), "Invalid node type for insertion");
+        return WebIDL::HierarchyRequestError::create(realm(), "Invalid node type for insertion"_fly_string);
 
     // 6. If parent is a document, and any of the statements below, switched on the interface node implements, are true, then throw a "HierarchyRequestError" DOMException.
     if (is<Document>(this)) {
@@ -362,18 +362,18 @@ WebIDL::ExceptionOr<void> Node::ensure_pre_insertion_validity(JS::NonnullGCPtr<N
             auto node_element_child_count = verify_cast<DocumentFragment>(*node).child_element_count();
             if ((node_element_child_count > 1 || node->has_child_of_type<Text>())
                 || (node_element_child_count == 1 && (has_child_of_type<Element>() || is<DocumentType>(child.ptr()) || (child && child->has_following_node_of_type_in_tree_order<DocumentType>())))) {
-                return WebIDL::HierarchyRequestError::create(realm(), "Invalid node type for insertion");
+                return WebIDL::HierarchyRequestError::create(realm(), "Invalid node type for insertion"_fly_string);
             }
         } else if (is<Element>(*node)) {
             // Element
             // If parent has an element child, child is a doctype, or child is non-null and a doctype is following child.
             if (has_child_of_type<Element>() || is<DocumentType>(child.ptr()) || (child && child->has_following_node_of_type_in_tree_order<DocumentType>()))
-                return WebIDL::HierarchyRequestError::create(realm(), "Invalid node type for insertion");
+                return WebIDL::HierarchyRequestError::create(realm(), "Invalid node type for insertion"_fly_string);
         } else if (is<DocumentType>(*node)) {
             // DocumentType
             // parent has a doctype child, child is non-null and an element is preceding child, or child is null and parent has an element child.
             if (has_child_of_type<DocumentType>() || (child && child->has_preceding_node_of_type_in_tree_order<Element>()) || (!child && has_child_of_type<Element>()))
-                return WebIDL::HierarchyRequestError::create(realm(), "Invalid node type for insertion");
+                return WebIDL::HierarchyRequestError::create(realm(), "Invalid node type for insertion"_fly_string);
         }
     }
 
@@ -521,7 +521,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Node>> Node::pre_remove(JS::NonnullGCPtr<No
 {
     // 1. If child’s parent is not parent, then throw a "NotFoundError" DOMException.
     if (child->parent() != this)
-        return WebIDL::NotFoundError::create(realm(), "Child does not belong to this node");
+        return WebIDL::NotFoundError::create(realm(), "Child does not belong to this node"_fly_string);
 
     // 2. Remove child.
     child->remove();
@@ -664,25 +664,25 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Node>> Node::replace_child(JS::NonnullGCPtr
 {
     // If parent is not a Document, DocumentFragment, or Element node, then throw a "HierarchyRequestError" DOMException.
     if (!is<Document>(this) && !is<DocumentFragment>(this) && !is<Element>(this))
-        return WebIDL::HierarchyRequestError::create(realm(), "Can only insert into a document, document fragment or element");
+        return WebIDL::HierarchyRequestError::create(realm(), "Can only insert into a document, document fragment or element"_fly_string);
 
     // 2. If node is a host-including inclusive ancestor of parent, then throw a "HierarchyRequestError" DOMException.
     if (node->is_host_including_inclusive_ancestor_of(*this))
-        return WebIDL::HierarchyRequestError::create(realm(), "New node is an ancestor of this node");
+        return WebIDL::HierarchyRequestError::create(realm(), "New node is an ancestor of this node"_fly_string);
 
     // 3. If child’s parent is not parent, then throw a "NotFoundError" DOMException.
     if (child->parent() != this)
-        return WebIDL::NotFoundError::create(realm(), "This node is not the parent of the given child");
+        return WebIDL::NotFoundError::create(realm(), "This node is not the parent of the given child"_fly_string);
 
     // FIXME: All the following "Invalid node type for insertion" messages could be more descriptive.
 
     // 4. If node is not a DocumentFragment, DocumentType, Element, or CharacterData node, then throw a "HierarchyRequestError" DOMException.
     if (!is<DocumentFragment>(*node) && !is<DocumentType>(*node) && !is<Element>(*node) && !is<Text>(*node) && !is<Comment>(*node) && !is<ProcessingInstruction>(*node))
-        return WebIDL::HierarchyRequestError::create(realm(), "Invalid node type for insertion");
+        return WebIDL::HierarchyRequestError::create(realm(), "Invalid node type for insertion"_fly_string);
 
     // 5. If either node is a Text node and parent is a document, or node is a doctype and parent is not a document, then throw a "HierarchyRequestError" DOMException.
     if ((is<Text>(*node) && is<Document>(this)) || (is<DocumentType>(*node) && !is<Document>(this)))
-        return WebIDL::HierarchyRequestError::create(realm(), "Invalid node type for insertion");
+        return WebIDL::HierarchyRequestError::create(realm(), "Invalid node type for insertion"_fly_string);
 
     // If parent is a document, and any of the statements below, switched on the interface node implements, are true, then throw a "HierarchyRequestError" DOMException.
     if (is<Document>(this)) {
@@ -693,18 +693,18 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Node>> Node::replace_child(JS::NonnullGCPtr
             auto node_element_child_count = verify_cast<DocumentFragment>(*node).child_element_count();
             if ((node_element_child_count > 1 || node->has_child_of_type<Text>())
                 || (node_element_child_count == 1 && (first_child_of_type<Element>() != child || child->has_following_node_of_type_in_tree_order<DocumentType>()))) {
-                return WebIDL::HierarchyRequestError::create(realm(), "Invalid node type for insertion");
+                return WebIDL::HierarchyRequestError::create(realm(), "Invalid node type for insertion"_fly_string);
             }
         } else if (is<Element>(*node)) {
             // Element
             // parent has an element child that is not child or a doctype is following child.
             if (first_child_of_type<Element>() != child || child->has_following_node_of_type_in_tree_order<DocumentType>())
-                return WebIDL::HierarchyRequestError::create(realm(), "Invalid node type for insertion");
+                return WebIDL::HierarchyRequestError::create(realm(), "Invalid node type for insertion"_fly_string);
         } else if (is<DocumentType>(*node)) {
             // DocumentType
             // parent has a doctype child that is not child, or an element is preceding child.
             if (first_child_of_type<DocumentType>() != node || child->has_preceding_node_of_type_in_tree_order<Element>())
-                return WebIDL::HierarchyRequestError::create(realm(), "Invalid node type for insertion");
+                return WebIDL::HierarchyRequestError::create(realm(), "Invalid node type for insertion"_fly_string);
         }
     }
 
@@ -848,7 +848,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Node>> Node::clone_node_binding(bool deep)
 {
     // 1. If this is a shadow root, then throw a "NotSupportedError" DOMException.
     if (is<ShadowRoot>(*this))
-        return WebIDL::NotSupportedError::create(realm(), "Cannot clone shadow root");
+        return WebIDL::NotSupportedError::create(realm(), "Cannot clone shadow root"_fly_string);
 
     // 2. Return a clone of this, with the clone children flag set if deep is true.
     return clone_node(nullptr, deep);

--- a/Userland/Libraries/LibWeb/DOM/Node.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Node.cpp
@@ -812,7 +812,7 @@ JS::NonnullGCPtr<Node> Node::clone_node(Document* document, bool clone_children)
         auto comment = verify_cast<Comment>(this);
 
         // Set copy’s data to that of node.
-        auto comment_copy = heap().allocate<Comment>(realm(), *document, comment->data());
+        auto comment_copy = heap().allocate<Comment>(realm(), *document, MUST(String::from_deprecated_string(comment->data())));
         copy = move(comment_copy);
     } else if (is<ProcessingInstruction>(this)) {
         // ProcessingInstruction

--- a/Userland/Libraries/LibWeb/DOM/Node.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Node.cpp
@@ -1502,7 +1502,7 @@ void Node::queue_mutation_record(FlyString const& type, DeprecatedString attribu
             //    then:
             if (!(node.ptr() != this && !options.subtree)
                 && !(type == MutationType::attributes && (!options.attributes.has_value() || !options.attributes.value()))
-                && !(type == MutationType::attributes && options.attribute_filter.has_value() && (!attribute_namespace.is_null() || !options.attribute_filter->contains_slow(attribute_name)))
+                && !(type == MutationType::attributes && options.attribute_filter.has_value() && (!attribute_namespace.is_null() || !options.attribute_filter->contains_slow(attribute_name.view())))
                 && !(type == MutationType::characterData && (!options.character_data.has_value() || !options.character_data.value()))
                 && !(type == MutationType::childList && !options.child_list)) {
                 // 1. Let mo be registered’s observer.

--- a/Userland/Libraries/LibWeb/DOM/Node.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Node.cpp
@@ -805,7 +805,7 @@ JS::NonnullGCPtr<Node> Node::clone_node(Document* document, bool clone_children)
         auto text = verify_cast<Text>(this);
 
         // Set copy’s data to that of node.
-        auto text_copy = heap().allocate<Text>(realm(), *document, text->data());
+        auto text_copy = heap().allocate<Text>(realm(), *document, MUST(String::from_deprecated_string(text->data())));
         copy = move(text_copy);
     } else if (is<Comment>(this)) {
         // Comment
@@ -1257,7 +1257,7 @@ void Node::string_replace_all(DeprecatedString const& string)
 
     // 2. If string is not the empty string, then set node to a new Text node whose data is string and node document is parent’s node document.
     if (!string.is_empty())
-        node = heap().allocate<Text>(realm(), document(), string);
+        node = heap().allocate<Text>(realm(), document(), MUST(String::from_deprecated_string(string)));
 
     // 3. Replace all with node within parent.
     replace_all(node);

--- a/Userland/Libraries/LibWeb/DOM/NodeIterator.cpp
+++ b/Userland/Libraries/LibWeb/DOM/NodeIterator.cpp
@@ -139,7 +139,7 @@ JS::ThrowCompletionOr<NodeFilter::Result> NodeIterator::filter(Node& node)
 {
     // 1. If traverser’s active flag is set, then throw an "InvalidStateError" DOMException.
     if (m_active)
-        return throw_completion(WebIDL::InvalidStateError::create(realm(), "NodeIterator is already active"));
+        return throw_completion(WebIDL::InvalidStateError::create(realm(), "NodeIterator is already active"_fly_string));
 
     // 2. Let n be node’s nodeType attribute value − 1.
     auto n = node.node_type() - 1;

--- a/Userland/Libraries/LibWeb/DOM/NodeOperations.cpp
+++ b/Userland/Libraries/LibWeb/DOM/NodeOperations.cpp
@@ -26,7 +26,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Node>> convert_nodes_to_single_node(Vector<
         if (node.has<JS::Handle<Node>>())
             return *node.get<JS::Handle<Node>>();
 
-        return document.heap().allocate<DOM::Text>(document.realm(), document, node.get<DeprecatedString>());
+        return document.heap().allocate<DOM::Text>(document.realm(), document, MUST(String::from_deprecated_string(node.get<DeprecatedString>())));
     };
 
     if (nodes.size() == 1)

--- a/Userland/Libraries/LibWeb/DOM/ParentNode.cpp
+++ b/Userland/Libraries/LibWeb/DOM/ParentNode.cpp
@@ -30,7 +30,7 @@ WebIDL::ExceptionOr<JS::GCPtr<Element>> ParentNode::query_selector(StringView se
 
     // 2. If s is failure, then throw a "SyntaxError" DOMException.
     if (!maybe_selectors.has_value())
-        return WebIDL::SyntaxError::create(realm(), "Failed to parse selector");
+        return WebIDL::SyntaxError::create(realm(), "Failed to parse selector"_fly_string);
 
     auto selectors = maybe_selectors.value();
 
@@ -62,7 +62,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<NodeList>> ParentNode::query_selector_all(S
 
     // 2. If s is failure, then throw a "SyntaxError" DOMException.
     if (!maybe_selectors.has_value())
-        return WebIDL::SyntaxError::create(realm(), "Failed to parse selector");
+        return WebIDL::SyntaxError::create(realm(), "Failed to parse selector"_fly_string);
 
     auto selectors = maybe_selectors.value();
 

--- a/Userland/Libraries/LibWeb/DOM/Range.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Range.cpp
@@ -165,11 +165,11 @@ WebIDL::ExceptionOr<void> Range::set_start_or_end(Node& node, u32 offset, StartO
 
     // 1. If node is a doctype, then throw an "InvalidNodeTypeError" DOMException.
     if (is<DocumentType>(node))
-        return WebIDL::InvalidNodeTypeError::create(realm(), "Node cannot be a DocumentType.");
+        return WebIDL::InvalidNodeTypeError::create(realm(), "Node cannot be a DocumentType."_fly_string);
 
     // 2. If offset is greater than node’s length, then throw an "IndexSizeError" DOMException.
     if (offset > node.length())
-        return WebIDL::IndexSizeError::create(realm(), DeprecatedString::formatted("Node does not contain a child at offset {}", offset));
+        return WebIDL::IndexSizeError::create(realm(), MUST(String::formatted("Node does not contain a child at offset {}", offset)));
 
     // 3. Let bp be the boundary point (node, offset).
 
@@ -225,7 +225,7 @@ WebIDL::ExceptionOr<void> Range::set_start_before(Node& node)
 
     // 2. If parent is null, then throw an "InvalidNodeTypeError" DOMException.
     if (!parent)
-        return WebIDL::InvalidNodeTypeError::create(realm(), "Given node has no parent.");
+        return WebIDL::InvalidNodeTypeError::create(realm(), "Given node has no parent."_fly_string);
 
     // 3. Set the start of this to boundary point (parent, node’s index).
     return set_start_or_end(*parent, node.index(), StartOrEnd::Start);
@@ -239,7 +239,7 @@ WebIDL::ExceptionOr<void> Range::set_start_after(Node& node)
 
     // 2. If parent is null, then throw an "InvalidNodeTypeError" DOMException.
     if (!parent)
-        return WebIDL::InvalidNodeTypeError::create(realm(), "Given node has no parent.");
+        return WebIDL::InvalidNodeTypeError::create(realm(), "Given node has no parent."_fly_string);
 
     // 3. Set the start of this to boundary point (parent, node’s index plus 1).
     return set_start_or_end(*parent, node.index() + 1, StartOrEnd::Start);
@@ -253,7 +253,7 @@ WebIDL::ExceptionOr<void> Range::set_end_before(Node& node)
 
     // 2. If parent is null, then throw an "InvalidNodeTypeError" DOMException.
     if (!parent)
-        return WebIDL::InvalidNodeTypeError::create(realm(), "Given node has no parent.");
+        return WebIDL::InvalidNodeTypeError::create(realm(), "Given node has no parent."_fly_string);
 
     // 3. Set the end of this to boundary point (parent, node’s index).
     return set_start_or_end(*parent, node.index(), StartOrEnd::End);
@@ -267,7 +267,7 @@ WebIDL::ExceptionOr<void> Range::set_end_after(Node& node)
 
     // 2. If parent is null, then throw an "InvalidNodeTypeError" DOMException.
     if (!parent)
-        return WebIDL::InvalidNodeTypeError::create(realm(), "Given node has no parent.");
+        return WebIDL::InvalidNodeTypeError::create(realm(), "Given node has no parent."_fly_string);
 
     // 3. Set the end of this to boundary point (parent, node’s index plus 1).
     return set_start_or_end(*parent, node.index() + 1, StartOrEnd::End);
@@ -283,11 +283,11 @@ WebIDL::ExceptionOr<i16> Range::compare_boundary_points(u16 how, Range const& so
     //      - END_TO_START,
     //    then throw a "NotSupportedError" DOMException.
     if (how != HowToCompareBoundaryPoints::START_TO_START && how != HowToCompareBoundaryPoints::START_TO_END && how != HowToCompareBoundaryPoints::END_TO_END && how != HowToCompareBoundaryPoints::END_TO_START)
-        return WebIDL::NotSupportedError::create(realm(), DeprecatedString::formatted("Expected 'how' to be one of START_TO_START (0), START_TO_END (1), END_TO_END (2) or END_TO_START (3), got {}", how));
+        return WebIDL::NotSupportedError::create(realm(), MUST(String::formatted("Expected 'how' to be one of START_TO_START (0), START_TO_END (1), END_TO_END (2) or END_TO_START (3), got {}", how)));
 
     // 2. If this’s root is not the same as sourceRange’s root, then throw a "WrongDocumentError" DOMException.
     if (&root() != &source_range.root())
-        return WebIDL::WrongDocumentError::create(realm(), "This range is not in the same tree as the source range.");
+        return WebIDL::WrongDocumentError::create(realm(), "This range is not in the same tree as the source range."_fly_string);
 
     JS::GCPtr<Node> this_point_node;
     u32 this_point_offset = 0;
@@ -368,7 +368,7 @@ WebIDL::ExceptionOr<void> Range::select(Node& node)
 
     // 2. If parent is null, then throw an "InvalidNodeTypeError" DOMException.
     if (!parent)
-        return WebIDL::InvalidNodeTypeError::create(realm(), "Given node has no parent.");
+        return WebIDL::InvalidNodeTypeError::create(realm(), "Given node has no parent."_fly_string);
 
     // 3. Let index be node’s index.
     auto index = node.index();
@@ -411,7 +411,7 @@ WebIDL::ExceptionOr<void> Range::select_node_contents(Node& node)
 {
     // 1. If node is a doctype, throw an "InvalidNodeTypeError" DOMException.
     if (is<DocumentType>(node))
-        return WebIDL::InvalidNodeTypeError::create(realm(), "Node cannot be a DocumentType.");
+        return WebIDL::InvalidNodeTypeError::create(realm(), "Node cannot be a DocumentType."_fly_string);
 
     // 2. Let length be the length of node.
     auto length = node.length();
@@ -505,11 +505,11 @@ WebIDL::ExceptionOr<bool> Range::is_point_in_range(Node const& node, u32 offset)
 
     // 2. If node is a doctype, then throw an "InvalidNodeTypeError" DOMException.
     if (is<DocumentType>(node))
-        return WebIDL::InvalidNodeTypeError::create(realm(), "Node cannot be a DocumentType.");
+        return WebIDL::InvalidNodeTypeError::create(realm(), "Node cannot be a DocumentType."_fly_string);
 
     // 3. If offset is greater than node’s length, then throw an "IndexSizeError" DOMException.
     if (offset > node.length())
-        return WebIDL::IndexSizeError::create(realm(), DeprecatedString::formatted("Node does not contain a child at offset {}", offset));
+        return WebIDL::IndexSizeError::create(realm(), MUST(String::formatted("Node does not contain a child at offset {}", offset)));
 
     // 4. If (node, offset) is before start or after end, return false.
     auto relative_position_to_start = position_of_boundary_point_relative_to_other_boundary_point(node, offset, m_start_container, m_start_offset);
@@ -526,15 +526,15 @@ WebIDL::ExceptionOr<i16> Range::compare_point(Node const& node, u32 offset) cons
 {
     // 1. If node’s root is different from this’s root, then throw a "WrongDocumentError" DOMException.
     if (&node.root() != &root())
-        return WebIDL::WrongDocumentError::create(realm(), "Given node is not in the same document as the range.");
+        return WebIDL::WrongDocumentError::create(realm(), "Given node is not in the same document as the range."_fly_string);
 
     // 2. If node is a doctype, then throw an "InvalidNodeTypeError" DOMException.
     if (is<DocumentType>(node))
-        return WebIDL::InvalidNodeTypeError::create(realm(), "Node cannot be a DocumentType.");
+        return WebIDL::InvalidNodeTypeError::create(realm(), "Node cannot be a DocumentType."_fly_string);
 
     // 3. If offset is greater than node’s length, then throw an "IndexSizeError" DOMException.
     if (offset > node.length())
-        return WebIDL::IndexSizeError::create(realm(), DeprecatedString::formatted("Node does not contain a child at offset {}", offset));
+        return WebIDL::IndexSizeError::create(realm(), MUST(String::formatted("Node does not contain a child at offset {}", offset)));
 
     // 4. If (node, offset) is before start, return −1.
     auto relative_position_to_start = position_of_boundary_point_relative_to_other_boundary_point(node, offset, m_start_container, m_start_offset);
@@ -667,7 +667,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<DocumentFragment>> Range::extract()
     // 12. If any member of contained children is a doctype, then throw a "HierarchyRequestError" DOMException.
     for (auto const& child : contained_children) {
         if (is<DocumentType>(*child))
-            return WebIDL::HierarchyRequestError::create(realm(), "Contained child is a DocumentType");
+            return WebIDL::HierarchyRequestError::create(realm(), "Contained child is a DocumentType"_fly_string);
     }
 
     JS::GCPtr<Node> new_node;
@@ -814,7 +814,7 @@ WebIDL::ExceptionOr<void> Range::insert(JS::NonnullGCPtr<Node> node)
     if ((is<ProcessingInstruction>(*m_start_container) || is<Comment>(*m_start_container))
         || (is<Text>(*m_start_container) && !m_start_container->parent_node())
         || m_start_container.ptr() == node.ptr()) {
-        return WebIDL::HierarchyRequestError::create(realm(), "Range has inappropriate start node for insertion");
+        return WebIDL::HierarchyRequestError::create(realm(), "Range has inappropriate start node for insertion"_fly_string);
     }
 
     // 2. Let referenceNode be null.
@@ -885,11 +885,11 @@ WebIDL::ExceptionOr<void> Range::surround_contents(JS::NonnullGCPtr<Node> new_pa
     if (is<Text>(*end_non_text_node))
         end_non_text_node = end_non_text_node->parent_node();
     if (start_non_text_node != end_non_text_node)
-        return WebIDL::InvalidStateError::create(realm(), "Non-Text node is partially contained in range.");
+        return WebIDL::InvalidStateError::create(realm(), "Non-Text node is partially contained in range."_fly_string);
 
     // 2. If newParent is a Document, DocumentType, or DocumentFragment node, then throw an "InvalidNodeTypeError" DOMException.
     if (is<Document>(*new_parent) || is<DocumentType>(*new_parent) || is<DocumentFragment>(*new_parent))
-        return WebIDL::InvalidNodeTypeError::create(realm(), "Invalid parent node type");
+        return WebIDL::InvalidNodeTypeError::create(realm(), "Invalid parent node type"_fly_string);
 
     // 3. Let fragment be the result of extracting this.
     auto fragment = TRY(extract());
@@ -993,7 +993,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<DocumentFragment>> Range::clone_the_content
     // 12. If any member of contained children is a doctype, then throw a "HierarchyRequestError" DOMException.
     for (auto const& child : contained_children) {
         if (is<DocumentType>(*child))
-            return WebIDL::HierarchyRequestError::create(realm(), "Contained child is a DocumentType");
+            return WebIDL::HierarchyRequestError::create(realm(), "Contained child is a DocumentType"_fly_string);
     }
 
     // 13. If first partially contained child is a CharacterData node, then:

--- a/Userland/Libraries/LibWeb/DOM/ShadowRoot.cpp
+++ b/Userland/Libraries/LibWeb/DOM/ShadowRoot.cpp
@@ -44,7 +44,7 @@ WebIDL::ExceptionOr<DeprecatedString> ShadowRoot::inner_html() const
 }
 
 // https://w3c.github.io/DOM-Parsing/#dom-innerhtml-innerhtml
-WebIDL::ExceptionOr<void> ShadowRoot::set_inner_html(DeprecatedString const& markup)
+WebIDL::ExceptionOr<void> ShadowRoot::set_inner_html(StringView markup)
 {
     TRY(DOMParsing::inner_html_setter(*this, markup));
 

--- a/Userland/Libraries/LibWeb/DOM/ShadowRoot.h
+++ b/Userland/Libraries/LibWeb/DOM/ShadowRoot.h
@@ -27,7 +27,7 @@ public:
     virtual EventTarget* get_parent(Event const&) override;
 
     WebIDL::ExceptionOr<DeprecatedString> inner_html() const;
-    WebIDL::ExceptionOr<void> set_inner_html(DeprecatedString const&);
+    WebIDL::ExceptionOr<void> set_inner_html(StringView);
 
 private:
     ShadowRoot(Document&, Element& host, Bindings::ShadowRootMode);

--- a/Userland/Libraries/LibWeb/DOM/ShadowRoot.idl
+++ b/Userland/Libraries/LibWeb/DOM/ShadowRoot.idl
@@ -2,7 +2,7 @@
 #import <DOM/InnerHTML.idl>
 
 // https://dom.spec.whatwg.org/#shadowroot
-[Exposed=Window, UseDeprecatedAKString]
+[Exposed=Window]
 interface ShadowRoot : DocumentFragment {
     readonly attribute ShadowRootMode mode;
     // FIXME: readonly attribute boolean delegatesFocus;

--- a/Userland/Libraries/LibWeb/DOM/StaticRange.cpp
+++ b/Userland/Libraries/LibWeb/DOM/StaticRange.cpp
@@ -26,10 +26,10 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<StaticRange>> StaticRange::construct_impl(J
 {
     // 1. If init["startContainer"] or init["endContainer"] is a DocumentType or Attr node, then throw an "InvalidNodeTypeError" DOMException.
     if (is<DocumentType>(*init.start_container) || is<Attr>(*init.start_container))
-        return WebIDL::InvalidNodeTypeError::create(realm, "startContainer cannot be a DocumentType or Attribute node.");
+        return WebIDL::InvalidNodeTypeError::create(realm, "startContainer cannot be a DocumentType or Attribute node."_fly_string);
 
     if (is<DocumentType>(*init.end_container) || is<Attr>(*init.end_container))
-        return WebIDL::InvalidNodeTypeError::create(realm, "endContainer cannot be a DocumentType or Attribute node.");
+        return WebIDL::InvalidNodeTypeError::create(realm, "endContainer cannot be a DocumentType or Attribute node."_fly_string);
 
     // 2. Set this’s start to (init["startContainer"], init["startOffset"]) and end to (init["endContainer"], init["endOffset"]).
     return realm.heap().allocate<StaticRange>(realm, *init.start_container, init.start_offset, *init.end_container, init.end_offset);

--- a/Userland/Libraries/LibWeb/DOM/Text.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Text.cpp
@@ -58,7 +58,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Text>> Text::split_text(size_t offset)
 
     // 2. If offset is greater than length, then throw an "IndexSizeError" DOMException.
     if (offset > length)
-        return WebIDL::IndexSizeError::create(realm(), "Split offset is greater than length");
+        return WebIDL::IndexSizeError::create(realm(), "Split offset is greater than length"_fly_string);
 
     // 3. Let count be length minus offset.
     auto count = length - offset;

--- a/Userland/Libraries/LibWeb/DOM/Text.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Text.cpp
@@ -14,13 +14,13 @@
 
 namespace Web::DOM {
 
-Text::Text(Document& document, DeprecatedString const& data)
-    : CharacterData(document, NodeType::TEXT_NODE, data)
+Text::Text(Document& document, String const& data)
+    : CharacterData(document, NodeType::TEXT_NODE, data.to_deprecated_string())
 {
 }
 
-Text::Text(Document& document, NodeType type, DeprecatedString const& data)
-    : CharacterData(document, type, data)
+Text::Text(Document& document, NodeType type, String const& data)
+    : CharacterData(document, type, data.to_deprecated_string())
 {
 }
 
@@ -37,7 +37,7 @@ void Text::visit_edges(Cell::Visitor& visitor)
 }
 
 // https://dom.spec.whatwg.org/#dom-text-text
-WebIDL::ExceptionOr<JS::NonnullGCPtr<Text>> Text::construct_impl(JS::Realm& realm, DeprecatedString const& data)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<Text>> Text::construct_impl(JS::Realm& realm, String const& data)
 {
     // The new Text(data) constructor steps are to set this’s data to data and this’s node document to current global object’s associated Document.
     auto& window = verify_cast<HTML::Window>(HTML::current_global_object());
@@ -67,7 +67,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Text>> Text::split_text(size_t offset)
     auto new_data = TRY(substring_data(offset, count));
 
     // 5. Let new node be a new Text node, with the same node document as node. Set new node’s data to new data.
-    auto new_node = heap().allocate<Text>(realm(), document(), new_data);
+    auto new_node = heap().allocate<Text>(realm(), document(), MUST(String::from_deprecated_string(new_data)));
 
     // 6. Let parent be node’s parent.
     JS::GCPtr<Node> parent = this->parent();

--- a/Userland/Libraries/LibWeb/DOM/Text.h
+++ b/Userland/Libraries/LibWeb/DOM/Text.h
@@ -18,7 +18,7 @@ class Text : public CharacterData {
 public:
     virtual ~Text() override = default;
 
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<Text>> construct_impl(JS::Realm& realm, DeprecatedString const& data);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<Text>> construct_impl(JS::Realm& realm, String const& data);
 
     // ^Node
     virtual DeprecatedFlyString node_name() const override { return "#text"; }
@@ -35,8 +35,8 @@ public:
     void set_is_password_input(Badge<HTML::HTMLInputElement>, bool b) { m_is_password_input = b; }
 
 protected:
-    Text(Document&, DeprecatedString const&);
-    Text(Document&, NodeType, DeprecatedString const&);
+    Text(Document&, String const&);
+    Text(Document&, NodeType, String const&);
 
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;

--- a/Userland/Libraries/LibWeb/DOM/Text.idl
+++ b/Userland/Libraries/LibWeb/DOM/Text.idl
@@ -1,7 +1,7 @@
 #import <DOM/CharacterData.idl>
 
 // https://dom.spec.whatwg.org/#text
-[Exposed=Window, UseDeprecatedAKString]
+[Exposed=Window]
 interface Text : CharacterData {
     constructor(optional DOMString data = "");
 

--- a/Userland/Libraries/LibWeb/DOM/TreeWalker.cpp
+++ b/Userland/Libraries/LibWeb/DOM/TreeWalker.cpp
@@ -237,7 +237,7 @@ JS::ThrowCompletionOr<NodeFilter::Result> TreeWalker::filter(Node& node)
 {
     // 1. If traverser’s active flag is set, then throw an "InvalidStateError" DOMException.
     if (m_active)
-        return throw_completion(WebIDL::InvalidStateError::create(realm(), "NodeIterator is already active"));
+        return throw_completion(WebIDL::InvalidStateError::create(realm(), "NodeIterator is already active"_fly_string));
 
     // 2. Let n be node’s nodeType attribute value − 1.
     auto n = node.node_type() - 1;

--- a/Userland/Libraries/LibWeb/DOMParsing/InnerHTML.cpp
+++ b/Userland/Libraries/LibWeb/DOMParsing/InnerHTML.cpp
@@ -32,7 +32,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<DOM::DocumentFragment>> parse_fragment(Depr
 }
 
 // https://w3c.github.io/DOM-Parsing/#dom-innerhtml-innerhtml
-WebIDL::ExceptionOr<void> inner_html_setter(JS::NonnullGCPtr<DOM::Node> context_object, DeprecatedString const& value)
+WebIDL::ExceptionOr<void> inner_html_setter(JS::NonnullGCPtr<DOM::Node> context_object, StringView value)
 {
     // 1. Let context element be the context object's host if the context object is a ShadowRoot object, or the context object otherwise.
     //    (This is handled in Element and ShadowRoot)

--- a/Userland/Libraries/LibWeb/DOMParsing/InnerHTML.h
+++ b/Userland/Libraries/LibWeb/DOMParsing/InnerHTML.h
@@ -14,7 +14,7 @@
 namespace Web::DOMParsing {
 
 // https://w3c.github.io/DOM-Parsing/#dom-innerhtml-innerhtml
-WebIDL::ExceptionOr<void> inner_html_setter(JS::NonnullGCPtr<DOM::Node> context_object, DeprecatedString const& value);
+WebIDL::ExceptionOr<void> inner_html_setter(JS::NonnullGCPtr<DOM::Node> context_object, StringView value);
 
 WebIDL::ExceptionOr<JS::NonnullGCPtr<DOM::DocumentFragment>> parse_fragment(DeprecatedString const& markup, DOM::Element& context_element);
 

--- a/Userland/Libraries/LibWeb/DOMParsing/XMLSerializer.cpp
+++ b/Userland/Libraries/LibWeb/DOMParsing/XMLSerializer.cpp
@@ -339,7 +339,7 @@ static WebIDL::ExceptionOr<DeprecatedString> serialize_element_attributes(DOM::E
             });
 
             if (local_name_set_iterator != local_name_set.end())
-                return WebIDL::InvalidStateError::create(realm, "Element contains two attributes with identical namespaces and local names");
+                return WebIDL::InvalidStateError::create(realm, "Element contains two attributes with identical namespaces and local names"_fly_string);
         }
 
         // 2. Create a new tuple consisting of attr's namespaceURI attribute and localName attribute, and add it to the localname set.
@@ -392,12 +392,12 @@ static WebIDL::ExceptionOr<DeprecatedString> serialize_element_attributes(DOM::E
                 // 2. If the require well-formed flag is set (its value is true), and the value of attr's value attribute matches the XMLNS namespace,
                 //    then throw an exception; the serialization of this attribute would produce invalid XML because the XMLNS namespace is reserved and cannot be applied as an element's namespace via XML parsing.
                 if (require_well_formed == RequireWellFormed::Yes && attribute->value() == Namespace::XMLNS)
-                    return WebIDL::InvalidStateError::create(realm, "The XMLNS namespace cannot be used as an element's namespace");
+                    return WebIDL::InvalidStateError::create(realm, "The XMLNS namespace cannot be used as an element's namespace"_fly_string);
 
                 // 3. If the require well-formed flag is set (its value is true), and the value of attr's value attribute is the empty string,
                 //    then throw an exception; namespace prefix declarations cannot be used to undeclare a namespace (use a default namespace declaration instead).
                 if (require_well_formed == RequireWellFormed::Yes && attribute->value().is_empty())
-                    return WebIDL::InvalidStateError::create(realm, "Attribute's value is empty");
+                    return WebIDL::InvalidStateError::create(realm, "Attribute's value is empty"_fly_string);
 
                 // 4. [If] the attr's prefix matches the string "xmlns", then let candidate prefix be the string "xmlns".
                 if (attribute->prefix() == "xmlns"sv)
@@ -440,12 +440,12 @@ static WebIDL::ExceptionOr<DeprecatedString> serialize_element_attributes(DOM::E
         //    or does not match the XML Name production or equals "xmlns" and attribute namespace is null, then throw an exception; the serialization of this attr would not be a well-formed attribute.
         if (require_well_formed == RequireWellFormed::Yes) {
             if (attribute->local_name().view().contains(':'))
-                return WebIDL::InvalidStateError::create(realm, "Attribute's local name contains a colon");
+                return WebIDL::InvalidStateError::create(realm, "Attribute's local name contains a colon"_fly_string);
 
             // FIXME: Check attribute's local name against the XML Name production.
 
             if (attribute->local_name() == "xmlns"sv && attribute_namespace.is_null())
-                return WebIDL::InvalidStateError::create(realm, "Attribute's local name is 'xmlns' and the attribute has no namespace");
+                return WebIDL::InvalidStateError::create(realm, "Attribute's local name is 'xmlns' and the attribute has no namespace"_fly_string);
         }
 
         // 9. Append the following strings to result, in the order listed:
@@ -475,7 +475,7 @@ static WebIDL::ExceptionOr<DeprecatedString> serialize_element(DOM::Element cons
     //    then throw an exception; the serialization of this node would not be a well-formed element.
     if (require_well_formed == RequireWellFormed::Yes) {
         if (element.local_name().view().contains(':'))
-            return WebIDL::InvalidStateError::create(realm, "Element's local name contains a colon");
+            return WebIDL::InvalidStateError::create(realm, "Element's local name contains a colon"_fly_string);
 
         // FIXME: Check element's local name against the XML Char production.
     }
@@ -547,7 +547,7 @@ static WebIDL::ExceptionOr<DeprecatedString> serialize_element(DOM::Element cons
         if (prefix == "xmlns"sv) {
             // 1. If the require well-formed flag is set, then throw an error. An Element with prefix "xmlns" will not legally round-trip in a conforming XML parser.
             if (require_well_formed == RequireWellFormed::Yes)
-                return WebIDL::InvalidStateError::create(realm, "Elements prefix is 'xmlns'");
+                return WebIDL::InvalidStateError::create(realm, "Elements prefix is 'xmlns'"_fly_string);
 
             // 2. Let candidate prefix be the value of prefix.
             candidate_prefix = prefix;
@@ -714,7 +714,7 @@ static WebIDL::ExceptionOr<DeprecatedString> serialize_document(DOM::Document co
     // If the require well-formed flag is set (its value is true), and this node has no documentElement (the documentElement attribute's value is null),
     // then throw an exception; the serialization of this node would not be a well-formed document.
     if (require_well_formed == RequireWellFormed::Yes && !document.document_element())
-        return WebIDL::InvalidStateError::create(document.realm(), "Document has no document element");
+        return WebIDL::InvalidStateError::create(document.realm(), "Document has no document element"_fly_string);
 
     // Otherwise, run the following steps:
     // 1. Let serialized document be an empty string.
@@ -738,10 +738,10 @@ static WebIDL::ExceptionOr<DeprecatedString> serialize_comment(DOM::Comment cons
         // FIXME: Check comment's data against the XML Char production.
 
         if (comment.data().contains("--"sv))
-            return WebIDL::InvalidStateError::create(comment.realm(), "Comment data contains two adjacent hyphens");
+            return WebIDL::InvalidStateError::create(comment.realm(), "Comment data contains two adjacent hyphens"_fly_string);
 
         if (comment.data().ends_with('-'))
-            return WebIDL::InvalidStateError::create(comment.realm(), "Comment data ends with a hyphen");
+            return WebIDL::InvalidStateError::create(comment.realm(), "Comment data ends with a hyphen"_fly_string);
     }
 
     // Otherwise, return the concatenation of "<!--", node's data, and "-->".
@@ -796,7 +796,7 @@ static WebIDL::ExceptionOr<DeprecatedString> serialize_document_type(DOM::Docume
         //    both a """ (U+0022 QUOTATION MARK) and a "'" (U+0027 APOSTROPHE), then throw an exception; the serialization of this node would not be a well-formed document type declaration.
         // FIXME: Check systemId against the XML Char production.
         if (document_type.system_id().contains('"') && document_type.system_id().contains('\''))
-            return WebIDL::InvalidStateError::create(document_type.realm(), "Document type system ID contains both a quotation mark and an apostrophe");
+            return WebIDL::InvalidStateError::create(document_type.realm(), "Document type system ID contains both a quotation mark and an apostrophe"_fly_string);
     }
 
     // 3. Let markup be an empty string.
@@ -858,16 +858,16 @@ static WebIDL::ExceptionOr<DeprecatedString> serialize_processing_instruction(DO
         // 1. If the require well-formed flag is set (its value is true), and node's target contains a ":" (U+003A COLON) character
         //    or is an ASCII case-insensitive match for the string "xml", then throw an exception; the serialization of this node's target would not be well-formed.
         if (processing_instruction.target().contains(':'))
-            return WebIDL::InvalidStateError::create(processing_instruction.realm(), "Processing instruction target contains a colon");
+            return WebIDL::InvalidStateError::create(processing_instruction.realm(), "Processing instruction target contains a colon"_fly_string);
 
         if (Infra::is_ascii_case_insensitive_match(processing_instruction.target(), "xml"sv))
-            return WebIDL::InvalidStateError::create(processing_instruction.realm(), "Processing instruction target is equal to 'xml'");
+            return WebIDL::InvalidStateError::create(processing_instruction.realm(), "Processing instruction target is equal to 'xml'"_fly_string);
 
         // 2. If the require well-formed flag is set (its value is true), and node's data contains characters that are not matched by the XML Char production or contains
         //    the string "?>" (U+003F QUESTION MARK, U+003E GREATER-THAN SIGN), then throw an exception; the serialization of this node's data would not be well-formed.
         // FIXME: Check data against the XML Char production.
         if (processing_instruction.data().contains("?>"sv))
-            return WebIDL::InvalidStateError::create(processing_instruction.realm(), "Processing instruction data contains a terminator");
+            return WebIDL::InvalidStateError::create(processing_instruction.realm(), "Processing instruction data contains a terminator"_fly_string);
     }
 
     // 3. Let markup be the concatenation of the following, in the order listed:

--- a/Userland/Libraries/LibWeb/Encoding/TextDecoder.cpp
+++ b/Userland/Libraries/LibWeb/Encoding/TextDecoder.cpp
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/DeprecatedFlyString.h>
+#include <AK/FlyString.h>
 #include <LibJS/Runtime/TypedArray.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Encoding/TextDecoder.h>
@@ -12,7 +12,7 @@
 
 namespace Web::Encoding {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<TextDecoder>> TextDecoder::construct_impl(JS::Realm& realm, DeprecatedFlyString encoding)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<TextDecoder>> TextDecoder::construct_impl(JS::Realm& realm, FlyString encoding)
 {
     auto& vm = realm.vm();
 
@@ -24,7 +24,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<TextDecoder>> TextDecoder::construct_impl(J
 }
 
 // https://encoding.spec.whatwg.org/#dom-textdecoder
-TextDecoder::TextDecoder(JS::Realm& realm, TextCodec::Decoder& decoder, DeprecatedFlyString encoding, bool fatal, bool ignore_bom)
+TextDecoder::TextDecoder(JS::Realm& realm, TextCodec::Decoder& decoder, FlyString encoding, bool fatal, bool ignore_bom)
     : PlatformObject(realm)
     , m_decoder(decoder)
     , m_encoding(move(encoding))
@@ -42,7 +42,7 @@ void TextDecoder::initialize(JS::Realm& realm)
 }
 
 // https://encoding.spec.whatwg.org/#dom-textdecoder-decode
-WebIDL::ExceptionOr<DeprecatedString> TextDecoder::decode(Optional<JS::Handle<JS::Object>> const& input) const
+WebIDL::ExceptionOr<String> TextDecoder::decode(Optional<JS::Handle<JS::Object>> const& input) const
 {
     if (!input.has_value())
         return TRY_OR_THROW_OOM(vm(), m_decoder.to_utf8({}));

--- a/Userland/Libraries/LibWeb/Encoding/TextDecoder.cpp
+++ b/Userland/Libraries/LibWeb/Encoding/TextDecoder.cpp
@@ -51,7 +51,7 @@ WebIDL::ExceptionOr<DeprecatedString> TextDecoder::decode(Optional<JS::Handle<JS
 
     auto data_buffer_or_error = WebIDL::get_buffer_source_copy(*input->cell());
     if (data_buffer_or_error.is_error())
-        return WebIDL::OperationError::create(realm(), "Failed to copy bytes from ArrayBuffer");
+        return WebIDL::OperationError::create(realm(), "Failed to copy bytes from ArrayBuffer"_fly_string);
     auto& data_buffer = data_buffer_or_error.value();
     return TRY_OR_THROW_OOM(vm(), m_decoder.to_utf8({ data_buffer.data(), data_buffer.size() }));
 }

--- a/Userland/Libraries/LibWeb/Encoding/TextDecoder.h
+++ b/Userland/Libraries/LibWeb/Encoding/TextDecoder.h
@@ -21,24 +21,24 @@ class TextDecoder : public Bindings::PlatformObject {
     WEB_PLATFORM_OBJECT(TextDecoder, Bindings::PlatformObject);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<TextDecoder>> construct_impl(JS::Realm&, DeprecatedFlyString encoding);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<TextDecoder>> construct_impl(JS::Realm&, FlyString encoding);
 
     virtual ~TextDecoder() override;
 
-    WebIDL::ExceptionOr<DeprecatedString> decode(Optional<JS::Handle<JS::Object>> const&) const;
+    WebIDL::ExceptionOr<String> decode(Optional<JS::Handle<JS::Object>> const&) const;
 
-    DeprecatedFlyString const& encoding() const { return m_encoding; }
+    FlyString const& encoding() const { return m_encoding; }
     bool fatal() const { return m_fatal; }
     bool ignore_bom() const { return m_ignore_bom; }
 
 private:
     // https://encoding.spec.whatwg.org/#dom-textdecoder
-    TextDecoder(JS::Realm&, TextCodec::Decoder&, DeprecatedFlyString encoding, bool fatal, bool ignore_bom);
+    TextDecoder(JS::Realm&, TextCodec::Decoder&, FlyString encoding, bool fatal, bool ignore_bom);
 
     virtual void initialize(JS::Realm&) override;
 
     TextCodec::Decoder& m_decoder;
-    DeprecatedFlyString m_encoding;
+    FlyString m_encoding;
     bool m_fatal { false };
     bool m_ignore_bom { false };
 };

--- a/Userland/Libraries/LibWeb/Encoding/TextDecoder.idl
+++ b/Userland/Libraries/LibWeb/Encoding/TextDecoder.idl
@@ -1,4 +1,4 @@
-[Exposed=(Window,Worker), UseDeprecatedAKString]
+[Exposed=(Window,Worker)]
 interface TextDecoder {
     // FIXME: 'optional TextDecoderOptions options = {}'
     constructor(optional DOMString label = "utf-8");

--- a/Userland/Libraries/LibWeb/Encoding/TextEncoder.cpp
+++ b/Userland/Libraries/LibWeb/Encoding/TextEncoder.cpp
@@ -31,7 +31,7 @@ void TextEncoder::initialize(JS::Realm& realm)
 }
 
 // https://encoding.spec.whatwg.org/#dom-textencoder-encode
-JS::Uint8Array* TextEncoder::encode(DeprecatedString const& input) const
+JS::Uint8Array* TextEncoder::encode(String const& input) const
 {
     // NOTE: The AK::DeprecatedString returned from PrimitiveString::string() is always UTF-8, regardless of the internal string type, so most of these steps are no-ops.
 
@@ -43,16 +43,16 @@ JS::Uint8Array* TextEncoder::encode(DeprecatedString const& input) const
     //     3. Assert: result is not an error.
     //     4. If result is finished, then convert output into a byte sequence and return a Uint8Array object wrapping an ArrayBuffer containing output.
 
-    auto byte_buffer = input.to_byte_buffer();
+    auto byte_buffer = MUST(ByteBuffer::copy(input.bytes()));
     auto array_length = byte_buffer.size();
     auto array_buffer = JS::ArrayBuffer::create(realm(), move(byte_buffer));
     return JS::Uint8Array::create(realm(), array_length, *array_buffer);
 }
 
 // https://encoding.spec.whatwg.org/#dom-textencoder-encoding
-DeprecatedFlyString const& TextEncoder::encoding()
+FlyString const& TextEncoder::encoding()
 {
-    static DeprecatedFlyString encoding = "utf-8"sv;
+    static const FlyString encoding = "utf-8"_fly_string;
     return encoding;
 }
 

--- a/Userland/Libraries/LibWeb/Encoding/TextEncoder.h
+++ b/Userland/Libraries/LibWeb/Encoding/TextEncoder.h
@@ -24,9 +24,9 @@ public:
 
     virtual ~TextEncoder() override;
 
-    JS::Uint8Array* encode(DeprecatedString const& input) const;
+    JS::Uint8Array* encode(String const& input) const;
 
-    static DeprecatedFlyString const& encoding();
+    static FlyString const& encoding();
 
 protected:
     // https://encoding.spec.whatwg.org/#dom-textencoder

--- a/Userland/Libraries/LibWeb/Encoding/TextEncoder.idl
+++ b/Userland/Libraries/LibWeb/Encoding/TextEncoder.idl
@@ -1,4 +1,4 @@
-[Exposed=(Window,Worker), UseDeprecatedAKString]
+[Exposed=(Window,Worker)]
 interface TextEncoder {
     constructor();
 

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/FetchController.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/FetchController.cpp
@@ -64,7 +64,7 @@ void FetchController::abort(JS::Realm& realm, Optional<JS::Value> error)
     m_state = State::Aborted;
 
     // 2. Let fallbackError be an "AbortError" DOMException.
-    auto fallback_error = WebIDL::AbortError::create(realm, "Fetch was aborted"sv);
+    auto fallback_error = WebIDL::AbortError::create(realm, "Fetch was aborted"_fly_string);
 
     // 3. Set error to fallbackError if it is not given.
     if (!error.has_value())

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Bodies.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Bodies.cpp
@@ -90,7 +90,7 @@ WebIDL::ExceptionOr<void> Body::fully_read(JS::Realm& realm, Web::Fetch::Infrast
         TRY_OR_THROW_OOM(vm, success_steps(move(byte_buffer)));
     } else {
         // Empty, Blob, FormData
-        error_steps(WebIDL::DOMException::create(realm, "DOMException", "Reading from Blob, FormData or null source is not yet implemented"sv));
+        error_steps(WebIDL::DOMException::create(realm, "DOMException"_fly_string, "Reading from Blob, FormData or null source is not yet implemented"_fly_string));
     }
     return {};
 }

--- a/Userland/Libraries/LibWeb/Geometry/DOMMatrixReadOnly.cpp
+++ b/Userland/Libraries/LibWeb/Geometry/DOMMatrixReadOnly.cpp
@@ -378,7 +378,7 @@ WebIDL::ExceptionOr<String> DOMMatrixReadOnly::to_string() const
         || !isfinite(m21()) || !isfinite(m22()) || !isfinite(m23()) || !isfinite(m24())
         || !isfinite(m31()) || !isfinite(m32()) || !isfinite(m33()) || !isfinite(m34())
         || !isfinite(m41()) || !isfinite(m42()) || !isfinite(m43()) || !isfinite(m44())) {
-        return WebIDL::InvalidStateError::create(realm(), "Cannot stringify non-finite matrix values");
+        return WebIDL::InvalidStateError::create(realm(), "Cannot stringify non-finite matrix values"_fly_string);
     }
 
     // 2. Let string be the empty string.

--- a/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
@@ -1104,7 +1104,7 @@ WebIDL::ExceptionOr<void> BrowsingContext::navigate(
         // 1. If exceptionsEnabled is given and is true, then throw a "SecurityError" DOMException.
         if (exceptions_enabled) {
             VERIFY(source_browsing_context.active_document());
-            return WebIDL::SecurityError::create(source_browsing_context.active_document()->realm(), "Source browsing context not allowed to navigate"sv);
+            return WebIDL::SecurityError::create(source_browsing_context.active_document()->realm(), "Source browsing context not allowed to navigate"_fly_string);
         }
 
         // FIXME: 2. Otherwise, the user agent may instead offer to open resource in a new top-level browsing context

--- a/Userland/Libraries/LibWeb/HTML/Canvas/CanvasPath.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Canvas/CanvasPath.cpp
@@ -48,17 +48,17 @@ void CanvasPath::bezier_curve_to(double cp1x, double cp1y, double cp2x, double c
 WebIDL::ExceptionOr<void> CanvasPath::arc(float x, float y, float radius, float start_angle, float end_angle, bool counter_clockwise)
 {
     if (radius < 0)
-        return WebIDL::IndexSizeError::create(m_self->realm(), DeprecatedString::formatted("The radius provided ({}) is negative.", radius));
+        return WebIDL::IndexSizeError::create(m_self->realm(), MUST(String::formatted("The radius provided ({}) is negative.", radius)));
     return ellipse(x, y, radius, radius, 0, start_angle, end_angle, counter_clockwise);
 }
 
 WebIDL::ExceptionOr<void> CanvasPath::ellipse(float x, float y, float radius_x, float radius_y, float rotation, float start_angle, float end_angle, bool counter_clockwise)
 {
     if (radius_x < 0)
-        return WebIDL::IndexSizeError::create(m_self->realm(), DeprecatedString::formatted("The major-axis radius provided ({}) is negative.", radius_x));
+        return WebIDL::IndexSizeError::create(m_self->realm(), MUST(String::formatted("The major-axis radius provided ({}) is negative.", radius_x)));
 
     if (radius_y < 0)
-        return WebIDL::IndexSizeError::create(m_self->realm(), DeprecatedString::formatted("The minor-axis radius provided ({}) is negative.", radius_y));
+        return WebIDL::IndexSizeError::create(m_self->realm(), MUST(String::formatted("The minor-axis radius provided ({}) is negative.", radius_y)));
 
     if (constexpr float tau = M_TAU; (!counter_clockwise && (end_angle - start_angle) >= tau)
         || (counter_clockwise && (start_angle - end_angle) >= tau)) {

--- a/Userland/Libraries/LibWeb/HTML/CanvasGradient.cpp
+++ b/Userland/Libraries/LibWeb/HTML/CanvasGradient.cpp
@@ -17,9 +17,9 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<CanvasGradient>> CanvasGradient::create_rad
 {
     // If either of r0 or r1 are negative, then an "IndexSizeError" DOMException must be thrown.
     if (r0 < 0)
-        return WebIDL::IndexSizeError::create(realm, "The r0 passed is less than 0");
+        return WebIDL::IndexSizeError::create(realm, "The r0 passed is less than 0"_fly_string);
     if (r1 < 0)
-        return WebIDL::IndexSizeError::create(realm, "The r1 passed is less than 0");
+        return WebIDL::IndexSizeError::create(realm, "The r1 passed is less than 0"_fly_string);
 
     auto radial_gradient = TRY_OR_THROW_OOM(realm.vm(), Gfx::CanvasRadialGradientPaintStyle::create(Gfx::FloatPoint { x0, y0 }, r0, Gfx::FloatPoint { x1, y1 }, r1));
     return realm.heap().allocate<CanvasGradient>(realm, realm, *radial_gradient);
@@ -58,14 +58,14 @@ WebIDL::ExceptionOr<void> CanvasGradient::add_color_stop(double offset, StringVi
 {
     // 1. If the offset is less than 0 or greater than 1, then throw an "IndexSizeError" DOMException.
     if (offset < 0 || offset > 1)
-        return WebIDL::IndexSizeError::create(realm(), "CanvasGradient color stop offset out of bounds");
+        return WebIDL::IndexSizeError::create(realm(), "CanvasGradient color stop offset out of bounds"_fly_string);
 
     // 2. Let parsed color be the result of parsing color.
     auto parsed_color = Color::from_string(color);
 
     // 3. If parsed color is failure, throw a "SyntaxError" DOMException.
     if (!parsed_color.has_value())
-        return WebIDL::SyntaxError::create(realm(), "Could not parse color for CanvasGradient");
+        return WebIDL::SyntaxError::create(realm(), "Could not parse color for CanvasGradient"_fly_string);
 
     // 4. Place a new stop on the gradient, at offset offset relative to the whole gradient, and with the color parsed color.
     TRY_OR_THROW_OOM(realm().vm(), m_gradient->add_color_stop(offset, parsed_color.value()));

--- a/Userland/Libraries/LibWeb/HTML/CanvasPattern.cpp
+++ b/Userland/Libraries/LibWeb/HTML/CanvasPattern.cpp
@@ -119,7 +119,7 @@ WebIDL::ExceptionOr<JS::GCPtr<CanvasPattern>> CanvasPattern::create(JS::Realm& r
     // then throw a "SyntaxError" DOMException.
     auto repetition_value = parse_repetition(repetition);
     if (!repetition_value.has_value())
-        return WebIDL::SyntaxError::create(realm, "Repetition value is not valid");
+        return WebIDL::SyntaxError::create(realm, "Repetition value is not valid"_fly_string);
 
     // Note: Bitmap won't be null here, as if it were it would have "bad" usability.
     auto const& bitmap = *image.visit([](auto const& source) -> Gfx::Bitmap const* { return source->bitmap(); });

--- a/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
+++ b/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
@@ -320,11 +320,11 @@ WebIDL::ExceptionOr<JS::GCPtr<ImageData>> CanvasRenderingContext2D::get_image_da
 {
     // 1. If either the sw or sh arguments are zero, then throw an "IndexSizeError" DOMException.
     if (width == 0 || height == 0)
-        return WebIDL::IndexSizeError::create(realm(), "Width and height must not be zero");
+        return WebIDL::IndexSizeError::create(realm(), "Width and height must not be zero"_fly_string);
 
     // 2. If the CanvasRenderingContext2D's origin-clean flag is set to false, then throw a "SecurityError" DOMException.
     if (!m_origin_clean)
-        return WebIDL::SecurityError::create(realm(), "CanvasRenderingContext2D is not origin-clean");
+        return WebIDL::SecurityError::create(realm(), "CanvasRenderingContext2D is not origin-clean"_fly_string);
 
     // 3. Let imageData be a new ImageData object.
     // 4. Initialize imageData given sw, sh, settings set to settings, and defaultColorSpace set to this's color space.
@@ -572,7 +572,7 @@ WebIDL::ExceptionOr<CanvasImageSourceUsability> check_usability_of_image(CanvasI
         [](JS::Handle<HTMLCanvasElement> const& canvas_element) -> WebIDL::ExceptionOr<Optional<CanvasImageSourceUsability>> {
             // If image has either a horizontal dimension or a vertical dimension equal to zero, then throw an "InvalidStateError" DOMException.
             if (canvas_element->width() == 0 || canvas_element->height() == 0)
-                return WebIDL::InvalidStateError::create(canvas_element->realm(), "Canvas width or height is zero");
+                return WebIDL::InvalidStateError::create(canvas_element->realm(), "Canvas width or height is zero"_fly_string);
             return Optional<CanvasImageSourceUsability> {};
         }));
     if (usability.has_value())

--- a/Userland/Libraries/LibWeb/HTML/CrossOrigin/AbstractOperations.cpp
+++ b/Userland/Libraries/LibWeb/HTML/CrossOrigin/AbstractOperations.cpp
@@ -78,7 +78,7 @@ JS::ThrowCompletionOr<JS::PropertyDescriptor> cross_origin_property_fallback(JS:
         return JS::PropertyDescriptor { .value = JS::js_undefined(), .writable = false, .enumerable = false, .configurable = true };
 
     // 2. Throw a "SecurityError" DOMException.
-    return throw_completion(WebIDL::SecurityError::create(*vm.current_realm(), DeprecatedString::formatted("Can't access property '{}' on cross-origin object", property_key)));
+    return throw_completion(WebIDL::SecurityError::create(*vm.current_realm(), MUST(String::formatted("Can't access property '{}' on cross-origin object", property_key))));
 }
 
 // 7.2.3.3 IsPlatformObjectSameOrigin ( O ), https://html.spec.whatwg.org/multipage/browsers.html#isplatformobjectsameorigin-(-o-)
@@ -205,7 +205,7 @@ JS::ThrowCompletionOr<JS::Value> cross_origin_get(JS::VM& vm, JS::Object const& 
 
     // 6. If getter is undefined, then throw a "SecurityError" DOMException.
     if (!getter.has_value())
-        return throw_completion(WebIDL::SecurityError::create(*vm.current_realm(), DeprecatedString::formatted("Can't get property '{}' on cross-origin object", property_key)));
+        return throw_completion(WebIDL::SecurityError::create(*vm.current_realm(), MUST(String::formatted("Can't get property '{}' on cross-origin object", property_key))));
 
     // 7. Return ? Call(getter, Receiver).
     return JS::call(vm, *getter, receiver);
@@ -231,7 +231,7 @@ JS::ThrowCompletionOr<bool> cross_origin_set(JS::VM& vm, JS::Object& object, JS:
     }
 
     // 4. Throw a "SecurityError" DOMException.
-    return throw_completion(WebIDL::SecurityError::create(*vm.current_realm(), DeprecatedString::formatted("Can't set property '{}' on cross-origin object", property_key)));
+    return throw_completion(WebIDL::SecurityError::create(*vm.current_realm(), MUST(String::formatted("Can't set property '{}' on cross-origin object", property_key))));
 }
 
 // 7.2.3.7 CrossOriginOwnPropertyKeys ( O ), https://html.spec.whatwg.org/multipage/browsers.html#crossoriginownpropertykeys-(-o-)

--- a/Userland/Libraries/LibWeb/HTML/CustomElements/CustomElementRegistry.cpp
+++ b/Userland/Libraries/LibWeb/HTML/CustomElements/CustomElementRegistry.cpp
@@ -112,7 +112,7 @@ JS::ThrowCompletionOr<void> CustomElementRegistry::define(String const& name, We
 
     // 2. If name is not a valid custom element name, then throw a "SyntaxError" DOMException.
     if (!is_valid_custom_element_name(name))
-        return JS::throw_completion(WebIDL::SyntaxError::create(realm, DeprecatedString::formatted("'{}' is not a valid custom element name"sv, name)));
+        return JS::throw_completion(WebIDL::SyntaxError::create(realm, MUST(String::formatted("'{}' is not a valid custom element name"sv, name))));
 
     // 3. If this CustomElementRegistry contains an entry with name name, then throw a "NotSupportedError" DOMException.
     auto existing_definition_with_name_iterator = m_custom_element_definitions.find_if([&name](JS::Handle<CustomElementDefinition> const& definition) {
@@ -120,7 +120,7 @@ JS::ThrowCompletionOr<void> CustomElementRegistry::define(String const& name, We
     });
 
     if (existing_definition_with_name_iterator != m_custom_element_definitions.end())
-        return JS::throw_completion(WebIDL::NotSupportedError::create(realm, DeprecatedString::formatted("A custom element with name '{}' is already defined"sv, name)));
+        return JS::throw_completion(WebIDL::NotSupportedError::create(realm, MUST(String::formatted("A custom element with name '{}' is already defined"sv, name))));
 
     // 4. If this CustomElementRegistry contains an entry with constructor constructor, then throw a "NotSupportedError" DOMException.
     auto existing_definition_with_constructor_iterator = m_custom_element_definitions.find_if([&constructor](JS::Handle<CustomElementDefinition> const& definition) {
@@ -128,7 +128,7 @@ JS::ThrowCompletionOr<void> CustomElementRegistry::define(String const& name, We
     });
 
     if (existing_definition_with_constructor_iterator != m_custom_element_definitions.end())
-        return JS::throw_completion(WebIDL::NotSupportedError::create(realm, "The given constructor is already in use by another custom element"sv));
+        return JS::throw_completion(WebIDL::NotSupportedError::create(realm, "The given constructor is already in use by another custom element"_fly_string));
 
     // 5. Let localName be name.
     String local_name = name;
@@ -140,11 +140,11 @@ JS::ThrowCompletionOr<void> CustomElementRegistry::define(String const& name, We
     if (extends.has_value()) {
         // 1. If extends is a valid custom element name, then throw a "NotSupportedError" DOMException.
         if (is_valid_custom_element_name(extends.value()))
-            return JS::throw_completion(WebIDL::NotSupportedError::create(realm, DeprecatedString::formatted("'{}' is a custom element name, only non-custom elements can be extended"sv, extends.value())));
+            return JS::throw_completion(WebIDL::NotSupportedError::create(realm, MUST(String::formatted("'{}' is a custom element name, only non-custom elements can be extended"sv, extends.value()))));
 
         // 2. If the element interface for extends and the HTML namespace is HTMLUnknownElement (e.g., if extends does not indicate an element definition in this specification), then throw a "NotSupportedError" DOMException.
         if (DOM::is_unknown_html_element(extends.value().to_deprecated_string()))
-            return JS::throw_completion(WebIDL::NotSupportedError::create(realm, DeprecatedString::formatted("'{}' is an unknown HTML element"sv, extends.value())));
+            return JS::throw_completion(WebIDL::NotSupportedError::create(realm, MUST(String::formatted("'{}' is an unknown HTML element"sv, extends.value()))));
 
         // 3. Set localName to extends.
         local_name = extends.value();
@@ -152,7 +152,7 @@ JS::ThrowCompletionOr<void> CustomElementRegistry::define(String const& name, We
 
     // 8. If this CustomElementRegistry's element definition is running flag is set, then throw a "NotSupportedError" DOMException.
     if (m_element_definition_is_running)
-        return JS::throw_completion(WebIDL::NotSupportedError::create(realm, "Cannot recursively define custom elements"sv));
+        return JS::throw_completion(WebIDL::NotSupportedError::create(realm, "Cannot recursively define custom elements"_fly_string));
 
     // 9. Set this CustomElementRegistry's element definition is running flag.
     m_element_definition_is_running = true;
@@ -334,7 +334,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> CustomElementRegistry::when_d
     // 1. If name is not a valid custom element name, then return a new promise rejected with a "SyntaxError" DOMException.
     if (!is_valid_custom_element_name(name)) {
         auto promise = JS::Promise::create(realm);
-        promise->reject(WebIDL::SyntaxError::create(realm, DeprecatedString::formatted("'{}' is not a valid custom element name"sv, name)));
+        promise->reject(WebIDL::SyntaxError::create(realm, MUST(String::formatted("'{}' is not a valid custom element name"sv, name))));
         return promise;
     }
 

--- a/Userland/Libraries/LibWeb/HTML/DOMParser.cpp
+++ b/Userland/Libraries/LibWeb/HTML/DOMParser.cpp
@@ -33,7 +33,7 @@ void DOMParser::initialize(JS::Realm& realm)
 }
 
 // https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-domparser-parsefromstring
-JS::NonnullGCPtr<DOM::Document> DOMParser::parse_from_string(DeprecatedString const& string, Bindings::DOMParserSupportedType type)
+JS::NonnullGCPtr<DOM::Document> DOMParser::parse_from_string(StringView string, Bindings::DOMParserSupportedType type)
 {
     // 1. Let document be a new Document, whose content type is type and url is this's relevant global object's associated Document's URL.
     JS::GCPtr<DOM::Document> document;
@@ -43,7 +43,7 @@ JS::NonnullGCPtr<DOM::Document> DOMParser::parse_from_string(DeprecatedString co
         // -> "text/html"
         // 1. Set document's type to "html".
         document = HTML::HTMLDocument::create(realm(), verify_cast<HTML::Window>(relevant_global_object(*this)).associated_document().url());
-        document->set_content_type(Bindings::idl_enum_to_deprecated_string(type));
+        document->set_content_type(Bindings::idl_enum_to_string(type).to_deprecated_string());
         document->set_document_type(DOM::Document::Type::HTML);
 
         // 2. Create an HTML parser parser, associated with document.
@@ -57,7 +57,7 @@ JS::NonnullGCPtr<DOM::Document> DOMParser::parse_from_string(DeprecatedString co
     } else {
         // -> Otherwise
         document = DOM::Document::create(realm(), verify_cast<HTML::Window>(relevant_global_object(*this)).associated_document().url());
-        document->set_content_type(Bindings::idl_enum_to_deprecated_string(type));
+        document->set_content_type(Bindings::idl_enum_to_string(type).to_deprecated_string());
 
         // 1. Create an XML parser parse, associated with document, and with XML scripting support disabled.
         XML::Parser parser(string, { .resolve_external_resource = resolve_xml_resource });

--- a/Userland/Libraries/LibWeb/HTML/DOMParser.h
+++ b/Userland/Libraries/LibWeb/HTML/DOMParser.h
@@ -23,7 +23,7 @@ public:
 
     virtual ~DOMParser() override;
 
-    JS::NonnullGCPtr<DOM::Document> parse_from_string(DeprecatedString const&, Bindings::DOMParserSupportedType type);
+    JS::NonnullGCPtr<DOM::Document> parse_from_string(StringView, Bindings::DOMParserSupportedType type);
 
 private:
     explicit DOMParser(JS::Realm&);

--- a/Userland/Libraries/LibWeb/HTML/DOMParser.idl
+++ b/Userland/Libraries/LibWeb/HTML/DOMParser.idl
@@ -9,7 +9,7 @@ enum DOMParserSupportedType {
 };
 
 // https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#domparser
-[Exposed=Window, UseDeprecatedAKString]
+[Exposed=Window]
 interface DOMParser {
     constructor();
 

--- a/Userland/Libraries/LibWeb/HTML/DOMStringMap.cpp
+++ b/Userland/Libraries/LibWeb/HTML/DOMStringMap.cpp
@@ -136,7 +136,7 @@ WebIDL::ExceptionOr<void> DOMStringMap::set_value_of_new_named_property(Deprecat
         if (current_character == '-' && character_index + 1 < name.length()) {
             auto next_character = name[character_index + 1];
             if (is_ascii_lower_alpha(next_character))
-                return WebIDL::SyntaxError::create(realm(), "Name cannot contain a '-' followed by a lowercase character.");
+                return WebIDL::SyntaxError::create(realm(), "Name cannot contain a '-' followed by a lowercase character."_fly_string);
         }
 
         // 2. For each ASCII upper alpha in name, insert a U+002D HYPHEN-MINUS character (-) before the character and replace the character with the same character converted to ASCII lowercase.

--- a/Userland/Libraries/LibWeb/HTML/HTMLElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLElement.cpp
@@ -119,7 +119,7 @@ WebIDL::ExceptionOr<void> HTMLElement::set_content_editable(StringView content_e
         MUST(set_attribute(HTML::AttributeNames::contenteditable, "false"));
         return {};
     }
-    return WebIDL::SyntaxError::create(realm(), "Invalid contentEditable value, must be 'true', 'false', or 'inherit'");
+    return WebIDL::SyntaxError::create(realm(), "Invalid contentEditable value, must be 'true', 'false', or 'inherit'"_fly_string);
 }
 
 void HTMLElement::set_inner_text(StringView text)

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -502,7 +502,7 @@ void HTMLInputElement::create_shadow_tree_if_needed()
     m_placeholder_element = heap().allocate<PlaceholderElement>(realm(), document());
     MUST(m_placeholder_element->style_for_bindings()->set_property(CSS::PropertyID::Height, "1lh"sv));
 
-    m_placeholder_text_node = heap().allocate<DOM::Text>(realm(), document(), initial_value);
+    m_placeholder_text_node = heap().allocate<DOM::Text>(realm(), document(), MUST(String::from_deprecated_string(initial_value)));
     m_placeholder_text_node->set_data(deprecated_attribute(HTML::AttributeNames::placeholder));
     m_placeholder_text_node->set_owner_input_element({}, *this);
     MUST(m_placeholder_element->append_child(*m_placeholder_text_node));
@@ -511,7 +511,7 @@ void HTMLInputElement::create_shadow_tree_if_needed()
     m_inner_text_element = DOM::create_element(document(), HTML::TagNames::div, Namespace::HTML).release_value_but_fixme_should_propagate_errors();
     MUST(m_inner_text_element->style_for_bindings()->set_property(CSS::PropertyID::Height, "1lh"sv));
 
-    m_text_node = heap().allocate<DOM::Text>(realm(), document(), initial_value);
+    m_text_node = heap().allocate<DOM::Text>(realm(), document(), MUST(String::from_deprecated_string(initial_value)));
     if (m_type == TypeAttributeState::FileUpload) {
         // NOTE: file upload state is mutable, but we don't allow the text node to be modifed
         m_text_node->set_always_editable(false);

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -223,7 +223,7 @@ WebIDL::ExceptionOr<void> HTMLInputElement::show_picker()
 
     // 1. If this is not mutable, then throw an "InvalidStateError" DOMException.
     if (!m_is_mutable)
-        return WebIDL::InvalidStateError::create(realm(), "Element is not mutable"sv);
+        return WebIDL::InvalidStateError::create(realm(), "Element is not mutable"_fly_string);
 
     // 2. If this's relevant settings object's origin is not same origin with this's relevant settings object's top-level origin,
     // and this's type attribute is not in the File Upload state or Color state, then throw a "SecurityError" DOMException.
@@ -231,14 +231,14 @@ WebIDL::ExceptionOr<void> HTMLInputElement::show_picker()
     //       and has never been guarded by an origin check.
     if (!relevant_settings_object(*this).origin().is_same_origin(relevant_settings_object(*this).top_level_origin)
         && m_type != TypeAttributeState::FileUpload && m_type != TypeAttributeState::Color) {
-        return WebIDL::SecurityError::create(realm(), "Cross origin pickers are not allowed"sv);
+        return WebIDL::SecurityError::create(realm(), "Cross origin pickers are not allowed"_fly_string);
     }
 
     // 3. If this's relevant global object does not have transient activation, then throw a "NotAllowedError" DOMException.
     // FIXME: The global object we get here should probably not need casted to Window to check for transient activation
     auto& global_object = relevant_global_object(*this);
     if (!is<HTML::Window>(global_object) || !static_cast<HTML::Window&>(global_object).has_transient_activation()) {
-        return WebIDL::NotAllowedError::create(realm(), "Too long since user activation to show picker"sv);
+        return WebIDL::NotAllowedError::create(realm(), "Too long since user activation to show picker"_fly_string);
     }
 
     // 4. Show the picker, if applicable, for this.
@@ -342,7 +342,7 @@ WebIDL::ExceptionOr<void> HTMLInputElement::set_value(String const& value)
     if (type_state() == TypeAttributeState::FileUpload) {
         // On setting, if the new value is the empty string, empty the list of selected files; otherwise, throw an "InvalidStateError" DOMException.
         if (!value.is_empty())
-            return WebIDL::InvalidStateError::create(realm(), "Setting value of input type file to non-empty string"sv);
+            return WebIDL::InvalidStateError::create(realm(), "Setting value of input type file to non-empty string"_fly_string);
         m_selected_files = nullptr;
         return {};
     }

--- a/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -342,7 +342,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> HTMLMediaElement::play()
     // 2. If the media element's error attribute is not null and its code is MEDIA_ERR_SRC_NOT_SUPPORTED, then return a promise
     //    rejected with a "NotSupportedError" DOMException.
     if (m_error && m_error->code() == MediaError::Code::SrcNotSupported) {
-        auto error = WebIDL::NotSupportedError::create(realm, m_error->message().to_deprecated_string());
+        auto error = WebIDL::NotSupportedError::create(realm, m_error->message());
         auto promise = WebIDL::create_rejected_promise(realm, error);
 
         return JS::NonnullGCPtr { verify_cast<JS::Promise>(*promise->promise()) };
@@ -396,7 +396,7 @@ WebIDL::ExceptionOr<void> HTMLMediaElement::set_volume(double volume)
     // set to the new value. If the new value is outside the range 0.0 to 1.0 inclusive, then, on setting, an
     // "IndexSizeError" DOMException must be thrown instead.
     if (volume < 0.0 || volume > 1.0)
-        return WebIDL::IndexSizeError::create(realm(), "Volume must be in the range 0.0 to 1.0, inclusive"sv);
+        return WebIDL::IndexSizeError::create(realm(), "Volume must be in the range 0.0 to 1.0, inclusive"_fly_string);
 
     m_volume = volume;
     volume_or_muted_attribute_changed();

--- a/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.h
@@ -197,7 +197,7 @@ private:
     {
         auto& realm = this->realm();
 
-        auto error = ErrorType::create(realm, message.to_deprecated_fly_string());
+        auto error = ErrorType::create(realm, message);
         reject_pending_play_promises(promises, error);
     }
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLOptionsCollection.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLOptionsCollection.cpp
@@ -45,11 +45,11 @@ WebIDL::ExceptionOr<void> HTMLOptionsCollection::add(HTMLOptionOrOptGroupElement
 
     // 1. If element is an ancestor of the select element on which the HTMLOptionsCollection is rooted, then throw a "HierarchyRequestError" DOMException.
     if (resolved_element->is_ancestor_of(root()))
-        return WebIDL::HierarchyRequestError::create(realm(), "The provided element is an ancestor of the root select element.");
+        return WebIDL::HierarchyRequestError::create(realm(), "The provided element is an ancestor of the root select element."_fly_string);
 
     // 2. If before is an element, but that element isn't a descendant of the select element on which the HTMLOptionsCollection is rooted, then throw a "NotFoundError" DOMException.
     if (before_element && !before_element->is_descendant_of(root()))
-        return WebIDL::NotFoundError::create(realm(), "The 'before' element is not a descendant of the root select element.");
+        return WebIDL::NotFoundError::create(realm(), "The 'before' element is not a descendant of the root select element."_fly_string);
 
     // 3. If element and before are the same element, then return.
     if (before_element && (resolved_element.ptr() == before_element.ptr()))

--- a/Userland/Libraries/LibWeb/HTML/HTMLTableElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableElement.cpp
@@ -153,7 +153,7 @@ WebIDL::ExceptionOr<void> HTMLTableElement::set_t_head(HTMLTableSectionElement* 
 {
     // If the new value is neither null nor a thead element, then a "HierarchyRequestError" DOMException must be thrown instead.
     if (thead && thead->local_name() != TagNames::thead)
-        return WebIDL::HierarchyRequestError::create(realm(), "Element is not thead");
+        return WebIDL::HierarchyRequestError::create(realm(), "Element is not thead"_fly_string);
 
     // On setting, if the new value is null or a thead element, the first thead element child of the table element,
     // if any, must be removed,
@@ -251,7 +251,7 @@ WebIDL::ExceptionOr<void> HTMLTableElement::set_t_foot(HTMLTableSectionElement* 
 {
     // If the new value is neither null nor a tfoot element, then a "HierarchyRequestError" DOMException must be thrown instead.
     if (tfoot && tfoot->local_name() != TagNames::tfoot)
-        return WebIDL::HierarchyRequestError::create(realm(), "Element is not tfoot");
+        return WebIDL::HierarchyRequestError::create(realm(), "Element is not tfoot"_fly_string);
 
     // On setting, if the new value is null or a tfoot element, the first tfoot element child of the table element,
     // if any, must be removed,
@@ -363,7 +363,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<HTMLTableRowElement>> HTMLTableElement::ins
     auto rows_length = rows->length();
 
     if (index < -1 || index > (long)rows_length) {
-        return WebIDL::IndexSizeError::create(realm(), "Index is negative or greater than the number of rows");
+        return WebIDL::IndexSizeError::create(realm(), "Index is negative or greater than the number of rows"_fly_string);
     }
     auto& tr = static_cast<HTMLTableRowElement&>(*TRY(DOM::create_element(document(), TagNames::tr, Namespace::HTML)));
     if (rows_length == 0 && !has_child_of_type<HTMLTableRowElement>()) {
@@ -390,7 +390,7 @@ WebIDL::ExceptionOr<void> HTMLTableElement::delete_row(long index)
 
     // 1. If index is less than −1 or greater than or equal to the number of elements in the rows collection, then throw an "IndexSizeError" DOMException.
     if (index < -1 || index >= (long)rows_length)
-        return WebIDL::IndexSizeError::create(realm(), "Index is negative or greater than or equal to the number of rows");
+        return WebIDL::IndexSizeError::create(realm(), "Index is negative or greater than or equal to the number of rows"_fly_string);
 
     // 2. If index is −1, then remove the last element in the rows collection from its parent, or do nothing if the rows collection is empty.
     if (index == -1) {

--- a/Userland/Libraries/LibWeb/HTML/HTMLTableRowElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableRowElement.cpp
@@ -129,7 +129,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<HTMLTableCellElement>> HTMLTableRowElement:
 
     // 1. If index is less than −1 or greater than the number of elements in the cells collection, then throw an "IndexSizeError" DOMException.
     if (index < -1 || index > cells_collection_size)
-        return WebIDL::IndexSizeError::create(realm(), "Index is negative or greater than the number of cells");
+        return WebIDL::IndexSizeError::create(realm(), "Index is negative or greater than the number of cells"_fly_string);
 
     // 2. Let table cell be the result of creating an element given this tr element's node document, td, and the HTML namespace.
     auto& table_cell = static_cast<HTMLTableCellElement&>(*TRY(DOM::create_element(document(), HTML::TagNames::td, Namespace::HTML)));
@@ -154,7 +154,7 @@ WebIDL::ExceptionOr<void> HTMLTableRowElement::delete_cell(i32 index)
 
     // 1. If index is less than −1 or greater than or equal to the number of elements in the cells collection, then throw an "IndexSizeError" DOMException.
     if (index < -1 || index >= cells_collection_size)
-        return WebIDL::IndexSizeError::create(realm(), "Index is negative or greater than or equal to the number of cells");
+        return WebIDL::IndexSizeError::create(realm(), "Index is negative or greater than or equal to the number of cells"_fly_string);
 
     // 2. If index is −1, then remove the last element in the cells collection from its parent, or do nothing if the cells collection is empty.
     if (index == -1) {

--- a/Userland/Libraries/LibWeb/HTML/HTMLTableSectionElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableSectionElement.cpp
@@ -54,7 +54,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<HTMLTableRowElement>> HTMLTableSectionEleme
 
     // 1. If index is less than −1 or greater than the number of elements in the rows collection, throw an "IndexSizeError" DOMException.
     if (index < -1 || index > rows_collection_size)
-        return WebIDL::IndexSizeError::create(realm(), "Index is negative or greater than the number of rows");
+        return WebIDL::IndexSizeError::create(realm(), "Index is negative or greater than the number of rows"_fly_string);
 
     // 2. Let table row be the result of creating an element given this element's node document, tr, and the HTML namespace.
     auto& table_row = static_cast<HTMLTableRowElement&>(*TRY(DOM::create_element(document(), TagNames::tr, Namespace::HTML)));
@@ -78,7 +78,7 @@ WebIDL::ExceptionOr<void> HTMLTableSectionElement::delete_row(long index)
 
     // 1. If index is less than −1 or greater than or equal to the number of elements in the rows collection, then throw an "IndexSizeError" DOMException.
     if (index < -1 || index >= rows_collection_size)
-        return WebIDL::IndexSizeError::create(realm(), "Index is negative or greater than or equal to the number of rows");
+        return WebIDL::IndexSizeError::create(realm(), "Index is negative or greater than or equal to the number of rows"_fly_string);
 
     // 2. If index is −1, then remove the last element in the rows collection from this element, or do nothing if the rows collection is empty.
     if (index == -1) {

--- a/Userland/Libraries/LibWeb/HTML/History.cpp
+++ b/Userland/Libraries/LibWeb/HTML/History.cpp
@@ -55,7 +55,7 @@ WebIDL::ExceptionOr<u64> History::length() const
 {
     // 1. If this's associated Document is not fully active, then throw a "SecurityError" DOMException.
     if (!m_associated_document->is_fully_active())
-        return WebIDL::SecurityError::create(realm(), "Cannot perform length on a document that isn't fully active."sv);
+        return WebIDL::SecurityError::create(realm(), "Cannot perform length on a document that isn't fully active."_fly_string);
 
     // 2. Return the number of entries in the top-level browsing context's joint session history.
     auto const* browsing_context = m_associated_document->browsing_context();
@@ -72,7 +72,7 @@ WebIDL::ExceptionOr<void> History::go(long delta = 0)
 
     // 2. If document is not fully active, then throw a "SecurityError" DOMException.
     if (!m_associated_document->is_fully_active())
-        return WebIDL::SecurityError::create(realm(), "Cannot perform go on a document that isn't fully active."sv);
+        return WebIDL::SecurityError::create(realm(), "Cannot perform go on a document that isn't fully active."_fly_string);
 
     // 3. If delta is 0, then act as if the location.reload() method was called, and return.
     auto* browsing_context = m_associated_document->browsing_context();
@@ -157,7 +157,7 @@ WebIDL::ExceptionOr<void> History::shared_history_push_replace_state(JS::Value v
 
     // 2. If document is not fully active, then throw a "SecurityError" DOMException.
     if (!document->is_fully_active())
-        return WebIDL::SecurityError::create(realm(), "Cannot perform pushState or replaceState on a document that isn't fully active."sv);
+        return WebIDL::SecurityError::create(realm(), "Cannot perform pushState or replaceState on a document that isn't fully active."_fly_string);
 
     // 3. Optionally, return. (For example, the user agent might disallow calls to these methods that are invoked on a timer,
     //    or from event listeners that are not triggered in response to a clear user action, or that are invoked in rapid succession.)
@@ -178,14 +178,14 @@ WebIDL::ExceptionOr<void> History::shared_history_push_replace_state(JS::Value v
 
         // 2. If that fails, then throw a "SecurityError" DOMException.
         if (!parsed_url.is_valid())
-            return WebIDL::SecurityError::create(realm(), "Cannot pushState or replaceState to incompatible URL"sv);
+            return WebIDL::SecurityError::create(realm(), "Cannot pushState or replaceState to incompatible URL"_fly_string);
 
         // 3. Set newURL to the resulting URL record.
         new_url = parsed_url;
 
         // 4. If document cannot have its URL rewritten to newURL, then throw a "SecurityError" DOMException.
         if (!can_have_its_url_rewritten(document, new_url))
-            return WebIDL::SecurityError::create(realm(), "Cannot pushState or replaceState to incompatible URL"sv);
+            return WebIDL::SecurityError::create(realm(), "Cannot pushState or replaceState to incompatible URL"_fly_string);
     }
 
     // FIXME: 7. Let navigation be history's relevant global object's navigation API.

--- a/Userland/Libraries/LibWeb/HTML/Location.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Location.cpp
@@ -108,7 +108,7 @@ WebIDL::ExceptionOr<String> Location::href() const
     // 1. If this's relevant Document is non-null and its origin is not same origin-domain with the entry settings object's origin, then throw a "SecurityError" DOMException.
     auto const relevant_document = this->relevant_document();
     if (relevant_document && !relevant_document->origin().is_same_origin_domain(entry_settings_object().origin()))
-        return WebIDL::SecurityError::create(realm(), "Location's relevant document is not same origin-domain with the entry settings object's origin"sv);
+        return WebIDL::SecurityError::create(realm(), "Location's relevant document is not same origin-domain with the entry settings object's origin"_fly_string);
 
     // 2. Return this's url, serialized.
     return TRY_OR_THROW_OOM(vm, String::from_deprecated_string(url().serialize()));
@@ -144,7 +144,7 @@ WebIDL::ExceptionOr<String> Location::origin() const
     // 1. If this's relevant Document is non-null and its origin is not same origin-domain with the entry settings object's origin, then throw a "SecurityError" DOMException.
     auto const relevant_document = this->relevant_document();
     if (relevant_document && !relevant_document->origin().is_same_origin_domain(entry_settings_object().origin()))
-        return WebIDL::SecurityError::create(realm(), "Location's relevant document is not same origin-domain with the entry settings object's origin"sv);
+        return WebIDL::SecurityError::create(realm(), "Location's relevant document is not same origin-domain with the entry settings object's origin"_fly_string);
 
     // 2. Return the serialization of this's url's origin.
     return TRY_OR_THROW_OOM(vm, String::from_deprecated_string(url().serialize_origin()));
@@ -158,7 +158,7 @@ WebIDL::ExceptionOr<String> Location::protocol() const
     // 1. If this's relevant Document is non-null and its origin is not same origin-domain with the entry settings object's origin, then throw a "SecurityError" DOMException.
     auto const relevant_document = this->relevant_document();
     if (relevant_document && !relevant_document->origin().is_same_origin_domain(entry_settings_object().origin()))
-        return WebIDL::SecurityError::create(realm(), "Location's relevant document is not same origin-domain with the entry settings object's origin"sv);
+        return WebIDL::SecurityError::create(realm(), "Location's relevant document is not same origin-domain with the entry settings object's origin"_fly_string);
 
     // 2. Return this's url's scheme, followed by ":".
     return TRY_OR_THROW_OOM(vm, String::formatted("{}:", url().scheme()));
@@ -178,7 +178,7 @@ WebIDL::ExceptionOr<String> Location::host() const
     // 1. If this's relevant Document is non-null and its origin is not same origin-domain with the entry settings object's origin, then throw a "SecurityError" DOMException.
     auto const relevant_document = this->relevant_document();
     if (relevant_document && !relevant_document->origin().is_same_origin_domain(entry_settings_object().origin()))
-        return WebIDL::SecurityError::create(realm(), "Location's relevant document is not same origin-domain with the entry settings object's origin"sv);
+        return WebIDL::SecurityError::create(realm(), "Location's relevant document is not same origin-domain with the entry settings object's origin"_fly_string);
 
     // 2. Let url be this's url.
     auto url = this->url();
@@ -209,7 +209,7 @@ WebIDL::ExceptionOr<String> Location::hostname() const
     // 1. If this's relevant Document is non-null and its origin is not same origin-domain with the entry settings object's origin, then throw a "SecurityError" DOMException.
     auto const relevant_document = this->relevant_document();
     if (relevant_document && !relevant_document->origin().is_same_origin_domain(entry_settings_object().origin()))
-        return WebIDL::SecurityError::create(realm(), "Location's relevant document is not same origin-domain with the entry settings object's origin"sv);
+        return WebIDL::SecurityError::create(realm(), "Location's relevant document is not same origin-domain with the entry settings object's origin"_fly_string);
 
     auto url = this->url();
 
@@ -235,7 +235,7 @@ WebIDL::ExceptionOr<String> Location::port() const
     // 1. If this's relevant Document is non-null and its origin is not same origin-domain with the entry settings object's origin, then throw a "SecurityError" DOMException.
     auto const relevant_document = this->relevant_document();
     if (relevant_document && !relevant_document->origin().is_same_origin_domain(entry_settings_object().origin()))
-        return WebIDL::SecurityError::create(realm(), "Location's relevant document is not same origin-domain with the entry settings object's origin"sv);
+        return WebIDL::SecurityError::create(realm(), "Location's relevant document is not same origin-domain with the entry settings object's origin"_fly_string);
 
     auto url = this->url();
 
@@ -261,7 +261,7 @@ WebIDL::ExceptionOr<String> Location::pathname() const
     // 1. If this's relevant Document is non-null and its origin is not same origin-domain with the entry settings object's origin, then throw a "SecurityError" DOMException.
     auto const relevant_document = this->relevant_document();
     if (relevant_document && !relevant_document->origin().is_same_origin_domain(entry_settings_object().origin()))
-        return WebIDL::SecurityError::create(realm(), "Location's relevant document is not same origin-domain with the entry settings object's origin"sv);
+        return WebIDL::SecurityError::create(realm(), "Location's relevant document is not same origin-domain with the entry settings object's origin"_fly_string);
 
     // 2. Return the result of URL path serializing this Location object's url.
     return TRY_OR_THROW_OOM(vm, String::from_deprecated_string(url().serialize_path()));
@@ -281,7 +281,7 @@ WebIDL::ExceptionOr<String> Location::search() const
     // 1. If this's relevant Document is non-null and its origin is not same origin-domain with the entry settings object's origin, then throw a "SecurityError" DOMException.
     auto const relevant_document = this->relevant_document();
     if (relevant_document && !relevant_document->origin().is_same_origin_domain(entry_settings_object().origin()))
-        return WebIDL::SecurityError::create(realm(), "Location's relevant document is not same origin-domain with the entry settings object's origin"sv);
+        return WebIDL::SecurityError::create(realm(), "Location's relevant document is not same origin-domain with the entry settings object's origin"_fly_string);
 
     auto url = this->url();
 
@@ -307,7 +307,7 @@ WebIDL::ExceptionOr<String> Location::hash() const
     // 1. If this's relevant Document is non-null and its origin is not same origin-domain with the entry settings object's origin, then throw a "SecurityError" DOMException.
     auto const relevant_document = this->relevant_document();
     if (relevant_document && !relevant_document->origin().is_same_origin_domain(entry_settings_object().origin()))
-        return WebIDL::SecurityError::create(realm(), "Location's relevant document is not same origin-domain with the entry settings object's origin"sv);
+        return WebIDL::SecurityError::create(realm(), "Location's relevant document is not same origin-domain with the entry settings object's origin"_fly_string);
 
     auto url = this->url();
 
@@ -331,7 +331,7 @@ WebIDL::ExceptionOr<void> Location::set_hash(String const& value)
 
     // 2. If this's relevant Document's origin is not same origin-domain with the entry settings object's origin, then throw a "SecurityError" DOMException.
     if (!relevant_document->origin().is_same_origin_domain(entry_settings_object().origin()))
-        return WebIDL::SecurityError::create(realm(), "Location's relevant document is not same origin-domain with the entry settings object's origin"sv);
+        return WebIDL::SecurityError::create(realm(), "Location's relevant document is not same origin-domain with the entry settings object's origin"_fly_string);
 
     // 3. Let copyURL be a copy of this's url.
     auto copy_url = this->url();
@@ -381,12 +381,12 @@ WebIDL::ExceptionOr<void> Location::assign(String const& url) const
 
     // 2. If this's relevant Document's origin is not same origin-domain with the entry settings object's origin, then throw a "SecurityError" DOMException.
     if (!relevant_document->origin().is_same_origin_domain(entry_settings_object().origin()))
-        return WebIDL::SecurityError::create(realm(), "Location's relevant document is not same origin-domain with the entry settings object's origin"sv);
+        return WebIDL::SecurityError::create(realm(), "Location's relevant document is not same origin-domain with the entry settings object's origin"_fly_string);
 
     // 3. Parse url relative to the entry settings object. If that failed, throw a "SyntaxError" DOMException.
     auto assign_url = entry_settings_object().parse_url(url);
     if (!assign_url.is_valid())
-        return WebIDL::SyntaxError::create(realm(), DeprecatedString::formatted("Invalid URL '{}'", url));
+        return WebIDL::SyntaxError::create(realm(), MUST(String::formatted("Invalid URL '{}'", url)));
 
     // 4. Location-object navigate this to the resulting URL record.
     auto& window = verify_cast<HTML::Window>(HTML::current_global_object());
@@ -469,7 +469,7 @@ JS::ThrowCompletionOr<bool> Location::internal_define_own_property(JS::PropertyK
     }
 
     // 2. Throw a "SecurityError" DOMException.
-    return throw_completion(WebIDL::SecurityError::create(realm(), DeprecatedString::formatted("Can't define property '{}' on cross-origin object", property_key)));
+    return throw_completion(WebIDL::SecurityError::create(realm(), MUST(String::formatted("Can't define property '{}' on cross-origin object", property_key))));
 }
 
 // 7.10.5.7 [[Get]] ( P, Receiver ), https://html.spec.whatwg.org/multipage/history.html#location-get
@@ -506,7 +506,7 @@ JS::ThrowCompletionOr<bool> Location::internal_delete(JS::PropertyKey const& pro
         return JS::Object::internal_delete(property_key);
 
     // 2. Throw a "SecurityError" DOMException.
-    return throw_completion(WebIDL::SecurityError::create(realm(), DeprecatedString::formatted("Can't delete property '{}' on cross-origin object", property_key)));
+    return throw_completion(WebIDL::SecurityError::create(realm(), MUST(String::formatted("Can't delete property '{}' on cross-origin object", property_key))));
 }
 
 // 7.10.5.10 [[OwnPropertyKeys]] ( ), https://html.spec.whatwg.org/multipage/history.html#location-ownpropertykeys

--- a/Userland/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Navigable.cpp
@@ -842,7 +842,7 @@ WebIDL::ExceptionOr<void> Navigable::navigate(
     if (!source_document->navigable()->allowed_by_sandboxing_to_navigate(*this, source_snapshot_params)) {
         // 1. If exceptionsEnabled is true, then throw a "SecurityError" DOMException.
         if (exceptions_enabled) {
-            return WebIDL::SecurityError::create(realm, "Source document's node navigable is not allowed to navigate"sv);
+            return WebIDL::SecurityError::create(realm, "Source document's node navigable is not allowed to navigate"_fly_string);
         }
 
         // 2 Return.

--- a/Userland/Libraries/LibWeb/HTML/NavigateEvent.cpp
+++ b/Userland/Libraries/LibWeb/HTML/NavigateEvent.cpp
@@ -72,11 +72,11 @@ WebIDL::ExceptionOr<void> NavigateEvent::intercept(NavigationInterceptOptions co
 
     // 2. If this's canIntercept attribute was initialized to false, then throw a "SecurityError" DOMException.
     if (!m_can_intercept)
-        return WebIDL::SecurityError::create(realm, "NavigateEvent cannot be intercepted");
+        return WebIDL::SecurityError::create(realm, "NavigateEvent cannot be intercepted"_fly_string);
 
     // 3. If this's dispatch flag is unset, then throw an "InvalidStateError" DOMException.
     if (!this->dispatched())
-        return WebIDL::InvalidStateError::create(realm, "NavigationEvent is not dispatched yet");
+        return WebIDL::InvalidStateError::create(realm, "NavigationEvent is not dispatched yet"_fly_string);
 
     // 4. Assert: this's interception state is either "none" or "intercepted".
     VERIFY(m_interception_state == InterceptionState::None || m_interception_state == InterceptionState::Intercepted);
@@ -130,7 +130,7 @@ WebIDL::ExceptionOr<void> NavigateEvent::scroll()
 
     // 2. If this's interception state is not "committed", then throw an "InvalidStateError" DOMException.
     if (m_interception_state != InterceptionState::Committed)
-        return WebIDL::InvalidStateError::create(realm(), "Cannot scroll NavigationEvent that is not committed");
+        return WebIDL::InvalidStateError::create(realm(), "Cannot scroll NavigationEvent that is not committed"_fly_string);
 
     // 3. Process scroll behavior given this.
     process_scroll_behavior();
@@ -147,15 +147,15 @@ WebIDL::ExceptionOr<void> NavigateEvent::perform_shared_checks()
     //    then throw an "InvalidStateError" DOMException.
     auto& associated_document = verify_cast<HTML::Window>(relevant_global_object(*this)).associated_document();
     if (!associated_document.is_fully_active())
-        return WebIDL::InvalidStateError::create(realm(), "Document is not fully active");
+        return WebIDL::InvalidStateError::create(realm(), "Document is not fully active"_fly_string);
 
     // 2. If event's isTrusted attribute was initialized to false, then throw a "SecurityError" DOMException.
     if (!this->is_trusted())
-        return WebIDL::SecurityError::create(realm(), "NavigateEvent is not trusted");
+        return WebIDL::SecurityError::create(realm(), "NavigateEvent is not trusted"_fly_string);
 
     // 3. If event's canceled flag is set, then throw an "InvalidStateError" DOMException.
     if (this->cancelled())
-        return WebIDL::InvalidStateError::create(realm(), "NavigateEvent already cancelled");
+        return WebIDL::InvalidStateError::create(realm(), "NavigateEvent already cancelled"_fly_string);
 
     return {};
 }

--- a/Userland/Libraries/LibWeb/HTML/Navigation.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Navigation.cpp
@@ -125,7 +125,7 @@ WebIDL::ExceptionOr<void> Navigation::update_current_entry(NavigationUpdateCurre
 
     // 2. If current is null, then throw an "InvalidStateError" DOMException.
     if (current == nullptr)
-        return WebIDL::InvalidStateError::create(realm(), "Cannot update current NavigationHistoryEntry when there is no current entry"sv);
+        return WebIDL::InvalidStateError::create(realm(), "Cannot update current NavigationHistoryEntry when there is no current entry"_fly_string);
 
     // 3. Let serializedState be StructuredSerializeForStorage(options["state"]), rethrowing any exceptions.
     auto serialized_state = TRY(structured_serialize_for_storage(vm(), options.state));
@@ -210,7 +210,7 @@ WebIDL::ExceptionOr<NavigationResult> Navigation::navigate(String url, Navigatio
     //    Otherwise, let urlRecord be the resulting URL record.
     auto url_record = relevant_settings_object(*this).parse_url(url);
     if (!url_record.is_valid())
-        return early_error_result(WebIDL::SyntaxError::create(realm, "Cannot navigate to Invalid URL"));
+        return early_error_result(WebIDL::SyntaxError::create(realm, "Cannot navigate to Invalid URL"_fly_string));
 
     // 2. Let document be this's relevant global object's associated Document.
     auto& document = verify_cast<HTML::Window>(relevant_global_object(*this)).associated_document();
@@ -218,7 +218,7 @@ WebIDL::ExceptionOr<NavigationResult> Navigation::navigate(String url, Navigatio
     // 3. If options["history"] is "push", and the navigation must be a replace given urlRecord and document,
     //    then return an early error result for a "NotSupportedError" DOMException.
     if (options.history == Bindings::NavigationHistoryBehavior::Push && navigation_must_be_a_replace(url_record, document))
-        return early_error_result(WebIDL::NotSupportedError::create(realm, "Navigation must be a replace, but push was requested"));
+        return early_error_result(WebIDL::NotSupportedError::create(realm, "Navigation must be a replace, but push was requested"_fly_string));
 
     // 4. Let state be options["state"], if it exists; otherwise, undefined.
     auto state = options.state.value_or(JS::js_undefined());
@@ -237,11 +237,11 @@ WebIDL::ExceptionOr<NavigationResult> Navigation::navigate(String url, Navigatio
 
     // 6. If document is not fully active, then return an early error result for an "InvalidStateError" DOMException.
     if (!document.is_fully_active())
-        return early_error_result(WebIDL::InvalidStateError::create(realm, "Document is not fully active"));
+        return early_error_result(WebIDL::InvalidStateError::create(realm, "Document is not fully active"_fly_string));
 
     // 7. If document's unload counter is greater than 0, then return an early error result for an "InvalidStateError" DOMException.
     if (document.unload_counter() > 0)
-        return early_error_result(WebIDL::InvalidStateError::create(realm, "Document already unloaded"));
+        return early_error_result(WebIDL::InvalidStateError::create(realm, "Document already unloaded"_fly_string));
 
     // 8. Let info be options["info"], if it exists; otherwise, undefined.
     auto info = options.info.value_or(JS::js_undefined());
@@ -270,7 +270,7 @@ WebIDL::ExceptionOr<NavigationResult> Navigation::navigate(String url, Navigatio
     //       that upcoming API method tracker to ongoing.
     if (m_upcoming_non_traverse_api_method_tracker == api_method_tracker) {
         m_upcoming_non_traverse_api_method_tracker = nullptr;
-        return early_error_result(WebIDL::AbortError::create(realm, "Navigation aborted"));
+        return early_error_result(WebIDL::AbortError::create(realm, "Navigation aborted"_fly_string));
     }
 
     // 12. Return a navigation API method tracker-derived result for apiMethodTracker.
@@ -313,11 +313,11 @@ WebIDL::ExceptionOr<NavigationResult> Navigation::reload(NavigationReloadOptions
 
     // 5. If document is not fully active, then return an early error result for an "InvalidStateError" DOMException.
     if (!document.is_fully_active())
-        return early_error_result(WebIDL::InvalidStateError::create(realm, "Document is not fully active"));
+        return early_error_result(WebIDL::InvalidStateError::create(realm, "Document is not fully active"_fly_string));
 
     // 6. If document's unload counter is greater than 0, then return an early error result for an "InvalidStateError" DOMException.
     if (document.unload_counter() > 0)
-        return early_error_result(WebIDL::InvalidStateError::create(realm, "Document already unloaded"));
+        return early_error_result(WebIDL::InvalidStateError::create(realm, "Document already unloaded"_fly_string));
 
     // 7. Let info be options["info"], if it exists; otherwise, undefined.
     auto info = options.info.value_or(JS::js_undefined());
@@ -341,7 +341,7 @@ WebIDL::ExceptionOr<NavigationResult> Navigation::traverse_to(String key, Naviga
 
     // 1. If this's current entry index is −1, then return an early error result for an "InvalidStateError" DOMException.
     if (m_current_entry_index == -1)
-        return early_error_result(WebIDL::InvalidStateError::create(realm, "Cannot traverseTo: no current session history entry"));
+        return early_error_result(WebIDL::InvalidStateError::create(realm, "Cannot traverseTo: no current session history entry"_fly_string));
 
     // 2. If this's entry list does not contain a NavigationHistoryEntry whose session history entry's navigation API key equals key,
     //    then return an early error result for an "InvalidStateError" DOMException.
@@ -349,7 +349,7 @@ WebIDL::ExceptionOr<NavigationResult> Navigation::traverse_to(String key, Naviga
         return entry->session_history_entry().navigation_api_key == key;
     });
     if (it == m_entry_list.end())
-        return early_error_result(WebIDL::InvalidStateError::create(realm, "Cannot traverseTo: key not found in session history list"));
+        return early_error_result(WebIDL::InvalidStateError::create(realm, "Cannot traverseTo: key not found in session history list"_fly_string));
 
     // 3. Return the result of performing a navigation API traversal given this, key, and options.
     return perform_a_navigation_api_traversal(key, options);
@@ -363,7 +363,7 @@ WebIDL::ExceptionOr<NavigationResult> Navigation::back(NavigationOptions const& 
 
     // 1. If this's current entry index is −1 or 0, then return an early error result for an "InvalidStateError" DOMException.
     if (m_current_entry_index == -1 || m_current_entry_index == 0)
-        return early_error_result(WebIDL::InvalidStateError::create(realm, "Cannot navigate back: no previous session history entry"));
+        return early_error_result(WebIDL::InvalidStateError::create(realm, "Cannot navigate back: no previous session history entry"_fly_string));
 
     // 2. Let key be this's entry list[this's current entry index − 1]'s session history entry's navigation API key.
     auto key = m_entry_list[m_current_entry_index - 1]->session_history_entry().navigation_api_key;
@@ -381,7 +381,7 @@ WebIDL::ExceptionOr<NavigationResult> Navigation::forward(NavigationOptions cons
     // 1. If this's current entry index is −1 or is equal to this's entry list's size − 1,
     //    then return an early error result for an "InvalidStateError" DOMException.
     if (m_current_entry_index == -1 || m_current_entry_index == static_cast<i64>(m_entry_list.size() - 1))
-        return early_error_result(WebIDL::InvalidStateError::create(realm, "Cannot navigate forward: no next session history entry"));
+        return early_error_result(WebIDL::InvalidStateError::create(realm, "Cannot navigate forward: no next session history entry"_fly_string));
 
     // 2. Let key be this's entry list[this's current entry index + 1]'s session history entry's navigation API key.
     auto key = m_entry_list[m_current_entry_index + 1]->session_history_entry().navigation_api_key;
@@ -610,11 +610,11 @@ WebIDL::ExceptionOr<NavigationResult> Navigation::perform_a_navigation_api_trave
 
     // 2. If document is not fully active, then return an early error result for an "InvalidStateError" DOMException.
     if (!document.is_fully_active())
-        return early_error_result(WebIDL::InvalidStateError::create(realm, "Document is not fully active"));
+        return early_error_result(WebIDL::InvalidStateError::create(realm, "Document is not fully active"_fly_string));
 
     // 3. If document's unload counter is greater than 0, then return an early error result for an "InvalidStateError" DOMException.
     if (document.unload_counter() > 0)
-        return early_error_result(WebIDL::InvalidStateError::create(realm, "Document already unloaded"));
+        return early_error_result(WebIDL::InvalidStateError::create(realm, "Document already unloaded"_fly_string));
 
     // 4. Let current be the current entry of navigation.
     auto current = current_entry();
@@ -666,7 +666,7 @@ WebIDL::ExceptionOr<NavigationResult> Navigation::perform_a_navigation_api_trave
             queue_global_task(HTML::Task::Source::NavigationAndTraversal, relevant_global_object(*this), [this, api_method_tracker] {
                 auto& reject_realm = relevant_realm(*this);
                 WebIDL::reject_promise(reject_realm, api_method_tracker->finished_promise,
-                    WebIDL::InvalidStateError::create(reject_realm, "Cannot traverse with stale session history entry"));
+                    WebIDL::InvalidStateError::create(reject_realm, "Cannot traverse with stale session history entry"_fly_string));
             });
 
             // 2. Abort these steps.

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
@@ -490,7 +490,7 @@ void HTMLParser::handle_initial(HTMLToken& token)
     }
 
     if (token.is_comment()) {
-        auto comment = realm().heap().allocate<DOM::Comment>(realm(), document(), token.comment());
+        auto comment = realm().heap().allocate<DOM::Comment>(realm(), document(), MUST(String::from_deprecated_string(token.comment())));
         MUST(document().append_child(*comment));
         return;
     }
@@ -525,7 +525,7 @@ void HTMLParser::handle_before_html(HTMLToken& token)
     // -> A comment token
     if (token.is_comment()) {
         // Insert a comment as the last child of the Document object.
-        auto comment = realm().heap().allocate<DOM::Comment>(realm(), document(), token.comment());
+        auto comment = realm().heap().allocate<DOM::Comment>(realm(), document(), MUST(String::from_deprecated_string(token.comment())));
         MUST(document().append_child(*comment));
         return;
     }
@@ -822,7 +822,7 @@ AnythingElse:
 void HTMLParser::insert_comment(HTMLToken& token)
 {
     auto adjusted_insertion_location = find_appropriate_place_for_inserting_node();
-    adjusted_insertion_location.parent->insert_before(realm().heap().allocate<DOM::Comment>(realm(), document(), token.comment()), adjusted_insertion_location.insert_before_sibling);
+    adjusted_insertion_location.parent->insert_before(realm().heap().allocate<DOM::Comment>(realm(), document(), MUST(String::from_deprecated_string(token.comment()))), adjusted_insertion_location.insert_before_sibling);
 }
 
 void HTMLParser::handle_in_head(HTMLToken& token)
@@ -1142,7 +1142,7 @@ void HTMLParser::handle_after_body(HTMLToken& token)
 
     if (token.is_comment()) {
         auto& insertion_location = m_stack_of_open_elements.first();
-        MUST(insertion_location.append_child(realm().heap().allocate<DOM::Comment>(realm(), document(), token.comment())));
+        MUST(insertion_location.append_child(realm().heap().allocate<DOM::Comment>(realm(), document(), MUST(String::from_deprecated_string(token.comment())))));
         return;
     }
 
@@ -1178,7 +1178,7 @@ void HTMLParser::handle_after_body(HTMLToken& token)
 void HTMLParser::handle_after_after_body(HTMLToken& token)
 {
     if (token.is_comment()) {
-        auto comment = realm().heap().allocate<DOM::Comment>(realm(), document(), token.comment());
+        auto comment = realm().heap().allocate<DOM::Comment>(realm(), document(), MUST(String::from_deprecated_string(token.comment())));
         MUST(document().append_child(*comment));
         return;
     }
@@ -3407,7 +3407,7 @@ void HTMLParser::handle_after_frameset(HTMLToken& token)
 void HTMLParser::handle_after_after_frameset(HTMLToken& token)
 {
     if (token.is_comment()) {
-        auto comment = document().heap().allocate<DOM::Comment>(document().realm(), document(), token.comment());
+        auto comment = document().heap().allocate<DOM::Comment>(document().realm(), document(), MUST(String::from_deprecated_string(token.comment())));
         MUST(document().append_child(comment));
         return;
     }

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
@@ -1009,7 +1009,7 @@ DOM::Text* HTMLParser::find_character_insertion_node()
     if (adjusted_insertion_location.insert_before_sibling) {
         if (is_empty_text_node(adjusted_insertion_location.insert_before_sibling->previous_sibling()))
             return static_cast<DOM::Text*>(adjusted_insertion_location.insert_before_sibling->previous_sibling());
-        auto new_text_node = realm().heap().allocate<DOM::Text>(realm(), document(), "");
+        auto new_text_node = realm().heap().allocate<DOM::Text>(realm(), document(), String {});
         adjusted_insertion_location.parent->insert_before(*new_text_node, *adjusted_insertion_location.insert_before_sibling);
         return new_text_node;
     }
@@ -1017,7 +1017,7 @@ DOM::Text* HTMLParser::find_character_insertion_node()
         return nullptr;
     if (is_empty_text_node(adjusted_insertion_location.parent->last_child()))
         return static_cast<DOM::Text*>(adjusted_insertion_location.parent->last_child());
-    auto new_text_node = realm().heap().allocate<DOM::Text>(realm(), document(), "");
+    auto new_text_node = realm().heap().allocate<DOM::Text>(realm(), document(), String {});
     MUST(adjusted_insertion_location.parent->append_child(*new_text_node));
     return new_text_node;
 }

--- a/Userland/Libraries/LibWeb/HTML/Scripting/ClassicScript.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/ClassicScript.cpp
@@ -118,7 +118,7 @@ JS::Completion ClassicScript::run(RethrowErrors rethrow_errors, JS::GCPtr<JS::En
             settings.clean_up_after_running_script();
 
             // 2. Throw a "NetworkError" DOMException.
-            return throw_completion(WebIDL::NetworkError::create(settings.realm(), "Script error."));
+            return throw_completion(WebIDL::NetworkError::create(settings.realm(), "Script error."_fly_string));
         }
 
         // 3. Otherwise, rethrow errors is false. Perform the following steps:

--- a/Userland/Libraries/LibWeb/HTML/Scripting/ModuleScript.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/ModuleScript.cpp
@@ -143,7 +143,7 @@ JS::Promise* JavaScriptModuleScript::run(PreventErrorReporting)
         // then set evaluationPromise to a promise rejected with a new "QuotaExceededError" DOMException.
         if (elevation_promise_or_error.is_error()) {
             auto promise = JS::Promise::create(settings_object().realm());
-            promise->reject(WebIDL::QuotaExceededError::create(settings_object().realm(), "Failed to evaluate module script").ptr());
+            promise->reject(WebIDL::QuotaExceededError::create(settings_object().realm(), "Failed to evaluate module script"_fly_string).ptr());
 
             evaluation_promise = promise;
         } else {

--- a/Userland/Libraries/LibWeb/HTML/StructuredSerialize.cpp
+++ b/Userland/Libraries/LibWeb/HTML/StructuredSerialize.cpp
@@ -127,7 +127,7 @@ public:
 
         // 5. If Type(value) is Symbol, then throw a "DataCloneError" DOMException.
         if (value.is_symbol())
-            return WebIDL::DataCloneError::create(*m_vm.current_realm(), "Cannot serialize Symbol"sv);
+            return WebIDL::DataCloneError::create(*m_vm.current_realm(), "Cannot serialize Symbol"_fly_string);
 
         // 6. Let serialized be an uninitialized value.
         //    NOTE: We use the range of the soon-to-be-serialized value in our serialized data buffer
@@ -173,7 +173,7 @@ public:
 
         // 12 - 24: FIXME: Serialize other data types
         else {
-            return throw_completion(WebIDL::DataCloneError::create(*m_vm.current_realm(), "Unsupported type"sv));
+            return throw_completion(WebIDL::DataCloneError::create(*m_vm.current_realm(), "Unsupported type"_fly_string));
         }
 
         // 25. Set memory[value] to serialized.
@@ -302,7 +302,7 @@ public:
                 break;
             }
             default:
-                m_error = "Unsupported type"sv;
+                m_error = "Unsupported type"_fly_string;
                 break;
             }
         }
@@ -311,16 +311,16 @@ public:
 
     WebIDL::ExceptionOr<JS::Value> result()
     {
-        if (m_error.is_null())
+        if (!m_error.has_value())
             return m_memory[0];
-        return WebIDL::DataCloneError::create(*m_vm.current_realm(), m_error);
+        return WebIDL::DataCloneError::create(*m_vm.current_realm(), m_error.value());
     }
 
 private:
     JS::VM& m_vm;
     SerializationRecord const& m_vector;
     JS::MarkedVector<JS::Value> m_memory; // Index -> JS value
-    StringView m_error;
+    Optional<FlyString> m_error;
 
     static WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::PrimitiveString>> deserialize_string_primitive(JS::VM& vm, Vector<u32> const& vector, u32& position)
     {

--- a/Userland/Libraries/LibWeb/HTML/Window.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Window.cpp
@@ -363,7 +363,7 @@ WebIDL::ExceptionOr<JS::GCPtr<WindowProxy>> Window::open_impl(StringView url, St
         if (!url.is_empty()) {
             url_record = entry_settings_object().parse_url(url);
             if (!url_record.is_valid())
-                return WebIDL::SyntaxError::create(realm(), "URL is not valid");
+                return WebIDL::SyntaxError::create(realm(), "URL is not valid"_fly_string);
         }
 
         // FIXME: 5. If urlRecord matches about:blank, then perform the URL and history update steps given target browsing context's active document and urlRecord.
@@ -393,7 +393,7 @@ WebIDL::ExceptionOr<JS::GCPtr<WindowProxy>> Window::open_impl(StringView url, St
             // 2. Parse url relative to the entry settings object, and set urlRecord to the resulting URL record, if any. If the parse a URL algorithm failed, then throw a "SyntaxError" DOMException.
             url_record = entry_settings_object().parse_url(url);
             if (!url_record.is_valid())
-                return WebIDL::SyntaxError::create(realm(), "URL is not valid");
+                return WebIDL::SyntaxError::create(realm(), "URL is not valid"_fly_string);
 
             // 3. Let request be a new request whose URL is urlRecord.
             auto request = Fetch::Infrastructure::Request::create(vm);

--- a/Userland/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.cpp
+++ b/Userland/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.cpp
@@ -96,7 +96,7 @@ WebIDL::ExceptionOr<String> WindowOrWorkerGlobalScopeMixin::btoa(String const& d
     byte_string.ensure_capacity(data.bytes().size());
     for (u32 code_point : Utf8View(data)) {
         if (code_point > 0xff)
-            return WebIDL::InvalidCharacterError::create(realm, "Data contains characters outside the range U+0000 and U+00FF");
+            return WebIDL::InvalidCharacterError::create(realm, "Data contains characters outside the range U+0000 and U+00FF"_fly_string);
         byte_string.append(code_point);
     }
 
@@ -116,7 +116,7 @@ WebIDL::ExceptionOr<String> WindowOrWorkerGlobalScopeMixin::atob(String const& d
 
     // 2. If decodedData is failure, then throw an "InvalidCharacterError" DOMException.
     if (decoded_data.is_error())
-        return WebIDL::InvalidCharacterError::create(realm, "Input string is not valid base64 data");
+        return WebIDL::InvalidCharacterError::create(realm, "Input string is not valid base64 data"_fly_string);
 
     // 3. Return decodedData.
     // decode_base64() returns a byte string. LibJS uses UTF-8 for strings. Use Latin1Decoder to convert bytes 128-255 to UTF-8.

--- a/Userland/Libraries/LibWeb/HTML/WindowProxy.cpp
+++ b/Userland/Libraries/LibWeb/HTML/WindowProxy.cpp
@@ -95,7 +95,7 @@ JS::ThrowCompletionOr<Optional<JS::PropertyDescriptor>> WindowProxy::internal_ge
                 return Optional<JS::PropertyDescriptor> {};
 
             // 2. Throw a "SecurityError" DOMException.
-            return throw_completion(WebIDL::SecurityError::create(m_window->realm(), DeprecatedString::formatted("Can't access property '{}' on cross-origin object", property_key)));
+            return throw_completion(WebIDL::SecurityError::create(m_window->realm(), MUST(String::formatted("Can't access property '{}' on cross-origin object", property_key))));
         }
 
         // 6. Return PropertyDescriptor{ [[Value]]: value, [[Writable]]: false, [[Enumerable]]: true, [[Configurable]]: true }.
@@ -145,7 +145,7 @@ JS::ThrowCompletionOr<bool> WindowProxy::internal_define_own_property(JS::Proper
     }
 
     // 3. Throw a "SecurityError" DOMException.
-    return throw_completion(WebIDL::SecurityError::create(m_window->realm(), DeprecatedString::formatted("Can't define property '{}' on cross-origin object", property_key)));
+    return throw_completion(WebIDL::SecurityError::create(m_window->realm(), MUST(String::formatted("Can't define property '{}' on cross-origin object", property_key))));
 }
 
 // 7.4.7 [[Get]] ( P, Receiver ), https://html.spec.whatwg.org/multipage/window-object.html#windowproxy-get
@@ -218,7 +218,7 @@ JS::ThrowCompletionOr<bool> WindowProxy::internal_delete(JS::PropertyKey const& 
     }
 
     // 3. Throw a "SecurityError" DOMException.
-    return throw_completion(WebIDL::SecurityError::create(m_window->realm(), DeprecatedString::formatted("Can't delete property '{}' on cross-origin object", property_key)));
+    return throw_completion(WebIDL::SecurityError::create(m_window->realm(), MUST(String::formatted("Can't delete property '{}' on cross-origin object", property_key))));
 }
 
 // 7.4.10 [[OwnPropertyKeys]] ( ), https://html.spec.whatwg.org/multipage/window-object.html#windowproxy-ownpropertykeys

--- a/Userland/Libraries/LibWeb/HTML/Worker.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Worker.cpp
@@ -51,7 +51,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Worker>> Worker::create(String const& scrip
 {
     // NOTE: We don't start a worker because they're not properly implemented yet and would likely crash.
     dbgln("FIXME: Implement web workers");
-    return WebIDL::NotSupportedError::create(document.realm(), "Web workers not supported yet");
+    return WebIDL::NotSupportedError::create(document.realm(), "Web workers not supported yet"_fly_string);
 
     dbgln_if(WEB_WORKER_DEBUG, "WebWorker: Creating worker with script_url = {}", script_url);
 
@@ -75,7 +75,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Worker>> Worker::create(String const& scrip
     // 4. If this fails, throw a "SyntaxError" DOMException.
     if (!url.is_valid()) {
         dbgln_if(WEB_WORKER_DEBUG, "WebWorker: Invalid URL loaded '{}'.", script_url);
-        return WebIDL::SyntaxError::create(document.realm(), "url is not valid");
+        return WebIDL::SyntaxError::create(document.realm(), "url is not valid"_fly_string);
     }
 
     // 5. Let worker URL be the resulting URL record.

--- a/Userland/Libraries/LibWeb/HighResolutionTime/Performance.cpp
+++ b/Userland/Libraries/LibWeb/HighResolutionTime/Performance.cpp
@@ -119,7 +119,7 @@ WebIDL::ExceptionOr<HighResolutionTime::DOMHighResTimeStamp> Performance::conver
 
     // 5. If endTime is 0, throw an InvalidAccessError.
     if (end_time == 0)
-        return WebIDL::InvalidAccessError::create(realm, DeprecatedString::formatted("The '{}' entry in the PerformanceTiming interface is equal to 0, meaning it hasn't happened yet", name));
+        return WebIDL::InvalidAccessError::create(realm, MUST(String::formatted("The '{}' entry in the PerformanceTiming interface is equal to 0, meaning it hasn't happened yet", name)));
 
     // 6. Return result of subtracting startTime from endTime.
     return static_cast<HighResolutionTime::DOMHighResTimeStamp>(end_time - start_time);
@@ -153,7 +153,7 @@ WebIDL::ExceptionOr<HighResolutionTime::DOMHighResTimeStamp> Performance::conver
         });
 
         if (!maybe_entry.has_value())
-            return WebIDL::SyntaxError::create(realm, DeprecatedString::formatted("No PerformanceMark object with name '{}' found in the performance timeline", mark_string));
+            return WebIDL::SyntaxError::create(realm, MUST(String::formatted("No PerformanceMark object with name '{}' found in the performance timeline", mark_string)));
 
         return maybe_entry.value()->start_time();
     }

--- a/Userland/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -206,7 +206,7 @@ ErrorOr<void> TreeBuilder::create_pseudo_element_if_needed(DOM::Element& element
 
     // FIXME: Handle images, and multiple values
     if (pseudo_element_content.type == CSS::ContentData::Type::String) {
-        auto text = document.heap().allocate<DOM::Text>(document.realm(), document, pseudo_element_content.data.to_deprecated_string());
+        auto text = document.heap().allocate<DOM::Text>(document.realm(), document, pseudo_element_content.data);
         auto text_node = document.heap().allocate_without_realm<Layout::TextNode>(document, *text);
         text_node->set_generated_for(generated_for, element);
 

--- a/Userland/Libraries/LibWeb/PerformanceTimeline/PerformanceObserver.cpp
+++ b/Userland/Libraries/LibWeb/PerformanceTimeline/PerformanceObserver.cpp
@@ -74,12 +74,12 @@ WebIDL::ExceptionOr<void> PerformanceObserver::observe(PerformanceObserverInit& 
     // 2. If this's observer type is "single" and options's entryTypes member is present, then throw an "InvalidModificationError".
     else if (m_observer_type == ObserverType::Single) {
         if (options.entry_types.has_value())
-            return WebIDL::InvalidModificationError::create(realm, "Cannot change a PerformanceObserver from observing a single type to observing multiple types"sv);
+            return WebIDL::InvalidModificationError::create(realm, "Cannot change a PerformanceObserver from observing a single type to observing multiple types"_fly_string);
     }
     // 3. If this's observer type is "multiple" and options's type member is present, then throw an "InvalidModificationError".
     else if (m_observer_type == ObserverType::Multiple) {
         if (options.type.has_value())
-            return WebIDL::InvalidModificationError::create(realm, "Cannot change a PerformanceObserver from observing multiple types to observing a single type"sv);
+            return WebIDL::InvalidModificationError::create(realm, "Cannot change a PerformanceObserver from observing multiple types to observing a single type"_fly_string);
     }
 
     // 5. Set this's requires dropped entries to true.

--- a/Userland/Libraries/LibWeb/Selection/Selection.cpp
+++ b/Userland/Libraries/LibWeb/Selection/Selection.cpp
@@ -118,7 +118,7 @@ WebIDL::ExceptionOr<JS::GCPtr<DOM::Range>> Selection::get_range_at(unsigned inde
 {
     // The method must throw an IndexSizeError exception if index is not 0, or if this is empty.
     if (index != 0 || is_empty())
-        return WebIDL::IndexSizeError::create(realm(), "Selection.getRangeAt() on empty Selection or with invalid argument"sv);
+        return WebIDL::IndexSizeError::create(realm(), "Selection.getRangeAt() on empty Selection or with invalid argument"_fly_string);
 
     // Otherwise, it must return a reference to (not a copy of) this's range.
     return m_range;
@@ -149,7 +149,7 @@ WebIDL::ExceptionOr<void> Selection::remove_range(JS::NonnullGCPtr<DOM::Range> r
     }
 
     // Otherwise, it must throw a NotFoundError.
-    return WebIDL::NotFoundError::create(realm(), "Selection.removeRange() with invalid argument"sv);
+    return WebIDL::NotFoundError::create(realm(), "Selection.removeRange() with invalid argument"_fly_string);
 }
 
 // https://w3c.github.io/selection-api/#dom-selection-removeallranges
@@ -177,7 +177,7 @@ WebIDL::ExceptionOr<void> Selection::collapse(JS::GCPtr<DOM::Node> node, unsigne
 
     // 2. The method must throw an IndexSizeError exception if offset is longer than node's length and abort these steps.
     if (offset > node->length()) {
-        return WebIDL::IndexSizeError::create(realm(), "Selection.collapse() with offset longer than node's length"sv);
+        return WebIDL::IndexSizeError::create(realm(), "Selection.collapse() with offset longer than node's length"_fly_string);
     }
 
     // 3. If node's root is not the document associated with this, abort these steps.
@@ -208,7 +208,7 @@ WebIDL::ExceptionOr<void> Selection::collapse_to_start()
 {
     // 1. The method must throw InvalidStateError exception if the this is empty.
     if (!m_range) {
-        return WebIDL::InvalidStateError::create(realm(), "Selection.collapse_to_start() on empty range"sv);
+        return WebIDL::InvalidStateError::create(realm(), "Selection.collapse_to_start() on empty range"_fly_string);
     }
 
     // 2. Otherwise, it must create a new range
@@ -228,7 +228,7 @@ WebIDL::ExceptionOr<void> Selection::collapse_to_end()
 {
     // 1. The method must throw InvalidStateError exception if the this is empty.
     if (!m_range) {
-        return WebIDL::InvalidStateError::create(realm(), "Selection.collapse_to_end() on empty range"sv);
+        return WebIDL::InvalidStateError::create(realm(), "Selection.collapse_to_end() on empty range"_fly_string);
     }
 
     // 2. Otherwise, it must create a new range
@@ -253,7 +253,7 @@ WebIDL::ExceptionOr<void> Selection::extend(JS::NonnullGCPtr<DOM::Node> node, un
 
     // 2. If this is empty, throw an InvalidStateError exception and abort these steps.
     if (!m_range) {
-        return WebIDL::InvalidStateError::create(realm(), "Selection.extend() on empty range"sv);
+        return WebIDL::InvalidStateError::create(realm(), "Selection.extend() on empty range"_fly_string);
     }
 
     // 3. Let oldAnchor and oldFocus be the this's anchor and focus, and let newFocus be the boundary point (node, offset).
@@ -298,10 +298,10 @@ WebIDL::ExceptionOr<void> Selection::set_base_and_extent(JS::NonnullGCPtr<DOM::N
 {
     // 1. If anchorOffset is longer than anchorNode's length or if focusOffset is longer than focusNode's length, throw an IndexSizeError exception and abort these steps.
     if (anchor_offset > anchor_node->length())
-        return WebIDL::IndexSizeError::create(realm(), "Anchor offset points outside of the anchor node");
+        return WebIDL::IndexSizeError::create(realm(), "Anchor offset points outside of the anchor node"_fly_string);
 
     if (focus_offset > focus_node->length())
-        return WebIDL::IndexSizeError::create(realm(), "Focus offset points outside of the focus node");
+        return WebIDL::IndexSizeError::create(realm(), "Focus offset points outside of the focus node"_fly_string);
 
     // 2. If the roots of anchorNode or focusNode are not the document associated with this, abort these steps.
     if (&anchor_node->root() != m_document.ptr())

--- a/Userland/Libraries/LibWeb/UserTiming/PerformanceMark.cpp
+++ b/Userland/Libraries/LibWeb/UserTiming/PerformanceMark.cpp
@@ -41,7 +41,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<PerformanceMark>> PerformanceMark::construc
 #undef __ENUMERATE_NAVIGATION_TIMING_ENTRY_NAME
 
         if (matched)
-            return WebIDL::SyntaxError::create(realm, DeprecatedString::formatted("'{}' markName cannot be used in a Window context because it is part of the PerformanceTiming interface", mark_name));
+            return WebIDL::SyntaxError::create(realm, MUST(String::formatted("'{}' markName cannot be used in a Window context because it is part of the PerformanceTiming interface", mark_name)));
     }
 
     // NOTE: Step 2 (creating the entry) is done after determining values, as we set the values once during creation and never change them after.

--- a/Userland/Libraries/LibWeb/WebAudio/AudioContext.cpp
+++ b/Userland/Libraries/LibWeb/WebAudio/AudioContext.cpp
@@ -114,7 +114,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> AudioContext::resume()
 
     // 3. If the [[control thread state]] on the AudioContext is closed reject the promise with InvalidStateError, abort these steps, returning promise.
     if (state() == Bindings::AudioContextState::Closed) {
-        WebIDL::reject_promise(realm, promise, WebIDL::InvalidStateError::create(realm, "Audio context is already closed."));
+        WebIDL::reject_promise(realm, promise, WebIDL::InvalidStateError::create(realm, "Audio context is already closed."_fly_string));
         return JS::NonnullGCPtr { verify_cast<JS::Promise>(*promise->promise()) };
     }
 
@@ -196,7 +196,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> AudioContext::suspend()
 
     // 3. If the [[control thread state]] on the AudioContext is closed reject the promise with InvalidStateError, abort these steps, returning promise.
     if (state() == Bindings::AudioContextState::Closed) {
-        WebIDL::reject_promise(realm, promise, WebIDL::InvalidStateError::create(realm, "Audio context is already closed."));
+        WebIDL::reject_promise(realm, promise, WebIDL::InvalidStateError::create(realm, "Audio context is already closed."_fly_string));
         return JS::NonnullGCPtr { verify_cast<JS::Promise>(*promise->promise()) };
     }
 
@@ -250,7 +250,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> AudioContext::close()
 
     // 3. If the [[control thread state]] flag on the AudioContext is closed reject the promise with InvalidStateError, abort these steps, returning promise.
     if (state() == Bindings::AudioContextState::Closed) {
-        WebIDL::reject_promise(realm, promise, WebIDL::InvalidStateError::create(realm, "Audio context is already closed."));
+        WebIDL::reject_promise(realm, promise, WebIDL::InvalidStateError::create(realm, "Audio context is already closed."_fly_string));
         return JS::NonnullGCPtr { verify_cast<JS::Promise>(*promise->promise()) };
     }
 

--- a/Userland/Libraries/LibWeb/WebIDL/DOMException.cpp
+++ b/Userland/Libraries/LibWeb/WebIDL/DOMException.cpp
@@ -9,17 +9,17 @@
 
 namespace Web::WebIDL {
 
-JS::NonnullGCPtr<DOMException> DOMException::create(JS::Realm& realm, DeprecatedFlyString const& name, DeprecatedFlyString const& message)
+JS::NonnullGCPtr<DOMException> DOMException::create(JS::Realm& realm, FlyString const& name, FlyString const& message)
 {
     return realm.heap().allocate<DOMException>(realm, realm, name, message);
 }
 
-JS::NonnullGCPtr<DOMException> DOMException::construct_impl(JS::Realm& realm, DeprecatedFlyString const& message, DeprecatedFlyString const& name)
+JS::NonnullGCPtr<DOMException> DOMException::construct_impl(JS::Realm& realm, FlyString const& message, FlyString const& name)
 {
     return realm.heap().allocate<DOMException>(realm, realm, name, message);
 }
 
-DOMException::DOMException(JS::Realm& realm, DeprecatedFlyString const& name, DeprecatedFlyString const& message)
+DOMException::DOMException(JS::Realm& realm, FlyString const& name, FlyString const& message)
     : PlatformObject(realm)
     , m_name(name)
     , m_message(message)

--- a/Userland/Libraries/LibWeb/WebIDL/DOMException.h
+++ b/Userland/Libraries/LibWeb/WebIDL/DOMException.h
@@ -6,8 +6,8 @@
 
 #pragma once
 
-#include <AK/DeprecatedFlyString.h>
 #include <AK/Diagnostics.h>
+#include <AK/FlyString.h>
 #include <LibWeb/Bindings/PlatformObject.h>
 #include <LibWeb/HTML/Scripting/Environments.h>
 
@@ -78,7 +78,7 @@ namespace Web::WebIDL {
     __ENUMERATE(OperationError)                      \
     __ENUMERATE(NotAllowedError)
 
-static u16 get_legacy_code_for_name(DeprecatedFlyString const& name)
+static u16 get_legacy_code_for_name(FlyString const& name)
 {
 #define __ENUMERATE(ErrorName, code) \
     if (name == #ErrorName)          \
@@ -93,35 +93,35 @@ class DOMException final : public Bindings::PlatformObject {
     WEB_PLATFORM_OBJECT(DOMException, Bindings::PlatformObject);
 
 public:
-    static JS::NonnullGCPtr<DOMException> create(JS::Realm& realm, DeprecatedFlyString const& name, DeprecatedFlyString const& message);
+    static JS::NonnullGCPtr<DOMException> create(JS::Realm& realm, FlyString const& name, FlyString const& message);
 
     // JS constructor has message first, name second
     // FIXME: This is a completely pointless footgun, let's use the same order for both factories.
-    static JS::NonnullGCPtr<DOMException> construct_impl(JS::Realm& realm, DeprecatedFlyString const& message, DeprecatedFlyString const& name);
+    static JS::NonnullGCPtr<DOMException> construct_impl(JS::Realm& realm, FlyString const& message, FlyString const& name);
 
     virtual ~DOMException() override;
 
-    DeprecatedFlyString const& name() const { return m_name; }
-    DeprecatedFlyString const& message() const { return m_message; }
+    FlyString const& name() const { return m_name; }
+    FlyString const& message() const { return m_message; }
     u16 code() const { return get_legacy_code_for_name(m_name); }
 
 protected:
-    DOMException(JS::Realm&, DeprecatedFlyString const& name, DeprecatedFlyString const& message);
+    DOMException(JS::Realm&, FlyString const& name, FlyString const& message);
 
     virtual void initialize(JS::Realm&) override;
 
 private:
-    DeprecatedFlyString m_name;
-    DeprecatedFlyString m_message;
+    FlyString m_name;
+    FlyString m_message;
 };
 
-#define __ENUMERATE(ErrorName)                                                                             \
-    class ErrorName final {                                                                                \
-    public:                                                                                                \
-        static JS::NonnullGCPtr<DOMException> create(JS::Realm& realm, DeprecatedFlyString const& message) \
-        {                                                                                                  \
-            return DOMException::create(realm, #ErrorName, message);                                       \
-        }                                                                                                  \
+#define __ENUMERATE(ErrorName)                                                                   \
+    class ErrorName final {                                                                      \
+    public:                                                                                      \
+        static JS::NonnullGCPtr<DOMException> create(JS::Realm& realm, FlyString const& message) \
+        {                                                                                        \
+            return DOMException::create(realm, #ErrorName##_fly_string, message);                \
+        }                                                                                        \
     };
 ENUMERATE_DOM_EXCEPTION_ERROR_NAMES
 #undef __ENUMERATE

--- a/Userland/Libraries/LibWeb/WebIDL/DOMException.idl
+++ b/Userland/Libraries/LibWeb/WebIDL/DOMException.idl
@@ -1,5 +1,5 @@
 // https://webidl.spec.whatwg.org/#idl-DOMException
-[Exposed=*, Serializable, UseDeprecatedAKString]
+[Exposed=*, Serializable]
 interface DOMException {
 
     constructor(optional DOMString message = "", optional DOMString name = "Error");

--- a/Userland/Libraries/LibWeb/WebSockets/WebSocket.cpp
+++ b/Userland/Libraries/LibWeb/WebSockets/WebSocket.cpp
@@ -65,7 +65,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<WebSocket>> WebSocket::construct_impl(JS::R
 
     // 3. If urlRecord is failure, then throw a "SyntaxError" DOMException.
     if (!url_record.is_valid())
-        return WebIDL::SyntaxError::create(realm, "Invalid URL");
+        return WebIDL::SyntaxError::create(realm, "Invalid URL"_fly_string);
 
     // 4. If urlRecord’s scheme is "http", then set urlRecord’s scheme to "ws".
     if (url_record.scheme() == "http"sv)
@@ -76,11 +76,11 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<WebSocket>> WebSocket::construct_impl(JS::R
 
     // 6. If urlRecord’s scheme is not "ws" or "wss", then throw a "SyntaxError" DOMException.
     if (!url_record.scheme().is_one_of("ws"sv, "wss"sv))
-        return WebIDL::SyntaxError::create(realm, "Invalid protocol"sv);
+        return WebIDL::SyntaxError::create(realm, "Invalid protocol"_fly_string);
 
     // 7. If urlRecord’s fragment is non-null, then throw a "SyntaxError" DOMException.
     if (url_record.fragment().has_value())
-        return WebIDL::SyntaxError::create(realm, "Presence of URL fragment is invalid"sv);
+        return WebIDL::SyntaxError::create(realm, "Presence of URL fragment is invalid"_fly_string);
 
     Vector<String> protocols_sequence;
     // 8. If protocols is a string, set protocols to a sequence consisting of just that string.
@@ -101,10 +101,10 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<WebSocket>> WebSocket::construct_impl(JS::R
         // separator characters as defined in [RFC2616] and MUST all be unique strings.
         auto protocol = sorted_protocols[i];
         if (i < sorted_protocols.size() - 1 && protocol == sorted_protocols[i + 1])
-            return WebIDL::SyntaxError::create(realm, "Found a duplicate protocol name in the specified list"sv);
+            return WebIDL::SyntaxError::create(realm, "Found a duplicate protocol name in the specified list"_fly_string);
         for (auto code_point : protocol.code_points()) {
             if (code_point < '\x21' || code_point > '\x7E')
-                return WebIDL::SyntaxError::create(realm, "Found invalid character in subprotocol name"sv);
+                return WebIDL::SyntaxError::create(realm, "Found invalid character in subprotocol name"_fly_string);
         }
     }
 
@@ -205,13 +205,13 @@ WebIDL::ExceptionOr<void> WebSocket::close(Optional<u16> code, Optional<String> 
 {
     // 1. If code is present, but is neither an integer equal to 1000 nor an integer in the range 3000 to 4999, inclusive, throw an "InvalidAccessError" DOMException.
     if (code.has_value() && *code != 1000 && (*code < 3000 || *code > 4099))
-        return WebIDL::InvalidAccessError::create(realm(), "The close error code is invalid");
+        return WebIDL::InvalidAccessError::create(realm(), "The close error code is invalid"_fly_string);
     // 2. If reason is present, then run these substeps:
     if (reason.has_value()) {
         // 1. Let reasonBytes be the result of encoding reason.
         // 2. If reasonBytes is longer than 123 bytes, then throw a "SyntaxError" DOMException.
         if (reason->bytes().size() > 123)
-            return WebIDL::SyntaxError::create(realm(), "The close reason is longer than 123 bytes");
+            return WebIDL::SyntaxError::create(realm(), "The close reason is longer than 123 bytes"_fly_string);
     }
     // 3. Run the first matching steps from the following list:
     auto state = ready_state();
@@ -232,7 +232,7 @@ WebIDL::ExceptionOr<void> WebSocket::send(Variant<JS::Handle<JS::Object>, JS::Ha
 {
     auto state = ready_state();
     if (state == WebSocket::ReadyState::Connecting)
-        return WebIDL::InvalidStateError::create(realm(), "Websocket is still CONNECTING");
+        return WebIDL::InvalidStateError::create(realm(), "Websocket is still CONNECTING"_fly_string);
     if (state == WebSocket::ReadyState::Open) {
         TRY_OR_THROW_OOM(vm(),
             data.visit(

--- a/Userland/Libraries/LibWeb/XHR/FormData.cpp
+++ b/Userland/Libraries/LibWeb/XHR/FormData.cpp
@@ -25,7 +25,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<FormData>> FormData::construct_impl(JS::Rea
         auto entry_list = TRY(construct_entry_list(realm, form.value()));
         // 2. If list is null, then throw an "InvalidStateError" DOMException.
         if (!entry_list.has_value())
-            return WebIDL::InvalidStateError::create(realm, "Form element does not contain any entries.");
+            return WebIDL::InvalidStateError::create(realm, "Form element does not contain any entries."_fly_string);
         // 3. Set this’s entry list to list.
         list = entry_list.release_value();
     }

--- a/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
+++ b/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
@@ -109,7 +109,7 @@ WebIDL::ExceptionOr<String> XMLHttpRequest::response_text() const
 {
     // 1. If this’s response type is not the empty string or "text", then throw an "InvalidStateError" DOMException.
     if (m_response_type != Bindings::XMLHttpRequestResponseType::Empty && m_response_type != Bindings::XMLHttpRequestResponseType::Text)
-        return WebIDL::InvalidStateError::create(realm(), "XHR responseText can only be used for responseType \"\" or \"text\"");
+        return WebIDL::InvalidStateError::create(realm(), "XHR responseText can only be used for responseType \"\" or \"text\""_fly_string);
 
     // 2. If this’s state is not loading or done, then return the empty string.
     if (m_state != State::Loading && m_state != State::Done)
@@ -127,11 +127,11 @@ WebIDL::ExceptionOr<void> XMLHttpRequest::set_response_type(Bindings::XMLHttpReq
 
     // 2. If this’s state is loading or done, then throw an "InvalidStateError" DOMException.
     if (m_state == State::Loading || m_state == State::Done)
-        return WebIDL::InvalidStateError::create(realm(), "Can't readyState when XHR is loading or done");
+        return WebIDL::InvalidStateError::create(realm(), "Can't readyState when XHR is loading or done"_fly_string);
 
     // 3. If the current global object is a Window object and this’s synchronous flag is set, then throw an "InvalidAccessError" DOMException.
     if (is<HTML::Window>(HTML::current_global_object()) && m_synchronous)
-        return WebIDL::InvalidAccessError::create(realm(), "Can't set readyState on synchronous XHR in Window environment");
+        return WebIDL::InvalidAccessError::create(realm(), "Can't set readyState on synchronous XHR in Window environment"_fly_string);
 
     // 4. Set this’s response type to the given value.
     m_response_type = response_type;
@@ -316,20 +316,20 @@ WebIDL::ExceptionOr<void> XMLHttpRequest::set_request_header(String const& name_
 
     // 1. If this’s state is not opened, then throw an "InvalidStateError" DOMException.
     if (m_state != State::Opened)
-        return WebIDL::InvalidStateError::create(realm, "XHR readyState is not OPENED");
+        return WebIDL::InvalidStateError::create(realm, "XHR readyState is not OPENED"_fly_string);
 
     // 2. If this’s send() flag is set, then throw an "InvalidStateError" DOMException.
     if (m_send)
-        return WebIDL::InvalidStateError::create(realm, "XHR send() flag is already set");
+        return WebIDL::InvalidStateError::create(realm, "XHR send() flag is already set"_fly_string);
 
     // 3. Normalize value.
     auto normalized_value = TRY_OR_THROW_OOM(vm, Fetch::Infrastructure::normalize_header_value(value));
 
     // 4. If name is not a header name or value is not a header value, then throw a "SyntaxError" DOMException.
     if (!Fetch::Infrastructure::is_header_name(name))
-        return WebIDL::SyntaxError::create(realm, "Header name contains invalid characters.");
+        return WebIDL::SyntaxError::create(realm, "Header name contains invalid characters."_fly_string);
     if (!Fetch::Infrastructure::is_header_value(value))
-        return WebIDL::SyntaxError::create(realm, "Header value contains invalid characters.");
+        return WebIDL::SyntaxError::create(realm, "Header value contains invalid characters."_fly_string);
 
     auto header = Fetch::Infrastructure::Header {
         .name = TRY_OR_THROW_OOM(vm, ByteBuffer::copy(name)),
@@ -361,16 +361,16 @@ WebIDL::ExceptionOr<void> XMLHttpRequest::open(String const& method_string, Stri
     if (is<HTML::Window>(HTML::relevant_global_object(*this))) {
         auto const& window = static_cast<HTML::Window const&>(HTML::relevant_global_object(*this));
         if (!window.associated_document().is_fully_active())
-            return WebIDL::InvalidStateError::create(realm(), "Invalid state: Window's associated document is not fully active.");
+            return WebIDL::InvalidStateError::create(realm(), "Invalid state: Window's associated document is not fully active."_fly_string);
     }
 
     // 2. If method is not a method, then throw a "SyntaxError" DOMException.
     if (!Fetch::Infrastructure::is_method(method))
-        return WebIDL::SyntaxError::create(realm(), "An invalid or illegal string was specified.");
+        return WebIDL::SyntaxError::create(realm(), "An invalid or illegal string was specified."_fly_string);
 
     // 3. If method is a forbidden method, then throw a "SecurityError" DOMException.
     if (Fetch::Infrastructure::is_forbidden_method(method))
-        return WebIDL::SecurityError::create(realm(), "Forbidden method, must not be 'CONNECT', 'TRACE', or 'TRACK'");
+        return WebIDL::SecurityError::create(realm(), "Forbidden method, must not be 'CONNECT', 'TRACE', or 'TRACK'"_fly_string);
 
     // 4. Normalize method.
     auto normalized_method = TRY_OR_THROW_OOM(vm(), Fetch::Infrastructure::normalize_method(method));
@@ -381,7 +381,7 @@ WebIDL::ExceptionOr<void> XMLHttpRequest::open(String const& method_string, Stri
 
     // 6. If parsedURL is failure, then throw a "SyntaxError" DOMException.
     if (!parsed_url.is_valid())
-        return WebIDL::SyntaxError::create(realm(), "Invalid URL");
+        return WebIDL::SyntaxError::create(realm(), "Invalid URL"_fly_string);
 
     // 7. If the async argument is omitted, set async to true, and set username and password to null.
     // NOTE: This is handled in the overload lacking the async argument.
@@ -401,7 +401,7 @@ WebIDL::ExceptionOr<void> XMLHttpRequest::open(String const& method_string, Stri
     if (!async
         && is<HTML::Window>(HTML::current_global_object())
         && (m_timeout != 0 || m_response_type != Bindings::XMLHttpRequestResponseType::Empty)) {
-        return WebIDL::InvalidAccessError::create(realm(), "Synchronous XMLHttpRequests in a Window context do not support timeout or a non-empty responseType");
+        return WebIDL::InvalidAccessError::create(realm(), "Synchronous XMLHttpRequests in a Window context do not support timeout or a non-empty responseType"_fly_string);
     }
 
     // 10. Terminate this’s fetch controller.
@@ -449,11 +449,11 @@ WebIDL::ExceptionOr<void> XMLHttpRequest::send(Optional<DocumentOrXMLHttpRequest
 
     // 1. If this’s state is not opened, then throw an "InvalidStateError" DOMException.
     if (m_state != State::Opened)
-        return WebIDL::InvalidStateError::create(realm, "XHR readyState is not OPENED");
+        return WebIDL::InvalidStateError::create(realm, "XHR readyState is not OPENED"_fly_string);
 
     // 2. If this’s send() flag is set, then throw an "InvalidStateError" DOMException.
     if (m_send)
-        return WebIDL::InvalidStateError::create(realm, "XHR send() flag is already set");
+        return WebIDL::InvalidStateError::create(realm, "XHR send() flag is already set"_fly_string);
 
     // 3. If this’s request method is `GET` or `HEAD`, then set body to null.
     if (m_request_method.is_one_of("GET"sv, "HEAD"sv))
@@ -917,7 +917,7 @@ WebIDL::ExceptionOr<void> XMLHttpRequest::override_mime_type(String const& mime)
 
     // 1. If this’s state is loading or done, then throw an "InvalidStateError" DOMException.
     if (m_state == State::Loading || m_state == State::Done)
-        return WebIDL::InvalidStateError::create(realm(), "Cannot override MIME type when state is Loading or Done.");
+        return WebIDL::InvalidStateError::create(realm(), "Cannot override MIME type when state is Loading or Done."_fly_string);
 
     // 2. Set this’s override MIME type to the result of parsing mime.
     m_override_mime_type = TRY_OR_THROW_OOM(vm, MimeSniff::MimeType::parse(mime));
@@ -935,7 +935,7 @@ WebIDL::ExceptionOr<void> XMLHttpRequest::set_timeout(u32 timeout)
     // 1. If the current global object is a Window object and this’s synchronous flag is set,
     //    then throw an "InvalidAccessError" DOMException.
     if (is<HTML::Window>(HTML::current_global_object()) && m_synchronous)
-        return WebIDL::InvalidAccessError::create(realm(), "Use of XMLHttpRequest's timeout attribute is not supported in the synchronous mode in window context.");
+        return WebIDL::InvalidAccessError::create(realm(), "Use of XMLHttpRequest's timeout attribute is not supported in the synchronous mode in window context."_fly_string);
 
     // 2. Set this’s timeout to the given value.
     m_timeout = timeout;
@@ -960,11 +960,11 @@ WebIDL::ExceptionOr<void> XMLHttpRequest::set_with_credentials(bool with_credent
 
     // 1. If this’s state is not unsent or opened, then throw an "InvalidStateError" DOMException.
     if (m_state != State::Unsent && m_state != State::Opened)
-        return WebIDL::InvalidStateError::create(realm, "XHR readyState is not UNSENT or OPENED");
+        return WebIDL::InvalidStateError::create(realm, "XHR readyState is not UNSENT or OPENED"_fly_string);
 
     // 2. If this’s send() flag is set, then throw an "InvalidStateError" DOMException.
     if (m_send)
-        return WebIDL::InvalidStateError::create(realm, "XHR send() flag is already set");
+        return WebIDL::InvalidStateError::create(realm, "XHR send() flag is already set"_fly_string);
 
     // 3. Set this’s cross-origin credentials to the given value.
     m_cross_origin_credentials = with_credentials;
@@ -1107,15 +1107,15 @@ WebIDL::ExceptionOr<void> XMLHttpRequest::handle_errors()
 
     // 2. If xhr’s timed out flag is set, then run the request error steps for xhr, timeout, and "TimeoutError" DOMException.
     if (m_timed_out)
-        return TRY(request_error_steps(EventNames::timeout, WebIDL::TimeoutError::create(realm(), "Timed out"sv)));
+        return TRY(request_error_steps(EventNames::timeout, WebIDL::TimeoutError::create(realm(), "Timed out"_fly_string)));
 
     // 3. Otherwise, if xhr’s response’s aborted flag is set, run the request error steps for xhr, abort, and "AbortError" DOMException.
     if (m_response->aborted())
-        return TRY(request_error_steps(EventNames::abort, WebIDL::AbortError::create(realm(), "Aborted"sv)));
+        return TRY(request_error_steps(EventNames::abort, WebIDL::AbortError::create(realm(), "Aborted"_fly_string)));
 
     // 4. Otherwise, if xhr’s response is a network error, then run the request error steps for xhr, error, and "NetworkError" DOMException.
     if (m_response->is_network_error())
-        return TRY(request_error_steps(EventNames::error, WebIDL::NetworkError::create(realm(), "Network error"sv)));
+        return TRY(request_error_steps(EventNames::error, WebIDL::NetworkError::create(realm(), "Network error"_fly_string)));
 
     return {};
 }


### PR DESCRIPTION
This ports 8 more interfaces from DeprecatedString to String, leaving only 10 more interfaces left. Relatively straight forward ports, most of this is mechanical changes for DOMException in particular.