### PR TITLE
Meta: Do not spam "<compiler-name>: command not found"

### DIFF
--- a/Meta/find_compiler.sh
+++ b/Meta/find_compiler.sh
@@ -9,7 +9,7 @@ is_supported_compiler() {
     fi
 
     local VERSION=""
-    VERSION="$($COMPILER -dumpversion)" || return 1
+    VERSION="$($COMPILER -dumpversion 2> /dev/null)" || return 1
     local MAJOR_VERSION=""
     MAJOR_VERSION="${VERSION%%.*}"
     if $COMPILER --version 2>&1 | grep "Apple clang" >/dev/null; then


### PR DESCRIPTION
In bd7d01e9, Meta/serenity.sh started checking cc and cxx if CC or CXX respectively are not set in the environment. My machine does not have cxx symlink in PATH, so every invocation of the script resulted in the "cxx: command not found" message outputted to stderr, and that became quite annoying.