### PR TITLE
LibWeb: Create `WebContentConsoleClient` for every new document

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -2652,6 +2652,8 @@ Vector<JS::Handle<HTML::BrowsingContext>> Document::list_of_descendant_browsing_
 // https://html.spec.whatwg.org/multipage/document-lifecycle.html#destroy-a-document
 void Document::destroy()
 {
+    page()->client().page_did_destroy_document(*this);
+
     // NOTE: Abort needs to happen before destory. There is currently bug in the spec: https://github.com/whatwg/html/issues/9148
     // 4. Abort document.
     abort();

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -203,6 +203,7 @@ public:
     virtual Gfx::IntRect page_did_request_fullscreen_window() { return {}; }
     virtual void page_did_start_loading(const AK::URL&, bool is_redirect) { (void)is_redirect; }
     virtual void page_did_create_new_document(Web::DOM::Document&) { }
+    virtual void page_did_destroy_document(Web::DOM::Document&) { }
     virtual void page_did_finish_loading(const AK::URL&) { }
     virtual void page_did_change_selection() { }
     virtual void page_did_request_cursor_change(Gfx::StandardCursor) { }

--- a/Userland/Services/WebContent/ConnectionFromClient.h
+++ b/Userland/Services/WebContent/ConnectionFromClient.h
@@ -34,6 +34,7 @@ public:
     virtual void die() override;
 
     void initialize_js_console(Badge<PageHost>, Web::DOM::Document& document);
+    void destroy_js_console(Badge<PageHost>, Web::DOM::Document& document);
 
     void request_file(Web::FileRequest);
 
@@ -127,8 +128,9 @@ private:
 
     HashMap<i32, NonnullRefPtr<Gfx::Bitmap>> m_backing_stores;
 
-    WeakPtr<JS::Realm> m_realm;
-    OwnPtr<WebContentConsoleClient> m_console_client;
+    HashMap<Web::DOM::Document*, NonnullOwnPtr<WebContentConsoleClient>> m_console_clients;
+    WeakPtr<WebContentConsoleClient> m_top_level_document_console_client;
+
     JS::Handle<JS::GlobalObject> m_console_global_object;
 
     HashMap<int, Web::FileRequest> m_requested_files {};

--- a/Userland/Services/WebContent/PageHost.cpp
+++ b/Userland/Services/WebContent/PageHost.cpp
@@ -287,6 +287,11 @@ void PageHost::page_did_create_new_document(Web::DOM::Document& document)
     m_client.initialize_js_console({}, document);
 }
 
+void PageHost::page_did_destroy_document(Web::DOM::Document& document)
+{
+    m_client.destroy_js_console({}, document);
+}
+
 void PageHost::page_did_finish_loading(const URL& url)
 {
     m_client.async_did_finish_loading(url);

--- a/Userland/Services/WebContent/PageHost.h
+++ b/Userland/Services/WebContent/PageHost.h
@@ -94,6 +94,7 @@ private:
     virtual void page_did_request_media_context_menu(Web::CSSPixelPoint, DeprecatedString const& target, unsigned modifiers, Web::Page::MediaContextMenu) override;
     virtual void page_did_start_loading(const URL&, bool) override;
     virtual void page_did_create_new_document(Web::DOM::Document&) override;
+    virtual void page_did_destroy_document(Web::DOM::Document&) override;
     virtual void page_did_finish_loading(const URL&) override;
     virtual void page_did_request_alert(String const&) override;
     virtual void page_did_request_confirm(String const&) override;

--- a/Userland/Services/WebContent/WebContentConsoleClient.h
+++ b/Userland/Services/WebContent/WebContentConsoleClient.h
@@ -16,7 +16,8 @@
 
 namespace WebContent {
 
-class WebContentConsoleClient final : public JS::ConsoleClient {
+class WebContentConsoleClient final : public JS::ConsoleClient
+    , public Weakable<WebContentConsoleClient> {
 public:
     WebContentConsoleClient(JS::Console&, JS::Realm&, ConnectionFromClient&);
 


### PR DESCRIPTION
Fixes regression introduced in b4fe118dff6c1bd839f0443f9d822ae078895814

The `WebContentConsoleClient` needs to be created not just once, but for every new document. Although the JS Console window allows communication only with the active document associated with the top-level browsing context, we still need a console client for each iframe's document to ensure their console logs are printed.

In the future, we might consider adding the ability to switch which document the JS Console window communicates with.

Fixes https://github.com/SerenityOS/serenity/issues/21117