### PR TITLE
Ladybird+LibWebView: Use Public Suffix List for deciding eTLD+1, and highlight AppKit's URL bar

### DIFF
--- a/Userland/Applications/Browser/CMakeLists.txt
+++ b/Userland/Applications/Browser/CMakeLists.txt
@@ -25,6 +25,7 @@ set(SOURCES
     StorageModel.cpp
     StorageWidget.cpp
     Tab.cpp
+    URLBox.cpp
     WindowActions.cpp
     main.cpp
 )

--- a/Userland/Applications/Browser/Tab.cpp
+++ b/Userland/Applications/Browser/Tab.cpp
@@ -21,6 +21,7 @@
 #include <AK/StringBuilder.h>
 #include <AK/URL.h>
 #include <Applications/Browser/TabGML.h>
+#include <Applications/Browser/URLBox.h>
 #include <Applications/BrowserSettings/Defaults.h>
 #include <LibConfig/Client.h>
 #include <LibGUI/Action.h>
@@ -157,7 +158,7 @@ Tab::Tab(BrowserWindow& window)
 
     toolbar.add_action(window.reload_action());
 
-    m_location_box = toolbar.add<GUI::UrlBox>();
+    m_location_box = toolbar.add<URLBox>();
     m_location_box->set_placeholder("Search or enter address"sv);
 
     m_location_box->on_return_pressed = [this] {

--- a/Userland/Applications/Browser/Tab.h
+++ b/Userland/Applications/Browser/Tab.h
@@ -28,6 +28,7 @@ class InspectorWidget;
 class ConsoleWidget;
 class HistoryWidget;
 class StorageWidget;
+class URLBox;
 
 class Tab final : public GUI::Widget {
     C_OBJECT(Tab);
@@ -120,7 +121,7 @@ private:
 
     RefPtr<WebView::OutOfProcessWebView> m_web_content_view;
 
-    RefPtr<GUI::UrlBox> m_location_box;
+    RefPtr<URLBox> m_location_box;
     RefPtr<GUI::Button> m_reset_zoom_button;
     RefPtr<GUI::Button> m_bookmark_button;
     RefPtr<InspectorWidget> m_dom_inspector_widget;

--- a/Userland/Applications/Browser/URLBox.cpp
+++ b/Userland/Applications/Browser/URLBox.cpp
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2023, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/URL.h>
+#include <Applications/Browser/URLBox.h>
+#include <LibGfx/Palette.h>
+#include <LibGfx/TextAttributes.h>
+
+namespace Browser {
+
+URLBox::URLBox()
+{
+    set_auto_focusable(false);
+
+    on_change = [this] {
+        highlight_url();
+    };
+}
+
+void URLBox::focusout_event(GUI::FocusEvent& event)
+{
+    set_focus_transition(true);
+
+    highlight_url();
+    GUI::TextBox::focusout_event(event);
+}
+
+void URLBox::focusin_event(GUI::FocusEvent& event)
+{
+    highlight_url();
+    GUI::TextBox::focusin_event(event);
+}
+
+void URLBox::mousedown_event(GUI::MouseEvent& event)
+{
+    if (is_displayonly())
+        return;
+
+    if (event.button() != GUI::MouseButton::Primary)
+        return;
+
+    if (is_focus_transition()) {
+        GUI::TextBox::select_current_line();
+
+        set_focus_transition(false);
+    } else {
+        GUI::TextBox::mousedown_event(event);
+    }
+}
+
+void URLBox::highlight_url()
+{
+    auto url = URL::create_with_url_or_path(text());
+    Vector<GUI::TextDocumentSpan> spans;
+
+    if (url.is_valid() && !is_focused()) {
+        if (url.scheme() == "http" || url.scheme() == "https" || url.scheme() == "gemini") {
+            auto serialized_host = url.serialized_host().release_value_but_fixme_should_propagate_errors().to_deprecated_string();
+            auto host_start = url.scheme().bytes_as_string_view().length() + 3;
+            auto host_length = serialized_host.length();
+
+            // FIXME: Maybe add a generator to use https://publicsuffix.org/list/public_suffix_list.dat
+            //        for now just highlight the whole host
+
+            Gfx::TextAttributes default_format;
+            default_format.color = palette().color(Gfx::ColorRole::PlaceholderText);
+            spans.append({
+                { { 0, 0 }, { 0, host_start } },
+                default_format,
+            });
+
+            Gfx::TextAttributes host_format;
+            host_format.color = palette().color(Gfx::ColorRole::BaseText);
+            spans.append({
+                { { 0, host_start }, { 0, host_start + host_length } },
+                host_format,
+            });
+
+            spans.append({
+                { { 0, host_start + host_length }, { 0, text().length() } },
+                default_format,
+            });
+        } else if (url.scheme() == "file") {
+            Gfx::TextAttributes scheme_format;
+            scheme_format.color = palette().color(Gfx::ColorRole::PlaceholderText);
+            spans.append({
+                { { 0, 0 }, { 0, url.scheme().bytes_as_string_view().length() + 3 } },
+                scheme_format,
+            });
+        }
+    }
+
+    document().set_spans(0, move(spans));
+    update();
+}
+
+}

--- a/Userland/Applications/Browser/URLBox.h
+++ b/Userland/Applications/Browser/URLBox.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2023, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibGUI/TextBox.h>
+
+namespace Browser {
+
+class URLBox : public GUI::TextBox {
+    C_OBJECT(URLBox)
+
+public:
+    virtual ~URLBox() override = default;
+
+    void set_focus_transition(bool focus_transition) { m_focus_transition = focus_transition; }
+    bool is_focus_transition() const { return m_focus_transition; }
+
+private:
+    URLBox();
+
+    void highlight_url();
+
+    virtual void mousedown_event(GUI::MouseEvent&) override;
+    virtual void focusout_event(GUI::FocusEvent&) override;
+    virtual void focusin_event(GUI::FocusEvent&) override;
+
+    bool m_focus_transition { true };
+};
+
+}

--- a/Userland/Libraries/LibGUI/Forward.h
+++ b/Userland/Libraries/LibGUI/Forward.h
@@ -79,7 +79,6 @@ class Statusbar;
 class TabWidget;
 class TableView;
 class TextBox;
-class UrlBox;
 class TextDocument;
 class TextDocumentUndoCommand;
 class TextEditor;

--- a/Userland/Libraries/LibGUI/TextBox.cpp
+++ b/Userland/Libraries/LibGUI/TextBox.cpp
@@ -6,16 +6,13 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/URL.h>
 #include <AK/Vector.h>
 #include <LibGUI/Painter.h>
 #include <LibGUI/TextBox.h>
 #include <LibGfx/Palette.h>
-#include <LibGfx/TextAttributes.h>
 
 REGISTER_WIDGET(GUI, TextBox)
 REGISTER_WIDGET(GUI, PasswordBox)
-REGISTER_WIDGET(GUI, UrlBox)
 
 namespace GUI {
 
@@ -130,92 +127,6 @@ void PasswordBox::mousedown_event(GUI::MouseEvent& event)
     } else {
         TextBox::mousedown_event(event);
     }
-}
-
-UrlBox::UrlBox()
-    : TextBox()
-{
-    set_auto_focusable(false);
-    on_change = [this] {
-        highlight_url();
-    };
-}
-
-void UrlBox::focusout_event(GUI::FocusEvent& event)
-{
-    set_focus_transition(true);
-
-    highlight_url();
-    TextBox::focusout_event(event);
-}
-
-void UrlBox::focusin_event(GUI::FocusEvent& event)
-{
-    highlight_url();
-    TextBox::focusin_event(event);
-}
-
-void UrlBox::mousedown_event(GUI::MouseEvent& event)
-{
-    if (is_displayonly())
-        return;
-
-    if (event.button() != MouseButton::Primary)
-        return;
-
-    if (is_focus_transition()) {
-        TextBox::select_current_line();
-
-        set_focus_transition(false);
-    } else {
-        TextBox::mousedown_event(event);
-    }
-}
-
-void UrlBox::highlight_url()
-{
-    auto url = AK::URL::create_with_url_or_path(text());
-    Vector<GUI::TextDocumentSpan> spans;
-
-    if (url.is_valid() && !is_focused()) {
-        if (url.scheme() == "http" || url.scheme() == "https" || url.scheme() == "gemini") {
-            auto serialized_host = url.serialized_host().release_value_but_fixme_should_propagate_errors().to_deprecated_string();
-            auto host_start = url.scheme().bytes_as_string_view().length() + 3;
-            auto host_length = serialized_host.length();
-
-            // FIXME: Maybe add a generator to use https://publicsuffix.org/list/public_suffix_list.dat
-            //        for now just highlight the whole host
-
-            Gfx::TextAttributes default_format;
-            default_format.color = palette().color(Gfx::ColorRole::PlaceholderText);
-            spans.append({
-                { { 0, 0 }, { 0, host_start } },
-                default_format,
-            });
-
-            Gfx::TextAttributes host_format;
-            host_format.color = palette().color(Gfx::ColorRole::BaseText);
-            spans.append({
-                { { 0, host_start }, { 0, host_start + host_length } },
-                host_format,
-            });
-
-            spans.append({
-                { { 0, host_start + host_length }, { 0, text().length() } },
-                default_format,
-            });
-        } else if (url.scheme() == "file") {
-            Gfx::TextAttributes scheme_format;
-            scheme_format.color = palette().color(Gfx::ColorRole::PlaceholderText);
-            spans.append({
-                { { 0, 0 }, { 0, url.scheme().bytes_as_string_view().length() + 3 } },
-                scheme_format,
-            });
-        }
-    }
-
-    document().set_spans(0, move(spans));
-    update();
 }
 
 }

