### PR TITLE
LibWeb: Handle shorthands in ResolvedCSSStyleDeclaration generically

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Properties.json
+++ b/Userland/Libraries/LibWeb/CSS/Properties.json
@@ -953,7 +953,9 @@
     ],
     "percentages-resolve-to": "length",
     "longhands": [
-      "grid-template"
+      "grid-template-areas",
+      "grid-template-rows",
+      "grid-template-columns"
     ]
   },
   "grid-area": {

--- a/Userland/Libraries/LibWeb/CSS/Properties.json
+++ b/Userland/Libraries/LibWeb/CSS/Properties.json
@@ -839,8 +839,11 @@
     "longhands": [
       "font-family",
       "font-size",
+      "font-stretch",
+      "font-style",
       "font-variant",
-      "font-weight"
+      "font-weight",
+      "line-height"
     ]
   },
   "font-family": {

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/ShorthandStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/ShorthandStyleValue.cpp
@@ -97,6 +97,15 @@ String ShorthandStyleValue::to_string() const
         return MUST(String::formatted("{} {} {}", longhand(PropertyID::FlexGrow)->to_string(), longhand(PropertyID::FlexShrink)->to_string(), longhand(PropertyID::FlexBasis)->to_string()));
     case PropertyID::FlexFlow:
         return MUST(String::formatted("{} {}", longhand(PropertyID::FlexDirection)->to_string(), longhand(PropertyID::FlexWrap)->to_string()));
+    case PropertyID::Font:
+        return MUST(String::formatted("{} {} {} {} {} / {} {}",
+            longhand(PropertyID::FontStyle)->to_string(),
+            longhand(PropertyID::FontVariant)->to_string(),
+            longhand(PropertyID::FontWeight)->to_string(),
+            longhand(PropertyID::FontStretch)->to_string(),
+            longhand(PropertyID::FontSize)->to_string(),
+            longhand(PropertyID::LineHeight)->to_string(),
+            longhand(PropertyID::FontFamily)->to_string()));
     case PropertyID::GridArea: {
         auto& row_start = longhand(PropertyID::GridRowStart)->as_grid_track_placement();
         auto& column_start = longhand(PropertyID::GridColumnStart)->as_grid_track_placement();


### PR DESCRIPTION
While making these consistent and removing some unnecessary null/invalid-value checks, I noticed that actually, we would be manually constructing ShorthandStyleValues over and over... and could just use our existing functions that tell you what longhands a shorthand has. So, let's do that!

We should now be producing a value for every style property! :tada:

Actually serializing these correctly has a long way to go unfortunately, and will require a fair bit of manual code in `ShorthandStyleValue::to_string()` unless someone has a better idea. :yakbait:

Fixed up some property data while I was at it, partly to stop the automatic shorthand code exploding. `ShorthandStyleValue::to_string()` expects certain longhands to be present, so if we're automatically constructing the ShorthandStyleValue, the list of longhands in Properties.json needs to match.