### PR TITLE
LibWeb: Set children of button layout box to be non-inline

### DIFF
--- a/Tests/LibWeb/Layout/expected/block-and-inline/button-baseline-align.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/button-baseline-align.txt
@@ -1,24 +1,22 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
-    BlockContainer <body> at (8,8) content-size 784x47.671875 children: inline
-      line 0 width: 61.1875, height: 47.671875, bottom: 47.671875, baseline: 35.84375
-        frag 0 from BlockContainer start: 0, length: 0, rect: [8,8 61.1875x47.671875]
-      BlockContainer <div.ib> at (8,8) content-size 61.1875x47.671875 inline-block [BFC] children: inline
-        line 0 width: 61.1875, height: 47.671875, bottom: 47.671875, baseline: 35.84375
-          frag 0 from BlockContainer start: 0, length: 0, rect: [9,26 17.828125x21.84375]
-          frag 1 from TextNode start: 0, length: 1, rect: [28,30 8x17.46875]
+    BlockContainer <body> at (8,8) content-size 784x47.6875 children: inline
+      line 0 width: 61.1875, height: 47.6875, bottom: 47.6875, baseline: 33.84375
+        frag 0 from BlockContainer start: 0, length: 0, rect: [8,8 61.1875x47.6875]
+      BlockContainer <div.ib> at (8,8) content-size 61.1875x47.6875 inline-block [BFC] children: inline
+        line 0 width: 61.1875, height: 47.6875, bottom: 47.6875, baseline: 33.84375
+          frag 0 from BlockContainer start: 0, length: 0, rect: [9,24 17.828125x21.84375]
+          frag 1 from TextNode start: 0, length: 1, rect: [28,28 8x17.46875]
             " "
-          frag 2 from BlockContainer start: 0, length: 0, rect: [41,10 23.359375x43.671875]
+          frag 2 from BlockContainer start: 0, length: 0, rect: [41,10 23.359375x43.6875]
         TextNode <#text>
-        BlockContainer <div.label> at (9,26) content-size 17.828125x21.84375 inline-block [BFC] children: inline
+        BlockContainer <div.label> at (9,24) content-size 17.828125x21.84375 inline-block [BFC] children: inline
           line 0 width: 17.828125, height: 21.84375, bottom: 21.84375, baseline: 16.921875
-            frag 0 from TextNode start: 0, length: 1, rect: [9,26 17.828125x21.84375]
+            frag 0 from TextNode start: 0, length: 1, rect: [9,24 17.828125x21.84375]
               "A"
           TextNode <#text>
         TextNode <#text>
-        BlockContainer <button> at (41,10) content-size 23.359375x43.671875 inline-block [BFC] children: inline
-          line 0 width: 23.359375, height: 43.671875, bottom: 43.671875, baseline: 33.84375
-            frag 0 from BlockContainer start: 0, length: 0, rect: [41,10 23.359375x43.6875]
+        BlockContainer <button> at (41,10) content-size 23.359375x43.6875 inline-block [BFC] children: not-inline
           BlockContainer <(anonymous)> at (41,10) content-size 23.359375x43.6875 flex-container(column) [FFC] children: not-inline
             BlockContainer <(anonymous)> at (41,10) content-size 23.359375x43.6875 flex-item [BFC] children: inline
               line 0 width: 23.359375, height: 43.6875, bottom: 43.6875, baseline: 33.84375
