### PR TITLE
pkg: Fix reading the installed package database and improve dependency parsing

### DIFF
--- a/Base/usr/share/man/man1/pkg.md
+++ b/Base/usr/share/man/man1/pkg.md
@@ -5,7 +5,7 @@ pkg - Package Manager
 ## Synopsis
 
 ```**sh
-$ pkg [-l] [-d] [-u] [-v] [-q package]
+$ pkg [-l] [-u] [-v] [-q package]
 ```
 
 ## Description
@@ -17,7 +17,6 @@ It does not currently support installing and uninstalling packages. To install t
 ## Options
 
 * `-l`, `--list-manual-ports`: Show all manually-installed ports
-* `-d`, `--list-dependency-ports`: Show all dependencies' ports
 * `-u`, `--update-ports-database`: Sync/Update ports database
 * `-v`, `--verbose`: Verbose output
 * `-q`, `--query-package`: Query the ports database for package name

--- a/Base/usr/share/man/man5/installed.md
+++ b/Base/usr/share/man/man5/installed.md
@@ -1,0 +1,41 @@
+## Name
+
+installed.db - Package database format
+
+## Description
+
+`/usr/Ports/installed.db` is a file keeping track of installed packages (or ports, respectively). It is a simple text-based format suitable for editing by the port system shell scripts. 
+
+Each line of installed.db consists of several space-separated fields. A line may also be empty and therefore ignored.
+
+The first field specifies what kind of entry the line contains:
+- `auto` specifies a port that is installed automatically, i.e. as a dependency of another port.
+- `manual` specifies a port that was installed manually.
+- `dependency` does not specify a new port, but the dependencies of a port. The port also has a `manual` or `auto` line somewhere else in the file.
+
+The second field always specifies the port's name.
+
+Lines that specify an installed port (`manual`/`auto`) have a third field specifying the version. Both name and version may be found exactly like this in the package.sh script of the port, and in the list of available ports.
+
+Lines that specify a port's dependencies (`dependency`) have any number of additional fields. Each field contains the name of another port that this port depends on. Note that while the port scripts never create an empty dependency list, this is still valid and simply means that the port depends on nothing else.
+
+## Examples
+
+```
+manual libfftw3 3.3.10
+auto libopus 1.3.1
+auto libsamplerate 0.2.2
+auto libogg 1.3.5
+auto flac 1.4.2
+dependency flac libogg
+auto lame 3.100
+auto libmpg123 1.29.3
+auto libvorbis 1.3.7
+dependency libvorbis libogg
+auto sqlite 3410200
+auto libsndfile 1.2.2
+dependency libsndfile flac lame libmpg123 libogg libopus libvorbis sqlite
+manual rubberband 3.3.0
+dependency rubberband libfftw3 libopus libsamplerate libsndfile
+auto x264 baee400fa9ced6f5481a728138fed6e867b0ff7f
+```

