### PR TITLE
LibPDF: Implement two SeparationColorSpace methods

### DIFF
--- a/Userland/Libraries/LibPDF/ColorSpace.cpp
+++ b/Userland/Libraries/LibPDF/ColorSpace.cpp
@@ -396,8 +396,7 @@ PDFErrorOr<Color> SeparationColorSpace::color(ReadonlySpan<Value>) const
 
 Vector<float> SeparationColorSpace::default_decode() const
 {
-    warnln("PDF: TODO implement SeparationColorSpace::default_decode()");
-    return {};
+    return { 0.0f, 1.0f };
 }
 
 }

--- a/Userland/Libraries/LibPDF/ColorSpace.h
+++ b/Userland/Libraries/LibPDF/ColorSpace.h
@@ -151,7 +151,7 @@ public:
     ~SeparationColorSpace() override = default;
 
     PDFErrorOr<Color> color(ReadonlySpan<Value> arguments) const override;
-    int number_of_components() const override { TODO(); }
+    int number_of_components() const override { return 1; }
     Vector<float> default_decode() const override;
     ColorSpaceFamily const& family() const override { return ColorSpaceFamily::Separation; }
 


### PR DESCRIPTION
Actually using separation color spaces still doesn't work, but we now no longer assert on them when they're used.

Fixes 2 crashes on the `-n 500` 0000.zip pdfa dataset.