### PR TITLE
LibWeb: Implement named property access AOs on Window

### DIFF
--- a/Tests/LibWeb/Text/expected/HTML/Window-named-properties-elements.txt
+++ b/Tests/LibWeb/Text/expected/HTML/Window-named-properties-elements.txt
@@ -1,0 +1,6 @@
+       george  true
+true
+true
+true
+true
+true

--- a/Tests/LibWeb/Text/expected/HTML/Window-named-properties-iframe.txt
+++ b/Tests/LibWeb/Text/expected/HTML/Window-named-properties-iframe.txt
@@ -1,0 +1,2 @@
+   true
+true

--- a/Tests/LibWeb/Text/expected/HTML/Window-prototype.txt
+++ b/Tests/LibWeb/Text/expected/HTML/Window-prototype.txt
@@ -1,0 +1,6 @@
+[object Window]
+[object Window]
+[object WindowProperties]
+[object EventTarget]
+[object Object]
+null

--- a/Tests/LibWeb/Text/input/HTML/Window-named-properties-elements.html
+++ b/Tests/LibWeb/Text/input/HTML/Window-named-properties-elements.html
@@ -1,0 +1,46 @@
+<script src="../include.js"></script>
+<embed name="m_bed" src="" type="">
+<img name="im_adge" src="">
+<form name="farm"></form>
+<object name="abject"></object>
+<div id="fred"></div>
+<div id="fred"></div>
+<div id="fred"></div>
+<div id="george"></div>
+<script>
+    test(() => {
+        let embeds = document.getElementsByTagName("embed");
+        let images = document.getElementsByTagName("img");
+        let forms = document.getElementsByTagName("form");
+        let objects = document.getElementsByTagName("object");
+
+        // NOTE: The whitespace at the beginning of the results is for the empty elements before the test
+        println(embeds[0] === m_bed);
+        println(images[0] === im_adge);
+        println(forms[0] === farm);
+        println(objects[0] === abject);
+
+        let freds = fred;
+        println(freds.length === 3)
+        let divs = document.getElementsByTagName("div");
+        for (let i = 0; i < 3; ++i) {
+            if (divs[i] !== freds[i])
+                println("FAIL: div " + i);
+        }
+        george.innerHTML = "george"
+
+        let also_fred = document.createElement("div");
+        also_fred.setAttribute("id", "fred");
+        document.body.appendChild(also_fred);
+        println(freds.length === 4);
+
+        // divs[3] is george
+        if (divs[4] !== freds[3])
+            println("FAILED: dynamic insertion");
+
+        // FIXME: Test the child navigable cases when window.open is less TODO
+        // let wandow = window.open("about:blank", "the_target");
+        // println(wandow === the_target);
+        // FIXME: Test that a child navigable is preferred over an element
+    });
+</script>

--- a/Tests/LibWeb/Text/input/HTML/Window-named-properties-iframe.html
+++ b/Tests/LibWeb/Text/input/HTML/Window-named-properties-iframe.html
@@ -1,0 +1,12 @@
+<script src="../include.js"></script>
+<iframe name="framey" src=""></iframe>
+<iframe name=spices></iframe>
+<script>
+    test(() => {
+        println(window.framey === window.frames[0]);
+        println(window.spices == window.frames[1]);
+
+        // FIXME: Test with cross-origin iframe?
+        // FIXME: Test with iframe that sets window.name -- this changes nothing atm
+    });
+</script>

--- a/Tests/LibWeb/Text/input/HTML/Window-prototype.html
+++ b/Tests/LibWeb/Text/input/HTML/Window-prototype.html
@@ -1,0 +1,11 @@
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        println(window)
+        println(window.__proto__)
+        println(window.__proto__.__proto__)
+        println(window.__proto__.__proto__.__proto__);
+        println(window.__proto__.__proto__.__proto__.__proto__);
+        println(window.__proto__.__proto__.__proto__.__proto__.__proto__);
+    });
+</script>

