### PR TITLE
LibWeb: Port DocumentFragment from DeprecatedString to String

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/CharacterData.cpp
+++ b/Userland/Libraries/LibWeb/DOM/CharacterData.cpp
@@ -33,7 +33,7 @@ void CharacterData::set_data(DeprecatedString data)
     // NOTE: Since the offset is 0, it can never be above data's length, so this can never throw.
     // NOTE: Setting the data to the same value as the current data still causes a mutation observer callback.
     // FIXME: Figure out a way to make this a no-op again if the passed in data is the same as the current data.
-    MUST(replace_data(0, m_data.length(), data));
+    MUST(replace_data(0, this->length(), data));
 }
 
 // https://dom.spec.whatwg.org/#concept-cd-substring
@@ -124,7 +124,7 @@ WebIDL::ExceptionOr<void> CharacterData::replace_data(size_t offset, size_t coun
 WebIDL::ExceptionOr<void> CharacterData::append_data(DeprecatedString const& data)
 {
     // The appendData(data) method steps are to replace data with node this, offset this’s length, count 0, and data data.
-    return replace_data(m_data.length(), 0, data);
+    return replace_data(this->length(), 0, data);
 }
 
 // https://dom.spec.whatwg.org/#dom-characterdata-insertdata

--- a/Userland/Libraries/LibWeb/DOM/ChildNode.h
+++ b/Userland/Libraries/LibWeb/DOM/ChildNode.h
@@ -31,7 +31,7 @@ public:
         auto viable_previous_sibling = viable_previous_sibling_for_insertion(nodes);
 
         // 4. Let node be the result of converting nodes into a node, given nodes and this’s node document.
-        auto node_to_insert = TRY(convert_nodes_to_single_node(nodes, node->document()));
+        auto node_to_insert = TRY(convert_nodes_to_single_node(from_deprecated_nodes(nodes), node->document()));
 
         // 5. If viablePreviousSibling is null, then set it to parent’s first child; otherwise to viablePreviousSibling’s next sibling.
         if (!viable_previous_sibling)
@@ -61,7 +61,7 @@ public:
         auto viable_next_sibling = viable_nest_sibling_for_insertion(nodes);
 
         // 4. Let node be the result of converting nodes into a node, given nodes and this’s node document.
-        auto node_to_insert = TRY(convert_nodes_to_single_node(nodes, node->document()));
+        auto node_to_insert = TRY(convert_nodes_to_single_node(from_deprecated_nodes(nodes), node->document()));
 
         // 5. Pre-insert node into parent before viableNextSibling.
         (void)TRY(parent->pre_insert(node_to_insert, viable_next_sibling));
@@ -85,7 +85,7 @@ public:
         auto viable_next_sibling = viable_nest_sibling_for_insertion(nodes);
 
         // 4. Let node be the result of converting nodes into a node, given nodes and this’s node document.
-        auto node_to_insert = TRY(convert_nodes_to_single_node(nodes, node->document()));
+        auto node_to_insert = TRY(convert_nodes_to_single_node(from_deprecated_nodes(nodes), node->document()));
 
         // 5. If this’s parent is parent, replace this with node within parent.
         // Note: This could have been inserted into node.

--- a/Userland/Libraries/LibWeb/DOM/DocumentFragment.idl
+++ b/Userland/Libraries/LibWeb/DOM/DocumentFragment.idl
@@ -5,7 +5,7 @@
 #import <DOM/ParentNode.idl>
 
 // https://dom.spec.whatwg.org/#documentfragment
-[Exposed=Window, UseDeprecatedAKString]
+[Exposed=Window]
 interface DocumentFragment : Node {
     constructor();
 

--- a/Userland/Libraries/LibWeb/DOM/NodeOperations.cpp
+++ b/Userland/Libraries/LibWeb/DOM/NodeOperations.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022, Luke Wilde <lukew@serenityos.org>
+ * Copyright (c) 2023, Shannon Booth <shannon@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -14,7 +15,7 @@
 namespace Web::DOM {
 
 // https://dom.spec.whatwg.org/#converting-nodes-into-a-node
-WebIDL::ExceptionOr<JS::NonnullGCPtr<Node>> convert_nodes_to_single_node(Vector<Variant<JS::Handle<Node>, DeprecatedString>> const& nodes, DOM::Document& document)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<Node>> convert_nodes_to_single_node(Vector<Variant<JS::Handle<Node>, String>> const& nodes, DOM::Document& document)
 {
     // 1. Let node be null.
     // 2. Replace each string in nodes with a new Text node whose data is the string and node document is document.
@@ -22,23 +23,39 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Node>> convert_nodes_to_single_node(Vector<
     // 4. Otherwise, set node to a new DocumentFragment node whose node document is document, and then append each node in nodes, if any, to it.
     // 5. Return node.
 
-    auto potentially_convert_string_to_text_node = [&document](Variant<JS::Handle<Node>, DeprecatedString> const& node) -> JS::NonnullGCPtr<Node> {
+    auto potentially_convert_string_to_text_node = [&document](Variant<JS::Handle<Node>, String> const& node) -> JS::NonnullGCPtr<Node> {
         if (node.has<JS::Handle<Node>>())
             return *node.get<JS::Handle<Node>>();
 
-        return document.heap().allocate<DOM::Text>(document.realm(), document, MUST(String::from_deprecated_string(node.get<DeprecatedString>())));
+        return document.heap().allocate<DOM::Text>(document.realm(), document, node.get<String>());
     };
 
     if (nodes.size() == 1)
         return potentially_convert_string_to_text_node(nodes.first());
 
     auto document_fragment = document.heap().allocate<DOM::DocumentFragment>(document.realm(), document);
-    for (auto& unconverted_node : nodes) {
+    for (auto const& unconverted_node : nodes) {
         auto node = potentially_convert_string_to_text_node(unconverted_node);
         (void)TRY(document_fragment->append_child(node));
     }
 
     return document_fragment;
+}
+
+Vector<Variant<JS::Handle<Node>, String>> from_deprecated_nodes(Vector<Variant<JS::Handle<Node>, DeprecatedString>> const& deprecated_nodes)
+{
+    Vector<Variant<JS::Handle<Node>, String>> nodes;
+    nodes.ensure_capacity(deprecated_nodes.size());
+    for (auto const& deprecated_node : deprecated_nodes) {
+        deprecated_node.visit(
+            [&nodes](JS::Handle<Node> node) {
+                nodes.unchecked_append(node);
+            },
+            [&nodes](DeprecatedString const& deprecated_node) {
+                nodes.unchecked_append(MUST(String::from_deprecated_string(deprecated_node)));
+            });
+    }
+    return nodes;
 }
 
 }

--- a/Userland/Libraries/LibWeb/DOM/NodeOperations.h
+++ b/Userland/Libraries/LibWeb/DOM/NodeOperations.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022, Luke Wilde <lukew@serenityos.org>
+ * Copyright (c) 2023, Shannon Booth <shannon@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -12,6 +13,8 @@
 
 namespace Web::DOM {
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<Node>> convert_nodes_to_single_node(Vector<Variant<JS::Handle<Node>, DeprecatedString>> const& nodes, DOM::Document& document);
+WebIDL::ExceptionOr<JS::NonnullGCPtr<Node>> convert_nodes_to_single_node(Vector<Variant<JS::Handle<Node>, String>> const& nodes, DOM::Document& document);
+
+Vector<Variant<JS::Handle<Node>, String>> from_deprecated_nodes(Vector<Variant<JS::Handle<Node>, DeprecatedString>> const& deprecated_nodes);
 
 }

--- a/Userland/Libraries/LibWeb/DOM/NonElementParentNode.h
+++ b/Userland/Libraries/LibWeb/DOM/NonElementParentNode.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/FlyString.h>
 #include <AK/Forward.h>
 #include <LibJS/Heap/GCPtr.h>
 #include <LibWeb/Forward.h>
@@ -17,6 +18,11 @@ namespace Web::DOM {
 template<typename NodeType>
 class NonElementParentNode {
 public:
+    JS::GCPtr<Element const> get_element_by_id(FlyString const& id) const
+    {
+        return get_element_by_id(id.to_deprecated_fly_string());
+    }
+
     JS::GCPtr<Element const> get_element_by_id(DeprecatedFlyString const& id) const
     {
         JS::GCPtr<Element const> found_element;
@@ -28,6 +34,11 @@ public:
             return IterationDecision::Continue;
         });
         return found_element;
+    }
+
+    JS::GCPtr<Element> get_element_by_id(FlyString const& id)
+    {
+        return get_element_by_id(id.to_deprecated_fly_string());
     }
 
     JS::GCPtr<Element> get_element_by_id(DeprecatedFlyString const& id)

--- a/Userland/Libraries/LibWeb/DOM/ParentNode.cpp
+++ b/Userland/Libraries/LibWeb/DOM/ParentNode.cpp
@@ -187,7 +187,7 @@ JS::NonnullGCPtr<HTMLCollection> ParentNode::get_elements_by_tag_name_ns(Depreca
 }
 
 // https://dom.spec.whatwg.org/#dom-parentnode-prepend
-WebIDL::ExceptionOr<void> ParentNode::prepend(Vector<Variant<JS::Handle<Node>, DeprecatedString>> const& nodes)
+WebIDL::ExceptionOr<void> ParentNode::prepend(Vector<Variant<JS::Handle<Node>, String>> const& nodes)
 {
     // 1. Let node be the result of converting nodes into a node given nodes and this’s node document.
     auto node = TRY(convert_nodes_to_single_node(nodes, document()));
@@ -198,7 +198,22 @@ WebIDL::ExceptionOr<void> ParentNode::prepend(Vector<Variant<JS::Handle<Node>, D
     return {};
 }
 
+WebIDL::ExceptionOr<void> ParentNode::prepend(Vector<Variant<JS::Handle<Node>, DeprecatedString>> const& nodes)
+{
+    return prepend(from_deprecated_nodes(nodes));
+}
+
 WebIDL::ExceptionOr<void> ParentNode::append(Vector<Variant<JS::Handle<Node>, DeprecatedString>> const& nodes)
+{
+    return append(from_deprecated_nodes(nodes));
+}
+
+WebIDL::ExceptionOr<void> ParentNode::replace_children(Vector<Variant<JS::Handle<Node>, DeprecatedString>> const& nodes)
+{
+    return replace_children(from_deprecated_nodes(nodes));
+}
+
+WebIDL::ExceptionOr<void> ParentNode::append(Vector<Variant<JS::Handle<Node>, String>> const& nodes)
 {
     // 1. Let node be the result of converting nodes into a node given nodes and this’s node document.
     auto node = TRY(convert_nodes_to_single_node(nodes, document()));
@@ -209,7 +224,7 @@ WebIDL::ExceptionOr<void> ParentNode::append(Vector<Variant<JS::Handle<Node>, De
     return {};
 }
 
-WebIDL::ExceptionOr<void> ParentNode::replace_children(Vector<Variant<JS::Handle<Node>, DeprecatedString>> const& nodes)
+WebIDL::ExceptionOr<void> ParentNode::replace_children(Vector<Variant<JS::Handle<Node>, String>> const& nodes)
 {
     // 1. Let node be the result of converting nodes into a node given nodes and this’s node document.
     auto node = TRY(convert_nodes_to_single_node(nodes, document()));

--- a/Userland/Libraries/LibWeb/DOM/ParentNode.h
+++ b/Userland/Libraries/LibWeb/DOM/ParentNode.h
@@ -31,6 +31,10 @@ public:
     JS::NonnullGCPtr<HTMLCollection> get_elements_by_tag_name(DeprecatedFlyString const&);
     JS::NonnullGCPtr<HTMLCollection> get_elements_by_tag_name_ns(DeprecatedFlyString const&, DeprecatedFlyString const&);
 
+    WebIDL::ExceptionOr<void> prepend(Vector<Variant<JS::Handle<Node>, String>> const& nodes);
+    WebIDL::ExceptionOr<void> append(Vector<Variant<JS::Handle<Node>, String>> const& nodes);
+    WebIDL::ExceptionOr<void> replace_children(Vector<Variant<JS::Handle<Node>, String>> const& nodes);
+
     WebIDL::ExceptionOr<void> prepend(Vector<Variant<JS::Handle<Node>, DeprecatedString>> const& nodes);
     WebIDL::ExceptionOr<void> append(Vector<Variant<JS::Handle<Node>, DeprecatedString>> const& nodes);
     WebIDL::ExceptionOr<void> replace_children(Vector<Variant<JS::Handle<Node>, DeprecatedString>> const& nodes);

--- a/Userland/Libraries/LibWeb/SVG/SVGGradientElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGGradientElement.cpp
@@ -100,7 +100,7 @@ JS::GCPtr<SVGGradientElement const> SVGGradientElement::linked_gradient() const
         auto id = url.fragment();
         if (!id.has_value() || id->is_empty())
             return {};
-        auto element = document().get_element_by_id(id->to_deprecated_string());
+        auto element = document().get_element_by_id(id.value());
         if (!element)
             return {};
         if (!is<SVGGradientElement>(*element))

--- a/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
@@ -49,7 +49,7 @@ Optional<Gfx::PaintStyle const&> SVGGraphicsElement::svg_paint_computed_value_to
     auto const& url = paint_value->as_url();
     if (!url.fragment().has_value())
         return {};
-    auto gradient = document().get_element_by_id(url.fragment()->to_deprecated_string());
+    auto gradient = document().get_element_by_id(url.fragment().value());
     if (!gradient)
         return {};
     if (is<SVG::SVGGradientElement>(*gradient))


### PR DESCRIPTION
This leaves 5 more interfaces to be ported over from DeprecatedString.

Also includes one commit to closer match the spec for CharacterData - which will also make it easier to port that interface from DeprecatedString in the future.