### PR TITLE
LibPDF: If softmask has different size than target bitmap, resize it

### DIFF
--- a/Userland/Libraries/LibGfx/Bitmap.cpp
+++ b/Userland/Libraries/LibGfx/Bitmap.cpp
@@ -362,7 +362,6 @@ ErrorOr<NonnullRefPtr<Gfx::Bitmap>> Bitmap::scaled(int sx, int sy) const
     return new_bitmap;
 }
 
-// http://fourier.eng.hmc.edu/e161/lectures/resize/node3.html
 ErrorOr<NonnullRefPtr<Gfx::Bitmap>> Bitmap::scaled(float sx, float sy) const
 {
     VERIFY(sx >= 0.0f && sy >= 0.0f);
@@ -371,8 +370,13 @@ ErrorOr<NonnullRefPtr<Gfx::Bitmap>> Bitmap::scaled(float sx, float sy) const
 
     int scaled_width = (int)ceilf(sx * (float)width());
     int scaled_height = (int)ceilf(sy * (float)height());
+    return scaled_to_size({ scaled_width, scaled_height });
+}
 
-    auto new_bitmap = TRY(Gfx::Bitmap::create(format(), { scaled_width, scaled_height }, scale()));
+// http://fourier.eng.hmc.edu/e161/lectures/resize/node3.html
+ErrorOr<NonnullRefPtr<Gfx::Bitmap>> Bitmap::scaled_to_size(Gfx::IntSize size) const
+{
+    auto new_bitmap = TRY(Gfx::Bitmap::create(format(), size, scale()));
 
     auto old_width = physical_width();
     auto old_height = physical_height();

--- a/Userland/Libraries/LibGfx/Bitmap.h
+++ b/Userland/Libraries/LibGfx/Bitmap.h
@@ -114,6 +114,7 @@ public:
     ErrorOr<NonnullRefPtr<Gfx::Bitmap>> flipped(Gfx::Orientation) const;
     ErrorOr<NonnullRefPtr<Gfx::Bitmap>> scaled(int sx, int sy) const;
     ErrorOr<NonnullRefPtr<Gfx::Bitmap>> scaled(float sx, float sy) const;
+    ErrorOr<NonnullRefPtr<Gfx::Bitmap>> scaled_to_size(Gfx::IntSize) const;
     ErrorOr<NonnullRefPtr<Gfx::Bitmap>> cropped(Gfx::IntRect, Optional<BitmapFormat> new_bitmap_format = {}) const;
     ErrorOr<NonnullRefPtr<Gfx::Bitmap>> to_bitmap_backed_by_anonymous_buffer() const;
     [[nodiscard]] ErrorOr<ByteBuffer> serialize_to_byte_buffer() const;

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -892,7 +892,12 @@ PDFErrorOr<void> Renderer::show_image(NonnullRefPtr<StreamObject> image)
     auto image_bitmap = TRY(load_image(image));
     if (image_dict->contains(CommonNames::SMask)) {
         auto smask_bitmap = TRY(load_image(TRY(image_dict->get_stream(m_document, CommonNames::SMask))));
-        VERIFY(smask_bitmap->rect() == image_bitmap->rect());
+
+        // Make softmask same size as image.
+        // FIXME: The smask code here is fairly ad-hoc and incomplete.
+        if (smask_bitmap->size() != image_bitmap->size())
+            smask_bitmap = TRY(smask_bitmap->scaled_to_size(image_bitmap->size()));
+
         for (int j = 0; j < image_bitmap->height(); ++j) {
             for (int i = 0; i < image_bitmap->width(); ++i) {
                 auto image_color = image_bitmap->get_pixel(i, j);


### PR DESCRIPTION
Size of smask and image aren't guaranteed to be equal by the spec (...except for /Matte, see page 555 of the PDF 1.7 spec, but we don't implement that), and in pratice they sometimes aren't.

Fixes an assert on page 4 of
https://devstreaming-cdn.apple.com/videos/wwdc/2017/821kjtggolzxsv/821/821_get_started_with_display_p3.pdf We now make it all the way to page 43 of 64 before crashing.