### PR TITLE
Kernel/riscv64: Add RISC-V Processor class

### DIFF
--- a/Kernel/Arch/CPUID.h
+++ b/Kernel/Arch/CPUID.h
@@ -12,6 +12,8 @@
 #    include <Kernel/Arch/x86_64/CPUID.h>
 #elif ARCH(AARCH64)
 #    include <Kernel/Arch/aarch64/CPUID.h>
+#elif ARCH(RISCV64)
+#    include <Kernel/Arch/riscv64/CPUID.h>
 #else
 #    error "Unknown architecture"
 #endif

--- a/Kernel/Arch/FPUState.h
+++ b/Kernel/Arch/FPUState.h
@@ -16,6 +16,8 @@ struct FPUState;
 #    include <Kernel/Arch/x86_64/FPUState.h>
 #elif ARCH(AARCH64)
 #    include <Kernel/Arch/aarch64/FPUState.h>
+#elif ARCH(RISCV64)
+#    include <Kernel/Arch/riscv64/FPUState.h>
 #else
 #    error "Unknown architecture"
 #endif

--- a/Kernel/Arch/Processor.h
+++ b/Kernel/Arch/Processor.h
@@ -210,6 +210,8 @@ template class ProcessorBase<Processor>;
 #    include <Kernel/Arch/x86_64/Processor.h>
 #elif ARCH(AARCH64)
 #    include <Kernel/Arch/aarch64/Processor.h>
+#elif ARCH(RISCV64)
+#    include <Kernel/Arch/riscv64/Processor.h>
 #else
 #    error "Unknown architecture"
 #endif

--- a/Kernel/Arch/RegisterState.h
+++ b/Kernel/Arch/RegisterState.h
@@ -12,6 +12,8 @@
 #    include <Kernel/Arch/x86_64/RegisterState.h>
 #elif ARCH(AARCH64)
 #    include <Kernel/Arch/aarch64/RegisterState.h>
+#elif ARCH(RISCV64)
+#    include <Kernel/Arch/riscv64/RegisterState.h>
 #else
 #    error "Unknown architecture"
 #endif

--- a/Kernel/Arch/ThreadRegisters.h
+++ b/Kernel/Arch/ThreadRegisters.h
@@ -12,6 +12,8 @@
 #    include <Kernel/Arch/x86_64/ThreadRegisters.h>
 #elif ARCH(AARCH64)
 #    include <Kernel/Arch/aarch64/ThreadRegisters.h>
+#elif ARCH(RISCV64)
+#    include <Kernel/Arch/riscv64/ThreadRegisters.h>
 #else
 #    error "Unknown architecture"
 #endif

--- a/Kernel/Arch/TrapFrame.h
+++ b/Kernel/Arch/TrapFrame.h
@@ -19,6 +19,8 @@
 #    include <Kernel/Arch/x86_64/TrapFrame.h>
 #elif ARCH(AARCH64)
 #    include <Kernel/Arch/aarch64/TrapFrame.h>
+#elif ARCH(RISCV64)
+#    include <Kernel/Arch/riscv64/TrapFrame.h>
 #else
 #    error "Unknown architecture"
 #endif

--- a/Kernel/Arch/riscv64/CPUID.h
+++ b/Kernel/Arch/riscv64/CPUID.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2023, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/ArbitrarySizedEnum.h>
+#include <AK/Types.h>
+#include <AK/UFixedBigInt.h>
+
+#include <AK/Platform.h>
+VALIDATE_IS_RISCV64()
+
+AK_MAKE_ARBITRARY_SIZED_ENUM(CPUFeature, u256,
+    __End = CPUFeature(1u) << 255u) // SENTINEL VALUE

