### PR TITLE
Fuzzers: Disable debug logging for all fuzzers

### DIFF
--- a/Meta/Lagom/Fuzzers/FuzzASN1.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzASN1.cpp
@@ -10,6 +10,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
+    AK::set_debug_enabled(false);
     (void)TLS::Certificate::parse_certificate({ data, size });
 
     return 0;

--- a/Meta/Lagom/Fuzzers/FuzzBLAKE2b.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzBLAKE2b.cpp
@@ -10,6 +10,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
+    AK::set_debug_enabled(false);
     Crypto::Hash::BLAKE2b::hash(data, size);
     return 0;
 }

--- a/Meta/Lagom/Fuzzers/FuzzBMPLoader.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzBMPLoader.cpp
@@ -9,6 +9,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
+    AK::set_debug_enabled(false);
     auto decoder_or_error = Gfx::BMPImageDecoderPlugin::create({ data, size });
     if (decoder_or_error.is_error())
         return 0;

--- a/Meta/Lagom/Fuzzers/FuzzBrotli.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzBrotli.cpp
@@ -10,6 +10,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
+    AK::set_debug_enabled(false);
     FixedMemoryStream bufstream { { data, size } };
 
     auto brotli_stream = Compress::BrotliDecompressionStream { MaybeOwned<Stream> { bufstream } };

--- a/Meta/Lagom/Fuzzers/FuzzCSSParser.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzCSSParser.cpp
@@ -24,6 +24,8 @@ Globals::Globals()
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
+    AK::set_debug_enabled(false);
+
     // FIXME: There's got to be a better way to do this "correctly"
     auto& vm = Web::Bindings::main_thread_vm();
     (void)Web::parse_css_stylesheet(Web::CSS::Parser::ParsingContext(*vm.current_realm()), { data, size });

--- a/Meta/Lagom/Fuzzers/FuzzCyrillicDecoder.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzCyrillicDecoder.cpp
@@ -10,6 +10,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
+    AK::set_debug_enabled(false);
     auto decoder = TextCodec::decoder_for("windows-1251"sv);
     VERIFY(decoder.has_value());
     (void)decoder->to_utf8({ data, size });

--- a/Meta/Lagom/Fuzzers/FuzzDDSLoader.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzDDSLoader.cpp
@@ -8,6 +8,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
+    AK::set_debug_enabled(false);
     auto decoder_or_error = Gfx::DDSImageDecoderPlugin::create({ data, size });
     if (decoder_or_error.is_error())
         return 0;

--- a/Meta/Lagom/Fuzzers/FuzzDeflateCompression.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzDeflateCompression.cpp
@@ -9,6 +9,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
+    AK::set_debug_enabled(false);
     (void)Compress::DeflateCompressor::compress_all(ReadonlyBytes { data, size });
     return 0;
 }

--- a/Meta/Lagom/Fuzzers/FuzzDeflateDecompression.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzDeflateDecompression.cpp
@@ -9,6 +9,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
+    AK::set_debug_enabled(false);
     (void)Compress::DeflateDecompressor::decompress_all(ReadonlyBytes { data, size });
     return 0;
 }

--- a/Meta/Lagom/Fuzzers/FuzzELF.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzELF.cpp
@@ -10,6 +10,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
+    AK::set_debug_enabled(false);
     ELF::Image elf(data, size, /*verbose_logging=*/false);
     return 0;
 }

--- a/Meta/Lagom/Fuzzers/FuzzFlacLoader.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzFlacLoader.cpp
@@ -9,5 +9,6 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
+    AK::set_debug_enabled(false);
     return fuzz_audio_loader<Audio::FlacLoaderPlugin>(data, size);
 }

--- a/Meta/Lagom/Fuzzers/FuzzGIFLoader.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzGIFLoader.cpp
@@ -12,6 +12,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
+    AK::set_debug_enabled(false);
     auto decoder_or_error = Gfx::GIFImageDecoderPlugin::create({ data, size });
     if (decoder_or_error.is_error())
         return 0;

--- a/Meta/Lagom/Fuzzers/FuzzGemini.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzGemini.cpp
@@ -12,6 +12,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
+    AK::set_debug_enabled(false);
     auto gemini = StringView(static_cast<unsigned char const*>(data), size);
     (void)Gemini::Document::parse(gemini, {});
     return 0;

--- a/Meta/Lagom/Fuzzers/FuzzGzipCompression.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzGzipCompression.cpp
@@ -9,6 +9,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
+    AK::set_debug_enabled(false);
     (void)Compress::GzipCompressor::compress_all(ReadonlyBytes { data, size });
     return 0;
 }

