### PR TITLE
JIT: Optimization for 64-bit mov

### DIFF
--- a/Userland/Libraries/LibJIT/Assembler.h
+++ b/Userland/Libraries/LibJIT/Assembler.h
@@ -115,6 +115,17 @@ struct Assembler {
         emit8(count.offset_or_immediate);
     }
 
+    void shift_left(Operand dst, Operand count)
+    {
+        VERIFY(dst.type == Operand::Type::Reg);
+        VERIFY(count.type == Operand::Type::Imm);
+        VERIFY(count.fits_in_u8());
+        emit8(0x48 | ((to_underlying(dst.reg) >= 8) ? 1 << 0 : 0));
+        emit8(0xc1);
+        emit8(0xf0 | encode_reg(dst.reg));
+        emit8(count.offset_or_immediate);
+    }
+
     enum class Patchable {
         Yes,
         No,

--- a/Userland/Libraries/LibJIT/Assembler.h
+++ b/Userland/Libraries/LibJIT/Assembler.h
@@ -160,6 +160,14 @@ struct Assembler {
                     emit32(src.offset_or_immediate);
                     return;
                 }
+                if ((src.offset_or_immediate & 0xffffffff) == 0) {
+                    if (dst.reg > Reg::RDI)
+                        emit8(0x41);
+                    emit8(0xb8 | encode_reg(dst.reg));
+                    emit32((src.offset_or_immediate >> 32) & 0xffffffff);
+                    shift_left(dst, Operand::Imm(32));
+                    return;
+                }
             }
             emit8(0x48 | ((to_underlying(dst.reg) >= 8) ? 1 << 0 : 0));
             emit8(0xb8 | encode_reg(dst.reg));


### PR DESCRIPTION
This introduces an optimization where a 64-bit-mov from an immediate to a register gets converted to a 32-bit-mov of the top bits of the immediate and a left-shift afterwards. Obviously this only works if the immediate's lower 32 bits are 0. This is quite often the case, for example the LibJS Tags reside in the top bits.
This encoding saves 1 byte compared to the plain 64-bit-mov.

I didn't expect this to have measurable results, but it has! A dumb loop program with 1 billion iterations gets about 2% faster. I just thought it was a fun exercise in the new shiny JIT and the confusing x86 instruction encoding...

Top: With, Bottom: Without
![image](https://github.com/SerenityOS/serenity/assets/6002167/9a598577-61fe-42f8-be34-48ea71fda0f5)
