### PR TITLE
LibJIT+LibJS+Embedders: Lazily collect stack traces

### DIFF
--- a/Meta/Lagom/Wasm/js_repl.cpp
+++ b/Meta/Lagom/Wasm/js_repl.cpp
@@ -165,31 +165,7 @@ static ErrorOr<bool> parse_and_run(JS::Realm& realm, StringView source, StringVi
 
         if (!thrown_value.is_object() || !is<JS::Error>(thrown_value.as_object()))
             return;
-        auto& traceback = static_cast<JS::Error const&>(thrown_value.as_object()).traceback();
-        if (traceback.size() > 1) {
-            unsigned repetitions = 0;
-            for (size_t i = 0; i < traceback.size(); ++i) {
-                auto& traceback_frame = traceback[i];
-                if (i + 1 < traceback.size()) {
-                    auto& next_traceback_frame = traceback[i + 1];
-                    if (next_traceback_frame.function_name == traceback_frame.function_name) {
-                        repetitions++;
-                        continue;
-                    }
-                }
-                if (repetitions > 4) {
-                    // If more than 5 (1 + >4) consecutive function calls with the same name, print
-                    // the name only once and show the number of repetitions instead. This prevents
-                    // printing ridiculously large call stacks of recursive functions.
-                    displayln(" -> {}", traceback_frame.function_name);
-                    displayln(" {} more calls", repetitions);
-                } else {
-                    for (size_t j = 0; j < repetitions + 1; ++j)
-                        displayln(" -> {}", traceback_frame.function_name);
-                }
-                repetitions = 0;
-            }
-        }
+        displayln("{}", static_cast<JS::Error const&>(thrown_value.as_object()).stack_string(JS::CompactTraceback::Yes));
     };
 
     if (!result.is_error())

--- a/Meta/gn/secondary/Userland/Libraries/LibJS/BUILD.gn
+++ b/Meta/gn/secondary/Userland/Libraries/LibJS/BUILD.gn
@@ -6,6 +6,7 @@ shared_library("LibJS") {
     # FIXME: Why does LibSyntax need to depend on WindowServer headers?
     "//Userland",
   ]
