### PR TITLE
AK: Pass correct length to convert_to_floating_point()

### DIFF
--- a/AK/StringUtils.cpp
+++ b/AK/StringUtils.cpp
@@ -247,7 +247,7 @@ Optional<T> convert_to_floating_point(StringView str, TrimWhitespace trim_whites
         : str;
 
     char const* start = string.characters_without_null_termination();
-    return parse_floating_point_completely<T>(start, start + str.length());
+    return parse_floating_point_completely<T>(start, start + string.length());
 }
 
 template Optional<double> convert_to_floating_point(StringView str, TrimWhitespace);

--- a/Tests/AK/TestStringUtils.cpp
+++ b/Tests/AK/TestStringUtils.cpp
@@ -319,6 +319,13 @@ TEST_CASE(convert_to_uint_from_octal)
     EXPECT_EQ(actual.value(), 0177777u);
 }
 
+TEST_CASE(convert_to_floating_point)
+{
+    auto number_string = "  123.45  "sv;
+    auto maybe_number = AK::StringUtils::convert_to_floating_point<float>(number_string, TrimWhitespace::Yes);
+    EXPECT_APPROXIMATE(maybe_number.value(), 123.45f);
+}
+
 TEST_CASE(ends_with)
 {
     DeprecatedString test_string = "ABCDEF";


### PR DESCRIPTION
Fixed the issue in StringUtils::convert_to_floating_point() where the end pointer of the trimmed string was not being passed, causing the function to consistently return 'None' when given strings with trailing whitespaces.
This PR Fixes #21428