### PR TITLE
LibWeb: Bail parsing transform-origin if the parsed value is null

### DIFF
--- a/Tests/LibWeb/Text/expected/css/transform-origin-serialization.txt
+++ b/Tests/LibWeb/Text/expected/css/transform-origin-serialization.txt
@@ -1,0 +1,7 @@
+center => 50% 50%
+10px => 10px 50%
+25% => 25% 50%
+left 20% => 0% 20%
+20px bottom => 20px 100%
+top right => 100% 0%
+"center" => (invalid)

--- a/Tests/LibWeb/Text/input/css/transform-origin-serialization.html
+++ b/Tests/LibWeb/Text/input/css/transform-origin-serialization.html
@@ -1,0 +1,23 @@
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        function serialize(input) {
+            const e = document.createElement("div");
+            e.style.transformOrigin = input;
+            const serialized = e.style.transformOrigin;
+            println(input + " => " + (serialized === '' ? '(invalid)' : serialized));
+        }
+
+        for (transformOrigin of [
+            'center',
+            '10px',
+            '25%',
+            'left 20%',
+            '20px bottom',
+            'top right',
+            '"center"',
+        ]) {
+            serialize(transformOrigin);
+        }
+    });
+</script>

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -5008,6 +5008,8 @@ RefPtr<StyleValue> Parser::parse_transform_origin_value(Vector<ComponentValue> c
     };
 
     auto to_axis_offset = [](RefPtr<StyleValue> value) -> Optional<AxisOffset> {
+        if (!value)
+            return OptionalNone {};
         if (value->is_percentage())
             return AxisOffset { Axis::None, value->as_percentage() };
         if (value->is_length())


### PR DESCRIPTION
Passing a value of a type different than number or length-percentage to transform-origin returned a null pointer, and we didn't take care of that path before.

This patch fixes a crash caused by an incorrect CSS declaration, such as `transform-origin: "center"`.

Fixes #21609