### PR TITLE
LibJS: Remove inline capacity from MarkedVector

### DIFF
--- a/Userland/Libraries/LibJS/Forward.h
+++ b/Userland/Libraries/LibJS/Forward.h
@@ -297,7 +297,7 @@ class ThrowCompletionOr;
 template<class T>
 class Handle;
 
-template<class T, size_t inline_capacity = 32>
+template<class T, size_t inline_capacity = 0>
 class MarkedVector;
 
 namespace Bytecode {


### PR DESCRIPTION
Turns out this was hurting performance instead of helping it. By removing the inline capacity, we shrink the size of ExecutionContext by 512 bytes, which substantially reduces the stack pressure created by JS recursion (each call creates a new ExecutionContext on the stack).

4.4% speed-up on the entire Kraken benchmark :^)