### PR TITLE
LibCore: Add ArgsParser::add_option for setting enum values from a flag

### DIFF
--- a/Userland/Libraries/LibCore/ArgsParser.h
+++ b/Userland/Libraries/LibCore/ArgsParser.h
@@ -87,6 +87,20 @@ public:
     void add_option(Option&&);
     void add_ignored(char const* long_name, char short_name, OptionHideMode hide_mode = OptionHideMode::None);
     void add_option(bool& value, char const* help_string, char const* long_name, char short_name, OptionHideMode hide_mode = OptionHideMode::None);
+    /// If the option is present, set the enum to have the given `new_value`.
+    template<Enum T>
+    void add_option(T& value, T new_value, char const* help_string, char const* long_name, char short_name, OptionHideMode hide_mode = OptionHideMode::None)
+    {
+        add_option({ .argument_mode = Core::ArgsParser::OptionArgumentMode::None,
+            .help_string = help_string,
+            .long_name = long_name,
+            .short_name = short_name,
+            .accept_value = [&](StringView) {
+                value = new_value;
+                return true;
+            },
+            .hide_mode = hide_mode });
+    }
     void add_option(DeprecatedString& value, char const* help_string, char const* long_name, char short_name, char const* value_name, OptionHideMode hide_mode = OptionHideMode::None);
     void add_option(String& value, char const* help_string, char const* long_name, char short_name, char const* value_name, OptionHideMode hide_mode = OptionHideMode::None);
     void add_option(StringView& value, char const* help_string, char const* long_name, char short_name, char const* value_name, OptionHideMode hide_mode = OptionHideMode::None);

--- a/Userland/Utilities/grep.cpp
+++ b/Userland/Utilities/grep.cpp
@@ -121,26 +121,8 @@ ErrorOr<int> serenity_main(Main::Arguments args)
             return true;
         },
     });
-    args_parser.add_option(Core::ArgsParser::Option {
-        .argument_mode = Core::ArgsParser::OptionArgumentMode::None,
-        .help_string = "Treat binary files as text (same as --binary-mode text)",
-        .long_name = "text",
-        .short_name = 'a',
-        .accept_value = [&](auto) {
-            binary_mode = BinaryFileMode::Text;
-            return true;
-        },
-    });
-    args_parser.add_option(Core::ArgsParser::Option {
-        .argument_mode = Core::ArgsParser::OptionArgumentMode::None,
-        .help_string = "Ignore binary files (same as --binary-mode skip)",
-        .long_name = nullptr,
-        .short_name = 'I',
-        .accept_value = [&](auto) {
-            binary_mode = BinaryFileMode::Skip;
-            return true;
-        },
-    });
+    args_parser.add_option(binary_mode, BinaryFileMode::Text, "Treat binary files as text (same as --binary-mode text)", "text", 'a');
+    args_parser.add_option(binary_mode, BinaryFileMode::Skip, "Ignore binary files (same as --binary-mode skip)", nullptr, 'I');
     args_parser.add_option(Core::ArgsParser::Option {
         .argument_mode = Core::ArgsParser::OptionArgumentMode::Required,
         .help_string = "When to use colored output for the matching text ([auto], never, always)",

--- a/Userland/Utilities/ls.cpp
+++ b/Userland/Utilities/ls.cpp
@@ -114,22 +114,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_option(flag_ignore_backups, "Do not list implied entries ending with ~", "ignore-backups", 'B');
     args_parser.add_option(flag_list_directories_only, "List directories themselves, not their contents", "directory", 'd');
     args_parser.add_option(flag_long, "Display long info", "long", 'l');
-    args_parser.add_option(Core::ArgsParser::Option {
-        .argument_mode = Core::ArgsParser::OptionArgumentMode::None,
-        .help_string = "Sort files by timestamp (newest first)",
-        .short_name = 't',
-        .accept_value = [](StringView) {
-            flag_sort_by = FieldToSortBy::ModifiedAt;
-            return true;
-        } });
-    args_parser.add_option(Core::ArgsParser::Option {
-        .argument_mode = Core::ArgsParser::OptionArgumentMode::None,
-        .help_string = "Sort files by size (largest first)",
-        .short_name = 'S',
-        .accept_value = [](StringView) {
-            flag_sort_by = FieldToSortBy::Size;
-            return true;
-        } });
+    args_parser.add_option(flag_sort_by, FieldToSortBy::ModifiedAt, "Sort files by timestamp (newest first)", nullptr, 't');
+    args_parser.add_option(flag_sort_by, FieldToSortBy::Size, "Sort files by size (largest first)", nullptr, 'S');
     args_parser.add_option(flag_reverse_sort, "Reverse sort order", "reverse", 'r');
     args_parser.add_option(flag_classify, "Append a file type indicator to entries", "classify", 'F');
     args_parser.add_option(flag_colorize, "Use pretty colors", nullptr, 'G');

--- a/Userland/Utilities/strings.cpp
+++ b/Userland/Utilities/strings.cpp
@@ -118,15 +118,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             }
             return true;
         } });
-    args_parser.add_option({ Core::ArgsParser::OptionArgumentMode::None,
-        "Equivalent to specifying -t o.",
-        nullptr,
-        'o',
-        nullptr,
-        [&string_offset_format](auto) {
-            string_offset_format = StringOffsetFormat::Octal;
-            return true;
-        } });
+    args_parser.add_option(string_offset_format, StringOffsetFormat::Octal, "Equivalent to specifying -t o.", nullptr, 'o');
     args_parser.set_general_help("Write the sequences of printable characters in files or pipes to stdout.");
     args_parser.add_positional_argument(paths, "File path", "path", Core::ArgsParser::Required::No);
     args_parser.parse(arguments);


### PR DESCRIPTION
Previously, argument-less options could only set a boolean to true. This
lets them also set an enum variable to a specific value, as is currently
done by the `ls` utility.

Inspired by the recent changes in #21208.