### PR TITLE
LibPDF: Make Reader::move_by() parameter more truthful

### DIFF
--- a/Userland/Libraries/LibPDF/Reader.h
+++ b/Userland/Libraries/LibPDF/Reader.h
@@ -43,12 +43,12 @@ public:
         return offset() + 1;
     }
 
-    void move_by(size_t count)
+    void move_by(ssize_t count)
     {
         if (m_forwards) {
-            m_offset += static_cast<ssize_t>(count);
+            m_offset += count;
         } else {
-            m_offset -= static_cast<ssize_t>(count);
+            m_offset -= count;
         }
     }
 


### PR DESCRIPTION
No behavior change, just simpler and less surprising.

----

I've had this sitting in a local branch for a while now and haven't found a PR where it fits in. I figured I'd just send it out, even though it's tiny.