### PR TITLE
LibJS/JIT: Static unwinding

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/BasicBlock.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/BasicBlock.cpp
@@ -33,8 +33,18 @@ BasicBlock::~BasicBlock()
 void BasicBlock::dump(Bytecode::Executable const& executable) const
 {
     Bytecode::InstructionStreamIterator it(instruction_stream());
+
     if (!m_name.is_empty())
-        warnln("{}:", m_name);
+        warn("{}", m_name);
+    if (m_handler || m_finalizer) {
+        warn(" [");
+        if (m_handler)
+            warn(" Handler: {}", Label { *m_handler });
+        if (m_finalizer)
+            warn(" Finalizer: {}", Label { *m_finalizer });
+        warn(" ]");
+    }
+    warnln(":");
     while (!it.at_end()) {
         warnln("[{:4x}] {}", it.offset(), (*it).to_deprecated_string(executable));
         ++it;

--- a/Userland/Libraries/LibJS/Bytecode/BasicBlock.h
+++ b/Userland/Libraries/LibJS/Bytecode/BasicBlock.h
@@ -15,8 +15,6 @@ namespace JS::Bytecode {
 
 struct UnwindInfo {
     Executable const* executable;
-    BasicBlock const* handler;
-    BasicBlock const* finalizer;
 
     JS::GCPtr<Environment> lexical_environment;
 

--- a/Userland/Libraries/LibJS/Bytecode/BasicBlock.h
+++ b/Userland/Libraries/LibJS/Bytecode/BasicBlock.h
@@ -43,10 +43,18 @@ public:
 
     DeprecatedString const& name() const { return m_name; }
 
+    void set_handler(BasicBlock const& handler) { m_handler = &handler; }
+    void set_finalizer(BasicBlock const& finalizer) { m_finalizer = &finalizer; }
+
+    BasicBlock const* handler() const { return m_handler; }
+    BasicBlock const* finalizer() const { return m_finalizer; }
+
 private:
     explicit BasicBlock(DeprecatedString name);
 
     Vector<u8> m_buffer;
+    BasicBlock const* m_handler { nullptr };
+    BasicBlock const* m_finalizer { nullptr };
     DeprecatedString m_name;
     bool m_terminated { false };
 };

--- a/Userland/Libraries/LibJS/Bytecode/BasicBlock.h
+++ b/Userland/Libraries/LibJS/Bytecode/BasicBlock.h
@@ -15,7 +15,6 @@ namespace JS::Bytecode {
 
 struct UnwindInfo {
     Executable const* executable;
-
     JS::GCPtr<Environment> lexical_environment;
 
     bool handler_called { false };

--- a/Userland/Libraries/LibJS/Bytecode/Executable.h
+++ b/Userland/Libraries/LibJS/Bytecode/Executable.h
@@ -7,10 +7,12 @@
 #pragma once
 
 #include <AK/DeprecatedFlyString.h>
+#include <AK/HashMap.h>
 #include <AK/NonnullOwnPtr.h>
 #include <AK/OwnPtr.h>
 #include <AK/WeakPtr.h>
 #include <LibJS/Bytecode/IdentifierTable.h>
+#include <LibJS/Bytecode/Label.h>
 #include <LibJS/Bytecode/StringTable.h>
 #include <LibJS/Forward.h>
 #include <LibJS/JIT/NativeExecutable.h>
@@ -57,6 +59,7 @@ public:
     NonnullOwnPtr<StringTable> string_table;
     NonnullOwnPtr<IdentifierTable> identifier_table;
     NonnullOwnPtr<RegexTable> regex_table;
+
     NonnullRefPtr<SourceCode const> source_code;
     size_t number_of_registers { 0 };
     bool is_strict_mode { false };

--- a/Userland/Libraries/LibJS/Bytecode/Generator.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/TemporaryChange.h>
 #include <LibJS/AST.h>
 #include <LibJS/Bytecode/BasicBlock.h>
 #include <LibJS/Bytecode/Generator.h>
@@ -93,6 +94,20 @@ Generator::SourceLocationScope::SourceLocationScope(Generator& generator, ASTNod
 Generator::SourceLocationScope::~SourceLocationScope()
 {
     m_generator.m_current_ast_node = m_previous_node;
+}
+
+Generator::UnwindContext::UnwindContext(Generator& generator, Optional<Label> finalizer)
+    : m_generator(generator)
+    , m_finalizer(finalizer)
+    , m_previous_context(m_generator.m_current_unwind_context)
+{
+    m_generator.m_current_unwind_context = this;
+}
+
+Generator::UnwindContext::~UnwindContext()
+{
+    VERIFY(m_generator.m_current_unwind_context == this);
+    m_generator.m_current_unwind_context = m_previous_context;
 }
 
 Label Generator::nearest_continuable_scope() const
@@ -400,6 +415,7 @@ void Generator::emit_set_variable(JS::Identifier const& identifier, Bytecode::Op
 
 void Generator::generate_scoped_jump(JumpType type)
 {
+    TemporaryChange temp { m_current_unwind_context, m_current_unwind_context };
     bool last_was_finally = false;
     for (size_t i = m_boundaries.size(); i > 0; --i) {
         auto boundary = m_boundaries[i - 1];
@@ -418,14 +434,20 @@ void Generator::generate_scoped_jump(JumpType type)
             }
             break;
         case Unwind:
-            if (!last_was_finally)
+            VERIFY(last_was_finally || !m_current_unwind_context->finalizer().has_value());
+            if (!last_was_finally) {
+                VERIFY(m_current_unwind_context && m_current_unwind_context->handler().has_value());
                 emit<Bytecode::Op::LeaveUnwindContext>();
+                m_current_unwind_context = m_current_unwind_context->previous();
+            }
             last_was_finally = false;
             break;
         case LeaveLexicalEnvironment:
             emit<Bytecode::Op::LeaveLexicalEnvironment>();
             break;
         case ReturnToFinally: {
+            VERIFY(m_current_unwind_context->finalizer().has_value());
+            m_current_unwind_context = m_current_unwind_context->previous();
             auto jump_type_name = type == JumpType::Break ? "break"sv : "continue"sv;
             auto& block = make_block(DeprecatedString::formatted("{}.{}", current_block().name(), jump_type_name));
             emit<Op::ScheduleJump>(Label { block });
@@ -440,6 +462,7 @@ void Generator::generate_scoped_jump(JumpType type)
 
 void Generator::generate_labelled_jump(JumpType type, DeprecatedFlyString const& label)
 {
+    TemporaryChange temp { m_current_unwind_context, m_current_unwind_context };
     size_t current_boundary = m_boundaries.size();
     bool last_was_finally = false;
 
@@ -449,12 +472,18 @@ void Generator::generate_labelled_jump(JumpType type, DeprecatedFlyString const&
         for (; current_boundary > 0; --current_boundary) {
             auto boundary = m_boundaries[current_boundary - 1];
             if (boundary == BlockBoundaryType::Unwind) {
-                if (!last_was_finally)
+                VERIFY(last_was_finally || !m_current_unwind_context->finalizer().has_value());
+                if (!last_was_finally) {
+                    VERIFY(m_current_unwind_context && m_current_unwind_context->handler().has_value());
                     emit<Bytecode::Op::LeaveUnwindContext>();
+                    m_current_unwind_context = m_current_unwind_context->previous();
+                }
                 last_was_finally = false;
             } else if (boundary == BlockBoundaryType::LeaveLexicalEnvironment) {
                 emit<Bytecode::Op::LeaveLexicalEnvironment>();
             } else if (boundary == BlockBoundaryType::ReturnToFinally) {
+                VERIFY(m_current_unwind_context->finalizer().has_value());
+                m_current_unwind_context = m_current_unwind_context->previous();
                 auto jump_type_name = type == JumpType::Break ? "break"sv : "continue"sv;
                 auto& block = make_block(DeprecatedString::formatted("{}.{}", current_block().name(), jump_type_name));
                 emit<Op::ScheduleJump>(Label { block });

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -277,6 +277,7 @@ void Interpreter::run_bytecode()
 
             if (result.is_error()) [[unlikely]] {
                 reg(Register::exception()) = *result.throw_completion().value();
+                m_scheduled_jump = {};
                 auto const* handler = m_current_block->handler();
                 auto const* finalizer = m_current_block->finalizer();
                 if (!handler && !finalizer)

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.h
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.h
@@ -32,6 +32,7 @@ struct CallFrame {
     Vector<Value> registers;
     Vector<GCPtr<Environment>> saved_lexical_environments;
     Vector<UnwindInfo> unwind_contexts;
+    Vector<BasicBlock const*> previously_scheduled_jumps;
 };
 
 class Interpreter {

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.h
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.h
@@ -70,7 +70,7 @@ public:
         reg(Register::exception()) = {};
     }
 
-    void enter_unwind_context(Optional<Label> handler_target, Optional<Label> finalizer_target);
+    void enter_unwind_context();
     void leave_unwind_context();
 
     Executable& current_executable() { return *m_current_executable; }

--- a/Userland/Libraries/LibJS/Tests/try-finally-break.js
+++ b/Userland/Libraries/LibJS/Tests/try-finally-break.js
@@ -339,3 +339,25 @@ test("labelled break in finally overrides labelled break in try", () => {
 
     expect(executionOrder).toEqual([1, 2]);
 });
+
+test("Throw while breaking", () => {
+    const executionOrder = [];
+    try {
+        for (const i = 1337; ; expect().fail("Jumped to for loop update block")) {
+            try {
+                executionOrder.push(1);
+                break;
+            } finally {
+                executionOrder.push(2);
+                throw 1;
+            }
+        }
+    } finally {
+        executionOrder.push(3);
+    }
+    expect(() => {
+        i;
+    }).toThrowWithMessage(ReferenceError, "'i' is not defined");
+
+    expect(executionOrder).toEqual([1, 2, 3]);
+});

--- a/Userland/Libraries/LibJS/Tests/try-finally-break.js
+++ b/Userland/Libraries/LibJS/Tests/try-finally-break.js
@@ -361,3 +361,88 @@ test("Throw while breaking", () => {
 
     expect(executionOrder).toEqual([1, 2, 3]);
 });
+
+test("Throw while breaking with nested try-catch in finalizer", () => {
+    const executionOrder = [];
+    try {
+        for (const i = 1337; ; expect().fail("Jumped to for loop update block")) {
+            try {
+                executionOrder.push(1);
+                break;
+            } finally {
+                try {
+                    throw 1;
+                } catch {
+                    executionOrder.push(2);
+                }
+                executionOrder.push(3);
+            }
+            expect().fail("Jumped out of inner finally statement");
+        }
+    } finally {
+        executionOrder.push(4);
+    }
+    expect(() => {
+        i;
+    }).toThrowWithMessage(ReferenceError, "'i' is not defined");
+
+    expect(executionOrder).toEqual([1, 2, 3, 4]);
+});
+
+test("Throw while breaking with nested try-catch-finally in finalizer", () => {
+    const executionOrder = [];
+    try {
+        for (const i = 1337; ; expect().fail("Jumped to for loop update block")) {
+            try {
+                executionOrder.push(1);
+                break;
+            } finally {
+                try {
+                    executionOrder.push(2);
+                } catch {
+                    expect.fail("Entered catch");
+                } finally {
+                    executionOrder.push(3);
+                }
+                executionOrder.push(4);
+            }
+            expect().fail("Jumped out of inner finally statement");
+        }
+    } finally {
+        executionOrder.push(5);
+    }
+    expect(() => {
+        i;
+    }).toThrowWithMessage(ReferenceError, "'i' is not defined");
+
+    expect(executionOrder).toEqual([1, 2, 3, 4, 5]);
+});
+
+test("Throw while breaking with nested try-catch-finally with throw in finalizer", () => {
+    const executionOrder = [];
+    try {
+        for (const i = 1337; ; expect().fail("Jumped to for loop update block")) {
+            try {
+                executionOrder.push(1);
+                break;
+            } finally {
+                try {
+                    throw 1;
+                } catch {
+                    executionOrder.push(2);
+                } finally {
+                    executionOrder.push(3);
+                }
+                executionOrder.push(4);
+            }
+            expect().fail("Jumped out of inner finally statement");
+        }
+    } finally {
+        executionOrder.push(5);
+    }
+    expect(() => {
+        i;
+    }).toThrowWithMessage(ReferenceError, "'i' is not defined");
+
+    expect(executionOrder).toEqual([1, 2, 3, 4, 5]);
+});


### PR DESCRIPTION
This PR implements static exception handler resolution for the LibJS JIT compiler on top of #21506.
As a side effect, the compiler becomes somewhat smaller. And also we no longer use one
of the registers.

Hope, I haven't interrupted someone's progress on this but this seemed
really interesting to implement... And also that's my first contribution :D

Depends on #21506