### PR TITLE
LibWeb: Port a whole bunch of DeprecatedFlyString to FlyString

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -3013,7 +3013,7 @@ JS_DEFINE_NATIVE_FUNCTION(@class_name@::@attribute.setter_callback@)
     if (!cpp_value)
         impl->remove_attribute(HTML::AttributeNames::@attribute.reflect_name@);
     else
-        MUST(impl->set_attribute(HTML::AttributeNames::@attribute.reflect_name@, DeprecatedString::empty()));
+        MUST(impl->set_attribute(HTML::AttributeNames::@attribute.reflect_name@, String {}));
 )~~~");
                 }
 

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -2589,7 +2589,7 @@ JS::ThrowCompletionOr<Optional<JS::PropertyDescriptor>> @named_properties_class@
 
     // 4. If the result of running the named property visibility algorithm with property name P and object object is true, then:
     if (TRY(is_named_property_exposed_on_object({ &object }, property_name))) {
-        auto property_name_string = property_name.to_string();
+        auto property_name_string = MUST(FlyString::from_deprecated_fly_string(property_name.to_string()));
 
         // 1. Let operation be the operation used to declare the named property getter.
         // 2. Let value be an uninitialized variable.

--- a/Tests/LibWeb/TestHTMLTokenizer.cpp
+++ b/Tests/LibWeb/TestHTMLTokenizer.cpp
@@ -61,7 +61,7 @@ using Token = Web::HTML::HTMLToken;
 
 #define EXPECT_TAG_TOKEN_ATTRIBUTE(name, attribute_value, name_start_column, name_end_column, value_start_column, value_end_column) \
     VERIFY(last_token);                                                                                                             \
-    auto name##_attr = last_token->raw_attribute(#name);                                                                            \
+    auto name##_attr = last_token->raw_attribute(#name##_fly_string);                                                               \
     VERIFY(name##_attr.has_value());                                                                                                \
     EXPECT_EQ(name##_attr->value, attribute_value);                                                                                 \
     EXPECT_EQ(name##_attr->name_start_position.column, name_start_column);                                                          \

--- a/Userland/Libraries/LibWeb/Bindings/AudioConstructor.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/AudioConstructor.cpp
@@ -46,14 +46,14 @@ JS::ThrowCompletionOr<JS::NonnullGCPtr<JS::Object>> AudioConstructor::construct(
     auto audio = TRY(Bindings::throw_dom_exception_if_needed(vm, [&]() { return DOM::create_element(document, HTML::TagNames::audio, Namespace::HTML); }));
 
     // 3. Set an attribute value for audio using "preload" and "auto".
-    MUST(audio->set_attribute(HTML::AttributeNames::preload, "auto"sv));
+    MUST(audio->set_attribute(HTML::AttributeNames::preload, "auto"_string));
 
     auto src_value = vm.argument(0);
 
     // 4. If src is given, then set an attribute value for audio using "src" and src.
     //    (This will cause the user agent to invoke the object's resource selection algorithm before returning.)
     if (!src_value.is_undefined()) {
-        auto src = TRY(src_value.to_deprecated_string(vm));
+        auto src = TRY(src_value.to_string(vm));
         MUST(audio->set_attribute(HTML::AttributeNames::src, move(src)));
     }
 

--- a/Userland/Libraries/LibWeb/Bindings/ImageConstructor.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/ImageConstructor.cpp
@@ -48,13 +48,13 @@ JS::ThrowCompletionOr<JS::NonnullGCPtr<JS::Object>> ImageConstructor::construct(
     // 3. If width is given, then set an attribute value for img using "width" and width.
     if (vm.argument_count() > 0) {
         u32 width = TRY(vm.argument(0).to_u32(vm));
-        MUST(image_element->set_attribute(HTML::AttributeNames::width, DeprecatedString::formatted("{}", width)));
+        MUST(image_element->set_attribute(HTML::AttributeNames::width, MUST(String::formatted("{}", width))));
     }
 
     // 4. If height is given, then set an attribute value for img using "height" and height.
     if (vm.argument_count() > 1) {
         u32 height = TRY(vm.argument(1).to_u32(vm));
-        MUST(image_element->set_attribute(HTML::AttributeNames::height, DeprecatedString::formatted("{}", height)));
+        MUST(image_element->set_attribute(HTML::AttributeNames::height, MUST(String::formatted("{}", height))));
     }
 
     // 5. Return img.

--- a/Userland/Libraries/LibWeb/Bindings/LegacyPlatformObject.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/LegacyPlatformObject.cpp
@@ -62,7 +62,7 @@ JS::ThrowCompletionOr<Optional<JS::PropertyDescriptor>> LegacyPlatformObject::le
         // 1. If the result of running the named property visibility algorithm with property name P and object O is true, then:
         if (TRY(WebIDL::is_named_property_exposed_on_object({ this }, property_name))) {
             // FIXME: It's unfortunate that this is done twice, once in is_named_property_exposed_on_object and here.
-            auto property_name_string = property_name.to_string();
+            auto property_name_string = MUST(FlyString::from_deprecated_fly_string(property_name.to_string()));
 
             // 1. Let operation be the operation used to declare the named property getter.
             // 2. Let value be an uninitialized variable.
@@ -376,7 +376,7 @@ WebIDL::ExceptionOr<JS::Value> LegacyPlatformObject::item_value(size_t) const
     return JS::js_undefined();
 }
 
-WebIDL::ExceptionOr<JS::Value> LegacyPlatformObject::named_item_value(DeprecatedFlyString const&) const
+WebIDL::ExceptionOr<JS::Value> LegacyPlatformObject::named_item_value(FlyString const&) const
 {
     return JS::js_undefined();
 }

--- a/Userland/Libraries/LibWeb/Bindings/LegacyPlatformObject.h
+++ b/Userland/Libraries/LibWeb/Bindings/LegacyPlatformObject.h
@@ -38,7 +38,7 @@ public:
     JS::ThrowCompletionOr<Optional<JS::PropertyDescriptor>> legacy_platform_object_get_own_property(JS::PropertyKey const&, IgnoreNamedProps ignore_named_props) const;
 
     virtual WebIDL::ExceptionOr<JS::Value> item_value(size_t index) const;
-    virtual WebIDL::ExceptionOr<JS::Value> named_item_value(DeprecatedFlyString const& name) const;
+    virtual WebIDL::ExceptionOr<JS::Value> named_item_value(FlyString const& name) const;
     virtual Vector<DeprecatedString> supported_property_names() const;
     virtual bool is_supported_property_index(u32) const;
 

--- a/Userland/Libraries/LibWeb/Bindings/OptionConstructor.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/OptionConstructor.cpp
@@ -61,7 +61,7 @@ JS::ThrowCompletionOr<JS::NonnullGCPtr<JS::Object>> OptionConstructor::construct
 
     // 4. If value is given, then set an attribute value for option using "value" and value.
     if (vm.argument_count() > 1) {
-        auto value = TRY(vm.argument(1).to_deprecated_string(vm));
+        auto value = TRY(vm.argument(1).to_string(vm));
         MUST(option_element->set_attribute(HTML::AttributeNames::value, value));
     }
 
@@ -69,7 +69,7 @@ JS::ThrowCompletionOr<JS::NonnullGCPtr<JS::Object>> OptionConstructor::construct
     if (vm.argument_count() > 2) {
         auto default_selected = vm.argument(2).to_boolean();
         if (default_selected) {
-            MUST(option_element->set_attribute(HTML::AttributeNames::selected, ""));
+            MUST(option_element->set_attribute(HTML::AttributeNames::selected, String {}));
         }
     }
 

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleDeclaration.cpp
@@ -183,7 +183,7 @@ void ElementInlineCSSStyleDeclaration::update_style_attribute()
     m_updating = true;
 
     // 5. Set an attribute value for owner node using "style" and the result of serializing declaration block.
-    MUST(m_element->set_attribute(HTML::AttributeNames::style, serialized()));
+    MUST(m_element->set_attribute(HTML::AttributeNames::style, MUST(String::from_deprecated_string(serialized()))));
 
     // 6. Unset declaration block’s updating flag.
     m_updating = false;

--- a/Userland/Libraries/LibWeb/DOM/Attr.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Attr.cpp
@@ -115,7 +115,7 @@ void Attr::handle_attribute_changes(Element& element, DeprecatedString const& ol
     }
 
     // 3. Run the attribute change steps with element, attribute’s local name, oldValue, newValue, and attribute’s namespace.
-    element.run_attribute_change_steps(local_name().to_deprecated_fly_string(), old_value, new_value, deprecated_namespace_uri);
+    element.run_attribute_change_steps(local_name(), old_value, new_value, deprecated_namespace_uri);
 }
 
 }

--- a/Userland/Libraries/LibWeb/DOM/Attr.h
+++ b/Userland/Libraries/LibWeb/DOM/Attr.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/DeprecatedFlyString.h>
 #include <AK/WeakPtr.h>
 #include <LibWeb/DOM/Node.h>
 #include <LibWeb/DOM/QualifiedName.h>

--- a/Userland/Libraries/LibWeb/DOM/Comment.h
+++ b/Userland/Libraries/LibWeb/DOM/Comment.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/DeprecatedFlyString.h>
 #include <LibWeb/DOM/CharacterData.h>
 
 namespace Web::DOM {

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -1733,7 +1733,7 @@ Document::IndicatedPart Document::determine_the_indicated_part() const
         return Document::TopOfTheDocument {};
 
     // 3. Let potentialIndicatedElement be the result of finding a potential indicated element given document and fragment.
-    auto* potential_indicated_element = find_a_potential_indicated_element(fragment.to_deprecated_string());
+    auto* potential_indicated_element = find_a_potential_indicated_element(fragment);
 
     // 4. If potentialIndicatedElement is not null, then return potentialIndicatedElement.
     if (potential_indicated_element)
@@ -1744,7 +1744,7 @@ Document::IndicatedPart Document::determine_the_indicated_part() const
     auto decoded_fragment = AK::URL::percent_decode(fragment);
 
     // 7. Set potentialIndicatedElement to the result of finding a potential indicated element given document and decodedFragment.
-    potential_indicated_element = find_a_potential_indicated_element(decoded_fragment);
+    potential_indicated_element = find_a_potential_indicated_element(MUST(FlyString::from_deprecated_fly_string(decoded_fragment)));
 
     // 8. If potentialIndicatedElement is not null, then return potentialIndicatedElement.
     if (potential_indicated_element)
@@ -1759,7 +1759,7 @@ Document::IndicatedPart Document::determine_the_indicated_part() const
 }
 
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#find-a-potential-indicated-element
-Element* Document::find_a_potential_indicated_element(DeprecatedString fragment) const
+Element* Document::find_a_potential_indicated_element(FlyString const& fragment) const
 {
     // To find a potential indicated element given a Document document and a string fragment, run these steps:
 
@@ -1772,7 +1772,7 @@ Element* Document::find_a_potential_indicated_element(DeprecatedString fragment)
     //    whose value is equal to fragment, then return the first such element in tree order.
     Element* element_with_name;
     root().for_each_in_subtree_of_type<Element>([&](Element const& element) {
-        if (element.name() == fragment) {
+        if (element.attribute(HTML::AttributeNames::name) == fragment) {
             element_with_name = const_cast<Element*>(&element);
             return IterationDecision::Break;
         }

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -554,7 +554,7 @@ private:
     void queue_intersection_observer_task();
     void queue_an_intersection_observer_entry(IntersectionObserver::IntersectionObserver&, HighResolutionTime::DOMHighResTimeStamp time, JS::NonnullGCPtr<Geometry::DOMRectReadOnly> root_bounds, JS::NonnullGCPtr<Geometry::DOMRectReadOnly> bounding_client_rect, JS::NonnullGCPtr<Geometry::DOMRectReadOnly> intersection_rect, bool is_intersecting, double intersection_ratio, JS::NonnullGCPtr<Element> target);
 
-    Element* find_a_potential_indicated_element(DeprecatedString fragment) const;
+    Element* find_a_potential_indicated_element(FlyString const& fragment) const;
 
     OwnPtr<CSS::StyleComputer> m_style_computer;
     JS::GCPtr<CSS::StyleSheetList> m_style_sheets;

--- a/Userland/Libraries/LibWeb/DOM/DocumentFragment.h
+++ b/Userland/Libraries/LibWeb/DOM/DocumentFragment.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/DeprecatedFlyString.h>
 #include <LibWeb/DOM/Element.h>
 #include <LibWeb/DOM/NonElementParentNode.h>
 #include <LibWeb/DOM/ParentNode.h>

--- a/Userland/Libraries/LibWeb/DOM/DocumentLoading.cpp
+++ b/Userland/Libraries/LibWeb/DOM/DocumentLoading.cpp
@@ -126,7 +126,7 @@ static bool build_image_document(DOM::Document& document, ByteBuffer const& data
     MUST(html_element->append_child(body_element));
 
     auto image_element = DOM::create_element(document, HTML::TagNames::img, Namespace::HTML).release_value_but_fixme_should_propagate_errors();
-    MUST(image_element->set_attribute(HTML::AttributeNames::src, document.url().to_deprecated_string()));
+    MUST(image_element->set_attribute(HTML::AttributeNames::src, MUST(document.url().to_string())));
     MUST(body_element->append_child(image_element));
 
     return true;
@@ -170,9 +170,9 @@ static bool build_video_document(DOM::Document& document)
     MUST(html_element->append_child(body_element));
 
     auto video_element = DOM::create_element(document, HTML::TagNames::video, Namespace::HTML).release_value_but_fixme_should_propagate_errors();
-    MUST(video_element->set_attribute(HTML::AttributeNames::src, document.url().to_deprecated_string()));
-    MUST(video_element->set_attribute(HTML::AttributeNames::autoplay, DeprecatedString::empty()));
-    MUST(video_element->set_attribute(HTML::AttributeNames::controls, DeprecatedString::empty()));
+    MUST(video_element->set_attribute(HTML::AttributeNames::src, MUST(document.url().to_string())));
+    MUST(video_element->set_attribute(HTML::AttributeNames::autoplay, String {}));
+    MUST(video_element->set_attribute(HTML::AttributeNames::controls, String {}));
     MUST(body_element->append_child(video_element));
 
     return true;
@@ -190,9 +190,9 @@ static bool build_audio_document(DOM::Document& document)
     MUST(html_element->append_child(body_element));
 
     auto video_element = DOM::create_element(document, HTML::TagNames::audio, Namespace::HTML).release_value_but_fixme_should_propagate_errors();
-    MUST(video_element->set_attribute(HTML::AttributeNames::src, document.url().to_deprecated_string()));
-    MUST(video_element->set_attribute(HTML::AttributeNames::autoplay, DeprecatedString::empty()));
-    MUST(video_element->set_attribute(HTML::AttributeNames::controls, DeprecatedString::empty()));
+    MUST(video_element->set_attribute(HTML::AttributeNames::src, MUST(document.url().to_string())));
+    MUST(video_element->set_attribute(HTML::AttributeNames::autoplay, String {}));
+    MUST(video_element->set_attribute(HTML::AttributeNames::controls, String {}));
     MUST(body_element->append_child(video_element));
 
     return true;

--- a/Userland/Libraries/LibWeb/DOM/DocumentType.h
+++ b/Userland/Libraries/LibWeb/DOM/DocumentType.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/DeprecatedFlyString.h>
 #include <AK/String.h>
 #include <LibWeb/DOM/ChildNode.h>
 #include <LibWeb/DOM/Node.h>

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -468,7 +468,7 @@ void Element::add_attribute_change_steps(AttributeChangeSteps steps)
     m_attribute_change_steps.append(move(steps));
 }
 
-void Element::run_attribute_change_steps(DeprecatedFlyString const& local_name, DeprecatedString const& old_value, DeprecatedString const& value, DeprecatedFlyString const& namespace_)
+void Element::run_attribute_change_steps(FlyString const& local_name, DeprecatedString const& old_value, DeprecatedString const& value, DeprecatedFlyString const& namespace_)
 {
     for (auto const& attribute_change_steps : m_attribute_change_steps)
         attribute_change_steps(local_name, old_value, value, namespace_);
@@ -478,7 +478,7 @@ void Element::run_attribute_change_steps(DeprecatedFlyString const& local_name, 
     invalidate_style_after_attribute_change(local_name);
 }
 
-void Element::attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value)
+void Element::attribute_changed(FlyString const& name, DeprecatedString const& value)
 {
     if (name == HTML::AttributeNames::class_) {
         auto new_classes = value.split_view(Infra::is_ascii_whitespace);
@@ -614,7 +614,7 @@ NonnullRefPtr<CSS::StyleProperties> Element::resolved_css_values()
 DOMTokenList* Element::class_list()
 {
     if (!m_class_list)
-        m_class_list = DOMTokenList::create(*this, FlyString::from_deprecated_fly_string(HTML::AttributeNames::class_).release_value());
+        m_class_list = DOMTokenList::create(*this, HTML::AttributeNames::class_);
     return m_class_list;
 }
 
@@ -1026,7 +1026,7 @@ i32 Element::tab_index() const
 // https://html.spec.whatwg.org/multipage/interaction.html#dom-tabindex
 void Element::set_tab_index(i32 tab_index)
 {
-    MUST(set_attribute(HTML::AttributeNames::tabindex, DeprecatedString::number(tab_index)));
+    MUST(set_attribute(HTML::AttributeNames::tabindex, MUST(String::number(tab_index))));
 }
 
 // https://drafts.csswg.org/cssom-view/#potentially-scrollable
@@ -1583,7 +1583,7 @@ ErrorOr<void> Element::scroll_into_view(Optional<Variant<bool, ScrollIntoViewOpt
     // FIXME: 8. Optionally perform some other action that brings the element to the user’s attention.
 }
 
-void Element::invalidate_style_after_attribute_change(DeprecatedFlyString const& attribute_name)
+void Element::invalidate_style_after_attribute_change(FlyString const& attribute_name)
 {
     // FIXME: Only invalidate if the attribute can actually affect style.
     (void)attribute_name;
@@ -1873,11 +1873,11 @@ void Element::set_prefix(Optional<FlyString> value)
     m_qualified_name.set_prefix(move(value));
 }
 
-void Element::for_each_attribute(Function<void(DeprecatedFlyString const&, DeprecatedString const&)> callback) const
+void Element::for_each_attribute(Function<void(FlyString const&, DeprecatedString const&)> callback) const
 {
     for (size_t i = 0; i < m_attributes->length(); ++i) {
         auto const* attribute = m_attributes->item(i);
-        callback(attribute->name().to_deprecated_fly_string(), attribute->value().to_deprecated_string());
+        callback(attribute->name(), attribute->value().to_deprecated_string());
     }
 }
 

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -1937,7 +1937,7 @@ void Element::scroll(HTML::ScrollToOptions const&)
 
 bool Element::id_reference_exists(DeprecatedString const& id_reference) const
 {
-    return document().get_element_by_id(id_reference);
+    return document().get_element_by_id(MUST(FlyString::from_deprecated_fly_string(id_reference)));
 }
 
 void Element::register_intersection_observer(Badge<IntersectionObserver::IntersectionObserver>, IntersectionObserver::IntersectionObserverRegistration registration)

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -145,7 +145,7 @@ public:
     int client_width() const;
     int client_height() const;
 
-    void for_each_attribute(Function<void(DeprecatedFlyString const&, DeprecatedString const&)>) const;
+    void for_each_attribute(Function<void(FlyString const&, DeprecatedString const&)>) const;
 
     bool has_class(FlyString const&, CaseSensitivity = CaseSensitivity::CaseSensitive) const;
     Vector<FlyString> const& class_names() const { return m_classes; }
@@ -153,11 +153,11 @@ public:
     virtual void apply_presentational_hints(CSS::StyleProperties&) const { }
 
     // https://dom.spec.whatwg.org/#concept-element-attributes-change-ext
-    using AttributeChangeSteps = Function<void(DeprecatedFlyString const& /*local_name*/, DeprecatedString const& /*old_value*/, DeprecatedString const& /*value*/, DeprecatedFlyString const& /*namespace_*/)>;
+    using AttributeChangeSteps = Function<void(FlyString const& /*local_name*/, DeprecatedString const& /*old_value*/, DeprecatedString const& /*value*/, DeprecatedFlyString const& /*namespace_*/)>;
 
     void add_attribute_change_steps(AttributeChangeSteps steps);
-    void run_attribute_change_steps(DeprecatedFlyString const& local_name, DeprecatedString const& old_value, DeprecatedString const& value, DeprecatedFlyString const& namespace_);
-    virtual void attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value);
+    void run_attribute_change_steps(FlyString const& local_name, DeprecatedString const& old_value, DeprecatedString const& value, DeprecatedFlyString const& namespace_);
+    virtual void attribute_changed(FlyString const& name, DeprecatedString const& value);
 
     struct [[nodiscard]] RequiredInvalidationAfterStyleChange {
         bool repaint { false };
@@ -386,7 +386,7 @@ protected:
 private:
     void make_html_uppercased_qualified_name();
 
-    void invalidate_style_after_attribute_change(DeprecatedFlyString const& attribute_name);
+    void invalidate_style_after_attribute_change(FlyString const& attribute_name);
 
     WebIDL::ExceptionOr<JS::GCPtr<Node>> insert_adjacent(DeprecatedString const& where, JS::NonnullGCPtr<Node> node);
 

--- a/Userland/Libraries/LibWeb/DOM/ElementFactory.cpp
+++ b/Userland/Libraries/LibWeb/DOM/ElementFactory.cpp
@@ -427,7 +427,7 @@ static JS::NonnullGCPtr<Element> create_html_element(JS::Realm& realm, Document&
 
 static JS::GCPtr<SVG::SVGElement> create_svg_element(JS::Realm& realm, Document& document, QualifiedName qualified_name)
 {
-    auto const& local_name = qualified_name.local_name().to_deprecated_fly_string();
+    auto const& local_name = qualified_name.local_name();
 
     if (local_name == SVG::TagNames::svg)
         return realm.heap().allocate<SVG::SVGSVGElement>(realm, document, move(qualified_name));

--- a/Userland/Libraries/LibWeb/DOM/EventTarget.h
+++ b/Userland/Libraries/LibWeb/DOM/EventTarget.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/DeprecatedFlyString.h>
 #include <AK/Noncopyable.h>
 #include <AK/Vector.h>
 #include <LibJS/Forward.h>

--- a/Userland/Libraries/LibWeb/DOM/HTMLCollection.cpp
+++ b/Userland/Libraries/LibWeb/DOM/HTMLCollection.cpp
@@ -147,9 +147,9 @@ WebIDL::ExceptionOr<JS::Value> HTMLCollection::item_value(size_t index) const
     return const_cast<Element*>(element);
 }
 
-WebIDL::ExceptionOr<JS::Value> HTMLCollection::named_item_value(DeprecatedFlyString const& index) const
+WebIDL::ExceptionOr<JS::Value> HTMLCollection::named_item_value(FlyString const& index) const
 {
-    auto* element = named_item(FlyString::from_deprecated_fly_string(index).release_value());
+    auto* element = named_item(index);
     if (!element)
         return JS::js_undefined();
     return const_cast<Element*>(element);

--- a/Userland/Libraries/LibWeb/DOM/HTMLCollection.h
+++ b/Userland/Libraries/LibWeb/DOM/HTMLCollection.h
@@ -45,7 +45,7 @@ public:
     JS::MarkedVector<Element*> collect_matching_elements() const;
 
     virtual WebIDL::ExceptionOr<JS::Value> item_value(size_t index) const override;
-    virtual WebIDL::ExceptionOr<JS::Value> named_item_value(DeprecatedFlyString const& name) const override;
+    virtual WebIDL::ExceptionOr<JS::Value> named_item_value(FlyString const& name) const override;
     virtual Vector<DeprecatedString> supported_property_names() const override;
     virtual bool is_supported_property_index(u32) const override;
 

--- a/Userland/Libraries/LibWeb/DOM/NamedNodeMap.cpp
+++ b/Userland/Libraries/LibWeb/DOM/NamedNodeMap.cpp
@@ -327,7 +327,7 @@ WebIDL::ExceptionOr<JS::Value> NamedNodeMap::item_value(size_t index) const
     return node;
 }
 
-WebIDL::ExceptionOr<JS::Value> NamedNodeMap::named_item_value(DeprecatedFlyString const& name) const
+WebIDL::ExceptionOr<JS::Value> NamedNodeMap::named_item_value(FlyString const& name) const
 {
     auto const* node = get_named_item(name);
     if (!node)

--- a/Userland/Libraries/LibWeb/DOM/NamedNodeMap.h
+++ b/Userland/Libraries/LibWeb/DOM/NamedNodeMap.h
@@ -28,7 +28,7 @@ public:
     virtual bool is_supported_property_index(u32 index) const override;
     virtual Vector<DeprecatedString> supported_property_names() const override;
     virtual WebIDL::ExceptionOr<JS::Value> item_value(size_t index) const override;
-    virtual WebIDL::ExceptionOr<JS::Value> named_item_value(DeprecatedFlyString const& name) const override;
+    virtual WebIDL::ExceptionOr<JS::Value> named_item_value(FlyString const& name) const override;
 
     size_t length() const { return m_attributes.size(); }
     bool is_empty() const { return m_attributes.is_empty(); }

--- a/Userland/Libraries/LibWeb/DOM/Node.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Node.cpp
@@ -131,7 +131,7 @@ const HTML::HTMLElement* Node::enclosing_html_element() const
     return first_ancestor_of_type<HTML::HTMLElement>();
 }
 
-const HTML::HTMLElement* Node::enclosing_html_element_with_attribute(DeprecatedFlyString const& attribute) const
+const HTML::HTMLElement* Node::enclosing_html_element_with_attribute(FlyString const& attribute) const
 {
     for (auto* node = this; node; node = node->parent()) {
         if (is<HTML::HTMLElement>(*node) && verify_cast<HTML::HTMLElement>(*node).has_attribute(attribute))
@@ -815,7 +815,7 @@ JS::NonnullGCPtr<Node> Node::clone_node(Document* document, bool clone_children)
         element.for_each_attribute([&](auto& name, auto& value) {
             // 1. Let copyAttribute be a clone of attribute.
             // 2. Append copyAttribute to copy.
-            MUST(element_copy->set_attribute(name, value));
+            MUST(element_copy->set_attribute(name, MUST(String::from_deprecated_string(value))));
         });
         copy = move(element_copy);
 

--- a/Userland/Libraries/LibWeb/DOM/Node.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Node.cpp
@@ -1802,7 +1802,7 @@ ErrorOr<String> Node::name_or_description(NameOrDescription target, Document con
             }
             // ii. For each IDREF:
             for (auto const& id_ref : id_list) {
-                auto node = document.get_element_by_id(id_ref);
+                auto node = document.get_element_by_id(MUST(FlyString::from_utf8(id_ref)));
                 if (!node)
                     continue;
 
@@ -1922,7 +1922,7 @@ ErrorOr<String> Node::accessible_description(Document const& document) const
     StringBuilder builder;
     auto id_list = described_by->bytes_as_string_view().split_view_if(Infra::is_ascii_whitespace);
     for (auto const& id : id_list) {
-        if (auto description_element = document.get_element_by_id(id)) {
+        if (auto description_element = document.get_element_by_id(MUST(FlyString::from_utf8(id)))) {
             auto description = TRY(
                 description_element->name_or_description(NameOrDescription::Description, document,
                     visited_nodes));
@@ -1943,7 +1943,7 @@ Optional<StringView> Node::first_valid_id(DeprecatedString const& value, Documen
 {
     auto id_list = value.split_view(Infra::is_ascii_whitespace);
     for (auto const& id : id_list) {
-        if (document.get_element_by_id(id))
+        if (document.get_element_by_id(MUST(FlyString::from_utf8(id))))
             return id;
     }
     return {};

--- a/Userland/Libraries/LibWeb/DOM/Node.h
+++ b/Userland/Libraries/LibWeb/DOM/Node.h
@@ -158,7 +158,7 @@ public:
 
     const HTML::HTMLAnchorElement* enclosing_link_element() const;
     const HTML::HTMLElement* enclosing_html_element() const;
-    const HTML::HTMLElement* enclosing_html_element_with_attribute(DeprecatedFlyString const&) const;
+    const HTML::HTMLElement* enclosing_html_element_with_attribute(FlyString const&) const;
 
     DeprecatedString child_text_content() const;
 

--- a/Userland/Libraries/LibWeb/DOM/NonElementParentNode.h
+++ b/Userland/Libraries/LibWeb/DOM/NonElementParentNode.h
@@ -20,14 +20,9 @@ class NonElementParentNode {
 public:
     JS::GCPtr<Element const> get_element_by_id(FlyString const& id) const
     {
-        return get_element_by_id(id.to_deprecated_fly_string());
-    }
-
-    JS::GCPtr<Element const> get_element_by_id(DeprecatedFlyString const& id) const
-    {
         JS::GCPtr<Element const> found_element;
         static_cast<NodeType const*>(this)->template for_each_in_inclusive_subtree_of_type<Element>([&](auto& element) {
-            if (element.deprecated_attribute(HTML::AttributeNames::id) == id) {
+            if (element.attribute(HTML::AttributeNames::id) == id) {
                 found_element = &element;
                 return IterationDecision::Break;
             }
@@ -38,14 +33,9 @@ public:
 
     JS::GCPtr<Element> get_element_by_id(FlyString const& id)
     {
-        return get_element_by_id(id.to_deprecated_fly_string());
-    }
-
-    JS::GCPtr<Element> get_element_by_id(DeprecatedFlyString const& id)
-    {
         JS::GCPtr<Element> found_element;
         static_cast<NodeType*>(this)->template for_each_in_inclusive_subtree_of_type<Element>([&](auto& element) {
-            if (element.deprecated_attribute(HTML::AttributeNames::id) == id) {
+            if (element.attribute(HTML::AttributeNames::id) == id) {
                 found_element = &element;
                 return IterationDecision::Break;
             }

--- a/Userland/Libraries/LibWeb/DOM/ProcessingInstruction.h
+++ b/Userland/Libraries/LibWeb/DOM/ProcessingInstruction.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/DeprecatedFlyString.h>
 #include <LibWeb/DOM/CharacterData.h>
 
 namespace Web::DOM {

--- a/Userland/Libraries/LibWeb/DOM/Text.h
+++ b/Userland/Libraries/LibWeb/DOM/Text.h
@@ -7,8 +7,6 @@
 
 #pragma once
 
-#include <AK/DeprecatedFlyString.h>
-#include <AK/DeprecatedString.h>
 #include <LibWeb/DOM/CharacterData.h>
 #include <LibWeb/DOM/Slottable.h>
 

--- a/Userland/Libraries/LibWeb/Dump.cpp
+++ b/Userland/Libraries/LibWeb/Dump.cpp
@@ -138,13 +138,13 @@ void dump_tree(StringBuilder& builder, Layout::Node const& layout_node, bool sho
     for (size_t i = 0; i < indent; ++i)
         builder.append("  "sv);
 
-    DeprecatedFlyString tag_name;
+    FlyString tag_name;
     if (layout_node.is_anonymous())
-        tag_name = "(anonymous)";
+        tag_name = "(anonymous)"_fly_string;
     else if (is<DOM::Element>(layout_node.dom_node()))
-        tag_name = verify_cast<DOM::Element>(*layout_node.dom_node()).local_name().to_deprecated_fly_string();
+        tag_name = verify_cast<DOM::Element>(*layout_node.dom_node()).local_name();
     else
-        tag_name = layout_node.dom_node()->node_name().to_deprecated_fly_string();
+        tag_name = layout_node.dom_node()->node_name();
 
     DeprecatedString identifier = "";
     if (layout_node.dom_node() && is<DOM::Element>(*layout_node.dom_node())) {

--- a/Userland/Libraries/LibWeb/Encoding/TextEncoder.cpp
+++ b/Userland/Libraries/LibWeb/Encoding/TextEncoder.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/DeprecatedFlyString.h>
 #include <LibJS/Runtime/TypedArray.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Encoding/TextEncoder.h>

--- a/Userland/Libraries/LibWeb/FontCache.cpp
+++ b/Userland/Libraries/LibWeb/FontCache.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/DeprecatedFlyString.h>
 #include <LibGfx/Font/Font.h>
 #include <LibWeb/FontCache.h>
 

--- a/Userland/Libraries/LibWeb/HTML/AttributeNames.cpp
+++ b/Userland/Libraries/LibWeb/HTML/AttributeNames.cpp
@@ -9,7 +9,7 @@
 namespace Web::HTML {
 namespace AttributeNames {
 
-#define __ENUMERATE_HTML_ATTRIBUTE(name) DeprecatedFlyString name;
+#define __ENUMERATE_HTML_ATTRIBUTE(name) FlyString name;
 ENUMERATE_HTML_ATTRIBUTES
 #undef __ENUMERATE_HTML_ATTRIBUTE
 
@@ -19,19 +19,19 @@ void initialize_strings()
     VERIFY(!s_initialized);
 
 #define __ENUMERATE_HTML_ATTRIBUTE(name) \
-    name = #name;
+    name = #name##_fly_string;
     ENUMERATE_HTML_ATTRIBUTES
 #undef __ENUMERATE_HTML_ATTRIBUTE
 
     // NOTE: Special cases for C++ keywords.
-    class_ = "class";
-    for_ = "for";
-    default_ = "default";
-    char_ = "char";
+    class_ = "class"_fly_string;
+    for_ = "for"_fly_string;
+    default_ = "default"_fly_string;
+    char_ = "char"_fly_string;
 
     // NOTE: Special cases for attributes with dashes in them.
-    accept_charset = "accept-charset";
-    http_equiv = "http-equiv";
+    accept_charset = "accept-charset"_fly_string;
+    http_equiv = "http-equiv"_fly_string;
 
     s_initialized = true;
 }
@@ -39,7 +39,7 @@ void initialize_strings()
 }
 
 // https://html.spec.whatwg.org/#boolean-attribute
-bool is_boolean_attribute(DeprecatedFlyString const& attribute)
+bool is_boolean_attribute(FlyString const& attribute)
 {
     // NOTE: This is the list of attributes from https://html.spec.whatwg.org/#attributes-3
     //       with a Value column value of "Boolean attribute".

--- a/Userland/Libraries/LibWeb/HTML/AttributeNames.h
+++ b/Userland/Libraries/LibWeb/HTML/AttributeNames.h
@@ -6,8 +6,8 @@
 
 #pragma once
 
-#include <AK/DeprecatedFlyString.h>
 #include <AK/Error.h>
+#include <AK/FlyString.h>
 
 namespace Web::HTML {
 namespace AttributeNames {
@@ -240,7 +240,7 @@ namespace AttributeNames {
     __ENUMERATE_HTML_ATTRIBUTE(width)                      \
     __ENUMERATE_HTML_ATTRIBUTE(wrap)
 
-#define __ENUMERATE_HTML_ATTRIBUTE(name) extern DeprecatedFlyString name;
+#define __ENUMERATE_HTML_ATTRIBUTE(name) extern FlyString name;
 ENUMERATE_HTML_ATTRIBUTES
 #undef __ENUMERATE_HTML_ATTRIBUTE
 
@@ -248,6 +248,6 @@ void initialize_strings();
 
 }
 
-bool is_boolean_attribute(DeprecatedFlyString const& attribute);
+bool is_boolean_attribute(FlyString const& attribute);
 
 }

--- a/Userland/Libraries/LibWeb/HTML/DOMStringMap.cpp
+++ b/Userland/Libraries/LibWeb/HTML/DOMStringMap.cpp
@@ -193,9 +193,9 @@ WebIDL::ExceptionOr<Bindings::LegacyPlatformObject::DidDeletionFail> DOMStringMa
     return DidDeletionFail::No;
 }
 
-WebIDL::ExceptionOr<JS::Value> DOMStringMap::named_item_value(DeprecatedFlyString const& name) const
+WebIDL::ExceptionOr<JS::Value> DOMStringMap::named_item_value(FlyString const& name) const
 {
-    return JS::PrimitiveString::create(vm(), determine_value_of_named_property(name));
+    return JS::PrimitiveString::create(vm(), determine_value_of_named_property(name.to_deprecated_fly_string()));
 }
 
 }

--- a/Userland/Libraries/LibWeb/HTML/DOMStringMap.cpp
+++ b/Userland/Libraries/LibWeb/HTML/DOMStringMap.cpp
@@ -48,10 +48,10 @@ Vector<DOMStringMap::NameValuePair> DOMStringMap::get_name_value_pairs() const
     //    in the order that those attributes are listed in the element's attribute list, add a name-value pair to list whose name is the attribute's name with the first five characters removed and whose value
     //    is the attribute's value.
     m_associated_element->for_each_attribute([&](auto& name, auto& value) {
-        if (!name.starts_with("data-"sv))
+        if (!name.bytes_as_string_view().starts_with("data-"sv))
             return;
 
-        auto name_after_starting_data = name.view().substring_view(5);
+        auto name_after_starting_data = name.bytes_as_string_view().substring_view(5);
 
         for (auto character : name_after_starting_data) {
             if (is_ascii_upper_alpha(character))

--- a/Userland/Libraries/LibWeb/HTML/DOMStringMap.h
+++ b/Userland/Libraries/LibWeb/HTML/DOMStringMap.h
@@ -35,7 +35,7 @@ private:
     virtual void visit_edges(Cell::Visitor&) override;
 
     // ^LegacyPlatformObject
-    virtual WebIDL::ExceptionOr<JS::Value> named_item_value(DeprecatedFlyString const&) const override;
+    virtual WebIDL::ExceptionOr<JS::Value> named_item_value(FlyString const&) const override;
     virtual Vector<DeprecatedString> supported_property_names() const override;
 
     virtual bool supports_indexed_properties() const override { return false; }

--- a/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.cpp
@@ -27,7 +27,7 @@ void HTMLAnchorElement::initialize(JS::Realm& realm)
     set_prototype(&Bindings::ensure_web_prototype<Bindings::HTMLAnchorElementPrototype>(realm, "HTMLAnchorElement"));
 }
 
-void HTMLAnchorElement::attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value)
+void HTMLAnchorElement::attribute_changed(FlyString const& name, DeprecatedString const& value)
 {
     HTMLElement::attribute_changed(name, value);
     if (name == HTML::AttributeNames::href) {
@@ -40,7 +40,7 @@ DeprecatedString HTMLAnchorElement::hyperlink_element_utils_href() const
     return deprecated_attribute(HTML::AttributeNames::href);
 }
 
-WebIDL::ExceptionOr<void> HTMLAnchorElement::set_hyperlink_element_utils_href(DeprecatedString href)
+WebIDL::ExceptionOr<void> HTMLAnchorElement::set_hyperlink_element_utils_href(String href)
 {
     return set_attribute(HTML::AttributeNames::href, move(href));
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.h
@@ -43,13 +43,13 @@ private:
     void run_activation_behavior(Web::DOM::Event const&);
 
     // ^DOM::Element
-    virtual void attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(FlyString const& name, DeprecatedString const& value) override;
     virtual i32 default_tab_index_value() const override;
 
     // ^HTML::HTMLHyperlinkElementUtils
     virtual DOM::Document& hyperlink_element_utils_document() override { return document(); }
     virtual DeprecatedString hyperlink_element_utils_href() const override;
-    virtual WebIDL::ExceptionOr<void> set_hyperlink_element_utils_href(DeprecatedString) override;
+    virtual WebIDL::ExceptionOr<void> set_hyperlink_element_utils_href(String) override;
     virtual bool hyperlink_element_utils_is_html_anchor_element() const final { return true; }
     virtual bool hyperlink_element_utils_is_connected() const final { return is_connected(); }
     virtual void hyperlink_element_utils_queue_an_element_task(HTML::Task::Source source, Function<void()> steps) override

--- a/Userland/Libraries/LibWeb/HTML/HTMLAreaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLAreaElement.cpp
@@ -23,7 +23,7 @@ void HTMLAreaElement::initialize(JS::Realm& realm)
     set_prototype(&Bindings::ensure_web_prototype<Bindings::HTMLAreaElementPrototype>(realm, "HTMLAreaElement"));
 }
 
-void HTMLAreaElement::attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value)
+void HTMLAreaElement::attribute_changed(FlyString const& name, DeprecatedString const& value)
 {
     HTMLElement::attribute_changed(name, value);
     if (name == HTML::AttributeNames::href) {
@@ -36,7 +36,7 @@ DeprecatedString HTMLAreaElement::hyperlink_element_utils_href() const
     return deprecated_attribute(HTML::AttributeNames::href);
 }
 
-WebIDL::ExceptionOr<void> HTMLAreaElement::set_hyperlink_element_utils_href(DeprecatedString href)
+WebIDL::ExceptionOr<void> HTMLAreaElement::set_hyperlink_element_utils_href(String href)
 {
     return set_attribute(HTML::AttributeNames::href, move(href));
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLAreaElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLAreaElement.h
@@ -26,13 +26,13 @@ private:
     virtual void initialize(JS::Realm&) override;
 
     // ^DOM::Element
-    virtual void attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(FlyString const& name, DeprecatedString const& value) override;
     virtual i32 default_tab_index_value() const override;
 
     // ^HTML::HTMLHyperlinkElementUtils
     virtual DOM::Document& hyperlink_element_utils_document() override { return document(); }
     virtual DeprecatedString hyperlink_element_utils_href() const override;
-    virtual WebIDL::ExceptionOr<void> set_hyperlink_element_utils_href(DeprecatedString) override;
+    virtual WebIDL::ExceptionOr<void> set_hyperlink_element_utils_href(String) override;
     virtual bool hyperlink_element_utils_is_html_anchor_element() const override { return false; }
     virtual bool hyperlink_element_utils_is_connected() const override { return is_connected(); }
     virtual void hyperlink_element_utils_queue_an_element_task(HTML::Task::Source source, Function<void()> steps) override

--- a/Userland/Libraries/LibWeb/HTML/HTMLBaseElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLBaseElement.cpp
@@ -43,7 +43,7 @@ void HTMLBaseElement::removed_from(Node* parent)
     document().update_base_element({});
 }
 
-void HTMLBaseElement::attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value)
+void HTMLBaseElement::attribute_changed(FlyString const& name, DeprecatedString const& value)
 {
     HTMLElement::attribute_changed(name, value);
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLBaseElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLBaseElement.h
@@ -23,7 +23,7 @@ public:
 
     virtual void inserted() override;
     virtual void removed_from(Node*) override;
-    virtual void attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(FlyString const& name, DeprecatedString const& value) override;
 
 private:
     HTMLBaseElement(DOM::Document&, DOM::QualifiedName);

--- a/Userland/Libraries/LibWeb/HTML/HTMLBodyElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLBodyElement.cpp
@@ -55,7 +55,7 @@ void HTMLBodyElement::apply_presentational_hints(CSS::StyleProperties& style) co
     });
 }
 
-void HTMLBodyElement::attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value)
+void HTMLBodyElement::attribute_changed(FlyString const& name, DeprecatedString const& value)
 {
     HTMLElement::attribute_changed(name, value);
     if (name.equals_ignoring_ascii_case("link"sv)) {

--- a/Userland/Libraries/LibWeb/HTML/HTMLBodyElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLBodyElement.h
@@ -20,7 +20,7 @@ class HTMLBodyElement final
 public:
     virtual ~HTMLBodyElement() override;
 
-    virtual void attribute_changed(DeprecatedFlyString const&, DeprecatedString const&) override;
+    virtual void attribute_changed(FlyString const&, DeprecatedString const&) override;
     virtual void apply_presentational_hints(CSS::StyleProperties&) const override;
 
     // https://www.w3.org/TR/html-aria/#el-body

--- a/Userland/Libraries/LibWeb/HTML/HTMLCanvasElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLCanvasElement.cpp
@@ -111,7 +111,7 @@ void HTMLCanvasElement::reset_context_to_default_state()
 
 WebIDL::ExceptionOr<void> HTMLCanvasElement::set_width(unsigned value)
 {
-    TRY(set_attribute(HTML::AttributeNames::width, DeprecatedString::number(value)));
+    TRY(set_attribute(HTML::AttributeNames::width, MUST(String::number(value))));
     m_bitmap = nullptr;
     reset_context_to_default_state();
     return {};
@@ -119,7 +119,7 @@ WebIDL::ExceptionOr<void> HTMLCanvasElement::set_width(unsigned value)
 
 WebIDL::ExceptionOr<void> HTMLCanvasElement::set_height(unsigned value)
 {
-    TRY(set_attribute(HTML::AttributeNames::height, DeprecatedString::number(value)));
+    TRY(set_attribute(HTML::AttributeNames::height, MUST(String::number(value))));
     m_bitmap = nullptr;
     reset_context_to_default_state();
     return {};

--- a/Userland/Libraries/LibWeb/HTML/HTMLDetailsElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLDetailsElement.cpp
@@ -41,7 +41,7 @@ void HTMLDetailsElement::initialize(JS::Realm& realm)
     create_shadow_tree(realm).release_value_but_fixme_should_propagate_errors();
 }
 
-void HTMLDetailsElement::attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value)
+void HTMLDetailsElement::attribute_changed(FlyString const& name, DeprecatedString const& value)
 {
     Base::attribute_changed(name, value);
 
@@ -160,13 +160,13 @@ void HTMLDetailsElement::update_shadow_tree_style()
     if (has_attribute(HTML::AttributeNames::open)) {
         MUST(m_descendants_slot->set_attribute(HTML::AttributeNames::style, R"~~~(
             display: block;
-        )~~~"));
+        )~~~"_string));
     } else {
         // FIXME: Should be `display: block` but we do not support `content-visibility: hidden`.
         MUST(m_descendants_slot->set_attribute(HTML::AttributeNames::style, R"~~~(
             display: none;
             content-visibility: hidden;
-        )~~~"));
+        )~~~"_string));
     }
 }
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLDetailsElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLDetailsElement.h
@@ -31,7 +31,7 @@ private:
     virtual void visit_edges(Cell::Visitor&) override;
 
     virtual void children_changed() override;
-    virtual void attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(FlyString const& name, DeprecatedString const& value) override;
 
     void queue_a_details_toggle_event_task(String old_state, String new_state);
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLElement.cpp
@@ -112,11 +112,11 @@ WebIDL::ExceptionOr<void> HTMLElement::set_content_editable(StringView content_e
         return {};
     }
     if (content_editable.equals_ignoring_ascii_case("true"sv)) {
-        MUST(set_attribute(HTML::AttributeNames::contenteditable, "true"));
+        MUST(set_attribute(HTML::AttributeNames::contenteditable, "true"_string));
         return {};
     }
     if (content_editable.equals_ignoring_ascii_case("false"sv)) {
-        MUST(set_attribute(HTML::AttributeNames::contenteditable, "false"));
+        MUST(set_attribute(HTML::AttributeNames::contenteditable, "false"_string));
         return {};
     }
     return WebIDL::SyntaxError::create(realm(), "Invalid contentEditable value, must be 'true', 'false', or 'inherit'"_fly_string);
@@ -224,7 +224,7 @@ bool HTMLElement::cannot_navigate() const
     return !is<HTML::HTMLAnchorElement>(this) && !is_connected();
 }
 
-void HTMLElement::attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value)
+void HTMLElement::attribute_changed(FlyString const& name, DeprecatedString const& value)
 {
     Element::attribute_changed(name, value);
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLElement.h
@@ -70,7 +70,7 @@ protected:
 
     virtual void initialize(JS::Realm&) override;
 
-    virtual void attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(FlyString const& name, DeprecatedString const& value) override;
 
     virtual void visit_edges(Cell::Visitor&) override;
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLFrameSetElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFrameSetElement.cpp
@@ -23,7 +23,7 @@ void HTMLFrameSetElement::initialize(JS::Realm& realm)
     set_prototype(&Bindings::ensure_web_prototype<Bindings::HTMLFrameSetElementPrototype>(realm, "HTMLFrameSetElement"));
 }
 
-void HTMLFrameSetElement::attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value)
+void HTMLFrameSetElement::attribute_changed(FlyString const& name, DeprecatedString const& value)
 {
     HTMLElement::attribute_changed(name, value);
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLFrameSetElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFrameSetElement.h
@@ -24,7 +24,7 @@ private:
     HTMLFrameSetElement(DOM::Document&, DOM::QualifiedName);
 
     virtual void initialize(JS::Realm&) override;
-    virtual void attribute_changed(DeprecatedFlyString const&, DeprecatedString const&) override;
+    virtual void attribute_changed(FlyString const&, DeprecatedString const&) override;
 
     // ^HTML::GlobalEventHandlers
     virtual EventTarget& global_event_handlers_to_event_target(FlyString const& event_name) override;

--- a/Userland/Libraries/LibWeb/HTML/HTMLHyperlinkElementUtils.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLHyperlinkElementUtils.cpp
@@ -441,10 +441,10 @@ DeprecatedString HTMLHyperlinkElementUtils::href() const
 }
 
 // https://html.spec.whatwg.org/multipage/links.html#dom-hyperlink-href
-WebIDL::ExceptionOr<void> HTMLHyperlinkElementUtils::set_href(StringView href)
+WebIDL::ExceptionOr<void> HTMLHyperlinkElementUtils::set_href(String href)
 {
     // The href attribute's setter must set this element's href content attribute's value to the given value.
-    return set_hyperlink_element_utils_href(href);
+    return set_hyperlink_element_utils_href(move(href));
 }
 
 // https://html.spec.whatwg.org/multipage/links.html#update-href

--- a/Userland/Libraries/LibWeb/HTML/HTMLHyperlinkElementUtils.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLHyperlinkElementUtils.h
@@ -20,7 +20,7 @@ public:
     DeprecatedString origin() const;
 
     DeprecatedString href() const;
-    WebIDL::ExceptionOr<void> set_href(StringView);
+    WebIDL::ExceptionOr<void> set_href(String);
 
     DeprecatedString protocol() const;
     void set_protocol(StringView);
@@ -52,7 +52,7 @@ public:
 protected:
     virtual DOM::Document& hyperlink_element_utils_document() = 0;
     virtual DeprecatedString hyperlink_element_utils_href() const = 0;
-    virtual WebIDL::ExceptionOr<void> set_hyperlink_element_utils_href(DeprecatedString) = 0;
+    virtual WebIDL::ExceptionOr<void> set_hyperlink_element_utils_href(String) = 0;
     virtual bool hyperlink_element_utils_is_html_anchor_element() const = 0;
     virtual bool hyperlink_element_utils_is_connected() const = 0;
     virtual DeprecatedString hyperlink_element_utils_get_an_elements_target() const = 0;

--- a/Userland/Libraries/LibWeb/HTML/HTMLIFrameElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLIFrameElement.cpp
@@ -33,7 +33,7 @@ JS::GCPtr<Layout::Node> HTMLIFrameElement::create_layout_node(NonnullRefPtr<CSS:
     return heap().allocate_without_realm<Layout::FrameBox>(document(), *this, move(style));
 }
 
-void HTMLIFrameElement::attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value)
+void HTMLIFrameElement::attribute_changed(FlyString const& name, DeprecatedString const& value)
 {
     HTMLElement::attribute_changed(name, value);
     if (m_content_navigable)

--- a/Userland/Libraries/LibWeb/HTML/HTMLIFrameElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLIFrameElement.h
@@ -36,7 +36,7 @@ private:
     // ^DOM::Element
     virtual void inserted() override;
     virtual void removed_from(Node*) override;
-    virtual void attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(FlyString const& name, DeprecatedString const& value) override;
     virtual i32 default_tab_index_value() const override;
 
     // https://html.spec.whatwg.org/multipage/iframe-embed-object.html#process-the-iframe-attributes

--- a/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -95,7 +95,7 @@ void HTMLImageElement::apply_presentational_hints(CSS::StyleProperties& style) c
     });
 }
 
-void HTMLImageElement::attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value)
+void HTMLImageElement::attribute_changed(FlyString const& name, DeprecatedString const& value)
 {
     HTMLElement::attribute_changed(name, value);
 
@@ -190,7 +190,7 @@ unsigned HTMLImageElement::width() const
 
 WebIDL::ExceptionOr<void> HTMLImageElement::set_width(unsigned width)
 {
-    return set_attribute(HTML::AttributeNames::width, DeprecatedString::number(width));
+    return set_attribute(HTML::AttributeNames::width, MUST(String::number(width)));
 }
 
 // https://html.spec.whatwg.org/multipage/embedded-content.html#dom-img-height
@@ -218,7 +218,7 @@ unsigned HTMLImageElement::height() const
 
 WebIDL::ExceptionOr<void> HTMLImageElement::set_height(unsigned height)
 {
-    return set_attribute(HTML::AttributeNames::height, DeprecatedString::number(height));
+    return set_attribute(HTML::AttributeNames::height, MUST(String::number(height)));
 }
 
 // https://html.spec.whatwg.org/multipage/embedded-content.html#dom-img-naturalwidth

--- a/Userland/Libraries/LibWeb/HTML/HTMLImageElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLImageElement.h
@@ -32,7 +32,7 @@ class HTMLImageElement final
 public:
     virtual ~HTMLImageElement() override;
 
-    virtual void attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(FlyString const& name, DeprecatedString const& value) override;
 
     DeprecatedString alt() const { return deprecated_attribute(HTML::AttributeNames::alt); }
     DeprecatedString src() const { return deprecated_attribute(HTML::AttributeNames::src); }

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -532,7 +532,7 @@ void HTMLInputElement::create_shadow_tree_if_needed()
         white-space: pre;
         border: none;
         padding: 1px 2px;
-)~~~"));
+)~~~"_string));
 
     m_placeholder_element = heap().allocate<PlaceholderElement>(realm(), document());
     MUST(m_placeholder_element->style_for_bindings()->set_property(CSS::PropertyID::Height, "1lh"sv));
@@ -586,7 +586,7 @@ void HTMLInputElement::did_lose_focus()
     });
 }
 
-void HTMLInputElement::attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value)
+void HTMLInputElement::attribute_changed(FlyString const& name, DeprecatedString const& value)
 {
     HTMLElement::attribute_changed(name, value);
     if (name == HTML::AttributeNames::checked) {

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -111,7 +111,7 @@ public:
     virtual bool is_focusable() const override { return m_type != TypeAttributeState::Hidden; }
 
     // ^HTMLElement
-    virtual void attribute_changed(DeprecatedFlyString const&, DeprecatedString const&) override;
+    virtual void attribute_changed(FlyString const&, DeprecatedString const&) override;
 
     // ^FormAssociatedElement
     // https://html.spec.whatwg.org/multipage/forms.html#category-listed

--- a/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
@@ -77,7 +77,7 @@ bool HTMLLinkElement::has_loaded_icon() const
     return m_relationship & Relationship::Icon && resource() && resource()->is_loaded() && resource()->has_encoded_data();
 }
 
-void HTMLLinkElement::attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value)
+void HTMLLinkElement::attribute_changed(FlyString const& name, DeprecatedString const& value)
 {
     HTMLElement::attribute_changed(name, value);
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.h
@@ -39,7 +39,7 @@ private:
     HTMLLinkElement(DOM::Document&, DOM::QualifiedName);
 
     virtual void initialize(JS::Realm&) override;
-    void attribute_changed(DeprecatedFlyString const&, DeprecatedString const&) override;
+    void attribute_changed(FlyString const&, DeprecatedString const&) override;
 
     // ^ResourceClient
     virtual void resource_did_fail() override;

--- a/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -83,7 +83,7 @@ void HTMLMediaElement::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_fetch_controller);
 }
 
-void HTMLMediaElement::attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value)
+void HTMLMediaElement::attribute_changed(FlyString const& name, DeprecatedString const& value)
 {
     Base::attribute_changed(name, value);
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.h
@@ -134,7 +134,7 @@ protected:
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
 
-    virtual void attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(FlyString const& name, DeprecatedString const& value) override;
     virtual void removed_from(DOM::Node*) override;
     virtual void children_changed() override;
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLObjectElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLObjectElement.cpp
@@ -45,7 +45,7 @@ void HTMLObjectElement::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_image_request);
 }
 
-void HTMLObjectElement::attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value)
+void HTMLObjectElement::attribute_changed(FlyString const& name, DeprecatedString const& value)
 {
     NavigableContainer::attribute_changed(name, value);
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLObjectElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLObjectElement.h
@@ -34,7 +34,7 @@ class HTMLObjectElement final
 public:
     virtual ~HTMLObjectElement() override;
 
-    virtual void attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(FlyString const& name, DeprecatedString const& value) override;
 
     String data() const;
     void set_data(String const& data) { MUST(set_attribute(HTML::AttributeNames::data, data)); }

--- a/Userland/Libraries/LibWeb/HTML/HTMLOptionElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLOptionElement.cpp
@@ -31,7 +31,7 @@ void HTMLOptionElement::initialize(JS::Realm& realm)
     set_prototype(&Bindings::ensure_web_prototype<Bindings::HTMLOptionElementPrototype>(realm, "HTMLOptionElement"));
 }
 
-void HTMLOptionElement::attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value)
+void HTMLOptionElement::attribute_changed(FlyString const& name, DeprecatedString const& value)
 {
     HTMLElement::attribute_changed(name, value);
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLOptionElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLOptionElement.h
@@ -40,7 +40,7 @@ private:
 
     virtual void initialize(JS::Realm&) override;
 
-    void attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value) override;
+    void attribute_changed(FlyString const& name, DeprecatedString const& value) override;
 
     void ask_for_a_reset();
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLProgressElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLProgressElement.cpp
@@ -71,7 +71,7 @@ WebIDL::ExceptionOr<void> HTMLProgressElement::set_value(double value)
     if (value < 0)
         return {};
 
-    TRY(set_attribute(HTML::AttributeNames::value, DeprecatedString::number(value)));
+    TRY(set_attribute(HTML::AttributeNames::value, MUST(String::number(value))));
     progress_position_updated();
     return {};
 }
@@ -98,7 +98,7 @@ WebIDL::ExceptionOr<void> HTMLProgressElement::set_max(double value)
     if (value <= 0)
         return {};
 
-    TRY(set_attribute(HTML::AttributeNames::max, DeprecatedString::number(value)));
+    TRY(set_attribute(HTML::AttributeNames::max, MUST(String::number(value))));
     progress_position_updated();
     return {};
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
@@ -45,7 +45,7 @@ void HTMLScriptElement::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_preparation_time_document.ptr());
 }
 
-void HTMLScriptElement::attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value)
+void HTMLScriptElement::attribute_changed(FlyString const& name, DeprecatedString const& value)
 {
     Base::attribute_changed(name, value);
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLScriptElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLScriptElement.h
@@ -62,7 +62,7 @@ private:
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
 
-    virtual void attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(FlyString const& name, DeprecatedString const& value) override;
 
     // https://html.spec.whatwg.org/multipage/scripting.html#prepare-the-script-element
     void prepare_script();

--- a/Userland/Libraries/LibWeb/HTML/HTMLSummaryElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLSummaryElement.cpp
@@ -27,7 +27,7 @@ HTMLSummaryElement::HTMLSummaryElement(DOM::Document& document, DOM::QualifiedNa
         if (parent->has_attribute(HTML::AttributeNames::open))
             parent->remove_attribute(HTML::AttributeNames::open);
         else
-            parent->set_attribute(HTML::AttributeNames::open, "").release_value_but_fixme_should_propagate_errors();
+            parent->set_attribute(HTML::AttributeNames::open, String {}).release_value_but_fixme_should_propagate_errors();
     };
 }
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLTableCellElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableCellElement.cpp
@@ -116,7 +116,7 @@ unsigned int HTMLTableCellElement::col_span() const
 
 WebIDL::ExceptionOr<void> HTMLTableCellElement::set_col_span(unsigned int value)
 {
-    return set_attribute(HTML::AttributeNames::colspan, DeprecatedString::number(value));
+    return set_attribute(HTML::AttributeNames::colspan, MUST(String::number(value)));
 }
 
 // This implements step 9 in the spec here:
@@ -136,7 +136,7 @@ unsigned int HTMLTableCellElement::row_span() const
 
 WebIDL::ExceptionOr<void> HTMLTableCellElement::set_row_span(unsigned int value)
 {
-    return set_attribute(HTML::AttributeNames::rowspan, DeprecatedString::number(value));
+    return set_attribute(HTML::AttributeNames::rowspan, MUST(String::number(value)));
 }
 
 Optional<ARIA::Role> HTMLTableCellElement::default_role() const

--- a/Userland/Libraries/LibWeb/HTML/HTMLVideoElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLVideoElement.cpp
@@ -40,7 +40,7 @@ void HTMLVideoElement::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_fetch_controller);
 }
 
-void HTMLVideoElement::attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value)
+void HTMLVideoElement::attribute_changed(FlyString const& name, DeprecatedString const& value)
 {
     Base::attribute_changed(name, value);
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLVideoElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLVideoElement.h
@@ -47,7 +47,7 @@ private:
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
 
-    virtual void attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(FlyString const& name, DeprecatedString const& value) override;
 
     virtual JS::GCPtr<Layout::Node> create_layout_node(NonnullRefPtr<CSS::StyleProperties>) override;
 

--- a/Userland/Libraries/LibWeb/HTML/MimeTypeArray.cpp
+++ b/Userland/Libraries/LibWeb/HTML/MimeTypeArray.cpp
@@ -75,7 +75,7 @@ JS::GCPtr<MimeType> MimeTypeArray::item(u32 index) const
 }
 
 // https://html.spec.whatwg.org/multipage/system-state.html#dom-mimetypearray-nameditem
-JS::GCPtr<MimeType> MimeTypeArray::named_item(String const& name) const
+JS::GCPtr<MimeType> MimeTypeArray::named_item(FlyString const& name) const
 {
     // 1. For each MimeType mimeType of this's relevant global object's PDF viewer mime type objects: if mimeType's type is name, then return mimeType.
     auto& window = verify_cast<HTML::Window>(HTML::relevant_global_object(*this));
@@ -98,10 +98,9 @@ WebIDL::ExceptionOr<JS::Value> MimeTypeArray::item_value(size_t index) const
     return return_value.ptr();
 }
 
-WebIDL::ExceptionOr<JS::Value> MimeTypeArray::named_item_value(DeprecatedFlyString const& name) const
+WebIDL::ExceptionOr<JS::Value> MimeTypeArray::named_item_value(FlyString const& name) const
 {
-    auto converted_name = TRY_OR_THROW_OOM(vm(), String::from_deprecated_string(name));
-    auto return_value = named_item(converted_name);
+    auto return_value = named_item(name);
     if (!return_value)
         return JS::js_null();
     return return_value.ptr();

--- a/Userland/Libraries/LibWeb/HTML/MimeTypeArray.h
+++ b/Userland/Libraries/LibWeb/HTML/MimeTypeArray.h
@@ -19,7 +19,7 @@ public:
 
     size_t length() const;
     JS::GCPtr<MimeType> item(u32 index) const;
-    JS::GCPtr<MimeType> named_item(String const& name) const;
+    JS::GCPtr<MimeType> named_item(FlyString const& name) const;
 
 private:
     MimeTypeArray(JS::Realm&);
@@ -29,7 +29,7 @@ private:
     // ^Bindings::LegacyPlatformObject
     virtual Vector<DeprecatedString> supported_property_names() const override;
     virtual WebIDL::ExceptionOr<JS::Value> item_value(size_t index) const override;
-    virtual WebIDL::ExceptionOr<JS::Value> named_item_value(DeprecatedFlyString const& name) const override;
+    virtual WebIDL::ExceptionOr<JS::Value> named_item_value(FlyString const& name) const override;
     virtual bool is_supported_property_index(u32) const override;
 
     virtual bool supports_indexed_properties() const override { return true; }

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
@@ -3514,7 +3514,7 @@ void HTMLParser::process_using_the_rules_for_foreign_content(HTMLToken& token)
         if (token.is_self_closing()) {
 
             // -> If the token's tag name is "script", and the new current node is in the SVG namespace
-            if (token.tag_name().to_deprecated_fly_string() == SVG::TagNames::script && current_node().namespace_() == Namespace::SVG) {
+            if (token.tag_name() == SVG::TagNames::script && current_node().namespace_() == Namespace::SVG) {
                 // Acknowledge the token's self-closing flag, and then act as described in the steps for a "script" end tag below.
                 token.acknowledge_self_closing_flag_if_set();
                 goto ScriptEndTag;
@@ -3531,7 +3531,7 @@ void HTMLParser::process_using_the_rules_for_foreign_content(HTMLToken& token)
     }
 
     // -> An end tag whose tag name is "script", if the current node is an SVG script element
-    if (token.is_end_tag() && current_node().namespace_() == Namespace::SVG && current_node().tag_name().to_deprecated_fly_string() == SVG::TagNames::script) {
+    if (token.is_end_tag() && current_node().namespace_() == Namespace::SVG && current_node().tag_name() == SVG::TagNames::script) {
     ScriptEndTag:
         // Pop the current node off the stack of open elements.
         (void)m_stack_of_open_elements.pop();

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
@@ -2189,7 +2189,7 @@ void HTMLParser::handle_in_body(HTMLToken& token)
 
 void HTMLParser::adjust_mathml_attributes(HTMLToken& token)
 {
-    token.adjust_attribute_name("definitionurl", "definitionURL");
+    token.adjust_attribute_name("definitionurl"_fly_string, "definitionURL"_fly_string);
 }
 
 void HTMLParser::adjust_svg_tag_names(HTMLToken& token)
@@ -2233,81 +2233,81 @@ void HTMLParser::adjust_svg_tag_names(HTMLToken& token)
 
 void HTMLParser::adjust_svg_attributes(HTMLToken& token)
 {
-    token.adjust_attribute_name("attributename", "attributeName");
-    token.adjust_attribute_name("attributetype", "attributeType");
-    token.adjust_attribute_name("basefrequency", "baseFrequency");
-    token.adjust_attribute_name("baseprofile", "baseProfile");
-    token.adjust_attribute_name("calcmode", "calcMode");
-    token.adjust_attribute_name("clippathunits", "clipPathUnits");
-    token.adjust_attribute_name("diffuseconstant", "diffuseConstant");
-    token.adjust_attribute_name("edgemode", "edgeMode");
-    token.adjust_attribute_name("filterunits", "filterUnits");
-    token.adjust_attribute_name("glyphref", "glyphRef");
-    token.adjust_attribute_name("gradienttransform", "gradientTransform");
-    token.adjust_attribute_name("gradientunits", "gradientUnits");
-    token.adjust_attribute_name("kernelmatrix", "kernelMatrix");
-    token.adjust_attribute_name("kernelunitlength", "kernelUnitLength");
-    token.adjust_attribute_name("keypoints", "keyPoints");
-    token.adjust_attribute_name("keysplines", "keySplines");
-    token.adjust_attribute_name("keytimes", "keyTimes");
-    token.adjust_attribute_name("lengthadjust", "lengthAdjust");
-    token.adjust_attribute_name("limitingconeangle", "limitingConeAngle");
-    token.adjust_attribute_name("markerheight", "markerHeight");
-    token.adjust_attribute_name("markerunits", "markerUnits");
-    token.adjust_attribute_name("markerwidth", "markerWidth");
-    token.adjust_attribute_name("maskcontentunits", "maskContentUnits");
-    token.adjust_attribute_name("maskunits", "maskUnits");
-    token.adjust_attribute_name("numoctaves", "numOctaves");
-    token.adjust_attribute_name("pathlength", "pathLength");
-    token.adjust_attribute_name("patterncontentunits", "patternContentUnits");
-    token.adjust_attribute_name("patterntransform", "patternTransform");
-    token.adjust_attribute_name("patternunits", "patternUnits");
-    token.adjust_attribute_name("pointsatx", "pointsAtX");
-    token.adjust_attribute_name("pointsaty", "pointsAtY");
-    token.adjust_attribute_name("pointsatz", "pointsAtZ");
-    token.adjust_attribute_name("preservealpha", "preserveAlpha");
-    token.adjust_attribute_name("preserveaspectratio", "preserveAspectRatio");
-    token.adjust_attribute_name("primitiveunits", "primitiveUnits");
-    token.adjust_attribute_name("refx", "refX");
-    token.adjust_attribute_name("refy", "refY");
-    token.adjust_attribute_name("repeatcount", "repeatCount");
-    token.adjust_attribute_name("repeatdur", "repeatDur");
-    token.adjust_attribute_name("requiredextensions", "requiredExtensions");
-    token.adjust_attribute_name("requiredfeatures", "requiredFeatures");
-    token.adjust_attribute_name("specularconstant", "specularConstant");
-    token.adjust_attribute_name("specularexponent", "specularExponent");
-    token.adjust_attribute_name("spreadmethod", "spreadMethod");
-    token.adjust_attribute_name("startoffset", "startOffset");
-    token.adjust_attribute_name("stddeviation", "stdDeviation");
-    token.adjust_attribute_name("stitchtiles", "stitchTiles");
-    token.adjust_attribute_name("surfacescale", "surfaceScale");
-    token.adjust_attribute_name("systemlanguage", "systemLanguage");
-    token.adjust_attribute_name("tablevalues", "tableValues");
-    token.adjust_attribute_name("targetx", "targetX");
-    token.adjust_attribute_name("targety", "targetY");
-    token.adjust_attribute_name("textlength", "textLength");
-    token.adjust_attribute_name("viewbox", "viewBox");
-    token.adjust_attribute_name("viewtarget", "viewTarget");
-    token.adjust_attribute_name("xchannelselector", "xChannelSelector");
-    token.adjust_attribute_name("ychannelselector", "yChannelSelector");
-    token.adjust_attribute_name("zoomandpan", "zoomAndPan");
+    token.adjust_attribute_name("attributename"_fly_string, "attributeName"_fly_string);
+    token.adjust_attribute_name("attributetype"_fly_string, "attributeType"_fly_string);
+    token.adjust_attribute_name("basefrequency"_fly_string, "baseFrequency"_fly_string);
+    token.adjust_attribute_name("baseprofile"_fly_string, "baseProfile"_fly_string);
+    token.adjust_attribute_name("calcmode"_fly_string, "calcMode"_fly_string);
+    token.adjust_attribute_name("clippathunits"_fly_string, "clipPathUnits"_fly_string);
+    token.adjust_attribute_name("diffuseconstant"_fly_string, "diffuseConstant"_fly_string);
+    token.adjust_attribute_name("edgemode"_fly_string, "edgeMode"_fly_string);
+    token.adjust_attribute_name("filterunits"_fly_string, "filterUnits"_fly_string);
+    token.adjust_attribute_name("glyphref"_fly_string, "glyphRef"_fly_string);
+    token.adjust_attribute_name("gradienttransform"_fly_string, "gradientTransform"_fly_string);
+    token.adjust_attribute_name("gradientunits"_fly_string, "gradientUnits"_fly_string);
+    token.adjust_attribute_name("kernelmatrix"_fly_string, "kernelMatrix"_fly_string);
+    token.adjust_attribute_name("kernelunitlength"_fly_string, "kernelUnitLength"_fly_string);
+    token.adjust_attribute_name("keypoints"_fly_string, "keyPoints"_fly_string);
+    token.adjust_attribute_name("keysplines"_fly_string, "keySplines"_fly_string);
+    token.adjust_attribute_name("keytimes"_fly_string, "keyTimes"_fly_string);
+    token.adjust_attribute_name("lengthadjust"_fly_string, "lengthAdjust"_fly_string);
+    token.adjust_attribute_name("limitingconeangle"_fly_string, "limitingConeAngle"_fly_string);
+    token.adjust_attribute_name("markerheight"_fly_string, "markerHeight"_fly_string);
+    token.adjust_attribute_name("markerunits"_fly_string, "markerUnits"_fly_string);
+    token.adjust_attribute_name("markerwidth"_fly_string, "markerWidth"_fly_string);
+    token.adjust_attribute_name("maskcontentunits"_fly_string, "maskContentUnits"_fly_string);
+    token.adjust_attribute_name("maskunits"_fly_string, "maskUnits"_fly_string);
+    token.adjust_attribute_name("numoctaves"_fly_string, "numOctaves"_fly_string);
+    token.adjust_attribute_name("pathlength"_fly_string, "pathLength"_fly_string);
+    token.adjust_attribute_name("patterncontentunits"_fly_string, "patternContentUnits"_fly_string);
+    token.adjust_attribute_name("patterntransform"_fly_string, "patternTransform"_fly_string);
+    token.adjust_attribute_name("patternunits"_fly_string, "patternUnits"_fly_string);
+    token.adjust_attribute_name("pointsatx"_fly_string, "pointsAtX"_fly_string);
+    token.adjust_attribute_name("pointsaty"_fly_string, "pointsAtY"_fly_string);
+    token.adjust_attribute_name("pointsatz"_fly_string, "pointsAtZ"_fly_string);
+    token.adjust_attribute_name("preservealpha"_fly_string, "preserveAlpha"_fly_string);
+    token.adjust_attribute_name("preserveaspectratio"_fly_string, "preserveAspectRatio"_fly_string);
+    token.adjust_attribute_name("primitiveunits"_fly_string, "primitiveUnits"_fly_string);
+    token.adjust_attribute_name("refx"_fly_string, "refX"_fly_string);
+    token.adjust_attribute_name("refy"_fly_string, "refY"_fly_string);
+    token.adjust_attribute_name("repeatcount"_fly_string, "repeatCount"_fly_string);
+    token.adjust_attribute_name("repeatdur"_fly_string, "repeatDur"_fly_string);
+    token.adjust_attribute_name("requiredextensions"_fly_string, "requiredExtensions"_fly_string);
+    token.adjust_attribute_name("requiredfeatures"_fly_string, "requiredFeatures"_fly_string);
+    token.adjust_attribute_name("specularconstant"_fly_string, "specularConstant"_fly_string);
+    token.adjust_attribute_name("specularexponent"_fly_string, "specularExponent"_fly_string);
+    token.adjust_attribute_name("spreadmethod"_fly_string, "spreadMethod"_fly_string);
+    token.adjust_attribute_name("startoffset"_fly_string, "startOffset"_fly_string);
+    token.adjust_attribute_name("stddeviation"_fly_string, "stdDeviation"_fly_string);
+    token.adjust_attribute_name("stitchtiles"_fly_string, "stitchTiles"_fly_string);
+    token.adjust_attribute_name("surfacescale"_fly_string, "surfaceScale"_fly_string);
+    token.adjust_attribute_name("systemlanguage"_fly_string, "systemLanguage"_fly_string);
+    token.adjust_attribute_name("tablevalues"_fly_string, "tableValues"_fly_string);
+    token.adjust_attribute_name("targetx"_fly_string, "targetX"_fly_string);
+    token.adjust_attribute_name("targety"_fly_string, "targetY"_fly_string);
+    token.adjust_attribute_name("textlength"_fly_string, "textLength"_fly_string);
+    token.adjust_attribute_name("viewbox"_fly_string, "viewBox"_fly_string);
+    token.adjust_attribute_name("viewtarget"_fly_string, "viewTarget"_fly_string);
+    token.adjust_attribute_name("xchannelselector"_fly_string, "xChannelSelector"_fly_string);
+    token.adjust_attribute_name("ychannelselector"_fly_string, "yChannelSelector"_fly_string);
+    token.adjust_attribute_name("zoomandpan"_fly_string, "zoomAndPan"_fly_string);
 }
 
 void HTMLParser::adjust_foreign_attributes(HTMLToken& token)
 {
-    token.adjust_foreign_attribute("xlink:actuate", "xlink", "actuate", Namespace::XLink);
-    token.adjust_foreign_attribute("xlink:arcrole", "xlink", "arcrole", Namespace::XLink);
-    token.adjust_foreign_attribute("xlink:href", "xlink", "href", Namespace::XLink);
-    token.adjust_foreign_attribute("xlink:role", "xlink", "role", Namespace::XLink);
-    token.adjust_foreign_attribute("xlink:show", "xlink", "show", Namespace::XLink);
-    token.adjust_foreign_attribute("xlink:title", "xlink", "title", Namespace::XLink);
-    token.adjust_foreign_attribute("xlink:type", "xlink", "type", Namespace::XLink);
+    token.adjust_foreign_attribute("xlink:actuate"_fly_string, "xlink", "actuate"_fly_string, Namespace::XLink);
+    token.adjust_foreign_attribute("xlink:arcrole"_fly_string, "xlink", "arcrole"_fly_string, Namespace::XLink);
+    token.adjust_foreign_attribute("xlink:href"_fly_string, "xlink", "href"_fly_string, Namespace::XLink);
+    token.adjust_foreign_attribute("xlink:role"_fly_string, "xlink", "role"_fly_string, Namespace::XLink);
+    token.adjust_foreign_attribute("xlink:show"_fly_string, "xlink", "show"_fly_string, Namespace::XLink);
+    token.adjust_foreign_attribute("xlink:title"_fly_string, "xlink", "title"_fly_string, Namespace::XLink);
+    token.adjust_foreign_attribute("xlink:type"_fly_string, "xlink", "type"_fly_string, Namespace::XLink);
 
-    token.adjust_foreign_attribute("xml:lang", "xml", "lang", Namespace::XML);
-    token.adjust_foreign_attribute("xml:space", "xml", "space", Namespace::XML);
+    token.adjust_foreign_attribute("xml:lang"_fly_string, "xml", "lang"_fly_string, Namespace::XML);
+    token.adjust_foreign_attribute("xml:space"_fly_string, "xml", "space"_fly_string, Namespace::XML);
 
-    token.adjust_foreign_attribute("xmlns", "", "xmlns", Namespace::XMLNS);
-    token.adjust_foreign_attribute("xmlns:xlink", "xmlns", "xlink", Namespace::XMLNS);
+    token.adjust_foreign_attribute("xmlns"_fly_string, "", "xmlns"_fly_string, Namespace::XMLNS);
+    token.adjust_foreign_attribute("xmlns:xlink"_fly_string, "xmlns", "xlink"_fly_string, Namespace::XMLNS);
 }
 
 void HTMLParser::increment_script_nesting_level()

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
@@ -813,7 +813,7 @@ void HTMLParser::handle_before_head(HTMLToken& token)
     }
 
 AnythingElse:
-    m_head_element = JS::make_handle(verify_cast<HTMLHeadElement>(*insert_html_element(HTMLToken::make_start_tag(HTML::TagNames::head.to_deprecated_fly_string()))));
+    m_head_element = JS::make_handle(verify_cast<HTMLHeadElement>(*insert_html_element(HTMLToken::make_start_tag(HTML::TagNames::head))));
     m_insertion_mode = InsertionMode::InHead;
     process_using_the_rules_for(InsertionMode::InHead, token);
     return;
@@ -1107,7 +1107,7 @@ void HTMLParser::handle_after_head(HTMLToken& token)
     }
 
 AnythingElse:
-    (void)insert_html_element(HTMLToken::make_start_tag(HTML::TagNames::body.to_deprecated_fly_string()));
+    (void)insert_html_element(HTMLToken::make_start_tag(HTML::TagNames::body));
     m_insertion_mode = InsertionMode::InBody;
     process_using_the_rules_for(m_insertion_mode, token);
 }
@@ -1242,7 +1242,7 @@ Create:
     VERIFY(!entry->is_marker());
 
     // FIXME: Hold on to the real token!
-    auto new_element = insert_html_element(HTMLToken::make_start_tag(entry->element->local_name().to_deprecated_fly_string()));
+    auto new_element = insert_html_element(HTMLToken::make_start_tag(entry->element->local_name()));
 
     // 9. Replace the entry for entry in the list with an entry for new element.
     m_list_of_active_formatting_elements.entries().at(index).element = JS::make_handle(new_element);
@@ -1383,7 +1383,7 @@ HTMLParser::AdoptionAgencyAlgorithmOutcome HTMLParser::run_the_adoption_agency_a
             // 6. Create an element for the token for which the element node was created,
             //    in the HTML namespace, with common ancestor as the intended parent;
             // FIXME: hold onto the real token
-            auto element = create_element_for(HTMLToken::make_start_tag(node->local_name().to_deprecated_fly_string()), Namespace::HTML, *common_ancestor);
+            auto element = create_element_for(HTMLToken::make_start_tag(node->local_name()), Namespace::HTML, *common_ancestor);
             // replace the entry for node in the list of active formatting elements with an entry for the new element,
             m_list_of_active_formatting_elements.replace(*node, *element);
             // replace the entry for node in the stack of open elements with an entry for the new element,
@@ -1412,7 +1412,7 @@ HTMLParser::AdoptionAgencyAlgorithmOutcome HTMLParser::run_the_adoption_agency_a
         // 15. Create an element for the token for which formatting element was created,
         //     in the HTML namespace, with furthest block as the intended parent.
         // FIXME: hold onto the real token
-        auto element = create_element_for(HTMLToken::make_start_tag(formatting_element->local_name().to_deprecated_fly_string()), Namespace::HTML, *furthest_block);
+        auto element = create_element_for(HTMLToken::make_start_tag(formatting_element->local_name()), Namespace::HTML, *furthest_block);
 
         // 16. Take all of the child nodes of furthest block and append them to the element created in the last step.
         for (auto& child : furthest_block->children_as_vector())
@@ -1846,7 +1846,7 @@ void HTMLParser::handle_in_body(HTMLToken& token)
     if (token.is_end_tag() && token.tag_name() == HTML::TagNames::p) {
         if (!m_stack_of_open_elements.has_in_button_scope(HTML::TagNames::p)) {
             log_parse_error();
-            (void)insert_html_element(HTMLToken::make_start_tag(HTML::TagNames::p.to_deprecated_fly_string()));
+            (void)insert_html_element(HTMLToken::make_start_tag(HTML::TagNames::p));
         }
         close_a_p_element();
         return;
@@ -2708,7 +2708,7 @@ void HTMLParser::handle_in_table_body(HTMLToken& token)
     if (token.is_start_tag() && token.tag_name().is_one_of(HTML::TagNames::th, HTML::TagNames::td)) {
         log_parse_error();
         clear_the_stack_back_to_a_table_body_context();
-        (void)insert_html_element(HTMLToken::make_start_tag(HTML::TagNames::tr.to_deprecated_fly_string()));
+        (void)insert_html_element(HTMLToken::make_start_tag(HTML::TagNames::tr));
         m_insertion_mode = InsertionMode::InRow;
         process_using_the_rules_for(m_insertion_mode, token);
         return;
@@ -2811,7 +2811,7 @@ void HTMLParser::handle_in_table(HTMLToken& token)
         clear_the_stack_back_to_a_table_context();
 
         // Insert an HTML element for a "colgroup" start tag token with no attributes, then switch the insertion mode to "in column group".
-        (void)insert_html_element(HTMLToken::make_start_tag(HTML::TagNames::colgroup.to_deprecated_fly_string()));
+        (void)insert_html_element(HTMLToken::make_start_tag(HTML::TagNames::colgroup));
         m_insertion_mode = InsertionMode::InColumnGroup;
 
         // Reprocess the current token.
@@ -2836,7 +2836,7 @@ void HTMLParser::handle_in_table(HTMLToken& token)
         clear_the_stack_back_to_a_table_context();
 
         // Insert an HTML element for a "tbody" start tag token with no attributes, then switch the insertion mode to "in table body".
-        (void)insert_html_element(HTMLToken::make_start_tag(HTML::TagNames::tbody.to_deprecated_fly_string()));
+        (void)insert_html_element(HTMLToken::make_start_tag(HTML::TagNames::tbody));
         m_insertion_mode = InsertionMode::InTableBody;
 
         // Reprocess the current token.

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.h
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.h
@@ -247,28 +247,29 @@ public:
         }
     }
 
-    StringView attribute(DeprecatedFlyString const& attribute_name) const
+    StringView attribute(FlyString const& attribute_name) const
     {
         if (auto result = raw_attribute(attribute_name); result.has_value())
             return result->value;
         return {};
     }
 
-    Optional<Attribute const&> raw_attribute(DeprecatedFlyString const& attribute_name) const
+    Optional<Attribute const&> raw_attribute(FlyString const& attribute_name) const
     {
         VERIFY(is_start_tag() || is_end_tag());
 
+        auto deprecated_attribute_name = attribute_name.to_deprecated_fly_string();
         auto* ptr = tag_attributes();
         if (!ptr)
             return {};
         for (auto& attribute : *ptr) {
-            if (attribute_name == attribute.local_name)
+            if (deprecated_attribute_name == attribute.local_name)
                 return attribute;
         }
         return {};
     }
 
-    bool has_attribute(DeprecatedFlyString const& attribute_name)
+    bool has_attribute(FlyString const& attribute_name) const
     {
         return !attribute(attribute_name).is_null();
     }

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.h
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.h
@@ -70,10 +70,10 @@ public:
         return token;
     }
 
-    static HTMLToken make_start_tag(DeprecatedFlyString const& tag_name)
+    static HTMLToken make_start_tag(FlyString const& tag_name)
     {
         HTMLToken token { Type::StartTag };
-        token.set_tag_name(tag_name);
+        token.set_tag_name(tag_name.to_deprecated_fly_string());
         return token;
     }
 

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.h
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.h
@@ -43,9 +43,9 @@ public:
 
     struct Attribute {
         DeprecatedString prefix;
-        DeprecatedString local_name { "" };
+        FlyString local_name;
         DeprecatedString namespace_;
-        DeprecatedString value { "" };
+        String value;
         Position name_start_position;
         Position value_start_position;
         Position name_end_position;
@@ -258,12 +258,11 @@ public:
     {
         VERIFY(is_start_tag() || is_end_tag());
 
-        auto deprecated_attribute_name = attribute_name.to_deprecated_fly_string();
         auto* ptr = tag_attributes();
         if (!ptr)
             return {};
-        for (auto& attribute : *ptr) {
-            if (deprecated_attribute_name == attribute.local_name)
+        for (auto const& attribute : *ptr) {
+            if (attribute_name == attribute.local_name)
                 return attribute;
         }
         return {};
@@ -281,7 +280,7 @@ public:
             set_tag_name(new_name);
     }
 
-    void adjust_attribute_name(DeprecatedFlyString const& old_name, DeprecatedFlyString const& new_name)
+    void adjust_attribute_name(FlyString const& old_name, FlyString const& new_name)
     {
         VERIFY(is_start_tag() || is_end_tag());
         for_each_attribute([&](Attribute& attribute) {
@@ -291,7 +290,7 @@ public:
         });
     }
 
-    void adjust_foreign_attribute(DeprecatedFlyString const& old_name, DeprecatedFlyString const& prefix, DeprecatedFlyString const& local_name, DeprecatedFlyString const& namespace_)
+    void adjust_foreign_attribute(FlyString const& old_name, DeprecatedFlyString const& prefix, FlyString const& local_name, DeprecatedFlyString const& namespace_)
     {
         VERIFY(is_start_tag() || is_end_tag());
         for_each_attribute([&](Attribute& attribute) {

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
@@ -1108,31 +1108,31 @@ _StartOfFunction:
                 ON_WHITESPACE
                 {
                     m_current_token.last_attribute().name_end_position = nth_last_position(1);
-                    m_current_token.last_attribute().local_name = consume_current_builder();
+                    m_current_token.last_attribute().local_name = MUST(FlyString::from_deprecated_fly_string(consume_current_builder()));
                     RECONSUME_IN(AfterAttributeName);
                 }
                 ON('/')
                 {
                     m_current_token.last_attribute().name_end_position = nth_last_position(1);
-                    m_current_token.last_attribute().local_name = consume_current_builder();
+                    m_current_token.last_attribute().local_name = MUST(FlyString::from_deprecated_fly_string(consume_current_builder()));
                     RECONSUME_IN(AfterAttributeName);
                 }
                 ON('>')
                 {
                     m_current_token.last_attribute().name_end_position = nth_last_position(1);
-                    m_current_token.last_attribute().local_name = consume_current_builder();
+                    m_current_token.last_attribute().local_name = MUST(FlyString::from_deprecated_fly_string(consume_current_builder()));
                     RECONSUME_IN(AfterAttributeName);
                 }
                 ON_EOF
                 {
                     m_current_token.last_attribute().name_end_position = nth_last_position(1);
-                    m_current_token.last_attribute().local_name = consume_current_builder();
+                    m_current_token.last_attribute().local_name = MUST(FlyString::from_deprecated_fly_string(consume_current_builder()));
                     RECONSUME_IN(AfterAttributeName);
                 }
                 ON('=')
                 {
                     m_current_token.last_attribute().name_end_position = nth_last_position(1);
-                    m_current_token.last_attribute().local_name = consume_current_builder();
+                    m_current_token.last_attribute().local_name = MUST(FlyString::from_deprecated_fly_string(consume_current_builder()));
                     SWITCH_TO(BeforeAttributeValue);
                 }
                 ON_ASCII_UPPER_ALPHA
@@ -1238,7 +1238,7 @@ _StartOfFunction:
             {
                 ON('"')
                 {
-                    m_current_token.last_attribute().value = consume_current_builder();
+                    m_current_token.last_attribute().value = MUST(String::from_deprecated_string(consume_current_builder()));
                     SWITCH_TO(AfterAttributeValueQuoted);
                 }
                 ON('&')
@@ -1270,7 +1270,7 @@ _StartOfFunction:
             {
                 ON('\'')
                 {
-                    m_current_token.last_attribute().value = consume_current_builder();
+                    m_current_token.last_attribute().value = MUST(String::from_deprecated_string(consume_current_builder()));
                     SWITCH_TO(AfterAttributeValueQuoted);
                 }
                 ON('&')
@@ -1302,7 +1302,7 @@ _StartOfFunction:
             {
                 ON_WHITESPACE
                 {
-                    m_current_token.last_attribute().value = consume_current_builder();
+                    m_current_token.last_attribute().value = MUST(String::from_deprecated_string(consume_current_builder()));
                     m_current_token.last_attribute().value_end_position = nth_last_position(1);
                     SWITCH_TO(BeforeAttributeName);
                 }
@@ -1313,7 +1313,7 @@ _StartOfFunction:
                 }
                 ON('>')
                 {
-                    m_current_token.last_attribute().value = consume_current_builder();
+                    m_current_token.last_attribute().value = MUST(String::from_deprecated_string(consume_current_builder()));
                     m_current_token.last_attribute().value_end_position = nth_last_position(1);
                     SWITCH_TO_AND_EMIT_CURRENT_TOKEN(Data);
                 }

--- a/Userland/Libraries/LibWeb/HTML/Plugin.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Plugin.cpp
@@ -98,7 +98,7 @@ JS::GCPtr<MimeType> Plugin::item(u32 index) const
     return nullptr;
 }
 
-JS::GCPtr<MimeType> Plugin::named_item(String const& name) const
+JS::GCPtr<MimeType> Plugin::named_item(FlyString const& name) const
 {
     // 1. For each MimeType mimeType of this's relevant global object's PDF viewer mime type objects: if mimeType's type is name, then return mimeType.
     auto& window = verify_cast<HTML::Window>(HTML::relevant_global_object(*this));
@@ -121,10 +121,9 @@ WebIDL::ExceptionOr<JS::Value> Plugin::item_value(size_t index) const
     return return_value.ptr();
 }
 
-WebIDL::ExceptionOr<JS::Value> Plugin::named_item_value(DeprecatedFlyString const& name) const
+WebIDL::ExceptionOr<JS::Value> Plugin::named_item_value(FlyString const& name) const
 {
-    auto converted_name = TRY_OR_THROW_OOM(vm(), String::from_deprecated_string(name));
-    auto return_value = named_item(converted_name);
+    auto return_value = named_item(name);
     if (!return_value)
         return JS::js_null();
     return return_value.ptr();

--- a/Userland/Libraries/LibWeb/HTML/Plugin.h
+++ b/Userland/Libraries/LibWeb/HTML/Plugin.h
@@ -22,7 +22,7 @@ public:
     String filename() const;
     size_t length() const;
     JS::GCPtr<MimeType> item(u32 index) const;
-    JS::GCPtr<MimeType> named_item(String const& name) const;
+    JS::GCPtr<MimeType> named_item(FlyString const& name) const;
 
 private:
     Plugin(JS::Realm&, String name);
@@ -35,7 +35,7 @@ private:
     // ^Bindings::LegacyPlatformObject
     virtual Vector<DeprecatedString> supported_property_names() const override;
     virtual WebIDL::ExceptionOr<JS::Value> item_value(size_t index) const override;
-    virtual WebIDL::ExceptionOr<JS::Value> named_item_value(DeprecatedFlyString const& name) const override;
+    virtual WebIDL::ExceptionOr<JS::Value> named_item_value(FlyString const& name) const override;
     virtual bool is_supported_property_index(u32) const override;
 
     virtual bool supports_indexed_properties() const override { return true; }

--- a/Userland/Libraries/LibWeb/HTML/PluginArray.cpp
+++ b/Userland/Libraries/LibWeb/HTML/PluginArray.cpp
@@ -84,7 +84,7 @@ JS::GCPtr<Plugin> PluginArray::item(u32 index) const
 }
 
 // https://html.spec.whatwg.org/multipage/system-state.html#dom-pluginarray-nameditem
-JS::GCPtr<Plugin> PluginArray::named_item(String const& name) const
+JS::GCPtr<Plugin> PluginArray::named_item(FlyString const& name) const
 {
     // 1. For each Plugin plugin of this's relevant global object's PDF viewer plugin objects: if plugin's name is name, then return plugin.
     auto& window = verify_cast<HTML::Window>(HTML::relevant_global_object(*this));
@@ -107,10 +107,9 @@ WebIDL::ExceptionOr<JS::Value> PluginArray::item_value(size_t index) const
     return return_value.ptr();
 }
 
-WebIDL::ExceptionOr<JS::Value> PluginArray::named_item_value(DeprecatedFlyString const& name) const
+WebIDL::ExceptionOr<JS::Value> PluginArray::named_item_value(FlyString const& name) const
 {
-    auto converted_name = TRY_OR_THROW_OOM(vm(), String::from_deprecated_string(name));
-    auto return_value = named_item(converted_name);
+    auto return_value = named_item(name);
     if (!return_value)
         return JS::js_null();
     return return_value.ptr();

--- a/Userland/Libraries/LibWeb/HTML/PluginArray.h
+++ b/Userland/Libraries/LibWeb/HTML/PluginArray.h
@@ -20,7 +20,7 @@ public:
     void refresh() const;
     size_t length() const;
     JS::GCPtr<Plugin> item(u32 index) const;
-    JS::GCPtr<Plugin> named_item(String const& name) const;
+    JS::GCPtr<Plugin> named_item(FlyString const& name) const;
 
 private:
     PluginArray(JS::Realm&);
@@ -30,7 +30,7 @@ private:
     // ^Bindings::LegacyPlatformObject
     virtual Vector<DeprecatedString> supported_property_names() const override;
     virtual WebIDL::ExceptionOr<JS::Value> item_value(size_t index) const override;
-    virtual WebIDL::ExceptionOr<JS::Value> named_item_value(DeprecatedFlyString const& name) const override;
+    virtual WebIDL::ExceptionOr<JS::Value> named_item_value(FlyString const& name) const override;
     virtual bool is_supported_property_index(u32) const override;
 
     virtual bool supports_indexed_properties() const override { return true; }

--- a/Userland/Libraries/LibWeb/HTML/Storage.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Storage.cpp
@@ -157,7 +157,7 @@ Vector<DeprecatedString> Storage::supported_property_names() const
     return names;
 }
 
-WebIDL::ExceptionOr<JS::Value> Storage::named_item_value(DeprecatedFlyString const& name) const
+WebIDL::ExceptionOr<JS::Value> Storage::named_item_value(FlyString const& name) const
 {
     auto value = get_item(name);
     if (!value.has_value())

--- a/Userland/Libraries/LibWeb/HTML/Storage.h
+++ b/Userland/Libraries/LibWeb/HTML/Storage.h
@@ -37,7 +37,7 @@ private:
     virtual void initialize(JS::Realm&) override;
 
     // ^LegacyPlatformObject
-    virtual WebIDL::ExceptionOr<JS::Value> named_item_value(DeprecatedFlyString const&) const override;
+    virtual WebIDL::ExceptionOr<JS::Value> named_item_value(FlyString const&) const override;
     virtual WebIDL::ExceptionOr<DidDeletionFail> delete_value(DeprecatedString const&) override;
     virtual Vector<DeprecatedString> supported_property_names() const override;
     virtual WebIDL::ExceptionOr<void> set_value_of_named_property(DeprecatedString const& key, JS::Value value) override;

--- a/Userland/Libraries/LibWeb/HTML/Window.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Window.cpp
@@ -1481,7 +1481,7 @@ Vector<DeprecatedString> Window::supported_property_names()
 }
 
 // https://html.spec.whatwg.org/#named-access-on-the-window-object
-WebIDL::ExceptionOr<JS::Value> Window::named_item_value(DeprecatedFlyString const& name)
+WebIDL::ExceptionOr<JS::Value> Window::named_item_value(FlyString const& name)
 {
     // To determine the value of a named property name in a Window object window, the user agent must return the value obtained using the following steps:
 
@@ -1515,9 +1515,9 @@ WebIDL::ExceptionOr<JS::Value> Window::named_item_value(DeprecatedFlyString cons
     //    whose filter matches only named objects of window with the name name. (By definition, these will all be elements.)
     return DOM::HTMLCollection::create(associated_document(), DOM::HTMLCollection::Scope::Descendants, [name](auto& element) -> bool {
         if ((is<HTMLEmbedElement>(element) || is<HTMLFormElement>(element) || is<HTMLImageElement>(element) || is<HTMLObjectElement>(element))
-            && (element.attribute(AttributeNames::name) == name.view()))
+            && (element.attribute(AttributeNames::name) == name))
             return true;
-        return element.attribute(AttributeNames::id) == name.view();
+        return element.attribute(AttributeNames::id) == name;
     });
 }
 

--- a/Userland/Libraries/LibWeb/HTML/Window.h
+++ b/Userland/Libraries/LibWeb/HTML/Window.h
@@ -194,7 +194,7 @@ public:
     [[nodiscard]] OrderedHashMap<String, JS::NonnullGCPtr<Navigable>> document_tree_child_navigable_target_name_property_set();
 
     [[nodiscard]] Vector<DeprecatedString> supported_property_names();
-    [[nodiscard]] WebIDL::ExceptionOr<JS::Value> named_item_value(DeprecatedFlyString const&);
+    [[nodiscard]] WebIDL::ExceptionOr<JS::Value> named_item_value(FlyString const&);
 
 private:
     explicit Window(JS::Realm&);

--- a/Userland/Libraries/LibWeb/SVG/AttributeNames.cpp
+++ b/Userland/Libraries/LibWeb/SVG/AttributeNames.cpp
@@ -8,7 +8,7 @@
 
 namespace Web::SVG::AttributeNames {
 
-#define __ENUMERATE_SVG_ATTRIBUTE(name) DeprecatedFlyString name;
+#define __ENUMERATE_SVG_ATTRIBUTE(name) FlyString name;
 ENUMERATE_SVG_ATTRIBUTES(__ENUMERATE_SVG_ATTRIBUTE)
 #undef __ENUMERATE_SVG_ATTRIBUTE
 
@@ -18,7 +18,7 @@ void initialize_strings()
     VERIFY(!s_initialized);
 
 #define __ENUMERATE_SVG_ATTRIBUTE(name) \
-    name = #name;
+    name = #name##_fly_string;
     ENUMERATE_SVG_ATTRIBUTES(__ENUMERATE_SVG_ATTRIBUTE)
 #undef __ENUMERATE_SVG_ATTRIBUTE
 

--- a/Userland/Libraries/LibWeb/SVG/AttributeNames.h
+++ b/Userland/Libraries/LibWeb/SVG/AttributeNames.h
@@ -6,8 +6,8 @@
 
 #pragma once
 
-#include <AK/DeprecatedFlyString.h>
 #include <AK/Error.h>
+#include <AK/FlyString.h>
 
 namespace Web::SVG::AttributeNames {
 
@@ -96,7 +96,7 @@ namespace Web::SVG::AttributeNames {
     E(yChannelSelector)             \
     E(zoomAndPan)
 
-#define __ENUMERATE_SVG_ATTRIBUTE(name) extern DeprecatedFlyString name;
+#define __ENUMERATE_SVG_ATTRIBUTE(name) extern FlyString name;
 ENUMERATE_SVG_ATTRIBUTES(__ENUMERATE_SVG_ATTRIBUTE)
 #undef __ENUMERATE_SVG_ATTRIBUTE
 

--- a/Userland/Libraries/LibWeb/SVG/SVGCircleElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGCircleElement.cpp
@@ -22,7 +22,7 @@ void SVGCircleElement::initialize(JS::Realm& realm)
     set_prototype(&Bindings::ensure_web_prototype<Bindings::SVGCircleElementPrototype>(realm, "SVGCircleElement"));
 }
 
-void SVGCircleElement::attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value)
+void SVGCircleElement::attribute_changed(FlyString const& name, DeprecatedString const& value)
 {
     SVGGeometryElement::attribute_changed(name, value);
 

--- a/Userland/Libraries/LibWeb/SVG/SVGCircleElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGCircleElement.h
@@ -17,7 +17,7 @@ class SVGCircleElement final : public SVGGeometryElement {
 public:
     virtual ~SVGCircleElement() override = default;
 
-    virtual void attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(FlyString const& name, DeprecatedString const& value) override;
 
     virtual Gfx::Path& get_path() override;
 

--- a/Userland/Libraries/LibWeb/SVG/SVGElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGElement.cpp
@@ -34,7 +34,7 @@ void SVGElement::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_dataset);
 }
 
-void SVGElement::attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value)
+void SVGElement::attribute_changed(FlyString const& name, DeprecatedString const& value)
 {
     Base::attribute_changed(name, value);
 

--- a/Userland/Libraries/LibWeb/SVG/SVGElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGElement.h
@@ -17,7 +17,7 @@ class SVGElement : public DOM::Element {
 public:
     virtual bool requires_svg_container() const override { return true; }
 
-    virtual void attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(FlyString const& name, DeprecatedString const& value) override;
 
     virtual void children_changed() override;
     virtual void inserted() override;

--- a/Userland/Libraries/LibWeb/SVG/SVGEllipseElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGEllipseElement.cpp
@@ -22,7 +22,7 @@ void SVGEllipseElement::initialize(JS::Realm& realm)
     set_prototype(&Bindings::ensure_web_prototype<Bindings::SVGEllipseElementPrototype>(realm, "SVGEllipseElement"));
 }
 
-void SVGEllipseElement::attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value)
+void SVGEllipseElement::attribute_changed(FlyString const& name, DeprecatedString const& value)
 {
     SVGGeometryElement::attribute_changed(name, value);
 

--- a/Userland/Libraries/LibWeb/SVG/SVGEllipseElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGEllipseElement.h
@@ -17,7 +17,7 @@ class SVGEllipseElement final : public SVGGeometryElement {
 public:
     virtual ~SVGEllipseElement() override = default;
 
-    virtual void attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(FlyString const& name, DeprecatedString const& value) override;
 
     virtual Gfx::Path& get_path() override;
 

--- a/Userland/Libraries/LibWeb/SVG/SVGGradientElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGGradientElement.cpp
@@ -17,7 +17,7 @@ SVGGradientElement::SVGGradientElement(DOM::Document& document, DOM::QualifiedNa
 {
 }
 
-void SVGGradientElement::attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value)
+void SVGGradientElement::attribute_changed(FlyString const& name, DeprecatedString const& value)
 {
     SVGElement::attribute_changed(name, value);
     if (name == AttributeNames::gradientUnits) {

--- a/Userland/Libraries/LibWeb/SVG/SVGGradientElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGGradientElement.h
@@ -40,7 +40,7 @@ class SVGGradientElement : public SVGElement {
 public:
     virtual ~SVGGradientElement() override = default;
 
-    virtual void attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(FlyString const& name, DeprecatedString const& value) override;
 
     virtual Optional<Gfx::PaintStyle const&> to_gfx_paint_style(SVGPaintContext const&) const = 0;
 

--- a/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
@@ -32,7 +32,7 @@ void SVGGraphicsElement::initialize(JS::Realm& realm)
     set_prototype(&Bindings::ensure_web_prototype<Bindings::SVGGraphicsElementPrototype>(realm, "SVGGraphicsElement"));
 }
 
-void SVGGraphicsElement::attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value)
+void SVGGraphicsElement::attribute_changed(FlyString const& name, DeprecatedString const& value)
 {
     SVGElement::attribute_changed(name, value);
     if (name == "transform"sv) {

--- a/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.h
@@ -25,7 +25,7 @@ class SVGGraphicsElement : public SVGElement {
 public:
     virtual void apply_presentational_hints(CSS::StyleProperties&) const override;
 
-    virtual void attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(FlyString const& name, DeprecatedString const& value) override;
 
     Optional<Gfx::Color> fill_color() const;
     Optional<FillRule> fill_rule() const;

--- a/Userland/Libraries/LibWeb/SVG/SVGLineElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGLineElement.cpp
@@ -22,7 +22,7 @@ void SVGLineElement::initialize(JS::Realm& realm)
     set_prototype(&Bindings::ensure_web_prototype<Bindings::SVGLineElementPrototype>(realm, "SVGLineElement"));
 }
 
-void SVGLineElement::attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value)
+void SVGLineElement::attribute_changed(FlyString const& name, DeprecatedString const& value)
 {
     SVGGeometryElement::attribute_changed(name, value);
 

--- a/Userland/Libraries/LibWeb/SVG/SVGLineElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGLineElement.h
@@ -17,7 +17,7 @@ class SVGLineElement final : public SVGGeometryElement {
 public:
     virtual ~SVGLineElement() override = default;
 
-    virtual void attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(FlyString const& name, DeprecatedString const& value) override;
 
     virtual Gfx::Path& get_path() override;
 

--- a/Userland/Libraries/LibWeb/SVG/SVGLinearGradientElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGLinearGradientElement.cpp
@@ -24,7 +24,7 @@ void SVGLinearGradientElement::initialize(JS::Realm& realm)
     set_prototype(&Bindings::ensure_web_prototype<Bindings::SVGLinearGradientElementPrototype>(realm, "SVGLinearGradientElement"));
 }
 
-void SVGLinearGradientElement::attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value)
+void SVGLinearGradientElement::attribute_changed(FlyString const& name, DeprecatedString const& value)
 {
     SVGGradientElement::attribute_changed(name, value);
 

--- a/Userland/Libraries/LibWeb/SVG/SVGLinearGradientElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGLinearGradientElement.h
@@ -18,7 +18,7 @@ class SVGLinearGradientElement : public SVGGradientElement {
 public:
     virtual ~SVGLinearGradientElement() override = default;
 
-    virtual void attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(FlyString const& name, DeprecatedString const& value) override;
 
     virtual Optional<Gfx::PaintStyle const&> to_gfx_paint_style(SVGPaintContext const&) const override;
 

--- a/Userland/Libraries/LibWeb/SVG/SVGMaskElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGMaskElement.cpp
@@ -31,7 +31,7 @@ JS::GCPtr<Layout::Node> SVGMaskElement::create_layout_node(NonnullRefPtr<CSS::St
     return heap().allocate_without_realm<Layout::SVGGraphicsBox>(document(), *this, move(style));
 }
 
-void SVGMaskElement::attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value)
+void SVGMaskElement::attribute_changed(FlyString const& name, DeprecatedString const& value)
 {
     SVGGraphicsElement::attribute_changed(name, value);
     if (name == AttributeNames::maskUnits) {

--- a/Userland/Libraries/LibWeb/SVG/SVGMaskElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGMaskElement.h
@@ -17,7 +17,7 @@ class SVGMaskElement final : public SVGGraphicsElement {
 public:
     virtual ~SVGMaskElement() override;
 
-    virtual void attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(FlyString const& name, DeprecatedString const& value) override;
 
     virtual JS::GCPtr<Layout::Node> create_layout_node(NonnullRefPtr<CSS::StyleProperties>) override;
 

--- a/Userland/Libraries/LibWeb/SVG/SVGPathElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGPathElement.cpp
@@ -95,7 +95,7 @@ void SVGPathElement::initialize(JS::Realm& realm)
     set_prototype(&Bindings::ensure_web_prototype<Bindings::SVGPathElementPrototype>(realm, "SVGPathElement"));
 }
 
-void SVGPathElement::attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value)
+void SVGPathElement::attribute_changed(FlyString const& name, DeprecatedString const& value)
 {
     SVGGeometryElement::attribute_changed(name, value);
 

--- a/Userland/Libraries/LibWeb/SVG/SVGPathElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGPathElement.h
@@ -19,7 +19,7 @@ class SVGPathElement final : public SVGGeometryElement {
 public:
     virtual ~SVGPathElement() override = default;
 
-    virtual void attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(FlyString const& name, DeprecatedString const& value) override;
 
     virtual Gfx::Path& get_path() override;
 

--- a/Userland/Libraries/LibWeb/SVG/SVGPolygonElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGPolygonElement.cpp
@@ -22,7 +22,7 @@ void SVGPolygonElement::initialize(JS::Realm& realm)
     set_prototype(&Bindings::ensure_web_prototype<Bindings::SVGPolygonElementPrototype>(realm, "SVGPolygonElement"));
 }
 
-void SVGPolygonElement::attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value)
+void SVGPolygonElement::attribute_changed(FlyString const& name, DeprecatedString const& value)
 {
     SVGGeometryElement::attribute_changed(name, value);
 

--- a/Userland/Libraries/LibWeb/SVG/SVGPolygonElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGPolygonElement.h
@@ -16,7 +16,7 @@ class SVGPolygonElement final : public SVGGeometryElement {
 public:
     virtual ~SVGPolygonElement() override = default;
 
-    virtual void attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(FlyString const& name, DeprecatedString const& value) override;
 
     virtual Gfx::Path& get_path() override;
 

--- a/Userland/Libraries/LibWeb/SVG/SVGPolylineElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGPolylineElement.cpp
@@ -22,7 +22,7 @@ void SVGPolylineElement::initialize(JS::Realm& realm)
     set_prototype(&Bindings::ensure_web_prototype<Bindings::SVGPolylineElementPrototype>(realm, "SVGPolylineElement"));
 }
 
-void SVGPolylineElement::attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value)
+void SVGPolylineElement::attribute_changed(FlyString const& name, DeprecatedString const& value)
 {
     SVGGeometryElement::attribute_changed(name, value);
 

--- a/Userland/Libraries/LibWeb/SVG/SVGPolylineElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGPolylineElement.h
@@ -16,7 +16,7 @@ class SVGPolylineElement final : public SVGGeometryElement {
 public:
     virtual ~SVGPolylineElement() override = default;
 
-    virtual void attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(FlyString const& name, DeprecatedString const& value) override;
 
     virtual Gfx::Path& get_path() override;
 

--- a/Userland/Libraries/LibWeb/SVG/SVGRadialGradientElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGRadialGradientElement.cpp
@@ -21,7 +21,7 @@ void SVGRadialGradientElement::initialize(JS::Realm& realm)
     set_prototype(&Bindings::ensure_web_prototype<Bindings::SVGRadialGradientElementPrototype>(realm, "SVGRadialGradientElement"));
 }
 
-void SVGRadialGradientElement::attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value)
+void SVGRadialGradientElement::attribute_changed(FlyString const& name, DeprecatedString const& value)
 {
     SVGGradientElement::attribute_changed(name, value);
 

--- a/Userland/Libraries/LibWeb/SVG/SVGRadialGradientElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGRadialGradientElement.h
@@ -18,7 +18,7 @@ class SVGRadialGradientElement : public SVGGradientElement {
 public:
     virtual ~SVGRadialGradientElement() override = default;
 
-    virtual void attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(FlyString const& name, DeprecatedString const& value) override;
 
     virtual Optional<Gfx::PaintStyle const&> to_gfx_paint_style(SVGPaintContext const&) const override;
 

--- a/Userland/Libraries/LibWeb/SVG/SVGRectElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGRectElement.cpp
@@ -24,7 +24,7 @@ void SVGRectElement::initialize(JS::Realm& realm)
     set_prototype(&Bindings::ensure_web_prototype<Bindings::SVGRectElementPrototype>(realm, "SVGRectElement"));
 }
 
-void SVGRectElement::attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value)
+void SVGRectElement::attribute_changed(FlyString const& name, DeprecatedString const& value)
 {
     SVGGeometryElement::attribute_changed(name, value);
 

--- a/Userland/Libraries/LibWeb/SVG/SVGRectElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGRectElement.h
@@ -17,7 +17,7 @@ class SVGRectElement final : public SVGGeometryElement {
 public:
     virtual ~SVGRectElement() override = default;
 
-    virtual void attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(FlyString const& name, DeprecatedString const& value) override;
 
     virtual Gfx::Path& get_path() override;
 

--- a/Userland/Libraries/LibWeb/SVG/SVGSVGElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGSVGElement.cpp
@@ -61,7 +61,7 @@ void SVGSVGElement::apply_presentational_hints(CSS::StyleProperties& style) cons
     }
 }
 
-void SVGSVGElement::attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value)
+void SVGSVGElement::attribute_changed(FlyString const& name, DeprecatedString const& value)
 {
     SVGGraphicsElement::attribute_changed(name, value);
 

--- a/Userland/Libraries/LibWeb/SVG/SVGSVGElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGSVGElement.h
@@ -36,7 +36,7 @@ private:
 
     virtual bool is_svg_svg_element() const override { return true; }
 
-    virtual void attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(FlyString const& name, DeprecatedString const& value) override;
 
     void update_fallback_view_box_for_svg_as_image();
 

--- a/Userland/Libraries/LibWeb/SVG/SVGStopElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGStopElement.cpp
@@ -19,7 +19,7 @@ SVGStopElement::SVGStopElement(DOM::Document& document, DOM::QualifiedName quali
 {
 }
 
-void SVGStopElement::attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value)
+void SVGStopElement::attribute_changed(FlyString const& name, DeprecatedString const& value)
 {
     SVGElement::attribute_changed(name, value);
     if (name == SVG::AttributeNames::offset) {

--- a/Userland/Libraries/LibWeb/SVG/SVGStopElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGStopElement.h
@@ -19,7 +19,7 @@ class SVGStopElement final : public SVGElement {
 public:
     virtual ~SVGStopElement() override = default;
 
-    virtual void attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(FlyString const& name, DeprecatedString const& value) override;
 
     JS::NonnullGCPtr<SVGAnimatedNumber> offset() const;
 

--- a/Userland/Libraries/LibWeb/SVG/SVGSymbolElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGSymbolElement.cpp
@@ -39,7 +39,7 @@ void SVGSymbolElement::apply_presentational_hints(CSS::StyleProperties& style) c
     }
 }
 
-void SVGSymbolElement::attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value)
+void SVGSymbolElement::attribute_changed(FlyString const& name, DeprecatedString const& value)
 {
     if (name.equals_ignoring_ascii_case(SVG::AttributeNames::viewBox))
         m_view_box = try_parse_view_box(value);

--- a/Userland/Libraries/LibWeb/SVG/SVGSymbolElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGSymbolElement.h
@@ -29,7 +29,7 @@ private:
 
     bool is_direct_child_of_use_shadow_tree() const;
 
-    virtual void attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(FlyString const& name, DeprecatedString const& value) override;
 
     Optional<ViewBox> m_view_box;
 };

--- a/Userland/Libraries/LibWeb/SVG/SVGTextPositioningElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGTextPositioningElement.cpp
@@ -28,7 +28,7 @@ void SVGTextPositioningElement::initialize(JS::Realm& realm)
     set_prototype(&Bindings::ensure_web_prototype<Bindings::SVGTextPositioningElementPrototype>(realm, "SVGTextPositioningElement"));
 }
 
-void SVGTextPositioningElement::attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value)
+void SVGTextPositioningElement::attribute_changed(FlyString const& name, DeprecatedString const& value)
 {
     SVGGraphicsElement::attribute_changed(name, value);
 

--- a/Userland/Libraries/LibWeb/SVG/SVGTextPositioningElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGTextPositioningElement.h
@@ -16,7 +16,7 @@ class SVGTextPositioningElement : public SVGTextContentElement {
     WEB_PLATFORM_OBJECT(SVGTextPositioningElement, SVGTextContentElement);
 
 public:
-    virtual void attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(FlyString const& name, DeprecatedString const& value) override;
 
     Gfx::FloatPoint get_offset() const;
 

--- a/Userland/Libraries/LibWeb/SVG/SVGUseElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGUseElement.cpp
@@ -45,7 +45,7 @@ void SVGUseElement::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_document_observer);
 }
 
-void SVGUseElement::attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value)
+void SVGUseElement::attribute_changed(FlyString const& name, DeprecatedString const& value)
 {
     Base::attribute_changed(name, value);
 

--- a/Userland/Libraries/LibWeb/SVG/SVGUseElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGUseElement.cpp
@@ -115,7 +115,7 @@ JS::GCPtr<DOM::Element> SVGUseElement::referenced_element()
     }
 
     // FIXME: Support loading of external svg documents
-    return document().get_element_by_id(m_referenced_id.value());
+    return document().get_element_by_id(MUST(FlyString::from_utf8(m_referenced_id.value())));
 }
 
 // https://svgwg.org/svg2-draft/struct.html#UseShadowTree

--- a/Userland/Libraries/LibWeb/SVG/SVGUseElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGUseElement.h
@@ -19,7 +19,7 @@ class SVGUseElement final : public SVGGraphicsElement {
 public:
     virtual ~SVGUseElement() override = default;
 
-    virtual void attribute_changed(DeprecatedFlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(FlyString const& name, DeprecatedString const& value) override;
 
     virtual void inserted() override;
 

--- a/Userland/Libraries/LibWeb/SVG/TagNames.cpp
+++ b/Userland/Libraries/LibWeb/SVG/TagNames.cpp
@@ -8,7 +8,7 @@
 
 namespace Web::SVG::TagNames {
 
-#define __ENUMERATE_SVG_TAG(name) DeprecatedFlyString name;
+#define __ENUMERATE_SVG_TAG(name) FlyString name;
 ENUMERATE_SVG_TAGS
 #undef __ENUMERATE_SVG_TAG
 
@@ -17,7 +17,7 @@ void initialize_strings()
     static bool s_initialized = false;
     VERIFY(!s_initialized);
 
-#define __ENUMERATE_SVG_TAG(name) name = #name;
+#define __ENUMERATE_SVG_TAG(name) name = #name##_fly_string;
     ENUMERATE_SVG_TAGS
 #undef __ENUMERATE_SVG_TAG
 

--- a/Userland/Libraries/LibWeb/SVG/TagNames.h
+++ b/Userland/Libraries/LibWeb/SVG/TagNames.h
@@ -6,8 +6,8 @@
 
 #pragma once
 
-#include <AK/DeprecatedFlyString.h>
 #include <AK/Error.h>
+#include <AK/FlyString.h>
 
 namespace Web::SVG::TagNames {
 
@@ -40,7 +40,7 @@ namespace Web::SVG::TagNames {
     __ENUMERATE_SVG_TAG(title)          \
     __ENUMERATE_SVG_TAG(use)
 
-#define __ENUMERATE_SVG_TAG(name) extern DeprecatedFlyString name;
+#define __ENUMERATE_SVG_TAG(name) extern FlyString name;
 ENUMERATE_SVG_TAGS
 #undef __ENUMERATE_SVG_TAG
 

--- a/Userland/Services/WebContent/WebDriverConnection.cpp
+++ b/Userland/Services/WebContent/WebDriverConnection.cpp
@@ -1064,18 +1064,16 @@ Messages::WebDriverClient::GetElementAttributeResponse WebDriverConnection::get_
     // 4. Let result be the result of the first matching condition:
     Optional<DeprecatedString> result;
 
-    auto deprecated_name = name.to_deprecated_string();
-
     // -> If name is a boolean attribute
-    if (Web::HTML::is_boolean_attribute(deprecated_name)) {
+    if (Web::HTML::is_boolean_attribute(name)) {
         // "true" (string) if the element has the attribute, otherwise null.
-        if (element->has_attribute(deprecated_name))
+        if (element->has_attribute(name))
             result = "true"sv;
     }
     // -> Otherwise
     else {
         // The result of getting an attribute by name name.
-        result = element->deprecated_get_attribute(deprecated_name);
+        result = element->deprecated_get_attribute(name);
     }
 
     // 5. Return success with data result.


### PR DESCRIPTION
Bunch of lines changing here, but pretty straight forward ports, getting rid of quite a portion of the use of DeprecatedFlyString in LibWeb