### PR TITLE
LibWeb: Consider colgroups while calculating table grid size

### DIFF
--- a/Tests/LibWeb/Layout/expected/table/colgroup-with-two-cols.txt
+++ b/Tests/LibWeb/Layout/expected/table/colgroup-with-two-cols.txt
@@ -1,0 +1,16 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x2 children: not-inline
+      TableWrapper <(anonymous)> at (8,8) content-size 6x2 [BFC] children: not-inline
+        Box <table> at (8,8) content-size 6x2 table-box [TFC] children: not-inline
+          BlockContainer <colgroup#my-group> (not painted) table-column-group children: not-inline
+            BlockContainer <col> (not painted) children: not-inline
+            BlockContainer <col> (not painted) children: not-inline
+          Box <tbody> at (8,8) content-size 0x0 table-row-group children: not-inline
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x2]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 6x2]
+        PaintableBox (Box<TABLE>) [8,8 6x2]
+          PaintableBox (Box<TBODY>) [8,8 0x0]

--- a/Tests/LibWeb/Layout/input/table/colgroup-with-two-cols.html
+++ b/Tests/LibWeb/Layout/input/table/colgroup-with-two-cols.html
@@ -1,0 +1,1 @@
+<table><colgroup id="my-group"><col width="40"><col></colgroup><tbody></tbody></table>

--- a/Userland/Libraries/LibWeb/Layout/TableGrid.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TableGrid.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibWeb/HTML/HTMLTableCellElement.h>
+#include <LibWeb/HTML/HTMLTableColElement.h>
 #include <LibWeb/Layout/TableGrid.h>
 
 namespace Web::Layout {
@@ -61,6 +62,18 @@ TableGrid TableGrid::calculate_row_column_grid(Box const& box, Vector<Cell>& cel
         rows.append(Row { row });
         y_current++;
     };
+
+    auto process_col_group = [&](auto& col_group) {
+        auto dom_node = col_group.dom_node();
+        dom_node->template for_each_in_subtree_of_type<HTML::HTMLTableColElement>([&](auto&) {
+            x_width += 1;
+            return IterationDecision::Continue;
+        });
+    };
+
+    for_each_child_box_matching(box, is_table_column_group, [&](auto& column_group_box) {
+        process_col_group(column_group_box);
+    });
 
     for_each_child_box_matching(box, is_table_row_group, [&](auto& row_group_box) {
         for_each_child_box_matching(row_group_box, is_table_row, [&](auto& row_box) {

--- a/Userland/Libraries/LibWeb/Layout/TableGrid.h
+++ b/Userland/Libraries/LibWeb/Layout/TableGrid.h
@@ -65,6 +65,11 @@ public:
         return box.display().is_table_row();
     }
 
+    static bool is_table_column_group(Box const& box)
+    {
+        return box.display().is_table_column_group();
+    }
+
     template<typename Matcher, typename Callback>
     static void for_each_child_box_matching(Box const& parent, Matcher matcher, Callback callback)
     {


### PR DESCRIPTION
We should take in account <col> elements in column groups while finding number of columns in a table.