### PR TITLE
LibGfx: Remove indexed palette formats from Bitmap and Painter

### DIFF
--- a/Userland/Applets/ClipboardHistory/ClipboardHistoryModel.cpp
+++ b/Userland/Applets/ClipboardHistory/ClipboardHistoryModel.cpp
@@ -44,14 +44,6 @@ static StringView bpp_for_format_resilient(DeprecatedString format)
     unsigned format_uint = format.to_uint().value_or(static_cast<unsigned>(Gfx::BitmapFormat::Invalid));
     // Cannot use Gfx::Bitmap::bpp_for_format here, as we have to accept invalid enum values.
     switch (static_cast<Gfx::BitmapFormat>(format_uint)) {
-    case Gfx::BitmapFormat::Indexed1:
-        return "1"sv;
-    case Gfx::BitmapFormat::Indexed2:
-        return "2"sv;
-    case Gfx::BitmapFormat::Indexed4:
-        return "4"sv;
-    case Gfx::BitmapFormat::Indexed8:
-        return "8"sv;
     case Gfx::BitmapFormat::BGRx8888:
     case Gfx::BitmapFormat::BGRA8888:
         return "32"sv;

--- a/Userland/Libraries/LibGUI/Clipboard.cpp
+++ b/Userland/Libraries/LibGUI/Clipboard.cpp
@@ -102,10 +102,6 @@ RefPtr<Gfx::Bitmap> Clipboard::DataAndType::as_bitmap() const
     if (!Gfx::is_valid_bitmap_format(format.value()))
         return nullptr;
     auto bitmap_format = (Gfx::BitmapFormat)format.value();
-    // We cannot handle indexed bitmaps, as the palette would be lost.
-    // Thankfully, everything that copies bitmaps also transforms them to RGB beforehand.
-    if (Gfx::determine_storage_format(bitmap_format) == Gfx::StorageFormat::Indexed8)
-        return nullptr;
 
     // We won't actually write to the clipping_bitmap, so casting away the const is okay.
     auto clipping_data = const_cast<u8*>(data.data());

--- a/Userland/Libraries/LibGUI/Window.cpp
+++ b/Userland/Libraries/LibGUI/Window.cpp
@@ -1025,7 +1025,7 @@ ErrorOr<NonnullOwnPtr<WindowBackingStore>> Window::create_backing_store(Gfx::Int
     auto buffer = TRY(Core::AnonymousBuffer::create_with_size(round_up_to_power_of_two(size_in_bytes, PAGE_SIZE)));
 
     // FIXME: Plumb scale factor here eventually.
-    auto bitmap = TRY(Gfx::Bitmap::create_with_anonymous_buffer(format, buffer, size, 1, {}));
+    auto bitmap = TRY(Gfx::Bitmap::create_with_anonymous_buffer(format, buffer, size, 1));
     return make<WindowBackingStore>(bitmap);
 }
 

--- a/Userland/Libraries/LibGfx/ImageFormats/BMPLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/BMPLoader.cpp
@@ -1236,13 +1236,10 @@ static ErrorOr<void> decode_bmp_pixel_data(BMPLoadingContext& context)
 
         switch (bits_per_pixel) {
         case 1:
-            return BitmapFormat::Indexed1;
         case 2:
-            return BitmapFormat::Indexed2;
         case 4:
-            return BitmapFormat::Indexed4;
         case 8:
-            return BitmapFormat::Indexed8;
+            return BitmapFormat::BGRx8888;
         case 16:
             if (context.dib.info.masks.size() == 4)
                 return BitmapFormat::BGRA8888;
@@ -1303,14 +1300,10 @@ static ErrorOr<void> decode_bmp_pixel_data(BMPLoadingContext& context)
                 while (column < width && mask > 0) {
                     mask -= 1;
                     size_t color_idx = (byte >> mask) & 0x1;
-                    if (context.is_included_in_ico) {
-                        if (color_idx >= context.color_table.size())
-                            return Error::from_string_literal("Invalid color table index");
-                        auto color = context.color_table[color_idx];
-                        context.bitmap->scanline(row)[column++] = color;
-                    } else {
-                        context.bitmap->scanline_u8(row)[column++] = color_idx;
-                    }
+                    if (color_idx >= context.color_table.size())
+                        return Error::from_string_literal("Invalid color table index");
+                    auto color = context.color_table[color_idx];
+                    context.bitmap->scanline(row)[column++] = color;
                 }
                 break;
             }
@@ -1322,14 +1315,10 @@ static ErrorOr<void> decode_bmp_pixel_data(BMPLoadingContext& context)
                 while (column < width && mask > 0) {
                     mask -= 2;
                     size_t color_idx = (byte >> mask) & 0x3;
-                    if (context.is_included_in_ico) {
-                        if (color_idx >= context.color_table.size())
-                            return Error::from_string_literal("Invalid color table index");
-                        auto color = context.color_table[color_idx];
-                        context.bitmap->scanline(row)[column++] = color;
-                    } else {
-                        context.bitmap->scanline_u8(row)[column++] = color_idx;
-                    }
+                    if (color_idx >= context.color_table.size())
+                        return Error::from_string_literal("Invalid color table index");
+                    auto color = context.color_table[color_idx];
+                    context.bitmap->scanline(row)[column++] = color;
                 }
                 break;
             }