--- a/Userland/Libraries/LibGUI/TextBox.h
+++ b/Userland/Libraries/LibGUI/TextBox.h
@@ -61,24 +61,4 @@ private:
     bool m_show_reveal_button { false };
 };
 
-class UrlBox : public TextBox {
-    C_OBJECT(UrlBox)
-public:
-    virtual ~UrlBox() override = default;
-
-    void set_focus_transition(bool focus_transition) { m_focus_transition = focus_transition; }
-    bool is_focus_transition() const { return m_focus_transition; }
-
-private:
-    UrlBox();
-
-    void highlight_url();
-
-    virtual void mousedown_event(GUI::MouseEvent&) override;
-    virtual void focusout_event(GUI::FocusEvent&) override;
-    virtual void focusin_event(GUI::FocusEvent&) override;
-
-    bool m_focus_transition { true };
-};
-
 }

--- a/Userland/Libraries/LibWebView/URL.h
+++ b/Userland/Libraries/LibWebView/URL.h
@@ -16,7 +16,13 @@ enum class AppendTLD {
     No,
     Yes,
 };
-
 Optional<URL> sanitize_url(StringView, Optional<StringView> search_engine = {}, AppendTLD = AppendTLD::No);
+
+struct URLParts {
+    StringView scheme_and_subdomain;
+    StringView effective_tld_plus_one;
+    StringView remainder;
+};
+Optional<URLParts> break_url_into_parts(StringView url);
 
 }


