### PR TITLE
LibJS: Implement missing IsSharedArrayBuffer checks

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/ArrayBuffer.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayBuffer.cpp
@@ -158,7 +158,7 @@ ThrowCompletionOr<ArrayBuffer*> allocate_array_buffer(VM& vm, FunctionObject& co
 ThrowCompletionOr<void> detach_array_buffer(VM& vm, ArrayBuffer& array_buffer, Optional<Value> key)
 {
     // 1. Assert: IsSharedArrayBuffer(arrayBuffer) is false.
-    // FIXME: Check for shared buffer
+    VERIFY(!array_buffer.is_shared_array_buffer());
 
     // 2. If key is not present, set key to undefined.
     if (!key.has_value())
@@ -207,7 +207,9 @@ ThrowCompletionOr<ArrayBuffer*> array_buffer_copy_and_detach(VM& vm, ArrayBuffer
 
     // 1. Perform ? RequireInternalSlot(arrayBuffer, [[ArrayBufferData]]).
 
-    // FIXME: 2. If IsSharedArrayBuffer(arrayBuffer) is true, throw a TypeError exception.
+    // 2. If IsSharedArrayBuffer(arrayBuffer) is true, throw a TypeError exception.
+    if (array_buffer.is_shared_array_buffer())
+        return vm.throw_completion<TypeError>(ErrorType::ThisCannotBeSharedArrayBuffer);
 
     // 3. If newLength is undefined, then
     // a. Let newByteLength be arrayBuffer.[[ArrayBufferByteLength]].

--- a/Userland/Libraries/LibJS/Runtime/ArrayBufferPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayBufferPrototype.cpp
@@ -47,7 +47,8 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayBufferPrototype::slice)
     auto array_buffer_object = TRY(typed_this_value(vm));
 
     // 3. If IsSharedArrayBuffer(O) is true, throw a TypeError exception.
-    // FIXME: Check for shared buffer
+    if (array_buffer_object->is_shared_array_buffer())
+        return vm.throw_completion<TypeError>(ErrorType::ThisCannotBeSharedArrayBuffer);
 
     // 4. If IsDetachedBuffer(O) is true, throw a TypeError exception.
     if (array_buffer_object->is_detached())
@@ -99,7 +100,8 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayBufferPrototype::slice)
     auto* new_array_buffer_object = static_cast<ArrayBuffer*>(new_array_buffer.ptr());
 
     // 18. If IsSharedArrayBuffer(new) is true, throw a TypeError exception.
-    // FIXME: Check for shared buffer
+    if (array_buffer_object->is_shared_array_buffer())
+        return vm.throw_completion<TypeError>(ErrorType::ThisCannotBeSharedArrayBuffer);
 
     // 19. If IsDetachedBuffer(new) is true, throw a TypeError exception.
     if (new_array_buffer_object->is_detached())
@@ -157,7 +159,8 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayBufferPrototype::detached_getter)
     auto array_buffer_object = TRY(typed_this_value(vm));
 
     // 3. If IsSharedArrayBuffer(O) is true, throw a TypeError exception.
-    // FIXME: Check for shared buffer
+    if (array_buffer_object->is_shared_array_buffer())
+        return vm.throw_completion<TypeError>(ErrorType::ThisCannotBeSharedArrayBuffer);
 
     // 4. Return IsDetachedBuffer(O).
     return Value(array_buffer_object->is_detached());

--- a/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
+++ b/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
@@ -293,6 +293,7 @@
     M(TemporalUnknownCriticalAnnotation, "Unknown annotation key in critical annotation: '{}'")                                         \
     M(TemporalZonedDateTimeRoundZeroOrNegativeLengthDay, "Cannot round a ZonedDateTime in a calendar or time zone that has zero or "    \
                                                          "negative length days")                                                        \
+    M(ThisCannotBeArrayBuffer, "|this| cannot be an ArrayBuffer")                                                                       \
     M(ThisCannotBeSharedArrayBuffer, "|this| cannot be a SharedArrayBuffer")                                                            \
     M(ThisHasNotBeenInitialized, "|this| has not been initialized")                                                                     \
     M(ThisIsAlreadyInitialized, "|this| is already initialized")                                                                        \

--- a/Userland/Libraries/LibJS/Runtime/SharedArrayBufferPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/SharedArrayBufferPrototype.cpp
@@ -38,7 +38,8 @@ JS_DEFINE_NATIVE_FUNCTION(SharedArrayBufferPrototype::byte_length_getter)
     auto array_buffer_object = TRY(typed_this_value(vm));
 
     // 3. If IsSharedArrayBuffer(O) is false, throw a TypeError exception.
