### PR TITLE
LibWeb: Use correct realm when focusing HTMLTextAreaElement

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
@@ -56,7 +56,7 @@ void HTMLTextAreaElement::did_receive_focus()
         return;
     if (!m_text_node)
         return;
-    browsing_context->set_cursor_position(DOM::Position::create(*vm().current_realm(), *m_text_node, 0));
+    browsing_context->set_cursor_position(DOM::Position::create(realm(), *m_text_node, 0));
 }
 
 void HTMLTextAreaElement::did_lose_focus()


### PR DESCRIPTION
This matches HTMLInputElement, and fixes the crash when focusing a textarea.