### PR TITLE
MacPDF: Unbreak persisting the current page

### DIFF
--- a/Meta/Lagom/Contrib/MacPDF/MacPDFWindowController.mm
+++ b/Meta/Lagom/Contrib/MacPDF/MacPDFWindowController.mm
@@ -29,6 +29,7 @@
         return nil;
 
     _pdfView = [[MacPDFView alloc] initWithFrame:NSZeroRect];
+    _pdfView.identifier = @"PDFView"; // To make state restoration work.
     [_pdfView setDelegate:self];
 
     NSSplitViewController* split_view = [[NSSplitViewController alloc] initWithNibName:nil bundle:nil];


### PR DESCRIPTION
I broke this when moving from a xib file to creating the UI in code (…in #21361).

https://developer.apple.com/documentation/appkit/nsuserinterfaceitemidentification/1396829-identifier says:

"Identifiers are used during window restoration operations to uniquely identify the windows of the application. [...] If you create an item in Interface Builder and do not set a value for this string, a unique value is created for the item when the nib file is loaded. For programmatically created views, you typically set this value after creating the item but before adding it to a window."

Without this, encodeRestorableStateWithCoder: / restoreStateWithCoder: in MacPDFView weren't getting called.