### PR TITLE
LibJS+LibJIT: Add fast paths for more binary ops with (Int32 op Int32)

### DIFF
--- a/Userland/Libraries/LibJIT/Assembler.h
+++ b/Userland/Libraries/LibJIT/Assembler.h
@@ -546,6 +546,28 @@ struct Assembler {
         }
     }
 
+    void mul32(Operand dest, Operand src, Optional<Label&> overflow_label)
+    {
+        // imul32 dest, src (32-bit signed)
+        if (dest.type == Operand::Type::Reg && src.type == Operand::Type::Reg) {
+            emit_rex_for_rm(dest, src, REX_W::No);
+            emit8(0x0f);
+            emit8(0xaf);
+            emit_modrm_rm(dest, src);
+        } else if (dest.type == Operand::Type::Reg && src.type == Operand::Type::Mem64BaseAndOffset) {
+            emit_rex_for_rm(dest, src, REX_W::No);
+            emit8(0x0f);
+            emit8(0xaf);
+            emit_modrm_rm(dest, src);
+        } else {
+            VERIFY_NOT_REACHED();
+        }
+
+        if (overflow_label.has_value()) {
+            jump_if(Condition::Overflow, *overflow_label);
+        }
+    }
+
     void enter()
     {
         push(Operand::Register(Reg::RBP));

--- a/Userland/Libraries/LibJIT/Assembler.h
+++ b/Userland/Libraries/LibJIT/Assembler.h
@@ -525,6 +525,27 @@ struct Assembler {
         }
     }
 
+    void bitwise_xor32(Operand dst, Operand src)
+    {
+        if (dst.is_register_or_memory() && src.type == Operand::Type::Reg) {
+            emit_rex_for_mr(dst, src, REX_W::No);
+            emit8(0x31);
+            emit_modrm_mr(dst, src);
+        } else if (dst.type == Operand::Type::Reg && src.type == Operand::Type::Imm && src.fits_in_i8()) {
+            emit_rex_for_slash(dst, REX_W::No);
+            emit8(0x83);
+            emit_modrm_slash(6, dst);
+            emit8(src.offset_or_immediate);
+        } else if (dst.type == Operand::Type::Reg && src.type == Operand::Type::Imm && src.fits_in_i32()) {
+            emit_rex_for_slash(dst, REX_W::No);
+            emit8(0x81);
+            emit_modrm_slash(6, dst);
+            emit32(src.offset_or_immediate);
+        } else {
+            VERIFY_NOT_REACHED();
+        }
+    }
+
     void enter()
     {
         push(Operand::Register(Reg::RBP));

--- a/Userland/Libraries/LibJS/JIT/Compiler.cpp
+++ b/Userland/Libraries/LibJS/JIT/Compiler.cpp
@@ -655,6 +655,35 @@ void Compiler::compile_bitwise_and(Bytecode::Op::BitwiseAnd const& op)
     end.link(m_assembler);
 }
 
+static Value cxx_bitwise_or(VM& vm, Value lhs, Value rhs)
+{
+    return TRY_OR_SET_EXCEPTION(bitwise_or(vm, lhs, rhs));
+}
+
+void Compiler::compile_bitwise_or(Bytecode::Op::BitwiseOr const& op)
+{
+    load_vm_register(ARG1, op.lhs());
+    load_accumulator(ARG2);
+
+    Assembler::Label end {};
+
+    branch_if_both_int32(ARG1, ARG2, [&] {
+        // NOTE: Since both sides are Int32, we know that the upper 32 bits are nothing but the INT32_TAG.
+        //       This means we can get away with just a simple 64-bit bitwise or.
+        m_assembler.bitwise_or(
+            Assembler::Operand::Register(ARG1),
+            Assembler::Operand::Register(ARG2));
+
+        store_accumulator(ARG1);
+        m_assembler.jump(end);
+    });
+
+    native_call((void*)cxx_bitwise_or);
+    store_accumulator(RET);
+    check_exception();
+    end.link(m_assembler);
+}
+
 static ThrowCompletionOr<Value> not_(VM&, Value value)
 {
     return Value(!value.to_boolean());

--- a/Userland/Libraries/LibJS/JIT/Compiler.cpp
+++ b/Userland/Libraries/LibJS/JIT/Compiler.cpp
@@ -578,6 +578,48 @@ void Compiler::compile_sub(Bytecode::Op::Sub const& op)
     end.link(m_assembler);
 }
 
