### PR TITLE
RISC-V disassembly, part 2/N: disasm: All-around better symbol handling

### DIFF
--- a/Userland/Utilities/disasm.cpp
+++ b/Userland/Utilities/disasm.cpp
@@ -41,12 +41,14 @@ struct Symbol {
 ErrorOr<int> serenity_main(Main::Arguments args)
 {
     StringView path {};
+    StringView target_symbol;
 
     Core::ArgsParser args_parser;
     args_parser.set_general_help(
         "Disassemble an executable, and show human-readable "
         "assembly code for each function.");
-    args_parser.add_positional_argument(path, "Path to i386 binary file", "path");
+    args_parser.add_positional_argument(path, "Path to binary file", "path");
+    args_parser.add_option(target_symbol, "Show disassembly only for a specific symbol", "symbol", 's', "symbol");
     args_parser.parse(args);
 
     OwnPtr<Core::MappedFile> file;
@@ -120,6 +122,7 @@ ErrorOr<int> serenity_main(Main::Arguments args)
     Vector<Symbol>::Iterator current_zero_size_symbol = zero_size_symbols.begin();
     bool is_first_symbol = true;
     bool current_instruction_is_in_symbol = false;
+    bool found_symbol = false;
 
     for (;;) {
         auto offset = stream.offset();
@@ -181,6 +184,16 @@ ErrorOr<int> serenity_main(Main::Arguments args)
 
             is_first_symbol = false;
         }
+
+        // Past the target symbol now; no need to disassemble more.
+        if (found_symbol && current_ranged_symbol->name != target_symbol)
+            break;
+
+        found_symbol = !target_symbol.is_empty() && current_ranged_symbol->name == target_symbol;
+
+        // We have not found the target symbol yet; don't print anything.
+        if (!target_symbol.is_empty() && current_ranged_symbol->name != target_symbol)
+            continue;
 
         if (needs_separator)
             outln();

--- a/Userland/Utilities/disasm.cpp
+++ b/Userland/Utilities/disasm.cpp
@@ -6,8 +6,11 @@
 
 #include <AK/Debug.h>
 #include <AK/Demangle.h>
+#include <AK/IterationDecision.h>
 #include <AK/OwnPtr.h>
 #include <AK/QuickSort.h>
+#include <AK/String.h>
+#include <AK/StringBuilder.h>
 #include <AK/Vector.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/MappedFile.h>
@@ -16,7 +19,24 @@
 #include <LibMain/Main.h>
 #include <LibX86/Disassembler.h>
 #include <LibX86/ELFSymbolProvider.h>
-#include <string.h>
+
+struct Symbol {
+    size_t value;
+    size_t size;
+    StringView name;
+
+    size_t address() const { return value; }
+    size_t address_end() const { return value + size; }
+
+    bool contains(size_t virtual_address) { return (address() <= virtual_address && virtual_address < address_end()) || (size == 0 && address() == virtual_address); }
+
+    String format_symbol_address() const
+    {
+        if (size > 0)
+            return MUST(String::formatted("{:p}-{:p}", address(), address_end()));
+        return MUST(String::formatted("{:p}", address()));
+    }
+};
 
 ErrorOr<int> serenity_main(Main::Arguments args)
 {
@@ -38,20 +58,12 @@ ErrorOr<int> serenity_main(Main::Arguments args)
         asm_size = MUST(file->size());
     }
 
-    struct Symbol {
-        size_t value;
-        size_t size;
-        StringView name;
-
-        size_t address() const { return value; }
-        size_t address_end() const { return value + size; }
-
-        bool contains(size_t virtual_address) { return address() <= virtual_address && virtual_address < address_end(); }
-    };
-    Vector<Symbol> symbols;
+    // Functions and similar symbols.
+    Vector<Symbol> ranged_symbols;
+    // Jump labels, relocation targets, etc.
+    Vector<Symbol> zero_size_symbols;
 
     size_t file_offset = 0;
-    Vector<Symbol>::Iterator current_symbol = symbols.begin();
     OwnPtr<X86::ELFSymbolProvider> symbol_provider; // nullptr for non-ELF disassembly.
     OwnPtr<ELF::Image> elf;
     if (asm_size >= 4 && strncmp(reinterpret_cast<char const*>(asm_data), "\u007fELF", 4) == 0) {
@@ -67,22 +79,36 @@ ErrorOr<int> serenity_main(Main::Arguments args)
                 file_offset = section.address();
                 return IterationDecision::Break;
             });
-            symbols.ensure_capacity(elf->symbol_count() + 1);
-            symbols.append({ 0, 0, StringView() }); // Sentinel.
+            ranged_symbols.ensure_capacity(elf->symbol_count() + 1);
+            zero_size_symbols.ensure_capacity(elf->symbol_count() + 1);
+            // Sentinels:
+            ranged_symbols.append({ 0, 0, StringView() });
+            zero_size_symbols.append({ 0, 0, StringView() });
+
             elf->for_each_symbol([&](ELF::Image::Symbol const& symbol) {
-                symbols.append({ symbol.value(), symbol.size(), symbol.name() });
+                if (symbol.name().is_empty())
+                    return IterationDecision::Continue;
+
+                if (symbol.size() == 0)
+                    zero_size_symbols.append({ symbol.value(), symbol.size(), symbol.name() });
+                else
+                    ranged_symbols.append({ symbol.value(), symbol.size(), symbol.name() });
                 return IterationDecision::Continue;
             });
-            quick_sort(symbols, [](auto& a, auto& b) {
+            auto symbol_order = [](auto& a, auto& b) {
                 if (a.value != b.value)
                     return a.value < b.value;
                 if (a.size != b.size)
                     return a.size < b.size;
                 return a.name < b.name;
-            });
+            };
+            quick_sort(ranged_symbols, symbol_order);
+            quick_sort(zero_size_symbols, symbol_order);
             if constexpr (DISASM_DUMP_DEBUG) {
-                for (size_t i = 0; i < symbols.size(); ++i)
-                    dbgln("{}: {:p}, {}", symbols[i].name, symbols[i].value, symbols[i].size);
+                for (size_t i = 0; i < ranged_symbols.size(); ++i)
+                    dbgln("{}: {:p}, {}", ranged_symbols[i].name, ranged_symbols[i].value, ranged_symbols[i].size);
+                for (size_t i = 0; i < zero_size_symbols.size(); ++i)
+                    dbgln("{}: {:p}", zero_size_symbols[i].name, zero_size_symbols[i].value);
             }
         }
     }
