### PR TITLE
LibWeb&Friends: Add support for `<meta name="theme-color">`

### DIFF
--- a/Ladybird/AppKit/UI/LadybirdWebView.h
+++ b/Ladybird/AppKit/UI/LadybirdWebView.h
@@ -26,6 +26,7 @@
 - (void)loadURL:(URL const&)url;
 - (void)onLoadStart:(URL const&)url isRedirect:(BOOL)is_redirect;
 - (void)onLoadFinish:(URL const&)url;
+- (void)onThemeColorChange:(Color)color;
 
 - (void)onTitleChange:(DeprecatedString const&)title;
 - (void)onFaviconChange:(Gfx::Bitmap const&)bitmap;

--- a/Ladybird/AppKit/UI/LadybirdWebView.mm
+++ b/Ladybird/AppKit/UI/LadybirdWebView.mm
@@ -615,6 +615,14 @@ struct HideCursor {
                                   url:url
                           activateTab:Web::HTML::ActivateTab::Yes];
     };
+
+    m_web_view_bridge->on_theme_color_change = [self](auto color) {
+        self.backgroundColor = [NSColor colorWithRed:(color.red() / 255.0)
+                                               green:(color.green() / 255.0)
+                                                blue:(color.blue() / 255.0)
+                                               alpha:1.0];
+        [self.observer onThemeColorChange:color];
+    };
 }
 
 - (void)colorPickerClosed:(NSNotification*)notification

--- a/Ladybird/AppKit/UI/Tab.mm
+++ b/Ladybird/AppKit/UI/Tab.mm
@@ -36,6 +36,8 @@ static constexpr CGFloat const WINDOW_HEIGHT = 800;
 @property (nonatomic, strong) ConsoleController* console_controller;
 @property (nonatomic, strong) InspectorController* inspector_controller;
 
+@property (nonatomic, assign) URL last_url;
+
 @end
 
 @implementation Tab
@@ -100,6 +102,8 @@ static constexpr CGFloat const WINDOW_HEIGHT = 800;
                  object:[scroll_view contentView]];
 
         [self setContentView:scroll_view];
+        self.backgroundColor = [NSColor windowBackgroundColor];
+        self.titlebarAppearsTransparent = YES;
     }
 
     return self;
@@ -242,6 +246,11 @@ static constexpr CGFloat const WINDOW_HEIGHT = 800;
 
 - (void)onLoadStart:(URL const&)url isRedirect:(BOOL)is_redirect
 {
+    if (url != self.last_url) {
+        self.backgroundColor = [NSColor windowBackgroundColor];
+        self.last_url = url;
+    }
+
     [[self tabController] onLoadStart:url isRedirect:is_redirect];
 
     self.title = Ladybird::string_to_ns_string(url.serialize());
@@ -272,6 +281,23 @@ static constexpr CGFloat const WINDOW_HEIGHT = 800;
 
     self.title = Ladybird::string_to_ns_string(title);
     [self updateTabTitleAndFavicon];
+}
+
+- (void)onThemeColorChange:(Color)color
+{
+    auto* nscolor = [NSColor colorWithRed:((CGFloat)color.red()) / 255.0
+                                    green:((CGFloat)color.green()) / 255.0
+                                     blue:((CGFloat)color.blue()) / 255.0
+                                    alpha:1.0];
+    CGFloat hue = 0.0;
+    CGFloat saturation = 0.0;
+    CGFloat brightness = 0.0;
+    [nscolor getHue:&hue saturation:&saturation brightness:&brightness alpha:nil];
+    if (brightness > 0.75)
+        brightness = 0.75;
+    nscolor = [NSColor colorWithHue:hue saturation:saturation brightness:brightness alpha:1.0];
+    self.backgroundColor = nscolor;
+    self.titlebarAppearsTransparent = YES;
 }
 
 - (void)onFaviconChange:(Gfx::Bitmap const&)bitmap

--- a/Ladybird/AppKit/UI/TabController.mm
+++ b/Ladybird/AppKit/UI/TabController.mm
@@ -193,9 +193,13 @@ enum class IsHistoryNavigation {
 {
     auto* delegate = (ApplicationDelegate*)[NSApp delegate];
 
+    self.tab.titlebarAppearsTransparent = NO;
+
     [delegate createNewTab:OptionalNone {}
                    fromTab:[self tab]
                activateTab:Web::HTML::ActivateTab::Yes];
+
+    self.tab.titlebarAppearsTransparent = YES;
 }
 
 - (void)updateNavigationButtonStates
@@ -212,7 +216,9 @@ enum class IsHistoryNavigation {
 
 - (void)showTabOverview:(id)sender
 {
+    self.tab.titlebarAppearsTransparent = NO;
     [self.window toggleTabOverview:sender];
+    self.tab.titlebarAppearsTransparent = YES;
 }
 
 - (void)dumpDOMTree:(id)sender

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -256,6 +256,8 @@ public:
 
     virtual void page_did_finish_text_test() {};
 
+    virtual void page_did_change_theme_color(Gfx::Color) { }
+
 protected:
     virtual ~PageClient() = default;
 };

--- a/Userland/Libraries/LibWebView/ViewImplementation.h
+++ b/Userland/Libraries/LibWebView/ViewImplementation.h
@@ -154,6 +154,7 @@ public:
     Function<void(Color current_color)> on_request_color_picker;
     Function<void(bool)> on_finish_handling_input_event;
     Function<void()> on_text_test_finish;
+    Function<void(Gfx::Color)> on_theme_color_change;
 
     virtual Gfx::IntRect viewport_rect() const = 0;
     virtual Gfx::IntPoint to_content_position(Gfx::IntPoint widget_position) const = 0;

--- a/Userland/Libraries/LibWebView/WebContentClient.cpp
+++ b/Userland/Libraries/LibWebView/WebContentClient.cpp
@@ -396,4 +396,10 @@ void WebContentClient::did_finish_handling_input_event(bool event_was_accepted)
         m_view.on_finish_handling_input_event(event_was_accepted);
 }
 
