### PR TITLE
Kernel/aarch64: Subtract KERNEL_MAPPING_BASE from driver_init section

### DIFF
--- a/Kernel/Arch/aarch64/linker.ld
+++ b/Kernel/Arch/aarch64/linker.ld
@@ -31,7 +31,7 @@ SECTIONS
         *(.text*)
     } :text
 
-    .driver_init ALIGN(4K) : AT (ADDR(.driver_init))
+    .driver_init ALIGN(4K) : AT (ADDR(.driver_init) - KERNEL_MAPPING_BASE)
     {
         driver_init_table_start = .;
         *(.driver_init)


### PR DESCRIPTION
This subtraction is necessary to ensure that the section has the correct address. Also, without this change, the Kernel ELF binary would explode in size. This was forgotten in a0dd6ec6b1a70e750dc9e504a648e967f4c5119e.