### PR TITLE
Userland: Use non-fallible `EventReceiver::add()` where possible

### DIFF
--- a/Base/res/devel/templates/serenity-application/main.cpp
+++ b/Base/res/devel/templates/serenity-application/main.cpp
@@ -24,8 +24,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     main_widget->set_layout<GUI::VerticalBoxLayout>(16);
 
-    auto button = TRY(main_widget->try_add<GUI::Button>("Click me!"_string));
-    button->on_click = [&](auto) {
+    auto& button = main_widget->add<GUI::Button>("Click me!"_string);
+    button.on_click = [&](auto) {
         GUI::MessageBox::show(window, "Hello friends!"sv, ":^)"sv);
     };
 

--- a/Userland/Applications/CrashReporter/main.cpp
+++ b/Userland/Applications/CrashReporter/main.cpp
@@ -239,41 +239,41 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto& backtrace_tab = tab_widget.add_tab<GUI::Widget>("Backtrace"_string);
     backtrace_tab.set_layout<GUI::VerticalBoxLayout>(4);
 
-    auto backtrace_label = TRY(backtrace_tab.try_add<GUI::Label>("A backtrace for each thread alive during the crash is listed below:"_string));
-    backtrace_label->set_text_alignment(Gfx::TextAlignment::CenterLeft);
-    backtrace_label->set_fixed_height(16);
+    auto& backtrace_label = backtrace_tab.add<GUI::Label>("A backtrace for each thread alive during the crash is listed below:"_string);
+    backtrace_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
+    backtrace_label.set_fixed_height(16);
 
-    auto backtrace_tab_widget = TRY(backtrace_tab.try_add<GUI::TabWidget>());
-    backtrace_tab_widget->set_tab_position(GUI::TabWidget::TabPosition::Bottom);
+    auto& backtrace_tab_widget = backtrace_tab.add<GUI::TabWidget>();
+    backtrace_tab_widget.set_tab_position(GUI::TabWidget::TabPosition::Bottom);
 
     auto& cpu_registers_tab = tab_widget.add_tab<GUI::Widget>("CPU Registers"_string);
     cpu_registers_tab.set_layout<GUI::VerticalBoxLayout>(4);
 
-    auto cpu_registers_label = TRY(cpu_registers_tab.try_add<GUI::Label>("The CPU register state for each thread alive during the crash is listed below:"_string));
-    cpu_registers_label->set_text_alignment(Gfx::TextAlignment::CenterLeft);
-    cpu_registers_label->set_fixed_height(16);
+    auto& cpu_registers_label = cpu_registers_tab.add<GUI::Label>("The CPU register state for each thread alive during the crash is listed below:"_string);
+    cpu_registers_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
+    cpu_registers_label.set_fixed_height(16);
 
-    auto cpu_registers_tab_widget = TRY(cpu_registers_tab.try_add<GUI::TabWidget>());
-    cpu_registers_tab_widget->set_tab_position(GUI::TabWidget::TabPosition::Bottom);
+    auto& cpu_registers_tab_widget = cpu_registers_tab.add<GUI::TabWidget>();
+    cpu_registers_tab_widget.set_tab_position(GUI::TabWidget::TabPosition::Bottom);
 
     auto& environment_tab = tab_widget.add_tab<GUI::Widget>("Environment"_string);
     environment_tab.set_layout<GUI::VerticalBoxLayout>(4);
 
-    auto environment_text_editor = TRY(environment_tab.try_add<GUI::TextEditor>());
-    environment_text_editor->set_text(DeprecatedString::join('\n', environment));
-    environment_text_editor->set_mode(GUI::TextEditor::Mode::ReadOnly);
-    environment_text_editor->set_wrapping_mode(GUI::TextEditor::WrappingMode::NoWrap);
-    environment_text_editor->set_should_hide_unnecessary_scrollbars(true);
+    auto& environment_text_editor = environment_tab.add<GUI::TextEditor>();
+    environment_text_editor.set_text(DeprecatedString::join('\n', environment));
+    environment_text_editor.set_mode(GUI::TextEditor::Mode::ReadOnly);
+    environment_text_editor.set_wrapping_mode(GUI::TextEditor::WrappingMode::NoWrap);
+    environment_text_editor.set_should_hide_unnecessary_scrollbars(true);
 
     auto& memory_regions_tab = tab_widget.add_tab<GUI::Widget>("Memory Regions"_string);
     memory_regions_tab.set_layout<GUI::VerticalBoxLayout>(4);
 
-    auto memory_regions_text_editor = TRY(memory_regions_tab.try_add<GUI::TextEditor>());
-    memory_regions_text_editor->set_text(DeprecatedString::join('\n', memory_regions));
-    memory_regions_text_editor->set_mode(GUI::TextEditor::Mode::ReadOnly);
-    memory_regions_text_editor->set_wrapping_mode(GUI::TextEditor::WrappingMode::NoWrap);
-    memory_regions_text_editor->set_should_hide_unnecessary_scrollbars(true);
-    memory_regions_text_editor->set_visualize_trailing_whitespace(false);
+    auto& memory_regions_text_editor = memory_regions_tab.add<GUI::TextEditor>();
+    memory_regions_text_editor.set_text(DeprecatedString::join('\n', memory_regions));
+    memory_regions_text_editor.set_mode(GUI::TextEditor::Mode::ReadOnly);
+    memory_regions_text_editor.set_wrapping_mode(GUI::TextEditor::WrappingMode::NoWrap);
+    memory_regions_text_editor.set_should_hide_unnecessary_scrollbars(true);
+    memory_regions_text_editor.set_visualize_trailing_whitespace(false);
 
     auto& close_button = *widget->find_descendant_of_type_named<GUI::Button>("close_button");
     close_button.on_click = [&](auto) {
@@ -330,24 +330,24 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         },
         [&](auto results) -> ErrorOr<void> {
             for (auto& backtrace : results.thread_backtraces) {
-                auto& container = backtrace_tab_widget->add_tab<GUI::Widget>(TRY(String::from_deprecated_string(backtrace.title)));
+                auto& container = backtrace_tab_widget.add_tab<GUI::Widget>(TRY(String::from_deprecated_string(backtrace.title)));
                 container.template set_layout<GUI::VerticalBoxLayout>(4);
-                auto backtrace_text_editor = TRY(container.template try_add<GUI::TextEditor>());
-                backtrace_text_editor->set_text(backtrace.text);
-                backtrace_text_editor->set_mode(GUI::TextEditor::Mode::ReadOnly);
-                backtrace_text_editor->set_wrapping_mode(GUI::TextEditor::WrappingMode::NoWrap);
-                backtrace_text_editor->set_should_hide_unnecessary_scrollbars(true);
+                auto& backtrace_text_editor = container.template add<GUI::TextEditor>();
+                backtrace_text_editor.set_text(backtrace.text);
+                backtrace_text_editor.set_mode(GUI::TextEditor::Mode::ReadOnly);
+                backtrace_text_editor.set_wrapping_mode(GUI::TextEditor::WrappingMode::NoWrap);
+                backtrace_text_editor.set_should_hide_unnecessary_scrollbars(true);
                 TRY(full_backtrace.try_appendff("==== {} ====\n{}\n", backtrace.title, backtrace.text));
             }
 
             for (auto& cpu_registers : results.thread_cpu_registers) {
-                auto& container = cpu_registers_tab_widget->add_tab<GUI::Widget>(TRY(String::from_deprecated_string(cpu_registers.title)));
+                auto& container = cpu_registers_tab_widget.add_tab<GUI::Widget>(TRY(String::from_deprecated_string(cpu_registers.title)));
                 container.template set_layout<GUI::VerticalBoxLayout>(4);
-                auto cpu_registers_text_editor = TRY(container.template try_add<GUI::TextEditor>());
-                cpu_registers_text_editor->set_text(cpu_registers.text);
-                cpu_registers_text_editor->set_mode(GUI::TextEditor::Mode::ReadOnly);
-                cpu_registers_text_editor->set_wrapping_mode(GUI::TextEditor::WrappingMode::NoWrap);
-                cpu_registers_text_editor->set_should_hide_unnecessary_scrollbars(true);
+                auto& cpu_registers_text_editor = container.template add<GUI::TextEditor>();
+                cpu_registers_text_editor.set_text(cpu_registers.text);
+                cpu_registers_text_editor.set_mode(GUI::TextEditor::Mode::ReadOnly);
+                cpu_registers_text_editor.set_wrapping_mode(GUI::TextEditor::WrappingMode::NoWrap);
+                cpu_registers_text_editor.set_should_hide_unnecessary_scrollbars(true);
             }
 
             progressbar.set_visible(false);

--- a/Userland/Applications/FileManager/PropertiesWindow.cpp
+++ b/Userland/Applications/FileManager/PropertiesWindow.cpp
@@ -84,17 +84,17 @@ ErrorOr<void> PropertiesWindow::create_widgets(bool disable_rename)
 
     button_widget.add_spacer();
 
-    auto ok_button = TRY(make_button("OK"_string, button_widget));
-    ok_button->on_click = [this](auto) {
+    auto& ok_button = make_button("OK"_string, button_widget);
+    ok_button.on_click = [this](auto) {
         if (apply_changes())
             close();
     };
-    auto cancel_button = TRY(make_button("Cancel"_string, button_widget));
-    cancel_button->on_click = [this](auto) {
+    auto& cancel_button = make_button("Cancel"_string, button_widget);
+    cancel_button.on_click = [this](auto) {
         close();
     };
 
-    m_apply_button = TRY(make_button("Apply"_string, button_widget));
+    m_apply_button = make_button("Apply"_string, button_widget);
     m_apply_button->on_click = [this](auto) { apply_changes(); };
     m_apply_button->set_enabled(false);
 
@@ -592,7 +592,7 @@ ErrorOr<void> PropertiesWindow::setup_permission_checkboxes(GUI::CheckBox& box_r
     return {};
 }
 
-ErrorOr<NonnullRefPtr<GUI::Button>> PropertiesWindow::make_button(String text, GUI::Widget& parent)
+GUI::Button& PropertiesWindow::make_button(String text, GUI::Widget& parent)
 {
     auto& button = parent.add<GUI::Button>(text);
     button.set_fixed_size(70, 22);

--- a/Userland/Applications/FileManager/PropertiesWindow.cpp
+++ b/Userland/Applications/FileManager/PropertiesWindow.cpp
@@ -74,15 +74,15 @@ ErrorOr<void> PropertiesWindow::create_widgets(bool disable_rename)
     main_widget->set_layout<GUI::VerticalBoxLayout>(4, 6);
     main_widget->set_fill_with_background_color(true);
 
-    auto tab_widget = TRY(main_widget->try_add<GUI::TabWidget>());
+    auto& tab_widget = main_widget->add<GUI::TabWidget>();
     TRY(create_general_tab(tab_widget, disable_rename));
     TRY(create_file_type_specific_tabs(tab_widget));
 
-    auto button_widget = TRY(main_widget->try_add<GUI::Widget>());
-    button_widget->set_layout<GUI::HorizontalBoxLayout>(GUI::Margins {}, 5);
-    button_widget->set_fixed_height(22);
+    auto& button_widget = main_widget->add<GUI::Widget>();
+    button_widget.set_layout<GUI::HorizontalBoxLayout>(GUI::Margins {}, 5);
+    button_widget.set_fixed_height(22);
 
-    button_widget->add_spacer();
+    button_widget.add_spacer();
 
     auto ok_button = TRY(make_button("OK"_string, button_widget));
     ok_button->on_click = [this](auto) {
@@ -594,8 +594,8 @@ ErrorOr<void> PropertiesWindow::setup_permission_checkboxes(GUI::CheckBox& box_r
 
 ErrorOr<NonnullRefPtr<GUI::Button>> PropertiesWindow::make_button(String text, GUI::Widget& parent)
 {
-    auto button = TRY(parent.try_add<GUI::Button>(text));
-    button->set_fixed_size(70, 22);
+    auto& button = parent.add<GUI::Button>(text);
+    button.set_fixed_size(70, 22);
     return button;
 }
 

--- a/Userland/Applications/FileManager/PropertiesWindow.h
+++ b/Userland/Applications/FileManager/PropertiesWindow.h
@@ -79,7 +79,7 @@ private:
         return "Unknown"sv;
     }
 
-    static ErrorOr<NonnullRefPtr<GUI::Button>> make_button(String, GUI::Widget& parent);
+    static GUI::Button& make_button(String, GUI::Widget& parent);
     ErrorOr<void> setup_permission_checkboxes(GUI::CheckBox& box_read, GUI::CheckBox& box_write, GUI::CheckBox& box_execute, PermissionMasks masks, mode_t mode);
     void permission_changed(mode_t mask, bool set);
     bool apply_changes();

--- a/Userland/Applications/Maps/main.cpp
+++ b/Userland/Applications/Maps/main.cpp
@@ -49,35 +49,35 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     root_widget->set_layout<GUI::VerticalBoxLayout>(GUI::Margins {}, 2);
 
     // Toolbar
-    auto toolbar_container = TRY(root_widget->try_add<GUI::ToolbarContainer>());
-    auto toolbar = TRY(toolbar_container->try_add<GUI::Toolbar>());
+    auto& toolbar_container = root_widget->add<GUI::ToolbarContainer>();
+    auto& toolbar = toolbar_container.add<GUI::Toolbar>();
 
     // Main Widget
-    auto main_widget = TRY(root_widget->try_add<GUI::HorizontalSplitter>());
+    auto& main_widget = root_widget->add<GUI::HorizontalSplitter>();
 
     // Map widget
     Maps::UsersMapWidget::Options options {};
     options.center.latitude = Config::read_string("Maps"sv, "MapView"sv, "CenterLatitude"sv, "30"sv).to_double().value_or(30.0);
     options.center.longitude = Config::read_string("Maps"sv, "MapView"sv, "CenterLongitude"sv, "0"sv).to_double().value_or(0.0);
     options.zoom = Config::read_i32("Maps"sv, "MapView"sv, "Zoom"sv, MAP_ZOOM_DEFAULT);
-    auto map_widget = TRY(main_widget->try_add<Maps::UsersMapWidget>(options));
-    map_widget->set_frame_style(Gfx::FrameStyle::SunkenContainer);
-    map_widget->set_show_users(Config::read_bool("Maps"sv, "MapView"sv, "ShowUsers"sv, false));
+    auto& map_widget = main_widget.add<Maps::UsersMapWidget>(options);
+    map_widget.set_frame_style(Gfx::FrameStyle::SunkenContainer);
+    map_widget.set_show_users(Config::read_bool("Maps"sv, "MapView"sv, "ShowUsers"sv, false));
 
     // Search panel
     auto search_panel = TRY(Maps::SearchPanel::create());
-    search_panel->on_places_change = [map_widget](auto) { map_widget->remove_markers_with_name("search"sv); };
-    search_panel->on_selected_place_change = [map_widget](auto const& place) {
+    search_panel->on_places_change = [&map_widget](auto) { map_widget.remove_markers_with_name("search"sv); };
+    search_panel->on_selected_place_change = [&map_widget](auto const& place) {
         // Remove old search markers
-        map_widget->remove_markers_with_name("search"sv);
+        map_widget.remove_markers_with_name("search"sv);
 
         // Add new marker and zoom into it
-        map_widget->add_marker({ place.latlng, place.name, {}, "search"_string });
-        map_widget->set_center(place.latlng);
-        map_widget->set_zoom(place.zoom);
+        map_widget.add_marker({ place.latlng, place.name, {}, "search"_string });
+        map_widget.set_center(place.latlng);
+        map_widget.set_zoom(place.zoom);
     };
     if (Config::read_bool("Maps"sv, "SearchPanel"sv, "Show"sv, false))
-        main_widget->insert_child_before(search_panel, map_widget);
+        main_widget.insert_child_before(search_panel, map_widget);
 
     // Main menu actions
     auto file_menu = window->add_menu("&File"_string);
@@ -90,27 +90,27 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto view_menu = window->add_menu("&View"_string);
     auto show_search_panel_action = GUI::Action::create_checkable(
-        "Show search panel", TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/find.png"sv)), [main_widget, search_panel, map_widget](auto& action) {
+        "Show search panel", TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/find.png"sv)), [&main_widget, search_panel, &map_widget](auto& action) {
             if (action.is_checked()) {
-                main_widget->insert_child_before(search_panel, map_widget);
+                main_widget.insert_child_before(search_panel, map_widget);
             } else {
-                map_widget->remove_markers_with_name("search"sv);
+                map_widget.remove_markers_with_name("search"sv);
                 search_panel->reset();
-                main_widget->remove_child(search_panel);
+                main_widget.remove_child(search_panel);
             }
         },
         window);
     show_search_panel_action->set_checked(Config::read_bool("Maps"sv, "SearchPanel"sv, "Show"sv, false));
     auto show_users_action = GUI::Action::create_checkable(
-        "Show SerenityOS users", TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/ladyball.png"sv)), [map_widget](auto& action) { map_widget->set_show_users(action.is_checked()); }, window);
-    show_users_action->set_checked(map_widget->show_users());
-    auto zoom_in_action = GUI::CommonActions::make_zoom_in_action([map_widget](auto&) { map_widget->set_zoom(map_widget->zoom() + 1); }, window);
-    auto zoom_out_action = GUI::CommonActions::make_zoom_out_action([map_widget](auto&) { map_widget->set_zoom(map_widget->zoom() - 1); }, window);
-    auto reset_zoom_action = GUI::CommonActions::make_reset_zoom_action([map_widget](auto&) { map_widget->set_zoom(MAP_ZOOM_DEFAULT); }, window);
-    auto fullscreen_action = GUI::CommonActions::make_fullscreen_action([window, toolbar_container, map_widget](auto&) {
+        "Show SerenityOS users", TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/ladyball.png"sv)), [&map_widget](auto& action) { map_widget.set_show_users(action.is_checked()); }, window);
+    show_users_action->set_checked(map_widget.show_users());
+    auto zoom_in_action = GUI::CommonActions::make_zoom_in_action([&map_widget](auto&) { map_widget.set_zoom(map_widget.zoom() + 1); }, window);
+    auto zoom_out_action = GUI::CommonActions::make_zoom_out_action([&map_widget](auto&) { map_widget.set_zoom(map_widget.zoom() - 1); }, window);
+    auto reset_zoom_action = GUI::CommonActions::make_reset_zoom_action([&map_widget](auto&) { map_widget.set_zoom(MAP_ZOOM_DEFAULT); }, window);
+    auto fullscreen_action = GUI::CommonActions::make_fullscreen_action([window, &toolbar_container, &map_widget](auto&) {
         window->set_fullscreen(!window->is_fullscreen());
-        toolbar_container->set_visible(!window->is_fullscreen());
-        map_widget->set_frame_style(window->is_fullscreen() ? Gfx::FrameStyle::NoFrame : Gfx::FrameStyle::SunkenContainer);
+        toolbar_container.set_visible(!window->is_fullscreen());
+        map_widget.set_frame_style(window->is_fullscreen() ? Gfx::FrameStyle::NoFrame : Gfx::FrameStyle::SunkenContainer);
     },
         window);
     view_menu->add_action(show_search_panel_action);
@@ -128,24 +128,24 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     help_menu->add_action(GUI::CommonActions::make_about_action("Maps"_string, app_icon, window));
 
     // Main toolbar actions
-    toolbar->add_action(show_search_panel_action);
-    toolbar->add_separator();
-    toolbar->add_action(show_users_action);
-    toolbar->add_separator();
-    toolbar->add_action(zoom_in_action);
-    toolbar->add_action(zoom_out_action);
-    toolbar->add_action(reset_zoom_action);
-    toolbar->add_separator();
-    toolbar->add_action(open_settings_action);
+    toolbar.add_action(show_search_panel_action);
+    toolbar.add_separator();
+    toolbar.add_action(show_users_action);
+    toolbar.add_separator();
+    toolbar.add_action(zoom_in_action);
+    toolbar.add_action(zoom_out_action);
+    toolbar.add_action(reset_zoom_action);
+    toolbar.add_separator();
+    toolbar.add_action(open_settings_action);
 
     window->show();
 
     // Remember last window state
     int exec = app->exec();
     Config::write_bool("Maps"sv, "SearchPanel"sv, "Show"sv, show_search_panel_action->is_checked());
-    Config::write_string("Maps"sv, "MapView"sv, "CenterLatitude"sv, TRY(String::number(map_widget->center().latitude)));
-    Config::write_string("Maps"sv, "MapView"sv, "CenterLongitude"sv, TRY(String::number(map_widget->center().longitude)));
-    Config::write_i32("Maps"sv, "MapView"sv, "Zoom"sv, map_widget->zoom());
-    Config::write_bool("Maps"sv, "MapView"sv, "ShowUsers"sv, map_widget->show_users());
+    Config::write_string("Maps"sv, "MapView"sv, "CenterLatitude"sv, TRY(String::number(map_widget.center().latitude)));
+    Config::write_string("Maps"sv, "MapView"sv, "CenterLongitude"sv, TRY(String::number(map_widget.center().longitude)));
+    Config::write_i32("Maps"sv, "MapView"sv, "Zoom"sv, map_widget.zoom());
+    Config::write_bool("Maps"sv, "MapView"sv, "ShowUsers"sv, map_widget.show_users());
     return exec;
 }

--- a/Userland/Applications/Piano/MainWidget.cpp
+++ b/Userland/Applications/Piano/MainWidget.cpp
@@ -39,11 +39,11 @@ ErrorOr<void> MainWidget::initialize()
     set_layout<GUI::VerticalBoxLayout>(2, 2);
     set_fill_with_background_color(true);
 
-    m_wave_widget = TRY(try_add<WaveWidget>(m_track_manager));
+    m_wave_widget = add<WaveWidget>(m_track_manager);
     m_wave_widget->set_fixed_height(100);
     TRY(m_wave_widget->set_sample_size(sample_count));
 
-    m_tab_widget = TRY(try_add<GUI::TabWidget>());
+    m_tab_widget = add<GUI::TabWidget>();
     m_roll_widget = m_tab_widget->add_tab<RollWidget>("Piano Roll"_string, m_track_manager);
 
     m_roll_widget->set_fixed_height(300);
@@ -51,23 +51,23 @@ ErrorOr<void> MainWidget::initialize()
     m_tab_widget->add_tab<SamplerWidget>("Sampler"_string, m_track_manager);
     m_player_widget = TRY(try_add<PlayerWidget>(m_track_manager, *this, m_audio_loop));
 
-    m_keys_and_knobs_container = TRY(try_add<GUI::Widget>());
+    m_keys_and_knobs_container = add<GUI::Widget>();
     m_keys_and_knobs_container->set_layout<GUI::HorizontalBoxLayout>(GUI::Margins {}, 2);
     m_keys_and_knobs_container->set_fixed_height(130);
     m_keys_and_knobs_container->set_fill_with_background_color(true);
 
-    m_keys_widget = TRY(m_keys_and_knobs_container->try_add<KeysWidget>(m_track_manager.keyboard()));
+    m_keys_widget = m_keys_and_knobs_container->add<KeysWidget>(m_track_manager.keyboard());
 
-    m_octave_container = TRY(m_keys_and_knobs_container->try_add<GUI::Widget>());
+    m_octave_container = m_keys_and_knobs_container->add<GUI::Widget>();
     m_octave_container->set_preferred_width(GUI::SpecialDimension::Fit);
     m_octave_container->set_layout<GUI::VerticalBoxLayout>();
-    auto octave_label = TRY(m_octave_container->try_add<GUI::Label>("Octave"_string));
-    octave_label->set_preferred_width(GUI::SpecialDimension::Fit);
-    m_octave_value = TRY(m_octave_container->try_add<GUI::Label>(TRY(String::number(m_track_manager.keyboard()->virtual_keyboard_octave()))));
+    auto& octave_label = m_octave_container->add<GUI::Label>("Octave"_string);
+    octave_label.set_preferred_width(GUI::SpecialDimension::Fit);
+    m_octave_value = m_octave_container->add<GUI::Label>(TRY(String::number(m_track_manager.keyboard()->virtual_keyboard_octave())));
     m_octave_value->set_preferred_width(GUI::SpecialDimension::Fit);
 
     // FIXME: Implement vertical flipping in GUI::Slider, not here.
-    m_octave_knob = TRY(m_octave_container->try_add<GUI::VerticalSlider>());
+    m_octave_knob = m_octave_container->add<GUI::VerticalSlider>();
     m_octave_knob->set_preferred_width(GUI::SpecialDimension::Fit);
     m_octave_knob->set_tooltip_deprecated("Z: octave down, X: octave up");
     m_octave_knob->set_range(octave_min - 1, octave_max - 1);
@@ -80,7 +80,7 @@ ErrorOr<void> MainWidget::initialize()
         m_octave_value->set_text(String::number(new_octave).release_value_but_fixme_should_propagate_errors());
     };
 
-    m_knobs_widget = TRY(m_keys_and_knobs_container->try_add<GUI::StackWidget>());
+    m_knobs_widget = m_keys_and_knobs_container->add<GUI::StackWidget>();
     for (auto track : m_track_manager.tracks())
         TRY(m_track_controls.try_append(TRY(m_knobs_widget->try_add<TrackControlsWidget>(TRY(track->try_make_weak_ptr())))));
 

--- a/Userland/Applications/Piano/PlayerWidget.cpp
+++ b/Userland/Applications/Piano/PlayerWidget.cpp
@@ -45,10 +45,10 @@ ErrorOr<void> PlayerWidget::initialize()
     set_fill_with_background_color(true);
     TRY(m_track_number_choices.try_append("1"));
 
-    RefPtr<GUI::Label> label = TRY(try_add<GUI::Label>("Track"_string));
+    RefPtr<GUI::Label> label = add<GUI::Label>("Track"_string);
     label->set_max_width(75);
 
-    m_track_dropdown = TRY(try_add<GUI::ComboBox>());
+    m_track_dropdown = add<GUI::ComboBox>();
     m_track_dropdown->set_max_width(75);
     m_track_dropdown->set_model(*GUI::ItemListModel<DeprecatedString>::create(m_track_number_choices));
     m_track_dropdown->set_only_allow_values_from_model(true);
@@ -59,7 +59,7 @@ ErrorOr<void> PlayerWidget::initialize()
         m_main_widget.update_selected_track();
     };
 
-    m_add_track_button = TRY(try_add<GUI::Button>());
+    m_add_track_button = add<GUI::Button>();
     m_add_track_button->set_icon(*m_add_track_icon);
     m_add_track_button->set_fixed_width(30);
     m_add_track_button->set_tooltip_deprecated("Add Track");
@@ -68,7 +68,7 @@ ErrorOr<void> PlayerWidget::initialize()
         add_track();
     };
 
-    m_next_track_button = TRY(try_add<GUI::Button>());
+    m_next_track_button = add<GUI::Button>();
     m_next_track_button->set_icon(*m_next_track_icon);
     m_next_track_button->set_fixed_width(30);
     m_next_track_button->set_tooltip_deprecated("Next Track");
@@ -77,7 +77,7 @@ ErrorOr<void> PlayerWidget::initialize()
         next_track();
     };
 
-    m_play_button = TRY(try_add<GUI::Button>());
+    m_play_button = add<GUI::Button>();
     m_play_button->set_icon(*m_pause_icon);
     m_play_button->set_fixed_width(30);
     m_play_button->set_tooltip_deprecated("Play/Pause playback");
@@ -92,7 +92,7 @@ ErrorOr<void> PlayerWidget::initialize()
         }
     };
 
-    m_back_button = TRY(try_add<GUI::Button>());
+    m_back_button = add<GUI::Button>();
     m_back_button->set_icon(*m_back_icon);
     m_back_button->set_fixed_width(30);
     m_back_button->set_tooltip_deprecated("Previous Note");
@@ -101,7 +101,7 @@ ErrorOr<void> PlayerWidget::initialize()
         m_track_manager.time_forward(-(sample_rate / (beats_per_minute / 60) / notes_per_beat));
     };
 
-    m_next_button = TRY(try_add<GUI::Button>());
+    m_next_button = add<GUI::Button>();
     m_next_button->set_icon(*m_next_icon);
     m_next_button->set_fixed_width(30);
     m_next_button->set_tooltip_deprecated("Next Note");

--- a/Userland/Applications/Piano/TrackControlsWidget.cpp
+++ b/Userland/Applications/Piano/TrackControlsWidget.cpp
@@ -26,24 +26,24 @@ ErrorOr<NonnullRefPtr<TrackControlsWidget>> TrackControlsWidget::try_create(Weak
     widget->set_preferred_width(GUI::SpecialDimension::Grow);
     widget->set_fill_with_background_color(true);
 
-    auto mastering_parameters = TRY(widget->try_add<GUI::GroupBox>());
-    mastering_parameters->set_layout<GUI::HorizontalBoxLayout>();
+    auto& mastering_parameters = widget->add<GUI::GroupBox>();
+    mastering_parameters.set_layout<GUI::HorizontalBoxLayout>();
 
     auto strong_track = widget->m_track.value();
 
     for (auto& parameter : strong_track->track_mastering()->parameters())
-        (void)TRY(mastering_parameters->try_add<ProcessorParameterWidget>(parameter));
+        mastering_parameters.add<ProcessorParameterWidget>(parameter);
 
     TRY(widget->m_processor_groups.try_append(mastering_parameters));
 
     widget->add_spacer();
 
     for (auto& processor : strong_track->processor_chain()) {
-        auto processor_parameters = TRY(widget->try_add<GUI::GroupBox>());
-        processor_parameters->set_layout<GUI::HorizontalBoxLayout>();
+        auto& processor_parameters = widget->add<GUI::GroupBox>();
+        processor_parameters.set_layout<GUI::HorizontalBoxLayout>();
 
         for (auto& parameter : processor->parameters())
-            (void)TRY(processor_parameters->try_add<ProcessorParameterWidget>(parameter));
+            processor_parameters.add<ProcessorParameterWidget>(parameter);
 
         TRY(widget->m_processor_groups.try_append(processor_parameters));
     }

--- a/Userland/Applications/PixelPaint/Filters/Bloom.cpp
+++ b/Userland/Applications/PixelPaint/Filters/Bloom.cpp
@@ -40,39 +40,39 @@ ErrorOr<RefPtr<GUI::Widget>> Bloom::get_settings_widget()
         auto settings_widget = GUI::Widget::construct();
         settings_widget->set_layout<GUI::VerticalBoxLayout>();
 
-        auto name_label = TRY(settings_widget->try_add<GUI::Label>("Bloom Filter"_string));
-        name_label->set_font_weight(Gfx::FontWeight::Bold);
-        name_label->set_text_alignment(Gfx::TextAlignment::CenterLeft);
-        name_label->set_fixed_height(20);
+        auto& name_label = settings_widget->add<GUI::Label>("Bloom Filter"_string);
+        name_label.set_font_weight(Gfx::FontWeight::Bold);
+        name_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
+        name_label.set_fixed_height(20);
 
-        auto luma_lower_container = TRY(settings_widget->try_add<GUI::Widget>());
-        luma_lower_container->set_fixed_height(50);
-        luma_lower_container->set_layout<GUI::VerticalBoxLayout>(GUI::Margins { 4, 0, 4, 0 });
+        auto& luma_lower_container = settings_widget->add<GUI::Widget>();
+        luma_lower_container.set_fixed_height(50);
+        luma_lower_container.set_layout<GUI::VerticalBoxLayout>(GUI::Margins { 4, 0, 4, 0 });
 
-        auto luma_lower_label = TRY(luma_lower_container->try_add<GUI::Label>("Luma lower bound:"_string));
-        luma_lower_label->set_text_alignment(Gfx::TextAlignment::CenterLeft);
-        luma_lower_label->set_fixed_height(20);
+        auto& luma_lower_label = luma_lower_container.add<GUI::Label>("Luma lower bound:"_string);
+        luma_lower_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
+        luma_lower_label.set_fixed_height(20);
 
-        auto luma_lower_slider = TRY(luma_lower_container->try_add<GUI::ValueSlider>(Orientation::Horizontal));
-        luma_lower_slider->set_range(0, 255);
-        luma_lower_slider->set_value(m_luma_lower);
-        luma_lower_slider->on_change = [&](int value) {
+        auto& luma_lower_slider = luma_lower_container.add<GUI::ValueSlider>(Orientation::Horizontal);
+        luma_lower_slider.set_range(0, 255);
+        luma_lower_slider.set_value(m_luma_lower);
+        luma_lower_slider.on_change = [&](int value) {
             m_luma_lower = value;
             update_preview();
         };
 
-        auto radius_container = TRY(settings_widget->try_add<GUI::Widget>());
-        radius_container->set_fixed_height(50);
-        radius_container->set_layout<GUI::VerticalBoxLayout>(GUI::Margins { 4, 0, 4, 0 });
+        auto& radius_container = settings_widget->add<GUI::Widget>();
+        radius_container.set_fixed_height(50);
+        radius_container.set_layout<GUI::VerticalBoxLayout>(GUI::Margins { 4, 0, 4, 0 });
 
-        auto radius_label = TRY(radius_container->try_add<GUI::Label>("Blur Radius:"_string));
-        radius_label->set_text_alignment(Gfx::TextAlignment::CenterLeft);
-        radius_label->set_fixed_height(20);
+        auto& radius_label = radius_container.add<GUI::Label>("Blur Radius:"_string);
+        radius_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
+        radius_label.set_fixed_height(20);
 
-        auto radius_slider = TRY(radius_container->try_add<GUI::ValueSlider>(Orientation::Horizontal, "px"_string));
-        radius_slider->set_range(0, 50);
-        radius_slider->set_value(m_blur_radius);
-        radius_slider->on_change = [&](int value) {
+        auto& radius_slider = radius_container.add<GUI::ValueSlider>(Orientation::Horizontal, "px"_string);
+        radius_slider.set_range(0, 50);
+        radius_slider.set_value(m_blur_radius);
+        radius_slider.on_change = [&](int value) {
             m_blur_radius = value;
             update_preview();
         };

--- a/Userland/Applications/PixelPaint/Filters/FastBoxBlur.cpp
+++ b/Userland/Applications/PixelPaint/Filters/FastBoxBlur.cpp
@@ -42,15 +42,15 @@ ErrorOr<RefPtr<GUI::Widget>> FastBoxBlur::get_settings_widget()
         auto settings_widget = GUI::Widget::construct();
         settings_widget->set_layout<GUI::VerticalBoxLayout>();
 
-        auto name_label = TRY(settings_widget->try_add<GUI::Label>("Fast Box Blur Filter"_string));
-        name_label->set_font_weight(Gfx::FontWeight::Bold);
-        name_label->set_text_alignment(Gfx::TextAlignment::CenterLeft);
-        name_label->set_fixed_height(10);
+        auto& name_label = settings_widget->add<GUI::Label>("Fast Box Blur Filter"_string);
+        name_label.set_font_weight(Gfx::FontWeight::Bold);
+        name_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
+        name_label.set_fixed_height(10);
 
-        auto asymmetric_checkbox = TRY(settings_widget->try_add<GUI::CheckBox>("Use Asymmetric Radii"_string));
-        asymmetric_checkbox->set_checked(false);
-        asymmetric_checkbox->set_fixed_height(15);
-        asymmetric_checkbox->on_checked = [this](bool checked) {
+        auto& asymmetric_checkbox = settings_widget->add<GUI::CheckBox>("Use Asymmetric Radii"_string);
+        asymmetric_checkbox.set_checked(false);
+        asymmetric_checkbox.set_fixed_height(15);
+        asymmetric_checkbox.on_checked = [this](bool checked) {
             m_use_asymmetric_radii = checked;
             if (m_use_asymmetric_radii) {
                 m_vector_checkbox->set_visible(true);
@@ -68,7 +68,7 @@ ErrorOr<RefPtr<GUI::Widget>> FastBoxBlur::get_settings_widget()
             update_preview();
         };
 
-        m_vector_checkbox = TRY(settings_widget->try_add<GUI::CheckBox>("Use Direction and magnitude"_string));
+        m_vector_checkbox = settings_widget->add<GUI::CheckBox>("Use Direction and magnitude"_string);
         m_vector_checkbox->set_checked(false);
         m_vector_checkbox->set_visible(false);
         m_vector_checkbox->set_fixed_height(15);
@@ -84,36 +84,36 @@ ErrorOr<RefPtr<GUI::Widget>> FastBoxBlur::get_settings_widget()
             update_preview();
         };
 
-        m_radius_container = TRY(settings_widget->try_add<GUI::Widget>());
+        m_radius_container = settings_widget->add<GUI::Widget>();
         m_radius_container->set_fixed_height(20);
         m_radius_container->set_layout<GUI::HorizontalBoxLayout>(GUI::Margins { 4, 0, 4, 0 });
 
-        auto radius_label = TRY(m_radius_container->try_add<GUI::Label>("Radius:"_string));
-        radius_label->set_text_alignment(Gfx::TextAlignment::CenterLeft);
-        radius_label->set_fixed_size(50, 20);
+        auto& radius_label = m_radius_container->add<GUI::Label>("Radius:"_string);
+        radius_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
+        radius_label.set_fixed_size(50, 20);
 
-        auto radius_slider = TRY(m_radius_container->try_add<GUI::ValueSlider>(Orientation::Horizontal, "px"_string));
-        radius_slider->set_range(0, 25);
-        radius_slider->set_value(m_radius);
-        radius_slider->on_change = [&](int value) {
+        auto& radius_slider = m_radius_container->add<GUI::ValueSlider>(Orientation::Horizontal, "px"_string);
+        radius_slider.set_range(0, 25);
+        radius_slider.set_value(m_radius);
+        radius_slider.on_change = [&](int value) {
             m_radius = value;
             update_preview();
         };
 
-        m_asymmetric_radius_container = TRY(settings_widget->try_add<GUI::Widget>());
+        m_asymmetric_radius_container = settings_widget->add<GUI::Widget>();
         m_asymmetric_radius_container->set_visible(false);
         m_asymmetric_radius_container->set_fixed_height(50);
         m_asymmetric_radius_container->set_layout<GUI::VerticalBoxLayout>(GUI::Margins { 4, 0, 4, 0 });
 
-        auto radius_x_container = TRY(m_asymmetric_radius_container->try_add<GUI::Widget>());
-        radius_x_container->set_fixed_height(20);
-        radius_x_container->set_layout<GUI::HorizontalBoxLayout>();
+        auto& radius_x_container = m_asymmetric_radius_container->add<GUI::Widget>();
+        radius_x_container.set_fixed_height(20);
+        radius_x_container.set_layout<GUI::HorizontalBoxLayout>();
 
-        auto radius_x_label = TRY(radius_x_container->try_add<GUI::Label>("Radius X:"_string));
-        radius_x_label->set_text_alignment(Gfx::TextAlignment::CenterLeft);
-        radius_x_label->set_fixed_size(50, 20);
+        auto& radius_x_label = radius_x_container.add<GUI::Label>("Radius X:"_string);
+        radius_x_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
+        radius_x_label.set_fixed_size(50, 20);
 
-        m_radius_x_slider = TRY(radius_x_container->try_add<GUI::ValueSlider>(Orientation::Horizontal, "px"_string));
+        m_radius_x_slider = radius_x_container.add<GUI::ValueSlider>(Orientation::Horizontal, "px"_string);
         m_radius_x_slider->set_range(0, 50);
         m_radius_x_slider->set_value(m_radius_x);
         m_radius_x_slider->on_change = [&](int value) {
@@ -121,15 +121,15 @@ ErrorOr<RefPtr<GUI::Widget>> FastBoxBlur::get_settings_widget()
             update_preview();
         };
 
-        auto radius_y_container = TRY(m_asymmetric_radius_container->try_add<GUI::Widget>());
-        radius_y_container->set_fixed_height(20);
-        radius_y_container->set_layout<GUI::HorizontalBoxLayout>();
+        auto& radius_y_container = m_asymmetric_radius_container->add<GUI::Widget>();
+        radius_y_container.set_fixed_height(20);
+        radius_y_container.set_layout<GUI::HorizontalBoxLayout>();
 
-        auto radius_y_label = TRY(radius_y_container->try_add<GUI::Label>("Radius Y:"_string));
-        radius_y_label->set_text_alignment(Gfx::TextAlignment::CenterLeft);
-        radius_y_label->set_fixed_size(50, 20);
+        auto& radius_y_label = radius_y_container.add<GUI::Label>("Radius Y:"_string);
+        radius_y_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
+        radius_y_label.set_fixed_size(50, 20);
 
-        m_radius_y_slider = TRY(radius_y_container->try_add<GUI::ValueSlider>(Orientation::Horizontal, "px"_string));
+        m_radius_y_slider = radius_y_container.add<GUI::ValueSlider>(Orientation::Horizontal, "px"_string);
         m_radius_y_slider->set_range(0, 50);
         m_radius_y_slider->set_value(m_radius_y);
         m_radius_y_slider->on_change = [&](int value) {
@@ -137,20 +137,20 @@ ErrorOr<RefPtr<GUI::Widget>> FastBoxBlur::get_settings_widget()
             update_preview();
         };
 
-        m_vector_container = TRY(settings_widget->try_add<GUI::Widget>());
+        m_vector_container = settings_widget->add<GUI::Widget>();
         m_vector_container->set_visible(false);
         m_vector_container->set_fixed_height(50);
         m_vector_container->set_layout<GUI::VerticalBoxLayout>(GUI::Margins { 4, 0, 4, 0 });
 
-        auto angle_container = TRY(m_vector_container->try_add<GUI::Widget>());
-        angle_container->set_fixed_height(20);
-        angle_container->set_layout<GUI::HorizontalBoxLayout>();
+        auto& angle_container = m_vector_container->add<GUI::Widget>();
+        angle_container.set_fixed_height(20);
+        angle_container.set_layout<GUI::HorizontalBoxLayout>();
 
-        auto angle_label = TRY(angle_container->try_add<GUI::Label>("Angle:"_string));
-        angle_label->set_text_alignment(Gfx::TextAlignment::CenterLeft);
-        angle_label->set_fixed_size(60, 20);
+        auto& angle_label = angle_container.add<GUI::Label>("Angle:"_string);
+        angle_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
+        angle_label.set_fixed_size(60, 20);
 
-        m_angle_slider = TRY(angle_container->try_add<GUI::ValueSlider>(Orientation::Horizontal, "°"_string));
+        m_angle_slider = angle_container.add<GUI::ValueSlider>(Orientation::Horizontal, "°"_string);
         m_angle_slider->set_range(0, 360);
         m_angle_slider->set_value(m_angle);
         m_angle_slider->on_change = [&](int value) {
@@ -158,15 +158,15 @@ ErrorOr<RefPtr<GUI::Widget>> FastBoxBlur::get_settings_widget()
             update_preview();
         };
 
-        auto magnitude_container = TRY(m_vector_container->try_add<GUI::Widget>());
-        magnitude_container->set_fixed_height(20);
-        magnitude_container->set_layout<GUI::HorizontalBoxLayout>();
+        auto& magnitude_container = m_vector_container->add<GUI::Widget>();
+        magnitude_container.set_fixed_height(20);
+        magnitude_container.set_layout<GUI::HorizontalBoxLayout>();
 
-        auto magnitude_label = TRY(magnitude_container->try_add<GUI::Label>("Magnitude:"_string));
-        magnitude_label->set_text_alignment(Gfx::TextAlignment::CenterLeft);
-        magnitude_label->set_fixed_size(60, 20);
+        auto& magnitude_label = magnitude_container.add<GUI::Label>("Magnitude:"_string);
+        magnitude_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
+        magnitude_label.set_fixed_size(60, 20);
 
-        m_magnitude_slider = TRY(magnitude_container->try_add<GUI::ValueSlider>(Orientation::Horizontal, "px"_string));
+        m_magnitude_slider = magnitude_container.add<GUI::ValueSlider>(Orientation::Horizontal, "px"_string);
         m_magnitude_slider->set_range(0, 50);
         m_magnitude_slider->set_value(m_radius);
         m_magnitude_slider->on_change = [&](int value) {
@@ -174,11 +174,11 @@ ErrorOr<RefPtr<GUI::Widget>> FastBoxBlur::get_settings_widget()
             update_preview();
         };
 
-        auto gaussian_container = TRY(settings_widget->try_add<GUI::Widget>());
-        gaussian_container->set_fixed_height(20);
-        gaussian_container->set_layout<GUI::HorizontalBoxLayout>(GUI::Margins { 4, 0, 4, 0 });
+        auto& gaussian_container = settings_widget->add<GUI::Widget>();
+        gaussian_container.set_fixed_height(20);
+        gaussian_container.set_layout<GUI::HorizontalBoxLayout>(GUI::Margins { 4, 0, 4, 0 });
 
-        m_gaussian_checkbox = TRY(gaussian_container->try_add<GUI::CheckBox>("Approximate Gaussian Blur"_string));
+        m_gaussian_checkbox = gaussian_container.add<GUI::CheckBox>("Approximate Gaussian Blur"_string);
         m_gaussian_checkbox->set_checked(m_approximate_gauss);
         m_gaussian_checkbox->set_tooltip_deprecated("A real gaussian blur can be approximated by running the box blur multiple times with different weights.");
         m_gaussian_checkbox->on_checked = [this](bool checked) {

--- a/Userland/Applications/PixelPaint/Filters/Filter.cpp
+++ b/Userland/Applications/PixelPaint/Filters/Filter.cpp
@@ -28,10 +28,10 @@ ErrorOr<RefPtr<GUI::Widget>> Filter::get_settings_widget()
         auto settings_widget = GUI::Widget::construct();
         settings_widget->set_layout<GUI::VerticalBoxLayout>();
 
-        auto name_label = TRY(settings_widget->try_add<GUI::Label>(TRY(String::from_utf8(filter_name()))));
-        name_label->set_text_alignment(Gfx::TextAlignment::TopLeft);
+        auto& name_label = settings_widget->add<GUI::Label>(TRY(String::from_utf8(filter_name())));
+        name_label.set_text_alignment(Gfx::TextAlignment::TopLeft);
 
-        (void)TRY(settings_widget->try_add<GUI::Widget>());
+        settings_widget->add<GUI::Widget>();
         m_settings_widget = settings_widget;
     }
 

--- a/Userland/Applications/PixelPaint/Filters/HueAndSaturation.cpp
+++ b/Userland/Applications/PixelPaint/Filters/HueAndSaturation.cpp
@@ -34,15 +34,15 @@ ErrorOr<RefPtr<GUI::Widget>> HueAndSaturation::get_settings_widget()
         settings_widget->set_layout<GUI::VerticalBoxLayout>();
 
         auto add_slider = [&](auto name, int min, int max, auto member) -> ErrorOr<void> {
-            auto name_label = TRY(settings_widget->try_add<GUI::Label>(TRY(String::from_utf8(name))));
-            name_label->set_font_weight(Gfx::FontWeight::Bold);
-            name_label->set_text_alignment(Gfx::TextAlignment::CenterLeft);
-            name_label->set_fixed_height(20);
+            auto& name_label = settings_widget->add<GUI::Label>(TRY(String::from_utf8(name)));
+            name_label.set_font_weight(Gfx::FontWeight::Bold);
+            name_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
+            name_label.set_fixed_height(20);
 
-            auto slider = TRY(settings_widget->try_add<GUI::ValueSlider>(Orientation::Horizontal));
-            slider->set_range(min, max);
-            slider->set_value(m_hue);
-            slider->on_change = [this, member](int value) {
+            auto& slider = settings_widget->add<GUI::ValueSlider>(Orientation::Horizontal);
+            slider.set_range(min, max);
+            slider.set_value(m_hue);
+            slider.on_change = [this, member](int value) {
                 this->*member = value;
                 update_preview();
             };

--- a/Userland/Applications/PixelPaint/Filters/Sepia.cpp
+++ b/Userland/Applications/PixelPaint/Filters/Sepia.cpp
@@ -23,23 +23,23 @@ ErrorOr<RefPtr<GUI::Widget>> Sepia::get_settings_widget()
         auto settings_widget = GUI::Widget::construct();
         settings_widget->set_layout<GUI::VerticalBoxLayout>();
 
-        auto name_label = TRY(settings_widget->try_add<GUI::Label>("Sepia Filter"_string));
-        name_label->set_font_weight(Gfx::FontWeight::Bold);
-        name_label->set_text_alignment(Gfx::TextAlignment::CenterLeft);
-        name_label->set_fixed_height(20);
+        auto& name_label = settings_widget->add<GUI::Label>("Sepia Filter"_string);
+        name_label.set_font_weight(Gfx::FontWeight::Bold);
+        name_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
+        name_label.set_fixed_height(20);
 
-        auto amount_container = TRY(settings_widget->try_add<GUI::Widget>());
-        amount_container->set_fixed_height(20);
-        amount_container->set_layout<GUI::HorizontalBoxLayout>(GUI::Margins { 4, 0, 4, 0 });
+        auto& amount_container = settings_widget->add<GUI::Widget>();
+        amount_container.set_fixed_height(20);
+        amount_container.set_layout<GUI::HorizontalBoxLayout>(GUI::Margins { 4, 0, 4, 0 });
 
-        auto amount_label = TRY(amount_container->try_add<GUI::Label>("Amount:"_string));
-        amount_label->set_text_alignment(Gfx::TextAlignment::CenterLeft);
-        amount_label->set_fixed_size(50, 20);
+        auto& amount_label = amount_container.add<GUI::Label>("Amount:"_string);
+        amount_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
+        amount_label.set_fixed_size(50, 20);
 
-        auto amount_slider = TRY(amount_container->try_add<GUI::ValueSlider>(Orientation::Horizontal, "%"_string));
-        amount_slider->set_range(0, 100);
-        amount_slider->set_value(m_amount * 100);
-        amount_slider->on_change = [this](int value) {
+        auto& amount_slider = amount_container.add<GUI::ValueSlider>(Orientation::Horizontal, "%"_string);
+        amount_slider.set_range(0, 100);
+        amount_slider.set_value(m_amount * 100);
+        amount_slider.on_change = [this](int value) {
             m_amount = value * 0.01f;
             update_preview();
         };

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -1190,7 +1190,7 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
     toolbar.add_action(*m_zoom_out_action);
     toolbar.add_action(*m_reset_zoom_action);
 
-    m_zoom_combobox = TRY(toolbar.try_add<GUI::ComboBox>());
+    m_zoom_combobox = toolbar.add<GUI::ComboBox>();
     m_zoom_combobox->set_max_width(75);
     m_zoom_combobox->set_model(*GUI::ItemListModel<DeprecatedString>::create(s_suggested_zoom_levels));
     m_zoom_combobox->on_change = [this](DeprecatedString const& value, GUI::ModelIndex const& index) {

--- a/Userland/Applications/PixelPaint/ToolPropertiesWidget.cpp
+++ b/Userland/Applications/PixelPaint/ToolPropertiesWidget.cpp
@@ -22,7 +22,6 @@ ToolPropertiesWidget::ToolPropertiesWidget()
     m_group_box = add<GUI::GroupBox>("Tool properties"sv);
     m_group_box->set_layout<GUI::VerticalBoxLayout>(8);
     m_tool_widget_stack = m_group_box->add<GUI::StackWidget>();
-    m_blank_widget = m_tool_widget_stack->add<GUI::Widget>();
     m_error_label = m_tool_widget_stack->add<GUI::Label>();
     m_error_label->set_enabled(false);
 }
@@ -33,18 +32,7 @@ void ToolPropertiesWidget::set_active_tool(Tool* tool)
         return;
 
     m_active_tool = tool;
-    auto active_tool_widget_or_error = tool->get_properties_widget();
-    if (active_tool_widget_or_error.is_error()) {
-        m_active_tool_widget = nullptr;
-        m_error_label->set_text(String::formatted("Error creating tool properties: {}", active_tool_widget_or_error.release_error()).release_value_but_fixme_should_propagate_errors());
-        m_tool_widget_stack->set_active_widget(m_error_label);
-        return;
-    }
-    m_active_tool_widget = active_tool_widget_or_error.release_value();
-    if (m_active_tool_widget == nullptr) {
-        m_tool_widget_stack->set_active_widget(m_blank_widget);
-        return;
-    }
+    m_active_tool_widget = tool->get_properties_widget();
 
     if (!m_tool_widget_stack->is_ancestor_of(*m_active_tool_widget))
         m_tool_widget_stack->add_child(*m_active_tool_widget);

--- a/Userland/Applications/PixelPaint/ToolPropertiesWidget.h
+++ b/Userland/Applications/PixelPaint/ToolPropertiesWidget.h
@@ -31,7 +31,6 @@ private:
 
     Tool* m_active_tool { nullptr };
     RefPtr<GUI::StackWidget> m_tool_widget_stack;
-    RefPtr<GUI::Widget> m_blank_widget;
     RefPtr<GUI::Label> m_error_label;
     GUI::Widget* m_active_tool_widget { nullptr };
 };

--- a/Userland/Applications/PixelPaint/Tools/BrushTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/BrushTool.cpp
@@ -197,7 +197,7 @@ void BrushTool::draw_line(Gfx::Bitmap& bitmap, Gfx::Color color, Gfx::IntPoint s
     }
 }
 
-ErrorOr<GUI::Widget*> BrushTool::get_properties_widget()
+NonnullRefPtr<GUI::Widget> BrushTool::get_properties_widget()
 {
     if (!m_properties_widget) {
         auto properties_widget = GUI::Widget::construct();
@@ -348,7 +348,7 @@ ErrorOr<GUI::Widget*> BrushTool::get_properties_widget()
         m_properties_widget = properties_widget;
     }
 
-    return m_properties_widget.ptr();
+    return *m_properties_widget;
 }
 
 NonnullRefPtr<Gfx::Bitmap> BrushTool::build_cursor()

--- a/Userland/Applications/PixelPaint/Tools/BrushTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/BrushTool.cpp
@@ -203,12 +203,12 @@ ErrorOr<GUI::Widget*> BrushTool::get_properties_widget()
         auto properties_widget = GUI::Widget::construct();
         properties_widget->set_layout<GUI::VerticalBoxLayout>();
 
-        auto mode_container = TRY(properties_widget->try_add<GUI::Widget>());
-        mode_container->set_fixed_height(20);
-        mode_container->set_layout<GUI::HorizontalBoxLayout>();
-        auto mode_label = TRY(mode_container->try_add<GUI::Label>("Mode:"_string));
-        mode_label->set_text_alignment(Gfx::TextAlignment::CenterLeft);
-        mode_label->set_fixed_size(60, 20);
+        auto& mode_container = properties_widget->add<GUI::Widget>();
+        mode_container.set_fixed_height(20);
+        mode_container.set_layout<GUI::HorizontalBoxLayout>();
+        auto& mode_label = mode_container.add<GUI::Label>("Mode:"_string);
+        mode_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
+        mode_label.set_fixed_size(60, 20);
 
         static constexpr auto s_mode_names = [] {
             Array<StringView, (int)BrushMode::__Count> names;
@@ -233,18 +233,18 @@ ErrorOr<GUI::Widget*> BrushTool::get_properties_widget()
             return names;
         }();
 
-        auto mode_combobox = TRY(mode_container->try_add<GUI::ComboBox>());
-        mode_combobox->set_only_allow_values_from_model(true);
-        mode_combobox->set_model(*GUI::ItemListModel<StringView, decltype(s_mode_names)>::create(s_mode_names));
-        mode_combobox->set_selected_index((int)m_mode, GUI::AllowCallback::No);
+        auto& mode_combobox = mode_container.add<GUI::ComboBox>();
+        mode_combobox.set_only_allow_values_from_model(true);
+        mode_combobox.set_model(*GUI::ItemListModel<StringView, decltype(s_mode_names)>::create(s_mode_names));
+        mode_combobox.set_selected_index((int)m_mode, GUI::AllowCallback::No);
 
-        auto priority_container = TRY(properties_widget->try_add<GUI::Widget>());
-        priority_container->set_fixed_height(20);
-        priority_container->set_visible(false);
-        priority_container->set_layout<GUI::HorizontalBoxLayout>();
-        auto priority_label = TRY(priority_container->try_add<GUI::Label>("Priority:"_string));
-        priority_label->set_text_alignment(Gfx::TextAlignment::CenterLeft);
-        priority_label->set_fixed_size(60, 20);
+        auto& priority_container = properties_widget->add<GUI::Widget>();
+        priority_container.set_fixed_height(20);
+        priority_container.set_visible(false);
+        priority_container.set_layout<GUI::HorizontalBoxLayout>();
+        auto& priority_label = priority_container.add<GUI::Label>("Priority:"_string);
+        priority_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
+        priority_label.set_fixed_size(60, 20);
 
         static constexpr auto s_priority_names = [] {
             Array<StringView, (int)PriorityMode::__Count> names;
@@ -266,37 +266,37 @@ ErrorOr<GUI::Widget*> BrushTool::get_properties_widget()
             return names;
         }();
 
-        auto priority_combobox = TRY(priority_container->try_add<GUI::ComboBox>());
-        priority_combobox->set_only_allow_values_from_model(true);
-        priority_combobox->set_model(*GUI::ItemListModel<StringView, decltype(s_priority_names)>::create(s_priority_names));
-        priority_combobox->set_selected_index((int)m_priority, GUI::AllowCallback::No);
+        auto& priority_combobox = priority_container.add<GUI::ComboBox>();
+        priority_combobox.set_only_allow_values_from_model(true);
+        priority_combobox.set_model(*GUI::ItemListModel<StringView, decltype(s_priority_names)>::create(s_priority_names));
+        priority_combobox.set_selected_index((int)m_priority, GUI::AllowCallback::No);
 
-        auto exposure_container = TRY(properties_widget->try_add<GUI::Widget>());
-        exposure_container->set_fixed_height(20);
-        exposure_container->set_visible(false);
-        exposure_container->set_layout<GUI::HorizontalBoxLayout>();
+        auto& exposure_container = properties_widget->add<GUI::Widget>();
+        exposure_container.set_fixed_height(20);
+        exposure_container.set_visible(false);
+        exposure_container.set_layout<GUI::HorizontalBoxLayout>();
 
-        auto exposure_label = TRY(exposure_container->try_add<GUI::Label>("Exposure:"_string));
-        exposure_label->set_text_alignment(Gfx::TextAlignment::CenterLeft);
-        exposure_label->set_fixed_size(60, 20);
+        auto& exposure_label = exposure_container.add<GUI::Label>("Exposure:"_string);
+        exposure_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
+        exposure_label.set_fixed_size(60, 20);
 
-        auto exposure_slider = TRY(exposure_container->try_add<GUI::ValueSlider>(Orientation::Horizontal, "%"_string));
-        exposure_slider->set_range(1, 100);
-        exposure_slider->set_value(m_exposure * 100);
+        auto& exposure_slider = exposure_container.add<GUI::ValueSlider>(Orientation::Horizontal, "%"_string);
+        exposure_slider.set_range(1, 100);
+        exposure_slider.set_value(m_exposure * 100);
 
-        mode_combobox->on_change = [this, priority_container, exposure_container](auto&, auto& model_index) {
+        mode_combobox.on_change = [this, &priority_container, &exposure_container](auto&, auto& model_index) {
             VERIFY(model_index.row() >= 0);
             VERIFY(model_index.row() < (int)BrushMode::__Count);
 
             m_mode = (BrushMode)model_index.row();
-            priority_container->set_visible(m_mode == BrushMode::Dodge || m_mode == BrushMode::Burn);
-            exposure_container->set_visible(m_mode == BrushMode::Dodge || m_mode == BrushMode::Burn);
+            priority_container.set_visible(m_mode == BrushMode::Dodge || m_mode == BrushMode::Burn);
+            exposure_container.set_visible(m_mode == BrushMode::Dodge || m_mode == BrushMode::Burn);
 
             if (m_mode == BrushMode::Dodge || m_mode == BrushMode::Burn)
                 update_precomputed_color_values();
         };
 
-        priority_combobox->on_change = [this](auto&, auto& model_index) {
+        priority_combobox.on_change = [this](auto&, auto& model_index) {
             VERIFY(model_index.row() >= 0);
             VERIFY(model_index.row() < (int)PriorityMode::__Count);
 
@@ -304,47 +304,47 @@ ErrorOr<GUI::Widget*> BrushTool::get_properties_widget()
             update_precomputed_color_values();
         };
 
-        exposure_slider->on_change = [this](int value) {
+        exposure_slider.on_change = [this](int value) {
             m_exposure = value / 100.0f;
             update_precomputed_color_values();
         };
 
-        auto size_container = TRY(properties_widget->try_add<GUI::Widget>());
-        size_container->set_fixed_height(20);
-        size_container->set_layout<GUI::HorizontalBoxLayout>();
+        auto& size_container = properties_widget->add<GUI::Widget>();
+        size_container.set_fixed_height(20);
+        size_container.set_layout<GUI::HorizontalBoxLayout>();
 
-        auto size_label = TRY(size_container->try_add<GUI::Label>("Size:"_string));
-        size_label->set_text_alignment(Gfx::TextAlignment::CenterLeft);
-        size_label->set_fixed_size(60, 20);
+        auto& size_label = size_container.add<GUI::Label>("Size:"_string);
+        size_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
+        size_label.set_fixed_size(60, 20);
 
-        auto size_slider = TRY(size_container->try_add<GUI::ValueSlider>(Orientation::Horizontal, "px"_string));
-        size_slider->set_range(1, 250);
-        size_slider->set_value(m_size);
-        size_slider->set_override_cursor(cursor());
+        auto& size_slider = size_container.add<GUI::ValueSlider>(Orientation::Horizontal, "px"_string);
+        size_slider.set_range(1, 250);
+        size_slider.set_value(m_size);
+        size_slider.set_override_cursor(cursor());
 
-        size_slider->on_change = [this, size_slider](int value) {
+        size_slider.on_change = [this, &size_slider](int value) {
             set_size(value);
             // Update cursor to provide an instant preview for the selected size.
-            size_slider->set_override_cursor(cursor());
+            size_slider.set_override_cursor(cursor());
         };
-        set_primary_slider(size_slider);
+        set_primary_slider(&size_slider);
 
-        auto hardness_container = TRY(properties_widget->try_add<GUI::Widget>());
-        hardness_container->set_fixed_height(20);
-        hardness_container->set_layout<GUI::HorizontalBoxLayout>();
+        auto& hardness_container = properties_widget->add<GUI::Widget>();
+        hardness_container.set_fixed_height(20);
+        hardness_container.set_layout<GUI::HorizontalBoxLayout>();
 
-        auto hardness_label = TRY(hardness_container->try_add<GUI::Label>("Hardness:"_string));
-        hardness_label->set_text_alignment(Gfx::TextAlignment::CenterLeft);
-        hardness_label->set_fixed_size(60, 20);
+        auto& hardness_label = hardness_container.add<GUI::Label>("Hardness:"_string);
+        hardness_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
+        hardness_label.set_fixed_size(60, 20);
 
-        auto hardness_slider = TRY(hardness_container->try_add<GUI::ValueSlider>(Orientation::Horizontal, "%"_string));
-        hardness_slider->set_range(1, 100);
-        hardness_slider->set_value(m_hardness);
+        auto& hardness_slider = hardness_container.add<GUI::ValueSlider>(Orientation::Horizontal, "%"_string);
+        hardness_slider.set_range(1, 100);
+        hardness_slider.set_value(m_hardness);
 
-        hardness_slider->on_change = [this](int value) {
+        hardness_slider.on_change = [this](int value) {
             set_hardness(value);
         };
-        set_secondary_slider(hardness_slider);
+        set_secondary_slider(&hardness_slider);
         m_properties_widget = properties_widget;
     }
 

--- a/Userland/Applications/PixelPaint/Tools/BrushTool.h
+++ b/Userland/Applications/PixelPaint/Tools/BrushTool.h
@@ -22,7 +22,7 @@ public:
     virtual void on_mousedown(Layer*, MouseEvent&) override;
     virtual void on_mousemove(Layer*, MouseEvent&) override;
     virtual void on_mouseup(Layer*, MouseEvent&) override;
-    virtual ErrorOr<GUI::Widget*> get_properties_widget() override;
+    virtual NonnullRefPtr<GUI::Widget> get_properties_widget() override;
     virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap const>> cursor() override
     {
         if (m_editor && m_editor->scale() != m_scale_last_created_cursor)

--- a/Userland/Applications/PixelPaint/Tools/BucketTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/BucketTool.cpp
@@ -67,22 +67,22 @@ ErrorOr<GUI::Widget*> BucketTool::get_properties_widget()
         auto properties_widget = GUI::Widget::construct();
         properties_widget->set_layout<GUI::VerticalBoxLayout>();
 
-        auto threshold_container = TRY(properties_widget->try_add<GUI::Widget>());
-        threshold_container->set_fixed_height(20);
-        threshold_container->set_layout<GUI::HorizontalBoxLayout>();
+        auto& threshold_container = properties_widget->add<GUI::Widget>();
+        threshold_container.set_fixed_height(20);
+        threshold_container.set_layout<GUI::HorizontalBoxLayout>();
 
-        auto threshold_label = TRY(threshold_container->try_add<GUI::Label>("Threshold:"_string));
-        threshold_label->set_text_alignment(Gfx::TextAlignment::CenterLeft);
-        threshold_label->set_fixed_size(80, 20);
+        auto& threshold_label = threshold_container.add<GUI::Label>("Threshold:"_string);
+        threshold_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
+        threshold_label.set_fixed_size(80, 20);
 
-        auto threshold_slider = TRY(threshold_container->try_add<GUI::ValueSlider>(Orientation::Horizontal, "%"_string));
-        threshold_slider->set_range(0, 100);
-        threshold_slider->set_value(m_threshold);
+        auto& threshold_slider = threshold_container.add<GUI::ValueSlider>(Orientation::Horizontal, "%"_string);
+        threshold_slider.set_range(0, 100);
+        threshold_slider.set_value(m_threshold);
 
-        threshold_slider->on_change = [this](int value) {
+        threshold_slider.on_change = [this](int value) {
             m_threshold = value;
         };
-        set_primary_slider(threshold_slider);
+        set_primary_slider(&threshold_slider);
         m_properties_widget = properties_widget;
     }
 

--- a/Userland/Applications/PixelPaint/Tools/BucketTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/BucketTool.cpp
@@ -61,7 +61,7 @@ void BucketTool::on_mousedown(Layer* layer, MouseEvent& event)
     m_editor->did_complete_action(tool_name());
 }
 
-ErrorOr<GUI::Widget*> BucketTool::get_properties_widget()
+NonnullRefPtr<GUI::Widget> BucketTool::get_properties_widget()
 {
     if (!m_properties_widget) {
         auto properties_widget = GUI::Widget::construct();
@@ -86,7 +86,7 @@ ErrorOr<GUI::Widget*> BucketTool::get_properties_widget()
         m_properties_widget = properties_widget;
     }
 
-    return m_properties_widget.ptr();
+    return *m_properties_widget;
 }
 
 }

--- a/Userland/Applications/PixelPaint/Tools/BucketTool.h
+++ b/Userland/Applications/PixelPaint/Tools/BucketTool.h
@@ -17,7 +17,7 @@ public:
     virtual ~BucketTool() override = default;
 
     virtual void on_mousedown(Layer*, MouseEvent&) override;
-    virtual ErrorOr<GUI::Widget*> get_properties_widget() override;
+    virtual NonnullRefPtr<GUI::Widget> get_properties_widget() override;
     virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap const>> cursor() override { return m_cursor; }
 
 private:

--- a/Userland/Applications/PixelPaint/Tools/CloneTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/CloneTool.cpp
@@ -131,40 +131,40 @@ ErrorOr<GUI::Widget*> CloneTool::get_properties_widget()
         auto properties_widget = GUI::Widget::construct();
         properties_widget->set_layout<GUI::VerticalBoxLayout>();
 
-        auto size_container = TRY(properties_widget->try_add<GUI::Widget>());
-        size_container->set_fixed_height(20);
-        size_container->set_layout<GUI::HorizontalBoxLayout>();
+        auto& size_container = properties_widget->add<GUI::Widget>();
+        size_container.set_fixed_height(20);
+        size_container.set_layout<GUI::HorizontalBoxLayout>();
 
-        auto size_label = TRY(size_container->try_add<GUI::Label>("Size:"_string));
-        size_label->set_text_alignment(Gfx::TextAlignment::CenterLeft);
-        size_label->set_fixed_size(80, 20);
+        auto& size_label = size_container.add<GUI::Label>("Size:"_string);
+        size_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
+        size_label.set_fixed_size(80, 20);
 
-        auto size_slider = TRY(size_container->try_add<GUI::ValueSlider>(Orientation::Horizontal, "px"_string));
-        size_slider->set_range(1, 100);
-        size_slider->set_value(size());
+        auto& size_slider = size_container.add<GUI::ValueSlider>(Orientation::Horizontal, "px"_string);
+        size_slider.set_range(1, 100);
+        size_slider.set_value(size());
 
-        size_slider->on_change = [this](int value) {
+        size_slider.on_change = [this](int value) {
             auto old_sample_marker_rect = sample_marker_rect();
             set_size(value);
             update_sample_marker(old_sample_marker_rect);
         };
-        set_primary_slider(size_slider);
+        set_primary_slider(&size_slider);
 
-        auto hardness_container = TRY(properties_widget->try_add<GUI::Widget>());
-        hardness_container->set_fixed_height(20);
-        hardness_container->set_layout<GUI::HorizontalBoxLayout>();
+        auto& hardness_container = properties_widget->add<GUI::Widget>();
+        hardness_container.set_fixed_height(20);
+        hardness_container.set_layout<GUI::HorizontalBoxLayout>();
 
-        auto hardness_label = TRY(hardness_container->try_add<GUI::Label>("Hardness:"_string));
-        hardness_label->set_text_alignment(Gfx::TextAlignment::CenterLeft);
-        hardness_label->set_fixed_size(80, 20);
+        auto& hardness_label = hardness_container.add<GUI::Label>("Hardness:"_string);
+        hardness_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
+        hardness_label.set_fixed_size(80, 20);
 
-        auto hardness_slider = TRY(hardness_container->try_add<GUI::ValueSlider>(Orientation::Horizontal, "%"_string));
-        hardness_slider->set_range(1, 100);
-        hardness_slider->on_change = [&](int value) {
+        auto& hardness_slider = hardness_container.add<GUI::ValueSlider>(Orientation::Horizontal, "%"_string);
+        hardness_slider.set_range(1, 100);
+        hardness_slider.on_change = [&](int value) {
             set_hardness(value);
         };
-        hardness_slider->set_value(100);
-        set_secondary_slider(hardness_slider);
+        hardness_slider.set_value(100);
+        set_secondary_slider(&hardness_slider);
         m_properties_widget = properties_widget;
     }
 

--- a/Userland/Applications/PixelPaint/Tools/CloneTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/CloneTool.cpp
@@ -125,7 +125,7 @@ void CloneTool::on_keyup(GUI::KeyEvent& event)
     }
 }
 
-ErrorOr<GUI::Widget*> CloneTool::get_properties_widget()
+NonnullRefPtr<GUI::Widget> CloneTool::get_properties_widget()
 {
     if (!m_properties_widget) {
         auto properties_widget = GUI::Widget::construct();
@@ -168,7 +168,7 @@ ErrorOr<GUI::Widget*> CloneTool::get_properties_widget()
         m_properties_widget = properties_widget;
     }
 
-    return m_properties_widget.ptr();
+    return *m_properties_widget;
 }
 
 Optional<Gfx::IntRect> CloneTool::sample_marker_rect()

--- a/Userland/Applications/PixelPaint/Tools/CloneTool.h
+++ b/Userland/Applications/PixelPaint/Tools/CloneTool.h
@@ -15,7 +15,7 @@ public:
     CloneTool() = default;
     virtual ~CloneTool() override = default;
 
-    virtual ErrorOr<GUI::Widget*> get_properties_widget() override;
+    virtual NonnullRefPtr<GUI::Widget> get_properties_widget() override;
     virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap const>> cursor() override;
 
     virtual bool is_overriding_alt() override { return true; }

--- a/Userland/Applications/PixelPaint/Tools/EllipseTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/EllipseTool.cpp
@@ -126,7 +126,7 @@ bool EllipseTool::on_keydown(GUI::KeyEvent& event)
     return Tool::on_keydown(event);
 }
 
-ErrorOr<GUI::Widget*> EllipseTool::get_properties_widget()
+NonnullRefPtr<GUI::Widget> EllipseTool::get_properties_widget()
 {
     if (!m_properties_widget) {
         auto properties_widget = GUI::Widget::construct();
@@ -208,7 +208,7 @@ ErrorOr<GUI::Widget*> EllipseTool::get_properties_widget()
         m_properties_widget = properties_widget;
     }
 
-    return m_properties_widget.ptr();
+    return *m_properties_widget;
 }
 
 }

--- a/Userland/Applications/PixelPaint/Tools/EllipseTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/EllipseTool.cpp
@@ -132,59 +132,59 @@ ErrorOr<GUI::Widget*> EllipseTool::get_properties_widget()
         auto properties_widget = GUI::Widget::construct();
         properties_widget->set_layout<GUI::VerticalBoxLayout>();
 
-        auto thickness_container = TRY(properties_widget->try_add<GUI::Widget>());
-        thickness_container->set_fixed_height(20);
-        thickness_container->set_layout<GUI::HorizontalBoxLayout>();
+        auto& thickness_container = properties_widget->add<GUI::Widget>();
+        thickness_container.set_fixed_height(20);
+        thickness_container.set_layout<GUI::HorizontalBoxLayout>();
 
-        auto thickness_label = TRY(thickness_container->try_add<GUI::Label>("Thickness:"_string));
-        thickness_label->set_text_alignment(Gfx::TextAlignment::CenterLeft);
-        thickness_label->set_fixed_size(80, 20);
+        auto& thickness_label = thickness_container.add<GUI::Label>("Thickness:"_string);
+        thickness_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
+        thickness_label.set_fixed_size(80, 20);
 
-        auto thickness_slider = TRY(thickness_container->try_add<GUI::ValueSlider>(Orientation::Horizontal, "px"_string));
-        thickness_slider->set_range(1, 10);
-        thickness_slider->set_value(m_thickness);
+        auto& thickness_slider = thickness_container.add<GUI::ValueSlider>(Orientation::Horizontal, "px"_string);
+        thickness_slider.set_range(1, 10);
+        thickness_slider.set_value(m_thickness);
 
-        thickness_slider->on_change = [this](int value) {
+        thickness_slider.on_change = [this](int value) {
             m_thickness = value;
         };
-        set_primary_slider(thickness_slider);
+        set_primary_slider(&thickness_slider);
 
-        auto mode_container = TRY(properties_widget->try_add<GUI::Widget>());
-        mode_container->set_fixed_height(70);
-        mode_container->set_layout<GUI::HorizontalBoxLayout>();
-        auto mode_label = TRY(mode_container->try_add<GUI::Label>("Mode:"_string));
-        mode_label->set_text_alignment(Gfx::TextAlignment::CenterLeft);
+        auto& mode_container = properties_widget->add<GUI::Widget>();
+        mode_container.set_fixed_height(70);
+        mode_container.set_layout<GUI::HorizontalBoxLayout>();
+        auto& mode_label = mode_container.add<GUI::Label>("Mode:"_string);
+        mode_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
 
-        auto mode_radio_container = TRY(mode_container->try_add<GUI::Widget>());
-        mode_radio_container->set_layout<GUI::VerticalBoxLayout>();
-        auto outline_mode_radio = TRY(mode_radio_container->try_add<GUI::RadioButton>("Outline"_string));
-        auto fill_mode_radio = TRY(mode_radio_container->try_add<GUI::RadioButton>("Fill"_string));
-        auto aa_enable_checkbox = TRY(mode_radio_container->try_add<GUI::CheckBox>("Anti-alias"_string));
+        auto& mode_radio_container = mode_container.add<GUI::Widget>();
+        mode_radio_container.set_layout<GUI::VerticalBoxLayout>();
+        auto& outline_mode_radio = mode_radio_container.add<GUI::RadioButton>("Outline"_string);
+        auto& fill_mode_radio = mode_radio_container.add<GUI::RadioButton>("Fill"_string);
+        auto& aa_enable_checkbox = mode_radio_container.add<GUI::CheckBox>("Anti-alias"_string);
 
-        aa_enable_checkbox->on_checked = [this](bool checked) {
+        aa_enable_checkbox.on_checked = [this](bool checked) {
             m_antialias_enabled = checked;
         };
-        outline_mode_radio->on_checked = [this](bool checked) {
+        outline_mode_radio.on_checked = [this](bool checked) {
             if (checked)
                 m_fill_mode = FillMode::Outline;
         };
-        fill_mode_radio->on_checked = [this](bool checked) {
+        fill_mode_radio.on_checked = [this](bool checked) {
             if (checked)
                 m_fill_mode = FillMode::Fill;
         };
 
-        aa_enable_checkbox->set_checked(true);
-        outline_mode_radio->set_checked(true);
+        aa_enable_checkbox.set_checked(true);
+        outline_mode_radio.set_checked(true);
 
-        auto aspect_container = TRY(properties_widget->try_add<GUI::Widget>());
-        aspect_container->set_fixed_height(20);
-        aspect_container->set_layout<GUI::HorizontalBoxLayout>();
+        auto& aspect_container = properties_widget->add<GUI::Widget>();
+        aspect_container.set_fixed_height(20);
+        aspect_container.set_layout<GUI::HorizontalBoxLayout>();
 
-        auto aspect_label = TRY(aspect_container->try_add<GUI::Label>("Aspect Ratio:"_string));
-        aspect_label->set_text_alignment(Gfx::TextAlignment::CenterLeft);
-        aspect_label->set_fixed_size(80, 20);
+        auto& aspect_label = aspect_container.add<GUI::Label>("Aspect Ratio:"_string);
+        aspect_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
+        aspect_label.set_fixed_size(80, 20);
 
-        m_aspect_w_textbox = TRY(aspect_container->try_add<GUI::TextBox>());
+        m_aspect_w_textbox = aspect_container.add<GUI::TextBox>();
         m_aspect_w_textbox->set_fixed_height(20);
         m_aspect_w_textbox->set_fixed_width(25);
         m_aspect_w_textbox->on_change = [this] {
@@ -197,11 +197,11 @@ ErrorOr<GUI::Widget*> EllipseTool::get_properties_widget()
             }
         };
 
-        auto multiply_label = TRY(aspect_container->try_add<GUI::Label>("x"_string));
-        multiply_label->set_text_alignment(Gfx::TextAlignment::Center);
-        multiply_label->set_fixed_size(10, 20);
+        auto& multiply_label = aspect_container.add<GUI::Label>("x"_string);
+        multiply_label.set_text_alignment(Gfx::TextAlignment::Center);
+        multiply_label.set_fixed_size(10, 20);
 
-        m_aspect_h_textbox = TRY(aspect_container->try_add<GUI::TextBox>());
+        m_aspect_h_textbox = aspect_container.add<GUI::TextBox>();
         m_aspect_h_textbox->set_fixed_height(20);
         m_aspect_h_textbox->set_fixed_width(25);
         m_aspect_h_textbox->on_change = [this] { m_aspect_w_textbox->on_change(); };

--- a/Userland/Applications/PixelPaint/Tools/EllipseTool.h
+++ b/Userland/Applications/PixelPaint/Tools/EllipseTool.h
@@ -25,7 +25,7 @@ public:
     virtual void on_mouseup(Layer*, MouseEvent&) override;
     virtual void on_second_paint(Layer const*, GUI::PaintEvent&) override;
     virtual bool on_keydown(GUI::KeyEvent&) override;
-    virtual ErrorOr<GUI::Widget*> get_properties_widget() override;
+    virtual NonnullRefPtr<GUI::Widget> get_properties_widget() override;
     virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap const>> cursor() override { return Gfx::StandardCursor::Crosshair; }
 
 private:

--- a/Userland/Applications/PixelPaint/Tools/EraseTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/EraseTool.cpp
@@ -60,78 +60,78 @@ ErrorOr<GUI::Widget*> EraseTool::get_properties_widget()
         auto properties_widget = GUI::Widget::construct();
         properties_widget->set_layout<GUI::VerticalBoxLayout>();
 
-        auto size_container = TRY(properties_widget->try_add<GUI::Widget>());
-        size_container->set_fixed_height(20);
-        size_container->set_layout<GUI::HorizontalBoxLayout>();
+        auto& size_container = properties_widget->add<GUI::Widget>();
+        size_container.set_fixed_height(20);
+        size_container.set_layout<GUI::HorizontalBoxLayout>();
 
-        auto size_label = TRY(size_container->try_add<GUI::Label>("Size:"_string));
-        size_label->set_text_alignment(Gfx::TextAlignment::CenterLeft);
-        size_label->set_fixed_size(80, 20);
+        auto& size_label = size_container.add<GUI::Label>("Size:"_string);
+        size_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
+        size_label.set_fixed_size(80, 20);
 
-        auto size_slider = TRY(size_container->try_add<GUI::ValueSlider>(Orientation::Horizontal, "px"_string));
-        size_slider->set_range(1, 250);
-        size_slider->set_value(size());
+        auto& size_slider = size_container.add<GUI::ValueSlider>(Orientation::Horizontal, "px"_string);
+        size_slider.set_range(1, 250);
+        size_slider.set_value(size());
 
-        size_slider->on_change = [this, size_slider](int value) {
+        size_slider.on_change = [this, &size_slider](int value) {
             set_size(value);
-            size_slider->set_override_cursor(cursor());
+            size_slider.set_override_cursor(cursor());
         };
-        set_primary_slider(size_slider);
+        set_primary_slider(&size_slider);
 
-        auto hardness_container = TRY(properties_widget->try_add<GUI::Widget>());
-        hardness_container->set_fixed_height(20);
-        hardness_container->set_layout<GUI::HorizontalBoxLayout>();
+        auto& hardness_container = properties_widget->add<GUI::Widget>();
+        hardness_container.set_fixed_height(20);
+        hardness_container.set_layout<GUI::HorizontalBoxLayout>();
 
-        auto hardness_label = TRY(hardness_container->try_add<GUI::Label>("Hardness:"_string));
-        hardness_label->set_text_alignment(Gfx::TextAlignment::CenterLeft);
-        hardness_label->set_fixed_size(80, 20);
+        auto& hardness_label = hardness_container.add<GUI::Label>("Hardness:"_string);
+        hardness_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
+        hardness_label.set_fixed_size(80, 20);
 
-        auto hardness_slider = TRY(hardness_container->try_add<GUI::ValueSlider>(Orientation::Horizontal, "%"_string));
-        hardness_slider->set_range(1, 100);
-        hardness_slider->set_value(hardness());
+        auto& hardness_slider = hardness_container.add<GUI::ValueSlider>(Orientation::Horizontal, "%"_string);
+        hardness_slider.set_range(1, 100);
+        hardness_slider.set_value(hardness());
 
-        hardness_slider->on_change = [this](int value) {
+        hardness_slider.on_change = [this](int value) {
             set_hardness(value);
         };
-        set_secondary_slider(hardness_slider);
+        set_secondary_slider(&hardness_slider);
 
-        auto secondary_color_container = TRY(properties_widget->try_add<GUI::Widget>());
-        secondary_color_container->set_fixed_height(20);
-        secondary_color_container->set_layout<GUI::HorizontalBoxLayout>();
+        auto& secondary_color_container = properties_widget->add<GUI::Widget>();
+        secondary_color_container.set_fixed_height(20);
+        secondary_color_container.set_layout<GUI::HorizontalBoxLayout>();
 
-        auto use_secondary_color_checkbox = TRY(secondary_color_container->try_add<GUI::CheckBox>());
-        use_secondary_color_checkbox->set_checked(m_use_secondary_color);
-        use_secondary_color_checkbox->set_text("Use secondary color"_string);
-        use_secondary_color_checkbox->on_checked = [this](bool checked) {
+        auto& use_secondary_color_checkbox = secondary_color_container.add<GUI::CheckBox>();
+        use_secondary_color_checkbox.set_checked(m_use_secondary_color);
+        use_secondary_color_checkbox.set_text("Use secondary color"_string);
+        use_secondary_color_checkbox.on_checked = [this](bool checked) {
             m_use_secondary_color = checked;
         };
 
-        auto mode_container = TRY(properties_widget->try_add<GUI::Widget>());
-        mode_container->set_fixed_height(46);
-        mode_container->set_layout<GUI::HorizontalBoxLayout>();
-        auto mode_label = TRY(mode_container->try_add<GUI::Label>("Draw Mode:"_string));
-        mode_label->set_text_alignment(Gfx::TextAlignment::CenterLeft);
-        mode_label->set_fixed_size(80, 20);
+        auto& mode_container = properties_widget->add<GUI::Widget>();
+        mode_container.set_fixed_height(46);
+        mode_container.set_layout<GUI::HorizontalBoxLayout>();
+        auto& mode_label = mode_container.add<GUI::Label>("Draw Mode:"_string);
+        mode_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
+        mode_label.set_fixed_size(80, 20);
 
-        auto mode_radio_container = TRY(mode_container->try_add<GUI::Widget>());
-        mode_radio_container->set_layout<GUI::VerticalBoxLayout>();
-        auto pencil_mode_radio = TRY(mode_radio_container->try_add<GUI::RadioButton>("Pencil"_string));
-        auto brush_mode_radio = TRY(mode_radio_container->try_add<GUI::RadioButton>("Brush"_string));
+        auto& mode_radio_container = mode_container.add<GUI::Widget>();
+        mode_radio_container.set_layout<GUI::VerticalBoxLayout>();
+        auto& pencil_mode_radio = mode_radio_container.add<GUI::RadioButton>("Pencil"_string);
+        auto& brush_mode_radio = mode_radio_container.add<GUI::RadioButton>("Brush"_string);
 
-        pencil_mode_radio->on_checked = [this, hardness_slider, size_slider](bool) {
+        pencil_mode_radio.on_checked = [this, &hardness_slider, &size_slider](bool) {
             m_draw_mode = DrawMode::Pencil;
-            hardness_slider->set_enabled(false);
+            hardness_slider.set_enabled(false);
             refresh_editor_cursor();
-            size_slider->set_override_cursor(cursor());
+            size_slider.set_override_cursor(cursor());
         };
-        brush_mode_radio->on_checked = [this, hardness_slider, size_slider](bool) {
+        brush_mode_radio.on_checked = [this, &hardness_slider, &size_slider](bool) {
             m_draw_mode = DrawMode::Brush;
-            hardness_slider->set_enabled(true);
+            hardness_slider.set_enabled(true);
             refresh_editor_cursor();
-            size_slider->set_override_cursor(cursor());
+            size_slider.set_override_cursor(cursor());
         };
 
-        pencil_mode_radio->set_checked(true);
+        pencil_mode_radio.set_checked(true);
         m_properties_widget = properties_widget;
     }
 

--- a/Userland/Applications/PixelPaint/Tools/EraseTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/EraseTool.cpp
@@ -54,7 +54,7 @@ void EraseTool::draw_point(Gfx::Bitmap& bitmap, Gfx::Color color, Gfx::IntPoint 
     }
 }
 
-ErrorOr<GUI::Widget*> EraseTool::get_properties_widget()
+NonnullRefPtr<GUI::Widget> EraseTool::get_properties_widget()
 {
     if (!m_properties_widget) {
         auto properties_widget = GUI::Widget::construct();
@@ -135,7 +135,7 @@ ErrorOr<GUI::Widget*> EraseTool::get_properties_widget()
         m_properties_widget = properties_widget;
     }
 
-    return m_properties_widget.ptr();
+    return *m_properties_widget;
 }
 
 NonnullRefPtr<Gfx::Bitmap> EraseTool::build_cursor()

--- a/Userland/Applications/PixelPaint/Tools/EraseTool.h
+++ b/Userland/Applications/PixelPaint/Tools/EraseTool.h
@@ -20,7 +20,7 @@ public:
     EraseTool() = default;
     virtual ~EraseTool() override = default;
 
-    virtual ErrorOr<GUI::Widget*> get_properties_widget() override;
+    virtual NonnullRefPtr<GUI::Widget> get_properties_widget() override;
 
 protected:
     virtual Color color_for(GUI::MouseEvent const& event) override;

--- a/Userland/Applications/PixelPaint/Tools/GradientTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/GradientTool.cpp
@@ -204,12 +204,12 @@ ErrorOr<GUI::Widget*> GradientTool::get_properties_widget()
         auto properties_widget = GUI::Widget::construct();
         properties_widget->set_layout<GUI::VerticalBoxLayout>();
 
-        auto mode_container = TRY(properties_widget->try_add<GUI::Widget>());
-        mode_container->set_fixed_height(20);
-        mode_container->set_layout<GUI::HorizontalBoxLayout>();
-        auto mode_label = TRY(mode_container->try_add<GUI::Label>("Gradient Type:"_string));
-        mode_label->set_text_alignment(Gfx::TextAlignment::CenterLeft);
-        mode_label->set_fixed_size(80, 20);
+        auto& mode_container = properties_widget->add<GUI::Widget>();
+        mode_container.set_fixed_height(20);
+        mode_container.set_layout<GUI::HorizontalBoxLayout>();
+        auto& mode_label = mode_container.add<GUI::Label>("Gradient Type:"_string);
+        mode_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
+        mode_label.set_fixed_size(80, 20);
 
         static constexpr auto s_mode_names = [] {
             Array<StringView, (int)GradientMode::__Count> names;
@@ -228,36 +228,36 @@ ErrorOr<GUI::Widget*> GradientTool::get_properties_widget()
             return names;
         }();
 
-        auto mode_combobox = TRY(mode_container->try_add<GUI::ComboBox>());
-        mode_combobox->set_only_allow_values_from_model(true);
-        mode_combobox->set_model(*GUI::ItemListModel<StringView, decltype(s_mode_names)>::create(s_mode_names));
-        mode_combobox->set_selected_index((int)m_mode, GUI::AllowCallback::No);
+        auto& mode_combobox = mode_container.add<GUI::ComboBox>();
+        mode_combobox.set_only_allow_values_from_model(true);
+        mode_combobox.set_model(*GUI::ItemListModel<StringView, decltype(s_mode_names)>::create(s_mode_names));
+        mode_combobox.set_selected_index((int)m_mode, GUI::AllowCallback::No);
 
-        auto opacity_container = TRY(properties_widget->try_add<GUI::Widget>());
-        opacity_container->set_fixed_height(20);
-        opacity_container->set_layout<GUI::HorizontalBoxLayout>();
+        auto& opacity_container = properties_widget->add<GUI::Widget>();
+        opacity_container.set_fixed_height(20);
+        opacity_container.set_layout<GUI::HorizontalBoxLayout>();
 
-        auto opacity_label = TRY(opacity_container->try_add<GUI::Label>("Opacity:"_string));
-        opacity_label->set_text_alignment(Gfx::TextAlignment::CenterLeft);
-        opacity_label->set_fixed_size(80, 20);
+        auto& opacity_label = opacity_container.add<GUI::Label>("Opacity:"_string);
+        opacity_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
+        opacity_label.set_fixed_size(80, 20);
 
-        auto opacity_slider = TRY(opacity_container->try_add<GUI::HorizontalOpacitySlider>());
-        opacity_slider->set_range(1, 100);
-        opacity_slider->set_value(100);
+        auto& opacity_slider = opacity_container.add<GUI::HorizontalOpacitySlider>();
+        opacity_slider.set_range(1, 100);
+        opacity_slider.set_value(100);
 
-        opacity_slider->on_change = [this](int value) {
+        opacity_slider.on_change = [this](int value) {
             m_opacity = value;
             m_editor->update();
         };
 
-        set_primary_slider(opacity_slider);
+        set_primary_slider(&opacity_slider);
 
-        auto hardness_container = TRY(properties_widget->try_add<GUI::Widget>());
-        hardness_container->set_layout<GUI::HorizontalBoxLayout>();
-        hardness_container->set_fixed_height(20);
-        hardness_container->set_visible(m_mode == GradientMode::Radial);
+        auto& hardness_container = properties_widget->add<GUI::Widget>();
+        hardness_container.set_layout<GUI::HorizontalBoxLayout>();
+        hardness_container.set_fixed_height(20);
+        hardness_container.set_visible(m_mode == GradientMode::Radial);
 
-        mode_combobox->on_change = [this, hardness_container](auto&, auto& model_index) {
+        mode_combobox.on_change = [this, &hardness_container](auto&, auto& model_index) {
             VERIFY(model_index.row() >= 0);
             VERIFY(model_index.row() < (int)GradientMode::__Count);
 
@@ -268,37 +268,37 @@ ErrorOr<GUI::Widget*> GradientTool::get_properties_widget()
                 reset();
             }
 
-            hardness_container->set_visible(m_mode == GradientMode::Radial);
+            hardness_container.set_visible(m_mode == GradientMode::Radial);
         };
 
-        auto hardness_label = TRY(hardness_container->try_add<GUI::Label>("Hardness:"_string));
-        hardness_label->set_text_alignment(Gfx::TextAlignment::CenterLeft);
-        hardness_label->set_fixed_size(80, 20);
+        auto& hardness_label = hardness_container.add<GUI::Label>("Hardness:"_string);
+        hardness_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
+        hardness_label.set_fixed_size(80, 20);
 
-        auto hardness_slider = TRY(hardness_container->try_add<GUI::ValueSlider>(Orientation::Horizontal, "%"_string));
-        hardness_slider->set_range(1, 99);
-        hardness_slider->set_value(m_hardness);
-        hardness_slider->on_change = [this](int value) {
+        auto& hardness_slider = hardness_container.add<GUI::ValueSlider>(Orientation::Horizontal, "%"_string);
+        hardness_slider.set_range(1, 99);
+        hardness_slider.set_value(m_hardness);
+        hardness_slider.on_change = [this](int value) {
             if (m_mode == GradientMode::Radial && m_editor) {
                 m_hardness = value;
                 m_editor->update();
             }
         };
-        set_secondary_slider(hardness_slider);
+        set_secondary_slider(&hardness_slider);
 
-        auto use_secondary_color_checkbox = TRY(properties_widget->try_add<GUI::CheckBox>("Use secondary color"_string));
-        use_secondary_color_checkbox->on_checked = [this](bool checked) {
+        auto& use_secondary_color_checkbox = properties_widget->add<GUI::CheckBox>("Use secondary color"_string);
+        use_secondary_color_checkbox.on_checked = [this](bool checked) {
             m_use_secondary_color = checked;
             m_editor->update();
         };
 
-        auto button_container = TRY(properties_widget->try_add<GUI::Widget>());
-        button_container->set_fixed_height(22);
-        button_container->set_layout<GUI::HorizontalBoxLayout>();
-        button_container->add_spacer();
+        auto& button_container = properties_widget->add<GUI::Widget>();
+        button_container.set_fixed_height(22);
+        button_container.set_layout<GUI::HorizontalBoxLayout>();
+        button_container.add_spacer();
 
-        auto apply_button = TRY(button_container->try_add<GUI::DialogButton>("Apply"_string));
-        apply_button->on_click = [this](auto) {
+        auto& apply_button = button_container.add<GUI::DialogButton>("Apply"_string);
+        apply_button.on_click = [this](auto) {
             rasterize_gradient();
         };
         m_properties_widget = properties_widget;

--- a/Userland/Applications/PixelPaint/Tools/GradientTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/GradientTool.cpp
@@ -198,7 +198,7 @@ void GradientTool::on_tool_activation()
     reset();
 }
 
-ErrorOr<GUI::Widget*> GradientTool::get_properties_widget()
+NonnullRefPtr<GUI::Widget> GradientTool::get_properties_widget()
 {
     if (!m_properties_widget) {
         auto properties_widget = GUI::Widget::construct();
@@ -304,7 +304,7 @@ ErrorOr<GUI::Widget*> GradientTool::get_properties_widget()
         m_properties_widget = properties_widget;
     }
 
-    return m_properties_widget.ptr();
+    return *m_properties_widget;
 }
 
 void GradientTool::rasterize_gradient()

--- a/Userland/Applications/PixelPaint/Tools/GradientTool.h
+++ b/Userland/Applications/PixelPaint/Tools/GradientTool.h
@@ -23,7 +23,7 @@ public:
     virtual void on_primary_color_change(Color) override;
     virtual void on_secondary_color_change(Color) override;
     virtual void on_tool_activation() override;
-    virtual ErrorOr<GUI::Widget*> get_properties_widget() override;
+    virtual NonnullRefPtr<GUI::Widget> get_properties_widget() override;
 
     virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap const>> cursor() override;
     virtual void on_second_paint(Layer const*, GUI::PaintEvent&) override;

--- a/Userland/Applications/PixelPaint/Tools/GuideTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/GuideTool.cpp
@@ -176,7 +176,7 @@ void GuideTool::on_tool_activation()
         m_editor->set_guide_visibility(true);
 }
 
-ErrorOr<GUI::Widget*> GuideTool::get_properties_widget()
+NonnullRefPtr<GUI::Widget> GuideTool::get_properties_widget()
 {
     if (!m_properties_widget) {
         auto properties_widget = GUI::Widget::construct();
@@ -202,7 +202,7 @@ ErrorOr<GUI::Widget*> GuideTool::get_properties_widget()
         m_properties_widget = properties_widget;
     }
 
-    return m_properties_widget.ptr();
+    return *m_properties_widget;
 }
 
 }

--- a/Userland/Applications/PixelPaint/Tools/GuideTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/GuideTool.cpp
@@ -182,23 +182,23 @@ ErrorOr<GUI::Widget*> GuideTool::get_properties_widget()
         auto properties_widget = GUI::Widget::construct();
         properties_widget->set_layout<GUI::VerticalBoxLayout>();
 
-        auto snapping_container = TRY(properties_widget->try_add<GUI::Widget>());
-        snapping_container->set_fixed_height(20);
-        snapping_container->set_layout<GUI::HorizontalBoxLayout>();
+        auto& snapping_container = properties_widget->add<GUI::Widget>();
+        snapping_container.set_fixed_height(20);
+        snapping_container.set_layout<GUI::HorizontalBoxLayout>();
 
-        auto snapping_label = TRY(snapping_container->try_add<GUI::Label>("Snap offset:"_string));
-        snapping_label->set_text_alignment(Gfx::TextAlignment::CenterLeft);
-        snapping_label->set_fixed_size(80, 20);
-        snapping_label->set_tooltip_deprecated("Press Shift to snap");
+        auto& snapping_label = snapping_container.add<GUI::Label>("Snap offset:"_string);
+        snapping_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
+        snapping_label.set_fixed_size(80, 20);
+        snapping_label.set_tooltip_deprecated("Press Shift to snap");
 
-        auto snapping_slider = TRY(snapping_container->try_add<GUI::ValueSlider>(Orientation::Horizontal, "px"_string));
-        snapping_slider->set_range(0, 50);
-        snapping_slider->set_value(m_snap_size);
+        auto& snapping_slider = snapping_container.add<GUI::ValueSlider>(Orientation::Horizontal, "px"_string);
+        snapping_slider.set_range(0, 50);
+        snapping_slider.set_value(m_snap_size);
 
-        snapping_slider->on_change = [this](int value) {
+        snapping_slider.on_change = [this](int value) {
             m_snap_size = value;
         };
-        set_primary_slider(snapping_slider);
+        set_primary_slider(&snapping_slider);
         m_properties_widget = properties_widget;
     }
 

--- a/Userland/Applications/PixelPaint/Tools/GuideTool.h
+++ b/Userland/Applications/PixelPaint/Tools/GuideTool.h
@@ -27,7 +27,7 @@ public:
 
     virtual void on_tool_activation() override;
 
-    virtual ErrorOr<GUI::Widget*> get_properties_widget() override;
+    virtual NonnullRefPtr<GUI::Widget> get_properties_widget() override;
     virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap const>> cursor() override { return Gfx::StandardCursor::Crosshair; }
 
 private:

--- a/Userland/Applications/PixelPaint/Tools/LassoSelectTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/LassoSelectTool.cpp
@@ -154,10 +154,10 @@ bool LassoSelectTool::on_keydown(GUI::KeyEvent& key_event)
     return Tool::on_keydown(key_event);
 }
 
-ErrorOr<GUI::Widget*> LassoSelectTool::get_properties_widget()
+NonnullRefPtr<GUI::Widget> LassoSelectTool::get_properties_widget()
 {
     if (m_properties_widget) {
-        return m_properties_widget.ptr();
+        return *m_properties_widget.ptr();
     }
 
     auto properties_widget = GUI::Widget::construct();
@@ -207,7 +207,7 @@ ErrorOr<GUI::Widget*> LassoSelectTool::get_properties_widget()
     };
 
     m_properties_widget = properties_widget;
-    return m_properties_widget.ptr();
+    return *m_properties_widget;
 }
 
 }

--- a/Userland/Applications/PixelPaint/Tools/LassoSelectTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/LassoSelectTool.cpp
@@ -163,14 +163,14 @@ ErrorOr<GUI::Widget*> LassoSelectTool::get_properties_widget()
     auto properties_widget = GUI::Widget::construct();
     properties_widget->set_layout<GUI::VerticalBoxLayout>();
 
-    auto mode_container = TRY(properties_widget->try_add<GUI::Widget>());
-    mode_container->set_fixed_height(20);
-    mode_container->set_layout<GUI::HorizontalBoxLayout>();
+    auto& mode_container = properties_widget->add<GUI::Widget>();
+    mode_container.set_fixed_height(20);
+    mode_container.set_layout<GUI::HorizontalBoxLayout>();
 
-    auto mode_label = TRY(mode_container->try_add<GUI::Label>());
-    mode_label->set_text("Mode:"_string);
-    mode_label->set_text_alignment(Gfx::TextAlignment::CenterLeft);
-    mode_label->set_fixed_size(80, 20);
+    auto& mode_label = mode_container.add<GUI::Label>();
+    mode_label.set_text("Mode:"_string);
+    mode_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
+    mode_label.set_fixed_size(80, 20);
 
     static constexpr auto s_merge_mode_names = [] {
         Array<StringView, (int)Selection::MergeMode::__Count> names;
@@ -195,11 +195,11 @@ ErrorOr<GUI::Widget*> LassoSelectTool::get_properties_widget()
         return names;
     }();
 
-    auto mode_combo = TRY(mode_container->try_add<GUI::ComboBox>());
-    mode_combo->set_only_allow_values_from_model(true);
-    mode_combo->set_model(*GUI::ItemListModel<StringView, decltype(s_merge_mode_names)>::create(s_merge_mode_names));
-    mode_combo->set_selected_index((int)m_merge_mode);
-    mode_combo->on_change = [this](auto&&, GUI::ModelIndex const& index) {
+    auto& mode_combo = mode_container.add<GUI::ComboBox>();
+    mode_combo.set_only_allow_values_from_model(true);
+    mode_combo.set_model(*GUI::ItemListModel<StringView, decltype(s_merge_mode_names)>::create(s_merge_mode_names));
+    mode_combo.set_selected_index((int)m_merge_mode);
+    mode_combo.on_change = [this](auto&&, GUI::ModelIndex const& index) {
         VERIFY(index.row() >= 0);
         VERIFY(index.row() < (int)Selection::MergeMode::__Count);
 

--- a/Userland/Applications/PixelPaint/Tools/LassoSelectTool.h
+++ b/Userland/Applications/PixelPaint/Tools/LassoSelectTool.h
@@ -25,7 +25,7 @@ public:
     virtual void on_mousemove(Layer*, MouseEvent& event) override;
     virtual bool on_keydown(GUI::KeyEvent&) override;
     virtual void on_second_paint(Layer const*, GUI::PaintEvent&) override;
-    virtual ErrorOr<GUI::Widget*> get_properties_widget() override;
+    virtual NonnullRefPtr<GUI::Widget> get_properties_widget() override;
     virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap const>> cursor() override { return Gfx::StandardCursor::Crosshair; }
 
 private:

--- a/Userland/Applications/PixelPaint/Tools/LineTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/LineTool.cpp
@@ -125,36 +125,36 @@ ErrorOr<GUI::Widget*> LineTool::get_properties_widget()
         auto properties_widget = GUI::Widget::construct();
         properties_widget->set_layout<GUI::VerticalBoxLayout>();
 
-        auto thickness_container = TRY(properties_widget->try_add<GUI::Widget>());
-        thickness_container->set_fixed_height(20);
-        thickness_container->set_layout<GUI::HorizontalBoxLayout>();
+        auto& thickness_container = properties_widget->add<GUI::Widget>();
+        thickness_container.set_fixed_height(20);
+        thickness_container.set_layout<GUI::HorizontalBoxLayout>();
 
-        auto thickness_label = TRY(thickness_container->try_add<GUI::Label>("Thickness:"_string));
-        thickness_label->set_text_alignment(Gfx::TextAlignment::CenterLeft);
-        thickness_label->set_fixed_size(80, 20);
+        auto& thickness_label = thickness_container.add<GUI::Label>("Thickness:"_string);
+        thickness_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
+        thickness_label.set_fixed_size(80, 20);
 
-        auto thickness_slider = TRY(thickness_container->try_add<GUI::ValueSlider>(Orientation::Horizontal, "px"_string));
-        thickness_slider->set_range(1, 10);
-        thickness_slider->set_value(m_thickness);
+        auto& thickness_slider = thickness_container.add<GUI::ValueSlider>(Orientation::Horizontal, "px"_string);
+        thickness_slider.set_range(1, 10);
+        thickness_slider.set_value(m_thickness);
 
-        thickness_slider->on_change = [this](int value) {
+        thickness_slider.on_change = [this](int value) {
             m_thickness = value;
         };
-        set_primary_slider(thickness_slider);
+        set_primary_slider(&thickness_slider);
 
-        auto mode_container = TRY(properties_widget->try_add<GUI::Widget>());
-        mode_container->set_fixed_height(20);
-        mode_container->set_layout<GUI::HorizontalBoxLayout>();
+        auto& mode_container = properties_widget->add<GUI::Widget>();
+        mode_container.set_fixed_height(20);
+        mode_container.set_layout<GUI::HorizontalBoxLayout>();
 
-        auto mode_label = TRY(mode_container->try_add<GUI::Label>("Mode:"_string));
-        mode_label->set_text_alignment(Gfx::TextAlignment::CenterLeft);
-        mode_label->set_fixed_size(80, 20);
+        auto& mode_label = mode_container.add<GUI::Label>("Mode:"_string);
+        mode_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
+        mode_label.set_fixed_size(80, 20);
 
-        auto aa_enable_checkbox = TRY(mode_container->try_add<GUI::CheckBox>("Anti-alias"_string));
-        aa_enable_checkbox->on_checked = [this](bool checked) {
+        auto& aa_enable_checkbox = mode_container.add<GUI::CheckBox>("Anti-alias"_string);
+        aa_enable_checkbox.on_checked = [this](bool checked) {
             m_antialias_enabled = checked;
         };
-        aa_enable_checkbox->set_checked(true);
+        aa_enable_checkbox.set_checked(true);
         m_properties_widget = properties_widget;
     }
 

--- a/Userland/Applications/PixelPaint/Tools/LineTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/LineTool.cpp
@@ -119,7 +119,7 @@ bool LineTool::on_keydown(GUI::KeyEvent& event)
     return Tool::on_keydown(event);
 }
 
-ErrorOr<GUI::Widget*> LineTool::get_properties_widget()
+NonnullRefPtr<GUI::Widget> LineTool::get_properties_widget()
 {
     if (!m_properties_widget) {
         auto properties_widget = GUI::Widget::construct();
@@ -158,7 +158,7 @@ ErrorOr<GUI::Widget*> LineTool::get_properties_widget()
         m_properties_widget = properties_widget;
     }
 
-    return m_properties_widget.ptr();
+    return *m_properties_widget;
 }
 
 }

--- a/Userland/Applications/PixelPaint/Tools/LineTool.h
+++ b/Userland/Applications/PixelPaint/Tools/LineTool.h
@@ -23,7 +23,7 @@ public:
     virtual void on_mouseup(Layer*, MouseEvent&) override;
     virtual void on_second_paint(Layer const*, GUI::PaintEvent&) override;
     virtual bool on_keydown(GUI::KeyEvent&) override;
-    virtual ErrorOr<GUI::Widget*> get_properties_widget() override;
+    virtual NonnullRefPtr<GUI::Widget> get_properties_widget() override;
     virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap const>> cursor() override { return Gfx::StandardCursor::Crosshair; }
 
     void draw_using(GUI::Painter&, Gfx::IntPoint start_position, Gfx::IntPoint end_position, Color color, int thickness);

--- a/Userland/Applications/PixelPaint/Tools/MoveTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/MoveTool.cpp
@@ -295,18 +295,18 @@ ErrorOr<GUI::Widget*> MoveTool::get_properties_widget()
         auto properties_widget = GUI::Widget::construct();
         properties_widget->set_layout<GUI::VerticalBoxLayout>();
 
-        auto selection_mode_container = TRY(properties_widget->try_add<GUI::Widget>());
-        selection_mode_container->set_layout<GUI::HorizontalBoxLayout>();
-        selection_mode_container->set_fixed_height(46);
-        auto selection_mode_label = TRY(selection_mode_container->try_add<GUI::Label>("Selection Mode:"_string));
-        selection_mode_label->set_text_alignment(Gfx::TextAlignment::CenterLeft);
-        selection_mode_label->set_fixed_size(80, 40);
+        auto& selection_mode_container = properties_widget->add<GUI::Widget>();
+        selection_mode_container.set_layout<GUI::HorizontalBoxLayout>();
+        selection_mode_container.set_fixed_height(46);
+        auto& selection_mode_label = selection_mode_container.add<GUI::Label>("Selection Mode:"_string);
+        selection_mode_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
+        selection_mode_label.set_fixed_size(80, 40);
 
-        auto mode_radio_container = TRY(selection_mode_container->try_add<GUI::Widget>());
-        mode_radio_container->set_layout<GUI::VerticalBoxLayout>();
-        m_selection_mode_foreground = TRY(mode_radio_container->try_add<GUI::RadioButton>("Foreground"_string));
+        auto& mode_radio_container = selection_mode_container.add<GUI::Widget>();
+        mode_radio_container.set_layout<GUI::VerticalBoxLayout>();
+        m_selection_mode_foreground = mode_radio_container.add<GUI::RadioButton>("Foreground"_string);
 
-        m_selection_mode_active = TRY(mode_radio_container->try_add<GUI::RadioButton>("Active Layer"_string));
+        m_selection_mode_active = mode_radio_container.add<GUI::RadioButton>("Active Layer"_string);
 
         m_selection_mode_foreground->on_checked = [this](bool) {
             m_layer_selection_mode = LayerSelectionMode::ForegroundLayer;

--- a/Userland/Applications/PixelPaint/Tools/MoveTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/MoveTool.cpp
@@ -289,7 +289,7 @@ Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap const>> MoveTool::cursor(
     return Gfx::StandardCursor::Move;
 }
 
-ErrorOr<GUI::Widget*> MoveTool::get_properties_widget()
+NonnullRefPtr<GUI::Widget> MoveTool::get_properties_widget()
 {
     if (!m_properties_widget) {
         auto properties_widget = GUI::Widget::construct();
@@ -319,7 +319,7 @@ ErrorOr<GUI::Widget*> MoveTool::get_properties_widget()
         m_properties_widget = properties_widget;
     }
 
-    return m_properties_widget.ptr();
+    return *m_properties_widget;
 }
 
 void MoveTool::toggle_selection_mode()

--- a/Userland/Applications/PixelPaint/Tools/MoveTool.h
+++ b/Userland/Applications/PixelPaint/Tools/MoveTool.h
@@ -35,7 +35,7 @@ public:
     virtual bool on_keydown(GUI::KeyEvent&) override;
     virtual void on_keyup(GUI::KeyEvent&) override;
     virtual void on_second_paint(Layer const*, GUI::PaintEvent&) override;
-    virtual ErrorOr<GUI::Widget*> get_properties_widget() override;
+    virtual NonnullRefPtr<GUI::Widget> get_properties_widget() override;
     virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap const>> cursor() override;
     virtual bool is_overriding_alt() override { return true; }
     LayerSelectionMode layer_selection_mode() const { return m_layer_selection_mode; }

--- a/Userland/Applications/PixelPaint/Tools/PenTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/PenTool.cpp
@@ -41,22 +41,22 @@ ErrorOr<GUI::Widget*> PenTool::get_properties_widget()
         auto properties_widget = GUI::Widget::construct();
         properties_widget->set_layout<GUI::VerticalBoxLayout>();
 
-        auto size_container = TRY(properties_widget->try_add<GUI::Widget>());
-        size_container->set_fixed_height(20);
-        size_container->set_layout<GUI::HorizontalBoxLayout>();
+        auto& size_container = properties_widget->add<GUI::Widget>();
+        size_container.set_fixed_height(20);
+        size_container.set_layout<GUI::HorizontalBoxLayout>();
 
-        auto size_label = TRY(size_container->try_add<GUI::Label>("Thickness:"_string));
-        size_label->set_text_alignment(Gfx::TextAlignment::CenterLeft);
-        size_label->set_fixed_size(80, 20);
+        auto& size_label = size_container.add<GUI::Label>("Thickness:"_string);
+        size_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
+        size_label.set_fixed_size(80, 20);
 
-        auto size_slider = TRY(size_container->try_add<GUI::ValueSlider>(Orientation::Horizontal, "px"_string));
-        size_slider->set_range(1, 20);
-        size_slider->set_value(size());
+        auto& size_slider = size_container.add<GUI::ValueSlider>(Orientation::Horizontal, "px"_string);
+        size_slider.set_range(1, 20);
+        size_slider.set_value(size());
 
-        size_slider->on_change = [this](int value) {
+        size_slider.on_change = [this](int value) {
             set_size(value);
         };
-        set_primary_slider(size_slider);
+        set_primary_slider(&size_slider);
         m_properties_widget = properties_widget;
     }
 

--- a/Userland/Applications/PixelPaint/Tools/PenTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/PenTool.cpp
@@ -35,7 +35,7 @@ void PenTool::draw_line(Gfx::Bitmap& bitmap, Gfx::Color color, Gfx::IntPoint sta
     painter.draw_line(start, end, color, size());
 }
 
-ErrorOr<GUI::Widget*> PenTool::get_properties_widget()
+NonnullRefPtr<GUI::Widget> PenTool::get_properties_widget()
 {
     if (!m_properties_widget) {
         auto properties_widget = GUI::Widget::construct();
@@ -60,7 +60,7 @@ ErrorOr<GUI::Widget*> PenTool::get_properties_widget()
         m_properties_widget = properties_widget;
     }
 
-    return m_properties_widget.ptr();
+    return *m_properties_widget;
 }
 
 }

--- a/Userland/Applications/PixelPaint/Tools/PenTool.h
+++ b/Userland/Applications/PixelPaint/Tools/PenTool.h
@@ -19,7 +19,7 @@ public:
     PenTool();
     virtual ~PenTool() override = default;
     virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap const>> cursor() override { return Gfx::StandardCursor::Crosshair; }
-    virtual ErrorOr<GUI::Widget*> get_properties_widget() override;
+    virtual NonnullRefPtr<GUI::Widget> get_properties_widget() override;
 
 protected:
     virtual void draw_point(Gfx::Bitmap& bitmap, Gfx::Color color, Gfx::IntPoint point) override;

--- a/Userland/Applications/PixelPaint/Tools/PickerTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/PickerTool.cpp
@@ -41,7 +41,7 @@ void PickerTool::on_mousemove(Layer* layer, MouseEvent& event)
     m_editor->set_editor_color_to_color_at_mouse_position(layer_event, m_sample_all_layers);
 }
 
-ErrorOr<GUI::Widget*> PickerTool::get_properties_widget()
+NonnullRefPtr<GUI::Widget> PickerTool::get_properties_widget()
 {
     if (!m_properties_widget) {
         auto properties_widget = GUI::Widget::construct();
@@ -55,7 +55,7 @@ ErrorOr<GUI::Widget*> PickerTool::get_properties_widget()
         m_properties_widget = properties_widget;
     }
 
-    return m_properties_widget.ptr();
+    return *m_properties_widget;
 }
 
 }

--- a/Userland/Applications/PixelPaint/Tools/PickerTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/PickerTool.cpp
@@ -47,9 +47,9 @@ ErrorOr<GUI::Widget*> PickerTool::get_properties_widget()
         auto properties_widget = GUI::Widget::construct();
         properties_widget->set_layout<GUI::VerticalBoxLayout>();
 
-        auto sample_checkbox = TRY(properties_widget->try_add<GUI::CheckBox>("Sample all layers"_string));
-        sample_checkbox->set_checked(m_sample_all_layers);
-        sample_checkbox->on_checked = [this](bool value) {
+        auto& sample_checkbox = properties_widget->add<GUI::CheckBox>("Sample all layers"_string);
+        sample_checkbox.set_checked(m_sample_all_layers);
+        sample_checkbox.on_checked = [this](bool value) {
             m_sample_all_layers = value;
         };
         m_properties_widget = properties_widget;

--- a/Userland/Applications/PixelPaint/Tools/PickerTool.h
+++ b/Userland/Applications/PixelPaint/Tools/PickerTool.h
@@ -21,7 +21,7 @@ public:
     virtual void on_mouseup(Layer*, MouseEvent&) override;
     virtual void on_mousemove(Layer*, MouseEvent&) override;
 
-    virtual ErrorOr<GUI::Widget*> get_properties_widget() override;
+    virtual NonnullRefPtr<GUI::Widget> get_properties_widget() override;
     virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap const>> cursor() override { return Gfx::StandardCursor::Eyedropper; }
 
 private:

--- a/Userland/Applications/PixelPaint/Tools/PolygonalSelectTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/PolygonalSelectTool.cpp
@@ -192,14 +192,14 @@ ErrorOr<GUI::Widget*> PolygonalSelectTool::get_properties_widget()
     auto properties_widget = GUI::Widget::construct();
     properties_widget->set_layout<GUI::VerticalBoxLayout>();
 
-    auto mode_container = TRY(properties_widget->try_add<GUI::Widget>());
-    mode_container->set_fixed_height(20);
-    mode_container->set_layout<GUI::HorizontalBoxLayout>();
+    auto& mode_container = properties_widget->add<GUI::Widget>();
+    mode_container.set_fixed_height(20);
+    mode_container.set_layout<GUI::HorizontalBoxLayout>();
 
-    auto mode_label = TRY(mode_container->try_add<GUI::Label>());
-    mode_label->set_text("Mode:"_string);
-    mode_label->set_text_alignment(Gfx::TextAlignment::CenterLeft);
-    mode_label->set_fixed_size(80, 20);
+    auto& mode_label = mode_container.add<GUI::Label>();
+    mode_label.set_text("Mode:"_string);
+    mode_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
+    mode_label.set_fixed_size(80, 20);
 
     static constexpr auto s_merge_mode_names = [] {
         Array<StringView, (int)Selection::MergeMode::__Count> names;
@@ -224,11 +224,11 @@ ErrorOr<GUI::Widget*> PolygonalSelectTool::get_properties_widget()
         return names;
     }();
 
-    auto mode_combo = TRY(mode_container->try_add<GUI::ComboBox>());
-    mode_combo->set_only_allow_values_from_model(true);
-    mode_combo->set_model(*GUI::ItemListModel<StringView, decltype(s_merge_mode_names)>::create(s_merge_mode_names));
-    mode_combo->set_selected_index((int)m_merge_mode);
-    mode_combo->on_change = [this](auto&&, GUI::ModelIndex const& index) {
+    auto& mode_combo = mode_container.add<GUI::ComboBox>();
+    mode_combo.set_only_allow_values_from_model(true);
+    mode_combo.set_model(*GUI::ItemListModel<StringView, decltype(s_merge_mode_names)>::create(s_merge_mode_names));
+    mode_combo.set_selected_index((int)m_merge_mode);
+    mode_combo.on_change = [this](auto&&, GUI::ModelIndex const& index) {
         VERIFY(index.row() >= 0);
         VERIFY(index.row() < (int)Selection::MergeMode::__Count);
 

--- a/Userland/Applications/PixelPaint/Tools/PolygonalSelectTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/PolygonalSelectTool.cpp
@@ -184,10 +184,10 @@ bool PolygonalSelectTool::on_keydown(GUI::KeyEvent& key_event)
     return Tool::on_keydown(key_event);
 }
 
-ErrorOr<GUI::Widget*> PolygonalSelectTool::get_properties_widget()
+NonnullRefPtr<GUI::Widget> PolygonalSelectTool::get_properties_widget()
 {
     if (m_properties_widget)
-        return m_properties_widget.ptr();
+        return *m_properties_widget.ptr();
 
     auto properties_widget = GUI::Widget::construct();
     properties_widget->set_layout<GUI::VerticalBoxLayout>();
@@ -236,7 +236,7 @@ ErrorOr<GUI::Widget*> PolygonalSelectTool::get_properties_widget()
     };
 
     m_properties_widget = properties_widget;
-    return m_properties_widget.ptr();
+    return *m_properties_widget;
 }
 
 Gfx::IntPoint PolygonalSelectTool::point_position_to_preferred_cell(Gfx::FloatPoint position) const

--- a/Userland/Applications/PixelPaint/Tools/PolygonalSelectTool.h
+++ b/Userland/Applications/PixelPaint/Tools/PolygonalSelectTool.h
@@ -22,7 +22,7 @@ public:
     virtual void on_mousemove(Layer*, MouseEvent& event) override;
     virtual bool on_keydown(GUI::KeyEvent&) override;
     virtual void on_second_paint(Layer const*, GUI::PaintEvent&) override;
-    virtual ErrorOr<GUI::Widget*> get_properties_widget() override;
+    virtual NonnullRefPtr<GUI::Widget> get_properties_widget() override;
     virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap const>> cursor() override { return Gfx::StandardCursor::Crosshair; }
     virtual Gfx::IntPoint point_position_to_preferred_cell(Gfx::FloatPoint position) const override;
 

--- a/Userland/Applications/PixelPaint/Tools/RectangleSelectTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/RectangleSelectTool.cpp
@@ -151,10 +151,10 @@ void RectangleSelectTool::on_second_paint(Layer const*, GUI::PaintEvent& event)
     m_editor->draw_marching_ants(painter, rect_in_editor.to_rounded<int>());
 }
 
-ErrorOr<GUI::Widget*> RectangleSelectTool::get_properties_widget()
+NonnullRefPtr<GUI::Widget> RectangleSelectTool::get_properties_widget()
 {
     if (m_properties_widget) {
-        return m_properties_widget.ptr();
+        return *m_properties_widget.ptr();
     }
 
     auto properties_widget = GUI::Widget::construct();
@@ -191,16 +191,16 @@ ErrorOr<GUI::Widget*> RectangleSelectTool::get_properties_widget()
     for (int i = 0; i < (int)Selection::MergeMode::__Count; i++) {
         switch ((Selection::MergeMode)i) {
         case Selection::MergeMode::Set:
-            TRY(m_merge_mode_names.try_append("Set"));
+            m_merge_mode_names.append("Set");
             break;
         case Selection::MergeMode::Add:
-            TRY(m_merge_mode_names.try_append("Add"));
+            m_merge_mode_names.append("Add");
             break;
         case Selection::MergeMode::Subtract:
-            TRY(m_merge_mode_names.try_append("Subtract"));
+            m_merge_mode_names.append("Subtract");
             break;
         case Selection::MergeMode::Intersect:
-            TRY(m_merge_mode_names.try_append("Intersect"));
+            m_merge_mode_names.append("Intersect");
             break;
         default:
             VERIFY_NOT_REACHED();
@@ -219,7 +219,7 @@ ErrorOr<GUI::Widget*> RectangleSelectTool::get_properties_widget()
     };
 
     m_properties_widget = properties_widget;
-    return m_properties_widget.ptr();
+    return *m_properties_widget;
 }
 
 Gfx::IntPoint RectangleSelectTool::point_position_to_preferred_cell(Gfx::FloatPoint position) const

--- a/Userland/Applications/PixelPaint/Tools/RectangleSelectTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/RectangleSelectTool.cpp
@@ -160,33 +160,33 @@ ErrorOr<GUI::Widget*> RectangleSelectTool::get_properties_widget()
     auto properties_widget = GUI::Widget::construct();
     properties_widget->set_layout<GUI::VerticalBoxLayout>();
 
-    auto feather_container = TRY(properties_widget->try_add<GUI::Widget>());
-    feather_container->set_fixed_height(20);
-    feather_container->set_layout<GUI::HorizontalBoxLayout>();
+    auto& feather_container = properties_widget->add<GUI::Widget>();
+    feather_container.set_fixed_height(20);
+    feather_container.set_layout<GUI::HorizontalBoxLayout>();
 
-    auto feather_label = TRY(feather_container->try_add<GUI::Label>());
-    feather_label->set_text("Feather:"_string);
-    feather_label->set_text_alignment(Gfx::TextAlignment::CenterLeft);
-    feather_label->set_fixed_size(80, 20);
+    auto& feather_label = feather_container.add<GUI::Label>();
+    feather_label.set_text("Feather:"_string);
+    feather_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
+    feather_label.set_fixed_size(80, 20);
 
     int const feather_slider_max = 100;
-    auto feather_slider = TRY(feather_container->try_add<GUI::ValueSlider>(Orientation::Horizontal, "%"_string));
-    feather_slider->set_range(0, feather_slider_max);
-    feather_slider->set_value((int)floorf(m_edge_feathering * (float)feather_slider_max));
+    auto& feather_slider = feather_container.add<GUI::ValueSlider>(Orientation::Horizontal, "%"_string);
+    feather_slider.set_range(0, feather_slider_max);
+    feather_slider.set_value((int)floorf(m_edge_feathering * (float)feather_slider_max));
 
-    feather_slider->on_change = [this](int value) {
+    feather_slider.on_change = [this](int value) {
         m_edge_feathering = (float)value / (float)feather_slider_max;
     };
-    set_primary_slider(feather_slider);
+    set_primary_slider(&feather_slider);
 
-    auto mode_container = TRY(properties_widget->try_add<GUI::Widget>());
-    mode_container->set_fixed_height(20);
-    mode_container->set_layout<GUI::HorizontalBoxLayout>();
+    auto& mode_container = properties_widget->add<GUI::Widget>();
+    mode_container.set_fixed_height(20);
+    mode_container.set_layout<GUI::HorizontalBoxLayout>();
 
-    auto mode_label = TRY(mode_container->try_add<GUI::Label>());
-    mode_label->set_text("Mode:"_string);
-    mode_label->set_text_alignment(Gfx::TextAlignment::CenterLeft);
-    mode_label->set_fixed_size(80, 20);
+    auto& mode_label = mode_container.add<GUI::Label>();
+    mode_label.set_text("Mode:"_string);
+    mode_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
+    mode_label.set_fixed_size(80, 20);
 
     for (int i = 0; i < (int)Selection::MergeMode::__Count; i++) {
         switch ((Selection::MergeMode)i) {
@@ -207,11 +207,11 @@ ErrorOr<GUI::Widget*> RectangleSelectTool::get_properties_widget()
         }
     }
 
-    auto mode_combo = TRY(mode_container->try_add<GUI::ComboBox>());
-    mode_combo->set_only_allow_values_from_model(true);
-    mode_combo->set_model(*GUI::ItemListModel<DeprecatedString>::create(m_merge_mode_names));
-    mode_combo->set_selected_index((int)m_merge_mode);
-    mode_combo->on_change = [this](auto&&, GUI::ModelIndex const& index) {
+    auto& mode_combo = mode_container.add<GUI::ComboBox>();
+    mode_combo.set_only_allow_values_from_model(true);
+    mode_combo.set_model(*GUI::ItemListModel<DeprecatedString>::create(m_merge_mode_names));
+    mode_combo.set_selected_index((int)m_merge_mode);
+    mode_combo.on_change = [this](auto&&, GUI::ModelIndex const& index) {
         VERIFY(index.row() >= 0);
         VERIFY(index.row() < (int)Selection::MergeMode::__Count);
 

--- a/Userland/Applications/PixelPaint/Tools/RectangleSelectTool.h
+++ b/Userland/Applications/PixelPaint/Tools/RectangleSelectTool.h
@@ -26,7 +26,7 @@ public:
     virtual bool on_keydown(GUI::KeyEvent&) override;
     virtual void on_keyup(GUI::KeyEvent&) override;
     virtual void on_second_paint(Layer const*, GUI::PaintEvent&) override;
-    virtual ErrorOr<GUI::Widget*> get_properties_widget() override;
+    virtual NonnullRefPtr<GUI::Widget> get_properties_widget() override;
     virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap const>> cursor() override { return Gfx::StandardCursor::Crosshair; }
     virtual Gfx::IntPoint point_position_to_preferred_cell(Gfx::FloatPoint position) const override;
 

--- a/Userland/Applications/PixelPaint/Tools/RectangleTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/RectangleTool.cpp
@@ -146,28 +146,28 @@ ErrorOr<GUI::Widget*> RectangleTool::get_properties_widget()
         auto properties_widget = GUI::Widget::construct();
         properties_widget->set_layout<GUI::VerticalBoxLayout>();
 
-        auto thickness_or_radius_container = TRY(properties_widget->try_add<GUI::Widget>());
-        thickness_or_radius_container->set_fixed_height(20);
-        thickness_or_radius_container->set_layout<GUI::HorizontalBoxLayout>();
+        auto& thickness_or_radius_container = properties_widget->add<GUI::Widget>();
+        thickness_or_radius_container.set_fixed_height(20);
+        thickness_or_radius_container.set_layout<GUI::HorizontalBoxLayout>();
 
-        auto thickness_or_radius_label = TRY(thickness_or_radius_container->try_add<GUI::Label>());
-        thickness_or_radius_label->set_text_alignment(Gfx::TextAlignment::CenterLeft);
-        thickness_or_radius_label->set_fixed_size(80, 20);
+        auto& thickness_or_radius_label = thickness_or_radius_container.add<GUI::Label>();
+        thickness_or_radius_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
+        thickness_or_radius_label.set_fixed_size(80, 20);
 
-        auto thickness_or_radius_slider = TRY(thickness_or_radius_container->try_add<GUI::ValueSlider>(Orientation::Horizontal, "px"_string));
+        auto& thickness_or_radius_slider = thickness_or_radius_container.add<GUI::ValueSlider>(Orientation::Horizontal, "px"_string);
 
-        thickness_or_radius_slider->on_change = [&](int value) {
+        thickness_or_radius_slider.on_change = [&](int value) {
             if (m_fill_mode == FillMode::RoundedCorners) {
                 m_corner_radius = value;
             } else
                 m_thickness = value;
         };
 
-        auto update_slider = [this, thickness_or_radius_label, thickness_or_radius_slider] {
+        auto update_slider = [this, &thickness_or_radius_label, &thickness_or_radius_slider] {
             auto update_values = [&](auto label, int value, int range_min, int range_max = 10) {
-                thickness_or_radius_label->set_text(String::from_utf8(label).release_value_but_fixme_should_propagate_errors());
-                thickness_or_radius_slider->set_range(range_min, range_max);
-                thickness_or_radius_slider->set_value(value);
+                thickness_or_radius_label.set_text(String::from_utf8(label).release_value_but_fixme_should_propagate_errors());
+                thickness_or_radius_slider.set_range(range_min, range_max);
+                thickness_or_radius_slider.set_value(value);
             };
             if (m_fill_mode == FillMode::RoundedCorners)
                 update_values("Radius:"sv, m_corner_radius, 0, 50);
@@ -176,64 +176,64 @@ ErrorOr<GUI::Widget*> RectangleTool::get_properties_widget()
         };
 
         update_slider();
-        set_primary_slider(thickness_or_radius_slider);
+        set_primary_slider(&thickness_or_radius_slider);
 
-        auto mode_container = TRY(properties_widget->try_add<GUI::Widget>());
-        mode_container->set_fixed_height(90);
-        mode_container->set_layout<GUI::HorizontalBoxLayout>();
-        auto mode_label = TRY(mode_container->try_add<GUI::Label>("Mode:"_string));
-        mode_label->set_text_alignment(Gfx::TextAlignment::CenterLeft);
-        mode_label->set_fixed_size(30, 20);
+        auto& mode_container = properties_widget->add<GUI::Widget>();
+        mode_container.set_fixed_height(90);
+        mode_container.set_layout<GUI::HorizontalBoxLayout>();
+        auto& mode_label = mode_container.add<GUI::Label>("Mode:"_string);
+        mode_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
+        mode_label.set_fixed_size(30, 20);
 
-        auto mode_radio_container = TRY(mode_container->try_add<GUI::Widget>());
-        mode_radio_container->set_layout<GUI::VerticalBoxLayout>();
-        auto outline_mode_radio = TRY(mode_radio_container->try_add<GUI::RadioButton>("Outline"_string));
-        auto fill_mode_radio = TRY(mode_radio_container->try_add<GUI::RadioButton>("Fill"_string));
-        auto gradient_mode_radio = TRY(mode_radio_container->try_add<GUI::RadioButton>("Gradient"_string));
-        mode_radio_container->set_fixed_width(70);
+        auto& mode_radio_container = mode_container.add<GUI::Widget>();
+        mode_radio_container.set_layout<GUI::VerticalBoxLayout>();
+        auto& outline_mode_radio = mode_radio_container.add<GUI::RadioButton>("Outline"_string);
+        auto& fill_mode_radio = mode_radio_container.add<GUI::RadioButton>("Fill"_string);
+        auto& gradient_mode_radio = mode_radio_container.add<GUI::RadioButton>("Gradient"_string);
+        mode_radio_container.set_fixed_width(70);
 
-        auto rounded_corners_mode_radio = TRY(mode_radio_container->try_add<GUI::RadioButton>("Rounded"_string));
+        auto& rounded_corners_mode_radio = mode_radio_container.add<GUI::RadioButton>("Rounded"_string);
 
-        outline_mode_radio->on_checked = [this, update_slider](bool) {
+        outline_mode_radio.on_checked = [this, update_slider](bool) {
             m_fill_mode = FillMode::Outline;
             update_slider();
         };
-        fill_mode_radio->on_checked = [this, update_slider](bool) {
+        fill_mode_radio.on_checked = [this, update_slider](bool) {
             m_fill_mode = FillMode::Fill;
             update_slider();
         };
-        gradient_mode_radio->on_checked = [this, update_slider](bool) {
+        gradient_mode_radio.on_checked = [this, update_slider](bool) {
             m_fill_mode = FillMode::Gradient;
             update_slider();
         };
-        rounded_corners_mode_radio->on_checked = [this, update_slider](bool) {
+        rounded_corners_mode_radio.on_checked = [this, update_slider](bool) {
             m_fill_mode = FillMode::RoundedCorners;
             update_slider();
         };
-        outline_mode_radio->set_checked(true);
+        outline_mode_radio.set_checked(true);
 
-        auto mode_extras_container = TRY(mode_container->try_add<GUI::Widget>());
-        mode_extras_container->set_layout<GUI::VerticalBoxLayout>();
+        auto& mode_extras_container = mode_container.add<GUI::Widget>();
+        mode_extras_container.set_layout<GUI::VerticalBoxLayout>();
 
-        auto aa_enable_checkbox = TRY(mode_extras_container->try_add<GUI::CheckBox>("Anti-alias"_string));
-        aa_enable_checkbox->on_checked = [this](bool checked) {
+        auto& aa_enable_checkbox = mode_extras_container.add<GUI::CheckBox>("Anti-alias"_string);
+        aa_enable_checkbox.on_checked = [this](bool checked) {
             m_antialias_enabled = checked;
         };
-        aa_enable_checkbox->set_checked(true);
+        aa_enable_checkbox.set_checked(true);
 
-        auto aspect_container = TRY(mode_extras_container->try_add<GUI::Widget>());
-        aspect_container->set_layout<GUI::VerticalBoxLayout>();
-        aspect_container->set_fixed_width(75);
+        auto& aspect_container = mode_extras_container.add<GUI::Widget>();
+        aspect_container.set_layout<GUI::VerticalBoxLayout>();
+        aspect_container.set_fixed_width(75);
 
-        auto aspect_label = TRY(aspect_container->try_add<GUI::Label>("Aspect Ratio:"_string));
-        aspect_label->set_text_alignment(Gfx::TextAlignment::CenterLeft);
-        aspect_label->set_fixed_size(75, 20);
+        auto& aspect_label = aspect_container.add<GUI::Label>("Aspect Ratio:"_string);
+        aspect_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
+        aspect_label.set_fixed_size(75, 20);
 
-        auto aspect_fields_container = TRY(aspect_container->try_add<GUI::Widget>());
-        aspect_fields_container->set_fixed_width(75);
-        aspect_fields_container->set_layout<GUI::HorizontalBoxLayout>();
+        auto& aspect_fields_container = aspect_container.add<GUI::Widget>();
+        aspect_fields_container.set_fixed_width(75);
+        aspect_fields_container.set_layout<GUI::HorizontalBoxLayout>();
 
-        m_aspect_w_textbox = TRY(aspect_fields_container->try_add<GUI::TextBox>());
+        m_aspect_w_textbox = aspect_fields_container.add<GUI::TextBox>();
         m_aspect_w_textbox->set_fixed_height(20);
         m_aspect_w_textbox->set_fixed_width(25);
         m_aspect_w_textbox->on_change = [this] {
@@ -246,11 +246,11 @@ ErrorOr<GUI::Widget*> RectangleTool::get_properties_widget()
             }
         };
 
-        auto multiply_label = TRY(aspect_fields_container->try_add<GUI::Label>("x"_string));
-        multiply_label->set_text_alignment(Gfx::TextAlignment::Center);
-        multiply_label->set_fixed_size(10, 20);
+        auto& multiply_label = aspect_fields_container.add<GUI::Label>("x"_string);
+        multiply_label.set_text_alignment(Gfx::TextAlignment::Center);
+        multiply_label.set_fixed_size(10, 20);
 
-        m_aspect_h_textbox = TRY(aspect_fields_container->try_add<GUI::TextBox>());
+        m_aspect_h_textbox = aspect_fields_container.add<GUI::TextBox>();
         m_aspect_h_textbox->set_fixed_height(20);
         m_aspect_h_textbox->set_fixed_width(25);
         m_aspect_h_textbox->on_change = [this] { m_aspect_w_textbox->on_change(); };

--- a/Userland/Applications/PixelPaint/Tools/RectangleTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/RectangleTool.cpp
@@ -140,7 +140,7 @@ bool RectangleTool::on_keydown(GUI::KeyEvent& event)
     return Tool::on_keydown(event);
 }
 
-ErrorOr<GUI::Widget*> RectangleTool::get_properties_widget()
+NonnullRefPtr<GUI::Widget> RectangleTool::get_properties_widget()
 {
     if (!m_properties_widget) {
         auto properties_widget = GUI::Widget::construct();
@@ -258,7 +258,7 @@ ErrorOr<GUI::Widget*> RectangleTool::get_properties_widget()
         m_properties_widget = properties_widget;
     }
 
-    return m_properties_widget.ptr();
+    return *m_properties_widget;
 }
 
 }

--- a/Userland/Applications/PixelPaint/Tools/RectangleTool.h
+++ b/Userland/Applications/PixelPaint/Tools/RectangleTool.h
@@ -24,7 +24,7 @@ public:
     virtual void on_mouseup(Layer*, MouseEvent&) override;
     virtual void on_second_paint(Layer const*, GUI::PaintEvent&) override;
     virtual bool on_keydown(GUI::KeyEvent&) override;
-    virtual ErrorOr<GUI::Widget*> get_properties_widget() override;
+    virtual NonnullRefPtr<GUI::Widget> get_properties_widget() override;
     virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap const>> cursor() override { return Gfx::StandardCursor::Crosshair; }
 
 private:

--- a/Userland/Applications/PixelPaint/Tools/SprayTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/SprayTool.cpp
@@ -90,7 +90,7 @@ void SprayTool::on_mouseup(Layer*, MouseEvent&)
     }
 }
 
-ErrorOr<GUI::Widget*> SprayTool::get_properties_widget()
+NonnullRefPtr<GUI::Widget> SprayTool::get_properties_widget()
 {
     if (!m_properties_widget) {
         auto properties_widget = GUI::Widget::construct();
@@ -132,7 +132,7 @@ ErrorOr<GUI::Widget*> SprayTool::get_properties_widget()
         m_properties_widget = properties_widget;
     }
 
-    return m_properties_widget.ptr();
+    return *m_properties_widget;
 }
 
 }

--- a/Userland/Applications/PixelPaint/Tools/SprayTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/SprayTool.cpp
@@ -96,39 +96,39 @@ ErrorOr<GUI::Widget*> SprayTool::get_properties_widget()
         auto properties_widget = GUI::Widget::construct();
         properties_widget->set_layout<GUI::VerticalBoxLayout>();
 
-        auto size_container = TRY(properties_widget->try_add<GUI::Widget>());
-        size_container->set_fixed_height(20);
-        size_container->set_layout<GUI::HorizontalBoxLayout>();
+        auto& size_container = properties_widget->add<GUI::Widget>();
+        size_container.set_fixed_height(20);
+        size_container.set_layout<GUI::HorizontalBoxLayout>();
 
-        auto size_label = TRY(size_container->try_add<GUI::Label>("Size:"_string));
-        size_label->set_text_alignment(Gfx::TextAlignment::CenterLeft);
-        size_label->set_fixed_size(80, 20);
+        auto& size_label = size_container.add<GUI::Label>("Size:"_string);
+        size_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
+        size_label.set_fixed_size(80, 20);
 
-        auto size_slider = TRY(size_container->try_add<GUI::ValueSlider>(Orientation::Horizontal, "px"_string));
-        size_slider->set_range(1, 20);
-        size_slider->set_value(m_thickness);
+        auto& size_slider = size_container.add<GUI::ValueSlider>(Orientation::Horizontal, "px"_string);
+        size_slider.set_range(1, 20);
+        size_slider.set_value(m_thickness);
 
-        size_slider->on_change = [this](int value) {
+        size_slider.on_change = [this](int value) {
             m_thickness = value;
         };
-        set_primary_slider(size_slider);
+        set_primary_slider(&size_slider);
 
-        auto density_container = TRY(properties_widget->try_add<GUI::Widget>());
-        density_container->set_fixed_height(20);
-        density_container->set_layout<GUI::HorizontalBoxLayout>();
+        auto& density_container = properties_widget->add<GUI::Widget>();
+        density_container.set_fixed_height(20);
+        density_container.set_layout<GUI::HorizontalBoxLayout>();
 
-        auto density_label = TRY(density_container->try_add<GUI::Label>("Density:"_string));
-        density_label->set_text_alignment(Gfx::TextAlignment::CenterLeft);
-        density_label->set_fixed_size(80, 20);
+        auto& density_label = density_container.add<GUI::Label>("Density:"_string);
+        density_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
+        density_label.set_fixed_size(80, 20);
 
-        auto density_slider = TRY(density_container->try_add<GUI::ValueSlider>(Orientation::Horizontal, "%"_string));
-        density_slider->set_range(1, 100);
-        density_slider->set_value(m_density);
+        auto& density_slider = density_container.add<GUI::ValueSlider>(Orientation::Horizontal, "%"_string);
+        density_slider.set_range(1, 100);
+        density_slider.set_value(m_density);
 
-        density_slider->on_change = [this](int value) {
+        density_slider.on_change = [this](int value) {
             m_density = value;
         };
-        set_secondary_slider(density_slider);
+        set_secondary_slider(&density_slider);
         m_properties_widget = properties_widget;
     }
 

--- a/Userland/Applications/PixelPaint/Tools/SprayTool.h
+++ b/Userland/Applications/PixelPaint/Tools/SprayTool.h
@@ -22,7 +22,7 @@ public:
     virtual void on_mousedown(Layer*, MouseEvent&) override;
     virtual void on_mouseup(Layer*, MouseEvent&) override;
     virtual void on_mousemove(Layer*, MouseEvent&) override;
-    virtual ErrorOr<GUI::Widget*> get_properties_widget() override;
+    virtual NonnullRefPtr<GUI::Widget> get_properties_widget() override;
     virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap const>> cursor() override { return Gfx::StandardCursor::Crosshair; }
 
 private:

--- a/Userland/Applications/PixelPaint/Tools/TextTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/TextTool.cpp
@@ -103,10 +103,10 @@ void TextTool::on_mousedown(Layer*, MouseEvent& event)
     }
 }
 
-ErrorOr<GUI::Widget*> TextTool::get_properties_widget()
+NonnullRefPtr<GUI::Widget> TextTool::get_properties_widget()
 {
     if (m_properties_widget)
-        return m_properties_widget.ptr();
+        return *m_properties_widget.ptr();
 
     auto properties_widget = GUI::Widget::construct();
     properties_widget->set_layout<GUI::VerticalBoxLayout>();
@@ -128,7 +128,7 @@ ErrorOr<GUI::Widget*> TextTool::get_properties_widget()
     };
 
     m_properties_widget = properties_widget;
-    return m_properties_widget.ptr();
+    return *m_properties_widget;
 }
 
 void TextTool::on_second_paint(Layer const* layer, GUI::PaintEvent& event)

--- a/Userland/Applications/PixelPaint/Tools/TextTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/TextTool.cpp
@@ -111,13 +111,13 @@ ErrorOr<GUI::Widget*> TextTool::get_properties_widget()
     auto properties_widget = GUI::Widget::construct();
     properties_widget->set_layout<GUI::VerticalBoxLayout>();
 
-    auto font_header = TRY(properties_widget->try_add<GUI::Label>("Current Font:"_string));
-    font_header->set_text_alignment(Gfx::TextAlignment::CenterLeft);
+    auto& font_header = properties_widget->add<GUI::Label>("Current Font:"_string);
+    font_header.set_text_alignment(Gfx::TextAlignment::CenterLeft);
 
-    m_font_label = TRY(properties_widget->try_add<GUI::Label>(m_selected_font->human_readable_name()));
+    m_font_label = properties_widget->add<GUI::Label>(m_selected_font->human_readable_name());
 
-    auto change_font_button = TRY(properties_widget->try_add<GUI::Button>("Change Font..."_string));
-    change_font_button->on_click = [this](auto) {
+    auto& change_font_button = properties_widget->add<GUI::Button>("Change Font..."_string);
+    change_font_button.on_click = [this](auto) {
         auto picker = GUI::FontPicker::construct(nullptr, m_selected_font, false);
         if (picker->exec() == GUI::Dialog::ExecResult::OK) {
             m_font_label->set_text(picker->font()->human_readable_name());

--- a/Userland/Applications/PixelPaint/Tools/TextTool.h
+++ b/Userland/Applications/PixelPaint/Tools/TextTool.h
@@ -41,7 +41,7 @@ public:
     virtual void on_primary_color_change(Color) override;
     virtual void on_tool_deactivation() override;
     virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap const>> cursor() override;
-    virtual ErrorOr<GUI::Widget*> get_properties_widget() override;
+    virtual NonnullRefPtr<GUI::Widget> get_properties_widget() override;
 
 private:
     virtual StringView tool_name() const override { return "Text Tool"sv; }

--- a/Userland/Applications/PixelPaint/Tools/Tool.h
+++ b/Userland/Applications/PixelPaint/Tools/Tool.h
@@ -67,7 +67,7 @@ public:
     virtual void on_secondary_color_change(Color) { }
     virtual void on_tool_activation() { }
     virtual void on_tool_deactivation() { }
-    virtual ErrorOr<GUI::Widget*> get_properties_widget() { return nullptr; }
+    virtual NonnullRefPtr<GUI::Widget> get_properties_widget() { return GUI::Widget::construct(); }
     virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap const>> cursor() { return Gfx::StandardCursor::None; }
     virtual Gfx::IntPoint point_position_to_preferred_cell(Gfx::FloatPoint position) const { return position.to_type<int>(); }
 

--- a/Userland/Applications/PixelPaint/Tools/WandSelectTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/WandSelectTool.cpp
@@ -75,31 +75,31 @@ ErrorOr<GUI::Widget*> WandSelectTool::get_properties_widget()
     auto properties_widget = GUI::Widget::construct();
     properties_widget->set_layout<GUI::VerticalBoxLayout>();
 
-    auto threshold_container = TRY(properties_widget->try_add<GUI::Widget>());
-    threshold_container->set_fixed_height(20);
-    threshold_container->set_layout<GUI::HorizontalBoxLayout>();
+    auto& threshold_container = properties_widget->add<GUI::Widget>();
+    threshold_container.set_fixed_height(20);
+    threshold_container.set_layout<GUI::HorizontalBoxLayout>();
 
-    auto threshold_label = TRY(threshold_container->try_add<GUI::Label>("Threshold:"_string));
-    threshold_label->set_text_alignment(Gfx::TextAlignment::CenterLeft);
-    threshold_label->set_fixed_size(80, 20);
+    auto& threshold_label = threshold_container.add<GUI::Label>("Threshold:"_string);
+    threshold_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
+    threshold_label.set_fixed_size(80, 20);
 
-    auto threshold_slider = TRY(threshold_container->try_add<GUI::ValueSlider>(Orientation::Horizontal, "%"_string));
-    threshold_slider->set_range(0, 100);
-    threshold_slider->set_value(m_threshold);
+    auto& threshold_slider = threshold_container.add<GUI::ValueSlider>(Orientation::Horizontal, "%"_string);
+    threshold_slider.set_range(0, 100);
+    threshold_slider.set_value(m_threshold);
 
-    threshold_slider->on_change = [this](int value) {
+    threshold_slider.on_change = [this](int value) {
         m_threshold = value;
     };
-    set_primary_slider(threshold_slider);
+    set_primary_slider(&threshold_slider);
 
-    auto mode_container = TRY(properties_widget->try_add<GUI::Widget>());
-    mode_container->set_fixed_height(20);
-    mode_container->set_layout<GUI::HorizontalBoxLayout>();
+    auto& mode_container = properties_widget->add<GUI::Widget>();
+    mode_container.set_fixed_height(20);
+    mode_container.set_layout<GUI::HorizontalBoxLayout>();
 
-    auto mode_label = TRY(mode_container->try_add<GUI::Label>());
-    mode_label->set_text("Mode:"_string);
-    mode_label->set_text_alignment(Gfx::TextAlignment::CenterLeft);
-    mode_label->set_fixed_size(80, 20);
+    auto& mode_label = mode_container.add<GUI::Label>();
+    mode_label.set_text("Mode:"_string);
+    mode_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
+    mode_label.set_fixed_size(80, 20);
 
     for (int i = 0; i < (int)Selection::MergeMode::__Count; i++) {
         switch ((Selection::MergeMode)i) {
@@ -120,11 +120,11 @@ ErrorOr<GUI::Widget*> WandSelectTool::get_properties_widget()
         }
     }
 
-    auto mode_combo = TRY(mode_container->try_add<GUI::ComboBox>());
-    mode_combo->set_only_allow_values_from_model(true);
-    mode_combo->set_model(*GUI::ItemListModel<DeprecatedString>::create(m_merge_mode_names));
-    mode_combo->set_selected_index((int)m_merge_mode);
-    mode_combo->on_change = [this](auto&&, GUI::ModelIndex const& index) {
+    auto& mode_combo = mode_container.add<GUI::ComboBox>();
+    mode_combo.set_only_allow_values_from_model(true);
+    mode_combo.set_model(*GUI::ItemListModel<DeprecatedString>::create(m_merge_mode_names));
+    mode_combo.set_selected_index((int)m_merge_mode);
+    mode_combo.on_change = [this](auto&&, GUI::ModelIndex const& index) {
         VERIFY(index.row() >= 0);
         VERIFY(index.row() < (int)Selection::MergeMode::__Count);
 

--- a/Userland/Applications/PixelPaint/Tools/WandSelectTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/WandSelectTool.cpp
@@ -66,10 +66,10 @@ void WandSelectTool::on_mousedown(Layer* layer, MouseEvent& event)
     m_editor->did_complete_action(tool_name());
 }
 
-ErrorOr<GUI::Widget*> WandSelectTool::get_properties_widget()
+NonnullRefPtr<GUI::Widget> WandSelectTool::get_properties_widget()
 {
     if (m_properties_widget) {
-        return m_properties_widget.ptr();
+        return *m_properties_widget.ptr();
     }
 
     auto properties_widget = GUI::Widget::construct();
@@ -104,16 +104,16 @@ ErrorOr<GUI::Widget*> WandSelectTool::get_properties_widget()
     for (int i = 0; i < (int)Selection::MergeMode::__Count; i++) {
         switch ((Selection::MergeMode)i) {
         case Selection::MergeMode::Set:
-            TRY(m_merge_mode_names.try_append("Set"));
+            m_merge_mode_names.append("Set");
             break;
         case Selection::MergeMode::Add:
-            TRY(m_merge_mode_names.try_append("Add"));
+            m_merge_mode_names.append("Add");
             break;
         case Selection::MergeMode::Subtract:
-            TRY(m_merge_mode_names.try_append("Subtract"));
+            m_merge_mode_names.append("Subtract");
             break;
         case Selection::MergeMode::Intersect:
-            TRY(m_merge_mode_names.try_append("Intersect"));
+            m_merge_mode_names.append("Intersect");
             break;
         default:
             VERIFY_NOT_REACHED();
@@ -132,7 +132,7 @@ ErrorOr<GUI::Widget*> WandSelectTool::get_properties_widget()
     };
 
     m_properties_widget = properties_widget;
-    return m_properties_widget.ptr();
+    return *m_properties_widget;
 }
 
 }

--- a/Userland/Applications/PixelPaint/Tools/WandSelectTool.h
+++ b/Userland/Applications/PixelPaint/Tools/WandSelectTool.h
@@ -23,7 +23,7 @@ public:
 
     virtual void on_mousedown(Layer*, MouseEvent& event) override;
     virtual bool on_keydown(GUI::KeyEvent&) override;
-    virtual ErrorOr<GUI::Widget*> get_properties_widget() override;
+    virtual NonnullRefPtr<GUI::Widget> get_properties_widget() override;
     virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap const>> cursor() override { return Gfx::StandardCursor::Crosshair; }
 
 private:

--- a/Userland/Applications/PixelPaint/Tools/ZoomTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/ZoomTool.cpp
@@ -23,7 +23,7 @@ void ZoomTool::on_mousedown(Layer*, MouseEvent& event)
     m_editor->scale_centered(new_scale, raw_event.position());
 }
 
-ErrorOr<GUI::Widget*> ZoomTool::get_properties_widget()
+NonnullRefPtr<GUI::Widget> ZoomTool::get_properties_widget()
 {
     if (!m_properties_widget) {
         auto properties_widget = GUI::Widget::construct();
@@ -48,7 +48,7 @@ ErrorOr<GUI::Widget*> ZoomTool::get_properties_widget()
         m_properties_widget = properties_widget;
     }
 
-    return m_properties_widget.ptr();
+    return *m_properties_widget;
 }
 
 }

--- a/Userland/Applications/PixelPaint/Tools/ZoomTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/ZoomTool.cpp
@@ -29,22 +29,22 @@ ErrorOr<GUI::Widget*> ZoomTool::get_properties_widget()
         auto properties_widget = GUI::Widget::construct();
         properties_widget->set_layout<GUI::VerticalBoxLayout>();
 
-        auto sensitivity_container = TRY(properties_widget->try_add<GUI::Widget>());
-        sensitivity_container->set_fixed_height(20);
-        sensitivity_container->set_layout<GUI::HorizontalBoxLayout>();
+        auto& sensitivity_container = properties_widget->add<GUI::Widget>();
+        sensitivity_container.set_fixed_height(20);
+        sensitivity_container.set_layout<GUI::HorizontalBoxLayout>();
 
-        auto sensitivity_label = TRY(sensitivity_container->try_add<GUI::Label>("Sensitivity:"_string));
-        sensitivity_label->set_text_alignment(Gfx::TextAlignment::CenterLeft);
-        sensitivity_label->set_fixed_size(80, 20);
+        auto& sensitivity_label = sensitivity_container.add<GUI::Label>("Sensitivity:"_string);
+        sensitivity_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
+        sensitivity_label.set_fixed_size(80, 20);
 
-        auto sensitivity_slider = TRY(sensitivity_container->try_add<GUI::ValueSlider>(Orientation::Horizontal, "%"_string));
-        sensitivity_slider->set_range(1, 100);
-        sensitivity_slider->set_value(100 * m_sensitivity);
+        auto& sensitivity_slider = sensitivity_container.add<GUI::ValueSlider>(Orientation::Horizontal, "%"_string);
+        sensitivity_slider.set_range(1, 100);
+        sensitivity_slider.set_value(100 * m_sensitivity);
 
-        sensitivity_slider->on_change = [this](int value) {
+        sensitivity_slider.on_change = [this](int value) {
             m_sensitivity = value / 100.0f;
         };
-        set_primary_slider(sensitivity_slider);
+        set_primary_slider(&sensitivity_slider);
         m_properties_widget = properties_widget;
     }
 

--- a/Userland/Applications/PixelPaint/Tools/ZoomTool.h
+++ b/Userland/Applications/PixelPaint/Tools/ZoomTool.h
@@ -18,7 +18,7 @@ public:
     virtual ~ZoomTool() override = default;
 
     virtual void on_mousedown(Layer*, MouseEvent&) override;
-    virtual ErrorOr<GUI::Widget*> get_properties_widget() override;
+    virtual NonnullRefPtr<GUI::Widget> get_properties_widget() override;
     virtual Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap const>> cursor() override { return Gfx::StandardCursor::Zoom; }
 
 private:

--- a/Userland/Applications/Settings/main.cpp
+++ b/Userland/Applications/Settings/main.cpp
@@ -105,16 +105,16 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     main_widget->set_fill_with_background_color(true);
     main_widget->set_layout<GUI::VerticalBoxLayout>();
 
-    auto icon_view = TRY(main_widget->try_add<GUI::IconView>());
-    icon_view->set_should_hide_unnecessary_scrollbars(true);
+    auto& icon_view = main_widget->add<GUI::IconView>();
+    icon_view.set_should_hide_unnecessary_scrollbars(true);
     auto model = adopt_ref(*new SettingsAppsModel);
-    icon_view->set_model(*model);
+    icon_view.set_model(*model);
 
-    icon_view->on_activation = [&](GUI::ModelIndex const& index) {
+    icon_view.on_activation = [&](GUI::ModelIndex const& index) {
         auto executable = model->data(index, GUI::ModelRole::Custom).as_string();
         auto requires_root = model->data(index, static_cast<GUI::ModelRole>(SettingsAppsModelCustomRole::RequiresRoot)).as_bool();
 
-        auto launch_origin_rect = icon_view->to_widget_rect(icon_view->content_rect(index)).translated(icon_view->screen_relative_rect().location());
+        auto launch_origin_rect = icon_view.to_widget_rect(icon_view.content_rect(index)).translated(icon_view.screen_relative_rect().location());
         setenv("__libgui_launch_origin_rect", DeprecatedString::formatted("{},{},{},{}", launch_origin_rect.x(), launch_origin_rect.y(), launch_origin_rect.width(), launch_origin_rect.height()).characters(), 1);
 
         if (requires_root)
@@ -123,17 +123,17 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             GUI::Process::spawn_or_show_error(window, executable);
     };
 
-    auto statusbar = TRY(main_widget->try_add<GUI::Statusbar>());
+    auto& statusbar = main_widget->add<GUI::Statusbar>();
 
-    icon_view->on_selection_change = [&] {
-        auto index = icon_view->selection().first();
+    icon_view.on_selection_change = [&] {
+        auto index = icon_view.selection().first();
         if (!index.is_valid()) {
-            statusbar->set_text({});
+            statusbar.set_text({});
             return;
         }
 
         auto& app = *(NonnullRefPtr<Desktop::AppFile>*)index.internal_data();
-        statusbar->set_text(String::from_deprecated_string(app->description()).release_value_but_fixme_should_propagate_errors());
+        statusbar.set_text(String::from_deprecated_string(app->description()).release_value_but_fixme_should_propagate_errors());
     };
 
     window->set_icon(app_icon.bitmap_for_size(16));

--- a/Userland/Applications/SpaceAnalyzer/ProgressWindow.cpp
+++ b/Userland/Applications/SpaceAnalyzer/ProgressWindow.cpp
@@ -18,10 +18,10 @@ ErrorOr<NonnullRefPtr<ProgressWindow>> ProgressWindow::try_create(StringView tit
     main_widget->set_fill_with_background_color(true);
     main_widget->set_layout<GUI::VerticalBoxLayout>();
 
-    auto label = TRY(main_widget->try_add<GUI::Label>("Analyzing storage space..."_string));
-    label->set_fixed_height(22);
+    auto& label = main_widget->add<GUI::Label>("Analyzing storage space..."_string);
+    label.set_fixed_height(22);
 
-    window->m_progress_label = TRY(main_widget->try_add<GUI::Label>());
+    window->m_progress_label = main_widget->add<GUI::Label>();
     window->m_progress_label->set_fixed_height(22);
 
     window->update_progress_label(0);

--- a/Userland/Applications/SystemMonitor/ProcessFileDescriptorMapWidget.cpp
+++ b/Userland/Applications/SystemMonitor/ProcessFileDescriptorMapWidget.cpp
@@ -19,7 +19,7 @@ ErrorOr<NonnullRefPtr<ProcessFileDescriptorMapWidget>> ProcessFileDescriptorMapW
 {
     auto widget = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) ProcessFileDescriptorMapWidget()));
     widget->set_layout<GUI::VerticalBoxLayout>(4);
-    widget->m_table_view = TRY(widget->try_add<GUI::TableView>());
+    widget->m_table_view = widget->add<GUI::TableView>();
 
     Vector<GUI::JsonArrayModel::FieldSpec> pid_fds_fields;
     TRY(pid_fds_fields.try_empend("fd", "FD"_string, Gfx::TextAlignment::CenterRight));

--- a/Userland/Applications/SystemMonitor/ProcessMemoryMapWidget.cpp
+++ b/Userland/Applications/SystemMonitor/ProcessMemoryMapWidget.cpp
@@ -53,7 +53,7 @@ ErrorOr<NonnullRefPtr<ProcessMemoryMapWidget>> ProcessMemoryMapWidget::try_creat
 {
     auto widget = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) ProcessMemoryMapWidget()));
     widget->set_layout<GUI::VerticalBoxLayout>(4);
-    widget->m_table_view = TRY(widget->try_add<GUI::TableView>());
+    widget->m_table_view = widget->add<GUI::TableView>();
 
     Vector<GUI::JsonArrayModel::FieldSpec> pid_vm_fields;
     TRY(pid_vm_fields.try_empend(
@@ -110,7 +110,7 @@ ErrorOr<NonnullRefPtr<ProcessMemoryMapWidget>> ProcessMemoryMapWidget::try_creat
     widget->m_table_view->set_column_painting_delegate(7, TRY(try_make<PagemapPaintingDelegate>()));
 
     widget->m_table_view->set_key_column_and_sort_order(0, GUI::SortOrder::Ascending);
-    widget->m_timer = TRY(widget->try_add<Core::Timer>(1000, [widget] { widget->refresh(); }));
+    widget->m_timer = widget->add<Core::Timer>(1000, [widget] { widget->refresh(); });
     widget->m_timer->start();
 
     return widget;

--- a/Userland/Applications/SystemMonitor/ProcessStateWidget.cpp
+++ b/Userland/Applications/SystemMonitor/ProcessStateWidget.cpp
@@ -97,7 +97,7 @@ ErrorOr<NonnullRefPtr<ProcessStateWidget>> ProcessStateWidget::try_create()
 {
     auto widget = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) ProcessStateWidget()));
     widget->set_layout<GUI::VerticalBoxLayout>(4);
-    widget->m_table_view = TRY(widget->try_add<GUI::TableView>());
+    widget->m_table_view = widget->add<GUI::TableView>();
     widget->m_table_view->set_model(TRY(try_make_ref_counted<ProcessStateModel>(ProcessModel::the(), 0)));
     widget->m_table_view->column_header().set_visible(false);
     widget->m_table_view->column_header().set_section_size(0, 90);

--- a/Userland/Applications/SystemMonitor/ProcessUnveiledPathsWidget.cpp
+++ b/Userland/Applications/SystemMonitor/ProcessUnveiledPathsWidget.cpp
@@ -20,7 +20,7 @@ ErrorOr<NonnullRefPtr<ProcessUnveiledPathsWidget>> ProcessUnveiledPathsWidget::t
 {
     auto widget = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) ProcessUnveiledPathsWidget()));
     widget->set_layout<GUI::VerticalBoxLayout>(4);
-    widget->m_table_view = TRY(widget->try_add<GUI::TableView>());
+    widget->m_table_view = widget->add<GUI::TableView>();
 
     Vector<GUI::JsonArrayModel::FieldSpec> pid_unveil_fields;
     TRY(pid_unveil_fields.try_empend("path", "Path"_string, Gfx::TextAlignment::CenterLeft));

--- a/Userland/Applications/SystemMonitor/ThreadStackWidget.cpp
+++ b/Userland/Applications/SystemMonitor/ThreadStackWidget.cpp
@@ -75,7 +75,7 @@ ErrorOr<NonnullRefPtr<ThreadStackWidget>> ThreadStackWidget::try_create()
 {
     auto widget = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) ThreadStackWidget()));
     widget->set_layout<GUI::VerticalBoxLayout>(4);
-    widget->m_stack_table = TRY(widget->try_add<GUI::TableView>());
+    widget->m_stack_table = widget->add<GUI::TableView>();
     widget->m_stack_table->set_model(TRY(try_make_ref_counted<ThreadStackModel>()));
     return widget;
 }

--- a/Userland/Applications/SystemMonitor/main.cpp
+++ b/Userland/Applications/SystemMonitor/main.cpp
@@ -332,8 +332,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             memory_stats_widget->refresh();
     };
     update_stats();
-    auto refresh_timer = TRY(window->try_add<Core::Timer>(frequency * 1000, move(update_stats)));
-    refresh_timer->start();
+    auto& refresh_timer = window->add<Core::Timer>(frequency * 1000, move(update_stats));
+    refresh_timer.start();
 
     auto selected_id = [&](ProcessModel::Column column) -> pid_t {
         if (process_table_view.selection().is_empty())
@@ -454,7 +454,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto make_frequency_action = [&](int seconds) -> ErrorOr<void> {
         auto action = GUI::Action::create_checkable(DeprecatedString::formatted("&{} Sec", seconds), [&refresh_timer, seconds](auto&) {
             Config::write_i32("SystemMonitor"sv, "Monitor"sv, "Frequency"sv, seconds);
-            refresh_timer->restart(seconds * 1000);
+            refresh_timer.restart(seconds * 1000);
         });
         action->set_status_tip(TRY(String::formatted("Refresh every {} seconds", seconds)));
         action->set_checked(frequency == seconds);
@@ -578,24 +578,24 @@ ErrorOr<void> build_performance_tab(GUI::Widget& graphs_container)
 
     Vector<SystemMonitor::GraphWidget&> cpu_graphs;
     for (auto row = 0u; row < cpu_graph_rows; ++row) {
-        auto cpu_graph_row = TRY(cpu_graph_group_box.try_add<GUI::Widget>());
-        cpu_graph_row->set_layout<GUI::HorizontalBoxLayout>(6);
-        cpu_graph_row->set_fixed_height(108);
+        auto& cpu_graph_row = cpu_graph_group_box.add<GUI::Widget>();
+        cpu_graph_row.set_layout<GUI::HorizontalBoxLayout>(6);
+        cpu_graph_row.set_fixed_height(108);
         for (auto i = 0u; i < cpu_graphs_per_row; ++i) {
-            auto cpu_graph = TRY(cpu_graph_row->try_add<SystemMonitor::GraphWidget>());
-            cpu_graph->set_max(100);
-            cpu_graph->set_value_format(0, {
-                                               .graph_color_role = ColorRole::SyntaxPreprocessorStatement,
-                                               .text_formatter = [](u64 value) {
-                                                   return DeprecatedString::formatted("Total: {}%", value);
-                                               },
-                                           });
-            cpu_graph->set_value_format(1, {
-                                               .graph_color_role = ColorRole::SyntaxPreprocessorValue,
-                                               .text_formatter = [](u64 value) {
-                                                   return DeprecatedString::formatted("Kernel: {}%", value);
-                                               },
-                                           });
+            auto& cpu_graph = cpu_graph_row.add<SystemMonitor::GraphWidget>();
+            cpu_graph.set_max(100);
+            cpu_graph.set_value_format(0, {
+                                              .graph_color_role = ColorRole::SyntaxPreprocessorStatement,
+                                              .text_formatter = [](u64 value) {
+                                                  return DeprecatedString::formatted("Total: {}%", value);
+                                              },
+                                          });
+            cpu_graph.set_value_format(1, {
+                                              .graph_color_role = ColorRole::SyntaxPreprocessorValue,
+                                              .text_formatter = [](u64 value) {
+                                                  return DeprecatedString::formatted("Kernel: {}%", value);
+                                              },
+                                          });
             cpu_graphs.append(cpu_graph);
         }
     }

--- a/Userland/Applications/Terminal/main.cpp
+++ b/Userland/Applications/Terminal/main.cpp
@@ -169,53 +169,53 @@ static ErrorOr<NonnullRefPtr<GUI::Window>> create_find_window(VT::TerminalWidget
     main_widget->set_background_role(ColorRole::Button);
     main_widget->set_layout<GUI::VerticalBoxLayout>(4);
 
-    auto find = TRY(main_widget->try_add<GUI::Widget>());
-    find->set_layout<GUI::HorizontalBoxLayout>(4);
-    find->set_fixed_height(30);
+    auto& find = main_widget->add<GUI::Widget>();
+    find.set_layout<GUI::HorizontalBoxLayout>(4);
+    find.set_fixed_height(30);
 
-    auto find_textbox = TRY(find->try_add<GUI::TextBox>());
-    find_textbox->set_fixed_width(230);
-    find_textbox->set_focus(true);
+    auto& find_textbox = find.add<GUI::TextBox>();
+    find_textbox.set_fixed_width(230);
+    find_textbox.set_focus(true);
     if (terminal.has_selection())
-        find_textbox->set_text(terminal.selected_text().replace("\n"sv, " "sv, ReplaceMode::All));
-    auto find_backwards = TRY(find->try_add<GUI::Button>());
-    find_backwards->set_fixed_width(25);
-    find_backwards->set_icon(TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/upward-triangle.png"sv)));
-    auto find_forwards = TRY(find->try_add<GUI::Button>());
-    find_forwards->set_fixed_width(25);
-    find_forwards->set_icon(TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/downward-triangle.png"sv)));
+        find_textbox.set_text(terminal.selected_text().replace("\n"sv, " "sv, ReplaceMode::All));
+    auto& find_backwards = find.add<GUI::Button>();
+    find_backwards.set_fixed_width(25);
+    find_backwards.set_icon(TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/upward-triangle.png"sv)));
+    auto& find_forwards = find.add<GUI::Button>();
+    find_forwards.set_fixed_width(25);
+    find_forwards.set_icon(TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/downward-triangle.png"sv)));
 
-    find_textbox->on_return_pressed = [find_backwards] {
-        find_backwards->click();
+    find_textbox.on_return_pressed = [&find_backwards] {
+        find_backwards.click();
     };
 
-    find_textbox->on_shift_return_pressed = [find_forwards] {
-        find_forwards->click();
+    find_textbox.on_shift_return_pressed = [&find_forwards] {
+        find_forwards.click();
     };
 
-    auto match_case = TRY(main_widget->try_add<GUI::CheckBox>("Case sensitive"_string));
-    auto wrap_around = TRY(main_widget->try_add<GUI::CheckBox>("Wrap around"_string));
+    auto& match_case = main_widget->add<GUI::CheckBox>("Case sensitive"_string);
+    auto& wrap_around = main_widget->add<GUI::CheckBox>("Wrap around"_string);
 
-    find_backwards->on_click = [&terminal, find_textbox, match_case, wrap_around](auto) {
-        auto needle = find_textbox->text();
+    find_backwards.on_click = [&terminal, &find_textbox, &match_case, &wrap_around](auto) {
+        auto needle = find_textbox.text();
         if (needle.is_empty()) {
             return;
         }
 
-        auto found_range = terminal.find_previous(needle, terminal.normalized_selection().start(), match_case->is_checked(), wrap_around->is_checked());
+        auto found_range = terminal.find_previous(needle, terminal.normalized_selection().start(), match_case.is_checked(), wrap_around.is_checked());
 
         if (found_range.is_valid()) {
             terminal.scroll_to_row(found_range.start().row());
             terminal.set_selection(found_range);
         }
     };
-    find_forwards->on_click = [&terminal, find_textbox, match_case, wrap_around](auto) {
-        auto needle = find_textbox->text();
+    find_forwards.on_click = [&terminal, &find_textbox, &match_case, &wrap_around](auto) {
+        auto needle = find_textbox.text();
         if (needle.is_empty()) {
             return;
         }
 
-        auto found_range = terminal.find_next(needle, terminal.normalized_selection().end(), match_case->is_checked(), wrap_around->is_checked());
+        auto found_range = terminal.find_next(needle, terminal.normalized_selection().end(), match_case.is_checked(), wrap_around.is_checked());
 
         if (found_range.is_valid()) {
             terminal.scroll_to_row(found_range.start().row());

--- a/Userland/Applications/ThemeEditor/MainWidget.cpp
+++ b/Userland/Applications/ThemeEditor/MainWidget.cpp
@@ -469,13 +469,13 @@ ErrorOr<void> MainWidget::add_property_tab(PropertyTab const& property_tab)
     properties_list->set_layout<GUI::VerticalBoxLayout>(GUI::Margins { 8 }, 12);
 
     for (auto const& group : property_tab.property_groups) {
-        NonnullRefPtr<GUI::GroupBox> group_box = TRY(properties_list->try_add<GUI::GroupBox>(group.title));
+        NonnullRefPtr<GUI::GroupBox> group_box = properties_list->add<GUI::GroupBox>(group.title);
         // 1px less on the left makes the text line up with the group title.
         group_box->set_layout<GUI::VerticalBoxLayout>(GUI::Margins { 8, 8, 8, 7 }, 12);
         group_box->set_preferred_height(GUI::SpecialDimension::Fit);
 
         for (auto const& property : group.properties) {
-            NonnullRefPtr<GUI::Widget> row_widget = TRY(group_box->try_add<GUI::Widget>());
+            NonnullRefPtr<GUI::Widget> row_widget = group_box->add<GUI::Widget>();
             row_widget->set_fixed_height(22);
             TRY(property.role.visit(
                 [&](Gfx::AlignmentRole role) -> ErrorOr<void> {

--- a/Userland/Demos/ModelGallery/GalleryWidget.cpp
+++ b/Userland/Demos/ModelGallery/GalleryWidget.cpp
@@ -15,7 +15,7 @@ GalleryWidget::GalleryWidget()
     auto& inner_widget = add<GUI::Widget>();
     inner_widget.set_layout<GUI::VerticalBoxLayout>(4);
 
-    m_tab_widget = inner_widget.try_add<GUI::TabWidget>().release_value_but_fixme_should_propagate_errors();
+    m_tab_widget = inner_widget.add<GUI::TabWidget>();
     m_statusbar = add<GUI::Statusbar>();
 
     (void)load_basic_model_tab();

--- a/Userland/Demos/Screensaver/main.cpp
+++ b/Userland/Demos/Screensaver/main.cpp
@@ -89,12 +89,12 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     main_widget->set_fill_with_background_color(true);
     main_widget->set_layout<GUI::VerticalBoxLayout>();
 
-    auto icon_view = TRY(main_widget->try_add<GUI::IconView>());
-    icon_view->set_should_hide_unnecessary_scrollbars(true);
+    auto& icon_view = main_widget->add<GUI::IconView>();
+    icon_view.set_should_hide_unnecessary_scrollbars(true);
     auto model = adopt_ref(*new ScreensaverAppsModel);
-    icon_view->set_model(*model);
+    icon_view.set_model(*model);
 
-    icon_view->on_activation = [&](GUI::ModelIndex const& index) {
+    icon_view.on_activation = [&](GUI::ModelIndex const& index) {
         auto executable = model->data(index, GUI::ModelRole::Custom).as_string();
         GUI::Process::spawn_or_show_error(window, executable);
     };

--- a/Userland/Libraries/LibGUI/InputBox.cpp
+++ b/Userland/Libraries/LibGUI/InputBox.cpp
@@ -132,13 +132,13 @@ ErrorOr<void> InputBox::build()
     main_widget->set_fill_with_background_color(true);
 
     if (!m_prompt.is_empty()) {
-        auto prompt_container = TRY(main_widget->try_add<Widget>());
-        prompt_container->set_layout<HorizontalBoxLayout>(0, 8);
+        auto& prompt_container = main_widget->add<Widget>();
+        prompt_container.set_layout<HorizontalBoxLayout>(0, 8);
         if (m_icon) {
-            auto image_widget = TRY(prompt_container->try_add<ImageWidget>());
-            image_widget->set_bitmap(m_icon);
+            auto& image_widget = prompt_container.add<ImageWidget>();
+            image_widget.set_bitmap(m_icon);
         }
-        m_prompt_label = TRY(prompt_container->try_add<Label>());
+        m_prompt_label = prompt_container.add<Label>();
         m_prompt_label->set_autosize(true);
         m_prompt_label->set_text_wrapping(Gfx::TextWrapping::DontWrap);
         m_prompt_label->set_text(m_prompt);
@@ -147,21 +147,21 @@ ErrorOr<void> InputBox::build()
     switch (m_input_type) {
     case InputType::Text:
     case InputType::NonemptyText:
-        m_text_editor = TRY(main_widget->try_add<TextBox>());
+        m_text_editor = main_widget->add<TextBox>();
         break;
     case InputType::Password:
-        m_text_editor = TRY(main_widget->try_add<PasswordBox>());
+        m_text_editor = main_widget->add<PasswordBox>();
         break;
     case InputType::Numeric:
-        m_spinbox = TRY(main_widget->try_add<SpinBox>());
+        m_spinbox = main_widget->add<SpinBox>();
         break;
     }
 
-    auto button_container = TRY(main_widget->try_add<Widget>());
-    button_container->set_layout<HorizontalBoxLayout>(0, 6);
-    button_container->add_spacer();
+    auto& button_container = main_widget->add<Widget>();
+    button_container.set_layout<HorizontalBoxLayout>(0, 6);
+    button_container.add_spacer();
 
-    m_ok_button = TRY(button_container->try_add<DialogButton>("OK"_string));
+    m_ok_button = button_container.add<DialogButton>("OK"_string);
     m_ok_button->on_click = [this](auto) {
         if (m_spinbox)
             m_spinbox->set_value_from_current_text();
@@ -169,15 +169,15 @@ ErrorOr<void> InputBox::build()
     };
     m_ok_button->set_default(true);
 
-    m_cancel_button = TRY(button_container->try_add<DialogButton>("Cancel"_string));
+    m_cancel_button = button_container.add<DialogButton>("Cancel"_string);
     m_cancel_button->on_click = [this](auto) { done(ExecResult::Cancel); };
 
-    auto guarantee_width = [this, button_container] {
+    auto guarantee_width = [this, &button_container] {
         if (m_prompt.is_empty())
             return;
-        auto width = button_container->calculated_min_size().value().width().as_int();
+        auto width = button_container.calculated_min_size().value().width().as_int();
         auto constexpr golden_ratio = 1.618;
-        button_container->set_min_width(width * golden_ratio);
+        button_container.set_min_width(width * golden_ratio);
     };
     guarantee_width();
     on_font_change = [guarantee_width] { guarantee_width(); };

--- a/Userland/Libraries/LibGUI/MessageBox.cpp
+++ b/Userland/Libraries/LibGUI/MessageBox.cpp
@@ -154,41 +154,41 @@ ErrorOr<void> MessageBox::build()
     main_widget->set_fill_with_background_color(true);
     main_widget->set_layout<VerticalBoxLayout>(8, 6);
 
-    auto message_container = TRY(main_widget->try_add<Widget>());
+    auto& message_container = main_widget->add<Widget>();
     auto message_margins = Margins { 8, m_type != Type::None ? 8 : 0 };
-    message_container->set_layout<HorizontalBoxLayout>(message_margins, 8);
+    message_container.set_layout<HorizontalBoxLayout>(message_margins, 8);
 
     if (auto icon = TRY(this->icon()); icon && m_type != Type::None) {
-        auto image_widget = TRY(message_container->try_add<ImageWidget>());
-        image_widget->set_bitmap(icon);
+        auto& image_widget = message_container.add<ImageWidget>();
+        image_widget.set_bitmap(icon);
     }
 
-    m_text_label = TRY(message_container->try_add<Label>());
+    m_text_label = message_container.add<Label>();
     m_text_label->set_text_wrapping(Gfx::TextWrapping::DontWrap);
     m_text_label->set_autosize(true);
     if (m_type != Type::None)
         m_text_label->set_text_alignment(Gfx::TextAlignment::CenterLeft);
 
-    auto button_container = TRY(main_widget->try_add<Widget>());
-    button_container->set_layout<HorizontalBoxLayout>(Margins {}, 8);
+    auto& button_container = main_widget->add<Widget>();
+    button_container.set_layout<HorizontalBoxLayout>(Margins {}, 8);
 
-    auto add_button = [&](String text, ExecResult result) -> ErrorOr<NonnullRefPtr<Button>> {
-        auto button = TRY(button_container->try_add<DialogButton>());
-        button->set_text(move(text));
-        button->on_click = [this, result](auto) { done(result); };
+    auto add_button = [&](String text, ExecResult result) -> NonnullRefPtr<Button> {
+        auto& button = button_container.add<DialogButton>();
+        button.set_text(move(text));
+        button.on_click = [this, result](auto) { done(result); };
         return button;
     };
 
-    button_container->add_spacer();
+    button_container.add_spacer();
     if (should_include_ok_button())
-        m_ok_button = TRY(add_button("OK"_string, ExecResult::OK));
+        m_ok_button = add_button("OK"_string, ExecResult::OK);
     if (should_include_yes_button())
-        m_yes_button = TRY(add_button("Yes"_string, ExecResult::Yes));
+        m_yes_button = add_button("Yes"_string, ExecResult::Yes);
     if (should_include_no_button())
-        m_no_button = TRY(add_button("No"_string, ExecResult::No));
+        m_no_button = add_button("No"_string, ExecResult::No);
     if (should_include_cancel_button())
-        m_cancel_button = TRY(add_button("Cancel"_string, ExecResult::Cancel));
-    button_container->add_spacer();
+        m_cancel_button = add_button("Cancel"_string, ExecResult::Cancel);
+    button_container.add_spacer();
 
     return {};
 }

--- a/Userland/Libraries/LibGUI/SettingsWindow.cpp
+++ b/Userland/Libraries/LibGUI/SettingsWindow.cpp
@@ -36,34 +36,34 @@ ErrorOr<NonnullRefPtr<SettingsWindow>> SettingsWindow::create(DeprecatedString t
     main_widget->set_fill_with_background_color(true);
     main_widget->set_layout<GUI::VerticalBoxLayout>(4, 6);
 
-    window->m_tab_widget = TRY(main_widget->try_add<GUI::TabWidget>());
+    window->m_tab_widget = main_widget->add<GUI::TabWidget>();
 
-    auto button_container = TRY(main_widget->try_add<GUI::Widget>());
-    button_container->set_preferred_size({ SpecialDimension::Grow, SpecialDimension::Fit });
-    button_container->set_layout<GUI::HorizontalBoxLayout>(GUI::Margins {}, 6);
+    auto& button_container = main_widget->add<GUI::Widget>();
+    button_container.set_preferred_size({ SpecialDimension::Grow, SpecialDimension::Fit });
+    button_container.set_layout<GUI::HorizontalBoxLayout>(GUI::Margins {}, 6);
 
     if (show_defaults_button == ShowDefaultsButton::Yes) {
-        window->m_reset_button = TRY(button_container->try_add<GUI::DialogButton>("Defaults"_string));
+        window->m_reset_button = button_container.add<GUI::DialogButton>("Defaults"_string);
         window->m_reset_button->on_click = [window = window->make_weak_ptr<SettingsWindow>()](auto) {
             window->reset_default_values();
         };
     }
 
-    button_container->add_spacer();
+    button_container.add_spacer();
 
-    window->m_ok_button = TRY(button_container->try_add<GUI::DialogButton>("OK"_string));
+    window->m_ok_button = button_container.add<GUI::DialogButton>("OK"_string);
     window->m_ok_button->on_click = [window = window->make_weak_ptr<SettingsWindow>()](auto) {
         window->apply_settings();
         GUI::Application::the()->quit();
     };
 
-    window->m_cancel_button = TRY(button_container->try_add<GUI::DialogButton>("Cancel"_string));
+    window->m_cancel_button = button_container.add<GUI::DialogButton>("Cancel"_string);
     window->m_cancel_button->on_click = [window = window->make_weak_ptr<SettingsWindow>()](auto) {
         window->cancel_settings();
         GUI::Application::the()->quit();
     };
 
-    window->m_apply_button = TRY(button_container->try_add<GUI::DialogButton>("Apply"_string));
+    window->m_apply_button = button_container.add<GUI::DialogButton>("Apply"_string);
     window->m_apply_button->set_enabled(false);
     window->m_apply_button->on_click = [window = window->make_weak_ptr<SettingsWindow>()](auto) {
         window->apply_settings();

--- a/Userland/Libraries/LibGUI/Wizards/CoverWizardPage.cpp
+++ b/Userland/Libraries/LibGUI/Wizards/CoverWizardPage.cpp
@@ -25,19 +25,19 @@ ErrorOr<void> CoverWizardPage::build(String title, String subtitle)
     set_fill_with_background_color(true);
     set_background_role(Gfx::ColorRole::Base);
     set_layout<HorizontalBoxLayout>();
-    m_banner_image_widget = TRY(try_add<ImageWidget>());
+    m_banner_image_widget = add<ImageWidget>();
     m_banner_image_widget->set_fixed_size(160, 315);
     m_banner_image_widget->load_from_file("/res/graphics/wizard-banner-simple.png"sv);
 
-    m_content_widget = TRY(try_add<Widget>());
+    m_content_widget = add<Widget>();
     m_content_widget->set_layout<VerticalBoxLayout>(20);
 
-    m_header_label = TRY(m_content_widget->try_add<Label>(move(title)));
+    m_header_label = m_content_widget->add<Label>(move(title));
     m_header_label->set_font(Gfx::FontDatabase::the().get("Pebbleton"_fly_string, 14, 700, Gfx::FontWidth::Normal, 0));
     m_header_label->set_text_alignment(Gfx::TextAlignment::TopLeft);
     m_header_label->set_fixed_height(48);
 
-    m_body_label = TRY(m_content_widget->try_add<Label>(move(subtitle)));
+    m_body_label = m_content_widget->add<Label>(move(subtitle));
     m_body_label->set_text_alignment(Gfx::TextAlignment::TopLeft);
 
     return {};

--- a/Userland/Libraries/LibGUI/Wizards/WizardDialog.cpp
+++ b/Userland/Libraries/LibGUI/Wizards/WizardDialog.cpp
@@ -29,24 +29,24 @@ ErrorOr<void> WizardDialog::build()
     main_widget->set_fill_with_background_color(true);
     main_widget->set_layout<VerticalBoxLayout>(Margins {}, 0);
 
-    m_page_container_widget = TRY(main_widget->try_add<Widget>());
+    m_page_container_widget = main_widget->add<Widget>();
     m_page_container_widget->set_fixed_size(500, 315);
     m_page_container_widget->set_layout<VerticalBoxLayout>();
 
-    auto separator = TRY(main_widget->try_add<SeparatorWidget>(Gfx::Orientation::Horizontal));
-    separator->set_fixed_height(2);
+    auto& separator = main_widget->add<SeparatorWidget>(Gfx::Orientation::Horizontal);
+    separator.set_fixed_height(2);
 
-    auto nav_container_widget = TRY(main_widget->try_add<Widget>());
-    nav_container_widget->set_layout<HorizontalBoxLayout>(Margins { 0, 10 }, 0);
-    nav_container_widget->set_fixed_height(42);
-    nav_container_widget->add_spacer();
+    auto& nav_container_widget = main_widget->add<Widget>();
+    nav_container_widget.set_layout<HorizontalBoxLayout>(Margins { 0, 10 }, 0);
+    nav_container_widget.set_fixed_height(42);
+    nav_container_widget.add_spacer();
 
-    m_back_button = TRY(nav_container_widget->try_add<DialogButton>("< Back"_string));
+    m_back_button = nav_container_widget.add<DialogButton>("< Back"_string);
     m_back_button->on_click = [&](auto) {
         pop_page();
     };
 
-    m_next_button = TRY(nav_container_widget->try_add<DialogButton>("Next >"_string));
+    m_next_button = nav_container_widget.add<DialogButton>("Next >"_string);
     m_next_button->on_click = [&](auto) {
         VERIFY(has_pages());
 
@@ -60,10 +60,10 @@ ErrorOr<void> WizardDialog::build()
         push_page(*next_page);
     };
 
-    auto button_spacer = TRY(nav_container_widget->try_add<Widget>());
-    button_spacer->set_fixed_width(10);
+    auto& button_spacer = nav_container_widget.add<Widget>();
+    button_spacer.set_fixed_width(10);
 
-    m_cancel_button = TRY(nav_container_widget->try_add<DialogButton>("Cancel"_string));
+    m_cancel_button = nav_container_widget.add<DialogButton>("Cancel"_string);
     m_cancel_button->on_click = [&](auto) {
         handle_cancel();
     };

--- a/Userland/Libraries/LibGUI/Wizards/WizardPage.cpp
+++ b/Userland/Libraries/LibGUI/Wizards/WizardPage.cpp
@@ -25,26 +25,26 @@ ErrorOr<void> WizardPage::build(String title, String subtitle)
 {
     set_layout<VerticalBoxLayout>(Margins {}, 0);
 
-    auto header_widget = TRY(try_add<Widget>());
-    header_widget->set_fill_with_background_color(true);
-    header_widget->set_background_role(Gfx::ColorRole::Base);
-    header_widget->set_fixed_height(58);
+    auto& header_widget = add<Widget>();
+    header_widget.set_fill_with_background_color(true);
+    header_widget.set_background_role(Gfx::ColorRole::Base);
+    header_widget.set_fixed_height(58);
 
-    header_widget->set_layout<VerticalBoxLayout>(Margins { 15, 30, 0 });
-    m_title_label = TRY(header_widget->try_add<Label>(move(title)));
+    header_widget.set_layout<VerticalBoxLayout>(Margins { 15, 30, 0 });
+    m_title_label = header_widget.add<Label>(move(title));
     m_title_label->set_font(Gfx::FontDatabase::default_font().bold_variant());
     m_title_label->set_fixed_height(m_title_label->font().pixel_size_rounded_up() + 2);
     m_title_label->set_text_alignment(Gfx::TextAlignment::TopLeft);
 
-    m_subtitle_label = TRY(header_widget->try_add<Label>(move(subtitle)));
+    m_subtitle_label = header_widget.add<Label>(move(subtitle));
     m_subtitle_label->set_text_alignment(Gfx::TextAlignment::TopLeft);
     m_subtitle_label->set_fixed_height(m_subtitle_label->font().pixel_size_rounded_up());
-    header_widget->add_spacer();
+    header_widget.add_spacer();
 
-    auto separator = TRY(try_add<SeparatorWidget>(Gfx::Orientation::Horizontal));
-    separator->set_fixed_height(2);
+    auto& separator = add<SeparatorWidget>(Gfx::Orientation::Horizontal);
+    separator.set_fixed_height(2);
 
-    m_body_widget = TRY(try_add<Widget>());
+    m_body_widget = add<Widget>();
     m_body_widget->set_layout<VerticalBoxLayout>(20);
 
     return {};

--- a/Userland/Services/Taskbar/TaskbarWindow.cpp
+++ b/Userland/Services/Taskbar/TaskbarWindow.cpp
@@ -78,17 +78,17 @@ ErrorOr<void> TaskbarWindow::populate_taskbar()
     m_quick_launch = TRY(Taskbar::QuickLaunchWidget::create());
     TRY(main_widget->try_add_child(*m_quick_launch));
 
-    m_task_button_container = TRY(main_widget->try_add<GUI::Widget>());
+    m_task_button_container = main_widget->add<GUI::Widget>();
     m_task_button_container->set_layout<GUI::HorizontalBoxLayout>(GUI::Margins {}, 3);
 
     m_default_icon = TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/window.png"sv));
 
-    m_applet_area_container = TRY(main_widget->try_add<GUI::Frame>());
+    m_applet_area_container = main_widget->add<GUI::Frame>();
     m_applet_area_container->set_frame_style(Gfx::FrameStyle::SunkenPanel);
 
-    m_clock_widget = TRY(main_widget->try_add<Taskbar::ClockWidget>());
+    m_clock_widget = main_widget->add<Taskbar::ClockWidget>();
 
-    m_show_desktop_button = TRY(main_widget->try_add<GUI::Button>());
+    m_show_desktop_button = main_widget->add<GUI::Button>();
     m_show_desktop_button->set_tooltip_deprecated("Show Desktop");
     m_show_desktop_button->set_icon(TRY(GUI::Icon::try_create_default_icon("desktop"sv)).bitmap_for_size(16));
     m_show_desktop_button->set_button_style(Gfx::ButtonStyle::Coolbar);


### PR DESCRIPTION
This PR replaces the majority of `EventReceiver::try_add()` calls with `EventReceiver::add()`. The only places where this wasn't possible was for objects which are constructed with `try_create()`.

I also made the construction of tool properties in PixelPaint non-fallible, as only minor changes were needed to achieve this after `try_add` was replaced.

Contributes to #20557