### PR TITLE
LibJS: Implement resizable ArrayBuffers and support for them in TypedArray/DataView

### DIFF
--- a/Userland/Libraries/LibJS/Print.cpp
+++ b/Userland/Libraries/LibJS/Print.cpp
@@ -388,14 +388,20 @@ ErrorOr<void> print_array_buffer(JS::PrintContext& print_context, JS::ArrayBuffe
 
     auto byte_length = array_buffer.byte_length();
     TRY(js_out(print_context, "\n  byteLength: "));
-    TRY(print_value(print_context, JS::Value((double)byte_length), seen_objects));
+    TRY(print_value(print_context, JS::Value(byte_length), seen_objects));
     if (array_buffer.is_detached()) {
-        TRY(js_out(print_context, "\n  Detached"));
+        TRY(js_out(print_context, "\n  (detached)"));
         return {};
     }
 
     if (byte_length == 0)
         return {};
+
+    auto max_byte_length = array_buffer.max_byte_length();
+    if (max_byte_length.has_value()) {
+        TRY(js_out(print_context, "\n  maxByteLength: "));
+        TRY(print_value(print_context, JS::Value(max_byte_length.value()), seen_objects));
+    }
 
     auto& buffer = array_buffer.buffer();
     TRY(js_out(print_context, "\n"));

--- a/Userland/Libraries/LibJS/Print.cpp
+++ b/Userland/Libraries/LibJS/Print.cpp
@@ -501,7 +501,13 @@ ErrorOr<void> print_data_view(JS::PrintContext& print_context, JS::DataView cons
 {
     TRY(print_type(print_context, "DataView"sv));
     TRY(js_out(print_context, "\n  byteLength: "));
-    TRY(print_value(print_context, JS::Value(data_view.byte_length()), seen_objects));
+    auto view_record = JS::make_data_view_with_buffer_witness_record(print_context.vm, data_view, JS::ArrayBuffer::Order::Unordered);
+    if (JS::is_view_out_of_bounds(view_record)) {
+        TRY(js_out(print_context, "(out of bounds)"));
+    } else {
+        auto byte_length = JS::get_view_byte_length(view_record);
+        TRY(print_value(print_context, JS::Value(byte_length), seen_objects));
+    }
     TRY(js_out(print_context, "\n  byteOffset: "));
     TRY(print_value(print_context, JS::Value(data_view.byte_offset()), seen_objects));
     TRY(js_out(print_context, "\n  buffer: "));

--- a/Userland/Libraries/LibJS/Runtime/ArrayBuffer.h
+++ b/Userland/Libraries/LibJS/Runtime/ArrayBuffer.h
@@ -64,11 +64,15 @@ public:
         return m_data_block.buffer().size();
     }
 
+    // [[ArrayBufferMaxByteLength]]
+    Optional<size_t> const& max_byte_length() const { return m_max_byte_length; }
+    void set_max_byte_length(Optional<size_t> new_max_byte_length) { m_max_byte_length = move(new_max_byte_length); }
+
     // [[ArrayBufferData]]
     ByteBuffer& buffer() { return m_data_block.buffer(); }
     ByteBuffer const& buffer() const { return m_data_block.buffer(); }
 
-    // Used by allocate_array_buffer() to attach the data block after construction
+    // Used to attach the data block after construction or resizing
     void set_data_block(DataBlock block) { m_data_block = move(block); }
 
     Value detach_key() const { return m_detach_key; }
@@ -84,6 +88,16 @@ public:
             return true;
         // 2. Return false.
         return false;
+    }
+
+    // 25.1.3.8 IsFixedLengthArrayBuffer ( arrayBuffer ), https://tc39.es/ecma262/#sec-isfixedlengtharraybuffer
+    bool is_fixed_length() const
+    {
+        // 1. If arrayBuffer has an [[ArrayBufferMaxByteLength]] internal slot, return false.
+        if (m_max_byte_length.has_value())
+            return false;
+        // 2. Return true
+        return true;
     }
 
     // 25.2.1.2 IsSharedArrayBuffer ( obj ), https://tc39.es/ecma262/#sec-issharedarraybuffer
@@ -123,15 +137,17 @@ private:
     // The various detach related members of ArrayBuffer are not used by any ECMA262 functionality,
     // but are required to be available for the use of various harnesses like the Test262 test runner.
     Value m_detach_key;
+    Optional<size_t> m_max_byte_length;
 };
 
 ThrowCompletionOr<DataBlock> create_byte_data_block(VM& vm, size_t size);
 void copy_data_block_bytes(ByteBuffer& to_block, u64 to_index, ByteBuffer const& from_block, u64 from_index, u64 count);
-ThrowCompletionOr<ArrayBuffer*> allocate_array_buffer(VM&, FunctionObject& constructor, size_t byte_length);
+ThrowCompletionOr<ArrayBuffer*> allocate_array_buffer(VM&, FunctionObject& constructor, size_t byte_length, Optional<size_t> max_byte_length = {});
 ThrowCompletionOr<void> detach_array_buffer(VM&, ArrayBuffer& array_buffer, Optional<Value> key = {});
 ThrowCompletionOr<ArrayBuffer*> clone_array_buffer(VM&, ArrayBuffer& source_buffer, size_t source_byte_offset, size_t source_length);
 ThrowCompletionOr<ArrayBuffer*> array_buffer_copy_and_detach(VM&, ArrayBuffer& array_buffer, Value new_length, PreserveResizability preserve_resizability);
 ThrowCompletionOr<NonnullGCPtr<ArrayBuffer>> allocate_shared_array_buffer(VM&, FunctionObject& constructor, size_t byte_length);
+size_t array_buffer_byte_length(VM&, ArrayBuffer const& array_buffer, ArrayBuffer::Order order);
 
 // 25.1.2.9 RawBytesToNumeric ( type, rawBytes, isLittleEndian ), https://tc39.es/ecma262/#sec-rawbytestonumeric
 template<typename T>

--- a/Userland/Libraries/LibJS/Runtime/ArrayBufferPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayBufferPrototype.cpp
@@ -24,11 +24,14 @@ void ArrayBufferPrototype::initialize(Realm& realm)
     auto& vm = this->vm();
     Base::initialize(realm);
     u8 attr = Attribute::Writable | Attribute::Configurable;
+    define_native_function(realm, vm.names.resize, resize, 1, attr);
     define_native_function(realm, vm.names.slice, slice, 2, attr);
     define_native_function(realm, vm.names.transfer, transfer, 0, attr);
     define_native_function(realm, vm.names.transferToFixedLength, transfer_to_fixed_length, 0, attr);
     define_native_accessor(realm, vm.names.byteLength, byte_length_getter, {}, Attribute::Configurable);
     define_native_accessor(realm, vm.names.detached, detached_getter, {}, Attribute::Configurable);
