### PR TITLE
AK/URLParser: Complete implementation of `is_url_code_point()`

### DIFF
--- a/AK/URLParser.cpp
+++ b/AK/URLParser.cpp
@@ -39,8 +39,10 @@ static void report_validation_error(SourceLocation const& location = SourceLocat
     dbgln_if(URL_PARSER_DEBUG, "URLParser::basic_parse: Validation error! {}", location);
 }
 
+// https://url.spec.whatwg.org/#concept-opaque-host-parser
 static Optional<URL::Host> parse_opaque_host(StringView input)
 {
+    // 1. If input contains a forbidden host code point, host-invalid-code-point validation error, return failure.
     auto forbidden_host_characters_excluding_percent = "\0\t\n\r #/:<>?@[\\]^|"sv;
     for (auto character : forbidden_host_characters_excluding_percent) {
         if (input.contains(character)) {
@@ -48,8 +50,13 @@ static Optional<URL::Host> parse_opaque_host(StringView input)
             return {};
         }
     }
-    // FIXME: If input contains a code point that is not a URL code point and not U+0025 (%), validation error.
-    // FIXME: If input contains a U+0025 (%) and the two code points following it are not ASCII hex digits, validation error.
+
+    // 2. If input contains a code point that is not a URL code point and not U+0025 (%), invalid-URL-unit validation error.
+    // 3. If input contains a U+0025 (%) and the two code points following it are not ASCII hex digits, invalid-URL-unit validation error.
+    // NOTE: These steps are not implemented because they are not cheap checks and exist just to report validation errors. With how we
+    //       currently report validation errors, they are only useful for debugging efforts in the URL parsing code.
+
+    // 4. Return the result of running UTF-8 percent-encode on input using the C0 control percent-encode set.
     return String::from_deprecated_string(URL::percent_encode(input, URL::PercentEncodeSet::C0Control)).release_value_but_fixme_should_propagate_errors();
 }
 

--- a/AK/URLParser.cpp
+++ b/AK/URLParser.cpp
@@ -21,10 +21,17 @@ namespace AK {
 // NOTE: This is similar to the LibC macro EOF = -1.
 constexpr u32 end_of_file = 0xFFFFFFFF;
 
+// https://url.spec.whatwg.org/#url-code-points
 static bool is_url_code_point(u32 code_point)
 {
-    // FIXME: [...] and code points in the range U+00A0 to U+10FFFD, inclusive, excluding surrogates and noncharacters.
-    return is_ascii_alphanumeric(code_point) || code_point >= 0xA0 || "!$&'()*+,-./:;=?@_~"sv.contains(code_point);
+    // The URL code points are ASCII alphanumeric, U+0021 (!), U+0024 ($), U+0026 (&),
+    // U+0027 ('), U+0028 LEFT PARENTHESIS, U+0029 RIGHT PARENTHESIS, U+002A (*),
+    // U+002B (+), U+002C (,), U+002D (-), U+002E (.), U+002F (/), U+003A (:),
+    // U+003B (;), U+003D (=), U+003F (?), U+0040 (@), U+005F (_), U+007E (~), and code
+    // points in the range U+00A0 to U+10FFFD, inclusive, excluding surrogates and
+    // noncharacters.
+    return is_ascii_alphanumeric(code_point) || "!$&'()*+,-./:;=?@_~"sv.contains(code_point)
+        || (code_point >= 0x00A0 && code_point <= 0x10FFFD && !is_unicode_surrogate(code_point) && !is_unicode_noncharacter(code_point));
 }
 
 static void report_validation_error(SourceLocation const& location = SourceLocation::current())


### PR DESCRIPTION
~~Might as well complete `is_url_code_point()` while we're at it since it is used in one spec step.~~

~~Manually tested the code paths by manipulating this URL that contains an opaque host (thanks to the URL spec for the example):~~

~~`git://github.com/whatwg/url.git`~~

Edit: Given feedback, this PR only adds spec comments to `parse_opaque_host()` instead of implementing the two missing spec steps and implements `is_url_code_point()` to meet the spec.