### PR TITLE
LibGfx: Don't read past EOF in JPEGLoader

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/JPEGLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEGLoader.cpp
@@ -230,6 +230,9 @@ private:
         VERIFY(m_byte_offset == m_current_size);
 
         m_current_size = TRY(m_stream->read_some(m_buffer.span())).size();
+        if (m_current_size == 0)
+            return Error::from_string_literal("Unexpected end of file");
+
         m_byte_offset = 0;
 
         return {};


### PR DESCRIPTION
Previously, it was possible to pass JPEGLoader a crafted input which would read past the end of the stream. We now return an error in such cases.

This fixes oss-fuzz issue: [62584](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=62584&sort=-opened&can=1&q=proj%3Aserenity) (and possibly other JPEGLoader issues).