### PR TITLE
LibWeb: Record painting commands in coordinates of stacking context

### DIFF
--- a/Userland/Libraries/LibWeb/Painting/BorderRadiusCornerClipper.cpp
+++ b/Userland/Libraries/LibWeb/Painting/BorderRadiusCornerClipper.cpp
@@ -113,7 +113,7 @@ ScopedCornerRadiusClip::ScopedCornerRadiusClip(PaintContext& context, DevicePixe
             .bottom_right = border_radii.bottom_right.as_corner(context),
             .bottom_left = border_radii.bottom_left.as_corner(context)
         };
-        auto clipper = BorderRadiusCornerClipper::create(corner_radii, border_rect, border_radii, corner_clip);
+        auto clipper = BorderRadiusCornerClipper::create(corner_radii, context.painter().state().translation.map(border_rect.to_type<int>()).to_type<DevicePixels>(), border_radii, corner_clip);
         if (!clipper.is_error()) {
             m_corner_clipper = clipper.release_value();
             m_context.painter().sample_under_corners(*m_corner_clipper);

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -484,7 +484,7 @@ void PaintableBox::apply_clip_overflow_rect(PaintContext& context, PaintPhase ph
             .bottom_left = border_radii_data.bottom_left.as_corner(context)
         };
         if (border_radii_data.has_any_radius()) {
-            auto corner_clipper = BorderRadiusCornerClipper::create(corner_radii, context.rounded_device_rect(*clip_rect), border_radii_data, CornerClip::Outside);
+            auto corner_clipper = BorderRadiusCornerClipper::create(corner_radii, context.painter().state().translation.map(context.rounded_device_rect(*clip_rect).to_type<int>()).to_type<DevicePixels>(), border_radii_data, CornerClip::Outside);
             if (corner_clipper.is_error()) {
                 dbgln("Failed to create overflow border-radius corner clipper: {}", corner_clipper.error());
                 return;
@@ -689,7 +689,7 @@ void PaintableWithLines::paint(PaintContext& context, PaintPhase phase) const
             .bottom_left = border_radii.bottom_left.as_corner(context)
         };
         if (border_radii.has_any_radius()) {
-            auto clipper = BorderRadiusCornerClipper::create(corner_radii, clip_box, border_radii);
+            auto clipper = BorderRadiusCornerClipper::create(corner_radii, context.painter().state().translation.map(clip_box.to_type<int>()).to_type<DevicePixels>(), border_radii);
             if (!clipper.is_error()) {
                 corner_clipper = clipper.release_value();
                 context.painter().sample_under_corners(*corner_clipper);

--- a/Userland/Libraries/LibWeb/Painting/RecordingPainter.h
+++ b/Userland/Libraries/LibWeb/Painting/RecordingPainter.h
@@ -83,12 +83,6 @@ struct DrawScaledBitmap {
     [[nodiscard]] CommandResult execute(CommandExecutionState&) const;
 };
 
-struct Translate {
-    Gfx::IntPoint translation_delta;
-
-    [[nodiscard]] CommandResult execute(CommandExecutionState&) const;
-};
-
 struct SaveState {
     [[nodiscard]] CommandResult execute(CommandExecutionState&) const;
 };
@@ -367,7 +361,6 @@ using PaintingCommand = Variant<
     DrawText,
     FillRect,
     DrawScaledBitmap,
-    Translate,
     SaveState,
     RestoreState,
     AddClipRect,
@@ -510,6 +503,17 @@ public:
 
     void execute(Gfx::Bitmap&);
 
+    RecordingPainter()
+    {
+        m_state_stack.append(State());
+    }
+
+    struct State {
+        Gfx::AffineTransform translation;
+    };
+    State& state() { return m_state_stack.last(); }
+    State const& state() const { return m_state_stack.last(); }
+
 private:
     void push_command(PaintingCommand command)
     {
@@ -517,6 +521,7 @@ private:
     }
 
     Vector<PaintingCommand> m_painting_commands;
+    Vector<State> m_state_stack;
 };
 
 class RecordingPainterStateSaver {

--- a/Userland/Libraries/LibWeb/Painting/ShadowPainting.cpp
+++ b/Userland/Libraries/LibWeb/Painting/ShadowPainting.cpp
@@ -564,7 +564,7 @@ void paint_box_shadow(PaintContext& context,
             .offset_y = offset_y,
             .blur_radius = blur_radius,
             .spread_distance = spread_distance,
-            .device_content_rect = device_content_rect,
+            .device_content_rect = context.painter().state().translation.map(device_content_rect.to_type<int>()).to_type<DevicePixels>(),
         };
 
         if (box_shadow_data.placement == ShadowPlacement::Inner) {

--- a/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -343,8 +343,8 @@ void StackingContext::paint(PaintContext& context) const
         paint_internal(context);
         context.painter().pop_stacking_context(pop_stacking_context_params);
     } else {
-        context.painter().push_stacking_context(push_stacking_context_params);
         context.painter().translate(affine_transform.translation().to_rounded<int>());
+        context.painter().push_stacking_context(push_stacking_context_params);
         paint_internal(context);
         context.painter().pop_stacking_context(pop_stacking_context_params);
     }


### PR DESCRIPTION
By storing painting command coordinates relative to the nearest stacking context we can get rid of the Translate command.

Additionally, this allows us to easily check if the bounding rectangles of the commands cover or intersect within a stacking context. This should be useful if we decide to optimize by avoiding the execution of commands that will be overpainted by the results of subsequent commands.