### PR TITLE
LibWeb: Add basic Navigator send beacon support

### DIFF
--- a/Meta/gn/secondary/Userland/Libraries/LibWeb/HTML/BUILD.gn
+++ b/Meta/gn/secondary/Userland/Libraries/LibWeb/HTML/BUILD.gn
@@ -130,6 +130,7 @@ source_set("HTML") {
     "NavigationHistoryEntry.cpp",
     "NavigationTransition.cpp",
     "Navigator.cpp",
+    "NavigatorBeacon.cpp",
     "NavigatorID.cpp",
     "Numbers.cpp",
     "PageTransitionEvent.cpp",

--- a/Tests/LibWeb/Text/expected/HTML/navigator-beacon.txt
+++ b/Tests/LibWeb/Text/expected/HTML/navigator-beacon.txt
@@ -1,0 +1,3 @@
+1. true
+2. Exception: TypeError
+3. Exception: TypeError

--- a/Tests/LibWeb/Text/input/HTML/navigator-beacon.html
+++ b/Tests/LibWeb/Text/input/HTML/navigator-beacon.html
@@ -1,0 +1,23 @@
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        let testCounter = 1;
+        function testPart(part) {
+            try {
+                println(`${testCounter}. ${JSON.stringify(part())}`);
+            } catch (e) {
+                println(`${testCounter}. Exception: ${e.name}`);
+            }
+            testCounter++;
+        }
+
+        // 1. Send beacon
+        testPart(() => navigator.sendBeacon('https://example.com/') == true);
+
+        // 2. Send beacon with wrong URL
+        testPart(() => navigator.sendBeacon('dsfhdsaklfhdasklf'));
+
+        // 3. Send beacon with wrong scheme
+        testPart(() => navigator.sendBeacon('wss://example.com/'));
+    });
+</script>

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -362,6 +362,7 @@ set(SOURCES
     HTML/NavigationHistoryEntry.cpp
     HTML/NavigationTransition.cpp
     HTML/Navigator.cpp
+    HTML/NavigatorBeacon.cpp
     HTML/NavigatorID.cpp
     HTML/Numbers.cpp
     HTML/PageTransitionEvent.cpp

--- a/Userland/Libraries/LibWeb/HTML/Navigator.h
+++ b/Userland/Libraries/LibWeb/HTML/Navigator.h
@@ -8,6 +8,7 @@
 
 #include <LibWeb/Bindings/PlatformObject.h>
 #include <LibWeb/HTML/MimeTypeArray.h>
+#include <LibWeb/HTML/NavigatorBeacon.h>
 #include <LibWeb/HTML/NavigatorConcurrentHardware.h>
 #include <LibWeb/HTML/NavigatorID.h>
 #include <LibWeb/HTML/NavigatorLanguage.h>
@@ -17,6 +18,7 @@
 namespace Web::HTML {
 
 class Navigator : public Bindings::PlatformObject
+    , public NavigatorBeaconMixin
     , public NavigatorConcurrentHardwareMixin
     , public NavigatorIDMixin
     , public NavigatorLanguageMixin

--- a/Userland/Libraries/LibWeb/HTML/Navigator.idl
+++ b/Userland/Libraries/LibWeb/HTML/Navigator.idl
@@ -1,4 +1,5 @@
 #import <HTML/MimeTypeArray.idl>
+#import <HTML/NavigatorBeacon.idl>
 #import <HTML/NavigatorID.idl>
 #import <HTML/NavigatorLanguage.idl>
 #import <HTML/NavigatorOnLine.idl>
@@ -38,6 +39,7 @@ interface mixin NavigatorAutomationInformation {
     readonly attribute boolean webdriver;
 };
 
+Navigator includes NavigatorBeacon;
 Navigator includes NavigatorID;
 Navigator includes NavigatorLanguage;
 Navigator includes NavigatorOnLine;

--- a/Userland/Libraries/LibWeb/HTML/NavigatorBeacon.cpp
+++ b/Userland/Libraries/LibWeb/HTML/NavigatorBeacon.cpp
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2023, Bastiaan van der Plaat <bastiaan.v.d.plaat@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWeb/DOM/Document.h>
+#include <LibWeb/Fetch/Fetching/Fetching.h>
+#include <LibWeb/Fetch/Infrastructure/FetchAlgorithms.h>
+#include <LibWeb/HTML/Navigator.h>
+#include <LibWeb/HTML/NavigatorBeacon.h>
+#include <LibWeb/HTML/Scripting/Environments.h>
+#include <LibWeb/HTML/Window.h>
+
+namespace Web::HTML {
+
+// https://w3c.github.io/beacon/#sendbeacon-method
+WebIDL::ExceptionOr<bool> NavigatorBeaconMixin::send_beacon(String const& url, Optional<Fetch::BodyInit> const& data)
+{
+    auto& navigator = verify_cast<Navigator>(*this);
+    auto& realm = navigator.realm();
+    auto& vm = realm.vm();
+    auto& relevant_settings_object = HTML::relevant_settings_object(navigator);
+
+    // 1. Set base to this's relevant settings object's API base URL.
+    auto base_url = relevant_settings_object.api_base_url();
+
+    // 2. Set origin to this's relevant settings object's origin.
+    auto origin = relevant_settings_object.origin();
+
+    // 3. Set parsedUrl to the result of the URL parser steps with url and base. If the algorithm returns an error, or if parsedUrl's scheme is not "http" or "https", throw a "TypeError" exception and terminate these steps.
+    auto parsed_url = URLParser::basic_parse(url, base_url);
+    if (!parsed_url.is_valid())
+        return WebIDL::SimpleException { WebIDL::SimpleExceptionType::TypeError, MUST(String::formatted("Beacon URL {} is invalid.", url)) };
+    if (parsed_url.scheme() != "http" && parsed_url.scheme() != "https")
+        return WebIDL::SimpleException { WebIDL::SimpleExceptionType::TypeError, MUST(String::formatted("Beacon URL {} must be either http:// or https://.", url)) };
+
+    // 4. Let headerList be an empty list.
+    auto header_list = Fetch::Infrastructure::HeaderList::create(vm);
+
+    // 5. Let corsMode be "no-cors".
+    auto cors_mode = Fetch::Infrastructure::Request::Mode::NoCORS;
+
+    // 6. If data is not null:
+    Optional<JS::NonnullGCPtr<Fetch::Infrastructure::Body>> transmitted_data;
+    if (data.has_value()) {
+        // 6.1 Set transmittedData and contentType to the result of extracting data's byte stream with the keepalive flag set.
+        auto body_with_type = TRY(Fetch::extract_body(realm, data.value(), true));
+        transmitted_data = body_with_type.body;
+        auto& content_type = body_with_type.type;
+
+        // 6.2 If the amount of data that can be queued to be sent by keepalive enabled requests is exceeded by the size of transmittedData (as defined in HTTP-network-or-cache fetch), set the return value to false and terminate these steps.
+        // FIXME: We don't have a size limit in Fetching::fetch
+
+        // 6.3 If contentType is not null:
+        if (content_type.has_value()) {
+            // Set corsMode to "cors".
+            cors_mode = Fetch::Infrastructure::Request::Mode::CORS;
+
+            // If contentType value is a CORS-safelisted request-header value for the Content-Type header, set corsMode to "no-cors".
+            auto content_type_header = MUST(Fetch::Infrastructure::Header::from_string_pair("Content-Type"sv, content_type.value()));
+            if (Fetch::Infrastructure::is_cors_safelisted_request_header(content_type_header))
+                cors_mode = Fetch::Infrastructure::Request::Mode::NoCORS;
+
+            // Append a Content-Type header with value contentType to headerList.
+            MUST(header_list->append(content_type_header));
+        }
+    }
+
+    // FIXME: 7. Set the return value to true, return the sendBeacon() call, and continue to run the following steps in parallel:
+
+    // 7.1 Let req be a new request, initialized as follows:
+    auto req = Fetch::Infrastructure::Request::create(vm);
+    req->set_method(MUST(ByteBuffer::copy("POST"sv.bytes()))); // method: POST
+    req->set_client(&relevant_settings_object);                // client: this's relevant settings object
+    req->set_url_list({ parsed_url });                         // url: parsedUrl
+    req->set_header_list(header_list);                         // header list: headerList
+    req->set_origin(origin);                                   // origin: origin
+    req->set_keepalive(true);                                  // keepalive: true
+    if (transmitted_data.has_value())
+        req->set_body(transmitted_data.value());                                         // body: transmittedData
+    req->set_mode(cors_mode);                                                            // mode: corsMode
+    req->set_credentials_mode(Fetch::Infrastructure::Request::CredentialsMode::Include); // credentials mode: include
+    req->set_initiator_type(Fetch::Infrastructure::Request::InitiatorType::Beacon);      // initiator type: "beacon"
+
+    // 7.2 Fetch req.
+    (void)Fetch::Fetching::fetch(realm, req, Fetch::Infrastructure::FetchAlgorithms::create(vm, {}));
+
+    return true;
+}
+
+}

--- a/Userland/Libraries/LibWeb/HTML/NavigatorBeacon.h
+++ b/Userland/Libraries/LibWeb/HTML/NavigatorBeacon.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2023, Bastiaan van der Plaat <bastiaan.v.d.plaat@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibWeb/Fetch/BodyInit.h>
+#include <LibWeb/HTML/Navigator.h>
+#include <LibWeb/WebIDL/ExceptionOr.h>
+
+namespace Web::HTML {
+
+class NavigatorBeaconMixin {
+public:
+    WebIDL::ExceptionOr<bool> send_beacon(String const& url, Optional<Fetch::BodyInit> const& data = {});
+
+private:
+    virtual ~NavigatorBeaconMixin() = default;
+
+    friend class Navigator;
+};
+
+}

--- a/Userland/Libraries/LibWeb/HTML/NavigatorBeacon.idl
+++ b/Userland/Libraries/LibWeb/HTML/NavigatorBeacon.idl
@@ -1,0 +1,7 @@
+#import <Fetch/BodyInit.idl>
+
+// https://w3c.github.io/beacon/#sendbeacon-method
+// FIXME: This is a partial interface not an interface mixin
+interface mixin NavigatorBeacon {
+    boolean sendBeacon(USVString url, optional BodyInit? data = null);
+};


### PR DESCRIPTION
I have added basic support for the `Navigator` `sendBeacon` method. Until today I didn't now this method exists. But it is an entry on [html5test.com](https://html5test.com/), an older but still useful basic web test that gives your browser a score.

The API is mostly used by Trackers and funny enough my uBlock Origin extension in Firefox blocks all `sendBeacon` requests 😆. But we still need to implemented this web API. With content filtering we can disable maybe it in the future again.