+void WebContentClient::did_change_theme_color(Gfx::Color color)
+{
+    if (m_view.on_theme_color_change)
+        m_view.on_theme_color_change(color);
+}
+
 }

--- a/Userland/Libraries/LibWebView/WebContentClient.h
+++ b/Userland/Libraries/LibWebView/WebContentClient.h
@@ -85,6 +85,7 @@ private:
     virtual void did_request_color_picker(Color const& current_color) override;
     virtual void did_finish_handling_input_event(bool event_was_accepted) override;
     virtual void did_finish_text_test() override;
+    virtual void did_change_theme_color(Gfx::Color color) override;
 
     ViewImplementation& m_view;
 };

--- a/Userland/Services/WebContent/PageHost.cpp
+++ b/Userland/Services/WebContent/PageHost.cpp
@@ -463,4 +463,9 @@ void PageHost::page_did_request_color_picker(Color current_color)
     m_client.async_did_request_color_picker(current_color);
 }
 
+void PageHost::page_did_change_theme_color(Gfx::Color color)
+{
+    m_client.async_did_change_theme_color(color);
+}
+
 }

--- a/Userland/Services/WebContent/PageHost.h
+++ b/Userland/Services/WebContent/PageHost.h
@@ -116,6 +116,7 @@ private:
     virtual void request_file(Web::FileRequest) override;
     virtual void page_did_request_color_picker(Color current_color) override;
     virtual void page_did_finish_text_test() override;
+    virtual void page_did_change_theme_color(Gfx::Color color) override;
 
     explicit PageHost(ConnectionFromClient&);
 

--- a/Userland/Services/WebContent/WebContentClient.ipc
+++ b/Userland/Services/WebContent/WebContentClient.ipc
@@ -1,5 +1,6 @@
 #include <AK/URL.h>
 #include <LibCore/AnonymousBuffer.h>
+#include <LibGfx/Color.h>
 #include <LibGfx/ShareableBitmap.h>
 #include <LibWeb/Cookie/Cookie.h>
 #include <LibWeb/Cookie/ParsedCookie.h>
@@ -61,6 +62,7 @@ endpoint WebContentClient
     did_request_file(DeprecatedString path, i32 request_id) =|
     did_request_color_picker(Color current_color) =|
     did_finish_handling_input_event(bool event_was_accepted) =|
+    did_change_theme_color(Gfx::Color color) =|
 
     did_output_js_console_message(i32 message_index) =|
     did_get_js_console_messages(i32 start_index, Vector<DeprecatedString> message_types, Vector<DeprecatedString> messages) =|


### PR DESCRIPTION
These patches add basic support for `<meta name="theme-color">` and a way to update the browser chrome color based on it.

In the menu bar, if the color is very bright we decrease its hsb brightness to 75% so that we have enough contrast for the buttons (see yellow sample below).

This patch has the added benefit of making it so that we get a more natural border color when resizing the window (if the site uses the meta tag that is).

## Samples

<img width="1006" alt="sample-2" src="https://github.com/SerenityOS/serenity/assets/40562373/12332dfd-6480-422b-9d1d-95bc477aab40">
<img width="1006" alt="sample-1" src="https://github.com/SerenityOS/serenity/assets/40562373/4d33350a-3c70-4159-8e08-eb906694643a">

## Code for the samples

```html
<!DOCTYPE html>
<html>
    <head>
        <!--
        <meta name="theme-color" content="#319197">
        <title>#319197</title>
        -->
        <meta name="theme-color" content="#ffe072">
        <title>#ffe072</title>

        <style>
            body {
                display: flex;
                justify-content: center;
                align-items: center;
            }

            html, body {
                margin: 0;
                height: 100%;
            }

            h1 {
                font-family: sans-serif;
            }
        </style>
    </head>
    <!--
    <body style="background-color:#319197">
        <h1 style="color:white">#319197</h1>
    </body>
    -->
    <body style="background-color:#ffe072;">
        <h1 style="color:black">#ffe072</h1>
    </body>
</html>
```