### PR TITLE
Userland: Port tooltips to String, remove Widget::set_tooltip_deprecated()

### DIFF
--- a/Userland/Applets/Audio/main.cpp
+++ b/Userland/Applets/Audio/main.cpp
@@ -87,7 +87,7 @@ private:
         m_root_container->set_frame_style(Gfx::FrameStyle::Window);
 
         m_percent_box = m_root_container->add<GUI::CheckBox>("\xE2\x84\xB9"_string);
-        m_percent_box->set_tooltip_deprecated(show_percent() ? "Hide percent" : "Show percent");
+        m_percent_box->set_tooltip(show_percent() ? "Hide percent"_string : "Show percent"_string);
         m_percent_box->set_checked(show_percent());
         m_percent_box->on_checked = [&](bool show_percent) {
             set_show_percent(show_percent);
@@ -111,9 +111,9 @@ private:
 
         m_mute_box = m_root_container->add<GUI::CheckBox>("\xE2\x9D\x8C"_string);
         m_mute_box->set_checked(m_audio_muted);
-        m_mute_box->set_tooltip_deprecated(m_audio_muted ? "Unmute" : "Mute");
+        m_mute_box->set_tooltip(m_audio_muted ? "Unmute"_string : "Mute"_string);
         m_mute_box->on_checked = [&](bool is_muted) {
-            m_mute_box->set_tooltip_deprecated(is_muted ? "Unmute" : "Mute");
+            m_mute_box->set_tooltip(is_muted ? "Unmute"_string : "Mute"_string);
             m_audio_client->set_main_mix_muted(is_muted);
             GUI::Application::the()->hide_tooltip();
         };
@@ -129,7 +129,7 @@ public:
     {
         m_show_percent = show_percent;
         m_percent_box->set_checked(show_percent);
-        m_percent_box->set_tooltip_deprecated(show_percent ? "Hide percent" : "Show percent");
+        m_percent_box->set_tooltip(show_percent ? "Hide percent"_string : "Show percent"_string);
         if (show_percent)
             window()->resize(44, 16);
         else

--- a/Userland/Applets/ClipboardHistory/main.cpp
+++ b/Userland/Applets/ClipboardHistory/main.cpp
@@ -101,7 +101,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     applet_window->set_window_type(GUI::WindowType::Applet);
     applet_window->set_has_alpha_channel(true);
     auto icon_widget = applet_window->set_main_widget<GUI::ImageWidget>();
-    icon_widget->set_tooltip_deprecated("Clipboard History");
+    icon_widget->set_tooltip("Clipboard History"_string);
     icon_widget->load_from_file("/res/icons/16x16/edit-copy.png"sv);
     icon_widget->on_click = [&main_window = *main_window] {
         main_window.show();

--- a/Userland/Applets/Keymap/KeymapStatusWidget.cpp
+++ b/Userland/Applets/Keymap/KeymapStatusWidget.cpp
@@ -66,7 +66,7 @@ ErrorOr<void> KeymapStatusWidget::refresh_menu()
 void KeymapStatusWidget::set_current_keymap(DeprecatedString const& keymap)
 {
     m_current_keymap = keymap;
-    set_tooltip_deprecated(keymap);
+    set_tooltip(MUST(String::from_deprecated_string(keymap)));
     update();
 }
 

--- a/Userland/Applets/ResourceGraph/main.cpp
+++ b/Userland/Applets/ResourceGraph/main.cpp
@@ -53,10 +53,10 @@ private:
                 m_last_idle = idle;
                 float cpu = total_diff > 0 ? (float)(total_diff - idle_diff) / (float)total_diff : 0;
                 m_history.enqueue(cpu);
-                m_tooltip = DeprecatedString::formatted("CPU usage: {:.1}%", 100 * cpu);
+                m_tooltip = MUST(String::formatted("CPU usage: {:.1}%", 100 * cpu));
             } else {
                 m_history.enqueue(-1);
-                m_tooltip = "Unable to determine CPU usage"sv;
+                m_tooltip = "Unable to determine CPU usage"_string;
             }
             break;
         }
@@ -66,10 +66,10 @@ private:
                 double total_memory = allocated + available;
                 double memory = (double)allocated / total_memory;
                 m_history.enqueue(memory);
-                m_tooltip = DeprecatedString::formatted("Memory: {} MiB of {:.1} MiB in use", allocated / MiB, total_memory / MiB);
+                m_tooltip = MUST(String::formatted("Memory: {} MiB of {:.1} MiB in use", allocated / MiB, total_memory / MiB));
             } else {
                 m_history.enqueue(-1);
-                m_tooltip = "Unable to determine memory usage"sv;
+                m_tooltip = "Unable to determine memory usage"_string;
             }
             break;
         }
@@ -97,17 +97,17 @@ private:
                     }
                 }
                 m_history.enqueue(static_cast<float>(recent_tx) / static_cast<float>(m_current_scale));
-                m_tooltip = DeprecatedString::formatted("Network: TX {} / RX {} ({:.1} kbit/s)", tx, rx, static_cast<double>(recent_tx) * 8.0 / 1000.0);
+                m_tooltip = MUST(String::formatted("Network: TX {} / RX {} ({:.1} kbit/s)", tx, rx, static_cast<double>(recent_tx) * 8.0 / 1000.0));
             } else {
                 m_history.enqueue(-1);
-                m_tooltip = "Unable to determine network usage"sv;
+                m_tooltip = "Unable to determine network usage"_string;
             }
             break;
         }
         default:
             VERIFY_NOT_REACHED();
         }
-        set_tooltip_deprecated(m_tooltip);
+        set_tooltip(m_tooltip);
         update();
     }
 
@@ -229,7 +229,7 @@ private:
     u64 m_last_total { 0 };
     static constexpr u64 const scale_unit = 8000;
     u64 m_current_scale { scale_unit };
-    DeprecatedString m_tooltip;
+    String m_tooltip;
     OwnPtr<Core::File> m_proc_stat;
     OwnPtr<Core::File> m_proc_mem;
     OwnPtr<Core::File> m_proc_net;

