### PR TITLE
LibPDF: Accept a comment between trailer and `startxref`

### DIFF
--- a/Userland/Libraries/LibPDF/DocumentParser.cpp
+++ b/Userland/Libraries/LibPDF/DocumentParser.cpp
@@ -527,6 +527,7 @@ PDFErrorOr<NonnullRefPtr<DictObject>> DocumentParser::parse_file_trailer()
     m_reader.consume_whitespace();
     auto dict = TRY(parse_dict());
 
+    parse_comment();
     if (!m_reader.matches("startxref"))
         return error("Expected \"startxref\"");
     m_reader.move_by(9);


### PR DESCRIPTION
Several files have a comment there, and per spec comments are allowed everywhere.

Reduces numbers of files we fail to open in the 0000.zip pdfa -n 500 dataset from 24 to 16 (helps e.g. with 0000772.pdf).

This is an alternative to #21536, since that one doesn't seem to get merged :^)