### PR TITLE
Assistant: Remember currently selected result when updating results

### DIFF
--- a/Userland/Applications/Assistant/main.cpp
+++ b/Userland/Applications/Assistant/main.cpp
@@ -262,10 +262,18 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     }));
 
     db.on_new_results = [&](auto results) {
-        if (results.is_empty())
+        if (results.is_empty()) {
             app_state.selected_index = {};
-        else
+        } else if (app_state.selected_index.has_value()) {
+            auto current_selected_result = app_state.results[app_state.selected_index.value()];
+            auto new_selected_index = results.find_first_index(current_selected_result).value_or(0);
+            if (new_selected_index >= Assistant::MAX_SEARCH_RESULTS) {
+                new_selected_index = 0;
+            }
+            app_state.selected_index = new_selected_index;
+        } else {
             app_state.selected_index = 0;
+        }
         app_state.results = results;
         app_state.visible_result_count = min(results.size(), Assistant::MAX_SEARCH_RESULTS);
 

--- a/Userland/Applications/Assistant/main.cpp
+++ b/Userland/Applications/Assistant/main.cpp
@@ -84,7 +84,7 @@ public:
     {
     }
 
-    Function<void(Vector<NonnullRefPtr<Result const>>)> on_new_results;
+    Function<void(Vector<NonnullRefPtr<Result const>>&&)> on_new_results;
 
     void search(DeprecatedString const& query)
     {
@@ -131,7 +131,7 @@ private:
             return a->score() > b->score();
         });
 
-        on_new_results(all_results);
+        on_new_results(move(all_results));
     }
 
     AppState& m_state;


### PR DESCRIPTION
This fixes an issue in Assistant where the selected result index would be reset to 0 when the file cache finished building and the results list updated.

Tested with the following steps:
1. Enter 'A' as a query (or anything really).
2. Quickly press the down arrow to select the second result.
3. Wait a moment for the file cache to finish building.
4. The second result should remain selected. Previously, the selected result would change back to the first one.