### PR TITLE
Kernel/USB: Add a basic Driver interface

### DIFF
--- a/Kernel/Arch/aarch64/linker.ld
+++ b/Kernel/Arch/aarch64/linker.ld
@@ -31,6 +31,13 @@ SECTIONS
         *(.text*)
     } :text
 
+    .driver_init ALIGN(4K) : AT (ADDR(.driver_init))
+    {
+        driver_init_table_start = .;
+        *(.driver_init)
+        driver_init_table_end = .;
+    } :text
+
     .rodata ALIGN(4K) : AT (ADDR(.rodata) - KERNEL_MAPPING_BASE)
     {
         start_heap_ctors = .;

--- a/Kernel/Arch/riscv64/linker.ld
+++ b/Kernel/Arch/riscv64/linker.ld
@@ -39,6 +39,13 @@ SECTIONS
         end_of_kernel_text = .;
     } :text
 
+    .driver_init ALIGN(4K) : AT (ADDR(.driver_init))
+    {
+        driver_init_table_start = .;
+        *(.driver_init)
+        driver_init_table_end = .;
+    } :text
+
     .rodata ALIGN(4K) :
     {
         start_heap_ctors = .;

--- a/Kernel/Arch/x86_64/linker.ld
+++ b/Kernel/Arch/x86_64/linker.ld
@@ -38,6 +38,13 @@ SECTIONS
         *(.text*)
     } :text
 
+    .driver_init ALIGN(4K) : AT (ADDR(.driver_init))
+    {
+        driver_init_table_start = .;
+        *(.driver_init)
+        driver_init_table_end = .;
+    } :text
+
     .unmap_after_init ALIGN(4K) : AT (ADDR(.unmap_after_init))
     {
         start_of_unmap_after_init = .;

--- a/Kernel/Bus/USB/Drivers/USBDriver.h
+++ b/Kernel/Bus/USB/Drivers/USBDriver.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2023, Jesse Buhagiar <jesse.buhagiar@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/AtomicRefCounted.h>
+#include <AK/Error.h>
+#include <AK/NonnullRefPtr.h>
+
+namespace Kernel::USB {
+
+class Device;
+struct USBDeviceDescriptor;
+class USBInterface;
+
+class Driver : public AtomicRefCounted<Driver> {
+public:
+    Driver(StringView name)
+        : m_driver_name(name)
+    {
+    }
+
+    virtual ~Driver() = default;
+
+    virtual ErrorOr<void> probe(USB::Device&) = 0;
+    virtual void detach(USB::Device&) = 0;
+    StringView name() const { return m_driver_name; }
+
+protected:
+    StringView const m_driver_name;
+};
+}

--- a/Kernel/Bus/USB/Drivers/USBDriver.h
+++ b/Kernel/Bus/USB/Drivers/USBDriver.h
@@ -12,6 +12,10 @@
 
 namespace Kernel::USB {
 
+using DriverInitFunction = void (*)();
+#define USB_DEVICE_DRIVER(driver_name) \
+    DriverInitFunction driver_init_function_ptr_##driver_name __attribute__((section(".driver_init"), used)) = &driver_name::init
+
 class Device;
 struct USBDeviceDescriptor;
 class USBInterface;

--- a/Kernel/Bus/USB/USBDevice.cpp
+++ b/Kernel/Bus/USB/USBDevice.cpp
@@ -39,6 +39,7 @@ ErrorOr<NonnullLockRefPtr<Device>> Device::try_create(USBController const& contr
         if (result.is_error())
             continue;
         dbgln_if(USB_DEBUG, "Found driver {} for device {:04x}:{:04x}!", driver->name(), device->m_vendor_id, device->m_product_id);
+        device->set_driver(driver);
         break;
     }
 

--- a/Kernel/Bus/USB/USBDevice.h
+++ b/Kernel/Bus/USB/USBDevice.h
@@ -10,6 +10,7 @@
 #include <AK/OwnPtr.h>
 #include <AK/Types.h>
 #include <AK/Vector.h>
+#include <Kernel/Bus/USB/Drivers/USBDriver.h>
 #include <Kernel/Bus/USB/USBConfiguration.h>
 #include <Kernel/Bus/USB/USBPipe.h>
 #include <Kernel/Locking/SpinlockProtected.h>
@@ -58,6 +59,14 @@ public:
 
     Vector<USBConfiguration> const& configurations() const { return m_configurations; }
 
+    void set_driver(Driver& driver) { m_driver = driver; }
+    void detach()
+    {
+        if (m_driver)
+            m_driver->detach(*this);
+        m_driver = nullptr;
+    }
+
     SpinlockProtected<RefPtr<SysFSUSBDeviceInformation>, LockRank::None>& sysfs_device_info_node(Badge<USB::Hub>) { return m_sysfs_device_info_node; }
 
 protected:
@@ -75,6 +84,8 @@ protected:
 
     NonnullLockRefPtr<USBController> m_controller;
     NonnullOwnPtr<ControlPipe> m_default_pipe; // Default communication pipe (endpoint0) used during enumeration
+
+    LockRefPtr<Driver> m_driver;
 
 private:
     IntrusiveListNode<Device, NonnullLockRefPtr<Device>> m_hub_child_node;

--- a/Kernel/Bus/USB/USBHub.cpp
+++ b/Kernel/Bus/USB/USBHub.cpp
@@ -295,6 +295,9 @@ void Hub::check_for_port_updates()
                         auto* hub_child = static_cast<Hub*>(device_to_remove.ptr());
                         hub_child->remove_children_from_sysfs();
                     }
+
+                    device_to_remove->detach();
+
                     m_children.remove(*device_to_remove);
                 } else {
                     dbgln_if(USB_DEBUG, "USB Hub: No child set up on port {}, ignoring detachment.", port_number);

--- a/Kernel/Bus/USB/USBInterface.h
+++ b/Kernel/Bus/USB/USBInterface.h
@@ -26,6 +26,7 @@ public:
     Vector<USBEndpointDescriptor> const& endpoints() const { return m_endpoint_descriptors; }
 
     USBInterfaceDescriptor const& descriptor() const { return m_descriptor; }
+    USBConfiguration const& configuration() const { return m_configuration; }
 
 private:
     USBConfiguration const& m_configuration;              // Configuration that this interface belongs to

--- a/Kernel/Bus/USB/USBManagement.cpp
+++ b/Kernel/Bus/USB/USBManagement.cpp
@@ -81,6 +81,12 @@ void USBManagement::register_driver(NonnullLockRefPtr<Driver> driver)
     m_available_drivers.append(driver);
 }
 
