### PR TITLE
LibJS: Create a static unwind mapping for BasicBlocks and fix some unwinding edge cases

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/BasicBlock.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/BasicBlock.cpp
@@ -33,8 +33,18 @@ BasicBlock::~BasicBlock()
 void BasicBlock::dump(Bytecode::Executable const& executable) const
 {
     Bytecode::InstructionStreamIterator it(instruction_stream());
+
     if (!m_name.is_empty())
-        warnln("{}:", m_name);
+        warn("{}", m_name);
+    if (m_handler || m_finalizer) {
+        warn(" [");
+        if (m_handler)
+            warn(" Handler: {}", Label { *m_handler });
+        if (m_finalizer)
+            warn(" Finalizer: {}", Label { *m_finalizer });
+        warn(" ]");
+    }
+    warnln(":");
     while (!it.at_end()) {
         warnln("[{:4x}] {}", it.offset(), (*it).to_deprecated_string(executable));
         ++it;

--- a/Userland/Libraries/LibJS/Bytecode/BasicBlock.h
+++ b/Userland/Libraries/LibJS/Bytecode/BasicBlock.h
@@ -15,8 +15,6 @@ namespace JS::Bytecode {
 
 struct UnwindInfo {
     Executable const* executable;
-    BasicBlock const* handler;
-    BasicBlock const* finalizer;
 
     JS::GCPtr<Environment> lexical_environment;
 

--- a/Userland/Libraries/LibJS/Bytecode/BasicBlock.h
+++ b/Userland/Libraries/LibJS/Bytecode/BasicBlock.h
@@ -43,10 +43,18 @@ public:
 
     DeprecatedString const& name() const { return m_name; }
 
+    void set_handler(BasicBlock const& handler) { m_handler = &handler; }
+    void set_finalizer(BasicBlock const& finalizer) { m_finalizer = &finalizer; }
+
+    BasicBlock const* handler() const { return m_handler; }
+    BasicBlock const* finalizer() const { return m_finalizer; }
+
 private:
     explicit BasicBlock(DeprecatedString name);
 
     Vector<u8> m_buffer;
+    BasicBlock const* m_handler { nullptr };
+    BasicBlock const* m_finalizer { nullptr };
     DeprecatedString m_name;
     bool m_terminated { false };
 };

--- a/Userland/Libraries/LibJS/Bytecode/BasicBlock.h
+++ b/Userland/Libraries/LibJS/Bytecode/BasicBlock.h
@@ -15,7 +15,6 @@ namespace JS::Bytecode {
 
 struct UnwindInfo {
     Executable const* executable;
-
     JS::GCPtr<Environment> lexical_environment;
 
     bool handler_called { false };

--- a/Userland/Libraries/LibJS/Bytecode/Executable.h
+++ b/Userland/Libraries/LibJS/Bytecode/Executable.h
@@ -7,9 +7,11 @@
 #pragma once
 
 #include <AK/DeprecatedFlyString.h>
+#include <AK/HashMap.h>
 #include <AK/NonnullOwnPtr.h>
 #include <AK/WeakPtr.h>
 #include <LibJS/Bytecode/IdentifierTable.h>
+#include <LibJS/Bytecode/Label.h>
 #include <LibJS/Bytecode/StringTable.h>
 #include <LibJS/Forward.h>
 
@@ -52,6 +54,7 @@ public:
     NonnullOwnPtr<StringTable> string_table;
     NonnullOwnPtr<IdentifierTable> identifier_table;
     NonnullOwnPtr<RegexTable> regex_table;
+
     NonnullRefPtr<SourceCode const> source_code;
     size_t number_of_registers { 0 };
     bool is_strict_mode { false };

--- a/Userland/Libraries/LibJS/Bytecode/Generator.h
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.h
@@ -44,6 +44,24 @@ public:
         ASTNode const* m_previous_node { nullptr };
     };
 
+    class UnwindContext {
+    public:
+        UnwindContext(Generator&, Optional<Label> finalizer);
+
+        UnwindContext const* previous() const { return m_previous_context; }
+        void set_handler(Label handler) { m_handler = handler; }
+        Optional<Label> handler() const { return m_handler; }
+        Optional<Label> finalizer() const { return m_finalizer; }
+
+        ~UnwindContext();
+
+    private:
+        Generator& m_generator;
+        Optional<Label> m_finalizer;
+        Optional<Label> m_handler {};
+        UnwindContext const* m_previous_context { nullptr };
+    };
+
     template<typename OpType, typename... Args>
     void emit(Args&&... args)
     {
@@ -114,7 +132,14 @@ public:
     {
         if (name.is_empty())
             name = DeprecatedString::number(m_next_block++);
-        m_root_basic_blocks.append(BasicBlock::create(name));
+        auto block = BasicBlock::create(name);
+        if (auto const* context = m_current_unwind_context) {
+            if (context->handler().has_value())
+                block->set_handler(context->handler().value().block());
+            if (m_current_unwind_context->finalizer().has_value())
+                block->set_finalizer(context->finalizer().value().block());
+        }
+        m_root_basic_blocks.append(move(block));
         return *m_root_basic_blocks.last();
     }
 
@@ -227,6 +252,8 @@ private:
 
     BasicBlock* m_current_basic_block { nullptr };
     ASTNode const* m_current_ast_node { nullptr };
+    UnwindContext const* m_current_unwind_context { nullptr };
+
     Vector<NonnullOwnPtr<BasicBlock>> m_root_basic_blocks;
     NonnullOwnPtr<StringTable> m_string_table;
     NonnullOwnPtr<IdentifierTable> m_identifier_table;

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -244,7 +244,7 @@ void Interpreter::run_bytecode()
                 enter_unwind_context();
                 m_current_block = &static_cast<Op::EnterUnwindContext const&>(instruction).entry_point().block();
                 goto start;
-            case Instruction::Type::ContinuePendingUnwind:
+            case Instruction::Type::ContinuePendingUnwind: {
                 if (auto exception = reg(Register::exception()); !exception.is_empty()) {
                     result = throw_completion(exception);
                     break;
@@ -253,14 +253,20 @@ void Interpreter::run_bytecode()
                     do_return(saved_return_value());
                     break;
                 }
+                auto const* old_scheduled_jump = call_frame().previously_scheduled_jumps.take_last();
                 if (m_scheduled_jump) {
                     // FIXME: If we `break` or `continue` in the finally, we need to clear
                     //        this field
+                    //        Same goes for popping an old_scheduled_jump form the stack
                     m_current_block = exchange(m_scheduled_jump, nullptr);
                 } else {
                     m_current_block = &static_cast<Op::ContinuePendingUnwind const&>(instruction).resume_target().block();
+                    // set the scheduled jump to the old value if we continue
+                    // where we left it
+                    m_scheduled_jump = old_scheduled_jump;
                 }
                 goto start;
+            }
             case Instruction::Type::ScheduleJump: {
                 m_scheduled_jump = &static_cast<Op::ScheduleJump const&>(instruction).target().block();
                 auto const* finalizer = m_current_block->finalizer();
@@ -405,6 +411,8 @@ void Interpreter::enter_unwind_context()
     unwind_contexts().empend(
         m_current_executable,
         vm().running_execution_context().lexical_environment);
+    call_frame().previously_scheduled_jumps.append(m_scheduled_jump);
+    m_scheduled_jump = nullptr;
 }
 
 void Interpreter::leave_unwind_context()

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -275,6 +275,7 @@ void Interpreter::run_bytecode()
 
             if (result.is_error()) [[unlikely]] {
                 reg(Register::exception()) = *result.throw_completion().value();
+                m_scheduled_jump = {};
                 auto const* handler = m_current_block->handler();
                 auto const* finalizer = m_current_block->finalizer();
                 if (!handler && !finalizer)

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -12,6 +12,7 @@
 #include <LibJS/Bytecode/Generator.h>
 #include <LibJS/Bytecode/Instruction.h>
 #include <LibJS/Bytecode/Interpreter.h>
+#include <LibJS/Bytecode/Label.h>
 #include <LibJS/Bytecode/Op.h>
 #include <LibJS/Runtime/AbstractOperations.h>
 #include <LibJS/Runtime/Array.h>
@@ -240,9 +241,7 @@ void Interpreter::run_bytecode()
                     m_current_block = &static_cast<Op::Jump const&>(instruction).false_target()->block();
                 goto start;
             case Instruction::Type::EnterUnwindContext:
-                enter_unwind_context(
-                    static_cast<Op::EnterUnwindContext const&>(instruction).handler_target(),
-                    static_cast<Op::EnterUnwindContext const&>(instruction).finalizer_target());
+                enter_unwind_context();
                 m_current_block = &static_cast<Op::EnterUnwindContext const&>(instruction).entry_point().block();
                 goto start;
             case Instruction::Type::ContinuePendingUnwind:
@@ -262,10 +261,13 @@ void Interpreter::run_bytecode()
                     m_current_block = &static_cast<Op::ContinuePendingUnwind const&>(instruction).resume_target().block();
                 }
                 goto start;
-            case Instruction::Type::ScheduleJump:
+            case Instruction::Type::ScheduleJump: {
                 m_scheduled_jump = &static_cast<Op::ScheduleJump const&>(instruction).target().block();
-                m_current_block = unwind_contexts().last().finalizer;
+                auto const* finalizer = m_current_block->finalizer();
+                VERIFY(finalizer);
+                m_current_block = finalizer;
                 goto start;
+            }
             default:
                 result = instruction.execute(*this);
                 break;
@@ -273,22 +275,26 @@ void Interpreter::run_bytecode()
 
             if (result.is_error()) [[unlikely]] {
                 reg(Register::exception()) = *result.throw_completion().value();
-                if (unwind_contexts().is_empty())
+                auto const* handler = m_current_block->handler();
+                auto const* finalizer = m_current_block->finalizer();
+                if (!handler && !finalizer)
                     return;
+
                 auto& unwind_context = unwind_contexts().last();
-                if (unwind_context.executable != m_current_executable)
-                    return;
-                if (unwind_context.handler && !unwind_context.handler_called) {
+                VERIFY(unwind_context.executable == m_current_executable);
+
+                if (handler) {
+                    VERIFY(!unwind_context.handler_called);
                     vm().running_execution_context().lexical_environment = unwind_context.lexical_environment;
-                    m_current_block = unwind_context.handler;
+                    m_current_block = handler;
                     unwind_context.handler_called = true;
 
                     accumulator = reg(Register::exception());
                     reg(Register::exception()) = {};
                     goto start;
                 }
-                if (unwind_context.finalizer) {
-                    m_current_block = unwind_context.finalizer;
+                if (finalizer) {
+                    m_current_block = finalizer;
                     // If an exception was thrown inside the corresponding `catch` block, we need to rethrow it
                     // from the `finally` block. But if the exception is from the `try` block, and has already been
                     // handled by `catch`, we swallow it.
@@ -314,15 +320,14 @@ void Interpreter::run_bytecode()
             ++pc;
         }
 
-        if (!unwind_contexts().is_empty() && !will_yield) {
+        if (auto const* finalizer = m_current_block->finalizer(); finalizer && !will_yield) {
             auto& unwind_context = unwind_contexts().last();
-            if (unwind_context.executable == m_current_executable && unwind_context.finalizer) {
-                reg(Register::saved_return_value()) = reg(Register::return_value());
-                reg(Register::return_value()) = {};
-                m_current_block = unwind_context.finalizer;
-                // the unwind_context will be pop'ed when entering the finally block
-                continue;
-            }
+            VERIFY(unwind_context.executable == m_current_executable);
+            reg(Register::saved_return_value()) = reg(Register::return_value());
+            reg(Register::return_value()) = {};
+            m_current_block = finalizer;
+            // the unwind_context will be pop'ed when entering the finally block
+            continue;
         }
 
         if (pc.at_end())
@@ -394,12 +399,10 @@ Interpreter::ValueAndFrame Interpreter::run_and_return_frame(Executable& executa
     return { return_value, nullptr };
 }
 
-void Interpreter::enter_unwind_context(Optional<Label> handler_target, Optional<Label> finalizer_target)
+void Interpreter::enter_unwind_context()
 {
     unwind_contexts().empend(
         m_current_executable,
-        handler_target.has_value() ? &handler_target->block() : nullptr,
-        finalizer_target.has_value() ? &finalizer_target->block() : nullptr,
         vm().running_execution_context().lexical_environment);
 }
 

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.h
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.h
@@ -32,6 +32,7 @@ struct CallFrame {
     Vector<Value> registers;
     Vector<GCPtr<Environment>> saved_lexical_environments;
     Vector<UnwindInfo> unwind_contexts;
+    Vector<BasicBlock const*> previously_scheduled_jumps;
 };
 
 class Interpreter {

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.h
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.h
@@ -70,7 +70,7 @@ public:
         reg(Register::exception()) = {};
     }
 
-    void enter_unwind_context(Optional<Label> handler_target, Optional<Label> finalizer_target);
+    void enter_unwind_context();
     void leave_unwind_context();
 
     Executable& current_executable() { return *m_current_executable; }

--- a/Userland/Libraries/LibJS/Tests/try-finally-break.js
+++ b/Userland/Libraries/LibJS/Tests/try-finally-break.js
@@ -339,3 +339,25 @@ test("labelled break in finally overrides labelled break in try", () => {
 
     expect(executionOrder).toEqual([1, 2]);
 });
+
+test("Throw while breaking", () => {
+    const executionOrder = [];
+    try {
+        for (const i = 1337; ; expect().fail("Jumped to for loop update block")) {
+            try {
+                executionOrder.push(1);
+                break;
+            } finally {
+                executionOrder.push(2);
+                throw 1;
+            }
+        }
+    } finally {
+        executionOrder.push(3);
+    }
+    expect(() => {
+        i;
+    }).toThrowWithMessage(ReferenceError, "'i' is not defined");
+
+    expect(executionOrder).toEqual([1, 2, 3]);
+});

--- a/Userland/Libraries/LibJS/Tests/try-finally-break.js
+++ b/Userland/Libraries/LibJS/Tests/try-finally-break.js
@@ -361,3 +361,88 @@ test("Throw while breaking", () => {
 
     expect(executionOrder).toEqual([1, 2, 3]);
 });
+
+test("Throw while breaking with nested try-catch in finalizer", () => {
+    const executionOrder = [];
+    try {
+        for (const i = 1337; ; expect().fail("Jumped to for loop update block")) {
+            try {
+                executionOrder.push(1);
+                break;
+            } finally {
+                try {
+                    throw 1;
+                } catch {
+                    executionOrder.push(2);
+                }
+                executionOrder.push(3);
+            }
+            expect().fail("Jumped out of inner finally statement");
+        }
+    } finally {
+        executionOrder.push(4);
+    }
+    expect(() => {
+        i;
+    }).toThrowWithMessage(ReferenceError, "'i' is not defined");
+
+    expect(executionOrder).toEqual([1, 2, 3, 4]);
+});
+
+test("Throw while breaking with nested try-catch-finally in finalizer", () => {
+    const executionOrder = [];
+    try {
+        for (const i = 1337; ; expect().fail("Jumped to for loop update block")) {
+            try {
+                executionOrder.push(1);
+                break;
+            } finally {
+                try {
+                    executionOrder.push(2);
+                } catch {
+                    expect.fail("Entered catch");
+                } finally {
+                    executionOrder.push(3);
+                }
+                executionOrder.push(4);
+            }
+            expect().fail("Jumped out of inner finally statement");
+        }
+    } finally {
+        executionOrder.push(5);
+    }
+    expect(() => {
+        i;
+    }).toThrowWithMessage(ReferenceError, "'i' is not defined");
+
+    expect(executionOrder).toEqual([1, 2, 3, 4, 5]);
+});
+
+test("Throw while breaking with nested try-catch-finally with throw in finalizer", () => {
+    const executionOrder = [];
+    try {
+        for (const i = 1337; ; expect().fail("Jumped to for loop update block")) {
+            try {
+                executionOrder.push(1);
+                break;
+            } finally {
+                try {
+                    throw 1;
+                } catch {
+                    executionOrder.push(2);
+                } finally {
+                    executionOrder.push(3);
+                }
+                executionOrder.push(4);
+            }
+            expect().fail("Jumped out of inner finally statement");
+        }
+    } finally {
+        executionOrder.push(5);
+    }
+    expect(() => {
+        i;
+    }).toThrowWithMessage(ReferenceError, "'i' is not defined");
+
+    expect(executionOrder).toEqual([1, 2, 3, 4, 5]);
+});


### PR DESCRIPTION
### LibJS: Create static unwind mappings for `BasicBlock`s

This is currently only used in the bytecode dump to annotate to where
unwinds lead per block, but will be hooked up to the virtual machine in
the next commit.

### LibJS: Use static unwind mappings for unwind related functions


### LibJS: Reset scheduled-jump flag when throwing an exception

Otherwise we might attempt to follow the scheduled jump later

### LibJS: Save scheduled jumps when entering unwind contexts

These are then restored upon `ContinuePendingUnwind`.
This stops us from forgetting where we needed to jump when we do extra
try-catches in finally blocks.

---

@awesomekling wasn't something like this what you wanted for your jit?
Note that the Unwind context still needs to hold onto info, like a lexical environment to enter for the handler, and if we entered the handler was called to check if the exception register needs clearing (Something feels dubious about this, maybe codegen can help)