### PR TITLE
LibPDF: Improve CalRGB color space handling

### DIFF
--- a/Userland/Libraries/LibPDF/ColorSpace.cpp
+++ b/Userland/Libraries/LibPDF/ColorSpace.cpp
@@ -229,7 +229,7 @@ PDFErrorOr<NonnullRefPtr<CalRGBColorSpace>> CalRGBColorSpace::create(Document* d
 
     if (dict->contains(CommonNames::Matrix)) {
         auto matrix_array = TRY(dict->get_array(document, CommonNames::Matrix));
-        if (matrix_array->size() == 3) {
+        if (matrix_array->size() == 9) {
             color_space->m_matrix[0] = matrix_array->at(0).to_float();
             color_space->m_matrix[1] = matrix_array->at(1).to_float();
             color_space->m_matrix[2] = matrix_array->at(2).to_float();

--- a/Userland/Libraries/LibPDF/ColorSpace.cpp
+++ b/Userland/Libraries/LibPDF/ColorSpace.cpp
@@ -255,7 +255,7 @@ constexpr Array<float, 3> matrix_multiply(Array<float, 9> a, Array<float, 3> b)
 }
 
 // Converts to a flat XYZ space with white point = (1, 1, 1)
-// Step 2 of https://www.adobe.com/content/dam/acom/en/devnet/photoshop/sdk/AdobeBPC.pdf
+// Step 2 of https://www.color.org/adobebpc.pdf
 constexpr Array<float, 3> flatten_and_normalize_whitepoint(Array<float, 3> whitepoint, Array<float, 3> xyz)
 {
     VERIFY(whitepoint[1] == 1.0f);

--- a/Userland/Libraries/LibPDF/ColorSpace.cpp
+++ b/Userland/Libraries/LibPDF/ColorSpace.cpp
@@ -293,17 +293,13 @@ constexpr Array<float, 3> scale_black_point(Array<float, 3> blackpoint, Array<fl
 }
 
 // https://en.wikipedia.org/wiki/Illuminant_D65
-constexpr Array<float, 3> convert_to_d65(Array<float, 3> whitepoint, Array<float, 3> xyz)
+constexpr Array<float, 3> convert_to_d65(Array<float, 3> xyz)
 {
     constexpr float d65x = 0.95047f;
     constexpr float d65y = 1.0f;
     constexpr float d65z = 1.08883f;
 
-    return {
-        (xyz[0] * d65x) / whitepoint[0],
-        (xyz[1] * d65y) / whitepoint[1],
-        (xyz[2] * d65z) / whitepoint[2],
-    };
+    return { xyz[0] * d65x, xyz[1] * d65y, xyz[2] * d65z };
 }
 
 // https://en.wikipedia.org/wiki/SRGB
@@ -343,7 +339,7 @@ PDFErrorOr<Color> CalRGBColorSpace::color(ReadonlySpan<Value> arguments) const
 
     auto flattened_xyz = flatten_and_normalize_whitepoint(m_whitepoint, { x, y, z });
     auto scaled_black_point_xyz = scale_black_point(m_blackpoint, flattened_xyz);
-    auto d65_normalized = convert_to_d65(m_whitepoint, scaled_black_point_xyz);
+    auto d65_normalized = convert_to_d65(scaled_black_point_xyz);
     auto srgb = convert_to_srgb(d65_normalized);
 
     auto red = static_cast<u8>(srgb[0] * 255.0f);

--- a/Userland/Libraries/LibPDF/ColorSpace.cpp
+++ b/Userland/Libraries/LibPDF/ColorSpace.cpp
@@ -342,9 +342,9 @@ PDFErrorOr<Color> CalRGBColorSpace::color(ReadonlySpan<Value> arguments) const
     auto d65_normalized = convert_to_d65(scaled_black_point_xyz);
     auto srgb = convert_to_srgb(d65_normalized);
 
-    auto red = static_cast<u8>(srgb[0] * 255.0f);
-    auto green = static_cast<u8>(srgb[1] * 255.0f);
-    auto blue = static_cast<u8>(srgb[2] * 255.0f);
+    auto red = static_cast<u8>(clamp(srgb[0], 0.0f, 1.0f) * 255.0f);
+    auto green = static_cast<u8>(clamp(srgb[1], 0.0f, 1.0f) * 255.0f);
+    auto blue = static_cast<u8>(clamp(srgb[2], 0.0f, 1.0f) * 255.0f);
 
     return Color(red, green, blue);
 }


### PR DESCRIPTION
This code was advertised in #7675 / 3896a897168c as "This isn't tested all that well".

I'm not sure it's tested much more thoroughly now, but at least it manages to map 1, 1, 1 to white for https://developer.apple.com/library/archive/documentation/mac/pdf/Text.pdf :)