### PR TITLE
LibWeb: Don't generate ::before/::after for BR elements

### DIFF
--- a/Tests/LibWeb/Layout/expected/br-should-not-generate-pseudo-before.txt
+++ b/Tests/LibWeb/Layout/expected/br-should-not-generate-pseudo-before.txt
@@ -1,0 +1,29 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x84.875 [BFC] children: not-inline
+    BlockContainer <body> at (8,16) content-size 784x68.875 children: not-inline
+      BlockContainer <p> at (8,16) content-size 784x17.46875 children: inline
+        line 0 width: 310.625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+          frag 0 from TextNode start: 0, length: 1, rect: [8,16 10.625x17.46875]
+            "+"
+          frag 1 from TextNode start: 0, length: 36, rect: [19,16 300x17.46875]
+            "P should generate a ::before pseudo."
+        InlineNode <(anonymous)>
+          TextNode <#text>
+        TextNode <#text>
+      BlockContainer <(anonymous)> at (8,49.46875) content-size 784x35.40625 children: inline
+        line 0 width: 0, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+        line 1 width: 120.578125, height: 17.9375, bottom: 35.40625, baseline: 13.53125
+          frag 0 from TextNode start: 0, length: 14, rect: [8,66.46875 120.578125x17.46875]
+            "BR should not!"
+        BreakNode <br>
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x84.875]
+    PaintableWithLines (BlockContainer<BODY>) [8,16 784x68.875]
+      PaintableWithLines (BlockContainer<P>) [8,16 784x17.46875]
+        InlinePaintable (InlineNode(anonymous))
+          TextPaintable (TextNode<#text>)
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,49.46875 784x35.40625]
+        TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/input/br-should-not-generate-pseudo-before.html
+++ b/Tests/LibWeb/Layout/input/br-should-not-generate-pseudo-before.html
@@ -1,0 +1,3 @@
+<!doctype html><style>
+    body ::before { content: "+"; }
+</style><body><p>P should generate a ::before pseudo.</p><br>BR should not!

--- a/Userland/Libraries/LibWeb/Layout/BreakNode.h
+++ b/Userland/Libraries/LibWeb/Layout/BreakNode.h
@@ -22,6 +22,7 @@ public:
 
 private:
     virtual bool is_break_node() const final { return true; }
+    virtual bool can_have_children() const override { return false; }
 };
 
 template<>

--- a/Userland/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -427,7 +427,7 @@ ErrorOr<void> TreeBuilder::create_layout_tree(DOM::Node& dom_node, TreeBuilder::
     }
 
     // Add nodes for the ::before and ::after pseudo-elements.
-    if (is<DOM::Element>(dom_node)) {
+    if (is<DOM::Element>(dom_node) && layout_node->can_have_children()) {
         auto& element = static_cast<DOM::Element&>(dom_node);
         push_parent(verify_cast<NodeWithStyle>(*layout_node));
         TRY(create_pseudo_element_if_needed(element, CSS::Selector::PseudoElement::Before, AppendOrPrepend::Prepend));


### PR DESCRIPTION
We shouldn't be putting generated pseudo elements inside elements that can't have children in the first place.

This patch fixes two issues:
- We stop generating pseudo elements for layout nodes that can't have children anyway.
- We mark Layout::BreakNode as not being able to have children.

Visual progression on the Dark Souls wiki (https://darksouls.wiki.fextralife.com/Titanite+Chunk)

Before:
![image](https://github.com/SerenityOS/serenity/assets/5954907/95420362-bfb0-4e3a-9fbe-67ebc4490b48)

After:
![image](https://github.com/SerenityOS/serenity/assets/5954907/6b830ddc-8508-461a-8bcb-a741785d70c1)