### PR DESCRIPTION
<img width="1035" alt="Screenshot 2023-10-17 at 12 47 37 PM" src="https://github.com/SerenityOS/serenity/assets/5600524/b8fb709a-d0de-4c4c-846e-8a3e499fcb91">
<img width="1035" alt="Screenshot 2023-10-17 at 12 47 32 PM" src="https://github.com/SerenityOS/serenity/assets/5600524/0f4c718b-9612-409a-83cb-8ca947e1c4af">

<img width="1035" alt="Screenshot 2023-10-17 at 12 47 22 PM" src="https://github.com/SerenityOS/serenity/assets/5600524/b4ecf2fa-56fb-4074-947a-f951397317f3">
<img width="991" alt="Screenshot 2023-10-17 at 12 47 26 PM" src="https://github.com/SerenityOS/serenity/assets/5600524/42c3e29d-501e-4863-bcc5-f473876e4d08">

<img width="1035" alt="Screenshot 2023-10-17 at 12 51 42 PM" src="https://github.com/SerenityOS/serenity/assets/5600524/c51d0ef6-f72a-46e9-aa50-97ebdcf186b0">
<img width="1035" alt="Screenshot 2023-10-17 at 12 52 02 PM" src="https://github.com/SerenityOS/serenity/assets/5600524/d8166417-b81c-4cd4-a260-3f95bfecd843">
