### PR TITLE
LibJS: Remove automatic ExecutionContext creation in BC interpreter

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/Instruction.h
+++ b/Userland/Libraries/LibJS/Bytecode/Instruction.h
@@ -132,7 +132,6 @@ public:
 #undef __BYTECODE_OP
     };
 
-    bool is_terminator() const;
     Type type() const { return m_type; }
     size_t length() const { return m_length; }
     DeprecatedString to_deprecated_string(Bytecode::Executable const&) const;

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -105,7 +105,7 @@ ThrowCompletionOr<Value> Interpreter::run(Script& script_record, JS::GCPtr<Envir
                 executable->dump();
 
             // a. Set result to the result of evaluating script.
-            auto result_or_error = run_and_return_frame(script_record.realm(), *executable, nullptr);
+            auto result_or_error = run_and_return_frame(*executable, nullptr);
             if (result_or_error.value.is_error())
                 result = result_or_error.value.release_error();
             else
@@ -165,7 +165,7 @@ ThrowCompletionOr<Value> Interpreter::run(SourceTextModule& module)
     return js_undefined();
 }
 
-Interpreter::ValueAndFrame Interpreter::run_and_return_frame(Realm&, Executable& executable, BasicBlock const* entry_point, CallFrame* in_frame)
+Interpreter::ValueAndFrame Interpreter::run_and_return_frame(Executable& executable, BasicBlock const* entry_point, CallFrame* in_frame)
 {
     dbgln_if(JS_BYTECODE_DEBUG, "Bytecode::Interpreter will run unit {:p}", &executable);
 

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.h
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.h
@@ -45,9 +45,9 @@ public:
     ThrowCompletionOr<Value> run(Script&, JS::GCPtr<Environment> lexical_environment_override = nullptr);
     ThrowCompletionOr<Value> run(SourceTextModule&);
 
-    ThrowCompletionOr<Value> run(Realm& realm, Bytecode::Executable& executable, Bytecode::BasicBlock const* entry_point = nullptr)
+    ThrowCompletionOr<Value> run(Bytecode::Executable& executable, Bytecode::BasicBlock const* entry_point = nullptr)
     {
-        auto value_and_frame = run_and_return_frame(realm, executable, entry_point);
+        auto value_and_frame = run_and_return_frame(executable, entry_point);
         return move(value_and_frame.value);
     }
 
@@ -55,7 +55,7 @@ public:
         ThrowCompletionOr<Value> value;
         OwnPtr<CallFrame> frame;
     };
-    ValueAndFrame run_and_return_frame(Realm&, Bytecode::Executable&, Bytecode::BasicBlock const* entry_point, CallFrame* = nullptr);
+    ValueAndFrame run_and_return_frame(Bytecode::Executable&, Bytecode::BasicBlock const* entry_point, CallFrame* = nullptr);
 
     ALWAYS_INLINE Value& accumulator() { return reg(Register::accumulator()); }
     ALWAYS_INLINE Value& saved_return_value() { return reg(Register::saved_return_value()); }

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -1440,18 +1440,4 @@ ALWAYS_INLINE ThrowCompletionOr<void> Instruction::execute(Bytecode::Interpreter
 #undef __BYTECODE_OP
 }
 
-ALWAYS_INLINE bool Instruction::is_terminator() const
-{
-#define __BYTECODE_OP(op) \
-    case Type::op:        \
-        return Op::op::IsTerminator;
-
-    switch (type()) {
-        ENUMERATE_BYTECODE_OPS(__BYTECODE_OP)
-    default:
-        VERIFY_NOT_REACHED();
-    }
-#undef __BYTECODE_OP
-}
-
 }

