### PR TITLE
Spreadsheet: Migrate to String

### DIFF
--- a/AK/String.cpp
+++ b/AK/String.cpp
@@ -30,13 +30,12 @@ ErrorOr<String> String::from_utf8(StringView view)
 {
     if (!Utf8View { view }.validate())
         return Error::from_string_literal("String::from_utf8: Input was not valid UTF-8");
+    return from_utf8_without_validation(view.bytes());
+}
 
-    String result;
-    TRY(result.replace_with_new_string(view.length(), [&](Bytes buffer) {
-        view.bytes().copy_to(buffer);
-        return ErrorOr<void> {};
-    }));
-    return result;
+ErrorOr<String> String::from_view(Utf8View view)
+{
+    return String::from_utf8_without_validation(view.as_string().bytes());
 }
 
 ErrorOr<String> String::from_stream(Stream& stream, size_t byte_count)

--- a/AK/String.h
+++ b/AK/String.h
@@ -53,6 +53,7 @@ public:
     template<typename T>
     requires(IsOneOf<RemoveCVReference<T>, ByteString, DeprecatedFlyString, FlyString, String>)
     static ErrorOr<String> from_utf8(T&&) = delete;
+    static ErrorOr<String> from_view(Utf8View view);
 
     [[nodiscard]] static String from_utf8_without_validation(ReadonlyBytes);
 

--- a/Userland/Applications/Spreadsheet/Cell.h
+++ b/Userland/Applications/Spreadsheet/Cell.h
@@ -11,7 +11,7 @@
 #include "Forward.h"
 #include "JSIntegration.h"
 #include "Position.h"
-#include <AK/ByteString.h>
+#include <AK/String.h>
 #include <AK/Types.h>
 #include <AK/WeakPtr.h>
 #include <LibGUI/Command.h>
@@ -24,7 +24,7 @@ struct Cell : public Weakable<Cell> {
         Formula,
     };
 
-    Cell(ByteString data, Position position, WeakPtr<Sheet> sheet)
+    Cell(String data, Position position, WeakPtr<Sheet> sheet)
         : m_dirty(false)
         , m_data(move(data))
         , m_kind(LiteralString)