+LockRefPtr<Driver> USBManagement::get_driver_by_name(StringView name)
+{
+    auto it = m_available_drivers.find_if([name](auto driver) { return driver->name() == name; });
+    return it.is_end() ? nullptr : LockRefPtr { *it };
+}
+
 void USBManagement::unregister_driver(NonnullLockRefPtr<Driver> driver)
 {
     dbgln_if(USB_DEBUG, "Unregistering driver {}", driver->name());

--- a/Kernel/Bus/USB/USBManagement.cpp
+++ b/Kernel/Bus/USB/USBManagement.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, Luke Wilde <lukew@serenityos.org>
+ * Copyright (c) 2023, Jesse Buhagiar <jesse.buhagiar@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -72,6 +73,20 @@ UNMAP_AFTER_INIT void USBManagement::initialize()
     }
 
     s_the.ensure_instance();
+}
+
+void USBManagement::register_driver(NonnullLockRefPtr<Driver> driver)
+{
+    dbgln_if(USB_DEBUG, "Registering driver {}", driver->name());
+    m_available_drivers.append(driver);
+}
+
+void USBManagement::unregister_driver(NonnullLockRefPtr<Driver> driver)
+{
+    dbgln_if(USB_DEBUG, "Unregistering driver {}", driver->name());
+    auto const& found_driver = m_available_drivers.find(driver);
+    if (!found_driver.is_end())
+        m_available_drivers.remove(found_driver.index());
 }
 
 USBManagement& USBManagement::the()

--- a/Kernel/Bus/USB/USBManagement.h
+++ b/Kernel/Bus/USB/USBManagement.h
@@ -1,11 +1,13 @@
 /*
  * Copyright (c) 2021, Luke Wilde <lukew@serenityos.org>
+ * Copyright (c) 2023, Jesse Buhagiar <jesse.buhagiar@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #pragma once
 
+#include <Kernel/Bus/USB/Drivers/USBDriver.h>
 #include <Kernel/Bus/USB/USBController.h>
 #include <Kernel/Library/NonnullLockRefPtr.h>
 
@@ -19,10 +21,16 @@ public:
     static void initialize();
     static USBManagement& the();
 
+    void register_driver(NonnullLockRefPtr<Driver> driver);
+    void unregister_driver(NonnullLockRefPtr<Driver> driver);
+
+    Vector<NonnullLockRefPtr<Driver>>& available_drivers() { return m_available_drivers; }
+
 private:
     void enumerate_controllers();
 
     USBController::List m_controllers;
+    Vector<NonnullLockRefPtr<Driver>> m_available_drivers;
 };
 
 }

--- a/Kernel/Bus/USB/USBManagement.h
+++ b/Kernel/Bus/USB/USBManagement.h
@@ -22,6 +22,7 @@ public:
     static USBManagement& the();
 
     void register_driver(NonnullLockRefPtr<Driver> driver);
+    LockRefPtr<Driver> get_driver_by_name(StringView name);
     void unregister_driver(NonnullLockRefPtr<Driver> driver);
 
     Vector<NonnullLockRefPtr<Driver>>& available_drivers() { return m_available_drivers; }


### PR DESCRIPTION
Rebased and adapted from @Quaker762's branch

Q: Should I move the driver registration function storage into unmap_after_init?

CC: @supercomputer7 @Quaker762 