### PR TITLE
LibWeb/Painting: Do not clip border radius when it is out of viewport

### DIFF
--- a/Userland/Libraries/LibWeb/Painting/BorderRadiusCornerClipper.cpp
+++ b/Userland/Libraries/LibWeb/Painting/BorderRadiusCornerClipper.cpp
@@ -53,7 +53,7 @@ ErrorOr<NonnullRefPtr<BorderRadiusCornerClipper>> BorderRadiusCornerClipper::cre
         .corner_bitmap_size = corners_bitmap_size
     };
 
-    return try_make_ref_counted<BorderRadiusCornerClipper>(corner_data, corner_bitmap.release_nonnull(), corner_clip);
+    return try_make_ref_counted<BorderRadiusCornerClipper>(corner_data, corner_bitmap.release_nonnull(), corner_clip, border_rect);
 }
 
 void BorderRadiusCornerClipper::sample_under_corners(Gfx::Painter& page_painter)

--- a/Userland/Libraries/LibWeb/Painting/BorderRadiusCornerClipper.h
+++ b/Userland/Libraries/LibWeb/Painting/BorderRadiusCornerClipper.h
@@ -41,10 +41,13 @@ public:
         DevicePixelSize corner_bitmap_size;
     } m_data;
 
-    BorderRadiusCornerClipper(CornerData corner_data, NonnullRefPtr<Gfx::Bitmap> corner_bitmap, CornerClip corner_clip)
+    DevicePixelRect border_rect() const { return m_border_rect; }
+
+    BorderRadiusCornerClipper(CornerData corner_data, NonnullRefPtr<Gfx::Bitmap> corner_bitmap, CornerClip corner_clip, DevicePixelRect const& border_rect)
         : m_data(move(corner_data))
         , m_corner_bitmap(corner_bitmap)
         , m_corner_clip(corner_clip)
+        , m_border_rect(border_rect)
     {
     }
 
@@ -52,6 +55,7 @@ private:
     NonnullRefPtr<Gfx::Bitmap> m_corner_bitmap;
     bool m_has_sampled { false };
     CornerClip m_corner_clip { false };
