### PR TITLE
LibWeb: Treat height as auto if containing block's height isn't explicitly set

### DIFF
--- a/Tests/LibWeb/Layout/expected/flex/flex-column-child-height-percentage.txt
+++ b/Tests/LibWeb/Layout/expected/flex/flex-column-child-height-percentage.txt
@@ -1,0 +1,28 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x116 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x100 children: not-inline
+      Box <div.flex-container> at (8,8) content-size 784x100 flex-container(column) [FFC] children: not-inline
+        BlockContainer <div.flex-item> at (8,8) content-size 784x100 flex-item [BFC] children: not-inline
+          BlockContainer <div.box> at (8,8) content-size 784x17.46875 children: inline
+            line 0 width: 259, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+              frag 0 from TextNode start: 0, length: 30, rect: [8,8 259x17.46875]
+                "I make music you can dream to."
+            TextNode <#text>
+          BlockContainer <div> at (8,25.46875) content-size 784x17.46875 children: inline
+            line 0 width: 119.03125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+              frag 0 from TextNode start: 0, length: 13, rect: [8,25.46875 119.03125x17.46875]
+                "My SoundCloud"
+            TextNode <#text>
+      BlockContainer <(anonymous)> at (8,108) content-size 784x0 children: inline
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x116]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x100]
+      PaintableBox (Box<DIV>.flex-container) [8,8 784x100]
+        PaintableWithLines (BlockContainer<DIV>.flex-item) [8,8 784x100]
+          PaintableWithLines (BlockContainer<DIV>.box) [8,8 784x17.46875]
+            TextPaintable (TextNode<#text>)
+          PaintableWithLines (BlockContainer<DIV>) [8,25.46875 784x17.46875]
+            TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,108 784x0]

