### PR TITLE
LibJS: Defer GC during cell construction

### DIFF
--- a/Userland/Libraries/LibJS/Heap/DeferGC.h
+++ b/Userland/Libraries/LibJS/Heap/DeferGC.h
@@ -15,12 +15,12 @@ public:
     explicit DeferGC(Heap& heap)
         : m_heap(heap)
     {
-        m_heap.defer_gc({});
+        m_heap.defer_gc();
     }
 
     ~DeferGC()
     {
-        m_heap.undefer_gc({});
+        m_heap.undefer_gc();
     }
 
 private:

--- a/Userland/Libraries/LibJS/Heap/Heap.cpp
+++ b/Userland/Libraries/LibJS/Heap/Heap.cpp
@@ -576,12 +576,12 @@ void Heap::did_destroy_weak_container(Badge<WeakContainer>, WeakContainer& set)
     m_weak_containers.remove(set);
 }
 
-void Heap::defer_gc(Badge<DeferGC>)
+void Heap::defer_gc()
 {
     ++m_gc_deferrals;
 }
 
-void Heap::undefer_gc(Badge<DeferGC>)
+void Heap::undefer_gc()
 {
     VERIFY(m_gc_deferrals > 0);
     --m_gc_deferrals;

--- a/Userland/Libraries/LibJS/Heap/Heap.h
+++ b/Userland/Libraries/LibJS/Heap/Heap.h
@@ -39,7 +39,9 @@ public:
     NonnullGCPtr<T> allocate_without_realm(Args&&... args)
     {
         auto* memory = allocate_cell(sizeof(T));
+        defer_gc();
         new (memory) T(forward<Args>(args)...);
+        undefer_gc();
         return *static_cast<T*>(memory);
     }
 
@@ -47,7 +49,9 @@ public:
     NonnullGCPtr<T> allocate(Realm& realm, Args&&... args)
     {
         auto* memory = allocate_cell(sizeof(T));
+        defer_gc();
         new (memory) T(forward<Args>(args)...);
+        undefer_gc();
         auto* cell = static_cast<T*>(memory);
         memory->initialize(realm);
         return *cell;

--- a/Userland/Libraries/LibJS/Heap/Heap.h
+++ b/Userland/Libraries/LibJS/Heap/Heap.h
@@ -73,9 +73,6 @@ public:
     void did_create_weak_container(Badge<WeakContainer>, WeakContainer&);
     void did_destroy_weak_container(Badge<WeakContainer>, WeakContainer&);
 
-    void defer_gc(Badge<DeferGC>);
-    void undefer_gc(Badge<DeferGC>);
-
     BlockAllocator& block_allocator() { return m_block_allocator; }
 
     void uproot_cell(Cell* cell);
@@ -83,6 +80,10 @@ public:
 private:
     friend class MarkingVisitor;
     friend class GraphConstructorVisitor;
+    friend class DeferGC;
+
+    void defer_gc();
+    void undefer_gc();
 
     static bool cell_must_survive_garbage_collection(Cell const&);
 


### PR DESCRIPTION
This should stop some GC bugs/crashes form happening