### PR TITLE
Meta+Documentation: Restore links to LibJS website

### DIFF
--- a/Documentation/Links.md
+++ b/Documentation/Links.md
@@ -22,6 +22,8 @@ This is a roughly categorized list of pages relating to SerenityOS and its subpr
 -   [Issues Found by OSS-Fuzz Continuous Fuzzing](https://bugs.chromium.org/p/oss-fuzz/issues/list?q=label:Proj-serenity)
 -   [Azure CI Overview](https://dev.azure.com/SerenityOS/SerenityOS/_build)
 -   [SonarCloud Static Analysis](https://sonarcloud.io/project/overview?id=SerenityOS_serenity)
+-   [LibJS website](https://serenityos.github.io/libjs-website/)
+    -   [Try LibJS Online!](https://serenityos.github.io/libjs-website/repl/)
 -   [Compiler Explorer](https://serenity.godbolt.org/): Select "Lagom trunk" under "Libraries" and add the compiler option `-std=c++20`
 
 ## Related Projects
@@ -57,7 +59,8 @@ This is a roughly categorized list of pages relating to SerenityOS and its subpr
 -   [Emoji Table](https://emoji.serenityos.net/)
     -   [Emoji Statistics](https://emoji.serenityos.net/chart.emoji.serenityos)
 -   [Flags](https://flags.serenityos.net/)
--   [test262](https://test262.fyi/) (JavaScript Spec Tests)
+-   [test262](https://serenityos.github.io/libjs-website/test262/) (JavaScript Spec Tests)
+-   [Wasm Spec Tests](https://serenityos.github.io/libjs-website/wasm/)
 -   [Test Performance](https://github.com/alimpfard/random-serenity-statistics/tree/main/view/benchmarks/x86_64)
 -   [serenityos.social Statistics](https://grafana.serenityos.social/public)
 

--- a/Meta/Lagom/ReadMe.md
+++ b/Meta/Lagom/ReadMe.md
@@ -14,7 +14,9 @@ Lagom is used by the Serenity project in the following ways:
 - [Unit tests](../../Documentation/RunningTests.md) in CI are built using the Lagom build for host systems to ensure portability.
 - [Continuous fuzzing](#fuzzing-on-oss-fuzz) is done with the help of OSS-fuzz using the Lagom build.
 - [The Ladybird browser](../../Ladybird/README.md) uses Lagom to provide LibWeb and LibJS for non-Serenity systems.
-- [ECMA 262 spec tests](https://v8.github.io/test262/website/default.html) for LibJS are run per-commit and tracked on [test262.fyi](https:/test262.fyi) by CanadaHonk.
+- [ECMA 262 spec tests](https://serenityos.github.io/libjs-website/test262) for LibJS are run per-commit and tracked on [LibJS website](https://serenityos.github.io/libjs-website/).
+- [Wasm spec tests](https://serenityos.github.io/libjs-website/wasm) for LibWasm are run per-commit and tracked on [LibJS website](https://serenityos.github.io/libjs-website/).
+- [A Wasm LibJS Repl](https://serenityos.github.io/libjs-website/repl) using an Emscripten build of Lagom is hosted on [LibJS website](https://serenityos.github.io/libjs-website/).
 - [The LibJS Repl](../../.github/workflows/serenity-js-artifacts.yml) is built per-commit for Linux and macOS for use by the [esvu](https://github.com/devsnek/esvu) project.
 
 ## Using Lagom in an External Project

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ You can watch videos of the system being developed on YouTube:
 ## Features
 
 * Modern x86 64-bit kernel with pre-emptive multi-threading
-* [Browser](Userland/Applications/Browser/) with JavaScript, WebAssembly, and more (check the spec compliance for [JS](https://test262.fyi/#|libjs) and [CSS](https://css.tobyase.de/))
+* [Browser](Userland/Applications/Browser/) with JavaScript, WebAssembly, and more (check the spec compliance for [JS](https://serenityos.github.io/libjs-website/test262/), [CSS](https://css.tobyase.de/), and [Wasm](https://serenityos.github.io/libjs-website/wasm/))
 * Security features (hardware protections, limited userland capabilities, W^X memory, `pledge` & `unveil`, (K)ASLR, OOM-resistance, web-content isolation, state-of-the-art TLS algorithms, ...)
 * [System services](Userland/Services/) (WindowServer, LoginServer, AudioServer, WebServer, RequestServer, CrashServer, ...) and modern IPC
 * Good POSIX compatibility ([LibC](Userland/Libraries/LibC/), Shell, syscalls, signals, pseudoterminals, filesystem notifications, standard Unix [utilities](Userland/Utilities/), ...)


### PR DESCRIPTION
This partially reverts dacf7265 and 67ca5d65.