### PR TITLE
Ladybird+Meta: Make the AppKit chrome the default on macOS

### DIFF
--- a/Documentation/BuildInstructionsLadybird.md
+++ b/Documentation/BuildInstructionsLadybird.md
@@ -47,7 +47,12 @@ Note that Xcode 13.x does not have sufficient C++20 support to build ladybird. X
 
 ```
 xcode-select --install
-brew install cmake qt ninja ccache
+brew install cmake ninja ccache
+```
+
+If you also plan to use the Qt chrome on macOS:
+```
+brew install qt
 ```
 
 On OpenIndiana:
@@ -71,7 +76,7 @@ MinGW/MSYS2 are not supported, but may work with sufficient elbow grease. Native
 For Android:
 
 On a Unix-like platform, install the prerequisites for that platform and then see the [Android Studio guide](AndroidStudioConfiguration.md).
-Or, download a version of Gradle >= 8.0.0, and run the ``gradlew`` program in ``Ladybird/Android`` 
+Or, download a version of Gradle >= 8.0.0, and run the ``gradlew`` program in ``Ladybird/Android``
 
 ## Build steps
 
@@ -85,18 +90,20 @@ The simplest way to build and run ladybird is via the serenity.sh script:
 ./Meta/serenity.sh gdb lagom ladybird
 ```
 
-By default, the above commands will build Ladybird using Qt for the browser chrome. We also support
-the following platform-specific browser chromes:
-
+The above commands will build Ladybird with one of the following browser chromes, depending on the platform:
+* [Android UI](https://developer.android.com/develop/ui) - The native chrome on Android.
 * [AppKit](https://developer.apple.com/documentation/appkit?language=objc) - The native chrome on macOS.
+* [Qt](https://doc.qt.io/qt-6/) - The chrome used on all other platforms.
 
-To build Ladybird using one of these chromes on the appropriate platform, use the following serenity.sh
-commands:
+The Qt chrome is available on platforms where it is not the default as well (except on Android). To build the
+Qt chrome, install the Qt dependencies for your platform, and enable the Qt chrome via CMake:
 
 ```bash
 # From /path/to/serenity
-./Meta/serenity.sh run lagom ladybird-appkit # Use the AppKit chrome on macOS.
+cmake -S Meta/Lagom -B Build/lagom -DENABLE_QT=ON
 ```
+
+To re-disable the Qt chrome, run the above command with `-DENABLE_QT=OFF`.
 
 ### Disabling Ladybird
 

--- a/Ladybird/CMakeLists.txt
+++ b/Ladybird/CMakeLists.txt
@@ -80,7 +80,12 @@ add_compile_options(-DAK_DONT_REPLACE_STD)
 add_compile_options(-Wno-expansion-to-defined)
 add_compile_options(-Wno-user-defined-literals)
 
-serenity_option(ENABLE_QT ON CACHE BOOL "Build ladybird application using Qt GUI")
+if (ANDROID OR APPLE)
+    serenity_option(ENABLE_QT OFF CACHE BOOL "Build ladybird application using Qt GUI")
+else()
+    serenity_option(ENABLE_QT ON CACHE BOOL "Build ladybird application using Qt GUI")
+endif()
+
 if (ANDROID AND ENABLE_QT)
     message(STATUS "Disabling Qt for Android")
     set(ENABLE_QT OFF CACHE BOOL "" FORCE)

--- a/Meta/Azure/Lagom.yml
+++ b/Meta/Azure/Lagom.yml
@@ -168,23 +168,6 @@ jobs:
           SERENITY_SOURCE_DIR: '$(Build.SourcesDirectory)'
           QT_QPA_PLATFORM: 'offscreen'
 
-    - ${{ if and(eq(parameters.fuzzer, 'NoFuzz'), eq(parameters.os, 'macOS') ) }}:
-      - script: |
-          set -e
-          cmake -DENABLE_QT=OFF -B Build
-        displayName: 'Enable the Ladybird AppKit chrome'
-        workingDirectory: $(Build.SourcesDirectory)/Meta/Lagom
-        env:
-          CCACHE_DIR: '$(SERENITY_CCACHE_DIR)'
-
-      - script: |
-          set -e
-          cmake --build .
-        displayName: 'Build Ladybird AppKit chrome'
-        workingDirectory: $(Build.SourcesDirectory)/Meta/Lagom/Build
-        env:
-          CCACHE_DIR: '$(SERENITY_CCACHE_DIR)'
-
     - ${{ if eq(parameters.lagom_lints, true) }}:
       - script: |
           set -e

--- a/Meta/serenity.sh
+++ b/Meta/serenity.sh
@@ -111,15 +111,6 @@ CMAKE_ARGS+=( "-DSERENITY_TOOLCHAIN=$TOOLCHAIN_TYPE" )
 
 CMD_ARGS=( "$@" )
 
-LADYBIRD_ENABLE_QT=1
-
-if [ "$TARGET" = "lagom" ]; then
-    if [ "${CMD_ARGS[0]}" = "ladybird-appkit" ]; then
-        CMD_ARGS[0]="ladybird"
-        LADYBIRD_ENABLE_QT=0
-    fi
-fi
-
 get_top_dir() {
     git rev-parse --show-toplevel
 }
@@ -140,7 +131,7 @@ is_valid_target() {
     if [ "$TARGET" = "lagom" ]; then
         CMAKE_ARGS+=("-DBUILD_LAGOM=ON")
         if [ "${CMD_ARGS[0]}" = "ladybird" ]; then
-            CMAKE_ARGS+=("-DENABLE_LAGOM_LADYBIRD=ON" "-DENABLE_QT=${LADYBIRD_ENABLE_QT}")
+            CMAKE_ARGS+=("-DENABLE_LAGOM_LADYBIRD=ON")
         fi
         return 0
     fi
@@ -211,7 +202,7 @@ build_target() {
         # invoked superbuild for serenity target that doesn't set -DBUILD_LAGOM=ON
         local EXTRA_CMAKE_ARGS=()
         if [ "${CMD_ARGS[0]}" = "ladybird" ]; then
-            EXTRA_CMAKE_ARGS=("-DENABLE_LAGOM_LADYBIRD=ON" "-DENABLE_QT=${LADYBIRD_ENABLE_QT}")
+            EXTRA_CMAKE_ARGS=("-DENABLE_LAGOM_LADYBIRD=ON")
         fi
         cmake -S "$SERENITY_SOURCE_DIR/Meta/Lagom" -B "$BUILD_DIR" -DBUILD_LAGOM=ON "${EXTRA_CMAKE_ARGS[@]}"
     fi


### PR DESCRIPTION
The Qt chrome is still available and may be enabled with CMake.