### PR TITLE
WindowServer+shot: Add the `-w` option to take a screenshot of a window

### DIFF
--- a/Base/usr/share/man/man1/shot.md
+++ b/Base/usr/share/man/man1/shot.md
@@ -5,7 +5,7 @@ shot
 ## Synopsis
 
 ```sh
-$ shot [--clipboard] [--delay seconds] [--screen index] [--region] [--edit] [output]
+$ shot [--clipboard] [--delay seconds] [--screen index] [--region] [--edit] [--window] [output]
 ```
 
 ## Options
@@ -15,6 +15,7 @@ $ shot [--clipboard] [--delay seconds] [--screen index] [--region] [--edit] [out
 * `-s index`, `--screen index`: The index of the screen (default: -1 for all screens)
 * `-r`, `--region`: Select a region to capture
 * `-e`, `--edit`: Open in PixelPaint
+* `-w`, `--window`: Select a window to capture
 
 ## Arguments
 

--- a/Userland/Services/WindowServer/ConnectionFromClient.h
+++ b/Userland/Services/WindowServer/ConnectionFromClient.h
@@ -93,6 +93,8 @@ private:
     void set_unresponsive(bool);
     void destroy_window(Window&, Vector<i32>& destroyed_window_ids);
 
+    static Gfx::ShareableBitmap get_bitmap(Gfx::IntRect const& rect, Optional<u32> const& screen_index);
+
     virtual void create_menu(i32, String const&) override;
     virtual void set_menu_name(i32, String const&) override;
     virtual void destroy_menu(i32) override;
@@ -177,6 +179,8 @@ private:
     virtual Messages::WindowServer::GetScreenBitmapResponse get_screen_bitmap(Optional<Gfx::IntRect> const&, Optional<u32> const&) override;
     virtual Messages::WindowServer::GetScreenBitmapAroundCursorResponse get_screen_bitmap_around_cursor(Gfx::IntSize) override;
     virtual Messages::WindowServer::GetScreenBitmapAroundLocationResponse get_screen_bitmap_around_location(Gfx::IntSize, Gfx::IntPoint) override;
+    virtual Messages::WindowServer::GetTopmostWindowIdResponse get_topmost_window_id(Gfx::IntPoint) override;
+    virtual Messages::WindowServer::GetWindowBitmapResponse get_window_bitmap(i32, Optional<u32> const&) override;
     virtual void set_double_click_speed(i32) override;
     virtual Messages::WindowServer::GetDoubleClickSpeedResponse get_double_click_speed() override;
     virtual void set_mouse_buttons_switched(bool) override;

--- a/Userland/Services/WindowServer/WindowServer.ipc
+++ b/Userland/Services/WindowServer/WindowServer.ipc
@@ -173,6 +173,9 @@ endpoint WindowServer
     get_screen_bitmap_around_cursor(Gfx::IntSize size) => (Gfx::ShareableBitmap bitmap)
     get_screen_bitmap_around_location(Gfx::IntSize size, Gfx::IntPoint location) => (Gfx::ShareableBitmap bitmap)
     get_color_under_cursor() => (Optional<Gfx::Color> color)
+    
+    get_topmost_window_id(Gfx::IntPoint location) => (i32 window_id)
+    get_window_bitmap(i32 window_id, Optional<u32> screen_index) => (Gfx::ShareableBitmap bitmap)
 
     pong() =|
 


### PR DESCRIPTION
This PR adds the `-w` option to the `shot` utility, which allows the user to capture a screenshot of a window.

In order to achieve this 2 new IPC calls have been added to `WindowServer`:

* `get_topmost_window_id()` - returns the ID of the foreground window at a given location.
* `get_window_bitmap()` - returns a bitmap of the window with the specified ID. An optional screen index may be given to crop the bitmap to a particular screen.

If the `--delay` option is used, the returned bitmap will show the window at the point the delay ended. An error is returned if the window is closed between the time the delay starts and the screenshot is taken.

If the `--screen` option is used, the returned bitmap will be cropped to the specified screen. An error is returned if the selected window does not intersect the specified screen.

Known issues (these are existing issues in `shot`):
* While the selected window may span multiple screens, the initial point selected must be on Screen 0. This is because the overlay that `shot` generates only covers that screen.
* Scale factors other than 1x do not work.
* I couldn't find an easy way to hide the cursor in the returned image.

Demo:

https://github.com/SerenityOS/serenity/assets/2817754/0ced6ac4-97ae-4f64-a80a-1b0cf440bf59

Multi-screen demo:

https://github.com/SerenityOS/serenity/assets/2817754/05411992-7165-4f91-aa71-7cade8df5819