### PR TITLE
Kernel: Enable boot from USB

### DIFF
--- a/Kernel/Arch/init.cpp
+++ b/Kernel/Arch/init.cpp
@@ -416,14 +416,14 @@ void init_stage2(void*)
 
     AudioManagement::the().initialize();
 
+    // Initialize all USB Drivers
+    for (auto* init_function = driver_init_table_start; init_function != driver_init_table_end; init_function++)
+        (*init_function)();
+
     StorageManagement::the().initialize(kernel_command_line().root_device(), kernel_command_line().is_force_pio(), kernel_command_line().is_nvme_polling_enabled());
     if (VirtualFileSystem::the().mount_root(StorageManagement::the().root_filesystem()).is_error()) {
         PANIC("VirtualFileSystem::mount_root failed");
     }
-
-    // Initialise all USB Drivers
-    for (auto* init_function = driver_init_table_start; init_function != driver_init_table_end; init_function++)
-        (*init_function)();
 
     // Switch out of early boot mode.
     g_in_early_boot = false;

--- a/Kernel/Devices/Storage/StorageManagement.cpp
+++ b/Kernel/Devices/Storage/StorageManagement.cpp
@@ -225,7 +225,6 @@ ErrorOr<void> StorageManagement::enumerate_device_partitions(StorageDevice& devi
 
 UNMAP_AFTER_INIT void StorageManagement::enumerate_disk_partitions()
 {
-    VERIFY(!m_storage_devices.is_empty());
     for (auto& device : m_storage_devices) {
         // FIXME: Maybe handle this error in some way shape or form
         (void)enumerate_device_partitions(device);

--- a/Kernel/Devices/Storage/StorageManagement.h
+++ b/Kernel/Devices/Storage/StorageManagement.h
@@ -24,9 +24,10 @@ class StorageManagement {
 
 public:
     StorageManagement();
-    void initialize(StringView boot_argument, bool force_pio, bool nvme_poll);
+    void initialize(bool force_pio, bool nvme_poll);
     static StorageManagement& the();
 
+    bool determine_boot_device(StringView boot_argument);
     NonnullRefPtr<FileSystem> root_filesystem() const;
 
     static MajorNumber storage_type_major_number();
@@ -49,7 +50,6 @@ private:
     ErrorOr<void> enumerate_device_partitions(StorageDevice&);
     void enumerate_disk_partitions();
 
-    void determine_boot_device();
     void determine_boot_device_with_partition_uuid();
 
     void resolve_partition_from_boot_device_parameter(StorageDevice const& chosen_storage_device, StringView boot_device_prefix);

--- a/Meta/run.sh
+++ b/Meta/run.sh
@@ -256,6 +256,11 @@ if [ -n "${SERENITY_USE_SDCARD}" ] && [ "${SERENITY_USE_SDCARD}" -eq 1 ]; then
     SERENITY_BOOT_DRIVE="-device sdhci-pci -device sd-card,drive=sd-boot-drive -drive id=sd-boot-drive,if=none,format=raw,file=${SERENITY_DISK_IMAGE}"
     SERENITY_KERNEL_CMDLINE="$SERENITY_KERNEL_CMDLINE root=sd2:0:0"
 fi
+if [ -n "${SERENITY_USE_USBDRIVE}" ] && [ "${SERENITY_USE_USBDRIVE}" -eq 1 ]; then
+    SERENITY_BOOT_DRIVE="-device usb-storage,drive=usbstick -drive if=none,id=usbstick,format=raw,file=${SERENITY_DISK_IMAGE}"
+    # FIXME: Find a better way to address the usb drive
+    SERENITY_KERNEL_CMDLINE="$SERENITY_KERNEL_CMDLINE root=block3:0"
+fi
 
 if [ -z "$SERENITY_HOST_IP" ]; then
     SERENITY_HOST_IP="127.0.0.1"


### PR DESCRIPTION
### Kernel: Load drivers before looking for the boot drive

### Kernel: Try 5 times to find the root boot drive

This gives us enough time to discover more devices, such as USB drives

### Kernel: Allow enumerating disk partitions without any devices detected

---

This allows us to boot from USB drives
to test this apply the following patch
(No fancy test mode included as of yet)
```diff
diff --git a/Meta/run.sh b/Meta/run.sh
index a2dd7308be..ebb3a86f49 100755
--- a/Meta/run.sh
+++ b/Meta/run.sh
@@ -240,22 +240,27 @@ if [ -z "$SERENITY_QEMU_DISPLAY_DEVICE" ]; then
     fi
 fi
 
-if [ "$SERENITY_ARCH" = 'aarch64' ]; then
-    SERENITY_BOOT_DRIVE="-drive file=${SERENITY_DISK_IMAGE},if=sd,format=raw"
-elif [ -z "${SERENITY_NVME_ENABLE}" ] || [ "${SERENITY_NVME_ENABLE}" -eq 1 ]; then
-    # NVME is enabled by default; disable by setting SERENITY_NVME_ENABLE=0
-    SERENITY_BOOT_DRIVE="-drive file=${SERENITY_DISK_IMAGE},format=raw,index=0,media=disk,if=none,id=disk"
-    SERENITY_BOOT_DRIVE="${SERENITY_BOOT_DRIVE} -device i82801b11-bridge,id=bridge4 -device sdhci-pci,bus=bridge4"
-    SERENITY_BOOT_DRIVE="${SERENITY_BOOT_DRIVE} -device nvme,serial=deadbeef,drive=disk,bus=bridge4,logical_block_size=4096,physical_block_size=4096"
-    SERENITY_KERNEL_CMDLINE="${SERENITY_KERNEL_CMDLINE} root=nvme0:1:0"
-else
-    SERENITY_BOOT_DRIVE="-drive file=${SERENITY_DISK_IMAGE},format=raw,index=0,media=disk,id=disk"
-fi
 
-if [ -n "${SERENITY_USE_SDCARD}" ] && [ "${SERENITY_USE_SDCARD}" -eq 1 ]; then
-    SERENITY_BOOT_DRIVE="-device sdhci-pci -device sd-card,drive=sd-boot-drive -drive id=sd-boot-drive,if=none,format=raw,file=${SERENITY_DISK_IMAGE}"
-    SERENITY_KERNEL_CMDLINE="$SERENITY_KERNEL_CMDLINE root=sd2:0:0"
-fi
+
+# if [ "$SERENITY_ARCH" = 'aarch64' ]; then
+#     SERENITY_BOOT_DRIVE="-drive file=${SERENITY_DISK_IMAGE},if=sd,format=raw"
+# elif [ -z "${SERENITY_NVME_ENABLE}" ] || [ "${SERENITY_NVME_ENABLE}" -eq 1 ]; then
+#     # NVME is enabled by default; disable by setting SERENITY_NVME_ENABLE=0
+#     SERENITY_BOOT_DRIVE="-drive file=${SERENITY_DISK_IMAGE},format=raw,index=0,media=disk,if=none,id=disk"
+#     SERENITY_BOOT_DRIVE="${SERENITY_BOOT_DRIVE} -device i82801b11-bridge,id=bridge4 -device sdhci-pci,bus=bridge4"
+#     SERENITY_BOOT_DRIVE="${SERENITY_BOOT_DRIVE} -device nvme,serial=deadbeef,drive=disk,bus=bridge4,logical_block_size=4096,physical_block_size=4096"
+#     SERENITY_KERNEL_CMDLINE="${SERENITY_KERNEL_CMDLINE} root=nvme0:1:0"
+# else
+#     SERENITY_BOOT_DRIVE="-drive file=${SERENITY_DISK_IMAGE},format=raw,index=0,media=disk,id=disk"
+# fi
+
+# if [ -n "${SERENITY_USE_SDCARD}" ] && [ "${SERENITY_USE_SDCARD}" -eq 1 ]; then
+#     SERENITY_BOOT_DRIVE="-device sdhci-pci -device sd-card,drive=sd-boot-drive -drive id=sd-boot-drive,if=none,format=raw,file=${SERENITY_DISK_IMAGE}"
+#     SERENITY_KERNEL_CMDLINE="$SERENITY_KERNEL_CMDLINE root=sd2:0:0"
+# fi
+
+SERENITY_BOOT_DRIVE="-device usb-storage,drive=usbstick -drive if=none,id=usbstick,format=raw,file=${SERENITY_DISK_IMAGE}"
+SERENITY_KERNEL_CMDLINE="$SERENITY_KERNEL_CMDLINE root=block3:0"
 
 if [ -z "$SERENITY_HOST_IP" ]; then
     SERENITY_HOST_IP="127.0.0.1"
@@ -339,11 +344,11 @@ fi
 [ -z "$SERENITY_COMMON_QEMU_ARGS" ] && SERENITY_COMMON_QEMU_ARGS="
 $SERENITY_EXTRA_QEMU_ARGS
 $SERENITY_MACHINE
+-usb
 $SERENITY_BOOT_DRIVE
 -cpu $SERENITY_QEMU_CPU
 -name SerenityOS
 -d guest_errors
--usb
 $SERENITY_SPICE_SERVER_CHARDEV
 "
 
```