### PR TITLE
HackStudio: Fix unsaved changes warning dialog behavior

### DIFF
--- a/Userland/DevTools/HackStudio/EditorWrapper.cpp
+++ b/Userland/DevTools/HackStudio/EditorWrapper.cpp
@@ -71,18 +71,24 @@ void EditorWrapper::set_filename(DeprecatedString const& filename)
     update_diff();
 }
 
-void EditorWrapper::save()
+bool EditorWrapper::save()
 {
     if (filename().is_empty()) {
         auto file_picker_action = GUI::CommonActions::make_save_as_action([&](auto&) {
             Optional<DeprecatedString> save_path = GUI::FilePicker::get_save_filepath(window(), "file"sv, "txt"sv, project_root().value());
-            set_filename(save_path.value());
+            if (save_path.has_value())
+                set_filename(save_path.value());
         });
         file_picker_action->activate();
+
+        if (filename().is_empty())
+            return false;
     }
     editor().write_to_file(filename()).release_value_but_fixme_should_propagate_errors();
     update_diff();
     editor().update();
+
+    return true;
 }
 
 void EditorWrapper::update_diff()

--- a/Userland/DevTools/HackStudio/EditorWrapper.h
+++ b/Userland/DevTools/HackStudio/EditorWrapper.h
@@ -30,7 +30,7 @@ public:
     Editor& editor() { return *m_editor; }
     Editor const& editor() const { return *m_editor; }
 
-    void save();
+    bool save();
 
     LanguageClient& language_client();
 

--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -1678,7 +1678,8 @@ HackStudioWidget::ContinueDecision HackStudioWidget::warn_unsaved_changes(Deprec
     if (result == GUI::MessageBox::ExecResult::Yes) {
         for (auto& editor_wrapper : m_all_editor_wrappers) {
             if (editor_wrapper->editor().document().is_modified()) {
-                editor_wrapper->save();
+                if (!editor_wrapper->save())
+                    return ContinueDecision::No;
             }
         }
     }

--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -1323,6 +1323,9 @@ ErrorOr<NonnullRefPtr<GUI::Action>> HackStudioWidget::create_run_action()
 {
     auto icon = TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/program-run.png"sv));
     return GUI::Action::create("&Run", { Mod_Ctrl, Key_R }, icon, [this](auto&) {
+        if (warn_unsaved_changes("There are unsaved changes, do you want to save before running?") == ContinueDecision::No)
+            return;
+
         reveal_action_tab(*m_terminal_wrapper);
         run();
     });


### PR DESCRIPTION
This PR fixes two issues with the unsaved changes warning dialog in HackStudio:

1. When trying to run with unsaved changes, HackStudio asks about whether you want to save the changes. If you selected "Yes", but cancelled the file picker, HackStudio would crash, since we expected a file to be picked if the dialog was opened. Now, the action that triggered the save request is cancelled.
2. Running with unsaved changes previously didn't ask at all whether you want to save. It now follows the same behavior as when building.

