### PR TITLE
Avoid LibGfx depending on LibGUI

### DIFF
--- a/Userland/Libraries/LibGUI/Forward.h
+++ b/Userland/Libraries/LibGUI/Forward.h
@@ -100,6 +100,8 @@ class ConnectionToWindowServer;
 enum class ModelRole;
 enum class SortOrder;
 
+enum class TabPosition;
+
 }
 
 namespace WindowServer {

--- a/Userland/Libraries/LibGUI/TabWidget.h
+++ b/Userland/Libraries/LibGUI/TabWidget.h
@@ -12,15 +12,17 @@
 
 namespace GUI {
 
+enum class TabPosition {
+    Top,
+    Bottom,
+    Left,
+    Right,
+};
+
 class TabWidget : public Widget {
     C_OBJECT(TabWidget)
 public:
-    enum TabPosition {
-        Top,
-        Bottom,
-        Left,
-        Right,
-    };
+    typedef GUI::TabPosition TabPosition;
 
     virtual ~TabWidget() override = default;
 

--- a/Userland/Libraries/LibGfx/ClassicStylePainter.cpp
+++ b/Userland/Libraries/LibGfx/ClassicStylePainter.cpp
@@ -9,6 +9,7 @@
  */
 
 #include <AK/StringView.h>
+#include <LibGUI/TabWidget.h>
 #include <LibGfx/AntiAliasingPainter.h>
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/CharacterBitmap.h>

--- a/Userland/Libraries/LibGfx/ClassicStylePainter.h
+++ b/Userland/Libraries/LibGfx/ClassicStylePainter.h
@@ -16,7 +16,7 @@ namespace Gfx {
 class ClassicStylePainter : public BaseStylePainter {
 public:
     virtual void paint_button(Painter&, IntRect const&, Palette const&, ButtonStyle, bool pressed, bool hovered = false, bool checked = false, bool enabled = true, bool focused = false, bool default_button = false) override;
-    virtual void paint_tab_button(Painter&, IntRect const&, Palette const&, bool active, bool hovered, bool enabled, GUI::TabWidget::TabPosition position, bool in_active_window, bool accented) override;
+    virtual void paint_tab_button(Painter&, IntRect const&, Palette const&, bool active, bool hovered, bool enabled, GUI::TabPosition position, bool in_active_window, bool accented) override;
     virtual void paint_frame(Painter&, IntRect const&, Palette const&, FrameStyle, bool skip_vertical_lines = false) override;
     virtual void paint_window_frame(Painter&, IntRect const&, Palette const&) override;
     virtual void paint_progressbar(Painter&, IntRect const&, Palette const&, int min, int max, int value, StringView text, Orientation = Orientation::Horizontal) override;

--- a/Userland/Libraries/LibGfx/StylePainter.cpp
+++ b/Userland/Libraries/LibGfx/StylePainter.cpp
@@ -18,7 +18,7 @@ BaseStylePainter& StylePainter::current()
     return style;
 }
 
-void StylePainter::paint_tab_button(Painter& painter, IntRect const& rect, Palette const& palette, bool active, bool hovered, bool enabled, GUI::TabWidget::TabPosition position, bool in_active_window, bool accented)
+void StylePainter::paint_tab_button(Painter& painter, IntRect const& rect, Palette const& palette, bool active, bool hovered, bool enabled, GUI::TabPosition position, bool in_active_window, bool accented)
 {
     current().paint_tab_button(painter, rect, palette, active, hovered, enabled, position, in_active_window, accented);
 }

--- a/Userland/Libraries/LibGfx/StylePainter.h
+++ b/Userland/Libraries/LibGfx/StylePainter.h
@@ -7,7 +7,7 @@
 #pragma once
 
 #include <AK/Forward.h>
-#include <LibGUI/TabWidget.h>
+#include <LibGUI/Forward.h>
 #include <LibGfx/Forward.h>
 #include <LibGfx/Orientation.h>
 
@@ -38,7 +38,7 @@ public:
     virtual ~BaseStylePainter() = default;
 
     virtual void paint_button(Painter&, IntRect const&, Palette const&, ButtonStyle, bool pressed, bool hovered = false, bool checked = false, bool enabled = true, bool focused = false, bool default_button = false) = 0;
-    virtual void paint_tab_button(Painter&, IntRect const&, Palette const&, bool active, bool hovered, bool enabled, GUI::TabWidget::TabPosition position, bool in_active_window, bool accented) = 0;
+    virtual void paint_tab_button(Painter&, IntRect const&, Palette const&, bool active, bool hovered, bool enabled, GUI::TabPosition position, bool in_active_window, bool accented) = 0;
     virtual void paint_frame(Painter&, IntRect const&, Palette const&, FrameStyle, bool skip_vertical_lines = false) = 0;
     virtual void paint_window_frame(Painter&, IntRect const&, Palette const&) = 0;
     virtual void paint_progressbar(Painter&, IntRect const&, Palette const&, int min, int max, int value, StringView text, Orientation = Orientation::Horizontal) = 0;
@@ -57,7 +57,7 @@ public:
 
     // FIXME: These are here for API compatibility, we should probably remove them and move BaseStylePainter into here
     static void paint_button(Painter&, IntRect const&, Palette const&, ButtonStyle, bool pressed, bool hovered = false, bool checked = false, bool enabled = true, bool focused = false, bool default_button = false);
-    static void paint_tab_button(Painter&, IntRect const&, Palette const&, bool active, bool hovered, bool enabled, GUI::TabWidget::TabPosition position, bool in_active_window, bool accented);
+    static void paint_tab_button(Painter&, IntRect const&, Palette const&, bool active, bool hovered, bool enabled, GUI::TabPosition position, bool in_active_window, bool accented);
     static void paint_frame(Painter&, IntRect const&, Palette const&, FrameStyle, bool skip_vertical_lines = false);
     static void paint_window_frame(Painter&, IntRect const&, Palette const&);
     static void paint_progressbar(Painter&, IntRect const&, Palette const&, int min, int max, int value, StringView text, Orientation = Orientation::Horizontal);


### PR DESCRIPTION
Unfortunately, it doesn't seem to be possible to declare (either fully, or forward-declare) a type nested in another forward-declared type. This means that even though LibGfx only used the `GUI::TabWidget::TabPosition` simple enum (top, bottom, left, right — it doesn't get much simpler than this), it had to include the complete `<LibGUI/TabWidget.h>` header to be able to refer to it. And `TabWidget` being a widget, it includes a lot of LibGUI machinery with it, such as `<LibGUI/Widget.h>`, `<LibGUI/Event.h>`, WindowServer IPC details, and so on. This is fine when using LibGUI on SerenityOS proper, but may be problematic for Lagom. Really, the only thing LibGfx wants here is the simple 4-case enum.

This commit moves `GUI::TabWidget::TabPosition` to `GUI::TabPosition` (the old name still works as an alias), which makes it possible to forward- declare it, and avoid including the full `<LibGUI/TabWidget.h>`.

--------

This makes Ladybird GTK 4 build again.