@@ -29,12 +27,12 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
-    PaintableWithLines (BlockContainer<BODY>) [8,8 784x47.671875]
-      PaintableWithLines (BlockContainer<DIV>.ib) [8,8 61.1875x47.671875]
-        PaintableWithLines (BlockContainer<DIV>.label) [8,25 19.828125x23.84375]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x47.6875]
+      PaintableWithLines (BlockContainer<DIV>.ib) [8,8 61.1875x47.6875]
+        PaintableWithLines (BlockContainer<DIV>.label) [8,23 19.828125x23.84375]
           TextPaintable (TextNode<#text>)
         TextPaintable (TextNode<#text>)
-        PaintableWithLines (BlockContainer<BUTTON>) [36,8 33.359375x47.671875]
+        PaintableWithLines (BlockContainer<BUTTON>) [36,8 33.359375x47.6875]
           PaintableWithLines (BlockContainer(anonymous)) [41,10 23.359375x43.6875]
             PaintableWithLines (BlockContainer(anonymous)) [41,10 23.359375x43.6875]
               TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/block-and-inline/button-image-only.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/button-image-only.txt
@@ -1,11 +1,9 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
-    BlockContainer <body> at (8,8) content-size 784x419.203125 children: inline
-      line 0 width: 430, height: 419.203125, bottom: 419.203125, baseline: 422
-        frag 0 from BlockContainer start: 0, length: 0, rect: [13,10 420x415.203125]
-      BlockContainer <button> at (13,10) content-size 420x415.203125 inline-block [BFC] children: inline
-        line 0 width: 420, height: 415.203125, bottom: 415.203125, baseline: 420
-          frag 0 from BlockContainer start: 0, length: 0, rect: [13,10 420x420]
+    BlockContainer <body> at (8,8) content-size 784x424 children: inline
+      line 0 width: 430, height: 424, bottom: 424, baseline: 420
+        frag 0 from BlockContainer start: 0, length: 0, rect: [13,10 420x420]
+      BlockContainer <button> at (13,10) content-size 420x420 inline-block [BFC] children: not-inline
         BlockContainer <(anonymous)> at (13,10) content-size 420x420 flex-container(column) [FFC] children: not-inline
           BlockContainer <(anonymous)> at (13,10) content-size 420x420 flex-item [BFC] children: inline
             line 0 width: 420, height: 420, bottom: 420, baseline: 420
@@ -17,8 +15,8 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
-    PaintableWithLines (BlockContainer<BODY>) [8,8 784x419.203125]
-      PaintableWithLines (BlockContainer<BUTTON>) [8,8 430x419.203125] overflow: [9,9 428x421]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x424]
+      PaintableWithLines (BlockContainer<BUTTON>) [8,8 430x424]
         PaintableWithLines (BlockContainer(anonymous)) [13,10 420x420]
           PaintableWithLines (BlockContainer(anonymous)) [13,10 420x420]
             ImagePaintable (ImageBox<IMG>) [13,10 420x420]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/button-with-abspos-pseudo-element.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/button-with-abspos-pseudo-element.txt
@@ -5,15 +5,15 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         frag 0 from BlockContainer start: 0, length: 0, rect: [29,29 0x0]
       BlockContainer <button> at (29,29) content-size 0x0 positioned inline-block [BFC] children: not-inline
         BlockContainer <(anonymous)> at (29,29) content-size 0x0 flex-container(column) [FFC] children: not-inline
-          BlockContainer <(anonymous)> at (29,29) content-size 0x0 flex-item [BFC] children: not-inline
-            BlockContainer <(anonymous)> at (9,9) content-size 40x40 positioned [BFC] children: inline
-              TextNode <#text>
+          BlockContainer <(anonymous)> at (29,29) content-size 0x0 [BFC] children: not-inline
+        BlockContainer <(anonymous)> at (9,9) content-size 40x40 positioned [BFC] children: inline
+          TextNode <#text>
       TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x58]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x42]
       PaintableWithLines (BlockContainer<BUTTON>) [8,8 42x42]
