### PR TITLE
LibTest: Add support for randomized tests

### DIFF
--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -643,6 +643,7 @@ if (BUILD_LAGOM)
             LibMarkdown
             LibPDF
             LibSQL
+            LibTest
             LibTextCodec
             LibTTF
             LibTimeZone

--- a/Tests/LibTest/CMakeLists.txt
+++ b/Tests/LibTest/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(TEST_SOURCES
     TestNoCrash.cpp
+    TestGenerator.cpp
 )
 
 foreach(source IN LISTS TEST_SOURCES)

--- a/Tests/LibTest/TestGenerator.cpp
+++ b/Tests/LibTest/TestGenerator.cpp
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2023, Martin Janiczek <martin@janiczek.cz>.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/StdLibExtras.h>
+#include <LibTest/Randomized/Generator.h>
+#include <LibTest/TestCase.h>
+
+using namespace Test::Randomized;
+
+RANDOMIZED_TEST_CASE(unsigned_int_max_bounds)
+{
+    GEN(n, Gen::unsigned_int(10));
+    EXPECT(n <= 10);
+}
+
+RANDOMIZED_TEST_CASE(unsigned_int_min_max_bounds)
+{
+    GEN(n, Gen::unsigned_int(3, 6));
+    EXPECT(n >= 3 && n <= 6);
+}
+
+RANDOMIZED_TEST_CASE(assume)
+{
+    GEN(n, Gen::unsigned_int(10));
+    ASSUME(n % 2 == 0); // This will try to generate until it finds an even number
+    EXPECT(n % 2 == 0); // This will then succeed
+    // It will give up if the value doesn't pass the ASSUME(...) predicate 15 times in a row.
+}
+
+// TODO find a way to test that a test "unsigned_int(3) can't reach 0" fails
+// TODO find a way to test that a test "unsigned_int(3) can't reach 3" fails
+// TODO find a way to test that a test "unsigned_int(3,6) can't reach 3" fails
+// TODO find a way to test that a test "unsigned_int(3,6) can't reach 6" fails
+// TODO find a way to test that a test "unsigned_int(10) can reach n>10" fails
+
+RANDOMIZED_TEST_CASE(map_like)
+{
+    GEN(n1, Gen::unsigned_int(10));
+    GEN(n2, n1 * 2);
+    EXPECT(n2 % 2 == 0);
+}
+
+RANDOMIZED_TEST_CASE(bind_like)
+{
+    GEN(n1, Gen::unsigned_int(1, 9));
+    GEN(n2, Gen::unsigned_int(n1 * 10, n1 * 100));
+    EXPECT(n2 >= 10 && n2 <= 900);
+}
+
+// An example of an user-defined generator (for the test bind_vector_suboptimal).
+//
+// For why this is a suboptimal way to generate collections, see the comment in
+// Shrink::shrink_delete().
+//
+// TL;DR: this makes the length non-local to the items we're trying to delete
+// (except the first item).
+//
+// There's a better way: flip a (biased) coin to decide whether to generate
+// a next item. That makes each item much better shrinkable, since its
+// contribution to the sequence length (a boolean 0 or 1) is right next to its
+// own data.
+//
+// Because it's a pretty natural way to do this, we take special care in the
+// internal shrinker to work well on this style too.
+template<typename FN>
+Vector<InvokeResult<FN>> vector_suboptimal(FN item_gen)
+{
+    u32 length = Gen::unsigned_int(5);
+    Vector<InvokeResult<FN>> acc;
+    for (u32 i = 0; i < length; ++i) {
+        acc.append(item_gen());
+    }
+    return acc;
+}
+
+RANDOMIZED_TEST_CASE(bind_vector_suboptimal)
+{
+    u32 max_item = 5;
+    GEN(vec, vector_suboptimal([&]() { return Gen::unsigned_int(max_item); }));
+    u32 sum = 0;
+    for (u32 n : vec) {
+        sum += n;
+    }
+    EXPECT(sum <= vec.size() * max_item);
+}
+
+RANDOMIZED_TEST_CASE(vector)
+{
+    u32 max_item = 5;
+    GEN(vec, Gen::vector([&]() { return Gen::unsigned_int(max_item); }));
+    EXPECT(vec.size() <= 32);
+}
+
+RANDOMIZED_TEST_CASE(vector_length)
+{
+    u32 max_item = 5;
+    GEN(vec, Gen::vector(3, [&]() { return Gen::unsigned_int(max_item); }));
+    EXPECT(vec.size() == 3);
+}
+
+RANDOMIZED_TEST_CASE(vector_min_max)
+{
+    u32 max_item = 5;
+    GEN(vec, Gen::vector(1, 4, [&]() { return Gen::unsigned_int(max_item); }));
+    EXPECT(vec.size() >= 1 && vec.size() <= 4);
+}
+
+RANDOMIZED_TEST_CASE(weighted_boolean_below0)
+{
+    GEN(b, Gen::weighted_boolean(-0.5));
+    EXPECT(b == false);
+}
+
+RANDOMIZED_TEST_CASE(weighted_boolean_0)
+{
+    GEN(b, Gen::weighted_boolean(0));
+    EXPECT(b == false);
+}
+
+RANDOMIZED_TEST_CASE(weighted_boolean_1)
+{
+    GEN(b, Gen::weighted_boolean(1));
+    EXPECT(b == true);
+}
+
+RANDOMIZED_TEST_CASE(weighted_boolean_above1)
+{
+    GEN(b, Gen::weighted_boolean(1.5));
+    EXPECT(b == true);
+}
+
+RANDOMIZED_TEST_CASE(weighted_boolean_fair_true)
+{
+    GEN(b, Gen::weighted_boolean(0.5));
+    ASSUME(b == true);
+    EXPECT(b == true);
+}
+
+RANDOMIZED_TEST_CASE(weighted_boolean_fair_false)
+{
+    GEN(b, Gen::weighted_boolean(0.5));
+    ASSUME(b == false);
+    EXPECT(b == false);
+}
+
+RANDOMIZED_TEST_CASE(boolean_true)
+{
+    GEN(b, Gen::boolean());
+    ASSUME(b == true);
+    EXPECT(b == true);
+}
+
+RANDOMIZED_TEST_CASE(boolean_false)
+{
+    GEN(b, Gen::boolean());
+    ASSUME(b == false);
+    EXPECT(b == false);
+}
+
+RANDOMIZED_TEST_CASE(frequency_int)
+{
+    GEN(x, Gen::frequency(Gen::Choice { 5, 'x' }, Gen::Choice { 1, 'o' }));
+    ASSUME(x == 'x');
+    EXPECT(x == 'x');
+}

--- a/Userland/Libraries/LibTest/Macros.h
+++ b/Userland/Libraries/LibTest/Macros.h
@@ -109,6 +109,25 @@ void disable_reporting();
 
 #define EXPECT_APPROXIMATE(a, b) EXPECT_APPROXIMATE_WITH_ERROR(a, b, 0.0000005)
 
