### PR TITLE
AK: Ensure unions with bitfield structs actually have correct sizes

### DIFF
--- a/AK/FPControl.h
+++ b/AK/FPControl.h
@@ -13,7 +13,7 @@ VALIDATE_IS_X86();
 
 namespace AK {
 
-enum class RoundingMode : u8 {
+enum class RoundingMode : u16 {
     NEAREST = 0b00,
     DOWN = 0b01,
     UP = 0b10,


### PR DESCRIPTION
The fun pattern of `union { struct { u32 a : 1; u64 b : 7; }; u8 x; }` produces complete garbage on windows, this commit fixes the two instances of those that exist in AK.
This commit also makes sure that the generated unions have the correct size (whereas FloatExtractor<f32> previously did not!) by adding some nice static_asserts.