### PR TITLE
LibWeb: Add extremely basic GPU painter

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -59,7 +59,7 @@ jobs:
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
           sudo add-apt-repository 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-16 main'
           sudo apt-get update
-          sudo apt-get install -y clang-format-16 ccache e2fsprogs gcc-12 g++-12 libstdc++-12-dev libmpfr-dev libmpc-dev ninja-build optipng qemu-utils qemu-system-i386 unzip generate-ninja
+          sudo apt-get install -y clang-format-16 ccache e2fsprogs gcc-12 g++-12 libstdc++-12-dev libmpfr-dev libmpc-dev ninja-build optipng qemu-utils qemu-system-i386 unzip generate-ninja libegl1-mesa-dev
           if ${{ matrix.arch == 'aarch64' }}; then
             # FIXME: Remove this when we no longer build our own Qemu binary.
             sudo apt-get install libgtk-3-dev libpixman-1-dev libsdl2-dev libslirp-dev

--- a/Ladybird/AppKit/UI/LadybirdWebViewBridge.cpp
+++ b/Ladybird/AppKit/UI/LadybirdWebViewBridge.cpp
@@ -184,7 +184,7 @@ void WebViewBridge::create_client(WebView::EnableCallgrindProfiling enable_callg
     m_client_state = {};
 
     auto candidate_web_content_paths = MUST(get_paths_for_helper_process("WebContent"sv));
-    auto new_client = MUST(launch_web_content_process(*this, candidate_web_content_paths, enable_callgrind_profiling, WebView::IsLayoutTestMode::No, Ladybird::UseLagomNetworking::Yes));
+    auto new_client = MUST(launch_web_content_process(*this, candidate_web_content_paths, enable_callgrind_profiling, WebView::IsLayoutTestMode::No, Ladybird::UseLagomNetworking::Yes, WebView::EnableGPUPainting::No));
 
     m_client_state.client = new_client;
     m_client_state.client->on_web_content_process_crash = [this] {

--- a/Ladybird/HelperProcess.cpp
+++ b/Ladybird/HelperProcess.cpp
@@ -10,7 +10,8 @@ ErrorOr<NonnullRefPtr<WebView::WebContentClient>> launch_web_content_process(Web
     ReadonlySpan<String> candidate_web_content_paths,
     WebView::EnableCallgrindProfiling enable_callgrind_profiling,
     WebView::IsLayoutTestMode is_layout_test_mode,
-    Ladybird::UseLagomNetworking use_lagom_networking)
+    Ladybird::UseLagomNetworking use_lagom_networking,
+    WebView::EnableGPUPainting enable_gpu_painting)
 {
     int socket_fds[2] {};
     TRY(Core::System::socketpair(AF_LOCAL, SOCK_STREAM, 0, socket_fds));
@@ -54,6 +55,8 @@ ErrorOr<NonnullRefPtr<WebView::WebContentClient>> launch_web_content_process(Web
                 arguments.append("--layout-test-mode"sv);
             if (use_lagom_networking == Ladybird::UseLagomNetworking::Yes)
                 arguments.append("--use-lagom-networking"sv);
+            if (enable_gpu_painting == WebView::EnableGPUPainting::Yes)
+                arguments.append("--use-gpu-painting"sv);
 
             result = Core::System::exec(arguments[0], arguments.span(), Core::System::SearchInPath::Yes);
             if (!result.is_error())

--- a/Ladybird/HelperProcess.h
+++ b/Ladybird/HelperProcess.h
@@ -20,7 +20,8 @@ ErrorOr<NonnullRefPtr<WebView::WebContentClient>> launch_web_content_process(Web
     ReadonlySpan<String> candidate_web_content_paths,
     WebView::EnableCallgrindProfiling,
     WebView::IsLayoutTestMode,
-    Ladybird::UseLagomNetworking);
+    Ladybird::UseLagomNetworking,
+    WebView::EnableGPUPainting);
 
 ErrorOr<NonnullRefPtr<ImageDecoderClient::Client>> launch_image_decoder_process(ReadonlySpan<String> candidate_image_decoder_paths);
 ErrorOr<NonnullRefPtr<Protocol::RequestClient>> launch_request_server_process(ReadonlySpan<String> candidate_request_server_paths, StringView serenity_resource_root);

--- a/Ladybird/Qt/BrowserWindow.cpp
+++ b/Ladybird/Qt/BrowserWindow.cpp
@@ -41,11 +41,12 @@ static QIcon const& app_icon()
     return icon;
 }
 
-BrowserWindow::BrowserWindow(Vector<URL> const& initial_urls, WebView::CookieJar& cookie_jar, StringView webdriver_content_ipc_path, WebView::EnableCallgrindProfiling enable_callgrind_profiling, UseLagomNetworking use_lagom_networking)
+BrowserWindow::BrowserWindow(Vector<URL> const& initial_urls, WebView::CookieJar& cookie_jar, StringView webdriver_content_ipc_path, WebView::EnableCallgrindProfiling enable_callgrind_profiling, UseLagomNetworking use_lagom_networking, WebView::EnableGPUPainting use_gpu_painting)
     : m_cookie_jar(cookie_jar)
     , m_webdriver_content_ipc_path(webdriver_content_ipc_path)
     , m_enable_callgrind_profiling(enable_callgrind_profiling)
     , m_use_lagom_networking(use_lagom_networking)
+    , m_use_gpu_painting(use_gpu_painting)
 {
     setWindowIcon(app_icon());
     m_tabs_container = new QTabWidget(this);
@@ -462,7 +463,7 @@ Tab& BrowserWindow::new_tab(StringView html, Web::HTML::ActivateTab activate_tab
 
 Tab& BrowserWindow::create_new_tab(Web::HTML::ActivateTab activate_tab)
 {
-    auto tab = make<Tab>(this, m_webdriver_content_ipc_path, m_enable_callgrind_profiling, m_use_lagom_networking);
+    auto tab = make<Tab>(this, m_webdriver_content_ipc_path, m_enable_callgrind_profiling, m_use_lagom_networking, m_use_gpu_painting);
     auto tab_ptr = tab.ptr();
     m_tabs.append(std::move(tab));
 

--- a/Ladybird/Qt/BrowserWindow.h
+++ b/Ladybird/Qt/BrowserWindow.h
@@ -25,7 +25,7 @@ class WebContentView;
 class BrowserWindow : public QMainWindow {
     Q_OBJECT
 public:
-    explicit BrowserWindow(Vector<URL> const& initial_urls, WebView::CookieJar&, StringView webdriver_content_ipc_path, WebView::EnableCallgrindProfiling, UseLagomNetworking);
+    explicit BrowserWindow(Vector<URL> const& initial_urls, WebView::CookieJar&, StringView webdriver_content_ipc_path, WebView::EnableCallgrindProfiling, UseLagomNetworking, WebView::EnableGPUPainting);
 
     WebContentView& view() const { return m_current_tab->view(); }
 
@@ -121,6 +121,7 @@ private:
     StringView m_webdriver_content_ipc_path;
     WebView::EnableCallgrindProfiling m_enable_callgrind_profiling;
     UseLagomNetworking m_use_lagom_networking;
+    WebView::EnableGPUPainting m_use_gpu_painting;
 };
 
 }

--- a/Ladybird/Qt/ConsoleWidget.cpp
+++ b/Ladybird/Qt/ConsoleWidget.cpp
@@ -25,7 +25,7 @@ ConsoleWidget::ConsoleWidget(WebContentView& content_view)
 {
     setLayout(new QVBoxLayout);
 
-    m_output_view = new WebContentView({}, WebView::EnableCallgrindProfiling::No, UseLagomNetworking::No);
+    m_output_view = new WebContentView({}, WebView::EnableCallgrindProfiling::No, UseLagomNetworking::No, WebView::EnableGPUPainting::No);
     if (is_using_dark_system_theme(*this))
         m_output_view->update_palette(WebContentView::PaletteMode::Dark);
 

--- a/Ladybird/Qt/Tab.cpp
+++ b/Ladybird/Qt/Tab.cpp
@@ -51,7 +51,7 @@ static QIcon create_tvg_icon_with_theme_colors(QString name, QPalette const& pal
     return QIcon(icon_engine);
 }
 
-Tab::Tab(BrowserWindow* window, StringView webdriver_content_ipc_path, WebView::EnableCallgrindProfiling enable_callgrind_profiling, UseLagomNetworking use_lagom_networking)
+Tab::Tab(BrowserWindow* window, StringView webdriver_content_ipc_path, WebView::EnableCallgrindProfiling enable_callgrind_profiling, UseLagomNetworking use_lagom_networking, WebView::EnableGPUPainting enable_gpu_painting)
     : QWidget(window)
     , m_window(window)
 {
@@ -59,7 +59,7 @@ Tab::Tab(BrowserWindow* window, StringView webdriver_content_ipc_path, WebView::
     m_layout->setSpacing(0);
     m_layout->setContentsMargins(0, 0, 0, 0);
 
-    m_view = new WebContentView(webdriver_content_ipc_path, enable_callgrind_profiling, use_lagom_networking);
+    m_view = new WebContentView(webdriver_content_ipc_path, enable_callgrind_profiling, use_lagom_networking, enable_gpu_painting);
     m_toolbar = new QToolBar(this);
     m_location_edit = new LocationEdit(this);
 

--- a/Ladybird/Qt/Tab.h
+++ b/Ladybird/Qt/Tab.h
@@ -28,7 +28,7 @@ class InspectorWidget;
 class Tab final : public QWidget {
     Q_OBJECT
 public:
-    Tab(BrowserWindow* window, StringView webdriver_content_ipc_path, WebView::EnableCallgrindProfiling, UseLagomNetworking);
+    Tab(BrowserWindow* window, StringView webdriver_content_ipc_path, WebView::EnableCallgrindProfiling, UseLagomNetworking, WebView::EnableGPUPainting);
     virtual ~Tab() override;
 
     WebContentView& view() { return *m_view; }

--- a/Ladybird/Qt/WebContentView.cpp
+++ b/Ladybird/Qt/WebContentView.cpp
@@ -52,8 +52,9 @@ namespace Ladybird {
 
 bool is_using_dark_system_theme(QWidget&);
 
-WebContentView::WebContentView(StringView webdriver_content_ipc_path, WebView::EnableCallgrindProfiling enable_callgrind_profiling, UseLagomNetworking use_lagom_networking)
+WebContentView::WebContentView(StringView webdriver_content_ipc_path, WebView::EnableCallgrindProfiling enable_callgrind_profiling, UseLagomNetworking use_lagom_networking, WebView::EnableGPUPainting enable_gpu_painting)
     : m_use_lagom_networking(use_lagom_networking)
+    , m_use_gpu_painting(enable_gpu_painting)
     , m_webdriver_content_ipc_path(webdriver_content_ipc_path)
 {
     setMouseTracking(true);
@@ -601,7 +602,7 @@ void WebContentView::create_client(WebView::EnableCallgrindProfiling enable_call
     m_client_state = {};
 
     auto candidate_web_content_paths = get_paths_for_helper_process("WebContent"sv).release_value_but_fixme_should_propagate_errors();
-    auto new_client = launch_web_content_process(*this, candidate_web_content_paths, enable_callgrind_profiling, WebView::IsLayoutTestMode::No, m_use_lagom_networking).release_value_but_fixme_should_propagate_errors();
+    auto new_client = launch_web_content_process(*this, candidate_web_content_paths, enable_callgrind_profiling, WebView::IsLayoutTestMode::No, m_use_lagom_networking, m_use_gpu_painting).release_value_but_fixme_should_propagate_errors();
 
     m_client_state.client = new_client;
     m_client_state.client->on_web_content_process_crash = [this] {

--- a/Ladybird/Qt/WebContentView.h
+++ b/Ladybird/Qt/WebContentView.h
@@ -42,7 +42,7 @@ class WebContentView final
     , public WebView::ViewImplementation {
     Q_OBJECT
 public:
-    explicit WebContentView(StringView webdriver_content_ipc_path, WebView::EnableCallgrindProfiling, UseLagomNetworking);
+    explicit WebContentView(StringView webdriver_content_ipc_path, WebView::EnableCallgrindProfiling, UseLagomNetworking, WebView::EnableGPUPainting);
     virtual ~WebContentView() override;
 
     Function<String(const AK::URL&, Web::HTML::ActivateTab)> on_tab_open_request;
@@ -93,6 +93,7 @@ private:
     qreal m_inverse_pixel_scaling_ratio { 1.0 };
     bool m_should_show_line_box_borders { false };
     UseLagomNetworking m_use_lagom_networking {};
+    WebView::EnableGPUPainting m_use_gpu_painting {};
 
     Gfx::IntRect m_viewport_rect;
 

--- a/Ladybird/Qt/main.cpp
+++ b/Ladybird/Qt/main.cpp
@@ -75,6 +75,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     bool enable_callgrind_profiling = false;
     bool enable_sql_database = false;
     bool use_lagom_networking = false;
+    bool use_gpu_painting = false;
 
     Core::ArgsParser args_parser;
     args_parser.set_general_help("The Ladybird web browser :^)");
@@ -83,6 +84,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_option(enable_callgrind_profiling, "Enable Callgrind profiling", "enable-callgrind-profiling", 'P');
     args_parser.add_option(enable_sql_database, "Enable SQL database", "enable-sql-database", 0);
     args_parser.add_option(use_lagom_networking, "Enable Lagom servers for networking", "enable-lagom-networking", 0);
+    args_parser.add_option(use_gpu_painting, "Enable GPU painting", "enable-gpu-painting", 0);
     args_parser.parse(arguments);
 
     RefPtr<WebView::Database> database;
@@ -106,7 +108,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         initial_urls.append(MUST(ak_string_from_qstring(new_tab_page)));
     }
 
-    Ladybird::BrowserWindow window(initial_urls, cookie_jar, webdriver_content_ipc_path, enable_callgrind_profiling ? WebView::EnableCallgrindProfiling::Yes : WebView::EnableCallgrindProfiling::No, use_lagom_networking ? Ladybird::UseLagomNetworking::Yes : Ladybird::UseLagomNetworking::No);
+    Ladybird::BrowserWindow window(initial_urls, cookie_jar, webdriver_content_ipc_path, enable_callgrind_profiling ? WebView::EnableCallgrindProfiling::Yes : WebView::EnableCallgrindProfiling::No, use_lagom_networking ? Ladybird::UseLagomNetworking::Yes : Ladybird::UseLagomNetworking::No, use_gpu_painting ? WebView::EnableGPUPainting::Yes : WebView::EnableGPUPainting::No);
     window.setWindowTitle("Ladybird");
 
     if (Ladybird::Settings::the()->is_maximized()) {

--- a/Ladybird/WebContent/CMakeLists.txt
+++ b/Ladybird/WebContent/CMakeLists.txt
@@ -76,3 +76,7 @@ if (HAVE_PULSEAUDIO)
         target_compile_definitions(webcontent PRIVATE HAVE_PULSEAUDIO=1)
     endif()
 endif()
+
+if (LINUX)
+    target_link_libraries(WebContent PRIVATE LibAccelGfx)
+endif()

--- a/Ladybird/WebContent/main.cpp
+++ b/Ladybird/WebContent/main.cpp
@@ -73,12 +73,19 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     int webcontent_fd_passing_socket { -1 };
     bool is_layout_test_mode = false;
     bool use_lagom_networking = false;
+    bool use_gpu_painting = false;
 
     Core::ArgsParser args_parser;
     args_parser.add_option(webcontent_fd_passing_socket, "File descriptor of the passing socket for the WebContent connection", "webcontent-fd-passing-socket", 'c', "webcontent_fd_passing_socket");
     args_parser.add_option(is_layout_test_mode, "Is layout test mode", "layout-test-mode", 0);
     args_parser.add_option(use_lagom_networking, "Enable Lagom servers for networking", "use-lagom-networking", 0);
+    args_parser.add_option(use_gpu_painting, "Enable GPU painting", "use-gpu-painting", 0);
+
     args_parser.parse(arguments);
+
+    if (use_gpu_painting) {
+        WebContent::PageHost::set_use_gpu_painter();
+    }
 
 #if defined(HAVE_QT)
     if (!use_lagom_networking) {

--- a/Meta/Azure/Setup.yml
+++ b/Meta/Azure/Setup.yml
@@ -21,7 +21,7 @@ steps:
         wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
         sudo add-apt-repository 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main'
         sudo apt-get update
-        sudo apt-get install ccache gcc-12 g++-12 clang-15 libstdc++-12-dev ninja-build unzip qt6-base-dev qt6-tools-dev-tools libqt6svg6-dev qt6-multimedia-dev libgl1-mesa-dev libpulse-dev libssl-dev
+        sudo apt-get install ccache gcc-12 g++-12 clang-15 libstdc++-12-dev ninja-build unzip qt6-base-dev qt6-tools-dev-tools libqt6svg6-dev qt6-multimedia-dev libgl1-mesa-dev libpulse-dev libssl-dev libegl1-mesa-dev
 
         sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-15 100
         sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-15 100

--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -405,6 +405,7 @@ endif()
 if (BUILD_LAGOM)
     # Lagom Libraries
     set(lagom_standard_libraries
+        AccelGfx
         Archive
         Audio
         Compress

--- a/Userland/Libraries/CMakeLists.txt
+++ b/Userland/Libraries/CMakeLists.txt
@@ -1,3 +1,4 @@
+add_subdirectory(LibAccelGfx)
 add_subdirectory(LibArchive)
 add_subdirectory(LibAudio)
 add_subdirectory(LibC)

--- a/Userland/Libraries/LibAccelGfx/CMakeLists.txt
+++ b/Userland/Libraries/LibAccelGfx/CMakeLists.txt
@@ -1,0 +1,10 @@
+if (LINUX)
+    set(SOURCES
+        Canvas.cpp
+        Context.cpp
+        Painter.cpp
+    )
+
+    serenity_lib(LibAccelGfx accelgfx)
+    target_link_libraries(LibAccelGfx PRIVATE LibGfx GL EGL)
+endif()

--- a/Userland/Libraries/LibAccelGfx/Canvas.cpp
+++ b/Userland/Libraries/LibAccelGfx/Canvas.cpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2023, Andreas Kling <kling@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "Canvas.h"
+#include <GL/gl.h>
+#include <LibGfx/Bitmap.h>
+
+namespace AccelGfx {
+
+Canvas Canvas::create(Context& context, NonnullRefPtr<Gfx::Bitmap> bitmap)
+{
+    VERIFY(bitmap->format() == Gfx::BitmapFormat::BGRA8888);
+    Canvas canvas { move(bitmap), context };
+    canvas.initialize();
+    return canvas;
+}
+
+Canvas::Canvas(NonnullRefPtr<Gfx::Bitmap> bitmap, Context& context)
+    : m_bitmap(move(bitmap))
+    , m_context(context)
+{
+}
+
+void Canvas::initialize()
+{
+    m_surface = m_context.create_surface(width(), height());
+    m_context.set_active_surface(m_surface);
+    glViewport(0, 0, width(), height());
+}
+
+void Canvas::flush()
+{
+    glPixelStorei(GL_PACK_ALIGNMENT, 1);
+    glReadPixels(0, 0, width(), height(), GL_BGRA, GL_UNSIGNED_BYTE, m_bitmap->scanline(0));
+}
+
+Canvas::~Canvas()
+{
+    m_context.destroy_surface(m_surface);
+}
+
+}

--- a/Userland/Libraries/LibAccelGfx/Canvas.h
+++ b/Userland/Libraries/LibAccelGfx/Canvas.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2023, Andreas Kling <kling@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibAccelGfx/Context.h>
+#include <LibAccelGfx/Forward.h>
+#include <LibGfx/Bitmap.h>
+#include <LibGfx/Rect.h>
+
+namespace AccelGfx {
+
+class Canvas {
+public:
+    static Canvas create(Context& context, NonnullRefPtr<Gfx::Bitmap> bitmap);
+
+    [[nodiscard]] Gfx::IntSize size() const { return m_bitmap->size(); }
+    [[nodiscard]] int width() const { return m_bitmap->width(); }
+    [[nodiscard]] int height() const { return m_bitmap->height(); }
+
+    void flush();
+
+    [[nodiscard]] Gfx::Bitmap const& bitmap() const { return *m_bitmap; }
+
+    ~Canvas();
+
+private:
+    explicit Canvas(NonnullRefPtr<Gfx::Bitmap>, Context&);
+
+    void initialize();
+
+    NonnullRefPtr<Gfx::Bitmap> m_bitmap;
+
+    Context& m_context;
+    Context::Surface m_surface;
+};
+
+}

--- a/Userland/Libraries/LibAccelGfx/Context.cpp
+++ b/Userland/Libraries/LibAccelGfx/Context.cpp
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2023, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibAccelGfx/Context.h>
+
+namespace AccelGfx {
+
+Context& Context::the()
+{
+    static OwnPtr<Context> s_the;
+    if (!s_the)
+        s_the = Context::create();
+    return *s_the;
+}
+
+Context::Surface Context::create_surface(int width, int height)
+{
+    EGLint const pbuffer_attributes[] = {
+        EGL_WIDTH,
+        width,
+        EGL_HEIGHT,
+        height,
+        EGL_NONE,
+    };
+
+    auto egl_surface = eglCreatePbufferSurface(m_egl_display, m_egl_config, pbuffer_attributes);
+    return { egl_surface };
+}
+
+void Context::destroy_surface(Surface surface)
+{
+    if (surface.egl_surface)
+        eglDestroySurface(m_egl_display, surface.egl_surface);
+}
+
+void Context::set_active_surface(Surface surface)
+{
+    VERIFY(eglMakeCurrent(m_egl_display, surface.egl_surface, surface.egl_surface, m_egl_context));
+}
+
+OwnPtr<Context> Context::create()
+{
+    EGLDisplay egl_display = eglGetDisplay(EGL_DEFAULT_DISPLAY);
+
+    EGLint major;
+    EGLint minor;
+    eglInitialize(egl_display, &major, &minor);
+
+    static EGLint const config_attributes[] = {
+        EGL_SURFACE_TYPE, EGL_PBUFFER_BIT,
+        EGL_BLUE_SIZE, 8,
+        EGL_GREEN_SIZE, 8,
+        EGL_RED_SIZE, 8,
+        EGL_DEPTH_SIZE, 8,
+        EGL_RENDERABLE_TYPE, EGL_OPENGL_BIT,
+        EGL_NONE
+    };
+
+    EGLConfig egl_config;
+    EGLint num_configs;
+    eglChooseConfig(egl_display, config_attributes, &egl_config, 1, &num_configs);
+
+    static EGLint const context_attributes[] = {
+        EGL_CONTEXT_CLIENT_VERSION, 2,
+        EGL_NONE
+    };
+    EGLContext egl_context = eglCreateContext(egl_display, egl_config, EGL_NO_CONTEXT, context_attributes);
+
+    return make<Context>(egl_display, egl_context, egl_config);
+}
+
+}

--- a/Userland/Libraries/LibAccelGfx/Context.h
+++ b/Userland/Libraries/LibAccelGfx/Context.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2023, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Assertions.h>
+#include <AK/OwnPtr.h>
+
+#ifdef AK_OS_LINUX
+#    include <EGL/egl.h>
+#endif
+
+namespace AccelGfx {
+
+class Context {
+public:
+    static Context& the();
+
+    struct Surface {
+        EGLSurface egl_surface { 0 };
+    };
+
+    Surface create_surface(int width, int height);
+    void destroy_surface(Surface surface);
+    void set_active_surface(Surface surface);
+
+    static OwnPtr<Context> create();
+
+    Context(EGLDisplay egl_display, EGLContext egl_context, EGLConfig egl_config)
+        : m_egl_display(egl_display)
+        , m_egl_context(egl_context)
+        , m_egl_config(egl_config)
+    {
+    }
+
+private:
+    EGLDisplay m_egl_display { nullptr };
+    EGLContext m_egl_context { nullptr };
+    EGLConfig m_egl_config { nullptr };
+};
+
+}

--- a/Userland/Libraries/LibAccelGfx/Forward.h
+++ b/Userland/Libraries/LibAccelGfx/Forward.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2023, Andreas Kling <kling@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+namespace AccelGfx {
+
+class Canvas;
+class Painter;
+
+}

--- a/Userland/Libraries/LibAccelGfx/Painter.cpp
+++ b/Userland/Libraries/LibAccelGfx/Painter.cpp
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2023, Andreas Kling <kling@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#define GL_GLEXT_PROTOTYPES
+
+#include "Painter.h"
+#include "Canvas.h"
+#include <GL/gl.h>
+#include <GL/glext.h>
+#include <LibGfx/Color.h>
+
+namespace AccelGfx {
+
+struct ColorComponents {
+    float red;
+    float green;
+    float blue;
+    float alpha;
+};
+
+static ColorComponents gfx_color_to_opengl_color(Gfx::Color color)
+{
+    ColorComponents components;
+    components.red = static_cast<float>(color.red()) / 255.0f;
+    components.green = static_cast<float>(color.green()) / 255.0f;
+    components.blue = static_cast<float>(color.blue()) / 255.0f;
+    components.alpha = static_cast<float>(color.alpha()) / 255.0f;
+    return components;
+}
+
+Gfx::FloatRect Painter::to_clip_space(Gfx::FloatRect const& screen_rect) const
+{
+    float x = 2.0f * screen_rect.x() / m_canvas.width() - 1.0f;
+    float y = -1.0f + 2.0f * screen_rect.y() / m_canvas.height();
+
+    float width = 2.0f * screen_rect.width() / m_canvas.width();
+    float height = 2.0f * screen_rect.height() / m_canvas.height();
+
+    return { x, y, width, height };
+}
+
+Painter::Painter(Canvas& canvas)
+    : m_canvas(canvas)
+{
+    m_state_stack.empend(State());
+}
+
+Painter::~Painter()
+{
+    flush();
+}
+
+void Painter::clear(Gfx::Color color)
+{
+    auto [red, green, blue, alpha] = gfx_color_to_opengl_color(color);
+    glClearColor(red, green, blue, alpha);
+    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+}
+
+void Painter::fill_rect(Gfx::IntRect rect, Gfx::Color color)
+{
+    fill_rect(rect.to_type<float>(), color);
+}
+
+static GLuint create_shader(GLenum type, char const* source)
+{
+    GLuint shader = glCreateShader(type);
+    glShaderSource(shader, 1, &source, nullptr);
+    glCompileShader(shader);
+
+    int success;
+    glGetShaderiv(shader, GL_COMPILE_STATUS, &success);
+    if (!success) {
+        char buffer[512];
+        glGetShaderInfoLog(shader, sizeof(buffer), nullptr, buffer);
+        dbgln("GLSL shader compilation failed: {}", buffer);
+        VERIFY_NOT_REACHED();
+    }
+
+    return shader;
+}
+
+static Array<GLfloat, 8> rect_to_vertices(Gfx::FloatRect const& rect)
+{
+    return {
+        rect.left(),
+        rect.top(),
+        rect.left(),
+        rect.bottom(),
+        rect.right(),
+        rect.bottom(),
+        rect.right(),
+        rect.top(),
+    };
+}
+
+void Painter::fill_rect(Gfx::FloatRect rect, Gfx::Color color)
+{
+    // Draw a filled rect (with `color`) using OpenGL after mapping it through the current transform.
+
+    auto vertices = rect_to_vertices(to_clip_space(transform().map(rect)));
+
+    char const* vertex_shader_source = R"(
+    attribute vec2 position;
+    void main() {
+        gl_Position = vec4(position, 0.0, 1.0);
+    }
+)";
+
+    char const* fragment_shader_source = R"(
+    precision mediump float;
+    uniform vec4 uColor;
+    void main() {
+        gl_FragColor = uColor;
+    }
+)";
+
+    auto [red, green, blue, alpha] = gfx_color_to_opengl_color(color);
+
+    GLuint vertex_shader = create_shader(GL_VERTEX_SHADER, vertex_shader_source);
+    GLuint fragment_shader = create_shader(GL_FRAGMENT_SHADER, fragment_shader_source);
+
+    GLuint program = glCreateProgram();
+
+    glAttachShader(program, vertex_shader);
+    glAttachShader(program, fragment_shader);
+    glLinkProgram(program);
+
+    int linked;
+    glGetProgramiv(program, GL_LINK_STATUS, &linked);
+    if (!linked) {
+        char buffer[512];
+        glGetProgramInfoLog(program, sizeof(buffer), nullptr, buffer);
+        dbgln("GLSL program linking failed: {}", buffer);
+        VERIFY_NOT_REACHED();
+    }
+
+    glUseProgram(program);
+
+    GLuint position_attribute = glGetAttribLocation(program, "position");
+    GLuint color_uniform = glGetUniformLocation(program, "uColor");
+
+    glUniform4f(color_uniform, red, green, blue, alpha);
+
+    glVertexAttribPointer(position_attribute, 2, GL_FLOAT, GL_FALSE, 2 * sizeof(float), vertices.data());
+    glEnableVertexAttribArray(position_attribute);
+
+    glEnable(GL_BLEND);
+    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+
+    glDrawArrays(GL_TRIANGLE_FAN, 0, 4);
+
+    glDeleteShader(vertex_shader);
+    glDeleteShader(fragment_shader);
+    glDeleteProgram(program);
+}
+
+void Painter::save()
+{
+    m_state_stack.append(state());
+}
+
+void Painter::restore()
+{
+    VERIFY(!m_state_stack.is_empty());
+    m_state_stack.take_last();
+}
+
+void Painter::flush()
+{
+    m_canvas.flush();
+}
+
+}

--- a/Userland/Libraries/LibAccelGfx/Painter.h
+++ b/Userland/Libraries/LibAccelGfx/Painter.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2023, Andreas Kling <kling@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Noncopyable.h>
+#include <AK/Vector.h>
+#include <LibAccelGfx/Forward.h>
+#include <LibGfx/AffineTransform.h>
+#include <LibGfx/Forward.h>
+
+namespace AccelGfx {
+
+class Painter {
+    AK_MAKE_NONCOPYABLE(Painter);
+    AK_MAKE_NONMOVABLE(Painter);
+
+public:
+    Painter(Canvas&);
+    ~Painter();
+
+    void clear(Gfx::Color);
+
+    void save();
+    void restore();
+
+    [[nodiscard]] Gfx::AffineTransform const& transform() const { return state().transform; }
+    void set_transform(Gfx::AffineTransform const& transform) { state().transform = transform; }
+
+    void fill_rect(Gfx::FloatRect, Gfx::Color);
+    void fill_rect(Gfx::IntRect, Gfx::Color);
+
+private:
+    void flush();
+
+    Canvas& m_canvas;
+
+    struct State {
+        Gfx::AffineTransform transform;
+    };
+
+    [[nodiscard]] State& state() { return m_state_stack.last(); }
+    [[nodiscard]] State const& state() const { return m_state_stack.last(); }
+
+    [[nodiscard]] Gfx::FloatRect to_clip_space(Gfx::FloatRect const& screen_rect) const;
+
+    Vector<State, 1> m_state_stack;
+};
+
+}

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -626,6 +626,10 @@ set(SOURCES
     XML/XMLDocumentBuilder.cpp
 )
 
+if (LINUX)
+    list(APPEND SOURCES Painting/PaintingCommandExecutorGPU.cpp)
+endif()
+
 invoke_generator(
         "AriaRoles.cpp"
         Lagom::GenerateAriaRoles
@@ -658,6 +662,10 @@ serenity_lib(LibWeb web)
 # NOTE: We link with LibSoftGPU here instead of lazy loading it via dlopen() so that we do not have to unveil the library and pledge prot_exec.
 target_link_libraries(LibWeb PRIVATE LibCore LibCrypto LibJS LibMarkdown LibHTTP LibGemini LibGL LibGUI LibGfx LibIPC LibLocale LibRegex LibSoftGPU LibSyntax LibTextCodec LibUnicode LibAudio LibVideo LibWasm LibXML LibIDL)
 link_with_locale_data(LibWeb)
+
+if (LINUX)
+    target_link_libraries(LibWeb PRIVATE LibAccelGfx)
+endif()
 
 generate_js_bindings(LibWeb)
 

--- a/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorGPU.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorGPU.cpp
@@ -1,0 +1,227 @@
+/*
+ * Copyright (c) 2023, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWeb/Painting/PaintingCommandExecutorGPU.h>
+
+namespace Web::Painting {
+
+PaintingCommandExecutorGPU::PaintingCommandExecutorGPU(Gfx::Bitmap& bitmap)
+    : m_target_bitmap(bitmap)
+    , m_canvas(AccelGfx::Canvas::create(AccelGfx::Context::the(), bitmap))
+    , m_painter(m_canvas)
+{
+}
+
+PaintingCommandExecutorGPU::~PaintingCommandExecutorGPU()
+{
+    m_canvas.flush();
+}
+
+CommandResult PaintingCommandExecutorGPU::draw_text_run(Color const&, Gfx::IntPoint const&, String const&, Gfx::Font const&)
+{
+    // FIXME
+    return CommandResult::Continue;
+}
+
+CommandResult PaintingCommandExecutorGPU::draw_text(Gfx::IntRect const&, String const&, Gfx::TextAlignment, Color const&, Gfx::TextElision, Gfx::TextWrapping, Optional<NonnullRefPtr<Gfx::Font>> const&)
+{
+    // FIXME
+    return CommandResult::Continue;
+}
+
+CommandResult PaintingCommandExecutorGPU::fill_rect(Gfx::IntRect const& rect, Color const& color)
+{
+    painter().fill_rect(rect, color);
+    return CommandResult::Continue;
+}
+
+CommandResult PaintingCommandExecutorGPU::draw_scaled_bitmap(Gfx::IntRect const&, Gfx::Bitmap const&, Gfx::IntRect const&, float, Gfx::Painter::ScalingMode)
+{
+    // FIXME
+    return CommandResult::Continue;
+}
+
+CommandResult PaintingCommandExecutorGPU::set_clip_rect(Gfx::IntRect const&)
+{
+    // FIXME
+    return CommandResult::Continue;
+}
+
+CommandResult PaintingCommandExecutorGPU::clear_clip_rect()
+{
+    // FIXME
+    return CommandResult::Continue;
+}
+
+CommandResult PaintingCommandExecutorGPU::set_font(Gfx::Font const&)
+{
+    // FIXME
+    return CommandResult::Continue;
+}
+
+CommandResult PaintingCommandExecutorGPU::push_stacking_context(bool, float, Gfx::FloatRect const&, Gfx::FloatRect const&, Gfx::IntPoint const&)
+{
+    // FIXME
+    return CommandResult::Continue;
+}
+
+CommandResult PaintingCommandExecutorGPU::pop_stacking_context(bool, Gfx::Painter::ScalingMode)
+{
+    // FIXME
+    return CommandResult::Continue;
+}
+
+CommandResult PaintingCommandExecutorGPU::push_stacking_context_with_mask(Gfx::IntRect const&)
+{
+    // FIXME
+    return CommandResult::Continue;
+}
+
+CommandResult PaintingCommandExecutorGPU::pop_stacking_context_with_mask(Gfx::IntRect const&, RefPtr<Gfx::Bitmap> const&, Gfx::Bitmap::MaskKind, float)
+{
+    // FIXME
+    return CommandResult::Continue;
+}
+
+CommandResult PaintingCommandExecutorGPU::paint_linear_gradient(Gfx::IntRect const&, Web::Painting::LinearGradientData const&)
+{
+    // FIXME
+    return CommandResult::Continue;
+}
+
+CommandResult PaintingCommandExecutorGPU::paint_outer_box_shadow(PaintOuterBoxShadowParams const&)
+{
+    // FIXME
+    return CommandResult::Continue;
+}
+
+CommandResult PaintingCommandExecutorGPU::paint_inner_box_shadow(PaintOuterBoxShadowParams const&)
+{
+    // FIXME
+    return CommandResult::Continue;
+}
+
+CommandResult PaintingCommandExecutorGPU::paint_text_shadow(int, Gfx::IntRect const&, Gfx::IntRect const&, String const&, Gfx::Font const&, Color const&, int, Gfx::IntPoint const&)
+{
+    // FIXME
+    return CommandResult::Continue;
+}
+
+CommandResult PaintingCommandExecutorGPU::fill_rect_with_rounded_corners(Gfx::IntRect const&, Color const&, Gfx::AntiAliasingPainter::CornerRadius const&, Gfx::AntiAliasingPainter::CornerRadius const&, Gfx::AntiAliasingPainter::CornerRadius const&, Gfx::AntiAliasingPainter::CornerRadius const&, Optional<Gfx::FloatPoint> const&)
+{
+    // FIXME
+    return CommandResult::Continue;
+}
+
+CommandResult PaintingCommandExecutorGPU::fill_path_using_color(Gfx::Path const&, Color const&, Gfx::Painter::WindingRule, Optional<Gfx::FloatPoint> const&)
+{
+    // FIXME
+    return CommandResult::Continue;
+}
+
+CommandResult PaintingCommandExecutorGPU::fill_path_using_paint_style(Gfx::Path const&, Gfx::PaintStyle const&, Gfx::Painter::WindingRule, float, Optional<Gfx::FloatPoint> const&)
+{
+    // FIXME
+    return CommandResult::Continue;
+}
+
+CommandResult PaintingCommandExecutorGPU::stroke_path_using_color(Gfx::Path const&, Color const&, float, Optional<Gfx::FloatPoint> const&)
+{
+    // FIXME
+    return CommandResult::Continue;
+}
+
+CommandResult PaintingCommandExecutorGPU::stroke_path_using_paint_style(Gfx::Path const&, Gfx::PaintStyle const&, float, float, Optional<Gfx::FloatPoint> const&)
+{
+    // FIXME
+    return CommandResult::Continue;
+}
+
+CommandResult PaintingCommandExecutorGPU::draw_ellipse(Gfx::IntRect const&, Color const&, int)
+{
+    // FIXME
+    return CommandResult::Continue;
+}
+
+CommandResult PaintingCommandExecutorGPU::fill_ellipse(Gfx::IntRect const&, Color const&, Gfx::AntiAliasingPainter::BlendMode)
+{
+    // FIXME
+    return CommandResult::Continue;
+}
+
+CommandResult PaintingCommandExecutorGPU::draw_line(Color const&, Gfx::IntPoint const&, Gfx::IntPoint const&, int, Gfx::Painter::LineStyle, Color const&)
+{
+    // FIXME
+    return CommandResult::Continue;
+}
+
+CommandResult PaintingCommandExecutorGPU::draw_signed_distance_field(Gfx::IntRect const&, Color const&, Gfx::GrayscaleBitmap const&, float)
+{
+    // FIXME
+    return CommandResult::Continue;
+}
+
+CommandResult PaintingCommandExecutorGPU::paint_progressbar(Gfx::IntRect const&, Gfx::IntRect const&, Palette const&, int, int, int, StringView const&)
+{
+    // FIXME
+    return CommandResult::Continue;
+}
+
+CommandResult PaintingCommandExecutorGPU::paint_frame(Gfx::IntRect const&, Palette const&, Gfx::FrameStyle)
+{
+    // FIXME
+    return CommandResult::Continue;
+}
+
+CommandResult PaintingCommandExecutorGPU::apply_backdrop_filter(Gfx::IntRect const&, Web::CSS::ResolvedBackdropFilter const&)
+{
+    // FIXME
+    return CommandResult::Continue;
+}
+
+CommandResult PaintingCommandExecutorGPU::draw_rect(Gfx::IntRect const&, Color const&, bool)
+{
+    // FIXME
+    return CommandResult::Continue;
+}
+
+CommandResult PaintingCommandExecutorGPU::paint_radial_gradient(Gfx::IntRect const&, Web::Painting::RadialGradientData const&, Gfx::IntPoint const&, Gfx::IntSize const&)
+{
+    // FIXME
+    return CommandResult::Continue;
+}
+
+CommandResult PaintingCommandExecutorGPU::paint_conic_gradient(Gfx::IntRect const&, Web::Painting::ConicGradientData const&, Gfx::IntPoint const&)
+{
+    // FIXME
+    return CommandResult::Continue;
+}
+
+CommandResult PaintingCommandExecutorGPU::draw_triangle_wave(Gfx::IntPoint const&, Gfx::IntPoint const&, Color const&, int, int)
+{
+    // FIXME
+    return CommandResult::Continue;
+}
+
+CommandResult PaintingCommandExecutorGPU::sample_under_corners(BorderRadiusCornerClipper&)
+{
+    // FIXME
+    return CommandResult::Continue;
+}
+
+CommandResult PaintingCommandExecutorGPU::blit_corner_clipping(BorderRadiusCornerClipper&)
+{
+    // FIXME
+    return CommandResult::Continue;
+}
+
+bool PaintingCommandExecutorGPU::would_be_fully_clipped_by_painter(Gfx::IntRect) const
+{
+    // FIXME
+    return false;
+}
+
+}

--- a/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorGPU.h
+++ b/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorGPU.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2023, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibAccelGfx/Canvas.h>
+#include <LibAccelGfx/Painter.h>
+#include <LibWeb/Painting/RecordingPainter.h>
+
+namespace Web::Painting {
+
+class PaintingCommandExecutorGPU : public PaintingCommandExecutor {
+public:
+    CommandResult draw_text_run(Color const&, Gfx::IntPoint const& baseline_start, String const& string, Gfx::Font const& font) override;
+    CommandResult draw_text(Gfx::IntRect const& rect, String const& raw_text, Gfx::TextAlignment alignment, Color const&, Gfx::TextElision, Gfx::TextWrapping, Optional<NonnullRefPtr<Gfx::Font>> const&) override;
+    CommandResult fill_rect(Gfx::IntRect const& rect, Color const&) override;
+    CommandResult draw_scaled_bitmap(Gfx::IntRect const& dst_rect, Gfx::Bitmap const& bitmap, Gfx::IntRect const& src_rect, float opacity, Gfx::Painter::ScalingMode scaling_mode) override;
+    CommandResult set_clip_rect(Gfx::IntRect const& rect) override;
+    CommandResult clear_clip_rect() override;
+    CommandResult set_font(Gfx::Font const&) override;
+    CommandResult push_stacking_context(bool semitransparent_or_has_non_identity_transform, float opacity, Gfx::FloatRect const& source_rect, Gfx::FloatRect const& transformed_destination_rect, Gfx::IntPoint const& painter_location) override;
+    CommandResult pop_stacking_context(bool semitransparent_or_has_non_identity_transform, Gfx::Painter::ScalingMode scaling_mode) override;
+    CommandResult push_stacking_context_with_mask(Gfx::IntRect const&) override;
+    CommandResult pop_stacking_context_with_mask(Gfx::IntRect const&, RefPtr<Gfx::Bitmap> const& mask_bitmap, Gfx::Bitmap::MaskKind mask_kind, float opacity) override;
+    CommandResult paint_linear_gradient(Gfx::IntRect const&, Web::Painting::LinearGradientData const&) override;
+    CommandResult paint_outer_box_shadow(PaintOuterBoxShadowParams const&) override;
+    CommandResult paint_inner_box_shadow(PaintOuterBoxShadowParams const&) override;
+    CommandResult paint_text_shadow(int blur_radius, Gfx::IntRect const& shadow_bounding_rect, Gfx::IntRect const& text_rect, String const& text, Gfx::Font const&, Color const&, int fragment_baseline, Gfx::IntPoint const& draw_location) override;
+    CommandResult fill_rect_with_rounded_corners(Gfx::IntRect const&, Color const&, Gfx::AntiAliasingPainter::CornerRadius const& top_left_radius, Gfx::AntiAliasingPainter::CornerRadius const& top_right_radius, Gfx::AntiAliasingPainter::CornerRadius const& bottom_left_radius, Gfx::AntiAliasingPainter::CornerRadius const& bottom_right_radius, Optional<Gfx::FloatPoint> const& aa_translation) override;
+    CommandResult fill_path_using_color(Gfx::Path const&, Color const&, Gfx::Painter::WindingRule winding_rule, Optional<Gfx::FloatPoint> const& aa_translation) override;
+    CommandResult fill_path_using_paint_style(Gfx::Path const&, Gfx::PaintStyle const& paint_style, Gfx::Painter::WindingRule winding_rule, float opacity, Optional<Gfx::FloatPoint> const& aa_translation) override;
+    CommandResult stroke_path_using_color(Gfx::Path const&, Color const& color, float thickness, Optional<Gfx::FloatPoint> const& aa_translation) override;
+    CommandResult stroke_path_using_paint_style(Gfx::Path const& path, Gfx::PaintStyle const& paint_style, float thickness, float opacity, Optional<Gfx::FloatPoint> const& aa_translation) override;
+    CommandResult draw_ellipse(Gfx::IntRect const& rect, Color const& color, int thickness) override;
+    CommandResult fill_ellipse(Gfx::IntRect const& rect, Color const& color, Gfx::AntiAliasingPainter::BlendMode blend_mode) override;
+    CommandResult draw_line(Color const&, Gfx::IntPoint const& from, Gfx::IntPoint const& to, int thickness, Gfx::Painter::LineStyle style, Color const& alternate_color) override;
+    CommandResult draw_signed_distance_field(Gfx::IntRect const& rect, Color const&, Gfx::GrayscaleBitmap const& sdf, float smoothing) override;
+    CommandResult paint_progressbar(Gfx::IntRect const& frame_rect, Gfx::IntRect const& progress_rect, Palette const& palette, int min, int max, int value, StringView const& text) override;
+    CommandResult paint_frame(Gfx::IntRect const& rect, Palette const&, Gfx::FrameStyle) override;
+    CommandResult apply_backdrop_filter(Gfx::IntRect const& backdrop_region, Web::CSS::ResolvedBackdropFilter const& backdrop_filter) override;
+    CommandResult draw_rect(Gfx::IntRect const& rect, Color const&, bool rough) override;
+    CommandResult paint_radial_gradient(Gfx::IntRect const& rect, Web::Painting::RadialGradientData const& radial_gradient_data, Gfx::IntPoint const& center, Gfx::IntSize const& size) override;
+    CommandResult paint_conic_gradient(Gfx::IntRect const& rect, Web::Painting::ConicGradientData const& conic_gradient_data, Gfx::IntPoint const& position) override;
+    CommandResult draw_triangle_wave(Gfx::IntPoint const& p1, Gfx::IntPoint const& p2, Color const&, int amplitude, int thickness) override;
+    CommandResult sample_under_corners(BorderRadiusCornerClipper&) override;
+    CommandResult blit_corner_clipping(BorderRadiusCornerClipper&) override;
+
+    bool would_be_fully_clipped_by_painter(Gfx::IntRect) const override;
+
+    PaintingCommandExecutorGPU(Gfx::Bitmap& bitmap);
+    ~PaintingCommandExecutorGPU() override;
+
+private:
+    AccelGfx::Painter& painter() { return m_painter; }
+
+    Gfx::Bitmap& m_target_bitmap;
+    AccelGfx::Canvas m_canvas;
+    AccelGfx::Painter m_painter;
+};
+
+}

--- a/Userland/Libraries/LibWeb/Painting/RecordingPainter.cpp
+++ b/Userland/Libraries/LibWeb/Painting/RecordingPainter.cpp
@@ -352,6 +352,11 @@ void RecordingPainter::paint_text_shadow(int blur_radius, Gfx::IntRect bounding_
 
 void RecordingPainter::fill_rect_with_rounded_corners(Gfx::IntRect const& rect, Color color, Gfx::AntiAliasingPainter::CornerRadius top_left_radius, Gfx::AntiAliasingPainter::CornerRadius top_right_radius, Gfx::AntiAliasingPainter::CornerRadius bottom_right_radius, Gfx::AntiAliasingPainter::CornerRadius bottom_left_radius)
 {
+    if (!top_left_radius && !top_right_radius && !bottom_right_radius && !bottom_left_radius) {
+        fill_rect(rect, color);
+        return;
+    }
+
     push_command(FillRectWithRoundedCorners {
         .rect = state().translation.map(rect),
         .color = color,

--- a/Userland/Libraries/LibWebView/ViewImplementation.h
+++ b/Userland/Libraries/LibWebView/ViewImplementation.h
@@ -25,6 +25,11 @@ enum class EnableCallgrindProfiling {
     Yes
 };
 
+enum class EnableGPUPainting {
+    No,
+    Yes
+};
+
 enum class IsLayoutTestMode {
     No,
     Yes

--- a/Userland/Services/WebContent/PageHost.h
+++ b/Userland/Services/WebContent/PageHost.h
@@ -24,6 +24,8 @@ public:
     static NonnullOwnPtr<PageHost> create(ConnectionFromClient& client) { return adopt_own(*new PageHost(client)); }
     virtual ~PageHost();
 
+    static void set_use_gpu_painter();
+
     virtual Web::Page& page() override { return *m_page; }
     virtual Web::Page const& page() const override { return *m_page; }
 

--- a/Userland/Utilities/headless-browser.cpp
+++ b/Userland/Utilities/headless-browser.cpp
@@ -60,7 +60,7 @@ public:
         (void)is_layout_test_mode;
 #else
         auto candidate_web_content_paths = TRY(get_paths_for_helper_process("WebContent"sv));
-        view->m_client_state.client = TRY(launch_web_content_process(*view, candidate_web_content_paths, WebView::EnableCallgrindProfiling::No, is_layout_test_mode, Ladybird::UseLagomNetworking::No));
+        view->m_client_state.client = TRY(launch_web_content_process(*view, candidate_web_content_paths, WebView::EnableCallgrindProfiling::No, is_layout_test_mode, Ladybird::UseLagomNetworking::No, WebView::EnableGPUPainting::No));
 #endif
 
         view->client().async_update_system_theme(move(theme));


### PR DESCRIPTION
This change introduces following things:
- LibAccelGfx library that uses OpenGL to paint 2D graphics.
- PaintingCommandExecutorGPU that uses LibAccelGfx to perform painting commands from RecordingPainter.
- `--enable-gpu-painting` parameter in Ladybird to enable GPU painting.

For now the only support operation is rectangle painting and it is possible to build only on linux but we have to start somewhere :)
