### PR TITLE
LibWeb: Boxes that establish FFC or GFC should avoid overlapping floats

### DIFF
--- a/Tests/LibWeb/Layout/expected/block-and-inline/flex-container-should-avoid-overlapping-floats.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/flex-container-should-avoid-overlapping-floats.txt
@@ -1,0 +1,23 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x66 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 400x50 children: not-inline
+      BlockContainer <div.right> at (370.890625,8) content-size 37.109375x17.46875 floating [BFC] children: inline
+        line 0 width: 37.109375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+          frag 0 from TextNode start: 0, length: 5, rect: [370.890625,8 37.109375x17.46875]
+            "right"
+        TextNode <#text>
+      Box <div.flex> at (8,8) content-size 362.890625x50 flex-container(row) [FFC] children: not-inline
+        BlockContainer <div.item> at (8,8) content-size 32.34375x50 flex-item [BFC] children: inline
+          line 0 width: 32.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 4, rect: [8,8 32.34375x17.46875]
+              "item"
+          TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x66]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 400x50]
+      PaintableWithLines (BlockContainer<DIV>.right) [370.890625,8 37.109375x17.46875]
+        TextPaintable (TextNode<#text>)
+      PaintableBox (Box<DIV>.flex) [8,8 362.890625x50]
+        PaintableWithLines (BlockContainer<DIV>.item) [8,8 32.34375x50]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/block-and-inline/grid-container-should-avoid-overlapping-floats.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/grid-container-should-avoid-overlapping-floats.txt
@@ -1,0 +1,16 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x66 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 400x50 children: not-inline
+      BlockContainer <div.right> at (370.890625,8) content-size 37.109375x17.46875 floating [BFC] children: inline
+        line 0 width: 37.109375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+          frag 0 from TextNode start: 0, length: 5, rect: [370.890625,8 37.109375x17.46875]
+            "right"
+        TextNode <#text>
+      Box <div.grid> at (8,8) content-size 362.890625x50 [GFC] children: not-inline
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x66]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 400x50]
+      PaintableWithLines (BlockContainer<DIV>.right) [370.890625,8 37.109375x17.46875]
+        TextPaintable (TextNode<#text>)
+      PaintableBox (Box<DIV>.grid) [8,8 362.890625x50]

--- a/Tests/LibWeb/Layout/input/block-and-inline/flex-container-should-avoid-overlapping-floats.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/flex-container-should-avoid-overlapping-floats.html
@@ -1,0 +1,14 @@
+<!doctype html><style>
+    * { outline: 1px solid black; }
+    body { width: 400px; }
+    .right {
+        float: right;
+        background: orange;
+    }
+    .flex { 
+        display: flex;
+        height: 50px;
+        background: wheat;
+    }
+    .item { background: pink; }
+</style><body><div class="right">right</div><div class="flex"><div class="item">item

--- a/Tests/LibWeb/Layout/input/block-and-inline/grid-container-should-avoid-overlapping-floats.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/grid-container-should-avoid-overlapping-floats.html
@@ -1,0 +1,13 @@
+<!doctype html><style>
+    * { outline: 1px solid black; }
+    body { width: 400px; }
+    .right {
+        float: right;
+        background: orange;
+    }
+    .grid {
+        display: grid;
+        height: 50px;
+        background: wheat;
+    }
+</style><body><div class="right">right</div><div class="grid">

--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.h
@@ -29,6 +29,7 @@ public:
     auto const& left_side_floats() const { return m_left_floats; }
     auto const& right_side_floats() const { return m_right_floats; }
 
+    bool box_should_avoid_floats_because_it_establishes_fc(Box const&);
     void compute_width(Box const&, AvailableSpace const&, LayoutMode = LayoutMode::Normal);
 
     // https://www.w3.org/TR/css-display/#block-formatting-context-root


### PR DESCRIPTION
Before, we only ensured that boxes establishing BFC did not overlap with floats because that is what CSS 2.2 specification says. However, we should also apply the same for boxes establishing FFC or GFC as this aligns with the behavior of other browsers.

Fixes https://github.com/SerenityOS/serenity/issues/21095