### PR TITLE
LibPDF: Don't overflow SIDs in type 1 charset parsing (and implement type 2)

### DIFF
--- a/Userland/Libraries/LibPDF/Fonts/CFF.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/CFF.cpp
@@ -631,7 +631,7 @@ PDFErrorOr<Vector<DeprecatedFlyString>> CFF::parse_charset(Reader&& reader, size
         while (names.size() < glyph_count - 1) {
             auto first_sid = TRY(reader.try_read<BigEndian<SID>>());
             int left = TRY(reader.try_read<Card8>());
-            for (u8 sid = first_sid; left >= 0; left--, sid++)
+            for (SID sid = first_sid; left >= 0; left--, sid++)
                 TRY(names.try_append(resolve_sid(sid, strings)));
         }
     }

--- a/Userland/Libraries/LibPDF/Fonts/CFF.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/CFF.cpp
@@ -637,6 +637,18 @@ PDFErrorOr<Vector<DeprecatedFlyString>> CFF::parse_charset(Reader&& reader, size
             for (SID sid = first_sid; left >= 0; left--, sid++)
                 TRY(names.try_append(resolve_sid(sid, strings)));
         }
+    } else if (format == 2) {
+        // CFF spec, "Table 20 Format 2"
+        // "Format 2 differs from format 1 only in the size of the Left field in each range."
+        while (names.size() < glyph_count - 1) {
+            // CFF spec, "Table 21 Range2 Format"
+            auto first_sid = TRY(reader.try_read<BigEndian<SID>>());
+            int left = TRY(reader.try_read<Card16>());
+            for (SID sid = first_sid; left >= 0; left--, sid++)
+                TRY(names.try_append(resolve_sid(sid, strings)));
+        }
+    } else {
+        dbgln("CFF: Unknown charset format {}", format);
     }
     return names;
 }

--- a/Userland/Libraries/LibPDF/Fonts/CFF.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/CFF.cpp
@@ -623,12 +623,15 @@ PDFErrorOr<Vector<DeprecatedFlyString>> CFF::parse_charset(Reader&& reader, size
     Vector<DeprecatedFlyString> names;
     auto format = TRY(reader.try_read<Card8>());
     if (format == 0) {
+        // CFF spec, "Table 17 Format 0"
         for (u8 i = 0; i < glyph_count - 1; i++) {
             SID sid = TRY(reader.try_read<BigEndian<SID>>());
             TRY(names.try_append(resolve_sid(sid, strings)));
         }
     } else if (format == 1) {
+        // CFF spec, "Table 18 Format 1"
         while (names.size() < glyph_count - 1) {
+            // CFF spec, "Table 19 Range1 Format (Charset)"
             auto first_sid = TRY(reader.try_read<BigEndian<SID>>());
             int left = TRY(reader.try_read<Card8>());
             for (SID sid = first_sid; left >= 0; left--, sid++)


### PR DESCRIPTION
first_sid has type SID (aka u16), so don't store it in an u8.

This fixes (among other things) page 24 on the PDF 1.7 spec.

-----

(Also requires the fixes from #21436, else all the spaces on that page are replaced with small superscript 1s.)