### PR TITLE
Ladybird: Implement an Inspector window for the AppKit chrome

### DIFF
--- a/Ladybird/AppKit/Application/ApplicationDelegate.mm
+++ b/Ladybird/AppKit/Application/ApplicationDelegate.mm
@@ -347,6 +347,9 @@
     [submenu addItem:[[NSMenuItem alloc] initWithTitle:@"Open Console"
                                                 action:@selector(openConsole:)
                                          keyEquivalent:@"J"]];
+    [submenu addItem:[[NSMenuItem alloc] initWithTitle:@"Open Inspector"
+                                                action:@selector(openInspector:)
+                                         keyEquivalent:@"I"]];
 
     [menu setSubmenu:submenu];
     return menu;

--- a/Ladybird/AppKit/UI/Inspector.h
+++ b/Ladybird/AppKit/UI/Inspector.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2023, Tim Flynn <trflynn89@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#import <System/Cocoa.h>
+
+@class LadybirdWebView;
+@class Tab;
+
+@interface Inspector : NSWindow
+
+- (instancetype)init:(Tab*)tab;
+
+- (void)inspect;
+- (void)reset;
+
+@end

--- a/Ladybird/AppKit/UI/Inspector.h
+++ b/Ladybird/AppKit/UI/Inspector.h
@@ -16,6 +16,7 @@
 - (instancetype)init:(Tab*)tab;
 
 - (void)inspect;
+- (void)inspectHoveredElement;
 - (void)reset;
 
 @end

