### PR TITLE
LibPDF: Implement support for callgsubr in CFF font programs, and opcode 28

### DIFF
--- a/Userland/Libraries/LibPDF/Fonts/CFF.h
+++ b/Userland/Libraries/LibPDF/Fonts/CFF.h
@@ -94,7 +94,7 @@ public:
 
     static PDFErrorOr<Vector<StringView>> parse_strings(Reader&);
 
-    static PDFErrorOr<Vector<CFF::Glyph>> parse_charstrings(Reader&&, Vector<ByteBuffer> const& subroutines);
+    static PDFErrorOr<Vector<CFF::Glyph>> parse_charstrings(Reader&&, Vector<ByteBuffer> const& local_subroutines, Vector<ByteBuffer> const& global_subroutines);
 
     static DeprecatedFlyString resolve_sid(SID, Vector<StringView> const&);
     static PDFErrorOr<Vector<DeprecatedFlyString>> parse_charset(Reader&&, size_t, Vector<StringView> const&);

--- a/Userland/Libraries/LibPDF/Fonts/PS1FontProgram.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/PS1FontProgram.cpp
@@ -92,7 +92,7 @@ PDFErrorOr<void> PS1FontProgram::parse_encrypted_portion(ByteBuffer const& buffe
                 reader.move_by(encrypted_size);
                 auto glyph_name = word.substring_view(1);
                 GlyphParserState state;
-                TRY(add_glyph(glyph_name, TRY(parse_glyph(line, subroutines, state, false))));
+                TRY(add_glyph(glyph_name, TRY(parse_glyph(line, subroutines, {}, state, false))));
             }
         }
     }

--- a/Userland/Libraries/LibPDF/Fonts/Type1FontProgram.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/Type1FontProgram.cpp
@@ -373,6 +373,21 @@ PDFErrorOr<Type1FontProgram::Glyph> Type1FontProgram::parse_glyph(ReadonlyBytes 
 
             case CallSubr: {
                 auto subr_number = pop();
+
+                if (is_type2) {
+                    // Type 2 spec:
+                    // "The numbering of subroutines is encoded more compactly by using the negative half of the number space, which effectively
+                    //  doubles the number of compactly encodable subroutine numbers. The bias applied depends on the number of subrs (gsubrs).
+                    //  If the number of subrs (gsubrs) is less than 1240, the bias is 107. Otherwise if it is less than 33900, it is 1131; otherwise
+                    //  it is 32768. This bias is added to the encoded subr (gsubr) number to find the appropriate entry in the subr (gsubr) array."
+                    if (subroutines.size() < 1240)
+                        subr_number += 107;
+                    else if (subroutines.size() < 33900)
+                        subr_number += 1131;
+                    else
+                        subr_number += 32768;
+                }
+
                 if (static_cast<size_t>(subr_number) >= subroutines.size())
                     return error("Subroutine index out of range");
 

--- a/Userland/Libraries/LibPDF/Fonts/Type1FontProgram.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/Type1FontProgram.cpp
@@ -274,6 +274,17 @@ PDFErrorOr<Type1FontProgram::Glyph> Type1FontProgram::parse_glyph(ReadonlyBytes 
             TRY(push(((v - 247) * 256) + w + 108));
         } else if (v >= 32) {
             TRY(push(v - 139));
+        } else if (v == 28) {
+            if (is_type2) {
+                // Type 2 spec: "In addition to the 32 to 255 range of values, a ShortInt value is specified by using the operator (28)
+                // followed by two bytes which represent numbers between –32768 and +32767. The most significant byte follows the (28)."
+                TRY(require(2));
+                i16 a = static_cast<i16>((data[i + 1] << 8) | data[i + 2]);
+                i += 2;
+                TRY(push(a));
+            } else {
+                return error(DeprecatedString::formatted("CFF Subr command 28 only valid in type2 data"));
+            }
         } else {
             // Not a parameter but a command byte.
             switch (v) {

--- a/Userland/Libraries/LibPDF/Fonts/Type1FontProgram.h
+++ b/Userland/Libraries/LibPDF/Fonts/Type1FontProgram.h
@@ -81,7 +81,7 @@ protected:
         Array<float, 24> postscript_stack;
     };
 
-    static PDFErrorOr<Glyph> parse_glyph(ReadonlyBytes const&, Vector<ByteBuffer> const&, GlyphParserState&, bool is_type2);
+    static PDFErrorOr<Glyph> parse_glyph(ReadonlyBytes const&, Vector<ByteBuffer> const& local_subroutines, Vector<ByteBuffer> const& global_subroutines, GlyphParserState&, bool is_type2);
 
     static Error error(
         DeprecatedString const& message


### PR DESCRIPTION
Font programs are bytecode programs defining glyphs. If several glyphs
share a piece of outline, that opcode sequence can be put in a
subroutine ("subr") table and the definition of those glyphs can then
call that subroutine by number, to reduce file size.

CFF fonts can in theory contain multiple fonts, and so there's a global
subr table shared by all the fonts in one CFF, and a local per-fornt
subr table.  We used to only implement the local subr table, now we
implement both.

(We only support one font per CFF, and at least in PDF files, that's
all that's ever used. So a global subr table isn't very useful.
But the spec explicitly allows it -- "Global subroutines may be used in
a FontSet even if it only contains one font." -- and it happens in
practice.)