### PR TITLE
Ladybird: Move host build into its own shell script 

### DIFF
--- a/Ladybird/Android/BuildLagomTools.sh
+++ b/Ladybird/Android/BuildLagomTools.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+SERENITY_ROOT="$(realpath "${DIR}"/../..)"
+
+# shellcheck source=/dev/null
+. "${SERENITY_ROOT}/Meta/shell_include.sh"
+
+# shellcheck source=/dev/null
+. "${SERENITY_ROOT}/Meta/find_compiler.sh"
+
+pick_host_compiler
+
+BUILD_DIR=${BUILD_DIR:-"${SERENITY_ROOT}/Build"}
+CACHE_DIR=${CACHE_DIR:-"${BUILD_DIR}/caches"}
+
+cmake -S "$SERENITY_ROOT/Meta/Lagom" -B "$BUILD_DIR/lagom-tools" \
+    -GNinja -Dpackage=LagomTools \
+    -DCMAKE_INSTALL_PREFIX="$BUILD_DIR/lagom-tools-install"  \
+    -DCMAKE_C_COMPILER="$CC" \
+    -DCMAKE_CXX_COMPILER="$CXX" \
+    -DSERENITY_CACHE_DIR="$CACHE_DIR"
+
+ninja -C "$BUILD_DIR/lagom-tools" install