--- a/Kernel/Arch/riscv64/CSR.h
+++ b/Kernel/Arch/riscv64/CSR.h
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 2023, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/BitCast.h>
+#include <AK/Types.h>
+
+#include <AK/Platform.h>
+VALIDATE_IS_RISCV64()
+
+// Documentation for the CSRs:
+// RISC-V ISA Manual, Volume II (https://github.com/riscv/riscv-isa-manual/releases/download/Priv-v1.12/riscv-privileged-20211203.pdf)
+
+namespace Kernel::RISCV64::CSR {
+
+// 2.2 CSR Listing
+enum class Address : u16 {
+    // Supervisor Trap Setup
+    SSTATUS = 0x100,
+    SIE = 0x104,
+    STVEC = 0x105,
+
+    // Supervisor Protection and Translation
+    SATP = 0x180,
+
+    // Unprivileged Counters/Timers
+    TIME = 0xc01,
+};
+
+inline FlatPtr read(Address address)
+{
+    FlatPtr ret;
+    asm volatile("csrr %0, %1"
+                 : "=r"(ret)
+                 : "i"(address));
+    return ret;
+}
+
+inline void write(Address address, FlatPtr value)
+{
+    asm volatile("csrw %0, %1" ::"i"(address), "Kr"(value));
+}
+
+inline FlatPtr read_and_set_bits(Address address, FlatPtr bit_mask)
+{
+    FlatPtr ret;
+    asm volatile("csrrs %0, %1, %2"
+                 : "=r"(ret)
+                 : "i"(address), "Kr"(bit_mask));
+    return ret;
+}
+
+inline void set_bits(Address address, FlatPtr bit_mask)
+{
+    asm volatile("csrs %0, %1" ::"i"(address), "Kr"(bit_mask));
+}
+
+inline void clear_bits(Address address, FlatPtr bit_mask)
+{
+    asm volatile("csrc %0, %1" ::"i"(address), "Kr"(bit_mask));
+}
+
+// 4.1.11 Supervisor Address Translation and Protection (satp) Register
+struct [[gnu::packed]] alignas(u64) SATP {
+    enum class Mode : u64 {
+        Bare = 0,
+        Sv39 = 8,
+        Sv48 = 9,
+        Sv67 = 10,
+    };
+
+    // Physical page number of root page table
+    u64 PPN : 44;
+
+    // Address space identifier
+    u64 ASID : 16;
+
+    // Current address-translation scheme
+    Mode MODE : 4;
+
+    static inline void write(SATP satp)
+    {
+        CSR::write(CSR::Address::SATP, bit_cast<FlatPtr>(satp));
+    }
+
+    static inline SATP read()
+    {
+        return bit_cast<SATP>(CSR::read(CSR::Address::SATP));
+    }
+};
+static_assert(AssertSize<SATP, 8>());
+
+// 4.1.1 Supervisor Status Register (sstatus)
+struct [[gnu::packed]] alignas(u64) SSTATUS {
+    // Useful for CSR::{set,clear}_bits
+    enum class Offset {
+        SIE = 1,
+        SPIE = 5,
+        UBE = 6,
+        SPP = 8,
+        VS = 9,
+        FS = 13,
+        XS = 15,
+        SUM = 18,
+        MXR = 19,
+        UXL = 32,
+        SD = 63,
+    };
+
+    enum class PrivilegeMode : u64 {
+        User = 0,
+        Supervisor = 1,
+    };
+
+    enum class FloatingPointStatus : u64 {
+        Off = 0,
+        Initial = 1,
+        Clean = 2,
+        Dirty = 3,
+    };
+
+    enum class VectorStatus : u64 {
+        Off = 0,
+        Initial = 1,
+        Clean = 2,
+        Dirty = 3,
+    };
+
+    enum class UserModeExtensionsStatus : u64 {
+        AllOff = 0,
+        NoneDirtyOrClean_SomeOn = 1,
+        NoneDirty_SomeOn = 2,
+        SomeDirty = 3,
+    };
+
+    enum class XLEN : u64 {
+        Bits32 = 1,
+        Bits64 = 2,
+        Bits128 = 3,
+    };
+
+    u64 _reserved0 : 1;
+
+    // Enables or disables all interrupts in supervisor mode
+    u64 SIE : 1;
+
+    u64 _reserved2 : 3;
+
+    // Indicates whether supervisor interrupts were enabled prior to trapping into supervisor mode
+    // When a trap is taken into supervisor mode, SPIE is set to SIE, and SIE is set to 0. When
+    // an SRET instruction is executed, SIE is set to SPIE, then SPIE is set to 1.
+    u64 SPIE : 1;
+
+    // Controls the endianness of explicit memory accesses made from
+    // U-mode, which may differ from the endianness of memory accesses in S-mode
+    u64 UBE : 1;
+
+    u64 _reserved7 : 1;
+
+    // Indicates the privilege level at which a hart was executing before entering supervisor mode
+    PrivilegeMode SPP : 1;
+
+    // Encodes the status of the vector extension state, including the vector registers v0–v31 and
+    // the CSRs vcsr, vxrm, vxsat, vstart, vl, vtype, and vlenb.
+    VectorStatus VS : 2;
+
+    u64 _reserved11 : 2;
+
+    // Encodes the status of the floating-point unit state,
+    // including the floating-point registers f0–f31 and the CSRs fcsr, frm, and fflags.
+    FloatingPointStatus FS : 2;
+
+    // The XS field encodes the status of additional user-mode extensions and associated state.
+    UserModeExtensionsStatus XS : 2;
+
+    u64 _reserved17 : 1;
+
+    // The SUM (permit Supervisor User Memory access) bit modifies the privilege with which S-mode
+    // loads and stores access virtual memory. When SUM=0, S-mode memory accesses to pages that are
+    // accessible by U-mode (U=1 in Figure 5.18) will fault. When SUM=1, these accesses are permitted.
+    // SUM has no effect when page-based virtual memory is not in effect, nor when executing in U-mode.
+    // Note that S-mode can never execute instructions from user pages, regardless of the state of SUM.
+    u64 SUM : 1;
+
+    // The MXR (Make eXecutable Readable) bit modifies the privilege with which loads access virtual
+    // memory. When MXR=0, only loads from pages marked readable (R=1 in Figure 5.18) will succeed.
+    // When MXR=1, loads from pages marked either readable or executable (R=1 or X=1) will succeed.
+    // MXR has no effect when page-based virtual memory is not in effect.
+    u64 MXR : 1;
+
+    u64 _reserved20 : 12;
+
+    // Controls the value of XLEN for U-mode
+    XLEN UXL : 2;
+
+    u64 _reserved34 : 29;
+
+    // The SD bit is a read-only bit that summarizes whether either the FS, VS, or XS fields signal the
+    // presence of some dirty state that will require saving extended user context to memory.
+    u64 SD : 1;
+
+    static inline void write(SSTATUS sstatus)
+    {
+        CSR::write(CSR::Address::SSTATUS, bit_cast<FlatPtr>(sstatus));
+    }
+
+    static inline SSTATUS read()
+    {
+        return bit_cast<SSTATUS>(CSR::read(CSR::Address::SSTATUS));
+    }
+};
+static_assert(AssertSize<SSTATUS, 8>());
+
+}

