### PR TITLE
LibJS: Unescape incorrectly escaped code units in regex patterns

### DIFF
--- a/Userland/Libraries/LibJS/Tests/builtins/RegExp/RegExp.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/RegExp/RegExp.js
@@ -60,3 +60,9 @@ test("regexp literals are re-useable", () => {
         expect(re.test("test")).toBeTrue();
     }
 });
+
+test("Incorrectly escaped code units not converted to invalid patterns", () => {
+    const re = /[\⪾-\⫀]/;
+    expect(re.test("⫀")).toBeTrue();
+    expect(re.test("\\u2abe")).toBeFalse(); // ⫀ is \u2abe
+});


### PR DESCRIPTION
We were translating the pattern [\⪾-\⫀] to [\\u2abe-\\u2ac0], which is a very different pattern; as a code unit converted to the \uhhh format has no meaning when escaped, this commit makes us simply skip escaping it when translating the pattern.