### PR TITLE
AK: Fix one-off error in BitmapView::find_first and find_one_anywhere

### DIFF
--- a/AK/BitmapView.h
+++ b/AK/BitmapView.h
@@ -94,7 +94,7 @@ public:
     Optional<size_t> find_one_anywhere(size_t hint = 0) const
     {
         VERIFY(hint < m_size);
-        u8 const* end = &m_data[m_size / 8];
+        u8 const* end = &m_data[size_in_bytes()];
 
         for (;;) {
             // We will use hint as what it is: a hint. Because we try to
@@ -128,7 +128,7 @@ public:
                 // We didn't find anything, check the remaining few bytes (if any)
                 u8 byte = VALUE ? 0x00 : 0xff;
                 size_t i = reinterpret_cast<u8 const*>(ptr_large) - &m_data[0];
-                size_t byte_count = m_size / 8;
+                size_t byte_count = size_in_bytes();
                 VERIFY(i <= byte_count);
                 while (i < byte_count && m_data[i] == byte)
                     i++;
@@ -171,7 +171,7 @@ public:
     template<bool VALUE>
     Optional<size_t> find_first() const
     {
-        size_t byte_count = m_size / 8;
+        size_t byte_count = size_in_bytes();
         size_t i = 0;
 
         u8 byte = VALUE ? 0x00 : 0xff;

--- a/Tests/AK/TestBitmap.cpp
+++ b/Tests/AK/TestBitmap.cpp
@@ -276,3 +276,21 @@ TEST_CASE(byte_aligned_access)
         EXPECT_EQ(bitmap.count_in_range(4, 4, true), 1u);
     }
 }
+
+TEST_CASE(find_one_anywhere_edge_case)
+{
+    {
+        auto bitmap = MUST(Bitmap::create(1, false));
+        bitmap.set(0, false);
+        EXPECT_EQ(bitmap.find_one_anywhere_unset(0).value(), 0UL);
+    }
+}
+
+TEST_CASE(find_first_edge_case)
+{
+    {
+        auto bitmap = MUST(Bitmap::create(1, false));
+        bitmap.set(0, false);
+        EXPECT_EQ(bitmap.find_first_unset().value(), 0UL);
+    }
+}


### PR DESCRIPTION
The mentioned functions used `m_size / 8` instead of `size_in_bytes()` (division with ceiling rounding mode), which resulted in an off-by-one error such that the functions didn't search in the last not-fully-8-bits byte.

Using `size_in_bytes()` instead of `m_size / 8` fixes this.

----

This was found using `RANDOMIZED_TEST_CASE` ([PR ready for review](https://github.com/SerenityOS/serenity/pull/21191)). I'd appreciate reviews there as well, so that I could commit the [randomized tests](https://github.com/Janiczek/serenity/pull/1/commits/79e8558a184dcee7377f13df3ea76bfeb72a65e4#diff-9796918a9e6f7c66e80c102f79cb8f2bcedc9986ced7e169c37b91d9a25164e0R325-R374) that found the issue as well!