### PR TITLE
LibWeb/CSS: Parser should treat calc() with flex values as invalid

### DIFF
--- a/Tests/LibWeb/Layout/expected/calc-with-fr.txt
+++ b/Tests/LibWeb/Layout/expected/calc-with-fr.txt
@@ -1,0 +1,30 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x68.40625 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x52.40625 children: not-inline
+      Box <div.container> at (8,8) content-size 784x52.40625 [GFC] children: not-inline
+        BlockContainer <div> at (8,8) content-size 784x17.46875 [BFC] children: inline
+          line 0 width: 6.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [8,8 6.34375x17.46875]
+              "1"
+          TextNode <#text>
+        BlockContainer <div> at (8,25.46875) content-size 784x17.46875 [BFC] children: inline
+          line 0 width: 8.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [8,25.46875 8.8125x17.46875]
+              "2"
+          TextNode <#text>
+        BlockContainer <div> at (8,42.9375) content-size 784x17.46875 [BFC] children: inline
+          line 0 width: 9.09375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [8,42.9375 9.09375x17.46875]
+              "3"
+          TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x68.40625]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x52.40625]
+      PaintableBox (Box<DIV>.container) [8,8 784x52.40625]
+        PaintableWithLines (BlockContainer<DIV>) [8,8 784x17.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [8,25.46875 784x17.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [8,42.9375 784x17.46875]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/input/calc-with-fr.html
+++ b/Tests/LibWeb/Layout/input/calc-with-fr.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html><style>
+    .container {
+        display: grid;
+        grid-template-columns: calc(1fr) calc(1fr);
+    }
+</style>
+<div class="container"><div>1</div><div>2</div><div>3</div></div>

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -6476,8 +6476,14 @@ OwnPtr<CalculationNode> Parser::parse_a_calculation(Vector<ComponentValue> const
             // FIXME: Resolutions, once calc() supports them.
             else if (dimension->is_time())
                 values.append({ NumericCalculationNode::create(dimension->time()) });
-            else
+            else if (dimension->is_flex()) {
+                // https://www.w3.org/TR/css3-grid-layout/#fr-unit
+                // NOTE: <flex> values are not <length>s (nor are they compatible with <length>s, like some <percentage> values),
+                //       so they cannot be represented in or combined with other unit types in calc() expressions.
+                return nullptr;
+            } else {
                 VERIFY_NOT_REACHED();
+            }
             continue;
         }
 


### PR DESCRIPTION
Fixes crash on https://signal.org/