### PR TITLE
LibWeb/URL: Add `strip_trailing_spaces_from_an_opaque_path()`

### DIFF
--- a/AK/URL.cpp
+++ b/AK/URL.cpp
@@ -260,16 +260,25 @@ bool URL::is_special_scheme(StringView scheme)
     return scheme.is_one_of("ftp", "file", "http", "https", "ws", "wss");
 }
 
-DeprecatedString URL::serialize_path() const
+// https://url.spec.whatwg.org/#url-path-serializer
+DeprecatedString URL::serialize_path(ApplyPercentDecoding apply_percent_decoding) const
 {
+    // If url has an opaque path, then return url’s path.
+    // FIXME: Reimplement this step once we modernize the URL implementation to meet the spec.
     if (cannot_be_a_base_url())
         return m_paths[0];
-    StringBuilder builder;
-    for (auto& path : m_paths) {
-        builder.append('/');
-        builder.append(percent_decode(path));
+
+    // Let output be the empty string.
+    StringBuilder output;
+
+    // For each segment of url’s path: append U+002F (/) followed by segment to output.
+    for (auto const& segment : m_paths) {
+        output.append('/');
+        output.append(apply_percent_decoding == ApplyPercentDecoding::Yes ? percent_decode(segment) : segment);
     }
-    return builder.to_deprecated_string();
+
+    // Return output.
+    return output.to_deprecated_string();
 }
 
 // https://url.spec.whatwg.org/#concept-url-serializer

--- a/AK/URL.h
+++ b/AK/URL.h
@@ -107,7 +107,11 @@ public:
         m_paths.append("");
     }
 
-    DeprecatedString serialize_path() const;
+    enum class ApplyPercentDecoding {
+        Yes,
+        No
+    };
+    DeprecatedString serialize_path(ApplyPercentDecoding = ApplyPercentDecoding::Yes) const;
     DeprecatedString serialize(ExcludeFragment = ExcludeFragment::No) const;
     DeprecatedString serialize_for_display() const;
     DeprecatedString to_deprecated_string() const { return serialize(); }

--- a/Tests/LibWeb/Text/expected/URL/strip_trailing_spaces_from_opaque_path.txt
+++ b/Tests/LibWeb/Text/expected/URL/strip_trailing_spaces_from_opaque_path.txt
@@ -1,0 +1,4 @@
+pathname => 'foobar                 '
+pathname => 'foobar'
+pathname => 'baz '
+pathname => 'baz'

--- a/Tests/LibWeb/Text/input/URL/strip_trailing_spaces_from_opaque_path.html
+++ b/Tests/LibWeb/Text/input/URL/strip_trailing_spaces_from_opaque_path.html
@@ -1,0 +1,14 @@
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        let url = new URL("scheme:foobar                 ?well=hello");
+        println(`pathname => '${url.pathname}'`);
+        url.search = "";
+        println(`pathname => '${url.pathname}'`);
+
+        url = new URL("scheme:baz #friends");
+        println(`pathname => '${url.pathname}'`);
+        url.hash = "";
+        println(`pathname => '${url.pathname}'`);
+    });
+</script>

--- a/Userland/Libraries/LibWeb/URL/URL.cpp
+++ b/Userland/Libraries/LibWeb/URL/URL.cpp
@@ -403,7 +403,8 @@ WebIDL::ExceptionOr<void> URL::set_search(String const& search)
         // 2. Empty this’s query object’s list.
         m_query->m_list.clear();
 
-        // FIXME: 3. Potentially strip trailing spaces from an opaque path with this.
+        // 3. Potentially strip trailing spaces from an opaque path with this.
+        strip_trailing_spaces_from_an_opaque_path(*this);
 
         // 4. Return.
         return {};
@@ -457,7 +458,8 @@ void URL::set_hash(String const& hash)
         // 1. Set this’s URL’s fragment to null.
         m_url.set_fragment({});
 
-        // FIXME: 2. Potentially strip trailing spaces from an opaque path with this.
+        // 2. Potentially strip trailing spaces from an opaque path with this.
+        strip_trailing_spaces_from_an_opaque_path(*this);
 
         // 3. Return.
         return;
