### PR TITLE
LibWeb: Make element ID matching faster

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
+++ b/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
@@ -583,7 +583,7 @@ static inline bool matches(CSS::Selector::SimpleSelector const& component, Optio
         VERIFY_NOT_REACHED();
     }
     case CSS::Selector::SimpleSelector::Type::Id:
-        return component.name() == element.deprecated_attribute(HTML::AttributeNames::id).view();
+        return component.name() == element.id();
     case CSS::Selector::SimpleSelector::Type::Class:
         return element.has_class(component.name());
     case CSS::Selector::SimpleSelector::Type::Attribute:

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -310,7 +310,7 @@ Vector<MatchingRule> StyleComputer::collect_matching_rules(DOM::Element const& e
         if (auto it = rule_cache.rules_by_class.find(class_name); it != rule_cache.rules_by_class.end())
             add_rules_to_run(it->value);
     }
-    if (auto id = element.get_attribute(HTML::AttributeNames::id); id.has_value()) {
+    if (auto id = element.id(); id.has_value()) {
         if (auto it = rule_cache.rules_by_id.find(id.value()); it != rule_cache.rules_by_id.end())
             add_rules_to_run(it->value);
     }

--- a/Userland/Libraries/LibWeb/DOM/AccessibilityTreeNode.cpp
+++ b/Userland/Libraries/LibWeb/DOM/AccessibilityTreeNode.cpp
@@ -41,7 +41,7 @@ void AccessibilityTreeNode::serialize_tree_as_json(JsonObjectSerializer<StringBu
             MUST(object.add("name"sv, name));
             auto description = MUST(element->accessible_description(document));
             MUST(object.add("description"sv, description));
-            MUST(object.add("id"sv, element->id()));
+            MUST(object.add("id"sv, element->unique_id()));
 
             if (has_role)
                 MUST(object.add("role"sv, ARIA::role_name(*role)));

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -478,7 +478,12 @@ void Element::attribute_changed(FlyString const& name, Optional<DeprecatedString
 {
     auto value_or_empty = value.value_or("");
 
-    if (name == HTML::AttributeNames::class_) {
+    if (name == HTML::AttributeNames::id) {
+        if (!value.has_value())
+            m_id = {};
+        else
+            m_id = MUST(FlyString::from_deprecated_fly_string(value_or_empty));
+    } else if (name == HTML::AttributeNames::class_) {
         auto new_classes = value_or_empty.split_view(Infra::is_ascii_whitespace);
         m_classes.clear();
         m_classes.ensure_capacity(new_classes.size());

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -995,7 +995,7 @@ void Element::serialize_pseudo_elements_as_json(JsonArraySerializer<StringBuilde
         auto object = MUST(children_array.add_object());
         MUST(object.add("name"sv, DeprecatedString::formatted("::{}", CSS::pseudo_element_name(static_cast<CSS::Selector::PseudoElement>(i)))));
         MUST(object.add("type"sv, "pseudo-element"));
-        MUST(object.add("parent-id"sv, id()));
+        MUST(object.add("parent-id"sv, unique_id()));
         MUST(object.add("pseudo-element"sv, i));
         MUST(object.finish());
     }

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -375,6 +375,8 @@ public:
     };
     Directionality directionality() const;
 
+    Optional<FlyString> const& id() const { return m_id; }
+
 protected:
     Element(Document&, DOM::QualifiedName);
     virtual void initialize(JS::Realm&) override;
@@ -410,6 +412,8 @@ private:
 
     Vector<FlyString> m_classes;
     Optional<Dir> m_dir;
+
+    Optional<FlyString> m_id;
 
     Array<JS::GCPtr<Layout::Node>, to_underlying(CSS::Selector::PseudoElement::PseudoElementCount)> m_pseudo_element_nodes;
 

--- a/Userland/Libraries/LibWeb/DOM/Node.h
+++ b/Userland/Libraries/LibWeb/DOM/Node.h
@@ -235,8 +235,8 @@ public:
     bool is_shadow_including_ancestor_of(Node const&) const;
     bool is_shadow_including_inclusive_ancestor_of(Node const&) const;
 
-    i32 id() const { return m_id; }
-    static Node* from_id(i32 node_id);
+    i32 unique_id() const { return m_unique_id; }
+    static Node* from_unique_id(i32);
 
     WebIDL::ExceptionOr<DeprecatedString> serialize_fragment(DOMParsing::RequireWellFormed) const;
 
@@ -689,7 +689,7 @@ protected:
     bool m_needs_style_update { false };
     bool m_child_needs_style_update { false };
 
-    i32 m_id;
+    i32 m_unique_id {};
 
     // https://dom.spec.whatwg.org/#registered-observer-list
     // "Nodes have a strong reference to registered observers in their registered observer list." https://dom.spec.whatwg.org/#garbage-collection

--- a/Userland/Libraries/LibWeb/DOM/NonElementParentNode.h
+++ b/Userland/Libraries/LibWeb/DOM/NonElementParentNode.h
@@ -22,7 +22,7 @@ public:
     {
         JS::GCPtr<Element const> found_element;
         static_cast<NodeType const*>(this)->template for_each_in_inclusive_subtree_of_type<Element>([&](auto& element) {
-            if (element.attribute(HTML::AttributeNames::id) == id) {
+            if (element.id() == id) {
                 found_element = &element;
                 return IterationDecision::Break;
             }
@@ -35,7 +35,7 @@ public:
     {
         JS::GCPtr<Element> found_element;
         static_cast<NodeType*>(this)->template for_each_in_inclusive_subtree_of_type<Element>([&](auto& element) {
-            if (element.attribute(HTML::AttributeNames::id) == id) {
+            if (element.id() == id) {
                 found_element = &element;
                 return IterationDecision::Break;
             }

--- a/Userland/Libraries/LibWeb/DOM/ShadowRoot.h
+++ b/Userland/Libraries/LibWeb/DOM/ShadowRoot.h
@@ -48,7 +48,7 @@ private:
 };
 
 template<>
-inline bool Node::fast_is<ShadowRoot>() const { return is_shadow_root(); }
+inline bool Node::fast_is<ShadowRoot>() const { return node_type() == to_underlying(NodeType::DOCUMENT_FRAGMENT_NODE) && is_shadow_root(); }
 
 template<typename Callback>
 inline IterationDecision Node::for_each_shadow_including_inclusive_descendant(Callback callback)

--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -312,7 +312,7 @@ bool EventHandler::handle_mouseup(CSSPixelPoint position, CSSPixelPoint screen_p
                         };
 
                         if (auto* page = m_browsing_context->page())
-                            page->did_request_media_context_menu(media_element.id(), m_browsing_context->to_top_level_position(position), "", modifiers, move(menu));
+                            page->did_request_media_context_menu(media_element.unique_id(), m_browsing_context->to_top_level_position(position), "", modifiers, move(menu));
                     } else if (auto* page = m_browsing_context->page()) {
                         page->client().page_did_request_context_menu(m_browsing_context->to_top_level_position(position));
                     }

--- a/Userland/Libraries/LibWeb/Page/Page.cpp
+++ b/Userland/Libraries/LibWeb/Page/Page.cpp
@@ -384,7 +384,7 @@ JS::GCPtr<HTML::HTMLMediaElement> Page::media_context_menu_element()
     if (!m_media_context_menu_element_id.has_value())
         return nullptr;
 
-    auto* dom_node = DOM::Node::from_id(*m_media_context_menu_element_id);
+    auto* dom_node = DOM::Node::from_unique_id(*m_media_context_menu_element_id);
     if (dom_node == nullptr)
         return nullptr;
 

--- a/Userland/Libraries/LibWeb/SVG/SVGElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGElement.cpp
@@ -61,7 +61,7 @@ void SVGElement::update_use_elements_that_reference_this()
         // If this element is in a shadow root, it already represents a clone and is not itself referenced.
         || is<DOM::ShadowRoot>(this->root())
         // If this does not have an id it cannot be referenced, no point in searching the entire DOM tree.
-        || !this->has_attribute(HTML::AttributeNames::id)
+        || !id().has_value()
         // An unconnected node cannot have valid references.
         // This also prevents searches for elements that are in the process of being constructed - as clones.
         || !this->is_connected()
@@ -87,7 +87,7 @@ void SVGElement::removed_from(Node* parent)
 
 void SVGElement::remove_from_use_element_that_reference_this()
 {
-    if (is<SVGUseElement>(this) || !this->has_attribute(HTML::AttributeNames::id)) {
+    if (is<SVGUseElement>(this) || !id().has_value()) {
         return;
     }
 

--- a/Userland/Libraries/LibWeb/SVG/SVGSymbolElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGSymbolElement.cpp
@@ -41,6 +41,7 @@ void SVGSymbolElement::apply_presentational_hints(CSS::StyleProperties& style) c
 
 void SVGSymbolElement::attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value)
 {
+    Base::attribute_changed(name, value);
     if (name.equals_ignoring_ascii_case(SVG::AttributeNames::viewBox))
         m_view_box = try_parse_view_box(value.value_or(""));
 }

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -517,7 +517,7 @@ Messages::WebContentServer::InspectDomNodeResponse ConnectionFromClient::inspect
         return IterationDecision::Continue;
     });
 
-    Web::DOM::Node* node = Web::DOM::Node::from_id(node_id);
+    Web::DOM::Node* node = Web::DOM::Node::from_unique_id(node_id);
     // Note: Nodes without layout (aka non-visible nodes, don't have style computed)
     if (!node || !node->layout_node()) {
         return { false, "", "", "", "", "" };
@@ -642,7 +642,7 @@ Messages::WebContentServer::GetHoveredNodeIdResponse ConnectionFromClient::get_h
     if (auto* document = page().top_level_browsing_context().active_document()) {
         auto hovered_node = document->hovered_node();
         if (hovered_node)
-            return hovered_node->id();
+            return hovered_node->unique_id();
     }
     return (i32)0;
 }

--- a/Userland/Services/WebContent/WebDriverConnection.cpp
+++ b/Userland/Services/WebContent/WebDriverConnection.cpp
@@ -123,7 +123,7 @@ static DeprecatedString get_or_create_a_web_element_reference(Web::DOM::Node con
     // FIXME: 2. Add element to the list of known elements of the current browsing context.
     // FIXME: 3. Return success with the element’s web element reference.
 
-    return DeprecatedString::number(element.id());
+    return DeprecatedString::number(element.unique_id());
 }
 
 // https://w3c.github.io/webdriver/#dfn-web-element-reference-object
@@ -154,7 +154,7 @@ static ErrorOr<Web::DOM::Element*, Web::WebDriver::Error> get_known_connected_el
     if (!element.has_value())
         return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidArgument, "Element ID is not an integer");
 
-    auto* node = Web::DOM::Node::from_id(*element);
+    auto* node = Web::DOM::Node::from_unique_id(*element);
 
     if (!node || !node->is_element())
         return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::NoSuchElement, DeprecatedString::formatted("Could not find element with ID: {}", element_id));
@@ -170,7 +170,7 @@ static DeprecatedString get_or_create_a_shadow_root_reference(Web::DOM::ShadowRo
     // FIXME: 2. Add shadow to the list of known shadow roots of the current browsing context.
     // FIXME: 3. Return success with the shadow’s shadow root reference.
 
-    return DeprecatedString::number(shadow_root.id());
+    return DeprecatedString::number(shadow_root.unique_id());
 }
 
 // https://w3c.github.io/webdriver/#dfn-shadow-root-reference-object
@@ -201,7 +201,7 @@ static ErrorOr<Web::DOM::ShadowRoot*, Web::WebDriver::Error> get_known_shadow_ro
     if (!shadow_root.has_value())
         return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidArgument, "Shadow ID is not an integer");
 
-    auto* node = Web::DOM::Node::from_id(*shadow_root);
+    auto* node = Web::DOM::Node::from_unique_id(*shadow_root);
 
     if (!node || !node->is_shadow_root())
         return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::NoSuchElement, DeprecatedString::formatted("Could not find shadow root with ID: {}", shadow_id));
@@ -982,7 +982,7 @@ Messages::WebDriverClient::GetActiveElementResponse WebDriverConnection::get_act
     // 4. If active element is a non-null element, return success with data set to web element reference object for active element.
     //    Otherwise, return error with error code no such element.
     if (active_element)
-        return DeprecatedString::number(active_element->id());
+        return DeprecatedString::number(active_element->unique_id());
 
     return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::NoSuchElement, "The current document does not have an active element"sv);
 }


### PR DESCRIPTION
Noticed element ID attribute lookups in a profile, so I made a stress test to isolate some of the issues and burn them down.

The main solution to all the problems is basically to cache the `id` attribute value as an `Optional<FlyString>` on `Element`. This makes checking an element's ID O(1) instead of O(n), which is very useful in a number of places.

The stress test creates a 3000-deep DOM tree and runs two selectors against a bunch of the elements.

```
BEFORE:
Single descendant: 404ms
Double descendant: 744ms

AFTER:
Single descendant: 96ms
Double descendant: 112ms
```

So basically a 4x speed-up the single-descendant selector, and 6.5x on the double-descendant one.

Here's the stress test:
```html
<script>
    document.addEventListener("DOMContentLoaded", function() {

        let insertionPoint = document.body;

        const limit = 3000;
        for (let i = 0; i < limit; ++i) {
            const e = document.createElement("div");
            e.setAttribute("id", "div" + i);
            insertionPoint.appendChild(e);
            insertionPoint = e;
        }

        {
            const before = performance.now();
            for (let i = 0; i < limit; ++i) {
                const e = document.querySelector("body #div" + i);
            }
            const elapsed = performance.now() - before;
            console.log("Single descendant: " + elapsed);
        }

        {
            const before = performance.now();
            for (let i = 0; i < limit; ++i) {
                const e = document.querySelector("body #div500 #div" + i);
            }
            const elapsed = performance.now() - before;
            console.log("Double descendant: " + elapsed);
        }

        document.body.firstChild.remove();
    });
</script>
```