### PR TITLE
LibHTTP: Fix duplicate Content-Length header

### DIFF
--- a/Userland/Libraries/LibHTTP/HttpRequest.cpp
+++ b/Userland/Libraries/LibHTTP/HttpRequest.cpp
@@ -69,7 +69,7 @@ ErrorOr<ByteBuffer> HttpRequest::to_raw_request() const
         TRY(builder.try_append("\r\n"sv));
     }
     if (!m_body.is_empty() || method() == Method::POST) {
-        TRY(builder.try_appendff("Content-Length: {}\r\n\r\n", m_body.size()));
+        TRY(builder.try_append("\r\n"sv));
         TRY(builder.try_append((char const*)m_body.data(), m_body.size()));
     }
     TRY(builder.try_append("\r\n"sv));


### PR DESCRIPTION
The previous implementation added a duplicate 'Content-Length' header in case a HTTP request was made with a non-zero length body or with POST method. 'Content-Length header seems to be present regardless. Therefore it shouldn't added twice.


Steps to reproduce:
1. In Ladybird, navigate to https://news.ycombinator.com/item?id=38057591, leave the comment box empty and press  'add comment'. 
2. You get a 400 error from Nginx indicating a problem with the HTTP request

On closer inspection in Wireshark you can see that a duplicate Content-Length is being sent:
<img width="711" alt="image" src="https://github.com/SerenityOS/serenity/assets/920770/679a2ca6-ccee-4402-9848-5e78e3d8530a">
