### PR TITLE
LibJS: Early reject pointers outside of allocated blocks range in GC

### DIFF
--- a/Userland/Libraries/LibJS/Heap/Heap.h
+++ b/Userland/Libraries/LibJS/Heap/Heap.h
@@ -93,9 +93,10 @@ private:
 
     Cell* allocate_cell(size_t);
 
+    void find_min_and_max_block_addresses(FlatPtr& min_address, FlatPtr& max_address);
     void gather_roots(HashMap<Cell*, HeapRoot>&);
     void gather_conservative_roots(HashMap<Cell*, HeapRoot>&);
-    void gather_asan_fake_stack_roots(HashMap<FlatPtr, HeapRoot>&, FlatPtr);
+    void gather_asan_fake_stack_roots(HashMap<FlatPtr, HeapRoot>&, FlatPtr, FlatPtr min_block_address, FlatPtr max_block_address);
     void mark_live_cells(HashMap<Cell*, HeapRoot> const& live_cells);
     void finalize_unmarked_cells();
     void sweep_dead_cells(bool print_report, Core::ElapsedTimer const&);


### PR DESCRIPTION
This change adds a check to discard pointers that are lower than the minimum address of all allocated blocks or higher than the maximum address of all blocks. By doing this we avoid executing plenty of set() operations on the HashMap in the add_possible_value().

With this change gather_conservative_roots() run 10x times faster in Speedometer React-Redux-TodoMVC test.