### PR TITLE
LibWeb: Add MouseEvent screenX,Y, modifier keys and follow spec more

### DIFF
--- a/Base/res/html/misc/mouse-events.html
+++ b/Base/res/html/misc/mouse-events.html
@@ -10,7 +10,7 @@
 <script>
 function handle(e) {
     var out = document.getElementById('out');
-    out.innerHTML = `${e.type} | client: ${e.clientX}x${e.y} | screen: ${e.screenX}x${e.screenY}\n${out.innerHTML}`;
+    out.innerHTML = `${e.type} | client: ${e.clientX}x${e.y} | screen: ${e.screenX}x${e.screenY} | ${e.ctrlKey ? 'CTRL' : ''} ${e.shiftKey ? 'Shift' : ''} ${e.altKey ? 'Alt' : ''}\n${out.innerHTML}`;
 }
 
 var rect = document.getElementById('rect');

--- a/Base/res/html/misc/mouse-events.html
+++ b/Base/res/html/misc/mouse-events.html
@@ -10,7 +10,7 @@
 <script>
 function handle(e) {
     var out = document.getElementById('out');
-    out.innerHTML = e.type + ' @ ' + e.offsetX + ',' + e.y + '\n' + out.innerHTML;
+    out.innerHTML = `${e.type} | client: ${e.clientX}x${e.y} | screen: ${e.screenX}x${e.screenY}\n${out.innerHTML}`;
 }
 
 var rect = document.getElementById('rect');

