### PR TITLE
LibJS+LibJIT: Put VM register array base in RBX so we can access it without ModR/M displacement

### DIFF
--- a/Userland/Libraries/LibJIT/Assembler.h
+++ b/Userland/Libraries/LibJIT/Assembler.h
@@ -161,7 +161,9 @@ struct Assembler {
                 | ((to_underlying(src.reg) >= 8) ? 1 << 2 : 0)
                 | ((to_underlying(dst.reg) >= 8) ? 1 << 0 : 0));
             emit8(0x89);
-            if (dst.offset_or_immediate <= 127) {
+            if (dst.reg <= Reg::RDI && dst.offset_or_immediate == 0) {
+                emit8(0x00 | (encode_reg(src.reg) << 3) | encode_reg(dst.reg));
+            } else if (dst.offset_or_immediate <= 127) {
                 emit8(0x40 | (encode_reg(src.reg) << 3) | encode_reg(dst.reg));
                 emit8(dst.offset_or_immediate);
             } else {
@@ -176,7 +178,9 @@ struct Assembler {
                 | ((to_underlying(dst.reg) >= 8) ? 1 << 2 : 0)
                 | ((to_underlying(src.reg) >= 8) ? 1 << 0 : 0));
             emit8(0x8b);
-            if (src.offset_or_immediate <= 127) {
+            if (src.reg <= Reg::RDI && src.offset_or_immediate == 0) {
+                emit8(0x00 | (encode_reg(dst.reg) << 3) | encode_reg(src.reg));
+            } else if (src.offset_or_immediate <= 127) {
                 emit8(0x40 | (encode_reg(dst.reg) << 3) | encode_reg(src.reg));
                 emit8(src.offset_or_immediate);
             } else {

--- a/Userland/Libraries/LibJS/JIT/Compiler.h
+++ b/Userland/Libraries/LibJS/JIT/Compiler.h
@@ -32,7 +32,7 @@ private:
     static constexpr auto ARG5 = Assembler::Reg::R9;
     static constexpr auto RET = Assembler::Reg::RAX;
     static constexpr auto STACK_POINTER = Assembler::Reg::RSP;
-    static constexpr auto REGISTER_ARRAY_BASE = Assembler::Reg::R13;
+    static constexpr auto REGISTER_ARRAY_BASE = Assembler::Reg::RBX;
     static constexpr auto LOCALS_ARRAY_BASE = Assembler::Reg::R14;
     static constexpr auto UNWIND_CONTEXT_BASE = Assembler::Reg::R15;
 #    endif


### PR DESCRIPTION
By moving it to a non-extended register instead of R13, we can use the ModR/M encoding without displacement for offset 0.

And the VM accumulator register is at offset 0, so this is *very* common. :^)