### PR TITLE
LibJS: Add an inline JIT fast path when `ToNumeric` has nothing to do

### DIFF
--- a/Userland/Libraries/LibJS/JIT/Compiler.h
+++ b/Userland/Libraries/LibJS/JIT/Compiler.h
@@ -152,6 +152,8 @@ private:
 
     void native_call(void* function_address, Vector<Assembler::Operand> const& stack_arguments = {});
 
+    void jump_if_int32(Assembler::Reg, Assembler::Label&);
+
     template<typename Codegen>
     void branch_if_int32(Assembler::Reg, Codegen);
 


### PR DESCRIPTION
In most cases, this op will do nothing, as it is running on an the accumulator while it already contains a number. Let's avoid doing that native call.