### PR TITLE
LibJS/JIT: Compile 11 more bytecode instructions

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -241,6 +241,10 @@ public:
         return round_up_to_power_of_two(alignof(void*), sizeof(*this) + sizeof(Register) * excluded_names_count);
     }
 
+    Register from_object() const { return m_from_object; }
+    size_t excluded_names_count() const { return m_excluded_names_count; }
+    Register const* excluded_names() const { return m_excluded_names; }
+
 private:
     Register m_from_object;
     size_t m_excluded_names_count { 0 };

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -1349,6 +1349,8 @@ public:
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     DeprecatedString to_deprecated_string_impl(Bytecode::Executable const&) const;
 
+    IdentifierTableIndex property() const { return m_property; }
+
 private:
     IdentifierTableIndex m_property;
 };

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -338,6 +338,9 @@ public:
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     DeprecatedString to_deprecated_string_impl(Bytecode::Executable const&) const;
 
+    Register specifier() const { return m_specifier; }
+    Register options() const { return m_options; }
+
 private:
     Register m_specifier;
     Register m_options;

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -1411,6 +1411,9 @@ public:
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     DeprecatedString to_deprecated_string_impl(Bytecode::Executable const&) const;
 
+    Completion::Type completion_type() const { return m_completion_type; }
+    Optional<Value> const& completion_value() const { return m_completion_value; }
+
 private:
     Completion::Type m_completion_type { Completion::Type::Normal };
     Optional<Value> m_completion_value;

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -645,6 +645,8 @@ public:
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     DeprecatedString to_deprecated_string_impl(Bytecode::Executable const&) const;
 
+    IdentifierTableIndex property() const { return m_property; }
+
 private:
     IdentifierTableIndex m_property;
 };

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -844,6 +844,11 @@ public:
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     DeprecatedString to_deprecated_string_impl(Bytecode::Executable const&) const;
 
+    Register base() const { return m_base; }
+    Register property() const { return m_property; }
+    Register this_value() const { return m_this_value; }
+    PropertyKind kind() const { return m_kind; }
+
 private:
     Register m_base;
     Register m_property;

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -212,6 +212,8 @@ private:
         ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;            \
         DeprecatedString to_deprecated_string_impl(Bytecode::Executable const&) const; \
                                                                                        \
+        StringTableIndex error_string() const { return m_error_string; }               \
+                                                                                       \
     private:                                                                           \
         StringTableIndex m_error_string;                                               \
     };

--- a/Userland/Libraries/LibJS/JIT/Compiler.cpp
+++ b/Userland/Libraries/LibJS/JIT/Compiler.cpp
@@ -1568,6 +1568,23 @@ void Compiler::compile_delete_variable(Bytecode::Op::DeleteVariable const& op)
     check_exception();
 }
 
+static Value cxx_get_method(VM& vm, Value value, DeprecatedFlyString const& identifier)
+{
+    auto method = TRY_OR_SET_EXCEPTION(value.get_method(vm, identifier));
+    return method ?: js_undefined();
+}
+
+void Compiler::compile_get_method(Bytecode::Op::GetMethod const& op)
+{
+    load_vm_register(ARG1, Bytecode::Register::accumulator());
+    m_assembler.mov(
+        Assembler::Operand::Register(ARG2),
+        Assembler::Operand::Imm(bit_cast<u64>(&m_bytecode_executable.get_identifier(op.property()))));
+    native_call((void*)cxx_get_method);
+    store_vm_register(Bytecode::Register::accumulator(), RET);
+    check_exception();
+}
+
 void Compiler::jump_to_exit()
 {
     m_assembler.jump(m_exit_label);

--- a/Userland/Libraries/LibJS/JIT/Compiler.cpp
+++ b/Userland/Libraries/LibJS/JIT/Compiler.cpp
@@ -1527,6 +1527,20 @@ void Compiler::compile_put_private_by_id(Bytecode::Op::PutPrivateById const& op)
     check_exception();
 }
 
