### PR TITLE
LibWeb/MimeSniff: Implement the rest of the MIME type checks

### DIFF
--- a/Userland/Libraries/LibWeb/MimeSniff/MimeType.cpp
+++ b/Userland/Libraries/LibWeb/MimeSniff/MimeType.cpp
@@ -252,6 +252,30 @@ bool MimeType::is_audio_or_video() const
     return type().is_one_of("audio"sv, "video"sv) || essence() == "application/ogg"sv;
 }
 
+// https://mimesniff.spec.whatwg.org/#font-mime-type
+bool MimeType::is_font() const
+{
+    // A font MIME type is any MIME type whose type is "font", or whose essence is one of the following:
+    //    - application/font-cff
+    //    - application/font-off
+    //    - application/font-sfnt
+    //    - application/font-ttf
+    //    - application/font-woff
+    //    - application/vnd.ms-fontobject
+    //    - application/vnd.ms-opentype
+    if (type() == "font"sv)
+        return true;
+
+    return essence().is_one_of(
+        "application/font-cff"sv,
+        "application/font-off"sv,
+        "application/font-sfnt"sv,
+        "application/font-ttf"sv,
+        "application/font-woff"sv,
+        "application/vnd.ms-fontobject"sv,
+        "application/vnd.ms-opentype"sv);
+}
+
 // https://mimesniff.spec.whatwg.org/#xml-mime-type
 bool MimeType::is_xml() const
 {

--- a/Userland/Libraries/LibWeb/MimeSniff/MimeType.cpp
+++ b/Userland/Libraries/LibWeb/MimeSniff/MimeType.cpp
@@ -276,6 +276,14 @@ bool MimeType::is_font() const
         "application/vnd.ms-opentype"sv);
 }
 
+// https://mimesniff.spec.whatwg.org/#zip-based-mime-type
+bool MimeType::is_zip_based() const
+{
+    // A ZIP-based MIME type is any MIME type whose subtype ends in "+zip" or whose essence is one of the following:
+    //    - application/zip
+    return subtype().ends_with_bytes("+zip"sv) || essence().is_one_of("application/zip"sv);
+}
+
 // https://mimesniff.spec.whatwg.org/#xml-mime-type
 bool MimeType::is_xml() const
 {

--- a/Userland/Libraries/LibWeb/MimeSniff/MimeType.cpp
+++ b/Userland/Libraries/LibWeb/MimeSniff/MimeType.cpp
@@ -284,6 +284,16 @@ bool MimeType::is_zip_based() const
     return subtype().ends_with_bytes("+zip"sv) || essence().is_one_of("application/zip"sv);
 }
 
+// https://mimesniff.spec.whatwg.org/#archive-mime-type
+bool MimeType::is_archive() const
+{
+    // An archive MIME type is any MIME type whose essence is one of the following:
+    //    - application/x-rar-compressed
+    //    - application/zip
+    //    - application/x-gzip
+    return essence().is_one_of("application/x-rar-compressed"sv, "application/zip"sv, "application/x-gzip"sv);
+}
+
 // https://mimesniff.spec.whatwg.org/#xml-mime-type
 bool MimeType::is_xml() const
 {

--- a/Userland/Libraries/LibWeb/MimeSniff/MimeType.cpp
+++ b/Userland/Libraries/LibWeb/MimeSniff/MimeType.cpp
@@ -335,4 +335,11 @@ bool MimeType::is_javascript() const
         "text/x-javascript"sv);
 }
 
+// https://mimesniff.spec.whatwg.org/#json-mime-type
+bool MimeType::is_json() const
+{
+    // A JSON MIME type is any MIME type whose subtype ends in "+json" or whose essence is "application/json" or "text/json".
+    return subtype().ends_with_bytes("+json"sv) || essence().is_one_of("application/json"sv, "text/json"sv);
+}
+
 }

--- a/Userland/Libraries/LibWeb/MimeSniff/MimeType.cpp
+++ b/Userland/Libraries/LibWeb/MimeSniff/MimeType.cpp
@@ -245,6 +245,13 @@ bool MimeType::is_image() const
     return type() == "image"sv;
 }
 
+// https://mimesniff.spec.whatwg.org/#audio-or-video-mime-type
+bool MimeType::is_audio_or_video() const
+{
+    // An audio or video MIME type is any MIME type whose type is "audio" or "video", or whose essence is "application/ogg".
+    return type().is_one_of("audio"sv, "video"sv) || essence() == "application/ogg"sv;
+}
+
 // https://mimesniff.spec.whatwg.org/#xml-mime-type
 bool MimeType::is_xml() const
 {

--- a/Userland/Libraries/LibWeb/MimeSniff/MimeType.cpp
+++ b/Userland/Libraries/LibWeb/MimeSniff/MimeType.cpp
@@ -306,6 +306,13 @@ bool MimeType::is_html() const
     return essence().is_one_of("text/html"sv);
 }
 
