### PR TITLE
Meta: Manually redirect CI serial output to stdout

### DIFF
--- a/Documentation/RunningTests.md
+++ b/Documentation/RunningTests.md
@@ -106,7 +106,7 @@ SystemModes=self-test
 ```
 
 `/dev/ttyS0` is used as stdio because that serial port is connected when qemu is run with `-display none` and
-`-nographic`, and output to it will show up in the stdout of the qemu window. Separately, the CI run script redirects
+`-serial mon:stdio`, and output to it will show up in the stdout of the qemu window. Separately, the CI run script redirects
 the serial debug output to `./debug.log` so that both stdout of the tests and the dbgln from the kernel/tests can be
 captured.
 

--- a/Meta/run.sh
+++ b/Meta/run.sh
@@ -518,7 +518,7 @@ elif [ "$SERENITY_RUN" = "ci" ]; then
             -M raspi3b \
             -d guest_errors \
             -no-reboot \
-            -nographic \
+            -serial mon:stdio \
             -monitor none \
             -display none \
             -serial file:debug.log \
@@ -536,7 +536,7 @@ elif [ "$SERENITY_RUN" = "ci" ]; then
             -no-reboot \
             -smp ${SERENITY_CPUS} \
             -device ich9-ahci \
-            -nographic \
+            -serial mon:stdio \
             -display none \
             -debugcon file:debug.log \
             $SERENITY_KERNEL_AND_INITRD \


### PR DESCRIPTION
`-nographic` additionally reconfigures the Terminal, which clears the previous scrollback and (ocasionally) breaks line wrapping. This is probably not something that we want, so only ask for the redirection behavior.