### PR TITLE
LibPDF: Fix corner case where we sometimes failed to decompress compressed streams

### DIFF
--- a/Userland/Libraries/LibPDF/DocumentParser.cpp
+++ b/Userland/Libraries/LibPDF/DocumentParser.cpp
@@ -92,6 +92,7 @@ PDFErrorOr<Version> DocumentParser::parse_header()
         return error(DeprecatedString::formatted("Unknown minor version \"{}\"", minor_ver));
 
     m_reader.consume_eol();
+    m_reader.consume_whitespace();
 
     // Parse optional high-byte comment, which signifies a binary file
     // FIXME: Do something with this?

--- a/Userland/Libraries/LibPDF/Parser.h
+++ b/Userland/Libraries/LibPDF/Parser.h
@@ -83,7 +83,7 @@ protected:
     WeakPtr<Document> m_document;
     Vector<Reference> m_current_reference_stack;
     bool m_enable_encryption { true };
-    bool m_enable_filters { false };
+    bool m_enable_filters { true };
 };
 
 };


### PR DESCRIPTION
Reduces number of crashes on 300 random PDFs from the
web (the first 300 from 0000.zip from
https://pdfa.org/new-large-scale-pdf-corpus-now-publicly-available/)
from 34 (11%) to 29 (9%).

Fixes most crashes looking like:

```
unsupported graphics symbol x
VERIFICATION FAILED: false at /Users/thakis/src/serenity/Meta/Lagom/../../Userland/Libraries/LibPDF/Operator.h:113
0   liblagom-core.0.0.0.dylib           0xc3ns0r3d ak_verification_failed + 136
1   liblagom-pdf.0.0.0.dylib            0xc3ns0r3d PDF::Operator::operator_type_from_symbol(AK::StringView) + 5856
```

(A few remain, these are because we also interpret inline image data from BI / ID / EI as operands. That's for another PR.)