### PR TITLE
LibWeb: Font family fallback if found font has missing glyphs

### DIFF
--- a/Tests/LibWeb/Layout/expected/css-dir-selector.txt
+++ b/Tests/LibWeb/Layout/expected/css-dir-selector.txt
@@ -2,82 +2,70 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (100,0) content-size 700x832 [BFC] children: not-inline
     BlockContainer <body> at (200,8) content-size 592x816 children: not-inline
       BlockContainer <div> at (301,9) content-size 100x100 children: inline
-        line 0 width: 79.96875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-          frag 0 from TextNode start: 0, length: 11, rect: [301,9 79.96875x17.46875]
-            "Well, hello"
-        line 1 width: 59.21875, height: 17.9375, bottom: 35.40625, baseline: 13.53125
-          frag 0 from TextNode start: 12, length: 8, rect: [301,26 59.21875x17.46875]
-            "friends!"
+        line 0 width: 100, height: 14, bottom: 14, baseline: 10
+          frag 0 from TextNode start: 0, length: 20, rect: [301,9 100x14]
+            "Well, hello friends!"
         TextNode <#text>
       BlockContainer <(anonymous)> at (200,110) content-size 592x0 children: inline
         TextNode <#text>
       BlockContainer <div> at (301,111) content-size 100x100 children: inline
-        line 0 width: 79.96875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-          frag 0 from TextNode start: 0, length: 11, rect: [301,111 79.96875x17.46875]
-            "Well, hello"
-        line 1 width: 59.21875, height: 17.9375, bottom: 35.40625, baseline: 13.53125
-          frag 0 from TextNode start: 12, length: 8, rect: [301,128 59.21875x17.46875]
-            "friends!"
+        line 0 width: 100, height: 14, bottom: 14, baseline: 10
+          frag 0 from TextNode start: 0, length: 20, rect: [301,111 100x14]
+            "Well, hello friends!"
         TextNode <#text>
       BlockContainer <(anonymous)> at (200,212) content-size 592x0 children: inline
         TextNode <#text>
       BlockContainer <div> at (401,213) content-size 100x100 children: inline
-        line 0 width: 79.96875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-          frag 0 from TextNode start: 0, length: 11, rect: [401,213 79.96875x17.46875]
-            "Well, hello"
-        line 1 width: 59.21875, height: 17.9375, bottom: 35.40625, baseline: 13.53125
-          frag 0 from TextNode start: 12, length: 8, rect: [401,230 59.21875x17.46875]
-            "friends!"
+        line 0 width: 100, height: 14, bottom: 14, baseline: 10
+          frag 0 from TextNode start: 0, length: 20, rect: [401,213 100x14]
+            "Well, hello friends!"
         TextNode <#text>
       BlockContainer <(anonymous)> at (200,314) content-size 592x0 children: inline
         TextNode <#text>
       BlockContainer <div> at (301,315) content-size 100x100 children: inline
-        line 0 width: 79.96875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-          frag 0 from TextNode start: 0, length: 11, rect: [301,315 79.96875x17.46875]
-            "Well, hello"
-        line 1 width: 59.21875, height: 17.9375, bottom: 35.40625, baseline: 13.53125
-          frag 0 from TextNode start: 12, length: 8, rect: [301,332 59.21875x17.46875]
-            "friends!"
+        line 0 width: 100, height: 14, bottom: 14, baseline: 10
+          frag 0 from TextNode start: 0, length: 20, rect: [301,315 100x14]
+            "Well, hello friends!"
         TextNode <#text>
       BlockContainer <(anonymous)> at (200,416) content-size 592x0 children: inline
         TextNode <#text>
       BlockContainer <div> at (301,417) content-size 100x100 children: inline
