### PR TITLE
LibWeb: Remove ClearRect command in RecordingPainter

### DIFF
--- a/Userland/Libraries/LibWeb/Painting/RecordingPainter.cpp
+++ b/Userland/Libraries/LibWeb/Painting/RecordingPainter.cpp
@@ -31,15 +31,6 @@ struct CommandExecutionState {
     Vector<StackingContext> stacking_contexts;
 };
 
-CommandResult ClearRect::execute(CommandExecutionState& state) const
-{
-    if (state.would_be_fully_clipped_by_painter(rect))
-        return CommandResult::Continue;
-
-    state.painter().clear_rect(rect, color);
-    return CommandResult::Continue;
-}
-
 CommandResult FillRectWithRoundedCorners::execute(CommandExecutionState& state) const
 {
     if (state.would_be_fully_clipped_by_painter(rect))
@@ -504,14 +495,6 @@ void RecordingPainter::sample_under_corners(NonnullRefPtr<BorderRadiusCornerClip
 void RecordingPainter::blit_corner_clipping(NonnullRefPtr<BorderRadiusCornerClipper> corner_clipper)
 {
     push_command(BlitCornerClipping { corner_clipper });
-}
-
-void RecordingPainter::clear_rect(Gfx::IntRect const& rect, Color color)
-{
-    push_command(ClearRect {
-        .rect = rect,
-        .color = color,
-    });
 }
 
 void RecordingPainter::fill_rect(Gfx::IntRect const& rect, Color color)

--- a/Userland/Libraries/LibWeb/Painting/RecordingPainter.h
+++ b/Userland/Libraries/LibWeb/Painting/RecordingPainter.h
@@ -40,13 +40,6 @@ enum class CommandResult {
     SkipStackingContext,
 };
 
-struct ClearRect {
-    Gfx::IntRect rect;
-    Color color;
-
-    [[nodiscard]] CommandResult execute(CommandExecutionState&) const;
-};
-
 struct DrawTextRun {
     Color color;
     Gfx::IntPoint baseline_start;
@@ -347,7 +340,6 @@ struct BlitCornerClipping {
 };
 
 using PaintingCommand = Variant<
-    ClearRect,
     DrawTextRun,
     DrawText,
     FillRect,
@@ -387,7 +379,6 @@ using PaintingCommand = Variant<
 
 class RecordingPainter {
 public:
-    void clear_rect(Gfx::IntRect const& rect, Color color);
     void fill_rect(Gfx::IntRect const& rect, Color color);
 
     struct FillPathUsingColorParams {

--- a/Userland/Services/WebContent/PageHost.cpp
+++ b/Userland/Services/WebContent/PageHost.cpp
@@ -133,7 +133,7 @@ void PageHost::paint(Web::DevicePixelRect const& content_rect, Gfx::Bitmap& targ
     Web::PaintContext context(recording_painter, palette(), device_pixels_per_css_pixel());
 
     if (background_color.alpha() < 255)
-        recording_painter.clear_rect(bitmap_rect, Web::CSS::SystemColor::canvas());
+        recording_painter.fill_rect(bitmap_rect, Web::CSS::SystemColor::canvas());
     recording_painter.fill_rect(bitmap_rect, background_color);
 
     if (!document->paintable())


### PR DESCRIPTION
There is only one usage of ClearRect command and it could be replaced with FillRect to make set of commands in RecordingPainter smaller.