### PR TITLE
LibWeb: Stop forward-declaring NavigationParams twice

### DIFF
--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -451,7 +451,6 @@ struct CrossOriginOpenerPolicyEnforcementResult;
 struct Environment;
 struct EnvironmentSettingsObject;
 struct NavigationParams;
-struct NavigationParams;
 struct PolicyContainer;
 struct POSTResource;
 struct ScrollOptions;


### PR DESCRIPTION
In the running for possibly the most exciting PR of 2023.