### PR TITLE
LibC+LibELF: Call destructors on `exit` and clean up crt0

### DIFF
--- a/Userland/Libraries/LibC/crt0.cpp
+++ b/Userland/Libraries/LibC/crt0.cpp
@@ -14,13 +14,10 @@
 #ifndef _DYNAMIC_LOADER
 extern "C" {
 
-extern uintptr_t __stack_chk_guard;
-extern bool s_global_initializers_ran;
-
 int main(int, char**, char**);
 
 // Tell the compiler that this may be called from somewhere else.
-int _entry(int argc, char** argv, char** env) __attribute__((used));
+int _entry(int argc, char** argv) __attribute__((used));
 void _start(int, char**, char**) __attribute__((used));
 
 NAKED void _start(int, char**, char**)
@@ -37,15 +34,9 @@ NAKED void _start(int, char**, char**)
 #    endif
 }
 
-int _entry(int argc, char** argv, char** env)
+int _entry(int argc, char** argv)
 {
-    environ = env;
-    __environ_is_malloced = false;
     __begin_atexit_locking();
-
-    s_global_initializers_ran = true;
-
-    _init();
 
     int status = main(argc, argv, environ);
 

--- a/Userland/Libraries/LibC/libcinit.cpp
+++ b/Userland/Libraries/LibC/libcinit.cpp
@@ -20,7 +20,6 @@ __thread int errno_storage;
 char** environ;
 bool __environ_is_malloced;
 bool __stdio_is_initialized;
-bool s_global_initializers_ran;
 void* __auxiliary_vector;
 
 static void __auxiliary_vector_init();

--- a/Userland/Libraries/LibC/stdlib.cpp
+++ b/Userland/Libraries/LibC/stdlib.cpp
@@ -345,6 +345,8 @@ static T c_str_to_floating_point(char const* str, char** endptr)
 
 extern "C" {
 
+void (*__call_fini_functions)();
+
 void exit(int status)
 {
     __cxa_finalize(nullptr);
@@ -352,8 +354,7 @@ void exit(int status)
     if (secure_getenv("LIBC_DUMP_MALLOC_STATS"))
         serenity_dump_malloc_stats();
 
-    extern void _fini();
-    _fini();
+    __call_fini_functions();
     fflush(nullptr);
 
 #ifndef _DYNAMIC_LOADER

--- a/Userland/Libraries/LibELF/DynamicLoader.cpp
+++ b/Userland/Libraries/LibELF/DynamicLoader.cpp
@@ -803,7 +803,7 @@ void DynamicLoader::call_object_init_functions()
     typedef void (*InitFunc)();
 
     if (m_dynamic_object->has_init_section()) {
-        auto init_function = (InitFunc)(m_dynamic_object->init_section().address().as_ptr());
+        auto init_function = m_dynamic_object->init_section_function();
         (init_function)();
     }
 

--- a/Userland/Libraries/LibELF/DynamicObject.cpp
+++ b/Userland/Libraries/LibELF/DynamicObject.cpp
@@ -364,6 +364,12 @@ DynamicObject::InitializationFunction DynamicObject::init_section_function() con
     return (InitializationFunction)init_section().address().as_ptr();
 }
 
+DynamicObject::FinalizationFunction DynamicObject::fini_section_function() const
+{
+    VERIFY(has_fini_section());
+    return (FinalizationFunction)fini_section().address().as_ptr();
+}
+
 char const* DynamicObject::name_for_dtag(ElfW(Sword) d_tag)
 {
     switch (d_tag) {

--- a/Userland/Libraries/LibELF/DynamicObject.h
+++ b/Userland/Libraries/LibELF/DynamicObject.h
@@ -245,14 +245,19 @@ public:
     Symbol symbol(unsigned) const;
 
     typedef void (*InitializationFunction)();
+    typedef void (*FinalizationFunction)();
     typedef ElfW(Addr) (*IfuncResolver)();
 
     bool has_init_section() const { return m_init_offset != 0; }
     bool has_init_array_section() const { return m_init_array_offset != 0; }
     Section init_section() const;
     InitializationFunction init_section_function() const;
-    Section fini_section() const;
     Section init_array_section() const;
+
+    bool has_fini_section() const { return m_fini_offset != 0; }
+    bool has_fini_array_section() const { return m_fini_array_offset != 0; }
+    Section fini_section() const;
+    FinalizationFunction fini_section_function() const;
     Section fini_array_section() const;
 
     HashSection hash_section() const


### PR DESCRIPTION
This PR makes `exit()` correctly call all destructors according to https://www.sco.com/developers/gabi/latest/ch5.dynamic.html#init_fini.

The `_init()` and `_fini()` in crt0.cpp and stdlib.cpp's `exit()` are unnecessary as we call them in the dynamic linker and we don't care about statically linked executables anymore.