### PR TITLE
LibWeb: Implement the :open and :closed pseudo-classes

### DIFF
--- a/Tests/LibWeb/Ref/css-open-closed-selectors.html
+++ b/Tests/LibWeb/Ref/css-open-closed-selectors.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<link rel="match" href="reference/css-open-closed-selectors-ref.html" />
+<style>
+:open {
+    color: green;
+}
+:closed {
+    color: red;
+}
+</style>
+<details open>
+    <summary>Hi</summary>
+    Well hello friends!
+</details>
+<details>
+    <summary>Hi</summary>
+    Well hello friends!
+</details>

--- a/Tests/LibWeb/Ref/reference/css-open-closed-selectors-ref.html
+++ b/Tests/LibWeb/Ref/reference/css-open-closed-selectors-ref.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<style>
+    .open {
+        color: green;
+    }
+    .closed {
+        color: red;
+    }
+</style>
+<details open class="open">
+    <summary>Hi</summary>
+    Well hello friends!
+</details>
+<details class="closed">
+    <summary>Hi</summary>
+    Well hello friends!
+</details>

--- a/Userland/Libraries/LibWeb/CSS/PseudoClasses.json
+++ b/Userland/Libraries/LibWeb/CSS/PseudoClasses.json
@@ -11,6 +11,9 @@
   "checked": {
     "argument": ""
   },
+  "closed": {
+    "argument": ""
+  },
   "defined": {
     "argument": ""
   },
@@ -90,6 +93,9 @@
     "argument": ""
   },
   "only-of-type": {
+    "argument": ""
+  },
+  "open": {
     "argument": ""
   },
   "paused": {

--- a/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
@@ -175,4 +175,13 @@ Optional<ARIA::Role> HTMLSelectElement::default_role() const
     return ARIA::Role::combobox;
 }
 
+void HTMLSelectElement::set_is_open(bool open)
+{
+    if (open == m_is_open)
+        return;
+
+    m_is_open = open;
+    invalidate_style();
+}
+
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.h
@@ -33,6 +33,9 @@ public:
     int selected_index() const;
     void set_selected_index(int);
 
+    bool is_open() const { return m_is_open; }
+    void set_is_open(bool);
+
     Vector<JS::Handle<HTMLOptionElement>> list_of_options() const;
 
     // ^EventTarget
@@ -72,6 +75,7 @@ private:
     virtual i32 default_tab_index_value() const override;
 
     JS::GCPtr<HTMLOptionsCollection> m_options;
+    bool m_is_open { false };
 };
 
 }


### PR DESCRIPTION
![image](https://github.com/SerenityOS/serenity/assets/222642/f4df69d4-1b97-498b-926b-771db00185fc)

I may have been waiting in anticipation of the `<details>` PR getting merged just so I could add more pseudo-classes. :sweat_smile: 

`<details>` works. `<dialog>` and `<select>` should also work with these once they actually get implemented - all the selector-side stuff is implemented.