### PR TITLE
LibGfx/JPEGWriter: Fix crash on macOS when csize coefficient is 0

### DIFF
--- a/Tests/LibWeb/Text/expected/canvas/export.txt
+++ b/Tests/LibWeb/Text/expected/canvas/export.txt
@@ -1,1 +1,2 @@
 1. "image/png"
+2. "image/jpeg"

--- a/Tests/LibWeb/Text/input/canvas/export.html
+++ b/Tests/LibWeb/Text/input/canvas/export.html
@@ -13,10 +13,9 @@
         });
 
         // 2. Export a canvas to JPEG data URL
-        // FIXME: This fails on macOS: https://github.com/SerenityOS/serenity/issues/21108
-        // testPart(() => {
-        //     const canvas = document.createElement('canvas');
-        //     return canvas.toDataURL('image/jpeg').substring(5, 15);
-        // });
+        testPart(() => {
+            const canvas = document.createElement('canvas');
+            return canvas.toDataURL('image/jpeg').substring(5, 15);
+        });
     });
 </script>

--- a/Userland/Libraries/LibGfx/ImageFormats/JPEGWriter.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEGWriter.cpp
@@ -326,6 +326,10 @@ private:
     static u8 csize(i16 coefficient)
     {
         VERIFY(coefficient >= -2047 && coefficient <= 2047);
+
+        if (coefficient == 0)
+            return 0;
+
         return floor(log2(abs(coefficient))) + 1;
     }
 


### PR DESCRIPTION
This fixes #21108