### PR TITLE
Kernel: Allow negative value for backlog in sys$listen

### DIFF
--- a/Kernel/Syscalls/socket.cpp
+++ b/Kernel/Syscalls/socket.cpp
@@ -66,7 +66,7 @@ ErrorOr<FlatPtr> Process::sys$listen(int sockfd, int backlog)
 {
     VERIFY_NO_PROCESS_BIG_LOCK(this);
     if (backlog < 0)
-        return EINVAL;
+        backlog = 0;
     auto description = TRY(open_file_description(sockfd));
     if (!description->is_socket())
         return ENOTSOCK;


### PR DESCRIPTION
From `listen(3p)`: "If listen() is called with a backlog argument value that is less than 0, the function behaves as if it had been called with a backlog argument value of 0."