### PR TITLE
WindowServer+LibGUI: Use floating rect when saving window state on exit

### DIFF
--- a/Userland/Libraries/LibGUI/Window.h
+++ b/Userland/Libraries/LibGUI/Window.h
@@ -109,6 +109,7 @@ public:
     int height() const { return rect().height(); }
 
     Gfx::IntRect rect() const;
+    Gfx::IntRect floating_rect() const;
     Gfx::IntRect applet_rect_on_screen() const;
     Gfx::IntSize size() const { return rect().size(); }
     void set_rect(Gfx::IntRect const&);
@@ -300,6 +301,7 @@ private:
     WeakPtr<Widget> m_hovered_widget;
     Gfx::IntRect m_rect_when_windowless;
     Gfx::IntSize m_minimum_size_when_windowless { 0, 0 };
+    Gfx::IntRect m_floating_rect;
     DeprecatedString m_title_when_windowless;
     Vector<Gfx::IntRect, 32> m_pending_paint_event_rects;
     Gfx::IntSize m_size_increment;

--- a/Userland/Services/WindowServer/ConnectionFromClient.cpp
+++ b/Userland/Services/WindowServer/ConnectionFromClient.cpp
@@ -502,6 +502,16 @@ Messages::WindowServer::GetWindowRectResponse ConnectionFromClient::get_window_r
     return it->value->rect();
 }
 
+Messages::WindowServer::GetWindowFloatingRectResponse ConnectionFromClient::get_window_floating_rect(i32 window_id)
+{
+    auto it = m_windows.find(window_id);
+    if (it == m_windows.end()) {
+        did_misbehave("GetWindowFloatingRect: Bad window ID");
+        return nullptr;
+    }
+    return it->value->floating_rect();
+}
+
 static Gfx::IntSize calculate_minimum_size_for_window(Window const& window)
 {
     if (window.is_frameless())

--- a/Userland/Services/WindowServer/ConnectionFromClient.h
+++ b/Userland/Services/WindowServer/ConnectionFromClient.h
@@ -115,6 +115,7 @@ private:
     virtual void start_window_resize(i32, i32) override;
     virtual Messages::WindowServer::SetWindowRectResponse set_window_rect(i32, Gfx::IntRect const&) override;
     virtual Messages::WindowServer::GetWindowRectResponse get_window_rect(i32) override;
+    virtual Messages::WindowServer::GetWindowFloatingRectResponse get_window_floating_rect(i32) override;
     virtual void set_window_minimum_size(i32, Gfx::IntSize) override;
     virtual Messages::WindowServer::GetWindowMinimumSizeResponse get_window_minimum_size(i32) override;
     virtual Messages::WindowServer::GetAppletRectOnScreenResponse get_applet_rect_on_screen(i32) override;

--- a/Userland/Services/WindowServer/WindowServer.ipc
+++ b/Userland/Services/WindowServer/WindowServer.ipc
@@ -77,6 +77,8 @@ endpoint WindowServer
     set_window_rect(i32 window_id, Gfx::IntRect rect) => (Gfx::IntRect rect)
     get_window_rect(i32 window_id) => (Gfx::IntRect rect)
 
+    get_window_floating_rect(i32 window_id) => (Gfx::IntRect rect)
+
     set_window_minimum_size(i32 window_id, Gfx::IntSize size) =|
     get_window_minimum_size(i32 window_id) => (Gfx::IntSize size)
 


### PR DESCRIPTION
Previously, exiting a fullscreen application when
`save_size_and_position_on_close()` was used would lead to the application having an unexpectedly large size when it was reopened. 

Exiting a maximized application would lead to the restore button not working as expected when the application was reopened.

The following scenarios have been tested:

1. Open Maps.
2. Press F11 to toggle Full Screen.
3. Press Alt+Tab to select another window, then right click the Maps application on the taskbar and click Close to exit.
4. Relaunch Maps - previously, the application would start with a window larger than the screen.

and

1. Open Maps.
2. Toggle Maximize.
3. Exit Maps.
4. Relaunch Maps - previously, the application would start maximized, but the restore button would have no effect.