### PR TITLE
LibJS: Compile the NewBigInt & CallWithArgumentArray bytecode instructions

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/CommonImplementations.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/CommonImplementations.cpp
@@ -7,6 +7,7 @@
 #include <LibJS/Bytecode/CommonImplementations.h>
 #include <LibJS/Bytecode/Interpreter.h>
 #include <LibJS/Bytecode/Op.h>
+#include <LibJS/Runtime/Array.h>
 #include <LibJS/Runtime/DeclarativeEnvironment.h>
 #include <LibJS/Runtime/ECMAScriptFunctionObject.h>
 #include <LibJS/Runtime/GlobalEnvironment.h>
@@ -393,6 +394,33 @@ Value new_regexp(VM& vm, ParsedRegex const& parsed_regex, DeprecatedString const
     // here as we know RegExpCreate calls RegExpAlloc with %RegExp% for newTarget.
     regexp_object->set_legacy_features_enabled(true);
     return regexp_object;
+}
+
+// 13.3.8.1 https://tc39.es/ecma262/#sec-runtime-semantics-argumentlistevaluation
+MarkedVector<Value> argument_list_evaluation(Bytecode::Interpreter& interpreter)
+{
+    // Note: Any spreading and actual evaluation is handled in preceding opcodes
+    // Note: The spec uses the concept of a list, while we create a temporary array
+    //       in the preceding opcodes, so we have to convert in a manner that is not
+    //       visible to the user
+    auto& vm = interpreter.vm();
+
+    MarkedVector<Value> argument_values { vm.heap() };
+    auto arguments = interpreter.accumulator();
+
+    auto& argument_array = arguments.as_array();
+    auto array_length = argument_array.indexed_properties().array_like_size();
+
+    argument_values.ensure_capacity(array_length);
+
+    for (size_t i = 0; i < array_length; ++i) {
+        if (auto maybe_value = argument_array.indexed_properties().get(i); maybe_value.has_value())
+            argument_values.append(maybe_value.release_value().value);
+        else
+            argument_values.append(js_undefined());
+    }
+
+    return argument_values;
 }
 
 }

--- a/Userland/Libraries/LibJS/Bytecode/CommonImplementations.h
+++ b/Userland/Libraries/LibJS/Bytecode/CommonImplementations.h
@@ -31,5 +31,6 @@ struct CalleeAndThis {
 };
 ThrowCompletionOr<CalleeAndThis> get_callee_and_this_from_environment(Bytecode::Interpreter&, DeprecatedFlyString const& name, u32 cache_index);
 Value new_regexp(VM&, ParsedRegex const&, DeprecatedString const& pattern, DeprecatedString const& flags);
+MarkedVector<Value> argument_list_evaluation(Bytecode::Interpreter&);
 
 }

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -1027,33 +1027,6 @@ ThrowCompletionOr<void> JumpUndefined::execute_impl(Bytecode::Interpreter&) cons
     __builtin_unreachable();
 }
 
-// 13.3.8.1 https://tc39.es/ecma262/#sec-runtime-semantics-argumentlistevaluation
-static MarkedVector<Value> argument_list_evaluation(Bytecode::Interpreter& interpreter)
-{
-    // Note: Any spreading and actual evaluation is handled in preceding opcodes
-    // Note: The spec uses the concept of a list, while we create a temporary array
-    //       in the preceding opcodes, so we have to convert in a manner that is not
-    //       visible to the user
-    auto& vm = interpreter.vm();
-
-    MarkedVector<Value> argument_values { vm.heap() };
-    auto arguments = interpreter.accumulator();
-
-    auto& argument_array = arguments.as_array();
-    auto array_length = argument_array.indexed_properties().array_like_size();
-
-    argument_values.ensure_capacity(array_length);
-
-    for (size_t i = 0; i < array_length; ++i) {
-        if (auto maybe_value = argument_array.indexed_properties().get(i); maybe_value.has_value())
-            argument_values.append(maybe_value.release_value().value);
-        else
-            argument_values.append(js_undefined());
-    }
-
-    return argument_values;
-}
-
 ThrowCompletionOr<void> Call::execute_impl(Bytecode::Interpreter& interpreter) const
 {
     auto& vm = interpreter.vm();

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -256,6 +256,8 @@ public:
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     DeprecatedString to_deprecated_string_impl(Bytecode::Executable const&) const;
 
+    Crypto::SignedBigInteger const& bigint() const { return m_bigint; }
+
 private:
     Crypto::SignedBigInteger m_bigint;
 };

--- a/Userland/Libraries/LibJS/JIT/Compiler.cpp
+++ b/Userland/Libraries/LibJS/JIT/Compiler.cpp
@@ -617,11 +617,6 @@ void Compiler::compile_new_string(Bytecode::Op::NewString const& op)
     store_vm_register(Bytecode::Register::accumulator(), RET);
 }
 
