### PR TITLE
LibJS: Add fast paths for array-like Get/Put with Int32 indexes

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -2573,6 +2573,8 @@ private:
     virtual JS::ThrowCompletionOr<bool> internal_set_prototype_of(JS::Object* prototype) override;
     virtual JS::ThrowCompletionOr<bool> internal_prevent_extensions() override;
 
+    virtual bool may_interfere_with_indexed_property_access() const final { return true; }
+
     JS::Realm& m_realm; // [[Realm]]
 };
 )~~~");

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -1580,8 +1580,27 @@ ThrowCompletionOr<void> PutByValue::execute_impl(Bytecode::Interpreter& interpre
     auto value = interpreter.accumulator();
 
     auto base = interpreter.reg(m_base);
+    auto property_key_value = interpreter.reg(m_property);
 
-    auto property_key = m_kind != PropertyKind::Spread ? TRY(interpreter.reg(m_property).to_property_key(vm)) : PropertyKey {};
+    // OPTIMIZATION: Fast path for simple Int32 indexes in array-like objects.
+    if (base.is_object() && property_key_value.is_int32() && property_key_value.as_i32() >= 0) {
+        auto& object = base.as_object();
+        auto* storage = object.indexed_properties().storage();
+        auto index = static_cast<u32>(property_key_value.as_i32());
+        if (storage
+            && storage->is_simple_storage()
+            && !object.may_interfere_with_indexed_property_access()
+            && storage->has_index(index)) {
+            auto existing_value = storage->get(index)->value;
+            if (!existing_value.is_accessor()) {
+                storage->put(index, value);
+                interpreter.accumulator() = value;
+                return {};
+            }
+        }
+    }
+
+    auto property_key = m_kind != PropertyKind::Spread ? TRY(property_key_value.to_property_key(vm)) : PropertyKey {};
     TRY(put_by_property_key(vm, base, base, value, property_key, m_kind));
     interpreter.accumulator() = value;
     return {};

--- a/Userland/Libraries/LibJS/Runtime/ArgumentsObject.h
+++ b/Userland/Libraries/LibJS/Runtime/ArgumentsObject.h
@@ -27,6 +27,8 @@ public:
     virtual ThrowCompletionOr<bool> internal_set(PropertyKey const&, Value value, Value receiver) override;
     virtual ThrowCompletionOr<bool> internal_delete(PropertyKey const&) override;
 
+    virtual bool may_interfere_with_indexed_property_access() const final { return true; }
+
     // [[ParameterMap]]
     Object& parameter_map() { return *m_parameter_map; }
 

--- a/Userland/Libraries/LibJS/Runtime/IndexedProperties.h
+++ b/Userland/Libraries/LibJS/Runtime/IndexedProperties.h
@@ -138,6 +138,9 @@ public:
     size_t array_like_size() const { return m_storage ? m_storage->array_like_size() : 0; }
     bool set_array_like_size(size_t);
 
+    IndexedPropertyStorage* storage() { return m_storage; }
+    IndexedPropertyStorage const* storage() const { return m_storage; }
+
     size_t real_size() const;
 
     Vector<u32> indices() const;

--- a/Userland/Libraries/LibJS/Runtime/ModuleNamespaceObject.h
+++ b/Userland/Libraries/LibJS/Runtime/ModuleNamespaceObject.h
@@ -31,6 +31,8 @@ public:
     virtual ThrowCompletionOr<MarkedVector<Value>> internal_own_property_keys() const override;
     virtual void initialize(Realm&) override;
 
+    virtual bool may_interfere_with_indexed_property_access() const final { return true; }
+
 private:
     ModuleNamespaceObject(Realm&, Module* module, Vector<DeprecatedFlyString> exports);
 

--- a/Userland/Libraries/LibJS/Runtime/Object.h
+++ b/Userland/Libraries/LibJS/Runtime/Object.h
@@ -135,6 +135,12 @@ public:
     virtual ThrowCompletionOr<bool> internal_delete(PropertyKey const&);
     virtual ThrowCompletionOr<MarkedVector<Value>> internal_own_property_keys() const;
 
+    // NOTE: Any subclass of Object that overrides property access slots ([[Get]], [[Set]] etc)
+    //       to customize access to indexed properties (properties where the name is a positive integer)
+    //       must return true for this, to opt out of optimizations that rely on assumptions that
+    //       might not hold when property access behaves differently.
+    virtual bool may_interfere_with_indexed_property_access() const { return false; }
+
     ThrowCompletionOr<bool> ordinary_set_with_own_descriptor(PropertyKey const&, Value, Value, Optional<PropertyDescriptor>);
 
     // 10.4.7 Immutable Prototype Exotic Objects, https://tc39.es/ecma262/#sec-immutable-prototype-exotic-objects

--- a/Userland/Libraries/LibJS/Runtime/ProxyObject.h
+++ b/Userland/Libraries/LibJS/Runtime/ProxyObject.h
@@ -45,6 +45,8 @@ public:
     virtual ThrowCompletionOr<Value> internal_call(Value this_argument, MarkedVector<Value> arguments_list) override;
     virtual ThrowCompletionOr<NonnullGCPtr<Object>> internal_construct(MarkedVector<Value> arguments_list, FunctionObject& new_target) override;
 
+    virtual bool may_interfere_with_indexed_property_access() const final { return true; }
+
 private:
     ProxyObject(Object& target, Object& handler, Object& prototype);
 

--- a/Userland/Libraries/LibJS/Runtime/StringObject.h
+++ b/Userland/Libraries/LibJS/Runtime/StringObject.h
@@ -30,6 +30,8 @@ private:
     virtual ThrowCompletionOr<bool> internal_define_own_property(PropertyKey const&, PropertyDescriptor const&) override;
     virtual ThrowCompletionOr<MarkedVector<Value>> internal_own_property_keys() const override;
 
+    virtual bool may_interfere_with_indexed_property_access() const final { return true; }
+
     virtual bool is_string_object() const final { return true; }
     virtual void visit_edges(Visitor&) override;
 

--- a/Userland/Libraries/LibJS/Runtime/TypedArray.h
+++ b/Userland/Libraries/LibJS/Runtime/TypedArray.h
@@ -414,6 +414,8 @@ public:
         return { move(keys) };
     }
 
