### PR TITLE
LibWeb: Use more CSSPixelFractions in GFC::expand_flexible_tracks

### DIFF
--- a/Tests/LibWeb/Layout/expected/grid/placement-1.txt
+++ b/Tests/LibWeb/Layout/expected/grid/placement-1.txt
@@ -2,22 +2,22 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (1,1) content-size 798x600 [BFC] children: not-inline
     BlockContainer <body> at (10,10) content-size 780x21.46875 children: not-inline
       Box <div.grid-container> at (11,11) content-size 778x19.46875 [GFC] children: not-inline
-        BlockContainer <div.a> at (12,12) content-size 516.75x17.46875 [BFC] children: inline
+        BlockContainer <div.a> at (12,12) content-size 516.625x17.46875 [BFC] children: inline
           line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [12,12 6.34375x17.46875]
               "1"
           TextNode <#text>
-        BlockContainer <div.b> at (530.75,12) content-size 257.375x17.46875 [BFC] children: inline
+        BlockContainer <div.b> at (530.625,12) content-size 257.3125x17.46875 [BFC] children: inline
           line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 1, rect: [530.75,12 8.8125x17.46875]
+            frag 0 from TextNode start: 0, length: 1, rect: [530.625,12 8.8125x17.46875]
               "2"
           TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x602]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x602]
     PaintableWithLines (BlockContainer<BODY>) [9,9 782x23.46875]
-      PaintableBox (Box<DIV>.grid-container) [10,10 780x21.46875] overflow: [11,11 778.125x19.46875]
-        PaintableWithLines (BlockContainer<DIV>.a) [11,11 518.75x19.46875]
+      PaintableBox (Box<DIV>.grid-container) [10,10 780x21.46875]
+        PaintableWithLines (BlockContainer<DIV>.a) [11,11 518.625x19.46875]
           TextPaintable (TextNode<#text>)
-        PaintableWithLines (BlockContainer<DIV>.b) [529.75,11 259.375x19.46875]
+        PaintableWithLines (BlockContainer<DIV>.b) [529.625,11 259.3125x19.46875]
           TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/grid/placement-2.txt
+++ b/Tests/LibWeb/Layout/expected/grid/placement-2.txt
@@ -2,22 +2,22 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (1,1) content-size 798x600 [BFC] children: not-inline
     BlockContainer <body> at (10,10) content-size 780x21.46875 children: not-inline
       Box <div.grid-container> at (11,11) content-size 778x19.46875 [GFC] children: not-inline
-        BlockContainer <div.grid-item.a> at (12,12) content-size 257.375x17.46875 [BFC] children: inline
+        BlockContainer <div.grid-item.a> at (12,12) content-size 257.3125x17.46875 [BFC] children: inline
           line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
             frag 0 from TextNode start: 0, length: 1, rect: [12,12 6.34375x17.46875]
               "1"
           TextNode <#text>
-        BlockContainer <div.grid-item.b> at (271.375,12) content-size 516.75x17.46875 [BFC] children: inline
+        BlockContainer <div.grid-item.b> at (271.3125,12) content-size 516.625x17.46875 [BFC] children: inline
           line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-            frag 0 from TextNode start: 0, length: 1, rect: [271.375,12 8.8125x17.46875]
+            frag 0 from TextNode start: 0, length: 1, rect: [271.3125,12 8.8125x17.46875]
               "2"
           TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x602]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x602]
     PaintableWithLines (BlockContainer<BODY>) [9,9 782x23.46875]
-      PaintableBox (Box<DIV>.grid-container) [10,10 780x21.46875] overflow: [11,11 778.125x19.46875]
-        PaintableWithLines (BlockContainer<DIV>.grid-item.a) [11,11 259.375x19.46875]
+      PaintableBox (Box<DIV>.grid-container) [10,10 780x21.46875]
+        PaintableWithLines (BlockContainer<DIV>.grid-item.a) [11,11 259.3125x19.46875]
           TextPaintable (TextNode<#text>)
-        PaintableWithLines (BlockContainer<DIV>.grid-item.b) [270.375,11 518.75x19.46875]
+        PaintableWithLines (BlockContainer<DIV>.grid-item.b) [270.3125,11 518.625x19.46875]
           TextPaintable (TextNode<#text>)


### PR DESCRIPTION
Also contains a drive-by expression simplification, and accidental double truncation, but does not seem to affect layout according to the current tests