### PR TITLE
LibWeb: Forbid sharing image requests across documents

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -3555,4 +3555,9 @@ void Document::update_for_history_step_application(JS::NonnullGCPtr<HTML::Sessio
     }
 }
 
+HashMap<AK::URL, HTML::SharedImageRequest*>& Document::shared_image_requests()
+{
+    return m_shared_image_requests;
+}
+
 }

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -30,6 +30,7 @@
 #include <LibWeb/HTML/Origin.h>
 #include <LibWeb/HTML/SandboxingFlagSet.h>
 #include <LibWeb/HTML/Scripting/Environments.h>
+#include <LibWeb/HTML/SharedImageRequest.h>
 #include <LibWeb/HTML/VisibilityState.h>
 #include <LibWeb/WebIDL/ExceptionOr.h>
 
@@ -531,6 +532,8 @@ public:
 
     void update_for_history_step_application(JS::NonnullGCPtr<HTML::SessionHistoryEntry>, bool do_not_reactive, size_t script_history_length, size_t script_history_index);
 
+    HashMap<AK::URL, HTML::SharedImageRequest*>& shared_image_requests();
+
 protected:
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
@@ -735,6 +738,8 @@ private:
 
     // https://html.spec.whatwg.org/multipage/browsing-the-web.html#latest-entry
     JS::GCPtr<HTML::SessionHistoryEntry> m_latest_entry;
+
+    HashMap<AK::URL, HTML::SharedImageRequest*> m_shared_image_requests;
 };
 
 template<>

--- a/Userland/Libraries/LibWeb/HTML/SharedImageRequest.h
+++ b/Userland/Libraries/LibWeb/HTML/SharedImageRequest.h
@@ -42,7 +42,7 @@ public:
     virtual void visit_edges(JS::Cell::Visitor&) override;
 
 private:
-    explicit SharedImageRequest(Page&, AK::URL);
+    explicit SharedImageRequest(Page&, AK::URL, JS::NonnullGCPtr<DOM::Document>);
 
     void handle_successful_fetch(AK::URL const&, StringView mime_type, ByteBuffer data);
     void handle_failed_fetch();
@@ -67,6 +67,8 @@ private:
     AK::URL m_url;
     RefPtr<DecodedImageData const> m_image_data;
     JS::GCPtr<Fetch::Infrastructure::FetchController> m_fetch_controller;
+
+    JS::GCPtr<DOM::Document> m_document;
 };
 
 }


### PR DESCRIPTION
This change addresses the bug where images unable to load when the reload button in the UI is clicked repeatedly. Before this fix, it was possible to use SharedImageRequests across multiple documents. However, when the document that initiated the request is gone, tasks scheduled on the event loop remain in the fetching state because the originating document is no longer active. Furthermore, another reason to prohibit the sharing of image requests across documents is that the "Origin" header in an image request is dependent on the document.