### PR TITLE
LibWeb: Implement a `<flex>` dimension type

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPropertyID.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPropertyID.cpp
@@ -21,7 +21,7 @@ void generate_bounds_checking_function(JsonObject& properties, SourceGenerator& 
 static bool type_name_is_enum(StringView type_name)
 {
     return !AK::first_is_one_of(type_name,
-        "angle"sv, "color"sv, "custom-ident"sv, "easing-function"sv, "frequency"sv, "image"sv,
+        "angle"sv, "color"sv, "custom-ident"sv, "easing-function"sv, "flex"sv, "frequency"sv, "image"sv,
         "integer"sv, "length"sv, "number"sv, "paint"sv, "percentage"sv, "ratio"sv, "rect"sv,
         "resolution"sv, "string"sv, "time"sv, "url"sv);
 }
@@ -172,6 +172,7 @@ enum class ValueType {
     CustomIdent,
     EasingFunction,
     FilterValueList,
+    Flex,
     Frequency,
     Image,
     Integer,
@@ -193,6 +194,7 @@ Optional<ValueType> property_resolves_percentages_relative_to(PropertyID);
 
 // These perform range-checking, but are also safe to call with properties that don't accept that type. (They'll just return false.)
 bool property_accepts_angle(PropertyID, Angle const&);
+bool property_accepts_flex(PropertyID, Flex const&);
 bool property_accepts_frequency(PropertyID, Frequency const&);
 bool property_accepts_integer(PropertyID, i64 const&);
 bool property_accepts_length(PropertyID, Length const&);
@@ -620,6 +622,8 @@ bool property_accepts_type(PropertyID property_id, ValueType value_type)
                     property_generator.appendln("        case ValueType::CustomIdent:");
                 } else if (type_name == "easing-function") {
                     property_generator.appendln("        case ValueType::EasingFunction:");
+                } else if (type_name == "flex") {
+                    property_generator.appendln("        case ValueType::Flex:");
                 } else if (type_name == "frequency") {
                     property_generator.appendln("        case ValueType::Frequency:");
                 } else if (type_name == "image") {
@@ -774,6 +778,7 @@ size_t property_maximum_value_count(PropertyID property_id)
 })~~~");
 
     generate_bounds_checking_function(properties, generator, "angle"sv, "Angle"sv, "Deg"sv);
+    generate_bounds_checking_function(properties, generator, "flex"sv, "Flex"sv, "Fr"sv);
     generate_bounds_checking_function(properties, generator, "frequency"sv, "Frequency"sv, "Hertz"sv);
     generate_bounds_checking_function(properties, generator, "integer"sv, "i64"sv, {}, "value"sv);
     generate_bounds_checking_function(properties, generator, "length"sv, "Length"sv, {}, "value.raw_value()"sv);

