### PR TITLE
LibPDF: Don't assert on outline destinations that use `null` as page

### DIFF
--- a/Userland/Libraries/LibPDF/Document.cpp
+++ b/Userland/Libraries/LibPDF/Document.cpp
@@ -418,6 +418,10 @@ PDFErrorOr<void> Document::build_outline()
 PDFErrorOr<Destination> Document::create_destination_from_parameters(NonnullRefPtr<ArrayObject> array, HashMap<u32, u32> const& page_number_by_index_ref)
 {
     auto page_ref = array->at(0);
+
+    if (page_ref.has<nullptr_t>())
+        return Destination { Destination::Type::XYZ, {}, {} };
+
     auto type_name = TRY(array->get_name_at(this, 1))->name();
 
     Vector<Optional<float>> parameters;


### PR DESCRIPTION
Nothing in PDF 1.7 spec 8.2.1 Destinations mentions the page being `null`, but it happens in 0000372.pdf (for the root outline element) and in 0000776.pdf (for every outline element, which looks like a bug in the generator maybe) of 0000.zip from the pdfa dataset.