### PR TITLE
LibJS: Stash thrown exception in a register before executing finalizer 

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/Register.h
+++ b/Userland/Libraries/LibJS/Bytecode/Register.h
@@ -45,7 +45,13 @@ public:
         return Register(return_value_index);
     }
 
-    static constexpr u32 reserved_register_count = 5;
+    static constexpr Register saved_exception()
+    {
+        constexpr u32 saved_exception_index = 5;
+        return Register(saved_exception_index);
+    }
+
+    static constexpr u32 reserved_register_count = 6;
 
     constexpr explicit Register(u32 index)
         : m_index(index)

--- a/Userland/Libraries/LibJS/JIT/Compiler.cpp
+++ b/Userland/Libraries/LibJS/JIT/Compiler.cpp
@@ -426,7 +426,6 @@ void Compiler::check_exception()
         m_assembler.jump(label_for(*handler));
         no_exception.link(m_assembler);
     } else if (auto const* finalizer = current_block().finalizer(); finalizer) {
-        store_vm_register(Bytecode::Register::exception(), GPR1);
         m_assembler.jump_if(Assembler::Operand::Register(GPR0),
             Assembler::Condition::NotEqualTo,
             Assembler::Operand::Register(GPR1),


### PR DESCRIPTION
This kills 2 birds with one stone:
1. It makes sure generated check_exception() calls in the finalizer don't mis-read the pending exception as caused by their matching operation.
2. It implicitly ensures that terminated finally blocks (by a return statement) overwrite any pending exceptions, since they will never execute the ContinuePendingUnwind operation that restores the stashed exception.

This additional logic is required in the JIT (as opposed to the interpreter), since the JIT uses the exception register to store and check the possibly-exceptional results from each individual operation, while the interpreter only modifies it when an operation has thrown an exception.