--- a/Userland/Applications/Assistant/Providers.cpp
+++ b/Userland/Applications/Assistant/Providers.cpp
@@ -85,7 +85,7 @@ void AppProvider::query(DeprecatedString const& query, Function<void(Vector<Nonn
             continue;
 
         auto icon = GUI::FileIconProvider::icon_for_executable(app_file->executable());
-        results.append(make_ref_counted<AppResult>(icon.bitmap_for_size(16), app_file->name(), DeprecatedString::empty(), app_file, arguments, match_result.score));
+        results.append(make_ref_counted<AppResult>(icon.bitmap_for_size(16), app_file->name(), String(), app_file, arguments, match_result.score));
     };
 
     on_complete(move(results));

--- a/Userland/Applications/Assistant/Providers.h
+++ b/Userland/Applications/Assistant/Providers.h
@@ -28,7 +28,7 @@ public:
     virtual Gfx::Bitmap const* bitmap() const = 0;
 
     DeprecatedString const& title() const { return m_title; }
-    DeprecatedString const& tooltip() const { return m_tooltip; }
+    String const& tooltip() const { return m_tooltip; }
     int score() const { return m_score; }
     bool equals(Result const& other) const
     {
@@ -38,7 +38,7 @@ public:
     }
 
 protected:
-    Result(DeprecatedString title, DeprecatedString tooltip, int score = 0)
+    Result(DeprecatedString title, String tooltip, int score = 0)
         : m_title(move(title))
         , m_tooltip(move(tooltip))
         , m_score(score)
@@ -47,13 +47,13 @@ protected:
 
 private:
     DeprecatedString m_title;
-    DeprecatedString m_tooltip;
+    String m_tooltip;
     int m_score { 0 };
 };
 
 class AppResult final : public Result {
 public:
-    AppResult(RefPtr<Gfx::Bitmap const> bitmap, DeprecatedString title, DeprecatedString tooltip, NonnullRefPtr<Desktop::AppFile> af, DeprecatedString arguments, int score)
+    AppResult(RefPtr<Gfx::Bitmap const> bitmap, DeprecatedString title, String tooltip, NonnullRefPtr<Desktop::AppFile> af, DeprecatedString arguments, int score)
         : Result(move(title), move(tooltip), score)
         , m_app_file(move(af))
         , m_arguments(move(arguments))
@@ -74,7 +74,7 @@ private:
 class CalculatorResult final : public Result {
 public:
     explicit CalculatorResult(DeprecatedString title)
-        : Result(move(title), "Copy to Clipboard"sv, 100)
+        : Result(move(title), "Copy to Clipboard"_string, 100)
         , m_bitmap(GUI::Icon::default_icon("app-calculator"sv).bitmap_for_size(16))
     {
     }
@@ -90,7 +90,7 @@ private:
 class FileResult final : public Result {
 public:
     explicit FileResult(DeprecatedString title, int score)
-        : Result(move(title), "", score)
+        : Result(move(title), String(), score)
     {
     }
     ~FileResult() override = default;
@@ -102,7 +102,7 @@ public:
 class TerminalResult final : public Result {
 public:
     explicit TerminalResult(DeprecatedString command)
-        : Result(move(command), "Run command in Terminal"sv, 100)
+        : Result(move(command), "Run command in Terminal"_string, 100)
         , m_bitmap(GUI::Icon::default_icon("app-terminal"sv).bitmap_for_size(16))
     {
     }
@@ -118,7 +118,7 @@ private:
 class URLResult final : public Result {
 public:
     explicit URLResult(const URL& url)
-        : Result(url.to_deprecated_string(), "Open URL in Browser"sv, 50)
+        : Result(url.to_deprecated_string(), "Open URL in Browser"_string, 50)
         , m_bitmap(GUI::Icon::default_icon("app-browser"sv).bitmap_for_size(16))
     {
     }

--- a/Userland/Applications/Assistant/main.cpp
+++ b/Userland/Applications/Assistant/main.cpp
@@ -250,7 +250,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             auto& match = results_container.add<Assistant::ResultRow>();
             match.set_icon(result->bitmap());
             match.set_text(String::from_deprecated_string(result->title()).release_value_but_fixme_should_propagate_errors());
-            match.set_tooltip_deprecated(result->tooltip());
+            match.set_tooltip(result->tooltip());
             match.on_click = [&result](auto) {
                 result->activate();
                 GUI::Application::the()->quit();

--- a/Userland/Applications/Browser/BookmarksBarWidget.cpp
+++ b/Userland/Applications/Browser/BookmarksBarWidget.cpp
@@ -216,7 +216,7 @@ void BookmarksBarWidget::model_did_update(unsigned)
         button.set_fixed_size(font().width(title) + 32, 20);
         button.set_relative_rect(rect);
         button.set_focus_policy(GUI::FocusPolicy::TabFocus);
-        button.set_tooltip_deprecated(url);
+        button.set_tooltip(MUST(String::from_deprecated_string(url)));
         button.set_allowed_mouse_buttons_for_pressing(GUI::MouseButton::Primary | GUI::MouseButton::Middle);
 
         button.on_click = [title, url, this](auto) {

--- a/Userland/Applications/Browser/BookmarksBarWidget.cpp
+++ b/Userland/Applications/Browser/BookmarksBarWidget.cpp
@@ -117,7 +117,7 @@ BookmarksBarWidget::BookmarksBarWidget(DeprecatedString const& bookmarks_file, b
         set_visible(false);
 
     m_additional = GUI::Button::construct();
-    m_additional->set_tooltip_deprecated("Show hidden bookmarks");
+    m_additional->set_tooltip("Show hidden bookmarks"_string);
     m_additional->set_menu(m_additional_menu);
     auto bitmap_or_error = Gfx::Bitmap::load_from_file("/res/icons/16x16/overflow-menu.png"sv);
     if (!bitmap_or_error.is_error())

--- a/Userland/Applications/Browser/ConsoleWidget.cpp
+++ b/Userland/Applications/Browser/ConsoleWidget.cpp
@@ -56,7 +56,7 @@ ConsoleWidget::ConsoleWidget(WebView::OutOfProcessWebView& content_view)
     auto& clear_button = bottom_container.add<GUI::Button>();
     clear_button.set_fixed_size(22, 22);
     clear_button.set_icon(g_icon_bag.delete_icon);
-    clear_button.set_tooltip_deprecated("Clear the console output");
+    clear_button.set_tooltip("Clear the console output"_string);
     clear_button.on_click = [this](auto) {
         m_console_client->clear();
     };

--- a/Userland/Applications/Browser/Tab.cpp
+++ b/Userland/Applications/Browser/Tab.cpp
@@ -204,7 +204,7 @@ Tab::Tab(BrowserWindow& window)
         this);
 
     m_reset_zoom_button = toolbar.add<GUI::Button>();
-    m_reset_zoom_button->set_tooltip_deprecated("Reset zoom level");
+    m_reset_zoom_button->set_tooltip("Reset zoom level"_string);
     m_reset_zoom_button->on_click = [&](auto) {
         view().reset_zoom();
         update_reset_zoom_button();
@@ -792,10 +792,10 @@ void Tab::update_bookmark_button(StringView url)
 {
     if (BookmarksBarWidget::the().contains_bookmark(url)) {
         m_bookmark_button->set_icon(g_icon_bag.bookmark_filled);
-        m_bookmark_button->set_tooltip_deprecated("Remove Bookmark");
+        m_bookmark_button->set_tooltip("Remove Bookmark"_string);
     } else {
         m_bookmark_button->set_icon(g_icon_bag.bookmark_contour);
-        m_bookmark_button->set_tooltip_deprecated("Add Bookmark");
+        m_bookmark_button->set_tooltip("Add Bookmark"_string);
     }
 }
 

--- a/Userland/Applications/DisplaySettings/MonitorSettingsWidget.cpp
+++ b/Userland/Applications/DisplaySettings/MonitorSettingsWidget.cpp
@@ -216,7 +216,7 @@ ErrorOr<void> MonitorSettingsWidget::selected_screen_index_or_resolution_changed
 
     if (screen_dpi.has_value()) {
         auto dpi_label_value = TRY(String::formatted("{} dpi", screen_dpi.value()));
-        m_dpi_label->set_tooltip_deprecated(screen_dpi_tooltip.to_deprecated_string());
+        m_dpi_label->set_tooltip(screen_dpi_tooltip);
         m_dpi_label->set_text(move(dpi_label_value));
         m_dpi_label->set_visible(true);
     } else {

--- a/Userland/Applications/Maps/MapWidget.cpp
+++ b/Userland/Applications/Maps/MapWidget.cpp
@@ -187,7 +187,7 @@ void MapWidget::mousemove_event(GUI::MouseEvent& event)
             marker_image->height()
         };
         if (marker_rect.contains(event.x(), event.y())) {
-            GUI::Application::the()->show_tooltip(marker.tooltip.value().to_deprecated_string(), this);
+            GUI::Application::the()->show_tooltip(marker.tooltip.value(), this);
             return;
         }
     }

--- a/Userland/Applications/Piano/MainWidget.cpp
+++ b/Userland/Applications/Piano/MainWidget.cpp
@@ -69,7 +69,7 @@ ErrorOr<void> MainWidget::initialize()
     // FIXME: Implement vertical flipping in GUI::Slider, not here.
     m_octave_knob = m_octave_container->add<GUI::VerticalSlider>();
     m_octave_knob->set_preferred_width(GUI::SpecialDimension::Fit);
-    m_octave_knob->set_tooltip_deprecated("Z: octave down, X: octave up");
+    m_octave_knob->set_tooltip("Z: octave down, X: octave up"_string);
     m_octave_knob->set_range(octave_min - 1, octave_max - 1);
     m_octave_knob->set_value((octave_max - 1) - (m_track_manager.keyboard()->virtual_keyboard_octave() - 1));
     m_octave_knob->set_step(1);

--- a/Userland/Applications/Piano/PlayerWidget.cpp
+++ b/Userland/Applications/Piano/PlayerWidget.cpp
@@ -62,7 +62,7 @@ ErrorOr<void> PlayerWidget::initialize()
     m_add_track_button = add<GUI::Button>();
     m_add_track_button->set_icon(*m_add_track_icon);
     m_add_track_button->set_fixed_width(30);
-    m_add_track_button->set_tooltip_deprecated("Add Track");
+    m_add_track_button->set_tooltip("Add Track"_string);
     m_add_track_button->set_focus_policy(GUI::FocusPolicy::NoFocus);
     m_add_track_button->on_click = [this](unsigned) {
         add_track();
@@ -71,7 +71,7 @@ ErrorOr<void> PlayerWidget::initialize()
     m_next_track_button = add<GUI::Button>();
     m_next_track_button->set_icon(*m_next_track_icon);
     m_next_track_button->set_fixed_width(30);
-    m_next_track_button->set_tooltip_deprecated("Next Track");
+    m_next_track_button->set_tooltip("Next Track"_string);
     m_next_track_button->set_focus_policy(GUI::FocusPolicy::NoFocus);
     m_next_track_button->on_click = [this](unsigned) {
         next_track();
@@ -80,7 +80,7 @@ ErrorOr<void> PlayerWidget::initialize()
     m_play_button = add<GUI::Button>();
     m_play_button->set_icon(*m_pause_icon);
     m_play_button->set_fixed_width(30);
-    m_play_button->set_tooltip_deprecated("Play/Pause playback");
+    m_play_button->set_tooltip("Play/Pause playback"_string);
     m_play_button->set_focus_policy(GUI::FocusPolicy::NoFocus);
     m_play_button->on_click = [this](unsigned) {
         m_audio_loop.toggle_paused();
@@ -95,7 +95,7 @@ ErrorOr<void> PlayerWidget::initialize()
     m_back_button = add<GUI::Button>();
     m_back_button->set_icon(*m_back_icon);
     m_back_button->set_fixed_width(30);
-    m_back_button->set_tooltip_deprecated("Previous Note");
+    m_back_button->set_tooltip("Previous Note"_string);
     m_back_button->set_focus_policy(GUI::FocusPolicy::NoFocus);
     m_back_button->on_click = [this](unsigned) {
         m_track_manager.time_forward(-(sample_rate / (beats_per_minute / 60) / notes_per_beat));
@@ -104,7 +104,7 @@ ErrorOr<void> PlayerWidget::initialize()
     m_next_button = add<GUI::Button>();
     m_next_button->set_icon(*m_next_icon);
     m_next_button->set_fixed_width(30);
-    m_next_button->set_tooltip_deprecated("Next Note");
+    m_next_button->set_tooltip("Next Note"_string);
     m_next_button->set_focus_policy(GUI::FocusPolicy::NoFocus);
     m_next_button->on_click = [this](unsigned) {
         m_track_manager.time_forward((sample_rate / (beats_per_minute / 60) / notes_per_beat));

--- a/Userland/Applications/Piano/ProcessorParameterWidget/Slider.cpp
+++ b/Userland/Applications/Piano/ProcessorParameterWidget/Slider.cpp
@@ -26,7 +26,7 @@ ProcessorParameterSlider::ProcessorParameterSlider(Orientation orientation, DSP:
         set_value(value_log);
         set_step((min_log - max_log) / slider_steps);
     }
-    set_tooltip_deprecated(m_parameter.name().to_deprecated_string());
+    set_tooltip(m_parameter.name());
     if (m_value_label != nullptr)
         m_value_label->set_text(String::formatted("{:.2f}", static_cast<double>(m_parameter)).release_value_but_fixme_should_propagate_errors());
 

--- a/Userland/Applications/PixelPaint/Filters/FastBoxBlur.cpp
+++ b/Userland/Applications/PixelPaint/Filters/FastBoxBlur.cpp
@@ -180,7 +180,7 @@ ErrorOr<RefPtr<GUI::Widget>> FastBoxBlur::get_settings_widget()
 
         m_gaussian_checkbox = gaussian_container.add<GUI::CheckBox>("Approximate Gaussian Blur"_string);
         m_gaussian_checkbox->set_checked(m_approximate_gauss);
-        m_gaussian_checkbox->set_tooltip_deprecated("A real gaussian blur can be approximated by running the box blur multiple times with different weights.");
+        m_gaussian_checkbox->set_tooltip("A real gaussian blur can be approximated by running the box blur multiple times with different weights."_string);
         m_gaussian_checkbox->on_checked = [this](bool checked) {
             m_approximate_gauss = checked;
             update_preview();

--- a/Userland/Applications/PixelPaint/Tools/GuideTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/GuideTool.cpp
@@ -189,7 +189,7 @@ NonnullRefPtr<GUI::Widget> GuideTool::get_properties_widget()
         auto& snapping_label = snapping_container.add<GUI::Label>("Snap offset:"_string);
         snapping_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
         snapping_label.set_fixed_size(80, 20);
-        snapping_label.set_tooltip_deprecated("Press Shift to snap");
+        snapping_label.set_tooltip("Press Shift to snap"_string);
 
         auto& snapping_slider = snapping_container.add<GUI::ValueSlider>(Orientation::Horizontal, "px"_string);
         snapping_slider.set_range(0, 50);

--- a/Userland/Applications/PixelPaint/Tools/GuideTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/GuideTool.cpp
@@ -74,7 +74,7 @@ void GuideTool::on_mousedown(Layer*, MouseEvent& event)
 
     if (m_selected_guide) {
         m_guide_origin = m_selected_guide->offset();
-        GUI::Application::the()->show_tooltip_immediately(DeprecatedString::formatted("{}", m_guide_origin), GUI::Application::the()->tooltip_source_widget());
+        GUI::Application::the()->show_tooltip_immediately(MUST(String::number(m_guide_origin)), GUI::Application::the()->tooltip_source_widget());
     }
 }
 
@@ -120,7 +120,7 @@ void GuideTool::on_mousemove(Layer*, MouseEvent& event)
 
     m_selected_guide->set_offset(new_offset);
 
-    GUI::Application::the()->show_tooltip_immediately(DeprecatedString::formatted("{}", new_offset), GUI::Application::the()->tooltip_source_widget());
+    GUI::Application::the()->show_tooltip_immediately(MUST(String::number(new_offset)), GUI::Application::the()->tooltip_source_widget());
 
     editor()->update();
 }

--- a/Userland/Applications/SpaceAnalyzer/TreeMapWidget.cpp
+++ b/Userland/Applications/SpaceAnalyzer/TreeMapWidget.cpp
@@ -280,7 +280,7 @@ void TreeMapWidget::mousemove_event(GUI::MouseEvent& event)
 {
     auto* node = path_node(m_viewpoint);
     if (!node) {
-        set_tooltip_deprecated({});
+        set_tooltip({});
         return;
     }
 
@@ -291,7 +291,7 @@ void TreeMapWidget::mousemove_event(GUI::MouseEvent& event)
         }
     });
 
-    set_tooltip_deprecated(DeprecatedString::formatted("{}\n{}", hovered_node->name(), human_readable_size(hovered_node->area())));
+    set_tooltip(MUST(String::formatted("{}\n{}", hovered_node->name(), human_readable_size(hovered_node->area()))));
 }
 
 void TreeMapWidget::mousedown_event(GUI::MouseEvent& event)

--- a/Userland/Applications/SpaceAnalyzer/main.cpp
+++ b/Userland/Applications/SpaceAnalyzer/main.cpp
@@ -154,7 +154,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                 if (tree_map_widget.viewpoint() == 0)
                     window->set_title("/ - SpaceAnalyzer");
 
-                breadcrumbbar.append_segment("/", GUI::FileIconProvider::icon_for_path("/"sv).bitmap_for_size(16), "/", "/");
+                breadcrumbbar.append_segment("/", GUI::FileIconProvider::icon_for_path("/"sv).bitmap_for_size(16), "/", "/"_string);
                 continue;
             }
 
@@ -167,7 +167,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             if (k == tree_map_widget.viewpoint())
                 window->set_title(DeprecatedString::formatted("{} - SpaceAnalyzer", builder.string_view()));
 
-            breadcrumbbar.append_segment(node->name(), GUI::FileIconProvider::icon_for_path(builder.string_view()).bitmap_for_size(16), builder.string_view(), builder.string_view());
+            breadcrumbbar.append_segment(node->name(), GUI::FileIconProvider::icon_for_path(builder.string_view()).bitmap_for_size(16), builder.string_view(), MUST(builder.to_string()));
         }
         breadcrumbbar.set_selected_segment(tree_map_widget.viewpoint());
     };

--- a/Userland/Applications/Spreadsheet/CellType/Date.cpp
+++ b/Userland/Applications/Spreadsheet/CellType/Date.cpp
@@ -39,10 +39,10 @@ JS::ThrowCompletionOr<JS::Value> DateCell::js_value(Cell& cell, CellTypeMetadata
     return JS::Value(value / 1000); // Turn it to seconds
 }
 
-DeprecatedString DateCell::metadata_hint(MetadataName metadata) const
+String DateCell::metadata_hint(MetadataName metadata) const
 {
     if (metadata == MetadataName::Format)
-        return "Date format string as supported by `strftime'";
+        return "Date format string as supported by `strftime'"_string;
     return {};
 }
 

--- a/Userland/Applications/Spreadsheet/CellType/Date.h
+++ b/Userland/Applications/Spreadsheet/CellType/Date.h
@@ -18,7 +18,7 @@ public:
     virtual ~DateCell() override = default;
     virtual JS::ThrowCompletionOr<DeprecatedString> display(Cell&, CellTypeMetadata const&) const override;
     virtual JS::ThrowCompletionOr<JS::Value> js_value(Cell&, CellTypeMetadata const&) const override;
-    DeprecatedString metadata_hint(MetadataName) const override;
+    virtual String metadata_hint(MetadataName) const override;
 };
 
 }

--- a/Userland/Applications/Spreadsheet/CellType/Identity.cpp
+++ b/Userland/Applications/Spreadsheet/CellType/Identity.cpp
@@ -30,12 +30,12 @@ JS::ThrowCompletionOr<JS::Value> IdentityCell::js_value(Cell& cell, CellTypeMeta
     return cell.js_data();
 }
 
-DeprecatedString IdentityCell::metadata_hint(MetadataName metadata) const
+String IdentityCell::metadata_hint(MetadataName metadata) const
 {
     if (metadata == MetadataName::Length)
-        return "Ignored";
+        return "Ignored"_string;
     if (metadata == MetadataName::Format)
-        return "JavaScript expression, `value' refers to the cell's value";
+        return "JavaScript expression, `value' refers to the cell's value"_string;
 
     return {};
 }

--- a/Userland/Applications/Spreadsheet/CellType/Identity.h
+++ b/Userland/Applications/Spreadsheet/CellType/Identity.h
@@ -17,7 +17,7 @@ public:
     virtual ~IdentityCell() override = default;
     virtual JS::ThrowCompletionOr<DeprecatedString> display(Cell&, CellTypeMetadata const&) const override;
     virtual JS::ThrowCompletionOr<JS::Value> js_value(Cell&, CellTypeMetadata const&) const override;
-    DeprecatedString metadata_hint(MetadataName) const override;
+    virtual String metadata_hint(MetadataName) const override;
 };
 
 }

--- a/Userland/Applications/Spreadsheet/CellType/Numeric.cpp
+++ b/Userland/Applications/Spreadsheet/CellType/Numeric.cpp
@@ -43,10 +43,10 @@ JS::ThrowCompletionOr<JS::Value> NumericCell::js_value(Cell& cell, CellTypeMetad
     });
 }
 
