### PR TITLE
LibTLS: Fix supported signature algorithms typo

### DIFF
--- a/Userland/Libraries/LibTLS/TLSv12.h
+++ b/Userland/Libraries/LibTLS/TLSv12.h
@@ -164,7 +164,7 @@ struct Options {
         { HashAlgorithm::SHA256, SignatureAlgorithm::RSA },
         { HashAlgorithm::SHA1, SignatureAlgorithm::RSA },
         { HashAlgorithm::SHA256, SignatureAlgorithm::ECDSA },
-        { HashAlgorithm::INTRINSIC, SignatureAlgorithm::ECDSA });
+        { HashAlgorithm::INTRINSIC, SignatureAlgorithm::ED25519 });
     OPTION_WITH_DEFAULTS(Vector<SupportedGroup>, elliptic_curves,
         SupportedGroup::X25519,
         SupportedGroup::SECP256R1,


### PR DESCRIPTION
The ED curve is INTRINSIC/ED25519, not INTRINSIC/ECDSA

See https://datatracker.ietf.org/doc/html/rfc8422#section-5.1.3 for more info.