### PR TITLE
LibPDF: Support indirect references in more places

### DIFF
--- a/Userland/Libraries/LibPDF/Document.cpp
+++ b/Userland/Libraries/LibPDF/Document.cpp
@@ -568,9 +568,9 @@ PDFErrorOr<NonnullRefPtr<OutlineItem>> Document::build_outline_item(NonnullRefPt
 
     if (outline_item_dict->contains(CommonNames::C)) {
         auto color_array = TRY(outline_item_dict->get_array(this, CommonNames::C));
-        auto r = static_cast<int>(255.0f * color_array->at(0).get<float>());
-        auto g = static_cast<int>(255.0f * color_array->at(1).get<float>());
-        auto b = static_cast<int>(255.0f * color_array->at(2).get<float>());
+        auto r = static_cast<int>(255.0f * color_array->at(0).to_float());
+        auto g = static_cast<int>(255.0f * color_array->at(1).to_float());
+        auto b = static_cast<int>(255.0f * color_array->at(2).to_float());
         outline_item->color = Color(r, g, b);
     }
 

--- a/Userland/Libraries/LibPDF/Document.cpp
+++ b/Userland/Libraries/LibPDF/Document.cpp
@@ -260,7 +260,7 @@ PDFErrorOr<Page> Document::get_page(u32 index)
     int rotate = 0;
     auto maybe_rotate = TRY(get_inheritable_value(CommonNames::Rotate, raw_page_object));
     if (maybe_rotate.has_value()) {
-        rotate = maybe_rotate.value().to_int();
+        rotate = TRY(resolve_to<int>(maybe_rotate.value()));
         VERIFY(rotate % 90 == 0);
     }
 

--- a/Userland/Libraries/LibPDF/Fonts/Type0Font.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/Type0Font.cpp
@@ -143,7 +143,7 @@ PDFErrorOr<void> Type0Font::initialize(Document* document, NonnullRefPtr<DictObj
 
                 i++;
             } else {
-                auto array = value.get<NonnullRefPtr<Object>>()->cast<ArrayObject>();
+                auto array = TRY(document->resolve_to<ArrayObject>(value));
                 auto code = pending_code.release_value();
                 for (auto& width : *array)
                     widths.set(code++, width.to_int());

--- a/Userland/Libraries/LibPDF/Fonts/Type0Font.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/Type0Font.cpp
@@ -134,12 +134,7 @@ PDFErrorOr<void> Type0Font::initialize(Document* document, NonnullRefPtr<DictObj
             auto& value = widths_array->at(i);
             if (!pending_code.has_value()) {
                 pending_code = value.to_int();
-            } else if (value.has<NonnullRefPtr<Object>>()) {
-                auto array = value.get<NonnullRefPtr<Object>>()->cast<ArrayObject>();
-                auto code = pending_code.release_value();
-                for (auto& width : *array)
-                    widths.set(code++, width.to_int());
-            } else {
+            } else if (value.has_number()) {
                 auto first_code = pending_code.release_value();
                 auto last_code = value.to_int();
                 auto width = widths_array->at(i + 1).to_int();
@@ -147,6 +142,11 @@ PDFErrorOr<void> Type0Font::initialize(Document* document, NonnullRefPtr<DictObj
                     widths.set(code, width);
 
                 i++;
+            } else {
+                auto array = value.get<NonnullRefPtr<Object>>()->cast<ArrayObject>();
+                auto code = pending_code.release_value();
+                for (auto& width : *array)
+                    widths.set(code++, width.to_int());
             }
         }
     }

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -820,8 +820,8 @@ PDFErrorOr<void> Renderer::show_text(DeprecatedString const& string)
 PDFErrorOr<NonnullRefPtr<Gfx::Bitmap>> Renderer::load_image(NonnullRefPtr<StreamObject> image)
 {
     auto image_dict = image->dict();
-    auto width = image_dict->get_value(CommonNames::Width).get<int>();
-    auto height = image_dict->get_value(CommonNames::Height).get<int>();
+    auto width = TRY(m_document->resolve_to<int>(image_dict->get_value(CommonNames::Width)));
+    auto height = TRY(m_document->resolve_to<int>(image_dict->get_value(CommonNames::Height)));
 
     auto is_filter = [&](DeprecatedFlyString const& name) -> PDFErrorOr<bool> {
         if (!image_dict->contains(CommonNames::Filter))
@@ -836,7 +836,7 @@ PDFErrorOr<NonnullRefPtr<Gfx::Bitmap>> Renderer::load_image(NonnullRefPtr<Stream
         return Error(Error::Type::RenderingUnsupported, "JPXDecode filter");
     }
     if (image_dict->contains(CommonNames::ImageMask)) {
-        auto is_mask = image_dict->get_value(CommonNames::ImageMask).get<bool>();
+        auto is_mask = TRY(m_document->resolve_to<bool>(image_dict->get_value(CommonNames::ImageMask)));
         if (is_mask) {
             return Error(Error::Type::RenderingUnsupported, "Image masks");
         }
@@ -853,7 +853,7 @@ PDFErrorOr<NonnullRefPtr<Gfx::Bitmap>> Renderer::load_image(NonnullRefPtr<Stream
     // FIXME: Do something with color_rendering_intent.
 
     // "Valid values are 1, 2, 4, 8, and (in PDF 1.5) 16."
-    auto bits_per_component = image_dict->get_value(CommonNames::BitsPerComponent).get<int>();
+    auto bits_per_component = TRY(m_document->resolve_to<int>(image_dict->get_value(CommonNames::BitsPerComponent)));
     if (bits_per_component != 8) {
         return Error(Error::Type::RenderingUnsupported, "Image's bit per component != 8");
     }
@@ -928,8 +928,8 @@ void Renderer::show_empty_image(int width, int height)
 PDFErrorOr<void> Renderer::show_image(NonnullRefPtr<StreamObject> image)
 {
     auto image_dict = image->dict();
-    auto width = image_dict->get_value(CommonNames::Width).get<int>();
-    auto height = image_dict->get_value(CommonNames::Height).get<int>();
+    auto width = TRY(m_document->resolve_to<int>(image_dict->get_value(CommonNames::Width)));
+    auto height = TRY(m_document->resolve_to<int>(image_dict->get_value(CommonNames::Height)));
 
     if (!m_rendering_preferences.show_images) {
         show_empty_image(width, height);


### PR DESCRIPTION
Except when explicitly noticed, every value in a PDF document can be an indirect reference (`42 0 R`) to an indirect object (`42 0 obj ... endobj`), and the value's contents is then the indirect object's reference.

Use the right methods to make this work in a few more places.

Also, make ints in outline item colors work.