--- a/Meta/Lagom/Fuzzers/FuzzGzipDecompression.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzGzipDecompression.cpp
@@ -9,6 +9,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
+    AK::set_debug_enabled(false);
     (void)Compress::GzipDecompressor::decompress_all(ReadonlyBytes { data, size });
     return 0;
 }

--- a/Meta/Lagom/Fuzzers/FuzzHebrewDecoder.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzHebrewDecoder.cpp
@@ -10,6 +10,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
+    AK::set_debug_enabled(false);
     auto decoder = TextCodec::decoder_for("windows-1255"sv);
     VERIFY(decoder.has_value());
     (void)decoder->to_utf8({ data, size });

--- a/Meta/Lagom/Fuzzers/FuzzHttpRequest.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzHttpRequest.cpp
@@ -10,6 +10,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
+    AK::set_debug_enabled(false);
     auto request_wrapper = HTTP::HttpRequest::from_raw_request(ReadonlyBytes { data, size });
     if (request_wrapper.is_error())
         return 0;

--- a/Meta/Lagom/Fuzzers/FuzzICCProfile.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzICCProfile.cpp
@@ -10,6 +10,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
+    AK::set_debug_enabled(false);
     (void)Gfx::ICC::Profile::try_load_from_externally_owned_memory({ data, size });
     return 0;
 }

--- a/Meta/Lagom/Fuzzers/FuzzICOLoader.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzICOLoader.cpp
@@ -10,6 +10,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
+    AK::set_debug_enabled(false);
     auto decoder_or_error = Gfx::ICOImageDecoderPlugin::create({ data, size });
     if (decoder_or_error.is_error())
         return 0;

--- a/Meta/Lagom/Fuzzers/FuzzILBMLoader.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzILBMLoader.cpp
@@ -9,6 +9,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
+    AK::set_debug_enabled(false);
     auto decoder_or_error = Gfx::ILBMImageDecoderPlugin::create({ data, size });
     if (decoder_or_error.is_error())
         return 0;

--- a/Meta/Lagom/Fuzzers/FuzzIMAPParser.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzIMAPParser.cpp
@@ -10,6 +10,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
+    AK::set_debug_enabled(false);
     auto parser = IMAP::Parser();
     parser.parse(ByteBuffer::copy(data, size).release_value(), true);
     parser.parse(ByteBuffer::copy(data, size).release_value(), false);

--- a/Meta/Lagom/Fuzzers/FuzzJPEGLoader.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzJPEGLoader.cpp
@@ -10,6 +10,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
+    AK::set_debug_enabled(false);
     auto decoder_or_error = Gfx::JPEGImageDecoderPlugin::create({ data, size });
     if (decoder_or_error.is_error())
         return 0;

--- a/Meta/Lagom/Fuzzers/FuzzJs.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzJs.cpp
@@ -14,6 +14,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
+    AK::set_debug_enabled(false);
     auto js = StringView(static_cast<unsigned char const*>(data), size);
     // FIXME: https://github.com/SerenityOS/serenity/issues/17899
     if (!Utf8View(js).validate())

--- a/Meta/Lagom/Fuzzers/FuzzJsonParser.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzJsonParser.cpp
@@ -8,6 +8,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
+    AK::set_debug_enabled(false);
     JsonParser parser({ data, size });
     (void)parser.parse();
     return 0;

--- a/Meta/Lagom/Fuzzers/FuzzLatin1Decoder.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzLatin1Decoder.cpp
@@ -10,6 +10,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
+    AK::set_debug_enabled(false);
     auto decoder = TextCodec::decoder_for("windows-1252"sv);
     VERIFY(decoder.has_value());
     (void)decoder->to_utf8({ data, size });

--- a/Meta/Lagom/Fuzzers/FuzzLatin2Decoder.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzLatin2Decoder.cpp
@@ -10,6 +10,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
+    AK::set_debug_enabled(false);
     auto decoder = TextCodec::decoder_for("iso-8859-2"sv);
     VERIFY(decoder.has_value());
     (void)decoder->to_utf8({ data, size });

--- a/Meta/Lagom/Fuzzers/FuzzLzmaDecompression.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzLzmaDecompression.cpp
@@ -9,6 +9,8 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
+    AK::set_debug_enabled(false);
+
     // LibFuzzer has a default memory limit of 2048 MB, so limit the dictionary size to a
     // reasonable number to make sure that we don't actually run into it by allocating a
     // huge dictionary. The chosen value is double of what the largest dictionary in the

