### PR TITLE
Ladybird: Allow opening multiple URLs at once from the command line

### DIFF
--- a/Ladybird/Qt/BrowserWindow.cpp
+++ b/Ladybird/Qt/BrowserWindow.cpp
@@ -39,7 +39,7 @@ static QIcon const& app_icon()
     return icon;
 }
 
-BrowserWindow::BrowserWindow(Optional<URL> const& initial_url, WebView::CookieJar& cookie_jar, StringView webdriver_content_ipc_path, WebView::EnableCallgrindProfiling enable_callgrind_profiling, UseLagomNetworking use_lagom_networking)
+BrowserWindow::BrowserWindow(Vector<URL> const& initial_urls, WebView::CookieJar& cookie_jar, StringView webdriver_content_ipc_path, WebView::EnableCallgrindProfiling enable_callgrind_profiling, UseLagomNetworking use_lagom_networking)
     : m_cookie_jar(cookie_jar)
     , m_webdriver_content_ipc_path(webdriver_content_ipc_path)
     , m_enable_callgrind_profiling(enable_callgrind_profiling)
@@ -403,9 +403,13 @@ BrowserWindow::BrowserWindow(Optional<URL> const& initial_url, WebView::CookieJa
     m_go_forward_action->setEnabled(false);
     m_reload_action->setEnabled(false);
 
-    if (initial_url.has_value()) {
-        auto initial_url_string = qstring_from_ak_deprecated_string(initial_url->serialize());
-        new_tab(initial_url_string, Web::HTML::ActivateTab::Yes);
+    if (!initial_urls.is_empty()) {
+        bool is_first_tab = true;
+        for (auto const& url : initial_urls) {
+            auto initial_url_string = qstring_from_ak_deprecated_string(url.serialize());
+            new_tab(initial_url_string, is_first_tab ? Web::HTML::ActivateTab::Yes : Web::HTML::ActivateTab::No);
+            is_first_tab = false;
+        }
     } else {
         new_tab(Settings::the()->new_tab_page(), Web::HTML::ActivateTab::Yes);
     }

--- a/Ladybird/Qt/BrowserWindow.h
+++ b/Ladybird/Qt/BrowserWindow.h
@@ -25,7 +25,7 @@ class WebContentView;
 class BrowserWindow : public QMainWindow {
     Q_OBJECT
 public:
-    explicit BrowserWindow(Optional<URL> const& initial_url, WebView::CookieJar&, StringView webdriver_content_ipc_path, WebView::EnableCallgrindProfiling, UseLagomNetworking);
+    explicit BrowserWindow(Vector<URL> const& initial_urls, WebView::CookieJar&, StringView webdriver_content_ipc_path, WebView::EnableCallgrindProfiling, UseLagomNetworking);
 
     WebContentView& view() const { return m_current_tab->view(); }
 


### PR DESCRIPTION
This is a small change that enables Ladybird to open multiple URLs supplied as command-line-arguments. Each URL is opened in a separate tab on startup, and the active tab is the first URL supplied.

This mirrors the behavior of other browsers like Chromium and Firefox (and the Serenity browser! :^)).