### PR TITLE
[RFC] LibCore: UTF-8 agnostic Core::Path

### DIFF
--- a/AK/Noncopyable.h
+++ b/AK/Noncopyable.h
@@ -20,3 +20,8 @@ private:                      \
 public:                            \
     c(c&&) = default;              \
     c& operator=(c&&) = default
+
+#define AK_MAKE_DEFAULT_COPYABLE(c) \
+public:                             \
+    c(c const&) = default;          \
+    c& operator=(c const&) = default

--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -667,6 +667,7 @@ if (BUILD_LAGOM)
         # LibCore
         if ((LINUX OR APPLE) AND NOT EMSCRIPTEN)
             lagom_test(../../Tests/LibCore/TestLibCoreFileWatcher.cpp)
+            lagom_test(../../Tests/LibCore/TestLibCorePath.cpp)
             lagom_test(../../Tests/LibCore/TestLibCorePromise.cpp LIBS LibThreading)
         endif()
 

--- a/Tests/LibCore/CMakeLists.txt
+++ b/Tests/LibCore/CMakeLists.txt
@@ -4,6 +4,7 @@ set(TEST_SOURCES
     TestLibCoreFilePermissionsMask.cpp
     TestLibCoreFileWatcher.cpp
     TestLibCoreMappedFile.cpp
+    TestLibCorePath.cpp
     TestLibCorePromise.cpp
     TestLibCoreSharedSingleProducerCircularQueue.cpp
     TestLibCoreStream.cpp

--- a/Tests/LibCore/TestLibCorePath.cpp
+++ b/Tests/LibCore/TestLibCorePath.cpp
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2023, Dan Klishch <danilklishch@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibCore/Directory.h>
+#include <LibCore/Path.h>
+#include <LibTest/TestCase.h>
+
+using Core::Path, Core::AbsolutePathSegment, Core::RelativePathSegment;
+
+template<typename T>
+struct ConstexprConstructibleChecker {
+    template<typename F, int = (T(F {}()), 0)>
+    consteval static bool check(F) { return true; }
+    consteval static bool check(...) { return false; }
+};
+
+#define IS_CONSTEXPR_CONSTRUCTIBLE(T, argument) ConstexprConstructibleChecker<T>::check([] { return argument; })
+
+#define CHECK_SEGMENT_CONSTEXPR_CONSTRUCTS(path)                              \
+    static_assert(IS_CONSTEXPR_CONSTRUCTIBLE(AbsolutePathSegment, "/" path)); \
+    static_assert(IS_CONSTEXPR_CONSTRUCTIBLE(RelativePathSegment, path))
+
+#define CHECK_SEGMENT_DOES_NOT_CONSTEXPR_CONSTRUCT(path)                       \
+    static_assert(!IS_CONSTEXPR_CONSTRUCTIBLE(AbsolutePathSegment, "/" path)); \
+    static_assert(!IS_CONSTEXPR_CONSTRUCTIBLE(RelativePathSegment, path))
+
+CHECK_SEGMENT_CONSTEXPR_CONSTRUCTS("a");
+CHECK_SEGMENT_CONSTEXPR_CONSTRUCTS("aaaaa");
+CHECK_SEGMENT_CONSTEXPR_CONSTRUCTS("usr/bin");
+CHECK_SEGMENT_CONSTEXPR_CONSTRUCTS("usr/bin/.");
+CHECK_SEGMENT_CONSTEXPR_CONSTRUCTS("directory/.");
+CHECK_SEGMENT_CONSTEXPR_CONSTRUCTS("./lib");
+CHECK_SEGMENT_CONSTEXPR_CONSTRUCTS("foo/./bar");
+CHECK_SEGMENT_CONSTEXPR_CONSTRUCTS("foo/././bar");
+CHECK_SEGMENT_CONSTEXPR_CONSTRUCTS(".");
+
+CHECK_SEGMENT_DOES_NOT_CONSTEXPR_CONSTRUCT("");
+CHECK_SEGMENT_DOES_NOT_CONSTEXPR_CONSTRUCT("/");
+CHECK_SEGMENT_DOES_NOT_CONSTEXPR_CONSTRUCT("//");
+CHECK_SEGMENT_DOES_NOT_CONSTEXPR_CONSTRUCT("..");
+CHECK_SEGMENT_DOES_NOT_CONSTEXPR_CONSTRUCT("../directory");
+CHECK_SEGMENT_DOES_NOT_CONSTEXPR_CONSTRUCT("directory/");
+CHECK_SEGMENT_DOES_NOT_CONSTEXPR_CONSTRUCT("directory/..");
+CHECK_SEGMENT_DOES_NOT_CONSTEXPR_CONSTRUCT("a//b");
+CHECK_SEGMENT_DOES_NOT_CONSTEXPR_CONSTRUCT("a//");
+CHECK_SEGMENT_DOES_NOT_CONSTEXPR_CONSTRUCT("/foo");
+
+#undef CHECK_SEGMENT_CONSTEXPR_CONSTRUCTS
+#undef CHECK_SEGMENT_DOES_NOT_CONSTEXPR_CONSTRUCT
+
+#ifdef AK_OS_SERENITY
+static StringView as_string_view(StringView s)
+{
+    return s;
+}
+#else
+static StringView as_string_view(char const* s)
+{
+    return StringView(s, __builtin_strlen(s));
+}
+#endif
+
+#define EXPECT_PATH_EQ(path, fd, relative_part, last_segment_, is_directory)    \
+    EXPECT_EQ(path.directory_fd_for_syscall(), fd);                             \
+    EXPECT_EQ(as_string_view(path.relative_path_for_syscall()), relative_part); \
+    EXPECT_EQ(path.last_segment(), last_segment_);                              \
+    EXPECT(path.is_surely_a_directory() == is_directory);
+
+TEST_CASE(simple)
+{
+    // Absolute paths
+    auto root = Path::root();
+    EXPECT_PATH_EQ(root, -1, "/.", ".", true);
+
+    auto root_usr = root / "usr";
+    EXPECT_PATH_EQ(root_usr, -1, "/./usr", "usr", false);
+
+    auto root_usr_bin = root_usr / "bin";
+    EXPECT_PATH_EQ(root_usr_bin, -1, "/./usr/bin", "bin", false);
+
+    auto root_usr_bin_2 = root / "usr/bin";
+    EXPECT_PATH_EQ(root_usr_bin, -1, "/./usr/bin", "bin", false);
+
+    Path root_usr_3("/usr");
+    EXPECT_PATH_EQ(root_usr_3, -1, "/usr", "usr", false);
+
+    auto root_usr_bin_3 = root_usr_3 / "bin";
+    EXPECT_PATH_EQ(root_usr_bin_3, -1, "/usr/bin", "bin", false);
+
+    // Paths relative to the initial working directory
+    auto cwd = Core::Directory::initial_working_directory();
+    int cwd_fd = cwd.fd();
+
+    Path cwd_path(cwd);
+    EXPECT_PATH_EQ(cwd_path, cwd_fd, ".", ".", true);
+
+    auto dot_usr = cwd_path / "usr";
+    EXPECT_PATH_EQ(dot_usr, cwd_fd, "usr", "usr", false);
+
+    auto dot_usr_bin = dot_usr / "bin";
+    EXPECT_PATH_EQ(dot_usr_bin, cwd_fd, "usr/bin", "bin", false);
+
+    auto dot_usr_bin_dot = dot_usr / "bin/.";
+    EXPECT_PATH_EQ(dot_usr_bin_dot, cwd_fd, "usr/bin/.", ".", true);
+
+    // Path relative to an open directory
+    auto root_directory = Core::Directory::initial_working_directory();
+    int root_fd = root_directory.fd();
+
+    auto opened_root_usr_bin = Path(root_directory) / "directory";
+    EXPECT_PATH_EQ(opened_root_usr_bin, root_fd, "directory", "directory", false);
+}
+
+TEST_CASE(path_from_string)
+{
+    auto cwd = Core::Directory::initial_working_directory();
+    int cwd_fd = cwd.fd();
+    EXPECT_NE(cwd_fd, -1);
+
+    auto empty_string_error = Path::create_from_string(""sv);
+    EXPECT(empty_string_error.is_error());
+
+    auto root = MUST(Path::create_from_string("/"sv));
+    EXPECT_PATH_EQ(root, -1, "/.", ".", true);
+
+    auto cwd_path = MUST(Path::create_from_string("."sv));
+    EXPECT_PATH_EQ(cwd_path, cwd_fd, ".", ".", true);
+
+    auto dot_dot = MUST(Path::create_from_string(".."sv));
+    EXPECT_PATH_EQ(dot_dot, cwd_fd, "..", "..", true);
+
+    auto dot_dot_slash = MUST(Path::create_from_string("../"sv));
+    EXPECT_PATH_EQ(dot_dot_slash, cwd_fd, "../.", ".", true);
+
+    auto usr_bin = MUST(Path::create_from_string("/usr/bin"sv));
+    EXPECT_PATH_EQ(usr_bin, -1, "/usr/bin", "bin", false);
+
+    auto usr_bin_slash = MUST(Path::create_from_string("/usr/bin/"sv));
+    EXPECT_PATH_EQ(usr_bin_slash, -1, "/usr/bin/.", ".", true);
+
+    auto cringe = MUST(Path::create_from_string("../usr/./../foo/bar"sv));
+    EXPECT_PATH_EQ(cringe, cwd_fd, "../usr/./../foo/bar", "bar", false);
+
+    auto root_directory = Core::Directory::initial_working_directory();
+    int root_fd = root_directory.fd();
+
+    auto root_root_path = Path(root_directory) / "root";
+    EXPECT_PATH_EQ(root_root_path, root_fd, "root", "root", false);
+}
+
+template<typename T>
+__attribute__((no_sanitize("undefined"))) Badge<T> fake_badge()
+{
+    // FIXME: Find out a way to construct fake badges without invoking UB.
+    void* fn_address = reinterpret_cast<void*>(+[] {});
+    AK::taint_for_optimizer(fn_address);
+    return reinterpret_cast<Badge<T> (*)()>(fn_address)();
+}
+
+TEST_CASE(can_be_considered_standard_stream)
+{
+    auto slash_minus = MUST(Path::create_from_string("/-"sv));
+    EXPECT(!slash_minus.can_be_considered_standard_stream(fake_badge<Core::File>()));
+
+    auto minus = MUST(Path::create_from_string("-"sv));
+    EXPECT(minus.can_be_considered_standard_stream(fake_badge<Core::File>()));
+
+    auto minus_slash = MUST(Path::create_from_string("-/"sv));
+    EXPECT(!minus_slash.can_be_considered_standard_stream(fake_badge<Core::File>()));
+}

--- a/Userland/Libraries/LibCore/CMakeLists.txt
+++ b/Userland/Libraries/LibCore/CMakeLists.txt
@@ -19,6 +19,7 @@ set(SOURCES
     MimeData.cpp
     NetworkJob.cpp
     Notifier.cpp
+    Path.cpp
     Process.cpp
     ProcessStatisticsReader.cpp
     SecretString.cpp

--- a/Userland/Libraries/LibCore/Forward.h
+++ b/Userland/Libraries/LibCore/Forward.h
@@ -17,8 +17,9 @@ class ChildEvent;
 class ConfigFile;
 class CustomEvent;
 class DateTime;
-class DirIterator;
 class DeferredInvocationContext;
+class Directory;
+class DirIterator;
 class ElapsedTimer;
 class Event;
 class EventLoop;
@@ -33,6 +34,7 @@ class NetworkResponse;
 class Notifier;
 class ProcessStatisticsReader;
 class Socket;
+class Path;
 template<typename Result, typename TError = AK::Error>
 class Promise;
 template<typename Result, typename TError = AK::Error>

--- a/Userland/Libraries/LibCore/Path.cpp
+++ b/Userland/Libraries/LibCore/Path.cpp
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) 2023, Dan Klishch <danilklishch@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibCore/Directory.h>
+#include <LibCore/Path.h>
+#include <LibCore/System.h>
+
+using namespace Core;
+using namespace Core::Detail;
+
+FileDescriptorOwner::~FileDescriptorOwner()
+{
+    if (m_fd != -1 && m_should_close) {
+        MUST(Core::System::close(m_fd));
+        m_fd = -1;
+    }
+}
+
+RuntimePath::RuntimePath(StringView view)
+{
+    data.append(view.characters_without_null_termination(), view.length());
+    if (view.ends_with('/'))
+        data.append('.');
+    if (make_paths_zero_terminated)
+        data.append(0);
+}
+
+StringView RuntimePath::view() const
+{
+    if (make_paths_zero_terminated) {
+        StringView result = data;
+        return result.substring_view(0, result.length() - 1);
+    }
+    return data;
+}
+
+void RuntimePath::append(RelativePathSegment segment)
+{
+    if (make_paths_zero_terminated)
+        data[data.size() - 1] = '/';
+    else
+        data.append('/');
+
+    StringView segment_view = segment.path();
+    data.append(segment_view.characters_without_null_termination(), segment_view.length());
+
+    if (segment_view.ends_with('/'))
+        data.append('.');
+
+    if (make_paths_zero_terminated)
+        data.append(0);
+}
+
+StringView CompiletimeConstantPath::view() const
+{
+    return data;
+}
+
+Path Path::root()
+{
+    return Path(AbsoluteCompiletimePath { .path = { "/."sv } });
+}
+
+ErrorOr<Path> Path::create_from_string(StringView path_string)
+{
+    return create_from_string(path_string, Directory::initial_working_directory());
+}
+
+ErrorOr<Path> Path::create_from_string(StringView path_string, Path const& base)
+{
+    if (path_string.is_empty())
+        return Error::from_string_literal("Path cannot be empty");
+
+    if (path_string.starts_with('/'))
+        return Path(AbsoluteRuntimePath({ path_string }));
+    return base / RelativePathSegment({}, path_string);
+}
+
+#ifdef AK_OS_SERENITY
+Path Path::create_from_c_string_without_copy_in_libc(char const* path)
+{
+    return Path(ForeignCStringPath { .dirfd = AT_FDCWD, .path = path });
+}
+
+Path Path::create_from_c_string_without_copy_in_libc(int dirfd, char const* path)
+{
+    return Path(ForeignCStringPath { .dirfd = dirfd, .path = path });
+}
+#endif
+
+Path::Path(AbsolutePathSegment path)
+    : m_path(ForeignCStringPath {}) // m_path does not have null state
+{
+    if (path.is_zero_terminated_literal())
+        m_path = AbsoluteCompiletimePath({ path.path() });
+    else
+        m_path = AbsoluteRuntimePath({ path.path() });
+}
+
+Path::Path(Directory directory)
+    : m_path(DirectoryPath { .directory = directory.fd_owner({}) })
+{
+}
+
+StringView Path::last_segment() const
+{
+    return m_path.visit(
+        [](ForeignCStringPath const&) -> StringView { VERIFY_NOT_REACHED(); },
+        [](DirectoryPath const&) { return "."sv; },
+        [](auto const& path) {
+            StringView relative_part = path.path.view();
+            return relative_part.substring_view(relative_part.find_last('/').value_or(-1) + 1);
+        });
+}
+
+bool Path::is_surely_a_directory() const
+{
+    auto segment = last_segment();
+    return segment == "." || segment == "..";
+}
+
+Path Path::operator/(RelativePathSegment segment) const
+{
+    return m_path.visit(
+        [&](ForeignCStringPath const&) -> Path { VERIFY_NOT_REACHED(); },
+        [&](DirectoryPath const& directory_path) {
+            if (segment.is_zero_terminated_literal())
+                return Path(RelativeCompiletimePath { directory_path.directory, { segment.path() } });
+            return Path(RelativeRuntimePath { directory_path.directory, { segment.path() } });
+        },
+        [&](OneOf<AbsoluteRuntimePath, RelativeRuntimePath> auto path) {
+            path.path.append(segment);
+            return Path(move(path));
+        },
+        [&](AbsoluteCompiletimePath const& absolute_path) {
+            auto new_path = AbsoluteRuntimePath({ absolute_path.path.data });
+            new_path.path.append(segment);
+            return Path(move(new_path));
+        },
+        [&](RelativeCompiletimePath const& relative_path) {
+            auto new_path = RelativeRuntimePath { relative_path.directory, { relative_path.path.data } };
+            new_path.path.append(segment);
+            return Path(move(new_path));
+        });
+}
+
+int Path::directory_fd_for_syscall() const
+{
+    return m_path.visit(
+        [&](ForeignCStringPath const& foreign_path) {
+            return foreign_path.dirfd;
+        },
+        [&](OneOf<DirectoryPath, RelativeRuntimePath, RelativeCompiletimePath> auto const& path) {
+            return path.directory->fd();
+        },
+        [&](OneOf<AbsoluteRuntimePath, AbsoluteCompiletimePath> auto const&) {
+            return -1;
+        });
+}
+
+#ifdef AK_OS_SERENITY
+StringView Path::relative_path_for_syscall() const
+{
+    return m_path.visit(
+        [&](ForeignCStringPath const& foreign_path) {
+            return StringView { foreign_path.path, __builtin_strlen(foreign_path.path) };
+        },
+        [&](DirectoryPath const&) {
+            return "."sv;
+        },
+        [&](auto const& path) {
+            return path.path.view();
+        });
+}
+#else
+char const* Path::relative_path_for_syscall() const
+{
+    return m_path.visit(
+        [&](ForeignCStringPath const& foreign_path) {
+            return foreign_path.path;
+        },
+        [&](DirectoryPath const&) {
+            return ".";
+        },
+        [&](auto const& path) {
+            return path.path.view().characters_without_null_termination();
+        });
+}
+#endif
+
+bool Path::can_be_considered_standard_stream(Badge<File>) const
+{
+    return m_path.visit(
+        [&](ForeignCStringPath const&) -> bool { VERIFY_NOT_REACHED(); },
+        [&](RelativeRuntimePath const& path) { return path.path.view() == "-"sv; },
+        [&](auto const&) { return false; });
+}

--- a/Userland/Libraries/LibCore/Path.h
+++ b/Userland/Libraries/LibCore/Path.h
@@ -1,0 +1,234 @@
+/*
+ * Copyright (c) 2023, Dan Klishch <danilklishch@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Badge.h>
+#include <AK/ByteBuffer.h>
+#include <AK/Noncopyable.h>
+#include <AK/RefCounted.h>
+#include <AK/RefPtr.h>
+#include <AK/StringView.h>
+#include <LibCore/Forward.h>
+
+#ifdef LIBCORE_DEPRECATE_OLD_PATH_API
+#    define LIBCORE_DEPRECATED_PATH_API [[deprecated]]
+#else
+#    define LIBCORE_DEPRECATED_PATH_API
+#endif
+
+namespace Core {
+
+namespace Detail {
+
+class FileDescriptorOwner : public RefCounted<FileDescriptorOwner> {
+    AK_MAKE_NONCOPYABLE(FileDescriptorOwner);
+    AK_MAKE_NONMOVABLE(FileDescriptorOwner);
+
+public:
+    FileDescriptorOwner(int fd, bool should_close)
+        : m_fd(fd)
+        , m_should_close(should_close)
+    {
+    }
+
+    ~FileDescriptorOwner();
+
+    int fd() const { return m_fd; }
+
+private:
+    int m_fd;
+    bool m_should_close;
+};
+
+enum class PathSegmentType {
+    Absolute,
+    Relative,
+};
+
+// FIXME(LexicalPath): Should this live in AK?
+template<PathSegmentType segment_type>
+class PathSegment {
+public:
+    consteval PathSegment(char const* path)
+        : m_path(StringView { path, __builtin_strlen(path) })
+        , m_is_zero_terminated_literal(true)
+    {
+        validate_compiletime_path_segment();
+    }
+
+    StringView path() const { return m_path; }
+    bool is_zero_terminated_literal() const { return m_is_zero_terminated_literal; }
+
+    PathSegment(Badge<Path>, StringView segment)
+        : m_path(segment)
+    {
+    }
+
+private:
+    consteval void validate_compiletime_path_segment()
+    {
+        if (m_path.is_empty())
+            AK::compiletime_fail("Path segment cannot be empty");
+
+        if (m_path[m_path.length() - 1] == '/')
+            AK::compiletime_fail("Path segment should not end with /");
+
+        if (segment_type == PathSegmentType::Absolute) {
+            if (m_path[0] != '/')
+                AK::compiletime_fail("Absolute path segment should start with /");
+        } else {
+            if (m_path[0] == '/')
+                AK::compiletime_fail("Relative path segment should not start with /");
+        }
+
+        for (size_t i = 1; i <= m_path.length(); ++i) {
+            if (i == m_path.length() || m_path[i] == '/') {
+                size_t j = i;
+                while (j--)
+                    if (m_path[j] == '/')
+                        break;
+                auto part = m_path.substring_view(j + 1, i - j - 1);
+                if (part == "")
+                    AK::compiletime_fail("Repeated slashes are not allowed");
+                if (part == "..")
+                    AK::compiletime_fail("Using .. with Core::Path is discouraged, use Core::Path::create_from_string if you _really_ need it");
+            }
+        }
+    }
+
+    StringView m_path;
+    bool m_is_zero_terminated_literal = false;
+};
+
+using RelativePathSegment = PathSegment<PathSegmentType::Relative>;
+using AbsolutePathSegment = PathSegment<PathSegmentType::Absolute>;
+
+#ifdef AK_OS_SERENITY
+inline constexpr bool make_paths_zero_terminated = false;
+#else
+inline constexpr bool make_paths_zero_terminated = true;
+#endif
+
+struct RuntimePath {
+    RuntimePath(StringView view);
+    RuntimePath(ByteBuffer&& buffer);
+
+    StringView view() const;
+    void append(RelativePathSegment segment);
+
+    ByteBuffer data; // != "" and "\0", ends with '\0' if not on Serenity, last non-zero byte is not '/'
+};
+
+struct CompiletimeConstantPath {
+    StringView view() const;
+
+    StringView data; // Has '\0' character past the end, does not end with '/', except if it is "/"
+};
+
+struct ForeignCStringPath {
+    int dirfd;
+    char const* path;
+};
+
+// Path constructed from Directory
+struct DirectoryPath {
+    NonnullRefPtr<FileDescriptorOwner> directory;
+};
+
+// Absolute path
+template<typename PathStorage>
+struct AbsolutePath {
+    PathStorage path; // Starts with '/'
+};
+
+using AbsoluteCompiletimePath = AbsolutePath<CompiletimeConstantPath>;
+using AbsoluteRuntimePath = AbsolutePath<RuntimePath>;
+
+// Path relative to a given directory
+template<typename PathStorage>
+struct RelativePath {
+    NonnullRefPtr<FileDescriptorOwner> directory;
+    PathStorage path;
+};
+
+using RelativeCompiletimePath = RelativePath<CompiletimeConstantPath>;
+using RelativeRuntimePath = RelativePath<RuntimePath>;
+using PathDataType = Variant<ForeignCStringPath, AbsoluteRuntimePath, AbsoluteCompiletimePath, RelativeRuntimePath, RelativeCompiletimePath, DirectoryPath>;
+
+}
+
+using Detail::AbsolutePathSegment;
+using Detail::RelativePathSegment;
+
+// Conceptually, Core::Path stores a pointer to a filesystem index node. After construction, it does
+// not provide any getters except for the last path segment.
+//
+// The only intended purpose of `Path::last_segment` is to query filename, if a path instance refers
+// to a file. For directories, calling `last_segment` might occasionally return . or .. instead of
+// an actual directory name.
+//
+// Internally, Path uses a directory file descriptor and a path string, which is resolved relative
+// to the aforementioned directory. Unfortunately, this design still leaves room for potential
+// filesystem races if not used carefully. This is the reason why you should treat Path instances
+// as an opaque pointers to something non-constant and rely on helpers from LibFileSystem to work
+// with a filesystem.
+class Path {
+public:
+    static Path root();
+
+    // For relative paths, resolution is done relative to the initial working directory. "." will
+    // be appended for paths ending with "/".
+    static ErrorOr<Path> create_from_string(StringView path_string);
+    static ErrorOr<Path> create_from_string(StringView path_string, Path const& base);
+
+    // FIXME(LexicalPath): Should there be constructors from LexicalPath?
+
+#ifdef AK_OS_SERENITY
+    // NOTE: Should not be called outside of LibC. Caller should guarantee that the string
+    //       outlives Path instances. Returned instances will be considered invalid and *will* cause
+    //       assertion failures if passed to functions other than in Core::System.
+    static Path create_from_c_string_without_copy_in_libc(char const* path);
+    static Path create_from_c_string_without_copy_in_libc(int dirfd, char const* path);
+#endif
+
+    Path(AbsolutePathSegment path);
+    Path(Directory directory);
+
+    // FIXME(LexicalPath): Should this return RelativePathSegment or some "LexicalPathView"?
+    StringView last_segment() const;
+
+    // Path is considered "surely" a directory if it is constructed from NNRP<Directory> or using
+    // Path::root() or its relative part ends with "/." or "/..".
+    bool is_surely_a_directory() const;
+
+    Path operator/(RelativePathSegment segment) const;
+
+    int directory_fd_for_syscall() const;
+#ifdef AK_OS_SERENITY
+    StringView relative_path_for_syscall() const;
+#else
+    char const* relative_path_for_syscall() const;
+#endif
+
+    bool can_be_considered_standard_stream(Badge<File>) const;
+
+    template<OneOf<Directory, File> VIP>
+    Detail::PathDataType const& internal_representation(Badge<VIP>) const
+    {
+        return m_path;
+    }
+
+protected:
+    Path(Detail::PathDataType&& path)
+        : m_path(move(path))
+    {
+    }
+
+    Detail::PathDataType m_path;
+};
+
+}


### PR DESCRIPTION
This PR introduces UTF-8 agnostic `Core::Path`, which internally stores paths as a pair of a directory file descriptor and 
a path relative to it. The relative part of a path is stored in a possibly zero-terminated byte buffer, so there is no need to copy the path just to add `\0` before making syscalls on non-Serenity platforms. The public API of `Core::Path` is somewhat constrained, so users are expected to rely on LibFileSystem for most of the tasks (like traversing directories, removing or creating them). This is done this way since it is notoriously difficult to do the aforementioned tasks without introducing TOCTOU errors in the case of concurrent access to FS.

Note that this is more an RFC rather than PR since it does not add any real uses of `Core::Path`. One can refer to tests to get an idea of how the class can be used. I have PoC tar implementation locally which does use `Core::Path` (and I can confirm that the exposed API is enough for it), however it requires substantial additional changes to `DirIterator`, `Directory`, `File` and `LibFileSystem`, so I decided to not include it here.

--------

(I made up the following a few days ago and found it really funny. Unfortunately, I feel some kind of apathy today and do not find it funny anymore. However, I do believe that others might find it entertaining nonetheless)

## STOP DOING `StringView path`

- `StringView` was not supposed to store paths
- 9 months after old string deprecation yet no good solution found for adding a zero terminator for syscalls on non-Serenity hosts
- Wanted to work with paths anyway? We have a tool for that: ByteBuffer
- "Yeah, we lost a filesystem race, so reading from Core::File returned EISDIR" - Statements dreamed up by the utterly Deranged

LOOK at what SerenityOS developers have been demanding your Respect for all this time with all the fancy libraries and full control over the stack
(This is real code, done by REAL SerenityOS developers)
```cpp
// NOTE: We have to ensure that the path is null-terminated.
DeprecatedString path_string = path;
int rc = ::openat(fd, path_string.characters(), options, mode);
```
?????
```cpp
auto canonicalized_path = TRY(String::from_deprecated_string(LexicalPath::canonicalized_path(path)));
TRY(tar_stream.add_link(canonicalized_path, statbuf.st_mode, TRY(Core::System::readlink(path))));
```
???????
```cpp
Core::DirIterator directory_iterator(directory_path, Core::DirIterator::Flags::SkipDots);
while (directory_iterator.has_next()) {
    auto name = directory_iterator.next_path();
    struct stat st = {};
    if (fstatat(directory_iterator.fd(), name.characters(), &st, AT_SYMLINK_NOFOLLOW) < 0)
        continue;
    bool is_directory = S_ISDIR(st.st_mode);
```
?????????????

"Hello I pretend that filesystem doesn't change while I am working with it"
They have played us for absolute fools
