### PR TITLE
LibWeb: Fix spec implementation mistakes in destroy_the_child_navigable

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/NavigableContainer.cpp
+++ b/Userland/Libraries/LibWeb/HTML/NavigableContainer.cpp
@@ -266,7 +266,7 @@ void NavigableContainer::destroy_the_child_navigable()
     navigable->active_document()->destroy();
 
     // 5. Let parentDocState be container's node navigable's active session history entry's document state.
-    auto parent_doc_state = navigable->active_session_history_entry()->document_state;
+    auto parent_doc_state = this->navigable()->active_session_history_entry()->document_state;
 
     // 6. Remove the nested history from parentDocState's nested histories whose id equals navigable's id.
     parent_doc_state->nested_histories().remove_all_matching([&](auto& nested_history) {
@@ -274,7 +274,7 @@ void NavigableContainer::destroy_the_child_navigable()
     });
 
     // 7. Let traversable be container's node navigable's traversable navigable.
-    auto traversable = navigable->traversable_navigable();
+    auto traversable = this->navigable()->traversable_navigable();
 
     // Not in the spec
     navigable->set_has_been_destroyed();


### PR DESCRIPTION
Fixes two places in child navigable destroy procedure where we used content navigable instead of container's navigable.

With this change, iframe's nested histories are actually destroyed along with the document that created them.