+    define_native_accessor(realm, vm.names.resizable, resizable_getter, {}, Attribute::Configurable);
+    define_native_accessor(realm, vm.names.maxByteLength, max_byte_length_getter, {}, Attribute::Configurable);
 
     // 25.1.5.4 ArrayBuffer.prototype [ @@toStringTag ], https://tc39.es/ecma262/#sec-arraybuffer.prototype-@@tostringtag
     define_direct_property(vm.well_known_symbol_to_string_tag(), PrimitiveString::create(vm, vm.names.ArrayBuffer.as_string()), Attribute::Configurable);
@@ -113,7 +116,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayBufferPrototype::slice)
     if (new_array_buffer_object->byte_length() < new_length)
         return vm.throw_completion<TypeError>(ErrorType::SpeciesConstructorReturned, "an ArrayBuffer smaller than requested");
 
-    // 22. NOTE: Side-effects of the above steps may have detached O.
+    // 22. NOTE: Side-effects of the above steps may have detached or resized O.
     // 23. If IsDetachedBuffer(O) is true, throw a TypeError exception.
     if (array_buffer_object->is_detached())
         return vm.throw_completion<TypeError>(ErrorType::DetachedArrayBuffer);
@@ -124,10 +127,19 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayBufferPrototype::slice)
     // 25. Let toBuf be new.[[ArrayBufferData]].
     auto& to_buf = new_array_buffer_object->buffer();
 
-    // 26. Perform CopyDataBlockBytes(toBuf, 0, fromBuf, first, newLen).
-    copy_data_block_bytes(to_buf, 0, from_buf, first, new_length);
+    // 26. Let currentLen be O.[[ArrayBufferByteLength]].
+    auto current_lenght = static_cast<double>(array_buffer_object->byte_length());
 
-    // 27. Return new.
+    // 27. If first < currentLen, then
+    if (first < current_lenght) {
+        // a. Let count be min(newLen, currentLen - first).
+        auto count = min(new_length, current_lenght - first);
+
+        // b. Perform CopyDataBlockBytes(toBuf, 0, fromBuf, first, count).
+        copy_data_block_bytes(to_buf, 0, from_buf, first, count);
+    }
+
+    // 28. Return new.
     return new_array_buffer_object;
 }
 
@@ -183,6 +195,108 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayBufferPrototype::transfer_to_fixed_length)
     // 2. Return ? ArrayBufferCopyAndDetach(O, newLength, fixed-length).
     auto new_length = vm.argument(0);
     return TRY(array_buffer_copy_and_detach(vm, array_buffer_object, new_length, PreserveResizability::FixedLength));
+}
+
+// 25.1.6.3 get ArrayBuffer.prototype.maxByteLength, https://tc39.es/ecma262/#sec-get-arraybuffer.prototype.maxbytelength
+JS_DEFINE_NATIVE_FUNCTION(ArrayBufferPrototype::max_byte_length_getter)
+{
+    // 1. Let O be the this value.
+    // 2. Perform ? RequireInternalSlot(O, [[ArrayBufferData]]).
+    auto array_buffer_object = TRY(typed_this_value(vm));
+
+    // 3. If IsSharedArrayBuffer(O) is true, throw a TypeError exception.
+    if (array_buffer_object->is_shared_array_buffer())
+        return vm.throw_completion<TypeError>(ErrorType::ThisCannotBeSharedArrayBuffer);
+
+    // 4. If IsDetachedBuffer(O) is true, return +0𝔽.
+    if (array_buffer_object->is_detached())
+        return Value(0);
+
+    size_t length;
+
+    // 5. If IsFixedLengthArrayBuffer(O) is true, then
+    if (array_buffer_object->is_fixed_length()) {
+        // a. Let length be O.[[ArrayBufferByteLength]]..
+        length = array_buffer_object->byte_length();
+    }
+    // 6. Else,
+    else {
+        // a. Let length be O.[[ArrayBufferMaxByteLength]].
+        length = array_buffer_object->max_byte_length().value();
+    }
+
+    // 7. Return 𝔽(length).
+    return Value(length);
+}
+
+// 25.1.6.4 get ArrayBuffer.prototype.resizable, https://tc39.es/ecma262/#sec-get-arraybuffer.prototype.resizable
+JS_DEFINE_NATIVE_FUNCTION(ArrayBufferPrototype::resizable_getter)
+{
+    // 1. Let O be the this value.
+    // 2. Perform ? RequireInternalSlot(O, [[ArrayBufferData]]).
+    auto array_buffer_object = TRY(typed_this_value(vm));
+
+    // 3. If IsSharedArrayBuffer(O) is true, throw a TypeError exception.
+    if (array_buffer_object->is_shared_array_buffer())
+        return vm.throw_completion<TypeError>(ErrorType::ThisCannotBeSharedArrayBuffer);
+
+    // 4. Return IsResizableArrayBuffer(O).
+    return !array_buffer_object->is_fixed_length();
+}
+
+// 25.1.6.5 ArrayBuffer.prototype.resize ( newLength ), https://tc39.es/ecma262/#sec-arraybuffer.prototype.resize
+JS_DEFINE_NATIVE_FUNCTION(ArrayBufferPrototype::resize)
+{
+    // 1. Let O be the this value.
+    auto array_buffer_object = TRY(typed_this_value(vm));
+
+    // 2. Perform ? RequireInternalSlot(O, [[ArrayBufferMaxByteLength]]).
+    if (array_buffer_object->is_fixed_length())
+        return vm.throw_completion<TypeError>(ErrorType::ResizingAFixedLengthArrayBuffer);
+
+    // 3. If IsSharedArrayBuffer(O) is true, throw a TypeError exception.
+    if (array_buffer_object->is_shared_array_buffer())
+        return vm.throw_completion<TypeError>(ErrorType::ThisCannotBeSharedArrayBuffer);
+
+    // 4. Let newByteLength be ? ToIndex(newLength).
+    auto new_byte_length = TRY(vm.argument(0).to_index(vm));
+
+    // 5. If IsDetachedBuffer(O) is true, throw a TypeError exception.
+    if (array_buffer_object->is_detached())
+        return vm.throw_completion<TypeError>(ErrorType::DetachedArrayBuffer);
+
+    // NOTE: newByteLength < 0 is always false as new_byte_length is unsigned
+    // 6. If newByteLength < 0 or newByteLength > O.[[ArrayBufferMaxByteLength]], throw a RangeError exception.
+    if (new_byte_length > array_buffer_object->max_byte_length().value())
+        return vm.throw_completion<RangeError>(ErrorType::InvalidByteLengthForResizableArrayBuffer, new_byte_length, array_buffer_object->max_byte_length().value());
+
+    // 7. Let hostHandled be ? HostResizeArrayBuffer(O, newByteLength)
+    auto host_handled = TRY(vm.host_resize_array_buffer(*array_buffer_object, new_byte_length));
+
+    // 8. If hostHandled is handled, return undefined.
+    if (host_handled == HostHandled::Handled)
+        return js_undefined();
+
+    // 9. Let oldBlock be O.[[ArrayBufferData]].
+    auto old_block = array_buffer_object->buffer();
+
+    // 10. Let newBlock be ? CreateByteDataBlock(newByteLength).
+    auto new_block = TRY(create_byte_data_block(vm, new_byte_length));
+
+    // 11. Let copyLength be min(newByteLength, O.[[ArrayBufferByteLength]]).
+    auto copy_length = min(new_byte_length, array_buffer_object->byte_length());
+
+    // 12. Perform CopyDataBlockBytes(newBlock, 0, oldBlock, 0, copyLength).
+    copy_data_block_bytes(new_block.buffer(), 0, old_block, 0, copy_length);
+
+    // 13. NOTE: Neither creation of the new Data Block nor copying from the old Data Block are observable. Implementations reserve the right to implement this method as in-place growth or shrinkage.
+
+    // 14. Set O.[[ArrayBufferData]] to newBlock.
+    // 15. Set O.[[ArrayBufferByteLength]] to newByteLength.
+    array_buffer_object->set_data_block(new_block);
+
+    // 16. Return undefined.
+    return js_undefined();
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/ArrayBufferPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/ArrayBufferPrototype.h
@@ -21,11 +21,14 @@ public:
 private:
     explicit ArrayBufferPrototype(Realm&);
 
+    JS_DECLARE_NATIVE_FUNCTION(resize);
     JS_DECLARE_NATIVE_FUNCTION(slice);
     JS_DECLARE_NATIVE_FUNCTION(transfer);
     JS_DECLARE_NATIVE_FUNCTION(transfer_to_fixed_length);
     JS_DECLARE_NATIVE_FUNCTION(byte_length_getter);
     JS_DECLARE_NATIVE_FUNCTION(detached_getter);
+    JS_DECLARE_NATIVE_FUNCTION(resizable_getter);
+    JS_DECLARE_NATIVE_FUNCTION(max_byte_length_getter);
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/ArrayIteratorPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayIteratorPrototype.cpp
@@ -54,7 +54,8 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayIteratorPrototype::next)
         if (typed_array.viewed_array_buffer()->is_detached())
             return vm.throw_completion<TypeError>(ErrorType::DetachedArrayBuffer);
 
