### PR TITLE
Documentation: Hide `Meta/serenity.sh rebuild-toolchain`

### DIFF
--- a/Documentation/BuildInstructions.md
+++ b/Documentation/BuildInstructions.md
@@ -92,14 +92,6 @@ There is also documentation for installing the build prerequisites for some less
 
 ## Build
 
-In order to build SerenityOS you will first need to build the toolchain by running the following command:
-
-```console
-Meta/serenity.sh rebuild-toolchain
-```
-
-Later on, when you use `git pull` to get the latest changes, there's (usually) no need to rebuild the toolchain.
-
 Run the following command to build and run SerenityOS:
 
 ```console
@@ -108,6 +100,11 @@ Meta/serenity.sh run
 
 This will compile all of SerenityOS and install the built files into the `Build/x86_64/Root` directory inside your Git
 repository. It will also build a disk image and start SerenityOS using QEMU.
+
+The first time this command is executed, it will also download some required database files from the internet and build
+the SerenityOS cross-compiler toolchain. These steps only have to be done once, so the next build will go much faster.
+When we update to a newer compiler, you might be prompted to re-build the toolchain; see the [troubleshooting guide](Troubleshooting.md#the-toolchain-is-outdated)
+for what to do when this happens.
 
 If, during build, an error like `fusermount: failed to open /etc/mtab: No such file or directory` appears, you have installed `fuse2fs` but your system does not provide the mtab symlink for various reasons. Simply create this symlink with `ln -sv /proc/self/mounts /etc/mtab`.
 

--- a/Documentation/NvimConfiguration.md
+++ b/Documentation/NvimConfiguration.md
@@ -4,8 +4,7 @@ NVim can be configured to use the [COC-clangd](https://github.com/clangd/coc-cla
 plugin to provide code-completion as well as inline
 [git blame](https://github.com/f-person/git-blame.nvim) using [vim-plug](https://github.com/junegunn/vim-plug).
 
-Make sure you ran `./Meta/serenity.sh rebuild-toolchain` as well as
-`./Meta/serenity.sh run`.
+Make sure you ran `Meta/serenity.sh run` at least once already.
 
 # Install vim-plug
 

--- a/Documentation/RunningOnRaspberryPi.md
+++ b/Documentation/RunningOnRaspberryPi.md
@@ -14,17 +14,9 @@ Currently only UART output is supported, no display.
 
 Please follow [build instructions](BuildInstructions.md) to download and build Serenity. Make sure everything builds successfully for x86.
 
-### Step 2: Build Aarch64 toolchain
+### Step 2: Build and run in emulator
 
-Use following the command to build the toolchain for Aarch64:
-
-```console
-Meta/serenity.sh rebuild-toolchain aarch64
-```
-
-### Step 3: Build and run in emulator
-
-Use the following command to build and run the Aarch64 kernel:
+Use the following command to build and run the AArch64 version of the system:
 
 ```console
 Meta/serenity.sh run aarch64

--- a/Documentation/Troubleshooting.md
+++ b/Documentation/Troubleshooting.md
@@ -14,6 +14,33 @@ version of CMake, you can download a binary release from the [CMake website](htt
 Ensure your [QEMU](https://www.qemu.org/) version is >= 5 with `qemu-system-i386 -version`. Otherwise,
 install it. You can also build it using the `Toolchain/BuildQemu.sh` script.
 
+### The toolchain is outdated
+
+We strive to use the latest compilers and build tools to ensure the best developer experience; so every
+few months, the toolchain needs to be updated. When such an update is due, an error like the following
+will be printed during the build:
+
+```
+CMake Error at CMakeLists.txt:28 (message):
+  GNU version (13.1.0) does not match expected compiler version (13.2.0).
+
+  Please rebuild the GNU Toolchain
+```
+
+Or like this one:
+
+```
+Your toolchain has an old version of binutils installed.
+    installed version: "GNU ld (GNU Binutils) 2.40"
+    expected version:  "GNU ld (GNU Binutils) 2.41"
+Please run Meta/serenity.sh rebuild-toolchain x86_64 to update it.
+```
+
+Run `Meta/serenity.sh rebuild-toolchain x86_64` to perform the update.
+
+CMake might cache the compiler version in some cases and print an error even after the toolchain has been rebuilt.
+If this happens, run `Meta/serenity.sh rebuild x86_64` to start over from a fresh build directory.
+
 ### GCC is missing or is outdated
 
 Ensure your gcc version is >= 12 with `gcc --version`. Otherwise, install it. If your gcc binary is not
@@ -78,5 +105,5 @@ extensions, or you try to use VirtualBox without using a x64 virtualization mode
 
 ### Boot fails with "KVM doesn't support guest debugging"
 - Update your host kernel to at least version `5.10`. This is the oldest kernel which properly supports the required KVM capability `KVM_CAP_SET_GUEST_DEBUG` (see corresponding [kernel commit](https://github.com/torvalds/linux/commit/b9b2782cd5)).
-- Make sure that your distro has the qemu debug feature actually enabled (the corresponding check is [here](https://gitlab.com/qemu-project/qemu/-/blob/222059a0fccf4af3be776fe35a5ea2d6a68f9a0b/accel/kvm/kvm-all.c#L2540)). 
+- Make sure that your distro has the qemu debug feature actually enabled (the corresponding check is [here](https://gitlab.com/qemu-project/qemu/-/blob/222059a0fccf4af3be776fe35a5ea2d6a68f9a0b/accel/kvm/kvm-all.c#L2540)).
 - Or, disable KVM debugging by setting this env var when running serenity: `SERENITY_DISABLE_GDB_SOCKET=1`


### PR DESCRIPTION
Unless a new toolchain update has been merged, users should not need to rebuild their toolchain. Yet, the first thing they see in the build documentation is to run `Meta/serenity.sh rebuild-toolchain`, which might incorrectly lead them to use it whenever they encounter an error. This is a waste of time and causes frustration.

Move any mentions of this option to `Troubleshooting.md` and add a note to `BuildInstructions.md` about the toolchain build being a one-time endeavor.