### PR TITLE
LibHTTP: Return an error if HTTP request URL is not valid UTF-8

### DIFF
--- a/Userland/Libraries/LibHTTP/HttpRequest.h
+++ b/Userland/Libraries/LibHTTP/HttpRequest.h
@@ -22,7 +22,8 @@ public:
         RequestTooLarge,
         RequestIncomplete,
         OutOfMemory,
-        UnsupportedMethod
+        UnsupportedMethod,
+        InvalidURL
     };
 
     static StringView parse_error_to_string(ParseError error)


### PR DESCRIPTION
This fixes oss fuzz issue [62046](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=62046)

Tested by feeding the fuzzer test case into the following program:

```c++
#include <LibMain/Main.h>
#include <LibHTTP/HttpRequest.h>

ErrorOr<int> serenity_main(Main::Arguments)
{
    auto stdin = TRY(Core::File::standard_input());
    auto data = TRY(stdin->read_until_eof());
    auto request_wrapper = HTTP::HttpRequest::from_raw_request(data);
    if (request_wrapper.is_error())
        return Error::from_string_literal("Task failed successfully!");

    auto& request = request_wrapper.value();
    VERIFY(request.method() != HTTP::HttpRequest::Method::Invalid);
    return 0;
}
```