--- a/Ladybird/AppKit/UI/Event.h
+++ b/Ladybird/AppKit/UI/Event.h
@@ -16,6 +16,7 @@ namespace Ladybird {
 
 struct MouseEvent {
     Gfx::IntPoint position {};
+    Gfx::IntPoint screen_position {};
     GUI::MouseButton button { GUI::MouseButton::Primary };
     KeyModifier modifiers { KeyModifier::Mod_None };
 };

--- a/Ladybird/AppKit/UI/Event.mm
+++ b/Ladybird/AppKit/UI/Event.mm
@@ -39,9 +39,10 @@ static KeyModifier ns_modifiers_to_key_modifiers(NSEventModifierFlags modifier_f
 MouseEvent ns_event_to_mouse_event(NSEvent* event, NSView* view, GUI::MouseButton button)
 {
     auto position = [view convertPoint:event.locationInWindow fromView:nil];
+    auto screen_position = [NSEvent mouseLocation];
     auto modifiers = ns_modifiers_to_key_modifiers(event.modifierFlags, button);
 
-    return { ns_point_to_gfx_point(position), button, modifiers };
+    return { ns_point_to_gfx_point(position), ns_point_to_gfx_point(screen_position), button, modifiers };
 }
 
 NSEvent* create_context_menu_mouse_event(NSView* view, Gfx::IntPoint position)

--- a/Ladybird/AppKit/UI/LadybirdWebView.mm
+++ b/Ladybird/AppKit/UI/LadybirdWebView.mm
@@ -906,58 +906,58 @@ static void copy_text_to_clipboard(StringView text)
 
 - (void)mouseMoved:(NSEvent*)event
 {
-    auto [position, button, modifiers] = Ladybird::ns_event_to_mouse_event(event, self, GUI::MouseButton::None);
-    m_web_view_bridge->mouse_move_event(position, button, modifiers);
+    auto [position, screen_position, button, modifiers] = Ladybird::ns_event_to_mouse_event(event, self, GUI::MouseButton::None);
+    m_web_view_bridge->mouse_move_event(position, screen_position, button, modifiers);
 }
 
 - (void)mouseDown:(NSEvent*)event
 {
     [[self window] makeFirstResponder:self];
 
-    auto [position, button, modifiers] = Ladybird::ns_event_to_mouse_event(event, self, GUI::MouseButton::Primary);
+    auto [position, screen_position, button, modifiers] = Ladybird::ns_event_to_mouse_event(event, self, GUI::MouseButton::Primary);
 
     if (event.clickCount % 2 == 0) {
-        m_web_view_bridge->mouse_double_click_event(position, button, modifiers);
+        m_web_view_bridge->mouse_double_click_event(position, screen_position, button, modifiers);
     } else {
-        m_web_view_bridge->mouse_down_event(position, button, modifiers);
+        m_web_view_bridge->mouse_down_event(position, screen_position, button, modifiers);
     }
 }
 
 - (void)mouseUp:(NSEvent*)event
 {
-    auto [position, button, modifiers] = Ladybird::ns_event_to_mouse_event(event, self, GUI::MouseButton::Primary);
-    m_web_view_bridge->mouse_up_event(position, button, modifiers);
+    auto [position, screen_position, button, modifiers] = Ladybird::ns_event_to_mouse_event(event, self, GUI::MouseButton::Primary);
+    m_web_view_bridge->mouse_up_event(position, screen_position, button, modifiers);
 }
 
 - (void)mouseDragged:(NSEvent*)event
 {
-    auto [position, button, modifiers] = Ladybird::ns_event_to_mouse_event(event, self, GUI::MouseButton::Primary);
-    m_web_view_bridge->mouse_move_event(position, button, modifiers);
+    auto [position, screen_position, button, modifiers] = Ladybird::ns_event_to_mouse_event(event, self, GUI::MouseButton::Primary);
+    m_web_view_bridge->mouse_move_event(position, screen_position, button, modifiers);
 }
 
 - (void)rightMouseDown:(NSEvent*)event
 {
     [[self window] makeFirstResponder:self];
 
-    auto [position, button, modifiers] = Ladybird::ns_event_to_mouse_event(event, self, GUI::MouseButton::Secondary);
+    auto [position, screen_position, button, modifiers] = Ladybird::ns_event_to_mouse_event(event, self, GUI::MouseButton::Secondary);
 
     if (event.clickCount % 2 == 0) {
-        m_web_view_bridge->mouse_double_click_event(position, button, modifiers);
+        m_web_view_bridge->mouse_double_click_event(position, screen_position, button, modifiers);
     } else {
-        m_web_view_bridge->mouse_down_event(position, button, modifiers);
+        m_web_view_bridge->mouse_down_event(position, screen_position, button, modifiers);
     }
 }
 
 - (void)rightMouseUp:(NSEvent*)event
 {
-    auto [position, button, modifiers] = Ladybird::ns_event_to_mouse_event(event, self, GUI::MouseButton::Secondary);
-    m_web_view_bridge->mouse_up_event(position, button, modifiers);
+    auto [position, screen_position, button, modifiers] = Ladybird::ns_event_to_mouse_event(event, self, GUI::MouseButton::Secondary);
+    m_web_view_bridge->mouse_up_event(position, screen_position, button, modifiers);
 }
 
 - (void)rightMouseDragged:(NSEvent*)event
 {
-    auto [position, button, modifiers] = Ladybird::ns_event_to_mouse_event(event, self, GUI::MouseButton::Secondary);
-    m_web_view_bridge->mouse_move_event(position, button, modifiers);
+    auto [position, screen_position, button, modifiers] = Ladybird::ns_event_to_mouse_event(event, self, GUI::MouseButton::Secondary);
+    m_web_view_bridge->mouse_move_event(position, screen_position, button, modifiers);
 }
 
 - (void)keyDown:(NSEvent*)event

--- a/Ladybird/AppKit/UI/LadybirdWebViewBridge.cpp
+++ b/Ladybird/AppKit/UI/LadybirdWebViewBridge.cpp
@@ -100,24 +100,24 @@ void WebViewBridge::set_preferred_color_scheme(Web::CSS::PreferredColorScheme co
     client().async_set_preferred_color_scheme(color_scheme);
 }
 
-void WebViewBridge::mouse_down_event(Gfx::IntPoint position, GUI::MouseButton button, KeyModifier modifiers)
+void WebViewBridge::mouse_down_event(Gfx::IntPoint position, Gfx::IntPoint screen_position, GUI::MouseButton button, KeyModifier modifiers)
 {
-    client().async_mouse_down(to_content_position(position), to_underlying(button), to_underlying(button), modifiers);
+    client().async_mouse_down(to_content_position(position), screen_position, to_underlying(button), to_underlying(button), modifiers);
 }
 
-void WebViewBridge::mouse_up_event(Gfx::IntPoint position, GUI::MouseButton button, KeyModifier modifiers)
+void WebViewBridge::mouse_up_event(Gfx::IntPoint position, Gfx::IntPoint screen_position, GUI::MouseButton button, KeyModifier modifiers)
 {
-    client().async_mouse_up(to_content_position(position), to_underlying(button), to_underlying(button), modifiers);
+    client().async_mouse_up(to_content_position(position), screen_position, to_underlying(button), to_underlying(button), modifiers);
 }
 
-void WebViewBridge::mouse_move_event(Gfx::IntPoint position, GUI::MouseButton button, KeyModifier modifiers)
+void WebViewBridge::mouse_move_event(Gfx::IntPoint position, Gfx::IntPoint screen_position, GUI::MouseButton button, KeyModifier modifiers)
 {
-    client().async_mouse_move(to_content_position(position), 0, to_underlying(button), modifiers);
+    client().async_mouse_move(to_content_position(position), screen_position, 0, to_underlying(button), modifiers);
 }
 
-void WebViewBridge::mouse_double_click_event(Gfx::IntPoint position, GUI::MouseButton button, KeyModifier modifiers)
+void WebViewBridge::mouse_double_click_event(Gfx::IntPoint position, Gfx::IntPoint screen_position, GUI::MouseButton button, KeyModifier modifiers)
 {
-    client().async_doubleclick(to_content_position(position), button, to_underlying(button), modifiers);
+    client().async_doubleclick(to_content_position(position), screen_position, button, to_underlying(button), modifiers);
 }
 
 void WebViewBridge::key_down_event(KeyCode key_code, KeyModifier modifiers, u32 code_point)

--- a/Ladybird/AppKit/UI/LadybirdWebViewBridge.h
+++ b/Ladybird/AppKit/UI/LadybirdWebViewBridge.h
@@ -39,10 +39,10 @@ public:
     void update_palette();
     void set_preferred_color_scheme(Web::CSS::PreferredColorScheme);
 
-    void mouse_down_event(Gfx::IntPoint, GUI::MouseButton, KeyModifier);
-    void mouse_up_event(Gfx::IntPoint, GUI::MouseButton, KeyModifier);
-    void mouse_move_event(Gfx::IntPoint, GUI::MouseButton, KeyModifier);
-    void mouse_double_click_event(Gfx::IntPoint, GUI::MouseButton, KeyModifier);
+    void mouse_down_event(Gfx::IntPoint, Gfx::IntPoint, GUI::MouseButton, KeyModifier);
+    void mouse_up_event(Gfx::IntPoint, Gfx::IntPoint, GUI::MouseButton, KeyModifier);
+    void mouse_move_event(Gfx::IntPoint, Gfx::IntPoint, GUI::MouseButton, KeyModifier);
+    void mouse_double_click_event(Gfx::IntPoint, Gfx::IntPoint, GUI::MouseButton, KeyModifier);
 
     void key_down_event(KeyCode, KeyModifier, u32);
     void key_up_event(KeyCode, KeyModifier, u32);

--- a/Ladybird/Qt/WebContentView.cpp
+++ b/Ladybird/Qt/WebContentView.cpp
@@ -325,13 +325,14 @@ void WebContentView::wheelEvent(QWheelEvent* event)
 {
     if (!event->modifiers().testFlag(Qt::ControlModifier)) {
         Gfx::IntPoint position(event->position().x() / m_inverse_pixel_scaling_ratio, event->position().y() / m_inverse_pixel_scaling_ratio);
+        Gfx::IntPoint screen_position(event->globalPosition().x() / m_inverse_pixel_scaling_ratio, event->globalPosition().y() / m_inverse_pixel_scaling_ratio);
         auto button = get_button_from_qt_event(*event);
         auto buttons = get_buttons_from_qt_event(*event);
         auto modifiers = get_modifiers_from_qt_mouse_event(*event);
 
         auto num_pixels = -event->pixelDelta();
         if (!num_pixels.isNull()) {
-            client().async_mouse_wheel(to_content_position(position), button, buttons, modifiers, num_pixels.x(), num_pixels.y());
+            client().async_mouse_wheel(to_content_position(position), screen_position, button, buttons, modifiers, num_pixels.x(), num_pixels.y());
         } else {
             auto num_degrees = -event->angleDelta();
             float delta_x = -num_degrees.x() / 120;
@@ -339,7 +340,7 @@ void WebContentView::wheelEvent(QWheelEvent* event)
             auto step_x = delta_x * QApplication::wheelScrollLines() * devicePixelRatio();
             auto step_y = delta_y * QApplication::wheelScrollLines() * devicePixelRatio();
             int scroll_step_size = verticalScrollBar()->singleStep();
-            client().async_mouse_wheel(to_content_position(position), button, buttons, modifiers, step_x * scroll_step_size, step_y * scroll_step_size);
+            client().async_mouse_wheel(to_content_position(position), screen_position, button, buttons, modifiers, step_x * scroll_step_size, step_y * scroll_step_size);
         }
         event->accept();
         return;
@@ -350,14 +351,16 @@ void WebContentView::wheelEvent(QWheelEvent* event)
 void WebContentView::mouseMoveEvent(QMouseEvent* event)
 {
     Gfx::IntPoint position(event->position().x() / m_inverse_pixel_scaling_ratio, event->position().y() / m_inverse_pixel_scaling_ratio);
+    Gfx::IntPoint screen_position(event->globalPosition().x() / m_inverse_pixel_scaling_ratio, event->globalPosition().y() / m_inverse_pixel_scaling_ratio);
     auto buttons = get_buttons_from_qt_event(*event);
     auto modifiers = get_modifiers_from_qt_mouse_event(*event);
-    client().async_mouse_move(to_content_position(position), 0, buttons, modifiers);
+    client().async_mouse_move(to_content_position(position), screen_position, 0, buttons, modifiers);
 }
 
 void WebContentView::mousePressEvent(QMouseEvent* event)
 {
     Gfx::IntPoint position(event->position().x() / m_inverse_pixel_scaling_ratio, event->position().y() / m_inverse_pixel_scaling_ratio);
+    Gfx::IntPoint screen_position(event->globalPosition().x() / m_inverse_pixel_scaling_ratio, event->globalPosition().y() / m_inverse_pixel_scaling_ratio);
     auto button = get_button_from_qt_event(*event);
     if (button == 0) {
         // We could not convert Qt buttons to something that Lagom can
@@ -367,12 +370,13 @@ void WebContentView::mousePressEvent(QMouseEvent* event)
     }
     auto modifiers = get_modifiers_from_qt_mouse_event(*event);
     auto buttons = get_buttons_from_qt_event(*event);
-    client().async_mouse_down(to_content_position(position), button, buttons, modifiers);
+    client().async_mouse_down(to_content_position(position), screen_position, button, buttons, modifiers);
 }
 
 void WebContentView::mouseReleaseEvent(QMouseEvent* event)
 {
     Gfx::IntPoint position(event->position().x() / m_inverse_pixel_scaling_ratio, event->position().y() / m_inverse_pixel_scaling_ratio);
+    Gfx::IntPoint screen_position(event->globalPosition().x() / m_inverse_pixel_scaling_ratio, event->globalPosition().y() / m_inverse_pixel_scaling_ratio);
     auto button = get_button_from_qt_event(*event);
 
     if (event->button() & Qt::MouseButton::BackButton) {
@@ -391,12 +395,13 @@ void WebContentView::mouseReleaseEvent(QMouseEvent* event)
     }
     auto modifiers = get_modifiers_from_qt_mouse_event(*event);
     auto buttons = get_buttons_from_qt_event(*event);
-    client().async_mouse_up(to_content_position(position), button, buttons, modifiers);
+    client().async_mouse_up(to_content_position(position), screen_position, button, buttons, modifiers);
 }
 
 void WebContentView::mouseDoubleClickEvent(QMouseEvent* event)
 {
     Gfx::IntPoint position(event->position().x() / m_inverse_pixel_scaling_ratio, event->position().y() / m_inverse_pixel_scaling_ratio);
+    Gfx::IntPoint screen_position(event->globalPosition().x() / m_inverse_pixel_scaling_ratio, event->globalPosition().y() / m_inverse_pixel_scaling_ratio);
     auto button = get_button_from_qt_event(*event);
     if (button == 0) {
         // We could not convert Qt buttons to something that Lagom can
@@ -406,7 +411,7 @@ void WebContentView::mouseDoubleClickEvent(QMouseEvent* event)
     }
     auto modifiers = get_modifiers_from_qt_mouse_event(*event);
     auto buttons = get_buttons_from_qt_event(*event);
-    client().async_doubleclick(to_content_position(position), button, buttons, modifiers);
+    client().async_doubleclick(to_content_position(position), screen_position, button, buttons, modifiers);
 }
 
 void WebContentView::dragEnterEvent(QDragEnterEvent* event)

--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -187,7 +187,9 @@ bool EventHandler::handle_mousewheel(CSSPixelPoint position, unsigned button, un
                 return false;
 
             auto offset = compute_mouse_event_offset(position, *layout_node);
-            if (node->dispatch_event(UIEvents::WheelEvent::create_from_platform_event(node->realm(), UIEvents::EventNames::wheel, offset.x(), offset.y(), position.x(), position.y(), wheel_delta_x, wheel_delta_y, buttons, button).release_value_but_fixme_should_propagate_errors())) {
+            auto client_offset = compute_mouse_event_client_offset(position);
+            auto page_offset = compute_mouse_event_page_offset(client_offset);
+            if (node->dispatch_event(UIEvents::WheelEvent::create_from_platform_event(node->realm(), UIEvents::EventNames::wheel, page_offset, client_offset, offset, wheel_delta_x, wheel_delta_y, button, buttons).release_value_but_fixme_should_propagate_errors())) {
                 if (auto* page = m_browsing_context->page()) {
                     if (m_browsing_context == &page->top_level_browsing_context())
                         page->client().page_did_request_scroll(wheel_delta_x, wheel_delta_y);
@@ -248,15 +250,15 @@ bool EventHandler::handle_mouseup(CSSPixelPoint position, unsigned button, unsig
             auto offset = compute_mouse_event_offset(position, *layout_node);
             auto client_offset = compute_mouse_event_client_offset(position);
             auto page_offset = compute_mouse_event_page_offset(client_offset);
-            node->dispatch_event(UIEvents::MouseEvent::create_from_platform_event(node->realm(), UIEvents::EventNames::mouseup, offset, client_offset, page_offset, {}, buttons, button).release_value_but_fixme_should_propagate_errors());
+            node->dispatch_event(UIEvents::MouseEvent::create_from_platform_event(node->realm(), UIEvents::EventNames::mouseup, page_offset, client_offset, offset, {}, button, buttons).release_value_but_fixme_should_propagate_errors());
             handled_event = true;
 
             bool run_activation_behavior = false;
             if (node.ptr() == m_mousedown_target) {
                 if (button == GUI::MouseButton::Primary)
-                    run_activation_behavior = node->dispatch_event(UIEvents::MouseEvent::create_from_platform_event(node->realm(), UIEvents::EventNames::click, offset, client_offset, page_offset, {}, button).release_value_but_fixme_should_propagate_errors());
+                    run_activation_behavior = node->dispatch_event(UIEvents::MouseEvent::create_from_platform_event(node->realm(), UIEvents::EventNames::click, page_offset, client_offset, offset, {}, 1, button).release_value_but_fixme_should_propagate_errors());
                 else if (button == GUI::MouseButton::Secondary && !(modifiers & Mod_Shift)) // Allow the user to bypass custom context menus by holding shift, like Firefox.
-                    run_activation_behavior = node->dispatch_event(UIEvents::MouseEvent::create_from_platform_event(node->realm(), UIEvents::EventNames::contextmenu, offset, client_offset, page_offset, {}, button).release_value_but_fixme_should_propagate_errors());
+                    run_activation_behavior = node->dispatch_event(UIEvents::MouseEvent::create_from_platform_event(node->realm(), UIEvents::EventNames::contextmenu, page_offset, client_offset, offset, {}, 1, button).release_value_but_fixme_should_propagate_errors());
             }
 
             if (run_activation_behavior) {
@@ -384,7 +386,7 @@ bool EventHandler::handle_mousedown(CSSPixelPoint position, unsigned button, uns
         auto offset = compute_mouse_event_offset(position, *layout_node);
         auto client_offset = compute_mouse_event_client_offset(position);
         auto page_offset = compute_mouse_event_page_offset(client_offset);
-        node->dispatch_event(UIEvents::MouseEvent::create_from_platform_event(node->realm(), UIEvents::EventNames::mousedown, offset, client_offset, page_offset, {}, buttons, button).release_value_but_fixme_should_propagate_errors());
+        node->dispatch_event(UIEvents::MouseEvent::create_from_platform_event(node->realm(), UIEvents::EventNames::mousedown, page_offset, client_offset, offset, {}, button, buttons).release_value_but_fixme_should_propagate_errors());
     }
 
     // NOTE: Dispatching an event may have disturbed the world.
@@ -498,7 +500,7 @@ bool EventHandler::handle_mousemove(CSSPixelPoint position, unsigned buttons, un
             auto client_offset = compute_mouse_event_client_offset(position);
             auto page_offset = compute_mouse_event_page_offset(client_offset);
             auto movement = compute_mouse_event_movement(client_offset);
-            node->dispatch_event(UIEvents::MouseEvent::create_from_platform_event(node->realm(), UIEvents::EventNames::mousemove, offset, client_offset, page_offset, movement, buttons).release_value_but_fixme_should_propagate_errors());
+            node->dispatch_event(UIEvents::MouseEvent::create_from_platform_event(node->realm(), UIEvents::EventNames::mousemove, page_offset, client_offset, offset, movement, 1, buttons).release_value_but_fixme_should_propagate_errors());
             m_mousemove_previous_client_offset = client_offset;
             // NOTE: Dispatching an event may have disturbed the world.
             if (!paint_root() || paint_root() != node->document().paintable_box())
@@ -584,7 +586,7 @@ bool EventHandler::handle_doubleclick(CSSPixelPoint position, unsigned button, u
     auto offset = compute_mouse_event_offset(position, *layout_node);
     auto client_offset = compute_mouse_event_client_offset(position);
     auto page_offset = compute_mouse_event_page_offset(client_offset);
-    node->dispatch_event(UIEvents::MouseEvent::create_from_platform_event(node->realm(), UIEvents::EventNames::dblclick, offset, client_offset, page_offset, {}, buttons, button).release_value_but_fixme_should_propagate_errors());
+    node->dispatch_event(UIEvents::MouseEvent::create_from_platform_event(node->realm(), UIEvents::EventNames::dblclick, page_offset, client_offset, offset, {}, button, buttons).release_value_but_fixme_should_propagate_errors());
 
     // NOTE: Dispatching an event may have disturbed the world.
     if (!paint_root() || paint_root() != node->document().paintable_box())

--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -189,7 +189,7 @@ bool EventHandler::handle_mousewheel(CSSPixelPoint position, CSSPixelPoint scree
             auto offset = compute_mouse_event_offset(position, *layout_node);
             auto client_offset = compute_mouse_event_client_offset(position);
             auto page_offset = compute_mouse_event_page_offset(client_offset);
-            if (node->dispatch_event(UIEvents::WheelEvent::create_from_platform_event(node->realm(), UIEvents::EventNames::wheel, screen_position, page_offset, client_offset, offset, wheel_delta_x, wheel_delta_y, button, buttons).release_value_but_fixme_should_propagate_errors())) {
+            if (node->dispatch_event(UIEvents::WheelEvent::create_from_platform_event(node->realm(), UIEvents::EventNames::wheel, screen_position, page_offset, client_offset, offset, wheel_delta_x, wheel_delta_y, button, buttons, modifiers).release_value_but_fixme_should_propagate_errors())) {
                 if (auto* page = m_browsing_context->page()) {
                     if (m_browsing_context == &page->top_level_browsing_context())
                         page->client().page_did_request_scroll(wheel_delta_x, wheel_delta_y);
@@ -250,15 +250,15 @@ bool EventHandler::handle_mouseup(CSSPixelPoint position, CSSPixelPoint screen_p
             auto offset = compute_mouse_event_offset(position, *layout_node);
             auto client_offset = compute_mouse_event_client_offset(position);
             auto page_offset = compute_mouse_event_page_offset(client_offset);
-            node->dispatch_event(UIEvents::MouseEvent::create_from_platform_event(node->realm(), UIEvents::EventNames::mouseup, screen_position, page_offset, client_offset, offset, {}, button, buttons).release_value_but_fixme_should_propagate_errors());
+            node->dispatch_event(UIEvents::MouseEvent::create_from_platform_event(node->realm(), UIEvents::EventNames::mouseup, screen_position, page_offset, client_offset, offset, {}, button, buttons, modifiers).release_value_but_fixme_should_propagate_errors());
             handled_event = true;
 
             bool run_activation_behavior = false;
             if (node.ptr() == m_mousedown_target) {
                 if (button == GUI::MouseButton::Primary)
-                    run_activation_behavior = node->dispatch_event(UIEvents::MouseEvent::create_from_platform_event(node->realm(), UIEvents::EventNames::click, screen_position, page_offset, client_offset, offset, {}, 1, button).release_value_but_fixme_should_propagate_errors());
+                    run_activation_behavior = node->dispatch_event(UIEvents::MouseEvent::create_from_platform_event(node->realm(), UIEvents::EventNames::click, screen_position, page_offset, client_offset, offset, {}, 1, button, modifiers).release_value_but_fixme_should_propagate_errors());
                 else if (button == GUI::MouseButton::Secondary && !(modifiers & Mod_Shift)) // Allow the user to bypass custom context menus by holding shift, like Firefox.
-                    run_activation_behavior = node->dispatch_event(UIEvents::MouseEvent::create_from_platform_event(node->realm(), UIEvents::EventNames::contextmenu, screen_position, page_offset, client_offset, offset, {}, 1, button).release_value_but_fixme_should_propagate_errors());
+                    run_activation_behavior = node->dispatch_event(UIEvents::MouseEvent::create_from_platform_event(node->realm(), UIEvents::EventNames::contextmenu, screen_position, page_offset, client_offset, offset, {}, 1, button, modifiers).release_value_but_fixme_should_propagate_errors());
             }
 
             if (run_activation_behavior) {
@@ -386,7 +386,7 @@ bool EventHandler::handle_mousedown(CSSPixelPoint position, CSSPixelPoint screen
         auto offset = compute_mouse_event_offset(position, *layout_node);
         auto client_offset = compute_mouse_event_client_offset(position);
         auto page_offset = compute_mouse_event_page_offset(client_offset);
-        node->dispatch_event(UIEvents::MouseEvent::create_from_platform_event(node->realm(), UIEvents::EventNames::mousedown, screen_position, page_offset, client_offset, offset, {}, button, buttons).release_value_but_fixme_should_propagate_errors());
+        node->dispatch_event(UIEvents::MouseEvent::create_from_platform_event(node->realm(), UIEvents::EventNames::mousedown, screen_position, page_offset, client_offset, offset, {}, button, buttons, modifiers).release_value_but_fixme_should_propagate_errors());
     }
 
     // NOTE: Dispatching an event may have disturbed the world.
@@ -500,7 +500,7 @@ bool EventHandler::handle_mousemove(CSSPixelPoint position, CSSPixelPoint screen
             auto client_offset = compute_mouse_event_client_offset(position);
             auto page_offset = compute_mouse_event_page_offset(client_offset);
             auto movement = compute_mouse_event_movement(screen_position);
-            node->dispatch_event(UIEvents::MouseEvent::create_from_platform_event(node->realm(), UIEvents::EventNames::mousemove, screen_position, page_offset, client_offset, offset, movement, 1, buttons).release_value_but_fixme_should_propagate_errors());
+            node->dispatch_event(UIEvents::MouseEvent::create_from_platform_event(node->realm(), UIEvents::EventNames::mousemove, screen_position, page_offset, client_offset, offset, movement, 1, buttons, modifiers).release_value_but_fixme_should_propagate_errors());
             m_mousemove_previous_screen_position = screen_position;
             // NOTE: Dispatching an event may have disturbed the world.
             if (!paint_root() || paint_root() != node->document().paintable_box())
@@ -586,7 +586,7 @@ bool EventHandler::handle_doubleclick(CSSPixelPoint position, CSSPixelPoint scre
     auto offset = compute_mouse_event_offset(position, *layout_node);
     auto client_offset = compute_mouse_event_client_offset(position);
     auto page_offset = compute_mouse_event_page_offset(client_offset);
-    node->dispatch_event(UIEvents::MouseEvent::create_from_platform_event(node->realm(), UIEvents::EventNames::dblclick, screen_position, page_offset, client_offset, offset, {}, button, buttons).release_value_but_fixme_should_propagate_errors());
+    node->dispatch_event(UIEvents::MouseEvent::create_from_platform_event(node->realm(), UIEvents::EventNames::dblclick, screen_position, page_offset, client_offset, offset, {}, button, buttons, modifiers).release_value_but_fixme_should_propagate_errors());
 
     // NOTE: Dispatching an event may have disturbed the world.
     if (!paint_root() || paint_root() != node->document().paintable_box())

--- a/Userland/Libraries/LibWeb/Page/EventHandler.h
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.h
@@ -24,11 +24,11 @@ public:
     explicit EventHandler(Badge<HTML::BrowsingContext>, HTML::BrowsingContext&);
     ~EventHandler();
 
-    bool handle_mouseup(CSSPixelPoint, unsigned button, unsigned buttons, unsigned modifiers);
-    bool handle_mousedown(CSSPixelPoint, unsigned button, unsigned buttons, unsigned modifiers);
-    bool handle_mousemove(CSSPixelPoint, unsigned buttons, unsigned modifiers);
-    bool handle_mousewheel(CSSPixelPoint, unsigned button, unsigned buttons, unsigned modifiers, int wheel_delta_x, int wheel_delta_y);
-    bool handle_doubleclick(CSSPixelPoint, unsigned button, unsigned buttons, unsigned modifiers);
+    bool handle_mouseup(CSSPixelPoint, CSSPixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers);
+    bool handle_mousedown(CSSPixelPoint, CSSPixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers);
+    bool handle_mousemove(CSSPixelPoint, CSSPixelPoint screen_position, unsigned buttons, unsigned modifiers);
+    bool handle_mousewheel(CSSPixelPoint, CSSPixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers, int wheel_delta_x, int wheel_delta_y);
+    bool handle_doubleclick(CSSPixelPoint, CSSPixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers);
 
     bool handle_keydown(KeyCode, unsigned modifiers, u32 code_point);
     bool handle_keyup(KeyCode, unsigned modifiers, u32 code_point);
@@ -65,7 +65,7 @@ private:
 
     WeakPtr<DOM::EventTarget> m_mousedown_target;
 
-    Optional<CSSPixelPoint> m_mousemove_previous_client_offset;
+    Optional<CSSPixelPoint> m_mousemove_previous_screen_position;
 };
 
 }

--- a/Userland/Libraries/LibWeb/Page/Page.cpp
+++ b/Userland/Libraries/LibWeb/Page/Page.cpp
@@ -132,29 +132,29 @@ DevicePixelRect Page::rounded_device_rect(CSSPixelRect rect) const
     };
 }
 
-bool Page::handle_mousewheel(DevicePixelPoint position, unsigned button, unsigned buttons, unsigned modifiers, int wheel_delta_x, int wheel_delta_y)
+bool Page::handle_mousewheel(DevicePixelPoint position, DevicePixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers, int wheel_delta_x, int wheel_delta_y)
 {
-    return top_level_browsing_context().event_handler().handle_mousewheel(device_to_css_point(position), button, buttons, modifiers, wheel_delta_x, wheel_delta_y);
+    return top_level_browsing_context().event_handler().handle_mousewheel(device_to_css_point(position), device_to_css_point(screen_position), button, buttons, modifiers, wheel_delta_x, wheel_delta_y);
 }
 
-bool Page::handle_mouseup(DevicePixelPoint position, unsigned button, unsigned buttons, unsigned modifiers)
+bool Page::handle_mouseup(DevicePixelPoint position, DevicePixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers)
 {
-    return top_level_browsing_context().event_handler().handle_mouseup(device_to_css_point(position), button, buttons, modifiers);
+    return top_level_browsing_context().event_handler().handle_mouseup(device_to_css_point(position), device_to_css_point(screen_position), button, buttons, modifiers);
 }
 
-bool Page::handle_mousedown(DevicePixelPoint position, unsigned button, unsigned buttons, unsigned modifiers)
+bool Page::handle_mousedown(DevicePixelPoint position, DevicePixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers)
 {
-    return top_level_browsing_context().event_handler().handle_mousedown(device_to_css_point(position), button, buttons, modifiers);
+    return top_level_browsing_context().event_handler().handle_mousedown(device_to_css_point(position), device_to_css_point(screen_position), button, buttons, modifiers);
 }
 
-bool Page::handle_mousemove(DevicePixelPoint position, unsigned buttons, unsigned modifiers)
+bool Page::handle_mousemove(DevicePixelPoint position, DevicePixelPoint screen_position, unsigned buttons, unsigned modifiers)
 {
-    return top_level_browsing_context().event_handler().handle_mousemove(device_to_css_point(position), buttons, modifiers);
+    return top_level_browsing_context().event_handler().handle_mousemove(device_to_css_point(position), device_to_css_point(screen_position), buttons, modifiers);
 }
 
-bool Page::handle_doubleclick(DevicePixelPoint position, unsigned button, unsigned buttons, unsigned modifiers)
+bool Page::handle_doubleclick(DevicePixelPoint position, DevicePixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers)
 {
-    return top_level_browsing_context().event_handler().handle_doubleclick(device_to_css_point(position), button, buttons, modifiers);
+    return top_level_browsing_context().event_handler().handle_doubleclick(device_to_css_point(position), device_to_css_point(screen_position), button, buttons, modifiers);
 }
 
 bool Page::handle_keydown(KeyCode key, unsigned modifiers, u32 code_point)

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -69,11 +69,11 @@ public:
     DevicePixelRect enclosing_device_rect(CSSPixelRect) const;
     DevicePixelRect rounded_device_rect(CSSPixelRect) const;
 
-    bool handle_mouseup(DevicePixelPoint, unsigned button, unsigned buttons, unsigned modifiers);
-    bool handle_mousedown(DevicePixelPoint, unsigned button, unsigned buttons, unsigned modifiers);
-    bool handle_mousemove(DevicePixelPoint, unsigned buttons, unsigned modifiers);
-    bool handle_mousewheel(DevicePixelPoint, unsigned button, unsigned buttons, unsigned modifiers, int wheel_delta_x, int wheel_delta_y);
-    bool handle_doubleclick(DevicePixelPoint, unsigned button, unsigned buttons, unsigned modifiers);
+    bool handle_mouseup(DevicePixelPoint, DevicePixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers);
+    bool handle_mousedown(DevicePixelPoint, DevicePixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers);
+    bool handle_mousemove(DevicePixelPoint, DevicePixelPoint screen_position, unsigned buttons, unsigned modifiers);
+    bool handle_mousewheel(DevicePixelPoint, DevicePixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers, int wheel_delta_x, int wheel_delta_y);
+    bool handle_doubleclick(DevicePixelPoint, DevicePixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers);
 
     bool handle_keydown(KeyCode, unsigned modifiers, u32 code_point);
     bool handle_keyup(KeyCode, unsigned modifiers, u32 code_point);

--- a/Userland/Libraries/LibWeb/UIEvents/KeyboardEvent.cpp
+++ b/Userland/Libraries/LibWeb/UIEvents/KeyboardEvent.cpp
@@ -516,7 +516,7 @@ JS::NonnullGCPtr<KeyboardEvent> KeyboardEvent::create_from_platform_event(JS::Re
     event_init.ctrl_key = modifiers & Mod_Ctrl;
     event_init.shift_key = modifiers & Mod_Shift;
     event_init.alt_key = modifiers & Mod_Alt;
-    event_init.meta_key = false;
+    event_init.meta_key = false; // FIXME: Implement meta key
     event_init.repeat = false;
     event_init.is_composing = false;
     event_init.key_code = key_code;

--- a/Userland/Libraries/LibWeb/UIEvents/MouseEvent.cpp
+++ b/Userland/Libraries/LibWeb/UIEvents/MouseEvent.cpp
@@ -63,9 +63,11 @@ JS::NonnullGCPtr<MouseEvent> MouseEvent::create(JS::Realm& realm, FlyString cons
     return realm.heap().allocate<MouseEvent>(realm, realm, event_name, event_init, page_x, page_y, offset_x, offset_y);
 }
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<MouseEvent>> MouseEvent::create_from_platform_event(JS::Realm& realm, FlyString const& event_name, CSSPixelPoint page, CSSPixelPoint client, CSSPixelPoint offset, Optional<CSSPixelPoint> movement, unsigned button, unsigned buttons)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<MouseEvent>> MouseEvent::create_from_platform_event(JS::Realm& realm, FlyString const& event_name, CSSPixelPoint screen, CSSPixelPoint page, CSSPixelPoint client, CSSPixelPoint offset, Optional<CSSPixelPoint> movement, unsigned button, unsigned buttons)
 {
     MouseEventInit event_init {};
+    event_init.screen_x = screen.x().to_double();
+    event_init.screen_y = screen.y().to_double();
     event_init.client_x = client.x().to_double();
     event_init.client_y = client.y().to_double();
     if (movement.has_value()) {

--- a/Userland/Libraries/LibWeb/UIEvents/MouseEvent.cpp
+++ b/Userland/Libraries/LibWeb/UIEvents/MouseEvent.cpp
@@ -13,14 +13,16 @@
 
 namespace Web::UIEvents {
 
-MouseEvent::MouseEvent(JS::Realm& realm, FlyString const& event_name, MouseEventInit const& event_init)
+MouseEvent::MouseEvent(JS::Realm& realm, FlyString const& event_name, MouseEventInit const& event_init, double page_x, double page_y, double offset_x, double offset_y)
     : UIEvent(realm, event_name, event_init)
-    , m_offset_x(event_init.offset_x)
-    , m_offset_y(event_init.offset_y)
+    , m_screen_x(event_init.screen_x)
+    , m_screen_y(event_init.screen_y)
+    , m_page_x(page_x)
+    , m_page_y(page_y)
     , m_client_x(event_init.client_x)
     , m_client_y(event_init.client_y)
-    , m_page_x(event_init.page_x)
-    , m_page_y(event_init.page_y)
+    , m_offset_x(offset_x)
+    , m_offset_y(offset_y)
     , m_movement_x(event_init.movement_x)
     , m_movement_y(event_init.movement_y)
     , m_button(event_init.button)
@@ -56,27 +58,23 @@ static i16 determine_button(unsigned mouse_button)
     }
 }
 
-JS::NonnullGCPtr<MouseEvent> MouseEvent::create(JS::Realm& realm, FlyString const& event_name, MouseEventInit const& event_init)
+JS::NonnullGCPtr<MouseEvent> MouseEvent::create(JS::Realm& realm, FlyString const& event_name, MouseEventInit const& event_init, double page_x, double page_y, double offset_x, double offset_y)
 {
-    return realm.heap().allocate<MouseEvent>(realm, realm, event_name, event_init);
+    return realm.heap().allocate<MouseEvent>(realm, realm, event_name, event_init, page_x, page_y, offset_x, offset_y);
 }
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<MouseEvent>> MouseEvent::create_from_platform_event(JS::Realm& realm, FlyString const& event_name, CSSPixelPoint offset, CSSPixelPoint client_offset, CSSPixelPoint page_offset, Optional<CSSPixelPoint> movement, unsigned buttons, unsigned mouse_button)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<MouseEvent>> MouseEvent::create_from_platform_event(JS::Realm& realm, FlyString const& event_name, CSSPixelPoint page, CSSPixelPoint client, CSSPixelPoint offset, Optional<CSSPixelPoint> movement, unsigned button, unsigned buttons)
 {
     MouseEventInit event_init {};
-    event_init.offset_x = offset.x().to_double();
-    event_init.offset_y = offset.y().to_double();
-    event_init.client_x = client_offset.x().to_double();
-    event_init.client_y = client_offset.y().to_double();
-    event_init.page_x = page_offset.x().to_double();
-    event_init.page_y = page_offset.y().to_double();
+    event_init.client_x = client.x().to_double();
+    event_init.client_y = client.y().to_double();
     if (movement.has_value()) {
         event_init.movement_x = movement.value().x().to_double();
         event_init.movement_y = movement.value().y().to_double();
     }
-    event_init.button = determine_button(mouse_button);
+    event_init.button = determine_button(button);
     event_init.buttons = buttons;
-    return MouseEvent::create(realm, event_name, event_init);
+    return MouseEvent::create(realm, event_name, event_init, page.x().to_double(), page.y().to_double(), offset.x().to_double(), offset.y().to_double());
 }
 
 void MouseEvent::set_event_characteristics()

--- a/Userland/Libraries/LibWeb/UIEvents/MouseEvent.h
+++ b/Userland/Libraries/LibWeb/UIEvents/MouseEvent.h
@@ -14,15 +14,12 @@
 namespace Web::UIEvents {
 
 struct MouseEventInit : public EventModifierInit {
-    double offset_x = 0;
-    double offset_y = 0;
+    double screen_x = 0;
+    double screen_y = 0;
     double client_x = 0;
     double client_y = 0;
-    double page_x = 0;
-    double page_y = 0;
     double movement_x = 0;
     double movement_y = 0;
-
     i16 button = 0;
     u16 buttons = 0;
 };
@@ -31,26 +28,25 @@ class MouseEvent : public UIEvent {
     WEB_PLATFORM_OBJECT(MouseEvent, UIEvent);
 
 public:
-    [[nodiscard]] static JS::NonnullGCPtr<MouseEvent> create(JS::Realm&, FlyString const& event_name, MouseEventInit const& = {});
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<MouseEvent>> create_from_platform_event(JS::Realm&, FlyString const& event_name, CSSPixelPoint offset, CSSPixelPoint client_offset, CSSPixelPoint page_offset, Optional<CSSPixelPoint> movement, unsigned buttons, unsigned mouse_button = 1);
+    [[nodiscard]] static JS::NonnullGCPtr<MouseEvent> create(JS::Realm&, FlyString const& event_name, MouseEventInit const& = {}, double page_x = 0, double page_y = 0, double offset_x = 0, double offset_y = 0);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<MouseEvent>> create_from_platform_event(JS::Realm&, FlyString const& event_name, CSSPixelPoint page, CSSPixelPoint client, CSSPixelPoint offset, Optional<CSSPixelPoint> movement, unsigned button, unsigned buttons);
 
     virtual ~MouseEvent() override;
 
-    double offset_x() const { return m_offset_x; }
-    double offset_y() const { return m_offset_y; }
-
-    double client_x() const { return m_client_x; }
-    double client_y() const { return m_client_y; }
-
-    // FIXME: Make these actually different from clientX and clientY.
-    double screen_x() const { return m_client_x; }
-    double screen_y() const { return m_client_y; }
+    double screen_x() const { return m_screen_x; }
+    double screen_y() const { return m_screen_y; }
 
     double page_x() const { return m_page_x; }
     double page_y() const { return m_page_y; }
 
+    double client_x() const { return m_client_x; }
+    double client_y() const { return m_client_y; }
+
     double x() const { return client_x(); }
     double y() const { return client_y(); }
+
+    double offset_x() const { return m_offset_x; }
+    double offset_y() const { return m_offset_y; }
 
     double movement_x() const { return m_movement_x; }
     double movement_y() const { return m_movement_y; }
@@ -61,19 +57,21 @@ public:
     virtual u32 which() const override { return m_button + 1; }
 
 protected:
-    MouseEvent(JS::Realm&, FlyString const& event_name, MouseEventInit const& event_init);
+    MouseEvent(JS::Realm&, FlyString const& event_name, MouseEventInit const& event_init, double page_x, double page_y, double offset_x, double offset_y);
 
     virtual void initialize(JS::Realm&) override;
 
 private:
     void set_event_characteristics();
 
-    double m_offset_x { 0 };
-    double m_offset_y { 0 };
-    double m_client_x { 0 };
-    double m_client_y { 0 };
+    double m_screen_x { 0 };
+    double m_screen_y { 0 };
     double m_page_x { 0 };
     double m_page_y { 0 };
+    double m_client_x { 0 };
+    double m_client_y { 0 };
+    double m_offset_x { 0 };
+    double m_offset_y { 0 };
     double m_movement_x { 0 };
     double m_movement_y { 0 };
     i16 m_button { 0 };

--- a/Userland/Libraries/LibWeb/UIEvents/MouseEvent.h
+++ b/Userland/Libraries/LibWeb/UIEvents/MouseEvent.h
@@ -28,8 +28,8 @@ class MouseEvent : public UIEvent {
     WEB_PLATFORM_OBJECT(MouseEvent, UIEvent);
 
 public:
-    [[nodiscard]] static JS::NonnullGCPtr<MouseEvent> create(JS::Realm&, FlyString const& event_name, MouseEventInit const& = {}, double page_x = 0, double page_y = 0, double offset_x = 0, double offset_y = 0);
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<MouseEvent>> create_from_platform_event(JS::Realm&, FlyString const& event_name, CSSPixelPoint screen, CSSPixelPoint page, CSSPixelPoint client, CSSPixelPoint offset, Optional<CSSPixelPoint> movement, unsigned button, unsigned buttons);
+    [[nodiscard]] static JS::NonnullGCPtr<MouseEvent> create(JS::Realm&, FlyString const& event_name, MouseEventInit const& = {}, double page_x = 0, double page_y = 0, double offset_x = 0, double offset_y = 0, unsigned modifiers = 0);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<MouseEvent>> create_from_platform_event(JS::Realm&, FlyString const& event_name, CSSPixelPoint screen, CSSPixelPoint page, CSSPixelPoint client, CSSPixelPoint offset, Optional<CSSPixelPoint> movement, unsigned button, unsigned buttons, unsigned modifiers);
 
     virtual ~MouseEvent() override;
 
@@ -48,6 +48,11 @@ public:
     double offset_x() const { return m_offset_x; }
     double offset_y() const { return m_offset_y; }
 
+    bool ctrl_key() const { return m_ctrl_key; }
+    bool shift_key() const { return m_shift_key; }
+    bool alt_key() const { return m_alt_key; }
+    bool meta_key() const { return m_meta_key; }
+
     double movement_x() const { return m_movement_x; }
     double movement_y() const { return m_movement_y; }
 
@@ -57,7 +62,7 @@ public:
     virtual u32 which() const override { return m_button + 1; }
 
 protected:
-    MouseEvent(JS::Realm&, FlyString const& event_name, MouseEventInit const& event_init, double page_x, double page_y, double offset_x, double offset_y);
+    MouseEvent(JS::Realm&, FlyString const& event_name, MouseEventInit const& event_init, double page_x, double page_y, double offset_x, double offset_y, unsigned modifiers);
 
     virtual void initialize(JS::Realm&) override;
 
@@ -72,6 +77,10 @@ private:
     double m_client_y { 0 };
     double m_offset_x { 0 };
     double m_offset_y { 0 };
+    bool m_ctrl_key { false };
+    bool m_shift_key { false };
+    bool m_alt_key { false };
+    bool m_meta_key { false };
     double m_movement_x { 0 };
     double m_movement_y { 0 };
     i16 m_button { 0 };

--- a/Userland/Libraries/LibWeb/UIEvents/MouseEvent.h
+++ b/Userland/Libraries/LibWeb/UIEvents/MouseEvent.h
@@ -29,7 +29,7 @@ class MouseEvent : public UIEvent {
 
 public:
     [[nodiscard]] static JS::NonnullGCPtr<MouseEvent> create(JS::Realm&, FlyString const& event_name, MouseEventInit const& = {}, double page_x = 0, double page_y = 0, double offset_x = 0, double offset_y = 0);
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<MouseEvent>> create_from_platform_event(JS::Realm&, FlyString const& event_name, CSSPixelPoint page, CSSPixelPoint client, CSSPixelPoint offset, Optional<CSSPixelPoint> movement, unsigned button, unsigned buttons);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<MouseEvent>> create_from_platform_event(JS::Realm&, FlyString const& event_name, CSSPixelPoint screen, CSSPixelPoint page, CSSPixelPoint client, CSSPixelPoint offset, Optional<CSSPixelPoint> movement, unsigned button, unsigned buttons);
 
     virtual ~MouseEvent() override;
 

--- a/Userland/Libraries/LibWeb/UIEvents/MouseEvent.idl
+++ b/Userland/Libraries/LibWeb/UIEvents/MouseEvent.idl
@@ -1,17 +1,24 @@
 // https://w3c.github.io/uievents/#mouseevent
 [Exposed=Window]
 interface MouseEvent : UIEvent {
+    // FIXME: constructor(DOMString type, optional MouseEventInit eventInitDict = {});
 
-    readonly attribute double offsetX;
-    readonly attribute double offsetY;
-    readonly attribute double clientX;
-    readonly attribute double clientY;
+    // https://drafts.csswg.org/cssom-view/#extensions-to-the-mouseevent-interface
     readonly attribute double screenX;
     readonly attribute double screenY;
-    readonly attribute double x;
-    readonly attribute double y;
     readonly attribute double pageX;
     readonly attribute double pageY;
+    readonly attribute double clientX;
+    readonly attribute double clientY;
+    readonly attribute double x;
+    readonly attribute double y;
+    readonly attribute double offsetX;
+    readonly attribute double offsetY;
+
+    // FIXME: readonly attribute boolean ctrlKey;
+    // FIXME: readonly attribute boolean shiftKey;
+    // FIXME: readonly attribute boolean altKey;
+    // FIXME: readonly attribute boolean metaKey;
 
     // https://w3c.github.io/pointerlock/#extensions-to-the-mouseevent-interface
     readonly attribute double movementX;
@@ -19,13 +26,17 @@ interface MouseEvent : UIEvent {
 
     readonly attribute short button;
     readonly attribute unsigned short buttons;
+
+    // FIXME: readonly attribute EventTarget? relatedTarget;
+
+    // FIXME: boolean getModifierState(DOMString keyArg);
 };
 
+// https://w3c.github.io/uievents/#idl-mouseeventinit
 dictionary MouseEventInit : EventModifierInit {
-
-    // FIXME: offsetX and offsetY shouldn't be here.
-    double offsetX = 0;
-    double offsetY = 0;
+    // https://drafts.csswg.org/cssom-view/#extensions-to-the-mouseevent-interface
+    double screenX = 0;
+    double screenY = 0;
     double clientX = 0;
     double clientY = 0;
 
@@ -34,5 +45,6 @@ dictionary MouseEventInit : EventModifierInit {
     double movementY = 0;
 
     short button = 0;
-
+    unsigned short buttons = 0;
+    // FIXME: EventTarget? relatedTarget = null;
 };

--- a/Userland/Libraries/LibWeb/UIEvents/MouseEvent.idl
+++ b/Userland/Libraries/LibWeb/UIEvents/MouseEvent.idl
@@ -15,10 +15,10 @@ interface MouseEvent : UIEvent {
     readonly attribute double offsetX;
     readonly attribute double offsetY;
 
-    // FIXME: readonly attribute boolean ctrlKey;
-    // FIXME: readonly attribute boolean shiftKey;
-    // FIXME: readonly attribute boolean altKey;
-    // FIXME: readonly attribute boolean metaKey;
+    readonly attribute boolean ctrlKey;
+    readonly attribute boolean shiftKey;
+    readonly attribute boolean altKey;
+    readonly attribute boolean metaKey;
 
     // https://w3c.github.io/pointerlock/#extensions-to-the-mouseevent-interface
     readonly attribute double movementX;

--- a/Userland/Libraries/LibWeb/UIEvents/WheelEvent.cpp
+++ b/Userland/Libraries/LibWeb/UIEvents/WheelEvent.cpp
@@ -12,8 +12,8 @@
 
 namespace Web::UIEvents {
 
-WheelEvent::WheelEvent(JS::Realm& realm, FlyString const& event_name, WheelEventInit const& event_init)
-    : MouseEvent(realm, event_name, event_init)
+WheelEvent::WheelEvent(JS::Realm& realm, FlyString const& event_name, WheelEventInit const& event_init, double page_x, double page_y, double offset_x, double offset_y)
+    : MouseEvent(realm, event_name, event_init, page_x, page_y, offset_x, offset_y)
     , m_delta_x(event_init.delta_x)
     , m_delta_y(event_init.delta_y)
     , m_delta_mode(event_init.delta_mode)
@@ -29,24 +29,22 @@ void WheelEvent::initialize(JS::Realm& realm)
     set_prototype(&Bindings::ensure_web_prototype<Bindings::WheelEventPrototype>(realm, "WheelEvent"));
 }
 
-JS::NonnullGCPtr<WheelEvent> WheelEvent::create(JS::Realm& realm, FlyString const& event_name, WheelEventInit const& event_init)
+JS::NonnullGCPtr<WheelEvent> WheelEvent::create(JS::Realm& realm, FlyString const& event_name, WheelEventInit const& event_init, double page_x, double page_y, double offset_x, double offset_y)
 {
-    return realm.heap().allocate<WheelEvent>(realm, realm, event_name, event_init);
+    return realm.heap().allocate<WheelEvent>(realm, realm, event_name, event_init, page_x, page_y, offset_x, offset_y);
 }
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<WheelEvent>> WheelEvent::create_from_platform_event(JS::Realm& realm, FlyString const& event_name, CSSPixels offset_x, CSSPixels offset_y, CSSPixels client_x, CSSPixels client_y, double delta_x, double delta_y, unsigned buttons, unsigned button)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<WheelEvent>> WheelEvent::create_from_platform_event(JS::Realm& realm, FlyString const& event_name, CSSPixelPoint page, CSSPixelPoint client, CSSPixelPoint offset, double delta_x, double delta_y, unsigned button, unsigned buttons)
 {
     WheelEventInit event_init {};
-    event_init.offset_x = offset_x.to_double();
-    event_init.offset_y = offset_y.to_double();
-    event_init.client_x = client_x.to_double();
-    event_init.client_y = client_y.to_double();
+    event_init.client_x = client.x().to_double();
+    event_init.client_y = client.y().to_double();
     event_init.button = button;
     event_init.buttons = buttons;
     event_init.delta_x = delta_x;
     event_init.delta_y = delta_y;
     event_init.delta_mode = WheelDeltaMode::DOM_DELTA_PIXEL;
-    return WheelEvent::create(realm, event_name, event_init);
+    return WheelEvent::create(realm, event_name, event_init, page.x().to_double(), page.y().to_double(), offset.x().to_double(), offset.y().to_double());
 }
 
 void WheelEvent::set_event_characteristics()

--- a/Userland/Libraries/LibWeb/UIEvents/WheelEvent.cpp
+++ b/Userland/Libraries/LibWeb/UIEvents/WheelEvent.cpp
@@ -12,8 +12,8 @@
 
 namespace Web::UIEvents {
 
-WheelEvent::WheelEvent(JS::Realm& realm, FlyString const& event_name, WheelEventInit const& event_init, double page_x, double page_y, double offset_x, double offset_y)
-    : MouseEvent(realm, event_name, event_init, page_x, page_y, offset_x, offset_y)
+WheelEvent::WheelEvent(JS::Realm& realm, FlyString const& event_name, WheelEventInit const& event_init, double page_x, double page_y, double offset_x, double offset_y, unsigned modifiers)
+    : MouseEvent(realm, event_name, event_init, page_x, page_y, offset_x, offset_y, modifiers)
     , m_delta_x(event_init.delta_x)
     , m_delta_y(event_init.delta_y)
     , m_delta_mode(event_init.delta_mode)
@@ -29,12 +29,12 @@ void WheelEvent::initialize(JS::Realm& realm)
     set_prototype(&Bindings::ensure_web_prototype<Bindings::WheelEventPrototype>(realm, "WheelEvent"));
 }
 
-JS::NonnullGCPtr<WheelEvent> WheelEvent::create(JS::Realm& realm, FlyString const& event_name, WheelEventInit const& event_init, double page_x, double page_y, double offset_x, double offset_y)
+JS::NonnullGCPtr<WheelEvent> WheelEvent::create(JS::Realm& realm, FlyString const& event_name, WheelEventInit const& event_init, double page_x, double page_y, double offset_x, double offset_y, unsigned modifiers)
 {
-    return realm.heap().allocate<WheelEvent>(realm, realm, event_name, event_init, page_x, page_y, offset_x, offset_y);
+    return realm.heap().allocate<WheelEvent>(realm, realm, event_name, event_init, page_x, page_y, offset_x, offset_y, modifiers);
 }
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<WheelEvent>> WheelEvent::create_from_platform_event(JS::Realm& realm, FlyString const& event_name, CSSPixelPoint screen, CSSPixelPoint page, CSSPixelPoint client, CSSPixelPoint offset, double delta_x, double delta_y, unsigned button, unsigned buttons)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<WheelEvent>> WheelEvent::create_from_platform_event(JS::Realm& realm, FlyString const& event_name, CSSPixelPoint screen, CSSPixelPoint page, CSSPixelPoint client, CSSPixelPoint offset, double delta_x, double delta_y, unsigned button, unsigned buttons, unsigned modifiers)
 {
     WheelEventInit event_init {};
     event_init.screen_x = screen.x().to_double();
@@ -46,7 +46,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<WheelEvent>> WheelEvent::create_from_platfo
     event_init.delta_x = delta_x;
     event_init.delta_y = delta_y;
     event_init.delta_mode = WheelDeltaMode::DOM_DELTA_PIXEL;
-    return WheelEvent::create(realm, event_name, event_init, page.x().to_double(), page.y().to_double(), offset.x().to_double(), offset.y().to_double());
+    return WheelEvent::create(realm, event_name, event_init, page.x().to_double(), page.y().to_double(), offset.x().to_double(), offset.y().to_double(), modifiers);
 }
 
 void WheelEvent::set_event_characteristics()

--- a/Userland/Libraries/LibWeb/UIEvents/WheelEvent.cpp
+++ b/Userland/Libraries/LibWeb/UIEvents/WheelEvent.cpp
@@ -34,9 +34,11 @@ JS::NonnullGCPtr<WheelEvent> WheelEvent::create(JS::Realm& realm, FlyString cons
     return realm.heap().allocate<WheelEvent>(realm, realm, event_name, event_init, page_x, page_y, offset_x, offset_y);
 }
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<WheelEvent>> WheelEvent::create_from_platform_event(JS::Realm& realm, FlyString const& event_name, CSSPixelPoint page, CSSPixelPoint client, CSSPixelPoint offset, double delta_x, double delta_y, unsigned button, unsigned buttons)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<WheelEvent>> WheelEvent::create_from_platform_event(JS::Realm& realm, FlyString const& event_name, CSSPixelPoint screen, CSSPixelPoint page, CSSPixelPoint client, CSSPixelPoint offset, double delta_x, double delta_y, unsigned button, unsigned buttons)
 {
     WheelEventInit event_init {};
+    event_init.screen_x = screen.x().to_double();
+    event_init.screen_y = screen.y().to_double();
     event_init.client_x = client.x().to_double();
     event_init.client_y = client.y().to_double();
     event_init.button = button;

--- a/Userland/Libraries/LibWeb/UIEvents/WheelEvent.h
+++ b/Userland/Libraries/LibWeb/UIEvents/WheelEvent.h
@@ -29,8 +29,8 @@ class WheelEvent final : public MouseEvent {
     WEB_PLATFORM_OBJECT(WheelEvent, MouseEvent);
 
 public:
-    [[nodiscard]] static JS::NonnullGCPtr<WheelEvent> create(JS::Realm&, FlyString const& event_name, WheelEventInit const& event_init = {}, double page_x = 0, double page_y = 0, double offset_x = 0, double offset_y = 0);
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<WheelEvent>> create_from_platform_event(JS::Realm&, FlyString const& event_name, CSSPixelPoint screen, CSSPixelPoint page, CSSPixelPoint client, CSSPixelPoint offset, double delta_x, double delta_y, unsigned button, unsigned buttons);
+    [[nodiscard]] static JS::NonnullGCPtr<WheelEvent> create(JS::Realm&, FlyString const& event_name, WheelEventInit const& event_init = {}, double page_x = 0, double page_y = 0, double offset_x = 0, double offset_y = 0, unsigned modifiers = 0);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<WheelEvent>> create_from_platform_event(JS::Realm&, FlyString const& event_name, CSSPixelPoint screen, CSSPixelPoint page, CSSPixelPoint client, CSSPixelPoint offset, double delta_x, double delta_y, unsigned button, unsigned buttons, unsigned modifiers);
 
     virtual ~WheelEvent() override;
 
@@ -40,7 +40,7 @@ public:
     unsigned long delta_mode() const { return to_underlying(m_delta_mode); }
 
 private:
-    WheelEvent(JS::Realm&, FlyString const& event_name, WheelEventInit const& event_init, double page_x, double page_y, double offset_x, double offset_y);
+    WheelEvent(JS::Realm&, FlyString const& event_name, WheelEventInit const& event_init, double page_x, double page_y, double offset_x, double offset_y, unsigned modifiers);
 
     virtual void initialize(JS::Realm&) override;
 

--- a/Userland/Libraries/LibWeb/UIEvents/WheelEvent.h
+++ b/Userland/Libraries/LibWeb/UIEvents/WheelEvent.h
@@ -30,7 +30,7 @@ class WheelEvent final : public MouseEvent {
 
 public:
     [[nodiscard]] static JS::NonnullGCPtr<WheelEvent> create(JS::Realm&, FlyString const& event_name, WheelEventInit const& event_init = {}, double page_x = 0, double page_y = 0, double offset_x = 0, double offset_y = 0);
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<WheelEvent>> create_from_platform_event(JS::Realm&, FlyString const& event_name, CSSPixelPoint page, CSSPixelPoint client, CSSPixelPoint offset, double delta_x, double delta_y, unsigned button, unsigned buttons);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<WheelEvent>> create_from_platform_event(JS::Realm&, FlyString const& event_name, CSSPixelPoint screen, CSSPixelPoint page, CSSPixelPoint client, CSSPixelPoint offset, double delta_x, double delta_y, unsigned button, unsigned buttons);
 
     virtual ~WheelEvent() override;
 

--- a/Userland/Libraries/LibWeb/UIEvents/WheelEvent.h
+++ b/Userland/Libraries/LibWeb/UIEvents/WheelEvent.h
@@ -29,8 +29,8 @@ class WheelEvent final : public MouseEvent {
     WEB_PLATFORM_OBJECT(WheelEvent, MouseEvent);
 
 public:
-    [[nodiscard]] static JS::NonnullGCPtr<WheelEvent> create(JS::Realm&, FlyString const& event_name, WheelEventInit const& event_init = {});
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<WheelEvent>> create_from_platform_event(JS::Realm&, FlyString const& event_name, CSSPixels offset_x, CSSPixels offset_y, CSSPixels client_x, CSSPixels client_y, double delta_x, double delta_y, unsigned buttons, unsigned button);
+    [[nodiscard]] static JS::NonnullGCPtr<WheelEvent> create(JS::Realm&, FlyString const& event_name, WheelEventInit const& event_init = {}, double page_x = 0, double page_y = 0, double offset_x = 0, double offset_y = 0);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<WheelEvent>> create_from_platform_event(JS::Realm&, FlyString const& event_name, CSSPixelPoint page, CSSPixelPoint client, CSSPixelPoint offset, double delta_x, double delta_y, unsigned button, unsigned buttons);
 
     virtual ~WheelEvent() override;
 
@@ -40,7 +40,7 @@ public:
     unsigned long delta_mode() const { return to_underlying(m_delta_mode); }
 
 private:
-    WheelEvent(JS::Realm&, FlyString const& event_name, WheelEventInit const& event_init);
+    WheelEvent(JS::Realm&, FlyString const& event_name, WheelEventInit const& event_init, double page_x, double page_y, double offset_x, double offset_y);
 
     virtual void initialize(JS::Realm&) override;
 

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
@@ -328,24 +328,25 @@ void OutOfProcessWebView::process_next_input_event()
             }
         },
         [this](GUI::MouseEvent const& event) {
+            auto screen_position = event.position() + (window()->position() + relative_position());
             switch (event.type()) {
             case GUI::Event::Type::MouseDown:
-                client().async_mouse_down(to_content_position(event.position()), event.button(), event.buttons(), event.modifiers());
+                client().async_mouse_down(to_content_position(event.position()), screen_position, event.button(), event.buttons(), event.modifiers());
                 break;
             case GUI::Event::Type::MouseUp:
-                client().async_mouse_up(to_content_position(event.position()), event.button(), event.buttons(), event.modifiers());
+                client().async_mouse_up(to_content_position(event.position()), screen_position, event.button(), event.buttons(), event.modifiers());
                 break;
             case GUI::Event::Type::MouseMove:
-                client().async_mouse_move(to_content_position(event.position()), event.button(), event.buttons(), event.modifiers());
+                client().async_mouse_move(to_content_position(event.position()), screen_position, event.button(), event.buttons(), event.modifiers());
                 break;
             case GUI::Event::Type::MouseWheel: {
                 // FIXME: This wheel delta step size multiplier is used to remain the old scroll behaviour, in future use system step size.
                 constexpr int scroll_step_size = 24;
-                client().async_mouse_wheel(to_content_position(event.position()), event.button(), event.buttons(), event.modifiers(), event.wheel_delta_x() * scroll_step_size, event.wheel_delta_y() * scroll_step_size);
+                client().async_mouse_wheel(to_content_position(event.position()), screen_position, event.button(), event.buttons(), event.modifiers(), event.wheel_delta_x() * scroll_step_size, event.wheel_delta_y() * scroll_step_size);
                 break;
             }
             case GUI::Event::Type::MouseDoubleClick:
-                client().async_doubleclick(to_content_position(event.position()), event.button(), event.buttons(), event.modifiers());
+                client().async_doubleclick(to_content_position(event.position()), screen_position, event.button(), event.buttons(), event.modifiers());
                 break;
             default:
                 dbgln("Unrecognized mouse event type in OOPWV input event queue: {}", event.type());

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -182,11 +182,13 @@ void ConnectionFromClient::process_next_input_event()
             case QueuedMouseEvent::Type::MouseDown:
                 report_finished_handling_input_event(page().handle_mousedown(
                     event.position.to_type<Web::DevicePixels>(),
+                    event.screen_position.to_type<Web::DevicePixels>(),
                     event.button, event.buttons, event.modifiers));
                 break;
             case QueuedMouseEvent::Type::MouseUp:
                 report_finished_handling_input_event(page().handle_mouseup(
                     event.position.to_type<Web::DevicePixels>(),
+                    event.screen_position.to_type<Web::DevicePixels>(),
                     event.button, event.buttons, event.modifiers));
                 break;
             case QueuedMouseEvent::Type::MouseMove:
@@ -197,11 +199,13 @@ void ConnectionFromClient::process_next_input_event()
                 }
                 report_finished_handling_input_event(page().handle_mousemove(
                     event.position.to_type<Web::DevicePixels>(),
+                    event.screen_position.to_type<Web::DevicePixels>(),
                     event.buttons, event.modifiers));
                 break;
             case QueuedMouseEvent::Type::DoubleClick:
                 report_finished_handling_input_event(page().handle_doubleclick(
                     event.position.to_type<Web::DevicePixels>(),
+                    event.screen_position.to_type<Web::DevicePixels>(),
                     event.button, event.buttons, event.modifiers));
                 break;
             case QueuedMouseEvent::Type::MouseWheel:
@@ -210,6 +214,7 @@ void ConnectionFromClient::process_next_input_event()
                 }
                 report_finished_handling_input_event(page().handle_mousewheel(
                     event.position.to_type<Web::DevicePixels>(),
+                    event.screen_position.to_type<Web::DevicePixels>(),
                     event.button, event.buttons, event.modifiers, event.wheel_delta_x, event.wheel_delta_y));
                 break;
             }
@@ -229,23 +234,25 @@ void ConnectionFromClient::process_next_input_event()
         m_input_event_queue_timer->start();
 }
 
-void ConnectionFromClient::mouse_down(Gfx::IntPoint position, unsigned int button, unsigned int buttons, unsigned int modifiers)
+void ConnectionFromClient::mouse_down(Gfx::IntPoint position, Gfx::IntPoint screen_position, unsigned int button, unsigned int buttons, unsigned int modifiers)
 {
     enqueue_input_event(
         QueuedMouseEvent {
             .type = QueuedMouseEvent::Type::MouseDown,
             .position = position,
+            .screen_position = screen_position,
             .button = button,
             .buttons = buttons,
             .modifiers = modifiers,
         });
 }
 
-void ConnectionFromClient::mouse_move(Gfx::IntPoint position, [[maybe_unused]] unsigned int button, unsigned int buttons, unsigned int modifiers)
+void ConnectionFromClient::mouse_move(Gfx::IntPoint position, Gfx::IntPoint screen_position, [[maybe_unused]] unsigned int button, unsigned int buttons, unsigned int modifiers)
 {
     auto event = QueuedMouseEvent {
         .type = QueuedMouseEvent::Type::MouseMove,
         .position = position,
+        .screen_position = screen_position,
         .button = button,
         .buttons = buttons,
         .modifiers = modifiers,
@@ -263,23 +270,25 @@ void ConnectionFromClient::mouse_move(Gfx::IntPoint position, [[maybe_unused]] u
     enqueue_input_event(move(event));
 }
 
-void ConnectionFromClient::mouse_up(Gfx::IntPoint position, unsigned int button, unsigned int buttons, unsigned int modifiers)
+void ConnectionFromClient::mouse_up(Gfx::IntPoint position, Gfx::IntPoint screen_position, unsigned int button, unsigned int buttons, unsigned int modifiers)
 {
     enqueue_input_event(
         QueuedMouseEvent {
             .type = QueuedMouseEvent::Type::MouseUp,
             .position = position,
+            .screen_position = screen_position,
             .button = button,
             .buttons = buttons,
             .modifiers = modifiers,
         });
 }
 
-void ConnectionFromClient::mouse_wheel(Gfx::IntPoint position, unsigned int button, unsigned int buttons, unsigned int modifiers, i32 wheel_delta_x, i32 wheel_delta_y)
+void ConnectionFromClient::mouse_wheel(Gfx::IntPoint position, Gfx::IntPoint screen_position, unsigned int button, unsigned int buttons, unsigned int modifiers, i32 wheel_delta_x, i32 wheel_delta_y)
 {
     auto event = QueuedMouseEvent {
         .type = QueuedMouseEvent::Type::MouseWheel,
         .position = position,
+        .screen_position = screen_position,
         .button = button,
         .buttons = buttons,
         .modifiers = modifiers,
@@ -302,12 +311,13 @@ void ConnectionFromClient::mouse_wheel(Gfx::IntPoint position, unsigned int butt
     enqueue_input_event(move(event));
 }
 
-void ConnectionFromClient::doubleclick(Gfx::IntPoint position, unsigned int button, unsigned int buttons, unsigned int modifiers)
+void ConnectionFromClient::doubleclick(Gfx::IntPoint position, Gfx::IntPoint screen_position, unsigned int button, unsigned int buttons, unsigned int modifiers)
 {
     enqueue_input_event(
         QueuedMouseEvent {
             .type = QueuedMouseEvent::Type::DoubleClick,
             .position = position,
+            .screen_position = screen_position,
             .button = button,
             .buttons = buttons,
             .modifiers = modifiers,

--- a/Userland/Services/WebContent/ConnectionFromClient.h
+++ b/Userland/Services/WebContent/ConnectionFromClient.h
@@ -58,11 +58,11 @@ private:
     virtual void load_html(DeprecatedString const&, URL const&) override;
     virtual void paint(Gfx::IntRect const&, i32) override;
     virtual void set_viewport_rect(Gfx::IntRect const&) override;
-    virtual void mouse_down(Gfx::IntPoint, unsigned, unsigned, unsigned) override;
-    virtual void mouse_move(Gfx::IntPoint, unsigned, unsigned, unsigned) override;
-    virtual void mouse_up(Gfx::IntPoint, unsigned, unsigned, unsigned) override;
-    virtual void mouse_wheel(Gfx::IntPoint, unsigned, unsigned, unsigned, i32, i32) override;
-    virtual void doubleclick(Gfx::IntPoint, unsigned, unsigned, unsigned) override;
+    virtual void mouse_down(Gfx::IntPoint, Gfx::IntPoint, unsigned, unsigned, unsigned) override;
+    virtual void mouse_move(Gfx::IntPoint, Gfx::IntPoint, unsigned, unsigned, unsigned) override;
+    virtual void mouse_up(Gfx::IntPoint, Gfx::IntPoint, unsigned, unsigned, unsigned) override;
+    virtual void mouse_wheel(Gfx::IntPoint, Gfx::IntPoint, unsigned, unsigned, unsigned, i32, i32) override;
+    virtual void doubleclick(Gfx::IntPoint, Gfx::IntPoint, unsigned, unsigned, unsigned) override;
     virtual void key_down(i32, unsigned, u32) override;
     virtual void key_up(i32, unsigned, u32) override;
     virtual void add_backing_store(i32, Gfx::ShareableBitmap const&) override;
@@ -144,6 +144,7 @@ private:
         };
         Type type {};
         Gfx::IntPoint position {};
+        Gfx::IntPoint screen_position {};
         unsigned button {};
         unsigned buttons {};
         unsigned modifiers {};

--- a/Userland/Services/WebContent/WebContentServer.ipc
+++ b/Userland/Services/WebContent/WebContentServer.ipc
@@ -27,11 +27,11 @@ endpoint WebContentServer
     paint(Gfx::IntRect content_rect, i32 backing_store_id) =|
     set_viewport_rect(Gfx::IntRect rect) =|
 
-    mouse_down(Gfx::IntPoint position, unsigned button, unsigned buttons, unsigned modifiers) =|
-    mouse_move(Gfx::IntPoint position, unsigned button, unsigned buttons, unsigned modifiers) =|
-    mouse_up(Gfx::IntPoint position, unsigned button, unsigned buttons, unsigned modifiers) =|
-    mouse_wheel(Gfx::IntPoint position, unsigned button, unsigned buttons, unsigned modifiers, i32 wheel_delta_x, i32 wheel_delta_y) =|
-    doubleclick(Gfx::IntPoint position, unsigned button, unsigned buttons, unsigned modifiers) =|
+    mouse_down(Gfx::IntPoint position, Gfx::IntPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers) =|
+    mouse_move(Gfx::IntPoint position, Gfx::IntPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers) =|
+    mouse_up(Gfx::IntPoint position, Gfx::IntPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers) =|
+    mouse_wheel(Gfx::IntPoint position, Gfx::IntPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers, i32 wheel_delta_x, i32 wheel_delta_y) =|
+    doubleclick(Gfx::IntPoint position, Gfx::IntPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers) =|
 
     key_down(i32 key, unsigned modifiers, u32 code_point) =|
     key_up(i32 key, unsigned modifiers, u32 code_point) =|


### PR DESCRIPTION
I have fixed many spec issues with the `MouseEvent` and `WheelEvent`:
- I have added the `screenX` and `screenY` properties
- I have reordered the properties to resemble the spec
- I have removed items from `MouseEventInit` that where not in spec
- I have added modifier keys support to `MouseEvent` and `WheelEvent`

This is quite a large change so careful feedback would be nice.

This pull request changes the `WebContent` IPC a bit. I have updated the Ladybird Qt, Appkit and SerenityOS Browser chromes. Other chromes like the GTK4 that are out of tree need to add the screen_position to mouse events otherwise you get errors.

# Demo video
https://github.com/SerenityOS/serenity/assets/19894029/eec00f76-b286-48c5-851e-f7a73545de07