### PR TITLE
LibWeb: Port Element::local_name / HTML::TagNames & Element::tag_name from DeprecatedString

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -3675,7 +3675,7 @@ JS::ThrowCompletionOr<JS::NonnullGCPtr<JS::Object>> @constructor_class@::constru
         static auto valid_local_names = MUST(DOM::valid_local_names_for_given_html_element_interface("@name@"sv));
 
         // 2. If valid local names does not contain definition's local name, then throw a TypeError.
-        if (!valid_local_names.contains_slow(definition->local_name().to_deprecated_string()))
+        if (!valid_local_names.contains_slow(definition->local_name()))
             return vm.throw_completion<JS::TypeError>(MUST(String::formatted("Local name '{}' of customized built-in element is not a valid local name for @name@"sv, definition->local_name())));
 
         // 3. Set is value to definition's name.

--- a/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
+++ b/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
@@ -548,7 +548,7 @@ static inline bool matches(CSS::Selector::SimpleSelector const& component, Optio
         if (component.type == CSS::Selector::SimpleSelector::Type::TagName) {
             // See https://html.spec.whatwg.org/multipage/semantics-other.html#case-sensitivity-of-selectors
             if (element.document().document_type() == DOM::Document::Type::HTML) {
-                if (qualified_name.name.lowercase_name != element.local_name().view())
+                if (qualified_name.name.lowercase_name != element.local_name())
                     return false;
             } else if (!Infra::is_ascii_case_insensitive_match(qualified_name.name.name, element.local_name())) {
                 return false;

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -314,7 +314,7 @@ Vector<MatchingRule> StyleComputer::collect_matching_rules(DOM::Element const& e
         if (auto it = rule_cache.rules_by_id.find(id.value()); it != rule_cache.rules_by_id.end())
             add_rules_to_run(it->value);
     }
-    if (auto it = rule_cache.rules_by_tag_name.find(FlyString::from_deprecated_fly_string(element.local_name()).release_value_but_fixme_should_propagate_errors()); it != rule_cache.rules_by_tag_name.end())
+    if (auto it = rule_cache.rules_by_tag_name.find(element.local_name()); it != rule_cache.rules_by_tag_name.end())
         add_rules_to_run(it->value);
     add_rules_to_run(rule_cache.other_rules);
 

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -1361,7 +1361,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Element>> Document::create_element(String c
         namespace_ = Namespace::HTML;
 
     // 6. Return the result of creating an element given this, localName, namespace, null, is, and with the synchronous custom elements flag set.
-    return TRY(DOM::create_element(*this, local_name, namespace_, {}, move(is_value), true));
+    return TRY(DOM::create_element(*this, MUST(FlyString::from_deprecated_fly_string(local_name)), namespace_, {}, move(is_value), true));
 }
 
 // https://dom.spec.whatwg.org/#dom-document-createelementns
@@ -1387,7 +1387,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Element>> Document::create_element_ns(Optio
     }
 
     // 4. Return the result of creating an element given document, localName, namespace, prefix, is, and with the synchronous custom elements flag set.
-    return TRY(DOM::create_element(*this, extracted_qualified_name.local_name().to_deprecated_fly_string(), extracted_qualified_name.deprecated_namespace_(), extracted_qualified_name.deprecated_prefix(), move(is_value), true));
+    return TRY(DOM::create_element(*this, extracted_qualified_name.local_name(), extracted_qualified_name.deprecated_namespace_(), extracted_qualified_name.deprecated_prefix(), move(is_value), true));
 }
 
 JS::NonnullGCPtr<DocumentFragment> Document::create_document_fragment()

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -629,7 +629,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<ShadowRoot>> Element::attach_shadow(ShadowR
     // 3. If this’s local name is a valid custom element name, or this’s is value is not null, then:
     if (HTML::is_valid_custom_element_name(local_name()) || m_is_value.has_value()) {
         // 1. Let definition be the result of looking up a custom element definition given this’s node document, its namespace, its local name, and its is value.
-        auto definition = document().lookup_custom_element_definition(namespace_(), local_name(), m_is_value);
+        auto definition = document().lookup_custom_element_definition(namespace_(), local_name().to_deprecated_fly_string(), m_is_value);
 
         // 2. If definition is not null and definition’s disable shadow is true, then throw a "NotSupportedError" DOMException.
         if (definition && definition->disable_shadow())
@@ -1825,7 +1825,7 @@ JS::ThrowCompletionOr<void> Element::upgrade_element(JS::NonnullGCPtr<HTML::Cust
 void Element::try_to_upgrade()
 {
     // 1. Let definition be the result of looking up a custom element definition given element's node document, element's namespace, element's local name, and element's is value.
-    auto definition = document().lookup_custom_element_definition(namespace_(), local_name(), m_is_value);
+    auto definition = document().lookup_custom_element_definition(namespace_(), local_name().to_deprecated_fly_string(), m_is_value);
 
     // 2. If definition is not null, then enqueue a custom element upgrade reaction given element and definition.
     if (definition)

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -82,7 +82,8 @@ public:
     FlyString const& local_name() const { return m_qualified_name.local_name(); }
 
     // NOTE: This is for the JS bindings
-    DeprecatedString const& tag_name() const { return html_uppercased_qualified_name(); }
+    FlyString tag_name() const { return MUST(FlyString::from_deprecated_fly_string(html_uppercased_qualified_name())); }
+    DeprecatedString const& deprecated_tag_name() const { return html_uppercased_qualified_name(); }
 
     Optional<FlyString> const& prefix() const { return m_qualified_name.prefix(); }
     DeprecatedFlyString deprecated_prefix() const { return m_qualified_name.deprecated_prefix(); }

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -78,7 +78,8 @@ public:
     DeprecatedString const& html_uppercased_qualified_name() const { return m_html_uppercased_qualified_name; }
 
     virtual FlyString node_name() const final { return MUST(FlyString::from_deprecated_fly_string(html_uppercased_qualified_name())); }
-    DeprecatedFlyString local_name() const { return m_qualified_name.local_name().to_deprecated_fly_string(); }
+    DeprecatedFlyString deprecated_local_name() const { return m_qualified_name.local_name().to_deprecated_fly_string(); }
+    FlyString const& local_name() const { return m_qualified_name.local_name(); }
 
     // NOTE: This is for the JS bindings
     DeprecatedString const& tag_name() const { return html_uppercased_qualified_name(); }

--- a/Userland/Libraries/LibWeb/DOM/Element.idl
+++ b/Userland/Libraries/LibWeb/DOM/Element.idl
@@ -25,7 +25,7 @@ dictionary ScrollIntoViewOptions : ScrollOptions {
 interface Element : Node {
     readonly attribute DOMString? namespaceURI;
     [ImplementedAs=deprecated_prefix] readonly attribute DOMString? prefix;
-    readonly attribute DOMString localName;
+    [ImplementedAs=deprecated_local_name] readonly attribute DOMString localName;
     readonly attribute DOMString tagName;
 
     [ImplementedAs=deprecated_get_attribute] DOMString? getAttribute(DOMString qualifiedName);

--- a/Userland/Libraries/LibWeb/DOM/Element.idl
+++ b/Userland/Libraries/LibWeb/DOM/Element.idl
@@ -26,7 +26,7 @@ interface Element : Node {
     readonly attribute DOMString? namespaceURI;
     [ImplementedAs=deprecated_prefix] readonly attribute DOMString? prefix;
     [ImplementedAs=deprecated_local_name] readonly attribute DOMString localName;
-    readonly attribute DOMString tagName;
+    [ImplementedAs=deprecated_tag_name] readonly attribute DOMString tagName;
 
     [ImplementedAs=deprecated_get_attribute] DOMString? getAttribute(DOMString qualifiedName);
     [CEReactions] undefined setAttribute(DOMString qualifiedName, DOMString value);

--- a/Userland/Libraries/LibWeb/DOM/ElementFactory.cpp
+++ b/Userland/Libraries/LibWeb/DOM/ElementFactory.cpp
@@ -80,6 +80,7 @@
 #include <LibWeb/HTML/HTMLUnknownElement.h>
 #include <LibWeb/HTML/HTMLVideoElement.h>
 #include <LibWeb/HTML/Scripting/ExceptionReporter.h>
+#include <LibWeb/Infra/Strings.h>
 #include <LibWeb/MathML/MathMLElement.h>
 #include <LibWeb/MathML/TagNames.h>
 #include <LibWeb/Namespace.h>
@@ -111,139 +112,139 @@
 
 namespace Web::DOM {
 
-ErrorOr<FixedArray<DeprecatedFlyString>> valid_local_names_for_given_html_element_interface(StringView html_element_interface_name)
+ErrorOr<FixedArray<FlyString>> valid_local_names_for_given_html_element_interface(StringView html_element_interface_name)
 {
     if (html_element_interface_name == "HTMLAnchorElement"sv)
-        return FixedArray<DeprecatedFlyString>::create({ HTML::TagNames::a });
+        return FixedArray<FlyString>::create({ HTML::TagNames::a });
     if (html_element_interface_name == "HTMLAreaElement"sv)
-        return FixedArray<DeprecatedFlyString>::create({ HTML::TagNames::area });
+        return FixedArray<FlyString>::create({ HTML::TagNames::area });
     if (html_element_interface_name == "HTMLAudioElement"sv)
-        return FixedArray<DeprecatedFlyString>::create({ HTML::TagNames::audio });
+        return FixedArray<FlyString>::create({ HTML::TagNames::audio });
     if (html_element_interface_name == "HTMLBaseElement"sv)
-        return FixedArray<DeprecatedFlyString>::create({ HTML::TagNames::base });
+        return FixedArray<FlyString>::create({ HTML::TagNames::base });
     if (html_element_interface_name == "HTMLBodyElement"sv)
-        return FixedArray<DeprecatedFlyString>::create({ HTML::TagNames::body });
+        return FixedArray<FlyString>::create({ HTML::TagNames::body });
     if (html_element_interface_name == "HTMLBRElement"sv)
-        return FixedArray<DeprecatedFlyString>::create({ HTML::TagNames::br });
+        return FixedArray<FlyString>::create({ HTML::TagNames::br });
     if (html_element_interface_name == "HTMLButtonElement"sv)
-        return FixedArray<DeprecatedFlyString>::create({ HTML::TagNames::button });
+        return FixedArray<FlyString>::create({ HTML::TagNames::button });
     if (html_element_interface_name == "HTMLCanvasElement"sv)
-        return FixedArray<DeprecatedFlyString>::create({ HTML::TagNames::canvas });
+        return FixedArray<FlyString>::create({ HTML::TagNames::canvas });
     if (html_element_interface_name == "HTMLDataElement"sv)
-        return FixedArray<DeprecatedFlyString>::create({ HTML::TagNames::data });
+        return FixedArray<FlyString>::create({ HTML::TagNames::data });
     if (html_element_interface_name == "HTMLDataListElement"sv)
-        return FixedArray<DeprecatedFlyString>::create({ HTML::TagNames::datalist });
+        return FixedArray<FlyString>::create({ HTML::TagNames::datalist });
     if (html_element_interface_name == "HTMLDetailsElement"sv)
-        return FixedArray<DeprecatedFlyString>::create({ HTML::TagNames::details });
+        return FixedArray<FlyString>::create({ HTML::TagNames::details });
     if (html_element_interface_name == "HTMLDialogElement"sv)
-        return FixedArray<DeprecatedFlyString>::create({ HTML::TagNames::dialog });
+        return FixedArray<FlyString>::create({ HTML::TagNames::dialog });
     if (html_element_interface_name == "HTMLDirectoryElement"sv)
-        return FixedArray<DeprecatedFlyString>::create({ HTML::TagNames::dir });
+        return FixedArray<FlyString>::create({ HTML::TagNames::dir });
     if (html_element_interface_name == "HTMLDivElement"sv)
-        return FixedArray<DeprecatedFlyString>::create({ HTML::TagNames::div });
+        return FixedArray<FlyString>::create({ HTML::TagNames::div });
     if (html_element_interface_name == "HTMLDListElement"sv)
-        return FixedArray<DeprecatedFlyString>::create({ HTML::TagNames::dl });
+        return FixedArray<FlyString>::create({ HTML::TagNames::dl });
     if (html_element_interface_name == "HTMLEmbedElement"sv)
-        return FixedArray<DeprecatedFlyString>::create({ HTML::TagNames::embed });
+        return FixedArray<FlyString>::create({ HTML::TagNames::embed });
     if (html_element_interface_name == "HTMLFieldsetElement"sv)
-        return FixedArray<DeprecatedFlyString>::create({ HTML::TagNames::fieldset });
+        return FixedArray<FlyString>::create({ HTML::TagNames::fieldset });
     if (html_element_interface_name == "HTMLFontElement"sv)
-        return FixedArray<DeprecatedFlyString>::create({ HTML::TagNames::font });
+        return FixedArray<FlyString>::create({ HTML::TagNames::font });
     if (html_element_interface_name == "HTMLFormElement"sv)
-        return FixedArray<DeprecatedFlyString>::create({ HTML::TagNames::form });
+        return FixedArray<FlyString>::create({ HTML::TagNames::form });
     if (html_element_interface_name == "HTMLFrameElement"sv)
-        return FixedArray<DeprecatedFlyString>::create({ HTML::TagNames::frame });
+        return FixedArray<FlyString>::create({ HTML::TagNames::frame });
     if (html_element_interface_name == "HTMLFrameSetElement"sv)
-        return FixedArray<DeprecatedFlyString>::create({ HTML::TagNames::frameset });
+        return FixedArray<FlyString>::create({ HTML::TagNames::frameset });
     if (html_element_interface_name == "HTMLHeadElement"sv)
-        return FixedArray<DeprecatedFlyString>::create({ HTML::TagNames::head });
+        return FixedArray<FlyString>::create({ HTML::TagNames::head });
     if (html_element_interface_name == "HTMLHeadingElement"sv)
-        return FixedArray<DeprecatedFlyString>::create({ HTML::TagNames::h1, HTML::TagNames::h2, HTML::TagNames::h3, HTML::TagNames::h4, HTML::TagNames::h5, HTML::TagNames::h6 });
+        return FixedArray<FlyString>::create({ HTML::TagNames::h1, HTML::TagNames::h2, HTML::TagNames::h3, HTML::TagNames::h4, HTML::TagNames::h5, HTML::TagNames::h6 });
     if (html_element_interface_name == "HTMLHRElement"sv)
-        return FixedArray<DeprecatedFlyString>::create({ HTML::TagNames::hr });
+        return FixedArray<FlyString>::create({ HTML::TagNames::hr });
     if (html_element_interface_name == "HTMLHtmlElement"sv)
-        return FixedArray<DeprecatedFlyString>::create({ HTML::TagNames::html });
+        return FixedArray<FlyString>::create({ HTML::TagNames::html });
     if (html_element_interface_name == "HTMLIFrameElement"sv)
-        return FixedArray<DeprecatedFlyString>::create({ HTML::TagNames::iframe });
+        return FixedArray<FlyString>::create({ HTML::TagNames::iframe });
     if (html_element_interface_name == "HTMLImageElement"sv)
-        return FixedArray<DeprecatedFlyString>::create({ HTML::TagNames::img });
+        return FixedArray<FlyString>::create({ HTML::TagNames::img });
     if (html_element_interface_name == "HTMLInputElement"sv)
-        return FixedArray<DeprecatedFlyString>::create({ HTML::TagNames::input });
+        return FixedArray<FlyString>::create({ HTML::TagNames::input });
     if (html_element_interface_name == "HTMLLabelElement"sv)
-        return FixedArray<DeprecatedFlyString>::create({ HTML::TagNames::label });
+        return FixedArray<FlyString>::create({ HTML::TagNames::label });
     if (html_element_interface_name == "HTMLLIElement"sv)
-        return FixedArray<DeprecatedFlyString>::create({ HTML::TagNames::li });
+        return FixedArray<FlyString>::create({ HTML::TagNames::li });
     if (html_element_interface_name == "HTMLLinkElement"sv)
-        return FixedArray<DeprecatedFlyString>::create({ HTML::TagNames::link });
+        return FixedArray<FlyString>::create({ HTML::TagNames::link });
     if (html_element_interface_name == "HTMLMapElement"sv)
-        return FixedArray<DeprecatedFlyString>::create({ HTML::TagNames::map });
+        return FixedArray<FlyString>::create({ HTML::TagNames::map });
     if (html_element_interface_name == "HTMLMarqueeElement"sv)
-        return FixedArray<DeprecatedFlyString>::create({ HTML::TagNames::marquee });
+        return FixedArray<FlyString>::create({ HTML::TagNames::marquee });
     if (html_element_interface_name == "HTMLMenuElement"sv)
-        return FixedArray<DeprecatedFlyString>::create({ HTML::TagNames::menu });
+        return FixedArray<FlyString>::create({ HTML::TagNames::menu });
     if (html_element_interface_name == "HTMLMeterElement"sv)
-        return FixedArray<DeprecatedFlyString>::create({ HTML::TagNames::meter });
+        return FixedArray<FlyString>::create({ HTML::TagNames::meter });
     if (html_element_interface_name == "HTMLModElement"sv)
-        return FixedArray<DeprecatedFlyString>::create({ HTML::TagNames::ins, HTML::TagNames::del });
+        return FixedArray<FlyString>::create({ HTML::TagNames::ins, HTML::TagNames::del });
     if (html_element_interface_name == "HTMLObjectElement"sv)
-        return FixedArray<DeprecatedFlyString>::create({ HTML::TagNames::object });
+        return FixedArray<FlyString>::create({ HTML::TagNames::object });
     if (html_element_interface_name == "HTMLOutputElement"sv)
-        return FixedArray<DeprecatedFlyString>::create({ HTML::TagNames::output });
+        return FixedArray<FlyString>::create({ HTML::TagNames::output });
     if (html_element_interface_name == "HTMLParagraphElement"sv)
-        return FixedArray<DeprecatedFlyString>::create({ HTML::TagNames::p });
+        return FixedArray<FlyString>::create({ HTML::TagNames::p });
     if (html_element_interface_name == "HTMLParamElement"sv)
-        return FixedArray<DeprecatedFlyString>::create({ HTML::TagNames::param });
+        return FixedArray<FlyString>::create({ HTML::TagNames::param });
     if (html_element_interface_name == "HTMLPictureElement"sv)
-        return FixedArray<DeprecatedFlyString>::create({ HTML::TagNames::picture });
+        return FixedArray<FlyString>::create({ HTML::TagNames::picture });
     if (html_element_interface_name == "HTMLPreElement"sv)
-        return FixedArray<DeprecatedFlyString>::create({ HTML::TagNames::pre, HTML::TagNames::listing, HTML::TagNames::xmp });
+        return FixedArray<FlyString>::create({ HTML::TagNames::pre, HTML::TagNames::listing, HTML::TagNames::xmp });
     if (html_element_interface_name == "HTMLProgressElement"sv)
-        return FixedArray<DeprecatedFlyString>::create({ HTML::TagNames::progress });
+        return FixedArray<FlyString>::create({ HTML::TagNames::progress });
     if (html_element_interface_name == "HTMLQuoteElement"sv)
-        return FixedArray<DeprecatedFlyString>::create({ HTML::TagNames::blockquote, HTML::TagNames::q });
+        return FixedArray<FlyString>::create({ HTML::TagNames::blockquote, HTML::TagNames::q });
     if (html_element_interface_name == "HTMLScriptElement"sv)
-        return FixedArray<DeprecatedFlyString>::create({ HTML::TagNames::script });
+        return FixedArray<FlyString>::create({ HTML::TagNames::script });
     if (html_element_interface_name == "HTMLSelectElement"sv)
-        return FixedArray<DeprecatedFlyString>::create({ HTML::TagNames::select });
+        return FixedArray<FlyString>::create({ HTML::TagNames::select });
     if (html_element_interface_name == "HTMLSlotElement"sv)
-        return FixedArray<DeprecatedFlyString>::create({ HTML::TagNames::slot });
+        return FixedArray<FlyString>::create({ HTML::TagNames::slot });
     if (html_element_interface_name == "HTMLSourceElement"sv)
-        return FixedArray<DeprecatedFlyString>::create({ HTML::TagNames::source });
+        return FixedArray<FlyString>::create({ HTML::TagNames::source });
     if (html_element_interface_name == "HTMLSpanElement"sv)
-        return FixedArray<DeprecatedFlyString>::create({ HTML::TagNames::span });
+        return FixedArray<FlyString>::create({ HTML::TagNames::span });
     if (html_element_interface_name == "HTMLStyleElement"sv)
-        return FixedArray<DeprecatedFlyString>::create({ HTML::TagNames::style });
+        return FixedArray<FlyString>::create({ HTML::TagNames::style });
     if (html_element_interface_name == "HTMLTableCaptionElement"sv)
-        return FixedArray<DeprecatedFlyString>::create({ HTML::TagNames::caption });
+        return FixedArray<FlyString>::create({ HTML::TagNames::caption });
     if (html_element_interface_name == "HTMLTableCellElement"sv)
-        return FixedArray<DeprecatedFlyString>::create({ HTML::TagNames::td, HTML::TagNames::th });
+        return FixedArray<FlyString>::create({ HTML::TagNames::td, HTML::TagNames::th });
     if (html_element_interface_name == "HTMLTableColElement"sv)
-        return FixedArray<DeprecatedFlyString>::create({ HTML::TagNames::colgroup, HTML::TagNames::col });
+        return FixedArray<FlyString>::create({ HTML::TagNames::colgroup, HTML::TagNames::col });
     if (html_element_interface_name == "HTMLTableElement"sv)
-        return FixedArray<DeprecatedFlyString>::create({ HTML::TagNames::table });
+        return FixedArray<FlyString>::create({ HTML::TagNames::table });
     if (html_element_interface_name == "HTMLTableSectionElement"sv)
-        return FixedArray<DeprecatedFlyString>::create({ HTML::TagNames::tbody, HTML::TagNames::thead, HTML::TagNames::tfoot });
+        return FixedArray<FlyString>::create({ HTML::TagNames::tbody, HTML::TagNames::thead, HTML::TagNames::tfoot });
     if (html_element_interface_name == "HTMLTemplateElement"sv)
-        return FixedArray<DeprecatedFlyString>::create({ HTML::TagNames::template_ });
+        return FixedArray<FlyString>::create({ HTML::TagNames::template_ });
     if (html_element_interface_name == "HTMLTextAreaElement"sv)
-        return FixedArray<DeprecatedFlyString>::create({ HTML::TagNames::textarea });
+        return FixedArray<FlyString>::create({ HTML::TagNames::textarea });
     if (html_element_interface_name == "HTMLTimeElement"sv)
-        return FixedArray<DeprecatedFlyString>::create({ HTML::TagNames::time });
+        return FixedArray<FlyString>::create({ HTML::TagNames::time });
     if (html_element_interface_name == "HTMLTitleElement"sv)
-        return FixedArray<DeprecatedFlyString>::create({ HTML::TagNames::title });
+        return FixedArray<FlyString>::create({ HTML::TagNames::title });
     if (html_element_interface_name == "HTMLTrackElement"sv)
-        return FixedArray<DeprecatedFlyString>::create({ HTML::TagNames::track });
+        return FixedArray<FlyString>::create({ HTML::TagNames::track });
     if (html_element_interface_name == "HTMLUListElement"sv)
-        return FixedArray<DeprecatedFlyString>::create({ HTML::TagNames::ul });
+        return FixedArray<FlyString>::create({ HTML::TagNames::ul });
     if (html_element_interface_name == "HTMLVideoElement"sv)
-        return FixedArray<DeprecatedFlyString>::create({ HTML::TagNames::video });
+        return FixedArray<FlyString>::create({ HTML::TagNames::video });
     if (html_element_interface_name == "HTMLElement"sv)
-        return FixedArray<DeprecatedFlyString>::create({ HTML::TagNames::article, HTML::TagNames::section, HTML::TagNames::nav, HTML::TagNames::aside, HTML::TagNames::hgroup, HTML::TagNames::header, HTML::TagNames::footer, HTML::TagNames::address, HTML::TagNames::dt, HTML::TagNames::dd, HTML::TagNames::figure, HTML::TagNames::figcaption, HTML::TagNames::main, HTML::TagNames::em, HTML::TagNames::strong, HTML::TagNames::small, HTML::TagNames::s, HTML::TagNames::cite, HTML::TagNames::dfn, HTML::TagNames::abbr, HTML::TagNames::ruby, HTML::TagNames::rt, HTML::TagNames::rp, HTML::TagNames::code, HTML::TagNames::var, HTML::TagNames::samp, HTML::TagNames::kbd, HTML::TagNames::sub, HTML::TagNames::sup, HTML::TagNames::i, HTML::TagNames::b, HTML::TagNames::u, HTML::TagNames::mark, HTML::TagNames::bdi, HTML::TagNames::bdo, HTML::TagNames::wbr, HTML::TagNames::summary, HTML::TagNames::noscript, HTML::TagNames::acronym, HTML::TagNames::basefont, HTML::TagNames::big, HTML::TagNames::center, HTML::TagNames::nobr, HTML::TagNames::noembed, HTML::TagNames::noframes, HTML::TagNames::plaintext, HTML::TagNames::rb, HTML::TagNames::rtc, HTML::TagNames::strike, HTML::TagNames::tt });
-    return FixedArray<DeprecatedFlyString>::create({});
+        return FixedArray<FlyString>::create({ HTML::TagNames::article, HTML::TagNames::section, HTML::TagNames::nav, HTML::TagNames::aside, HTML::TagNames::hgroup, HTML::TagNames::header, HTML::TagNames::footer, HTML::TagNames::address, HTML::TagNames::dt, HTML::TagNames::dd, HTML::TagNames::figure, HTML::TagNames::figcaption, HTML::TagNames::main, HTML::TagNames::em, HTML::TagNames::strong, HTML::TagNames::small, HTML::TagNames::s, HTML::TagNames::cite, HTML::TagNames::dfn, HTML::TagNames::abbr, HTML::TagNames::ruby, HTML::TagNames::rt, HTML::TagNames::rp, HTML::TagNames::code, HTML::TagNames::var, HTML::TagNames::samp, HTML::TagNames::kbd, HTML::TagNames::sub, HTML::TagNames::sup, HTML::TagNames::i, HTML::TagNames::b, HTML::TagNames::u, HTML::TagNames::mark, HTML::TagNames::bdi, HTML::TagNames::bdo, HTML::TagNames::wbr, HTML::TagNames::summary, HTML::TagNames::noscript, HTML::TagNames::acronym, HTML::TagNames::basefont, HTML::TagNames::big, HTML::TagNames::center, HTML::TagNames::nobr, HTML::TagNames::noembed, HTML::TagNames::noframes, HTML::TagNames::plaintext, HTML::TagNames::rb, HTML::TagNames::rtc, HTML::TagNames::strike, HTML::TagNames::tt });
+    return FixedArray<FlyString>::create({});
 }
 
 // https://html.spec.whatwg.org/multipage/dom.html#elements-in-the-dom%3Aelement-interface
-bool is_unknown_html_element(DeprecatedFlyString const& tag_name)
+bool is_unknown_html_element(FlyString const& tag_name)
 {
     // NOTE: This is intentionally case-sensitive.
 
@@ -272,7 +273,7 @@ bool is_unknown_html_element(DeprecatedFlyString const& tag_name)
 // https://html.spec.whatwg.org/#elements-in-the-dom:element-interface
 static JS::NonnullGCPtr<Element> create_html_element(JS::Realm& realm, Document& document, QualifiedName qualified_name)
 {
-    auto lowercase_tag_name = qualified_name.local_name().to_deprecated_fly_string().to_lowercase();
+    FlyString lowercase_tag_name = MUST(Infra::to_ascii_lowercase(qualified_name.local_name()));
 
     if (lowercase_tag_name == HTML::TagNames::a)
         return realm.heap().allocate<HTML::HTMLAnchorElement>(realm, document, move(qualified_name));
@@ -489,7 +490,7 @@ static JS::GCPtr<MathML::MathMLElement> create_mathml_element(JS::Realm& realm, 
     return nullptr;
 }
 // https://dom.spec.whatwg.org/#concept-create-element
-WebIDL::ExceptionOr<JS::NonnullGCPtr<Element>> create_element(Document& document, DeprecatedFlyString local_name, DeprecatedFlyString namespace_, DeprecatedFlyString prefix, Optional<String> is_value, bool synchronous_custom_elements_flag)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<Element>> create_element(Document& document, FlyString local_name, DeprecatedFlyString namespace_, DeprecatedFlyString prefix, Optional<String> is_value, bool synchronous_custom_elements_flag)
 {
     auto& realm = document.realm();
 
@@ -503,7 +504,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Element>> create_element(Document& document
     // NOTE: We collapse this into just returning an element where necessary.
 
     // 4. Let definition be the result of looking up a custom element definition given document, namespace, localName, and is.
-    auto definition = document.lookup_custom_element_definition(namespace_, local_name, is_value);
+    auto definition = document.lookup_custom_element_definition(namespace_, local_name.to_deprecated_fly_string(), is_value);
 
     // 5. If definition is non-null, and definition’s name is not equal to its local name (i.e., definition represents a customized built-in element), then:
     if (definition && definition->name() != definition->local_name()) {
@@ -511,7 +512,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Element>> create_element(Document& document
         // 2. Set result to a new element that implements interface, with no attributes, namespace set to the HTML namespace,
         //    namespace prefix set to prefix, local name set to localName, custom element state set to "undefined", custom element definition set to null,
         //    is value set to is, and node document set to document.
-        auto element = create_html_element(realm, document, QualifiedName { MUST(FlyString::from_deprecated_fly_string(local_name)), prefix, Namespace::HTML });
+        auto element = create_html_element(realm, document, QualifiedName { local_name, prefix, Namespace::HTML });
 
         // 3. If the synchronous custom elements flag is set, then run this step while catching any exceptions:
         if (synchronous_custom_elements_flag) {
@@ -596,7 +597,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Element>> create_element(Document& document
 
                 // 2. Set result to a new element that implements the HTMLUnknownElement interface, with no attributes, namespace set to the HTML namespace, namespace prefix set to prefix,
                 //    local name set to localName, custom element state set to "failed", custom element definition set to null, is value set to null, and node document set to document.
-                JS::NonnullGCPtr<Element> element = realm.heap().allocate<HTML::HTMLUnknownElement>(realm, document, QualifiedName { MUST(FlyString::from_deprecated_fly_string(local_name)), prefix, Namespace::HTML });
+                JS::NonnullGCPtr<Element> element = realm.heap().allocate<HTML::HTMLUnknownElement>(realm, document, QualifiedName { local_name, prefix, Namespace::HTML });
                 element->set_custom_element_state(CustomElementState::Failed);
                 return element;
             }
@@ -607,7 +608,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Element>> create_element(Document& document
         // 2. Otherwise:
         // 1. Set result to a new element that implements the HTMLElement interface, with no attributes, namespace set to the HTML namespace, namespace prefix set to prefix,
         //    local name set to localName, custom element state set to "undefined", custom element definition set to null, is value set to null, and node document set to document.
-        auto element = realm.heap().allocate<HTML::HTMLElement>(realm, document, QualifiedName { MUST(FlyString::from_deprecated_fly_string(local_name)), prefix, Namespace::HTML });
+        auto element = realm.heap().allocate<HTML::HTMLElement>(realm, document, QualifiedName { local_name, prefix, Namespace::HTML });
         element->set_custom_element_state(CustomElementState::Undefined);
 
         // 2. Enqueue a custom element upgrade reaction given result and definition.
@@ -621,7 +622,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Element>> create_element(Document& document
     //       local name set to localName, custom element state set to "uncustomized", custom element definition set to null, is value set to is,
     //       and node document set to document.
 
-    auto qualified_name = QualifiedName { MUST(FlyString::from_deprecated_fly_string(local_name)), prefix, namespace_ };
+    auto qualified_name = QualifiedName { local_name, prefix, namespace_ };
 
     if (namespace_ == Namespace::HTML) {
         auto element = create_html_element(realm, document, move(qualified_name));

--- a/Userland/Libraries/LibWeb/DOM/ElementFactory.h
+++ b/Userland/Libraries/LibWeb/DOM/ElementFactory.h
@@ -11,10 +11,10 @@
 
 namespace Web::DOM {
 
-ErrorOr<FixedArray<DeprecatedFlyString>> valid_local_names_for_given_html_element_interface(StringView html_element_interface_name);
-bool is_unknown_html_element(DeprecatedFlyString const& tag_name);
+ErrorOr<FixedArray<FlyString>> valid_local_names_for_given_html_element_interface(StringView html_element_interface_name);
+bool is_unknown_html_element(FlyString const& tag_name);
 
 // FIXME: The spec doesn't say what the default value of synchronous_custom_elements_flag should be.
-WebIDL::ExceptionOr<JS::NonnullGCPtr<Element>> create_element(Document&, DeprecatedFlyString local_name, DeprecatedFlyString namespace_, DeprecatedFlyString prefix = {}, Optional<String> is = Optional<String> {}, bool synchronous_custom_elements_flag = false);
+WebIDL::ExceptionOr<JS::NonnullGCPtr<Element>> create_element(Document&, FlyString local_name, DeprecatedFlyString namespace_, DeprecatedFlyString prefix = {}, Optional<String> is = Optional<String> {}, bool synchronous_custom_elements_flag = false);
 
 }

--- a/Userland/Libraries/LibWeb/DOM/ParentNode.cpp
+++ b/Userland/Libraries/LibWeb/DOM/ParentNode.cpp
@@ -165,8 +165,10 @@ JS::NonnullGCPtr<HTMLCollection> ParentNode::get_elements_by_tag_name(Deprecated
 
 // https://dom.spec.whatwg.org/#concept-getelementsbytagnamens
 // NOTE: This method is only exposed on Document and Element, but is in ParentNode to prevent code duplication.
-JS::NonnullGCPtr<HTMLCollection> ParentNode::get_elements_by_tag_name_ns(DeprecatedFlyString const& nullable_namespace, DeprecatedFlyString const& local_name)
+JS::NonnullGCPtr<HTMLCollection> ParentNode::get_elements_by_tag_name_ns(DeprecatedFlyString const& nullable_namespace, DeprecatedFlyString const& deprecated_local_name)
 {
+    auto local_name = MUST(FlyString::from_deprecated_fly_string(deprecated_local_name));
+
     // 1. If namespace is the empty string, set it to null.
     DeprecatedString namespace_ = nullable_namespace;
     if (namespace_.is_empty())

--- a/Userland/Libraries/LibWeb/DOM/Range.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Range.cpp
@@ -1181,7 +1181,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<DocumentFragment>> Range::create_contextual
         // - "body" as its local name,
         // - The HTML namespace as its namespace, and
         // - The context object's node document as its node document.
-        element = TRY(DOM::create_element(node->document(), "body"sv, Namespace::HTML));
+        element = TRY(DOM::create_element(node->document(), HTML::TagNames::body, Namespace::HTML));
     }
 
     // 3. Let fragment node be the result of invoking the fragment parsing algorithm with fragment as markup, and element as the context element.

--- a/Userland/Libraries/LibWeb/DOMParsing/XMLSerializer.cpp
+++ b/Userland/Libraries/LibWeb/DOMParsing/XMLSerializer.cpp
@@ -485,7 +485,7 @@ static WebIDL::ExceptionOr<DeprecatedString> serialize_element(DOM::Element cons
     // 1. If the require well-formed flag is set (its value is true), and this node's localName attribute contains the character ":" (U+003A COLON) or does not match the XML Name production,
     //    then throw an exception; the serialization of this node would not be a well-formed element.
     if (require_well_formed == RequireWellFormed::Yes) {
-        if (element.local_name().view().contains(':'))
+        if (element.local_name().bytes_as_string_view().contains(':'))
             return WebIDL::InvalidStateError::create(realm, "Element's local name contains a colon"_fly_string);
 
         // FIXME: Check element's local name against the XML Char production.

--- a/Userland/Libraries/LibWeb/Dump.cpp
+++ b/Userland/Libraries/LibWeb/Dump.cpp
@@ -142,7 +142,7 @@ void dump_tree(StringBuilder& builder, Layout::Node const& layout_node, bool sho
     if (layout_node.is_anonymous())
         tag_name = "(anonymous)";
     else if (is<DOM::Element>(layout_node.dom_node()))
-        tag_name = verify_cast<DOM::Element>(*layout_node.dom_node()).local_name();
+        tag_name = verify_cast<DOM::Element>(*layout_node.dom_node()).local_name().to_deprecated_fly_string();
     else
         tag_name = layout_node.dom_node()->node_name().to_deprecated_fly_string();
 

--- a/Userland/Libraries/LibWeb/HTML/CustomElements/CustomElementRegistry.cpp
+++ b/Userland/Libraries/LibWeb/HTML/CustomElements/CustomElementRegistry.cpp
@@ -143,7 +143,7 @@ JS::ThrowCompletionOr<void> CustomElementRegistry::define(String const& name, We
             return JS::throw_completion(WebIDL::NotSupportedError::create(realm, MUST(String::formatted("'{}' is a custom element name, only non-custom elements can be extended"sv, extends.value()))));
 
         // 2. If the element interface for extends and the HTML namespace is HTMLUnknownElement (e.g., if extends does not indicate an element definition in this specification), then throw a "NotSupportedError" DOMException.
-        if (DOM::is_unknown_html_element(extends.value().to_deprecated_string()))
+        if (DOM::is_unknown_html_element(extends.value()))
             return JS::throw_completion(WebIDL::NotSupportedError::create(realm, MUST(String::formatted("'{}' is an unknown HTML element"sv, extends.value()))));
 
         // 3. Set localName to extends.
@@ -285,7 +285,7 @@ JS::ThrowCompletionOr<void> CustomElementRegistry::define(String const& name, We
 
         auto& inclusive_descendant_element = static_cast<DOM::Element&>(inclusive_descendant);
 
-        if (inclusive_descendant_element.namespace_() == Namespace::HTML && inclusive_descendant_element.local_name() == local_name.to_deprecated_string() && (!extends.has_value() || inclusive_descendant_element.is_value() == name))
+        if (inclusive_descendant_element.namespace_() == Namespace::HTML && inclusive_descendant_element.local_name() == local_name && (!extends.has_value() || inclusive_descendant_element.is_value() == name))
             upgrade_candidates.append(JS::make_handle(inclusive_descendant_element));
 
         return IterationDecision::Continue;

--- a/Userland/Libraries/LibWeb/HTML/DOMParser.cpp
+++ b/Userland/Libraries/LibWeb/HTML/DOMParser.cpp
@@ -70,7 +70,7 @@ JS::NonnullGCPtr<DOM::Document> DOMParser::parse_from_string(StringView string, 
             // 1. Assert: document has no child nodes.
             document->remove_all_children(true);
             // 2. Let root be the result of creating an element given document, "parsererror", and "http://www.mozilla.org/newlayout/xml/parsererror.xml".
-            auto root = DOM::create_element(*document, "parsererror", "http://www.mozilla.org/newlayout/xml/parsererror.xml").release_value_but_fixme_should_propagate_errors();
+            auto root = DOM::create_element(*document, "parsererror"_fly_string, "http://www.mozilla.org/newlayout/xml/parsererror.xml").release_value_but_fixme_should_propagate_errors();
             // FIXME: 3. Optionally, add attributes or children to root to describe the nature of the parsing error.
             // 4. Append root to document.
             MUST(document->append_child(*root));

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -495,7 +495,7 @@ class PlaceholderElement final : public HTMLDivElement {
 
 public:
     PlaceholderElement(DOM::Document& document)
-        : HTMLDivElement(document, DOM::QualifiedName { MUST(FlyString::from_deprecated_fly_string(HTML::TagNames::div)), ""sv, Namespace::HTML })
+        : HTMLDivElement(document, DOM::QualifiedName { HTML::TagNames::div, ""sv, Namespace::HTML })
     {
     }
     virtual Optional<CSS::Selector::PseudoElement> pseudo_element() const override { return CSS::Selector::PseudoElement::Placeholder; }

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
@@ -3531,7 +3531,7 @@ void HTMLParser::process_using_the_rules_for_foreign_content(HTMLToken& token)
     }
 
     // -> An end tag whose tag name is "script", if the current node is an SVG script element
-    if (token.is_end_tag() && current_node().namespace_() == Namespace::SVG && current_node().tag_name() == SVG::TagNames::script) {
+    if (token.is_end_tag() && current_node().namespace_() == Namespace::SVG && current_node().tag_name().to_deprecated_fly_string() == SVG::TagNames::script) {
     ScriptEndTag:
         // Pop the current node off the stack of open elements.
         (void)m_stack_of_open_elements.pop();
@@ -3562,9 +3562,9 @@ void HTMLParser::process_using_the_rules_for_foreign_content(HTMLToken& token)
     if (token.is_end_tag()) {
         // 1. Initialize node to be the current node (the bottommost node of the stack).
         JS::GCPtr<DOM::Element> node = current_node();
-        // FIXME: Not sure if this is the correct to_lowercase, as the specification says "to ASCII lowercase"
+
         // 2. If node's tag name, converted to ASCII lowercase, is not the same as the tag name of the token, then this is a parse error.
-        if (node->tag_name().to_lowercase() != token.tag_name().to_deprecated_fly_string())
+        if (node->tag_name().equals_ignoring_ascii_case(token.tag_name()))
             log_parse_error();
 
         // 3. Loop: If node is the topmost element in the stack of open elements, then return. (fragment case)
@@ -3573,10 +3573,10 @@ void HTMLParser::process_using_the_rules_for_foreign_content(HTMLToken& token)
                 VERIFY(m_parsing_fragment);
                 return;
             }
-            // FIXME: See the above FIXME
+
             // 4. If node's tag name, converted to ASCII lowercase, is the same as the tag name of the token, pop elements from the stack
             // of open elements until node has been popped from the stack, and then return.
-            if (node->tag_name().to_lowercase() == token.tag_name().to_deprecated_fly_string()) {
+            if (node->tag_name().equals_ignoring_ascii_case(token.tag_name())) {
                 while (&current_node() != node.ptr())
                     (void)m_stack_of_open_elements.pop();
                 (void)m_stack_of_open_elements.pop();

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.h
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.h
@@ -68,7 +68,7 @@ public:
 
     InsertionMode insertion_mode() const { return m_insertion_mode; }
 
-    static bool is_special_tag(DeprecatedFlyString const& tag_name, DeprecatedFlyString const& namespace_);
+    static bool is_special_tag(FlyString const& tag_name, DeprecatedFlyString const& namespace_);
 
     HTMLTokenizer& tokenizer() { return m_tokenizer; }
 
@@ -118,7 +118,7 @@ private:
 
     void stop_parsing() { m_stop_parsing = true; }
 
-    void generate_implied_end_tags(DeprecatedFlyString const& exception = {});
+    void generate_implied_end_tags(FlyString const& exception = {});
     void generate_all_implied_end_tags_thoroughly();
     JS::NonnullGCPtr<DOM::Element> create_element_for(HTMLToken const&, DeprecatedFlyString const& namespace_, DOM::Node& intended_parent);
 

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.h
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.h
@@ -9,6 +9,7 @@
 
 #include <AK/DeprecatedFlyString.h>
 #include <AK/DeprecatedString.h>
+#include <AK/FlyString.h>
 #include <AK/Function.h>
 #include <AK/OwnPtr.h>
 #include <AK/Types.h>
@@ -145,10 +146,10 @@ public:
         m_string_data = move(comment);
     }
 
-    DeprecatedFlyString const& tag_name() const
+    FlyString tag_name() const
     {
         VERIFY(is_start_tag() || is_end_tag());
-        return m_string_data;
+        return MUST(FlyString::from_deprecated_fly_string(m_string_data));
     }
 
     void set_tag_name(DeprecatedString name)
@@ -275,7 +276,7 @@ public:
     void adjust_tag_name(DeprecatedFlyString const& old_name, DeprecatedFlyString const& new_name)
     {
         VERIFY(is_start_tag() || is_end_tag());
-        if (old_name == tag_name())
+        if (old_name == tag_name().to_deprecated_fly_string())
             set_tag_name(new_name);
     }
 

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
@@ -2845,7 +2845,7 @@ void HTMLTokenizer::switch_to(Badge<HTMLParser>, State new_state)
 void HTMLTokenizer::will_emit(HTMLToken& token)
 {
     if (token.is_start_tag())
-        m_last_emitted_start_tag_name = token.tag_name();
+        m_last_emitted_start_tag_name = token.tag_name().to_deprecated_fly_string();
 
     auto is_start_or_end_tag = token.type() == HTMLToken::Type::StartTag || token.type() == HTMLToken::Type::EndTag;
     token.set_end_position({}, nth_last_position(is_start_or_end_tag ? 1 : 0));
@@ -2856,7 +2856,7 @@ bool HTMLTokenizer::current_end_tag_token_is_appropriate() const
     VERIFY(m_current_token.is_end_tag());
     if (!m_last_emitted_start_tag_name.has_value())
         return false;
-    return m_current_token.tag_name() == m_last_emitted_start_tag_name.value();
+    return m_current_token.tag_name().to_deprecated_fly_string() == m_last_emitted_start_tag_name.value();
 }
 
 bool HTMLTokenizer::consumed_as_part_of_an_attribute() const

--- a/Userland/Libraries/LibWeb/HTML/Parser/ListOfActiveFormattingElements.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/ListOfActiveFormattingElements.cpp
@@ -37,7 +37,7 @@ bool ListOfActiveFormattingElements::contains(const DOM::Element& element) const
     return false;
 }
 
-DOM::Element* ListOfActiveFormattingElements::last_element_with_tag_name_before_marker(DeprecatedFlyString const& tag_name)
+DOM::Element* ListOfActiveFormattingElements::last_element_with_tag_name_before_marker(FlyString const& tag_name)
 {
     for (ssize_t i = m_entries.size() - 1; i >= 0; --i) {
         auto& entry = m_entries[i];

--- a/Userland/Libraries/LibWeb/HTML/Parser/ListOfActiveFormattingElements.h
+++ b/Userland/Libraries/LibWeb/HTML/Parser/ListOfActiveFormattingElements.h
@@ -36,7 +36,7 @@ public:
     Vector<Entry> const& entries() const { return m_entries; }
     Vector<Entry>& entries() { return m_entries; }
 
-    DOM::Element* last_element_with_tag_name_before_marker(DeprecatedFlyString const& tag_name);
+    DOM::Element* last_element_with_tag_name_before_marker(FlyString const& tag_name);
 
     void clear_up_to_the_last_marker();
 

--- a/Userland/Libraries/LibWeb/HTML/Parser/StackOfOpenElements.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/StackOfOpenElements.cpp
@@ -10,7 +10,7 @@
 
 namespace Web::HTML {
 
-static Vector<DeprecatedFlyString> s_base_list { "applet", "caption", "html", "table", "td", "th", "marquee", "object", "template" };
+static Vector<FlyString> s_base_list { "applet"_fly_string, "caption"_fly_string, "html"_fly_string, "table"_fly_string, "td"_fly_string, "th"_fly_string, "marquee"_fly_string, "object"_fly_string, "template"_fly_string };
 
 StackOfOpenElements::~StackOfOpenElements() = default;
 
@@ -20,7 +20,7 @@ void StackOfOpenElements::visit_edges(JS::Cell::Visitor& visitor)
         visitor.visit(element);
 }
 
-bool StackOfOpenElements::has_in_scope_impl(DeprecatedFlyString const& tag_name, Vector<DeprecatedFlyString> const& list) const
+bool StackOfOpenElements::has_in_scope_impl(FlyString const& tag_name, Vector<FlyString> const& list) const
 {
     for (auto const& element : m_elements.in_reverse()) {
         if (element->local_name() == tag_name)
@@ -31,12 +31,12 @@ bool StackOfOpenElements::has_in_scope_impl(DeprecatedFlyString const& tag_name,
     VERIFY_NOT_REACHED();
 }
 
-bool StackOfOpenElements::has_in_scope(DeprecatedFlyString const& tag_name) const
+bool StackOfOpenElements::has_in_scope(FlyString const& tag_name) const
 {
     return has_in_scope_impl(tag_name, s_base_list);
 }
 
-bool StackOfOpenElements::has_in_scope_impl(const DOM::Element& target_node, Vector<DeprecatedFlyString> const& list) const
+bool StackOfOpenElements::has_in_scope_impl(const DOM::Element& target_node, Vector<FlyString> const& list) const
 {
     for (auto& element : m_elements.in_reverse()) {
         if (element.ptr() == &target_node)
@@ -52,23 +52,23 @@ bool StackOfOpenElements::has_in_scope(const DOM::Element& target_node) const
     return has_in_scope_impl(target_node, s_base_list);
 }
 
-bool StackOfOpenElements::has_in_button_scope(DeprecatedFlyString const& tag_name) const
+bool StackOfOpenElements::has_in_button_scope(FlyString const& tag_name) const
 {
     auto list = s_base_list;
-    list.append("button");
+    list.append("button"_fly_string);
     return has_in_scope_impl(tag_name, list);
 }
 
-bool StackOfOpenElements::has_in_table_scope(DeprecatedFlyString const& tag_name) const
+bool StackOfOpenElements::has_in_table_scope(FlyString const& tag_name) const
 {
-    return has_in_scope_impl(tag_name, { "html", "table", "template" });
+    return has_in_scope_impl(tag_name, { "html"_fly_string, "table"_fly_string, "template"_fly_string });
 }
 
-bool StackOfOpenElements::has_in_list_item_scope(DeprecatedFlyString const& tag_name) const
+bool StackOfOpenElements::has_in_list_item_scope(FlyString const& tag_name) const
 {
     auto list = s_base_list;
-    list.append("ol");
-    list.append("ul");
+    list.append("ol"_fly_string);
+    list.append("ul"_fly_string);
     return has_in_scope_impl(tag_name, list);
 }
 
@@ -78,7 +78,7 @@ bool StackOfOpenElements::has_in_list_item_scope(DeprecatedFlyString const& tag_
 // - optgroup in the HTML namespace
 // - option in the HTML namespace
 // NOTE: In this case it's "all element types _except_"
-bool StackOfOpenElements::has_in_select_scope(DeprecatedFlyString const& tag_name) const
+bool StackOfOpenElements::has_in_select_scope(FlyString const& tag_name) const
 {
     // https://html.spec.whatwg.org/multipage/parsing.html#has-an-element-in-the-specific-scope
     // 1. Initialize node to be the current node (the bottommost node of the stack).
@@ -106,7 +106,7 @@ bool StackOfOpenElements::contains(const DOM::Element& element) const
     return false;
 }
 
-bool StackOfOpenElements::contains(DeprecatedFlyString const& tag_name) const
+bool StackOfOpenElements::contains(FlyString const& tag_name) const
 {
     for (auto& element_on_stack : m_elements) {
         if (element_on_stack->local_name() == tag_name)
@@ -115,7 +115,7 @@ bool StackOfOpenElements::contains(DeprecatedFlyString const& tag_name) const
     return false;
 }
 
-void StackOfOpenElements::pop_until_an_element_with_tag_name_has_been_popped(DeprecatedFlyString const& tag_name)
+void StackOfOpenElements::pop_until_an_element_with_tag_name_has_been_popped(FlyString const& tag_name)
 {
     while (m_elements.last()->local_name() != tag_name)
         (void)pop();
@@ -134,7 +134,7 @@ JS::GCPtr<DOM::Element> StackOfOpenElements::topmost_special_node_below(DOM::Ele
     return found_element.ptr();
 }
 
-StackOfOpenElements::LastElementResult StackOfOpenElements::last_element_with_tag_name(DeprecatedFlyString const& tag_name)
+StackOfOpenElements::LastElementResult StackOfOpenElements::last_element_with_tag_name(FlyString const& tag_name)
 {
     for (ssize_t i = m_elements.size() - 1; i >= 0; --i) {
         auto& element = m_elements[i];

--- a/Userland/Libraries/LibWeb/HTML/Parser/StackOfOpenElements.h
+++ b/Userland/Libraries/LibWeb/HTML/Parser/StackOfOpenElements.h
@@ -35,21 +35,21 @@ public:
     const DOM::Element& current_node() const { return *m_elements.last(); }
     DOM::Element& current_node() { return *m_elements.last(); }
 
-    bool has_in_scope(DeprecatedFlyString const& tag_name) const;
-    bool has_in_button_scope(DeprecatedFlyString const& tag_name) const;
-    bool has_in_table_scope(DeprecatedFlyString const& tag_name) const;
-    bool has_in_list_item_scope(DeprecatedFlyString const& tag_name) const;
-    bool has_in_select_scope(DeprecatedFlyString const& tag_name) const;
+    bool has_in_scope(FlyString const& tag_name) const;
+    bool has_in_button_scope(FlyString const& tag_name) const;
+    bool has_in_table_scope(FlyString const& tag_name) const;
+    bool has_in_list_item_scope(FlyString const& tag_name) const;
+    bool has_in_select_scope(FlyString const& tag_name) const;
 
     bool has_in_scope(const DOM::Element&) const;
 
     bool contains(const DOM::Element&) const;
-    bool contains(DeprecatedFlyString const& tag_name) const;
+    bool contains(FlyString const& tag_name) const;
 
     auto const& elements() const { return m_elements; }
     auto& elements() { return m_elements; }
 
-    void pop_until_an_element_with_tag_name_has_been_popped(DeprecatedFlyString const&);
+    void pop_until_an_element_with_tag_name_has_been_popped(FlyString const&);
 
     JS::GCPtr<DOM::Element> topmost_special_node_below(DOM::Element const&);
 
@@ -57,14 +57,14 @@ public:
         JS::GCPtr<DOM::Element> element;
         ssize_t index;
     };
-    LastElementResult last_element_with_tag_name(DeprecatedFlyString const&);
+    LastElementResult last_element_with_tag_name(FlyString const&);
     JS::GCPtr<DOM::Element> element_immediately_above(DOM::Element const&);
 
     void visit_edges(JS::Cell::Visitor&);
 
 private:
-    bool has_in_scope_impl(DeprecatedFlyString const& tag_name, Vector<DeprecatedFlyString> const&) const;
-    bool has_in_scope_impl(const DOM::Element& target_node, Vector<DeprecatedFlyString> const&) const;
+    bool has_in_scope_impl(FlyString const& tag_name, Vector<FlyString> const&) const;
+    bool has_in_scope_impl(const DOM::Element& target_node, Vector<FlyString> const&) const;
 
     Vector<JS::NonnullGCPtr<DOM::Element>> m_elements;
 };

--- a/Userland/Libraries/LibWeb/HTML/SyntaxHighlighter/SyntaxHighlighter.cpp
+++ b/Userland/Libraries/LibWeb/HTML/SyntaxHighlighter/SyntaxHighlighter.cpp
@@ -150,7 +150,7 @@ void SyntaxHighlighter::rehighlight(Palette const& palette)
                 token->start_position().line,
                 token->start_position().column,
                 token->start_position().line,
-                token->start_position().column + token->tag_name().length(),
+                token->start_position().column + token->tag_name().bytes().size(),
                 { palette.syntax_keyword(), {}, true },
                 token->is_start_tag() ? AugmentedTokenKind::OpenTag : AugmentedTokenKind::CloseTag);
 

--- a/Userland/Libraries/LibWeb/HTML/TagNames.cpp
+++ b/Userland/Libraries/LibWeb/HTML/TagNames.cpp
@@ -8,7 +8,7 @@
 
 namespace Web::HTML::TagNames {
 
-#define __ENUMERATE_HTML_TAG(name) DeprecatedFlyString name;
+#define __ENUMERATE_HTML_TAG(name) FlyString name;
 ENUMERATE_HTML_TAGS
 #undef __ENUMERATE_HTML_TAG
 
@@ -18,11 +18,11 @@ void initialize_strings()
     VERIFY(!s_initialized);
 
 #define __ENUMERATE_HTML_TAG(name) \
-    name = #name;
+    name = #name##_fly_string;
     ENUMERATE_HTML_TAGS
 #undef __ENUMERATE_HTML_TAG
 
-    template_ = "template";
+    template_ = "template"_fly_string;
 
     s_initialized = true;
 }

--- a/Userland/Libraries/LibWeb/HTML/TagNames.h
+++ b/Userland/Libraries/LibWeb/HTML/TagNames.h
@@ -6,8 +6,8 @@
 
 #pragma once
 
-#include <AK/DeprecatedFlyString.h>
 #include <AK/Error.h>
+#include <AK/FlyString.h>
 
 namespace Web::HTML::TagNames {
 
@@ -157,7 +157,7 @@ namespace Web::HTML::TagNames {
     __ENUMERATE_HTML_TAG(wbr)        \
     __ENUMERATE_HTML_TAG(xmp)
 
-#define __ENUMERATE_HTML_TAG(name) extern DeprecatedFlyString name;
+#define __ENUMERATE_HTML_TAG(name) extern FlyString name;
 ENUMERATE_HTML_TAGS
 #undef __ENUMERATE_HTML_TAG
 

--- a/Userland/Libraries/LibWeb/MathML/MathMLElement.cpp
+++ b/Userland/Libraries/LibWeb/MathML/MathMLElement.cpp
@@ -28,7 +28,7 @@ void MathMLElement::initialize(JS::Realm& realm)
 Optional<ARIA::Role> MathMLElement::default_role() const
 {
     // https://www.w3.org/TR/html-aria/#el-math
-    if (local_name() == TagNames::math.to_deprecated_fly_string())
+    if (local_name() == TagNames::math)
         return ARIA::Role::math;
     return {};
 }

--- a/Userland/Libraries/LibWeb/XML/XMLDocumentBuilder.cpp
+++ b/Userland/Libraries/LibWeb/XML/XMLDocumentBuilder.cpp
@@ -56,12 +56,12 @@ void XMLDocumentBuilder::element_start(const XML::Name& name, HashMap<XML::Name,
 
     // FIXME: This should not live here at all.
     if (auto it = attributes.find("xmlns"); it != attributes.end()) {
-        if (name == HTML::TagNames::html && it->value != Namespace::HTML) {
+        if (name == HTML::TagNames::html.to_deprecated_fly_string() && it->value != Namespace::HTML) {
             m_has_error = true;
             return;
         }
 
-        if (name == HTML::TagNames::svg) {
+        if (name == HTML::TagNames::svg.to_deprecated_fly_string()) {
             if (it->value != Namespace::SVG) {
                 m_has_error = true;
                 return;
@@ -71,17 +71,17 @@ void XMLDocumentBuilder::element_start(const XML::Name& name, HashMap<XML::Name,
         }
     }
 
-    auto node = DOM::create_element(m_document, name, m_namespace).release_value_but_fixme_should_propagate_errors();
+    auto node = DOM::create_element(m_document, MUST(FlyString::from_deprecated_fly_string(name)), m_namespace).release_value_but_fixme_should_propagate_errors();
 
     // When an XML parser with XML scripting support enabled creates a script element,
     // it must have its parser document set and its "force async" flag must be unset.
     // FIXME: If the parser was created as part of the XML fragment parsing algorithm, then the element must be marked as "already started" also.
-    if (m_scripting_support == XMLScriptingSupport::Enabled && HTML::TagNames::script == name) {
+    if (m_scripting_support == XMLScriptingSupport::Enabled && HTML::TagNames::script.to_deprecated_fly_string() == name) {
         auto& script_element = static_cast<HTML::HTMLScriptElement&>(*node);
         script_element.set_parser_document(Badge<XMLDocumentBuilder> {}, m_document);
         script_element.set_force_async(Badge<XMLDocumentBuilder> {}, false);
     }
-    if (HTML::TagNames::template_ == m_current_node->node_name().to_deprecated_fly_string()) {
+    if (HTML::TagNames::template_.to_deprecated_fly_string() == m_current_node->node_name().to_deprecated_fly_string()) {
         // When an XML parser would append a node to a template element, it must instead append it to the template element's template contents (a DocumentFragment node).
         MUST(static_cast<HTML::HTMLTemplateElement&>(*m_current_node).content()->append_child(node));
     } else {
@@ -101,7 +101,7 @@ void XMLDocumentBuilder::element_end(const XML::Name& name)
     VERIFY(m_current_node->node_name().equals_ignoring_ascii_case(name));
     // When an XML parser with XML scripting support enabled creates a script element, [...]
     // When the element's end tag is subsequently parsed,
-    if (m_scripting_support == XMLScriptingSupport::Enabled && HTML::TagNames::script == name) {
+    if (m_scripting_support == XMLScriptingSupport::Enabled && HTML::TagNames::script.to_deprecated_fly_string() == name) {
         // the user agent must perform a microtask checkpoint,
         HTML::perform_a_microtask_checkpoint();
         // and then prepare the script element.

--- a/Userland/Libraries/LibWebView/SourceHighlighter.cpp
+++ b/Userland/Libraries/LibWebView/SourceHighlighter.cpp
@@ -108,7 +108,7 @@ String highlight_source(URL const& url, StringView source)
             auto tag_name_start = token->start_position().byte_offset;
 
             append_source(tag_name_start);
-            append_source(tag_name_start + token->tag_name().length(), "tag"sv);
+            append_source(tag_name_start + token->tag_name().bytes().size(), "tag"sv);
 
             token->for_each_attribute([&](auto const& attribute) {
                 append_source(attribute.name_start_position.byte_offset);

--- a/Userland/Services/WebContent/WebDriverConnection.cpp
+++ b/Userland/Services/WebContent/WebDriverConnection.cpp
@@ -1183,7 +1183,7 @@ Messages::WebDriverClient::GetElementTagNameResponse WebDriverConnection::get_el
     auto qualified_name = element->tag_name();
 
     // 5. Return success with data qualified name.
-    return qualified_name;
+    return MUST(JsonValue::from_string(qualified_name));
 }
 
 // 12.4.7 Get Element Rect, https://w3c.github.io/webdriver/#dfn-get-element-rect


### PR DESCRIPTION
This should be the second to last merge request before yeeting DeprecatedString support from the IDL generator, and some supporting code