### PR TITLE
LibC: Add fenv+rounding support for RISC-V (and test fenv in the first place)

### DIFF
--- a/AK/StdLibExtras.h
+++ b/AK/StdLibExtras.h
@@ -179,7 +179,7 @@ requires(IsIntegral<T>)
 }
 
 template<typename T>
-ALWAYS_INLINE constexpr void taint_for_optimizer(T& value)
+ALWAYS_INLINE constexpr T taint_for_optimizer(T value)
 requires(!IsIntegral<T>)
 {
     if (!is_constant_evaluated()) {
@@ -188,6 +188,7 @@ requires(!IsIntegral<T>)
                      : "m"(value)
                      : "memory");
     }
+    return value;
 }
 
 // These can't be exported into the global namespace as they would clash with the C standard library.

--- a/Tests/LibC/CMakeLists.txt
+++ b/Tests/LibC/CMakeLists.txt
@@ -3,6 +3,7 @@ set(TEST_SOURCES
     TestAssert.cpp
     TestCType.cpp
     TestEnvironment.cpp
+    TestFenv.cpp
     TestIo.cpp
     TestLibCExec.cpp
     TestLibCGrp.cpp
@@ -40,6 +41,8 @@ set(TEST_SOURCES
 
 set_source_files_properties(TestMath.cpp PROPERTIES COMPILE_FLAGS "-fno-builtin")
 set_source_files_properties(TestStrtodAccuracy.cpp PROPERTIES COMPILE_FLAGS "-fno-builtin-strtod")
+# Don't assume default rounding behavior is used for testing rounding behavior modifications.
+set_source_files_properties(TestFenv.cpp PROPERTIES COMPILE_FLAGS "-frounding-math")
 
 foreach(source IN LISTS TEST_SOURCES)
     serenity_test("${source}" LibC)

--- a/Tests/LibC/CMakeLists.txt
+++ b/Tests/LibC/CMakeLists.txt
@@ -42,7 +42,10 @@ set(TEST_SOURCES
 set_source_files_properties(TestMath.cpp PROPERTIES COMPILE_FLAGS "-fno-builtin")
 set_source_files_properties(TestStrtodAccuracy.cpp PROPERTIES COMPILE_FLAGS "-fno-builtin-strtod")
 # Don't assume default rounding behavior is used for testing rounding behavior modifications.
-set_source_files_properties(TestFenv.cpp PROPERTIES COMPILE_FLAGS "-frounding-math")
+# Clang doesn't seem support this on RISC-V, though (see comment on opaque_add() ).
+if (NOT (CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND "${SERENITY_ARCH}" STREQUAL "riscv64"))
+    set_source_files_properties(TestFenv.cpp PROPERTIES COMPILE_FLAGS "-frounding-math")
+endif()
 
 foreach(source IN LISTS TEST_SOURCES)
     serenity_test("${source}" LibC)

--- a/Tests/LibC/TestFenv.cpp
+++ b/Tests/LibC/TestFenv.cpp
@@ -13,55 +13,64 @@
 // However, it is enough to distinguish the different rounding errors we test for.
 static constexpr double acceptable_float_error = 0.000001;
 
+// // Add two constants without the compiler constant-folding the calculation, so that the addition is affected by float rounding mode.
+// // The same functionality is achieved through -frounding-math, but Clang doesn't support that on RISC-V
+// // FIXME: Remove this workaround once Clang supports it on RISC-V.
+// static ALWAYS_INLINE float opaque_add(double a, double b) {
+//     volatile auto opaque_a = a;
+//     volatile auto opaque_b = b;
+//     return opaque_a + opaque_b;
+// }
+
 TEST_CASE(float_round_up)
 {
     fesetround(FE_UPWARD);
-    EXPECT_APPROXIMATE_WITH_ERROR(0.1f + 0.2f, 0.3f, acceptable_float_error);
-    EXPECT_APPROXIMATE_WITH_ERROR(0.1f + 0.3f, 0.4f, acceptable_float_error);
-    EXPECT_APPROXIMATE_WITH_ERROR(0.1f + 0.4f, 0.5f, acceptable_float_error);
-    EXPECT_APPROXIMATE_WITH_ERROR(-1.f + -0.1f, -1.099999f, acceptable_float_error);
-    EXPECT_APPROXIMATE_WITH_ERROR(1.f + 0.1f, 1.1f, acceptable_float_error);
+    EXPECT_APPROXIMATE_WITH_ERROR(AK::taint_for_optimizer(0.1f) + AK::taint_for_optimizer(0.2f), 0.3f, acceptable_float_error);
+    EXPECT_APPROXIMATE_WITH_ERROR(AK::taint_for_optimizer(0.1f) + AK::taint_for_optimizer(0.3f), 0.4f, acceptable_float_error);
+    EXPECT_APPROXIMATE_WITH_ERROR(AK::taint_for_optimizer(0.1f) + AK::taint_for_optimizer(0.4f), 0.5f, acceptable_float_error);
+    EXPECT_APPROXIMATE_WITH_ERROR(AK::taint_for_optimizer(-1.f) + AK::taint_for_optimizer(-0.1f), -1.099999f, acceptable_float_error);
+    EXPECT_APPROXIMATE_WITH_ERROR(AK::taint_for_optimizer(1.f) + AK::taint_for_optimizer(0.1f), 1.1f, acceptable_float_error);
 }
 
 TEST_CASE(float_round_down)
 {
     fesetround(FE_DOWNWARD);
-    EXPECT_APPROXIMATE_WITH_ERROR(0.1f + 0.2f, 0.299999f, acceptable_float_error);
-    EXPECT_APPROXIMATE_WITH_ERROR(0.1f + 0.3f, 0.4f, acceptable_float_error);
-    EXPECT_APPROXIMATE_WITH_ERROR(0.1f + 0.4f, 0.5f, acceptable_float_error);
-    EXPECT_APPROXIMATE_WITH_ERROR(-1.f + -0.1f, -1.1f, acceptable_float_error);
-    EXPECT_APPROXIMATE_WITH_ERROR(1.f + 0.1f, 1.099999f, acceptable_float_error);
+    EXPECT_APPROXIMATE_WITH_ERROR(AK::taint_for_optimizer(0.1f) + AK::taint_for_optimizer(0.2f), 0.299999f, acceptable_float_error);
+    EXPECT_APPROXIMATE_WITH_ERROR(AK::taint_for_optimizer(0.1f) + AK::taint_for_optimizer(0.3f), 0.4f, acceptable_float_error);
+    EXPECT_APPROXIMATE_WITH_ERROR(AK::taint_for_optimizer(0.1f) + AK::taint_for_optimizer(0.4f), 0.5f, acceptable_float_error);
+    EXPECT_APPROXIMATE_WITH_ERROR(AK::taint_for_optimizer(-1.f) + AK::taint_for_optimizer(-0.1f), -1.1f, acceptable_float_error);
+    EXPECT_APPROXIMATE_WITH_ERROR(AK::taint_for_optimizer(1.f) + AK::taint_for_optimizer(0.1f), 1.099999f, acceptable_float_error);
 }
 
 TEST_CASE(float_round_to_zero)
 {
     fesetround(FE_TOWARDZERO);
-    EXPECT_APPROXIMATE_WITH_ERROR(0.1f + 0.2f, 0.299999f, acceptable_float_error);
-    EXPECT_APPROXIMATE_WITH_ERROR(0.1f + 0.3f, 0.4f, acceptable_float_error);
-    EXPECT_APPROXIMATE_WITH_ERROR(0.1f + 0.4f, 0.5f, acceptable_float_error);
-    EXPECT_APPROXIMATE_WITH_ERROR(-1.f + -0.1f, -1.099999f, acceptable_float_error);
-    EXPECT_APPROXIMATE_WITH_ERROR(1.f + 0.1f, 1.099999f, acceptable_float_error);
+    EXPECT_APPROXIMATE_WITH_ERROR(AK::taint_for_optimizer(0.1f) + AK::taint_for_optimizer(0.2f), 0.299999f, acceptable_float_error);
+    EXPECT_APPROXIMATE_WITH_ERROR(AK::taint_for_optimizer(0.1f) + AK::taint_for_optimizer(0.3f), 0.4f, acceptable_float_error);
+    EXPECT_APPROXIMATE_WITH_ERROR(AK::taint_for_optimizer(0.1f) + AK::taint_for_optimizer(0.4f), 0.5f, acceptable_float_error);
+    EXPECT_APPROXIMATE_WITH_ERROR(AK::taint_for_optimizer(-1.f) + AK::taint_for_optimizer(-0.1f), -1.099999f, acceptable_float_error);
+    EXPECT_APPROXIMATE_WITH_ERROR(AK::taint_for_optimizer(1.f) + AK::taint_for_optimizer(0.1f), 1.099999f, acceptable_float_error);
 }
 
 TEST_CASE(float_round_to_nearest)
 {
     fesetround(FE_TONEAREST);
-    EXPECT_APPROXIMATE_WITH_ERROR(0.1f + 0.2f, 0.3, acceptable_float_error);
-    EXPECT_APPROXIMATE_WITH_ERROR(0.1f + 0.3f, 0.4, acceptable_float_error);
-    EXPECT_APPROXIMATE_WITH_ERROR(0.1f + 0.4f, 0.5, acceptable_float_error);
-    EXPECT_APPROXIMATE_WITH_ERROR(-1.f + -0.1f, -1.1f, acceptable_float_error);
-    EXPECT_APPROXIMATE_WITH_ERROR(1.f + 0.1f, 1.1f, acceptable_float_error);
+    EXPECT_APPROXIMATE_WITH_ERROR(AK::taint_for_optimizer(0.1f) + AK::taint_for_optimizer(0.2f), 0.3, acceptable_float_error);
+    EXPECT_APPROXIMATE_WITH_ERROR(AK::taint_for_optimizer(0.1f) + AK::taint_for_optimizer(0.3f), 0.4, acceptable_float_error);
+    EXPECT_APPROXIMATE_WITH_ERROR(AK::taint_for_optimizer(0.1f) + AK::taint_for_optimizer(0.4f), 0.5, acceptable_float_error);
+    EXPECT_APPROXIMATE_WITH_ERROR(AK::taint_for_optimizer(-1.f) + AK::taint_for_optimizer(-0.1f), -1.1f, acceptable_float_error);
+    EXPECT_APPROXIMATE_WITH_ERROR(AK::taint_for_optimizer(1.f) + AK::taint_for_optimizer(0.1f), 1.1f, acceptable_float_error);
 }
 
 // FIXME: Figure out some tests to distinguish nearest from max-magnitude on supported platforms.
 TEST_CASE(float_round_to_max_magnitude)
 {
     fesetround(FE_TOMAXMAGNITUDE);
-    EXPECT_APPROXIMATE_WITH_ERROR(0.1f + 0.2f, 0.3f, acceptable_float_error);
-    EXPECT_APPROXIMATE_WITH_ERROR(0.1f + 0.3f, 0.4f, acceptable_float_error);
-    EXPECT_APPROXIMATE_WITH_ERROR(0.1f + 0.4f, 0.5f, acceptable_float_error);
-    EXPECT_APPROXIMATE_WITH_ERROR(-1.f + -0.1f, -1.1f, acceptable_float_error);
-    EXPECT_APPROXIMATE_WITH_ERROR(1.f + 0.1f, 1.1f, acceptable_float_error);
+    EXPECT_APPROXIMATE_WITH_ERROR(AK::taint_for_optimizer(0.1f) + AK::taint_for_optimizer(0.2f), 0.3f, acceptable_float_error);
+    EXPECT_APPROXIMATE_WITH_ERROR(AK::taint_for_optimizer(0.1f) + AK::taint_for_optimizer(0.3f), 0.4f, acceptable_float_error);
+    EXPECT_APPROXIMATE_WITH_ERROR(AK::taint_for_optimizer(0.1f) + AK::taint_for_optimizer(0.4f), 0.5f, acceptable_float_error);
+    EXPECT_APPROXIMATE_WITH_ERROR(AK::taint_for_optimizer(-1.f) + AK::taint_for_optimizer(-0.1f), -1.1f, acceptable_float_error);
+    EXPECT_APPROXIMATE_WITH_ERROR(AK::taint_for_optimizer(1.f) + AK::taint_for_optimizer(0.1f), 1.1f, acceptable_float_error);
 }
 
 TEST_CASE(store_round_in_env)
@@ -71,10 +80,10 @@ TEST_CASE(store_round_in_env)
     fegetenv(&env);
     fesetround(FE_UPWARD);
     // This result only happens under upward rounding.
-    EXPECT_APPROXIMATE_WITH_ERROR(-1.f + -0.1f, -1.099999f, acceptable_float_error);
+    EXPECT_APPROXIMATE_WITH_ERROR(AK::taint_for_optimizer(-1.f) + AK::taint_for_optimizer(-0.1f), -1.099999f, acceptable_float_error);
     fesetenv(&env);
     // ... and this only under downward rounding.
-    EXPECT_APPROXIMATE_WITH_ERROR(-1.f + -0.1f, -1.1f, acceptable_float_error);
+    EXPECT_APPROXIMATE_WITH_ERROR(AK::taint_for_optimizer(-1.f) + AK::taint_for_optimizer(-0.1f), -1.1f, acceptable_float_error);
 }
 
 TEST_CASE(save_restore_round)
@@ -85,9 +94,9 @@ TEST_CASE(save_restore_round)
 
     fesetround(FE_UPWARD);
     EXPECT_EQ(fegetround(), FE_UPWARD);
-    EXPECT_APPROXIMATE_WITH_ERROR(-1.f + -0.1f, -1.099999f, acceptable_float_error);
+    EXPECT_APPROXIMATE_WITH_ERROR(AK::taint_for_optimizer(-1.f) + AK::taint_for_optimizer(-0.1f), -1.099999f, acceptable_float_error);
     fesetround(rounding_mode);
-    EXPECT_APPROXIMATE_WITH_ERROR(-1.f + -0.1f, -1.1f, acceptable_float_error);
+    EXPECT_APPROXIMATE_WITH_ERROR(AK::taint_for_optimizer(-1.f) + AK::taint_for_optimizer(-0.1f), -1.1f, acceptable_float_error);
 
 #if ARCH(X86_64)
     // Max-magnitude rounding is not supported by x86, so we expect fesetround to decay it to some other rounding mode.

--- a/Tests/LibC/TestFenv.cpp
+++ b/Tests/LibC/TestFenv.cpp
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2023, kleines Filmröllchen <filmroellchen@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibTest/TestCase.h>
+#include <fenv.h>
+
+// TODO: Add tests for floating-point exception management.
+
+// This error happens even with float literals; e.g. -1.099999f becomes -1.099998f.
+// However, it is enough to distinguish the different rounding errors we test for.
+static constexpr double acceptable_float_error = 0.000001;
+
+TEST_CASE(float_round_up)
+{
+    fesetround(FE_UPWARD);
+    EXPECT_APPROXIMATE_WITH_ERROR(0.1f + 0.2f, 0.3f, acceptable_float_error);
+    EXPECT_APPROXIMATE_WITH_ERROR(0.1f + 0.3f, 0.4f, acceptable_float_error);
+    EXPECT_APPROXIMATE_WITH_ERROR(0.1f + 0.4f, 0.5f, acceptable_float_error);
+    EXPECT_APPROXIMATE_WITH_ERROR(-1.f + -0.1f, -1.099999f, acceptable_float_error);
+    EXPECT_APPROXIMATE_WITH_ERROR(1.f + 0.1f, 1.1f, acceptable_float_error);
+}
+
+TEST_CASE(float_round_down)
+{
+    fesetround(FE_DOWNWARD);
+    EXPECT_APPROXIMATE_WITH_ERROR(0.1f + 0.2f, 0.299999f, acceptable_float_error);
+    EXPECT_APPROXIMATE_WITH_ERROR(0.1f + 0.3f, 0.4f, acceptable_float_error);
+    EXPECT_APPROXIMATE_WITH_ERROR(0.1f + 0.4f, 0.5f, acceptable_float_error);
+    EXPECT_APPROXIMATE_WITH_ERROR(-1.f + -0.1f, -1.1f, acceptable_float_error);
+    EXPECT_APPROXIMATE_WITH_ERROR(1.f + 0.1f, 1.099999f, acceptable_float_error);
+}
+
+TEST_CASE(float_round_to_zero)
+{
+    fesetround(FE_TOWARDZERO);
+    EXPECT_APPROXIMATE_WITH_ERROR(0.1f + 0.2f, 0.299999f, acceptable_float_error);
+    EXPECT_APPROXIMATE_WITH_ERROR(0.1f + 0.3f, 0.4f, acceptable_float_error);
+    EXPECT_APPROXIMATE_WITH_ERROR(0.1f + 0.4f, 0.5f, acceptable_float_error);
+    EXPECT_APPROXIMATE_WITH_ERROR(-1.f + -0.1f, -1.099999f, acceptable_float_error);
+    EXPECT_APPROXIMATE_WITH_ERROR(1.f + 0.1f, 1.099999f, acceptable_float_error);
+}
+
+TEST_CASE(float_round_to_nearest)
+{
+    fesetround(FE_TONEAREST);
+    EXPECT_APPROXIMATE_WITH_ERROR(0.1f + 0.2f, 0.3, acceptable_float_error);
+    EXPECT_APPROXIMATE_WITH_ERROR(0.1f + 0.3f, 0.4, acceptable_float_error);
+    EXPECT_APPROXIMATE_WITH_ERROR(0.1f + 0.4f, 0.5, acceptable_float_error);
+    EXPECT_APPROXIMATE_WITH_ERROR(-1.f + -0.1f, -1.1f, acceptable_float_error);
+    EXPECT_APPROXIMATE_WITH_ERROR(1.f + 0.1f, 1.1f, acceptable_float_error);
+}
+
+// FIXME: Figure out some tests to distinguish nearest from max-magnitude on supported platforms.
+TEST_CASE(float_round_to_max_magnitude)
+{
+    fesetround(FE_TOMAXMAGNITUDE);
+    EXPECT_APPROXIMATE_WITH_ERROR(0.1f + 0.2f, 0.3f, acceptable_float_error);
+    EXPECT_APPROXIMATE_WITH_ERROR(0.1f + 0.3f, 0.4f, acceptable_float_error);
+    EXPECT_APPROXIMATE_WITH_ERROR(0.1f + 0.4f, 0.5f, acceptable_float_error);
+    EXPECT_APPROXIMATE_WITH_ERROR(-1.f + -0.1f, -1.1f, acceptable_float_error);
+    EXPECT_APPROXIMATE_WITH_ERROR(1.f + 0.1f, 1.1f, acceptable_float_error);
+}
+
+TEST_CASE(store_round_in_env)
+{
+    fesetround(FE_DOWNWARD);
+    fenv_t env;
+    fegetenv(&env);
+    fesetround(FE_UPWARD);
+    // This result only happens under upward rounding.
+    EXPECT_APPROXIMATE_WITH_ERROR(-1.f + -0.1f, -1.099999f, acceptable_float_error);
+    fesetenv(&env);
+    // ... and this only under downward rounding.
+    EXPECT_APPROXIMATE_WITH_ERROR(-1.f + -0.1f, -1.1f, acceptable_float_error);
+}
+
+TEST_CASE(save_restore_round)
+{
+    fesetround(FE_DOWNWARD);
+    auto rounding_mode = fegetround();
+    EXPECT_EQ(rounding_mode, FE_DOWNWARD);
+
+    fesetround(FE_UPWARD);
+    EXPECT_EQ(fegetround(), FE_UPWARD);
+    EXPECT_APPROXIMATE_WITH_ERROR(-1.f + -0.1f, -1.099999f, acceptable_float_error);
+    fesetround(rounding_mode);
+    EXPECT_APPROXIMATE_WITH_ERROR(-1.f + -0.1f, -1.1f, acceptable_float_error);
+
+#if ARCH(X86_64)
+    // Max-magnitude rounding is not supported by x86, so we expect fesetround to decay it to some other rounding mode.
+    fesetround(FE_TOMAXMAGNITUDE);
+    EXPECT_NE(fegetround(), FE_TOMAXMAGNITUDE);
+#endif
+}

--- a/Tests/LibC/TestMath.cpp
+++ b/Tests/LibC/TestMath.cpp
@@ -56,12 +56,6 @@ TEST_CASE(trig)
     EXPECT_APPROXIMATE(atan(555.5), 1.568996);
 }
 
-TEST_CASE(other)
-{
-    EXPECT_EQ(trunc(9999999999999.5), 9999999999999.0);
-    EXPECT_EQ(trunc(-9999999999999.5), -9999999999999.0);
-}
-
 TEST_CASE(exponents)
 {
     struct values {
@@ -272,22 +266,77 @@ TEST_CASE(acos)
 
 TEST_CASE(floor)
 {
-    EXPECT_EQ(floor(0.125), 0);
-    EXPECT_EQ(floor(-0.125), -1.0);
-    EXPECT_EQ(floor(0.5), 0);
-    EXPECT_EQ(floor(-0.5), -1.0);
-    EXPECT_EQ(floor(0.25), 0);
-    EXPECT_EQ(floor(-0.25), -1.0);
-    EXPECT_EQ(floor(-3.0 / 2.0), -2.0);
+    // NOTE: We run tests for all three float types since architecture-specific code may vary significantly between types.
+#define TEST_FLOOR_FOR(suffix)                \
+    EXPECT_EQ(floor##suffix(0.125f), 0.f);    \
+    EXPECT_EQ(floor##suffix(-0.125f), -1.0f); \
+    EXPECT_EQ(floor##suffix(0.5f), 0.f);      \
+    EXPECT_EQ(floor##suffix(-0.5f), -1.0f);   \
+    EXPECT_EQ(floor##suffix(0.25f), 0.f);     \
+    EXPECT_EQ(floor##suffix(-0.25f), -1.0f);  \
+    EXPECT_EQ(floor##suffix(-3.0f / 2.0f), -2.0f);
+
+    TEST_FLOOR_FOR();
+    TEST_FLOOR_FOR(f);
+    TEST_FLOOR_FOR(l);
+
+    EXPECT_EQ(floor(-9999999999999.5), -10000000000000.0);
+    EXPECT_EQ(floor(9999999999999.5), 9999999999999.0);
 }
 
 TEST_CASE(ceil)
 {
-    EXPECT_EQ(ceil(0.125), 1.0);
-    EXPECT_EQ(ceil(-0.125), 0);
-    EXPECT_EQ(ceil(0.5), 1.0);
-    EXPECT_EQ(ceil(-0.5), 0);
-    EXPECT_EQ(ceil(0.25), 1.0);
-    EXPECT_EQ(ceil(-0.25), 0);
-    EXPECT_EQ(ceil(-3.0 / 2.0), -1.0);
+#define TEST_CEIL_FOR(suffix)                            \
+    EXPECT_EQ(ceil##suffix(0.125##suffix), 1.0##suffix); \
+    EXPECT_EQ(ceil##suffix(-0.125##suffix), 0.##suffix); \
+    EXPECT_EQ(ceil##suffix(0.5##suffix), 1.0##suffix);   \
+    EXPECT_EQ(ceil##suffix(-0.5##suffix), 0.##suffix);   \
+    EXPECT_EQ(ceil##suffix(0.25##suffix), 1.0##suffix);  \
+    EXPECT_EQ(ceil##suffix(-0.25##suffix), 0.##suffix);  \
+    EXPECT_EQ(ceil##suffix(-3.0##suffix / 2.0##suffix), -1.0##suffix);
+
+    TEST_CEIL_FOR();
+    TEST_CEIL_FOR(f);
+    TEST_CEIL_FOR(l);
+
+    EXPECT_EQ(ceil(9999999999999.5), 10000000000000.0);
+    EXPECT_EQ(ceil(-9999999999999.5), -9999999999999.0);
+}
+
+TEST_CASE(trunc)
+{
+#define TEST_TRUNC_FOR(suffix)                            \
+    EXPECT_EQ(trunc##suffix(0.125##suffix), 0.##suffix);  \
+    EXPECT_EQ(trunc##suffix(-0.125##suffix), 0.##suffix); \
+    EXPECT_EQ(trunc##suffix(0.5##suffix), 0.##suffix);    \
+    EXPECT_EQ(trunc##suffix(-0.5##suffix), 0.##suffix);   \
+    EXPECT_EQ(trunc##suffix(0.25##suffix), 0.##suffix);   \
+    EXPECT_EQ(trunc##suffix(-0.25##suffix), 0.##suffix);  \
+    EXPECT_EQ(trunc##suffix(-3.0##suffix / 2.0##suffix), -1.0##suffix);
+
+    TEST_TRUNC_FOR();
+    TEST_TRUNC_FOR(f);
+    TEST_TRUNC_FOR(l);
+
+    EXPECT_EQ(trunc(9999999999999.5), 9999999999999.0);
+    EXPECT_EQ(trunc(-9999999999999.5), -9999999999999.0);
+}
+
+TEST_CASE(round)
+{
+#define TEST_ROUND_FOR(suffix)                            \
+    EXPECT_EQ(round##suffix(0.125##suffix), 0.##suffix);  \
+    EXPECT_EQ(round##suffix(-0.125##suffix), 0.##suffix); \
+    EXPECT_EQ(round##suffix(0.5##suffix), 1.0##suffix);   \
+    EXPECT_EQ(round##suffix(-0.5##suffix), -1.0##suffix); \
+    EXPECT_EQ(round##suffix(0.25##suffix), 0.##suffix);   \
+    EXPECT_EQ(round##suffix(-0.25##suffix), 0.##suffix);  \
+    EXPECT_EQ(round##suffix(-3.0##suffix / 2.0##suffix), -2.0##suffix);
+
+    TEST_ROUND_FOR();
+    TEST_ROUND_FOR(f);
+    TEST_ROUND_FOR(l);
+
+    EXPECT_EQ(round(9999999999999.5), 10000000000000.0);
+    EXPECT_EQ(round(-9999999999999.5), -10000000000000.0);
 }

--- a/Userland/Libraries/LibC/fenv.cpp
+++ b/Userland/Libraries/LibC/fenv.cpp
@@ -1,16 +1,19 @@
 /*
  * Copyright (c) 2021, Mițca Dumitru <dumitru0mitca@gmail.com>
+ * Copyright (c) 2023, kleines Filmröllchen <filmroellchen@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/EnumBits.h>
 #include <AK/Types.h>
 #include <fenv.h>
+
+#if ARCH(X86_64)
 
 // This is the size of the floating point environment image in protected mode
 static_assert(sizeof(__x87_floating_point_environment) == 28);
 
-#if ARCH(X86_64)
 static u16 read_status_register()
 {
     u16 status_register;
@@ -46,6 +49,162 @@ static void set_mxcsr(u32 new_mxcsr)
 }
 
 static constexpr u32 default_mxcsr_value = 0x1f80;
+
+#elif ARCH(RISCV64)
+
+// RISC-V F extension version 2.2
+// Table 11.1 (frm rounding mode encoding)
+enum class RoundingMode : u8 {
+    // Round to Nearest, ties to Even
+    RNE = 0b000,
+    // Round towards Zero
+    RTZ = 0b001,
+    // Round Down (towards −∞)
+    RDN = 0b010,
+    // Round Up (towards +∞)
+    RUP = 0b011,
+    // Round to Nearest, ties to Max Magnitude
+    RMM = 0b100,
+    // Reserved for future use.
+    Reserved5 = 0b101,
+    Reserved6 = 0b110,
+    // In instruction’s rm field, selects dynamic rounding mode; In Rounding Mode register, Invalid.
+    DYN = 0b111,
+};
+
+static RoundingMode frm_from_feround(int c_rounding_mode)
+{
+    switch (c_rounding_mode) {
+    case FE_TONEAREST:
+        return RoundingMode::RNE;
+    case FE_TOWARDZERO:
+        return RoundingMode::RTZ;
+    case FE_DOWNWARD:
+        return RoundingMode::RDN;
+    case FE_UPWARD:
+        return RoundingMode::RUP;
+    case FE_TOMAXMAGNITUDE:
+        return RoundingMode::RMM;
+    default:
+        VERIFY_NOT_REACHED();
+    }
+}
+
+static int feround_from_frm(RoundingMode frm)
+{
+    switch (frm) {
+    case RoundingMode::RNE:
+        return FE_TONEAREST;
+    case RoundingMode::RTZ:
+        return FE_TOWARDZERO;
+    case RoundingMode::RDN:
+        return FE_DOWNWARD;
+    case RoundingMode::RUP:
+        return FE_UPWARD;
+    case RoundingMode::RMM:
+        return FE_TOMAXMAGNITUDE;
+    default:
+        // DYN is invalid in the frm register and therefore should never appear here.
+    case RoundingMode::DYN:
+        VERIFY_NOT_REACHED();
+    }
+}
+
+static RoundingMode get_rounding_mode()
+{
+    size_t rounding_mode;
+    asm volatile("frrm %0"
+                 : "=r"(rounding_mode));
+    return static_cast<RoundingMode>(rounding_mode);
+}
+
+// Returns the old rounding mode, since we get that for free.
+static RoundingMode set_rounding_mode(RoundingMode frm)
+{
+    size_t old_rounding_mode;
+    size_t const new_rounding_mode = to_underlying(frm);
+    asm volatile("fsrm %0, %1"
+                 : "=r"(old_rounding_mode)
+                 : "r"(new_rounding_mode));
+    return static_cast<RoundingMode>(old_rounding_mode);
+}
+
+// Figure 11.2 (fflags)
+enum class AccruedExceptions : u8 {
+    None = 0,
+    // Inexact
+    NX = 1 << 0,
+    // Underflow
+    UF = 1 << 1,
+    // Overflow
+    OF = 1 << 2,
+    // Divide by Zero
+    DZ = 1 << 3,
+    // Invalid Operation
+    NV = 1 << 4,
+    All = NX | UF | OF | DZ | NV,
+};
+
+AK_ENUM_BITWISE_OPERATORS(AccruedExceptions);
+
+static AccruedExceptions fflags_from_fexcept(fexcept_t c_exceptions)
+{
+    AccruedExceptions exceptions = AccruedExceptions::None;
+    if ((c_exceptions & FE_INEXACT) != 0)
+        exceptions |= AccruedExceptions::NX;
+    if ((c_exceptions & FE_UNDERFLOW) != 0)
+        exceptions |= AccruedExceptions::UF;
+    if ((c_exceptions & FE_OVERFLOW) != 0)
+        exceptions |= AccruedExceptions::OF;
+    if ((c_exceptions & FE_DIVBYZERO) != 0)
+        exceptions |= AccruedExceptions::DZ;
+    if ((c_exceptions & FE_INVALID) != 0)
+        exceptions |= AccruedExceptions::NV;
+
+    return exceptions;
+}
+
+static fexcept_t fexcept_from_fflags(AccruedExceptions fflags)
+{
+    fexcept_t c_exceptions = 0;
+    if ((fflags & AccruedExceptions::NX) != AccruedExceptions::None)
+        c_exceptions |= FE_INEXACT;
+    if ((fflags & AccruedExceptions::UF) != AccruedExceptions::None)
+        c_exceptions |= FE_UNDERFLOW;
+    if ((fflags & AccruedExceptions::OF) != AccruedExceptions::None)
+        c_exceptions |= FE_OVERFLOW;
+    if ((fflags & AccruedExceptions::DZ) != AccruedExceptions::None)
+        c_exceptions |= FE_DIVBYZERO;
+    if ((fflags & AccruedExceptions::NV) != AccruedExceptions::None)
+        c_exceptions |= FE_INVALID;
+
+    return c_exceptions;
+}
+
+static AccruedExceptions get_accrued_exceptions()
+{
+    size_t fflags;
+    asm volatile("frflags %0"
+                 : "=r"(fflags));
+    return static_cast<AccruedExceptions>(fflags);
+}
+
+// Returns the old exceptions, since we get them for free.
+static AccruedExceptions set_accrued_exceptions(AccruedExceptions exceptions)
+{
+    size_t old_exceptions;
+    size_t const new_exceptions = to_underlying(exceptions);
+    asm volatile("fsflags %0, %1"
+                 : "=r"(old_exceptions)
+                 : "r"(new_exceptions));
+    return static_cast<AccruedExceptions>(old_exceptions);
+}
+
+static void clear_accrued_exceptions(AccruedExceptions exceptions)
+{
+    asm volatile("csrc fcsr, %0" ::"r"(to_underlying(exceptions)));
+}
+
 #endif
 
 extern "C" {
@@ -59,8 +218,8 @@ int fegetenv(fenv_t* env)
     (void)env;
     TODO_AARCH64();
 #elif ARCH(RISCV64)
-    (void)env;
-    TODO_RISCV64();
+    asm volatile("csrr %0, fcsr"
+                 : "=r"(env));
 #elif ARCH(X86_64)
     asm volatile("fnstenv %0"
                  : "=m"(env->__x87_fpu_env)::"memory");
@@ -82,8 +241,7 @@ int fesetenv(fenv_t const* env)
     (void)env;
     TODO_AARCH64();
 #elif ARCH(RISCV64)
-    (void)env;
-    TODO_RISCV64();
+    asm volatile("csrw fcsr, %0" ::"r"(env));
 #elif ARCH(X86_64)
     if (env == FE_DFL_ENV) {
         asm volatile("finit");
@@ -106,24 +264,24 @@ int feholdexcept(fenv_t* env)
 {
     fegetenv(env);
 
-    fenv_t current_env;
-    fegetenv(&current_env);
-
 #if ARCH(AARCH64)
     (void)env;
     TODO_AARCH64();
 #elif ARCH(RISCV64)
-    (void)env;
-    TODO_RISCV64();
+    // RISC-V does not have trapping floating point exceptions. Therefore, feholdexcept just clears fflags.
+    clear_accrued_exceptions(AccruedExceptions::All);
 #elif ARCH(X86_64)
+    fenv_t current_env;
+    fegetenv(&current_env);
+
     current_env.__x87_fpu_env.__status_word &= ~FE_ALL_EXCEPT;
     current_env.__x87_fpu_env.__status_word &= ~(1 << 7);      // Clear the "Exception Status Summary" bit
     current_env.__x87_fpu_env.__control_word &= FE_ALL_EXCEPT; // Masking these bits stops the corresponding exceptions from being generated according to the Intel Programmer's Manual
+
+    fesetenv(&current_env);
 #else
 #    error Unknown architecture
 #endif
-
-    fesetenv(&current_env);
 
     return 0;
 }
@@ -150,26 +308,25 @@ int fesetexceptflag(fexcept_t const* except, int exceptions)
     if (!except)
         return 1;
 
-    fenv_t current_env;
-    fegetenv(&current_env);
-
     exceptions &= FE_ALL_EXCEPT;
+
 #if ARCH(AARCH64)
     (void)exceptions;
     (void)except;
     TODO_AARCH64();
 #elif ARCH(RISCV64)
-    (void)exceptions;
-    (void)except;
-    TODO_RISCV64();
+    auto exceptions_to_set = fflags_from_fexcept(*except) & fflags_from_fexcept(exceptions);
+    set_accrued_exceptions(exceptions_to_set);
 #elif ARCH(X86_64)
+    fenv_t current_env;
+    fegetenv(&current_env);
     current_env.__x87_fpu_env.__status_word &= exceptions;
     current_env.__x87_fpu_env.__status_word &= ~(1 << 7); // Make sure exceptions don't get raised
+    fesetenv(&current_env);
 #else
 #    error Unknown architecture
 #endif
 
-    fesetenv(&current_env);
     return 0;
 }
 
@@ -178,7 +335,8 @@ int fegetround()
 #if ARCH(AARCH64)
     TODO_AARCH64();
 #elif ARCH(RISCV64)
-    TODO_RISCV64();
+    auto rounding_mode = get_rounding_mode();
+    return feround_from_frm(rounding_mode);
 #elif ARCH(X86_64)
     // There's no way to signal whether the SSE rounding mode and x87 ones are different, so we assume they're the same
     return (read_status_register() >> 10) & 3;
@@ -189,14 +347,18 @@ int fegetround()
 
 int fesetround(int rounding_mode)
 {
-    if (rounding_mode < FE_TONEAREST || rounding_mode > FE_TOWARDZERO)
+    if (rounding_mode < FE_TONEAREST || rounding_mode > FE_TOMAXMAGNITUDE)
         return 1;
 
 #if ARCH(AARCH64)
     TODO_AARCH64();
 #elif ARCH(RISCV64)
-    TODO_RISCV64();
+    auto frm = frm_from_feround(rounding_mode);
+    set_rounding_mode(frm);
 #elif ARCH(X86_64)
+    if (rounding_mode == FE_TOMAXMAGNITUDE)
+        rounding_mode = FE_TONEAREST;
+
     auto control_word = read_control_word();
 
     control_word &= ~(3 << 10);
@@ -221,23 +383,26 @@ int feclearexcept(int exceptions)
 {
     exceptions &= FE_ALL_EXCEPT;
 
-    fenv_t current_env;
-    fegetenv(&current_env);
-
 #if ARCH(AARCH64)
     (void)exceptions;
     TODO_AARCH64();
 #elif ARCH(RISCV64)
-    (void)exceptions;
-    TODO_RISCV64();
+    auto exception_clear_flag = fflags_from_fexcept(exceptions);
+    // Use CSRRC to directly clear exception flags in fcsr which is faster.
+    // Conveniently, the exception flags are the lower bits, so we don't need to shift anything around.
+    clear_accrued_exceptions(exception_clear_flag);
 #elif ARCH(X86_64)
+
+    fenv_t current_env;
+    fegetenv(&current_env);
     current_env.__x87_fpu_env.__status_word &= ~exceptions;
     current_env.__x87_fpu_env.__status_word &= ~(1 << 7); // Clear the "Exception Status Summary" bit
+    fesetenv(&current_env);
+
 #else
 #    error Unknown architecture
 #endif
 
-    fesetenv(&current_env);
     return 0;
 }
 
@@ -247,8 +412,9 @@ int fetestexcept(int exceptions)
     (void)exceptions;
     TODO_AARCH64();
 #elif ARCH(RISCV64)
-    (void)exceptions;
-    TODO_RISCV64();
+    auto fflags = get_accrued_exceptions();
+    auto mask = fflags_from_fexcept(exceptions);
+    return fexcept_from_fflags(fflags & mask);
 #elif ARCH(X86_64)
     u16 status_register = read_status_register() & FE_ALL_EXCEPT;
     exceptions &= FE_ALL_EXCEPT;
@@ -270,8 +436,8 @@ int feraiseexcept(int exceptions)
     (void)exceptions;
     TODO_AARCH64();
 #elif ARCH(RISCV64)
-    (void)exceptions;
-    TODO_RISCV64();
+    // RISC-V does not have trapping floating-point exceptions, so this function behaves as a simple exception setter.
+    set_accrued_exceptions(fflags_from_fexcept(exceptions));
 #elif ARCH(X86_64)
     // While the order in which the exceptions is raised is unspecified, FE_OVERFLOW and FE_UNDERFLOW must be raised before FE_INEXACT, so handle that case in this branch
     if (exceptions & FE_INEXACT) {

--- a/Userland/Libraries/LibC/math.cpp
+++ b/Userland/Libraries/LibC/math.cpp
@@ -57,7 +57,9 @@ enum class RoundingMode {
     ToZero = FE_TOWARDZERO,
     Up = FE_UPWARD,
     Down = FE_DOWNWARD,
-    ToEven = FE_TONEAREST
+    ToEven = FE_TONEAREST,
+    // Round to nearest, ties away from zero.
+    ToMaxMagnitude = FE_TOMAXMAGNITUDE,
 };
 
 // This is much branchier than it really needs to be
@@ -117,6 +119,9 @@ static FloatType internal_to_integer(FloatType x, RoundingMode rounding_mode)
             should_round = has_nonhalf_fraction || has_half_fraction;
         break;
     case RoundingMode::ToZero:
+        break;
+    case RoundingMode::ToMaxMagnitude:
+        should_round = true;
         break;
     }
 
@@ -397,6 +402,14 @@ double trunc(double x) NOEXCEPT
             : [temp] "m"(temp));
         return x;
     }
+#elif ARCH(RISCV64)
+    if (fabs(x) < LONG_LONG_MAX) {
+        i64 output;
+        asm("fcvt.l.d %0, %1, rtz"
+            : "=r"(output)
+            : "f"(x));
+        return static_cast<double>(output);
+    }
 #endif
 
     return internal_to_integer(x, RoundingMode::ToZero);
@@ -413,6 +426,14 @@ float truncf(float x) NOEXCEPT
             : "+t"(x)
             : [temp] "m"(temp));
         return x;
+    }
+#elif ARCH(RISCV64)
+    if (fabsf(x) < LONG_LONG_MAX) {
+        i64 output;
+        asm("fcvt.l.s %0, %1, rtz"
+            : "=r"(output)
+            : "f"(x));
+        return static_cast<float>(output);
     }
 #endif
 
@@ -444,8 +465,12 @@ double rint(double value)
     (void)value;
     TODO_AARCH64();
 #elif ARCH(RISCV64)
-    (void)value;
-    TODO_RISCV64();
+    i64 output;
+    // FIXME: This saturates at 64-bit integer boundaries; see Table 11.4 (RISC-V Unprivileged ISA V20191213)
+    asm("fcvt.l.d %0, %1, dyn"
+        : "=r"(output)
+        : "f"(value));
+    return static_cast<double>(output);
 #elif ARCH(X86_64)
     double res;
     asm(
@@ -463,8 +488,12 @@ float rintf(float value)
     (void)value;
     TODO_AARCH64();
 #elif ARCH(RISCV64)
-    (void)value;
-    TODO_RISCV64();
+    i64 output;
+    // FIXME: This saturates at 64-bit integer boundaries; see Table 11.4 (RISC-V Unprivileged ISA V20191213)
+    asm("fcvt.l.s %0, %1, dyn"
+        : "=r"(output)
+        : "f"(value));
+    return static_cast<float>(output);
 #elif ARCH(X86_64)
     float res;
     asm(
@@ -503,8 +532,12 @@ long lrint(double value)
     (void)value;
     TODO_AARCH64();
 #elif ARCH(RISCV64)
-    (void)value;
-    TODO_RISCV64();
+    i64 output;
+    // FIXME: This saturates at 64-bit integer boundaries; see Table 11.4 (RISC-V Unprivileged ISA V20191213)
+    asm("fcvt.l.d %0, %1, dyn"
+        : "=r"(output)
+        : "f"(value));
+    return output;
 #elif ARCH(X86_64)
     long res;
     asm(
@@ -523,8 +556,12 @@ long lrintf(float value)
     (void)value;
     TODO_AARCH64();
 #elif ARCH(RISCV64)
-    (void)value;
-    TODO_RISCV64();
+    i64 output;
+    // FIXME: This saturates at 64-bit integer boundaries; see Table 11.4 (RISC-V Unprivileged ISA V20191213)
+    asm("fcvt.l.s %0, %1, dyn"
+        : "=r"(output)
+        : "f"(value));
+    return output;
 #elif ARCH(X86_64)
     long res;
     asm(
@@ -544,8 +581,8 @@ long long llrintl(long double value)
     (void)value;
     TODO_AARCH64();
 #elif ARCH(RISCV64)
-    (void)value;
-    TODO_RISCV64();
+    // NOTE: RISC-V LP64 specifies long long == long.
+    return static_cast<long long>(lrintl(value));
 #elif ARCH(X86_64)
     long long res;
     asm(
@@ -564,8 +601,8 @@ long long llrint(double value)
     (void)value;
     TODO_AARCH64();
 #elif ARCH(RISCV64)
-    (void)value;
-    TODO_RISCV64();
+    // NOTE: RISC-V LP64 specifies long long == long.
+    return static_cast<long long>(lrint(value));
 #elif ARCH(X86_64)
     long long res;
     asm(
@@ -584,8 +621,8 @@ long long llrintf(float value)
     (void)value;
     TODO_AARCH64();
 #elif ARCH(RISCV64)
-    (void)value;
-    TODO_RISCV64();
+    // NOTE: RISC-V LP64 specifies long long == long.
+    return static_cast<long long>(lrintf(value));
 #elif ARCH(X86_64)
     long long res;
     asm(
@@ -680,16 +717,34 @@ long double frexpl(long double x, int* exp) NOEXCEPT
     return scalbnl(x, -(*exp));
 }
 
-#if !(ARCH(X86_64))
-
-double round(double value) NOEXCEPT
+double round(double x) NOEXCEPT
 {
-    return internal_to_integer(value, RoundingMode::ToEven);
+#if ARCH(RISCV64)
+    if (fabs(x) < LONG_LONG_MAX) {
+        i64 output;
+        asm("fcvt.l.d %0, %1, rmm"
+            : "=r"(output)
+            : "f"(x));
+        return static_cast<double>(output);
+    }
+#endif
+
+    return internal_to_integer(x, RoundingMode::ToEven);
 }
 
-float roundf(float value) NOEXCEPT
+float roundf(float x) NOEXCEPT
 {
-    return internal_to_integer(value, RoundingMode::ToEven);
+#if ARCH(RISCV64)
+    if (fabsf(x) < LONG_LONG_MAX) {
+        i64 output;
+        asm("fcvt.l.s %0, %1, rmm"
+            : "=r"(output)
+            : "f"(x));
+        return static_cast<float>(output);
+    }
+#endif
+
+    return internal_to_integer(x, RoundingMode::ToEven);
 }
 
 long double roundl(long double value) NOEXCEPT
@@ -699,174 +754,163 @@ long double roundl(long double value) NOEXCEPT
 
 long lroundf(float value) NOEXCEPT
 {
-    return internal_to_integer(value, RoundingMode::ToEven);
-}
-
-long lround(double value) NOEXCEPT
-{
-    return internal_to_integer(value, RoundingMode::ToEven);
-}
-
-long lroundl(long double value) NOEXCEPT
-{
-    return internal_to_integer(value, RoundingMode::ToEven);
-}
-
-long long llroundf(float value) NOEXCEPT
-{
-    return internal_to_integer(value, RoundingMode::ToEven);
-}
-
-long long llround(double value) NOEXCEPT
-{
-    return internal_to_integer(value, RoundingMode::ToEven);
-}
-
-long long llroundd(long double value) NOEXCEPT
-{
-    return internal_to_integer(value, RoundingMode::ToEven);
-}
-
-float floorf(float value) NOEXCEPT
-{
-    return internal_to_integer(value, RoundingMode::Down);
-}
-
-double floor(double value) NOEXCEPT
-{
-    return internal_to_integer(value, RoundingMode::Down);
-}
-
-long double floorl(long double value) NOEXCEPT
-{
-    return internal_to_integer(value, RoundingMode::Down);
-}
-
-float ceilf(float value) NOEXCEPT
-{
-    return internal_to_integer(value, RoundingMode::Up);
-}
-
-double ceil(double value) NOEXCEPT
-{
-    return internal_to_integer(value, RoundingMode::Up);
-}
-
-long double ceill(long double value) NOEXCEPT
-{
-    return internal_to_integer(value, RoundingMode::Up);
-}
-
-#else
-
-double round(double x) NOEXCEPT
-{
-    // Note: This is break-tie-away-from-zero, so not the hw's understanding of
-    //       "nearest", which would be towards even.
-    if (x == 0.)
-        return x;
-    if (x > 0.)
-        return floor(x + .5);
-    return ceil(x - .5);
-}
-
-float roundf(float x) NOEXCEPT
-{
-    if (x == 0.f)
-        return x;
-    if (x > 0.f)
-        return floorf(x + .5f);
-    return ceilf(x - .5f);
-}
-
-long double roundl(long double x) NOEXCEPT
-{
-    if (x == 0.L)
-        return x;
-    if (x > 0.L)
-        return floorl(x + .5L);
-    return ceill(x - .5L);
-}
-
-long lroundf(float value) NOEXCEPT
-{
-    return static_cast<long>(roundf(value));
-}
-
-long lround(double value) NOEXCEPT
-{
-    return static_cast<long>(round(value));
-}
-
-long lroundl(long double value) NOEXCEPT
-{
-    return static_cast<long>(roundl(value));
-}
-
-long long llroundf(float value) NOEXCEPT
-{
-    return static_cast<long long>(roundf(value));
-}
-
-long long llround(double value) NOEXCEPT
-{
-    return static_cast<long long>(round(value));
-}
-
-long long llroundd(long double value) NOEXCEPT
-{
-    return static_cast<long long>(roundl(value));
-}
-
-float floorf(float value) NOEXCEPT
-{
-    AK::X87RoundingModeScope scope { AK::RoundingMode::DOWN };
-    asm("frndint"
-        : "+t"(value));
-    return value;
-}
-
-double floor(double value) NOEXCEPT
-{
-    AK::X87RoundingModeScope scope { AK::RoundingMode::DOWN };
-    asm("frndint"
-        : "+t"(value));
-    return value;
-}
-
-long double floorl(long double value) NOEXCEPT
-{
-    AK::X87RoundingModeScope scope { AK::RoundingMode::DOWN };
-    asm("frndint"
-        : "+t"(value));
-    return value;
-}
-
-float ceilf(float value) NOEXCEPT
-{
-    AK::X87RoundingModeScope scope { AK::RoundingMode::UP };
-    asm("frndint"
-        : "+t"(value));
-    return value;
-}
-
-double ceil(double value) NOEXCEPT
-{
-    AK::X87RoundingModeScope scope { AK::RoundingMode::UP };
-    asm("frndint"
-        : "+t"(value));
-    return value;
-}
-
-long double ceill(long double value) NOEXCEPT
-{
-    AK::X87RoundingModeScope scope { AK::RoundingMode::UP };
-    asm("frndint"
-        : "+t"(value));
-    return value;
-}
-
+#if ARCH(RISCV64)
+    i64 output;
+    asm("fcvt.l.s %0, %1, rmm"
+        : "=r"(output)
+        : "f"(value));
+    return output;
 #endif
+
+    return internal_to_integer(value, RoundingMode::ToEven);
+}
+
+long lround(double value) NOEXCEPT
+{
+#if ARCH(RISCV64)
+    i64 output;
+    asm("fcvt.l.d %0, %1, rmm"
+        : "=r"(output)
+        : "f"(value));
+    return output;
+#endif
+
+    return internal_to_integer(value, RoundingMode::ToEven);
+}
+
+long lroundl(long double value) NOEXCEPT
+{
+    return internal_to_integer(value, RoundingMode::ToEven);
+}
+
+long long llroundf(float value) NOEXCEPT
+{
+#if ARCH(RISCV64)
+    i64 output;
+    asm("fcvt.l.s %0, %1, rmm"
+        : "=r"(output)
+        : "f"(value));
+    return output;
+#endif
+
+    return internal_to_integer(value, RoundingMode::ToEven);
+}
+
+long long llround(double value) NOEXCEPT
+{
+#if ARCH(RISCV64)
+    i64 output;
+    asm("fcvt.l.d %0, %1, rmm"
+        : "=r"(output)
+        : "f"(value));
+    return output;
+#endif
+
+    return internal_to_integer(value, RoundingMode::ToEven);
+}
+
+long long llroundd(long double value) NOEXCEPT
+{
+    return internal_to_integer(value, RoundingMode::ToEven);
+}
+
+float floorf(float value) NOEXCEPT
+{
+#if ARCH(RISCV64)
+    if (fabsf(value) < LONG_LONG_MAX) {
+        i64 output;
+        asm("fcvt.l.s %0, %1, rdn"
+            : "=r"(output)
+            : "f"(value));
+        return static_cast<float>(output);
+    }
+#elif ARCH(X86_64)
+    AK::X87RoundingModeScope scope { AK::RoundingMode::DOWN };
+    asm("frndint"
+        : "+t"(value));
+    return value;
+#endif
+    return internal_to_integer(value, RoundingMode::Down);
+}
+
+double floor(double value) NOEXCEPT
+{
+#if ARCH(RISCV64)
+    if (fabs(value) < LONG_LONG_MAX) {
+        i64 output;
+        asm("fcvt.l.d %0, %1, rdn"
+            : "=r"(output)
+            : "f"(value));
+        return static_cast<double>(output);
+    }
+#elif ARCH(X86_64)
+    AK::X87RoundingModeScope scope { AK::RoundingMode::DOWN };
+    asm("frndint"
+        : "+t"(value));
+    return value;
+#endif
+    return internal_to_integer(value, RoundingMode::Down);
+}
+
+long double floorl(long double value) NOEXCEPT
+{
+#if ARCH(X86_64)
+    AK::X87RoundingModeScope scope { AK::RoundingMode::DOWN };
+    asm("frndint"
+        : "+t"(value));
+    return value;
+#endif
+    return internal_to_integer(value, RoundingMode::Down);
+}
+
+float ceilf(float value) NOEXCEPT
+{
+#if ARCH(RISCV64)
+    if (fabsf(value) < LONG_LONG_MAX) {
+        i64 output;
+        asm("fcvt.l.s %0, %1, rup"
+            : "=r"(output)
+            : "f"(value));
+        return static_cast<float>(output);
+    }
+#elif ARCH(X86_64)
+    AK::X87RoundingModeScope scope { AK::RoundingMode::UP };
+    asm("frndint"
+        : "+t"(value));
+    return value;
+#endif
+    return internal_to_integer(value, RoundingMode::Up);
+}
+
+double ceil(double value) NOEXCEPT
+{
+#if ARCH(RISCV64)
+    if (fabs(value) < LONG_LONG_MAX) {
+        i64 output;
+        asm("fcvt.l.d %0, %1, rup"
+            : "=r"(output)
+            : "f"(value));
+        return static_cast<double>(output);
+    }
+#elif ARCH(X86_64)
+    AK::X87RoundingModeScope scope { AK::RoundingMode::UP };
+    asm("frndint"
+        : "+t"(value));
+    return value;
+#endif
+    return internal_to_integer(value, RoundingMode::Up);
+}
+
+long double ceill(long double value) NOEXCEPT
+{
+#if ARCH(X86_64)
+    AK::X87RoundingModeScope scope { AK::RoundingMode::UP };
+    asm("frndint"
+        : "+t"(value));
+    return value;
+#endif
+    return internal_to_integer(value, RoundingMode::Up);
+}
 
 long double modfl(long double x, long double* intpart) NOEXCEPT
 {


### PR DESCRIPTION
Because the new tests failed on x86 extended floating point (a truly cursed float format), you're getting two x87 fixes for free!

### LibC: Start on fenv support for RISC-V

### LibC: Add some fenv tests

Turns out that fegetround() is broken on x87, so the corresponding test
assertions are commented out for now.

### AK: Use common ComponentType integer type for float bitfields

This allows us to easily use an appropriate integer type when performing
float bitfield operations.

This change also adds a comment about the technically-incorrect 80-bit
extended float mantissa field.

### LibC: Prevent undefined shift in internal_to_integer

New tests will hit a dead bit count of 64, leading to an undefined
shift.

### LibC: Add rounding specializations for RISC-V

Whenever the floating-point values are in integer range, we can use the
various FCVT functions with static rounding mode to perform fast
rounding. I took this opportunity to clean up the architecture
differentiation for these functions, which allows us to use the software
rounding implementation for all extreme and unimplemented cases,
including AArch64.

Also adds more round & trunc tests.

### LibC: Fix extended floating point software rounding

Contrary to IEEE formats, x86's 80-bit extended floats need the topmost
mantissa bit to be 1 or else a special kind of NaN is produced. We fix
this by reinserting the special bit if necessary.
