### PR TITLE
Ports: Add riscv64 target to QEMU

### DIFF
--- a/Ports/qemu/package.sh
+++ b/Ports/qemu/package.sh
@@ -6,7 +6,7 @@ port='qemu'
 version="${QEMU_VERSION}"
 useconfigure='true'
 configopts=(
-    '--target-list=aarch64-softmmu,i386-softmmu,x86_64-softmmu'
+    '--target-list=aarch64-softmmu,i386-softmmu,riscv64-softmmu,x86_64-softmmu'
     "--cross-prefix=${SERENITY_ARCH}-pc-serenity-"
     '--extra-ldflags=-lm'
     '--without-default-features'
@@ -36,7 +36,7 @@ post_install() {
     # Add a drop-in fstab entry to make sure that we can use anonymous executable memory and bypass W^X
     mkdir -p "${SERENITY_INSTALL_ROOT}/etc/fstab.d"
     rm -rf "${SERENITY_INSTALL_ROOT}/etc/fstab.d/qemu"
-    for i in /usr/local/bin/qemu-system-{aarch64,i386,x86_64}; do
+    for i in /usr/local/bin/qemu-system-{aarch64,i386,riscv64,x86_64}; do
         echo "${i}	${i}	bind	bind,wxallowed,axallowed" >> "${SERENITY_INSTALL_ROOT}/etc/fstab.d/qemu"
     done
 }


### PR DESCRIPTION
So we can run Serenity for RISC-V in Serenity in the future :^) 