+static Value cxx_mul(VM& vm, Value lhs, Value rhs)
+{
+    return TRY_OR_SET_EXCEPTION(mul(vm, lhs, rhs));
+}
+
+void Compiler::compile_mul(Bytecode::Op::Mul const& op)
+{
+    load_vm_register(ARG1, op.lhs());
+    load_accumulator(ARG2);
+
+    Assembler::Label end {};
+    Assembler::Label slow_case {};
+
+    branch_if_both_int32(ARG1, ARG2, [&] {
+        // GPR0 = ARG1 * ARG2 (32-bit)
+        // if (overflow) goto slow_case;
+        m_assembler.mov(
+            Assembler::Operand::Register(GPR0),
+            Assembler::Operand::Register(ARG1));
+        m_assembler.mul32(
+            Assembler::Operand::Register(GPR0),
+            Assembler::Operand::Register(ARG2),
+            slow_case);
+
+        // accumulator = GPR0 | SHIFTED_INT32_TAG;
+        m_assembler.mov(
+            Assembler::Operand::Register(GPR1),
+            Assembler::Operand::Imm(SHIFTED_INT32_TAG));
+        m_assembler.bitwise_or(
+            Assembler::Operand::Register(GPR0),
+            Assembler::Operand::Register(GPR1));
+        store_accumulator(GPR0);
+        m_assembler.jump(end);
+    });
+
+    slow_case.link(m_assembler);
+    native_call((void*)cxx_mul);
+    store_accumulator(RET);
+    check_exception();
+    end.link(m_assembler);
+}
+
 static Value cxx_less_than(VM& vm, Value lhs, Value rhs)
 {
     return TRY_OR_SET_EXCEPTION(less_than(vm, lhs, rhs));

--- a/Userland/Libraries/LibJS/JIT/Compiler.cpp
+++ b/Userland/Libraries/LibJS/JIT/Compiler.cpp
@@ -536,6 +536,48 @@ void Compiler::compile_add(Bytecode::Op::Add const& op)
     end.link(m_assembler);
 }
 