@@ -1342,19 +1331,13 @@ static ErrorOr<void> decode_bmp_pixel_data(BMPLoadingContext& context)
                 u32 high_color_idx = (byte >> 4) & 0xf;
                 u32 low_color_idx = byte & 0xf;
 
-                if (context.is_included_in_ico) {
-                    if (high_color_idx >= context.color_table.size() || low_color_idx >= context.color_table.size())
-                        return Error::from_string_literal("Invalid color table index");
-                    auto high_color = context.color_table[high_color_idx];
-                    auto low_color = context.color_table[low_color_idx];
-                    context.bitmap->scanline(row)[column++] = high_color;
-                    if (column < width) {
-                        context.bitmap->scanline(row)[column++] = low_color;
-                    }
-                } else {
-                    context.bitmap->scanline_u8(row)[column++] = high_color_idx;
-                    if (column < width)
-                        context.bitmap->scanline_u8(row)[column++] = low_color_idx;
+                if (high_color_idx >= context.color_table.size() || low_color_idx >= context.color_table.size())
+                    return Error::from_string_literal("Invalid color table index");
+                auto high_color = context.color_table[high_color_idx];
+                auto low_color = context.color_table[low_color_idx];
+                context.bitmap->scanline(row)[column++] = high_color;
+                if (column < width) {
+                    context.bitmap->scanline(row)[column++] = low_color;
                 }
                 break;
             }
@@ -1363,14 +1346,10 @@ static ErrorOr<void> decode_bmp_pixel_data(BMPLoadingContext& context)
                     return Error::from_string_literal("Cannot read 8 bits");
 
                 u8 byte = streamer.read_u8();
-                if (context.is_included_in_ico) {
-                    if (byte >= context.color_table.size())
-                        return Error::from_string_literal("Invalid color table index");
-                    auto color = context.color_table[byte];
-                    context.bitmap->scanline(row)[column++] = color;
-                } else {
-                    context.bitmap->scanline_u8(row)[column++] = byte;
-                }
+                if (byte >= context.color_table.size())
+                    return Error::from_string_literal("Invalid color table index");
+                auto color = context.color_table[byte];
+                context.bitmap->scanline(row)[column++] = color;
                 break;
             }
             case 16: {
@@ -1454,12 +1433,6 @@ static ErrorOr<void> decode_bmp_pixel_data(BMPLoadingContext& context)
             for (i32 row = height - 1; row >= 0; --row) {
                 TRY(process_mask_row(row));
             }
-        }
-    }
-
-    if (!context.is_included_in_ico) {
-        for (size_t i = 0; i < context.color_table.size(); ++i) {
-            context.bitmap->set_palette_color(i, Color::from_rgb(context.color_table[i]));
         }
     }
 

