### PR TITLE
LibWeb/Fetch: Include body and headers in Response for failed requests 

### DIFF
--- a/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
@@ -1776,7 +1776,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<PendingResponse>> nonstandard_resource_load
             // FIXME: Set response status message
             pending_response->resolve(response);
         },
-        [&vm, request, pending_response](auto& error, auto status_code) {
+        [&realm, &vm, request, pending_response](auto& error, auto status_code, auto, auto&) {
             dbgln_if(WEB_FETCH_DEBUG, "Fetch: ResourceLoader load for '{}' failed: {} (status {})", request->url(), error, status_code.value_or(0));
             auto response = Infrastructure::Response::create(vm);
             // FIXME: This is ugly, ResourceLoader should tell us.

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Responses.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Responses.cpp
@@ -79,9 +79,22 @@ bool Response::is_aborted_network_error() const
 // https://fetch.spec.whatwg.org/#concept-network-error
 bool Response::is_network_error() const
 {
-    // A response whose type is "error" is known as a network error.
+    // A network error is a response whose type is "error", status is 0, status message is the empty byte sequence,
+    // header list is « », body is null, and body info is a new response body info.
     // NOTE: We have to use the virtual getter here to not bypass filtered responses.
-    return type() == Type::Error;
+    if (type() != Type::Error)
+        return false;
+    if (status() != 0)
+        return false;
+    if (!status_message().is_empty())
+        return false;
+    if (!header_list()->is_empty())
+        return false;
+    if (!body())
+        return false;
+    if (body_info() != BodyInfo {})
+        return false;
+    return true;
 }
 
 // https://fetch.spec.whatwg.org/#concept-response-url

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Responses.h
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Responses.h
@@ -47,6 +47,8 @@ public:
 
         // https://fetch.spec.whatwg.org/#fetch-timing-info-decoded-body-size
         u64 decoded_size { 0 };
+
+        bool operator==(BodyInfo const&) const = default;
     };
 
     [[nodiscard]] static JS::NonnullGCPtr<Response> create(JS::VM&);

--- a/Userland/Libraries/LibWeb/HTML/Worker.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Worker.cpp
@@ -314,7 +314,7 @@ void Worker::run_a_worker(AK::URL& url, EnvironmentSettingsObject& outside_setti
 
             // 28. Event loop: Run the responsible event loop specified by inside settings until it is destroyed.
         },
-        [](auto&, auto) {
+        [](auto&, auto, auto, auto&) {
             dbgln_if(WEB_WORKER_DEBUG, "WebWorker: HONK! Failed to load script.");
         });
 }

--- a/Userland/Libraries/LibWeb/Loader/ResourceLoader.h
+++ b/Userland/Libraries/LibWeb/Loader/ResourceLoader.h
@@ -104,8 +104,12 @@ public:
 
     RefPtr<Resource> load_resource(Resource::Type, LoadRequest&);
 
-    void load(LoadRequest&, Function<void(ReadonlyBytes, HashMap<DeprecatedString, DeprecatedString, CaseInsensitiveStringTraits> const& response_headers, Optional<u32> status_code)> success_callback, Function<void(DeprecatedString const&, Optional<u32> status_code)> error_callback = nullptr, Optional<u32> timeout = {}, Function<void()> timeout_callback = nullptr);
-    void load(const AK::URL&, Function<void(ReadonlyBytes, HashMap<DeprecatedString, DeprecatedString, CaseInsensitiveStringTraits> const& response_headers, Optional<u32> status_code)> success_callback, Function<void(DeprecatedString const&, Optional<u32> status_code)> error_callback = nullptr, Optional<u32> timeout = {}, Function<void()> timeout_callback = nullptr);
+    using SuccessCallback = Function<void(ReadonlyBytes, HashMap<DeprecatedString, DeprecatedString, CaseInsensitiveStringTraits> const& response_headers, Optional<u32> status_code)>;
+    using ErrorCallback = Function<void(DeprecatedString const&, Optional<u32> status_code, ReadonlyBytes payload, HashMap<DeprecatedString, DeprecatedString, CaseInsensitiveStringTraits> const& response_headers)>;
+    using TimeoutCallback = Function<void()>;
+
+    void load(LoadRequest&, SuccessCallback success_callback, ErrorCallback error_callback = nullptr, Optional<u32> timeout = {}, TimeoutCallback timeout_callback = nullptr);
+    void load(const AK::URL&, SuccessCallback success_callback, ErrorCallback error_callback = nullptr, Optional<u32> timeout = {}, TimeoutCallback timeout_callback = nullptr);
 
     ResourceLoaderConnector& connector() { return *m_connector; }
 


### PR DESCRIPTION
Fixes https://github.com/SerenityOS/serenity/issues/21290