### PR TITLE
LibAccelGfx: Implement draw_scaled_bitmap()

### DIFF
--- a/Userland/Libraries/LibAccelGfx/CMakeLists.txt
+++ b/Userland/Libraries/LibAccelGfx/CMakeLists.txt
@@ -5,6 +5,7 @@ if (HAS_ACCELERATED_GRAPHICS)
         Canvas.cpp
         Context.cpp
         Painter.cpp
+        Program.cpp
     )
 
     serenity_lib(LibAccelGfx accelgfx)

--- a/Userland/Libraries/LibAccelGfx/Context.cpp
+++ b/Userland/Libraries/LibAccelGfx/Context.cpp
@@ -69,6 +69,12 @@ OwnPtr<Context> Context::create()
     };
     EGLContext egl_context = eglCreateContext(egl_display, egl_config, EGL_NO_CONTEXT, context_attributes);
 
+    EGLBoolean result = eglMakeCurrent(egl_display, EGL_NO_SURFACE, EGL_NO_SURFACE, egl_context);
+    if (result == EGL_FALSE) {
+        dbgln("eglMakeCurrent failed");
+        VERIFY_NOT_REACHED();
+    }
+
     return make<Context>(egl_display, egl_context, egl_config);
 }
 

--- a/Userland/Libraries/LibAccelGfx/Painter.cpp
+++ b/Userland/Libraries/LibAccelGfx/Painter.cpp
@@ -33,17 +33,23 @@ static ColorComponents gfx_color_to_opengl_color(Gfx::Color color)
 
 Gfx::FloatRect Painter::to_clip_space(Gfx::FloatRect const& screen_rect) const
 {
-    float x = 2.0f * screen_rect.x() / m_canvas.width() - 1.0f;
-    float y = -1.0f + 2.0f * screen_rect.y() / m_canvas.height();
+    float x = 2.0f * screen_rect.x() / m_canvas->width() - 1.0f;
+    float y = -1.0f + 2.0f * screen_rect.y() / m_canvas->height();
 
-    float width = 2.0f * screen_rect.width() / m_canvas.width();
-    float height = 2.0f * screen_rect.height() / m_canvas.height();
+    float width = 2.0f * screen_rect.width() / m_canvas->width();
+    float height = 2.0f * screen_rect.height() / m_canvas->height();
 
     return { x, y, width, height };
 }
 
-Painter::Painter(Canvas& canvas)
-    : m_canvas(canvas)
+OwnPtr<Painter> Painter::create()
+{
+    auto& context = Context::the();
+    return make<Painter>(context);
+}
+
+Painter::Painter(Context& context)
+    : m_context(context)
 {
     m_state_stack.empend(State());
 }
@@ -171,7 +177,7 @@ void Painter::restore()
 
 void Painter::flush()
 {
-    m_canvas.flush();
+    m_canvas->flush();
 }
 
 }

--- a/Userland/Libraries/LibAccelGfx/Painter.h
+++ b/Userland/Libraries/LibAccelGfx/Painter.h
@@ -10,6 +10,7 @@
 #include <AK/Vector.h>
 #include <LibAccelGfx/Canvas.h>
 #include <LibAccelGfx/Forward.h>
+#include <LibAccelGfx/Program.h>
 #include <LibGfx/AffineTransform.h>
 #include <LibGfx/Forward.h>
 
@@ -53,6 +54,8 @@ private:
     [[nodiscard]] Gfx::FloatRect to_clip_space(Gfx::FloatRect const& screen_rect) const;
 
     Vector<State, 1> m_state_stack;
+
+    Program m_rectangle_program;
 };
 
 }

--- a/Userland/Libraries/LibAccelGfx/Painter.h
+++ b/Userland/Libraries/LibAccelGfx/Painter.h
@@ -8,6 +8,7 @@
 
 #include <AK/Noncopyable.h>
 #include <AK/Vector.h>
+#include <LibAccelGfx/Canvas.h>
 #include <LibAccelGfx/Forward.h>
 #include <LibGfx/AffineTransform.h>
 #include <LibGfx/Forward.h>