--- a/Meta/gn/secondary/Userland/Libraries/LibWeb/CSS/BUILD.gn
+++ b/Meta/gn/secondary/Userland/Libraries/LibWeb/CSS/BUILD.gn
@@ -28,6 +28,7 @@ source_set("CSS") {
     "Clip.cpp",
     "Display.cpp",
     "EdgeRect.cpp",
+    "Flex.cpp",
     "FontFace.cpp",
     "Frequency.cpp",
     "GridTrackPlacement.cpp",

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -38,6 +38,7 @@ set(SOURCES
     CSS/CSSSupportsRule.cpp
     CSS/Display.cpp
     CSS/EdgeRect.cpp
+    CSS/Flex.cpp
     CSS/FontFace.cpp
     CSS/Frequency.cpp
     CSS/GridTrackPlacement.cpp

--- a/Userland/Libraries/LibWeb/CSS/CSSNumericType.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSNumericType.cpp
@@ -20,6 +20,8 @@ Optional<CSSNumericType::BaseType> CSSNumericType::base_type_from_value_type(Val
     switch (value_type) {
     case ValueType::Angle:
         return BaseType::Angle;
+    case ValueType::Flex:
+        return BaseType::Flex;
     case ValueType::Frequency:
         return BaseType::Frequency;
     case ValueType::Length:

--- a/Userland/Libraries/LibWeb/CSS/CSSNumericType.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSNumericType.h
@@ -66,7 +66,6 @@ public:
     bool matches_angle() const { return matches_dimension(BaseType::Angle); }
     bool matches_angle_percentage() const { return matches_dimension_percentage(BaseType::Angle); }
     bool matches_flex() const { return matches_dimension(BaseType::Flex); }
-    bool matches_flex_percentage() const { return matches_dimension_percentage(BaseType::Flex); }
     bool matches_frequency() const { return matches_dimension(BaseType::Frequency); }
     bool matches_frequency_percentage() const { return matches_dimension_percentage(BaseType::Frequency); }
     bool matches_length() const { return matches_dimension(BaseType::Length); }

--- a/Userland/Libraries/LibWeb/CSS/Flex.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Flex.cpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2023, Sam Atkins <atkinssj@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "Flex.h"
+#include <LibWeb/CSS/Percentage.h>
+
+namespace Web::CSS {
+
+Flex::Flex(double value, Type type)
+    : m_type(type)
+    , m_value(value)
+{
+}
+
+Flex Flex::make_fr(double value)
+{
+    return { value, Type::Fr };
+}
+
+Flex Flex::percentage_of(Percentage const& percentage) const
+{
+    return Flex { percentage.as_fraction() * m_value, m_type };
+}
+
+String Flex::to_string() const
+{
+    return MUST(String::formatted("{}fr", to_fr()));
+}
+
+double Flex::to_fr() const
+{
+    switch (m_type) {
+    case Type::Fr:
+        return m_value;
+    }
+    VERIFY_NOT_REACHED();
+}
+
+StringView Flex::unit_name() const
+{
+    switch (m_type) {
+    case Type::Fr:
+        return "fr"sv;
+    }
+    VERIFY_NOT_REACHED();
+}
+
+Optional<Flex::Type> Flex::unit_from_name(StringView name)
+{
+    if (name.equals_ignoring_ascii_case("fr"sv))
+        return Type::Fr;
+
+    return {};
+}
+
+}

--- a/Userland/Libraries/LibWeb/CSS/Flex.h
+++ b/Userland/Libraries/LibWeb/CSS/Flex.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2023, Sam Atkins <atkinssj@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Optional.h>
+#include <AK/String.h>
+#include <LibWeb/Forward.h>
+
+namespace Web::CSS {
+
+// https://drafts.csswg.org/css-grid-2/#typedef-flex
+class Flex {
+public:
+    enum class Type {
+        Fr,
+    };
+
+    static Optional<Type> unit_from_name(StringView);
+
+    Flex(double value, Type type);
+    static Flex make_fr(double);
+    Flex percentage_of(Percentage const&) const;
+
+    String to_string() const;
+    double to_fr() const;
+
+    Type type() const { return m_type; }
+    double raw_value() const { return m_value; }
+
+    bool operator==(Flex const& other) const
+    {
+        return m_type == other.m_type && m_value == other.m_value;
+    }
+
+    int operator<=>(Flex const& other) const
+    {
+        auto this_fr = to_fr();
+        auto other_fr = other.to_fr();
+
+        if (this_fr < other_fr)
+            return -1;
+        if (this_fr > other_fr)
+            return 1;
+        return 0;
+    }
+
+private:
+    StringView unit_name() const;
+
+    Type m_type;
+    double m_value { 0 };
+};
+
+}
+
+template<>
+struct AK::Formatter<Web::CSS::Flex> : Formatter<StringView> {
+    ErrorOr<void> format(FormatBuilder& builder, Web::CSS::Flex const& flex)
+    {
+        return Formatter<StringView>::format(builder, flex.to_string());
+    }
+};

--- a/Userland/Libraries/LibWeb/CSS/GridTrackSize.cpp
+++ b/Userland/Libraries/LibWeb/CSS/GridTrackSize.cpp
@@ -14,7 +14,7 @@ GridSize::GridSize(LengthPercentage length_percentage)
     : m_type(Type::LengthPercentage)
     , m_length_percentage(length_percentage) {};
 
-GridSize::GridSize(double flex_factor)
+GridSize::GridSize(Flex flex_factor)
     : m_type(Type::FlexibleLength)
     , m_length_percentage { Length::make_px(0) }
     , m_flex_factor(flex_factor)
@@ -87,7 +87,7 @@ String GridSize::to_string() const
     case Type::LengthPercentage:
         return m_length_percentage.to_string();
     case Type::FlexibleLength:
-        return MUST(String::formatted("{}fr", m_flex_factor));
+        return m_flex_factor.to_string();
     case Type::MaxContent:
         return "max-content"_string;
     case Type::MinContent:

--- a/Userland/Libraries/LibWeb/CSS/GridTrackSize.h
+++ b/Userland/Libraries/LibWeb/CSS/GridTrackSize.h
@@ -22,7 +22,7 @@ public:
     };
 
     GridSize(LengthPercentage);
-    GridSize(double);
+    GridSize(Flex);
     GridSize(Type);
     GridSize();
     ~GridSize();
@@ -38,7 +38,7 @@ public:
     bool is_min_content() const { return m_type == Type::MinContent; }
 
     LengthPercentage length_percentage() const { return m_length_percentage; }
-    double flex_factor() const { return m_flex_factor; }
+    double flex_factor() const { return m_flex_factor.to_fr(); }
 
     // https://www.w3.org/TR/css-grid-2/#layout-algorithm
     // An intrinsic sizing function (min-content, max-content, auto, fit-content()).
@@ -57,13 +57,13 @@ public:
     {
         return m_type == other.type()
             && m_length_percentage == other.length_percentage()
-            && m_flex_factor == other.flex_factor();
+            && m_flex_factor == other.m_flex_factor;
     }
 
 private:
     Type m_type;
     LengthPercentage m_length_percentage;
-    double m_flex_factor { 0 };
+    Flex m_flex_factor { 0, Flex::Type::Fr };
 };
 
 class GridMinMax {

--- a/Userland/Libraries/LibWeb/CSS/GridTrackSize.h
+++ b/Userland/Libraries/LibWeb/CSS/GridTrackSize.h
@@ -37,8 +37,8 @@ public:
     bool is_max_content() const { return m_type == Type::MaxContent; }
     bool is_min_content() const { return m_type == Type::MinContent; }
 
-    LengthPercentage length_percentage() const { return m_length_percentage; }
-    double flex_factor() const { return m_flex_factor.to_fr(); }
+    LengthPercentage length_percentage() const { return m_value.get<LengthPercentage>(); }
+    double flex_factor() const { return m_value.get<Flex>().to_fr(); }
 
     // https://www.w3.org/TR/css-grid-2/#layout-algorithm
     // An intrinsic sizing function (min-content, max-content, auto, fit-content()).
@@ -47,7 +47,7 @@ public:
 
     bool is_definite() const
     {
-        return type() == Type::LengthPercentage && !m_length_percentage.is_auto();
+        return type() == Type::LengthPercentage && !length_percentage().is_auto();
     }
 
     Size css_size() const;
@@ -56,14 +56,12 @@ public:
     bool operator==(GridSize const& other) const
     {
         return m_type == other.type()
-            && m_length_percentage == other.length_percentage()
-            && m_flex_factor == other.m_flex_factor;
+            && m_value == other.m_value;
     }
 
 private:
     Type m_type;
-    LengthPercentage m_length_percentage;
-    Flex m_flex_factor { 0, Flex::Type::Fr };
+    Variant<Empty, LengthPercentage, Flex> m_value;
 };
 
 class GridMinMax {

--- a/Userland/Libraries/LibWeb/CSS/Parser/Dimension.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Dimension.h
@@ -8,6 +8,7 @@
 
 #include <AK/Variant.h>
 #include <LibWeb/CSS/Angle.h>
+#include <LibWeb/CSS/Flex.h>
 #include <LibWeb/CSS/Frequency.h>
 #include <LibWeb/CSS/Length.h>
 #include <LibWeb/CSS/Percentage.h>
@@ -20,6 +21,11 @@ namespace Web::CSS::Parser {
 class Dimension {
 public:
     Dimension(Angle&& value)
+        : m_value(move(value))
+    {
+    }
+
+    Dimension(Flex&& value)
         : m_value(move(value))
     {
     }
@@ -58,6 +64,9 @@ public:
             return angle();
         return percentage();
     }
+
+    bool is_flex() const { return m_value.has<Flex>(); }
+    Flex flex() const { return m_value.get<Flex>(); }
 
     bool is_frequency() const { return m_value.has<Frequency>(); }
     Frequency frequency() const { return m_value.get<Frequency>(); }
@@ -99,7 +108,7 @@ public:
     }
 
 private:
-    Variant<Angle, Frequency, Length, Percentage, Resolution, Time> m_value;
+    Variant<Angle, Flex, Frequency, Length, Percentage, Resolution, Time> m_value;
 };
 
 }

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -6957,6 +6957,17 @@ bool Parser::substitute_attr_function(DOM::Element& element, StringView property
                     return true;
                 }
             }
