### PR TITLE
LibPDF: Implement text_next_line_show_string_set_spacing

### DIFF
--- a/Userland/Libraries/LibPDF/ColorSpace.cpp
+++ b/Userland/Libraries/LibPDF/ColorSpace.cpp
@@ -76,7 +76,7 @@ NonnullRefPtr<DeviceGrayColorSpace> DeviceGrayColorSpace::the()
     return instance;
 }
 
-PDFErrorOr<Color> DeviceGrayColorSpace::color(Vector<Value> const& arguments) const
+PDFErrorOr<Color> DeviceGrayColorSpace::color(ReadonlySpan<Value> arguments) const
 {
     VERIFY(arguments.size() == 1);
     auto gray = static_cast<u8>(arguments[0].to_float() * 255.0f);
@@ -94,7 +94,7 @@ NonnullRefPtr<DeviceRGBColorSpace> DeviceRGBColorSpace::the()
     return instance;
 }
 
-PDFErrorOr<Color> DeviceRGBColorSpace::color(Vector<Value> const& arguments) const
+PDFErrorOr<Color> DeviceRGBColorSpace::color(ReadonlySpan<Value> arguments) const
 {
     VERIFY(arguments.size() == 3);
     auto r = static_cast<u8>(arguments[0].to_float() * 255.0f);
@@ -114,7 +114,7 @@ NonnullRefPtr<DeviceCMYKColorSpace> DeviceCMYKColorSpace::the()
     return instance;
 }
 
-PDFErrorOr<Color> DeviceCMYKColorSpace::color(Vector<Value> const& arguments) const
+PDFErrorOr<Color> DeviceCMYKColorSpace::color(ReadonlySpan<Value> arguments) const
 {
     VERIFY(arguments.size() == 4);
     auto c = arguments[0].to_float();
@@ -272,7 +272,7 @@ constexpr Array<float, 3> convert_to_srgb(Array<float, 3> xyz)
     return matrix_multiply(conversion_matrix, xyz);
 }
 
