### PR TITLE
LibIMAP: Stop parsing immediately on error

### DIFF
--- a/Userland/Applications/Mail/MailWidget.cpp
+++ b/Userland/Applications/Mail/MailWidget.cpp
@@ -317,33 +317,33 @@ void MailWidget::selected_mailbox(GUI::ModelIndex const& index)
         auto seen = !response_data.flags().find_if([](StringView value) { return value.equals_ignoring_ascii_case("\\Seen"sv); }).is_end();
 
         DeprecatedString date = internal_date.to_deprecated_string();
-        DeprecatedString subject = envelope.subject.value_or("(No subject)");
+        DeprecatedString subject = envelope.subject.is_empty() ? "(No subject)" : envelope.subject;
         if (subject.contains("=?"sv) && subject.contains("?="sv)) {
             subject = MUST(IMAP::decode_rfc2047_encoded_words(subject));
         }
 
         StringBuilder sender_builder;
-        if (envelope.from.has_value()) {
+        if (!envelope.from.is_empty()) {
             bool first { true };
-            for (auto const& address : *envelope.from) {
+            for (auto const& address : envelope.from) {
                 if (!first)
                     sender_builder.append(", "sv);
 
-                if (address.name.has_value()) {
-                    if (address.name->contains("=?"sv) && address.name->contains("?="sv))
-                        sender_builder.append(MUST(IMAP::decode_rfc2047_encoded_words(*address.name)));
+                if (!address.name.is_empty()) {
+                    if (address.name.contains("=?"sv) && address.name.contains("?="sv))
+                        sender_builder.append(MUST(IMAP::decode_rfc2047_encoded_words(address.name)));
                     else
-                        sender_builder.append(*address.name);
+                        sender_builder.append(address.name);
 
                     sender_builder.append(" <"sv);
-                    sender_builder.append(address.mailbox.value_or({}));
+                    sender_builder.append(address.mailbox);
                     sender_builder.append('@');
-                    sender_builder.append(address.host.value_or({}));
+                    sender_builder.append(address.host);
                     sender_builder.append('>');
                 } else {
-                    sender_builder.append(address.mailbox.value_or({}));
+                    sender_builder.append(address.mailbox);
                     sender_builder.append('@');
-                    sender_builder.append(address.host.value_or({}));
+                    sender_builder.append(address.host);
                 }
             }
         }
@@ -474,13 +474,13 @@ void MailWidget::selected_email_to_load(GUI::ModelIndex const& index)
     }
 
     auto& body_data = fetch_response_data.body_data();
-    auto body_text_part_iterator = body_data.find_if([](Tuple<IMAP::FetchCommand::DataItem, Optional<DeprecatedString>>& data) {
+    auto body_text_part_iterator = body_data.find_if([](Tuple<IMAP::FetchCommand::DataItem, DeprecatedString>& data) {
         const auto data_item = data.get<0>();
         return data_item.section.has_value() && data_item.section->type == IMAP::FetchCommand::DataItem::SectionType::Parts;
     });
     VERIFY(body_text_part_iterator != body_data.end());
 
-    auto& encoded_data = body_text_part_iterator->get<1>().value();
+    auto& encoded_data = body_text_part_iterator->get<1>();
 
     DeprecatedString decoded_data;
 

--- a/Userland/Libraries/LibIMAP/Objects.h
+++ b/Userland/Libraries/LibIMAP/Objects.h
@@ -169,23 +169,23 @@ private:
 };
 
 struct Address {
-    Optional<DeprecatedString> name;
-    Optional<DeprecatedString> source_route;
-    Optional<DeprecatedString> mailbox;
-    Optional<DeprecatedString> host;
+    DeprecatedString name;
+    DeprecatedString source_route;
+    DeprecatedString mailbox;
+    DeprecatedString host;
 };
 
 struct Envelope {
-    Optional<DeprecatedString> date; // Format of date not specified.
-    Optional<DeprecatedString> subject;
-    Optional<Vector<Address>> from;
-    Optional<Vector<Address>> sender;
-    Optional<Vector<Address>> reply_to;
-    Optional<Vector<Address>> to;
-    Optional<Vector<Address>> cc;
-    Optional<Vector<Address>> bcc;
-    Optional<DeprecatedString> in_reply_to;
-    Optional<DeprecatedString> message_id;
+    DeprecatedString date; // Format of date not specified.
+    DeprecatedString subject;
+    Vector<Address> from;
+    Vector<Address> sender;
+    Vector<Address> reply_to;
+    Vector<Address> to;
+    Vector<Address> cc;
+    Vector<Address> bcc;
+    DeprecatedString in_reply_to;
+    DeprecatedString message_id;
 };
 
 class BodyStructure;
@@ -199,28 +199,28 @@ struct MultiPartBodyStructureData {
     Vector<OwnPtr<BodyStructure>> bodies;
     Vector<DeprecatedString> langs;
     DeprecatedString multipart_subtype;
-    Optional<HashMap<DeprecatedString, DeprecatedString>> params;
-    Optional<DeprecatedString> location;
-    Optional<Vector<BodyExtension>> extensions;
+    HashMap<DeprecatedString, DeprecatedString> params;
+    DeprecatedString location;
+    Vector<BodyExtension> extensions;
 };
 
 struct BodyStructureData {
     DeprecatedString type;
     DeprecatedString subtype;
-    Optional<DeprecatedString> id {};
-    Optional<DeprecatedString> desc {};
+    DeprecatedString id {};
+    DeprecatedString desc {};
     DeprecatedString encoding;
     HashMap<DeprecatedString, DeprecatedString> fields;
     unsigned bytes { 0 };
     unsigned lines { 0 };
     Optional<Tuple<Envelope, NonnullOwnPtr<BodyStructure>>> contanied_message;
 
-    Optional<DeprecatedString> md5 {};
+    DeprecatedString md5 {};
     Optional<Tuple<DeprecatedString, HashMap<DeprecatedString, DeprecatedString>>> disposition {};
     Optional<Vector<DeprecatedString>> langs {};
-    Optional<DeprecatedString> location {};
+    DeprecatedString location {};
 
-    Optional<Vector<BodyExtension>> extensions {};
+    Vector<BodyExtension> extensions {};
 };
 
 class BodyStructure {
@@ -332,13 +332,13 @@ public:
         m_response_type |= static_cast<unsigned>(type);
     }
 
-    void add_body_data(FetchCommand::DataItem&& data_item, Optional<DeprecatedString>&& body)
+    void add_body_data(FetchCommand::DataItem&& data_item, DeprecatedString&& body)
     {
         add_response_type(FetchResponseType::Body);
         m_bodies.append({ move(data_item), move(body) });
     }
 
-    Vector<Tuple<FetchCommand::DataItem, Optional<DeprecatedString>>>& body_data()
+    Vector<Tuple<FetchCommand::DataItem, DeprecatedString>>& body_data()
     {
         VERIFY(contains_response_type(FetchResponseType::Body));
         return m_bodies;
@@ -411,7 +411,7 @@ public:
 
 private:
     Vector<DeprecatedString> m_flags;
-    Vector<Tuple<FetchCommand::DataItem, Optional<DeprecatedString>>> m_bodies;
+    Vector<Tuple<FetchCommand::DataItem, DeprecatedString>> m_bodies;
     Core::DateTime m_internal_date;
     Envelope m_envelope;
     unsigned m_uid { 0 };

--- a/Userland/Libraries/LibIMAP/Parser.h
+++ b/Userland/Libraries/LibIMAP/Parser.h
@@ -26,7 +26,7 @@ private:
     static MailboxFlag parse_mailbox_flag(StringView);
 
     void consume(StringView);
-    bool try_consume(StringView);
+    bool consume_if(StringView);
     StringView consume_while(Function<bool(u8)> should_consume);
     StringView consume_until_end_of_line();
 

--- a/Userland/Libraries/LibIMAP/Parser.h
+++ b/Userland/Libraries/LibIMAP/Parser.h
@@ -25,7 +25,9 @@ public:
 private:
     static MailboxFlag parse_mailbox_flag(StringView);
 
-    void consume(StringView);
+    ErrorOr<ParseStatus> try_parse(ByteBuffer&& buffer, bool expecting_tag);
+
+    ErrorOr<void> consume(StringView);
     bool consume_if(StringView);
     StringView consume_while(Function<bool(u8)> should_consume);
     StringView consume_until_end_of_line();
@@ -35,39 +37,38 @@ private:
     ErrorOr<unsigned> parse_number();
     Optional<unsigned> try_parse_number();
 
-    void parse_response_done();
-    void parse_untagged();
-    void parse_capability_response();
+    ErrorOr<void> parse_response_done();
+    ErrorOr<void> parse_untagged();
+    ErrorOr<void> parse_capability_response();
 
     StringView parse_atom();
-    StringView parse_quoted_string();
-    StringView parse_literal_string();
-    StringView parse_string();
-    StringView parse_astring();
-    Optional<StringView> parse_nstring();
+    ErrorOr<StringView> parse_quoted_string();
+    ErrorOr<StringView> parse_literal_string();
+    ErrorOr<StringView> parse_string();
+    ErrorOr<StringView> parse_astring();
+    ErrorOr<StringView> parse_nstring();
 
-    ResponseStatus parse_status();
-    ListItem parse_list_item();
-    FetchCommand::DataItem parse_fetch_data_item();
-    FetchResponseData parse_fetch_response();
-    Optional<Vector<Address>> parse_address_list();
-    Address parse_address();
-    HashMap<DeprecatedString, DeprecatedString> parse_body_fields_params();
-    BodyStructure parse_body_structure();
-    BodyStructure parse_one_part_body();
-    BodyExtension parse_body_extension();
-    Tuple<DeprecatedString, HashMap<DeprecatedString, DeprecatedString>> parse_disposition();
-    Vector<DeprecatedString> parse_langs();
-    Envelope parse_envelope();
+    ErrorOr<ResponseStatus> parse_status();
+    ErrorOr<ListItem> parse_list_item();
+    ErrorOr<FetchCommand::DataItem> parse_fetch_data_item();
+    ErrorOr<FetchResponseData> parse_fetch_response();
+    ErrorOr<Vector<Address>> parse_address_list();
+    ErrorOr<Address> parse_address();
+    ErrorOr<HashMap<DeprecatedString, DeprecatedString>> parse_body_fields_params();
+    ErrorOr<BodyStructure> parse_body_structure();
+    ErrorOr<BodyStructure> parse_one_part_body();
+    ErrorOr<BodyExtension> parse_body_extension();
+    ErrorOr<Tuple<DeprecatedString, HashMap<DeprecatedString, DeprecatedString>>> parse_disposition();
+    ErrorOr<Vector<DeprecatedString>> parse_langs();
+    ErrorOr<Envelope> parse_envelope();
 
     template<typename T>
-    Vector<T> parse_list(T (*converter)(StringView));
+    ErrorOr<Vector<T>> parse_list(T (*converter)(StringView));
 
     // To retain state if parsing is not finished
     ByteBuffer m_buffer;
     SolidResponse m_response;
     unsigned m_position { 0 };
     bool m_incomplete { false };
-    bool m_parsing_failed { false };
 };
 }

--- a/Userland/Utilities/test-imap.cpp
+++ b/Userland/Utilities/test-imap.cpp
@@ -125,12 +125,11 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                 .first()
                 .get<IMAP::FetchResponseData>()
                 .body_data()
-                .find_if([](Tuple<IMAP::FetchCommand::DataItem, Optional<DeprecatedString>>& data) {
+                .find_if([](Tuple<IMAP::FetchCommand::DataItem, DeprecatedString>& data) {
                     const auto data_item = data.get<0>();
                     return data_item.section.has_value() && data_item.section->type == IMAP::FetchCommand::DataItem::SectionType::HeaderFields;
                 })
-                ->get<1>()
-                .value());
+                ->get<1>());
     }
 
     // FIXME: There is a discrepancy between IMAP::Sequence wanting signed ints


### PR DESCRIPTION
This makes the parser more resilient to invalid IMAP messages.

Usages of `Optional` have also been removed where the empty case is equivalent to an empty object.

Let me know if I should split the removal of the `Optional` types into a separate commit. I ended up doing everything together to avoid changing the same code more than once in the same PR.

I tested this against a new `outlook.com` email address I set up, with a few plain-text only emails. Trying to log in to my gmail account failed (with 2 factor authentication + app passwords). I also set up a new gmail account and tried that with a normal password; this also failed.

The Mail application can quite easily hang when navigating around different folders and messages. I don't think those issues are related to this change though, as this behavior is also present for me on `master`.

This fixes oss fuzz issues: [62062](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=62062), [37380](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=37380) and [36557](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=36557)