### PR TITLE
Userland: Remember window state of productivity / editor applications

### DIFF
--- a/Userland/Applications/Browser/BrowserWindow.cpp
+++ b/Userland/Applications/Browser/BrowserWindow.cpp
@@ -64,7 +64,8 @@ BrowserWindow::BrowserWindow(WebView::CookieJar& cookie_jar, URL url)
     auto app_icon = GUI::Icon::default_icon("app-browser"sv);
     m_bookmarks_bar = Browser::BookmarksBarWidget::construct(Browser::bookmarks_file_path(), true);
 
-    resize(730, 560);
+    restore_size_and_position("Browser"sv, "Window"sv, { { 730, 560 } });
+    save_size_and_position_on_close("Browser"sv, "Window"sv);
     set_icon(app_icon.bitmap_for_size(16));
     set_title("Ladybird");
 

--- a/Userland/Applications/Calendar/main.cpp
+++ b/Userland/Applications/Calendar/main.cpp
@@ -60,7 +60,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto app_icon = TRY(GUI::Icon::try_create_default_icon("app-calendar"sv));
     auto window = GUI::Window::construct();
     window->set_title("Calendar");
-    window->resize(600, 480);
+    window->restore_size_and_position("Calendar"sv, "Window"sv, { { 600, 480 } });
+    window->save_size_and_position_on_close("Calendar"sv, "Window"sv);
     window->set_icon(app_icon.bitmap_for_size(16));
 
     auto calendar_widget = TRY(Calendar::CalendarWidget::create(window));

--- a/Userland/Applications/FontEditor/main.cpp
+++ b/Userland/Applications/FontEditor/main.cpp
@@ -43,7 +43,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto window = GUI::Window::construct();
     window->set_icon(app_icon.bitmap_for_size(16));
-    window->resize(640, 470);
+    window->restore_size_and_position("FontEditor"sv, "Window"sv, { { 640, 470 } });
+    window->save_size_and_position_on_close("FontEditor"sv, "Window"sv);
 
     auto font_editor = TRY(FontEditor::MainWidget::try_create());
     window->set_main_widget(font_editor);

--- a/Userland/Applications/HexEditor/main.cpp
+++ b/Userland/Applications/HexEditor/main.cpp
@@ -34,7 +34,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto window = GUI::Window::construct();
     window->set_title("Hex Editor");
-    window->resize(640, 400);
+    window->restore_size_and_position("HexEditor"sv, "Window"sv, { { 640, 400 } });
+    window->save_size_and_position_on_close("HexEditor"sv, "Window"sv);
 
     auto hex_editor_widget = window->set_main_widget<HexEditorWidget>();
 

--- a/Userland/Applications/KeyboardMapper/main.cpp
+++ b/Userland/Applications/KeyboardMapper/main.cpp
@@ -32,7 +32,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_title("Keyboard Mapper");
     window->set_icon(app_icon.bitmap_for_size(16));
     auto keyboard_mapper_widget = window->set_main_widget<KeyboardMapperWidget>();
-    window->resize(775, 315);
+    window->restore_size_and_position("KeyboardMapper"sv, "Window"sv, { { 775, 315 } });
+    window->save_size_and_position_on_close("KeyboardMapper"sv, "Window"sv);
     window->set_resizable(false);
 
     if (path.is_empty())

--- a/Userland/Applications/Mail/main.cpp
+++ b/Userland/Applications/Mail/main.cpp
@@ -43,7 +43,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto mail_widget = window->set_main_widget<MailWidget>();
 
     window->set_title("Mail");
-    window->resize(640, 400);
+    window->restore_size_and_position("Mail"sv, "Window"sv, { { 640, 400 } });
+    window->save_size_and_position_on_close("Mail"sv, "Window"sv);
 
     auto file_menu = window->add_menu("&File"_string);
 

--- a/Userland/Applications/Piano/main.cpp
+++ b/Userland/Applications/Piano/main.cpp
@@ -47,7 +47,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto main_widget = TRY(MainWidget::try_create(track_manager, audio_loop));
     window->set_main_widget(main_widget);
     window->set_title("Piano");
-    window->resize(840, 600);
+    window->restore_size_and_position("Piano"sv, "Window"sv, { { 840, 600 } });
+    window->save_size_and_position_on_close("Piano"sv, "Window"sv);
     window->set_icon(app_icon.bitmap_for_size(16));
 
     auto wav_progress_window = ExportProgressWindow::construct(*window, wav_percent_written);

--- a/Userland/Applications/PixelPaint/main.cpp
+++ b/Userland/Applications/PixelPaint/main.cpp
@@ -44,7 +44,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto window = GUI::Window::construct();
     window->set_title("Pixel Paint");
-    window->resize(800, 520);
+    window->restore_size_and_position("PixelPaint"sv, "Window"sv, { { 800, 520 } });
+    window->save_size_and_position_on_close("PixelPaint"sv, "Window"sv);
     window->set_icon(app_icon.bitmap_for_size(16));
 
     auto main_widget = window->set_main_widget<PixelPaint::MainWidget>();

--- a/Userland/Applications/Presenter/main.cpp
+++ b/Userland/Applications/Presenter/main.cpp
@@ -27,6 +27,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto window = GUI::Window::construct();
     window->set_title("Presenter");
     window->set_icon(GUI::Icon::default_icon("app-presenter"sv).bitmap_for_size(16));
