### PR TITLE
LibWeb+WebContent: Set ConsoleClient for nested browsing contexts

### DIFF
--- a/Userland/Libraries/LibWeb/Loader/FrameLoader.cpp
+++ b/Userland/Libraries/LibWeb/Loader/FrameLoader.cpp
@@ -325,7 +325,7 @@ void FrameLoader::resource_did_load()
 
     browsing_context().set_active_document(document);
     if (auto* page = browsing_context().page())
-        page->client().page_did_create_main_document();
+        page->client().page_did_create_new_document(*document);
 
     if (!parse_document(*document, resource()->encoded_data())) {
         load_error_page(url, "Failed to parse content.");

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -200,7 +200,7 @@ public:
     virtual Gfx::IntRect page_did_request_minimize_window() { return {}; }
     virtual Gfx::IntRect page_did_request_fullscreen_window() { return {}; }
     virtual void page_did_start_loading(const AK::URL&, bool is_redirect) { (void)is_redirect; }
-    virtual void page_did_create_main_document() { }
+    virtual void page_did_create_new_document(Web::DOM::Document&) { }
     virtual void page_did_finish_loading(const AK::URL&) { }
     virtual void page_did_change_selection() { }
     virtual void page_did_request_cursor_change(Gfx::StandardCursor) { }

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -601,16 +601,16 @@ Messages::WebContentServer::GetHoveredNodeIdResponse ConnectionFromClient::get_h
     return (i32)0;
 }
 
-void ConnectionFromClient::initialize_js_console(Badge<PageHost>)
+void ConnectionFromClient::initialize_js_console(Badge<PageHost>, Web::DOM::Document& document)
 {
-    auto* document = page().top_level_browsing_context().active_document();
-    auto realm = document->realm().make_weak_ptr();
+    auto realm = document.realm().make_weak_ptr();
     if (m_realm.ptr() == realm.ptr())
         return;
 
     auto console_object = realm->intrinsics().console_object();
     m_realm = realm;
-    m_console_client = make<WebContentConsoleClient>(console_object->console(), *m_realm, *this);
+    if (!m_console_client)
+        m_console_client = make<WebContentConsoleClient>(console_object->console(), *m_realm, *this);
     console_object->console().set_client(*m_console_client.ptr());
 }
 

--- a/Userland/Services/WebContent/ConnectionFromClient.h
+++ b/Userland/Services/WebContent/ConnectionFromClient.h
@@ -33,7 +33,7 @@ public:
 
     virtual void die() override;
 
-    void initialize_js_console(Badge<PageHost>);
+    void initialize_js_console(Badge<PageHost>, Web::DOM::Document& document);
 
     void request_file(Web::FileRequest);
 

--- a/Userland/Services/WebContent/PageHost.cpp
+++ b/Userland/Services/WebContent/PageHost.cpp
@@ -281,9 +281,9 @@ void PageHost::page_did_start_loading(const URL& url, bool is_redirect)
     m_client.async_did_start_loading(url, is_redirect);
 }
 
-void PageHost::page_did_create_main_document()
+void PageHost::page_did_create_new_document(Web::DOM::Document& document)
 {
-    m_client.initialize_js_console({});
+    m_client.initialize_js_console({}, document);
 }
 
 void PageHost::page_did_finish_loading(const URL& url)

--- a/Userland/Services/WebContent/PageHost.h
+++ b/Userland/Services/WebContent/PageHost.h
@@ -93,7 +93,7 @@ private:
     virtual void page_did_request_image_context_menu(Web::CSSPixelPoint, const URL&, DeprecatedString const& target, unsigned modifiers, Gfx::Bitmap const*) override;
     virtual void page_did_request_media_context_menu(Web::CSSPixelPoint, DeprecatedString const& target, unsigned modifiers, Web::Page::MediaContextMenu) override;
     virtual void page_did_start_loading(const URL&, bool) override;
-    virtual void page_did_create_main_document() override;
+    virtual void page_did_create_new_document(Web::DOM::Document&) override;
     virtual void page_did_finish_loading(const URL&) override;
     virtual void page_did_request_alert(String const&) override;
     virtual void page_did_request_confirm(String const&) override;


### PR DESCRIPTION
Before page_did_create_main_document() only initialized ConsoleClient for top-level browsing context which means that nested browsing context could not print into the console.

With this change, ConsoleClient is initialized for documents created for nested browsing context too. One ConsoleClient is shared between all browsing contexts within the same page.