### PR TITLE
Kernel: Add USB mouse support

### DIFF
--- a/Base/usr/share/man/man7/boot_parameters.md
+++ b/Base/usr/share/man/man7/boot_parameters.md
@@ -28,6 +28,8 @@ List of options:
    during the boot sequence. Leaving only the AHCI and Ram Disk controllers.
 
 * **`disable_physical_storage`** - If present on the command line, neither AHCI, or IDE controllers will be initialized on boot.
+
+* **`disable_ps2_mouse`** - If present on the command line, no PS2 mouse will be attached.
     
 * **`disable_uhci_controller`** - If present on the command line, the UHCI controller will not be initialized on boot.
 

--- a/Kernel/Arch/x86_64/ISABus/I8042Controller.cpp
+++ b/Kernel/Arch/x86_64/ISABus/I8042Controller.cpp
@@ -8,6 +8,7 @@
 #include <Kernel/Arch/x86_64/IO.h>
 #include <Kernel/Arch/x86_64/ISABus/HID/VMWareMouseDevice.h>
 #include <Kernel/Arch/x86_64/ISABus/I8042Controller.h>
+#include <Kernel/Boot/CommandLine.h>
 #include <Kernel/Bus/SerialIO/Device.h>
 #include <Kernel/Devices/HID/KeyboardDevice.h>
 #include <Kernel/Devices/HID/MouseDevice.h>
@@ -216,7 +217,7 @@ UNMAP_AFTER_INIT ErrorOr<void> I8042Controller::detect_devices()
             m_first_ps2_port.device = error_or_device.release_value();
         }
     }
