### PR TITLE
AK: Avoid nullptr deref in DeprecatedString(DeprecatedFlyString const&)

### DIFF
--- a/AK/DeprecatedString.cpp
+++ b/AK/DeprecatedString.cpp
@@ -374,7 +374,7 @@ DeprecatedString escape_html_entities(StringView html)
 }
 
 DeprecatedString::DeprecatedString(DeprecatedFlyString const& string)
-    : m_impl(*string.impl())
+    : m_impl(*(string.impl() ?: &StringImpl::the_empty_stringimpl()))
 {
 }
 


### PR DESCRIPTION
Prior to this commit, constructing a DS from a null DFS would cause a nullptr deref, which broke (at least) Profiler.
This commit converts the null DFS to an empty DS, avoiding the nullptr deref (until DFS loses its null state, or we decide to not make it convertible to a DS).

cc @gmta @tcl3 (thanks for boog report)