### PR TITLE
LibWeb: Fix crash in XMLHttpRequest::response_xml() if response empty

### DIFF
--- a/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
+++ b/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
@@ -144,6 +144,8 @@ WebIDL::ExceptionOr<JS::GCPtr<DOM::Document>> XMLHttpRequest::response_xml()
     set_document_response();
 
     // 6. Return this’s response object.
+    if (m_response_object.has<Empty>())
+        return nullptr;
     return &verify_cast<DOM::Document>(m_response_object.get<JS::Value>().as_object());
 }
 


### PR DESCRIPTION
If response object is empty we should return nullptr.

Fixes crash on https://store.steampowered.com/