### PR TITLE
LibGfx/ICC: Avoid overflow when checking tag bounds

### DIFF
--- a/Userland/Libraries/LibGfx/ICC/Profile.cpp
+++ b/Userland/Libraries/LibGfx/ICC/Profile.cpp
@@ -560,7 +560,7 @@ static ErrorOr<NonnullRefPtr<TagData>> read_tag(ReadonlyBytes bytes, u32 offset_
     if (offset_to_beginning_of_tag_data_element % 4 != 0)
         return Error::from_string_literal("ICC::Profile: Tag data not aligned");
 
-    if (offset_to_beginning_of_tag_data_element + size_of_tag_data_element > bytes.size())
+    if (static_cast<u64>(offset_to_beginning_of_tag_data_element) + size_of_tag_data_element > bytes.size())
         return Error::from_string_literal("ICC::Profile: Tag data out of bounds");
 
     auto tag_bytes = bytes.slice(offset_to_beginning_of_tag_data_element, size_of_tag_data_element);


### PR DESCRIPTION
Fixes oss fuzz issues [62030](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=62030), [60281](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=60281) and [57461](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=57461)