### PR TITLE
LibWeb: Incorrect font selection for SerenityOS bitmap fonts

### DIFF
--- a/Tests/LibWeb/Layout/expected/css-bitmap-font-inherit.txt
+++ b/Tests/LibWeb/Layout/expected/css-bitmap-font-inherit.txt
@@ -1,0 +1,23 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <(anonymous)> at (0,0) content-size 800x0 children: inline
+      TextNode <#text>
+    BlockContainer <body> at (8,13) content-size 784x17 children: not-inline
+      BlockContainer <(anonymous)> at (8,13) content-size 784x0 children: inline
+        TextNode <#text>
+      BlockContainer <p> at (8,13) content-size 784x17 children: inline
+        line 0 width: 30, height: 17, bottom: 17, baseline: 11
+          frag 0 from TextNode start: 0, length: 5, rect: [8,13 30x17]
+            "Hello"
+        TextNode <#text>
+      BlockContainer <(anonymous)> at (8,43) content-size 784x0 children: inline
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer(anonymous)) [0,0 800x0]
+    PaintableWithLines (BlockContainer<BODY>) [8,13 784x17] overflow: [8,13 784x30]
+      PaintableWithLines (BlockContainer(anonymous)) [8,13 784x0]
+      PaintableWithLines (BlockContainer<P>) [8,13 784x17]
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,43 784x0]

--- a/Tests/LibWeb/Layout/input/css-bitmap-font-inherit.html
+++ b/Tests/LibWeb/Layout/input/css-bitmap-font-inherit.html
@@ -1,0 +1,13 @@
+<html>
+<head>
+<style>
+body {
+    font-family: Katica;
+    font-size: 13px;
+}
+</style>
+</head>
+<body>
+    <p>Hello</p>
+<body>
+</html>

--- a/Userland/Libraries/LibGfx/Font/FontDatabase.cpp
+++ b/Userland/Libraries/LibGfx/Font/FontDatabase.cpp
@@ -270,4 +270,14 @@ void FontDatabase::for_each_typeface_with_family_name(FlyString const& family_na
         callback(*typeface);
 }
 
+bool FontDatabase::is_bitmap_family(FlyString const& family_name)
+{
+    auto it = m_private->typefaces.find(family_name);
+    if (it != m_private->typefaces.end()) {
+        for (auto const& typeface : it->value)
+            return typeface->is_fixed_size();
+    }
+    return false;
+}
+
 }

--- a/Userland/Libraries/LibGfx/Font/FontDatabase.h
+++ b/Userland/Libraries/LibGfx/Font/FontDatabase.h
@@ -58,6 +58,8 @@ public:
     void for_each_typeface(Function<void(Typeface const&)>);
     void for_each_typeface_with_family_name(FlyString const& family_name, Function<void(Typeface const&)>);
 
+    bool is_bitmap_family(FlyString const& family_name);
+
     void load_all_fonts_from_path(DeprecatedString const&);
 
 private:

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -1757,7 +1757,6 @@ RefPtr<Gfx::Font const> StyleComputer::compute_font_for_style_values(DOM::Elemen
         if (font_size.is_percentage()) {
             // Percentages refer to parent element's font size
             maybe_length = Length::make_px(CSSPixels::nearest_value_for(font_size.as_percentage().percentage().as_fraction() * parent_font_size().to_double()));
-
         } else if (font_size.is_length()) {
             maybe_length = font_size.as_length().length();
         } else if (font_size.is_calculated()) {
@@ -1776,9 +1775,11 @@ RefPtr<Gfx::Font const> StyleComputer::compute_font_for_style_values(DOM::Elemen
     FontSelector font_selector;
     bool monospace = false;
 
-    float const font_size_in_pt = font_size_in_px * 0.75f;
+    float font_size_in_pt = font_size_in_px * (POINTS_PER_INCH / DEFAULT_DPI);
 
     auto find_font = [&](FlyString const& family) -> RefPtr<Gfx::Font const> {
+        if (Gfx::FontDatabase::the().is_bitmap_family(family))
+            font_size_in_pt = font_size_in_px * 1.0f;
         font_selector = { family, font_size_in_pt, weight, width, slope };
 
         FontFaceKey key {


### PR DESCRIPTION
To find a suitable font in `StyleComputer::compute_font_for_style_values` we compute `font_size_in_px` and then convert this size from px to pt using this assumed conversion factor:
```
    float const font_size_in_pt = font_size_in_px * 0.75f;
```
While that seems to hold for vector fonts, it doesn't hold for SerenityOS bitmap fonts.

For example "Katica Regular 10" has a pixel_size of 10 and point_size of 10. 

For bitmap fonts it seems safer to use a factor of 1.0 when converting from px to pt to avoid selecting an incorrect font during font computation. 

This factor holds for most SerenityOS bitmap fonts (.font), except for "Katica Regular 12", which has a pixel_size of 13 and point_size of 12. However, font selection is still done correctly as the best match for a font with a now computed point_size of 13 is "Katica Regular 12". Without the proposed patch we would have calculated a `font_size_in_pt` of 9.75 and incorrectly selected "Katica Regular 10" as the paragraph tag's computed font.

For the attached test case:
```
<html>
<head>
<style>
body {
    font-family: Katica;
    font-size: 13px;
}
</style>
</head>
<body>
    <p>Hello</p>
<body>
</html>
```
Before:
![before_font](https://github.com/SerenityOS/serenity/assets/7834601/6f51958d-54a8-4745-999a-30c1d99eb46e)

After:
![after_font](https://github.com/SerenityOS/serenity/assets/7834601/a159d29d-54b1-4e72-890a-1b547577fe20)
