### PR TITLE
LibJS+LibWeb: Track SharedArrayBuffers' shared state

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/ArrayBufferPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayBufferPrototype.cpp
@@ -139,7 +139,8 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayBufferPrototype::byte_length_getter)
     auto array_buffer_object = TRY(typed_this_value(vm));
 
     // 3. If IsSharedArrayBuffer(O) is true, throw a TypeError exception.
-    // FIXME: Check for shared buffer
+    if (array_buffer_object->is_shared_array_buffer())
+        return vm.throw_completion<TypeError>(ErrorType::ThisCannotBeSharedArrayBuffer);
 
     // NOTE: These steps are done in byte_length()
     // 4. If IsDetachedBuffer(O) is true, return +0𝔽.

--- a/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
+++ b/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
@@ -293,6 +293,7 @@
     M(TemporalUnknownCriticalAnnotation, "Unknown annotation key in critical annotation: '{}'")                                         \
     M(TemporalZonedDateTimeRoundZeroOrNegativeLengthDay, "Cannot round a ZonedDateTime in a calendar or time zone that has zero or "    \
                                                          "negative length days")                                                        \
+    M(ThisCannotBeSharedArrayBuffer, "|this| cannot be a SharedArrayBuffer")                                                            \
     M(ThisHasNotBeenInitialized, "|this| has not been initialized")                                                                     \
     M(ThisIsAlreadyInitialized, "|this| is already initialized")                                                                        \
     M(ToObjectNullOrUndefined, "ToObject on null or undefined")                                                                         \

--- a/Userland/Libraries/LibJS/Runtime/SharedArrayBufferPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/SharedArrayBufferPrototype.cpp
@@ -37,7 +37,7 @@ JS_DEFINE_NATIVE_FUNCTION(SharedArrayBufferPrototype::byte_length_getter)
     // 2. Perform ? RequireInternalSlot(O, [[ArrayBufferData]]).
     auto array_buffer_object = TRY(typed_this_value(vm));
 
-    // 3. If IsSharedArrayBuffer(O) is true, throw a TypeError exception.
+    // 3. If IsSharedArrayBuffer(O) is false, throw a TypeError exception.
     // FIXME: Check for shared buffer
 
     // 4. Let length be O.[[ArrayBufferByteLength]].

--- a/Userland/Libraries/LibWeb/HTML/StructuredSerialize.cpp
+++ b/Userland/Libraries/LibWeb/HTML/StructuredSerialize.cpp
@@ -309,7 +309,7 @@ private:
             auto data_copy = TRY(JS::create_byte_data_block(m_vm, size));
 
             // 4. Perform CopyDataBlockBytes(dataCopy, 0, value.[[ArrayBufferData]], 0, size).
-            JS::copy_data_block_bytes(data_copy, 0, array_buffer.buffer(), 0, size);
+            JS::copy_data_block_bytes(data_copy.buffer(), 0, array_buffer.buffer(), 0, size);
 
             // FIXME: 5. If value has an [[ArrayBufferMaxByteLength]] internal slot, then set serialized to { [[Type]]: "ResizableArrayBuffer",
             //    [[ArrayBufferData]]: dataCopy, [[ArrayBufferByteLength]]: size, [[ArrayBufferMaxByteLength]]: value.[[ArrayBufferMaxByteLength]] }.
@@ -318,7 +318,7 @@ private:
             // 6. Otherwise, set serialized to { [[Type]]: "ArrayBuffer", [[ArrayBufferData]]: dataCopy, [[ArrayBufferByteLength]]: size }.
             else {
                 vector.append(ValueTag::ArrayBuffer);
-                TRY(serialize_bytes(vector, data_copy.bytes()));
+                TRY(serialize_bytes(vector, data_copy.buffer().bytes()));
             }
         }
         return {};


### PR DESCRIPTION
ArrayBuffer no longer stores a plain ByteBuffer internally, but a DataBlock instead, which encapsulated the ByteBuffer together with information if it is shared or not.