@@ -533,6 +535,29 @@ bool host_is_domain(AK::URL::Host const& host)
 {
     // A domain is a non-empty ASCII string that identifies a realm within a network.
     return host.has<String>() && host.get<String>() != String {};
+}
+
+// https://url.spec.whatwg.org/#potentially-strip-trailing-spaces-from-an-opaque-path
+void strip_trailing_spaces_from_an_opaque_path(URL& url)
+{
+    // 1. If url’s URL does not have an opaque path, then return.
+    // FIXME: Reimplement this step once we modernize the URL implementation to meet the spec.
+    if (!url.cannot_be_a_base_url())
+        return;
+
+    // 2. If url’s URL’s fragment is non-null, then return.
+    if (url.fragment().has_value())
+        return;
+
+    // 3. If url’s URL’s query is non-null, then return.
+    if (url.query().has_value())
+        return;
+
+    // 4. Remove all trailing U+0020 SPACE code points from url’s URL’s path.
+    // NOTE: At index 0 since the first step tells us that the URL only has one path segment.
+    auto opaque_path = url.path_segment_at_index(0);
+    auto trimmed_path = opaque_path.trim(" "sv, TrimMode::Right);
+    url.set_paths({ trimmed_path });
 }
 
 // https://url.spec.whatwg.org/#concept-url-parser

--- a/Userland/Libraries/LibWeb/URL/URL.cpp
+++ b/Userland/Libraries/LibWeb/URL/URL.cpp
@@ -353,7 +353,7 @@ WebIDL::ExceptionOr<String> URL::pathname() const
     auto& vm = realm().vm();
 
     // The pathname getter steps are to return the result of URL path serializing this’s URL.
-    return TRY_OR_THROW_OOM(vm, String::from_deprecated_string(m_url.serialize_path()));
+    return TRY_OR_THROW_OOM(vm, String::from_deprecated_string(m_url.serialize_path(AK::URL::ApplyPercentDecoding::No)));
 }
 
 // https://url.spec.whatwg.org/#ref-for-dom-url-pathname%E2%91%A0

--- a/Userland/Libraries/LibWeb/URL/URL.h
+++ b/Userland/Libraries/LibWeb/URL/URL.h
@@ -55,6 +55,15 @@ public:
     WebIDL::ExceptionOr<String> pathname() const;
     void set_pathname(String const&);
 
+    Optional<String> const& fragment() const { return m_url.fragment(); }
+
+    DeprecatedString path_segment_at_index(size_t index) const { return m_url.path_segment_at_index(index); }
+
+    void set_paths(Vector<DeprecatedString> const& paths) { return m_url.set_paths(paths); }
+
+    // FIXME: Reimplement this to meet the definition in https://url.spec.whatwg.org/#url-opaque-path once we modernize URL to meet the spec.
+    bool cannot_be_a_base_url() const { return m_url.cannot_be_a_base_url(); }
+
     WebIDL::ExceptionOr<String> search() const;
     WebIDL::ExceptionOr<void> set_search(String const&);
 
@@ -65,6 +74,7 @@ public:
 
     WebIDL::ExceptionOr<String> to_json() const;
 
+    Optional<String> const& query() const { return m_url.query(); }
     void set_query(Badge<URLSearchParams>, Optional<String> query) { m_url.set_query(move(query)); }
 
 private:
@@ -79,6 +89,9 @@ private:
 
 HTML::Origin url_origin(AK::URL const&);
 bool host_is_domain(AK::URL::Host const&);
+
+// https://url.spec.whatwg.org/#potentially-strip-trailing-spaces-from-an-opaque-path
+void strip_trailing_spaces_from_an_opaque_path(URL& url);
 
 // https://url.spec.whatwg.org/#concept-url-parser
 AK::URL parse(StringView input, Optional<AK::URL> const& base_url = {});


### PR DESCRIPTION
Adds https://url.spec.whatwg.org/#potentially-strip-trailing-spaces-from-an-opaque-path.

Tested the code paths in `set_search()` and `set_hash()`  and they appear fine, though I think the design may be questionable, specifically with exposing more methods and delegating the work in those methods to `AK::URL`.