--- a/Userland/Libraries/LibWeb/Bindings/LegacyPlatformObject.h
+++ b/Userland/Libraries/LibWeb/Bindings/LegacyPlatformObject.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <LibWeb/Bindings/PlatformObject.h>
+#include <LibWeb/WebIDL/AbstractOperations.h>
 #include <LibWeb/WebIDL/ExceptionOr.h>
 
 namespace Web::Bindings {
@@ -15,6 +16,8 @@ namespace Web::Bindings {
 // https://webidl.spec.whatwg.org/#dfn-legacy-platform-object
 class LegacyPlatformObject : public PlatformObject {
     WEB_PLATFORM_OBJECT(LegacyPlatformObject, PlatformObject);
+
+    virtual bool has_legacy_override_built_ins_interface_extended_attribute() const = 0;
 
 public:
     virtual ~LegacyPlatformObject() override;
@@ -25,8 +28,6 @@ public:
     virtual JS::ThrowCompletionOr<bool> internal_delete(JS::PropertyKey const&) override;
     virtual JS::ThrowCompletionOr<bool> internal_prevent_extensions() override;
     virtual JS::ThrowCompletionOr<JS::MarkedVector<JS::Value>> internal_own_property_keys() const override;
-
-    JS::ThrowCompletionOr<bool> is_named_property_exposed_on_object(JS::PropertyKey const&) const;
 
     enum class IgnoreNamedProps {
         No,
@@ -80,7 +81,6 @@ protected:
 
     virtual bool has_named_property_deleter() const = 0;
 
-    virtual bool has_legacy_override_built_ins_interface_extended_attribute() const = 0;
     virtual bool has_legacy_unenumerable_named_properties_interface_extended_attribute() const = 0;
     virtual bool has_global_interface_extended_attribute() const = 0;
 

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -30,6 +30,7 @@ enum class StateAndProperties;
 
 namespace Web::Bindings {
 class Intrinsics;
+class LegacyPlatformObject;
 class OptionConstructor;
 
 enum class AudioContextLatencyCategory;

--- a/Userland/Libraries/LibWeb/HTML/Window.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Window.cpp
@@ -1437,4 +1437,16 @@ OrderedHashMap<String, JS::NonnullGCPtr<Navigable>> Window::document_tree_child_
     return names;
 }
 
+// https://html.spec.whatwg.org/#named-access-on-the-window-object
+Vector<DeprecatedString> Window::supported_property_names()
+{
+    return {};
+}
+
+// https://html.spec.whatwg.org/#named-access-on-the-window-object
+WebIDL::ExceptionOr<JS::Value> Window::named_item_value(DeprecatedFlyString const& name)
+{
+    return JS::js_undefined();
+}
+
 }

--- a/Userland/Libraries/LibWeb/HTML/Window.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Window.cpp
@@ -1395,4 +1395,46 @@ JS::NonnullGCPtr<CustomElementRegistry> Window::custom_elements()
     return JS::NonnullGCPtr { *m_custom_element_registry };
 }
 
+// https://html.spec.whatwg.org/#document-tree-child-navigable-target-name-property-set
+OrderedHashMap<String, JS::NonnullGCPtr<Navigable>> Window::document_tree_child_navigable_target_name_property_set()
+{
+    // The document-tree child navigable target name property set of a Window object window is the return value of running these steps:
+
+    // 1. Let children be the document-tree child navigables of window's associated Document.
+    auto children = associated_document().document_tree_child_navigables();
+
+    // 2. Let firstNamedChildren be an empty ordered set.
+    OrderedHashMap<String, JS::NonnullGCPtr<Navigable>> first_named_children;
+
+    // 3. For each navigable of children:
+    for (auto const& navigable : children) {
+        // 1. Let name be navigable's target name.
+        auto const& name = navigable->target_name();
+
+        // 2. If name is the empty string, then continue.
+        if (name.is_empty())
+            continue;
+
+        // 3. If firstNamedChildren contains a navigable whose target name is name, then continue.
+        if (first_named_children.contains(name))
+            continue;
+
+        // 4. Append navigable to firstNamedChildren.
+        (void)first_named_children.set(name, *navigable);
+    }
+
+    // 4. Let names be an empty ordered set.
+    OrderedHashMap<String, JS::NonnullGCPtr<Navigable>> names;
+
+    // 5. For each navigable of firstNamedChildren:
+    for (auto const& [name, navigable] : first_named_children) {
+        // 1. Let name be navigable's target name.
+        // 2. If navigable's active document's origin is same origin with window's relevant settings object's origin, then append name to names.
+        if (navigable->active_document()->origin().is_same_origin(relevant_settings_object(*this).origin()))
+            names.set(name, *navigable);
+    }
+
+    return names;
+}
+
 }

--- a/Userland/Libraries/LibWeb/HTML/Window.h
+++ b/Userland/Libraries/LibWeb/HTML/Window.h
@@ -209,6 +209,12 @@ private:
 
     void invoke_idle_callbacks();
 
+    struct [[nodiscard]] NamedObjects {
+        Vector<JS::NonnullGCPtr<Navigable>> navigables;
+        Vector<JS::NonnullGCPtr<DOM::Element>> elements;
+    };
+    NamedObjects named_objects(StringView name);
+
     // https://html.spec.whatwg.org/multipage/window-object.html#concept-document-window
     JS::GCPtr<DOM::Document> m_associated_document;
 

--- a/Userland/Libraries/LibWeb/HTML/Window.h
+++ b/Userland/Libraries/LibWeb/HTML/Window.h
@@ -193,6 +193,9 @@ public:
 
     [[nodiscard]] OrderedHashMap<String, JS::NonnullGCPtr<Navigable>> document_tree_child_navigable_target_name_property_set();
 
+    [[nodiscard]] Vector<DeprecatedString> supported_property_names();
+    [[nodiscard]] WebIDL::ExceptionOr<JS::Value> named_item_value(DeprecatedFlyString const&);
+
 private:
     explicit Window(JS::Realm&);
 

--- a/Userland/Libraries/LibWeb/HTML/Window.h
+++ b/Userland/Libraries/LibWeb/HTML/Window.h
@@ -191,6 +191,8 @@ public:
 
     static void set_internals_object_exposed(bool);
 
+    [[nodiscard]] OrderedHashMap<String, JS::NonnullGCPtr<Navigable>> document_tree_child_navigable_target_name_property_set();
+
 private:
     explicit Window(JS::Realm&);
 

--- a/Userland/Libraries/LibWeb/HTML/Window.idl
+++ b/Userland/Libraries/LibWeb/HTML/Window.idl
@@ -37,6 +37,11 @@ interface Window : EventTarget {
     readonly attribute Element? frameElement;
     WindowProxy? open(optional USVString url = "", optional DOMString target = "_blank", optional [LegacyNullToEmptyString] DOMString features = "");
 
+    // Since this is the global object, the IDL named getter adds a NamedPropertiesObject exotic
+    // object on the prototype chain. Indeed, this does not make the global object an exotic object.
+    // Indexed access is taken care of by the WindowProxy exotic object.
+    getter object (DOMString name);
+
     // the user agent
     readonly attribute Navigator navigator;
     [ImplementedAs=navigator] readonly attribute Navigator clientInformation; // legacy alias of .navigator

--- a/Userland/Libraries/LibWeb/HTML/WindowProxy.cpp
+++ b/Userland/Libraries/LibWeb/HTML/WindowProxy.cpp
@@ -113,10 +113,11 @@ JS::ThrowCompletionOr<Optional<JS::PropertyDescriptor>> WindowProxy::internal_ge
     if (property.has_value())
         return property;
 
-    // FIXME: 6. If property is undefined and P is in W's document-tree child browsing context name property set, then:
-    if (false) {
-        // FIXME: 1. Let value be the WindowProxy object of the named object of W with the name P.
-        auto value = JS::js_undefined();
+    // 6. If property is undefined and P is in W's document-tree child navigable target name property set, then:
+    auto navigable_property_set = m_window->document_tree_child_navigable_target_name_property_set();
+    if (auto navigable = navigable_property_set.get(property_key.to_string().view()); navigable.has_value()) {
+        // 1. Let value be the active WindowProxy of the named object of W with the name P.
+        auto value = navigable.value()->active_window_proxy();
 
         // 2. Return PropertyDescriptor{ [[Value]]: value, [[Enumerable]]: false, [[Writable]]: false, [[Configurable]]: true }.
         // NOTE: The reason the property descriptors are non-enumerable, despite this mismatching the same-origin behavior, is for compatibility with existing web content. See issue #3183 for details.

--- a/Userland/Libraries/LibWeb/WebIDL/AbstractOperations.h
+++ b/Userland/Libraries/LibWeb/WebIDL/AbstractOperations.h
@@ -61,4 +61,6 @@ JS::Completion construct(WebIDL::CallbackType& callback, Args&&... args)
     return construct(callback, move(arguments_list));
 }
 
+JS::ThrowCompletionOr<bool> is_named_property_exposed_on_object(Variant<Bindings::LegacyPlatformObject const*, HTML::Window*> const& variant, JS::PropertyKey const& property_key);
+
 }


### PR DESCRIPTION
First, implement document-tree child navigable target name property set on Window. This AO allows accessing child navigables by their name as named properties on the WindowProxy object.

Next, add the named properties object to the Window prototype chain, and add the required getter AOs to window. 
These allow accessing embeds, forms, images and objects with a given
name attribute, and any element with a given id attribute, as top level
properties on the global object.

It also allows accessing NavigableContainers by target name as top level
properties on the global object.

The current implementation feels very expensive. It's likely that
these values will need smarter caching in the future.