### PR TITLE
LibWeb: Fix infinite loop in GFC growth limit distribution

### DIFF
--- a/Tests/LibWeb/Layout/expected/grid/should-not-hang-in-size-distribution.txt
+++ b/Tests/LibWeb/Layout/expected/grid/should-not-hang-in-size-distribution.txt
@@ -1,0 +1,16 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x33.46875 [BFC] children: not-inline
+    Box <body> at (8,8) content-size 784x17.46875 [GFC] children: not-inline
+      BlockContainer <div#item> at (8,8) content-size 784x17.46875 [BFC] children: not-inline
+        BlockContainer <div#block> at (8,8) content-size 784x17.46875 children: inline
+          line 0 width: 210.484375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 26, rect: [8,8 210.484375x17.46875]
+              "Taika Waititi's Best Roles"
+          TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x33.46875]
+    PaintableBox (Box<BODY>) [8,8 784x17.46875]
+      PaintableWithLines (BlockContainer<DIV>#item) [8,8 784x17.46875]
+        PaintableWithLines (BlockContainer<DIV>#block) [8,8 784x17.46875]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/input/grid/should-not-hang-in-size-distribution.html
+++ b/Tests/LibWeb/Layout/input/grid/should-not-hang-in-size-distribution.html
@@ -1,0 +1,17 @@
+<!doctype html><style>    
+* {                        
+    outline: 1px solid black;              
+}    
+html {    
+    font: inherit;    
+}    
+body {     
+    display: grid;    
+}    
+#item {     
+    grid-column: span 4 / auto;    
+}    
+#block {    
+    min-width: 0px;    
+}    
+</style><body><div id="item"><div id="block">Taika Waititi's Best Roles  


### PR DESCRIPTION
This change is https://github.com/SerenityOS/serenity/commit/bd85e1b30b57e89ec058ef61833f7562514b3c9c ported from base size to growth limit distribution.

Fixes https://github.com/SerenityOS/serenity/issues/21056

@Zaggy1024 any chance you know less ugly way to fix the issue?