### PR TITLE
GameOfLife: Make single key shortcuts work again

### DIFF
--- a/Userland/Games/GameOfLife/BoardWidget.cpp
+++ b/Userland/Games/GameOfLife/BoardWidget.cpp
@@ -78,11 +78,7 @@ void BoardWidget::set_running(bool running)
     if (running == m_running)
         return;
 
-    if (m_selected_pattern) {
-        m_selected_pattern = nullptr;
-        if (on_pattern_selection_state_change)
-            on_pattern_selection_state_change();
-    }
+    clear_selected_pattern();
 
     m_running = running;
 
@@ -206,17 +202,23 @@ void BoardWidget::mousedown_event(GUI::MouseEvent& event)
         if (m_selected_pattern) {
             place_pattern(row, column);
             if (!event.ctrl()) {
-                m_selected_pattern = nullptr;
-                if (on_pattern_selection_state_change)
-                    on_pattern_selection_state_change();
-
-                if (m_pattern_preview_timer->is_active())
-                    m_pattern_preview_timer->stop();
+                clear_selected_pattern();
             }
         } else {
             toggle_cell(row, column);
         }
     }
+}
+
+void BoardWidget::keydown_event(GUI::KeyEvent& event)
+{
+    if (event.key() == Key_Escape) {
+        clear_selected_pattern();
+        update();
+        return;
+    }
+
+    event.ignore();
 }
 
 void BoardWidget::context_menu_event(GUI::ContextMenuEvent& event)
@@ -285,6 +287,19 @@ void BoardWidget::place_pattern(size_t row, size_t column)
         }
         y_offset++;
     }
+}
+
+void BoardWidget::clear_selected_pattern()
+{
+    if (!m_selected_pattern)
+        return;
+
+    m_selected_pattern = nullptr;
+    if (on_pattern_selection_state_change)
+        on_pattern_selection_state_change();
+
+    if (m_pattern_preview_timer->is_active())
+        m_pattern_preview_timer->stop();
 }
 
 void BoardWidget::setup_patterns()

--- a/Userland/Games/GameOfLife/BoardWidget.h
+++ b/Userland/Games/GameOfLife/BoardWidget.h
@@ -26,6 +26,7 @@ public:
     virtual void mousemove_event(GUI::MouseEvent&) override;
     virtual void mouseup_event(GUI::MouseEvent&) override;
     virtual void mousedown_event(GUI::MouseEvent&) override;
+    virtual void keydown_event(GUI::KeyEvent&) override;
     virtual void context_menu_event(GUI::ContextMenuEvent&) override;
 
     void set_toggling_cells(bool toggling)
@@ -74,6 +75,7 @@ private:
     BoardWidget(size_t rows, size_t columns);
     void setup_patterns();
     void place_pattern(size_t row, size_t column);
+    void clear_selected_pattern();
 
     bool m_toggling_cells { false };
     Board::RowAndColumn m_last_cell_toggled {};

--- a/Userland/Games/GameOfLife/CMakeLists.txt
+++ b/Userland/Games/GameOfLife/CMakeLists.txt
@@ -4,17 +4,14 @@ serenity_component(
     TARGETS GameOfLife
 )
 
-stringify_gml(GameOfLife.gml GameOfLifeGML.h game_of_life_gml)
+compile_gml(GameOfLife.gml GameOfLifeGML.cpp)
 
 set(SOURCES
     main.cpp
     Board.cpp
     BoardWidget.cpp
+    GameOfLifeGML.cpp
     Pattern.cpp
-)
-
-set(GENERATED_SOURCES
-    GameOfLifeGML.h
 )
 
 serenity_app(GameOfLife ICON app-gameoflife)

--- a/Userland/Games/GameOfLife/GameOfLife.gml
+++ b/Userland/Games/GameOfLife/GameOfLife.gml
@@ -1,4 +1,4 @@
-@GUI::Widget {
+@GameOfLife::MainWidget {
     layout: @GUI::VerticalBoxLayout {}
 
     @GUI::ToolbarContainer {

--- a/Userland/Games/GameOfLife/MainWidget.h
+++ b/Userland/Games/GameOfLife/MainWidget.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2023, Tim Ledbetter <timledbetter@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibGUI/Widget.h>
+
+namespace GameOfLife {
+
+class MainWidget : public GUI::Widget {
+    C_OBJECT_ABSTRACT(MainWidget)
+public:
+    static ErrorOr<NonnullRefPtr<MainWidget>> try_create();
+    virtual ~MainWidget() override = default;
+
+private:
+    MainWidget() = default;
+};
+
+}

--- a/Userland/Games/GameOfLife/main.cpp
+++ b/Userland/Games/GameOfLife/main.cpp
@@ -6,9 +6,9 @@
  */
 
 #include "BoardWidget.h"
+#include "MainWidget.h"
 #include <AK/Try.h>
 #include <AK/URL.h>
-#include <Games/GameOfLife/GameOfLifeGML.h>
 #include <LibCore/System.h>
 #include <LibDesktop/Launcher.h>
 #include <LibGUI/Application.h>
@@ -53,8 +53,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_double_buffering_enabled(false);
     window->set_title("Game of Life");
 
-    auto main_widget = window->set_main_widget<GUI::Widget>();
-    TRY(main_widget->load_from_gml(game_of_life_gml));
+    auto main_widget = TRY(GameOfLife::MainWidget::try_create());
+    window->set_main_widget(main_widget);
     main_widget->set_fill_with_background_color(true);
 
     auto& main_toolbar = *main_widget->find_descendant_of_type_named<GUI::Toolbar>("toolbar");

--- a/Userland/Games/GameOfLife/main.cpp
+++ b/Userland/Games/GameOfLife/main.cpp
@@ -63,6 +63,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto& board_widget_container = *main_widget->find_descendant_of_type_named<GUI::Widget>("board_widget_container");
     board_widget_container.set_layout<GUI::VerticalBoxLayout>(GUI::Margins {}, 0);
     auto& board_widget = board_widget_container.add<BoardWidget>(board_rows, board_columns);
+    board_widget.set_focus_policy(GUI::FocusPolicy::StrongFocus);
+    board_widget.set_focus(true);
     board_widget.randomize_cells();
     board_widget.set_min_size(board_columns, board_rows);
 

--- a/Userland/Libraries/LibGUI/Statusbar.h
+++ b/Userland/Libraries/LibGUI/Statusbar.h
@@ -63,6 +63,7 @@ public:
     };
 
     Segment& segment(size_t index) { return m_segments.at(index); }
+    void set_segment_count(size_t);
 
 protected:
     explicit Statusbar(int segment_count = 1);
@@ -70,7 +71,6 @@ protected:
     virtual void resize_event(ResizeEvent&) override;
 
 private:
-    void set_segment_count(size_t);
     size_t segment_count() const { return m_segments.size(); }
     void update_segment(size_t);
     NonnullRefPtr<Segment> create_segment();


### PR DESCRIPTION
This PR makes the following changes to `GameOfLife`:
* The GML compiler is now used to construct the main widget. This required a small change to LibGUI to make `Statusbar::set_segment_count` public so that the GML compiler can use it. Making this method public also allows the segement count to be changed at runtime.
* The game board is now in focus on startup. Interacting with the game board now sets focus on it. This makes single key shortcuts work again.
* Pressing escape with a pattern selected now clears that pattern.