### PR TITLE
LibWeb: Fix input and form elements IDL definitions

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/AttributeNames.h
+++ b/Userland/Libraries/LibWeb/HTML/AttributeNames.h
@@ -24,6 +24,7 @@ namespace AttributeNames {
     __ENUMERATE_HTML_ATTRIBUTE(alt)                        \
     __ENUMERATE_HTML_ATTRIBUTE(archive)                    \
     __ENUMERATE_HTML_ATTRIBUTE(async)                      \
+    __ENUMERATE_HTML_ATTRIBUTE(autocomplete)               \
     __ENUMERATE_HTML_ATTRIBUTE(autofocus)                  \
     __ENUMERATE_HTML_ATTRIBUTE(autoplay)                   \
     __ENUMERATE_HTML_ATTRIBUTE(axis)                       \

--- a/Userland/Libraries/LibWeb/HTML/HTMLButtonElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLButtonElement.idl
@@ -1,16 +1,29 @@
 #import <HTML/HTMLElement.idl>
+#import <HTML/HTMLFormElement.idl>
 
 // https://html.spec.whatwg.org/multipage/semantics.html#htmlbuttonelement
 [Exposed=Window]
 interface HTMLButtonElement : HTMLElement {
-
     [HTMLConstructor] constructor();
 
     [CEReactions, Reflect] attribute boolean disabled;
+    readonly attribute HTMLFormElement? form;
+    [CEReactions, Reflect=formaction] attribute USVString formAction;
+    [CEReactions, Reflect=formenctype] attribute DOMString formEnctype;
+    [CEReactions, Reflect=formmethod] attribute DOMString formMethod;
     [CEReactions, Reflect=formnovalidate] attribute boolean formNoValidate;
     [CEReactions, Reflect=formtarget] attribute DOMString formTarget;
     [CEReactions, Reflect] attribute DOMString name;
+    [CEReactions, Reflect] attribute DOMString type;
     [CEReactions, Reflect] attribute DOMString value;
-    [CEReactions] attribute DOMString type;
 
+    // FIXME: readonly attribute boolean willValidate;
+    // FIXME: readonly attribute ValidityState validity;
+    // FIXME: readonly attribute DOMString validationMessage;
+    // FIXME: boolean checkValidity();
+    // FIXME: boolean reportValidity();
+    // FIXME: undefined setCustomValidity(DOMString error);
+
+    // FIXME: readonly attribute NodeList labels;
 };
+// FIXME: HTMLButtonElement includes PopoverInvokerElement;

--- a/Userland/Libraries/LibWeb/HTML/HTMLDataListElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLDataListElement.idl
@@ -3,7 +3,7 @@
 // https://html.spec.whatwg.org/multipage/semantics.html#htmldatalistelement
 [Exposed=Window]
 interface HTMLDataListElement : HTMLElement {
-
     [HTMLConstructor] constructor();
 
+    // FIXME: [SameObject] readonly attribute HTMLCollection options;
 };

--- a/Userland/Libraries/LibWeb/HTML/HTMLFieldSetElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFieldSetElement.idl
@@ -1,11 +1,23 @@
 #import <HTML/HTMLElement.idl>
+#import <HTML/HTMLFormElement.idl>
 
 // https://html.spec.whatwg.org/multipage/semantics.html#htmlfieldsetelement
 [Exposed=Window]
 interface HTMLFieldSetElement : HTMLElement {
-
     [HTMLConstructor] constructor();
+
+    [CEReactions, Reflect] attribute boolean disabled;
+    readonly attribute HTMLFormElement? form;
+    [CEReactions, Reflect] attribute DOMString name;
 
     readonly attribute DOMString type;
 
+    // FIXME: [SameObject] readonly attribute HTMLCollection elements;
+
+    // FIXME: readonly attribute boolean willValidate;
+    // FIXME: [SameObject] readonly attribute ValidityState validity;
+    // FIXME: readonly attribute DOMString validationMessage;
+    // FIXME: boolean checkValidity();
+    // FIXME: boolean reportValidity();
+    // FIXME: undefined setCustomValidity(DOMString error);
 };

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -1080,6 +1080,39 @@ i32 HTMLInputElement::default_tab_index_value() const
     return 0;
 }
 
