### PR TITLE
Userland: Don't use `String::from_utf8()` for literal strings

### DIFF
--- a/Userland/Applications/DisplaySettings/BackgroundSettingsWidget.cpp
+++ b/Userland/Applications/DisplaySettings/BackgroundSettingsWidget.cpp
@@ -35,9 +35,9 @@ ErrorOr<NonnullRefPtr<BackgroundSettingsWidget>> BackgroundSettingsWidget::try_c
 {
     auto background_settings_widget = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) BackgroundSettingsWidget(background_settings_changed)));
 
-    TRY(background_settings_widget->m_modes.try_append(TRY(String::from_utf8("Tile"sv))));
-    TRY(background_settings_widget->m_modes.try_append(TRY(String::from_utf8("Center"sv))));
-    TRY(background_settings_widget->m_modes.try_append(TRY(String::from_utf8("Stretch"sv))));
+    TRY(background_settings_widget->m_modes.try_append("Tile"_string));
+    TRY(background_settings_widget->m_modes.try_append("Center"_string));
+    TRY(background_settings_widget->m_modes.try_append("Stretch"_string));
 
     TRY(background_settings_widget->create_frame());
     TRY(background_settings_widget->load_current_settings());
@@ -154,7 +154,7 @@ ErrorOr<void> BackgroundSettingsWidget::load_current_settings()
     auto mode = TRY(String::from_deprecated_string(ws_config->read_entry("Background", "Mode", "Center")));
     if (!m_modes.contains_slow(mode)) {
         warnln("Invalid background mode '{}' in WindowServer config, falling back to 'Center'", mode);
-        mode = TRY(String::from_utf8("Center"sv));
+        mode = "Center"_string;
     }
     m_monitor_widget->set_wallpaper_mode(mode);
     m_mode_combo->set_selected_index(m_modes.find_first_index(mode).value_or(0), GUI::AllowCallback::No);

--- a/Userland/Applications/FontEditor/MainWidget.cpp
+++ b/Userland/Applications/FontEditor/MainWidget.cpp
@@ -423,7 +423,7 @@ ErrorOr<void> MainWidget::create_models()
 
     auto unicode_blocks = Unicode::block_display_names();
     TRY(m_unicode_block_list.try_ensure_capacity(unicode_blocks.size() + 1));
-    m_unicode_block_list.unchecked_append(TRY(String::from_utf8("Show All"sv)));
+    m_unicode_block_list.unchecked_append("Show All"_string);
     for (auto& block : unicode_blocks)
         m_unicode_block_list.unchecked_append(TRY(String::from_utf8(block.display_name)));
 

--- a/Userland/Applications/PixelPaint/main.cpp
+++ b/Userland/Applications/PixelPaint/main.cpp
@@ -24,7 +24,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto app = TRY(GUI::Application::create(arguments));
     Config::pledge_domain("PixelPaint");
-    app->set_config_domain(TRY(String::from_utf8("PixelPaint"sv)));
+    app->set_config_domain("PixelPaint"_string);
 
     StringView image_file;
     Core::ArgsParser args_parser;

--- a/Userland/Libraries/LibGUI/UIDimensions.h
+++ b/Userland/Libraries/LibGUI/UIDimensions.h
@@ -156,13 +156,13 @@ public:
         if (is_int())
             value_source = TRY(String::number(m_value));
         else if (is_shrink())
-            value_source = TRY(String::from_utf8("GUI::SpecialDimension::Shrink"sv));
+            value_source = "GUI::SpecialDimension::Shrink"_string;
         else if (is_grow())
-            value_source = TRY(String::from_utf8("GUI::SpecialDimension::Grow"sv));
+            value_source = "GUI::SpecialDimension::Grow"_string;
         else if (is_opportunistic_grow())
-            value_source = TRY(String::from_utf8("GUI::SpecialDimension::OpportunisticGrow"sv));
+            value_source = "GUI::SpecialDimension::OpportunisticGrow"_string;
         else if (is_fit())
-            value_source = TRY(String::from_utf8("GUI::SpecialDimension::Fit"sv));
+            value_source = "GUI::SpecialDimension::Fit"_string;
         return String::formatted("GUI::UIDimension {{ {} }}", value_source);
     }
 

--- a/Userland/Services/DeviceMapper/DeviceEventLoop.cpp
+++ b/Userland/Services/DeviceMapper/DeviceEventLoop.cpp
@@ -87,7 +87,7 @@ ErrorOr<NonnullRefPtr<DeviceNodeFamily>> DeviceEventLoop::find_or_register_new_d
 
 static ErrorOr<String> build_suffix_with_letters(size_t allocation_index)
 {
-    auto base_string = TRY(String::from_utf8(""sv));
+    String base_string {};
     while (true) {
         base_string = TRY(String::formatted("{:c}{}", 'a' + (allocation_index % 26), base_string));
         allocation_index = (allocation_index / 26);

--- a/Userland/Utilities/cal.cpp
+++ b/Userland/Utilities/cal.cpp
@@ -111,7 +111,7 @@ static ErrorOr<Vector<String>> month_lines_to_print(Header header_mode, int star
     int day = 1;
     for (int i = 1; day <= days_in_month; ++i) {
         if (i - 1 < first_day_of_week_for_month) {
-            TRY(days_in_row.try_append(TRY(String::from_utf8("  "sv))));
+            TRY(days_in_row.try_append("  "_string));
         } else {
             if (year == current_year && month == current_month && day == current_day) {
                 TRY(days_in_row.try_append(TRY(String::formatted(ANSI_INVERT_OUTPUT "{:2}" ANSI_RESET_OUTPUT, day))));

--- a/Userland/Utilities/pkg/AvailablePort.cpp
+++ b/Userland/Utilities/pkg/AvailablePort.cpp
@@ -155,11 +155,11 @@ ErrorOr<HashMap<String, AvailablePort>> AvailablePort::read_available_ports_list
         auto name = TRY(extract_port_name_from_column(port_name_column, port_index));
         auto website = TRY(String::from_deprecated_string(port_website_column.rows[port_index].render_for_terminal()));
         if (website.is_empty())
-            website = TRY(String::from_utf8("n/a"sv));
+            website = "n/a"_string;
 
         auto version = TRY(String::from_deprecated_string(port_version_column.rows[port_index].render_for_terminal()));
         if (version.is_empty())
-            version = TRY(String::from_utf8("n/a"sv));
+            version = "n/a"_string;
 
         TRY(available_ports.try_set(name, AvailablePort { name, version, website }));
     }

--- a/Userland/Utilities/pkg/InstalledPort.cpp
+++ b/Userland/Utilities/pkg/InstalledPort.cpp
@@ -26,7 +26,7 @@ ErrorOr<HashMap<String, InstalledPort>> InstalledPort::read_ports_database()
             auto type = InstalledPort::Type::Dependency;
             // FIXME: Add versioning when printing these ports!
             auto name = TRY(String::from_utf8(parts[2]));
-            TRY(ports.try_set(name, InstalledPort { TRY(String::from_utf8(parts[2])), type, TRY(String::from_utf8(""sv)) }));
+            TRY(ports.try_set(name, InstalledPort { TRY(String::from_utf8(parts[2])), type, {} }));
         } else if (line.starts_with("auto"sv)) {
             auto parts = line.split_view(' ');
             VERIFY(parts.size() == 3);


### PR DESCRIPTION
Contributes to #20405