--- a/Userland/Libraries/LibJS/Runtime/AbstractOperations.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AbstractOperations.cpp
@@ -708,7 +708,7 @@ ThrowCompletionOr<Value> perform_eval(VM& vm, Value x, CallerMode strict_caller,
     executable->name = "eval"sv;
     if (Bytecode::g_dump_bytecode)
         executable->dump();
-    auto result_or_error = vm.bytecode_interpreter().run_and_return_frame(eval_realm, *executable, nullptr);
+    auto result_or_error = vm.bytecode_interpreter().run_and_return_frame(*executable, nullptr);
     if (result_or_error.value.is_error())
         return result_or_error.value.release_error();
 

--- a/Userland/Libraries/LibJS/Runtime/AsyncGenerator.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AsyncGenerator.cpp
@@ -199,7 +199,7 @@ void AsyncGenerator::execute(VM& vm, Completion completion)
         else
             bytecode_interpreter.accumulator() = completion_object;
 
-        auto next_result = bytecode_interpreter.run_and_return_frame(realm, *m_generating_function->bytecode_executable(), next_block, frame);
+        auto next_result = bytecode_interpreter.run_and_return_frame(*m_generating_function->bytecode_executable(), next_block, frame);
 
         if (!m_frame.has_value())
             m_frame = move(*next_result.frame);

--- a/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
@@ -626,7 +626,7 @@ ThrowCompletionOr<void> ECMAScriptFunctionObject::function_declaration_instantia
                 } else if (i < execution_context_arguments.size() && !execution_context_arguments[i].is_undefined()) {
                     argument_value = execution_context_arguments[i];
                 } else if (parameter.default_value) {
-                    auto value_and_frame = vm.bytecode_interpreter().run_and_return_frame(realm, *m_default_parameter_bytecode_executables[default_parameter_index - 1], nullptr);
+                    auto value_and_frame = vm.bytecode_interpreter().run_and_return_frame(*m_default_parameter_bytecode_executables[default_parameter_index - 1], nullptr);
                     if (value_and_frame.value.is_error())
                         return value_and_frame.value.release_error();
                     // Resulting value is in the accumulator.
@@ -998,7 +998,7 @@ void async_block_start(VM& vm, T const& async_body, PromiseCapability const& pro
     auto& running_context = vm.running_execution_context();
 
     // 3. Set the code evaluation state of asyncContext such that when evaluation is resumed for that execution context the following steps will be performed:
-    auto execution_steps = NativeFunction::create(realm, "", [&realm, &async_body, &promise_capability, &async_context](auto& vm) -> ThrowCompletionOr<Value> {
+    auto execution_steps = NativeFunction::create(realm, "", [&async_body, &promise_capability, &async_context](auto& vm) -> ThrowCompletionOr<Value> {
         Completion result;
 
         // a. If asyncBody is a Parse Node, then
@@ -1009,12 +1009,10 @@ void async_block_start(VM& vm, T const& async_body, PromiseCapability const& pro
             if (maybe_executable.is_error())
                 result = maybe_executable.release_error();
             else
-                result = vm.bytecode_interpreter().run_and_return_frame(realm, *maybe_executable.value(), nullptr).value;
+                result = vm.bytecode_interpreter().run_and_return_frame(*maybe_executable.value(), nullptr).value;
         }
         // b. Else,
         else {
-            (void)realm;
-
             // i. Assert: asyncBody is an Abstract Closure with no parameters.
             static_assert(IsCallableWithArguments<T, Completion>);
 
@@ -1126,7 +1124,7 @@ Completion ECMAScriptFunctionObject::ordinary_call_evaluate_body()
         }
     }
 
-    auto result_and_frame = vm.bytecode_interpreter().run_and_return_frame(realm, *m_bytecode_executable, nullptr);
+    auto result_and_frame = vm.bytecode_interpreter().run_and_return_frame(*m_bytecode_executable, nullptr);
 
     VERIFY(result_and_frame.frame != nullptr);
     if (result_and_frame.value.is_error())

--- a/Userland/Libraries/LibJS/Runtime/GeneratorObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/GeneratorObject.cpp
@@ -120,7 +120,7 @@ ThrowCompletionOr<Value> GeneratorObject::execute(VM& vm, Completion const& comp
     else
         bytecode_interpreter.accumulator() = completion_object;
 
-    auto next_result = bytecode_interpreter.run_and_return_frame(realm, *m_generating_function->bytecode_executable(), next_block, frame);
+    auto next_result = bytecode_interpreter.run_and_return_frame(*m_generating_function->bytecode_executable(), next_block, frame);
 
     vm.pop_execution_context();
 

--- a/Userland/Libraries/LibJS/Runtime/ShadowRealm.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ShadowRealm.cpp
@@ -178,7 +178,7 @@ ThrowCompletionOr<Value> perform_shadow_realm_eval(VM& vm, StringView source_tex
         else {
             auto executable = maybe_executable.release_value();
 
-            auto value_and_frame = vm.bytecode_interpreter().run_and_return_frame(eval_realm, *executable, nullptr);
+            auto value_and_frame = vm.bytecode_interpreter().run_and_return_frame(*executable, nullptr);
             if (value_and_frame.value.is_error()) {
                 result = value_and_frame.value.release_error();
             } else {

--- a/Userland/Libraries/LibJS/Runtime/VM.cpp
+++ b/Userland/Libraries/LibJS/Runtime/VM.cpp
@@ -306,7 +306,7 @@ ThrowCompletionOr<void> VM::binding_initialization(NonnullRefPtr<BindingPattern 
 ThrowCompletionOr<Value> VM::execute_ast_node(ASTNode const& node)
 {
     auto executable = TRY(Bytecode::compile(*this, node, FunctionKind::Normal, ""sv));
-    auto result_or_error = bytecode_interpreter().run_and_return_frame(*current_realm(), *executable, nullptr);
+    auto result_or_error = bytecode_interpreter().run_and_return_frame(*executable, nullptr);
     if (result_or_error.value.is_error())
         return result_or_error.value.release_error();
     return result_or_error.frame->registers[0];

--- a/Userland/Libraries/LibJS/SourceTextModule.cpp
+++ b/Userland/Libraries/LibJS/SourceTextModule.cpp
@@ -701,7 +701,7 @@ ThrowCompletionOr<void> SourceTextModule::execute_module(VM& vm, GCPtr<PromiseCa
         else {
             auto executable = maybe_executable.release_value();
 
-            auto value_and_frame = vm.bytecode_interpreter().run_and_return_frame(realm(), *executable, nullptr);
+            auto value_and_frame = vm.bytecode_interpreter().run_and_return_frame(*executable, nullptr);
             if (value_and_frame.value.is_error()) {
                 result = value_and_frame.value.release_error();
             } else {


### PR DESCRIPTION
This was a remnant from the AST/BC hybrid interpreter times. We've had
a VERIFY in here for weeks now that would catch anything depending on
this behavior, and nothing has hit it, so let's remove the unnecessary
code (but leave the VERIFY) :^)

+ two follow-on cleanups.