### PR TITLE
LibAudio+LibCore: Make MappedFile a stream and use it for audio

### DIFF
--- a/AK/MemoryStream.cpp
+++ b/AK/MemoryStream.cpp
@@ -93,7 +93,11 @@ ErrorOr<size_t> FixedMemoryStream::seek(i64 offset, SeekMode seek_mode)
 
 ErrorOr<size_t> FixedMemoryStream::write_some(ReadonlyBytes bytes)
 {
-    VERIFY(m_writing_enabled);
+    // MemoryStream isn't based on file-descriptors, but since most other
+    // Stream implementations are, the interface specifies EBADF as the
+    // "we don't support this particular operation" error code.
+    if (!m_writing_enabled)
+        return Error::from_errno(EBADF);
 
     // FIXME: Can this not error?
     auto const nwritten = bytes.copy_trimmed_to(m_bytes.slice(m_offset));

--- a/AK/MemoryStream.cpp
+++ b/AK/MemoryStream.cpp
@@ -12,8 +12,9 @@
 
 namespace AK {
 
-FixedMemoryStream::FixedMemoryStream(Bytes bytes)
+FixedMemoryStream::FixedMemoryStream(Bytes bytes, bool writing_enabled)
     : m_bytes(bytes)
+    , m_writing_enabled(writing_enabled)
 {
 }
 

--- a/AK/MemoryStream.h
+++ b/AK/MemoryStream.h
@@ -16,7 +16,7 @@ namespace AK {
 /// using a single read/write head.
 class FixedMemoryStream : public SeekableStream {
 public:
-    explicit FixedMemoryStream(Bytes bytes);
+    explicit FixedMemoryStream(Bytes bytes, bool writing_enabled = true);
     explicit FixedMemoryStream(ReadonlyBytes bytes);
 
     virtual bool is_eof() const override;

--- a/AK/MemoryStream.h
+++ b/AK/MemoryStream.h
@@ -14,7 +14,7 @@ namespace AK {
 
 /// A stream class that allows for reading/writing on a preallocated memory area
 /// using a single read/write head.
-class FixedMemoryStream final : public SeekableStream {
+class FixedMemoryStream : public SeekableStream {
 public:
     explicit FixedMemoryStream(Bytes bytes);
     explicit FixedMemoryStream(ReadonlyBytes bytes);

--- a/Tests/AK/TestMemoryStream.cpp
+++ b/Tests/AK/TestMemoryStream.cpp
@@ -190,11 +190,7 @@ TEST_CASE(fixed_memory_read_only)
 
     TRY_OR_FAIL(stream.seek(0));
     ReadonlyBytes buffer { some_words.characters_without_null_termination(), some_words.length() };
-    EXPECT_CRASH("Write protection assert", [&] {
-        (void)stream.write_some(buffer);
-        return Test::Crash::Failure::DidNotCrash;
-    });
-
+    EXPECT(stream.write_some(buffer).is_error());
     EXPECT_EQ(TRY_OR_FAIL(stream.tell()), 0ull);
     EXPECT(!stream.is_eof());
 }

--- a/Tests/LibCore/CMakeLists.txt
+++ b/Tests/LibCore/CMakeLists.txt
@@ -3,6 +3,7 @@ set(TEST_SOURCES
     TestLibCoreDeferredInvoke.cpp
     TestLibCoreFilePermissionsMask.cpp
     TestLibCoreFileWatcher.cpp
+    TestLibCoreMappedFile.cpp
     TestLibCorePromise.cpp
     TestLibCoreSharedSingleProducerCircularQueue.cpp
     TestLibCoreStream.cpp

--- a/Tests/LibCore/TestLibCoreMappedFile.cpp
+++ b/Tests/LibCore/TestLibCoreMappedFile.cpp
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 2021, sin-ack <sin-ack@protonmail.com>
+ * Copyright (c) 2023, kleines Filmröllchen <filmroellchen@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Format.h>
+#include <AK/MaybeOwned.h>
+#include <AK/String.h>
+#include <LibCore/File.h>
+#include <LibCore/MappedFile.h>
+#include <LibTest/TestCase.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+TEST_CASE(mapped_file_open)
+{
+    // Fill the file with a little content so we can write to it.
+    constexpr auto text = "Here's some text to be mmapped."sv;
+    {
+        auto maybe_file = Core::File::open("/tmp/file-open-test.txt"sv, Core::File::OpenMode::Write);
+        if (maybe_file.is_error()) {
+            warnln("Failed to open the file: {}", strerror(maybe_file.error().code()));
+            VERIFY_NOT_REACHED();
+        }
+        TRY_OR_FAIL(maybe_file.value()->write_until_depleted(text.bytes()));
+    }
+
+    auto maybe_file = Core::MappedFile::map("/tmp/file-open-test.txt"sv, Core::MappedFile::OpenMode::ReadWrite);
+    if (maybe_file.is_error()) {
+        warnln("Failed to open the file: {}", strerror(maybe_file.error().code()));
+        VERIFY_NOT_REACHED();
+    }
+
+    // Testing out some basic file properties.
+    auto file = maybe_file.release_value();
+    EXPECT(file->is_open());
+    EXPECT(!file->is_eof());
+
+    auto size = TRY_OR_FAIL(file->size());
+    EXPECT_EQ(size, text.length());
+}
+
+constexpr auto expected_buffer_contents = "&lt;small&gt;(Please consider translating this message for the benefit of your fellow Wikimedians. Please also consider translating"sv;
+
+TEST_CASE(mapped_file_read_bytes)
+{
+    auto file = TRY_OR_FAIL(Core::MappedFile::map("/usr/Tests/LibCore/long_lines.txt"sv, Core::MappedFile::OpenMode::ReadOnly));
+
+    auto buffer = TRY_OR_FAIL(ByteBuffer::create_uninitialized(131));
+
+    auto result = file->read_some(buffer);
+    EXPECT_EQ(TRY_OR_FAIL(result).size(), 131ul);
+
+    StringView buffer_contents { buffer.bytes() };
+    EXPECT_EQ(buffer_contents, expected_buffer_contents);
+}
+
+constexpr auto expected_seek_contents1 = "|Lleer esti mens"sv;
+constexpr auto expected_seek_contents2 = "s of advanced ad"sv;
+constexpr auto expected_seek_contents3 = "levels of advanc"sv;
+
+TEST_CASE(mapped_file_seeking_around)
+{
+    auto file = TRY_OR_FAIL(Core::MappedFile::map("/usr/Tests/LibCore/long_lines.txt"sv, Core::MappedFile::OpenMode::ReadOnly));
+
+    EXPECT_EQ(file->size().release_value(), 8702ul);
+
+    auto buffer = TRY_OR_FAIL(ByteBuffer::create_uninitialized(16));
+
+    StringView buffer_contents { buffer.bytes() };
+
+    TRY_OR_FAIL(file->seek(500, SeekMode::SetPosition));
+    EXPECT_EQ(file->tell().release_value(), 500ul);
+    TRY_OR_FAIL(file->read_until_filled(buffer));
+    EXPECT_EQ(buffer_contents, expected_seek_contents1);
+
+    TRY_OR_FAIL(file->seek(234, SeekMode::FromCurrentPosition));
+    EXPECT_EQ(file->tell().release_value(), 750ul);
+    TRY_OR_FAIL(file->read_until_filled(buffer));
+    EXPECT_EQ(buffer_contents, expected_seek_contents2);
+
+    TRY_OR_FAIL(file->seek(-105, SeekMode::FromEndPosition));
+    EXPECT_EQ(file->tell().release_value(), 8597ul);
+    TRY_OR_FAIL(file->read_until_filled(buffer));
+    EXPECT_EQ(buffer_contents, expected_seek_contents3);
+}
+
+BENCHMARK_CASE(file_tell)
+{
+    auto file = TRY_OR_FAIL(Core::MappedFile::map("/usr/Tests/LibCore/10kb.txt"sv, Core::MappedFile::OpenMode::ReadOnly));
+    auto expected_file_offset = 0u;
+    auto ten_byte_buffer = TRY_OR_FAIL(ByteBuffer::create_uninitialized(1));
+    for (auto i = 0u; i < 4000; ++i) {
+        TRY_OR_FAIL(file->read_until_filled(ten_byte_buffer));
+        expected_file_offset += 1u;
+        EXPECT_EQ(expected_file_offset, TRY_OR_FAIL(file->tell()));
+    }
+
+    for (auto i = 0u; i < 4000; ++i) {
+        auto seek_file_offset = TRY_OR_FAIL(file->seek(-1, SeekMode::FromCurrentPosition));
+        expected_file_offset -= 1;
+        EXPECT_EQ(seek_file_offset, TRY_OR_FAIL(file->tell()));
+        EXPECT_EQ(expected_file_offset, TRY_OR_FAIL(file->tell()));
+    }
+}
+
+TEST_CASE(mapped_file_adopt_fd)
+{
+    int rc = ::open("/usr/Tests/LibCore/long_lines.txt", O_RDONLY);
+    EXPECT(rc >= 0);
+
+    auto file = TRY_OR_FAIL(Core::MappedFile::map_from_fd_and_close(rc, "/usr/Tests/LibCore/long_lines.txt"sv));
+
+    EXPECT_EQ(file->size().release_value(), 8702ul);
+
+    auto buffer = TRY_OR_FAIL(ByteBuffer::create_uninitialized(16));
+
+    StringView buffer_contents { buffer.bytes() };
+
+    TRY_OR_FAIL(file->seek(500, SeekMode::SetPosition));
+    EXPECT_EQ(file->tell().release_value(), 500ul);
+    TRY_OR_FAIL(file->read_until_filled(buffer));
+    EXPECT_EQ(buffer_contents, expected_seek_contents1);
+
+    // A single seek & read test should be fine for now.
+}
+
+TEST_CASE(mapped_file_adopt_invalid_fd)
+{
+    auto maybe_file = Core::MappedFile::map_from_fd_and_close(-1, "/usr/Tests/LibCore/long_lines.txt"sv);
+    EXPECT(maybe_file.is_error());
+    EXPECT_EQ(maybe_file.error().code(), EBADF);
+}
+
+TEST_CASE(mapped_file_tell_and_seek)
+{
+    auto mapped_file = Core::MappedFile::map("/usr/Tests/LibCore/small.txt"sv).release_value();
+
+    // Initial state.
+    {
+        auto current_offset = mapped_file->tell().release_value();
+        EXPECT_EQ(current_offset, 0ul);
+    }
+
+    // Read a character.
+    {
+        auto character = mapped_file->read_value<char>().release_value();
+        EXPECT_EQ(character, 'W');
+        auto current_offset = mapped_file->tell().release_value();
+        EXPECT_EQ(current_offset, 1ul);
+    }
+
+    // Read one more character.
+    {
+        auto character = mapped_file->read_value<char>().release_value();
+        EXPECT_EQ(character, 'e');
+        auto current_offset = mapped_file->tell().release_value();
+        EXPECT_EQ(current_offset, 2ul);
+    }
+
+    // Seek seven characters forward.
+    {
+        auto current_offset = mapped_file->seek(7, SeekMode::FromCurrentPosition).release_value();
+        EXPECT_EQ(current_offset, 9ul);
+    }
+
+    // Read a character again.
+    {
+        auto character = mapped_file->read_value<char>().release_value();
+        EXPECT_EQ(character, 'o');
+        auto current_offset = mapped_file->tell().release_value();
+        EXPECT_EQ(current_offset, 10ul);
+    }
+
+    // Seek five characters backwards.
+    {
+        auto current_offset = mapped_file->seek(-5, SeekMode::FromCurrentPosition).release_value();
+        EXPECT_EQ(current_offset, 5ul);
+    }
+
+    // Read a character.
+    {
+        auto character = mapped_file->read_value<char>().release_value();
+        EXPECT_EQ(character, 'h');
+        auto current_offset = mapped_file->tell().release_value();
+        EXPECT_EQ(current_offset, 6ul);
+    }
+
+    // Seek back to the beginning.
+    {
+        auto current_offset = mapped_file->seek(0, SeekMode::SetPosition).release_value();
+        EXPECT_EQ(current_offset, 0ul);
+    }
+
+    // Read the first character. This should prime the buffer if it hasn't happened already.
+    {
+        auto character = mapped_file->read_value<char>().release_value();
+        EXPECT_EQ(character, 'W');
+        auto current_offset = mapped_file->tell().release_value();
+        EXPECT_EQ(current_offset, 1ul);
+    }
+
+    // Seek beyond the buffer size, which should invalidate the buffer.
+    {
+        auto current_offset = mapped_file->seek(12, SeekMode::SetPosition).release_value();
+        EXPECT_EQ(current_offset, 12ul);
+    }
+
+    // Ensure that we still read the correct contents from the new offset with a (presumably) freshly filled buffer.
+    {
+        auto character = mapped_file->read_value<char>().release_value();
+        EXPECT_EQ(character, 'r');
+        auto current_offset = mapped_file->tell().release_value();
+        EXPECT_EQ(current_offset, 13ul);
+    }
+}

--- a/Userland/Applications/FileManager/PropertiesWindow.cpp
+++ b/Userland/Applications/FileManager/PropertiesWindow.cpp
@@ -246,7 +246,7 @@ ErrorOr<void> PropertiesWindow::create_file_type_specific_tabs(GUI::TabWidget& t
     return {};
 }
 
-ErrorOr<void> PropertiesWindow::create_archive_tab(GUI::TabWidget& tab_widget, NonnullRefPtr<Core::MappedFile> mapped_file)
+ErrorOr<void> PropertiesWindow::create_archive_tab(GUI::TabWidget& tab_widget, NonnullOwnPtr<Core::MappedFile> mapped_file)
 {
     auto maybe_zip = Archive::Zip::try_create(mapped_file->bytes());
     if (!maybe_zip.has_value()) {
@@ -268,7 +268,7 @@ ErrorOr<void> PropertiesWindow::create_archive_tab(GUI::TabWidget& tab_widget, N
     return {};
 }
 
-ErrorOr<void> PropertiesWindow::create_audio_tab(GUI::TabWidget& tab_widget, NonnullRefPtr<Core::MappedFile> mapped_file)
+ErrorOr<void> PropertiesWindow::create_audio_tab(GUI::TabWidget& tab_widget, NonnullOwnPtr<Core::MappedFile> mapped_file)
 {
     auto loader_or_error = Audio::Loader::create(mapped_file->bytes());
     if (loader_or_error.is_error()) {
@@ -317,10 +317,10 @@ struct FontInfo {
     Format format;
     NonnullRefPtr<Gfx::Typeface> typeface;
 };
-static ErrorOr<FontInfo> load_font(StringView path, StringView mime_type, NonnullRefPtr<Core::MappedFile> mapped_file)
+static ErrorOr<FontInfo> load_font(StringView path, StringView mime_type, NonnullOwnPtr<Core::MappedFile> mapped_file)
 {
     if (path.ends_with(".font"sv)) {
-        auto font = TRY(Gfx::BitmapFont::try_load_from_mapped_file(mapped_file));
+        auto font = TRY(Gfx::BitmapFont::try_load_from_mapped_file(move(mapped_file)));
         auto typeface = TRY(try_make_ref_counted<Gfx::Typeface>(font->family(), font->variant()));
         typeface->add_bitmap_font(move(font));
         return FontInfo { FontInfo::Format::BitmapFont, move(typeface) };
@@ -349,9 +349,9 @@ static ErrorOr<FontInfo> load_font(StringView path, StringView mime_type, Nonnul
     return Error::from_string_view("Unrecognized font format."sv);
 }
 
-ErrorOr<void> PropertiesWindow::create_font_tab(GUI::TabWidget& tab_widget, NonnullRefPtr<Core::MappedFile> mapped_file, StringView mime_type)
+ErrorOr<void> PropertiesWindow::create_font_tab(GUI::TabWidget& tab_widget, NonnullOwnPtr<Core::MappedFile> mapped_file, StringView mime_type)
 {
-    auto font_info_or_error = load_font(m_path, mime_type, mapped_file);
+    auto font_info_or_error = load_font(m_path, mime_type, move(mapped_file));
     if (font_info_or_error.is_error()) {
         warnln("Failed to open '{}': {}", m_path, font_info_or_error.release_error());
         return {};
@@ -398,7 +398,7 @@ ErrorOr<void> PropertiesWindow::create_font_tab(GUI::TabWidget& tab_widget, Nonn
     return {};
 }
 
-ErrorOr<void> PropertiesWindow::create_image_tab(GUI::TabWidget& tab_widget, NonnullRefPtr<Core::MappedFile> mapped_file, StringView mime_type)
+ErrorOr<void> PropertiesWindow::create_image_tab(GUI::TabWidget& tab_widget, NonnullOwnPtr<Core::MappedFile> mapped_file, StringView mime_type)
 {
     auto image_decoder = Gfx::ImageDecoder::try_create_for_raw_bytes(mapped_file->bytes(), mime_type);
     if (!image_decoder)
@@ -456,7 +456,7 @@ ErrorOr<void> PropertiesWindow::create_image_tab(GUI::TabWidget& tab_widget, Non
     return {};
 }
 
-ErrorOr<void> PropertiesWindow::create_pdf_tab(GUI::TabWidget& tab_widget, NonnullRefPtr<Core::MappedFile> mapped_file)
+ErrorOr<void> PropertiesWindow::create_pdf_tab(GUI::TabWidget& tab_widget, NonnullOwnPtr<Core::MappedFile> mapped_file)
 {
     auto maybe_document = PDF::Document::create(mapped_file->bytes());
     if (maybe_document.is_error()) {

--- a/Userland/Applications/FileManager/PropertiesWindow.h
+++ b/Userland/Applications/FileManager/PropertiesWindow.h
@@ -30,11 +30,11 @@ private:
     ErrorOr<void> create_widgets(bool disable_rename);
     ErrorOr<void> create_general_tab(GUI::TabWidget&, bool disable_rename);
     ErrorOr<void> create_file_type_specific_tabs(GUI::TabWidget&);
-    ErrorOr<void> create_archive_tab(GUI::TabWidget&, NonnullRefPtr<Core::MappedFile>);
-    ErrorOr<void> create_audio_tab(GUI::TabWidget&, NonnullRefPtr<Core::MappedFile>);
-    ErrorOr<void> create_font_tab(GUI::TabWidget&, NonnullRefPtr<Core::MappedFile>, StringView mime_type);
-    ErrorOr<void> create_image_tab(GUI::TabWidget&, NonnullRefPtr<Core::MappedFile>, StringView mime_type);
-    ErrorOr<void> create_pdf_tab(GUI::TabWidget&, NonnullRefPtr<Core::MappedFile>);
+    ErrorOr<void> create_archive_tab(GUI::TabWidget&, NonnullOwnPtr<Core::MappedFile>);
+    ErrorOr<void> create_audio_tab(GUI::TabWidget&, NonnullOwnPtr<Core::MappedFile>);
+    ErrorOr<void> create_font_tab(GUI::TabWidget&, NonnullOwnPtr<Core::MappedFile>, StringView mime_type);
+    ErrorOr<void> create_image_tab(GUI::TabWidget&, NonnullOwnPtr<Core::MappedFile>, StringView mime_type);
+    ErrorOr<void> create_pdf_tab(GUI::TabWidget&, NonnullOwnPtr<Core::MappedFile>);
 
     struct PermissionMasks {
         mode_t read;

--- a/Userland/Applications/FontEditor/MainWidget.cpp
+++ b/Userland/Applications/FontEditor/MainWidget.cpp
@@ -818,7 +818,7 @@ ErrorOr<void> MainWidget::save_file(StringView path, NonnullOwnPtr<Core::File> f
 ErrorOr<void> MainWidget::open_file(StringView path, NonnullOwnPtr<Core::File> file)
 {
     auto mapped_file = TRY(Core::MappedFile::map_from_file(move(file), path));
-    auto unmasked_font = TRY(TRY(Gfx::BitmapFont::try_load_from_mapped_file(mapped_file))->unmasked_character_set());
+    auto unmasked_font = TRY(TRY(Gfx::BitmapFont::try_load_from_mapped_file(move(mapped_file)))->unmasked_character_set());
     TRY(initialize(path, move(unmasked_font)));
     if (!path.is_empty())
         GUI::Application::the()->set_most_recently_open_file(TRY(String::from_utf8(path)));

--- a/Userland/Applications/Help/ManualModel.h
+++ b/Userland/Applications/Help/ManualModel.h
@@ -42,5 +42,5 @@ private:
     GUI::Icon m_section_open_icon;
     GUI::Icon m_section_icon;
     GUI::Icon m_page_icon;
-    mutable HashMap<String, NonnullRefPtr<Core::MappedFile>> m_mapped_files;
+    mutable HashMap<String, NonnullOwnPtr<Core::MappedFile>> m_mapped_files;
 };

--- a/Userland/DevTools/Profiler/DisassemblyModel.cpp
+++ b/Userland/DevTools/Profiler/DisassemblyModel.cpp
@@ -29,7 +29,8 @@ static ELF::Image* try_load_kernel_binary()
     auto kernel_binary_or_error = Core::MappedFile::map("/boot/Kernel"sv);
     if (!kernel_binary_or_error.is_error()) {
         auto kernel_binary = kernel_binary_or_error.release_value();
-        s_kernel_binary = { { kernel_binary, ELF::Image(kernel_binary->bytes()) } };
+        auto image = ELF::Image(kernel_binary->bytes());
+        s_kernel_binary = { { move(kernel_binary), image } };
         return &s_kernel_binary->elf;
     }
     return nullptr;

--- a/Userland/DevTools/Profiler/Process.h
+++ b/Userland/DevTools/Profiler/Process.h
@@ -17,7 +17,7 @@
 namespace Profiler {
 
 struct MappedObject {
-    NonnullRefPtr<Core::MappedFile> file;
+    NonnullOwnPtr<Core::MappedFile> file;
     ELF::Image elf;
 };
 

--- a/Userland/DevTools/Profiler/Profile.cpp
+++ b/Userland/DevTools/Profiler/Profile.cpp
@@ -280,7 +280,7 @@ ErrorOr<NonnullOwnPtr<Profile>> Profile::load_from_perfcore_file(StringView path
         if (!debuginfo_file_or_error.is_error()) {
             auto debuginfo_file = debuginfo_file_or_error.release_value();
             auto debuginfo_image = ELF::Image(debuginfo_file->bytes());
-            g_kernel_debuginfo_object = { { debuginfo_file, move(debuginfo_image) } };
+            g_kernel_debuginfo_object = { { move(debuginfo_file), move(debuginfo_image) } };
         }
     }
 

--- a/Userland/DevTools/UserspaceEmulator/Emulator.h
+++ b/Userland/DevTools/UserspaceEmulator/Emulator.h
@@ -286,7 +286,7 @@ private:
     Optional<size_t> m_loader_text_size;
 
     struct CachedELF {
-        NonnullRefPtr<Core::MappedFile> mapped_file;
+        NonnullOwnPtr<Core::MappedFile> mapped_file;
         NonnullOwnPtr<Debug::DebugInfo> debug_info;
         NonnullOwnPtr<ELF::Image> image;
     };

--- a/Userland/Libraries/LibAudio/Loader.cpp
+++ b/Userland/Libraries/LibAudio/Loader.cpp
@@ -10,7 +10,7 @@
 #include <LibAudio/MP3Loader.h>
 #include <LibAudio/QOALoader.h>
 #include <LibAudio/WavLoader.h>
-#include <LibCore/File.h>
+#include <LibCore/MappedFile.h>
 
 namespace Audio {
 
@@ -44,7 +44,7 @@ static constexpr LoaderPluginInitializer s_initializers[] = {
 
 ErrorOr<NonnullRefPtr<Loader>, LoaderError> Loader::create(StringView path)
 {
-    auto stream = TRY(Core::InputBufferedFile::create(TRY(Core::File::open(path, Core::File::OpenMode::Read))));
+    auto stream = TRY(Core::MappedFile::map(path, Core::MappedFile::OpenMode::ReadOnly));
     return adopt_ref(*new (nothrow) Loader(TRY(Loader::create_plugin(move(stream)))));
 }
 

--- a/Userland/Libraries/LibCompress/Gzip.cpp
+++ b/Userland/Libraries/LibCompress/Gzip.cpp
@@ -266,7 +266,7 @@ ErrorOr<void> GzipCompressor::compress_file(StringView input_filename, NonnullOw
 {
     // We map the whole file instead of streaming to reduce size overhead (gzip header) and increase the deflate block size (better compression)
     // TODO: automatically fallback to buffered streaming for very large files
-    RefPtr<Core::MappedFile> file;
+    OwnPtr<Core::MappedFile> file;
     ReadonlyBytes input_bytes;
 
     if (TRY(Core::System::stat(input_filename)).st_size > 0) {

--- a/Userland/Libraries/LibCore/MappedFile.cpp
+++ b/Userland/Libraries/LibCore/MappedFile.cpp
@@ -14,18 +14,18 @@
 
 namespace Core {
 
-ErrorOr<NonnullRefPtr<MappedFile>> MappedFile::map(StringView path)
+ErrorOr<NonnullOwnPtr<MappedFile>> MappedFile::map(StringView path)
 {
     auto fd = TRY(Core::System::open(path, O_RDONLY | O_CLOEXEC, 0));
     return map_from_fd_and_close(fd, path);
 }
 
-ErrorOr<NonnullRefPtr<MappedFile>> MappedFile::map_from_file(NonnullOwnPtr<Core::File> stream, StringView path)
+ErrorOr<NonnullOwnPtr<MappedFile>> MappedFile::map_from_file(NonnullOwnPtr<Core::File> stream, StringView path)
 {
     return map_from_fd_and_close(stream->leak_fd(Badge<MappedFile> {}), path);
 }
 
-ErrorOr<NonnullRefPtr<MappedFile>> MappedFile::map_from_fd_and_close(int fd, [[maybe_unused]] StringView path)
+ErrorOr<NonnullOwnPtr<MappedFile>> MappedFile::map_from_fd_and_close(int fd, [[maybe_unused]] StringView path)
 {
     TRY(Core::System::fcntl(fd, F_SETFD, FD_CLOEXEC));
 
@@ -38,7 +38,7 @@ ErrorOr<NonnullRefPtr<MappedFile>> MappedFile::map_from_fd_and_close(int fd, [[m
 
     auto* ptr = TRY(Core::System::mmap(nullptr, size, PROT_READ, MAP_SHARED, fd, 0, 0, path));
 
-    return adopt_ref(*new MappedFile(ptr, size));
+    return adopt_own(*new MappedFile(ptr, size));
 }
 
 MappedFile::MappedFile(void* ptr, size_t size)

--- a/Userland/Libraries/LibCore/MappedFile.h
+++ b/Userland/Libraries/LibCore/MappedFile.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2023, kleines Filmröllchen <filmroellchen@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -8,20 +9,20 @@
 
 #include <AK/Error.h>
 #include <AK/Noncopyable.h>
-#include <AK/NonnullRefPtr.h>
+#include <AK/NonnullOwnPtr.h>
 #include <AK/RefCounted.h>
 #include <LibCore/Forward.h>
 
 namespace Core {
 
-class MappedFile : public RefCounted<MappedFile> {
+class MappedFile {
     AK_MAKE_NONCOPYABLE(MappedFile);
     AK_MAKE_NONMOVABLE(MappedFile);
 
 public:
-    static ErrorOr<NonnullRefPtr<MappedFile>> map(StringView path);
-    static ErrorOr<NonnullRefPtr<MappedFile>> map_from_file(NonnullOwnPtr<Core::File>, StringView path);
-    static ErrorOr<NonnullRefPtr<MappedFile>> map_from_fd_and_close(int fd, StringView path);
+    static ErrorOr<NonnullOwnPtr<MappedFile>> map(StringView path);
+    static ErrorOr<NonnullOwnPtr<MappedFile>> map_from_file(NonnullOwnPtr<Core::File>, StringView path);
+    static ErrorOr<NonnullOwnPtr<MappedFile>> map_from_fd_and_close(int fd, StringView path);
     ~MappedFile();
 
     void* data() { return m_data; }
@@ -36,6 +37,20 @@ private:
 
     void* m_data { nullptr };
     size_t m_size { 0 };
+};
+
+class SharedMappedFile : public RefCounted<SharedMappedFile> {
+public:
+    explicit SharedMappedFile(NonnullOwnPtr<MappedFile> file)
+        : m_file(move(file))
+    {
+    }
+
+    MappedFile const& operator->() const { return *m_file; }
+    MappedFile& operator->() { return *m_file; }
+
+private:
+    NonnullOwnPtr<MappedFile> m_file;
 };
 
 }

--- a/Userland/Libraries/LibCoredump/Backtrace.h
+++ b/Userland/Libraries/LibCoredump/Backtrace.h
@@ -15,14 +15,14 @@
 namespace Coredump {
 
 struct ELFObjectInfo {
-    ELFObjectInfo(NonnullRefPtr<Core::MappedFile> file, NonnullOwnPtr<Debug::DebugInfo>&& debug_info, NonnullOwnPtr<ELF::Image> image)
+    ELFObjectInfo(NonnullOwnPtr<Core::MappedFile> file, NonnullOwnPtr<Debug::DebugInfo>&& debug_info, NonnullOwnPtr<ELF::Image> image)
         : file(move(file))
         , debug_info(move(debug_info))
         , image(move(image))
     {
     }
 
-    NonnullRefPtr<Core::MappedFile> file;
+    NonnullOwnPtr<Core::MappedFile> file;
     NonnullOwnPtr<Debug::DebugInfo> debug_info;
     NonnullOwnPtr<ELF::Image> image;
 };

--- a/Userland/Libraries/LibCoredump/Inspector.cpp
+++ b/Userland/Libraries/LibCoredump/Inspector.cpp
@@ -47,7 +47,7 @@ void Inspector::parse_loaded_libraries(Function<void(float)> on_progress)
 
         auto image = make<ELF::Image>(file_or_error.value()->bytes());
         auto debug_info = make<Debug::DebugInfo>(*image, DeprecatedString {}, library.base_address);
-        m_loaded_libraries.append(make<Debug::LoadedLibrary>(library.name, file_or_error.value(), move(image), move(debug_info), library.base_address));
+        m_loaded_libraries.append(make<Debug::LoadedLibrary>(library.name, file_or_error.release_value(), move(image), move(debug_info), library.base_address));
     });
 }
 

--- a/Userland/Libraries/LibCoredump/Reader.cpp
+++ b/Userland/Libraries/LibCoredump/Reader.cpp
@@ -43,7 +43,7 @@ Reader::Reader(ByteBuffer buffer)
     m_coredump_buffer = move(buffer);
 }
 
-Reader::Reader(NonnullRefPtr<Core::MappedFile> file)
+Reader::Reader(NonnullOwnPtr<Core::MappedFile> file)
     : Reader(file->bytes())
 {
     m_mapped_file = move(file);

--- a/Userland/Libraries/LibCoredump/Reader.h
+++ b/Userland/Libraries/LibCoredump/Reader.h
@@ -66,7 +66,7 @@ public:
     struct LibraryData {
         DeprecatedString name;
         FlatPtr base_address { 0 };
-        NonnullRefPtr<Core::MappedFile> file;
+        NonnullOwnPtr<Core::MappedFile> file;
         ELF::Image lib_elf;
     };
     LibraryData const* library_containing(FlatPtr address) const;
@@ -83,7 +83,7 @@ public:
 private:
     explicit Reader(ReadonlyBytes);
     explicit Reader(ByteBuffer);
-    explicit Reader(NonnullRefPtr<Core::MappedFile>);
+    explicit Reader(NonnullOwnPtr<Core::MappedFile>);
 
     static Optional<ByteBuffer> decompress_coredump(ReadonlyBytes);
 
@@ -108,7 +108,7 @@ private:
     const JsonObject process_info() const;
 
     // For uncompressed coredumps, we keep the MappedFile
-    RefPtr<Core::MappedFile> m_mapped_file;
+    OwnPtr<Core::MappedFile> m_mapped_file;
 
     // For compressed coredumps, we decompress them into a ByteBuffer
     ByteBuffer m_coredump_buffer;

--- a/Userland/Libraries/LibDebug/LoadedLibrary.h
+++ b/Userland/Libraries/LibDebug/LoadedLibrary.h
@@ -14,12 +14,12 @@
 namespace Debug {
 struct LoadedLibrary {
     DeprecatedString name;
-    NonnullRefPtr<Core::MappedFile> file;
+    NonnullOwnPtr<Core::MappedFile> file;
     NonnullOwnPtr<ELF::Image> image;
     NonnullOwnPtr<DebugInfo> debug_info;
     FlatPtr base_address {};
 
-    LoadedLibrary(DeprecatedString const& name, NonnullRefPtr<Core::MappedFile> file, NonnullOwnPtr<ELF::Image> image, NonnullOwnPtr<DebugInfo>&& debug_info, FlatPtr base_address)
+    LoadedLibrary(DeprecatedString const& name, NonnullOwnPtr<Core::MappedFile> file, NonnullOwnPtr<ELF::Image> image, NonnullOwnPtr<DebugInfo>&& debug_info, FlatPtr base_address)
         : name(name)
         , file(move(file))
         , image(move(image))

--- a/Userland/Libraries/LibGUI/FileIconProvider.cpp
+++ b/Userland/Libraries/LibGUI/FileIconProvider.cpp
@@ -174,7 +174,7 @@ Icon FileIconProvider::icon_for_executable(DeprecatedString const& path)
 
     auto& mapped_file = file_or_error.value();
 
-    if (mapped_file->size() < SELFMAG) {
+    if (mapped_file->size().release_value() < SELFMAG) {
         app_icon_cache.set(path, s_executable_icon);
         return s_executable_icon;
     }
@@ -184,7 +184,7 @@ Icon FileIconProvider::icon_for_executable(DeprecatedString const& path)
         return s_executable_icon;
     }
 
-    auto image = ELF::Image((u8 const*)mapped_file->data(), mapped_file->size());
+    auto image = ELF::Image((u8 const*)mapped_file->data(), mapped_file->size().release_value());
     if (!image.is_valid()) {
         app_icon_cache.set(path, s_executable_icon);
         return s_executable_icon;

--- a/Userland/Libraries/LibGfx/Font/BitmapFont.cpp
+++ b/Userland/Libraries/LibGfx/Font/BitmapFont.cpp
@@ -239,10 +239,10 @@ ErrorOr<NonnullRefPtr<BitmapFont>> BitmapFont::try_load_from_file(DeprecatedStri
     return try_load_from_mapped_file(move(mapped_file));
 }
 
-ErrorOr<NonnullRefPtr<BitmapFont>> BitmapFont::try_load_from_mapped_file(RefPtr<Core::MappedFile> const& mapped_file)
+ErrorOr<NonnullRefPtr<BitmapFont>> BitmapFont::try_load_from_mapped_file(OwnPtr<Core::MappedFile> mapped_file)
 {
     auto font = TRY(load_from_memory((u8 const*)mapped_file->data()));
-    font->m_mapped_file = mapped_file;
+    font->m_mapped_file = move(mapped_file);
     return font;
 }
 

--- a/Userland/Libraries/LibGfx/Font/BitmapFont.h
+++ b/Userland/Libraries/LibGfx/Font/BitmapFont.h
@@ -32,7 +32,7 @@ public:
 
     static RefPtr<BitmapFont> load_from_file(DeprecatedString const& path);
     static ErrorOr<NonnullRefPtr<BitmapFont>> try_load_from_file(DeprecatedString const& path);
-    static ErrorOr<NonnullRefPtr<BitmapFont>> try_load_from_mapped_file(RefPtr<Core::MappedFile> const&);
+    static ErrorOr<NonnullRefPtr<BitmapFont>> try_load_from_mapped_file(OwnPtr<Core::MappedFile>);
 
     ErrorOr<void> write_to_file(DeprecatedString const& path);
     ErrorOr<void> write_to_file(NonnullOwnPtr<Core::File> file);
@@ -156,7 +156,7 @@ private:
 
     u8* m_rows { nullptr };
     u8* m_glyph_widths { nullptr };
-    RefPtr<Core::MappedFile> m_mapped_file;
+    OwnPtr<Core::MappedFile> m_mapped_file;
 
     u8 m_glyph_width { 0 };
     u8 m_glyph_height { 0 };

--- a/Userland/Libraries/LibGfx/Font/OpenType/Font.h
+++ b/Userland/Libraries/LibGfx/Font/OpenType/Font.h
@@ -107,7 +107,7 @@ private:
     {
     }
 
-    RefPtr<Core::MappedFile> m_mapped_file;
+    OwnPtr<Core::MappedFile> m_mapped_file;
 
     ReadonlyBytes m_buffer;
 

--- a/Userland/Libraries/LibPCIDB/Database.h
+++ b/Userland/Libraries/LibPCIDB/Database.h
@@ -64,7 +64,7 @@ public:
     const StringView get_programming_interface(u8 class_id, u8 subclass_id, u8 programming_interface_id) const;
 
 private:
-    explicit Database(NonnullRefPtr<Core::MappedFile> file)
+    explicit Database(NonnullOwnPtr<Core::MappedFile> file)
         : m_file(move(file))
     {
     }
@@ -77,7 +77,7 @@ private:
         ClassMode,
     };
 
-    NonnullRefPtr<Core::MappedFile> m_file;
+    NonnullOwnPtr<Core::MappedFile> m_file;
     StringView m_view {};
     HashMap<int, NonnullOwnPtr<Vendor>> m_vendors;
     HashMap<int, NonnullOwnPtr<Class>> m_classes;

--- a/Userland/Libraries/LibSymbolication/Symbolication.cpp
+++ b/Userland/Libraries/LibSymbolication/Symbolication.cpp
@@ -19,7 +19,7 @@
 namespace Symbolication {
 
 struct CachedELF {
-    NonnullRefPtr<Core::MappedFile> mapped_file;
+    NonnullOwnPtr<Core::MappedFile> mapped_file;
     NonnullOwnPtr<Debug::DebugInfo> debug_info;
     NonnullOwnPtr<ELF::Image> image;
 };

--- a/Userland/Libraries/LibUSBDB/Database.h
+++ b/Userland/Libraries/LibUSBDB/Database.h
@@ -63,7 +63,7 @@ public:
     const StringView get_protocol(u8 class_id, u8 subclass_id, u8 protocol_id) const;
 
 private:
-    explicit Database(NonnullRefPtr<Core::MappedFile> file)
+    explicit Database(NonnullOwnPtr<Core::MappedFile> file)
         : m_file(move(file))
     {
     }
@@ -76,7 +76,7 @@ private:
         ClassMode,
     };
 
-    NonnullRefPtr<Core::MappedFile> m_file;
+    NonnullOwnPtr<Core::MappedFile> m_file;
     StringView m_view {};
     HashMap<int, NonnullOwnPtr<Vendor>> m_vendors;
     HashMap<int, NonnullOwnPtr<Class>> m_classes;

--- a/Userland/Libraries/LibVideo/Containers/Matroska/MatroskaDemuxer.cpp
+++ b/Userland/Libraries/LibVideo/Containers/Matroska/MatroskaDemuxer.cpp
@@ -14,7 +14,7 @@ DecoderErrorOr<NonnullOwnPtr<MatroskaDemuxer>> MatroskaDemuxer::from_file(String
     return make<MatroskaDemuxer>(TRY(Reader::from_file(filename)));
 }
 
-DecoderErrorOr<NonnullOwnPtr<MatroskaDemuxer>> MatroskaDemuxer::from_mapped_file(NonnullRefPtr<Core::MappedFile> mapped_file)
+DecoderErrorOr<NonnullOwnPtr<MatroskaDemuxer>> MatroskaDemuxer::from_mapped_file(NonnullOwnPtr<Core::MappedFile> mapped_file)
 {
     return make<MatroskaDemuxer>(TRY(Reader::from_mapped_file(move(mapped_file))));
 }

--- a/Userland/Libraries/LibVideo/Containers/Matroska/MatroskaDemuxer.h
+++ b/Userland/Libraries/LibVideo/Containers/Matroska/MatroskaDemuxer.h
@@ -18,7 +18,7 @@ public:
     // FIXME: We should instead accept some abstract data streaming type so that the demuxer
     //        can work with non-contiguous data.
     static DecoderErrorOr<NonnullOwnPtr<MatroskaDemuxer>> from_file(StringView filename);
-    static DecoderErrorOr<NonnullOwnPtr<MatroskaDemuxer>> from_mapped_file(NonnullRefPtr<Core::MappedFile> mapped_file);
+    static DecoderErrorOr<NonnullOwnPtr<MatroskaDemuxer>> from_mapped_file(NonnullOwnPtr<Core::MappedFile> mapped_file);
 
     static DecoderErrorOr<NonnullOwnPtr<MatroskaDemuxer>> from_data(ReadonlyBytes data);
 

--- a/Userland/Libraries/LibVideo/Containers/Matroska/Reader.cpp
+++ b/Userland/Libraries/LibVideo/Containers/Matroska/Reader.cpp
@@ -86,13 +86,13 @@ constexpr u32 CUE_REFERENCE_ID = 0xDB;
 DecoderErrorOr<Reader> Reader::from_file(StringView path)
 {
     auto mapped_file = DECODER_TRY(DecoderErrorCategory::IO, Core::MappedFile::map(path));
-    return from_mapped_file(mapped_file);
+    return from_mapped_file(move(mapped_file));
 }
 
-DecoderErrorOr<Reader> Reader::from_mapped_file(NonnullRefPtr<Core::MappedFile> mapped_file)
+DecoderErrorOr<Reader> Reader::from_mapped_file(NonnullOwnPtr<Core::MappedFile> mapped_file)
 {
     auto reader = TRY(from_data(mapped_file->bytes()));
-    reader.m_mapped_file = move(mapped_file);
+    reader.m_mapped_file = make_ref_counted<Core::SharedMappedFile>(move(mapped_file));
     return reader;
 }
 

--- a/Userland/Libraries/LibVideo/Containers/Matroska/Reader.h
+++ b/Userland/Libraries/LibVideo/Containers/Matroska/Reader.h
@@ -25,7 +25,7 @@ public:
     typedef Function<DecoderErrorOr<IterationDecision>(TrackEntry const&)> TrackEntryCallback;
 
     static DecoderErrorOr<Reader> from_file(StringView path);
-    static DecoderErrorOr<Reader> from_mapped_file(NonnullRefPtr<Core::MappedFile> mapped_file);
+    static DecoderErrorOr<Reader> from_mapped_file(NonnullOwnPtr<Core::MappedFile> mapped_file);
 
     static DecoderErrorOr<Reader> from_data(ReadonlyBytes data);
 
@@ -60,7 +60,7 @@ private:
     DecoderErrorOr<void> ensure_cues_are_parsed();
     DecoderErrorOr<void> seek_to_cue_for_timestamp(SampleIterator&, Duration const&);
 
-    RefPtr<Core::MappedFile> m_mapped_file;
+    RefPtr<Core::SharedMappedFile> m_mapped_file;
     ReadonlyBytes m_data;
 
     Optional<EBMLHeader> m_header;
@@ -89,7 +89,7 @@ public:
 private:
     friend class Reader;
 
-    SampleIterator(RefPtr<Core::MappedFile> file, ReadonlyBytes data, TrackEntry track, u64 timestamp_scale, size_t position)
+    SampleIterator(RefPtr<Core::SharedMappedFile> file, ReadonlyBytes data, TrackEntry track, u64 timestamp_scale, size_t position)
         : m_file(move(file))
         , m_data(data)
         , m_track(move(track))
@@ -100,7 +100,7 @@ private:
 
     DecoderErrorOr<void> seek_to_cue_point(CuePoint const& cue_point);
 
-    RefPtr<Core::MappedFile> m_file;
+    RefPtr<Core::SharedMappedFile> m_file;
     ReadonlyBytes m_data;
     TrackEntry m_track;
     u64 m_segment_timestamp_scale { 0 };

--- a/Userland/Libraries/LibVideo/PlaybackManager.cpp
+++ b/Userland/Libraries/LibVideo/PlaybackManager.cpp
@@ -31,7 +31,7 @@ DecoderErrorOr<NonnullOwnPtr<PlaybackManager>> PlaybackManager::from_file(String
     return create(move(demuxer));
 }
 
-DecoderErrorOr<NonnullOwnPtr<PlaybackManager>> PlaybackManager::from_mapped_file(NonnullRefPtr<Core::MappedFile> mapped_file)
+DecoderErrorOr<NonnullOwnPtr<PlaybackManager>> PlaybackManager::from_mapped_file(NonnullOwnPtr<Core::MappedFile> mapped_file)
 {
     auto demuxer = TRY(Matroska::MatroskaDemuxer::from_mapped_file(move(mapped_file)));
     return create(move(demuxer));

--- a/Userland/Libraries/LibVideo/PlaybackManager.h
+++ b/Userland/Libraries/LibVideo/PlaybackManager.h
@@ -112,7 +112,7 @@ public:
     static constexpr SeekMode DEFAULT_SEEK_MODE = SeekMode::Accurate;
 
     static DecoderErrorOr<NonnullOwnPtr<PlaybackManager>> from_file(StringView file);
-    static DecoderErrorOr<NonnullOwnPtr<PlaybackManager>> from_mapped_file(NonnullRefPtr<Core::MappedFile> file);
+    static DecoderErrorOr<NonnullOwnPtr<PlaybackManager>> from_mapped_file(NonnullOwnPtr<Core::MappedFile> file);
 
     static DecoderErrorOr<NonnullOwnPtr<PlaybackManager>> from_data(ReadonlyBytes data);
 

--- a/Userland/Utilities/disasm.cpp
+++ b/Userland/Utilities/disasm.cpp
@@ -29,13 +29,13 @@ ErrorOr<int> serenity_main(Main::Arguments args)
     args_parser.add_positional_argument(path, "Path to i386 binary file", "path");
     args_parser.parse(args);
 
-    OwnPtr<Core::MappedFile const> file;
+    OwnPtr<Core::MappedFile> file;
     u8 const* asm_data = nullptr;
     size_t asm_size = 0;
     if ((TRY(Core::System::stat(path))).st_size > 0) {
         file = TRY(Core::MappedFile::map(path));
         asm_data = static_cast<u8 const*>(file->data());
-        asm_size = file->size();
+        asm_size = MUST(file->size());
     }
 
     struct Symbol {

--- a/Userland/Utilities/disasm.cpp
+++ b/Userland/Utilities/disasm.cpp
@@ -29,7 +29,7 @@ ErrorOr<int> serenity_main(Main::Arguments args)
     args_parser.add_positional_argument(path, "Path to i386 binary file", "path");
     args_parser.parse(args);
 
-    RefPtr<Core::MappedFile> file;
+    OwnPtr<Core::MappedFile const> file;
     u8 const* asm_data = nullptr;
     size_t asm_size = 0;
     if ((TRY(Core::System::stat(path))).st_size > 0) {

--- a/Userland/Utilities/fdtdump.cpp
+++ b/Userland/Utilities/fdtdump.cpp
@@ -31,7 +31,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     }
 
     auto const* fdt_header = reinterpret_cast<DeviceTree::FlattenedDeviceTreeHeader const*>(file->data());
-    auto bytes = ReadonlyBytes { file->data(), file->size() };
+    auto bytes = file->bytes();
 
     TRY(DeviceTree::dump(*fdt_header, bytes));
 

--- a/Userland/Utilities/fdtdump.cpp
+++ b/Userland/Utilities/fdtdump.cpp
@@ -25,7 +25,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     // FIXME: Figure out how to do this sanely from stdin
     auto file = TRY(Core::MappedFile::map(filename));
 
-    if (file->size() < sizeof(DeviceTree::FlattenedDeviceTreeHeader)) {
+    if (TRY(file->size()) < sizeof(DeviceTree::FlattenedDeviceTreeHeader)) {
         warnln("Not enough data in {} to contain a device tree header!", filename);
         return 1;
     }

--- a/Userland/Utilities/image.cpp
+++ b/Userland/Utilities/image.cpp
@@ -116,7 +116,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     Optional<ReadonlyBytes> icc_data = TRY(decoder->icc_data());
 
-    RefPtr<Core::MappedFile> icc_file;
+    OwnPtr<Core::MappedFile> icc_file;
     if (!assign_color_profile_path.is_empty()) {
         icc_file = TRY(Core::MappedFile::map(assign_color_profile_path));
         icc_data = icc_file->bytes();
@@ -128,7 +128,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             return 1;
         }
 
-        auto source_icc_file = icc_file;
+        auto source_icc_file = move(icc_file);
         auto source_icc_data = icc_data.value();
         icc_file = TRY(Core::MappedFile::map(convert_color_profile_path));
         icc_data = icc_file->bytes();

--- a/Userland/Utilities/unzip.cpp
+++ b/Userland/Utilities/unzip.cpp
@@ -122,7 +122,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     // FIXME: Map file chunk-by-chunk once we have mmap() with offset.
     //        This will require mapping some parts then unmapping them repeatedly,
     //        but it would be significantly faster and less syscall heavy than seek()/read() at every read.
-    RefPtr<Core::MappedFile> mapped_file;
+    OwnPtr<Core::MappedFile> mapped_file;
     ReadonlyBytes input_bytes;
     if (st.st_size > 0) {
         mapped_file = TRY(Core::MappedFile::map(zip_file_path));

--- a/Userland/Utilities/wasm.cpp
+++ b/Userland/Utilities/wasm.cpp
@@ -258,8 +258,7 @@ static Optional<Wasm::Module> parse(StringView filename)
         return {};
     }
 
-    FixedMemoryStream stream { ReadonlyBytes { result.value()->data(), result.value()->size() } };
-    auto parse_result = Wasm::Module::parse(stream);
+    auto parse_result = Wasm::Module::parse(*result.value());
     if (parse_result.is_error()) {
         warnln("Something went wrong, either the file is invalid, or there's a bug with LibWasm!");
         warnln("The parse error was {}", Wasm::parse_error_to_deprecated_string(parse_result.error()));


### PR DESCRIPTION
MappedFile thereby provides an essentially identical API to Core::File; we might even unify their OpenModes at some point but I kept MappedFile simple for now.

This is 10-20% of a speed increase on platforms with fast I/O (Linux) and not a slowdown on Serenity.


### AK: Make FixedMemoryStream non-final


### AK: Allow specifying writability of a FixedMemoryStream


### AK: Make writability violation of FixedMemoryStream non-fatal

Writing to a read-only file is not a program-crashing error either, so
we just return the standard EBADFD (see write(2)) here.

### LibCore: Make MappedFile OwnPtr-based

Since it will become a stream in a little bit, it should behave like all
non-trivial stream classes, who are not primarily intended to have
shared ownership to make closing behavior more predictable. Across all
uses of MappedFile, there is only one use case of shared mapped files in
LibVideo, which now uses the thin SharedMappedFile wrapper.

### LibCore: Make MappedFile a Stream

The internal reuse of FixedMemoryStream makes this straightforward.
There alread is one user of the new API, demonstrating the need for this
change beyond what I said out to use it for :^)

### LibAudio: Use mapped files for audio playback