### PR TITLE
Meta: Add python related build files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ sync-local.sh
 .vim/
 .exrc
 .helix/
+__pycache__/
 
 # Gradle/AndroidStudio
 .gradle/

--- a/Ladybird/.gitignore
+++ b/Ladybird/.gitignore
@@ -6,3 +6,4 @@ Build
 build
 CMakeLists.txt.user
 Android/src/main/assets/
+Qt/ladybird_rc.py


### PR DESCRIPTION
On master after running `./Meta/serenity.sh run lagom ladybird` on linux:
```
git status
On branch master
Untracked files:
  (use "git add <file>..." to include in what will be committed)
	Ladybird/Qt/ladybird_rc.py
	Meta/__pycache__/
```