### PR TITLE
MacPDF: Make opt-up and opt-down always go to previous / next page

### DIFF
--- a/Meta/Lagom/Contrib/MacPDF/MacPDFView.h
+++ b/Meta/Lagom/Contrib/MacPDF/MacPDFView.h
@@ -23,4 +23,7 @@
 
 - (void)setDelegate:(id<MacPDFViewDelegate>)delegate;
 
+- (IBAction)goToNextPage:(id)sender;
+- (IBAction)goToPreviousPage:(id)sender;
+
 @end

--- a/Meta/Lagom/Contrib/MacPDF/MacPDFView.mm
+++ b/Meta/Lagom/Contrib/MacPDF/MacPDFView.mm
@@ -164,6 +164,12 @@ static NSBitmapImageRep* ns_from_gfx(NonnullRefPtr<Gfx::Bitmap> bitmap_p)
     [self interpretKeyEvents:@[ event ]];
 }
 
+// Called on down arrow.
+- (IBAction)moveDown:(id)sender
+{
+    [self goToNextPage:self];
+}
+
 // Called on left arrow.
 - (IBAction)moveLeft:(id)sender
 {
@@ -174,6 +180,12 @@ static NSBitmapImageRep* ns_from_gfx(NonnullRefPtr<Gfx::Bitmap> bitmap_p)
 - (IBAction)moveRight:(id)sender
 {
     [self goToNextPage:self];
+}
+
+// Called on up arrow.
+- (IBAction)moveUp:(id)sender
+{
+    [self goToPreviousPage:self];
 }
 
 #pragma mark - State restoration

--- a/Meta/Lagom/Contrib/MacPDF/MacPDFView.mm
+++ b/Meta/Lagom/Contrib/MacPDF/MacPDFView.mm
@@ -146,6 +146,18 @@ static NSBitmapImageRep* ns_from_gfx(NonnullRefPtr<Gfx::Bitmap> bitmap_p)
     return YES;
 }
 
+- (IBAction)goToNextPage:(id)sender
+{
+    int current_page = _page_index + 1;
+    [self goToPage:current_page + 1];
+}
+
+- (IBAction)goToPreviousPage:(id)sender
+{
+    int current_page = _page_index + 1;
+    [self goToPage:current_page - 1];
+}
+
 - (void)keyDown:(NSEvent*)event
 {
     // Calls moveLeft: or moveRight: below.
@@ -155,15 +167,13 @@ static NSBitmapImageRep* ns_from_gfx(NonnullRefPtr<Gfx::Bitmap> bitmap_p)
 // Called on left arrow.
 - (IBAction)moveLeft:(id)sender
 {
-    int current_page = _page_index + 1;
-    [self goToPage:current_page - 1];
+    [self goToPreviousPage:self];
 }
 
 // Called on right arrow.
 - (IBAction)moveRight:(id)sender
 {
-    int current_page = _page_index + 1;
-    [self goToPage:current_page + 1];
+    [self goToNextPage:self];
 }
 
 #pragma mark - State restoration

--- a/Meta/Lagom/Contrib/MacPDF/MacPDFWindowController.h
+++ b/Meta/Lagom/Contrib/MacPDF/MacPDFWindowController.h
@@ -18,7 +18,11 @@ NS_ASSUME_NONNULL_BEGIN
 @interface MacPDFWindowController : NSWindowController <MacPDFViewDelegate, NSOutlineViewDelegate, NSToolbarDelegate>
 
 - (instancetype)initWithDocument:(MacPDFDocument*)document;
+
+- (IBAction)goToNextPage:(id)sender;
+- (IBAction)goToPreviousPage:(id)sender;
 - (IBAction)showGoToPageDialog:(id)sender;
+
 - (void)pdfDidInitialize;
 
 @end

--- a/Meta/Lagom/Contrib/MacPDF/MacPDFWindowController.mm
+++ b/Meta/Lagom/Contrib/MacPDF/MacPDFWindowController.mm
@@ -122,6 +122,16 @@
     _outlineView.delegate = self;
 }
 
+- (IBAction)goToNextPage:(id)sender
+{
+    [_pdfView goToNextPage:sender];
+}
+
+- (IBAction)goToPreviousPage:(id)sender
+{
+    [_pdfView goToPreviousPage:sender];
+}
+
 - (IBAction)showGoToPageDialog:(id)sender
 {
     auto alert = [[NSAlert alloc] init];

--- a/Meta/Lagom/Contrib/MacPDF/MainMenu.xib
+++ b/Meta/Lagom/Contrib/MacPDF/MainMenu.xib
@@ -639,10 +639,22 @@
                     <modifierMask key="keyEquivalentModifierMask"/>
                     <menu key="submenu" title="Go" id="u8F-oH-oMu">
                         <items>
-                            <menuItem title="Go to Page…" keyEquivalent="g" id="Ou1-5M-LzJ">
+                            <menuItem title="Previous Page" keyEquivalent="" id="Ou1-5M-LzJ">
+                                <modifierMask key="keyEquivalentModifierMask" option="YES"/>
+                                <connections>
+                                    <action selector="goToPreviousPage:" target="-1" id="e1c-zc-WR6"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Next Page" keyEquivalent="" id="mfm-mG-pLT">
+                                <modifierMask key="keyEquivalentModifierMask" option="YES"/>
+                                <connections>
+                                    <action selector="goToNextPage:" target="-1" id="lt2-m9-Iyp"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Go to Page…" keyEquivalent="g" id="pzP-g1-BeT">
                                 <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
                                 <connections>
-                                    <action selector="showGoToPageDialog:" target="-1" id="hmq-Sy-pJC"/>
+                                    <action selector="showGoToPageDialog:" target="-1" id="fPI-BN-18g"/>
                                 </connections>
                             </menuItem>
                         </items>


### PR DESCRIPTION
When the outline has focus, arrow keys navigate the outline instead
of changing the current page.

Add opt-up and opt-down as a way to move by one page even when the
outline has focus. (This matches Preview.app.)

Also make up and down flip pages when the pdf view has focus,
in addition to left/right and opt-up / opt-down.