### PR TITLE
Ladybird/AppKit: Add cancel load button

### DIFF
--- a/Ladybird/AppKit/UI/Tab.mm
+++ b/Ladybird/AppKit/UI/Tab.mm
@@ -260,6 +260,7 @@ static constexpr CGFloat const WINDOW_HEIGHT = 800;
 
 - (void)onLoadFinish:(URL const&)url
 {
+    [self.tabController onLoadFinish:url];
     if (self.inspector_controller != nil) {
         auto* inspector = (Inspector*)[self.inspector_controller window];
         [inspector inspect];

--- a/Ladybird/AppKit/UI/TabController.h
+++ b/Ladybird/AppKit/UI/TabController.h
@@ -27,6 +27,7 @@ struct TabSettings {
 - (void)loadHTML:(StringView)html url:(URL const&)url;
 
 - (void)onLoadStart:(URL const&)url isRedirect:(BOOL)isRedirect;
+- (void)onLoadFinish:(URL const&)url;
 - (void)onTitleChange:(DeprecatedString const&)title;
 
 - (void)navigateBack:(id)sender;


### PR DESCRIPTION
This patch adds a cancel load button to the AppKit chrome of Ladybird. It isn't currently hooked up to anything, but it still works as a neat progress indicator.

## Loading

<img width="1233" alt="loading" src="https://github.com/SerenityOS/serenity/assets/40562373/ed31c38d-4dd5-4067-9869-9813a534cf8e">

## Done

<img width="1233" alt="done" src="https://github.com/SerenityOS/serenity/assets/40562373/f6900921-ec04-4de0-a091-01dc8f5d661a">