### PR TITLE
LibWeb: Set table width to GRIDMAX if calculated value is max-content

### DIFF
--- a/Tests/LibWeb/Layout/expected/table/table-max-content-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/table-max-content-width.txt
@@ -1,0 +1,17 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x140 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x124 children: not-inline
+      TableWrapper <(anonymous)> at (8,8) content-size 126x124 [BFC] children: not-inline
+        Box <table.table> at (18,18) content-size 106x104 table-box [TFC] children: not-inline
+          Box <tbody> at (18,18) content-size 102x100 table-row-group children: not-inline
+            Box <tr> at (20,20) content-size 102x100 table-row children: not-inline
+              BlockContainer <td> at (21,70) content-size 100x0 table-cell [BFC] children: not-inline
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x140]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x124]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 126x124]
+        PaintableBox (Box<TABLE>.table) [8,8 126x124]
+          PaintableBox (Box<TBODY>) [18,18 102x100] overflow: [18,18 104x102]
+            PaintableBox (Box<TR>) [20,20 102x100]
+              PaintableWithLines (BlockContainer<TD>) [20,20 102x100]

--- a/Tests/LibWeb/Layout/input/table/table-max-content-width.html
+++ b/Tests/LibWeb/Layout/input/table/table-max-content-width.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html><style type="text/css">
+.table {
+    width: max-content;
+    background-color: magenta;
+    border: 10px solid gold;
+}
+</style><table class="table"><tr style="height: 100px"><td style="width: 100px"></td></tr></table>

--- a/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -503,6 +503,8 @@ void TableFormattingContext::compute_table_width()
                     used_width = max(used_width, adjusted_used_width);
             }
         }
+    } else if (computed_values.width().is_max_content()) {
+        used_width = grid_max;
     } else {
         // If the table-root’s width property has a computed value (resolving to
         // resolved-table-width) other than auto, the used width is the greater


### PR DESCRIPTION
If the width of the table container is specified as max-content, then it seems sensible to resolve it as the sum of the maximum widths of the columns.

Visual progression on GitHub profile page.

Before:
<img width="1417" alt="Screenshot 2023-10-31 at 17 48 35" src="https://github.com/SerenityOS/serenity/assets/45686940/2a98cbe5-6d1d-4a40-9f0f-65e7e362fe8a">

After:
<img width="1423" alt="Screenshot 2023-10-31 at 17 47 54" src="https://github.com/SerenityOS/serenity/assets/45686940/3856bce4-fd9d-4957-87f6-1c51953d0891">
