### PR TITLE
LibWeb: Spec-comment and fill in more of StyleValue resolution

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
@@ -199,7 +199,7 @@ RefPtr<StyleValue const> ResolvedCSSStyleDeclaration::style_value_for_property(L
         // -> padding-left
         // -> padding-right
         // -> padding-top
-        // FIXME: -> width
+        // -> width
         // -> A resolved value special case property like height defined in another specification
         // FIXME: If the property applies to the element or pseudo-element and the resolved value of the
         //    display property is not none or contents, then the resolved value is the used value.
@@ -305,56 +305,50 @@ RefPtr<StyleValue const> ResolvedCSSStyleDeclaration::style_value_for_property(L
                     EdgeStyleValue::create(PositionEdge::Top, Percentage(0)));
             });
     case PropertyID::Border: {
-        auto top = layout_node.computed_values().border_top();
-        auto right = layout_node.computed_values().border_right();
-        auto bottom = layout_node.computed_values().border_bottom();
-        auto left = layout_node.computed_values().border_left();
+        auto width = style_value_for_property(layout_node, PropertyID::BorderWidth);
+        auto style = style_value_for_property(layout_node, PropertyID::BorderStyle);
+        auto color = style_value_for_property(layout_node, PropertyID::BorderColor);
         // `border` only has a reasonable value if all four sides are the same.
-        if (top != right || top != bottom || top != left)
+        if (width->is_value_list() || style->is_value_list() || color->is_value_list())
             return nullptr;
-        auto width = LengthStyleValue::create(Length::make_px(top.width));
-        auto style = IdentifierStyleValue::create(to_value_id(top.line_style));
-        auto color = ColorStyleValue::create(top.color);
         return ShorthandStyleValue::create(property_id,
             { PropertyID::BorderWidth, PropertyID::BorderStyle, PropertyID::BorderColor },
-            { width, style, color });
+            { width.release_nonnull(), style.release_nonnull(), color.release_nonnull() });
     }
     case PropertyID::BorderColor: {
-        auto top = ColorStyleValue::create(layout_node.computed_values().border_top().color);
-        auto right = ColorStyleValue::create(layout_node.computed_values().border_right().color);
-        auto bottom = ColorStyleValue::create(layout_node.computed_values().border_bottom().color);
-        auto left = ColorStyleValue::create(layout_node.computed_values().border_left().color);
-        return style_value_for_sided_shorthand(top, right, bottom, left);
+        auto top = style_value_for_property(layout_node, PropertyID::BorderTopColor);
+        auto right = style_value_for_property(layout_node, PropertyID::BorderRightColor);
+        auto bottom = style_value_for_property(layout_node, PropertyID::BorderBottomColor);
+        auto left = style_value_for_property(layout_node, PropertyID::BorderLeftColor);
+        return style_value_for_sided_shorthand(top.release_nonnull(), right.release_nonnull(), bottom.release_nonnull(), left.release_nonnull());
     }
     case PropertyID::BorderStyle: {
-        auto top = IdentifierStyleValue::create(to_value_id(layout_node.computed_values().border_top().line_style));
-        auto right = IdentifierStyleValue::create(to_value_id(layout_node.computed_values().border_right().line_style));
-        auto bottom = IdentifierStyleValue::create(to_value_id(layout_node.computed_values().border_bottom().line_style));
-        auto left = IdentifierStyleValue::create(to_value_id(layout_node.computed_values().border_left().line_style));
-        return style_value_for_sided_shorthand(top, right, bottom, left);
+        auto top = style_value_for_property(layout_node, PropertyID::BorderTopStyle);
+        auto right = style_value_for_property(layout_node, PropertyID::BorderRightStyle);
+        auto bottom = style_value_for_property(layout_node, PropertyID::BorderBottomStyle);
+        auto left = style_value_for_property(layout_node, PropertyID::BorderLeftStyle);
+        return style_value_for_sided_shorthand(top.release_nonnull(), right.release_nonnull(), bottom.release_nonnull(), left.release_nonnull());
     }
     case PropertyID::BorderWidth: {
-        auto top = LengthStyleValue::create(Length::make_px(layout_node.computed_values().border_top().width));
-        auto right = LengthStyleValue::create(Length::make_px(layout_node.computed_values().border_right().width));
-        auto bottom = LengthStyleValue::create(Length::make_px(layout_node.computed_values().border_bottom().width));
-        auto left = LengthStyleValue::create(Length::make_px(layout_node.computed_values().border_left().width));
-        return style_value_for_sided_shorthand(top, right, bottom, left);
+        auto top = style_value_for_property(layout_node, PropertyID::BorderTopWidth);
+        auto right = style_value_for_property(layout_node, PropertyID::BorderRightWidth);
+        auto bottom = style_value_for_property(layout_node, PropertyID::BorderBottomWidth);
+        auto left = style_value_for_property(layout_node, PropertyID::BorderLeftWidth);
+        return style_value_for_sided_shorthand(top.release_nonnull(), right.release_nonnull(), bottom.release_nonnull(), left.release_nonnull());
     }
     case PropertyID::Margin: {
-        auto margin = layout_node.computed_values().margin();
-        auto top = style_value_for_length_percentage(margin.top());
-        auto right = style_value_for_length_percentage(margin.right());
-        auto bottom = style_value_for_length_percentage(margin.bottom());
-        auto left = style_value_for_length_percentage(margin.left());
-        return style_value_for_sided_shorthand(move(top), move(right), move(bottom), move(left));
+        auto top = style_value_for_property(layout_node, PropertyID::MarginTop);
+        auto right = style_value_for_property(layout_node, PropertyID::MarginRight);
+        auto bottom = style_value_for_property(layout_node, PropertyID::MarginBottom);
+        auto left = style_value_for_property(layout_node, PropertyID::MarginLeft);
+        return style_value_for_sided_shorthand(top.release_nonnull(), right.release_nonnull(), bottom.release_nonnull(), left.release_nonnull());
     }
     case PropertyID::Padding: {
-        auto padding = layout_node.computed_values().padding();
-        auto top = style_value_for_length_percentage(padding.top());
-        auto right = style_value_for_length_percentage(padding.right());
-        auto bottom = style_value_for_length_percentage(padding.bottom());
-        auto left = style_value_for_length_percentage(padding.left());
-        return style_value_for_sided_shorthand(move(top), move(right), move(bottom), move(left));
+        auto top = style_value_for_property(layout_node, PropertyID::PaddingTop);
+        auto right = style_value_for_property(layout_node, PropertyID::PaddingRight);
+        auto bottom = style_value_for_property(layout_node, PropertyID::PaddingBottom);
+        auto left = style_value_for_property(layout_node, PropertyID::PaddingLeft);
+        return style_value_for_sided_shorthand(top.release_nonnull(), right.release_nonnull(), bottom.release_nonnull(), left.release_nonnull());
     }
     case PropertyID::Invalid:
         return IdentifierStyleValue::create(ValueID::Invalid);

