### PR TITLE
LibWeb+WebServer: Use human-readable sizes on directory listing

### DIFF
--- a/Userland/Libraries/LibWeb/Loader/FileDirectoryLoader.cpp
+++ b/Userland/Libraries/LibWeb/Loader/FileDirectoryLoader.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/NumberFormat.h>
 #include <AK/QuickSort.h>
 #include <AK/SourceGenerator.h>
 #include <LibCore/DateTime.h>
@@ -31,10 +32,12 @@ ErrorOr<DeprecatedString> load_file_directory_page(LoadRequest const& request)
         auto maybe_st = Core::System::stat(path.string());
         if (!maybe_st.is_error()) {
             auto st = maybe_st.release_value();
+            auto is_directory = S_ISDIR(st.st_mode);
+
             contents.append("<tr>"sv);
-            contents.appendff("<td><span class=\"{}\"></span></td>", S_ISDIR(st.st_mode) ? "folder" : "file");
+            contents.appendff("<td><span class=\"{}\"></span></td>", is_directory ? "folder" : "file");
             contents.appendff("<td><a href=\"file://{}\">{}</a></td><td>&nbsp;</td>"sv, path, name);
-            contents.appendff("<td>{:10}</td><td>&nbsp;</td>", st.st_size);
+            contents.appendff("<td>{:10}</td><td>&nbsp;</td>", is_directory ? "-" : human_readable_size(st.st_size));
             contents.appendff("<td>{}</td>"sv, Core::DateTime::from_timestamp(st.st_mtime).to_deprecated_string());
             contents.append("</tr>\n"sv);
         }

--- a/Userland/Services/WebServer/Client.cpp
+++ b/Userland/Services/WebServer/Client.cpp
@@ -10,6 +10,7 @@
 #include <AK/Debug.h>
 #include <AK/LexicalPath.h>
 #include <AK/MemoryStream.h>
+#include <AK/NumberFormat.h>
 #include <AK/QuickSort.h>
 #include <AK/StringBuilder.h>
 #include <AK/URL.h>
@@ -310,7 +311,7 @@ ErrorOr<void> Client::handle_directory_listing(String const& requested_path, Str
         TRY(builder.try_append(escape_html_entities(name)));
         TRY(builder.try_append("</a></td><td>&nbsp;</td>"sv));
 
-        TRY(builder.try_appendff("<td>{:10}</td><td>&nbsp;</td>", st.st_size));
+        TRY(builder.try_appendff("<td>{:10}</td><td>&nbsp;</td>", is_directory ? "-" : human_readable_size(st.st_size)));
         TRY(builder.try_append("<td>"sv));
         TRY(builder.try_append(TRY(Core::DateTime::from_timestamp(st.st_mtime).to_string())));
         TRY(builder.try_append("</td>"sv));


### PR DESCRIPTION
This PR makes the following changes to `WebServer`:

* Sizes displayed by the directory listing are now human readable for files. Size for directories is now left blank. 
* Files are no longer displayed in the directory view if their corresponding `stat` call fails. For example, it was previously possible to crash the program if there was a symlink that pointed outside the permitted directory
* A 403 is now returned when trying to access non-readable files or non-searchable directories.

WebServer:
![webserver_directory_listing](https://github.com/SerenityOS/serenity/assets/2817754/0d24e9d9-e978-45b0-b778-efe751120b11)

**EDIT**: I've now implemented human readable sizes for the directory listing in Ladybird as well

Ladybird:
![ladybird_directory_listing](https://github.com/SerenityOS/serenity/assets/2817754/1a5892b3-ed4d-4b0e-80c5-7a309c2a793a)