-DeprecatedString NumericCell::metadata_hint(MetadataName metadata) const
+String NumericCell::metadata_hint(MetadataName metadata) const
 {
     if (metadata == MetadataName::Format)
-        return "Format string as accepted by `printf', all numeric formats refer to the same value (the cell's value)";
+        return "Format string as accepted by `printf', all numeric formats refer to the same value (the cell's value)"_string;
 
     return {};
 }

--- a/Userland/Applications/Spreadsheet/CellType/Numeric.h
+++ b/Userland/Applications/Spreadsheet/CellType/Numeric.h
@@ -28,7 +28,7 @@ public:
     virtual ~NumericCell() override = default;
     virtual JS::ThrowCompletionOr<DeprecatedString> display(Cell&, CellTypeMetadata const&) const override;
     virtual JS::ThrowCompletionOr<JS::Value> js_value(Cell&, CellTypeMetadata const&) const override;
-    DeprecatedString metadata_hint(MetadataName) const override;
+    virtual String metadata_hint(MetadataName) const override;
 };
 
 }

--- a/Userland/Applications/Spreadsheet/CellType/String.cpp
+++ b/Userland/Applications/Spreadsheet/CellType/String.cpp
@@ -32,10 +32,10 @@ JS::ThrowCompletionOr<JS::Value> StringCell::js_value(Cell& cell, CellTypeMetada
     return JS::PrimitiveString::create(vm, string);
 }
 