--- a/Userland/Libraries/LibGfx/ImageFormats/WebPLoaderLossless.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/WebPLoaderLossless.cpp
@@ -888,8 +888,6 @@ ErrorOr<NonnullOwnPtr<ColorIndexingTransform>> ColorIndexingTransform::read(Litt
 
 ErrorOr<NonnullRefPtr<Bitmap>> ColorIndexingTransform::transform(NonnullRefPtr<Bitmap> bitmap)
 {
-    // FIXME: If this is the last transform, consider returning an Indexed8 bitmap here?
-
     if (pixels_per_pixel() == 1) {
         for (ARGB32& pixel : *bitmap) {
             // "The inverse transform for the image is simply replacing the pixel values (which are indices to the color table)

--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -63,14 +63,6 @@ ALWAYS_INLINE static Color color_for_format(BitmapFormat format, ARGB32 value)
 template<BitmapFormat format = BitmapFormat::Invalid>
 ALWAYS_INLINE Color get_pixel(Gfx::Bitmap const& bitmap, int x, int y)
 {
-    if constexpr (format == BitmapFormat::Indexed8)
-        return bitmap.palette_color(bitmap.scanline_u8(y)[x]);
-    if constexpr (format == BitmapFormat::Indexed4)
-        return bitmap.palette_color(bitmap.scanline_u8(y)[x]);
-    if constexpr (format == BitmapFormat::Indexed2)
-        return bitmap.palette_color(bitmap.scanline_u8(y)[x]);
-    if constexpr (format == BitmapFormat::Indexed1)
-        return bitmap.palette_color(bitmap.scanline_u8(y)[x]);
     if constexpr (format == BitmapFormat::BGRx8888)
         return Color::from_rgb(bitmap.scanline(y)[x]);
     if constexpr (format == BitmapFormat::BGRA8888)
@@ -1126,18 +1118,6 @@ void Painter::blit(IntPoint position, Gfx::Bitmap const& source, IntRect const& 
         return;
     }
 
-    if (Bitmap::is_indexed(source.format())) {
-        u8 const* src = source.scanline_u8(src_rect.top() + first_row) + src_rect.left() + first_column;
-        size_t const src_skip = source.pitch();
-        for (int row = first_row; row <= last_row; ++row) {
-            for (int i = 0; i < clipped_rect.width(); ++i)
-                dst[i] = source.palette_color(src[i]).value();
-            dst += dst_skip;
-            src += src_skip;
-        }
-        return;
-    }
-
     VERIFY_NOT_REACHED();
 }
 
@@ -1373,18 +1353,6 @@ void Painter::draw_scaled_bitmap(IntRect const& a_dst_rect, Gfx::Bitmap const& s
         case BitmapFormat::BGRA8888:
             do_draw_scaled_bitmap<true>(*m_target, dst_rect, clipped_rect, source, src_rect, Gfx::get_pixel<BitmapFormat::BGRA8888>, opacity, scaling_mode);
             break;
-        case BitmapFormat::Indexed8:
-            do_draw_scaled_bitmap<true>(*m_target, dst_rect, clipped_rect, source, src_rect, Gfx::get_pixel<BitmapFormat::Indexed8>, opacity, scaling_mode);
-            break;
-        case BitmapFormat::Indexed4:
-            do_draw_scaled_bitmap<true>(*m_target, dst_rect, clipped_rect, source, src_rect, Gfx::get_pixel<BitmapFormat::Indexed4>, opacity, scaling_mode);
-            break;
-        case BitmapFormat::Indexed2:
-            do_draw_scaled_bitmap<true>(*m_target, dst_rect, clipped_rect, source, src_rect, Gfx::get_pixel<BitmapFormat::Indexed2>, opacity, scaling_mode);
-            break;
-        case BitmapFormat::Indexed1:
-            do_draw_scaled_bitmap<true>(*m_target, dst_rect, clipped_rect, source, src_rect, Gfx::get_pixel<BitmapFormat::Indexed1>, opacity, scaling_mode);
-            break;
         default:
             do_draw_scaled_bitmap<true>(*m_target, dst_rect, clipped_rect, source, src_rect, Gfx::get_pixel<BitmapFormat::Invalid>, opacity, scaling_mode);
             break;
@@ -1393,9 +1361,6 @@ void Painter::draw_scaled_bitmap(IntRect const& a_dst_rect, Gfx::Bitmap const& s
         switch (source.format()) {
         case BitmapFormat::BGRx8888:
             do_draw_scaled_bitmap<false>(*m_target, dst_rect, clipped_rect, source, src_rect, Gfx::get_pixel<BitmapFormat::BGRx8888>, opacity, scaling_mode);
-            break;
-        case BitmapFormat::Indexed8:
-            do_draw_scaled_bitmap<false>(*m_target, dst_rect, clipped_rect, source, src_rect, Gfx::get_pixel<BitmapFormat::Indexed8>, opacity, scaling_mode);
             break;
         default:
             do_draw_scaled_bitmap<false>(*m_target, dst_rect, clipped_rect, source, src_rect, Gfx::get_pixel<BitmapFormat::Invalid>, opacity, scaling_mode);

--- a/Userland/Libraries/LibGfx/ShareableBitmap.cpp
+++ b/Userland/Libraries/LibGfx/ShareableBitmap.cpp
@@ -34,11 +34,6 @@ ErrorOr<void> encode(Encoder& encoder, Gfx::ShareableBitmap const& shareable_bit
     TRY(encoder.encode(bitmap.size()));
     TRY(encoder.encode(static_cast<u32>(bitmap.scale())));
     TRY(encoder.encode(static_cast<u32>(bitmap.format())));
-    if (bitmap.is_indexed()) {
-        auto palette = bitmap.palette_to_vector();
-        TRY(encoder.encode(palette));
-    }
-
     return {};
 }
 
@@ -57,12 +52,8 @@ ErrorOr<Gfx::ShareableBitmap> decode(Decoder& decoder)
 
     auto bitmap_format = static_cast<Gfx::BitmapFormat>(raw_bitmap_format);
 
-    Vector<Gfx::ARGB32> palette;
-    if (Gfx::Bitmap::is_indexed(bitmap_format))
-        palette = TRY(decoder.decode<decltype(palette)>());
-
     auto buffer = TRY(Core::AnonymousBuffer::create_from_anon_fd(anon_file.take_fd(), Gfx::Bitmap::size_in_bytes(Gfx::Bitmap::minimum_pitch(size.width() * scale, bitmap_format), size.height() * scale)));
-    auto bitmap = TRY(Gfx::Bitmap::create_with_anonymous_buffer(bitmap_format, move(buffer), size, scale, palette));
+    auto bitmap = TRY(Gfx::Bitmap::create_with_anonymous_buffer(bitmap_format, move(buffer), size, scale));
 
     return Gfx::ShareableBitmap { move(bitmap), Gfx::ShareableBitmap::ConstructWithKnownGoodBitmap };
 }

--- a/Userland/Services/WindowServer/ConnectionFromClient.cpp
+++ b/Userland/Services/WindowServer/ConnectionFromClient.cpp
@@ -778,8 +778,7 @@ void ConnectionFromClient::set_window_backing_store(i32 window_id, [[maybe_unuse
             has_alpha_channel ? Gfx::BitmapFormat::BGRA8888 : Gfx::BitmapFormat::BGRx8888,
             buffer_or_error.release_value(),
             size,
-            1,
-            {});
+            1);
         if (backing_store_or_error.is_error()) {
             did_misbehave("");
         }

--- a/Userland/Utilities/image.cpp
+++ b/Userland/Utilities/image.cpp
@@ -71,11 +71,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     if (move_alpha_to_rgb) {
         switch (frame->format()) {
         case Gfx::BitmapFormat::Invalid:
-        case Gfx::BitmapFormat::Indexed1:
-        case Gfx::BitmapFormat::Indexed2:
-        case Gfx::BitmapFormat::Indexed4:
-        case Gfx::BitmapFormat::Indexed8:
-            warnln("Can't --strip-alpha with indexed or invalid bitmaps");
+            warnln("Can't --strip-alpha with invalid bitmaps");
             return 1;
         case Gfx::BitmapFormat::RGBA8888:
             // No image decoder currently produces bitmaps with this format.
@@ -96,11 +92,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     if (strip_alpha) {
         switch (frame->format()) {
         case Gfx::BitmapFormat::Invalid:
-        case Gfx::BitmapFormat::Indexed1:
-        case Gfx::BitmapFormat::Indexed2:
-        case Gfx::BitmapFormat::Indexed4:
-        case Gfx::BitmapFormat::Indexed8:
-            warnln("Can't --strip-alpha with indexed or invalid bitmaps");
+            warnln("Can't --strip-alpha with invalid bitmaps");
             return 1;
         case Gfx::BitmapFormat::RGBA8888:
             // No image decoder currently produces bitmaps with this format.


### PR DESCRIPTION
These are only used by the BMP image decoder, which already has a path for decoding to BGRA8888 which we can simply reuse for every input format.