### PR TITLE
GameOfLife: Allow ctrl+click to place multiple patterns

### DIFF
--- a/Userland/Games/GameOfLife/BoardWidget.cpp
+++ b/Userland/Games/GameOfLife/BoardWidget.cpp
@@ -78,6 +78,12 @@ void BoardWidget::set_running(bool running)
     if (running == m_running)
         return;
 
+    if (m_selected_pattern) {
+        m_selected_pattern = nullptr;
+        if (on_pattern_selection_state_change)
+            on_pattern_selection_state_change();
+    }
+
     m_running = running;
 
     if (m_running) {

--- a/Userland/Games/GameOfLife/BoardWidget.cpp
+++ b/Userland/Games/GameOfLife/BoardWidget.cpp
@@ -196,6 +196,7 @@ void BoardWidget::paint_event(GUI::PaintEvent& event)
 void BoardWidget::mousedown_event(GUI::MouseEvent& event)
 {
     if (event.button() == GUI::MouseButton::Primary) {
+        m_dragging_enabled = (m_selected_pattern == nullptr);
         set_toggling_cells(true);
         auto row_and_column = get_row_and_column_for_point(event.x(), event.y());
         if (!row_and_column.has_value())
@@ -239,7 +240,7 @@ void BoardWidget::mousemove_event(GUI::MouseEvent& event)
     if (!row_and_column.has_value())
         return;
     auto [row, column] = row_and_column.value();
-    if (m_toggling_cells) {
+    if (m_toggling_cells && m_dragging_enabled) {
         if (m_last_cell_toggled.row != row || m_last_cell_toggled.column != column)
             toggle_cell(row, column);
     }
@@ -253,6 +254,7 @@ void BoardWidget::mousemove_event(GUI::MouseEvent& event)
 void BoardWidget::mouseup_event(GUI::MouseEvent&)
 {
     set_toggling_cells(false);
+    m_dragging_enabled = true;
 }
 
 Optional<Board::RowAndColumn> BoardWidget::get_row_and_column_for_point(int x, int y) const

--- a/Userland/Games/GameOfLife/BoardWidget.cpp
+++ b/Userland/Games/GameOfLife/BoardWidget.cpp
@@ -195,10 +195,20 @@ void BoardWidget::mousedown_event(GUI::MouseEvent& event)
         if (!row_and_column.has_value())
             return;
         auto [row, column] = row_and_column.value();
-        if (m_selected_pattern == nullptr)
-            toggle_cell(row, column);
-        else
+
+        if (m_selected_pattern) {
             place_pattern(row, column);
+            if (!event.ctrl()) {
+                m_selected_pattern = nullptr;
+                if (on_pattern_selection_state_change)
+                    on_pattern_selection_state_change();
+
+                if (m_pattern_preview_timer->is_active())
+                    m_pattern_preview_timer->stop();
+            }
+        } else {
+            toggle_cell(row, column);
+        }
     }
 }
 
@@ -267,11 +277,6 @@ void BoardWidget::place_pattern(size_t row, size_t column)
         }
         y_offset++;
     }
-    m_selected_pattern = nullptr;
-    if (on_pattern_selection_state_change)
-        on_pattern_selection_state_change();
-    if (m_pattern_preview_timer->is_active())
-        m_pattern_preview_timer->stop();
 }
 
 void BoardWidget::setup_patterns()

--- a/Userland/Games/GameOfLife/BoardWidget.h
+++ b/Userland/Games/GameOfLife/BoardWidget.h
@@ -84,6 +84,7 @@ private:
     NonnullOwnPtr<Board> m_board;
 
     bool m_running { false };
+    bool m_dragging_enabled { true };
 
     int m_running_timer_interval { 500 };
     int m_running_pattern_preview_timer_interval { 100 };

--- a/Userland/Games/GameOfLife/main.cpp
+++ b/Userland/Games/GameOfLife/main.cpp
@@ -71,7 +71,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     statusbar.segment(1).set_fixed_width(ceil(width));
 
     auto show_statusbar_hint = [&]() {
-        auto tip = board_widget->selected_pattern() ? pattern_place_tip : toggle_cells_tip;
+        auto tip = board_widget.selected_pattern() ? pattern_place_tip : toggle_cells_tip;
         statusbar.segment(0).set_text(tip);
     };
     show_statusbar_hint();


### PR DESCRIPTION
This PR makes the following changes to pattern placement in `GameOfLife`:

* Holding Ctrl when placing a pattern allows that same pattern to be placed again, previously the pattern had to be selected again. A hint has also been added to the status bar describing this feature, when a pattern is selected.
* When the game starts running, the selected pattern is now cleared
* Dragging the mouse to toggle cells is now disabled when a pattern is selected. It was previously very easy to inadvertently toggle cells when placing patterns.

Demo:

https://github.com/SerenityOS/serenity/assets/2817754/60486364-9947-4beb-898c-c48ea09d7f42

