### PR TITLE
LibVideo/VP9: Ensure color space is not set to reserved value

### DIFF
--- a/Userland/Libraries/LibVideo/VP9/Parser.cpp
+++ b/Userland/Libraries/LibVideo/VP9/Parser.cpp
@@ -330,6 +330,9 @@ DecoderErrorOr<ColorConfig> Parser::parse_color_config(BigEndianInputBitStream& 
     }
 
     auto color_space = static_cast<ColorSpace>(TRY_READ(bit_stream.read_bits(3)));
+    if (color_space == ColorSpace::Reserved)
+        return DecoderError::corrupted("color_config: Color space reserved value was set"sv);
+
     VERIFY(color_space <= ColorSpace::RGB);
 
     VideoFullRangeFlag video_full_range_flag;


### PR DESCRIPTION
This fixes oss fuzz issue [63182](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=63182)