### PR TITLE
LibWeb: Don't break for atomic inline elements in `white-space: nowrap`

### DIFF
--- a/Tests/LibWeb/Layout/expected/block-and-inline/atomic-inline-with-white-space-nowrap.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/atomic-inline-with-white-space-nowrap.txt
@@ -1,0 +1,18 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x33.46875 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 37.15625x17.46875 children: not-inline
+      BlockContainer <div> at (8,8) content-size 37.15625x17.46875 children: inline
+        line 0 width: 37.15625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+          frag 0 from TextNode start: 0, length: 3, rect: [8,8 27.15625x17.46875]
+            "foo"
+          frag 1 from ImageBox start: 0, length: 0, rect: [35,11 10x10]
+        TextNode <#text>
+        ImageBox <img> at (35,11) content-size 10x10 children: not-inline
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x33.46875]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 37.15625x17.46875]
+      PaintableWithLines (BlockContainer<DIV>) [8,8 37.15625x17.46875]
+        TextPaintable (TextNode<#text>)
+        ImagePaintable (ImageBox<IMG>) [35,11 10x10]

--- a/Tests/LibWeb/Layout/input/block-and-inline/atomic-inline-with-white-space-nowrap.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/atomic-inline-with-white-space-nowrap.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html><style>
+    body { width: min-content; }
+    div { white-space: nowrap; }
+    img {
+        width: 10px;
+        height: 10px;
+    }
+</style><body><div>foo<img>

--- a/Userland/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -272,7 +272,9 @@ void InlineFormattingContext::generate_line_boxes(LayoutMode layout_mode)
         case InlineLevelIterator::Item::Type::Element: {
             auto& box = verify_cast<Layout::Box>(*item.node);
             compute_inset(box);
-            line_builder.break_if_needed(item.border_box_width());
+            if (containing_block().computed_values().white_space() != CSS::WhiteSpace::Nowrap) {
+                line_builder.break_if_needed(item.border_box_width());
+            }
             line_builder.append_box(box, item.border_start + item.padding_start, item.padding_end + item.border_end, item.margin_start, item.margin_end);
             break;
         }


### PR DESCRIPTION
Visual progression on https://substack.com/

Before:
![Screenshot at 2023-09-16 14-43-48](https://github.com/SerenityOS/serenity/assets/5954907/99a189f4-73dc-4cda-beaa-0adb934eefeb)

After:
![Screenshot at 2023-09-16 14-44-44](https://github.com/SerenityOS/serenity/assets/5954907/96ef3a6b-c2a3-4c75-bfab-013f118a6494)
