### PR TITLE
Update Navigator.cpp

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/Navigator.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Navigator.cpp
@@ -50,15 +50,11 @@ bool Navigator::webdriver() const
     // NOTE: The NavigatorAutomationInformation interface should not be exposed on WorkerNavigator.
     auto const& window = verify_cast<HTML::Window>(HTML::current_global_object());
     if(window && window.page())
-    {
         return window.page()->is_webdriver_active();
-    }
     else
-    {
         // Handle the case where window or page is null
         // You can return false or throw an exception based on your requirements.
         return false;
-    }
 }
 
 void Navigator::visit_edges(Cell::Visitor& visitor)

--- a/Userland/Libraries/LibWeb/HTML/Navigator.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Navigator.cpp
@@ -49,7 +49,16 @@ bool Navigator::webdriver() const
 
     // NOTE: The NavigatorAutomationInformation interface should not be exposed on WorkerNavigator.
     auto const& window = verify_cast<HTML::Window>(HTML::current_global_object());
-    return window.page()->is_webdriver_active();
+    if(window && window.page())
+    {
+        return window.page()->is_webdriver_active();
+    }
+    else
+    {
+        // Handle the case where window or page is null
+        // You can return false or throw an exception based on your requirements.
+        return false;
+    }
 }
 
 void Navigator::visit_edges(Cell::Visitor& visitor)


### PR DESCRIPTION
solves: #21305
Added an if else exception handling condition for handling the  case when the window or window.page() is not there. 

In the else condition, the handler simply returns false