+// https://mimesniff.spec.whatwg.org/#scriptable-mime-type
+bool MimeType::is_scriptable() const
+{
+    // A scriptable MIME type is an XML MIME type, HTML MIME type, or any MIME type whose essence is "application/pdf".
+    return is_xml() || is_html() || essence() == "application/pdf"sv;
+}
+
 // https://mimesniff.spec.whatwg.org/#javascript-mime-type
 bool MimeType::is_javascript() const
 {

--- a/Userland/Libraries/LibWeb/MimeSniff/MimeType.cpp
+++ b/Userland/Libraries/LibWeb/MimeSniff/MimeType.cpp
@@ -238,6 +238,13 @@ ErrorOr<void> MimeType::set_parameter(String name, String value)
     return {};
 }
 
+// https://mimesniff.spec.whatwg.org/#image-mime-type
+bool MimeType::is_image() const
+{
+    // An image MIME type is a MIME type whose type is "image".
+    return type() == "image"sv;
+}
+
 // https://mimesniff.spec.whatwg.org/#xml-mime-type
 bool MimeType::is_xml() const
 {

--- a/Userland/Libraries/LibWeb/MimeSniff/MimeType.h
+++ b/Userland/Libraries/LibWeb/MimeSniff/MimeType.h
@@ -29,6 +29,7 @@ public:
     bool is_image() const;
     bool is_audio_or_video() const;
     bool is_font() const;
+    bool is_zip_based() const;
     bool is_xml() const;
     bool is_html() const;
     bool is_javascript() const;

--- a/Userland/Libraries/LibWeb/MimeSniff/MimeType.h
+++ b/Userland/Libraries/LibWeb/MimeSniff/MimeType.h
@@ -27,6 +27,7 @@ public:
     OrderedHashMap<String, String> const& parameters() const { return m_parameters; }
 
     bool is_image() const;
+    bool is_audio_or_video() const;
     bool is_xml() const;
     bool is_html() const;
     bool is_javascript() const;

--- a/Userland/Libraries/LibWeb/MimeSniff/MimeType.h
+++ b/Userland/Libraries/LibWeb/MimeSniff/MimeType.h
@@ -35,6 +35,7 @@ public:
     bool is_html() const;
     bool is_scriptable() const;
     bool is_javascript() const;
+    bool is_json() const;
 
     ErrorOr<void> set_parameter(String name, String value);
 

--- a/Userland/Libraries/LibWeb/MimeSniff/MimeType.h
+++ b/Userland/Libraries/LibWeb/MimeSniff/MimeType.h
@@ -28,6 +28,7 @@ public:
 
     bool is_image() const;
     bool is_audio_or_video() const;
+    bool is_font() const;
     bool is_xml() const;
     bool is_html() const;
     bool is_javascript() const;

--- a/Userland/Libraries/LibWeb/MimeSniff/MimeType.h
+++ b/Userland/Libraries/LibWeb/MimeSniff/MimeType.h
@@ -30,6 +30,7 @@ public:
     bool is_audio_or_video() const;
     bool is_font() const;
     bool is_zip_based() const;
+    bool is_archive() const;
     bool is_xml() const;
     bool is_html() const;
     bool is_javascript() const;

--- a/Userland/Libraries/LibWeb/MimeSniff/MimeType.h
+++ b/Userland/Libraries/LibWeb/MimeSniff/MimeType.h
@@ -33,6 +33,7 @@ public:
     bool is_archive() const;
     bool is_xml() const;
     bool is_html() const;
+    bool is_scriptable() const;
     bool is_javascript() const;
 
     ErrorOr<void> set_parameter(String name, String value);

--- a/Userland/Libraries/LibWeb/MimeSniff/MimeType.h
+++ b/Userland/Libraries/LibWeb/MimeSniff/MimeType.h
@@ -26,6 +26,7 @@ public:
     String const& subtype() const { return m_subtype; }
     OrderedHashMap<String, String> const& parameters() const { return m_parameters; }
 
+    bool is_image() const;
     bool is_xml() const;
     bool is_html() const;
     bool is_javascript() const;


### PR DESCRIPTION
Should implement all the missing MIME type check algorithms from the [MIME type groups section](https://mimesniff.spec.whatwg.org/#mime-type-groups).

I tried to have the implementation mimic the wording I found in the spec, so you will see a both `String::is_one_of()` and `==` used when comparing a single MIME type essence.