### PR TITLE
LibIMAP: Handle invalid escape sequences in Quoted-Printable parser 

### DIFF
--- a/Tests/LibIMAP/TestQuotedPrintable.cpp
+++ b/Tests/LibIMAP/TestQuotedPrintable.cpp
@@ -46,4 +46,17 @@ TEST_CASE(test_decode)
 
     auto illegal_character_decode = MUST(IMAP::decode_quoted_printable(illegal_character_builder.to_deprecated_string()));
     EXPECT(illegal_character_decode.is_empty());
+
+    // If an escape sequence is invalid the characters are output unaltered. Illegal characters are ignored as usual.
+    decode_equal("="sv, "="sv);
+    decode_equal("=Z"sv, "=Z"sv);
+    decode_equal("=\x7F"sv, "="sv);
+    decode_equal("=\x7F\x7F"sv, "="sv);
+    decode_equal("=A\x7F"sv, "=A"sv);
+    decode_equal("=A"sv, "=A"sv);
+    decode_equal("=AZ"sv, "=AZ"sv);
+    decode_equal("=\r"sv, "=\r"sv);
+    decode_equal("=\r\r"sv, "=\r\r"sv);
+    decode_equal("=\n\r"sv, "=\n\r"sv);
+    decode_equal("=\rA"sv, "=\rA"sv);
 }


### PR DESCRIPTION
This fixes oss fuzz issues: [62064](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=62064), [42993](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=42993) and [40909](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=40909).

Tested by feeding fuzzer test cases into the following program:

```c++
#include <LibMain/Main.h>
#include <LibIMAP/QuotedPrintable.h>

ErrorOr<int> serenity_main(Main::Arguments)
{
    auto stdin = TRY(Core::File::standard_input());
    auto data = TRY(stdin->read_until_eof());
    TRY(IMAP::decode_quoted_printable(data));
    return 0;
}
```