### PR TITLE
Userland+Ladybird: Always specify url to be about:srcdoc in load_html()

### DIFF
--- a/Ladybird/AppKit/UI/LadybirdWebView.h
+++ b/Ladybird/AppKit/UI/LadybirdWebView.h
@@ -40,7 +40,7 @@
 - (instancetype)init:(id<LadybirdWebViewObserver>)observer;
 
 - (void)loadURL:(URL const&)url;
-- (void)loadHTML:(StringView)html url:(URL const&)url;
+- (void)loadHTML:(StringView)html;
 
 - (WebView::ViewImplementation&)view;
 - (String const&)handle;

--- a/Ladybird/AppKit/UI/LadybirdWebView.mm
+++ b/Ladybird/AppKit/UI/LadybirdWebView.mm
@@ -109,9 +109,9 @@ struct HideCursor {
     m_web_view_bridge->load(url);
 }
 
-- (void)loadHTML:(StringView)html url:(URL const&)url
+- (void)loadHTML:(StringView)html
 {
-    m_web_view_bridge->load_html(html, url);
+    m_web_view_bridge->load_html(html);
 }
 
 - (WebView::ViewImplementation&)view

--- a/Ladybird/AppKit/UI/TabController.mm
+++ b/Ladybird/AppKit/UI/TabController.mm
@@ -91,7 +91,7 @@ enum class IsHistoryNavigation {
 
 - (void)loadHTML:(StringView)html url:(URL const&)url
 {
-    [[self tab].web_view loadHTML:html url:url];
+    [[self tab].web_view loadHTML:html];
 }
 
 - (void)onLoadStart:(URL const&)url isRedirect:(BOOL)isRedirect

--- a/Ladybird/Qt/BrowserWindow.cpp
+++ b/Ladybird/Qt/BrowserWindow.cpp
@@ -442,10 +442,10 @@ Tab& BrowserWindow::new_tab(QString const& url, Web::HTML::ActivateTab activate_
     return tab;
 }
 
-Tab& BrowserWindow::new_tab(StringView html, URL const& url, Web::HTML::ActivateTab activate_tab)
+Tab& BrowserWindow::new_tab(StringView html, Web::HTML::ActivateTab activate_tab)
 {
     auto& tab = create_new_tab(activate_tab);
-    tab.load_html(html, url);
+    tab.load_html(html);
     return tab;
 }
 

--- a/Ladybird/Qt/BrowserWindow.h
+++ b/Ladybird/Qt/BrowserWindow.h
@@ -70,7 +70,7 @@ public slots:
     void tab_title_changed(int index, QString const&);
     void tab_favicon_changed(int index, QIcon const& icon);
     Tab& new_tab(QString const&, Web::HTML::ActivateTab);
-    Tab& new_tab(StringView html, URL const& url, Web::HTML::ActivateTab);
+    Tab& new_tab(StringView html, Web::HTML::ActivateTab);
     void activate_tab(int index);
     void close_tab(int index);
     void close_current_tab();

--- a/Ladybird/Qt/Tab.cpp
+++ b/Ladybird/Qt/Tab.cpp
@@ -217,7 +217,7 @@ Tab::Tab(BrowserWindow* window, StringView webdriver_content_ipc_path, WebView::
 
     view().on_received_source = [this](auto const& url, auto const& source) {
         auto html = WebView::highlight_source(url, source);
-        m_window->new_tab(html, url, Web::HTML::ActivateTab::Yes);
+        m_window->new_tab(html, Web::HTML::ActivateTab::Yes);
     };
 
     view().on_navigate_back = [this]() {
@@ -550,9 +550,9 @@ void Tab::navigate(QString url_qstring)
     view().load(url_string);
 }
 
-void Tab::load_html(StringView html, URL const& url)
+void Tab::load_html(StringView html)
 {
-    view().load_html(html, url);
+    view().load_html(html);
 }
 
 void Tab::back()

--- a/Ladybird/Qt/Tab.h
+++ b/Ladybird/Qt/Tab.h
@@ -34,7 +34,7 @@ public:
     WebContentView& view() { return *m_view; }
 
     void navigate(QString);
-    void load_html(StringView, URL const&);
+    void load_html(StringView);
 
     void back();
     void forward();

--- a/Userland/Applications/Mail/MailWidget.cpp
+++ b/Userland/Applications/Mail/MailWidget.cpp
@@ -505,5 +505,5 @@ void MailWidget::selected_email_to_load(GUI::ModelIndex const& index)
     // FIXME: I'm not sure what the URL should be. Just use the default URL "about:blank".
     // FIXME: It would be nice if we could pass over the charset.
     // FIXME: Add ability to cancel the load when we switch to another email. Feels very sluggish on heavy emails otherwise
-    m_web_view->load_html(decoded_data, "about:blank"sv);
+    m_web_view->load_html(decoded_data);
 }

--- a/Userland/Applications/Presenter/PresenterWidget.cpp
+++ b/Userland/Applications/Presenter/PresenterWidget.cpp
@@ -152,7 +152,7 @@ void PresenterWidget::set_file(StringView file_name)
         m_current_presentation = presentation.release_value();
         window()->set_title(DeprecatedString::formatted(title_template, m_current_presentation->title(), m_current_presentation->author()));
         set_min_size(m_current_presentation->normative_size());
-        m_web_view->load_html(MUST(m_current_presentation->render()), "presenter://slide.html"sv);
+        m_web_view->load_html(MUST(m_current_presentation->render()));
         update_slides_actions();
     }
 }

