### PR TITLE
LibWeb: Update session history when History entry is pushed/replaced 

### DIFF
--- a/Tests/LibWeb/Text/expected/navigation/history-pushstate.txt
+++ b/Tests/LibWeb/Text/expected/navigation/history-pushstate.txt
@@ -1,0 +1,1 @@
+  history object length has changed by 1

--- a/Tests/LibWeb/Text/input/navigation/history-pushstate-iframe.html
+++ b/Tests/LibWeb/Text/input/navigation/history-pushstate-iframe.html
@@ -1,0 +1,20 @@
+<script src="../include.js"></script>
+<script>
+    try {
+        const initialHistoryLength = window.history.length;
+
+        history.pushState({}, "hello", "history-pushstate-iframe.html#hello");
+
+        if (window.self !== window.top) {
+            parent.postMessage(
+                "history object length has changed by " +
+                    (window.history.length - initialHistoryLength),
+                "*"
+            );
+        } else {
+            test(() => {});
+        }
+    } catch (e) {
+        if (window.self !== window.top) parent.postMessage("ERROR:" + e, "*");
+    }
+</script>

--- a/Tests/LibWeb/Text/input/navigation/history-pushstate.html
+++ b/Tests/LibWeb/Text/input/navigation/history-pushstate.html
@@ -1,0 +1,23 @@
+<script src="../include.js"></script>
+<iframe id="testIframe" src="about:blank"></iframe>
+<script>
+    asyncTest(async done => {
+        const iframe = document.getElementById("testIframe");
+
+        function navigateIframe(src) {
+            return new Promise(resolve => {
+                iframe.addEventListener("load", () => {
+                    resolve();
+                });
+                iframe.src = src;
+            });
+        }
+
+        window.addEventListener("message", event => {
+            println(event.data);
+            done();
+        });
+
+        await navigateIframe("./history-pushstate-iframe.html");
+    }); 
+</script>

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -3489,4 +3489,37 @@ Painting::ViewportPaintable* Document::paintable()
     return static_cast<Painting::ViewportPaintable*>(Node::paintable());
 }
 
+// https://html.spec.whatwg.org/multipage/browsing-the-web.html#update-document-for-history-step-application
+void Document::update_for_history_step_application(JS::NonnullGCPtr<HTML::SessionHistoryEntry> entry, bool do_not_reactive, size_t script_history_length, size_t script_history_index)
+{
+    // 1. Let documentIsNew be true if document's latest entry is null; otherwise false.
+    auto document_is_new = !m_latest_entry;
+
+    // 2. Let documentsEntryChanged be true if document's latest entry is not entry; otherwise false.
+    auto documents_entry_changed = m_latest_entry != entry;
+
+    // 3. Set document's history object's index to scriptHistoryIndex.
+    history()->m_index = script_history_index;
+
+    // 4. Set document's history object's length to scriptHistoryLength.
+    history()->m_length = script_history_length;
+
+    // 5. If documentsEntryChanged is true, then:
+    if (documents_entry_changed) {
+        // FIXME: Implement this.
+    }
+
+    // 6. If documentIsNew is true, then:
+    if (document_is_new) {
+        // FIXME: 1. Try to scroll to the fragment for document.
+        // FIXME: 2. At this point scripts may run for the newly-created document document.
+    }
+
+    // 7. Otherwise, if documentsEntryChanged is false and doNotReactivate is false, then:
+    if (!documents_entry_changed && !do_not_reactive) {
+        // FIXME: 1. Assert: entriesForNavigationAPI is given.
+        // FIXME: 2. Reactivate document given entry and entriesForNavigationAPI.
+    }
+}
+
 }

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -531,6 +531,8 @@ public:
 
     HTML::SourceSnapshotParams snapshot_source_snapshot_params() const;
 
+    void update_for_history_step_application(JS::NonnullGCPtr<HTML::SessionHistoryEntry>, bool do_not_reactive, size_t script_history_length, size_t script_history_index);
+
 protected:
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
@@ -730,6 +732,9 @@ private:
     RefPtr<Core::Timer> m_active_refresh_timer;
 
     bool m_temporary_document_for_fragment_parsing { false };
+
+    // https://html.spec.whatwg.org/multipage/browsing-the-web.html#latest-entry
+    JS::GCPtr<HTML::SessionHistoryEntry> m_latest_entry;
 };
 
 template<>