-DeprecatedString StringCell::metadata_hint(MetadataName metadata) const
+String StringCell::metadata_hint(MetadataName metadata) const
 {
     if (metadata == MetadataName::Format)
-        return "Ignored";
+        return "Ignored"_string;
     return {};
 }
 

--- a/Userland/Applications/Spreadsheet/CellType/String.h
+++ b/Userland/Applications/Spreadsheet/CellType/String.h
@@ -17,7 +17,7 @@ public:
     virtual ~StringCell() override = default;
     virtual JS::ThrowCompletionOr<DeprecatedString> display(Cell&, CellTypeMetadata const&) const override;
     virtual JS::ThrowCompletionOr<JS::Value> js_value(Cell&, CellTypeMetadata const&) const override;
-    DeprecatedString metadata_hint(MetadataName) const override;
+    virtual String metadata_hint(MetadataName) const override;
 };
 
 }

--- a/Userland/Applications/Spreadsheet/CellType/Type.h
+++ b/Userland/Applications/Spreadsheet/CellType/Type.h
@@ -37,7 +37,7 @@ public:
 
     virtual JS::ThrowCompletionOr<DeprecatedString> display(Cell&, CellTypeMetadata const&) const = 0;
     virtual JS::ThrowCompletionOr<JS::Value> js_value(Cell&, CellTypeMetadata const&) const = 0;
