### PR TITLE
LibJS/JIT: Consolidate exception handling code

### DIFF
--- a/Userland/Libraries/LibJIT/Assembler.h
+++ b/Userland/Libraries/LibJIT/Assembler.h
@@ -250,17 +250,12 @@ struct Assembler {
         }
     };
 
-    [[nodiscard]] Label make_label()
-    {
-        return Label {};
-    }
-
     [[nodiscard]] Label jump()
     {
         // jmp target (RIP-relative 32-bit offset)
         emit8(0xe9);
         emit32(0xdeadbeef);
-        auto label = make_label();
+        Assembler::Label label {};
         label.add_jump(*this, m_output.size());
         return label;
     }

--- a/Userland/Libraries/LibJIT/Assembler.h
+++ b/Userland/Libraries/LibJIT/Assembler.h
@@ -215,12 +215,14 @@ struct Assembler {
     }
 
     struct Label {
-        size_t offset_of_label_in_instruction_stream { 0 };
+        Optional<size_t> offset_of_label_in_instruction_stream;
         Vector<size_t> jump_slot_offsets_in_instruction_stream;
 
-        void add_jump(size_t offset)
+        void add_jump(Assembler& assembler, size_t offset)
         {
             jump_slot_offsets_in_instruction_stream.append(offset);
+            if (offset_of_label_in_instruction_stream.has_value())
+                link_jump(assembler, offset);
         }
 
         void link(Assembler& assembler)
@@ -230,24 +232,27 @@ struct Assembler {
 
         void link_to(Assembler& assembler, size_t link_offset)
         {
+            VERIFY(!offset_of_label_in_instruction_stream.has_value());
             offset_of_label_in_instruction_stream = link_offset;
-            for (auto offset_in_instruction_stream : jump_slot_offsets_in_instruction_stream) {
-                auto offset = offset_of_label_in_instruction_stream - offset_in_instruction_stream;
-                auto jump_slot = offset_in_instruction_stream - 4;
-                assembler.m_output[jump_slot + 0] = (offset >> 0) & 0xff;
-                assembler.m_output[jump_slot + 1] = (offset >> 8) & 0xff;
-                assembler.m_output[jump_slot + 2] = (offset >> 16) & 0xff;
-                assembler.m_output[jump_slot + 3] = (offset >> 24) & 0xff;
-            }
+            for (auto offset_in_instruction_stream : jump_slot_offsets_in_instruction_stream)
+                link_jump(assembler, offset_in_instruction_stream);
+        }
+
+    private:
+        void link_jump(Assembler& assembler, size_t offset_in_instruction_stream)
+        {
+            auto offset = offset_of_label_in_instruction_stream.value() - offset_in_instruction_stream;
+            auto jump_slot = offset_in_instruction_stream - 4;
+            assembler.m_output[jump_slot + 0] = (offset >> 0) & 0xff;
+            assembler.m_output[jump_slot + 1] = (offset >> 8) & 0xff;
+            assembler.m_output[jump_slot + 2] = (offset >> 16) & 0xff;
+            assembler.m_output[jump_slot + 3] = (offset >> 24) & 0xff;
         }
     };
 
     [[nodiscard]] Label make_label()
     {
-        return Label {
-            .offset_of_label_in_instruction_stream = m_output.size(),
-            .jump_slot_offsets_in_instruction_stream = {},
-        };
+        return Label {};
     }
 
     [[nodiscard]] Label jump()
@@ -256,7 +261,7 @@ struct Assembler {
         emit8(0xe9);
         emit32(0xdeadbeef);
         auto label = make_label();
-        label.add_jump(m_output.size());
+        label.add_jump(*this, m_output.size());
         return label;
     }
 
@@ -265,7 +270,7 @@ struct Assembler {
         // jmp target (RIP-relative 32-bit offset)
         emit8(0xe9);
         emit32(0xdeadbeef);
-        label.add_jump(m_output.size());
+        label.add_jump(*this, m_output.size());
     }
 
     void jump(Operand op)
@@ -337,7 +342,7 @@ struct Assembler {
         emit8(0x0f);
         emit8(0x84);
         emit32(0xdeadbeef);
-        label.add_jump(m_output.size());
+        label.add_jump(*this, m_output.size());
     }
 
     void jump_if_not_zero(Operand reg, Label& label)
@@ -348,7 +353,7 @@ struct Assembler {
         emit8(0x0f);
         emit8(0x85);
         emit32(0xdeadbeef);
-        label.add_jump(m_output.size());
+        label.add_jump(*this, m_output.size());
     }
 
     void jump_if_equal(Operand lhs, Operand rhs, Label& label)
@@ -364,7 +369,7 @@ struct Assembler {
         emit8(0x0f);
         emit8(0x84);
         emit32(0xdeadbeef);
-        label.add_jump(m_output.size());
+        label.add_jump(*this, m_output.size());
     }
 
     void jump_if_not_equal(Operand lhs, Operand rhs, Label& label)
@@ -380,7 +385,7 @@ struct Assembler {
         emit8(0x0f);
         emit8(0x85);
         emit32(0xdeadbeef);
-        label.add_jump(m_output.size());
+        label.add_jump(*this, m_output.size());
     }
 
     void jump_if_less_than(Operand lhs, Operand rhs, Label& label)
@@ -391,7 +396,7 @@ struct Assembler {
         emit8(0x0f);
         emit8(0x8c);
         emit32(0xdeadbeef);
-        label.add_jump(m_output.size());
+        label.add_jump(*this, m_output.size());
     }
 
     void sign_extend_32_to_64_bits(Reg reg)

--- a/Userland/Libraries/LibJS/JIT/Compiler.cpp
+++ b/Userland/Libraries/LibJS/JIT/Compiler.cpp
@@ -137,7 +137,7 @@ void Compiler::compile_to_boolean(Assembler::Reg dst, Assembler::Reg src)
         Assembler::Operand::Imm(48));
 
     // if (dst != BOOLEAN_TAG) goto slow_case;