-        PaintableWithLines (BlockContainer(anonymous)) [29,29 0x0] overflow: [9,9 40x40]
-          PaintableWithLines (BlockContainer(anonymous)) [29,29 0x0] overflow: [9,9 40x40]
-            PaintableWithLines (BlockContainer(anonymous)) [9,9 40x40]
+        PaintableWithLines (BlockContainer(anonymous)) [29,29 0x0]
+          PaintableWithLines (BlockContainer(anonymous)) [29,29 0x0]
+        PaintableWithLines (BlockContainer(anonymous)) [9,9 40x40]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/button-with-after-pseudo.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/button-with-after-pseudo.txt
@@ -1,0 +1,23 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x74.59375 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x58.59375 children: inline
+      line 0 width: 424.640625, height: 58.59375, bottom: 58.59375, baseline: 42.28125
+        frag 0 from BlockContainer start: 0, length: 0, rect: [13,10 414.640625x54.59375]
+      BlockContainer <button.button_button___eDCW> at (13,10) content-size 414.640625x54.59375 positioned inline-block [BFC] children: not-inline
+        BlockContainer <(anonymous)> at (13,10) content-size 414.640625x54.59375 flex-container(column) [FFC] children: not-inline
+          BlockContainer <(anonymous)> at (13,10) content-size 414.640625x54.59375 flex-item [BFC] children: inline
+            line 0 width: 414.640625, height: 54.59375, bottom: 54.59375, baseline: 42.28125
+              frag 0 from TextNode start: 0, length: 14, rect: [13,10 414.640625x54.59375]
+                "See more games"
+            TextNode <#text>
+        BlockContainer <(anonymous)> at (9,9) content-size 422.640625x56.59375 positioned [BFC] children: inline
+          TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x74.59375]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x58.59375]
+      PaintableWithLines (BlockContainer<BUTTON>.button_button___eDCW) [8,8 424.640625x58.59375]
+        PaintableWithLines (BlockContainer(anonymous)) [13,10 414.640625x54.59375]
+          PaintableWithLines (BlockContainer(anonymous)) [13,10 414.640625x54.59375]
+            TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer(anonymous)) [9,9 422.640625x56.59375]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/button-with-before-pseudo.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/button-with-before-pseudo.txt
@@ -1,0 +1,23 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x74.59375 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x58.59375 children: inline
+      line 0 width: 424.640625, height: 58.59375, bottom: 58.59375, baseline: 42.28125
+        frag 0 from BlockContainer start: 0, length: 0, rect: [13,10 414.640625x54.59375]
+      BlockContainer <button.button_button___eDCW> at (13,10) content-size 414.640625x54.59375 positioned inline-block [BFC] children: not-inline
+        BlockContainer <(anonymous)> at (9,9) content-size 422.640625x56.59375 positioned [BFC] children: inline
+          TextNode <#text>
+        BlockContainer <(anonymous)> at (13,10) content-size 414.640625x54.59375 flex-container(column) [FFC] children: not-inline
+          BlockContainer <(anonymous)> at (13,10) content-size 414.640625x54.59375 flex-item [BFC] children: inline
+            line 0 width: 414.640625, height: 54.59375, bottom: 54.59375, baseline: 42.28125
+              frag 0 from TextNode start: 0, length: 14, rect: [13,10 414.640625x54.59375]
+                "See more games"
+            TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x74.59375]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x58.59375]
+      PaintableWithLines (BlockContainer<BUTTON>.button_button___eDCW) [8,8 424.640625x58.59375]
+        PaintableWithLines (BlockContainer(anonymous)) [9,9 422.640625x56.59375]
+        PaintableWithLines (BlockContainer(anonymous)) [13,10 414.640625x54.59375]
+          PaintableWithLines (BlockContainer(anonymous)) [13,10 414.640625x54.59375]
+            TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/block-and-inline/button-with-multiple-words-text-node-label.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/button-with-multiple-words-text-node-label.txt
@@ -1,11 +1,9 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x21.46875 children: inline
-      line 0 width: 59.921875, height: 21.46875, bottom: 21.46875, baseline: 15.53125
+      line 0 width: 59.921875, height: 21.46875, bottom: 21.46875, baseline: 13.53125
         frag 0 from BlockContainer start: 0, length: 0, rect: [13,10 49.921875x17.46875]
