### PR TITLE
LibUnicode: Update to Unicode version 15.1.0

### DIFF
--- a/Meta/CMake/unicode_data.cmake
+++ b/Meta/CMake/unicode_data.cmake
@@ -1,6 +1,6 @@
 include(${CMAKE_CURRENT_LIST_DIR}/utils.cmake)
 
-set(UCD_VERSION 15.0.0)
+set(UCD_VERSION 15.1.0)
 set(UCD_PATH "${SERENITY_CACHE_DIR}/UCD" CACHE PATH "Download location for UCD files")
 set(UCD_VERSION_FILE "${UCD_PATH}/version.txt")
 

--- a/Tests/LibUnicode/TestSegmentation.cpp
+++ b/Tests/LibUnicode/TestSegmentation.cpp
@@ -51,6 +51,27 @@ TEST_CASE(grapheme_segmentation)
     test_grapheme_segmentation("a👩🏼‍❤️‍👨🏻b"sv, { 0u, 1u, 29u, 30u });
 }
 
+TEST_CASE(grapheme_segmentation_indic_conjunct_break)
+{
+    test_grapheme_segmentation("\u0915"sv, { 0u, 3u });
+    test_grapheme_segmentation("\u0915a"sv, { 0u, 3u, 4u });
+    test_grapheme_segmentation("\u0915\u0916"sv, { 0u, 3u, 6u });
+
+    test_grapheme_segmentation("\u0915\u094D\u0916"sv, { 0u, 9u });
+
+    test_grapheme_segmentation("\u0915\u09BC\u09CD\u094D\u0916"sv, { 0u, 15u });
+    test_grapheme_segmentation("\u0915\u094D\u09BC\u09CD\u0916"sv, { 0u, 15u });
+
+    test_grapheme_segmentation("\u0915\u09BC\u09CD\u094D\u09BC\u09CD\u0916"sv, { 0u, 21u });
+    test_grapheme_segmentation("\u0915\u09BC\u09CD\u09BC\u09CD\u094D\u0916"sv, { 0u, 21u });
+    test_grapheme_segmentation("\u0915\u094D\u09BC\u09CD\u09BC\u09CD\u0916"sv, { 0u, 21u });
+
+    test_grapheme_segmentation("\u0915\u09BC\u09CD\u09BC\u09CD\u094D\u09BC\u09CD\u0916"sv, { 0u, 27u });
+    test_grapheme_segmentation("\u0915\u09BC\u09CD\u094D\u09BC\u09CD\u09BC\u09CD\u0916"sv, { 0u, 27u });
+
+    test_grapheme_segmentation("\u0915\u09BC\u09CD\u09BC\u09CD\u094D\u09BC\u09CD\u09BC\u09CD\u0916"sv, { 0u, 33u });
+}
+
 template<size_t N>
 static void test_word_segmentation(StringView string, size_t const (&expected_boundaries)[N])
 {


### PR DESCRIPTION
https://unicode.org/versions/Unicode15.1.0/

This update includes a new set of code point properties, Indic Conjunct Break. These may have the values Consonant, Linker, or Extend. These are used in text segmentation to prevent breaking on some extended grapheme cluster sequences.

Note: The following test262 tests will fail due to code point property changes, until test262 updates their tests for this release:
```
test/built-ins/RegExp/property-escapes/generated/Alphabetic.js                      ✅ -> ❌
test/built-ins/RegExp/property-escapes/generated/Assigned.js                        ✅ -> ❌
test/built-ins/RegExp/property-escapes/generated/General_Category_-_Letter.js       ✅ -> ❌
test/built-ins/RegExp/property-escapes/generated/General_Category_-_Other.js        ✅ -> ❌
test/built-ins/RegExp/property-escapes/generated/General_Category_-_Other_Letter.js ✅ -> ❌
test/built-ins/RegExp/property-escapes/generated/General_Category_-_Other_Symbol.js ✅ -> ❌
test/built-ins/RegExp/property-escapes/generated/General_Category_-_Symbol.js       ✅ -> ❌
test/built-ins/RegExp/property-escapes/generated/General_Category_-_Unassigned.js   ✅ -> ❌
test/built-ins/RegExp/property-escapes/generated/Grapheme_Base.js                   ✅ -> ❌
test/built-ins/RegExp/property-escapes/generated/IDS_Binary_Operator.js             ✅ -> ❌
test/built-ins/RegExp/property-escapes/generated/ID_Continue.js                     ✅ -> ❌
test/built-ins/RegExp/property-escapes/generated/ID_Start.js                        ✅ -> ❌
test/built-ins/RegExp/property-escapes/generated/Ideographic.js                     ✅ -> ❌
test/built-ins/RegExp/property-escapes/generated/Script_-_Common.js                 ✅ -> ❌
test/built-ins/RegExp/property-escapes/generated/Script_-_Han.js                    ✅ -> ❌
test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Common.js      ✅ -> ❌
test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Han.js         ✅ -> ❌
test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Malayalam.js   ✅ -> ❌
test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Sharada.js     ✅ -> ❌
test/built-ins/RegExp/property-escapes/generated/Script_Extensions_-_Sinhala.js     ✅ -> ❌
test/built-ins/RegExp/property-escapes/generated/Sentence_Terminal.js               ✅ -> ❌
test/built-ins/RegExp/property-escapes/generated/Unified_Ideograph.js               ✅ -> ❌
test/built-ins/RegExp/property-escapes/generated/XID_Continue.js                    ✅ -> ❌
test/built-ins/RegExp/property-escapes/generated/XID_Start.js                       ✅ -> ❌
```