### PR TITLE
LibPDF: Make Subrs optional in PS1FontProgram

### DIFF
--- a/Userland/Libraries/LibPDF/Fonts/PS1FontProgram.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/PS1FontProgram.cpp
@@ -70,9 +70,9 @@ PDFErrorOr<void> PS1FontProgram::parse_encrypted_portion(ByteBuffer const& buffe
     if (seek_name(reader, "lenIV"))
         m_lenIV = TRY(parse_int(reader));
 
-    if (!seek_name(reader, "Subrs"))
-        return error("Missing subroutine array");
-    auto subroutines = TRY(parse_subroutines(reader));
+    Vector<ByteBuffer> subroutines;
+    if (seek_name(reader, "Subrs"))
+        subroutines = TRY(parse_subroutines(reader));
 
     if (!seek_name(reader, "CharStrings"))
         return error("Missing char strings array");


### PR DESCRIPTION
https://adobe-type-tools.github.io/font-tech-notes/pdfs/T1_SPEC.pdf :

"Using charstring subroutines is not a requirement of a Type 1 font program."

And some versions of Computer Modern do in fact not contain a Subrs array.

Together with #21473, makes Problemset.pdf from the pdffiles repro render ok instead of crashing.