### PR TITLE
LibPDF: Replace TODO()s in Type0Font code with Errors

### DIFF
--- a/Userland/Libraries/LibPDF/Fonts/Type0Font.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/Type0Font.cpp
@@ -49,9 +49,9 @@ PDFErrorOr<NonnullOwnPtr<CIDFontType2>> CIDFontType2::create(Document* document,
     if (descendant->contains(CommonNames::CIDToGIDMap)) {
         auto value = TRY(descendant->get_object(document, CommonNames::CIDToGIDMap));
         if (value->is<StreamObject>()) {
-            TODO();
+            return Error::rendering_unsupported_error("Type0 font subtype 2: support for stream cid maps not yet implemented");
         } else if (value->cast<NameObject>()->name() != "Identity") {
-            TODO();
+            return Error::rendering_unsupported_error("Type0 font: support for non-Identity named cid maps not yet implemented");
         }
     }
 
@@ -98,7 +98,7 @@ PDFErrorOr<void> Type0Font::initialize(Document* document, NonnullRefPtr<DictObj
     // FIXME: Support arbitrary CMaps
     auto cmap_value = TRY(dict->get_object(document, CommonNames::Encoding));
     if (!cmap_value->is<NameObject>() || cmap_value->cast<NameObject>()->name() != CommonNames::IdentityH)
-        TODO();
+        return Error::rendering_unsupported_error("Type0 font: support for general Encodings not yet implemented");
 
     auto descendant_font_value = TRY(dict->get_array(document, CommonNames::DescendantFonts));
     auto descendant_font = TRY(descendant_font_value->get_dict_at(document, 0));


### PR DESCRIPTION
...which causes us to not render these fonts instead of crashing.

Reduces number of crashes on 300 random PDFs from the web (the first 300 from 0000.zip from
https://pdfa.org/new-large-scale-pdf-corpus-now-publicly-available/) from 64 (21%) to 42 (14%).