### PR TITLE
LibGfx: Check bounds of color table accesses in BMPLoader

### DIFF
--- a/Userland/Applications/ImageViewer/ViewWidget.cpp
+++ b/Userland/Applications/ImageViewer/ViewWidget.cpp
@@ -246,7 +246,7 @@ ErrorOr<void> ViewWidget::try_open_file(String const& path, Core::File& file)
         frames.ensure_capacity(decoded_image->frames.size());
         for (u32 i = 0; i < decoded_image->frames.size(); i++) {
             auto& frame_data = decoded_image->frames[i];
-            frames.unchecked_append({ BitmapImage::create(*frame_data.bitmap), int(frame_data.duration) });
+            frames.unchecked_append({ BitmapImage::create(frame_data.bitmap), int(frame_data.duration) });
         }
     }
 

--- a/Userland/Applications/PixelPaint/Image.cpp
+++ b/Userland/Applications/PixelPaint/Image.cpp
@@ -66,10 +66,7 @@ ErrorOr<NonnullRefPtr<Gfx::Bitmap>> Image::decode_bitmap(ReadonlyBytes bitmap_da
     if (decoded_image.frames.is_empty())
         return Error::from_string_literal("Image decode failed (no frames)");
 
-    auto decoded_bitmap = decoded_image.frames.first().bitmap;
-    if (decoded_bitmap.is_null())
-        return Error::from_string_literal("Image decode failed (no bitmap for frame)");
-    return decoded_bitmap.release_nonnull();
+    return decoded_image.frames.first().bitmap;
 }
 
 ErrorOr<NonnullRefPtr<Image>> Image::create_from_bitmap(NonnullRefPtr<Gfx::Bitmap> const& bitmap)

--- a/Userland/Libraries/LibGfx/ImageFormats/BMPLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/BMPLoader.cpp
@@ -1292,8 +1292,10 @@ static ErrorOr<void> decode_bmp_pixel_data(BMPLoadingContext& context)
                 u8 mask = 8;
                 while (column < width && mask > 0) {
                     mask -= 1;
-                    auto color_idx = (byte >> mask) & 0x1;
+                    size_t color_idx = (byte >> mask) & 0x1;
                     if (context.is_included_in_ico) {
+                        if (color_idx >= context.color_table.size())
+                            return Error::from_string_literal("Invalid color table index");
                         auto color = context.color_table[color_idx];
                         context.bitmap->scanline(row)[column++] = color;
                     } else {
@@ -1309,8 +1311,10 @@ static ErrorOr<void> decode_bmp_pixel_data(BMPLoadingContext& context)
                 u8 mask = 8;
                 while (column < width && mask > 0) {
                     mask -= 2;
-                    auto color_idx = (byte >> mask) & 0x3;
+                    size_t color_idx = (byte >> mask) & 0x3;
                     if (context.is_included_in_ico) {
+                        if (color_idx >= context.color_table.size())
+                            return Error::from_string_literal("Invalid color table index");
                         auto color = context.color_table[color_idx];
                         context.bitmap->scanline(row)[column++] = color;
                     } else {
@@ -1329,6 +1333,8 @@ static ErrorOr<void> decode_bmp_pixel_data(BMPLoadingContext& context)
                 u32 low_color_idx = byte & 0xf;
 
                 if (context.is_included_in_ico) {
+                    if (high_color_idx >= context.color_table.size() || low_color_idx >= context.color_table.size())
+                        return Error::from_string_literal("Invalid color table index");
                     auto high_color = context.color_table[high_color_idx];
                     auto low_color = context.color_table[low_color_idx];
                     context.bitmap->scanline(row)[column++] = high_color;
@@ -1348,6 +1354,8 @@ static ErrorOr<void> decode_bmp_pixel_data(BMPLoadingContext& context)
 
                 u8 byte = streamer.read_u8();
                 if (context.is_included_in_ico) {
+                    if (byte >= context.color_table.size())
+                        return Error::from_string_literal("Invalid color table index");
                     auto color = context.color_table[byte];
                     context.bitmap->scanline(row)[column++] = color;
                 } else {

--- a/Userland/Libraries/LibImageDecoderClient/Client.cpp
+++ b/Userland/Libraries/LibImageDecoderClient/Client.cpp
@@ -48,12 +48,13 @@ Optional<DecodedImage> Client::decode_image(ReadonlyBytes encoded_data, Optional
     DecodedImage image;
     image.is_animated = response.is_animated();
     image.loop_count = response.loop_count();
-    image.frames.resize(response.bitmaps().size());
+    image.frames.ensure_capacity(response.bitmaps().size());
     auto bitmaps = response.take_bitmaps();
-    for (size_t i = 0; i < image.frames.size(); ++i) {
-        auto& frame = image.frames[i];
-        frame.bitmap = bitmaps[i].bitmap();
-        frame.duration = response.durations()[i];
+    for (size_t i = 0; i < bitmaps.size(); ++i) {
+        if (!bitmaps[i].is_valid())
+            return {};
+
+        image.frames.empend(*bitmaps[i].bitmap(), response.durations()[i]);
     }
     return image;
 }

--- a/Userland/Libraries/LibImageDecoderClient/Client.h
+++ b/Userland/Libraries/LibImageDecoderClient/Client.h
@@ -14,7 +14,7 @@
 namespace ImageDecoderClient {
 
 struct Frame {
-    RefPtr<Gfx::Bitmap> bitmap;
+    NonnullRefPtr<Gfx::Bitmap> bitmap;
     u32 duration { 0 };
 };
 

--- a/Userland/Services/WebContent/ImageCodecPluginSerenity.cpp
+++ b/Userland/Services/WebContent/ImageCodecPluginSerenity.cpp
@@ -31,9 +31,7 @@ Optional<Web::Platform::DecodedImage> ImageCodecPluginSerenity::decode_image(Rea
     decoded_image.is_animated = result.is_animated;
     decoded_image.loop_count = result.loop_count;
     for (auto const& frame : result.frames) {
-        if (!frame.bitmap)
-            return {};
-        decoded_image.frames.empend(move(frame.bitmap), frame.duration);
+        decoded_image.frames.empend(frame.bitmap, frame.duration);
     }
 
     return decoded_image;

--- a/Userland/Utilities/pixelflut.cpp
+++ b/Userland/Utilities/pixelflut.cpp
@@ -80,7 +80,7 @@ ErrorOr<NonnullRefPtr<Client>> Client::create(StringView image_path, StringView 
     if (!maybe_image.has_value())
         return Error::from_string_view("Image could not be read"sv);
 
-    auto image = maybe_image->frames.take_first().bitmap.release_nonnull();
+    auto image = maybe_image->frames.take_first().bitmap;
 
     // Make sure to not draw out of bounds; some servers will disconnect us for that!
     if (image->width() > canvas_size.width()) {


### PR DESCRIPTION
This fixes the following oss-fuzz issue: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=62541&sort=-opened&can=1&q=proj%3Aserenity

I also fixed a crash that happened when attempting to load the test file with `ImageViewer`.