-    virtual DeprecatedString metadata_hint(MetadataName) const { return {}; }
+    virtual String metadata_hint(MetadataName) const { return {}; }
     virtual ~CellType() = default;
 
     DeprecatedString const& name() const { return m_name; }

--- a/Userland/Applications/Spreadsheet/CellTypeDialog.cpp
+++ b/Userland/Applications/Spreadsheet/CellTypeDialog.cpp
@@ -153,7 +153,7 @@ void CellTypeDialog::setup_tabs(GUI::TabWidget& tabs, Vector<Position> const& po
 
             m_type = CellType::get_by_name(g_types.at(index.row()));
             if (auto* editor = right_side.find_descendant_of_type_named<GUI::TextEditor>("format_editor"))
-                editor->set_tooltip_deprecated(m_type->metadata_hint(MetadataName::Format));
+                editor->set_tooltip(m_type->metadata_hint(MetadataName::Format));
         };
 
         {

--- a/Userland/Applications/Spreadsheet/SpreadsheetView.cpp
+++ b/Userland/Applications/Spreadsheet/SpreadsheetView.cpp
@@ -80,10 +80,10 @@ void InfinitelyScrollableTableView::mousemove_event(GUI::MouseEvent& event)
         if (!is_dragging()) {
             auto tooltip = model->data(index, static_cast<GUI::ModelRole>(SheetModel::Role::Tooltip));
             if (tooltip.is_string()) {
-                set_tooltip_deprecated(tooltip.as_string());
+                set_tooltip(MUST(String::from_deprecated_string(tooltip.as_string())));
                 show_or_hide_tooltip();
             } else {
-                set_tooltip_deprecated({});
+                set_tooltip({});
             }
         }
 

--- a/Userland/Applications/Spreadsheet/SpreadsheetWidget.cpp
+++ b/Userland/Applications/Spreadsheet/SpreadsheetWidget.cpp
@@ -46,7 +46,7 @@ SpreadsheetWidget::SpreadsheetWidget(GUI::Window& parent_window, Vector<NonnullR
 
     auto& help_button = top_bar.add<GUI::Button>();
     help_button.set_icon(Gfx::Bitmap::load_from_file("/res/icons/16x16/app-help.png"sv).release_value_but_fixme_should_propagate_errors());
-    help_button.set_tooltip_deprecated("Functions Help");
+    help_button.set_tooltip("Functions Help"_string);
     help_button.set_fixed_size(20, 20);
     help_button.on_click = [&](auto) {
         if (!current_view()) {

--- a/Userland/DevTools/HackStudio/Git/GitWidget.cpp
+++ b/Userland/DevTools/HackStudio/Git/GitWidget.cpp
@@ -32,7 +32,7 @@ GitWidget::GitWidget()
     auto& refresh_button = unstaged_header.add<GUI::Button>();
     refresh_button.set_icon(Gfx::Bitmap::load_from_file("/res/icons/16x16/reload.png"sv).release_value_but_fixme_should_propagate_errors());
     refresh_button.set_fixed_size(16, 16);
-    refresh_button.set_tooltip_deprecated("refresh");
+    refresh_button.set_tooltip("refresh"_string);
     refresh_button.on_click = [this](int) { refresh(); };
 
     auto& unstaged_label = unstaged_header.add<GUI::Label>();
@@ -62,7 +62,7 @@ GitWidget::GitWidget()
     auto& commit_button = staged_header.add<GUI::Button>();
     commit_button.set_icon(Gfx::Bitmap::load_from_file("/res/icons/16x16/commit.png"sv).release_value_but_fixme_should_propagate_errors());
     commit_button.set_fixed_size(16, 16);
-    commit_button.set_tooltip_deprecated("commit");
+    commit_button.set_tooltip("commit"_string);
     commit_button.on_click = [this](int) { commit(); };
 
     auto& staged_label = staged_header.add<GUI::Label>();

--- a/Userland/DevTools/Profiler/FlameGraphView.cpp
+++ b/Userland/DevTools/Profiler/FlameGraphView.cpp
@@ -89,11 +89,11 @@ void FlameGraphView::mousemove_event(GUI::MouseEvent& event)
     if (on_hover_change)
         on_hover_change();
 
-    DeprecatedString label = "";
+    String label;
     if (m_hovered_bar != nullptr && m_hovered_bar->index.is_valid()) {
         label = bar_label(*m_hovered_bar);
     }
-    set_tooltip_deprecated(label);
+    set_tooltip(label);
     show_or_hide_tooltip();
 
     update();
@@ -175,12 +175,12 @@ void FlameGraphView::paint_event(GUI::PaintEvent& event)
     }
 }
 
-DeprecatedString FlameGraphView::bar_label(StackBar const& bar) const
+String FlameGraphView::bar_label(StackBar const& bar) const
 {
     auto label_index = bar.index.sibling_at_column(m_text_column);
-    DeprecatedString label = "All";
+    String label = "All"_string;
     if (label_index.is_valid()) {
-        label = m_model.data(label_index).to_deprecated_string();
+        label = MUST(String::from_deprecated_string(m_model.data(label_index).to_deprecated_string()));
     }
     return label;
 }

--- a/Userland/DevTools/Profiler/FlameGraphView.h
+++ b/Userland/DevTools/Profiler/FlameGraphView.h
@@ -46,7 +46,7 @@ private:
         bool selected;
     };
 
-    DeprecatedString bar_label(StackBar const&) const;
+    String bar_label(StackBar const&) const;
     void layout_bars();
     void layout_children(GUI::ModelIndex& parent, int depth, int left, int right, Vector<GUI::ModelIndex>& selected);
 

--- a/Userland/DevTools/Profiler/TimelineTrack.cpp
+++ b/Userland/DevTools/Profiler/TimelineTrack.cpp
@@ -130,7 +130,7 @@ void TimelineTrack::mousemove_event(GUI::MouseEvent& event)
         Gfx::IntRect hoverable_rect { x - hoverable_padding, frame_thickness(), hoverable_padding * 2, height() - frame_thickness() * 2 };
         if (hoverable_rect.contains_horizontally(event.x())) {
             auto const& data = signpost.data.template get<Profile::Event::SignpostData>();
-            GUI::Application::the()->show_tooltip_immediately(DeprecatedString::formatted("{}, {}", data.string, data.arg), this);
+            GUI::Application::the()->show_tooltip_immediately(MUST(String::formatted("{}, {}", data.string, data.arg)), this);
             hovering_a_signpost = true;
             return IterationDecision::Break;
         }

--- a/Userland/Libraries/LibGUI/Action.cpp
+++ b/Userland/Libraries/LibGUI/Action.cpp
@@ -308,7 +308,7 @@ void Action::set_tooltip(DeprecatedString tooltip)
         return;
     m_tooltip = move(tooltip);
     for_each_toolbar_button([&](auto& button) {
-        button.set_tooltip_deprecated(*m_tooltip);
+        button.set_tooltip(MUST(String::from_deprecated_string(*m_tooltip)));
     });
     for_each_menu_item([&](auto& menu_item) {
         menu_item.update_from_action({});

--- a/Userland/Libraries/LibGUI/Action.cpp
+++ b/Userland/Libraries/LibGUI/Action.cpp
@@ -297,6 +297,11 @@ void Action::set_text(DeprecatedString text)
     });
 }
 
