### PR TITLE
AK+LibCore: Stop using `DeprecatedString::characters()`

### DIFF
--- a/AK/Demangle.h
+++ b/AK/Demangle.h
@@ -17,7 +17,7 @@ namespace AK {
 inline DeprecatedString demangle(StringView name)
 {
     int status = 0;
-    auto* demangled_name = abi::__cxa_demangle(name.to_deprecated_string().characters(), nullptr, nullptr, &status);
+    auto* demangled_name = abi::__cxa_demangle(name.to_deprecated_string().characters_for_external_api(), nullptr, nullptr, &status);
     auto string = DeprecatedString(status == 0 ? StringView { demangled_name, strlen(demangled_name) } : name);
     if (status == 0)
         free(demangled_name);

--- a/AK/DeprecatedFlyString.h
+++ b/AK/DeprecatedFlyString.h
@@ -62,6 +62,7 @@ public:
 
     StringImpl const* impl() const { return m_impl; }
     char const* characters() const { return m_impl ? m_impl->characters() : nullptr; }
+    char const* characters_without_null_termination() const { return m_impl ? m_impl->characters() : nullptr; }
     size_t length() const { return m_impl ? m_impl->length() : 0; }
 
     ALWAYS_INLINE u32 hash() const { return m_impl ? m_impl->existing_hash() : 0; }

--- a/AK/DeprecatedString.cpp
+++ b/AK/DeprecatedString.cpp
@@ -50,7 +50,7 @@ bool DeprecatedString::copy_characters_to_buffer(char* buffer, size_t buffer_siz
     VERIFY(buffer_size > 0);
 
     size_t characters_to_copy = min(length(), buffer_size - 1);
-    __builtin_memcpy(buffer, characters(), characters_to_copy);
+    __builtin_memcpy(buffer, characters_without_null_termination(), characters_to_copy);
     buffer[characters_to_copy] = 0;
 
     return characters_to_copy == length();
@@ -72,26 +72,26 @@ DeprecatedString DeprecatedString::substring(size_t start, size_t length) const
         return DeprecatedString::empty();
     VERIFY(!Checked<size_t>::addition_would_overflow(start, length));
     VERIFY(start + length <= m_impl->length());
-    return { characters() + start, length };
+    return { characters_without_null_termination() + start, length };
 }
 
 DeprecatedString DeprecatedString::substring(size_t start) const
 {
     VERIFY(start <= length());
-    return { characters() + start, length() - start };
+    return { characters_without_null_termination() + start, length() - start };
 }
 
 StringView DeprecatedString::substring_view(size_t start, size_t length) const
 {
     VERIFY(!Checked<size_t>::addition_would_overflow(start, length));
     VERIFY(start + length <= m_impl->length());
-    return { characters() + start, length };
+    return { characters_without_null_termination() + start, length };
 }
 
 StringView DeprecatedString::substring_view(size_t start) const
 {
     VERIFY(start <= length());
-    return { characters() + start, length() - start };
+    return { characters_without_null_termination() + start, length() - start };
 }
 
 Vector<DeprecatedString> DeprecatedString::split(char separator, SplitBehavior split_behavior) const
@@ -108,8 +108,9 @@ Vector<DeprecatedString> DeprecatedString::split_limit(char separator, size_t li
     size_t substart = 0;
     bool keep_empty = has_flag(split_behavior, SplitBehavior::KeepEmpty);
     bool keep_separator = has_flag(split_behavior, SplitBehavior::KeepTrailingSeparator);
+    char const* characters = characters_without_null_termination();
     for (size_t i = 0; i < length() && (v.size() + 1) != limit; ++i) {
-        char ch = characters()[i];
+        char ch = characters[i];
         if (ch == separator) {
             size_t sublen = i - substart;
             if (sublen != 0 || keep_empty)
@@ -132,8 +133,9 @@ Vector<StringView> DeprecatedString::split_view(Function<bool(char)> separator, 
     size_t substart = 0;
     bool keep_empty = has_flag(split_behavior, SplitBehavior::KeepEmpty);
     bool keep_separator = has_flag(split_behavior, SplitBehavior::KeepTrailingSeparator);
+    char const* characters = characters_without_null_termination();
     for (size_t i = 0; i < length(); ++i) {
-        char ch = characters()[i];
+        char ch = characters[i];
         if (separator(ch)) {
             size_t sublen = i - substart;
             if (sublen != 0 || keep_empty)
@@ -203,7 +205,7 @@ bool DeprecatedString::starts_with(char ch) const
 {
     if (is_empty())
         return false;
-    return characters()[0] == ch;
+    return characters_without_null_termination()[0] == ch;
 }
 
 bool DeprecatedString::ends_with(StringView str, CaseSensitivity case_sensitivity) const
@@ -215,7 +217,7 @@ bool DeprecatedString::ends_with(char ch) const
 {
     if (is_empty())
         return false;
-    return characters()[length() - 1] == ch;
+    return characters_without_null_termination()[length() - 1] == ch;
 }
 
 DeprecatedString DeprecatedString::repeated(char ch, size_t count)
@@ -349,8 +351,9 @@ bool DeprecatedString::equals_ignoring_ascii_case(StringView other) const
 DeprecatedString DeprecatedString::reverse() const
 {
     StringBuilder reversed_string(length());
+    char const* characters = characters_without_null_termination();
     for (size_t i = length(); i-- > 0;) {
-        reversed_string.append(characters()[i]);
+        reversed_string.append(characters[i]);
     }
     return reversed_string.to_deprecated_string();
 }

--- a/AK/DeprecatedString.h
+++ b/AK/DeprecatedString.h
@@ -280,7 +280,7 @@ public:
 
     [[nodiscard]] StringView view() const
     {
-        return { characters(), length() };
+        return { characters_without_null_termination(), length() };
     }
 
     [[nodiscard]] DeprecatedString replace(StringView needle, StringView replacement, ReplaceMode replace_mode = ReplaceMode::All) const { return StringUtils::replace(*this, needle, replacement, replace_mode); }

--- a/AK/DeprecatedString.h
+++ b/AK/DeprecatedString.h
@@ -172,6 +172,8 @@ public:
     [[nodiscard]] ALWAYS_INLINE size_t length() const { return m_impl->length(); }
     // Includes NUL-terminator.
     [[nodiscard]] ALWAYS_INLINE char const* characters() const { return m_impl->characters(); }
+    [[nodiscard]] ALWAYS_INLINE char const* characters_for_external_api() const { return m_impl->characters(); }
+    [[nodiscard]] ALWAYS_INLINE char const* characters_without_null_termination() const { return m_impl->characters(); }
 
     [[nodiscard]] bool copy_characters_to_buffer(char* buffer, size_t buffer_size) const;
 

--- a/AK/StringView.cpp
+++ b/AK/StringView.cpp
@@ -35,13 +35,13 @@ StringView::StringView(FlyString const& string)
 }
 
 StringView::StringView(DeprecatedString const& string)
-    : m_characters(string.characters())
+    : m_characters(string.characters_without_null_termination())
     , m_length(string.length())
 {
 }
 
 StringView::StringView(DeprecatedFlyString const& string)
-    : m_characters(string.characters())
+    : m_characters(string.characters_without_null_termination())
     , m_length(string.length())
 {
 }

--- a/Userland/Libraries/LibCore/DirIterator.cpp
+++ b/Userland/Libraries/LibCore/DirIterator.cpp
@@ -15,7 +15,7 @@ DirIterator::DirIterator(DeprecatedString path, Flags flags)
     : m_path(move(path))
     , m_flags(flags)
 {
-    m_dir = opendir(m_path.characters());
+    m_dir = opendir(m_path.characters_for_external_api());
     if (!m_dir) {
         m_error = Error::from_errno(errno);
     }

--- a/Userland/Libraries/LibCore/FileWatcherLinux.cpp
+++ b/Userland/Libraries/LibCore/FileWatcherLinux.cpp
@@ -143,7 +143,7 @@ ErrorOr<bool> FileWatcherBase::add_watch(DeprecatedString path, FileWatcherEvent
     if (has_flag(event_mask, FileWatcherEvent::Type::MetadataModified))
         inotify_mask |= IN_ATTRIB;
 
-    int watch_descriptor = ::inotify_add_watch(m_watcher_fd, path.characters(), inotify_mask);
+    int watch_descriptor = ::inotify_add_watch(m_watcher_fd, path.characters_for_external_api(), inotify_mask);
     if (watch_descriptor < 0)
         return Error::from_errno(errno);
 

--- a/Userland/Libraries/LibCore/Group.cpp
+++ b/Userland/Libraries/LibCore/Group.cpp
@@ -78,7 +78,7 @@ ErrorOr<void> Group::add_group(Group& group)
         return Error::from_string_literal("Group name has invalid characters.");
 
     // Disallow names starting with '_', '-' or other non-alpha characters.
-    if (group.name().starts_with('_') || group.name().starts_with('-') || !is_ascii_alpha(group.name().characters()[0]))
+    if (group.name().starts_with('_') || group.name().starts_with('-') || !is_ascii_alpha(group.name().characters_without_null_termination()[0]))
         return Error::from_string_literal("Group name has invalid characters.");
 
     // Verify group name does not already exist
@@ -162,7 +162,7 @@ ErrorOr<bool> Group::id_exists(gid_t id)
 ErrorOr<struct group> Group::to_libc_group()
 {
     struct group gr;
-    gr.gr_name = const_cast<char*>(m_name.characters());
+    gr.gr_name = const_cast<char*>(m_name.characters_for_external_api());
     gr.gr_passwd = const_cast<char*>("x");
     gr.gr_gid = m_id;
     gr.gr_mem = nullptr;
@@ -175,7 +175,7 @@ ErrorOr<struct group> Group::to_libc_group()
     if (m_members.size() > 0) {
         TRY(members.try_ensure_capacity(m_members.size() + 1));
         for (auto member : m_members)
-            members.unchecked_append(const_cast<char*>(member.characters()));
+            members.unchecked_append(const_cast<char*>(member.characters_for_external_api()));
         members.unchecked_append(nullptr);
 
         gr.gr_mem = const_cast<char**>(members.data());

--- a/Userland/Libraries/LibCore/Process.cpp
+++ b/Userland/Libraries/LibCore/Process.cpp
@@ -43,7 +43,7 @@ struct ArgvList {
         : m_path { path }
     {
         m_argv.ensure_capacity(size + 2);
-        m_argv.append(m_path.characters());
+        m_argv.append(m_path.characters_for_external_api());
     }
 
     void append(char const* arg)
@@ -72,7 +72,7 @@ struct ArgvList {
             posix_spawn_file_actions_destroy(&spawn_actions);
         };
         if (!m_working_directory.is_empty())
-            posix_spawn_file_actions_addchdir(&spawn_actions, m_working_directory.characters());
+            posix_spawn_file_actions_addchdir(&spawn_actions, m_working_directory.characters_for_external_api());
 
         auto pid = TRY(System::posix_spawn(m_path.view(), &spawn_actions, nullptr, const_cast<char**>(get().data()), System::environment()));
         if (keep_as_child == Process::KeepAsChild::No)
@@ -90,7 +90,7 @@ ErrorOr<pid_t> Process::spawn(StringView path, ReadonlySpan<DeprecatedString> ar
 {
     ArgvList argv { path, arguments.size() };
     for (auto const& arg : arguments)
-        argv.append(arg.characters());
+        argv.append(arg.characters_for_external_api());
     argv.set_working_directory(working_directory);
     return argv.spawn(keep_as_child);
 }
@@ -102,7 +102,7 @@ ErrorOr<pid_t> Process::spawn(StringView path, ReadonlySpan<StringView> argument
     ArgvList argv { path, arguments.size() };
     for (auto const& arg : arguments) {
         backing_strings.append(arg);
-        argv.append(backing_strings.last().characters());
+        argv.append(backing_strings.last().characters_for_external_api());
     }
     argv.set_working_directory(working_directory);
     return argv.spawn(keep_as_child);

--- a/Userland/Libraries/LibCore/SOCKSProxyClient.cpp
+++ b/Userland/Libraries/LibCore/SOCKSProxyClient.cpp
@@ -166,7 +166,7 @@ ErrorOr<Reply> send_connect_request_message(Core::Socket& socket, Core::SOCKSPro
             address_data[0] = to_underlying(AddressType::DomainName);
             address_data[1] = hostname.length();
             TRY(stream.write_until_depleted({ address_data, sizeof(address_data) }));
-            TRY(stream.write_until_depleted({ hostname.characters(), hostname.length() }));
+            TRY(stream.write_until_depleted({ hostname.characters_without_null_termination(), hostname.length() }));
             return {};
         },
         [&](u32 ipv4) -> ErrorOr<void> {
@@ -223,12 +223,12 @@ ErrorOr<u8> send_username_password_authentication_message(Core::Socket& socket, 
     u8 username_length = auth_data.username.length();
     TRY(stream.write_value(username_length));
 
-    TRY(stream.write_until_depleted({ auth_data.username.characters(), auth_data.username.length() }));
+    TRY(stream.write_until_depleted({ auth_data.username.characters_without_null_termination(), auth_data.username.length() }));
 
     u8 password_length = auth_data.password.length();
     TRY(stream.write_value(password_length));
 
-    TRY(stream.write_until_depleted({ auth_data.password.characters(), auth_data.password.length() }));
+    TRY(stream.write_until_depleted({ auth_data.password.characters_without_null_termination(), auth_data.password.length() }));
 
     auto buffer = TRY(ByteBuffer::create_uninitialized(stream.used_buffer_size()));
     TRY(stream.read_until_filled(buffer.bytes()));

--- a/Userland/Libraries/LibCore/Socket.cpp
+++ b/Userland/Libraries/LibCore/Socket.cpp
@@ -66,7 +66,7 @@ ErrorOr<IPv4Address> Socket::resolve_host(DeprecatedString const& host, SocketTy
     hints.ai_flags = 0;
     hints.ai_protocol = 0;
 
-    auto const results = TRY(Core::System::getaddrinfo(host.characters(), nullptr, hints));
+    auto const results = TRY(Core::System::getaddrinfo(host.characters_for_external_api(), nullptr, hints));
 
     for (auto const& result : results.addresses()) {
         if (result.ai_family == AF_INET) {


### PR DESCRIPTION
There are two distinct cases when we use this function currently. The first one is when we don't actually care about zero termination and pass length with the string. The second is when we are about to call some external C API and do actually care. With this PR, I propose to use new `DeprecatedString::characters_without_null_termination` in the former case and continue to use `DeprecatedString::characters` in the later.

Why do I care? As you probably know, I want to unify `*String` classes memory layout and thus allow fast casts between them. This is impossible to do cleanly without either reintroducing zero-termination to `String` or making `DeprecatedString` zero-termination optional. I decided to take the second path.

Optional zero-termination means that `characters()` won't be a cheap method to call anymore. It will have to reallocate underlying buffer in case it is not zero-terminated already (and it won't be in most of the cases). Fortunately, we don't have to call `characters()` often. Due to Serenity's NIH, we only need zero-termination when we interact with GUI framework in Ladybird chrome or invoke syscall/LibC syscall wrapper in Lagom. Both of these operations are relatively rare, so I'm fine with String doing memory gymnastics in these cases.

On Serenity itself, we do not have external APIs at all, so we theoretically don't even need `DeprecatedString::characters()` and all the reallocation code. In practice however, we sometimes call LibC functions, which do not have equivalents with `StringView` arguments. So, wrapping `characters` in `#ifndef AK_OS_SERENITY` will require a substantial refactor of Serenity-specific code, which I am currently not ready to do.

I am ready, however, to check all the calling sites of `characters` and mark if they need zero termination or not.

------

In case what is written above makes sense, this is first in series of migration PRs. I decided to also add superfluous `characters_for_external_api` to make this refactoring easier. With it, I can easily add `[[deprecated]]` to `characters()` locally and fix compilation errors. Note that I haven't added similar `DeprecatedFlyString::characters_for_external_api`, since I believe it doesn't make sense to use FlyString to call APIs (if one absolutely have to, casting to `DeprecatedString` is a trivial workaround).

This PR removes all uses of `Deprecated{Fly,}String::characters()` in AK and LibCore except for `LibCore/System.cpp`, `LibCore/DateTime.cpp` and `LibCore/SystemServerTakeover.cpp`. Two latter are addressed in #21701. I decided to not touch `System.cpp` since it has a million calls to `characters`, which all should be replaced with `characters_for_external_api`, and I am not sure what maintainers think about this name.