### PR TITLE
grep: Hyperlink filenames in tty & other small fixes found along the way

### DIFF
--- a/Base/usr/share/man/man1/grep.md
+++ b/Base/usr/share/man/man1/grep.md
@@ -5,7 +5,7 @@ grep
 ## Synopsis
 
 ```sh
-$ grep [--recursive] [--extended-regexp] [--fixed-strings] [--regexp Pattern] [--file File] [-i] [--line-numbers] [--invert-match] [--quiet] [--no-messages] [--binary-mode ] [--text] [-I] [--color WHEN] [--count] [file...]
+$ grep [--recursive] [--extended-regexp] [--fixed-strings] [--regexp Pattern] [--file File] [-i] [--line-numbers] [--invert-match] [--quiet] [--no-messages] [--binary-mode ] [--text] [-I] [--color WHEN] [--no-hyperlinks] [--count] [file...]
 ```
 
 ## Options
@@ -24,6 +24,7 @@ $ grep [--recursive] [--extended-regexp] [--fixed-strings] [--regexp Pattern] [-
 * `-a`, `--text`: Treat binary files as text (same as --binary-mode text)
 * `-I`: Ignore binary files (same as --binary-mode skip)
 * `--color WHEN`: When to use colored output for the matching text ([auto], never, always)
+* `--no-hyperlinks`: Disable hyperlinks
 * `-c`, `--count`: Output line count instead of line contents
 
 ## Arguments

--- a/Userland/Utilities/grep.cpp
+++ b/Userland/Utilities/grep.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020, Emanuel Sprung <emanuel.sprung@gmail.com>
+ * Copyright (c) 2023, Karol Kosek <krkk@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -9,6 +10,7 @@
 #include <AK/LexicalPath.h>
 #include <AK/ScopeGuard.h>
 #include <AK/StringBuilder.h>
+#include <AK/URL.h>
 #include <AK/Vector.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/DirIterator.h>
@@ -56,6 +58,61 @@ static DeprecatedString escape_characters(StringView string, StringView characte
     return builder.to_deprecated_string();
 }
 
+static DeprecatedString& hostname()
+{
+    static DeprecatedString s_hostname;
+    if (s_hostname.is_empty()) {
+        auto result = Core::System::gethostname();
+        if (result.is_error())
+            s_hostname = "localhost";
+        else
+            s_hostname = result.release_value();
+    }
+    return s_hostname;
+}
+
+enum class PrintType {
+    Path = 1 << 0,
+    LineNumbers = 1 << 1,
+};
+AK_ENUM_BITWISE_OPERATORS(PrintType)
+
+static void append_formatted_path(StringBuilder& builder, StringView path, Optional<size_t> line_number, PrintType print_type, bool with_hyperlinks, bool with_color)
+{
+    if (path == '-') {
+        path = "(standard input)"sv;
+        with_hyperlinks = false;
+    }
+
+    if (with_hyperlinks) {
+        auto full_path_or_error = FileSystem::real_path(path);
+        if (!full_path_or_error.is_error()) {
+            auto fullpath = full_path_or_error.release_value();
+            auto url = URL::create_with_file_scheme(fullpath.to_deprecated_string(), {}, hostname());
+            if (has_flag(print_type, PrintType::LineNumbers) && line_number.has_value())
+                url.set_query(MUST(String::formatted("line_number={}", *line_number)));
+            builder.appendff("\033]8;;{}\033\\", url.serialize());
+        }
+    }
+    if (has_flag(print_type, PrintType::Path)) {
+        if (with_color)
+            builder.appendff("\033[34m{}\033[39m", path);
+        else
+            builder.append(path);
+    }
+    if (has_flag(print_type, PrintType::LineNumbers) && line_number.has_value()) {
+        if (has_flag(print_type, PrintType::Path))
+            builder.append(':');
+
+        if (with_color)
+            builder.appendff("\033[35m{}\033[39m", *line_number);
+        else
+            builder.appendff("{}", *line_number);
+    }
+    if (with_hyperlinks)
+        builder.append("\033]8;;\033\\"sv);
+}
+
 ErrorOr<int> serenity_main(Main::Arguments args)
 {
     TRY(Core::System::pledge("stdio rpath"));
@@ -75,7 +132,9 @@ ErrorOr<int> serenity_main(Main::Arguments args)
     bool invert_match = false;
     bool quiet_mode = false;
     bool suppress_errors = false;
-    bool colored_output = isatty(STDOUT_FILENO);
+    bool is_a_tty = isatty(STDOUT_FILENO) == 1;
+    bool colored_output = is_a_tty;
+    bool disable_hyperlinks = !is_a_tty;
     bool count_lines = false;
 
     size_t matched_line_count = 0;
@@ -163,6 +222,7 @@ ErrorOr<int> serenity_main(Main::Arguments args)
             return true;
         },
     });
