### PR TITLE
LibWeb: Set module map entry before invoking callbacks

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/Scripting/ModuleMap.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/ModuleMap.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, networkException <networkexception@serenityos.org>
+ * Copyright (c) 2022-2023, networkException <networkexception@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -42,12 +42,14 @@ Optional<ModuleMap::Entry> ModuleMap::get(AK::URL const& url, DeprecatedString c
 
 AK::HashSetResult ModuleMap::set(AK::URL const& url, DeprecatedString const& type, Entry entry)
 {
+    auto value = m_values.set({ url, type }, entry);
+
     auto callbacks = m_callbacks.get({ url, type });
     if (callbacks.has_value())
         for (auto const& callback : *callbacks)
             callback(entry);
 
-    return m_values.set({ url, type }, entry);
+    return value;
 }
 
 void ModuleMap::wait_for_change(AK::URL const& url, DeprecatedString const& type, Function<void(Entry)> callback)


### PR DESCRIPTION
This pull request fixes the value of a module map entry being wrong in the callbacks invoked in the set call. Previously we would set the value in only after invoking the callbacks, leading to crashes when a callback implementation would rightfully assume the value to be set already.

Resolves #20994

Here's Reddit!

![image](https://github.com/SerenityOS/serenity/assets/42888162/2fc52953-0579-4963-b37f-f91e476a9d0c)


