### PR TITLE
LibWeb: Account for box-sizing in grid-items width calculation

### DIFF
--- a/Tests/LibWeb/Layout/expected/grid/item-with-box-sizing-border-box.txt
+++ b/Tests/LibWeb/Layout/expected/grid/item-with-box-sizing-border-box.txt
@@ -1,0 +1,27 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (1,1) content-size 798x41.46875 [BFC] children: not-inline
+    BlockContainer <body> at (10,10) content-size 780x23.46875 children: not-inline
+      Box <div.grid> at (11,11) content-size 778x21.46875 [GFC] children: not-inline
+        BlockContainer <div.item> at (112,12) content-size 187x19.46875 [BFC] children: not-inline
+          BlockContainer <div> at (113,13) content-size 185x17.46875 children: inline
+            line 0 width: 29.8125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+              frag 0 from TextNode start: 0, length: 3, rect: [113,13 29.8125x17.46875]
+                "One"
+            TextNode <#text>
+        BlockContainer <div.item> at (501,12) content-size 187x19.46875 [BFC] children: not-inline
+          BlockContainer <div> at (502,13) content-size 185x17.46875 children: inline
+            line 0 width: 33.875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+              frag 0 from TextNode start: 0, length: 3, rect: [502,13 33.875x17.46875]
+                "Two"
+            TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x43.46875]
+    PaintableWithLines (BlockContainer<BODY>) [9,9 782x25.46875]
+      PaintableBox (Box<DIV>.grid) [10,10 780x23.46875]
+        PaintableWithLines (BlockContainer<DIV>.item) [11,11 389x21.46875]
+          PaintableWithLines (BlockContainer<DIV>) [112,12 187x19.46875]
+            TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.item) [400,11 389x21.46875]
+          PaintableWithLines (BlockContainer<DIV>) [501,12 187x19.46875]
+            TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/input/grid/item-with-box-sizing-border-box.html
+++ b/Tests/LibWeb/Layout/input/grid/item-with-box-sizing-border-box.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html><style type="text/css">
+* {
+    border: 1px solid black;
+}
+
+.grid {
+    grid-template-columns: 1fr 1fr;
+    display: grid;
+}
+
+.item {
+    padding: 0 100px;
+    width: 100%;
+    box-sizing: border-box;
+}
+</style><div class="grid"><div class="item"><div>One</div></div><div class="item"><div>Two</div></div></div>

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -1641,18 +1641,21 @@ void GridFormattingContext::resolve_grid_item_widths()
         } else if (computed_width.is_fit_content()) {
             used_alignment = try_compute_width(calculate_fit_content_width(item.box, available_space));
         } else {
-            used_alignment = try_compute_width(computed_width.to_px(grid_container(), containing_block_width));
+            auto width_px = calculate_inner_width(item.box, available_space.width, computed_width).to_px(item.box);
+            used_alignment = try_compute_width(width_px);
         }
 
         if (!should_treat_max_width_as_none(item.box, m_available_space->width)) {
-            auto max_width_alignment = try_compute_width(computed_values.max_width().to_px(grid_container(), containing_block_width));
+            auto max_width_px = calculate_inner_width(item.box, available_space.width, computed_values.max_width()).to_px(item.box);
+            auto max_width_alignment = try_compute_width(max_width_px);
             if (used_alignment.width > max_width_alignment.width) {
                 used_alignment = max_width_alignment;
             }
         }
 
         if (!computed_values.min_width().is_auto()) {
-            auto min_width_alignment = try_compute_width(computed_values.min_width().to_px(grid_container(), containing_block_width));
+            auto min_width_px = calculate_inner_width(item.box, available_space.width, computed_values.min_width()).to_px(item.box);
+            auto min_width_alignment = try_compute_width(min_width_px);
             if (used_alignment.width < min_width_alignment.width) {
                 used_alignment = min_width_alignment;
             }


### PR DESCRIPTION
Visual improvement on (now there is a gap between grid items): https://twinings.co.uk/collections/earl-grey-tea