### PR TITLE
LibWeb: Handle custom ident values for the CSS font-family property

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -36,6 +36,7 @@
 #include <LibWeb/CSS/StyleValues/BorderStyleValue.h>
 #include <LibWeb/CSS/StyleValues/ColorStyleValue.h>
 #include <LibWeb/CSS/StyleValues/CompositeStyleValue.h>
+#include <LibWeb/CSS/StyleValues/CustomIdentStyleValue.h>
 #include <LibWeb/CSS/StyleValues/DisplayStyleValue.h>
 #include <LibWeb/CSS/StyleValues/EasingStyleValue.h>
 #include <LibWeb/CSS/StyleValues/FilterValueListStyleValue.h>
@@ -2136,6 +2137,8 @@ RefPtr<Gfx::Font const> StyleComputer::compute_font_for_style_values(DOM::Elemen
                 found_font = find_generic_font(family->to_identifier());
             } else if (family->is_string()) {
                 found_font = find_font(family->as_string().string_value());
+            } else if (family->is_custom_ident()) {
+                found_font = find_font(family->as_custom_ident().custom_ident());
             }
             if (found_font)
                 break;
@@ -2144,6 +2147,8 @@ RefPtr<Gfx::Font const> StyleComputer::compute_font_for_style_values(DOM::Elemen
         found_font = find_generic_font(font_family.to_identifier());
     } else if (font_family.is_string()) {
         found_font = find_font(font_family.as_string().string_value());
+    } else if (font_family.is_custom_ident()) {
+        found_font = find_font(font_family.as_custom_ident().custom_ident());
     }
 
     if (!found_font) {


### PR DESCRIPTION
We were parsing these all right, but ignoring them in StyleComputer.

No test unfortunately, since we don't currently have a way to delay the load event until a @font-face has been fully loaded. (Any test of this right now would be flaky.)

Visual progression on the https://substack.com/ front page.

Before:
![Screenshot at 2023-09-18 15-49-48](https://github.com/SerenityOS/serenity/assets/5954907/4db31bf1-2352-44e4-9741-f9f0adced2f9)

After:
![Screenshot at 2023-09-18 15-49-30](https://github.com/SerenityOS/serenity/assets/5954907/8deea043-3564-4595-ac1d-270dd00e5313)

