### PR TITLE
LibCards+Hearts: Keep markings visible on very dark or light backgrounds

### DIFF
--- a/Userland/Games/Hearts/Game.cpp
+++ b/Userland/Games/Hearts/Game.cpp
@@ -892,7 +892,8 @@ void Game::paint_event(GUI::PaintEvent& event)
 
     for (auto& player : m_players) {
         auto& font = painter.font().bold_variant();
-        painter.draw_text(player.name_position, player.name, font, player.name_alignment, Color::Black, Gfx::TextElision::None);
+        Gfx::Color text_color = background_color.luminosity() > 80 ? Color::Black : Color::White;
+        painter.draw_text(player.name_position, player.name, font, player.name_alignment, text_color, Gfx::TextElision::None);
 
         if (!game_ended()) {
             for (auto& card : player.hand)

--- a/Userland/Libraries/LibCards/CardStack.cpp
+++ b/Userland/Libraries/LibCards/CardStack.cpp
@@ -34,6 +34,8 @@ void CardStack::clear()
 
 void CardStack::paint(GUI::Painter& painter, Gfx::Color background_color)
 {
+    auto background_markings_color = (background_color.luminosity() > 64) ? Color(0, 0, 0, 128) : Color(255, 255, 255, 128);
+
     auto draw_background_if_empty = [&]() {
         size_t number_of_moving_cards = 0;
         for (auto const& card : m_stack)
@@ -45,7 +47,7 @@ void CardStack::paint(GUI::Painter& painter, Gfx::Color background_color)
             return false;
 
         auto paint_rect = m_base;
-        painter.fill_rect_with_rounded_corners(paint_rect, background_color.darkened(0.5), Card::card_radius);
+        painter.fill_rect_with_rounded_corners(paint_rect, background_markings_color, Card::card_radius);
         paint_rect.shrink(2, 2);
 
         if (m_highlighted) {
@@ -61,7 +63,8 @@ void CardStack::paint(GUI::Painter& painter, Gfx::Color background_color)
     switch (m_type) {
     case Type::Stock:
         if (draw_background_if_empty()) {
-            painter.fill_rect(m_base.shrunken(Card::width / 4, Card::height / 4), background_color.lightened(1.5));
+            auto stock_highlight_color = (background_color.luminosity() < 196) ? Color(255, 255, 255, 128) : Color(0, 0, 0, 64);
+            painter.fill_rect(m_base.shrunken(Card::width / 4, Card::height / 4), stock_highlight_color);
             painter.fill_rect(m_base.shrunken(Card::width / 2, Card::height / 2), background_color);
         }
         break;
@@ -69,7 +72,7 @@ void CardStack::paint(GUI::Painter& painter, Gfx::Color background_color)
         if (draw_background_if_empty()) {
             for (int y = 0; y < (m_base.height() - 4) / 8; ++y) {
                 for (int x = 0; x < (m_base.width() - 4) / 5; ++x) {
-                    painter.draw_rect({ 4 + m_base.x() + x * 5, 4 + m_base.y() + y * 8, 1, 1 }, background_color.darkened(0.5));
+                    painter.draw_rect({ 4 + m_base.x() + x * 5, 4 + m_base.y() + y * 8, 1, 1 }, background_markings_color);
                 }
             }
         }


### PR DESCRIPTION
Noticed while playing around with the cards settings, that some background colours made things invisible or very hard to see. This PR fixes that by using lighter colours on dark backgrounds, and darker on lights. The luminosity values were chosen via trial and error to look about right to me.

![image](https://github.com/SerenityOS/serenity/assets/222642/6cf4be0f-4a0a-4bc9-8e52-0fa2826a8448)

![image](https://github.com/SerenityOS/serenity/assets/222642/8cfc6652-4fff-4f0e-8b69-c0265ab37411)