-        line 0 width: 86.125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-          frag 0 from TextNode start: 0, length: 26, rect: [301,417 86.125x17.46875]
-            "حسنًا ، مرحباً"
-        line 1 width: 78.125, height: 17.9375, bottom: 35.40625, baseline: 13.53125
-          frag 0 from TextNode start: 27, length: 25, rect: [301,434 78.125x17.46875]
-            "أيها الأصدقاء"
+        line 0 width: 100, height: 14, bottom: 14, baseline: 10
+          frag 0 from TextNode start: 0, length: 35, rect: [301,417 100x14]
+            "حسنًا ، مرحباً أيها"
+        line 1 width: 41, height: 14, bottom: 28, baseline: 10
+          frag 0 from TextNode start: 36, length: 16, rect: [301,431 41x14]
+            "الأصدقاء"
         TextNode <#text>
       BlockContainer <(anonymous)> at (200,518) content-size 592x0 children: inline
         TextNode <#text>
       BlockContainer <div> at (301,519) content-size 100x100 children: inline
-        line 0 width: 86.125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-          frag 0 from TextNode start: 0, length: 26, rect: [301,519 86.125x17.46875]
-            "حسنًا ، مرحباً"
-        line 1 width: 78.125, height: 17.9375, bottom: 35.40625, baseline: 13.53125
-          frag 0 from TextNode start: 27, length: 25, rect: [301,536 78.125x17.46875]
-            "أيها الأصدقاء"
+        line 0 width: 100, height: 14, bottom: 14, baseline: 10
+          frag 0 from TextNode start: 0, length: 35, rect: [301,519 100x14]
+            "حسنًا ، مرحباً أيها"
+        line 1 width: 41, height: 14, bottom: 28, baseline: 10
+          frag 0 from TextNode start: 36, length: 16, rect: [301,533 41x14]
+            "الأصدقاء"
         TextNode <#text>
       BlockContainer <(anonymous)> at (200,620) content-size 592x0 children: inline
         TextNode <#text>
       BlockContainer <div> at (401,621) content-size 100x100 children: inline
-        line 0 width: 86.125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-          frag 0 from TextNode start: 0, length: 26, rect: [401,621 86.125x17.46875]
-            "حسنًا ، مرحباً"
-        line 1 width: 78.125, height: 17.9375, bottom: 35.40625, baseline: 13.53125
-          frag 0 from TextNode start: 27, length: 25, rect: [401,638 78.125x17.46875]
-            "أيها الأصدقاء"
+        line 0 width: 100, height: 14, bottom: 14, baseline: 10
+          frag 0 from TextNode start: 0, length: 35, rect: [401,621 100x14]
+            "حسنًا ، مرحباً أيها"
+        line 1 width: 41, height: 14, bottom: 28, baseline: 10
+          frag 0 from TextNode start: 36, length: 16, rect: [401,635 41x14]
+            "الأصدقاء"
         TextNode <#text>
       BlockContainer <(anonymous)> at (200,722) content-size 592x0 children: inline
         TextNode <#text>
       BlockContainer <div> at (401,723) content-size 100x100 children: inline
-        line 0 width: 86.125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-          frag 0 from TextNode start: 0, length: 26, rect: [401,723 86.125x17.46875]
-            "حسنًا ، مرحباً"
-        line 1 width: 78.125, height: 17.9375, bottom: 35.40625, baseline: 13.53125
-          frag 0 from TextNode start: 27, length: 25, rect: [401,740 78.125x17.46875]
-            "أيها الأصدقاء"
+        line 0 width: 100, height: 14, bottom: 14, baseline: 10
+          frag 0 from TextNode start: 0, length: 35, rect: [401,723 100x14]
+            "حسنًا ، مرحباً أيها"
+        line 1 width: 41, height: 14, bottom: 28, baseline: 10
+          frag 0 from TextNode start: 36, length: 16, rect: [401,737 41x14]
+            "الأصدقاء"
         TextNode <#text>
       BlockContainer <(anonymous)> at (200,824) content-size 592x0 children: inline
         TextNode <#text>