--- a/Userland/Applications/TextEditor/MainWidget.cpp
+++ b/Userland/Applications/TextEditor/MainWidget.cpp
@@ -909,7 +909,7 @@ void MainWidget::update_markdown_preview()
     if (document) {
         auto html = document->render_to_html();
         auto current_scroll_pos = m_page_view->visible_content_rect();
-        m_page_view->load_html(html, URL::create_with_file_scheme(m_path));
+        m_page_view->load_html(html);
         m_page_view->scroll_into_view(current_scroll_pos, true, true);
     }
 }
@@ -917,7 +917,7 @@ void MainWidget::update_markdown_preview()
 void MainWidget::update_html_preview()
 {
     auto current_scroll_pos = m_page_view->visible_content_rect();
-    m_page_view->load_html(m_editor->text(), URL::create_with_file_scheme(m_path));
+    m_page_view->load_html(m_editor->text());
     m_page_view->scroll_into_view(current_scroll_pos, true, true);
 }
 

--- a/Userland/DevTools/HackStudio/Editor.cpp
+++ b/Userland/DevTools/HackStudio/Editor.cpp
@@ -229,7 +229,7 @@ void Editor::show_documentation_tooltip_if_available(DeprecatedString const& hov
         return;
     }
 
-    s_tooltip_page_view->load_html(man_document->render_to_html("<style>body { background-color: #dac7b5; }</style>"sv), {});
+    s_tooltip_page_view->load_html(man_document->render_to_html("<style>body { background-color: #dac7b5; }</style>"sv));
 
     s_tooltip_window->set_rect(0, 0, 500, 400);
     s_tooltip_window->move_to(screen_location.translated(4, 4));
@@ -722,7 +722,7 @@ void Editor::handle_function_parameters_hint_request()
         }
         html.append("<style>body { background-color: #dac7b5; }</style>"sv);
 
-        s_tooltip_page_view->load_html(html.to_deprecated_string(), {});
+        s_tooltip_page_view->load_html(html.to_deprecated_string());
 
         auto cursor_rect = current_editor().cursor_content_rect().location().translated(screen_relative_rect().location());
 

--- a/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
@@ -49,7 +49,7 @@ bool url_matches_about_blank(AK::URL const& url)
 }
 
 // https://html.spec.whatwg.org/multipage/document-sequences.html#determining-the-origin