--- a/Kernel/Arch/riscv64/FPUState.h
+++ b/Kernel/Arch/riscv64/FPUState.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2023, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Types.h>
+
+#include <AK/Platform.h>
+VALIDATE_IS_RISCV64()
+
+namespace Kernel {
+
+struct FPUState {
+    u64 f[32];
+    u64 fcsr;
+};
+
+}

--- a/Kernel/Arch/riscv64/Processor.cpp
+++ b/Kernel/Arch/riscv64/Processor.cpp
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2023, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/Arch/Interrupts.h>
+#include <Kernel/Arch/Processor.h>
+#include <Kernel/Arch/TrapFrame.h>
+#include <Kernel/Interrupts/InterruptDisabler.h>
+#include <Kernel/Sections.h>
+#include <Kernel/Security/Random.h>
+#include <Kernel/Tasks/Process.h>
+#include <Kernel/Tasks/Scheduler.h>
+
+namespace Kernel {
+
+Processor* g_current_processor;
+
+template<typename T>
+void ProcessorBase<T>::early_initialize(u32 cpu)
+{
+    VERIFY(g_current_processor == nullptr);
+    m_cpu = cpu;
+
+    g_current_processor = static_cast<Processor*>(this);
+}
+
+template<typename T>
+void ProcessorBase<T>::initialize(u32)
+{
+    m_deferred_call_pool.init();
+
+    // Enable the FPU
+    auto sstatus = RISCV64::CSR::SSTATUS::read();
+    sstatus.FS = RISCV64::CSR::SSTATUS::FloatingPointStatus::Initial;
+    RISCV64::CSR::SSTATUS::write(sstatus);
+
+    initialize_interrupts();
+}
+
+template<typename T>
+[[noreturn]] void ProcessorBase<T>::halt()
+{
+    // WFI ignores the value of sstatus.SIE, so we can't use disable_interrupts().
+    // Instead, disable all interrupts sources by setting sie to zero.
+    RISCV64::CSR::write(RISCV64::CSR::Address::SIE, 0);
+    for (;;)
+        asm volatile("wfi");
+}
+
+template<typename T>
+void ProcessorBase<T>::flush_tlb_local(VirtualAddress, size_t)
+{
+    // FIXME: Don't flush all pages
+    flush_entire_tlb_local();
+}
+
+template<typename T>
+void ProcessorBase<T>::flush_entire_tlb_local()
+{
+    asm volatile("sfence.vma");
+}
+
+template<typename T>
+void ProcessorBase<T>::flush_tlb(Memory::PageDirectory const*, VirtualAddress vaddr, size_t page_count)
+{
+    flush_tlb_local(vaddr, page_count);
+}
+
+template<typename T>
+u32 ProcessorBase<T>::clear_critical()
+{
+    InterruptDisabler disabler;
+    auto prev_critical = in_critical();
+    auto& proc = current();
+    proc.m_in_critical = 0;
+    if (proc.m_in_irq == 0)
+        proc.check_invoke_scheduler();
+    return prev_critical;
+}
+
+template<typename T>
+u32 ProcessorBase<T>::smp_wake_n_idle_processors(u32)
+{
+    // FIXME: Actually wake up other cores when SMP is supported for riscv64.
+    return 0;
+}
+
+template<typename T>
+void ProcessorBase<T>::initialize_context_switching(Thread&)
+{
+    TODO_RISCV64();
+}
+
+template<typename T>
+void ProcessorBase<T>::switch_context(Thread*&, Thread*&)
+{
+    TODO_RISCV64();
+}
+
+extern "C" FlatPtr do_init_context(Thread*, u32)
+{
+    TODO_RISCV64();
+}
+
+template<typename T>
+void ProcessorBase<T>::assume_context(Thread&, InterruptsState)
+{
+    TODO_RISCV64();
+}
+
+template<typename T>
+FlatPtr ProcessorBase<T>::init_context(Thread&, bool)
+{
+    TODO_RISCV64();
+}
+
+template<typename T>
+void ProcessorBase<T>::exit_trap(TrapFrame&)
+{
+    TODO_RISCV64();
+}
+
+template<typename T>
+ErrorOr<Vector<FlatPtr, 32>> ProcessorBase<T>::capture_stack_trace(Thread&, size_t)
+{
+    dbgln("FIXME: Implement Processor::capture_stack_trace() for riscv64");
+    return Vector<FlatPtr, 32> {};
+}
+
+NAKED void thread_context_first_enter(void)
+{
+    asm("unimp");
+}
+
+NAKED void do_assume_context(Thread*, u32)
+{
+    asm("unimp");
+}
+
+template<typename T>
+StringView ProcessorBase<T>::platform_string()
+{
+    return "riscv64"sv;
+}
+
+template<typename T>
+void ProcessorBase<T>::set_thread_specific_data(VirtualAddress)
+{
+    TODO_RISCV64();
+}
+
+template<typename T>
+void ProcessorBase<T>::wait_for_interrupt() const
+{
+    asm("wfi");
+}
+
+template<typename T>
+Processor& ProcessorBase<T>::by_id(u32)
+{
+    TODO_RISCV64();
+}
+
+}
+
+#include <Kernel/Arch/ProcessorFunctions.include>