@@ -19,7 +20,9 @@ class Painter {
     AK_MAKE_NONMOVABLE(Painter);
 
 public:
-    Painter(Canvas&);
+    static OwnPtr<Painter> create();
+
+    Painter(Context&);
     ~Painter();
 
     void clear(Gfx::Color);
@@ -33,10 +36,12 @@ public:
     void fill_rect(Gfx::FloatRect, Gfx::Color);
     void fill_rect(Gfx::IntRect, Gfx::Color);
 
-private:
+    void set_canvas(Canvas& canvas) { m_canvas = canvas; }
     void flush();
 
-    Canvas& m_canvas;
+private:
+    Context& m_context;
+    Optional<Canvas> m_canvas;
 
     struct State {
         Gfx::AffineTransform transform;

--- a/Userland/Libraries/LibAccelGfx/Painter.h
+++ b/Userland/Libraries/LibAccelGfx/Painter.h
@@ -37,6 +37,14 @@ public:
     void fill_rect(Gfx::FloatRect, Gfx::Color);
     void fill_rect(Gfx::IntRect, Gfx::Color);
 
+    enum class ScalingMode {
+        NearestNeighbor,
+        Bilinear,
+    };
+
+    void draw_scaled_bitmap(Gfx::FloatRect const& dst_rect, Gfx::Bitmap const&, Gfx::FloatRect const& src_rect, ScalingMode = ScalingMode::NearestNeighbor);
+    void draw_scaled_bitmap(Gfx::IntRect const& dst_rect, Gfx::Bitmap const&, Gfx::IntRect const& src_rect, ScalingMode = ScalingMode::NearestNeighbor);
+
     void set_canvas(Canvas& canvas) { m_canvas = canvas; }
     void flush();
 
@@ -56,6 +64,7 @@ private:
     Vector<State, 1> m_state_stack;
 
     Program m_rectangle_program;
+    Program m_blit_program;
 };
 
 }

--- a/Userland/Libraries/LibAccelGfx/Program.cpp
+++ b/Userland/Libraries/LibAccelGfx/Program.cpp
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2023, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#define GL_GLEXT_PROTOTYPES
+
+#include <AK/Assertions.h>
+#include <AK/Format.h>
+#include <GL/gl.h>
+#include <GL/glext.h>
+#include <LibAccelGfx/Program.h>
+
+namespace AccelGfx {
+
+static GLuint create_shader(GLenum type, char const* source)
+{
+    GLuint shader = glCreateShader(type);
+    glShaderSource(shader, 1, &source, nullptr);
+    glCompileShader(shader);
+
+    int success;
+    glGetShaderiv(shader, GL_COMPILE_STATUS, &success);
+    if (!success) {
+        char buffer[512];
+        glGetShaderInfoLog(shader, sizeof(buffer), nullptr, buffer);
+        dbgln("GLSL shader compilation failed: {}", buffer);
+        VERIFY_NOT_REACHED();
+    }
+
+    return shader;
+}
+
+Program Program::create(char const* vertex_shader_source, char const* fragment_shader_source)
+{
+    GLuint program = glCreateProgram();
+
+    auto vertex_shader = create_shader(GL_VERTEX_SHADER, vertex_shader_source);
+    auto fragment_shader = create_shader(GL_FRAGMENT_SHADER, fragment_shader_source);
+
+    glAttachShader(program, vertex_shader);
+    glAttachShader(program, fragment_shader);
+    glLinkProgram(program);
+
+    int linked;
+    glGetProgramiv(program, GL_LINK_STATUS, &linked);
+    if (!linked) {
+        char buffer[512];
+        glGetProgramInfoLog(program, sizeof(buffer), nullptr, buffer);
+        dbgln("GLSL program linking failed: {}", buffer);
+        VERIFY_NOT_REACHED();
+    }
+
+    glDeleteShader(vertex_shader);
+    glDeleteShader(fragment_shader);
+
+    return Program { program };
+}
+
+void Program::use()
+{
+    glUseProgram(m_id);
+}
+
+GLuint Program::get_attribute_location(char const* name)
+{
+    return glGetAttribLocation(m_id, name);
+}
+
+GLuint Program::get_uniform_location(char const* name)
+{
+    return glGetUniformLocation(m_id, name);
+}
+
+Program::~Program()
+{
+    glDeleteProgram(m_id);
+}
+
+}

--- a/Userland/Libraries/LibAccelGfx/Program.h
+++ b/Userland/Libraries/LibAccelGfx/Program.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2023, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Noncopyable.h>
+#include <GL/gl.h>
+
+namespace AccelGfx {
+
+class Program {
+    AK_MAKE_NONCOPYABLE(Program);
+
+public:
+    static Program create(char const* vertex_shader_source, char const* fragment_shader_source);
+
+    void use();
+    GLuint get_attribute_location(char const* name);
+    GLuint get_uniform_location(char const* name);
+
+    ~Program();
+
+private:
+    Program(GLuint id)
+        : m_id(id)
+    {
+    }
+
+    GLuint m_id { 0 };
+};
+
+}

