### PR TITLE
LibJS/JIT: Fix most test262 regressions

### DIFF
--- a/Userland/Libraries/LibJS/JIT/Compiler.cpp
+++ b/Userland/Libraries/LibJS/JIT/Compiler.cpp
@@ -398,6 +398,7 @@ void Compiler::check_exception()
         m_assembler.jump(label_for(*handler));
         no_exception.link(m_assembler);
     } else if (auto const* finalizer = current_block().finalizer(); finalizer) {
+        store_vm_register(Bytecode::Register::exception(), GPR1);
         m_assembler.jump_if(Assembler::Operand::Register(GPR0),
             Assembler::Condition::NotEqualTo,
             Assembler::Operand::Register(GPR1),

--- a/Userland/Libraries/LibJS/JIT/Compiler.cpp
+++ b/Userland/Libraries/LibJS/JIT/Compiler.cpp
@@ -1091,8 +1091,7 @@ void Compiler::compile_block_declaration_instantiation(Bytecode::Op::BlockDeclar
 
 static Value cxx_super_call_with_argument_array(VM& vm, Value argument_array, bool is_synthetic)
 {
-    TRY_OR_SET_EXCEPTION(Bytecode::super_call_with_argument_array(vm, argument_array, is_synthetic));
-    return {};
+    return TRY_OR_SET_EXCEPTION(Bytecode::super_call_with_argument_array(vm, argument_array, is_synthetic));
 }
 
 void Compiler::compile_super_call_with_argument_array(Bytecode::Op::SuperCallWithArgumentArray const& op)

--- a/Userland/Libraries/LibJS/JIT/Compiler.cpp
+++ b/Userland/Libraries/LibJS/JIT/Compiler.cpp
@@ -1042,12 +1042,12 @@ void Compiler::compile_continue_pending_unwind(Bytecode::Op::ContinuePendingUnwi
     // re-throw the exception if we reached the end of the finally block and there was no catch block to handle it
     check_exception();
 
-    // if (!saved_return_value.is_empty()) goto resume_block;
+    // if (saved_return_value.is_empty()) goto resume_block;
     load_vm_register(GPR0, Bytecode::Register::saved_return_value());
     m_assembler.mov(Assembler::Operand::Register(GPR1), Assembler::Operand::Imm(Value().encoded()));
     m_assembler.jump_if(
         Assembler::Operand::Register(GPR0),
-        Assembler::Condition::NotEqualTo,
+        Assembler::Condition::EqualTo,
         Assembler::Operand::Register(GPR1),
         label_for(op.resume_target().block()));
 


### PR DESCRIPTION
The remaining difference compared to the Bytecode interpreter:
```
Summary:
    Diff Tests:
         -2 ✅   +2 ❌   

Diff Tests:
    test/language/statements/try/S12.14_A13_T3.js                       ✅ -> ❌
    test/language/statements/try/completion-values-fn-finally-normal.js ✅ -> ❌
```