### PR TITLE
AK: Add support for backtraces on Haiku

### DIFF
--- a/AK/Assertions.cpp
+++ b/AK/Assertions.cpp
@@ -10,7 +10,7 @@
 #include <AK/StringBuilder.h>
 #include <AK/StringView.h>
 
-#if (defined(AK_OS_LINUX) && !defined(AK_OS_ANDROID)) || defined(AK_LIBC_GLIBC) || defined(AK_OS_BSD_GENERIC) || defined(AK_OS_SOLARIS)
+#if (defined(AK_OS_LINUX) && !defined(AK_OS_ANDROID)) || defined(AK_LIBC_GLIBC) || defined(AK_OS_BSD_GENERIC) || defined(AK_OS_SOLARIS) || defined(AK_OS_HAIKU)
 #    define EXECINFO_BACKTRACE
 #endif
 

--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -340,8 +340,8 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "SunOS")
     # Solaris has socket and networking related functions in two extra libraries
     target_link_libraries(LibCore PRIVATE nsl socket)
 endif()
-if (${CMAKE_SYSTEM_NAME} MATCHES "BSD$")
-    # BSD Platforms have backtrace(3) in a separate library
+if (${CMAKE_SYSTEM_NAME} MATCHES "BSD$" OR HAIKU)
+    # BSD Platforms and Haiku have backtrace(3) in a separate library
     target_link_libraries(LibCore PRIVATE execinfo)
 endif()
 if (HAIKU)


### PR DESCRIPTION
This change implements #20852 for the Haiku platform.
Haiku has execinfo in a extra library, like the BSDs.