### PR TITLE
LibWeb: Stop doing SVG layout during painting and get `<text>` elements to respect the `viewBox`

### DIFF
--- a/Tests/LibWeb/Layout/expected/css-namespace-tag-name-selector.txt
+++ b/Tests/LibWeb/Layout/expected/css-namespace-tag-name-selector.txt
@@ -9,7 +9,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           frag 2 from Box start: 0, length: 0, rect: [319,51 0x108]
         SVGSVGBox <svg> at (9,9) content-size 300x150 [SVG] children: inline
           InlineNode <a>
-            SVGTextBox <text> at (9,9) content-size 0x0 children: inline
+            SVGTextBox <text> at (29,9) content-size 198.90625x80 children: inline
               TextNode <#text>
         TextNode <#text>
         Box <math> at (319,51) content-size 0x108 children: not-inline

--- a/Tests/LibWeb/Layout/expected/svg-text-with-viewbox.txt
+++ b/Tests/LibWeb/Layout/expected/svg-text-with-viewbox.txt
@@ -1,0 +1,30 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x261.328125 children: inline
+      line 0 width: 784, height: 261.328125, bottom: 261.328125, baseline: 261.328125
+        frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,8 784x261.328125]
+      SVGSVGBox <svg> at (8,8) content-size 784x261.328125 [SVG] children: inline
+        TextNode <#text>
+        TextNode <#text>
+        SVGTextBox <text.small> at (73.34375,79.859375) content-size 50.265625x42.46875 children: inline
+          TextNode <#text>
+        TextNode <#text>
+        SVGTextBox <text.heavy> at (138.6875,24.328125) content-size 153.703125x98 children: inline
+          TextNode <#text>
+        TextNode <#text>
+        SVGTextBox <text.small> at (187.671875,145.1875) content-size 36.90625x42.46875 children: inline
+          TextNode <#text>
+        TextNode <#text>
+        SVGTextBox <text.Rrrrr> at (220.34375,57) content-size 526.609375x130.65625 children: inline
+          TextNode <#text>
+        TextNode <#text>
+      TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x261.328125]
+      SVGSVGPaintable (SVGSVGBox<svg>) [8,8 784x261.328125]
+        SVGTextPaintable (SVGTextBox<text>.small) [73.34375,79.859375 50.265625x42.46875]
+        SVGTextPaintable (SVGTextBox<text>.heavy) [138.6875,24.328125 153.703125x98]
+        SVGTextPaintable (SVGTextBox<text>.small) [187.671875,145.1875 36.90625x42.46875]
+        SVGTextPaintable (SVGTextBox<text>.Rrrrr) [220.34375,57 526.609375x130.65625]

--- a/Tests/LibWeb/Layout/expected/svg/text-fill-none.txt
+++ b/Tests/LibWeb/Layout/expected/svg/text-fill-none.txt
@@ -4,11 +4,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       line 0 width: 300, height: 150, bottom: 150, baseline: 150
         frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,8 300x150]
       SVGSVGBox <svg> at (8,8) content-size 300x150 [SVG] children: not-inline
-        SVGTextBox <text> at (8,8) content-size 0x0 children: not-inline
+        SVGTextBox <text> at (8,-8) content-size 0x16 children: not-inline
       TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x150]
-      SVGSVGPaintable (SVGSVGBox<svg>) [8,8 300x150]
-        SVGTextPaintable (SVGTextBox<text>) [8,8 0x0]
+      SVGSVGPaintable (SVGSVGBox<svg>) [8,8 300x150] overflow: [8,-8 300x166]
+        SVGTextPaintable (SVGTextBox<text>) [8,-8 0x16]

--- a/Tests/LibWeb/Layout/input/svg-text-with-viewbox.html
+++ b/Tests/LibWeb/Layout/input/svg-text-with-viewbox.html
@@ -1,0 +1,20 @@
+<svg viewBox="0 0 240 80" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .small {
+      font: italic 13px sans-serif;
+    }
+    .heavy {
+      font: bold 30px sans-serif;
+    }
+
+    .Rrrrr {
+      font: italic 40px serif;
+      fill: red;
+    }
+  </style>
+
+  <text x="20" y="35" class="small">My</text>
+  <text x="40" y="35" class="heavy">cat</text>
+  <text x="55" y="55" class="small">is</text>
+  <text x="65" y="55" class="Rrrrr">Grumpy!</text>
+</svg>

