### PR TITLE
Userland: Prefer non-fallible construction for LibGUI objects

### DIFF
--- a/Userland/Applets/ClipboardHistory/main.cpp
+++ b/Userland/Applets/ClipboardHistory/main.cpp
@@ -84,7 +84,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         GUI::Clipboard::the().clear();
     });
 
-    auto entry_context_menu = TRY(GUI::Menu::try_create());
+    auto entry_context_menu = GUI::Menu::construct();
     entry_context_menu->add_action(delete_action);
     entry_context_menu->add_action(debug_dump_action);
     entry_context_menu->add_separator();

--- a/Userland/Applications/AnalogClock/main.cpp
+++ b/Userland/Applications/AnalogClock/main.cpp
@@ -37,7 +37,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             clock->set_show_window_frame(action.is_checked());
         });
     show_window_frame_action->set_checked(clock->show_window_frame());
-    auto menu = TRY(GUI::Menu::try_create());
+    auto menu = GUI::Menu::construct();
     menu->add_action(*show_window_frame_action);
 
     clock->on_context_menu_request = [&](auto& event) {

--- a/Userland/Applications/BrowserSettings/AutoplaySettingsWidget.cpp
+++ b/Userland/Applications/BrowserSettings/AutoplaySettingsWidget.cpp
@@ -65,7 +65,7 @@ ErrorOr<NonnullRefPtr<AutoplaySettingsWidget>> AutoplaySettingsWidget::create()
             widget->set_modified(true);
         }
     });
-    widget->m_entry_context_menu = TRY(GUI::Menu::try_create());
+    widget->m_entry_context_menu = GUI::Menu::construct();
     widget->m_entry_context_menu->add_action(move(delete_action));
 
     return widget;

--- a/Userland/Applications/CalendarSettings/CalendarSettingsWidget.cpp
+++ b/Userland/Applications/CalendarSettings/CalendarSettingsWidget.cpp
@@ -43,7 +43,7 @@ ErrorOr<void> CalendarSettingsWidget::setup()
     m_first_day_of_week_combobox = *find_descendant_of_type_named<GUI::ComboBox>("first_day_of_week");
     m_first_day_of_week_combobox->set_text(Config::read_string("Calendar"sv, "View"sv, "FirstDayOfWeek"sv, "Sunday"sv));
     m_first_day_of_week_combobox->set_only_allow_values_from_model(true);
-    m_first_day_of_week_combobox->set_model(*TRY((GUI::ItemListModel<StringView, Array<StringView, 7>>::try_create(AK::long_day_names))));
+    m_first_day_of_week_combobox->set_model(GUI::ItemListModel<StringView, Array<StringView, 7>>::create(AK::long_day_names));
     m_first_day_of_week_combobox->on_change = [&](auto, auto) {
         set_modified(true);
     };
@@ -51,7 +51,7 @@ ErrorOr<void> CalendarSettingsWidget::setup()
     m_first_day_of_weekend_combobox = *find_descendant_of_type_named<GUI::ComboBox>("first_day_of_weekend");
     m_first_day_of_weekend_combobox->set_text(Config::read_string("Calendar"sv, "View"sv, "FirstDayOfWeekend"sv, "Saturday"sv));
     m_first_day_of_weekend_combobox->set_only_allow_values_from_model(true);
-    m_first_day_of_weekend_combobox->set_model(*TRY((GUI::ItemListModel<StringView, Array<StringView, 7>>::try_create(AK::long_day_names))));
+    m_first_day_of_weekend_combobox->set_model(GUI::ItemListModel<StringView, Array<StringView, 7>>::create(AK::long_day_names));
     m_first_day_of_weekend_combobox->on_change = [&](auto, auto) {
         set_modified(true);
     };
@@ -65,7 +65,7 @@ ErrorOr<void> CalendarSettingsWidget::setup()
     m_default_view_combobox = *find_descendant_of_type_named<GUI::ComboBox>("default_view");
     m_default_view_combobox->set_text(Config::read_string("Calendar"sv, "View"sv, "DefaultView"sv, "Month"sv));
     m_default_view_combobox->set_only_allow_values_from_model(true);
-    m_default_view_combobox->set_model(*TRY((GUI::ItemListModel<StringView, Array<StringView, 2>>::try_create(m_view_modes))));
+    m_default_view_combobox->set_model(GUI::ItemListModel<StringView, Array<StringView, 2>>::create(m_view_modes));
     m_default_view_combobox->on_change = [&](auto, auto) {
         set_modified(true);
     };

--- a/Userland/Applications/FileManager/main.cpp
+++ b/Userland/Applications/FileManager/main.cpp
@@ -476,7 +476,7 @@ ErrorOr<int> run_in_desktop_mode()
         paste_action->set_enabled(data_type == "text/uri-list" && access(directory_view->path().characters(), W_OK) == 0);
     };
 
