### PR TITLE
Kernel/USB: Separate USBManagement creation from it's initialization and make it PCI-less safe

### DIFF
--- a/Kernel/Arch/init.cpp
+++ b/Kernel/Arch/init.cpp
@@ -393,9 +393,7 @@ void init_stage2(void*)
 
     auto boot_profiling = kernel_command_line().is_boot_profiling_enabled();
 
-    if (!PCI::Access::is_disabled()) {
-        USB::USBManagement::initialize();
-    }
+    USB::USBManagement::initialize();
     SysFSFirmwareDirectory::initialize();
 
     if (!PCI::Access::is_disabled()) {

--- a/Kernel/Bus/USB/USBManagement.cpp
+++ b/Kernel/Bus/USB/USBManagement.cpp
@@ -65,13 +65,6 @@ UNMAP_AFTER_INIT void USBManagement::enumerate_controllers()
     }));
 }
 
-bool USBManagement::initialized()
-{
-    // FIXME: Footgun, as the state of the singleton does not dictate if we have
-    //        set up the SysFSDirectory or enumerated controllers
-    return s_the.is_initialized();
-}
-
 UNMAP_AFTER_INIT void USBManagement::initialize()
 {
     if (!s_initialized_sys_fs_directory) {

--- a/Kernel/Bus/USB/USBManagement.h
+++ b/Kernel/Bus/USB/USBManagement.h
@@ -17,7 +17,6 @@ class USBManagement {
 
 public:
     USBManagement();
-    static bool initialized();
     static void initialize();
     static USBManagement& the();
 


### PR DESCRIPTION
### Kernel/USB: Move controller enumeration into `initialize`

Also adds a `PCI::Access::is_disabled()` guard before the PCI device
enumeration, which allows us to skip that check in `init.cpp`, as well
as support non-PCI controllers at some point.
This also has the nice side-effect of allowing us to call
`USBManagement::the()` indiscriminately again, which previously caused
issues on platforms without PCI, so the initialization checks for the
driver related code were also removed.

### Kernel/USB: Remove unused, foot-gun-y USBManagement::initialized method

This is now unused and only checked if the singleton was constructed,
which does not mirror the state of USB initialization since the last
commit

