### PR TITLE
LibWeb: Implement loading a favicon in absence of a <link> icon element

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -1887,6 +1887,8 @@ void Document::update_readiness(HTML::DocumentReadyState readiness_value)
     dispatch_event(Event::create(realm(), HTML::EventNames::readystatechange));
 
     if (readiness_value == HTML::DocumentReadyState::Complete && is_active() && navigable()->is_traversable()) {
+        HTML::HTMLLinkElement::load_fallback_favicon_if_needed(*this).release_value_but_fixme_should_propagate_errors();
+
         if (auto* page = navigable()->traversable_navigable()->page()) {
             page->client().page_did_finish_loading(url());
         }

--- a/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
@@ -462,7 +462,7 @@ bool HTMLLinkElement::load_favicon_and_use_if_window_is_active()
         navigable()->traversable_navigable()->page()->client().page_did_change_favicon(*favicon_bitmap);
     }
 
-    return false;
+    return true;
 }
 
 void HTMLLinkElement::visit_edges(Cell::Visitor& visitor)

--- a/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.h
@@ -35,6 +35,8 @@ public:
     bool has_loaded_icon() const;
     bool load_favicon_and_use_if_window_is_active();
 
+    static WebIDL::ExceptionOr<void> load_fallback_favicon_if_needed(JS::NonnullGCPtr<DOM::Document>);
+
 private:
     HTMLLinkElement(DOM::Document&, DOM::QualifiedName);
 


### PR DESCRIPTION
Noticed we were no longer getting the favicon for display on serenityos.org :^(

Before:
<img width="882" alt="Screenshot 2023-10-30 at 10 51 36 AM" src="https://github.com/SerenityOS/serenity/assets/5600524/cad0b7bf-6c91-4ac0-b056-601d25ee74d1">

After:
<img width="961" alt="Screenshot 2023-10-30 at 10 52 20 AM" src="https://github.com/SerenityOS/serenity/assets/5600524/93bc2bbc-8a37-40ab-b087-47cba7be690c">

