### PR TITLE
LibCompress: Fix a typo in `m_read_final_block`

### DIFF
--- a/Userland/Libraries/LibCompress/Deflate.cpp
+++ b/Userland/Libraries/LibCompress/Deflate.cpp
@@ -270,10 +270,10 @@ ErrorOr<Bytes> DeflateDecompressor::read_some(Bytes bytes)
         auto slice = bytes.slice(total_read);
 
         if (m_state == State::Idle) {
-            if (m_read_final_bock)
+            if (m_read_final_block)
                 break;
 
-            m_read_final_bock = TRY(m_input_stream->read_bit());
+            m_read_final_block = TRY(m_input_stream->read_bit());
             auto const block_type = TRY(m_input_stream->read_bits(2));
 
             if (block_type == 0b00) {
@@ -352,7 +352,7 @@ ErrorOr<Bytes> DeflateDecompressor::read_some(Bytes bytes)
     return bytes.slice(0, total_read);
 }
 
-bool DeflateDecompressor::is_eof() const { return m_state == State::Idle && m_read_final_bock; }
+bool DeflateDecompressor::is_eof() const { return m_state == State::Idle && m_read_final_block; }
 
 ErrorOr<size_t> DeflateDecompressor::write_some(ReadonlyBytes)
 {

--- a/Userland/Libraries/LibCompress/Deflate.h
+++ b/Userland/Libraries/LibCompress/Deflate.h
@@ -108,7 +108,7 @@ private:
 
     static constexpr u16 max_back_reference_length = 258;
 
-    bool m_read_final_bock { false };
+    bool m_read_final_block { false };
 
     State m_state { State::Idle };
     union {


### PR DESCRIPTION
I solemnly swear that I stumbled upon this randomly while participating in a CTF.