### PR TITLE
LibGfx/ILBM: Explicitly fail decoding if body chunk isn't present

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/ILBMLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/ILBMLoader.cpp
@@ -289,6 +289,9 @@ static ErrorOr<void> decode_iff_chunks(ILBMLoadingContext& context)
         }
     }
 
+    if (context.state != ILBMLoadingContext::State::BitmapDecoded)
+        return Error::from_string_literal("Missing body chunk");
+
     return {};
 }
 


### PR DESCRIPTION
Previously, the decoder would crash in this case.

This fixes oss fuzz issue: [63296](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=63296).