-    auto slow_case = m_assembler.make_label();
+    Assembler::Label slow_case {};
     m_assembler.jump_if_not_equal(
         Assembler::Operand::Register(dst),
         Assembler::Operand::Imm(BOOLEAN_TAG),
@@ -220,7 +220,7 @@ void Compiler::branch_if_int32(Assembler::Reg reg, Codegen codegen)
     m_assembler.mov(Assembler::Operand::Register(GPR0), Assembler::Operand::Register(reg));
     m_assembler.shift_right(Assembler::Operand::Register(GPR0), Assembler::Operand::Imm(48));
 
-    auto not_int32_case = m_assembler.make_label();
+    Assembler::Label not_int32_case {};
     m_assembler.jump_if_not_equal(
         Assembler::Operand::Register(GPR0),
         Assembler::Operand::Imm(INT32_TAG),
@@ -242,7 +242,7 @@ void Compiler::branch_if_both_int32(Assembler::Reg lhs, Assembler::Reg rhs, Code
     m_assembler.mov(Assembler::Operand::Register(GPR1), Assembler::Operand::Register(rhs));
     m_assembler.shift_right(Assembler::Operand::Register(GPR1), Assembler::Operand::Imm(48));
 
-    auto not_int32_case = m_assembler.make_label();
+    Assembler::Label not_int32_case {};
     m_assembler.jump_if_not_equal(
         Assembler::Operand::Register(GPR0),
         Assembler::Operand::Imm(INT32_TAG),
@@ -261,8 +261,8 @@ void Compiler::compile_increment(Bytecode::Op::Increment const&)
 {
     load_vm_register(ARG1, Bytecode::Register::accumulator());
 
-    auto end = m_assembler.make_label();
-    auto slow_case = m_assembler.make_label();
+    Assembler::Label end {};
+    Assembler::Label slow_case {};
 
     branch_if_int32(ARG1, [&] {
         // GPR0 = ARG1 & 0xffffffff;
@@ -328,7 +328,7 @@ void Compiler::check_exception()
     // We have an exception!
 
     // if (!unwind_context.valid) return;
-    auto handle_exception = m_assembler.make_label();
+    Assembler::Label handle_exception {};
     m_assembler.mov(
         Assembler::Operand::Register(GPR0),
         Assembler::Operand::Mem64BaseAndOffset(UNWIND_CONTEXT_BASE, 0));
@@ -347,7 +347,7 @@ void Compiler::check_exception()
     //     exception = Value();
     //     goto handler;
     // }
-    auto no_handler = m_assembler.make_label();
+    Assembler::Label no_handler {};
     m_assembler.mov(
         Assembler::Operand::Register(GPR0),
         Assembler::Operand::Mem64BaseAndOffset(UNWIND_CONTEXT_BASE, 8));
@@ -367,7 +367,7 @@ void Compiler::check_exception()
     no_handler.link(m_assembler);
 
     // if (unwind_context.finalizer) goto finalizer;
-    auto no_finalizer = m_assembler.make_label();
+    Assembler::Label no_finalizer {};
     m_assembler.mov(
         Assembler::Operand::Register(GPR0),
         Assembler::Operand::Mem64BaseAndOffset(UNWIND_CONTEXT_BASE, 16));
@@ -505,13 +505,13 @@ void Compiler::compile_less_than(Bytecode::Op::LessThan const& op)
     load_vm_register(ARG1, op.lhs());
     load_vm_register(ARG2, Bytecode::Register::accumulator());
 
-    auto end = m_assembler.make_label();
+    Assembler::Label end {};
 
     branch_if_both_int32(ARG1, ARG2, [&] {
         // if (ARG1 < ARG2) return true;
         // else return false;
 
-        auto true_case = m_assembler.make_label();
+        Assembler::Label true_case {};
 
         m_assembler.sign_extend_32_to_64_bits(ARG1);
         m_assembler.sign_extend_32_to_64_bits(ARG2);
@@ -575,7 +575,7 @@ void Compiler::compile_return(Bytecode::Op::Return const&)
 
     // check for finalizer
     // if (!unwind_context.valid) goto normal_return;
-    auto normal_return = m_assembler.make_label();
+    Assembler::Label normal_return {};
     m_assembler.mov(
         Assembler::Operand::Register(GPR1),
         Assembler::Operand::Mem64BaseAndOffset(UNWIND_CONTEXT_BASE, 0));
@@ -831,7 +831,7 @@ void Compiler::compile_resolve_this_binding(Bytecode::Op::ResolveThisBinding con
         Assembler::Operand::Register(GPR1),
         Assembler::Operand::Imm(Value().encoded()));
 
-    auto slow_case = m_assembler.make_label();
+    Assembler::Label slow_case {};
     m_assembler.jump_if_equal(
         Assembler::Operand::Register(GPR0),
         Assembler::Operand::Register(GPR1),

--- a/Userland/Libraries/LibJS/JIT/Compiler.cpp
+++ b/Userland/Libraries/LibJS/JIT/Compiler.cpp
@@ -319,14 +319,18 @@ void Compiler::compile_decrement(Bytecode::Op::Decrement const&)
 
 void Compiler::check_exception()
 {
-    // if (exception.is_empty()) goto no_exception;
+    // if (!exception.is_empty()) goto m_exception_handler;
     load_vm_register(GPR0, Bytecode::Register::exception());
     m_assembler.mov(Assembler::Operand::Register(GPR1), Assembler::Operand::Imm(Value().encoded()));
-    auto no_exception = m_assembler.make_label();
-    m_assembler.jump_if_equal(Assembler::Operand::Register(GPR0), Assembler::Operand::Register(GPR1), no_exception);
+    m_assembler.jump_if_not_equal(
+        Assembler::Operand::Register(GPR0),
+        Assembler::Operand::Register(GPR1),
+        m_exception_handler
+    );
+}
 
-    // We have an exception!
-
+void Compiler::handle_exception()
+{
     // if (!unwind_context.valid) return;
     Assembler::Label handle_exception {};
     m_assembler.mov(
@@ -382,9 +386,6 @@ void Compiler::check_exception()
     // NOTE: No catch and no finally!? Crash.
     no_finalizer.link(m_assembler);
     m_assembler.verify_not_reached();
-
-    // no_exception:
-    no_exception.link(m_assembler);
 }
 
 void Compiler::push_unwind_context(bool valid, Optional<Bytecode::Label> const& handler, Optional<Bytecode::Label> const& finalizer)
@@ -1193,6 +1194,11 @@ OwnPtr<NativeExecutable> Compiler::compile(Bytecode::Executable& bytecode_execut
 
     compiler.m_exit_label.link(compiler.m_assembler);
     compiler.m_assembler.exit();
+
+    if (!compiler.m_exception_handler.jump_slot_offsets_in_instruction_stream.is_empty()) {
+        compiler.m_exception_handler.link(compiler.m_assembler);
+        compiler.handle_exception();
+    }
 
     auto* executable_memory = mmap(nullptr, compiler.m_output.size(), PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE, 0, 0);
     if (executable_memory == MAP_FAILED) {

--- a/Userland/Libraries/LibJS/JIT/Compiler.h
+++ b/Userland/Libraries/LibJS/JIT/Compiler.h
@@ -123,6 +123,7 @@ private:
     void compile_to_boolean(Assembler::Reg dst, Assembler::Reg src);
 
     void check_exception();
+    void handle_exception();
 
     void push_unwind_context(bool valid, Optional<Bytecode::Label> const& handler, Optional<Bytecode::Label> const& finalizer);
     void pop_unwind_context();
@@ -165,6 +166,7 @@ private:
     Vector<u8> m_output;
     Assembler m_assembler { m_output };
     Assembler::Label m_exit_label;
+    Assembler::Label m_exception_handler;
     Bytecode::Executable& m_bytecode_executable;
 };
 


### PR DESCRIPTION
This code size optimization saves 2.08MiB on Kraken/ai-astar.js