### PR TITLE
Kernel/VirtIO: Ensure proper error propagation in core methods

### DIFF
--- a/Kernel/Bus/VirtIO/Console.h
+++ b/Kernel/Bus/VirtIO/Console.h
@@ -59,7 +59,7 @@ private:
     constexpr static size_t CONTROL_MESSAGE_SIZE = sizeof(ControlMessage);
     constexpr static size_t CONTROL_BUFFER_SIZE = CONTROL_MESSAGE_SIZE * 32;
 
-    virtual bool handle_device_config_change() override;
+    virtual ErrorOr<void> handle_device_config_change() override;
     virtual void handle_queue_update(u16 queue_index) override;
 
     Vector<LockRefPtr<ConsolePort>> m_ports;

--- a/Kernel/Bus/VirtIO/Device.h
+++ b/Kernel/Bus/VirtIO/Device.h
@@ -35,7 +35,7 @@ protected:
 
     void mask_status_bits(u8 status_mask);
     void set_status_bit(u8);
-    bool setup_queues(u16 requested_queue_count = 0);
+    ErrorOr<void> setup_queues(u16 requested_queue_count = 0);
     void finish_init();
 
     Queue& get_queue(u16 queue_index)
@@ -51,7 +51,7 @@ protected:
     }
 
     template<typename F>
-    bool negotiate_features(F f)
+    ErrorOr<void> negotiate_features(F f)
     {
         u64 device_features = m_transport_entity->get_device_features();
         u64 accept_features = f(device_features);
@@ -72,16 +72,16 @@ protected:
 
     void supply_chain_and_notify(u16 queue_index, QueueChain& chain);
 
-    virtual bool handle_device_config_change() = 0;
+    virtual ErrorOr<void> handle_device_config_change() = 0;
     virtual void handle_queue_update(u16 queue_index) = 0;
 
     TransportEntity& transport_entity() { return *m_transport_entity; }
 
 private:
-    bool accept_device_features(u64 device_features, u64 accepted_features);
+    ErrorOr<void> accept_device_features(u64 device_features, u64 accepted_features);
 
-    bool setup_queue(u16 queue_index);
-    bool activate_queue(u16 queue_index);
+    ErrorOr<void> setup_queue(u16 queue_index);
+    ErrorOr<void> activate_queue(u16 queue_index);
     void notify_queue(u16 queue_index);
 
     Vector<NonnullOwnPtr<Queue>> m_queues;

--- a/Kernel/Bus/VirtIO/RNG.h
+++ b/Kernel/Bus/VirtIO/RNG.h
@@ -27,7 +27,7 @@ public:
 private:
     virtual StringView class_name() const override { return "VirtIORNG"sv; }
     explicit RNG(NonnullOwnPtr<TransportEntity>);
-    virtual bool handle_device_config_change() override;
+    virtual ErrorOr<void> handle_device_config_change() override;
     virtual void handle_queue_update(u16 queue_index) override;
     void request_entropy_from_host();
 

--- a/Kernel/Bus/VirtIO/Transport/Entity.cpp
+++ b/Kernel/Bus/VirtIO/Transport/Entity.cpp
@@ -135,16 +135,16 @@ void TransportEntity::notify_queue(Badge<VirtIO::Device>, NotifyQueueDescriptor 
         config_write16(*m_notify_cfg, descriptor.possible_notify_offset * m_notify_multiplier, descriptor.queue_index);
 }
 
-bool TransportEntity::activate_queue(Badge<VirtIO::Device>, u16 queue_index)
+ErrorOr<void> TransportEntity::activate_queue(Badge<VirtIO::Device>, u16 queue_index)
 {
     if (!m_common_cfg)
-        return false;
+        return Error::from_errno(ENXIO);
 
     config_write16(*m_common_cfg, COMMON_CFG_QUEUE_SELECT, queue_index);
     config_write16(*m_common_cfg, COMMON_CFG_QUEUE_ENABLE, true);
 
     dbgln_if(VIRTIO_DEBUG, "Queue[{}] activated", queue_index);
-    return true;
+    return {};
 }
 
 u64 TransportEntity::get_device_features()

--- a/Kernel/Bus/VirtIO/Transport/Entity.h
+++ b/Kernel/Bus/VirtIO/Transport/Entity.h
@@ -30,7 +30,7 @@ public:
         u16 possible_notify_offset;
     };
     void notify_queue(Badge<VirtIO::Device>, NotifyQueueDescriptor);
-    bool activate_queue(Badge<VirtIO::Device>, u16 queue_index);
+    ErrorOr<void> activate_queue(Badge<VirtIO::Device>, u16 queue_index);
     ErrorOr<NonnullOwnPtr<Queue>> setup_queue(Badge<VirtIO::Device>, u16 queue_index);
     void set_status_bits(Badge<VirtIO::Device>, u8 status_bits);
     void reset_device(Badge<VirtIO::Device>);

--- a/Kernel/Devices/GPU/VirtIO/GraphicsAdapter.h
+++ b/Kernel/Devices/GPU/VirtIO/GraphicsAdapter.h
@@ -69,7 +69,7 @@ private:
 
     ErrorOr<void> initialize_adapter();
 
-    virtual bool handle_device_config_change() override;
+    virtual ErrorOr<void> handle_device_config_change() override;
     virtual void handle_queue_update(u16 queue_index) override;
     u32 get_pending_events();
     void clear_pending_events(u32 event_bitmask);

--- a/Kernel/Net/VirtIO/VirtIONetworkAdapter.h
+++ b/Kernel/Net/VirtIO/VirtIONetworkAdapter.h
@@ -37,7 +37,7 @@ private:
     explicit VirtIONetworkAdapter(StringView interface_name, NonnullOwnPtr<VirtIO::TransportEntity>);
 
     // VirtIO::Device
-    virtual bool handle_device_config_change() override;
+    virtual ErrorOr<void> handle_device_config_change() override;
     virtual void handle_queue_update(u16 queue_index) override;
 
     // NetworkAdapter


### PR DESCRIPTION
Taken as a task from this comment ([here](https://github.com/SerenityOS/serenity/pull/19757#discussion_r1259259110), by @ADKaster).