### PR TITLE
NotificationServer: Two display fixes

### DIFF
--- a/Userland/Services/NotificationServer/NotificationWindow.cpp
+++ b/Userland/Services/NotificationServer/NotificationWindow.cpp
@@ -18,7 +18,7 @@
 
 namespace NotificationServer {
 
-static HashMap<u32, RefPtr<NotificationWindow>> s_windows;
+static OrderedHashMap<u32, RefPtr<NotificationWindow>> s_windows;
 
 static void update_notification_window_locations(Gfx::IntRect const& screen_rect)
 {

--- a/Userland/Services/NotificationServer/NotificationWindow.cpp
+++ b/Userland/Services/NotificationServer/NotificationWindow.cpp
@@ -32,7 +32,6 @@ static void update_notification_window_locations(Gfx::IntRect const& screen_rect
             new_window_location = screen_rect.top_right().translated(-window->rect().width() - 24 - 1, 7);
         if (window->rect().location() != new_window_location) {
             window->move_to(new_window_location);
-            window->set_original_rect(window->rect());
         }
         last_window_rect = window->rect();
     }
@@ -50,8 +49,8 @@ NotificationWindow::NotificationWindow(i32 client_id, String const& text, String
     for (auto& window_entry : s_windows) {
         auto& window = window_entry.value;
         if (!lowest_notification_rect_on_screen.has_value()
-            || (window->m_original_rect.y() > lowest_notification_rect_on_screen.value().y()))
-            lowest_notification_rect_on_screen = window->m_original_rect;
+            || (window->rect().y() > lowest_notification_rect_on_screen.value().y()))
+            lowest_notification_rect_on_screen = window->rect();
     }
 
     s_windows.set(m_id, this);
@@ -65,8 +64,6 @@ NotificationWindow::NotificationWindow(i32 client_id, String const& text, String
         rect.set_location(lowest_notification_rect_on_screen.value().bottom_left().moved_down(9));
 
     set_rect(rect);
-
-    m_original_rect = rect;
 
     auto widget = set_main_widget<GUI::Widget>();
 

--- a/Userland/Services/NotificationServer/NotificationWindow.h
+++ b/Userland/Services/NotificationServer/NotificationWindow.h
@@ -16,7 +16,6 @@ class NotificationWindow final : public GUI::Window {
 
 public:
     virtual ~NotificationWindow() override = default;
-    void set_original_rect(Gfx::IntRect original_rect) { m_original_rect = original_rect; }
 
     void set_text(String const&);
     void set_title(String const&);
@@ -36,7 +35,6 @@ private:
     void resize_to_fit_text();
     void set_height(int);
 
-    Gfx::IntRect m_original_rect;
     i32 m_id;
 
     GUI::Label* m_text_label;


### PR DESCRIPTION
- NotificationServer: Make notifications not overlap when they appear
- NotificationServer: Don't shuffle notifications on first hover
