### PR TITLE
LibPDF: Implement ICCBasedColorSpace::number_of_components(), and other minor image tweaks

### DIFF
--- a/Userland/Libraries/LibPDF/ColorSpace.cpp
+++ b/Userland/Libraries/LibPDF/ColorSpace.cpp
@@ -354,6 +354,11 @@ PDFErrorOr<Color> ICCBasedColorSpace::color(Vector<Value> const& arguments) cons
     return Color(output[0], output[1], output[2]);
 }
 
+int ICCBasedColorSpace::number_of_components() const
+{
+    return Gfx::ICC::number_of_components_in_color_space(m_profile->data_color_space());
+}
+
 Vector<float> ICCBasedColorSpace::default_decode() const
 {
     auto color_space = m_profile->data_color_space();

--- a/Userland/Libraries/LibPDF/ColorSpace.h
+++ b/Userland/Libraries/LibPDF/ColorSpace.h
@@ -133,7 +133,7 @@ public:
     ~ICCBasedColorSpace() override = default;
 
     PDFErrorOr<Color> color(Vector<Value> const& arguments) const override;
-    int number_of_components() const override { VERIFY_NOT_REACHED(); }
+    int number_of_components() const override;
     Vector<float> default_decode() const override;
     ColorSpaceFamily const& family() const override { return ColorSpaceFamily::ICCBased; }
 

--- a/Userland/Libraries/LibPDF/CommonNames.h
+++ b/Userland/Libraries/LibPDF/CommonNames.h
@@ -89,6 +89,7 @@
     X(Index)                      \
     X(Indexed)                    \
     X(Info)                       \
+    X(Intent)                     \
     X(JBIG2Decode)                \
     X(JPXDecode)                  \
     X(Keywords)                   \

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -862,7 +862,7 @@ PDFErrorOr<NonnullRefPtr<Gfx::Bitmap>> Renderer::load_image(NonnullRefPtr<Stream
     }
 
     if (TRY(is_filter(CommonNames::DCTDecode))) {
-        // TODO: stream objects could store Variant<bytes/Bitmap> to avoid seialisation/deserialisation here
+        // TODO: stream objects could store Variant<bytes/Bitmap> to avoid serialisation/deserialisation here
         return TRY(Gfx::Bitmap::create_from_serialized_bytes(image->bytes()));
     }
 

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -842,6 +842,7 @@ PDFErrorOr<NonnullRefPtr<Gfx::Bitmap>> Renderer::load_image(NonnullRefPtr<Stream
         color_rendering_intent = TRY(image_dict->get_name(m_document, CommonNames::Intent))->name();
     // FIXME: Do something with color_rendering_intent.
 
+    // "Valid values are 1, 2, 4, 8, and (in PDF 1.5) 16."
     auto bits_per_component = image_dict->get_value(CommonNames::BitsPerComponent).get<int>();
     if (bits_per_component != 8) {
         return Error(Error::Type::RenderingUnsupported, "Image's bit per component != 8");

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -836,6 +836,12 @@ PDFErrorOr<NonnullRefPtr<Gfx::Bitmap>> Renderer::load_image(NonnullRefPtr<Stream
 
     auto color_space_object = MUST(image_dict->get_object(m_document, CommonNames::ColorSpace));
     auto color_space = TRY(get_color_space_from_document(color_space_object));
+
+    auto color_rendering_intent = state().color_rendering_intent;
+    if (image_dict->contains(CommonNames::Intent))
+        color_rendering_intent = TRY(image_dict->get_name(m_document, CommonNames::Intent))->name();
+    // FIXME: Do something with color_rendering_intent.
+
     auto bits_per_component = image_dict->get_value(CommonNames::BitsPerComponent).get<int>();
     if (bits_per_component != 8) {
         return Error(Error::Type::RenderingUnsupported, "Image's bit per component != 8");

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -834,6 +834,8 @@ PDFErrorOr<NonnullRefPtr<Gfx::Bitmap>> Renderer::load_image(NonnullRefPtr<Stream
         }
     }
 
+    // "(Required for images, except those that use the JPXDecode filter; not allowed for image masks) [...]
+    //  it can be any type of color space except Pattern."
     auto color_space_object = MUST(image_dict->get_object(m_document, CommonNames::ColorSpace));
     auto color_space = TRY(get_color_space_from_document(color_space_object));
 


### PR DESCRIPTION
We now no longer crash on images that use an ICC-based color space.
Reduces number of crashes on 300 random PDFs from the web (the first 300
from 0000.zip from
https://pdfa.org/new-large-scale-pdf-corpus-now-publicly-available/)
from 81 (27%) to 64 (21%).

Also fixes all remaining crashes in
411_getting_started_with_instruments.pdf and
513_high_efficiency_image_file_format.pdf.

---

Note that `DCTDecode` (ie jpegs) early-exit before this code runs, so jpegs in PDFs currently aren't color-managed.