-HTML::Origin determine_the_origin(AK::URL const& url, SandboxingFlagSet sandbox_flags, Optional<HTML::Origin> source_origin, Optional<HTML::Origin> container_origin)
+HTML::Origin determine_the_origin(AK::URL const& url, SandboxingFlagSet sandbox_flags, Optional<HTML::Origin> source_origin)
 {
     // 1. If sandboxFlags has its sandboxed origin browsing context flag set, then return a new opaque origin.
     if (has_flag(sandbox_flags, SandboxingFlagSet::SandboxedOrigin)) {
@@ -61,11 +61,11 @@ HTML::Origin determine_the_origin(AK::URL const& url, SandboxingFlagSet sandbox_
 
     // 3. If url is about:srcdoc, then:
     if (url == "about:srcdoc"sv) {
-        // 1. Assert: containerOrigin is non-null.
-        VERIFY(container_origin.has_value());
+        // 1. Assert: sourceOrigin is non-null.
+        VERIFY(source_origin.has_value());
 
-        // 2. Return containerOrigin.
-        return container_origin.release_value();
+        // 2. Return sourceOrigin.
+        return source_origin.release_value();
     }
 
     // 4. If url matches about:blank and sourceOrigin is non-null, then return sourceOrigin.
@@ -134,8 +134,8 @@ WebIDL::ExceptionOr<BrowsingContext::BrowsingContextAndDocument> BrowsingContext
     // FIXME: 5. Let sandboxFlags be the result of determining the creation sandboxing flags given browsingContext and embedder.
     SandboxingFlagSet sandbox_flags = {};
 
-    // 6. Let origin be the result of determining the origin given about:blank, sandboxFlags, creatorOrigin, and null.
-    auto origin = determine_the_origin(AK::URL("about:blank"sv), sandbox_flags, creator_origin, {});
+    // 6. Let origin be the result of determining the origin given about:blank, sandboxFlags, and creatorOrigin.
+    auto origin = determine_the_origin(AK::URL("about:blank"sv), sandbox_flags, creator_origin);
 
     // FIXME: 7. Let permissionsPolicy be the result of creating a permissions policy given browsingContext and origin. [PERMISSIONSPOLICY]
 

--- a/Userland/Libraries/LibWeb/HTML/BrowsingContext.h
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContext.h
@@ -278,7 +278,7 @@ private:
     bool m_has_been_discarded { false };
 };
 
-HTML::Origin determine_the_origin(AK::URL const& url, SandboxingFlagSet sandbox_flags, Optional<HTML::Origin> source_origin, Optional<HTML::Origin> container_origin);
+HTML::Origin determine_the_origin(AK::URL const& url, SandboxingFlagSet sandbox_flags, Optional<HTML::Origin> source_origin);
 
 SandboxingFlagSet determine_the_creation_sandboxing_flags(BrowsingContext const&, JS::GCPtr<DOM::Element> embedder);
 

--- a/Userland/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Navigable.cpp
@@ -399,7 +399,7 @@ static WebIDL::ExceptionOr<NavigationParams> create_navigation_params_from_a_src
     response->set_body(TRY(Fetch::Infrastructure::byte_sequence_as_body(realm, document_resource.get<String>().bytes())));
 
     // 3. Let responseOrigin be the result of determining the origin given response's URL, targetSnapshotParams's sandboxing flags, null, and entry's document state's origin.
-    auto response_origin = determine_the_origin(*response->url(), SandboxingFlagSet {}, {}, entry->document_state->origin());
+    auto response_origin = determine_the_origin(*response->url(), SandboxingFlagSet {}, entry->document_state->origin());
 
     // 4. Let coop be a new cross-origin opener policy.
     CrossOriginOpenerPolicy coop;
@@ -598,9 +598,8 @@ static WebIDL::ExceptionOr<Optional<NavigationParams>> create_navigation_params_
             entry->document_state->set_resource(Empty {});
         }
 
-        // 11. Set responseOrigin to the result of determining the origin given response's URL, finalSandboxFlags,
-        //     entry's document state's initiator origin, and null.
-        response_origin = determine_the_origin(*response_holder->response()->url(), final_sandbox_flags, entry->document_state->initiator_origin(), {});
+        // 11. Set responseOrigin to the result of determining the origin given response's URL, finalSandboxFlags, and entry's document state's initiator origin.
+        response_origin = determine_the_origin(*response_holder->response()->url(), final_sandbox_flags, entry->document_state->initiator_origin());
 
         // 14. Set locationURL to response's location URL given currentURL's fragment.
         auto location_url = response_holder->response()->location_url(current_url.fragment());

--- a/Userland/Libraries/LibWeb/Page/Page.cpp
+++ b/Userland/Libraries/LibWeb/Page/Page.cpp
@@ -47,9 +47,9 @@ void Page::load(const AK::URL& url)
     (void)top_level_traversable()->navigate(url, *top_level_traversable()->active_document());
 }
 
-void Page::load_html(StringView html, const AK::URL& url)
+void Page::load_html(StringView html)
 {
-    (void)top_level_traversable()->navigate(url, *top_level_traversable()->active_document(), String::from_utf8(html).release_value_but_fixme_should_propagate_errors());
+    (void)top_level_traversable()->navigate("about:srcdoc"sv, *top_level_traversable()->active_document(), String::from_utf8(html).release_value_but_fixme_should_propagate_errors());
 }
 
 bool Page::has_ongoing_navigation() const

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -60,7 +60,7 @@ public:
 
     void load(const AK::URL&);
 
-    void load_html(StringView, const AK::URL&);
+    void load_html(StringView);
 
     bool has_ongoing_navigation() const;
 

--- a/Userland/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Userland/Libraries/LibWebView/ViewImplementation.cpp
@@ -86,15 +86,14 @@ void ViewImplementation::load(AK::URL const& url)
     client().async_load_url(url);
 }
 
