### PR TITLE
LibPDF: Allow /Pattern to be used directly as a color space name

### DIFF
--- a/Userland/Libraries/LibPDF/ColorSpace.cpp
+++ b/Userland/Libraries/LibPDF/ColorSpace.cpp
@@ -14,16 +14,16 @@ namespace PDF {
 
 RefPtr<Gfx::ICC::Profile> ICCBasedColorSpace::s_srgb_profile;
 
-#define ENUMERATE(name, ever_needs_parameters) \
-    ColorSpaceFamily ColorSpaceFamily::name { #name, ever_needs_parameters };
+#define ENUMERATE(name, may_be_specified_directly) \
+    ColorSpaceFamily ColorSpaceFamily::name { #name, may_be_specified_directly };
 ENUMERATE_COLOR_SPACE_FAMILIES(ENUMERATE);
 #undef ENUMERATE
 
 PDFErrorOr<ColorSpaceFamily> ColorSpaceFamily::get(DeprecatedFlyString const& family_name)
 {
-#define ENUMERATE(f_name, ever_needs_parameters) \
-    if (family_name == f_name.name()) {          \
-        return ColorSpaceFamily::f_name;         \
+#define ENUMERATE(f_name, may_be_specified_directly) \
+    if (family_name == f_name.name()) {              \
+        return ColorSpaceFamily::f_name;             \
     }
     ENUMERATE_COLOR_SPACE_FAMILIES(ENUMERATE)
 #undef ENUMERATE

--- a/Userland/Libraries/LibPDF/ColorSpace.cpp
+++ b/Userland/Libraries/LibPDF/ColorSpace.cpp
@@ -39,6 +39,8 @@ PDFErrorOr<NonnullRefPtr<ColorSpace>> ColorSpace::create(DeprecatedFlyString con
         return DeviceRGBColorSpace::the();
     if (name == CommonNames::DeviceCMYK)
         return DeviceCMYKColorSpace::the();
+    if (name == CommonNames::Pattern)
+        return Error::rendering_unsupported_error("Pattern color spaces not yet implemented");
     VERIFY_NOT_REACHED();
 }
 

--- a/Userland/Libraries/LibPDF/ColorSpace.h
+++ b/Userland/Libraries/LibPDF/ColorSpace.h
@@ -29,23 +29,23 @@ namespace PDF {
 
 class ColorSpaceFamily {
 public:
-    ColorSpaceFamily(DeprecatedFlyString name, bool never_needs_paramaters_p)
+    ColorSpaceFamily(DeprecatedFlyString name, bool may_be_specified_directly)
         : m_name(move(name))
-        , m_never_needs_parameters(never_needs_paramaters_p)
+        , m_may_be_specified_directly(may_be_specified_directly)
     {
     }
 
     DeprecatedFlyString name() const { return m_name; }
-    bool never_needs_parameters() const { return m_never_needs_parameters; }
+    bool may_be_specified_directly() const { return m_may_be_specified_directly; }
     static PDFErrorOr<ColorSpaceFamily> get(DeprecatedFlyString const&);
 
-#define ENUMERATE(name, ever_needs_parameters) static ColorSpaceFamily name;
+#define ENUMERATE(name, may_be_specified_directly) static ColorSpaceFamily name;
     ENUMERATE_COLOR_SPACE_FAMILIES(ENUMERATE)
 #undef ENUMERATE
 
 private:
     DeprecatedFlyString m_name;
-    bool m_never_needs_parameters;
+    bool m_may_be_specified_directly;
 };
 
 class ColorSpace : public RefCounted<ColorSpace> {

--- a/Userland/Libraries/LibPDF/ColorSpace.h
+++ b/Userland/Libraries/LibPDF/ColorSpace.h
@@ -21,7 +21,7 @@
     V(Lab, false)                         \
     V(ICCBased, false)                    \
     V(Indexed, false)                     \
-    V(Pattern, false)                     \
+    V(Pattern, true)                      \
     V(Separation, false)                  \
     V(DeviceN, false)
 

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -958,7 +958,7 @@ PDFErrorOr<NonnullRefPtr<ColorSpace>> Renderer::get_color_space_from_resources(V
     auto maybe_color_space_family = ColorSpaceFamily::get(color_space_name);
     if (!maybe_color_space_family.is_error()) {
         auto color_space_family = maybe_color_space_family.release_value();
-        if (color_space_family.never_needs_parameters()) {
+        if (color_space_family.may_be_specified_directly()) {
             return ColorSpace::create(color_space_name);
         }
     }


### PR DESCRIPTION
Per spec:

"If the color space is one that can be specified by a name and no
additional parameters (DeviceGray, DeviceRGB, DeviceCMYK, and certain
cases of Pattern), the name may be specified directly."

We still don't implement /Pattern color spaces, but now we no longer
crash trying to look up the potentially-nonexistent /ColorSpace
dictionary on the page object when /Pattern is used directly as color
space name.

On top of https://github.com/SerenityOS/serenity/pull/21514, reduces number of crashes on 300 random PDFs from the
web (the first 300 from 0000.zip from
https://pdfa.org/new-large-scale-pdf-corpus-now-publicly-available/)
from 42 (14%) to 34 (11%).