+DeprecatedString Action::tooltip() const
+{
+    return m_tooltip.value_or_lazy_evaluated([this] { return Gfx::parse_ampersand_string(m_text); });
+}
+
 void Action::set_tooltip(DeprecatedString tooltip)
 {
     if (m_tooltip == tooltip)

--- a/Userland/Libraries/LibGUI/Action.h
+++ b/Userland/Libraries/LibGUI/Action.h
@@ -84,7 +84,7 @@ public:
     DeprecatedString text() const { return m_text; }
     void set_text(DeprecatedString);
 
-    DeprecatedString tooltip() const { return m_tooltip.value_or(m_text); }
+    DeprecatedString tooltip() const;
     void set_tooltip(DeprecatedString);
 
     Optional<String> status_tip() const;

--- a/Userland/Libraries/LibGUI/Application.cpp
+++ b/Userland/Libraries/LibGUI/Application.cpp
@@ -27,7 +27,7 @@ class Application::TooltipWindow final : public Window {
 public:
     void set_tooltip(DeprecatedString const& tooltip)
     {
-        m_label->set_text(String::from_deprecated_string(Gfx::parse_ampersand_string(tooltip)).release_value_but_fixme_should_propagate_errors());
+        m_label->set_text(String::from_deprecated_string(tooltip).release_value_but_fixme_should_propagate_errors());
         int tooltip_width = m_label->effective_min_size().width().as_int() + 10;
         int line_count = m_label->text().count("\n"sv);
         int font_size = m_label->font().pixel_size_rounded_up();

--- a/Userland/Libraries/LibGUI/Application.cpp
+++ b/Userland/Libraries/LibGUI/Application.cpp
@@ -25,9 +25,9 @@ class Application::TooltipWindow final : public Window {
     C_OBJECT(TooltipWindow);
 
 public:
-    void set_tooltip(DeprecatedString const& tooltip)
+    void set_tooltip(String tooltip)
     {
-        m_label->set_text(String::from_deprecated_string(tooltip).release_value_but_fixme_should_propagate_errors());
+        m_label->set_text(move(tooltip));
         int tooltip_width = m_label->effective_min_size().width().as_int() + 10;
         int line_count = m_label->text().count("\n"sv);
         int font_size = m_label->font().pixel_size_rounded_up();
@@ -152,7 +152,7 @@ Action* Application::action_for_shortcut(Shortcut const& shortcut) const
     return (*it).value;
 }
 
-void Application::show_tooltip(DeprecatedString tooltip, Widget const* tooltip_source_widget)
+void Application::show_tooltip(String tooltip, Widget const* tooltip_source_widget)
 {
     if (!Desktop::the().system_effects().tooltips())
         return;
@@ -173,7 +173,7 @@ void Application::show_tooltip(DeprecatedString tooltip, Widget const* tooltip_s
     }
 }
 
-void Application::show_tooltip_immediately(DeprecatedString tooltip, Widget const* tooltip_source_widget)
+void Application::show_tooltip_immediately(String tooltip, Widget const* tooltip_source_widget)
 {
     if (!Desktop::the().system_effects().tooltips())
         return;

--- a/Userland/Libraries/LibGUI/Application.h
+++ b/Userland/Libraries/LibGUI/Application.h
@@ -41,8 +41,8 @@ public:
     void register_global_shortcut_action(Badge<Action>, Action&);
     void unregister_global_shortcut_action(Badge<Action>, Action&);
 
-    void show_tooltip(DeprecatedString, Widget const* tooltip_source_widget);
-    void show_tooltip_immediately(DeprecatedString, Widget const* tooltip_source_widget);
+    void show_tooltip(String, Widget const* tooltip_source_widget);
+    void show_tooltip_immediately(String, Widget const* tooltip_source_widget);
     void hide_tooltip();
     Widget const* tooltip_source_widget() { return m_tooltip_source_widget; }
 

--- a/Userland/Libraries/LibGUI/Breadcrumbbar.cpp
+++ b/Userland/Libraries/LibGUI/Breadcrumbbar.cpp
@@ -70,13 +70,13 @@ void Breadcrumbbar::clear_segments()
     m_selected_segment = {};
 }
 
-void Breadcrumbbar::append_segment(DeprecatedString text, Gfx::Bitmap const* icon, DeprecatedString data, DeprecatedString tooltip)
+void Breadcrumbbar::append_segment(DeprecatedString text, Gfx::Bitmap const* icon, DeprecatedString data, String tooltip)
 {
     auto& button = add<BreadcrumbButton>();
     button.set_button_style(Gfx::ButtonStyle::Coolbar);
     button.set_text(String::from_deprecated_string(text).release_value_but_fixme_should_propagate_errors());
     button.set_icon(icon);
-    button.set_tooltip_deprecated(move(tooltip));
+    button.set_tooltip(move(tooltip));
     button.set_focus_policy(FocusPolicy::TabFocus);
     button.set_checkable(true);
     button.set_exclusive(true);

--- a/Userland/Libraries/LibGUI/Breadcrumbbar.h
+++ b/Userland/Libraries/LibGUI/Breadcrumbbar.h
@@ -19,7 +19,7 @@ public:
     virtual ~Breadcrumbbar() override = default;
 
     void clear_segments();
-    void append_segment(DeprecatedString text, Gfx::Bitmap const* icon = nullptr, DeprecatedString data = {}, DeprecatedString tooltip = {});
+    void append_segment(DeprecatedString text, Gfx::Bitmap const* icon = nullptr, DeprecatedString data = {}, String tooltip = {});
     void remove_end_segments(size_t segment_index);
     void relayout();
 

--- a/Userland/Libraries/LibGUI/EmojiInputDialog.cpp
+++ b/Userland/Libraries/LibGUI/EmojiInputDialog.cpp
@@ -144,7 +144,7 @@ auto EmojiInputDialog::supported_emoji() -> Vector<Emoji>
         };
 
         if (!emoji->name.is_empty())
-            button->set_tooltip_deprecated(emoji->name);
+            button->set_tooltip(MUST(String::from_utf8(emoji->name)));
 
         emojis.empend(move(button), emoji.release_value(), move(text));
     }

--- a/Userland/Libraries/LibGUI/EmojiInputDialog.cpp
+++ b/Userland/Libraries/LibGUI/EmojiInputDialog.cpp
@@ -67,7 +67,7 @@ EmojiInputDialog::EmojiInputDialog(Window* parent_window)
 
     for (auto const& category : s_emoji_groups) {
         auto name = Unicode::emoji_group_to_string(category.group);
-        auto tooltip = name.replace("&"sv, "&&"sv, ReplaceMode::FirstOnly);
+        DeprecatedString tooltip = name;
 
         auto set_filter_action = Action::create_checkable(
             category.representative_emoji,

--- a/Userland/Libraries/LibGUI/LinkLabel.cpp
+++ b/Userland/Libraries/LibGUI/LinkLabel.cpp
@@ -118,9 +118,9 @@ void LinkLabel::did_change_text()
 void LinkLabel::update_tooltip_if_needed()
 {
     if (width() < font().width(text())) {
-        set_tooltip_deprecated(text().to_deprecated_string());
+        set_tooltip(text());
     } else {
-        set_tooltip_deprecated({});
+        set_tooltip({});
     }
 }
 

--- a/Userland/Libraries/LibGUI/PathBreadcrumbbar.cpp
+++ b/Userland/Libraries/LibGUI/PathBreadcrumbbar.cpp
@@ -110,7 +110,7 @@ void PathBreadcrumbbar::set_current_path(DeprecatedString const& new_path)
     } else {
         m_breadcrumbbar->clear_segments();
 
-        m_breadcrumbbar->append_segment("/", GUI::FileIconProvider::icon_for_path("/"sv).bitmap_for_size(16), "/", "/");
+        m_breadcrumbbar->append_segment("/", GUI::FileIconProvider::icon_for_path("/"sv).bitmap_for_size(16), "/", "/"_string);
         StringBuilder builder;
 
         for (auto& part : lexical_path.parts()) {
@@ -118,7 +118,7 @@ void PathBreadcrumbbar::set_current_path(DeprecatedString const& new_path)
             builder.append('/');
             builder.append(part);
 
-            m_breadcrumbbar->append_segment(part, GUI::FileIconProvider::icon_for_path(builder.string_view()).bitmap_for_size(16), builder.string_view(), builder.string_view());
+            m_breadcrumbbar->append_segment(part, GUI::FileIconProvider::icon_for_path(builder.string_view()).bitmap_for_size(16), builder.string_view(), MUST(builder.to_string()));
         }
 
         m_breadcrumbbar->set_selected_segment(m_breadcrumbbar->segment_count() - 1);

--- a/Userland/Libraries/LibGUI/Toolbar.cpp
+++ b/Userland/Libraries/LibGUI/Toolbar.cpp
@@ -49,7 +49,7 @@ private:
         if (action.group() && action.group()->is_exclusive())
             set_exclusive(true);
         set_action(action);
-        set_tooltip_deprecated(tooltip(action));
+        set_tooltip(tooltip(action));
         set_focus_policy(FocusPolicy::NoFocus);
         if (action.icon())
             set_icon(action.icon());
@@ -63,12 +63,12 @@ private:
         auto const* action = this->action();
         VERIFY(action);
 
-        set_tooltip_deprecated(tooltip(*action));
+        set_tooltip(tooltip(*action));
         if (!action->icon())
             Button::set_text(move(text));
     }
 
-    DeprecatedString tooltip(Action const& action) const
+    String tooltip(Action const& action) const
     {
         StringBuilder builder;
         builder.append(action.tooltip());
@@ -77,7 +77,7 @@ private:
             builder.append(action.shortcut().to_deprecated_string());
             builder.append(')');
         }
-        return builder.to_deprecated_string();
+        return MUST(builder.to_string());
     }
 
     virtual void enter_event(Core::Event& event) override

--- a/Userland/Libraries/LibGUI/Widget.cpp
+++ b/Userland/Libraries/LibGUI/Widget.cpp
@@ -1122,7 +1122,7 @@ void Widget::set_tooltip(String tooltip)
 void Widget::show_or_hide_tooltip()
 {
     if (has_tooltip())
-        Application::the()->show_tooltip(m_tooltip.to_deprecated_string(), this);
+        Application::the()->show_tooltip(m_tooltip, this);
     else
         Application::the()->hide_tooltip();
 }

--- a/Userland/Libraries/LibGUI/Widget.cpp
+++ b/Userland/Libraries/LibGUI/Widget.cpp
@@ -1107,11 +1107,6 @@ Gfx::IntRect Widget::relative_non_grabbable_rect() const
     return rect;
 }
 
-void Widget::set_tooltip_deprecated(DeprecatedString tooltip)
-{
-    set_tooltip(String::from_deprecated_string(move(tooltip)).release_value_but_fixme_should_propagate_errors());
-}
-
 void Widget::set_tooltip(String tooltip)
 {
     m_tooltip = move(tooltip);

--- a/Userland/Libraries/LibGUI/Widget.h
+++ b/Userland/Libraries/LibGUI/Widget.h
@@ -163,8 +163,6 @@ public:
     bool has_tooltip() const { return !m_tooltip.is_empty(); }
     String tooltip() const { return m_tooltip; }
     void set_tooltip(String tooltip);
-    DeprecatedString tooltip_deprecated() const { return tooltip().to_deprecated_string(); }
-    void set_tooltip_deprecated(DeprecatedString);
 
     bool is_auto_focusable() const { return m_auto_focusable; }
     void set_auto_focusable(bool auto_focusable) { m_auto_focusable = auto_focusable; }

--- a/Userland/Libraries/LibVT/TerminalWidget.cpp
+++ b/Userland/Libraries/LibVT/TerminalWidget.cpp
@@ -878,18 +878,18 @@ void TerminalWidget::mousemove_event(GUI::MouseEvent& event)
                     auto file_name = LexicalPath::basename(path);
 
                     if (path == handlers[0]) {
-                        set_tooltip_deprecated(DeprecatedString::formatted("Execute {}", app_name));
+                        set_tooltip(MUST(String::formatted("Execute {}", app_name)));
                     } else {
-                        set_tooltip_deprecated(DeprecatedString::formatted("Open {} with {}", file_name, app_name));
+                        set_tooltip(MUST(String::formatted("Open {} with {}", file_name, app_name)));
                     }
                 } else {
-                    set_tooltip_deprecated(DeprecatedString::formatted("Open {} with {}", attribute.href, app_name));
+                    set_tooltip(MUST(String::formatted("Open {} with {}", attribute.href, app_name)));
                 }
             }
         } else {
             m_hovered_href_id = {};
             m_hovered_href = {};
-            set_tooltip_deprecated({});
+            set_tooltip({});
         }
         show_or_hide_tooltip();
         if (!m_hovered_href.is_empty())
