### PR TITLE
Kernel: Switch init boot argument to "/init"

### DIFF
--- a/Kernel/Arch/init.cpp
+++ b/Kernel/Arch/init.cpp
@@ -446,6 +446,8 @@ void init_stage2(void*)
     auto userspace_init = kernel_command_line().userspace_init();
     auto init_args = kernel_command_line().userspace_init_args();
 
+    dmesgln("Running first user process: {}", userspace_init);
+    dmesgln("Init (first) process args: {}", init_args);
     auto init_or_error = Process::create_user_process(userspace_init, UserID(0), GroupID(0), move(init_args), {}, tty0);
     if (init_or_error.is_error())
         PANIC("init_stage2: Error spawning init process: {}", init_or_error.error());

--- a/Kernel/Boot/CommandLine.cpp
+++ b/Kernel/Boot/CommandLine.cpp
@@ -298,7 +298,7 @@ UNMAP_AFTER_INIT CommandLine::GraphicsSubsystemMode CommandLine::graphics_subsys
 
 StringView CommandLine::userspace_init() const
 {
-    return lookup("init"sv).value_or("/bin/SystemServer"sv);
+    return lookup("init"sv).value_or("/init"sv);
 }
 
 Vector<NonnullOwnPtr<KString>> CommandLine::userspace_init_args() const

--- a/Meta/build-root-filesystem.sh
+++ b/Meta/build-root-filesystem.sh
@@ -201,6 +201,7 @@ ln -sf Shell mnt/bin/sh
 ln -sf test mnt/bin/[
 ln -sf less mnt/bin/more
 ln -sf /bin/env mnt/usr/bin/env
+ln -sf /bin/SystemServer mnt/init
 echo "done"
 
 printf "installing 'checksum' variants... "


### PR DESCRIPTION
This doesn't affect system functionality, but somewhat reduces the
reliance on complicated hardcoded paths. It also allows the user to
simply link /init (which is normally a symbolic link) to another program
to run it instead of SystemServer as the default option.

This kind of functionality is present on linux systems, and is considered a good preparation if we want an init(ram)fs functionality as well.
Old filesystems such as [BFS](https://www.kernel.org/doc/html/latest/filesystems/bfs.html) (known as BootFS, not to be confused with BeFS from BeOS) also don't support directories, so if we choose that filesystem or another simplistic design for an initramfs (so we can simply don't care about directories), this can help as well.