### PR TITLE
LibJS/JIT: Some JIT code refactoring and alternative inc/dec/add/sub.

### DIFF
--- a/Userland/Libraries/LibJS/JIT/Compiler.h
+++ b/Userland/Libraries/LibJS/JIT/Compiler.h
@@ -161,14 +161,23 @@ private:
     void jump_to_exit();
 
     void native_call(void* function_address, Vector<Assembler::Operand> const& stack_arguments = {});
+    void jump_if_int32_condition(Assembler::Reg reg, Assembler::Condition cond, Assembler::Label& cond_label);
 
-    void jump_if_int32(Assembler::Reg, Assembler::Label&);
+    void jump_if_int32(Assembler::Reg reg, Assembler::Label& int32_case)
+    {
+        jump_if_int32_condition(reg, Assembler::Condition::EqualTo, int32_case);
+    }
 
-    template<typename Codegen>
-    void branch_if_int32(Assembler::Reg, Codegen);
+    void jump_if_not_int32(Assembler::Reg reg, Assembler::Label& not_int32_case)
+    {
+        jump_if_int32_condition(reg, Assembler::Condition::NotEqualTo, not_int32_case);
+    }
 
-    template<typename Codegen>
-    void branch_if_both_int32(Assembler::Reg, Assembler::Reg, Codegen);
+    template <typename CXXOp>
+    void compile_increment_or_decrement(Assembler::ArithSign sign, CXXOp cxx_op);
+
+    template <typename CXXOp>
+    void compile_add_or_sub(Bytecode::Register lhs, Assembler::ArithSign sign, CXXOp cxx_op);
 
     explicit Compiler(Bytecode::Executable& bytecode_executable)
         : m_bytecode_executable(bytecode_executable)


### PR DESCRIPTION
Since this is my first contribution here, I would like to ask for someone more experienced with Serenity to double check the output.
It seems correct to me though, and a bit of testing did not show any problems.

This commit changes the way inc/dec/add/sub are emitted to:
- Do the operation in 32 bits and check for overflow
- If no overflow do it again with the int32 tag already in the top 32 bits

This reduces the generated code size slightly.

Also, with a modified SunSpider/string-base64.js that uses a seeded random implementation and printing the generated output (to check for errors), the time goes from 500-ish milliseconds to 80-ish milliseconds on my machine.