### PR TITLE
CMake: Use a helper file to find GL and EGL in a platform agonstic way

### DIFF
--- a/Documentation/AdvancedBuildInstructions.md
+++ b/Documentation/AdvancedBuildInstructions.md
@@ -70,6 +70,7 @@ There are some optional features that can be enabled during compilation that are
 - `BUILD_EVERYTHING`: builds all optional components, overrides other `BUILD_<component>` flags when enabled
 - `SERENITY_CACHE_DIR`: sets the location of a shared cache of downloaded files. Should not need to be set unless managing a distribution package.
 - `ENABLE_NETWORK_DOWNLOADS`: allows downloading files from the internet during the build. Default on, turning off enables offline builds. For offline builds, the structure of the SERENITY_CACHE_DIR must be set up the way that the build expects.
+- `ENABLE_ACCELERATED_GRAPHICS`: builds features that use accelerated graphics APIs to speed up painting and drawing using native graphics libraries. 
 
 Many parts of the SerenityOS codebase have debug functionality, mostly consisting of additional messages printed to the debug console. This is done via the `<component_name>_DEBUG` macros, which can be enabled individually at build time. They are listed in [this file](../Meta/CMake/all_the_debug_macros.cmake).
 

--- a/Meta/CMake/accelerated_graphics.cmake
+++ b/Meta/CMake/accelerated_graphics.cmake
@@ -1,0 +1,14 @@
+if (NOT ENABLE_ACCELERATED_GRAPHICS OR EMSCRIPTEN)
+    # FIXME: Enable GL emulation in emscripten: https://emscripten.org/docs/porting/multimedia_and_graphics/OpenGL-support.html
+    set(HAS_ACCELERATED_GRAPHICS OFF CACHE BOOL "" FORCE)
+    return()
+endif()
+
+find_package(OpenGL COMPONENTS OpenGL EGL)
+
+if (OPENGL_FOUND)
+    set(HAS_ACCELERATED_GRAPHICS ON CACHE BOOL "" FORCE)
+    set(ACCEL_GFX_LIBS OpenGL::OpenGL OpenGL::EGL CACHE STRING "" FORCE)
+else()
+    set(HAS_ACCELERATED_GRAPHICS OFF CACHE BOOL "" FORCE)
+endif()

--- a/Meta/CMake/common_options.cmake
+++ b/Meta/CMake/common_options.cmake
@@ -21,6 +21,7 @@ serenity_option(ENABLE_PUBLIC_SUFFIX_DOWNLOAD ON CACHE BOOL "Enable download of 
 serenity_option(INCLUDE_WASM_SPEC_TESTS OFF CACHE BOOL "Download and include the WebAssembly spec testsuite")
 serenity_option(INCLUDE_FLAC_SPEC_TESTS OFF CACHE BOOL "Download and include the FLAC spec testsuite")
 serenity_option(ENABLE_CACERT_DOWNLOAD ON CACHE BOOL "Enable download of cacert.pem at build time")
+serenity_option(ENABLE_ACCELERATED_GRAPHICS ON CACHE BOOL "Enable use of accelerated graphics APIs")
 
 serenity_option(HACKSTUDIO_BUILD OFF CACHE BOOL "Automatically enabled when building from HackStudio")
 

--- a/Userland/Libraries/LibAccelGfx/CMakeLists.txt
+++ b/Userland/Libraries/LibAccelGfx/CMakeLists.txt
@@ -1,4 +1,6 @@
-if (LINUX)
+include(accelerated_graphics)
+
+if (HAS_ACCELERATED_GRAPHICS)
     set(SOURCES
         Canvas.cpp
         Context.cpp
@@ -6,5 +8,5 @@ if (LINUX)
     )
 
     serenity_lib(LibAccelGfx accelgfx)
-    target_link_libraries(LibAccelGfx PRIVATE LibGfx GL EGL)
+    target_link_libraries(LibAccelGfx PRIVATE LibGfx ${ACCEL_GFX_LIBS})
 endif()

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -1,4 +1,5 @@
 include(libweb_generators)
+include(accelerated_graphics)
 
 set(SOURCES
     ARIA/AriaData.cpp
@@ -626,10 +627,6 @@ set(SOURCES
     XML/XMLDocumentBuilder.cpp
 )
 
-if (LINUX)
-    list(APPEND SOURCES Painting/PaintingCommandExecutorGPU.cpp)
-endif()
-
 invoke_generator(
         "AriaRoles.cpp"
         Lagom::GenerateAriaRoles
@@ -663,7 +660,8 @@ serenity_lib(LibWeb web)
 target_link_libraries(LibWeb PRIVATE LibCore LibCrypto LibJS LibMarkdown LibHTTP LibGemini LibGL LibGUI LibGfx LibIPC LibLocale LibRegex LibSoftGPU LibSyntax LibTextCodec LibUnicode LibAudio LibVideo LibWasm LibXML LibIDL)
 link_with_locale_data(LibWeb)
 
-if (LINUX)
+if (HAS_ACCELERATED_GRAPHICS)
+    target_sources(LibWeb PRIVATE Painting/PaintingCommandExecutorGPU.cpp)
     target_link_libraries(LibWeb PRIVATE LibAccelGfx)
 endif()
 


### PR DESCRIPTION
Also add a flag to turn off accelerated graphics entirely.

This uses <https://cmake.org/cmake/help/latest/module/FindOpenGL.html>