-    auto desktop_view_context_menu = TRY(GUI::Menu::try_create("Directory View"_string));
+    auto desktop_view_context_menu = GUI::Menu::construct("Directory View"_string);
 
     auto file_manager_action = GUI::Action::create("Open in File &Manager", {}, TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/app-file-manager.png"sv)), [&](auto&) {
         auto paths = directory_view->selected_file_paths();
@@ -518,7 +518,7 @@ ErrorOr<int> run_in_desktop_mode()
     desktop_view_context_menu->add_separator();
     desktop_view_context_menu->add_action(display_properties_action);
 
-    auto desktop_context_menu = TRY(GUI::Menu::try_create("Directory View Directory"_string));
+    auto desktop_context_menu = GUI::Menu::construct("Directory View Directory"_string);
 
     desktop_context_menu->add_action(file_manager_action);
     desktop_context_menu->add_action(open_terminal_action);
@@ -679,9 +679,9 @@ ErrorOr<int> run_in_windowed_mode(DeprecatedString const& initial_location, Depr
         directory_view->refresh();
     };
 
-    auto directory_context_menu = TRY(GUI::Menu::try_create("Directory View Directory"_string));
-    auto directory_view_context_menu = TRY(GUI::Menu::try_create("Directory View"_string));
-    auto tree_view_directory_context_menu = TRY(GUI::Menu::try_create("Tree View Directory"_string));
+    auto directory_context_menu = GUI::Menu::construct("Directory View Directory"_string);
+    auto directory_view_context_menu = GUI::Menu::construct("Directory View"_string);
+    auto tree_view_directory_context_menu = GUI::Menu::construct("Tree View Directory"_string);
 
     auto open_parent_directory_action = GUI::Action::create("Open &Parent Directory", { Mod_Alt, Key_Up }, TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/open-parent-directory.png"sv)), [&](GUI::Action const&) {
         directory_view->open_parent_directory();

--- a/Userland/Applications/FontEditor/MainWidget.cpp
+++ b/Userland/Applications/FontEditor/MainWidget.cpp
@@ -414,12 +414,12 @@ ErrorOr<void> MainWidget::create_models()
     TRY(m_font_slope_list.try_ensure_capacity(Gfx::font_slope_names.size()));
     for (auto& it : Gfx::font_slope_names)
         m_font_slope_list.unchecked_append(TRY(String::from_utf8(it.name)));
-    m_slope_combobox->set_model(TRY(GUI::ItemListModel<String>::try_create(m_font_slope_list)));
+    m_slope_combobox->set_model(GUI::ItemListModel<String>::create(m_font_slope_list));
 
     TRY(m_font_weight_list.try_ensure_capacity(Gfx::font_weight_names.size()));
     for (auto& it : Gfx::font_weight_names)
         m_font_weight_list.unchecked_append(TRY(String::from_utf8(it.name)));
-    m_weight_combobox->set_model(TRY(GUI::ItemListModel<String>::try_create(m_font_weight_list)));
+    m_weight_combobox->set_model(GUI::ItemListModel<String>::create(m_font_weight_list));
 
     auto unicode_blocks = Unicode::block_display_names();
     TRY(m_unicode_block_list.try_ensure_capacity(unicode_blocks.size() + 1));
@@ -427,7 +427,7 @@ ErrorOr<void> MainWidget::create_models()
     for (auto& block : unicode_blocks)
         m_unicode_block_list.unchecked_append(TRY(String::from_utf8(block.display_name)));
 
-    m_unicode_block_model = TRY(GUI::ItemListModel<String>::try_create(m_unicode_block_list));
+    m_unicode_block_model = GUI::ItemListModel<String>::create(m_unicode_block_list);
     m_filter_model = TRY(GUI::FilteringProxyModel::create(*m_unicode_block_model));
     m_filter_model->set_filter_term(""sv);
 

--- a/Userland/Applications/FontEditor/NewFontDialog.cpp
+++ b/Userland/Applications/FontEditor/NewFontDialog.cpp
@@ -145,13 +145,13 @@ ErrorOr<void> NewFontDialog::build()
     TRY(m_font_weight_list.try_ensure_capacity(Gfx::font_weight_names.size()));
     for (auto& it : Gfx::font_weight_names)
         m_font_weight_list.unchecked_append(TRY(String::from_utf8(it.name)));
-    m_weight_combobox->set_model(TRY(GUI::ItemListModel<String>::try_create(m_font_weight_list)));
+    m_weight_combobox->set_model(GUI::ItemListModel<String>::create(m_font_weight_list));
     m_weight_combobox->set_selected_index(3);
 
     TRY(m_font_slope_list.try_ensure_capacity(Gfx::font_slope_names.size()));
     for (auto& it : Gfx::font_slope_names)
         m_font_slope_list.unchecked_append(TRY(String::from_utf8(it.name)));
-    m_slope_combobox->set_model(TRY(GUI::ItemListModel<String>::try_create(m_font_slope_list)));
+    m_slope_combobox->set_model(GUI::ItemListModel<String>::create(m_font_slope_list));
     m_slope_combobox->set_selected_index(0);
 
     m_presentation_spinbox->set_value(12);

--- a/Userland/Applications/Help/MainWidget.cpp
+++ b/Userland/Applications/Help/MainWidget.cpp
@@ -223,7 +223,7 @@ ErrorOr<void> MainWidget::initialize_fallibles(GUI::Window& window)
     }));
     help_menu->add_action(GUI::CommonActions::make_about_action("Help"_string, TRY(GUI::Icon::try_create_default_icon("app-help"sv)), &window));
 
-    m_context_menu = TRY(GUI::Menu::try_create());
+    m_context_menu = GUI::Menu::construct();
     m_context_menu->add_action(*m_go_back_action);
     m_context_menu->add_action(*m_go_forward_action);
     m_context_menu->add_action(*m_go_home_action);

--- a/Userland/Applications/MailSettings/MailSettingsWidget.cpp
+++ b/Userland/Applications/MailSettings/MailSettingsWidget.cpp
@@ -60,7 +60,7 @@ ErrorOr<void> MailSettingsWidget::setup()
     m_port_combobox = *find_descendant_of_type_named<GUI::ComboBox>("port_input");
     m_port_combobox->set_text(Config::read_string("Mail"sv, "Connection"sv, "Port"sv, "993"sv));
     m_port_combobox->set_only_allow_values_from_model(false);
-    m_port_combobox->set_model(*TRY(GUI::ItemListModel<DeprecatedString>::try_create(m_common_ports)));
+    m_port_combobox->set_model(*GUI::ItemListModel<DeprecatedString>::create(m_common_ports));
     m_port_combobox->on_change = [&](auto, auto) {
         set_modified(true);
     };

