### PR TITLE
Ladybird/AppKit: Fix scrolling issues caused in #21124

### DIFF
--- a/Ladybird/AppKit/UI/ConsoleController.mm
+++ b/Ladybird/AppKit/UI/ConsoleController.mm
@@ -60,4 +60,9 @@
     }
 }
 
+- (void)windowDidChangeBackingProperties:(NSNotification*)notification
+{
+    [[[self console] web_view] handleDevicePixelRatioChange];
+}
+
 @end

--- a/Ladybird/AppKit/UI/LadybirdWebView.h
+++ b/Ladybird/AppKit/UI/LadybirdWebView.h
@@ -47,6 +47,7 @@
 - (String const&)handle;
 
 - (void)handleResize;
+- (void)handleDevicePixelRatioChange;
 - (void)handleScroll;
 - (void)handleVisibility:(BOOL)is_visible;
 

--- a/Ladybird/AppKit/UI/LadybirdWebView.mm
+++ b/Ladybird/AppKit/UI/LadybirdWebView.mm
@@ -87,6 +87,7 @@ struct HideCursor {
             screen_rects.unchecked_append(screen_rect);
         }
 
+        // This returns device pixel ratio of the screen the window is opened in
         auto device_pixel_ratio = [[NSScreen mainScreen] backingScaleFactor];
 
         m_web_view_bridge = MUST(Ladybird::WebViewBridge::create(move(screen_rects), device_pixel_ratio, [delegate webdriverContentIPCPath], [delegate preferredColorScheme]));
@@ -126,6 +127,13 @@ struct HideCursor {
 
 - (void)handleResize
 {
+    [self updateViewportRect:Ladybird::WebViewBridge::ForResize::Yes];
+    [self updateStatusLabelPosition];
+}
+
+- (void)handleDevicePixelRatioChange
+{
+    m_web_view_bridge->set_device_pixel_ratio([[self window] backingScaleFactor]);
     [self updateViewportRect:Ladybird::WebViewBridge::ForResize::Yes];
     [self updateStatusLabelPosition];
 }

--- a/Ladybird/AppKit/UI/LadybirdWebViewBridge.cpp
+++ b/Ladybird/AppKit/UI/LadybirdWebViewBridge.cpp
@@ -34,7 +34,6 @@ WebViewBridge::WebViewBridge(Vector<Gfx::IntRect> screen_rects, float device_pix
     , m_preferred_color_scheme(preferred_color_scheme)
 {
     m_device_pixel_ratio = device_pixel_ratio;
-    m_inverse_device_pixel_ratio = 1.0 / device_pixel_ratio;
 
     create_client(WebView::EnableCallgrindProfiling::No);
 
@@ -69,6 +68,12 @@ WebViewBridge::WebViewBridge(Vector<Gfx::IntRect> screen_rects, float device_pix
 }
 
 WebViewBridge::~WebViewBridge() = default;
+
+void WebViewBridge::set_device_pixel_ratio(float device_pixel_ratio)
+{
+    m_device_pixel_ratio = device_pixel_ratio;
+    client().async_set_device_pixels_per_css_pixel(device_pixel_ratio);
+}
 
 void WebViewBridge::set_system_visibility_state(bool is_visible)
 {
@@ -169,7 +174,7 @@ Gfx::IntPoint WebViewBridge::to_content_position(Gfx::IntPoint widget_position) 
 
 Gfx::IntPoint WebViewBridge::to_widget_position(Gfx::IntPoint content_position) const
 {
-    return scale_for_device(content_position, m_inverse_device_pixel_ratio);
+    return scale_for_device(content_position, inverse_device_pixel_ratio());
 }
 
 void WebViewBridge::create_client(WebView::EnableCallgrindProfiling enable_callgrind_profiling)

--- a/Ladybird/AppKit/UI/LadybirdWebViewBridge.cpp
+++ b/Ladybird/AppKit/UI/LadybirdWebViewBridge.cpp
@@ -38,9 +38,7 @@ WebViewBridge::WebViewBridge(Vector<Gfx::IntRect> screen_rects, float device_pix
     create_client(WebView::EnableCallgrindProfiling::No);
 
     on_scroll_by_delta = [this](auto x_delta, auto y_delta) {
-        // FIXME: This currently isn't reached because we do not yet propagate mouse wheel events to WebContent.
-        //        When that is implemented, make sure our mutations to the viewport position here are correct.
-        auto position = m_viewport_rect.location();
+        auto position = to_widget_position(m_viewport_rect.location());
         position.set_x(position.x() + x_delta);
         position.set_y(position.y() + y_delta);
 

--- a/Ladybird/AppKit/UI/LadybirdWebViewBridge.h
+++ b/Ladybird/AppKit/UI/LadybirdWebViewBridge.h
@@ -26,7 +26,8 @@ public:
     virtual ~WebViewBridge() override;
 
     float device_pixel_ratio() const { return m_device_pixel_ratio; }
-    float inverse_device_pixel_ratio() const { return m_inverse_device_pixel_ratio; }
+    void set_device_pixel_ratio(float device_pixel_ratio);
+    float inverse_device_pixel_ratio() const { return 1.0f / m_device_pixel_ratio; }
 
     void set_system_visibility_state(bool is_visible);
 
@@ -66,8 +67,6 @@ private:
 
     Vector<Gfx::IntRect> m_screen_rects;
     Gfx::IntRect m_viewport_rect;
-
-    float m_inverse_device_pixel_ratio { 1.0 };
 
     Optional<StringView> m_webdriver_content_ipc_path;
     Web::CSS::PreferredColorScheme m_preferred_color_scheme { Web::CSS::PreferredColorScheme::Auto };

--- a/Ladybird/AppKit/UI/TabController.mm
+++ b/Ladybird/AppKit/UI/TabController.mm
@@ -472,6 +472,11 @@ enum class IsHistoryNavigation {
     }
 }
 
+- (void)windowDidChangeBackingProperties:(NSNotification*)notification
+{
+    [[[self tab] web_view] handleDevicePixelRatioChange];
+}
+
 - (BOOL)validateMenuItem:(NSMenuItem*)item
 {
     if ([item action] == @selector(toggleLineBoxBorders:)) {


### PR DESCRIPTION
It was a pain but I found the bugs:
- First the AppKit chrome didn't listen for dpi changes so if you opend the browser in a low dpi screen and moved it to a high dpi screen the `device_pixel_ratio` was in correct
- `m_viewport_rect` contains real pixels so that needs to be converted to device pixels when adding the scroll delta in `on_scroll_by_delta`. There was a fixme about it, that I forgot to see last time 😳