### PR TITLE
ClockSettings: Use a Vector as the time zone model's container type

### DIFF
--- a/Userland/Applications/ClockSettings/TimeZoneSettingsWidget.cpp
+++ b/Userland/Applications/ClockSettings/TimeZoneSettingsWidget.cpp
@@ -24,8 +24,6 @@
 #include <spawn.h>
 #include <unistd.h>
 
-using StringViewListModel = GUI::ItemListModel<StringView, ReadonlySpan<StringView>>;
-
 static constexpr auto PI_OVER_180 = M_PIf32 / 180.0f;
 static constexpr auto PI_OVER_4 = M_PIf32 / 4.0f;
 static constexpr auto TAU = M_PIf32 * 2.0f;
@@ -78,7 +76,7 @@ TimeZoneSettingsWidget::TimeZoneSettingsWidget()
 
     m_time_zone_combo_box = *find_descendant_of_type_named<GUI::ComboBox>("time_zone_input");
     m_time_zone_combo_box->set_only_allow_values_from_model(true);
-    m_time_zone_combo_box->set_model(*StringViewListModel::create(time_zones));
+    m_time_zone_combo_box->set_model(*GUI::ItemListModel<StringView>::create(time_zones));
     m_time_zone_combo_box->set_text(m_time_zone);
     m_time_zone_combo_box->on_change = [&](auto, auto) {
         set_modified(true);


### PR DESCRIPTION
The time zones were stored as a static Span until commit 0bc401a1d653f487738e05e8677dfe5167fc5a36, and are now stored in a Vector. By continuing to tell the ItemListModel that the container is a Span, we create a temporary Span in its constructor, which the model tries to hold a constant reference to. Use the default Vector container type now instead to prevent creating such temporaries.

Fixes #21710