### PR TITLE
LibGUI: Don't update ComboBox text when model index is invalid

### DIFF
--- a/Userland/Libraries/LibGUI/ComboBox.cpp
+++ b/Userland/Libraries/LibGUI/ComboBox.cpp
@@ -177,12 +177,13 @@ void ComboBox::navigate_relative(int delta)
 
 void ComboBox::selection_updated(ModelIndex const& index)
 {
-    if (index.is_valid())
+    if (index.is_valid()) {
         m_selected_index = index;
-    else
+        auto new_value = index.data().to_deprecated_string();
+        m_editor->set_text(new_value);
+    } else {
         m_selected_index.clear();
-    auto new_value = index.data().to_deprecated_string();
-    m_editor->set_text(new_value);
+    }
     if (!m_only_allow_values_from_model)
         m_editor->select_all();
 }


### PR DESCRIPTION
Without ENABLE_TIME_ZONE_DATA the user is able to update the time zone selection in TimeZoneSettingsWidget when using "on_mousewheel" or "on_{up,down}_pressed" even though UTC is supposed to be the only option. Due to an invalid model index, the selection is set to "[null]".

Prior to this patch, the ComboBox text in "selection_updated" is set at each call.