+    virtual bool may_interfere_with_indexed_property_access() const final { return true; }
+
     ReadonlySpan<UnderlyingBufferDataType> data() const
     {
         return { reinterpret_cast<UnderlyingBufferDataType const*>(m_viewed_array_buffer->buffer().data() + m_byte_offset), m_array_length };

--- a/Userland/Libraries/LibWeb/Bindings/LegacyPlatformObject.h
+++ b/Userland/Libraries/LibWeb/Bindings/LegacyPlatformObject.h
@@ -29,6 +29,8 @@ public:
     virtual JS::ThrowCompletionOr<bool> internal_prevent_extensions() override;
     virtual JS::ThrowCompletionOr<JS::MarkedVector<JS::Value>> internal_own_property_keys() const override;
 
+    virtual bool may_interfere_with_indexed_property_access() const final { return true; }
+
     enum class IgnoreNamedProps {
         No,
         Yes,

--- a/Userland/Libraries/LibWeb/HTML/AudioTrackList.h
+++ b/Userland/Libraries/LibWeb/HTML/AudioTrackList.h
@@ -51,6 +51,8 @@ private:
     virtual void initialize(JS::Realm&) override;
     virtual JS::ThrowCompletionOr<Optional<JS::PropertyDescriptor>> internal_get_own_property(JS::PropertyKey const& property_name) const override;
 
+    virtual bool may_interfere_with_indexed_property_access() const final { return true; }
+
     JS::MarkedVector<JS::NonnullGCPtr<AudioTrack>> m_audio_tracks;
 };
 

--- a/Userland/Libraries/LibWeb/HTML/Location.h
+++ b/Userland/Libraries/LibWeb/HTML/Location.h
@@ -64,6 +64,8 @@ public:
     virtual JS::ThrowCompletionOr<bool> internal_delete(JS::PropertyKey const&) override;
     virtual JS::ThrowCompletionOr<JS::MarkedVector<JS::Value>> internal_own_property_keys() const override;
 
+    virtual bool may_interfere_with_indexed_property_access() const final { return true; }
+
     HTML::CrossOriginPropertyDescriptorMap const& cross_origin_property_descriptor_map() const { return m_cross_origin_property_descriptor_map; }
     HTML::CrossOriginPropertyDescriptorMap& cross_origin_property_descriptor_map() { return m_cross_origin_property_descriptor_map; }
 

--- a/Userland/Libraries/LibWeb/HTML/VideoTrackList.h
+++ b/Userland/Libraries/LibWeb/HTML/VideoTrackList.h
@@ -44,6 +44,8 @@ private:
     virtual void initialize(JS::Realm&) override;
     virtual JS::ThrowCompletionOr<Optional<JS::PropertyDescriptor>> internal_get_own_property(JS::PropertyKey const& property_name) const override;
 
+    virtual bool may_interfere_with_indexed_property_access() const final { return true; }
+
     JS::MarkedVector<JS::NonnullGCPtr<VideoTrack>> m_video_tracks;
 };
 

