### PR TITLE
AK+LibJS: Remove error-prone JsonValue constructor

### DIFF
--- a/AK/JsonParser.cpp
+++ b/AK/JsonParser.cpp
@@ -304,7 +304,7 @@ ErrorOr<JsonValue> JsonParser::parse_null()
 {
     if (!consume_specific("null"))
         return Error::from_string_literal("JsonParser: Expected 'null'");
-    return JsonValue(JsonValue::Type::Null);
+    return JsonValue {};
 }
 
 ErrorOr<JsonValue> JsonParser::parse_helper()

--- a/AK/JsonValue.cpp
+++ b/AK/JsonValue.cpp
@@ -15,11 +15,6 @@
 
 namespace AK {
 
-JsonValue::JsonValue(Type type)
-    : m_type(type)
-{
-}
-
 JsonValue::JsonValue(JsonValue const& other)
 {
     copy_from(other);

--- a/AK/JsonValue.h
+++ b/AK/JsonValue.h
@@ -36,7 +36,6 @@ public:
     static ErrorOr<JsonValue> from_string(StringView);
 
     JsonValue() = default;
-    explicit JsonValue(Type);
     ~JsonValue() { clear(); }
 
     JsonValue(JsonValue const&);

--- a/Tests/LibJS/test262-runner.cpp
+++ b/Tests/LibJS/test262-runner.cpp
@@ -753,7 +753,7 @@ int main(int argc, char** argv)
                 if (!output.contains("Test262:AsyncTestComplete"sv) || output.contains("Test262:AsyncTestFailure"sv)) {
                     result_object.set("async_fail", true);
                     if (!first_output.has_value())
-                        result_object.set("output", JsonValue { AK::JsonValue::Type::Null });
+                        result_object.set("output", JsonValue {});
 
                     passed = false;
                 }
@@ -778,7 +778,7 @@ int main(int argc, char** argv)
                 if (!output.contains("Test262:AsyncTestComplete"sv) || output.contains("Test262:AsyncTestFailure"sv)) {
                     result_object.set("async_fail", true);
                     if (!first_output.has_value())
-                        result_object.set("output", JsonValue { AK::JsonValue::Type::Null });
+                        result_object.set("output", JsonValue {});
 
                     passed = false;
                 }


### PR DESCRIPTION
Consider the following:
```c++
JsonValue value { JsonValue::Type::Object };
value.as_object().set("foo"sv, "bar"sv);
```

The `JsonValue(Type)` constructor does not initialize the underlying union that stores its value. Thus `JsonValue::as_object()` will A) refer to an uninitialized union member, B) deference that member.

This constructor only has 2 users, both of which initialize the type to `Type::Null`. Rather than implementing unused functionality here, replace those uses with the default `JsonValue` constructor, and remove the faulty constructor.