### PR TITLE
LibWeb: Port CharacterData from DeprecatedString to String

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/CharacterData.h
+++ b/Userland/Libraries/LibWeb/DOM/CharacterData.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <AK/DeprecatedString.h>
+#include <AK/String.h>
 #include <LibWeb/DOM/ChildNode.h>
 #include <LibWeb/DOM/Node.h>
 #include <LibWeb/DOM/NonDocumentTypeChildNode.h>
@@ -22,24 +22,25 @@ class CharacterData
 public:
     virtual ~CharacterData() override = default;
 
-    DeprecatedString const& data() const { return m_data; }
-    void set_data(DeprecatedString);
+    String const& data() const { return m_data; }
+    void set_data(String const&);
 
-    unsigned length() const { return m_data.length(); }
+    // FIXME: This should be in UTF-16 code units, not byte size.
+    unsigned length() const { return m_data.bytes().size(); }
 
-    WebIDL::ExceptionOr<DeprecatedString> substring_data(size_t offset, size_t count) const;
-    WebIDL::ExceptionOr<void> append_data(DeprecatedString const&);
-    WebIDL::ExceptionOr<void> insert_data(size_t offset, DeprecatedString const&);
+    WebIDL::ExceptionOr<String> substring_data(size_t offset, size_t count) const;
+    WebIDL::ExceptionOr<void> append_data(String const&);
+    WebIDL::ExceptionOr<void> insert_data(size_t offset, String const&);
     WebIDL::ExceptionOr<void> delete_data(size_t offset, size_t count);
-    WebIDL::ExceptionOr<void> replace_data(size_t offset, size_t count, DeprecatedString const&);
+    WebIDL::ExceptionOr<void> replace_data(size_t offset, size_t count, String const&);
 
 protected:
-    CharacterData(Document&, NodeType, DeprecatedString const&);
+    CharacterData(Document&, NodeType, String const&);
 
     virtual void initialize(JS::Realm&) override;
 
 private:
-    DeprecatedString m_data;
+    String m_data;
 };
 
 }

--- a/Userland/Libraries/LibWeb/DOM/CharacterData.idl
+++ b/Userland/Libraries/LibWeb/DOM/CharacterData.idl
@@ -3,7 +3,7 @@
 #import <DOM/Node.idl>
 
 // https://dom.spec.whatwg.org/#characterdata