+static Value cxx_import_call(VM& vm, Value specifier, Value options)
+{
+    return TRY_OR_SET_EXCEPTION(perform_import_call(vm, specifier, options));
+}
+
+void Compiler::compile_import_call(Bytecode::Op::ImportCall const& op)
+{
+    load_vm_register(ARG1, op.specifier());
+    load_vm_register(ARG2, op.options());
+    native_call((void*)cxx_import_call);
+    store_vm_register(Bytecode::Register::accumulator(), RET);
+    check_exception();
+}
+
 void Compiler::jump_to_exit()
 {
     m_assembler.jump(m_exit_label);

--- a/Userland/Libraries/LibJS/JIT/Compiler.cpp
+++ b/Userland/Libraries/LibJS/JIT/Compiler.cpp
@@ -1585,6 +1585,17 @@ void Compiler::compile_get_method(Bytecode::Op::GetMethod const& op)
     check_exception();
 }
 
+static Value cxx_get_new_target(VM& vm)
+{
+    return vm.get_new_target();
+}
+
+void Compiler::compile_get_new_target(Bytecode::Op::GetNewTarget const&)
+{
+    native_call((void*)cxx_get_new_target);
+    store_vm_register(Bytecode::Register::accumulator(), RET);
+}
+
 void Compiler::jump_to_exit()
 {
     m_assembler.jump(m_exit_label);

--- a/Userland/Libraries/LibJS/JIT/Compiler.cpp
+++ b/Userland/Libraries/LibJS/JIT/Compiler.cpp
@@ -212,6 +212,23 @@ void Compiler::compile_jump_nullish(Bytecode::Op::JumpNullish const& op)
     m_assembler.jump(label_for(op.false_target()->block()));
 }
 
+void Compiler::compile_jump_undefined(Bytecode::Op::JumpUndefined const& op)
+{
+    load_vm_register(GPR0, Bytecode::Register::accumulator());
+
+    m_assembler.shift_right(
+        Assembler::Operand::Register(GPR0),
+        Assembler::Operand::Imm(48));
+
+    m_assembler.jump_if(
+        Assembler::Operand::Register(GPR0),
+        Assembler::Condition::EqualTo,
+        Assembler::Operand::Imm(UNDEFINED_TAG),
+        label_for(op.true_target()->block()));
+
+    m_assembler.jump(label_for(op.false_target()->block()));
+}
+
 [[maybe_unused]] static Value cxx_increment(VM& vm, Value value)
 {
     auto old_value = TRY_OR_SET_EXCEPTION(value.to_numeric(vm));

--- a/Userland/Libraries/LibJS/JIT/Compiler.cpp
+++ b/Userland/Libraries/LibJS/JIT/Compiler.cpp
@@ -1541,6 +1541,17 @@ void Compiler::compile_import_call(Bytecode::Op::ImportCall const& op)
     check_exception();
 }
 
