### PR TITLE
LibPDF: Implement color_rendering_intent operator

### DIFF
--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -180,7 +180,11 @@ RENDERER_HANDLER(set_dash_pattern)
     return {};
 }
 
-RENDERER_TODO(set_color_rendering_intent)
+RENDERER_HANDLER(set_color_rendering_intent)
+{
+    state().color_rendering_intent = MUST(m_document->resolve_to<NameObject>(args[0]))->name();
+    return {};
+}
 
 RENDERER_HANDLER(set_flatness_tolerance)
 {
@@ -748,7 +752,9 @@ PDFErrorOr<void> Renderer::set_graphics_state_from_dict(NonnullRefPtr<DictObject
         TRY(handle_set_dash_pattern(array->elements()));
     }
 
-    // FIXME: RI
+    if (dict->contains(CommonNames::RI))
+        TRY(handle_set_color_rendering_intent({ dict->get_value(CommonNames::RI) }));
+
     // FIXME: OP
     // FIXME: op
     // FIXME: OPM

--- a/Userland/Libraries/LibPDF/Renderer.h
+++ b/Userland/Libraries/LibPDF/Renderer.h
@@ -76,6 +76,7 @@ struct GraphicsState {
     RefPtr<ColorSpace> paint_color_space { DeviceGrayColorSpace::the() };
     Gfx::Color stroke_color { Gfx::Color::NamedColor::Black };
     Gfx::Color paint_color { Gfx::Color::NamedColor::Black };
+    DeprecatedString color_rendering_intent { "RelativeColorimetric"sv };
     float flatness_tolerance { 0.0f };
     float line_width { 1.0f };
     LineCapStyle line_cap_style { LineCapStyle::ButtCap };
@@ -281,6 +282,7 @@ struct Formatter<PDF::GraphicsState> : Formatter<StringView> {
         builder.appendff("  ctm={}\n", state.ctm);
         builder.appendff("  stroke_color={}\n", state.stroke_color);
         builder.appendff("  paint_color={}\n", state.paint_color);
+        builder.appendff("  color_rendering_intent={}\n", state.color_rendering_intent);
         builder.appendff("  flatness_tolerance={}\n", state.flatness_tolerance);
         builder.appendff("  line_width={}\n", state.line_width);
         builder.appendff("  line_cap_style={}\n", state.line_cap_style);


### PR DESCRIPTION
Implements the `ri` operator, and the `RI` key in a graphics state dictionary.

We don't do anything yet with the color rendering intent except store it.

No behavior change except removing a few "not yet implemented" messages.