### PR TITLE
LibJS: Avoid crash on empty stack trace

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/Error.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Error.cpp
@@ -93,6 +93,9 @@ void Error::populate_stack()
 
 String Error::stack_string(CompactTraceback compact) const
 {
+    if (m_traceback.is_empty())
+        return {};
+
     StringBuilder stack_string_builder;
 
     // Note: We roughly follow V8's formatting


### PR DESCRIPTION
We were trying to stringify the stack trace without the last element, leading to a loop bound of (size_t)(0 - 1) and accessing m_traceback[0] out-of-bounds.

Instead, just return an empty string in that case.

Fixes #21747