### PR TITLE
Shell: Make configure parse in POSIX mode

### DIFF
--- a/Userland/Shell/Builtin.cpp
+++ b/Userland/Shell/Builtin.cpp
@@ -258,7 +258,7 @@ ErrorOr<int> Shell::builtin_continue(Main::Arguments arguments)
     if (!parser.parse(arguments, Core::ArgsParser::FailureBehavior::PrintUsage))
         return 1;
 
-    if (count != 0) {
+    if (count != 1) {
         raise_error(ShellError::EvaluatedSyntaxError, "continue: count must be equal to 1 (NYI)");
         return 1;
     }

--- a/Userland/Shell/PosixLexer.h
+++ b/Userland/Shell/PosixLexer.h
@@ -197,6 +197,7 @@ struct State {
     StringBuilder buffer {};
     Reduction previous_reduction { Reduction::Start };
     bool escaping { false };
+    bool in_skip_mode { false };
     AST::Position position {
         .start_offset = 0,
         .end_offset = 0,
@@ -320,6 +321,14 @@ struct Token {
             return Token::Type::Less;
         if (name == "\n"sv)
             return Token::Type::Newline;
+        if (name == "("sv)
+            return Token::Type::OpenParen;
+        if (name == "{"sv)
+            return Token::Type::OpenBrace;
+        if (name == ")"sv)
+            return Token::Type::CloseParen;
+        if (name == "}"sv)
+            return Token::Type::CloseBrace;
 
         return {};
     }
@@ -431,6 +440,7 @@ private:
         explicit SkipTokens(Lexer& lexer)
             : m_state_change(lexer.m_state, lexer.m_state)
         {
+            lexer.m_state.in_skip_mode = true;
         }
 
         TemporaryChange<State> m_state_change;

--- a/Userland/Shell/PosixParser.cpp
+++ b/Userland/Shell/PosixParser.cpp
@@ -2073,7 +2073,16 @@ ErrorOr<RefPtr<AST::Node>> Parser::parse_io_file(AST::Position start_position, O
 
     auto io_operator_token = consume();
 
-    auto word = TRY(parse_word());
+    RefPtr<AST::Node> word;
+    if (peek().type == Token::Type::IoNumber) {
+        auto token = consume();
+        word = make_ref_counted<AST::BarewordLiteral>(
+            token.position.value_or(empty_position()),
+            token.value);
+    } else {
+        word = TRY(parse_word());
+    }
+
     if (!word) {
         m_token_index = start_index;
         return nullptr;

--- a/Userland/Shell/PosixParser.cpp
+++ b/Userland/Shell/PosixParser.cpp
@@ -188,7 +188,7 @@ void Parser::handle_heredoc_contents()
 
 ErrorOr<Optional<Token>> Parser::next_expanded_token(Optional<Reduction> starting_reduction)
 {
-    while (m_token_buffer.find_if([](auto& token) { return token.type == Token::Type::Eof; }).is_end()) {
+    while (m_token_buffer.is_empty() || m_token_buffer.last().type != Token::Type::Eof) {
         auto tokens = TRY(m_lexer.batch_next(starting_reduction));
         auto expanded = perform_expansions(move(tokens));
         m_token_buffer.extend(expanded);
@@ -1749,7 +1749,8 @@ ErrorOr<RefPtr<AST::Node>> Parser::parse_word()
             case '\'':
                 if (in_quote == Quote::Single) {
                     in_quote = Quote::None;
-                    TRY(append_string_literal(string.substring_view(*run_start, i - *run_start)));
+                    if (run_start.has_value())
+                        TRY(append_string_literal(string.substring_view(*run_start, i - *run_start)));
                     run_start = i + 1;
                     continue;
                 }

--- a/Userland/Shell/Shell.h
+++ b/Userland/Shell/Shell.h
@@ -32,6 +32,7 @@
     __ENUMERATE_SHELL_BUILTIN(pwd, InAllModes)               \
     __ENUMERATE_SHELL_BUILTIN(type, InAllModes)              \
     __ENUMERATE_SHELL_BUILTIN(exec, InAllModes)              \
+    __ENUMERATE_SHELL_BUILTIN(eval, OnlyInPOSIXMode)         \
     __ENUMERATE_SHELL_BUILTIN(exit, InAllModes)              \
     __ENUMERATE_SHELL_BUILTIN(export, InAllModes)            \
     __ENUMERATE_SHELL_BUILTIN(glob, InAllModes)              \


### PR DESCRIPTION
Just a bunch of misc work, the Shell can now parse configure scripts - but running it no worky yet:
```
❯ $SHELL --posix configure
Parameter expansion range 17-9 is out of bounds for '$as_unset'
Parameter expansion range 10-9 is out of bounds for '$as_unset'
Parameter expansion range 78- is out of bounds for '`(set) 2>&1 |
               sed -n 's/^ac_env_([a-zA-Z_0-9]*)_set=.*/1/p'`'
Parameter expansion range 84- is out of bounds for '`echo "testingc" 2>/dev/null; echo 1,2,3`,`echo -n testing 2>/dev/null; echo 1,2,3`'
Parameter expansion range 35-14 is out of bounds for '$ac_config_sub'
Parameter expansion range 29- is out of bounds for '`echo "$0" |sed 's,.*[/],,'`'
$as_unset: Command not found.
$as_unset: Command not found.
turingcomplete-MkII
Shell: Job 3 (uname -n) exited

Shell: No command given to exec
configure: error: missing argument to --
```