### PR TITLE
LibWeb: Wait for SessionHistoryEntries to initialize to avoid crash

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/TraversableNavigable.cpp
+++ b/Userland/Libraries/LibWeb/HTML/TraversableNavigable.cpp
@@ -636,6 +636,10 @@ void finalize_a_same_document_navigation(JS::NonnullGCPtr<TraversableNavigable> 
         // 4. Append targetEntry to targetEntries.
         target_entries.append(target_entry);
     } else {
+        Platform::EventLoopPlugin::the().spin_until([&] {
+            return entry_to_replace->step.has<int>();
+        });
+
         // 1. Replace entryToReplace with targetEntry in targetEntries.
         *(target_entries.find(*entry_to_replace)) = target_entry;
 


### PR DESCRIPTION
It could happen that the SessionHistoryEntry that was to be replaced in finalize_a_same_document_navigation did not yet fully initialize (i.e. step was SessionHistoryEntry::Pending) and thus crashing when continuing. Now we wait for others to finish up the init of the entry before continuing the navigation.

This fixes #21355 