-[Exposed=Window, UseDeprecatedAKString]
+[Exposed=Window]
 interface CharacterData : Node {
     [LegacyNullToEmptyString] attribute DOMString data;
     readonly attribute unsigned long length;

--- a/Userland/Libraries/LibWeb/DOM/ChildNode.h
+++ b/Userland/Libraries/LibWeb/DOM/ChildNode.h
@@ -16,7 +16,7 @@ template<typename NodeType>
 class ChildNode {
 public:
     // https://dom.spec.whatwg.org/#dom-childnode-before
-    WebIDL::ExceptionOr<void> before(Vector<Variant<JS::Handle<Node>, DeprecatedString>> const& nodes)
+    WebIDL::ExceptionOr<void> before(Vector<Variant<JS::Handle<Node>, String>> const& nodes)
     {
         auto* node = static_cast<NodeType*>(this);
 
@@ -31,7 +31,7 @@ public:
         auto viable_previous_sibling = viable_previous_sibling_for_insertion(nodes);
 
         // 4. Let node be the result of converting nodes into a node, given nodes and this’s node document.
-        auto node_to_insert = TRY(convert_nodes_to_single_node(from_deprecated_nodes(nodes), node->document()));
+        auto node_to_insert = TRY(convert_nodes_to_single_node(nodes, node->document()));
 
         // 5. If viablePreviousSibling is null, then set it to parent’s first child; otherwise to viablePreviousSibling’s next sibling.
         if (!viable_previous_sibling)
@@ -46,7 +46,7 @@ public:
     }
 
     // https://dom.spec.whatwg.org/#dom-childnode-after
-    WebIDL::ExceptionOr<void> after(Vector<Variant<JS::Handle<Node>, DeprecatedString>> const& nodes)
+    WebIDL::ExceptionOr<void> after(Vector<Variant<JS::Handle<Node>, String>> const& nodes)
     {
         auto* node = static_cast<NodeType*>(this);
 
@@ -61,7 +61,7 @@ public:
         auto viable_next_sibling = viable_nest_sibling_for_insertion(nodes);
 
         // 4. Let node be the result of converting nodes into a node, given nodes and this’s node document.
-        auto node_to_insert = TRY(convert_nodes_to_single_node(from_deprecated_nodes(nodes), node->document()));
+        auto node_to_insert = TRY(convert_nodes_to_single_node(nodes, node->document()));
 
         // 5. Pre-insert node into parent before viableNextSibling.
         (void)TRY(parent->pre_insert(node_to_insert, viable_next_sibling));
@@ -70,7 +70,7 @@ public:
     }
 
     // https://dom.spec.whatwg.org/#dom-childnode-replacewith
-    WebIDL::ExceptionOr<void> replace_with(Vector<Variant<JS::Handle<Node>, DeprecatedString>> const& nodes)
+    WebIDL::ExceptionOr<void> replace_with(Vector<Variant<JS::Handle<Node>, String>> const& nodes)
     {
         auto* node = static_cast<NodeType*>(this);
 
@@ -85,7 +85,7 @@ public:
         auto viable_next_sibling = viable_nest_sibling_for_insertion(nodes);
 
         // 4. Let node be the result of converting nodes into a node, given nodes and this’s node document.
-        auto node_to_insert = TRY(convert_nodes_to_single_node(from_deprecated_nodes(nodes), node->document()));
+        auto node_to_insert = TRY(convert_nodes_to_single_node(nodes, node->document()));
 
         // 5. If this’s parent is parent, replace this with node within parent.
         // Note: This could have been inserted into node.
@@ -113,11 +113,26 @@ public:
         node->remove();
     }
 
+    WebIDL::ExceptionOr<void> before(Vector<Variant<JS::Handle<Node>, DeprecatedString>> const& nodes)
+    {
+        return before(from_deprecated_nodes(nodes));
+    }
+
+    WebIDL::ExceptionOr<void> after(Vector<Variant<JS::Handle<Node>, DeprecatedString>> const& nodes)
+    {
+        return after(from_deprecated_nodes(nodes));
+    }
+
+    WebIDL::ExceptionOr<void> replace_with(Vector<Variant<JS::Handle<Node>, DeprecatedString>> const& nodes)
+    {
+        return replace_with(from_deprecated_nodes(nodes));
+    }
+
 protected:
     ChildNode() = default;
 
 private:
-    JS::GCPtr<Node> viable_previous_sibling_for_insertion(Vector<Variant<JS::Handle<Node>, DeprecatedString>> const& nodes)
+    JS::GCPtr<Node> viable_previous_sibling_for_insertion(Vector<Variant<JS::Handle<Node>, String>> const& nodes)
     {
         auto* node = static_cast<NodeType*>(this);
 
@@ -142,7 +157,7 @@ private:
         return nullptr;
     }
 
-    JS::GCPtr<Node> viable_nest_sibling_for_insertion(Vector<Variant<JS::Handle<Node>, DeprecatedString>> const& nodes)
+    JS::GCPtr<Node> viable_nest_sibling_for_insertion(Vector<Variant<JS::Handle<Node>, String>> const& nodes)
     {
         auto* node = static_cast<NodeType*>(this);
 

--- a/Userland/Libraries/LibWeb/DOM/Comment.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Comment.cpp
@@ -12,7 +12,7 @@
 namespace Web::DOM {
 
 Comment::Comment(Document& document, String const& data)
-    : CharacterData(document, NodeType::COMMENT_NODE, data.to_deprecated_string())
+    : CharacterData(document, NodeType::COMMENT_NODE, data)
 {
 }
 

--- a/Userland/Libraries/LibWeb/DOM/Position.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Position.cpp
@@ -67,7 +67,7 @@ bool Position::offset_is_at_end_of_node() const
 
     auto& node = verify_cast<DOM::Text>(*m_node);
     auto text = node.data();
-    return m_offset == text.length();
+    return m_offset == text.bytes_as_string_view().length();
 }
 
 }

--- a/Userland/Libraries/LibWeb/DOM/ProcessingInstruction.cpp
+++ b/Userland/Libraries/LibWeb/DOM/ProcessingInstruction.cpp
@@ -12,7 +12,7 @@
 namespace Web::DOM {
 
 ProcessingInstruction::ProcessingInstruction(Document& document, DeprecatedString const& data, DeprecatedString const& target)
-    : CharacterData(document, NodeType::PROCESSING_INSTRUCTION_NODE, data)
+    : CharacterData(document, NodeType::PROCESSING_INSTRUCTION_NODE, MUST(String::from_deprecated_string(data)))
     , m_target(target)
 {
 }

--- a/Userland/Libraries/LibWeb/DOM/Text.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Text.cpp
@@ -14,12 +14,12 @@
 namespace Web::DOM {
 
 Text::Text(Document& document, String const& data)
-    : CharacterData(document, NodeType::TEXT_NODE, data.to_deprecated_string())
+    : CharacterData(document, NodeType::TEXT_NODE, data)
 {
 }
 
 Text::Text(Document& document, NodeType type, String const& data)
-    : CharacterData(document, type, data.to_deprecated_string())
+    : CharacterData(document, type, data)
 {
 }
 
@@ -63,7 +63,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Text>> Text::split_text(size_t offset)
     auto new_data = TRY(substring_data(offset, count));
 
     // 5. Let new node be a new Text node, with the same node document as node. Set new node’s data to new data.
-    auto new_node = heap().allocate<Text>(realm(), document(), MUST(String::from_deprecated_string(new_data)));
+    auto new_node = heap().allocate<Text>(realm(), document(), new_data);
 
     // 6. Let parent be node’s parent.
     JS::GCPtr<Node> parent = this->parent();
@@ -100,7 +100,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Text>> Text::split_text(size_t offset)
     }
 
     // 8. Replace data with node node, offset offset, count count, and data the empty string.
-    TRY(replace_data(offset, count, ""));
+    TRY(replace_data(offset, count, String {}));
 
     // 9. Return new node.
     return new_node;

--- a/Userland/Libraries/LibWeb/DOMParsing/XMLSerializer.cpp
+++ b/Userland/Libraries/LibWeb/DOMParsing/XMLSerializer.cpp
@@ -755,16 +755,16 @@ static WebIDL::ExceptionOr<DeprecatedString> serialize_text(DOM::Text const& tex
     //           then throw an exception; the serialization of this node's data would not be well-formed.
 
     // 2. Let markup be the value of node's data.
-    DeprecatedString markup = text.data();
+    auto markup = text.data();
 
     // 3. Replace any occurrences of "&" in markup by "&amp;".
-    markup = markup.replace("&"sv, "&amp;"sv, ReplaceMode::All);
+    markup = MUST(markup.replace("&"sv, "&amp;"sv, ReplaceMode::All));
 
     // 4. Replace any occurrences of "<" in markup by "&lt;".
-    markup = markup.replace("<"sv, "&lt;"sv, ReplaceMode::All);
+    markup = MUST(markup.replace("<"sv, "&lt;"sv, ReplaceMode::All));
 
     // 5. Replace any occurrences of ">" in markup by "&gt;".
-    markup = markup.replace(">"sv, "&gt;"sv, ReplaceMode::All);
+    markup = MUST(markup.replace(">"sv, "&gt;"sv, ReplaceMode::All));
 
     // 6. Return the value of markup.
     return markup;

--- a/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
@@ -447,11 +447,11 @@ static DeprecatedString visible_text_in_range(DOM::Range const& range)
     if (range.start_container() == range.end_container() && is<DOM::Text>(*range.start_container())) {
         if (!range.start_container()->layout_node())
             return ""sv;
-        return static_cast<DOM::Text const&>(*range.start_container()).data().substring(range.start_offset(), range.end_offset() - range.start_offset());
+        return MUST(static_cast<DOM::Text const&>(*range.start_container()).data().substring_from_byte_offset(range.start_offset(), range.end_offset() - range.start_offset())).to_deprecated_string();
     }
 
     if (is<DOM::Text>(*range.start_container()) && range.start_container()->layout_node())
-        builder.append(static_cast<DOM::Text const&>(*range.start_container()).data().substring_view(range.start_offset()));
+        builder.append(static_cast<DOM::Text const&>(*range.start_container()).data().bytes_as_string_view().substring_view(range.start_offset()));
 
     for (DOM::Node const* node = range.start_container(); node != range.end_container()->next_sibling(); node = node->next_in_pre_order()) {
         if (is<DOM::Text>(*node) && range.contains_node(*node) && node->layout_node())
@@ -459,7 +459,7 @@ static DeprecatedString visible_text_in_range(DOM::Range const& range)
     }
 
     if (is<DOM::Text>(*range.end_container()) && range.end_container()->layout_node())
-        builder.append(static_cast<DOM::Text const&>(*range.end_container()).data().substring_view(0, range.end_offset()));
+        builder.append(static_cast<DOM::Text const&>(*range.end_container()).data().bytes_as_string_view().substring_view(0, range.end_offset()));
 
     return builder.to_deprecated_string();
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -287,7 +287,7 @@ WebIDL::ExceptionOr<void> HTMLInputElement::run_input_activation_behavior()
 void HTMLInputElement::did_edit_text_node(Badge<BrowsingContext>)
 {
     // An input element's dirty value flag must be set to true whenever the user interacts with the control in a way that changes the value.
-    m_value = value_sanitization_algorithm(m_text_node->data());
+    m_value = value_sanitization_algorithm(m_text_node->data().to_deprecated_string());
     m_dirty_value = true;
 
     update_placeholder_visibility();
@@ -363,7 +363,7 @@ WebIDL::ExceptionOr<void> HTMLInputElement::set_value(String const& value)
     //    and the element has a text entry cursor position, move the text entry cursor position to the end of the
     //    text control, unselecting any selected text and resetting the selection direction to "none".
     if (m_text_node && (m_value != old_value)) {
-        m_text_node->set_data(m_value);
+        m_text_node->set_data(MUST(String::from_deprecated_string(m_value)));
         update_placeholder_visibility();
     }
 
@@ -502,7 +502,7 @@ void HTMLInputElement::create_shadow_tree_if_needed()
     MUST(m_placeholder_element->style_for_bindings()->set_property(CSS::PropertyID::Height, "1lh"sv));
 
     m_placeholder_text_node = heap().allocate<DOM::Text>(realm(), document(), MUST(String::from_deprecated_string(initial_value)));
-    m_placeholder_text_node->set_data(deprecated_attribute(HTML::AttributeNames::placeholder));
+    m_placeholder_text_node->set_data(attribute(HTML::AttributeNames::placeholder).value_or(String {}));
     m_placeholder_text_node->set_editable_text_node_owner(Badge<HTMLInputElement> {}, *this);
     MUST(m_placeholder_element->append_child(*m_placeholder_text_node));
     MUST(element->append_child(*m_placeholder_element));
@@ -581,7 +581,7 @@ void HTMLInputElement::attribute_changed(DeprecatedFlyString const& name, Deprec
         }
     } else if (name == HTML::AttributeNames::placeholder) {
         if (m_placeholder_text_node)
-            m_placeholder_text_node->set_data(value);
+            m_placeholder_text_node->set_data(MUST(String::from_deprecated_string(value)));
     } else if (name == HTML::AttributeNames::readonly) {
         handle_readonly_attribute(value);
     }
@@ -909,7 +909,7 @@ void HTMLInputElement::reset_algorithm()
     // and then invoke the value sanitization algorithm, if the type attribute's current state defines one.
     m_value = value_sanitization_algorithm(m_value);
     if (m_text_node) {
-        m_text_node->set_data(m_value);
+        m_text_node->set_data(MUST(String::from_deprecated_string(m_value)));
         update_placeholder_visibility();
     }
 }

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
@@ -1026,7 +1026,7 @@ void HTMLParser::flush_character_insertions()
 {
     if (m_character_insertion_builder.is_empty())
         return;
-    m_character_insertion_node->set_data(m_character_insertion_builder.to_deprecated_string());
+    m_character_insertion_node->set_data(MUST(m_character_insertion_builder.to_string()));
     m_character_insertion_builder.clear();
 }
 

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -1654,7 +1654,7 @@ bool FormattingContext::can_skip_is_anonymous_text_run(Box& box)
     if (box.is_anonymous() && !box.is_generated() && !box.first_child_of_type<BlockContainer>()) {
         bool contains_only_white_space = true;
         box.for_each_in_subtree([&](auto const& node) {
-            if (!is<TextNode>(node) || !static_cast<TextNode const&>(node).dom_node().data().is_whitespace()) {
+            if (!is<TextNode>(node) || !static_cast<TextNode const&>(node).dom_node().data().bytes_as_string_view().is_whitespace()) {
                 contains_only_white_space = false;
                 return IterationDecision::Break;
             }

--- a/Userland/Libraries/LibWeb/Layout/TextNode.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TextNode.cpp
@@ -328,7 +328,7 @@ void TextNode::compute_text_for_rendering()
     if (dom_node().is_editable() && !dom_node().is_uninteresting_whitespace_node())
         collapse = false;
 
-    auto data = apply_text_transform(dom_node().data(), computed_values().text_transform()).release_value_but_fixme_should_propagate_errors();
+    auto data = apply_text_transform(dom_node().data().to_deprecated_string(), computed_values().text_transform()).release_value_but_fixme_should_propagate_errors();
 
     if (dom_node().is_password_input()) {
         m_text_for_rendering = DeprecatedString::repeated('*', data.length());

--- a/Userland/Libraries/LibWeb/Page/EditEventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EditEventHandler.cpp
@@ -29,9 +29,9 @@ void EditEventHandler::handle_delete_character_after(DOM::Position const& cursor
     }
 
     StringBuilder builder;
-    builder.append(text.substring_view(0, cursor_position.offset()));
-    builder.append(text.substring_view(*next_grapheme_offset));
-    node.set_data(builder.to_deprecated_string());
+    builder.append(text.bytes_as_string_view().substring_view(0, cursor_position.offset()));
+    builder.append(text.bytes_as_string_view().substring_view(*next_grapheme_offset));
+    node.set_data(MUST(builder.to_string()));
 
     // FIXME: When nodes are removed from the DOM, the associated layout nodes become stale and still
     //        remain in the layout tree. This has to be fixed, this just causes everything to be recomputed
@@ -49,10 +49,10 @@ void EditEventHandler::handle_delete(DOM::Range& range)
 
     if (start == end) {
         StringBuilder builder;
-        builder.append(start->data().substring_view(0, range.start_offset()));
-        builder.append(end->data().substring_view(range.end_offset()));
+        builder.append(start->data().bytes_as_string_view().substring_view(0, range.start_offset()));
+        builder.append(end->data().bytes_as_string_view().substring_view(range.end_offset()));
 
-        start->set_data(builder.to_deprecated_string());
+        start->set_data(MUST(builder.to_string()));
     } else {
         // Remove all the nodes that are fully enclosed in the range.
         HashTable<DOM::Node*> queued_for_deletion;
@@ -87,10 +87,10 @@ void EditEventHandler::handle_delete(DOM::Range& range)
 
         // Join the start and end nodes.
         StringBuilder builder;
-        builder.append(start->data().substring_view(0, range.start_offset()));
-        builder.append(end->data().substring_view(range.end_offset()));
+        builder.append(start->data().bytes_as_string_view().substring_view(0, range.start_offset()));
+        builder.append(end->data().bytes_as_string_view().substring_view(range.end_offset()));
 
-        start->set_data(builder.to_deprecated_string());
+        start->set_data(MUST(builder.to_string()));
         end->remove();
     }
 
@@ -108,10 +108,10 @@ void EditEventHandler::handle_insert(DOM::Position position, u32 code_point)
         auto& node = verify_cast<DOM::Text>(*position.node());
 
         StringBuilder builder;
-        builder.append(node.data().substring_view(0, position.offset()));
+        builder.append(node.data().bytes_as_string_view().substring_view(0, position.offset()));
         builder.append_code_point(code_point);
-        builder.append(node.data().substring_view(position.offset()));
-        node.set_data(builder.to_deprecated_string());
+        builder.append(node.data().bytes_as_string_view().substring_view(position.offset()));
+        node.set_data(MUST(builder.to_string()));
 
         node.invalidate_style();
     }

--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -772,7 +772,7 @@ bool EventHandler::handle_keydown(KeyCode key, unsigned modifiers, u32 code_poin
         }
         if (key == KeyCode::Key_End) {
             auto& node = *static_cast<DOM::Text*>(const_cast<DOM::Node*>(m_browsing_context->cursor_position().node()));
-            m_browsing_context->set_cursor_position(DOM::Position { node, (unsigned)node.data().length() });
+            m_browsing_context->set_cursor_position(DOM::Position { node, (unsigned)node.data().bytes().size() });
             return true;
         }
         if (!should_ignore_keydown_event(code_point)) {

--- a/Userland/Libraries/LibWeb/XML/XMLDocumentBuilder.cpp
+++ b/Userland/Libraries/LibWeb/XML/XMLDocumentBuilder.cpp
@@ -140,7 +140,7 @@ void XMLDocumentBuilder::text(StringView data)
         auto& text_node = static_cast<DOM::Text&>(*last);
         text_builder.append(text_node.data());
         text_builder.append(data);
-        text_node.set_data(text_builder.to_deprecated_string());
+        text_node.set_data(MUST(text_builder.to_string()));
         text_builder.clear();
     } else {
         auto string = DeprecatedString::empty();


### PR DESCRIPTION
The existing implementation has some pre-existing issues where it is
incorrectly assumes that byte offsets are given through the IDL instead
of UTF-16 code units. While making these changes, leave some FIXMEs for
that.

Leaves only two interfaces left.