### PR TITLE
Userland: Make `Window::set_main_widget()` non-fallible

### DIFF
--- a/Base/res/devel/templates/serenity-application/main.cpp
+++ b/Base/res/devel/templates/serenity-application/main.cpp
@@ -19,7 +19,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->resize(200, 200);
     window->set_resizable(false);
 
-    auto main_widget = TRY(window->set_main_widget<GUI::Widget>());
+    auto main_widget = window->set_main_widget<GUI::Widget>();
     main_widget->set_fill_with_background_color(true);
 
     main_widget->set_layout<GUI::VerticalBoxLayout>(16);

--- a/Userland/Applets/Audio/main.cpp
+++ b/Userland/Applets/Audio/main.cpp
@@ -81,7 +81,7 @@ private:
         m_slider_window = add<GUI::Window>(window());
         m_slider_window->set_window_type(GUI::WindowType::Popup);
 
-        m_root_container = TRY(m_slider_window->set_main_widget<GUI::Frame>());
+        m_root_container = m_slider_window->set_main_widget<GUI::Frame>();
         m_root_container->set_fill_with_background_color(true);
         m_root_container->set_layout<GUI::VerticalBoxLayout>(4, 0);
         m_root_container->set_frame_style(Gfx::FrameStyle::Window);
@@ -245,7 +245,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_title("Audio");
     window->set_window_type(GUI::WindowType::Applet);
 
-    auto audio_widget = TRY(window->set_main_widget<AudioWidget>());
+    auto audio_widget = TRY(AudioWidget::try_create());
+    window->set_main_widget(audio_widget);
     window->show();
 
     // This affects the positioning, which depends on the window actually existing.

--- a/Userland/Applets/ClipboardHistory/main.cpp
+++ b/Userland/Applets/ClipboardHistory/main.cpp
@@ -43,7 +43,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     main_window->set_rect(670, 65, 325, 500);
     main_window->set_icon(app_icon.bitmap_for_size(16));
 
-    auto table_view = TRY(main_window->set_main_widget<GUI::TableView>());
+    auto table_view = main_window->set_main_widget<GUI::TableView>();
     auto model = ClipboardHistoryModel::create();
 
     TRY(model->read_from_file(clipboard_file_path));
@@ -100,7 +100,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     applet_window->set_title("ClipboardHistory");
     applet_window->set_window_type(GUI::WindowType::Applet);
     applet_window->set_has_alpha_channel(true);
