### PR TITLE
LibGfx: Check bounds of color table access in TinyVGLoader

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/TinyVGLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/TinyVGLoader.cpp
@@ -205,6 +205,9 @@ public:
     {
         auto read_color = [&]() -> ErrorOr<Color> {
             auto color_index = TRY(m_stream.read_value<VarUInt>());
+            if (color_index >= m_color_table.size())
+                return Error::from_string_literal("Invalid color table index");
+
             return m_color_table[color_index];
         };
         auto read_gradient = [&]() -> ErrorOr<NonnullRefPtr<SVGGradientPaintStyle>> {


### PR DESCRIPTION
This fixes oss-fuzz issue [62047](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=62047&q=proj%3Aserenity&can=2&sort=-reported).