### PR TITLE
LibWeb: Fix document leak in SVGDecodedImageData

### DIFF
--- a/Userland/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
@@ -67,8 +67,10 @@ ErrorOr<NonnullRefPtr<SVGDecodedImageData>> SVGDecodedImageData::create(Page& ho
         .cross_origin_opener_policy = HTML::CrossOriginOpenerPolicy {},
         .about_base_url = {},
     };
+    // FIXME: Use Navigable::navigate() instead of manually replacing the navigable's document.
     auto document = DOM::Document::create_and_initialize(DOM::Document::Type::HTML, "text/html", navigation_params).release_value_but_fixme_should_propagate_errors();
     navigable->set_ongoing_navigation({});
+    navigable->active_document()->destroy();
     navigable->active_session_history_entry()->document_state->set_document(document);
 
     auto parser = HTML::HTMLParser::create_with_uncertain_encoding(document, data);


### PR DESCRIPTION
The SVGDecodedImageData creates a new Page and replaces its document with a new one that contains SVG content. This change adds a destroy call on the replaced document. Without this addition, all tasks scheduled on the event loop during navigation, initiated while the page's traversable is being created, will never execute, as the initial replaced document will become inactive. This leads to a document leak because the tasks use JS::Handle to hold document pointer. Making the destroy call resolves the issue because it removes all tasks associated with the destroyed document from the queue.