-void ViewImplementation::load_html(StringView html, AK::URL const& url)
+void ViewImplementation::load_html(StringView html)
 {
-    m_url = url;
-    client().async_load_html(html, url);
+    client().async_load_html(html);
 }
 
 void ViewImplementation::load_empty_document()
 {
-    load_html(""sv, {});
+    load_html(""sv);
 }
 
 void ViewImplementation::zoom_in()
@@ -328,7 +327,7 @@ void ViewImplementation::handle_web_content_process_crash()
     auto escaped_url = escape_html_entities(m_url.to_deprecated_string());
     builder.appendff("The web page <a href=\"{}\">{}</a> has crashed.<br><br>You can reload the page to try again.", escaped_url, escaped_url);
     builder.append("</body></html>"sv);
-    load_html(builder.to_deprecated_string(), m_url);
+    load_html(builder.to_deprecated_string());
 }
 
 ErrorOr<void> ViewImplementation::take_screenshot(ScreenshotType type)

--- a/Userland/Libraries/LibWebView/ViewImplementation.h
+++ b/Userland/Libraries/LibWebView/ViewImplementation.h
@@ -52,7 +52,7 @@ public:
     void server_did_change_selection(Badge<WebContentClient>);
 
     void load(AK::URL const&);
-    void load_html(StringView, AK::URL const&);
+    void load_html(StringView);
     void load_empty_document();
 
     void zoom_in();

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -119,10 +119,10 @@ void ConnectionFromClient::load_url(const URL& url)
     page().load(url);
 }
 
-void ConnectionFromClient::load_html(DeprecatedString const& html, const URL& url)
+void ConnectionFromClient::load_html(DeprecatedString const& html)
 {
-    dbgln_if(SPAM_DEBUG, "handle: WebContentServer::LoadHTML: html={}, url={}", html, url);
-    page().load_html(html, url);
+    dbgln_if(SPAM_DEBUG, "handle: WebContentServer::LoadHTML: html={}", html);
+    page().load_html(html);
 }
 
 void ConnectionFromClient::set_viewport_rect(Gfx::IntRect const& rect)
@@ -481,7 +481,7 @@ void ConnectionFromClient::debug_request(DeprecatedString const& request, Deprec
             auto maybe_link = document->query_selector("link[rel=match]"sv);
             if (maybe_link.is_error() || !maybe_link.value()) {
                 // To make sure that we fail the ref-test if the link is missing, load the error page.
-                load_html("<h1>Failed to find &lt;link rel=&quot;match&quot; /&gt; in ref test page!</h1> Make sure you added it.", "about:blank"sv);
+                load_html("<h1>Failed to find &lt;link rel=&quot;match&quot; /&gt; in ref test page!</h1> Make sure you added it.");
             } else {
                 auto link = maybe_link.release_value();
                 auto url = document->parse_url(link->get_attribute(Web::HTML::AttributeNames::href));

--- a/Userland/Services/WebContent/ConnectionFromClient.h
+++ b/Userland/Services/WebContent/ConnectionFromClient.h
@@ -55,7 +55,7 @@ private:
     virtual void update_system_fonts(DeprecatedString const&, DeprecatedString const&, DeprecatedString const&) override;
     virtual void update_screen_rects(Vector<Gfx::IntRect> const&, u32) override;
     virtual void load_url(URL const&) override;
-    virtual void load_html(DeprecatedString const&, URL const&) override;
+    virtual void load_html(DeprecatedString const&) override;
     virtual void paint(Gfx::IntRect const&, i32) override;
     virtual void set_viewport_rect(Gfx::IntRect const&) override;
     virtual void mouse_down(Gfx::IntPoint, Gfx::IntPoint, unsigned, unsigned, unsigned) override;

--- a/Userland/Services/WebContent/WebContentServer.ipc
+++ b/Userland/Services/WebContent/WebContentServer.ipc
@@ -19,7 +19,7 @@ endpoint WebContentServer
     update_screen_rects(Vector<Gfx::IntRect> rects, u32 main_screen_index) =|
 
     load_url(URL url) =|
-    load_html(DeprecatedString html, URL url) =|
+    load_html(DeprecatedString html) =|
 
     add_backing_store(i32 backing_store_id, Gfx::ShareableBitmap bitmap) =|
     remove_backing_store(i32 backing_store_id) =|


### PR DESCRIPTION
After moving to navigables, we started reusing the code that populates
session history entries with the srcdoc attribute value from iframes
in `Page::load_html()` for loading HTML.

This change addresses a crash in `determine_the_origin` which occurred
because this method expected the URL to be `about:srcdoc` if we also
provided HTML content (previously, it was the URL passed along with the
HTML content into `load_html()`).
