### PR TITLE
LibWeb: Port Attr interface from DeprecatedString to String

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -3689,7 +3689,7 @@ JS::ThrowCompletionOr<JS::NonnullGCPtr<JS::Object>> @constructor_class@::constru
         // 3. Set element's namespace to the HTML namespace.
         // 4. Set element's namespace prefix to null.
         // 5. Set element's local name to definition's local name.
-        auto element = realm.heap().allocate<@fully_qualified_name@>(realm, window.associated_document(), DOM::QualifiedName { definition->local_name().to_deprecated_string(), {}, Namespace::HTML });
+        auto element = realm.heap().allocate<@fully_qualified_name@>(realm, window.associated_document(), DOM::QualifiedName { definition->local_name(), {}, Namespace::HTML });
 
         // https://webidl.spec.whatwg.org/#internally-create-a-new-object-implementing-the-interface
         // Important steps from "internally create a new object implementing the interface"

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -277,7 +277,7 @@ StyleComputer::RuleCache const& StyleComputer::rule_cache_for_cascade_origin(Cas
 {
     // FIXME: Filter out non-default namespace using prefixes
     auto namespace_uri = rule.sheet->default_namespace();
-    if (namespace_uri.has_value() && namespace_uri.value() != element.namespace_uri()) {
+    if (namespace_uri.has_value() && namespace_uri.value() != element.namespace_()) {
         return false;
     }
     return true;

--- a/Userland/Libraries/LibWeb/DOM/Attr.h
+++ b/Userland/Libraries/LibWeb/DOM/Attr.h
@@ -18,22 +18,22 @@ class Attr final : public Node {
     WEB_PLATFORM_OBJECT(Attr, Node);
 
 public:
-    [[nodiscard]] static JS::NonnullGCPtr<Attr> create(Document&, QualifiedName, DeprecatedString value = "", Element* = nullptr);
-    [[nodiscard]] static JS::NonnullGCPtr<Attr> create(Document&, DeprecatedFlyString local_name, DeprecatedString value = "", Element* = nullptr);
+    [[nodiscard]] static JS::NonnullGCPtr<Attr> create(Document&, QualifiedName, String value = {}, Element* = nullptr);
+    [[nodiscard]] static JS::NonnullGCPtr<Attr> create(Document&, FlyString local_name, String value = {}, Element* = nullptr);
     JS::NonnullGCPtr<Attr> clone(Document&);
 
     virtual ~Attr() override = default;
 
-    virtual FlyString node_name() const override { return MUST(FlyString::from_deprecated_fly_string(name())); }
+    virtual FlyString node_name() const override { return name(); }
 
-    DeprecatedFlyString const& namespace_uri() const { return m_qualified_name.namespace_(); }
-    DeprecatedFlyString const& prefix() const { return m_qualified_name.prefix(); }
-    DeprecatedFlyString const& local_name() const { return m_qualified_name.local_name(); }
-    DeprecatedFlyString const& name() const { return m_qualified_name.as_string(); }
+    Optional<FlyString> const& namespace_uri() const { return m_qualified_name.namespace_(); }
+    Optional<FlyString> const& prefix() const { return m_qualified_name.prefix(); }
+    FlyString const& local_name() const { return m_qualified_name.local_name(); }
+    FlyString const& name() const { return m_qualified_name.as_string(); }
 
-    DeprecatedString const& value() const { return m_value; }
-    void set_value(DeprecatedString value);
-    void change_attribute(DeprecatedString value);
+    String const& value() const { return m_value; }
+    void set_value(String value);
+    void change_attribute(String value);
 
     Element* owner_element();
     Element const* owner_element() const;
@@ -45,13 +45,13 @@ public:
     void handle_attribute_changes(Element&, DeprecatedString const& old_value, DeprecatedString const& new_value);
 
 private:
-    Attr(Document&, QualifiedName, DeprecatedString value, Element*);
+    Attr(Document&, QualifiedName, String value, Element*);
 
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
 
     QualifiedName m_qualified_name;
-    DeprecatedString m_value;
+    String m_value;
     JS::GCPtr<Element> m_owner_element;
 };
 

--- a/Userland/Libraries/LibWeb/DOM/Attr.idl
+++ b/Userland/Libraries/LibWeb/DOM/Attr.idl
@@ -1,7 +1,7 @@
 #import <DOM/Node.idl>
 #import <DOM/Element.idl>
 
-[Exposed=Window, UseDeprecatedAKString]
+[Exposed=Window]
 interface Attr : Node {
     readonly attribute DOMString? namespaceURI;
     readonly attribute DOMString? prefix;

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -1387,7 +1387,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Element>> Document::create_element_ns(Optio
     }
 
     // 4. Return the result of creating an element given document, localName, namespace, prefix, is, and with the synchronous custom elements flag set.
-    return TRY(DOM::create_element(*this, extracted_qualified_name.local_name(), extracted_qualified_name.namespace_(), extracted_qualified_name.prefix(), move(is_value), true));
+    return TRY(DOM::create_element(*this, extracted_qualified_name.local_name().to_deprecated_fly_string(), extracted_qualified_name.deprecated_namespace_(), extracted_qualified_name.deprecated_prefix(), move(is_value), true));
 }
 
 JS::NonnullGCPtr<DocumentFragment> Document::create_document_fragment()
@@ -2963,7 +2963,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Attr>> Document::create_attribute(String co
     // 2. If this is an HTML document, then set localName to localName in ASCII lowercase.
     // 3. Return a new attribute whose local name is localName and node document is this.
     auto deprecated_local_name = local_name.to_deprecated_string();
-    return Attr::create(*this, is_html_document() ? deprecated_local_name.to_lowercase() : deprecated_local_name);
+    return Attr::create(*this, MUST(FlyString::from_deprecated_fly_string(is_html_document() ? deprecated_local_name.to_lowercase() : deprecated_local_name)));
 }
 
 // https://dom.spec.whatwg.org/#dom-document-createattributens

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -295,7 +295,7 @@ WebIDL::ExceptionOr<JS::GCPtr<Attr>> Element::set_attribute_node_ns(Attr& attr)
 }
 
 // https://dom.spec.whatwg.org/#dom-element-removeattribute
-void Element::remove_attribute(DeprecatedFlyString const& name)
+void Element::remove_attribute(StringView name)
 {
     // The removeAttribute(qualifiedName) method steps are to remove an attribute given qualifiedName and this, and then return undefined.
     m_attributes->remove_attribute(name);

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -131,7 +131,7 @@ void Element::visit_edges(Cell::Visitor& visitor)
 }
 
 // https://dom.spec.whatwg.org/#dom-element-getattribute
-DeprecatedString Element::get_attribute(DeprecatedFlyString const& name) const
+DeprecatedString Element::get_attribute(StringView name) const
 {
     // 1. Let attr be the result of getting an attribute given qualifiedName and this.
     auto const* attribute = m_attributes->get_attribute(name);
@@ -145,7 +145,7 @@ DeprecatedString Element::get_attribute(DeprecatedFlyString const& name) const
 }
 
 // https://dom.spec.whatwg.org/#concept-element-attributes-get-value
-DeprecatedString Element::get_attribute_value(DeprecatedFlyString const& local_name, DeprecatedFlyString const& namespace_) const
+DeprecatedString Element::get_attribute_value(StringView local_name, DeprecatedFlyString const& namespace_) const
 {
     // 1. Let attr be the result of getting an attribute given namespace, localName, and element.
     auto const* attribute = m_attributes->get_attribute_ns(namespace_, local_name);

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -715,7 +715,7 @@ WebIDL::ExceptionOr<DOM::Element const*> Element::closest(StringView selectors) 
     return nullptr;
 }
 
-WebIDL::ExceptionOr<void> Element::set_inner_html(DeprecatedString const& markup)
+WebIDL::ExceptionOr<void> Element::set_inner_html(StringView markup)
 {
     TRY(DOMParsing::inner_html_setter(*this, markup));
     return {};

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -175,7 +175,7 @@ WebIDL::ExceptionOr<void> Element::set_attribute(DeprecatedFlyString const& name
 
     // 2. If this is in the HTML namespace and its node document is an HTML document, then set qualifiedName to qualifiedName in ASCII lowercase.
     // FIXME: Handle the second condition, assume it is an HTML document for now.
-    bool insert_as_lowercase = namespace_uri() == Namespace::HTML;
+    bool insert_as_lowercase = namespace_() == Namespace::HTML;
 
     // 3. Let attribute be the first attribute in this’s attribute list whose qualified name is qualifiedName, and null otherwise.
     auto* attribute = m_attributes->get_attribute(name);
@@ -328,7 +328,7 @@ WebIDL::ExceptionOr<bool> Element::toggle_attribute(DeprecatedFlyString const& n
 
     // 2. If this is in the HTML namespace and its node document is an HTML document, then set qualifiedName to qualifiedName in ASCII lowercase.
     // FIXME: Handle the second condition, assume it is an HTML document for now.
-    bool insert_as_lowercase = namespace_uri() == Namespace::HTML;
+    bool insert_as_lowercase = namespace_() == Namespace::HTML;
 
     // 3. Let attribute be the first attribute in this’s attribute list whose qualified name is qualifiedName, and null otherwise.
     auto* attribute = m_attributes->get_attribute(name);

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -748,10 +748,10 @@ bool Element::is_document_element() const
     return document().document_element() == this;
 }
 
-JS::NonnullGCPtr<HTMLCollection> Element::get_elements_by_class_name(DeprecatedFlyString const& class_names)
+JS::NonnullGCPtr<HTMLCollection> Element::get_elements_by_class_name(StringView class_names)
 {
     Vector<FlyString> list_of_class_names;
-    for (auto& name : class_names.view().split_view_if(Infra::is_ascii_whitespace)) {
+    for (auto& name : class_names.split_view_if(Infra::is_ascii_whitespace)) {
         list_of_class_names.append(FlyString::from_utf8(name).release_value_but_fixme_should_propagate_errors());
     }
     return HTMLCollection::create(*this, HTMLCollection::Scope::Descendants, [list_of_class_names = move(list_of_class_names), quirks_mode = document().in_quirks_mode()](Element const& element) {

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -302,7 +302,7 @@ void Element::remove_attribute(StringView name)
 }
 
 // https://dom.spec.whatwg.org/#dom-element-hasattribute
-bool Element::has_attribute(DeprecatedFlyString const& name) const
+bool Element::has_attribute(StringView name) const
 {
     return m_attributes->get_attribute(name) != nullptr;
 }

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -91,7 +91,8 @@ public:
     // NOTE: This is for the JS bindings
     DeprecatedFlyString namespace_uri() const { return namespace_(); }
 
-    bool has_attribute(DeprecatedFlyString const& name) const;
+    // FIXME: This should be taking a 'FlyString const&'
+    bool has_attribute(StringView name) const;
     bool has_attribute_ns(DeprecatedFlyString namespace_, DeprecatedFlyString const& name) const;
     bool has_attributes() const;
 
@@ -104,6 +105,7 @@ public:
         return String::from_deprecated_string(ret).release_value();
     }
 
+    // FIXME: This should be taking a 'FlyString const&' / 'Optional<FlyString> const&'
     DeprecatedString get_attribute(DeprecatedFlyString const& name) const;
     DeprecatedString get_attribute_value(DeprecatedFlyString const& local_name, DeprecatedFlyString const& namespace_ = {}) const;
 

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -114,7 +114,9 @@ public:
     WebIDL::ExceptionOr<JS::GCPtr<Attr>> set_attribute_node(Attr&);
     WebIDL::ExceptionOr<JS::GCPtr<Attr>> set_attribute_node_ns(Attr&);
 
-    void remove_attribute(DeprecatedFlyString const& name);
+    // FIXME: This should take a 'FlyString cosnt&'
+    void remove_attribute(StringView name);
+
     WebIDL::ExceptionOr<bool> toggle_attribute(DeprecatedFlyString const& name, Optional<bool> force);
     size_t attribute_list_size() const;
     NamedNodeMap const* attributes() const { return m_attributes.ptr(); }

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -199,7 +199,7 @@ public:
     bool is_target() const;
     bool is_document_element() const;
 
-    JS::NonnullGCPtr<HTMLCollection> get_elements_by_class_name(DeprecatedFlyString const&);
+    JS::NonnullGCPtr<HTMLCollection> get_elements_by_class_name(StringView);
 
     bool is_shadow_host() const;
     ShadowRoot* shadow_root_internal() { return m_shadow_root.ptr(); }

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -188,7 +188,7 @@ public:
     CSS::CSSStyleDeclaration* style_for_bindings();
 
     WebIDL::ExceptionOr<DeprecatedString> inner_html() const;
-    WebIDL::ExceptionOr<void> set_inner_html(DeprecatedString const&);
+    WebIDL::ExceptionOr<void> set_inner_html(StringView);
 
     WebIDL::ExceptionOr<void> insert_adjacent_html(DeprecatedString position, DeprecatedString text);
 

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -74,21 +74,22 @@ class Element
 public:
     virtual ~Element() override;
 
-    DeprecatedFlyString const& qualified_name() const { return m_qualified_name.as_string(); }
+    DeprecatedFlyString qualified_name() const { return m_qualified_name.as_string().to_deprecated_fly_string(); }
     DeprecatedString const& html_uppercased_qualified_name() const { return m_html_uppercased_qualified_name; }
+
     virtual FlyString node_name() const final { return MUST(FlyString::from_deprecated_fly_string(html_uppercased_qualified_name())); }
-    DeprecatedFlyString const& local_name() const { return m_qualified_name.local_name(); }
+    DeprecatedFlyString local_name() const { return m_qualified_name.local_name().to_deprecated_fly_string(); }
 
     // NOTE: This is for the JS bindings
     DeprecatedString const& tag_name() const { return html_uppercased_qualified_name(); }
 
-    DeprecatedFlyString const& prefix() const { return m_qualified_name.prefix(); }
+    DeprecatedFlyString prefix() const { return m_qualified_name.deprecated_prefix(); }
     void set_prefix(DeprecatedFlyString const& value);
 
-    DeprecatedFlyString const& namespace_() const { return m_qualified_name.namespace_(); }
+    DeprecatedFlyString namespace_() const { return m_qualified_name.deprecated_namespace_(); }
 
     // NOTE: This is for the JS bindings
-    DeprecatedFlyString const& namespace_uri() const { return namespace_(); }
+    DeprecatedFlyString namespace_uri() const { return namespace_(); }
 
     bool has_attribute(DeprecatedFlyString const& name) const;
     bool has_attribute_ns(DeprecatedFlyString namespace_, DeprecatedFlyString const& name) const;

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -96,8 +96,9 @@ public:
     bool has_attribute_ns(DeprecatedFlyString namespace_, DeprecatedFlyString const& name) const;
     bool has_attributes() const;
 
-    DeprecatedString deprecated_attribute(DeprecatedFlyString const& name) const { return get_attribute(name); }
-    Optional<String> attribute(DeprecatedFlyString const& name) const
+    // FIXME: This should be taking a 'FlyString const&'
+    DeprecatedString deprecated_attribute(StringView name) const { return get_attribute(name); }
+    Optional<String> attribute(StringView name) const
     {
         auto ret = deprecated_attribute(name);
         if (ret.is_null())
@@ -106,8 +107,8 @@ public:
     }
 
     // FIXME: This should be taking a 'FlyString const&' / 'Optional<FlyString> const&'
-    DeprecatedString get_attribute(DeprecatedFlyString const& name) const;
-    DeprecatedString get_attribute_value(DeprecatedFlyString const& local_name, DeprecatedFlyString const& namespace_ = {}) const;
+    DeprecatedString get_attribute(StringView name) const;
+    DeprecatedString get_attribute_value(StringView local_name, DeprecatedFlyString const& namespace_ = {}) const;
 
     WebIDL::ExceptionOr<void> set_attribute(DeprecatedFlyString const& name, DeprecatedString const& value);
     WebIDL::ExceptionOr<void> set_attribute(DeprecatedFlyString const& name, Optional<String> const& value);
@@ -264,55 +265,55 @@ public:
     }
 
     // https://www.w3.org/TR/wai-aria-1.2/#accessibilityroleandproperties-correspondence
-    ARIA_IMPL(role, "role");
-    ARIA_IMPL(aria_active_descendant, "aria-activedescendant");
-    ARIA_IMPL(aria_atomic, "aria-atomic");
-    ARIA_IMPL(aria_auto_complete, "aria-autocomplete");
-    ARIA_IMPL(aria_busy, "aria-busy");
-    ARIA_IMPL(aria_checked, "aria-checked");
-    ARIA_IMPL(aria_col_count, "aria-colcount");
-    ARIA_IMPL(aria_col_index, "aria-colindex");
-    ARIA_IMPL(aria_col_span, "aria-colspan");
-    ARIA_IMPL(aria_controls, "aria-controls");
-    ARIA_IMPL(aria_current, "aria-current");
-    ARIA_IMPL(aria_described_by, "aria-describedby");
-    ARIA_IMPL(aria_details, "aria-details");
-    ARIA_IMPL(aria_drop_effect, "aria-dropeffect");
-    ARIA_IMPL(aria_error_message, "aria-errormessage");
-    ARIA_IMPL(aria_disabled, "aria-disabled");
-    ARIA_IMPL(aria_expanded, "aria-expanded");
-    ARIA_IMPL(aria_flow_to, "aria-flowto");
-    ARIA_IMPL(aria_grabbed, "aria-grabbed");
-    ARIA_IMPL(aria_has_popup, "aria-haspopup");
-    ARIA_IMPL(aria_hidden, "aria-hidden");
-    ARIA_IMPL(aria_invalid, "aria-invalid");
-    ARIA_IMPL(aria_key_shortcuts, "aria-keyshortcuts");
-    ARIA_IMPL(aria_label, "aria-label");
-    ARIA_IMPL(aria_labelled_by, "aria-labelledby");
-    ARIA_IMPL(aria_level, "aria-level");
-    ARIA_IMPL(aria_live, "aria-live");
-    ARIA_IMPL(aria_modal, "aria-modal");
-    ARIA_IMPL(aria_multi_line, "aria-multiline");
-    ARIA_IMPL(aria_multi_selectable, "aria-multiselectable");
-    ARIA_IMPL(aria_orientation, "aria-orientation");
-    ARIA_IMPL(aria_owns, "aria-owns");
-    ARIA_IMPL(aria_placeholder, "aria-placeholder");
-    ARIA_IMPL(aria_pos_in_set, "aria-posinset");
-    ARIA_IMPL(aria_pressed, "aria-pressed");
-    ARIA_IMPL(aria_read_only, "aria-readonly");
-    ARIA_IMPL(aria_relevant, "aria-relevant");
-    ARIA_IMPL(aria_required, "aria-required");
-    ARIA_IMPL(aria_role_description, "aria-roledescription");
-    ARIA_IMPL(aria_row_count, "aria-rowcount");
-    ARIA_IMPL(aria_row_index, "aria-rowindex");
-    ARIA_IMPL(aria_row_span, "aria-rowspan");
-    ARIA_IMPL(aria_selected, "aria-selected");
-    ARIA_IMPL(aria_set_size, "aria-setsize");
-    ARIA_IMPL(aria_sort, "aria-sort");
-    ARIA_IMPL(aria_value_max, "aria-valuemax");
-    ARIA_IMPL(aria_value_min, "aria-valuemin");
-    ARIA_IMPL(aria_value_now, "aria-valuenow");
-    ARIA_IMPL(aria_value_text, "aria-valuetext");
+    ARIA_IMPL(role, "role"sv);
+    ARIA_IMPL(aria_active_descendant, "aria-activedescendant"sv);
+    ARIA_IMPL(aria_atomic, "aria-atomic"sv);
+    ARIA_IMPL(aria_auto_complete, "aria-autocomplete"sv);
+    ARIA_IMPL(aria_busy, "aria-busy"sv);
+    ARIA_IMPL(aria_checked, "aria-checked"sv);
+    ARIA_IMPL(aria_col_count, "aria-colcount"sv);
+    ARIA_IMPL(aria_col_index, "aria-colindex"sv);
+    ARIA_IMPL(aria_col_span, "aria-colspan"sv);
+    ARIA_IMPL(aria_controls, "aria-controls"sv);
+    ARIA_IMPL(aria_current, "aria-current"sv);
+    ARIA_IMPL(aria_described_by, "aria-describedby"sv);
+    ARIA_IMPL(aria_details, "aria-details"sv);
+    ARIA_IMPL(aria_drop_effect, "aria-dropeffect"sv);
+    ARIA_IMPL(aria_error_message, "aria-errormessage"sv);
+    ARIA_IMPL(aria_disabled, "aria-disabled"sv);
+    ARIA_IMPL(aria_expanded, "aria-expanded"sv);
+    ARIA_IMPL(aria_flow_to, "aria-flowto"sv);
+    ARIA_IMPL(aria_grabbed, "aria-grabbed"sv);
+    ARIA_IMPL(aria_has_popup, "aria-haspopup"sv);
+    ARIA_IMPL(aria_hidden, "aria-hidden"sv);
+    ARIA_IMPL(aria_invalid, "aria-invalid"sv);
+    ARIA_IMPL(aria_key_shortcuts, "aria-keyshortcuts"sv);
+    ARIA_IMPL(aria_label, "aria-label"sv);
+    ARIA_IMPL(aria_labelled_by, "aria-labelledby"sv);
+    ARIA_IMPL(aria_level, "aria-level"sv);
+    ARIA_IMPL(aria_live, "aria-live"sv);
+    ARIA_IMPL(aria_modal, "aria-modal"sv);
+    ARIA_IMPL(aria_multi_line, "aria-multiline"sv);
+    ARIA_IMPL(aria_multi_selectable, "aria-multiselectable"sv);
+    ARIA_IMPL(aria_orientation, "aria-orientation"sv);
+    ARIA_IMPL(aria_owns, "aria-owns"sv);
+    ARIA_IMPL(aria_placeholder, "aria-placeholder"sv);
+    ARIA_IMPL(aria_pos_in_set, "aria-posinset"sv);
+    ARIA_IMPL(aria_pressed, "aria-pressed"sv);
+    ARIA_IMPL(aria_read_only, "aria-readonly"sv);
+    ARIA_IMPL(aria_relevant, "aria-relevant"sv);
+    ARIA_IMPL(aria_required, "aria-required"sv);
+    ARIA_IMPL(aria_role_description, "aria-roledescription"sv);
+    ARIA_IMPL(aria_row_count, "aria-rowcount"sv);
+    ARIA_IMPL(aria_row_index, "aria-rowindex"sv);
+    ARIA_IMPL(aria_row_span, "aria-rowspan"sv);
+    ARIA_IMPL(aria_selected, "aria-selected"sv);
+    ARIA_IMPL(aria_set_size, "aria-setsize"sv);
+    ARIA_IMPL(aria_sort, "aria-sort"sv);
+    ARIA_IMPL(aria_value_max, "aria-valuemax"sv);
+    ARIA_IMPL(aria_value_min, "aria-valuemin"sv);
+    ARIA_IMPL(aria_value_now, "aria-valuenow"sv);
+    ARIA_IMPL(aria_value_text, "aria-valuetext"sv);
 
 #undef ARIA_IMPL
 

--- a/Userland/Libraries/LibWeb/DOM/ElementFactory.cpp
+++ b/Userland/Libraries/LibWeb/DOM/ElementFactory.cpp
@@ -272,7 +272,7 @@ bool is_unknown_html_element(DeprecatedFlyString const& tag_name)
 // https://html.spec.whatwg.org/#elements-in-the-dom:element-interface
 static JS::NonnullGCPtr<Element> create_html_element(JS::Realm& realm, Document& document, QualifiedName qualified_name)
 {
-    auto lowercase_tag_name = qualified_name.local_name().to_lowercase();
+    auto lowercase_tag_name = qualified_name.local_name().to_deprecated_fly_string().to_lowercase();
 
     if (lowercase_tag_name == HTML::TagNames::a)
         return realm.heap().allocate<HTML::HTMLAnchorElement>(realm, document, move(qualified_name));
@@ -426,7 +426,7 @@ static JS::NonnullGCPtr<Element> create_html_element(JS::Realm& realm, Document&
 
 static JS::GCPtr<SVG::SVGElement> create_svg_element(JS::Realm& realm, Document& document, QualifiedName qualified_name)
 {
-    auto const& local_name = qualified_name.local_name();
+    auto const& local_name = qualified_name.local_name().to_deprecated_fly_string();
 
     if (local_name == SVG::TagNames::svg)
         return realm.heap().allocate<SVG::SVGSVGElement>(realm, document, move(qualified_name));
@@ -481,7 +481,7 @@ static JS::GCPtr<SVG::SVGElement> create_svg_element(JS::Realm& realm, Document&
 
 static JS::GCPtr<MathML::MathMLElement> create_mathml_element(JS::Realm& realm, Document& document, QualifiedName qualified_name)
 {
-    auto const& local_name = MUST(FlyString::from_deprecated_fly_string(qualified_name.local_name()));
+    auto const& local_name = qualified_name.local_name();
 
     if (local_name.is_one_of(MathML::TagNames::annotation, MathML::TagNames::annotation_xml, MathML::TagNames::maction, MathML::TagNames::math, MathML::TagNames::merror, MathML::TagNames::mfrac, MathML::TagNames::mi, MathML::TagNames::mmultiscripts, MathML::TagNames::mn, MathML::TagNames::mo, MathML::TagNames::mover, MathML::TagNames::mpadded, MathML::TagNames::mphantom, MathML::TagNames::mprescripts, MathML::TagNames::mroot, MathML::TagNames::mrow, MathML::TagNames::ms, MathML::TagNames::mspace, MathML::TagNames::msqrt, MathML::TagNames::mstyle, MathML::TagNames::msub, MathML::TagNames::msubsup, MathML::TagNames::msup, MathML::TagNames::mtable, MathML::TagNames::mtd, MathML::TagNames::mtext, MathML::TagNames::mtr, MathML::TagNames::munder, MathML::TagNames::munderover, MathML::TagNames::semantics))
         return realm.heap().allocate<MathML::MathMLElement>(realm, document, move(qualified_name));
@@ -511,7 +511,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Element>> create_element(Document& document
         // 2. Set result to a new element that implements interface, with no attributes, namespace set to the HTML namespace,
         //    namespace prefix set to prefix, local name set to localName, custom element state set to "undefined", custom element definition set to null,
         //    is value set to is, and node document set to document.
-        auto element = create_html_element(realm, document, QualifiedName { local_name, prefix, Namespace::HTML });
+        auto element = create_html_element(realm, document, QualifiedName { MUST(FlyString::from_deprecated_fly_string(local_name)), prefix, Namespace::HTML });
 
         // 3. If the synchronous custom elements flag is set, then run this step while catching any exceptions:
         if (synchronous_custom_elements_flag) {
@@ -596,7 +596,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Element>> create_element(Document& document
 
                 // 2. Set result to a new element that implements the HTMLUnknownElement interface, with no attributes, namespace set to the HTML namespace, namespace prefix set to prefix,
                 //    local name set to localName, custom element state set to "failed", custom element definition set to null, is value set to null, and node document set to document.
-                JS::NonnullGCPtr<Element> element = realm.heap().allocate<HTML::HTMLUnknownElement>(realm, document, QualifiedName { local_name, prefix, Namespace::HTML });
+                JS::NonnullGCPtr<Element> element = realm.heap().allocate<HTML::HTMLUnknownElement>(realm, document, QualifiedName { MUST(FlyString::from_deprecated_fly_string(local_name)), prefix, Namespace::HTML });
                 element->set_custom_element_state(CustomElementState::Failed);
                 return element;
             }
@@ -607,7 +607,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Element>> create_element(Document& document
         // 2. Otherwise:
         // 1. Set result to a new element that implements the HTMLElement interface, with no attributes, namespace set to the HTML namespace, namespace prefix set to prefix,
         //    local name set to localName, custom element state set to "undefined", custom element definition set to null, is value set to null, and node document set to document.
-        auto element = realm.heap().allocate<HTML::HTMLElement>(realm, document, QualifiedName { local_name, prefix, Namespace::HTML });
+        auto element = realm.heap().allocate<HTML::HTMLElement>(realm, document, QualifiedName { MUST(FlyString::from_deprecated_fly_string(local_name)), prefix, Namespace::HTML });
         element->set_custom_element_state(CustomElementState::Undefined);
 
         // 2. Enqueue a custom element upgrade reaction given result and definition.
@@ -621,7 +621,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Element>> create_element(Document& document
     //       local name set to localName, custom element state set to "uncustomized", custom element definition set to null, is value set to is,
     //       and node document set to document.
 
-    auto qualified_name = QualifiedName { local_name, prefix, namespace_ };
+    auto qualified_name = QualifiedName { MUST(FlyString::from_deprecated_fly_string(local_name)), prefix, namespace_ };
 
     if (namespace_ == Namespace::HTML) {
         auto element = create_html_element(realm, document, move(qualified_name));

--- a/Userland/Libraries/LibWeb/DOM/NamedNodeMap.cpp
+++ b/Userland/Libraries/LibWeb/DOM/NamedNodeMap.cpp
@@ -60,7 +60,7 @@ Vector<DeprecatedString> NamedNodeMap::supported_property_names() const
 
     // 2. If this NamedNodeMap object’s element is in the HTML namespace and its node document is an HTML document, then for each name in names:
     // FIXME: Handle the second condition, assume it is an HTML document for now.
-    if (associated_element().namespace_uri() == Namespace::HTML) {
+    if (associated_element().namespace_() == Namespace::HTML) {
         // 1. Let lowercaseName be name, in ASCII lowercase.
         // 2. If lowercaseName is not equal to name, remove name from names.
         names.remove_all_matching([](auto const& name) { return name != name.to_lowercase(); });
@@ -157,7 +157,7 @@ Attr const* NamedNodeMap::get_attribute(StringView qualified_name, size_t* item_
 
     // 1. If element is in the HTML namespace and its node document is an HTML document, then set qualifiedName to qualifiedName in ASCII lowercase.
     // FIXME: Handle the second condition, assume it is an HTML document for now.
-    bool compare_as_lowercase = associated_element().namespace_uri() == Namespace::HTML;
+    bool compare_as_lowercase = associated_element().namespace_() == Namespace::HTML;
 
     // 2. Return the first attribute in element’s attribute list whose qualified name is qualifiedName; otherwise null.
     for (auto const& attribute : m_attributes) {

--- a/Userland/Libraries/LibWeb/DOM/NamedNodeMap.h
+++ b/Userland/Libraries/LibWeb/DOM/NamedNodeMap.h
@@ -43,6 +43,7 @@ public:
     WebIDL::ExceptionOr<Attr const*> remove_named_item_ns(Optional<String> const& namespace_, StringView local_name);
 
     // Methods defined by the spec for internal use:
+    // FIXME: These should be taking `FlyString const&' / 'Optional<FlyString> const&'
     Attr* get_attribute(StringView qualified_name, size_t* item_index = nullptr);
     Attr* get_attribute_ns(StringView namespace_, StringView local_name, size_t* item_index = nullptr);
     Attr const* get_attribute(StringView qualified_name, size_t* item_index = nullptr) const;

--- a/Userland/Libraries/LibWeb/DOM/NamedNodeMap.h
+++ b/Userland/Libraries/LibWeb/DOM/NamedNodeMap.h
@@ -50,6 +50,8 @@ public:
     WebIDL::ExceptionOr<JS::GCPtr<Attr>> set_attribute(Attr& attribute);
     void replace_attribute(Attr& old_attribute, Attr& new_attribute, size_t old_attribute_index);
     void append_attribute(Attr& attribute);
+
+    // FIXME: This should take a 'FlyString cosnt&'
     Attr const* remove_attribute(StringView qualified_name);
     Attr const* remove_attribute_ns(StringView namespace_, StringView local_name);
 

--- a/Userland/Libraries/LibWeb/DOM/Node.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Node.cpp
@@ -166,7 +166,7 @@ Optional<String> Node::text_content() const
 
     // If Attr node, return this's value.
     if (is<Attr>(*this))
-        return MUST(String::from_deprecated_string(static_cast<Attr const&>(*this).value()));
+        return static_cast<Attr const&>(*this).value();
 
     // Otherwise, return null
     return {};
@@ -196,7 +196,7 @@ void Node::set_text_content(Optional<String> const& maybe_content)
 
     // If Attr, set an existing attribute value with this and the given value.
     if (is<Attr>(*this)) {
-        static_cast<Attr&>(*this).set_value(content);
+        static_cast<Attr&>(*this).set_value(MUST(String::from_deprecated_string(content)));
     }
 
     // Otherwise, do nothing.
@@ -212,7 +212,7 @@ Optional<String> Node::node_value() const
 
     // If Attr, return this’s value.
     if (is<Attr>(this)) {
-        return MUST(String::from_deprecated_string(verify_cast<Attr>(this)->value()));
+        return verify_cast<Attr>(this)->value();
     }
 
     // If CharacterData, return this’s data.
@@ -233,7 +233,7 @@ void Node::set_node_value(Optional<String> const& maybe_value)
 
     // If Attr, set an existing attribute value with this and the given value.
     if (is<Attr>(this)) {
-        verify_cast<Attr>(this)->set_value(value.to_deprecated_string());
+        verify_cast<Attr>(this)->set_value(move(value));
     } else if (is<CharacterData>(this)) {
         // If CharacterData, replace data with node this, offset 0, count this’s length, and data the given value.
         verify_cast<CharacterData>(this)->set_data(value);

--- a/Userland/Libraries/LibWeb/DOM/QualifiedName.cpp
+++ b/Userland/Libraries/LibWeb/DOM/QualifiedName.cpp
@@ -9,10 +9,20 @@
 
 namespace Web::DOM {
 
+static unsigned hash_impl(FlyString const& local_name, Optional<FlyString> const& prefix, Optional<FlyString> const& namespace_)
+{
+    unsigned hash = local_name.hash();
+    if (prefix.has_value())
+        hash = pair_int_hash(hash, prefix->hash());
+    if (namespace_.has_value())
+        hash = pair_int_hash(hash, namespace_->hash());
+    return hash;
+}
+
 struct ImplTraits : public Traits<QualifiedName::Impl*> {
     static unsigned hash(QualifiedName::Impl* impl)
     {
-        return pair_int_hash(impl->local_name.hash(), pair_int_hash(impl->prefix.hash(), impl->namespace_.hash()));
+        return hash_impl(impl->local_name, impl->prefix, impl->namespace_);
     }
 
     static bool equals(QualifiedName::Impl* a, QualifiedName::Impl* b)
@@ -25,9 +35,10 @@ struct ImplTraits : public Traits<QualifiedName::Impl*> {
 
 static HashTable<QualifiedName::Impl*, ImplTraits> impls;
 
-static NonnullRefPtr<QualifiedName::Impl> ensure_impl(DeprecatedFlyString const& local_name, DeprecatedFlyString const& prefix, DeprecatedFlyString const& namespace_)
+static NonnullRefPtr<QualifiedName::Impl> ensure_impl(FlyString const& local_name, Optional<FlyString> const& prefix, Optional<FlyString> const& namespace_)
 {
-    auto hash = pair_int_hash(local_name.hash(), pair_int_hash(prefix.hash(), namespace_.hash()));
+    unsigned hash = hash_impl(local_name, prefix, namespace_);
+
     auto it = impls.find(hash, [&](QualifiedName::Impl* entry) {
         return entry->local_name == local_name
             && entry->prefix == prefix
@@ -38,12 +49,17 @@ static NonnullRefPtr<QualifiedName::Impl> ensure_impl(DeprecatedFlyString const&
     return adopt_ref(*new QualifiedName::Impl(local_name, prefix, namespace_));
 }
 
-QualifiedName::QualifiedName(DeprecatedFlyString const& local_name, DeprecatedFlyString const& prefix, DeprecatedFlyString const& namespace_)
+QualifiedName::QualifiedName(FlyString const& local_name, Optional<FlyString> const& prefix, Optional<FlyString> const& namespace_)
     : m_impl(ensure_impl(local_name, prefix, namespace_))
 {
 }
 
-QualifiedName::Impl::Impl(DeprecatedFlyString const& a_local_name, DeprecatedFlyString const& a_prefix, DeprecatedFlyString const& a_namespace)
+QualifiedName::QualifiedName(FlyString const& local_name, DeprecatedFlyString const& prefix, DeprecatedFlyString const& namespace_)
+    : QualifiedName(local_name, prefix.is_null() ? Optional<FlyString> {} : MUST(FlyString::from_deprecated_fly_string(prefix)), namespace_.is_null() ? Optional<FlyString> {} : MUST(FlyString::from_deprecated_fly_string(namespace_)))
+{
+}
+
+QualifiedName::Impl::Impl(FlyString const& a_local_name, Optional<FlyString> const& a_prefix, Optional<FlyString> const& a_namespace)
     : local_name(a_local_name)
     , prefix(a_prefix)
     , namespace_(a_namespace)
@@ -62,17 +78,17 @@ QualifiedName::Impl::~Impl()
 void QualifiedName::Impl::make_internal_string()
 {
     // This is possible to do according to the spec: "User agents could have this as an internal slot as an optimization."
-    if (prefix.is_null()) {
+    if (!prefix.has_value()) {
         as_string = local_name;
         return;
     }
 
-    as_string = DeprecatedString::formatted("{}:{}", prefix, local_name);
+    as_string = MUST(String::formatted("{}:{}", prefix.value(), local_name));
 }
 
-void QualifiedName::set_prefix(DeprecatedFlyString const& value)
+void QualifiedName::set_prefix(Optional<FlyString> value)
 {
-    m_impl->prefix = value;
+    m_impl->prefix = move(value);
 }
 
 }

--- a/Userland/Libraries/LibWeb/DOM/QualifiedName.h
+++ b/Userland/Libraries/LibWeb/DOM/QualifiedName.h
@@ -8,31 +8,48 @@
 #pragma once
 
 #include <AK/DeprecatedFlyString.h>
+#include <AK/FlyString.h>
+#include <AK/Optional.h>
 
 namespace Web::DOM {
 
 class QualifiedName {
 public:
-    QualifiedName(DeprecatedFlyString const& local_name, DeprecatedFlyString const& prefix, DeprecatedFlyString const& namespace_);
+    QualifiedName(FlyString const& local_name, Optional<FlyString> const& prefix, Optional<FlyString> const& namespace_);
+    QualifiedName(FlyString const& local_name, DeprecatedFlyString const& prefix, DeprecatedFlyString const& namespace_);
 
-    DeprecatedFlyString const& local_name() const { return m_impl->local_name; }
-    DeprecatedFlyString const& prefix() const { return m_impl->prefix; }
-    DeprecatedFlyString const& namespace_() const { return m_impl->namespace_; }
+    FlyString const& local_name() const { return m_impl->local_name; }
+    Optional<FlyString> const& prefix() const { return m_impl->prefix; }
+    Optional<FlyString> const& namespace_() const { return m_impl->namespace_; }
 
-    DeprecatedFlyString const& as_string() const { return m_impl->as_string; }
+    DeprecatedFlyString deprecated_prefix() const
+    {
+        if (!m_impl->prefix.has_value())
+            return {};
+        return m_impl->prefix->to_deprecated_fly_string();
+    }
+
+    DeprecatedFlyString deprecated_namespace_() const
+    {
+        if (!m_impl->namespace_.has_value())
+            return {};
+        return m_impl->namespace_->to_deprecated_fly_string();
+    }
+
+    FlyString const& as_string() const { return m_impl->as_string; }
 
     struct Impl : public RefCounted<Impl> {
-        Impl(DeprecatedFlyString const& local_name, DeprecatedFlyString const& prefix, DeprecatedFlyString const& namespace_);
+        Impl(FlyString const& local_name, Optional<FlyString> const& prefix, Optional<FlyString> const& namespace_);
         ~Impl();
 
         void make_internal_string();
-        DeprecatedFlyString local_name;
-        DeprecatedFlyString prefix;
-        DeprecatedFlyString namespace_;
-        DeprecatedFlyString as_string;
+        FlyString local_name;
+        Optional<FlyString> prefix;
+        Optional<FlyString> namespace_;
+        FlyString as_string;
     };
 
-    void set_prefix(DeprecatedFlyString const& value);
+    void set_prefix(Optional<FlyString> value);
 
 private:
     NonnullRefPtr<Impl> m_impl;

--- a/Userland/Libraries/LibWeb/DOMParsing/InnerHTML.cpp
+++ b/Userland/Libraries/LibWeb/DOMParsing/InnerHTML.cpp
@@ -14,7 +14,7 @@
 namespace Web::DOMParsing {
 
 // https://w3c.github.io/DOM-Parsing/#dfn-fragment-parsing-algorithm
-WebIDL::ExceptionOr<JS::NonnullGCPtr<DOM::DocumentFragment>> parse_fragment(DeprecatedString const& markup, DOM::Element& context_element)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<DOM::DocumentFragment>> parse_fragment(StringView markup, DOM::Element& context_element)
 {
     // FIXME: Handle XML documents.
 

--- a/Userland/Libraries/LibWeb/DOMParsing/InnerHTML.h
+++ b/Userland/Libraries/LibWeb/DOMParsing/InnerHTML.h
@@ -16,6 +16,6 @@ namespace Web::DOMParsing {
 // https://w3c.github.io/DOM-Parsing/#dom-innerhtml-innerhtml
 WebIDL::ExceptionOr<void> inner_html_setter(JS::NonnullGCPtr<DOM::Node> context_object, StringView value);
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<DOM::DocumentFragment>> parse_fragment(DeprecatedString const& markup, DOM::Element& context_element);
+WebIDL::ExceptionOr<JS::NonnullGCPtr<DOM::DocumentFragment>> parse_fragment(StringView markup, DOM::Element& context_element);
 
 }

--- a/Userland/Libraries/LibWeb/DOMParsing/XMLSerializer.cpp
+++ b/Userland/Libraries/LibWeb/DOMParsing/XMLSerializer.cpp
@@ -526,7 +526,7 @@ static WebIDL::ExceptionOr<DeprecatedString> serialize_element(DOM::Element cons
     auto inherited_ns = namespace_;
 
     // 10. Let ns be the value of node's namespaceURI attribute.
-    auto const& ns = element.namespace_uri();
+    auto const& ns = element.namespace_();
 
     // 11. If inherited ns is equal to ns, then:
     if (inherited_ns == ns) {

--- a/Userland/Libraries/LibWeb/HTML/AttributeNames.h
+++ b/Userland/Libraries/LibWeb/HTML/AttributeNames.h
@@ -93,6 +93,7 @@ namespace AttributeNames {
     __ENUMERATE_HTML_ATTRIBUTE(lang)                       \
     __ENUMERATE_HTML_ATTRIBUTE(language)                   \
     __ENUMERATE_HTML_ATTRIBUTE(link)                       \
+    __ENUMERATE_HTML_ATTRIBUTE(list)                       \
     __ENUMERATE_HTML_ATTRIBUTE(loading)                    \
     __ENUMERATE_HTML_ATTRIBUTE(longdesc)                   \
     __ENUMERATE_HTML_ATTRIBUTE(loop)                       \

--- a/Userland/Libraries/LibWeb/HTML/HTMLHeadingElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLHeadingElement.h
@@ -25,7 +25,7 @@ public:
     virtual DeprecatedString aria_level() const override
     {
         // TODO: aria-level = the number in the element's tag name
-        return get_attribute("aria-level");
+        return get_attribute("aria-level"sv);
     }
 
 private:

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -1088,7 +1088,7 @@ Optional<ARIA::Role> HTMLInputElement::default_role() const
     if (type_state() == TypeAttributeState::Checkbox)
         return ARIA::Role::checkbox;
     // https://www.w3.org/TR/html-aria/#el-input-email
-    if (type_state() == TypeAttributeState::Email && deprecated_attribute("list").is_null())
+    if (type_state() == TypeAttributeState::Email && !has_attribute(AttributeNames::list))
         return ARIA::Role::textbox;
     // https://www.w3.org/TR/html-aria/#el-input-image
     if (type_state() == TypeAttributeState::ImageButton)
@@ -1111,10 +1111,10 @@ Optional<ARIA::Role> HTMLInputElement::default_role() const
             || type_state() == TypeAttributeState::Telephone
             || type_state() == TypeAttributeState::URL
             || type_state() == TypeAttributeState::Email)
-        && !deprecated_attribute("list").is_null())
+        && has_attribute(AttributeNames::list))
         return ARIA::Role::combobox;
     // https://www.w3.org/TR/html-aria/#el-input-search
-    if (type_state() == TypeAttributeState::Search && deprecated_attribute("list").is_null())
+    if (type_state() == TypeAttributeState::Search && !has_attribute(AttributeNames::list))
         return ARIA::Role::textbox;
     // https://www.w3.org/TR/html-aria/#el-input-submit
     if (type_state() == TypeAttributeState::SubmitButton)
@@ -1123,10 +1123,10 @@ Optional<ARIA::Role> HTMLInputElement::default_role() const
     if (type_state() == TypeAttributeState::Telephone)
         return ARIA::Role::textbox;
     // https://www.w3.org/TR/html-aria/#el-input-text
-    if (type_state() == TypeAttributeState::Text && deprecated_attribute("list").is_null())
+    if (type_state() == TypeAttributeState::Text && !has_attribute(AttributeNames::list))
         return ARIA::Role::textbox;
     // https://www.w3.org/TR/html-aria/#el-input-url
-    if (type_state() == TypeAttributeState::URL && deprecated_attribute("list").is_null())
+    if (type_state() == TypeAttributeState::URL && !has_attribute(AttributeNames::list))
         return ARIA::Role::textbox;
 
     // https://www.w3.org/TR/html-aria/#el-input-color

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -461,7 +461,7 @@ class PlaceholderElement final : public HTMLDivElement {
 
 public:
     PlaceholderElement(DOM::Document& document)
-        : HTMLDivElement(document, DOM::QualifiedName { HTML::TagNames::div, ""sv, Namespace::HTML })
+        : HTMLDivElement(document, DOM::QualifiedName { MUST(FlyString::from_deprecated_fly_string(HTML::TagNames::div)), ""sv, Namespace::HTML })
     {
     }
     virtual Optional<CSS::Selector::PseudoElement> pseudo_element() const override { return CSS::Selector::PseudoElement::Placeholder; }

--- a/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
@@ -167,7 +167,7 @@ Optional<ARIA::Role> HTMLSelectElement::default_role() const
     if (has_attribute(AttributeNames::multiple))
         return ARIA::Role::listbox;
     if (has_attribute(AttributeNames::size)) {
-        auto size_attribute = deprecated_attribute("size").to_int();
+        auto size_attribute = deprecated_attribute(AttributeNames::size).to_int();
         if (size_attribute.has_value() && size_attribute.value() > 1)
             return ARIA::Role::listbox;
     }

--- a/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
@@ -164,9 +164,9 @@ String const& HTMLSelectElement::type() const
 Optional<ARIA::Role> HTMLSelectElement::default_role() const
 {
     // https://www.w3.org/TR/html-aria/#el-select-multiple-or-size-greater-1
-    if (has_attribute("multiple"))
+    if (has_attribute(AttributeNames::multiple))
         return ARIA::Role::listbox;
-    if (has_attribute("size")) {
+    if (has_attribute(AttributeNames::size)) {
         auto size_attribute = deprecated_attribute("size").to_int();
         if (size_attribute.has_value() && size_attribute.value() > 1)
             return ARIA::Role::listbox;

--- a/Userland/Libraries/LibWeb/SVG/SVGGradientElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGGradientElement.cpp
@@ -94,7 +94,7 @@ JS::GCPtr<SVGGradientElement const> SVGGradientElement::linked_gradient() const
     // FIXME: This entire function is an ad-hoc hack!
     // It can only resolve #<ids> in the same document.
 
-    auto link = has_attribute("href") ? get_attribute("href") : get_attribute("xlink:href");
+    auto link = has_attribute(AttributeNames::href) ? get_attribute(AttributeNames::href) : get_attribute("xlink:href"sv);
     if (auto href = link; !href.is_empty()) {
         auto url = document().parse_url(href);
         auto id = url.fragment();

--- a/Userland/Services/WebContent/WebDriverConnection.cpp
+++ b/Userland/Services/WebContent/WebDriverConnection.cpp
@@ -1345,7 +1345,7 @@ Messages::WebDriverClient::ElementClickResponse WebDriverConnection::element_cli
 
             // 3. If element’s container has the multiple attribute, toggle the element’s selectedness state
             //    by setting it to the opposite value of its current selectedness.
-            if (parent_node.has_value() && parent_node->has_attribute("multiple")) {
+            if (parent_node.has_value() && parent_node->has_attribute(Web::HTML::AttributeNames::multiple)) {
                 option_element.set_selected(!option_element.selected());
             }
             //    Otherwise, set the element’s selectedness state to true.


### PR DESCRIPTION
There are an unfortunate number of DeprecatedString conversions required here, but these should all fall away and look much more pretty again when other places are also ported away from DeprecatedString.

Leaves only the Element IDL interface left :^)