### PR TITLE
ls: Add the `-S` option to sort files by size

### DIFF
--- a/Base/usr/share/man/man1/ls.md
+++ b/Base/usr/share/man/man1/ls.md
@@ -23,7 +23,8 @@ If no *path* argument is provided the current working directory is used.
 * `-F`, `--classify`: Append a file type indicator to entries
 * `-d`, `--directory`: List directories themselves, not their contents
 * `-l`, `--long`: Display long info
-* `-t`: Sort files by timestamp
+* `-t`: Sort files by timestamp (newest first)
+* `-S`: Sort files by size (largest first)
 * `-r`, `--reverse`: Reverse sort order
 * `-G`: Use pretty colors
 * `-i`, `--inode`: Show inode ids


### PR DESCRIPTION
This option will override the `-t` option and vice-versa.

Example usage:

![ls_sort_by_size](https://github.com/SerenityOS/serenity/assets/2817754/15114ea5-add7-4327-aa7b-e0e8f1cedeec)