--- a/Userland/Utilities/pkg/InstalledPort.cpp
+++ b/Userland/Utilities/pkg/InstalledPort.cpp
@@ -1,13 +1,24 @@
 /*
  * Copyright (c) 2023, Liav A. <liavalb@hotmail.co.il>
+ * Copyright (c) 2023, kleines Filmröllchen <filmroellchen@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #include "InstalledPort.h"
 #include <AK/Function.h>
+#include <AK/StringUtils.h>
 #include <LibCore/File.h>
 #include <LibCore/System.h>
+
+Optional<InstalledPort::Type> InstalledPort::type_from_string(StringView type)
+{
+    if (type == "auto"sv)
+        return Type::Auto;
+    if (type == "manual"sv)
+        return Type::Manual;
+    return {};
+}
 
 ErrorOr<HashMap<String, InstalledPort>> InstalledPort::read_ports_database()
 {
@@ -18,27 +29,39 @@ ErrorOr<HashMap<String, InstalledPort>> InstalledPort::read_ports_database()
     HashMap<String, InstalledPort> ports;
     while (TRY(buffered_file->can_read_line())) {
         auto line = TRY(buffered_file->read_line(buffer));
-        if (line.is_empty()) {
+        if (line.is_empty())
             continue;
-        } else if (line.starts_with("dependency"sv)) {
-            auto parts = line.split_view(' ');
-            VERIFY(parts.size() == 3);
-            auto type = InstalledPort::Type::Dependency;
-            // FIXME: Add versioning when printing these ports!
-            auto name = TRY(String::from_utf8(parts[2]));
-            TRY(ports.try_set(name, InstalledPort { TRY(String::from_utf8(parts[2])), type, {} }));
-        } else if (line.starts_with("auto"sv)) {
-            auto parts = line.split_view(' ');
-            VERIFY(parts.size() == 3);
-            auto type = InstalledPort::Type::Auto;
-            auto name = TRY(String::from_utf8(parts[1]));
-            TRY(ports.try_set(name, InstalledPort { name, type, TRY(String::from_utf8(parts[2])) }));
-        } else if (line.starts_with("manual"sv)) {
-            auto parts = line.split_view(' ');
-            VERIFY(parts.size() == 3);
-            auto type = InstalledPort::Type::Manual;
-            auto name = TRY(String::from_utf8(parts[1]));
-            TRY(ports.try_set(name, InstalledPort { name, type, TRY(String::from_utf8(parts[2])) }));
+
+        auto parts = line.split_view(' ');
+        if (parts.size() < 2) {
+            dbgln("Invalid database entry {} (only {} parts)", line, parts.size());
+            // FIXME: Skip over invalid entries instead?
+            return Error::from_string_view("Database entry too short"sv);
+        }
+        auto string_type = parts[0];
+        auto name = TRY(String::from_utf8(parts[1]));
+
+        if (auto maybe_type = type_from_string(string_type); maybe_type.has_value()) {
+            auto const type = maybe_type.release_value();
+            if (parts.size() < 3)
+                return Error::from_string_view("Port is missing a version specification"sv);
+            auto version = TRY(String::from_utf8(parts[2]));
+
+            auto& port = ports.ensure(name, [&] { return InstalledPort { name, {}, {} }; });
+            port.m_type = type;
+            port.m_version = move(version);
+        } else if (string_type == "dependency"sv) {
+            // Accept an empty dependency list.
+            auto dependency_views = parts.span().slice(2);
+            Vector<String> dependencies;
+            TRY(dependencies.try_ensure_capacity(dependency_views.size()));
+            for (auto const& view : dependency_views)
+                dependencies.unchecked_append(TRY(String::from_utf8(view)));
+
+            // Assume the port as automatically installed if the "dependency" line occurs before the "manual"/"auto" line.
+            // This is fine since these entries override the port type in any case.
+            auto& port = ports.ensure(name, [&] { return InstalledPort { name, Type::Auto, {} }; });
+            port.m_dependencies = move(dependencies);
         } else {
             return Error::from_string_literal("Unknown installed port type");
         }

--- a/Userland/Utilities/pkg/InstalledPort.cpp
+++ b/Userland/Utilities/pkg/InstalledPort.cpp
@@ -11,7 +11,7 @@
 
 ErrorOr<HashMap<String, InstalledPort>> InstalledPort::read_ports_database()
 {
-    auto file = TRY(Core::File::open("/usr/Ports/installed.db"sv, Core::File::OpenMode::Read));
+    auto file = TRY(Core::File::open(ports_database, Core::File::OpenMode::Read));
     auto buffered_file = TRY(Core::InputBufferedFile::create(move(file)));
     auto buffer = TRY(ByteBuffer::create_uninitialized(PAGE_SIZE));
 

--- a/Userland/Utilities/pkg/InstalledPort.h
+++ b/Userland/Utilities/pkg/InstalledPort.h
@@ -17,15 +17,15 @@ class InstalledPort {
 public:
     enum class Type {
         Auto,
-        Dependency,
         Manual,
     };
+    static Optional<Type> type_from_string(StringView);
 
     static ErrorOr<HashMap<String, InstalledPort>> read_ports_database();
     static ErrorOr<void> for_each_by_type(HashMap<String, InstalledPort>&, Type type, Function<ErrorOr<void>(InstalledPort const&)> callback);
 
     InstalledPort(String name, Type type, String version)
-        : m_name(name)
+        : m_name(move(name))
         , m_type(type)
         , m_version(move(version))
     {
@@ -36,8 +36,6 @@ public:
     {
         if (m_type == Type::Auto)
             return "Automatic"sv;
-        if (m_type == Type::Dependency)
-            return "Dependency"sv;
         if (m_type == Type::Manual)
             return "Manual"sv;
         VERIFY_NOT_REACHED();
@@ -45,9 +43,11 @@ public:
 
     StringView name() const { return m_name.bytes_as_string_view(); }
     StringView version() const { return m_version.bytes_as_string_view(); }
+    ReadonlySpan<String> dependencies() const { return m_dependencies.span(); }
 
 private:
     String m_name;
     Type m_type;
     String m_version;
+    Vector<String> m_dependencies;
 };

--- a/Userland/Utilities/pkg/InstalledPort.h
+++ b/Userland/Utilities/pkg/InstalledPort.h
@@ -11,6 +11,8 @@
 #include <AK/StringView.h>
 #include <AK/Types.h>
 
+constexpr StringView ports_database = "/usr/Ports/installed.db"sv;
+
 class InstalledPort {
 public:
     enum class Type {

--- a/Userland/Utilities/pkg/main.cpp
+++ b/Userland/Utilities/pkg/main.cpp
@@ -54,8 +54,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     HashMap<String, InstalledPort> installed_ports;
     HashMap<String, AvailablePort> available_ports;
     if (show_all_installed_ports || show_all_dependency_ports || !query_package.is_null()) {
-        if (Core::System::access("/usr/Ports/installed.md"sv, R_OK).is_error()) {
-            warnln("pkg: /usr/Ports/installed.md isn't accessible, did you install a package in the past?");
+        if (Core::System::access(ports_database, R_OK).is_error()) {
+            warnln("pkg: {} isn't accessible, did you install a package in the past?", ports_database);
             return 1;
         }
         installed_ports = TRY(InstalledPort::read_ports_database());


### PR DESCRIPTION
This mainly makes pkg actually capable of reading `dependency` lines, and fixes an oversight in the file name. I also took this opportunity and refactored how dependencies are stored internally, since it makes more semantical sense this way.

CC @supercomputer7

### pkg: Always use correct installed.db

The access() check was on the wrong file previously.

### pkg: Parse dependencies as part of the main port entry

The "dependency" lines really belong to the main port entry, it doesn't
make sense logically to represent them separately and handling them
together will also allow easier dependency management later on. This
commit greatly simplifies the port database parsing to facilitate this,
and removes the -d option from the command line. Instead, ports are
listed with their dependencies, if they have any.

### Base: Specify the installed.db port database format

