### PR TITLE
LibJS/JIT: Compile Await & Yield, remove PushDeclarativeEnvironment

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/Instruction.h
+++ b/Userland/Libraries/LibJS/Bytecode/Instruction.h
@@ -89,7 +89,6 @@
     O(NewString)                       \
     O(NewTypeError)                    \
     O(Not)                             \
-    O(PushDeclarativeEnvironment)      \
     O(PutById)                         \
     O(PutByIdWithThis)                 \
     O(PutByValue)                      \

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -1038,14 +1038,6 @@ ThrowCompletionOr<void> ContinuePendingUnwind::execute_impl(Bytecode::Interprete
     __builtin_unreachable();
 }
 
-ThrowCompletionOr<void> PushDeclarativeEnvironment::execute_impl(Bytecode::Interpreter& interpreter) const
-{
-    auto environment = interpreter.vm().heap().allocate_without_realm<DeclarativeEnvironment>(interpreter.vm().lexical_environment());
-    interpreter.vm().running_execution_context().lexical_environment = environment;
-    interpreter.vm().running_execution_context().variable_environment = environment;
-    return {};
-}
-
 ThrowCompletionOr<void> Yield::execute_impl(Bytecode::Interpreter& interpreter) const
 {
     auto yielded_value = interpreter.accumulator().value_or(js_undefined());
@@ -1590,21 +1582,6 @@ DeprecatedString LeaveUnwindContext::to_deprecated_string_impl(Bytecode::Executa
 DeprecatedString ContinuePendingUnwind::to_deprecated_string_impl(Bytecode::Executable const&) const
 {
     return DeprecatedString::formatted("ContinuePendingUnwind resume:{}", m_resume_target);
-}
-
-DeprecatedString PushDeclarativeEnvironment::to_deprecated_string_impl(Bytecode::Executable const& executable) const
-{
-    StringBuilder builder;
-    builder.append("PushDeclarativeEnvironment"sv);
-    if (!m_variables.is_empty()) {
-        builder.append(" {"sv);
-        Vector<DeprecatedString> names;
-        for (auto& it : m_variables)
-            names.append(executable.get_string(it.key));
-        builder.append('}');
-        builder.join(", "sv, names);
-    }
-    return builder.to_deprecated_string();
 }
 
 DeprecatedString Yield::to_deprecated_string_impl(Bytecode::Executable const&) const

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -367,7 +367,10 @@ Interpreter::ValueAndFrame Interpreter::run_and_return_frame(Executable& executa
     vm().execution_context_stack().last()->executable = &executable;
 
     if (auto native_executable = executable.get_or_create_native_executable()) {
-        native_executable->run(vm());
+        auto block_index = 0;
+        if (entry_point)
+            block_index = executable.basic_blocks.find_first_index_if([&](auto const& block) { return block.ptr() == entry_point; }).value();
+        native_executable->run(vm(), block_index);
 
 #if 0
         for (size_t i = 0; i < vm().running_execution_context().local_variables.size(); ++i) {

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -1319,21 +1319,6 @@ private:
     Label m_continuation_label;
 };
 
-class PushDeclarativeEnvironment final : public Instruction {
-public:
-    explicit PushDeclarativeEnvironment(HashMap<u32, Variable> variables)
-        : Instruction(Type::PushDeclarativeEnvironment, sizeof(*this))
-        , m_variables(move(variables))
-    {
-    }
-
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
-    DeprecatedString to_deprecated_string_impl(Bytecode::Executable const&) const;
-
-private:
-    HashMap<u32, Variable> m_variables;
-};
-
 class GetIterator final : public Instruction {
 public:
     GetIterator(IteratorHint hint = IteratorHint::Sync)

--- a/Userland/Libraries/LibJS/JIT/Compiler.cpp
+++ b/Userland/Libraries/LibJS/JIT/Compiler.cpp
@@ -1724,6 +1724,11 @@ void Compiler::compile_yield(Bytecode::Op::Yield const& op)
     compile_continuation(op.continuation(), false);
 }
 
+void Compiler::compile_await(Bytecode::Op::Await const& op)
+{
+    compile_continuation(op.continuation(), true);
+}
+
 void Compiler::jump_to_exit()
 {
     m_assembler.jump(m_exit_label);

--- a/Userland/Libraries/LibJS/JIT/Compiler.h
+++ b/Userland/Libraries/LibJS/JIT/Compiler.h
@@ -140,7 +140,8 @@ private:
         O(HasPrivateId, has_private_id)                                          \
         O(PutByValueWithThis, put_by_value_with_this)                            \
         O(CopyObjectExcludingProperties, copy_object_excluding_properties)       \
-        O(AsyncIteratorClose, async_iterator_close)
+        O(AsyncIteratorClose, async_iterator_close)                              \
+        O(Yield, yield)
 
 #    define DECLARE_COMPILE_OP(OpTitleCase, op_snake_case, ...) \
         void compile_##op_snake_case(Bytecode::Op::OpTitleCase const&);
@@ -160,6 +161,7 @@ private:
     void store_accumulator(Assembler::Reg);
 
     void compile_to_boolean(Assembler::Reg dst, Assembler::Reg src);
+    void compile_continuation(Optional<Bytecode::Label>, bool is_await);
 
     void check_exception();
     void handle_exception();

--- a/Userland/Libraries/LibJS/JIT/Compiler.h
+++ b/Userland/Libraries/LibJS/JIT/Compiler.h
@@ -141,7 +141,8 @@ private:
         O(PutByValueWithThis, put_by_value_with_this)                            \
         O(CopyObjectExcludingProperties, copy_object_excluding_properties)       \
         O(AsyncIteratorClose, async_iterator_close)                              \
-        O(Yield, yield)
+        O(Yield, yield)                                                          \
+        O(Await, await)
 
 #    define DECLARE_COMPILE_OP(OpTitleCase, op_snake_case, ...) \
         void compile_##op_snake_case(Bytecode::Op::OpTitleCase const&);

--- a/Userland/Libraries/LibJS/JIT/NativeExecutable.h
+++ b/Userland/Libraries/LibJS/JIT/NativeExecutable.h
@@ -31,7 +31,7 @@ public:
     NativeExecutable(void* code, size_t size, Vector<BytecodeMapping>);
     ~NativeExecutable();
 
-    void run(VM&) const;
+    void run(VM&, size_t entry_point) const;
     void dump_disassembly(Bytecode::Executable const& executable) const;
     BytecodeMapping const& find_mapping_entry(size_t native_offset) const;
     Optional<UnrealizedSourceRange> get_source_range(Bytecode::Executable const& executable, FlatPtr address) const;
@@ -42,6 +42,7 @@ private:
     void* m_code { nullptr };
     size_t m_size { 0 };
     Vector<BytecodeMapping> m_mapping;
+    Vector<FlatPtr> m_block_entry_points;
     mutable OwnPtr<Bytecode::InstructionStreamIterator> m_instruction_stream_iterator;
 };
 


### PR DESCRIPTION
This leaves 2 instructions to do: EnterObjectEnvironment & ScheduleJump