### PR TITLE
Userland: Draw tooltip over glyph to show UTF-8 code point in Font Editor

### DIFF
--- a/Userland/Libraries/LibGUI/GlyphMapWidget.cpp
+++ b/Userland/Libraries/LibGUI/GlyphMapWidget.cpp
@@ -247,6 +247,17 @@ void GlyphMapWidget::mouseup_event(GUI::MouseEvent& event)
 void GlyphMapWidget::mousemove_event(GUI::MouseEvent& event)
 {
     m_last_mousemove_position = event.position();
+    if (auto maybe_glyph = glyph_at_position(event.position()); maybe_glyph.has_value() && maybe_glyph != m_tooltip_glyph) {
+        m_tooltip_glyph = maybe_glyph.value();
+        auto draw_tooltip = [this]() -> ErrorOr<void> {
+            StringBuilder builder;
+            TRY(builder.try_appendff("U+{:04X}", m_tooltip_glyph));
+            set_tooltip(TRY(builder.to_string()));
+            return {};
+        }();
+        if (draw_tooltip.is_error())
+            warnln("Failed to draw tooltip");
+    }
     if (m_in_drag_select) {
         auto constrained = event.position().constrained(widget_inner_rect());
         auto glyph = glyph_at_position_clamped(constrained);

--- a/Userland/Libraries/LibGUI/GlyphMapWidget.h
+++ b/Userland/Libraries/LibGUI/GlyphMapWidget.h
@@ -111,6 +111,7 @@ private:
     int m_vertical_spacing { 4 };
     Selection m_selection;
     int m_active_glyph { 0 };
+    int m_tooltip_glyph { 0 };
     int m_visible_glyphs { 0 };
     bool m_in_drag_select { false };
     bool m_highlight_modifications { false };


### PR DESCRIPTION
Currently finding a particular glyph with a given code point is a bit tedious as it requires clicking on the glyph to update the status bar and display the glyph's name and codepoint. A more convenient way to know where we are in the Glyph Map is by seeing a tooltip over the glyph where the mouse is currently hovering over. This patch adds that support by setting the Widget tooltip with the glyph found at the current position in GlyphMapWidget::mousemove_event.

![glyph_tooltip](https://github.com/SerenityOS/serenity/assets/7834601/f3a2a145-29f5-4cdf-be7d-675e1e70323d)
