### PR TITLE
Add Manual Links to the help entry of the Context menus of 3DFileViewer, Calculator and Spider

### DIFF
--- a/Userland/Applications/3DFileViewer/CMakeLists.txt
+++ b/Userland/Applications/3DFileViewer/CMakeLists.txt
@@ -12,4 +12,4 @@ set(SOURCES
 )
 
 serenity_app(3DFileViewer ICON app-3d-file-viewer)
-target_link_libraries(3DFileViewer PRIVATE LibCore LibGfx LibGUI LibGL LibFileSystemAccessClient LibMain)
+target_link_libraries(3DFileViewer PRIVATE LibCore LibDesktop LibGfx LibGUI LibGL LibFileSystemAccessClient LibMain)

--- a/Userland/Applications/3DFileViewer/main.cpp
+++ b/Userland/Applications/3DFileViewer/main.cpp
@@ -8,6 +8,7 @@
 #include <LibCore/ArgsParser.h>
 #include <LibCore/ElapsedTimer.h>
 #include <LibCore/System.h>
+#include <LibDesktop/Launcher.h>
 #include <LibFileSystemAccessClient/Client.h>
 #include <LibGL/GL/gl.h>
 #include <LibGL/GLContext.h>
@@ -338,6 +339,11 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     auto app = TRY(GUI::Application::create(arguments));
 
+    auto const man_file = "/usr/share/man/man1/Applications/3DFileViewer.md";
+
+    TRY(Desktop::Launcher::add_allowed_handler_with_only_specific_urls("/bin/Help", { URL::create_with_file_scheme(man_file) }));
+    TRY(Desktop::Launcher::seal_allowlist());
+
     StringView filename;
 
     Core::ArgsParser args_parser;
@@ -564,6 +570,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto help_menu = window->add_menu("&Help"_string);
     help_menu->add_action(GUI::CommonActions::make_command_palette_action(window));
+    help_menu->add_action(GUI::CommonActions::make_help_action([&man_file](auto&) {
+        Desktop::Launcher::open(URL::create_with_file_scheme(man_file), "/bin/Help");
+    }));
     help_menu->add_action(GUI::CommonActions::make_about_action("3D File Viewer"_string, app_icon, window));
 
     window->show();

--- a/Userland/Applications/Calculator/CMakeLists.txt
+++ b/Userland/Applications/Calculator/CMakeLists.txt
@@ -17,4 +17,4 @@ set(GENERATED_SOURCES
 )
 
 serenity_app(Calculator ICON app-calculator)
-target_link_libraries(Calculator PRIVATE LibCore LibCrypto LibGfx LibGUI LibMain)
+target_link_libraries(Calculator PRIVATE LibCore LibCrypto LibDesktop LibGfx LibGUI LibMain)

--- a/Userland/Applications/Calculator/main.cpp
+++ b/Userland/Applications/Calculator/main.cpp
@@ -5,8 +5,10 @@
  */
 
 #include "CalculatorWidget.h"
+#include <AK/URL.h>
 #include <LibCore/System.h>
 #include <LibCrypto/NumberTheory/ModularFunctions.h>
+#include <LibDesktop/Launcher.h>
 #include <LibGUI/Action.h>
 #include <LibGUI/ActionGroup.h>
 #include <LibGUI/Application.h>
@@ -23,6 +25,11 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     TRY(Core::System::pledge("stdio recvfd sendfd rpath unix"));
     auto app = TRY(GUI::Application::create(arguments));
+
+    auto const man_file = "/usr/share/man/man1/Applications/Calculator.md";
+
+    TRY(Desktop::Launcher::add_allowed_handler_with_only_specific_urls("/bin/Help", { URL::create_with_file_scheme(man_file) }));
+    TRY(Desktop::Launcher::seal_allowlist());
 
     TRY(Core::System::pledge("stdio recvfd sendfd rpath"));
     TRY(Core::System::unveil("/res", "r"));
@@ -123,6 +130,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto help_menu = window->add_menu("&Help"_string);
     help_menu->add_action(GUI::CommonActions::make_command_palette_action(window));
+    help_menu->add_action(GUI::CommonActions::make_help_action([&man_file](auto&) {
+        Desktop::Launcher::open(URL::create_with_file_scheme(man_file), "/bin/Help");
+    }));
     help_menu->add_action(GUI::CommonActions::make_about_action("Calculator"_string, app_icon, window));
 
     window->show();

--- a/Userland/Games/Spider/CMakeLists.txt
+++ b/Userland/Games/Spider/CMakeLists.txt
@@ -16,4 +16,4 @@ set(GENERATED_SOURCES
 )
 
 serenity_app(Spider ICON app-spider)
-target_link_libraries(Spider PRIVATE LibCards LibGUI LibGfx LibCore LibConfig LibMain)
+target_link_libraries(Spider PRIVATE LibCards LibGUI LibGfx LibCore LibDesktop LibConfig LibMain)

--- a/Userland/Games/Spider/main.cpp
+++ b/Userland/Games/Spider/main.cpp
@@ -8,10 +8,12 @@
 
 #include "Game.h"
 #include <AK/NumberFormat.h>
+#include <AK/URL.h>
 #include <Games/Spider/SpiderGML.h>
 #include <LibConfig/Client.h>
 #include <LibCore/System.h>
 #include <LibCore/Timer.h>
+#include <LibDesktop/Launcher.h>
 #include <LibGUI/Action.h>
 #include <LibGUI/ActionGroup.h>
 #include <LibGUI/Application.h>
@@ -39,6 +41,11 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     Config::pledge_domains({ "Games", "Spider" });
     Config::monitor_domain("Games");
+
+    auto const man_file = "/usr/share/man/man6/Spider.md";
+
+    TRY(Desktop::Launcher::add_allowed_handler_with_only_specific_urls("/bin/Help", { URL::create_with_file_scheme(man_file) }));
+    TRY(Desktop::Launcher::seal_allowlist());
 
     TRY(Core::System::pledge("stdio recvfd sendfd rpath proc exec"));
 
@@ -279,6 +286,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto help_menu = window->add_menu("&Help"_string);
     help_menu->add_action(GUI::CommonActions::make_command_palette_action(window));
+    help_menu->add_action(GUI::CommonActions::make_help_action([&man_file](auto&) {
+        Desktop::Launcher::open(URL::create_with_file_scheme(man_file), "/bin/Help");
+    }));
     help_menu->add_action(GUI::CommonActions::make_about_action("Spider"_string, app_icon, window));
 
     window->set_resizable(false);


### PR DESCRIPTION
I have added Help Entries the Context menus of 3DFileViewer, Calculator and Spider, advancing progress on issue: #21091