### PR TITLE
LibTLS: Don't attempt to read past EOF when parsing TBSCertificate

### DIFF
--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -655,6 +655,7 @@ if (BUILD_LAGOM)
 
         # LibTLS needs a special working directory to find cacert.pem
         lagom_test(../../Tests/LibTLS/TestTLSHandshake.cpp LibTLS LIBS LibTLS LibCrypto)
+        lagom_test(../../Tests/LibTLS/TestTLSCertificateParser.cpp LibTLS LIBS LibTLS)
 
         # The FLAC tests need a special working directory to find the test files
         lagom_test(../../Tests/LibAudio/TestFLACSpec.cpp LIBS LibAudio WORKING_DIRECTORY "${FLAC_TEST_PATH}/..")

--- a/Tests/LibTLS/CMakeLists.txt
+++ b/Tests/LibTLS/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(TEST_SOURCES
+    TestTLSCertificateParser.cpp
     TestTLSHandshake.cpp
 )
 

--- a/Tests/LibTLS/TestTLSCertificateParser.cpp
+++ b/Tests/LibTLS/TestTLSCertificateParser.cpp
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2023, Tim Ledbetter  <timledbetter@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibTLS/Certificate.h>
+#include <LibTest/TestCase.h>
+
+TEST_CASE(certificate_with_malformed_tbscertificate_should_fail_gracefully)
+{
+    Array<u8, 4> invalid_certificate_data { 0xB0, 0x02, 0x70, 0x00 };
+    auto parse_result = TLS::Certificate::parse_certificate(invalid_certificate_data);
+    EXPECT(parse_result.is_error());
+}


### PR DESCRIPTION
This allows the decoder to fail gracefully when reading a partial or malformed TBSCertificate. We also now ensure that the certificate data is valid before making a copy of it.

This fixes oss fuzz issue [62026](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=62026)

Tested by feeding the fuzzer test case into the following program:

```c++
#include <LibMain/Main.h>
#include <LibTLS/Certificate.h>

ErrorOr<int> serenity_main(Main::Arguments)
{
    auto stdin = TRY(Core::File::standard_input());
    auto data = TRY(stdin->read_until_eof());
    TRY(TLS::Certificate::parse_certificate(data));
    return 0;
}
```