--- a/Ladybird/AppKit/UI/Inspector.mm
+++ b/Ladybird/AppKit/UI/Inspector.mm
@@ -1,0 +1,257 @@
+/*
+ * Copyright (c) 2023, Tim Flynn <trflynn89@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/DeprecatedString.h>
+#include <LibWebView/ViewImplementation.h>
+
+#import <UI/Inspector.h>
+#import <UI/LadybirdWebView.h>
+#import <UI/Tab.h>
+#import <Utilities/Conversions.h>
+#import <Utilities/NSString+Ladybird.h>
+
+#if !__has_feature(objc_arc)
+#    error "This project requires ARC"
+#endif
+
+static constexpr CGFloat const WINDOW_WIDTH = 600;
+static constexpr CGFloat const WINDOW_HEIGHT = 800;
+
+@interface Inspector () <NSOutlineViewDataSource, NSOutlineViewDelegate>
+
+@property (nonatomic, strong) Tab* tab;
+
+@property (nonatomic, strong) NSOutlineView* dom_tree_outline_view;
+@property (nonatomic, strong) NSDictionary* dom_tree;
+
+@end
+
+@implementation Inspector
+
+@synthesize tab = _tab;
+
+- (instancetype)init:(Tab*)tab
+{
+    auto tab_rect = [tab frame];
+    auto position_x = tab_rect.origin.x + (tab_rect.size.width - WINDOW_WIDTH) / 2;
+    auto position_y = tab_rect.origin.y + (tab_rect.size.height - WINDOW_HEIGHT) / 2;
+
+    auto window_rect = NSMakeRect(position_x, position_y, WINDOW_WIDTH, WINDOW_HEIGHT);
+    auto style_mask = NSWindowStyleMaskTitled | NSWindowStyleMaskClosable | NSWindowStyleMaskMiniaturizable | NSWindowStyleMaskResizable;
+
+    self = [super initWithContentRect:window_rect
+                            styleMask:style_mask
+                              backing:NSBackingStoreBuffered
+                                defer:NO];
+
+    if (self) {
+        self.tab = tab;
+
+        auto* split_view = [[NSSplitView alloc] initWithFrame:[self frame]];
+        [split_view setDividerStyle:NSSplitViewDividerStylePaneSplitter];
+
+        auto* top_tab_view = [[NSTabView alloc] init];
+        [split_view addSubview:top_tab_view];
+
+        [self initializeDOMTreeTab:top_tab_view];
+        [self reset];
+
+        auto& web_view = [[self.tab web_view] view];
+        __weak Inspector* weak_self = self;
+
+        web_view.on_received_dom_tree = [weak_self](auto const& dom_tree) {
+            Inspector* strong_self = weak_self;
+            if (strong_self == nil) {
+                return;
+            }
+
+            strong_self.dom_tree = Ladybird::deserialize_json_to_dictionary(dom_tree);
+
+            if (strong_self.dom_tree) {
+                [strong_self.dom_tree_outline_view reloadItem:nil reloadChildren:YES];
+                [strong_self.dom_tree_outline_view sizeToFit];
+            } else {
+                strong_self.dom_tree = @{};
+            }
+        };
+
+        [self setContentView:split_view];
+        [self setTitle:@"Inspector"];
+        [self setIsVisible:YES];
+
+        auto split_view_height = [split_view frame].size.height;
+        [split_view setPosition:(split_view_height * 0.6f) ofDividerAtIndex:0];
+    }
+
+    return self;
+}
+
+- (void)dealloc
+{
+    auto& web_view = [[self.tab web_view] view];
+    web_view.on_received_dom_tree = nullptr;
+}
+
+#pragma mark - Public methods
+
+- (void)inspect
+{
+    auto& web_view = [[self.tab web_view] view];
+    web_view.inspect_dom_tree();
+}
+
+- (void)reset
+{
+    self.dom_tree = @{};
+    [self.dom_tree_outline_view reloadItem:nil reloadChildren:YES];
+    [self.dom_tree_outline_view sizeToFit];
+}
+
+#pragma mark - Private methods
+
+- (void)initializeDOMTreeTab:(NSTabView*)tab_view
+{
+    auto* tab = [[NSTabViewItem alloc] initWithIdentifier:@"DOM Tree"];
+    [tab setLabel:@"DOM"];
+
+    auto* scroll_view = [[NSScrollView alloc] init];
+    [scroll_view setHasVerticalScroller:YES];
+    [scroll_view setHasHorizontalScroller:YES];
+    [scroll_view setLineScroll:24];
+    [tab setView:scroll_view];
+
+    self.dom_tree_outline_view = [[NSOutlineView alloc] initWithFrame:[tab_view frame]];
+    [self.dom_tree_outline_view setDoubleAction:@selector(onTreeDoubleClick:)];
+    [self.dom_tree_outline_view setDataSource:self];
+    [self.dom_tree_outline_view setDelegate:self];
+    [self.dom_tree_outline_view setHeaderView:nil];
+    [scroll_view setDocumentView:self.dom_tree_outline_view];
+
+    auto* column = [[NSTableColumn alloc] initWithIdentifier:@"DOM Tree"];
+    [self.dom_tree_outline_view addTableColumn:column];
+
+    [tab_view addTabViewItem:tab];
+}
+
+- (void)onTreeDoubleClick:(id)sender
+{
+    NSOutlineView* outline_view = sender;
+    id item = [outline_view itemAtRow:[outline_view clickedRow]];
+
+    if ([outline_view isItemExpanded:item]) {
+        [outline_view collapseItem:item];
+    } else {
+        [outline_view expandItem:item];
+    }
+}
+
+#pragma mark - NSOutlineViewDataSource
+
+- (id)outlineView:(NSOutlineView*)view
+            child:(NSInteger)index
+           ofItem:(id)item
+{
+    if (item == nil) {
+        item = self.dom_tree;
+    }
+
+    NSArray* children = [item objectForKey:@"children"];
+    return [children objectAtIndex:index];
+}
+
+- (NSInteger)outlineView:(NSOutlineView*)view
+    numberOfChildrenOfItem:(id)item
+{
+    if (item == nil) {
+        item = self.dom_tree;
+    }
+
+    NSArray* children = [item objectForKey:@"children"];
+    return static_cast<NSInteger>(children.count);
+}
+
+- (BOOL)outlineView:(NSOutlineView*)view
+    isItemExpandable:(id)item
+{
+    NSArray* children = [item objectForKey:@"children"];
+    return children.count != 0;
+}
+
+- (NSView*)outlineView:(NSOutlineView*)outline_view
+    viewForTableColumn:(NSTableColumn*)table_column
+                  item:(id)item
+{
+    auto* font = [NSFont monospacedSystemFontOfSize:12.0 weight:NSFontWeightRegular];
+    auto* bold_font = [NSFont monospacedSystemFontOfSize:12.0 weight:NSFontWeightBold];
+
+    auto attributed_text = [&](NSString* text, NSColor* color = nil, BOOL bold = false) {
+        auto* attributes = [[NSMutableDictionary alloc] initWithDictionary:@{
+            NSFontAttributeName : bold ? bold_font : font,
+        }];
+
+        if (color != nil) {
+            [attributes setObject:color forKey:NSForegroundColorAttributeName];
+        }
+
+        return [[NSMutableAttributedString alloc] initWithString:text attributes:attributes];
+    };
+
+    NSString* type = [item objectForKey:@"type"];
+    NSMutableAttributedString* text = nil;
+
+    if ([type isEqualToString:@"text"]) {
+        text = attributed_text([[item objectForKey:@"text"] stringByCollapsingConsecutiveWhitespace]);
+    } else if ([type isEqualToString:@"comment"]) {
+        auto* comment = [NSString stringWithFormat:@"<!--%@-->", [item objectForKey:@"data"]];
+        text = attributed_text(comment, [NSColor systemGreenColor]);
+    } else if ([type isEqualToString:@"shadow-root"]) {
+        auto* shadow = [NSString stringWithFormat:@"%@ (%@)", [item objectForKey:@"name"], [item objectForKey:@"mode"]];
+        text = attributed_text(shadow, [NSColor systemGrayColor]);
+    } else if ([type isEqualToString:@"element"]) {
+        text = attributed_text(@"<");
+
+        auto* element = attributed_text(
+            [[item objectForKey:@"name"] lowercaseString],
+            [NSColor systemPinkColor],
+            YES);
+        [text appendAttributedString:element];
+
+        NSDictionary* attributes = [item objectForKey:@"attributes"];
+
+        [attributes enumerateKeysAndObjectsUsingBlock:^(id name, id value, BOOL*) {
+            [text appendAttributedString:attributed_text(@" ")];
+
+            name = attributed_text(name, [NSColor systemOrangeColor]);
+            [text appendAttributedString:name];
+
+            [text appendAttributedString:attributed_text(@"=")];
+
+            value = [NSString stringWithFormat:@"\"%@\"", [value stringByCollapsingConsecutiveWhitespace]];
+            value = attributed_text(value, [NSColor systemCyanColor]);
+            [text appendAttributedString:value];
+        }];
+
+        [text appendAttributedString:attributed_text(@">")];
+    } else {
+        text = attributed_text([item objectForKey:@"name"], [NSColor systemGrayColor]);
+    }
+
+    auto* view = [NSTextField labelWithAttributedString:text];
+    view.identifier = [NSString stringWithFormat:@"%@", [item objectForKey:@"id"]];
+
+    return view;
+}
+
+#pragma mark - NSOutlineViewDelegate
+
+- (BOOL)outlineView:(NSOutlineView*)outline_view
+    shouldEditTableColumn:(NSTableColumn*)table_column
+                     item:(id)item
+{
+    return NO;
+}
+
+@end

--- a/Ladybird/AppKit/UI/Inspector.mm
+++ b/Ladybird/AppKit/UI/Inspector.mm
@@ -5,6 +5,7 @@
  */
 
 #include <AK/DeprecatedString.h>
