### PR TITLE
Ports/curl: Set CMake cache variable HAVE_GETADDRINFO_THREADSAFE to 1

### DIFF
--- a/Ports/curl/package.sh
+++ b/Ports/curl/package.sh
@@ -26,7 +26,8 @@ configure() {
         -DCURL_DISABLE_NTLM='ON' \
         -DCURL_DISABLE_SOCKETPAIR='ON' \
         -DCURL_DISABLE_TESTS='ON' \
-        -DCURL_HIDDEN_SYMBOLS='OFF'
+        -DCURL_HIDDEN_SYMBOLS='OFF' \
+        -DHAVE_GETADDRINFO_THREADSAFE=1
 }
 
 build() {


### PR DESCRIPTION
According to the issue https://github.com/curl/curl/issues/12093 the curl build doesn't properly detect that Serenity has getaddrinfo() and outputs the following:
```
Performing Test HAVE_H_ERRNO_ASSIGNABLE
CMake Error: try_run() invoked in cross-compiling mode, please set the following cache variables appropriately:
HAVE_H_ERRNO_ASSIGNABLE_EXITCODE (advanced)
```

Setting the CMake cache variable HAVE_GETADDRINFO_THREADSAFE=1 solves the mentioned error.

Also see: https://github.com/curl/curl/pull/12094