-PDFErrorOr<Color> CalRGBColorSpace::color(Vector<Value> const& arguments) const
+PDFErrorOr<Color> CalRGBColorSpace::color(ReadonlySpan<Value> arguments) const
 {
     VERIFY(arguments.size() == 3);
     auto a = clamp(arguments[0].to_float(), 0.0f, 1.0f);
@@ -336,7 +336,7 @@ ICCBasedColorSpace::ICCBasedColorSpace(NonnullRefPtr<Gfx::ICC::Profile> profile)
 {
 }
 
-PDFErrorOr<Color> ICCBasedColorSpace::color(Vector<Value> const& arguments) const
+PDFErrorOr<Color> ICCBasedColorSpace::color(ReadonlySpan<Value> arguments) const
 {
     if (!s_srgb_profile)
         s_srgb_profile = TRY(Gfx::ICC::sRGB());
@@ -387,7 +387,7 @@ PDFErrorOr<NonnullRefPtr<SeparationColorSpace>> SeparationColorSpace::create(Doc
     return color_space;
 }
 
-PDFErrorOr<Color> SeparationColorSpace::color(Vector<Value> const&) const
+PDFErrorOr<Color> SeparationColorSpace::color(ReadonlySpan<Value>) const
 {
     return Error::rendering_unsupported_error("Separation color spaces not yet implemented");
 }

--- a/Userland/Libraries/LibPDF/ColorSpace.h
+++ b/Userland/Libraries/LibPDF/ColorSpace.h
@@ -55,7 +55,7 @@ public:
 
     virtual ~ColorSpace() = default;
 
-    virtual PDFErrorOr<Color> color(Vector<Value> const& arguments) const = 0;
+    virtual PDFErrorOr<Color> color(ReadonlySpan<Value> arguments) const = 0;
     virtual int number_of_components() const = 0;
     virtual Vector<float> default_decode() const = 0;
     virtual ColorSpaceFamily const& family() const = 0;
@@ -67,7 +67,7 @@ public:
 
     ~DeviceGrayColorSpace() override = default;
 
-    PDFErrorOr<Color> color(Vector<Value> const& arguments) const override;
+    PDFErrorOr<Color> color(ReadonlySpan<Value> arguments) const override;
     int number_of_components() const override { return 1; }
     Vector<float> default_decode() const override;
     ColorSpaceFamily const& family() const override { return ColorSpaceFamily::DeviceGray; }
@@ -82,7 +82,7 @@ public:
 
     ~DeviceRGBColorSpace() override = default;
 
-    PDFErrorOr<Color> color(Vector<Value> const& arguments) const override;
+    PDFErrorOr<Color> color(ReadonlySpan<Value> arguments) const override;
     int number_of_components() const override { return 3; }
     Vector<float> default_decode() const override;
     ColorSpaceFamily const& family() const override { return ColorSpaceFamily::DeviceRGB; }
@@ -97,7 +97,7 @@ public:
 
     ~DeviceCMYKColorSpace() override = default;
 
-    PDFErrorOr<Color> color(Vector<Value> const& arguments) const override;
+    PDFErrorOr<Color> color(ReadonlySpan<Value> arguments) const override;
     int number_of_components() const override { return 4; }
     Vector<float> default_decode() const override;
     ColorSpaceFamily const& family() const override { return ColorSpaceFamily::DeviceCMYK; }
@@ -112,7 +112,7 @@ public:
 
     ~CalRGBColorSpace() override = default;
 
-    PDFErrorOr<Color> color(Vector<Value> const& arguments) const override;
+    PDFErrorOr<Color> color(ReadonlySpan<Value> arguments) const override;
     int number_of_components() const override { return 3; }
     Vector<float> default_decode() const override;
     ColorSpaceFamily const& family() const override { return ColorSpaceFamily::CalRGB; }
@@ -132,7 +132,7 @@ public:
 
     ~ICCBasedColorSpace() override = default;
 
-    PDFErrorOr<Color> color(Vector<Value> const& arguments) const override;
+    PDFErrorOr<Color> color(ReadonlySpan<Value> arguments) const override;
     int number_of_components() const override;
     Vector<float> default_decode() const override;
     ColorSpaceFamily const& family() const override { return ColorSpaceFamily::ICCBased; }
@@ -150,7 +150,7 @@ public:
 
     ~SeparationColorSpace() override = default;
 
-    PDFErrorOr<Color> color(Vector<Value> const& arguments) const override;
+    PDFErrorOr<Color> color(ReadonlySpan<Value> arguments) const override;
     int number_of_components() const override { TODO(); }
     Vector<float> default_decode() const override;
     ColorSpaceFamily const& family() const override { return ColorSpaceFamily::Separation; }

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -11,7 +11,7 @@
 #include <LibPDF/Renderer.h>
 
 #define RENDERER_HANDLER(name) \
-    PDFErrorOr<void> Renderer::handle_##name([[maybe_unused]] Vector<Value> const& args, [[maybe_unused]] Optional<NonnullRefPtr<DictObject>> extra_resources)
+    PDFErrorOr<void> Renderer::handle_##name([[maybe_unused]] ReadonlySpan<Value> args, [[maybe_unused]] Optional<NonnullRefPtr<DictObject>> extra_resources)
 
 #define RENDERER_TODO(name)                                                        \
     RENDERER_HANDLER(name)                                                         \
@@ -489,7 +489,7 @@ RENDERER_HANDLER(text_set_matrix_and_line_matrix)
 
 RENDERER_HANDLER(text_next_line)
 {
-    TRY(handle_text_next_line_offset({ 0.0f, -text_state().leading }));
+    TRY(handle_text_next_line_offset(Array<Value, 2> { 0.0f, -text_state().leading }));
     return {};
 }
 
@@ -742,16 +742,16 @@ PDFErrorOr<void> Renderer::set_graphics_state_from_dict(NonnullRefPtr<DictObject
     // ISO 32000 (PDF 2.0), 8.4.5 Graphics state parameter dictionaries
 
     if (dict->contains(CommonNames::LW))
-        TRY(handle_set_line_width({ dict->get_value(CommonNames::LW) }));
+        TRY(handle_set_line_width(Array { dict->get_value(CommonNames::LW) }));
 
     if (dict->contains(CommonNames::LC))
-        TRY(handle_set_line_cap({ dict->get_value(CommonNames::LC) }));
+        TRY(handle_set_line_cap(Array { dict->get_value(CommonNames::LC) }));
 
     if (dict->contains(CommonNames::LJ))
-        TRY(handle_set_line_join({ dict->get_value(CommonNames::LJ) }));
+        TRY(handle_set_line_join(Array { dict->get_value(CommonNames::LJ) }));
 
     if (dict->contains(CommonNames::ML))
-        TRY(handle_set_miter_limit({ dict->get_value(CommonNames::ML) }));
+        TRY(handle_set_miter_limit(Array { dict->get_value(CommonNames::ML) }));
 
     if (dict->contains(CommonNames::D)) {
         auto array = MUST(dict->get_array(m_document, CommonNames::D));
@@ -759,7 +759,7 @@ PDFErrorOr<void> Renderer::set_graphics_state_from_dict(NonnullRefPtr<DictObject
     }
 
     if (dict->contains(CommonNames::RI))
-        TRY(handle_set_color_rendering_intent({ dict->get_value(CommonNames::RI) }));
+        TRY(handle_set_color_rendering_intent(Array { dict->get_value(CommonNames::RI) }));
 
     // FIXME: OP
     // FIXME: op
@@ -774,7 +774,7 @@ PDFErrorOr<void> Renderer::set_graphics_state_from_dict(NonnullRefPtr<DictObject
     // FIXME: HT
 
     if (dict->contains(CommonNames::FL))
-        TRY(handle_set_flatness_tolerance({ dict->get_value(CommonNames::FL) }));
+        TRY(handle_set_flatness_tolerance(Array { dict->get_value(CommonNames::FL) }));
 
     // FIXME: SM
     // FIXME: SA

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -507,7 +507,13 @@ RENDERER_HANDLER(text_next_line_show_string)
     return {};
 }
 
-RENDERER_TODO(text_next_line_show_string_set_spacing)
+RENDERER_HANDLER(text_next_line_show_string_set_spacing)
+{
+    TRY(handle_text_set_word_space(args.slice(0, 1)));
+    TRY(handle_text_set_char_space(args.slice(1, 1)));
+    TRY(handle_text_next_line_show_string(args.slice(2)));
+    return {};
+}
 
 RENDERER_HANDLER(text_show_string_array)
 {

--- a/Userland/Libraries/LibPDF/Renderer.h
+++ b/Userland/Libraries/LibPDF/Renderer.h
@@ -114,11 +114,11 @@ private:
 
     PDFErrorOr<void> handle_operator(Operator const&, Optional<NonnullRefPtr<DictObject>> = {});
 #define V(name, snake_name, symbol) \
-    PDFErrorOr<void> handle_##snake_name(Vector<Value> const& args, Optional<NonnullRefPtr<DictObject>> = {});
+    PDFErrorOr<void> handle_##snake_name(ReadonlySpan<Value> args, Optional<NonnullRefPtr<DictObject>> = {});
     ENUMERATE_OPERATORS(V)
 #undef V
-    PDFErrorOr<void> handle_text_next_line_show_string(Vector<Value> const& args, Optional<NonnullRefPtr<DictObject>> = {});
-    PDFErrorOr<void> handle_text_next_line_show_string_set_spacing(Vector<Value> const& args, Optional<NonnullRefPtr<DictObject>> = {});
+    PDFErrorOr<void> handle_text_next_line_show_string(ReadonlySpan<Value> args, Optional<NonnullRefPtr<DictObject>> = {});
+    PDFErrorOr<void> handle_text_next_line_show_string_set_spacing(ReadonlySpan<Value> args, Optional<NonnullRefPtr<DictObject>> = {});
 
     void begin_path_paint();
     void end_path_paint();


### PR DESCRIPTION
Not used terribly often, but e.g. used in 000333.pdf page 17 in
stillhq.com-pdfdb.

---

Before:

<img width="734" alt="Screenshot 2023-10-20 at 11 56 57 AM" src="https://github.com/SerenityOS/serenity/assets/3487/f5931b0d-3bc4-418c-8767-4477f3f70f5b">

After:

<img width="734" alt="Screenshot 2023-10-20 at 11 57 02 AM" src="https://github.com/SerenityOS/serenity/assets/3487/0ccc9502-2c9f-46e1-9920-88aa4892d140">