+        } else if (attribute_type.equals_ignoring_ascii_case("flex"_fly_string)) {
+            // Parse a component value from the attribute’s value.
+            auto component_value = MUST(Parser::Parser::create(m_context, attribute_value)).parse_as_component_value();
+            // If the result is a <dimension-token> whose unit matches the given type, the result is the substitution value.
+            // Otherwise, there is no substitution value.
+            if (component_value.has_value() && component_value->is(Token::Type::Dimension)) {
+                if (Flex::unit_from_name(component_value->token().dimension_unit()).has_value()) {
+                    dest.append(component_value.release_value());
+                    return true;
+                }
+            }
         } else if (attribute_type.equals_ignoring_ascii_case("frequency"_fly_string)) {
             // Parse a component value from the attribute’s value.
             auto component_value = MUST(Parser::Parser::create(m_context, attribute_value)).parse_as_component_value();
@@ -7043,6 +7054,9 @@ bool Parser::substitute_attr_function(DOM::Element& element, StringView property
                     dest.empend(Token::create_dimension(component_value->token().number_value(), attribute_type));
                     return true;
                 } else if (auto angle_unit = Angle::unit_from_name(attribute_type); angle_unit.has_value()) {
+                    dest.empend(Token::create_dimension(component_value->token().number_value(), attribute_type));
+                    return true;
+                } else if (auto flex_unit = Flex::unit_from_name(attribute_type); flex_unit.has_value()) {
                     dest.empend(Token::create_dimension(component_value->token().number_value(), attribute_type));
                     return true;
                 } else if (auto frequency_unit = Frequency::unit_from_name(attribute_type); frequency_unit.has_value()) {

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -6194,6 +6194,7 @@ Optional<Parser::PropertyAndValue> Parser::parse_css_value_for_properties(Readon
     }
 
     bool property_accepts_dimension = any_property_accepts_type(property_ids, ValueType::Angle).has_value()
+        || any_property_accepts_type(property_ids, ValueType::Frequency).has_value()
         || any_property_accepts_type(property_ids, ValueType::Length).has_value()
         || any_property_accepts_type(property_ids, ValueType::Percentage).has_value()
         || any_property_accepts_type(property_ids, ValueType::Resolution).has_value()

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
@@ -24,6 +24,7 @@
 #include <LibWeb/CSS/StyleValues/EasingStyleValue.h>
 #include <LibWeb/CSS/StyleValues/EdgeStyleValue.h>
 #include <LibWeb/CSS/StyleValues/FilterValueListStyleValue.h>
+#include <LibWeb/CSS/StyleValues/FlexStyleValue.h>
 #include <LibWeb/CSS/StyleValues/FrequencyStyleValue.h>
 #include <LibWeb/CSS/StyleValues/GridAutoFlowStyleValue.h>
 #include <LibWeb/CSS/StyleValues/GridTemplateAreaStyleValue.h>

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -96,6 +96,7 @@ using StyleValueVector = Vector<ValueComparingNonnullRefPtr<StyleValue const>>;
     __ENUMERATE_STYLE_VALUE_TYPE(Easing, easing)                           \
     __ENUMERATE_STYLE_VALUE_TYPE(Edge, edge)                               \
     __ENUMERATE_STYLE_VALUE_TYPE(FilterValueList, filter_value_list)       \
+    __ENUMERATE_STYLE_VALUE_TYPE(Flex, flex)                               \
     __ENUMERATE_STYLE_VALUE_TYPE(Frequency, frequency)                     \
     __ENUMERATE_STYLE_VALUE_TYPE(GridAutoFlow, grid_auto_flow)             \
     __ENUMERATE_STYLE_VALUE_TYPE(GridTemplateArea, grid_template_area)     \

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
@@ -12,6 +12,7 @@
 #include <AK/Function.h>
 #include <LibWeb/CSS/Angle.h>
 #include <LibWeb/CSS/CSSNumericType.h>
+#include <LibWeb/CSS/Flex.h>
 #include <LibWeb/CSS/Frequency.h>
 #include <LibWeb/CSS/Length.h>
 #include <LibWeb/CSS/Percentage.h>
@@ -26,6 +27,7 @@ class CalculatedStyleValue : public StyleValue {
 public:
     enum class ResolvedType {
         Angle,
+        Flex,
         Frequency,
         Integer,
         Length,
@@ -43,11 +45,11 @@ public:
         Divide,
     };
 
-    using PercentageBasis = Variant<Empty, Angle, Frequency, Length, Time>;
+    using PercentageBasis = Variant<Empty, Angle, Flex, Frequency, Length, Time>;
 
     class CalculationResult {
     public:
-        using Value = Variant<Number, Angle, Frequency, Length, Percentage, Time>;
+        using Value = Variant<Number, Angle, Flex, Frequency, Length, Percentage, Time>;
         CalculationResult(Value value)
             : m_value(move(value))
         {
@@ -78,6 +80,9 @@ public:
     bool resolves_to_angle_percentage() const { return m_resolved_type.matches_angle_percentage(); }
     Optional<Angle> resolve_angle() const;
     Optional<Angle> resolve_angle_percentage(Angle const& percentage_basis) const;
+
+    bool resolves_to_flex() const { return m_resolved_type.matches_flex(); }
+    Optional<Flex> resolve_flex() const;
 
     bool resolves_to_frequency() const { return m_resolved_type.matches_frequency(); }
     bool resolves_to_frequency_percentage() const { return m_resolved_type.matches_frequency_percentage(); }

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/FlexStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/FlexStyleValue.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2023, Sam Atkins <atkinssj@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibWeb/CSS/Flex.h>
+#include <LibWeb/CSS/StyleValue.h>
+
+namespace Web::CSS {
+
+class FlexStyleValue final : public StyleValueWithDefaultOperators<FlexStyleValue> {
+public:
+    static ValueComparingNonnullRefPtr<FlexStyleValue> create(Flex flex)
+    {
+        return adopt_ref(*new (nothrow) FlexStyleValue(move(flex)));
+    }
+    virtual ~FlexStyleValue() override = default;
+
+    Flex const& flex() const { return m_flex; }
+    Flex& flex() { return m_flex; }
+
+    virtual String to_string() const override { return m_flex.to_string(); }
+
+    bool properties_equal(FlexStyleValue const& other) const { return m_flex == other.m_flex; }
+
+private:
+    FlexStyleValue(Flex&& flex)
+        : StyleValueWithDefaultOperators(Type::Flex)
+        , m_flex(flex)
+    {
+    }
+
+    Flex m_flex;
+};
+
+}

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -101,6 +101,8 @@ class EdgeStyleValue;
 class ElementInlineCSSStyleDeclaration;
 class ExplicitGridTrack;
 class FilterValueListStyleValue;
+class Flex;
+class FlexStyleValue;
 class FontFace;
 class Frequency;
 class FrequencyOrCalculated;

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -1250,9 +1250,11 @@ void GridFormattingContext::expand_flexible_tracks(AvailableSpace const& availab
     // For each flexible track, if the product of the used flex fraction and the track’s flex factor is greater than
     // the track’s base size, set its base size to that product.
     for (auto& track : tracks_and_gaps) {
-        auto scaled_fraction = CSSPixels::nearest_value_for(track.max_track_sizing_function.flex_factor()) * flex_fraction;
-        if (scaled_fraction > track.base_size) {
-            track.base_size = scaled_fraction;
+        if (track.max_track_sizing_function.is_flexible_length()) {
+            auto scaled_fraction = CSSPixels::nearest_value_for(track.max_track_sizing_function.flex_factor()) * flex_fraction;
+            if (scaled_fraction > track.base_size) {
+                track.base_size = scaled_fraction;
+            }
         }
     }
 }


### PR DESCRIPTION
This replaces the manual check for a "fr" dimension in `Parser::parse_grid_size()`, and also means we can have `attr()` and `calc()` return `<flex>` values.

Much of this we can't properly test, since nothing takes a plan `<flex>` as a value, but it's there if and when a property needs it. The `grid-*` properties do use `<flex>`, but I do not at all understand how that all works so I don't want to go messing with it too much.