### PR TITLE
Userland+Tests: Add initial riscv64 support

### DIFF
--- a/Tests/Kernel/crash.cpp
+++ b/Tests/Kernel/crash.cpp
@@ -210,6 +210,9 @@ int main(int argc, char** argv)
 #elif ARCH(AARCH64)
             (void)makeshift_esp;
             TODO_AARCH64();
+#elif ARCH(RISCV64)
+            (void)makeshift_esp;
+            TODO_RISCV64();
 #else
 #    error Unknown architecture
 #endif
@@ -226,6 +229,9 @@ int main(int argc, char** argv)
 #elif ARCH(AARCH64)
             (void)bad_esp;
             TODO_AARCH64();
+#elif ARCH(RISCV64)
+            (void)bad_esp;
+            TODO_RISCV64();
 #else
 #    error Unknown architecture
 #endif
@@ -247,6 +253,9 @@ int main(int argc, char** argv)
 #elif ARCH(AARCH64)
             (void)bad_esp;
             TODO_AARCH64();
+#elif ARCH(RISCV64)
+            (void)bad_esp;
+            TODO_RISCV64();
 #else
 #    error Unknown architecture
 #endif
@@ -290,6 +299,8 @@ int main(int argc, char** argv)
             asm volatile("str %eax");
 #elif ARCH(AARCH64)
             TODO_AARCH64();
+#elif ARCH(RISCV64)
+            TODO_RISCV64();
 #else
 #    error Unknown architecture
 #endif

