### PR TITLE
LibJS: Don't evaluate computed MemberExpression LHS twice in assignments

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/Generator.h
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.h
@@ -74,15 +74,17 @@ public:
         op->set_source_record({ m_current_ast_node->start_offset(), m_current_ast_node->end_offset() });
     }
 
-    CodeGenerationErrorOr<void> emit_load_from_reference(JS::ASTNode const&);
+    struct ReferenceRegisters {
+        Register base;                      // [[Base]]
+        Optional<Register> referenced_name; // [[ReferencedName]]
+        Register this_value;                // [[ThisValue]]
+    };
+
+    CodeGenerationErrorOr<Optional<ReferenceRegisters>> emit_load_from_reference(JS::ASTNode const&);
     CodeGenerationErrorOr<void> emit_store_to_reference(JS::ASTNode const&);
+    CodeGenerationErrorOr<void> emit_store_to_reference(ReferenceRegisters const&);
     CodeGenerationErrorOr<void> emit_delete_reference(JS::ASTNode const&);
 
-    struct ReferenceRegisters {
-        Register base;                                // [[Base]]
-        Optional<Bytecode::Register> referenced_name; // [[ReferencedName]]
-        Register this_value;                          // [[ThisValue]]
-    };
     CodeGenerationErrorOr<ReferenceRegisters> emit_super_reference(MemberExpression const&);
 
     void emit_set_variable(JS::Identifier const& identifier, Bytecode::Op::SetVariable::InitializationMode initialization_mode = Bytecode::Op::SetVariable::InitializationMode::Set, Bytecode::Op::EnvironmentMode mode = Bytecode::Op::EnvironmentMode::Lexical);


### PR DESCRIPTION
The following snippet would cause "i" to be incremented twice(!):

    let a = []
    let i = 0
    a[++i] += 0

This patch solves the issue by remembering the base object and property name for computed MemberExpression LHS in codegen. We the store the result of the assignment to the same object and property (instead of computing the LHS again).

3 new passes on test262. :^)

```
Summary:
    Diff Tests:
        +3 ✅    -3 ❌   

Diff Tests:
    test/language/expressions/logical-assignment/lgcl-and-assignment-operator-lhs-before-rhs.js     ❌ -> ✅
    test/language/expressions/logical-assignment/lgcl-nullish-assignment-operator-lhs-before-rhs.js ❌ -> ✅
    test/language/expressions/logical-assignment/lgcl-or-assignment-operator-lhs-before-rhs.js      ❌ -> ✅
```