### PR TITLE
LibWeb: Add SVG-presentation-attribute-parsing mode to CSS parser

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Parser/ParsingContext.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/ParsingContext.cpp
@@ -13,29 +13,33 @@
 
 namespace Web::CSS::Parser {
 
-ParsingContext::ParsingContext(JS::Realm& realm)
+ParsingContext::ParsingContext(JS::Realm& realm, Mode mode)
     : m_realm(realm)
+    , m_mode(mode)
 {
 }
 
-ParsingContext::ParsingContext(DOM::Document const& document, AK::URL url)
+ParsingContext::ParsingContext(DOM::Document const& document, AK::URL url, Mode mode)
     : m_realm(const_cast<JS::Realm&>(document.realm()))
     , m_document(&document)
     , m_url(move(url))
+    , m_mode(mode)
 {
 }
 
-ParsingContext::ParsingContext(DOM::Document const& document)
+ParsingContext::ParsingContext(DOM::Document const& document, Mode mode)
     : m_realm(const_cast<JS::Realm&>(document.realm()))
     , m_document(&document)
     , m_url(document.url())
+    , m_mode(mode)
 {
 }
 
-ParsingContext::ParsingContext(DOM::ParentNode& parent_node)
+ParsingContext::ParsingContext(DOM::ParentNode& parent_node, Mode mode)
     : m_realm(parent_node.realm())
     , m_document(&parent_node.document())
     , m_url(parent_node.document().url())
+    , m_mode(mode)
 {
 }
 

--- a/Userland/Libraries/LibWeb/CSS/Parser/ParsingContext.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/ParsingContext.h
@@ -14,10 +14,18 @@ namespace Web::CSS::Parser {
 
 class ParsingContext {
 public:
-    explicit ParsingContext(JS::Realm&);
-    explicit ParsingContext(DOM::Document const&);
-    explicit ParsingContext(DOM::Document const&, AK::URL);
-    explicit ParsingContext(DOM::ParentNode&);
+    enum class Mode {
+        Normal,
+        SVGPresentationAttribute, // See https://svgwg.org/svg2-draft/types.html#presentation-attribute-css-value
+    };
+
+    explicit ParsingContext(JS::Realm&, Mode = Mode::Normal);
+    explicit ParsingContext(DOM::Document const&, Mode = Mode::Normal);
+    explicit ParsingContext(DOM::Document const&, AK::URL, Mode = Mode::Normal);
+    explicit ParsingContext(DOM::ParentNode&, Mode = Mode::Normal);
+
+    Mode mode() const { return m_mode; }
+    bool is_parsing_svg_presentation_attribute() const { return m_mode == Mode::SVGPresentationAttribute; }
 
     bool in_quirks_mode() const;
     DOM::Document const* document() const { return m_document; }
@@ -34,6 +42,7 @@ private:
     JS::GCPtr<DOM::Document const> m_document;
     PropertyID m_current_property_id { PropertyID::Invalid };
     AK::URL m_url;
+    Mode m_mode { Mode::Normal };
 };
 
 }

--- a/Userland/Libraries/LibWeb/SVG/SVGElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGElement.h
@@ -11,27 +11,6 @@
 
 namespace Web::SVG {
 
-namespace FIXME {
-class TemporarilyEnableQuirksMode {
-public:
-    TemporarilyEnableQuirksMode(DOM::Document const& document)
-        : m_document(const_cast<DOM::Document&>(document))
-        , m_previous_quirks_mode(document.mode())
-    {
-        m_document.set_quirks_mode(DOM::QuirksMode::Yes);
-    }
-
-    ~TemporarilyEnableQuirksMode()
-    {
-        m_document.set_quirks_mode(m_previous_quirks_mode);
-    }
-
-private:
-    DOM::Document& m_document;
-    DOM::QuirksMode m_previous_quirks_mode {};
-};
-}
-
 class SVGElement : public DOM::Element {
     WEB_PLATFORM_OBJECT(SVGElement, DOM::Element);
 

--- a/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
@@ -118,10 +118,7 @@ Gfx::AffineTransform SVGGraphicsElement::get_transform() const
 
 void SVGGraphicsElement::apply_presentational_hints(CSS::StyleProperties& style) const
 {
-    // FIXME: Hack to ensure unitless SVG properties (such as font-size) are parsed.
-    FIXME::TemporarilyEnableQuirksMode enable_quirks(document());
-
-    CSS::Parser::ParsingContext parsing_context { document() };
+    CSS::Parser::ParsingContext parsing_context { document(), CSS::Parser::ParsingContext::Mode::SVGPresentationAttribute };
     for_each_attribute([&](auto& name, auto& value) {
         if (name.equals_ignoring_ascii_case("fill"sv)) {
             // FIXME: The `fill` attribute and CSS `fill` property are not the same! But our support is limited enough that they are equivalent for now.

--- a/Userland/Libraries/LibWeb/SVG/SVGSVGElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGSVGElement.cpp
@@ -38,11 +38,8 @@ void SVGSVGElement::apply_presentational_hints(CSS::StyleProperties& style) cons
 {
     Base::apply_presentational_hints(style);
 
-    // NOTE: Hack to ensure SVG unitless widths/heights are parsed even with <!DOCTYPE html>
-    FIXME::TemporarilyEnableQuirksMode enable_quirks(document());
-
     auto width_attribute = deprecated_attribute(SVG::AttributeNames::width);
-    auto parsing_context = CSS::Parser::ParsingContext { document() };
+    auto parsing_context = CSS::Parser::ParsingContext { document(), CSS::Parser::ParsingContext::Mode::SVGPresentationAttribute };
     if (auto width_value = parse_css_value(parsing_context, deprecated_attribute(Web::HTML::AttributeNames::width), CSS::PropertyID::Width)) {
         style.set_property(CSS::PropertyID::Width, width_value.release_nonnull());
     } else if (width_attribute == "") {


### PR DESCRIPTION
When parsing these, <number> is allowed anywhere that would usually allow a `<length>`, `<length-percentage>`, or `<angle>`. The spec is not clear on exactly how this should work (see w3c/svgwg#792 ) so I'm using some artistic license until things are clearer:
- If we expected a `<length>`, treat the `<number>` as pixels.
- If we expected an `<angle>`, treat the `<number>` as degrees.
- Only allow direct `<number>` tokens, not calc() or other functions.

From what I can tell this is what the spec *intended* but I may be very wrong. In any case, telling the ParsingContext whether we're parsing one of these attributes is a cleaner approach and more correct than temporarily enabling quirks mode, which we did previously.