--- a/Ladybird/Android/build.gradle.kts
+++ b/Ladybird/Android/build.gradle.kts
@@ -7,12 +7,13 @@ plugins {
 
 var cacheDir = System.getenv("SERENITY_CACHE_DIR") ?: "$buildDir/caches"
 
-// FIXME: Move this somewhere nicer, with better behavior (like controlling host compiler)
 task<Exec>("buildLagomTools") {
-    commandLine = listOf("sh", "-c", "cmake -S ../../Meta/Lagom -B $buildDir/lagom-tools " +
-        " -Dpackage=LagomTools -DCMAKE_INSTALL_PREFIX=$buildDir/lagom-tools-install -GNinja" +
-        " -DSERENITY_CACHE_DIR=$cacheDir;" +
-        " ninja -C $buildDir/lagom-tools install")
+    commandLine = listOf("./BuildLagomTools.sh")
+    environment = mapOf(
+        "BUILD_DIR" to "$buildDir",
+        "CACHE_DIR" to "$cacheDir",
+        "PATH" to System.getenv("PATH")!!
+    )
 }
 tasks.named("preBuild").dependsOn("buildLagomTools")
 
@@ -47,7 +48,10 @@ android {
     buildTypes {
         release {
             isMinifyEnabled = false
-            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
         }
     }
     compileOptions {

--- a/Meta/find_compiler.sh
+++ b/Meta/find_compiler.sh
@@ -1,0 +1,78 @@
+# shellcheck shell=bash
+
+HOST_COMPILER=""
+
+is_supported_compiler() {
+    local COMPILER="$1"
+    if [ -z "$COMPILER" ]; then
+        return 1
+    fi
+
+    local VERSION=""
+    VERSION="$($COMPILER -dumpversion)" || return 1
+    local MAJOR_VERSION=""
+    MAJOR_VERSION="${VERSION%%.*}"
+    if $COMPILER --version 2>&1 | grep "Apple clang" >/dev/null; then
+        # Apple Clang version check
+        BUILD_VERSION=$(echo | $COMPILER -dM -E - | grep __apple_build_version__ | cut -d ' ' -f3)
+        # Xcode 14.3, based on upstream LLVM 15
+        [ "$BUILD_VERSION" -ge 14030022 ] && return 0
+    elif $COMPILER --version 2>&1 | grep "clang" >/dev/null; then
+        # Clang version check
+        [ "$MAJOR_VERSION" -ge 15 ] && return 0
+    else
+        # GCC version check
+        [ "$MAJOR_VERSION" -ge 12 ] && return 0
+    fi
+    return 1
+}
+
+find_newest_compiler() {
+    local BEST_VERSION=0
+    local BEST_CANDIDATE=""
+    for CANDIDATE in "$@"; do
+        if ! command -v "$CANDIDATE" >/dev/null 2>&1; then
+            continue
+        fi
+        if ! $CANDIDATE -dumpversion >/dev/null 2>&1; then
+            continue
+        fi
+        local VERSION=""
+        VERSION="$($CANDIDATE -dumpversion)"
+        local MAJOR_VERSION="${VERSION%%.*}"
+        if [ "$MAJOR_VERSION" -gt "$BEST_VERSION" ]; then
+            BEST_VERSION=$MAJOR_VERSION
+            BEST_CANDIDATE="$CANDIDATE"
+        fi
+    done
+    HOST_COMPILER=$BEST_CANDIDATE
+}
+
+pick_host_compiler() {
+    CC=${CC:-"cc"}
+    CXX=${CXX:-"cxx"}
+
+    if is_supported_compiler "$CC" && is_supported_compiler "$CXX"; then
+        return
+    fi
+
+    find_newest_compiler clang clang-15 clang-16 /opt/homebrew/opt/llvm/bin/clang
+    if is_supported_compiler "$HOST_COMPILER"; then
+        export CC="${HOST_COMPILER}"
+        export CXX="${HOST_COMPILER/clang/clang++}"
+        return
+    fi
+
+    find_newest_compiler egcc gcc gcc-12 gcc-13 /usr/local/bin/gcc-{12,13} /opt/homebrew/bin/gcc-{12,13}
+    if is_supported_compiler "$HOST_COMPILER"; then
+        export CC="${HOST_COMPILER}"
+        export CXX="${HOST_COMPILER/gcc/g++}"
+        return
+    fi
+
+    if [ "$(uname -s)" = "Darwin" ]; then
+        die "Please make sure that Xcode 14.3, Homebrew Clang 15, or higher is installed."
+    else
+        die "Please make sure that GCC version 12, Clang version 15, or higher is installed."
+    fi
+}

--- a/Meta/serenity.sh
+++ b/Meta/serenity.sh
@@ -86,6 +86,9 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 exit_if_running_as_root "Do not run serenity.sh as root, your Build directory will become root-owned"
 
+# shellcheck source=/dev/null
+. "${DIR}/find_compiler.sh"
+
 if [ -n "$1" ]; then
     TARGET="$1"; shift
 else
@@ -93,7 +96,6 @@ else
 fi
 
 CMAKE_ARGS=()
-HOST_COMPILER=""
 
 # Toolchain selection only applies to non-lagom targets.
 if [ "$TARGET" != "lagom" ] && [ -n "$1" ]; then
@@ -150,78 +152,6 @@ create_build_dir() {
         cmake -GNinja "${CMAKE_ARGS[@]}" -S "$SERENITY_SOURCE_DIR/Meta/CMake/Superbuild" -B "$SUPER_BUILD_DIR"
     else
         cmake -GNinja "${CMAKE_ARGS[@]}" -S "$SERENITY_SOURCE_DIR/Meta/Lagom" -B "$SUPER_BUILD_DIR"
-    fi
-}
-
-is_supported_compiler() {
-    local COMPILER="$1"
-    if [ -z "$COMPILER" ]; then
-        return 1
-    fi
-
-    local VERSION=""
-    VERSION="$($COMPILER -dumpversion)" || return 1
-    local MAJOR_VERSION=""
-    MAJOR_VERSION="${VERSION%%.*}"
-    if $COMPILER --version 2>&1 | grep "Apple clang" >/dev/null; then
-        # Apple Clang version check
-        BUILD_VERSION=$(echo | $COMPILER -dM -E - | grep __apple_build_version__ | cut -d ' ' -f3)
-        # Xcode 14.3, based on upstream LLVM 15
-        [ "$BUILD_VERSION" -ge 14030022 ] && return 0
-    elif $COMPILER --version 2>&1 | grep "clang" >/dev/null; then
-        # Clang version check
-        [ "$MAJOR_VERSION" -ge 15 ] && return 0
-    else
-        # GCC version check
-        [ "$MAJOR_VERSION" -ge 12 ] && return 0
-    fi
-    return 1
-}
-
-find_newest_compiler() {
-    local BEST_VERSION=0
-    local BEST_CANDIDATE=""
-    for CANDIDATE in "$@"; do
-        if ! command -v "$CANDIDATE" >/dev/null 2>&1; then
-            continue
-        fi
-        if ! $CANDIDATE -dumpversion >/dev/null 2>&1; then
-            continue
-        fi
-        local VERSION=""
-        VERSION="$($CANDIDATE -dumpversion)"
-        local MAJOR_VERSION="${VERSION%%.*}"
-        if [ "$MAJOR_VERSION" -gt "$BEST_VERSION" ]; then
-            BEST_VERSION=$MAJOR_VERSION
-            BEST_CANDIDATE="$CANDIDATE"
-        fi
-    done
-    HOST_COMPILER=$BEST_CANDIDATE
-}
-
-pick_host_compiler() {
-    if is_supported_compiler "$CC" && is_supported_compiler "$CXX"; then
-        return
-    fi
-
-    find_newest_compiler clang clang-15 clang-16 /opt/homebrew/opt/llvm/bin/clang
-    if is_supported_compiler "$HOST_COMPILER"; then
-        export CC="${HOST_COMPILER}"
-        export CXX="${HOST_COMPILER/clang/clang++}"
-        return
-    fi
-
-    find_newest_compiler egcc gcc gcc-12 gcc-13 /usr/local/bin/gcc-{12,13} /opt/homebrew/bin/gcc-{12,13}
-    if is_supported_compiler "$HOST_COMPILER"; then
-        export CC="${HOST_COMPILER}"
-        export CXX="${HOST_COMPILER/gcc/g++}"
-        return
-    fi
-
-    if [ "$(uname -s)" = "Darwin" ]; then
-        die "Please make sure that Xcode 14.3, Homebrew Clang 15, or higher is installed."
-    else
-        die "Please make sure that GCC version 12, Clang version 15, or higher is installed."
     fi
 }
 


### PR DESCRIPTION
This lets us select a proper host compiler version if cc/cxx are not
suitable for building Lagom.