-    // FIXME: Check for shared buffer
+    if (!array_buffer_object->is_shared_array_buffer())
+        return vm.throw_completion<TypeError>(ErrorType::ThisCannotBeArrayBuffer);
 
     // 4. Let length be O.[[ArrayBufferByteLength]].
     // 5. Return 𝔽(length).
@@ -58,7 +59,8 @@ JS_DEFINE_NATIVE_FUNCTION(SharedArrayBufferPrototype::slice)
     auto array_buffer_object = TRY(typed_this_value(vm));
 
     // 3. If IsSharedArrayBuffer(O) is false, throw a TypeError exception.
-    // FIXME: Check for shared buffer
+    if (!array_buffer_object->is_shared_array_buffer())
+        return vm.throw_completion<TypeError>(ErrorType::ThisCannotBeArrayBuffer);
 
     // 4. Let len be O.[[ArrayBufferByteLength]].
     auto length = array_buffer_object->byte_length();
@@ -105,8 +107,9 @@ JS_DEFINE_NATIVE_FUNCTION(SharedArrayBufferPrototype::slice)
         return vm.throw_completion<TypeError>(ErrorType::SpeciesConstructorDidNotCreate, "an ArrayBuffer");
     auto* new_array_buffer_object = static_cast<ArrayBuffer*>(new_array_buffer.ptr());
 
-    // 17. If IsSharedArrayBuffer(new) is true, throw a TypeError exception.
-    // FIXME: Check for shared buffer
+    // 17. If IsSharedArrayBuffer(new) is false, throw a TypeError exception.
+    if (!new_array_buffer_object->is_shared_array_buffer())
+        return vm.throw_completion<TypeError>(ErrorType::SpeciesConstructorDidNotCreate, "a SharedArrayBuffer");
 
     // 18. If new.[[ArrayBufferData]] is O.[[ArrayBufferData]], throw a TypeError exception.
     if (new_array_buffer == array_buffer_object)

--- a/Userland/Libraries/LibJS/Tests/builtins/ArrayBuffer/ArrayBuffer.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/ArrayBuffer/ArrayBuffer.js
@@ -17,3 +17,11 @@ test("ArrayBuffer size limit", () => {
         new ArrayBuffer(2 ** 53);
     }).toThrowWithMessage(RangeError, "Invalid array buffer length");
 });
+
+test("ArrayBuffer is detached after transfer()", () => {
+    const ab = new ArrayBuffer(16);
+    expect(ab.detached).toBe(false);
+    const transferred = ab.transfer();
+    expect(ab.detached).toBe(true);
+    expect(transferred.detached).toBe(false);
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/ArrayBuffer/ArrayBuffer.prototype.slice.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/ArrayBuffer/ArrayBuffer.prototype.slice.js
@@ -27,3 +27,14 @@ test("both parameters", () => {
     expect(slicedView).toHaveLength(1);
     expect(slicedView[0]).toBe(12);
 });
+
+test("throws TypeError if |this| is SharedArrayBuffer", () => {
+    const sab = new SharedArrayBuffer(16);
+    expect(() => ArrayBuffer.prototype.slice.call(sab)).toThrow(TypeError);
+});
+
+test("slice creates a new ArrayBuffer", () => {
+    const ab = new ArrayBuffer(16);
+    expect(ab).toBeInstanceOf(ArrayBuffer);
+    expect(ab.slice(0)).toBeInstanceOf(ArrayBuffer);
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/SharedArrayBuffer/SharedArrayBuffer.prototype.slice.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/SharedArrayBuffer/SharedArrayBuffer.prototype.slice.js
@@ -27,3 +27,14 @@ test("both parameters", () => {
     expect(slicedView).toHaveLength(1);
     expect(slicedView[0]).toBe(12);
 });
+
+test("throws TypeError if |this| is ArrayBuffer", () => {
+    const ab = new ArrayBuffer(16);
+    expect(() => SharedArrayBuffer.prototype.slice.call(ab)).toThrow(TypeError);
+});
+
+test("slice creates a new SharedArrayBuffer", () => {
+    const sab = new SharedArrayBuffer(16);
+    expect(sab).toBeInstanceOf(SharedArrayBuffer);
+    expect(sab.slice(0)).toBeInstanceOf(SharedArrayBuffer);
+});


### PR DESCRIPTION
Remove existing FIXME comments and replace them by properly checking if ArrayBuffer is_shared_array_buffer().

Fixes 7 previously failing test262 tests.