@@ -957,7 +957,7 @@ void TerminalWidget::leave_event(Core::Event&)
     bool should_update = !m_hovered_href.is_empty();
     m_hovered_href = {};
     m_hovered_href_id = {};
-    set_tooltip_deprecated(m_hovered_href);
+    set_tooltip({});
     set_override_cursor(Gfx::StandardCursor::IBeam);
     if (should_update)
         update();

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
@@ -65,7 +65,7 @@ OutOfProcessWebView::OutOfProcessWebView()
     };
 
     on_enter_tooltip_area = [](auto, auto tooltip) {
-        GUI::Application::the()->show_tooltip(tooltip, nullptr);
+        GUI::Application::the()->show_tooltip(MUST(String::from_deprecated_string(tooltip)), nullptr);
     };
 
     on_leave_tooltip_area = []() {

--- a/Userland/Services/Taskbar/ClockWidget.cpp
+++ b/Userland/Services/Taskbar/ClockWidget.cpp
@@ -30,7 +30,7 @@ ClockWidget::ClockWidget()
         if (now != last_update_time) {
             tick_clock();
             last_update_time = now;
-            set_tooltip_deprecated(Core::DateTime::now().to_deprecated_string("%Y-%m-%d"sv));
+            set_tooltip(MUST(Core::DateTime::now().to_string("%Y-%m-%d"sv)));
         }
     });
     m_timer->start();
