### PR TITLE
SystemServer: Use correct unix device numbers for null, full and random

### DIFF
--- a/Userland/Services/SystemServer/main.cpp
+++ b/Userland/Services/SystemServer/main.cpp
@@ -130,9 +130,9 @@ static ErrorOr<void> prepare_bare_minimum_devtmpfs_directory_structure()
     TRY(Core::System::create_char_device("/dev/devctl"sv, 0660, 2, 10));
     TRY(Core::System::create_char_device("/dev/zero"sv, 0666, 1, 5));
     TRY(Core::System::create_char_device("/dev/mem"sv, 0600, 1, 1));
-    TRY(Core::System::create_char_device("/dev/null"sv, 0666, 3, 0));
-    TRY(Core::System::create_char_device("/dev/full"sv, 0666, 7, 0));
-    TRY(Core::System::create_char_device("/dev/random"sv, 0666, 8, 0));
+    TRY(Core::System::create_char_device("/dev/null"sv, 0666, 1, 3));
+    TRY(Core::System::create_char_device("/dev/full"sv, 0666, 1, 7));
+    TRY(Core::System::create_char_device("/dev/random"sv, 0666, 1, 8));
     TRY(Core::System::create_char_device("/dev/console"sv, 0666, 5, 1));
     TRY(Core::System::create_char_device("/dev/ptmx"sv, 0666, 5, 2));
     TRY(Core::System::create_char_device("/dev/tty"sv, 0666, 5, 0));


### PR DESCRIPTION
This fixes regression made in 446200d6f3bcf3a828e23902e9dbbb44702135d0