### PR TITLE
LibGfx: Fix serializing Gfx::Bitmaps

### DIFF
--- a/Tests/LibGfx/TestGfxBitmap.cpp
+++ b/Tests/LibGfx/TestGfxBitmap.cpp
@@ -126,3 +126,12 @@ TEST_CASE(0008_bitmap_downscaling_height1)
         }
     }
 }
+
+TEST_CASE(0009_serialize_and_deserialize_roundtrip)
+{
+    auto original_bitmap = MUST(Gfx::Bitmap::create(Gfx::BitmapFormat::BGRx8888, Gfx::IntSize { 10, 10 }));
+    original_bitmap->fill(Gfx::Color::Red);
+    auto bytes = MUST(original_bitmap->serialize_to_byte_buffer());
+    auto bitmap = MUST(Gfx::Bitmap::create_from_serialized_bytes(bytes));
+    EXPECT(bitmap->visually_equals(original_bitmap));
+}

--- a/Userland/Libraries/LibGfx/Bitmap.cpp
+++ b/Userland/Libraries/LibGfx/Bitmap.cpp
@@ -237,7 +237,7 @@ ErrorOr<NonnullRefPtr<Bitmap>> Bitmap::create_from_serialized_bytes(ReadonlyByte
 
 ErrorOr<ByteBuffer> Bitmap::serialize_to_byte_buffer() const
 {
-    auto buffer = TRY(ByteBuffer::create_uninitialized(sizeof(size_t) + 4 * sizeof(unsigned) + sizeof(BitmapFormat) + size_in_bytes()));
+    auto buffer = TRY(ByteBuffer::create_uninitialized(sizeof(size_t) + 3 * sizeof(unsigned) + sizeof(BitmapFormat) + size_in_bytes()));
     FixedMemoryStream stream { buffer.span() };
 
     TRY(stream.write_value(size_in_bytes()));


### PR DESCRIPTION
a396bb0 removed the palette field but did not update the allocation size in `Bitmap::serialize_to_byte_buffer()`. This led to a few crashes (I noticed this from a drag/drop crash in the file manager).

Fixes #21434