### PR TITLE
Shell: Remove '#' from the list of acceptable bareword characters

### DIFF
--- a/Base/usr/share/man/man5/Shell.md
+++ b/Base/usr/share/man/man5/Shell.md
@@ -104,7 +104,7 @@ Any two expressions joined by the Join operator (` ` [whitespace]), or a _variab
 * Syntactic Lists: Any _list_ enclosed in parentheses (`(` and `)`)
 
 ##### Comments
-Any text following a `#` in _bareword_ position, up to but not including a newline
+Any text following and including that in a word starting with `#`, up to but not including a newline
 
 ##### Keywords
 The following tokens:
@@ -497,7 +497,7 @@ variable_ref :: '$' identifier
 
 slice :: '[' brace_expansion_spec ']'
 
-comment :: '#' [^\n]*
+comment :: (?<!\w) '#' .*
 
 immediate_expression :: '$' '{' immediate_function expression* '}'
 
@@ -515,8 +515,8 @@ word_selector :: number
                | '^'                   {== 0}
                | '$'                   {== end}
 
-bareword :: [^"'*$&#|()[\]{} ?;<>] bareword?
-          | '\' [^"'*$&#|()[\]{} ?;<>] bareword?
+bareword :: [^"'*$&|()[\]{} ?;<>] bareword?
+          | '\' [^"'*$&|()[\]{} ?;<>] bareword?
 
 bareword_with_tilde_expansion :: '~' bareword?
 

--- a/Userland/Shell/Parser.cpp
+++ b/Userland/Shell/Parser.cpp
@@ -1913,7 +1913,7 @@ RefPtr<AST::Node> Parser::parse_bareword()
     auto rule_start = push_start();
     StringBuilder builder;
     auto is_acceptable_bareword_character = [&](char c) {
-        return strchr("\\\"'*$&#|(){} ?;<>\n", c) == nullptr
+        return strchr("\\\"'*$&|(){} ?;<>\n", c) == nullptr
             && !m_extra_chars_not_allowed_in_barewords.contains_slow(c);
     };
     while (!at_end()) {

--- a/Userland/Shell/Parser.h
+++ b/Userland/Shell/Parser.h
@@ -292,7 +292,7 @@ variable_ref :: '$' identifier
 
 slice :: '[' brace_expansion_spec ']'
 
-comment :: '#' [^\n]*
+comment :: (?<!\w) '#' .*
 
 immediate_expression :: '$' '{' immediate_function expression* '}'
 
@@ -310,8 +310,8 @@ word_selector :: number
                | '^'                   {== 0}
                | '$'                   {== end}
 
-bareword :: [^"'*$&#|()[\]{} ?;<>] bareword?
-          | '\' [^"'*$&#|()[\]{} ?;<>] bareword?
+bareword :: [^"'*$&|()[\]{} ?;<>] bareword?
+          | '\' [^"'*$&|()[\]{} ?;<>] bareword?
 
 bareword_with_tilde_expansion :: '~' bareword?
 


### PR DESCRIPTION
This stops the shell from always interpreting '#' as the start of a comment in non-Posix mode.

Fixes #21650. 