### PR TITLE
LibWeb: Support Object-position CSS property

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Userland/Libraries/LibWeb/CSS/ComputedValues.h
@@ -90,7 +90,7 @@ public:
     static CSS::WhiteSpace white_space() { return CSS::WhiteSpace::Normal; }
     static CSS::TextAlign text_align() { return CSS::TextAlign::Left; }
     static CSS::TextJustify text_justify() { return CSS::TextJustify::Auto; }
-    static CSS::Position position() { return CSS::Position::Static; }
+    static CSS::Positioning position() { return CSS::Positioning::Static; }
     static CSS::TextDecorationLine text_decoration_line() { return CSS::TextDecorationLine::None; }
     static CSS::Length text_decoration_thickness() { return Length::make_auto(); }
     static CSS::TextDecorationStyle text_decoration_style() { return CSS::TextDecorationStyle::Solid; }
@@ -304,7 +304,7 @@ public:
     Color text_decoration_color() const { return m_noninherited.text_decoration_color; }
     CSS::TextTransform text_transform() const { return m_inherited.text_transform; }
     Vector<ShadowData> const& text_shadow() const { return m_inherited.text_shadow; }
-    CSS::Position position() const { return m_noninherited.position; }
+    CSS::Positioning position() const { return m_noninherited.position; }
     CSS::WhiteSpace white_space() const { return m_inherited.white_space; }
     CSS::FlexDirection flex_direction() const { return m_noninherited.flex_direction; }
     CSS::FlexWrap flex_wrap() const { return m_noninherited.flex_wrap; }
@@ -463,7 +463,7 @@ protected:
         CSS::LengthPercentage text_decoration_thickness { InitialValues::text_decoration_thickness() };
         CSS::TextDecorationStyle text_decoration_style { InitialValues::text_decoration_style() };
         Color text_decoration_color { InitialValues::color() };
-        CSS::Position position { InitialValues::position() };
+        CSS::Positioning position { InitialValues::position() };
         CSS::Size width { InitialValues::width() };
         CSS::Size min_width { InitialValues::min_width() };
         CSS::Size max_width { InitialValues::max_width() };
@@ -570,7 +570,7 @@ public:
     void set_text_transform(CSS::TextTransform value) { m_inherited.text_transform = value; }
     void set_text_shadow(Vector<ShadowData>&& value) { m_inherited.text_shadow = move(value); }
     void set_text_indent(CSS::LengthPercentage value) { m_inherited.text_indent = move(value); }
-    void set_position(CSS::Position position) { m_noninherited.position = position; }
+    void set_position(CSS::Positioning position) { m_noninherited.position = position; }
     void set_white_space(CSS::WhiteSpace value) { m_inherited.white_space = value; }
     void set_width(CSS::Size const& width) { m_noninherited.width = width; }
     void set_min_width(CSS::Size const& width) { m_noninherited.min_width = width; }

--- a/Userland/Libraries/LibWeb/CSS/Enums.json
+++ b/Userland/Libraries/LibWeb/CSS/Enums.json
@@ -319,7 +319,7 @@
     "all",
     "none"
   ],