--- a/Tests/Kernel/elf-symbolication-kernel-read-exploit.cpp
+++ b/Tests/Kernel/elf-symbolication-kernel-read-exploit.cpp
@@ -19,6 +19,10 @@ asm("haxcode:\n"
 asm("haxcode:\n"
     "1: b 1b\n"
     "haxcode_end:\n");
+#elif ARCH(RISCV64)
+asm("haxcode:\n"
+    "1: j 1b\n"
+    "haxcode_end:\n");
 #else
 #    error Unknown architecture
 #endif

--- a/Userland/Applications/CrashReporter/main.cpp
+++ b/Userland/Applications/CrashReporter/main.cpp
@@ -140,6 +140,12 @@ static TitleAndText build_cpu_registers(const ELF::Core::ThreadInfo& thread_info
     builder.appendff("x20={:p} x21={:p} x22={:p} x23={:p} x24={:p}\n", regs.x[20], regs.x[21], regs.x[22], regs.x[23], regs.x[24]);
     builder.appendff("x25={:p} x26={:p} x27={:p} x28={:p} x29={:p}\n", regs.x[25], regs.x[26], regs.x[27], regs.x[28], regs.x[29]);
     builder.appendff("x30={:p}", regs.x[30]);
+#elif ARCH(RISCV64)
+    builder.appendff("Program counter pc={:p}\n", regs.pc);
+    builder.appendff("ra={:p} sp={:p} gp={:p} tp={:p} fp={:p}\n", regs.x[0], regs.x[1], regs.x[2], regs.x[3], regs.x[7]);
+    builder.appendff("a0={:p} a1={:p} a2={:p} a3={:p} a4={:p} a5={:p} a6={:p} a7={:p}\n", regs.x[9], regs.x[10], regs.x[11], regs.x[12], regs.x[13], regs.x[14], regs.x[15], regs.x[16]);
+    builder.appendff("t0={:p} t1={:p} t2={:p} t3={:p} t4={:p} t5={:p} t6={:p}\n", regs.x[4], regs.x[5], regs.x[6], regs.x[27], regs.x[28], regs.x[29], regs.x[30]);
+    builder.appendff("s1={:p} s2={:p} s3={:p} s4={:p} s5={:p} s6={:p} s7={:p} s8={:p} s9={:p} s10={:p} s11={:p}\n", regs.x[8], regs.x[17], regs.x[18], regs.x[19], regs.x[20], regs.x[21], regs.x[22], regs.x[23], regs.x[24], regs.x[25], regs.x[26]);
 #else
 #    error Unknown architecture
 #endif

--- a/Userland/Applications/Debugger/main.cpp
+++ b/Userland/Applications/Debugger/main.cpp
@@ -48,6 +48,9 @@ static void handle_print_registers(PtraceRegisters const& regs)
 #elif ARCH(AARCH64)
     (void)regs;
     TODO_AARCH64();
+#elif ARCH(RISCV64)
+    (void)regs;
+    TODO_RISCV64();
 #else
 #    error Unknown architecture
 #endif
@@ -251,6 +254,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 #elif ARCH(AARCH64)
         const FlatPtr ip = 0; // FIXME
         TODO_AARCH64();
+#elif ARCH(RISCV64)
+        const FlatPtr ip = 0; // FIXME
+        TODO_RISCV64();
 #else
 #    error Unknown architecture
 #endif

--- a/Userland/DevTools/HackStudio/Debugger/RegistersModel.cpp
+++ b/Userland/DevTools/HackStudio/Debugger/RegistersModel.cpp
@@ -40,6 +40,8 @@ RegistersModel::RegistersModel(PtraceRegisters const& regs)
     m_registers.append({ "gs", regs.gs });
 #elif ARCH(AARCH64)
     TODO_AARCH64();
+#elif ARCH(RISCV64)
+    TODO_RISCV64();
 #else
 #    error Unknown architecture
 #endif
@@ -76,6 +78,9 @@ RegistersModel::RegistersModel(PtraceRegisters const& current_regs, PtraceRegist
 #elif ARCH(AARCH64)
     (void)previous_regs;
     TODO_AARCH64();
+#elif ARCH(RISCV64)
+    (void)previous_regs;
+    TODO_RISCV64();
 #else
 #    error Unknown architecture
 #endif

--- a/Userland/DynamicLoader/main.cpp
+++ b/Userland/DynamicLoader/main.cpp
@@ -73,10 +73,17 @@ NAKED void _start(int, char**, char**)
         "mov x29, 0\n"
         "mov x30, 0\n"
         "bl _entry\n");
-#else
+#elif ARCH(RISCV64)
+    asm(
+        "li fp, 0\n"
+        "li ra, 0\n"
+        "tail _entry@plt\n");
+#elif ARCH(X86_64)
     asm(
         "push $0\n"
         "jmp _entry@plt\n");
+#else
+#    error "Unknown architecture"
 #endif
 }
 

--- a/Userland/Libraries/LibC/arch/riscv64/setjmp.S
+++ b/Userland/Libraries/LibC/arch/riscv64/setjmp.S
@@ -1,1 +1,20 @@
-# Intentionally empty.
+.global _setjmp
+.global setjmp
+_setjmp:
+setjmp:
+    # FIXME: Implement setjmp.
+    unimp
+
+.global _longjmp
+.global longjmp
+_longjmp:
+longjmp:
+    # FIXME: Implement longjmp.
+    unimp
+
+.global _sigsetjmp
+.global sigsetjmp
+_sigsetjmp:
+sigsetjmp:
+    # FIXME: Implement sigsetjmp.
+    unimp

--- a/Userland/Libraries/LibC/crt0.cpp
+++ b/Userland/Libraries/LibC/crt0.cpp
@@ -27,10 +27,17 @@ NAKED void _start(int, char**, char**)
         "mov x29, 0\n"
         "mov x30, 0\n"
         "bl _entry\n");
-#    else
+#    elif ARCH(RISCV64)
+    asm(
+        "li fp, 0\n"
+        "li ra, 0\n"
+        "tail _entry@plt\n");
+#    elif ARCH(X86_64)
     asm(
         "push $0\n"
         "jmp _entry@plt\n");
+#    else
+#        error "Unknown architecture"
 #    endif
 }
 

--- a/Userland/Libraries/LibC/math.cpp
+++ b/Userland/Libraries/LibC/math.cpp
@@ -9,7 +9,7 @@
 
 #include <AK/BuiltinWrappers.h>
 #include <AK/FloatingPoint.h>
-#if !ARCH(AARCH64)
+#if ARCH(X86_64)
 #    include <AK/FPControl.h>
 #endif
 #include <AK/Math.h>
