### PR TITLE
pkg+Shell: Extract data from a locally available port's package.sh

### DIFF
--- a/Userland/Shell/Shell.cpp
+++ b/Userland/Shell/Shell.cpp
@@ -578,10 +578,6 @@ Optional<DeprecatedString> Shell::help_path_for(Vector<RunnablePath> visited, Sh
 
 int Shell::run_command(StringView cmd, Optional<SourcePosition> source_position_override)
 {
-    // The default-constructed mode of the shell
-    // should not be used for execution!
-    VERIFY(!m_default_constructed);
-
     take_error();
 
     if (!last_return_code.has_value())
@@ -2236,7 +2232,7 @@ void Shell::notify_child_event()
 }
 
 Shell::Shell()
-    : m_default_constructed(true)
+    : m_is_interactive(false)
 {
     push_frame("main", LocalFrameKind::FunctionOrGlobal).leak_frame();
 
@@ -2336,9 +2332,6 @@ Shell::~Shell()
 
 void Shell::destroy()
 {
-    if (m_default_constructed)
-        return;
-
     stop_all_jobs();
     if (!m_is_interactive)
         return;

--- a/Userland/Shell/Shell.cpp
+++ b/Userland/Shell/Shell.cpp
@@ -2231,8 +2231,9 @@ void Shell::notify_child_event()
     }
 }
 
-Shell::Shell()
+Shell::Shell(bool posix_mode)
     : m_is_interactive(false)
+    , m_in_posix_mode(posix_mode)
 {
     push_frame("main", LocalFrameKind::FunctionOrGlobal).leak_frame();
 

--- a/Userland/Shell/Shell.cpp
+++ b/Userland/Shell/Shell.cpp
@@ -615,7 +615,8 @@ int Shell::run_command(StringView cmd, Optional<SourcePosition> source_position_
         return 1;
     }
 
-    tcgetattr(0, &termios);
+    if (m_is_interactive)
+        tcgetattr(0, &termios);
 
     (void)command->run(*this);
 
@@ -1132,7 +1133,8 @@ void Shell::restore_ios()
 {
     if (m_is_subshell)
         return;
-    tcsetattr(0, TCSANOW, &termios);
+    if (m_is_interactive)
+        tcsetattr(0, TCSANOW, &termios);
     tcsetpgrp(STDOUT_FILENO, m_pid);
     tcsetpgrp(STDIN_FILENO, m_pid);
 }

--- a/Userland/Shell/Shell.h
+++ b/Userland/Shell/Shell.h
@@ -507,8 +507,6 @@ private:
 
     RefPtr<Line::Editor> m_editor;
 
-    bool m_default_constructed { false };
-
     mutable bool m_last_continuation_state { false }; // false == not needed.
 
     Optional<size_t> m_history_autosave_time;

--- a/Userland/Shell/Shell.h
+++ b/Userland/Shell/Shell.h
@@ -414,7 +414,7 @@ public:
 
 private:
     Shell(Line::Editor&, bool attempt_interactive, bool posix_mode = false);
-    Shell();
+    Shell(bool posix_mode = false);
     virtual ~Shell() override;
 
     void destroy();

--- a/Userland/Shell/Shell.h
+++ b/Userland/Shell/Shell.h
@@ -332,9 +332,9 @@ public:
     bool was_interrupted { false };
     bool was_resized { false };
 
-    DeprecatedString cwd;
-    DeprecatedString username;
-    DeprecatedString home;
+    DeprecatedString cwd { "" };
+    DeprecatedString username { "" };
+    DeprecatedString home { "" };
 
     constexpr static auto TTYNameSize = 32;
     constexpr static auto HostNameSize = 64;

--- a/Userland/Utilities/pkg/AvailablePort.cpp
+++ b/Userland/Utilities/pkg/AvailablePort.cpp
@@ -20,6 +20,7 @@
 #include <LibProtocol/RequestClient.h>
 
 #include "AvailablePort.h"
+#include "BuildablePort.h"
 #include "MarkdownTableFinder.h"
 
 #include <Shell/AST.h>
@@ -59,7 +60,16 @@ ErrorOr<int> AvailablePort::query_details_for_package(HashMap<String, AvailableP
             outln("Yes");
         else
             outln("No");
+
+        auto result = BuildablePort::from_available_port(available_port);
+        if (result.is_error()) {
+            warnln("pkg: error in port script: {}", result.release_error());
+        } else {
+            auto buildable_port = result.release_value();
+            outln("    Dependencies: {}", buildable_port.dependencies());
+        }
     }
+
     return 0;
 }
 

--- a/Userland/Utilities/pkg/AvailablePort.h
+++ b/Userland/Utilities/pkg/AvailablePort.h
@@ -8,6 +8,7 @@
 
 #include "InstalledPort.h"
 #include <AK/HashMap.h>
+#include <AK/LexicalPath.h>
 #include <AK/String.h>
 #include <AK/StringView.h>
 #include <AK/Types.h>
@@ -19,7 +20,7 @@ public:
     static ErrorOr<int> update_available_ports_list_file();
 
     AvailablePort(String name, String version, String website)
-        : m_name(name)
+        : m_name(move(name))
         , m_website(move(website))
         , m_version(move(version))
     {
@@ -28,6 +29,7 @@ public:
     StringView name() const { return m_name.bytes_as_string_view(); }
     StringView version() const { return m_version.bytes_as_string_view(); }
     StringView website() const { return m_website.bytes_as_string_view(); }
+    LexicalPath local_port_root() const { return { LexicalPath::join("/usr/Ports"sv, m_name) }; }
 
 private:
     String m_name;

--- a/Userland/Utilities/pkg/BuildablePort.cpp
+++ b/Userland/Utilities/pkg/BuildablePort.cpp
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2023, kleines Filmröllchen <filmroellchen@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "BuildablePort.h"
+#include <AK/LexicalPath.h>
+#include <AK/NonnullRefPtr.h>
+#include <LibCore/File.h>
+#include <LibCore/System.h>
+#include <LibCrypto/BigInt/UnsignedBigInteger.h>
+#include <LibCrypto/Hash/SHA2.h>
+#include <LibFileSystem/FileSystem.h>
+#include <LibLine/Editor.h>
+#include <Shell/AST.h>
+#include <Shell/NodeVisitor.h>
+#include <Shell/Parser.h>
+#include <Shell/PosixParser.h>
+#include <Shell/Shell.h>
+#include <unistd.h>
+
+static ErrorOr<Vector<PortInputFile>> parse_file_list(Span<String> raw_file_list)
+{
+    Vector<PortInputFile> file_list;
+    file_list.ensure_capacity(raw_file_list.size());
+
+    for (auto const& raw_file : raw_file_list) {
+        auto url = URL { raw_file };
+        if (!url.is_valid())
+            return Error::from_string_view("Invalid input file URL"sv);
+
+        auto maybe_fragment = url.fragment();
+        if (!maybe_fragment.has_value())
+            return Error::from_string_view("Input file is missing a hash or git revision"sv);
+        auto fragment = maybe_fragment.release_value();
+
+        if (url.scheme() == "https" || url.scheme() == "http") {
+            auto bigint_hash = Crypto::UnsignedBigInteger::from_base(16, fragment);
+            VERIFY(bigint_hash.length() * Crypto::UnsignedBigInteger::BITS_IN_WORD / 8 == Crypto::Hash::SHA256::digest_size());
+            Crypto::Hash::SHA256::DigestType hash;
+            bigint_hash.export_data({ &hash.data, hash.data_length() });
+            url.set_fragment({});
+            file_list.append({ .url = move(url), .type_specific_info = PortInputFile::HTTPInfo { hash } });
+        } else if (url.scheme() == "git+https") {
+            url.set_fragment({});
+            url.set_scheme("https"_string);
+            file_list.append({ .url = move(url), .type_specific_info = PortInputFile::GitInfo { move(fragment) } });
+        } else {
+            return Error::from_string_view("Unsupported input file scheme"sv);
+        }
+    }
+
+    return file_list;
+}
+
+ErrorOr<BuildablePort> BuildablePort::from_available_port(AvailablePort const& port)
+{
+    auto port_root = port.local_port_root();
+    if (!FileSystem::is_directory(port_root.string()))
+        return Error::from_string_view("Port is not available in the local file system"sv);
+
+    auto package_base_path = LexicalPath::join(port_root.string(), "package.sh"sv);
+    if (!FileSystem::exists(package_base_path.string()))
+        return Error::from_string_view("Port is missing a package.sh script, it may be an empty directory"sv);
+
+    auto shell = Shell::Shell::construct(true);
+    {
+        // FIXME: Find a nicer way of disabling Shell's output.
+        auto old_stdout = TRY(Core::System::dup(STDOUT_FILENO));
+        auto old_stderr = TRY(Core::System::dup(STDERR_FILENO));
+        auto null_device = TRY(Core::System::open("/dev/null"sv, O_RDWR));
+        TRY(Core::System::dup2(null_device, STDOUT_FILENO));
+        TRY(Core::System::dup2(null_device, STDERR_FILENO));
+        ScopeGuard restore_stdio { [&] {
+            MUST(Core::System::dup2(old_stdout, STDOUT_FILENO));
+            MUST(Core::System::dup2(old_stderr, STDERR_FILENO));
+        } };
+
+        auto was_successful = shell->run_file(package_base_path.string());
+        if (!was_successful)
+            return Error::from_string_view("Port package.sh couldn't be executed."sv);
+    }
+
+    BuildablePort buildable_port;
+    buildable_port.m_absolute_path = port_root;
+
+    buildable_port.m_name = TRY(String::from_deprecated_string(TRY(shell->local_variable_or("port"sv, ""))));
+    if (buildable_port.m_name.is_empty())
+        return Error::from_string_view("Port name is not a string"sv);
+
+    buildable_port.m_version = TRY(String::from_deprecated_string(TRY(shell->local_variable_or("version"sv, ""))));
+    if (buildable_port.m_version.is_empty())
+        return Error::from_string_view("Port version is not a string"sv);
+
+    // Dependencies and files list are not required, unlike version and port name.
+    auto dependencies = TRY(shell->look_up_local_variable("depends"sv));
+    if (dependencies != nullptr && dependencies->is_list())
+        buildable_port.m_dependencies = TRY(const_cast<Shell::AST::Value&>(*dependencies).resolve_as_list(shell));
+
+    auto files = TRY(shell->look_up_local_variable("files"sv));
+    if (files != nullptr && files->is_list())
+        buildable_port.m_input_files = TRY(parse_file_list(TRY(const_cast<Shell::AST::Value&>(*files).resolve_as_list(shell))));
+
+    return buildable_port;
+}

--- a/Userland/Utilities/pkg/BuildablePort.h
+++ b/Userland/Utilities/pkg/BuildablePort.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2023, kleines Filmröllchen <filmroellchen@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include "AvailablePort.h"
+#include <AK/LexicalPath.h>
+#include <AK/String.h>
+#include <AK/URL.h>
+#include <AK/Utf8View.h>
+#include <AK/Variant.h>
+#include <LibCrypto/Hash/SHA2.h>
+
+struct PortInputFile {
+    URL url;
+
+    struct GitInfo {
+        String revision;
+    };
+    struct HTTPInfo {
+        Crypto::Hash::SHA256::DigestType hash;
+    };
+
+    Variant<GitInfo, HTTPInfo> type_specific_info;
+
+    bool is_git() const { return type_specific_info.has<GitInfo>(); }
+    bool is_http() const { return type_specific_info.has<HTTPInfo>(); }
+};
+
+class BuildablePort {
+public:
+    // Requires the port to be downloaded and accessible locally.
+    static ErrorOr<BuildablePort> from_available_port(AvailablePort const& port);
+
+    Utf8View name() const { return m_name.code_points(); }
+    Utf8View version() const { return m_version.code_points(); }
+    ReadonlySpan<String> dependencies() const { return m_dependencies.span(); }
+    ReadonlySpan<PortInputFile> input_files() const { return m_input_files.span(); }
+
+private:
+    BuildablePort() = default;
+
+    String m_name;
+    LexicalPath m_absolute_path { "" };
+    String m_version;
+    Vector<String> m_dependencies;
+    Vector<PortInputFile> m_input_files;
+};
+
+namespace AK {
+
+template<>
+struct Formatter<PortInputFile> : Formatter<StringView> {
+    ErrorOr<void> format(FormatBuilder& builder, PortInputFile const& property_descriptor)
+    {
+        return Formatter<StringView>::format(builder,
+            TRY(String::formatted("{} ({})", property_descriptor.url,
+                TRY(property_descriptor.type_specific_info.visit(
+                    [](PortInputFile::GitInfo const& info) { return String::formatted("Git, rev {}", info.revision); },
+                    [](PortInputFile::HTTPInfo const& info) { return String::formatted("HTTP, SHA256 {}", info.hash); })))));
+    }
+};
+
+}

--- a/Userland/Utilities/pkg/CMakeLists.txt
+++ b/Userland/Utilities/pkg/CMakeLists.txt
@@ -7,9 +7,10 @@ serenity_component(
 
 set(SOURCES
     AvailablePort.cpp
+    BuildablePort.cpp
     InstalledPort.cpp
     main.cpp
 )
 
 serenity_app(PackageManager ICON app-assistant)
-target_link_libraries(PackageManager PRIVATE LibCore LibMain LibFileSystem LibProtocol LibHTTP LibMarkdown LibShell)
+target_link_libraries(PackageManager PRIVATE LibCore LibMain LibFileSystem LibProtocol LibHTTP LibMarkdown LibShell LibLine LibCrypto)

--- a/Userland/Utilities/pkg/main.cpp
+++ b/Userland/Utilities/pkg/main.cpp
@@ -35,6 +35,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::unveil("/res"sv, "r"sv));
     TRY(Core::System::unveil("/usr/lib"sv, "r"sv));
     TRY(Core::System::unveil("/etc/passwd"sv, "r"sv));
+    TRY(Core::System::unveil("/dev/null"sv, "rw"sv));
     TRY(Core::System::unveil(nullptr, nullptr));
 
     bool verbose = false;

--- a/Userland/Utilities/pkg/main.cpp
+++ b/Userland/Utilities/pkg/main.cpp
@@ -25,6 +25,8 @@ static void print_port_details(InstalledPort const& port)
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
+    // It is particularly important to prevent pkg from having exec permissions and a large veil,
+    // since it partially executes untrusted package.sh scripts.
     TRY(Core::System::pledge("stdio recvfd thread unix rpath cpath wpath"));
 
     TRY(Core::System::unveil("/tmp/session/%sid/portal/request", "rw"));
@@ -32,6 +34,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::unveil("/usr/Ports"sv, "rwc"sv));
     TRY(Core::System::unveil("/res"sv, "r"sv));
     TRY(Core::System::unveil("/usr/lib"sv, "r"sv));
+    TRY(Core::System::unveil("/etc/passwd"sv, "r"sv));
     TRY(Core::System::unveil(nullptr, nullptr));
 
     bool verbose = false;


### PR DESCRIPTION
##### Before you scream "but arbitrary code execution!", read some of the arguments below.

This allows pkg to read various data from package.sh; for now we only display the dependency list. To allow us to execute Shell in-process properly, some small adjustments there are needed.

---

### Shell: Default-construct cwd, username and home to a non-null string

If we can't access /etc/passwd, avoid crashing in setenv().

### Shell: Remove default constructed safeguards

As discussed, it appears that there is no issue with using a default
constructed Shell for actual execution work - it's just that it can
never be interactive due to a missing line editor. This is fine for use
cases that embed simple non-interactive shell execution.

### Shell: Only call tcgetattr for interactive shells

Non-interactive shells may not have a terminal attached, and their
processes may not have "tty" pledged. The termios information is not
important without an editor or background jobs anyways.

### Shell: Allow constructing an editor-free shell in POSIX mode

Also makes this kind of shell non-interactive, since you definitely need
a line editor for interactivity.

### pkg: Allow running a shell in-process

With the changes to Shell, this only requires us to pledge /etc/passwd
read-only.

### pkg: Read buildable port data from package.sh

This uses an internal POSIX shell to execute package.sh and extract
relevant variables. Right now, we use it to display dependencies for any
locally-available ports, even ones that are not installed.

This method of reading port data is a huge security burden, but there
are several good arguments why this is (1) the best way and (2) safer
than you might think:
- Just parsing the script is not enough. All ports use some degree of
  string interpolation to determine various properties.
- Executing the script here is a good early indication of whether the
  port is actually installable.
- A non-malicious port script only contains variable and function
  definitions, which are entirely side-effect free.
- Executing a malicious script actually has little danger associated
  with it. pkg is strongly pledged (and if its pledges are relaxed in
  the future, this specific code path can be very strongly pledged
  regardless) and veiled so that a malicious script will quickly crash
  pkg before it can get anywhere. Additionally, pkg doesn't require
  superuser priviledges to perform this action (and should not be run
  with such).
- The Ports directory is not owned by a normal user and therefore a
  malicious package.sh script can only be installed by the superuser. An
  attacker with this access level can compromise the system or an
  individual user more easily than through pkg.
- If the user is actually paranoid about a malicious package.sh slipping
  past SerenityOS code review, they can inspect any package.sh script
  manually before running pkg.