@@ -90,6 +116,8 @@ ErrorOr<int> serenity_main(Main::Arguments args)
     X86::SimpleInstructionStream stream(asm_data, asm_size);
     X86::Disassembler disassembler(stream);
 
+    Vector<Symbol>::Iterator current_ranged_symbol = ranged_symbols.begin();
+    Vector<Symbol>::Iterator current_zero_size_symbol = zero_size_symbols.begin();
     bool is_first_symbol = true;
     bool current_instruction_is_in_symbol = false;
 
@@ -99,37 +127,68 @@ ErrorOr<int> serenity_main(Main::Arguments args)
         if (!insn.has_value())
             break;
 
+        size_t virtual_offset = file_offset + offset;
         // Prefix regions of instructions belonging to a symbol with the symbol's name.
         // Separate regions of instructions belonging to distinct symbols with newlines,
         // and separate regions of instructions not belonging to symbols from regions belonging to symbols with newlines.
         // Interesting cases:
         // - More than 1 symbol covering a region of instructions (ICF, D1/D2)
         // - Symbols of size 0 that don't cover any instructions but are at an address (want to print them, separated from instructions both before and after)
-        // Invariant: current_symbol is the largest instruction containing insn, or it is the largest instruction that has an address less than the instruction's address.
-        size_t virtual_offset = file_offset + offset;
-        if (current_symbol < symbols.end() && !current_symbol->contains(virtual_offset)) {
+        // Invariant: current_ranged_symbol is the largest instruction containing insn, or it is the largest instruction that has an address less than the instruction's address.
+        StringBuilder dangling_symbols;
+        StringBuilder instruction_symbols;
+        bool needs_separator = false;
+        if (current_zero_size_symbol < zero_size_symbols.end()) {
+            // Print "dangling" symbols preceding the current instruction.
+            while (current_zero_size_symbol + 1 < zero_size_symbols.end() && !(current_zero_size_symbol + 1)->contains(virtual_offset) && (current_zero_size_symbol + 1)->address() <= virtual_offset) {
+                ++current_zero_size_symbol;
+                if (!is_first_symbol)
+                    dangling_symbols.appendff("\n({} ({}))\n", demangle(current_zero_size_symbol->name), current_zero_size_symbol->format_symbol_address());
+            }
+            // Find and print all symbols covering the current instruction.
+            while (current_zero_size_symbol + 1 < zero_size_symbols.end() && (current_zero_size_symbol + 1)->contains(virtual_offset)) {
+                if (!is_first_symbol && !current_instruction_is_in_symbol)
+                    needs_separator = true;
+                ++current_zero_size_symbol;
+                current_instruction_is_in_symbol = true;
+
+                instruction_symbols.appendff("{} ({}):\n", demangle(current_zero_size_symbol->name), current_zero_size_symbol->format_symbol_address());
+            }
+        }
+        // Handle ranged symbols separately.
+        if (current_ranged_symbol < ranged_symbols.end() && !current_ranged_symbol->contains(virtual_offset)) {
             if (!is_first_symbol && current_instruction_is_in_symbol) {
                 // The previous instruction was part of a symbol that doesn't cover the current instruction, so separate it from the current instruction with a newline.
-                outln();
-                current_instruction_is_in_symbol = (current_symbol + 1 < symbols.end() && (current_symbol + 1)->contains(virtual_offset));
+                needs_separator = true;
+                current_instruction_is_in_symbol = (current_ranged_symbol + 1 < ranged_symbols.end() && (current_ranged_symbol + 1)->contains(virtual_offset));
             }
 
-            // Try to find symbol covering current instruction, if one exists.
-            while (current_symbol + 1 < symbols.end() && !(current_symbol + 1)->contains(virtual_offset) && (current_symbol + 1)->address() <= virtual_offset) {
-                ++current_symbol;
+            // Print "dangling" symbols preceding the current instruction.
+            while (current_ranged_symbol + 1 < ranged_symbols.end() && !(current_ranged_symbol + 1)->contains(virtual_offset) && (current_ranged_symbol + 1)->address() <= virtual_offset) {
+                ++current_ranged_symbol;
                 if (!is_first_symbol)
-                    outln("\n({} ({:p}-{:p}))\n", demangle(current_symbol->name), current_symbol->address(), current_symbol->address_end());
+                    dangling_symbols.appendff("\n({} ({}))\n", demangle(current_ranged_symbol->name), current_ranged_symbol->format_symbol_address());
             }
-            while (current_symbol + 1 < symbols.end() && (current_symbol + 1)->contains(virtual_offset)) {
+            // Find and print all symbols covering the current instruction.
+            while (current_ranged_symbol + 1 < ranged_symbols.end() && (current_ranged_symbol + 1)->contains(virtual_offset)) {
                 if (!is_first_symbol && !current_instruction_is_in_symbol)
-                    outln();
-                ++current_symbol;
+                    needs_separator = true;
+                ++current_ranged_symbol;
                 current_instruction_is_in_symbol = true;
-                outln("{} ({:p}-{:p}):", demangle(current_symbol->name), current_symbol->address(), current_symbol->address_end());
+
+                instruction_symbols.appendff("{} ({}):\n", demangle(current_ranged_symbol->name), current_ranged_symbol->format_symbol_address());
             }
 
             is_first_symbol = false;
         }
+
+        if (needs_separator)
+            outln();
+        // Insert extra newline after the "dangling" symbols.
+        if (auto dangling_symbols_text = TRY(dangling_symbols.to_string()); !dangling_symbols_text.is_empty())
+            outln("{}", dangling_symbols_text);
+        if (auto instruction_symbols_text = TRY(instruction_symbols.to_string()); !instruction_symbols_text.is_empty())
+            out("{}", instruction_symbols_text);
 
         size_t length = insn.value().length();
         StringBuilder builder;


### PR DESCRIPTION
This is part 2 of a long chain of PRs and commits that add RISC-V disassembly support. Today: Two changes to disasm that (1) improve and fix the way symbols are printed and (2) allow just one symbol to be printed.

### disasm: Overhaul symbol printing

We now split up symbols into zero-sized symbols that label single
instructions (no need to separate them by newlines; they are used for
jump labels and relocation targets within a larger block of code) and
ranged symbols that label functions. Empty symbols are discarded since
at least RISC-V ELF files contain quite a few of those. Zero-sized
symbols and ranged symbols are handled almost the same, but this way we
can make sure that zero-sized symbols don't interfere with ranged
symbol's newline separation logic. For zero-sized symbols, the "symbol
contains address" logic is updated so they actually contain the one
address they're pointing at, fixing the bug with many "dangling"
zero-sized symbols after a function that contained them. Zero-sized
labels are also no longer printed as a start-end range, since that is
unnecessary visual noise.

For comparison, here's the start of the RISC-V libc before the change:

```
__do_init (0x0000000000091000-0x0000000000091060):
0x0000000000091000  41 11                 addi x2, x2, -16
0x0000000000091002  06 e4                 sd x1, 0x008(x2)
0x0000000000091004  22 e0                 sd x8, 0x000(x2)
0x0000000000091006  00 08                 addi x8, x2, 16
0x0000000000091008  17 b5 0a 00           auipc x10, 700416
0x000000000009100c  13 05 05 00           addi x10, x10, 0
0x0000000000091010  03 45 05 00           lbu x10, 0x000(x10)
0x0000000000091014  05 89                 andi x10, x10, 1
0x0000000000091016  63 06 05 00           beq x10, x0, +0x00c
0x000000000009101a  6f 00 40 00           jal x0, +0x000004
0x000000000009101e  6f 00 a0 03           jal x0, +0x00003a
0x0000000000091022  17 b5 0a 00           auipc x10, 700416
0x0000000000091026  93 05 65 fe           addi x11, x10, -26
0x000000000009102a  05 45                 addi x10, x0, 1
0x000000000009102c  23 80 a5 00           sb x10, 0x000(x11)
0x0000000000091030  17 95 0a 00           auipc x10, 692224
0x0000000000091034  03 35 85 4b           ld x10, 0x4b8(x10)
0x0000000000091038  63 00 05 02           beq x10, x0, +0x020
0x000000000009103c  6f 00 40 00           jal x0, +0x000004
0x0000000000091040  17 85 fe ff           auipc x10, -98304
0x0000000000091044  13 05 85 10           addi x10, x10, 264
0x0000000000091048  97 b5 0a 00           auipc x11, 700416
0x000000000009104c  93 85 85 fc           addi x11, x11, -56
0x0000000000091050  ef 10 53 0c           jal x1, +0x0318c4
0x0000000000091054  6f 00 40 00           jal x0, +0x000004
0x0000000000091058  a2 60                 ld x1, 0x008(x2)
0x000000000009105a  02 64                 ld x8, 0x000(x2)
0x000000000009105c  41 01                 addi x2, x2, 16
0x000000000009105e  82 80                 jalr x0, x1+0x000

( (0x0000000000091002-0x0000000000091002))

( (0x0000000000091006-0x0000000000091006))

( (0x0000000000091006-0x0000000000091006))

( (0x0000000000091008-0x0000000000091008))

(.Lpcrel_hi0 (0x0000000000091008-0x0000000000091008))

(.LBB0_1 (0x000000000009101e-0x000000000009101e))

(.LBB0_2 (0x0000000000091022-0x0000000000091022))

(.Lpcrel_hi1 (0x0000000000091022-0x0000000000091022))

(.Lpcrel_hi2 (0x0000000000091030-0x0000000000091030))

(.LBB0_3 (0x0000000000091040-0x0000000000091040))

(.Lpcrel_hi3 (0x0000000000091040-0x0000000000091040))

(.Lpcrel_hi4 (0x0000000000091048-0x0000000000091048))

(.LBB0_4 (0x0000000000091058-0x0000000000091058))

( (0x0000000000091060-0x0000000000091060))

( (0x0000000000091060-0x0000000000091060))

__do_fini (0x0000000000091060-0x00000000000910da):
0x0000000000091060  41 11                 addi x2, x2, -16
0x0000000000091062  06 e4                 sd x1, 0x008(x2)
0x0000000000091064  22 e0                 sd x8, 0x000(x2)
0x0000000000091066  00 08                 addi x8, x2, 16
0x0000000000091068  17 b5 0a 00           auipc x10, 700416
0x000000000009106c  13 05 85 fe           addi x10, x10, -24
0x0000000000091070  03 45 05 00           lbu x10, 0x000(x10)
0x0000000000091074  05 89                 andi x10, x10, 1
0x0000000000091076  63 06 05 00           beq x10, x0, +0x00c
0x000000000009107a  6f 00 40 00           jal x0, +0x000004
0x000000000009107e  6f 00 40 05           jal x0, +0x000054
0x0000000000091082  17 b5 0a 00           auipc x10, 700416
0x0000000000091086  93 05 e5 fc           addi x11, x10, -50
0x000000000009108a  05 45                 addi x10, x0, 1
0x000000000009108c  23 80 a5 00           sb x10, 0x000(x11)
0x0000000000091090  17 95 0a 00           auipc x10, 692224
0x0000000000091094  03 35 05 46           ld x10, 0x460(x10)
0x0000000000091098  63 0d 05 00           beq x10, x0, +0x01a
0x000000000009109c  6f 00 40 00           jal x0, +0x000004
0x00000000000910a0  17 b5 0a 00           auipc x10, 700416
0x00000000000910a4  13 05 05 a0           addi x10, x10, -1536
```

and after the change (some lines wrapped or truncated for 72 columns):

```
__do_init (0x0000000000091000-0x0000000000091060):
0x0000000000091000  41 11                 addi sp, sp, -16
0x0000000000091002  06 e4                 sd ra, 0x008(sp)
0x0000000000091004  22 e0                 sd s0, 0x000(sp)
0x0000000000091006  00 08                 addi s0, sp, 16
.Lpcrel_hi0 (0x0000000000091008):
0x0000000000091008  17 b5 0a 00           auipc a0, 0x13c008 <__do_init.
0x000000000009100c  13 05 05 00           addi a0, a0, 0
0x0000000000091010  03 45 05 00           lbu a0, 0x000(a0)
0x0000000000091014  05 89                 andi a0, a0, 1
0x0000000000091016  63 06 05 00           beq a0, zero, 0x91022 <.Lpcrel
0x000000000009101a  6f 00 40 00           j 0x9101e <.LBB0_1>
.LBB0_1 (0x000000000009101e):
0x000000000009101e  6f 00 a0 03           j 0x91058 <.LBB0_4>
.LBB0_2 (0x0000000000091022):
.Lpcrel_hi1 (0x0000000000091022):
0x0000000000091022  17 b5 0a 00           auipc a0, 0x13c022 <__do_init.
0x0000000000091026  93 05 65 fe           addi a1, a0, -26
0x000000000009102a  05 45                 addi a0, zero, 1
0x000000000009102c  23 80 a5 00           sb a0, 0x000(a1)
.Lpcrel_hi2 (0x0000000000091030):
0x0000000000091030  17 95 0a 00           auipc a0, 0x13a030 <vtable for
0x0000000000091034  03 35 85 4b           ld a0, 0x4b8(a0)
0x0000000000091038  63 00 05 02           beq a0, zero, 0x91058 <.LBB0_4
0x000000000009103c  6f 00 40 00           j 0x91040 <.LBB0_3>
.LBB0_3 (0x0000000000091040):
.Lpcrel_hi3 (0x0000000000091040):
0x0000000000091040  17 85 fe ff           auipc a0, 0x79040 <.Lline_tabl
0x0000000000091044  13 05 85 10           addi a0, a0, 264
.Lpcrel_hi4 (0x0000000000091048):
0x0000000000091048  97 b5 0a 00           auipc a1, 0x13c048 <__do_init.
0x000000000009104c  93 85 85 fc           addi a1, a1, -56
0x0000000000091050  ef 10 53 0c           jal ra, 0xc2914
0x0000000000091054  6f 00 40 00           j 0x91058 <.LBB0_4>
.LBB0_4 (0x0000000000091058):
0x0000000000091058  a2 60                 ld ra, 0x008(sp)
0x000000000009105a  02 64                 ld s0, 0x000(sp)
0x000000000009105c  41 01                 addi sp, sp, 16
0x000000000009105e  82 80                 jalr zero, ra, 0x9105e <.LBB0_

__do_fini (0x0000000000091060-0x00000000000910da):
0x0000000000091060  41 11                 addi sp, sp, -16
0x0000000000091062  06 e4                 sd ra, 0x008(sp)
0x0000000000091064  22 e0                 sd s0, 0x000(sp)
0x0000000000091066  00 08                 addi s0, sp, 16
.Lpcrel_hi5 (0x0000000000091068):
0x0000000000091068  17 b5 0a 00           auipc a0, 0x13c068 <inet_ntoa:
0x000000000009106c  13 05 85 fe           addi a0, a0, -24
0x0000000000091070  03 45 05 00           lbu a0, 0x000(a0)
0x0000000000091074  05 89                 andi a0, a0, 1
0x0000000000091076  63 06 05 00           beq a0, zero, 0x91082 <.LBB1_2
0x000000000009107a  6f 00 40 00           j 0x9107e <.LBB1_1>
.LBB1_1 (0x000000000009107e):
0x000000000009107e  6f 00 40 05           j 0x910d2 <.LBB1_6>
.LBB1_2 (0x0000000000091082):
.Lpcrel_hi6 (0x0000000000091082):
0x0000000000091082  17 b5 0a 00           auipc a0, 0x13c082 <atexit_mut
0x0000000000091086  93 05 e5 fc           addi a1, a0, -50
0x000000000009108a  05 45                 addi a0, zero, 1
0x000000000009108c  23 80 a5 00           sb a0, 0x000(a1)
.Lpcrel_hi7 (0x0000000000091090):
0x0000000000091090  17 95 0a 00           auipc a0, 0x13a090 <vtable for
0x0000000000091094  03 35 05 46           ld a0, 0x460(a0)
0x0000000000091098  63 0d 05 00           beq a0, zero, 0x910b2 <.LBB1_4
0x000000000009109c  6f 00 40 00           j 0x910a0 <.LBB1_3>
.LBB1_3 (0x00000000000910a0):
.Lpcrel_hi8 (0x00000000000910a0):
0x00000000000910a0  17 b5 0a 00           auipc a0, 0x13c0a0 <__dlclose>
0x00000000000910a4  13 05 05 a0           addi a0, a0, -1536
0x00000000000910a8  08 61                 ld a0, 0x000(a0)
0x00000000000910aa  ef 40 a0 15           jal ra, 0x95204
0x00000000000910ae  6f 00 40 00           j 0x910b2 <.LBB1_4>
.LBB1_4 (0x00000000000910b2):
.Lpcrel_hi9 (0x00000000000910b2):
0x00000000000910b2  17 95 0a 00           auipc a0, 0x13a0b2 <vtable for
0x00000000000910b6  03 35 65 44           ld a0, 0x446(a0)
0x00000000000910ba  63 0c 05 00           beq a0, zero, 0x910d2 <.LBB1_6
0x00000000000910be  6f 00 40 00           j 0x910c2 <.Lpcrel_hi10>
.LBB1_5 (0x00000000000910c2):
.Lpcrel_hi10 (0x00000000000910c2):
0x00000000000910c2  17 85 fe ff           auipc a0, 0x790c2 <.Lline_tabl
0x00000000000910c6  13 05 65 08           addi a0, a0, 134
0x00000000000910ca  ef 10 b3 05           jal ra, 0xc2924 <__deregister_
0x00000000000910ce  6f 00 40 00           j 0x910d2 <.LBB1_6>
.LBB1_6 (0x00000000000910d2):
0x00000000000910d2  a2 60                 ld ra, 0x008(sp)
0x00000000000910d4  02 64                 ld s0, 0x000(sp)
0x00000000000910d6  41 01                 addi sp, sp, 16
0x00000000000910d8  82 80                 jalr zero, ra, 0x910d8 <.LBB1_

0x00000000000910da  00 00                 addi s0, sp, 0

TimeZone::time_zone_from_string(AK::StringView)
                                (0x00000000000910dc-0x0000000000091198):
0x00000000000910dc  41 11                 addi sp, sp, -16
0x00000000000910de  06 e4                 sd ra, 0x008(sp)
0x00000000000910e0  22 e0                 sd s0, 0x000(sp)
0x00000000000910e2  00 08                 addi s0, sp, 16
0x00000000000910e4  29 c2                 beq a2, zero, 0x91126 <.LBB0_4
0x00000000000910e6  81 46                 addi a3, zero, 0
.LBB0_2 (0x00000000000910e8):
0x00000000000910e8  03 c7 05 00           lbu a4, 0x000(a1)
0x00000000000910ec  9b 07 f7 fb           addiw a5, a4, -65
0x00000000000910f0  93 f7 f7 0f           andi a5, a5, 255
0x00000000000910f4  93 b7 a7 01           sltiu a5, a5, 26
0x00000000000910f8  96 07                 slli a5, a5, 5
0x00000000000910fa  ba 96                 add a3, a3, a4
0x00000000000910fc  be 96                 add a3, a3, a5
0x00000000000910fe  13 97 a6 00           slli a4, a3, 10
0x0000000000091102  ba 96                 add a3, a3, a4
0x0000000000091104  1b d7 66 00           sraiw a4, a3, 6
0x0000000000091108  b9 8e                 xor a3, a3, a4
0x000000000009110a  7d 16                 addi a2, a2, -1
0x000000000009110c  85 05                 addi a1, a1, 1
0x000000000009110e  69 fe                 bne a2, zero, 0x910e8
0x0000000000091110  93 95 36 00           slli a1, a3, 3
0x0000000000091114  b6 95                 add a1, a1, a3
0x0000000000091116  1b d6 b5 00           sraiw a2, a1, 11
0x000000000009111a  b1 8d                 xor a1, a1, a2
0x000000000009111c  13 96 f5 00           slli a2, a1, 15
0x0000000000091120  bb 02 b6 00           addw t0, a2, a1
0x0000000000091124  11 a0                 j 0x91128 <.LBB0_5>
.LBB0_4 (0x0000000000091126):
0x0000000000091126  81 42                 addi t0, zero, 0
.LBB0_5 (0x0000000000091128):
0x0000000000091128  01 46                 addi a2, zero, 0
0x000000000009112a  93 07 30 25           addi a5, zero, 595
0x000000000009112e  13 08 40 25           addi a6, zero, 596
.Lpcrel_hi0 (0x0000000000091132):
0x0000000000091132  97 35 f9 ff           auipc a1, 0x24132
0x0000000000091136  93 88 a5 76           addi a7, a1, 1898
.LBB0_6 (0x000000000009113a):
0x000000000009113a  b3 85 c7 40           sub a1, a5, a2
0x000000000009113e  85 81                 sub a1, a1, s1
0x0000000000091140  33 87 c5 00           add a4, a1, a2
0x0000000000091144  63 74 07 05           bgeu a4, a6, 0x9118c <.Lpcrel_
0x0000000000091148  93 16 37 00           slli a3, a4, 3
0x000000000009114c  c6 96                 add a3, a3, a7
```

### disasm: Allow disassembling just one symbol

This is done in a crude way for now in that we
disassemble all instructions up to the symbol without printing them.
