### PR TITLE
LibJS: Create const variables in ForIn/OfBodyEvaluation in strict mode

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -2877,7 +2877,7 @@ static Bytecode::CodeGenerationErrorOr<void> for_in_of_body_evaluation(Bytecode:
             // a. If IsConstantDeclaration of LetOrConst is true, then
             if (variable_declaration.is_constant_declaration()) {
                 // i. Perform ! environment.CreateImmutableBinding(name, true).
-                generator.emit<Bytecode::Op::CreateVariable>(interned_identifier, Bytecode::Op::EnvironmentMode::Lexical, true);
+                generator.emit<Bytecode::Op::CreateVariable>(interned_identifier, Bytecode::Op::EnvironmentMode::Lexical, true, false, true);
             }
             // b. Else,
             else {

--- a/Userland/Libraries/LibJS/Bytecode/Op.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Op.cpp
@@ -568,15 +568,15 @@ ThrowCompletionOr<void> CreateVariable::execute_impl(Bytecode::Interpreter& inte
             return vm.throw_completion<InternalError>(TRY_OR_THROW_OOM(vm, String::formatted("Lexical environment already has binding '{}'", name)));
 
         if (m_is_immutable)
-            return vm.lexical_environment()->create_immutable_binding(vm, name, vm.in_strict_mode());
+            return vm.lexical_environment()->create_immutable_binding(vm, name, m_is_strict);
         else
-            return vm.lexical_environment()->create_mutable_binding(vm, name, vm.in_strict_mode());
+            return vm.lexical_environment()->create_mutable_binding(vm, name, m_is_strict);
     } else {
         if (!m_is_global) {
             if (m_is_immutable)
-                return vm.variable_environment()->create_immutable_binding(vm, name, vm.in_strict_mode());
+                return vm.variable_environment()->create_immutable_binding(vm, name, m_is_strict);
             else
-                return vm.variable_environment()->create_mutable_binding(vm, name, vm.in_strict_mode());
+                return vm.variable_environment()->create_mutable_binding(vm, name, m_is_strict);
         } else {
             // NOTE: CreateVariable with m_is_global set to true is expected to only be used in GlobalDeclarationInstantiation currently, which only uses "false" for "can_be_deleted".
             //       The only area that sets "can_be_deleted" to true is EvalDeclarationInstantiation, which is currently fully implemented in C++ and not in Bytecode.

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -382,12 +382,13 @@ public:
 
 class CreateVariable final : public Instruction {
 public:
-    explicit CreateVariable(IdentifierTableIndex identifier, EnvironmentMode mode, bool is_immutable, bool is_global = false)
+    explicit CreateVariable(IdentifierTableIndex identifier, EnvironmentMode mode, bool is_immutable, bool is_global = false, bool is_strict = false)
         : Instruction(Type::CreateVariable, sizeof(*this))
         , m_identifier(identifier)
         , m_mode(mode)
         , m_is_immutable(is_immutable)
         , m_is_global(is_global)
+        , m_is_strict(is_strict)
     {
     }
 
@@ -399,6 +400,7 @@ private:
     EnvironmentMode m_mode;
     bool m_is_immutable : 4 { false };
     bool m_is_global : 4 { false };
+    bool m_is_strict { false };
 };
 
 class SetVariable final : public Instruction {

--- a/Userland/Libraries/LibJS/Tests/loops/for-in-basic.js
+++ b/Userland/Libraries/LibJS/Tests/loops/for-in-basic.js
@@ -99,7 +99,7 @@ describe("special left hand sides", () => {
         }).toThrowWithMessage(ReferenceError, "Invalid left-hand side in assignment");
     });
 
-    test.xfail("Cannot change constant declaration in body", () => {
+    test("Cannot change constant declaration in body", () => {
         const vals = [];
         for (const v in [1, 2]) {
             expect(() => v++).toThrowWithMessage(TypeError, "Invalid assignment to const variable");

--- a/Userland/Libraries/LibJS/Tests/loops/for-of-basic.js
+++ b/Userland/Libraries/LibJS/Tests/loops/for-of-basic.js
@@ -143,7 +143,7 @@ describe("special left hand sides", () => {
         }).toThrowWithMessage(ReferenceError, "Invalid left-hand side in assignment");
     });
 
-    test.xfail("Cannot change constant declaration in body", () => {
+    test("Cannot change constant declaration in body", () => {
         const vals = [];
         for (const v of [1, 2]) {
             expect(() => v++).toThrowWithMessage(TypeError, "Invalid assignment to const variable");


### PR DESCRIPTION
Our implementation of environment.CreateImmutableBinding(name, true)
in this AO was not correctly initializing variables in strict mode.
This would mean that constant declarations in for loop bodies would not
throw if they were modified.

To fix this, add a new parameter to CreateVariable to force strict mode.

This fixes two of our test-js tests, no change to test262.

Not too happy with this fix right now, feels like there is a better approach,
open to ideas here!