+    DevicePixelRect m_border_rect;
 };
 
 struct ScopedCornerRadiusClip {

--- a/Userland/Libraries/LibWeb/Painting/RecordingPainter.cpp
+++ b/Userland/Libraries/LibWeb/Painting/RecordingPainter.cpp
@@ -44,7 +44,6 @@ CommandResult FillRectWithRoundedCorners::execute(CommandExecutionState& state) 
 {
     if (state.would_be_fully_clipped_by_painter(rect))
         return CommandResult::Continue;
-    ;
 
     auto& painter = state.painter();
 
@@ -65,7 +64,6 @@ CommandResult DrawText::execute(CommandExecutionState& state) const
 {
     if (state.would_be_fully_clipped_by_painter(rect))
         return CommandResult::Continue;
-    ;
     auto& painter = state.painter();
     if (font.has_value()) {
         painter.draw_text(rect, raw_text, *font, alignment, color, elision, wrapping);
@@ -79,7 +77,6 @@ CommandResult DrawTextRun::execute(CommandExecutionState& state) const
 {
     if (state.would_be_fully_clipped_by_painter(rect))
         return CommandResult::Continue;
-    ;
     auto& painter = state.painter();
     painter.draw_text_run(baseline_start, Utf8View(string), font, color);
     return CommandResult::Continue;
@@ -275,7 +272,6 @@ CommandResult PushStackingContextWithMask::execute(CommandExecutionState& state)
     auto bitmap_or_error = Gfx::Bitmap::create(Gfx::BitmapFormat::BGRA8888, paint_rect.size().to_type<int>());
     if (bitmap_or_error.is_error())
         return CommandResult::Continue;
-    ;
     auto bitmap = bitmap_or_error.release_value();
 
     Gfx::Painter stacking_context_painter(bitmap);
@@ -316,7 +312,6 @@ CommandResult PaintRadialGradient::execute(CommandExecutionState& state) const
 {
     if (state.would_be_fully_clipped_by_painter(rect))
         return CommandResult::Continue;
-    ;
     auto& painter = state.painter();
     painter.fill_rect_with_radial_gradient(rect, radial_gradient_data.color_stops.list, center, size, radial_gradient_data.color_stops.repeat_length);
     return CommandResult::Continue;
@@ -326,7 +321,6 @@ CommandResult PaintConicGradient::execute(CommandExecutionState& state) const
 {
     if (state.would_be_fully_clipped_by_painter(rect))
         return CommandResult::Continue;
-    ;
     auto& painter = state.painter();
     painter.fill_rect_with_conic_gradient(rect, conic_gradient_data.color_stops.list, position, conic_gradient_data.start_angle, conic_gradient_data.color_stops.repeat_length);
     return CommandResult::Continue;
@@ -350,14 +344,12 @@ CommandResult PaintTextShadow::execute(CommandExecutionState& state) const
 {
     if (state.would_be_fully_clipped_by_painter(text_rect.to_type<int>()))
         return CommandResult::Continue;
-    ;
 
     // FIXME: Figure out the maximum bitmap size for all shadows and then allocate it once and reuse it?
     auto maybe_shadow_bitmap = Gfx::Bitmap::create(Gfx::BitmapFormat::BGRA8888, bounding_rect.size().to_type<int>());
     if (maybe_shadow_bitmap.is_error()) {
         dbgln("Unable to allocate temporary bitmap {} for text-shadow rendering: {}", bounding_rect.size(), maybe_shadow_bitmap.error());
         return CommandResult::Continue;
-        ;
     }
     auto shadow_bitmap = maybe_shadow_bitmap.release_value();
 
@@ -379,7 +371,6 @@ CommandResult DrawEllipse::execute(CommandExecutionState& state) const
 {
     if (state.would_be_fully_clipped_by_painter(rect))
         return CommandResult::Continue;
-    ;
     auto& painter = state.painter();
     Gfx::AntiAliasingPainter aa_painter(painter);
     aa_painter.draw_ellipse(rect, color, thickness);
@@ -390,7 +381,6 @@ CommandResult FillElipse::execute(CommandExecutionState& state) const
 {
     if (state.would_be_fully_clipped_by_painter(rect))
         return CommandResult::Continue;
-    ;
     auto& painter = state.painter();
     Gfx::AntiAliasingPainter aa_painter(painter);
     aa_painter.fill_ellipse(rect, color, blend_mode);
@@ -412,7 +402,6 @@ CommandResult DrawSignedDistanceField::execute(CommandExecutionState& state) con
 {
     if (state.would_be_fully_clipped_by_painter(rect))
         return CommandResult::Continue;
-    ;
     auto& painter = state.painter();
     painter.draw_signed_distance_field(rect, color, sdf, smoothing);
     return CommandResult::Continue;
@@ -450,7 +439,6 @@ CommandResult ApplyBackdropFilter::execute(CommandExecutionState& state) const
     auto maybe_backdrop_bitmap = painter.get_region_bitmap(backdrop_region, Gfx::BitmapFormat::BGRA8888, actual_region);
     if (actual_region.is_empty())
         return CommandResult::Continue;
-    ;
     if (maybe_backdrop_bitmap.is_error()) {
         dbgln("Failed get region bitmap for backdrop-filter");
         return CommandResult::Continue;
@@ -475,7 +463,6 @@ CommandResult DrawRect::execute(CommandExecutionState& state) const
 {
     if (state.would_be_fully_clipped_by_painter(rect))
         return CommandResult::Continue;
-    ;
     auto& painter = state.painter();
     painter.draw_rect(rect, color, rough);
     return CommandResult::Continue;

--- a/Userland/Libraries/LibWeb/Painting/RecordingPainter.cpp
+++ b/Userland/Libraries/LibWeb/Painting/RecordingPainter.cpp
@@ -328,6 +328,9 @@ CommandResult PaintConicGradient::execute(CommandExecutionState& state) const
 
 CommandResult PaintOuterBoxShadow::execute(CommandExecutionState& state) const
 {
+    auto bounding_rect = get_outer_box_shadow_bounding_rect(outer_box_shadow_params);
+    if (state.would_be_fully_clipped_by_painter(bounding_rect))
+        return CommandResult::Continue;
     auto& painter = state.painter();
     paint_outer_box_shadow(painter, outer_box_shadow_params);
     return CommandResult::Continue;

--- a/Userland/Libraries/LibWeb/Painting/RecordingPainter.cpp
+++ b/Userland/Libraries/LibWeb/Painting/RecordingPainter.cpp
@@ -482,6 +482,8 @@ CommandResult DrawTriangleWave::execute(CommandExecutionState& state) const
 
 CommandResult SampleUnderCorners::execute(CommandExecutionState& state) const
 {
+    if (state.would_be_fully_clipped_by_painter(corner_clipper->border_rect().to_type<int>()))
+        return CommandResult::Continue;
     auto& painter = state.painter();
     corner_clipper->sample_under_corners(painter);
     return CommandResult::Continue;
@@ -489,6 +491,8 @@ CommandResult SampleUnderCorners::execute(CommandExecutionState& state) const
 
 CommandResult BlitCornerClipping::execute(CommandExecutionState& state) const
 {
+    if (state.would_be_fully_clipped_by_painter(corner_clipper->border_rect().to_type<int>()))
+        return CommandResult::Continue;
     auto& painter = state.painter();
     corner_clipper->blit_corner_clipping(painter);
     return CommandResult::Continue;

--- a/Userland/Libraries/LibWeb/Painting/RecordingPainter.cpp
+++ b/Userland/Libraries/LibWeb/Painting/RecordingPainter.cpp
@@ -87,6 +87,8 @@ CommandResult DrawTextRun::execute(CommandExecutionState& state) const
 
 CommandResult FillPathUsingColor::execute(CommandExecutionState& state) const
 {
+    if (state.would_be_fully_clipped_by_painter(bounding_rect))
+        return CommandResult::Continue;
     auto& painter = state.painter();
     Gfx::AntiAliasingPainter aa_painter(painter);
     if (aa_translation.has_value())
@@ -97,6 +99,8 @@ CommandResult FillPathUsingColor::execute(CommandExecutionState& state) const
 
 CommandResult FillPathUsingPaintStyle::execute(CommandExecutionState& state) const
 {
+    if (state.would_be_fully_clipped_by_painter(bounding_rect))
+        return CommandResult::Continue;
     auto& painter = state.painter();
     Gfx::AntiAliasingPainter aa_painter(painter);
     if (aa_translation.has_value())
@@ -107,6 +111,8 @@ CommandResult FillPathUsingPaintStyle::execute(CommandExecutionState& state) con
 
 CommandResult StrokePathUsingColor::execute(CommandExecutionState& state) const
 {
+    if (state.would_be_fully_clipped_by_painter(bounding_rect))
+        return CommandResult::Continue;
     auto& painter = state.painter();
     Gfx::AntiAliasingPainter aa_painter(painter);
     if (aa_translation.has_value())
@@ -117,6 +123,8 @@ CommandResult StrokePathUsingColor::execute(CommandExecutionState& state) const
 
 CommandResult StrokePathUsingPaintStyle::execute(CommandExecutionState& state) const
 {
+    if (state.would_be_fully_clipped_by_painter(bounding_rect))
+        return CommandResult::Continue;
     auto& painter = state.painter();
     Gfx::AntiAliasingPainter aa_painter(painter);
     if (aa_translation.has_value())
@@ -526,7 +534,9 @@ void RecordingPainter::fill_rect(Gfx::IntRect const& rect, Color color)
 
 void RecordingPainter::fill_path(FillPathUsingColorParams params)
 {
+    auto bounding_rect = params.path.bounding_box().translated(params.translation.value_or({})).to_type<int>();
     push_command(FillPathUsingColor {
+        .bounding_rect = bounding_rect,
         .path = params.path,
         .color = params.color,
         .winding_rule = params.winding_rule,
@@ -536,7 +546,9 @@ void RecordingPainter::fill_path(FillPathUsingColorParams params)
 
 void RecordingPainter::fill_path(FillPathUsingPaintStyleParams params)
 {
+    auto bounding_rect = params.path.bounding_box().translated(params.translation.value_or({})).to_type<int>();
     push_command(FillPathUsingPaintStyle {
+        .bounding_rect = bounding_rect,
         .path = params.path,
         .paint_style = params.paint_style,
         .winding_rule = params.winding_rule,
@@ -547,7 +559,9 @@ void RecordingPainter::fill_path(FillPathUsingPaintStyleParams params)
 
 void RecordingPainter::stroke_path(StrokePathUsingColorParams params)
 {
+    auto bounding_rect = params.path.bounding_box().translated(params.translation.value_or({})).to_type<int>();
     push_command(StrokePathUsingColor {
+        .bounding_rect = bounding_rect,
         .path = params.path,
         .color = params.color,
         .thickness = params.thickness,
@@ -557,7 +571,9 @@ void RecordingPainter::stroke_path(StrokePathUsingColorParams params)
 
 void RecordingPainter::stroke_path(StrokePathUsingPaintStyleParams params)
 {
+    auto bounding_rect = params.path.bounding_box().translated(params.translation.value_or({})).to_type<int>();
     push_command(StrokePathUsingPaintStyle {
+        .bounding_rect = bounding_rect,
         .path = params.path,
         .paint_style = params.paint_style,
         .thickness = params.thickness,

--- a/Userland/Libraries/LibWeb/Painting/RecordingPainter.h
+++ b/Userland/Libraries/LibWeb/Painting/RecordingPainter.h
@@ -194,6 +194,7 @@ struct FillRectWithRoundedCorners {
 };
 
 struct FillPathUsingColor {
+    Gfx::IntRect bounding_rect;
     Gfx::Path path;
     Color color;
     Gfx::Painter::WindingRule winding_rule;
@@ -203,6 +204,7 @@ struct FillPathUsingColor {
 };
 
 struct FillPathUsingPaintStyle {
+    Gfx::IntRect bounding_rect;
     Gfx::Path path;
     NonnullRefPtr<Gfx::PaintStyle> paint_style;
     Gfx::Painter::WindingRule winding_rule;
@@ -213,6 +215,7 @@ struct FillPathUsingPaintStyle {
 };
 
 struct StrokePathUsingColor {
+    Gfx::IntRect bounding_rect;
     Gfx::Path path;
     Color color;
     float thickness;
@@ -222,6 +225,7 @@ struct StrokePathUsingColor {
 };
 
 struct StrokePathUsingPaintStyle {
+    Gfx::IntRect bounding_rect;
     Gfx::Path path;
     NonnullRefPtr<Gfx::PaintStyle> paint_style;
     float thickness;

--- a/Userland/Libraries/LibWeb/Painting/ShadowPainting.h
+++ b/Userland/Libraries/LibWeb/Painting/ShadowPainting.h
@@ -14,8 +14,10 @@
 
 namespace Web::Painting {
 
-void paint_outer_box_shadow(Gfx::Painter&, PaintOuterBoxShadowParams params);
 void paint_inner_box_shadow(Gfx::Painter&, PaintOuterBoxShadowParams params);
+
+Gfx::IntRect get_outer_box_shadow_bounding_rect(PaintOuterBoxShadowParams params);
+void paint_outer_box_shadow(Gfx::Painter& painter, PaintOuterBoxShadowParams params);
 
 void paint_box_shadow(
     PaintContext&,


### PR DESCRIPTION
Painting optimizations to do less unnecessary work.