### PR TITLE
WindowServer: Show disallowed cursor when resizing fixed-size window

### DIFF
--- a/Userland/Services/WindowServer/WindowFrame.cpp
+++ b/Userland/Services/WindowServer/WindowFrame.cpp
@@ -986,6 +986,26 @@ void WindowFrame::latch_window_to_screen_edge(ResizeDirection resize_direction)
         || resize_direction == ResizeDirection::DownLeft)
         window_rect.inflate(0, 0, 0, frame_rect.left() - screen_rect.left());
 
+    // If required, maintain fixed aspect ratio by scaling the other dimension appropriately
+    if (m_window.resize_aspect_ratio().has_value()) {
+        auto& ratio = m_window.resize_aspect_ratio().value();
+
+        if (window_rect.width() == m_window.rect().width()) {
+            // Up or Down
+            window_rect.set_width(window_rect.height() * ratio.width() / ratio.height());
+        } else {
+            // Left, Right, UpLeft, UpRight, DownLeft or DownRight
+            window_rect.set_height(window_rect.width() * ratio.height() / ratio.width());
+
+            // Match bottom corner of the frame and the screen
+            if (resize_direction == ResizeDirection::DownLeft
+                || resize_direction == ResizeDirection::DownRight) {
+                auto new_frame_rect = frame_rect_for_window(m_window, window_rect);
+                window_rect.translate_by(0, screen_rect.bottom() - new_frame_rect.bottom());
+            }
+        }
+    }
+
     m_window.set_rect(window_rect);
 }
 

--- a/Userland/Services/WindowServer/WindowFrame.cpp
+++ b/Userland/Services/WindowServer/WindowFrame.cpp
@@ -835,9 +835,6 @@ void WindowFrame::handle_mouse_event(MouseEvent const& event)
 
 void WindowFrame::handle_border_mouse_event(MouseEvent const& event)
 {
-    if (!m_window.is_resizable())
-        return;
-
     auto& wm = WindowManager::the();
 
     constexpr ResizeDirection direction_for_hot_area[3][3] = {
@@ -867,6 +864,9 @@ void WindowFrame::handle_border_mouse_event(MouseEvent const& event)
         Compositor::the().invalidate_cursor();
         return;
     }
+
+    if (!m_window.is_resizable())
+        return;
 
     if (event.type() == Event::MouseDown && event.button() == MouseButton::Primary)
         wm.start_window_resize(m_window, event.translated(rect().location()), resize_direction);

--- a/Userland/Services/WindowServer/WindowManager.cpp
+++ b/Userland/Services/WindowServer/WindowManager.cpp
@@ -852,9 +852,10 @@ bool WindowManager::process_ongoing_window_move(MouseEvent& event)
                 m_move_window_origin = m_move_window->position();
             }
         } else {
+            bool has_fixed_aspect_ratio = m_move_window->resize_aspect_ratio().has_value();
             bool is_resizable = m_move_window->is_resizable();
             auto tile_window = m_system_effects.tile_window();
-            bool allow_tile = is_resizable && tile_window != TileWindow::Never;
+            bool allow_tile = !has_fixed_aspect_ratio && is_resizable && tile_window != TileWindow::Never;
             auto pixels_moved_from_start = event.position().pixels_moved(m_move_origin);
 
             auto apply_window_tile = [&](WindowTileType tile_type) {


### PR DESCRIPTION
```
If the window is not resizable and you try to resize it (hovering over
borders or Super+Secondary-click) the disallowed cursor will be shown.

This conveys to the user that the window is not resizable.
```

#### Hovering over the borders:
![mouse](https://github.com/SerenityOS/serenity/assets/70647861/fdf3830e-2a7a-4ae4-8ceb-6644ebb14003)

#### Doing Super+Secondary-click:
![key](https://github.com/SerenityOS/serenity/assets/70647861/e39ae285-0a84-4772-abb4-4833d45efda2)

Bug/feature: For the keyboard shortcut scenario the disallowed cursor will turn into arrow cursor immediately on mouse movements even though the Super and Secondary mouse button is held down.

A side-effect:
- Before `m_resize_candidate` was only ever a window that was resizable. But now it can also be window that cannot be resized. So only the former ones can turn into `m_resize_window`s.

I used the disallowed cursor for now but a resize cursor with a lock/cross on it would be cool too. (that's why I kept the direction info that gets passed to `set_resize_candidate()`.