### PR TITLE
LibJS: Stop vending unstable pointers to instructions while generating bytecode

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/Generator.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.cpp
@@ -394,13 +394,13 @@ void Generator::generate_scoped_jump(JumpType type)
         switch (boundary) {
         case Break:
             if (type == JumpType::Break) {
-                emit<Op::Jump>().set_targets(nearest_breakable_scope(), {});
+                emit<Op::Jump>(nearest_breakable_scope());
                 return;
             }
             break;
         case Continue:
             if (type == JumpType::Continue) {
-                emit<Op::Jump>().set_targets(nearest_continuable_scope(), {});
+                emit<Op::Jump>(nearest_continuable_scope());
                 return;
             }
             break;
@@ -455,7 +455,7 @@ void Generator::generate_labelled_jump(JumpType type, DeprecatedFlyString const&
         }
 
         if (jumpable_scope.language_label_set.contains_slow(label)) {
-            emit<Op::Jump>().set_targets(jumpable_scope.bytecode_target, {});
+            emit<Op::Jump>(jumpable_scope.bytecode_target);
             return;
         }
     }

--- a/Userland/Libraries/LibJS/Bytecode/Generator.h
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.h
@@ -45,7 +45,7 @@ public:
     };
 
     template<typename OpType, typename... Args>
-    OpType& emit(Args&&... args)
+    void emit(Args&&... args)
     {
         VERIFY(!is_current_block_terminated());
         size_t slot_offset = m_current_basic_block->size();
@@ -56,7 +56,6 @@ public:
             m_current_basic_block->terminate({});
         auto* op = static_cast<OpType*>(slot);
         op->set_source_record({ m_current_ast_node->start_offset(), m_current_ast_node->end_offset() });
-        return *op;
     }
 
     template<typename OpType, typename... Args>

--- a/Userland/Libraries/LibJS/Bytecode/Generator.h
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.h
@@ -60,7 +60,7 @@ public:
     }
 
     template<typename OpType, typename... Args>
-    OpType& emit_with_extra_register_slots(size_t extra_register_slots, Args&&... args)
+    void emit_with_extra_register_slots(size_t extra_register_slots, Args&&... args)
     {
         VERIFY(!is_current_block_terminated());
 
@@ -73,7 +73,6 @@ public:
             m_current_basic_block->terminate({});
         auto* op = static_cast<OpType*>(slot);
         op->set_source_record({ m_current_ast_node->start_offset(), m_current_ast_node->end_offset() });
-        return *op;
     }
 
     CodeGenerationErrorOr<void> emit_load_from_reference(JS::ASTNode const&);

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -830,12 +830,6 @@ public:
     {
     }
 
-    void set_targets(Label true_target, Optional<Label> false_target)
-    {
-        m_true_target = move(true_target);
-        m_false_target = move(false_target);
-    }
-
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     DeprecatedString to_deprecated_string_impl(Bytecode::Executable const&) const;
 

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -816,21 +816,21 @@ class Jump : public Instruction {
 public:
     constexpr static bool IsTerminator = true;
 
-    explicit Jump(Type type, Optional<Label> taken_target = {}, Optional<Label> nontaken_target = {})
+    explicit Jump(Type type, Label taken_target, Optional<Label> nontaken_target = {})
         : Instruction(type, sizeof(*this))
         , m_true_target(move(taken_target))
         , m_false_target(move(nontaken_target))
     {
     }
 
-    explicit Jump(Optional<Label> taken_target = {}, Optional<Label> nontaken_target = {})
+    explicit Jump(Label taken_target, Optional<Label> nontaken_target = {})
         : Instruction(Type::Jump, sizeof(*this))
         , m_true_target(move(taken_target))
         , m_false_target(move(nontaken_target))
     {
     }
 
-    void set_targets(Optional<Label> true_target, Optional<Label> false_target)
+    void set_targets(Label true_target, Optional<Label> false_target)
     {
         m_true_target = move(true_target);
         m_false_target = move(false_target);
@@ -849,7 +849,7 @@ protected:
 
 class JumpConditional final : public Jump {
 public:
-    explicit JumpConditional(Optional<Label> true_target = {}, Optional<Label> false_target = {})
+    explicit JumpConditional(Label true_target, Label false_target)
         : Jump(Type::JumpConditional, move(true_target), move(false_target))
     {
     }
@@ -860,7 +860,7 @@ public:
 
 class JumpNullish final : public Jump {
 public:
-    explicit JumpNullish(Optional<Label> true_target = {}, Optional<Label> false_target = {})
+    explicit JumpNullish(Label true_target, Label false_target)
         : Jump(Type::JumpNullish, move(true_target), move(false_target))
     {
     }
@@ -871,7 +871,7 @@ public:
 
 class JumpUndefined final : public Jump {
 public:
-    explicit JumpUndefined(Optional<Label> true_target = {}, Optional<Label> false_target = {})
+    explicit JumpUndefined(Label true_target, Label false_target)
         : Jump(Type::JumpUndefined, move(true_target), move(false_target))
     {
     }


### PR DESCRIPTION
The bytecode instruction storage may resize while generating bytecode, so it's not safe to take the address of an instruction and use it later.

Thankfully, we don't actually need to do that, so this PR removes the APIs that allowed you to do it.