--- a/Tests/LibWeb/Ref/reference/simple-svg-mask-ref.html
+++ b/Tests/LibWeb/Ref/reference/simple-svg-mask-ref.html
@@ -1,4 +1,4 @@
-<svg width="200" viewBox="-10 -10 120 120">
+<svg width="120" viewBox="-10 -10 120 120">
   <rect x="-10" y="-10" width="120" height="120" fill="blue" />
   <rect x="50" y="10" width="40" height="80" fill="red"  />
 </svg>

--- a/Tests/LibWeb/Ref/simple-svg-mask.html
+++ b/Tests/LibWeb/Ref/simple-svg-mask.html
@@ -1,5 +1,5 @@
 <link rel="match" href="reference/simple-svg-mask-ref.html" />
-<svg width="200" viewBox="-10 -10 120 120">
+<svg width="120" viewBox="-10 -10 120 120">
   <mask id="myMask">
     <!-- Everything under a white pixel will be visible -->
     <rect x="0" y="0" width="100" height="100" fill="white" />

--- a/Tests/LibWeb/Ref/svg-alpha-mask.html
+++ b/Tests/LibWeb/Ref/svg-alpha-mask.html
@@ -1,5 +1,5 @@
 <link rel="match" href="reference/simple-svg-mask-ref.html" />
-<svg width="200" viewBox="-10 -10 120 120">
+<svg width="120" viewBox="-10 -10 120 120">
   <defs>
     <mask id="myMask" style="mask-type:alpha">
       <!-- Everything solid pixel (alpha=255) will be visible -->

--- a/Tests/LibWeb/Ref/svg-mask-in-defs.html
+++ b/Tests/LibWeb/Ref/svg-mask-in-defs.html
@@ -1,5 +1,5 @@
 <link rel="match" href="reference/simple-svg-mask-ref.html" />
-<svg width="200" viewBox="-10 -10 120 120">
+<svg width="120" viewBox="-10 -10 120 120">
   <defs>
     <mask id="myMask">
       <!-- Everything under a white pixel will be visible -->

--- a/Tests/LibWeb/Ref/svg-mask-maskUnits-userSpaceOnUse.html
+++ b/Tests/LibWeb/Ref/svg-mask-maskUnits-userSpaceOnUse.html
@@ -1,5 +1,5 @@
 <link rel="match" href="reference/simple-svg-mask-ref.html" />
-<svg width="200" viewBox="-10 -10 120 120">
+<svg width="120" viewBox="-10 -10 120 120">
   <defs>
     <mask id="myMask" maskUnits="userSpaceOnUse">
       <!-- Everything under a white pixel will be visible -->

--- a/Userland/Libraries/LibWeb/Layout/LayoutState.cpp
+++ b/Userland/Libraries/LibWeb/Layout/LayoutState.cpp
@@ -265,6 +265,11 @@ void LayoutState::commit(Box& root)
                 paintable_with_lines.set_line_boxes(move(used_values.line_boxes));
                 paintables_with_lines.append(paintable_with_lines);
             }
+
+            if (used_values.svg_path_data().has_value() && is<Painting::SVGGeometryPaintable>(paintable_box)) {
+                auto& svg_geometry_paintable = static_cast<Painting::SVGGeometryPaintable&>(paintable_box);
+                svg_geometry_paintable.set_path_data(move(*used_values.svg_path_data()));
+            }
         }
     }
 

--- a/Userland/Libraries/LibWeb/Layout/LayoutState.cpp
+++ b/Userland/Libraries/LibWeb/Layout/LayoutState.cpp
@@ -10,6 +10,7 @@
 #include <LibWeb/Layout/LayoutState.h>
 #include <LibWeb/Layout/TextNode.h>
 #include <LibWeb/Layout/Viewport.h>
+#include <LibWeb/Painting/SVGGeometryPaintable.h>
 
 namespace Web::Layout {
 
@@ -266,9 +267,14 @@ void LayoutState::commit(Box& root)
                 paintables_with_lines.append(paintable_with_lines);
             }
 
