### PR TITLE
find: Add the `-maxdepth` and `-mindepth` options

### DIFF
--- a/Base/usr/share/man/man1/find.md
+++ b/Base/usr/share/man/man1/find.md
@@ -24,6 +24,12 @@ specified commands, a `-print` command is implicitly appended.
 
 ## Commands
 
+* `-maxdepth n`: Do not descend more than `n` levels below each path given on
+  the command line. Specifying `-maxdepth 0` has the effect of only evaluating
+  each command line argument.
+* `-mindepth n`: Descend `n` levels below each path given on the command line
+  before executing any commands. Specifying `-mindepth 1` has the effect of
+  processing all files except the command line arguments.
 * `-type t`: Checks if the file is of the specified type, which must be one of
   `b` (for block device), `c` (character device), `d` (directory), `l` (symbolic
   link), `p` (FIFO), `f` (regular file), and `s` (socket).


### PR DESCRIPTION
The `-maxdepth` option limits the number of levels `find` will descend into the file system for each given starting point.

The `-mindepth` option causes commands not to be evaluated until the specified depth is reached.

Example `-maxdepth` usage:

![find_maxdepth](https://github.com/SerenityOS/serenity/assets/2817754/504fe706-7c07-472c-b856-850b8d12d4ef)

Example `-mindepth` usage:

![find_mindepth](https://github.com/SerenityOS/serenity/assets/2817754/26dd5146-8312-4495-b9ad-baa770fd375a)
