### PR TITLE
AK, LibCompress: Add randomized tests

### DIFF
--- a/Meta/Lagom/Fuzzers/FuzzBase64Roundtrip.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzBase64Roundtrip.cpp
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2023, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Base64.h>
+#include <stdio.h>
+
+extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
+{
+    AK::set_debug_enabled(false);
+    auto input = ReadonlyBytes { data, size };
+
+    auto encoded = MUST(encode_base64(input));
+    auto decoded = MUST(decode_base64(encoded));
+
+    VERIFY(decoded == input);
+
+    return 0;
+}

--- a/Meta/Lagom/Fuzzers/FuzzGzipRoundtrip.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzGzipRoundtrip.cpp
@@ -10,6 +10,12 @@
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
     AK::set_debug_enabled(false);
-    (void)Compress::GzipCompressor::compress_all(ReadonlyBytes { data, size });
+    auto input = ReadonlyBytes { data, size };
+
+    auto compressed = MUST(Compress::GzipCompressor::compress_all(input));
+    auto decompressed = MUST(Compress::GzipDecompressor::decompress_all(compressed));
+
+    VERIFY(decompressed == input);
+
     return 0;
 }

--- a/Meta/Lagom/Fuzzers/fuzzers.cmake
+++ b/Meta/Lagom/Fuzzers/fuzzers.cmake
@@ -1,5 +1,6 @@
 set(FUZZER_TARGETS
     ASN1
+    Base64Roundtrip
     BLAKE2b
     BMPLoader
     Brotli

--- a/Meta/Lagom/Fuzzers/fuzzers.cmake
+++ b/Meta/Lagom/Fuzzers/fuzzers.cmake
@@ -11,8 +11,8 @@ set(FUZZER_TARGETS
     FlacLoader
     Gemini
     GIFLoader
-    GzipCompression
     GzipDecompression
+    GzipRoundtrip
     HttpRequest
     ICCProfile
     ICOLoader
@@ -83,8 +83,8 @@ set(FUZZER_DEPENDENCIES_ELF LibELF)
 set(FUZZER_DEPENDENCIES_FlacLoader LibAudio)
 set(FUZZER_DEPENDENCIES_Gemini LibGemini)
 set(FUZZER_DEPENDENCIES_GIFLoader LibGfx)
-set(FUZZER_DEPENDENCIES_GzipCompression LibCompress)
 set(FUZZER_DEPENDENCIES_GzipDecompression LibCompress)
+set(FUZZER_DEPENDENCIES_GzipRoundtrip LibCompress)
 set(FUZZER_DEPENDENCIES_HttpRequest LibHTTP)
 set(FUZZER_DEPENDENCIES_ICCProfile LibGfx)
 set(FUZZER_DEPENDENCIES_ICOLoader LibGfx)

--- a/Tests/AK/TestAllOf.cpp
+++ b/Tests/AK/TestAllOf.cpp
@@ -10,6 +10,34 @@
 #include <AK/Array.h>
 #include <AK/Vector.h>
 
+using namespace Test::Randomized;
+
+TEST_CASE(vacuous_truth)
+{
+    constexpr Array<int, 0> a {};
+    static_assert(all_of(a.begin(), a.end(), [](auto) { return false; }));
+    EXPECT(all_of(a.begin(), a.end(), [](auto) { return false; }));
+}
+
+TEST_CASE(all_but_one_false)
+{
+    constexpr Array<int, 5> a { 0, 1, 2, 3, 4 };
+    static_assert(!all_of(a.begin(), a.end(), [](auto n) { return n != 3; }));
+    EXPECT(!all_of(a.begin(), a.end(), [](auto n) { return n != 3; }));
+}
+
+RANDOMIZED_TEST_CASE(trivial_all_true)
+{
+    GEN(vec, Gen::vector(0, 10, []() { return Gen::unsigned_int(); }));
+    EXPECT(all_of(vec.begin(), vec.end(), [](auto) { return true; }));
+}
+
+RANDOMIZED_TEST_CASE(trivial_all_false)
+{
+    GEN(vec, Gen::vector(1, 10, []() { return Gen::unsigned_int(); }));
+    EXPECT(!all_of(vec.begin(), vec.end(), [](auto) { return false; }));
+}
+
 TEST_CASE(should_determine_if_predicate_applies_to_all_elements_in_container)
 {
     constexpr Array<int, 10> a {};

--- a/Tests/AK/TestAnyOf.cpp
+++ b/Tests/AK/TestAnyOf.cpp
@@ -10,6 +10,34 @@
 #include <AK/Array.h>
 #include <AK/Vector.h>
 
+using namespace Test::Randomized;
+
+TEST_CASE(vacuous_truth)
+{
+    constexpr Array<int, 0> a {};
+    static_assert(!any_of(a.begin(), a.end(), [](auto) { return true; }));
+    EXPECT(!any_of(a.begin(), a.end(), [](auto) { return true; }));
+}
+
+TEST_CASE(all_false)
+{
+    constexpr Array<int, 5> a { 0, 1, 2, 3, 4 };
+    static_assert(!any_of(a.begin(), a.end(), [](auto n) { return n > 10; }));
+    EXPECT(!any_of(a.begin(), a.end(), [](auto n) { return n > 10; }));
+}
+
+RANDOMIZED_TEST_CASE(trivial_all_true)
+{
+    GEN(vec, Gen::vector(1, 10, []() { return Gen::unsigned_int(); }));
+    EXPECT(any_of(vec.begin(), vec.end(), [](auto) { return true; }));
+}
+
+RANDOMIZED_TEST_CASE(trivial_all_false)
+{
+    GEN(vec, Gen::vector(0, 10, []() { return Gen::unsigned_int(); }));
+    EXPECT(!any_of(vec.begin(), vec.end(), [](auto) { return false; }));
+}
+
 TEST_CASE(should_determine_if_predicate_applies_to_any_element_in_container)
 {
     constexpr Array<int, 10> a { 1 };

--- a/Tests/AK/TestBinaryHeap.cpp
+++ b/Tests/AK/TestBinaryHeap.cpp
@@ -9,6 +9,8 @@
 #include <AK/BinaryHeap.h>
 #include <AK/DeprecatedString.h>
 
+using namespace Test::Randomized;
+
 TEST_CASE(construct)
 {
     BinaryHeap<int, int, 5> empty;
@@ -63,5 +65,40 @@ TEST_CASE(large_populate_reverse)
     for (int i = 0; i < 1024; i++) {
         EXPECT_EQ(ints.peek_min(), i);
         EXPECT_EQ(ints.pop_min(), i);
+    }
+}
+
+RANDOMIZED_TEST_CASE(pop_min_is_min)
+{
+    GEN(vec, Gen::vector(1, 10, []() { return Gen::unsigned_int(); }));
+
+    auto sorted { vec };
+    AK::quick_sort(sorted);
+
+    BinaryHeap<u32, u32, 10> heap;
+
+    // insert in a non-sorted order
+    for (u32 n : vec) {
+        heap.insert(n, n);
+    }
+
+    // check in a sorted order
+    for (u32 sorted_n : sorted) {
+        EXPECT_EQ(heap.pop_min(), sorted_n);
+    }
+}
+
+RANDOMIZED_TEST_CASE(peek_min_same_as_pop_min)
+{
+    GEN(vec, Gen::vector(1, 10, []() { return Gen::unsigned_int(); }));
+    BinaryHeap<u32, u32, 10> heap;
+    for (u32 n : vec) {
+        heap.insert(n, n);
+    }
+
+    while (!heap.is_empty()) {
+        u32 peeked = heap.peek_min();
+        u32 popped = heap.pop_min();
+        EXPECT_EQ(peeked, popped);
     }
 }

--- a/Tests/AK/TestBinarySearch.cpp
+++ b/Tests/AK/TestBinarySearch.cpp
@@ -12,6 +12,8 @@
 #include <cstring>
 #include <new>
 
+using namespace Test::Randomized;
+
 TEST_CASE(vector_ints)
 {
     Vector<int> ints;
@@ -116,4 +118,28 @@ TEST_CASE(unsigned_to_signed_regression)
     size_t nearby_index = 1;
     EXPECT_EQ(binary_search(input, 1u, &nearby_index), &input[1]);
     EXPECT_EQ(nearby_index, 1u);
+}
+
+RANDOMIZED_TEST_CASE(finds_number_that_is_present)
+{
+    GEN(vec, Gen::vector(1, 16, []() { return Gen::unsigned_int(); }));
+    GEN(i, Gen::unsigned_int(0, vec.size() - 1));
+    AK::quick_sort(vec);
+    u32 n = vec[i];
+    auto ptr = binary_search(vec, n);
+    EXPECT_NE(ptr, nullptr);
+    EXPECT_EQ(*ptr, n);
+}
+
+RANDOMIZED_TEST_CASE(doesnt_find_number_that_is_not_present)
+{
+    GEN(vec, Gen::vector(1, 16, []() { return Gen::unsigned_int(); }));
+    AK::quick_sort(vec);
+
+    u32 not_present = 0;
+    while (!vec.find(not_present).is_end()) {
+        ++not_present;
+    }
+
+    EXPECT_EQ(binary_search(vec, not_present), nullptr);
 }

--- a/Tests/AK/TestBitStream.cpp
+++ b/Tests/AK/TestBitStream.cpp
@@ -8,6 +8,8 @@
 #include <AK/MemoryStream.h>
 #include <LibTest/TestCase.h>
 
+using namespace Test::Randomized;
+
 // Note: This does not do any checks on the internal representation, it just ensures that the behavior of the input and output streams match.
 TEST_CASE(little_endian_bit_stream_input_output_match)
 {
@@ -128,4 +130,91 @@ TEST_CASE(big_endian_bit_stream_input_output_match)
         auto result = MUST(bit_read_stream.read_bits(16));
         EXPECT_EQ(0b1101001000100001u, result);
     }
+}
+
+RANDOMIZED_TEST_CASE(roundtrip_u8_little_endian)
+{
+    GEN(n, Gen::unsigned_int(NumericLimits<u8>::max()));
+
+    auto memory_stream = make<AllocatingMemoryStream>();
+    LittleEndianOutputBitStream sut_write { MaybeOwned<Stream>(*memory_stream) };
+    LittleEndianInputBitStream sut_read { MaybeOwned<Stream>(*memory_stream) };
+
+    MUST(sut_write.write_bits(n, 8));
+    MUST(sut_write.flush_buffer_to_stream());
+    auto result = MUST(sut_read.read_bits<u64>(8));
+
+    EXPECT_EQ(result, n);
+}
+
+RANDOMIZED_TEST_CASE(roundtrip_u16_little_endian)
+{
+    GEN(n, Gen::unsigned_int(NumericLimits<u16>::max()));
+
+    auto memory_stream = make<AllocatingMemoryStream>();
+    LittleEndianOutputBitStream sut_write { MaybeOwned<Stream>(*memory_stream) };
+    LittleEndianInputBitStream sut_read { MaybeOwned<Stream>(*memory_stream) };
+
+    MUST(sut_write.write_bits(n, 16));
+    MUST(sut_write.flush_buffer_to_stream());
+    auto result = MUST(sut_read.read_bits<u64>(16));
+
+    EXPECT_EQ(result, n);
+}
+
+RANDOMIZED_TEST_CASE(roundtrip_u32_little_endian)
+{
+    GEN(n, Gen::unsigned_int(NumericLimits<u32>::max()));
+
+    auto memory_stream = make<AllocatingMemoryStream>();
+    LittleEndianOutputBitStream sut_write { MaybeOwned<Stream>(*memory_stream) };
+    LittleEndianInputBitStream sut_read { MaybeOwned<Stream>(*memory_stream) };
+
+    MUST(sut_write.write_bits(n, 32));
+    MUST(sut_write.flush_buffer_to_stream());
+    auto result = MUST(sut_read.read_bits<u64>(32));
+
+    EXPECT_EQ(result, n);
+}
+
+RANDOMIZED_TEST_CASE(roundtrip_u8_big_endian)
+{
+    GEN(n, Gen::unsigned_int(NumericLimits<u8>::max()));
+
+    auto memory_stream = make<AllocatingMemoryStream>();
+    BigEndianOutputBitStream sut_write { MaybeOwned<Stream>(*memory_stream) };
+    BigEndianInputBitStream sut_read { MaybeOwned<Stream>(*memory_stream) };
+
+    MUST(sut_write.write_bits(n, 8));
+    auto result = MUST(sut_read.read_bits<u64>(8));
+
+    EXPECT_EQ(result, n);
+}
+
+RANDOMIZED_TEST_CASE(roundtrip_u16_big_endian)
+{
+    GEN(n, Gen::unsigned_int(NumericLimits<u16>::max()));
+
+    auto memory_stream = make<AllocatingMemoryStream>();
+    BigEndianOutputBitStream sut_write { MaybeOwned<Stream>(*memory_stream) };
+    BigEndianInputBitStream sut_read { MaybeOwned<Stream>(*memory_stream) };
+
+    MUST(sut_write.write_bits(n, 16));
+    auto result = MUST(sut_read.read_bits<u64>(16));
+
+    EXPECT_EQ(result, n);
+}
+
+RANDOMIZED_TEST_CASE(roundtrip_u32_big_endian)
+{
+    GEN(n, Gen::unsigned_int(NumericLimits<u32>::max()));
+
+    auto memory_stream = make<AllocatingMemoryStream>();
+    BigEndianOutputBitStream sut_write { MaybeOwned<Stream>(*memory_stream) };
+    BigEndianInputBitStream sut_read { MaybeOwned<Stream>(*memory_stream) };
+
+    MUST(sut_write.write_bits(n, 32));
+    auto result = MUST(sut_read.read_bits<u64>(32));
+
+    EXPECT_EQ(result, n);
 }

--- a/Userland/Libraries/LibTest/Randomized/Generator.h
+++ b/Userland/Libraries/LibTest/Randomized/Generator.h
@@ -49,7 +49,9 @@ inline u32 unsigned_int(u32 max)
         return 0;
 
     u32 random = Test::randomness_source().draw_value(max, [&]() {
-        return AK::get_random_uniform(max + 1);
+        // `clamp` to guard against integer overflow and calling get_random_uniform(0).
+        u32 exclusive_bound = AK::clamp(max + 1, max, NumericLimits<u32>::max());
+        return AK::get_random_uniform(exclusive_bound);
     });
     return random;
 }

--- a/Userland/Utilities/test-fuzz.cpp
+++ b/Userland/Utilities/test-fuzz.cpp
@@ -13,6 +13,7 @@
 // TODO: Look into generating this from the authoritative list of fuzzing targets in fuzzer.cmake.
 #define ENUMERATE_TARGETS(T) \
     T(ASN1)                  \
+    T(Base64Roundtrip)       \
     T(BLAKE2b)               \
     T(BMPLoader)             \
     T(Brotli)                \

--- a/Userland/Utilities/test-fuzz.cpp
+++ b/Userland/Utilities/test-fuzz.cpp
@@ -25,8 +25,8 @@
     T(FlacLoader)            \
     T(Gemini)                \
     T(GIFLoader)             \
-    T(GzipCompression)       \
     T(GzipDecompression)     \
+    T(GzipRoundtrip)         \
     T(HttpRequest)           \
     T(ICCProfile)            \
     T(ICOLoader)             \


### PR DESCRIPTION
Let me know if you want some of these split into separate PRs!
I have more tests to write, I'm going through the current test suites alphabetically. Probably to come in separate PRs.
What I have right now:

## Roundtrip properties

> dec(enc(x)) == x

- LibCompress/Gzip - `decompress_all`, `compress_all` (fuzzer)
- AK/Base64 - `decode_base64`, `encode_base64` (fuzzer)
- AK/BitStream - `read_bits`, `write_bits` (randomized test, ⚠️ on a single call though, BitStream behaves weird when multiple reads and writes happen)

## Oracle tests

> my_impl(x) == definitely_correct_impl(x)

- CharacterTypes
  - `isascii` == `is_ascii` in the UNICODE char range
  - `tolower` == `to_ascii_lowercase` in the UNICODE char range
  - `toupper` == `to_ascii_uppercase` in the UNICODE char range

## Safety/Liveness

> Safety = "doesn't do the wrong thing"
> Liveness = "does the right thing"

- BinaryHeap
  - `pop_min()` returns values in ASC sorted order
  - `pop_min()` returns the same values as `peek_min()`
- BinarySearch
  - finds number that is present in a vector
  - doesn't find number that is not present in a vector
- Bitmap
  - after `set`, `get` finds the value
  - after `set_range`, `get` finds the values and `count_in_range` reports the correct count
  - after `fill`, the whole bitmap is set with the given value
  - `find_one_anywhere` finds a value after we set a value
  - `find_first` finds a value after we set a value

## Other

- AllOf
  - an always true predicate makes `allOf` true for any input (even empty)
  - an always false predicate makes `allOf` false for any non-empty input
  - also unit tests for vacuous truth
- AnyOf
  - an always true predicate makes `anyOf` true for any non-empty input
  - an always false predicate makes `anyOf` false for any input (even empty)
  - also unit tests for vacuous truth
- BuiltinWrappers
  - `count_leading_zeroes` doesn't change if set bits below MSB
  - `count_required_bits(n) == log2(n) + 1`
  - `bit_scan_forward(n) == count_trailing_zeroes(n) + 1` (except for 0)