### PR TITLE
HackStudio: Pass the correct `VariableInfo` address to `create_index`

### DIFF
--- a/Userland/DevTools/HackStudio/Debugger/VariablesModel.cpp
+++ b/Userland/DevTools/HackStudio/Debugger/VariablesModel.cpp
@@ -15,7 +15,7 @@ GUI::ModelIndex VariablesModel::index(int row, int column, const GUI::ModelIndex
     if (!parent_index.is_valid()) {
         if (static_cast<size_t>(row) >= m_variables.size())
             return {};
-        return create_index(row, column, &m_variables[row]);
+        return create_index(row, column, m_variables[row].ptr());
     }
     auto* parent = static_cast<Debug::DebugInfo::VariableInfo const*>(parent_index.internal_data());
     if (static_cast<size_t>(row) >= parent->members.size())


### PR DESCRIPTION
Fixes #21642
Previously, we tried to store `VariableInfo` to `ModelIndex` internal data, but accidently stored address of wrapper class `NonnullOwnPtr`. When we retrieved it later in `VariablesModel::data()` it made program to crash.

This allows us to run debug normally after setting any break point in `HackStudio`.