--- a/Meta/Lagom/Fuzzers/FuzzLzmaRoundtrip.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzLzmaRoundtrip.cpp
@@ -9,6 +9,8 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
+    AK::set_debug_enabled(false);
+
     AllocatingMemoryStream stream {};
 
     auto compressor = MUST(Compress::LzmaCompressor::create_container(MaybeOwned<Stream> { stream }, {}));

--- a/Meta/Lagom/Fuzzers/FuzzMD5.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzMD5.cpp
@@ -10,6 +10,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
+    AK::set_debug_enabled(false);
     Crypto::Hash::MD5::hash(data, size);
     return 0;
 }

--- a/Meta/Lagom/Fuzzers/FuzzMP3Loader.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzMP3Loader.cpp
@@ -9,5 +9,6 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
+    AK::set_debug_enabled(false);
     return fuzz_audio_loader<Audio::MP3LoaderPlugin>(data, size);
 }

--- a/Meta/Lagom/Fuzzers/FuzzMarkdown.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzMarkdown.cpp
@@ -12,6 +12,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
+    AK::set_debug_enabled(false);
     auto markdown = StringView(static_cast<unsigned char const*>(data), size);
     (void)Markdown::Document::parse(markdown);
     return 0;

--- a/Meta/Lagom/Fuzzers/FuzzMatroskaReader.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzMatroskaReader.cpp
@@ -9,6 +9,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(u8 const* data, size_t size)
 {
+    AK::set_debug_enabled(false);
     auto matroska_reader_result = Video::Matroska::Reader::from_data({ data, size });
     if (matroska_reader_result.is_error())
         return 0;

--- a/Meta/Lagom/Fuzzers/FuzzPBMLoader.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzPBMLoader.cpp
@@ -10,6 +10,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
+    AK::set_debug_enabled(false);
     auto decoder_or_error = Gfx::PBMImageDecoderPlugin::create({ data, size });
     if (decoder_or_error.is_error())
         return 0;

--- a/Meta/Lagom/Fuzzers/FuzzPDF.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzPDF.cpp
@@ -9,6 +9,8 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
+    AK::set_debug_enabled(false);
+
     ReadonlyBytes bytes { data, size };
 
     if (auto maybe_document = PDF::Document::create(bytes); !maybe_document.is_error()) {

--- a/Meta/Lagom/Fuzzers/FuzzPEM.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzPEM.cpp
@@ -10,6 +10,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
+    AK::set_debug_enabled(false);
     (void)Crypto::decode_pem({ data, size });
     return 0;
 }

--- a/Meta/Lagom/Fuzzers/FuzzPGMLoader.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzPGMLoader.cpp
@@ -10,6 +10,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
+    AK::set_debug_enabled(false);
     auto decoder_or_error = Gfx::PGMImageDecoderPlugin::create({ data, size });
     if (decoder_or_error.is_error())
         return 0;

--- a/Meta/Lagom/Fuzzers/FuzzPNGLoader.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzPNGLoader.cpp
@@ -10,6 +10,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
+    AK::set_debug_enabled(false);
     auto decoder_or_error = Gfx::PNGImageDecoderPlugin::create({ data, size });
     if (decoder_or_error.is_error())
         return 0;

--- a/Meta/Lagom/Fuzzers/FuzzPPMLoader.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzPPMLoader.cpp
@@ -10,6 +10,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
+    AK::set_debug_enabled(false);
     auto decoder_or_error = Gfx::PPMImageDecoderPlugin::create({ data, size });
     if (decoder_or_error.is_error())
         return 0;

--- a/Meta/Lagom/Fuzzers/FuzzPoly1305.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzPoly1305.cpp
@@ -4,12 +4,15 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Format.h>
 #include <LibCrypto/Authentication/Poly1305.h>
 #include <stddef.h>
 #include <stdint.h>
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
+    AK::set_debug_enabled(false);
+
     if (size < 32)
         return 0;
 

--- a/Meta/Lagom/Fuzzers/FuzzQOALoader.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzQOALoader.cpp
@@ -9,5 +9,6 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
+    AK::set_debug_enabled(false);
     return fuzz_audio_loader<Audio::QOALoaderPlugin>(data, size);
 }

--- a/Meta/Lagom/Fuzzers/FuzzQOILoader.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzQOILoader.cpp
@@ -10,6 +10,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
+    AK::set_debug_enabled(false);
     auto decoder_or_error = Gfx::QOIImageDecoderPlugin::create({ data, size });
     if (decoder_or_error.is_error())
         return 0;

