### PR TITLE
MacPDF: Save currently expanded outline items

### DIFF
--- a/Meta/Lagom/Contrib/MacPDF/MacPDFOutlineViewDataSource.mm
+++ b/Meta/Lagom/Contrib/MacPDF/MacPDFOutlineViewDataSource.mm
@@ -8,18 +8,23 @@
 
 @interface OutlineItemWrapper ()
 {
-    // Only one of those two is set.
-    RefPtr<PDF::OutlineItem> _item;
+    // Either _groupName or the other fields are set.
     NSString* _groupName;
+
+    RefPtr<PDF::OutlineItem> _item;
+    NSInteger _index;
+    __weak OutlineItemWrapper* _parent;
 }
 @end
 
 @implementation OutlineItemWrapper
-- (instancetype)initWithItem:(NonnullRefPtr<PDF::OutlineItem>)item
+- (instancetype)initWithItem:(NonnullRefPtr<PDF::OutlineItem>)item index:(NSInteger)index parent:(OutlineItemWrapper*)parent
 {
     if (self = [super init]; !self)
         return nil;
     _item = move(item);
+    _index = index;
+    _parent = parent;
     _groupName = nil;
     return self;
 }
@@ -62,6 +67,16 @@
         return _groupName;
     return [NSString stringWithFormat:@"%s", _item->title.characters()]; // FIXME: encoding?
 }
+
+- (NSInteger)index
+{
+    return _index;
+}
+
+- (OutlineItemWrapper*)parent
+{
+    return _parent;
+}
 @end
 
 @interface MacPDFOutlineViewDataSource ()
@@ -88,7 +103,7 @@
     if (item) {
         auto item_wrapper = (OutlineItemWrapper*)item;
         return _wrappers.ensure([item_wrapper child:index].ptr(), [&]() {
-            return [[OutlineItemWrapper alloc] initWithItem:[item_wrapper child:index]];
+            return [[OutlineItemWrapper alloc] initWithItem:[item_wrapper child:index] index:index parent:item_wrapper];
         });
     }
 
@@ -101,7 +116,7 @@
     }
 
     return _wrappers.ensure(_outline->children[index - 1].ptr(), [&]() {
-        return [[OutlineItemWrapper alloc] initWithItem:_outline->children[index - 1]];
+        return [[OutlineItemWrapper alloc] initWithItem:_outline->children[index - 1] index:index - 1 parent:nil];
     });
 }
 
@@ -121,6 +136,31 @@
 - (id)outlineView:(NSOutlineView*)outlineView objectValueForTableColumn:(nullable NSTableColumn*)tableColumn byItem:(nullable id)item
 {
     return [(OutlineItemWrapper*)item objectValue];
+}
+
+- (id)outlineView:(NSOutlineView*)outlineView itemForPersistentObject:(id)object
+{
+    OutlineItemWrapper* outline_item = nil;
+    for (NSNumber* number in object) {
+        NSInteger index = number.integerValue;
+        if (!outline_item)
+            ++index;
+        if (index >= [self outlineView:outlineView numberOfChildrenOfItem:outline_item])
+            return nil;
+        outline_item = [self outlineView:outlineView child:index ofItem:outline_item];
+    }
+    return outline_item;
+}
+
+- (id)outlineView:(NSOutlineView*)outlineView persistentObjectForItem:(id)item
+{
+    NSMutableArray* array = [@[] mutableCopy];
+    OutlineItemWrapper* outline_item = item;
+    while (outline_item) {
+        [array addObject:@(outline_item.index)];
+        outline_item = outline_item.parent;
+    }
+    return [[array reverseObjectEnumerator] allObjects];
 }
 
 @end

--- a/Meta/Lagom/Contrib/MacPDF/MacPDFOutlineViewDataSource.mm
+++ b/Meta/Lagom/Contrib/MacPDF/MacPDFOutlineViewDataSource.mm
@@ -44,9 +44,9 @@
     return _item->dest.page.map([](u32 page_index) { return page_index + 1; });
 }
 
-- (OutlineItemWrapper*)child:(NSInteger)index
+- (NonnullRefPtr<PDF::OutlineItem>)child:(NSInteger)index
 {
-    return [[OutlineItemWrapper alloc] initWithItem:_item->children[index]];
+    return _item->children[index];
 }
 
 - (NSInteger)numberOfChildren
@@ -85,7 +85,7 @@
 - (id)outlineView:(NSOutlineView*)outlineView child:(NSInteger)index ofItem:(nullable id)item
 {
     if (item)
-        return [(OutlineItemWrapper*)item child:index];
+        return [[OutlineItemWrapper alloc] initWithItem:[(OutlineItemWrapper*)item child:index]];
 
     if (index == 0) {
         bool has_outline = _outline && !_outline->children.is_empty();

--- a/Meta/Lagom/Contrib/MacPDF/MacPDFWindowController.mm
+++ b/Meta/Lagom/Contrib/MacPDF/MacPDFWindowController.mm
@@ -74,8 +74,6 @@
     _outlineView.focusRingType = NSFocusRingTypeNone;
     _outlineView.headerView = nil;
 
-    // FIXME: Implement data source support for autosaveExpandedItems and use that.
-
     // rowSizeStyle does not default to NSTableViewRowSizeStyleDefault, but needs to be set to it for outline views in sourcelist style.
     _outlineView.rowSizeStyle = NSTableViewRowSizeStyleDefault;
 
@@ -120,6 +118,8 @@
     _outlineDataSource = [[MacPDFOutlineViewDataSource alloc] initWithOutline:_pdfDocument.pdf->outline()];
     _outlineView.dataSource = _outlineDataSource;
     _outlineView.delegate = self;
+    _outlineView.autosaveName = @"OutlineView";
+    _outlineView.autosaveExpandedItems = YES;
 }
 
 - (IBAction)showGoToPageDialog:(id)sender


### PR DESCRIPTION
The implementation is fairly generic and should work for most outline
views: For every expanded item, it stores the list of indices to
reach that item.

This makes me wonder why I have to implement these methods instead
of the framework doing it, and I worry I'm misunderstanding something.
It seems to mostly work, though.

If a document's outline changes, we'll open different subsections
when restoring. That's likely very rare and seems fine. (But maybe
that's why this isn't the default implementation.)

One thing that doesn't work: If expanding one item and then expanding
one of its children and closing the outer item again, then the code
correctly serializes and deserializes that the grandchild should be
open when the child is opened. However, when I expand the child,
the grandchild is still closed. Maybe the framework intentionally
doesn't "half-restore" such expansion states?

Preview.app doesn't save expansion state across restarts.

---

(Notes.app and Xcode's Project (Cmd-1) navigator do remember expansion state for example, though.)

The scroll view doesn't save its current scroll position. Maybe that's too much though; nothing else seems to do this. 

The outline view doesn't save the current selection, but we'll get that part once we update the outline selection on page number change (since we do restore the currently-open page). And that'll at least scroll the currently-selected outline item into view, which is probably better than restoring the current scroll state (?)