### PR TITLE
LibWeb: Allow block level boxes to be floated and have clearance

### DIFF
--- a/Tests/LibWeb/Layout/expected/block-and-inline/block-level-floating-box-with-clearance.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/block-level-floating-box-with-clearance.txt
@@ -1,0 +1,34 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x976 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 600x960 children: not-inline
+      BlockContainer <div.normal> at (18,18) content-size 300x300 children: not-inline
+      BlockContainer <div#top> at (8,328) content-size 100x100 floating [BFC] children: inline
+        line 0 width: 26.640625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+          frag 0 from TextNode start: 0, length: 3, rect: [8,328 26.640625x17.46875]
+            "top"
+        TextNode <#text>
+      BlockContainer <div#left> at (8,428) content-size 100x100 floating [BFC] children: inline
+        line 0 width: 26.25, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+          frag 0 from TextNode start: 0, length: 4, rect: [8,428 26.25x17.46875]
+            "left"
+        TextNode <#text>
+      BlockContainer <div#right> at (108,428) content-size 100x100 floating [BFC] children: inline
+        line 0 width: 37.109375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+          frag 0 from TextNode start: 0, length: 5, rect: [108,428 37.109375x17.46875]
+            "right"
+        TextNode <#text>
+      BlockContainer <div.normal> at (18,338) content-size 300x300 children: not-inline
+      BlockContainer <div.normal> at (18,658) content-size 300x300 children: not-inline
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x976]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x976]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 600x960]
+      PaintableWithLines (BlockContainer<DIV>.normal) [8,8 320x320]
+      PaintableWithLines (BlockContainer<DIV>#top) [8,328 100x100]
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer<DIV>#left) [8,428 100x100]
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer<DIV>#right) [108,428 100x100]
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer<DIV>.normal) [8,328 320x320]
+      PaintableWithLines (BlockContainer<DIV>.normal) [8,648 320x320]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/floats-with-negative-percentage-margins.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/floats-with-negative-percentage-margins.txt
@@ -1,0 +1,28 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x208 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 600x0 children: not-inline
+      BlockContainer <div#top> at (8,8) content-size 100x100 floating [BFC] children: inline
+        line 0 width: 26.640625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+          frag 0 from TextNode start: 0, length: 3, rect: [8,8 26.640625x17.46875]
+            "top"
+        TextNode <#text>
+      BlockContainer <div#left> at (8,108) content-size 100x100 floating [BFC] children: inline
+        line 0 width: 26.25, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+          frag 0 from TextNode start: 0, length: 4, rect: [8,108 26.25x17.46875]
+            "left"
+        TextNode <#text>
+      BlockContainer <div#right> at (208,108) content-size 100x100 floating [BFC] children: inline
+        line 0 width: 37.109375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+          frag 0 from TextNode start: 0, length: 5, rect: [208,108 37.109375x17.46875]
+            "right"
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x208]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 600x0] overflow: [8,8 300x200]
+      PaintableWithLines (BlockContainer<DIV>#top) [8,8 100x100]
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer<DIV>#left) [8,108 100x100]
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer<DIV>#right) [208,108 100x100]
+        TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/input/block-and-inline/block-level-floating-box-with-clearance.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/block-level-floating-box-with-clearance.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html><style>
+* { outline: 1px solid black; }
+body { width: 600px; }
+div {
+    width: 100px;
+    height: 100px;
+}
+#top {
+    float: left;
+    background: green;
+}
+#left {
+    float: left;
+    background: pink;
+    clear: both;
+}
+#right {
+    float: left;
+    background: orange;
+}
+.normal {
+    width: 300px;
+    height: 300px;
+    background-color: gray;
+    border: 10px solid sandybrown;
+}
+</style><body><div class="normal"></div><div id="top">top</div><div id="left">left</div><div id="right">right</div><div class="normal"></div><div class="normal"></div>

--- a/Tests/LibWeb/Layout/input/block-and-inline/floats-with-negative-percentage-margins.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/floats-with-negative-percentage-margins.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html><style>
+* { outline: 1px solid black; }
+body { width: 600px; }
+div {
+    width: 100px;
+    height: 100px;
+    float: left;
+}
+#top {
+    background: green;
+}
+#left {
+    background: pink;
+    margin-right: -100%;
+    clear: both;
+}
+#right {
+    background: orange;
+    margin-left: 200px;
+    margin-right: -100%;
+}
+</style><body><div id="top">top</div><div id="left">left</div><div id="right">right

--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -962,7 +962,7 @@ void BlockFormattingContext::layout_floating_box(Box const& box, BlockContainer 
                 CSSPixels tentative_offset_from_edge = 0;
                 bool fits_next_to_preceding_float = false;
                 if (side == FloatSide::Left) {
-                    tentative_offset_from_edge = preceding_float.offset_from_edge + preceding_float_state.content_width() + preceding_float_state.margin_box_right() + box_state.margin_box_left();
+                    tentative_offset_from_edge = max(preceding_float.offset_from_edge + preceding_float_state.content_width() + preceding_float_state.margin_box_right(), 0) + box_state.margin_box_left();
                     if (available_space.width.is_definite()) {
                         fits_next_to_preceding_float = (tentative_offset_from_edge + box_state.content_width() + box_state.margin_box_right()) <= available_space.width.to_px_or_zero();
                     } else if (available_space.width.is_max_content() || available_space.width.is_indefinite()) {

--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -904,6 +904,7 @@ void BlockFormattingContext::layout_floating_box(Box const& box, BlockContainer 
     VERIFY(box.is_floating());
 
     auto& box_state = m_state.get_mutable(box);
+    auto const& computed_values = box.computed_values();
 
     resolve_vertical_box_model_metrics(box);
 
@@ -979,10 +980,18 @@ void BlockFormattingContext::layout_floating_box(Box const& box, BlockContainer 
                 break;
             }
 
-            if (!did_touch_preceding_float || !did_place_next_to_preceding_float) {
-                // One of two things happened:
+            auto has_clearance = false;
+            if (side == FloatSide::Left) {
+                has_clearance = computed_values.clear() == CSS::Clear::Left || computed_values.clear() == CSS::Clear::Both;
+            } else if (side == FloatSide::Right) {
+                has_clearance = computed_values.clear() == CSS::Clear::Right || computed_values.clear() == CSS::Clear::Both;
+            }
+
+            if (!did_touch_preceding_float || !did_place_next_to_preceding_float || has_clearance) {
+                // One of three things happened:
                 // - This box does not touch another floating box.
                 // - We ran out of horizontal space on this "float line", and need to break.
+                // - This box has clearance.
                 // Either way, we float this box all the way to the edge.
                 float_to_edge();
                 CSSPixels lowest_margin_edge = 0;


### PR DESCRIPTION
Before, we completely ignored clearance for block-level boxes if they were floated. This was incorrect because it is valid for a block-level box to be floated and still have clearance. However, unlike clearance on normal flow boxes, clearance on floating boxes does not affect the y-position of subsequent normal flow boxes. Instead, it pushes the box's position to the very beginning of an edge.