### PR TITLE
Kernel: Fix kernel panic on zero-length write

### DIFF
--- a/Kernel/Syscalls/write.cpp
+++ b/Kernel/Syscalls/write.cpp
@@ -89,7 +89,8 @@ ErrorOr<FlatPtr> Process::do_write(OpenFileDescription& description, UserOrKerne
                 Thread::current()->send_signal(SIGPIPE, &Process::current());
             return nwritten_or_error.release_error();
         }
-        VERIFY(nwritten_or_error.value() > 0);
+        if (nwritten_or_error.value() == 0)
+            break;
         total_nwritten += nwritten_or_error.value();
     }
     return total_nwritten;


### PR DESCRIPTION
Fixes https://github.com/SerenityOS/serenity/issues/21320. I first found this issue when trying the `composer` port and suspect that this affects many other apps.