### PR TITLE
Revert "AK: Refill a BufferedStream when it has less than the requested size"

### DIFF
--- a/AK/BufferedStream.h
+++ b/AK/BufferedStream.h
@@ -55,7 +55,7 @@ public:
             return buffer;
 
         // Fill the internal buffer if it has run dry.
-        if (m_buffer.used_space() < buffer.size())
+        if (m_buffer.used_space() == 0)
             TRY(populate_read_buffer());
 
         // Let's try to take all we can from the buffer first.


### PR DESCRIPTION
This reverts commit 13573a6c4bc0311f91371fd4563bc930d4811682.

Some clients of `BufferedStream` expect a non-blocking read by `read_some` which the commit above made impossible by potentially performing a blocking read. For example, the following command hangs:

    pro http://ipecho.net/plain

This is caused by the HTTP job expecting to read the body of the response which is included in the active buffer, but since the buffered data size is less than the buffer passed into `read_some`, another blocking read is performed before anything is returned.

By reverting this commit, all tests still pass and `pro` no longer hangs. Note that because of another bug related to `stdout` / `stderr` mixing and the absence of a line ending, there is no output to the command above except a progress update.

CC @trflynn89 