### PR TITLE
HackStudio: Add toggle terminal feature to HackStudio

### DIFF
--- a/Userland/DevTools/HackStudio/HackStudioWidget.h
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.h
@@ -123,6 +123,7 @@ private:
     ErrorOr<NonnullRefPtr<GUI::Action>> create_add_editor_action();
     ErrorOr<NonnullRefPtr<GUI::Action>> create_add_terminal_action();
     ErrorOr<NonnullRefPtr<GUI::Action>> create_remove_current_terminal_action();
+    ErrorOr<NonnullRefPtr<GUI::Action>> create_toggle_terminal_action();
     ErrorOr<NonnullRefPtr<GUI::Action>> create_debug_action();
     ErrorOr<NonnullRefPtr<GUI::Action>> create_build_action();
     ErrorOr<NonnullRefPtr<GUI::Action>> create_run_action();
@@ -241,6 +242,7 @@ private:
     RefPtr<GUI::Action> m_add_editor_tab_widget_action;
     RefPtr<GUI::Action> m_add_terminal_action;
     RefPtr<GUI::Action> m_remove_current_terminal_action;
+    RefPtr<GUI::Action> m_toggle_terminal_action;
     RefPtr<GUI::Action> m_stop_action;
     RefPtr<GUI::Action> m_debug_action;
     RefPtr<GUI::Action> m_build_action;


### PR DESCRIPTION
This adds a new feature toggle terminal(similar to VSCodium). It creates a new terminal if not created already otherwise focusses on the terminal. If focus is already in the terminal then it switches back to editor.


<img width="1036" alt="image" src="https://github.com/SerenityOS/serenity/assets/15072510/2025bd4b-b337-458b-b3da-4318050d5346">
