### PR TITLE
LibJIT/LibJS: Unify the multiple `jump_if_*()` functions into one `jump_if()`

### DIFF
--- a/Userland/Libraries/LibJIT/Assembler.h
+++ b/Userland/Libraries/LibJIT/Assembler.h
@@ -358,40 +358,6 @@ struct Assembler {
         label.add_jump(*this, m_output.size());
     }
 
-    void jump_if_zero(Operand reg, Label& label)
-    {
-        jump_if(reg, Condition::EqualTo, Operand::Imm(0), label);
-    }
-
-    void jump_if_not_zero(Operand reg, Label& label)
-    {
-        jump_if(reg, Condition::NotEqualTo, Operand::Imm(0), label);
-    }
-
-    void jump_if_equal(Operand lhs, Operand rhs, Label& label)
-    {
-        jump_if(lhs, Condition::EqualTo, rhs, label);
-    }
-
-    void jump_if_not_equal(Operand lhs, Operand rhs, Label& label)
-    {
-        jump_if(lhs, Condition::NotEqualTo, rhs, label);
-    }
-
-    void jump_if_less_than(Operand lhs, Operand rhs, Label& label)
-    {
-        jump_if(lhs, Condition::SignedLessThan, rhs, label);
-    }
-
-    void jump_if_overflow(Label& label)
-    {
-        // jo label (RIP-relative 32-bit offset)
-        emit8(0x0f);
-        emit8(0x80);
-        emit32(0xdeadbeef);
-        label.add_jump(*this, m_output.size());
-    }
-
     void sign_extend_32_to_64_bits(Reg reg)
     {
         // movsxd (reg as 64-bit), (reg as 32-bit)
@@ -545,7 +511,7 @@ struct Assembler {
         }
     }
 
-    void add32(Operand dst, Operand src)
+    void add32(Operand dst, Operand src, Optional<Label&> label)
     {
         if (dst.type == Operand::Type::Reg && to_underlying(dst.reg) < 8 && src.type == Operand::Type::Reg && to_underlying(src.reg) < 8) {
             emit8(0x01);
@@ -560,6 +526,14 @@ struct Assembler {
             emit32(src.offset_or_immediate);
         } else {
             VERIFY_NOT_REACHED();
+        }
+
+        if (label.has_value()) {
+            // jo label (RIP-relative 32-bit offset)
+            emit8(0x0f);
+            emit8(0x80);
+            emit32(0xdeadbeef);
+            label->add_jump(*this, m_output.size());
         }
     }
 

--- a/Userland/Libraries/LibJIT/Assembler.h
+++ b/Userland/Libraries/LibJIT/Assembler.h
@@ -293,7 +293,9 @@ struct Assembler {
 
     void cmp(Operand lhs, Operand rhs)
     {
-        if (lhs.type == Operand::Type::Reg && rhs.type == Operand::Type::Reg) {
+        if (rhs.type == Operand::Type::Imm && rhs.offset_or_immediate == 0) {
+            test(lhs, lhs);
+        } else if (lhs.type == Operand::Type::Reg && rhs.type == Operand::Type::Reg) {
             emit8(0x48
                 | ((to_underlying(rhs.reg) >= 8) ? 1 << 2 : 0)
                 | ((to_underlying(lhs.reg) >= 8) ? 1 << 0 : 0));


### PR DESCRIPTION
While investigating some (unfruitful) micro-optimizations, I noticed that the jump conditions are determined according to (I believe) 4 bits of the opcode. We can leverage that to provide one function that uses an enum to implement all conditional jump instructions at once instead of creating individual functions for them, i.e.:

```cpp
    m_assembler.jump_if(
        Assembler::Operand::Register(dst),
        Assembler::Condition::NotEqualTo,
        Assembler::Operand::Imm(BOOLEAN_TAG),
        slow_case);
```

The nibble that contains the condition of the jump instruction appears to also be consistent between `CMOVcc` and `SETcc`, so those can be implemented very easily using the same enum. I've created those locally, but since there are currently no uses for those instructions, I've omitted them here.