### PR TITLE
LibJS: Disable Temporal custom time zone test

### DIFF
--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/Now/Now.plainDateTime.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/Now/Now.plainDateTime.js
@@ -29,7 +29,10 @@ describe("correct behavior", () => {
     //       and negative timezones and skip one if we jump the year. To ensure at least one is
     //       tested we have the timeZoneTested which is only set to true if one of the tests passed.
 
-    test("custom time zone positive", () => {
+    // FIXME: The custom time zone tests are disabled due to being flaky. See:
+    //        https://github.com/SerenityOS/serenity/issues/20806
+
+    test.skip("custom time zone positive", () => {
         const calendar = new Temporal.Calendar("iso8601");
         const timeZone = {
             getOffsetNanosecondsFor() {
@@ -53,7 +56,7 @@ describe("correct behavior", () => {
         timeZoneTested = true;
     });
 
-    test("custom time zone negative", () => {
+    test.skip("custom time zone negative", () => {
         const calendar = new Temporal.Calendar("iso8601");
         const timeZone = {
             getOffsetNanosecondsFor() {
@@ -77,7 +80,9 @@ describe("correct behavior", () => {
         timeZoneTested = true;
     });
 
-    expect(timeZoneTested).toBeTrue();
+    test.skip("custom time zone test was executed", () => {
+        expect(timeZoneTested).toBeTrue();
+    });
 
     test("cannot have a time zone with more than a day", () => {
         [86400000000000, -86400000000000, 86400000000001, 86400000000002].forEach(offset => {


### PR DESCRIPTION
This test has been flaky for quite some time. Disable it for now, and revisit once we've caught up with the Temporal spec.

(We disable this test already in Now.plainDateTimeISO.js, but I didn't realize there was a non-ISO variant of this test).