### PR TITLE
LibAudio+aconv: Perfect resampling, try two

### DIFF
--- a/AK/Span.h
+++ b/AK/Span.h
@@ -190,6 +190,18 @@ public:
         __builtin_memmove(this->data() + offset, data, data_size);
     }
 
+    ALWAYS_INLINE constexpr void move_to(Span<RemoveConst<T>> other)
+    {
+        VERIFY(other.size() >= size());
+        TypedTransfer<RemoveConst<T>>::move(other.data(), data(), size());
+    }
+
+    ALWAYS_INLINE constexpr void move_trimmed_to(Span<RemoveConst<T>> other)
+    {
+        auto const count = min(size(), other.size());
+        TypedTransfer<RemoveConst<T>>::move(other.data(), data(), count);
+    }
+
     ALWAYS_INLINE constexpr size_t copy_to(Span<RemoveConst<T>> other) const
     {
         VERIFY(other.size() >= size());

--- a/Userland/Libraries/LibAudio/WavWriter.cpp
+++ b/Userland/Libraries/LibAudio/WavWriter.cpp
@@ -52,7 +52,7 @@ ErrorOr<void> WavWriter::write_samples(ReadonlySpan<Sample> samples)
             if (m_num_channels == 2)
                 TRY(m_file->write_value(right));
         }
-        m_data_sz += samples.size() * 2 * sizeof(u8);
+        m_data_sz += samples.size() * m_num_channels * sizeof(u8);
         break;
     }
     case PcmSampleFormat::Int16: {
@@ -64,7 +64,7 @@ ErrorOr<void> WavWriter::write_samples(ReadonlySpan<Sample> samples)
             if (m_num_channels == 2)
                 TRY(m_file->write_value(right));
         }
-        m_data_sz += samples.size() * 2 * sizeof(u16);
+        m_data_sz += samples.size() * m_num_channels * sizeof(u16);
         break;
     }
     default:

--- a/Userland/Libraries/LibAudio/WavWriter.cpp
+++ b/Userland/Libraries/LibAudio/WavWriter.cpp
@@ -46,10 +46,11 @@ ErrorOr<void> WavWriter::write_samples(ReadonlySpan<Sample> samples)
     case PcmSampleFormat::Uint8: {
         constexpr float scale = static_cast<float>(NumericLimits<u8>::max()) * .5f;
         for (auto const& sample : samples) {
-            u8 left = static_cast<u8>((sample.left + 1) * scale);
-            u8 right = static_cast<u8>((sample.right + 1) * scale);
+            u8 left = clip<u8>((sample.left + 1) * scale);
+            u8 right = clip<u8>((sample.right + 1) * scale);
             TRY(m_file->write_value(left));
-            TRY(m_file->write_value(right));
+            if (m_num_channels == 2)
+                TRY(m_file->write_value(right));
         }
         m_data_sz += samples.size() * 2 * sizeof(u8);
         break;
@@ -57,10 +58,11 @@ ErrorOr<void> WavWriter::write_samples(ReadonlySpan<Sample> samples)
     case PcmSampleFormat::Int16: {
         constexpr float scale = static_cast<float>(NumericLimits<i16>::max());
         for (auto const& sample : samples) {
-            u16 left = AK::convert_between_host_and_little_endian(static_cast<i16>(sample.left * scale));
-            u16 right = AK::convert_between_host_and_little_endian(static_cast<i16>(sample.right * scale));
+            u16 left = AK::convert_between_host_and_little_endian(clip<i16>(sample.left * scale));
+            u16 right = AK::convert_between_host_and_little_endian(clip<i16>(sample.right * scale));
             TRY(m_file->write_value(left));
-            TRY(m_file->write_value(right));
+            if (m_num_channels == 2)
+                TRY(m_file->write_value(right));
         }
         m_data_sz += samples.size() * 2 * sizeof(u16);
         break;

--- a/Userland/Libraries/LibAudio/WavWriter.h
+++ b/Userland/Libraries/LibAudio/WavWriter.h
@@ -41,6 +41,16 @@ public:
     void set_sample_format(PcmSampleFormat sample_format) { m_sample_format = sample_format; }
 
 private:
+    template<typename T>
+    T clip(float value)
+    {
+        if (value > NumericLimits<T>::max())
+            return NumericLimits<T>::max();
+        if (value < NumericLimits<T>::min())
+            return NumericLimits<T>::min();
+        return value;
+    }
+
     ErrorOr<void> write_header();
     OwnPtr<Core::File> m_file;
     bool m_finalized { false };

--- a/Userland/Libraries/LibDSP/FIRFilter.h
+++ b/Userland/Libraries/LibDSP/FIRFilter.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2023, Sarsaparilla
+ * Copyright (c) 2023, kleines Filmröllchen <filmroellchen@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/FixedArray.h>
+#include <AK/Noncopyable.h>
+#include <AK/Span.h>
+#include <AK/StdLibExtraDetails.h>
+
+namespace DSP {
+
+template<typename SampleType, typename TapType>
+requires(IsTriviallyMoveConstructible<SampleType>)
+class FIRFilter {
+    AK_MAKE_NONCOPYABLE(FIRFilter);
+
+public:
+    static ErrorOr<FIRFilter> create(Span<TapType> coefficients_span)
+    {
+        auto coefficients = TRY(FixedArray<TapType>::create(coefficients_span.size()));
+        coefficients_span.copy_to(coefficients.span());
+        return create(move(coefficients));
+    }
+
+    static ErrorOr<FIRFilter> create(FixedArray<TapType>&& coefficients)
+    {
+        return FIRFilter(move(coefficients), TRY(FixedArray<SampleType>::create(coefficients.size())));
+    }
+
+    FIRFilter(FIRFilter&& other)
+        : m_coefficients(move(other.m_coefficients))
+        , m_buffer(move(other.m_buffer))
+    {
+    }
+
+    SampleType process(SampleType input)
+    {
+        // This memmove is only defined behavior if the type is trivially moveable, therefore the requires() above.
+        m_buffer.span().move_trimmed_to(m_buffer.span().slice(1));
+        m_buffer.unchecked_at(0) = input;
+
+        SampleType result {};
+        // Indices are known to never be out of range, so unchecked indices allows optimizations to kick in better.
+        for (size_t i = 0; i < m_coefficients.size(); i++)
+            result += m_buffer.unchecked_at(i) * m_coefficients.unchecked_at(i);
+
+        return result;
+    }
+
+private:
+    FIRFilter(FixedArray<TapType>&& coefficients, FixedArray<SampleType>&& buffer)
+        : m_coefficients(move(coefficients))
+        , m_buffer(move(buffer))
+    {
+    }
+
+    FixedArray<TapType> m_coefficients;
+    FixedArray<SampleType> m_buffer;
+};
+
+}

--- a/Userland/Libraries/LibDSP/Resampler.h
+++ b/Userland/Libraries/LibDSP/Resampler.h
@@ -1,0 +1,241 @@
+/*
+ * Copyright (c) 2023, Sarsaparilla
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Array.h>
+#include <AK/Function.h>
+#include <AK/Math.h>
+#include <AK/NumericLimits.h>
+#include <AK/Span.h>
+#include <LibDSP/FIRFilter.h>
+#include <LibDSP/Window.h>
+
+namespace DSP {
+
+constexpr float normalized_sinc(float phi)
+{
+    if (AK::abs(phi) < NumericLimits<float>::epsilon())
+        return 1.0;
+
+    phi *= AK::Pi<float>;
+    return AK::sin(phi) / phi;
+}
+
+struct Sinc {
+    constexpr float operator()(float phi) const { return normalized_sinc(phi); }
+};
+
+// Oversample is the number of lookup values between the taps. The more, the less aliasing noise.
+// TODO: Use something better than linear interpolation so that we can save memory.
+template<size_t sinc_taps_parameter, size_t oversample_parameter>
+struct InterpolatedSinc {
+public:
+    static constexpr size_t sinc_taps = sinc_taps_parameter;
+    static constexpr size_t oversample = oversample_parameter;
+
+    static constexpr float oversample_float = static_cast<float>(oversample);
+
+    // +1 to skip the rounding error buffer tap
+    static constexpr size_t index_offset = (sinc_taps + 1) * oversample;
+
+    // +1 because we want the taps to be the same amount to the left and to the right.
+    // And another +1 because of an additional tap at (-TapCount - 1) to protect against bad lookups
+    // coming from rounding errors.
+    static constexpr size_t sinc_lookup_table_size = (2 * sinc_taps + 2) * oversample;
+    static_assert(sinc_taps <= NumericLimits<ssize_t>::max());
+
+    // FIXME: Make this constexpr once Clang understands constexpr cos().
+    static Array<float, sinc_lookup_table_size> make_sinc_table()
+    {
+        Array<float, sinc_lookup_table_size> sinc_table;
+
+        for (ssize_t k = -static_cast<ssize_t>(sinc_taps) - 1; k <= static_cast<ssize_t>(sinc_taps); k++) {
+            for (size_t i = 0; i < oversample; i++) {
+                float const sinc_index = static_cast<float>(k) + static_cast<float>(i) / oversample_float;
+                size_t const window_index = (k + sinc_taps + 1) * oversample + i;
+                float const window = Window<float>::blackman_harris(window_index, sinc_lookup_table_size);
+                sinc_table[window_index] = normalized_sinc(sinc_index) * window;
+            }
+        }
+
+        return sinc_table;
+    }
+    static inline Array<float, sinc_lookup_table_size> sinc_table { make_sinc_table() };
+
+    float operator()(float phi) const
+    {
+        auto const fraction = phi - static_cast<float>(static_cast<i64>(phi));
+
+        size_t const n = static_cast<size_t>(phi * oversample_float + index_offset);
+
+        // Use check-free indexing since we know the index will always be in range.
+        // That allows various high-impact optimizations (FMA and vectorizations) to kick in.
+        auto const y1 = *sinc_table.span().offset_pointer(n);
+        auto const y2 = *sinc_table.span().offset_pointer(n + 1);
+
+        return y1 + fraction * (y2 - y1);
+    }
+};
+
+template<typename SampleType, typename SincFunctionType>
+requires(IsCallableWithArguments<SincFunctionType, float, float>)
+class SincResampler {
+public:
+    using SincFunction = SincFunctionType;
+
+    SincResampler(float ratio, size_t sinc_taps, FixedArray<SampleType>&& input_buffer, FIRFilter<SampleType, float>&& lowpass)
+        : m_sinc_taps(sinc_taps)
+        , m_ratio(ratio)
+        , m_lowpass(move(lowpass))
+        , m_input_buffer_size(input_buffer.size())
+        , m_input_buffer(move(input_buffer))
+    {
+    }
+
+    static ErrorOr<SincResampler> create(u32 rate_from, u32 rate_to, size_t max_input_buffer_size, size_t sinc_taps, float transition_bandwidth_hz)
+    {
+        float const ratio = rate_from / static_cast<float>(rate_to);
+
+        // Cutoff frequency as a fraction of pi (1/2 is the nyquist frequency)
+        float const cutoff = 1.0f / (2.0f * ratio);
+        float const transition_bandwidth = transition_bandwidth_hz / static_cast<float>(rate_from);
+
+        FIRFilter lowpass = TRY(calculate_lowpass(cutoff, transition_bandwidth));
+
+        // The input buffer is a shifting window over all the input data.
+        // When we shift the window to the right, we have to leave room for the previous
+        // `sinc_taps` number of samples to be multiplied with the left side of the sinc.
+        size_t const input_buffer_size = max_input_buffer_size + 2 * sinc_taps + 1;
+
+        auto input_buffer = TRY(FixedArray<SampleType>::create(input_buffer_size));
+
+        return SincResampler(ratio, sinc_taps, move(input_buffer), move(lowpass));
+    }
+
+    size_t process(ReadonlySpan<SampleType> input, Span<SampleType> output)
+    {
+        auto const total_tap_count = 2 * m_sinc_taps + 1;
+
+        // We need some of the last samples for lookback, since the sinc interpolation considers samples on both sides of the center sample.
+        // Therefore, copy the needed old samples to the start of the buffer, and insert the new samples after that.
+        auto old_data = m_input_buffer.span().slice_from_end(total_tap_count);
+        auto new_data = m_input_buffer.span().slice(total_tap_count, input.size());
+        old_data.move_to(m_input_buffer.span());
+        input.copy_trimmed_to(new_data);
+        m_input_buffer_size = old_data.size() + input.size();
+
+        VERIFY(m_input_buffer_size <= m_input_buffer.size());
+
+        if (m_ratio > 1) {
+            // Band-limit the signal to the target sample rate's Nyquist frequency to prevent aliasing.
+            for (size_t i = 0; i < input.size(); i++)
+                *new_data.offset_pointer(i) = static_cast<SampleType>(m_lowpass.process(*new_data.offset_pointer(i)));
+        }
+
+        // If the "output phase" wrapped around since the last write, we need to write one less sample to the output.
+        // This accounts for the fact that our output write limit is effectively rounded up by nature of sinc_center_index,
+        // and we would start pitch shifting for larger ratios.
+        auto fractional_output_size = static_cast<double>(input.size()) / static_cast<double>(m_ratio);
+        m_output_phase += fractional_output_size - static_cast<size_t>(fractional_output_size);
+        // By default, we remove the rounding up by adding this extra limit to the loop.
+        auto extra_input_limit = m_ratio;
+        if (m_output_phase >= 1) {
+            extra_input_limit = 0;
+            m_output_phase -= 1;
+        }
+
+        size_t samples_written = 0;
+        auto const input_buffer_start_sample_count = static_cast<size_t>(m_processed_sample_count * m_ratio);
+        auto sinc_center_index = m_sinc_taps;
+
+        auto const input_buffer_size_float = m_input_buffer_size;
+        while (static_cast<float>(sinc_center_index + m_sinc_taps + 1) + extra_input_limit < input_buffer_size_float) {
+            // Whittaker–Shannon interpolation formula, a convolution between the input buffer and the sinc kernel.
+            SampleType sum {};
+            for (ssize_t k = -m_sinc_taps; k <= static_cast<ssize_t>(m_sinc_taps); k++)
+                sum += m_input_buffer.unchecked_at(sinc_center_index + k) * sinc_function(m_phase - static_cast<float>(k));
+
+            output[samples_written] = sum;
+
+            samples_written++;
+            m_processed_sample_count++;
+
+            // Current position within the input buffer, may lie between samples.
+            m_phase = m_processed_sample_count * m_ratio;
+            auto const next_sample = static_cast<size_t>(m_phase);
+            // Convert the next sample position to an index matching our current buffer window.
+            sinc_center_index = m_sinc_taps + next_sample - input_buffer_start_sample_count;
+            // Remove the non-fractional part from the phase to reestablish the range [0, 1].
+            m_phase = m_phase - static_cast<float>(next_sample);
+        }
+
+        return samples_written;
+    }
+
+    constexpr float ratio() const { return m_ratio; }
+    constexpr float sinc_taps() const { return m_sinc_taps; }
+
+private:
+    static ErrorOr<FIRFilter<SampleType, float>> calculate_lowpass(float cutoff, float transition_bandwidth)
+    {
+        // The stopband should begin at the cutoff
+        cutoff -= transition_bandwidth;
+
+        // Just a rough estimate
+        size_t taps = AK::round_to<size_t>(4.f / transition_bandwidth);
+        // Make taps symmetrical
+        if (taps % 2 == 0)
+            taps += 1;
+
+        auto coefficients = TRY(FixedArray<float>::create(taps));
+
+        float sum = 0;
+        for (size_t i = 0; i < taps; i++) {
+            float const phi = 2.f * cutoff * (static_cast<float>(i) - static_cast<float>(taps - 1) / 2.f);
+            float const coefficient = normalized_sinc(phi) * Window<float>::blackman_harris(i, taps);
+
+            sum += coefficient;
+            coefficients[i] = coefficient;
+        }
+
+        for (size_t i = 0; i < taps; i++)
+            coefficients[i] /= sum;
+
+        return FIRFilter<SampleType, float>::create(move(coefficients));
+    }
+
+    SincFunction const sinc_function {};
+
+    float m_phase { 0.f };
+    float m_output_phase { 0.f };
+    size_t const m_sinc_taps;
+
+    float const m_ratio;
+    FIRFilter<SampleType, float> m_lowpass;
+
+    size_t m_processed_sample_count { 0 };
+    size_t m_input_buffer_size;
+    FixedArray<SampleType> m_input_buffer;
+};
+
+template<typename SampleType, size_t sinc_taps, size_t oversample>
+using InterpolatedSincResampler = SincResampler<SampleType, InterpolatedSinc<sinc_taps, oversample>>;
+
+// Good parameters for float sample processing.
+// Adapted from: https://ccrma.stanford.edu/~jos/resample/Implementation.html
+// "As shown below, if n_c denotes the word-length of the stored impulse-response samples,
+//  then one may choose n_l=1+n_c/2, and n_η=n_c/2 to obtain n_c-1 effective bits of precision in the interpolated impulse response."
+// Since we are not using fixed point, in a first step we have to approximate the number of binary digits to the floating point mantissa: n_c=23.
+// We obtain the tap count exponent n_l=12 (4096 taps) and the interpolation count exponent n_η=11 (2048 interpolation lookup values per tap).
+// This would be slow, but gives an upper limit of what is even numerically sensible.
+// Consider further that the limit of human hearing is around a range of 60dB.
+// In 32-bit floating point, this corresponds to an epsilon of 10^{-60/20} = 0.001 ≈ 2^{-10}.
+// Therefore, we need no higher precision than n_c=10, which gives n_l=6, n_η=5.
+constexpr size_t recommended_float_sinc_taps = 1 << 6;
+constexpr size_t recommended_float_oversample = 1 << 5;
+
+}

--- a/Userland/Libraries/LibDSP/Window.h
+++ b/Userland/Libraries/LibDSP/Window.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, Arne Elster <arne@elster.li>
+ * Copyright (c) 2023, Sarsaparilla
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -17,14 +18,17 @@ public:
     template<size_t size>
     constexpr static Array<T, size> hamming() { return make_window<size>(calculate_hamming); }
     constexpr static FixedArray<T> hamming(size_t size) { return make_window(size, calculate_hamming); }
+    constexpr static T hamming(u32 index, size_t size) { return calculate_hamming(index, size); }
 
     template<size_t size>
     constexpr static Array<T, size> hann() { return make_window<size>(calculate_hann); }
     constexpr static FixedArray<T> hann(size_t size) { return make_window(size, calculate_hann); }
+    constexpr static T hann(u32 index, size_t size) { return calculate_hann(index, size); }
 
     template<size_t size>
     constexpr static Array<T, size> blackman_harris() { return make_window<size>(calculate_blackman_harris); }
     constexpr static FixedArray<T> blackman_harris(size_t size) { return make_window(size, calculate_blackman_harris); }
+    constexpr static T blackman_harris(u32 index, size_t size) { return calculate_blackman_harris(index, size); }
 
 private:
     constexpr static float calculate_hann(size_t index, size_t size)
@@ -43,7 +47,7 @@ private:
         T const a1 = 0.48829;
         T const a2 = 0.14128;
         T const a3 = 0.01168;
-        return a0 - a1 * AK::cos(2 * AK::Pi<T> * index / size) + a2 * AK::cos(4 * AK::Pi<T> * index / size) - a3 * AK::cos(6 * AK::Pi<T> * index / size);
+        return a0 - a1 * AK::cos((2 * AK::Pi<T> * index) / (size - 1)) + a2 * AK::cos((4 * AK::Pi<T> * index) / (size - 1)) - a3 * AK::cos((6 * AK::Pi<T> * index) / (size - 1));
     }
 
     template<size_t size>

--- a/Userland/Utilities/aconv.cpp
+++ b/Userland/Utilities/aconv.cpp
@@ -132,7 +132,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             writer.emplace(TRY(Audio::WavWriter::create_from_file(
                 output,
                 static_cast<int>(target_samplerate),
-                2, // input_loader->num_channels(),
+                input_loader->num_channels(),
                 parsed_output_sample_format)));
         } else if (output_format == "flac"sv) {
             auto parsed_output_sample_format = input_loader->pcm_format();


### PR DESCRIPTION
Just an improved version of #19854 with much improved performance. CC @sarsaparilla89

Performance-wise, in aconv, we drop to 20x-30x realtime processing on usual sample rates when converting WAV to FLAC. This is not significant, especially considering that we may parallelize the read, write, and resample operations in the future.

### AK: Add move helpers to span, mirroring copy helpers

overwrite() is a giant footgun, since it operates on byte data, and
shouldn't be used for move operations.

These new move helpers are the only correct way for moving data within a
span, and avoid the use of TypedTransfer::move in user code.

### LibDSP: Add FIR filter

This adds a basic one-dimensional FIR (finite impulse response) filter.

### LibDSP: Extend window methods

Sometimes there is no need to allocate memory to calculate a whole
window. This adds methods to directly calculate individual window
cofficients.

This commit also fixes an off-by-one error in the blackman window.

### LibDSP: Add sinc resampler

Adds a sinc resampler to be used with bandlimited signals.
The resampler can be used with expensive sine calculations in its main
loop, or with a fast linear approximation of it. However the linear
approximation costs more memory depending on how accurate it has to be.

### aconv: Allow resampling input files

Extends aconv so that it can resample the input before writing the
output.

### LibAudio: Make WavWriter clamp samples, not overflow them

Samples bigger than +-1 should not overflow but instead be clamped to
+-1. Overflow adds a lot of unnecessary distortion.

### LibAudio: Make WavWriter respect channel count

WavWriter should only write a second channel if it is configured to do
so.
