### PR TITLE
LibWeb: Fix setTimeout() when there's no active script

### DIFF
--- a/Tests/LibWeb/Text/expected/set-timeout-with-no-active-script.txt
+++ b/Tests/LibWeb/Text/expected/set-timeout-with-no-active-script.txt
@@ -1,0 +1,1 @@
+didn't crash!

--- a/Tests/LibWeb/Text/input/set-timeout-with-no-active-script.html
+++ b/Tests/LibWeb/Text/input/set-timeout-with-no-active-script.html
@@ -1,0 +1,9 @@
+<script src="include.js"></script>
+<script>
+    test(() => {
+        queueMicrotask(setTimeout.bind(this, () => {}));
+        queueMicrotask(() => {
+            println("didn't crash!");
+        });
+    });
+</script>

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Fetching.h
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Fetching.h
@@ -26,7 +26,7 @@ struct ScriptFetchOptions {
     String integrity_metadata {};
 
     // https://html.spec.whatwg.org/multipage/webappapis.html#concept-script-fetch-options-parser
-    Optional<Fetch::Infrastructure::Request::ParserMetadata> parser_metadata;
+    Fetch::Infrastructure::Request::ParserMetadata parser_metadata { Fetch::Infrastructure::Request::ParserMetadata::NotParserInserted };
 
     // https://html.spec.whatwg.org/multipage/webappapis.html#concept-script-fetch-options-credentials
     Fetch::Infrastructure::Request::CredentialsMode credentials_mode { Fetch::Infrastructure::Request::CredentialsMode::SameOrigin };

--- a/Userland/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.h
+++ b/Userland/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.h
@@ -69,7 +69,7 @@ private:
         Yes,
         No,
     };
-    i32 run_timer_initialization_steps(TimerHandler handler, i32 timeout, JS::MarkedVector<JS::Value> arguments, Repeat repeat, Optional<i32> previous_id = {}, Optional<AK::URL> base_url = {});
+    i32 run_timer_initialization_steps(TimerHandler handler, i32 timeout, JS::MarkedVector<JS::Value> arguments, Repeat repeat, Optional<i32> previous_id = {});
 
     IDAllocator m_timer_id_allocator;
     HashMap<int, JS::NonnullGCPtr<Timer>> m_timers;


### PR DESCRIPTION
Implements https://github.com/whatwg/html/pull/9712
Fixes https://github.com/SerenityOS/serenity/issues/20970

-----

LibWeb: Default ScriptFetchOptions parser metadata to NotParserInserted

See: https://html.spec.whatwg.org/multipage/webappapis.html#default-classic-script-fetch-options
