### PR TITLE
LibWeb/HTMLInputElement: Improve appearance of color picker

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Default.css
+++ b/Userland/Libraries/LibWeb/CSS/Default.css
@@ -26,7 +26,7 @@ label {
 }
 
 /* FIXME: This is a temporary hack until we can render a native-looking frame for these. */
-input, textarea {
+input:not([type=submit], input[type=button], input[type=reset], input[type=checkbox], input[type=radio]), textarea {
     border: 1px solid ButtonBorder;
     min-width: 80px;
     min-height: 16px;
@@ -42,14 +42,6 @@ textarea {
     font-family: monospace;
     width: attr(cols ch, 20ch);
     height: attr(rows lh, 2lh);
-}
-
-input[type=submit], input[type=button], input[type=reset], input[type=checkbox], input[type=radio] {
-    border: none;
-    min-width: unset;
-    min-height: unset;
-    width: unset;
-    cursor: unset;
 }
 
 input::placeholder {

--- a/Userland/Libraries/LibWeb/CSS/Default.css
+++ b/Userland/Libraries/LibWeb/CSS/Default.css
@@ -26,7 +26,7 @@ label {
 }
 
 /* FIXME: This is a temporary hack until we can render a native-looking frame for these. */
-input:not([type=submit], input[type=button], input[type=reset], input[type=checkbox], input[type=radio]), textarea {
+input:not([type=submit], input[type=button], input[type=reset], input[type=color], input[type=checkbox], input[type=radio]), textarea {
     border: 1px solid ButtonBorder;
     min-width: 80px;
     min-height: 16px;

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -507,7 +507,6 @@ void HTMLInputElement::create_shadow_tree_if_needed()
     if (shadow_root_internal())
         return;
 
-    // FIXME: This could be better factored. Everything except the below types becomes a text input.
     switch (type_state()) {
     case TypeAttributeState::RadioButton:
     case TypeAttributeState::Checkbox:
@@ -516,11 +515,16 @@ void HTMLInputElement::create_shadow_tree_if_needed()
     case TypeAttributeState::ResetButton:
     case TypeAttributeState::ImageButton:
     case TypeAttributeState::Color:
-        return;
+        break;
+    // FIXME: This could be better factored. Everything except the above types becomes a text input.
     default:
+        create_text_input_shadow_tree();
         break;
     }
+}
 
+void HTMLInputElement::create_text_input_shadow_tree()
+{
     auto shadow_root = heap().allocate<DOM::ShadowRoot>(realm(), document(), *this, Bindings::ShadowRootMode::Closed);
     auto initial_value = m_value;
     auto element = DOM::create_element(document(), HTML::TagNames::div, Namespace::HTML).release_value_but_fixme_should_propagate_errors();

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -167,6 +167,7 @@ private:
     static TypeAttributeState parse_type_attribute(StringView);
     void create_shadow_tree_if_needed();
     void create_text_input_shadow_tree();
+    void create_color_input_shadow_tree();
     WebIDL::ExceptionOr<void> run_input_activation_behavior();
     void set_checked_within_group();
 
@@ -180,6 +181,7 @@ private:
     JS::GCPtr<DOM::Text> m_placeholder_text_node;
 
     JS::GCPtr<DOM::Element> m_inner_text_element;
+    JS::GCPtr<DOM::Element> m_color_well_element;
     JS::GCPtr<DOM::Text> m_text_node;
     bool m_checked { false };
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -166,6 +166,7 @@ private:
 
     static TypeAttributeState parse_type_attribute(StringView);
     void create_shadow_tree_if_needed();
+    void create_text_input_shadow_tree();
     WebIDL::ExceptionOr<void> run_input_activation_behavior();
     void set_checked_within_group();
 


### PR DESCRIPTION
Instead of a plain ButtonBox, it now appears as a color well styled after the buttons.

https://github.com/SerenityOS/serenity/assets/39885272/62cf2e14-7fe1-4ff6-bb9c-d0470f271d09.mp4