--- a/Kernel/Arch/riscv64/Processor.h
+++ b/Kernel/Arch/riscv64/Processor.h
@@ -1,0 +1,215 @@
+/*
+ * Copyright (c) 2023, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Function.h>
+#include <AK/Types.h>
+#include <AK/Vector.h>
+
+#include <Kernel/API/POSIX/errno.h>
+#include <Kernel/Arch/DeferredCallPool.h>
+#include <Kernel/Arch/ProcessorSpecificDataID.h>
+#include <Kernel/Arch/riscv64/CSR.h>
+#include <Kernel/Memory/VirtualAddress.h>
+
+#include <AK/Platform.h>
+VALIDATE_IS_RISCV64()
+
+namespace Kernel {
+
+namespace Memory {
+class PageDirectory;
+};
+
+class Thread;
+class Processor;
+struct TrapFrame;
+enum class InterruptsState;
+
+template<typename ProcessorT>
+class ProcessorBase;
+
+// FIXME: Remove this once we support SMP in riscv64
+extern Processor* g_current_processor;
+
+constexpr size_t MAX_CPU_COUNT = 1;
+
+class Processor final : public ProcessorBase<Processor> {
+public:
+    template<IteratorFunction<Processor&> Callback>
+    static inline IterationDecision for_each(Callback callback)
+    {
+        // FIXME: Once we support SMP for riscv64, make sure to call the callback for every processor.
+        if (callback(*g_current_processor) == IterationDecision::Break)
+            return IterationDecision::Break;
+        return IterationDecision::Continue;
+    }
+
+    template<VoidFunction<Processor&> Callback>
+    static inline IterationDecision for_each(Callback callback)
+    {
+        // FIXME: Once we support SMP for riscv64, make sure to call the callback for every processor.
+        callback(*g_current_processor);
+        return IterationDecision::Continue;
+    }
+};
+
+template<typename T>
+ALWAYS_INLINE bool ProcessorBase<T>::is_initialized()
+{
+    return g_current_processor != nullptr;
+}
+
+template<typename T>
+ALWAYS_INLINE Thread* ProcessorBase<T>::idle_thread()
+{
+    return current().m_idle_thread;
+}
+
+template<typename T>
+ALWAYS_INLINE void ProcessorBase<T>::set_current_thread(Thread& current_thread)
+{
+    current().m_current_thread = &current_thread;
+}
+
+// FIXME: When riscv64 supports multiple cores, return the correct core id here.
+template<typename T>
+ALWAYS_INLINE u32 ProcessorBase<T>::current_id()
+{
+    return 0;
+}
+
+template<typename T>
+ALWAYS_INLINE u32 ProcessorBase<T>::in_critical()
+{
+    return current().m_in_critical;
+}
+
+template<typename T>
+ALWAYS_INLINE void ProcessorBase<T>::enter_critical()
+{
+    auto& current_processor = current();
+    current_processor.m_in_critical += 1;
+}
+
+template<typename T>
+ALWAYS_INLINE void ProcessorBase<T>::restore_critical(u32 prev_critical)
+{
+    current().m_in_critical = prev_critical;
+}
+
+template<typename T>
+ALWAYS_INLINE T& ProcessorBase<T>::current()
+{
+    return *g_current_processor;
+}
+
+template<typename T>
+void ProcessorBase<T>::idle_begin() const
+{
+    // FIXME: Implement this when SMP for riscv64 is supported.
+}
+
+template<typename T>
+void ProcessorBase<T>::idle_end() const
+{
+    // FIXME: Implement this when SMP for riscv64 is supported.
+}
+
+template<typename T>
+void ProcessorBase<T>::smp_enable()
+{
+    // FIXME: Implement this when SMP for riscv64 is supported.
+}
+
+template<typename T>
+bool ProcessorBase<T>::is_smp_enabled()
+{
+    return false;
+}
+
+template<typename T>
+ALWAYS_INLINE bool ProcessorBase<T>::are_interrupts_enabled()
+{
+    return RISCV64::CSR::SSTATUS::read().SIE == 1;
+}
+
+template<typename T>
+ALWAYS_INLINE void ProcessorBase<T>::enable_interrupts()
+{
+    RISCV64::CSR::set_bits(RISCV64::CSR::Address::SSTATUS, 1 << to_underlying(RISCV64::CSR::SSTATUS::Offset::SIE));
+}
+
+template<typename T>
+ALWAYS_INLINE void ProcessorBase<T>::disable_interrupts()
+{
+    RISCV64::CSR::clear_bits(RISCV64::CSR::Address::SSTATUS, 1 << to_underlying(RISCV64::CSR::SSTATUS::Offset::SIE));
+}
+
+template<typename T>
+ALWAYS_INLINE bool ProcessorBase<T>::is_kernel_mode()
+{
+    // FIXME: Implement this correctly.
+    return true;
+}
+
+template<typename T>
+ALWAYS_INLINE bool ProcessorBase<T>::current_in_scheduler()
+{
+    return current().m_in_scheduler;
+}
+
+template<typename T>
+ALWAYS_INLINE void ProcessorBase<T>::set_current_in_scheduler(bool value)
+{
+    current().m_in_scheduler = value;
+}
+
+template<typename T>
+ALWAYS_INLINE bool ProcessorBase<T>::has_nx() const
+{
+    return true;
+}
+
+template<typename T>
+ALWAYS_INLINE bool ProcessorBase<T>::has_pat() const
+{
+    return false;
+}
+
+template<typename T>
+ALWAYS_INLINE FlatPtr ProcessorBase<T>::current_in_irq()
+{
+    return current().m_in_irq;
+}
+
+template<typename T>
+ALWAYS_INLINE Thread* ProcessorBase<T>::current_thread()
+{
+    return current().m_current_thread;
+}
+
+template<typename T>
+ALWAYS_INLINE void ProcessorBase<T>::pause()
+{
+    TODO_RISCV64();
+}
+
+template<typename T>
+ALWAYS_INLINE void ProcessorBase<T>::wait_check()
+{
+    Processor::pause();
+    // FIXME: Process SMP messages once we support SMP on riscv64; cf. x86_64
+}
+
+template<typename T>
+ALWAYS_INLINE u64 ProcessorBase<T>::read_cpu_counter()
+{
+    TODO_RISCV64();
+}
+
+}

--- a/Kernel/Arch/riscv64/RegisterState.h
+++ b/Kernel/Arch/riscv64/RegisterState.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2023, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <sys/arch/riscv64/regs.h>
+
+#include <Kernel/Arch/riscv64/CSR.h>
+#include <Kernel/Security/ExecutionMode.h>
+
+#include <AK/Platform.h>
+VALIDATE_IS_RISCV64()
+
+namespace Kernel {
+
+struct RegisterState {
+    u64 x[31];
+
+    RISCV64::CSR::SSTATUS sstatus;
+    u64 sepc;
+    u64 scause;
+    u64 stval;
+
+    u64 user_sp;
+
+    FlatPtr userspace_sp() const { return user_sp; }
+    void set_userspace_sp(FlatPtr value) { user_sp = value; }
+
+    FlatPtr ip() const { return sepc; }
+    void set_ip(FlatPtr value) { sepc = value; }
+
+    FlatPtr bp() const { return x[7]; }
+    void set_bp(FlatPtr value) { x[7] = value; }
+
+    ExecutionMode previous_mode() const
+    {
+        switch (sstatus.SPP) {
+        case RISCV64::CSR::SSTATUS::PrivilegeMode::User:
+            return ExecutionMode::User;
+        case RISCV64::CSR::SSTATUS::PrivilegeMode::Supervisor:
+            return ExecutionMode::Kernel;
+        default:
+            VERIFY_NOT_REACHED();
+        }
+    }
+
+    void set_return_reg(FlatPtr value) { x[9] = value; }
+    void capture_syscall_params(FlatPtr& function, FlatPtr& arg1, FlatPtr& arg2, FlatPtr& arg3, FlatPtr& arg4) const
+    {
+        function = x[16];
+        arg1 = x[9];
+        arg2 = x[10];
+        arg3 = x[11];
+        arg4 = x[12];
+    }
+};
+
+#define REGISTER_STATE_SIZE (36 * 8)
+static_assert(AssertSize<RegisterState, REGISTER_STATE_SIZE>());
+
+inline void copy_kernel_registers_into_ptrace_registers(PtraceRegisters& ptrace_regs, RegisterState const& kernel_regs)
+{
+    for (auto i = 0; i < 31; i++)
+        ptrace_regs.x[i] = kernel_regs.x[i];
+
+    ptrace_regs.sp = kernel_regs.userspace_sp();
+    ptrace_regs.pc = kernel_regs.ip();
+}
+
+inline void copy_ptrace_registers_into_kernel_registers(RegisterState& kernel_regs, PtraceRegisters const& ptrace_regs)
+{
+    for (auto i = 0; i < 31; i++)
+        kernel_regs.x[i] = ptrace_regs.x[i];
+
+    kernel_regs.set_userspace_sp(ptrace_regs.sp);
+    kernel_regs.set_ip(ptrace_regs.pc);
+}
+
+struct DebugRegisterState {
+};
+
+}

--- a/Kernel/Arch/riscv64/ThreadRegisters.h
+++ b/Kernel/Arch/riscv64/ThreadRegisters.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2023, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Types.h>
+#include <Kernel/Arch/riscv64/CSR.h>
+#include <Kernel/Library/StdLib.h>
+#include <Kernel/Memory/AddressSpace.h>
+
+#include <AK/Platform.h>
+VALIDATE_IS_RISCV64()
+
+namespace Kernel {
+
+struct ThreadRegisters {
+    u64 x[31];
+    RISCV64::CSR::SSTATUS sstatus;
+    RISCV64::CSR::SATP satp;
+    u64 pc;
+
+    u64 kernel_sp;
+
+    FlatPtr ip() const { return pc; }
+    void set_ip(FlatPtr value) { pc = value; }
+
+    FlatPtr sp() const { return x[1]; }
+    void set_sp(FlatPtr value) { x[1] = value; }
+
+    void set_initial_state(bool is_kernel_process, Memory::AddressSpace& space, FlatPtr kernel_stack_top)
+    {
+        set_sp(kernel_stack_top);
+        satp = space.page_directory().satp();
+        set_sstatus(is_kernel_process);
+    }
+
+    void set_entry_function(FlatPtr entry_ip, FlatPtr entry_data)
+    {
+        set_ip(entry_ip);
+        x[9] = entry_data; // a0
+    }
+
+    void set_exec_state(FlatPtr entry_ip, FlatPtr userspace_sp, Memory::AddressSpace& space)
+    {
+        set_ip(entry_ip);
+        set_sp(userspace_sp);
+        satp = space.page_directory().satp();
+        set_sstatus(false);
+    }
+
+    void set_sstatus(bool is_kernel_process)
+    {
+        // Enable interrupts
+        sstatus.SPIE = 1;
+
+        sstatus.FS = RISCV64::CSR::SSTATUS::FloatingPointStatus::Initial;
+
+        sstatus.SPP = is_kernel_process ? RISCV64::CSR::SSTATUS::PrivilegeMode::Supervisor : RISCV64::CSR::SSTATUS::PrivilegeMode::User;
+        sstatus.UXL = RISCV64::CSR::SSTATUS::XLEN::Bits64;
+    }
+};
+
+}

--- a/Kernel/Arch/riscv64/TrapFrame.h
+++ b/Kernel/Arch/riscv64/TrapFrame.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2023, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <Kernel/Arch/RegisterState.h>
+
+#include <AK/Platform.h>
+VALIDATE_IS_RISCV64()
+
+namespace Kernel {
+
+struct TrapFrame {
+    TrapFrame* next_trap;
+    RegisterState* regs;
+
+    TrapFrame() = delete;
+    TrapFrame(TrapFrame const&) = delete;
+    TrapFrame(TrapFrame&&) = delete;
+    TrapFrame& operator=(TrapFrame const&) = delete;
+    TrapFrame& operator=(TrapFrame&&) = delete;
+};
+
+#define TRAP_FRAME_SIZE (2 * 8)
+static_assert(AssertSize<TrapFrame, TRAP_FRAME_SIZE>());
+
+extern "C" void exit_trap(TrapFrame*) __attribute__((used));
+
+}

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -513,6 +513,7 @@ elseif("${SERENITY_ARCH}" STREQUAL "riscv64")
         kprintf.cpp
 
         Arch/riscv64/boot.S
+        Arch/riscv64/Processor.cpp
         Arch/riscv64/SBI.cpp
     )
 

--- a/Kernel/Library/Assertions.h
+++ b/Kernel/Library/Assertions.h
@@ -27,6 +27,7 @@ extern "C" {
 
 #define TODO() __assertion_failed("TODO", __FILE__, __LINE__, __PRETTY_FUNCTION__)
 #define TODO_AARCH64() __assertion_failed("TODO_AARCH64", __FILE__, __LINE__, __PRETTY_FUNCTION__)
+#define TODO_RISCV64() __assertion_failed("TODO_RISCV64", __FILE__, __LINE__, __PRETTY_FUNCTION__)
 
 #define VERIFY_INTERRUPTS_DISABLED() VERIFY(!(Processor::are_interrupts_enabled()))
 #define VERIFY_INTERRUPTS_ENABLED() VERIFY(Processor::are_interrupts_enabled())

--- a/Userland/Libraries/LibC/sys/arch/regs.h
+++ b/Userland/Libraries/LibC/sys/arch/regs.h
@@ -12,4 +12,6 @@
 #    include "x86_64/regs.h"
 #elif ARCH(AARCH64)
 #    include "aarch64/regs.h"
+#elif ARCH(RISCV64)
+#    include "riscv64/regs.h"
 #endif

--- a/Userland/Libraries/LibC/sys/arch/riscv64/regs.h
+++ b/Userland/Libraries/LibC/sys/arch/riscv64/regs.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2023, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Platform.h>
+
+#if defined(__cplusplus) && defined(__cpp_concepts)
+#    include <AK/Types.h>
+#else
+#    include <sys/types.h>
+#endif
+
+#include <Kernel/Arch/mcontext.h>
+
+#ifdef __cplusplus
+struct [[gnu::packed]] PtraceRegisters : public __mcontext {
+#    if defined(__cplusplus) && defined(__cpp_concepts)
+    FlatPtr ip() const
+    {
+        return pc;
+    }
+
+    void set_ip(FlatPtr ip)
+    {
+        pc = ip;
+    }
+
+    FlatPtr bp() const
+    {
+        return x[7];
+    }
+
+    void set_bp(FlatPtr bp)
+    {
+        x[7] = bp;
+    }
+#    endif
+};
+
+#else
+typedef struct __mcontext PthreadRegisters;
+#endif


### PR DESCRIPTION
This an initial implementation of a RISC-V processor class.
Note that this PR won't yet compile though, as many headers are still missing on riscv64.

I am not completely happy with CSR.h, but this is the best way of implementing that header I could think of.