### PR TITLE
MacPDF: Show PDF outline in sidebar view

### DIFF
--- a/Meta/Lagom/Contrib/MacPDF/CMakeLists.txt
+++ b/Meta/Lagom/Contrib/MacPDF/CMakeLists.txt
@@ -17,6 +17,7 @@ add_executable(MacPDF MACOSX_BUNDLE
     main.mm
     AppDelegate.mm
     MacPDFDocument.mm
+    MacPDFOutlineViewDataSource.mm
     MacPDFView.mm
     MacPDFWindowController.mm
 )

--- a/Meta/Lagom/Contrib/MacPDF/MacPDFOutlineViewDataSource.h
+++ b/Meta/Lagom/Contrib/MacPDF/MacPDFOutlineViewDataSource.h
@@ -15,6 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 // Objective-C wrapper of PDF::OutlineItem, to launder it through the NSOutlineViewDataSource protocol.
 @interface OutlineItemWrapper : NSObject
 
+- (BOOL)isGroupItem;
 - (Optional<u32>)page;
 
 @end

--- a/Meta/Lagom/Contrib/MacPDF/MacPDFOutlineViewDataSource.h
+++ b/Meta/Lagom/Contrib/MacPDF/MacPDFOutlineViewDataSource.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2023, Nico Weber <thakis@chromium.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include "CocoaWrapper.h"
+
+#include <LibPDF/Document.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+// Objective-C wrapper of PDF::OutlineItem, to launder it through the NSOutlineViewDataSource protocol.
+@interface OutlineItemWrapper : NSObject
+
+- (Optional<u32>)page;
+
+@end
+
+@interface MacPDFOutlineViewDataSource : NSObject <NSOutlineViewDataSource>
+
+- (instancetype)initWithOutline:(RefPtr<PDF::OutlineDict>)outline;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Meta/Lagom/Contrib/MacPDF/MacPDFOutlineViewDataSource.mm
+++ b/Meta/Lagom/Contrib/MacPDF/MacPDFOutlineViewDataSource.mm
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2023, Nico Weber <thakis@chromium.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#import "MacPDFOutlineViewDataSource.h"
+
+@interface OutlineItemWrapper ()
+{
+    RefPtr<PDF::OutlineItem> _item;
+}
+@end
+
+@implementation OutlineItemWrapper
+- (instancetype)initWithItem:(NonnullRefPtr<PDF::OutlineItem>)item
+{
+    if (self = [super init]; !self)
+        return nil;
+    _item = move(item);
+    return self;
+}
+
+- (Optional<u32>)page
+{
+    return _item->dest.page.map([](u32 page_index) { return page_index + 1; });
+}
+
+- (OutlineItemWrapper*)child:(NSInteger)index
+{
+    return [[OutlineItemWrapper alloc] initWithItem:_item->children[index]];
+}
+
+- (NSInteger)numberOfChildren
+{
+    return _item->children.size();
+}
+
+- (NSString*)objectValue
+{
+    return [NSString stringWithFormat:@"%s", _item->title.characters()]; // FIXME: encoding?
+}
+@end
+
+@interface MacPDFOutlineViewDataSource ()
+{
+    RefPtr<PDF::OutlineDict> _outline;
+}
+@end
+
+@implementation MacPDFOutlineViewDataSource
+
+- (instancetype)initWithOutline:(RefPtr<PDF::OutlineDict>)outline
+{
+    if (self = [super init]; !self)
+        return nil;
+    _outline = move(outline);
+    return self;
+}
+
+#pragma mark - NSOutlineViewDataSource
+
+- (id)outlineView:(NSOutlineView*)outlineView child:(NSInteger)index ofItem:(nullable id)item
+{
+    if (item)
+        return [(OutlineItemWrapper*)item child:index];
+
+    return [[OutlineItemWrapper alloc] initWithItem:_outline->children[index]];
+}
+
+- (BOOL)outlineView:(NSOutlineView*)outlineView isItemExpandable:(id)item
+{
+    return [self outlineView:outlineView numberOfChildrenOfItem:item] > 0;
+}
+
+- (NSInteger)outlineView:(NSOutlineView*)outlineView numberOfChildrenOfItem:(nullable id)item
+{
+    if (item)
+        return [(OutlineItemWrapper*)item numberOfChildren];
+
+    return _outline ? _outline->children.size() : 0;
+}
+
+- (id)outlineView:(NSOutlineView*)outlineView objectValueForTableColumn:(nullable NSTableColumn*)tableColumn byItem:(nullable id)item
+{
+    return [(OutlineItemWrapper*)item objectValue];
+}
+
+@end

--- a/Meta/Lagom/Contrib/MacPDF/MacPDFWindowController.h
+++ b/Meta/Lagom/Contrib/MacPDF/MacPDFWindowController.h
@@ -15,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @class MacPDFDocument;
 
-@interface MacPDFWindowController : NSWindowController <MacPDFViewDelegate, NSToolbarDelegate>
+@interface MacPDFWindowController : NSWindowController <MacPDFViewDelegate, NSOutlineViewDelegate, NSToolbarDelegate>
 
 - (instancetype)initWithDocument:(MacPDFDocument*)document;
 - (IBAction)showGoToPageDialog:(id)sender;

