### PR TITLE
MacPDF: Make "Open With" and dropping files on dock tile work

### DIFF
--- a/Meta/Lagom/Contrib/MacPDF/AppDelegate.mm
+++ b/Meta/Lagom/Contrib/MacPDF/AppDelegate.mm
@@ -35,4 +35,13 @@
     return YES;
 }
 
+- (BOOL)application:(NSApplication*)sender openFile:(NSString*)filename
+{
+    [[NSDocumentController sharedDocumentController]
+        openDocumentWithContentsOfURL:[NSURL fileURLWithPath:filename]
+                              display:YES
+                    completionHandler:^(NSDocument*, BOOL, NSError*) {}];
+    return YES;
+}
+
 @end


### PR DESCRIPTION
I would've expected that there's some way to have this work automatically in an NSDocument-based application, but I haven't found it yet. So manually implement the delegate for now.