### PR TITLE
AK: Use __has_include instead of an #ifdef platform chain in Assertions.cpp

### DIFF
--- a/AK/Assertions.cpp
+++ b/AK/Assertions.cpp
@@ -10,8 +10,12 @@
 #include <AK/StringBuilder.h>
 #include <AK/StringView.h>
 
-#if (defined(AK_OS_LINUX) && !defined(AK_OS_ANDROID)) || defined(AK_LIBC_GLIBC) || defined(AK_OS_BSD_GENERIC) || defined(AK_OS_SOLARIS) || defined(AK_OS_HAIKU)
+#if __has_include(<execinfo.h>) && __ANDROID_API__ >= 33
 #    define EXECINFO_BACKTRACE
+#endif
+
+#if defined(AK_OS_ANDROID) && __ANDROID_API__ >= 33
+#    undef EXECINFO_BACKTRACE
 #endif
 
 #if defined(AK_OS_ANDROID) && (__ANDROID_API__ >= 33)


### PR DESCRIPTION
Previously it checked for linux or glibc. But that is wrong for multiple reasons:
1) glibc can only exist on linux (AFAIK)
2) there are linux systems which don't use glibc
By removing the check for linux, this file should compile on any linux system. Tested on musl.

Also see #16463.