### PR TITLE
Meta: Update libjs.dev links to test262.fyi

### DIFF
--- a/Documentation/Links.md
+++ b/Documentation/Links.md
@@ -22,8 +22,6 @@ This is a roughly categorized list of pages relating to SerenityOS and its subpr
 -   [Issues Found by OSS-Fuzz Continuous Fuzzing](https://bugs.chromium.org/p/oss-fuzz/issues/list?q=label:Proj-serenity)
 -   [Azure CI Overview](https://dev.azure.com/SerenityOS/SerenityOS/_build)
 -   [SonarCloud Static Analysis](https://sonarcloud.io/project/overview?id=SerenityOS_serenity)
--   [libjs.dev](https://libjs.dev/)
-    -   [Try LibJS Online!](https://libjs.dev/repl/)
 -   [Compiler Explorer](https://serenity.godbolt.org/): Select "Lagom trunk" under "Libraries" and add the compiler option `-std=c++20`
 
 ## Related Projects
@@ -59,8 +57,7 @@ This is a roughly categorized list of pages relating to SerenityOS and its subpr
 -   [Emoji Table](https://emoji.serenityos.net/)
     -   [Emoji Statistics](https://emoji.serenityos.net/chart.emoji.serenityos)
 -   [Flags](https://flags.serenityos.net/)
--   [test262](https://libjs.dev/test262/) (JavaScript Spec Tests)
--   [Wasm Spec Tests](https://libjs.dev/wasm/)
+-   [test262](https://test262.fyi/) (JavaScript Spec Tests)
 -   [Test Performance](https://github.com/alimpfard/random-serenity-statistics/tree/main/view/benchmarks/x86_64)
 -   [serenityos.social Statistics](https://grafana.serenityos.social/public)
 

--- a/Meta/Lagom/ReadMe.md
+++ b/Meta/Lagom/ReadMe.md
@@ -14,9 +14,7 @@ Lagom is used by the Serenity project in the following ways:
 - [Unit tests](../../Documentation/RunningTests.md) in CI are built using the Lagom build for host systems to ensure portability.
 - [Continuous fuzzing](#fuzzing-on-oss-fuzz) is done with the help of OSS-fuzz using the Lagom build.
 - [The Ladybird browser](../../Ladybird/README.md) uses Lagom to provide LibWeb and LibJS for non-Serenity systems.
-- [ECMA 262 spec tests](https://libjs.dev/test262) for LibJS are run per-commit and tracked on [libjs.dev](https://libjs.dev).
-- [Wasm spec tests](https://libjs.dev/wasm) for LibWasm are run per-commit and tracked on [libjs.dev](https://libjs.dev).
-- [A Wasm LibJS Repl](https://libjs.dev/repl) using an Emscripten build of Lagom is hosted on [libjs.dev](https://libjs.dev).
+- [ECMA 262 spec tests](https://v8.github.io/test262/website/default.html) for LibJS are run per-commit and tracked on [test262.fyi](https:/test262.fyi) by CanadaHonk.
 - [The LibJS Repl](../../.github/workflows/serenity-js-artifacts.yml) is built per-commit for Linux and macOS for use by the [esvu](https://github.com/devsnek/esvu) project.
 
 ## Using Lagom in an External Project


### PR DESCRIPTION
`libjs.dev` is down, and `test262.fyi` looks to be the replacement.

I deleted the notes on WASM because I didn't find a replacement. Let me  know if I should keep some notes on them.