+static Value cxx_get_import_meta(VM& vm)
+{
+    return vm.get_import_meta();
+}
+
+void Compiler::compile_get_import_meta(Bytecode::Op::GetImportMeta const&)
+{
+    native_call((void*)cxx_get_import_meta);
+    store_vm_register(Bytecode::Register::accumulator(), RET);
+}
+
 void Compiler::jump_to_exit()
 {
     m_assembler.jump(m_exit_label);

--- a/Userland/Libraries/LibJS/JIT/Compiler.h
+++ b/Userland/Libraries/LibJS/JIT/Compiler.h
@@ -139,7 +139,8 @@ private:
         O(GetNewTarget, get_new_target)                                          \
         O(HasPrivateId, has_private_id)                                          \
         O(PutByValueWithThis, put_by_value_with_this)                            \
-        O(CopyObjectExcludingProperties, copy_object_excluding_properties)
+        O(CopyObjectExcludingProperties, copy_object_excluding_properties)       \
+        O(AsyncIteratorClose, async_iterator_close)
 
 #    define DECLARE_COMPILE_OP(OpTitleCase, op_snake_case, ...) \
         void compile_##op_snake_case(Bytecode::Op::OpTitleCase const&);

--- a/Userland/Libraries/LibJS/JIT/Compiler.h
+++ b/Userland/Libraries/LibJS/JIT/Compiler.h
@@ -130,7 +130,8 @@ private:
         O(ImportCall, import_call)                                               \
         O(GetImportMeta, get_import_meta)                                        \
         O(DeleteVariable, delete_variable)                                       \
-        O(GetMethod, get_method)
+        O(GetMethod, get_method)                                                 \
+        O(GetNewTarget, get_new_target)
 
 #    define DECLARE_COMPILE_OP(OpTitleCase, op_snake_case) \
         void compile_##op_snake_case(Bytecode::Op::OpTitleCase const&);

--- a/Userland/Libraries/LibJS/JIT/Compiler.h
+++ b/Userland/Libraries/LibJS/JIT/Compiler.h
@@ -137,7 +137,8 @@ private:
         O(DeleteVariable, delete_variable)                                       \
         O(GetMethod, get_method)                                                 \
         O(GetNewTarget, get_new_target)                                          \
-        O(HasPrivateId, has_private_id)
+        O(HasPrivateId, has_private_id)                                          \
+        O(PutByValueWithThis, put_by_value_with_this)
 
 #    define DECLARE_COMPILE_OP(OpTitleCase, op_snake_case, ...) \
         void compile_##op_snake_case(Bytecode::Op::OpTitleCase const&);

--- a/Userland/Libraries/LibJS/JIT/Compiler.h
+++ b/Userland/Libraries/LibJS/JIT/Compiler.h
@@ -74,6 +74,7 @@ private:
         O(Jump, jump)                                                            \
         O(JumpConditional, jump_conditional)                                     \
         O(JumpNullish, jump_nullish)                                             \
+        O(JumpUndefined, jump_undefined)                                         \
         O(Increment, increment)                                                  \
         O(Decrement, decrement)                                                  \
         O(EnterUnwindContext, enter_unwind_context)                              \

--- a/Userland/Libraries/LibJS/JIT/Compiler.h
+++ b/Userland/Libraries/LibJS/JIT/Compiler.h
@@ -126,7 +126,8 @@ private:
         O(GetByValueWithThis, get_by_value_with_this)                            \
         O(DeleteByIdWithThis, delete_by_id_with_this)                            \
         O(PutByIdWithThis, put_by_id_with_this)                                  \
-        O(PutPrivateById, put_private_by_id)
+        O(PutPrivateById, put_private_by_id)                                     \
+        O(ImportCall, import_call)
 
 #    define DECLARE_COMPILE_OP(OpTitleCase, op_snake_case) \
         void compile_##op_snake_case(Bytecode::Op::OpTitleCase const&);

--- a/Userland/Libraries/LibJS/JIT/Compiler.h
+++ b/Userland/Libraries/LibJS/JIT/Compiler.h
@@ -128,7 +128,8 @@ private:
         O(PutByIdWithThis, put_by_id_with_this)                                  \
         O(PutPrivateById, put_private_by_id)                                     \
         O(ImportCall, import_call)                                               \
-        O(GetImportMeta, get_import_meta)
+        O(GetImportMeta, get_import_meta)                                        \
+        O(DeleteVariable, delete_variable)
 
 #    define DECLARE_COMPILE_OP(OpTitleCase, op_snake_case) \
         void compile_##op_snake_case(Bytecode::Op::OpTitleCase const&);

--- a/Userland/Libraries/LibJS/JIT/Compiler.h
+++ b/Userland/Libraries/LibJS/JIT/Compiler.h
@@ -62,9 +62,13 @@ private:
         O(RightShift, right_shift)                              \
         O(UnsignedRightShift, unsigned_right_shift)
 
+#    define JS_ENUMERATE_NEW_BUILTIN_ERROR_BYTECODE_OPS(O) \
+        O(NewTypeError, new_type_error, TypeError)
+
 #    define JS_ENUMERATE_IMPLEMENTED_JIT_OPS(O)                                  \
         JS_ENUMERATE_COMMON_BINARY_OPS(O)                                        \
         JS_ENUMERATE_COMMON_UNARY_OPS(O)                                         \
+        JS_ENUMERATE_NEW_BUILTIN_ERROR_BYTECODE_OPS(O)                           \
         O(LoadImmediate, load_immediate)                                         \
         O(Load, load)                                                            \
         O(Store, store)                                                          \
@@ -135,7 +139,7 @@ private:
         O(GetNewTarget, get_new_target)                                          \
         O(HasPrivateId, has_private_id)
 
-#    define DECLARE_COMPILE_OP(OpTitleCase, op_snake_case) \
+#    define DECLARE_COMPILE_OP(OpTitleCase, op_snake_case, ...) \
         void compile_##op_snake_case(Bytecode::Op::OpTitleCase const&);
 
     JS_ENUMERATE_IMPLEMENTED_JIT_OPS(DECLARE_COMPILE_OP)

--- a/Userland/Libraries/LibJS/JIT/Compiler.h
+++ b/Userland/Libraries/LibJS/JIT/Compiler.h
@@ -138,7 +138,8 @@ private:
         O(GetMethod, get_method)                                                 \
         O(GetNewTarget, get_new_target)                                          \
         O(HasPrivateId, has_private_id)                                          \
-        O(PutByValueWithThis, put_by_value_with_this)
+        O(PutByValueWithThis, put_by_value_with_this)                            \
+        O(CopyObjectExcludingProperties, copy_object_excluding_properties)
 
 #    define DECLARE_COMPILE_OP(OpTitleCase, op_snake_case, ...) \
         void compile_##op_snake_case(Bytecode::Op::OpTitleCase const&);

--- a/Userland/Libraries/LibJS/JIT/Compiler.h
+++ b/Userland/Libraries/LibJS/JIT/Compiler.h
@@ -129,7 +129,8 @@ private:
         O(PutPrivateById, put_private_by_id)                                     \
         O(ImportCall, import_call)                                               \
         O(GetImportMeta, get_import_meta)                                        \
-        O(DeleteVariable, delete_variable)
+        O(DeleteVariable, delete_variable)                                       \
+        O(GetMethod, get_method)
 
 #    define DECLARE_COMPILE_OP(OpTitleCase, op_snake_case) \
         void compile_##op_snake_case(Bytecode::Op::OpTitleCase const&);

--- a/Userland/Libraries/LibJS/JIT/Compiler.h
+++ b/Userland/Libraries/LibJS/JIT/Compiler.h
@@ -131,7 +131,8 @@ private:
         O(GetImportMeta, get_import_meta)                                        \
         O(DeleteVariable, delete_variable)                                       \
         O(GetMethod, get_method)                                                 \
-        O(GetNewTarget, get_new_target)
+        O(GetNewTarget, get_new_target)                                          \
+        O(HasPrivateId, has_private_id)
 
 #    define DECLARE_COMPILE_OP(OpTitleCase, op_snake_case) \
         void compile_##op_snake_case(Bytecode::Op::OpTitleCase const&);

--- a/Userland/Libraries/LibJS/JIT/Compiler.h
+++ b/Userland/Libraries/LibJS/JIT/Compiler.h
@@ -127,7 +127,8 @@ private:
         O(DeleteByIdWithThis, delete_by_id_with_this)                            \
         O(PutByIdWithThis, put_by_id_with_this)                                  \
         O(PutPrivateById, put_private_by_id)                                     \
-        O(ImportCall, import_call)
+        O(ImportCall, import_call)                                               \
+        O(GetImportMeta, get_import_meta)
 
 #    define DECLARE_COMPILE_OP(OpTitleCase, op_snake_case) \
         void compile_##op_snake_case(Bytecode::Op::OpTitleCase const&);


### PR DESCRIPTION
There are 5 instructions remaining:
- PushDeclarativeEnvironment: Never generated. Should this be deleted?
- Await & Yield: I'll leave those to someone more familiar with how the continuations work.
- EnterObjectEnvironment: I have an implementation, but it fails one test in test-js (with-basic/restores lexical environment even when exception is thrown)
- ScheduleJump: Somewhat complicated control flow, possibly affected by #21506 / #21653

I couldn't really test `GetMethod` and `AsyncIteratorClose`, since those rely on `Yield` being compilable.