### PR TITLE
LibWeb: Rerun rows sizings if grid auto height is less than min-height

### DIFF
--- a/Tests/LibWeb/Layout/expected/grid/container-min-height.txt
+++ b/Tests/LibWeb/Layout/expected/grid/container-min-height.txt
@@ -1,0 +1,23 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (1,1) content-size 798x220 [BFC] children: not-inline
+    BlockContainer <body> at (10,10) content-size 780x202 children: not-inline
+      Box <div.container> at (11,11) content-size 778x200 [GFC] children: not-inline
+        BlockContainer <div> at (12,12) content-size 776x98 [BFC] children: inline
+          line 0 width: 311.21875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 35, rect: [12,12 311.21875x17.46875]
+              "Making Commerce Better for Everyone"
+          TextNode <#text>
+        BlockContainer <div> at (12,112) content-size 776x98 [BFC] children: inline
+          line 0 width: 311.21875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 35, rect: [12,112 311.21875x17.46875]
+              "Making Commerce Better for Everyone"
+          TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x222]
+    PaintableWithLines (BlockContainer<BODY>) [9,9 782x204]
+      PaintableBox (Box<DIV>.container) [10,10 780x202]
+        PaintableWithLines (BlockContainer<DIV>) [11,11 778x100]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [11,111 778x100]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/input/grid/container-min-height.html
+++ b/Tests/LibWeb/Layout/input/grid/container-min-height.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html><style type="text/css">
+* {
+    border: 1px solid black;
+}
+
+.container {
+    display: grid;
+    min-height: 200px;
+}
+</style><div class="container"><div>Making Commerce Better for Everyone</div><div>Making Commerce Better for Everyone</div>

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -1803,6 +1803,25 @@ void GridFormattingContext::run(Box const& box, LayoutMode, AvailableSpace const
 
     determine_grid_container_height();
 
+    auto const& containing_block_state = m_state.get(*grid_container().containing_block());
+    auto height_of_containing_block = containing_block_state.content_height();
+    auto min_height = grid_container().computed_values().min_height().to_px(grid_container(), height_of_containing_block);
+
+    // If automatic grid container height is less than min-height, we need to re-run the track sizing algorithm
+    if (m_automatic_content_height < min_height) {
+        resolve_items_box_metrics(GridDimension::Row);
+
+        AvailableSize width(available_space.width);
+        AvailableSize height(AvailableSize::make_definite(min_height));
+        run_track_sizing(AvailableSpace(width, height), GridDimension::Row);
+
+        resolve_items_box_metrics(GridDimension::Row);
+
+        resolve_grid_item_heights();
+
+        determine_grid_container_height();
+    }
+
     if (available_space.height.is_intrinsic_sizing_constraint() || available_space.width.is_intrinsic_sizing_constraint()) {
         determine_intrinsic_size_of_grid_container(available_space);
         return;


### PR DESCRIPTION
If the first pass of rows sizing results in the container's automatic height being less than the specified min-height, we need to run a second pass using the updated available space.