### PR TITLE
Maps: Fix occasional gray/missing tiles

### DIFF
--- a/Userland/Applications/Maps/MapWidget.cpp
+++ b/Userland/Applications/Maps/MapWidget.cpp
@@ -490,7 +490,7 @@ void MapWidget::paint_map(GUI::Painter& painter)
                     if ((child_tile_y & 1) > 0)
                         target_rect.translate_by(0, TILE_SIZE / 2);
 
-                    painter.draw_scaled_bitmap(target_rect, *child_tile.release_value(), tile_source, 1.f, Gfx::Painter::ScalingMode::BoxSampling);
+                    painter.draw_scaled_bitmap(target_rect, *child_tile.release_value(), tile_source, 1.f, Gfx::Painter::ScalingMode::BilinearBlend);
                     ++cached_tiles_used;
                 }
             }

--- a/Userland/Applications/Maps/MapWidget.cpp
+++ b/Userland/Applications/Maps/MapWidget.cpp
@@ -438,10 +438,11 @@ void MapWidget::paint_map(GUI::Painter& painter)
     double offset_x = (longitude_to_tile_x(m_center.longitude, m_zoom) - center_tile_x) * TILE_SIZE;
     double offset_y = (latitude_to_tile_y(m_center.latitude, m_zoom) - center_tile_y) * TILE_SIZE;
 
-    // Draw grid around center tile
-    int grid_width = (width() + TILE_SIZE - 1) / TILE_SIZE;
-    int grid_height = (height() + TILE_SIZE - 1) / TILE_SIZE;
-    for (auto const delta : CenterOutwardsIterable { grid_width + 1, grid_height + 1 }) {
+    // Draw grid around center tile; always pad the dimensions with 2 tiles for left/right and top/bottom edges
+    // plus one additional tile to account for the width() / 2 in CenterOutwardsIterable.
+    int grid_width = width() / TILE_SIZE + 3;
+    int grid_height = height() / TILE_SIZE + 3;
+    for (auto const delta : CenterOutwardsIterable { grid_width, grid_height }) {
         int tile_x = center_tile_x + delta.x();
         int tile_y = center_tile_y + delta.y();
 

--- a/Userland/Applications/Maps/MapWidget.cpp
+++ b/Userland/Applications/Maps/MapWidget.cpp
@@ -379,10 +379,8 @@ public:
         T height;
 
         T index { 0 };
-        T current_x { 0 };
-        T current_y { 0 };
 
-        Gfx::Point<T> last_valid_position { current_x, current_y };
+        Gfx::Point<T> position { 0, 0 };
 
         constexpr Iterator(T width, T height)
             : width(move(width))
@@ -401,28 +399,24 @@ public:
         constexpr bool operator==(Iterator const& other) const { return index == other.index; }
         constexpr bool operator!=(Iterator const& other) const { return index != other.index; }
 
-        constexpr Gfx::Point<T> operator*() const { return last_valid_position; }
+        constexpr Gfx::Point<T> operator*() const { return position; }
 
         constexpr Iterator operator++()
         {
-            auto found_valid_position = false;
-
-            while (!found_valid_position && !is_end()) {
-                // Translating the coordinates makes the range check simpler:
-                T xp = current_x + width / 2;
-                T yp = current_y + height / 2;
-                if (xp >= 0 && xp <= width && yp >= 0 && yp <= height) {
-                    last_valid_position = { current_x, current_y };
-                    found_valid_position = true;
-                }
-
+            while (!is_end()) {
                 // Figure out in which of the four squares we are.
-                if (AK::abs(current_x) <= AK::abs(current_y) && (current_x != current_y || current_x >= 0))
-                    current_x += ((current_y >= 0) ? 1 : -1);
+                if (AK::abs(position.x()) <= AK::abs(position.y()) && (position.x() != position.y() || position.x() >= 0))
+                    position.translate_by(position.y() >= 0 ? 1 : -1, 0);
                 else
-                    current_y += ((current_x >= 0) ? -1 : 1);
-
+                    position.translate_by(0, position.x() >= 0 ? -1 : 1);
                 ++index;
+
+                // Translating the coordinates makes the range check simpler:
+                T xp = position.x() + width / 2;
+                T yp = position.y() + height / 2;
+                if (xp >= 0 && xp <= width && yp >= 0 && yp <= height) {
+                    break;
+                }
             }
 
             return *this;


### PR DESCRIPTION
There were two issues with the way we generated MapWidget's tile coordinates.

**Maps before:**
<img src="https://github.com/SerenityOS/serenity/assets/3210731/4e4a83c1-1333-4cb5-bd3b-b07f363e039b" width="320"> <img src="https://github.com/SerenityOS/serenity/assets/3210731/32bbf99d-ea08-43cd-9bd5-844f35193547" width="320">

**Maps after:**
<img src="https://github.com/SerenityOS/serenity/assets/3210731/9e6230cd-14f0-449e-84da-3b30cd45d3c1" width="320"> <img src="https://github.com/SerenityOS/serenity/assets/3210731/c339a065-7323-4747-98e7-8ec7cdb6d53f" width="320">

CC @kleinesfilmroellchen @bplaat 