### PR TITLE
LibWeb/Painting: Fix translation for FIllRect command

### DIFF
--- a/Userland/Libraries/LibWeb/Painting/RecordingPainter.cpp
+++ b/Userland/Libraries/LibWeb/Painting/RecordingPainter.cpp
@@ -37,7 +37,7 @@ void RecordingPainter::blit_corner_clipping(NonnullRefPtr<BorderRadiusCornerClip
 void RecordingPainter::fill_rect(Gfx::IntRect const& rect, Color color)
 {
     push_command(FillRect {
-        .rect = rect,
+        .rect = state().translation.map(rect),
         .color = color,
     });
 }


### PR DESCRIPTION
After 4318bcf447ecb97b867af13dfcba1b72de107049 RecordingPainter is suppoed to write commands in coordinate system of stacking context.

This commit adds missing translation for FillRect command.