### PR TITLE
LibPDF: Sketch out Lab color space

### DIFF
--- a/Userland/Libraries/LibPDF/ColorSpace.cpp
+++ b/Userland/Libraries/LibPDF/ColorSpace.cpp
@@ -62,6 +62,9 @@ PDFErrorOr<NonnullRefPtr<ColorSpace>> ColorSpace::create(Document* document, Non
     if (color_space_name == CommonNames::Indexed)
         return Error::rendering_unsupported_error("Indexed color spaces not yet implemented");
 
+    if (color_space_name == CommonNames::Lab)
+        return TRY(LabColorSpace::create(document, move(parameters)));
+
     if (color_space_name == CommonNames::Pattern)
         return Error::rendering_unsupported_error("Pattern color spaces not yet implemented");
 
@@ -380,6 +383,26 @@ Vector<float> ICCBasedColorSpace::default_decode() const
         }
         return decoding_ranges;
     }
+}
+
+PDFErrorOr<NonnullRefPtr<LabColorSpace>> LabColorSpace::create(Document*, Vector<Value>&& parameters)
+{
+    if (parameters.size() != 1)
+        return Error { Error::Type::MalformedPDF, "Lab color space expects one parameter" };
+
+    auto color_space = adopt_ref(*new LabColorSpace());
+    // FIXME: Implement.
+    return color_space;
+}
+
+PDFErrorOr<Color> LabColorSpace::color(ReadonlySpan<Value>) const
+{
+    return Error::rendering_unsupported_error("Lab color spaces not yet implemented");
+}
+
+Vector<float> LabColorSpace::default_decode() const
+{
+    return { 0.0f, 1.0f, 0.0f, 1.0f, 0.0f, 1.0f };
 }
 
 PDFErrorOr<NonnullRefPtr<SeparationColorSpace>> SeparationColorSpace::create(Document*, Vector<Value>&&)

--- a/Userland/Libraries/LibPDF/ColorSpace.h
+++ b/Userland/Libraries/LibPDF/ColorSpace.h
@@ -144,6 +144,21 @@ private:
     NonnullRefPtr<Gfx::ICC::Profile> m_profile;
 };
 
+class LabColorSpace final : public ColorSpace {
+public:
+    static PDFErrorOr<NonnullRefPtr<LabColorSpace>> create(Document*, Vector<Value>&& parameters);
+
+    ~LabColorSpace() override = default;
+
+    PDFErrorOr<Color> color(ReadonlySpan<Value> arguments) const override;
+    int number_of_components() const override { return 3; }
+    Vector<float> default_decode() const override;
+    ColorSpaceFamily const& family() const override { return ColorSpaceFamily::Lab; }
+
+private:
+    LabColorSpace() = default;
+};
+
 class SeparationColorSpace final : public ColorSpace {
 public:
     static PDFErrorOr<NonnullRefPtr<SeparationColorSpace>> create(Document*, Vector<Value>&& parameters);

--- a/Userland/Libraries/LibPDF/CommonNames.h
+++ b/Userland/Libraries/LibPDF/CommonNames.h
@@ -99,6 +99,7 @@
     X(LJ)                         \
     X(LW)                         \
     X(LZWDecode)                  \
+    X(Lab)                        \
     X(Last)                       \
     X(LastChar)                   \
     X(Length)                     \

--- a/Userland/Libraries/LibPDF/Parser.cpp
+++ b/Userland/Libraries/LibPDF/Parser.cpp
@@ -543,6 +543,7 @@ PDFErrorOr<Vector<Operator>> Parser::parse_operators()
                 if (!operator_args.is_empty())
                     return error("operator args not empty on start of inline image");
 
+                // FIXME: `EI` can be part of the image data, e.g. on page 3 of 0000450.pdf of 0000.zip of the RGBA dataset.
                 while (!m_reader.done()) {
                     if (m_reader.matches("EI")) {
                         break;


### PR DESCRIPTION
Same as other recent color spaces: Enough to make us not assert,
but not enough to actually produce color.

Fixes 2 asserts on the `-n 500` 0000.zip pdfa dataset.