--- a/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorGPU.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorGPU.cpp
@@ -36,9 +36,25 @@ CommandResult PaintingCommandExecutorGPU::fill_rect(Gfx::IntRect const& rect, Co
     return CommandResult::Continue;
 }
 
-CommandResult PaintingCommandExecutorGPU::draw_scaled_bitmap(Gfx::IntRect const&, Gfx::Bitmap const&, Gfx::IntRect const&, float, Gfx::Painter::ScalingMode)
+CommandResult PaintingCommandExecutorGPU::draw_scaled_bitmap(Gfx::IntRect const& dst_rect, Gfx::Bitmap const& bitmap, Gfx::IntRect const& src_rect, float, Gfx::Painter::ScalingMode scaling_mode)
 {
-    // FIXME
+    // FIXME: We should avoid using Gfx::Painter specific enums in painting commands
+    AccelGfx::Painter::ScalingMode accel_scaling_mode;
+    switch (scaling_mode) {
+    case Gfx::Painter::ScalingMode::NearestNeighbor:
+    case Gfx::Painter::ScalingMode::BoxSampling:
+    case Gfx::Painter::ScalingMode::SmoothPixels:
+    case Gfx::Painter::ScalingMode::None:
+        accel_scaling_mode = AccelGfx::Painter::ScalingMode::NearestNeighbor;
+        break;
+    case Gfx::Painter::ScalingMode::BilinearBlend:
+        accel_scaling_mode = AccelGfx::Painter::ScalingMode::Bilinear;
+        break;
+    default:
+        VERIFY_NOT_REACHED();
+    }
+
+    painter().draw_scaled_bitmap(dst_rect, bitmap, src_rect, accel_scaling_mode);
     return CommandResult::Continue;
 }
 

--- a/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorGPU.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorGPU.cpp
@@ -8,16 +8,14 @@
 
 namespace Web::Painting {
 
-PaintingCommandExecutorGPU::PaintingCommandExecutorGPU(Gfx::Bitmap& bitmap)
-    : m_target_bitmap(bitmap)
-    , m_canvas(AccelGfx::Canvas::create(AccelGfx::Context::the(), bitmap))
-    , m_painter(m_canvas)
+PaintingCommandExecutorGPU::PaintingCommandExecutorGPU(AccelGfx::Painter& painter)
+    : m_painter(painter)
 {
 }
 
 PaintingCommandExecutorGPU::~PaintingCommandExecutorGPU()
 {
-    m_canvas.flush();
+    m_painter.flush();
 }
 
 CommandResult PaintingCommandExecutorGPU::draw_text_run(Color const&, Gfx::IntPoint const&, String const&, Gfx::Font const&)

--- a/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorGPU.h
+++ b/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorGPU.h
@@ -50,15 +50,13 @@ public:
 
     bool would_be_fully_clipped_by_painter(Gfx::IntRect) const override;
 
-    PaintingCommandExecutorGPU(Gfx::Bitmap& bitmap);
+    PaintingCommandExecutorGPU(AccelGfx::Painter& painter);
     ~PaintingCommandExecutorGPU() override;
 
 private:
     AccelGfx::Painter& painter() { return m_painter; }
 
-    Gfx::Bitmap& m_target_bitmap;
-    AccelGfx::Canvas m_canvas;
-    AccelGfx::Painter m_painter;
+    AccelGfx::Painter& m_painter;
 };
 
 }

--- a/Userland/Services/WebContent/PageHost.h
+++ b/Userland/Services/WebContent/PageHost.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <LibAccelGfx/Forward.h>
 #include <LibGfx/Rect.h>
 #include <LibWeb/Page/Page.h>
 #include <LibWeb/PixelUnits.h>
@@ -139,6 +140,10 @@ private:
     Web::CSS::PreferredColorScheme m_preferred_color_scheme { Web::CSS::PreferredColorScheme::Auto };
 
     RefPtr<WebDriverConnection> m_webdriver;
+
+#ifdef HAS_ACCELERATED_GRAPHICS
+    OwnPtr<AccelGfx::Painter> m_accelerated_painter;
+#endif
 };
 
 }


### PR DESCRIPTION
With these changes besides rectangles we can paint images using accelerated painter.
Also there are rearrangements in the painter to compile all required shaders only once.