+// https://html.spec.whatwg.org/multipage/input.html#dom-input-valueasnumber
+WebIDL::ExceptionOr<double> HTMLInputElement::value_as_number() const
+{
+    // On getting, if the valueAsNumber attribute does not apply, as defined for the input element's type attribute's current state, then return a Not-a-Number (NaN) value.
+    if (type_state() != TypeAttributeState::Date || type_state() != TypeAttributeState::Month || type_state() != TypeAttributeState::Week || type_state() != TypeAttributeState::Time || type_state() != TypeAttributeState::LocalDateAndTime || type_state() != TypeAttributeState::Number || type_state() != TypeAttributeState::Range)
+        return NAN;
+
+    // Otherwise, run the algorithm to convert a string to a number defined for that state to the element's value; if the algorithm returned a number, then return it, otherwise, return a Not-a-Number (NaN) value.
+    return value().to_double().value_or(NAN);
+}
+
+// https://html.spec.whatwg.org/multipage/input.html#dom-input-valueasnumber
+WebIDL::ExceptionOr<void> HTMLInputElement::set_value_as_number(double value)
+{
+    // On setting, if the new value is infinite, then throw a TypeError exception.
+    if (!isfinite(value))
+        return WebIDL::SimpleException { WebIDL::SimpleExceptionType::TypeError, "valueAsNumber: Value is infinite"sv };
+
+    // Otherwise, if the valueAsNumber attribute does not apply, as defined for the input element's type attribute's current state, then throw an "InvalidStateError" DOMException.
+    if (type_state() != TypeAttributeState::Date || type_state() != TypeAttributeState::Month || type_state() != TypeAttributeState::Week || type_state() != TypeAttributeState::Time || type_state() != TypeAttributeState::LocalDateAndTime || type_state() != TypeAttributeState::Number || type_state() != TypeAttributeState::Range)
+        return WebIDL::InvalidStateError::create(realm(), "valueAsNumber: Invalid input type used"_fly_string);
+
+    // Otherwise, if the new value is a Not-a-Number (NaN) value, then set the value of the element to the empty string.
+    if (value == NAN) {
+        m_value = "";
+        return {};
+    }
+
+    // Otherwise, run the algorithm to convert a number to a string, as defined for that state, on the new value, and set the value of the element to the resulting string.
+    m_value = DeprecatedString::number(value);
+    return {};
+}
+
 // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-checkvalidity
 WebIDL::ExceptionOr<bool> HTMLInputElement::check_validity()
 {

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -508,6 +508,7 @@ void HTMLInputElement::create_shadow_tree_if_needed()
 
     // FIXME: This could be better factored. Everything except the below types becomes a text input.
     switch (type_state()) {
+    case TypeAttributeState::Hidden:
     case TypeAttributeState::RadioButton:
     case TypeAttributeState::Checkbox:
     case TypeAttributeState::Button:

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -94,6 +94,9 @@ public:
     // https://html.spec.whatwg.org/multipage/input.html#update-the-file-selection
     void update_the_file_selection(JS::NonnullGCPtr<FileAPI::FileList>);
 
+    WebIDL::ExceptionOr<double> value_as_number() const;
+    WebIDL::ExceptionOr<void> set_value_as_number(double value);
+
     WebIDL::ExceptionOr<bool> check_validity();
     WebIDL::ExceptionOr<bool> report_validity();
     void set_custom_validity(String const&);

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.idl
@@ -19,7 +19,7 @@ interface HTMLInputElement : HTMLElement {
     // FIXME: [CEReactions] attribute USVString formAction;
     // FIXME: [CEReactions] attribute DOMString formEnctype;
     // FIXME: [CEReactions] attribute DOMString formMethod;
-   [CEReactions, Reflect=formnovalidate] attribute boolean formNoValidate;
+    [CEReactions, Reflect=formnovalidate] attribute boolean formNoValidate;
     [CEReactions, Reflect=formtarget] attribute DOMString formTarget;
     // FIXME: [CEReactions] attribute unsigned long height;
     attribute boolean indeterminate;
@@ -41,7 +41,7 @@ interface HTMLInputElement : HTMLElement {
     [CEReactions, Reflect=value] attribute DOMString defaultValue;
     [CEReactions, LegacyNullToEmptyString] attribute DOMString value;
     // FIXME: attribute object? valueAsDate;
-    // FIXME: attribute unrestricted double valueAsNumber;
+    attribute unrestricted double valueAsNumber;
     // FIXME: [CEReactions] attribute unsigned long width;
 
     // FIXME: undefined stepUp(optional long n = 1);

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.idl
@@ -5,49 +5,69 @@
 // https://html.spec.whatwg.org/multipage/input.html#htmlinputelement
 [Exposed=Window]
 interface HTMLInputElement : HTMLElement {
-
     [HTMLConstructor] constructor();
-
-    readonly attribute HTMLFormElement? form;
-    attribute FileList? files;
 
     [CEReactions, Reflect] attribute DOMString accept;
     [CEReactions, Reflect] attribute DOMString alt;
-    [CEReactions, Reflect] attribute DOMString max;
-    [CEReactions, Reflect] attribute DOMString min;
-    [CEReactions, Reflect] attribute DOMString pattern;
-    [CEReactions, Reflect] attribute DOMString placeholder;
-    [CEReactions, Reflect] attribute DOMString src;
-    [CEReactions, Reflect] attribute DOMString step;
-    [CEReactions, Reflect] attribute DOMString name;
-    [CEReactions, Reflect=dirname] attribute DOMString dirName;
-    [CEReactions, Reflect=value] attribute DOMString defaultValue;
-
-    [CEReactions] attribute DOMString type;
-    attribute boolean indeterminate;
-
-    [CEReactions, LegacyNullToEmptyString] attribute DOMString value;
-
-    [ImplementedAs=checked_binding] attribute boolean checked;
-
-    [CEReactions, Reflect] attribute boolean disabled;
+    // FIXME: [CEReactions] attribute DOMString autocomplete;
     [CEReactions, Reflect=checked] attribute boolean defaultChecked;
-    [CEReactions, Reflect=formnovalidate] attribute boolean formNoValidate;
+    [ImplementedAs=checked_binding] attribute boolean checked;
+    [CEReactions, Reflect=dirname] attribute DOMString dirName;
+    [CEReactions, Reflect] attribute boolean disabled;
+    readonly attribute HTMLFormElement? form;
+    attribute FileList? files;
+    // FIXME: [CEReactions] attribute USVString formAction;
+    // FIXME: [CEReactions] attribute DOMString formEnctype;
+    // FIXME: [CEReactions] attribute DOMString formMethod;
+   [CEReactions, Reflect=formnovalidate] attribute boolean formNoValidate;
     [CEReactions, Reflect=formtarget] attribute DOMString formTarget;
+    // FIXME: [CEReactions] attribute unsigned long height;
+    attribute boolean indeterminate;
+    // FIXME: readonly attribute HTMLDataListElement? list;
+    [CEReactions, Reflect] attribute DOMString max;
+    // FIXME: [CEReactions] attribute long maxLength;
+    [CEReactions, Reflect] attribute DOMString min;
+    // FIXME: [CEReactions] attribute long minLength;
     [CEReactions, Reflect] attribute boolean multiple;
+    [CEReactions, Reflect] attribute DOMString name;
+    // FIXME: [CEReactions] attribute DOMString pattern;
+    [CEReactions, Reflect] attribute DOMString placeholder;
     [CEReactions, Reflect=readonly] attribute boolean readOnly;
     [CEReactions, Reflect] attribute boolean required;
+    // FIXME: [CEReactions] attribute unsigned long size;
+    [CEReactions, Reflect] attribute DOMString src;
+    [CEReactions, Reflect] attribute DOMString step;
+    [CEReactions] attribute DOMString type;
+    [CEReactions, Reflect=value] attribute DOMString defaultValue;
+    [CEReactions, LegacyNullToEmptyString] attribute DOMString value;
+    // FIXME: attribute object? valueAsDate;
+    // FIXME: attribute unrestricted double valueAsNumber;
+    // FIXME: [CEReactions] attribute unsigned long width;
 
-    [CEReactions, Reflect] attribute DOMString align;
-    [CEReactions, Reflect=usemap] attribute DOMString useMap;
+    // FIXME: undefined stepUp(optional long n = 1);
+    // FIXME: undefined stepDown(optional long n = 1);
 
+    // FIXME: readonly attribute boolean willValidate;
+    // FIXME: readonly attribute ValidityState validity;
+    // FIXME: readonly attribute DOMString validationMessage;
     boolean checkValidity();
     boolean reportValidity();
     undefined setCustomValidity(DOMString error);
 
+    // FIXME: readonly attribute NodeList? labels;
+
     undefined select();
+    // FIXME: attribute unsigned long? selectionStart;
+    // FIXME: attribute unsigned long? selectionEnd;
+    // FIXME: attribute DOMString? selectionDirection;
+    // FIXME: undefined setRangeText(DOMString replacement);
+    // FIXME: undefined setRangeText(DOMString replacement, unsigned long start, unsigned long end, optional SelectionMode selectionMode = "preserve");
     undefined setSelectionRange(unsigned long start, unsigned long end, optional DOMString direction);
 
     undefined showPicker();
 
+    // Obsolete
+    [CEReactions, Reflect] attribute DOMString align;
+    [CEReactions, Reflect=usemap] attribute DOMString useMap;
 };
+// FIXME: HTMLInputElement includes PopoverInvokerElement;

--- a/Userland/Libraries/LibWeb/HTML/HTMLLegendElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLLegendElement.idl
@@ -3,9 +3,10 @@
 // https://html.spec.whatwg.org/multipage/form-elements.html#htmllegendelement
 [Exposed=Window]
 interface HTMLLegendElement : HTMLElement {
-
     [HTMLConstructor] constructor();
 
-    [CEReactions, Reflect] attribute DOMString align;
+    // FIXME: readonly attribute HTMLFormElement? form;
 
+    // Obsolete
+    [CEReactions, Reflect] attribute DOMString align;
 };

--- a/Userland/Libraries/LibWeb/HTML/HTMLMeterElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMeterElement.idl
@@ -3,7 +3,13 @@
 // https://html.spec.whatwg.org/multipage/form-elements.html#htmlmeterelement
 [Exposed=Window]
 interface HTMLMeterElement : HTMLElement {
-
     [HTMLConstructor] constructor();
 
+    // FIXME: [CEReactions] attribute double value;
+    // FIXME: [CEReactions] attribute double min;
+    // FIXME: [CEReactions] attribute double max;
+    // FIXME: [CEReactions] attribute double low;
+    // FIXME: [CEReactions] attribute double high;
+    // FIXME: [CEReactions] attribute double optimum;
+    // FIXME: readonly attribute NodeList labels;
 };

--- a/Userland/Libraries/LibWeb/HTML/HTMLOptGroupElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLOptGroupElement.idl
@@ -3,10 +3,8 @@
 // https://html.spec.whatwg.org/multipage/form-elements.html#htmloptgroupelement
 [Exposed=Window]
 interface HTMLOptGroupElement : HTMLElement {
-
     [HTMLConstructor] constructor();
 
     [CEReactions, Reflect] attribute boolean disabled;
     [CEReactions, Reflect] attribute DOMString label;
-
 };

--- a/Userland/Libraries/LibWeb/HTML/HTMLOptionElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLOptionElement.idl
@@ -3,15 +3,15 @@
 // https://html.spec.whatwg.org/multipage/form-elements.html#htmloptionelement
 [Exposed=Window,  LegacyFactoryFunction=Option(optional DOMString text = "", optional DOMString value, optional boolean defaultSelected = false, optional boolean selected = false)]
 interface HTMLOptionElement : HTMLElement {
-
     [HTMLConstructor] constructor();
 
     [CEReactions, Reflect] attribute boolean disabled;
+    // FIXME: readonly attribute HTMLFormElement? form;
+    [CEReactions, Reflect] attribute DOMString label;
     [CEReactions, Reflect=selected] attribute boolean defaultSelected;
     attribute boolean selected;
     [CEReactions] attribute DOMString value;
 
     [CEReactions] attribute DOMString text;
     readonly attribute long index;
-
 };

--- a/Userland/Libraries/LibWeb/HTML/HTMLOutputElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLOutputElement.idl
@@ -1,11 +1,25 @@
 #import <HTML/HTMLElement.idl>
+#import <HTML/HTMLFormElement.idl>
 
 // https://html.spec.whatwg.org/multipage/form-elements.html#htmloutputelement
 [Exposed=Window]
 interface HTMLOutputElement : HTMLElement {
-
     [HTMLConstructor] constructor();
 
-    readonly attribute DOMString type;
+    // FIXME: [SameObject, PutForwards=value] readonly attribute DOMTokenList htmlFor;
+    readonly attribute HTMLFormElement? form;
+    [CEReactions, Reflect] attribute DOMString name;
 
+    readonly attribute DOMString type;
+    // FIXME: [CEReactions] attribute DOMString defaultValue;
+    // FIXME: [CEReactions] attribute DOMString value;
+
+    // FIXME: readonly attribute boolean willValidate;
+    // FIXME: readonly attribute ValidityState validity;
+    // FIXME: readonly attribute DOMString validationMessage;
+    // FIXME: boolean checkValidity();
+    // FIXME: boolean reportValidity();
+    // FIXME: undefined setCustomValidity(DOMString error);
+
+    // FIXME: readonly attribute NodeList labels;
 };

--- a/Userland/Libraries/LibWeb/HTML/HTMLProgressElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLProgressElement.idl
@@ -3,11 +3,10 @@
 // https://html.spec.whatwg.org/multipage/form-elements.html#htmlprogresselement
 [Exposed=Window]
 interface HTMLProgressElement : HTMLElement {
-
     [HTMLConstructor] constructor();
 
     [CEReactions] attribute double value;
     [CEReactions] attribute double max;
     readonly attribute double position;
-
+    // FIXME: readonly attribute NodeList labels;
 };

--- a/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.idl
@@ -4,21 +4,40 @@
 // https://html.spec.whatwg.org/multipage/form-elements.html#htmlselectelement
 [Exposed=Window]
 interface HTMLSelectElement : HTMLElement {
-
     [HTMLConstructor] constructor();
 
+    [CEReactions, Reflect] attribute DOMString autocomplete;
     [CEReactions, Reflect] attribute boolean disabled;
+    readonly attribute HTMLFormElement? form;
     [CEReactions, Reflect] attribute boolean multiple;
+    [CEReactions, Reflect] attribute DOMString name;
     [CEReactions, Reflect] attribute boolean required;
-    [SameObject] readonly attribute HTMLOptionsCollection options;
+    // FIXME: [CEReactions] attribute unsigned long size;
 
     readonly attribute DOMString type;
 
-    readonly attribute unsigned long length;
+    [SameObject] readonly attribute HTMLOptionsCollection options;
+    // FIXME: This isn't readonly
+    [CEReactions] readonly attribute unsigned long length;
+    // FIXME: Element is really HTMLOptionElement
     getter Element? item(unsigned long index);
-    getter Element? namedItem(DOMString name);
+    // FIXME: Element is really HTMLOptionElement
+    Element? namedItem(DOMString name);
     [CEReactions] undefined add((HTMLOptionElement or HTMLOptGroupElement) element, optional (HTMLElement or long)? before = null);
+    // FIXME: [CEReactions] undefined remove(); // ChildNode overload
+    // FIXME: [CEReactions] undefined remove(long index);
+    // FIXME: [CEReactions] setter undefined (unsigned long index, HTMLOptionElement? option);
 
+    // FIXME: [SameObject] readonly attribute HTMLCollection selectedOptions;
     attribute long selectedIndex;
+    // FIXME: attribute DOMString value;
 
+    // FIXME: readonly attribute boolean willValidate;
+    // FIXME: readonly attribute ValidityState validity;
+    // FIXME: readonly attribute DOMString validationMessage;
+    // FIXME: boolean checkValidity();
+    // FIXME: boolean reportValidity();
+    // FIXME: undefined setCustomValidity(DOMString error);
+
+    // FIXME: readonly attribute NodeList labels;
 };

--- a/Userland/Libraries/LibWeb/HTML/HTMLTextAreaElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTextAreaElement.idl
@@ -1,18 +1,44 @@
 #import <HTML/HTMLElement.idl>
+#import <HTML/HTMLFormElement.idl>
 
 // https://html.spec.whatwg.org/multipage/form-elements.html#htmltextareaelement
 [Exposed=Window]
 interface HTMLTextAreaElement : HTMLElement {
-
     [HTMLConstructor] constructor();
 
-    [CEReactions, Reflect] attribute DOMString placeholder;
-    [CEReactions, Reflect] attribute DOMString name;
-    [CEReactions, Reflect] attribute DOMString wrap;
-    readonly attribute DOMString type;
-
+    [CEReactions, Reflect] attribute DOMString autocomplete;
+    // FIXME: [CEReactions] attribute unsigned long cols;
+    [CEReactions, Reflect=dirname] attribute DOMString dirName;
     [CEReactions, Reflect] attribute boolean disabled;
+    readonly attribute HTMLFormElement? form;
+    // FIXME: [CEReactions] attribute long maxLength;
+    // FIXME: [CEReactions] attribute long minLength;
+    [CEReactions, Reflect] attribute DOMString name;
+    [CEReactions, Reflect] attribute DOMString placeholder;
     [CEReactions, Reflect=readonly] attribute boolean readOnly;
     [CEReactions, Reflect] attribute boolean required;
+    // FIXME: [CEReactions] attribute unsigned long rows;
+    [CEReactions, Reflect] attribute DOMString wrap;
 
+    readonly attribute DOMString type;
+    // FIXME: [CEReactions] attribute DOMString defaultValue;
+    // FIXME: attribute [LegacyNullToEmptyString] DOMString value;
+    // FIXME: readonly attribute unsigned long textLength;
+
+    // FIXME: readonly attribute boolean willValidate;
+    // FIXME: readonly attribute ValidityState validity;
+    // FIXME: readonly attribute DOMString validationMessage;
+    // FIXME: boolean checkValidity();
+    // FIXME: boolean reportValidity();
+    // FIXME: undefined setCustomValidity(DOMString error);
+
+    // FIXME: readonly attribute NodeList labels;
+
+    // FIXME: undefined select();
+    // FIXME: attribute unsigned long selectionStart;
+    // FIXME: attribute unsigned long selectionEnd;
+    // FIXME: attribute DOMString selectionDirection;
+    // FIXME: undefined setRangeText(DOMString replacement);
+    // FIXME: undefined setRangeText(DOMString replacement, unsigned long start, unsigned long end, optional SelectionMode selectionMode = "preserve");
+    // FIXME: undefined setSelectionRange(unsigned long start, unsigned long end, optional DOMString direction);
 };


### PR DESCRIPTION
This month I want to make the form elements more spec compliant. My workflow mostly consist of finding FIXME's in the IDL files and implementing missing methods and/or getters and setters. Most of the form elements IDL files where not based on the spec so I copied most IDL spec definitions and added fixme's of all the stuff that is not implemented. That way we can implement stuff along the way 🎉

Maybe I forgot something so a nice review is needed.