--- a/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
@@ -177,8 +177,14 @@ RefPtr<StyleValue const> ResolvedCSSStyleDeclaration::style_value_for_property(L
     case PropertyID::TextDecorationColor:
         return ColorStyleValue::create(layout_node.computed_values().text_decoration_color());
 
-        // FIXME: -> line-height
+        // -> line-height
         //    The resolved value is normal if the computed value is normal, or the used value otherwise.
+    case PropertyID::LineHeight: {
+        auto line_height = static_cast<DOM::Element const&>(*layout_node.dom_node()).computed_css_values()->property(property_id);
+        if (line_height->is_identifier() && line_height->to_identifier() == ValueID::Normal)
+            return line_height;
+        return LengthStyleValue::create(Length::make_px(layout_node.line_height()));
+    }
 
         // FIXME: -> block-size
         // -> height

--- a/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
@@ -136,6 +136,28 @@ static NonnullRefPtr<StyleValue const> style_value_for_sided_shorthand(ValueComp
     return StyleValueList::create(StyleValueVector { move(top), move(right), move(bottom), move(left) }, StyleValueList::Separator::Space);
 }
 
+enum class LogicalSide {
+    BlockStart,
+    BlockEnd,
+    InlineStart,
+    InlineEnd,
+};
+static RefPtr<StyleValue const> style_value_for_length_box_logical_side(Layout::NodeWithStyle const&, LengthBox const& box, LogicalSide logical_side)
+{
+    // FIXME: Actually determine the logical sides based on layout_node's writing-mode and direction.
+    switch (logical_side) {
+    case LogicalSide::BlockStart:
+        return style_value_for_length_percentage(box.top());
+    case LogicalSide::BlockEnd:
+        return style_value_for_length_percentage(box.bottom());
+    case LogicalSide::InlineStart:
+        return style_value_for_length_percentage(box.left());
+    case LogicalSide::InlineEnd:
+        return style_value_for_length_percentage(box.right());
+    }
+    VERIFY_NOT_REACHED();
+}
+
 RefPtr<StyleValue const> ResolvedCSSStyleDeclaration::style_value_for_property(Layout::NodeWithStyle const& layout_node, PropertyID property_id) const
 {
     // A limited number of properties have special rules for producing their "resolved value".
@@ -189,19 +211,19 @@ RefPtr<StyleValue const> ResolvedCSSStyleDeclaration::style_value_for_property(L
         // FIXME: -> block-size
         // -> height
         // FIXME: -> inline-size
-        // FIXME: -> margin-block-end
-        // FIXME: -> margin-block-start
+        // -> margin-block-end
+        // -> margin-block-start
         // -> margin-bottom
-        // FIXME: -> margin-inline-end
-        // FIXME: -> margin-inline-start
+        // -> margin-inline-end
+        // -> margin-inline-start
         // -> margin-left
         // -> margin-right
         // -> margin-top
-        // FIXME: -> padding-block-end
-        // FIXME: -> padding-block-start
+        // -> padding-block-end
+        // -> padding-block-start
         // -> padding-bottom
-        // FIXME: -> padding-inline-end
-        // FIXME: -> padding-inline-start
+        // -> padding-inline-end
+        // -> padding-inline-start
         // -> padding-left
         // -> padding-right
         // -> padding-top
@@ -212,16 +234,32 @@ RefPtr<StyleValue const> ResolvedCSSStyleDeclaration::style_value_for_property(L
         //    Otherwise the resolved value is the computed value.
     case PropertyID::Height:
         return style_value_for_size(layout_node.computed_values().height());
+    case PropertyID::MarginBlockEnd:
+        return style_value_for_length_box_logical_side(layout_node, layout_node.computed_values().margin(), LogicalSide::BlockEnd);
+    case PropertyID::MarginBlockStart:
+        return style_value_for_length_box_logical_side(layout_node, layout_node.computed_values().margin(), LogicalSide::BlockStart);
     case PropertyID::MarginBottom:
         return style_value_for_length_percentage(layout_node.computed_values().margin().bottom());
+    case PropertyID::MarginInlineEnd:
+        return style_value_for_length_box_logical_side(layout_node, layout_node.computed_values().margin(), LogicalSide::InlineEnd);
+    case PropertyID::MarginInlineStart:
+        return style_value_for_length_box_logical_side(layout_node, layout_node.computed_values().margin(), LogicalSide::InlineStart);
     case PropertyID::MarginLeft:
         return style_value_for_length_percentage(layout_node.computed_values().margin().left());
     case PropertyID::MarginRight:
         return style_value_for_length_percentage(layout_node.computed_values().margin().right());
     case PropertyID::MarginTop:
         return style_value_for_length_percentage(layout_node.computed_values().margin().top());
+    case PropertyID::PaddingBlockEnd:
+        return style_value_for_length_box_logical_side(layout_node, layout_node.computed_values().padding(), LogicalSide::BlockEnd);
+    case PropertyID::PaddingBlockStart:
+        return style_value_for_length_box_logical_side(layout_node, layout_node.computed_values().padding(), LogicalSide::BlockStart);
     case PropertyID::PaddingBottom:
         return style_value_for_length_percentage(layout_node.computed_values().padding().bottom());
+    case PropertyID::PaddingInlineEnd:
+        return style_value_for_length_box_logical_side(layout_node, layout_node.computed_values().padding(), LogicalSide::InlineEnd);
+    case PropertyID::PaddingInlineStart:
+        return style_value_for_length_box_logical_side(layout_node, layout_node.computed_values().padding(), LogicalSide::InlineStart);
     case PropertyID::PaddingLeft:
         return style_value_for_length_percentage(layout_node.computed_values().padding().left());
     case PropertyID::PaddingRight:
@@ -233,10 +271,10 @@ RefPtr<StyleValue const> ResolvedCSSStyleDeclaration::style_value_for_property(L
 
         // -> bottom
         // -> left
-        // FIXME: -> inset-block-end
-        // FIXME: -> inset-block-start
-        // FIXME: -> inset-inline-end
-        // FIXME: -> inset-inline-start
+        // -> inset-block-end
+        // -> inset-block-start
+        // -> inset-inline-end
+        // -> inset-inline-start
         // -> right
         // -> top
         // -> A resolved value special case property like top defined in another specification
@@ -245,6 +283,14 @@ RefPtr<StyleValue const> ResolvedCSSStyleDeclaration::style_value_for_property(L
         //    Otherwise the resolved value is the computed value.
     case PropertyID::Bottom:
         return style_value_for_length_percentage(layout_node.computed_values().inset().bottom());
+    case PropertyID::InsetBlockEnd:
+        return style_value_for_length_box_logical_side(layout_node, layout_node.computed_values().inset(), LogicalSide::BlockEnd);
+    case PropertyID::InsetBlockStart:
+        return style_value_for_length_box_logical_side(layout_node, layout_node.computed_values().inset(), LogicalSide::BlockStart);
+    case PropertyID::InsetInlineEnd:
+        return style_value_for_length_box_logical_side(layout_node, layout_node.computed_values().inset(), LogicalSide::InlineEnd);
+    case PropertyID::InsetInlineStart:
+        return style_value_for_length_box_logical_side(layout_node, layout_node.computed_values().inset(), LogicalSide::InlineStart);
     case PropertyID::Left:
         return style_value_for_length_percentage(layout_node.computed_values().inset().left());
     case PropertyID::Right:

--- a/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
@@ -319,15 +319,6 @@ RefPtr<StyleValue const> ResolvedCSSStyleDeclaration::style_value_for_property(L
             { PropertyID::BorderWidth, PropertyID::BorderStyle, PropertyID::BorderColor },
             { width, style, color });
     }
-    case PropertyID::BorderBottom: {
-        auto border = layout_node.computed_values().border_bottom();
-        auto width = LengthStyleValue::create(Length::make_px(border.width));
-        auto style = IdentifierStyleValue::create(to_value_id(border.line_style));
-        auto color = ColorStyleValue::create(border.color);
-        return ShorthandStyleValue::create(property_id,
-            { PropertyID::BorderBottomWidth, PropertyID::BorderBottomStyle, PropertyID::BorderBottomColor },
-            { width, style, color });
-    }
     case PropertyID::BorderColor: {
         auto top = ColorStyleValue::create(layout_node.computed_values().border_top().color);
         auto right = ColorStyleValue::create(layout_node.computed_values().border_right().color);
@@ -335,39 +326,12 @@ RefPtr<StyleValue const> ResolvedCSSStyleDeclaration::style_value_for_property(L
         auto left = ColorStyleValue::create(layout_node.computed_values().border_left().color);
         return style_value_for_sided_shorthand(top, right, bottom, left);
     }
-    case PropertyID::BorderLeft: {
-        auto border = layout_node.computed_values().border_left();
-        auto width = LengthStyleValue::create(Length::make_px(border.width));
-        auto style = IdentifierStyleValue::create(to_value_id(border.line_style));
-        auto color = ColorStyleValue::create(border.color);
-        return ShorthandStyleValue::create(property_id,
-            { PropertyID::BorderLeftWidth, PropertyID::BorderLeftStyle, PropertyID::BorderLeftColor },
-            { width, style, color });
-    }
-    case PropertyID::BorderRight: {
-        auto border = layout_node.computed_values().border_right();
-        auto width = LengthStyleValue::create(Length::make_px(border.width));
-        auto style = IdentifierStyleValue::create(to_value_id(border.line_style));
-        auto color = ColorStyleValue::create(border.color);
-        return ShorthandStyleValue::create(property_id,
-            { PropertyID::BorderRightWidth, PropertyID::BorderRightStyle, PropertyID::BorderRightColor },
-            { width, style, color });
-    }
     case PropertyID::BorderStyle: {
         auto top = IdentifierStyleValue::create(to_value_id(layout_node.computed_values().border_top().line_style));
         auto right = IdentifierStyleValue::create(to_value_id(layout_node.computed_values().border_right().line_style));
         auto bottom = IdentifierStyleValue::create(to_value_id(layout_node.computed_values().border_bottom().line_style));
         auto left = IdentifierStyleValue::create(to_value_id(layout_node.computed_values().border_left().line_style));
         return style_value_for_sided_shorthand(top, right, bottom, left);
-    }
-    case PropertyID::BorderTop: {
-        auto border = layout_node.computed_values().border_top();
-        auto width = LengthStyleValue::create(Length::make_px(border.width));
-        auto style = IdentifierStyleValue::create(to_value_id(border.line_style));
-        auto color = ColorStyleValue::create(border.color);
-        return ShorthandStyleValue::create(property_id,
-            { PropertyID::BorderTopWidth, PropertyID::BorderTopStyle, PropertyID::BorderTopColor },
-            { width, style, color });
     }
     case PropertyID::BorderWidth: {
         auto top = LengthStyleValue::create(Length::make_px(layout_node.computed_values().border_top().width));

--- a/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
@@ -142,118 +142,70 @@ RefPtr<StyleValue const> ResolvedCSSStyleDeclaration::style_value_for_property(L
     // We also have to manually construct shorthands from their longhands here.
     // Everything else uses the computed value.
     // https://www.w3.org/TR/cssom-1/#resolved-values
+
+    // The resolved value for a given longhand property can be determined as follows:
     switch (property_id) {
+        // -> background-color
+        // FIXME: -> border-block-end-color
+        // FIXME: -> border-block-start-color
+        // -> border-bottom-color
+        // FIXME: -> border-inline-end-color
+        // FIXME: -> border-inline-start-color
+        // -> border-left-color
+        // -> border-right-color
+        // -> border-top-color
+        // FIXME: -> box-shadow
+        // FIXME: -> caret-color
+        // -> color
+        // -> outline-color
+        // -> A resolved value special case property like color defined in another specification
+        //    The resolved value is the used value.
     case PropertyID::BackgroundColor:
         return ColorStyleValue::create(layout_node.computed_values().background_color());
-    case PropertyID::BackgroundPosition:
-        return style_value_for_background_property(
-            layout_node,
-            [](auto& layer) -> NonnullRefPtr<StyleValue> {
-                return PositionStyleValue::create(
-                    EdgeStyleValue::create(layer.position_edge_x, layer.position_offset_x),
-                    EdgeStyleValue::create(layer.position_edge_y, layer.position_offset_y));
-            },
-            []() -> NonnullRefPtr<StyleValue> {
-                return PositionStyleValue::create(
-                    EdgeStyleValue::create(PositionEdge::Left, Percentage(0)),
-                    EdgeStyleValue::create(PositionEdge::Top, Percentage(0)));
-            });
-    case PropertyID::Border: {
-        auto top = layout_node.computed_values().border_top();
-        auto right = layout_node.computed_values().border_right();
-        auto bottom = layout_node.computed_values().border_bottom();
-        auto left = layout_node.computed_values().border_left();
-        // `border` only has a reasonable value if all four sides are the same.
-        if (top != right || top != bottom || top != left)
-            return nullptr;
-        auto width = LengthStyleValue::create(Length::make_px(top.width));
-        auto style = IdentifierStyleValue::create(to_value_id(top.line_style));
-        auto color = ColorStyleValue::create(top.color);
-        return ShorthandStyleValue::create(property_id,
-            { PropertyID::BorderWidth, PropertyID::BorderStyle, PropertyID::BorderColor },
-            { width, style, color });
-    }
-    case PropertyID::BorderBottom: {
-        auto border = layout_node.computed_values().border_bottom();
-        auto width = LengthStyleValue::create(Length::make_px(border.width));
-        auto style = IdentifierStyleValue::create(to_value_id(border.line_style));
-        auto color = ColorStyleValue::create(border.color);
-        return ShorthandStyleValue::create(property_id,
-            { PropertyID::BorderBottomWidth, PropertyID::BorderBottomStyle, PropertyID::BorderBottomColor },
-            { width, style, color });
-    }
     case PropertyID::BorderBottomColor:
         return ColorStyleValue::create(layout_node.computed_values().border_bottom().color);
-    case PropertyID::BorderColor: {
-        auto top = ColorStyleValue::create(layout_node.computed_values().border_top().color);
-        auto right = ColorStyleValue::create(layout_node.computed_values().border_right().color);
-        auto bottom = ColorStyleValue::create(layout_node.computed_values().border_bottom().color);
-        auto left = ColorStyleValue::create(layout_node.computed_values().border_left().color);
-        return style_value_for_sided_shorthand(top, right, bottom, left);
-    }
-    case PropertyID::BorderLeft: {
-        auto border = layout_node.computed_values().border_left();
-        auto width = LengthStyleValue::create(Length::make_px(border.width));
-        auto style = IdentifierStyleValue::create(to_value_id(border.line_style));
-        auto color = ColorStyleValue::create(border.color);
-        return ShorthandStyleValue::create(property_id,
-            { PropertyID::BorderLeftWidth, PropertyID::BorderLeftStyle, PropertyID::BorderLeftColor },
-            { width, style, color });
-    }
     case PropertyID::BorderLeftColor:
         return ColorStyleValue::create(layout_node.computed_values().border_left().color);
-    case PropertyID::BorderRight: {
-        auto border = layout_node.computed_values().border_right();
-        auto width = LengthStyleValue::create(Length::make_px(border.width));
-        auto style = IdentifierStyleValue::create(to_value_id(border.line_style));
-        auto color = ColorStyleValue::create(border.color);
-        return ShorthandStyleValue::create(property_id,
-            { PropertyID::BorderRightWidth, PropertyID::BorderRightStyle, PropertyID::BorderRightColor },
-            { width, style, color });
-    }
     case PropertyID::BorderRightColor:
         return ColorStyleValue::create(layout_node.computed_values().border_right().color);
-    case PropertyID::BorderStyle: {
-        auto top = IdentifierStyleValue::create(to_value_id(layout_node.computed_values().border_top().line_style));
-        auto right = IdentifierStyleValue::create(to_value_id(layout_node.computed_values().border_right().line_style));
-        auto bottom = IdentifierStyleValue::create(to_value_id(layout_node.computed_values().border_bottom().line_style));
-        auto left = IdentifierStyleValue::create(to_value_id(layout_node.computed_values().border_left().line_style));
-        return style_value_for_sided_shorthand(top, right, bottom, left);
-    }
-    case PropertyID::BorderTop: {
-        auto border = layout_node.computed_values().border_top();
-        auto width = LengthStyleValue::create(Length::make_px(border.width));
-        auto style = IdentifierStyleValue::create(to_value_id(border.line_style));
-        auto color = ColorStyleValue::create(border.color);
-        return ShorthandStyleValue::create(property_id,
-            { PropertyID::BorderTopWidth, PropertyID::BorderTopStyle, PropertyID::BorderTopColor },
-            { width, style, color });
-    }
     case PropertyID::BorderTopColor:
         return ColorStyleValue::create(layout_node.computed_values().border_top().color);
-    case PropertyID::BorderWidth: {
-        auto top = LengthStyleValue::create(Length::make_px(layout_node.computed_values().border_top().width));
-        auto right = LengthStyleValue::create(Length::make_px(layout_node.computed_values().border_right().width));
-        auto bottom = LengthStyleValue::create(Length::make_px(layout_node.computed_values().border_bottom().width));
-        auto left = LengthStyleValue::create(Length::make_px(layout_node.computed_values().border_left().width));
-        return style_value_for_sided_shorthand(top, right, bottom, left);
-    }
-    case PropertyID::Bottom:
-        return style_value_for_length_percentage(layout_node.computed_values().inset().bottom());
     case PropertyID::Color:
         return ColorStyleValue::create(layout_node.computed_values().color());
+    case PropertyID::OutlineColor:
+        return ColorStyleValue::create(layout_node.computed_values().outline_color());
+    case PropertyID::TextDecorationColor:
+        return ColorStyleValue::create(layout_node.computed_values().text_decoration_color());
+
+        // FIXME: -> line-height
+        //    The resolved value is normal if the computed value is normal, or the used value otherwise.
+
+        // FIXME: -> block-size
+        // -> height
+        // FIXME: -> inline-size
+        // FIXME: -> margin-block-end
+        // FIXME: -> margin-block-start
+        // -> margin-bottom
+        // FIXME: -> margin-inline-end
+        // FIXME: -> margin-inline-start
+        // -> margin-left
+        // -> margin-right
+        // -> margin-top
+        // FIXME: -> padding-block-end
+        // FIXME: -> padding-block-start
+        // -> padding-bottom
+        // FIXME: -> padding-inline-end
+        // FIXME: -> padding-inline-start
+        // -> padding-left
+        // -> padding-right
+        // -> padding-top
+        // FIXME: -> width
+        // -> A resolved value special case property like height defined in another specification
+        // FIXME: If the property applies to the element or pseudo-element and the resolved value of the
+        //    display property is not none or contents, then the resolved value is the used value.
+        //    Otherwise the resolved value is the computed value.
     case PropertyID::Height:
         return style_value_for_size(layout_node.computed_values().height());
-    case PropertyID::Left:
-        return style_value_for_length_percentage(layout_node.computed_values().inset().left());
-    case PropertyID::Margin: {
-        auto margin = layout_node.computed_values().margin();
-        auto top = style_value_for_length_percentage(margin.top());
-        auto right = style_value_for_length_percentage(margin.right());
-        auto bottom = style_value_for_length_percentage(margin.bottom());
-        auto left = style_value_for_length_percentage(margin.left());
-        return style_value_for_sided_shorthand(move(top), move(right), move(bottom), move(left));
-    }
     case PropertyID::MarginBottom:
         return style_value_for_length_percentage(layout_node.computed_values().margin().bottom());
     case PropertyID::MarginLeft:
@@ -262,16 +214,6 @@ RefPtr<StyleValue const> ResolvedCSSStyleDeclaration::style_value_for_property(L
         return style_value_for_length_percentage(layout_node.computed_values().margin().right());
     case PropertyID::MarginTop:
         return style_value_for_length_percentage(layout_node.computed_values().margin().top());
-    case PropertyID::OutlineColor:
-        return ColorStyleValue::create(layout_node.computed_values().outline_color());
-    case PropertyID::Padding: {
-        auto padding = layout_node.computed_values().padding();
-        auto top = style_value_for_length_percentage(padding.top());
-        auto right = style_value_for_length_percentage(padding.right());
-        auto bottom = style_value_for_length_percentage(padding.bottom());
-        auto left = style_value_for_length_percentage(padding.left());
-        return style_value_for_sided_shorthand(move(top), move(right), move(bottom), move(left));
-    }
     case PropertyID::PaddingBottom:
         return style_value_for_length_percentage(layout_node.computed_values().padding().bottom());
     case PropertyID::PaddingLeft:
@@ -280,12 +222,32 @@ RefPtr<StyleValue const> ResolvedCSSStyleDeclaration::style_value_for_property(L
         return style_value_for_length_percentage(layout_node.computed_values().padding().right());
     case PropertyID::PaddingTop:
         return style_value_for_length_percentage(layout_node.computed_values().padding().top());
+    case PropertyID::Width:
+        return style_value_for_size(layout_node.computed_values().width());
+
+        // -> bottom
+        // -> left
+        // FIXME: -> inset-block-end
+        // FIXME: -> inset-block-start
+        // FIXME: -> inset-inline-end
+        // FIXME: -> inset-inline-start
+        // -> right
+        // -> top
+        // -> A resolved value special case property like top defined in another specification
+        // FIXME: If the property applies to a positioned element and the resolved value of the display property is not
+        //    none or contents, and the property is not over-constrained, then the resolved value is the used value.
+        //    Otherwise the resolved value is the computed value.
+    case PropertyID::Bottom:
+        return style_value_for_length_percentage(layout_node.computed_values().inset().bottom());
+    case PropertyID::Left:
+        return style_value_for_length_percentage(layout_node.computed_values().inset().left());
     case PropertyID::Right:
         return style_value_for_length_percentage(layout_node.computed_values().inset().right());
-    case PropertyID::TextDecorationColor:
-        return ColorStyleValue::create(layout_node.computed_values().text_decoration_color());
     case PropertyID::Top:
         return style_value_for_length_percentage(layout_node.computed_values().inset().top());
+
+        // -> A resolved value special case property defined in another specification
+        //    As defined in the relevant specification.
     case PropertyID::Transform: {
         // NOTE: The computed value for `transform` serializes as a single `matrix(...)` value, instead of
         //       the original list of transform functions. So, we produce a StyleValue for that.
@@ -323,8 +285,113 @@ RefPtr<StyleValue const> ResolvedCSSStyleDeclaration::style_value_for_property(L
         StyleValueVector matrix_functions { matrix_function };
         return StyleValueList::create(move(matrix_functions), StyleValueList::Separator::Space);
     }
-    case PropertyID::Width:
-        return style_value_for_size(layout_node.computed_values().width());
+
+        // -> Any other property
+        //    The resolved value is the computed value.
+        //    NOTE: This is handled inside the `default` case.
+
+        // NOTE: Everything below is a shorthand that requires some manual construction.
+    case PropertyID::BackgroundPosition:
+        return style_value_for_background_property(
+            layout_node,
+            [](auto& layer) -> NonnullRefPtr<StyleValue> {
+                return PositionStyleValue::create(
+                    EdgeStyleValue::create(layer.position_edge_x, layer.position_offset_x),
+                    EdgeStyleValue::create(layer.position_edge_y, layer.position_offset_y));
+            },
+            []() -> NonnullRefPtr<StyleValue> {
+                return PositionStyleValue::create(
+                    EdgeStyleValue::create(PositionEdge::Left, Percentage(0)),
+                    EdgeStyleValue::create(PositionEdge::Top, Percentage(0)));
+            });
+    case PropertyID::Border: {
+        auto top = layout_node.computed_values().border_top();
+        auto right = layout_node.computed_values().border_right();
+        auto bottom = layout_node.computed_values().border_bottom();
+        auto left = layout_node.computed_values().border_left();
+        // `border` only has a reasonable value if all four sides are the same.
+        if (top != right || top != bottom || top != left)
+            return nullptr;
+        auto width = LengthStyleValue::create(Length::make_px(top.width));
+        auto style = IdentifierStyleValue::create(to_value_id(top.line_style));
+        auto color = ColorStyleValue::create(top.color);
+        return ShorthandStyleValue::create(property_id,
+            { PropertyID::BorderWidth, PropertyID::BorderStyle, PropertyID::BorderColor },
+            { width, style, color });
+    }
+    case PropertyID::BorderBottom: {
+        auto border = layout_node.computed_values().border_bottom();
+        auto width = LengthStyleValue::create(Length::make_px(border.width));
+        auto style = IdentifierStyleValue::create(to_value_id(border.line_style));
+        auto color = ColorStyleValue::create(border.color);
+        return ShorthandStyleValue::create(property_id,
+            { PropertyID::BorderBottomWidth, PropertyID::BorderBottomStyle, PropertyID::BorderBottomColor },
+            { width, style, color });
+    }
+    case PropertyID::BorderColor: {
+        auto top = ColorStyleValue::create(layout_node.computed_values().border_top().color);
+        auto right = ColorStyleValue::create(layout_node.computed_values().border_right().color);
+        auto bottom = ColorStyleValue::create(layout_node.computed_values().border_bottom().color);
+        auto left = ColorStyleValue::create(layout_node.computed_values().border_left().color);
+        return style_value_for_sided_shorthand(top, right, bottom, left);
+    }
+    case PropertyID::BorderLeft: {
+        auto border = layout_node.computed_values().border_left();
+        auto width = LengthStyleValue::create(Length::make_px(border.width));
+        auto style = IdentifierStyleValue::create(to_value_id(border.line_style));
+        auto color = ColorStyleValue::create(border.color);
+        return ShorthandStyleValue::create(property_id,
+            { PropertyID::BorderLeftWidth, PropertyID::BorderLeftStyle, PropertyID::BorderLeftColor },
+            { width, style, color });
+    }
+    case PropertyID::BorderRight: {
+        auto border = layout_node.computed_values().border_right();
+        auto width = LengthStyleValue::create(Length::make_px(border.width));
+        auto style = IdentifierStyleValue::create(to_value_id(border.line_style));
+        auto color = ColorStyleValue::create(border.color);
+        return ShorthandStyleValue::create(property_id,
+            { PropertyID::BorderRightWidth, PropertyID::BorderRightStyle, PropertyID::BorderRightColor },
+            { width, style, color });
+    }
+    case PropertyID::BorderStyle: {
+        auto top = IdentifierStyleValue::create(to_value_id(layout_node.computed_values().border_top().line_style));
+        auto right = IdentifierStyleValue::create(to_value_id(layout_node.computed_values().border_right().line_style));
+        auto bottom = IdentifierStyleValue::create(to_value_id(layout_node.computed_values().border_bottom().line_style));
+        auto left = IdentifierStyleValue::create(to_value_id(layout_node.computed_values().border_left().line_style));
+        return style_value_for_sided_shorthand(top, right, bottom, left);
+    }
+    case PropertyID::BorderTop: {
+        auto border = layout_node.computed_values().border_top();
+        auto width = LengthStyleValue::create(Length::make_px(border.width));
+        auto style = IdentifierStyleValue::create(to_value_id(border.line_style));
+        auto color = ColorStyleValue::create(border.color);
+        return ShorthandStyleValue::create(property_id,
+            { PropertyID::BorderTopWidth, PropertyID::BorderTopStyle, PropertyID::BorderTopColor },
+            { width, style, color });
+    }
+    case PropertyID::BorderWidth: {
+        auto top = LengthStyleValue::create(Length::make_px(layout_node.computed_values().border_top().width));
+        auto right = LengthStyleValue::create(Length::make_px(layout_node.computed_values().border_right().width));
+        auto bottom = LengthStyleValue::create(Length::make_px(layout_node.computed_values().border_bottom().width));
+        auto left = LengthStyleValue::create(Length::make_px(layout_node.computed_values().border_left().width));
+        return style_value_for_sided_shorthand(top, right, bottom, left);
+    }
+    case PropertyID::Margin: {
+        auto margin = layout_node.computed_values().margin();
+        auto top = style_value_for_length_percentage(margin.top());
+        auto right = style_value_for_length_percentage(margin.right());
+        auto bottom = style_value_for_length_percentage(margin.bottom());
+        auto left = style_value_for_length_percentage(margin.left());
+        return style_value_for_sided_shorthand(move(top), move(right), move(bottom), move(left));
+    }
+    case PropertyID::Padding: {
+        auto padding = layout_node.computed_values().padding();
+        auto top = style_value_for_length_percentage(padding.top());
+        auto right = style_value_for_length_percentage(padding.right());
+        auto bottom = style_value_for_length_percentage(padding.bottom());
+        auto left = style_value_for_length_percentage(padding.left());
+        return style_value_for_sided_shorthand(move(top), move(right), move(bottom), move(left));
+    }
     case PropertyID::Invalid:
         return IdentifierStyleValue::create(ValueID::Invalid);
     case PropertyID::Custom:


### PR DESCRIPTION
Comment and rearrange the list of properties according to the list [here](https://www.w3.org/TR/cssom-1/#resolved-values), and then fill-in the missing properties that we currently support.

Also, some related tidying-up:
- Remove some manual code we don't need.
- Make the other manual code for shorthands use the normal code path to get their longhands, instead of manually creating StyleValues for them.

There's still work to do here to make it match the spec fully, but we're getting there, and it's now more obvious where we're lacking.