-      BlockContainer <button> at (13,10) content-size 49.921875x17.46875 inline-block [BFC] children: inline
-        line 0 width: 49.921875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-          frag 0 from BlockContainer start: 0, length: 0, rect: [13,10 49.921875x17.46875]
+      BlockContainer <button> at (13,10) content-size 49.921875x17.46875 inline-block [BFC] children: not-inline
         BlockContainer <(anonymous)> at (13,10) content-size 49.921875x17.46875 flex-container(column) [FFC] children: not-inline
           BlockContainer <(anonymous)> at (13,10) content-size 49.921875x17.46875 flex-item [BFC] children: inline
             line 0 width: 49.921875, height: 17.46875, bottom: 17.46875, baseline: 13.53125

--- a/Tests/LibWeb/Layout/expected/block-and-inline/button-with-text-node-label-and-font-size.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/button-with-text-node-label-and-font-size.txt
@@ -1,11 +1,9 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x56.40625 children: inline
-      line 0 width: 121.65625, height: 56.40625, bottom: 56.40625, baseline: 42.59375
+      line 0 width: 121.65625, height: 56.40625, bottom: 56.40625, baseline: 40.59375
         frag 0 from BlockContainer start: 0, length: 0, rect: [13,10 111.65625x52.40625]
-      BlockContainer <button> at (13,10) content-size 111.65625x52.40625 inline-block [BFC] children: inline
-        line 0 width: 111.65625, height: 52.40625, bottom: 52.40625, baseline: 40.59375
-          frag 0 from BlockContainer start: 0, length: 0, rect: [13,10 111.65625x52.40625]
+      BlockContainer <button> at (13,10) content-size 111.65625x52.40625 inline-block [BFC] children: not-inline
         BlockContainer <(anonymous)> at (13,10) content-size 111.65625x52.40625 flex-container(column) [FFC] children: not-inline
           BlockContainer <(anonymous)> at (13,10) content-size 111.65625x52.40625 flex-item [BFC] children: inline
             line 0 width: 111.65625, height: 52.40625, bottom: 52.40625, baseline: 40.59375

--- a/Tests/LibWeb/Layout/expected/block-and-inline/button-with-text-node-label.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/button-with-text-node-label.txt
@@ -1,11 +1,9 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x21.46875 children: inline
-      line 0 width: 47.21875, height: 21.46875, bottom: 21.46875, baseline: 15.53125
+      line 0 width: 47.21875, height: 21.46875, bottom: 21.46875, baseline: 13.53125
         frag 0 from BlockContainer start: 0, length: 0, rect: [13,10 37.21875x17.46875]
-      BlockContainer <button> at (13,10) content-size 37.21875x17.46875 inline-block [BFC] children: inline
-        line 0 width: 37.21875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-          frag 0 from BlockContainer start: 0, length: 0, rect: [13,10 37.21875x17.46875]
+      BlockContainer <button> at (13,10) content-size 37.21875x17.46875 inline-block [BFC] children: not-inline
         BlockContainer <(anonymous)> at (13,10) content-size 37.21875x17.46875 flex-container(column) [FFC] children: not-inline
           BlockContainer <(anonymous)> at (13,10) content-size 37.21875x17.46875 flex-item [BFC] children: inline
             line 0 width: 37.21875, height: 17.46875, bottom: 17.46875, baseline: 13.53125

--- a/Tests/LibWeb/Layout/input/block-and-inline/button-with-after-pseudo.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/button-with-after-pseudo.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html><style type="text/css">
+    button {
+      background-color: initial;
+    }
+    .button_button___eDCW {
+      font-size: 50px;
+      position: relative;
+      color: blueviolet;
+    }
+    .button_button___eDCW:after {
+      content: "";
+      position: absolute;
+      z-index: -1;
+      left: 0;
+      top: 0;
+      background-color: #d1ccb6;
+      width: 100%;
+      height: 100%;
+    }
+  </style><button class="button_button___eDCW">See more games</button>

