### PR TITLE
LibELF: Calculate size of relocation table correctly in all cases

### DIFF
--- a/Userland/Libraries/LibELF/DynamicObject.cpp
+++ b/Userland/Libraries/LibELF/DynamicObject.cpp
@@ -189,6 +189,19 @@ void DynamicObject::parse()
         m_size_of_relocation_entry = sizeof(ElfW(Rel));
     }
 
+    // Whether or not RELASZ (stored in m_size_of_relocation_table) only refers to non-PLT entries is not clearly specified.
+    // So check if [JMPREL, JMPREL+PLTRELSZ) is in [RELA, RELA+RELASZ).
+    // If so, change the size of the non-PLT relocation table.
+    if (m_plt_relocation_offset_location >= m_relocation_table_offset                                     // JMPREL >= RELA
+        && m_plt_relocation_offset_location < (m_relocation_table_offset + m_size_of_relocation_table)) { // JMPREL < (RELA + RELASZ)
+        // [JMPREL, JMPREL+PLTRELSZ) is in [RELA, RELA+RELASZ)
+
+        // Verify that the ends of the tables match up
+        VERIFY(m_plt_relocation_offset_location + m_size_of_plt_relocation_entry_list == m_relocation_table_offset + m_size_of_relocation_table);
+
+        m_size_of_relocation_table -= m_size_of_plt_relocation_entry_list;
+    }
+
     auto hash_section_address = hash_section().address().as_ptr();
     // TODO: consider base address - it might not be zero
     auto num_hash_chains = ((u32*)hash_section_address)[1];


### PR DESCRIPTION
The `DT_RELASZ` dynamic tag in riscv64's `libgcc_s.so` contains the total size of both non-PLT and PLT relocation entries. Serenity currently expects that `RELASZ` contains the size of only non-PLT entries. Both behaviors are apparently correct according to the ELF spec.

- https://www.github.com/llvm/llvm-project/issues/39026#issuecomment-981005259
- https://sourceware.org/pipermail/binutils/2023-August/128935.html