--- a/Meta/Lagom/Fuzzers/FuzzQuotedPrintableParser.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzQuotedPrintableParser.cpp
@@ -4,11 +4,13 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Format.h>
 #include <AK/StringView.h>
 #include <LibIMAP/QuotedPrintable.h>
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
+    AK::set_debug_enabled(false);
     auto quoted_printable_string = StringView(static_cast<unsigned char const*>(data), size);
     (void)IMAP::decode_quoted_printable(quoted_printable_string);
     return 0;

--- a/Meta/Lagom/Fuzzers/FuzzRSAKeyParsing.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzRSAKeyParsing.cpp
@@ -10,6 +10,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
+    AK::set_debug_enabled(false);
     Crypto::PK::RSA::parse_rsa_key({ data, size });
     return 0;
 }

--- a/Meta/Lagom/Fuzzers/FuzzRegexECMA262.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzRegexECMA262.cpp
@@ -11,6 +11,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
+    AK::set_debug_enabled(false);
     auto pattern = StringView(static_cast<unsigned char const*>(data), size);
     [[maybe_unused]] auto re = Regex<ECMA262>(pattern);
     return 0;

--- a/Meta/Lagom/Fuzzers/FuzzRegexPosixBasic.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzRegexPosixBasic.cpp
@@ -11,6 +11,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
+    AK::set_debug_enabled(false);
     auto pattern = StringView(static_cast<unsigned char const*>(data), size);
     [[maybe_unused]] auto re = Regex<PosixBasic>(pattern);
     return 0;

--- a/Meta/Lagom/Fuzzers/FuzzRegexPosixExtended.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzRegexPosixExtended.cpp
@@ -11,6 +11,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
+    AK::set_debug_enabled(false);
     auto pattern = StringView(static_cast<unsigned char const*>(data), size);
     [[maybe_unused]] auto re = Regex<PosixExtended>(pattern);
     return 0;

--- a/Meta/Lagom/Fuzzers/FuzzSHA1.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzSHA1.cpp
@@ -10,6 +10,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
+    AK::set_debug_enabled(false);
     Crypto::Hash::SHA1::hash(data, size);
     return 0;
 }

--- a/Meta/Lagom/Fuzzers/FuzzSHA256.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzSHA256.cpp
@@ -10,6 +10,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
+    AK::set_debug_enabled(false);
     Crypto::Hash::SHA256::hash(data, size);
     return 0;
 }

--- a/Meta/Lagom/Fuzzers/FuzzSHA384.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzSHA384.cpp
@@ -10,6 +10,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
+    AK::set_debug_enabled(false);
     Crypto::Hash::SHA384::hash(data, size);
     return 0;
 }

--- a/Meta/Lagom/Fuzzers/FuzzSHA512.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzSHA512.cpp
@@ -10,6 +10,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
+    AK::set_debug_enabled(false);
     Crypto::Hash::SHA512::hash(data, size);
     return 0;
 }

--- a/Meta/Lagom/Fuzzers/FuzzSQLParser.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzSQLParser.cpp
@@ -10,6 +10,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
+    AK::set_debug_enabled(false);
     auto parser = SQL::AST::Parser(SQL::AST::Lexer({ data, size }));
     [[maybe_unused]] auto statement = parser.next_statement();
     return 0;

--- a/Meta/Lagom/Fuzzers/FuzzShell.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzShell.cpp
@@ -11,6 +11,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
+    AK::set_debug_enabled(false);
     auto source = StringView(static_cast<unsigned char const*>(data), size);
     Shell::Parser parser(source);
     (void)parser.parse();

--- a/Meta/Lagom/Fuzzers/FuzzShellPosix.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzShellPosix.cpp
@@ -12,6 +12,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
+    AK::set_debug_enabled(false);
     auto source = StringView(static_cast<unsigned char const*>(data), size);
     Shell::Posix::Parser parser(source);
     (void)parser.parse();

--- a/Meta/Lagom/Fuzzers/FuzzTGALoader.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzTGALoader.cpp
@@ -10,6 +10,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
+    AK::set_debug_enabled(false);
     auto decoder_or_error = Gfx::TGAImageDecoderPlugin::create({ data, size });
     if (decoder_or_error.is_error())
         return 0;

--- a/Meta/Lagom/Fuzzers/FuzzTTF.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzTTF.cpp
@@ -10,6 +10,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(u8 const* data, size_t size)
 {
+    AK::set_debug_enabled(false);
     (void)OpenType::Font::try_load_from_externally_owned_memory({ data, size });
     return 0;
 }

