### PR TITLE
LibWeb: Handle the NavigationHistoryEntries for the navigation API 

### DIFF
--- a/Tests/LibWeb/Text/expected/HTML/Navigation-object-properties.txt
+++ b/Tests/LibWeb/Text/expected/HTML/Navigation-object-properties.txt
@@ -1,5 +1,5 @@
-entries is empty: true
-currentEntry is null: true
+entries[length - 1] is current entry: true
+currentEntry is a [object NavigationHistoryEntry]
 transition is null: true
-canGoBack: false
-canGoForward: false
+canGoBack: true
+canGoForward: true

--- a/Tests/LibWeb/Text/expected/navigation/navigation-navigate.txt
+++ b/Tests/LibWeb/Text/expected/navigation/navigation-navigate.txt
@@ -1,0 +1,7 @@
+  Initial history length is 1
+NavigateEvent for Push navigation-navigate-iframe.html#1 (Same document? true) with info: 42
+currententrychange for change to navigation-navigate-iframe.html#1 of type Push from navigation-navigate-iframe.html
+Committed to navigation to navigation-navigate-iframe.html#1
+Finished navigation to navigation-navigate-iframe.html#1
+History length after navigate is 2
+DONE

--- a/Tests/LibWeb/Text/input/HTML/Navigation-object-properties.html
+++ b/Tests/LibWeb/Text/input/HTML/Navigation-object-properties.html
@@ -3,10 +3,10 @@
     test(() => {
         let n = window.navigation;
 
-        // FIXME: Once we set up the interaction between Navigables and Navigation,
-        //        These two should become 1 and [object NavigationHistoryEntry], respectively
-        println(`entries is empty: ${n.entries().length == 0}`);
-        println(`currentEntry is null: ${n.currentEntry == null}`);
+        let len = n.entries().length;
+
+        println(`entries[length - 1] is current entry: ${n.entries()[len - 1] === n.currentEntry}`);
+        println(`currentEntry is a ${n.currentEntry}`);
 
         println(`transition is null: ${n.transition == null}`);
         println(`canGoBack: ${n.canGoBack}`);

--- a/Tests/LibWeb/Text/input/include.js
+++ b/Tests/LibWeb/Text/input/include.js
@@ -1,4 +1,9 @@
 var __outputElement = null;
+if (internals === undefined) {
+    var internals = {
+        signalTextTestIsDone: () => undefined,
+    };
+}
 
 function println(s) {
     __outputElement.appendChild(document.createTextNode(s + "\n"));

--- a/Tests/LibWeb/Text/input/navigation/navigation-navigate-iframe.html
+++ b/Tests/LibWeb/Text/input/navigation/navigation-navigate-iframe.html
@@ -1,0 +1,83 @@
+<script src="../include.js"></script>
+<script>
+    function filename(path) {
+        url = new URL(path)
+        return url.pathname.split('/').pop() + url.hash
+    }
+    asyncTest(async done => {
+    if (window.self === window.top) {
+        test(() => {});
+        return;
+    }
+
+    try {
+        parent.postMessage(`Initial history length is ${navigation.entries().length}`, "*");
+
+        navigation.oncurrententrychange = (e) => {
+            parent.postMessage(`${e.type} for change to ${filename(navigation.currentEntry.url)} of type ${e.navigationType} from ${filename(e.from.url)}`, "*");
+        }
+
+        navigation.onnavigate = (e) => {
+            parent.postMessage(`NavigateEvent for ${e.navigationType} ${filename(e.destination.url)} (Same document? ${e.destination.sameDocument}) with info: ${e.info}`, "*")
+        }
+
+        // Navigate to fragment
+        let a = navigation.navigate("navigation-navigate-iframe.html#1", { info: 42, history: "push" });
+
+        await a.committed.then((f) => {
+           parent.postMessage(`Committed to navigation to ${filename(f.url)}`, "*");
+        },
+        (e) => {
+            parent.postMessage("ERROR:" + e, "*", "*");
+        })
+
+        await a.finished.then((f) => {
+           parent.postMessage(`Finished navigation to ${filename(f.url)}`, "*");
+        },
+        (e) => {
+            parent.postMessage("ERROR:" + e, "*");
+        })
+
+        parent.postMessage(`History length after navigate is ${navigation.entries().length}`, "*");
+
+        // FIXME: Enable these tests 😅
+        // Navigate backwards
+        // let b = navigation.back()
+        // await b.committed.then((f) => {
+        //    parent.postMessage(`Committed to back navigation to ${filename(f.url)}`, "*");
+        // },
+        // (e) => {
+        //     parent.postMessage("ERROR:" + e, "*", "*");
+        // })
+        // await b.finished.then((f) => {
+        //    parent.postMessage(`Finished back navigation to ${filename(f.url)}`, "*");
+        // },
+        // (e) => {
+        //     parent.postMessage("ERROR:" + e, "*");
+        // })
+
+        // parent.postMessage(`History length after back is ${navigation.entries().length}`, "*");
+
+        // Navigate forwards
+        // let c = navigation.forward()
+        // await c.committed.then((f) => {
+        //    parent.postMessage(`Committed to forward navigation to ${filename(f.url)}`, "*");
+        // },
+        // (e) => {
+        //     parent.postMessage("ERROR:" + e, "*", "*");
+        // })
+        // await c.finished.then((f) => {
+        //    parent.postMessage(`Finished forward navigation to ${filename(f.url)}`, "*");
+        // },
+        // (e) => {
+        //     parent.postMessage("ERROR:" + e, "*");
+        // })
+
+        // parent.postMessage(`History length after forward is ${navigation.entries().length}`, "*");
+        
+    } catch (e) {
+        parent.postMessage("ERROR:" + e, "*");
+    }
+    parent.postMessage("DONE", "*");
+    });
+</script>

--- a/Tests/LibWeb/Text/input/navigation/navigation-navigate.html
+++ b/Tests/LibWeb/Text/input/navigation/navigation-navigate.html
@@ -1,0 +1,24 @@
+<script src="../include.js"></script>
+<iframe id="testIframe" src="about:blank"></iframe>
+<script>
+    asyncTest(async done => {
+        const iframe = document.getElementById("testIframe");
+
+        function navigateIframe(src) {
+            return new Promise(resolve => {
+                iframe.addEventListener("load", () => {
+                    resolve();
+                });
+                iframe.src = src;
+            });
+        }
+
+        window.addEventListener("message", event => {
+            println(event.data);
+            if (event.data === "DONE")
+                done();
+        });
+
+        await navigateIframe("./navigation-navigate-iframe.html");
+    }); 
+</script>

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -1777,7 +1777,7 @@ Element* Document::find_a_potential_indicated_element(FlyString const& fragment)
 
     // 2. If there is an a element in the document tree whose root is document that has a name attribute
     //    whose value is equal to fragment, then return the first such element in tree order.
-    Element* element_with_name;
+    Element* element_with_name = nullptr;
     root().for_each_in_subtree_of_type<Element>([&](Element const& element) {
         if (element.attribute(HTML::AttributeNames::name) == fragment) {
             element_with_name = const_cast<Element*>(&element);

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -71,6 +71,7 @@
 #include <LibWeb/HTML/Location.h>
 #include <LibWeb/HTML/MessageEvent.h>
 #include <LibWeb/HTML/Navigable.h>
+#include <LibWeb/HTML/Navigation.h>
 #include <LibWeb/HTML/NavigationParams.h>
 #include <LibWeb/HTML/Numbers.h>
 #include <LibWeb/HTML/Origin.h>
@@ -3544,7 +3545,7 @@ void Document::restore_the_history_object_state(JS::NonnullGCPtr<HTML::SessionHi
 }
 
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#update-document-for-history-step-application
-void Document::update_for_history_step_application(JS::NonnullGCPtr<HTML::SessionHistoryEntry> entry, bool do_not_reactive, size_t script_history_length, size_t script_history_index)
+void Document::update_for_history_step_application(JS::NonnullGCPtr<HTML::SessionHistoryEntry> entry, bool do_not_reactivate, size_t script_history_length, size_t script_history_index, Optional<Vector<JS::NonnullGCPtr<HTML::SessionHistoryEntry>>> entries_for_navigation_api, bool update_navigation_api)
 {
     // 1. Let documentIsNew be true if document's latest entry is null; otherwise false.
     auto document_is_new = !m_latest_entry;
@@ -3559,8 +3560,52 @@ void Document::update_for_history_step_application(JS::NonnullGCPtr<HTML::Sessio
     history()->m_length = script_history_length;
 
     // 5. If documentsEntryChanged is true, then:
+    // NOTE: documentsEntryChanged can be false for one of two reasons: either we are restoring from bfcache,
+    //      or we are asynchronously finishing up a synchronous navigation which already synchronously set document's latest entry.
+    //      The doNotReactivate argument distinguishes between these two cases.
     if (documents_entry_changed) {
-        // FIXME: Implement this.
+        // 1. Let oldURL be document's latest entry's URL.
+        auto old_url = m_latest_entry ? m_latest_entry->url : AK::URL {};
+
+        // 2. Set document's latest entry to entry.
+        m_latest_entry = entry;
+
+        // 3. Restore the history object state given document and entry.
+        restore_the_history_object_state(entry);
+
+        // 4. Let navigation be history's relevant global object's navigation API.
+        auto navigation = verify_cast<HTML::Window>(HTML::relevant_global_object(*this)).navigation();
+
+        // 5. If documentIsNew is false, then:
+        if (!document_is_new) {
+            // AD HOC: Skip this in situations the spec steps don't account for
+            if (update_navigation_api) {
+                // 1. Update the navigation API entries for a same-document navigation given navigation, entry, and "traverse".
+                navigation->update_the_navigation_api_entries_for_a_same_document_navigation(entry, Bindings::NavigationType::Traverse);
+            }
+
+            // FIXME: 2. Fire an event named popstate at document's relevant global object, using PopStateEvent,
+            //           with the state attribute initialized to document's history object's state and hasUAVisualTransition initialized to true
+            //           if a visual transition, to display a cached rendered state of the latest entry, was done by the user agent.
+
+            // FIXME: 3. Restore persisted state given entry.
+
+            // FIXME: 4. If oldURL's fragment is not equal to entry's URL's fragment, then queue a global task on the DOM manipulation task source
+            //           given document's relevant global object to fire an event named hashchange at document's relevant global object,
+            //           using HashChangeEvent, with the oldURL attribute initialized to the serialization of oldURL and the newURL attribute
+            //           initialized to the serialization of entry's URL.
+        }
+
+        // 6. Otherwise:
+        else {
+            // 1. Assert: entriesForNavigationAPI is given.
+            VERIFY(entries_for_navigation_api.has_value());
+
+            // FIXME: 2. Restore persisted state given entry.
+
+            // 3. Initialize the navigation API entries for a new document given navigation, entriesForNavigationAPI, and entry.
+            navigation->initialize_the_navigation_api_entries_for_a_new_document(*entries_for_navigation_api, entry);
+        }
     }
 
     // 6. If documentIsNew is true, then:
@@ -3570,7 +3615,8 @@ void Document::update_for_history_step_application(JS::NonnullGCPtr<HTML::Sessio
     }
 
     // 7. Otherwise, if documentsEntryChanged is false and doNotReactivate is false, then:
-    if (!documents_entry_changed && !do_not_reactive) {
+    // NOTE: This is for bfcache restoration
+    if (!documents_entry_changed && !do_not_reactivate) {
         // FIXME: 1. Assert: entriesForNavigationAPI is given.
         // FIXME: 2. Reactivate document given entry and entriesForNavigationAPI.
     }

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -3528,6 +3528,21 @@ Painting::ViewportPaintable* Document::paintable()
     return static_cast<Painting::ViewportPaintable*>(Node::paintable());
 }
 
+// https://html.spec.whatwg.org/multipage/browsing-the-web.html#restore-the-history-object-state
+void Document::restore_the_history_object_state(JS::NonnullGCPtr<HTML::SessionHistoryEntry> entry)
+{
+    // 1. Let targetRealm be document's relevant realm.
+    auto& target_realm = HTML::relevant_realm(*this);
+
+    // 2. Let state be StructuredDeserialize(entry's classic history API state, targetRealm). If this throws an exception, catch it and let state be null.
+    // 3. Set document's history object's state to state.
+    auto state_or_error = HTML::structured_deserialize(target_realm.vm(), entry->classic_history_api_state, target_realm, {});
+    if (state_or_error.is_error())
+        m_history->set_state(JS::js_null());
+    else
+        m_history->set_state(state_or_error.release_value());
+}
+
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#update-document-for-history-step-application
 void Document::update_for_history_step_application(JS::NonnullGCPtr<HTML::SessionHistoryEntry> entry, bool do_not_reactive, size_t script_history_length, size_t script_history_index)
 {

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -530,15 +530,19 @@ public:
 
     HTML::SourceSnapshotParams snapshot_source_snapshot_params() const;
 
-    void update_for_history_step_application(JS::NonnullGCPtr<HTML::SessionHistoryEntry>, bool do_not_reactive, size_t script_history_length, size_t script_history_index);
+    void update_for_history_step_application(JS::NonnullGCPtr<HTML::SessionHistoryEntry>, bool do_not_reactivate, size_t script_history_length, size_t script_history_index, Optional<Vector<JS::NonnullGCPtr<HTML::SessionHistoryEntry>>> entries_for_navigation_api = {}, bool update_navigation_api = true);
 
     HashMap<AK::URL, HTML::SharedImageRequest*>& shared_image_requests();
+
     void restore_the_history_object_state(JS::NonnullGCPtr<HTML::SessionHistoryEntry> entry);
 
     JS::NonnullGCPtr<Animations::DocumentTimeline> timeline();
 
     void associate_with_timeline(JS::NonnullGCPtr<Animations::AnimationTimeline>);
     void disassociate_with_timeline(JS::NonnullGCPtr<Animations::AnimationTimeline>);
+
+    JS::GCPtr<HTML::SessionHistoryEntry> latest_entry() const { return m_latest_entry; }
+    void set_latest_entry(JS::GCPtr<HTML::SessionHistoryEntry> e) { m_latest_entry = e; }
 
 protected:
     virtual void initialize(JS::Realm&) override;

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -533,6 +533,7 @@ public:
     void update_for_history_step_application(JS::NonnullGCPtr<HTML::SessionHistoryEntry>, bool do_not_reactive, size_t script_history_length, size_t script_history_index);
 
     HashMap<AK::URL, HTML::SharedImageRequest*>& shared_image_requests();
+    void restore_the_history_object_state(JS::NonnullGCPtr<HTML::SessionHistoryEntry> entry);
 
     JS::NonnullGCPtr<Animations::DocumentTimeline> timeline();
 

--- a/Userland/Libraries/LibWeb/HTML/History.cpp
+++ b/Userland/Libraries/LibWeb/HTML/History.cpp
@@ -35,7 +35,8 @@ void History::initialize(JS::Realm& realm)
 void History::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(m_associated_document.ptr());
+    visitor.visit(m_associated_document);
+    visitor.visit(m_state);
 }
 
 // https://html.spec.whatwg.org/multipage/history.html#dom-history-pushstate
@@ -61,6 +62,17 @@ WebIDL::ExceptionOr<u64> History::length() const
 
     // 2. Return this's length.
     return m_length;
+}
+
+// https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-history-state
+WebIDL::ExceptionOr<JS::Value> History::state() const
+{
+    // 1. If this's relevant global object's associated Document is not fully active, then throw a "SecurityError" DOMException.
+    if (!m_associated_document->is_fully_active())
+        return WebIDL::SecurityError::create(realm(), "Cannot perform state on a document that isn't fully active."_fly_string);
+
+    // 2. Return this's state.
+    return m_state;
 }
 
 // https://html.spec.whatwg.org/multipage/history.html#dom-history-go

--- a/Userland/Libraries/LibWeb/HTML/History.cpp
+++ b/Userland/Libraries/LibWeb/HTML/History.cpp
@@ -158,8 +158,10 @@ bool can_have_its_url_rewritten(DOM::Document const& document, AK::URL const& ta
 }
 
 // https://html.spec.whatwg.org/multipage/history.html#shared-history-push/replace-state-steps
-WebIDL::ExceptionOr<void> History::shared_history_push_replace_state(JS::Value value, Optional<String> const& url, HistoryHandlingBehavior history_handling)
+WebIDL::ExceptionOr<void> History::shared_history_push_replace_state(JS::Value data, Optional<String> const& url, HistoryHandlingBehavior history_handling)
 {
+    auto& vm = this->vm();
+
     // 1. Let document be history's associated Document.
     auto& document = m_associated_document;
 
@@ -173,7 +175,8 @@ WebIDL::ExceptionOr<void> History::shared_history_push_replace_state(JS::Value v
     // 4. Let serializedData be StructuredSerializeForStorage(data). Rethrow any exceptions.
     //    FIXME: Actually rethrow exceptions here once we start using the serialized data.
     //           Throwing here on data types we don't yet serialize will regress sites that use push/replaceState.
-    [[maybe_unused]] auto serialized_data_or_error = structured_serialize_for_storage(vm(), value);
+    auto serialized_data_or_error = structured_serialize_for_storage(vm, data);
+    auto serialized_data = serialized_data_or_error.is_error() ? MUST(structured_serialize_for_storage(vm, JS::js_null())) : serialized_data_or_error.release_value();
 
     // 5. Let newURL be document's URL.
     auto new_url = document->url();
@@ -210,7 +213,7 @@ WebIDL::ExceptionOr<void> History::shared_history_push_replace_state(JS::Value v
 
     // 10. Run the URL and history update steps given document and newURL, with serializedData set to
     //     serializedData and historyHandling set to historyHandling.
-    perform_url_and_history_update_steps(document, new_url, history_handling);
+    perform_url_and_history_update_steps(document, new_url, serialized_data, history_handling);
 
     return {};
 }

--- a/Userland/Libraries/LibWeb/HTML/History.h
+++ b/Userland/Libraries/LibWeb/HTML/History.h
@@ -27,9 +27,12 @@ public:
     WebIDL::ExceptionOr<void> back();
     WebIDL::ExceptionOr<void> forward();
     WebIDL::ExceptionOr<u64> length() const;
+    WebIDL::ExceptionOr<JS::Value> state() const;
 
     u64 m_index { 0 };
     u64 m_length { 0 };
+
+    void set_state(JS::Value s) { m_state = s; }
 
 private:
     History(JS::Realm&, DOM::Document&);
@@ -40,6 +43,7 @@ private:
     WebIDL::ExceptionOr<void> shared_history_push_replace_state(JS::Value data, Optional<String> const& url, HistoryHandlingBehavior);
 
     JS::NonnullGCPtr<DOM::Document> m_associated_document;
+    JS::Value m_state { JS::js_null() };
 };
 
 bool can_have_its_url_rewritten(DOM::Document const& document, AK::URL const& target_url);

--- a/Userland/Libraries/LibWeb/HTML/History.idl
+++ b/Userland/Libraries/LibWeb/HTML/History.idl
@@ -3,7 +3,7 @@
 interface History {
     readonly attribute unsigned long length;
     // FIXME: attribute ScrollRestoration scrollRestoration;
-    // FIXME: readonly attribute any state;
+    readonly attribute any state;
     undefined go(optional long delta = 0);
     undefined back();
     undefined forward();

--- a/Userland/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Navigable.cpp
@@ -1388,17 +1388,13 @@ WebIDL::ExceptionOr<void> Navigable::navigate_to_a_fragment(AK::URL const& url, 
     auto traversable = traversable_navigable();
 
     // 17. Append the following session history synchronous navigation steps involving navigable to traversable:
-    traversable->append_session_history_traversal_steps([this, traversable, history_entry, entry_to_replace, navigation_id] {
-        if (this->ongoing_navigation() != navigation_id) {
-            // NOTE: This check is not in the spec but we should not continue navigation if ongoing navigation id has changed.
-            return;
-        }
-
+    traversable->append_session_history_synchronous_navigation_steps(*this, [this, traversable, history_entry, entry_to_replace, navigation_id] {
         // 1. Finalize a same-document navigation given traversable, navigable, historyEntry, and entryToReplace.
         finalize_a_same_document_navigation(*traversable, *this, history_entry, entry_to_replace);
 
         // FIXME: 2. Invoke WebDriver BiDi fragment navigated with navigable's active browsing context and a new WebDriver BiDi
         //            navigation status whose id is navigationId, url is url, and status is "complete".
+        (void)navigation_id;
     });
 
     return {};
@@ -1804,7 +1800,7 @@ void perform_url_and_history_update_steps(DOM::Document& document, AK::URL new_u
     auto traversable = navigable->traversable_navigable();
 
     // 13. Append the following session history synchronous navigation steps involving navigable to traversable:
-    traversable->append_session_history_traversal_steps([traversable, navigable, new_entry, entry_to_replace] {
+    traversable->append_session_history_synchronous_navigation_steps(*navigable, [traversable, navigable, new_entry, entry_to_replace] {
         // 1. Finalize a same-document navigation given traversable, navigable, newEntry, and entryToReplace.
         finalize_a_same_document_navigation(*traversable, *navigable, new_entry, entry_to_replace);
     });

--- a/Userland/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Navigable.cpp
@@ -1156,8 +1156,8 @@ WebIDL::ExceptionOr<void> Navigable::navigate(NavigateParams params)
         && !response
         && url.equals(active_session_history_entry()->url, AK::URL::ExcludeFragment::Yes)
         && url.fragment().has_value()) {
-        // 1. Navigate to a fragment given navigable, url, historyHandling, and navigationId.
-        TRY(navigate_to_a_fragment(url, to_history_handling_behavior(history_handling), navigation_id));
+        // 1. Navigate to a fragment given navigable, url, historyHandling, userInvolvement, navigationAPIState, and navigationId.
+        TRY(navigate_to_a_fragment(url, to_history_handling_behavior(history_handling), user_involvement, navigation_api_state, navigation_id));
 
         traversable_navigable()->process_session_history_traversal_queue();
 
@@ -1283,14 +1283,14 @@ WebIDL::ExceptionOr<void> Navigable::navigate(NavigateParams params)
         history_entry->url = url;
         history_entry->document_state = document_state;
 
-        // 8. Let navigationParams be null.
+        // 7. Let navigationParams be null.
         Variant<Empty, NavigationParams, NonFetchSchemeNavigationParams> navigation_params = Empty {};
 
-        // FIXME: 9. If response is non-null:
+        // FIXME: 8. If response is non-null:
         if (response) {
         }
 
-        // 10. Attempt to populate the history entry's document
+        // 9. Attempt to populate the history entry's document
         //     for historyEntry, given navigable, "navigate", sourceSnapshotParams,
         //     targetSnapshotParams, navigationId, navigationParams, cspNavigationType, with allowPOST
         //     set to true and completionSteps set to the following step:
@@ -1313,16 +1313,26 @@ WebIDL::ExceptionOr<void> Navigable::navigate(NavigateParams params)
     return {};
 }
 
-WebIDL::ExceptionOr<void> Navigable::navigate_to_a_fragment(AK::URL const& url, HistoryHandlingBehavior history_handling, String navigation_id)
+// https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate-fragid
+WebIDL::ExceptionOr<void> Navigable::navigate_to_a_fragment(AK::URL const& url, HistoryHandlingBehavior history_handling, UserNavigationInvolvement user_involvement, Optional<SerializationRecord> navigation_api_state, String navigation_id)
 {
     (void)navigation_id;
 
-    // FIXME: 1. Let navigation be navigable's active window's navigation API.
-    // FIXME: 2. Let destinationNavigationAPIState be navigable's active session history entry's navigation API state.
-    // FIXME: 3. If navigationAPIState is not null, then set destinationNavigationAPIState to navigationAPIState.
-    // FIXME: 4. Let continue be the result of firing a push/replace/reload navigate event at navigation with navigationType set to historyHandling, isSameDocument set to true,
-    //           userInvolvement set to userInvolvement, and destinationURL set to url, and navigationAPIState set to destinationNavigationAPIState.
-    // FIXME: 5. If continue is false, then return.
+    // 1. Let navigation be navigable's active window's navigation API.
+    auto navigation = active_window()->navigation();
+
+    // 2. Let destinationNavigationAPIState be navigable's active session history entry's navigation API state.
+    // 3. If navigationAPIState is not null, then set destinationNavigationAPIState to navigationAPIState.
+    auto destination_navigation_api_state = navigation_api_state.has_value() ? *navigation_api_state : active_session_history_entry()->navigation_api_state;
+
+    // 4. Let continue be the result of firing a push/replace/reload navigate event at navigation with navigationType set to historyHandling, isSameDocument set to true,
+    //    userInvolvement set to userInvolvement, and destinationURL set to url, and navigationAPIState set to destinationNavigationAPIState.
+    auto navigation_type = history_handling == HistoryHandlingBehavior::Push ? Bindings::NavigationType::Push : Bindings::NavigationType::Replace;
+    bool const continue_ = navigation->fire_a_push_replace_reload_navigate_event(navigation_type, url, true, user_involvement, {}, destination_navigation_api_state);
+
+    // 5. If continue is false, then return.
+    if (!continue_)
+        return {};
 
     // 6. Let historyEntry be a new session history entry, with
     //      URL: url
@@ -1332,6 +1342,7 @@ WebIDL::ExceptionOr<void> Navigable::navigate_to_a_fragment(AK::URL const& url, 
     JS::NonnullGCPtr<SessionHistoryEntry> history_entry = heap().allocate_without_realm<SessionHistoryEntry>();
     history_entry->url = url;
     history_entry->document_state = active_session_history_entry()->document_state;
+    history_entry->navigation_api_state = destination_navigation_api_state;
     history_entry->scroll_restoration_mode = active_session_history_entry()->scroll_restoration_mode;
 
     // 7. Let entryToReplace be navigable's active session history entry if historyHandling is "replace", otherwise null.
@@ -1348,7 +1359,8 @@ WebIDL::ExceptionOr<void> Navigable::navigate_to_a_fragment(AK::URL const& url, 
 
     // 11. If historyHandling is "push", then:
     if (history_handling == HistoryHandlingBehavior::Push) {
-        // FIXME: 1. Set history's state to null.
+        // 1. Set history's state to null.
+        history->set_state(JS::js_null());
 
         // 2. Increment scriptHistoryIndex.
         script_history_index++;
@@ -1361,9 +1373,11 @@ WebIDL::ExceptionOr<void> Navigable::navigate_to_a_fragment(AK::URL const& url, 
     m_active_session_history_entry = history_entry;
 
     // 13. Update document for history step application given navigable's active document, historyEntry, true, scriptHistoryIndex, and scriptHistoryLength.
-    active_document()->update_for_history_step_application(*history_entry, true, script_history_length, script_history_index);
+    // AD HOC: Skip updating the navigation api entries twice here
+    active_document()->update_for_history_step_application(*history_entry, true, script_history_length, script_history_index, {}, false);
 
-    // FIXME: 14. Update the navigation API entries for a same-document navigation given navigation, historyEntry, and historyHandling.
+    // 14. Update the navigation API entries for a same-document navigation given navigation, historyEntry, and historyHandling.
+    navigation->update_the_navigation_api_entries_for_a_same_document_navigation(history_entry, navigation_type);
 
     // 15. Scroll to the fragment given navigable's active document.
     // FIXME: Specification doesn't say when document url needs to update during fragment navigation
@@ -1730,7 +1744,7 @@ void finalize_a_cross_document_navigation(JS::NonnullGCPtr<Navigable> navigable,
 }
 
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#url-and-history-update-steps
-void perform_url_and_history_update_steps(DOM::Document& document, AK::URL new_url, HistoryHandlingBehavior history_handling)
+void perform_url_and_history_update_steps(DOM::Document& document, AK::URL new_url, Optional<SerializationRecord> serialized_data, HistoryHandlingBehavior history_handling)
 {
     // 1. Let navigable be document's node navigable.
     auto navigable = document.navigable();
@@ -1738,14 +1752,16 @@ void perform_url_and_history_update_steps(DOM::Document& document, AK::URL new_u
     // 2. Let activeEntry be navigable's active session history entry.
     auto active_entry = navigable->active_session_history_entry();
 
+    // FIXME: Spec should be updated to say "classic history api state" instead of serialized state
     // 3. Let newEntry be a new session history entry, with
     //      URL: newURL
     //      serialized state: if serializedData is not null, serializedData; otherwise activeEntry's classic history API state
     //      document state: activeEntry's document state
     //      scroll restoration mode: activeEntry's scroll restoration mode
-    //      persisted user state: activeEntry's persisted user state
+    // FIXME: persisted user state: activeEntry's persisted user state
     JS::NonnullGCPtr<SessionHistoryEntry> new_entry = document.heap().allocate_without_realm<SessionHistoryEntry>();
     new_entry->url = new_url;
+    new_entry->classic_history_api_state = serialized_data.value_or(active_entry->classic_history_api_state);
     new_entry->document_state = active_entry->document_state;
     new_entry->scroll_restoration_mode = active_entry->scroll_restoration_mode;
 
@@ -1766,17 +1782,23 @@ void perform_url_and_history_update_steps(DOM::Document& document, AK::URL new_u
         document.history()->m_length = document.history()->m_index + 1;
     }
 
-    // FIXME: 7. If serializedData is not null, then restore the history object state given document and newEntry.
+    // If serializedData is not null, then restore the history object state given document and newEntry.
+    if (serialized_data.has_value())
+        document.restore_the_history_object_state(new_entry);
 
     // 8. Set document's URL to newURL.
     document.set_url(new_url);
 
-    // FIXME: 9. Set document's latest entry to newEntry.
+    // 9. Set document's latest entry to newEntry.
+    document.set_latest_entry(new_entry);
 
     // 10. Set navigable's active session history entry to newEntry.
     navigable->set_active_session_history_entry(new_entry);
 
-    // FIXME: 11. Update the navigation API entries for a same-document navigation given document's relevant global object's navigation API, newEntry, and historyHandling.
+    // 11. Update the navigation API entries for a same-document navigation given document's relevant global object's navigation API, newEntry, and historyHandling.
+    auto& relevant_global_object = verify_cast<Window>(HTML::relevant_global_object(document));
+    auto navigation_type = history_handling == HistoryHandlingBehavior::Push ? Bindings::NavigationType::Push : Bindings::NavigationType::Replace;
+    relevant_global_object.navigation()->update_the_navigation_api_entries_for_a_same_document_navigation(new_entry, navigation_type);
 
     // 12. Let traversable be navigable's traversable navigable.
     auto traversable = navigable->traversable_navigable();

--- a/Userland/Libraries/LibWeb/HTML/Navigable.h
+++ b/Userland/Libraries/LibWeb/HTML/Navigable.h
@@ -137,10 +137,12 @@ public:
 
     WebIDL::ExceptionOr<void> navigate(NavigateParams);
 
-    WebIDL::ExceptionOr<void> navigate_to_a_fragment(AK::URL const&, HistoryHandlingBehavior, String navigation_id);
+    WebIDL::ExceptionOr<void> navigate_to_a_fragment(AK::URL const&, HistoryHandlingBehavior, UserNavigationInvolvement, Optional<SerializationRecord> navigation_api_state, String navigation_id);
 
     WebIDL::ExceptionOr<JS::GCPtr<DOM::Document>> evaluate_javascript_url(AK::URL const&, Origin const& new_document_origin, String navigation_id);
     WebIDL::ExceptionOr<void> navigate_to_a_javascript_url(AK::URL const&, HistoryHandlingBehavior, Origin const& initiator_origin, CSPNavigationType csp_navigation_type, String navigation_id);
+
+    bool allowed_by_sandboxing_to_navigate(Navigable const& target, SourceSnapshotParams const&);
 
     void reload();
 
@@ -180,8 +182,6 @@ protected:
     TokenizedFeature::Popup m_is_popup { TokenizedFeature::Popup::No };
 
 private:
-    bool allowed_by_sandboxing_to_navigate(Navigable const& target, SourceSnapshotParams const&);
-
     void scroll_offset_did_change();
 
     void inform_the_navigation_api_about_aborting_navigation();
@@ -217,6 +217,6 @@ HashTable<Navigable*>& all_navigables();
 
 bool navigation_must_be_a_replace(AK::URL const& url, DOM::Document const& document);
 void finalize_a_cross_document_navigation(JS::NonnullGCPtr<Navigable>, HistoryHandlingBehavior, JS::NonnullGCPtr<SessionHistoryEntry>);
-void perform_url_and_history_update_steps(DOM::Document& document, AK::URL new_url, HistoryHandlingBehavior history_handling = HistoryHandlingBehavior::Reload);
+void perform_url_and_history_update_steps(DOM::Document& document, AK::URL new_url, Optional<SerializationRecord> = {}, HistoryHandlingBehavior history_handling = HistoryHandlingBehavior::Reload);
 
 }

--- a/Userland/Libraries/LibWeb/HTML/NavigableContainer.cpp
+++ b/Userland/Libraries/LibWeb/HTML/NavigableContainer.cpp
@@ -262,25 +262,27 @@ void NavigableContainer::destroy_the_child_navigable()
     // 3. Set container's content navigable to null.
     m_content_navigable = nullptr;
 
-    // 4. Destroy navigable's active document.
+    // FIXME: 4. Inform the navigation API about child navigable destruction given navigable.
+
+    // 5. Destroy navigable's active document.
     navigable->active_document()->destroy();
 
-    // 5. Let parentDocState be container's node navigable's active session history entry's document state.
+    // 6. Let parentDocState be container's node navigable's active session history entry's document state.
     auto parent_doc_state = this->navigable()->active_session_history_entry()->document_state;
 
-    // 6. Remove the nested history from parentDocState's nested histories whose id equals navigable's id.
+    // 7. Remove the nested history from parentDocState's nested histories whose id equals navigable's id.
     parent_doc_state->nested_histories().remove_all_matching([&](auto& nested_history) {
         return navigable->id() == nested_history.id;
     });
 
-    // 7. Let traversable be container's node navigable's traversable navigable.
+    // 8. Let traversable be container's node navigable's traversable navigable.
     auto traversable = this->navigable()->traversable_navigable();
 
     // Not in the spec
     navigable->set_has_been_destroyed();
     HTML::all_navigables().remove(navigable);
 
-    // 8. Append the following session history traversal steps to traversable:
+    // 9. Append the following session history traversal steps to traversable:
     traversable->append_session_history_traversal_steps([traversable] {
         // 1. Apply pending history changes to traversable.
         traversable->update_for_navigable_creation_or_destruction();

--- a/Userland/Libraries/LibWeb/HTML/NavigateEvent.h
+++ b/Userland/Libraries/LibWeb/HTML/NavigateEvent.h
@@ -74,6 +74,7 @@ public:
     JS::NonnullGCPtr<DOM::AbortController> abort_controller() const { return *m_abort_controller; }
     InterceptionState interception_state() const { return m_interception_state; }
     Vector<NavigationInterceptHandler> const& navigation_handler_list() const { return m_navigation_handler_list; }
+    Optional<SerializationRecord> classic_history_api_state() const { return m_classic_history_api_state; }
 
     void set_abort_controller(JS::NonnullGCPtr<DOM::AbortController> c) { m_abort_controller = c; }
     void set_interception_state(InterceptionState s) { m_interception_state = s; }

--- a/Userland/Libraries/LibWeb/HTML/Navigation.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Navigation.cpp
@@ -801,8 +801,6 @@ void Navigation::promote_an_upcoming_api_method_tracker_to_ongoing(Optional<Stri
 
     // 3. Otherwise:
     else {
-        VERIFY(m_upcoming_non_traverse_api_method_tracker != nullptr);
-
         // 1. Set navigation's ongoing API method tracker to navigation's upcoming non-traverse API method tracker.
         m_ongoing_api_method_tracker = m_upcoming_non_traverse_api_method_tracker;
 

--- a/Userland/Libraries/LibWeb/HTML/Navigation.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Navigation.cpp
@@ -146,7 +146,7 @@ WebIDL::ExceptionOr<void> Navigation::update_current_entry(NavigationUpdateCurre
     NavigationCurrentEntryChangeEventInit event_init = {};
     event_init.navigation_type = {};
     event_init.from = current;
-    dispatch_event(HTML::NavigationCurrentEntryChangeEvent::create(realm(), HTML::EventNames::currententrychange, event_init));
+    dispatch_event(HTML::NavigationCurrentEntryChangeEvent::construct_impl(realm(), HTML::EventNames::currententrychange, event_init));
 
     return {};
 }
@@ -866,6 +866,28 @@ void Navigation::reject_the_finished_promise(JS::NonnullGCPtr<NavigationAPIMetho
     clean_up(api_method_tracker);
 }
 
+// https://html.spec.whatwg.org/multipage/nav-history-apis.html#notify-about-the-committed-to-entry
+void Navigation::notify_about_the_committed_to_entry(JS::NonnullGCPtr<NavigationAPIMethodTracker> api_method_tracker, JS::NonnullGCPtr<NavigationHistoryEntry> nhe)
+{
+    auto& realm = this->realm();
+
+    // 1. Set apiMethodTracker's committed-to entry to nhe.
+    api_method_tracker->commited_to_entry = nhe;
+
+    // 2. If apiMethodTracker's serialized state is not null, then set nhe's session history entry's navigation API state to apiMethodTracker's serialized state.'
+    // NOTE: If it's null, then we're traversing to nhe via navigation.traverseTo(), which does not allow changing the state.
+    if (api_method_tracker->serialized_state.has_value()) {
+        // NOTE: At this point, apiMethodTracker's serialized state is no longer needed.
+        //       Implementations might want to clear it out to avoid keeping it alive for the lifetime of the navigation API method tracker.
+        nhe->session_history_entry().navigation_api_state = *api_method_tracker->serialized_state;
+        api_method_tracker->serialized_state = {};
+    }
+
+    // 3. Resolve apiMethodTracker's committed promise with nhe.
+    TemporaryExecutionContext execution_context { relevant_settings_object(*this) };
+    WebIDL::resolve_promise(realm, api_method_tracker->committed_promise, nhe);
+}
+
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#inner-navigate-event-firing-algorithm
 bool Navigation::inner_navigate_event_firing_algorithm(
     Bindings::NavigationType navigation_type,
@@ -1323,6 +1345,136 @@ bool Navigation::fire_a_download_request_navigate_event(AK::URL destination_url,
     //   "push", event, destination, userInvolvement, null, and filename.
     // AD-HOC: We don't pass the event, but we do pass the classic_history_api state at the end to be set later
     return inner_navigate_event_firing_algorithm(Bindings::NavigationType::Push, destination, user_involvement, {}, move(filename), {});
+}
+
+// https://html.spec.whatwg.org/multipage/nav-history-apis.html#initialize-the-navigation-api-entries-for-a-new-document
+void Navigation::initialize_the_navigation_api_entries_for_a_new_document(Vector<JS::NonnullGCPtr<SessionHistoryEntry>> const& new_shes, JS::NonnullGCPtr<SessionHistoryEntry> initial_she)
+{
+    auto& realm = relevant_realm(*this);
+
+    // 1. Assert: navigation's entry list is empty.
+    VERIFY(m_entry_list.is_empty());
+
+    // 2. Assert: navigation's current entry index is −1.
+    VERIFY(m_current_entry_index == -1);
+
+    // 3. If navigation has entries and events disabled, then return.
+    if (has_entries_and_events_disabled())
+        return;
+
+    // 4. For each newSHE of newSHEs:
+    for (auto const& new_she : new_shes) {
+        // 1. Let newNHE be a new NavigationHistoryEntry created in the relevant realm of navigation.
+        // 2. Set newNHE's session history entry to newSHE.
+        auto new_nhe = NavigationHistoryEntry::create(realm, new_she);
+
+        // 3. Append newNHE to navigation's entry list.
+        m_entry_list.append(new_nhe);
+    }
+
+    // 5. Set navigation's current entry index to the result of getting the navigation API entry index of initialSHE within navigation.
+    m_current_entry_index = get_the_navigation_api_entry_index(*initial_she);
+}
+
+// https://html.spec.whatwg.org/multipage/nav-history-apis.html#update-the-navigation-api-entries-for-a-same-document-navigation
+void Navigation::update_the_navigation_api_entries_for_a_same_document_navigation(JS::NonnullGCPtr<SessionHistoryEntry> destination_she, Bindings::NavigationType navigation_type)
+{
+    auto& realm = relevant_realm(*this);
+
+    // 1. If navigation has entries and events disabled, then return.
+    if (has_entries_and_events_disabled())
+        return;
+
+    // 2. Let oldCurrentNHE be the current entry of navigation.
+    auto old_current_nhe = current_entry();
+
+    // 3. Let disposedNHEs be a new empty list.
+    Vector<JS::NonnullGCPtr<NavigationHistoryEntry>> disposed_nhes;
+
+    // 4. If navigationType is "traverse", then:
+    if (navigation_type == Bindings::NavigationType::Traverse) {
+        // 1. Set navigation's current entry index to the result of getting the navigation API entry index of destinationSHE within navigation.
+        m_current_entry_index = get_the_navigation_api_entry_index(destination_she);
+
+        // 2. Assert: navigation's current entry index is not −1.
+        // NOTE: This algorithm is only called for same-document traversals.
+        //       Cross-document traversals will instead call either initialize the navigation API entries for a new document
+        //       or update the navigation API entries for reactivation
+        VERIFY(m_current_entry_index != -1);
+    }
+
+    // 5. Otherwise, if navigationType is "push", then:
+    else if (navigation_type == Bindings::NavigationType::Push) {
+        // 1. Set navigation's current entry index to navigation's current entry index + 1.
+        m_current_entry_index++;
+
+        // 2. Let i be navigation's current entry index.
+        auto i = m_current_entry_index;
+
+        // 3. While i < navigation's entry list's size:
+        while (i < static_cast<i64>(m_entry_list.size())) {
+            // 1. Append navigation's entry list[i] to disposedNHEs.
+            disposed_nhes.append(m_entry_list[i]);
+
+            // 2. Set i to i + 1.
+            ++i;
+        }
+
+        // 4. Remove all items in disposedNHEs from navigation's entry list.
+        m_entry_list.remove(m_current_entry_index, m_entry_list.size() - m_current_entry_index);
+    }
+
+    // 6. Otherwise, if navigationType is "replace", then:
+    else if (navigation_type == Bindings::NavigationType::Replace) {
+        VERIFY(old_current_nhe != nullptr);
+
+        // 1. Append oldCurrentNHE to disposedNHEs.
+        disposed_nhes.append(*old_current_nhe);
+    }
+
+    // 7. If navigationType is "push" or "replace", then:
+    if (navigation_type == Bindings::NavigationType::Push || navigation_type == Bindings::NavigationType::Replace) {
+        // 1. Let newNHE be a new NavigationHistoryEntry created in the relevant realm of navigation.
+        // 2. Set newNHE's session history entry to destinationSHE.
+        auto new_nhe = NavigationHistoryEntry::create(realm, destination_she);
+
+        VERIFY(m_current_entry_index != -1);
+
+        // 3. Set navigation's entry list[navigation's current entry index] to newNHE.
+        if (m_current_entry_index < static_cast<i64>(m_entry_list.size()))
+            m_entry_list[m_current_entry_index] = new_nhe;
+        else {
+            VERIFY(m_current_entry_index == static_cast<i64>(m_entry_list.size()));
+            m_entry_list.append(new_nhe);
+        }
+    }
+
+    // 8. If navigation's ongoing API method tracker is non-null, then notify about the committed-to entry
+    //    given navigation's ongoing API method tracker and the current entry of navigation.
+    // NOTE: It is important to do this before firing the dispose or currententrychange events,
+    //       since event handlers could start another navigation, or otherwise change the value of
+    //       navigation's ongoing API method tracker.
+    if (m_ongoing_api_method_tracker != nullptr)
+        notify_about_the_committed_to_entry(*m_ongoing_api_method_tracker, *current_entry());
+
+    // 9. Prepare to run script given navigation's relevant settings object.
+    relevant_settings_object(*this).prepare_to_run_script();
+
+    // 10. Fire an event named currententrychange at navigation using NavigationCurrentEntryChangeEvent,
+    //     with its navigationType attribute initialized to navigationType and its from initialized to oldCurrentNHE.
+    NavigationCurrentEntryChangeEventInit event_init = {};
+    event_init.navigation_type = navigation_type;
+    event_init.from = old_current_nhe;
+    dispatch_event(NavigationCurrentEntryChangeEvent::construct_impl(realm, EventNames::currententrychange, event_init));
+
+    // 11. For each disposedNHE of disposedNHEs:
+    for (auto& disposed_nhe : disposed_nhes) {
+        // 1. Fire an event named dispose at disposedNHE.
+        disposed_nhe->dispatch_event(DOM::Event::create(realm, EventNames::dispose, {}));
+    }
+
+    // 12. Clean up after running script given navigation's relevant settings object.
+    relevant_settings_object(*this).clean_up_after_running_script();
 }
 
 }

--- a/Userland/Libraries/LibWeb/HTML/Navigation.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Navigation.cpp
@@ -257,14 +257,11 @@ WebIDL::ExceptionOr<NavigationResult> Navigation::navigate(String url, Navigatio
     // FIXME: Fix spec typo here
     // NOTE: Unlike location.assign() and friends, which are exposed across origin-domain boundaries,
     //       navigation.navigate() can only be accessed by code with direct synchronous access to the
-    ///      window.navigation property. Thus, we avoid the complications about attributing the source document
+    //       window.navigation property. Thus, we avoid the complications about attributing the source document
     //       of the navigation, and we don't need to deal with the allowed by sandboxing to navigate check and its
     //       acccompanying exceptionsEnabled flag. We just treat all navigations as if they come from the Document
     //       corresponding to this Navigation object itself (i.e., document).
-    [[maybe_unused]] auto history_handling_behavior = to_history_handling_behavior(options.history);
-    // FIXME: Actually call navigate once Navigables are implemented enough to guarantee a node navigable on
-    //        an active document that's not being unloaded.
-    //        document.navigable().navigate(url, document, history behavior, state)
+    TRY(document.navigable()->navigate({ .url = url_record, .source_document = document, .history_handling = options.history, .navigation_api_state = move(serialized_state) }));
 
     // 11. If this's upcoming non-traverse API method tracker is apiMethodTracker, then:
     // NOTE: If the upcoming non-traverse API method tracker is still apiMethodTracker, this means that the navigate
@@ -328,9 +325,8 @@ WebIDL::ExceptionOr<NavigationResult> Navigation::reload(NavigationReloadOptions
     auto api_method_tracker = maybe_set_the_upcoming_non_traverse_api_method_tracker(info, serialized_state);
 
     // 9. Reload document's node navigable with navigationAPIState set to serializedState.
-    // FIXME: Actually call reload once Navigables are implemented enough to guarantee a node navigable on
-    //        an active document that's not being unloaded.
-    //        document.navigable().reload(state)
+    // FIXME: Pass serialized_state to reload
+    document.navigable()->reload();
 
     return navigation_api_method_tracker_derived_result(api_method_tracker);
 }
@@ -651,7 +647,7 @@ WebIDL::ExceptionOr<NavigationResult> Navigation::perform_a_navigation_api_trave
     auto source_snapshot_params = document.snapshot_source_snapshot_params();
 
     // 12. Append the following session history traversal steps to traversable:
-    traversable->append_session_history_traversal_steps([key, api_method_tracker, navigable, source_snapshot_params, this] {
+    traversable->append_session_history_traversal_steps([key, api_method_tracker, navigable, source_snapshot_params, traversable, this] {
         // 1. Let navigableSHEs be the result of getting session history entries given navigable.
         auto navigable_shes = navigable->get_session_history_entries();
 
@@ -667,6 +663,7 @@ WebIDL::ExceptionOr<NavigationResult> Navigation::perform_a_navigation_api_trave
             //    to reject the finished promise for apiMethodTracker with an "InvalidStateError" DOMException.
             queue_global_task(HTML::Task::Source::NavigationAndTraversal, relevant_global_object(*this), [this, api_method_tracker] {
                 auto& reject_realm = relevant_realm(*this);
+                TemporaryExecutionContext execution_context { relevant_settings_object(*this) };
                 WebIDL::reject_promise(reject_realm, api_method_tracker->finished_promise,
                     WebIDL::InvalidStateError::create(reject_realm, "Cannot traverse with stale session history entry"_fly_string));
             });
@@ -682,22 +679,36 @@ WebIDL::ExceptionOr<NavigationResult> Navigation::perform_a_navigation_api_trave
         if (target_she == navigable->active_session_history_entry())
             return;
 
-        // FIXME: 4. Let result be the result of applying the traverse history step given by targetSHE's step to traversable,
+        // 4. Let result be the result of applying the traverse history step given by targetSHE's step to traversable,
         //    given sourceSnapshotParams, navigable, and "none".
-        (void)source_snapshot_params;
+        auto result = traversable->apply_the_traverse_history_step(target_she->step.get<int>(), source_snapshot_params, navigable, UserNavigationInvolvement::None);
 
         // NOTE: When result is "canceled-by-beforeunload" or "initiator-disallowed", the navigate event was never fired,
         //       aborting the ongoing navigation would not be correct; it would result in a navigateerror event without a
         //       preceding navigate event. In the "canceled-by-navigate" case, navigate is fired, but the inner navigate event
         //       firing algorithm will take care of aborting the ongoing navigation.
 
-        // FIXME: 5. If result is "canceled-by-beforeunload", then queue a global task on the navigation and traversal task source
-        //           given navigation's relevant global object to reject the finished promise for apiMethodTracker with a
-        //           new "AbortError"DOMException created in navigation's relevant realm.
+        // 5. If result is "canceled-by-beforeunload", then queue a global task on the navigation and traversal task source
+        //    given navigation's relevant global object to reject the finished promise for apiMethodTracker with a
+        //    new "AbortError" DOMException created in navigation's relevant realm.
+        auto& realm = relevant_realm(*this);
+        auto& global = relevant_global_object(*this);
+        if (result == TraversableNavigable::HistoryStepResult::CanceledByBeforeUnload) {
+            queue_global_task(Task::Source::NavigationAndTraversal, global, [this, api_method_tracker, &realm] {
+                TemporaryExecutionContext execution_context { relevant_settings_object(*this) };
+                reject_the_finished_promise(api_method_tracker, WebIDL::AbortError::create(realm, "Navigation cancelled by beforeunload"_fly_string));
+            });
+        }
 
-        // FIXME: 6. If result is "initiator-disallowed", then queue a global task on the navigation and traversal task source
-        //           given navigation's relevant global object to reject the finished promise for apiMethodTracker with a
-        //           new "SecurityError" DOMException created in navigation's relevant realm.
+        // 6. If result is "initiator-disallowed", then queue a global task on the navigation and traversal task source
+        //    given navigation's relevant global object to reject the finished promise for apiMethodTracker with a
+        //    new "SecurityError" DOMException created in navigation's relevant realm.
+        if (result == TraversableNavigable::HistoryStepResult::InitiatorDisallowed) {
+            queue_global_task(Task::Source::NavigationAndTraversal, global, [this, api_method_tracker, &realm] {
+                TemporaryExecutionContext execution_context { relevant_settings_object(*this) };
+                reject_the_finished_promise(api_method_tracker, WebIDL::SecurityError::create(realm, "Navigation disallowed from this origin"_fly_string));
+            });
+        }
     });
 
     // 13. Return a navigation API method tracker-derived result for apiMethodTracker.

--- a/Userland/Libraries/LibWeb/HTML/Navigation.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Navigation.cpp
@@ -22,6 +22,7 @@
 #include <LibWeb/HTML/NavigationHistoryEntry.h>
 #include <LibWeb/HTML/NavigationTransition.h>
 #include <LibWeb/HTML/Scripting/ExceptionReporter.h>
+#include <LibWeb/HTML/Scripting/TemporaryExecutionContext.h>
 #include <LibWeb/HTML/TraversableNavigable.h>
 #include <LibWeb/HTML/Window.h>
 #include <LibWeb/WebIDL/AbstractOperations.h>
@@ -1066,7 +1067,7 @@ bool Navigation::inner_navigate_event_firing_algorithm(
 
     // 31. Prepare to run script given navigation's relevant settings object.
     // NOTE: There's a massive spec note here
-    relevant_settings_object(*this).prepare_to_run_script();
+    TemporaryExecutionContext execution_context { relevant_settings_object(*this) };
 
     // 32. If event's interception state is not "none":
     if (event->interception_state() != NavigateEvent::InterceptionState::None) {
@@ -1115,11 +1116,6 @@ bool Navigation::inner_navigate_event_firing_algorithm(
         for (auto const& handler : event->navigation_handler_list()) {
             // 1. Append the result of invoking handler with an empty arguments list to promisesList.
             auto result = WebIDL::invoke_callback(handler, {});
-            if (result.is_abrupt()) {
-                // FIXME: https://github.com/whatwg/html/issues/9774
-                report_exception(result.release_error(), realm);
-                continue;
-            }
             // This *should* be equivalent to converting a promise to a promise capability
             promises_list.append(WebIDL::create_resolved_promise(realm, result.value().value()));
         }
@@ -1137,9 +1133,12 @@ bool Navigation::inner_navigate_event_firing_algorithm(
 
         // 4. Wait for all of promisesList, with the following success steps:
         WebIDL::wait_for_all(
-            realm, promises_list, [&](JS::MarkedVector<JS::Value> const&) -> void {
+            realm, promises_list, [event, this, api_method_tracker](auto const&) -> void {
+
                 // FIXME: Spec issue: Event's relevant global objects' *associated document*
                 // 1. If event's relevant global object is not fully active, then abort these steps.
+                auto& relevant_global_object = verify_cast<HTML::Window>(HTML::relevant_global_object(*event));
+                auto& realm = event->realm();
                 if (!relevant_global_object.associated_document().is_fully_active())
                     return;
 
@@ -1168,12 +1167,14 @@ bool Navigation::inner_navigate_event_firing_algorithm(
                 m_transition = nullptr;
 
                 // 9. If apiMethodTracker is non-null, then resolve the finished promise for apiMethodTracker.
-                if (api_method_tracker)
+                if (api_method_tracker != nullptr)
                     resolve_the_finished_promise(*api_method_tracker); },
             // and the following failure steps given reason rejectionReason:
-            [&](JS::Value rejection_reason) -> void {
+            [event, this, api_method_tracker](JS::Value rejection_reason) -> void {
                 // FIXME: Spec issue: Event's relevant global objects' *associated document*
                 // 1. If event's relevant global object is not fully active, then abort these steps.
+                auto& relevant_global_object = verify_cast<HTML::Window>(HTML::relevant_global_object(*event));
+                auto& realm = event->realm();
                 if (!relevant_global_object.associated_document().is_fully_active())
                     return;
 
@@ -1211,18 +1212,18 @@ bool Navigation::inner_navigate_event_firing_algorithm(
                 m_transition = nullptr;
 
                 // 9. If apiMethodTracker is non-null, then reject the finished promise for apiMethodTracker with rejectionReason.
-                if (api_method_tracker)
+                if (api_method_tracker != nullptr)
                     reject_the_finished_promise(*api_method_tracker, rejection_reason);
             });
     }
 
     // 34. Otherwise, if apiMethodTracker is non-null, then clean up apiMethodTracker.
-    else if (api_method_tracker) {
+    else if (api_method_tracker != nullptr) {
         clean_up(*api_method_tracker);
     }
 
     // 35. Clean up after running script given navigation's relevant settings object.
-    relevant_settings_object(*this).clean_up_after_running_script();
+    // Handled by TemporaryExecutionContext destructor from step 31
 
     // 36. If event's interception state is "none", then return true.
     // 37. Return false.

--- a/Userland/Libraries/LibWeb/HTML/Navigation.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Navigation.cpp
@@ -1094,10 +1094,9 @@ bool Navigation::inner_navigate_event_firing_algorithm(
         // 7. If navigationType is "push" or "replace", then run the URL and history update steps given document and
         //    event's destination's URL, with serialiedData set to event's classic history API state and historyHandling
         //    set to navigationType.
-        // FIXME: Pass the serialized data to this algorithm
         if (navigation_type == Bindings::NavigationType::Push || navigation_type == Bindings::NavigationType::Replace) {
             auto history_handling = navigation_type == Bindings::NavigationType::Push ? HistoryHandlingBehavior::Push : HistoryHandlingBehavior::Replace;
-            perform_url_and_history_update_steps(document, event->destination()->raw_url(), history_handling);
+            perform_url_and_history_update_steps(document, event->destination()->raw_url(), event->classic_history_api_state(), history_handling);
         }
         // Big spec note about reload here
     }

--- a/Userland/Libraries/LibWeb/HTML/Navigation.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Navigation.cpp
@@ -114,10 +114,8 @@ JS::GCPtr<NavigationHistoryEntry> Navigation::current_entry() const
     if (has_entries_and_events_disabled())
         return nullptr;
 
-    // FIXME 2. Assert: navigation's current entry index is not −1.
-    // FIXME: This should not happen once Navigable's algorithms properly set up NHEs.
-    if (m_current_entry_index == -1)
-        return nullptr;
+    // 2. Assert: navigation's current entry index is not −1.
+    VERIFY(m_current_entry_index != -1);
 
     // 3. Return navigation's entry list[navigation's current entry index].
     return m_entry_list[m_current_entry_index];
@@ -160,10 +158,8 @@ bool Navigation::can_go_back() const
     if (has_entries_and_events_disabled())
         return false;
 
-    // FIXME 2. Assert: navigation's current entry index is not −1.
-    // FIXME: This should not happen once Navigable's algorithms properly set up NHEs.
-    if (m_current_entry_index == -1)
-        return false;
+    // 2. Assert: navigation's current entry index is not −1.
+    VERIFY(m_current_entry_index != -1);
 
     // 3. If this's current entry index is 0, then return false.
     // 4. Return true.
@@ -179,10 +175,8 @@ bool Navigation::can_go_forward() const
     if (has_entries_and_events_disabled())
         return false;
 
-    // FIXME 2. Assert: navigation's current entry index is not −1.
-    // FIXME: This should not happen once Navigable's algorithms properly set up NHEs.
-    if (m_current_entry_index == -1)
-        return false;
+    // 2. Assert: navigation's current entry index is not −1.
+    VERIFY(m_current_entry_index != -1);
 
     // 3. If this's current entry index is equal to this's entry list's size, then return false.
     // 4. Return true.

--- a/Userland/Libraries/LibWeb/HTML/Navigation.h
+++ b/Userland/Libraries/LibWeb/HTML/Navigation.h
@@ -120,6 +120,9 @@ public:
         Optional<SerializationRecord> classic_history_api_state = {});
     bool fire_a_download_request_navigate_event(AK::URL destination_url, UserNavigationInvolvement user_involvement, String filename);
 
+    void initialize_the_navigation_api_entries_for_a_new_document(Vector<JS::NonnullGCPtr<SessionHistoryEntry>> const& new_shes, JS::NonnullGCPtr<SessionHistoryEntry> initial_she);
+    void update_the_navigation_api_entries_for_a_same_document_navigation(JS::NonnullGCPtr<SessionHistoryEntry> destination_she, Bindings::NavigationType);
+
     virtual ~Navigation() override;
 
     // Internal Getters/Setters
@@ -144,6 +147,7 @@ private:
     void resolve_the_finished_promise(JS::NonnullGCPtr<NavigationAPIMethodTracker>);
     void reject_the_finished_promise(JS::NonnullGCPtr<NavigationAPIMethodTracker>, JS::Value exception);
     void clean_up(JS::NonnullGCPtr<NavigationAPIMethodTracker>);
+    void notify_about_the_committed_to_entry(JS::NonnullGCPtr<NavigationAPIMethodTracker>, JS::NonnullGCPtr<NavigationHistoryEntry>);
 
     bool inner_navigate_event_firing_algorithm(
         Bindings::NavigationType,

--- a/Userland/Libraries/LibWeb/HTML/SessionHistoryTraversalQueue.h
+++ b/Userland/Libraries/LibWeb/HTML/SessionHistoryTraversalQueue.h
@@ -6,9 +6,18 @@
 
 #pragma once
 
+#include <AK/Vector.h>
 #include <LibCore/Timer.h>
+#include <LibJS/Heap/GCPtr.h>
+#include <LibJS/SafeFunction.h>
+#include <LibWeb/Forward.h>
 
 namespace Web::HTML {
+
+struct SessionHistoryTraversalQueueEntry {
+    JS::SafeFunction<void()> steps;
+    JS::GCPtr<HTML::Navigable> target_navigable;
+};
 
 // https://html.spec.whatwg.org/multipage/document-sequences.html#tn-session-history-traversal-queue
 class SessionHistoryTraversalQueue {
@@ -17,30 +26,47 @@ public:
     {
         m_timer = Core::Timer::create_single_shot(0, [this] {
             while (m_queue.size() > 0) {
-                auto steps = m_queue.take_first();
-                steps();
+                auto entry = m_queue.take_first();
+                entry.steps();
             }
         }).release_value_but_fixme_should_propagate_errors();
     }
 
     void append(JS::SafeFunction<void()> steps)
     {
-        m_queue.append(move(steps));
+        m_queue.append({ move(steps), nullptr });
         if (!m_timer->is_active()) {
             m_timer->start();
         }
     }
 
+    void append_sync(JS::SafeFunction<void()> steps, JS::GCPtr<Navigable> target_navigable)
+    {
+        m_queue.append({ move(steps), target_navigable });
+        if (!m_timer->is_active()) {
+            m_timer->start();
+        }
+    }
+
+    // https://html.spec.whatwg.org/multipage/browsing-the-web.html#sync-navigations-jump-queue
+    SessionHistoryTraversalQueueEntry first_synchronous_navigation_steps_with_target_navigable_not_contained_in(Vector<JS::GCPtr<Navigable>> const& list)
+    {
+        auto index = m_queue.find_first_index_if([&list](auto const& entry) -> bool {
+            return (entry.target_navigable != nullptr) && !list.contains_slow(entry.target_navigable);
+        });
+        return index.has_value() ? m_queue.take(*index) : SessionHistoryTraversalQueueEntry {};
+    }
+
     void process()
     {
         while (m_queue.size() > 0) {
-            auto steps = m_queue.take_first();
-            steps();
+            auto entry = m_queue.take_first();
+            entry.steps();
         }
     }
 
 private:
-    Vector<JS::SafeFunction<void()>> m_queue;
+    Vector<SessionHistoryTraversalQueueEntry> m_queue;
     RefPtr<Core::Timer> m_timer;
 };
 

--- a/Userland/Libraries/LibWeb/HTML/StructuredSerialize.cpp
+++ b/Userland/Libraries/LibWeb/HTML/StructuredSerialize.cpp
@@ -27,6 +27,7 @@
 #include <LibJS/Runtime/TypedArray.h>
 #include <LibJS/Runtime/VM.h>
 #include <LibWeb/Bindings/ExceptionOrUtils.h>
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/StructuredSerialize.h>
 #include <LibWeb/WebIDL/ExceptionOr.h>
 
@@ -948,8 +949,16 @@ WebIDL::ExceptionOr<JS::Value> structured_deserialize(JS::VM& vm, SerializationR
     if (!memory.has_value())
         memory = DeserializationMemory { vm.heap() };
 
+    // IMPLEMENTATION DEFINED: We need to make sure there's an execution context for target_realm on the stack before constructing these JS objects
+    auto& target_settings = Bindings::host_defined_environment_settings_object(target_realm);
+    target_settings.prepare_to_run_script();
+
     Deserializer deserializer(vm, target_realm, serialized.span(), *memory);
-    return deserializer.deserialize();
+
+    auto result = deserializer.deserialize();
+
+    target_settings.clean_up_after_running_script();
+    return result;
 }
 
 }

--- a/Userland/Libraries/LibWeb/HTML/TraversableNavigable.cpp
+++ b/Userland/Libraries/LibWeb/HTML/TraversableNavigable.cpp
@@ -317,16 +317,11 @@ Vector<JS::Handle<Navigable>> TraversableNavigable::get_all_navigables_that_migh
 TraversableNavigable::HistoryStepResult TraversableNavigable::apply_the_history_step(
     int step,
     bool check_for_cancelation,
-    bool fire_navigate_event_on_commit,
     Optional<SourceSnapshotParams> source_snapshot_params,
     JS::GCPtr<Navigable> initiator_to_check,
     Optional<UserNavigationInvolvement> user_involvement_for_navigate_events)
 {
-    // FIXME: fireNavigateEventOnCommit is unused in this algorithm (https://github.com/whatwg/html/issues/9800)
-    (void)fire_navigate_event_on_commit;
-
     auto& vm = this->vm();
-
     // FIXME: 1. Assert: This is running within traversable's session history traversal queue.
 
     // 2. Let targetStep be the result of getting the used step given traversable and step.
@@ -762,39 +757,35 @@ void TraversableNavigable::traverse_the_history_by_delta(int delta, Optional<DOM
 }
 
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#update-for-navigable-creation/destruction
-void TraversableNavigable::update_for_navigable_creation_or_destruction()
+TraversableNavigable::HistoryStepResult TraversableNavigable::update_for_navigable_creation_or_destruction()
 {
     // 1. Let step be traversable's current session history step.
     auto step = current_session_history_step();
 
-    // 2. Return the result of applying the history step step to traversable given false, false, null, null, and null.
-    // FIXME: Return result of history application.
-    apply_the_history_step(step, false, false, {}, {}, {});
+    // 2. Return the result of applying the history step step to traversable given, false, null, null, and null.
+    return apply_the_history_step(step, false, {}, {}, {});
 }
 
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#apply-the-reload-history-step
-void TraversableNavigable::apply_the_reload_history_step()
+TraversableNavigable::HistoryStepResult TraversableNavigable::apply_the_reload_history_step()
 {
     // 1. Let step be traversable's current session history step.
     auto step = current_session_history_step();
 
-    // 2. Return the result of applying the history step step to traversable given true, false, null, null, and null.
-    // FIXME: Return result of history application.
-    apply_the_history_step(step, true, false, {}, {}, {});
+    // 2. Return the result of applying the history step step to traversable given true, null, null, and null.
+    return apply_the_history_step(step, true, {}, {}, {});
 }
 
-void TraversableNavigable::apply_the_push_or_replace_history_step(int step)
+TraversableNavigable::HistoryStepResult TraversableNavigable::apply_the_push_or_replace_history_step(int step)
 {
-    // 1. Return the result of applying the history step step to traversable given false, false, null, null, and null.
-    // FIXME: Return result of history application.
-    apply_the_history_step(step, false, false, {}, {}, {});
+    // 1. Return the result of applying the history step step to traversable given false, null, null, and null.
+    return apply_the_history_step(step, false, {}, {}, {});
 }
 
-void TraversableNavigable::apply_the_traverse_history_step(int step, Optional<SourceSnapshotParams> source_snapshot_params, JS::GCPtr<Navigable> initiator_to_check, UserNavigationInvolvement user_involvement)
+TraversableNavigable::HistoryStepResult TraversableNavigable::apply_the_traverse_history_step(int step, Optional<SourceSnapshotParams> source_snapshot_params, JS::GCPtr<Navigable> initiator_to_check, UserNavigationInvolvement user_involvement)
 {
-    // 1. Return the result of applying the history step step to traversable given true, true, sourceSnapshotParams, initiatorToCheck, and userInvolvement.
-    // FIXME: Return result of history application.
-    apply_the_history_step(step, true, true, move(source_snapshot_params), initiator_to_check, user_involvement);
+    // 1. Return the result of applying the history step step to traversable given true, sourceSnapshotParams, initiatorToCheck, and userInvolvement.
+    return apply_the_history_step(step, true, move(source_snapshot_params), initiator_to_check, user_involvement);
 }
 
 // https://html.spec.whatwg.org/multipage/document-sequences.html#close-a-top-level-traversable

--- a/Userland/Libraries/LibWeb/HTML/TraversableNavigable.cpp
+++ b/Userland/Libraries/LibWeb/HTML/TraversableNavigable.cpp
@@ -9,6 +9,7 @@
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/BrowsingContextGroup.h>
 #include <LibWeb/HTML/DocumentState.h>
+#include <LibWeb/HTML/Navigation.h>
 #include <LibWeb/HTML/NavigationParams.h>
 #include <LibWeb/HTML/SessionHistoryEntry.h>
 #include <LibWeb/HTML/TraversableNavigable.h>
@@ -236,24 +237,130 @@ Vector<JS::Handle<Navigable>> TraversableNavigable::get_all_navigables_whose_cur
     return results;
 }
 
-// https://html.spec.whatwg.org/multipage/browsing-the-web.html#apply-the-history-step
-void TraversableNavigable::apply_the_history_step(int step, Optional<SourceSnapshotParams> source_snapshot_params)
+// https://html.spec.whatwg.org/multipage/browsing-the-web.html#getting-all-navigables-that-only-need-history-object-length/index-update
+Vector<JS::Handle<Navigable>> TraversableNavigable::get_all_navigables_that_only_need_history_object_length_index_update(int target_step) const
 {
+    // NOTE: Other navigables might not be impacted by the traversal. For example, if the response is a 204, the currently active document will remain.
+    //       Additionally, going 'back' after a 204 will change the current session history entry, but the active session history entry will already be correct.
+
+    // 1. Let results be an empty list.
+    Vector<JS::Handle<Navigable>> results;
+
+    // 2. Let navigablesToCheck be « traversable ».
+    Vector<JS::Handle<Navigable>> navigables_to_check;
+    navigables_to_check.append(const_cast<TraversableNavigable&>(*this));
+
+    // 3. For each navigable of navigablesToCheck:
+    while (!navigables_to_check.is_empty()) {
+        auto navigable = navigables_to_check.take_first();
+
+        // 1. Let targetEntry be the result of getting the target history entry given navigable and targetStep.
+        auto target_entry = navigable->get_the_target_history_entry(target_step);
+
+        // 2. If targetEntry is navigable's current session history entry and targetEntry's document state's reload pending is false, then:
+        if (target_entry == navigable->current_session_history_entry() && !target_entry->document_state->reload_pending()) {
+            // 1.  Append navigable to results.
+            results.append(navigable);
+
+            // 2. Extend navigablesToCheck with navigable's child navigables.
+            navigables_to_check.extend(navigable->child_navigables());
+        }
+    }
+
+    // 4. Return results.
+    return results;
+}
+
+// https://html.spec.whatwg.org/multipage/browsing-the-web.html#getting-all-navigables-that-might-experience-a-cross-document-traversal
+Vector<JS::Handle<Navigable>> TraversableNavigable::get_all_navigables_that_might_experience_a_cross_document_traversal(int target_step) const
+{
+    // NOTE: From traversable's session history traversal queue's perspective, these documents are candidates for going cross-document during the
+    //       traversal described by targetStep. They will not experience a cross-document traversal if the status code for their target document is
+    //       HTTP 204 No Content.
+    //       Note that if a given navigable might experience a cross-document traversal, this algorithm will return navigable but not its child navigables.
+    //       Those would end up unloaded, not traversed.
+
+    // 1. Let results be an empty list.
+    Vector<JS::Handle<Navigable>> results;
+
+    // 2. Let navigablesToCheck be « traversable ».
+    Vector<JS::Handle<Navigable>> navigables_to_check;
+    navigables_to_check.append(const_cast<TraversableNavigable&>(*this));
+
+    // 3. For each navigable of navigablesToCheck:
+    while (!navigables_to_check.is_empty()) {
+        auto navigable = navigables_to_check.take_first();
+
+        // 1. Let targetEntry be the result of getting the target history entry given navigable and targetStep.
+        auto target_entry = navigable->get_the_target_history_entry(target_step);
+
+        // 2. If targetEntry's document is not navigable's document or targetEntry's document state's reload pending is true, then append navigable to results.
+        // NOTE: Although navigable's active history entry can change synchronously, the new entry will always have the same Document,
+        //       so accessing navigable's document is reliable.
+        if (target_entry->document_state->document() != navigable->active_document() || target_entry->document_state->reload_pending()) {
+            results.append(navigable);
+        }
+
+        // 3. Otherwise, extend navigablesToCheck with navigable's child navigables.
+        //    Adding child navigables to navigablesToCheck means those navigables will also be checked by this loop.
+        //    Child navigables are only checked if the navigable's active document will not change as part of this traversal.
+        else {
+            navigables_to_check.extend(navigable->child_navigables());
+        }
+    }
+
+    // 4. Return results.
+    return results;
+}
+
+// https://html.spec.whatwg.org/multipage/browsing-the-web.html#apply-the-history-step
+TraversableNavigable::HistoryStepResult TraversableNavigable::apply_the_history_step(
+    int step,
+    bool check_for_cancelation,
+    bool fire_navigate_event_on_commit,
+    Optional<SourceSnapshotParams> source_snapshot_params,
+    JS::GCPtr<Navigable> initiator_to_check,
+    Optional<UserNavigationInvolvement> user_involvement_for_navigate_events)
+{
+    // FIXME: fireNavigateEventOnCommit is unused in this algorithm (https://github.com/whatwg/html/issues/9800)
+    (void)fire_navigate_event_on_commit;
+
+    auto& vm = this->vm();
+
     // FIXME: 1. Assert: This is running within traversable's session history traversal queue.
 
     // 2. Let targetStep be the result of getting the used step given traversable and step.
     auto target_step = get_the_used_step(step);
 
-    // FIXME: 3. If initiatorToCheck is given, then:
+    // Note: Calling this early so we can re-use the same list in 3.2 and 6.
+    auto change_or_reload_navigables = get_all_navigables_whose_current_session_history_entry_will_change_or_reload(target_step);
 
-    // FIXME: 4. Let navigablesCrossingDocuments be the result of getting all navigables that might experience a cross-document traversal given traversable and targetStep.
+    // 3. If initiatorToCheck is not null, then:
+    if (initiator_to_check != nullptr) {
+        // 1. Assert: sourceSnapshotParams is not null.
+        VERIFY(source_snapshot_params.has_value());
 
-    // FIXME: 5. If checkForUserCancelation is true, and the result of checking if unloading is user-canceled given navigablesCrossingDocuments given traversable and targetStep is true, then return.
+        // 2. For each navigable of get all navigables whose current session history entry will change or reload:
+        //    if initiatorToCheck is not allowed by sandboxing to navigate navigable given sourceSnapshotParams, then return "initiator-disallowed".
+        for (auto const& navigable : change_or_reload_navigables) {
+            if (!initiator_to_check->allowed_by_sandboxing_to_navigate(*navigable, *source_snapshot_params))
+                return HistoryStepResult::InitiatorDisallowed;
+        }
+    }
+
+    // 4. Let navigablesCrossingDocuments be the result of getting all navigables that might experience a cross-document traversal given traversable and targetStep.
+    [[maybe_unused]] auto navigables_crossing_documents = get_all_navigables_that_might_experience_a_cross_document_traversal(target_step);
+
+    // 5. FIXME: If checkForCancelation is true, and the result of checking if unloading is canceled given navigablesCrossingDocuments, traversable, targetStep,
+    //           and userInvolvementForNavigateEvents is not "continue", then return that result.
+    (void)check_for_cancelation;
+    (void)user_involvement_for_navigate_events;
 
     // 6. Let changingNavigables be the result of get all navigables whose current session history entry will change or reload given traversable and targetStep.
-    auto changing_navigables = get_all_navigables_whose_current_session_history_entry_will_change_or_reload(target_step);
+    auto changing_navigables = move(change_or_reload_navigables);
 
-    // FIXME: 7. Let nonchangingNavigablesThatStillNeedUpdates be the result of getting all navigables that only need history object length/index update given traversable and targetStep.
+    // 7. Let nonchangingNavigablesThatStillNeedUpdates be the result of getting all navigables that only need history object length/index update given traversable and targetStep.
+    auto non_changing_navigables_that_still_need_updates = get_all_navigables_that_only_need_history_object_length_index_update(target_step);
 
     // 8. For each navigable of changingNavigables:
     for (auto& navigable : changing_navigables) {
@@ -277,10 +384,11 @@ void TraversableNavigable::apply_the_history_step(int step, Optional<SourceSnaps
         JS::Handle<DOM::Document> displayed_document;
         JS::Handle<SessionHistoryEntry> target_entry;
         JS::Handle<Navigable> navigable;
-        bool update_only;
+        bool update_only = false;
     };
 
     // 11. Let changingNavigableContinuations be an empty queue of changing navigable continuation states.
+    // NOTE: This queue is used to split the operations on changingNavigables into two parts. Specifically, changingNavigableContinuations holds data for the second part.
     Queue<ChangingNavigableContinuationState> changing_navigable_continuations;
 
     // 12. For each navigable of changingNavigables, queue a global task on the navigation and traversal task source of navigable's active window to run the steps:
@@ -317,17 +425,31 @@ void TraversableNavigable::apply_the_history_step(int step, Optional<SourceSnaps
             }
 
             // 5. Let oldOrigin be targetEntry's document state's origin.
-            [[maybe_unused]] auto old_origin = target_entry->document_state->origin();
+            auto old_origin = target_entry->document_state->origin();
 
-            auto after_document_populated = [target_entry, changing_navigable_continuation, &changing_navigable_continuations]() mutable {
+            auto after_document_populated = [old_origin, target_entry, changing_navigable_continuation, &changing_navigable_continuations, &vm, &navigable]() mutable {
                 // 1. If targetEntry's document is null, then set changingNavigableContinuation's update-only to true.
                 if (!target_entry->document_state->document()) {
                     changing_navigable_continuation.update_only = true;
                 }
 
-                // FIXME: 2. If targetEntry's document's origin is not oldOrigin, then set targetEntry's serialized state to StructuredSerializeForStorage(null).
+                else {
+                    // 2. If targetEntry's document's origin is not oldOrigin, then set targetEntry's classic history API state to StructuredSerializeForStorage(null).
+                    if (target_entry->document_state->document()->origin() != old_origin) {
+                        target_entry->classic_history_api_state = MUST(structured_serialize_for_storage(vm, JS::js_null()));
+                    }
 
-                // FIXME: 3. If all of the following are true:
+                    // 3. If all of the following are true:
+                    //     - navigable's parent is null;
+                    //     - targetEntry's document's browsing context is not an auxiliary browsing context whose opener browsing context is non-null; and
+                    //     - targetEntry's document's origin is not oldOrigin,
+                    //    then set targetEntry's document state's navigable target name to the empty string.
+                    if (navigable->parent() != nullptr
+                        && target_entry->document_state->document()->browsing_context()->opener_browsing_context() == nullptr
+                        && target_entry->document_state->origin() != old_origin) {
+                        target_entry->document_state->set_navigable_target_name(String {});
+                    }
+                }
 
                 // 4. Enqueue changingNavigableContinuation on changingNavigableContinuations.
                 changing_navigable_continuations.enqueue(move(changing_navigable_continuation));
@@ -416,8 +538,11 @@ void TraversableNavigable::apply_the_history_step(int step, Optional<SourceSnaps
 
         // FIXME: 9. Append navigable to navigablesThatMustWaitBeforeHandlingSyncNavigation.
 
-        // 10. Queue a global task on the navigation and traversal task source given navigable's active window to run the steps:
-        queue_global_task(Task::Source::NavigationAndTraversal, *navigable->active_window(), [&, target_entry, navigable, displayed_document, update_only = changing_navigable_continuation.update_only, script_history_length, script_history_index] {
+        // 10. Let entriesForNavigationAPI be the result of getting session history entries for the navigation API given navigable and targetStep.
+        auto entries_for_navigation_api = get_session_history_entries_for_the_navigation_api(*navigable, target_step);
+
+        // 11. Queue a global task on the navigation and traversal task source given navigable's active window to run the steps:
+        queue_global_task(Task::Source::NavigationAndTraversal, *navigable->active_window(), [&, target_entry, navigable, displayed_document, update_only = changing_navigable_continuation.update_only, script_history_length, script_history_index, entries_for_navigation_api = move(entries_for_navigation_api)]() mutable {
             // NOTE: This check is not in the spec but we should not continue navigation if navigable has been destroyed.
             if (navigable->has_been_destroyed())
                 return;
@@ -442,15 +567,33 @@ void TraversableNavigable::apply_the_history_step(int step, Optional<SourceSnaps
                 navigable->activate_history_entry(*target_entry);
             }
 
-            // FIXME: 2. If targetEntry's document is not equal to displayedDocument, then queue a global task on the navigation and traversal task source given targetEntry's document's
-            //           relevant global object to perform the following step. Otherwise, continue onward to perform the following step within the currently-queued task.
+            // 2. If navigable is not traversable, and targetEntry is not navigable's current session history entry, and targetEntry's document state's origin is the same as
+            //    navigable's current session history entry's document state's origin, then fire a traverse navigate event given targetEntry and userInvolvementForNavigateEvents.
+            auto target_origin = target_entry->document_state->origin();
+            auto current_origin = navigable->current_session_history_entry()->document_state->origin();
+            bool const is_same_origin = target_origin.has_value() && current_origin.has_value() && target_origin->is_same_origin(*current_origin);
+            if (!navigable->is_traversable()
+                && target_entry.ptr() != navigable->current_session_history_entry()
+                && is_same_origin) {
+                navigable->active_window()->navigation()->fire_a_traverse_navigate_event(*target_entry, user_involvement_for_navigate_events.value_or(UserNavigationInvolvement::None));
+            }
 
-            // 3. Update document for history step application given targetEntry's document, targetEntry, changingNavigableContinuation's update-only, scriptHistoryLength, and
-            //    scriptHistoryIndex and entriesForNavigationAPI.
-            //    FIXME: Pass entriesForNavigationAPI
-            target_entry->document_state->document()->update_for_history_step_application(*target_entry, update_only, script_history_length, script_history_index);
+            // 3. Let updateDocument be an algorithm step which performs update document for history step application given targetEntry's document,
+            //    targetEntry, changingNavigableContinuation's update-only, scriptHistoryLength, scriptHistoryIndex, and entriesForNavigationAPI.
+            auto update_document = JS::SafeFunction<void()>([target_entry, update_only, script_history_length, script_history_index, entries_for_navigation_api = move(entries_for_navigation_api)] {
+                target_entry->document_state->document()->update_for_history_step_application(*target_entry, update_only, script_history_length, script_history_index, entries_for_navigation_api);
+            });
 
-            // 4. Increment completedChangeJobs.
+            // 4. If targetEntry's document is equal to displayedDocument, then perform updateDocument.
+            if (target_entry->document_state->document() == displayed_document.ptr()) {
+                update_document();
+            }
+            // 5. Otherwise, queue a global task on the navigation and traversal task source given targetEntry's document's relevant global object to perform updateDocument
+            else {
+                queue_global_task(Task::Source::NavigationAndTraversal, relevant_global_object(*target_entry->document_state->document()), move(update_document));
+            }
+
+            // 6. Increment completedChangeJobs.
             completed_change_jobs++;
         });
     }
@@ -467,6 +610,9 @@ void TraversableNavigable::apply_the_history_step(int step, Optional<SourceSnaps
 
     // 20. Set traversable's current session history step to targetStep.
     m_current_session_history_step = target_step;
+
+    // 21. Return "applied".
+    return HistoryStepResult::Applied;
 }
 
 Vector<JS::NonnullGCPtr<SessionHistoryEntry>> TraversableNavigable::get_session_history_entries_for_the_navigation_api(JS::NonnullGCPtr<Navigable> navigable, int target_step)
@@ -572,14 +718,29 @@ void TraversableNavigable::clear_the_forward_session_history()
 }
 
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#traverse-the-history-by-a-delta
-void TraversableNavigable::traverse_the_history_by_delta(int delta)
+void TraversableNavigable::traverse_the_history_by_delta(int delta, Optional<DOM::Document&> source_document)
 {
-    // FIXME: 1. Let sourceSnapshotParams and initiatorToCheck be null.
+    // 1. Let sourceSnapshotParams and initiatorToCheck be null.
+    Optional<SourceSnapshotParams> source_snapshot_params = {};
+    JS::GCPtr<Navigable> initiator_to_check = nullptr;
 
-    // FIXME: 2. If sourceDocument is given, then:
+    // 2. Let userInvolvement be "browser UI".
+    UserNavigationInvolvement user_involvement = UserNavigationInvolvement::BrowserUI;
 
-    // 3. Append the following session history traversal steps to traversable:
-    append_session_history_traversal_steps([this, delta] {
+    // 1. If sourceDocument is given, then:
+    if (source_document.has_value()) {
+        // 1. Set sourceSnapshotParams to the result of snapshotting source snapshot params given sourceDocument.
+        source_snapshot_params = source_document->snapshot_source_snapshot_params();
+
+        // 2. Set initiatorToCheck to sourceDocument's node navigable.
+        initiator_to_check = source_document->navigable();
+
+        // 3. Set userInvolvement to "none".
+        user_involvement = UserNavigationInvolvement::None;
+    }
+
+    // 4. Append the following session history traversal steps to traversable:
+    append_session_history_traversal_steps([this, delta, source_snapshot_params = move(source_snapshot_params), initiator_to_check, user_involvement] {
         // 1. Let allSteps be the result of getting all used history steps for traversable.
         auto all_steps = get_all_used_history_steps();
 
@@ -594,9 +755,9 @@ void TraversableNavigable::traverse_the_history_by_delta(int delta)
             return;
         }
 
-        // 5. Apply the history step allSteps[targetStepIndex] to traversable, with checkForUserCancelation set to true,
-        //    sourceSnapshotParams set to sourceSnapshotParams, and initiatorToCheck set to initiatorToCheck.
-        apply_the_history_step(all_steps[target_step_index]);
+        // 5. Apply the traverse history step allSteps[targetStepIndex] to traversable, given sourceSnapshotParams,
+        //    initiatorToCheck, and userInvolvement.
+        apply_the_traverse_history_step(all_steps[target_step_index], source_snapshot_params, initiator_to_check, user_involvement);
     });
 }
 
@@ -607,8 +768,8 @@ void TraversableNavigable::update_for_navigable_creation_or_destruction()
     auto step = current_session_history_step();
 
     // 2. Return the result of applying the history step step to traversable given false, false, null, null, and null.
-    // FIXME: Pass false, false, null, null, and null as arguments.
-    apply_the_history_step(step);
+    // FIXME: Return result of history application.
+    apply_the_history_step(step, false, false, {}, {}, {});
 }
 
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#apply-the-reload-history-step
@@ -618,16 +779,22 @@ void TraversableNavigable::apply_the_reload_history_step()
     auto step = current_session_history_step();
 
     // 2. Return the result of applying the history step step to traversable given true, false, null, null, and null.
-    // FIXME: Pass true, false, null, null, and null as arguments.
-    apply_the_history_step(step);
+    // FIXME: Return result of history application.
+    apply_the_history_step(step, true, false, {}, {}, {});
 }
 
 void TraversableNavigable::apply_the_push_or_replace_history_step(int step)
 {
     // 1. Return the result of applying the history step step to traversable given false, false, null, null, and null.
-    // FIXME: Pass false, false, null, null, and null as arguments.
     // FIXME: Return result of history application.
-    apply_the_history_step(step);
+    apply_the_history_step(step, false, false, {}, {}, {});
+}
+
+void TraversableNavigable::apply_the_traverse_history_step(int step, Optional<SourceSnapshotParams> source_snapshot_params, JS::GCPtr<Navigable> initiator_to_check, UserNavigationInvolvement user_involvement)
+{
+    // 1. Return the result of applying the history step step to traversable given true, true, sourceSnapshotParams, initiatorToCheck, and userInvolvement.
+    // FIXME: Return result of history application.
+    apply_the_history_step(step, true, true, move(source_snapshot_params), initiator_to_check, user_involvement);
 }
 
 // https://html.spec.whatwg.org/multipage/document-sequences.html#close-a-top-level-traversable

--- a/Userland/Libraries/LibWeb/HTML/TraversableNavigable.cpp
+++ b/Userland/Libraries/LibWeb/HTML/TraversableNavigable.cpp
@@ -469,6 +469,77 @@ void TraversableNavigable::apply_the_history_step(int step, Optional<SourceSnaps
     m_current_session_history_step = target_step;
 }
 
+Vector<JS::NonnullGCPtr<SessionHistoryEntry>> TraversableNavigable::get_session_history_entries_for_the_navigation_api(JS::NonnullGCPtr<Navigable> navigable, int target_step)
+{
+    // 1. Let rawEntries be the result of getting session history entries for navigable.
+    auto raw_entries = navigable->get_session_history_entries();
+
+    if (raw_entries.is_empty())
+        return {};
+
+    // 2. Let entriesForNavigationAPI be a new empty list.
+    Vector<JS::NonnullGCPtr<SessionHistoryEntry>> entries_for_navigation_api;
+
+    // 3. Let startingIndex be the index of the session history entry in rawEntries who has the greatest step less than or equal to targetStep.
+    // FIXME: Use min/max_element algorithm or some such here
+    int starting_index = 0;
+    auto max_step = 0;
+    for (auto i = 0u; i < raw_entries.size(); ++i) {
+        auto const& entry = raw_entries[i];
+        if (entry->step.has<int>()) {
+            auto step = entry->step.get<int>();
+            if (step <= target_step && step > max_step) {
+                starting_index = static_cast<int>(i);
+            }
+        }
+    }
+
+    // 4. Append rawEntries[startingIndex] to entriesForNavigationAPI.
+    entries_for_navigation_api.append(raw_entries[starting_index]);
+
+    // 5. Let startingOrigin be rawEntries[startingIndex]'s document state's origin.
+    auto starting_origin = raw_entries[starting_index]->document_state->origin();
+
+    // 6. Let i be startingIndex − 1.
+    auto i = starting_index - 1;
+
+    // 7. While i > 0:
+    while (i > 0) {
+        auto& entry = raw_entries[static_cast<unsigned>(i)];
+        // 1. If rawEntries[i]'s document state's origin is not same origin with startingOrigin, then break.
+        auto entry_origin = entry->document_state->origin();
+        if (starting_origin.has_value() && entry_origin.has_value() && !entry_origin->is_same_origin(*starting_origin))
+            break;
+
+        // 2. Prepend rawEntries[i] to entriesForNavigationAPI.
+        entries_for_navigation_api.prepend(entry);
+
+        // 3. Set i to i − 1.
+        --i;
+    }
+
+    // 8. Set i to startingIndex + 1.
+    i = starting_index + 1;
+
+    // 9. While i < rawEntries's size:
+    while (i < static_cast<int>(raw_entries.size())) {
+        auto& entry = raw_entries[static_cast<unsigned>(i)];
+        // 1. If rawEntries[i]'s document state's origin is not same origin with startingOrigin, then break.
+        auto entry_origin = entry->document_state->origin();
+        if (starting_origin.has_value() && entry_origin.has_value() && !entry_origin->is_same_origin(*starting_origin))
+            break;
+
+        // 2. Append rawEntries[i] to entriesForNavigationAPI.
+        entries_for_navigation_api.append(entry);
+
+        // 3. Set i to i + 1.
+        ++i;
+    }
+
+    // 10. Return entriesForNavigationAPI.
+    return entries_for_navigation_api;
+}
+
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#clear-the-forward-session-history
 void TraversableNavigable::clear_the_forward_session_history()
 {

--- a/Userland/Libraries/LibWeb/HTML/TraversableNavigable.cpp
+++ b/Userland/Libraries/LibWeb/HTML/TraversableNavigable.cpp
@@ -349,7 +349,6 @@ TraversableNavigable::HistoryStepResult TraversableNavigable::apply_the_history_
     // 5. FIXME: If checkForCancelation is true, and the result of checking if unloading is canceled given navigablesCrossingDocuments, traversable, targetStep,
     //           and userInvolvementForNavigateEvents is not "continue", then return that result.
     (void)check_for_cancelation;
-    (void)user_involvement_for_navigate_events;
 
     // 6. Let changingNavigables be the result of get all navigables whose current session history entry will change or reload given traversable and targetStep.
     auto changing_navigables = move(change_or_reload_navigables);
@@ -474,12 +473,14 @@ TraversableNavigable::HistoryStepResult TraversableNavigable::apply_the_history_
                 // 7. In parallel, attempt to populate the history entry's document for targetEntry, given navigable, potentiallyTargetSpecificSourceSnapshotParams,
                 //    targetSnapshotParams, with allowPOST set to allowPOST and completionSteps set to queue a global task on the navigation and traversal task source given
                 //    navigable's active window to run afterDocumentPopulated.
-                navigable->populate_session_history_entry_document(target_entry, *potentially_target_specific_source_snapshot_params, target_snapshot_params, {}, Empty {}, CSPNavigationType::Other, allow_POST, [this, after_document_populated]() mutable {
-                             queue_global_task(Task::Source::NavigationAndTraversal, *active_window(), [after_document_populated]() mutable {
-                                 after_document_populated();
-                             });
-                         })
-                    .release_value_but_fixme_should_propagate_errors();
+                Platform::EventLoopPlugin::the().deferred_invoke([target_entry, potentially_target_specific_source_snapshot_params, target_snapshot_params, this, allow_POST, navigable, after_document_populated] {
+                    navigable->populate_session_history_entry_document(target_entry, *potentially_target_specific_source_snapshot_params, target_snapshot_params, {}, Empty {}, CSPNavigationType::Other, allow_POST, [this, after_document_populated]() mutable {
+                                 queue_global_task(Task::Source::NavigationAndTraversal, *active_window(), [after_document_populated]() mutable {
+                                     after_document_populated();
+                                 });
+                             })
+                        .release_value_but_fixme_should_propagate_errors();
+                });
             }
             // Otherwise, run afterDocumentPopulated immediately.
             else {
@@ -488,11 +489,35 @@ TraversableNavigable::HistoryStepResult TraversableNavigable::apply_the_history_
         });
     }
 
-    // FIXME: 13. Let navigablesThatMustWaitBeforeHandlingSyncNavigation be an empty set.
+    // 13. Let navigablesThatMustWaitBeforeHandlingSyncNavigation be an empty set.
+    Vector<JS::GCPtr<Navigable>> navigables_that_must_wait_before_handling_sync_navigation;
 
-    // FIXME: 14. While completedChangeJobs does not equal totalChangeJobs:
+    // 14. While completedChangeJobs does not equal totalChangeJobs:
     while (completed_change_jobs != total_change_jobs) {
-        // FIXME: 1. If traversable's running nested apply history step is false, then:
+        // NOTE: Synchronous navigations that are intended to take place before this traversal jump the queue at this point,
+        //       so they can be added to the correct place in traversable's session history entries before this traversal
+        //       potentially unloads their document. More details can be found here (https://html.spec.whatwg.org/multipage/browsing-the-web.html#sync-navigation-steps-queue-jumping-examples)
+        // 1. If traversable's running nested apply history step is false, then:
+        if (!m_running_nested_apply_history_step) {
+            // 1. While traversable's session history traversal queue's algorithm set contains one or more synchronous
+            //    navigation steps with a target navigable not contained in navigablesThatMustWaitBeforeHandlingSyncNavigation:
+            //   1. Let steps be the first item in traversable's session history traversal queue's algorithm set
+            //    that is synchronous navigation steps with a target navigable not contained in navigablesThatMustWaitBeforeHandlingSyncNavigation.
+            //   2. Remove steps from traversable's session history traversal queue's algorithm set.
+            for (auto steps = m_session_history_traversal_queue.first_synchronous_navigation_steps_with_target_navigable_not_contained_in(navigables_that_must_wait_before_handling_sync_navigation);
+                 steps.target_navigable != nullptr;
+                 steps = m_session_history_traversal_queue.first_synchronous_navigation_steps_with_target_navigable_not_contained_in(navigables_that_must_wait_before_handling_sync_navigation)) {
+
+                // 3. Set traversable's running nested apply history step to true.
+                m_running_nested_apply_history_step = true;
+
+                // 4. Run steps.
+                steps.steps();
+
+                // 5. Set traversable's running nested apply history step to false.
+                m_running_nested_apply_history_step = false;
+            }
+        }
 
         // AD-HOC: Since currently populate_session_history_entry_document does not run in parallel
         //         we call spin_until to interrupt execution of this function and let document population
@@ -531,16 +556,18 @@ TraversableNavigable::HistoryStepResult TraversableNavigable::apply_the_history_
         auto script_history_length = history_object_length_and_index.script_history_length;
         auto script_history_index = history_object_length_and_index.script_history_index;
 
-        // FIXME: 9. Append navigable to navigablesThatMustWaitBeforeHandlingSyncNavigation.
+        // 9. Append navigable to navigablesThatMustWaitBeforeHandlingSyncNavigation.
+        navigables_that_must_wait_before_handling_sync_navigation.append(*navigable);
 
         // 10. Let entriesForNavigationAPI be the result of getting session history entries for the navigation API given navigable and targetStep.
         auto entries_for_navigation_api = get_session_history_entries_for_the_navigation_api(*navigable, target_step);
 
         // 11. Queue a global task on the navigation and traversal task source given navigable's active window to run the steps:
-        queue_global_task(Task::Source::NavigationAndTraversal, *navigable->active_window(), [&, target_entry, navigable, displayed_document, update_only = changing_navigable_continuation.update_only, script_history_length, script_history_index, entries_for_navigation_api = move(entries_for_navigation_api)]() mutable {
+        queue_global_task(Task::Source::NavigationAndTraversal, *navigable->active_window(), [&completed_change_jobs, target_entry, navigable, displayed_document, update_only = changing_navigable_continuation.update_only, script_history_length, script_history_index, entries_for_navigation_api = move(entries_for_navigation_api), user_involvement_for_navigate_events]() mutable {
             // NOTE: This check is not in the spec but we should not continue navigation if navigable has been destroyed.
-            if (navigable->has_been_destroyed())
+            if (navigable->has_been_destroyed()) {
                 return;
+            }
 
             // 1. If changingNavigableContinuation's update-only is false, then:
             if (!update_only) {
@@ -593,15 +620,47 @@ TraversableNavigable::HistoryStepResult TraversableNavigable::apply_the_history_
         });
     }
 
-    // FIXME: 15. Let totalNonchangingJobs be the size of nonchangingNavigablesThatStillNeedUpdates.
+    // 15. Let totalNonchangingJobs be the size of nonchangingNavigablesThatStillNeedUpdates.
+    auto total_non_changing_jobs = non_changing_navigables_that_still_need_updates.size();
 
-    // FIXME: 16. Let completedNonchangingJobs be 0.
+    // 16. Let completedNonchangingJobs be 0.
+    auto completed_non_changing_jobs = 0u;
 
-    // FIXME: 17. Let (scriptHistoryLength, scriptHistoryIndex) be the result of getting the history object length and index given traversable and targetStep.
+    // 17. Let (scriptHistoryLength, scriptHistoryIndex) be the result of getting the history object length and index given traversable and targetStep.
+    auto length_and_index = get_the_history_object_length_and_index(target_step);
+    auto script_history_length = length_and_index.script_history_length;
+    auto script_history_index = length_and_index.script_history_index;
 
-    // FIXME: 18. For each navigable of nonchangingNavigablesThatStillNeedUpdates, queue a global task on the navigation and traversal task source given navigable's active window to run the steps:
+    // 18. For each navigable of nonchangingNavigablesThatStillNeedUpdates, queue a global task on the navigation and traversal task source given navigable's active window to run the steps:
+    for (auto& navigable : non_changing_navigables_that_still_need_updates) {
+        queue_global_task(Task::Source::NavigationAndTraversal, *navigable->active_window(), [&] {
+            // NOTE: This check is not in the spec but we should not continue navigation if navigable has been destroyed.
+            if (navigable->has_been_destroyed()) {
+                ++completed_non_changing_jobs;
+                return;
+            }
 
-    // FIXME: 19. Wait for completedNonchangingJobs to equal totalNonchangingJobs.
+            // 1. Let document be navigable's active document.
+            auto document = navigable->active_document();
+
+            // 2. Set document's history object's index to scriptHistoryIndex.
+            document->history()->m_index = script_history_index;
+
+            // 3. Set document's history object's length to scriptHistoryLength.
+            document->history()->m_length = script_history_length;
+
+            // 4. Increment completedNonchangingJobs.
+            ++completed_non_changing_jobs;
+        });
+    }
+
+    // 19. Wait for completedNonchangingJobs to equal totalNonchangingJobs.
+    // AD-HOC: Since currently populate_session_history_entry_document does not run in parallel
+    //         we call spin_until to interrupt execution of this function and let document population
+    //         to complete.
+    Platform::EventLoopPlugin::the().spin_until([&] {
+        return completed_non_changing_jobs == total_non_changing_jobs;
+    });
 
     // 20. Set traversable's current session history step to targetStep.
     m_current_session_history_step = target_step;

--- a/Userland/Libraries/LibWeb/HTML/TraversableNavigable.h
+++ b/Userland/Libraries/LibWeb/HTML/TraversableNavigable.h
@@ -39,10 +39,17 @@ public:
     };
     HistoryObjectLengthAndIndex get_the_history_object_length_and_index(int) const;
 
-    void apply_the_traverse_history_step(int, Optional<SourceSnapshotParams>, JS::GCPtr<Navigable>, UserNavigationInvolvement);
-    void apply_the_reload_history_step();
-    void apply_the_push_or_replace_history_step(int step);
-    void update_for_navigable_creation_or_destruction();
+    enum class HistoryStepResult {
+        InitiatorDisallowed,
+        CanceledByBeforeUnload,
+        CanceledByNavigate,
+        Applied,
+    };
+
+    HistoryStepResult apply_the_traverse_history_step(int, Optional<SourceSnapshotParams>, JS::GCPtr<Navigable>, UserNavigationInvolvement);
+    HistoryStepResult apply_the_reload_history_step();
+    HistoryStepResult apply_the_push_or_replace_history_step(int step);
+    HistoryStepResult update_for_navigable_creation_or_destruction();
 
     int get_the_used_step(int step) const;
     Vector<JS::Handle<Navigable>> get_all_navigables_whose_current_session_history_entry_will_change_or_reload(int) const;
@@ -74,17 +81,10 @@ private:
 
     virtual void visit_edges(Cell::Visitor&) override;
 
-    enum class HistoryStepResult {
-        InitiatorDisallowed,
-        CanceledByBeforeUnload,
-        CanceledByNavigate,
-        Applied,
-    };
     // FIXME: Fix spec typo cancelation --> cancellation
     HistoryStepResult apply_the_history_step(
         int step,
         bool check_for_cancelation,
-        bool fire_navigate_event_on_commit,
         Optional<SourceSnapshotParams>,
         JS::GCPtr<Navigable> initiator_to_check,
         Optional<UserNavigationInvolvement> user_involvement_for_navigate_events);

--- a/Userland/Libraries/LibWeb/HTML/TraversableNavigable.h
+++ b/Userland/Libraries/LibWeb/HTML/TraversableNavigable.h
@@ -68,6 +68,11 @@ public:
         m_session_history_traversal_queue.append(move(steps));
     }
 
+    void append_session_history_synchronous_navigation_steps(JS::NonnullGCPtr<Navigable> target_navigable, JS::SafeFunction<void()> steps)
+    {
+        m_session_history_traversal_queue.append_sync(move(steps), target_navigable);
+    }
+
     void process_session_history_traversal_queue()
     {
         m_session_history_traversal_queue.process();

--- a/Userland/Libraries/LibWeb/HTML/TraversableNavigable.h
+++ b/Userland/Libraries/LibWeb/HTML/TraversableNavigable.h
@@ -72,6 +72,8 @@ private:
 
     void apply_the_history_step(int step, Optional<SourceSnapshotParams> = {});
 
+    Vector<JS::NonnullGCPtr<SessionHistoryEntry>> get_session_history_entries_for_the_navigation_api(JS::NonnullGCPtr<Navigable>, int);
+
     // https://html.spec.whatwg.org/multipage/document-sequences.html#tn-current-session-history-step
     int m_current_session_history_step { 0 };
 

--- a/Userland/Libraries/LibWeb/HTML/TraversableNavigable.h
+++ b/Userland/Libraries/LibWeb/HTML/TraversableNavigable.h
@@ -39,15 +39,19 @@ public:
     };
     HistoryObjectLengthAndIndex get_the_history_object_length_and_index(int) const;
 
+    void apply_the_traverse_history_step(int, Optional<SourceSnapshotParams>, JS::GCPtr<Navigable>, UserNavigationInvolvement);
     void apply_the_reload_history_step();
     void apply_the_push_or_replace_history_step(int step);
     void update_for_navigable_creation_or_destruction();
 
     int get_the_used_step(int step) const;
     Vector<JS::Handle<Navigable>> get_all_navigables_whose_current_session_history_entry_will_change_or_reload(int) const;
+    Vector<JS::Handle<Navigable>> get_all_navigables_that_only_need_history_object_length_index_update(int) const;
+    Vector<JS::Handle<Navigable>> get_all_navigables_that_might_experience_a_cross_document_traversal(int) const;
+
     Vector<int> get_all_used_history_steps() const;
     void clear_the_forward_session_history();
-    void traverse_the_history_by_delta(int delta);
+    void traverse_the_history_by_delta(int delta, Optional<DOM::Document&> source_document = {});
 
     void close_top_level_traversable();
     void destroy_top_level_traversable();
@@ -70,7 +74,20 @@ private:
 
     virtual void visit_edges(Cell::Visitor&) override;
 
-    void apply_the_history_step(int step, Optional<SourceSnapshotParams> = {});
+    enum class HistoryStepResult {
+        InitiatorDisallowed,
+        CanceledByBeforeUnload,
+        CanceledByNavigate,
+        Applied,
+    };
+    // FIXME: Fix spec typo cancelation --> cancellation
+    HistoryStepResult apply_the_history_step(
+        int step,
+        bool check_for_cancelation,
+        bool fire_navigate_event_on_commit,
+        Optional<SourceSnapshotParams>,
+        JS::GCPtr<Navigable> initiator_to_check,
+        Optional<UserNavigationInvolvement> user_involvement_for_navigate_events);
 
     Vector<JS::NonnullGCPtr<SessionHistoryEntry>> get_session_history_entries_for_the_navigation_api(JS::NonnullGCPtr<Navigable>, int);
 

--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -285,7 +285,7 @@ bool EventHandler::handle_mouseup(CSSPixelPoint position, CSSPixelPoint screen_p
                     auto url = document->parse_url(href);
                     dbgln("Web::EventHandler: Clicking on a link to {}", url);
                     if (button == GUI::MouseButton::Primary) {
-                        MUST(document->navigable()->navigate({ .url = url, .source_document = document }));
+                        MUST(document->navigable()->navigate({ .url = url, .source_document = document, .user_involvement = HTML::UserNavigationInvolvement::BrowserUI }));
                     } else if (button == GUI::MouseButton::Middle) {
                         if (auto* page = m_browsing_context->page())
                             page->client().page_did_middle_click_link(url, link->target(), modifiers);

--- a/Userland/Libraries/LibWeb/Page/Page.cpp
+++ b/Userland/Libraries/LibWeb/Page/Page.cpp
@@ -45,14 +45,16 @@ void Page::set_focused_browsing_context(Badge<EventHandler>, HTML::BrowsingConte
 
 void Page::load(const AK::URL& url)
 {
-    (void)top_level_traversable()->navigate({ .url = url, .source_document = *top_level_traversable()->active_document() });
+    (void)top_level_traversable()->navigate({ .url = url, .source_document = *top_level_traversable()->active_document(), .user_involvement = HTML::UserNavigationInvolvement::BrowserUI });
 }
 
 void Page::load_html(StringView html)
 {
+
     (void)top_level_traversable()->navigate({ .url = "about:srcdoc"sv,
         .source_document = *top_level_traversable()->active_document(),
-        .document_resource = String::from_utf8(html).release_value_but_fixme_should_propagate_errors() });
+        .document_resource = String::from_utf8(html).release_value_but_fixme_should_propagate_errors(),
+        .user_involvement = HTML::UserNavigationInvolvement::BrowserUI });
 }
 
 Gfx::Palette Page::palette() const

--- a/Userland/Libraries/LibWeb/WebIDL/Promise.h
+++ b/Userland/Libraries/LibWeb/WebIDL/Promise.h
@@ -29,6 +29,6 @@ JS::NonnullGCPtr<JS::Promise> react_to_promise(Promise const&, Optional<Reaction
 JS::NonnullGCPtr<JS::Promise> upon_fulfillment(Promise const&, ReactionSteps);
 JS::NonnullGCPtr<JS::Promise> upon_rejection(Promise const&, ReactionSteps);
 void mark_promise_as_handled(Promise const&);
-void wait_for_all(JS::Realm&, JS::MarkedVector<JS::NonnullGCPtr<Promise>> const& promises, JS::SafeFunction<void(JS::MarkedVector<JS::Value> const&)> success_steps, JS::SafeFunction<void(JS::Value)> failure_steps);
+void wait_for_all(JS::Realm&, Vector<JS::NonnullGCPtr<Promise>> const& promises, Function<void(Vector<JS::Value> const&)> success_steps, Function<void(JS::Value)> failure_steps);
 
 }


### PR DESCRIPTION
For some reason, `navigation.navigate(navigation.currentEntry.url + "#some-fragment")` crashes in an assertion failure, while history.pushState({}, "hello", navigation.currentEntry.url + "#hello") does not.