### PR TITLE
LibWeb: Add missing visit_edges() for ImageStyleValue

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/HTMLBodyElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLBodyElement.cpp
@@ -22,6 +22,13 @@ HTMLBodyElement::HTMLBodyElement(DOM::Document& document, DOM::QualifiedName qua
 
 HTMLBodyElement::~HTMLBodyElement() = default;
 
+void HTMLBodyElement::visit_edges(Visitor& visitor)
+{
+    Base::visit_edges(visitor);
+    if (m_background_style_value)
+        m_background_style_value->visit_edges(visitor);
+}
+
 void HTMLBodyElement::initialize(JS::Realm& realm)
 {
     Base::initialize(realm);

--- a/Userland/Libraries/LibWeb/HTML/HTMLBodyElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLBodyElement.h
@@ -29,6 +29,8 @@ public:
 private:
     HTMLBodyElement(DOM::Document&, DOM::QualifiedName);
 
+    virtual void visit_edges(Visitor&) override;
+
     // ^DOM::Node
     virtual bool is_html_body_element() const override { return true; }
 

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -307,6 +307,17 @@ NodeWithStyle::NodeWithStyle(DOM::Document& document, DOM::Node* node, CSS::Comp
     m_font = Platform::FontPlugin::the().default_font();
 }
 
+void NodeWithStyle::visit_edges(Visitor& visitor)
+{
+    Base::visit_edges(visitor);
+    for (auto& layer : m_computed_values.background_layers()) {
+        if (layer.background_image && layer.background_image->is_image())
+            layer.background_image->as_image().visit_edges(visitor);
+    }
+    if (m_list_style_image && m_list_style_image->is_image())
+        m_list_style_image->as_image().visit_edges(visitor);
+}
+
 // https://www.w3.org/TR/css-values-4/#snap-a-length-as-a-border-width
 static CSSPixels snap_a_length_as_a_border_width(double device_pixels_per_css_pixel, CSSPixels length)
 {

--- a/Userland/Libraries/LibWeb/Layout/Node.h
+++ b/Userland/Libraries/LibWeb/Layout/Node.h
@@ -15,6 +15,7 @@
 #include <LibWeb/CSS/ComputedValues.h>
 #include <LibWeb/CSS/StyleComputer.h>
 #include <LibWeb/CSS/StyleProperties.h>
+#include <LibWeb/CSS/StyleValues/ImageStyleValue.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/FontCache.h>
 #include <LibWeb/Forward.h>
@@ -221,6 +222,8 @@ public:
     JS::NonnullGCPtr<NodeWithStyle> create_anonymous_wrapper() const;
 
     void transfer_table_box_computed_values_to_wrapper_computed_values(CSS::ComputedValues& wrapper_computed_values);
+
+    virtual void visit_edges(Cell::Visitor& visitor) override;
 
 protected:
     NodeWithStyle(DOM::Document&, DOM::Node*, NonnullRefPtr<CSS::StyleProperties>);


### PR DESCRIPTION
ImageStyleValue has a visit_edges() method, although it is not a GC-allocated object. This is necessary because it owns a GC-allocated ImageRequest that we want to visit, instead of using JS::Handle, to avoid leaks. In the future, we might want to make StyleValue be GC-allocated.

For now, this change adds missing visit_edges() calls for objects that own ImageStyleValue.