-        length = typed_array.array_length();
+        // FIXME: shouldn't be auto unaware, however it seems this function needs to be re-written entirely
+        length = typed_array.auto_unaware_array_length();
     } else {
         length = TRY(length_of_array_like(vm, array));
     }

--- a/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
+++ b/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
@@ -346,6 +346,7 @@ namespace JS {
     P(leftContext)                           \
     P(map)                                   \
     P(max)                                   \
+    P(maxByteLength)                         \
     P(maximize)                              \
     P(mergeFields)                           \
     P(message)                               \
@@ -421,6 +422,8 @@ namespace JS {
     P(reject)                                \
     P(relativeTo)                            \
     P(repeat)                                \
+    P(resize)                                \
+    P(resizable)                             \
     P(resolve)                               \
     P(resolvedOptions)                       \
     P(reverse)                               \

--- a/Userland/Libraries/LibJS/Runtime/DataView.cpp
+++ b/Userland/Libraries/LibJS/Runtime/DataView.cpp
@@ -8,15 +8,15 @@
 
 namespace JS {
 
-NonnullGCPtr<DataView> DataView::create(Realm& realm, ArrayBuffer* viewed_buffer, size_t byte_length, size_t byte_offset)
+NonnullGCPtr<DataView> DataView::create(Realm& realm, ArrayBuffer* viewed_buffer, Optional<size_t> byte_length, size_t byte_offset)
 {
     return realm.heap().allocate<DataView>(realm, viewed_buffer, byte_length, byte_offset, realm.intrinsics().data_view_prototype());
 }
 
-DataView::DataView(ArrayBuffer* viewed_buffer, size_t byte_length, size_t byte_offset, Object& prototype)
+DataView::DataView(ArrayBuffer* viewed_buffer, Optional<size_t> byte_length, size_t byte_offset, Object& prototype)
     : Object(ConstructWithPrototypeTag::Tag, prototype)
     , m_viewed_array_buffer(viewed_buffer)
-    , m_byte_length(byte_length)
+    , m_byte_length(move(byte_length))
     , m_byte_offset(byte_offset)
 {
 }
@@ -25,6 +25,94 @@ void DataView::visit_edges(Visitor& visitor)
 {
     Base::visit_edges(visitor);
     visitor.visit(m_viewed_array_buffer);
+}
+
+// 25.3.1.2 MakeDataViewWithBufferWitnessRecord ( obj, order )
+DataViewRecord make_data_view_with_buffer_witness_record(VM& vm, DataView const& data_view, ArrayBuffer::Order order)
+{
+    // 1. Let buffer be obj.[[ViewedArrayBuffer]].
+    auto* buffer = data_view.viewed_array_buffer();
+
+    // 2. If IsDetachedBuffer(buffer) is true, then
+    // a. Let byteLength be detached.
+    // 3. Else,
+    // a. Let byteLength be ArrayBufferByteLength(buffer, order).
+    auto byte_length = buffer->is_detached() ? Optional<size_t> {} : array_buffer_byte_length(vm, *buffer, order);
+
+    // 4. Return the DataView With Buffer Witness Record { [[Object]]: obj, [[CachedBufferByteLength]]: byteLength }.
+    return { &data_view, byte_length };
+}
+
+// 25.3.1.3 GetViewByteLength ( viewRecord ), https://tc39.es/ecma262/#sec-getviewbytelength
+size_t get_view_byte_length(DataViewRecord const& view_record)
+{
+    // 1. Assert: IsViewOutOfBounds(viewRecord) is false.
+    VERIFY(!is_view_out_of_bounds(view_record));
+
+    // 2. Let view be viewRecord.[[Object]].
+    auto const* view = view_record.object;
+
+    // 3. If view.[[ByteLength]] is not auto, return view.[[ByteLength]].
+    if (!view->is_byte_length_auto())
+        return view->byte_length().value();
+
+    // 4. Assert: IsFixedLengthArrayBuffer(view.[[ViewedArrayBuffer]]) is false.
+    VERIFY(!view->viewed_array_buffer()->is_fixed_length());
+
+    // 5. Let byteOffset be view.[[ByteOffset]].
+    auto byte_offset = view->byte_offset();
+
+    // 6. Let byteLength be viewRecord.[[CachedBufferByteLength]].
+    auto byte_length = view_record.cached_buffer_byte_length;
+
+    // 7. Assert: byteLength is not detached.
+    VERIFY(byte_length.has_value());
+
+    // 8. Return byteLength - byteOffset.
+    return byte_length.value() - byte_offset;
+}
+
+// 25.3.1.4 IsViewOutOfBounds ( viewRecord ), https://tc39.es/ecma262/#sec-getviewbytelength
+bool is_view_out_of_bounds(DataViewRecord const& view_record)
+{
+    // 1. Let view be viewRecord.[[Object]].
+    auto const* view = view_record.object;
+
+    // 2. Let bufferByteLength be viewRecord.[[CachedBufferByteLength]].
+    auto buffer_byte_length = view_record.cached_buffer_byte_length;
+
+    // 3. Assert: IsDetachedBuffer(view.[[ViewedArrayBuffer]]) is true if and only if bufferByteLength is detached.
+    if (!buffer_byte_length.has_value()) {
+        VERIFY(view->viewed_array_buffer()->is_detached());
+
+        // 4. If bufferByteLength is detached, return true.
+        return true;
+    }
+
+    // 5. Let byteOffsetStart be view.[[ByteOffset]].
+    auto byte_offset_start = view->byte_offset();
+
+    size_t byte_offset_end = 0;
+
+    // 6. If view.[[ByteLength]] is auto, then
+    if (view->is_byte_length_auto()) {
+        // a. Let byteOffsetEnd be bufferByteLength.
+        byte_offset_end = buffer_byte_length.value();
+    }
+    // 7. Else,
+    else {
+        // a. Let byteOffsetEnd be byteOffsetStart + view.[[ByteLength]].
+        byte_offset_end = byte_offset_start + view->byte_length().value();
+    }
+
+    // 8. If byteOffsetStart > bufferByteLength or byteOffsetEnd > bufferByteLength, return true.
+    if (byte_offset_start > buffer_byte_length.value() || byte_offset_end > buffer_byte_length.value())
+        return true;
+
+    // 9. NOTE: 0-length DataViews are not considered out-of-bounds.
+
+    // 10. Return false.
+    return false;
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/DataView.h
+++ b/Userland/Libraries/LibJS/Runtime/DataView.h
@@ -12,25 +12,44 @@
 
 namespace JS {
 
+// 25.3.1.1 DataView With Buffer Witness Records, https://tc39.es/ecma262/#sec-dataview-with-buffer-witness-records
+struct DataViewRecord {
+    DataView const* object;
+    Optional<size_t> cached_buffer_byte_length;
+};
+
+DataViewRecord make_data_view_with_buffer_witness_record(VM&, DataView const&, ArrayBuffer::Order);
+size_t get_view_byte_length(DataViewRecord const&);
+bool is_view_out_of_bounds(DataViewRecord const&);
+
 class DataView : public Object {
     JS_OBJECT(DataView, Object);
 
 public:
-    static NonnullGCPtr<DataView> create(Realm&, ArrayBuffer*, size_t byte_length, size_t byte_offset);
+    static NonnullGCPtr<DataView> create(Realm&, ArrayBuffer*, Optional<size_t> byte_length, size_t byte_offset);
 
     virtual ~DataView() override = default;
 
     ArrayBuffer* viewed_array_buffer() const { return m_viewed_array_buffer; }
-    size_t byte_length() const { return m_byte_length; }
+    Optional<size_t> byte_length() const { return m_byte_length; }
+    bool is_byte_length_auto() const { return !m_byte_length.has_value(); }
     size_t byte_offset() const { return m_byte_offset; }
 
+    // FIXME: Some functions in other web specs aren't aware of byte length potentionally being auto
+    // These functions performs the steps to get the byte length that is used in other parts of the EMCAScript spec
+    size_t auto_unaware_byte_length() const
+    {
+        auto view_record = make_data_view_with_buffer_witness_record(vm(), *this, ArrayBuffer::Order::Unordered);
+        return is_view_out_of_bounds(view_record) ? 0 : get_view_byte_length(view_record);
+    }
+
 private:
-    DataView(ArrayBuffer*, size_t byte_length, size_t byte_offset, Object& prototype);
+    DataView(ArrayBuffer*, Optional<size_t> byte_length, size_t byte_offset, Object& prototype);
 
     virtual void visit_edges(Visitor& visitor) override;
 
     GCPtr<ArrayBuffer> m_viewed_array_buffer;
-    size_t m_byte_length { 0 };
+    Optional<size_t> m_byte_length { 0 };
     size_t m_byte_offset { 0 };
 };
 

--- a/Userland/Libraries/LibJS/Runtime/DataViewPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/DataViewPrototype.cpp
@@ -51,7 +51,7 @@ void DataViewPrototype::initialize(Realm& realm)
     define_direct_property(vm.well_known_symbol_to_string_tag(), PrimitiveString::create(vm, vm.names.DataView.as_string()), Attribute::Configurable);
 }
 
-// 25.3.1.1 GetViewValue ( view, requestIndex, isLittleEndian, type ), https://tc39.es/ecma262/#sec-getviewvalue
+// 25.3.1.5 GetViewValue ( view, requestIndex, isLittleEndian, type ), https://tc39.es/ecma262/#sec-getviewvalue
 template<typename T>
 static ThrowCompletionOr<Value> get_view_value(VM& vm, Value request_index, Value is_little_endian)
 {
@@ -65,38 +65,40 @@ static ThrowCompletionOr<Value> get_view_value(VM& vm, Value request_index, Valu
     // 4. Set isLittleEndian to ToBoolean(isLittleEndian).
     auto little_endian = is_little_endian.to_boolean();
 
-    // 5. Let buffer be view.[[ViewedArrayBuffer]].
-    auto buffer = view->viewed_array_buffer();
-
-    // 6. If IsDetachedBuffer(buffer) is true, throw a TypeError exception.
-    if (buffer->is_detached())
-        return vm.template throw_completion<TypeError>(ErrorType::DetachedArrayBuffer);
-
-    // 7. Let viewOffset be view.[[ByteOffset]].
+    // 5. Let viewOffset be view.[[ByteOffset]].
     auto view_offset = view->byte_offset();
 
-    // 8. Let viewSize be view.[[ByteLength]].
-    auto view_size = view->byte_length();
+    // 6. Let viewRecord be MakeDataViewWithBufferWitnessRecord(view, unordered).
+    auto view_record = make_data_view_with_buffer_witness_record(vm, *view, ArrayBuffer::Order::Unordered);
 
-    // 9. Let elementSize be the Element Size value specified in Table 68 for Element Type type.
+    // 7. NOTE: Bounds checking is not a synchronizing operation when view's backing buffer is a growable SharedArrayBuffer.
+
+    // 8. If IsViewOutOfBounds(viewRecord) is true, throw a TypeError exception.
+    if (is_view_out_of_bounds(view_record))
+        return vm.throw_completion<TypeError>(ErrorType::DataViewOutOfBounds);
+
+    // 9. Let viewSize be GetViewByteLength(viewRecord).
+    auto view_size = get_view_byte_length(view_record);
+
+    // 10. Let elementSize be the Element Size value specified in Table 71 for Element Type type.
     auto element_size = sizeof(T);
-
-    // 11. Let bufferIndex be getIndex + viewOffset.
-    Checked<size_t> buffer_index = get_index;
-    buffer_index += view_offset;
 
     Checked<size_t> end_index = get_index;
     end_index += element_size;
 
-    // 10. If getIndex + elementSize > viewSize, throw a RangeError exception.
+    // 12. Let bufferIndex be getIndex + viewOffset.
+    Checked<size_t> buffer_index = get_index;
+    buffer_index += view_offset;
+
+    // 11. If getIndex + elementSize > viewSize, throw a RangeError exception.
     if (buffer_index.has_overflow() || end_index.has_overflow() || end_index.value() > view_size)
         return vm.throw_completion<RangeError>(ErrorType::DataViewOutOfRangeByteOffset, get_index, view_size);
 
-    // 12. Return GetValueFromBuffer(buffer, bufferIndex, type, false, Unordered, isLittleEndian).
-    return buffer->get_value<T>(buffer_index.value(), false, ArrayBuffer::Order::Unordered, little_endian);
+    // 13. Return GetValueFromBuffer(view.[[ViewedArrayBuffer]], bufferIndex, type, false, unordered, isLittleEndian).
+    return view->viewed_array_buffer()->get_value<T>(buffer_index.value(), false, ArrayBuffer::Order::Unordered, little_endian);
 }
 
-// 25.3.1.2 SetViewValue ( view, requestIndex, isLittleEndian, type, value ), https://tc39.es/ecma262/#sec-setviewvalue
+// 25.3.1.6 SetViewValue ( view, requestIndex, isLittleEndian, type, value ), https://tc39.es/ecma262/#sec-setviewvalue
 template<typename T>
 static ThrowCompletionOr<Value> set_view_value(VM& vm, Value request_index, Value is_little_endian, Value value)
 {
@@ -119,37 +121,39 @@ static ThrowCompletionOr<Value> set_view_value(VM& vm, Value request_index, Valu
     // 6. Set isLittleEndian to ToBoolean(isLittleEndian).
     auto little_endian = is_little_endian.to_boolean();
 
-    // 7. Let buffer be view.[[ViewedArrayBuffer]].
-    auto buffer = view->viewed_array_buffer();
-
-    // 8. If IsDetachedBuffer(buffer) is true, throw a TypeError exception.
-    if (buffer->is_detached())
-        return vm.throw_completion<TypeError>(ErrorType::DetachedArrayBuffer);
-
-    // 9. Let viewOffset be view.[[ByteOffset]].
+    // 7. Let viewOffset be view.[[ByteOffset]].
     auto view_offset = view->byte_offset();
 
-    // 10. Let viewSize be view.[[ByteLength]].
-    auto view_size = view->byte_length();
+    // 8. Let viewRecord be MakeDataViewWithBufferWitnessRecord(view, unordered).
+    auto view_record = make_data_view_with_buffer_witness_record(vm, *view, ArrayBuffer::Order::Unordered);
 
-    // 11. Let elementSize be the Element Size value specified in Table 68 for Element Type type.
+    // 9. NOTE: Bounds checking is not a synchronizing operation when view's backing buffer is a growable SharedArrayBuffer.
+
+    // 10. If IsViewOutOfBounds(viewRecord) is true, throw a TypeError exception.
+    if (is_view_out_of_bounds(view_record))
+        return vm.throw_completion<TypeError>(ErrorType::DataViewOutOfBounds);
+
+    // 11. Let viewSize be GetViewByteLength(viewRecord).
+    auto view_size = get_view_byte_length(view_record);
+
+    // 12. Let elementSize be the Element Size value specified in Table 68 for Element Type type.
     auto element_size = sizeof(T);
 
-    // 13. Let bufferIndex be getIndex + viewOffset.
+    // 14. Let bufferIndex be getIndex + viewOffset.
     Checked<size_t> buffer_index = get_index;
     buffer_index += view_offset;
 
     Checked<size_t> end_index = get_index;
     end_index += element_size;
 
-    // 12. If getIndex + elementSize > viewSize, throw a RangeError exception.
+    // 13. If getIndex + elementSize > viewSize, throw a RangeError exception.
     if (buffer_index.has_overflow() || end_index.has_overflow() || end_index.value() > view_size)
         return vm.throw_completion<RangeError>(ErrorType::DataViewOutOfRangeByteOffset, get_index, view_size);
 
-    // 14. Perform SetValueInBuffer(buffer, bufferIndex, type, numberValue, false, Unordered, isLittleEndian).
-    MUST_OR_THROW_OOM(buffer->set_value<T>(buffer_index.value(), number_value, false, ArrayBuffer::Order::Unordered, little_endian));
+    // 15. Perform SetValueInBuffer(view.[[ViewedArrayBuffer]], bufferIndex, type, numberValue, false, unordered, isLittleEndian).
+    MUST_OR_THROW_OOM(view->viewed_array_buffer()->set_value<T>(buffer_index.value(), number_value, false, ArrayBuffer::Order::Unordered, little_endian));
 
-    // 15. Return undefined.
+    // 16. Return undefined.
     return js_undefined();
 }
 
@@ -174,14 +178,18 @@ JS_DEFINE_NATIVE_FUNCTION(DataViewPrototype::byte_length_getter)
     // 3. Assert: O has a [[ViewedArrayBuffer]] internal slot.
     auto data_view = TRY(typed_this_value(vm));
 
-    // 4. Let buffer be O.[[ViewedArrayBuffer]].
-    // 5. If IsDetachedBuffer(buffer) is true, throw a TypeError exception.
-    if (data_view->viewed_array_buffer()->is_detached())
-        return vm.throw_completion<TypeError>(ErrorType::DetachedArrayBuffer);
+    // 4. Let viewRecord be MakeDataViewWithBufferWitnessRecord(O, seq-cst).
+    auto view_record = make_data_view_with_buffer_witness_record(vm, *data_view, ArrayBuffer::Order::SeqCst);
 
-    // 6. Let size be O.[[ByteLength]].
+    // 5. If IsViewOutOfBounds(viewRecord) is true, throw a TypeError exception.
+    if (is_view_out_of_bounds(view_record))
+        return vm.throw_completion<TypeError>(ErrorType::DataViewOutOfBounds);
+
+    // 6. Let size be GetViewByteLength(viewRecord).
+    auto size = get_view_byte_length(view_record);
+
     // 7. Return 𝔽(size).
-    return Value(data_view->byte_length());
+    return Value(size);
 }
 
 // 25.3.4.3 get DataView.prototype.byteOffset, https://tc39.es/ecma262/#sec-get-dataview.prototype.byteoffset
@@ -192,14 +200,18 @@ JS_DEFINE_NATIVE_FUNCTION(DataViewPrototype::byte_offset_getter)
     // 3. Assert: O has a [[ViewedArrayBuffer]] internal slot.
     auto data_view = TRY(typed_this_value(vm));
 
-    // 4. Let buffer be O.[[ViewedArrayBuffer]].
-    // 5. If IsDetachedBuffer(buffer) is true, throw a TypeError exception.
-    if (data_view->viewed_array_buffer()->is_detached())
-        return vm.throw_completion<TypeError>(ErrorType::DetachedArrayBuffer);
+    // 4. Let viewRecord be MakeDataViewWithBufferWitnessRecord(O, seq-cst).
+    auto view_record = make_data_view_with_buffer_witness_record(vm, *data_view, ArrayBuffer::Order::SeqCst);
+
+    // 5. If IsViewOutOfBounds(viewRecord) is true, throw a TypeError exception.
+    if (is_view_out_of_bounds(view_record))
+        return vm.throw_completion<TypeError>(ErrorType::DataViewOutOfBounds);
 
     // 6. Let offset be O.[[ByteOffset]].
+    auto offset = data_view->byte_offset();
+
     // 7. Return 𝔽(offset).
-    return Value(data_view->byte_offset());
+    return Value(offset);
 }
 
 // 25.3.4.5 DataView.prototype.getBigInt64 ( byteOffset [ , littleEndian ] ), https://tc39.es/ecma262/#sec-dataview.prototype.getbigint64

--- a/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
+++ b/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
@@ -27,6 +27,7 @@
     M(ClassIsAbstract, "Abstract class {} cannot be constructed directly")                                                              \
     M(ConstructorWithoutNew, "{} constructor must be called with 'new'")                                                                \
     M(Convert, "Cannot convert {} to {}")                                                                                               \
+    M(DataViewOutOfBounds, "Data view is out of bounds")                                                                                \
     M(DataViewOutOfRangeByteOffset, "Data view byte offset {} is out of range for buffer with length {}")                               \
     M(DerivedConstructorReturningInvalidValue, "Derived constructor return invalid value")                                              \
     M(DescWriteNonWritable, "Cannot write to non-writable property '{}'")                                                               \

--- a/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
+++ b/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
@@ -43,6 +43,7 @@
     M(IndexOutOfRange, "Index {} is out of range of array length {}")                                                                   \
     M(InOperatorWithObject, "'in' operator must be used on an object")                                                                  \
     M(InstanceOfOperatorBadPrototype, "'prototype' property of {} is not an object")                                                    \
+    M(IntegerIndexedObjectOutOfRange, "Integer indexed object '{}' is out of range")                                                    \
     M(IntlInvalidDateTimeFormatOption, "Option {} cannot be set when also providing {}")                                                \
     M(IntlInvalidKey, "{} is not a valid key")                                                                                          \
     M(IntlInvalidLanguageTag, "{} is not a structurally valid language tag")                                                            \

--- a/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
+++ b/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
@@ -58,6 +58,8 @@
     M(IntlNonNumericOr2DigitAfterNumericOr2Digit, "Styles other than 'numeric' and '2-digit' may not be used in smaller units after "   \
                                                   "being used in larger units")                                                         \
     M(InvalidAssignToConst, "Invalid assignment to const variable")                                                                     \
+    M(InvalidByteLengthForResizableArrayBuffer, "Byte length of {} is not less or equal to maxByteLength {} for resizable "             \
+                                                "ArrayBuffer")                                                                          \
     M(InvalidCodePoint, "Invalid code point {}, must be an integer no less than 0 and no greater than 0x10FFFF")                        \
     M(InvalidFormat, "Invalid {} format")                                                                                               \
     M(InvalidFractionDigits, "Fraction Digits must be an integer no less than 0, and no greater than 100")                              \
@@ -214,6 +216,7 @@
     M(RegExpObjectBadFlag, "Invalid RegExp flag '{}'")                                                                                  \
     M(RegExpObjectRepeatedFlag, "Repeated RegExp flag '{}'")                                                                            \
     M(RegExpObjectIncompatibleFlags, "RegExp flag '{}' is incompatible with flag '{}'")                                                 \
+    M(ResizingAFixedLengthArrayBuffer, "Tried to resize an ArrayBuffer that is fixed length")                                           \
     M(RestrictedFunctionPropertiesAccess, "Restricted function properties like 'callee', 'caller' and 'arguments' may "                 \
                                           "not be accessed in strict mode")                                                             \
     M(RestrictedGlobalProperty, "Cannot declare global property '{}'")                                                                  \

--- a/Userland/Libraries/LibJS/Runtime/VM.cpp
+++ b/Userland/Libraries/LibJS/Runtime/VM.cpp
@@ -17,6 +17,7 @@
 #include <LibJS/Bytecode/Interpreter.h>
 #include <LibJS/Runtime/AbstractOperations.h>
 #include <LibJS/Runtime/Array.h>
+#include <LibJS/Runtime/ArrayBuffer.h>
 #include <LibJS/Runtime/BoundFunction.h>
 #include <LibJS/Runtime/Completion.h>
 #include <LibJS/Runtime/ECMAScriptFunctionObject.h>
@@ -165,6 +166,20 @@ VM::VM(OwnPtr<CustomData> custom_data, ErrorMessages error_messages)
         // This abstract operation is only invoked by ECMAScript hosts that are web browsers.
         // NOTE: Since LibJS has no way of knowing whether the current environment is a browser we always
         //       call HostEnsureCanAddPrivateElement when needed.
+    };
+
+    // 25.1.3.7 HostResizeArrayBuffer ( buffer, newByteLength ), https://tc39.es/ecma262/#sec-hostresizearraybuffer
+    host_resize_array_buffer = [this](ArrayBuffer& buffer, size_t new_byte_length) -> ThrowCompletionOr<HostHandled> {
+        // The host-defined abstract operation HostResizeArrayBuffer takes arguments buffer (an ArrayBuffer)
+        // and newByteLength (a non-negative integer) and returns either a normal completion containing either handled or unhandled,
+        // or a throw completion. It gives the host an opportunity to perform implementation-defined resizing of buffer.
+        // If the host chooses not to handle resizing of buffer, it may return unhandled for the default behaviour.
+        // The implementation of HostResizeArrayBuffer must conform to the following requirements:
+        // The abstract operation does not detach buffer.
+        // If the abstract operation completes normally with handled, buffer.[[ArrayBufferByteLength]] is newByteLength.
+        // The default implementation of HostResizeArrayBuffer is to return NormalCompletion(unhandled).
+        TRY_OR_THROW_OOM(*this, buffer.buffer().try_resize(new_byte_length));
+        return HostHandled::Handled;
     };
 }
 

--- a/Userland/Libraries/LibJS/Runtime/VM.h
+++ b/Userland/Libraries/LibJS/Runtime/VM.h
@@ -29,6 +29,11 @@ namespace JS {
 class Identifier;
 struct BindingPattern;
 
+enum class HostHandled {
+    Handled,
+    Unhandled
+};
+
 class VM : public RefCounted<VM> {
 public:
     struct CustomData {
@@ -240,6 +245,7 @@ public:
     Function<JobCallback(FunctionObject&)> host_make_job_callback;
     Function<ThrowCompletionOr<void>(Realm&)> host_ensure_can_compile_strings;
     Function<ThrowCompletionOr<void>(Object&)> host_ensure_can_add_private_element;
+    Function<ThrowCompletionOr<HostHandled>(ArrayBuffer&, size_t)> host_resize_array_buffer;
 
     // Execute a specific AST node either in AST or BC interpreter, depending on which one is enabled by default.
     // NOTE: This is meant as a temporary stopgap until everything is bytecode.

--- a/Userland/Libraries/LibJS/Tests/builtins/ArrayBuffer/ArrayBuffer.constructor.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/ArrayBuffer/ArrayBuffer.constructor.js
@@ -1,0 +1,12 @@
+test("invalid maxByteLength throws", () => {
+    expect(() => {
+        new ArrayBuffer(8, { maxByteLength: 4 });
+    }).toThrowWithMessage(
+        RangeError,
+        "Byte length of 8 is not less or equal to maxByteLength 4 for resizable ArrayBuffer"
+    );
+
+    expect(() => {
+        new ArrayBuffer(8, { maxByteLength: -1 });
+    }).toThrowWithMessage(RangeError, "Index must be a positive integer");
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/ArrayBuffer/ArrayBuffer.prototype.maxByteLength.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/ArrayBuffer/ArrayBuffer.prototype.maxByteLength.js
@@ -1,0 +1,21 @@
+test("basic functionality", () => {
+    expect(new ArrayBuffer(0, { maxByteLength: 0 }).maxByteLength).toBe(0);
+    expect(new ArrayBuffer(0, { maxByteLength: 1 }).maxByteLength).toBe(1);
+    expect(new ArrayBuffer(0, { maxByteLength: 64 }).maxByteLength).toBe(64);
+    expect(new ArrayBuffer(0, { maxByteLength: 128 }).maxByteLength).toBe(128);
+});
+
+test("maxByteLength returning byteLength", () => {
+    expect(new ArrayBuffer(0).maxByteLength).toBe(0);
+    expect(new ArrayBuffer(1).maxByteLength).toBe(1);
+    expect(new ArrayBuffer(64).maxByteLength).toBe(64);
+    expect(new ArrayBuffer(128).maxByteLength).toBe(128);
+});
+
+test("detached returns 0", () => {
+    let source = new ArrayBuffer(8, { maxByteLength: 16 });
+    let dest = source.transfer();
+
+    expect(source.maxByteLength).toBe(0);
+    expect(dest.maxByteLength).toBe(16);
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/ArrayBuffer/ArrayBuffer.prototype.resizable.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/ArrayBuffer/ArrayBuffer.prototype.resizable.js
@@ -1,0 +1,6 @@
+test("basic functionality", () => {
+    expect(new ArrayBuffer().resizable).toBeFalse();
+    expect(new ArrayBuffer(0, { byteLength: 16 }).resizable).toBeFalse();
+    expect(new ArrayBuffer(0, { maxByteLength: 0 }).resizable).toBeTrue();
+    expect(new ArrayBuffer(16, { maxByteLength: 16 }).resizable).toBeTrue();
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/ArrayBuffer/ArrayBuffer.prototype.resize.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/ArrayBuffer/ArrayBuffer.prototype.resize.js
@@ -1,0 +1,25 @@
+test("basic functionality", () => {
+    const resizableBuffer = new ArrayBuffer(8, { maxByteLength: 16 });
+
+    expect(resizableBuffer.resize(8)).toBeUndefined();
+    expect(resizableBuffer.resize(0)).toBeUndefined();
+    expect(resizableBuffer.resize(16)).toBeUndefined();
+
+    expect(() => {
+        resizableBuffer.resize(-1);
+    }).toThrowWithMessage(RangeError, "Index must be a positive integer");
+    expect(() => {
+        resizableBuffer.resize(17);
+    }).toThrowWithMessage(
+        RangeError,
+        "Byte length of 17 is not less or equal to maxByteLength 16 for resizable ArrayBuffer"
+    );
+});
+
+test("fixed length buffer resize should throw", () => {
+    const staticBuffer = new ArrayBuffer(8);
+
+    expect(() => {
+        staticBuffer.resize(0);
+    }).toThrowWithMessage(TypeError, "Tried to resize an ArrayBuffer that is fixed length");
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/ArrayBuffer/ArrayBuffer.prototype.transfer.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/ArrayBuffer/ArrayBuffer.prototype.transfer.js
@@ -1,0 +1,25 @@
+test("basic functionality", () => {
+    const emptyArray = new ArrayBuffer(0);
+    const emptyDest = emptyArray.transfer();
+
+    expect(emptyArray.detached).toBe(true);
+    expect(emptyDest.detached).toBe(false);
+    expect(emptyDest.byteLength).toBe(0);
+    expect(emptyDest.maxByteLength).toBe(0);
+
+    const resizableArray = new ArrayBuffer(8, { maxByteLength: 16 });
+    const fullView = new Uint8Array(resizableArray);
+    fullView[0] = 1;
+
+    const resizableDest = resizableArray.transfer();
+    const fullDestView = new Uint8Array(resizableDest);
+
+    expect(resizableArray.detached).toBe(true);
+    expect(resizableDest.detached).toBe(false);
+    expect(resizableDest.resizable).toBe(true);
+    expect(fullView.byteLength).toBe(0);
+    expect(resizableDest.byteLength).toBe(8);
+    expect(resizableDest.maxByteLength).toBe(16);
+    expect(fullDestView.byteLength).toBe(8);
+    expect(fullDestView[0]).toBe(1);
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/ArrayBuffer/ArrayBuffer.prototype.transferToFixedLength.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/ArrayBuffer/ArrayBuffer.prototype.transferToFixedLength.js
@@ -1,0 +1,33 @@
+test("basic functionality", () => {
+    const emptyArray = new ArrayBuffer(0);
+    const emptyDest = emptyArray.transferToFixedLength();
+
+    expect(emptyArray.detached).toBe(true);
+    expect(emptyDest.detached).toBe(false);
+    expect(emptyDest.byteLength).toBe(0);
+    expect(emptyDest.maxByteLength).toBe(0);
+
+    const resizableArray = new ArrayBuffer(8, { maxByteLength: 16 });
+    const resizableDest = resizableArray.transferToFixedLength();
+
+    expect(resizableArray.detached).toBe(true);
+    expect(resizableDest.detached).toBe(false);
+    expect(resizableDest.resizable).toBe(false);
+    expect(resizableDest.byteLength).toBe(8);
+    expect(resizableDest.maxByteLength).toBe(8);
+
+    const staticArray = new ArrayBuffer(8);
+    const fullView = new Uint8Array(staticArray);
+    fullView[0] = 1;
+
+    const staticDest = staticArray.transferToFixedLength();
+    const fullDestView = new Uint8Array(staticDest);
+
+    expect(staticArray.detached).toBe(true);
+    expect(fullView.byteLength).toBe(0);
+    expect(staticDest.detached).toBe(false);
+    expect(staticDest.byteLength).toBe(8);
+    expect(staticDest.maxByteLength).toBe(8);
+    expect(fullDestView.byteLength).toBe(8);
+    expect(fullDestView[0]).toBe(1);
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.js
@@ -390,3 +390,19 @@ test("source is not the same value as the receiver, and the index is invalid", (
         expect(receiver[2]).toBeUndefined();
     });
 });
+
+test("resizing array buffer changes typed array length", () => {
+    TYPED_ARRAYS.forEach(T => {
+        const resizable = new ArrayBuffer(4 * T.BYTES_PER_ELEMENT, {
+            maxByteLength: 8 * T.BYTES_PER_ELEMENT,
+        });
+        const array = new T(resizable);
+        expect(array.byteLength).toBe(4 * T.BYTES_PER_ELEMENT);
+
+        resizable.resize(8 * T.BYTES_PER_ELEMENT);
+        expect(array.byteLength).toBe(8 * T.BYTES_PER_ELEMENT);
+
+        resizable.resize(0);
+        expect(array.byteLength).toBe(0);
+    });
+});

--- a/Userland/Libraries/LibWeb/Crypto/Crypto.cpp
+++ b/Userland/Libraries/LibWeb/Crypto/Crypto.cpp
@@ -48,7 +48,7 @@ WebIDL::ExceptionOr<JS::Value> Crypto::get_random_values(JS::Value array) const
     auto& typed_array = static_cast<JS::TypedArrayBase&>(array.as_object());
 
     // 2. If the byteLength of array is greater than 65536, throw a QuotaExceededError and terminate the algorithm.
-    if (typed_array.byte_length() > 65536)
+    if (typed_array.auto_unaware_byte_length() > 65536)
         return WebIDL::QuotaExceededError::create(realm(), "array's byteLength may not be greater than 65536"_fly_string);
 
     // IMPLEMENTATION DEFINED: If the viewed array buffer is detached, throw a InvalidStateError and terminate the algorithm.

--- a/Userland/Libraries/LibWeb/HTML/StructuredSerialize.cpp
+++ b/Userland/Libraries/LibWeb/HTML/StructuredSerialize.cpp
@@ -365,9 +365,9 @@ private:
             vector.append(bit_cast<u32*>(&serialized_buffer_size), 2);
             vector.extend(move(buffer_serialized));             // [[ArrayBufferSerialized]]
             TRY(serialize_string(vector, view.element_name())); // [[Constructor]]
-            vector.append(view.byte_length());
+            vector.append(view.auto_unaware_byte_length());
             vector.append(view.byte_offset());
-            vector.append(view.array_length());
+            vector.append(view.auto_unaware_array_length());
         }
         return {};
     }

--- a/Userland/Libraries/LibWeb/HTML/StructuredSerialize.cpp
+++ b/Userland/Libraries/LibWeb/HTML/StructuredSerialize.cpp
@@ -349,7 +349,7 @@ private:
             vector.append(bit_cast<u32*>(&serialized_buffer_size), 2);
             vector.extend(move(buffer_serialized));           // [[ArrayBufferSerialized]]
             TRY(serialize_string(vector, "DataView"_string)); // [[Constructor]]
-            vector.append(view.byte_length());
+            vector.append(view.auto_unaware_byte_length());
             vector.append(view.byte_offset());
         }
 

--- a/Userland/Libraries/LibWeb/Streams/AbstractOperations.cpp
+++ b/Userland/Libraries/LibWeb/Streams/AbstractOperations.cpp
@@ -1521,7 +1521,7 @@ WebIDL::ExceptionOr<void> readable_byte_stream_controller_enqueue(ReadableByteSt
     auto byte_offset = typed_array->byte_offset();
 
     // 5. Let byteLength be chunk.[[ByteLength]].
-    auto byte_length = typed_array->byte_length();
+    auto byte_length = typed_array->auto_unaware_byte_length();
 
     // 6. If ! IsDetachedBuffer(buffer) is true, throw a TypeError exception.
     if (buffer->is_detached()) {

--- a/Userland/Libraries/LibWeb/WebAssembly/WebAssembly.cpp
+++ b/Userland/Libraries/LibWeb/WebAssembly/WebAssembly.cpp
@@ -308,7 +308,7 @@ JS::ThrowCompletionOr<size_t> parse_module(JS::VM& vm, JS::Object* buffer_object
         data = buffer.buffer();
     } else if (is<JS::TypedArrayBase>(buffer_object)) {
         auto& buffer = static_cast<JS::TypedArrayBase&>(*buffer_object);
-        data = buffer.viewed_array_buffer()->buffer().span().slice(buffer.byte_offset(), buffer.byte_length());
+        data = buffer.viewed_array_buffer()->buffer().span().slice(buffer.byte_offset(), buffer.auto_unaware_byte_length());
     } else if (is<JS::DataView>(buffer_object)) {
         auto& buffer = static_cast<JS::DataView&>(*buffer_object);
         data = buffer.viewed_array_buffer()->buffer().span().slice(buffer.byte_offset(), buffer.byte_length());

--- a/Userland/Libraries/LibWeb/WebAssembly/WebAssembly.cpp
+++ b/Userland/Libraries/LibWeb/WebAssembly/WebAssembly.cpp
@@ -311,7 +311,7 @@ JS::ThrowCompletionOr<size_t> parse_module(JS::VM& vm, JS::Object* buffer_object
         data = buffer.viewed_array_buffer()->buffer().span().slice(buffer.byte_offset(), buffer.auto_unaware_byte_length());
     } else if (is<JS::DataView>(buffer_object)) {
         auto& buffer = static_cast<JS::DataView&>(*buffer_object);
-        data = buffer.viewed_array_buffer()->buffer().span().slice(buffer.byte_offset(), buffer.byte_length());
+        data = buffer.viewed_array_buffer()->buffer().span().slice(buffer.byte_offset(), buffer.auto_unaware_byte_length());
     } else {
         return vm.throw_completion<JS::TypeError>("Not a BufferSource"sv);
     }

--- a/Userland/Libraries/LibWeb/WebIDL/AbstractOperations.cpp
+++ b/Userland/Libraries/LibWeb/WebIDL/AbstractOperations.cpp
@@ -56,7 +56,7 @@ ErrorOr<ByteBuffer> get_buffer_source_copy(JS::Object const& buffer_source)
         offset = es_buffer_source.byte_offset();
 
         // 3. Set length to esBufferSource.[[ByteLength]].
-        length = es_buffer_source.byte_length();
+        length = es_buffer_source.auto_unaware_byte_length();
     }
     // 6. Otherwise:
     else {

--- a/Userland/Libraries/LibWeb/WebIDL/AbstractOperations.cpp
+++ b/Userland/Libraries/LibWeb/WebIDL/AbstractOperations.cpp
@@ -45,7 +45,7 @@ ErrorOr<ByteBuffer> get_buffer_source_copy(JS::Object const& buffer_source)
         offset = es_buffer_source.byte_offset();
 
         // 3. Set length to esBufferSource.[[ByteLength]].
-        length = es_buffer_source.byte_length();
+        length = es_buffer_source.auto_unaware_byte_length();
     } else if (is<JS::DataView>(buffer_source)) {
         auto const& es_buffer_source = static_cast<JS::DataView const&>(buffer_source);
 


### PR DESCRIPTION
This pr supports resizable ArrayBuffers, as well as support for TypedArray/DataViews to have resizable ArrayBuffers views.

Test262 Diff: ✅ +240 ❌ -240 :^)

Closes #21048