### PR TITLE
LibPDF: Read Global subr data in CFF reader

### DIFF
--- a/Userland/Libraries/LibPDF/Fonts/CFF.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/CFF.cpp
@@ -207,8 +207,14 @@ PDFErrorOr<NonnullRefPtr<CFF>> CFF::create(ReadonlyBytes const& cff_bytes, RefPt
 
     auto strings = TRY(parse_strings(reader));
 
-    // FIXME: CFF spec "16 Local/Global Subrs INDEXes"
-    //        "Global subrs are stored in an INDEX structure which follows the String INDEX."
+    // CFF spec "16 Local/Global Subrs INDEXes"
+    // "Global subrs are stored in an INDEX structure which follows the String INDEX."
+    Vector<ByteBuffer> global_subroutines;
+    TRY(parse_index(reader, [&](ReadonlyBytes const& subroutine_bytes) -> PDFErrorOr<void> {
+        return TRY(global_subroutines.try_append(TRY(ByteBuffer::copy(subroutine_bytes))));
+    }));
+    if (!global_subroutines.is_empty())
+        dbgln("CFF data contains Global subrs, which aren't implemented yet"); // FIXME
 
     // Create glyphs (now that we have the subroutines) and associate missing information to store them and their encoding
     auto glyphs = TRY(parse_charstrings(Reader(cff_bytes.slice(charstrings_offset)), local_subroutines));

--- a/Userland/Libraries/LibPDF/Fonts/CFF.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/CFF.cpp
@@ -116,7 +116,7 @@ PDFErrorOr<NonnullRefPtr<CFF>> CFF::create(ReadonlyBytes const& cff_bytes, RefPt
     int charset_offset = 0;
     int encoding_offset = 0;
     auto charstrings_offset = 0;
-    Vector<ByteBuffer> subroutines;
+    Vector<ByteBuffer> local_subroutines;
     float defaultWidthX = 0;
     float nominalWidthX = 0;
     TRY(parse_index(reader, [&](ReadonlyBytes const& element_data) {
@@ -181,7 +181,7 @@ PDFErrorOr<NonnullRefPtr<CFF>> CFF::create(ReadonlyBytes const& cff_bytes, RefPt
                         Reader subrs_reader { cff_bytes.slice(private_dict_offset + subrs_offset) };
                         dbgln("Parsing Subrs INDEX");
                         TRY(parse_index(subrs_reader, [&](ReadonlyBytes const& subroutine_bytes) -> PDFErrorOr<void> {
-                            return TRY(subroutines.try_append(TRY(ByteBuffer::copy(subroutine_bytes))));
+                            return TRY(local_subroutines.try_append(TRY(ByteBuffer::copy(subroutine_bytes))));
                         }));
                         break;
                     }
@@ -211,7 +211,7 @@ PDFErrorOr<NonnullRefPtr<CFF>> CFF::create(ReadonlyBytes const& cff_bytes, RefPt
     //        "Global subrs are stored in an INDEX structure which follows the String INDEX."
 
     // Create glyphs (now that we have the subroutines) and associate missing information to store them and their encoding
-    auto glyphs = TRY(parse_charstrings(Reader(cff_bytes.slice(charstrings_offset)), subroutines));
+    auto glyphs = TRY(parse_charstrings(Reader(cff_bytes.slice(charstrings_offset)), local_subroutines));
 
     // CFF spec, "Table 16 Encoding ID"
     // FIXME: Only read this if the built-in encoding is actually needed? (ie. `if (!encoding)`)


### PR DESCRIPTION
This was the last piece of data we didn't read yet.
(We also don't yet support multiple fonts per CFF, but I haven't
found a PDF using that yet.)

We still don't do anything with it, but now we at least print a
warning if this data is there and we ignore it.