### PR TITLE
LibWeb/URL: Use the correct spec URL comment for `URL::port()`

### DIFF
--- a/Userland/Libraries/LibWeb/URL/URL.cpp
+++ b/Userland/Libraries/LibWeb/URL/URL.cpp
@@ -315,7 +315,7 @@ void URL::set_hostname(String const& hostname)
         m_url = move(result_url);
 }
 
-// https://url.spec.whatwg.org/#ref-for-dom-url-hostname①
+// https://url.spec.whatwg.org/#dom-url-port
 WebIDL::ExceptionOr<String> URL::port() const
 {
     auto& vm = realm().vm();


### PR DESCRIPTION
Since in the previous snapshot we were using the hostname setter's spec URL.