### PR TITLE
LibJS: Store the bytecode accumulator in a dedicated physical register

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/CommonImplementations.h
+++ b/Userland/Libraries/LibJS/Bytecode/CommonImplementations.h
@@ -31,9 +31,9 @@ struct CalleeAndThis {
 };
 ThrowCompletionOr<CalleeAndThis> get_callee_and_this_from_environment(Bytecode::Interpreter&, DeprecatedFlyString const& name, u32 cache_index);
 Value new_regexp(VM&, ParsedRegex const&, DeprecatedString const& pattern, DeprecatedString const& flags);
-MarkedVector<Value> argument_list_evaluation(Bytecode::Interpreter&);
+MarkedVector<Value> argument_list_evaluation(VM&, Value arguments);
 ThrowCompletionOr<void> create_variable(VM&, DeprecatedFlyString const& name, Op::EnvironmentMode, bool is_global, bool is_immutable, bool is_strict);
-ThrowCompletionOr<ECMAScriptFunctionObject*> new_class(VM&, ClassExpression const&, Optional<IdentifierTableIndex> const& lhs_name);
+ThrowCompletionOr<ECMAScriptFunctionObject*> new_class(VM&, Value super_class, ClassExpression const&, Optional<IdentifierTableIndex> const& lhs_name);
 ThrowCompletionOr<NonnullGCPtr<Object>> super_call_with_argument_array(VM&, Value argument_array, bool is_synthetic);
 Object* iterator_to_object(VM&, IteratorRecord);
 IteratorRecord object_to_iterator(VM&, Object&);

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -934,7 +934,7 @@ ThrowCompletionOr<void> CallWithArgumentArray::execute_impl(Bytecode::Interprete
 {
     auto callee = interpreter.reg(m_callee);
     TRY(throw_if_needed_for_call(interpreter, callee, call_type(), expression_string()));
-    auto argument_values = argument_list_evaluation(interpreter);
+    auto argument_values = argument_list_evaluation(interpreter.vm(), interpreter.accumulator());
     interpreter.accumulator() = TRY(perform_call(interpreter, interpreter.reg(m_this_value), call_type(), callee, move(argument_values)));
     return {};
 }
@@ -1217,7 +1217,7 @@ ThrowCompletionOr<void> IteratorResultValue::execute_impl(Bytecode::Interpreter&
 
 ThrowCompletionOr<void> NewClass::execute_impl(Bytecode::Interpreter& interpreter) const
 {
-    interpreter.accumulator() = TRY(new_class(interpreter.vm(), m_class_expression, m_lhs_name));
+    interpreter.accumulator() = TRY(new_class(interpreter.vm(), interpreter.accumulator(), m_class_expression, m_lhs_name));
     return {};
 }
 

--- a/Userland/Libraries/LibJS/JIT/Compiler.h
+++ b/Userland/Libraries/LibJS/JIT/Compiler.h
@@ -37,6 +37,7 @@ private:
     static constexpr auto STACK_POINTER = Assembler::Reg::RSP;
     static constexpr auto REGISTER_ARRAY_BASE = Assembler::Reg::RBX;
     static constexpr auto LOCALS_ARRAY_BASE = Assembler::Reg::R14;
+    static constexpr auto CACHED_ACCUMULATOR = Assembler::Reg::R13;
 #    endif
 
 #    define JS_ENUMERATE_COMMON_BINARY_OPS_WITHOUT_FAST_PATH(O) \
@@ -152,6 +153,11 @@ private:
 
     void store_vm_local(size_t, Assembler::Reg);
     void load_vm_local(Assembler::Reg, size_t);
+
+    void reload_cached_accumulator();
+    void flush_cached_accumulator();
+    void load_accumulator(Assembler::Reg);
+    void store_accumulator(Assembler::Reg);
 
     void compile_to_boolean(Assembler::Reg dst, Assembler::Reg src);
 


### PR DESCRIPTION
We now use a dedicated physical register to store the bytecode accumulator, instead of loading and storing it to the memory everytime.
This results in a small speedup (up to 8%) in most Kraken tests, and no regression in the rest.
```
Suite    Test                                   Speedup  Old (Mean ± Range)        New (Mean ± Range)
-------  -----------------------------------  ---------  ------------------------  ------------------------
Kraken   ai-astar.js                              1.011  6.180 ± 6.150 … 6.200     6.110 ± 6.010 … 6.290
Kraken   audio-beat-detection.js                  1.051  3.900 ± 3.850 … 3.940     3.710 ± 3.670 … 3.750
Kraken   audio-dft.js                             1.01   3.273 ± 3.190 … 3.350     3.240 ± 3.200 … 3.270
Kraken   audio-fft.js                             1.078  3.877 ± 3.690 … 4.220     3.597 ± 3.580 … 3.620
Kraken   audio-oscillator.js                      1.05   5.020 ± 4.990 … 5.050     4.780 ± 4.700 … 4.830
Kraken   imaging-darkroom.js                      1.041  8.717 ± 8.600 … 8.800     8.373 ± 8.270 … 8.470
Kraken   imaging-desaturate.js                    1.083  6.007 ± 5.780 … 6.330     5.547 ± 5.510 … 5.600
Kraken   imaging-gaussian-blur.js                 1.059  38.660 ± 38.220 … 39.450  36.507 ± 36.490 … 36.520
Kraken   json-parse-financial.js                  1      0.130 ± 0.130 … 0.130     0.130 ± 0.130 … 0.130
Kraken   json-stringify-tinderbox.js              1      0.337 ± 0.330 … 0.340     0.337 ± 0.330 … 0.340
Kraken   stanford-crypto-aes.js                   1.039  1.857 ± 1.850 … 1.860     1.787 ± 1.780 … 1.790
Kraken   stanford-crypto-ccm.js                   1.033  1.563 ± 1.550 … 1.580     1.513 ± 1.500 … 1.530
Kraken   stanford-crypto-pbkdf2.js                1.031  3.330 ± 3.310 … 3.350     3.230 ± 3.210 … 3.240
Kraken   stanford-crypto-sha256-iterative.js      1.038  1.267 ± 1.260 … 1.270     1.220 ± 1.210 … 1.240
```