### PR TITLE
LibWeb: Protect ad-hoc `scroll` against a potentially null paintable box

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -1924,7 +1924,8 @@ HashMap<DeprecatedFlyString, CSS::StyleProperty> const& Element::custom_properti
 void Element::scroll(double x, double y)
 {
     // AD-HOC:
-    paintable_box()->scroll_by(x, y);
+    if (auto* paintable_box = this->paintable_box())
+        paintable_box->scroll_by(x, y);
 }
 
 // https://drafts.csswg.org/cssom-view/#dom-element-scroll


### PR DESCRIPTION
We perform such a check in other users of the paintable box in this file as the box may be null before layout completes. This prevents UB seen in some CI runs.