+#include <LibWeb/CSS/Selector.h>
 #include <LibWebView/ViewImplementation.h>
 
 #import <UI/Inspector.h>
@@ -20,12 +21,37 @@
 static constexpr CGFloat const WINDOW_WIDTH = 600;
 static constexpr CGFloat const WINDOW_HEIGHT = 800;
 
-@interface Inspector () <NSOutlineViewDataSource, NSOutlineViewDelegate>
+static NSString* const CSS_PROPERTY_COLUMN = @"Property";
+static NSString* const CSS_VALUE_COLUMN = @"Value";
+
+struct Selection {
+    bool operator==(Selection const& other) const = default;
+
+    i32 dom_node_id { 0 };
+    Optional<Web::CSS::Selector::PseudoElement> pseudo_element {};
+};
+
+@interface Inspector () <NSOutlineViewDataSource, NSOutlineViewDelegate, NSTableViewDataSource>
+{
+    Selection m_selection;
+}
 
 @property (nonatomic, strong) Tab* tab;
 
 @property (nonatomic, strong) NSOutlineView* dom_tree_outline_view;
 @property (nonatomic, strong) NSDictionary* dom_tree;
+
+@property (nonatomic, strong) NSTableView* computed_style_table_view;
+@property (nonatomic, strong) NSDictionary* computed_style;
+@property (nonatomic, strong) NSArray* computed_style_keys;
+
+@property (nonatomic, strong) NSTableView* resolved_style_table_view;
+@property (nonatomic, strong) NSDictionary* resolved_style;
+@property (nonatomic, strong) NSArray* resolved_style_keys;
+
+@property (nonatomic, strong) NSTableView* variables_table_view;
+@property (nonatomic, strong) NSDictionary* variables;
+@property (nonatomic, strong) NSArray* variables_keys;
 
 @end
 
