### PR TITLE
LibJS: Make line-and-column resolution fast for large minified JS

### DIFF
--- a/Userland/Libraries/LibJS/Position.h
+++ b/Userland/Libraries/LibJS/Position.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2023, Andreas Kling <kling@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+namespace JS {
+
+struct Position {
+    size_t line { 0 };
+    size_t column { 0 };
+    size_t offset { 0 };
+};
+
+}

--- a/Userland/Libraries/LibJS/SourceCode.h
+++ b/Userland/Libraries/LibJS/SourceCode.h
@@ -9,6 +9,7 @@
 #include <AK/String.h>
 #include <AK/Vector.h>
 #include <LibJS/Forward.h>
+#include <LibJS/Position.h>
 
 namespace JS {
 
@@ -24,12 +25,14 @@ public:
 private:
     SourceCode(String filename, String code);
 
-    void compute_line_break_offsets() const;
-
     String m_filename;
     String m_code;
 
-    Optional<Vector<size_t>> mutable m_line_break_offsets;
+    // For fast mapping of offsets to line/column numbers, we build a list of
+    // starting points (with byte offsets into the source string) and which
+    // line:column they map to. This can then be binary-searched.
+    void fill_position_cache() const;
+    Vector<Position> mutable m_cached_positions;
 };
 
 }

--- a/Userland/Libraries/LibJS/SourceRange.h
+++ b/Userland/Libraries/LibJS/SourceRange.h
@@ -10,15 +10,10 @@
 #include <AK/NonnullRefPtr.h>
 #include <AK/StringView.h>
 #include <AK/Types.h>
+#include <LibJS/Position.h>
 #include <LibJS/SourceCode.h>
 
 namespace JS {
-
-struct Position {
-    size_t line { 0 };
-    size_t column { 0 };
-    size_t offset { 0 };
-};
 
 struct SourceRange {
     [[nodiscard]] bool contains(Position const& position) const { return position.offset <= end.offset && position.offset >= start.offset; }


### PR DESCRIPTION
Instead of caching start-of-line offsets, we now cache byte offsets at regular intervals. This fixes an issue where we had terrible performance on large minified JS, since that often means one very, VERY long line (with no line endings to cache).

My machine was spending ~35ms per stack frame when throwing errors on some heavy minified websites, and after this patch, we now spend <1ms per stack frame.