### PR TITLE
GameOfLife: Ensure BoardWidget can always contain the board

### DIFF
--- a/Userland/Games/GameOfLife/BoardWidget.cpp
+++ b/Userland/Games/GameOfLife/BoardWidget.cpp
@@ -52,6 +52,7 @@ void BoardWidget::resize_board(size_t rows, size_t columns)
         return;
     m_board->resize(rows, columns);
     m_last_cell_toggled = { rows, columns };
+    set_min_size(columns, rows);
 }
 
 void BoardWidget::set_running_timer_interval(int interval)

--- a/Userland/Games/GameOfLife/main.cpp
+++ b/Userland/Games/GameOfLife/main.cpp
@@ -63,6 +63,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     board_widget_container.set_layout<GUI::VerticalBoxLayout>(GUI::Margins {}, 0);
     auto board_widget = TRY(board_widget_container.try_add<BoardWidget>(board_rows, board_columns));
     board_widget->randomize_cells();
+    board_widget->set_min_size(board_columns, board_rows);
 
     auto& statusbar = *main_widget->find_descendant_of_type_named<GUI::Statusbar>("statusbar");
     statusbar.set_text(click_tip);


### PR DESCRIPTION
Previously, when there were more rows or columns than the BoardWidget could contain, nothing was displayed. The BoardWidget minimum size is now set whenever the number of rows or columns changes.

Video:

https://github.com/SerenityOS/serenity/assets/2817754/826ca9a0-e669-40e1-8111-23c4e437151c