### PR TITLE
LibWeb: Add XMLHttpRequest Document response type

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/DocumentLoading.cpp
+++ b/Userland/Libraries/LibWeb/DOM/DocumentLoading.cpp
@@ -146,7 +146,7 @@ static bool build_gemini_document(DOM::Document& document, ByteBuffer const& dat
     return true;
 }
 
-static bool build_xml_document(DOM::Document& document, ByteBuffer const& data)
+bool build_xml_document(DOM::Document& document, ByteBuffer const& data)
 {
     auto encoding = HTML::run_encoding_sniffing_algorithm(document, data);
     auto decoder = TextCodec::decoder_for(encoding);

--- a/Userland/Libraries/LibWeb/DOM/DocumentLoading.h
+++ b/Userland/Libraries/LibWeb/DOM/DocumentLoading.h
@@ -11,6 +11,7 @@
 
 namespace Web {
 
+bool build_xml_document(DOM::Document& document, ByteBuffer const& data);
 bool parse_document(DOM::Document& document, ByteBuffer const& data);
 JS::GCPtr<DOM::Document> load_document(Optional<HTML::NavigationParams> navigation_params);
 JS::GCPtr<DOM::Document> create_document_for_inline_content(JS::GCPtr<HTML::Navigable> navigable, Optional<String> navigation_id, StringView content_html);

--- a/Userland/Libraries/LibWeb/MimeSniff/MimeType.cpp
+++ b/Userland/Libraries/LibWeb/MimeSniff/MimeType.cpp
@@ -238,6 +238,18 @@ ErrorOr<void> MimeType::set_parameter(String name, String value)
     return {};
 }
 
+// https://mimesniff.spec.whatwg.org/#xml-mime-type
+bool MimeType::is_xml() const
+{
+    return m_subtype.ends_with_bytes("+xml"sv) || essence().is_one_of("text/xml"sv, "application/xml"sv);
+}
+
+// https://mimesniff.spec.whatwg.org/#html-mime-type
+bool MimeType::is_html() const
+{
+    return essence().is_one_of("text/html"sv);
+}
+
 // https://mimesniff.spec.whatwg.org/#javascript-mime-type
 bool MimeType::is_javascript() const
 {

--- a/Userland/Libraries/LibWeb/MimeSniff/MimeType.h
+++ b/Userland/Libraries/LibWeb/MimeSniff/MimeType.h
@@ -25,6 +25,8 @@ public:
     String const& subtype() const { return m_subtype; }
     OrderedHashMap<String, String> const& parameters() const { return m_parameters; }
 
+    bool is_xml() const;
+    bool is_html() const;
     bool is_javascript() const;
 
     ErrorOr<void> set_parameter(String name, String value);

--- a/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.h
+++ b/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.h
@@ -48,6 +48,7 @@ public:
     Fetch::Infrastructure::Status status() const;
     WebIDL::ExceptionOr<String> status_text() const;
     WebIDL::ExceptionOr<String> response_text() const;
+    WebIDL::ExceptionOr<JS::GCPtr<DOM::Document>> response_xml();
     WebIDL::ExceptionOr<JS::Value> response();
     Bindings::XMLHttpRequestResponseType response_type() const { return m_response_type; }
 
@@ -86,6 +87,7 @@ private:
     ErrorOr<MimeSniff::MimeType> get_final_mime_type() const;
 
     String get_text_response() const;
+    void set_document_response();
 
     WebIDL::ExceptionOr<void> handle_response_end_of_body();
     WebIDL::ExceptionOr<void> handle_errors();

--- a/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.idl
+++ b/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.idl
@@ -29,6 +29,7 @@ interface XMLHttpRequest : XMLHttpRequestEventTarget {
     readonly attribute unsigned short status;
     readonly attribute ByteString statusText;
     readonly attribute DOMString responseText;
+    readonly attribute Document? responseXML;
     readonly attribute any response;
     attribute XMLHttpRequestResponseType responseType;
     attribute unsigned long timeout;


### PR DESCRIPTION
I have added the XMLHttpRequest Document response type. XMLHttpRequest is quite a large codebase so maybe I did something quite wrong, looking forward to feedback :^)

I could not figure out howto cast a `JS::Value` in `XMLHttpRequest::response_xml()` to `JS::GCPtr<DOM::Document>`. So right now I put that `GCPtr` in `m_response_document`, this works but is maybe not what we want.