### PR TITLE
LibWeb: Fix GC-leaks caused by HTML::Timer

### DIFF
--- a/Tests/LibWeb/Text/expected/setInterval.txt
+++ b/Tests/LibWeb/Text/expected/setInterval.txt
@@ -1,0 +1,3 @@
+setInterval completed count=0
+setInterval completed count=1
+setInterval completed count=2

--- a/Tests/LibWeb/Text/expected/setTimeout.txt
+++ b/Tests/LibWeb/Text/expected/setTimeout.txt
@@ -1,0 +1,1 @@
+setTimeout completed

--- a/Tests/LibWeb/Text/input/setInterval.html
+++ b/Tests/LibWeb/Text/input/setInterval.html
@@ -1,0 +1,13 @@
+<script src="include.js"></script>
+<script>
+    asyncTest(done => {
+        let count = 0;
+        let intervalId = setInterval(() => {
+            println("setInterval completed count=" + count++);
+            if (count === 3) {
+                clearInterval(intervalId);
+                done();
+            }
+        }, 0);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/setTimeout.html
+++ b/Tests/LibWeb/Text/input/setTimeout.html
@@ -1,0 +1,9 @@
+<script src="include.js"></script>
+<script>
+    asyncTest(done => {
+        setTimeout(() => {
+            println("setTimeout completed");
+            done();
+        }, 0);
+    });
+</script>

--- a/Userland/Libraries/LibJS/Heap/HeapFunction.h
+++ b/Userland/Libraries/LibJS/Heap/HeapFunction.h
@@ -24,7 +24,7 @@ public:
 
     virtual ~HeapFunction() override = default;
 
-    Function<T> const& function() const { return m_function; }
+    [[nodiscard]] Function<T> const& function() const { return m_function; }
 
 private:
     HeapFunction(Function<T> function)

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -2656,6 +2656,27 @@ Vector<JS::Handle<HTML::BrowsingContext>> Document::list_of_descendant_browsing_
     return list;
 }
 
+// https://html.spec.whatwg.org/multipage/document-lifecycle.html#unloading-document-cleanup-steps
+void Document::run_unloading_cleanup_steps()
+{
+    // 1. Let window be document's relevant global object.
+    auto* window = dynamic_cast<HTML::WindowOrWorkerGlobalScopeMixin*>(&HTML::relevant_global_object(*this));
+    VERIFY(window);
+
+    // FIXME: 2. For each WebSocket object webSocket whose relevant global object is window, make disappear webSocket.
+    //            If this affected any WebSocket objects, then set document's salvageable state to false.
+
+    // FIXME: 3. For each WebTransport object transport whose relevant global object is window, run the context cleanup steps given transport.
+
+    // 4. If document's salvageable state is false, then:
+    if (m_salvageable) {
+        // FIXME: 1. For each EventSource object eventSource whose relevant global object is equal to window, forcibly close eventSource.
+
+        // 2. Clear window's map of active timers.
+        window->clear_map_of_active_timers();
+    }
+}
+
 // https://html.spec.whatwg.org/multipage/document-lifecycle.html#destroy-a-document
 void Document::destroy()
 {
@@ -2668,7 +2689,8 @@ void Document::destroy()
     // 2. Set document's salvageable state to false.
     m_salvageable = false;
 
-    // FIXME: 3. Run any unloading document cleanup steps for document that are defined by this specification and other applicable specifications.
+    // 3. Run any unloading document cleanup steps for document that are defined by this specification and other applicable specifications.
+    run_unloading_cleanup_steps();
 
     // 5. Remove any tasks whose document is document from any task queue (without running those tasks).
     HTML::main_thread_event_loop().task_queue().remove_tasks_matching([this](auto& task) {

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -545,6 +545,8 @@ private:
 
     void tear_down_layout_tree();
 
+    void run_unloading_cleanup_steps();
+
     void evaluate_media_rules();
 
     WebIDL::ExceptionOr<void> run_the_document_write_steps(StringView);

--- a/Userland/Libraries/LibWeb/HTML/Timer.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Timer.cpp
@@ -34,11 +34,17 @@ void Timer::visit_edges(Cell::Visitor& visitor)
 
 Timer::~Timer()
 {
+    VERIFY(!m_timer->is_active());
 }
 
 void Timer::start()
 {
     m_timer->start();
+}
+
+void Timer::stop()
+{
+    m_timer->stop();
 }
 
 }

--- a/Userland/Libraries/LibWeb/HTML/Timer.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Timer.cpp
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibCore/Timer.h>
 #include <LibJS/Runtime/Object.h>
 #include <LibWeb/HTML/Timer.h>
 #include <LibWeb/HTML/Window.h>
-#include <LibWeb/Platform/Timer.h>
 
 namespace Web::HTML {
 
@@ -21,9 +21,9 @@ Timer::Timer(JS::Object& window_or_worker_global_scope, i32 milliseconds, Functi
     , m_callback(move(callback))
     , m_id(id)
 {
-    m_timer = Platform::Timer::create_single_shot(milliseconds, [this] {
+    m_timer = Core::Timer::create_single_shot(milliseconds, [this] {
         m_callback();
-    });
+    }).release_value_but_fixme_should_propagate_errors();
 }
 
 void Timer::visit_edges(Cell::Visitor& visitor)

--- a/Userland/Libraries/LibWeb/HTML/Timer.h
+++ b/Userland/Libraries/LibWeb/HTML/Timer.h
@@ -31,7 +31,7 @@ private:
 
     virtual void visit_edges(Cell::Visitor&) override;
 
-    RefPtr<Platform::Timer> m_timer;
+    RefPtr<Core::Timer> m_timer;
     JS::NonnullGCPtr<JS::Object> m_window_or_worker_global_scope;
     Function<void()> m_callback;
     i32 m_id { 0 };

--- a/Userland/Libraries/LibWeb/HTML/Timer.h
+++ b/Userland/Libraries/LibWeb/HTML/Timer.h
@@ -24,6 +24,7 @@ public:
     virtual ~Timer() override;
 
     void start();
+    void stop();
 
 private:
     Timer(JS::Object& window, i32 milliseconds, Function<void()> callback, i32 id);

--- a/Userland/Libraries/LibWeb/HTML/Timer.h
+++ b/Userland/Libraries/LibWeb/HTML/Timer.h
@@ -12,6 +12,7 @@
 #include <LibCore/Forward.h>
 #include <LibJS/Heap/Cell.h>
 #include <LibJS/Heap/GCPtr.h>
+#include <LibJS/Heap/HeapFunction.h>
 #include <LibWeb/Forward.h>
 
 namespace Web::HTML {
@@ -27,13 +28,13 @@ public:
     void stop();
 
 private:
-    Timer(JS::Object& window, i32 milliseconds, Function<void()> callback, i32 id);
+    Timer(JS::Object& window, i32 milliseconds, JS::NonnullGCPtr<JS::HeapFunction<void()>> callback, i32 id);
 
     virtual void visit_edges(Cell::Visitor&) override;
 
     RefPtr<Core::Timer> m_timer;
     JS::NonnullGCPtr<JS::Object> m_window_or_worker_global_scope;
-    Function<void()> m_callback;
+    JS::NonnullGCPtr<JS::HeapFunction<void()>> m_callback;
     i32 m_id { 0 };
 };
 

--- a/Userland/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.cpp
+++ b/Userland/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.cpp
@@ -183,13 +183,24 @@ i32 WindowOrWorkerGlobalScopeMixin::set_interval(TimerHandler handler, i32 timeo
 // https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#dom-cleartimeout
 void WindowOrWorkerGlobalScopeMixin::clear_timeout(i32 id)
 {
+    if (auto timer = m_timers.get(id); timer.has_value())
+        timer.value()->stop();
     m_timers.remove(id);
 }
 
 // https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#dom-clearinterval
 void WindowOrWorkerGlobalScopeMixin::clear_interval(i32 id)
 {
+    if (auto timer = m_timers.get(id); timer.has_value())
+        timer.value()->stop();
     m_timers.remove(id);
+}
+
+void WindowOrWorkerGlobalScopeMixin::clear_map_of_active_timers()
+{
+    for (auto& it : m_timers)
+        it.value->stop();
+    m_timers.clear();
 }
 
 // https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#timer-initialisation-steps

--- a/Userland/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.h
+++ b/Userland/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.h
@@ -46,6 +46,7 @@ public:
     i32 set_interval(TimerHandler, i32 timeout, JS::MarkedVector<JS::Value> arguments);
     void clear_timeout(i32);
     void clear_interval(i32);
+    void clear_map_of_active_timers();
 
     PerformanceTimeline::PerformanceEntryTuple& relevant_performance_entry_tuple(FlyString const& entry_type);
     void queue_performance_entry(JS::NonnullGCPtr<PerformanceTimeline::PerformanceEntry> new_entry);


### PR DESCRIPTION
This change implements a step from the document's destroy procedure in
the specification, saying that all active timers should be cleared.

By doing this, we also fix the leaking of a document in case where we
have navigated away from a page that has scheduled timers that haven't
yet been triggered.