### PR TITLE
LibCompress: Avoid buffer overrun when building canonical Huffman code

### DIFF
--- a/Tests/LibCompress/TestDeflate.cpp
+++ b/Tests/LibCompress/TestDeflate.cpp
@@ -55,6 +55,13 @@ TEST_CASE(canonical_code_complex)
         EXPECT_EQ(MUST(huffman.read_symbol(bit_stream)), output[idx]);
 }
 
+TEST_CASE(invalid_canonical_code)
+{
+    Array<u8, 257> code;
+    code.fill(0x08);
+    EXPECT(Compress::CanonicalCode::from_bytes(code).is_error());
+}
+
 TEST_CASE(deflate_decompress_compressed_block)
 {
     Array<u8, 28> const compressed {

--- a/Userland/Libraries/LibCompress/Deflate.cpp
+++ b/Userland/Libraries/LibCompress/Deflate.cpp
@@ -100,6 +100,9 @@ ErrorOr<CanonicalCode> CanonicalCode::from_bytes(ReadonlyBytes bytes)
                 return Error::from_string_literal("Failed to decode code lengths");
 
             if (code_length <= CanonicalCode::max_allowed_prefixed_code_length) {
+                if (number_of_prefix_codes >= prefix_codes.size())
+                    return Error::from_string_literal("Invalid canonical Huffman code");
+
                 auto& prefix_code = prefix_codes[number_of_prefix_codes++];
                 prefix_code.symbol_code = next_code;
                 prefix_code.symbol_value = symbol;


### PR DESCRIPTION
Previously, decompressing a DEFLATE stream an invalid canonical Huffman code could cause a buffer overrun. We now return an error in this case.

This bug frequently crashes both `FuzzGzipDecompression` and `FuzzZlibDecompression`, so this fix should allow both fuzzers to make more progress.

This fixes oss fuzz issues:  [62027](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=62027), [58967](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=58967) and [59770](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=59770).