--- a/Tests/LibWeb/Layout/input/block-and-inline/button-with-before-pseudo.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/button-with-before-pseudo.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html><style type="text/css">
+.button_button___eDCW {
+    background-color: initial;
+    font-size: 50px;
+    position: relative;
+    color: blueviolet;
+}
+.button_button___eDCW:before {
+    content: "";
+    position: absolute;
+    z-index: -1;
+    left: 0;
+    top: 0;
+    background-color: #d1ccb6;
+    width: 100%;
+    height: 100%;
+}
+</style><button class="button_button___eDCW">See more games</button>

--- a/Userland/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -411,6 +411,7 @@ ErrorOr<void> TreeBuilder::create_layout_tree(DOM::Node& dom_node, TreeBuilder::
         flex_wrapper->append_child(*content_box_wrapper);
 
         parent.append_child(*flex_wrapper);
+        parent.set_children_are_inline(false);
     }
 
     return {};

--- a/Userland/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -332,15 +332,6 @@ ErrorOr<void> TreeBuilder::create_layout_tree(DOM::Node& dom_node, TreeBuilder::
         pop_parent();
     }
 
-    // Add nodes for the ::before and ::after pseudo-elements.
-    if (is<DOM::Element>(dom_node)) {
-        auto& element = static_cast<DOM::Element&>(dom_node);
-        push_parent(verify_cast<NodeWithStyle>(*layout_node));
-        TRY(create_pseudo_element_if_needed(element, CSS::Selector::PseudoElement::Before, AppendOrPrepend::Prepend));
-        TRY(create_pseudo_element_if_needed(element, CSS::Selector::PseudoElement::After, AppendOrPrepend::Append));
-        pop_parent();
-    }
-
     if (is<ListItemBox>(*layout_node)) {
         auto& element = static_cast<DOM::Element&>(dom_node);
         int child_index = layout_node->parent()->index_of_child<ListItemBox>(*layout_node).value();
@@ -412,6 +403,15 @@ ErrorOr<void> TreeBuilder::create_layout_tree(DOM::Node& dom_node, TreeBuilder::
 
         parent.append_child(*flex_wrapper);
         parent.set_children_are_inline(false);
+    }
+
+    // Add nodes for the ::before and ::after pseudo-elements.
+    if (is<DOM::Element>(dom_node)) {
+        auto& element = static_cast<DOM::Element&>(dom_node);
+        push_parent(verify_cast<NodeWithStyle>(*layout_node));
+        TRY(create_pseudo_element_if_needed(element, CSS::Selector::PseudoElement::Before, AppendOrPrepend::Prepend));
+        TRY(create_pseudo_element_if_needed(element, CSS::Selector::PseudoElement::After, AppendOrPrepend::Append));
+        pop_parent();
     }
 
     return {};


### PR DESCRIPTION
LibWeb: Add boxes for before/after pseudos post button layout tweak

When a button should use flex for alignment and also has ::before
and/or ::after, we previously did the following:
1. Prepended/appended the button's children with boxes for
   pseudo-elements.
2. Replaced the button's direct children with a flex container that
   contains its children.
As a result, the generated boxes for ::before/::after ended up as
children of the generated flex item, instead of being direct children
of the button layout box as they were supposed to be.

This change reverses these steps, ensuring that boxes for
pseudo-elements are generated only after modifications inside the
button layout are completed.

Before:
<img width="1188" alt="Screenshot 2023-09-10 at 22 48 12" src="https://github.com/SerenityOS/serenity/assets/45686940/c61ba2c4-06cf-4ca2-919c-14c9b981a72f">

After:
<img width="1188" alt="Screenshot 2023-09-10 at 22 47 44" src="https://github.com/SerenityOS/serenity/assets/45686940/0f340cb3-92e0-4084-96e7-67bc82199c84">
