### PR TITLE
Fix terminal zoom

### DIFF
--- a/Userland/Applications/Terminal/main.cpp
+++ b/Userland/Applications/Terminal/main.cpp
@@ -400,10 +400,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     }));
     view_menu->add_action(terminal->clear_including_history_action());
 
-    auto adjust_font_size = [&](float adjustment) {
+    auto adjust_font_size = [&](float adjustment, Gfx::Font::AllowInexactSizeMatch preference) {
         auto& font = terminal->font();
         auto new_size = max(5, font.presentation_size() + adjustment);
-        if (auto new_font = Gfx::FontDatabase::the().get(font.family(), new_size, font.weight(), font.width(), font.slope())) {
+        if (auto new_font = Gfx::FontDatabase::the().get(font.family(), new_size, font.weight(), font.width(), font.slope(), preference)) {
             terminal->set_font_and_resize_to_fit(*new_font);
             terminal->apply_size_increments_to_window(*window);
             window->resize(terminal->size());
@@ -412,10 +412,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     view_menu->add_separator();
     view_menu->add_action(GUI::CommonActions::make_zoom_in_action([&](auto&) {
-        adjust_font_size(1);
+        adjust_font_size(1, Gfx::Font::AllowInexactSizeMatch::Larger);
     }));
     view_menu->add_action(GUI::CommonActions::make_zoom_out_action([&](auto&) {
-        adjust_font_size(-1);
+        adjust_font_size(-1, Gfx::Font::AllowInexactSizeMatch::Smaller);
     }));
 
     auto help_menu = window->add_menu("&Help"_string);

--- a/Userland/Libraries/LibGfx/Font/Font.h
+++ b/Userland/Libraries/LibGfx/Font/Font.h
@@ -148,6 +148,8 @@ public:
     enum class AllowInexactSizeMatch {
         No,
         Yes,
+        Larger,
+        Smaller,
     };
 
     virtual NonnullRefPtr<Font> clone() const = 0;

--- a/Userland/Libraries/LibGfx/Font/Typeface.cpp
+++ b/Userland/Libraries/LibGfx/Font/Typeface.cpp
@@ -73,16 +73,22 @@ RefPtr<Font> Typeface::get_font(float point_size, Font::AllowInexactSizeMatch al
     for (auto font : m_bitmap_fonts) {
         if (font->presentation_size() == size)
             return font;
-        if (allow_inexact_size_match == Font::AllowInexactSizeMatch::Yes) {
+        if (allow_inexact_size_match != Font::AllowInexactSizeMatch::No) {
             int delta = static_cast<int>(font->presentation_size()) - static_cast<int>(size);
-            if (abs(delta) < best_delta) {
+            if (abs(delta) == best_delta) {
+                if (allow_inexact_size_match == Font::AllowInexactSizeMatch::Larger && delta > 0) {
+                    best_match = font;
+                } else if (allow_inexact_size_match == Font::AllowInexactSizeMatch::Smaller && delta < 0) {
+                    best_match = font;
+                }
+            } else if (abs(delta) < best_delta) {
                 best_match = font;
                 best_delta = abs(delta);
             }
         }
     }
 
-    if (allow_inexact_size_match == Font::AllowInexactSizeMatch::Yes && best_match)
+    if (allow_inexact_size_match != Font::AllowInexactSizeMatch::No && best_match)
         return best_match;
 
     return {};


### PR DESCRIPTION
Terminal zoom was failing due to not being able to find a font of the exact requested size. This PR fixes that by allowing it to find a font of a close size in the right direction according to if the user requested to zoom in or out.