### PR TITLE
LibJS: Store local variables in the bytecode register file

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/Generator.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.cpp
@@ -20,12 +20,17 @@ Generator::Generator()
 {
 }
 
-CodeGenerationErrorOr<NonnullRefPtr<Executable>> Generator::generate(ASTNode const& node, FunctionKind enclosing_function_kind)
+CodeGenerationErrorOr<NonnullRefPtr<Executable>> Generator::generate(ASTNode const& node, FunctionKind enclosing_function_kind, size_t local_register_count)
 {
     Generator generator;
     generator.switch_to_basic_block(generator.make_block());
     SourceLocationScope scope(generator, node);
     generator.m_enclosing_function_kind = enclosing_function_kind;
+    // Pre-allocate registers for all local variables
+    // The runtime equivalent is done in `ECMAScriptFunctionObject::function_declaration_instantiation()`
+    // FIXME: Maybe keep a copy of the local variable names as debug info
+    generator.m_next_register += local_register_count;
+
     if (generator.is_in_generator_or_async_function()) {
         // Immediately yield with no value.
         auto& start_block = generator.make_block();

--- a/Userland/Libraries/LibJS/Bytecode/Generator.h
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.h
@@ -30,7 +30,7 @@ public:
         Function,
         Block,
     };
-    static CodeGenerationErrorOr<NonnullRefPtr<Executable>> generate(ASTNode const&, FunctionKind = FunctionKind::Normal);
+    static CodeGenerationErrorOr<NonnullRefPtr<Executable>> generate(ASTNode const&, FunctionKind = FunctionKind::Normal, size_t local_register_count = 0);
 
     Register allocate_register();
 

--- a/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.h
+++ b/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.h
@@ -14,6 +14,9 @@
 #include <LibJS/Runtime/FunctionObject.h>
 
 namespace JS {
+namespace Bytecode {
+struct CallFrame;
+}
 
 template<typename T>
 void async_block_start(VM&, T const& async_body, PromiseCapability const&, ExecutionContext&);
@@ -108,7 +111,7 @@ private:
     ThrowCompletionOr<void> prepare_for_ordinary_call(ExecutionContext& callee_context, Object* new_target);
     void ordinary_call_bind_this(ExecutionContext&, Value this_argument);
 
-    ThrowCompletionOr<void> function_declaration_instantiation();
+    ThrowCompletionOr<NonnullOwnPtr<Bytecode::CallFrame>> function_declaration_instantiation();
 
     DeprecatedFlyString m_name;
     RefPtr<Bytecode::Executable> m_bytecode_executable;

--- a/Userland/Libraries/LibJS/Runtime/ExecutionContext.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ExecutionContext.cpp
@@ -13,19 +13,17 @@ namespace JS {
 
 ExecutionContext::ExecutionContext(Heap& heap)
     : arguments(heap)
-    , local_variables(heap)
 {
 }
 
-ExecutionContext::ExecutionContext(MarkedVector<Value> existing_arguments, MarkedVector<Value> existing_local_variables)
+ExecutionContext::ExecutionContext(MarkedVector<Value> existing_arguments)
     : arguments(move(existing_arguments))
-    , local_variables(move(existing_local_variables))
 {
 }
 
 ExecutionContext ExecutionContext::copy() const
 {
-    ExecutionContext copy { arguments, local_variables };
+    ExecutionContext copy { arguments };
 
     copy.function = function;
     copy.realm = realm;
@@ -36,6 +34,7 @@ ExecutionContext ExecutionContext::copy() const
     copy.instruction_stream_iterator = instruction_stream_iterator;
     copy.function_name = function_name;
     copy.this_value = this_value;
+    copy.local_variable_count = local_variable_count;
     copy.is_strict_mode = is_strict_mode;
 
     return copy;

--- a/Userland/Libraries/LibJS/Runtime/ExecutionContext.h
+++ b/Userland/Libraries/LibJS/Runtime/ExecutionContext.h
@@ -31,7 +31,7 @@ struct ExecutionContext {
     void visit_edges(Cell::Visitor&);
 
 private:
-    explicit ExecutionContext(MarkedVector<Value> existing_arguments, MarkedVector<Value> existing_local_variables);
+    explicit ExecutionContext(MarkedVector<Value> existing_arguments);
 
 public:
     GCPtr<FunctionObject> function;                // [[Function]]
@@ -48,7 +48,7 @@ public:
     DeprecatedFlyString function_name;
     Value this_value;
     MarkedVector<Value> arguments;
-    MarkedVector<Value> local_variables;
+    size_t local_variable_count { 0 };
     bool is_strict_mode { false };
 
     // https://html.spec.whatwg.org/multipage/webappapis.html#skip-when-determining-incumbent-counter

--- a/Userland/Libraries/LibJS/Runtime/VM.h
+++ b/Userland/Libraries/LibJS/Runtime/VM.h
@@ -28,6 +28,9 @@ namespace JS {
 
 class Identifier;
 struct BindingPattern;
+namespace Bytecode {
+struct CallFrame;
+}
 
 class VM : public RefCounted<VM> {
 public:
@@ -210,9 +213,13 @@ public:
     CustomData* custom_data() { return m_custom_data; }
 
     ThrowCompletionOr<void> binding_initialization(DeprecatedFlyString const& target, Value value, Environment* environment);
-    ThrowCompletionOr<void> binding_initialization(NonnullRefPtr<BindingPattern const> const& target, Value value, Environment* environment);
+    // FIXME: Avoid passing a CallFrame,
+    //        for this we need to bind the call frame earlier in a functions call preparation, than at the beginning of the actual evaluation
+    ThrowCompletionOr<void> binding_initialization(NonnullRefPtr<BindingPattern const> const& target, Value value, Environment* environment, Bytecode::CallFrame&);
 
-    ThrowCompletionOr<Value> named_evaluation_if_anonymous_function(ASTNode const& expression, DeprecatedFlyString const& name);
+    // FIXME: Avoid passing a CallFrame,
+    //        for this we need to bind the call frame earlier in a functions call preparation, than at the beginning of the actual evaluation
+    ThrowCompletionOr<Value> named_evaluation_if_anonymous_function(ASTNode const& expression, DeprecatedFlyString const& name, Bytecode::CallFrame&);
 
     void save_execution_context_stack();
     void restore_execution_context_stack();
@@ -243,7 +250,7 @@ public:
 
     // Execute a specific AST node either in AST or BC interpreter, depending on which one is enabled by default.
     // NOTE: This is meant as a temporary stopgap until everything is bytecode.
-    ThrowCompletionOr<Value> execute_ast_node(ASTNode const&);
+    ThrowCompletionOr<Value> execute_ast_node(ASTNode const&, Bytecode::CallFrame&);
 
 private:
     using ErrorMessages = AK::Array<String, to_underlying(ErrorMessage::__Count)>;
@@ -257,8 +264,8 @@ private:
 
     VM(OwnPtr<CustomData>, ErrorMessages);
 
-    ThrowCompletionOr<void> property_binding_initialization(BindingPattern const& binding, Value value, Environment* environment);
-    ThrowCompletionOr<void> iterator_binding_initialization(BindingPattern const& binding, IteratorRecord& iterator_record, Environment* environment);
+    ThrowCompletionOr<void> property_binding_initialization(BindingPattern const& binding, Value value, Environment* environment, Bytecode::CallFrame&);
+    ThrowCompletionOr<void> iterator_binding_initialization(BindingPattern const& binding, IteratorRecord& iterator_record, Environment* environment, Bytecode::CallFrame&);
 
     ThrowCompletionOr<NonnullGCPtr<Module>> resolve_imported_module(ScriptOrModule referencing_script_or_module, ModuleRequest const& module_request);
     ThrowCompletionOr<void> link_and_eval_module(Module& module);


### PR DESCRIPTION
### LibJS: Move local variables into the bytecode register file

Local variables now lie in the first registers after the reserved
registers.
The codegen is unaffected by this, ie we still use [Set,Get]Local, as
the handling of empty values for locals differs to the handling of empty
registers.
