### PR TITLE
LibTest: Remove the redefinition of VERIFY family of macros

### DIFF
--- a/Userland/Libraries/LibTest/Macros.h
+++ b/Userland/Libraries/LibTest/Macros.h
@@ -22,29 +22,6 @@ namespace Test {
 void current_test_case_did_fail();
 }
 
-#undef VERIFY
-#define VERIFY(x)                                                                                    \
-    do {                                                                                             \
-        if (!(x)) {                                                                                  \
-            ::AK::warnln("\033[31;1mFAIL\033[0m: {}:{}: VERIFY({}) failed", __FILE__, __LINE__, #x); \
-            ::Test::current_test_case_did_fail();                                                    \
-        }                                                                                            \
-    } while (false)
-
-#undef VERIFY_NOT_REACHED
-#define VERIFY_NOT_REACHED()                                                                           \
-    do {                                                                                               \
-        ::AK::warnln("\033[31;1mFAIL\033[0m: {}:{}: VERIFY_NOT_REACHED() called", __FILE__, __LINE__); \
-        ::abort();                                                                                     \
-    } while (false)
-
-#undef TODO
-#define TODO()                                                                           \
-    do {                                                                                 \
-        ::AK::warnln("\033[31;1mFAIL\033[0m: {}:{}: TODO() called", __FILE__, __LINE__); \
-        ::abort();                                                                       \
-    } while (false)
-
 #define EXPECT_EQ(a, b)                                                                                                                                                                      \
     do {                                                                                                                                                                                     \
         auto lhs = (a);                                                                                                                                                                      \


### PR DESCRIPTION
Previously VERIFY et al. was redefined inside tests to not abort and instead fail the test. This wouldn't apply to non-header code though, and was not helpful, as it prevented you from easily attaching gdb near the abort.

After this removal tests can still use the EXPECT family of macros, but VERIFY will behave like it does in the rest of the codebase (abort etc.).