@@ -363,7 +363,7 @@ MAKE_AK_BACKED2(remainder);
 
 long double truncl(long double x) NOEXCEPT
 {
-#if !ARCH(AARCH64)
+#if ARCH(X86_64)
     if (fabsl(x) < LONG_LONG_MAX) {
         // This is 1.6 times faster than the implementation using the "internal_to_integer"
         // helper (on x86_64)
@@ -383,7 +383,7 @@ long double truncl(long double x) NOEXCEPT
 
 double trunc(double x) NOEXCEPT
 {
-#if !ARCH(AARCH64)
+#if ARCH(X86_64)
     if (fabs(x) < LONG_LONG_MAX) {
         u64 temp;
         asm(
@@ -400,7 +400,7 @@ double trunc(double x) NOEXCEPT
 
 float truncf(float x) NOEXCEPT
 {
-#if !ARCH(AARCH64)
+#if ARCH(X86_64)
     if (fabsf(x) < LONG_LONG_MAX) {
         u64 temp;
         asm(
@@ -420,13 +420,18 @@ long double rintl(long double value)
 #if ARCH(AARCH64)
     (void)value;
     TODO_AARCH64();
-#else
+#elif ARCH(RISCV64)
+    (void)value;
+    TODO_RISCV64();
+#elif ARCH(X86_64)
     long double res;
     asm(
         "frndint\n"
         : "=t"(res)
         : "0"(value));
     return res;
+#else
+#    error "Unknown architecture"
 #endif
 }
 double rint(double value)
@@ -434,13 +439,18 @@ double rint(double value)
 #if ARCH(AARCH64)
     (void)value;
     TODO_AARCH64();
-#else
+#elif ARCH(RISCV64)
+    (void)value;
+    TODO_RISCV64();
+#elif ARCH(X86_64)
     double res;
     asm(
         "frndint\n"
         : "=t"(res)
         : "0"(value));
     return res;
+#else
+#    error "Unknown architecture"
 #endif
 }
 float rintf(float value)
@@ -448,13 +458,18 @@ float rintf(float value)
 #if ARCH(AARCH64)
     (void)value;
     TODO_AARCH64();
-#else
+#elif ARCH(RISCV64)
+    (void)value;
+    TODO_RISCV64();
+#elif ARCH(X86_64)
     float res;
     asm(
         "frndint\n"
         : "=t"(res)
         : "0"(value));
     return res;
+#else
+#    error "Unknown architecture"
 #endif
 }
 
@@ -463,7 +478,10 @@ long lrintl(long double value)
 #if ARCH(AARCH64)
     (void)value;
     TODO_AARCH64();
-#else
+#elif ARCH(RISCV64)
+    (void)value;
+    TODO_RISCV64();
+#elif ARCH(X86_64)
     long res;
     asm(
         "fistpl %0\n"
@@ -471,6 +489,8 @@ long lrintl(long double value)
         : "t"(value)
         : "st");
     return res;
+#else
+#    error "Unknown architecture"
 #endif
 }
 long lrint(double value)
@@ -478,7 +498,10 @@ long lrint(double value)
 #if ARCH(AARCH64)
     (void)value;
     TODO_AARCH64();
-#else
+#elif ARCH(RISCV64)
+    (void)value;
+    TODO_RISCV64();
+#elif ARCH(X86_64)
     long res;
     asm(
         "fistpl %0\n"
@@ -486,6 +509,8 @@ long lrint(double value)
         : "t"(value)
         : "st");
     return res;
+#else
+#    error "Unknown architecture"
 #endif
 }
 long lrintf(float value)
@@ -493,7 +518,10 @@ long lrintf(float value)
 #if ARCH(AARCH64)
     (void)value;
     TODO_AARCH64();
-#else
+#elif ARCH(RISCV64)
+    (void)value;
+    TODO_RISCV64();
+#elif ARCH(X86_64)
     long res;
     asm(
         "fistpl %0\n"
@@ -501,6 +529,8 @@ long lrintf(float value)
         : "t"(value)
         : "st");
     return res;
+#else
+#    error "Unknown architecture"
 #endif
 }
 
@@ -509,7 +539,10 @@ long long llrintl(long double value)
 #if ARCH(AARCH64)
     (void)value;
     TODO_AARCH64();
-#else
+#elif ARCH(RISCV64)
+    (void)value;
+    TODO_RISCV64();
+#elif ARCH(X86_64)
     long long res;
     asm(
         "fistpq %0\n"
@@ -517,6 +550,8 @@ long long llrintl(long double value)
         : "t"(value)
         : "st");
     return res;
+#else
+#    error "Unknown architecture"
 #endif
 }
 long long llrint(double value)
@@ -524,7 +559,10 @@ long long llrint(double value)
 #if ARCH(AARCH64)
     (void)value;
     TODO_AARCH64();
-#else
+#elif ARCH(RISCV64)
+    (void)value;
+    TODO_RISCV64();
+#elif ARCH(X86_64)
     long long res;
     asm(
         "fistpq %0\n"
@@ -532,6 +570,8 @@ long long llrint(double value)
         : "t"(value)
         : "st");
     return res;
+#else
+#    error "Unknown architecture"
 #endif
 }
 long long llrintf(float value)
