### PR TITLE
LibGUI: Don't enter TableView edit mode when a control key is pressed

### DIFF
--- a/Userland/Libraries/LibGUI/TableView.cpp
+++ b/Userland/Libraries/LibGUI/TableView.cpp
@@ -194,8 +194,8 @@ void TableView::keydown_event(KeyEvent& event)
     auto is_delete = event.key() == Key_Delete;
     auto is_backspace = event.key() == Key_Backspace;
     auto is_clear = is_delete || is_backspace;
-    auto has_ctrl = event.modifiers() & KeyModifier::Mod_Ctrl;
-    if (is_editable() && edit_triggers() & EditTrigger::AnyKeyPressed && (event.code_point() != 0 || is_clear) && !has_ctrl) {
+    auto is_control_character = is_ascii_c0_control(event.code_point());
+    if (is_editable() && edit_triggers() & EditTrigger::AnyKeyPressed && !event.ctrl() && (!is_control_character || is_clear)) {
         begin_editing(cursor_index());
         if (m_editing_delegate) {
             if (is_delete) {


### PR DESCRIPTION
This PR attempts to solve the same issue as #19800.

A key press, which is an ASCII control character will no longer cause
TableView to begin editing.

This fixes an issue in Spreadsheet where navigating to a cell then pressing escape would cause a that cell's text to be set to a non-printable value.

I couldn't find any other key (on my keyboard) that causes a non-printable character to be printed in Spreadsheet. This solution may not work for non-ascii, non-printable, non-control characters :shrug:.