### PR TITLE
LibGUI: Improve responseiveness when generating lots of thumbnails

### DIFF
--- a/Userland/Libraries/LibGUI/FileSystemModel.h
+++ b/Userland/Libraries/LibGUI/FileSystemModel.h
@@ -9,6 +9,7 @@
 
 #include <AK/HashMap.h>
 #include <LibCore/DateTime.h>
+#include <LibCore/ElapsedTimer.h>
 #include <LibCore/FileWatcher.h>
 #include <LibGUI/Model.h>
 #include <string.h>
@@ -173,6 +174,8 @@ private:
 
     unsigned m_thumbnail_progress { 0 };
     unsigned m_thumbnail_progress_total { 0 };
+
+    Core::ElapsedTimer m_ui_update_timer;
 
     Optional<Vector<DeprecatedString>> m_allowed_file_extensions;
 


### PR DESCRIPTION
Instead of updating the UI after each thumbnail is generated, we now only update the UI every 100ms. This improves the responsiveness of FileManager when navigating directories with lots of small thumbnails.

There are still opportunities to improve performance further here, but this change at least makes `/res/emoji` navigable, whereas previously it would lock up the system for a significant amount of time.

Demo (from a cold reboot):

https://github.com/SerenityOS/serenity/assets/2817754/75d449b8-5e69-413c-933b-2cff403834e3

Fixes #20906