### PR TITLE
LibWeb: Fix width of text when using bitmap fonts being 1 pixel too long

### DIFF
--- a/Tests/LibWeb/Layout/expected/textnode-width-bitmap-font.txt
+++ b/Tests/LibWeb/Layout/expected/textnode-width-bitmap-font.txt
@@ -1,0 +1,17 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x38 [BFC] children: not-inline
+    BlockContainer <body> at (8,13) content-size 784x17 children: not-inline
+      BlockContainer <p> at (8,13) content-size 784x17 children: inline
+        line 0 width: 102, height: 17, bottom: 17, baseline: 11
+          frag 0 from TextNode start: 0, length: 18, rect: [8,13 102x17]
+            "This is some text."
+        TextNode <#text>
+      BlockContainer <(anonymous)> at (8,43) content-size 784x0 children: inline
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x38] overflow: [0,0 800x43]
+    PaintableWithLines (BlockContainer<BODY>) [8,13 784x17] overflow: [8,13 784x30]
+      PaintableWithLines (BlockContainer<P>) [8,13 784x17]
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,43 784x0]

--- a/Tests/LibWeb/Layout/input/textnode-width-bitmap-font.html
+++ b/Tests/LibWeb/Layout/input/textnode-width-bitmap-font.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><p style="font-family: Katica">This is some text.</p>

--- a/Userland/Libraries/LibWeb/Layout/InlineLevelIterator.cpp
+++ b/Userland/Libraries/LibWeb/Layout/InlineLevelIterator.cpp
@@ -180,13 +180,19 @@ Optional<InlineLevelIterator::Item> InlineLevelIterator::next_without_lookahead(
             m_text_node_context->is_last_chunk = true;
 
         auto& chunk = chunk_opt.value();
-        CSSPixels chunk_width = CSSPixels::nearest_value_for(text_node.font().width(chunk.view) + text_node.font().glyph_spacing());
 
         if (m_text_node_context->do_respect_linebreaks && chunk.has_breaking_newline) {
             return Item {
                 .type = Item::Type::ForcedBreak,
             };
         }
+
+        CSSPixels chunk_width;
+
+        if (m_text_node_context->is_last_chunk)
+            chunk_width = CSSPixels::nearest_value_for(text_node.font().width(chunk.view));
+        else
+            chunk_width = CSSPixels::nearest_value_for(text_node.font().width(chunk.view) + text_node.font().glyph_spacing());
 
         // NOTE: We never consider `content: ""` to be collapsible whitespace.
         bool is_generated_empty_string = text_node.is_generated() && chunk.length == 0;


### PR DESCRIPTION
When calculating the width of text using a SerenityOS bitmap font, a glyph spacing is added at the end of each fragment (so that adjacent fragments are properly spaced). This includes the last one, with no adjacent fragment, this meant that everything was 1 pixel too long. This bug did not affect vector fonts, and tests thus don't need to be rebaselined.