### PR TITLE
LibGfx: Use safe version of `count_leading_zeroes()` in WOFF parsers

### DIFF
--- a/Userland/Libraries/LibGfx/Font/WOFF/Font.cpp
+++ b/Userland/Libraries/LibGfx/Font/WOFF/Font.cpp
@@ -65,7 +65,7 @@ static u16 pow_2_less_than_or_equal(u16 x)
 {
     VERIFY(x > 0);
     VERIFY(x < 32769);
-    return 1 << (sizeof(u16) * 8 - count_leading_zeroes<u16>(x - 1));
+    return 1 << (sizeof(u16) * 8 - count_leading_zeroes_safe<u16>(x - 1));
 }
 
 ErrorOr<NonnullRefPtr<Font>> Font::try_load_from_file(DeprecatedString path, unsigned int index)

--- a/Userland/Libraries/LibGfx/Font/WOFF2/Font.cpp
+++ b/Userland/Libraries/LibGfx/Font/WOFF2/Font.cpp
@@ -113,7 +113,7 @@ static u16 pow_2_less_than_or_equal(u16 x)
 {
     VERIFY(x > 0);
     VERIFY(x < 32769);
-    return 1 << (sizeof(u16) * 8 - count_leading_zeroes<u16>(x - 1));
+    return 1 << (sizeof(u16) * 8 - count_leading_zeroes_safe<u16>(x - 1));
 }
 
 enum class TransformationVersion {


### PR DESCRIPTION
This guards against undefined behavior when zero is given as an argument.

This fixes oss fuzz issues: [63635](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=63635) and  [63637](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=63637)