-  "position": [
+  "positioning": [
     "absolute",
     "fixed",
     "relative",

--- a/Userland/Libraries/LibWeb/CSS/Enums.json
+++ b/Userland/Libraries/LibWeb/CSS/Enums.json
@@ -319,6 +319,13 @@
     "all",
     "none"
   ],
+  "position": [
+    "left",
+    "right",
+    "top",
+    "bottom",
+    "center"
+  ],
   "positioning": [
     "absolute",
     "fixed",

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -5950,6 +5950,12 @@ Parser::ParseErrorOr<NonnullRefPtr<StyleValue>> Parser::parse_css_value(Property
         if (auto parsed_value = parse_math_depth_value(component_values))
             return parsed_value.release_nonnull();
         return ParseError::SyntaxError;
+    case PropertyID::ObjectPosition:
+        // FIXME: This should use a parse_position compatible to VALUES-4
+        //        and not the background position, which is almost the same.
+        if (auto parsed_value = parse_comma_separated_value_list(component_values, [this](auto& tokens) { return parse_single_background_position_value(tokens); }))
+            return parsed_value.release_nonnull();
+        return ParseError::SyntaxError;
     case PropertyID::Overflow:
         if (auto parsed_value = parse_overflow_value(component_values))
             return parsed_value.release_nonnull();

--- a/Userland/Libraries/LibWeb/CSS/Properties.json
+++ b/Userland/Libraries/LibWeb/CSS/Properties.json
@@ -1624,6 +1624,18 @@
       "object-fit"
     ]
   },
+  "object-position": {
+    "affects-layout": false,
+    "inherited": false,
+    "initial": "50% 50%",
+    "max-values": 2,
+    "valid-types": [
+      "length [-∞,∞]",
+      "percentage [-∞,∞]",
+      "position"
+    ],
+    "percentages-resolve-to": "length"
+  },
   "opacity": {
     "affects-layout": false,
     "affects-stacking-context": true,

--- a/Userland/Libraries/LibWeb/CSS/Properties.json
+++ b/Userland/Libraries/LibWeb/CSS/Properties.json
@@ -1863,7 +1863,7 @@
     "inherited": false,
     "initial": "static",
     "valid-types": [
-      "position"
+      "positioning"
     ]
   },
   "quotes": {

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -1986,7 +1986,7 @@ static BoxTypeTransformation required_box_type_transformation(StyleProperties co
         return BoxTypeTransformation::None;
 
     // Absolute positioning or floating an element blockifies the box’s display type. [CSS2]
-    if (style.position() == CSS::Position::Absolute || style.position() == CSS::Position::Fixed || style.float_() != CSS::Float::None)
+    if (style.position() == CSS::Positioning::Absolute || style.position() == CSS::Positioning::Fixed || style.float_() != CSS::Float::None)
         return BoxTypeTransformation::Blockify;
 
     // FIXME: Containment in a ruby container inlinifies the box’s display type, as described in [CSS-RUBY-1].

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -558,10 +558,10 @@ CSS::BackdropFilter StyleProperties::backdrop_filter() const
     return BackdropFilter::make_none();
 }
 
-Optional<CSS::Position> StyleProperties::position() const
+Optional<CSS::Positioning> StyleProperties::position() const
 {
     auto value = property(CSS::PropertyID::Position);
-    return value_id_to_position(value->to_identifier());
+    return value_id_to_positioning(value->to_identifier());
 }
 
 bool StyleProperties::operator==(StyleProperties const& other) const

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -22,6 +22,7 @@
 #include <LibWeb/CSS/StyleValues/MathDepthStyleValue.h>
 #include <LibWeb/CSS/StyleValues/NumberStyleValue.h>
 #include <LibWeb/CSS/StyleValues/PercentageStyleValue.h>
+#include <LibWeb/CSS/StyleValues/PositionStyleValue.h>
 #include <LibWeb/CSS/StyleValues/RectStyleValue.h>
 #include <LibWeb/CSS/StyleValues/ShadowStyleValue.h>
 #include <LibWeb/CSS/StyleValues/StringStyleValue.h>
@@ -1005,6 +1006,12 @@ Optional<CSS::ObjectFit> StyleProperties::object_fit() const
 {
     auto value = property(CSS::PropertyID::ObjectFit);
     return value_id_to_object_fit(value->to_identifier());
+}
+
+CSS::PositionStyleValue const& StyleProperties::object_position() const
+{
+    auto value = property(CSS::PropertyID::ObjectPosition);
+    return value->as_position();
 }
 
 Optional<CSS::TableLayout> StyleProperties::table_layout() const

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.h
@@ -117,6 +117,7 @@ public:
     Vector<Vector<String>> grid_template_areas() const;
     String grid_area() const;
     Optional<CSS::ObjectFit> object_fit() const;
+    CSS::PositionStyleValue const& object_position() const;
     Optional<CSS::TableLayout> table_layout() const;
 
     Vector<CSS::Transformation> transformations() const;

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.h
@@ -145,7 +145,7 @@ public:
 
     bool operator==(StyleProperties const&) const;
 
-    Optional<CSS::Position> position() const;
+    Optional<CSS::Positioning> position() const;
     Optional<int> z_index() const;
 
     void set_math_depth(int math_depth);

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -1204,7 +1204,7 @@ void FormattingContext::compute_height_for_absolutely_positioned_replaced_elemen
 // https://www.w3.org/TR/css-position-3/#relpos-insets
 void FormattingContext::compute_inset(NodeWithStyleAndBoxModelMetrics const& box)
 {
-    if (box.computed_values().position() != CSS::Position::Relative)
+    if (box.computed_values().position() != CSS::Positioning::Relative)
         return;
 
     auto resolve_two_opposing_insets = [&](CSS::LengthPercentage const& computed_first, CSS::LengthPercentage const& computed_second, CSSPixels& used_start, CSSPixels& used_end, CSSPixels reference_for_percentage) {
@@ -1486,7 +1486,7 @@ CSS::Length FormattingContext::calculate_inner_height(Layout::Box const& box, Av
     auto const* containing_block = box.non_anonymous_containing_block();
     auto const& containing_block_state = m_state.get(*containing_block);
     auto height_of_containing_block = containing_block_state.content_height();
-    if (box.computed_values().position() == CSS::Position::Absolute) {
+    if (box.computed_values().position() == CSS::Positioning::Absolute) {
         // https://www.w3.org/TR/css-position-3/#def-cb
         // If the box has position: absolute, then the containing block is formed by the padding edge of the ancestor
         height_of_containing_block += containing_block_state.padding_top + containing_block_state.padding_bottom;

--- a/Userland/Libraries/LibWeb/Layout/LayoutState.cpp
+++ b/Userland/Libraries/LibWeb/Layout/LayoutState.cpp
@@ -163,7 +163,7 @@ void LayoutState::resolve_relative_positions(Vector<Painting::PaintableWithLines
             offset = used_values.offset;
         }
         // Apply relative position inset if appropriate.
-        if (node.computed_values().position() == CSS::Position::Relative && is<NodeWithStyleAndBoxModelMetrics>(node)) {
+        if (node.computed_values().position() == CSS::Positioning::Relative && is<NodeWithStyleAndBoxModelMetrics>(node)) {
             auto& inset = static_cast<NodeWithStyleAndBoxModelMetrics const&>(node).box_model().inset;
             offset.translate_by(inset.left, inset.top);
         }
@@ -184,7 +184,7 @@ void LayoutState::resolve_relative_positions(Vector<Painting::PaintableWithLines
                         break;
                     if (!ancestor->display().is_inline_outside() || !ancestor->display().is_flow_inside())
                         break;
-                    if (ancestor->computed_values().position() == CSS::Position::Relative) {
+                    if (ancestor->computed_values().position() == CSS::Positioning::Relative) {
                         auto const& ancestor_node = static_cast<Layout::NodeWithStyleAndBoxModelMetrics const&>(*ancestor);
                         auto const& inset = ancestor_node.box_model().inset;
                         offset.translate_by(inset.left, inset.top);

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -75,7 +75,7 @@ bool Node::is_out_of_flow(FormattingContext const& formatting_context) const
 
 bool Node::can_contain_boxes_with_position_absolute() const
 {
-    if (computed_values().position() != CSS::Position::Static)
+    if (computed_values().position() != CSS::Positioning::Static)
         return true;
 
     if (is<Viewport>(*this))
@@ -110,7 +110,7 @@ Box const* Node::containing_block() const
     auto position = computed_values().position();
 
     // https://drafts.csswg.org/css-position-3/#absolute-cb
-    if (position == CSS::Position::Absolute) {
+    if (position == CSS::Positioning::Absolute) {
         auto const* ancestor = parent();
         while (ancestor && !ancestor->can_contain_boxes_with_position_absolute())
             ancestor = ancestor->parent();
@@ -119,7 +119,7 @@ Box const* Node::containing_block() const
         return static_cast<Box const*>(ancestor);
     }
 
-    if (position == CSS::Position::Fixed)
+    if (position == CSS::Positioning::Fixed)
         return &root();
 
     return nearest_ancestor_capable_of_forming_a_containing_block(*this);
@@ -157,14 +157,14 @@ bool Node::establishes_stacking_context() const
     auto position = computed_values().position();
 
     // Element with a position value absolute or relative and z-index value other than auto.
-    if (position == CSS::Position::Absolute || position == CSS::Position::Relative) {
+    if (position == CSS::Positioning::Absolute || position == CSS::Positioning::Relative) {
         if (computed_values().z_index().has_value()) {
             return true;
         }
     }
 
     // Element with a position value fixed or sticky.
-    if (position == CSS::Position::Fixed || position == CSS::Position::Sticky)
+    if (position == CSS::Positioning::Fixed || position == CSS::Positioning::Sticky)
         return true;
 
     if (!computed_values().transformations().is_empty())
@@ -273,7 +273,7 @@ bool Node::is_floating() const
 
 bool Node::is_positioned() const
 {
-    return has_style() && computed_values().position() != CSS::Position::Static;
+    return has_style() && computed_values().position() != CSS::Positioning::Static;
 }
 
 bool Node::is_absolutely_positioned() const
@@ -281,7 +281,7 @@ bool Node::is_absolutely_positioned() const
     if (!has_style())
         return false;
     auto position = computed_values().position();
-    return position == CSS::Position::Absolute || position == CSS::Position::Fixed;
+    return position == CSS::Positioning::Absolute || position == CSS::Positioning::Fixed;
 }
 
 bool Node::is_fixed_position() const
@@ -289,7 +289,7 @@ bool Node::is_fixed_position() const
     if (!has_style())
         return false;
     auto position = computed_values().position();
-    return position == CSS::Position::Fixed;
+    return position == CSS::Positioning::Fixed;
 }
 
 NodeWithStyle::NodeWithStyle(DOM::Document& document, DOM::Node* node, NonnullRefPtr<CSS::StyleProperties> computed_style)

--- a/Userland/Libraries/LibWeb/Painting/Paintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/Paintable.cpp
@@ -35,7 +35,7 @@ bool Paintable::is_positioned() const
         // grid items with z_index should behave as if position were "relative"
         return true;
     }
-    return computed_values().position() != CSS::Position::Static;
+    return computed_values().position() != CSS::Positioning::Static;
 }
 
 void Paintable::set_dom_node(JS::GCPtr<DOM::Node> dom_node)


### PR DESCRIPTION
This PR add support for the object-position property.
As I recently built the object-fit property, this seemed like a logical next step.
With object-position you can tell your image how you want to paint it, very useful in combination with the object-fit!

I introduced the object-position property and a "Position Identifier", which can hold the different identifiers that are valid for the property. The rendering is then just a sea of pain with offsets and pixel-math.
This implementation looks the same in Ladybird and Firefox :^)

![image](https://github.com/SerenityOS/serenity/assets/6002167/bbf52f28-7c22-40ae-920b-3fb4556600be)
![image](https://github.com/SerenityOS/serenity/assets/6002167/94dff79f-62ec-47ec-9396-ed1ad3620570)
