### PR TITLE
Ladybird/AppKit: Add mouse wheel events

### DIFF
--- a/Ladybird/AppKit/UI/LadybirdWebView.mm
+++ b/Ladybird/AppKit/UI/LadybirdWebView.mm
@@ -987,6 +987,18 @@ static void copy_text_to_clipboard(StringView text)
     m_web_view_bridge->mouse_move_event(position, screen_position, button, modifiers);
 }
 
+- (void)scrollWheel:(NSEvent*)event
+{
+    auto [position, screen_position, button, modifiers] = Ladybird::ns_event_to_mouse_event(event, self, GUI::MouseButton::Middle);
+    CGFloat delta_x = [event scrollingDeltaX];
+    CGFloat delta_y = -[event scrollingDeltaY];
+    if (![event hasPreciseScrollingDeltas]) {
+        delta_x *= [self scrollView].horizontalLineScroll;
+        delta_y *= [self scrollView].verticalLineScroll;
+    }
+    m_web_view_bridge->mouse_wheel_event(position, screen_position, button, modifiers, delta_x, delta_y);
+}
+
 - (void)mouseDown:(NSEvent*)event
 {
     [[self window] makeFirstResponder:self];

--- a/Ladybird/AppKit/UI/LadybirdWebViewBridge.cpp
+++ b/Ladybird/AppKit/UI/LadybirdWebViewBridge.cpp
@@ -100,6 +100,11 @@ void WebViewBridge::set_preferred_color_scheme(Web::CSS::PreferredColorScheme co
     client().async_set_preferred_color_scheme(color_scheme);
 }
 
+void WebViewBridge::mouse_wheel_event(Gfx::IntPoint position, Gfx::IntPoint screen_position, GUI::MouseButton button, KeyModifier modifiers, int wheel_delta_x, int wheel_delta_y)
+{
+    client().async_mouse_wheel(to_content_position(position), screen_position, to_underlying(button), to_underlying(button), modifiers, wheel_delta_x, wheel_delta_y);
+}
+
 void WebViewBridge::mouse_down_event(Gfx::IntPoint position, Gfx::IntPoint screen_position, GUI::MouseButton button, KeyModifier modifiers)
 {
     client().async_mouse_down(to_content_position(position), screen_position, to_underlying(button), to_underlying(button), modifiers);

--- a/Ladybird/AppKit/UI/LadybirdWebViewBridge.h
+++ b/Ladybird/AppKit/UI/LadybirdWebViewBridge.h
@@ -39,6 +39,7 @@ public:
     void update_palette();
     void set_preferred_color_scheme(Web::CSS::PreferredColorScheme);
 
+    void mouse_wheel_event(Gfx::IntPoint, Gfx::IntPoint, GUI::MouseButton, KeyModifier, int, int);
     void mouse_down_event(Gfx::IntPoint, Gfx::IntPoint, GUI::MouseButton, KeyModifier);
     void mouse_up_event(Gfx::IntPoint, Gfx::IntPoint, GUI::MouseButton, KeyModifier);
     void mouse_move_event(Gfx::IntPoint, Gfx::IntPoint, GUI::MouseButton, KeyModifier);


### PR DESCRIPTION
With these changes the Ladybird AppKit chrome sends mouse wheel events to webcontent process.
With this OpenStreetMap.org starts to work:

https://github.com/SerenityOS/serenity/assets/19894029/a84c85ba-b5a4-4226-9315-d09d44e02ceb

CC: @trflynn89