### PR TITLE
LibWeb: Fixes regarding calculation of text width

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
+++ b/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
@@ -476,12 +476,10 @@ CanvasRenderingContext2D::PreparedText CanvasRenderingContext2D::prepare_text(De
     // ...and with all other properties set to their initial values.
     // FIXME: Actually use a LineBox here instead of, you know, using the default font and measuring its size (which is not the spec at all).
     // FIXME: Once we have CanvasTextDrawingStyles, add the CSS attributes.
-    size_t width = 0;
+    size_t width = font->width(text.view());
     size_t height = font->pixel_size();
 
     Utf8View replaced_text_view { replaced_text };
-    for (auto it = replaced_text_view.begin(); it != replaced_text_view.end(); ++it)
-        width += font->glyph_or_emoji_width(it);
 
     // 6. If maxWidth was provided and the hypothetical width of the inline box in the hypothetical line box is greater than maxWidth CSS pixels, then change font to have a more condensed font (if one is available or if a reasonably readable one can be synthesized by applying a horizontal scale factor to the font) or a smaller font, and return to the previous step.
     // FIXME: Record the font size used for this piece of text, and actually retry with a smaller size if needed.

--- a/Userland/Libraries/LibWeb/Layout/InlineLevelIterator.cpp
+++ b/Userland/Libraries/LibWeb/Layout/InlineLevelIterator.cpp
@@ -180,13 +180,19 @@ Optional<InlineLevelIterator::Item> InlineLevelIterator::next_without_lookahead(
             m_text_node_context->is_last_chunk = true;
 
         auto& chunk = chunk_opt.value();
-        CSSPixels chunk_width = CSSPixels::nearest_value_for(text_node.font().width(chunk.view) + text_node.font().glyph_spacing());
 
         if (m_text_node_context->do_respect_linebreaks && chunk.has_breaking_newline) {
             return Item {
                 .type = Item::Type::ForcedBreak,
             };
         }
+
+        CSSPixels chunk_width;
+
+        if (m_text_node_context->is_last_chunk)
+            chunk_width = CSSPixels::nearest_value_for(text_node.font().width(chunk.view));
+        else
+            chunk_width = CSSPixels::nearest_value_for(text_node.font().width(chunk.view) + text_node.font().glyph_spacing());
 
         // NOTE: We never consider `content: ""` to be collapsible whitespace.
         bool is_generated_empty_string = text_node.is_generated() && chunk.length == 0;


### PR DESCRIPTION
This fixes the Canvas measureText function to provide the correct width, and the calculation of the width of TextNodes.

The TextNode fix is visible here:

Before:
![Screenshot at 2023-09-28 18-44-32](https://github.com/SerenityOS/serenity/assets/39885272/c098a6ab-0b6c-433d-8d33-93013ca153da)

After:
![Screenshot at 2023-09-28 18-44-58](https://github.com/SerenityOS/serenity/assets/39885272/c3239ff2-6865-4889-82ed-cb7ebad73c0f)