### PR TITLE
Ladybird: Implement content zooming in the AppKit chrome

### DIFF
--- a/Ladybird/AppKit/Application/ApplicationDelegate.mm
+++ b/Ladybird/AppKit/Application/ApplicationDelegate.mm
@@ -303,7 +303,24 @@
                                                        keyEquivalent:@""];
     [color_scheme_menu_item setSubmenu:color_scheme_menu];
 
+    auto* zoom_menu = [[NSMenu alloc] init];
+    [zoom_menu addItem:[[NSMenuItem alloc] initWithTitle:@"Zoom In"
+                                                  action:@selector(zoomIn:)
+                                           keyEquivalent:@"+"]];
+    [zoom_menu addItem:[[NSMenuItem alloc] initWithTitle:@"Zoom Out"
+                                                  action:@selector(zoomOut:)
+                                           keyEquivalent:@"-"]];
+    [zoom_menu addItem:[[NSMenuItem alloc] initWithTitle:@"Actual Size"
+                                                  action:@selector(resetZoom:)
+                                           keyEquivalent:@"0"]];
+
+    auto* zoom_menu_item = [[NSMenuItem alloc] initWithTitle:@"Zoom"
+                                                      action:nil
+                                               keyEquivalent:@""];
+    [zoom_menu_item setSubmenu:zoom_menu];
+
     [submenu addItem:color_scheme_menu_item];
+    [submenu addItem:zoom_menu_item];
     [submenu addItem:[NSMenuItem separatorItem]];
 
     [menu setSubmenu:submenu];

--- a/Ladybird/AppKit/UI/LadybirdWebView.h
+++ b/Ladybird/AppKit/UI/LadybirdWebView.h
@@ -54,6 +54,11 @@
 
 - (void)setPreferredColorScheme:(Web::CSS::PreferredColorScheme)color_scheme;
 
+- (void)zoomIn;
+- (void)zoomOut;
+- (void)resetZoom;
+- (float)zoomLevel;
+
 - (void)debugRequest:(DeprecatedString const&)request argument:(DeprecatedString const&)argument;
 
 - (void)viewSource;

--- a/Ladybird/AppKit/UI/LadybirdWebView.mm
+++ b/Ladybird/AppKit/UI/LadybirdWebView.mm
@@ -149,6 +149,26 @@ struct HideCursor {
     m_web_view_bridge->set_system_visibility_state(is_visible);
 }
 
+- (void)zoomIn
+{
+    m_web_view_bridge->zoom_in();
+}
+
+- (void)zoomOut
+{
+    m_web_view_bridge->zoom_out();
+}
+
+- (void)resetZoom
+{
+    m_web_view_bridge->reset_zoom();
+}
+
+- (float)zoomLevel
+{
+    return m_web_view_bridge->zoom_level();
+}
+
 - (void)setPreferredColorScheme:(Web::CSS::PreferredColorScheme)color_scheme
 {
     m_web_view_bridge->set_preferred_color_scheme(color_scheme);
@@ -342,6 +362,10 @@ struct HideCursor {
         default:
             break;
         }
+    };
+
+    m_web_view_bridge->on_zoom_level_changed = [self]() {
+        [self updateViewportRect:Ladybird::WebViewBridge::ForResize::Yes];
     };
 
     m_web_view_bridge->on_navigate_back = [self]() {

--- a/Ladybird/AppKit/UI/LadybirdWebViewBridge.cpp
+++ b/Ladybird/AppKit/UI/LadybirdWebViewBridge.cpp
@@ -70,7 +70,7 @@ WebViewBridge::~WebViewBridge() = default;
 void WebViewBridge::set_device_pixel_ratio(float device_pixel_ratio)
 {
     m_device_pixel_ratio = device_pixel_ratio;
-    client().async_set_device_pixels_per_css_pixel(device_pixel_ratio);
+    client().async_set_device_pixels_per_css_pixel(m_device_pixel_ratio * m_zoom_level);
 }
 
 void WebViewBridge::set_system_visibility_state(bool is_visible)
@@ -158,6 +158,10 @@ Optional<WebViewBridge::Paintable> WebViewBridge::paintable()
 
 void WebViewBridge::update_zoom()
 {
+    client().async_set_device_pixels_per_css_pixel(m_device_pixel_ratio * m_zoom_level);
+
+    if (on_zoom_level_changed)
+        on_zoom_level_changed();
 }
 
 Gfx::IntRect WebViewBridge::viewport_rect() const

--- a/Ladybird/AppKit/UI/LadybirdWebViewBridge.h
+++ b/Ladybird/AppKit/UI/LadybirdWebViewBridge.h
@@ -55,6 +55,8 @@ public:
     };
     Optional<Paintable> paintable();
 
+    Function<void()> on_zoom_level_changed;
+
 private:
     WebViewBridge(Vector<Gfx::IntRect> screen_rects, float device_pixel_ratio, Optional<StringView> webdriver_content_ipc_path, Web::CSS::PreferredColorScheme);
 


### PR DESCRIPTION
This lets the user zoom in and out on a web page using the View menu or keyboard shortcuts. This does not implement zooming with ctrl+scroll.

In the future, it'd be nice to embed the zoom level display inside the location toolbar. But to do that, we will need to invent our own custom search field and all of the UI classes (controller, cell, etc.) to draw the field. So for now, this places the zoom level display to the right of the location toolbar.



https://github.com/SerenityOS/serenity/assets/5600524/690b79dc-5f6f-415a-92b5-c779a13f1538



