### PR TITLE
less: Add `-N` option to show line numbers

### DIFF
--- a/Base/usr/share/man/man1/less.md
+++ b/Base/usr/share/man/man1/less.md
@@ -5,8 +5,8 @@
 ## Synopsis
 
 ```**sh
-$ cat file | less [-PXem]
-$ less [-PXem] [file]
+$ cat file | less [-PXNem]
+$ less [-PXNem] [file]
 $ cat file | more
 $ more [file]
 ```
@@ -21,6 +21,7 @@ but largely incompatible with
 
 * `-P`, `--prompt`: Set the prompt format string. See [Prompts](#prompts) for more details.
 * `-X`, `--no-init`: Don't switch to the xterm alternate buffer on startup.
+* `-N`, `--line-numbers`: Show line numbers before printed lines.
 * `-e`, `--quit-at-eof`: Immediately exit less when the last line of the document is reached.
 * `-m`, `--emulate-more`: Apply `-Xe`, set the prompt to `--More--`, and disable
   scrollback. This option is automatically applied when `less` is executed as `more`


### PR DESCRIPTION
This PR continues work started in #20121 to add the `-N` option to `less`. This option displays the line number before each line of text.

I've included @supercomputer7 as co-author, as this PR is based off of his work.

Demo:

https://github.com/SerenityOS/serenity/assets/2817754/6f9b7180-360a-4bfa-8b68-c93156120af1
