### PR TITLE
LibWeb: Inhibit floats in GFC

### DIFF
--- a/Tests/LibWeb/Layout/expected/grid/floating-item.txt
+++ b/Tests/LibWeb/Layout/expected/grid/floating-item.txt
@@ -1,0 +1,11 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (1,1) content-size 798x122 [BFC] children: not-inline
+    BlockContainer <body> at (10,10) content-size 780x104 children: not-inline
+      Box <div.grid> at (11,11) content-size 778x102 [GFC] children: not-inline
+        BlockContainer <div.float-left> at (12,12) content-size 100x100 floating [BFC] children: not-inline
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x124]
+    PaintableWithLines (BlockContainer<BODY>) [9,9 782x106]
+      PaintableBox (Box<DIV>.grid) [10,10 780x104]
+        PaintableWithLines (BlockContainer<DIV>.float-left) [11,11 102x102]

--- a/Tests/LibWeb/Layout/input/grid/floating-item.html
+++ b/Tests/LibWeb/Layout/input/grid/floating-item.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html><style>
+* {
+    border: 1px solid black;
+}
+
+.grid {
+    display: grid;
+}
+
+.float-left {
+    float: left;
+    width: 100px;
+    height: 100px;
+}
+</style><div class="grid"><div class="float-left"></div></div>

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.h
@@ -97,6 +97,8 @@ public:
     explicit GridFormattingContext(LayoutState&, Box const& grid_container, FormattingContext* parent);
     ~GridFormattingContext();
 
+    virtual bool inhibits_floating() const override { return true; }
+
     virtual void run(Box const&, LayoutMode, AvailableSpace const& available_space) override;
     virtual CSSPixels automatic_content_width() const override;
     virtual CSSPixels automatic_content_height() const override;


### PR DESCRIPTION
Grid items with float property not equal to none should not be treated as "out of flow".