### PR TITLE
LibPDF: Don't crash on files with float CFF defaultWidthX

### DIFF
--- a/Userland/Libraries/LibPDF/Fonts/CFF.h
+++ b/Userland/Libraries/LibPDF/Fonts/CFF.h
@@ -56,6 +56,13 @@ public:
     using SID = u16;
     using DictOperand = Variant<int, float>;
 
+    static float to_number(DictOperand operand)
+    {
+        if (operand.has<int>())
+            return operand.get<int>();
+        return operand.get<float>();
+    }
+
     static int load_int_dict_operand(u8 b0, Reader&);
     static float load_float_dict_operand(Reader&);
     static PDFErrorOr<DictOperand> load_dict_operand(u8, Reader&);


### PR DESCRIPTION
We'd unconditionally get the int from a Variant<int, float> here, but PDFs often have a float for defaultWidthX and nominalWidthX.

Fixes crash opening Bakke2010a.pdf from pdffiles (but while the file loads ok, it looks completely busted).