### PR TITLE
Ladybird/Appkit: Remember last window position and size

### DIFF
--- a/Ladybird/AppKit/UI/Tab.mm
+++ b/Ladybird/AppKit/UI/Tab.mm
@@ -68,6 +68,9 @@ static constexpr CGFloat const WINDOW_HEIGHT = 800;
                               backing:NSBackingStoreBuffered
                                 defer:NO];
 
+    // Remember last window position
+    self.frameAutosaveName = @"window";
+
     if (self) {
         self.web_view = [[LadybirdWebView alloc] init:self];
         [self.web_view setPostsBoundsChangedNotifications:YES];


### PR DESCRIPTION
Remember Ladybird Appkit chrome last window position and size. Fortunately, this can be done in macOS with one line of code 🎉

CC: @trflynn89