--- a/Userland/Applications/NetworkSettings/NetworkSettingsWidget.cpp
+++ b/Userland/Applications/NetworkSettings/NetworkSettingsWidget.cpp
@@ -109,7 +109,7 @@ ErrorOr<void> NetworkSettingsWidget::setup()
         ::exit(1);
     }
 
-    m_adapters_combobox->set_model(TRY(GUI::ItemListModel<DeprecatedString>::try_create(m_adapter_names)));
+    m_adapters_combobox->set_model(GUI::ItemListModel<DeprecatedString>::create(m_adapter_names));
     m_adapters_combobox->on_change = [this](DeprecatedString const& text, GUI::ModelIndex const&) {
         on_switch_adapter(text);
     };

--- a/Userland/Applications/PixelPaint/FilterGallery.cpp
+++ b/Userland/Applications/PixelPaint/FilterGallery.cpp
@@ -36,7 +36,7 @@ FilterGallery::FilterGallery(GUI::Window* parent_window, ImageEditor* editor)
     VERIFY(m_config_widget);
     VERIFY(m_preview_widget);
 
-    m_error_label = GUI::Label::try_create().release_value_but_fixme_should_propagate_errors();
+    m_error_label = GUI::Label::construct();
     m_error_label->set_enabled(false);
 
     auto filter_tree_model = MUST(create_filter_tree_model(editor));

