### PR TITLE
Meta: Remove myself from LibELF-related CODEOWNERS entries

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,13 +8,13 @@
 /Toolchain @BertalanD
 /Userland/Applications/Spreadsheet @alimpfard
 /Userland/BuggieBox @timschumi
-/Userland/DynamicLoader @BertalanD @timschumi
+/Userland/DynamicLoader @BertalanD
 /Userland/Libraries/LibArchive @timschumi
 /Userland/Libraries/LibCompress @timschumi
 /Userland/Libraries/LibCore/File.* @timschumi
 /Userland/Libraries/LibCore/Socket.* @timschumi
 /Userland/Libraries/LibCrypto @alimpfard
-/Userland/Libraries/LibELF @BertalanD @timschumi
+/Userland/Libraries/LibELF @BertalanD
 /Userland/Libraries/LibGL @GMTA
 /Userland/Libraries/LibGPU @GMTA
 /Userland/Libraries/LibHTTP @alimpfard
@@ -38,7 +38,7 @@
 /Userland/Utilities/gunzip.cpp @timschumi
 /Userland/Utilities/gzip.cpp @timschumi
 /Userland/Utilities/lzcat.cpp @timschumi
-/Userland/Utilities/readelf.cpp @timschumi
+/Userland/Utilities/readelf.cpp @BertalanD
 /Userland/Utilities/sql.cpp @trflynn89
 /Userland/Utilities/tar.cpp @timschumi
 /Userland/Utilities/unzip.cpp @timschumi


### PR DESCRIPTION
I'll continue to do reviews in a normal capacity, it just feels kind of dishonest to be listed as a codeowner if I'm way out of my depth half of the time. :^)

Adding Daniel to `readelf.cpp` in my place I have discussed with him in advance.