+    args_parser.add_option(disable_hyperlinks, "Disable hyperlinks", "no-hyperlinks", 0);
     args_parser.add_option(count_lines, "Output line count instead of line contents", "count", 'c');
     args_parser.add_positional_argument(files, "File(s) to process", "file", Core::ArgsParser::Required::No);
     args_parser.parse(args);
@@ -218,12 +278,21 @@ ErrorOr<int> serenity_main(Main::Arguments args)
                 }
 
                 if (is_binary && binary_mode == BinaryFileMode::Binary) {
-                    outln(colored_output ? "binary file \x1B[34m{}\x1B[0m matches"sv : "binary file {} matches"sv, filename);
+                    StringBuilder filename_builder;
+                    append_formatted_path(filename_builder, filename, {}, PrintType::Path, !disable_hyperlinks, colored_output);
+                    outln("binary file {} matches"sv, filename_builder.string_view());
                 } else {
-                    if ((result.matches.size() || invert_match) && print_filename)
-                        out(colored_output ? "\x1B[34m{}:\x1B[0m"sv : "{}:"sv, filename);
-                    if ((result.matches.size() || invert_match) && line_numbers)
-                        out(colored_output ? "\x1B[35m{}:\x1B[0m"sv : "{}:"sv, line_number);
+                    PrintType print_type { 0 };
+                    if (print_filename)
+                        print_type |= PrintType::Path;
+                    if (line_numbers)
+                        print_type |= PrintType::LineNumbers;
+
+                    if ((result.matches.size() || invert_match) && has_any_flag(print_type, PrintType::Path | PrintType::LineNumbers)) {
+                        StringBuilder filename_builder;
+                        append_formatted_path(filename_builder, filename, line_number, print_type, !disable_hyperlinks, colored_output);
+                        out("{}:"sv, filename_builder.string_view());
+                    }
 
                     for (auto& match : result.matches) {
                         auto pre_match_length = match.global_offset - last_printed_char_pos;
@@ -244,12 +313,10 @@ ErrorOr<int> serenity_main(Main::Arguments args)
 
         auto exit_status = ExitStatus::NoLinesMatched;
 
-        auto handle_file = [&matches, binary_mode, count_lines, quiet_mode,
+        auto handle_file = [&matches, binary_mode, count_lines, quiet_mode, disable_hyperlinks, colored_output,
                                &matched_line_count, &exit_status](StringView filename, bool print_filename) -> ErrorOr<void> {
             auto file = TRY(Core::File::open_file_or_standard_stream(filename, Core::File::OpenMode::Read));
             auto buffered_file = TRY(Core::InputBufferedFile::create(move(file)));
-            if (filename == '-')
-                filename = "stdin"sv;
 
             for (size_t line_number = 1; TRY(buffered_file->can_read_line()); ++line_number) {
                 Array<u8, PAGE_SIZE> buffer;
@@ -267,10 +334,12 @@ ErrorOr<int> serenity_main(Main::Arguments args)
             }
 
             if (count_lines && !quiet_mode) {
-                if (print_filename)
-                    outln("{}:{}", filename, matched_line_count);
-                else
-                    outln("{}", matched_line_count);
+                if (print_filename) {
+                    StringBuilder filename_builder;
+                    append_formatted_path(filename_builder, filename, {}, PrintType::Path, !disable_hyperlinks, colored_output);
+                    out("{}:", filename_builder.string_view());
+                }
+                outln("{}", matched_line_count);
                 matched_line_count = 0;
             }
 

--- a/Userland/Utilities/grep.cpp
+++ b/Userland/Utilities/grep.cpp
@@ -299,10 +299,8 @@ ErrorOr<int> serenity_main(Main::Arguments args)
             bool print_filename { files.size() > 1 };
             for (auto& filename : files) {
                 auto result = handle_file(filename, print_filename);
-                if (result.is_error()) {
-                    if (!suppress_errors)
-                        warnln("Failed with file {}: {}", filename, result.release_error());
-                    return 1;
+                if (result.is_error() && !suppress_errors) {
+                    warnln("Failed with file {}: {}", filename, result.release_error());
                 }
             }
         }

--- a/Userland/Utilities/grep.cpp
+++ b/Userland/Utilities/grep.cpp
@@ -272,7 +272,8 @@ ErrorOr<int> serenity_main(Main::Arguments args)
             while (it.has_next()) {
                 auto path = it.next_full_path();
                 if (!FileSystem::is_directory(path)) {
-                    auto key = user_has_specified_files ? path.view() : path.substring_view(base.length() + 1, path.length() - base.length() - 1);
+                    // Remove leading './' when `grep -r` was run without any specified paths.
+                    auto key = user_has_specified_files ? path.view() : path.substring_view(base.length() + 1);
                     if (auto result = handle_file(key, true); result.is_error() && !suppress_errors)
                         warnln("Failed with file {}: {}", key, result.release_error());
 

--- a/Userland/Utilities/grep.cpp
+++ b/Userland/Utilities/grep.cpp
@@ -186,7 +186,6 @@ ErrorOr<int> serenity_main(Main::Arguments args)
         patterns.append(files.take_first());
 
     auto user_has_specified_files = !files.is_empty();
-    auto user_specified_multiple_files = files.size() >= 2;
 
     PosixOptions options {};
     if (case_insensitive)
@@ -246,7 +245,7 @@ ErrorOr<int> serenity_main(Main::Arguments args)
         auto exit_status = ExitStatus::NoLinesMatched;
 
         auto handle_file = [&matches, binary_mode, count_lines, quiet_mode,
-                               user_specified_multiple_files, &matched_line_count, &exit_status](StringView filename, bool print_filename) -> ErrorOr<void> {
+                               &matched_line_count, &exit_status](StringView filename, bool print_filename) -> ErrorOr<void> {
             auto file = TRY(Core::File::open_file_or_standard_stream(filename, Core::File::OpenMode::Read));
             auto buffered_file = TRY(Core::InputBufferedFile::create(move(file)));
             if (filename == '-')
@@ -268,7 +267,7 @@ ErrorOr<int> serenity_main(Main::Arguments args)
             }
 
             if (count_lines && !quiet_mode) {
-                if (user_specified_multiple_files)
+                if (print_filename)
                     outln("{}:{}", filename, matched_line_count);
                 else
                     outln("{}", matched_line_count);

--- a/Userland/Utilities/grep.cpp
+++ b/Userland/Utilities/grep.cpp
@@ -241,8 +241,10 @@ ErrorOr<int> serenity_main(Main::Arguments args)
 
         auto handle_file = [&matches, binary_mode, count_lines, quiet_mode,
                                user_specified_multiple_files, &matched_line_count, &did_match_something](StringView filename, bool print_filename) -> ErrorOr<void> {
-            auto file = TRY(Core::File::open(filename, Core::File::OpenMode::Read));
+            auto file = TRY(Core::File::open_file_or_standard_stream(filename, Core::File::OpenMode::Read));
             auto buffered_file = TRY(Core::InputBufferedFile::create(move(file)));
+            if (filename == '-')
+                filename = "stdin"sv;
 
             for (size_t line_number = 1; TRY(buffered_file->can_read_line()); ++line_number) {
                 Array<u8, PAGE_SIZE> buffer;
@@ -283,51 +285,24 @@ ErrorOr<int> serenity_main(Main::Arguments args)
             }
         };
 
-        if (!files.size() && !recursive) {
-            char* line = nullptr;
-            size_t line_len = 0;
-            ssize_t nread = 0;
-            ScopeGuard free_line = [line] { free(line); };
-            size_t line_number = 0;
-            while ((nread = getline(&line, &line_len, stdin)) != -1) {
-                VERIFY(nread > 0);
-                if (line[nread - 1] == '\n')
-                    --nread;
-                // Human-readable indexes start at 1, so it's fine to increment already.
-                line_number += 1;
-                StringView line_view(line, nread);
-                bool is_binary = line_view.contains('\0');
+        if (recursive) {
+            if (!user_has_specified_files)
+                files.append("."sv);
 
-                if (is_binary && binary_mode == BinaryFileMode::Skip)
-                    return 1;
-
-                auto matched = matches(line_view, "stdin"sv, line_number, false, is_binary);
-                did_match_something = did_match_something || matched;
-                if (matched && is_binary && binary_mode == BinaryFileMode::Binary)
-                    break;
+            for (auto& filename : files) {
+                add_directory(filename, {}, add_directory);
             }
-
-            if (count_lines && !quiet_mode)
-                outln("{}", matched_line_count);
         } else {
-            if (recursive) {
-                if (user_has_specified_files) {
-                    for (auto& filename : files) {
-                        add_directory(filename, {}, add_directory);
-                    }
-                } else {
-                    add_directory(".", {}, add_directory);
-                }
+            if (!user_has_specified_files)
+                files.append("-"sv);
 
-            } else {
-                bool print_filename { files.size() > 1 };
-                for (auto& filename : files) {
-                    auto result = handle_file(filename, print_filename);
-                    if (result.is_error()) {
-                        if (!suppress_errors)
-                            warnln("Failed with file {}: {}", filename, result.release_error());
-                        return 1;
-                    }
+            bool print_filename { files.size() > 1 };
+            for (auto& filename : files) {
+                auto result = handle_file(filename, print_filename);
+                if (result.is_error()) {
+                    if (!suppress_errors)
+                        warnln("Failed with file {}: {}", filename, result.release_error());
+                    return 1;
                 }
             }
         }


### PR DESCRIPTION
- **Add comment describing why we take leading characters from paths**
- **Remove separate stdin handling logic**

  Previously we had two somewhat duplicated methods: one just for handling stdin with the standard C API, and the other one used for everything else with our Core::File class. By using always Core::File, the code should be now a little bit cleaner.

  Additionally, grep will now use the standard input when it finds a '-' argument (previously it tried to open a file with that name.)

  ![screenshot](https://github.com/SerenityOS/serenity/assets/16520278/c211e2f0-5ccc-4488-b651-a602a2fb8f80)

- **Don't end the program early after failing to grep a file**

  We should still try to read remaining files.

  ![screenshot](https://github.com/SerenityOS/serenity/assets/16520278/8d581514-e3a8-4795-8011-493ee92dcf5b)

- **Return exit code '2' on error**  
- **Print filenames when counting lines and path size is less than 2**

  `grep --count --recursive foo` doesn't specify any file, but we should show the paths anyway.

  ![screenshot](https://github.com/SerenityOS/serenity/assets/16520278/1f99c523-df99-40da-82ed-0e95c4c410f7)

- **Hyperlink filenames in tty**

  As the newly created function has been also applied to printing the number of matched file lines, file names will now also be colored with the `--count` option set. :^)

  ![screenshot](https://github.com/SerenityOS/serenity/assets/16520278/f7afaf0c-8235-45a0-93d2-77c4f88b4606)