@@ -56,7 +82,11 @@ static constexpr CGFloat const WINDOW_HEIGHT = 800;
         auto* top_tab_view = [[NSTabView alloc] init];
         [split_view addSubview:top_tab_view];
 
+        auto* bottom_tab_view = [[NSTabView alloc] init];
+        [split_view addSubview:bottom_tab_view];
+
         [self initializeDOMTreeTab:top_tab_view];
+        [self initializeCSSTables:bottom_tab_view];
         [self reset];
 
         auto& web_view = [[self.tab web_view] view];
@@ -93,6 +123,7 @@ static constexpr CGFloat const WINDOW_HEIGHT = 800;
 {
     auto& web_view = [[self.tab web_view] view];
     web_view.on_received_dom_tree = nullptr;
+    web_view.clear_inspected_dom_node();
 }
 
 #pragma mark - Public methods
@@ -105,9 +136,23 @@ static constexpr CGFloat const WINDOW_HEIGHT = 800;
 
 - (void)reset
 {
+    m_selection = {};
+
     self.dom_tree = @{};
     [self.dom_tree_outline_view reloadItem:nil reloadChildren:YES];
     [self.dom_tree_outline_view sizeToFit];
+
+    self.computed_style = @{};
+    self.computed_style_keys = @[];
+    [self.computed_style_table_view reloadData];
+
+    self.resolved_style = @{};
+    self.resolved_style_keys = @[];
+    [self.resolved_style_table_view reloadData];
+
+    self.variables = @{};
+    self.variables_keys = @[];
+    [self.variables_table_view reloadData];
 }
 
 #pragma mark - Private methods
@@ -136,6 +181,42 @@ static constexpr CGFloat const WINDOW_HEIGHT = 800;
     [tab_view addTabViewItem:tab];
 }
 
+- (NSTableView*)createCSSTable:(NSTabView*)tab_view identifier:(NSString*)identifier
+{
+    auto* tab = [[NSTabViewItem alloc] initWithIdentifier:identifier];
+    [tab setLabel:identifier];
+
+    auto* scroll_view = [[NSScrollView alloc] init];
+    [scroll_view setHasVerticalScroller:YES];
+    [scroll_view setHasHorizontalScroller:YES];
+    [scroll_view setLineScroll:24];
+    [tab setView:scroll_view];
+
+    auto* table_view = [[NSTableView alloc] initWithFrame:[tab_view frame]];
+    [table_view setDataSource:self];
+    [table_view setColumnAutoresizingStyle:NSTableViewUniformColumnAutoresizingStyle];
+    [scroll_view setDocumentView:table_view];
+
+    auto* property_column = [[NSTableColumn alloc] initWithIdentifier:CSS_PROPERTY_COLUMN];
+    [property_column setTitle:CSS_PROPERTY_COLUMN];
+    [table_view addTableColumn:property_column];
+
+    auto* value_column = [[NSTableColumn alloc] initWithIdentifier:CSS_VALUE_COLUMN];
+    [value_column setTitle:CSS_VALUE_COLUMN];
+    [table_view addTableColumn:value_column];
+
+    [tab_view addTabViewItem:tab];
+
+    return table_view;
+}
+
+- (void)initializeCSSTables:(NSTabView*)tab_view
+{
+    self.computed_style_table_view = [self createCSSTable:tab_view identifier:@"Computed Style"];
+    self.resolved_style_table_view = [self createCSSTable:tab_view identifier:@"Resolved Style"];
+    self.variables_table_view = [self createCSSTable:tab_view identifier:@"Variables"];
+}
+
 - (void)onTreeDoubleClick:(id)sender
 {
     NSOutlineView* outline_view = sender;
@@ -146,6 +227,45 @@ static constexpr CGFloat const WINDOW_HEIGHT = 800;
     } else {
         [outline_view expandItem:item];
     }
