### PR TITLE
Base: Fix sys(7) manual page

### DIFF
--- a/Base/usr/share/man/man7/sys.md
+++ b/Base/usr/share/man/man7/sys.md
@@ -55,6 +55,9 @@ them.
 * **`jails`** - This node exports information about existing jails (only if the current process is not in jail).
 * **`power_state`** - This node only responds to write requests on it. A written value of `1` results
 in system reboot. A written value of `2` results in system shutdown.
+* **`load_base`** - This node reveals the loading address of the kernel.
+* **`system_mode`** - This node exports the chosen system mode as it was decided based on the kernel commandline or a default value.
+* **`cmdline`** - This node exports the kernel boot commandline that was passed from the bootloader.
 
 #### `net` directory
 
@@ -72,16 +75,6 @@ This subdirectory includes global settings of the kernel.
 * **`kmalloc_stacks`** - This node controls whether to send information about kmalloc to debug log.
 * **`ubsan_is_deadly`** - This node controls the deadliness of the kernel undefined behavior
 sanitizer errors.
-
-#### `constants` directory
-
-This subdirectory includes global constants of the kernel.
-Those nodes are generated during the boot sequence and are completely static,
-therefore making them very fast to read (no kmalloc or locking is needed).
-
-* **`load_base`** - This node reveals the loading address of the kernel.
-* **`system_mode`** - This node exports the chosen system mode as it was decided based on the kernel commandline or a default value.
-* **`cmdline`** - This node exports the kernel boot commandline that was passed from the bootloader.
 
 ### Consistency and stability of data across multiple read operations
 

--- a/Base/usr/share/man/man7/sys.md
+++ b/Base/usr/share/man/man7/sys.md
@@ -34,7 +34,7 @@ A file called `power_state` is responsible for power state switching.
 
 ### `kernel` directory
 
-This directory includes two subdirectories - `net` and `variables`.
+This directory includes two subdirectories - `net` and `conf`.
 All other files in the directory are global data nodes which provide statistics
 and other kernel-related data to userspace.
 
@@ -67,7 +67,7 @@ in system reboot. A written value of `2` results in system shutdown.
 * **`tcp`** - This node exports information on TCP sockets.
 * **`udp`** - This node exports information on UDP sockets.
 
-#### `variables` directory
+#### `conf` directory
 
 This subdirectory includes global settings of the kernel.
 


### PR DESCRIPTION
There's no constants directory anymore under /sys/kernel, so bring all the described nodes back to the "kernel" directory entries list.

Also, the /sys/kernel/variables directory was renamed to /sys/kernel/conf so let's fix this as well.