### PR TITLE
LibWeb: Include standard SVG user agent style sheet

### DIFF
--- a/Meta/CMake/libweb_generators.cmake
+++ b/Meta/CMake/libweb_generators.cmake
@@ -96,6 +96,14 @@ function (generate_css_implementation)
         NAMESPACE "Web::CSS"
     )
 
+    embed_as_string_view(
+        "SVGStyleSheetSource.cpp"
+        "${LIBWEB_INPUT_FOLDER}/SVG/Default.css"
+        "SVG/SVGStyleSheetSource.cpp"
+        "svg_stylesheet_source"
+        NAMESPACE "Web::CSS"
+    )
+
     set(CSS_GENERATED_TO_INSTALL
         "CSS/EasingFunctions.h"
         "CSS/Enums.h"

--- a/Meta/gn/secondary/Userland/Libraries/LibWeb/BUILD.gn
+++ b/Meta/gn/secondary/Userland/Libraries/LibWeb/BUILD.gn
@@ -230,6 +230,13 @@ embed_as_string_view("generate_mathml_stylesheet_source") {
   namespace = "Web::CSS"
 }
 
+embed_as_string_view("generate_svg_stylesheet_source") {
+  input = "SVG/Default.css"
+  output = "$target_gen_dir/SVG/SVGStyleSheetSource.cpp"
+  variable_name = "svg_stylesheet_source"
+  namespace = "Web::CSS"
+}
+
 embed_as_string_view("generate_quirks_mode_stylesheet_source") {
   input = "CSS/QuirksMode.css"
   output = "$target_gen_dir/CSS/QuirksModeStyleSheetSource.cpp"

--- a/Tests/LibWeb/Layout/expected/svg/svg-symbol-with-viewbox.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-symbol-with-viewbox.txt
@@ -11,7 +11,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         SVGSVGBox <svg> at (8,8) content-size 300x150 [SVG] children: inline
           TextNode <#text>
           Box <use> at (8,8) content-size 0x0 children: inline
-            Box <symbol#braces> at (8,8) content-size 0x0 children: inline
+            Box <symbol#braces> at (8,8) content-size 0x0 [BFC] children: inline
               TextNode <#text>
               SVGGeometryBox <path> at (92.375,26.75) content-size 131.25x112.15625 children: inline
                 TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/svg/svg-with-zero-intrinsic-size-and-no-viewbox.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-with-zero-intrinsic-size-and-no-viewbox.txt
@@ -8,7 +8,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         frag 2 from SVGSVGBox start: 0, length: 0, rect: [16,21 0x0]
       ImageBox <img> at (8,21) content-size 0x0 children: not-inline
         (SVG-as-image isolated context)
-        Viewport <#document> at (0,0) content-size 0x0 children: inline
+        Viewport <#document> at (0,0) content-size 0x0 [BFC] children: inline
           SVGSVGBox <svg> at (0,0) content-size 0x0 [SVG] children: inline
             TextNode <#text>
             SVGGeometryBox <rect> at (0,0) content-size 1x1 children: not-inline

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -655,6 +655,7 @@ set(GENERATED_SOURCES
     CSS/TransformFunctions.cpp
     CSS/ValueID.cpp
     MathML/MathMLStyleSheetSource.cpp
+    SVG/SVGStyleSheetSource.cpp
 )
 
 serenity_lib(LibWeb web)

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -239,6 +239,16 @@ static CSSStyleSheet& mathml_stylesheet(DOM::Document const& document)
     return *sheet;
 }
 
+static CSSStyleSheet& svg_stylesheet(DOM::Document const& document)
+{
+    static JS::Handle<CSSStyleSheet> sheet;
+    if (!sheet.cell()) {
+        extern StringView svg_stylesheet_source;
+        sheet = JS::make_handle(parse_css_stylesheet(CSS::Parser::ParsingContext(document), svg_stylesheet_source));
+    }
+    return *sheet;
+}
+
 template<typename Callback>
 void StyleComputer::for_each_stylesheet(CascadeOrigin cascade_origin, Callback callback) const
 {
@@ -247,6 +257,7 @@ void StyleComputer::for_each_stylesheet(CascadeOrigin cascade_origin, Callback c
         if (document().in_quirks_mode())
             callback(quirks_mode_stylesheet(document()));
         callback(mathml_stylesheet(document()));
+        callback(svg_stylesheet(document()));
     }
     if (cascade_origin == CascadeOrigin::User) {
         if (m_user_style_sheet)

--- a/Userland/Libraries/LibWeb/SVG/Default.css
+++ b/Userland/Libraries/LibWeb/SVG/Default.css
@@ -1,0 +1,39 @@
+/* https://svgwg.org/svg2-draft/styling.html#UAStyleSheet */
+
+@namespace url(http://www.w3.org/2000/svg);
+@namespace xml url(http://www.w3.org/XML/1998/namespace);
+
+svg:not(:root), image, marker, pattern, symbol { overflow: hidden; }
+
+*:not(svg),
+*:not(foreignObject) > svg {
+    transform-origin: 0 0;
+}
+
+*[xml|space=preserve] {
+    text-space-collapse: preserve-spaces;
+}
+
+/* FIXME: Allow setting the rest of these to `display: none`.
+          Currently that breaks <use> and <mask> and probably others. */
+desc, title, metadata,
+pattern, linearGradient, radialGradient,
+script, style {
+    display: none !important;
+}
+/*
+defs,
+clipPath, mask, marker,
+desc, title, metadata,
+pattern, linearGradient, radialGradient,
+script, style,
+symbol {
+    display: none !important;
+}
+*/
+:host(use) > symbol {
+    display: inline !important;
+}
+:link, :visited {
+    cursor: pointer;
+}

--- a/Userland/Libraries/LibWeb/SVG/SVGSymbolElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGSymbolElement.cpp
@@ -33,18 +33,9 @@ void SVGSymbolElement::apply_presentational_hints(CSS::StyleProperties& style) c
 {
     Base::apply_presentational_hints(style);
 
-    // The user agent style sheet sets the overflow property for ‘symbol’ elements to hidden.
-    auto hidden = CSS::IdentifierStyleValue::create(CSS::ValueID::Hidden);
-    style.set_property(CSS::PropertyID::Overflow, CSS::OverflowStyleValue::create(hidden, hidden));
-
     if (is_direct_child_of_use_shadow_tree()) {
         // The generated instance of a ‘symbol’ that is the direct referenced element of a ‘use’ element must always have a computed value of inline for the display property.
         style.set_property(CSS::PropertyID::Display, CSS::DisplayStyleValue::create(CSS::Display::from_short(CSS::Display::Short::Inline)));
-    } else {
-        // FIXME: When we have a DefaultSVG.css then use https://svgwg.org/svg2-draft/styling.html#UAStyleSheet instead.
-        // The user agent must set the display property on the ‘symbol’ element to none, as part of the user agent style sheet,
-        // and this declaration must have importance over any other CSS rule or presentation attribute.
-        style.set_property(CSS::PropertyID::Display, CSS::DisplayStyleValue::create(CSS::Display::from_short(CSS::Display::Short::None)));
     }
 }
 


### PR DESCRIPTION
For now, part of this is commented-out. Our current implementations of
`<mask>` and `<symbol>` rely on creating layout nodes, so they can't be
`display: none`.