--- a/Userland/Applications/PixelPaint/Filters/Bloom.cpp
+++ b/Userland/Applications/PixelPaint/Filters/Bloom.cpp
@@ -37,7 +37,7 @@ void Bloom::apply(Gfx::Bitmap& target_bitmap) const
 ErrorOr<RefPtr<GUI::Widget>> Bloom::get_settings_widget()
 {
     if (!m_settings_widget) {
-        auto settings_widget = TRY(GUI::Widget::try_create());
+        auto settings_widget = GUI::Widget::construct();
         settings_widget->set_layout<GUI::VerticalBoxLayout>();
 
         auto name_label = TRY(settings_widget->try_add<GUI::Label>("Bloom Filter"_string));

--- a/Userland/Applications/PixelPaint/Filters/FastBoxBlur.cpp
+++ b/Userland/Applications/PixelPaint/Filters/FastBoxBlur.cpp
@@ -39,7 +39,7 @@ void FastBoxBlur::apply(Gfx::Bitmap& target_bitmap) const
 ErrorOr<RefPtr<GUI::Widget>> FastBoxBlur::get_settings_widget()
 {
     if (!m_settings_widget) {
-        auto settings_widget = TRY(GUI::Widget::try_create());
+        auto settings_widget = GUI::Widget::construct();
         settings_widget->set_layout<GUI::VerticalBoxLayout>();
 
         auto name_label = TRY(settings_widget->try_add<GUI::Label>("Fast Box Blur Filter"_string));

--- a/Userland/Applications/PixelPaint/Filters/Filter.cpp
+++ b/Userland/Applications/PixelPaint/Filters/Filter.cpp
@@ -25,7 +25,7 @@ Filter::Filter(ImageEditor* editor)
 ErrorOr<RefPtr<GUI::Widget>> Filter::get_settings_widget()
 {
     if (!m_settings_widget) {
-        auto settings_widget = TRY(GUI::Widget::try_create());
+        auto settings_widget = GUI::Widget::construct();
         settings_widget->set_layout<GUI::VerticalBoxLayout>();
 
         auto name_label = TRY(settings_widget->try_add<GUI::Label>(TRY(String::from_utf8(filter_name()))));

--- a/Userland/Applications/PixelPaint/Filters/HueAndSaturation.cpp
+++ b/Userland/Applications/PixelPaint/Filters/HueAndSaturation.cpp
@@ -30,7 +30,7 @@ void HueAndSaturation::apply(Gfx::Bitmap& target_bitmap) const
 ErrorOr<RefPtr<GUI::Widget>> HueAndSaturation::get_settings_widget()
 {
     if (!m_settings_widget) {
-        auto settings_widget = TRY(GUI::Widget::try_create());
+        auto settings_widget = GUI::Widget::construct();
         settings_widget->set_layout<GUI::VerticalBoxLayout>();
 
         auto add_slider = [&](auto name, int min, int max, auto member) -> ErrorOr<void> {

--- a/Userland/Applications/PixelPaint/Filters/Median.cpp
+++ b/Userland/Applications/PixelPaint/Filters/Median.cpp
@@ -45,7 +45,7 @@ void Median::apply(Gfx::Bitmap& target_bitmap, Gfx::Bitmap const& source_bitmap)
 ErrorOr<RefPtr<GUI::Widget>> Median::get_settings_widget()
 {
     if (!m_settings_widget) {
-        auto settings_widget = TRY(GUI::Widget::try_create());
+        auto settings_widget = GUI::Widget::construct();
         TRY(settings_widget->load_from_gml(median_settings_gml));
         settings_widget->find_descendant_of_type_named<GUI::SpinBox>("filter_radius")->on_change = [this](auto value) {
             m_filter_radius = value;

--- a/Userland/Applications/PixelPaint/Filters/Sepia.cpp
+++ b/Userland/Applications/PixelPaint/Filters/Sepia.cpp
@@ -20,7 +20,7 @@ void Sepia::apply(Gfx::Bitmap& target_bitmap, Gfx::Bitmap const& source_bitmap) 
 ErrorOr<RefPtr<GUI::Widget>> Sepia::get_settings_widget()
 {
     if (!m_settings_widget) {
-        auto settings_widget = TRY(GUI::Widget::try_create());
+        auto settings_widget = GUI::Widget::construct();
         settings_widget->set_layout<GUI::VerticalBoxLayout>();
 
         auto name_label = TRY(settings_widget->try_add<GUI::Label>("Sepia Filter"_string));

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -564,13 +564,13 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
     show_pixel_grid_action->set_checked(Config::read_bool("PixelPaint"sv, "PixelGrid"sv, "Show"sv, true));
     m_view_menu->add_action(*show_pixel_grid_action);
 
-    m_show_rulers_action = TRY(GUI::Action::try_create_checkable(
+    m_show_rulers_action = GUI::Action::create_checkable(
         "Show R&ulers", { Mod_Ctrl, Key_R }, [&](auto& action) {
             Config::write_bool("PixelPaint"sv, "Rulers"sv, "Show"sv, action.is_checked());
             auto* editor = current_image_editor();
             VERIFY(editor);
             editor->set_ruler_visibility(action.is_checked());
-        }));
+        });
     m_show_rulers_action->set_checked(Config::read_bool("PixelPaint"sv, "Rulers"sv, "Show"sv, true));
     m_view_menu->add_action(*m_show_rulers_action);
 

--- a/Userland/Applications/PixelPaint/Tools/BrushTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/BrushTool.cpp
@@ -200,7 +200,7 @@ void BrushTool::draw_line(Gfx::Bitmap& bitmap, Gfx::Color color, Gfx::IntPoint s
 ErrorOr<GUI::Widget*> BrushTool::get_properties_widget()
 {
     if (!m_properties_widget) {
-        auto properties_widget = TRY(GUI::Widget::try_create());
+        auto properties_widget = GUI::Widget::construct();
         properties_widget->set_layout<GUI::VerticalBoxLayout>();
 
         auto mode_container = TRY(properties_widget->try_add<GUI::Widget>());

--- a/Userland/Applications/PixelPaint/Tools/BucketTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/BucketTool.cpp
@@ -64,7 +64,7 @@ void BucketTool::on_mousedown(Layer* layer, MouseEvent& event)
 ErrorOr<GUI::Widget*> BucketTool::get_properties_widget()
 {
     if (!m_properties_widget) {
-        auto properties_widget = TRY(GUI::Widget::try_create());
+        auto properties_widget = GUI::Widget::construct();
         properties_widget->set_layout<GUI::VerticalBoxLayout>();
 
         auto threshold_container = TRY(properties_widget->try_add<GUI::Widget>());

--- a/Userland/Applications/PixelPaint/Tools/CloneTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/CloneTool.cpp
@@ -128,7 +128,7 @@ void CloneTool::on_keyup(GUI::KeyEvent& event)
 ErrorOr<GUI::Widget*> CloneTool::get_properties_widget()
 {
     if (!m_properties_widget) {
-        auto properties_widget = TRY(GUI::Widget::try_create());
+        auto properties_widget = GUI::Widget::construct();
         properties_widget->set_layout<GUI::VerticalBoxLayout>();
 
         auto size_container = TRY(properties_widget->try_add<GUI::Widget>());

--- a/Userland/Applications/PixelPaint/Tools/EllipseTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/EllipseTool.cpp
@@ -129,7 +129,7 @@ bool EllipseTool::on_keydown(GUI::KeyEvent& event)
 ErrorOr<GUI::Widget*> EllipseTool::get_properties_widget()
 {
     if (!m_properties_widget) {
-        auto properties_widget = TRY(GUI::Widget::try_create());
+        auto properties_widget = GUI::Widget::construct();
         properties_widget->set_layout<GUI::VerticalBoxLayout>();
 
         auto thickness_container = TRY(properties_widget->try_add<GUI::Widget>());

--- a/Userland/Applications/PixelPaint/Tools/EraseTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/EraseTool.cpp
@@ -57,7 +57,7 @@ void EraseTool::draw_point(Gfx::Bitmap& bitmap, Gfx::Color color, Gfx::IntPoint 
 ErrorOr<GUI::Widget*> EraseTool::get_properties_widget()
 {
     if (!m_properties_widget) {
-        auto properties_widget = TRY(GUI::Widget::try_create());
+        auto properties_widget = GUI::Widget::construct();
         properties_widget->set_layout<GUI::VerticalBoxLayout>();
 
         auto size_container = TRY(properties_widget->try_add<GUI::Widget>());

--- a/Userland/Applications/PixelPaint/Tools/GradientTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/GradientTool.cpp
@@ -201,7 +201,7 @@ void GradientTool::on_tool_activation()
 ErrorOr<GUI::Widget*> GradientTool::get_properties_widget()
 {
     if (!m_properties_widget) {
-        auto properties_widget = TRY(GUI::Widget::try_create());
+        auto properties_widget = GUI::Widget::construct();
         properties_widget->set_layout<GUI::VerticalBoxLayout>();
 
         auto mode_container = TRY(properties_widget->try_add<GUI::Widget>());

--- a/Userland/Applications/PixelPaint/Tools/GuideTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/GuideTool.cpp
@@ -179,7 +179,7 @@ void GuideTool::on_tool_activation()
 ErrorOr<GUI::Widget*> GuideTool::get_properties_widget()
 {
     if (!m_properties_widget) {
-        auto properties_widget = TRY(GUI::Widget::try_create());
+        auto properties_widget = GUI::Widget::construct();
         properties_widget->set_layout<GUI::VerticalBoxLayout>();
 
         auto snapping_container = TRY(properties_widget->try_add<GUI::Widget>());

--- a/Userland/Applications/PixelPaint/Tools/LassoSelectTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/LassoSelectTool.cpp
@@ -160,7 +160,7 @@ ErrorOr<GUI::Widget*> LassoSelectTool::get_properties_widget()
         return m_properties_widget.ptr();
     }
 
-    auto properties_widget = TRY(GUI::Widget::try_create());
+    auto properties_widget = GUI::Widget::construct();
     properties_widget->set_layout<GUI::VerticalBoxLayout>();
 
     auto mode_container = TRY(properties_widget->try_add<GUI::Widget>());

--- a/Userland/Applications/PixelPaint/Tools/LineTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/LineTool.cpp
@@ -122,7 +122,7 @@ bool LineTool::on_keydown(GUI::KeyEvent& event)
 ErrorOr<GUI::Widget*> LineTool::get_properties_widget()
 {
     if (!m_properties_widget) {
-        auto properties_widget = TRY(GUI::Widget::try_create());
+        auto properties_widget = GUI::Widget::construct();
         properties_widget->set_layout<GUI::VerticalBoxLayout>();
 
         auto thickness_container = TRY(properties_widget->try_add<GUI::Widget>());

--- a/Userland/Applications/PixelPaint/Tools/MoveTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/MoveTool.cpp
@@ -292,7 +292,7 @@ Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap const>> MoveTool::cursor(
 ErrorOr<GUI::Widget*> MoveTool::get_properties_widget()
 {
     if (!m_properties_widget) {
-        auto properties_widget = TRY(GUI::Widget::try_create());
+        auto properties_widget = GUI::Widget::construct();
         properties_widget->set_layout<GUI::VerticalBoxLayout>();
 
         auto selection_mode_container = TRY(properties_widget->try_add<GUI::Widget>());

--- a/Userland/Applications/PixelPaint/Tools/PenTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/PenTool.cpp
@@ -38,7 +38,7 @@ void PenTool::draw_line(Gfx::Bitmap& bitmap, Gfx::Color color, Gfx::IntPoint sta
 ErrorOr<GUI::Widget*> PenTool::get_properties_widget()
 {
     if (!m_properties_widget) {
-        auto properties_widget = TRY(GUI::Widget::try_create());
+        auto properties_widget = GUI::Widget::construct();
         properties_widget->set_layout<GUI::VerticalBoxLayout>();
 
         auto size_container = TRY(properties_widget->try_add<GUI::Widget>());

--- a/Userland/Applications/PixelPaint/Tools/PickerTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/PickerTool.cpp
@@ -44,7 +44,7 @@ void PickerTool::on_mousemove(Layer* layer, MouseEvent& event)
 ErrorOr<GUI::Widget*> PickerTool::get_properties_widget()
 {
     if (!m_properties_widget) {
-        auto properties_widget = TRY(GUI::Widget::try_create());
+        auto properties_widget = GUI::Widget::construct();
         properties_widget->set_layout<GUI::VerticalBoxLayout>();
 
         auto sample_checkbox = TRY(properties_widget->try_add<GUI::CheckBox>("Sample all layers"_string));

--- a/Userland/Applications/PixelPaint/Tools/PolygonalSelectTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/PolygonalSelectTool.cpp
@@ -189,7 +189,7 @@ ErrorOr<GUI::Widget*> PolygonalSelectTool::get_properties_widget()
     if (m_properties_widget)
         return m_properties_widget.ptr();
 
-    auto properties_widget = TRY(GUI::Widget::try_create());
+    auto properties_widget = GUI::Widget::construct();
     properties_widget->set_layout<GUI::VerticalBoxLayout>();
 
     auto mode_container = TRY(properties_widget->try_add<GUI::Widget>());

--- a/Userland/Applications/PixelPaint/Tools/RectangleSelectTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/RectangleSelectTool.cpp
@@ -157,7 +157,7 @@ ErrorOr<GUI::Widget*> RectangleSelectTool::get_properties_widget()
         return m_properties_widget.ptr();
     }
 
-    auto properties_widget = TRY(GUI::Widget::try_create());
+    auto properties_widget = GUI::Widget::construct();
     properties_widget->set_layout<GUI::VerticalBoxLayout>();
 
     auto feather_container = TRY(properties_widget->try_add<GUI::Widget>());

--- a/Userland/Applications/PixelPaint/Tools/RectangleTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/RectangleTool.cpp
@@ -143,7 +143,7 @@ bool RectangleTool::on_keydown(GUI::KeyEvent& event)
 ErrorOr<GUI::Widget*> RectangleTool::get_properties_widget()
 {
     if (!m_properties_widget) {
-        auto properties_widget = TRY(GUI::Widget::try_create());
+        auto properties_widget = GUI::Widget::construct();
         properties_widget->set_layout<GUI::VerticalBoxLayout>();
 
         auto thickness_or_radius_container = TRY(properties_widget->try_add<GUI::Widget>());

--- a/Userland/Applications/PixelPaint/Tools/SprayTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/SprayTool.cpp
@@ -93,7 +93,7 @@ void SprayTool::on_mouseup(Layer*, MouseEvent&)
 ErrorOr<GUI::Widget*> SprayTool::get_properties_widget()
 {
     if (!m_properties_widget) {
-        auto properties_widget = TRY(GUI::Widget::try_create());
+        auto properties_widget = GUI::Widget::construct();
         properties_widget->set_layout<GUI::VerticalBoxLayout>();
 
         auto size_container = TRY(properties_widget->try_add<GUI::Widget>());

--- a/Userland/Applications/PixelPaint/Tools/TextTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/TextTool.cpp
@@ -108,7 +108,7 @@ ErrorOr<GUI::Widget*> TextTool::get_properties_widget()
     if (m_properties_widget)
         return m_properties_widget.ptr();
 
-    auto properties_widget = TRY(GUI::Widget::try_create());
+    auto properties_widget = GUI::Widget::construct();
     properties_widget->set_layout<GUI::VerticalBoxLayout>();
 
     auto font_header = TRY(properties_widget->try_add<GUI::Label>("Current Font:"_string));

--- a/Userland/Applications/PixelPaint/Tools/WandSelectTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/WandSelectTool.cpp
@@ -72,7 +72,7 @@ ErrorOr<GUI::Widget*> WandSelectTool::get_properties_widget()
         return m_properties_widget.ptr();
     }
 
-    auto properties_widget = TRY(GUI::Widget::try_create());
+    auto properties_widget = GUI::Widget::construct();
     properties_widget->set_layout<GUI::VerticalBoxLayout>();
 
     auto threshold_container = TRY(properties_widget->try_add<GUI::Widget>());

--- a/Userland/Applications/PixelPaint/Tools/ZoomTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/ZoomTool.cpp
@@ -26,7 +26,7 @@ void ZoomTool::on_mousedown(Layer*, MouseEvent& event)
 ErrorOr<GUI::Widget*> ZoomTool::get_properties_widget()
 {
     if (!m_properties_widget) {
-        auto properties_widget = TRY(GUI::Widget::try_create());
+        auto properties_widget = GUI::Widget::construct();
         properties_widget->set_layout<GUI::VerticalBoxLayout>();
 
         auto sensitivity_container = TRY(properties_widget->try_add<GUI::Widget>());

--- a/Userland/Applications/SpaceAnalyzer/main.cpp
+++ b/Userland/Applications/SpaceAnalyzer/main.cpp
@@ -134,7 +134,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         }
     });
 
-    auto context_menu = TRY(GUI::Menu::try_create());
+    auto context_menu = GUI::Menu::construct();
     context_menu->add_action(open_action);
     context_menu->add_action(copy_path_action);
     context_menu->add_action(delete_action);

--- a/Userland/Applications/SystemMonitor/NetworkStatisticsWidget.cpp
+++ b/Userland/Applications/SystemMonitor/NetworkStatisticsWidget.cpp
@@ -71,7 +71,7 @@ NetworkStatisticsWidget::NetworkStatisticsWidget()
         net_adapters_fields.empend("bytes_out", "Bytes Out"_string, Gfx::TextAlignment::CenterRight);
         m_adapter_model = GUI::JsonArrayModel::create("/sys/kernel/net/adapters", move(net_adapters_fields));
         m_adapter_table_view->set_model(MUST(GUI::SortingProxyModel::create(*m_adapter_model)));
-        m_adapter_context_menu = MUST(GUI::Menu::try_create());
+        m_adapter_context_menu = GUI::Menu::construct();
         m_adapter_context_menu->add_action(GUI::Action::create(
             "Open in Network Settings...", MUST(Gfx::Bitmap::load_from_file("/res/icons/16x16/network.png"sv)), [this](GUI::Action&) {
                 m_adapter_table_view->selection().for_each_index([this](GUI::ModelIndex const& index) {

--- a/Userland/Applications/SystemMonitor/main.cpp
+++ b/Userland/Applications/SystemMonitor/main.cpp
@@ -432,7 +432,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         GUI::Application::the()->quit();
     }));
 
-    auto process_context_menu = TRY(GUI::Menu::try_create());
+    auto process_context_menu = GUI::Menu::construct();
     process_context_menu->add_action(kill_action);
     process_context_menu->add_action(stop_action);
     process_context_menu->add_action(continue_action);

--- a/Userland/Applications/ThemeEditor/MainWidget.cpp
+++ b/Userland/Applications/ThemeEditor/MainWidget.cpp
@@ -464,7 +464,7 @@ ErrorOr<void> MainWidget::add_property_tab(PropertyTab const& property_tab)
     auto& scrollable_container = m_property_tabs->add_tab<GUI::ScrollableContainerWidget>(TRY(String::from_utf8(property_tab.title)));
     scrollable_container.set_should_hide_unnecessary_scrollbars(true);
 
-    auto properties_list = TRY(GUI::Widget::try_create());
+    auto properties_list = GUI::Widget::construct();
     scrollable_container.set_widget(properties_list);
     properties_list->set_layout<GUI::VerticalBoxLayout>(GUI::Margins { 8 }, 12);
 

--- a/Userland/Demos/CatDog/main.cpp
+++ b/Userland/Demos/CatDog/main.cpp
@@ -44,7 +44,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_main_widget(catdog_widget);
     catdog_widget->set_layout<GUI::VerticalBoxLayout>(GUI::Margins {}, 0);
 
-    auto context_menu = TRY(GUI::Menu::try_create());
+    auto context_menu = GUI::Menu::construct();
     context_menu->add_action(GUI::CommonActions::make_about_action("CatDog Demo"_string, app_icon, window));
     context_menu->add_separator();
     context_menu->add_action(GUI::CommonActions::make_quit_action([&](auto&) { app->quit(); }));

--- a/Userland/Demos/WidgetGallery/GalleryWidget.cpp
+++ b/Userland/Demos/WidgetGallery/GalleryWidget.cpp
@@ -89,7 +89,7 @@ GalleryWidget::GalleryWidget()
     m_font_button->set_icon(Gfx::Bitmap::load_from_file("/res/icons/16x16/app-font-editor.png"sv).release_value_but_fixme_should_propagate_errors());
 
     m_font_button->on_click = [&](auto) {
-        auto picker = GUI::FontPicker::try_create(window(), &m_text_editor->font(), false).release_value_but_fixme_should_propagate_errors();
+        auto picker = GUI::FontPicker::construct(window(), &m_text_editor->font(), false);
         if (picker->exec() == GUI::Dialog::ExecResult::OK) {
             m_text_editor->set_font(picker->font());
         }

--- a/Userland/DevTools/HackStudio/GMLPreviewWidget.cpp
+++ b/Userland/DevTools/HackStudio/GMLPreviewWidget.cpp
@@ -29,7 +29,7 @@ void GMLPreviewWidget::load_gml(DeprecatedString const& gml)
 
     // FIXME: Parsing errors happen while the user is typing. What should we do about them?
     (void)load_from_gml(gml, [](StringView name) -> ErrorOr<NonnullRefPtr<Core::EventReceiver>> {
-        return GUI::Label::try_create(TRY(String::formatted("{} is not registered as a GML element!", name)));
+        return GUI::Label::construct(TRY(String::formatted("{} is not registered as a GML element!", name)));
     });
 
     if (children().is_empty()) {

--- a/Userland/DevTools/Profiler/main.cpp
+++ b/Userland/DevTools/Profiler/main.cpp
@@ -92,7 +92,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     main_widget->set_fill_with_background_color(true);
     main_widget->set_layout<GUI::VerticalBoxLayout>();
 
-    auto timeline_header_container = TRY(GUI::Widget::try_create());
+    auto timeline_header_container = GUI::Widget::construct();
     timeline_header_container->set_layout<GUI::VerticalBoxLayout>();
     timeline_header_container->set_fill_with_background_color(true);
     timeline_header_container->set_shrink_to_fit(true);

--- a/Userland/Games/BrickGame/main.cpp
+++ b/Userland/Games/BrickGame/main.cpp
@@ -60,10 +60,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         game->toggle_pause();
     }));
 
-    auto show_shadow_piece_action = TRY(GUI::Action::try_create_checkable("Show Shadow Piece", GUI::Shortcut {}, [&](auto& action) {
+    auto show_shadow_piece_action = GUI::Action::create_checkable("Show Shadow Piece", GUI::Shortcut {}, [&](auto& action) {
         game->set_show_shadow_hint(action.is_checked());
         Config::write_bool(app_name, app_name, "ShowShadowPiece"sv, action.is_checked());
-    }));
+    });
     game->set_show_shadow_hint(Config::read_bool(app_name, app_name, "ShowShadowPiece"sv, true));
     show_shadow_piece_action->set_checked(game->show_shadow_hint());
 

--- a/Userland/Games/Snake/main.cpp
+++ b/Userland/Games/Snake/main.cpp
@@ -127,11 +127,11 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     skin_menu->set_icon(app_icon.bitmap_for_size(16));
 
     auto add_skin_action = [&](StringView name, bool enable_color) -> ErrorOr<void> {
-        auto action = TRY(GUI::Action::try_create_checkable(name, {}, [&, enable_color](auto& action) {
+        auto action = GUI::Action::create_checkable(name, GUI::Shortcut {}, [&, enable_color](auto& action) {
             Config::write_string("Snake"sv, "Snake"sv, "SnakeSkin"sv, action.text());
             game.set_skin_name(String::from_deprecated_string(action.text()).release_value_but_fixme_should_propagate_errors());
             change_snake_color->set_enabled(enable_color);
-        }));
+        });
 
         skin_action_group.add_action(*action);
         if (snake_skin_name == name)

--- a/Userland/Libraries/LibGUI/Action.cpp
+++ b/Userland/Libraries/LibGUI/Action.cpp
@@ -65,11 +65,6 @@ NonnullRefPtr<Action> Action::create_checkable(DeprecatedString text, Shortcut c
     return adopt_ref(*new Action(move(text), shortcut, Shortcut {}, move(icon), move(callback), parent, true));
 }
 
-ErrorOr<NonnullRefPtr<Action>> Action::try_create_checkable(DeprecatedString text, Shortcut const& shortcut, Function<void(Action&)> callback, Core::EventReceiver* parent)
-{
-    return adopt_nonnull_ref_or_enomem(new (nothrow) Action(move(text), shortcut, Shortcut {}, move(callback), parent, true));
-}
-
 RefPtr<Action> Action::find_action_for_shortcut(Core::EventReceiver& object, Shortcut const& shortcut)
 {
     RefPtr<Action> found_action = nullptr;

--- a/Userland/Libraries/LibGUI/Action.h
+++ b/Userland/Libraries/LibGUI/Action.h
@@ -77,8 +77,6 @@ public:
     static NonnullRefPtr<Action> create_checkable(DeprecatedString text, Shortcut const& shortcut, Function<void(Action&)> callback, Core::EventReceiver* parent = nullptr);
     static NonnullRefPtr<Action> create_checkable(DeprecatedString text, Shortcut const& shortcut, RefPtr<Gfx::Bitmap const> icon, Function<void(Action&)> callback, Core::EventReceiver* parent = nullptr);
 
-    static ErrorOr<NonnullRefPtr<Action>> try_create_checkable(DeprecatedString text, Shortcut const& shortcut, Function<void(Action&)> callback, Core::EventReceiver* parent = nullptr);
-
     static RefPtr<Action> find_action_for_shortcut(Core::EventReceiver& object, Shortcut const& shortcut);
 
     virtual ~Action() override;

--- a/Userland/Libraries/LibGUI/FilePicker.cpp
+++ b/Userland/Libraries/LibGUI/FilePicker.cpp
@@ -38,7 +38,7 @@ namespace GUI {
 
 ErrorOr<Optional<String>> FilePicker::get_filepath(Badge<FileSystemAccessServer::ConnectionFromClient>, i32 window_server_client_id, i32 parent_window_id, Mode mode, StringView window_title, StringView file_basename, StringView path, Optional<Vector<FileTypeFilter>> allowed_file_types)
 {
-    auto picker = TRY(FilePicker::try_create(nullptr, mode, file_basename, path, ScreenPosition::DoNotPosition, move(allowed_file_types)));
+    auto picker = FilePicker::construct(nullptr, mode, file_basename, path, ScreenPosition::DoNotPosition, move(allowed_file_types));
     auto parent_rect = ConnectionToWindowServer::the().get_window_rect_from_client(window_server_client_id, parent_window_id);
     picker->center_within(parent_rect);
     picker->constrain_to_desktop();

--- a/Userland/Libraries/LibGUI/ItemListModel.h
+++ b/Userland/Libraries/LibGUI/ItemListModel.h
@@ -36,17 +36,6 @@ public:
         return adopt_ref(*new ItemListModel<T, Container>(data, row_count));
     }
 
-    static ErrorOr<NonnullRefPtr<ItemListModel>> try_create(Container const& data, ColumnNamesT const& column_names, Optional<size_t> const& row_count = {})
-    requires(IsTwoDimensional)
-    {
-        return adopt_nonnull_ref_or_enomem(new (nothrow) ItemListModel<T, Container, ColumnNameListType>(data, column_names, row_count));
-    }
-    static ErrorOr<NonnullRefPtr<ItemListModel>> try_create(Container const& data, Optional<size_t> const& row_count = {})
-    requires(!IsTwoDimensional)
-    {
-        return adopt_nonnull_ref_or_enomem(new (nothrow) ItemListModel<T, Container>(data, row_count));
-    }
-
     virtual ~ItemListModel() override = default;
 
     virtual int row_count(ModelIndex const& index) const override

--- a/Userland/Libraries/LibGUI/LinkLabel.cpp
+++ b/Userland/Libraries/LibGUI/LinkLabel.cpp
@@ -23,7 +23,7 @@ ErrorOr<NonnullRefPtr<LinkLabel>> LinkLabel::try_create(String text)
 {
     auto label = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) LinkLabel(move(text))));
     TRY(label->create_actions());
-    TRY(label->create_menus());
+    label->create_menus();
     return label;
 }
 
@@ -47,13 +47,12 @@ ErrorOr<void> LinkLabel::create_actions()
     return {};
 }
 
-ErrorOr<void> LinkLabel::create_menus()
+void LinkLabel::create_menus()
 {
-    m_context_menu = TRY(Menu::try_create());
+    m_context_menu = Menu::construct();
     m_context_menu->add_action(*m_open_action);
     m_context_menu->add_separator();
     m_context_menu->add_action(*m_copy_action);
-    return {};
 }
 
 void LinkLabel::set_hovered(bool hover)

--- a/Userland/Libraries/LibGUI/LinkLabel.h
+++ b/Userland/Libraries/LibGUI/LinkLabel.h
@@ -22,7 +22,7 @@ private:
     explicit LinkLabel(String text = {});
 
     ErrorOr<void> create_actions();
-    ErrorOr<void> create_menus();
+    void create_menus();
 
     virtual void mousemove_event(MouseEvent&) override;
     virtual void mousedown_event(MouseEvent&) override;

--- a/Userland/Libraries/LibGUI/PathBreadcrumbbar.cpp
+++ b/Userland/Libraries/LibGUI/PathBreadcrumbbar.cpp
@@ -23,8 +23,8 @@ namespace GUI {
 
 ErrorOr<NonnullRefPtr<PathBreadcrumbbar>> PathBreadcrumbbar::try_create()
 {
-    auto location_text_box = TRY(TextBox::try_create());
-    auto breadcrumbbar = TRY(Breadcrumbbar::try_create());
+    auto location_text_box = TextBox::construct();
+    auto breadcrumbbar = Breadcrumbbar::construct();
 
     auto path_breadcrumbbar = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) PathBreadcrumbbar(*location_text_box, *breadcrumbbar)));
     path_breadcrumbbar->set_layout<GUI::VerticalBoxLayout>();

--- a/Userland/Libraries/LibGUI/Toolbar.cpp
+++ b/Userland/Libraries/LibGUI/Toolbar.cpp
@@ -221,7 +221,7 @@ ErrorOr<void> Toolbar::update_overflow_menu()
     m_overflow_action->set_enabled(true);
     m_overflow_button->set_visible(true);
 
-    m_overflow_menu = TRY(Menu::try_create());
+    m_overflow_menu = Menu::construct();
     m_overflow_button->set_menu(m_overflow_menu);
 
     for (size_t i = marginal_index.value(); i < m_items.size(); ++i) {

--- a/Userland/Services/Taskbar/main.cpp
+++ b/Userland/Services/Taskbar/main.cpp
@@ -117,7 +117,7 @@ ErrorOr<Vector<DeprecatedString>> discover_apps_and_categories()
 ErrorOr<NonnullRefPtr<GUI::Menu>> build_system_menu(GUI::Window& window)
 {
     Vector<DeprecatedString> const sorted_app_categories = TRY(discover_apps_and_categories());
-    auto system_menu = TRY(GUI::Menu::try_create("\xE2\x9A\xA1"_string)); // HIGH VOLTAGE SIGN
+    auto system_menu = GUI::Menu::construct("\xE2\x9A\xA1"_string); // HIGH VOLTAGE SIGN
 
     system_menu->add_action(GUI::Action::create("&About SerenityOS", TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/ladyball.png"sv)), [&](auto&) {
         GUI::Process::spawn_or_show_error(&window, "/bin/About"sv);

--- a/Userland/Utilities/notify.cpp
+++ b/Userland/Utilities/notify.cpp
@@ -23,7 +23,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_positional_argument(icon_path, "Path of icon to display in the notification", "icon-path", Core::ArgsParser::Required::No);
     args_parser.parse(arguments);
 
-    auto notification = TRY(GUI::Notification::try_create());
+    auto notification = GUI::Notification::construct();
     notification->set_text(message);
     notification->set_title(title);
     if (!icon_path.is_empty()) {


### PR DESCRIPTION
This PR makes the construction of LibGUI objects non-fallible by replacing `try_create()` calls with `construct()`.

Things this PR doesn't touch:

* I left `GUI::Icon::try_create_default_icon()` alone, as this loads a file from disk.
* Any custom widgets (outside of LibGUI) that use `try_create()`.
* The `REGISTER_WIDGET` macro still calls `try_create()`.