### PR TITLE
3DFileViewer+LibGL+Lib*GPU: Small performance improvements

### DIFF
--- a/Userland/Applications/3DFileViewer/main.cpp
+++ b/Userland/Applications/3DFileViewer/main.cpp
@@ -61,7 +61,7 @@ private:
         m_context = MUST(GL::create_context(*m_bitmap));
         m_framerate_timer = Core::ElapsedTimer::start_new();
 
-        start_timer(20);
+        start_timer(15);
 
         GL::make_context_current(m_context);
         glFrontFace(GL_CCW);

--- a/Userland/Libraries/LibGL/GLContext.cpp
+++ b/Userland/Libraries/LibGL/GLContext.cpp
@@ -169,7 +169,7 @@ void GLContext::gl_end()
         VERIFY_NOT_REACHED();
     }
 
-    m_rasterizer->draw_primitives(primitive_type, model_view_matrix(), projection_matrix(), m_vertex_list);
+    m_rasterizer->draw_primitives(primitive_type, m_vertex_list);
     m_vertex_list.clear_with_capacity();
 }
 
@@ -837,7 +837,8 @@ void GLContext::gl_raster_pos(GLfloat x, GLfloat y, GLfloat z, GLfloat w)
     APPEND_TO_CALL_LIST_AND_RETURN_IF_NEEDED(gl_raster_pos, x, y, z, w);
     RETURN_WITH_ERROR_IF(m_in_draw_state, GL_INVALID_OPERATION);
 
-    m_rasterizer->set_raster_position({ x, y, z, w }, model_view_matrix(), projection_matrix());
+    sync_matrices();
+    m_rasterizer->set_raster_position({ x, y, z, w });
 }
 
 void GLContext::gl_line_width(GLfloat width)
@@ -917,11 +918,12 @@ void GLContext::present()
 
 void GLContext::sync_device_config()
 {
+    sync_clip_planes();
     sync_device_sampler_config();
     sync_device_texture_units();
     sync_light_state();
+    sync_matrices();
     sync_stencil_configuration();
-    sync_clip_planes();
 }
 
 ErrorOr<ByteBuffer> GLContext::build_extension_string()

--- a/Userland/Libraries/LibGL/GLContext.h
+++ b/Userland/Libraries/LibGL/GLContext.h
@@ -242,12 +242,13 @@ public:
     void gl_get_program(GLuint program, GLenum pname, GLint* params);
 
 private:
+    void sync_clip_planes();
     void sync_device_config();
     void sync_device_sampler_config();
     void sync_device_texture_units();
     void sync_light_state();
+    void sync_matrices();
     void sync_stencil_configuration();
-    void sync_clip_planes();
 
     ErrorOr<ByteBuffer> build_extension_string();
 
@@ -298,10 +299,12 @@ private:
     Vector<FloatMatrix4x4> m_model_view_matrix_stack { FloatMatrix4x4::identity() };
     Vector<FloatMatrix4x4>* m_current_matrix_stack { &m_model_view_matrix_stack };
     FloatMatrix4x4* m_current_matrix { &m_current_matrix_stack->last() };
+    bool m_matrices_dirty { true };
 
     ALWAYS_INLINE void update_current_matrix(FloatMatrix4x4 const& new_matrix)
     {
         *m_current_matrix = new_matrix;
+        m_matrices_dirty = true;
 
         if (m_current_matrix_mode == GL_TEXTURE)
             m_texture_units_dirty = true;

--- a/Userland/Libraries/LibGL/Matrix.cpp
+++ b/Userland/Libraries/LibGL/Matrix.cpp
@@ -125,6 +125,7 @@ void GLContext::gl_pop_matrix()
 
     m_current_matrix_stack->take_last();
     m_current_matrix = &m_current_matrix_stack->last();
+    m_matrices_dirty = true;
 }
 
 void GLContext::gl_push_matrix()
@@ -135,6 +136,7 @@ void GLContext::gl_push_matrix()
 
     m_current_matrix_stack->append(*m_current_matrix);
     m_current_matrix = &m_current_matrix_stack->last();
+    m_matrices_dirty = true;
 }
 
 void GLContext::gl_rotate(GLfloat angle, GLfloat x, GLfloat y, GLfloat z)
@@ -165,6 +167,17 @@ void GLContext::gl_translate(GLfloat x, GLfloat y, GLfloat z)
 
     auto translation_matrix = Gfx::translation_matrix(FloatVector3 { x, y, z });
     update_current_matrix(*m_current_matrix * translation_matrix);
+}
+
+void GLContext::sync_matrices()
+{
+    if (!m_matrices_dirty)
+        return;
+
+    m_rasterizer->set_model_view_transform(model_view_matrix());
+    m_rasterizer->set_projection_transform(projection_matrix());
+
+    m_matrices_dirty = false;
 }
 
 }

