### PR TITLE
LibJS/JIT: Compile 3 more Instructions

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/CommonImplementations.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/CommonImplementations.cpp
@@ -423,4 +423,30 @@ MarkedVector<Value> argument_list_evaluation(Bytecode::Interpreter& interpreter)
     return argument_values;
 }
 
+ThrowCompletionOr<void> create_variable(VM& vm, DeprecatedFlyString const& name, Op::EnvironmentMode mode, bool is_global, bool is_immutable, bool is_strict)
+{
+    if (mode == Op::EnvironmentMode::Lexical) {
+        VERIFY(!is_global);
+
+        // Note: This is papering over an issue where "FunctionDeclarationInstantiation" creates these bindings for us.
+        //       Instead of crashing in there, we'll just raise an exception here.
+        if (TRY(vm.lexical_environment()->has_binding(name)))
+            return vm.throw_completion<InternalError>(TRY_OR_THROW_OOM(vm, String::formatted("Lexical environment already has binding '{}'", name)));
+
+        if (is_immutable)
+            return vm.lexical_environment()->create_immutable_binding(vm, name, is_strict);
+        return vm.lexical_environment()->create_mutable_binding(vm, name, is_strict);
+    }
+
+    if (!is_global) {
+        if (is_immutable)
+            return vm.variable_environment()->create_immutable_binding(vm, name, is_strict);
+        return vm.variable_environment()->create_mutable_binding(vm, name, is_strict);
+    }
+
+    // NOTE: CreateVariable with m_is_global set to true is expected to only be used in GlobalDeclarationInstantiation currently, which only uses "false" for "can_be_deleted".
+    //       The only area that sets "can_be_deleted" to true is EvalDeclarationInstantiation, which is currently fully implemented in C++ and not in Bytecode.
+    return verify_cast<GlobalEnvironment>(vm.variable_environment())->create_global_var_binding(name, false);
+}
+
 }

--- a/Userland/Libraries/LibJS/Bytecode/CommonImplementations.h
+++ b/Userland/Libraries/LibJS/Bytecode/CommonImplementations.h
@@ -32,5 +32,6 @@ struct CalleeAndThis {
 ThrowCompletionOr<CalleeAndThis> get_callee_and_this_from_environment(Bytecode::Interpreter&, DeprecatedFlyString const& name, u32 cache_index);
 Value new_regexp(VM&, ParsedRegex const&, DeprecatedString const& pattern, DeprecatedString const& flags);
 MarkedVector<Value> argument_list_evaluation(Bytecode::Interpreter&);
+ThrowCompletionOr<void> create_variable(VM&, DeprecatedFlyString const& name, Op::EnvironmentMode, bool is_global, bool is_immutable, bool is_strict);
 
 }