@@ -33,7 +33,7 @@ struct Cell : public Weakable<Cell> {
     {
     }
 
-    Cell(ByteString source, JS::Value&& cell_value, Position position, WeakPtr<Sheet> sheet)
+    Cell(String source, JS::Value&& cell_value, Position position, WeakPtr<Sheet> sheet)
         : m_dirty(false)
         , m_data(move(source))
         , m_evaluated_data(move(cell_value))
@@ -45,7 +45,7 @@ struct Cell : public Weakable<Cell> {
 
     void reference_from(Cell*);
 
-    void set_data(ByteString new_data);
+    void set_data(String new_data);
     void set_data(JS::Value new_data);
     bool dirty() const { return m_dirty; }
     void clear_dirty() { m_dirty = false; }
@@ -55,7 +55,7 @@ struct Cell : public Weakable<Cell> {
         if (!m_name_for_javascript.is_empty())
             return m_name_for_javascript;
 
-        m_name_for_javascript = ByteString::formatted("cell {}", m_position.to_cell_identifier(sheet));
+        m_name_for_javascript = MUST(String::formatted("cell {}", m_position.to_cell_identifier(sheet)));
         return m_name_for_javascript;
     }
 
@@ -67,7 +67,7 @@ struct Cell : public Weakable<Cell> {
         return m_thrown_value;
     }
 
-    ByteString const& data() const { return m_data; }
+    String const& data() const { return m_data; }
     const JS::Value& evaluated_data() const { return m_evaluated_data; }
     Kind kind() const { return m_kind; }
     Vector<WeakPtr<Cell>> const& referencing_cells() const { return m_referencing_cells; }
@@ -95,14 +95,14 @@ struct Cell : public Weakable<Cell> {
         m_conditional_formats = move(fmts);
     }
 
-    JS::ThrowCompletionOr<ByteString> typed_display() const;
+    JS::ThrowCompletionOr<String> typed_display() const;
     JS::ThrowCompletionOr<JS::Value> typed_js_data() const;
 
     CellType const& type() const;
     CellTypeMetadata const& type_metadata() const { return m_type_metadata; }
     CellTypeMetadata& type_metadata() { return m_type_metadata; }
 
-    ByteString source() const;
+    String source() const;
 
     JS::Value js_data();
 
@@ -117,7 +117,7 @@ struct Cell : public Weakable<Cell> {
 private:
     bool m_dirty { false };
     bool m_evaluated_externally { false };
-    ByteString m_data;
+    String m_data;
     JS::Value m_evaluated_data;
     JS::Value m_thrown_value;
     Kind m_kind { LiteralString };
@@ -126,7 +126,7 @@ private:
     CellType const* m_type { nullptr };
     CellTypeMetadata m_type_metadata;
     Position m_position;
-    mutable ByteString m_name_for_javascript;
+    mutable String m_name_for_javascript;
 
     Vector<ConditionalFormat> m_conditional_formats;
     Format m_evaluated_formats;

--- a/Userland/Applications/Spreadsheet/CellType/Date.cpp
+++ b/Userland/Applications/Spreadsheet/CellType/Date.cpp
@@ -17,15 +17,15 @@ DateCell::DateCell()
 {
 }
 
-JS::ThrowCompletionOr<ByteString> DateCell::display(Cell& cell, CellTypeMetadata const& metadata) const
+JS::ThrowCompletionOr<String> DateCell::display(Cell& cell, CellTypeMetadata const& metadata) const
 {
-    return propagate_failure(cell, [&]() -> JS::ThrowCompletionOr<ByteString> {
+    return propagate_failure(cell, [&]() -> JS::ThrowCompletionOr<String> {
         auto& vm = cell.sheet().global_object().vm();
         auto timestamp = TRY(js_value(cell, metadata));
-        auto string = Core::DateTime::from_timestamp(TRY(timestamp.to_i32(vm))).to_byte_string(metadata.format.is_empty() ? "%Y-%m-%d %H:%M:%S"sv : metadata.format.view());
+        auto string = MUST(Core::DateTime::from_timestamp(TRY(timestamp.to_i32(vm))).to_string(metadata.format.is_empty() ? "%Y-%m-%d %H:%M:%S"sv : metadata.format.bytes_as_string_view()));
 
         if (metadata.length >= 0)
-            return string.substring(0, metadata.length);
+            return MUST(String::from_view(string.code_points().unicode_substring_view(0, min(string.code_points().length(), metadata.length))));
 
         return string;
     });

--- a/Userland/Applications/Spreadsheet/CellType/Date.h
+++ b/Userland/Applications/Spreadsheet/CellType/Date.h
@@ -16,7 +16,7 @@ class DateCell : public CellType {
 public:
     DateCell();
     virtual ~DateCell() override = default;
-    virtual JS::ThrowCompletionOr<ByteString> display(Cell&, CellTypeMetadata const&) const override;
+    virtual JS::ThrowCompletionOr<String> display(Cell&, CellTypeMetadata const&) const override;
     virtual JS::ThrowCompletionOr<JS::Value> js_value(Cell&, CellTypeMetadata const&) const override;
     virtual String metadata_hint(MetadataName) const override;
 };

--- a/Userland/Applications/Spreadsheet/CellType/Format.cpp
+++ b/Userland/Applications/Spreadsheet/CellType/Format.cpp
@@ -5,8 +5,8 @@
  */
 
 #include "Format.h"
-#include <AK/ByteString.h>
 #include <AK/PrintfImplementation.h>
+#include <AK/String.h>
 #include <AK/StringBuilder.h>
 
 namespace Spreadsheet {
@@ -37,13 +37,13 @@ struct PrintfImpl : public PrintfImplementation::PrintfImpl<PutChFunc, ArgumentL
     }
 };
 
-ByteString format_double(char const* format, double value)
+String format_double(char const* format, double value)
 {
     StringBuilder builder;
     auto putch = [&](auto, auto ch) { builder.append(ch); };
     printf_internal<decltype(putch), PrintfImpl, double, SingleEntryListNext>(putch, nullptr, format, value);
 
-    return builder.to_byte_string();
+    return MUST(builder.to_string());
 }
 
 }

--- a/Userland/Applications/Spreadsheet/CellType/Format.h
+++ b/Userland/Applications/Spreadsheet/CellType/Format.h
@@ -10,6 +10,6 @@
 
 namespace Spreadsheet {
 
-ByteString format_double(char const* format, double value);
+String format_double(char const* format, double value);
 
 }

--- a/Userland/Applications/Spreadsheet/CellType/Identity.cpp
+++ b/Userland/Applications/Spreadsheet/CellType/Identity.cpp
@@ -15,14 +15,14 @@ IdentityCell::IdentityCell()
 {
 }
 
-JS::ThrowCompletionOr<ByteString> IdentityCell::display(Cell& cell, CellTypeMetadata const& metadata) const
+JS::ThrowCompletionOr<String> IdentityCell::display(Cell& cell, CellTypeMetadata const& metadata) const
 {
     auto& vm = cell.sheet().global_object().vm();
     auto data = cell.js_data();
     if (!metadata.format.is_empty())
         data = TRY(cell.sheet().evaluate(metadata.format, &cell));
 
-    return data.to_byte_string(vm);
+    return data.to_string(vm);
 }
 
 JS::ThrowCompletionOr<JS::Value> IdentityCell::js_value(Cell& cell, CellTypeMetadata const&) const

--- a/Userland/Applications/Spreadsheet/CellType/Identity.h
+++ b/Userland/Applications/Spreadsheet/CellType/Identity.h
@@ -15,7 +15,7 @@ class IdentityCell : public CellType {
 public:
     IdentityCell();
     virtual ~IdentityCell() override = default;
-    virtual JS::ThrowCompletionOr<ByteString> display(Cell&, CellTypeMetadata const&) const override;
+    virtual JS::ThrowCompletionOr<String> display(Cell&, CellTypeMetadata const&) const override;
     virtual JS::ThrowCompletionOr<JS::Value> js_value(Cell&, CellTypeMetadata const&) const override;
     virtual String metadata_hint(MetadataName) const override;
 };

--- a/Userland/Applications/Spreadsheet/CellType/Numeric.h
+++ b/Userland/Applications/Spreadsheet/CellType/Numeric.h
@@ -26,7 +26,7 @@ class NumericCell : public CellType {
 public:
     NumericCell();
     virtual ~NumericCell() override = default;
-    virtual JS::ThrowCompletionOr<ByteString> display(Cell&, CellTypeMetadata const&) const override;
+    virtual JS::ThrowCompletionOr<String> display(Cell&, CellTypeMetadata const&) const override;
     virtual JS::ThrowCompletionOr<JS::Value> js_value(Cell&, CellTypeMetadata const&) const override;
     virtual String metadata_hint(MetadataName) const override;
 };

--- a/Userland/Applications/Spreadsheet/CellType/String.cpp
+++ b/Userland/Applications/Spreadsheet/CellType/String.cpp
@@ -7,6 +7,7 @@
 #include "String.h"
 #include "../Cell.h"
 #include "../Spreadsheet.h"
+#include <LibJS/Runtime/Completion.h>
 
 namespace Spreadsheet {
 
@@ -15,12 +16,12 @@ StringCell::StringCell()
 {
 }
 
-JS::ThrowCompletionOr<ByteString> StringCell::display(Cell& cell, CellTypeMetadata const& metadata) const
+JS::ThrowCompletionOr<String> StringCell::display(Cell& cell, CellTypeMetadata const& metadata) const
 {
     auto& vm = cell.sheet().global_object().vm();
-    auto string = TRY(cell.js_data().to_byte_string(vm));
+    auto string = TRY(cell.js_data().to_string(vm));
     if (metadata.length >= 0)
-        return string.substring(0, metadata.length);
+        return MUST(String::from_view(string.code_points().unicode_substring_view(0, metadata.length)));
 
     return string;
 }

--- a/Userland/Applications/Spreadsheet/CellType/String.h
+++ b/Userland/Applications/Spreadsheet/CellType/String.h
@@ -15,7 +15,7 @@ class StringCell : public CellType {
 public:
     StringCell();
     virtual ~StringCell() override = default;
-    virtual JS::ThrowCompletionOr<ByteString> display(Cell&, CellTypeMetadata const&) const override;
+    virtual JS::ThrowCompletionOr<String> display(Cell&, CellTypeMetadata const&) const override;
     virtual JS::ThrowCompletionOr<JS::Value> js_value(Cell&, CellTypeMetadata const&) const override;
     virtual String metadata_hint(MetadataName) const override;
 };

--- a/Userland/Applications/Spreadsheet/CellType/Type.cpp
+++ b/Userland/Applications/Spreadsheet/CellType/Type.cpp
@@ -12,7 +12,7 @@
 #include <AK/HashMap.h>
 #include <AK/OwnPtr.h>
 
-static HashMap<ByteString, Spreadsheet::CellType*> s_cell_types;
+static HashMap<String, Spreadsheet::CellType*> s_cell_types;
 static Spreadsheet::StringCell s_string_cell;
 static Spreadsheet::NumericCell s_numeric_cell;
 static Spreadsheet::IdentityCell s_identity_cell;
@@ -34,10 +34,10 @@ Vector<StringView> CellType::names()
 }
 
 CellType::CellType(StringView name)
-    : m_name(name)
+    : m_name(MUST(String::from_utf8(name)))
 {
     VERIFY(!s_cell_types.contains(name));
-    s_cell_types.set(name, this);
+    s_cell_types.set(m_name, this);
 }
 
 }

--- a/Userland/Applications/Spreadsheet/CellType/Type.h
+++ b/Userland/Applications/Spreadsheet/CellType/Type.h
@@ -8,8 +8,8 @@
 
 #include "../ConditionalFormatting.h"
 #include "../Forward.h"
-#include <AK/ByteString.h>
 #include <AK/Forward.h>
+#include <AK/String.h>
 #include <LibGfx/Color.h>
 #include <LibGfx/TextAlignment.h>
 #include <LibJS/Forward.h>
@@ -18,7 +18,7 @@ namespace Spreadsheet {
 
 struct CellTypeMetadata {
     int length { -1 };
-    ByteString format;
+    String format;
     Gfx::TextAlignment alignment { Gfx::TextAlignment::CenterRight };
     Format static_format;
 };
@@ -35,18 +35,18 @@ public:
     static CellType const* get_by_name(StringView);
     static Vector<StringView> names();
 
-    virtual JS::ThrowCompletionOr<ByteString> display(Cell&, CellTypeMetadata const&) const = 0;
+    virtual JS::ThrowCompletionOr<String> display(Cell&, CellTypeMetadata const&) const = 0;
     virtual JS::ThrowCompletionOr<JS::Value> js_value(Cell&, CellTypeMetadata const&) const = 0;
     virtual String metadata_hint(MetadataName) const { return {}; }
     virtual ~CellType() = default;
 
-    ByteString const& name() const { return m_name; }
+    String const& name() const { return m_name; }
 
 protected:
     CellType(StringView name);
 
 private:
-    ByteString m_name;
+    String m_name;
 };
 
 }

--- a/Userland/Applications/Spreadsheet/CellTypeDialog.cpp
+++ b/Userland/Applications/Spreadsheet/CellTypeDialog.cpp
@@ -61,9 +61,9 @@ CellTypeDialog::CellTypeDialog(Vector<Position> const& positions, Sheet& sheet, 
     ok_button.on_click = [&](auto) { done(ExecResult::OK); };
 }
 
-Vector<ByteString> const g_horizontal_alignments { "Left", "Center", "Right" };
-Vector<ByteString> const g_vertical_alignments { "Top", "Center", "Bottom" };
-Vector<ByteString> g_types;
+Vector<String> const g_horizontal_alignments { "Left"_string, "Center"_string, "Right"_string };
+Vector<String> const g_vertical_alignments { "Top"_string, "Center"_string, "Bottom"_string };
+Vector<String> g_types;
 
 constexpr static CellTypeDialog::VerticalAlignment vertical_alignment_from(Gfx::TextAlignment alignment)
 {
@@ -113,7 +113,7 @@ void CellTypeDialog::setup_tabs(GUI::TabWidget& tabs, Vector<Position> const& po
 {
     g_types.clear();
     for (auto& type_name : CellType::names())
-        g_types.append(type_name);
+        g_types.append(MUST(String::from_utf8(type_name)));
 
     Vector<Cell&> cells;
     for (auto& position : positions) {
@@ -142,7 +142,7 @@ void CellTypeDialog::setup_tabs(GUI::TabWidget& tabs, Vector<Position> const& po
         right_side.set_fixed_width(170);
 
         auto& type_list = left_side.add<GUI::ListView>();
-        type_list.set_model(*GUI::ItemListModel<ByteString>::create(g_types));
+        type_list.set_model(*GUI::ItemListModel<String>::create(g_types));
         type_list.set_should_hide_unnecessary_scrollbars(true);
         type_list.on_selection_change = [&] {
             const auto& index = type_list.selection().first();
@@ -188,11 +188,11 @@ void CellTypeDialog::setup_tabs(GUI::TabWidget& tabs, Vector<Position> const& po
             checkbox.on_checked = [&](auto checked) {
                 editor.set_enabled(checked);
                 if (!checked)
-                    m_format = ByteString::empty();
+                    m_format = {};
                 editor.set_text(m_format);
             };
             editor.on_change = [&] {
-                m_format = editor.text();
+                m_format = MUST(String::from_byte_string(editor.text()));
             };
         }
     }
@@ -213,7 +213,7 @@ void CellTypeDialog::setup_tabs(GUI::TabWidget& tabs, Vector<Position> const& po
 
             auto& horizontal_combobox = alignment_tab.add<GUI::ComboBox>();
             horizontal_combobox.set_only_allow_values_from_model(true);
-            horizontal_combobox.set_model(*GUI::ItemListModel<ByteString>::create(g_horizontal_alignments));
+            horizontal_combobox.set_model(*GUI::ItemListModel<String>::create(g_horizontal_alignments));
             horizontal_combobox.set_selected_index((int)m_horizontal_alignment);
             horizontal_combobox.on_change = [&](auto&, const GUI::ModelIndex& index) {
                 switch (index.row()) {
@@ -244,7 +244,7 @@ void CellTypeDialog::setup_tabs(GUI::TabWidget& tabs, Vector<Position> const& po
 
             auto& vertical_combobox = alignment_tab.add<GUI::ComboBox>();
             vertical_combobox.set_only_allow_values_from_model(true);
-            vertical_combobox.set_model(*GUI::ItemListModel<ByteString>::create(g_vertical_alignments));
+            vertical_combobox.set_model(*GUI::ItemListModel<String>::create(g_vertical_alignments));
             vertical_combobox.set_selected_index((int)m_vertical_alignment);
             vertical_combobox.on_change = [&](auto&, const GUI::ModelIndex& index) {
                 switch (index.row()) {
@@ -412,7 +412,7 @@ ConditionView::ConditionView(ConditionalFormat& fmt)
     formula_editor.set_syntax_highlighter(make<JS::SyntaxHighlighter>());
     formula_editor.set_should_hide_unnecessary_scrollbars(true);
     formula_editor.on_change = [&] {
-        m_format.condition = formula_editor.text();
+        m_format.condition = MUST(String::from_byte_string(formula_editor.text()));
     };
 }
 

--- a/Userland/Applications/Spreadsheet/CellTypeDialog.h
+++ b/Userland/Applications/Spreadsheet/CellTypeDialog.h
@@ -39,7 +39,7 @@ private:
     CellType const* m_type { nullptr };
 
     int m_length { -1 };
-    ByteString m_format;
+    String m_format;
     HorizontalAlignment m_horizontal_alignment { HorizontalAlignment::Right };
     VerticalAlignment m_vertical_alignment { VerticalAlignment::Center };
     Format m_static_format;

--- a/Userland/Applications/Spreadsheet/ConditionalFormatting.h
+++ b/Userland/Applications/Spreadsheet/ConditionalFormatting.h
@@ -7,7 +7,7 @@
 #pragma once
 
 #include "Forward.h"
-#include <AK/ByteString.h>
+#include <AK/String.h>
 #include <LibGUI/AbstractScrollableWidget.h>
 #include <LibGfx/Color.h>
 
@@ -19,7 +19,7 @@ struct Format {
 };
 
 struct ConditionalFormat : public Format {
-    ByteString condition;
+    String condition;
 };
 
 enum class FormatType {

--- a/Userland/Applications/Spreadsheet/ExportDialog.h
+++ b/Userland/Applications/Spreadsheet/ExportDialog.h
@@ -33,8 +33,8 @@ protected:
     void update_preview();
 
 private:
-    Vector<Vector<ByteString>> m_data;
-    Vector<ByteString> m_headers;
+    Vector<Vector<String>> m_data;
+    Vector<String> m_headers;
     RefPtr<GUI::WizardPage> m_page;
     RefPtr<GUI::RadioButton> m_delimiter_comma_radio;
     RefPtr<GUI::RadioButton> m_delimiter_semicolon_radio;
@@ -50,10 +50,10 @@ private:
     RefPtr<GUI::CheckBox> m_export_header_check_box;
     RefPtr<GUI::CheckBox> m_quote_all_fields_check_box;
     RefPtr<GUI::TextEditor> m_data_preview_text_editor;
-    Vector<ByteString> m_quote_escape_items {
+    Vector<String> m_quote_escape_items {
         // Note: Keep in sync with Writer::WriterTraits::QuoteEscape.
-        "Repeat",
-        "Backslash",
+        "Repeat"_string,
+        "Backslash"_string,
     };
 };
 

--- a/Userland/Applications/Spreadsheet/HelpWindow.h
+++ b/Userland/Applications/Spreadsheet/HelpWindow.h
@@ -32,7 +32,7 @@ public:
 
 private:
     static RefPtr<HelpWindow> s_the;
-    ByteString render(StringView key);
+    String render(StringView key);
     HelpWindow(GUI::Window* parent = nullptr);
 
     JsonObject m_docs;

--- a/Userland/Applications/Spreadsheet/ImportDialog.h
+++ b/Userland/Applications/Spreadsheet/ImportDialog.h
@@ -47,15 +47,15 @@ private:
     RefPtr<GUI::TableView> m_data_preview_table_view;
     RefPtr<GUI::Label> m_data_preview_error_label;
     RefPtr<GUI::StackWidget> m_data_preview_widget;
-    Vector<ByteString> m_quote_escape_items {
+    Vector<String> m_quote_escape_items {
         // Note: Keep in sync with Reader::ParserTraits::QuoteEscape.
-        "Repeat",
-        "Backslash",
+        "Repeat"_string,
+        "Backslash"_string,
     };
 };
 
 struct ImportDialog {
-    static ErrorOr<Vector<NonnullRefPtr<Sheet>>, ByteString> make_and_run_for(GUI::Window& parent, StringView mime, String const& filename, Core::File& file, Workbook&);
+    static ErrorOr<Vector<NonnullRefPtr<Sheet>>, String> make_and_run_for(GUI::Window& parent, StringView mime, ByteString const& filename, Core::File& file, Workbook&);
 };
 
 }

--- a/Userland/Applications/Spreadsheet/JSIntegration.h
+++ b/Userland/Applications/Spreadsheet/JSIntegration.h
@@ -14,7 +14,7 @@
 namespace Spreadsheet {
 
 struct FunctionAndArgumentIndex {
-    ByteString function_name;
+    String function_name;
     size_t argument_index { 0 };
 };
 Optional<FunctionAndArgumentIndex> get_function_and_argument_index(StringView source);

--- a/Userland/Applications/Spreadsheet/Position.h
+++ b/Userland/Applications/Spreadsheet/Position.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <AK/ByteString.h>
+#include <AK/String.h>
 #include <AK/Types.h>
 #include <AK/URL.h>
 
@@ -37,7 +37,7 @@ struct Position {
         return row == other.row && column == other.column;
     }
 
-    ByteString to_cell_identifier(Sheet const& sheet) const;
+    String to_cell_identifier(Sheet const& sheet) const;
     URL to_url(Sheet const& sheet) const;
 
     size_t column { 0 };

--- a/Userland/Applications/Spreadsheet/Readers/CSV.h
+++ b/Userland/Applications/Spreadsheet/Readers/CSV.h
@@ -15,7 +15,7 @@ namespace Reader {
 class CSV : public XSV {
 public:
     CSV(StringView source, ParserBehavior behaviors = default_behaviors())
-        : XSV(source, { ",", "\"", ParserTraits::Repeat }, behaviors)
+        : XSV(source, { ","_string, "\""_string, ParserTraits::Repeat }, behaviors)
     {
     }
 };

--- a/Userland/Applications/Spreadsheet/Readers/XSV.h
+++ b/Userland/Applications/Spreadsheet/Readers/XSV.h
@@ -6,8 +6,8 @@
 
 #pragma once
 
-#include <AK/ByteString.h>
 #include <AK/GenericLexer.h>
+#include <AK/String.h>
 #include <AK/StringView.h>
 #include <AK/Types.h>
 #include <AK/Vector.h>
@@ -31,20 +31,20 @@ ParserBehavior operator&(ParserBehavior left, ParserBehavior right);
 ParserBehavior operator|(ParserBehavior left, ParserBehavior right);
 
 struct ParserTraits {
-    ByteString separator;
-    ByteString quote { "\"" };
+    String separator;
+    String quote { "\""_string };
     enum QuoteEscape {
         Repeat,
         Backslash,
     } quote_escape { Repeat };
 };
 
-#define ENUMERATE_READ_ERRORS()                                                   \
-    E(None, "No errors")                                                          \
-    E(NonConformingColumnCount, "Header count does not match given column count") \
-    E(QuoteFailure, "Quoting failure")                                            \
-    E(InternalError, "Internal error")                                            \
-    E(DataPastLogicalEnd, "Extra data past the logical end of the rows")
+#define ENUMERATE_READ_ERRORS()                                                          \
+    E(None, "No errors"_string)                                                          \
+    E(NonConformingColumnCount, "Header count does not match given column count"_string) \
+    E(QuoteFailure, "Quoting failure"_string)                                            \
+    E(InternalError, "Internal error"_string)                                            \
+    E(DataPastLogicalEnd, "Extra data past the logical end of the rows"_string)
 
 enum class ReadError {
 #define E(name, _) name,
@@ -73,7 +73,7 @@ public:
     void parse();
     bool has_error() const { return m_error != ReadError::None; }
     ReadError error() const { return m_error; }
-    ByteString error_string() const
+    String error_string() const
     {
         switch (m_error) {
 #define E(x, y)        \
@@ -87,7 +87,7 @@ public:
     }
 
     size_t size() const { return m_rows.size(); }
-    Vector<ByteString> headers() const;
+    Vector<String> headers() const;
     [[nodiscard]] bool has_explicit_headers() const { return (static_cast<u32>(m_behaviors) & static_cast<u32>(ParserBehavior::ReadHeaders)) != 0; }
 
     class Row {
@@ -185,7 +185,7 @@ public:
 private:
     struct Field {
         StringView as_string_view;
-        ByteString as_string; // This member only used if the parser couldn't use the original source verbatim.
+        String as_string; // This member only used if the parser couldn't use the original source verbatim.
         bool is_string_view { true };
 
         bool operator==(StringView other) const

--- a/Userland/Applications/Spreadsheet/SpreadsheetModel.cpp
+++ b/Userland/Applications/Spreadsheet/SpreadsheetModel.cpp
@@ -21,9 +21,9 @@ GUI::Variant SheetModel::data(const GUI::ModelIndex& index, GUI::ModelRole role)
     if (role == GUI::ModelRole::Display) {
         auto const* cell = m_sheet->at({ (size_t)index.column(), (size_t)index.row() });
         if (!cell)
-            return ByteString::empty();
+            return String {};
 
-        Function<ByteString(JS::Value)> to_byte_string_as_exception = [&](JS::Value value) {
+        Function<String(JS::Value)> to_string_as_exception = [&](JS::Value value) {
             auto& vm = cell->sheet().global_object().vm();
             StringBuilder builder;
             builder.append("Error: "sv);
@@ -31,31 +31,31 @@ GUI::Variant SheetModel::data(const GUI::ModelIndex& index, GUI::ModelRole role)
                 auto& object = value.as_object();
                 if (is<JS::Error>(object)) {
                     auto message = object.get_without_side_effects("message");
-                    auto error = message.to_byte_string(vm);
+                    auto error = message.to_string(vm);
                     if (error.is_throw_completion())
                         builder.append(message.to_string_without_side_effects());
                     else
                         builder.append(error.release_value());
-                    return builder.to_byte_string();
+                    return MUST(builder.to_string());
                 }
             }
-            auto error_message = value.to_byte_string(vm);
+            auto error_message = value.to_string(vm);
 
             if (error_message.is_throw_completion())
-                return to_byte_string_as_exception(*error_message.release_error().value());
+                return to_string_as_exception(*error_message.release_error().value());
 
             builder.append(error_message.release_value());
-            return builder.to_byte_string();
+            return MUST(builder.to_string());
         };
 
         if (cell->kind() == Spreadsheet::Cell::Formula) {
             if (auto opt_throw_value = cell->thrown_value(); opt_throw_value.has_value())
-                return to_byte_string_as_exception(*opt_throw_value);
+                return to_string_as_exception(*opt_throw_value);
         }
 
         auto display = cell->typed_display();
         if (display.is_error())
-            return to_byte_string_as_exception(*display.release_error().value());
+            return to_string_as_exception(*display.release_error().value());
 
         return display.release_value();
     }
@@ -154,10 +154,10 @@ RefPtr<Core::MimeData> SheetModel::mime_data(const GUI::ModelSelection& selectio
 
     Position cursor_position { (size_t)cursor->column(), (size_t)cursor->row() };
     auto mime_data_buffer = mime_data->data("text/x-spreadsheet-data"sv);
-    auto new_data = ByteString::formatted("{}\n{}",
-        cursor_position.to_url(m_sheet).to_byte_string(),
-        StringView(mime_data_buffer));
-    mime_data->set_data("text/x-spreadsheet-data"_string, new_data.to_byte_buffer());
+    auto new_data = MUST(String::formatted("{}\n{}",
+        cursor_position.to_url(m_sheet),
+        StringView(mime_data_buffer)));
+    mime_data->set_data("text/x-spreadsheet-data"_string, MUST(ByteBuffer::copy(new_data.bytes())));
 
     return mime_data;
 }
@@ -167,7 +167,7 @@ ErrorOr<String> SheetModel::column_name(int index) const
     if (index < 0)
         return String {};
 
-    return TRY(String::from_byte_string(m_sheet->column(index)));
+    return m_sheet->column(index);
 }
 
 bool SheetModel::is_editable(const GUI::ModelIndex& index) const
@@ -185,7 +185,7 @@ void SheetModel::set_data(const GUI::ModelIndex& index, const GUI::Variant& valu
 
     auto& cell = m_sheet->ensure({ (size_t)index.column(), (size_t)index.row() });
     auto previous_data = cell.data();
-    cell.set_data(value.to_byte_string());
+    cell.set_data(MUST(String::from_byte_string(value.to_byte_string())));
     if (on_cell_data_change)
         on_cell_data_change(cell, previous_data);
     did_update(UpdateFlag::DontInvalidateIndices);
@@ -202,7 +202,7 @@ CellsUndoCommand::CellsUndoCommand(Vector<CellChange> cell_changes)
     m_cell_changes = cell_changes;
 }
 
-CellsUndoCommand::CellsUndoCommand(Cell& cell, ByteString const& previous_data)
+CellsUndoCommand::CellsUndoCommand(Cell& cell, String const& previous_data)
 {
     m_cell_changes.append(CellChange(cell, previous_data));
 }

--- a/Userland/Applications/Spreadsheet/SpreadsheetModel.h
+++ b/Userland/Applications/Spreadsheet/SpreadsheetModel.h
@@ -34,7 +34,7 @@ public:
 
     void update();
 
-    Function<void(Cell&, ByteString&)> on_cell_data_change;
+    Function<void(Cell&, String&)> on_cell_data_change;
     Function<void(Vector<CellChange>)> on_cells_data_change;
 
 private:
@@ -48,7 +48,7 @@ private:
 
 class CellsUndoCommand : public GUI::Command {
 public:
-    CellsUndoCommand(Cell&, ByteString const&);
+    CellsUndoCommand(Cell&, String const&);
     CellsUndoCommand(Vector<CellChange>);
 
     virtual void undo() override;

--- a/Userland/Applications/Spreadsheet/SpreadsheetView.cpp
+++ b/Userland/Applications/Spreadsheet/SpreadsheetView.cpp
@@ -448,7 +448,7 @@ SpreadsheetView::SpreadsheetView(Sheet& sheet)
 
         if (event.mime_data().has_text()) {
             auto& target_cell = m_sheet->ensure({ (size_t)index.column(), (size_t)index.row() });
-            target_cell.set_data(event.text());
+            target_cell.set_data(MUST(String::from_byte_string(event.text())));
             return;
         }
     };

--- a/Userland/Applications/Spreadsheet/SpreadsheetWidget.h
+++ b/Userland/Applications/Spreadsheet/SpreadsheetWidget.h
@@ -22,9 +22,9 @@ class SpreadsheetWidget final
 public:
     virtual ~SpreadsheetWidget() override = default;
 
-    void save(String const& filename, Core::File&);
-    void load_file(String const& filename, Core::File&);
-    void import_sheets(String const& filename, Core::File&);
+    void save(ByteString const& filename, Core::File&);
+    void load_file(ByteString const& filename, Core::File&);
+    void import_sheets(ByteString const& filename, Core::File&);
     bool request_close();
     void add_sheet();
     void add_sheet(NonnullRefPtr<Sheet>&&);

--- a/Userland/Applications/Spreadsheet/Workbook.cpp
+++ b/Userland/Applications/Spreadsheet/Workbook.cpp
@@ -50,31 +50,31 @@ bool Workbook::set_filename(ByteString const& filename)
     return true;
 }
 
-ErrorOr<void, ByteString> Workbook::open_file(String const& filename, Core::File& file)
+ErrorOr<void, String> Workbook::open_file(ByteString const& filename, Core::File& file)
 {
     auto mime = Core::guess_mime_type_based_on_filename(filename);
 
     // Make an import dialog, we might need to import it.
     m_sheets = TRY(ImportDialog::make_and_run_for(m_parent_window, mime, filename, file, *this));
 
-    set_filename(filename.to_byte_string());
+    set_filename(filename);
 
     return {};
 }
 
-ErrorOr<void> Workbook::write_to_file(String const& filename, Core::File& stream)
+ErrorOr<void> Workbook::write_to_file(ByteString const& filename, Core::File& stream)
 {
     auto mime = Core::guess_mime_type_based_on_filename(filename);
 
     // Make an export dialog, we might need to import it.
-    TRY(ExportDialog::make_and_run_for(mime, stream, filename.to_byte_string(), *this));
+    TRY(ExportDialog::make_and_run_for(mime, stream, filename, *this));
 
-    set_filename(filename.to_byte_string());
+    set_filename(filename);
     set_dirty(false);
     return {};
 }
 
-ErrorOr<bool, ByteString> Workbook::import_file(String const& filename, Core::File& file)
+ErrorOr<bool, String> Workbook::import_file(ByteString const& filename, Core::File& file)
 {
     auto mime = Core::guess_mime_type_based_on_filename(filename);
 

--- a/Userland/Applications/Spreadsheet/Workbook.h
+++ b/Userland/Applications/Spreadsheet/Workbook.h
@@ -15,10 +15,10 @@ class Workbook {
 public:
     Workbook(Vector<NonnullRefPtr<Sheet>>&& sheets, GUI::Window& parent_window);
 
-    ErrorOr<void, ByteString> open_file(String const& filename, Core::File&);
-    ErrorOr<void> write_to_file(String const& filename, Core::File&);
+    ErrorOr<void, String> open_file(ByteString const& filename, Core::File&);
+    ErrorOr<void> write_to_file(ByteString const& filename, Core::File&);
 
-    ErrorOr<bool, ByteString> import_file(String const& filename, Core::File&);
+    ErrorOr<bool, String> import_file(ByteString const& filename, Core::File&);
 
     ByteString const& current_filename() const { return m_current_filename; }
     bool set_filename(ByteString const& filename);

--- a/Userland/Applications/Spreadsheet/Writers/CSV.h
+++ b/Userland/Applications/Spreadsheet/Writers/CSV.h
@@ -17,13 +17,13 @@ public:
     template<typename ContainerType>
     static ErrorOr<void> generate(Stream& output, ContainerType const& data, Vector<StringView> headers = {}, WriterBehavior behaviors = default_behaviors())
     {
-        return XSV<ContainerType>::generate(output, data, { ",", "\"", WriterTraits::Repeat }, move(headers), behaviors);
+        return XSV<ContainerType>::generate(output, data, { ","_string, "\""_string, WriterTraits::Repeat }, move(headers), behaviors);
     }
 
     template<typename ContainerType>
     static ErrorOr<void> generate_preview(Stream& output, ContainerType const& data, Vector<StringView> headers = {}, WriterBehavior behaviors = default_behaviors())
     {
-        return XSV<ContainerType>::generate_preview(output, data, { ",", "\"", WriterTraits::Repeat }, move(headers), behaviors);
+        return XSV<ContainerType>::generate_preview(output, data, { ","_string, "\""_string, WriterTraits::Repeat }, move(headers), behaviors);
     }
 };
 

--- a/Userland/Applications/Spreadsheet/Writers/Test/TestXSVWriter.cpp
+++ b/Userland/Applications/Spreadsheet/Writers/Test/TestXSVWriter.cpp
@@ -52,9 +52,9 @@ TEST_CASE(can_write_with_header)
 
 TEST_CASE(can_write_with_different_behaviors)
 {
-    Vector<Vector<ByteString>> data = {
-        { "Well", "Hello\"", "Friends" },
-        { "We\"ll", "Hello,", "   Friends" },
+    Vector<Vector<String>> data = {
+        { "Well"_string, "Hello\""_string, "Friends"_string },
+        { "We\"ll"_string, "Hello,"_string, "   Friends"_string },
     };
 
     AllocatingMemoryStream stream;

--- a/Userland/Applications/Spreadsheet/main.cpp
+++ b/Userland/Applications/Spreadsheet/main.cpp
@@ -71,7 +71,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     if (!filename.is_empty()) {
         auto file = TRY(FileSystemAccessClient::Client::the().request_file_read_only_approved(window, filename));
-        spreadsheet_widget->load_file(file.filename(), file.stream());
+        spreadsheet_widget->load_file(file.filename().to_byte_string(), file.stream());
     }
 
     return app->exec();


### PR DESCRIPTION
As per #20405, this ignores most String OOMs and assumes (as before) that all string data inside Spreadsheet is UTF-8, crashing the program otherwise.