### PR TITLE
Kernel/riscv64: Make the kernel compile

### DIFF
--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -544,16 +544,17 @@ struct SC_faccessat_params {
 void initialize();
 int sync();
 
-#    if ARCH(X86_64) || ARCH(AARCH64)
+#    if ARCH(X86_64) || ARCH(AARCH64) || ARCH(RISCV64)
 inline uintptr_t invoke(Function function)
 {
-    uintptr_t result;
 #        if ARCH(X86_64)
+    uintptr_t result;
     asm volatile("syscall"
                  : "=a"(result)
                  : "a"(function)
                  : "rcx", "r11", "memory");
 #        elif ARCH(AARCH64)
+    uintptr_t result;
     register uintptr_t x0 asm("x0");
     register uintptr_t x8 asm("x8") = function;
     asm volatile("svc #0"
@@ -561,6 +562,13 @@ inline uintptr_t invoke(Function function)
                  : "r"(x8)
                  : "memory");
     result = x0;
+#        elif ARCH(RISCV64)
+    register uintptr_t a7 asm("a7") = function;
+    register uintptr_t result asm("a0");
+    asm volatile("ecall"
+                 : "=r"(result)
+                 : "r"(a7)
+                 : "memory");
 #        endif
     return result;
 }
@@ -568,13 +576,14 @@ inline uintptr_t invoke(Function function)
 template<typename T1>
 inline uintptr_t invoke(Function function, T1 arg1)
 {
-    uintptr_t result;
 #        if ARCH(X86_64)
+    uintptr_t result;
     asm volatile("syscall"
                  : "=a"(result)
                  : "a"(function), "d"((uintptr_t)arg1)
                  : "rcx", "r11", "memory");
 #        elif ARCH(AARCH64)
+    uintptr_t result;
     register uintptr_t x0 asm("x0");
     register uintptr_t x1 asm("x1") = arg1;
     register uintptr_t x8 asm("x8") = function;
@@ -583,6 +592,14 @@ inline uintptr_t invoke(Function function, T1 arg1)
                  : "r"(x1), "r"(x8)
                  : "memory");
     result = x0;
+#        elif ARCH(RISCV64)
+    register uintptr_t a0 asm("a0") = arg1;
+    register uintptr_t a7 asm("a7") = function;
+    register uintptr_t result asm("a0");
+    asm volatile("ecall"
+                 : "=r"(result)
+                 : "0"(a0), "r"(a7)
+                 : "memory");
 #        endif
     return result;
 }
@@ -590,13 +607,14 @@ inline uintptr_t invoke(Function function, T1 arg1)
 template<typename T1, typename T2>
 inline uintptr_t invoke(Function function, T1 arg1, T2 arg2)
 {
-    uintptr_t result;
 #        if ARCH(X86_64)
+    uintptr_t result;
     asm volatile("syscall"
                  : "=a"(result)
                  : "a"(function), "d"((uintptr_t)arg1), "D"((uintptr_t)arg2)
                  : "rcx", "r11", "memory");
 #        elif ARCH(AARCH64)
+    uintptr_t result;
     register uintptr_t x0 asm("x0");
     register uintptr_t x1 asm("x1") = arg1;
     register uintptr_t x2 asm("x2") = arg2;
@@ -606,6 +624,15 @@ inline uintptr_t invoke(Function function, T1 arg1, T2 arg2)
                  : "r"(x1), "r"(x2), "r"(x8)
                  : "memory");
     result = x0;
+#        elif ARCH(RISCV64)
+    register uintptr_t a0 asm("a0") = arg1;
+    register uintptr_t a1 asm("a1") = arg2;
+    register uintptr_t a7 asm("a7") = function;
+    register uintptr_t result asm("a0");
+    asm volatile("ecall"
+                 : "=r"(result)
+                 : "0"(a0), "r"(a1), "r"(a7)
+                 : "memory");
 #        endif
     return result;
 }
@@ -613,13 +640,14 @@ inline uintptr_t invoke(Function function, T1 arg1, T2 arg2)
 template<typename T1, typename T2, typename T3>
 inline uintptr_t invoke(Function function, T1 arg1, T2 arg2, T3 arg3)
 {
-    uintptr_t result;
 #        if ARCH(X86_64)
+    uintptr_t result;
     asm volatile("syscall"
                  : "=a"(result)
                  : "a"(function), "d"((uintptr_t)arg1), "D"((uintptr_t)arg2), "b"((uintptr_t)arg3)
                  : "rcx", "r11", "memory");
 #        elif ARCH(AARCH64)
+    uintptr_t result;
     register uintptr_t x0 asm("x0");
     register uintptr_t x1 asm("x1") = arg1;
     register uintptr_t x2 asm("x2") = arg2;
@@ -630,6 +658,16 @@ inline uintptr_t invoke(Function function, T1 arg1, T2 arg2, T3 arg3)
                  : "r"(x1), "r"(x2), "r"(x3), "r"(x8)
                  : "memory");
     result = x0;
+#        elif ARCH(RISCV64)
+    register uintptr_t a0 asm("a0") = arg1;
+    register uintptr_t a1 asm("a1") = arg2;
+    register uintptr_t a2 asm("a2") = arg3;
+    register uintptr_t a7 asm("a7") = function;
+    register uintptr_t result asm("a0");
+    asm volatile("ecall"
+                 : "=r"(result)
+                 : "0"(a0), "r"(a1), "r"(a2), "r"(a7)
+                 : "memory");
 #        endif
     return result;
 }