+}
+
+- (void)setSelection:(Selection)selection
+{
+    if (selection == m_selection)
+        return;
+
+    m_selection = move(selection);
+
+    auto deserialize_json = [](auto const& json) {
+        auto* dictionary = Ladybird::deserialize_json_to_dictionary(json);
+        if (!dictionary) {
+            return @{};
+        }
+
+        return dictionary;
+    };
+
+    auto& web_view = [[self.tab web_view] view];
+    auto properties = web_view.inspect_dom_node(m_selection.dom_node_id, m_selection.pseudo_element);
+
+    if (!properties.is_error()) {
+        self.computed_style = deserialize_json(properties.value().computed_style_json);
+        self.resolved_style = deserialize_json(properties.value().resolved_style_json);
+        self.variables = deserialize_json(properties.value().custom_properties_json);
+    } else {
+        self.computed_style = @{};
+        self.resolved_style = @{};
+        self.variables = @{};
+    }
+
+    self.computed_style_keys = [[self.computed_style allKeys] sortedArrayUsingSelector:@selector(compare:)];
+    [self.computed_style_table_view reloadData];
+
+    self.resolved_style_keys = [[self.resolved_style allKeys] sortedArrayUsingSelector:@selector(compare:)];
+    [self.resolved_style_table_view reloadData];
+
+    self.variables_keys = [[self.variables allKeys] sortedArrayUsingSelector:@selector(compare:)];
+    [self.variables_table_view reloadData];
 }
 
 #pragma mark - NSOutlineViewDataSource
@@ -252,6 +372,70 @@ static constexpr CGFloat const WINDOW_HEIGHT = 800;
                      item:(id)item
 {
     return NO;
+}
+
+- (BOOL)outlineView:(NSOutlineView*)outline_view
+    shouldSelectItem:(id)item
+{
+    i32 dom_node_id { 0 };
+    Optional<Web::CSS::Selector::PseudoElement> pseudo_element;
+
+    if (id element = [item objectForKey:@"pseudo-element"]) {
+        dom_node_id = [[item objectForKey:@"parent-id"] intValue];
+        pseudo_element = static_cast<Web::CSS::Selector::PseudoElement>([element intValue]);
+    } else {
+        dom_node_id = [[item objectForKey:@"id"] intValue];
+    }
+
+    [self setSelection: { dom_node_id, move(pseudo_element) }];
+    return YES;
+}
+
+#pragma mark - NSTableViewDataSource
+
+- (NSInteger)numberOfRowsInTableView:(NSTableView*)table_view
+{
+    if (table_view == self.computed_style_table_view) {
+        return static_cast<NSInteger>(self.computed_style.count);
+    }
+    if (table_view == self.resolved_style_table_view) {
+        return static_cast<NSInteger>(self.resolved_style.count);
+    }
+    if (table_view == self.variables_table_view) {
+        return static_cast<NSInteger>(self.variables.count);
+    }
+
+    return 0;
+}
+
+- (id)tableView:(NSTableView*)table_view
+    objectValueForTableColumn:(NSTableColumn*)table_column
+                          row:(NSInteger)row
+{
+    NSDictionary* values = nil;
+    NSArray* keys = nil;
+
+    if (table_view == self.computed_style_table_view) {
+        values = self.computed_style;
+        keys = self.computed_style_keys;
+    } else if (table_view == self.resolved_style_table_view) {
+        values = self.resolved_style;
+        keys = self.resolved_style_keys;
+    } else if (table_view == self.variables_table_view) {
+        values = self.variables;
+        keys = self.variables_keys;
+    } else {
+        return nil;
+    }
+
+    if ([[table_column identifier] isEqualToString:CSS_PROPERTY_COLUMN]) {
+        return keys[row];
+    }
+    if ([[table_column identifier] isEqualToString:CSS_VALUE_COLUMN]) {
+        return values[keys[row]];
+    }
+
+    return nil;
 }
 
 @end

--- a/Ladybird/AppKit/UI/InspectorController.h
+++ b/Ladybird/AppKit/UI/InspectorController.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2023, Tim Flynn <trflynn89@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#import <System/Cocoa.h>
+
+@class Tab;
+
+@interface InspectorController : NSWindowController
+
+- (instancetype)init:(Tab*)tab;
+
+@end

--- a/Ladybird/AppKit/UI/InspectorController.mm
+++ b/Ladybird/AppKit/UI/InspectorController.mm
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2023, Tim Flynn <trflynn89@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#import <UI/Inspector.h>
+#import <UI/InspectorController.h>
+#import <UI/LadybirdWebView.h>
+#import <UI/Tab.h>
+
+#if !__has_feature(objc_arc)
+#    error "This project requires ARC"
+#endif
+
+@interface InspectorController () <NSWindowDelegate>
+
+@property (nonatomic, strong) Tab* tab;
+
+@end
+
+@implementation InspectorController
+
+- (instancetype)init:(Tab*)tab
+{
+    if (self = [super init]) {
+        self.tab = tab;
+    }
+
+    return self;
+}
+
+#pragma mark - Private methods
+
+- (Inspector*)inspector
+{
+    return (Inspector*)[self window];
+}
+
+#pragma mark - NSWindowController
+
+- (IBAction)showWindow:(id)sender
+{
+    self.window = [[Inspector alloc] init:self.tab];
+    [self.window setDelegate:self];
+    [self.window makeKeyAndOrderFront:sender];
+
+    [[self inspector] inspect];
+}
+
+#pragma mark - NSWindowDelegate
+
+- (void)windowWillClose:(NSNotification*)notification
+{
+    [self.tab onInspectorClosed];
+}
+
+@end

