### PR TITLE
Ladybird: Add WebContentService for Android port

### DIFF
--- a/Ladybird/Android/src/main/AndroidManifest.xml
+++ b/Ladybird/Android/src/main/AndroidManifest.xml
@@ -1,41 +1,54 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          xmlns:tools="http://schemas.android.com/tools"
-          android:installLocation="auto"
-          android:versionCode="001"
-          android:versionName="head">
-<supports-screens android:anyDensity="true"
-                  android:largeScreens="true"
-                  android:normalScreens="true"
-                  android:smallScreens="true"/>
-<application
+    xmlns:tools="http://schemas.android.com/tools"
+    android:installLocation="auto"
+    android:versionCode="001"
+    android:versionName="head">
+
+    <supports-screens
+        android:anyDensity="true"
+        android:largeScreens="true"
+        android:normalScreens="true"
+        android:smallScreens="true" />
+
+    <uses-permission android:name="com.android.browser.permission.READ_HISTORY_BOOKMARKS" />
+
+    <application
+        android:allowBackup="true"
+        android:allowNativeHeapPointerTagging="false"
         android:dataExtractionRules="@xml/data_extraction_rules"
+        android:enableOnBackInvokedCallback="true"
         android:fullBackupContent="@xml/backup_rules"
+        android:fullBackupOnly="false"
+        android:hardwareAccelerated="true"
         android:icon="@mipmap/ic_launcher"
+        android:label="@string/app_name"
+        android:requestLegacyExternalStorage="true"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.Ladybird"
-        tools:targetApi="33"
-        android:hardwareAccelerated="true"
-        android:label="@string/app_name"
-        android:requestLegacyExternalStorage="true"
-        android:allowNativeHeapPointerTagging="false"
-        android:allowBackup="true"
-        android:fullBackupOnly="false"
-        android:enableOnBackInvokedCallback="true">
-    <activity
+        tools:targetApi="33">
+
+        <activity
             android:name=".LadybirdActivity"
             android:configChanges="orientation|uiMode|screenLayout|screenSize|smallestScreenSize|layoutDirection|locale|fontScale|keyboard|keyboardHidden|navigation|mcc|mnc|density"
+            android:exported="true"
             android:label="@string/app_name"
             android:launchMode="singleTop"
-            android:screenOrientation="unspecified"
-            android:exported="true">
-        <intent-filter>
-            <action android:name="android.intent.action.MAIN" />
-            <category android:name="android.intent.category.LAUNCHER" />
-        </intent-filter>
-        <meta-data android:name="android.app.extract_android_style" android:value="minimal"/>
-    </activity>
-</application>
-<uses-permission android:name="com.android.browser.permission.READ_HISTORY_BOOKMARKS"/>
+            android:screenOrientation="unspecified">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+            <meta-data
+                android:name="android.app.extract_android_style"
+                android:value="minimal" />
+        </activity>
+
+        <service
+            android:name=".WebContentService"
+            android:exported="false"
+            android:process=":WebContent"/>
+    </application>
+
 </manifest>

--- a/Ladybird/Android/src/main/cpp/WebContentService.cpp
+++ b/Ladybird/Android/src/main/cpp/WebContentService.cpp
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2023, Andrew Kaster <akaster@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <android/log.h>
+#include <jni.h>
+#include <unistd.h>
+
+extern "C" JNIEXPORT void JNICALL
+Java_org_serenityos_ladybird_WebContentService_nativeHandleTransferSockets(JNIEnv*, jobject /* thiz */, jint ipc_socket, jint fd_passing_socket)
+{
+    __android_log_print(ANDROID_LOG_INFO, "WebContent", "New binding received, sockets %d and %d", ipc_socket, fd_passing_socket);
+    ::close(ipc_socket);
+    ::close(fd_passing_socket);
+}

--- a/Ladybird/Android/src/main/java/org/serenityos/ladybird/WebContentService.kt
+++ b/Ladybird/Android/src/main/java/org/serenityos/ladybird/WebContentService.kt
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2023, Andrew Kaster <akaster@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+package org.serenityos.ladybird
+
+import android.app.Service
+import android.content.Intent
+import android.util.Log
+import android.os.ParcelFileDescriptor
+import android.os.Handler
+import android.os.IBinder
+import android.os.Message
+import android.os.Messenger
+
+const val MSG_TRANSFER_SOCKETS = 1
+
+class WebContentService : Service() {
+    private val TAG = "WebContentService"
+
+    override fun onCreate() {
+        super.onCreate()
+        Log.i(TAG, "Creating Service")
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        Log.i(TAG, "Destroying Service")
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        Log.i(TAG, "Start command received")
+        return super.onStartCommand(intent, flags, startId)
+    }
+
+    private fun handleTransferSockets(msg: Message) {
+        val bundle = msg.data
+        // FIXME: Handle garbage messages from wierd clients
+        val ipcSocket = bundle.getParcelable<ParcelFileDescriptor>("IPC_SOCKET")!!
+        val fdSocket = bundle.getParcelable<ParcelFileDescriptor>("FD_PASSING_SOCKET")!!
+        nativeHandleTransferSockets(ipcSocket.detachFd(), fdSocket.detachFd())
+    }
+
+    private external fun nativeHandleTransferSockets(ipcSocket: Int, fdPassingSocket: Int)
+
+    internal class IncomingHandler(
+        context: WebContentService,
+        private val owner: WebContentService = context
+    ) : Handler() {
+        override fun handleMessage(msg: Message) {
+            when (msg.what) {
+                MSG_TRANSFER_SOCKETS -> this.owner.handleTransferSockets(msg)
+                else -> super.handleMessage(msg)
+            }
+        }
+    }
+
+    override fun onBind(p0: Intent?): IBinder? {
+        // FIXME: Check the intent to make sure it's legit
+        return Messenger(IncomingHandler(this)).binder
+    }
+
+    companion object {
+        init {
+            System.loadLibrary("webcontent")
+        }
+    }
+}

