### PR TITLE
Kernel+stat: Populate `stat.st_dev` with `fsid` and show it in `stat`

### DIFF
--- a/Kernel/FileSystem/InodeMetadata.h
+++ b/Kernel/FileSystem/InodeMetadata.h
@@ -104,7 +104,7 @@ struct InodeMetadata {
         buffer.st_nlink = link_count;
         buffer.st_uid = uid.value();
         buffer.st_gid = gid.value();
-        buffer.st_dev = 0; // FIXME
+        buffer.st_dev = inode.fsid().value();
         buffer.st_size = size;
         buffer.st_blksize = block_size;
         buffer.st_blocks = block_count;

--- a/Userland/Utilities/stat.cpp
+++ b/Userland/Utilities/stat.cpp
@@ -18,6 +18,7 @@ static ErrorOr<int> stat(StringView file, bool should_follow_links)
 {
     auto st = TRY(should_follow_links ? Core::System::stat(file) : Core::System::lstat(file));
     outln("    File: {}", file);
+    outln("  Device: {}", st.st_dev);
     outln("   Inode: {}", st.st_ino);
     if (S_ISCHR(st.st_mode) || S_ISBLK(st.st_mode))
         outln("  Device: {},{}", major(st.st_rdev), minor(st.st_rdev));


### PR DESCRIPTION
Previously, `st_dev` was always set to 0, which caused an issue in `du` where files with the same inode number on different devices weren't counted correctly.

This probably isn't the most correct way to do this, but I believe the `fsid` we generate satisfies the requirements for `st_dev`, namely that `st_dev` and `st_ino` taken together can uniquely identify a file on the local machine.

Before:

![stat_device_id_before](https://github.com/SerenityOS/serenity/assets/2817754/016396df-f9fe-4e29-9b19-bd6bcc6029b4)

After:

![stat_device_id_after](https://github.com/SerenityOS/serenity/assets/2817754/5707e958-939c-4436-a175-feeab177d598)


