### PR TITLE
AK: pow() with less UB and more performance

### DIFF
--- a/AK/Math.h
+++ b/AK/Math.h
@@ -984,11 +984,25 @@ using Hyperbolic::cosh;
 using Hyperbolic::sinh;
 using Hyperbolic::tanh;
 
+// Calculate x^y with fast exponentiation when the power is a natural number.
+template<FloatingPoint F, Unsigned U>
+constexpr F pow_int(F x, U y)
+{
+    auto result = static_cast<F>(1);
+    while (y > 0) {
+        if (y % 2 == 1) {
+            result *= x;
+        }
+        x = x * x;
+        y >>= 1;
+    }
+    return result;
+}
+
 template<FloatingPoint T>
 constexpr T pow(T x, T y)
 {
     CONSTEXPR_STATE(pow, x, y);
-    // FIXME: I am naive
     if (__builtin_isnan(y))
         return y;
     if (y == 0)
@@ -1002,15 +1016,14 @@ constexpr T pow(T x, T y)
     if (y >= static_cast<T>(NumericLimits<i64>::min()) && y < static_cast<T>(NumericLimits<i64>::max())) {
         i64 y_as_int = static_cast<i64>(y);
         if (y == static_cast<T>(y_as_int)) {
-            T result = x;
-            for (u64 i = 0; i < static_cast<u64>(fabs<T>(y) - 1); ++i)
-                result *= x;
+            T result = pow_int(x, static_cast<u64>(fabs<T>(y)));
             if (y < 0)
                 result = static_cast<T>(1.0l) / result;
             return result;
         }
     }
 
+    // FIXME: This formula suffers from error magnification.
     return exp2<T>(y * log2<T>(x));
 }
 

--- a/AK/Math.h
+++ b/AK/Math.h
@@ -12,6 +12,7 @@
 #include <AK/NumericLimits.h>
 #include <AK/StdLibExtraDetails.h>
 #include <AK/Types.h>
+#include <math.h>
 
 #ifdef KERNEL
 #    error "Including AK/Math.h from the Kernel is never correct! Floating point is disabled."
@@ -996,14 +997,18 @@ constexpr T pow(T x, T y)
         return 0;
     if (y == 1)
         return x;
-    int y_as_int = (int)y;
-    if (y == (T)y_as_int) {
-        T result = x;
-        for (int i = 0; i < fabs<T>(y) - 1; ++i)
-            result *= x;
-        if (y < 0)
-            result = 1.0l / result;
-        return result;
+
+    // Take an integer fast path as long as the value fits within a 64-bit integer.
+    if (y >= static_cast<T>(NumericLimits<i64>::min()) && y < static_cast<T>(NumericLimits<i64>::max())) {
+        i64 y_as_int = static_cast<i64>(y);
+        if (y == static_cast<T>(y_as_int)) {
+            T result = x;
+            for (u64 i = 0; i < static_cast<u64>(fabs<T>(y) - 1); ++i)
+                result *= x;
+            if (y < 0)
+                result = static_cast<T>(1.0l) / result;
+            return result;
+        }
     }
 
     return exp2<T>(y * log2<T>(x));

--- a/Tests/AK/CMakeLists.txt
+++ b/Tests/AK/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(AK_TEST_SOURCES
+    TestAKMath.cpp
     TestAllOf.cpp
     TestAnyOf.cpp
     TestArbitrarySizedEnum.cpp

--- a/Tests/AK/TestAKMath.cpp
+++ b/Tests/AK/TestAKMath.cpp
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2023, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibTest/Macros.h>
+#include <LibTest/TestCase.h>
+
+#include <AK/Math.h>
+
+// Test cases for pow(2, x) generated with Python + numpy:
+// echo -e "import numpy as np\nfor x in np.arange(-1020, 1020, 0.9):\n    print(f'{{ {x}, {2**x} }},')" | python3
+// FIXME: Actually use these for a test of AK::pow; currently many inputs are broken due to our bad implementation.
+TEST_CASE(pow)
+{
+    EXPECT_EQ(AK::pow(10., 0.), 1.);
+    EXPECT_EQ(AK::pow(10., 1.), 10.);
+    EXPECT_EQ(AK::pow(10., 2.), 100.);
+    EXPECT_EQ(AK::pow(10., 3.), 1'000.);
+    EXPECT_EQ(AK::pow(10., 4.), 10'000.);
+    EXPECT_EQ(AK::pow(10., 5.), 100'000.);
+    EXPECT_EQ(AK::pow(10., 6.), 1'000'000.);
+    EXPECT_EQ(AK::pow(1.e18, 2.), 1.e36);
+    EXPECT_EQ(AK::pow(1.e19, 2.), 1.e38);
+    EXPECT_EQ(AK::pow(1.e20, 2.), 1.e40);
+    EXPECT_EQ(AK::pow(1.e21, 2.), 1.e42);
+    EXPECT_EQ(AK::pow(1.e22, 2.), 1.e44);
+    // Largest 64-bit float value that fits in a 64-bit integer.
+    EXPECT_EQ(AK::pow(1., 9223372036854774784.0), 1.);
+    // Should not take the integer fast path anymore, since the exponent is beyond 64-bit integers.
+    EXPECT_EQ(AK::pow(1., 9223372036854775808.0), 1.);
+    EXPECT_EQ(AK::pow(1., 9223372036854777856.0), 1.);
+
+    EXPECT_EQ(AK::pow(1., -9223372036854774784.0), 1.);
+    EXPECT_EQ(AK::pow(1., -9223372036854775808.0), 1.);
+    EXPECT_EQ(AK::pow(1., -9223372036854777856.0), 1.);
+}


### PR DESCRIPTION
(1) remove UB by only taking the integer fast path if the exponent fits in the i64 integer limits.

(2) use exponentiation by squaring for the integer fast path, thereby actually making it fast (and not time out on the new tests...)