--- a/Userland/Libraries/LibGL/Vertex.cpp
+++ b/Userland/Libraries/LibGL/Vertex.cpp
@@ -295,7 +295,10 @@ void GLContext::gl_vertex(GLfloat x, GLfloat y, GLfloat z, GLfloat w)
         vertex.tex_coords[i] = m_current_vertex_tex_coord[i];
     vertex.normal = m_current_vertex_normal;
 
-    m_vertex_list.append(vertex);
+    // Optimization: by pulling in the Vector size vs. capacity check, we can always perform an unchecked append
+    if (m_vertex_list.size() == m_vertex_list.capacity())
+        m_vertex_list.grow_capacity(m_vertex_list.size() + 1);
+    m_vertex_list.unchecked_append(vertex);
 }
 
 void GLContext::gl_vertex_pointer(GLint size, GLenum type, GLsizei stride, void const* pointer)

--- a/Userland/Libraries/LibGPU/Device.h
+++ b/Userland/Libraries/LibGPU/Device.h
@@ -39,7 +39,7 @@ public:
 
     virtual DeviceInfo info() const = 0;
 
-    virtual void draw_primitives(PrimitiveType, FloatMatrix4x4 const& model_view_transform, FloatMatrix4x4 const& projection_transform, Vector<Vertex>& vertices) = 0;
+    virtual void draw_primitives(PrimitiveType, Vector<Vertex>& vertices) = 0;
     virtual void resize(Gfx::IntSize min_size) = 0;
     virtual void clear_color(FloatVector4 const&) = 0;
     virtual void clear_depth(DepthType) = 0;
@@ -59,6 +59,8 @@ public:
     virtual NonnullRefPtr<Image> create_image(PixelFormat const&, u32 width, u32 height, u32 depth, u32 max_levels) = 0;
     virtual ErrorOr<NonnullRefPtr<Shader>> create_shader(IR::Shader const&) = 0;
 
+    virtual void set_model_view_transform(FloatMatrix4x4 const&) = 0;
+    virtual void set_projection_transform(FloatMatrix4x4 const&) = 0;
     virtual void set_sampler_config(unsigned, SamplerConfig const&) = 0;
     virtual void set_light_state(unsigned, Light const&) = 0;
     virtual void set_material_state(Face, Material const&) = 0;
@@ -68,7 +70,7 @@ public:
 
     virtual RasterPosition raster_position() const = 0;
     virtual void set_raster_position(RasterPosition const& raster_position) = 0;
-    virtual void set_raster_position(FloatVector4 const& position, FloatMatrix4x4 const& model_view_transform, FloatMatrix4x4 const& projection_transform) = 0;
+    virtual void set_raster_position(FloatVector4 const& position) = 0;
 
     virtual void bind_fragment_shader(RefPtr<Shader>) = 0;
 };

