### PR TITLE
AK: Colorize log message for failed assertions

### DIFF
--- a/AK/Assertions.cpp
+++ b/AK/Assertions.cpp
@@ -89,7 +89,17 @@ extern "C" {
 
 void ak_verification_failed(char const* message)
 {
-    ERRORLN("VERIFICATION FAILED: {}", message);
+#    if defined(AK_OS_SERENITY) || defined(AK_OS_ANDROID)
+    bool colorize_output = true;
+#    else
+    bool colorize_output = isatty(STDERR_FILENO) == 1;
+#    endif
+
+    if (colorize_output)
+        ERRORLN("\033[31;1mVERIFICATION FAILED\033[0m: {}", message);
+    else
+        ERRORLN("VERIFICATION FAILED: {}", message);
+
 #    if defined(EXECINFO_BACKTRACE)
     dump_backtrace();
 #    endif


### PR DESCRIPTION
The log message can be hard to spot in a sea of debug messages. Colorize it to make the message more immediately pop out.

![assert](https://github.com/SerenityOS/serenity/assets/5600524/984d69c0-0e60-468f-8d88-0214152ae0ee)
