### PR TITLE
LibPDF: Ensure xref stream field widths are within expected range

### DIFF
--- a/Userland/Libraries/LibPDF/DocumentParser.cpp
+++ b/Userland/Libraries/LibPDF/DocumentParser.cpp
@@ -430,7 +430,12 @@ PDFErrorOr<NonnullRefPtr<XRefTable>> DocumentParser::parse_xref_stream()
         for (int i = 0; i < count; i++) {
             Array<long, 3> fields;
             for (size_t field_index = 0; field_index < 3; ++field_index) {
+                if (!field_sizes->at(field_index).has_u32())
+                    return error("Malformed xref stream");
+
                 auto field_size = field_sizes->at(field_index).get_u32();
+                if (field_size > 8)
+                    return error("Malformed xref stream");
 
                 if (byte_index + field_size > stream->bytes().size())
                     return error("The xref stream data cut off early");


### PR DESCRIPTION
Previously, an xref stream with a field with larger than 8 would result in an undefined shift occurring. We now ensure that each field width is a number and is less than or equal to 8.

I looked at a few PDF libraries and none of them perform this check. All the implementations I looked at [shifted the value one byte at a time](https://github.com/ArtifexSoftware/mupdf/blob/384425820b0ed144758c6d237911cbadb7aa4f3b/source/pdf/pdf-xref.c#L1363), but as far as I can tell, this could still result in an overflow.

No change in `test_pdf` output with a selection of 776 random PDFs from my local machine.

This fixes oss fuzz issue: [63232](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=63232)