### PR TITLE
LibJS: Avoid pointless HashTable copying during GC mark phase

### DIFF
--- a/Userland/Libraries/LibJS/Heap/Heap.cpp
+++ b/Userland/Libraries/LibJS/Heap/Heap.cpp
@@ -114,7 +114,7 @@ static void add_possible_value(HashMap<FlatPtr, HeapRootTypeOrLocation>& possibl
 }
 
 template<typename Callback>
-static void for_each_cell_among_possible_pointers(HashTable<HeapBlock*> all_live_heap_blocks, HashMap<FlatPtr, HeapRootTypeOrLocation>& possible_pointers, Callback callback)
+static void for_each_cell_among_possible_pointers(HashTable<HeapBlock*> const& all_live_heap_blocks, HashMap<FlatPtr, HeapRootTypeOrLocation>& possible_pointers, Callback callback)
 {
     for (auto possible_pointer : possible_pointers.keys()) {
         if (!possible_pointer)


### PR DESCRIPTION
for_each_cell_among_possible_pointers() was taking HashTable by value instead of by const reference for no reason.

The copying was soaking up ~4% of CPU time while loading https://x.com/