### PR TITLE
AK: Use array element count instead of memory size in backtrace call

### DIFF
--- a/AK/Assertions.cpp
+++ b/AK/Assertions.cpp
@@ -41,7 +41,7 @@ ALWAYS_INLINE void dump_backtrace()
 {
     // Grab symbols and dso name for up to 256 frames
     void* trace[256] = {};
-    int const num_frames = backtrace(trace, sizeof(trace));
+    int const num_frames = backtrace(trace, array_size(trace));
     char** syms = backtrace_symbols(trace, num_frames);
 
     for (auto i = 0; i < num_frames; ++i) {


### PR DESCRIPTION
The backtrace execinfo API takes the number of addresses the result buffer can hold instead of its size, for some reason. Previously backtraces larger than 256 frames deep would write past the end of the result buffer.

Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=63214 & https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=62263