### PR TITLE
Base+Maps: Add manpage for Maps

### DIFF
--- a/Base/usr/share/man/man1/Applications.md
+++ b/Base/usr/share/man/man1/Applications.md
@@ -32,6 +32,7 @@ Note that many applications can be disabled at SerenityOS build time if desired.
 - [Image Viewer](help://man/1/Applications/ImageViewer)
 - [Magnifier](help://man/1/Applications/Magnifier)
 - [Mail](help://man/1/Applications/Mail)
+- [Maps](help://man/1/Applications/Maps)
 - [Mouse Settings](help://man/1/Applications/MouseSettings)
 - [Presenter](help://man/1/Applications/Presenter)
 - [Profiler](help://man/1/Applications/Profiler)

--- a/Base/usr/share/man/man1/Applications/Maps.md
+++ b/Base/usr/share/man/man1/Applications/Maps.md
@@ -1,0 +1,36 @@
+## Name
+
+![Icon](/res/icons/16x16/app-maps.png) Maps
+
+[Open](file:///bin/Maps)
+
+## Synopsis
+
+```**sh
+$ Maps
+```
+
+## Description
+
+`Maps` is an application for browsing a map of the world.
+
+The default data provider is [OpenStreetMaps](https://www.openstreetmap.org/), an open-source community-maintained map similar in spirit to Wikipedia.
+
+## Features
+Pan around the map by clicking and dragging.
+
+Zoom by using the toolbar icons, the mouse wheel or `Ctrl +` to zoom-in and `Ctrl -` to zoom-out. Reset the zoom to a global view with `Ctrl 0`.
+Double-clicking anywhere on the map zooms-in to that location. Double-clicking whilst holding `Shift` zooms-out.
+
+Right-click on a location to:
+* Copy its coordinates to the Clipboard
+* Open it in various mapping services
+* Center the map on it
+
+Show and hide the search panel by clicking on the leftmost magnifying glass in the toolbar. Type your query, press `Return` and then click on a result to focus on it in the map. Navigate the search results with the `Up` and `Down` arrow keys.
+
+The default map tile provider can be changed in `Maps Settings`, enabling maps with labels in other languages, different types of map (e.g. topographical) and even setting a custom map. Other tile providers can be found [here](https://wiki.openstreetmap.org/wiki/Raster_tile_providers).
+
+To see an overlay of where in the world SerenityOS users are, click on the Ladyball icon (the SerenityOS logo) or enable `View → Show SerenityOS Users`.
+This shows those who have added their location to the [SerenityOS User Map](https://usermap.serenityos.org). Hover over a marker to reveal the name of a user. Project contributors are distinguished by a blue marker. The total number of users on the map is listed in the top-right.
+Add yourself in the [user-map repository](https://github.com/SerenityOS/user-map)!

--- a/Userland/Applications/Maps/main.cpp
+++ b/Userland/Applications/Maps/main.cpp
@@ -8,6 +8,7 @@
 #include "UsersMapWidget.h"
 #include <LibConfig/Client.h>
 #include <LibCore/System.h>
+#include <LibDesktop/Launcher.h>
 #include <LibGUI/Action.h>
 #include <LibGUI/Application.h>
 #include <LibGUI/BoxLayout.h>
@@ -125,6 +126,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto help_menu = window->add_menu("&Help"_string);
     help_menu->add_action(GUI::CommonActions::make_command_palette_action(window));
+    help_menu->add_action(GUI::CommonActions::make_help_action([](auto&) {
+        Desktop::Launcher::open(URL::create_with_file_scheme("/usr/share/man/man1/Applications/Maps.md"), "/bin/Help");
+    }));
     help_menu->add_action(GUI::CommonActions::make_about_action("Maps"_string, app_icon, window));
 
     // Main toolbar actions


### PR DESCRIPTION
Also, list Maps in `Applications.md` and add a link to the manpage in Map's Help menu.

Contributes towards #21091