### PR TITLE
Base+Solitaire: Update Snake & Flappy Bug manpages + Rearrange Solitaire Help Menu

### DIFF
--- a/Base/usr/share/man/man6/FlappyBug.md
+++ b/Base/usr/share/man/man6/FlappyBug.md
@@ -12,6 +12,8 @@ $ FlappyBug
 
 ## Description
 
-Flappy Bug is a SerenityOS themed version of the 2013 game Flappy Bird.
+`Flappy Bug` is a SerenityOS themed version of the 2013 game [Flappy Bird](https://en.wikipedia.org/wiki/Flappy_Bird).
 
-The goal of the game is to survive with Buggie as long as possible by avoiding obstacles. Buggie automatically descends by gravity and ascends when you press any key. Press the escape key to give up.
+The goal is to keep Flappy Bug alive as long as possible by avoiding obstacles. Flappy Bug will automatically descend due to gravity and will ascend when you press any key.
+
+Press `Esc` to quit.

--- a/Base/usr/share/man/man6/Snake.md
+++ b/Base/usr/share/man/man6/Snake.md
@@ -11,5 +11,13 @@ $ Snake
 ```
 
 ## Description
+`Snake` is an arcade game in which you navigate Snake to eat food. With each item of food you eat Snake grows longer by one block. The challenge is to keep growing without colliding with yourself. Once this happens, the game is over.
 
-Grow the snake as large as possible by eating the fruits and not crashing into itself.
+Use the arrow keys to move Up, Down, Left and Right or alternatively use `W`, `A`, `S`, `D`.
+Moving into any edge will teleport Snake to the opposite edge.
+
+Press `Spacebar` to pause and unpause the game.
+
+Customize Snake's default color or change its appearance with one of the included skins in the `Game` menu. Bonus skins are available in the [Serenity Theming Port](https://github.com/SerenityOS/theming).
+
+Trivia: the food is what snakes actually eat. The glyphs are from the [SerenityOS Emoji font](https://emoji.serenityos.org).

--- a/Userland/Games/Solitaire/main.cpp
+++ b/Userland/Games/Solitaire/main.cpp
@@ -222,11 +222,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto help_menu = window->add_menu("&Help"_string);
     help_menu->add_action(GUI::CommonActions::make_command_palette_action(window));
-    help_menu->add_action(GUI::CommonActions::make_about_action("Solitaire"_string, app_icon, window));
-
     help_menu->add_action(GUI::CommonActions::make_help_action([&man_file](auto&) {
         Desktop::Launcher::open(URL::create_with_file_scheme(man_file), "/bin/Help");
     }));
+    help_menu->add_action(GUI::CommonActions::make_about_action("Solitaire"_string, app_icon, window));
 
     window->set_resizable(false);
     window->resize(Solitaire::Game::width, Solitaire::Game::height + statusbar.max_height().as_int());


### PR DESCRIPTION
These commits contribute towards #21091:
* Update the Snake & Flappy Bug manpages to read better with more detail
* Rearrange Solitaire's `Help` menu so the actions are in the same order as other application's Help menus

**Before:**
<img width="330" alt="Before" src="https://github.com/SerenityOS/serenity/assets/7754483/fadee27f-966d-4956-99bd-57e6e2bd415a">

**After:**
<img width="334" alt="After" src="https://github.com/SerenityOS/serenity/assets/7754483/9f0438ea-1a2a-48e7-b30f-07c9673ac110">
