### PR TITLE
LibDNS+Fuzzers: Add a DNS packet fuzzer and prevent some buffer overflows

### DIFF
--- a/Meta/Lagom/Fuzzers/FuzzDNSPacket.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzDNSPacket.cpp
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2023, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibDNS/Packet.h>
+
+extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
+{
+    AK::set_debug_enabled(false);
+    auto maybe_packet = DNS::Packet::from_raw_packet({ data, size });
+    if (!maybe_packet.has_value())
+        return 0;
+
+    (void)maybe_packet.value().to_byte_buffer();
+    return 0;
+}

--- a/Meta/Lagom/Fuzzers/fuzzers.cmake
+++ b/Meta/Lagom/Fuzzers/fuzzers.cmake
@@ -5,6 +5,7 @@ set(FUZZER_TARGETS
     Brotli
     CyrillicDecoder
     DDSLoader
+    DNSPacket
     DeflateCompression
     DeflateDecompression
     ELF
@@ -79,6 +80,7 @@ set(FUZZER_DEPENDENCIES_Brotli LibCompress)
 set(FUZZER_DEPENDENCIES_CSSParser LibWeb)
 set(FUZZER_DEPENDENCIES_CyrillicDecoder LibTextCodec)
 set(FUZZER_DEPENDENCIES_DDSLoader LibGfx)
+set(FUZZER_DEPENDENCIES_DNSPacket LibDNS)
 set(FUZZER_DEPENDENCIES_DeflateCompression LibCompress)
 set(FUZZER_DEPENDENCIES_DeflateDecompression LibCompress)
 set(FUZZER_DEPENDENCIES_ELF LibELF)

--- a/Userland/Libraries/LibDNS/Name.h
+++ b/Userland/Libraries/LibDNS/Name.h
@@ -17,7 +17,7 @@ public:
     Name() = default;
     Name(DeprecatedString const&);
 
-    static Name parse(u8 const* data, size_t& offset, size_t max_offset, size_t recursion_level = 0);
+    static Name parse(ReadonlyBytes data, size_t& offset, size_t recursion_level = 0);
 
     size_t serialized_size() const;
     DeprecatedString const& as_string() const { return m_name; }

--- a/Userland/Libraries/LibDNS/Packet.h
+++ b/Userland/Libraries/LibDNS/Packet.h
@@ -24,7 +24,7 @@ class Packet {
 public:
     Packet() = default;
 
-    static Optional<Packet> from_raw_packet(u8 const*, size_t);
+    static Optional<Packet> from_raw_packet(ReadonlyBytes bytes);
     ErrorOr<ByteBuffer> to_byte_buffer() const;
 
     bool is_query() const { return !m_query_or_response; }

--- a/Userland/Services/LookupServer/DNSServer.cpp
+++ b/Userland/Services/LookupServer/DNSServer.cpp
@@ -29,7 +29,7 @@ ErrorOr<void> DNSServer::handle_client()
 {
     sockaddr_in client_address;
     auto buffer = TRY(receive(1024, client_address));
-    auto optional_request = Packet::from_raw_packet(buffer.data(), buffer.size());
+    auto optional_request = Packet::from_raw_packet(buffer);
     if (!optional_request.has_value()) {
         dbgln("Got an invalid DNS packet");
         return {};

--- a/Userland/Services/LookupServer/LookupServer.cpp
+++ b/Userland/Services/LookupServer/LookupServer.cpp
@@ -263,13 +263,13 @@ ErrorOr<Vector<Answer>> LookupServer::lookup(Name const& name, DeprecatedString 
     TRY(udp_socket->write_until_depleted(buffer));
 
     u8 response_buffer[4096];
-    int nrecv = TRY(udp_socket->read_some({ response_buffer, sizeof(response_buffer) })).size();
+    auto nrecv = TRY(udp_socket->read_some({ response_buffer, sizeof(response_buffer) })).size();
     if (udp_socket->is_eof())
         return Vector<Answer> {};
 
     did_get_response = true;
 
-    auto o_response = Packet::from_raw_packet(response_buffer, nrecv);
+    auto o_response = Packet::from_raw_packet({ response_buffer, nrecv });
     if (!o_response.has_value())
         return Vector<Answer> {};
 

--- a/Userland/Services/LookupServer/MulticastDNS.cpp
+++ b/Userland/Services/LookupServer/MulticastDNS.cpp
@@ -56,7 +56,7 @@ MulticastDNS::MulticastDNS(Core::EventReceiver* parent)
 ErrorOr<void> MulticastDNS::handle_packet()
 {
     auto buffer = TRY(receive(1024));
-    auto optional_packet = Packet::from_raw_packet(buffer.data(), buffer.size());
+    auto optional_packet = Packet::from_raw_packet(buffer);
     if (!optional_packet.has_value()) {
         dbgln("Got an invalid mDNS packet");
         return {};
@@ -175,7 +175,7 @@ ErrorOr<Vector<Answer>> MulticastDNS::lookup(Name const& name, RecordType record
         auto buffer = TRY(receive(1024));
         if (buffer.is_empty())
             return Vector<Answer> {};
-        auto optional_packet = Packet::from_raw_packet(buffer.data(), buffer.size());
+        auto optional_packet = Packet::from_raw_packet(buffer);
         if (!optional_packet.has_value()) {
             dbgln("Got an invalid mDNS packet");
             continue;

--- a/Userland/Utilities/test-fuzz.cpp
+++ b/Userland/Utilities/test-fuzz.cpp
@@ -19,6 +19,7 @@
     T(CSSParser)             \
     T(CyrillicDecoder)       \
     T(DDSLoader)             \
+    T(DNSPacket)             \
     T(DeflateCompression)    \
     T(DeflateDecompression)  \
     T(ELF)                   \


### PR DESCRIPTION
This PR makes the following changes to LibDNS:

* Adds a fuzzer for `DNS::Packet`, which should cover the majority of LibDNS.
* Replaces raw pointer usages with Spans and C-style casts with `bit_cast`.
* Prevents some buffer overflows found via local fuzzing. I'm including these in this PR since they stop the fuzzer making much progress.

I tried to replace the casting entirely by using streams, but IMO this made the code less easy to follow, so I didn't include it.