### PR TITLE
LibLine: Do not clear the buffer on interrupt

### DIFF
--- a/Userland/Libraries/LibLine/Editor.cpp
+++ b/Userland/Libraries/LibLine/Editor.cpp
@@ -817,13 +817,13 @@ void Editor::handle_interrupt_event()
 
     m_previous_interrupt_was_handled_as_interrupt = true;
 
+    insert("^C"sv);
     fprintf(stderr, "^C");
     fflush(stderr);
 
     if (on_interrupt_handled)
         on_interrupt_handled();
 
-    m_buffer.clear();
     m_chars_touched_in_the_middle = buffer().size();
     m_cursor = 0;
 


### PR DESCRIPTION
Discarding all the characters that happen to be in the buffer prior to handling an interrupt causes us to permanently lose track of those characters, which prevents us from redrawing them when refresh_display() gets called.

This patch also appends the '^C' string to the buffer in addition to printing it to stderr when an interrupt is handled.