--- a/Ladybird/AppKit/UI/LadybirdWebView.h
+++ b/Ladybird/AppKit/UI/LadybirdWebView.h
@@ -25,6 +25,7 @@
 
 - (void)loadURL:(URL const&)url;
 - (void)onLoadStart:(URL const&)url isRedirect:(BOOL)is_redirect;
+- (void)onLoadFinish:(URL const&)url;
 
 - (void)onTitleChange:(DeprecatedString const&)title;
 - (void)onFaviconChange:(Gfx::Bitmap const&)bitmap;

--- a/Ladybird/AppKit/UI/LadybirdWebView.mm
+++ b/Ladybird/AppKit/UI/LadybirdWebView.mm
@@ -227,6 +227,10 @@ struct HideCursor {
         }
     };
 
+    m_web_view_bridge->on_load_finish = [self](auto const& url) {
+        [self.observer onLoadFinish:url];
+    };
+
     m_web_view_bridge->on_title_change = [self](auto const& title) {
         [self.observer onTitleChange:title];
     };

--- a/Ladybird/AppKit/UI/LadybirdWebView.mm
+++ b/Ladybird/AppKit/UI/LadybirdWebView.mm
@@ -722,6 +722,9 @@ static void copy_text_to_clipboard(StringView text)
         [_page_context_menu addItem:[[NSMenuItem alloc] initWithTitle:@"View Source"
                                                                action:@selector(viewSource:)
                                                         keyEquivalent:@""]];
+        [_page_context_menu addItem:[[NSMenuItem alloc] initWithTitle:@"Inspect Element"
+                                                               action:@selector(inspectElement:)
+                                                        keyEquivalent:@""]];
     }
 
     return _page_context_menu;
@@ -742,6 +745,11 @@ static void copy_text_to_clipboard(StringView text)
 
         [_link_context_menu addItem:[[NSMenuItem alloc] initWithTitle:@"Copy URL"
                                                                action:@selector(copyLink:)
+                                                        keyEquivalent:@""]];
+        [_link_context_menu addItem:[NSMenuItem separatorItem]];
+
+        [_link_context_menu addItem:[[NSMenuItem alloc] initWithTitle:@"Inspect Element"
+                                                               action:@selector(inspectElement:)
                                                         keyEquivalent:@""]];
     }
 
@@ -766,6 +774,11 @@ static void copy_text_to_clipboard(StringView text)
                                                          keyEquivalent:@""]];
         [_image_context_menu addItem:[[NSMenuItem alloc] initWithTitle:@"Copy Image URL"
                                                                 action:@selector(copyLink:)
+                                                         keyEquivalent:@""]];
+        [_image_context_menu addItem:[NSMenuItem separatorItem]];
+
+        [_image_context_menu addItem:[[NSMenuItem alloc] initWithTitle:@"Inspect Element"
+                                                                action:@selector(inspectElement:)
                                                          keyEquivalent:@""]];
     }
 
@@ -814,6 +827,11 @@ static void copy_text_to_clipboard(StringView text)
         [_audio_context_menu addItem:[[NSMenuItem alloc] initWithTitle:@"Copy Audio URL"
                                                                 action:@selector(copyLink:)
                                                          keyEquivalent:@""]];
+        [_audio_context_menu addItem:[NSMenuItem separatorItem]];
+
+        [_audio_context_menu addItem:[[NSMenuItem alloc] initWithTitle:@"Inspect Element"
+                                                                action:@selector(inspectElement:)
+                                                         keyEquivalent:@""]];
     }
 
     return _audio_context_menu;
@@ -860,6 +878,11 @@ static void copy_text_to_clipboard(StringView text)
 
         [_video_context_menu addItem:[[NSMenuItem alloc] initWithTitle:@"Copy Video URL"
                                                                 action:@selector(copyLink:)
+                                                         keyEquivalent:@""]];
+        [_video_context_menu addItem:[NSMenuItem separatorItem]];
+
+        [_video_context_menu addItem:[[NSMenuItem alloc] initWithTitle:@"Inspect Element"
+                                                                action:@selector(inspectElement:)
                                                          keyEquivalent:@""]];
     }
 

