### PR TITLE
Meta: Add anchors to headings of man pages

### DIFF
--- a/Meta/Websites/man.serenityos.org/add-anchors.lua
+++ b/Meta/Websites/man.serenityos.org/add-anchors.lua
@@ -1,0 +1,14 @@
+function Header(header)
+    local level = header.level
+    local identifier = header.identifier
+    local anchor = pandoc.RawInline('html', '<a style="margin-right: 15px" href="#' .. identifier .. '">#</a>')
+  
+    -- Create a list of inline elements containing the anchor and header content
+    local new_content = pandoc.List({anchor})
+    for _, elem in ipairs(header.content) do
+      new_content:insert(elem)
+    end
+  
+    return pandoc.Header(level, new_content, identifier)
+  end
+  

--- a/Meta/build-manpages-website.sh
+++ b/Meta/build-manpages-website.sh
@@ -42,6 +42,7 @@ for md_file in $(find "${MAN_DIR}" -iname '*.md' | ${SORT}); do
     pandoc -f gfm -t html5 -s \
         -B Meta/Websites/man.serenityos.org/banner-preamble.inc \
         --lua-filter=Meta/convert-markdown-links.lua \
+        --lua-filter=Meta/Websites/man.serenityos.org/add-anchors.lua \
         --metadata title="${name}(${section_number}) - SerenityOS man pages" \
         -o "${output_file}" \
         "${md_file}" &


### PR DESCRIPTION
This is _somewhat_ similar to #21245, but for man pages. 

![image](https://github.com/SerenityOS/serenity/assets/28386721/e75a01fb-884a-457c-8935-6a805ae4abe7)