@@ -107,7 +107,7 @@ ClockWidget::ClockWidget()
     m_jump_to_button->set_button_style(Gfx::ButtonStyle::Coolbar);
     m_jump_to_button->set_fixed_size(24, 24);
     m_jump_to_button->set_icon(Gfx::Bitmap::load_from_file("/res/icons/16x16/calendar-date.png"sv).release_value_but_fixme_should_propagate_errors());
-    m_jump_to_button->set_tooltip_deprecated("Jump to today");
+    m_jump_to_button->set_tooltip("Jump to today"_string);
     m_jump_to_button->on_click = [this](auto) {
         jump_to_current_date();
     };
@@ -116,7 +116,7 @@ ClockWidget::ClockWidget()
     m_calendar_launcher->set_button_style(Gfx::ButtonStyle::Coolbar);
     m_calendar_launcher->set_fixed_size(24, 24);
     m_calendar_launcher->set_icon(Gfx::Bitmap::load_from_file("/res/icons/16x16/app-calendar.png"sv).release_value_but_fixme_should_propagate_errors());
-    m_calendar_launcher->set_tooltip_deprecated("Calendar");
+    m_calendar_launcher->set_tooltip("Calendar"_string);
     m_calendar_launcher->on_click = [this](auto) {
         GUI::Process::spawn_or_show_error(window(), "/bin/Calendar"sv);
     };

--- a/Userland/Services/Taskbar/QuickLaunchWidget.cpp
+++ b/Userland/Services/Taskbar/QuickLaunchWidget.cpp
@@ -191,7 +191,7 @@ ErrorOr<void> QuickLaunchWidget::add_or_adjust_button(DeprecatedString const& bu
     button->set_button_style(Gfx::ButtonStyle::Coolbar);
     auto icon = entry->icon();
     button->set_icon(icon.bitmap_for_size(16));
-    button->set_tooltip_deprecated(entry->name());
+    button->set_tooltip(MUST(String::from_deprecated_string(entry->name())));
     button->set_name(button_name);
     button->on_click = [entry = move(entry), this](auto) {
         auto result = entry->launch();

--- a/Userland/Services/Taskbar/TaskbarWindow.cpp
+++ b/Userland/Services/Taskbar/TaskbarWindow.cpp
@@ -89,7 +89,7 @@ ErrorOr<void> TaskbarWindow::populate_taskbar()
     m_clock_widget = main_widget->add<Taskbar::ClockWidget>();
 
     m_show_desktop_button = main_widget->add<GUI::Button>();
-    m_show_desktop_button->set_tooltip_deprecated("Show Desktop");
+    m_show_desktop_button->set_tooltip("Show Desktop"_string);
     m_show_desktop_button->set_icon(TRY(GUI::Icon::try_create_default_icon("desktop"sv)).bitmap_for_size(16));
     m_show_desktop_button->set_button_style(Gfx::ButtonStyle::Coolbar);
     m_show_desktop_button->set_fixed_size(24, 24);

--- a/Userland/Services/Taskbar/TaskbarWindow.cpp
+++ b/Userland/Services/Taskbar/TaskbarWindow.cpp
@@ -199,7 +199,7 @@ void TaskbarWindow::update_window_button(::Window& window, bool show_as_active)
     if (!button)
         return;
     button->set_text(String::from_deprecated_string(window.title()).release_value_but_fixme_should_propagate_errors());
-    button->set_tooltip_deprecated(window.title());
+    button->set_tooltip(String::from_deprecated_string(window.title()).release_value_but_fixme_should_propagate_errors());
     button->set_checked(show_as_active);
     button->set_visible(is_window_on_current_workspace(window));
 }


### PR DESCRIPTION
work towards https://github.com/SerenityOS/serenity/issues/17128