--- a/Ladybird/AppKit/UI/Tab.h
+++ b/Ladybird/AppKit/UI/Tab.h
@@ -17,6 +17,9 @@
 - (void)openConsole:(id)sender;
 - (void)onConsoleClosed;
 
+- (void)openInspector:(id)sender;
+- (void)onInspectorClosed;
+
 @property (nonatomic, strong) LadybirdWebView* web_view;
 
 @end

--- a/Ladybird/AppKit/UI/Tab.mm
+++ b/Ladybird/AppKit/UI/Tab.mm
@@ -14,6 +14,8 @@
 #import <Application/ApplicationDelegate.h>
 #import <UI/Console.h>
 #import <UI/ConsoleController.h>
+#import <UI/Inspector.h>
+#import <UI/InspectorController.h>
 #import <UI/LadybirdWebView.h>
 #import <UI/Tab.h>
 #import <UI/TabController.h>
@@ -32,6 +34,7 @@ static constexpr CGFloat const WINDOW_HEIGHT = 800;
 @property (nonatomic, strong) NSImage* favicon;
 
 @property (nonatomic, strong) ConsoleController* console_controller;
+@property (nonatomic, strong) InspectorController* inspector_controller;
 
 @end
 
@@ -106,6 +109,9 @@ static constexpr CGFloat const WINDOW_HEIGHT = 800;
     if (self.console_controller != nil) {
         [self.console_controller.window close];
     }
+    if (self.inspector_controller != nil) {
+        [self.inspector_controller.window close];
+    }
 }
 
 - (void)openConsole:(id)sender
@@ -122,6 +128,22 @@ static constexpr CGFloat const WINDOW_HEIGHT = 800;
 - (void)onConsoleClosed
 {
     self.console_controller = nil;
+}
+
+- (void)openInspector:(id)sender
+{
+    if (self.inspector_controller != nil) {
+        [self.inspector_controller.window makeKeyAndOrderFront:sender];
+        return;
+    }
+
+    self.inspector_controller = [[InspectorController alloc] init:self];
+    [self.inspector_controller showWindow:nil];
+}
+
+- (void)onInspectorClosed
+{
+    self.inspector_controller = nil;
 }
 
 #pragma mark - Private methods
@@ -218,6 +240,18 @@ static constexpr CGFloat const WINDOW_HEIGHT = 800;
     if (self.console_controller != nil) {
         auto* console = (Console*)[self.console_controller window];
         [console reset];
+    }
+    if (self.inspector_controller != nil) {
+        auto* inspector = (Inspector*)[self.inspector_controller window];
+        [inspector reset];
+    }
+}
+
+- (void)onLoadFinish:(URL const&)url
+{
+    if (self.inspector_controller != nil) {
+        auto* inspector = (Inspector*)[self.inspector_controller window];
+        [inspector inspect];
     }
 }
 

--- a/Ladybird/AppKit/UI/Tab.mm
+++ b/Ladybird/AppKit/UI/Tab.mm
@@ -146,6 +146,14 @@ static constexpr CGFloat const WINDOW_HEIGHT = 800;
     self.inspector_controller = nil;
 }
 
+- (void)inspectElement:(id)sender
+{
+    [self openInspector:sender];
+
+    auto* inspector = (Inspector*)[self.inspector_controller window];
+    [inspector inspectHoveredElement];
+}
+
 #pragma mark - Private methods
 
 - (TabController*)tabController

