### PR TITLE
LibJS: Get initial_value from local variables if id represents a local

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
@@ -661,7 +661,11 @@ ThrowCompletionOr<void> ECMAScriptFunctionObject::function_declaration_instantia
                     // 4. Else,
                     else {
                         // a. Let initialValue be ! env.GetBindingValue(n, false).
-                        initial_value = MUST(environment->get_binding_value(vm, id.string(), false));
+                        if (id.is_local()) {
+                            initial_value = callee_context.local_variables[id.local_variable_index()];
+                        } else {
+                            initial_value = MUST(environment->get_binding_value(vm, id.string(), false));
+                        }
                     }
 
                     // 5. Perform ! varEnv.InitializeBinding(n, initialValue).

--- a/Userland/Libraries/LibJS/Tests/functions/function-default-parameters.js
+++ b/Userland/Libraries/LibJS/Tests/functions/function-default-parameters.js
@@ -151,3 +151,12 @@ test("use variable as default function parameter", () => {
 
     expect(func()).toBe(a);
 });
+
+test("variable is initialized to the value of the parameter if one with the same name exists", () => {
+    function func(a = 1) {
+        var a;
+        return a;
+    }
+
+    expect(func()).toBe(1);
+});


### PR DESCRIPTION
If identifier represents local variable we should get its value from `local_variables` in `ExecutionContext` instead of environment.