@@ -539,7 +579,10 @@ long long llrintf(float value)
 #if ARCH(AARCH64)
     (void)value;
     TODO_AARCH64();
-#else
+#elif ARCH(RISCV64)
+    (void)value;
+    TODO_RISCV64();
+#elif ARCH(X86_64)
     long long res;
     asm(
         "fistpq %0\n"
@@ -547,6 +590,8 @@ long long llrintf(float value)
         : "t"(value)
         : "st");
     return res;
+#else
+#    error "Unknown architecture"
 #endif
 }
 

--- a/Userland/Libraries/LibC/setjmp.h
+++ b/Userland/Libraries/LibC/setjmp.h
@@ -31,8 +31,13 @@ struct __jmp_buf {
 #elif defined(__aarch64__)
     // FIXME: This is likely incorrect.
     uint64_t regs[22];
+#elif defined(__riscv) && __riscv_xlen == 64
+    // FIXME: This is likely incorrect.
+    uint64_t s[12];
+    uint64_t sp;
+    uint64_t pc;
 #else
-#    error
+#    error "Unknown architecture"
 #endif
     int did_save_signal_mask;
     sigset_t saved_signal_mask;
@@ -49,8 +54,10 @@ typedef struct __jmp_buf sigjmp_buf[1];
 static_assert(sizeof(struct __jmp_buf) == 72, "struct __jmp_buf unsynchronized with x86_64/setjmp.S");
 #    elif defined(__aarch64__)
 static_assert(sizeof(struct __jmp_buf) == 184, "struct __jmp_buf unsynchronized with aarch64/setjmp.S");
+#    elif defined(__riscv) && __riscv_xlen == 64
+static_assert(sizeof(struct __jmp_buf) == 120, "struct __jmp_buf unsynchronized with riscv64/setjmp.S");
 #    else
-#        error
+#        error "Unknown architecture"
 #    endif
 #endif
 

--- a/Userland/Libraries/LibC/sys/arch/regs.h
+++ b/Userland/Libraries/LibC/sys/arch/regs.h
@@ -14,4 +14,6 @@
 #    include "aarch64/regs.h"
 #elif ARCH(RISCV64)
 #    include "riscv64/regs.h"
+#else
+#    error Unknown architecture
 #endif

--- a/Userland/Libraries/LibCoredump/Backtrace.cpp
+++ b/Userland/Libraries/LibCoredump/Backtrace.cpp
@@ -50,6 +50,9 @@ Backtrace::Backtrace(Reader const& coredump, const ELF::Core::ThreadInfo& thread
 #elif ARCH(AARCH64)
     auto start_bp = m_thread_info.regs.x[29];
     auto start_ip = m_thread_info.regs.pc;
+#elif ARCH(RISCV64)
+    auto start_bp = m_thread_info.regs.x[7];
+    auto start_ip = m_thread_info.regs.pc;
 #else
 #    error Unknown architecture
 #endif

--- a/Userland/Libraries/LibDebug/DebugInfo.cpp
+++ b/Userland/Libraries/LibDebug/DebugInfo.cpp
@@ -170,6 +170,8 @@ ErrorOr<Vector<NonnullOwnPtr<DebugInfo::VariableInfo>>> DebugInfo::get_variables
         ip = regs.rip;
 #elif ARCH(AARCH64)
         TODO_AARCH64();
+#elif ARCH(RISCV64)
+        TODO_RISCV64();
 #else
 #    error Unknown architecture
 #endif

--- a/Userland/Libraries/LibDebug/DebugSession.cpp
+++ b/Userland/Libraries/LibDebug/DebugSession.cpp
@@ -377,6 +377,8 @@ FlatPtr DebugSession::single_step()
     regs.rflags |= TRAP_FLAG;
 #elif ARCH(AARCH64)
     TODO_AARCH64();
+#elif ARCH(RISCV64)
+    TODO_RISCV64();
 #else
 #    error Unknown architecture
 #endif
@@ -394,6 +396,8 @@ FlatPtr DebugSession::single_step()
     regs.rflags &= ~(TRAP_FLAG);
 #elif ARCH(AARCH64)
     TODO_AARCH64();
+#elif ARCH(RISCV64)
+    TODO_RISCV64();
 #else
 #    error Unknown architecture
 #endif

--- a/Userland/Libraries/LibDebug/DebugSession.h
+++ b/Userland/Libraries/LibDebug/DebugSession.h
@@ -193,6 +193,9 @@ void DebugSession::run(DesiredInitialDebugeeState initial_debugee_state, Callbac
 #elif ARCH(AARCH64)
         FlatPtr current_instruction;
         TODO_AARCH64();
+#elif ARCH(RISCV64)
+        FlatPtr current_instruction;
+        TODO_RISCV64();
 #else
 #    error Unknown architecture
 #endif
@@ -217,6 +220,9 @@ void DebugSession::run(DesiredInitialDebugeeState initial_debugee_state, Callbac
 #elif ARCH(AARCH64)
                 FlatPtr current_ebp;
                 TODO_AARCH64();
+#elif ARCH(RISCV64)
+                FlatPtr current_ebp;
+                TODO_RISCV64();
 #else
 #    error Unknown architecture
 #endif
@@ -266,6 +272,9 @@ void DebugSession::run(DesiredInitialDebugeeState initial_debugee_state, Callbac
 #elif ARCH(AARCH64)
             (void)breakpoint_addr;
             TODO_AARCH64();
+#elif ARCH(RISCV64)
+            (void)breakpoint_addr;
+            TODO_RISCV64();
 #else
 #    error Unknown architecture
 #endif

--- a/Userland/Libraries/LibELF/Arch/riscv64/entry.S
+++ b/Userland/Libraries/LibELF/Arch/riscv64/entry.S
@@ -1,1 +1,11 @@
-# Intentionally empty.
+/*
+ * Copyright (c) 2023, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+.globl _invoke_entry
+.hidden _invoke_entry
+.type _invoke_entry,@function
+_invoke_entry: # (argc, argv, envp, entry)
+    jr a3

--- a/Userland/Libraries/LibELF/Arch/riscv64/plt_trampoline.S
+++ b/Userland/Libraries/LibELF/Arch/riscv64/plt_trampoline.S
@@ -1,1 +1,14 @@
-# Intentionally empty.
+/*
+ * Copyright (c) 2023, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+.p2align 4
+.globl _plt_trampoline
+.hidden _plt_trampoline
+.type _plt_trampoline,@function
+
+_plt_trampoline:
+    // FIXME: Implement the PLT trampoline.
+    unimp

--- a/Userland/Libraries/LibELF/DynamicLinker.cpp
+++ b/Userland/Libraries/LibELF/DynamicLinker.cpp
@@ -723,8 +723,12 @@ void ELF::DynamicLinker::linker_main(DeprecatedString&& main_program_path, int m
     if (s_do_breakpoint_trap_before_entry) {
 #if ARCH(AARCH64)
         asm("brk #0");
-#else
+#elif ARCH(RISCV64)
+        asm("ebreak");
+#elif ARCH(X86_64)
         asm("int3");
+#else
+#    error "Unknown architecture"
 #endif
     }
 

--- a/Userland/Libraries/LibELF/ELFABI.h
+++ b/Userland/Libraries/LibELF/ELFABI.h
@@ -204,6 +204,7 @@ typedef struct {
 #define EM_X86_64 EM_AMD64
 #define EM_VAX 75      /* DEC VAX */
 #define EM_AARCH64 183 /* ARM 64-bit architecture (AArch64) */
+#define EM_RISCV 243   /* RISC-V */
 
 /* Non-standard */
 #define EM_ALPHA_EXP 0x9026 /* DEC ALPHA */

--- a/Userland/Libraries/LibJS/Runtime/Value.h
+++ b/Userland/Libraries/LibJS/Runtime/Value.h
@@ -416,8 +416,8 @@ public:
         // For 32-bit system the pointer fully fits so we can just return it directly.
         static_assert(sizeof(void*) == sizeof(u32));
         return static_cast<FlatPtr>(encoded & 0xffff'ffff);
-#elif ARCH(X86_64)
-        // For x86_64 the top 16 bits should be sign extending the "real" top bit (47th).
+#elif ARCH(X86_64) || ARCH(RISCV64)
+        // For x86_64 and riscv64 the top 16 bits should be sign extending the "real" top bit (47th).
         // So first shift the top 16 bits away then using the right shift it sign extends the top 16 bits.
         return static_cast<FlatPtr>((static_cast<i64>(encoded << 16)) >> 16);
 #elif ARCH(AARCH64)

--- a/Userland/Libraries/LibWeb/Loader/ResourceLoader.h
+++ b/Userland/Libraries/LibWeb/Loader/ResourceLoader.h
@@ -24,6 +24,10 @@ namespace Web {
 #    define CPU_STRING "AArch64"
 #elif ARCH(I386)
 #    define CPU_STRING "x86"
+#elif ARCH(RISCV64)
+#    define CPU_STRING "RISC-V 64"
+#else
+#    error Unknown architecture
 #endif
 
 #if defined(AK_OS_SERENITY)

--- a/Userland/Utilities/functrace.cpp
+++ b/Userland/Utilities/functrace.cpp
@@ -62,6 +62,11 @@ static void print_syscall(PtraceRegisters& regs, size_t depth)
     (void)begin_color;
     (void)end_color;
     TODO_AARCH64();
+#elif ARCH(RISCV64)
+    (void)regs;
+    (void)begin_color;
+    (void)end_color;
+    TODO_RISCV64();
 #else
 #    error Unknown architecture
 #endif
@@ -142,6 +147,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 #elif ARCH(AARCH64)
         const FlatPtr ip = 0; // FIXME
         TODO_AARCH64();
+#elif ARCH(RISCV64)
+        const FlatPtr ip = 0; // FIXME
+        TODO_RISCV64();
 #else
 #    error Unknown architecture
 #endif

--- a/Userland/Utilities/strace.cpp
+++ b/Userland/Utilities/strace.cpp
@@ -907,6 +907,12 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         syscall_arg_t arg2 = 0;          // FIXME
         syscall_arg_t arg3 = 0;          // FIXME
         TODO_AARCH64();
+#elif ARCH(RISCV64)
+        syscall_arg_t syscall_index = 0; // FIXME
+        syscall_arg_t arg1 = 0;          // FIXME
+        syscall_arg_t arg2 = 0;          // FIXME
+        syscall_arg_t arg3 = 0;          // FIXME
+        TODO_RISCV64();
 #else
 #    error Unknown architecture
 #endif
@@ -924,6 +930,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 #elif ARCH(AARCH64)
         u64 res = 0; // FIXME
         TODO_AARCH64();
+#elif ARCH(RISCV64)
+        u64 res = 0; // FIXME
+        TODO_RISCV64();
 #else
 #    error Unknown architecture
 #endif


### PR DESCRIPTION
This PR makes Userland and Tests compile under riscv64.
I didn't include my DynamicLoader related patches, as I will refactor them.

To compile this PR using the riscv64 clang toolchain you can use [this patch](https://gist.github.com/spholz/feac2d166fa8c1bc1330726a7c275aae), which disables building the kernel and adds the necessary kernel syscall API.
Compiling using GCC doesn't yet work, as you would get a lot of undefined references to `__atomic` functions (this will be fixed in a later PR). It also throws a lot of `-Wcast-align` warnings (which shouldn't really matter). 