### PR TITLE
LibJS/JIT: Dump disassembly of generated code using LibX86

### DIFF
--- a/Userland/Libraries/LibJS/CMakeLists.txt
+++ b/Userland/Libraries/LibJS/CMakeLists.txt
@@ -268,3 +268,6 @@ set(SOURCES
 
 serenity_lib(LibJS js)
 target_link_libraries(LibJS PRIVATE LibCore LibCrypto LibFileSystem LibRegex LibSyntax LibLocale LibUnicode LibJIT)
+if("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "x86_64")
+    target_link_libraries(LibJS PRIVATE LibX86)
+endif()

--- a/Userland/Libraries/LibJS/JIT/Compiler.cpp
+++ b/Userland/Libraries/LibJS/JIT/Compiler.cpp
@@ -24,6 +24,7 @@
 #    define LOG_JIT_SUCCESS 1
 #    define LOG_JIT_FAILURE 1
 #    define DUMP_JIT_MACHINE_CODE_TO_STDOUT 0
+#    define DUMP_JIT_DISASSEMBLY 0
 
 #    define TRY_OR_SET_EXCEPTION(expression)                                                                                        \
         ({                                                                                                                          \
@@ -1154,7 +1155,10 @@ OwnPtr<NativeExecutable> Compiler::compile(Bytecode::Executable& bytecode_execut
         dbgln("\033[32;1mJIT compilation succeeded!\033[0m {}", bytecode_executable.name);
     }
 
-    return make<NativeExecutable>(executable_memory, compiler.m_output.size());
+    auto executable = make<NativeExecutable>(executable_memory, compiler.m_output.size());
+    if constexpr (DUMP_JIT_DISASSEMBLY)
+        executable->dump_disassembly();
+    return executable;
 }
 
 }

--- a/Userland/Libraries/LibJS/JIT/NativeExecutable.cpp
+++ b/Userland/Libraries/LibJS/JIT/NativeExecutable.cpp
@@ -7,6 +7,7 @@
 #include <LibJS/Bytecode/Interpreter.h>
 #include <LibJS/JIT/NativeExecutable.h>
 #include <LibJS/Runtime/VM.h>
+#include <LibX86/Disassembler.h>
 #include <sys/mman.h>
 
 namespace JS::JIT {
@@ -28,6 +29,44 @@ void NativeExecutable::run(VM& vm) const
     ((JITCode)m_code)(vm,
         vm.bytecode_interpreter().registers().data(),
         vm.running_execution_context().local_variables.data());
+}
+
+void NativeExecutable::dump_disassembly() const
+{
+#if ARCH(X86_64)
+    auto const* code_bytes = static_cast<u8 const*>(m_code);
+    auto stream = X86::SimpleInstructionStream { code_bytes, m_size };
+    auto disassembler = X86::Disassembler(stream);
+
+    while (true) {
+        auto offset = stream.offset();
+        auto virtual_offset = bit_cast<size_t>(m_code) + offset;
+        auto insn = disassembler.next();
+        if (!insn.has_value())
+            break;
+
+        StringBuilder builder;
+        builder.appendff("{:p}  ", virtual_offset);
+        auto length = insn.value().length();
+        for (size_t i = 0; i < 7; i++) {
+            if (i < length)
+                builder.appendff("{:02x} ", code_bytes[offset + i]);
+            else
+                builder.append("   "sv);
+        }
+        builder.append(" "sv);
+        builder.append(insn.value().to_deprecated_string(virtual_offset, nullptr));
+        dbgln("{}", builder.string_view());
+
+        for (size_t bytes_printed = 7; bytes_printed < length; bytes_printed += 7) {
+            builder.clear();
+            builder.appendff("{:p} ", virtual_offset + bytes_printed);
+            for (size_t i = bytes_printed; i < bytes_printed + 7 && i < length; i++)
+                builder.appendff(" {:02x}", code_bytes[offset + i]);
+            dbgln("{}", builder.string_view());
+        }
+    }
+#endif
 }
 
 }

--- a/Userland/Libraries/LibJS/JIT/NativeExecutable.h
+++ b/Userland/Libraries/LibJS/JIT/NativeExecutable.h
@@ -21,6 +21,7 @@ public:
     ~NativeExecutable();
 
     void run(VM&) const;
+    void dump_disassembly() const;
 
 private:
     void* m_code { nullptr };

--- a/Userland/Libraries/LibX86/Instruction.cpp
+++ b/Userland/Libraries/LibX86/Instruction.cpp
@@ -1236,7 +1236,8 @@ static void build_sse_66_slash(u8 op, u8 slash, char const* mnemonic, Instructio
     table64[0x9A] = {};                         // far CALL
     table64[0x9C].long_mode_default_64 = true;  // PUSHF/D/Q
     table64[0x9D].long_mode_default_64 = true;  // POPF/D/Q
-    build_in_table(table64, 0xB8, "MOV", OP_regW_immW, &Interpreter::MOV_reg32_imm32, LockPrefixNotAllowed);
+    for (u8 mov = 0xB8; mov <= 0xBF; ++mov)
+        build_in_table(table64, mov, "MOV", OP_regW_immW, &Interpreter::MOV_reg32_imm32, LockPrefixNotAllowed);
     table64[0xC2].long_mode_force_64 = true;   // near RET
     table64[0xC3].long_mode_force_64 = true;   // near RET
     table64[0xC4] = {};                        // LES


### PR DESCRIPTION
This avoids the need for redirecting stdout to a file and using ndisasm, which can lead to problems if other things are printed.
Also fixes a decoding bug for imm64 MOVs in LibX86.