### PR TITLE
Shell: Expand prompt formatting options

### DIFF
--- a/Base/usr/share/man/man7/Shell-vars.md
+++ b/Base/usr/share/man/man7/Shell-vars.md
@@ -63,6 +63,13 @@ The value of this variable is used to generate a prompt, the following escape se
 - `\\u`: the current username
 - `\\w`: a collapsed path (relative to home) to the current directory
 - `\\X`: reset style (foreground and background color, etc)
+- `\\t`: Current time in the 24-hour format HH:MM:SS
+- `\\T`: Current time in the 12-hour format HH:MM
+- `\\@`: Current time in the 12-hour format HH:MM AM/PM
+- `\\D{format}`: Current time, where the string _format_ is passed on to `Core::DateTime::to_string`. If _format_ is empty, a default format string is chosen.
+- `\\j`: The number of jobs currently managed by the shell
+- `\\!`: The history number of the next command to be run
+- `\\\\`: A backslash
 
 Any other escaped character shall be ignored.
 

--- a/Userland/Shell/Shell.cpp
+++ b/Userland/Shell/Shell.cpp
@@ -19,6 +19,7 @@
 #include <AK/StringBuilder.h>
 #include <AK/TemporaryChange.h>
 #include <AK/URL.h>
+#include <LibCore/DateTime.h>
 #include <LibCore/DirIterator.h>
 #include <LibCore/Event.h>
 #include <LibCore/EventLoop.h>
@@ -128,6 +129,15 @@ DeprecatedString Shell::prompt() const
 
         } else if (lexer.consume_specific('p')) {
             builder.append(uid == 0 ? '#' : '$');
+
+        } else if (lexer.consume_specific('t')) {
+            builder.append(Core::DateTime::now().to_deprecated_string("%H:%M:%S"sv));
+
+        } else if (lexer.consume_specific('T')) {
+            builder.append(Core::DateTime::now().to_deprecated_string("%I:%M:%S"sv));
+
+        } else if (lexer.consume_specific('@')) {
+            builder.append(Core::DateTime::now().to_deprecated_string("%I:%M %p"sv));
 
         } else if (lexer.consume_specific('j')) {
             builder.appendff("{}", jobs.size());

--- a/Userland/Shell/Shell.cpp
+++ b/Userland/Shell/Shell.cpp
@@ -2133,10 +2133,10 @@ bool Shell::read_single_line()
         if (line.is_empty())
             return true;
 
-        run_command(line);
-
         if (!has_history_event(line))
             m_editor->add_to_history(line);
+
+        run_command(line);
 
         return true;
     }

--- a/Userland/Shell/Shell.cpp
+++ b/Userland/Shell/Shell.cpp
@@ -139,6 +139,15 @@ DeprecatedString Shell::prompt() const
         } else if (lexer.consume_specific('@')) {
             builder.append(Core::DateTime::now().to_deprecated_string("%I:%M %p"sv));
 
+        } else if (lexer.consume_specific("D{"sv)) {
+            auto format = lexer.consume_until('}');
+            if (!lexer.consume_specific('}'))
+                continue;
+
+            if (format.is_empty())
+                format = "%y-%m-%d"sv;
+            builder.append(Core::DateTime::now().to_deprecated_string(format));
+
         } else if (lexer.consume_specific('j')) {
             builder.appendff("{}", jobs.size());
 

--- a/Userland/Shell/Shell.cpp
+++ b/Userland/Shell/Shell.cpp
@@ -129,6 +129,12 @@ DeprecatedString Shell::prompt() const
         } else if (lexer.consume_specific('p')) {
             builder.append(uid == 0 ? '#' : '$');
 
+        } else if (lexer.consume_specific('!')) {
+            if (m_editor)
+                builder.appendff("{}", m_editor->history().size() + 1);
+            else
+                builder.append('!');
+
         } else {
             lexer.consume();
         }

--- a/Userland/Shell/Shell.cpp
+++ b/Userland/Shell/Shell.cpp
@@ -157,6 +157,9 @@ DeprecatedString Shell::prompt() const
             else
                 builder.append('!');
 
+        } else if (lexer.consume_specific('\\')) {
+            builder.append('\\');
+
         } else {
             lexer.consume();
         }

--- a/Userland/Shell/Shell.cpp
+++ b/Userland/Shell/Shell.cpp
@@ -129,6 +129,9 @@ DeprecatedString Shell::prompt() const
         } else if (lexer.consume_specific('p')) {
             builder.append(uid == 0 ? '#' : '$');
 
+        } else if (lexer.consume_specific('j')) {
+            builder.appendff("{}", jobs.size());
+
         } else if (lexer.consume_specific('!')) {
             if (m_editor)
                 builder.appendff("{}", m_editor->history().size() + 1);


### PR DESCRIPTION
This pull request adds more formatting options to the `$PROMPT` variable, that is used to set the shell prompt. I've tried to copy what [Bash](https://www.gnu.org/software/bash/manual/bash.html#Controlling-the-Prompt) and [Zsh](https://zsh.sourceforge.io/Doc/Release/Prompt-Expansion.html) is doing as much as possible. Where they disagree with each other, I've made my own decision for how Shell should act.

New special characters:

- `\t`: Current time in the 24-hour format HH:MM:SS
- `\T`: Current time in the 12-hour format HH:MM
- `\@`:  Current time in the 12-hour format HH:MM AM/PM
- `\D{format}`: Current time, where the string _format_ is passed on to `Core::DateTime::to_string`. If _format_ is empty, a default format string is chosen.
- `\j`: The number of jobs currently managed by the shell
- `\!`: The history number of the next command to be run
- `\\`: A backslash

![Screenshot](https://github.com/SerenityOS/serenity/assets/58829763/c7978051-2961-4579-aa17-275166fc3bda)