--- a/Ladybird/Android/src/main/java/org/serenityos/ladybird/WebContentServiceConnection.kt
+++ b/Ladybird/Android/src/main/java/org/serenityos/ladybird/WebContentServiceConnection.kt
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2023, Andrew Kaster <akaster@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+package org.serenityos.ladybird
+
+import android.content.ComponentName
+import android.content.ServiceConnection
+import android.os.IBinder
+import android.os.Message
+import android.os.Messenger
+import android.os.ParcelFileDescriptor
+
+class WebContentServiceConnection(private var ipcFd: Int, private var fdPassingFd: Int) :
+    ServiceConnection {
+    var boundToWebContent: Boolean = false
+    var onDisconnect: () -> Unit = {}
+    private var webContentService: Messenger? = null
+
+    override fun onServiceConnected(className: ComponentName, svc: IBinder) {
+        // This is called when the connection with the service has been
+        // established, giving us the object we can use to
+        // interact with the service.  We are communicating with the
+        // service using a Messenger, so here we get a client-side
+        // representation of that from the raw IBinder object.
+        webContentService = Messenger(svc)
+        boundToWebContent = true
+
+        var msg = Message.obtain(null, MSG_TRANSFER_SOCKETS)
+        msg.data.putParcelable("IPC_SOCKET", ParcelFileDescriptor.adoptFd(ipcFd))
+        msg.data.putParcelable("FD_PASSING_SOCKET", ParcelFileDescriptor.adoptFd(fdPassingFd))
+        webContentService!!.send(msg)
+    }
+
+    override fun onServiceDisconnected(className: ComponentName) {
+        // This is called when the connection with the service has been
+        // unexpectedly disconnected; that is, its process crashed.
+        webContentService = null
+        boundToWebContent = false
+
+        // Notify owner that the service is dead
+        onDisconnect()
+    }
+}

--- a/Ladybird/Android/src/main/java/org/serenityos/ladybird/WebView.kt
+++ b/Ladybird/Android/src/main/java/org/serenityos/ladybird/WebView.kt
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2023, Andrew Kaster <akaster@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
 package org.serenityos.ladybird
 
 import android.content.Context
@@ -8,7 +14,7 @@ import android.view.View
 
 // FIXME: This should (eventually) implement NestedScrollingChild3 and ScrollingView
 class WebView(context: Context, attributeSet: AttributeSet) : View(context, attributeSet) {
-    private val viewImpl = WebViewImplementation()
+    private val viewImpl = WebViewImplementation(context)
     private lateinit var contentBitmap: Bitmap
 
     fun dispose() {

--- a/Ladybird/WebContent/CMakeLists.txt
+++ b/Ladybird/WebContent/CMakeLists.txt
@@ -29,8 +29,11 @@ if (ENABLE_QT)
     target_link_libraries(WebContent PRIVATE Qt::Core Qt::Network Qt::Multimedia)
     target_compile_definitions(WebContent PRIVATE HAVE_QT=1)
 else()
-    # FIXME: Remove when chromes are upstreamed
-    add_library(webcontent STATIC ${WEBCONTENT_SOURCES})
+    set(LIB_TYPE STATIC)
+    if (ANDROID)
+        set(LIB_TYPE SHARED)
+    endif()
+    add_library(webcontent ${LIB_TYPE} ${WEBCONTENT_SOURCES})
     target_include_directories(webcontent PRIVATE ${SERENITY_SOURCE_DIR}/Userland/Services/)
     target_include_directories(webcontent PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/..)
     target_link_libraries(webcontent PRIVATE LibAudio LibCore LibFileSystem LibGfx LibIPC LibJS LibMain LibWeb LibWebSocket LibProtocol LibWebView)
@@ -48,6 +51,11 @@ else()
               ${WEBCONTENT_SOURCE_DIR}/WebContentConsoleClient.h
               ${WEBCONTENT_SOURCE_DIR}/WebDriverConnection.h
     )
+
+    if (ANDROID)
+        target_sources(webcontent PRIVATE ../Android/src/main/cpp/WebContentService.cpp)
+        target_link_libraries(webcontent PRIVATE log)
+    endif()
 
     add_executable(WebContent main.cpp)
     target_link_libraries(WebContent PRIVATE webcontent)

--- a/Ladybird/cmake/InstallRules.cmake
+++ b/Ladybird/cmake/InstallRules.cmake
@@ -38,7 +38,10 @@ list(REMOVE_ITEM all_required_lagom_libraries ladybird)
 
 # Install webcontent impl library if it exists
 if (TARGET webcontent)
-  list(APPEND all_required_lagom_libraries webcontent)
+  get_target_property(target_type webcontent TYPE)
+  if ("${target_type}" STREQUAL STATIC_LIBRARY)
+      list(APPEND all_required_lagom_libraries webcontent)
+  endif()
 endif()
 
 install(TARGETS ${all_required_lagom_libraries}


### PR DESCRIPTION
This will let us spawn a new process for an Android Service to handle all our WebContent needs. The ServiceConnection is manged by each WebView. The lifecycle of the Service is not quite clear yet, but each bindService call will get a unique Messenger that can be used to transfer the WebContent side of the LibIPC socketpair we use in other ports.