### PR TITLE
LibWeb: Use "POST" instead of "post" for POST resources in navigables

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Navigable.cpp
@@ -583,7 +583,7 @@ static WebIDL::ExceptionOr<Variant<Empty, NavigationParams, NonFetchSchemeNaviga
     // 4. If documentResource is a POST resource, then:
     if (document_resource.has<POSTResource>()) {
         // 1. Set request's method to `POST`.
-        request->set_method(TRY_OR_THROW_OOM(vm, ByteBuffer::copy("post"sv.bytes())));
+        request->set_method(TRY_OR_THROW_OOM(vm, ByteBuffer::copy("POST"sv.bytes())));
 
         // 2. Set request's body to documentResource's request body.
         request->set_body(document_resource.get<POSTResource>().request_body.value());


### PR DESCRIPTION
HTTP methods are case sensitive and the Fetch layer treats it as such. For example, http_redirect_fetch case sensitively checks if the method is "POST" to change the method to "GET" and nullify the body. https://github.com/SerenityOS/serenity/blob/9d7e2175663eff6a00b176d4e1873b10836ee992/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp#L1125-L1135

Fixes https://github.com/SerenityOS/serenity/issues/21347