-    auto icon_widget = TRY(applet_window->set_main_widget<GUI::ImageWidget>());
+    auto icon_widget = applet_window->set_main_widget<GUI::ImageWidget>();
     icon_widget->set_tooltip_deprecated("Clipboard History");
     icon_widget->load_from_file("/res/icons/16x16/edit-copy.png"sv);
     icon_widget->on_click = [&main_window = *main_window] {

--- a/Userland/Applets/Keymap/KeymapStatusWindow.cpp
+++ b/Userland/Applets/Keymap/KeymapStatusWindow.cpp
@@ -12,7 +12,7 @@ KeymapStatusWindow::KeymapStatusWindow()
 {
     set_window_type(GUI::WindowType::Applet);
     set_has_alpha_channel(true);
-    m_status_widget = set_main_widget<KeymapStatusWidget>().release_value_but_fixme_should_propagate_errors();
+    m_status_widget = set_main_widget<KeymapStatusWidget>();
 
     auto current_keymap = MUST(Keyboard::CharacterMap::fetch_system_map());
     m_status_widget->set_current_keymap(current_keymap.character_map_name());

--- a/Userland/Applets/Network/main.cpp
+++ b/Userland/Applets/Network/main.cpp
@@ -187,7 +187,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_window_type(GUI::WindowType::Applet);
     window->set_has_alpha_channel(true);
     window->resize(16, 16);
-    auto icon = TRY(window->set_main_widget<NetworkWidget>(display_notifications));
+    auto icon = TRY(NetworkWidget::try_create(display_notifications));
+    window->set_main_widget(icon);
     icon->load_from_file("/res/icons/16x16/network.png"sv);
     window->resize(16, 16);
     window->show();

--- a/Userland/Applets/ResourceGraph/main.cpp
+++ b/Userland/Applets/ResourceGraph/main.cpp
@@ -275,7 +275,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         window->set_window_type(GUI::WindowType::Applet);
         window->resize(GraphWidget::history_size + 2, 15);
 
-        auto graph_widget = TRY(window->set_main_widget<GraphWidget>(graph_type, graph_color, Optional<Gfx::Color> {}));
+        auto graph_widget = window->set_main_widget<GraphWidget>(graph_type, graph_color, Optional<Gfx::Color> {});
         window->show();
         applet_windows.append(move(window));
 

--- a/Userland/Applets/WorkspacePicker/DesktopStatusWindow.cpp
+++ b/Userland/Applets/WorkspacePicker/DesktopStatusWindow.cpp
@@ -148,7 +148,7 @@ DesktopStatusWindow::DesktopStatusWindow()
 {
     set_window_type(GUI::WindowType::Applet);
     set_has_alpha_channel(true);
-    m_widget = set_main_widget<DesktopStatusWidget>().release_value_but_fixme_should_propagate_errors();
+    m_widget = set_main_widget<DesktopStatusWidget>();
 }
 
 void DesktopStatusWindow::wm_event(GUI::WMEvent& event)

--- a/Userland/Applications/3DFileViewer/main.cpp
+++ b/Userland/Applications/3DFileViewer/main.cpp
@@ -362,7 +362,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->resize(640 + 4, 480 + 4);
     window->set_resizable(false);
     window->set_double_buffering_enabled(true);
-    auto widget = TRY(window->set_main_widget<GLContextWidget>());
+    auto widget = window->set_main_widget<GLContextWidget>();
 
     auto& time = widget->add<GUI::Label>();
     time.set_visible(false);

--- a/Userland/Applications/AnalogClock/main.cpp
+++ b/Userland/Applications/AnalogClock/main.cpp
@@ -30,7 +30,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_icon(app_icon.bitmap_for_size(16));
     window->resize(170, 170);
     window->set_resizable(false);
-    auto clock = TRY(window->set_main_widget<AnalogClock>());
+    auto clock = window->set_main_widget<AnalogClock>();
 
     auto show_window_frame_action = GUI::Action::create_checkable(
         "Show Window &Frame", { Mod_Alt, KeyCode::Key_F }, [&](auto& action) {

--- a/Userland/Applications/Assistant/main.cpp
+++ b/Userland/Applications/Assistant/main.cpp
@@ -174,7 +174,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     };
     Assistant::Database db { app_state, providers };
 
-    auto container = TRY(window->set_main_widget<GUI::Frame>());
+    auto container = window->set_main_widget<GUI::Frame>();
     container->set_fill_with_background_color(true);
     container->set_frame_style(Gfx::FrameStyle::Window);
     container->set_layout<GUI::VerticalBoxLayout>(8);

--- a/Userland/Applications/Browser/BookmarksBarWidget.cpp
+++ b/Userland/Applications/Browser/BookmarksBarWidget.cpp
@@ -53,7 +53,7 @@ private:
     BookmarkEditor(Window* parent_window, StringView title, StringView url)
         : Dialog(parent_window)
     {
-        auto widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
+        auto widget = set_main_widget<GUI::Widget>();
         widget->load_from_gml(edit_bookmark_gml).release_value_but_fixme_should_propagate_errors();
 
         set_resizable(false);

--- a/Userland/Applications/Browser/BrowserWindow.cpp
+++ b/Userland/Applications/Browser/BrowserWindow.cpp
@@ -68,7 +68,7 @@ BrowserWindow::BrowserWindow(WebView::CookieJar& cookie_jar, URL url)
     set_icon(app_icon.bitmap_for_size(16));
     set_title("Ladybird");
 
-    auto widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
+    auto widget = set_main_widget<GUI::Widget>();
     widget->load_from_gml(browser_window_gml).release_value_but_fixme_should_propagate_errors();
 
     auto& top_line = *widget->find_descendant_of_type_named<GUI::HorizontalSeparator>("top_line");

--- a/Userland/Applications/Browser/Tab.cpp
+++ b/Userland/Applications/Browser/Tab.cpp
@@ -71,14 +71,14 @@ void Tab::start_download(const URL& url)
     window->resize(300, 170);
     window->set_title(DeprecatedString::formatted("0% of {}", url.basename()));
     window->set_resizable(false);
-    (void)window->set_main_widget<DownloadWidget>(url).release_value_but_fixme_should_propagate_errors();
+    (void)window->set_main_widget<DownloadWidget>(url);
     window->show();
 }
 
 void Tab::view_source(const URL& url, DeprecatedString const& source)
 {
     auto window = GUI::Window::construct(&this->window());
-    auto editor = window->set_main_widget<GUI::TextEditor>().release_value_but_fixme_should_propagate_errors();
+    auto editor = window->set_main_widget<GUI::TextEditor>();
     editor->set_text(source);
     editor->set_mode(GUI::TextEditor::ReadOnly);
     editor->set_syntax_highlighter(make<Web::HTML::SyntaxHighlighter>());
@@ -877,7 +877,7 @@ void Tab::show_inspector_window(Browser::Tab::InspectorTarget inspector_target)
         window->on_close = [&]() {
             m_web_content_view->clear_inspected_dom_node();
         };
-        m_dom_inspector_widget = window->set_main_widget<InspectorWidget>().release_value_but_fixme_should_propagate_errors();
+        m_dom_inspector_widget = window->set_main_widget<InspectorWidget>();
         m_dom_inspector_widget->set_web_view(*m_web_content_view);
         m_web_content_view->inspect_dom_tree();
         m_web_content_view->inspect_accessibility_tree();
@@ -918,7 +918,7 @@ void Tab::show_console_window()
         console_window->set_title("JS Console");
         console_window->set_icon(g_icon_bag.filetype_javascript);
 
-        m_console_widget = MUST(console_window->set_main_widget<ConsoleWidget>(view()));
+        m_console_widget = console_window->set_main_widget<ConsoleWidget>(view());
     }
 
     auto* window = m_console_widget->window();
@@ -933,7 +933,7 @@ void Tab::show_storage_inspector()
         storage_window->resize(500, 300);
         storage_window->set_title("Storage Inspector");
         storage_window->set_icon(g_icon_bag.cookie);
-        m_storage_widget = storage_window->set_main_widget<StorageWidget>().release_value_but_fixme_should_propagate_errors();
+        m_storage_widget = storage_window->set_main_widget<StorageWidget>();
         m_storage_widget->on_update_cookie = [this](Web::Cookie::Cookie cookie) {
             if (on_update_cookie)
                 on_update_cookie(move(cookie));
@@ -970,7 +970,7 @@ void Tab::show_history_inspector()
         history_window->resize(500, 300);
         history_window->set_title("History");
         history_window->set_icon(g_icon_bag.history);
-        m_history_widget = history_window->set_main_widget<HistoryWidget>().release_value_but_fixme_should_propagate_errors();
+        m_history_widget = history_window->set_main_widget<HistoryWidget>();
     }
 
     m_history_widget->clear_history_entries();

--- a/Userland/Applications/Calculator/main.cpp
+++ b/Userland/Applications/Calculator/main.cpp
@@ -35,7 +35,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_resizable(false);
     window->resize(250, 215);
 
-    auto widget = TRY(window->set_main_widget<CalculatorWidget>());
+    auto widget = window->set_main_widget<CalculatorWidget>();
 
     window->set_icon(app_icon.bitmap_for_size(16));
 

--- a/Userland/Applications/Calendar/AddEventDialog.cpp
+++ b/Userland/Applications/Calendar/AddEventDialog.cpp
@@ -33,7 +33,7 @@ AddEventDialog::AddEventDialog(Core::DateTime date_time, EventManager& event_man
 
     m_date_time = Core::DateTime::create(m_date_time.year(), m_date_time.month(), m_date_time.day(), 12, 0);
 
-    auto widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
+    auto widget = set_main_widget<GUI::Widget>();
     widget->set_fill_with_background_color(true);
     widget->set_layout<GUI::VerticalBoxLayout>();
 

--- a/Userland/Applications/CharacterMap/CharacterMapWidget.cpp
+++ b/Userland/Applications/CharacterMap/CharacterMapWidget.cpp
@@ -86,7 +86,7 @@ CharacterMapWidget::CharacterMapWidget()
     m_find_glyphs_action = GUI::Action::create("&Find Glyphs...", { Mod_Ctrl, Key_F }, Gfx::Bitmap::load_from_file("/res/icons/16x16/find.png"sv).release_value_but_fixme_should_propagate_errors(), [&](auto&) {
         if (m_find_window.is_null()) {
             m_find_window = GUI::Window::construct(window());
-            auto search_widget = m_find_window->set_main_widget<CharacterSearchWidget>().release_value_but_fixme_should_propagate_errors();
+            auto search_widget = m_find_window->set_main_widget<CharacterSearchWidget>();
             search_widget->on_character_selected = [&](auto code_point) {
                 m_glyph_map->set_active_glyph(code_point);
                 m_glyph_map->scroll_to_glyph(code_point);

--- a/Userland/Applications/CharacterMap/main.cpp
+++ b/Userland/Applications/CharacterMap/main.cpp
@@ -69,7 +69,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_icon(app_icon.bitmap_for_size(16));
     window->resize(600, 400);
 
-    auto character_map_widget = TRY(window->set_main_widget<CharacterMapWidget>());
+    auto character_map_widget = window->set_main_widget<CharacterMapWidget>();
     TRY(character_map_widget->initialize_menubar(*window));
 
     auto font_query = Config::read_string("CharacterMap"sv, "History"sv, "Font"sv, Gfx::FontDatabase::the().default_font_query());

--- a/Userland/Applications/CrashReporter/main.cpp
+++ b/Userland/Applications/CrashReporter/main.cpp
@@ -202,7 +202,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             unlink_coredump(coredump_path);
     };
 
-    auto widget = TRY(window->set_main_widget<GUI::Widget>());
+    auto widget = window->set_main_widget<GUI::Widget>();
     TRY(widget->load_from_gml(crash_reporter_window_gml));
 
     auto& icon_image_widget = *widget->find_descendant_of_type_named<GUI::ImageWidget>("icon");

--- a/Userland/Applications/Escalator/EscalatorWindow.cpp
+++ b/Userland/Applications/Escalator/EscalatorWindow.cpp
@@ -36,7 +36,7 @@ EscalatorWindow::EscalatorWindow(StringView executable, Vector<StringView> argum
     set_resizable(false);
     set_minimizable(false);
 
-    auto main_widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
+    auto main_widget = set_main_widget<GUI::Widget>();
     main_widget->load_from_gml(escalator_gml).release_value_but_fixme_should_propagate_errors();
 
     RefPtr<GUI::Label> app_label = *main_widget->find_descendant_of_type_named<GUI::Label>("description");

--- a/Userland/Applications/FileManager/FileUtils.cpp
+++ b/Userland/Applications/FileManager/FileUtils.cpp
@@ -101,7 +101,7 @@ ErrorOr<void> run_file_operation(FileOperation operation, Vector<DeprecatedStrin
     auto pipe_input_file = TRY(Core::File::adopt_fd(pipe_fds[0], Core::File::OpenMode::Read));
     auto buffered_pipe = TRY(Core::InputBufferedFile::create(move(pipe_input_file)));
 
-    (void)TRY(window->set_main_widget<FileOperationProgressWidget>(operation, move(buffered_pipe), pipe_fds[0]));
+    (void)window->set_main_widget<FileOperationProgressWidget>(operation, move(buffered_pipe), pipe_fds[0]);
     window->resize(320, 190);
     if (parent_window)
         window->center_within(*parent_window);

--- a/Userland/Applications/FileManager/PropertiesWindow.cpp
+++ b/Userland/Applications/FileManager/PropertiesWindow.cpp
@@ -70,7 +70,7 @@ PropertiesWindow::PropertiesWindow(DeprecatedString const& path, Window* parent_
 
 ErrorOr<void> PropertiesWindow::create_widgets(bool disable_rename)
 {
-    auto main_widget = TRY(set_main_widget<GUI::Widget>());
+    auto main_widget = set_main_widget<GUI::Widget>();
     main_widget->set_layout<GUI::VerticalBoxLayout>(4, 6);
     main_widget->set_fill_with_background_color(true);
 

--- a/Userland/Applications/FileManager/main.cpp
+++ b/Userland/Applications/FileManager/main.cpp
@@ -387,7 +387,7 @@ ErrorOr<int> run_in_desktop_mode()
     auto desktop_icon = TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/desktop.png"sv));
     window->set_icon(desktop_icon);
 
-    auto desktop_widget = TRY(window->set_main_widget<FileManager::DesktopWidget>());
+    auto desktop_widget = window->set_main_widget<FileManager::DesktopWidget>();
     desktop_widget->set_layout<GUI::VerticalBoxLayout>();
 
     auto directory_view = TRY(desktop_widget->try_add<DirectoryView>(DirectoryView::Mode::Desktop));
@@ -609,7 +609,7 @@ ErrorOr<int> run_in_windowed_mode(DeprecatedString const& initial_location, Depr
     auto window = GUI::Window::construct();
     window->set_title("File Manager");
 
-    auto widget = TRY(window->set_main_widget<GUI::Widget>());
+    auto widget = window->set_main_widget<GUI::Widget>();
     TRY(widget->load_from_gml(file_manager_window_gml));
 
     auto& toolbar_container = *widget->find_descendant_of_type_named<GUI::ToolbarContainer>("toolbar_container");

--- a/Userland/Applications/FontEditor/MainWidget.cpp
+++ b/Userland/Applications/FontEditor/MainWidget.cpp
@@ -82,7 +82,7 @@ ErrorOr<RefPtr<GUI::Window>> MainWidget::create_preview_window()
     window->resize(400, 150);
     window->center_within(*this->window());
 
-    auto main_widget = TRY(window->set_main_widget<GUI::Widget>());
+    auto main_widget = window->set_main_widget<GUI::Widget>();
     TRY(main_widget->load_from_gml(font_preview_window_gml));
 
     m_preview_label = find_descendant_of_type_named<GUI::Label>("preview_label");

--- a/Userland/Applications/FontEditor/main.cpp
+++ b/Userland/Applications/FontEditor/main.cpp
@@ -45,7 +45,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_icon(app_icon.bitmap_for_size(16));
     window->resize(640, 470);
 
-    auto font_editor = TRY(window->set_main_widget<FontEditor::MainWidget>());
+    auto font_editor = TRY(FontEditor::MainWidget::try_create());
+    window->set_main_widget(font_editor);
     TRY(font_editor->initialize_menubar(*window));
     font_editor->reset();
 

--- a/Userland/Applications/Help/main.cpp
+++ b/Userland/Applications/Help/main.cpp
@@ -60,7 +60,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_title("Help");
     window->resize(570, 500);
 
-    auto main_widget = TRY(window->set_main_widget<MainWidget>());
+    auto main_widget = TRY(MainWidget::try_create());
+    window->set_main_widget(main_widget);
+
     TRY(main_widget->initialize_fallibles(window));
     TRY(main_widget->set_start_page(query_parameters));
 

--- a/Userland/Applications/HexEditor/FindDialog.cpp
+++ b/Userland/Applications/HexEditor/FindDialog.cpp
@@ -99,7 +99,7 @@ FindDialog::FindDialog()
     set_resizable(false);
     set_title("Find");
 
-    auto main_widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
+    auto main_widget = set_main_widget<GUI::Widget>();
     main_widget->load_from_gml(find_dialog_gml).release_value_but_fixme_should_propagate_errors();
 
     m_text_editor = *main_widget->find_descendant_of_type_named<GUI::TextBox>("text_editor");

--- a/Userland/Applications/HexEditor/GoToOffsetDialog.cpp
+++ b/Userland/Applications/HexEditor/GoToOffsetDialog.cpp
@@ -96,7 +96,7 @@ GoToOffsetDialog::GoToOffsetDialog()
     set_resizable(false);
     set_title("Go to Offset");
 
-    auto main_widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
+    auto main_widget = set_main_widget<GUI::Widget>();
     main_widget->load_from_gml(go_to_offset_dialog_gml).release_value_but_fixme_should_propagate_errors();
 
     m_text_editor = *main_widget->find_descendant_of_type_named<GUI::TextBox>("text_editor");

--- a/Userland/Applications/HexEditor/main.cpp
+++ b/Userland/Applications/HexEditor/main.cpp
@@ -36,7 +36,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_title("Hex Editor");
     window->resize(640, 400);
 
-    auto hex_editor_widget = TRY(window->set_main_widget<HexEditorWidget>());
+    auto hex_editor_widget = window->set_main_widget<HexEditorWidget>();
 
     window->on_close_request = [&]() -> GUI::Window::CloseRequestDecision {
         if (hex_editor_widget->request_close())

--- a/Userland/Applications/ImageViewer/main.cpp
+++ b/Userland/Applications/ImageViewer/main.cpp
@@ -70,7 +70,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_icon(app_icon.bitmap_for_size(16));
     window->set_title("Image Viewer");
 
-    auto root_widget = TRY(window->set_main_widget<MainWidget>());
+    auto root_widget = window->set_main_widget<MainWidget>();
 
     auto toolbar_container = TRY(root_widget->try_add<GUI::ToolbarContainer>());
     auto main_toolbar = TRY(toolbar_container->try_add<GUI::Toolbar>());

--- a/Userland/Applications/KeyboardMapper/main.cpp
+++ b/Userland/Applications/KeyboardMapper/main.cpp
@@ -31,7 +31,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto window = GUI::Window::construct();
     window->set_title("Keyboard Mapper");
     window->set_icon(app_icon.bitmap_for_size(16));
-    auto keyboard_mapper_widget = TRY(window->set_main_widget<KeyboardMapperWidget>());
+    auto keyboard_mapper_widget = window->set_main_widget<KeyboardMapperWidget>();
     window->resize(775, 315);
     window->set_resizable(false);
 

--- a/Userland/Applications/KeyboardSettings/KeyboardSettingsWidget.cpp
+++ b/Userland/Applications/KeyboardSettings/KeyboardSettingsWidget.cpp
@@ -52,7 +52,7 @@ private:
     KeymapSelectionDialog(Window* parent_window, Vector<DeprecatedString> const& selected_keymaps)
         : Dialog(parent_window)
     {
-        auto widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
+        auto widget = set_main_widget<GUI::Widget>();
         widget->load_from_gml(keymap_dialog_gml).release_value_but_fixme_should_propagate_errors();
 
         set_resizable(false);

--- a/Userland/Applications/Magnifier/main.cpp
+++ b/Userland/Applications/Magnifier/main.cpp
@@ -59,7 +59,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->resize(window_dimensions, window_dimensions);
     window->set_minimizable(false);
     window->set_icon(app_icon.bitmap_for_size(16));
-    auto magnifier = TRY(window->set_main_widget<MagnifierWidget>());
+    auto magnifier = window->set_main_widget<MagnifierWidget>();
 
     auto file_menu = window->add_menu("&File"_string);
     file_menu->add_action(GUI::CommonActions::make_save_as_action([&](auto&) {

--- a/Userland/Applications/Mail/main.cpp
+++ b/Userland/Applications/Mail/main.cpp
@@ -40,7 +40,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto app_icon = GUI::Icon::default_icon("app-mail"sv);
     window->set_icon(app_icon.bitmap_for_size(16));
 
-    auto mail_widget = TRY(window->set_main_widget<MailWidget>());
+    auto mail_widget = window->set_main_widget<MailWidget>();
 
     window->set_title("Mail");
     window->resize(640, 400);

--- a/Userland/Applications/Maps/main.cpp
+++ b/Userland/Applications/Maps/main.cpp
@@ -41,7 +41,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->save_size_and_position_on_close("Maps"sv, "Window"sv);
 
     // Root widget
-    auto root_widget = TRY(window->set_main_widget<GUI::Widget>());
+    auto root_widget = window->set_main_widget<GUI::Widget>();
     root_widget->set_fill_with_background_color(true);
     root_widget->set_layout<GUI::VerticalBoxLayout>(GUI::Margins {}, 2);
 

--- a/Userland/Applications/PDFViewer/main.cpp
+++ b/Userland/Applications/PDFViewer/main.cpp
@@ -39,7 +39,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
-    auto pdf_viewer_widget = TRY(window->set_main_widget<PDFViewerWidget>());
+    auto pdf_viewer_widget = window->set_main_widget<PDFViewerWidget>();
 
     TRY(pdf_viewer_widget->initialize_menubar(*window));
 

--- a/Userland/Applications/PartitionEditor/main.cpp
+++ b/Userland/Applications/PartitionEditor/main.cpp
@@ -58,7 +58,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         return Error::from_string_view(error_message);
     }
 
-    auto widget = TRY(window->set_main_widget<GUI::Widget>());
+    auto widget = window->set_main_widget<GUI::Widget>();
     TRY(widget->load_from_gml(partition_editor_window_gml));
 
     auto device_paths = get_device_paths();

--- a/Userland/Applications/Piano/ExportProgressWindow.cpp
+++ b/Userland/Applications/Piano/ExportProgressWindow.cpp
@@ -20,7 +20,7 @@ ExportProgressWindow::ExportProgressWindow(GUI::Window& parent_window, Atomic<in
 
 ErrorOr<void> ExportProgressWindow::initialize_fallibles()
 {
-    auto main_widget = TRY(set_main_widget<GUI::Widget>());
+    auto main_widget = set_main_widget<GUI::Widget>();
     TRY(main_widget->load_from_gml(export_progress_widget));
 
     set_resizable(false);

--- a/Userland/Applications/Piano/main.cpp
+++ b/Userland/Applications/Piano/main.cpp
@@ -44,7 +44,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto app_icon = GUI::Icon::default_icon("app-piano"sv);
     auto window = GUI::Window::construct();
-    auto main_widget = TRY(window->set_main_widget<MainWidget>(track_manager, audio_loop));
+    auto main_widget = TRY(MainWidget::try_create(track_manager, audio_loop));
+    window->set_main_widget(main_widget);
     window->set_title("Piano");
     window->resize(840, 600);
     window->set_icon(app_icon.bitmap_for_size(16));

--- a/Userland/Applications/PixelPaint/CreateNewImageDialog.cpp
+++ b/Userland/Applications/PixelPaint/CreateNewImageDialog.cpp
@@ -27,7 +27,7 @@ CreateNewImageDialog::CreateNewImageDialog(GUI::Window* parent_window)
     set_icon(parent_window->icon());
     resize(200, 220);
 
-    auto main_widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
+    auto main_widget = set_main_widget<GUI::Widget>();
     main_widget->set_fill_with_background_color(true);
 
     main_widget->set_layout<GUI::VerticalBoxLayout>(4);

--- a/Userland/Applications/PixelPaint/CreateNewLayerDialog.cpp
+++ b/Userland/Applications/PixelPaint/CreateNewLayerDialog.cpp
@@ -20,7 +20,7 @@ CreateNewLayerDialog::CreateNewLayerDialog(Gfx::IntSize suggested_size, GUI::Win
     set_icon(parent_window->icon());
     resize(200, 200);
 
-    auto main_widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
+    auto main_widget = set_main_widget<GUI::Widget>();
     main_widget->set_fill_with_background_color(true);
     main_widget->set_layout<GUI::VerticalBoxLayout>(4);
 

--- a/Userland/Applications/PixelPaint/EditGuideDialog.cpp
+++ b/Userland/Applications/PixelPaint/EditGuideDialog.cpp
@@ -23,7 +23,7 @@ EditGuideDialog::EditGuideDialog(GUI::Window* parent_window, DeprecatedString co
     resize(200, 130);
     set_resizable(false);
 
-    auto main_widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
+    auto main_widget = set_main_widget<GUI::Widget>();
     main_widget->load_from_gml(edit_guide_dialog_gml).release_value_but_fixme_should_propagate_errors();
 
     auto horizontal_radio = main_widget->find_descendant_of_type_named<GUI::RadioButton>("orientation_horizontal_radio");

--- a/Userland/Applications/PixelPaint/FilterGallery.cpp
+++ b/Userland/Applications/PixelPaint/FilterGallery.cpp
@@ -21,7 +21,7 @@ FilterGallery::FilterGallery(GUI::Window* parent_window, ImageEditor* editor)
     resize(400, 250);
     set_resizable(true);
 
-    auto main_widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
+    auto main_widget = set_main_widget<GUI::Widget>();
     main_widget->load_from_gml(filter_gallery_gml).release_value_but_fixme_should_propagate_errors();
 
     m_filter_tree = main_widget->find_descendant_of_type_named<GUI::TreeView>("tree_view");

--- a/Userland/Applications/PixelPaint/FilterParams.h
+++ b/Userland/Applications/PixelPaint/FilterParams.h
@@ -48,7 +48,7 @@ private:
         set_title(builder.string_view());
 
         resize(200, 250);
-        auto main_widget = set_main_widget<GUI::Frame>().release_value_but_fixme_should_propagate_errors();
+        auto main_widget = set_main_widget<GUI::Frame>();
         main_widget->set_frame_style(Gfx::FrameStyle::RaisedContainer);
         main_widget->set_fill_with_background_color(true);
         main_widget->template set_layout<GUI::VerticalBoxLayout>(4);

--- a/Userland/Applications/PixelPaint/ImageMasking.cpp
+++ b/Userland/Applications/PixelPaint/ImageMasking.cpp
@@ -26,7 +26,7 @@ ImageMasking::ImageMasking(GUI::Window* parent_window, ImageEditor* editor, Mask
 {
     set_icon(parent_window->icon());
 
-    auto main_widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
+    auto main_widget = set_main_widget<GUI::Widget>();
 
     set_resizable(false);
     m_previous_edit_mode = m_editor->active_layer()->edit_mode();

--- a/Userland/Applications/PixelPaint/LevelsDialog.cpp
+++ b/Userland/Applications/PixelPaint/LevelsDialog.cpp
@@ -18,7 +18,7 @@ LevelsDialog::LevelsDialog(GUI::Window* parent_window, ImageEditor* editor)
     set_title("Levels");
     set_icon(parent_window->icon());
 
-    auto main_widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
+    auto main_widget = set_main_widget<GUI::Widget>();
     main_widget->load_from_gml(levels_dialog_gml).release_value_but_fixme_should_propagate_errors();
 
     resize(305, 202);

--- a/Userland/Applications/PixelPaint/ResizeImageDialog.cpp
+++ b/Userland/Applications/PixelPaint/ResizeImageDialog.cpp
@@ -27,7 +27,7 @@ ResizeImageDialog::ResizeImageDialog(Gfx::IntSize suggested_size, GUI::Window* p
     resize(260, 228);
     set_icon(parent_window->icon());
 
-    auto main_widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
+    auto main_widget = set_main_widget<GUI::Widget>();
     main_widget->load_from_gml(resize_image_dialog_gml).release_value_but_fixme_should_propagate_errors();
 
     auto width_spinbox = main_widget->find_descendant_of_type_named<GUI::SpinBox>("width_spinbox");

--- a/Userland/Applications/PixelPaint/main.cpp
+++ b/Userland/Applications/PixelPaint/main.cpp
@@ -47,7 +47,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->resize(800, 520);
     window->set_icon(app_icon.bitmap_for_size(16));
 
-    auto main_widget = TRY(window->set_main_widget<PixelPaint::MainWidget>());
+    auto main_widget = window->set_main_widget<PixelPaint::MainWidget>();
 
     TRY(main_widget->initialize_menubar(*window));
 

--- a/Userland/Applications/Presenter/main.cpp
+++ b/Userland/Applications/Presenter/main.cpp
@@ -27,7 +27,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto window = GUI::Window::construct();
     window->set_title("Presenter");
     window->set_icon(GUI::Icon::default_icon("app-presenter"sv).bitmap_for_size(16));
-    auto main_widget = TRY(window->set_main_widget<PresenterWidget>());
+    auto main_widget = window->set_main_widget<PresenterWidget>();
     TRY(main_widget->initialize_menubar());
     window->show();
 

--- a/Userland/Applications/Run/RunWindow.cpp
+++ b/Userland/Applications/Run/RunWindow.cpp
@@ -41,7 +41,7 @@ RunWindow::RunWindow()
     set_resizable(false);
     set_minimizable(false);
 
-    auto main_widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
+    auto main_widget = set_main_widget<GUI::Widget>();
     main_widget->load_from_gml(run_gml).release_value_but_fixme_should_propagate_errors();
 
     m_icon_image_widget = *main_widget->find_descendant_of_type_named<GUI::ImageWidget>("icon");

--- a/Userland/Applications/Settings/main.cpp
+++ b/Userland/Applications/Settings/main.cpp
@@ -101,7 +101,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     help_menu->add_action(GUI::CommonActions::make_command_palette_action(window));
     help_menu->add_action(GUI::CommonActions::make_about_action("Settings"_string, app_icon, window));
 
-    auto main_widget = TRY(window->set_main_widget<GUI::Widget>());
+    auto main_widget = window->set_main_widget<GUI::Widget>();
     main_widget->set_fill_with_background_color(true);
     main_widget->set_layout<GUI::VerticalBoxLayout>();
 

--- a/Userland/Applications/SoundPlayer/main.cpp
+++ b/Userland/Applications/SoundPlayer/main.cpp
@@ -52,7 +52,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_icon(app_icon.bitmap_for_size(16));
 
     // start in advanced view by default
-    Player* player = TRY(window->set_main_widget<SoundPlayerWidget>(window, audio_client, decoder_client));
+    Player* player = window->set_main_widget<SoundPlayerWidget>(window, audio_client, decoder_client);
 
     if (!file_path.is_empty()) {
         player->play_file_path(file_path);

--- a/Userland/Applications/SpaceAnalyzer/ProgressWindow.cpp
+++ b/Userland/Applications/SpaceAnalyzer/ProgressWindow.cpp
@@ -14,7 +14,7 @@ ErrorOr<NonnullRefPtr<ProgressWindow>> ProgressWindow::try_create(StringView tit
 {
     auto window = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) ProgressWindow(title, parent)));
 
-    auto main_widget = TRY(window->set_main_widget<GUI::Widget>());
+    auto main_widget = window->set_main_widget<GUI::Widget>();
     main_widget->set_fill_with_background_color(true);
     main_widget->set_layout<GUI::VerticalBoxLayout>();
 

--- a/Userland/Applications/SpaceAnalyzer/main.cpp
+++ b/Userland/Applications/SpaceAnalyzer/main.cpp
@@ -53,7 +53,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_icon(app_icon.bitmap_for_size(16));
 
     // Load widgets.
-    auto main_widget = TRY(window->set_main_widget<GUI::Widget>());
+    auto main_widget = window->set_main_widget<GUI::Widget>();
     TRY(main_widget->load_from_gml(space_analyzer_gml));
     auto& breadcrumbbar = *main_widget->find_descendant_of_type_named<GUI::Breadcrumbbar>("breadcrumbbar");
     auto& tree_map_widget = *main_widget->find_descendant_of_type_named<SpaceAnalyzer::TreeMapWidget>("tree_map");

--- a/Userland/Applications/Spreadsheet/CellTypeDialog.cpp
+++ b/Userland/Applications/Spreadsheet/CellTypeDialog.cpp
@@ -45,7 +45,7 @@ CellTypeDialog::CellTypeDialog(Vector<Position> const& positions, Sheet& sheet, 
     set_icon(parent->icon());
     resize(285, 360);
 
-    auto main_widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
+    auto main_widget = set_main_widget<GUI::Widget>();
     main_widget->set_layout<GUI::VerticalBoxLayout>(4);
     main_widget->set_fill_with_background_color(true);
 

--- a/Userland/Applications/Spreadsheet/HelpWindow.cpp
+++ b/Userland/Applications/Spreadsheet/HelpWindow.cpp
@@ -68,7 +68,7 @@ HelpWindow::HelpWindow(GUI::Window* parent)
     set_icon(Gfx::Bitmap::load_from_file("/res/icons/16x16/app-help.png"sv).release_value_but_fixme_should_propagate_errors());
     set_window_mode(GUI::WindowMode::Modeless);
 
-    auto widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
+    auto widget = set_main_widget<GUI::Widget>();
     widget->set_layout<GUI::VerticalBoxLayout>();
     widget->set_fill_with_background_color(true);
 
@@ -115,7 +115,7 @@ HelpWindow::HelpWindow(GUI::Window* parent)
             window->set_title(DeprecatedString::formatted("Spreadsheet Help - Example {} for {}", name, entry));
             window->on_close = [window = window.ptr()] { window->remove_from_parent(); };
 
-            auto widget = window->set_main_widget<SpreadsheetWidget>(window, Vector<NonnullRefPtr<Sheet>> {}, false).release_value_but_fixme_should_propagate_errors();
+            auto widget = window->set_main_widget<SpreadsheetWidget>(window, Vector<NonnullRefPtr<Sheet>> {}, false);
             auto sheet = Sheet::from_json(value, widget->workbook());
             if (!sheet) {
                 GUI::MessageBox::show_error(this, DeprecatedString::formatted("Corrupted example '{}' in '{}'", name, example_path));

--- a/Userland/Applications/Spreadsheet/SpreadsheetWidget.cpp
+++ b/Userland/Applications/Spreadsheet/SpreadsheetWidget.cpp
@@ -80,7 +80,7 @@ SpreadsheetWidget::SpreadsheetWidget(GUI::Window& parent_window, Vector<NonnullR
     m_inline_documentation_window->set_rect(m_cell_value_editor->rect().translated(0, m_cell_value_editor->height() + 7).inflated(6, 6));
     m_inline_documentation_window->set_window_type(GUI::WindowType::Tooltip);
     m_inline_documentation_window->set_resizable(false);
-    auto inline_widget = m_inline_documentation_window->set_main_widget<GUI::Frame>().release_value_but_fixme_should_propagate_errors();
+    auto inline_widget = m_inline_documentation_window->set_main_widget<GUI::Frame>();
     inline_widget->set_fill_with_background_color(true);
     inline_widget->set_layout<GUI::VerticalBoxLayout>(4);
     inline_widget->set_frame_style(Gfx::FrameStyle::Plain);

--- a/Userland/Applications/Spreadsheet/main.cpp
+++ b/Userland/Applications/Spreadsheet/main.cpp
@@ -55,7 +55,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->resize(640, 480);
     window->set_icon(app_icon.bitmap_for_size(16));
 
-    auto spreadsheet_widget = TRY(window->set_main_widget<Spreadsheet::SpreadsheetWidget>(*window, Vector<NonnullRefPtr<Spreadsheet::Sheet>> {}, filename.is_empty()));
+    auto spreadsheet_widget = window->set_main_widget<Spreadsheet::SpreadsheetWidget>(*window, Vector<NonnullRefPtr<Spreadsheet::Sheet>> {}, filename.is_empty());
 
     TRY(spreadsheet_widget->initialize_menubar(*window));
     spreadsheet_widget->update_window_title();

--- a/Userland/Applications/SystemMonitor/main.cpp
+++ b/Userland/Applications/SystemMonitor/main.cpp
@@ -282,7 +282,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_title("System Monitor");
     window->resize(560, 430);
 
-    auto main_widget = TRY(window->set_main_widget<GUI::Widget>());
+    auto main_widget = window->set_main_widget<GUI::Widget>();
     TRY(main_widget->load_from_gml(system_monitor_gml));
     auto& tabwidget = *main_widget->find_descendant_of_type_named<GUI::TabWidget>("main_tabs");
     statusbar = main_widget->find_descendant_of_type_named<GUI::Statusbar>("statusbar");
@@ -530,7 +530,7 @@ ErrorOr<NonnullRefPtr<GUI::Window>> build_process_window(pid_t pid)
     auto app_icon = TRY(GUI::Icon::try_create_default_icon("app-system-monitor"sv));
     window->set_icon(app_icon.bitmap_for_size(16));
 
-    auto main_widget = TRY(window->set_main_widget<GUI::Widget>());
+    auto main_widget = window->set_main_widget<GUI::Widget>();
     TRY(main_widget->load_from_gml(process_window_gml));
 
     GUI::ModelIndex process_index;

--- a/Userland/Applications/Terminal/main.cpp
+++ b/Userland/Applications/Terminal/main.cpp
@@ -164,7 +164,7 @@ static ErrorOr<NonnullRefPtr<GUI::Window>> create_find_window(VT::TerminalWidget
     window->set_resizable(false);
     window->resize(300, 90);
 
-    auto main_widget = TRY(window->set_main_widget<GUI::Widget>());
+    auto main_widget = window->set_main_widget<GUI::Widget>();
     main_widget->set_fill_with_background_color(true);
     main_widget->set_background_role(ColorRole::Button);
     main_widget->set_layout<GUI::VerticalBoxLayout>(4);
@@ -283,7 +283,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_title("Terminal");
     window->set_obey_widget_min_size(false);
 
-    auto terminal = TRY(window->set_main_widget<VT::TerminalWidget>(ptm_fd, true));
+    auto terminal = window->set_main_widget<VT::TerminalWidget>(ptm_fd, true);
     terminal->on_command_exit = [&] {
         app->quit(0);
     };

--- a/Userland/Applications/TextEditor/main.cpp
+++ b/Userland/Applications/TextEditor/main.cpp
@@ -44,7 +44,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto window = GUI::Window::construct();
     window->resize(640, 400);
 
-    auto text_widget = TRY(window->set_main_widget<MainWidget>());
+    auto text_widget = window->set_main_widget<MainWidget>();
 
     text_widget->editor().set_focus(true);
 

--- a/Userland/Applications/ThemeEditor/main.cpp
+++ b/Userland/Applications/ThemeEditor/main.cpp
@@ -50,7 +50,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto app_icon = GUI::Icon::default_icon("app-theme-editor"sv);
     auto window = GUI::Window::construct();
 
-    auto main_widget = TRY(window->set_main_widget<ThemeEditor::MainWidget>());
+    auto main_widget = TRY(ThemeEditor::MainWidget::try_create());
+    window->set_main_widget(main_widget);
 
     if (path.has_value()) {
         // Note: This is deferred to ensure that the window has already popped and any error dialog boxes would show up correctly.

--- a/Userland/Applications/VideoPlayer/main.cpp
+++ b/Userland/Applications/VideoPlayer/main.cpp
@@ -34,7 +34,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
-    auto main_widget = TRY(window->set_main_widget<VideoPlayer::VideoPlayerWidget>());
+    auto main_widget = TRY(VideoPlayer::VideoPlayerWidget::try_create());
+    window->set_main_widget(main_widget);
     main_widget->update_title();
     TRY(main_widget->initialize_menubar(window));
 

--- a/Userland/Applications/Welcome/main.cpp
+++ b/Userland/Applications/Welcome/main.cpp
@@ -32,7 +32,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->center_on_screen();
     window->set_title("Welcome");
     window->set_icon(app_icon.bitmap_for_size(16));
-    auto welcome_widget = TRY(window->set_main_widget<WelcomeWidget>());
+    auto welcome_widget = TRY(WelcomeWidget::try_create());
+    window->set_main_widget(welcome_widget);
 
     window->show();
 

--- a/Userland/Demos/CatDog/main.cpp
+++ b/Userland/Demos/CatDog/main.cpp
@@ -61,7 +61,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     advice_window->set_has_alpha_channel(true);
     advice_window->set_alpha_hit_threshold(1.0f);
 
-    auto advice_widget = TRY(advice_window->set_main_widget<SpeechBubble>(catdog_widget));
+    auto advice_widget = advice_window->set_main_widget<SpeechBubble>(catdog_widget);
     advice_widget->set_layout<GUI::VerticalBoxLayout>(GUI::Margins {}, 0);
 
     auto advice_timer = TRY(Core::Timer::create_single_shot(15'000, [&] {

--- a/Userland/Demos/Eyes/main.cpp
+++ b/Userland/Demos/Eyes/main.cpp
@@ -96,7 +96,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     }));
     help_menu->add_action(GUI::CommonActions::make_about_action("Eyes Demo"_string, app_icon, window));
 
-    auto eyes_widget = TRY(window->set_main_widget<EyesWidget>(num_eyes, full_rows, extra_columns));
+    auto eyes_widget = window->set_main_widget<EyesWidget>(num_eyes, full_rows, extra_columns);
     eyes_widget->on_context_menu_request = [&](auto& event) {
         file_menu->popup(event.screen_position());
     };

--- a/Userland/Demos/Gradient/Gradient.cpp
+++ b/Userland/Demos/Gradient/Gradient.cpp
@@ -97,7 +97,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto window = TRY(Desktop::Screensaver::create_window("Gradient"sv, "app-gradient"sv));
 
-    auto gradient_widget = TRY(window->set_main_widget<Gradient>(64, 48, 10000));
+    auto gradient_widget = window->set_main_widget<Gradient>(64, 48, 10000);
     gradient_widget->set_fill_with_background_color(false);
     gradient_widget->set_override_cursor(Gfx::StandardCursor::Hidden);
     gradient_widget->update();

--- a/Userland/Demos/LibGfxDemo/main.cpp
+++ b/Userland/Demos/LibGfxDemo/main.cpp
@@ -202,7 +202,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto app_icon = TRY(GUI::Icon::try_create_default_icon("app-libgfx-demo"sv));
     window->set_icon(app_icon.bitmap_for_size(16));
-    (void)TRY(window->set_main_widget<Canvas>());
+    (void)window->set_main_widget<Canvas>();
     window->show();
 
     return app->exec();

--- a/Userland/Demos/LibGfxScaleDemo/main.cpp
+++ b/Userland/Demos/LibGfxScaleDemo/main.cpp
@@ -121,7 +121,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto app_icon = TRY(GUI::Icon::try_create_default_icon("app-libgfx-demo"sv));
     window->set_icon(app_icon.bitmap_for_size(16));
-    (void)TRY(window->set_main_widget<Canvas>());
+    (void)window->set_main_widget<Canvas>();
     window->show();
 
     return app->exec();

--- a/Userland/Demos/Mandelbrot/Mandelbrot.cpp
+++ b/Userland/Demos/Mandelbrot/Mandelbrot.cpp
@@ -411,7 +411,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_obey_widget_min_size(false);
     window->set_minimum_size(320, 240);
     window->resize(window->minimum_size() * 2);
-    auto mandelbrot = TRY(window->set_main_widget<Mandelbrot>());
+    auto mandelbrot = window->set_main_widget<Mandelbrot>();
 
     auto file_menu = window->add_menu("&File"_string);
 

--- a/Userland/Demos/ModelGallery/main.cpp
+++ b/Userland/Demos/ModelGallery/main.cpp
@@ -28,7 +28,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_title("Model Gallery");
     window->set_icon(app_icon.bitmap_for_size(16));
     window->resize(430, 480);
-    (void)TRY(window->set_main_widget<GalleryWidget>());
+    (void)window->set_main_widget<GalleryWidget>();
 
     window->show();
     return app->exec();

--- a/Userland/Demos/Screensaver/main.cpp
+++ b/Userland/Demos/Screensaver/main.cpp
@@ -85,7 +85,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     help_menu->add_action(GUI::CommonActions::make_command_palette_action(window));
     help_menu->add_action(GUI::CommonActions::make_about_action("Screensaver"_string, app_icon, window));
 
-    auto main_widget = TRY(window->set_main_widget<GUI::Widget>());
+    auto main_widget = window->set_main_widget<GUI::Widget>();
     main_widget->set_fill_with_background_color(true);
     main_widget->set_layout<GUI::VerticalBoxLayout>();
 

--- a/Userland/Demos/Starfield/Starfield.cpp
+++ b/Userland/Demos/Starfield/Starfield.cpp
@@ -167,7 +167,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto window = TRY(Desktop::Screensaver::create_window("Starfield"sv, "app-starfield"sv));
 
-    auto starfield_widget = TRY(window->set_main_widget<Starfield>(refresh_rate));
+    auto starfield_widget = window->set_main_widget<Starfield>(refresh_rate);
     starfield_widget->set_fill_with_background_color(false);
     starfield_widget->set_override_cursor(Gfx::StandardCursor::Hidden);
     starfield_widget->update();

--- a/Userland/Demos/Tubes/main.cpp
+++ b/Userland/Demos/Tubes/main.cpp
@@ -29,7 +29,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto window = TRY(Desktop::Screensaver::create_window("Tubes"sv, "app-tubes"sv));
     window->update();
 
-    auto tubes_widget = TRY(window->set_main_widget<Tubes>(refresh_rate));
+    auto tubes_widget = window->set_main_widget<Tubes>(refresh_rate);
     tubes_widget->set_fill_with_background_color(false);
     tubes_widget->set_override_cursor(Gfx::StandardCursor::Hidden);
     window->show();

--- a/Userland/Demos/WidgetGallery/main.cpp
+++ b/Userland/Demos/WidgetGallery/main.cpp
@@ -27,7 +27,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->resize(430, 480);
     window->set_title("Widget Gallery");
     window->set_icon(app_icon.bitmap_for_size(16));
-    (void)TRY(window->set_main_widget<GalleryWidget>());
+    (void)window->set_main_widget<GalleryWidget>();
     window->show();
 
     return app->exec();

--- a/Userland/DevTools/GMLPlayground/MainWidget.cpp
+++ b/Userland/DevTools/GMLPlayground/MainWidget.cpp
@@ -76,7 +76,7 @@ ErrorOr<NonnullRefPtr<MainWidget>> MainWidget::try_create(GUI::Icon const& icon)
     main_widget->m_preview_window = GUI::Window::construct(main_widget);
     main_widget->m_preview_window->set_title("Preview - GML Playground");
     main_widget->m_preview_window->set_icon(icon.bitmap_for_size(16));
-    main_widget->m_preview_window_widget = TRY(main_widget->m_preview_window->set_main_widget<GUI::Widget>());
+    main_widget->m_preview_window_widget = main_widget->m_preview_window->set_main_widget<GUI::Widget>();
     main_widget->m_preview_window_widget->set_fill_with_background_color(true);
 
     main_widget->m_preview = main_widget->m_preview_frame_widget;

--- a/Userland/DevTools/GMLPlayground/main.cpp
+++ b/Userland/DevTools/GMLPlayground/main.cpp
@@ -45,7 +45,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_icon(app_icon.bitmap_for_size(16));
     window->resize(800, 600);
 
-    auto main_widget = TRY(window->set_main_widget<MainWidget>(app_icon));
+    auto main_widget = TRY(MainWidget::try_create(app_icon));
+    window->set_main_widget(main_widget);
 
     TRY(main_widget->initialize_menubar(window));
 

--- a/Userland/DevTools/HackStudio/Dialogs/Git/GitCommitDialog.cpp
+++ b/Userland/DevTools/HackStudio/Dialogs/Git/GitCommitDialog.cpp
@@ -17,7 +17,7 @@ GitCommitDialog::GitCommitDialog(GUI::Window* parent)
     set_title("Commit");
     set_icon(parent->icon());
 
-    auto widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
+    auto widget = set_main_widget<GUI::Widget>();
     widget->load_from_gml(git_commit_dialog_gml).release_value_but_fixme_should_propagate_errors();
 
     m_message_editor = widget->find_descendant_of_type_named<GUI::TextEditor>("message_editor");

--- a/Userland/DevTools/HackStudio/Dialogs/NewProjectDialog.cpp
+++ b/Userland/DevTools/HackStudio/Dialogs/NewProjectDialog.cpp
@@ -49,7 +49,7 @@ NewProjectDialog::NewProjectDialog(GUI::Window* parent)
     set_resizable(false);
     set_title("New Project");
 
-    auto main_widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
+    auto main_widget = set_main_widget<GUI::Widget>();
     main_widget->load_from_gml(new_project_dialog_gml).release_value_but_fixme_should_propagate_errors();
 
     m_icon_view_container = *main_widget->find_descendant_of_type_named<GUI::Widget>("icon_view_container");

--- a/Userland/DevTools/HackStudio/Editor.cpp
+++ b/Userland/DevTools/HackStudio/Editor.cpp
@@ -132,7 +132,7 @@ ErrorOr<void> Editor::initialize_tooltip_window()
         s_tooltip_window->set_window_type(GUI::WindowType::Tooltip);
     }
     if (s_tooltip_page_view.is_null()) {
-        s_tooltip_page_view = TRY(s_tooltip_window->set_main_widget<WebView::OutOfProcessWebView>());
+        s_tooltip_page_view = s_tooltip_window->set_main_widget<WebView::OutOfProcessWebView>();
     }
     return {};
 }

--- a/Userland/DevTools/HackStudio/Locator.cpp
+++ b/Userland/DevTools/HackStudio/Locator.cpp
@@ -149,7 +149,7 @@ Locator::Locator(Core::EventReceiver* parent)
     m_popup_window->set_window_type(GUI::WindowType::Popup);
     m_popup_window->set_rect(0, 0, 500, 200);
 
-    m_suggestion_view = m_popup_window->set_main_widget<GUI::TableView>().release_value_but_fixme_should_propagate_errors();
+    m_suggestion_view = m_popup_window->set_main_widget<GUI::TableView>();
     m_suggestion_view->set_column_headers_visible(false);
 
     m_suggestion_view->on_activation = [this](auto& index) {

--- a/Userland/DevTools/Profiler/main.cpp
+++ b/Userland/DevTools/Profiler/main.cpp
@@ -88,7 +88,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_icon(app_icon.bitmap_for_size(16));
     window->resize(800, 600);
 
-    auto main_widget = TRY(window->set_main_widget<GUI::Widget>());
+    auto main_widget = window->set_main_widget<GUI::Widget>();
     main_widget->set_fill_with_background_color(true);
     main_widget->set_layout<GUI::VerticalBoxLayout>();
 
@@ -319,7 +319,7 @@ static bool prompt_to_stop_profiling(pid_t pid, DeprecatedString const& process_
     window->set_icon(Gfx::Bitmap::load_from_file("/res/icons/16x16/app-profiler.png"sv).release_value_but_fixme_should_propagate_errors());
     window->center_on_screen();
 
-    auto widget = window->set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
+    auto widget = window->set_main_widget<GUI::Widget>();
     widget->set_fill_with_background_color(true);
     widget->set_layout<GUI::VerticalBoxLayout>(GUI::Margins { 0, 0, 16 });
 

--- a/Userland/Games/2048/GameSizeDialog.cpp
+++ b/Userland/Games/2048/GameSizeDialog.cpp
@@ -25,7 +25,7 @@ GameSizeDialog::GameSizeDialog(GUI::Window* parent, size_t board_size, size_t ta
     set_icon(parent->icon());
     set_resizable(false);
 
-    auto main_widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
+    auto main_widget = set_main_widget<GUI::Widget>();
     main_widget->load_from_gml(game_size_dialog_gml).release_value_but_fixme_should_propagate_errors();
 
     auto board_size_spinbox = main_widget->find_descendant_of_type_named<GUI::SpinBox>("board_size_spinbox");

--- a/Userland/Games/2048/main.cpp
+++ b/Userland/Games/2048/main.cpp
@@ -65,7 +65,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_title("2048");
     window->resize(315, 336);
 
-    auto main_widget = TRY(window->set_main_widget<GUI::Widget>());
+    auto main_widget = window->set_main_widget<GUI::Widget>();
     TRY(main_widget->load_from_gml(game_window_gml));
 
     Game game { board_size, target_tile, evil_ai };

--- a/Userland/Games/BrickGame/main.cpp
+++ b/Userland/Games/BrickGame/main.cpp
@@ -49,7 +49,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->resize(360, 462);
     window->set_resizable(false);
 
-    auto game = TRY(window->set_main_widget<BrickGame>(app_name));
+    auto game = window->set_main_widget<BrickGame>(app_name);
 
     auto game_menu = window->add_menu("&Game"_string);
 

--- a/Userland/Games/Chess/PromotionDialog.cpp
+++ b/Userland/Games/Chess/PromotionDialog.cpp
@@ -17,7 +17,7 @@ PromotionDialog::PromotionDialog(ChessWidget& chess_widget)
     set_icon(chess_widget.window()->icon());
     resize(70 * 4, 70);
 
-    auto main_widget = set_main_widget<GUI::Frame>().release_value_but_fixme_should_propagate_errors();
+    auto main_widget = set_main_widget<GUI::Frame>();
     main_widget->set_frame_style(Gfx::FrameStyle::SunkenContainer);
     main_widget->set_fill_with_background_color(true);
     main_widget->set_layout<GUI::HorizontalBoxLayout>();

--- a/Userland/Games/Chess/main.cpp
+++ b/Userland/Games/Chess/main.cpp
@@ -63,7 +63,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto app_icon = TRY(GUI::Icon::try_create_default_icon("app-chess"sv));
 
     auto window = GUI::Window::construct();
-    auto widget = TRY(window->set_main_widget<ChessWidget>());
+    auto widget = TRY(ChessWidget::try_create());
+    window->set_main_widget(widget);
 
     auto engines = TRY(available_engines());
     for (auto const& engine : engines)

--- a/Userland/Games/ColorLines/main.cpp
+++ b/Userland/Games/ColorLines/main.cpp
@@ -48,7 +48,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->resize(436, 481);
     window->set_resizable(false);
 
-    auto game = TRY(window->set_main_widget<ColorLines>(app_name));
+    auto game = window->set_main_widget<ColorLines>(app_name);
 
     auto game_menu = window->add_menu("&Game"_string);
 

--- a/Userland/Games/FlappyBug/main.cpp
+++ b/Userland/Games/FlappyBug/main.cpp
@@ -43,7 +43,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_title("Flappy Bug");
     window->set_double_buffering_enabled(false);
     window->set_resizable(false);
-    auto widget = TRY(window->set_main_widget<FlappyBug::Game>(TRY(FlappyBug::Game::Bug::construct()), TRY(FlappyBug::Game::Cloud::construct())));
+    auto widget = window->set_main_widget<FlappyBug::Game>(TRY(FlappyBug::Game::Bug::construct()), TRY(FlappyBug::Game::Cloud::construct()));
 
     widget->on_game_end = [&](u32 score) {
         if (score <= high_score)

--- a/Userland/Games/GameOfLife/main.cpp
+++ b/Userland/Games/GameOfLife/main.cpp
@@ -52,7 +52,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_double_buffering_enabled(false);
     window->set_title("Game of Life");
 
-    auto main_widget = TRY(window->set_main_widget<GUI::Widget>());
+    auto main_widget = window->set_main_widget<GUI::Widget>();
     TRY(main_widget->load_from_gml(game_of_life_gml));
     main_widget->set_fill_with_background_color(true);
 

--- a/Userland/Games/Hearts/Game.cpp
+++ b/Userland/Games/Hearts/Game.cpp
@@ -122,7 +122,7 @@ void Game::show_score_card(bool game_over)
     score_dialog->set_resizable(false);
     score_dialog->set_icon(window()->icon());
 
-    auto score_widget = score_dialog->set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
+    auto score_widget = score_dialog->set_main_widget<GUI::Widget>();
     score_widget->set_fill_with_background_color(true);
     score_widget->set_layout<GUI::HorizontalBoxLayout>(10, 15);
 

--- a/Userland/Games/Hearts/SettingsDialog.cpp
+++ b/Userland/Games/Hearts/SettingsDialog.cpp
@@ -19,7 +19,7 @@ SettingsDialog::SettingsDialog(GUI::Window* parent, DeprecatedString player_name
     set_icon(parent->icon());
     set_resizable(false);
 
-    auto main_widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
+    auto main_widget = set_main_widget<GUI::Widget>();
     main_widget->set_fill_with_background_color(true);
 
     main_widget->set_layout<GUI::VerticalBoxLayout>(4);

--- a/Userland/Games/Hearts/main.cpp
+++ b/Userland/Games/Hearts/main.cpp
@@ -50,7 +50,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto window = GUI::Window::construct();
     window->set_title("Hearts");
 
-    auto widget = TRY(window->set_main_widget<GUI::Widget>());
+    auto widget = window->set_main_widget<GUI::Widget>();
     TRY(widget->load_from_gml(hearts_gml));
 
     auto& game = *widget->find_descendant_of_type_named<Hearts::Game>("game");

--- a/Userland/Games/MasterWord/main.cpp
+++ b/Userland/Games/MasterWord/main.cpp
@@ -47,7 +47,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_resizable(false);
     window->set_auto_shrink(true);
 
-    auto main_widget = TRY(window->set_main_widget<GUI::Widget>());
+    auto main_widget = window->set_main_widget<GUI::Widget>();
     TRY(main_widget->load_from_gml(master_word_gml));
     auto& game = *main_widget->find_descendant_of_type_named<MasterWord::WordGame>("word_game");
     auto& statusbar = *main_widget->find_descendant_of_type_named<GUI::Statusbar>("statusbar");

--- a/Userland/Games/Minesweeper/CustomGameDialog.cpp
+++ b/Userland/Games/Minesweeper/CustomGameDialog.cpp
@@ -45,7 +45,7 @@ CustomGameDialog::CustomGameDialog(Window* parent_window)
     set_resizable(false);
     set_title("Custom Game");
 
-    auto main_widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
+    auto main_widget = set_main_widget<GUI::Widget>();
     main_widget->load_from_gml(minesweeper_custom_game_window_gml).release_value_but_fixme_should_propagate_errors();
 
     m_columns_spinbox = *main_widget->find_descendant_of_type_named<GUI::SpinBox>("columns_spinbox");

--- a/Userland/Games/Minesweeper/main.cpp
+++ b/Userland/Games/Minesweeper/main.cpp
@@ -49,7 +49,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_title("Minesweeper");
     window->set_auto_shrink(true);
 
-    auto widget = TRY(window->set_main_widget<GUI::Widget>());
+    auto widget = window->set_main_widget<GUI::Widget>();
     TRY(widget->load_from_gml(minesweeper_window_gml));
 
     auto& flag_label = *widget->find_descendant_of_type_named<GUI::Label>("flag_label");

--- a/Userland/Games/Snake/main.cpp
+++ b/Userland/Games/Snake/main.cpp
@@ -52,7 +52,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_title("Snake");
     window->resize(324, 345);
 
-    auto widget = TRY(window->set_main_widget<GUI::Widget>());
+    auto widget = window->set_main_widget<GUI::Widget>();
     TRY(widget->load_from_gml(snake_gml));
 
     auto& game = *widget->find_descendant_of_type_named<Snake::Game>("game");

--- a/Userland/Games/Solitaire/main.cpp
+++ b/Userland/Games/Solitaire/main.cpp
@@ -84,7 +84,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     if (mode >= Solitaire::Mode::__Count)
         update_mode(Solitaire::Mode::SingleCardDraw);
 
-    auto widget = TRY(window->set_main_widget<GUI::Widget>());
+    auto widget = window->set_main_widget<GUI::Widget>();
     TRY(widget->load_from_gml(solitaire_gml));
 
     auto& game = *widget->find_descendant_of_type_named<Solitaire::Game>("game");

--- a/Userland/Games/Spider/main.cpp
+++ b/Userland/Games/Spider/main.cpp
@@ -109,7 +109,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     if (statistic_display >= StatisticDisplay::__Count)
         update_statistic_display(StatisticDisplay::HighScore);
 
-    auto widget = TRY(window->set_main_widget<GUI::Widget>());
+    auto widget = window->set_main_widget<GUI::Widget>();
     TRY(widget->load_from_gml(spider_gml));
 
     auto& game = *widget->find_descendant_of_type_named<Spider::Game>("game");

--- a/Userland/Libraries/LibGUI/AboutDialog.cpp
+++ b/Userland/Libraries/LibGUI/AboutDialog.cpp
@@ -24,7 +24,7 @@ NonnullRefPtr<AboutDialog> AboutDialog::create(String const& name, String versio
     auto dialog = adopt_ref(*new AboutDialog(name, version, icon, parent_window));
     dialog->set_title(DeprecatedString::formatted("About {}", name));
 
-    auto widget = MUST(dialog->set_main_widget<Widget>());
+    auto widget = dialog->set_main_widget<Widget>();
     MUST(widget->load_from_gml(about_dialog_gml));
 
     auto icon_wrapper = widget->find_descendant_of_type_named<Widget>("icon_wrapper");

--- a/Userland/Libraries/LibGUI/Application.cpp
+++ b/Userland/Libraries/LibGUI/Application.cpp
@@ -45,7 +45,7 @@ private:
     {
         set_window_type(WindowType::Tooltip);
         set_obey_widget_min_size(false);
-        m_label = set_main_widget<Label>().release_value_but_fixme_should_propagate_errors();
+        m_label = set_main_widget<Label>();
         m_label->set_background_role(Gfx::ColorRole::Tooltip);
         m_label->set_foreground_role(Gfx::ColorRole::TooltipText);
         m_label->set_fill_with_background_color(true);

--- a/Userland/Libraries/LibGUI/AutocompleteProvider.cpp
+++ b/Userland/Libraries/LibGUI/AutocompleteProvider.cpp
@@ -92,7 +92,7 @@ AutocompleteBox::AutocompleteBox(TextEditor& editor)
     m_popup_window->set_obey_widget_min_size(false);
     m_popup_window->set_rect(0, 0, 175, 25);
 
-    auto main_widget = m_popup_window->set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
+    auto main_widget = m_popup_window->set_main_widget<GUI::Widget>();
     main_widget->set_fill_with_background_color(true);
     main_widget->set_layout<GUI::VerticalBoxLayout>();
 

--- a/Userland/Libraries/LibGUI/ColorPicker.cpp
+++ b/Userland/Libraries/LibGUI/ColorPicker.cpp
@@ -207,7 +207,7 @@ void ColorPicker::set_color_has_alpha_channel(bool has_alpha)
 
 void ColorPicker::build_ui()
 {
-    auto root_container = set_main_widget<Widget>().release_value_but_fixme_should_propagate_errors();
+    auto root_container = set_main_widget<Widget>();
     root_container->set_layout<VerticalBoxLayout>(4);
     root_container->set_fill_with_background_color(true);
 

--- a/Userland/Libraries/LibGUI/ComboBox.cpp
+++ b/Userland/Libraries/LibGUI/ComboBox.cpp
@@ -116,7 +116,7 @@ ComboBox::ComboBox()
     m_list_window = add<Window>(window());
     m_list_window->set_window_type(GUI::WindowType::Popup);
 
-    m_list_view = m_list_window->set_main_widget<ListView>().release_value_but_fixme_should_propagate_errors();
+    m_list_view = m_list_window->set_main_widget<ListView>();
     m_list_view->set_should_hide_unnecessary_scrollbars(true);
     m_list_view->set_alternating_row_colors(false);
     m_list_view->set_hover_highlighting(true);

--- a/Userland/Libraries/LibGUI/CommandPalette.cpp
+++ b/Userland/Libraries/LibGUI/CommandPalette.cpp
@@ -183,7 +183,7 @@ CommandPalette::CommandPalette(GUI::Window& parent_window, ScreenPosition screen
 
     collect_actions(parent_window);
 
-    auto main_widget = set_main_widget<GUI::Frame>().release_value_but_fixme_should_propagate_errors();
+    auto main_widget = set_main_widget<GUI::Frame>();
     main_widget->set_frame_style(Gfx::FrameStyle::Window);
     main_widget->set_fill_with_background_color(true);
 

--- a/Userland/Libraries/LibGUI/EmojiInputDialog.cpp
+++ b/Userland/Libraries/LibGUI/EmojiInputDialog.cpp
@@ -48,7 +48,7 @@ EmojiInputDialog::EmojiInputDialog(Window* parent_window)
     : Dialog(parent_window)
     , m_category_action_group(make<ActionGroup>())
 {
-    auto main_widget = set_main_widget<Frame>().release_value_but_fixme_should_propagate_errors();
+    auto main_widget = set_main_widget<Frame>();
     main_widget->load_from_gml(emoji_input_dialog_gml).release_value_but_fixme_should_propagate_errors();
 
     set_window_type(GUI::WindowType::Popup);

--- a/Userland/Libraries/LibGUI/FilePicker.cpp
+++ b/Userland/Libraries/LibGUI/FilePicker.cpp
@@ -109,7 +109,7 @@ FilePicker::FilePicker(Window* parent_window, Mode mode, StringView filename, St
     }
     resize(560, 320);
 
-    auto widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
+    auto widget = set_main_widget<GUI::Widget>();
     widget->load_from_gml(file_picker_dialog_gml).release_value_but_fixme_should_propagate_errors();
 
     auto& toolbar = *widget->find_descendant_of_type_named<GUI::Toolbar>("toolbar");

--- a/Userland/Libraries/LibGUI/FontPicker.cpp
+++ b/Userland/Libraries/LibGUI/FontPicker.cpp
@@ -26,7 +26,7 @@ FontPicker::FontPicker(Window* parent_window, Gfx::Font const* current_font, boo
     resize(430, 280);
     set_icon(Gfx::Bitmap::load_from_file("/res/icons/16x16/app-font-editor.png"sv).release_value_but_fixme_should_propagate_errors());
 
-    auto widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
+    auto widget = set_main_widget<GUI::Widget>();
     widget->load_from_gml(font_picker_dialog_gml).release_value_but_fixme_should_propagate_errors();
 
     m_family_list_view = *widget->find_descendant_of_type_named<ListView>("family_list_view");

--- a/Userland/Libraries/LibGUI/InputBox.cpp
+++ b/Userland/Libraries/LibGUI/InputBox.cpp
@@ -127,7 +127,7 @@ void InputBox::on_done(ExecResult result)
 
 ErrorOr<void> InputBox::build()
 {
-    auto main_widget = TRY(set_main_widget<Widget>());
+    auto main_widget = set_main_widget<Widget>();
     main_widget->set_layout<VerticalBoxLayout>(6, 6);
     main_widget->set_fill_with_background_color(true);
 

--- a/Userland/Libraries/LibGUI/MessageBox.cpp
+++ b/Userland/Libraries/LibGUI/MessageBox.cpp
@@ -150,7 +150,7 @@ bool MessageBox::should_include_no_button() const
 
 ErrorOr<void> MessageBox::build()
 {
-    auto main_widget = TRY(set_main_widget<Widget>());
+    auto main_widget = set_main_widget<Widget>();
     main_widget->set_fill_with_background_color(true);
     main_widget->set_layout<VerticalBoxLayout>(8, 6);
 

--- a/Userland/Libraries/LibGUI/PasswordInputDialog.cpp
+++ b/Userland/Libraries/LibGUI/PasswordInputDialog.cpp
@@ -23,7 +23,7 @@ PasswordInputDialog::PasswordInputDialog(Window* parent_window, DeprecatedString
     resize(340, 122);
     set_title(move(title));
 
-    auto widget = set_main_widget<Widget>().release_value_but_fixme_should_propagate_errors();
+    auto widget = set_main_widget<Widget>();
     widget->load_from_gml(password_input_dialog_gml).release_value_but_fixme_should_propagate_errors();
 
     auto& key_icon = *widget->find_descendant_of_type_named<GUI::ImageWidget>("key_icon");

--- a/Userland/Libraries/LibGUI/ProcessChooser.cpp
+++ b/Userland/Libraries/LibGUI/ProcessChooser.cpp
@@ -31,7 +31,7 @@ ProcessChooser::ProcessChooser(StringView window_title, String button_label, Gfx
     resize(300, 340);
     center_on_screen();
 
-    auto widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
+    auto widget = set_main_widget<GUI::Widget>();
     widget->set_fill_with_background_color(true);
     widget->set_layout<GUI::VerticalBoxLayout>();
 

--- a/Userland/Libraries/LibGUI/SettingsWindow.cpp
+++ b/Userland/Libraries/LibGUI/SettingsWindow.cpp
@@ -32,7 +32,7 @@ ErrorOr<NonnullRefPtr<SettingsWindow>> SettingsWindow::create(DeprecatedString t
     window->set_resizable(false);
     window->set_minimizable(false);
 
-    auto main_widget = TRY(window->set_main_widget<GUI::Widget>());
+    auto main_widget = window->set_main_widget<GUI::Widget>();
     main_widget->set_fill_with_background_color(true);
     main_widget->set_layout<GUI::VerticalBoxLayout>(4, 6);
 

--- a/Userland/Libraries/LibGUI/Window.h
+++ b/Userland/Libraries/LibGUI/Window.h
@@ -150,9 +150,9 @@ public:
     void set_main_widget(Widget*);
 
     template<class T, class... Args>
-    inline ErrorOr<NonnullRefPtr<T>> set_main_widget(Args&&... args)
+    inline NonnullRefPtr<T> set_main_widget(Args&&... args)
     {
-        auto widget = TRY(T::try_create(forward<Args>(args)...));
+        auto widget = T::construct(forward<Args>(args)...);
         set_main_widget(widget.ptr());
         return widget;
     }

--- a/Userland/Libraries/LibGUI/Wizards/WizardDialog.cpp
+++ b/Userland/Libraries/LibGUI/Wizards/WizardDialog.cpp
@@ -25,7 +25,7 @@ ErrorOr<NonnullRefPtr<WizardDialog>> WizardDialog::create(Window* parent_window)
 
 ErrorOr<void> WizardDialog::build()
 {
-    auto main_widget = TRY(set_main_widget<Widget>());
+    auto main_widget = set_main_widget<Widget>();
     main_widget->set_fill_with_background_color(true);
     main_widget->set_layout<VerticalBoxLayout>(Margins {}, 0);
 

--- a/Userland/Services/LoginServer/LoginWindow.cpp
+++ b/Userland/Services/LoginServer/LoginWindow.cpp
@@ -20,7 +20,7 @@ LoginWindow::LoginWindow(GUI::Window* parent)
     set_closeable(false);
     set_icon(GUI::Icon::default_icon("ladyball"sv).bitmap_for_size(16));
 
-    auto widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
+    auto widget = set_main_widget<GUI::Widget>();
     widget->load_from_gml(login_window_gml).release_value_but_fixme_should_propagate_errors();
     m_banner = *widget->find_descendant_of_type_named<GUI::ImageWidget>("banner");
     m_banner->load_from_file("/res/graphics/brand-banner.png"sv);

--- a/Userland/Services/NotificationServer/NotificationWindow.cpp
+++ b/Userland/Services/NotificationServer/NotificationWindow.cpp
@@ -68,7 +68,7 @@ NotificationWindow::NotificationWindow(i32 client_id, String const& text, String
 
     m_original_rect = rect;
 
-    auto widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
+    auto widget = set_main_widget<GUI::Widget>();
 
     widget->set_fill_with_background_color(true);
     widget->set_layout<GUI::HorizontalBoxLayout>(8, 6);

--- a/Userland/Services/Taskbar/ClockWidget.cpp
+++ b/Userland/Services/Taskbar/ClockWidget.cpp
@@ -39,7 +39,7 @@ ClockWidget::ClockWidget()
     m_calendar_window->set_window_type(GUI::WindowType::Popup);
     m_calendar_window->resize(m_window_size.width(), m_window_size.height());
 
-    auto root_container = m_calendar_window->set_main_widget<GUI::Frame>().release_value_but_fixme_should_propagate_errors();
+    auto root_container = m_calendar_window->set_main_widget<GUI::Frame>();
     root_container->set_fill_with_background_color(true);
     root_container->set_layout<GUI::VerticalBoxLayout>(GUI::Margins { 2, 0 }, 0);
     root_container->set_frame_style(Gfx::FrameStyle::Window);

--- a/Userland/Services/Taskbar/ShutdownDialog.cpp
+++ b/Userland/Services/Taskbar/ShutdownDialog.cpp
@@ -41,7 +41,7 @@ Optional<ShutdownDialog::Command const&> ShutdownDialog::show()
 ShutdownDialog::ShutdownDialog()
     : Dialog(nullptr)
 {
-    auto widget = set_main_widget<GUI::Widget>().release_value_but_fixme_should_propagate_errors();
+    auto widget = set_main_widget<GUI::Widget>();
     widget->set_fill_with_background_color(true);
     widget->set_layout<GUI::VerticalBoxLayout>(GUI::Margins {}, 0);
 

--- a/Userland/Services/Taskbar/TaskbarWindow.cpp
+++ b/Userland/Services/Taskbar/TaskbarWindow.cpp
@@ -72,7 +72,7 @@ TaskbarWindow::TaskbarWindow()
 
 ErrorOr<void> TaskbarWindow::populate_taskbar()
 {
-    auto main_widget = TRY(set_main_widget<TaskbarWidget>());
+    auto main_widget = set_main_widget<TaskbarWidget>();
     main_widget->set_layout<GUI::HorizontalBoxLayout>(GUI::Margins { 2, 3, 0, 3 });
 
     m_quick_launch = TRY(Taskbar::QuickLaunchWidget::create());

--- a/Userland/Utilities/shot.cpp
+++ b/Userland/Utilities/shot.cpp
@@ -116,7 +116,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     Optional<Gfx::IntRect> crop_region;
     if (select_region) {
         auto window = GUI::Window::construct();
-        auto container = TRY(window->set_main_widget<SelectableLayover>(window));
+        auto container = window->set_main_widget<SelectableLayover>(window);
 
         window->set_title("shot");
         window->set_has_alpha_channel(true);


### PR DESCRIPTION
This change makes `Window::set_main_widget()` non-fallible. In cases where a widget with a `try_create()` method was being constructed, the `try_create()` method is now called prior to `set_main_widget()`. 

An alternative would be to call `MUST(try_create(...))` inside `Window::set_main_widget()`.

I believe this approach is best because `try_create()` may have a legitimate reason to fail, in which case a more relevant error message will be produced.

Contributes to: #20557