### PR TITLE
Shell: Add a 'in_parallel' builtin for easy concurrency

### DIFF
--- a/Userland/Shell/Shell.h
+++ b/Userland/Shell/Shell.h
@@ -64,6 +64,7 @@
     __ENUMERATE_SHELL_BUILTIN(read, OnlyInPOSIXMode)         \
     __ENUMERATE_SHELL_BUILTIN(run_with_env, OnlyInPOSIXMode) \
     __ENUMERATE_SHELL_BUILTIN(argsparser_parse, InAllModes)  \
+    __ENUMERATE_SHELL_BUILTIN(in_parallel, InAllModes)       \
     __ENUMERATE_SHELL_BUILTIN(shell_set_active_prompt, InAllModes)
 
 #define ENUMERATE_SHELL_OPTIONS()                                                                                    \


### PR DESCRIPTION
I'm sick of GNU parallel, so here's a better option.
![image](https://github.com/SerenityOS/serenity/assets/14001776/71833370-8e28-4d49-88fd-9a98264d6131)