+#define REJECT(message)                                                \
+    do {                                                               \
+        if (::Test::is_reporting_enabled())                            \
+            ::AK::warnln("\033[31;1mREJECTED\033[0m: {}:{}: {}",       \
+                __FILE__, __LINE__, #message);                         \
+        ::Test::set_current_test_result(::Test::TestResult::Rejected); \
+    } while (false)
+
+#define ASSUME(x)                                                                                                      \
+    do {                                                                                                               \
+        if (!(x)) {                                                                                                    \
+            if (::Test::is_reporting_enabled())                                                                        \
+                ::AK::warnln("\033[31;1mREJECTED\033[0m: {}:{}: Couldn't generate random value satisfying ASSUME({})", \
+                    __FILE__, __LINE__, #x);                                                                           \
+            ::Test::set_current_test_result(::Test::TestResult::Rejected);                                             \
+            return;                                                                                                    \
+        }                                                                                                              \
+    } while (false)
+
 #define FAIL(message)                                                                      \
     do {                                                                                   \
         if (::Test::is_reporting_enabled())                                                \

--- a/Userland/Libraries/LibTest/Macros.h
+++ b/Userland/Libraries/LibTest/Macros.h
@@ -11,6 +11,7 @@
 #include <AK/CheckedFormatString.h>
 #include <AK/Math.h>
 #include <LibTest/CrashTest.h>
+#include <LibTest/Randomized/RandomnessSource.h>
 #include <LibTest/TestResult.h>
 
 namespace AK {
@@ -22,6 +23,9 @@ namespace Test {
 // Declare helpers so that we can call them from VERIFY in included headers
 // the setter for TestResult is already declared in TestResult.h
 TestResult current_test_result();
+
+Randomized::RandomnessSource& randomness_source();
+void set_randomness_source(Randomized::RandomnessSource);
 }
 
 #define EXPECT_EQ(a, b)                                                                                                                                                                      \

--- a/Userland/Libraries/LibTest/Macros.h
+++ b/Userland/Libraries/LibTest/Macros.h
@@ -26,59 +26,71 @@ TestResult current_test_result();
 
 Randomized::RandomnessSource& randomness_source();
 void set_randomness_source(Randomized::RandomnessSource);
+
+bool is_reporting_enabled();
+void enable_reporting();
+void disable_reporting();
 }
 
-#define EXPECT_EQ(a, b)                                                                                                                                                                      \
-    do {                                                                                                                                                                                     \
-        auto lhs = (a);                                                                                                                                                                      \
-        auto rhs = (b);                                                                                                                                                                      \
-        if (lhs != rhs) {                                                                                                                                                                    \
-            ::AK::warnln("\033[31;1mFAIL\033[0m: {}:{}: EXPECT_EQ({}, {}) failed with lhs={} and rhs={}", __FILE__, __LINE__, #a, #b, FormatIfSupported { lhs }, FormatIfSupported { rhs }); \
-            ::Test::set_current_test_result(::Test::TestResult::Failed);                                                                                                                     \
-        }                                                                                                                                                                                    \
+#define EXPECT_EQ(a, b)                                                                                       \
+    do {                                                                                                      \
+        auto lhs = (a);                                                                                       \
+        auto rhs = (b);                                                                                       \
+        if (lhs != rhs) {                                                                                     \
+            if (::Test::is_reporting_enabled())                                                               \
+                ::AK::warnln("\033[31;1mFAIL\033[0m: {}:{}: EXPECT_EQ({}, {}) failed with lhs={} and rhs={}", \
+                    __FILE__, __LINE__, #a, #b, FormatIfSupported { lhs }, FormatIfSupported { rhs });        \
+            ::Test::set_current_test_result(::Test::TestResult::Failed);                                      \
+        }                                                                                                     \
     } while (false)
 
-#define EXPECT_EQ_TRUTH(a, b)                                                                                             \
-    do {                                                                                                                  \
-        auto lhs = (a);                                                                                                   \
-        auto rhs = (b);                                                                                                   \
-        bool ltruth = static_cast<bool>(lhs);                                                                             \
-        bool rtruth = static_cast<bool>(rhs);                                                                             \
-        if (ltruth != rtruth) {                                                                                           \
-            ::AK::warnln("\033[31;1mFAIL\033[0m: {}:{}: EXPECT_EQ_TRUTH({}, {}) failed with lhs={} ({}) and rhs={} ({})", \
-                __FILE__, __LINE__, #a, #b, FormatIfSupported { lhs }, ltruth, FormatIfSupported { rhs }, rtruth);        \
-            ::Test::set_current_test_result(::Test::TestResult::Failed);                                                  \
-        }                                                                                                                 \
+#define EXPECT_EQ_TRUTH(a, b)                                                                                                 \
+    do {                                                                                                                      \
+        auto lhs = (a);                                                                                                       \
+        auto rhs = (b);                                                                                                       \
+        bool ltruth = static_cast<bool>(lhs);                                                                                 \
+        bool rtruth = static_cast<bool>(rhs);                                                                                 \
+        if (ltruth != rtruth) {                                                                                               \
+            if (::Test::is_reporting_enabled())                                                                               \
+                ::AK::warnln("\033[31;1mFAIL\033[0m: {}:{}: EXPECT_EQ_TRUTH({}, {}) failed with lhs={} ({}) and rhs={} ({})", \
+                    __FILE__, __LINE__, #a, #b, FormatIfSupported { lhs }, ltruth, FormatIfSupported { rhs }, rtruth);        \
+            ::Test::set_current_test_result(::Test::TestResult::Failed);                                                      \
+        }                                                                                                                     \
     } while (false)
 
 // If you're stuck and `EXPECT_EQ` seems to refuse to print anything useful,
 // try this: It'll spit out a nice compiler error telling you why it doesn't print.
-#define EXPECT_EQ_FORCE(a, b)                                                                                                                    \
-    do {                                                                                                                                         \
-        auto lhs = (a);                                                                                                                          \
-        auto rhs = (b);                                                                                                                          \
-        if (lhs != rhs) {                                                                                                                        \
-            ::AK::warnln("\033[31;1mFAIL\033[0m: {}:{}: EXPECT_EQ({}, {}) failed with lhs={} and rhs={}", __FILE__, __LINE__, #a, #b, lhs, rhs); \
-            ::Test::set_current_test_result(::Test::TestResult::Failed);                                                                         \
-        }                                                                                                                                        \
+#define EXPECT_EQ_FORCE(a, b)                                                                                 \
+    do {                                                                                                      \
+        auto lhs = (a);                                                                                       \
+        auto rhs = (b);                                                                                       \
+        if (lhs != rhs) {                                                                                     \
+            if (::Test::is_reporting_enabled())                                                               \
+                ::AK::warnln("\033[31;1mFAIL\033[0m: {}:{}: EXPECT_EQ({}, {}) failed with lhs={} and rhs={}", \
+                    __FILE__, __LINE__, #a, #b, lhs, rhs);                                                    \
+            ::Test::set_current_test_result(::Test::TestResult::Failed);                                      \
+        }                                                                                                     \
     } while (false)
 
-#define EXPECT_NE(a, b)                                                                                                                                                                      \
-    do {                                                                                                                                                                                     \
-        auto lhs = (a);                                                                                                                                                                      \
-        auto rhs = (b);                                                                                                                                                                      \
-        if (lhs == rhs) {                                                                                                                                                                    \
-            ::AK::warnln("\033[31;1mFAIL\033[0m: {}:{}: EXPECT_NE({}, {}) failed with lhs={} and rhs={}", __FILE__, __LINE__, #a, #b, FormatIfSupported { lhs }, FormatIfSupported { rhs }); \
-            ::Test::set_current_test_result(::Test::TestResult::Failed);                                                                                                                     \
-        }                                                                                                                                                                                    \
+#define EXPECT_NE(a, b)                                                                                       \
+    do {                                                                                                      \
+        auto lhs = (a);                                                                                       \
+        auto rhs = (b);                                                                                       \
+        if (lhs == rhs) {                                                                                     \
+            if (::Test::is_reporting_enabled())                                                               \
+                ::AK::warnln("\033[31;1mFAIL\033[0m: {}:{}: EXPECT_NE({}, {}) failed with lhs={} and rhs={}", \
+                    __FILE__, __LINE__, #a, #b, FormatIfSupported { lhs }, FormatIfSupported { rhs });        \
+            ::Test::set_current_test_result(::Test::TestResult::Failed);                                      \
+        }                                                                                                     \
     } while (false)
 
-#define EXPECT(x)                                                                                    \
-    do {                                                                                             \
-        if (!(x)) {                                                                                  \
-            ::AK::warnln("\033[31;1mFAIL\033[0m: {}:{}: EXPECT({}) failed", __FILE__, __LINE__, #x); \
-            ::Test::set_current_test_result(::Test::TestResult::Failed);                             \
-        }                                                                                            \
+#define EXPECT(x)                                                                                        \
+    do {                                                                                                 \
+        if (!(x)) {                                                                                      \
+            if (::Test::is_reporting_enabled())                                                          \
+                ::AK::warnln("\033[31;1mFAIL\033[0m: {}:{}: EXPECT({}) failed", __FILE__, __LINE__, #x); \
+            ::Test::set_current_test_result(::Test::TestResult::Failed);                                 \
+        }                                                                                                \
     } while (false)
 
 #define EXPECT_APPROXIMATE_WITH_ERROR(a, b, err)                                                                \
@@ -87,19 +99,21 @@ void set_randomness_source(Randomized::RandomnessSource);
         auto expect_close_rhs = b;                                                                              \
         auto expect_close_diff = static_cast<double>(expect_close_lhs) - static_cast<double>(expect_close_rhs); \
         if (AK::fabs(expect_close_diff) > (err)) {                                                              \
-            ::AK::warnln("\033[31;1mFAIL\033[0m: {}:{}: EXPECT_APPROXIMATE({}, {})"                             \
-                         " failed with lhs={}, rhs={}, (lhs-rhs)={}",                                           \
-                __FILE__, __LINE__, #a, #b, expect_close_lhs, expect_close_rhs, expect_close_diff);             \
+            if (::Test::is_reporting_enabled())                                                                 \
+                ::AK::warnln("\033[31;1mFAIL\033[0m: {}:{}: EXPECT_APPROXIMATE({}, {})"                         \
+                             " failed with lhs={}, rhs={}, (lhs-rhs)={}",                                       \
+                    __FILE__, __LINE__, #a, #b, expect_close_lhs, expect_close_rhs, expect_close_diff);         \
             ::Test::set_current_test_result(::Test::TestResult::Failed);                                        \
         }                                                                                                       \
     } while (false)
 
 #define EXPECT_APPROXIMATE(a, b) EXPECT_APPROXIMATE_WITH_ERROR(a, b, 0.0000005)
 
-#define FAIL(message)                                                                  \
-    do {                                                                               \
-        ::AK::warnln("\033[31;1mFAIL\033[0m: {}:{}: {}", __FILE__, __LINE__, message); \
-        ::Test::set_current_test_result(::Test::TestResult::Failed);                   \
+#define FAIL(message)                                                                      \
+    do {                                                                                   \
+        if (::Test::is_reporting_enabled())                                                \
+            ::AK::warnln("\033[31;1mFAIL\033[0m: {}:{}: {}", __FILE__, __LINE__, message); \
+        ::Test::set_current_test_result(::Test::TestResult::Failed);                       \
     } while (false)
 
 // To use, specify the lambda to execute in a sub process and verify it exits:

--- a/Userland/Libraries/LibTest/Randomized/Chunk.h
+++ b/Userland/Libraries/LibTest/Randomized/Chunk.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2023, Martin Janiczek <martin@janiczek.cz>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Format.h>
+#include <AK/String.h>
+
+namespace Test {
+namespace Randomized {
+
+// Chunk is a description of a RandomRun slice.
+// Used to say which part of a given RandomRun will be shrunk by some
+// ShrinkCommand.
+//
+// For a RandomRun [0,1,2,3,4,5,6,7,8], the Chunk{size=4, index=2} means this:
+//                 [_,_,X,X,X,X,_,_,_]
+//
+// Different ShrinkCommands will use the Chunk in different ways.
+// A few examples:
+//
+//     Original RandomRun:             [5,1,3,9,4,2,3,0]
+//     Chunk we'll show off:           [_,_,X,X,X,X,_,_]
+//
+//     ZeroChunk:                      [5,1,0,0,0,0,3,0]
+//     SortChunk:                      [5,1,2,3,4,9,3,0]
+//     DeleteChunkAndMaybeDecPrevious: [5,1,        3,0]
+struct Chunk {
+    // Possible sizes: 1,2,3,4,8
+    u8 size = 0;
+    size_t index = 0;
+};
+
+} // namespace Randomized
+} // namespace Test
+
+template<>
+struct AK::Formatter<Test::Randomized::Chunk> : Formatter<StringView> {
+    ErrorOr<void> format(FormatBuilder& builder, Test::Randomized::Chunk chunk)
+    {
+        return Formatter<StringView>::format(builder, TRY(String::formatted("Chunk<size={}, i={}>", chunk.size, chunk.index)));
+    }
+};

--- a/Userland/Libraries/LibTest/Randomized/Generator.h
+++ b/Userland/Libraries/LibTest/Randomized/Generator.h
@@ -1,0 +1,333 @@
+/*
+ * Copyright (c) 2023, Martin Janiczek <martin@janiczek.cz>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibTest/Macros.h>
+#include <LibTest/Randomized/RandomRun.h>
+
+#include <AK/Function.h>
+#include <AK/Random.h>
+#include <AK/String.h>
+#include <AK/StringView.h>
+#include <AK/Tuple.h>
+
+namespace Test {
+namespace Randomized {
+
+// Returns a random double value in range 0..1.
+inline double get_random_probability()
+{
+    static constexpr u32 max_u32 = NumericLimits<u32>::max();
+    u32 random_u32 = AK::get_random_uniform(max_u32);
+    return static_cast<double>(random_u32) / static_cast<double>(max_u32);
+}
+
+// Generators take random bits from the RandomnessSource and return a value
+// back.
+//
+// Example:
+// - Gen::u32(5,10) --> 9, 7, 5, 10, 8, ...
+namespace Gen {
+
+// An unsigned integer generator.
+//
+// The minimum value will always be 0.
+// The maximum value is given by user in the argument.
+//
+// Gen::unsigned_int(10) -> value 5, RandomRun [5]
+//                       -> value 8, RandomRun [8]
+//                       etc.
+//
+// Shrinks towards 0.
+inline u32 unsigned_int(u32 max)
+{
+    u32 random = Test::randomness_source().draw_value(max, [&]() {
+        return AK::get_random_uniform(max + 1);
+    });
+    return random;
+}
+
+// An unsigned integer generator in a particular range.
+//
+// Gen::unsigned_int(3,10) -> value 3,  RandomRun [0]
+//                         -> value 8,  RandomRun [5]
+//                         -> value 10, RandomRun [7]
+//                         etc.
+//
+// In case `min == max`, the RandomRun footprint will be smaller, as we'll
+// switch to a `constant` and won't need any randomness to generate that
+// value:
+//
+// Gen::unsigned_int(3,3) -> value 3, RandomRun [] (always)
+//
+// Shrinks towards the smaller argument.
+inline u32 unsigned_int(u32 min, u32 max)
+{
+    VERIFY(max >= min);
+    if (min == max) {
+        return min;
+    }
+    return unsigned_int(max - min) + min;
+}
+
+// Randomly (uniformly) selects a value out of the given arguments.
+//
+// Gen::one_of(20,5,10) --> value 20, RandomRun [0]
+//                      --> value 5,  RandomRun [1]
+//                      --> value 10, RandomRun [2]
+//
+// Shrinks towards the earlier arguments (above, towards 20).
+template<typename... Ts>
+requires(sizeof...(Ts) > 0)
+CommonType<Ts...> one_of(Ts... choices)
+{
+    Vector<CommonType<Ts...>> choices_vec { choices... };
+
+    constexpr size_t count = sizeof...(choices);
+    size_t i = unsigned_int(count - 1);
+    return choices_vec[i];
+}
+
+template<typename T>
+struct Choice {
+    i32 weight;
+    T value;
+};
+// Workaround for clang bug fixed in clang 17
+template<typename T>
+Choice(i32, T) -> Choice<T>;
+
+// Randomly (uniformly) selects a value out of the given weighted arguments.
+//
+// Gen::frequency(
+//   Gen::Choice {5,999},
+//   Gen::Choice {1,111},
+// )
+//     --> value 999 (5 out of 6 times), RandomRun [0]
+//     --> value 111 (1 out of 6 times), RandomRun [1]
+//
+// Shrinks towards the earlier arguments (above, towards 'x').
+template<typename... Ts>
+requires(sizeof...(Ts) > 0)
+CommonType<Ts...> frequency(Choice<Ts>... choices)
+{
+    Vector<Choice<CommonType<Ts...>>> choices_vec { choices... };
+
+    u32 sum = 0;
+    for (auto const& choice : choices_vec) {
+        VERIFY(choice.weight > 0);
+        sum += static_cast<u32>(choice.weight);
+    }
+
+    u32 target = unsigned_int(sum);
+    size_t i = 0;
+    for (auto const& choice : choices_vec) {
+        u32 weight = static_cast<u32>(choice.weight);
+        if (weight >= target) {
+            return choice.value;
+        }
+        target -= weight;
+        ++i;
+    }
+    return choices_vec[i - 1].value;
+}
+
+// An unsigned integer generator in the full u32 range.
+//
+// 8/17 (47%) of the time it will bias towards 8bit numbers,
+// 4/17 (23%) towards 4bit numbers,
+// 2/17 (12%) towards 16bit numbers,
+// 1/17 (6%) towards 32bit numbers,
+// 2/17 (12%) towards edge cases like 0 and NumericLimits::max() of various unsigned int types.
+//
+// Gen::unsigned_int() -> value 3,     RandomRun [0,3]
+//                     -> value 8,     RandomRun [1,8]
+//                     -> value 100,   RandomRun [2,100]
+//                     -> value 5,     RandomRun [3,5]
+//                     -> value 255,   RandomRun [4,1]
+//                     -> value 65535, RandomRun [4,2]
+//                     etc.
+//
+// Shrinks towards 0.
+inline u32 unsigned_int()
+{
+    u32 bits = frequency(
+        // weight, bits
+        Choice { 4, 4 },
+        Choice { 8, 8 },
+        Choice { 2, 16 },
+        Choice { 1, 32 },
+        Choice { 2, 0 });
+
+    // The special cases go last as they can be the most extreme (large) values.
+
+    if (bits == 0) {
+        // Special cases, eg. max integers for u8, u16, u32.
+        return one_of(
+            0U,
+            NumericLimits<u8>::max(),
+            NumericLimits<u16>::max(),
+            NumericLimits<u32>::max());
+    }
+
+    u32 max = (bits == 32)
+        ? NumericLimits<u32>::max()
+        : ((u64)1 << bits) - 1;
+    return unsigned_int(max);
+}
+
+// A generator returning `true` with the given `probability` (0..1).
+//
+// If probability <= 0, doesn't use any randomness and returns false.
+// If probability >= 1, doesn't use any randomness and returns true.
+//
+// In general case:
+// Gen::weighted_boolean(0.75)
+//   -> value false, RandomRun [0]
+//   -> value true,  RandomRun [1]
+//
+// Shrinks towards false.
+inline bool weighted_boolean(double probability)
+{
+    if (probability <= 0)
+        return false;
+    if (probability >= 1)
+        return true;
+
+    u32 random_int = Test::randomness_source().draw_value(1, [&]() {
+        double drawn_probability = get_random_probability();
+        return drawn_probability <= probability ? 1 : 0;
+    });
+    bool random_bool = random_int == 1;
+    return random_bool;
+}
+
+// A (fair) boolean generator.
+//
+// Gen::boolean()
+//   -> value false, RandomRun [0]
+//   -> value true,  RandomRun [1]
+//
+// Shrinks towards false.
+inline bool boolean()
+{
+    return weighted_boolean(0.5);
+}
+
+// A vector generator of a random length between the given limits.
+//
+// Gen::vector(2,3,[]() { return Gen::unsigned_int(5); })
+//   -> value [1,5],      RandomRun [1,1,1,5,0]
+//   -> value [1,5,0],    RandomRun [1,1,1,5,1,0,0]
+//   etc.
+//
+// In case `min == max`, the RandomRun footprint will be smaller, as there will
+// be no randomness involved in figuring out the length:
+//
+// Gen::vector(3,3,[]() { return Gen::unsigned_int(5); })
+//   -> value [1,3], RandomRun [1,3]
+//   -> value [5,2], RandomRun [5,2]
+//   etc.
+//
+// Shrinks towards shorter vectors, with simpler elements inside.
+template<typename Fn>
+inline Vector<InvokeResult<Fn>> vector(size_t min, size_t max, Fn item_gen)
+{
+    VERIFY(max >= min);
+
+    size_t size = 0;
+    Vector<InvokeResult<Fn>> acc;
+
+    // Special case: no randomness for the boolean
+    if (min == max) {
+        while (size < min) {
+            acc.append(item_gen());
+            ++size;
+        }
+        return acc;
+    }
+
+    // General case: before each item we "flip a coin" to decide whether to
+    // generate another one.
+    //
+    // This algorithm is used instead of the more intuitive "generate length,
+    // then generate that many items" algorithm, because it produces RandomRun
+    // patterns that shrink more easily.
+    //
+    // See the Hypothesis paper [1], section 3.3, around the paragraph starting
+    // with "More commonly".
+    //
+    // [1]: https://drops.dagstuhl.de/opus/volltexte/2020/13170/pdf/LIPIcs-ECOOP-2020-13.pdf
+    while (size < min) {
+        acc.append(item_gen());
+        ++size;
+    }
+
+    double average = static_cast<double>(min + max) / 2.0;
+    VERIFY(average > 0);
+
+    // A geometric distribution: https://en.wikipedia.org/wiki/Geometric_distribution#Moments_and_cumulants
+    // The below derives from the E(X) = 1/p formula.
+    //
+    // We need to flip the `p` to `1-p` as our success ("another item!") is
+    // a "failure" in the geometric distribution's interpretation ("we fail X
+    // times before succeeding the first time").
+    //
+    // That gives us `1 - 1/p`. Then, E(X) also contains the final success, so we
+    // need to say `1 + average` instead of `average`, as it will mean "our X
+    // items + the final failure that stops the process".
+    double probability = 1.0 - 1.0 / (1.0 + average);
+
+    while (size < max) {
+        if (weighted_boolean(probability)) {
+            acc.append(item_gen());
+            ++size;
+        } else {
+            break;
+        }
+    }
+
+    return acc;
+}
+
+// A vector generator of a given length.
+//
+// Gen::vector_of_length(3,[]() { return Gen::unsigned_int(5); })
+//   -> value [1,5,0],    RandomRun [1,1,1,5,1,0,0]
+//   -> value [2,9,3],    RandomRun [1,2,1,9,1,3,0]
+//   etc.
+//
+// Shrinks towards shorter vectors, with simpler elements inside.
+template<typename Fn>
+inline Vector<InvokeResult<Fn>> vector(size_t length, Fn item_gen)
+{
+    return vector(length, length, item_gen);
+}
+
+// A vector generator of a random length between 0 and 32 elements.
+//
+// If you need a different length, use vector(max,item_gen) or
+// vector(min,max,item_gen).
+//
+// Gen::vector([]() { return Gen::unsigned_int(5); })
+//   -> value [],         RandomRun [0]
+//   -> value [1],        RandomRun [1,1,0]
+//   -> value [1,5],      RandomRun [1,1,1,5,0]
+//   -> value [1,5,0],    RandomRun [1,1,1,5,1,0,0]
+//   -> value [1,5,0,2],  RandomRun [1,1,1,5,1,0,1,2,0]
+//   etc.
+//
+// Shrinks towards shorter vectors, with simpler elements inside.
+template<typename Fn>
+inline Vector<InvokeResult<Fn>> vector(Fn item_gen)
+{
+    return vector(0, 32, item_gen);
+}
+
+} // namespace Gen
+} // namespace Randomized
+} // namespace Test

--- a/Userland/Libraries/LibTest/Randomized/README.md
+++ b/Userland/Libraries/LibTest/Randomized/README.md
@@ -1,0 +1,119 @@
+# LibTest/Randomized
+
+Classes in this folder implement a randomized ("property based") testing library
+for SerenityOS.
+
+## Example
+
+```cpp
+RANDOMIZED_TEST_CASE(addition_commutative)
+{
+    GEN(int_a, Gen::unsigned_int());
+    GEN(int_b, Gen::unsigned_int());
+    CSSPixels a(int_a);
+    CSSPixels b(int_b);
+    EXPECT_EQ(a + b, b + a);
+}
+```
+
+The runner will then run the test case many times, with random data in each of
+the `GEN`'d variables. If it finds any set of values where the expectation fails,
+it shrinks it to a minimal failing example and presents it to the user:
+
+```
+Running test 'addition_commutative'.
+int_a = 0
+int_b = 1
+FAIL: /.../SomeTest.cpp:26: EXPECT_EQ(a + b, b + a) failed with lhs=0 and rhs=1
+Failed test 'addition_commutative' in 0ms
+```
+
+(Note that the runner most likely started out with much larger values like
+1587197 and 753361. The 0 and 1 are the shrunk, minimal values.)
+
+In the above case, the test runner tells us that `CSSPixels(0) + CSSPixels(1)`
+wasn't equal to `CSSPixels(1) + CSSPixels(0)`.
+
+> [!NOTE]
+> I made this failing example up. Don't worry, `CSSPixels` is fine :^)
+
+## Property based testing?
+
+Property based testing (PBT) involves generating random test inputs and checking
+that they satisfy certain properties. This allows testing a large number of
+possible cases automatically, and is exceptionally good at finding edge cases.
+
+When a failure is found, it's automatically shrunk to a minimal reproducing
+case. (This is good, because random values contain a lot of unimportant details
+that only hamper understanding of the root cause. See http://sscce.org)
+
+This particular implementation belongs to the "internal shrinking" family of PBT
+libraries (Hypothesis, minithesis, elm-test, ...). This is important for the DX
+as it gives the most resilient shrinkers without any user effort, compared to
+the "integrated shrinking" lazy-tree based implementations (Hedgehog etc.) or
+the manual shrinking ones (original QuickCheck etc.). (More information in this
+talk: https://www.youtube.com/watch?v=WE5bmt0zBxg)
+
+## Implementation
+
+On a very high level, the PBT runner remembers the random bits (`RandomRun`)
+used when generating the random value, and when it finds a value that fails the
+user's test, instead of trying to shrink the generated value it tries to shrink
+these random bits and then generate a new value from them. 
+
+This makes shrinking work automatically on any data you might want to generate.
+
+Generators are implemented in such a way that a smaller/shorter `RandomRun` will
+result in a simpler generated value.
+
+If the new RandomRun can be successfully turned into a value and if the test
+still fails on that new simpler value, we keep the RandomRun as our new best and
+try again. Once we can't improve things anymore, we turn on error reporting, run
+the test one last time with the final RandomRun, and report the failing value to
+the user.
+
+## Code organization
+
+- `TestResult.h`
+  - Defines an enum class TestResult.
+    This expands the typical "passed / failed": we also need to care about
+    a generator rejecting a RandomRun (eg. when the user calls the ASSUME(...)
+    macro with a predicate that can't be satisfied).
+
+- `Generator.h`
+  - Contains generators: fns of shape T(), eg. `u32 Gen::unsigned_int(u32 max)`
+    - These implicitly depend on a RandomnessSource held by the singleton
+      TestSuite.
+  - These can be called directly, but the top-level use by the user should always
+    happen via the GEN(...) macro which makes sure the generated value gets
+    logged to the user in case of a failure.
+  - Example:
+    `Gen::vector(1, 4, []() { return Gen::unsigned_int(5); })`
+    generates vectors of length between 1 and 4, of unsigned ints in range 0..5.
+    Eg. `{2,5,3}`, `{0}`, `{1,5,5,2}`.
+
+- `RandomnessSource.h`
+  - A source of random bits.
+  - There are two variants of `RandomnessSource`:
+    - Live: gives `AK/Random` u32 values and remembers them into a `RandomRun`
+    - Recorded: gives (replays) u32 values from a static `RandomRun`
+
+- `RandomRun.h`
+  - A finite sequence of random bits (in practice, `u32`s).
+  - Example: `{2,5,0,11,8,0,0,1}`
+
+- `ShrinkCommand.h`
+  - A high-level recipe for how to try and minimize a given `RandomRun`.
+  - For example, "zero this contiguous chunk of it" or "minimize the number on
+    this index using binary search".
+  - These later get interpreted by the PBT runner on a specific `RandomRun`.
+
+- `Chunk.h`
+  - A description of a contiguous `RandomRun` slice.
+  - Example: `Chunk{size = 4, index = 2}`:  [_,_,X,X,X,X,...]
+
+- `Shrink.h`
+  - Algorithms for interpreting `ShrinkCommand`s and the main shrinking loop
+
+- `TestCase.h`
+  - The `TestCase::randomized(...)` function contains the main testing loop

--- a/Userland/Libraries/LibTest/Randomized/RandomRun.h
+++ b/Userland/Libraries/LibTest/Randomized/RandomRun.h
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2023, Martin Janiczek <martin@janiczek.cz>.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/QuickSort.h>
+#include <AK/Vector.h>
+#include <LibTest/Randomized/Chunk.h>
+
+namespace Test {
+namespace Randomized {
+
+// RandomRun is a record of random bits used in generation of random values.
+// Once a value failing user test is found, we then attempt to shrink its
+// RandomRun using various ShrinkCommands.
+//
+// This means that we construct new RandomRuns by saying "OK, but what if the
+// PRNG gave you 0 instead of 23 that time..." The runner then tries to
+// generate a new value from the new RandomRun; if it succeeds and the value
+// still fails the test, we've shrunk our counterexample some!
+//
+// RandomRun is conceptually a sequence of unsigned integers, e.g.
+// [5,3,10,8,0,0,1].
+class RandomRun {
+public:
+    RandomRun() = default;
+    RandomRun(RandomRun const& rhs) = default;
+    RandomRun& operator=(RandomRun const& rhs) = default;
+    explicit RandomRun(Vector<u32> const& data)
+        : m_data(move(data))
+    {
+    }
+    bool is_empty() const { return m_data.is_empty(); }
+    bool contains_chunk(Chunk const& c) const { return c.index + c.size <= m_data.size(); }
+    void append(u32 n) { m_data.append(n); }
+    size_t size() const { return m_data.size(); }
+    Optional<u32> next()
+    {
+        if (m_current_index < m_data.size()) {
+            return m_data[m_current_index++];
+        }
+        return Optional<u32> {};
+    }
+    u32& operator[](size_t index) { return m_data[index]; }
+    u32 const& operator[](size_t index) const { return m_data[index]; }
+    Vector<u32> data() const { return m_data; }
+
+    // Shortlex sorting
+    //
+    // This is the metric by which we try to minimize (shrink) the sequence of
+    // random choices, from which we later generate values.
+    //
+    // Shorter is better; if the length is equal then lexicographic order is
+    // used. See [paper], section 2.2.
+    //
+    // Examples:
+    // [9,9,9] < [0,0,0,0] (shorter is better)
+    // [8,9,9] < [9,0,0] (lexicographic ordering: numbers that appear earlier
+    //                    are more "important" than numbers that follow them)
+    //
+    // [paper]: https://drops.dagstuhl.de/opus/volltexte/2020/13170/
+    bool is_shortlex_smaller_than(RandomRun const& rhs) const
+    {
+        auto lhs_size = size();
+        auto rhs_size = rhs.size();
+
+        if (lhs_size < rhs_size)
+            return true;
+
+        if (lhs_size > rhs_size)
+            return false;
+
+        for (size_t i = 0; i < lhs_size; i++) {
+            if (m_data[i] < rhs.m_data[i])
+                return true;
+
+            if (m_data[i] > rhs.m_data[i])
+                return false;
+        }
+        return false;
+    }
+
+    RandomRun with_sorted(Chunk c) const
+    {
+        Vector<u32> new_data = m_data;
+        AK::dual_pivot_quick_sort(
+            new_data,
+            c.index,
+            c.index + c.size - 1,
+            [](auto& a, auto& b) { return a < b; });
+        return RandomRun(move(new_data));
+    }
+    RandomRun with_deleted(Chunk c) const
+    {
+        Vector<u32> new_data(m_data);
+        new_data.remove(c.index, c.size);
+        return RandomRun(move(new_data));
+    }
+
+private:
+    Vector<u32> m_data;
+    size_t m_current_index = 0;
+};
+
+} // namespace Randomized
+} // namespace Test
+
+template<>
+struct AK::Formatter<Test::Randomized::RandomRun> : Formatter<StringView> {
+    ErrorOr<void> format(FormatBuilder& builder, Test::Randomized::RandomRun run)
+    {
+        return Formatter<StringView>::format(builder, TRY(String::formatted("[{}]"sv, TRY(String::join(',', run.data(), "{}"sv)))));
+    }
+};

--- a/Userland/Libraries/LibTest/Randomized/RandomnessSource.h
+++ b/Userland/Libraries/LibTest/Randomized/RandomnessSource.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2023, Martin Janiczek <martin@janiczek.cz>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Function.h>
+#include <LibTest/Randomized/RandomRun.h>
+#include <LibTest/TestResult.h>
+
+namespace Test {
+namespace Randomized {
+
+// RandomnessSource provides random bits to Generators.
+//
+// If it's live, a PRNG will be used and the random values will be recorded into
+// its RandomRun.
+//
+// If it's recorded, its RandomRun will be used to "mock" the PRNG. This allows
+// us to replay the generation of a particular value, and to test out
+// "alternative histories": "what if the PRNG generated 0 instead of 13 here?"
+class RandomnessSource {
+public:
+    static RandomnessSource live() { return RandomnessSource(RandomRun(), true); }
+    static RandomnessSource recorded(RandomRun const& run) { return RandomnessSource(run, false); }
+    RandomRun& run() { return m_run; }
+    u32 draw_value(u32 max, Function<u32()> random_generator)
+    {
+        // Live: use the random generator and remember the value.
+        if (m_is_live) {
+            u32 value = random_generator();
+            m_run.append(value);
+            return value;
+        }
+
+        // Not live! let's get another prerecorded value.
+        auto next = m_run.next();
+        if (next.has_value()) {
+            return min(next.value(), max);
+        }
+
+        // Signal a failure. The value returned doesn't matter at this point but
+        // we need to return something.
+        set_current_test_result(TestResult::Overrun);
+        return 0;
+    }
+
+private:
+    explicit RandomnessSource(RandomRun const& run, bool is_live)
+        : m_run(run)
+        , m_is_live(is_live)
+    {
+    }
+    RandomRun m_run;
+    bool m_is_live;
+};
+
+} // namespace Randomized
+} // namespace Test

--- a/Userland/Libraries/LibTest/Randomized/Shrink.h
+++ b/Userland/Libraries/LibTest/Randomized/Shrink.h
@@ -1,0 +1,363 @@
+/*
+ * Copyright (c) 2023, Martin Janiczek <martin@janiczek.cz>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibTest/Randomized/Generator.h>
+#include <LibTest/Randomized/RandomRun.h>
+#include <LibTest/Randomized/RandomnessSource.h>
+#include <LibTest/Randomized/ShrinkCommand.h>
+#include <LibTest/TestResult.h>
+
+#include <AK/String.h>
+
+namespace Test {
+namespace Randomized {
+
+enum class WasImprovement {
+    Yes,
+    No,
+};
+
+struct ShrinkResult {
+    WasImprovement was_improvement;
+    RandomRun run;
+};
+
+inline ShrinkResult no_improvement(RandomRun run)
+{
+    return ShrinkResult { WasImprovement::No, run };
+}
+
+// When calling keep_if_better we have a new RandomRun that might be better than
+// our current_best (which is guaranteed to generate a value and fail the test).
+//
+// We need to try to generate a value from the new_run and run the test. If the
+// generated value fails the test, we say it was an improvement (because of our
+// convention for generators that _shorter / smaller RandomRuns lead to simpler
+// values_). In all other cases we say it wasn't an improvement.
+template<typename Fn>
+ShrinkResult keep_if_better(RandomRun const& new_run, RandomRun const& current_best, Fn const& test_function)
+{
+    if (!new_run.is_shortlex_smaller_than(current_best))
+        // The new run is worse or equal to the current best. Let's not even try!
+        return no_improvement(current_best);
+
+    set_randomness_source(RandomnessSource::recorded(new_run));
+    set_current_test_result(TestResult::NotRun);
+    test_function();
+    if (current_test_result() == TestResult::NotRun) {
+        set_current_test_result(TestResult::Passed);
+    }
+
+    switch (current_test_result()) {
+    case TestResult::Failed:
+        // Our smaller RandomRun resulted in a simpler failing value!
+        // Let's keep it.
+        return ShrinkResult { WasImprovement::Yes, new_run };
+    case TestResult::Passed:
+    case TestResult::Rejected:
+    case TestResult::Overrun:
+        // Passing:  We shrank from a failing value to a passing value.
+        // Rejected: We shrank to value that doesn't get past the ASSUME(...)
+        //           macro.
+        // Overrun:  Generators can't draw enough random bits to generate all
+        //           needed values.
+        // In all cases: Let's try something else.
+        return no_improvement(current_best);
+    case TestResult::NotRun:
+    default:
+        // We've literally just set it to Passed if it was NotRun!
+        VERIFY_NOT_REACHED();
+        return no_improvement(current_best);
+    }
+}
+
+template<typename Fn, typename UpdateRunFn>
+ShrinkResult binary_shrink(u32 orig_low, u32 orig_high, UpdateRunFn update_run, RandomRun const& orig_run, Fn const& test_function)
+{
+    if (orig_low == orig_high) {
+        return no_improvement(orig_run);
+    }
+
+    RandomRun current_best = orig_run;
+    u32 low = orig_low;
+    u32 high = orig_high;
+
+    // Let's try with the best case (low = most shrunk) first
+    RandomRun run_with_low = update_run(low, current_best);
+    ShrinkResult after_low = keep_if_better(run_with_low, current_best, test_function);
+    switch (after_low.was_improvement) {
+    case WasImprovement::Yes:
+        // We can't do any better
+        return after_low;
+    case WasImprovement::No:
+        break;
+    }
+
+    // Ah well, gotta do some actual work.
+    //
+    // We're already guaranteed that `high` makes the test fail. We're trying to
+    // get as low as `low` (but we know `low` doesn't make the test fail, else
+    // the `if` above would succeed and return).
+    //
+    // Failing value above, passing value below; we try to find the lowest value
+    // that still fails.
+    //
+    // `high` is always guaranteed to fail, `low` is always guaranteed to
+    // pass/reject/overrun.
+    ShrinkResult result = after_low;
+    while (low + 1 < high) {
+        u32 mid = low + (high - low) / 2;
+        RandomRun run_with_mid = update_run(mid, current_best);
+        ShrinkResult after_mid = keep_if_better(run_with_mid, current_best, test_function);
+        switch (after_mid.was_improvement) {
+        case WasImprovement::Yes:
+            high = mid;
+            break;
+        case WasImprovement::No:
+            low = mid;
+            break;
+        }
+        result = after_mid;
+        current_best = after_mid.run;
+    }
+
+    // did we get below the original `high` at all?
+    if (current_best.is_shortlex_smaller_than(orig_run)) {
+        result.was_improvement = WasImprovement::Yes;
+    } else {
+        result.was_improvement = WasImprovement::No;
+        result.run = orig_run;
+    }
+    set_current_test_result(TestResult::Failed);
+    return result;
+}
+
+template<typename Fn>
+ShrinkResult shrink_zero(ZeroChunk command, RandomRun const& run, Fn const& test_function)
+{
+    RandomRun new_run = run;
+    size_t end = command.chunk.index + command.chunk.size;
+    for (size_t i = command.chunk.index; i < end; i++) {
+        new_run[i] = 0;
+    }
+    return keep_if_better(new_run, run, test_function);
+}
+
+template<typename Fn>
+ShrinkResult shrink_sort(SortChunk command, RandomRun const& run, Fn const& test_function)
+{
+    RandomRun new_run = run.with_sorted(command.chunk);
+    return keep_if_better(new_run, run, test_function);
+}
+
+template<typename Fn>
+ShrinkResult shrink_delete(DeleteChunkAndMaybeDecPrevious command, RandomRun const& run, Fn const& test_function)
+{
+    RandomRun run_deleted = run.with_deleted(command.chunk);
+    // Optional: decrement the previous value. This deals with a non-optimal but
+    // relatively common generation pattern: run length encoding.
+    //
+    // Example: let's say somebody generates lists in this way:
+    // * generate a random integer >=0 for the length of the list.
+    // * then, generate that many items
+    //
+    // This results in RandomRuns like this one:
+    // [ 3 (length), 50 (item 1), 21 (item 2), 1 (item 3) ]
+    //
+    // Then if we tried deleting the second item without decrementing
+    // the length, it would fail:
+    // [ 3 (length), 21 (item 1), 1 (item 2) ] ... runs out of randomness when
+    // trying to generate the third item!
+    //
+    // That's why we try to decrement the number right before the deleted items:
+    // [ 2 (length), 21 (item 1), 1 (item 2) ] ... generates fine!
+    //
+    // Aside: this is why we're generating lists in a different way that plays
+    // nicer with shrinking: we flip a coin (generate a bool which is `true` with
+    // a certain probability) to see whether to generate another item. This makes
+    // items "local" instead of entangled with the non-local length.
+    if (run_deleted.size() > command.chunk.index - 1 && run_deleted[command.chunk.index - 1] > 0) {
+        RandomRun run_decremented = run_deleted;
+        run_decremented[command.chunk.index - 1]--;
+        return keep_if_better(run_decremented, run, test_function);
+    }
+
+    // Decrementing didn't work; let's try with just the deletion.
+    return keep_if_better(run_deleted, run, test_function);
+}
+
+template<typename Fn>
+ShrinkResult shrink_minimize(MinimizeChoice command, RandomRun const& run, Fn const& test_function)
+{
+    u32 value = run[command.index];
+
+    // We can't minimize 0! Already the best possible case.
+    if (value == 0) {
+        return no_improvement(run);
+    }
+
+    return binary_shrink(
+        0,
+        value,
+        [&](u32 new_value, RandomRun const& run) {
+            RandomRun copied_run = run;
+            copied_run[command.index] = new_value;
+            return copied_run;
+        },
+        run,
+        test_function);
+}
+
+template<typename Fn>
+ShrinkResult shrink_swap_chunk(SwapChunkWithNeighbour command, RandomRun const& run, Fn const& test_function)
+{
+    RandomRun run_swapped = run;
+    // The safety of these swaps was guaranteed by has_a_chance() earlier
+    for (size_t i = command.chunk.index; i < command.chunk.index + command.chunk.size; ++i) {
+        AK::swap(run_swapped[i], run_swapped[i + command.chunk.size]);
+    }
+    return keep_if_better(run_swapped, run, test_function);
+}
+
+template<typename Fn>
+ShrinkResult shrink_redistribute(RedistributeChoicesAndMaybeInc command, RandomRun const& run, Fn const& test_function)
+{
+    RandomRun current_best = run;
+    RandomRun run_after_swap = current_best;
+
+    // First try to swap them if they're out of order.
+    if (run_after_swap[command.left_index] > run_after_swap[command.right_index])
+        AK::swap(run_after_swap[command.left_index], run_after_swap[command.right_index]);
+
+    ShrinkResult after_swap = keep_if_better(run_after_swap, current_best, test_function);
+    current_best = after_swap.run;
+    u32 constant_sum = current_best[command.right_index] + current_best[command.left_index];
+
+    ShrinkResult after_redistribute = binary_shrink(
+        0,
+        current_best[command.left_index],
+        [&](u32 new_value, RandomRun const& run) {
+            RandomRun copied_run = run;
+            copied_run[command.left_index] = new_value;
+            copied_run[command.right_index] = constant_sum - new_value;
+            return copied_run;
+        },
+        current_best,
+        test_function);
+
+    switch (after_redistribute.was_improvement) {
+    case WasImprovement::Yes:
+        return after_redistribute;
+        break;
+    case WasImprovement::No:
+        break;
+    }
+
+    // If the redistribute failed, this can sometimes signal that a value needs
+    // to fall into the next `int_frequency` bucket. We can try one last-ditch
+    // attempt and see if incrementing the number right before the right index
+    // helps.
+
+    if (command.left_index == command.right_index - 1) {
+        // There's no "bucket index" between the left and right index.
+        // Let's not even try.
+        return after_swap;
+    }
+
+    RandomRun run_after_increment = after_redistribute.run;
+    ++run_after_increment[command.right_index - 1];
+
+    ShrinkResult after_inc_redistribute = binary_shrink(
+        0,
+        current_best[command.left_index],
+        [&](u32 new_value, RandomRun const& run) {
+            RandomRun copied_run = run;
+            copied_run[command.left_index] = new_value;
+            copied_run[command.right_index] = constant_sum - new_value;
+            return copied_run;
+        },
+        current_best,
+        test_function);
+
+    switch (after_inc_redistribute.was_improvement) {
+    case WasImprovement::Yes:
+        return after_inc_redistribute;
+        break;
+    case WasImprovement::No:
+        break;
+    }
+
+    return after_swap;
+}
+
+template<typename Fn>
+ShrinkResult shrink_with_command(ShrinkCommand command, RandomRun const& run, Fn const& test_function)
+{
+    return command.visit(
+        [&](ZeroChunk c) { return shrink_zero(c, run, test_function); },
+        [&](SortChunk c) { return shrink_sort(c, run, test_function); },
+        [&](DeleteChunkAndMaybeDecPrevious c) { return shrink_delete(c, run, test_function); },
+        [&](MinimizeChoice c) { return shrink_minimize(c, run, test_function); },
+        [&](RedistributeChoicesAndMaybeInc c) { return shrink_redistribute(c, run, test_function); },
+        [&](SwapChunkWithNeighbour c) { return shrink_swap_chunk(c, run, test_function); });
+}
+
+template<typename Fn>
+RandomRun shrink_once(RandomRun const& run, Fn const& test_function)
+{
+    RandomRun current = run;
+
+    auto commands = ShrinkCommand::for_run(run);
+    for (ShrinkCommand command : commands) {
+        // We're keeping the list of ShrinkCommands we generated from the initial
+        // RandomRun, as we try to shrink our current best RandomRun.
+        //
+        // That means some of the ShrinkCommands might have no chance to
+        // successfully finish (eg. the command's chunk is out of bounds of the
+        // run). That's what we check here and based on what we skip those
+        // commands early.
+        //
+        // In the next `shrink -> shrink_once` loop we'll generate a better set
+        // of commands, more tailored to the current best RandomRun.
+        if (!command.has_a_chance(current)) {
+            continue;
+        }
+        ShrinkResult result = shrink_with_command(command, current, test_function);
+        switch (result.was_improvement) {
+        case WasImprovement::Yes:
+            current = result.run;
+            break;
+        case WasImprovement::No:
+            break;
+        }
+    }
+    return current;
+}
+
+template<typename Fn>
+RandomRun shrink(RandomRun const& first_failure, Fn const& test_function)
+{
+    if (first_failure.is_empty()) {
+        // We can't do any better
+        return first_failure;
+    }
+
+    RandomRun next = first_failure;
+    RandomRun current;
+    do {
+        current = next;
+        next = shrink_once(current, test_function);
+    } while (next.is_shortlex_smaller_than(current));
+
+    set_current_test_result(TestResult::Failed);
+
+    return next;
+}
+
+} // namespace Randomized
+} // namespace Test

--- a/Userland/Libraries/LibTest/Randomized/ShrinkCommand.h
+++ b/Userland/Libraries/LibTest/Randomized/ShrinkCommand.h
@@ -1,0 +1,249 @@
+/*
+ * Copyright (c) 2023, Martin Janiczek <martin@janiczek.cz>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibTest/Randomized/Chunk.h>
+#include <LibTest/Randomized/RandomRun.h>
+
+#include <AK/String.h>
+#include <AK/Variant.h>
+#include <AK/Vector.h>
+
+namespace Test {
+namespace Randomized {
+
+struct ZeroChunk {
+    Chunk chunk;
+};
+struct SortChunk {
+    Chunk chunk;
+};
+struct DeleteChunkAndMaybeDecPrevious {
+    Chunk chunk;
+};
+struct MinimizeChoice {
+    size_t index;
+};
+struct SwapChunkWithNeighbour {
+    Chunk chunk;
+
+    Chunk const neighbour()
+    {
+        return Chunk { chunk.size, chunk.index + chunk.size };
+    }
+};
+struct RedistributeChoicesAndMaybeInc {
+    size_t left_index;
+    size_t right_index;
+};
+
+using CommandVariant = Variant<
+    ZeroChunk,
+    SortChunk,
+    DeleteChunkAndMaybeDecPrevious,
+    MinimizeChoice,
+    SwapChunkWithNeighbour,
+    RedistributeChoicesAndMaybeInc>;
+
+enum class AllowSizeOneChunks {
+    Yes,
+    No,
+};
+
+class ShrinkCommand {
+public:
+    explicit ShrinkCommand(CommandVariant const& command)
+        : m_command(command)
+    {
+    }
+
+    static Vector<ShrinkCommand> for_run(RandomRun const& run)
+    {
+        size_t run_size = run.size();
+
+        Vector<ShrinkCommand> all;
+        // Sorted roughly in the order of effectiveness. Deleting chunks is better
+        // than minimizing them.
+        all.extend(deletion_commands(run_size));
+        all.extend(zero_commands(run_size));
+        all.extend(sort_commands(run_size));
+        all.extend(swap_chunk_commands(run_size));
+        all.extend(minimize_commands(run_size));
+        all.extend(redistribute_commands(run_size));
+        return all;
+    }
+
+    bool has_a_chance(RandomRun const& run) const
+    {
+        return m_command.visit(
+            [&](ZeroChunk c) { return run.contains_chunk(c.chunk); },
+            [&](SortChunk c) { return run.contains_chunk(c.chunk); },
+            [&](DeleteChunkAndMaybeDecPrevious c) { return run.contains_chunk(c.chunk); },
+            [&](MinimizeChoice c) { return run.size() > c.index; },
+            [&](RedistributeChoicesAndMaybeInc c) { return run.size() > c.right_index; },
+            [&](SwapChunkWithNeighbour c) { return run.contains_chunk(c.neighbour()); });
+    }
+
+    ErrorOr<String> to_string()
+    {
+        return m_command.visit(
+            [](ZeroChunk c) { return String::formatted("ZeroChunk({})", c.chunk); },
+            [](SortChunk c) { return String::formatted("SortChunk({})", c.chunk); },
+            [](DeleteChunkAndMaybeDecPrevious c) { return String::formatted("DeleteChunkAndMaybeDecPrevious({})", c.chunk); },
+            [](MinimizeChoice c) { return String::formatted("MinimizeChoice(i={})", c.index); },
+            [](RedistributeChoicesAndMaybeInc c) { return String::formatted("RedistributeChoicesAndMaybeInc(left={},right={})", c.left_index, c.right_index); },
+            [](SwapChunkWithNeighbour c) { return String::formatted("SwapChunkWithNeighbour({})", c.chunk); });
+    }
+
+    template<typename... Fs>
+    auto visit(Fs&&... callbacks)
+    {
+        return m_command.visit(forward<Fs>(callbacks)...);
+    }
+
+private:
+    CommandVariant m_command;
+
+    // Will generate ShrinkCommands for all chunks of sizes 1,2,3,4,8 in bounds of the
+    // given RandomRun size.
+    //
+    // They will be given in a reverse order (largest chunks first), to maximize our
+    // chances of saving work (minimizing the RandomRun faster).
+    //
+    // chunkCommands(10, false, [](Chunk c){ return SortChunk(c); })
+    // -->
+    // [ // Chunks of size 8
+    //   SortChunk { chunk_size = 8, start_index = 0 }, // [XXXXXXXX..]
+    //   SortChunk { chunk_size = 8, start_index = 1 }, // [.XXXXXXXX.]
+    //   SortChunk { chunk_size = 8, start_index = 2 }, // [..XXXXXXXX]
+    //
+    //   // Chunks of size 4
+    //   SortChunk { chunk_size = 4, start_index = 0 }, // [XXXX......]
+    //   SortChunk { chunk_size = 4, start_index = 1 }, // [.XXXX.....]
+    //   // ...
+    //   SortChunk { chunk_size = 4, start_index = 5 }, // [.....XXXX.]
+    //   SortChunk { chunk_size = 4, start_index = 6 }, // [......XXXX]
+    //
+    //   // Chunks of size 3
+    //   SortChunk { chunk_size = 3, start_index = 0 }, // [XXX.......]
+    //   SortChunk { chunk_size = 3, start_index = 1 }, // [.XXX......]
+    //   // ...
+    //   SortChunk { chunk_size = 3, start_index = 6 }, // [......XXX.]
+    //   SortChunk { chunk_size = 3, start_index = 7 }, // [.......XXX]
+    //
+    //   // Chunks of size 2
+    //   SortChunk { chunk_size = 2, start_index = 0 }, // [XX........]
+    //   SortChunk { chunk_size = 2, start_index = 1 }, // [.XX.......]
+    //   // ...
+    //   SortChunk { chunk_size = 2, start_index = 7 }, // [.......XX.]
+    //   SortChunk { chunk_size = 2, start_index = 8 }, // [........XX]
+    // ]
+    template<typename FN>
+    static Vector<ShrinkCommand> chunk_commands(size_t run_size, AllowSizeOneChunks allow_chunks_size1, FN chunk_to_command)
+    {
+        Vector<u8> sizes = { 8, 4, 3, 2 };
+        switch (allow_chunks_size1) {
+        case AllowSizeOneChunks::Yes:
+            sizes.append(1);
+            break;
+        case AllowSizeOneChunks::No:
+            break;
+        }
+
+        Vector<ShrinkCommand> commands;
+        for (u8 chunk_size : sizes) {
+            if (chunk_size > run_size)
+                continue;
+
+            for (size_t i = 0; i < run_size - chunk_size + 1; ++i) {
+                ShrinkCommand command = chunk_to_command(Chunk { chunk_size, i });
+                commands.append(command);
+            }
+        }
+        return commands;
+    }
+
+    static Vector<ShrinkCommand> deletion_commands(size_t run_size)
+    {
+        return chunk_commands(
+            run_size,
+            AllowSizeOneChunks::Yes,
+            [](Chunk c) { return ShrinkCommand(DeleteChunkAndMaybeDecPrevious { c }); });
+    }
+
+    static Vector<ShrinkCommand> minimize_commands(size_t run_size)
+    {
+        Vector<ShrinkCommand> commands;
+        for (size_t i = 0; i < run_size; ++i) {
+            ShrinkCommand command = ShrinkCommand(MinimizeChoice { i });
+            commands.append(command);
+        }
+        return commands;
+    }
+
+    static Vector<ShrinkCommand> redistribute_commands(size_t run_size)
+    {
+        Vector<ShrinkCommand> commands;
+        for (size_t offset = 3; offset > 0; --offset) {
+            if (offset >= run_size)
+                continue;
+            for (size_t i = 0; i < run_size - offset; ++i) {
+                ShrinkCommand command = ShrinkCommand(RedistributeChoicesAndMaybeInc { i, i + offset });
+                commands.append(command);
+            }
+        }
+        return commands;
+    }
+
+    static Vector<ShrinkCommand> sort_commands(size_t run_size)
+    {
+        return chunk_commands(
+            run_size,
+            AllowSizeOneChunks::No, // doesn't make sense for sorting
+            [](Chunk c) { return ShrinkCommand(SortChunk { c }); });
+    }
+
+    static Vector<ShrinkCommand> zero_commands(size_t run_size)
+    {
+        return chunk_commands(
+            run_size,
+            AllowSizeOneChunks::No, // already happens in binary search
+            [](Chunk c) { return ShrinkCommand(ZeroChunk { c }); });
+    }
+
+    static Vector<ShrinkCommand> swap_chunk_commands(size_t run_size)
+    {
+        return chunk_commands(
+            // TODO: This is not optimal as the chunks near the end of
+            // the RandomRun will hit OOB.
+            //
+            // This is because SwapChunkWithNeighbour doesn't just
+            // touch the Chunk but also its right neighbour:
+            // [_,_,X,X,X,Y,Y,Y,_]
+            //
+            // If the chunk is too far to the right, it would go OOB:
+            // [_,_,_,_,X,X,X,Y,Y]Y
+            //
+            // For now, this will work though, there will just be a
+            // bit of unnecessary work calling .has_a_chance() on
+            // these chunks that are too far to the right.
+            run_size,
+            AllowSizeOneChunks::No, // already happens in "redistribute choice"
+            [](Chunk c) { return ShrinkCommand(SwapChunkWithNeighbour { c }); });
+    }
+};
+
+} // namespace Randomized
+} // namespace Test
+
+template<>
+struct AK::Formatter<Test::Randomized::ShrinkCommand> : Formatter<StringView> {
+    ErrorOr<void> format(FormatBuilder& builder, Test::Randomized::ShrinkCommand command)
+    {
+        return Formatter<StringView>::format(builder, TRY(command.to_string()));
+    }
+};

--- a/Userland/Libraries/LibTest/TestCase.h
+++ b/Userland/Libraries/LibTest/TestCase.h
@@ -82,3 +82,11 @@ void set_suite_setup_function(Function<void()> setup);
     };                                                                                               \
     static struct __BENCHMARK_TYPE(x) __BENCHMARK_TYPE(x);                                           \
     static void __BENCHMARK_FUNC(x)()
+
+// This allows us to print the generated locals in the test after a failure is fully shrunk.
+#define GEN(identifier, value)                                        \
+    auto identifier = (value);                                        \
+    if (::Test::current_test_result() == ::Test::TestResult::Overrun) \
+        return;                                                       \
+    if (::Test::is_reporting_enabled())                               \
+    ::AK::warnln("{} = {}", #identifier, (identifier))

--- a/Userland/Libraries/LibTest/TestCase.h
+++ b/Userland/Libraries/LibTest/TestCase.h
@@ -8,15 +8,35 @@
 #pragma once
 
 #include <LibTest/Macros.h> // intentionally first -- we redefine VERIFY and friends in here
+#include <LibTest/Randomized/RandomnessSource.h>
+#include <LibTest/Randomized/Shrink.h>
 
 #include <AK/DeprecatedString.h>
 #include <AK/Function.h>
 #include <AK/NonnullRefPtr.h>
 #include <AK/RefCounted.h>
 
+#ifndef MAX_GENERATED_VALUES_PER_TEST
+#    define MAX_GENERATED_VALUES_PER_TEST 100
+#endif
+
+#ifndef MAX_GEN_ATTEMPTS_PER_VALUE
+#    define MAX_GEN_ATTEMPTS_PER_VALUE 15
+#endif
+
 namespace Test {
 
 using TestFunction = Function<void()>;
+
+inline void run_with_randomness_source(Randomized::RandomnessSource source, TestFunction const& test_function)
+{
+    set_randomness_source(move(source));
+    set_current_test_result(TestResult::NotRun);
+    test_function();
+    if (current_test_result() == TestResult::NotRun) {
+        set_current_test_result(TestResult::Passed);
+    }
+}
 
 class TestCase : public RefCounted<TestCase> {
 public:
@@ -30,6 +50,60 @@ public:
     bool is_benchmark() const { return m_is_benchmark; }
     DeprecatedString const& name() const { return m_name; }
     TestFunction const& func() const { return m_function; }
+
+    static NonnullRefPtr<TestCase> randomized(DeprecatedString const& name, TestFunction&& test_function)
+    {
+        using namespace Randomized;
+        TestFunction test_case_function = [test_function = move(test_function)]() {
+            for (u32 i = 0; i < MAX_GENERATED_VALUES_PER_TEST; ++i) {
+                bool generated_successfully = false;
+                u8 gen_attempt;
+                for (gen_attempt = 0; gen_attempt < MAX_GEN_ATTEMPTS_PER_VALUE && !generated_successfully; ++gen_attempt) {
+                    // We're going to run the test function many times, so let's turn off the reporting until we finish.
+                    disable_reporting();
+
+                    set_current_test_result(TestResult::NotRun);
+                    run_with_randomness_source(RandomnessSource::live(), test_function);
+                    switch (current_test_result()) {
+                    case TestResult::NotRun:
+                        VERIFY_NOT_REACHED();
+                        break;
+                    case TestResult::Passed: {
+                        generated_successfully = true;
+                        break;
+                    }
+                    case TestResult::Failed: {
+                        generated_successfully = true;
+                        RandomRun first_failure = randomness_source().run();
+                        RandomRun best_failure = shrink(first_failure, test_function);
+
+                        // Run one last time with reporting on, so that the user can see the minimal failure
+                        enable_reporting();
+                        run_with_randomness_source(RandomnessSource::recorded(best_failure), test_function);
+                        return;
+                    }
+                    case TestResult::Rejected:
+                        break;
+                    case TestResult::Overrun:
+                        break;
+                    default:
+                        VERIFY_NOT_REACHED();
+                        break;
+                    }
+                }
+                enable_reporting();
+                if (!generated_successfully) {
+                    // The loop above got to the full MAX_GEN_ATTEMPTS_PER_VALUE and gave up.
+                    // Run one last time with reporting on, so that the user gets the REJECTED message.
+                    RandomRun last_failure = randomness_source().run();
+                    run_with_randomness_source(RandomnessSource::recorded(last_failure), test_function);
+                    return;
+                }
+            }
+            // MAX_GENERATED_VALUES_PER_TEST values generated, all passed the test.
+        };
+        return make_ref_counted<TestCase>(name, move(test_case_function), false);
+    }
 
 private:
     DeprecatedString m_name;
@@ -53,6 +127,8 @@ void set_suite_setup_function(Function<void()> setup);
     static struct __setup_type __setup_type;         \
     static void __setup()
 
+// Unit test
+
 #define __TESTCASE_FUNC(x) __test_##x
 #define __TESTCASE_TYPE(x) __TestCase_##x
 
@@ -68,6 +144,8 @@ void set_suite_setup_function(Function<void()> setup);
     static struct __TESTCASE_TYPE(x) __TESTCASE_TYPE(x);                                             \
     static void __TESTCASE_FUNC(x)()
 
+// Benchmark
+
 #define __BENCHMARK_FUNC(x) __benchmark_##x
 #define __BENCHMARK_TYPE(x) __BenchmarkCase_##x
 
@@ -82,6 +160,23 @@ void set_suite_setup_function(Function<void()> setup);
     };                                                                                               \
     static struct __BENCHMARK_TYPE(x) __BENCHMARK_TYPE(x);                                           \
     static void __BENCHMARK_FUNC(x)()
+
+// Randomized test
+
+#define __RANDOMIZED_TEST_FUNC(x) __randomized_test_##x
+#define __RANDOMIZED_TEST_TYPE(x) __RandomizedTestCase_##x
+
+#define RANDOMIZED_TEST_CASE(x)                                                                  \
+    static void __RANDOMIZED_TEST_FUNC(x)();                                                     \
+    struct __RANDOMIZED_TEST_TYPE(x) {                                                           \
+        __RANDOMIZED_TEST_TYPE(x)                                                                \
+        ()                                                                                       \
+        {                                                                                        \
+            add_test_case_to_suite(::Test::TestCase::randomized(#x, __RANDOMIZED_TEST_FUNC(x))); \
+        }                                                                                        \
+    };                                                                                           \
+    static struct __RANDOMIZED_TEST_TYPE(x) __RANDOMIZED_TEST_TYPE(x);                           \
+    static void __RANDOMIZED_TEST_FUNC(x)()
 
 // This allows us to print the generated locals in the test after a failure is fully shrunk.
 #define GEN(identifier, value)                                        \

--- a/Userland/Libraries/LibTest/TestResult.h
+++ b/Userland/Libraries/LibTest/TestResult.h
@@ -18,6 +18,11 @@ enum class TestResult {
     // Didn't get through EXPECT(...).
     Failed,
 
+    // Didn't get through the ASSUME(...) filter 15 times in a row
+    // (in a randomized test).
+    // Alternatively, user used REJECT(...).
+    Rejected,
+
     // Ran out of RandomRun data (in a randomized test, when shrinking).
     // This is fine, we'll just try some other shrink.
     Overrun,

--- a/Userland/Libraries/LibTest/TestResult.h
+++ b/Userland/Libraries/LibTest/TestResult.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2023, Martin Janiczek <martin@janiczek.cz>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+namespace Test {
+
+// TestResult signals to the TestSuite how the TestCase execution went.
+enum class TestResult {
+    NotRun,
+
+    // Test fn ran to completion without setting any of the below flags
+    Passed,
+
+    // Didn't get through EXPECT(...).
+    Failed,
+};
+
+// Used eg. to signal we've ran out of prerecorded random bits.
+// Defined in TestSuite.cpp
+void set_current_test_result(TestResult);
+
+} // namespace Test

--- a/Userland/Libraries/LibTest/TestResult.h
+++ b/Userland/Libraries/LibTest/TestResult.h
@@ -17,6 +17,10 @@ enum class TestResult {
 
     // Didn't get through EXPECT(...).
     Failed,
+
+    // Ran out of RandomRun data (in a randomized test, when shrinking).
+    // This is fine, we'll just try some other shrink.
+    Overrun,
 };
 
 // Used eg. to signal we've ran out of prerecorded random bits.

--- a/Userland/Libraries/LibTest/TestSuite.cpp
+++ b/Userland/Libraries/LibTest/TestSuite.cpp
@@ -52,6 +52,18 @@ void set_current_test_result(TestResult result)
     TestSuite::the().set_current_test_result(result);
 }
 
+// Declared in Macros.h
+void set_randomness_source(Randomized::RandomnessSource source)
+{
+    TestSuite::the().set_randomness_source(move(source));
+}
+
+// Declared in Macros.h
+Randomized::RandomnessSource& randomness_source()
+{
+    return TestSuite::the().randomness_source();
+}
+
 // Declared in TestCase.h
 void add_test_case_to_suite(NonnullRefPtr<TestCase> const& test_case)
 {
@@ -73,6 +85,8 @@ static DeprecatedString test_result_to_string(TestResult result)
         return "Completed";
     case TestResult::Failed:
         return "Failed";
+    case TestResult::Overrun:
+        return "Ran out of randomness";
     default:
         return "Unknown TestResult";
     }

--- a/Userland/Libraries/LibTest/TestSuite.cpp
+++ b/Userland/Libraries/LibTest/TestSuite.cpp
@@ -103,6 +103,8 @@ static DeprecatedString test_result_to_string(TestResult result)
         return "Completed";
     case TestResult::Failed:
         return "Failed";
+    case TestResult::Rejected:
+        return "Rejected";
     case TestResult::Overrun:
         return "Ran out of randomness";
     default:

--- a/Userland/Libraries/LibTest/TestSuite.cpp
+++ b/Userland/Libraries/LibTest/TestSuite.cpp
@@ -76,6 +76,24 @@ void set_suite_setup_function(Function<void()> setup)
     TestSuite::the().set_suite_setup(move(setup));
 }
 
+// Declared in Macros.h
+bool is_reporting_enabled()
+{
+    return TestSuite::the().is_reporting_enabled();
+}
+
+// Declared in Macros.h
+void enable_reporting()
+{
+    TestSuite::the().enable_reporting();
+}
+
+// Declared in Macros.h
+void disable_reporting()
+{
+    TestSuite::the().disable_reporting();
+}
+
 static DeprecatedString test_result_to_string(TestResult result)
 {
     switch (result) {
@@ -164,6 +182,7 @@ int TestSuite::run(Vector<NonnullRefPtr<TestCase>> const& tests)
 
         warnln("Running {} '{}'.", test_type, t->name());
         m_current_test_result = TestResult::NotRun;
+        enable_reporting();
 
         u64 total_time = 0;
         u64 sum_of_squared_times = 0;

--- a/Userland/Libraries/LibTest/TestSuite.h
+++ b/Userland/Libraries/LibTest/TestSuite.h
@@ -13,6 +13,7 @@
 #include <AK/Function.h>
 #include <AK/Vector.h>
 #include <LibTest/TestCase.h>
+#include <LibTest/TestResult.h>
 
 namespace Test {
 
@@ -40,7 +41,8 @@ public:
         m_cases.append(test_case);
     }
 
-    void current_test_case_did_fail() { m_current_test_case_passed = false; }
+    TestResult current_test_result() const { return m_current_test_result; }
+    void set_current_test_result(TestResult result) { m_current_test_result = result; }
 
     void set_suite_setup(Function<void()> setup) { m_setup = move(setup); }
 
@@ -51,8 +53,8 @@ private:
     u64 m_benchtime = 0;
     DeprecatedString m_suite_name;
     u64 m_benchmark_repetitions = 1;
-    bool m_current_test_case_passed = true;
     Function<void()> m_setup;
+    TestResult m_current_test_result = TestResult::NotRun;
 };
 
 }

--- a/Userland/Libraries/LibTest/TestSuite.h
+++ b/Userland/Libraries/LibTest/TestSuite.h
@@ -12,6 +12,7 @@
 #include <AK/DeprecatedString.h>
 #include <AK/Function.h>
 #include <AK/Vector.h>
+#include <LibTest/Randomized/RandomnessSource.h>
 #include <LibTest/TestCase.h>
 #include <LibTest/TestResult.h>
 
@@ -45,6 +46,12 @@ public:
     void set_current_test_result(TestResult result) { m_current_test_result = result; }
 
     void set_suite_setup(Function<void()> setup) { m_setup = move(setup); }
+    // The RandomnessSource is where generators record / replay random data
+    // from. Initially a live "truly random" RandomnessSource is used, and when
+    // a failure is found, a set of hardcoded RandomnessSources is used during
+    // shrinking.
+    void set_randomness_source(Randomized::RandomnessSource source) { m_randomness_source = move(source); }
+    Randomized::RandomnessSource& randomness_source() { return m_randomness_source; }
 
 private:
     static TestSuite* s_global;
@@ -55,6 +62,7 @@ private:
     u64 m_benchmark_repetitions = 1;
     Function<void()> m_setup;
     TestResult m_current_test_result = TestResult::NotRun;
+    Randomized::RandomnessSource m_randomness_source = Randomized::RandomnessSource::live();
 };
 
 }

--- a/Userland/Libraries/LibTest/TestSuite.h
+++ b/Userland/Libraries/LibTest/TestSuite.h
@@ -53,6 +53,14 @@ public:
     void set_randomness_source(Randomized::RandomnessSource source) { m_randomness_source = move(source); }
     Randomized::RandomnessSource& randomness_source() { return m_randomness_source; }
 
+    // Dictates whether FAIL(), EXPECT() and similar macros in LibTest/Macros.h
+    // print messages or not. This is important for randomized tests because
+    // they run the test function many times in a row, and we only want to
+    // report the _minimal_ (shrunk) failure to the user, not all of them.
+    bool is_reporting_enabled() { return m_reporting_enabled; }
+    void enable_reporting() { m_reporting_enabled = true; }
+    void disable_reporting() { m_reporting_enabled = false; }
+
 private:
     static TestSuite* s_global;
     Vector<NonnullRefPtr<TestCase>> m_cases;
@@ -63,6 +71,7 @@ private:
     Function<void()> m_setup;
     TestResult m_current_test_result = TestResult::NotRun;
     Randomized::RandomnessSource m_randomness_source = Randomized::RandomnessSource::live();
+    bool m_reporting_enabled = true;
 };
 
 }


### PR DESCRIPTION
Add a way to run randomized tests (commonly called "property-based"): that is, tests that generate random data to run the test case with, and if they find a failure they shrink the input to a minimal failing example before reporting it to the user.

See [README.md](https://github.com/SerenityOS/serenity/pull/21191/files#diff-db605979eb83d9ca5b80e9a4ec840b9db3870a805117e0e9f2bc97829a0294eb) for more in-depth description.

## Examples:
```cpp
// Tests/LibCompress/TestGzip.cpp
// This test didn't find anything but shows off a very common property we can test with this.
RANDOMIZED_TEST_CASE(roundtrip)
{
    GEN(buffer, Gen::vector(2048,[](){return (u8)Gen::unsigned_int(255);}));
    auto const compressed = MUST(Compress::GzipCompressor::compress_all(buffer));
    auto const decompressed = MUST(Compress::GzipDecompressor::decompress_all(compressed));
    EXPECT(buffer == decompressed);
}
```

```cpp
// Tests/LibIMAP/TestQuotedPrintable.cpp
// The randomized test below found a deviation from the spec!

TEST_CASE(section_6_7_3_white_space_regressions)
{
    // Found by the randomized test below.

    // Throws the encoded tab/space at the end of the string away
    DECODE_EQUAL("!\t"sv,  "!"sv);
    DECODE_EQUAL("! "sv,   "!"sv);

    // Doesn't throw the encoded tab/space in the middle of the string away
    DECODE_EQUAL("!\t!"sv, "!\t!"sv);
    DECODE_EQUAL("! !"sv,  "! !"sv);
}

RANDOMIZED_TEST_CASE(section_6_7_3_white_space)
{
    /* https://datatracker.ietf.org/doc/html/rfc2045#section-6.7

       (3) (White Space) Octets with values of 9 and 32 MAY be
           represented as US-ASCII TAB (HT) and SPACE characters,
           respectively, but MUST NOT be so represented at the end
           of an encoded line.  Any TAB (HT) or SPACE characters
           on an encoded line MUST thus be followed on that line
           by a printable character.  In particular, an "=" at the
           end of an encoded line, indicating a soft line break
           (see rule #5) may follow one or more TAB (HT) or SPACE
           characters.  It follows that an octet with decimal
           value 9 or 32 appearing at the end of an encoded line
           must be represented according to Rule #1.  This rule is
           necessary because some MTAs (Message Transport Agents,
           programs which transport messages from one user to
           another, or perform a portion of such transfers) are
           known to pad lines of text with SPACEs, and others are
           known to remove "white space" characters from the end
           of a line.  Therefore, when decoding a Quoted-Printable
           body, any trailing white space on a line must be
           deleted, as it will necessarily have been added by
           intermediate transport agents.
     */

    GEN(prefix, literals_gen());
    auto prefix_sv = vector_to_string_view(prefix);

    // Throws the encoded tab at the end of the string away
    StringBuilder tab_at_end;
    tab_at_end.append(prefix_sv);
    tab_at_end.append(9);
    DECODE_EQUAL(tab_at_end.string_view(), prefix_sv);

    // Throws the encoded space at the end of the string away
    StringBuilder space_at_end;
    space_at_end.append(prefix_sv);
    space_at_end.append(32);
    DECODE_EQUAL(space_at_end.string_view(), prefix_sv);

    GEN(suffix, literals_gen());
    auto suffix_sv = vector_to_string_view(suffix);

    // Doesn't throw the encoded tab in the middle of the string away
    StringBuilder tab_in_middle;
    tab_in_middle.append(prefix_sv);
    tab_in_middle.append(9);
    tab_in_middle.append(suffix_sv);
    StringView tab_in_middle_sv = tab_in_middle.string_view();
    DECODE_EQUAL(tab_in_middle_sv, tab_in_middle_sv);

    // Doesn't throw the encoded space in the middle of the string away
    StringBuilder space_in_middle;
    space_in_middle.append(prefix_sv);
    space_in_middle.append(32);
    space_in_middle.append(suffix_sv);
    StringView space_in_middle_sv = space_in_middle.string_view();
    DECODE_EQUAL(space_in_middle_sv, space_in_middle_sv);
}

```

(I'll make another PR with usages of `RANDOMIZED_TEST_CASE` that will build on this one; I appreciate this PR is already big as it is!)

> [!NOTE]
> This being my first SerenityOS contribution, I'll be glad for any suggestions (code style, C++ tricks, namespace organization)!