### PR TITLE
ls: Add the `-g` option to omit owner information in long format

### DIFF
--- a/Base/usr/share/man/man1/ls.md
+++ b/Base/usr/share/man/man1/ls.md
@@ -30,8 +30,8 @@ If no *path* argument is provided the current working directory is used.
 * `-G`: Use pretty colors
 * `-i`, `--inode`: Show inode ids
 * `-I`, `--raw-inode`: Show raw inode ids if possible (see Notes to understand when this will not work)
-* `-n`, `--numeric-uid-gid`: In long format, display numeric UID/GID
-* `-o`, In long format, do not show group information
+* `-n`, `--numeric-uid-gid`: In long format, display numeric UID/GID. Implies `-l`
+* `-o`: In long format, do not show group information. Implies `-l`
 * `-h`, `--human-readable`: Print human-readable sizes
 * `--si`: Print human-readable sizes in SI units
 * `-K`, `--no-hyperlinks`: Disable hyperlinks

--- a/Base/usr/share/man/man1/ls.md
+++ b/Base/usr/share/man/man1/ls.md
@@ -32,6 +32,7 @@ If no *path* argument is provided the current working directory is used.
 * `-I`, `--raw-inode`: Show raw inode ids if possible (see Notes to understand when this will not work)
 * `-n`, `--numeric-uid-gid`: In long format, display numeric UID/GID. Implies `-l`
 * `-o`: In long format, do not show group information. Implies `-l`
+* `-g`: In long format, do not show owner information. Implies `-l`
 * `-h`, `--human-readable`: Print human-readable sizes
 * `--si`: Print human-readable sizes in SI units
 * `-K`, `--no-hyperlinks`: Disable hyperlinks

--- a/Userland/Utilities/ls.cpp
+++ b/Userland/Utilities/ls.cpp
@@ -76,6 +76,7 @@ static bool flag_show_inode = false;
 static bool flag_show_raw_inode = false;
 static bool flag_print_numeric = false;
 static bool flag_hide_group = false;
+static bool flag_hide_owner = false;
 static bool flag_human_readable = false;
 static bool flag_human_readable_si = false;
 static FieldToSortBy flag_sort_by { FieldToSortBy::Name };
@@ -133,6 +134,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_option(flag_show_raw_inode, "Show raw inode ids if possible", "raw-inode", 'I');
     args_parser.add_option(flag_print_numeric, "In long format, display numeric UID/GID. Implies '-l'", "numeric-uid-gid", 'n');
     args_parser.add_option(flag_hide_group, "In long format, do not show group information. Implies '-l'", nullptr, 'o');
+    args_parser.add_option(flag_hide_owner, "In long format, do not show owner information. Implies '-l'", nullptr, 'g');
     args_parser.add_option(flag_human_readable, "Print human-readable sizes", "human-readable", 'h');
     args_parser.add_option(flag_human_readable_si, "Print human-readable sizes in SI units", "si", 0);
     args_parser.add_option(flag_disable_hyperlinks, "Disable hyperlinks", "no-hyperlinks", 'K');
@@ -141,7 +143,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_positional_argument(paths, "Directory to list", "path", Core::ArgsParser::Required::No);
     args_parser.parse(arguments);
 
-    if (flag_print_numeric || flag_hide_group)
+    if (flag_print_numeric || flag_hide_group || flag_hide_owner)
         flag_long = true;
 
     if (flag_show_almost_all_dotfiles)
@@ -368,11 +370,13 @@ static bool print_filesystem_object(DeprecatedString const& path, DeprecatedStri
 
     printf(" %3lu", st.st_nlink);
 
-    auto username = users.get(st.st_uid);
-    if (!flag_print_numeric && username.has_value()) {
-        printf(" %7s", username.value().characters());
-    } else {
-        printf(" %7u", st.st_uid);
+    if (!flag_hide_owner) {
+        auto username = users.get(st.st_uid);
+        if (!flag_print_numeric && username.has_value()) {
+            printf(" %7s", username.value().characters());
+        } else {
+            printf(" %7u", st.st_uid);
+        }
     }
 
     if (!flag_hide_group) {

--- a/Userland/Utilities/ls.cpp
+++ b/Userland/Utilities/ls.cpp
@@ -131,8 +131,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_option(flag_colorize, "Use pretty colors", nullptr, 'G');
     args_parser.add_option(flag_show_inode, "Show inode ids", "inode", 'i');
     args_parser.add_option(flag_show_raw_inode, "Show raw inode ids if possible", "raw-inode", 'I');
-    args_parser.add_option(flag_print_numeric, "In long format, display numeric UID/GID", "numeric-uid-gid", 'n');
-    args_parser.add_option(flag_hide_group, "In long format, do not show group information", nullptr, 'o');
+    args_parser.add_option(flag_print_numeric, "In long format, display numeric UID/GID. Implies '-l'", "numeric-uid-gid", 'n');
+    args_parser.add_option(flag_hide_group, "In long format, do not show group information. Implies '-l'", nullptr, 'o');
     args_parser.add_option(flag_human_readable, "Print human-readable sizes", "human-readable", 'h');
     args_parser.add_option(flag_human_readable_si, "Print human-readable sizes in SI units", "si", 0);
     args_parser.add_option(flag_disable_hyperlinks, "Disable hyperlinks", "no-hyperlinks", 'K');
@@ -140,6 +140,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_option(flag_force_newline, "List one file per line", nullptr, '1');
     args_parser.add_positional_argument(paths, "Directory to list", "path", Core::ArgsParser::Required::No);
     args_parser.parse(arguments);
+
+    if (flag_print_numeric || flag_hide_group)
+        flag_long = true;
 
     if (flag_show_almost_all_dotfiles)
         flag_show_dotfiles = true;

--- a/Userland/Utilities/ls.cpp
+++ b/Userland/Utilities/ls.cpp
@@ -373,18 +373,18 @@ static bool print_filesystem_object(DeprecatedString const& path, DeprecatedStri
     if (!flag_hide_owner) {
         auto username = users.get(st.st_uid);
         if (!flag_print_numeric && username.has_value()) {
-            printf(" %7s", username.value().characters());
+            printf(" %-7s", username.value().characters());
         } else {
-            printf(" %7u", st.st_uid);
+            printf(" %-7u", st.st_uid);
         }
     }
 
     if (!flag_hide_group) {
         auto groupname = groups.get(st.st_gid);
         if (!flag_print_numeric && groupname.has_value()) {
-            printf(" %7s", groupname.value().characters());
+            printf(" %-7s", groupname.value().characters());
         } else {
-            printf(" %7u", st.st_gid);
+            printf(" %-7u", st.st_gid);
         }
     }
 


### PR DESCRIPTION
This PR makes the following changes to `ls`:

* The `-n` and `-o` options now imply long mode should be used.
* Adds the `-g` option, displays results in long mode but hides owner information.
* Owner and group information are now left justified in long mode. This means users/groups of different lengths line up nicely. 

Example usage:

![ls_long_format_options](https://github.com/SerenityOS/serenity/assets/2817754/7c640874-9176-49c2-8226-0936dcf1cae7)