### PR TITLE
CI: Remove git LFS tracking of test262 data

### DIFF
--- a/.github/workflows/libjs-test262.yml
+++ b/.github/workflows/libjs-test262.yml
@@ -32,11 +32,6 @@ jobs:
         with:
           repository: SerenityOS/libjs-test262-data
           path: libjs-test262-data
-          lfs: true
-
-      - name: Checkout SerenityOS/libjs-test262-data LFS objects
-        working-directory: libjs-test262-data
-        run: git lfs checkout
 
       - name: Checkout tc39/test262
         uses: actions/checkout@v4


### PR DESCRIPTION
See:
https://github.com/SerenityOS/libjs-test262-data/commit/75f5027d5e4f92db6aed60d4f5e69b8cb6f98fe9