+  cflags_cc = [ "-fno-omit-frame-pointer" ]
   deps = [
     "//AK",
     "//Userland/Libraries/LibCore",

--- a/Userland/Applications/Spreadsheet/Spreadsheet.cpp
+++ b/Userland/Applications/Spreadsheet/Spreadsheet.cpp
@@ -72,11 +72,7 @@ Sheet::Sheet(Workbook& workbook)
                 if (thrown_value.is_object() && is<JS::Error>(thrown_value.as_object())) {
                     auto& error = static_cast<JS::Error const&>(thrown_value.as_object());
                     warnln(" with message '{}'", error.get_without_side_effects(vm.names.message));
-                    for (auto& traceback_frame : error.traceback()) {
-                        auto& function_name = traceback_frame.function_name;
-                        auto& source_range = traceback_frame.source_range();
-                        dbgln("  {} at {}:{}:{}", function_name, source_range.filename(), source_range.start.line, source_range.start.column);
-                    }
+                    dbgln("{}", error.stack_string(JS::CompactTraceback::Yes));
                 } else {
                     warnln();
                 }

--- a/Userland/Libraries/LibJIT/Assembler.h
+++ b/Userland/Libraries/LibJIT/Assembler.h
@@ -522,18 +522,18 @@ struct Assembler {
 
     void enter()
     {
-        push_callee_saved_registers();
-
         push(Operand::Register(Reg::RBP));
         mov(Operand::Register(Reg::RBP), Operand::Register(Reg::RSP));
+
+        push_callee_saved_registers();
     }
 
     void exit()
     {
+        pop_callee_saved_registers();
+
         // leave
         emit8(0xc9);
-
-        pop_callee_saved_registers();
 
         // ret
         emit8(0xc3);

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -56,13 +56,6 @@ void Interpreter::visit_edges(Cell::Visitor& visitor)
     }
 }
 
-Optional<InstructionStreamIterator const&> Interpreter::instruction_stream_iterator() const
-{
-    if (m_current_executable && m_current_executable->native_executable())
-        return m_current_executable->native_executable()->instruction_stream_iterator(*m_current_executable);
-    return m_pc;
-}
-
 // 16.1.6 ScriptEvaluation ( scriptRecord ), https://tc39.es/ecma262/#sec-runtime-semantics-scriptevaluation
 ThrowCompletionOr<Value> Interpreter::run(Script& script_record, JS::GCPtr<Environment> lexical_environment_override)
 {
@@ -370,6 +363,8 @@ Interpreter::ValueAndFrame Interpreter::run_and_return_frame(Executable& executa
         push_call_frame(in_frame, executable.number_of_registers);
     else
         push_call_frame(make<CallFrame>(), executable.number_of_registers);
+
+    vm().execution_context_stack().last()->executable = &executable;
 
     if (auto native_executable = executable.get_or_create_native_executable()) {
         native_executable->run(vm());

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.h
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.h
@@ -78,7 +78,7 @@ public:
     Executable& current_executable() { return *m_current_executable; }
     Executable const& current_executable() const { return *m_current_executable; }
     BasicBlock const& current_block() const { return *m_current_block; }
-    Optional<InstructionStreamIterator const&> instruction_stream_iterator() const;
+    Optional<InstructionStreamIterator const&> instruction_stream_iterator() const { return m_pc; }
 
     void visit_edges(Cell::Visitor&);
 

--- a/Userland/Libraries/LibJS/CMakeLists.txt
+++ b/Userland/Libraries/LibJS/CMakeLists.txt
@@ -271,3 +271,4 @@ target_link_libraries(LibJS PRIVATE LibCore LibCrypto LibFileSystem LibRegex Lib
 if("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "x86_64")
     target_link_libraries(LibJS PRIVATE LibX86)
 endif()
+target_compile_options(LibJS PRIVATE -fno-omit-frame-pointer)

--- a/Userland/Libraries/LibJS/JIT/NativeExecutable.cpp
+++ b/Userland/Libraries/LibJS/JIT/NativeExecutable.cpp
@@ -79,9 +79,13 @@ void NativeExecutable::dump_disassembly([[maybe_unused]] Bytecode::Executable co
     auto symbol_provider = JITSymbolProvider(*this);
     auto mapping = m_mapping.begin();
 
-    auto first_instruction = Bytecode::InstructionStreamIterator { executable.basic_blocks[0]->instruction_stream(), &executable };
-    auto source_range = first_instruction.source_range().realize();
-    dbgln("Disassembly of '{}' ({}:{}:{}):", executable.name, source_range.filename(), source_range.start.line, source_range.start.column);
+    if (!executable.basic_blocks.is_empty() && executable.basic_blocks[0]->size() != 0) {
+        auto first_instruction = Bytecode::InstructionStreamIterator { executable.basic_blocks[0]->instruction_stream(), &executable };
+        auto source_range = first_instruction.source_range().realize();
+        dbgln("Disassembly of '{}' ({}:{}:{}):", executable.name, source_range.filename(), source_range.start.line, source_range.start.column);
+    } else {
+        dbgln("Disassembly of '{}':", executable.name);
+    }
 
     while (true) {
         auto offset = stream.offset();

--- a/Userland/Libraries/LibJS/JIT/NativeExecutable.h
+++ b/Userland/Libraries/LibJS/JIT/NativeExecutable.h
@@ -34,7 +34,7 @@ public:
     void run(VM&) const;
     void dump_disassembly(Bytecode::Executable const& executable) const;
     BytecodeMapping const& find_mapping_entry(size_t native_offset) const;
-    Optional<Bytecode::InstructionStreamIterator const&> instruction_stream_iterator(Bytecode::Executable const& executable) const;
+    Optional<UnrealizedSourceRange> get_source_range(Bytecode::Executable const& executable, FlatPtr address) const;
 
     ReadonlyBytes code_bytes() const { return { m_code, m_size }; }
 

--- a/Userland/Libraries/LibJS/Runtime/Error.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Error.cpp
@@ -75,13 +75,13 @@ ThrowCompletionOr<void> Error::install_error_cause(Value options)
 
 void Error::populate_stack()
 {
-    auto& vm = this->vm();
-    m_traceback.ensure_capacity(vm.execution_context_stack().size());
-    for (ssize_t i = vm.execution_context_stack().size() - 1; i >= 0; i--) {
-        auto context = vm.execution_context_stack()[i];
+    auto stack_trace = vm().stack_trace();
+    m_traceback.ensure_capacity(stack_trace.size());
+    for (auto& element : stack_trace) {
+        auto* context = element.execution_context;
         UnrealizedSourceRange range = {};
-        if (context->instruction_stream_iterator.has_value())
-            range = context->instruction_stream_iterator->source_range();
+        if (element.source_range.has_value())
+            range = element.source_range.value();
         TracebackFrame frame {
             .function_name = context->function_name,
             .source_range_storage = range,

--- a/Userland/Libraries/LibJS/Runtime/Error.h
+++ b/Userland/Libraries/LibJS/Runtime/Error.h
@@ -22,6 +22,11 @@ struct TracebackFrame {
     mutable Variant<SourceRange, UnrealizedSourceRange> source_range_storage;
 };
 
+enum CompactTraceback {
+    No,
+    Yes,
+};
+
 class Error : public Object {
     JS_OBJECT(Error, Object);
 
@@ -32,7 +37,7 @@ public:
 
     virtual ~Error() override = default;
 
-    [[nodiscard]] String stack_string() const;
+    [[nodiscard]] String stack_string(CompactTraceback compact = CompactTraceback::No) const;
 
     ThrowCompletionOr<void> install_error_cause(Value options);
 

--- a/Userland/Libraries/LibJS/Runtime/ExecutionContext.h
+++ b/Userland/Libraries/LibJS/Runtime/ExecutionContext.h
@@ -51,9 +51,16 @@ public:
     MarkedVector<Value> local_variables;
     bool is_strict_mode { false };
 
+    RefPtr<Bytecode::Executable> executable;
+
     // https://html.spec.whatwg.org/multipage/webappapis.html#skip-when-determining-incumbent-counter
     // FIXME: Move this out of LibJS (e.g. by using the CustomData concept), as it's used exclusively by LibWeb.
     size_t skip_when_determining_incumbent_counter { 0 };
+};
+
+struct StackTraceElement {
+    ExecutionContext* execution_context;
+    Optional<UnrealizedSourceRange> source_range;
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/VM.cpp
+++ b/Userland/Libraries/LibJS/Runtime/VM.cpp
@@ -15,6 +15,7 @@
 #include <LibFileSystem/FileSystem.h>
 #include <LibJS/AST.h>
 #include <LibJS/Bytecode/Interpreter.h>
+#include <LibJS/JIT/NativeExecutable.h>
 #include <LibJS/Runtime/AbstractOperations.h>
 #include <LibJS/Runtime/Array.h>
 #include <LibJS/Runtime/BoundFunction.h>
@@ -1133,6 +1134,68 @@ void VM::pop_execution_context()
     m_execution_context_stack.take_last();
     if (m_execution_context_stack.is_empty() && on_call_stack_emptied)
         on_call_stack_emptied();
+}
+
+#if ARCH(X86_64)
+struct [[gnu::packed]] NativeStackFrame {
+    NativeStackFrame* prev;
+    FlatPtr return_address;
+};
+#endif
+
+Vector<FlatPtr> VM::get_native_stack_trace() const
+{
+    Vector<FlatPtr> buffer;
+#if ARCH(X86_64)
+    // Manually walk the stack, because backtrace() does not traverse through JIT frames.
+    auto* frame = bit_cast<NativeStackFrame*>(__builtin_frame_address(0));
+    while (bit_cast<FlatPtr>(frame) < m_stack_info.top() && bit_cast<FlatPtr>(frame) >= m_stack_info.base()) {
+        buffer.append(frame->return_address);
+        frame = frame->prev;
+    }
+#endif
+    return buffer;
+}
+
+static Optional<UnrealizedSourceRange> get_source_range(ExecutionContext const* context, Vector<FlatPtr> const& native_stack)
+{
+    // native function
+    if (!context->executable)
+        return {};
+
+    auto const* native_executable = context->executable->native_executable();
+    if (!native_executable) {
+        // Interpreter frame
+        if (context->instruction_stream_iterator.has_value())
+            return context->instruction_stream_iterator->source_range();
+        return {};
+    }
+
+    // JIT frame
+    for (auto address : native_stack) {
+        auto range = native_executable->get_source_range(*context->executable, address);
+        if (range.has_value()) {
+            auto realized = range->realize();
+            return range;
+        }
+    }
+
+    return {};
+}
+
+Vector<StackTraceElement> VM::stack_trace() const
+{
+    auto native_stack = get_native_stack_trace();
+    Vector<StackTraceElement> stack_trace;
+    for (ssize_t i = m_execution_context_stack.size() - 1; i >= 0; i--) {
+        auto* context = m_execution_context_stack[i];
+        stack_trace.append({
+            .execution_context = context,
+            .source_range = get_source_range(context, native_stack).value_or({}),
+        });
+    }
+
+    return stack_trace;
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/VM.h
+++ b/Userland/Libraries/LibJS/Runtime/VM.h
@@ -254,6 +254,8 @@ public:
     // NOTE: This is meant as a temporary stopgap until everything is bytecode.
     ThrowCompletionOr<Value> execute_ast_node(ASTNode const&);
 
+    Vector<StackTraceElement> stack_trace() const;
+
 private:
     using ErrorMessages = AK::Array<String, to_underlying(ErrorMessage::__Count)>;
 
@@ -276,6 +278,8 @@ private:
     void finish_dynamic_import(ScriptOrModule referencing_script_or_module, ModuleRequest module_request, PromiseCapability const& promise_capability, Promise* inner_promise);
 
     void set_well_known_symbols(WellKnownSymbols well_known_symbols) { m_well_known_symbols = move(well_known_symbols); }
+
+    Vector<FlatPtr> get_native_stack_trace() const;
 
     HashMap<String, GCPtr<PrimitiveString>> m_string_cache;
     HashMap<DeprecatedString, GCPtr<PrimitiveString>> m_deprecated_string_cache;

--- a/Userland/Libraries/LibJS/Tests/builtins/Error/Error.prototype.stack.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Error/Error.prototype.stack.js
@@ -5,7 +5,7 @@ const stackSetter = stackDescriptor.set;
 describe("getter - normal behavior", () => {
     test("basic functionality", () => {
         const stackFrames = [
-            /^    at .*Error \(.*\/Error\.prototype\.stack\.js:\d+:\d+\)$/,
+            /^    at .*Error$/,
             /^    at .+\/Error\/Error\.prototype\.stack\.js:\d+:\d+$/,
             /^    at test \(.+\/test-common.js:\d+:\d+\)$/,
             /^    at .+\/Error\/Error\.prototype\.stack\.js:6:9$/,

--- a/Userland/Libraries/LibWeb/HTML/Scripting/ExceptionReporter.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/ExceptionReporter.cpp
@@ -31,11 +31,7 @@ void report_exception_to_console(JS::Value value, JS::Realm& realm, ErrorInPromi
         }
         if (is<JS::Error>(object)) {
             auto const& error_value = static_cast<JS::Error const&>(object);
-            for (auto& traceback_frame : error_value.traceback()) {
-                auto& function_name = traceback_frame.function_name;
-                auto& source_range = traceback_frame.source_range();
-                dbgln("  {} at {}:{}:{}", function_name, source_range.filename(), source_range.start.line, source_range.start.column);
-            }
+            dbgln("{}", error_value.stack_string(JS::CompactTraceback::Yes));
             console.report_exception(error_value, error_in_promise == ErrorInPromise::Yes);
 
             return;

--- a/Userland/Utilities/js.cpp
+++ b/Userland/Utilities/js.cpp
@@ -251,36 +251,7 @@ static ErrorOr<bool> parse_and_run(JS::Realm& realm, StringView source, StringVi
 
         if (!thrown_value.is_object() || !is<JS::Error>(thrown_value.as_object()))
             return {};
-        auto const& traceback = static_cast<JS::Error const&>(thrown_value.as_object()).traceback();
-        if (traceback.size() > 1) {
-            unsigned repetitions = 0;
-            for (size_t i = 0; i < traceback.size(); ++i) {
-                auto const& traceback_frame = traceback[i];
-                if (i + 1 < traceback.size()) {
-                    auto const& next_traceback_frame = traceback[i + 1];
-                    if (next_traceback_frame.function_name == traceback_frame.function_name) {
-                        repetitions++;
-                        continue;
-                    }
-                }
-                if (repetitions > 4) {
-                    // If more than 5 (1 + >4) consecutive function calls with the same name, print
-                    // the name only once and show the number of repetitions instead. This prevents
-                    // printing ridiculously large call stacks of recursive functions.
-                    warnln(" -> {}", traceback_frame.function_name);
-                    warnln(" {} more calls", repetitions);
-                } else {
-                    for (size_t j = 0; j < repetitions + 1; ++j) {
-                        warnln(" -> {} ({}:{},{})",
-                            traceback_frame.function_name,
-                            traceback_frame.source_range().code->filename(),
-                            traceback_frame.source_range().start.line,
-                            traceback_frame.source_range().start.column);
-                    }
-                }
-                repetitions = 0;
-            }
-        }
+        warnln("{}", static_cast<JS::Error const&>(thrown_value.as_object()).stack_string(JS::CompactTraceback::Yes));
         return {};
     };
 


### PR DESCRIPTION
The previous implementation was calling `backtrace()` for every function call, which is quite slow.
I noticed while running `Kraken/imaging-gaussian-blur` which took ages.
With these changes it's back to ~20s on my machine.