### PR TITLE
Shell: Add support for the bashy list literals in POSIX mode

### DIFF
--- a/Userland/Shell/AST.h
+++ b/Userland/Shell/AST.h
@@ -451,6 +451,7 @@ public:
     virtual bool should_override_execution_in_current_process() const { return false; }
 
     Position const& position() const { return m_position; }
+    Position& position() { return m_position; }
     virtual void clear_syntax_error();
     virtual void set_is_syntax_error(SyntaxError& error_node);
     virtual SyntaxError& syntax_error_node()

--- a/Userland/Shell/PosixLexer.cpp
+++ b/Userland/Shell/PosixLexer.cpp
@@ -961,6 +961,8 @@ StringView Token::type_name() const
         return "HeredocContents"sv;
     case Type::AssignmentWord:
         return "AssignmentWord"sv;
+    case Type::ListAssignmentWord:
+        return "ListAssignmentWord"sv;
     case Type::Bang:
         return "Bang"sv;
     case Type::Case:

--- a/Userland/Shell/PosixLexer.h
+++ b/Userland/Shell/PosixLexer.h
@@ -242,6 +242,7 @@ struct Token {
 
         // Not produced by this lexer, but generated in later stages.
         AssignmentWord,
+        ListAssignmentWord,
         Bang,
         Case,
         CloseBrace,

--- a/Userland/Shell/PosixParser.h
+++ b/Userland/Shell/PosixParser.h
@@ -21,8 +21,13 @@ public:
         (void)fill_token_buffer(starting_reduction);
     }
 
+    enum class AllowNewlines {
+        No,
+        Yes,
+    };
+
     RefPtr<AST::Node> parse();
-    RefPtr<AST::Node> parse_word_list();
+    RefPtr<AST::Node> parse_word_list(AllowNewlines = AllowNewlines::No);
 
     struct Error {
         DeprecatedString message;
@@ -94,6 +99,7 @@ private:
     ErrorOr<RefPtr<AST::Node>> parse_io_file(AST::Position, Optional<int> fd);
     ErrorOr<RefPtr<AST::Node>> parse_io_here(AST::Position, Optional<int> fd);
     ErrorOr<RefPtr<AST::Node>> parse_word();
+    ErrorOr<RefPtr<AST::Node>> parse_bash_like_list();
     ErrorOr<CaseItemsResult> parse_case_list();
 
     template<typename... Ts>


### PR DESCRIPTION
This is currently only allowed in assignments, where x=(...) is parsed as the assignment of the list (...) to the variable x.