### PR TITLE
LibPDF: Allow moving Reader::move_to() to end of data stream

### DIFF
--- a/Userland/Libraries/LibPDF/Reader.h
+++ b/Userland/Libraries/LibPDF/Reader.h
@@ -110,7 +110,7 @@ public:
     template<typename T = char>
     void move_to(size_t offset)
     {
-        VERIFY(offset < m_bytes.size());
+        VERIFY(offset <= m_bytes.size());
         m_offset = static_cast<ssize_t>(offset);
     }
 


### PR DESCRIPTION
CFF::parse_index_data() calls move_to() to put the reader's current position behind the index data.

In several PDFs, the PrivDictOperator::Subrs case in CFF::create() sets up a span that contains exactly the Subrs data and nothing after it, so that finale move_to() call in parse_index_data() would cause an assert.

This is similar to fe3612ebcb5, where the caller was also in CFF. So maybe CFF just has a different view of what valid values to pass to Reader are, compared to the rest of the code? But having an iterator point to one past the valid data in a container is common, so maybe this is the Right Fix after all.

Fixes a crash opening 411_getting_started_with_instruments.pdf (and a whole bunch of other WWDC slides). Rendering is pretty glitchy and we still crash on page 14, but at least we can open the file now.

The file is currently available at:
https://devstreaming-cdn.apple.com/videos/wwdc/2019/411cbc60y12x68arcof/411/411_getting_started_with_instruments.pdf