-    if (m_second_port_available) {
+    if (m_second_port_available && !kernel_command_line().disable_ps2_mouse()) {
         // FIXME: Actually figure out the connected PS2 device type
         m_second_ps2_port.device_type = PS2DeviceType::StandardMouse;
         auto mouse_device = TRY(MouseDevice::try_to_initialize());

--- a/Kernel/Boot/CommandLine.cpp
+++ b/Kernel/Boot/CommandLine.cpp
@@ -226,6 +226,11 @@ UNMAP_AFTER_INIT bool CommandLine::is_physical_networking_disabled() const
     return contains("disable_physical_networking"sv);
 }
 
+UNMAP_AFTER_INIT bool CommandLine::disable_ps2_mouse() const
+{
+    return contains("disable_ps2_mouse"sv);
+}
+
 UNMAP_AFTER_INIT bool CommandLine::disable_physical_storage() const
 {
     return contains("disable_physical_storage"sv);

--- a/Kernel/Boot/CommandLine.h
+++ b/Kernel/Boot/CommandLine.h
@@ -90,6 +90,7 @@ public:
     [[nodiscard]] PanicMode panic_mode(Validate should_validate = Validate::No) const;
     [[nodiscard]] HPETMode hpet_mode() const;
     [[nodiscard]] bool disable_physical_storage() const;
+    [[nodiscard]] bool disable_ps2_mouse() const;
     [[nodiscard]] bool disable_uhci_controller() const;
     [[nodiscard]] bool disable_usb() const;
     [[nodiscard]] bool disable_virtio() const;

--- a/Kernel/Bus/USB/Drivers/HID/Codes.h
+++ b/Kernel/Bus/USB/Drivers/HID/Codes.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2023, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/StdLibExtraDetails.h>
+#include <AK/StringView.h>
+#include <AK/Types.h>
+
+namespace Kernel::USB::HID {
+
+enum class SubclassCode : u8 {
+    BootProtocol = 0x01,
+};
+
+struct [[gnu::packed]] MouseBootProtocolPacket {
+    u8 buttons;
+    i8 x;
+    i8 y;
+    i8 z;
+    i8 reserved1;
+    i8 reserved2;
+};
+
+static_assert(AssertSize<MouseBootProtocolPacket, 6>());
+
+constexpr StringView subclass_string(SubclassCode code)
+{
+    switch (code) {
+    case SubclassCode::BootProtocol:
+        return "Boot Protocol"sv;
+    }
+
+    return "Reserved"sv;
+}
+
+enum class InterfaceProtocol : u8 {
+    Mouse = 0x02,
+};
+
+}

--- a/Kernel/Bus/USB/Drivers/HID/MouseDriver.cpp
+++ b/Kernel/Bus/USB/Drivers/HID/MouseDriver.cpp
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2023, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Find.h>
+#include <Kernel/Bus/USB/Drivers/HID/Codes.h>
+#include <Kernel/Bus/USB/Drivers/HID/MouseDriver.h>
+#include <Kernel/Bus/USB/USBClasses.h>
+#include <Kernel/Bus/USB/USBEndpoint.h>
+#include <Kernel/Bus/USB/USBRequest.h>
+#include <Kernel/Devices/DeviceManagement.h>
+#include <Kernel/Devices/HID/Management.h>
+
+namespace Kernel::USB {
+
+USB_DEVICE_DRIVER(MouseDriver);
+
+void MouseDriver::init()
+{
+    auto driver = MUST(adopt_nonnull_lock_ref_or_enomem(new MouseDriver()));
+    USBManagement::the().register_driver(driver);
+}
+
+ErrorOr<void> MouseDriver::checkout_interface(USB::Device& device, USBInterface const& interface)
+{
+    auto const& descriptor = interface.descriptor();
+    if (descriptor.interface_class_code == USB_CLASS_HID
+        && descriptor.interface_sub_class_code == to_underlying(HID::SubclassCode::BootProtocol)
+        && descriptor.interface_protocol == to_underlying(HID::InterfaceProtocol::Mouse)) {
+        dmesgln("USB HID Mouse Interface for device {:#04x}:{:#04x} found", device.device_descriptor().vendor_id, device.device_descriptor().product_id);
+        return initialize_device(device, interface);
+    }
+    return ENOTSUP;
+}
+
+ErrorOr<void> MouseDriver::probe(USB::Device& device)
+{
+    if (device.device_descriptor().device_class != USB_CLASS_DEVICE
+        || device.device_descriptor().device_sub_class != 0x00
+        || device.device_descriptor().device_protocol != 0x00)
+        return ENOTSUP;
+    // FIXME: Are we guaranteed to have one USB configuration for a mouse device?
+    if (device.configurations().size() != 1)
+        return ENOTSUP;
+    // FIXME: If we have multiple USB configurations for a mouse device, find the appropriate one
+    // and handle multiple interfaces for it.
+    if (device.configurations()[0].interfaces().size() != 1)
+        return ENOTSUP;
+
+    TRY(checkout_interface(device, device.configurations()[0].interfaces()[0]));
+
+    return ENOTSUP;
+}
+
+ErrorOr<void> MouseDriver::initialize_device(USB::Device& device, USBInterface const& interface)
+{
+    if (interface.endpoints().size() != 1)
+        return ENOTSUP;
+    auto const& configuration = interface.configuration();
+    // FIXME: Should we check other configurations?
+    TRY(device.control_transfer(
+        USB_REQUEST_RECIPIENT_DEVICE | USB_REQUEST_TYPE_STANDARD | USB_REQUEST_TRANSFER_DIRECTION_HOST_TO_DEVICE,
+        USB_REQUEST_SET_CONFIGURATION, configuration.configuration_id(), 0, 0, nullptr));
+
+    auto const& endpoint_descriptor = interface.endpoints()[0];
+    auto interrupt_in_pipe = TRY(USB::InterruptInPipe::create(device.controller(), endpoint_descriptor.endpoint_address, endpoint_descriptor.max_packet_size, device.address(), 10));
+    auto mouse_device = TRY(USBMouseDevice::try_create_instance(device, endpoint_descriptor.max_packet_size, move(interrupt_in_pipe)));
+    HIDManagement::the().attach_standalone_hid_device(*mouse_device);
+    m_interfaces.append(mouse_device);
+    return {};
+}
+
+void MouseDriver::detach(USB::Device& device)
+{
+    auto&& mouse_device = AK::find_if(m_interfaces.begin(), m_interfaces.end(), [&device](auto& interface) { return &interface.device() == &device; });
+
+    HIDManagement::the().detach_standalone_hid_device(*mouse_device);
+    m_interfaces.remove(*mouse_device);
+}
+
+}

--- a/Kernel/Bus/USB/Drivers/HID/MouseDriver.h
+++ b/Kernel/Bus/USB/Drivers/HID/MouseDriver.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2023, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <Kernel/Bus/USB/Drivers/USBDriver.h>
+#include <Kernel/Bus/USB/USBInterface.h>
+#include <Kernel/Bus/USB/USBManagement.h>
+#include <Kernel/Devices/HID/USB/MouseDevice.h>
+
+namespace Kernel::USB {
+
+class MouseDriver final : public Driver {
+public:
+    MouseDriver()
+        : Driver("USB Mouse"sv)
+    {
+    }
+
+    static void init();
+
+    virtual ~MouseDriver() override = default;
+
+    virtual ErrorOr<void> probe(USB::Device&) override;
+    virtual void detach(USB::Device&) override;
+
+private:
+    USBMouseDevice::List m_interfaces;
+
+    ErrorOr<void> checkout_interface(USB::Device&, USBInterface const&);
+
+    ErrorOr<void> initialize_device(USB::Device&, USBInterface const&);
+};
+
+}

--- a/Kernel/Bus/USB/UHCI/UHCIController.cpp
+++ b/Kernel/Bus/USB/UHCI/UHCIController.cpp
@@ -561,6 +561,11 @@ size_t UHCIController::poll_transfer_queue(QueueHead& transfer_queue)
     while (descriptor) {
         u32 status = descriptor->status();
 
+        if (status & TransferDescriptor::StatusBits::NAKReceived) {
+            transfer_still_in_progress = false;
+            break;
+        }
+
         if (status & TransferDescriptor::StatusBits::Active) {
             transfer_still_in_progress = true;
             break;

--- a/Kernel/Bus/USB/USBTransfer.cpp
+++ b/Kernel/Bus/USB/USBTransfer.cpp
@@ -61,6 +61,8 @@ ErrorOr<void> Transfer::write_buffer(u16 len, UserOrKernelBuffer data)
 
 void Transfer::invoke_async_callback()
 {
+    if (transfer_data_size() == 0)
+        return;
     if (m_callback)
         m_callback(this);
 }

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -33,6 +33,7 @@ set(KERNEL_SOURCES
     Bus/PCI/DeviceIdentifier.cpp
     Bus/USB/UHCI/UHCIController.cpp
     Bus/USB/UHCI/UHCIRootHub.cpp
+    Bus/USB/Drivers/HID/MouseDriver.cpp
     Bus/USB/Drivers/MassStorage/MassStorageDriver.cpp
     Bus/USB/USBConfiguration.cpp
     Bus/USB/USBController.cpp
@@ -73,6 +74,7 @@ set(KERNEL_SOURCES
     Devices/HID/MouseDevice.cpp
     Devices/HID/PS2/KeyboardDevice.cpp
     Devices/HID/PS2/MouseDevice.cpp
+    Devices/HID/USB/MouseDevice.cpp
     Devices/Generic/ConsoleDevice.cpp
     Devices/Generic/DeviceControlDevice.cpp
     Devices/Generic/FullDevice.cpp

--- a/Kernel/Devices/HID/Device.h
+++ b/Kernel/Devices/HID/Device.h
@@ -11,7 +11,9 @@
 
 namespace Kernel {
 
+class HIDManagement;
 class HIDDevice : public CharacterDevice {
+    friend class HIDManagement;
 
 protected:
     HIDDevice(MajorNumber major, MinorNumber minor)
@@ -20,6 +22,8 @@ protected:
     }
 
     EntropySource m_entropy_source;
+
+    IntrusiveListNode<HIDDevice, NonnullRefPtr<HIDDevice>> m_list_node;
 };
 
 }

--- a/Kernel/Devices/HID/Management.cpp
+++ b/Kernel/Devices/HID/Management.cpp
@@ -115,6 +115,20 @@ void HIDManagement::set_maps(NonnullOwnPtr<KString> character_map_name, Keyboard
     });
 }
 
+void HIDManagement::detach_standalone_hid_device(HIDDevice& device)
+{
+    m_standalone_hid_devices.with([&](auto& list) {
+        list.remove(device);
+    });
+}
+
+void HIDManagement::attach_standalone_hid_device(HIDDevice& device)
+{
+    m_standalone_hid_devices.with([&](auto& list) {
+        list.append(device);
+    });
+}
+
 UNMAP_AFTER_INIT ErrorOr<void> HIDManagement::enumerate()
 {
     // FIXME: When we have USB HID support, we should ensure that we disable

--- a/Kernel/Devices/HID/Management.h
+++ b/Kernel/Devices/HID/Management.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/Atomic.h>
+#include <AK/Badge.h>
 #include <AK/CircularQueue.h>
 #include <AK/Error.h>
 #include <AK/IntrusiveList.h>
@@ -15,6 +16,7 @@
 #include <AK/Types.h>
 #include <Kernel/API/KeyCode.h>
 #include <Kernel/Bus/SerialIO/Controller.h>
+#include <Kernel/Devices/HID/Device.h>
 #include <Kernel/Locking/Spinlock.h>
 #include <Kernel/Locking/SpinlockProtected.h>
 #include <Kernel/UnixTypes.h>
@@ -51,6 +53,9 @@ public:
     void set_client(KeyboardClient* client);
     void set_maps(NonnullOwnPtr<KString> character_map_name, Keyboard::CharacterMapData const& character_map);
 
+    void attach_standalone_hid_device(HIDDevice&);
+    void detach_standalone_hid_device(HIDDevice&);
+
 private:
     size_t generate_minor_device_number_for_mouse();
     size_t generate_minor_device_number_for_keyboard();
@@ -61,6 +66,10 @@ private:
     KeyboardClient* m_client { nullptr };
 
     SpinlockProtected<IntrusiveList<&SerialIOController::m_list_node>, LockRank::None> m_hid_serial_io_controllers;
+    // NOTE: This list is used for standalone devices, like USB HID devices
+    // (which are not attached via a SerialIO controller in the sense that
+    // there's no specific serial IO controller to coordinate their usage).
+    SpinlockProtected<IntrusiveList<&HIDDevice::m_list_node>, LockRank::None> m_standalone_hid_devices;
     Spinlock<LockRank::None> m_client_lock;
 };
 

--- a/Kernel/Devices/HID/USB/MouseDevice.cpp
+++ b/Kernel/Devices/HID/USB/MouseDevice.cpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2022, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Try.h>
+#include <AK/TypedTransfer.h>
+#include <Kernel/Bus/USB/Drivers/HID/Codes.h>
+#include <Kernel/Bus/USB/USBController.h>
+#include <Kernel/Bus/USB/USBDescriptors.h>
+#include <Kernel/Bus/USB/USBRequest.h>
+#include <Kernel/Bus/USB/USBTransfer.h>
+#include <Kernel/Devices/DeviceManagement.h>
+#include <Kernel/Devices/HID/USB/MouseDevice.h>
+#include <Kernel/Library/KString.h>
+
+namespace Kernel {
+
+ErrorOr<NonnullRefPtr<USBMouseDevice>> USBMouseDevice::try_create_instance(USB::Device const& usb_device, size_t max_packet_size, NonnullOwnPtr<USB::InterruptInPipe> pipe)
+{
+    if (max_packet_size < 4)
+        return Error::from_errno(ENOTSUP);
+    auto device = TRY(DeviceManagement::try_create_device<USBMouseDevice>(usb_device, move(pipe)));
+    TRY(device->create_and_start_polling_process(max_packet_size));
+    return *device;
+}
+
+ErrorOr<void> USBMouseDevice::create_and_start_polling_process(size_t max_packet_size)
+{
+    VERIFY(max_packet_size >= 4);
+    [[maybe_unused]] auto interrupt_in_transfer = TRY(m_interrupt_in_pipe->submit_interrupt_in_transfer(max_packet_size, 10, [this](auto* transfer) {
+        USB::HID::MouseBootProtocolPacket packet_raw;
+        memcpy(&packet_raw, transfer->buffer().as_ptr(), 4);
+        MousePacket packet;
+        packet.buttons = packet_raw.buttons & 0x07;
+        packet.x = packet_raw.x;
+        packet.y = -packet_raw.y;
+        packet.z = -packet_raw.z;
+        packet.w = 0;
+        packet.is_relative = true;
+
+        handle_mouse_packet_input_event(packet);
+    }));
+    return {};
+}
+
+USBMouseDevice::USBMouseDevice(USB::Device const& usb_device, NonnullOwnPtr<USB::InterruptInPipe> pipe)
+    : MouseDevice()
+    , m_interrupt_in_pipe(move(pipe))
+    , m_attached_usb_device(usb_device)
+{
+}
+
+}

--- a/Kernel/Devices/HID/USB/MouseDevice.h
+++ b/Kernel/Devices/HID/USB/MouseDevice.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2022-2023, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Badge.h>
+#include <AK/CircularQueue.h>
+#include <AK/OwnPtr.h>
+#include <AK/RefPtr.h>
+#include <Kernel/API/MousePacket.h>
+#include <Kernel/Bus/USB/USBDevice.h>
+#include <Kernel/Bus/USB/USBPipe.h>
+#include <Kernel/Devices/HID/MouseDevice.h>
+#include <Kernel/Library/KString.h>
+#include <Kernel/Security/Random.h>
+
+namespace Kernel {
+
+class USBMouseDevice final : public MouseDevice {
+    friend class DeviceManagement;
+
+public:
+    static ErrorOr<NonnullRefPtr<USBMouseDevice>> try_create_instance(USB::Device const&, size_t max_packet_size, NonnullOwnPtr<USB::InterruptInPipe> pipe);
+    virtual ~USBMouseDevice() override {};
+
+    USB::Device const& device() const { return *m_attached_usb_device; }
+
+private:
+    ErrorOr<void> create_and_start_polling_process(size_t max_packet_size);
+
+    USBMouseDevice(USB::Device const&, NonnullOwnPtr<USB::InterruptInPipe> pipe);
+    NonnullOwnPtr<USB::InterruptInPipe> m_interrupt_in_pipe;
+    NonnullRefPtr<USB::Device> m_attached_usb_device;
+
+    IntrusiveListNode<USBMouseDevice, NonnullRefPtr<USBMouseDevice>> m_list_node;
+
+public:
+    using List = IntrusiveList<&USBMouseDevice::m_list_node>;
+};
+
+}


### PR DESCRIPTION
To test this, add the following parameters to `run.sh`:
```
-M pc,i8042=off
-machine vmport=off
-device usb-mouse
```

Derived from #18673. We can get this merged quite quickly and later on figure out the details for HID keyboards, including USB ones.

cc @FireFox317 