### PR TITLE
Toolchain: Remove dependency on `gnu-sed` for Clang on Darwin

### DIFF
--- a/Toolchain/BuildClang.sh
+++ b/Toolchain/BuildClang.sh
@@ -36,7 +36,6 @@ elif [ "$SYSTEM_NAME" = "Darwin" ]; then
     MD5SUM="md5 -q"
     REALPATH="grealpath"  # GNU coreutils
     INSTALL="ginstall"    # GNU coreutils
-    SED="gsed"            # GNU sed
 fi
 
 NPROC=$(get_number_of_processing_units)


### PR DESCRIPTION
The Clang toolchain build fine without `gnu-sed` installed. It is required to build some ports, but not to build the toolchain. Removing the dependency precedes adding it as a [dependency](https://github.com/SerenityOS/serenity/pull/20888/files#r1314309614) IMO.

Closes: #20888 