### PR TITLE
AK+Everywhere: Remove the null state of DeprecatedString

### DIFF
--- a/AK/DeprecatedFlyString.cpp
+++ b/AK/DeprecatedFlyString.cpp
@@ -38,8 +38,6 @@ void DeprecatedFlyString::did_destroy_impl(Badge<StringImpl>, StringImpl& impl)
 
 DeprecatedFlyString::DeprecatedFlyString(DeprecatedString const& string)
 {
-    if (string.is_null())
-        return;
     if (string.impl()->is_fly()) {
         m_impl = string.impl();
         return;
@@ -60,7 +58,7 @@ DeprecatedFlyString::DeprecatedFlyString(StringView string)
     if (string.is_null())
         return;
     auto it = fly_impls().find(string.hash(), [&](auto& candidate) {
-        return string == candidate;
+        return string == *candidate;
     });
     if (it == fly_impls().end()) {
         auto new_string = string.to_deprecated_string();

--- a/AK/GenericLexer.cpp
+++ b/AK/GenericLexer.cpp
@@ -129,7 +129,7 @@ StringView GenericLexer::consume_quoted_string(char escape_char)
 }
 
 #ifndef KERNEL
-DeprecatedString GenericLexer::consume_and_unescape_string(char escape_char)
+Optional<DeprecatedString> GenericLexer::consume_and_unescape_string(char escape_char)
 {
     auto view = consume_quoted_string(escape_char);
     if (view.is_null())

--- a/AK/GenericLexer.h
+++ b/AK/GenericLexer.h
@@ -119,7 +119,7 @@ public:
     StringView consume_until(StringView);
     StringView consume_quoted_string(char escape_char = 0);
 #ifndef KERNEL
-    DeprecatedString consume_and_unescape_string(char escape_char = '\\');
+    Optional<DeprecatedString> consume_and_unescape_string(char escape_char = '\\');
 #endif
 
     enum class UnicodeEscapeError {

--- a/AK/JsonParser.cpp
+++ b/AK/JsonParser.cpp
@@ -132,8 +132,6 @@ ErrorOr<JsonValue> JsonParser::parse_object()
             break;
         ignore_while(is_space);
         auto name = TRY(consume_and_unescape_string());
-        if (name.is_null())
-            return Error::from_string_literal("JsonParser: Expected object property name");
         ignore_while(is_space);
         if (!consume_specific(':'))
             return Error::from_string_literal("JsonParser: Expected ':'");

--- a/AK/JsonValue.cpp
+++ b/AK/JsonValue.cpp
@@ -174,13 +174,9 @@ JsonValue::JsonValue(double value)
 
 JsonValue::JsonValue(DeprecatedString const& value)
 {
-    if (value.is_null()) {
-        m_type = Type::Null;
-    } else {
-        m_type = Type::String;
-        m_value.as_string = const_cast<StringImpl*>(value.impl());
-        m_value.as_string->ref();
-    }
+    m_type = Type::String;
+    m_value.as_string = const_cast<StringImpl*>(value.impl());
+    m_value.as_string->ref();
 }
 
 JsonValue::JsonValue(StringView value)

--- a/AK/LexicalPath.cpp
+++ b/AK/LexicalPath.cpp
@@ -90,9 +90,6 @@ bool LexicalPath::is_child_of(LexicalPath const& possible_parent) const
 
 DeprecatedString LexicalPath::canonicalized_path(DeprecatedString path)
 {
-    if (path.is_null())
-        return {};
-
     // NOTE: We never allow an empty m_string, if it's empty, we just set it to '.'.
     if (path.is_empty())
         return ".";

--- a/AK/StringImpl.cpp
+++ b/AK/StringImpl.cpp
@@ -47,9 +47,6 @@ NonnullRefPtr<StringImpl const> StringImpl::create_uninitialized(size_t length, 
 
 RefPtr<StringImpl const> StringImpl::create(char const* cstring, size_t length, ShouldChomp should_chomp)
 {
-    if (!cstring)
-        return nullptr;
-
     if (should_chomp) {
         while (length) {
             char last_ch = cstring[length - 1];
@@ -72,10 +69,7 @@ RefPtr<StringImpl const> StringImpl::create(char const* cstring, size_t length, 
 
 RefPtr<StringImpl const> StringImpl::create(char const* cstring, ShouldChomp shouldChomp)
 {
-    if (!cstring)
-        return nullptr;
-
-    if (!*cstring)
+    if (!cstring || !*cstring)
         return the_empty_stringimpl();
 
     return create(cstring, strlen(cstring), shouldChomp);
@@ -88,8 +82,6 @@ RefPtr<StringImpl const> StringImpl::create(ReadonlyBytes bytes, ShouldChomp sho
 
 RefPtr<StringImpl const> StringImpl::create_lowercased(char const* cstring, size_t length)
 {
-    if (!cstring)
-        return nullptr;
     if (!length)
         return the_empty_stringimpl();
     char* buffer;
@@ -101,8 +93,6 @@ RefPtr<StringImpl const> StringImpl::create_lowercased(char const* cstring, size
 
 RefPtr<StringImpl const> StringImpl::create_uppercased(char const* cstring, size_t length)
 {
-    if (!cstring)
-        return nullptr;
     if (!length)
         return the_empty_stringimpl();
     char* buffer;

--- a/AK/StringView.cpp
+++ b/AK/StringView.cpp
@@ -178,12 +178,12 @@ bool StringView::equals_ignoring_ascii_case(StringView other) const
 #ifndef KERNEL
 DeprecatedString StringView::to_lowercase_string() const
 {
-    return StringImpl::create_lowercased(characters_without_null_termination(), length());
+    return StringImpl::create_lowercased(characters_without_null_termination(), length()).release_nonnull();
 }
 
 DeprecatedString StringView::to_uppercase_string() const
 {
-    return StringImpl::create_uppercased(characters_without_null_termination(), length());
+    return StringImpl::create_uppercased(characters_without_null_termination(), length()).release_nonnull();
 }
 
 DeprecatedString StringView::to_titlecase_string() const

--- a/AK/URL.cpp
+++ b/AK/URL.cpp
@@ -191,13 +191,11 @@ URL URL::create_with_file_scheme(DeprecatedString const& path, DeprecatedString 
 
     URL url;
     url.set_scheme("file"_string);
-    // NOTE: If the hostname is localhost (or null, which implies localhost), it should be set to the empty string.
-    //       This is because a file URL always needs a non-null hostname.
-    url.set_host(hostname.is_null() || hostname == "localhost" ? String {} : String::from_deprecated_string(hostname).release_value_but_fixme_should_propagate_errors());
+    url.set_host(hostname == "localhost" ? String {} : String::from_deprecated_string(hostname).release_value_but_fixme_should_propagate_errors());
     url.set_paths(lexical_path.parts());
     if (path.ends_with('/'))
         url.append_slash();
-    if (!fragment.is_null())
+    if (!fragment.is_empty())
         url.set_fragment(String::from_deprecated_string(fragment).release_value_but_fixme_should_propagate_errors());
     return url;
 }
@@ -208,14 +206,12 @@ URL URL::create_with_help_scheme(DeprecatedString const& path, DeprecatedString 
 
     URL url;
     url.set_scheme("help"_string);
-    // NOTE: If the hostname is localhost (or null, which implies localhost), it should be set to the empty string.
-    //       This is because a file URL always needs a non-null hostname.
-    url.set_host(hostname.is_null() || hostname == "localhost" ? String {} : String::from_deprecated_string(hostname).release_value_but_fixme_should_propagate_errors());
+    url.set_host(hostname == "localhost" ? String {} : String::from_deprecated_string(hostname).release_value_but_fixme_should_propagate_errors());
 
     url.set_paths(lexical_path.parts());
     if (path.ends_with('/'))
         url.append_slash();
-    if (!fragment.is_null())
+    if (!fragment.is_empty())
         url.set_fragment(String::from_deprecated_string(fragment).release_value_but_fixme_should_propagate_errors());
     return url;
 }

--- a/AK/URL.cpp
+++ b/AK/URL.cpp
@@ -62,14 +62,6 @@ DeprecatedString URL::basename() const
     return percent_decode(last_segment);
 }
 
-// NOTE: This only exists for compatibility with the existing URL tests which check for both .is_null() and .is_empty().
-static DeprecatedString deprecated_string_percent_encode(DeprecatedString const& input, URL::PercentEncodeSet set = URL::PercentEncodeSet::Userinfo, URL::SpaceAsPlus space_as_plus = URL::SpaceAsPlus::No)
-{
-    if (input.is_null() || input.is_empty())
-        return input;
-    return URL::percent_encode(input.view(), set, space_as_plus);
-}
-
 void URL::set_scheme(String scheme)
 {
     m_scheme = move(scheme);
@@ -80,7 +72,7 @@ void URL::set_scheme(String scheme)
 ErrorOr<void> URL::set_username(StringView username)
 {
     // To set the username given a url and username, set url’s username to the result of running UTF-8 percent-encode on username using the userinfo percent-encode set.
-    m_username = TRY(String::from_deprecated_string(deprecated_string_percent_encode(username, PercentEncodeSet::Userinfo)));
+    m_username = TRY(String::from_deprecated_string(percent_encode(username, PercentEncodeSet::Userinfo)));
     m_valid = compute_validity();
     return {};
 }
@@ -89,7 +81,7 @@ ErrorOr<void> URL::set_username(StringView username)
 ErrorOr<void> URL::set_password(StringView password)
 {
     // To set the password given a url and password, set url’s password to the result of running UTF-8 percent-encode on password using the userinfo percent-encode set.
-    m_password = TRY(String::from_deprecated_string(deprecated_string_percent_encode(password, PercentEncodeSet::Userinfo)));
+    m_password = TRY(String::from_deprecated_string(percent_encode(password, PercentEncodeSet::Userinfo)));
     m_valid = compute_validity();
     return {};
 }
@@ -121,13 +113,13 @@ void URL::set_paths(Vector<DeprecatedString> const& paths)
     m_paths.clear_with_capacity();
     m_paths.ensure_capacity(paths.size());
     for (auto const& segment : paths)
-        m_paths.unchecked_append(deprecated_string_percent_encode(segment, PercentEncodeSet::Path));
+        m_paths.unchecked_append(percent_encode(segment, PercentEncodeSet::Path));
     m_valid = compute_validity();
 }
 
 void URL::append_path(StringView path)
 {
-    m_paths.append(deprecated_string_percent_encode(path, PercentEncodeSet::Path));
+    m_paths.append(percent_encode(path, PercentEncodeSet::Path));
 }
 
 // https://url.spec.whatwg.org/#cannot-have-a-username-password-port

--- a/Meta/Lagom/Tools/CodeGenerators/IPCCompiler/main.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/IPCCompiler/main.cpp
@@ -311,7 +311,7 @@ void do_message(SourceGenerator message_generator, DeprecatedString const& name,
 class @message.pascal_name@ final : public IPC::Message {
 public:)~~~");
 
-    if (!response_type.is_null())
+    if (!response_type.is_empty())
         message_generator.appendln(R"~~~(
    typedef class @message.response_type@ ResponseType;)~~~");
 

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -785,7 +785,7 @@ static void generate_to_cpp(SourceGenerator& generator, ParameterType& parameter
                 }
                 i++;
             }
-            if (current_dictionary->parent_name.is_null())
+            if (current_dictionary->parent_name.is_empty())
                 break;
             VERIFY(interface.dictionaries.contains(current_dictionary->parent_name));
             current_dictionary = &interface.dictionaries.find(current_dictionary->parent_name)->value;
@@ -1755,7 +1755,7 @@ static void generate_wrap_statement(SourceGenerator& generator, DeprecatedString
 )~~~");
             }
 
-            if (current_dictionary->parent_name.is_null())
+            if (current_dictionary->parent_name.is_empty())
                 break;
             VERIFY(interface.dictionaries.contains(current_dictionary->parent_name));
             current_dictionary = &interface.dictionaries.find(current_dictionary->parent_name)->value;
@@ -2352,7 +2352,7 @@ static void collect_attribute_values_of_an_inheritance_stack(SourceGenerator& fu
 
             if (attribute.extended_attributes.contains("Reflect")) {
                 auto attribute_name = attribute.extended_attributes.get("Reflect").value();
-                if (attribute_name.is_null())
+                if (attribute_name.is_empty())
                     attribute_name = attribute.name;
                 attribute_name = make_input_acceptable_cpp(attribute_name);
 
@@ -2837,7 +2837,7 @@ static JS::ThrowCompletionOr<@fully_qualified_name@*> impl_from(JS::VM& vm)
 
         if (attribute.extended_attributes.contains("Reflect")) {
             auto attribute_name = attribute.extended_attributes.get("Reflect").value();
-            if (attribute_name.is_null())
+            if (attribute_name.is_empty())
                 attribute_name = attribute.name;
             attribute_name = make_input_acceptable_cpp(attribute_name);
 

--- a/Meta/Lagom/Tools/IPCMagicLinter/main.cpp
+++ b/Meta/Lagom/Tools/IPCMagicLinter/main.cpp
@@ -52,7 +52,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                 if (!line.starts_with("endpoint "sv))
                     continue;
                 auto line_endpoint_name = line.substring_view("endpoint "sv.length());
-                if (!endpoint_name.is_null()) {
+                if (!endpoint_name.is_empty()) {
                     // Note: If there are three or more endpoints defined in a file, these errors will look a bit wonky.
                     // However, that's fine, because it shouldn't happen in the first place.
                     warnln("Error: Multiple endpoints in file '{}': Found {} and {}", filename, endpoint_name, line_endpoint_name);
@@ -72,7 +72,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             had_errors = true;
             continue; // next file
         }
-        if (endpoint_name.is_null()) {
+        if (endpoint_name.is_empty()) {
             // If this happens, this file probably needs to parse the endpoint name more carefully.
             warnln("Error: Could not detect endpoint name in file '{}'", filename);
             had_errors = true;

--- a/Tests/AK/TestCircularDeque.cpp
+++ b/Tests/AK/TestCircularDeque.cpp
@@ -41,7 +41,7 @@ TEST_CASE(enqueue_begin_being_moved_from)
 
     DeprecatedString str { "test" };
     strings.enqueue_begin(move(str));
-    EXPECT(str.is_null());
+    EXPECT(str.is_empty());
 }
 
 TEST_CASE(deque_end)

--- a/Tests/AK/TestDeprecatedString.cpp
+++ b/Tests/AK/TestDeprecatedString.cpp
@@ -14,11 +14,9 @@
 
 TEST_CASE(construct_empty)
 {
-    EXPECT(DeprecatedString().is_null());
     EXPECT(DeprecatedString().is_empty());
-    EXPECT(!DeprecatedString().characters());
+    EXPECT(DeprecatedString().characters() != nullptr);
 
-    EXPECT(!DeprecatedString("").is_null());
     EXPECT(DeprecatedString("").is_empty());
     EXPECT(DeprecatedString("").characters() != nullptr);
 
@@ -29,7 +27,6 @@ TEST_CASE(construct_contents)
 {
     DeprecatedString test_string = "ABCDEF";
     EXPECT(!test_string.is_empty());
-    EXPECT(!test_string.is_null());
     EXPECT_EQ(test_string.length(), 6u);
     EXPECT_EQ(test_string.length(), strlen(test_string.characters()));
     EXPECT(test_string.characters() != nullptr);
@@ -42,7 +39,7 @@ TEST_CASE(construct_contents)
 
 TEST_CASE(equal)
 {
-    EXPECT_NE(DeprecatedString::empty(), DeprecatedString {});
+    EXPECT_EQ(DeprecatedString::empty(), DeprecatedString {});
 }
 
 TEST_CASE(compare)
@@ -116,7 +113,7 @@ TEST_CASE(move_string)
     auto test_string_copy = test_string;
     auto test_string_move = move(test_string_copy);
     EXPECT_EQ(test_string, test_string_move);
-    EXPECT(test_string_copy.is_null());
+    EXPECT(test_string_copy.is_empty());
 }
 
 TEST_CASE(repeated)
@@ -253,7 +250,6 @@ TEST_CASE(builder_zero_initial_capacity)
     StringBuilder builder(0);
     builder.append(""sv);
     auto built = builder.to_deprecated_string();
-    EXPECT_EQ(built.is_null(), false);
     EXPECT_EQ(built.length(), 0u);
 }
 

--- a/Tests/AK/TestHashMap.cpp
+++ b/Tests/AK/TestHashMap.cpp
@@ -49,7 +49,7 @@ TEST_CASE(range_loop)
 
     int loop_counter = 0;
     for (auto& it : number_to_string) {
-        EXPECT_EQ(it.value.is_null(), false);
+        EXPECT_EQ(it.value.is_empty(), false);
         ++loop_counter;
     }
     EXPECT_EQ(loop_counter, 3);

--- a/Tests/AK/TestHashTable.cpp
+++ b/Tests/AK/TestHashTable.cpp
@@ -64,7 +64,7 @@ TEST_CASE(range_loop)
 
     int loop_counter = 0;
     for (auto& it : strings) {
-        EXPECT_EQ(it.is_null(), false);
+        EXPECT_EQ(it.is_empty(), false);
         ++loop_counter;
     }
     EXPECT_EQ(loop_counter, 3);

--- a/Tests/AK/TestJSON.cpp
+++ b/Tests/AK/TestJSON.cpp
@@ -60,7 +60,6 @@ TEST_CASE(json_empty_string)
 {
     auto json = JsonValue::from_string("\"\""sv).value();
     EXPECT_EQ(json.type(), JsonValue::Type::String);
-    EXPECT_EQ(json.as_string().is_null(), false);
     EXPECT_EQ(json.as_string().is_empty(), true);
 }
 
@@ -68,7 +67,6 @@ TEST_CASE(json_string)
 {
     auto json = JsonValue::from_string("\"A\""sv).value();
     EXPECT_EQ(json.type(), JsonValue::Type::String);
-    EXPECT_EQ(json.as_string().is_null(), false);
     EXPECT_EQ(json.as_string().length(), size_t { 1 });
     EXPECT_EQ(json.as_string() == "A", true);
 }
@@ -77,7 +75,6 @@ TEST_CASE(json_utf8_character)
 {
     auto json = JsonValue::from_string("\"\\u0041\""sv).value();
     EXPECT_EQ(json.type(), JsonValue::Type::String);
-    EXPECT_EQ(json.as_string().is_null(), false);
     EXPECT_EQ(json.as_string().length(), size_t { 1 });
     EXPECT_EQ(json.as_string() == "A", true);
 }
@@ -92,7 +89,6 @@ TEST_CASE(json_utf8_multibyte)
 
     auto& json = json_or_error.value();
     EXPECT_EQ(json.type(), JsonValue::Type::String);
-    EXPECT_EQ(json.as_string().is_null(), false);
     EXPECT_EQ(json.as_string().length(), size_t { 2 });
     EXPECT_EQ(json.as_string() == "š", true);
     EXPECT_EQ(json.as_string() == "\xc5\xa1", true);

--- a/Tests/AK/TestVector.cpp
+++ b/Tests/AK/TestVector.cpp
@@ -44,14 +44,12 @@ TEST_CASE(strings)
 
     int loop_counter = 0;
     for (DeprecatedString const& string : strings) {
-        EXPECT(!string.is_null());
         EXPECT(!string.is_empty());
         ++loop_counter;
     }
 
     loop_counter = 0;
     for (auto& string : (const_cast<Vector<DeprecatedString> const&>(strings))) {
-        EXPECT(!string.is_null());
         EXPECT(!string.is_empty());
         ++loop_counter;
     }

--- a/Tests/LibC/TestRealpath.cpp
+++ b/Tests/LibC/TestRealpath.cpp
@@ -21,7 +21,7 @@ static constexpr char PATH_LOREM_250[] = "This-is-an-annoyingly-long-name-that-s
 
 static constexpr size_t ITERATION_DEPTH = 17;
 
-static void check_result(char const* what, DeprecatedString const& expected, char const* actual)
+static void check_result(char const* what, StringView expected, char const* actual)
 {
     if (expected != actual)
         FAIL(DeprecatedString::formatted("Expected {} to be \"{}\" ({} characters)", what, actual, actual ? strlen(actual) : 0));

--- a/Userland/Applications/DisplaySettings/MonitorSettingsWidget.cpp
+++ b/Userland/Applications/DisplaySettings/MonitorSettingsWidget.cpp
@@ -141,7 +141,7 @@ static ErrorOr<String> display_name_from_edid(EDID::Parser const& edid)
     auto product_name = edid.display_product_name();
 
     auto build_manufacturer_product_name = [&]() -> ErrorOr<String> {
-        if (product_name.is_null() || product_name.is_empty())
+        if (product_name.is_empty())
             return TRY(String::from_deprecated_string(manufacturer_name));
         return String::formatted("{} {}", manufacturer_name, product_name);
     };

--- a/Userland/Applications/Mail/MailWidget.cpp
+++ b/Userland/Applications/Mail/MailWidget.cpp
@@ -319,7 +319,7 @@ void MailWidget::selected_mailbox(GUI::ModelIndex const& index)
         DeprecatedString date = internal_date.to_deprecated_string();
         DeprecatedString subject = envelope.subject.value_or("(No subject)");
         if (subject.contains("=?"sv) && subject.contains("?="sv)) {
-            subject = MUST(IMAP::decode_rfc2047_encoded_words(subject));
+            subject = MUST(IMAP::decode_rfc2047_encoded_words(subject)).span();
         }
 
         StringBuilder sender_builder;
@@ -491,9 +491,9 @@ void MailWidget::selected_email_to_load(GUI::ModelIndex const& index)
     } else if (selected_alternative_encoding.equals_ignoring_ascii_case("base64"sv)) {
         auto decoded_base64 = decode_base64(encoded_data);
         if (!decoded_base64.is_error())
-            decoded_data = decoded_base64.release_value();
+            decoded_data = decoded_base64.release_value().span();
     } else if (selected_alternative_encoding.equals_ignoring_ascii_case("quoted-printable"sv)) {
-        decoded_data = IMAP::decode_quoted_printable(encoded_data).release_value_but_fixme_should_propagate_errors();
+        decoded_data = IMAP::decode_quoted_printable(encoded_data).release_value_but_fixme_should_propagate_errors().span();
     } else {
         dbgln("Mail: Unimplemented decoder for encoding: {}", selected_alternative_encoding);
         GUI::MessageBox::show(window(), DeprecatedString::formatted("The e-mail encoding '{}' is currently unsupported.", selected_alternative_encoding), "Unsupported"sv, GUI::MessageBox::Type::Information);

--- a/Userland/Applications/NetworkSettings/main.cpp
+++ b/Userland/Applications/NetworkSettings/main.cpp
@@ -24,7 +24,7 @@ ErrorOr<int> serenity_main(Main::Arguments args)
     TRY(Core::System::unveil("/tmp/portal/window", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
-    DeprecatedString adapter;
+    StringView adapter;
 
     Core::ArgsParser parser;
     parser.add_positional_argument(adapter, "Adapter to display settings for", "adapter", Core::ArgsParser::Required::No);

--- a/Userland/Applications/SoundPlayer/M3UParser.cpp
+++ b/Userland/Applications/SoundPlayer/M3UParser.cpp
@@ -26,7 +26,7 @@ NonnullOwnPtr<M3UParser> M3UParser::from_file(StringView path)
 NonnullOwnPtr<M3UParser> M3UParser::from_memory(DeprecatedString const& m3u_contents, bool utf8)
 {
     auto parser = make<M3UParser>();
-    VERIFY(!m3u_contents.is_null() && !m3u_contents.is_empty() && !m3u_contents.is_whitespace());
+    VERIFY(!m3u_contents.is_empty() && !m3u_contents.is_whitespace());
     parser->m_m3u_raw_data = m3u_contents;
     parser->m_use_utf8 = utf8;
     return parser;

--- a/Userland/Applications/SoundPlayer/Player.cpp
+++ b/Userland/Applications/SoundPlayer/Player.cpp
@@ -40,9 +40,6 @@ Player::Player(Audio::ConnectionToServer& audio_client_connection)
 
 void Player::play_file_path(DeprecatedString const& path)
 {
-    if (path.is_null())
-        return;
-
     if (!FileSystem::exists(path)) {
         audio_load_error(path, "File does not exist"sv);
         return;

--- a/Userland/Applications/Spreadsheet/SpreadsheetView.cpp
+++ b/Userland/Applications/Spreadsheet/SpreadsheetView.cpp
@@ -22,7 +22,7 @@ namespace Spreadsheet {
 
 void SpreadsheetView::EditingDelegate::set_value(GUI::Variant const& value, GUI::ModelEditingDelegate::SelectionBehavior selection_behavior)
 {
-    if (value.as_string().is_null()) {
+    if (!value.is_valid()) {
         StringModelEditingDelegate::set_value("", selection_behavior);
         commit();
         return;

--- a/Userland/Applications/SystemMonitor/MemoryStatsWidget.cpp
+++ b/Userland/Applications/SystemMonitor/MemoryStatsWidget.cpp
@@ -74,7 +74,7 @@ void MemoryStatsWidget::set_graph_widget(GraphWidget& graph)
 void MemoryStatsWidget::set_graph_widget_via_name(DeprecatedString name)
 {
     m_graph_widget_name = move(name);
-    if (!m_graph_widget_name.is_null()) {
+    if (!m_graph_widget_name.is_empty()) {
         // FIXME: We assume here that the graph widget is a sibling or descendant of a sibling. This prevents more complex hierarchies.
         auto* maybe_graph = parent_widget()->find_descendant_of_type_named<GraphWidget>(m_graph_widget_name);
         if (maybe_graph) {

--- a/Userland/Applications/TextEditor/MainWidget.cpp
+++ b/Userland/Applications/TextEditor/MainWidget.cpp
@@ -279,7 +279,7 @@ MainWidget::MainWidget()
 
     m_save_as_action = GUI::CommonActions::make_save_as_action([&](auto&) {
         auto extension = m_extension;
-        if (extension.is_null() && m_editor->syntax_highlighter())
+        if (extension.is_empty() && m_editor->syntax_highlighter())
             extension = Syntax::common_language_extension(m_editor->syntax_highlighter()->language());
 
         auto response = FileSystemAccessClient::Client::the().save_file(window(), m_name, extension);

--- a/Userland/DevTools/HackStudio/Debugger/BacktraceModel.cpp
+++ b/Userland/DevTools/HackStudio/Debugger/BacktraceModel.cpp
@@ -47,7 +47,7 @@ Vector<BacktraceModel::FrameInfo> BacktraceModel::create_backtrace(Debug::Proces
         if (frame_index > 0)
             --current_instruction;
         DeprecatedString name = lib->debug_info->elf().symbolicate(current_instruction - lib->base_address);
-        if (name.is_null()) {
+        if (name.is_empty()) {
             dbgln("BacktraceModel: couldn't find containing function for address: {:p} (library={})", current_instruction, lib->name);
             name = "<missing>";
         }

--- a/Userland/DevTools/HackStudio/Debugger/Debugger.cpp
+++ b/Userland/DevTools/HackStudio/Debugger/Debugger.cpp
@@ -134,7 +134,7 @@ void Debugger::start()
 
 Debugger::CreateDebugSessionResult Debugger::create_debug_session()
 {
-    if (!m_executable_path.is_null()) {
+    if (!m_executable_path.is_empty()) {
         auto child_setup_callback = [this]() {
             if (m_child_setup_callback)
                 return m_child_setup_callback();

--- a/Userland/DevTools/HackStudio/EditorWrapper.cpp
+++ b/Userland/DevTools/HackStudio/EditorWrapper.cpp
@@ -113,7 +113,7 @@ void EditorWrapper::set_project_root(DeprecatedString const& project_root)
 void EditorWrapper::update_title()
 {
     StringBuilder title;
-    if (m_filename.is_null())
+    if (m_filename.is_empty())
         title.append(untitled_label);
     else
         title.append(m_filename);

--- a/Userland/DevTools/HackStudio/Git/GitRepo.cpp
+++ b/Userland/DevTools/HackStudio/Git/GitRepo.cpp
@@ -24,7 +24,7 @@ GitRepo::CreateResult GitRepo::try_to_create(DeprecatedString const& repository_
 RefPtr<GitRepo> GitRepo::initialize_repository(DeprecatedString const& repository_root)
 {
     auto res = command_wrapper({ "init" }, repository_root);
-    if (res.is_null())
+    if (!res.has_value())
         return {};
 
     VERIFY(git_repo_exists(repository_root));
@@ -42,25 +42,25 @@ Vector<DeprecatedString> GitRepo::unstaged_files() const
 Vector<DeprecatedString> GitRepo::staged_files() const
 {
     auto raw_result = command({ "diff", "--cached", "--name-only" });
-    if (raw_result.is_null())
+    if (!raw_result.has_value())
         return {};
-    return parse_files_list(raw_result);
+    return parse_files_list(*raw_result);
 }
 
 Vector<DeprecatedString> GitRepo::modified_files() const
 {
     auto raw_result = command({ "ls-files", "--modified", "--exclude-standard" });
-    if (raw_result.is_null())
+    if (!raw_result.has_value())
         return {};
-    return parse_files_list(raw_result);
+    return parse_files_list(*raw_result);
 }
 
 Vector<DeprecatedString> GitRepo::untracked_files() const
 {
     auto raw_result = command({ "ls-files", "--others", "--exclude-standard" });
-    if (raw_result.is_null())
+    if (!raw_result.has_value())
         return {};
-    return parse_files_list(raw_result);
+    return parse_files_list(*raw_result);
 }
 
 Vector<DeprecatedString> GitRepo::parse_files_list(DeprecatedString const& raw_result)
@@ -73,12 +73,12 @@ Vector<DeprecatedString> GitRepo::parse_files_list(DeprecatedString const& raw_r
     return files;
 }
 
-DeprecatedString GitRepo::command(Vector<DeprecatedString> const& command_parts) const
+Optional<DeprecatedString> GitRepo::command(Vector<DeprecatedString> const& command_parts) const
 {
     return command_wrapper(command_parts, m_repository_root);
 }
 
-DeprecatedString GitRepo::command_wrapper(Vector<DeprecatedString> const& command_parts, DeprecatedString const& chdir)
+Optional<DeprecatedString> GitRepo::command_wrapper(Vector<DeprecatedString> const& command_parts, DeprecatedString const& chdir)
 {
     auto const result = Core::command("git", command_parts, LexicalPath(chdir));
     if (result.is_error() || result.value().exit_code != 0)
@@ -88,27 +88,27 @@ DeprecatedString GitRepo::command_wrapper(Vector<DeprecatedString> const& comman
 
 bool GitRepo::git_is_installed()
 {
-    return !command_wrapper({ "--help" }, "/").is_null();
+    return command_wrapper({ "--help" }, "/").has_value();
 }
 
 bool GitRepo::git_repo_exists(DeprecatedString const& repo_root)
 {
-    return !command_wrapper({ "status" }, repo_root).is_null();
+    return command_wrapper({ "status" }, repo_root).has_value();
 }
 
 bool GitRepo::stage(DeprecatedString const& file)
 {
-    return !command({ "add", file }).is_null();
+    return command({ "add", file }).has_value();
 }
 
 bool GitRepo::unstage(DeprecatedString const& file)
 {
-    return !command({ "reset", "HEAD", "--", file }).is_null();
+    return command({ "reset", "HEAD", "--", file }).has_value();
 }
 
 bool GitRepo::commit(DeprecatedString const& message)
 {
-    return !command({ "commit", "-m", message }).is_null();
+    return command({ "commit", "-m", message }).has_value();
 }
 
 Optional<DeprecatedString> GitRepo::original_file_content(DeprecatedString const& file) const
@@ -124,10 +124,10 @@ Optional<DeprecatedString> GitRepo::unstaged_diff(DeprecatedString const& file) 
 bool GitRepo::is_tracked(DeprecatedString const& file) const
 {
     auto res = command({ "ls-files", file });
-    if (res.is_null())
+    if (!res.has_value())
         return false;
 
-    return !res.is_empty();
+    return !res->is_empty();
 }
 
 }

--- a/Userland/DevTools/HackStudio/Git/GitRepo.h
+++ b/Userland/DevTools/HackStudio/Git/GitRepo.h
@@ -45,7 +45,7 @@ private:
     static bool git_is_installed();
     static bool git_repo_exists(DeprecatedString const& repo_root);
 
-    static DeprecatedString command_wrapper(Vector<DeprecatedString> const& command_parts, DeprecatedString const& chdir);
+    static Optional<DeprecatedString> command_wrapper(Vector<DeprecatedString> const& command_parts, DeprecatedString const& chdir);
     static Vector<DeprecatedString> parse_files_list(DeprecatedString const&);
 
     explicit GitRepo(DeprecatedString const& repository_root)
@@ -56,7 +56,7 @@ private:
     Vector<DeprecatedString> modified_files() const;
     Vector<DeprecatedString> untracked_files() const;
 
-    DeprecatedString command(Vector<DeprecatedString> const& command_parts) const;
+    Optional<DeprecatedString> command(Vector<DeprecatedString> const& command_parts) const;
 
     DeprecatedString m_repository_root;
 };

--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -909,15 +909,15 @@ NonnullRefPtr<GUI::Action> HackStudioWidget::create_save_as_action()
 
         auto suggested_path = FileSystem::absolute_path(old_path.string()).release_value_but_fixme_should_propagate_errors();
         Optional<DeprecatedString> save_path = GUI::FilePicker::get_save_filepath(window(),
-            old_filename.is_null() ? "Untitled"sv : old_path.title(),
-            old_filename.is_null() ? "txt"sv : old_path.extension(),
+            old_filename.is_empty() ? "Untitled"sv : old_path.title(),
+            old_filename.is_empty() ? "txt"sv : old_path.extension(),
             suggested_path);
         if (!save_path.has_value()) {
             return;
         }
 
         DeprecatedString const relative_file_path = LexicalPath::relative_path(save_path.value(), m_project->root_path());
-        if (current_editor_wrapper().filename().is_null()) {
+        if (current_editor_wrapper().filename().is_empty()) {
             current_editor_wrapper().set_filename(relative_file_path);
         } else {
             for (auto& editor_wrapper : m_all_editor_wrappers) {
@@ -1729,7 +1729,7 @@ void HackStudioWidget::update_current_editor_title()
 void HackStudioWidget::on_cursor_change()
 {
     update_statusbar();
-    if (current_editor_wrapper().filename().is_null())
+    if (current_editor_wrapper().filename().is_empty())
         return;
 
     auto current_location = current_project_location();

--- a/Userland/DevTools/HackStudio/LanguageServers/FileDB.cpp
+++ b/Userland/DevTools/HackStudio/LanguageServers/FileDB.cpp
@@ -68,9 +68,9 @@ DeprecatedString FileDB::to_absolute_path(DeprecatedString const& filename) cons
     if (LexicalPath { filename }.is_absolute()) {
         return filename;
     }
-    if (m_project_root.is_null())
+    if (!m_project_root.has_value())
         return filename;
-    return LexicalPath { DeprecatedString::formatted("{}/{}", m_project_root, filename) }.string();
+    return LexicalPath { DeprecatedString::formatted("{}/{}", *m_project_root, filename) }.string();
 }
 
 ErrorOr<NonnullRefPtr<GUI::TextDocument>> FileDB::create_from_filesystem(DeprecatedString const& filename) const

--- a/Userland/DevTools/HackStudio/LanguageServers/FileDB.h
+++ b/Userland/DevTools/HackStudio/LanguageServers/FileDB.h
@@ -38,7 +38,7 @@ private:
 
 private:
     HashMap<DeprecatedString, NonnullRefPtr<GUI::TextDocument>> m_open_files;
-    DeprecatedString m_project_root;
+    Optional<DeprecatedString> m_project_root;
 };
 
 }

--- a/Userland/DevTools/HackStudio/Locator.cpp
+++ b/Userland/DevTools/HackStudio/Locator.cpp
@@ -60,7 +60,7 @@ public:
         }
         if (suggestion.is_symbol_declaration()) {
             if (index.column() == Column::Name) {
-                if (suggestion.as_symbol_declaration.value().scope.is_null())
+                if (!suggestion.as_symbol_declaration.value().scope.is_empty())
                     return suggestion.as_symbol_declaration.value().name;
                 return DeprecatedString::formatted("{}::{}", suggestion.as_symbol_declaration.value().scope, suggestion.as_symbol_declaration.value().name);
             }

--- a/Userland/Libraries/LibC/unistd.cpp
+++ b/Userland/Libraries/LibC/unistd.cpp
@@ -881,17 +881,17 @@ void sync()
     syscall(SC_sync);
 }
 
-static DeprecatedString getlogin_buffer;
+static Optional<DeprecatedString> getlogin_buffer {};
 
 char* getlogin()
 {
-    if (getlogin_buffer.is_null()) {
+    if (!getlogin_buffer.has_value()) {
         if (auto* passwd = getpwuid(getuid())) {
             getlogin_buffer = DeprecatedString(passwd->pw_name);
         }
         endpwent();
     }
-    return const_cast<char*>(getlogin_buffer.characters());
+    return const_cast<char*>(getlogin_buffer->characters());
 }
 
 // https://pubs.opengroup.org/onlinepubs/9699919799/functions/ftruncate.html

--- a/Userland/Libraries/LibCodeComprehension/Cpp/CppComprehensionEngine.cpp
+++ b/Userland/Libraries/LibCodeComprehension/Cpp/CppComprehensionEngine.cpp
@@ -210,7 +210,7 @@ Vector<CodeComprehension::AutocompleteResultEntry> CppComprehensionEngine::autoc
 {
     VERIFY(parent.object());
     auto type = type_of(document, *parent.object());
-    if (type.is_null()) {
+    if (type.is_empty()) {
         dbgln_if(CPP_LANGUAGE_SERVER_DEBUG, "Could not infer type of object");
         return {};
     }
@@ -385,7 +385,7 @@ DeprecatedString CppComprehensionEngine::document_path_from_include_path(StringV
     };
 
     auto result = document_path_for_library_include(include_path);
-    if (result.is_null())
+    if (result.is_empty())
         result = document_path_for_user_defined_include(include_path);
 
     return result;
@@ -703,7 +703,7 @@ Optional<Vector<CodeComprehension::AutocompleteResultEntry>> CppComprehensionEng
             partial_include = partial_include.substring_view(0, partial_include.length() - 1).trim_whitespace();
         }
     } else if (partial_include.starts_with('"')) {
-        include_root = filedb().project_root();
+        include_root = filedb().project_root().value_or("");
         if (partial_include.length() > 1 && partial_include.ends_with('\"')) {
             already_has_suffix = true;
             partial_include = partial_include.substring_view(0, partial_include.length() - 1).trim_whitespace();

--- a/Userland/Libraries/LibCodeComprehension/Cpp/Tests.cpp
+++ b/Userland/Libraries/LibCodeComprehension/Cpp/Tests.cpp
@@ -52,8 +52,8 @@ public:
     virtual Optional<DeprecatedString> get_or_read_from_filesystem(StringView filename) const override
     {
         DeprecatedString target_filename = filename;
-        if (!project_root().is_null() && filename.starts_with(project_root())) {
-            target_filename = LexicalPath::relative_path(filename, project_root());
+        if (project_root().has_value() && filename.starts_with(*project_root())) {
+            target_filename = LexicalPath::relative_path(filename, *project_root());
         }
         return m_map.get(target_filename);
     }

--- a/Userland/Libraries/LibCodeComprehension/FileDB.cpp
+++ b/Userland/Libraries/LibCodeComprehension/FileDB.cpp
@@ -14,9 +14,9 @@ DeprecatedString FileDB::to_absolute_path(StringView filename) const
     if (LexicalPath { filename }.is_absolute()) {
         return filename;
     }
-    if (m_project_root.is_null())
+    if (!m_project_root.has_value())
         return filename;
-    return LexicalPath { DeprecatedString::formatted("{}/{}", m_project_root, filename) }.string();
+    return LexicalPath { DeprecatedString::formatted("{}/{}", *m_project_root, filename) }.string();
 }
 
 }

--- a/Userland/Libraries/LibCodeComprehension/FileDB.h
+++ b/Userland/Libraries/LibCodeComprehension/FileDB.h
@@ -19,15 +19,21 @@ public:
     virtual ~FileDB() = default;
 
     virtual Optional<DeprecatedString> get_or_read_from_filesystem(StringView filename) const = 0;
-    void set_project_root(StringView project_root) { m_project_root = project_root; }
-    DeprecatedString const& project_root() const { return m_project_root; }
+    void set_project_root(StringView project_root)
+    {
+        if (project_root.is_null())
+            m_project_root.clear();
+        else
+            m_project_root = project_root;
+    }
+    Optional<DeprecatedString> const& project_root() const { return m_project_root; }
     DeprecatedString to_absolute_path(StringView filename) const;
 
 protected:
     FileDB() = default;
 
 private:
-    DeprecatedString m_project_root;
+    Optional<DeprecatedString> m_project_root;
 };
 
 }

--- a/Userland/Libraries/LibCore/Account.h
+++ b/Userland/Libraries/LibCore/Account.h
@@ -41,7 +41,7 @@ public:
     ErrorOr<void> login() const;
 
     DeprecatedString username() const { return m_username; }
-    DeprecatedString password_hash() const { return m_password_hash; }
+    DeprecatedString password_hash() const { return m_password_hash.value_or(DeprecatedString::empty()); }
 
     // Setters only affect in-memory copy of password.
     // You must call sync to apply changes.
@@ -56,9 +56,9 @@ public:
     void set_extra_gids(Vector<gid_t> extra_gids) { m_extra_gids = move(extra_gids); }
     void delete_password();
 
-    // A null password means that this account was missing from /etc/shadow.
+    // A nonexistent password means that this account was missing from /etc/shadow.
     // It's considered to have a password in that case, and authentication will always fail.
-    bool has_password() const { return !m_password_hash.is_empty() || m_password_hash.is_null(); }
+    bool has_password() const { return !m_password_hash.has_value() || !m_password_hash->is_empty(); }
 
     uid_t uid() const { return m_uid; }
     gid_t gid() const { return m_gid; }
@@ -82,7 +82,7 @@ private:
 
     DeprecatedString m_username;
 
-    DeprecatedString m_password_hash;
+    Optional<DeprecatedString> m_password_hash;
     uid_t m_uid { 0 };
     gid_t m_gid { 0 };
     DeprecatedString m_gecos;

--- a/Userland/Libraries/LibCore/ConfigFile.cpp
+++ b/Userland/Libraries/LibCore/ConfigFile.cpp
@@ -140,11 +140,10 @@ ErrorOr<void> ConfigFile::reparse()
     return {};
 }
 
-DeprecatedString ConfigFile::read_entry(DeprecatedString const& group, DeprecatedString const& key, DeprecatedString const& default_value) const
+Optional<DeprecatedString> ConfigFile::read_entry_optional(const AK::DeprecatedString& group, const AK::DeprecatedString& key) const
 {
-    if (!has_key(group, key)) {
-        return default_value;
-    }
+    if (!has_key(group, key))
+        return {};
     auto it = m_groups.find(group);
     auto jt = it->value.find(key);
     return jt->value;

--- a/Userland/Libraries/LibCore/ConfigFile.h
+++ b/Userland/Libraries/LibCore/ConfigFile.h
@@ -42,7 +42,11 @@ public:
 
     size_t num_groups() const { return m_groups.size(); }
 
-    DeprecatedString read_entry(DeprecatedString const& group, DeprecatedString const& key, DeprecatedString const& default_value = DeprecatedString()) const;
+    DeprecatedString read_entry(DeprecatedString const& group, DeprecatedString const& key, DeprecatedString const& default_value = {}) const
+    {
+        return read_entry_optional(group, key).value_or(default_value);
+    }
+    Optional<DeprecatedString> read_entry_optional(DeprecatedString const& group, DeprecatedString const& key) const;
     bool read_bool_entry(DeprecatedString const& group, DeprecatedString const& key, bool default_value = false) const;
 
     template<Integral T = int>
@@ -52,9 +56,9 @@ public:
             return default_value;
 
         if constexpr (IsSigned<T>)
-            return read_entry(group, key).to_int<T>().value_or(default_value);
+            return read_entry(group, key, "").to_int<T>().value_or(default_value);
         else
-            return read_entry(group, key).to_uint<T>().value_or(default_value);
+            return read_entry(group, key, "").to_uint<T>().value_or(default_value);
     }
 
     void write_entry(DeprecatedString const& group, DeprecatedString const& key, DeprecatedString const& value);

--- a/Userland/Libraries/LibCore/SystemServerTakeover.cpp
+++ b/Userland/Libraries/LibCore/SystemServerTakeover.cpp
@@ -41,7 +41,7 @@ ErrorOr<NonnullOwnPtr<Core::LocalSocket>> take_over_socket_from_system_server(De
         parse_sockets_from_system_server();
 
     int fd;
-    if (socket_path.is_null()) {
+    if (socket_path.is_empty()) {
         // We want the first (and only) socket.
         VERIFY(s_overtaken_sockets.size() == 1);
         fd = s_overtaken_sockets.begin()->value;

--- a/Userland/Libraries/LibCpp/Preprocessor.cpp
+++ b/Userland/Libraries/LibCpp/Preprocessor.cpp
@@ -102,7 +102,7 @@ void Preprocessor::handle_preprocessor_statement(StringView line)
     consume_whitespace(lexer);
     auto keyword = lexer.consume_until(' ');
     lexer.ignore();
-    if (keyword.is_empty() || keyword.is_null() || keyword.is_whitespace())
+    if (keyword.is_empty() || keyword.is_whitespace())
         return;
 
     handle_preprocessor_keyword(keyword, lexer);
@@ -243,7 +243,7 @@ void Preprocessor::handle_preprocessor_keyword(StringView keyword, GenericLexer&
 
 size_t Preprocessor::do_substitution(Vector<Token> const& tokens, size_t token_index, Definition const& defined_value)
 {
-    if (defined_value.value.is_null())
+    if (defined_value.value.is_empty())
         return token_index;
 
     Substitution sub;

--- a/Userland/Libraries/LibDNS/Packet.cpp
+++ b/Userland/Libraries/LibDNS/Packet.cpp
@@ -161,7 +161,7 @@ Optional<Packet> Packet::from_raw_packet(u8 const* raw_data, size_t raw_size)
         case RecordType::AAAA:
             // Fall through
         case RecordType::SRV:
-            data = { record.data(), record.data_length() };
+            data = ReadonlyBytes { record.data(), record.data_length() };
             break;
         default:
             // FIXME: Parse some other record types perhaps?

--- a/Userland/Libraries/LibDebug/DebugInfo.cpp
+++ b/Userland/Libraries/LibDebug/DebugInfo.cpp
@@ -95,7 +95,7 @@ ErrorOr<void> DebugInfo::prepare_lines()
     auto compute_full_path = [&](DeprecatedFlyString const& file_path) -> Optional<DeprecatedString> {
         if (file_path.view().contains("Toolchain/"sv) || file_path.view().contains("libgcc"sv))
             return {};
-        if (file_path.view().starts_with("./"sv) && !m_source_root.is_null())
+        if (file_path.view().starts_with("./"sv) && !m_source_root.is_empty())
             return LexicalPath::join(m_source_root, file_path).string();
         if (auto index_of_serenity_slash = file_path.view().find("serenity/"sv); index_of_serenity_slash.has_value()) {
             auto start_index = index_of_serenity_slash.value() + "serenity/"sv.length();

--- a/Userland/Libraries/LibELF/Image.cpp
+++ b/Userland/Libraries/LibELF/Image.cpp
@@ -455,7 +455,7 @@ DeprecatedString Image::symbolicate(FlatPtr address, u32* out_offset) const
     }
 
     auto& demangled_name = symbol->demangled_name;
-    if (demangled_name.is_null())
+    if (demangled_name.is_empty())
         demangled_name = demangle(symbol->name);
 
     if (out_offset) {

--- a/Userland/Libraries/LibFileSystemAccessClient/Client.cpp
+++ b/Userland/Libraries/LibFileSystemAccessClient/Client.cpp
@@ -98,7 +98,7 @@ Result Client::save_file(GUI::Window* parent_window, DeprecatedString const& nam
         GUI::ConnectionToWindowServer::the().remove_window_stealing_for_client(child_window_server_client_id, parent_window_id);
     });
 
-    async_prompt_save_file(id, parent_window_server_client_id, parent_window_id, name.is_null() ? "Untitled" : name, ext.is_null() ? "txt" : ext, Core::StandardPaths::home_directory(), requested_access);
+    async_prompt_save_file(id, parent_window_server_client_id, parent_window_id, name.is_empty() ? "Untitled" : name, ext.is_empty() ? "txt" : ext, Core::StandardPaths::home_directory(), requested_access);
 
     return handle_promise(id);
 }

--- a/Userland/Libraries/LibGUI/AbstractView.h
+++ b/Userland/Libraries/LibGUI/AbstractView.h
@@ -199,7 +199,7 @@ private:
 
     RefPtr<Model> m_model;
     ModelSelection m_selection;
-    DeprecatedString m_highlighted_search;
+    Optional<DeprecatedString> m_highlighted_search;
     RefPtr<Core::Timer> m_highlighted_search_timer;
     SelectionBehavior m_selection_behavior { SelectionBehavior::SelectItems };
     SelectionMode m_selection_mode { SelectionMode::SingleSelection };

--- a/Userland/Libraries/LibGUI/FilePicker.h
+++ b/Userland/Libraries/LibGUI/FilePicker.h
@@ -44,7 +44,7 @@ public:
 
     virtual ~FilePicker() override;
 
-    DeprecatedString const& selected_file() const { return m_selected_file; }
+    Optional<DeprecatedString> const& selected_file() const { return m_selected_file; }
 
 private:
     void on_file_return();
@@ -77,7 +77,7 @@ private:
 
     RefPtr<MultiView> m_view;
     NonnullRefPtr<FileSystemModel> m_model;
-    DeprecatedString m_selected_file;
+    Optional<DeprecatedString> m_selected_file;
 
     Vector<DeprecatedString> m_allowed_file_types_names;
     Optional<Vector<FileTypeFilter>> m_allowed_file_types;

--- a/Userland/Libraries/LibGUI/FileSystemModel.cpp
+++ b/Userland/Libraries/LibGUI/FileSystemModel.cpp
@@ -68,7 +68,7 @@ bool FileSystemModel::Node::fetch_data(DeprecatedString const& full_path, bool i
             perror("readlink");
         else {
             symlink_target = sym_link_target_or_error.release_value().to_deprecated_string();
-            if (symlink_target.is_null())
+            if (symlink_target.is_empty())
                 perror("readlink");
         }
     }
@@ -364,7 +364,7 @@ void FileSystemModel::update_node_on_selection(ModelIndex const& index, bool con
 
 void FileSystemModel::set_root_path(DeprecatedString root_path)
 {
-    if (root_path.is_null())
+    if (root_path.is_empty())
         m_root_path = {};
     else
         m_root_path = LexicalPath::canonicalized_path(move(root_path));
@@ -382,7 +382,7 @@ void FileSystemModel::invalidate()
 {
     m_root = adopt_own(*new Node(*this));
 
-    if (m_root_path.is_null())
+    if (m_root_path.is_empty())
         m_root->m_parent_of_root = true;
 
     m_root->reify_if_needed();

--- a/Userland/Libraries/LibGUI/ModelEditingDelegate.h
+++ b/Userland/Libraries/LibGUI/ModelEditingDelegate.h
@@ -96,7 +96,10 @@ public:
     virtual void set_value(Variant const& value, SelectionBehavior selection_behavior) override
     {
         auto& textbox = static_cast<TextBox&>(*widget());
-        textbox.set_text(value.to_deprecated_string());
+        if (value.is_valid())
+            textbox.set_text(value.to_deprecated_string());
+        else
+            textbox.clear();
         if (selection_behavior == SelectionBehavior::SelectAll)
             textbox.select_all();
     }

--- a/Userland/Libraries/LibGUI/TableView.cpp
+++ b/Userland/Libraries/LibGUI/TableView.cpp
@@ -202,10 +202,10 @@ void TableView::keydown_event(KeyEvent& event)
                 if (selection().size() > 1) {
                     selection().for_each_index([&](GUI::ModelIndex& index) {
                         begin_editing(index);
-                        m_editing_delegate->set_value(DeprecatedString {});
+                        m_editing_delegate->set_value(GUI::Variant {});
                     });
                 } else {
-                    m_editing_delegate->set_value(DeprecatedString {});
+                    m_editing_delegate->set_value(GUI::Variant {});
                 }
             } else if (is_backspace) {
                 m_editing_delegate->set_value(DeprecatedString::empty());

--- a/Userland/Libraries/LibGUI/Variant.h
+++ b/Userland/Libraries/LibGUI/Variant.h
@@ -98,7 +98,6 @@ public:
         return visit(
             [](Empty) { return false; },
             [](Detail::Boolean v) { return v.value; },
-            [](DeprecatedString const& v) { return !v.is_null(); },
             [](Integral auto v) { return v != 0; },
             [](Gfx::IntPoint const& v) { return !v.is_zero(); },
             [](OneOf<Gfx::IntRect, Gfx::IntSize> auto const& v) { return !v.is_empty(); },

--- a/Userland/Libraries/LibGemini/Line.cpp
+++ b/Userland/Libraries/LibGemini/Line.cpp
@@ -69,7 +69,7 @@ Link::Link(DeprecatedString text, Document const& document)
         m_name = url_string.substring_view(offset, url_string.length() - offset);
     }
     m_url = document.url().complete_url(url);
-    if (m_name.is_null())
+    if (m_name.is_empty())
         m_name = m_url.to_deprecated_string();
 }
 

--- a/Userland/Libraries/LibJS/Runtime/JSONObject.h
+++ b/Userland/Libraries/LibJS/Runtime/JSONObject.h
@@ -19,7 +19,7 @@ public:
 
     // The base implementation of stringify is exposed because it is used by
     // test-js to communicate between the JS tests and the C++ test runner.
-    static ThrowCompletionOr<DeprecatedString> stringify_impl(VM&, Value value, Value replacer, Value space);
+    static ThrowCompletionOr<Optional<DeprecatedString>> stringify_impl(VM&, Value value, Value replacer, Value space);
 
     static Value parse_json_value(VM&, JsonValue const&);
 
@@ -35,7 +35,7 @@ private:
     };
 
     // Stringify helpers
-    static ThrowCompletionOr<DeprecatedString> serialize_json_property(VM&, StringifyState&, PropertyKey const& key, Object* holder);
+    static ThrowCompletionOr<Optional<DeprecatedString>> serialize_json_property(VM&, StringifyState&, PropertyKey const& key, Object* holder);
     static ThrowCompletionOr<DeprecatedString> serialize_json_object(VM&, StringifyState&, Object&);
     static ThrowCompletionOr<DeprecatedString> serialize_json_array(VM&, StringifyState&, Object&);
     static DeprecatedString quote_json_string(DeprecatedString);

--- a/Userland/Libraries/LibJS/Runtime/PrimitiveString.cpp
+++ b/Userland/Libraries/LibJS/Runtime/PrimitiveString.cpp
@@ -221,7 +221,7 @@ NonnullGCPtr<PrimitiveString> PrimitiveString::create(VM& vm, DeprecatedString s
 
 NonnullGCPtr<PrimitiveString> PrimitiveString::create(VM& vm, DeprecatedFlyString const& string)
 {
-    return create(vm, string.impl());
+    return create(vm, *string.impl());
 }
 
 NonnullGCPtr<PrimitiveString> PrimitiveString::create(VM& vm, PrimitiveString& lhs, PrimitiveString& rhs)

--- a/Userland/Libraries/LibJS/Runtime/VM.cpp
+++ b/Userland/Libraries/LibJS/Runtime/VM.cpp
@@ -910,7 +910,7 @@ ThrowCompletionOr<NonnullGCPtr<Module>> VM::resolve_imported_module(ScriptOrModu
     VERIFY(module_request.assertions.is_empty() || (module_request.assertions.size() == 1 && module_request.assertions.first().key == "type"));
     auto module_type = module_request.assertions.is_empty() ? DeprecatedString {} : module_request.assertions.first().value;
 
-    dbgln_if(JS_MODULE_DEBUG, "[JS MODULE] module at {} has type {} [is_null={}]", module_request.module_specifier, module_type, module_type.is_null());
+    dbgln_if(JS_MODULE_DEBUG, "[JS MODULE] module at {} has type {}", module_request.module_specifier, module_type);
 
     StringView base_filename = referencing_script_or_module.visit(
         [&](Empty) {

--- a/Userland/Libraries/LibJS/Token.cpp
+++ b/Userland/Libraries/LibJS/Token.cpp
@@ -174,7 +174,7 @@ DeprecatedString Token::string_value(StringValueStatus& status) const
 
         // In non-strict mode LegacyOctalEscapeSequence is allowed in strings:
         // https://tc39.es/ecma262/#sec-additional-syntax-string-literals
-        DeprecatedString octal_str;
+        Optional<DeprecatedString> octal_str;
 
         auto is_octal_digit = [](char ch) { return ch >= '0' && ch <= '7'; };
         auto is_zero_to_three = [](char ch) { return ch >= '0' && ch <= '3'; };
@@ -193,9 +193,9 @@ DeprecatedString Token::string_value(StringValueStatus& status) const
         else if (is_zero_to_three(lexer.peek()) && is_octal_digit(lexer.peek(1)) && is_octal_digit(lexer.peek(2)))
             octal_str = lexer.consume(3);
 
-        if (!octal_str.is_null()) {
+        if (octal_str.has_value()) {
             status = StringValueStatus::LegacyOctalEscapeSequence;
-            auto code_point = strtoul(octal_str.characters(), nullptr, 8);
+            auto code_point = strtoul(octal_str->characters(), nullptr, 8);
             VERIFY(code_point <= 255);
             builder.append_code_point(code_point);
             continue;

--- a/Userland/Libraries/LibPDF/Parser.cpp
+++ b/Userland/Libraries/LibPDF/Parser.cpp
@@ -256,8 +256,6 @@ NonnullRefPtr<StringObject> Parser::parse_string()
         is_binary_string = true;
     }
 
-    VERIFY(!string.is_null());
-
     auto string_object = make_object<StringObject>(string, is_binary_string);
 
     if (m_document->security_handler() && m_enable_encryption)

--- a/Userland/Libraries/LibSQL/AST/AST.h
+++ b/Userland/Libraries/LibSQL/AST/AST.h
@@ -186,8 +186,8 @@ public:
 
     ResultType type() const { return m_type; }
 
-    bool select_from_table() const { return !m_table_name.is_null(); }
-    DeprecatedString const& table_name() const { return m_table_name; }
+    bool select_from_table() const { return m_table_name.has_value(); }
+    Optional<DeprecatedString> const& table_name() const { return m_table_name; }
 
     bool select_from_expression() const { return !m_expression.is_null(); }
     RefPtr<Expression> const& expression() const { return m_expression; }
@@ -196,7 +196,7 @@ public:
 private:
     ResultType m_type { ResultType::All };
 
-    DeprecatedString m_table_name {};
+    Optional<DeprecatedString> m_table_name {};
 
     RefPtr<Expression> m_expression {};
     DeprecatedString m_column_alias {};

--- a/Userland/Libraries/LibSQL/AST/Parser.h
+++ b/Userland/Libraries/LibSQL/AST/Parser.h
@@ -74,7 +74,7 @@ private:
     bool match_secondary_expression() const;
     RefPtr<Expression> parse_literal_value_expression();
     RefPtr<Expression> parse_bind_parameter_expression();
-    RefPtr<Expression> parse_column_name_expression(DeprecatedString with_parsed_identifier = {}, bool with_parsed_period = false);
+    RefPtr<Expression> parse_column_name_expression(Optional<DeprecatedString> with_parsed_identifier = {}, bool with_parsed_period = false);
     RefPtr<Expression> parse_unary_operator_expression();
     RefPtr<Expression> parse_binary_operator_expression(NonnullRefPtr<Expression> lhs);
     RefPtr<Expression> parse_chained_expression(bool surrounded_by_parentheses = true);

--- a/Userland/Libraries/LibTLS/Handshake.cpp
+++ b/Userland/Libraries/LibTLS/Handshake.cpp
@@ -44,7 +44,7 @@ ByteBuffer TLSv12::build_hello()
     size_t alpn_negotiated_length = 0;
 
     // ALPN
-    if (!m_context.negotiated_alpn.is_null()) {
+    if (!m_context.negotiated_alpn.is_empty()) {
         alpn_negotiated_length = m_context.negotiated_alpn.length();
         alpn_length = alpn_negotiated_length + 1;
         extension_length += alpn_length + 6;
@@ -69,7 +69,7 @@ ByteBuffer TLSv12::build_hello()
 
     // set SNI if we have one, and the user hasn't explicitly asked us to omit it.
     auto sni_length = 0;
-    if (!m_context.extensions.SNI.is_null() && m_context.options.use_sni)
+    if (!m_context.extensions.SNI.is_empty() && m_context.options.use_sni)
         sni_length = m_context.extensions.SNI.length();
 
     auto elliptic_curves_length = 2 * m_context.options.elliptic_curves.size();

--- a/Userland/Libraries/LibTest/JavaScriptTestRunner.h
+++ b/Userland/Libraries/LibTest/JavaScriptTestRunner.h
@@ -247,9 +247,10 @@ inline AK::Result<JS::NonnullGCPtr<JS::SourceTextModule>, ParserError> parse_mod
 inline ErrorOr<JsonValue> get_test_results(JS::Realm& realm)
 {
     auto results = MUST(realm.global_object().get("__TestResults__"));
-    auto json_string = MUST(JS::JSONObject::stringify_impl(*g_vm, results, JS::js_undefined(), JS::js_undefined()));
-
-    return JsonValue::from_string(json_string);
+    auto maybe_json_string = MUST(JS::JSONObject::stringify_impl(*g_vm, results, JS::js_undefined(), JS::js_undefined()));
+    if (maybe_json_string.has_value())
+        return JsonValue::from_string(*maybe_json_string);
+    return JsonValue();
 }
 
 inline void TestRunner::do_run_single_test(DeprecatedString const& test_path, size_t, size_t)

--- a/Userland/Libraries/LibVT/Attribute.h
+++ b/Userland/Libraries/LibVT/Attribute.h
@@ -38,7 +38,7 @@ struct Attribute {
 
 #ifndef KERNEL
     DeprecatedString href;
-    DeprecatedString href_id;
+    Optional<DeprecatedString> href_id;
 #endif
 
     enum class Flags : u8 {

--- a/Userland/Libraries/LibVT/TerminalWidget.cpp
+++ b/Userland/Libraries/LibVT/TerminalWidget.cpp
@@ -292,7 +292,7 @@ void TerminalWidget::paint_event(GUI::PaintEvent& event)
 
     // Pass: Compute the rect(s) of the currently hovered link, if any.
     Vector<Gfx::IntRect> hovered_href_rects;
-    if (!m_hovered_href_id.is_null()) {
+    if (m_hovered_href_id.has_value()) {
         for (u16 visual_row = 0; visual_row < m_terminal.rows(); ++visual_row) {
             auto& line = m_terminal.line(first_row_from_history + visual_row);
             for (size_t column = 0; column < line.length(); ++column) {
@@ -415,7 +415,7 @@ void TerminalWidget::paint_event(GUI::PaintEvent& event)
 
             auto character_rect = glyph_rect(visual_row, column);
 
-            if (!m_hovered_href_id.is_null() && attribute.href_id == m_hovered_href_id) {
+            if (m_hovered_href_id.has_value() && attribute.href_id == m_hovered_href_id) {
                 text_color = palette().base_text();
             }
 
@@ -754,7 +754,7 @@ void TerminalWidget::doubleclick_event(GUI::MouseEvent& event)
 {
     if (event.button() == GUI::MouseButton::Primary) {
         auto attribute = m_terminal.attribute_at(buffer_position_at(event.position()));
-        if (!attribute.href_id.is_null()) {
+        if (attribute.href_id.has_value()) {
             dbgln("Open hyperlinked URL: '{}'", attribute.href);
             Desktop::Launcher::open(attribute.href);
             return;
@@ -806,7 +806,7 @@ void TerminalWidget::copy()
 void TerminalWidget::mouseup_event(GUI::MouseEvent& event)
 {
     if (event.button() == GUI::MouseButton::Primary) {
-        if (!m_active_href_id.is_null()) {
+        if (m_active_href_id.has_value()) {
             m_active_href = {};
             m_active_href_id = {};
             update();
@@ -862,7 +862,7 @@ void TerminalWidget::mousemove_event(GUI::MouseEvent& event)
     auto attribute = m_terminal.attribute_at(position);
 
     if (attribute.href_id != m_hovered_href_id) {
-        if (!attribute.href_id.is_null()) {
+        if (attribute.href_id.has_value()) {
             m_hovered_href_id = attribute.href_id;
             m_hovered_href = attribute.href;
 
@@ -902,7 +902,7 @@ void TerminalWidget::mousemove_event(GUI::MouseEvent& event)
     if (!(event.buttons() & GUI::MouseButton::Primary))
         return;
 
-    if (!m_active_href_id.is_null()) {
+    if (m_active_href_id.has_value()) {
         auto diff = event.position() - m_left_mousedown_position;
         auto distance_travelled_squared = diff.x() * diff.x() + diff.y() * diff.y();
         constexpr int drag_distance_threshold = 5;
@@ -1111,7 +1111,7 @@ void TerminalWidget::set_cursor_shape(CursorShape shape)
 
 void TerminalWidget::context_menu_event(GUI::ContextMenuEvent& event)
 {
-    if (m_hovered_href_id.is_null()) {
+    if (!m_hovered_href_id.has_value()) {
         m_context_menu->popup(event.screen_position());
     } else {
         m_context_menu_href = m_hovered_href;

--- a/Userland/Libraries/LibVT/TerminalWidget.h
+++ b/Userland/Libraries/LibVT/TerminalWidget.h
@@ -168,10 +168,10 @@ private:
     VT::Range m_selection;
 
     DeprecatedString m_hovered_href;
-    DeprecatedString m_hovered_href_id;
+    Optional<DeprecatedString> m_hovered_href_id;
 
     DeprecatedString m_active_href;
-    DeprecatedString m_active_href_id;
+    Optional<DeprecatedString> m_active_href_id;
 
     // Snapshot of m_hovered_href when opening a context menu for a hyperlink.
     DeprecatedString m_context_menu_href;

--- a/Userland/Libraries/LibWeb/CSS/CSSNamespaceRule.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSNamespaceRule.cpp
@@ -40,7 +40,7 @@ DeprecatedString CSSNamespaceRule::serialized() const
     builder.append("@namespace "sv);
 
     // followed by the serialization as an identifier of the prefix attribute (if any),
-    if (!m_prefix.is_empty() && !m_prefix.is_null()) {
+    if (!m_prefix.is_empty()) {
         serialize_an_identifier(builder, m_prefix);
         // followed by a single SPACE (U+0020) if there is a prefix,
         builder.append(" "sv);

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleRule.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleRule.cpp
@@ -53,23 +53,23 @@ DeprecatedString CSSStyleRule::serialized() const
     builder.append(" {"sv);
 
     // 2. Let decls be the result of performing serialize a CSS declaration block on the rule’s associated declarations, or null if there are no such declarations.
-    auto decls = declaration().serialized();
+    auto decls = declaration().length() > 0 ? declaration().serialized() : Optional<DeprecatedString>();
 
     // FIXME: 3. Let rules be the result of performing serialize a CSS rule on each rule in the rule’s cssRules list, or null if there are no such rules.
-    DeprecatedString rules;
+    Optional<DeprecatedString> rules;
 
     // 4. If decls and rules are both null, append " }" to s (i.e. a single SPACE (U+0020) followed by RIGHT CURLY BRACKET (U+007D)) and return s.
-    if (decls.is_null() && rules.is_null()) {
+    if (!decls.has_value() && !rules.has_value()) {
         builder.append(" }"sv);
         return builder.to_deprecated_string();
     }
 
     // 5. If rules is null:
-    if (rules.is_null()) {
+    if (!rules.has_value()) {
         //    1. Append a single SPACE (U+0020) to s
         builder.append(' ');
         //    2. Append decls to s
-        builder.append(decls);
+        builder.append(*decls);
         //    3. Append " }" to s (i.e. a single SPACE (U+0020) followed by RIGHT CURLY BRACKET (U+007D)).
         builder.append(" }"sv);
         //    4. Return s.

--- a/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
+++ b/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
@@ -36,9 +36,9 @@ static inline bool matches_lang_pseudo_class(DOM::Element const& element, Vector
 {
     FlyString element_language;
     for (auto const* e = &element; e; e = e->parent_element()) {
-        auto lang = e->deprecated_attribute(HTML::AttributeNames::lang);
-        if (!lang.is_null()) {
-            element_language = FlyString::from_deprecated_fly_string(lang).release_value_but_fixme_should_propagate_errors();
+        auto lang = e->attribute(HTML::AttributeNames::lang);
+        if (lang.has_value()) {
+            element_language = lang.release_value();
             break;
         }
     }

--- a/Userland/Libraries/LibWeb/DOM/Attr.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Attr.cpp
@@ -92,7 +92,7 @@ void Attr::change_attribute(String value)
 }
 
 // https://dom.spec.whatwg.org/#handle-attribute-changes
-void Attr::handle_attribute_changes(Element& element, DeprecatedString const& old_value, DeprecatedString const& new_value)
+void Attr::handle_attribute_changes(Element& element, Optional<DeprecatedString> old_value, Optional<DeprecatedString> new_value)
 {
     DeprecatedString deprecated_namespace_uri;
     if (namespace_uri().has_value())
@@ -107,8 +107,8 @@ void Attr::handle_attribute_changes(Element& element, DeprecatedString const& ol
 
         JS::MarkedVector<JS::Value> arguments { vm.heap() };
         arguments.append(JS::PrimitiveString::create(vm, local_name()));
-        arguments.append(old_value.is_null() ? JS::js_null() : JS::PrimitiveString::create(vm, old_value));
-        arguments.append(new_value.is_null() ? JS::js_null() : JS::PrimitiveString::create(vm, new_value));
+        arguments.append(!old_value.has_value() ? JS::js_null() : JS::PrimitiveString::create(vm, old_value.release_value()));
+        arguments.append(!new_value.has_value() ? JS::js_null() : JS::PrimitiveString::create(vm, new_value.release_value()));
         arguments.append(!namespace_uri().has_value() ? JS::js_null() : JS::PrimitiveString::create(vm, namespace_uri().value()));
 
         element.enqueue_a_custom_element_callback_reaction(HTML::CustomElementReactionNames::attributeChangedCallback, move(arguments));

--- a/Userland/Libraries/LibWeb/DOM/Attr.h
+++ b/Userland/Libraries/LibWeb/DOM/Attr.h
@@ -41,7 +41,7 @@ public:
     // Always returns true: https://dom.spec.whatwg.org/#dom-attr-specified
     constexpr bool specified() const { return true; }
 
-    void handle_attribute_changes(Element&, DeprecatedString const& old_value, DeprecatedString const& new_value);
+    void handle_attribute_changes(Element&, Optional<DeprecatedString> old_value, Optional<DeprecatedString> new_value);
 
 private:
     Attr(Document&, QualifiedName, String value, Element*);

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -153,11 +153,11 @@ public:
     virtual void apply_presentational_hints(CSS::StyleProperties&) const { }
 
     // https://dom.spec.whatwg.org/#concept-element-attributes-change-ext
-    using AttributeChangeSteps = Function<void(FlyString const& /*local_name*/, DeprecatedString const& /*old_value*/, DeprecatedString const& /*value*/, DeprecatedFlyString const& /*namespace_*/)>;
+    using AttributeChangeSteps = Function<void(FlyString const& /*local_name*/, Optional<DeprecatedString> const& /*old_value*/, Optional<DeprecatedString> const& /*value*/, DeprecatedFlyString const& /*namespace_*/)>;
 
     void add_attribute_change_steps(AttributeChangeSteps steps);
-    void run_attribute_change_steps(FlyString const& local_name, DeprecatedString const& old_value, DeprecatedString const& value, DeprecatedFlyString const& namespace_);
-    virtual void attribute_changed(FlyString const& name, DeprecatedString const& value);
+    void run_attribute_change_steps(FlyString const& local_name, Optional<DeprecatedString> const& old_value, Optional<DeprecatedString> const& value, DeprecatedFlyString const& namespace_);
+    virtual void attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value);
 
     struct [[nodiscard]] RequiredInvalidationAfterStyleChange {
         bool repaint { false };

--- a/Userland/Libraries/LibWeb/DOM/Node.h
+++ b/Userland/Libraries/LibWeb/DOM/Node.h
@@ -259,7 +259,7 @@ public:
 
     void add_registered_observer(RegisteredObserver& registered_observer) { m_registered_observer_list.append(registered_observer); }
 
-    void queue_mutation_record(FlyString const& type, DeprecatedString attribute_name, DeprecatedString attribute_namespace, DeprecatedString old_value, Vector<JS::Handle<Node>> added_nodes, Vector<JS::Handle<Node>> removed_nodes, Node* previous_sibling, Node* next_sibling) const;
+    void queue_mutation_record(FlyString const& type, Optional<DeprecatedString> attribute_name, Optional<DeprecatedString> attribute_namespace, Optional<DeprecatedString> old_value, Vector<JS::Handle<Node>> added_nodes, Vector<JS::Handle<Node>> removed_nodes, Node* previous_sibling, Node* next_sibling) const;
 
     // https://dom.spec.whatwg.org/#concept-shadow-including-inclusive-descendant
     template<typename Callback>

--- a/Userland/Libraries/LibWeb/DOM/StyleElementUtils.h
+++ b/Userland/Libraries/LibWeb/DOM/StyleElementUtils.h
@@ -20,7 +20,7 @@ public:
 
 private:
     void remove_a_css_style_sheet(DOM::Document& document, CSS::CSSStyleSheet& sheet);
-    void create_a_css_style_sheet(DOM::Document& document, DeprecatedString type, DOM::Element* owner_node, DeprecatedString media, DeprecatedString title, bool alternate, bool origin_clean, DeprecatedString location, CSS::CSSStyleSheet* parent_style_sheet, CSS::CSSRule* owner_rule, CSS::CSSStyleSheet& sheet);
+    void create_a_css_style_sheet(DOM::Document& document, DeprecatedString type, DOM::Element* owner_node, DeprecatedString media, DeprecatedString title, bool alternate, bool origin_clean, Optional<DeprecatedString> location, CSS::CSSStyleSheet* parent_style_sheet, CSS::CSSRule* owner_rule, CSS::CSSStyleSheet& sheet);
     void add_a_css_style_sheet(DOM::Document& document, CSS::CSSStyleSheet& sheet);
 
     // https://www.w3.org/TR/cssom/#associated-css-style-sheet

--- a/Userland/Libraries/LibWeb/Dump.cpp
+++ b/Userland/Libraries/LibWeb/Dump.cpp
@@ -821,7 +821,7 @@ ErrorOr<void> dump_namespace_rule(StringBuilder& builder, CSS::CSSNamespaceRule 
 {
     indent(builder, indent_levels);
     TRY(builder.try_appendff("  Namespace: {}\n", namespace_.namespace_uri()));
-    if (!namespace_.prefix().is_null() && !namespace_.prefix().is_empty())
+    if (!namespace_.prefix().is_empty())
         TRY(builder.try_appendff("  Prefix: {}\n", namespace_.prefix()));
 
     return {};

--- a/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.cpp
@@ -27,7 +27,7 @@ void HTMLAnchorElement::initialize(JS::Realm& realm)
     set_prototype(&Bindings::ensure_web_prototype<Bindings::HTMLAnchorElementPrototype>(realm, "HTMLAnchorElement"));
 }
 
-void HTMLAnchorElement::attribute_changed(FlyString const& name, DeprecatedString const& value)
+void HTMLAnchorElement::attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value)
 {
     HTMLElement::attribute_changed(name, value);
     if (name == HTML::AttributeNames::href) {
@@ -35,9 +35,9 @@ void HTMLAnchorElement::attribute_changed(FlyString const& name, DeprecatedStrin
     }
 }
 
-DeprecatedString HTMLAnchorElement::hyperlink_element_utils_href() const
+Optional<String> HTMLAnchorElement::hyperlink_element_utils_href() const
 {
-    return deprecated_attribute(HTML::AttributeNames::href);
+    return attribute(HTML::AttributeNames::href);
 }
 
 WebIDL::ExceptionOr<void> HTMLAnchorElement::set_hyperlink_element_utils_href(String href)
@@ -98,7 +98,7 @@ i32 HTMLAnchorElement::default_tab_index_value() const
 Optional<ARIA::Role> HTMLAnchorElement::default_role() const
 {
     // https://www.w3.org/TR/html-aria/#el-a-no-href
-    if (!href().is_null())
+    if (!href().is_empty())
         return ARIA::Role::link;
     // https://www.w3.org/TR/html-aria/#el-a
     return ARIA::Role::generic;

--- a/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.h
@@ -43,12 +43,12 @@ private:
     void run_activation_behavior(Web::DOM::Event const&);
 
     // ^DOM::Element
-    virtual void attribute_changed(FlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value) override;
     virtual i32 default_tab_index_value() const override;
 
     // ^HTML::HTMLHyperlinkElementUtils
     virtual DOM::Document& hyperlink_element_utils_document() override { return document(); }
-    virtual DeprecatedString hyperlink_element_utils_href() const override;
+    virtual Optional<String> hyperlink_element_utils_href() const override;
     virtual WebIDL::ExceptionOr<void> set_hyperlink_element_utils_href(String) override;
     virtual bool hyperlink_element_utils_is_html_anchor_element() const final { return true; }
     virtual bool hyperlink_element_utils_is_connected() const final { return is_connected(); }

--- a/Userland/Libraries/LibWeb/HTML/HTMLAreaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLAreaElement.cpp
@@ -23,7 +23,7 @@ void HTMLAreaElement::initialize(JS::Realm& realm)
     set_prototype(&Bindings::ensure_web_prototype<Bindings::HTMLAreaElementPrototype>(realm, "HTMLAreaElement"));
 }
 
-void HTMLAreaElement::attribute_changed(FlyString const& name, DeprecatedString const& value)
+void HTMLAreaElement::attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value)
 {
     HTMLElement::attribute_changed(name, value);
     if (name == HTML::AttributeNames::href) {
@@ -31,9 +31,9 @@ void HTMLAreaElement::attribute_changed(FlyString const& name, DeprecatedString 
     }
 }
 
-DeprecatedString HTMLAreaElement::hyperlink_element_utils_href() const
+Optional<String> HTMLAreaElement::hyperlink_element_utils_href() const
 {
-    return deprecated_attribute(HTML::AttributeNames::href);
+    return attribute(HTML::AttributeNames::href);
 }
 
 WebIDL::ExceptionOr<void> HTMLAreaElement::set_hyperlink_element_utils_href(String href)
@@ -51,7 +51,7 @@ i32 HTMLAreaElement::default_tab_index_value() const
 Optional<ARIA::Role> HTMLAreaElement::default_role() const
 {
     // https://www.w3.org/TR/html-aria/#el-area-no-href
-    if (!href().is_null())
+    if (!href().is_empty())
         return ARIA::Role::link;
     // https://www.w3.org/TR/html-aria/#el-area
     return ARIA::Role::generic;

--- a/Userland/Libraries/LibWeb/HTML/HTMLAreaElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLAreaElement.h
@@ -26,12 +26,12 @@ private:
     virtual void initialize(JS::Realm&) override;
 
     // ^DOM::Element
-    virtual void attribute_changed(FlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value) override;
     virtual i32 default_tab_index_value() const override;
 
     // ^HTML::HTMLHyperlinkElementUtils
     virtual DOM::Document& hyperlink_element_utils_document() override { return document(); }
-    virtual DeprecatedString hyperlink_element_utils_href() const override;
+    virtual Optional<String> hyperlink_element_utils_href() const override;
     virtual WebIDL::ExceptionOr<void> set_hyperlink_element_utils_href(String) override;
     virtual bool hyperlink_element_utils_is_html_anchor_element() const override { return false; }
     virtual bool hyperlink_element_utils_is_connected() const override { return is_connected(); }

--- a/Userland/Libraries/LibWeb/HTML/HTMLBaseElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLBaseElement.cpp
@@ -43,7 +43,7 @@ void HTMLBaseElement::removed_from(Node* parent)
     document().update_base_element({});
 }
 
-void HTMLBaseElement::attribute_changed(FlyString const& name, DeprecatedString const& value)
+void HTMLBaseElement::attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value)
 {
     HTMLElement::attribute_changed(name, value);
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLBaseElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLBaseElement.h
@@ -23,7 +23,7 @@ public:
 
     virtual void inserted() override;
     virtual void removed_from(Node*) override;
-    virtual void attribute_changed(FlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value) override;
 
 private:
     HTMLBaseElement(DOM::Document&, DOM::QualifiedName);

--- a/Userland/Libraries/LibWeb/HTML/HTMLBodyElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLBodyElement.cpp
@@ -55,26 +55,26 @@ void HTMLBodyElement::apply_presentational_hints(CSS::StyleProperties& style) co
     });
 }
 
-void HTMLBodyElement::attribute_changed(FlyString const& name, DeprecatedString const& value)
+void HTMLBodyElement::attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value)
 {
     HTMLElement::attribute_changed(name, value);
     if (name.equals_ignoring_ascii_case("link"sv)) {
         // https://html.spec.whatwg.org/multipage/rendering.html#the-page:rules-for-parsing-a-legacy-colour-value-3
-        auto color = parse_legacy_color_value(value);
+        auto color = parse_legacy_color_value(value.value_or(""));
         if (color.has_value())
             document().set_link_color(color.value());
     } else if (name.equals_ignoring_ascii_case("alink"sv)) {
         // https://html.spec.whatwg.org/multipage/rendering.html#the-page:rules-for-parsing-a-legacy-colour-value-5
-        auto color = parse_legacy_color_value(value);
+        auto color = parse_legacy_color_value(value.value_or(""));
         if (color.has_value())
             document().set_active_link_color(color.value());
     } else if (name.equals_ignoring_ascii_case("vlink"sv)) {
         // https://html.spec.whatwg.org/multipage/rendering.html#the-page:rules-for-parsing-a-legacy-colour-value-4
-        auto color = parse_legacy_color_value(value);
+        auto color = parse_legacy_color_value(value.value_or(""));
         if (color.has_value())
             document().set_visited_link_color(color.value());
     } else if (name.equals_ignoring_ascii_case("background"sv)) {
-        m_background_style_value = CSS::ImageStyleValue::create(document().parse_url(value));
+        m_background_style_value = CSS::ImageStyleValue::create(document().parse_url(value.value_or("")));
         m_background_style_value->on_animate = [this] {
             if (layout_node()) {
                 layout_node()->set_needs_display();
@@ -83,9 +83,9 @@ void HTMLBodyElement::attribute_changed(FlyString const& name, DeprecatedString 
     }
 
 #undef __ENUMERATE
-#define __ENUMERATE(attribute_name, event_name)                                                                     \
-    if (name == HTML::AttributeNames::attribute_name) {                                                             \
-        element_event_handler_attribute_changed(event_name, String::from_deprecated_string(value).release_value()); \
+#define __ENUMERATE(attribute_name, event_name)                                                                                          \
+    if (name == HTML::AttributeNames::attribute_name) {                                                                                  \
+        element_event_handler_attribute_changed(event_name, value.map([](auto& v) { return MUST(String::from_deprecated_string(v)); })); \
     }
     ENUMERATE_WINDOW_EVENT_HANDLERS(__ENUMERATE)
 #undef __ENUMERATE

--- a/Userland/Libraries/LibWeb/HTML/HTMLBodyElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLBodyElement.h
@@ -20,7 +20,7 @@ class HTMLBodyElement final
 public:
     virtual ~HTMLBodyElement() override;
 
-    virtual void attribute_changed(FlyString const&, DeprecatedString const&) override;
+    virtual void attribute_changed(FlyString const&, Optional<DeprecatedString> const&) override;
     virtual void apply_presentational_hints(CSS::StyleProperties&) const override;
 
     // https://www.w3.org/TR/html-aria/#el-body

--- a/Userland/Libraries/LibWeb/HTML/HTMLDetailsElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLDetailsElement.cpp
@@ -41,14 +41,14 @@ void HTMLDetailsElement::initialize(JS::Realm& realm)
     create_shadow_tree(realm).release_value_but_fixme_should_propagate_errors();
 }
 
-void HTMLDetailsElement::attribute_changed(FlyString const& name, DeprecatedString const& value)
+void HTMLDetailsElement::attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value)
 {
     Base::attribute_changed(name, value);
 
     // https://html.spec.whatwg.org/multipage/interactive-elements.html#details-notification-task-steps
     if (name == HTML::AttributeNames::open) {
         // 1. If the open attribute is added, queue a details toggle event task given the details element, "closed", and "open".
-        if (!value.is_null()) {
+        if (value.has_value()) {
             queue_a_details_toggle_event_task("closed"_string, "open"_string);
         }
         // 2. Otherwise, queue a details toggle event task given the details element, "open", and "closed".

--- a/Userland/Libraries/LibWeb/HTML/HTMLDetailsElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLDetailsElement.h
@@ -31,7 +31,7 @@ private:
     virtual void visit_edges(Cell::Visitor&) override;
 
     virtual void children_changed() override;
-    virtual void attribute_changed(FlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value) override;
 
     void queue_a_details_toggle_event_task(String old_state, String new_state);
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLElement.cpp
@@ -224,18 +224,18 @@ bool HTMLElement::cannot_navigate() const
     return !is<HTML::HTMLAnchorElement>(this) && !is_connected();
 }
 
-void HTMLElement::attribute_changed(FlyString const& name, DeprecatedString const& value)
+void HTMLElement::attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value)
 {
     Element::attribute_changed(name, value);
 
     if (name == HTML::AttributeNames::contenteditable) {
-        if (value.is_null()) {
+        if (!value.has_value()) {
             m_content_editable_state = ContentEditableState::Inherit;
         } else {
-            if (value.is_empty() || value.equals_ignoring_ascii_case("true"sv)) {
+            if (value->is_empty() || value->equals_ignoring_ascii_case("true"sv)) {
                 // "true", an empty string or a missing value map to the "true" state.
                 m_content_editable_state = ContentEditableState::True;
-            } else if (value.equals_ignoring_ascii_case("false"sv)) {
+            } else if (value->equals_ignoring_ascii_case("false"sv)) {
                 // "false" maps to the "false" state.
                 m_content_editable_state = ContentEditableState::False;
             } else {
@@ -248,9 +248,9 @@ void HTMLElement::attribute_changed(FlyString const& name, DeprecatedString cons
     // 1. If namespace is not null, or localName is not the name of an event handler content attribute on element, then return.
     // FIXME: Add the namespace part once we support attribute namespaces.
 #undef __ENUMERATE
-#define __ENUMERATE(attribute_name, event_name)                                                                     \
-    if (name == HTML::AttributeNames::attribute_name) {                                                             \
-        element_event_handler_attribute_changed(event_name, String::from_deprecated_string(value).release_value()); \
+#define __ENUMERATE(attribute_name, event_name)                                                                                          \
+    if (name == HTML::AttributeNames::attribute_name) {                                                                                  \
+        element_event_handler_attribute_changed(event_name, value.map([](auto& v) { return MUST(String::from_deprecated_string(v)); })); \
     }
     ENUMERATE_GLOBAL_EVENT_HANDLERS(__ENUMERATE)
 #undef __ENUMERATE

--- a/Userland/Libraries/LibWeb/HTML/HTMLElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLElement.h
@@ -27,7 +27,7 @@ class HTMLElement
 public:
     virtual ~HTMLElement() override;
 
-    DeprecatedString title() const { return deprecated_attribute(HTML::AttributeNames::title); }
+    Optional<String> title() const { return attribute(HTML::AttributeNames::title); }
 
     StringView dir() const;
     void set_dir(String const&);
@@ -70,7 +70,7 @@ protected:
 
     virtual void initialize(JS::Realm&) override;
 
-    virtual void attribute_changed(FlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value) override;
 
     virtual void visit_edges(Cell::Visitor&) override;
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLFrameSetElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFrameSetElement.cpp
@@ -23,14 +23,14 @@ void HTMLFrameSetElement::initialize(JS::Realm& realm)
     set_prototype(&Bindings::ensure_web_prototype<Bindings::HTMLFrameSetElementPrototype>(realm, "HTMLFrameSetElement"));
 }
 
-void HTMLFrameSetElement::attribute_changed(FlyString const& name, DeprecatedString const& value)
+void HTMLFrameSetElement::attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value)
 {
     HTMLElement::attribute_changed(name, value);
 
 #undef __ENUMERATE
-#define __ENUMERATE(attribute_name, event_name)                                                                     \
-    if (name == HTML::AttributeNames::attribute_name) {                                                             \
-        element_event_handler_attribute_changed(event_name, String::from_deprecated_string(value).release_value()); \
+#define __ENUMERATE(attribute_name, event_name)                                                                                          \
+    if (name == HTML::AttributeNames::attribute_name) {                                                                                  \
+        element_event_handler_attribute_changed(event_name, value.map([](auto& v) { return MUST(String::from_deprecated_string(v)); })); \
     }
     ENUMERATE_WINDOW_EVENT_HANDLERS(__ENUMERATE)
 #undef __ENUMERATE

--- a/Userland/Libraries/LibWeb/HTML/HTMLFrameSetElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFrameSetElement.h
@@ -24,7 +24,7 @@ private:
     HTMLFrameSetElement(DOM::Document&, DOM::QualifiedName);
 
     virtual void initialize(JS::Realm&) override;
-    virtual void attribute_changed(FlyString const&, DeprecatedString const&) override;
+    virtual void attribute_changed(FlyString const&, Optional<DeprecatedString> const&) override;
 
     // ^HTML::GlobalEventHandlers
     virtual EventTarget& global_event_handlers_to_event_target(FlyString const& event_name) override;

--- a/Userland/Libraries/LibWeb/HTML/HTMLHyperlinkElementUtils.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLHyperlinkElementUtils.cpp
@@ -29,14 +29,14 @@ void HTMLHyperlinkElementUtils::set_the_url()
 {
     // 1. If this element's href content attribute is absent, set this element's url to null.
     auto href_content_attribute = hyperlink_element_utils_href();
-    if (href_content_attribute.is_null()) {
+    if (!href_content_attribute.has_value()) {
         m_url = {};
         return;
     }
 
     // 2. Otherwise, parse this element's href content attribute value relative to this element's node document.
     //    If parsing is successful, set this element's url to the result; otherwise, set this element's url to null.
-    m_url = hyperlink_element_utils_document().parse_url(href_content_attribute);
+    m_url = hyperlink_element_utils_document().parse_url(*href_content_attribute);
 }
 
 // https://html.spec.whatwg.org/multipage/links.html#dom-hyperlink-origin
@@ -429,12 +429,12 @@ DeprecatedString HTMLHyperlinkElementUtils::href() const
 
     // 3. If url is null and this element has no href content attribute, return the empty string.
     auto href_content_attribute = hyperlink_element_utils_href();
-    if (!url.has_value() && href_content_attribute.is_null())
+    if (!url.has_value() && !href_content_attribute.has_value())
         return DeprecatedString::empty();
 
     // 4. Otherwise, if url is null, return this element's href content attribute's value.
     if (!url->is_valid())
-        return href_content_attribute;
+        return href_content_attribute->to_deprecated_string();
 
     // 5. Return url, serialized.
     return url->serialize();

--- a/Userland/Libraries/LibWeb/HTML/HTMLHyperlinkElementUtils.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLHyperlinkElementUtils.h
@@ -51,7 +51,7 @@ public:
 
 protected:
     virtual DOM::Document& hyperlink_element_utils_document() = 0;
-    virtual DeprecatedString hyperlink_element_utils_href() const = 0;
+    virtual Optional<String> hyperlink_element_utils_href() const = 0;
     virtual WebIDL::ExceptionOr<void> set_hyperlink_element_utils_href(String) = 0;
     virtual bool hyperlink_element_utils_is_html_anchor_element() const = 0;
     virtual bool hyperlink_element_utils_is_connected() const = 0;

--- a/Userland/Libraries/LibWeb/HTML/HTMLIFrameElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLIFrameElement.cpp
@@ -33,7 +33,7 @@ JS::GCPtr<Layout::Node> HTMLIFrameElement::create_layout_node(NonnullRefPtr<CSS:
     return heap().allocate_without_realm<Layout::FrameBox>(document(), *this, move(style));
 }
 
-void HTMLIFrameElement::attribute_changed(FlyString const& name, DeprecatedString const& value)
+void HTMLIFrameElement::attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value)
 {
     HTMLElement::attribute_changed(name, value);
     if (m_content_navigable)

--- a/Userland/Libraries/LibWeb/HTML/HTMLIFrameElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLIFrameElement.h
@@ -36,7 +36,7 @@ private:
     // ^DOM::Element
     virtual void inserted() override;
     virtual void removed_from(Node*) override;
-    virtual void attribute_changed(FlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value) override;
     virtual i32 default_tab_index_value() const override;
 
     // https://html.spec.whatwg.org/multipage/iframe-embed-object.html#process-the-iframe-attributes

--- a/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -95,15 +95,15 @@ void HTMLImageElement::apply_presentational_hints(CSS::StyleProperties& style) c
     });
 }
 
-void HTMLImageElement::attribute_changed(FlyString const& name, DeprecatedString const& value)
+void HTMLImageElement::attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value)
 {
     HTMLElement::attribute_changed(name, value);
 
     if (name == HTML::AttributeNames::crossorigin) {
-        if (value.is_null()) {
+        if (!value.has_value()) {
             m_cors_setting = CORSSettingAttribute::NoCORS;
         } else {
-            m_cors_setting = cors_setting_attribute_from_keyword(String::from_deprecated_string(value).release_value_but_fixme_should_propagate_errors());
+            m_cors_setting = cors_setting_attribute_from_keyword(String::from_deprecated_string(*value).release_value_but_fixme_should_propagate_errors());
         }
     }
 
@@ -255,7 +255,7 @@ bool HTMLImageElement::complete() const
         return true;
 
     // - The srcset attribute is omitted and the src attribute's value is the empty string.
-    if (!has_attribute(HTML::AttributeNames::srcset) && deprecated_attribute(HTML::AttributeNames::src) == ""sv)
+    if (!has_attribute(HTML::AttributeNames::srcset) && attribute(HTML::AttributeNames::src).value().is_empty())
         return true;
 
     // - The img element's current request's state is completely available and its pending request is null.
@@ -273,7 +273,7 @@ Optional<ARIA::Role> HTMLImageElement::default_role() const
 {
     // https://www.w3.org/TR/html-aria/#el-img
     // https://www.w3.org/TR/html-aria/#el-img-no-alt
-    if (alt().is_null() || !alt().is_empty())
+    if (!alt().is_empty())
         return ARIA::Role::img;
     // https://www.w3.org/TR/html-aria/#el-img-empty-alt
     return ARIA::Role::presentation;
@@ -870,38 +870,38 @@ static void update_the_source_set(DOM::Element& element)
 
             // 4. If el is an img element that has a srcset attribute, then set srcset to that attribute's value.
             if (is<HTMLImageElement>(element)) {
-                if (auto srcset_value = element.deprecated_attribute(HTML::AttributeNames::srcset); !srcset_value.is_null())
-                    srcset = String::from_deprecated_string(srcset_value).release_value_but_fixme_should_propagate_errors();
+                if (auto srcset_value = element.attribute(HTML::AttributeNames::srcset); srcset_value.has_value())
+                    srcset = srcset_value.release_value();
             }
 
             // 5. Otherwise, if el is a link element that has an imagesrcset attribute, then set srcset to that attribute's value.
             else if (is<HTMLLinkElement>(element)) {
-                if (auto imagesrcset_value = element.deprecated_attribute(HTML::AttributeNames::imagesrcset); !imagesrcset_value.is_null())
-                    srcset = String::from_deprecated_string(imagesrcset_value).release_value_but_fixme_should_propagate_errors();
+                if (auto imagesrcset_value = element.attribute(HTML::AttributeNames::imagesrcset); imagesrcset_value.has_value())
+                    srcset = imagesrcset_value.release_value();
             }
 
             // 6. If el is an img element that has a sizes attribute, then set sizes to that attribute's value.
             if (is<HTMLImageElement>(element)) {
-                if (auto sizes_value = element.deprecated_attribute(HTML::AttributeNames::sizes); !sizes_value.is_null())
-                    sizes = String::from_deprecated_string(sizes_value).release_value_but_fixme_should_propagate_errors();
+                if (auto sizes_value = element.attribute(HTML::AttributeNames::sizes); sizes_value.has_value())
+                    sizes = sizes_value.release_value();
             }
 
             // 7. Otherwise, if el is a link element that has an imagesizes attribute, then set sizes to that attribute's value.
             else if (is<HTMLLinkElement>(element)) {
-                if (auto imagesizes_value = element.deprecated_attribute(HTML::AttributeNames::imagesizes); !imagesizes_value.is_null())
-                    sizes = String::from_deprecated_string(imagesizes_value).release_value_but_fixme_should_propagate_errors();
+                if (auto imagesizes_value = element.attribute(HTML::AttributeNames::imagesizes); imagesizes_value.has_value())
+                    sizes = imagesizes_value.release_value();
             }
 
             // 8. If el is an img element that has a src attribute, then set default source to that attribute's value.
             if (is<HTMLImageElement>(element)) {
-                if (auto src_value = element.deprecated_attribute(HTML::AttributeNames::src); !src_value.is_null())
-                    default_source = String::from_deprecated_string(src_value).release_value_but_fixme_should_propagate_errors();
+                if (auto src_value = element.attribute(HTML::AttributeNames::src); src_value.has_value())
+                    default_source = src_value.release_value();
             }
 
             // 9. Otherwise, if el is a link element that has an href attribute, then set default source to that attribute's value.
             else if (is<HTMLLinkElement>(element)) {
-                if (auto href_value = element.deprecated_attribute(HTML::AttributeNames::href); !href_value.is_null())
-                    default_source = String::from_deprecated_string(href_value).release_value_but_fixme_should_propagate_errors();
+                if (auto href_value = element.attribute(HTML::AttributeNames::href); href_value.has_value())
+                    default_source = href_value.release_value();
             }
 
             // 10. Let el's source set be the result of creating a source set given default source, srcset, and sizes.

--- a/Userland/Libraries/LibWeb/HTML/HTMLImageElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLImageElement.h
@@ -32,7 +32,7 @@ class HTMLImageElement final
 public:
     virtual ~HTMLImageElement() override;
 
-    virtual void attribute_changed(FlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value) override;
 
     DeprecatedString alt() const { return deprecated_attribute(HTML::AttributeNames::alt); }
     DeprecatedString src() const { return deprecated_attribute(HTML::AttributeNames::src); }

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -111,7 +111,7 @@ public:
     virtual bool is_focusable() const override { return m_type != TypeAttributeState::Hidden; }
 
     // ^HTMLElement
-    virtual void attribute_changed(FlyString const&, DeprecatedString const&) override;
+    virtual void attribute_changed(FlyString const&, Optional<DeprecatedString> const&) override;
 
     // ^FormAssociatedElement
     // https://html.spec.whatwg.org/multipage/forms.html#category-listed

--- a/Userland/Libraries/LibWeb/HTML/HTMLLabelElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLLabelElement.h
@@ -18,7 +18,7 @@ public:
 
     virtual JS::GCPtr<Layout::Node> create_layout_node(NonnullRefPtr<CSS::StyleProperties>) override;
 
-    DeprecatedString for_() const { return deprecated_attribute(HTML::AttributeNames::for_); }
+    Optional<String> for_() const { return attribute(HTML::AttributeNames::for_); }
 
 private:
     HTMLLabelElement(DOM::Document&, DOM::QualifiedName);

--- a/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.h
@@ -39,7 +39,7 @@ private:
     HTMLLinkElement(DOM::Document&, DOM::QualifiedName);
 
     virtual void initialize(JS::Realm&) override;
-    void attribute_changed(FlyString const&, DeprecatedString const&) override;
+    void attribute_changed(FlyString const&, Optional<DeprecatedString> const&) override;
 
     // ^ResourceClient
     virtual void resource_did_fail() override;

--- a/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -83,17 +83,17 @@ void HTMLMediaElement::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_fetch_controller);
 }
 
-void HTMLMediaElement::attribute_changed(FlyString const& name, DeprecatedString const& value)
+void HTMLMediaElement::attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value)
 {
     Base::attribute_changed(name, value);
 
     if (name == HTML::AttributeNames::src) {
         load_element().release_value_but_fixme_should_propagate_errors();
     } else if (name == HTML::AttributeNames::crossorigin) {
-        if (value.is_null())
+        if (!value.has_value())
             m_crossorigin = cors_setting_attribute_from_keyword({});
         else
-            m_crossorigin = cors_setting_attribute_from_keyword(String::from_deprecated_string(value).release_value_but_fixme_should_propagate_errors());
+            m_crossorigin = cors_setting_attribute_from_keyword(String::from_deprecated_string(*value).release_value_but_fixme_should_propagate_errors());
     } else if (name == HTML::AttributeNames::muted) {
         set_muted(true);
     }

--- a/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.h
@@ -134,7 +134,7 @@ protected:
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
 
-    virtual void attribute_changed(FlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value) override;
     virtual void removed_from(DOM::Node*) override;
     virtual void children_changed() override;
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLObjectElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLObjectElement.cpp
@@ -45,7 +45,7 @@ void HTMLObjectElement::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_image_request);
 }
 
-void HTMLObjectElement::attribute_changed(FlyString const& name, DeprecatedString const& value)
+void HTMLObjectElement::attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value)
 {
     NavigableContainer::attribute_changed(name, value);
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLObjectElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLObjectElement.h
@@ -34,7 +34,7 @@ class HTMLObjectElement final
 public:
     virtual ~HTMLObjectElement() override;
 
-    virtual void attribute_changed(FlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value) override;
 
     String data() const;
     void set_data(String const& data) { MUST(set_attribute(HTML::AttributeNames::data, data)); }

--- a/Userland/Libraries/LibWeb/HTML/HTMLOptionElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLOptionElement.cpp
@@ -31,12 +31,12 @@ void HTMLOptionElement::initialize(JS::Realm& realm)
     set_prototype(&Bindings::ensure_web_prototype<Bindings::HTMLOptionElementPrototype>(realm, "HTMLOptionElement"));
 }
 
-void HTMLOptionElement::attribute_changed(FlyString const& name, DeprecatedString const& value)
+void HTMLOptionElement::attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value)
 {
     HTMLElement::attribute_changed(name, value);
 
     if (name == HTML::AttributeNames::selected) {
-        if (value.is_null()) {
+        if (!value.has_value()) {
             // Whenever an option element's selected attribute is removed, if its dirtiness is false, its selectedness must be set to false.
             if (!m_dirty)
                 m_selected = false;

--- a/Userland/Libraries/LibWeb/HTML/HTMLOptionElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLOptionElement.h
@@ -40,7 +40,7 @@ private:
 
     virtual void initialize(JS::Realm&) override;
 
-    void attribute_changed(FlyString const& name, DeprecatedString const& value) override;
+    void attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value) override;
 
     void ask_for_a_reset();
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
@@ -45,20 +45,20 @@ void HTMLScriptElement::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_preparation_time_document.ptr());
 }
 
-void HTMLScriptElement::attribute_changed(FlyString const& name, DeprecatedString const& value)
+void HTMLScriptElement::attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value)
 {
     Base::attribute_changed(name, value);
 
     if (name == HTML::AttributeNames::crossorigin) {
-        if (value.is_null())
+        if (!value.has_value())
             m_crossorigin = cors_setting_attribute_from_keyword({});
         else
-            m_crossorigin = cors_setting_attribute_from_keyword(String::from_deprecated_string(value).release_value_but_fixme_should_propagate_errors());
+            m_crossorigin = cors_setting_attribute_from_keyword(String::from_deprecated_string(*value).release_value_but_fixme_should_propagate_errors());
     } else if (name == HTML::AttributeNames::referrerpolicy) {
-        if (value.is_null())
+        if (!value.has_value())
             m_referrer_policy.clear();
         else
-            m_referrer_policy = ReferrerPolicy::from_string(value);
+            m_referrer_policy = ReferrerPolicy::from_string(*value);
     }
 }
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLScriptElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLScriptElement.h
@@ -62,7 +62,7 @@ private:
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
 
-    virtual void attribute_changed(FlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value) override;
 
     // https://html.spec.whatwg.org/multipage/scripting.html#prepare-the-script-element
     void prepare_script();

--- a/Userland/Libraries/LibWeb/HTML/HTMLSlotElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLSlotElement.cpp
@@ -24,19 +24,19 @@ HTMLSlotElement::HTMLSlotElement(DOM::Document& document, DOM::QualifiedName qua
                 return;
 
             // 2. If value is null and oldValue is the empty string, then return.
-            if (value.is_null() && old_value == DeprecatedString::empty())
+            if (!value.has_value() && old_value == DeprecatedString::empty())
                 return;
 
             // 3. If value is the empty string and oldValue is null, then return.
-            if (value == DeprecatedString::empty() && old_value.is_null())
+            if (value == DeprecatedString::empty() && !old_value.has_value())
                 return;
 
             // 4. If value is null or the empty string, then set element’s name to the empty string.
-            if (value.is_empty())
+            if (!value.has_value())
                 set_slot_name({});
             // 5. Otherwise, set element’s name to value.
             else
-                set_slot_name(MUST(String::from_deprecated_string(value)));
+                set_slot_name(MUST(String::from_deprecated_string(*value)));
 
             // 6. Run assign slottables for a tree with element’s root.
             DOM::assign_slottables_for_a_tree(root());

--- a/Userland/Libraries/LibWeb/HTML/HTMLVideoElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLVideoElement.cpp
@@ -40,15 +40,15 @@ void HTMLVideoElement::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_fetch_controller);
 }
 
-void HTMLVideoElement::attribute_changed(FlyString const& name, DeprecatedString const& value)
+void HTMLVideoElement::attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value)
 {
     Base::attribute_changed(name, value);
 
     if (name == HTML::AttributeNames::poster) {
-        if (value.is_null())
+        if (!value.has_value())
             determine_element_poster_frame({}).release_value_but_fixme_should_propagate_errors();
         else
-            determine_element_poster_frame(value).release_value_but_fixme_should_propagate_errors();
+            determine_element_poster_frame(*value).release_value_but_fixme_should_propagate_errors();
     }
 }
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLVideoElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLVideoElement.h
@@ -47,7 +47,7 @@ private:
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
 
-    virtual void attribute_changed(FlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value) override;
 
     virtual JS::GCPtr<Layout::Node> create_layout_node(NonnullRefPtr<CSS::StyleProperties>) override;
 

--- a/Userland/Libraries/LibWeb/HTML/NavigableContainer.cpp
+++ b/Userland/Libraries/LibWeb/HTML/NavigableContainer.cpp
@@ -76,8 +76,8 @@ WebIDL::ExceptionOr<void> NavigableContainer::create_new_child_navigable()
     Optional<String> target_name;
 
     // 5. If element has a name content attribute, then set targetName to the value of that attribute.
-    if (auto value = deprecated_attribute(HTML::AttributeNames::name); !value.is_null())
-        target_name = String::from_deprecated_string(value).release_value_but_fixme_should_propagate_errors();
+    if (auto value = attribute(HTML::AttributeNames::name); value.has_value())
+        target_name = move(value);
 
     // 6. Let documentState be a new document state, with
     //  - document: document
@@ -195,7 +195,7 @@ Optional<AK::URL> NavigableContainer::shared_attribute_processing_steps_for_ifra
     //    then parse the value of that attribute relative to element's node document.
     //    If this is successful, then set url to the resulting URL record.
     auto src_attribute_value = deprecated_attribute(HTML::AttributeNames::src);
-    if (!src_attribute_value.is_null() && !src_attribute_value.is_empty()) {
+    if (!src_attribute_value.is_empty()) {
         auto parsed_src = document().parse_url(src_attribute_value);
         if (parsed_src.is_valid())
             url = parsed_src;

--- a/Userland/Libraries/LibWeb/HTML/Origin.h
+++ b/Userland/Libraries/LibWeb/HTML/Origin.h
@@ -16,7 +16,7 @@ namespace Web::HTML {
 class Origin {
 public:
     Origin() = default;
-    Origin(DeprecatedString const& scheme, AK::URL::Host const& host, u16 port)
+    Origin(Optional<DeprecatedString> const& scheme, AK::URL::Host const& host, u16 port)
         : m_scheme(scheme)
         , m_host(host)
         , m_port(port)
@@ -24,9 +24,12 @@ public:
     }
 
     // https://html.spec.whatwg.org/multipage/origin.html#concept-origin-opaque
-    bool is_opaque() const { return m_scheme.is_null() && m_host.has<Empty>() && m_port == 0; }
+    bool is_opaque() const { return !m_scheme.has_value() && m_host.has<Empty>() && m_port == 0; }
 
-    DeprecatedString const& scheme() const { return m_scheme; }
+    StringView scheme() const
+    {
+        return m_scheme.map([](auto& str) { return str.view(); }).value_or(StringView {});
+    }
     AK::URL::Host const& host() const { return m_host; }
     u16 port() const { return m_port; }
 
@@ -110,7 +113,7 @@ public:
     bool operator==(Origin const& other) const { return is_same_origin(other); }
 
 private:
-    DeprecatedString m_scheme;
+    Optional<DeprecatedString> m_scheme;
     AK::URL::Host m_host;
     u16 m_port { 0 };
 };

--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -1092,10 +1092,11 @@ void BlockFormattingContext::layout_list_item_marker(ListItemBox const& list_ite
 
     CSSPixels default_marker_width = max(4, marker.font().pixel_size_rounded_up() - 4);
 
-    if (marker.text().is_empty()) {
+    auto marker_text = marker.text().value_or("");
+    if (marker_text.is_empty()) {
         marker_state.set_content_width(image_width + default_marker_width);
     } else {
-        auto text_width = marker.font().width(marker.text());
+        auto text_width = marker.font().width(marker_text);
         marker_state.set_content_width(image_width + CSSPixels::nearest_value_for(text_width));
     }
 

--- a/Userland/Libraries/LibWeb/Layout/Label.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Label.cpp
@@ -93,7 +93,7 @@ Label const* Label::label_for_control_node(LabelableNode const& control)
     // same tree as the label element. If the attribute is specified and there is an element in the tree
     // whose ID is equal to the value of the for attribute, and the first such element in tree order is
     // a labelable element, then that element is the label element's labeled control.
-    if (auto id = control.dom_node().deprecated_attribute(HTML::AttributeNames::id); !id.is_empty()) {
+    if (auto id = control.dom_node().attribute(HTML::AttributeNames::id); id.has_value() && !id->is_empty()) {
         Label const* label = nullptr;
 
         control.document().layout_node()->for_each_in_inclusive_subtree_of_type<Label>([&](auto& node) {
@@ -126,9 +126,9 @@ LabelableNode* Label::labeled_control()
     // same tree as the label element. If the attribute is specified and there is an element in the tree
     // whose ID is equal to the value of the for attribute, and the first such element in tree order is
     // a labelable element, then that element is the label element's labeled control.
-    if (auto for_ = dom_node().for_(); !for_.is_null()) {
+    if (auto for_ = dom_node().for_(); for_.has_value()) {
         document().layout_node()->for_each_in_inclusive_subtree_of_type<LabelableNode>([&](auto& node) {
-            if (node.dom_node().deprecated_attribute(HTML::AttributeNames::id) == for_) {
+            if (node.dom_node().attribute(HTML::AttributeNames::id) == for_) {
                 control = &node;
                 return IterationDecision::Break;
             }

--- a/Userland/Libraries/LibWeb/Layout/ListItemMarkerBox.h
+++ b/Userland/Libraries/LibWeb/Layout/ListItemMarkerBox.h
@@ -18,7 +18,7 @@ public:
     explicit ListItemMarkerBox(DOM::Document&, CSS::ListStyleType, CSS::ListStylePosition, size_t index, NonnullRefPtr<CSS::StyleProperties>);
     virtual ~ListItemMarkerBox() override;
 
-    DeprecatedString const& text() const { return m_text; }
+    Optional<DeprecatedString> const& text() const { return m_text; }
 
     virtual JS::GCPtr<Painting::Paintable> create_paintable() const override;
 
@@ -33,7 +33,7 @@ private:
     CSS::ListStylePosition m_list_style_position { CSS::ListStylePosition::Outside };
     size_t m_index;
 
-    DeprecatedString m_text {};
+    Optional<DeprecatedString> m_text {};
 };
 
 template<>

--- a/Userland/Libraries/LibWeb/Layout/TextNode.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TextNode.cpp
@@ -306,9 +306,9 @@ void TextNode::invalidate_text_for_rendering()
 
 DeprecatedString const& TextNode::text_for_rendering() const
 {
-    if (m_text_for_rendering.is_null())
+    if (!m_text_for_rendering.has_value())
         const_cast<TextNode*>(this)->compute_text_for_rendering();
-    return m_text_for_rendering;
+    return *m_text_for_rendering;
 }
 
 // NOTE: This collapses whitespace into a single ASCII space if the CSS white-space property tells us to.

--- a/Userland/Libraries/LibWeb/Layout/TextNode.h
+++ b/Userland/Libraries/LibWeb/Layout/TextNode.h
@@ -55,7 +55,7 @@ public:
 private:
     virtual bool is_text_node() const final { return true; }
 
-    DeprecatedString m_text_for_rendering;
+    Optional<DeprecatedString> m_text_for_rendering;
 };
 
 template<>

--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -533,8 +533,8 @@ bool EventHandler::handle_mousemove(CSSPixelPoint position, CSSPixelPoint screen
 
         if (hovered_node_changed) {
             JS::GCPtr<HTML::HTMLElement const> hovered_html_element = document.hovered_node() ? document.hovered_node()->enclosing_html_element_with_attribute(HTML::AttributeNames::title) : nullptr;
-            if (hovered_html_element && !hovered_html_element->title().is_null()) {
-                page->client().page_did_enter_tooltip_area(m_browsing_context->to_top_level_position(position), hovered_html_element->title());
+            if (hovered_html_element && hovered_html_element->title().has_value()) {
+                page->client().page_did_enter_tooltip_area(m_browsing_context->to_top_level_position(position), hovered_html_element->title()->to_deprecated_string());
             } else {
                 page->client().page_did_leave_tooltip_area();
             }

--- a/Userland/Libraries/LibWeb/Painting/MarkerPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/MarkerPaintable.cpp
@@ -113,13 +113,15 @@ void MarkerPaintable::paint(PaintContext& context, PaintPhase phase) const
     case CSS::ListStyleType::LowerRoman:
     case CSS::ListStyleType::UpperAlpha:
     case CSS::ListStyleType::UpperLatin:
-    case CSS::ListStyleType::UpperRoman:
-        if (layout_box().text().is_null())
+    case CSS::ListStyleType::UpperRoman: {
+        auto text = layout_box().text();
+        if (!text.has_value())
             break;
         // FIXME: This should use proper text layout logic!
         // This does not line up with the text in the <li> element which looks very sad :(
-        context.painter().draw_text(device_enclosing.to_type<int>(), layout_box().text(), layout_box().scaled_font(context), Gfx::TextAlignment::Center, color);
+        context.painter().draw_text(device_enclosing.to_type<int>(), *text, layout_box().scaled_font(context), Gfx::TextAlignment::Center, color);
         break;
+    }
     case CSS::ListStyleType::None:
         return;
 

--- a/Userland/Libraries/LibWeb/SVG/SVGCircleElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGCircleElement.cpp
@@ -22,18 +22,18 @@ void SVGCircleElement::initialize(JS::Realm& realm)
     set_prototype(&Bindings::ensure_web_prototype<Bindings::SVGCircleElementPrototype>(realm, "SVGCircleElement"));
 }
 
-void SVGCircleElement::attribute_changed(FlyString const& name, DeprecatedString const& value)
+void SVGCircleElement::attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value)
 {
     SVGGeometryElement::attribute_changed(name, value);
 
     if (name == SVG::AttributeNames::cx) {
-        m_center_x = AttributeParser::parse_coordinate(value);
+        m_center_x = AttributeParser::parse_coordinate(value.value_or(""));
         m_path.clear();
     } else if (name == SVG::AttributeNames::cy) {
-        m_center_y = AttributeParser::parse_coordinate(value);
+        m_center_y = AttributeParser::parse_coordinate(value.value_or(""));
         m_path.clear();
     } else if (name == SVG::AttributeNames::r) {
-        m_radius = AttributeParser::parse_positive_length(value);
+        m_radius = AttributeParser::parse_positive_length(value.value_or(""));
         m_path.clear();
     }
 }

--- a/Userland/Libraries/LibWeb/SVG/SVGCircleElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGCircleElement.h
@@ -17,7 +17,7 @@ class SVGCircleElement final : public SVGGeometryElement {
 public:
     virtual ~SVGCircleElement() override = default;
 
-    virtual void attribute_changed(FlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value) override;
 
     virtual Gfx::Path& get_path() override;
 

--- a/Userland/Libraries/LibWeb/SVG/SVGElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGElement.cpp
@@ -34,7 +34,7 @@ void SVGElement::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_dataset);
 }
 
-void SVGElement::attribute_changed(FlyString const& name, DeprecatedString const& value)
+void SVGElement::attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value)
 {
     Base::attribute_changed(name, value);
 

--- a/Userland/Libraries/LibWeb/SVG/SVGElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGElement.h
@@ -17,7 +17,7 @@ class SVGElement : public DOM::Element {
 public:
     virtual bool requires_svg_container() const override { return true; }
 
-    virtual void attribute_changed(FlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value) override;
 
     virtual void children_changed() override;
     virtual void inserted() override;

--- a/Userland/Libraries/LibWeb/SVG/SVGEllipseElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGEllipseElement.cpp
@@ -22,21 +22,21 @@ void SVGEllipseElement::initialize(JS::Realm& realm)
     set_prototype(&Bindings::ensure_web_prototype<Bindings::SVGEllipseElementPrototype>(realm, "SVGEllipseElement"));
 }
 
-void SVGEllipseElement::attribute_changed(FlyString const& name, DeprecatedString const& value)
+void SVGEllipseElement::attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value)
 {
     SVGGeometryElement::attribute_changed(name, value);
 
     if (name == SVG::AttributeNames::cx) {
-        m_center_x = AttributeParser::parse_coordinate(value);
+        m_center_x = AttributeParser::parse_coordinate(value.value_or(""));
         m_path.clear();
     } else if (name == SVG::AttributeNames::cy) {
-        m_center_y = AttributeParser::parse_coordinate(value);
+        m_center_y = AttributeParser::parse_coordinate(value.value_or(""));
         m_path.clear();
     } else if (name == SVG::AttributeNames::rx) {
-        m_radius_x = AttributeParser::parse_positive_length(value);
+        m_radius_x = AttributeParser::parse_positive_length(value.value_or(""));
         m_path.clear();
     } else if (name == SVG::AttributeNames::ry) {
-        m_radius_y = AttributeParser::parse_positive_length(value);
+        m_radius_y = AttributeParser::parse_positive_length(value.value_or(""));
         m_path.clear();
     }
 }

--- a/Userland/Libraries/LibWeb/SVG/SVGEllipseElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGEllipseElement.h
@@ -17,7 +17,7 @@ class SVGEllipseElement final : public SVGGeometryElement {
 public:
     virtual ~SVGEllipseElement() override = default;
 
-    virtual void attribute_changed(FlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value) override;
 
     virtual Gfx::Path& get_path() override;
 

--- a/Userland/Libraries/LibWeb/SVG/SVGGradientElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGGradientElement.cpp
@@ -17,15 +17,15 @@ SVGGradientElement::SVGGradientElement(DOM::Document& document, DOM::QualifiedNa
 {
 }
 
-void SVGGradientElement::attribute_changed(FlyString const& name, DeprecatedString const& value)
+void SVGGradientElement::attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value)
 {
     SVGElement::attribute_changed(name, value);
     if (name == AttributeNames::gradientUnits) {
-        m_gradient_units = AttributeParser::parse_units(value);
+        m_gradient_units = AttributeParser::parse_units(value.value_or(""));
     } else if (name == AttributeNames::spreadMethod) {
-        m_spread_method = AttributeParser::parse_spread_method(value);
+        m_spread_method = AttributeParser::parse_spread_method(value.value_or(""));
     } else if (name == AttributeNames::gradientTransform) {
-        if (auto transform_list = AttributeParser::parse_transform(value); transform_list.has_value()) {
+        if (auto transform_list = AttributeParser::parse_transform(value.value_or("")); transform_list.has_value()) {
             m_gradient_transform = transform_from_transform_list(*transform_list);
         } else {
             m_gradient_transform = {};

--- a/Userland/Libraries/LibWeb/SVG/SVGGradientElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGGradientElement.h
@@ -40,7 +40,7 @@ class SVGGradientElement : public SVGElement {
 public:
     virtual ~SVGGradientElement() override = default;
 
-    virtual void attribute_changed(FlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value) override;
 
     virtual Optional<Gfx::PaintStyle const&> to_gfx_paint_style(SVGPaintContext const&) const = 0;
 

--- a/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
@@ -32,11 +32,11 @@ void SVGGraphicsElement::initialize(JS::Realm& realm)
     set_prototype(&Bindings::ensure_web_prototype<Bindings::SVGGraphicsElementPrototype>(realm, "SVGGraphicsElement"));
 }
 
-void SVGGraphicsElement::attribute_changed(FlyString const& name, DeprecatedString const& value)
+void SVGGraphicsElement::attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value)
 {
     SVGElement::attribute_changed(name, value);
     if (name == "transform"sv) {
-        auto transform_list = AttributeParser::parse_transform(value);
+        auto transform_list = AttributeParser::parse_transform(value.value_or(""));
         if (transform_list.has_value())
             m_transform = transform_from_transform_list(*transform_list);
     }

--- a/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.h
@@ -25,7 +25,7 @@ class SVGGraphicsElement : public SVGElement {
 public:
     virtual void apply_presentational_hints(CSS::StyleProperties&) const override;
 
-    virtual void attribute_changed(FlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value) override;
 
     Optional<Gfx::Color> fill_color() const;
     Optional<FillRule> fill_rule() const;

--- a/Userland/Libraries/LibWeb/SVG/SVGLineElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGLineElement.cpp
@@ -22,21 +22,21 @@ void SVGLineElement::initialize(JS::Realm& realm)
     set_prototype(&Bindings::ensure_web_prototype<Bindings::SVGLineElementPrototype>(realm, "SVGLineElement"));
 }
 
-void SVGLineElement::attribute_changed(FlyString const& name, DeprecatedString const& value)
+void SVGLineElement::attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value)
 {
     SVGGeometryElement::attribute_changed(name, value);
 
     if (name == SVG::AttributeNames::x1) {
-        m_x1 = AttributeParser::parse_coordinate(value);
+        m_x1 = AttributeParser::parse_coordinate(value.value_or(""));
         m_path.clear();
     } else if (name == SVG::AttributeNames::y1) {
-        m_y1 = AttributeParser::parse_coordinate(value);
+        m_y1 = AttributeParser::parse_coordinate(value.value_or(""));
         m_path.clear();
     } else if (name == SVG::AttributeNames::x2) {
-        m_x2 = AttributeParser::parse_coordinate(value);
+        m_x2 = AttributeParser::parse_coordinate(value.value_or(""));
         m_path.clear();
     } else if (name == SVG::AttributeNames::y2) {
-        m_y2 = AttributeParser::parse_coordinate(value);
+        m_y2 = AttributeParser::parse_coordinate(value.value_or(""));
         m_path.clear();
     }
 }

--- a/Userland/Libraries/LibWeb/SVG/SVGLineElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGLineElement.h
@@ -17,7 +17,7 @@ class SVGLineElement final : public SVGGeometryElement {
 public:
     virtual ~SVGLineElement() override = default;
 
-    virtual void attribute_changed(FlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value) override;
 
     virtual Gfx::Path& get_path() override;
 

--- a/Userland/Libraries/LibWeb/SVG/SVGLinearGradientElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGLinearGradientElement.cpp
@@ -24,22 +24,22 @@ void SVGLinearGradientElement::initialize(JS::Realm& realm)
     set_prototype(&Bindings::ensure_web_prototype<Bindings::SVGLinearGradientElementPrototype>(realm, "SVGLinearGradientElement"));
 }
 
-void SVGLinearGradientElement::attribute_changed(FlyString const& name, DeprecatedString const& value)
+void SVGLinearGradientElement::attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value)
 {
     SVGGradientElement::attribute_changed(name, value);
 
     // FIXME: Should allow for `<number-percentage> | <length>` for x1, x2, y1, y2
     if (name == SVG::AttributeNames::x1) {
-        m_x1 = AttributeParser::parse_number_percentage(value);
+        m_x1 = AttributeParser::parse_number_percentage(value.value_or(""));
         m_paint_style = nullptr;
     } else if (name == SVG::AttributeNames::y1) {
-        m_y1 = AttributeParser::parse_number_percentage(value);
+        m_y1 = AttributeParser::parse_number_percentage(value.value_or(""));
         m_paint_style = nullptr;
     } else if (name == SVG::AttributeNames::x2) {
-        m_x2 = AttributeParser::parse_number_percentage(value);
+        m_x2 = AttributeParser::parse_number_percentage(value.value_or(""));
         m_paint_style = nullptr;
     } else if (name == SVG::AttributeNames::y2) {
-        m_y2 = AttributeParser::parse_number_percentage(value);
+        m_y2 = AttributeParser::parse_number_percentage(value.value_or(""));
         m_paint_style = nullptr;
     }
 }

--- a/Userland/Libraries/LibWeb/SVG/SVGLinearGradientElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGLinearGradientElement.h
@@ -18,7 +18,7 @@ class SVGLinearGradientElement : public SVGGradientElement {
 public:
     virtual ~SVGLinearGradientElement() override = default;
 
-    virtual void attribute_changed(FlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value) override;
 
     virtual Optional<Gfx::PaintStyle const&> to_gfx_paint_style(SVGPaintContext const&) const override;
 

--- a/Userland/Libraries/LibWeb/SVG/SVGMaskElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGMaskElement.cpp
@@ -31,13 +31,13 @@ JS::GCPtr<Layout::Node> SVGMaskElement::create_layout_node(NonnullRefPtr<CSS::St
     return heap().allocate_without_realm<Layout::SVGGraphicsBox>(document(), *this, move(style));
 }
 
-void SVGMaskElement::attribute_changed(FlyString const& name, DeprecatedString const& value)
+void SVGMaskElement::attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value)
 {
     SVGGraphicsElement::attribute_changed(name, value);
     if (name == AttributeNames::maskUnits) {
-        m_mask_units = AttributeParser::parse_units(value);
+        m_mask_units = AttributeParser::parse_units(value.value_or(""));
     } else if (name == AttributeNames::maskContentUnits) {
-        m_mask_content_units = AttributeParser::parse_units(value);
+        m_mask_content_units = AttributeParser::parse_units(value.value_or(""));
     }
 }
 

--- a/Userland/Libraries/LibWeb/SVG/SVGMaskElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGMaskElement.h
@@ -17,7 +17,7 @@ class SVGMaskElement final : public SVGGraphicsElement {
 public:
     virtual ~SVGMaskElement() override;
 
-    virtual void attribute_changed(FlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value) override;
 
     virtual JS::GCPtr<Layout::Node> create_layout_node(NonnullRefPtr<CSS::StyleProperties>) override;
 

--- a/Userland/Libraries/LibWeb/SVG/SVGPathElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGPathElement.cpp
@@ -95,12 +95,12 @@ void SVGPathElement::initialize(JS::Realm& realm)
     set_prototype(&Bindings::ensure_web_prototype<Bindings::SVGPathElementPrototype>(realm, "SVGPathElement"));
 }
 
-void SVGPathElement::attribute_changed(FlyString const& name, DeprecatedString const& value)
+void SVGPathElement::attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value)
 {
     SVGGeometryElement::attribute_changed(name, value);
 
     if (name == "d") {
-        m_instructions = AttributeParser::parse_path_data(value);
+        m_instructions = AttributeParser::parse_path_data(value.value_or(""));
         m_path.clear();
     }
 }

--- a/Userland/Libraries/LibWeb/SVG/SVGPathElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGPathElement.h
@@ -19,7 +19,7 @@ class SVGPathElement final : public SVGGeometryElement {
 public:
     virtual ~SVGPathElement() override = default;
 
-    virtual void attribute_changed(FlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value) override;
 
     virtual Gfx::Path& get_path() override;
 

--- a/Userland/Libraries/LibWeb/SVG/SVGPolygonElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGPolygonElement.cpp
@@ -22,12 +22,12 @@ void SVGPolygonElement::initialize(JS::Realm& realm)
     set_prototype(&Bindings::ensure_web_prototype<Bindings::SVGPolygonElementPrototype>(realm, "SVGPolygonElement"));
 }
 
-void SVGPolygonElement::attribute_changed(FlyString const& name, DeprecatedString const& value)
+void SVGPolygonElement::attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value)
 {
     SVGGeometryElement::attribute_changed(name, value);
 
     if (name == SVG::AttributeNames::points) {
-        m_points = AttributeParser::parse_points(value);
+        m_points = AttributeParser::parse_points(value.value_or(""));
         m_path.clear();
     }
 }

--- a/Userland/Libraries/LibWeb/SVG/SVGPolygonElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGPolygonElement.h
@@ -16,7 +16,7 @@ class SVGPolygonElement final : public SVGGeometryElement {
 public:
     virtual ~SVGPolygonElement() override = default;
 
-    virtual void attribute_changed(FlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value) override;
 
     virtual Gfx::Path& get_path() override;
 

--- a/Userland/Libraries/LibWeb/SVG/SVGPolylineElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGPolylineElement.cpp
@@ -22,12 +22,12 @@ void SVGPolylineElement::initialize(JS::Realm& realm)
     set_prototype(&Bindings::ensure_web_prototype<Bindings::SVGPolylineElementPrototype>(realm, "SVGPolylineElement"));
 }
 
-void SVGPolylineElement::attribute_changed(FlyString const& name, DeprecatedString const& value)
+void SVGPolylineElement::attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value)
 {
     SVGGeometryElement::attribute_changed(name, value);
 
     if (name == SVG::AttributeNames::points) {
-        m_points = AttributeParser::parse_points(value);
+        m_points = AttributeParser::parse_points(value.value_or(""));
         m_path.clear();
     }
 }

--- a/Userland/Libraries/LibWeb/SVG/SVGPolylineElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGPolylineElement.h
@@ -16,7 +16,7 @@ class SVGPolylineElement final : public SVGGeometryElement {
 public:
     virtual ~SVGPolylineElement() override = default;
 
-    virtual void attribute_changed(FlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value) override;
 
     virtual Gfx::Path& get_path() override;
 

--- a/Userland/Libraries/LibWeb/SVG/SVGRadialGradientElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGRadialGradientElement.cpp
@@ -21,29 +21,29 @@ void SVGRadialGradientElement::initialize(JS::Realm& realm)
     set_prototype(&Bindings::ensure_web_prototype<Bindings::SVGRadialGradientElementPrototype>(realm, "SVGRadialGradientElement"));
 }
 
-void SVGRadialGradientElement::attribute_changed(FlyString const& name, DeprecatedString const& value)
+void SVGRadialGradientElement::attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value)
 {
     SVGGradientElement::attribute_changed(name, value);
 
     // FIXME: These are <length> or <coordinate> in the spec, but all examples seem to allow percentages
     // and unitless values.
     if (name == SVG::AttributeNames::cx) {
-        m_cx = AttributeParser::parse_number_percentage(value);
+        m_cx = AttributeParser::parse_number_percentage(value.value_or(""));
         m_paint_style = nullptr;
     } else if (name == SVG::AttributeNames::cy) {
-        m_cy = AttributeParser::parse_number_percentage(value);
+        m_cy = AttributeParser::parse_number_percentage(value.value_or(""));
         m_paint_style = nullptr;
     } else if (name == SVG::AttributeNames::fx) {
-        m_fx = AttributeParser::parse_number_percentage(value);
+        m_fx = AttributeParser::parse_number_percentage(value.value_or(""));
         m_paint_style = nullptr;
     } else if (name == SVG::AttributeNames::fy) {
-        m_fy = AttributeParser::parse_number_percentage(value);
+        m_fy = AttributeParser::parse_number_percentage(value.value_or(""));
         m_paint_style = nullptr;
     } else if (name == SVG::AttributeNames::fr) {
-        m_fr = AttributeParser::parse_number_percentage(value);
+        m_fr = AttributeParser::parse_number_percentage(value.value_or(""));
         m_paint_style = nullptr;
     } else if (name == SVG::AttributeNames::r) {
-        m_r = AttributeParser::parse_number_percentage(value);
+        m_r = AttributeParser::parse_number_percentage(value.value_or(""));
         m_paint_style = nullptr;
     }
 }

--- a/Userland/Libraries/LibWeb/SVG/SVGRadialGradientElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGRadialGradientElement.h
@@ -18,7 +18,7 @@ class SVGRadialGradientElement : public SVGGradientElement {
 public:
     virtual ~SVGRadialGradientElement() override = default;
 
-    virtual void attribute_changed(FlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value) override;
 
     virtual Optional<Gfx::PaintStyle const&> to_gfx_paint_style(SVGPaintContext const&) const override;
 

--- a/Userland/Libraries/LibWeb/SVG/SVGRectElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGRectElement.cpp
@@ -24,27 +24,27 @@ void SVGRectElement::initialize(JS::Realm& realm)
     set_prototype(&Bindings::ensure_web_prototype<Bindings::SVGRectElementPrototype>(realm, "SVGRectElement"));
 }
 
-void SVGRectElement::attribute_changed(FlyString const& name, DeprecatedString const& value)
+void SVGRectElement::attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value)
 {
     SVGGeometryElement::attribute_changed(name, value);
 
     if (name == SVG::AttributeNames::x) {
-        m_x = AttributeParser::parse_coordinate(value);
+        m_x = AttributeParser::parse_coordinate(value.value_or(""));
         m_path.clear();
     } else if (name == SVG::AttributeNames::y) {
-        m_y = AttributeParser::parse_coordinate(value);
+        m_y = AttributeParser::parse_coordinate(value.value_or(""));
         m_path.clear();
     } else if (name == SVG::AttributeNames::width) {
-        m_width = AttributeParser::parse_positive_length(value);
+        m_width = AttributeParser::parse_positive_length(value.value_or(""));
         m_path.clear();
     } else if (name == SVG::AttributeNames::height) {
-        m_height = AttributeParser::parse_positive_length(value);
+        m_height = AttributeParser::parse_positive_length(value.value_or(""));
         m_path.clear();
     } else if (name == SVG::AttributeNames::rx) {
-        m_radius_x = AttributeParser::parse_length(value);
+        m_radius_x = AttributeParser::parse_length(value.value_or(""));
         m_path.clear();
     } else if (name == SVG::AttributeNames::ry) {
-        m_radius_y = AttributeParser::parse_length(value);
+        m_radius_y = AttributeParser::parse_length(value.value_or(""));
         m_path.clear();
     }
 }

--- a/Userland/Libraries/LibWeb/SVG/SVGRectElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGRectElement.h
@@ -17,7 +17,7 @@ class SVGRectElement final : public SVGGeometryElement {
 public:
     virtual ~SVGRectElement() override = default;
 
-    virtual void attribute_changed(FlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value) override;
 
     virtual Gfx::Path& get_path() override;
 

--- a/Userland/Libraries/LibWeb/SVG/SVGSVGElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGSVGElement.cpp
@@ -38,7 +38,7 @@ void SVGSVGElement::apply_presentational_hints(CSS::StyleProperties& style) cons
 {
     Base::apply_presentational_hints(style);
 
-    auto width_attribute = deprecated_attribute(SVG::AttributeNames::width);
+    auto width_attribute = attribute(SVG::AttributeNames::width);
     auto parsing_context = CSS::Parser::ParsingContext { document(), CSS::Parser::ParsingContext::Mode::SVGPresentationAttribute };
     if (auto width_value = parse_css_value(parsing_context, deprecated_attribute(Web::HTML::AttributeNames::width), CSS::PropertyID::Width)) {
         style.set_property(CSS::PropertyID::Width, width_value.release_nonnull());
@@ -50,7 +50,7 @@ void SVGSVGElement::apply_presentational_hints(CSS::StyleProperties& style) cons
     }
 
     // Height defaults to 100%
-    auto height_attribute = deprecated_attribute(SVG::AttributeNames::height);
+    auto height_attribute = attribute(SVG::AttributeNames::height);
     if (auto height_value = parse_css_value(parsing_context, deprecated_attribute(Web::HTML::AttributeNames::height), CSS::PropertyID::Height)) {
         style.set_property(CSS::PropertyID::Height, height_value.release_nonnull());
     } else if (height_attribute == "") {
@@ -61,14 +61,14 @@ void SVGSVGElement::apply_presentational_hints(CSS::StyleProperties& style) cons
     }
 }
 
-void SVGSVGElement::attribute_changed(FlyString const& name, DeprecatedString const& value)
+void SVGSVGElement::attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value)
 {
     SVGGraphicsElement::attribute_changed(name, value);
 
     if (name.equals_ignoring_ascii_case(SVG::AttributeNames::viewBox))
-        m_view_box = try_parse_view_box(value);
+        m_view_box = try_parse_view_box(value.value_or(""));
     if (name.equals_ignoring_ascii_case(SVG::AttributeNames::preserveAspectRatio))
-        m_preserve_aspect_ratio = AttributeParser::parse_preserve_aspect_ratio(value);
+        m_preserve_aspect_ratio = AttributeParser::parse_preserve_aspect_ratio(value.value_or(""));
     if (name.equals_ignoring_ascii_case(SVG::AttributeNames::width) || name.equals_ignoring_ascii_case(SVG::AttributeNames::height))
         update_fallback_view_box_for_svg_as_image();
 }

--- a/Userland/Libraries/LibWeb/SVG/SVGSVGElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGSVGElement.h
@@ -36,7 +36,7 @@ private:
 
     virtual bool is_svg_svg_element() const override { return true; }
 
-    virtual void attribute_changed(FlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value) override;
 
     void update_fallback_view_box_for_svg_as_image();
 

--- a/Userland/Libraries/LibWeb/SVG/SVGStopElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGStopElement.cpp
@@ -19,11 +19,11 @@ SVGStopElement::SVGStopElement(DOM::Document& document, DOM::QualifiedName quali
 {
 }
 
-void SVGStopElement::attribute_changed(FlyString const& name, DeprecatedString const& value)
+void SVGStopElement::attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value)
 {
     SVGElement::attribute_changed(name, value);
     if (name == SVG::AttributeNames::offset) {
-        m_offset = AttributeParser::parse_number_percentage(value);
+        m_offset = AttributeParser::parse_number_percentage(value.value_or(""));
     }
 }
 

--- a/Userland/Libraries/LibWeb/SVG/SVGStopElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGStopElement.h
@@ -19,7 +19,7 @@ class SVGStopElement final : public SVGElement {
 public:
     virtual ~SVGStopElement() override = default;
 
-    virtual void attribute_changed(FlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value) override;
 
     JS::NonnullGCPtr<SVGAnimatedNumber> offset() const;
 

--- a/Userland/Libraries/LibWeb/SVG/SVGSymbolElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGSymbolElement.cpp
@@ -39,10 +39,10 @@ void SVGSymbolElement::apply_presentational_hints(CSS::StyleProperties& style) c
     }
 }
 
-void SVGSymbolElement::attribute_changed(FlyString const& name, DeprecatedString const& value)
+void SVGSymbolElement::attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value)
 {
     if (name.equals_ignoring_ascii_case(SVG::AttributeNames::viewBox))
-        m_view_box = try_parse_view_box(value);
+        m_view_box = try_parse_view_box(value.value_or(""));
 }
 
 bool SVGSymbolElement::is_direct_child_of_use_shadow_tree() const

--- a/Userland/Libraries/LibWeb/SVG/SVGSymbolElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGSymbolElement.h
@@ -29,7 +29,7 @@ private:
 
     bool is_direct_child_of_use_shadow_tree() const;
 
-    virtual void attribute_changed(FlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value) override;
 
     Optional<ViewBox> m_view_box;
 };

--- a/Userland/Libraries/LibWeb/SVG/SVGTextPositioningElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGTextPositioningElement.cpp
@@ -28,18 +28,18 @@ void SVGTextPositioningElement::initialize(JS::Realm& realm)
     set_prototype(&Bindings::ensure_web_prototype<Bindings::SVGTextPositioningElementPrototype>(realm, "SVGTextPositioningElement"));
 }
 
-void SVGTextPositioningElement::attribute_changed(FlyString const& name, DeprecatedString const& value)
+void SVGTextPositioningElement::attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value)
 {
     SVGGraphicsElement::attribute_changed(name, value);
 
     if (name == SVG::AttributeNames::x) {
-        m_x = AttributeParser::parse_coordinate(value).value_or(m_x);
+        m_x = AttributeParser::parse_coordinate(value.value_or("")).value_or(m_x);
     } else if (name == SVG::AttributeNames::y) {
-        m_y = AttributeParser::parse_coordinate(value).value_or(m_y);
+        m_y = AttributeParser::parse_coordinate(value.value_or("")).value_or(m_y);
     } else if (name == SVG::AttributeNames::dx) {
-        m_dx = AttributeParser::parse_coordinate(value).value_or(m_dx);
+        m_dx = AttributeParser::parse_coordinate(value.value_or("")).value_or(m_dx);
     } else if (name == SVG::AttributeNames::dy) {
-        m_dy = AttributeParser::parse_coordinate(value).value_or(m_dy);
+        m_dy = AttributeParser::parse_coordinate(value.value_or("")).value_or(m_dy);
     }
 }
 

--- a/Userland/Libraries/LibWeb/SVG/SVGTextPositioningElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGTextPositioningElement.h
@@ -16,7 +16,7 @@ class SVGTextPositioningElement : public SVGTextContentElement {
     WEB_PLATFORM_OBJECT(SVGTextPositioningElement, SVGTextContentElement);
 
 public:
-    virtual void attribute_changed(FlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value) override;
 
     Gfx::FloatPoint get_offset() const;
 

--- a/Userland/Libraries/LibWeb/SVG/SVGUseElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGUseElement.cpp
@@ -45,18 +45,18 @@ void SVGUseElement::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_document_observer);
 }
 
-void SVGUseElement::attribute_changed(FlyString const& name, DeprecatedString const& value)
+void SVGUseElement::attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value)
 {
     Base::attribute_changed(name, value);
 
     // https://svgwg.org/svg2-draft/struct.html#UseLayout
     if (name == SVG::AttributeNames::x) {
-        m_x = AttributeParser::parse_coordinate(value);
+        m_x = AttributeParser::parse_coordinate(value.value_or(""));
     } else if (name == SVG::AttributeNames::y) {
-        m_y = AttributeParser::parse_coordinate(value);
+        m_y = AttributeParser::parse_coordinate(value.value_or(""));
     } else if (name == SVG::AttributeNames::href) {
         // FIXME: Support the xlink:href attribute as a fallback
-        m_referenced_id = parse_id_from_href(value);
+        m_referenced_id = parse_id_from_href(value.value_or(""));
 
         clone_element_tree_as_our_shadow_tree(referenced_element());
     }

--- a/Userland/Libraries/LibWeb/SVG/SVGUseElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGUseElement.h
@@ -20,7 +20,7 @@ class SVGUseElement final : public SVGGraphicsElement {
 public:
     virtual ~SVGUseElement() override = default;
 
-    virtual void attribute_changed(FlyString const& name, DeprecatedString const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value) override;
 
     virtual void inserted() override;
 

--- a/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
+++ b/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
@@ -512,7 +512,7 @@ WebIDL::ExceptionOr<void> XMLHttpRequest::open(String const& method_string, Stri
     // Unset this’s upload listener flag.
     m_upload_listener = false;
     // Set this’s request method to method.
-    m_request_method = move(normalized_method);
+    m_request_method = normalized_method.span();
     // Set this’s request URL to parsedURL.
     m_request_url = parsed_url;
     // Set this’s synchronous flag if async is false; otherwise unset this’s synchronous flag.

--- a/Userland/Services/LaunchServer/Launcher.cpp
+++ b/Userland/Services/LaunchServer/Launcher.cpp
@@ -188,7 +188,7 @@ Optional<StringView> Launcher::mime_type_for_file(DeprecatedString path)
 
 bool Launcher::open_url(const URL& url, DeprecatedString const& handler_name)
 {
-    if (!handler_name.is_null())
+    if (!handler_name.is_empty())
         return open_with_handler_name(url, handler_name);
 
     if (url.scheme() == "file")

--- a/Userland/Services/SystemServer/Service.h
+++ b/Userland/Services/SystemServer/Service.h
@@ -54,7 +54,7 @@ private:
     // Extra arguments, starting from argv[1], to pass when exec'ing.
     DeprecatedString m_extra_arguments;
     // File path to open as stdio fds.
-    DeprecatedString m_stdio_file_path;
+    Optional<DeprecatedString> m_stdio_file_path;
     int m_priority { 1 };
     // Whether we should re-launch it if it exits.
     bool m_keep_alive { false };
@@ -65,9 +65,9 @@ private:
     // Whether we should only spawn this service once somebody connects to the socket.
     bool m_lazy;
     // The name of the user we should run this service as.
-    DeprecatedString m_user;
+    Optional<DeprecatedString> m_user;
     // The working directory in which to spawn the service.
-    DeprecatedString m_working_directory;
+    Optional<DeprecatedString> m_working_directory;
     // System modes in which to run this service. By default, this is the graphical mode.
     Vector<DeprecatedString> m_system_modes;
     // Whether several instances of this service can run at once.

--- a/Userland/Services/Taskbar/QuickLaunchWidget.cpp
+++ b/Userland/Services/Taskbar/QuickLaunchWidget.cpp
@@ -169,7 +169,7 @@ static DeprecatedString sanitize_entry_name(DeprecatedString const& name)
 ErrorOr<void> QuickLaunchWidget::add_or_adjust_button(DeprecatedString const& button_name, NonnullOwnPtr<QuickLaunchEntry>&& entry)
 {
     auto file_name_to_watch = entry->file_name_to_watch();
-    if (!file_name_to_watch.is_null()) {
+    if (!file_name_to_watch.is_empty()) {
         if (!m_watcher) {
             m_watcher = TRY(Core::FileWatcher::create());
             m_watcher->on_change = [this](Core::FileWatcherEvent const& event) {

--- a/Userland/Services/WindowServer/ScreenLayout.ipp
+++ b/Userland/Services/WindowServer/ScreenLayout.ipp
@@ -31,7 +31,7 @@ bool ScreenLayout::is_valid(DeprecatedString* error_msg) const
     int smallest_y = 0;
     for (size_t i = 0; i < screens.size(); i++) {
         auto& screen = screens[i];
-        if (screen.mode == Screen::Mode::Device && (screen.device->is_empty() || screen.device->is_null())) {
+        if (screen.mode == Screen::Mode::Device && screen.device->is_empty()) {
             if (error_msg)
                 *error_msg = DeprecatedString::formatted("Screen #{} has no path", i);
             return false;

--- a/Userland/Shell/Shell.h
+++ b/Userland/Shell/Shell.h
@@ -116,7 +116,7 @@ public:
     void setup_keybinds();
 
     struct SourcePosition {
-        DeprecatedString source_file;
+        Optional<DeprecatedString> source_file;
         DeprecatedString literal_source_text;
         Optional<AST::Position> position;
     };
@@ -183,7 +183,7 @@ public:
     static Vector<DeprecatedString> expand_globs(Vector<StringView> path_segments, StringView base);
     ErrorOr<Vector<AST::Command>> expand_aliases(Vector<AST::Command>);
     DeprecatedString resolve_path(DeprecatedString) const;
-    DeprecatedString resolve_alias(StringView) const;
+    Optional<DeprecatedString> resolve_alias(StringView) const;
 
     static bool has_history_event(StringView);
 

--- a/Userland/Utilities/ini.cpp
+++ b/Userland/Utilities/ini.cpp
@@ -17,7 +17,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     StringView path;
     DeprecatedString group;
     DeprecatedString key;
-    DeprecatedString value_to_write;
+    StringView value_to_write;
 
     Core::ArgsParser args_parser;
     args_parser.add_positional_argument(path, "Path to INI file", "path");

--- a/Userland/Utilities/ls.cpp
+++ b/Userland/Utilities/ls.cpp
@@ -248,15 +248,15 @@ static int print_escaped(StringView name)
 
 static DeprecatedString& hostname()
 {
-    static DeprecatedString s_hostname;
-    if (s_hostname.is_null()) {
+    static Optional<DeprecatedString> s_hostname;
+    if (!s_hostname.has_value()) {
         char buffer[HOST_NAME_MAX];
         if (gethostname(buffer, sizeof(buffer)) == 0)
             s_hostname = buffer;
         else
             s_hostname = "localhost";
     }
-    return s_hostname;
+    return *s_hostname;
 }
 
 static size_t print_name(const struct stat& st, DeprecatedString const& name, Optional<StringView> path_for_link_resolution, StringView path_for_hyperlink)
@@ -470,7 +470,6 @@ static int do_file_system_object_long(DeprecatedString const& path)
         builder.append('/');
         builder.append(metadata.name);
         metadata.path = builder.to_deprecated_string();
-        VERIFY(!metadata.path.is_null());
         int rc = lstat(metadata.path.characters(), &metadata.stat);
         if (rc < 0)
             perror("lstat");
@@ -595,7 +594,6 @@ int do_file_system_object_short(DeprecatedString const& path)
         builder.append('/');
         builder.append(metadata.name);
         metadata.path = builder.to_deprecated_string();
-        VERIFY(!metadata.path.is_null());
         int rc = lstat(metadata.path.characters(), &metadata.stat);
         if (rc < 0)
             perror("lstat");

--- a/Userland/Utilities/markdown-check.cpp
+++ b/Userland/Utilities/markdown-check.cpp
@@ -179,10 +179,11 @@ RecursionDecision MarkdownLinkage::visit(Markdown::Heading const& heading)
 RecursionDecision MarkdownLinkage::visit(Markdown::Text::LinkNode const& link_node)
 {
     DeprecatedString const& href = link_node.href;
-    if (href.is_null()) {
+    if (href.is_empty()) {
         // Nothing to do here.
         return RecursionDecision::Recurse;
     }
+
     auto url = URL::create_with_url_or_path(href);
     if (url.is_valid()) {
         if (url.scheme() == "https" || url.scheme() == "http") {

--- a/Userland/Utilities/mktemp.cpp
+++ b/Userland/Utilities/mktemp.cpp
@@ -30,7 +30,7 @@ static DeprecatedString generate_random_filename(DeprecatedString const& pattern
     return new_filename.to_deprecated_string();
 }
 
-static ErrorOr<DeprecatedString> make_temp(DeprecatedString const& pattern, bool directory, bool dry_run)
+static ErrorOr<Optional<DeprecatedString>> make_temp(DeprecatedString const& pattern, bool directory, bool dry_run)
 {
     for (int i = 0; i < 100; ++i) {
         auto path = generate_random_filename(pattern);
@@ -49,7 +49,7 @@ static ErrorOr<DeprecatedString> make_temp(DeprecatedString const& pattern, bool
             }
         }
     }
-    return DeprecatedString {};
+    return OptionalNone {};
 }
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
@@ -100,7 +100,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto target_path = LexicalPath::join(final_target_directory->to_deprecated_string(), final_file_template->to_deprecated_string()).string();
 
     auto final_path = TRY(make_temp(target_path, create_directory, dry_run));
-    if (final_path.is_null()) {
+    if (!final_path.has_value()) {
         if (!quiet) {
             if (create_directory)
                 warnln("Failed to create directory via template {}", target_path.characters());
@@ -110,7 +110,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         return 1;
     }
 
-    outln("{}", final_path);
+    outln("{}", *final_path);
 
     return 0;
 }

--- a/Userland/Utilities/paste.cpp
+++ b/Userland/Utilities/paste.cpp
@@ -72,7 +72,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         clipboard.on_change = [&](DeprecatedString const&) {
             // Technically there's a race here...
             auto data_and_type = clipboard.fetch_data_and_type();
-            if (data_and_type.mime_type.is_null()) {
+            if (data_and_type.mime_type.is_empty()) {
                 spawn_command(watch_command, {}, "clear");
             } else {
                 spawn_command(watch_command, data_and_type.data, "data");
@@ -87,7 +87,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto data_and_type = clipboard.fetch_data_and_type();
 
-    if (data_and_type.mime_type.is_null()) {
+    if (data_and_type.mime_type.is_empty()) {
         warnln("Nothing copied");
         return 1;
     }

--- a/Userland/Utilities/su.cpp
+++ b/Userland/Utilities/su.cpp
@@ -18,7 +18,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     StringView first_positional;
     StringView second_positional;
-    DeprecatedString command;
+    StringView command;
     bool simulate_login = false;
 
     Core::ArgsParser args_parser;
@@ -65,7 +65,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     if (command.is_null()) {
         TRY(Core::System::exec(account.shell(), Array<StringView, 1> { account.shell().view() }, Core::System::SearchInPath::No));
     } else {
-        TRY(Core::System::exec(account.shell(), Array<StringView, 3> { account.shell().view(), "-c"sv, command.view() }, Core::System::SearchInPath::No));
+        TRY(Core::System::exec(account.shell(), Array<StringView, 3> { account.shell().view(), "-c"sv, command }, Core::System::SearchInPath::No));
     }
 
     return 1;

--- a/Userland/Utilities/sysctl.cpp
+++ b/Userland/Utilities/sysctl.cpp
@@ -12,7 +12,7 @@
 
 static bool s_set_variable = false;
 
-static DeprecatedString get_variable(StringView name)
+static Optional<DeprecatedString> get_variable(StringView name)
 {
     auto path = DeprecatedString::formatted("/sys/kernel/conf/{}", name);
     auto file = Core::File::open(path, Core::File::OpenMode::Read);
@@ -25,22 +25,22 @@ static DeprecatedString get_variable(StringView name)
         warnln("Failed to read {}: {}", path, buffer.error());
         return {};
     }
-    return { (char const*)buffer.value().data(), buffer.value().size(), Chomp };
+    return DeprecatedString { (char const*)buffer.value().data(), buffer.value().size(), Chomp };
 }
 
 static bool read_variable(StringView name)
 {
     auto value = get_variable(name);
-    if (value.is_null())
+    if (!value.has_value())
         return false;
-    outln("{} = {}", name, value);
+    outln("{} = {}", name, *value);
     return true;
 }
 
 static bool write_variable(StringView name, StringView value)
 {
     auto old_value = get_variable(name);
-    if (old_value.is_null())
+    if (!old_value.has_value())
         return false;
     auto path = DeprecatedString::formatted("/sys/kernel/conf/{}", name);
     auto file = Core::File::open(path, Core::File::OpenMode::Write);
@@ -52,7 +52,7 @@ static bool write_variable(StringView name, StringView value)
         warnln("Failed to write {}: {}", path, result.error());
         return false;
     }
-    outln("{}: {} -> {}", name, old_value, value);
+    outln("{}: {} -> {}", name, *old_value, value);
     return true;
 }
 

--- a/Userland/Utilities/wallpaper.cpp
+++ b/Userland/Utilities/wallpaper.cpp
@@ -22,7 +22,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     bool show_all = false;
     bool show_current = false;
     bool set_random = false;
-    DeprecatedString path;
+    StringView path;
 
     Core::ArgsParser args_parser;
     args_parser.add_option(show_all, "Show all wallpapers", "show-all", 'a');


### PR DESCRIPTION
The (hopefully) uncontroversial part of un-deprecating `DeprecatedString` and calling it `ByteString`.

This PR removes the null state, and converts all its users to either `Optional<DeprecatedString>`, or when unused, simply `DeprecatedString`.

Note that due to the very tangled nature of this change, the second commit can't be meaningfully split.

Also note that this is very lightly tested compared to its API surface, so please review carefully (though I will continue testing it in the meantime). 