### PR TITLE
LibWeb: Stop adding extra whitespace when serializing CSS Functions

### DIFF
--- a/Tests/LibWeb/Text/expected/css/attr-serialization.txt
+++ b/Tests/LibWeb/Text/expected/css/attr-serialization.txt
@@ -1,0 +1,8 @@
+attr(foo)
+attr( foo )
+attr(foo, "fallback")
+attr( foo , "fallback" )
+attr(foo string)
+attr( foo string )
+attr(foo string, "fallback")
+attr( foo string , "fallback" )

--- a/Tests/LibWeb/Text/input/css/attr-serialization.html
+++ b/Tests/LibWeb/Text/input/css/attr-serialization.html
@@ -1,0 +1,22 @@
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        function serialize(input) {
+            document.body.style.content = input;
+            println(document.body.style.content);
+        }
+
+        serialize('attr(foo)');
+        // FIXME: This should produce `attr(foo)` but doesn't yet.
+        serialize('attr(    foo    )');
+        serialize('attr(foo, "fallback")');
+        // FIXME: This should produce `attr(foo, "fallback")` but doesn't yet.
+        serialize('attr(   foo   ,    "fallback"   )');
+        serialize('attr(foo string)');
+        // FIXME: This should produce `attr(foo string)` but doesn't yet.
+        serialize('attr(  foo   string  )');
+        serialize('attr(foo string, "fallback")');
+        // FIXME: This should produce `attr(foo string, "fallback")` but doesn't yet.
+        serialize('attr(  foo   string  ,   "fallback"  )');
+    });
+</script>

--- a/Userland/Libraries/LibWeb/CSS/Parser/Function.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Function.cpp
@@ -24,7 +24,8 @@ String Function::to_string() const
 
     serialize_an_identifier(builder, m_name);
     builder.append('(');
-    builder.join(' ', m_values);
+    for (auto& item : m_values)
+        builder.append(item.to_string());
     builder.append(')');
 
     return MUST(builder.to_string());


### PR DESCRIPTION
Otherwise `attr(|name, "fallback")` becomes `attr(| name ,  "fallback")`

This makes exactly one more test on https://goose.icu/attr pass.