### PR TITLE
Kernel/Ext2: Avoid overflow when updating UID and GID values

### DIFF
--- a/Kernel/FileSystem/Ext2FS/FileSystem.cpp
+++ b/Kernel/FileSystem/Ext2FS/FileSystem.cpp
@@ -510,8 +510,10 @@ ErrorOr<NonnullRefPtr<Inode>> Ext2FS::create_inode(Ext2FSInode& parent_inode, St
     ext2_inode e2inode {};
     auto now = kgettimeofday().truncated_seconds_since_epoch();
     e2inode.i_mode = mode;
-    e2inode.i_uid = uid.value();
-    e2inode.i_gid = gid.value();
+    e2inode.i_uid = static_cast<u16>(uid.value());
+    ext2fs_set_i_uid_high(e2inode, uid.value() >> 16);
+    e2inode.i_gid = static_cast<u16>(gid.value());
+    ext2fs_set_i_gid_high(e2inode, gid.value() >> 16);
     e2inode.i_size = 0;
     e2inode.i_atime = now;
     e2inode.i_ctime = now;

--- a/Meta/build-root-filesystem.sh
+++ b/Meta/build-root-filesystem.sh
@@ -98,6 +98,10 @@ if [ -f mnt/bin/timezone ]; then
     chown 0:$phys_gid mnt/bin/timezone
     chmod 4750 mnt/bin/timezone
 fi
+if [ -f mnt/usr/Tests/Kernel/TestExt2FS ]; then
+    chown 0:0 mnt/usr/Tests/Kernel/TestExt2FS
+    chmod 4755 mnt/usr/Tests/Kernel/TestExt2FS
+fi
 if [ -f mnt/usr/Tests/Kernel/TestMemoryDeviceMmap ]; then
     chown 0:0 mnt/usr/Tests/Kernel/TestMemoryDeviceMmap
     chmod 4755 mnt/usr/Tests/Kernel/TestMemoryDeviceMmap

--- a/Tests/Kernel/CMakeLists.txt
+++ b/Tests/Kernel/CMakeLists.txt
@@ -40,6 +40,7 @@ serenity_test("crash.cpp" Kernel MAIN_ALREADY_DEFINED)
 set(LIBTEST_BASED_SOURCES
     TestEmptyPrivateInodeVMObject.cpp
     TestEmptySharedInodeVMObject.cpp
+    TestExt2FS.cpp
     TestInvalidUIDSet.cpp
     TestSharedInodeVMObject.cpp
     TestPosixFallocate.cpp

--- a/Tests/Kernel/TestExt2FS.cpp
+++ b/Tests/Kernel/TestExt2FS.cpp
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2023, Tim Ledbetter <timledbetter@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibTest/TestCase.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+TEST_CASE(test_uid_and_gid_high_bits_are_set)
+{
+    static constexpr auto TEST_FILE_PATH = "/home/anon/.ext2_test";
+
+    auto uid = geteuid();
+    EXPECT_EQ(uid, 0u);
+
+    auto fd = open(TEST_FILE_PATH, O_CREAT);
+    auto cleanup_guard = ScopeGuard([&] {
+        close(fd);
+        unlink(TEST_FILE_PATH);
+    });
+
+    EXPECT_EQ(setuid(0), 0);
+    EXPECT_EQ(fchown(fd, 65536, 65536), 0);
+
+    struct stat st;
+    EXPECT_EQ(fstat(fd, &st), 0);
+    EXPECT_EQ(st.st_uid, 65536u);
+    EXPECT_EQ(st.st_gid, 65536u);
+}


### PR DESCRIPTION
Previously, attempting to write a UID or GID larger than 65535 would overflow. We now write the high bits of UIDs and GIDs to the same place that Linux does within the `osd2` struct.

Before:

![ext2_uid_gid_overflow_before](https://github.com/SerenityOS/serenity/assets/2817754/531e0585-7bd9-4b61-8cca-482793a68b1e)

After:

![ext2_uid_gid_overflow_after](https://github.com/SerenityOS/serenity/assets/2817754/8e7dbf89-0c02-403a-90d5-5743d69e106b)

NB: I also tested creating a new file as the `not_root` user. I had to do this with `bash` though, as `Shell` crashed when I ran `su not_root` :shrug:.