### PR TITLE
AK: Add to_radians and to_degrees math functions

### DIFF
--- a/AK/Math.h
+++ b/AK/Math.h
@@ -53,6 +53,18 @@ template<size_t value>
 constexpr size_t product_odd() { return value * product_odd<value - 2>(); }
 }
 
+template<FloatingPoint T>
+constexpr T to_radians(T degrees)
+{
+    return degrees * AK::Pi<T> / 180;
+}
+
+template<FloatingPoint T>
+constexpr T to_degrees(T radians)
+{
+    return radians * 180 / AK::Pi<T>;
+}
+
 #define CONSTEXPR_STATE(function, args...)        \
     if (is_constant_evaluated()) {                \
         if (IsSame<T, long double>)               \

--- a/Userland/Applications/Maps/MapWidget.cpp
+++ b/Userland/Applications/Maps/MapWidget.cpp
@@ -11,16 +11,6 @@
 #include <LibProtocol/Request.h>
 
 // Math helpers
-static double radians(double degrees)
-{
-    return degrees * M_PI / 180.0;
-}
-
-static double degrees(double radians)
-{
-    return radians * 180.0 / M_PI;
-}
-
 // https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames#Pseudo-code
 static double longitude_to_tile_x(double longitude, int zoom)
 {
@@ -29,7 +19,7 @@ static double longitude_to_tile_x(double longitude, int zoom)
 
 static double latitude_to_tile_y(double latitude, int zoom)
 {
-    return pow(2, zoom) * (1.0 - (log(tan(radians(latitude)) + (1.0 / cos(radians(latitude)))) / M_PI)) / 2.0;
+    return pow(2, zoom) * (1.0 - (log(tan(AK::to_radians(latitude)) + (1.0 / cos(AK::to_radians(latitude)))) / M_PI)) / 2.0;
 }
 
 static double tile_x_to_longitude(double x, int zoom)
@@ -39,7 +29,7 @@ static double tile_x_to_longitude(double x, int zoom)
 
 static double tile_y_to_latitude(double y, int zoom)
 {
-    return degrees(atan(sinh(M_PI * (1.0 - 2.0 * y / pow(2, zoom)))));
+    return AK::to_degrees(atan(sinh(M_PI * (1.0 - 2.0 * y / pow(2, zoom)))));
 }
 
 static double nice_round_number(double number)
@@ -52,7 +42,7 @@ static double nice_round_number(double number)
 double MapWidget::LatLng::distance_to(LatLng const& other) const
 {
     double const earth_radius = 6371000.0;
-    return earth_radius * 2.0 * asin(sqrt(pow(sin((radians(other.latitude) - radians(latitude)) / 2.0), 2.0) + cos(radians(latitude)) * cos(radians(other.latitude)) * pow(sin((radians(other.longitude) - radians(longitude)) / 2.0), 2.0)));
+    return earth_radius * 2.0 * asin(sqrt(pow(sin((AK::to_radians(other.latitude) - AK::to_radians(latitude)) / 2.0), 2.0) + cos(AK::to_radians(latitude)) * cos(AK::to_radians(other.latitude)) * pow(sin((AK::to_radians(other.longitude) - AK::to_radians(longitude)) / 2.0), 2.0)));
 }
 
 // MapWidget class

--- a/Userland/Applications/PixelPaint/ImageMasking.cpp
+++ b/Userland/Applications/PixelPaint/ImageMasking.cpp
@@ -312,7 +312,7 @@ void ColorWheelWidget::paint_event(GUI::PaintEvent&)
 
     auto wedge_edge = Gfx::FloatPoint(0, -height() / 2);
 
-    float deg_as_radians = 10.0f * (AK::Pi<float> / 180);
+    float deg_as_radians = AK::to_radians(10.0f);
     Gfx::AffineTransform transform;
     transform.rotate_radians(deg_as_radians);
 
@@ -339,12 +339,12 @@ void ColorWheelWidget::paint_event(GUI::PaintEvent&)
     }
 
     transform.rotate_radians(-deg_as_radians);
-    deg_as_radians = static_cast<float>(hue()) * (AK::Pi<float> / 180);
+    deg_as_radians = AK::to_radians(static_cast<float>(hue()));
     transform.rotate_radians(deg_as_radians);
     auto selected_color = Gfx::FloatPoint(0, -height() / 2);
     selected_color.transform_by(transform);
 
-    deg_as_radians = static_cast<float>(color_range()) * (AK::Pi<float> / 180);
+    deg_as_radians = AK::to_radians(static_cast<float>(color_range()));
 
     auto selected_color_edge_1 = Gfx::FloatPoint(0, -height() / 2);
     transform.rotate_radians(deg_as_radians);
@@ -356,7 +356,7 @@ void ColorWheelWidget::paint_event(GUI::PaintEvent&)
     selected_color_edge_2.transform_by(transform);
 
     transform.rotate_radians(deg_as_radians);
-    deg_as_radians = static_cast<float>(color_range() * static_cast<double>(hardness()) / 100.0) * (AK::Pi<float> / 180);
+    deg_as_radians = AK::to_radians(static_cast<float>(color_range() * static_cast<double>(hardness()) / 100.0));
 
     auto hardness_edge_1 = Gfx::FloatPoint(0, -height() / 2);
     transform.rotate_radians(deg_as_radians);
@@ -438,7 +438,7 @@ void ColorWheelWidget::calc_hue(Gfx::IntPoint const& position)
 {
     auto center = Gfx::IntPoint(width() / 2, height() / 2);
 
-    auto angle = AK::atan2(static_cast<float>(position.y() - center.y()), static_cast<float>(position.x() - center.x())) * 180 / AK::Pi<float>;
+    auto angle = AK::atan2(static_cast<float>(position.y() - center.y()), AK::to_degrees(static_cast<float>(position.x() - center.x())));
     set_hue(angle + 90);
 }
 

--- a/Userland/Applications/PixelPaint/Tools/GradientTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/GradientTool.cpp
@@ -354,7 +354,7 @@ void GradientTool::draw_gradient(GUI::Painter& painter, bool with_guidelines, co
     int height = m_editor->active_layer()->rect().height() * scale;
 
     float rotation_radians = atan2f(t_gradient_begin_line.a().y() - t_gradient_end_line.a().y(), t_gradient_begin_line.a().x() - t_gradient_end_line.a().x());
-    float rotation_degrees = (rotation_radians * 180) / AK::Pi<float>;
+    float rotation_degrees = AK::to_degrees(rotation_radians);
 
     auto determine_required_side_length = [&](int center, int side_length) {
         if (center < 0)

--- a/Userland/Games/ColorLines/HueFilter.h
+++ b/Userland/Games/ColorLines/HueFilter.h
@@ -30,7 +30,7 @@ public:
 private:
     static FloatMatrix3x3 calculate_hue_rotate_matrix(float angle_degrees)
     {
-        float const angle_rads = angle_degrees * (AK::Pi<float> / 180.0f);
+        float const angle_rads = AK::to_radians(angle_degrees);
         float cos_angle = 0.;
         float sin_angle = 0.;
         AK::sincos(angle_rads, sin_angle, cos_angle);

--- a/Userland/Libraries/LibGL/Matrix.cpp
+++ b/Userland/Libraries/LibGL/Matrix.cpp
@@ -145,7 +145,7 @@ void GLContext::gl_rotate(GLfloat angle, GLfloat x, GLfloat y, GLfloat z)
     FloatVector3 axis = { x, y, z };
     if (axis.length() > 0.f)
         axis.normalize();
-    auto rotation_mat = Gfx::rotation_matrix(axis, angle * static_cast<float>(M_PI * 2 / 360));
+    auto rotation_mat = Gfx::rotation_matrix(axis, AK::to_radians(angle));
     update_current_matrix(*m_current_matrix * rotation_mat);
 }
 

--- a/Userland/Libraries/LibGfx/DeltaE.cpp
+++ b/Userland/Libraries/LibGfx/DeltaE.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/Format.h>
+#include <AK/Math.h>
 #include <LibGfx/DeltaE.h>
 #include <math.h>
 
@@ -39,7 +40,7 @@ float DeltaE(CIELAB const& c1, CIELAB const& c2)
         float h_prime = atan2(b, a_prime);
         if (h_prime < 0)
             h_prime += 2 * static_cast<float>(M_PI);
-        return h_prime * 180 / static_cast<float>(M_PI);
+        return AK::to_degrees(h_prime);
     };
     float h1_prime = h_prime(c1.b, a1_prime);
     float h2_prime = h_prime(c2.b, a2_prime);
@@ -54,8 +55,8 @@ float DeltaE(CIELAB const& c1, CIELAB const& c2)
     else
         delta_h_prime = h2_prime - h1_prime - 360;
 
-    auto sin_degrees = [](float x) { return sinf(x * static_cast<float>(M_PI) / 180); };
-    auto cos_degrees = [](float x) { return cosf(x * static_cast<float>(M_PI) / 180); };
+    auto sin_degrees = [](float x) { return sinf(AK::to_radians(x)); };
+    auto cos_degrees = [](float x) { return cosf(AK::to_radians(x)); };
 
     float delta_H_prime = 2 * sqrtf(C1_prime * C2_prime) * sin_degrees(delta_h_prime / 2);
 

--- a/Userland/Libraries/LibGfx/Filters/HueRotateFilter.h
+++ b/Userland/Libraries/LibGfx/Filters/HueRotateFilter.h
@@ -27,7 +27,7 @@ public:
 private:
     static FloatMatrix3x3 calculate_hue_rotate_matrix(float angle_degrees)
     {
-        float angle_rads = angle_degrees * (AK::Pi<float> / 180);
+        float angle_rads = AK::to_radians(angle_degrees);
         float cos_angle = 0;
         float sin_angle = 0;
         AK::sincos(angle_rads, sin_angle, cos_angle);

--- a/Userland/Libraries/LibGfx/GradientPainting.cpp
+++ b/Userland/Libraries/LibGfx/GradientPainting.cpp
@@ -241,7 +241,7 @@ static auto create_conic_gradient(ReadonlySpan<ColorStop> color_stops, FloatPoin
         [=](int x, int y) {
             auto point = FloatPoint { x, y } - center_point;
             // FIXME: We could probably get away with some approximation here:
-            auto loc = fmod((AK::atan2(point.y(), point.x()) * 180.0f / AK::Pi<float> + 360.0f + normalized_start_angle), 360.0f);
+            auto loc = fmod((AK::to_degrees(AK::atan2(point.y(), point.x())) + 360.0f + normalized_start_angle), 360.0f);
             return should_floor_angles ? floor(loc) : loc;
         }
     };
@@ -256,7 +256,7 @@ static auto create_radial_gradient(IntRect const& physical_rect, ReadonlySpan<Co
     auto center_point = FloatPoint { center }.translated(0.5, 0.5);
     AffineTransform rotation_transform;
     if (rotation_angle.has_value()) {
-        auto angle_as_radians = rotation_angle.value() * (AK::Pi<float> / 180);
+        auto angle_as_radians = AK::to_radians(rotation_angle.value());
         rotation_transform.rotate_radians(angle_as_radians);
     }
 

--- a/Userland/Libraries/LibGfx/Gradients.h
+++ b/Userland/Libraries/LibGfx/Gradients.h
@@ -24,7 +24,7 @@ inline float normalized_gradient_angle_radians(float gradient_angle)
 {
     // Adjust angle so 0 degrees is bottom
     float real_angle = 90 - gradient_angle;
-    return real_angle * (AK::Pi<float> / 180);
+    return AK::to_radians(real_angle);
 }
 
 template<typename T>

--- a/Userland/Libraries/LibSoftGPU/Device.cpp
+++ b/Userland/Libraries/LibSoftGPU/Device.cpp
@@ -904,7 +904,7 @@ void Device::calculate_vertex_lighting(GPU::Vertex& vertex) const
         float spotlight_factor = 1.0f;
         if (light.spotlight_cutoff_angle != 180.0f) {
             auto const vertex_to_light_dot_spotlight_direction = sgi_dot_operator(vertex_to_light, light.spotlight_direction.normalized());
-            auto const cos_spotlight_cutoff = AK::cos<float>(light.spotlight_cutoff_angle * AK::Pi<float> / 180.f);
+            auto const cos_spotlight_cutoff = AK::cos<float>(AK::to_radians(light.spotlight_cutoff_angle));
 
             if (vertex_to_light_dot_spotlight_direction >= cos_spotlight_cutoff)
                 spotlight_factor = AK::pow<float>(vertex_to_light_dot_spotlight_direction, light.spotlight_exponent);

--- a/Userland/Libraries/LibWeb/CSS/Angle.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Angle.cpp
@@ -39,7 +39,7 @@ double Angle::to_degrees() const
     case Type::Grad:
         return m_value * (360.0 / 400.0);
     case Type::Rad:
-        return m_value * (180.0 / AK::Pi<double>);
+        return AK::to_degrees(m_value);
     case Type::Turn:
         return m_value * 360.0;
     }
@@ -48,7 +48,7 @@ double Angle::to_degrees() const
 
 double Angle::to_radians() const
 {
-    return to_degrees() * (AK::Pi<double> / 180.0);
+    return AK::to_radians(to_degrees());
 }
 
 StringView Angle::unit_name() const

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/LinearGradientStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/LinearGradientStyleValue.cpp
@@ -66,7 +66,7 @@ bool LinearGradientStyleValue::equals(StyleValue const& other_) const
 float LinearGradientStyleValue::angle_degrees(CSSPixelSize gradient_size) const
 {
     auto corner_angle_degrees = [&] {
-        return atan2(gradient_size.height().to_double(), gradient_size.width().to_double()) * 180 / AK::Pi<double>;
+        return AK::to_degrees(atan2(gradient_size.height().to_double(), gradient_size.width().to_double()));
     };
     return m_properties.direction.visit(
         [&](SideOrCorner side_or_corner) {

--- a/Userland/Libraries/LibWeb/Geometry/DOMMatrix.cpp
+++ b/Userland/Libraries/LibWeb/Geometry/DOMMatrix.cpp
@@ -313,7 +313,7 @@ JS::NonnullGCPtr<DOMMatrix> DOMMatrix::skew_x_self(double sx)
 {
     // 1. Post-multiply a skewX transformation on the current matrix by the specified angle sx in degrees. The 2D skewX matrix is described in CSS Transforms with alpha = sx in degrees. [CSS3-TRANSFORMS]
     // clang-format off
-    Gfx::DoubleMatrix4x4 skew_matrix = { 1, tan(sx * M_PI / 180.0), 0, 0,
+    Gfx::DoubleMatrix4x4 skew_matrix = { 1, tan(AK::to_radians(sx)), 0, 0,
         0, 1, 0, 0,
         0, 0, 1, 0,
         0, 0, 0, 1 };
@@ -330,7 +330,7 @@ JS::NonnullGCPtr<DOMMatrix> DOMMatrix::skew_y_self(double sy)
     // 1. Post-multiply a skewX transformation on the current matrix by the specified angle sy in degrees. The 2D skewY matrix is described in CSS Transforms with beta = sy in degrees. [CSS3-TRANSFORMS]
     // clang-format off
     Gfx::DoubleMatrix4x4 skew_matrix = { 1, 0, 0, 0,
-        tan(sy * M_PI / 180.0), 1, 0, 0,
+        tan(AK::to_radians(sy)), 1, 0, 0,
         0, 0, 1, 0,
         0, 0, 0, 1 };
     // clang-format on

--- a/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
@@ -74,9 +74,6 @@ Optional<Gfx::PaintStyle const&> SVGGraphicsElement::stroke_paint_style(SVGPaint
 Gfx::AffineTransform transform_from_transform_list(ReadonlySpan<Transform> transform_list)
 {
     Gfx::AffineTransform affine_transform;
-    auto to_radians = [](float degrees) {
-        return degrees * (AK::Pi<float> / 180.0f);
-    };
     for (auto& transform : transform_list) {
         transform.operation.visit(
             [&](Transform::Translate const& translate) {
@@ -90,14 +87,14 @@ Gfx::AffineTransform transform_from_transform_list(ReadonlySpan<Transform> trans
                 affine_transform.multiply(
                     Gfx::AffineTransform {}
                         .translate({ rotate.x, rotate.y })
-                        .rotate_radians(to_radians(rotate.a))
+                        .rotate_radians(AK::to_radians(rotate.a))
                         .translate({ -rotate.x, -rotate.y }));
             },
             [&](Transform::SkewX const& skew_x) {
-                affine_transform.multiply(Gfx::AffineTransform {}.skew_radians(to_radians(skew_x.a), 0));
+                affine_transform.multiply(Gfx::AffineTransform {}.skew_radians(AK::to_radians(skew_x.a), 0));
             },
             [&](Transform::SkewY const& skew_y) {
-                affine_transform.multiply(Gfx::AffineTransform {}.skew_radians(0, to_radians(skew_y.a)));
+                affine_transform.multiply(Gfx::AffineTransform {}.skew_radians(0, AK::to_radians(skew_y.a)));
             },
             [&](Transform::Matrix const& matrix) {
                 affine_transform.multiply(Gfx::AffineTransform {


### PR DESCRIPTION
This adds the `to_radians` and `to_degrees` functions to AK math, I have also updated all instances in the codebase where degrees where converted to radians and reverse, maybe I missed some then they can also be added to this commit.

These functions make the code a little bit easier to read.