+    window->restore_size_and_position("Presenter"sv, "Window"sv, { { 640, 400 } });
+    window->save_size_and_position_on_close("Presenter"sv, "Window"sv);
     auto main_widget = window->set_main_widget<PresenterWidget>();
     TRY(main_widget->initialize_menubar());
     window->show();

--- a/Userland/Applications/Spreadsheet/main.cpp
+++ b/Userland/Applications/Spreadsheet/main.cpp
@@ -52,7 +52,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto app_icon = GUI::Icon::default_icon("app-spreadsheet"sv);
     auto window = GUI::Window::construct();
-    window->resize(640, 480);
+    window->restore_size_and_position("Spreadsheet"sv, "Window"sv, { { 640, 480 } });
+    window->save_size_and_position_on_close("Spreadsheet"sv, "Window"sv);
     window->set_icon(app_icon.bitmap_for_size(16));
 
     auto spreadsheet_widget = window->set_main_widget<Spreadsheet::SpreadsheetWidget>(*window, Vector<NonnullRefPtr<Spreadsheet::Sheet>> {}, filename.is_empty());

--- a/Userland/Applications/SystemMonitor/main.cpp
+++ b/Userland/Applications/SystemMonitor/main.cpp
@@ -280,7 +280,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto window = GUI::Window::construct();
     window->set_title("System Monitor");
-    window->resize(560, 430);
+    window->restore_size_and_position("SystemMonitor"sv, "Window"sv, { { 560, 430 } });
+    window->save_size_and_position_on_close("SystemMonitor"sv, "Window"sv);
 
     auto main_widget = window->set_main_widget<GUI::Widget>();
     TRY(main_widget->load_from_gml(system_monitor_gml));

--- a/Userland/Applications/TextEditor/main.cpp
+++ b/Userland/Applications/TextEditor/main.cpp
@@ -42,7 +42,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto app_icon = GUI::Icon::default_icon("app-text-editor"sv);
 
     auto window = GUI::Window::construct();
-    window->resize(640, 400);
+    window->restore_size_and_position("TextEditor"sv, "Window"sv, { { 640, 400 } });
+    window->save_size_and_position_on_close("TextEditor"sv, "Window"sv);
 
     auto text_widget = window->set_main_widget<MainWidget>();
 

--- a/Userland/Applications/ThemeEditor/main.cpp
+++ b/Userland/Applications/ThemeEditor/main.cpp
@@ -73,7 +73,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         return main_widget->request_close();
     };
 
-    window->resize(820, 520);
+    window->restore_size_and_position("ThemeEditor"sv, "Window"sv, { { 820, 520 } });
+    window->save_size_and_position_on_close("ThemeEditor"sv, "Window"sv);
     window->set_resizable(false);
     window->show();
     window->set_icon(app_icon.bitmap_for_size(16));

--- a/Userland/DevTools/GMLPlayground/main.cpp
+++ b/Userland/DevTools/GMLPlayground/main.cpp
@@ -43,7 +43,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto window = GUI::Window::construct();
     window->set_title("GML Playground");
     window->set_icon(app_icon.bitmap_for_size(16));
-    window->resize(800, 600);
+    window->restore_size_and_position("GMLPlayground"sv, "Window"sv, { { 800, 600 } });
+    window->save_size_and_position_on_close("GMLPlayground"sv, "Window"sv);
 
     auto main_widget = TRY(MainWidget::try_create(app_icon));
     window->set_main_widget(main_widget);

--- a/Userland/DevTools/HackStudio/main.cpp
+++ b/Userland/DevTools/HackStudio/main.cpp
@@ -44,7 +44,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     Config::pledge_domains({ "HackStudio", "Terminal", "FileManager" });
 
     auto window = GUI::Window::construct();
-    window->resize(840, 600);
+    window->restore_size_and_position("HackStudio"sv, "Window"sv, { { 840, 600 } });
+    window->save_size_and_position_on_close("HackStudio"sv, "Window"sv);
     auto icon = TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/app-hack-studio.png"sv));
     window->set_icon(icon);
 

--- a/Userland/DevTools/Profiler/main.cpp
+++ b/Userland/DevTools/Profiler/main.cpp
@@ -86,7 +86,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     window->set_title("Profiler");
     window->set_icon(app_icon.bitmap_for_size(16));
-    window->resize(800, 600);
+    window->restore_size_and_position("Profiler"sv, "Window"sv, { { 800, 600 } });
+    window->save_size_and_position_on_close("Profiler"sv, "Window"sv);
 
     auto main_widget = window->set_main_widget<GUI::Widget>();
     main_widget->set_fill_with_background_color(true);

--- a/Userland/DevTools/SQLStudio/main.cpp
+++ b/Userland/DevTools/SQLStudio/main.cpp
@@ -26,7 +26,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto app_icon = GUI::Icon::default_icon("app-sql-studio"sv);
 
     auto window = GUI::Window::construct();
-    window->resize(640, 480);
+    window->restore_size_and_position("SQLStudio"sv, "Window"sv, { { 640, 480 } });
+    window->save_size_and_position_on_close("SQLStudio"sv, "Window"sv);
     window->set_icon(app_icon.bitmap_for_size(16));
     window->set_title("SQL Studio");
 


### PR DESCRIPTION
A few weeks a go I have added a API for windows to easily remember it state (#20769).

I have now updated all productivity / editor applications to use this feature. This gives the system more premium feel because all the application windows opens up in the old position it was closed. So less annoying initial dragging and resizing has to be done by the user 🎉.