### PR TITLE
LibGfx/PNGLoader: Don't allow multiple consecutive IHDR chunks

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/PNGLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/PNGLoader.cpp
@@ -926,22 +926,6 @@ static bool is_valid_filter_method(u8 filter_method)
     return filter_method == 0;
 }
 
-static bool is_valid_bit_depth(u8 bit_depth, PNG::ColorType color_type)
-{
-    switch (bit_depth) {
-    case 1:
-    case 2:
-    case 4:
-        return color_type == PNG::ColorType::Greyscale || color_type == PNG::ColorType::IndexedColor;
-    case 8:
-        return true;
-    case 16:
-        return color_type != PNG::ColorType::IndexedColor;
-    default:
-        return false;
-    }
-}
-
 static ErrorOr<void> process_IHDR(ReadonlyBytes data, PNGLoadingContext& context)
 {
     if (data.size() < (int)sizeof(PNG_IHDR))
@@ -957,11 +941,6 @@ static ErrorOr<void> process_IHDR(ReadonlyBytes data, PNGLoadingContext& context
     if (ihdr.height == 0 || ihdr.height > NumericLimits<i32>::max()) {
         dbgln("PNG has invalid height {}", ihdr.height);
         return Error::from_string_literal("Invalid height");
-    }
-
-    if (!is_valid_bit_depth(ihdr.bit_depth, ihdr.color_type)) {
-        dbgln("PNG has invalid bit depth {} for color type {}", ihdr.bit_depth, to_underlying(ihdr.color_type));
-        return Error::from_string_literal("Invalid bit depth");
     }
 
     if (!is_valid_compression_method(ihdr.compression_method)) {

--- a/Userland/Libraries/LibGfx/ImageFormats/PNGLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/PNGLoader.cpp
@@ -1237,8 +1237,12 @@ static ErrorOr<void> process_chunk(Streamer& streamer, PNGLoadingContext& contex
     }
     dbgln_if(PNG_DEBUG, "Chunk type: '{}', size: {}, crc: {:x}", chunk_type, chunk_size, chunk_crc);
 
-    if (chunk_type == "IHDR"sv)
+    if (chunk_type == "IHDR"sv) {
+        if (context.state >= PNGLoadingContext::IHDRDecoded)
+            return Error::from_string_literal("Multiple IHDR chunks");
+
         return process_IHDR(chunk_data, context);
+    }
 
     if (context.state < PNGLoadingContext::IHDRDecoded)
         return Error::from_string_literal("IHDR is not the first chunk of the file");


### PR DESCRIPTION
This PR also removes redundant bit depth validation added in #21316. Bit depth validation was already done later on, but adding it earlier masked the underlying issue, which this PR fixes.

This fixes oss fuzz issue [63052](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=63052).