### PR TITLE
Ladybird: Add more items to the debug menu of the AppKit chrome

### DIFF
--- a/Ladybird/AppKit/UI/LadybirdWebView.h
+++ b/Ladybird/AppKit/UI/LadybirdWebView.h
@@ -51,6 +51,8 @@
 
 - (void)setPreferredColorScheme:(Web::CSS::PreferredColorScheme)color_scheme;
 
+- (void)debugRequest:(DeprecatedString const&)request argument:(DeprecatedString const&)argument;
+
 - (void)viewSource;
 
 @end

--- a/Ladybird/AppKit/UI/LadybirdWebView.mm
+++ b/Ladybird/AppKit/UI/LadybirdWebView.mm
@@ -146,6 +146,11 @@ struct HideCursor {
     m_web_view_bridge->set_preferred_color_scheme(color_scheme);
 }
 
+- (void)debugRequest:(DeprecatedString const&)request argument:(DeprecatedString const&)argument
+{
+    m_web_view_bridge->debug_request(request, argument);
+}
+
 - (void)viewSource
 {
     m_web_view_bridge->get_source();

--- a/Ladybird/AppKit/UI/TabController.h
+++ b/Ladybird/AppKit/UI/TabController.h
@@ -11,6 +11,14 @@
 
 #import <System/Cocoa.h>
 
+struct TabSettings {
+    BOOL should_show_line_box_borders { NO };
+    BOOL scripting_enabled { YES };
+    BOOL block_popups { YES };
+    BOOL same_origin_policy_enabled { NO };
+    DeprecatedString user_agent_name { "Disabled"sv };
+};
+
 @interface TabController : NSWindowController <NSWindowDelegate>
 
 - (instancetype)init;
@@ -25,6 +33,8 @@
 - (void)navigateForward:(id)sender;
 - (void)reload:(id)sender;
 - (void)clearHistory;
+
+- (void)debugRequest:(DeprecatedString const&)request argument:(DeprecatedString const&)argument;
 
 - (void)focusLocationToolbarItem;
 

--- a/Ladybird/Qt/BrowserWindow.cpp
+++ b/Ladybird/Qt/BrowserWindow.cpp
@@ -18,6 +18,7 @@
 #include <LibWeb/CSS/PreferredColorScheme.h>
 #include <LibWeb/Loader/ResourceLoader.h>
 #include <LibWebView/CookieJar.h>
+#include <LibWebView/UserAgent.h>
 #include <QAction>
 #include <QActionGroup>
 #include <QClipboard>
@@ -297,8 +298,8 @@ BrowserWindow::BrowserWindow(Vector<URL> const& initial_urls, WebView::CookieJar
 
     auto* user_agent_group = new QActionGroup(this);
 
-    auto add_user_agent = [this, &user_agent_group, &spoof_user_agent_menu](auto& name, auto& user_agent) {
-        auto* action = new QAction(name, this);
+    auto add_user_agent = [this, &user_agent_group, &spoof_user_agent_menu](auto const& name, auto const& user_agent) {
+        auto* action = new QAction(qstring_from_ak_deprecated_string(name), this);
         action->setCheckable(true);
         user_agent_group->addAction(action);
         spoof_user_agent_menu->addAction(action);
@@ -311,12 +312,8 @@ BrowserWindow::BrowserWindow(Vector<URL> const& initial_urls, WebView::CookieJar
 
     auto* disable_spoofing = add_user_agent("Disabled", Web::default_user_agent);
     disable_spoofing->setChecked(true);
-    add_user_agent("Chrome Linux Desktop", "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Safari/537.36");
-    add_user_agent("Firefox Linux Desktop", "Mozilla/5.0 (X11; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/116.0");
-    add_user_agent("Safari macOS Desktop", "Mozilla/5.0 (Macintosh; Intel Mac OS X 13_5_1) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.5 Safari/605.1.15");
-    add_user_agent("Chrome Android Mobile", "Mozilla/5.0 (Linux; Android 10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.5845.114 Mobile Safari/537.36");
-    add_user_agent("Firefox Android Mobile", "Mozilla/5.0 (Android 13; Mobile; rv:109.0) Gecko/116.0 Firefox/116.0");
-    add_user_agent("Safari iOS Mobile", "Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.0 Mobile/15E148 Safari/604.1");
+    for (auto const& user_agent : WebView::user_agents)
+        add_user_agent(user_agent.key.to_deprecated_string(), user_agent.value.to_deprecated_string());
 
     auto* custom_user_agent_action = new QAction("Custom...", this);
     custom_user_agent_action->setCheckable(true);

--- a/Userland/Applications/Browser/BrowserWindow.cpp
+++ b/Userland/Applications/Browser/BrowserWindow.cpp
@@ -36,6 +36,7 @@
 #include <LibWeb/Loader/ResourceLoader.h>
 #include <LibWebView/CookieJar.h>
 #include <LibWebView/OutOfProcessWebView.h>
+#include <LibWebView/UserAgent.h>
 #include <LibWebView/WebContentClient.h>
 
 namespace Browser {
@@ -416,12 +417,8 @@ void BrowserWindow::build_menus()
         spoof_user_agent_menu->add_action(action);
         m_user_agent_spoof_actions.add_action(action);
     };
-    add_user_agent("Chrome Linux Desktop", "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.128 Safari/537.36"sv);
-    add_user_agent("Firefox Linux Desktop", "Mozilla/5.0 (X11; Linux x86_64; rv:87.0) Gecko/20100101 Firefox/87.0"sv);
-    add_user_agent("Safari macOS Desktop", "Mozilla/5.0 (Macintosh; Intel Mac OS X 11_2_3) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0.3 Safari/605.1.15"sv);
-    add_user_agent("Chrome Android Mobile", "Mozilla/5.0 (Linux; Android 10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.66 Mobile Safari/537.36"sv);
-    add_user_agent("Firefox Android Mobile", "Mozilla/5.0 (Android 11; Mobile; rv:68.0) Gecko/68.0 Firefox/86.0"sv);
-    add_user_agent("Safari iOS Mobile", "Mozilla/5.0 (iPhone; CPU iPhone OS 14_4_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0 Mobile/15E148 Safari/604.1"sv);
+    for (auto const& user_agent : WebView::user_agents)
+        add_user_agent(user_agent.key, user_agent.value);
 
     auto custom_user_agent = GUI::Action::create_checkable("Custom...", [this](auto& action) {
         String user_agent;

--- a/Userland/Libraries/LibWebView/CMakeLists.txt
+++ b/Userland/Libraries/LibWebView/CMakeLists.txt
@@ -9,6 +9,7 @@ set(SOURCES
     RequestServerAdapter.cpp
     SourceHighlighter.cpp
     StylePropertiesModel.cpp
+    UserAgent.cpp
     ViewImplementation.cpp
     WebContentClient.cpp
     WebSocketClientAdapter.cpp

--- a/Userland/Libraries/LibWebView/UserAgent.cpp
+++ b/Userland/Libraries/LibWebView/UserAgent.cpp
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2023, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "UserAgent.h"
+
+namespace WebView {
+
+HashMap<StringView, StringView> const user_agents = {
+    { "Chrome Linux Desktop"sv, "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Safari/537.36"sv },
+    { "Firefox Linux Desktop"sv, "Mozilla/5.0 (X11; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/116.0"sv },
+    { "Safari macOS Desktop"sv, "Mozilla/5.0 (Macintosh; Intel Mac OS X 13_5_1) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.5 Safari/605.1.15"sv },
+    { "Chrome Android Mobile"sv, "Mozilla/5.0 (Linux; Android 10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.5845.114 Mobile Safari/537.36"sv },
+    { "Firefox Android Mobile"sv, "Mozilla/5.0 (Android 13; Mobile; rv:109.0) Gecko/116.0 Firefox/116.0"sv },
+    { "Safari iOS Mobile"sv, "Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.0 Mobile/15E148 Safari/604.1"sv },
+};
+
+}

--- a/Userland/Libraries/LibWebView/UserAgent.h
+++ b/Userland/Libraries/LibWebView/UserAgent.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2023, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/HashMap.h>
+#include <AK/StringView.h>
+
+namespace WebView {
+
+extern HashMap<StringView, StringView> const user_agents;
+
+}


### PR DESCRIPTION
This PR brings the debug menu of the AppKit chrome to near feature-parity with that of the Qt chrome. In addition, this PR allows the list of user agent strings to be shared across different chromes.