### PR TITLE
ls: Add the `-p` option to append a trailing slash to directories

### DIFF
--- a/Base/usr/share/man/man1/ls.md
+++ b/Base/usr/share/man/man1/ls.md
@@ -21,6 +21,7 @@ If no *path* argument is provided the current working directory is used.
 * `-A`: Do not list implied . and .. directories
 * `-B`, `--ignore-backups`: Do not list implied entries ending with ~
 * `-F`, `--classify`: Append a file type indicator to entries
+* `-p`: Append a '/' indicator to directories
 * `-d`, `--directory`: List directories themselves, not their contents
 * `-l`, `--long`: Display long info
 * `-t`: Sort files by timestamp (newest first)


### PR DESCRIPTION
This overrides the `-F` option and vice-versa.

Example usage:

![ls_directory_trailing_slash](https://github.com/SerenityOS/serenity/assets/2817754/fb612b7f-d56f-4bf4-a408-89b2e1934718)