@@ -637,13 +675,14 @@ inline uintptr_t invoke(Function function, T1 arg1, T2 arg2, T3 arg3)
 template<typename T1, typename T2, typename T3, typename T4>
 inline uintptr_t invoke(Function function, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
 {
-    uintptr_t result;
 #        if ARCH(X86_64)
+    uintptr_t result;
     asm volatile("syscall"
                  : "=a"(result)
                  : "a"(function), "d"((uintptr_t)arg1), "D"((uintptr_t)arg2), "b"((uintptr_t)arg3), "S"((uintptr_t)arg4)
                  : "memory");
 #        elif ARCH(AARCH64)
+    uintptr_t result;
     register uintptr_t x0 asm("x0");
     register uintptr_t x1 asm("x1") = arg1;
     register uintptr_t x2 asm("x2") = arg2;
@@ -655,6 +694,17 @@ inline uintptr_t invoke(Function function, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
                  : "r"(x1), "r"(x2), "r"(x3), "r"(x4), "r"(x8)
                  : "memory");
     result = x0;
+#        elif ARCH(RISCV64)
+    register uintptr_t a0 asm("a0") = arg1;
+    register uintptr_t a1 asm("a1") = arg2;
+    register uintptr_t a2 asm("a2") = arg3;
+    register uintptr_t a3 asm("a3") = arg4;
+    register uintptr_t a7 asm("a7") = function;
+    register uintptr_t result asm("a0");
+    asm volatile("ecall"
+                 : "=r"(result)
+                 : "0"(a0), "r"(a1), "r"(a2), "r"(a3), "r"(a7)
+                 : "memory");
 #        endif
     return result;
 }

--- a/Kernel/Arch/CPU.h
+++ b/Kernel/Arch/CPU.h
@@ -20,6 +20,8 @@
 #    include <Kernel/Arch/x86_64/CPU.h>
 #elif ARCH(AARCH64)
 #    include <Kernel/Arch/aarch64/CPU.h>
+#elif ARCH(RISCV64)
+#    include <Kernel/Arch/riscv64/CPU.h>
 #else
 #    error "Unknown architecture"
 #endif

--- a/Kernel/Arch/IRQController.h
+++ b/Kernel/Arch/IRQController.h
@@ -12,6 +12,8 @@
 #    include <Kernel/Arch/x86_64/IRQController.h>
 #elif ARCH(AARCH64)
 #    include <Kernel/Arch/aarch64/IRQController.h>
+#elif ARCH(RISCV64)
+#    include <Kernel/Arch/riscv64/IRQController.h>
 #else
 #    error "Unknown architecture"
 #endif

--- a/Kernel/Arch/InterruptManagement.h
+++ b/Kernel/Arch/InterruptManagement.h
@@ -12,6 +12,8 @@
 #    include <Kernel/Arch/x86_64/InterruptManagement.h>
 #elif ARCH(AARCH64)
 #    include <Kernel/Arch/aarch64/InterruptManagement.h>
+#elif ARCH(RISCV64)
+#    include <Kernel/Arch/riscv64/InterruptManagement.h>
 #else
 #    error "Unknown architecture"
 #endif

--- a/Kernel/Arch/Interrupts.h
+++ b/Kernel/Arch/Interrupts.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Error.h>
 #include <AK/Platform.h>
 #include <AK/Types.h>
 

--- a/Kernel/Arch/PCIMSI.h
+++ b/Kernel/Arch/PCIMSI.h
@@ -14,7 +14,7 @@ u64 msi_address_register(u8 destination_id, bool redirection_hint, bool destinat
 u32 msi_data_register(u8 vector, bool level_trigger, bool assert);
 u32 msix_vector_control_register(u32 vector_control, bool mask);
 void msi_signal_eoi();
-#elif ARCH(AARCH64)
+#elif ARCH(AARCH64) || ARCH(RISCV64)
 [[maybe_unused]] static u64 msi_address_register([[maybe_unused]] u8 destination_id, [[maybe_unused]] bool redirection_hint, [[maybe_unused]] bool destination_mode)
 {
     TODO_AARCH64();

--- a/Kernel/Arch/PageDirectory.h
+++ b/Kernel/Arch/PageDirectory.h
@@ -13,6 +13,8 @@
 #    include <Kernel/Arch/x86_64/PageDirectory.h>
 #elif ARCH(AARCH64)
 #    include <Kernel/Arch/aarch64/PageDirectory.h>
+#elif ARCH(RISCV64)
+#    include <Kernel/Arch/riscv64/PageDirectory.h>
 #else
 #    error "Unknown architecture"
 #endif

--- a/Kernel/Arch/riscv64/CPU.h
+++ b/Kernel/Arch/riscv64/CPU.h
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2023, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Platform.h>
+VALIDATE_IS_RISCV64()

--- a/Kernel/Arch/riscv64/DebugOutput.cpp
+++ b/Kernel/Arch/riscv64/DebugOutput.cpp
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2023, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/Library/Assertions.h>
+
+namespace Kernel {
+
+void debug_output(char)
+{
+    TODO_RISCV64();
+}
+
+}

--- a/Kernel/Arch/riscv64/Delay.cpp
+++ b/Kernel/Arch/riscv64/Delay.cpp
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2023, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/Arch/Delay.h>
+
+namespace Kernel {
+
+void microseconds_delay(u32)
+{
+    TODO_RISCV64();
+}
+
+}

--- a/Kernel/Arch/riscv64/Firmware/ACPI/StaticParsing.cpp
+++ b/Kernel/Arch/riscv64/Firmware/ACPI/StaticParsing.cpp
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2023, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/Firmware/ACPI/StaticParsing.h>
+
+namespace Kernel::ACPI::StaticParsing {
+
+ErrorOr<Optional<PhysicalAddress>> find_rsdp_in_platform_specific_memory_locations()
+{
+    // FIXME: Implement finding RSDP for riscv64.
+    return Optional<PhysicalAddress> {};
+}
+
+}

--- a/Kernel/Arch/riscv64/IRQController.h
+++ b/Kernel/Arch/riscv64/IRQController.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2023, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/AtomicRefCounted.h>
+#include <AK/StringView.h>
+#include <AK/Types.h>
+
+#include <Kernel/Interrupts/GenericInterruptHandler.h>
+
+#include <AK/Platform.h>
+VALIDATE_IS_RISCV64()
+
+namespace Kernel {
+
+class IRQController : public AtomicRefCounted<IRQController> {
+public:
+    virtual ~IRQController() = default;
+
+    virtual void enable(GenericInterruptHandler const&) = 0;
+    virtual void disable(GenericInterruptHandler const&) = 0;
+
+    virtual void eoi(GenericInterruptHandler const&) const = 0;
+
+    virtual u64 pending_interrupts() const = 0;
+
+    virtual StringView model() const = 0;
+
+protected:
+    IRQController() = default;
+};
+
+}

--- a/Kernel/Arch/riscv64/InterruptController.h
+++ b/Kernel/Arch/riscv64/InterruptController.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2023, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/StringView.h>
+#include <AK/Types.h>
+#include <Kernel/Arch/riscv64/IRQController.h>
+
+#include <AK/Platform.h>
+VALIDATE_IS_RISCV64()
+
+namespace Kernel::RISCV64 {
+
+class InterruptController : public IRQController {
+public:
+    InterruptController();
+
+private:
+    virtual void enable(GenericInterruptHandler const&) override;
+    virtual void disable(GenericInterruptHandler const&) override;
+
+    virtual void eoi(GenericInterruptHandler const&) const override;
+
+    virtual u64 pending_interrupts() const override;
+
+    virtual StringView model() const override
+    {
+        return "cpu-intc"sv;
+    }
+};
+
+}

--- a/Kernel/Arch/riscv64/InterruptManagement.cpp
+++ b/Kernel/Arch/riscv64/InterruptManagement.cpp
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2023, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/Arch/Interrupts.h>
+#include <Kernel/Arch/riscv64/IRQController.h>
+#include <Kernel/Arch/riscv64/InterruptManagement.h>
+#include <Kernel/Interrupts/SharedIRQHandler.h>
+
+namespace Kernel {
+
+static InterruptManagement* s_interrupt_management;
+
+bool InterruptManagement::initialized()
+{
+    return s_interrupt_management != nullptr;
+}
+
+InterruptManagement& InterruptManagement::the()
+{
+    VERIFY(InterruptManagement::initialized());
+    return *s_interrupt_management;
+}
+
+void InterruptManagement::initialize()
+{
+    VERIFY(!InterruptManagement::initialized());
+    s_interrupt_management = new InterruptManagement;
+
+    the().find_controllers();
+}
+
+void InterruptManagement::find_controllers()
+{
+    TODO_RISCV64();
+}
+
+u8 InterruptManagement::acquire_mapped_interrupt_number(u8)
+{
+    TODO_RISCV64();
+}
+
+Vector<NonnullLockRefPtr<IRQController>> const& InterruptManagement::controllers()
+{
+    return m_interrupt_controllers;
+}
+
+NonnullLockRefPtr<IRQController> InterruptManagement::get_responsible_irq_controller(size_t)
+{
+    TODO_RISCV64();
+}
+
+void InterruptManagement::enumerate_interrupt_handlers(Function<void(GenericInterruptHandler&)>)
+{
+    TODO_RISCV64();
+}
+
+}

--- a/Kernel/Arch/riscv64/InterruptManagement.h
+++ b/Kernel/Arch/riscv64/InterruptManagement.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2023, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Vector.h>
+#include <Kernel/Arch/riscv64/IRQController.h>
+
+#include <AK/Platform.h>
+VALIDATE_IS_RISCV64()
+
+namespace Kernel {
+
+class InterruptManagement {
+public:
+    static InterruptManagement& the();
+    static void initialize();
+    static bool initialized();
+
+    static u8 acquire_mapped_interrupt_number(u8 original_irq);
+
+    Vector<NonnullLockRefPtr<IRQController>> const& controllers();
+    NonnullLockRefPtr<IRQController> get_responsible_irq_controller(size_t irq_number);
+
+    void enumerate_interrupt_handlers(Function<void(GenericInterruptHandler&)>);
+
+private:
+    InterruptManagement() = default;
+    void find_controllers();
+
+    Vector<NonnullLockRefPtr<IRQController>> m_interrupt_controllers;
+};
+
+}

--- a/Kernel/Arch/riscv64/Interrupts.cpp
+++ b/Kernel/Arch/riscv64/Interrupts.cpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2023, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Error.h>
+#include <AK/Types.h>
+
+#include <Kernel/Arch/TrapFrame.h>
+#include <Kernel/Interrupts/GenericInterruptHandler.h>
+
+namespace Kernel {
+
+void dump_registers(RegisterState const&)
+{
+}
+
+// FIXME: Share the code below with Arch/x86_64/Interrupts.cpp
+//        While refactoring, the interrupt handlers can also be moved into the InterruptManagement class.
+GenericInterruptHandler& get_interrupt_handler(u8)
+{
+    TODO_RISCV64();
+}
+
+// Sets the reserved flag on `number_of_irqs` if it finds unused interrupt handler on
+// a contiguous range.
+ErrorOr<u8> reserve_interrupt_handlers(u8)
+{
+    TODO_RISCV64();
+}
+
+void register_generic_interrupt_handler(u8, GenericInterruptHandler&)
+{
+    TODO_RISCV64();
+}
+
+void unregister_generic_interrupt_handler(u8, GenericInterruptHandler&)
+{
+}
+
+void initialize_interrupts()
+{
+    TODO_RISCV64();
+}
+
+}

--- a/Kernel/Arch/riscv64/PCI.cpp
+++ b/Kernel/Arch/riscv64/PCI.cpp
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2023, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/Library/Assertions.h>
+
+namespace Kernel::PCI {
+
+bool g_pci_access_io_probe_failed { false };
+bool g_pci_access_is_disabled_from_commandline { true };
+
+void initialize()
+{
+    TODO_RISCV64();
+}
+
+}

--- a/Kernel/Arch/riscv64/PageDirectory.cpp
+++ b/Kernel/Arch/riscv64/PageDirectory.cpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2023, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Format.h>
+#include <AK/Singleton.h>
+
+#include <Kernel/Arch/PageDirectory.h>
+#include <Kernel/Library/LockRefPtr.h>
+#include <Kernel/Sections.h>
+
+namespace Kernel::Memory {
+
+void PageDirectory::register_page_directory(PageDirectory*)
+{
+    TODO_RISCV64();
+}
+
+void PageDirectory::deregister_page_directory(PageDirectory*)
+{
+    TODO_RISCV64();
+}
+
+ErrorOr<NonnullLockRefPtr<PageDirectory>> PageDirectory::try_create_for_userspace(Process&)
+{
+    TODO_RISCV64();
+}
+
+LockRefPtr<PageDirectory> PageDirectory::find_current()
+{
+    TODO_RISCV64();
+}
+
+void activate_kernel_page_directory(PageDirectory const&)
+{
+    TODO_RISCV64();
+}
+
+void activate_page_directory(PageDirectory const&, Thread*)
+{
+    TODO_RISCV64();
+}
+
+UNMAP_AFTER_INIT NonnullLockRefPtr<PageDirectory> PageDirectory::must_create_kernel_page_directory()
+{
+    return adopt_lock_ref_if_nonnull(new (nothrow) PageDirectory).release_nonnull();
+}
+
+PageDirectory::PageDirectory() = default;
+
+UNMAP_AFTER_INIT void PageDirectory::allocate_kernel_directory()
+{
+    TODO_RISCV64();
+}
+
+PageDirectory::~PageDirectory()
+{
+    if (is_root_table_initialized()) {
+        deregister_page_directory(this);
+    }
+}
+
+}

--- a/Kernel/Arch/riscv64/PageDirectory.h
+++ b/Kernel/Arch/riscv64/PageDirectory.h
@@ -1,0 +1,208 @@
+/*
+ * Copyright (c) 2023, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/AtomicRefCounted.h>
+#include <AK/IntrusiveRedBlackTree.h>
+#include <AK/RefPtr.h>
+
+#include <Kernel/Forward.h>
+#include <Kernel/Locking/Spinlock.h>
+#include <Kernel/Memory/PhysicalAddress.h>
+#include <Kernel/Memory/PhysicalPage.h>
+
+#include <AK/Platform.h>
+VALIDATE_IS_RISCV64()
+
+namespace Kernel::Memory {
+
+// Documentation for RISC-V Virtual Memory:
+// The RISC-V Instruction Set Manual, Volume II: Privileged Architecture
+// https://github.com/riscv/riscv-isa-manual/releases/download/Priv-v1.12/riscv-privileged-20211203.pdf
+
+// Currently, only the Sv39 (3 level paging) virtual memory system is implemented
+
+// Figure 4.19-4.21
+constexpr size_t PAGE_TABLE_SHIFT = 12;
+constexpr size_t PAGE_TABLE_SIZE = 1LU << PAGE_TABLE_SHIFT;
+
+constexpr size_t PADDR_PPN_OFFSET = PAGE_TABLE_SHIFT;
+constexpr size_t VADDR_VPN_OFFSET = PAGE_TABLE_SHIFT;
+constexpr size_t PTE_PPN_OFFSET = 10;
+
+constexpr size_t PPN_SIZE = 26 + 9 + 9;
+constexpr size_t VPN_SIZE = 9 + 9 + 9;
+
+constexpr size_t VPN_2_OFFSET = 30;
+constexpr size_t VPN_1_OFFSET = 21;
+constexpr size_t VPN_0_OFFSET = 12;
+
+constexpr size_t PPN_MASK = (1LU << PPN_SIZE) - 1;
+constexpr size_t PTE_PPN_MASK = PPN_MASK << PTE_PPN_OFFSET;
+
+constexpr size_t PAGE_TABLE_INDEX_MASK = 0x1ff;
+
+enum class PageTableEntryBits {
+    Valid = 1 << 0,
+    Readable = 1 << 1,
+    Writeable = 1 << 2,
+    Executable = 1 << 3,
+    UserAllowed = 1 << 4,
+    Global = 1 << 5,
+    Accessed = 1 << 6,
+    Dirty = 1 << 7,
+};
+AK_ENUM_BITWISE_OPERATORS(PageTableEntryBits);
+
+class PageDirectoryEntry {
+public:
+    PhysicalPtr page_table_base() const { return (m_raw >> PTE_PPN_OFFSET) << PADDR_PPN_OFFSET; }
+    void set_page_table_base(PhysicalPtr value)
+    {
+        m_raw &= ~PTE_PPN_MASK;
+        m_raw |= (value >> PADDR_PPN_OFFSET) << PTE_PPN_OFFSET;
+    }
+
+    void clear() { m_raw = 0; }
+
+    bool is_present() const { return (m_raw & to_underlying(PageTableEntryBits::Valid)) != 0; }
+    void set_present(bool b) { set_bit(PageTableEntryBits::Valid, b); }
+
+    bool is_user_allowed() const { TODO_RISCV64(); }
+    void set_user_allowed(bool) { }
+
+    bool is_writable() const { TODO_RISCV64(); }
+    void set_writable(bool) { }
+
+    bool is_global() const { TODO_RISCV64(); }
+    void set_global(bool) { }
+
+private:
+    void set_bit(PageTableEntryBits bit, bool value)
+    {
+        if (value)
+            m_raw |= to_underlying(bit);
+        else
+            m_raw &= ~to_underlying(bit);
+    }
+
+    u64 m_raw;
+};
+
+class PageTableEntry {
+public:
+    PhysicalPtr physical_page_base() const { return PhysicalAddress::physical_page_base(m_raw); }
+    void set_physical_page_base(PhysicalPtr value)
+    {
+        m_raw &= ~PTE_PPN_MASK;
+        m_raw |= (value >> PADDR_PPN_OFFSET) << PTE_PPN_OFFSET;
+    }
+
+    bool is_present() const { return (m_raw & to_underlying(PageTableEntryBits::Valid)) != 0; }
+    void set_present(bool b)
+    {
+        set_bit(PageTableEntryBits::Valid, b);
+        set_bit(PageTableEntryBits::Readable, b);
+
+        // Always set the A/D bits as we don't know if the hardware updates them automatically.
+        // If the hardware doesn't update them automatically they act like additional permission bits.
+        set_bit(PageTableEntryBits::Accessed, b);
+        set_bit(PageTableEntryBits::Dirty, b);
+    }
+
+    bool is_user_allowed() const { TODO_RISCV64(); }
+    void set_user_allowed(bool b) { set_bit(PageTableEntryBits::UserAllowed, b); }
+
+    bool is_writable() const { return (m_raw & to_underlying(PageTableEntryBits::Writeable)) != 0; }
+    void set_writable(bool b) { set_bit(PageTableEntryBits::Writeable, b); }
+
+    bool is_cache_disabled() const { TODO_RISCV64(); }
+    void set_cache_disabled(bool) { }
+
+    bool is_global() const { TODO_RISCV64(); }
+    void set_global(bool b) { set_bit(PageTableEntryBits::Global, b); }
+
+    bool is_execute_disabled() const { TODO_RISCV64(); }
+    void set_execute_disabled(bool b) { set_bit(PageTableEntryBits::Executable, !b); }
+
+    bool is_pat() const { TODO_RISCV64(); }
+    void set_pat(bool) { }
+
+    bool is_null() const { return m_raw == 0; }
+    void clear() { m_raw = 0; }
+
+private:
+    void set_bit(PageTableEntryBits bit, bool value)
+    {
+        if (value)
+            m_raw |= to_underlying(bit);
+        else
+            m_raw &= ~to_underlying(bit);
+    }
+
+    u64 m_raw;
+};
+
+class PageDirectoryPointerTable {
+public:
+    PageDirectoryEntry* directory(size_t index)
+    {
+        VERIFY(index <= (NumericLimits<size_t>::max() << 30));
+        return (PageDirectoryEntry*)(PhysicalAddress::physical_page_base(raw[index]));
+    }
+
+    u64 raw[512];
+};
+
+class PageDirectory final : public AtomicRefCounted<PageDirectory> {
+    friend class MemoryManager;
+
+public:
+    static ErrorOr<NonnullLockRefPtr<PageDirectory>> try_create_for_userspace(Process&);
+    static NonnullLockRefPtr<PageDirectory> must_create_kernel_page_directory();
+    static LockRefPtr<PageDirectory> find_current();
+
+    ~PageDirectory();
+
+    void allocate_kernel_directory();
+
+    RISCV64::CSR::SATP satp() const
+    {
+        return {
+            .PPN = m_directory_table->paddr().get() >> PADDR_PPN_OFFSET,
+            .ASID = 0,
+            .MODE = RISCV64::CSR::SATP::Mode::Sv39,
+        };
+    }
+
+    bool is_root_table_initialized() const
+    {
+        return m_directory_table != nullptr;
+    }
+
+    Process* process() { return m_process; }
+
+    RecursiveSpinlock<LockRank::None>& get_lock() { return m_lock; }
+
+    // This has to be public to let the global singleton access the member pointer
+    IntrusiveRedBlackTreeNode<FlatPtr, PageDirectory, RawPtr<PageDirectory>> m_tree_node;
+
+private:
+    PageDirectory();
+    static void register_page_directory(PageDirectory* directory);
+    static void deregister_page_directory(PageDirectory* directory);
+
+    Process* m_process { nullptr };
+    RefPtr<PhysicalPage> m_directory_table;
+    RefPtr<PhysicalPage> m_directory_pages[512];
+    RecursiveSpinlock<LockRank::None> m_lock {};
+};
+
+void activate_kernel_page_directory(PageDirectory const& page_directory);
+void activate_page_directory(PageDirectory const& page_directory, Thread* current_thread);
+
+}

--- a/Kernel/Arch/riscv64/Panic.cpp
+++ b/Kernel/Arch/riscv64/Panic.cpp
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2022, Timon Kruiper <timonkruiper@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/Arch/Processor.h>
+#include <Kernel/KSyms.h>
+#include <Kernel/Library/Panic.h>
+
+// FIXME: Merge the code in this file with Kernel/Library/Panic.cpp once the proper abstractions are in place.
+
+// Note: This is required here, since __assertion_failed should be out of the Kernel namespace,
+//       but the PANIC macro uses functions that require the Kernel namespace.
+using namespace Kernel;
+
+[[noreturn]] void __assertion_failed(char const* msg, char const* file, unsigned line, char const* func)
+{
+    critical_dmesgln("ASSERTION FAILED: {}", msg);
+    critical_dmesgln("{}:{} in {}", file, line, func);
+
+    // Used for printing a nice backtrace!
+    PANIC("Aborted");
+}

--- a/Kernel/Arch/riscv64/PowerState.cpp
+++ b/Kernel/Arch/riscv64/PowerState.cpp
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2023, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/Arch/PowerState.h>
+
+namespace Kernel {
+
+void arch_specific_reboot()
+{
+    TODO_RISCV64();
+}
+
+void arch_specific_poweroff()
+{
+    TODO_RISCV64();
+}
+
+}

--- a/Kernel/Arch/riscv64/SafeMem.cpp
+++ b/Kernel/Arch/riscv64/SafeMem.cpp
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2022, Timon Kruiper <timonkruiper@gmail.com>
+ * Copyright (c) 2023, Daniel Bertalan <dani@danielbertalan.dev>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/Arch/RegisterState.h>
+#include <Kernel/Arch/SafeMem.h>
+#include <Kernel/Library/StdLib.h>
+
+#define CODE_SECTION(section_name) __attribute__((section(section_name)))
+
+extern "C" u8 start_of_safemem_text[];
+extern "C" u8 end_of_safemem_text[];
+
+extern "C" u8 start_of_safemem_atomic_text[];
+extern "C" u8 end_of_safemem_atomic_text[];
+
+namespace Kernel {
+
+CODE_SECTION(".text.safemem")
+NEVER_INLINE FLATTEN bool safe_memset(void* dest_ptr, int c, size_t n, void*& fault_at)
+{
+    // FIXME: Actually implement a safe memset.
+    auto* dest = static_cast<u8*>(dest_ptr);
+    for (; n--;)
+        *dest++ = c;
+    fault_at = nullptr;
+    return true;
+}
+
+CODE_SECTION(".text.safemem")
+NEVER_INLINE FLATTEN ssize_t safe_strnlen(char const* str, unsigned long max_n, void*& fault_at)
+{
+    // FIXME: Actually implement a safe strnlen.
+    size_t len = 0;
+    for (; len < max_n && *str; str++)
+        len++;
+    fault_at = nullptr;
+    return len;
+}
+
+CODE_SECTION(".text.safemem")
+NEVER_INLINE FLATTEN bool safe_memcpy(void* dest_ptr, void const* src_ptr, unsigned long n, void*& fault_at)
+{
+    // FIXME: Actually implement a safe memcpy.
+    auto* pd = static_cast<u8*>(dest_ptr);
+    auto const* ps = static_cast<u8 const*>(src_ptr);
+    for (; n--;)
+        *pd++ = *ps++;
+    fault_at = nullptr;
+    return true;
+}
+
+CODE_SECTION(".text.safemem.atomic")
+NEVER_INLINE FLATTEN Optional<bool> safe_atomic_compare_exchange_relaxed(u32 volatile* var, u32& expected, u32 val)
+{
+    // FIXME: Handle access faults.
+    return AK::atomic_compare_exchange_strong(var, expected, val, AK::memory_order_relaxed);
+}
+
+CODE_SECTION(".text.safemem.atomic")
+NEVER_INLINE FLATTEN Optional<u32> safe_atomic_load_relaxed(u32 volatile* var)
+{
+    // FIXME: Handle access faults.
+    return AK::atomic_load(var, AK::memory_order_relaxed);
+}
+
+CODE_SECTION(".text.safemem.atomic")
+NEVER_INLINE FLATTEN Optional<u32> safe_atomic_fetch_add_relaxed(u32 volatile* var, u32 val)
+{
+    // FIXME: Handle access faults.
+    return AK::atomic_fetch_add(var, val, AK::memory_order_relaxed);
+}
+
+CODE_SECTION(".text.safemem.atomic")
+NEVER_INLINE FLATTEN Optional<u32> safe_atomic_exchange_relaxed(u32 volatile* var, u32 val)
+{
+    // FIXME: Handle access faults.
+    return AK::atomic_exchange(var, val, AK::memory_order_relaxed);
+}
+
+CODE_SECTION(".text.safemem.atomic")
+NEVER_INLINE FLATTEN bool safe_atomic_store_relaxed(u32 volatile* var, u32 val)
+{
+    // FIXME: Handle access faults.
+    AK::atomic_store(var, val);
+    return true;
+}
+
+bool handle_safe_access_fault(RegisterState& regs, FlatPtr fault_address)
+{
+    FlatPtr ip = regs.ip();
+
+    if (ip >= (FlatPtr)&start_of_safemem_text && ip < (FlatPtr)&end_of_safemem_text) {
+        dbgln("FIXME: Faulted while accessing userspace address {:p}.", fault_address);
+        dbgln("       We need to jump back into the appropriate SafeMem function, set fault_at and return failure.");
+        TODO_RISCV64();
+    } else if (ip >= (FlatPtr)&start_of_safemem_atomic_text && ip < (FlatPtr)&end_of_safemem_atomic_text) {
+        dbgln("FIXME: Faulted while accessing userspace address {:p}.", fault_address);
+        dbgln("       We need to jump back into the appropriate atomic SafeMem function and return failure.");
+        TODO_RISCV64();
+    }
+
+    return false;
+}
+
+}

--- a/Kernel/Arch/riscv64/SmapDisabler.cpp
+++ b/Kernel/Arch/riscv64/SmapDisabler.cpp
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2023, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/Arch/SmapDisabler.h>
+#include <Kernel/Arch/riscv64/CSR.h>
+
+namespace Kernel {
+
+SmapDisabler::SmapDisabler()
+    : m_flags(RISCV64::CSR::read_and_set_bits(RISCV64::CSR::Address::SSTATUS, 1 << to_underlying(RISCV64::CSR::SSTATUS::Offset::SUM)))
+{
+}
+
+SmapDisabler::~SmapDisabler()
+{
+    if ((m_flags & (1 << to_underlying(RISCV64::CSR::SSTATUS::Offset::SUM))) == 0)
+        RISCV64::CSR::clear_bits(RISCV64::CSR::Address::SSTATUS, 1 << to_underlying(RISCV64::CSR::SSTATUS::Offset::SUM));
+}
+
+}

--- a/Kernel/Arch/riscv64/pre_init.cpp
+++ b/Kernel/Arch/riscv64/pre_init.cpp
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2023, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Types.h>
+
+#include <Kernel/Arch/Processor.h>
+#include <Kernel/Memory/PhysicalAddress.h>
+
+namespace Kernel {
+
+extern "C" [[noreturn]] void pre_init(FlatPtr mhartid, PhysicalPtr fdt_phys_addr);
+extern "C" [[noreturn]] void pre_init(FlatPtr mhartid, PhysicalPtr fdt_phys_addr)
+{
+    (void)mhartid;
+    (void)fdt_phys_addr;
+
+    // FIXME: Implement this
+
+    Processor::halt();
+}
+
+}

--- a/Kernel/Bus/PCI/Definitions.h
+++ b/Kernel/Bus/PCI/Definitions.h
@@ -9,6 +9,7 @@
 #include <AK/Badge.h>
 #include <AK/DistinctNumeric.h>
 #include <AK/Function.h>
+#include <AK/RefCounted.h>
 #include <AK/Types.h>
 #include <AK/Vector.h>
 #include <Kernel/Debug.h>

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -512,9 +512,22 @@ elseif("${SERENITY_ARCH}" STREQUAL "riscv64")
         Arch/Processor.cpp
         kprintf.cpp
 
+        Arch/riscv64/Firmware/ACPI/StaticParsing.cpp
+
         Arch/riscv64/boot.S
+        Arch/riscv64/DebugOutput.cpp
+        Arch/riscv64/Delay.cpp
+        Arch/riscv64/InterruptManagement.cpp
+        Arch/riscv64/Interrupts.cpp
+        Arch/riscv64/PageDirectory.cpp
+        Arch/riscv64/Panic.cpp
+        Arch/riscv64/PCI.cpp
+        Arch/riscv64/PowerState.cpp
+        Arch/riscv64/pre_init.cpp
         Arch/riscv64/Processor.cpp
+        Arch/riscv64/SafeMem.cpp
         Arch/riscv64/SBI.cpp
+        Arch/riscv64/SmapDisabler.cpp
     )
 
     add_compile_options(-fno-stack-protector -fno-sanitize=all)

--- a/Kernel/Devices/Storage/StorageManagement.cpp
+++ b/Kernel/Devices/Storage/StorageManagement.cpp
@@ -122,6 +122,11 @@ UNMAP_AFTER_INIT void StorageManagement::enumerate_pci_controllers(bool force_pi
 #elif ARCH(AARCH64)
             (void)force_pio;
             TODO_AARCH64();
+#elif ARCH(RISCV64)
+            (void)force_pio;
+            if (subclass_code == SubclassID::IDEController && kernel_command_line().is_ide_enabled()) {
+                TODO_RISCV64();
+            }
 #else
 #    error Unknown architecture
 #endif

--- a/Kernel/FileSystem/SysFS/Subsystems/Kernel/CPUInfo.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Kernel/CPUInfo.cpp
@@ -81,6 +81,10 @@ ErrorOr<void> SysFSCPUInformation::try_generate(KBufferBuilder& builder)
     (void)builder;
     dmesgln("TODO: Implement ProcessorInfo for AArch64!");
     return Error::from_errno(EINVAL);
+#elif ARCH(RISCV64)
+    (void)builder;
+    dmesgln("TODO: Implement ProcessorInfo for riscv64!");
+    return Error::from_errno(EINVAL);
 #else
 #    error Unknown architecture
 #endif

--- a/Kernel/Heap/kmalloc.cpp
+++ b/Kernel/Heap/kmalloc.cpp
@@ -18,7 +18,7 @@
 #include <Kernel/Sections.h>
 #include <Kernel/Tasks/PerformanceManager.h>
 
-#if ARCH(X86_64) || ARCH(AARCH64)
+#if ARCH(X86_64) || ARCH(AARCH64) || ARCH(RISCV64)
 static constexpr size_t CHUNK_SIZE = 64;
 #else
 #    error Unknown architecture

--- a/Kernel/KSyms.cpp
+++ b/Kernel/KSyms.cpp
@@ -90,7 +90,7 @@ UNMAP_AFTER_INIT static void load_kernel_symbols_from_data(Bytes buffer)
         //        of zero, so the address of a symbol does not need to be offset by the kernel_load_base.
 #if ARCH(X86_64)
         ksym.address = kernel_load_base + address;
-#elif ARCH(AARCH64)
+#elif ARCH(AARCH64) || ARCH(RISCV64)
         ksym.address = address;
 #else
 #    error "Unknown architecture"

--- a/Kernel/Syscalls/SyscallHandler.cpp
+++ b/Kernel/Syscalls/SyscallHandler.cpp
@@ -107,6 +107,8 @@ NEVER_INLINE void syscall_handler(TrapFrame* trap)
     clac();
 #elif ARCH(AARCH64)
     // FIXME: Implement the security mechanism for aarch64
+#elif ARCH(RISCV64)
+    // FIXME: Implement the security mechanism for riscv64
 #else
 #    error Unknown architecture
 #endif
@@ -148,6 +150,8 @@ NEVER_INLINE void syscall_handler(TrapFrame* trap)
     }
 #elif ARCH(AARCH64)
     // FIXME: Implement the security mechanism for aarch64
+#elif ARCH(RISCV64)
+    // FIXME: Implement the security mechanism for riscv64
 #else
 #    error Unknown architecture
 #endif

--- a/Kernel/Syscalls/execve.cpp
+++ b/Kernel/Syscalls/execve.cpp
@@ -156,6 +156,10 @@ static ErrorOr<FlatPtr> make_userspace_context_for_main_thread([[maybe_unused]] 
     regs.x[0] = argv_entries.size();
     regs.x[1] = argv;
     regs.x[2] = envp;
+#elif ARCH(RISCV64)
+    (void)argv;
+    (void)envp;
+    TODO_RISCV64();
 #else
 #    error Unknown architecture
 #endif
@@ -737,6 +741,8 @@ static Array<ELF::AuxiliaryValue, auxiliary_vector_size> generate_auxiliary_vect
         { ELF::AuxiliaryValue::HwCap, (long)CPUID(1).edx() },
 #elif ARCH(AARCH64)
         { ELF::AuxiliaryValue::HwCap, (long)0 },
+#elif ARCH(RISCV64)
+        { ELF::AuxiliaryValue::HwCap, (long)0 }, // TODO
 #else
 #    error "Unknown architecture"
 #endif

--- a/Kernel/Syscalls/fork.cpp
+++ b/Kernel/Syscalls/fork.cpp
@@ -150,6 +150,10 @@ ErrorOr<FlatPtr> Process::sys$fork(RegisterState& regs)
     child_regs.spsr_el1 = regs.spsr_el1;
     child_regs.elr_el1 = regs.elr_el1;
     child_regs.sp_el0 = regs.sp_el0;
+#elif ARCH(RISCV64)
+    (void)child_regs;
+    (void)regs;
+    TODO_RISCV64();
 #else
 #    error Unknown architecture
 #endif

--- a/Kernel/Syscalls/ptrace.cpp
+++ b/Kernel/Syscalls/ptrace.cpp
@@ -258,6 +258,9 @@ ErrorOr<FlatPtr> Thread::peek_debug_register(u32 register_index)
 #elif ARCH(AARCH64)
     (void)register_index;
     TODO_AARCH64();
+#elif ARCH(RISCV64)
+    (void)register_index;
+    TODO_RISCV64();
 #else
 #    error "Unknown architecture"
 #endif
@@ -290,6 +293,10 @@ ErrorOr<void> Thread::poke_debug_register(u32 register_index, FlatPtr data)
     (void)register_index;
     (void)data;
     TODO_AARCH64();
+#elif ARCH(RISCV64)
+    (void)register_index;
+    (void)data;
+    TODO_RISCV64();
 #else
 #    error "Unknown architecture"
 #endif

--- a/Kernel/Syscalls/thread.cpp
+++ b/Kernel/Syscalls/thread.cpp
@@ -76,6 +76,8 @@ ErrorOr<FlatPtr> Process::sys$create_thread(void* (*entry)(void*), Userspace<Sys
     regs.x[1] = (FlatPtr)params.entry_argument;
     regs.x[2] = (FlatPtr)params.stack_location;
     regs.x[3] = (FlatPtr)params.stack_size;
+#elif ARCH(RISCV64)
+    TODO_RISCV64();
 #else
 #    error Unknown architecture
 #endif

--- a/Kernel/Syscalls/uname.cpp
+++ b/Kernel/Syscalls/uname.cpp
@@ -15,6 +15,8 @@ namespace Kernel {
 #    define UNAME_MACHINE "x86_64"
 #elif ARCH(AARCH64)
 #    define UNAME_MACHINE "AArch64"
+#elif ARCH(RISCV64)
+#    define UNAME_MACHINE "riscv64"
 #else
 #    error Unknown architecture
 #endif

--- a/Kernel/Tasks/Coredump.cpp
+++ b/Kernel/Tasks/Coredump.cpp
@@ -120,7 +120,7 @@ ErrorOr<void> Coredump::write_elf_header()
     elf_file_header.e_ident[EI_MAG1] = 'E';
     elf_file_header.e_ident[EI_MAG2] = 'L';
     elf_file_header.e_ident[EI_MAG3] = 'F';
-#if ARCH(X86_64) || ARCH(AARCH64)
+#if ARCH(X86_64) || ARCH(AARCH64) || ARCH(RISCV64)
     elf_file_header.e_ident[EI_CLASS] = ELFCLASS64;
 #else
 #    error Unknown architecture
@@ -140,6 +140,8 @@ ErrorOr<void> Coredump::write_elf_header()
     elf_file_header.e_machine = EM_X86_64;
 #elif ARCH(AARCH64)
     elf_file_header.e_machine = EM_AARCH64;
+#elif ARCH(RISCV64)
+    elf_file_header.e_machine = EM_RISCV;
 #else
 #    error Unknown architecture
 #endif

--- a/Kernel/Time/TimeManagement.cpp
+++ b/Kernel/Time/TimeManagement.cpp
@@ -18,6 +18,7 @@
 #    include <Kernel/Arch/x86_64/Time/RTC.h>
 #elif ARCH(AARCH64)
 #    include <Kernel/Arch/aarch64/RPi/Timer.h>
+#elif ARCH(RISCV64)
 #else
 #    error Unknown architecture
 #endif
@@ -135,6 +136,8 @@ MonotonicTime TimeManagement::monotonic_time(TimePrecision precision) const
 #elif ARCH(AARCH64)
             // FIXME: Get rid of these horrible casts
             const_cast<RPi::Timer*>(static_cast<RPi::Timer const*>(m_system_timer.ptr()))->update_time(seconds, ticks, true);
+#elif ARCH(RISCV64)
+            TODO_RISCV64();
 #else
 #    error Unknown architecture
 #endif
@@ -203,6 +206,8 @@ UNMAP_AFTER_INIT void TimeManagement::initialize([[maybe_unused]] u32 cpu)
         VERIFY(!s_the.is_initialized());
         s_the.ensure_instance();
     }
+#elif ARCH(RISCV64)
+    TODO_RISCV64();
 #else
 #    error Unknown architecture
 #endif
@@ -231,7 +236,7 @@ UnixDateTime TimeManagement::boot_time()
 {
 #if ARCH(X86_64)
     return RTC::boot_time();
-#elif ARCH(AARCH64)
+#elif ARCH(AARCH64) || ARCH(RISCV64)
     // FIXME: Return correct boot time
     return UnixDateTime::epoch();
 #else
@@ -271,6 +276,8 @@ UNMAP_AFTER_INIT TimeManagement::TimeManagement()
     }
 #elif ARCH(AARCH64)
     probe_and_set_aarch64_hardware_timers();
+#elif ARCH(RISCV64)
+    probe_and_set_riscv64_hardware_timers();
 #else
 #    error Unknown architecture
 #endif
@@ -473,6 +480,11 @@ UNMAP_AFTER_INIT bool TimeManagement::probe_and_set_aarch64_hardware_timers()
     m_time_keeper_timer = m_system_timer;
 
     return true;
+}
+#elif ARCH(RISCV64)
+UNMAP_AFTER_INIT bool TimeManagement::probe_and_set_riscv64_hardware_timers()
+{
+    TODO_RISCV64();
 }
 #else
 #    error Unknown architecture

--- a/Kernel/Time/TimeManagement.h
+++ b/Kernel/Time/TimeManagement.h
@@ -87,6 +87,8 @@ private:
     static void update_time(RegisterState const&);
 #elif ARCH(AARCH64)
     bool probe_and_set_aarch64_hardware_timers();
+#elif ARCH(RISCV64)
+    bool probe_and_set_riscv64_hardware_timers();
 #else
 #    error Unknown architecture
 #endif


### PR DESCRIPTION
Depends on #21504 and #21139 (the second one is necessary for `Meta/serenity.sh build riscv64 Clang` to work)

This PR is split into multiple commits as the commits before the last one don't just insert TODOs everywhere, as I didn't want the last commit, which is quite big, to also contain actual code.

Note: The kernel can still only currently compile using clang (as explained in #21139).