-static Value cxx_new_regexp(VM& vm, Bytecode::ParsedRegex const& parsed_regex, DeprecatedString const& pattern, DeprecatedString const& flags)
-{
-    return Bytecode::new_regexp(vm, parsed_regex, pattern, flags);
-}
-
 void Compiler::compile_new_regexp(Bytecode::Op::NewRegExp const& op)
 {
     auto const& parsed_regex = m_bytecode_executable.regex_table->get(op.regex_index());
@@ -638,7 +633,7 @@ void Compiler::compile_new_regexp(Bytecode::Op::NewRegExp const& op)
         Assembler::Operand::Register(ARG3),
         Assembler::Operand::Imm(bit_cast<u64>(&flags)));
 
-    native_call((void*)cxx_new_regexp);
+    native_call((void*)Bytecode::new_regexp);
     store_vm_register(Bytecode::Register::accumulator(), RET);
 }
 
@@ -677,15 +672,6 @@ void Compiler::compile_new_array(Bytecode::Op::NewArray const& op)
     store_vm_register(Bytecode::Register::accumulator(), RET);
 }
 
-static Value cxx_new_function(
-    VM& vm,
-    FunctionExpression const& function_node,
-    Optional<Bytecode::IdentifierTableIndex> const& lhs_name,
-    Optional<Bytecode::Register> const& home_object)
-{
-    return Bytecode::new_function(vm, function_node, lhs_name, home_object);
-}
-
 void Compiler::compile_new_function(Bytecode::Op::NewFunction const& op)
 {
     m_assembler.mov(
@@ -697,7 +683,7 @@ void Compiler::compile_new_function(Bytecode::Op::NewFunction const& op)
     m_assembler.mov(
         Assembler::Operand::Register(ARG3),
         Assembler::Operand::Imm(bit_cast<u64>(&op.home_object())));
-    native_call((void*)cxx_new_function);
+    native_call((void*)Bytecode::new_function);
     store_vm_register(Bytecode::Register::accumulator(), RET);
 }
 

--- a/Userland/Libraries/LibJS/JIT/Compiler.cpp
+++ b/Userland/Libraries/LibJS/JIT/Compiler.cpp
@@ -637,6 +637,20 @@ void Compiler::compile_new_regexp(Bytecode::Op::NewRegExp const& op)
     store_vm_register(Bytecode::Register::accumulator(), RET);
 }
 
+static Value cxx_new_bigint(VM& vm, Crypto::SignedBigInteger const& bigint)
+{
+    return BigInt::create(vm, bigint);
+}
+
+void Compiler::compile_new_bigint(Bytecode::Op::NewBigInt const& op)
+{
+    m_assembler.mov(
+        Assembler::Operand::Register(ARG1),
+        Assembler::Operand::Imm(bit_cast<u64>(&op.bigint())));
+    native_call((void*)cxx_new_bigint);
+    store_vm_register(Bytecode::Register::accumulator(), RET);
+}
+
 static Value cxx_new_object(VM& vm)
 {
     auto& realm = *vm.current_realm();
@@ -1105,6 +1119,9 @@ OwnPtr<NativeExecutable> Compiler::compile(Bytecode::Executable& bytecode_execut
                 break;
             case Bytecode::Instruction::Type::NewRegExp:
                 compiler.compile_new_regexp(static_cast<Bytecode::Op::NewRegExp const&>(op));
+                break;
+            case Bytecode::Instruction::Type::NewBigInt:
+                compiler.compile_new_bigint(static_cast<Bytecode::Op::NewBigInt const&>(op));
                 break;
             case Bytecode::Instruction::Type::GetById:
                 compiler.compile_get_by_id(static_cast<Bytecode::Op::GetById const&>(op));

--- a/Userland/Libraries/LibJS/JIT/Compiler.h
+++ b/Userland/Libraries/LibJS/JIT/Compiler.h
@@ -111,6 +111,7 @@ private:
     void compile_put_by_value(Bytecode::Op::PutByValue const&);
 
     void compile_call(Bytecode::Op::Call const&);
+    void compile_call_with_argument_array(Bytecode::Op::CallWithArgumentArray const&);
     void compile_typeof_variable(Bytecode::Op::TypeofVariable const&);
     void compile_set_variable(Bytecode::Op::SetVariable const&);
     void compile_continue_pending_unwind(Bytecode::Op::ContinuePendingUnwind const&);

--- a/Userland/Libraries/LibJS/JIT/Compiler.h
+++ b/Userland/Libraries/LibJS/JIT/Compiler.h
@@ -99,6 +99,7 @@ private:
     void compile_new_array(Bytecode::Op::NewArray const&);
     void compile_new_function(Bytecode::Op::NewFunction const&);
     void compile_new_regexp(Bytecode::Op::NewRegExp const&);
+    void compile_new_bigint(Bytecode::Op::NewBigInt const&);
 
     void compile_get_by_id(Bytecode::Op::GetById const&);
     void compile_get_by_value(Bytecode::Op::GetByValue const&);


### PR DESCRIPTION
Just a couple of random instructions that were showing up a lot in test-js compilation failures.