### PR TITLE
AK: Make AK::Format print floats in a roundtrip-safe way by default

### DIFF
--- a/AK/Format.h
+++ b/AK/Format.h
@@ -238,15 +238,16 @@ public:
         SignMode sign_mode = SignMode::OnlyIfNeeded,
         RealNumberDisplayMode = RealNumberDisplayMode::Default);
 
-    ErrorOr<void> put_f64(
-        double value,
+    template<OneOf<f32, f64> T>
+    ErrorOr<void> put_f32_or_f64(
+        T value,
         u8 base = 10,
         bool upper_case = false,
         bool zero_pad = false,
         bool use_separator = false,
         Align align = Align::Right,
         size_t min_width = 0,
-        size_t precision = 6,
+        Optional<size_t> precision = {},
         char fill = ' ',
         SignMode sign_mode = SignMode::OnlyIfNeeded,
         RealNumberDisplayMode = RealNumberDisplayMode::Default);
@@ -265,6 +266,21 @@ public:
 
 private:
     StringBuilder& m_builder;
+
+#ifndef KERNEL
+    ErrorOr<void> put_f64_with_precision(
+        double value,
+        u8 base,
+        bool upper_case,
+        bool zero_pad,
+        bool use_separator,
+        Align align,
+        size_t min_width,
+        size_t precision,
+        char fill,
+        SignMode sign_mode,
+        RealNumberDisplayMode);
+#endif
 };
 
 class TypeErasedFormatParams {

--- a/Tests/AK/TestFormat.cpp
+++ b/Tests/AK/TestFormat.cpp
@@ -283,6 +283,28 @@ TEST_CASE(floating_point_numbers)
     EXPECT_EQ(DeprecatedString::formatted("{:x>5.1}", 1.12), "xx1.1");
 }
 
+TEST_CASE(floating_point_default_precision)
+{
+#define EXPECT_FORMAT(lit, value) \
+    EXPECT_EQ(DeprecatedString::formatted("{}", lit), value##sv)
+
+    EXPECT_FORMAT(10.3f, "10.3");
+    EXPECT_FORMAT(123e4f, "1230000");
+    EXPECT_FORMAT(1.23e4f, "12300");
+    EXPECT_FORMAT(134232544.4365f, "134232540");
+    EXPECT_FORMAT(1.43e24, "1.43e+24");
+    EXPECT_FORMAT(1.43e-24, "1.43e-24");
+    EXPECT_FORMAT(0.0f, "0");
+    EXPECT_FORMAT(3.14159265358979, "3.14159265358979");
+    EXPECT_FORMAT(1.61803399, "1.61803399");
+    EXPECT_FORMAT(2.71827, "2.71827");
+    EXPECT_FORMAT(42.f, "42");
+    EXPECT_FORMAT(123456.78, "123456.78");
+    EXPECT_FORMAT(23456.78910, "23456.7891");
+
+#undef EXPECT_FORMAT
+}
+
 TEST_CASE(no_precision_no_trailing_number)
 {
     EXPECT_EQ(DeprecatedString::formatted("{:.0}", 0.1), "0");

--- a/Userland/Libraries/LibPDF/Document.h
+++ b/Userland/Libraries/LibPDF/Document.h
@@ -232,7 +232,7 @@ struct Formatter<PDF::Destination> : Formatter<FormatString> {
             TRY(builder.put_literal(" parameters="sv));
             for (auto const& param : destination.parameters) {
                 if (param.has_value())
-                    TRY(builder.put_f64(double(param.value())));
+                    TRY(builder.put_f32_or_f64(param.value()));
                 else
                     TRY(builder.put_literal("{{}}"sv));
                 TRY(builder.put_literal(" "sv));


### PR DESCRIPTION
Previously we assumed a default precision of 6, which made the printed values quite odd in some cases.
This commit changes that default to print them with just enough precision to produce the exact same float when roundtripped.

Samples (printed as `{:'28}`):
```
[src             ] old                          // new                         
[10.3f           ] 10.3                         // 10.3                        
[123e4f          ] 1,230,000                    // 1,230,000                   
[1.23e4f         ] 12,300                       // 12,300                      
[134232544.4365f ] 134,232,544                  // 134,232,540                 
[1.43e24         ] 9,223,372,036,854,775,808.000001 // 1.43e+24                    
[1.43e-24        ] 0                            // 1.43e-24                    
[0.0             ] 0                            // 0                           
[3.14159265358979] 3.141593                     // 3.14159265358979            
[1.61803399      ] 1.618034                     // 1.61803399                  
[2.71827         ] 2.71827                      // 2.71827                     
[42.f            ] 42                           // 42                          
[123456.78       ] 123,456.780000               // 123,456.78                  
[23456.78910     ] 23,456.7891                  // 23,456.7891                 
[-5.0            ] -5                           // -5
```