### PR TITLE
Ladybird/AppKit: Add color picker support

### DIFF
--- a/Ladybird/AppKit/Utilities/Conversions.h
+++ b/Ladybird/AppKit/Utilities/Conversions.h
@@ -8,6 +8,7 @@
 
 #include <AK/String.h>
 #include <AK/StringView.h>
+#include <LibGfx/Color.h>
 #include <LibGfx/Point.h>
 #include <LibGfx/Rect.h>
 #include <LibGfx/Size.h>
@@ -29,5 +30,8 @@ NSSize gfx_size_to_ns_size(Gfx::IntSize);
 
 Gfx::IntPoint ns_point_to_gfx_point(NSPoint);
 NSPoint gfx_point_to_ns_point(Gfx::IntPoint);
+
+Gfx::Color ns_color_to_gfx_color(NSColor*);
+NSColor* gfx_color_to_ns_color(Gfx::Color);
 
 }

--- a/Ladybird/AppKit/Utilities/Conversions.mm
+++ b/Ladybird/AppKit/Utilities/Conversions.mm
@@ -86,4 +86,25 @@ NSPoint gfx_point_to_ns_point(Gfx::IntPoint point)
         static_cast<CGFloat>(point.y()));
 }
 
+Gfx::Color ns_color_to_gfx_color(NSColor* color)
+{
+    auto rgb_color = [color colorUsingColorSpace:NSColorSpace.genericRGBColorSpace];
+    if (rgb_color != nil)
+        return {
+            static_cast<u8>([rgb_color redComponent] * 255),
+            static_cast<u8>([rgb_color greenComponent] * 255),
+            static_cast<u8>([rgb_color blueComponent] * 255),
+            static_cast<u8>([rgb_color alphaComponent] * 255)
+        };
+    return {};
+}
+
+NSColor* gfx_color_to_ns_color(Gfx::Color color)
+{
+    return [NSColor colorWithRed:(color.red() / 255.f)
+                           green:(color.green() / 255.f)
+                            blue:(color.blue() / 255.f)
+                           alpha:(color.alpha() / 255.f)];
+}
+
 }


### PR DESCRIPTION
I have added color picker support to the Ladybird AppKit chrome, to complete #20951.

Mostly based on this code: https://github.com/chromium/chromium/blob/master/components/remote_cocoa/app_shim/color_panel_bridge.mm#L104

# Demo video
https://github.com/SerenityOS/serenity/assets/19894029/70432a38-4568-4c84-8136-a45af98fe847