### PR TITLE
DynamicLoader: Make heuristic for running directly actually correct

### DIFF
--- a/Kernel/Syscalls/execve.cpp
+++ b/Kernel/Syscalls/execve.cpp
@@ -858,8 +858,6 @@ ErrorOr<RefPtr<OpenFileDescription>> Process::find_elf_interpreter_for_executabl
     if (main_executable_header.e_type == ET_DYN) {
         // If it's ET_DYN with no PT_INTERP, then it's a dynamic executable responsible
         // for its own relocation (i.e. it's /usr/lib/Loader.so)
-        if (path != "/usr/lib/Loader.so")
-            dbgln("exec({}): WARNING - Dynamic ELF executable without a PT_INTERP header, and isn't /usr/lib/Loader.so", path);
         return nullptr;
     }
 

--- a/Userland/DynamicLoader/main.cpp
+++ b/Userland/DynamicLoader/main.cpp
@@ -129,7 +129,7 @@ void _entry(int argc, char** argv, char** envp)
         }
     }
 
-    if (main_program_path == "/usr/lib/Loader.so"sv) {
+    if (main_program_fd == -1) {
         // We've been invoked directly as an executable rather than as the
         // ELF interpreter for some other binary. The second argv string should
         // be the path to the ELF executable, and if we don't have enough strings in argv

--- a/Userland/Libraries/LibELF/DynamicObject.cpp
+++ b/Userland/Libraries/LibELF/DynamicObject.cpp
@@ -183,6 +183,7 @@ void DynamicObject::parse()
         case DT_DEBUG:
             break;
         case DT_FLAGS_1:
+            m_is_pie = true;
             break;
         case DT_NEEDED:
             // We handle these in for_each_needed_library

--- a/Userland/Libraries/LibELF/DynamicObject.h
+++ b/Userland/Libraries/LibELF/DynamicObject.h
@@ -254,6 +254,8 @@ public:
     InitializationFunction init_section_function() const;
     Section init_array_section() const;
 
+    bool is_pie() const { return m_is_pie; }
+
     bool has_fini_section() const { return m_fini_offset != 0; }
     bool has_fini_array_section() const { return m_fini_array_offset != 0; }
     Section fini_section() const;
@@ -377,6 +379,8 @@ private:
     size_t m_size_of_relr_relocation_table { 0 };
     FlatPtr m_relr_relocation_table_offset { 0 };
     bool m_is_elf_dynamic { false };
+
+    bool m_is_pie { false };
 
     // DT_FLAGS
     ElfW(Word) m_dt_flags { 0 };


### PR DESCRIPTION
When we run directly the dynamic loader, we shouldn't rely on the passed program path to be run, but rather on whether the main program fd number is not -1, because the kernel will set it to a non-negative number if it exists.

To test that the heuristic is working correctly, the /usr/lib/Loader.so file can be copied to /tmp/Loader.so and then be invoked from that path.