--- a/Meta/Lagom/Contrib/MacPDF/MacPDFWindowController.mm
+++ b/Meta/Lagom/Contrib/MacPDF/MacPDFWindowController.mm
@@ -116,6 +116,7 @@
     // FIXME: Only set data source when sidebar is open.
     _outlineDataSource = [[MacPDFOutlineViewDataSource alloc] initWithOutline:_pdfDocument.pdf->outline()];
     _outlineView.dataSource = _outlineDataSource;
+    _outlineView.delegate = self;
 }
 
 - (IBAction)showGoToPageDialog:(id)sender
@@ -173,6 +174,19 @@
     // Not called for standard identifiers, but the implementation of the method must exist, or else:
     // ERROR: invalid delegate <MacPDFWindowController: 0x600003054c80> (does not implement all required methods)
     return nil;
+}
+
+#pragma mark - NSOutlineViewDelegate
+
+- (void)outlineViewSelectionDidChange:(NSNotification*)notification
+{
+    NSInteger row = _outlineView.selectedRow;
+    if (row == -1)
+        return;
+
+    OutlineItemWrapper* item = [_outlineView itemAtRow:row];
+    if (auto page = [item page]; page.has_value())
+        [_pdfView goToPage:page.value()];
 }
 
 @end

--- a/Meta/Lagom/Contrib/MacPDF/MacPDFWindowController.mm
+++ b/Meta/Lagom/Contrib/MacPDF/MacPDFWindowController.mm
@@ -69,6 +69,7 @@
 {
     _outlineView = [[NSOutlineView alloc] initWithFrame:NSZeroRect];
 
+    _outlineView.floatsGroupRows = NO;
     _outlineView.focusRingType = NSFocusRingTypeNone;
     _outlineView.headerView = nil;
 
@@ -178,6 +179,16 @@
 }
 
 #pragma mark - NSOutlineViewDelegate
+
+- (BOOL)outlineView:(NSOutlineView*)outlineView isGroupItem:(id)item
+{
+    return [item isGroupItem];
+}
+
+- (BOOL)outlineView:(NSOutlineView*)outlineView shouldSelectItem:(id)item
+{
+    return ![self outlineView:outlineView isGroupItem:item];
+}
 
 // "This method is required if you wish to turn on the use of NSViews instead of NSCells."
 - (NSView*)outlineView:(NSOutlineView*)outlineView viewForTableColumn:(NSTableColumn*)tableColumn item:(id)item

--- a/Meta/Lagom/Contrib/MacPDF/MacPDFWindowController.mm
+++ b/Meta/Lagom/Contrib/MacPDF/MacPDFWindowController.mm
@@ -69,8 +69,8 @@
 {
     _outlineView = [[NSOutlineView alloc] initWithFrame:NSZeroRect];
 
-    _outlineView.style = NSTableViewStyleSourceList;
     _outlineView.focusRingType = NSFocusRingTypeNone;
+    _outlineView.headerView = nil;
 
     // FIXME: Implement data source support for autosaveExpandedItems and use that.
 
@@ -83,6 +83,7 @@
 
     NSScrollView* scrollView = [[NSScrollView alloc] initWithFrame:NSZeroRect];
     scrollView.hasVerticalScroller = YES;
+    scrollView.drawsBackground = NO;
     scrollView.documentView = _outlineView;
 
     // The scroll view knows to put things only in the safe area, but it doesn't clip to it.


### PR DESCRIPTION
Follow-up to #21361.

In addition to things I'm confused about in comments and commit descriptions, I also was a bit confused by the layout constraints system (which NSSplitViewController requires). Initially, I made the NSOutlineView the only view in the left sidebar. But since the outline has a preferred size, that apparently gets translated into hard constraints, and the window height then snaps to the height of the outline and the height can no longer be changed when resizing the window. If the current PDF had no outline, that had the effect of snapping the window to a very small height. So the outline has to be put in a containing view, but `autoresizingMask` defaults to NSViewNotSizable, so nothing showed up at first. (Beginner mistake, but hey.) And debugging constraints isn't very easy, the dumpConstraints: on the LHS of https://github.com/SerenityOS/serenity/commit/09fbbe764c1a1fbd7c52e24f34e666037779efad is the best I could find. (iOS allegedly has `_autolayoutTrace`, but macOS apparently doesn't. The internet mentions that WWDC 2015 sessions 218 and 219 are useful, but https://developer.apple.com/videos/wwdc/2015/?id=218 is long dead.)

Weird-looking things I didn't include a screenshot for below:
* The very-low-height window mentioned above
* If `rowSizeStyle` isn't set, things look weird
* In many of the weird states, if `focusRingType` isn't set, the focus ring looks very weird as well

Note to self, possible things to do after this:
* Add a shortcut for switching pages since arrow keys now navigate the outline when the sidebar has focus
* Persist outline expansion state
* Make rendering of the index pages of the PDF 1.7 standard PDF faster
* When switching pages and the outline is open, adjust the selection to match the current page