### PR TITLE
LibGUI: Make GUI applications more responsive to file system changes

### DIFF
--- a/Userland/Libraries/LibGUI/FileSystemModel.cpp
+++ b/Userland/Libraries/LibGUI/FileSystemModel.cpp
@@ -400,6 +400,8 @@ void FileSystemModel::invalidate()
         m_root->m_parent_of_root = true;
 
     m_root->reify_if_needed();
+    for (auto const& child : m_root->m_children)
+        child->reify_if_needed();
 
     Model::invalidate();
 }

--- a/Userland/Libraries/LibGUI/FileSystemModel.cpp
+++ b/Userland/Libraries/LibGUI/FileSystemModel.cpp
@@ -437,6 +437,7 @@ void FileSystemModel::handle_file_event(Core::FileWatcherEvent const& event)
             break;
 
         auto child = maybe_child.release_nonnull();
+        child->reify_if_needed();
 
         bool const is_new_child_dir = S_ISDIR(child->mode);
         int insert_index = 0;

--- a/Userland/Libraries/LibGUI/FileSystemModel.cpp
+++ b/Userland/Libraries/LibGUI/FileSystemModel.cpp
@@ -481,9 +481,14 @@ void FileSystemModel::handle_file_event(Core::FileWatcherEvent const& event)
         break;
     }
     case Core::FileWatcherEvent::Type::MetadataModified: {
-        // FIXME: Do we do anything in case the metadata is modified?
-        //        Perhaps re-stat'ing the modified node would make sense
-        //        here, but let's leave that to when we actually need it.
+        auto child = node_for_path(event.event_path);
+        if (!child.has_value()) {
+            dbgln("Got a MetadataModified on '{}' but the child does not exist?!", event.event_path);
+            break;
+        }
+
+        auto& mutable_child = const_cast<Node&>(child.value());
+        mutable_child.fetch_data(mutable_child.full_path(), &mutable_child == m_root);
         break;
     }
     default:

--- a/Userland/Libraries/LibGUI/FileSystemModel.cpp
+++ b/Userland/Libraries/LibGUI/FileSystemModel.cpp
@@ -185,10 +185,9 @@ OwnPtr<FileSystemModel::Node> FileSystemModel::Node::create_child(DeprecatedStri
 
 void FileSystemModel::Node::reify_if_needed()
 {
+    if (mode == 0)
+        fetch_data(full_path(), m_parent == nullptr || m_parent->m_parent_of_root);
     traverse_if_needed();
-    if (mode != 0)
-        return;
-    fetch_data(full_path(), m_parent == nullptr || m_parent->m_parent_of_root);
 }
 
 bool FileSystemModel::Node::is_symlink_to_directory() const


### PR DESCRIPTION
These changes make it possible for GUI applications to react to more changes to the file system, and for their view of the state of the file system to be as accurate as possible.

This includes:
- Preserving correct file order when a new file is created
- Reacting when file metadata changes
- Keeping track of changes to newly created files

This responsiveness can be most clearly seen in FileManager:

https://github.com/SerenityOS/serenity/assets/58829763/d9fce887-7b75-49e8-9671-03c809c7c959

