### PR TITLE
Meta: Misc README fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ You can watch videos of the system being developed on YouTube:
 
 ## Screenshot
 
-![Screenshot as of c03b788.png](https://raw.githubusercontent.com/SerenityOS/serenity/master/Meta/Screenshots/screenshot-c03b788.png)
+![Screenshot as of c03b788.png](Meta/Screenshots/screenshot-c03b788.png)
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ You can watch videos of the system being developed on YouTube:
 ## Features
 
 * Modern x86 64-bit kernel with pre-emptive multi-threading
-* [Browser](Userland/Applications/Browser/) with JavaScript, WebAssembly, and more (check the spec compliance for [JS](https://libjs.dev/test262/), [CSS](https://css.tobyase.de/), and [Wasm](https://libjs.dev/wasm/))
+* [Browser](Userland/Applications/Browser/) with JavaScript, WebAssembly, and more (check the spec compliance for [JS](https://test262.fyi/#|libjs) and [CSS](https://css.tobyase.de/))
 * Security features (hardware protections, limited userland capabilities, W^X memory, `pledge` & `unveil`, (K)ASLR, OOM-resistance, web-content isolation, state-of-the-art TLS algorithms, ...)
 * [System services](Userland/Services/) (WindowServer, LoginServer, AudioServer, WebServer, RequestServer, CrashServer, ...) and modern IPC
 * Good POSIX compatibility ([LibC](Userland/Libraries/LibC/), Shell, syscalls, signals, pseudoterminals, filesystem notifications, standard Unix [utilities](Userland/Utilities/), ...)

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ You can watch videos of the system being developed on YouTube:
 
 ... and all of the above are right in this repository, no extra dependencies, built from-scratch by us :^)
 
-Additionally, there are [over two hundred ports of popular open-source software](Ports/AvailablePorts.md), including games, compilers, Unix tools, multimedia apps and more.
+Additionally, there are [over three hundred ports of popular open-source software](Ports/AvailablePorts.md), including games, compilers, Unix tools, multimedia apps and more.
 
 ## How do I read the documentation?
 


### PR DESCRIPTION
## Meta: Remove spec-related dead links from README
Due to the removal of libjs.dev, replace the test262 link with the
test262.fyi counterpart and remove WASM link.

## Meta: Use relative path for screenshot in README
GitHub allows relative paths to be used to display images, this should
make the image continue working even when viewing the README from an
earlier commit of the repo in case the location of screenshots is moved.

This is also just a cleaner way to do this.

## Meta: Specify we now have over three hundred ports in the README :^)