-            if (used_values.svg_path_data().has_value() && is<Painting::SVGGeometryPaintable>(paintable_box)) {
+            if (used_values.computed_svg_transforms().has_value() && is<Painting::SVGGraphicsPaintable>(paintable_box)) {
+                auto& svg_graphics_paintable = static_cast<Painting::SVGGraphicsPaintable&>(paintable_box);
+                svg_graphics_paintable.set_computed_transforms(*used_values.computed_svg_transforms());
+            }
+
+            if (used_values.computed_svg_path().has_value() && is<Painting::SVGGeometryPaintable>(paintable_box)) {
                 auto& svg_geometry_paintable = static_cast<Painting::SVGGeometryPaintable&>(paintable_box);
-                svg_geometry_paintable.set_path_data(move(*used_values.svg_path_data()));
+                svg_geometry_paintable.set_computed_path(move(*used_values.computed_svg_path()));
             }
         }
     }

--- a/Userland/Libraries/LibWeb/Layout/LayoutState.h
+++ b/Userland/Libraries/LibWeb/Layout/LayoutState.h
@@ -11,7 +11,7 @@
 #include <LibWeb/Layout/Box.h>
 #include <LibWeb/Layout/LineBox.h>
 #include <LibWeb/Painting/PaintableBox.h>