--- a/Tests/LibWeb/Layout/expected/flex/flex-nested-height-percentage.txt
+++ b/Tests/LibWeb/Layout/expected/flex/flex-nested-height-percentage.txt
@@ -1,0 +1,27 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x98.9375 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x82.9375 children: not-inline
+      Box <div.flex-container> at (8,8) content-size 784x82.9375 flex-container(row) [FFC] children: not-inline
+        BlockContainer <div.box> at (8,8) content-size 167.65625x82.9375 flex-item [BFC] children: not-inline
+          BlockContainer <div.box> at (8,8) content-size 167.65625x0 children: not-inline
+          BlockContainer <p> at (8,24) content-size 167.65625x17.46875 children: inline
+            line 0 width: 167.65625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+              frag 0 from TextNode start: 0, length: 19, rect: [8,24 167.65625x17.46875]
+                "Something something"
+            TextNode <#text>
+          BlockContainer <p> at (8,57.46875) content-size 167.65625x17.46875 children: inline
+            line 0 width: 138.28125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+              frag 0 from TextNode start: 0, length: 18, rect: [8,57.46875 138.28125x17.46875]
+                "Well hello friends"
+            TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x98.9375]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x82.9375]
+      PaintableBox (Box<DIV>.flex-container) [8,8 784x82.9375]
+        PaintableWithLines (BlockContainer<DIV>.box) [8,8 167.65625x82.9375]
+          PaintableWithLines (BlockContainer<DIV>.box) [8,8 167.65625x0]
+          PaintableWithLines (BlockContainer<P>) [8,24 167.65625x17.46875]
+            TextPaintable (TextNode<#text>)
+          PaintableWithLines (BlockContainer<P>) [8,57.46875 167.65625x17.46875]
+            TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/input/flex/flex-column-child-height-percentage.html
+++ b/Tests/LibWeb/Layout/input/flex/flex-column-child-height-percentage.html
@@ -1,0 +1,16 @@
+<!doctype html><style>
+    * {
+        outline: 1px solid black !important;
+    }
+    .flex-item {
+        flex-grow: 1;
+    }
+    .box {
+        height: 100%;
+    }
+    .flex-container {
+        display: flex;
+        min-height: 100px;
+        flex-direction: column;
+    }
+</style><div class="flex-container"><div class="flex-item"><div class="box">I make music you can dream to.</div><div>My SoundCloud</div></div></div>

--- a/Tests/LibWeb/Layout/input/flex/flex-nested-height-percentage.html
+++ b/Tests/LibWeb/Layout/input/flex/flex-nested-height-percentage.html
@@ -1,0 +1,11 @@
+<!doctype html><style>
+  * {
+    outline: 1px solid black !important;
+  }
+  .box {
+    height: 100%;
+  }
+  .flex-container {
+    display: flex;
+  }
+</style><div class="flex-container"><div class="box"><div class="box"></div><p>Something something</p><p>Well hello friends</p></div></div>

--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -461,7 +461,7 @@ void BlockFormattingContext::compute_height(Box const& box, AvailableSpace const
     if (box_is_sized_as_replaced_element(box)) {
         height = compute_height_for_replaced_element(box, available_space);
     } else {
-        if (should_treat_height_as_auto(box, available_space)) {
+        if (should_treat_height_as_auto(box)) {
             height = compute_auto_height_for_block_level_element(box, m_state.get(box).available_inner_space_or_constraints_from(available_space));
         } else {
             height = calculate_inner_height(box, available_space.height, computed_values.height()).to_px(box);

--- a/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -1937,13 +1937,13 @@ bool FlexFormattingContext::should_treat_main_size_as_auto(Box const& box) const
 {
     if (is_row_layout())
         return should_treat_width_as_auto(box, m_available_space_for_items->space);
-    return should_treat_height_as_auto(box, m_available_space_for_items->space);
+    return should_treat_height_as_auto(box);
 }
 
 bool FlexFormattingContext::should_treat_cross_size_as_auto(Box const& box) const
 {
     if (is_row_layout())
-        return should_treat_height_as_auto(box, m_available_space_for_items->space);
+        return should_treat_height_as_auto(box);
     return should_treat_width_as_auto(box, m_available_space_for_items->space);
 }
 

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -386,7 +386,7 @@ CSSPixels FormattingContext::tentative_width_for_replaced_element(Box const& box
     if (computed_width.is_percentage() && !m_state.get(*box.containing_block()).has_definite_width())
         return 0;
 
-    auto computed_height = should_treat_height_as_auto(box, available_space) ? CSS::Size::make_auto() : box.computed_values().height();
+    auto computed_height = should_treat_height_as_auto(box) ? CSS::Size::make_auto() : box.computed_values().height();
 
     CSSPixels used_width = calculate_inner_width(box, available_space.width, computed_width).to_px(box);
 
@@ -451,7 +451,7 @@ CSSPixels FormattingContext::compute_width_for_replaced_element(Box const& box, 
     auto width_of_containing_block = available_space.width.to_px_or_zero();
 
     auto computed_width = should_treat_width_as_auto(box, available_space) ? CSS::Size::make_auto() : box.computed_values().width();
-    auto computed_height = should_treat_height_as_auto(box, available_space) ? CSS::Size::make_auto() : box.computed_values().height();
+    auto computed_height = should_treat_height_as_auto(box) ? CSS::Size::make_auto() : box.computed_values().height();
 
     // 1. The tentative used width is calculated (without 'min-width' and 'max-width')
     auto used_width = tentative_width_for_replaced_element(box, computed_width, available_space);
@@ -490,7 +490,7 @@ CSSPixels FormattingContext::tentative_height_for_replaced_element(Box const& bo
 {
     // If 'height' and 'width' both have computed values of 'auto' and the element also has
     // an intrinsic height, then that intrinsic height is the used value of 'height'.
-    if (should_treat_width_as_auto(box, available_space) && should_treat_height_as_auto(box, available_space) && box.has_natural_height())
+    if (should_treat_width_as_auto(box, available_space) && should_treat_height_as_auto(box) && box.has_natural_height())
         return box.natural_height().value();
 
     // Otherwise, if 'height' has a computed value of 'auto', and the element has an intrinsic ratio then the used value of 'height' is:
@@ -522,7 +522,7 @@ CSSPixels FormattingContext::compute_height_for_replaced_element(Box const& box,
 
     auto height_of_containing_block = m_state.get(*box.non_anonymous_containing_block()).content_height();
     auto computed_width = should_treat_width_as_auto(box, available_space) ? CSS::Size::make_auto() : box.computed_values().width();
-    auto computed_height = should_treat_height_as_auto(box, available_space) ? CSS::Size::make_auto() : box.computed_values().height();
+    auto computed_height = should_treat_height_as_auto(box) ? CSS::Size::make_auto() : box.computed_values().height();
 
     // 1. The tentative used height is calculated (without 'min-height' and 'max-height')
     CSSPixels used_height = tentative_height_for_replaced_element(box, computed_height, available_space);
@@ -894,7 +894,7 @@ void FormattingContext::compute_height_for_absolutely_positioned_non_replaced_el
     };
 
     // If all three of top, height, and bottom are auto:
-    if (top.is_auto() && should_treat_height_as_auto(box, available_space) && bottom.is_auto()) {
+    if (top.is_auto() && should_treat_height_as_auto(box) && bottom.is_auto()) {
         // First set any auto values for margin-top and margin-bottom to 0,
         if (margin_top.is_auto())
             margin_top = CSS::Length::make_px(0);
@@ -922,7 +922,7 @@ void FormattingContext::compute_height_for_absolutely_positioned_non_replaced_el
     }
 
     // If none of the three are auto:
-    else if (!top.is_auto() && !should_treat_height_as_auto(box, available_space) && !bottom.is_auto()) {
+    else if (!top.is_auto() && !should_treat_height_as_auto(box) && !bottom.is_auto()) {
         // If both margin-top and margin-bottom are auto,
         if (margin_top.is_auto() && margin_bottom.is_auto()) {
             // solve the equation under the extra constraint that the two margins get equal values.
@@ -956,7 +956,7 @@ void FormattingContext::compute_height_for_absolutely_positioned_non_replaced_el
         // and pick one of the following six rules that apply.
 
         // 1. If top and height are auto and bottom is not auto,
-        if (top.is_auto() && should_treat_height_as_auto(box, available_space) && !bottom.is_auto()) {
+        if (top.is_auto() && should_treat_height_as_auto(box) && !bottom.is_auto()) {
             // then the height is based on the Auto heights for block formatting context roots,
             auto maybe_height = compute_auto_height_for_absolutely_positioned_element(box, available_space, before_or_after_inside_layout);
             if (!maybe_height.has_value())
@@ -968,7 +968,7 @@ void FormattingContext::compute_height_for_absolutely_positioned_non_replaced_el
         }
 
         // 2. If top and bottom are auto and height is not auto,
-        else if (top.is_auto() && bottom.is_auto() && !should_treat_height_as_auto(box, available_space)) {
+        else if (top.is_auto() && bottom.is_auto() && !should_treat_height_as_auto(box)) {
             // then set top to the static position,
             top = CSS::Length::make_px(calculate_static_position(box).y());
 
@@ -977,7 +977,7 @@ void FormattingContext::compute_height_for_absolutely_positioned_non_replaced_el
         }
 
         // 3. If height and bottom are auto and top is not auto,
-        else if (should_treat_height_as_auto(box, available_space) && bottom.is_auto() && !top.is_auto()) {
+        else if (should_treat_height_as_auto(box) && bottom.is_auto() && !top.is_auto()) {
             // then the height is based on the Auto heights for block formatting context roots,
             auto maybe_height = compute_auto_height_for_absolutely_positioned_element(box, available_space, before_or_after_inside_layout);
             if (!maybe_height.has_value())
@@ -989,19 +989,19 @@ void FormattingContext::compute_height_for_absolutely_positioned_non_replaced_el
         }
 
         // 4. If top is auto, height and bottom are not auto,
-        else if (top.is_auto() && !should_treat_height_as_auto(box, available_space) && !bottom.is_auto()) {
+        else if (top.is_auto() && !should_treat_height_as_auto(box) && !bottom.is_auto()) {
             // then solve for top.
             solve_for_top();
         }
 
         // 5. If height is auto, top and bottom are not auto,
-        else if (should_treat_height_as_auto(box, available_space) && !top.is_auto() && !bottom.is_auto()) {
+        else if (should_treat_height_as_auto(box) && !top.is_auto() && !bottom.is_auto()) {
             // then solve for height.
             solve_for_height();
         }
 
         // 6. If bottom is auto, top and height are not auto,
-        else if (bottom.is_auto() && !top.is_auto() && !should_treat_height_as_auto(box, available_space)) {
+        else if (bottom.is_auto() && !top.is_auto() && !should_treat_height_as_auto(box)) {
             // then solve for bottom.
             solve_for_bottom();
         }
@@ -1010,7 +1010,7 @@ void FormattingContext::compute_height_for_absolutely_positioned_non_replaced_el
     // Compute the height based on box type and CSS properties:
     // https://www.w3.org/TR/css-sizing-3/#box-sizing
     CSSPixels used_height = 0;
-    if (should_treat_height_as_auto(box, available_space)) {
+    if (should_treat_height_as_auto(box)) {
         used_height = height.to_px(box, height_of_containing_block);
     } else {
         used_height = calculate_inner_height(box, available_space.height, height).to_px(box);
@@ -1626,7 +1626,7 @@ bool FormattingContext::should_treat_width_as_auto(Box const& box, AvailableSpac
     return false;
 }
 
-bool FormattingContext::should_treat_height_as_auto(Box const& box, AvailableSpace const& available_space)
+bool FormattingContext::should_treat_height_as_auto(Box const& box)
 {
     auto computed_height = box.computed_values().height();
     if (computed_height.is_auto())
@@ -1640,11 +1640,23 @@ bool FormattingContext::should_treat_height_as_auto(Box const& box, AvailableSpa
     if (computed_height.is_min_content() || computed_height.is_max_content() || computed_height.is_fit_content())
         return true;
 
+    // https://www.w3.org/TR/CSS2/visudet.html#propdef-height
+    // The percentage is calculated with respect to the height of the generated box's containing block.
     if (box.computed_values().height().contains_percentage()) {
-        if (available_space.height.is_max_content())
+
+        // If the height of the containing block is not specified explicitly (i.e., it depends on content height),
+        // and this element is not absolutely positioned, the value computes to 'auto'.
+        if (!box.is_absolutely_positioned() && should_treat_height_as_auto(*box.non_anonymous_containing_block())) {
+            // NOTE: In quirks mode, the html element's height matches the viewport so it can be treated as definite
+            auto box_is_root_an_html_element_in_quirks_mode = box.document().in_quirks_mode()
+                && box.non_anonymous_containing_block()->dom_node()
+                && box.non_anonymous_containing_block()->dom_node()->is_html_html_element();
+
+            if (box_is_root_an_html_element_in_quirks_mode)
+                return false;
+
             return true;
-        if (available_space.height.is_indefinite())
-            return true;
+        }
     }
     return false;
 }

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.h
@@ -102,7 +102,7 @@ protected:
     FormattingContext(Type, LayoutState&, Box const&, FormattingContext* parent = nullptr);
 
     static bool should_treat_width_as_auto(Box const&, AvailableSpace const&);
-    static bool should_treat_height_as_auto(Box const&, AvailableSpace const&);
+    static bool should_treat_height_as_auto(Box const&);
 
     [[nodiscard]] bool should_treat_max_width_as_none(Box const&, AvailableSize const&) const;
     [[nodiscard]] bool should_treat_max_height_as_none(Box const&, AvailableSize const&) const;

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -2192,7 +2192,7 @@ CSSPixels GridFormattingContext::calculate_min_content_contribution(GridItem con
     auto should_treat_preferred_size_as_auto = [&] {
         if (dimension == GridDimension::Column)
             return should_treat_width_as_auto(item.box, available_space_for_item);
-        return should_treat_height_as_auto(item.box, available_space_for_item);
+        return should_treat_height_as_auto(item.box);
     }();
 
     if (should_treat_preferred_size_as_auto) {
@@ -2211,7 +2211,7 @@ CSSPixels GridFormattingContext::calculate_max_content_contribution(GridItem con
     auto should_treat_preferred_size_as_auto = [&] {
         if (dimension == GridDimension::Column)
             return should_treat_width_as_auto(item.box, available_space_for_item);
-        return should_treat_height_as_auto(item.box, available_space_for_item);
+        return should_treat_height_as_auto(item.box);
     }();
 
     auto preferred_size = get_item_preferred_size(item, dimension);
@@ -2327,7 +2327,7 @@ CSSPixels GridFormattingContext::calculate_minimum_contribution(GridItem const& 
     auto should_treat_preferred_size_as_auto = [&] {
         if (dimension == GridDimension::Column)
             return should_treat_width_as_auto(item.box, get_available_space_for_item(item));
-        return should_treat_height_as_auto(item.box, get_available_space_for_item(item));
+        return should_treat_height_as_auto(item.box);
     }();
 
     if (should_treat_preferred_size_as_auto) {

--- a/Userland/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -175,7 +175,7 @@ void InlineFormattingContext::dimension_box_on_line(Box const& box, LayoutMode l
     auto independent_formatting_context = layout_inside(box, layout_mode, box_state.available_inner_space_or_constraints_from(*m_available_space));
 
     auto const& height_value = box.computed_values().height();
-    if (should_treat_height_as_auto(box, *m_available_space)) {
+    if (should_treat_height_as_auto(box)) {
         // FIXME: (10.6.6) If 'height' is 'auto', the height depends on the element's descendants per 10.6.7.
         parent().compute_height(box, AvailableSpace(AvailableSize::make_indefinite(), AvailableSize::make_indefinite()));
     } else {


### PR DESCRIPTION
This brings the `should_treat_height_as_auto()` closer to the spec, which fixes #21054 and makes the https://linktr.ee/katalinkult look almost perfect :^)

| Before | After |
| --- | --- |
| <video src="https://github.com/SerenityOS/serenity/assets/36564831/514711e1-805b-4136-9638-4fa9f1a90e97"/> | <video src="https://github.com/SerenityOS/serenity/assets/36564831/9793a45e-689d-4e2e-aaed-d8e45d1eb087"/> |