### PR TITLE
LibJIT: Add and use helpers for ModRM byte and REX prefix emission

### DIFF
--- a/Userland/Libraries/LibJIT/Assembler.h
+++ b/Userland/Libraries/LibJIT/Assembler.h
@@ -615,14 +615,17 @@ struct Assembler {
 
     void add32(Operand dst, Operand src, Optional<Label&> label)
     {
-        if (dst.type == Operand::Type::Reg && to_underlying(dst.reg) < 8 && src.type == Operand::Type::Reg && to_underlying(src.reg) < 8) {
+        if (dst.is_register_or_memory() && src.type == Operand::Type::Reg) {
+            emit_rex_for_mr(dst, src, REX_W::No);
             emit8(0x01);
             emit_modrm_mr(dst, src);
-        } else if (dst.type == Operand::Type::Reg && to_underlying(dst.reg) < 8 && src.type == Operand::Type::Imm && src.fits_in_i8()) {
+        } else if (dst.is_register_or_memory() && src.type == Operand::Type::Imm && src.fits_in_i8()) {
+            emit_rex_for_slash(dst, REX_W::No);
             emit8(0x83);
             emit_modrm_slash(0, dst);
             emit8(src.offset_or_immediate);
-        } else if (dst.type == Operand::Type::Reg && to_underlying(dst.reg) < 8 && src.type == Operand::Type::Imm && src.fits_in_i32()) {
+        } else if (dst.is_register_or_memory() && src.type == Operand::Type::Imm && src.fits_in_i32()) {
+            emit_rex_for_slash(dst, REX_W::No);
             emit8(0x81);
             emit_modrm_slash(0, dst);
             emit32(src.offset_or_immediate);


### PR DESCRIPTION
### LibJIT: Add a ModRM helper for argument encoding


### LibJIT: Use ModRM helpers where applicable

This also widens the argument coverage of some helpers, to allow
memory offsets, this also consolidates the displacement size choosing.
This also stops us from some out argument ordering bugs, as we now just
need to look up the correct calling convention and call the correct
function.

### LibJIT: Introduce and use REX prefix helper

This makes the code a bit more readable and in conjunction with the
ModRM helper should prevent some operand ordering bugs.
This also includes one incidental bugfix:
`sign_extend_32_to_64_bits`, was not setting the `REX.R` bit when
appropriate,
And one size obvious optimization:
We may now elide the REX prefix on `xor eax, eax` as storing to a 32 bit
register clears the upper 32 bit of said register, which is wanted here.

---
Lets see if Co-Pilot can handle this