--- a/Tests/LibWeb/Layout/input/css-dir-selector.html
+++ b/Tests/LibWeb/Layout/input/css-dir-selector.html
@@ -1,5 +1,7 @@
 <style>
     div {
+        font-family: Katica;
+        font-size: 10px;
         width: 100px;
         height: 100px;
         border: 1px solid black;

--- a/Tests/LibWeb/Ref/css-quotes.html
+++ b/Tests/LibWeb/Ref/css-quotes.html
@@ -1,6 +1,10 @@
 <!doctype html>
 <link rel="match" href="reference/css-quotes-ref.html" />
 <style>
+    div {
+        font-family: Katica;
+        font-size: 10px;
+    }
     div::before {
         content: open-quote "Well, hello friends!" close-quote;
     }

--- a/Tests/LibWeb/Ref/reference/css-quotes-ref.html
+++ b/Tests/LibWeb/Ref/reference/css-quotes-ref.html
@@ -1,4 +1,10 @@
 <!doctype html>
+<style>
+  div {
+      font-family: Katica;
+      font-size: 10px;
+  }
+</style>
 <div class="a">Well, hello friends!</div>
 <div class="b">“Well, hello friends!”</div>
 <div class="c">/* Well, hello friends! */</div>

--- a/Userland/Libraries/LibGfx/Font/FontDatabase.cpp
+++ b/Userland/Libraries/LibGfx/Font/FontDatabase.cpp
@@ -214,6 +214,11 @@ RefPtr<Gfx::Font> FontDatabase::get_by_name(StringView name)
     return it->value;
 }
 
+Vector<FlyString> FontDatabase::get_typeface_family_names()
+{
+    return m_private->typefaces.keys();
+}
+
 RefPtr<Gfx::Font> FontDatabase::get(FlyString const& family, float point_size, unsigned weight, unsigned width, unsigned slope, Font::AllowInexactSizeMatch allow_inexact_size_match)
 {
     auto it = m_private->typefaces.find(family);

--- a/Userland/Libraries/LibGfx/Font/FontDatabase.h
+++ b/Userland/Libraries/LibGfx/Font/FontDatabase.h
@@ -52,6 +52,7 @@ public:
     RefPtr<Gfx::Font> get(FlyString const& family, float point_size, unsigned weight, unsigned width, unsigned slope, Font::AllowInexactSizeMatch = Font::AllowInexactSizeMatch::No);
     RefPtr<Gfx::Font> get(FlyString const& family, FlyString const& variant, float point_size, Font::AllowInexactSizeMatch = Font::AllowInexactSizeMatch::No);
     RefPtr<Gfx::Font> get_by_name(StringView);
+    Vector<FlyString> get_typeface_family_names();
     void for_each_font(Function<void(Gfx::Font const&)>);
     void for_each_fixed_width_font(Function<void(Gfx::Font const&)>);
 


### PR DESCRIPTION
Implement section 5.2.2 from the font-matching algorithm found in https://www.w3.org/TR/css-fonts-4/#font-matching-algorithm  
> If no matching face exists or the matched face does not contain  a glyph for the character to be rendered, the next family name is selected and the previous three steps repeated. Glyphs from other faces in the family are not considered.
    
Also : 
- Add comments to clarify which sections of this spec the existing code covers.
- Add FontDatabase::get_typeface_family_names method to allow us to get the family names available for potential fallback.
- Update two tests to use Katica font to ensure tests have font with glyphs they use. Otherwise, we would not render the glyph if the default font doesn't support these glyphs (as is the case with SerenitySans used by headless-browser).

For example this allows fallback to Droid Sans Fallback Regular on my system which contains glyphs for:  [https://jp.wikipedia.org/](https://jp.wikipedia.org/) and we can render most of the text on the page.

Before:
![before_fallback_font](https://github.com/SerenityOS/serenity/assets/7834601/b67a555a-0972-4d78-9578-e08f8d880ed3)

After: 
![after_fallback_font](https://github.com/SerenityOS/serenity/assets/7834601/eb5adf70-965d-4401-ad7f-448291a1ddf8)
