### PR TITLE
LibPDF: Fix rare assertions when constructing outlines

### DIFF
--- a/Userland/Libraries/LibPDF/Document.cpp
+++ b/Userland/Libraries/LibPDF/Document.cpp
@@ -507,7 +507,7 @@ PDFErrorOr<Destination> Document::create_destination_from_object(NonnullRefPtr<O
             return TRY(create_destination_from_dictionary_entry(entry, page_number_by_index_ref));
         }
         if (auto names_value = m_catalog->get(CommonNames::Names); names_value.has_value()) {
-            auto names = TRY(resolve(names_value.release_value())).get<NonnullRefPtr<Object>>()->cast<DictObject>();
+            auto names = TRY(resolve_to<DictObject>(names_value.release_value()));
             if (!names->contains(CommonNames::Dests))
                 return Error { Error::Type::MalformedPDF, "Missing Dests key in document catalogue's Names dictionary" };
             auto dest_obj = TRY(find_in_name_tree(TRY(names->get_dict(this, CommonNames::Dests)), dest_name));

--- a/Userland/Libraries/LibPDF/Document.cpp
+++ b/Userland/Libraries/LibPDF/Document.cpp
@@ -502,7 +502,7 @@ PDFErrorOr<Destination> Document::create_destination_from_object(NonnullRefPtr<O
         else
             dest_name = dest_obj->cast<StringObject>()->string();
         if (auto dests_value = m_catalog->get(CommonNames::Dests); dests_value.has_value()) {
-            auto dests = dests_value.value().get<NonnullRefPtr<Object>>()->cast<DictObject>();
+            auto dests = TRY(resolve_to<DictObject>(dests_value.value()));
             auto entry = MUST(dests->get_object(this, dest_name));
             return TRY(create_destination_from_dictionary_entry(entry, page_number_by_index_ref));
         }

--- a/Userland/Libraries/LibPDF/Document.cpp
+++ b/Userland/Libraries/LibPDF/Document.cpp
@@ -451,7 +451,15 @@ PDFErrorOr<Destination> Document::create_destination_from_parameters(NonnullRefP
         VERIFY_NOT_REACHED();
     }
 
-    return Destination { type, page_number_by_index_ref.get(page_ref.as_ref_index()), parameters };
+    // The spec requires page_ref to be an indirect reference to a page object,
+    // but in practice it's sometimes a page index.
+    Optional<u32> page_number;
+    if (page_ref.has<int>())
+        page_number = page_ref.get<int>();
+    else
+        page_number = page_number_by_index_ref.get(page_ref.as_ref_index());
+
+    return Destination { type, page_number, parameters };
 }
 
 PDFErrorOr<Optional<NonnullRefPtr<Object>>> Document::get_inheritable_object(DeprecatedFlyString const& name, NonnullRefPtr<DictObject> object)


### PR DESCRIPTION
Makes 0000847.pdf, 0000327.pdf, 0000124.pdf from 0000.zip from
https://pdfa.org/new-large-scale-pdf-corpus-now-publicly-available/
assert later when rendering them, instead of when building the outline.