--- a/Userland/Libraries/LibJS/Bytecode/CommonImplementations.h
+++ b/Userland/Libraries/LibJS/Bytecode/CommonImplementations.h
@@ -33,5 +33,6 @@ ThrowCompletionOr<CalleeAndThis> get_callee_and_this_from_environment(Bytecode::
 Value new_regexp(VM&, ParsedRegex const&, DeprecatedString const& pattern, DeprecatedString const& flags);
 MarkedVector<Value> argument_list_evaluation(Bytecode::Interpreter&);
 ThrowCompletionOr<void> create_variable(VM&, DeprecatedFlyString const& name, Op::EnvironmentMode, bool is_global, bool is_immutable, bool is_strict);
+ThrowCompletionOr<ECMAScriptFunctionObject*> new_class(VM&, ClassExpression const&, Optional<IdentifierTableIndex> const& lhs_name);
 
 }

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -1443,25 +1443,7 @@ ThrowCompletionOr<void> IteratorResultValue::execute_impl(Bytecode::Interpreter&
 
 ThrowCompletionOr<void> NewClass::execute_impl(Bytecode::Interpreter& interpreter) const
 {
-    auto& vm = interpreter.vm();
-    auto name = m_class_expression.name();
-    auto super_class = interpreter.accumulator();
-
-    // NOTE: NewClass expects classEnv to be active lexical environment
-    auto class_environment = vm.lexical_environment();
-    vm.running_execution_context().lexical_environment = interpreter.saved_lexical_environment_stack().take_last();
-
-    DeprecatedFlyString binding_name;
-    DeprecatedFlyString class_name;
-    if (!m_class_expression.has_name() && m_lhs_name.has_value()) {
-        class_name = interpreter.current_executable().get_identifier(m_lhs_name.value());
-    } else {
-        binding_name = name;
-        class_name = name.is_null() ? ""sv : name;
-    }
-
-    interpreter.accumulator() = TRY(m_class_expression.create_class_constructor(vm, class_environment, vm.lexical_environment(), super_class, binding_name, class_name));
-
+    interpreter.accumulator() = TRY(new_class(interpreter.vm(), m_class_expression, m_lhs_name));
     return {};
 }
 

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -1005,6 +1005,9 @@ public:
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     DeprecatedString to_deprecated_string_impl(Bytecode::Executable const&) const;
 
+    ClassExpression const& class_expression() const { return m_class_expression; }
+    Optional<IdentifierTableIndex> const& lhs_name() const { return m_lhs_name; }
+
 private:
     ClassExpression const& m_class_expression;
     Optional<IdentifierTableIndex> m_lhs_name;

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -410,6 +410,12 @@ public:
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     DeprecatedString to_deprecated_string_impl(Bytecode::Executable const&) const;
 
+    IdentifierTableIndex identifier() const { return m_identifier; }
+    EnvironmentMode mode() const { return m_mode; }
+    bool is_immutable() const { return m_is_immutable; }
+    bool is_global() const { return m_is_global; }
+    bool is_strict() const { return m_is_strict; }
+
 private:
     IdentifierTableIndex m_identifier;
     EnvironmentMode m_mode;

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -362,6 +362,8 @@ public:
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     DeprecatedString to_deprecated_string_impl(Bytecode::Executable const&) const;
 
+    Register lhs() const { return m_lhs; }
+
 private:
     Register m_lhs;
 };

--- a/Userland/Libraries/LibJS/JIT/Compiler.h
+++ b/Userland/Libraries/LibJS/JIT/Compiler.h
@@ -101,6 +101,8 @@ private:
     void compile_new_regexp(Bytecode::Op::NewRegExp const&);
     void compile_new_bigint(Bytecode::Op::NewBigInt const&);
 
+    void compile_create_variable(Bytecode::Op::CreateVariable const&);
+
     void compile_get_by_id(Bytecode::Op::GetById const&);
     void compile_get_by_value(Bytecode::Op::GetByValue const&);
     void compile_get_global(Bytecode::Op::GetGlobal const&);

--- a/Userland/Libraries/LibJS/JIT/Compiler.h
+++ b/Userland/Libraries/LibJS/JIT/Compiler.h
@@ -100,6 +100,7 @@ private:
     void compile_new_function(Bytecode::Op::NewFunction const&);
     void compile_new_regexp(Bytecode::Op::NewRegExp const&);
     void compile_new_bigint(Bytecode::Op::NewBigInt const&);
+    void compile_new_class(Bytecode::Op::NewClass const&);
 
     void compile_create_variable(Bytecode::Op::CreateVariable const&);
 

--- a/Userland/Libraries/LibJS/JIT/Compiler.h
+++ b/Userland/Libraries/LibJS/JIT/Compiler.h
@@ -115,6 +115,7 @@ private:
     void compile_typeof_variable(Bytecode::Op::TypeofVariable const&);
     void compile_set_variable(Bytecode::Op::SetVariable const&);
     void compile_continue_pending_unwind(Bytecode::Op::ContinuePendingUnwind const&);
+    void compile_concat_string(Bytecode::Op::ConcatString const&);
 
     void store_vm_register(Bytecode::Register, Assembler::Reg);
     void load_vm_register(Assembler::Reg, Bytecode::Register);


### PR DESCRIPTION
This adds support for `ConcatString`, `CreateVariable` and `NewClass`.

Also includes a fix for a bug in exception handling, which was uncovered after implementing CreateVariable.