### PR TITLE
Ports/devilutionX: Remove SDL2_mixer dependency

### DIFF
--- a/Ports/devilutionX/package.sh
+++ b/Ports/devilutionX/package.sh
@@ -10,7 +10,6 @@ depends=(
     'libpng'
     'SDL2'
     'SDL2_image'
-    'SDL2_mixer'
 )
 configopts=(
     '-DCMAKE_BUILD_TYPE=Release'


### PR DESCRIPTION
This was replaced by SDL_audiolib a couple of versions ago