### PR TITLE
ICC: Implement Profile::to_pcs() for grayscale colors

### DIFF
--- a/Userland/Libraries/LibGfx/ICC/Profile.cpp
+++ b/Userland/Libraries/LibGfx/ICC/Profile.cpp
@@ -1437,9 +1437,12 @@ ErrorOr<FloatVector3> Profile::to_pcs(ReadonlyBytes color) const
         };
 
         if (data_color_space() == ColorSpace::Gray) {
+            VERIFY(color.size() == 1); // True because of color.size() check further up.
+
             // ICC v4, F.2 grayTRCTag
-            // FIXME
-            return Error::from_string_literal("ICC::Profile::to_pcs: Gray handling not yet implemented");
+            // "connection = grayTRC[device]"
+            float gray = evaluate_curve(grayTRCTag, color[0] / 255.f);
+            return FloatVector3 { gray, gray, gray };
         }
 
         // FIXME: Per ICC v4, A.1 General, this should also handle HLS, HSV, YCbCr.


### PR DESCRIPTION
There's probably a nicer way of doing this where we don't need to expand
the gray value into a full Vector3, but for now this is good enough.

Makes PDFs written by macOS 13.5.2's "Save as PDF..." feature show up.

---

Before:

<img width="712" alt="Screenshot 2023-09-28 at 10 08 51 AM" src="https://github.com/SerenityOS/serenity/assets/3487/03a3b473-ddac-48f9-9fc9-d9c5b33c0699">

After:

<img width="712" alt="Screenshot 2023-09-28 at 10 09 03 AM" src="https://github.com/SerenityOS/serenity/assets/3487/f36eddd5-65c2-4d44-aa60-dc20b8c21419">

(This is with a PDF that I made in TextEdit by typing in "Test" and then using either File->Export as PDF… or File->Print…->PDF->Save as PDF…)