### PR TITLE
LibVideo/VP9: Fix some simple fuzzer issues

### DIFF
--- a/Userland/Libraries/LibVideo/VP9/Decoder.cpp
+++ b/Userland/Libraries/LibVideo/VP9/Decoder.cpp
@@ -1347,9 +1347,9 @@ inline void Decoder::butterfly_rotation_in_place(Span<Intermediate> data, size_t
     auto cos = cos64(angle);
     auto sin = sin64(angle);
     // 1. The variable x is set equal to T[ a ] * cos64( angle ) - T[ b ] * sin64( angle ).
-    i64 rotated_a = data[index_a] * cos - data[index_b] * sin;
+    i64 rotated_a = static_cast<i64>(data[index_a]) * cos - static_cast<i64>(data[index_b]) * sin;
     // 2. The variable y is set equal to T[ a ] * sin64( angle ) + T[ b ] * cos64( angle ).
-    i64 rotated_b = data[index_a] * sin + data[index_b] * cos;
+    i64 rotated_b = static_cast<i64>(data[index_a]) * sin + static_cast<i64>(data[index_b]) * cos;
     // 3. T[ a ] is set equal to Round2( x, 14 ).
     data[index_a] = rounded_right_shift(rotated_a, 14);
     // 4. T[ b ] is set equal to Round2( y, 14 ).

--- a/Userland/Libraries/LibVideo/VP9/Parser.cpp
+++ b/Userland/Libraries/LibVideo/VP9/Parser.cpp
@@ -1409,6 +1409,9 @@ DecoderErrorOr<bool> Parser::residual(BlockContext& block_context, bool has_bloc
         auto plane_subsampling_x = (plane > 0) ? block_context.frame_context.color_config.subsampling_x : false;
         auto plane_subsampling_y = (plane > 0) ? block_context.frame_context.color_config.subsampling_y : false;
         auto plane_size = get_subsampled_block_size(block_context.size, plane_subsampling_x, plane_subsampling_y);
+        if (plane_size == Block_Invalid) {
+            return DecoderError::corrupted("Invalid block size"sv);
+        }
         auto transform_size = get_uv_transform_size(block_context.transform_size, plane_size);
         auto transform_size_in_sub_blocks = transform_size_to_sub_blocks(transform_size);
         auto block_size_in_sub_blocks = block_size_to_sub_blocks(plane_size);

--- a/Userland/Libraries/LibVideo/VP9/Parser.cpp
+++ b/Userland/Libraries/LibVideo/VP9/Parser.cpp
@@ -355,7 +355,7 @@ DecoderErrorOr<ColorConfig> Parser::parse_color_config(BigEndianInputBitStream& 
                 return DecoderError::corrupted("color_config: RGB reserved zero was set"sv);
         } else {
             // FIXME: Spec does not specify the subsampling value here. Is this an error or should we set a default?
-            VERIFY_NOT_REACHED();
+            return DecoderError::corrupted("color_config: Invalid subsampling value for profile 0 or 2"sv);
         }
     }
 


### PR DESCRIPTION
This PR makes 3 simple changes to VP9 decoding.

* We now return an error when the color config for a frame has an invalid chroma subsampling format. I left the FIXME in place here, as what it says is still true. I had a quick look at `libvpx` and it also [returns an error in this case](https://github.com/webmproject/libvpx/blob/7c31749387e0297a16289ba851559df4fd2f935d/vp9/decoder/vp9_decodeframe.c#L2615)
* Overflow is now avoided when performing in place butterfly rotation.
* A check for an invalid block size is now performed after calling `Parser::get_subsampled_block_size()`

Fixes oss fuzz issues: [62054](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=62054), [60386](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=60386), [56672](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=56672), [52630](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=52630), [58377](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=58377) and [53977](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=53977)