### PR TITLE
LibPDF: Tolerate comments after dict values

### DIFF
--- a/Userland/Libraries/LibPDF/Parser.cpp
+++ b/Userland/Libraries/LibPDF/Parser.cpp
@@ -421,6 +421,7 @@ PDFErrorOr<NonnullRefPtr<DictObject>> Parser::parse_dict()
     while (!m_reader.done()) {
         if (m_reader.matches(">>"))
             break;
+        parse_comment();
         auto name = TRY(parse_name())->name();
         auto value = TRY(parse_value());
         map.set(name, value);


### PR DESCRIPTION
Makes 0000607.pdf from 0000.zip from the pdfa dataset load.