### PR TITLE
Kernel: Mark SDHC InterruptStatus structured view as const

### DIFF
--- a/Kernel/Devices/Storage/SD/Registers.h
+++ b/Kernel/Devices/Storage/SD/Registers.h
@@ -103,7 +103,7 @@ struct HostControlRegisterMap {
             u32 tuning_error : 1;
             u32 response_error : 1;
             u32 vendor_specific_error : 1;
-        };
+        } const;
         u32 raw;
     } interrupt_status;
     u32 interrupt_status_enable;


### PR DESCRIPTION
This view is really nice to check flags, but when clearing them we must make sure that we only ever try to set 1 bit at a time, which makes setting bits through the structured view a footgun, as that fetches, ors in and then sets, potentially resetting other flags.


---
Some time ago I learned, you can mark struct member declarations as `const`