### PR TITLE
LibWasm: Make sure to place imported functions before the module's

### DIFF
--- a/Userland/Libraries/LibWasm/AbstractMachine/AbstractMachine.h
+++ b/Userland/Libraries/LibWasm/AbstractMachine/AbstractMachine.h
@@ -623,7 +623,7 @@ public:
     void enable_instruction_count_limit() { m_should_limit_instruction_count = true; }
 
 private:
-    Optional<InstantiationError> allocate_all_initial_phase(Module const&, ModuleInstance&, Vector<ExternValue>&, Vector<Value>& global_values);
+    Optional<InstantiationError> allocate_all_initial_phase(Module const&, ModuleInstance&, Vector<ExternValue>&, Vector<Value>& global_values, Vector<FunctionAddress>& own_functions);
     Optional<InstantiationError> allocate_all_final_phase(Module const&, ModuleInstance&, Vector<Vector<Reference>>& elements);
     Store m_store;
     StackInfo m_stack_info;


### PR DESCRIPTION
aafef1e92d8e750b8abd2100e5896df75505e2a1 broke this while trying to make the global import available in initialisation, this commit makes sure we place the module's own functions after all resolved imports.