### PR TITLE
LibWeb: Skip assigning slottables inserting nodes under non-shadow roots

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Node.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Node.cpp
@@ -456,8 +456,8 @@ void Node::insert_before(JS::NonnullGCPtr<Node> node, JS::GCPtr<Node> child, boo
             auto is_named_shadow_host = element.is_shadow_host()
                 && element.shadow_root_internal()->slot_assignment() == Bindings::SlotAssignmentMode::Named;
 
-            if (is_named_shadow_host && node->is_slottable())
-                assign_a_slot(node->as_slottable());
+            if (is_named_shadow_host && node_to_insert->is_slottable())
+                assign_a_slot(node_to_insert->as_slottable());
         }
 
         // 5. If parent’s root is a shadow root, and parent is a slot whose assigned nodes is the empty list, then run
@@ -470,7 +470,7 @@ void Node::insert_before(JS::NonnullGCPtr<Node> node, JS::GCPtr<Node> child, boo
         }
 
         // 6. Run assign slottables for a tree with node’s root.
-        assign_slottables_for_a_tree(node->root());
+        assign_slottables_for_a_tree(node_to_insert->root());
 
         node_to_insert->invalidate_style();
 

--- a/Userland/Libraries/LibWeb/DOM/Slottable.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Slottable.cpp
@@ -176,6 +176,12 @@ void assign_slottables(JS::NonnullGCPtr<HTML::HTMLSlotElement> slot)
 // https://dom.spec.whatwg.org/#assign-slotables-for-a-tree
 void assign_slottables_for_a_tree(JS::NonnullGCPtr<Node> root)
 {
+    // AD-HOC: This method iterates over the root's entire subtree. That iteration does nothing if the root is not a
+    //         shadow root (see `find_slottables`). This iteration can be very expensive as the HTML parser inserts
+    //         nodes, especially on sites with many elements. So we skip it if we know it's going to be a no-op anyways.
+    if (!root->is_shadow_root())
+        return;
+
     // To assign slottables for a tree, given a node root, run assign slottables for each slot slot in root’s inclusive
     // descendants, in tree order.
     root->for_each_in_inclusive_subtree_of_type<HTML::HTMLSlotElement>([](auto& slot) {


### PR DESCRIPTION
For example, on https://html.spec.whatwg.org/, there are hundreds of
thousands of nodes. Traversing the entire tree as each of them become
inserted takes a prohibitively long time.