--- a/Userland/Libraries/LibWeb/HTML/WindowProxy.h
+++ b/Userland/Libraries/LibWeb/HTML/WindowProxy.h
@@ -31,6 +31,8 @@ public:
     virtual JS::ThrowCompletionOr<bool> internal_delete(JS::PropertyKey const&) override;
     virtual JS::ThrowCompletionOr<JS::MarkedVector<JS::Value>> internal_own_property_keys() const override;
 
+    virtual bool may_interfere_with_indexed_property_access() const final { return true; }
+
     JS::GCPtr<Window> window() const { return m_window; }
     void set_window(JS::NonnullGCPtr<Window>);
 


### PR DESCRIPTION
This yields a whopping 28.4% speed-up on the entire Kraken benchmark:

```
Suite    Test                                   Speedup  Old Std Dev (%)    New Std Dev (%)    Old CI               New CI
-------  -----------------------------------  ---------  -----------------  -----------------  -------------------  -------------------
Kraken   ai-astar.js                           1.13818   1.69%              1.64%              6.895094-9.357817    6.994254-7.285441
Kraken   audio-beat-detection.js               1.77504   1.76%              1.90%              6.809037-9.358706    4.446562-4.661837
Kraken   audio-dft.js                          1.31805   2.04%              1.63%              3.818871-5.534287    3.476439-3.619786
Kraken   audio-fft.js                          1.7694    1.54%              1.26%              6.801070-8.987318    4.391961-4.531061
Kraken   audio-oscillator.js                   1.26269   1.62%              0.86%              4.939566-6.628330    4.531766-4.629531
Kraken   imaging-darkroom.js                   1.11313   0.19%              1.25%              8.731798-9.027524    7.852906-8.101483
Kraken   imaging-desaturate.js                 2.06749   0.71%              0.72%              14.164275-16.095920  7.252836-7.383335
Kraken   imaging-gaussian-blur.js              1.1042    0.22%              0.98%              39.010538-40.619829  35.620032-36.495923
Kraken   json-parse-financial.js               1.0143    1.90%              1.36%              0.095537-0.134762    0.111609-0.115443
Kraken   json-stringify-tinderbox.js           0.974902  0.48%              2.80%              0.214363-0.233648    0.221786-0.237759
Kraken   stanford-crypto-aes.js                1.23012   0.42%              0.67%              2.368331-2.554190    1.984222-2.017433
Kraken   stanford-crypto-ccm.js                1.19605   0.42%              1.17%              1.728458-1.864284    1.480088-1.523744
Kraken   stanford-crypto-pbkdf2.js             1.12203   0.43%              0.81%              4.210273-4.548810    3.863852-3.942592
Kraken   stanford-crypto-sha256-iterative.js   1.09494   0.93%              0.18%              1.339491-1.583566    1.331746-1.337854
Kraken   Total                                 1.28453
```