--- a/Ladybird/AppKit/Utilities/Conversions.h
+++ b/Ladybird/AppKit/Utilities/Conversions.h
@@ -19,6 +19,8 @@ namespace Ladybird {
 String ns_string_to_string(NSString*);
 NSString* string_to_ns_string(StringView);
 
+NSDictionary* deserialize_json_to_dictionary(StringView);
+
 Gfx::IntRect ns_rect_to_gfx_rect(NSRect);
 NSRect gfx_rect_to_ns_rect(Gfx::IntRect);
 

--- a/Ladybird/AppKit/Utilities/Conversions.mm
+++ b/Ladybird/AppKit/Utilities/Conversions.mm
@@ -20,6 +20,23 @@ NSString* string_to_ns_string(StringView string)
     return [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
 }
 
+NSDictionary* deserialize_json_to_dictionary(StringView json)
+{
+    auto* ns_json = string_to_ns_string(json);
+    auto* json_data = [ns_json dataUsingEncoding:NSUTF8StringEncoding];
+
+    NSError* error = nil;
+    NSDictionary* dictionary = [NSJSONSerialization JSONObjectWithData:json_data
+                                                               options:0
+                                                                 error:&error];
+
+    if (!dictionary) {
+        NSLog(@"Error deserializing DOM tree: %@", error);
+    }
+
+    return dictionary;
+}
+
 Gfx::IntRect ns_rect_to_gfx_rect(NSRect rect)
 {
     return {

--- a/Ladybird/AppKit/Utilities/NSString+Ladybird.h
+++ b/Ladybird/AppKit/Utilities/NSString+Ladybird.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2023, Tim Flynn <trflynn89@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#import <System/Cocoa.h>
+
+@interface NSString (Ladybird)
+
+- (NSString*)stringByCollapsingConsecutiveWhitespace;
+
+@end

--- a/Ladybird/AppKit/Utilities/NSString+Ladybird.mm
+++ b/Ladybird/AppKit/Utilities/NSString+Ladybird.mm
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2023, Tim Flynn <trflynn89@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/CharacterTypes.h>
+#include <AK/StringView.h>
+#include <AK/Utf8View.h>
+#include <LibUnicode/CharacterTypes.h>
+
+#import <Utilities/Conversions.h>
+#import <Utilities/NSString+Ladybird.h>
+
+static BOOL code_point_is_whitespace(u32 code_point)
+{
+    static auto white_space_category = Unicode::property_from_string("White_Space"sv);
+
+    if (!white_space_category.has_value())
+        return is_ascii_space(code_point);
+
+    return Unicode::code_point_has_property(code_point, *white_space_category);
+}
+
+@implementation NSString (Ladybird)
+
+- (NSString*)stringByCollapsingConsecutiveWhitespace
+{
+    auto* result = [NSMutableString string];
+
+    auto const* string = [self UTF8String];
+    Utf8View code_points { StringView { string, strlen(string) } };
+
+    bool currently_skipping_spaces = false;
+
+    for (auto code_point : code_points) {
+        if (code_point_is_whitespace(code_point)) {
+            if (!currently_skipping_spaces) {
+                currently_skipping_spaces = true;
+                [result appendString:@" "];
+            }
+
+            continue;
+        }
+
+        auto code_point_string = String::from_code_point(code_point);
+        [result appendString:Ladybird::string_to_ns_string(code_point_string)];
+
+        currently_skipping_spaces = false;
+    }
+
+    return result;
+}
+
+@end

--- a/Ladybird/CMakeLists.txt
+++ b/Ladybird/CMakeLists.txt
@@ -129,6 +129,8 @@ elseif (APPLE)
         AppKit/UI/Console.mm
         AppKit/UI/ConsoleController.mm
         AppKit/UI/Event.mm
+        AppKit/UI/Inspector.mm
+        AppKit/UI/InspectorController.mm
         AppKit/UI/LadybirdWebView.mm
         AppKit/UI/LadybirdWebViewBridge.cpp
         AppKit/UI/Palette.mm

--- a/Ladybird/CMakeLists.txt
+++ b/Ladybird/CMakeLists.txt
@@ -135,10 +135,11 @@ elseif (APPLE)
         AppKit/UI/Tab.mm
         AppKit/UI/TabController.mm
         AppKit/Utilities/Conversions.mm
+        AppKit/Utilities/NSString+Ladybird.mm
         AppKit/Utilities/URL.mm
     )
     target_include_directories(ladybird PRIVATE AppKit)
-    target_link_libraries(ladybird PRIVATE ${COCOA_LIBRARY})
+    target_link_libraries(ladybird PRIVATE ${COCOA_LIBRARY} LibUnicode)
     target_compile_options(ladybird PRIVATE
         -fobjc-arc
         -Wno-deprecated-anon-enum-enum-conversion # Required for CGImageCreate


### PR DESCRIPTION
This implementation contains the DOM tree and CSS style table (computed properties, resolved properties, and variables). You can click nodes in the inspector's DOM tree to further inspect them, or right-click on elements on the page to inspect them from the context menu.

<img width="992" alt="Screenshot 2023-09-13 at 10 48 02 PM" src="https://github.com/SerenityOS/serenity/assets/5600524/5ec951da-02fd-4e24-8e79-738bde1d4f9e">

<img width="995" alt="Screenshot 2023-09-13 at 10 47 40 PM" src="https://github.com/SerenityOS/serenity/assets/5600524/54aee445-d38b-472d-b983-5e905574b06b">