--- a/Meta/Lagom/Fuzzers/FuzzTar.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzTar.cpp
@@ -11,6 +11,8 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
+    AK::set_debug_enabled(false);
+
     auto input_stream_or_error = try_make<FixedMemoryStream>(ReadonlyBytes { data, size });
 
     if (input_stream_or_error.is_error())

--- a/Meta/Lagom/Fuzzers/FuzzTinyVGLoader.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzTinyVGLoader.cpp
@@ -8,6 +8,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
+    AK::set_debug_enabled(false);
     auto decoder_or_error = Gfx::TinyVGImageDecoderPlugin::create({ data, size });
     if (decoder_or_error.is_error())
         return 0;

--- a/Meta/Lagom/Fuzzers/FuzzURL.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzURL.cpp
@@ -8,6 +8,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
+    AK::set_debug_enabled(false);
     auto string_view = StringView(data, size);
     auto url = URL(string_view);
     return 0;

--- a/Meta/Lagom/Fuzzers/FuzzUTF16BEDecoder.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzUTF16BEDecoder.cpp
@@ -10,6 +10,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
+    AK::set_debug_enabled(false);
     auto decoder = TextCodec::decoder_for("utf-16be"sv);
     VERIFY(decoder.has_value());
     (void)decoder->to_utf8({ data, size });

--- a/Meta/Lagom/Fuzzers/FuzzVP9Decoder.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzVP9Decoder.cpp
@@ -9,6 +9,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(u8 const* data, size_t size)
 {
+    AK::set_debug_enabled(false);
     Video::VP9::Decoder vp9_decoder;
     (void)vp9_decoder.receive_sample({ data, size });
     return 0;

--- a/Meta/Lagom/Fuzzers/FuzzWAVLoader.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzWAVLoader.cpp
@@ -9,5 +9,6 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
+    AK::set_debug_enabled(false);
     return fuzz_audio_loader<Audio::WavLoaderPlugin>(data, size);
 }

--- a/Meta/Lagom/Fuzzers/FuzzWOFF.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzWOFF.cpp
@@ -9,6 +9,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(u8 const* data, size_t size)
 {
+    AK::set_debug_enabled(false);
     (void)WOFF::Font::try_load_from_externally_owned_memory({ data, size });
     return 0;
 }

--- a/Meta/Lagom/Fuzzers/FuzzWOFF2.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzWOFF2.cpp
@@ -9,6 +9,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(u8 const* data, size_t size)
 {
+    AK::set_debug_enabled(false);
     (void)WOFF2::Font::try_load_from_externally_owned_memory({ data, size });
     return 0;
 }

--- a/Meta/Lagom/Fuzzers/FuzzWasmParser.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzWasmParser.cpp
@@ -11,6 +11,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
+    AK::set_debug_enabled(false);
     ReadonlyBytes bytes { data, size };
     FixedMemoryStream stream { bytes };
     [[maybe_unused]] auto result = Wasm::Module::parse(stream);

--- a/Meta/Lagom/Fuzzers/FuzzWebPLoader.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzWebPLoader.cpp
@@ -10,6 +10,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
+    AK::set_debug_enabled(false);
     auto decoder_or_error = Gfx::WebPImageDecoderPlugin::create({ data, size });
     if (decoder_or_error.is_error())
         return 0;

--- a/Meta/Lagom/Fuzzers/FuzzXML.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzXML.cpp
@@ -8,6 +8,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(u8 const* data, size_t size)
 {
+    AK::set_debug_enabled(false);
     XML::Parser parser({ data, size });
     (void)parser.parse();
     return 0;

--- a/Meta/Lagom/Fuzzers/FuzzZip.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzZip.cpp
@@ -10,6 +10,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
+    AK::set_debug_enabled(false);
     auto zip_file = Archive::Zip::try_create({ data, size });
     if (!zip_file.has_value())
         return 0;

--- a/Meta/Lagom/Fuzzers/FuzzZlibDecompression.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzZlibDecompression.cpp
@@ -10,6 +10,8 @@
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
+    AK::set_debug_enabled(false);
+
     auto stream = make<FixedMemoryStream>(ReadonlyBytes { data, size });
 
     auto decompressor_or_error = Compress::ZlibDecompressor::create(move(stream));


### PR DESCRIPTION
Previously, some fuzzers were generating an excessive amount of debug logging. This change explicitly disables debug logging for all fuzzers. This allows higher test throughput and makes the logs easier to read when fuzzing locally.

Here's the OSS-Fuzz fuzzer statistics page, listing the fuzzers with the most unwanted log lines:

![fuzzer_statistics_excessive_logging](https://github.com/SerenityOS/serenity/assets/2817754/7d39454a-e95d-4e09-8e5d-3f43d40a1458)
