### PR TITLE
LibGfx/ICC: Implement conversion to PCS for AToB*Tags using mAB 

### DIFF
--- a/Userland/Libraries/LibGfx/ICC/TagTypes.h
+++ b/Userland/Libraries/LibGfx/ICC/TagTypes.h
@@ -13,6 +13,7 @@
 #include <AK/String.h>
 #include <AK/Vector.h>
 #include <LibGfx/ICC/DistinctFourCC.h>
+#include <LibGfx/Vector3.h>
 #include <math.h>
 
 namespace Gfx::ICC {
@@ -410,6 +411,9 @@ public:
     Optional<Vector<LutCurveType>> const& m_curves() const { return m_m_curves; }
     Optional<EMatrix3x4> const& e_matrix() const { return m_e; }
     Vector<LutCurveType> const& b_curves() const { return m_b_curves; }
+
+    // Returns the result of the LUT pipeline for u8 inputs.
+    ErrorOr<FloatVector3> evaluate(ReadonlyBytes) const;
 
 private:
     u8 m_number_of_input_channels;
@@ -983,6 +987,70 @@ public:
 private:
     Vector<XYZ, 1> m_xyzs;
 };
+
+inline ErrorOr<FloatVector3> LutAToBTagData::evaluate(ReadonlyBytes color_u8) const
+{
+    VERIFY(number_of_input_channels() == color_u8.size());
+    VERIFY(number_of_output_channels() == 3);
+
+    // ICC v4, 10.12 lutAToBType
+    // "Data are processed using these elements via the following sequence:
+    //  (“A” curves) ⇨ (multi-dimensional lookup table, CLUT) ⇨ (“M” curves) ⇨ (matrix) ⇨ (“B” curves).
+
+    auto evaluate_curve = [](LutCurveType const& curve, float f) {
+        VERIFY(curve->type() == CurveTagData::Type || curve->type() == ParametricCurveTagData::Type);
+        if (curve->type() == CurveTagData::Type)
+            return static_cast<CurveTagData const&>(*curve).evaluate(f);
+        return static_cast<ParametricCurveTagData const&>(*curve).evaluate(f);
+    };
+
+    VERIFY(m_a_curves.has_value() == m_clut.has_value());
+    if (m_a_curves.has_value()) {
+        // FIXME
+        return Error::from_string_literal("mAB evaluation not yet implemented for A curve and CLUT");
+    }
+
+    FloatVector3 color { color_u8[0] / 255.f, color_u8[1] / 255.f, color_u8[2] / 255.f };
+
+    VERIFY(m_m_curves.has_value() == m_e.has_value());
+    if (m_m_curves.has_value()) {
+        auto const& m_curves = m_m_curves.value();
+        color = FloatVector3 {
+            evaluate_curve(m_curves[0], color[0]),
+            evaluate_curve(m_curves[1], color[1]),
+            evaluate_curve(m_curves[2], color[2])
+        };
+
+        // ICC v4, 10.12.5 Matrix
+        // "The resultant values Y1, Y2 and Y3 shall be clipped to the range 0,0 to 1,0 and used as inputs to the “B” curves."
+        EMatrix3x4 const& e = m_e.value();
+        FloatVector3 new_color = {
+            (float)e[0] * color[0] + (float)e[1] * color[1] + (float)e[2] * color[2] + (float)e[9],
+            (float)e[3] * color[0] + (float)e[4] * color[1] + (float)e[5] * color[2] + (float)e[10],
+            (float)e[6] * color[0] + (float)e[7] * color[1] + (float)e[8] * color[2] + (float)e[11]
+        };
+
+        // Mystery conversion factor!
+        // skcms, littlecms, and argyll all do this somewhere, but I don't understand why!
+        // skcms has a "TODO: understand" comment as well.
+        // littlecms and argyll have both comments which don't make sense to me.
+        // littlecms does this to the matrix profile matrices (i.e. it considers the lut pcs scale canonical).
+        // skcms does it to the mAB matrix (...which means it'll do something different if the matrix is missing,
+        //     and it'll also do something different if the b curve isn't the identity).
+        // argyll does it in Lut_Lut2XYZ(), but I'm not clear on when that's called.
+        // SampleICC does it in IccCmm.cpp, XYZScale() and in IccUtil.cpp, icXyzFromPcs().
+        // Without this, colors are too bright. So let's do it too, and maybe I'll understand it one day.
+        new_color *= 65535 / 32768.f; // ???
+
+        color = new_color.clamped(0.f, 1.f);
+    }
+
+    return FloatVector3 {
+        evaluate_curve(m_b_curves[0], color[0]),
+        evaluate_curve(m_b_curves[1], color[1]),
+        evaluate_curve(m_b_curves[2], color[2])
+    };
+}
 
 }
 

--- a/Userland/Libraries/LibGfx/ICC/TagTypes.h
+++ b/Userland/Libraries/LibGfx/ICC/TagTypes.h
@@ -171,12 +171,12 @@ public:
         if (values().size() == 1)
             return powf(x, values()[0] / (float)0x100);
 
-        size_t i = static_cast<size_t>(x * (values().size() - 1));
+        size_t n = values().size() - 1;
+        size_t i = static_cast<size_t>(x * n);
         if (i == values().size() - 1)
             --i;
 
-        float f = x * (values().size() - 1) - i;
-        return mix(values()[i] / 65535.f, values()[i + 1] / 65535.f, f);
+        return mix(values()[i] / 65535.f, values()[i + 1] / 65535.f, x * n - i);
     }
 
     // y must be in [0..1].


### PR DESCRIPTION
...as long as the mAB tag doesn't have A curves and a CLUT.

With this, we can convert images that use AToB* tags to the profile
connection space (and then from there to, say, sRGB), if the AToB* tag
uses the mAB format.

We can't yet do this if the mAB tag has A curves or a CLUT.

We can't convert back from PCS to this space yet.

We don't yet handle AToB* tags that use mft1 or mft2 instead of mAB.

-----

I've had this sitting in a local branch for months now, in part because it's missing the A curve / CLUT, in part of the "mystery conversion factor" bit.

But it does the right thing for profiles without A curve / CLUT, so it's probably better to check it in that not.

https://www.color.org/version4pdf.pdf at HEAD:

<img width="722" alt="version4pdf.pdf_p1_before" src="https://github.com/SerenityOS/serenity/assets/3487/d46f04c8-cb5d-4ed5-a0df-09e7861e98ea">

With a local branch that makes LibPDF apply color profiles:

<img width="722" alt="version4pdf.pdf_p1_step1" src="https://github.com/SerenityOS/serenity/assets/3487/4355e88b-86e9-4861-85cd-6f2f56627de3">

With that and this PR (the missing top right image needs A curves / CLUT support):

<img width="722" alt="version4pdf.pdf_p1_after" src="https://github.com/SerenityOS/serenity/assets/3487/4e196cce-2c85-4948-a96b-da8086763df7">

(All three are missing the text, too.)