+static Value cxx_sub(VM& vm, Value lhs, Value rhs)
+{
+    return TRY_OR_SET_EXCEPTION(sub(vm, lhs, rhs));
+}
+
+void Compiler::compile_sub(Bytecode::Op::Sub const& op)
+{
+    load_vm_register(ARG1, op.lhs());
+    load_accumulator(ARG2);
+
+    Assembler::Label end {};
+    Assembler::Label slow_case {};
+
+    branch_if_both_int32(ARG1, ARG2, [&] {
+        // GPR0 = ARG1 + ARG2 (32-bit)
+        // if (overflow) goto slow_case;
+        m_assembler.mov(
+            Assembler::Operand::Register(GPR0),
+            Assembler::Operand::Register(ARG1));
+        m_assembler.sub32(
+            Assembler::Operand::Register(GPR0),
+            Assembler::Operand::Register(ARG2),
+            slow_case);
+
+        // accumulator = GPR0 | SHIFTED_INT32_TAG;
+        m_assembler.mov(
+            Assembler::Operand::Register(GPR1),
+            Assembler::Operand::Imm(SHIFTED_INT32_TAG));
+        m_assembler.bitwise_or(
+            Assembler::Operand::Register(GPR0),
+            Assembler::Operand::Register(GPR1));
+        store_accumulator(GPR0);
+        m_assembler.jump(end);
+    });
+
+    slow_case.link(m_assembler);
+    native_call((void*)cxx_sub);
+    store_accumulator(RET);
+    check_exception();
+    end.link(m_assembler);
+}
+
 static Value cxx_less_than(VM& vm, Value lhs, Value rhs)
 {
     return TRY_OR_SET_EXCEPTION(less_than(vm, lhs, rhs));

--- a/Userland/Libraries/LibJS/JIT/Compiler.h
+++ b/Userland/Libraries/LibJS/JIT/Compiler.h
@@ -41,7 +41,6 @@ private:
 #    endif
 
 #    define JS_ENUMERATE_COMMON_BINARY_OPS_WITHOUT_FAST_PATH(O) \
-        O(Sub, sub)                                             \
         O(Mul, mul)                                             \
         O(Div, div)                                             \
         O(Exp, exp)                                             \

--- a/Userland/Libraries/LibJS/JIT/Compiler.h
+++ b/Userland/Libraries/LibJS/JIT/Compiler.h
@@ -54,7 +54,6 @@ private:
         O(LooselyEquals, abstract_equals)                       \
         O(StrictlyInequals, typed_inequals)                     \
         O(StrictlyEquals, typed_equals)                         \
-        O(BitwiseXor, bitwise_xor)                              \
         O(LeftShift, left_shift)                                \
         O(RightShift, right_shift)                              \
         O(UnsignedRightShift, unsigned_right_shift)

--- a/Userland/Libraries/LibJS/JIT/Compiler.h
+++ b/Userland/Libraries/LibJS/JIT/Compiler.h
@@ -54,7 +54,6 @@ private:
         O(LooselyEquals, abstract_equals)                       \
         O(StrictlyInequals, typed_inequals)                     \
         O(StrictlyEquals, typed_equals)                         \
-        O(BitwiseAnd, bitwise_and)                              \
         O(BitwiseOr, bitwise_or)                                \
         O(BitwiseXor, bitwise_xor)                              \
         O(LeftShift, left_shift)                                \

--- a/Userland/Libraries/LibJS/JIT/Compiler.h
+++ b/Userland/Libraries/LibJS/JIT/Compiler.h
@@ -41,7 +41,6 @@ private:
 #    endif
 
 #    define JS_ENUMERATE_COMMON_BINARY_OPS_WITHOUT_FAST_PATH(O) \
-        O(Mul, mul)                                             \
         O(Div, div)                                             \
         O(Exp, exp)                                             \
         O(Mod, mod)                                             \

--- a/Userland/Libraries/LibJS/JIT/Compiler.h
+++ b/Userland/Libraries/LibJS/JIT/Compiler.h
@@ -54,7 +54,6 @@ private:
         O(LooselyEquals, abstract_equals)                       \
         O(StrictlyInequals, typed_inequals)                     \
         O(StrictlyEquals, typed_equals)                         \
-        O(BitwiseOr, bitwise_or)                                \
         O(BitwiseXor, bitwise_xor)                              \
         O(LeftShift, left_shift)                                \
         O(RightShift, right_shift)                              \


### PR DESCRIPTION
Nice incremental speed-up across the Kraken tests:

```
Suite    Test                                   Speedup  Old (Mean ± Range)        New (Mean ± Range)
-------  -----------------------------------  ---------  ------------------------  ------------------------
Kraken   ai-astar.js                              1.028  3.500 ± 3.480 … 3.520     3.403 ± 3.390 … 3.430
Kraken   audio-beat-detection.js                  1.01   1.967 ± 1.940 … 1.980     1.947 ± 1.920 … 1.980
Kraken   audio-dft.js                             1.055  1.803 ± 1.800 … 1.810     1.710 ± 1.700 … 1.720
Kraken   audio-fft.js                             1.004  1.820 ± 1.800 … 1.830     1.813 ± 1.790 … 1.830
Kraken   audio-oscillator.js                      1.051  2.760 ± 2.720 … 2.780     2.627 ± 2.620 … 2.630
Kraken   imaging-darkroom.js                      1.02   4.673 ± 4.600 … 4.730     4.583 ± 4.540 … 4.630
Kraken   imaging-desaturate.js                    1.105  3.060 ± 2.990 … 3.180     2.770 ± 2.750 … 2.790
Kraken   imaging-gaussian-blur.js                 1.045  20.377 ± 20.240 … 20.550  19.497 ± 19.310 … 19.640
Kraken   json-parse-financial.js                  1.042  0.083 ± 0.080 … 0.090     0.080 ± 0.080 … 0.080
Kraken   json-stringify-tinderbox.js              1.048  0.220 ± 0.220 … 0.220     0.210 ± 0.210 … 0.210
Kraken   stanford-crypto-aes.js                   1.115  1.033 ± 1.030 … 1.040     0.927 ± 0.910 … 0.940
Kraken   stanford-crypto-ccm.js                   1.082  0.877 ± 0.870 … 0.880     0.810 ± 0.810 … 0.810
Kraken   stanford-crypto-pbkdf2.js                1.099  1.887 ± 1.880 … 1.890     1.717 ± 1.700 … 1.750
Kraken   stanford-crypto-sha256-iterative.js      1.077  0.700 ± 0.700 … 0.700     0.650 ± 0.640 … 0.670
```