### PR TITLE
GameOfLife: Add a tick counter to the status bar

### DIFF
--- a/Userland/Games/GameOfLife/BoardWidget.cpp
+++ b/Userland/Games/GameOfLife/BoardWidget.cpp
@@ -38,6 +38,12 @@ BoardWidget::BoardWidget(size_t rows, size_t columns)
 void BoardWidget::run_generation()
 {
     m_board->run_generation();
+    if (!m_board->is_stalled())
+        m_ticks++;
+
+    if (on_tick)
+        on_tick(m_ticks);
+
     update();
     if (m_board->is_stalled()) {
         if (on_stall)
@@ -91,6 +97,8 @@ void BoardWidget::toggle_cell(size_t row, size_t column)
     if (m_running || !m_toggling_cells || (m_last_cell_toggled.row == row && m_last_cell_toggled.column == column))
         return;
 
+    m_ticks = 0;
+
     m_last_cell_toggled = { row, column };
     m_board->toggle_cell(row, column);
 
@@ -98,6 +106,18 @@ void BoardWidget::toggle_cell(size_t row, size_t column)
         on_cell_toggled(m_board, row, column);
 
     update();
+}
+
+void BoardWidget::clear_cells()
+{
+    m_ticks = 0;
+    m_board->clear();
+}
+
+void BoardWidget::randomize_cells()
+{
+    m_ticks = 0;
+    m_board->randomize();
 }
 
 int BoardWidget::get_cell_size() const

--- a/Userland/Games/GameOfLife/BoardWidget.h
+++ b/Userland/Games/GameOfLife/BoardWidget.h
@@ -36,8 +36,8 @@ public:
     }
 
     void toggle_cell(size_t row, size_t column);
-    void clear_cells() { m_board->clear(); }
-    void randomize_cells() { m_board->randomize(); }
+    void clear_cells();
+    void randomize_cells();
 
     int get_cell_size() const;
     Gfx::IntSize get_board_offset() const;
@@ -64,6 +64,7 @@ public:
     int running_timer_interval() const { return m_running_timer_interval; }
     void set_running_timer_interval(int interval);
 
+    Function<void(u64)> on_tick;
     Function<void()> on_running_state_change;
     Function<void()> on_stall;
     Function<void()> on_pattern_selection_state_change;
@@ -86,6 +87,8 @@ private:
 
     int m_running_timer_interval { 500 };
     int m_running_pattern_preview_timer_interval { 100 };
+
+    u64 m_ticks { 0 };
 
     RefPtr<GUI::Menu> m_context_menu;
 

--- a/Userland/Games/GameOfLife/GameOfLife.gml
+++ b/Userland/Games/GameOfLife/GameOfLife.gml
@@ -61,5 +61,6 @@
 
     @GUI::Statusbar {
         name: "statusbar"
+        segment_count: 2
     }
 }


### PR DESCRIPTION
The counter is incremented after each new generation and reset whenever any cell on the board is toggled. Resizing the board does not reset the tick count.

![gameoflife_tick_counter](https://github.com/SerenityOS/serenity/assets/2817754/3b9cbb23-014f-4929-a9fa-47df2cfce0e7)