### PR TITLE
LibGfx: Replace raw pointers in BitmapFont code, and other tidying up

### DIFF
--- a/Tests/LibGfx/TestFontHandling.cpp
+++ b/Tests/LibGfx/TestFontHandling.cpp
@@ -52,7 +52,7 @@ TEST_CASE(test_clone)
 {
     u8 glyph_height = 1;
     u8 glyph_width = 1;
-    auto font = Gfx::BitmapFont::create(glyph_height, glyph_width, true, 256);
+    auto font = MUST(Gfx::BitmapFont::create(glyph_height, glyph_width, true, 256));
 
     auto new_font = font->clone();
     EXPECT(!new_font->name().is_empty());
@@ -65,7 +65,7 @@ TEST_CASE(test_set_name)
 {
     u8 glyph_height = 1;
     u8 glyph_width = 1;
-    auto font = Gfx::BitmapFont::create(glyph_height, glyph_width, true, 256);
+    auto font = MUST(Gfx::BitmapFont::create(glyph_height, glyph_width, true, 256));
 
     auto name = "my newly created font"_string;
     font->set_name(name);
@@ -78,7 +78,7 @@ TEST_CASE(test_set_family)
 {
     u8 glyph_height = 1;
     u8 glyph_width = 1;
-    auto font = Gfx::BitmapFont::create(glyph_height, glyph_width, true, 256);
+    auto font = MUST(Gfx::BitmapFont::create(glyph_height, glyph_width, true, 256));
 
     auto family = "my newly created font family"_string;
     font->set_family(family);
@@ -91,7 +91,7 @@ TEST_CASE(test_set_glyph_width)
 {
     u8 glyph_height = 1;
     u8 glyph_width = 1;
-    auto font = Gfx::BitmapFont::create(glyph_height, glyph_width, true, 256);
+    auto font = MUST(Gfx::BitmapFont::create(glyph_height, glyph_width, true, 256));
 
     size_t ch = 123;
     font->set_glyph_width(ch, glyph_width);
@@ -103,7 +103,7 @@ TEST_CASE(test_set_glyph_spacing)
 {
     u8 glyph_height = 1;
     u8 glyph_width = 1;
-    auto font = Gfx::BitmapFont::create(glyph_height, glyph_width, true, 256);
+    auto font = MUST(Gfx::BitmapFont::create(glyph_height, glyph_width, true, 256));
 
     u8 glyph_spacing = 8;
     font->set_glyph_spacing(glyph_spacing);
@@ -115,7 +115,7 @@ TEST_CASE(test_width)
 {
     u8 glyph_height = 1;
     u8 glyph_width = 1;
-    auto font = Gfx::BitmapFont::create(glyph_height, glyph_width, true, 256);
+    auto font = MUST(Gfx::BitmapFont::create(glyph_height, glyph_width, true, 256));
 
     EXPECT(font->width("A"sv) == glyph_width);
 }
@@ -124,7 +124,7 @@ TEST_CASE(test_glyph_or_emoji_width)
 {
     u8 glyph_height = 1;
     u8 glyph_width = 1;
-    auto font = Gfx::BitmapFont::create(glyph_height, glyph_width, true, 256);
+    auto font = MUST(Gfx::BitmapFont::create(glyph_height, glyph_width, true, 256));
 
     Utf8View view { " "sv };
     auto it = view.begin();
@@ -142,7 +142,7 @@ TEST_CASE(test_write_to_file)
 {
     u8 glyph_height = 1;
     u8 glyph_width = 1;
-    auto font = Gfx::BitmapFont::create(glyph_height, glyph_width, true, 256);
+    auto font = MUST(Gfx::BitmapFont::create(glyph_height, glyph_width, true, 256));
 
     char path[] = "/tmp/new.font.XXXXXX";
     EXPECT(mkstemp(path) != -1);

--- a/Userland/Applications/FontEditor/NewFontDialog.cpp
+++ b/Userland/Applications/FontEditor/NewFontDialog.cpp
@@ -236,7 +236,7 @@ ErrorOr<NonnullRefPtr<Gfx::BitmapFont>> NewFontDialog::create_font()
 {
     save_metadata();
 
-    auto font = TRY(Gfx::BitmapFont::try_create(m_new_font_metadata.glyph_height, m_new_font_metadata.glyph_width, m_new_font_metadata.is_fixed_width, 0x110000));
+    auto font = TRY(Gfx::BitmapFont::create(m_new_font_metadata.glyph_height, m_new_font_metadata.glyph_width, m_new_font_metadata.is_fixed_width, 0x110000));
     font->set_name(m_new_font_metadata.name);
     font->set_family(m_new_font_metadata.family);
     font->set_presentation_size(m_new_font_metadata.presentation_size);

--- a/Userland/Libraries/LibCore/System.cpp
+++ b/Userland/Libraries/LibCore/System.cpp
@@ -1837,4 +1837,12 @@ ErrorOr<String> current_executable_path()
     return String::from_utf8({ path, strlen(path) });
 }
 
+ErrorOr<Bytes> allocate(size_t count, size_t size)
+{
+    auto* data = static_cast<u8*>(calloc(count, size));
+    if (!data)
+        return Error::from_errno(errno);
+    return Bytes { data, size * count };
+}
+
 }

--- a/Userland/Libraries/LibCore/System.h
+++ b/Userland/Libraries/LibCore/System.h
@@ -280,4 +280,6 @@ char** environment();
 
 ErrorOr<String> current_executable_path();
 
+ErrorOr<Bytes> allocate(size_t count, size_t size);
+
 }

--- a/Userland/Libraries/LibGfx/Font/BitmapFont.cpp
+++ b/Userland/Libraries/LibGfx/Font/BitmapFont.cpp
@@ -53,8 +53,8 @@ ErrorOr<NonnullRefPtr<Font>> BitmapFont::try_clone() const
     auto new_rows = TRY(Core::System::allocate(m_glyph_count, bytes_per_glyph));
     m_rows.copy_to(new_rows);
     auto new_widths = TRY(Core::System::allocate(m_glyph_count, 1));
-    memcpy(new_widths.data(), m_glyph_widths, m_glyph_count);
-    return TRY(adopt_nonnull_ref_or_enomem(new (nothrow) BitmapFont(m_name, m_family, new_rows, new_widths.data(), m_fixed_width, m_glyph_width, m_glyph_height, m_glyph_spacing, new_range_mask, m_baseline, m_mean_line, m_presentation_size, m_weight, m_slope, true)));
+    m_glyph_widths.copy_to(new_widths);
+    return TRY(adopt_nonnull_ref_or_enomem(new (nothrow) BitmapFont(m_name, m_family, new_rows, new_widths, m_fixed_width, m_glyph_width, m_glyph_height, m_glyph_spacing, new_range_mask, m_baseline, m_mean_line, m_presentation_size, m_weight, m_slope, true)));
 }
 
 ErrorOr<NonnullRefPtr<BitmapFont>> BitmapFont::create(u8 glyph_height, u8 glyph_width, bool fixed, size_t glyph_count)
@@ -70,7 +70,7 @@ ErrorOr<NonnullRefPtr<BitmapFont>> BitmapFont::create(u8 glyph_height, u8 glyph_
     size_t bytes_per_glyph = sizeof(u32) * glyph_height;
     auto new_rows = TRY(Core::System::allocate(glyph_count, bytes_per_glyph));
     auto new_widths = TRY(Core::System::allocate(glyph_count, 1));
-    return adopt_nonnull_ref_or_enomem(new (nothrow) BitmapFont("Untitled"_string, "Untitled"_string, new_rows, new_widths.data(), fixed, glyph_width, glyph_height, 1, new_range_mask, 0, 0, 0, 400, 0, true));
+    return adopt_nonnull_ref_or_enomem(new (nothrow) BitmapFont("Untitled"_string, "Untitled"_string, new_rows, new_widths, fixed, glyph_width, glyph_height, 1, new_range_mask, 0, 0, 0, 400, 0, true));
 }
 
 ErrorOr<NonnullRefPtr<BitmapFont>> BitmapFont::unmasked_character_set() const
@@ -84,11 +84,11 @@ ErrorOr<NonnullRefPtr<BitmapFont>> BitmapFont::unmasked_character_set() const
     for (size_t code_point = 0; code_point < s_max_glyph_count; ++code_point) {
         auto index = glyph_index(code_point);
         if (index.has_value()) {
-            memcpy(&new_widths[code_point], &m_glyph_widths[index.value()], 1);
+            new_widths[code_point] = m_glyph_widths[index.value()];
             memcpy(&new_rows[code_point * bytes_per_glyph], &m_rows[index.value() * bytes_per_glyph], bytes_per_glyph);
         }
     }
-    return adopt_nonnull_ref_or_enomem(new (nothrow) BitmapFont(m_name, m_family, new_rows, new_widths.data(), m_fixed_width, m_glyph_width, m_glyph_height, m_glyph_spacing, new_range_mask, m_baseline, m_mean_line, m_presentation_size, m_weight, m_slope, true));
+    return adopt_nonnull_ref_or_enomem(new (nothrow) BitmapFont(m_name, m_family, new_rows, new_widths, m_fixed_width, m_glyph_width, m_glyph_height, m_glyph_spacing, new_range_mask, m_baseline, m_mean_line, m_presentation_size, m_weight, m_slope, true));
 }
 
 ErrorOr<NonnullRefPtr<BitmapFont>> BitmapFont::masked_character_set() const
@@ -115,15 +115,15 @@ ErrorOr<NonnullRefPtr<BitmapFont>> BitmapFont::masked_character_set() const
             i += 255;
             continue;
         }
-        memcpy(&new_widths[i - j * 256], &m_glyph_widths[i], 1);
+        new_widths[i - j * 256] = m_glyph_widths[i];
         memcpy(&new_rows[(i - j * 256) * bytes_per_glyph], &m_rows[i * bytes_per_glyph], bytes_per_glyph);
     }
     // Now that we're done working with the range-mask memory, reduce its reported size down to what it should be.
     new_range_mask = { new_range_mask.data(), new_range_mask_size };
-    return adopt_nonnull_ref_or_enomem(new (nothrow) BitmapFont(m_name, m_family, new_rows, new_widths.data(), m_fixed_width, m_glyph_width, m_glyph_height, m_glyph_spacing, new_range_mask, m_baseline, m_mean_line, m_presentation_size, m_weight, m_slope, true));
+    return adopt_nonnull_ref_or_enomem(new (nothrow) BitmapFont(m_name, m_family, new_rows, new_widths, m_fixed_width, m_glyph_width, m_glyph_height, m_glyph_spacing, new_range_mask, m_baseline, m_mean_line, m_presentation_size, m_weight, m_slope, true));
 }
 
