### PR TITLE
Meta: Don't pass ^C through the serial console on CI

### DIFF
--- a/Documentation/RunningTests.md
+++ b/Documentation/RunningTests.md
@@ -106,7 +106,7 @@ SystemModes=self-test
 ```
 
 `/dev/ttyS0` is used as stdio because that serial port is connected when qemu is run with `-display none` and
-`-serial mon:stdio`, and output to it will show up in the stdout of the qemu window. Separately, the CI run script redirects
+`-serial stdio`, and output to it will show up in the stdout of the qemu window. Separately, the CI run script redirects
 the serial debug output to `./debug.log` so that both stdout of the tests and the dbgln from the kernel/tests can be
 captured.
 

--- a/Meta/run.sh
+++ b/Meta/run.sh
@@ -523,7 +523,6 @@ elif [ "$SERENITY_RUN" = "ci" ]; then
             -M raspi3b \
             -d guest_errors \
             -no-reboot \
-            -serial mon:stdio \
             -monitor none \
             -display none \
             -serial file:debug.log \
@@ -541,7 +540,7 @@ elif [ "$SERENITY_RUN" = "ci" ]; then
             -no-reboot \
             -smp ${SERENITY_CPUS} \
             -device ich9-ahci \
-            -serial mon:stdio \
+            -serial stdio \
             -display none \
             -debugcon file:debug.log \
             $SERENITY_KERNEL_AND_INITRD \


### PR DESCRIPTION
`-serial mon:stdio` passes through all kinds of key combinations, `-serial stdio` doesn't. This probably isn't something that we want while running tests or CI, so switch to the non-passing variant.

aarch64 actually failed to run due to this, since it already had `-serial stdio` in its arguments, causing a conflict. This is why that entry is now gone entirely.