### PR TITLE
find: Add `-gid` and `-uid` options to filter files by group and user ID

### DIFF
--- a/Base/usr/share/man/man1/find.md
+++ b/Base/usr/share/man/man1/find.md
@@ -70,6 +70,8 @@ by the current user.
   the specified reference file. If `file` is a symbolic link and the `-L`
   option is in use, then the creation time of the file pointed to by the
   symbolic link is used.
+* `-gid [-|+]number`: Checks if the file is owned by a group with an ID less
+  than, greater than or exactly `number`.
 * `-print`: Outputs the file path, followed by a newline. Always evaluates to
   true.
 * `-print0`: Outputs the file path, followed by a zero byte. Always evaluates to

--- a/Base/usr/share/man/man1/find.md
+++ b/Base/usr/share/man/man1/find.md
@@ -72,6 +72,8 @@ by the current user.
   symbolic link is used.
 * `-gid [-|+]number`: Checks if the file is owned by a group with an ID less
   than, greater than or exactly `number`.
+* `-uid [-|+]number`: Checks if the file is owned by a user with an ID less
+  than, greater than or exactly `number`.
 * `-print`: Outputs the file path, followed by a newline. Always evaluates to
   true.
 * `-print0`: Outputs the file path, followed by a zero byte. Always evaluates to

--- a/Userland/Utilities/find.cpp
+++ b/Userland/Utilities/find.cpp
@@ -473,7 +473,27 @@ private:
         return m_gid_range.contains(stat.st_gid);
     }
 
-    NumericRange<gid_t> m_gid_range;
+    NumericRange<gid_t> m_gid_range {};
+};
+
+class UidCommand final : public StatCommand {
+public:
+    UidCommand(char const* arg)
+    {
+        auto uid_or_error = NumericRange<uid_t>::parse({ arg, strlen(arg) });
+        if (uid_or_error.is_error())
+            fatal_error("find: Invalid argument '{}' to '-uid'", arg);
+
+        m_uid_range = uid_or_error.release_value();
+    }
+
+private:
+    virtual bool evaluate(struct stat const& stat) const override
+    {
+        return m_uid_range.contains(stat.st_uid);
+    }
+
+    NumericRange<uid_t> m_uid_range {};
 };
 
 class PrintCommand final : public Command {
@@ -691,6 +711,10 @@ static OwnPtr<Command> parse_simple_command(Vector<char*>& args)
         if (args.is_empty())
             fatal_error("-gid: requires additional arguments");
         return make<GidCommand>(args.take_first());
+    } else if (arg == "-uid") {
+        if (args.is_empty())
+            fatal_error("-uid: requires additional arguments");
+        return make<UidCommand>(args.take_first());
     } else if (arg == "-print") {
         g_have_seen_action_command = true;
         return make<PrintCommand>();

--- a/Userland/Utilities/find.cpp
+++ b/Userland/Utilities/find.cpp
@@ -456,6 +456,26 @@ private:
     TimestampType m_timestamp_type { TimestampType::LastModification };
 };
 
+class GidCommand final : public StatCommand {
+public:
+    GidCommand(char const* arg)
+    {
+        auto gid_or_error = NumericRange<gid_t>::parse({ arg, strlen(arg) });
+        if (gid_or_error.is_error())
+            fatal_error("find: Invalid argument '{}' to '-gid'", arg);
+
+        m_gid_range = gid_or_error.release_value();
+    }
+
+private:
+    virtual bool evaluate(struct stat const& stat) const override
+    {
+        return m_gid_range.contains(stat.st_gid);
+    }
+
+    NumericRange<gid_t> m_gid_range;
+};
+
 class PrintCommand final : public Command {
 public:
     PrintCommand(char terminator = '\n')
@@ -667,6 +687,10 @@ static OwnPtr<Command> parse_simple_command(Vector<char*>& args)
         if (args.is_empty())
             fatal_error("-cnewer: requires additional arguments");
         return make<NewerCommand>(args.take_first(), NewerCommand::TimestampType::Creation);
+    } else if (arg == "-gid") {
+        if (args.is_empty())
+            fatal_error("-gid: requires additional arguments");
+        return make<GidCommand>(args.take_first());
     } else if (arg == "-print") {
         g_have_seen_action_command = true;
         return make<PrintCommand>();


### PR DESCRIPTION
This PR adds the `-gid` and `-uid` options to filter files by user and group ID. Both of these options can be prefixed with '+' or '-' to return files with an ID greater than or less than the given value.

Example usage:

![find_uid_gid_option](https://github.com/SerenityOS/serenity/assets/2817754/4eba4188-b428-421c-bdbd-9b439a452452)
