### PR TITLE
LibWeb: Use max content contribution in flex_fraction in GFC

### DIFF
--- a/Tests/LibWeb/Layout/expected/grid/items-min-content-size-should-account-paddings.txt
+++ b/Tests/LibWeb/Layout/expected/grid/items-min-content-size-should-account-paddings.txt
@@ -1,0 +1,18 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x133.46875 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x117.46875 children: not-inline
+      Box <div.cta-banner> at (8,8) content-size 784x117.46875 flex-container(row) [FFC] children: not-inline
+        Box <div.w-layout-grid> at (8,8) content-size 470.4375x117.46875 flex-item [GFC] children: not-inline
+          BlockContainer <div.button> at (58,58) content-size 135.21875x17.46875 [BFC] children: inline
+            line 0 width: 135.21875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+              frag 0 from TextNode start: 0, length: 16, rect: [58,58 135.21875x17.46875]
+                "Sign up for free"
+            TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x133.46875]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x117.46875]
+      PaintableBox (Box<DIV>.cta-banner) [8,8 784x117.46875]
+        PaintableBox (Box<DIV>.w-layout-grid) [8,8 470.4375x117.46875]
+          PaintableWithLines (BlockContainer<DIV>.button) [8,8 235.21875x117.46875]
+            TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/input/grid/items-min-content-size-should-account-paddings.html
+++ b/Tests/LibWeb/Layout/input/grid/items-min-content-size-should-account-paddings.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html><style type="text/css">
+.w-layout-grid {
+    grid-template-rows: auto auto;
+    grid-template-columns: 1fr 1fr;
+    grid-auto-columns: 1fr;
+    display: grid;
+}
+.button {
+    padding: 50px;
+    color: rgb(255, 255, 255);
+    background-color: rgb(56, 152, 236);
+}
+.cta-banner {
+    display: flex;
+}
+</style><div class="cta-banner"><div class="w-layout-grid"><div class="button">Sign up for free</div></div></div>

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -1240,7 +1240,7 @@ void GridFormattingContext::expand_flexible_tracks(AvailableSpace const& availab
                 });
 
                 if (crosses_flexible_track)
-                    result = max(result, find_the_size_of_an_fr(spanned_tracks, calculate_max_content_size(item, dimension)));
+                    result = max(result, find_the_size_of_an_fr(spanned_tracks, calculate_max_content_contribution(item, dimension)));
             }
 
             return result;


### PR DESCRIPTION
As spec comment in the code says we should use item’s max-content contribution to calculate flex fraction.

Likely, it was calculate_max_content_size() because we didn't have calculate_max_content_contribution() when this function was implemented initially.