--- a/Userland/Libraries/LibWeb/HTML/History.cpp
+++ b/Userland/Libraries/LibWeb/HTML/History.cpp
@@ -9,6 +9,7 @@
 #include <LibWeb/HTML/History.h>
 #include <LibWeb/HTML/StructuredSerialize.h>
 #include <LibWeb/HTML/TraversableNavigable.h>
+#include <LibWeb/Page/Page.h>
 
 namespace Web::HTML {
 
@@ -188,6 +189,12 @@ WebIDL::ExceptionOr<void> History::shared_history_push_replace_state(JS::Value v
     ///          with navigationType set to historyHandling, isSameDocument set to true, destinationURL set to newURL,
     //           and classicHistoryAPIState set to serializedData.
     // FIXME: 9. If continue is false, then return.
+
+    auto navigable = document->navigable();
+    if (navigable->is_top_level_traversable()) {
+        if (auto* page = navigable->active_browsing_context()->page())
+            page->client().page_did_start_loading(new_url, false);
+    }
 
     // 10. Run the URL and history update steps given document and newURL, with serializedData set to
     //     serializedData and historyHandling set to historyHandling.

--- a/Userland/Libraries/LibWeb/HTML/History.cpp
+++ b/Userland/Libraries/LibWeb/HTML/History.cpp
@@ -38,17 +38,17 @@ void History::visit_edges(Cell::Visitor& visitor)
 }
 
 // https://html.spec.whatwg.org/multipage/history.html#dom-history-pushstate
+// The pushState(data, unused, url) method steps are to run the shared history push/replace state steps given this, data, url, and "push".
 WebIDL::ExceptionOr<void> History::push_state(JS::Value data, String const&, Optional<String> const& url)
 {
-    // NOTE: The second parameter of this function is intentionally unused.
-    return shared_history_push_replace_state(data, url, IsPush::Yes);
+    return shared_history_push_replace_state(data, url, HistoryHandlingBehavior::Push);
 }
 
 // https://html.spec.whatwg.org/multipage/history.html#dom-history-replacestate
+// The replaceState(data, unused, url) method steps are to run the shared history push/replace state steps given this, data, url, and "replace".
 WebIDL::ExceptionOr<void> History::replace_state(JS::Value data, String const&, Optional<String> const& url)
 {
-    // NOTE: The second parameter of this function is intentionally unused.
-    return shared_history_push_replace_state(data, url, IsPush::No);
+    return shared_history_push_replace_state(data, url, HistoryHandlingBehavior::Replace);
 }
 
 // https://html.spec.whatwg.org/multipage/history.html#dom-history-length
@@ -145,7 +145,7 @@ bool can_have_its_url_rewritten(DOM::Document const& document, AK::URL const& ta
 }
 
 // https://html.spec.whatwg.org/multipage/history.html#shared-history-push/replace-state-steps
-WebIDL::ExceptionOr<void> History::shared_history_push_replace_state(JS::Value value, Optional<String> const& url, IsPush)
+WebIDL::ExceptionOr<void> History::shared_history_push_replace_state(JS::Value value, Optional<String> const& url, HistoryHandlingBehavior history_handling)
 {
     // 1. Let document be history's associated Document.
     auto& document = m_associated_document;
@@ -188,10 +188,11 @@ WebIDL::ExceptionOr<void> History::shared_history_push_replace_state(JS::Value v
     ///          with navigationType set to historyHandling, isSameDocument set to true, destinationURL set to newURL,
     //           and classicHistoryAPIState set to serializedData.
     // FIXME: 9. If continue is false, then return.
-    // FIXME: 10. Run the URL and history update steps given document and newURL, with serializedData set to
-    //            serializedData and historyHandling set to historyHandling.
 
-    dbgln("FIXME: Implement shared_history_push_replace_state.");
+    // 10. Run the URL and history update steps given document and newURL, with serializedData set to
+    //     serializedData and historyHandling set to historyHandling.
+    perform_url_and_history_update_steps(document, new_url, history_handling);
+
     return {};
 }
 

--- a/Userland/Libraries/LibWeb/HTML/History.cpp
+++ b/Userland/Libraries/LibWeb/HTML/History.cpp
@@ -54,16 +54,12 @@ WebIDL::ExceptionOr<void> History::replace_state(JS::Value data, String const&, 
 // https://html.spec.whatwg.org/multipage/history.html#dom-history-length
 WebIDL::ExceptionOr<u64> History::length() const
 {
-    // 1. If this's associated Document is not fully active, then throw a "SecurityError" DOMException.
+    // 1. If this's relevant global object's associated Document is not fully active, then throw a "SecurityError" DOMException.
     if (!m_associated_document->is_fully_active())
         return WebIDL::SecurityError::create(realm(), "Cannot perform length on a document that isn't fully active."_fly_string);
 
-    // 2. Return the number of entries in the top-level browsing context's joint session history.
-    auto const* browsing_context = m_associated_document->browsing_context();
-
-    // FIXME: We don't have the concept of "joint session history", this is an ad-hoc implementation.
-    //        See: https://html.spec.whatwg.org/multipage/history.html#joint-session-history
-    return browsing_context->session_history().size();
+    // 2. Return this's length.
+    return m_length;
 }
 
 // https://html.spec.whatwg.org/multipage/history.html#dom-history-go

--- a/Userland/Libraries/LibWeb/HTML/History.h
+++ b/Userland/Libraries/LibWeb/HTML/History.h
@@ -27,6 +27,9 @@ public:
     WebIDL::ExceptionOr<void> forward();
     WebIDL::ExceptionOr<u64> length() const;
 
+    u64 m_index { 0 };
+    u64 m_length { 0 };
+
 private:
     History(JS::Realm&, DOM::Document&);
 

--- a/Userland/Libraries/LibWeb/HTML/History.h
+++ b/Userland/Libraries/LibWeb/HTML/History.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <LibWeb/Bindings/PlatformObject.h>
+#include <LibWeb/HTML/HistoryHandlingBehavior.h>
 #include <LibWeb/WebIDL/ExceptionOr.h>
 
 namespace Web::HTML {
@@ -36,11 +37,7 @@ private:
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
 
-    enum class IsPush {
-        No,
-        Yes,
-    };
-    WebIDL::ExceptionOr<void> shared_history_push_replace_state(JS::Value data, Optional<String> const& url, IsPush is_push);
+    WebIDL::ExceptionOr<void> shared_history_push_replace_state(JS::Value data, Optional<String> const& url, HistoryHandlingBehavior);
 
     JS::NonnullGCPtr<DOM::Document> m_associated_document;
 };

--- a/Userland/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Navigable.cpp
@@ -1744,9 +1744,11 @@ void perform_url_and_history_update_steps(DOM::Document& document, AK::URL new_u
 
     // 6. If historyHandling is "push", then:
     if (history_handling == HistoryHandlingBehavior::Push) {
-        // FIXME: 1. Increment document's history object's index.
-        // FIXME: 2. Set document's history object's length to its index + 1.
-        TODO();
+        // 1. Increment document's history object's index.
+        document.history()->m_index++;
+
+        // 2. Set document's history object's length to its index + 1.
+        document.history()->m_length = document.history()->m_index + 1;
     }
 
     // FIXME: 7. If serializedData is not null, then restore the history object state given document and newEntry.

--- a/Userland/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Navigable.cpp
@@ -1330,23 +1330,31 @@ WebIDL::ExceptionOr<void> Navigable::navigate_to_a_fragment(AK::URL const& url, 
     // 7. Let entryToReplace be navigable's active session history entry if historyHandling is "replace", otherwise null.
     auto entry_to_replace = history_handling == HistoryHandlingBehavior::Replace ? active_session_history_entry() : nullptr;
 
-    // FIXME: 8. Let history be navigable's active document's history object.
+    // 8. Let history be navigable's active document's history object.
+    auto history = active_document()->history();
 
-    // FIXME: 9. Let scriptHistoryIndex be history's index.
+    // 9. Let scriptHistoryIndex be history's index.
+    auto script_history_index = history->m_index;
 
-    // FIXME: 10. Let scriptHistoryIndex be history's index.
+    // 10. Let scriptHistoryLength be history's length.
+    auto script_history_length = history->m_length;
 
     // 11. If historyHandling is "push", then:
     if (history_handling == HistoryHandlingBehavior::Push) {
         // FIXME: 1. Set history's state to null.
-        // FIXME: 2. Increment scriptHistoryIndex.
-        // FIXME: 3. Set scriptHistoryLength to scriptHistoryIndex + 1.
+
+        // 2. Increment scriptHistoryIndex.
+        script_history_index++;
+
+        // 3. Set scriptHistoryLength to scriptHistoryIndex + 1.
+        script_history_length = script_history_index + 1;
     }
 
     // 12. Set navigable's active session history entry to historyEntry.
     m_active_session_history_entry = history_entry;
 
-    // FIXME: 13. Update document for history step application given navigable's active document, historyEntry, true, scriptHistoryIndex, and scriptHistoryLength.
+    // 13. Update document for history step application given navigable's active document, historyEntry, true, scriptHistoryIndex, and scriptHistoryLength.
+    active_document()->update_for_history_step_application(*history_entry, true, script_history_length, script_history_index);
 
     // FIXME: 14. Update the navigation API entries for a same-document navigation given navigation, historyEntry, and historyHandling.
 

--- a/Userland/Libraries/LibWeb/HTML/TraversableNavigable.cpp
+++ b/Userland/Libraries/LibWeb/HTML/TraversableNavigable.cpp
@@ -407,14 +407,14 @@ void TraversableNavigable::apply_the_history_step(int step, Optional<SourceSnaps
         navigable->set_ongoing_navigation({});
 
         // 8. Let (scriptHistoryLength, scriptHistoryIndex) be the result of getting the history object length and index given traversable and targetStep.
-        auto [script_history_length, script_history_index] = get_the_history_object_length_and_index(target_step);
-        (void)script_history_length;
-        (void)script_history_index;
+        auto history_object_length_and_index = get_the_history_object_length_and_index(target_step);
+        auto script_history_length = history_object_length_and_index.script_history_length;
+        auto script_history_index = history_object_length_and_index.script_history_index;
 
         // FIXME: 9. Append navigable to navigablesThatMustWaitBeforeHandlingSyncNavigation.
 
         // 10. Queue a global task on the navigation and traversal task source given navigable's active window to run the steps:
-        queue_global_task(Task::Source::NavigationAndTraversal, *navigable->active_window(), [&, target_entry, navigable, displayed_document, update_only = changing_navigable_continuation.update_only] {
+        queue_global_task(Task::Source::NavigationAndTraversal, *navigable->active_window(), [&, target_entry, navigable, displayed_document, update_only = changing_navigable_continuation.update_only, script_history_length, script_history_index] {
             // NOTE: This check is not in the spec but we should not continue navigation if navigable has been destroyed.
             if (navigable->has_been_destroyed())
                 return;
@@ -439,8 +439,10 @@ void TraversableNavigable::apply_the_history_step(int step, Optional<SourceSnaps
             // FIXME: 2. If targetEntry's document is not equal to displayedDocument, then queue a global task on the navigation and traversal task source given targetEntry's document's
             //           relevant global object to perform the following step. Otherwise, continue onward to perform the following step within the currently-queued task.
 
-            // FIXME: 3. Update document for history step application given targetEntry's document, targetEntry, changingNavigableContinuation's update-only, scriptHistoryLength, and
-            //           scriptHistoryIndex.
+            // 3. Update document for history step application given targetEntry's document, targetEntry, changingNavigableContinuation's update-only, scriptHistoryLength, and
+            //    scriptHistoryIndex and entriesForNavigationAPI.
+            //    FIXME: Pass entriesForNavigationAPI
+            target_entry->document_state->document()->update_for_history_step_application(*target_entry, update_only, script_history_length, script_history_index);
 
             // 4. Increment completedChangeJobs.
             completed_change_jobs++;

--- a/Userland/Libraries/LibWeb/HTML/TraversableNavigable.h
+++ b/Userland/Libraries/LibWeb/HTML/TraversableNavigable.h
@@ -34,8 +34,8 @@ public:
     void set_system_visibility_state(VisibilityState);
 
     struct HistoryObjectLengthAndIndex {
-        size_t script_history_length;
-        size_t script_history_index;
+        u64 script_history_length;
+        u64 script_history_index;
     };
     HistoryObjectLengthAndIndex get_the_history_object_length_and_index(int) const;
 


### PR DESCRIPTION
- Update `HTML::History` to have index and length like latest specification says
- Make `shared_history_push_replace_state()` to actually add/replace session history entry
- Update URL in UI when `pushState()` or `replaceState()` happens
- Add test for `pushState()` :)

Fixes https://github.com/SerenityOS/serenity/issues/21185