--- a/Userland/Libraries/LibSoftGPU/Clipper.cpp
+++ b/Userland/Libraries/LibSoftGPU/Clipper.cpp
@@ -76,6 +76,10 @@ FLATTEN static void clip_plane(Vector<GPU::Vertex>& input_list, Vector<GPU::Vert
     if (input_list_size == 0)
         return;
 
+    // Ensure we can perform unchecked appends in the loop below
+    if (input_list_size * 2 > output_list.capacity())
+        output_list.ensure_capacity(input_list_size * 2);
+
     auto const* prev_vec = &input_list.data()[0];
     auto is_prev_point_within_plane = point_within_plane<plane>(*prev_vec, clip_plane);
 
@@ -84,10 +88,10 @@ FLATTEN static void clip_plane(Vector<GPU::Vertex>& input_list, Vector<GPU::Vert
         auto const is_curr_point_within_plane = point_within_plane<plane>(curr_vec, clip_plane);
 
         if (is_curr_point_within_plane != is_prev_point_within_plane)
-            output_list.append(clip_intersection_point<plane>(*prev_vec, curr_vec, clip_plane));
+            output_list.unchecked_append(clip_intersection_point<plane>(*prev_vec, curr_vec, clip_plane));
 
         if (is_curr_point_within_plane)
-            output_list.append(curr_vec);
+            output_list.unchecked_append(curr_vec);
 
         prev_vec = &curr_vec;
         is_prev_point_within_plane = is_curr_point_within_plane;

--- a/Userland/Libraries/LibSoftGPU/Device.cpp
+++ b/Userland/Libraries/LibSoftGPU/Device.cpp
@@ -766,6 +766,9 @@ Device::Device(Gfx::IntSize size)
 {
     m_options.scissor_box = m_frame_buffer->rect();
     m_options.viewport = m_frame_buffer->rect();
+
+    // Ensure we can always append 3 vertices unchecked
+    m_clipped_vertices.ensure_capacity(3);
 }
 
 GPU::DeviceInfo Device::info() const
@@ -1112,9 +1115,9 @@ void Device::draw_primitives(GPU::PrimitiveType primitive_type, Vector<GPU::Vert
     // Clip triangles
     for (auto& triangle : m_triangle_list) {
         m_clipped_vertices.clear_with_capacity();
-        m_clipped_vertices.append(triangle.vertices[0]);
-        m_clipped_vertices.append(triangle.vertices[1]);
-        m_clipped_vertices.append(triangle.vertices[2]);
+        m_clipped_vertices.unchecked_append(triangle.vertices[0]);
+        m_clipped_vertices.unchecked_append(triangle.vertices[1]);
+        m_clipped_vertices.unchecked_append(triangle.vertices[2]);
         m_clipper.clip_triangle_against_frustum(m_clipped_vertices);
 
         if (m_clip_planes.size() > 0)

--- a/Userland/Libraries/LibSoftGPU/Device.h
+++ b/Userland/Libraries/LibSoftGPU/Device.h
@@ -26,6 +26,7 @@
 #include <LibGPU/TextureUnitConfiguration.h>
 #include <LibGPU/Vertex.h>
 #include <LibGfx/Bitmap.h>
+#include <LibGfx/Matrix3x3.h>
 #include <LibGfx/Matrix4x4.h>
 #include <LibGfx/Rect.h>
 #include <LibGfx/Vector4.h>
@@ -48,7 +49,7 @@ public:
 
     virtual GPU::DeviceInfo info() const override;
 
-    virtual void draw_primitives(GPU::PrimitiveType, FloatMatrix4x4 const& model_view_transform, FloatMatrix4x4 const& projection_transform, Vector<GPU::Vertex>& vertices) override;
+    virtual void draw_primitives(GPU::PrimitiveType, Vector<GPU::Vertex>& vertices) override;
     virtual void resize(Gfx::IntSize min_size) override;
     virtual void clear_color(FloatVector4 const&) override;
     virtual void clear_depth(GPU::DepthType) override;
@@ -68,6 +69,8 @@ public:
     virtual NonnullRefPtr<GPU::Image> create_image(GPU::PixelFormat const&, u32 width, u32 height, u32 depth, u32 max_levels) override;
     virtual ErrorOr<NonnullRefPtr<GPU::Shader>> create_shader(GPU::IR::Shader const&) override;
 
+    virtual void set_model_view_transform(FloatMatrix4x4 const&) override;
+    virtual void set_projection_transform(FloatMatrix4x4 const&) override;
     virtual void set_sampler_config(unsigned, GPU::SamplerConfig const&) override;
     virtual void set_light_state(unsigned, GPU::Light const&) override;
     virtual void set_material_state(GPU::Face, GPU::Material const&) override;
@@ -77,7 +80,7 @@ public:
 
     virtual GPU::RasterPosition raster_position() const override { return m_raster_position; }
     virtual void set_raster_position(GPU::RasterPosition const& raster_position) override;
-    virtual void set_raster_position(FloatVector4 const& position, FloatMatrix4x4 const& model_view_transform, FloatMatrix4x4 const& projection_transform) override;
+    virtual void set_raster_position(FloatVector4 const& position) override;
 
     virtual void bind_fragment_shader(RefPtr<GPU::Shader>) override;
 
@@ -105,6 +108,9 @@ private:
 
     RefPtr<FrameBuffer<GPU::ColorType, GPU::DepthType, GPU::StencilType>> m_frame_buffer {};
     GPU::RasterizerOptions m_options;
+    FloatMatrix4x4 m_model_view_transform;
+    FloatMatrix3x3 m_normal_transform;
+    FloatMatrix4x4 m_projection_transform;
     GPU::LightModelParameters m_lighting_model;
     Clipper m_clipper;
     Vector<Triangle> m_triangle_list;

--- a/Userland/Libraries/LibVirtGPU/Device.cpp
+++ b/Userland/Libraries/LibVirtGPU/Device.cpp
@@ -193,7 +193,7 @@ void Device::encode_constant_buffer(Gfx::FloatMatrix4x4 const& matrix, Vector<fl
     }
 }
 
-void Device::draw_primitives(GPU::PrimitiveType primitive_type, FloatMatrix4x4 const& modelview_matrix, FloatMatrix4x4 const& projection_matrix, Vector<GPU::Vertex>& vertices)
+void Device::draw_primitives(GPU::PrimitiveType primitive_type, Vector<GPU::Vertex>& vertices)
 {
     // Transform incoming vertices to our own format.
     m_vertices.clear_with_capacity();
@@ -211,7 +211,7 @@ void Device::draw_primitives(GPU::PrimitiveType primitive_type, FloatMatrix4x4 c
     // Compute combined transform matrix
     // Flip the y axis. This is done because OpenGLs coordinate space has a Y-axis of
     // Opposite direction to that of LibGfx
-    auto combined_matrix = (Gfx::scale_matrix(FloatVector3 { 1, -1, 1 }) * projection_matrix * modelview_matrix).transpose();
+    auto combined_matrix = (Gfx::scale_matrix(FloatVector3 { 1, -1, 1 }) * m_projection_transform * m_model_view_transform).transpose();
     encode_constant_buffer(combined_matrix, m_constant_buffer_data);
 
     // Create command buffer
@@ -372,6 +372,16 @@ ErrorOr<NonnullRefPtr<GPU::Shader>> Device::create_shader(GPU::IR::Shader const&
     return adopt_ref(*new Shader(this));
 }
 
+void Device::set_model_view_transform(Gfx::FloatMatrix4x4 const& model_view_transform)
+{
+    m_model_view_transform = model_view_transform;
+}
+
+void Device::set_projection_transform(Gfx::FloatMatrix4x4 const& projection_transform)
+{
+    m_projection_transform = projection_transform;
+}
+
 void Device::set_sampler_config(unsigned, GPU::SamplerConfig const&)
 {
     dbgln("VirtGPU::Device::set_sampler_config(): unimplemented");
@@ -413,7 +423,7 @@ void Device::set_raster_position(GPU::RasterPosition const&)
     dbgln("VirtGPU::Device::set_raster_position(): unimplemented");
 }
 
-void Device::set_raster_position(FloatVector4 const&, FloatMatrix4x4 const&, FloatMatrix4x4 const&)
+void Device::set_raster_position(FloatVector4 const&)
 {
     dbgln("VirtGPU::Device::set_raster_position(): unimplemented");
 }

--- a/Userland/Libraries/LibVirtGPU/Device.h
+++ b/Userland/Libraries/LibVirtGPU/Device.h
@@ -26,7 +26,7 @@ public:
 
     virtual GPU::DeviceInfo info() const override;
 
-    virtual void draw_primitives(GPU::PrimitiveType, FloatMatrix4x4 const& model_view_transform, FloatMatrix4x4 const& projection_transform, Vector<GPU::Vertex>& vertices) override;
+    virtual void draw_primitives(GPU::PrimitiveType, Vector<GPU::Vertex>& vertices) override;
     virtual void resize(Gfx::IntSize min_size) override;
     virtual void clear_color(FloatVector4 const&) override;
     virtual void clear_depth(GPU::DepthType) override;
@@ -46,6 +46,8 @@ public:
     virtual NonnullRefPtr<GPU::Image> create_image(GPU::PixelFormat const&, u32 width, u32 height, u32 depth, u32 max_levels) override;
     virtual ErrorOr<NonnullRefPtr<GPU::Shader>> create_shader(GPU::IR::Shader const&) override;
 
+    virtual void set_model_view_transform(FloatMatrix4x4 const&) override;
+    virtual void set_projection_transform(FloatMatrix4x4 const&) override;
     virtual void set_sampler_config(unsigned, GPU::SamplerConfig const&) override;
     virtual void set_light_state(unsigned, GPU::Light const&) override;
     virtual void set_material_state(GPU::Face, GPU::Material const&) override;
@@ -55,7 +57,7 @@ public:
 
     virtual GPU::RasterPosition raster_position() const override;
     virtual void set_raster_position(GPU::RasterPosition const& raster_position) override;
-    virtual void set_raster_position(FloatVector4 const& position, FloatMatrix4x4 const& model_view_transform, FloatMatrix4x4 const& projection_transform) override;
+    virtual void set_raster_position(FloatVector4 const& position) override;
 
     virtual void bind_fragment_shader(RefPtr<GPU::Shader>) override;
 
@@ -66,6 +68,9 @@ private:
     ErrorOr<void> upload_command_buffer(Vector<u32> const&);
 
     NonnullOwnPtr<Core::File> m_gpu_file;
+
+    FloatMatrix4x4 m_model_view_transform;
+    FloatMatrix4x4 m_projection_transform;
 
     Protocol::ResourceID m_vbo_resource_id { 0 };
     Protocol::ResourceID m_drawtarget { 0 };


### PR DESCRIPTION
* 3DFileViewer: Show the correct frame rate, try to run at 60 FPS
* LibGL+Lib*GPU: Optimize normal transformation calculation
* LibGL & LibSoftGPU: Optimize vertex appends by performing safe unchecked appends

On my machine this yields some small FPS improvements:

| Game | Old FPS | New FPS |
| --- | --- | ---
| glquake | 20.4 | 21.4 (+5%) |
| quake3 | 10.7 | 11.1 (+4%) |
| tuxracer | 25.6 | 26.1 (+2%) |