-#include <LibWeb/Painting/SVGGeometryPaintable.h>
+#include <LibWeb/Painting/SVGGraphicsPaintable.h>
 
 namespace Web::Layout {
 
@@ -124,8 +124,11 @@ struct LayoutState {
         void set_table_cell_coordinates(Painting::PaintableBox::TableCellCoordinates const& table_cell_coordinates) { m_table_cell_coordinates = table_cell_coordinates; }
         auto const& table_cell_coordinates() const { return m_table_cell_coordinates; }
 
-        void set_svg_path_data(Painting::SVGGeometryPaintable::PathData const& svg_path_data) { m_svg_path_data = svg_path_data; }
-        auto& svg_path_data() const { return m_svg_path_data; }
+        void set_computed_svg_path(Gfx::Path const& svg_path) { m_computed_svg_path = svg_path; }
+        auto& computed_svg_path() { return m_computed_svg_path; }
+
+        void set_computed_svg_transforms(Painting::SVGGraphicsPaintable::ComputedTransforms const& computed_transforms) { m_computed_svg_transforms = computed_transforms; }
+        auto const& computed_svg_transforms() const { return m_computed_svg_transforms; }
 
     private:
         AvailableSize available_width_inside() const;
@@ -151,7 +154,8 @@ struct LayoutState {
         Optional<Painting::PaintableBox::BordersDataWithElementKind> m_override_borders_data;
         Optional<Painting::PaintableBox::TableCellCoordinates> m_table_cell_coordinates;
 
-        Optional<Painting::SVGGeometryPaintable::PathData> m_svg_path_data;
+        Optional<Gfx::Path> m_computed_svg_path;
+        Optional<Painting::SVGGraphicsPaintable::ComputedTransforms> m_computed_svg_transforms;
     };
 
     // Commits the used values produced by layout and builds a paintable tree.

--- a/Userland/Libraries/LibWeb/Layout/LayoutState.h
+++ b/Userland/Libraries/LibWeb/Layout/LayoutState.h
@@ -11,6 +11,7 @@
 #include <LibWeb/Layout/Box.h>
 #include <LibWeb/Layout/LineBox.h>
 #include <LibWeb/Painting/PaintableBox.h>
+#include <LibWeb/Painting/SVGGeometryPaintable.h>
 
 namespace Web::Layout {
 
@@ -123,6 +124,9 @@ struct LayoutState {
         void set_table_cell_coordinates(Painting::PaintableBox::TableCellCoordinates const& table_cell_coordinates) { m_table_cell_coordinates = table_cell_coordinates; }
         auto const& table_cell_coordinates() const { return m_table_cell_coordinates; }
 
+        void set_svg_path_data(Painting::SVGGeometryPaintable::PathData const& svg_path_data) { m_svg_path_data = svg_path_data; }
+        auto& svg_path_data() const { return m_svg_path_data; }
+
     private:
         AvailableSize available_width_inside() const;
         AvailableSize available_height_inside() const;
@@ -146,6 +150,8 @@ struct LayoutState {
 
         Optional<Painting::PaintableBox::BordersDataWithElementKind> m_override_borders_data;
         Optional<Painting::PaintableBox::TableCellCoordinates> m_table_cell_coordinates;
+
+        Optional<Painting::SVGGeometryPaintable::PathData> m_svg_path_data;
     };
 
     // Commits the used values produced by layout and builds a paintable tree.

--- a/Userland/Libraries/LibWeb/Layout/SVGGeometryBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/SVGGeometryBox.cpp
@@ -17,43 +17,6 @@ SVGGeometryBox::SVGGeometryBox(DOM::Document& document, SVG::SVGGeometryElement&
 {
 }
 
-CSSPixelPoint SVGGeometryBox::viewbox_origin() const
-{
-    auto* svg_box = dom_node().shadow_including_first_ancestor_of_type<SVG::SVGSVGElement>();
-    if (!svg_box || !svg_box->view_box().has_value())
-        return { 0, 0 };
-    return { svg_box->view_box().value().min_x, svg_box->view_box().value().min_y };
-}
-
-Optional<Gfx::AffineTransform> SVGGeometryBox::layout_transform(Gfx::AffineTransform additional_svg_transform) const
-{
-    auto& geometry_element = dom_node();
-    auto transform = geometry_element.get_transform();
-    auto* svg_box = geometry_element.shadow_including_first_ancestor_of_type<SVG::SVGSVGElement>();
-    double scaling = 1;
-    auto origin = viewbox_origin().to_type<float>();
-    Gfx::FloatPoint paint_offset = {};
-    if (svg_box && geometry_element.view_box().has_value()) {
-        // Note: SVGFormattingContext has already done the scaling based on the viewbox,
-        // we now have to derive what it was from the original bounding box size.
-        // FIXME: It would be nice if we could store the transform from layout somewhere, so we don't have to solve for it here.
-        auto original_bounding_box = Gfx::AffineTransform {}.translate(-origin).multiply(transform).map(const_cast<SVG::SVGGeometryElement&>(geometry_element).get_path().bounding_box());
-        float stroke_width = geometry_element.visible_stroke_width();
-        original_bounding_box.inflate(stroke_width, stroke_width);
-        // If the transform (or path) results in a empty box we can't display this.
-        if (original_bounding_box.is_empty())
-            return {};
-        auto scaled_width = paintable_box()->content_width().to_double();
-        auto scaled_height = paintable_box()->content_height().to_double();
-        scaling = min(scaled_width / static_cast<double>(original_bounding_box.width()), scaled_height / static_cast<double>(original_bounding_box.height()));
-        auto scaled_bounding_box = original_bounding_box.scaled(scaling, scaling);
-        paint_offset = (paintable_box()->absolute_rect().location() - svg_box->paintable_box()->absolute_rect().location()).to_type<float>() - scaled_bounding_box.location();
-    }
-    // Note: The "additional_svg_transform" is applied during mask painting to transform the mask element to match its target.
-    // It has to be applied while still in the SVG coordinate space.
-    return Gfx::AffineTransform {}.translate(paint_offset).scale(scaling, scaling).translate(-origin).multiply(additional_svg_transform).multiply(transform);
-}
-
 JS::GCPtr<Painting::Paintable> SVGGeometryBox::create_paintable() const
 {
     return Painting::SVGGeometryPaintable::create(*this);

--- a/Userland/Libraries/LibWeb/Layout/SVGGeometryBox.h
+++ b/Userland/Libraries/LibWeb/Layout/SVGGeometryBox.h
@@ -22,13 +22,9 @@ public:
     SVG::SVGGeometryElement& dom_node() { return static_cast<SVG::SVGGeometryElement&>(SVGGraphicsBox::dom_node()); }
     SVG::SVGGeometryElement const& dom_node() const { return static_cast<SVG::SVGGeometryElement const&>(SVGGraphicsBox::dom_node()); }
 
-    Optional<Gfx::AffineTransform> layout_transform(Gfx::AffineTransform additional_svg_transform) const;
-
     virtual JS::GCPtr<Painting::Paintable> create_paintable() const override;
 
 private:
-    CSSPixelPoint viewbox_origin() const;
-
     virtual bool is_svg_geometry_box() const final { return true; }
 };
 

--- a/Userland/Libraries/LibWeb/Layout/SVGTextBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/SVGTextBox.cpp
@@ -15,27 +15,6 @@ SVGTextBox::SVGTextBox(DOM::Document& document, SVG::SVGTextPositioningElement& 
 {
 }
 
-CSSPixelPoint SVGTextBox::viewbox_origin() const
-{
-    auto* svg_box = dom_node().first_ancestor_of_type<SVG::SVGSVGElement>();
-    if (!svg_box || !svg_box->view_box().has_value())
-        return { 0, 0 };
-    return { svg_box->view_box().value().min_x, svg_box->view_box().value().min_y };
-}
-
-Optional<Gfx::AffineTransform> SVGTextBox::layout_transform() const
-{
-    // FIXME: Since text layout boxes are currently 0x0 it is not possible handle viewBox scaling here.
-    auto& geometry_element = dom_node();
-    auto transform = geometry_element.get_transform();
-    auto* svg_box = geometry_element.first_ancestor_of_type<SVG::SVGSVGElement>();
-    auto origin = viewbox_origin().to_type<float>();
-    Gfx::FloatPoint paint_offset = {};
-    if (svg_box && svg_box->view_box().has_value())
-        paint_offset = svg_box->paintable_box()->absolute_rect().location().to_type<float>();
-    return Gfx::AffineTransform {}.translate(paint_offset).translate(-origin).multiply(transform);
-}
-
 JS::GCPtr<Painting::Paintable> SVGTextBox::create_paintable() const
 {
     return Painting::SVGTextPaintable::create(*this);

--- a/Userland/Libraries/LibWeb/Layout/SVGTextBox.h
+++ b/Userland/Libraries/LibWeb/Layout/SVGTextBox.h
@@ -22,8 +22,6 @@ public:
     SVG::SVGTextPositioningElement& dom_node() { return static_cast<SVG::SVGTextPositioningElement&>(SVGGraphicsBox::dom_node()); }
     SVG::SVGTextPositioningElement const& dom_node() const { return static_cast<SVG::SVGTextPositioningElement const&>(SVGGraphicsBox::dom_node()); }
 
-    Optional<Gfx::AffineTransform> layout_transform() const;
-
     virtual JS::GCPtr<Painting::Paintable> create_paintable() const override;
 
 private:

--- a/Userland/Libraries/LibWeb/Painting/SVGGeometryPaintable.h
+++ b/Userland/Libraries/LibWeb/Painting/SVGGeometryPaintable.h
@@ -15,41 +15,6 @@ class SVGGeometryPaintable final : public SVGGraphicsPaintable {
     JS_CELL(SVGGeometryPaintable, SVGGraphicsPaintable);
 
 public:
-    class PathData {
-    public:
-        PathData(Gfx::Path path, Gfx::AffineTransform svg_to_viewbox_transform, Gfx::AffineTransform svg_transform)
-            : m_computed_path(move(path))
-            , m_svg_to_viewbox_transform(svg_to_viewbox_transform)
-            , m_svg_transform(svg_transform)
-        {
-        }
-
-        Gfx::Path const& computed_path() const { return m_computed_path; }
-
-        Gfx::AffineTransform const& svg_to_viewbox_transform() const { return m_svg_to_viewbox_transform; }
-
-        Gfx::AffineTransform const& svg_transform() const { return m_svg_transform; }
-
-        Gfx::AffineTransform svg_to_css_pixels_transform(
-            Optional<Gfx::AffineTransform const&> additional_svg_transform = {}) const
-        {
-            return Gfx::AffineTransform {}.multiply(svg_to_viewbox_transform()).multiply(additional_svg_transform.value_or(Gfx::AffineTransform {})).multiply(svg_transform());
-        }
-
-        Gfx::AffineTransform svg_to_device_pixels_transform(
-            PaintContext const& context,
-            Gfx::AffineTransform const& additional_svg_transform) const
-        {
-            auto css_scale = context.device_pixels_per_css_pixel();
-            return Gfx::AffineTransform {}.scale({ css_scale, css_scale }).multiply(svg_to_css_pixels_transform(additional_svg_transform));
-        }
-
-    private:
-        Gfx::Path m_computed_path;
-        Gfx::AffineTransform m_svg_to_viewbox_transform;
-        Gfx::AffineTransform m_svg_transform;
-    };
-
     static JS::NonnullGCPtr<SVGGeometryPaintable> create(Layout::SVGGeometryBox const&);
 
     virtual Optional<HitTestResult> hit_test(CSSPixelPoint, HitTestType) const override;
@@ -58,17 +23,17 @@ public:
 
     Layout::SVGGeometryBox const& layout_box() const;
 
-    void set_path_data(PathData path_data)
+    void set_computed_path(Gfx::Path path)
     {
-        m_path_data = move(path_data);
+        m_computed_path = move(path);
     }
 
-    Optional<PathData> const& path_data() const { return m_path_data; }
+    Optional<Gfx::Path> const& computed_path() const { return m_computed_path; }
 
 protected:
     SVGGeometryPaintable(Layout::SVGGeometryBox const&);
 
-    Optional<PathData> m_path_data = {};
+    Optional<Gfx::Path> m_computed_path = {};
 };
 
 }

--- a/Userland/Libraries/LibWeb/Painting/SVGGeometryPaintable.h
+++ b/Userland/Libraries/LibWeb/Painting/SVGGeometryPaintable.h
@@ -15,6 +15,41 @@ class SVGGeometryPaintable final : public SVGGraphicsPaintable {
     JS_CELL(SVGGeometryPaintable, SVGGraphicsPaintable);
 
 public:
+    class PathData {
+    public:
+        PathData(Gfx::Path path, Gfx::AffineTransform svg_to_viewbox_transform, Gfx::AffineTransform svg_transform)
+            : m_computed_path(move(path))
+            , m_svg_to_viewbox_transform(svg_to_viewbox_transform)
+            , m_svg_transform(svg_transform)
+        {
+        }
+
+        Gfx::Path const& computed_path() const { return m_computed_path; }
+
+        Gfx::AffineTransform const& svg_to_viewbox_transform() const { return m_svg_to_viewbox_transform; }
+
+        Gfx::AffineTransform const& svg_transform() const { return m_svg_transform; }
+
+        Gfx::AffineTransform svg_to_css_pixels_transform(
+            Optional<Gfx::AffineTransform const&> additional_svg_transform = {}) const
+        {
+            return Gfx::AffineTransform {}.multiply(svg_to_viewbox_transform()).multiply(additional_svg_transform.value_or(Gfx::AffineTransform {})).multiply(svg_transform());
+        }
+
+        Gfx::AffineTransform svg_to_device_pixels_transform(
+            PaintContext const& context,
+            Gfx::AffineTransform const& additional_svg_transform) const
+        {
+            auto css_scale = context.device_pixels_per_css_pixel();
+            return Gfx::AffineTransform {}.scale({ css_scale, css_scale }).multiply(svg_to_css_pixels_transform(additional_svg_transform));
+        }
+
+    private:
+        Gfx::Path m_computed_path;
+        Gfx::AffineTransform m_svg_to_viewbox_transform;
+        Gfx::AffineTransform m_svg_transform;
+    };
+
     static JS::NonnullGCPtr<SVGGeometryPaintable> create(Layout::SVGGeometryBox const&);
 
     virtual Optional<HitTestResult> hit_test(CSSPixelPoint, HitTestType) const override;
@@ -23,8 +58,17 @@ public:
 
     Layout::SVGGeometryBox const& layout_box() const;
 
+    void set_path_data(PathData path_data)
+    {
+        m_path_data = move(path_data);
+    }
+
+    Optional<PathData> const& path_data() const { return m_path_data; }
+
 protected:
     SVGGeometryPaintable(Layout::SVGGeometryBox const&);
+
+    Optional<PathData> m_path_data = {};
 };
 
 }

--- a/Userland/Libraries/LibWeb/Painting/SVGGraphicsPaintable.h
+++ b/Userland/Libraries/LibWeb/Painting/SVGGraphicsPaintable.h
@@ -15,6 +15,36 @@ class SVGGraphicsPaintable : public SVGPaintable {
     JS_CELL(SVGGraphicsPaintable, SVGPaintable);
 
 public:
+    class ComputedTransforms {
+    public:
+        ComputedTransforms(Gfx::AffineTransform svg_to_viewbox_transform, Gfx::AffineTransform svg_transform)
+            : m_svg_to_viewbox_transform(svg_to_viewbox_transform)
+            , m_svg_transform(svg_transform)
+        {
+        }
+
+        ComputedTransforms() = default;
+
+        Gfx::AffineTransform const& svg_to_viewbox_transform() const { return m_svg_to_viewbox_transform; }
+        Gfx::AffineTransform const& svg_transform() const { return m_svg_transform; }
+
+        Gfx::AffineTransform svg_to_css_pixels_transform(
+            Optional<Gfx::AffineTransform const&> additional_svg_transform = {}) const
+        {
+            return Gfx::AffineTransform {}.multiply(svg_to_viewbox_transform()).multiply(additional_svg_transform.value_or(Gfx::AffineTransform {})).multiply(svg_transform());
+        }
+
+        Gfx::AffineTransform svg_to_device_pixels_transform(PaintContext const& context) const
+        {
+            auto css_scale = context.device_pixels_per_css_pixel();
+            return Gfx::AffineTransform {}.scale({ css_scale, css_scale }).multiply(svg_to_css_pixels_transform(context.svg_transform()));
+        }
+
+    private:
+        Gfx::AffineTransform m_svg_to_viewbox_transform {};
+        Gfx::AffineTransform m_svg_transform {};
+    };
+
     static JS::NonnullGCPtr<SVGGraphicsPaintable> create(Layout::SVGGraphicsBox const&);
 
     Layout::SVGGraphicsBox const& layout_box() const;
@@ -25,8 +55,20 @@ public:
     virtual Optional<Gfx::Bitmap::MaskKind> get_mask_type() const override;
     virtual RefPtr<Gfx::Bitmap> calculate_mask(PaintContext&, CSSPixelRect const& masking_area) const override;
 
+    void set_computed_transforms(ComputedTransforms computed_transforms)
+    {
+        m_computed_transforms = computed_transforms;
+    }
+
+    ComputedTransforms const& computed_transforms() const
+    {
+        return m_computed_transforms;
+    }
+
 protected:
     SVGGraphicsPaintable(Layout::SVGGraphicsBox const&);
+
+    ComputedTransforms m_computed_transforms;
 };
 
 }

--- a/Userland/Libraries/LibWeb/Painting/SVGTextPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/SVGTextPaintable.cpp
@@ -19,13 +19,6 @@ SVGTextPaintable::SVGTextPaintable(Layout::SVGTextBox const& layout_box)
 {
 }
 
-Optional<HitTestResult> SVGTextPaintable::hit_test(CSSPixelPoint position, HitTestType type) const
-{
-    (void)position;
-    (void)type;
-    return {};
-}
-
 void SVGTextPaintable::paint(PaintContext& context, PaintPhase phase) const
 {
     if (!is_visible())
@@ -45,57 +38,13 @@ void SVGTextPaintable::paint(PaintContext& context, PaintPhase phase) const
         return;
 
     auto& painter = context.painter();
-
-    auto& text_element = layout_box().dom_node();
-    auto const* svg_element = text_element.shadow_including_first_ancestor_of_type<SVG::SVGSVGElement>();
-    auto svg_element_rect = svg_element->paintable_box()->absolute_rect();
-
-    RecordingPainterStateSaver save_painter { painter };
-    auto svg_context_offset = context.floored_device_point(svg_element_rect.location()).to_type<int>();
-    painter.translate(svg_context_offset);
-
     auto const& dom_node = layout_box().dom_node();
+    auto paint_transform = computed_transforms().svg_to_device_pixels_transform(context);
+    auto& scaled_font = layout_box().scaled_font(paint_transform.x_scale());
+    auto text_rect = context.enclosing_device_rect(absolute_rect()).to_type<int>();
+    auto text_contents = dom_node.text_contents();
 
-    auto child_text_content = dom_node.child_text_content();
-
-    auto maybe_transform = layout_box().layout_transform();
-    if (!maybe_transform.has_value())
-        return;
-
-    auto transform = Gfx::AffineTransform(context.svg_transform()).multiply(*maybe_transform);
-
-    // FIXME: Support arbitrary path transforms for fonts.
-    // FIMXE: This assumes transform->x_scale() == transform->y_scale().
-    auto& scaled_font = layout_node().scaled_font(static_cast<float>(context.device_pixels_per_css_pixel()) * transform.x_scale());
-
-    Utf8View text_content { child_text_content };
-    auto text_offset = context.floored_device_point(dom_node.get_offset().transformed(transform).to_type<CSSPixels>());
-
-    // FIXME: Once SVGFormattingContext does text layout this logic should move there.
-    // https://svgwg.org/svg2-draft/text.html#TextAnchoringProperties
-    switch (text_element.text_anchor().value_or(SVG::TextAnchor::Start)) {
-    case SVG::TextAnchor::Start:
-        // The rendered characters are aligned such that the start of the resulting rendered text is at the initial
-        // current text position.
-        break;
-    case SVG::TextAnchor::Middle: {
-        // The rendered characters are shifted such that the geometric middle of the resulting rendered text
-        // (determined from the initial and final current text position before applying the text-anchor property)
-        // is at the initial current text position.
-        text_offset.translate_by(-scaled_font.width(text_content) / 2, 0);
-        break;
-    }
-    case SVG::TextAnchor::End: {
-        // The rendered characters are shifted such that the end of the resulting rendered text (final current text
-        // position before applying the text-anchor property) is at the initial current text position.
-        text_offset.translate_by(-scaled_font.width(text_content), 0);
-        break;
-    }
-    default:
-        VERIFY_NOT_REACHED();
-    }
-
-    painter.draw_text_run(text_offset.to_type<int>(), text_content, scaled_font, layout_node().computed_values().fill()->as_color(), context.enclosing_device_rect(svg_element_rect).to_type<int>());
+    painter.draw_text_run(text_rect.bottom_left(), Utf8View { text_contents }, scaled_font, layout_node().computed_values().fill()->as_color(), text_rect);
 }
 
 }

--- a/Userland/Libraries/LibWeb/Painting/SVGTextPaintable.h
+++ b/Userland/Libraries/LibWeb/Painting/SVGTextPaintable.h
@@ -17,8 +17,6 @@ class SVGTextPaintable final : public SVGGraphicsPaintable {
 public:
     static JS::NonnullGCPtr<SVGTextPaintable> create(Layout::SVGTextBox const&);
 
-    virtual Optional<HitTestResult> hit_test(CSSPixelPoint, HitTestType) const override;
-
     virtual void paint(PaintContext&, PaintPhase) const override;
 
     Layout::SVGTextBox const& layout_box() const

--- a/Userland/Libraries/LibWeb/SVG/SVGTextContentElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGTextContentElement.cpp
@@ -45,10 +45,15 @@ Optional<TextAnchor> SVGTextContentElement::text_anchor() const
     }
 }
 
+DeprecatedString SVGTextContentElement::text_contents() const
+{
+    return child_text_content().trim_whitespace();
+}
+
 // https://svgwg.org/svg2-draft/text.html#__svg__SVGTextContentElement__getNumberOfChars
 WebIDL::ExceptionOr<int> SVGTextContentElement::get_number_of_chars() const
 {
-    auto chars = TRY_OR_THROW_OOM(vm(), utf8_to_utf16(child_text_content()));
+    auto chars = TRY_OR_THROW_OOM(vm(), utf8_to_utf16(text_contents()));
     return static_cast<int>(chars.size());
 }
 

--- a/Userland/Libraries/LibWeb/SVG/SVGTextContentElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGTextContentElement.h
@@ -21,6 +21,8 @@ public:
 
     Optional<TextAnchor> text_anchor() const;
 
+    DeprecatedString text_contents() const;
+
 protected:
     SVGTextContentElement(DOM::Document&, DOM::QualifiedName);
 


### PR DESCRIPTION
Previously, both SVG `<text>` and geometry elements were doing some awkward hacks to do (or re-do) layout work during painting. Geometry elements would re-compute the transform applied during layout in a hacky way, and `<text>` had no layout computed, which meant they were zero-sized, and could not correctly compute the `viewBox` transform. 

This PR moves all the SVG text layout and sizing logic into the `SVGFormattingContext`, and the SVG path and transform state into the `LayoutState` and `Paintables`. So now text scales with the `viewBox` correctly, and SVG geometry layout is a little simpler. 

This should also make implementing relative-sized geometry elements (e.g. `width="50%"`), and future work on masking simpler.

---

Progression on MDN SVG `<text>` example (with a `viewBox` that should scale to fit the window):

**Before:**
![image](https://github.com/SerenityOS/serenity/assets/11597044/ae5a50df-9124-423c-95a3-fb275f7aabc5)

**After:**
![image](https://github.com/SerenityOS/serenity/assets/11597044/2ddbb7ee-74bf-4e57-b9e8-10772ea5243a)
