### PR TITLE
Kernel: Fix SipHash aarch64 boot regression

### DIFF
--- a/Kernel/Arch/init.cpp
+++ b/Kernel/Arch/init.cpp
@@ -262,12 +262,6 @@ extern "C" [[noreturn]] UNMAP_AFTER_INIT void init([[maybe_unused]] BootInfo con
     }
     dmesgln("Starting SerenityOS...");
 
-    DeviceManagement::initialize();
-    SysFSComponentRegistry::initialize();
-    DeviceManagement::the().attach_null_device(*NullDevice::must_initialize());
-    DeviceManagement::the().attach_console_device(*ConsoleDevice::must_create());
-    DeviceManagement::the().attach_device_control_device(*DeviceControlDevice::must_create());
-
     MM.unmap_prekernel();
 
 #if ARCH(X86_64)
@@ -286,6 +280,12 @@ extern "C" [[noreturn]] UNMAP_AFTER_INIT void init([[maybe_unused]] BootInfo con
 
     // Initialize TimeManagement before using randomness!
     TimeManagement::initialize(0);
+
+    DeviceManagement::initialize();
+    SysFSComponentRegistry::initialize();
+    DeviceManagement::the().attach_null_device(*NullDevice::must_initialize());
+    DeviceManagement::the().attach_console_device(*ConsoleDevice::must_create());
+    DeviceManagement::the().attach_device_control_device(*DeviceControlDevice::must_create());
 
     __stack_chk_guard = get_fast_random<uintptr_t>();
 


### PR DESCRIPTION
Moving the DeviceManagement initialization, which is only needed by
userland in the first place, to after interrupt and time management
initialization (like other things that require randomness) allows the
SipHash initialization to access good randomness without problems.

Note: There currently is another, unrelated boot problem on aarch64,
which is not caused by SipHash as far as we know. This commit therefore
only fixes the SipHash regression.