### PR TITLE
LibWeb: Add {de}serialization steps for TypedArrayBuffers and DataViews

### DIFF
--- a/Tests/LibWeb/Text/expected/HTML/StructuredClone-array-buffer-views.txt
+++ b/Tests/LibWeb/Text/expected/HTML/StructuredClone-array-buffer-views.txt
@@ -1,0 +1,12 @@
+Uint8Array 30,40,50,60
+Uint8ClampedArray 30,40,50,60
+Uint16Array 30,40,50,60
+Uint32Array 30,40,50,60
+Int8Array 30,40,50,60
+Int16Array 30,40,50,60
+Int32Array 30,40,50,60
+Float32Array 30,40,50,60
+Float64Array 30,40,50,60
+BigUint64Array 30,40,50,60
+BigInt64Array 30,40,50,60
+DataView [object DataView]

--- a/Tests/LibWeb/Text/input/HTML/StructuredClone-array-buffer-views.html
+++ b/Tests/LibWeb/Text/input/HTML/StructuredClone-array-buffer-views.html
@@ -1,0 +1,51 @@
+<script src="../include.js"></script>
+<script>
+    const TYPED_ARRAYS = [
+        Uint8Array,
+        Uint8ClampedArray,
+        Uint16Array,
+        Uint32Array,
+        Int8Array,
+        Int16Array,
+        Int32Array,
+        Float32Array,
+        Float64Array,
+    ];
+
+    const BIGINT_TYPED_ARRAYS = [BigUint64Array, BigInt64Array];
+
+    test(() => {
+        TYPED_ARRAYS.forEach(T => {
+            const a = new T([30, 40, 50, 60]);
+            let b = structuredClone(a)
+            if (!a.every((value, index) => value === b[index]))
+                println("FAIL")
+            println(`${b[Symbol.toStringTag]} ${b}`)
+        });
+
+        BIGINT_TYPED_ARRAYS.forEach(T => {
+            const a = new T([30n, 40n, 50n, 60n]);
+            let b = structuredClone(a)
+            if (!a.every((value, index) => value === b[index]))
+                println("FAIL")
+
+            println(`${b[Symbol.toStringTag]} ${b}`)
+        });
+
+        // Test DataView clone
+        let a = new ArrayBuffer(64);
+        for(let i = 0; i < a.byteLength; ++i) {
+            a[i] = i;
+        }
+        let view = new DataView(a);
+        let view2 = structuredClone(view);
+        if (view.buffer === view2.buffer)
+            println("FAIL: Buffer not deep copied");
+
+        for (let i = 0; i < view.byteLength; ++i) {
+            if (!view[i] === view2[i])
+                println("FAIL: Data not copied")
+        }
+        println(`${view2[Symbol.toStringTag]} ${view2}`)
+    });
+</script>

--- a/Userland/Libraries/LibWeb/HTML/StructuredSerialize.h
+++ b/Userland/Libraries/LibWeb/HTML/StructuredSerialize.h
@@ -29,7 +29,7 @@ using SerializationMemory = HashMap<JS::Handle<JS::Value>, SerializationRange>;
 
 WebIDL::ExceptionOr<SerializationRecord> structured_serialize(JS::VM& vm, JS::Value);
 WebIDL::ExceptionOr<SerializationRecord> structured_serialize_for_storage(JS::VM& vm, JS::Value);
-WebIDL::ExceptionOr<SerializationRecord> structured_serialize_internal(JS::VM& vm, JS::Value, bool for_storage, Optional<SerializationMemory>);
+WebIDL::ExceptionOr<SerializationRecord> structured_serialize_internal(JS::VM& vm, JS::Value, bool for_storage, SerializationMemory&);
 
 WebIDL::ExceptionOr<JS::Value> structured_deserialize(JS::VM& vm, SerializationRecord const& serialized, JS::Realm& target_realm, Optional<SerializationMemory>);
 


### PR DESCRIPTION
Also lay the groundwork for the object property, map, etc serializations by making recursive calls to serialize/deseriualize not terrible.