-BitmapFont::BitmapFont(String name, String family, Bytes rows, u8* widths, bool is_fixed_width, u8 glyph_width, u8 glyph_height, u8 glyph_spacing, Bytes range_mask, u8 baseline, u8 mean_line, u8 presentation_size, u16 weight, u8 slope, bool owns_arrays)
+BitmapFont::BitmapFont(String name, String family, Bytes rows, Span<u8> widths, bool is_fixed_width, u8 glyph_width, u8 glyph_height, u8 glyph_spacing, Bytes range_mask, u8 baseline, u8 mean_line, u8 presentation_size, u16 weight, u8 slope, bool owns_arrays)
     : m_name(move(name))
     , m_family(move(family))
     , m_range_mask(range_mask)
@@ -142,8 +142,6 @@ BitmapFont::BitmapFont(String name, String family, Bytes rows, u8* widths, bool 
     , m_fixed_width(is_fixed_width)
     , m_owns_arrays(owns_arrays)
 {
-    VERIFY(m_glyph_widths);
-
     update_x_height();
 
     for (size_t i = 0, index = 0; i < m_range_mask.size(); ++i) {
@@ -172,7 +170,7 @@ BitmapFont::BitmapFont(String name, String family, Bytes rows, u8* widths, bool 
 BitmapFont::~BitmapFont()
 {
     if (m_owns_arrays) {
-        free(m_glyph_widths);
+        free(m_glyph_widths.data());
         free(m_rows.data());
         free(m_range_mask.data());
     }
@@ -196,7 +194,7 @@ ErrorOr<NonnullRefPtr<BitmapFont>> BitmapFont::load_from_memory(u8 const* data)
         glyph_count += 256 * popcount(range_mask[i]);
     u8* rows_start = range_mask_start + header.range_mask_size;
     Bytes rows { rows_start, glyph_count * bytes_per_glyph };
-    u8* widths = rows_start + glyph_count * bytes_per_glyph;
+    Span<u8> widths { rows_start + glyph_count * bytes_per_glyph, glyph_count };
     auto name = TRY(String::from_utf8(ReadonlyBytes { header.name, strlen(header.name) }));
     auto family = TRY(String::from_utf8(ReadonlyBytes { header.family, strlen(header.family) }));
     return adopt_nonnull_ref_or_enomem(new (nothrow) BitmapFont(move(name), move(family), rows, widths, !header.is_variable_width, header.glyph_width, header.glyph_height, header.glyph_spacing, range_mask, header.baseline, header.mean_line, header.presentation_size, header.weight, header.slope));
@@ -249,7 +247,7 @@ ErrorOr<void> BitmapFont::write_to_file(NonnullOwnPtr<Core::File> file)
     TRY(file->write_until_depleted({ &header, sizeof(header) }));
     TRY(file->write_until_depleted(m_range_mask));
     TRY(file->write_until_depleted(m_rows));
-    TRY(file->write_until_depleted({ m_glyph_widths, m_glyph_count }));
+    TRY(file->write_until_depleted(m_glyph_widths));
 
     return {};
 }

--- a/Userland/Libraries/LibGfx/Font/BitmapFont.cpp
+++ b/Userland/Libraries/LibGfx/Font/BitmapFont.cpp
@@ -61,12 +61,7 @@ ErrorOr<NonnullRefPtr<Font>> BitmapFont::try_clone() const
     return TRY(adopt_nonnull_ref_or_enomem(new (nothrow) BitmapFont(m_name, m_family, new_rows, new_widths, m_fixed_width, m_glyph_width, m_glyph_height, m_glyph_spacing, m_range_mask_size, new_range_mask, m_baseline, m_mean_line, m_presentation_size, m_weight, m_slope, true)));
 }
 
-NonnullRefPtr<BitmapFont> BitmapFont::create(u8 glyph_height, u8 glyph_width, bool fixed, size_t glyph_count)
-{
-    return MUST(try_create(glyph_height, glyph_width, fixed, glyph_count));
-}
-
-ErrorOr<NonnullRefPtr<BitmapFont>> BitmapFont::try_create(u8 glyph_height, u8 glyph_width, bool fixed, size_t glyph_count)
+ErrorOr<NonnullRefPtr<BitmapFont>> BitmapFont::create(u8 glyph_height, u8 glyph_width, bool fixed, size_t glyph_count)
 {
     glyph_count += 256 - (glyph_count % 256);
     glyph_count = min(glyph_count, s_max_glyph_count);

--- a/Userland/Libraries/LibGfx/Font/BitmapFont.cpp
+++ b/Userland/Libraries/LibGfx/Font/BitmapFont.cpp
@@ -260,8 +260,9 @@ Glyph BitmapFont::glyph(u32 code_point) const
     // character, fall back to painting '?' if necessary.
     auto index = glyph_index(code_point).value_or('?');
     auto width = m_glyph_widths[index];
+    auto glyph_byte_count = m_glyph_height * GlyphBitmap::bytes_per_row();
     return Glyph(
-        GlyphBitmap(m_rows.data(), index * m_glyph_height, { width, m_glyph_height }),
+        GlyphBitmap(m_rows.slice(index * glyph_byte_count, glyph_byte_count), { width, m_glyph_height }),
         0,
         width,
         m_glyph_height);
@@ -270,8 +271,9 @@ Glyph BitmapFont::glyph(u32 code_point) const
 Glyph BitmapFont::raw_glyph(u32 code_point) const
 {
     auto width = m_glyph_widths[code_point];
+    auto glyph_byte_count = m_glyph_height * GlyphBitmap::bytes_per_row();
     return Glyph(
-        GlyphBitmap(m_rows.data(), code_point * m_glyph_height, { width, m_glyph_height }),
+        GlyphBitmap(m_rows.slice(code_point * glyph_byte_count, glyph_byte_count), { width, m_glyph_height }),
         0,
         width,
         m_glyph_height);

--- a/Userland/Libraries/LibGfx/Font/BitmapFont.h
+++ b/Userland/Libraries/LibGfx/Font/BitmapFont.h
@@ -22,8 +22,7 @@ class BitmapFont final : public Font {
 public:
     virtual NonnullRefPtr<Font> clone() const override;
     ErrorOr<NonnullRefPtr<Font>> try_clone() const override;
-    static NonnullRefPtr<BitmapFont> create(u8 glyph_height, u8 glyph_width, bool fixed, size_t glyph_count);
-    static ErrorOr<NonnullRefPtr<BitmapFont>> try_create(u8 glyph_height, u8 glyph_width, bool fixed, size_t glyph_count);
+    static ErrorOr<NonnullRefPtr<BitmapFont>> create(u8 glyph_height, u8 glyph_width, bool fixed, size_t glyph_count);
 
     virtual FontPixelMetrics pixel_metrics() const override;
 

--- a/Userland/Libraries/LibGfx/Font/BitmapFont.h
+++ b/Userland/Libraries/LibGfx/Font/BitmapFont.h
@@ -38,7 +38,7 @@ public:
 
     ~BitmapFont();
 
-    u8* rows() { return m_rows; }
+    u8* rows() { return m_rows.data(); }
     u8* widths() { return m_glyph_widths; }
 
     virtual float point_size() const override { return m_presentation_size; }
@@ -131,7 +131,7 @@ public:
     virtual RefPtr<Font> with_size(float point_size) const override;
 
 private:
-    BitmapFont(String name, String family, u8* rows, u8* widths, bool is_fixed_width,
+    BitmapFont(String name, String family, Bytes rows, u8* widths, bool is_fixed_width,
         u8 glyph_width, u8 glyph_height, u8 glyph_spacing, Bytes range_mask,
         u8 baseline, u8 mean_line, u8 presentation_size, u16 weight, u8 slope, bool owns_arrays = false);
 
@@ -151,7 +151,7 @@ private:
     Bytes m_range_mask;
     Vector<Optional<size_t>> m_range_indices;
 
-    u8* m_rows { nullptr };
+    Bytes m_rows;
     u8* m_glyph_widths { nullptr };
     OwnPtr<Core::MappedFile> m_mapped_file;
 

--- a/Userland/Libraries/LibGfx/Font/BitmapFont.h
+++ b/Userland/Libraries/LibGfx/Font/BitmapFont.h
@@ -21,7 +21,7 @@ namespace Gfx {
 class BitmapFont final : public Font {
 public:
     virtual NonnullRefPtr<Font> clone() const override;
-    ErrorOr<NonnullRefPtr<Font>> try_clone() const override;
+    virtual ErrorOr<NonnullRefPtr<Font>> try_clone() const override;
     static ErrorOr<NonnullRefPtr<BitmapFont>> create(u8 glyph_height, u8 glyph_width, bool fixed, size_t glyph_count);
 
     virtual FontPixelMetrics pixel_metrics() const override;

--- a/Userland/Libraries/LibGfx/Font/BitmapFont.h
+++ b/Userland/Libraries/LibGfx/Font/BitmapFont.h
@@ -31,7 +31,7 @@ public:
 
     static RefPtr<BitmapFont> load_from_file(DeprecatedString const& path);
     static ErrorOr<NonnullRefPtr<BitmapFont>> try_load_from_file(DeprecatedString const& path);
-    static ErrorOr<NonnullRefPtr<BitmapFont>> try_load_from_mapped_file(OwnPtr<Core::MappedFile>);
+    static ErrorOr<NonnullRefPtr<BitmapFont>> try_load_from_mapped_file(NonnullOwnPtr<Core::MappedFile>);
 
     ErrorOr<void> write_to_file(DeprecatedString const& path);
     ErrorOr<void> write_to_file(NonnullOwnPtr<Core::File> file);
@@ -133,8 +133,6 @@ private:
     BitmapFont(String name, String family, Bytes rows, Span<u8> widths, bool is_fixed_width,
         u8 glyph_width, u8 glyph_height, u8 glyph_spacing, Bytes range_mask,
         u8 baseline, u8 mean_line, u8 presentation_size, u16 weight, u8 slope, bool owns_arrays = false);
-
-    static ErrorOr<NonnullRefPtr<BitmapFont>> load_from_memory(u8 const*);
 
     template<typename T>
     int unicode_view_width(T const& view) const;

--- a/Userland/Libraries/LibGfx/Font/BitmapFont.h
+++ b/Userland/Libraries/LibGfx/Font/BitmapFont.h
@@ -38,8 +38,8 @@ public:
 
     ~BitmapFont();
 
-    u8* rows() { return m_rows.data(); }
-    u8* widths() { return m_glyph_widths.data(); }
+    Bytes rows() { return m_rows; }
+    Span<u8> widths() { return m_glyph_widths; }
 
     virtual float point_size() const override { return m_presentation_size; }
 

--- a/Userland/Libraries/LibGfx/Font/BitmapFont.h
+++ b/Userland/Libraries/LibGfx/Font/BitmapFont.h
@@ -39,7 +39,7 @@ public:
     ~BitmapFont();
 
     u8* rows() { return m_rows.data(); }
-    u8* widths() { return m_glyph_widths; }
+    u8* widths() { return m_glyph_widths.data(); }
 
     virtual float point_size() const override { return m_presentation_size; }
 
@@ -112,7 +112,6 @@ public:
 
     void set_glyph_width(u32 code_point, u8 width)
     {
-        VERIFY(m_glyph_widths);
         m_glyph_widths[code_point] = width;
     }
 
@@ -131,7 +130,7 @@ public:
     virtual RefPtr<Font> with_size(float point_size) const override;
 
 private:
-    BitmapFont(String name, String family, Bytes rows, u8* widths, bool is_fixed_width,
+    BitmapFont(String name, String family, Bytes rows, Span<u8> widths, bool is_fixed_width,
         u8 glyph_width, u8 glyph_height, u8 glyph_spacing, Bytes range_mask,
         u8 baseline, u8 mean_line, u8 presentation_size, u16 weight, u8 slope, bool owns_arrays = false);
 
@@ -152,7 +151,7 @@ private:
     Vector<Optional<size_t>> m_range_indices;
 
     Bytes m_rows;
-    u8* m_glyph_widths { nullptr };
+    Span<u8> m_glyph_widths;
     OwnPtr<Core::MappedFile> m_mapped_file;
 
     u8 m_glyph_width { 0 };

--- a/Userland/Libraries/LibGfx/Font/BitmapFont.h
+++ b/Userland/Libraries/LibGfx/Font/BitmapFont.h
@@ -119,7 +119,6 @@ public:
     size_t glyph_count() const override { return m_glyph_count; }
     Optional<size_t> glyph_index(u32 code_point) const;
 
-    u16 range_size() const { return m_range_mask_size; }
     bool is_range_empty(u32 code_point) const { return !(m_range_mask[code_point / 256 / 8] & 1 << (code_point / 256 % 8)); }
 
     virtual String family() const override { return m_family; }
@@ -133,7 +132,7 @@ public:
 
 private:
     BitmapFont(String name, String family, u8* rows, u8* widths, bool is_fixed_width,
-        u8 glyph_width, u8 glyph_height, u8 glyph_spacing, u16 range_mask_size, u8* range_mask,
+        u8 glyph_width, u8 glyph_height, u8 glyph_spacing, Bytes range_mask,
         u8 baseline, u8 mean_line, u8 presentation_size, u16 weight, u8 slope, bool owns_arrays = false);
 
     static ErrorOr<NonnullRefPtr<BitmapFont>> load_from_memory(u8 const*);
@@ -149,8 +148,7 @@ private:
     String m_family;
     size_t m_glyph_count { 0 };
 
-    u16 m_range_mask_size { 0 };
-    u8* m_range_mask { nullptr };
+    Bytes m_range_mask;
     Vector<Optional<size_t>> m_range_indices;
 
     u8* m_rows { nullptr };

--- a/Userland/Libraries/LibGfx/Font/Font.h
+++ b/Userland/Libraries/LibGfx/Font/Font.h
@@ -23,9 +23,8 @@ namespace Gfx {
 class GlyphBitmap {
 public:
     GlyphBitmap() = default;
-    GlyphBitmap(u8 const* rows, size_t start_index, IntSize size)
+    GlyphBitmap(Bytes rows, IntSize size)
         : m_rows(rows)
-        , m_start_index(start_index)
         , m_size(size)
     {
     }
@@ -46,11 +45,10 @@ public:
 private:
     AK::Bitmap bitmap(size_t y) const
     {
-        return { const_cast<u8*>(m_rows) + bytes_per_row() * (m_start_index + y), bytes_per_row() * 8 };
+        return { const_cast<u8*>(m_rows.offset_pointer(bytes_per_row() * y)), bytes_per_row() * 8 };
     }
 
-    u8 const* m_rows { nullptr };
-    size_t m_start_index { 0 };
+    Bytes m_rows;
     IntSize m_size { 0, 0 };
 };
 


### PR DESCRIPTION
I found it a bit spooky how much manual pointer manipulation was happening in `BitmapFont::load_from_memory(u8*)` (and the fact that it had zero bounds checking) so let's fix that! Its fields are now Span/Bytes, we load using streaming methods so we don't have to keep track of offsets, and besides being safe from buffer overruns, we also make sure there's no data left over.

To help with this, I've added a couple of methods to FixedMemoryStream to read values "in place", meaning we get some kind of pointer into the fixed memory instead of making a copy of it.

There are also a few other small changes to things while I was at it.