### PR TITLE
AK: Avoid overflow when passing i64 minimum value to `vformat()`

### DIFF
--- a/AK/Format.cpp
+++ b/AK/Format.cpp
@@ -363,9 +363,14 @@ ErrorOr<void> FormatBuilder::put_i64(
     SignMode sign_mode)
 {
     auto const is_negative = value < 0;
-    value = is_negative ? -value : value;
+    u64 positive_value;
+    if (value == NumericLimits<i64>::min()) {
+        positive_value = static_cast<u64>(NumericLimits<i64>::max()) + 1;
+    } else {
+        positive_value = is_negative ? -value : value;
+    }
 
-    TRY(put_u64(static_cast<u64>(value), base, prefix, upper_case, zero_pad, use_separator, align, min_width, fill, sign_mode, is_negative));
+    TRY(put_u64(positive_value, base, prefix, upper_case, zero_pad, use_separator, align, min_width, fill, sign_mode, is_negative));
     return {};
 }
 

--- a/Tests/AK/TestFormat.cpp
+++ b/Tests/AK/TestFormat.cpp
@@ -35,6 +35,8 @@ TEST_CASE(format_integers)
     EXPECT_EQ(DeprecatedString::formatted("{:08x}", 4096), "00001000");
     EXPECT_EQ(DeprecatedString::formatted("{:x}", 0x1111222233334444ull), "1111222233334444");
     EXPECT_EQ(DeprecatedString::formatted("{:4}", 12345678), "12345678");
+    EXPECT_EQ(DeprecatedString::formatted("{}", AK::NumericLimits<i64>::min()), "-9223372036854775808");
+    EXPECT_EQ(DeprecatedString::formatted("{:x}", AK::NumericLimits<i64>::min()), "-8000000000000000");
     EXPECT_EQ(DeprecatedString::formatted("{:'}", 0), "0");
     EXPECT_EQ(DeprecatedString::formatted("{:'}", 4096), "4,096");
     EXPECT_EQ(DeprecatedString::formatted("{:'}", 16777216), "16,777,216");


### PR DESCRIPTION
This fixes oss fuzz issue [57633](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=57633)