### PR TITLE
LibWeb: Store the SVG `<use>` element's referenced ID as a FlyString

### DIFF
--- a/Userland/Libraries/LibWeb/SVG/SVGUseElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGUseElement.cpp
@@ -62,14 +62,15 @@ void SVGUseElement::attribute_changed(FlyString const& name, DeprecatedString co
     }
 }
 
-Optional<StringView> SVGUseElement::parse_id_from_href(DeprecatedString const& href)
+Optional<FlyString> SVGUseElement::parse_id_from_href(DeprecatedString const& href)
 {
     auto id_seperator = href.find('#');
     if (!id_seperator.has_value()) {
         return {};
     }
 
-    return href.substring_view(id_seperator.value() + 1);
+    auto id = href.substring_view(id_seperator.value() + 1);
+    return MUST(FlyString::from_utf8(id));
 }
 
 Gfx::AffineTransform SVGUseElement::element_transform() const
@@ -115,7 +116,7 @@ JS::GCPtr<DOM::Element> SVGUseElement::referenced_element()
     }
 
     // FIXME: Support loading of external svg documents
-    return document().get_element_by_id(MUST(FlyString::from_utf8(m_referenced_id.value())));
+    return document().get_element_by_id(m_referenced_id.value());
 }
 
 // https://svgwg.org/svg2-draft/struct.html#UseShadowTree

--- a/Userland/Libraries/LibWeb/SVG/SVGUseElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGUseElement.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/FlyString.h>
 #include <LibGfx/Path.h>
 #include <LibWeb/DOM/DocumentObserver.h>
 #include <LibWeb/SVG/SVGAnimatedLength.h>
@@ -46,7 +47,7 @@ private:
 
     virtual JS::GCPtr<Layout::Node> create_layout_node(NonnullRefPtr<CSS::StyleProperties>) override;
 
-    Optional<StringView> parse_id_from_href(DeprecatedString const& href);
+    Optional<FlyString> parse_id_from_href(DeprecatedString const& href);
 
     JS::GCPtr<DOM::Element> referenced_element();
 
@@ -56,7 +57,7 @@ private:
     Optional<float> m_x;
     Optional<float> m_y;
 
-    Optional<StringView> m_referenced_id;
+    Optional<FlyString> m_referenced_id;
 
     JS::GCPtr<DOM::DocumentObserver> m_document_observer;
 };


### PR DESCRIPTION
We currently store a `StringView` into the `DeprecatedString` provided to `SVGUseElement::attribute_changed`. This is a temporary string created by `String::to_deprecated_string`, so this `StringView` is always a dangling pointer.

Instead, since this string value is an ID and is primarily used as a `FlyString`, store it as a `FlyString` from the get-go.

Fixes #21413.