### PR TITLE
FileManager: Migrate from DeprecatedString to String 

### DIFF
--- a/AK/URL.h
+++ b/AK/URL.h
@@ -97,6 +97,7 @@ public:
     void set_host(Host);
     void set_port(Optional<u16>);
     void set_paths(Vector<DeprecatedString> const&);
+    void set_paths(Vector<String> const&);
     void set_query(Optional<String> query) { m_query = move(query); }
     void set_fragment(Optional<String> fragment) { m_fragment = move(fragment); }
     void set_cannot_be_a_base_url(bool value) { m_cannot_be_a_base_url = value; }
@@ -132,6 +133,7 @@ public:
 
     static URL create_with_url_or_path(DeprecatedString const&);
     static URL create_with_file_scheme(DeprecatedString const& path, DeprecatedString const& fragment = {}, DeprecatedString const& hostname = {});
+    static URL create_with_file_scheme(String const& path, String const& fragment = {}, String const& hostname = {});
     static URL create_with_help_scheme(DeprecatedString const& path, DeprecatedString const& fragment = {}, DeprecatedString const& hostname = {});
     static URL create_with_data(StringView mime_type, StringView payload, bool is_base64 = false);
 

--- a/Userland/Applications/FileManager/DirectoryView.h
+++ b/Userland/Applications/FileManager/DirectoryView.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <AK/String.h>
+#include <AK/StringView.h>
 #include <AK/URL.h>
 #include <AK/Vector.h>
 #include <LibConfig/Listener.h>
@@ -51,8 +53,8 @@ public:
 
     virtual ~DirectoryView() override;
 
-    bool open(DeprecatedString const& path);
-    DeprecatedString path() const { return model().root_path(); }
+    bool open(StringView const& path);
+    String path() const { return MUST(String::from_deprecated_string(model().root_path())); }
     void open_parent_directory();
     void open_previous_directory();
     void open_next_directory();
@@ -60,7 +62,7 @@ public:
     int path_history_position() const { return m_path_history_position; }
     static RefPtr<LauncherHandler> get_default_launch_handler(Vector<NonnullRefPtr<LauncherHandler>> const& handlers);
     static Vector<NonnullRefPtr<LauncherHandler>> get_launch_handlers(URL const& url);
-    static Vector<NonnullRefPtr<LauncherHandler>> get_launch_handlers(DeprecatedString const& path);
+    static Vector<NonnullRefPtr<LauncherHandler>> get_launch_handlers(String const& path);
 
     void refresh();
 
@@ -82,7 +84,7 @@ public:
     void set_view_mode(ViewMode);
     ViewMode view_mode() const { return m_view_mode; }
 
-    void set_view_mode_from_string(DeprecatedString const&);
+    void set_view_mode_from_string(StringView const&);
 
     GUI::AbstractView& current_view()
     {
@@ -120,7 +122,7 @@ public:
 
     bool is_desktop() const { return m_mode == Mode::Desktop; }
 
-    Vector<DeprecatedString> selected_file_paths() const;
+    Vector<String> selected_file_paths() const;
 
     GUI::Action& mkdir_action() { return *m_mkdir_action; }
     GUI::Action& touch_action() { return *m_touch_action; }
@@ -166,8 +168,8 @@ private:
     NonnullRefPtr<GUI::FileSystemModel> m_model;
     NonnullRefPtr<GUI::SortingProxyModel> m_sorting_model;
     size_t m_path_history_position { 0 };
-    Vector<DeprecatedString> m_path_history;
-    void add_path_to_history(DeprecatedString);
+    Vector<String> m_path_history;
+    void add_path_to_history(String);
 
     RefPtr<GUI::Label> m_error_label;
 

--- a/Userland/Applications/FileManager/FileOperationProgressWidget.cpp
+++ b/Userland/Applications/FileManager/FileOperationProgressWidget.cpp
@@ -138,38 +138,38 @@ void FileOperationProgressWidget::did_error(StringView message)
     window()->close();
 }
 
-DeprecatedString FileOperationProgressWidget::estimate_time(off_t bytes_done, off_t total_byte_count)
+ErrorOr<String> FileOperationProgressWidget::estimate_time(off_t bytes_done, off_t total_byte_count)
 {
     i64 const elapsed_seconds = m_elapsed_timer.elapsed_time().to_seconds();
 
     if (bytes_done == 0 || elapsed_seconds < 3)
-        return "Estimating...";
+        return "Estimating..."_string;
 
     off_t bytes_left = total_byte_count - bytes_done;
     int seconds_remaining = (bytes_left * elapsed_seconds) / bytes_done;
 
     if (seconds_remaining < 30)
-        return DeprecatedString::formatted("{} seconds", 5 + seconds_remaining - seconds_remaining % 5);
+        return String::formatted("{} seconds", 5 + seconds_remaining - seconds_remaining % 5);
     if (seconds_remaining < 60)
-        return "About a minute";
+        return "About a minute"_string;
     if (seconds_remaining < 90)
-        return "Over a minute";
+        return "Over a minute"_string;
     if (seconds_remaining < 120)
-        return "Less than two minutes";
+        return "Less than two minutes"_string;
 
     time_t minutes_remaining = seconds_remaining / 60;
     seconds_remaining %= 60;
 
     if (minutes_remaining < 60) {
         if (seconds_remaining < 30)
-            return DeprecatedString::formatted("About {} minutes", minutes_remaining);
-        return DeprecatedString::formatted("Over {} minutes", minutes_remaining);
+            return String::formatted("About {} minutes", minutes_remaining);
+        return String::formatted("Over {} minutes", minutes_remaining);
     }
 
     time_t hours_remaining = minutes_remaining / 60;
     minutes_remaining %= 60;
 
-    return DeprecatedString::formatted("{} hours and {} minutes", hours_remaining, minutes_remaining);
+    return String::formatted("{} hours and {} minutes", hours_remaining, minutes_remaining);
 }
 
 void FileOperationProgressWidget::did_progress(off_t bytes_done, off_t total_byte_count, size_t files_done, size_t total_file_count, [[maybe_unused]] off_t current_file_done, [[maybe_unused]] off_t current_file_size, StringView current_filename)
@@ -195,7 +195,7 @@ void FileOperationProgressWidget::did_progress(off_t bytes_done, off_t total_byt
         VERIFY_NOT_REACHED();
     }
 
-    estimated_time_label.set_text(String::from_deprecated_string(estimate_time(bytes_done, total_byte_count)).release_value_but_fixme_should_propagate_errors());
+    estimated_time_label.set_text(estimate_time(bytes_done, total_byte_count).release_value_but_fixme_should_propagate_errors());
 
     if (total_byte_count) {
         window()->set_progress(100.0f * bytes_done / total_byte_count);

--- a/Userland/Applications/FileManager/FileOperationProgressWidget.h
+++ b/Userland/Applications/FileManager/FileOperationProgressWidget.h
@@ -29,7 +29,7 @@ private:
 
     void close_pipe();
 
-    DeprecatedString estimate_time(off_t bytes_done, off_t total_byte_count);
+    ErrorOr<String> estimate_time(off_t bytes_done, off_t total_byte_count);
     Core::ElapsedTimer m_elapsed_timer;
 
     FileOperation m_operation;

--- a/Userland/Applications/FileManager/FileUtils.cpp
+++ b/Userland/Applications/FileManager/FileUtils.cpp
@@ -19,11 +19,11 @@ namespace FileManager {
 
 HashTable<NonnullRefPtr<GUI::Window>> file_operation_windows;
 
-void delete_paths(Vector<DeprecatedString> const& paths, bool should_confirm, GUI::Window* parent_window)
+void delete_paths(Vector<String> const& paths, bool should_confirm, GUI::Window* parent_window)
 {
     DeprecatedString message;
     if (paths.size() == 1) {
-        message = DeprecatedString::formatted("Are you sure you want to delete \"{}\"?", LexicalPath::basename(paths[0]));
+        message = DeprecatedString::formatted("Are you sure you want to delete \"{}\"?", LexicalPath::basename(paths[0].to_deprecated_string()));
     } else {
         message = DeprecatedString::formatted("Are you sure you want to delete {} files?", paths.size());
     }
@@ -42,7 +42,7 @@ void delete_paths(Vector<DeprecatedString> const& paths, bool should_confirm, GU
         _exit(1);
 }
 
-ErrorOr<void> run_file_operation(FileOperation operation, Vector<DeprecatedString> const& sources, DeprecatedString const& destination, GUI::Window* parent_window)
+ErrorOr<void> run_file_operation(FileOperation operation, Vector<String> const& sources, String const& destination, GUI::Window* parent_window)
 {
     auto pipe_fds = TRY(Core::System::pipe2(0));
 
@@ -70,10 +70,10 @@ ErrorOr<void> run_file_operation(FileOperation operation, Vector<DeprecatedStrin
         }
 
         for (auto& source : sources)
-            file_operation_args.append(source.view());
+            file_operation_args.append(source);
 
         if (operation != FileOperation::Delete)
-            file_operation_args.append(destination.view());
+            file_operation_args.append(destination);
 
         TRY(Core::System::exec(file_operation_args.first(), file_operation_args, Core::System::SearchInPath::Yes));
         VERIFY_NOT_REACHED();
@@ -110,7 +110,7 @@ ErrorOr<void> run_file_operation(FileOperation operation, Vector<DeprecatedStrin
     return {};
 }
 
-ErrorOr<bool> handle_drop(GUI::DropEvent const& event, DeprecatedString const& destination, GUI::Window* window)
+ErrorOr<bool> handle_drop(GUI::DropEvent const& event, String const& destination, GUI::Window* window)
 {
     bool has_accepted_drop = false;
 
@@ -122,12 +122,12 @@ ErrorOr<bool> handle_drop(GUI::DropEvent const& event, DeprecatedString const& d
         return has_accepted_drop;
     }
 
-    auto const target = LexicalPath::canonicalized_path(destination);
+    auto const target = TRY(String::from_deprecated_string(LexicalPath::canonicalized_path(destination.bytes_as_string_view())));
 
     if (!FileSystem::is_directory(target))
         return has_accepted_drop;
 
-    Vector<DeprecatedString> paths_to_copy;
+    Vector<String> paths_to_copy;
     for (auto& url_to_copy : urls) {
         auto file_path = url_to_copy.serialize_path();
         if (!url_to_copy.is_valid() || file_path == target)
@@ -136,7 +136,7 @@ ErrorOr<bool> handle_drop(GUI::DropEvent const& event, DeprecatedString const& d
         if (file_path == new_path)
             continue;
 
-        paths_to_copy.append(file_path);
+        paths_to_copy.append(TRY(String::from_deprecated_string(file_path)));
         has_accepted_drop = true;
     }
 

--- a/Userland/Applications/FileManager/FileUtils.h
+++ b/Userland/Applications/FileManager/FileUtils.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <AK/DeprecatedString.h>
+#include <AK/String.h>
 #include <LibCore/Forward.h>
 #include <LibGUI/Forward.h>
 
@@ -19,8 +19,8 @@ enum class FileOperation {
     Delete,
 };
 
-void delete_paths(Vector<DeprecatedString> const&, bool should_confirm, GUI::Window*);
+void delete_paths(Vector<String> const&, bool should_confirm, GUI::Window*);
 
-ErrorOr<void> run_file_operation(FileOperation, Vector<DeprecatedString> const& sources, DeprecatedString const& destination, GUI::Window*);
-ErrorOr<bool> handle_drop(GUI::DropEvent const& event, DeprecatedString const& destination, GUI::Window* window);
+ErrorOr<void> run_file_operation(FileOperation, Vector<String> const& sources, String const& destination, GUI::Window*);
+ErrorOr<bool> handle_drop(GUI::DropEvent const& event, String const& destination, GUI::Window* window);
 }

--- a/Userland/Applications/FileManager/PropertiesWindow.h
+++ b/Userland/Applications/FileManager/PropertiesWindow.h
@@ -20,13 +20,13 @@ class PropertiesWindow final : public GUI::Window {
     C_OBJECT(PropertiesWindow);
 
 public:
-    static ErrorOr<NonnullRefPtr<PropertiesWindow>> try_create(DeprecatedString const& path, bool disable_rename, Window* parent = nullptr);
+    static ErrorOr<NonnullRefPtr<PropertiesWindow>> try_create(String const& path, bool disable_rename, Window* parent = nullptr);
     virtual ~PropertiesWindow() override = default;
 
     virtual void close() final;
 
 private:
-    PropertiesWindow(DeprecatedString const& path, Window* parent = nullptr);
+    PropertiesWindow(String const& path, Window* parent = nullptr);
     ErrorOr<void> create_widgets(bool disable_rename);
     ErrorOr<void> create_general_tab(GUI::TabWidget&, bool disable_rename);
     ErrorOr<void> create_file_type_specific_tabs(GUI::TabWidget&);
@@ -44,7 +44,7 @@ private:
 
     class DirectoryStatisticsCalculator final : public RefCounted<DirectoryStatisticsCalculator> {
     public:
-        DirectoryStatisticsCalculator(DeprecatedString path);
+        DirectoryStatisticsCalculator(String path);
         void start();
         void stop();
         Function<void(off_t total_size_in_bytes, size_t file_count, size_t directory_count)> on_update;
@@ -54,7 +54,7 @@ private:
         size_t m_file_count { 0 };
         size_t m_directory_count { 0 };
         RefPtr<Threading::BackgroundAction<int>> m_background_action;
-        Queue<DeprecatedString> m_work_queue;
+        Queue<String> m_work_queue;
     };
 
     static StringView const get_description(mode_t const mode)
@@ -84,7 +84,7 @@ private:
     void permission_changed(mode_t mask, bool set);
     bool apply_changes();
     void update();
-    DeprecatedString make_full_path(DeprecatedString const& name);
+    String make_full_path(String const& name);
 
     RefPtr<GUI::Button> m_apply_button;
     RefPtr<GUI::TextBox> m_name_box;
@@ -92,9 +92,9 @@ private:
     RefPtr<GUI::Label> m_size_label;
     RefPtr<DirectoryStatisticsCalculator> m_directory_statistics_calculator;
     RefPtr<GUI::Action> m_on_escape;
-    DeprecatedString m_name;
-    DeprecatedString m_parent_path;
-    DeprecatedString m_path;
+    String m_name;
+    String m_parent_path;
+    String m_path;
     mode_t m_mode { 0 };
     mode_t m_old_mode { 0 };
     bool m_permissions_dirty { false };

--- a/Userland/Applications/FileManager/main.cpp
+++ b/Userland/Applications/FileManager/main.cpp
@@ -59,15 +59,15 @@
 using namespace FileManager;
 
 static ErrorOr<int> run_in_desktop_mode();
-static ErrorOr<int> run_in_windowed_mode(DeprecatedString const& initial_location, DeprecatedString const& entry_focused_on_init);
-static void do_copy(Vector<DeprecatedString> const& selected_file_paths, FileOperation file_operation);
-static void do_paste(DeprecatedString const& target_directory, GUI::Window* window);
-static void do_create_link(Vector<DeprecatedString> const& selected_file_paths, GUI::Window* window);
-static void do_create_archive(Vector<DeprecatedString> const& selected_file_paths, GUI::Window* window);
-static void do_set_wallpaper(DeprecatedString const& file_path, GUI::Window* window);
-static void do_unzip_archive(Vector<DeprecatedString> const& selected_file_paths, GUI::Window* window);
-static void show_properties(DeprecatedString const& container_dir_path, DeprecatedString const& path, Vector<DeprecatedString> const& selected, GUI::Window* window);
-static bool add_launch_handler_actions_to_menu(RefPtr<GUI::Menu>& menu, DirectoryView const& directory_view, DeprecatedString const& full_path, RefPtr<GUI::Action>& default_action, Vector<NonnullRefPtr<LauncherHandler>>& current_file_launch_handlers);
+static ErrorOr<int> run_in_windowed_mode(String const& initial_location, String const& entry_focused_on_init);
+static void do_copy(Vector<String> const& selected_file_paths, FileOperation file_operation);
+static void do_paste(String const& target_directory, GUI::Window* window);
+static void do_create_link(Vector<String> const& selected_file_paths, GUI::Window* window);
+static void do_create_archive(Vector<String> const& selected_file_paths, GUI::Window* window);
+static void do_set_wallpaper(String const& file_path, GUI::Window* window);
+static void do_unzip_archive(Vector<String> const& selected_file_paths, GUI::Window* window);
+static void show_properties(String const& container_dir_path, String const& path, Vector<String> const& selected, GUI::Window* window);
+static bool add_launch_handler_actions_to_menu(RefPtr<GUI::Menu>& menu, DirectoryView const& directory_view, String const& full_path, RefPtr<GUI::Action>& default_action, Vector<NonnullRefPtr<LauncherHandler>>& current_file_launch_handlers);
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
@@ -82,7 +82,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     bool is_desktop_mode { false };
     bool is_selection_mode { false };
     bool ignore_path_resolution { false };
-    DeprecatedString initial_location;
+    String initial_location;
     args_parser.add_option(is_desktop_mode, "Run in desktop mode", "desktop", 'd');
     args_parser.add_option(is_selection_mode, "Show entry in parent folder", "select", 's');
     args_parser.add_option(ignore_path_resolution, "Use raw path, do not resolve real path", "raw", 'r');
@@ -106,10 +106,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     // 3. the user's home directory
     // 4. the root directory
 
-    LexicalPath path(initial_location);
+    LexicalPath path(initial_location.to_deprecated_string());
     if (!initial_location.is_empty()) {
         if (auto error_or_path = FileSystem::real_path(initial_location); !ignore_path_resolution && !error_or_path.is_error())
-            initial_location = error_or_path.release_value().to_deprecated_string();
+            initial_location = error_or_path.release_value();
 
         if (!FileSystem::is_directory(initial_location)) {
             // We want to extract zips to a temporary directory when FileManager is launched with a .zip file as its first argument
@@ -134,7 +134,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                     return -1;
                 }
 
-                return run_in_windowed_mode(temp_directory_path.to_deprecated_string(), path.basename());
+                return run_in_windowed_mode(temp_directory_path, TRY(String::from_utf8(path.basename())));
             }
 
             is_selection_mode = true;
@@ -142,24 +142,24 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     }
 
     if (auto error_or_cwd = FileSystem::current_working_directory(); initial_location.is_empty() && !error_or_cwd.is_error())
-        initial_location = error_or_cwd.release_value().to_deprecated_string();
+        initial_location = error_or_cwd.release_value();
 
     if (initial_location.is_empty())
-        initial_location = Core::StandardPaths::home_directory();
+        initial_location = TRY(String::from_deprecated_string(Core::StandardPaths::home_directory()));
 
     if (initial_location.is_empty())
-        initial_location = "/";
+        initial_location = "/"_string;
 
-    DeprecatedString focused_entry;
+    String focused_entry;
     if (is_selection_mode) {
-        initial_location = path.dirname();
-        focused_entry = path.basename();
+        initial_location = TRY(String::from_utf8(path.dirname()));
+        focused_entry = TRY(String::from_utf8(path.basename()));
     }
 
     return run_in_windowed_mode(initial_location, focused_entry);
 }
 
-void do_copy(Vector<DeprecatedString> const& selected_file_paths, FileOperation file_operation)
+void do_copy(Vector<String> const& selected_file_paths, FileOperation file_operation)
 {
     VERIFY(!selected_file_paths.is_empty());
 
@@ -174,14 +174,15 @@ void do_copy(Vector<DeprecatedString> const& selected_file_paths, FileOperation 
     GUI::Clipboard::the().set_data(copy_text.to_deprecated_string().bytes(), "text/uri-list");
 }
 
-void do_paste(DeprecatedString const& target_directory, GUI::Window* window)
+void do_paste(String const& target_directory, GUI::Window* window)
 {
     auto data_and_type = GUI::Clipboard::the().fetch_data_and_type();
     if (data_and_type.mime_type != "text/uri-list") {
         dbgln("Cannot paste clipboard type {}", data_and_type.mime_type);
         return;
     }
-    auto copied_lines = DeprecatedString::copy(data_and_type.data).split('\n');
+
+    auto copied_lines = MUST(MUST(String::from_utf8(data_and_type.data)).split('\n'));
     if (copied_lines.is_empty()) {
         dbgln("No files to paste");
         return;
@@ -193,7 +194,7 @@ void do_paste(DeprecatedString const& target_directory, GUI::Window* window)
         copied_lines.remove(0);
     }
 
-    Vector<DeprecatedString> source_paths;
+    Vector<String> source_paths;
     for (auto& uri_as_string : copied_lines) {
         if (uri_as_string.is_empty())
             continue;
@@ -202,7 +203,7 @@ void do_paste(DeprecatedString const& target_directory, GUI::Window* window)
             dbgln("Cannot paste URI {}", uri_as_string);
             continue;
         }
-        source_paths.append(url.serialize_path());
+        source_paths.append(MUST(String::from_deprecated_string(url.serialize_path())));
     }
 
     if (!source_paths.is_empty()) {
@@ -211,23 +212,23 @@ void do_paste(DeprecatedString const& target_directory, GUI::Window* window)
     }
 }
 
-void do_create_link(Vector<DeprecatedString> const& selected_file_paths, GUI::Window* window)
+void do_create_link(Vector<String> const& selected_file_paths, GUI::Window* window)
 {
     auto path = selected_file_paths.first();
-    auto destination = DeprecatedString::formatted("{}/{}", Core::StandardPaths::desktop_directory(), LexicalPath::basename(path));
+    auto destination = MUST(String::formatted("{}/{}", Core::StandardPaths::desktop_directory(), LexicalPath::basename(path.to_deprecated_string())));
     if (auto result = FileSystem::link_file(destination, path); result.is_error()) {
         GUI::MessageBox::show(window, DeprecatedString::formatted("Could not create desktop shortcut:\n{}", result.error()), "File Manager"sv,
             GUI::MessageBox::Type::Error);
     }
 }
 
-void do_create_archive(Vector<DeprecatedString> const& selected_file_paths, GUI::Window* window)
+void do_create_archive(Vector<String> const& selected_file_paths, GUI::Window* window)
 {
     String archive_name;
     if (GUI::InputBox::show(window, archive_name, "Enter name:"sv, "Create Archive"sv) != GUI::InputBox::ExecResult::OK)
         return;
 
-    auto output_directory_path = LexicalPath(selected_file_paths.first());
+    auto output_directory_path = LexicalPath(selected_file_paths.first().to_deprecated_string());
 
     StringBuilder path_builder;
     path_builder.append(output_directory_path.dirname());
@@ -249,15 +250,16 @@ void do_create_archive(Vector<DeprecatedString> const& selected_file_paths, GUI:
     }
 
     if (!zip_pid) {
-        Vector<DeprecatedString> relative_paths;
+        Vector<String> relative_paths;
         Vector<char const*> arg_list;
         arg_list.append("/bin/zip");
         arg_list.append("-r");
         arg_list.append("-f");
         arg_list.append(output_path.characters());
         for (auto const& path : selected_file_paths) {
-            relative_paths.append(LexicalPath::relative_path(path, output_directory_path.dirname()));
-            arg_list.append(relative_paths.last().characters());
+            auto relative_path = MUST(String::from_deprecated_string(LexicalPath::relative_path(path, output_directory_path.dirname())));
+            relative_paths.append(relative_path);
+            arg_list.append(relative_paths.last().to_deprecated_string().characters());
         }
         arg_list.append(nullptr);
         int rc = execvp("/bin/zip", const_cast<char* const*>(arg_list.data()));
@@ -273,7 +275,7 @@ void do_create_archive(Vector<DeprecatedString> const& selected_file_paths, GUI:
     }
 }
 
-void do_set_wallpaper(DeprecatedString const& file_path, GUI::Window* window)
+void do_set_wallpaper(String const& file_path, GUI::Window* window)
 {
     auto show_error = [&] {
         GUI::MessageBox::show(window, DeprecatedString::formatted("Failed to set {} as wallpaper.", file_path), "Failed to set wallpaper"sv, GUI::MessageBox::Type::Error);
@@ -289,10 +291,10 @@ void do_set_wallpaper(DeprecatedString const& file_path, GUI::Window* window)
         show_error();
 }
 
-void do_unzip_archive(Vector<DeprecatedString> const& selected_file_paths, GUI::Window* window)
+void do_unzip_archive(Vector<String> const& selected_file_paths, GUI::Window* window)
 {
-    DeprecatedString archive_file_path = selected_file_paths.first();
-    DeprecatedString output_directory_path = archive_file_path.substring(0, archive_file_path.length() - 4);
+    String archive_file_path = selected_file_paths.first();
+    String output_directory_path = MUST(archive_file_path.substring_from_byte_offset(0, archive_file_path.bytes_as_string_view().length() - 4));
 
     pid_t unzip_pid = fork();
     if (unzip_pid < 0) {
@@ -301,7 +303,7 @@ void do_unzip_archive(Vector<DeprecatedString> const& selected_file_paths, GUI::
     }
 
     if (!unzip_pid) {
-        int rc = execlp("/bin/unzip", "/bin/unzip", "-d", output_directory_path.characters(), archive_file_path.characters(), nullptr);
+        int rc = execlp("/bin/unzip", "/bin/unzip", "-d", output_directory_path.to_deprecated_string().characters(), archive_file_path.to_deprecated_string().characters(), nullptr);
         if (rc < 0) {
             perror("execlp");
             _exit(1);
@@ -315,13 +317,13 @@ void do_unzip_archive(Vector<DeprecatedString> const& selected_file_paths, GUI::
     }
 }
 
-void show_properties(DeprecatedString const& container_dir_path, DeprecatedString const& path, Vector<DeprecatedString> const& selected, GUI::Window* window)
+void show_properties(String const& container_dir_path, String const& path, Vector<String> const& selected, GUI::Window* window)
 {
     ErrorOr<RefPtr<PropertiesWindow>> properties_or_error = nullptr;
     if (selected.is_empty()) {
         properties_or_error = window->try_add<PropertiesWindow>(path, true);
     } else {
-        properties_or_error = window->try_add<PropertiesWindow>(selected.first(), access(container_dir_path.characters(), W_OK) != 0);
+        properties_or_error = window->try_add<PropertiesWindow>(selected.first(), access(container_dir_path.to_deprecated_string().characters(), W_OK) != 0);
     }
 
     if (properties_or_error.is_error()) {
@@ -337,7 +339,7 @@ void show_properties(DeprecatedString const& container_dir_path, DeprecatedStrin
     properties->show();
 }
 
-bool add_launch_handler_actions_to_menu(RefPtr<GUI::Menu>& menu, DirectoryView const& directory_view, DeprecatedString const& full_path, RefPtr<GUI::Action>& default_action, Vector<NonnullRefPtr<LauncherHandler>>& current_file_launch_handlers)
+bool add_launch_handler_actions_to_menu(RefPtr<GUI::Menu>& menu, DirectoryView const& directory_view, String const& full_path, RefPtr<GUI::Action>& default_action, Vector<NonnullRefPtr<LauncherHandler>>& current_file_launch_handlers)
 {
     current_file_launch_handlers = directory_view.get_launch_handlers(full_path);
 
@@ -345,6 +347,7 @@ bool add_launch_handler_actions_to_menu(RefPtr<GUI::Menu>& menu, DirectoryView c
     auto default_file_handler = directory_view.get_default_launch_handler(current_file_launch_handlers);
     if (default_file_handler) {
         auto file_open_action = default_file_handler->create_launch_action([&, full_path = move(full_path)](auto& launcher_handler) {
+            dbgln("Running launch action for {}", full_path);
             directory_view.launch(URL::create_with_file_scheme(full_path), launcher_handler);
         });
         if (default_file_handler->details().launcher_type == Desktop::Launcher::LauncherType::Application)
@@ -458,8 +461,8 @@ ErrorOr<int> run_in_desktop_mode()
 
     auto properties_action = GUI::CommonActions::make_properties_action(
         [&](auto&) {
-            DeprecatedString path = directory_view->path();
-            Vector<DeprecatedString> selected = directory_view->selected_file_paths();
+            auto path = directory_view->path();
+            Vector<String> selected = directory_view->selected_file_paths();
 
             show_properties(path, path, selected, directory_view->window());
         },
@@ -470,10 +473,10 @@ ErrorOr<int> run_in_desktop_mode()
             do_paste(directory_view->path(), directory_view->window());
         },
         window);
-    paste_action->set_enabled(GUI::Clipboard::the().fetch_mime_type() == "text/uri-list" && access(directory_view->path().characters(), W_OK) == 0);
+    paste_action->set_enabled(GUI::Clipboard::the().fetch_mime_type() == "text/uri-list" && !Core::System::access(directory_view->path(), W_OK).is_error());
 
     GUI::Clipboard::the().on_change = [&](DeprecatedString const& data_type) {
-        paste_action->set_enabled(data_type == "text/uri-list" && access(directory_view->path().characters(), W_OK) == 0);
+        paste_action->set_enabled(data_type == "text/uri-list" && !Core::System::access(directory_view->path(), W_OK).is_error());
     };
 
     auto desktop_view_context_menu = GUI::Menu::construct("Directory View"_string);
@@ -543,7 +546,8 @@ ErrorOr<int> run_in_desktop_mode()
             } else {
                 file_context_menu = GUI::Menu::construct("Directory View File"_string);
 
-                bool added_open_menu_items = add_launch_handler_actions_to_menu(file_context_menu, directory_view, node.full_path(), file_context_menu_action_default_action, current_file_handlers);
+                auto node_path = MUST(String::from_deprecated_string(node.full_path()));
+                bool added_open_menu_items = add_launch_handler_actions_to_menu(file_context_menu, directory_view, node_path, file_context_menu_action_default_action, current_file_handlers);
                 if (added_open_menu_items)
                     file_context_menu->add_separator();
 
@@ -604,7 +608,7 @@ ErrorOr<int> run_in_desktop_mode()
     return GUI::Application::the()->exec();
 }
 
-ErrorOr<int> run_in_windowed_mode(DeprecatedString const& initial_location, DeprecatedString const& entry_focused_on_init)
+ErrorOr<int> run_in_windowed_mode(String const& initial_location, String const& entry_focused_on_init)
 {
     auto window = GUI::Window::construct();
     window->set_title("File Manager");
@@ -659,18 +663,17 @@ ErrorOr<int> run_in_windowed_mode(DeprecatedString const& initial_location, Depr
 
         auto current_path = directory_view->path();
 
-        struct stat st;
         // If the directory no longer exists, we find a parent that does.
-        while (stat(current_path.characters(), &st) != 0) {
+        while (Core::System::stat(current_path).is_error()) {
             directory_view->open_parent_directory();
             current_path = directory_view->path();
-            if (current_path == directories_model->root_path()) {
+            if (current_path.bytes_as_string_view() == directories_model->root_path()) {
                 break;
             }
         }
 
         // Reselect the existing folder in the tree.
-        auto new_index = directories_model->index(current_path, GUI::FileSystemModel::Column::Name);
+        auto new_index = directories_model->index(current_path.to_deprecated_string(), GUI::FileSystemModel::Column::Name);
         if (new_index.is_valid()) {
             tree_view.expand_all_parents_of(new_index);
             tree_view.set_cursor(new_index, GUI::AbstractView::SelectionUpdate::Set, true);
@@ -762,10 +765,10 @@ ErrorOr<int> run_in_windowed_mode(DeprecatedString const& initial_location, Depr
     view_type_action_group->add_action(directory_view->view_as_columns_action());
 
     auto tree_view_selected_file_paths = [&] {
-        Vector<DeprecatedString> paths;
+        Vector<String> paths;
         auto& view = tree_view;
         view.selection().for_each_index([&](GUI::ModelIndex const& index) {
-            paths.append(directories_model->full_path(index));
+            paths.append(MUST(String::from_deprecated_string(directories_model->full_path(index))));
         });
         return paths;
     };
@@ -802,7 +805,7 @@ ErrorOr<int> run_in_windowed_mode(DeprecatedString const& initial_location, Depr
 
     auto copy_path_action = GUI::Action::create(
         "Copy Path", [&](GUI::Action const&) {
-            Vector<DeprecatedString> selected_paths;
+            Vector<String> selected_paths;
             if (directory_view->active_widget()->is_focused()) {
                 selected_paths = directory_view->selected_file_paths();
             } else if (tree_view.is_focused()) {
@@ -822,7 +825,7 @@ ErrorOr<int> run_in_windowed_mode(DeprecatedString const& initial_location, Depr
             {},
             TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/app-file-manager.png"sv)),
             [&](GUI::Action const& action) {
-                Vector<DeprecatedString> paths;
+                Vector<String> paths;
                 if (action.activator() == tree_view_directory_context_menu)
                     paths = tree_view_selected_file_paths();
                 else
@@ -841,7 +844,7 @@ ErrorOr<int> run_in_windowed_mode(DeprecatedString const& initial_location, Depr
             {},
             TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/app-terminal.png"sv)),
             [&](GUI::Action const& action) {
-                Vector<DeprecatedString> paths;
+                Vector<String> paths;
                 if (action.activator() == tree_view_directory_context_menu)
                     paths = tree_view_selected_file_paths();
                 else
@@ -911,16 +914,16 @@ ErrorOr<int> run_in_windowed_mode(DeprecatedString const& initial_location, Depr
 
     auto properties_action = GUI::CommonActions::make_properties_action(
         [&](auto& action) {
-            DeprecatedString container_dir_path;
-            DeprecatedString path;
-            Vector<DeprecatedString> selected;
+            String container_dir_path;
+            String path;
+            Vector<String> selected;
             if (action.activator() == directory_context_menu || directory_view->active_widget()->is_focused()) {
                 path = directory_view->path();
                 container_dir_path = path;
                 selected = directory_view->selected_file_paths();
             } else {
-                path = directories_model->full_path(tree_view.selection().first());
-                container_dir_path = LexicalPath::basename(path);
+                path = MUST(String::from_deprecated_string(directories_model->full_path(tree_view.selection().first())));
+                container_dir_path = MUST(String::from_deprecated_string(LexicalPath::basename(path.to_deprecated_string())));
                 selected = tree_view_selected_file_paths();
             }
 
@@ -930,7 +933,7 @@ ErrorOr<int> run_in_windowed_mode(DeprecatedString const& initial_location, Depr
 
     auto paste_action = GUI::CommonActions::make_paste_action(
         [&](GUI::Action const& action) {
-            DeprecatedString target_directory;
+            String target_directory;
             if (action.activator() == directory_context_menu)
                 target_directory = directory_view->selected_file_paths()[0];
             else
@@ -942,7 +945,7 @@ ErrorOr<int> run_in_windowed_mode(DeprecatedString const& initial_location, Depr
 
     auto folder_specific_paste_action = GUI::CommonActions::make_paste_action(
         [&](GUI::Action const& action) {
-            DeprecatedString target_directory;
+            String target_directory;
             if (action.activator() == directory_context_menu)
                 target_directory = directory_view->selected_file_paths()[0];
             else
@@ -972,7 +975,7 @@ ErrorOr<int> run_in_windowed_mode(DeprecatedString const& initial_location, Depr
 
     GUI::Clipboard::the().on_change = [&](DeprecatedString const& data_type) {
         auto current_location = directory_view->path();
-        paste_action->set_enabled(data_type == "text/uri-list" && access(current_location.characters(), W_OK) == 0);
+        paste_action->set_enabled(data_type == "text/uri-list" && !Core::System::access(current_location, W_OK).is_error());
     };
 
     auto tree_view_delete_action = GUI::CommonActions::make_delete_action(
@@ -1104,7 +1107,7 @@ ErrorOr<int> run_in_windowed_mode(DeprecatedString const& initial_location, Depr
             directory_view->open(selected_path);
         } else {
             dbgln("Breadcrumb path '{}' doesn't exist", selected_path);
-            breadcrumbbar.set_current_path(directory_view->path());
+            breadcrumbbar.set_current_path(directory_view->path().to_deprecated_string());
         }
     };
 
@@ -1157,11 +1160,11 @@ ErrorOr<int> run_in_windowed_mode(DeprecatedString const& initial_location, Depr
 
     directory_view->on_selection_change = [&](GUI::AbstractView& view) {
         auto& selection = view.selection();
-        cut_action->set_enabled(!selection.is_empty() && access(directory_view->path().characters(), W_OK) == 0);
+        cut_action->set_enabled(!selection.is_empty() && !Core::System::access(directory_view->path(), W_OK).is_error());
         copy_action->set_enabled(!selection.is_empty());
         copy_path_action->set_text(selection.size() > 1 ? "Copy Paths" : "Copy Path");
         focus_dependent_delete_action->set_enabled((!tree_view.selection().is_empty() && tree_view.is_focused())
-            || (!directory_view->current_view().selection().is_empty() && access(directory_view->path().characters(), W_OK) == 0));
+            || (!directory_view->current_view().selection().is_empty() && !Core::System::access(directory_view->path(), W_OK).is_error()));
     };
 
     auto directory_open_action = GUI::Action::create("Open", TRY(Gfx::Bitmap::load_from_file("/res/icons/16x16/open.png"sv)), [&](auto&) {
@@ -1220,7 +1223,8 @@ ErrorOr<int> run_in_windowed_mode(DeprecatedString const& initial_location, Depr
             } else {
                 file_context_menu = GUI::Menu::construct("Directory View File"_string);
 
-                bool added_launch_file_handlers = add_launch_handler_actions_to_menu(file_context_menu, directory_view, node.full_path(), file_context_menu_action_default_action, current_file_handlers);
+                auto node_path = MUST(String::from_deprecated_string(node.full_path()));
+                bool added_launch_file_handlers = add_launch_handler_actions_to_menu(file_context_menu, directory_view, node_path, file_context_menu_action_default_action, current_file_handlers);
                 if (added_launch_file_handlers)
                     file_context_menu->add_separator();
 
@@ -1267,7 +1271,7 @@ ErrorOr<int> run_in_windowed_mode(DeprecatedString const& initial_location, Depr
         directories_model->m_previously_selected_index = index;
 
         auto path = directories_model->full_path(index);
-        if (directory_view->path() == path)
+        if (directory_view->path().to_deprecated_string() == path)
             return;
         TemporaryChange change(is_reacting_to_tree_view_selection_change, true);
         directory_view->open(path);
@@ -1288,14 +1292,15 @@ ErrorOr<int> run_in_windowed_mode(DeprecatedString const& initial_location, Depr
     };
 
     breadcrumbbar.on_paths_drop = [&](auto path, GUI::DropEvent const& event) {
-        bool const has_accepted_drop = handle_drop(event, path, window).release_value_but_fixme_should_propagate_errors();
+        bool const has_accepted_drop = handle_drop(event, MUST(String::from_utf8(path)), window).release_value_but_fixme_should_propagate_errors();
         if (has_accepted_drop)
             refresh_tree_view();
     };
 
     tree_view.on_drop = [&](GUI::ModelIndex const& index, GUI::DropEvent const& event) {
         auto const& target_node = directories_model->node(index);
-        bool const has_accepted_drop = handle_drop(event, target_node.full_path(), window).release_value_but_fixme_should_propagate_errors();
+        auto target_node_path = MUST(String::from_deprecated_string(target_node.full_path()));
+        bool const has_accepted_drop = handle_drop(event, target_node_path, window).release_value_but_fixme_should_propagate_errors();
         if (has_accepted_drop) {
             refresh_tree_view();
             const_cast<GUI::DropEvent&>(event).accept();
@@ -1305,7 +1310,7 @@ ErrorOr<int> run_in_windowed_mode(DeprecatedString const& initial_location, Depr
     directory_view->open(initial_location);
     directory_view->set_focus(true);
 
-    paste_action->set_enabled(GUI::Clipboard::the().fetch_mime_type() == "text/uri-list" && access(initial_location.characters(), W_OK) == 0);
+    paste_action->set_enabled(GUI::Clipboard::the().fetch_mime_type() == "text/uri-list" && !Core::System::access(initial_location, W_OK).is_error());
 
     window->restore_size_and_position("FileManager"sv, "Window"sv, { { 640, 480 } });
     window->save_size_and_position_on_close("FileManager"sv, "Window"sv);

--- a/Userland/Libraries/LibGUI/Variant.h
+++ b/Userland/Libraries/LibGUI/Variant.h
@@ -219,6 +219,24 @@ public:
             [](auto const& v) { return DeprecatedString::formatted("{}", v); });
     }
 
+    ErrorOr<String> to_string() const
+    {
+        return visit(
+            [](Empty) -> ErrorOr<String> { return "[null]"_string; },
+            [](DeprecatedString v) { return String::from_deprecated_string(v); },
+            [](String v) -> ErrorOr<String> { return v; },
+            [](Gfx::TextAlignment v) { return String::formatted("Gfx::TextAlignment::{}", Gfx::to_string(v)); },
+            [](Gfx::ColorRole v) { return String::formatted("Gfx::ColorRole::{}", Gfx::to_string(v)); },
+            [](Gfx::AlignmentRole v) { return String::formatted("Gfx::AlignmentRole::{}", Gfx::to_string(v)); },
+            [](Gfx::FlagRole v) { return String::formatted("Gfx::FlagRole::{}", Gfx::to_string(v)); },
+            [](Gfx::MetricRole v) { return String::formatted("Gfx::MetricRole::{}", Gfx::to_string(v)); },
+            [](Gfx::PathRole v) { return String::formatted("Gfx::PathRole::{}", Gfx::to_string(v)); },
+            [](NonnullRefPtr<Gfx::Font const> const& font) { return String::formatted("[Font: {}]", font->name()); },
+            [](NonnullRefPtr<Gfx::Bitmap const> const&) -> ErrorOr<String> { return "[Gfx::Bitmap]"_string; },
+            [](GUI::Icon const&) -> ErrorOr<String> { return "[GUI::Icon]"_string; },
+            [](Detail::Boolean v) { return String::formatted("{}", v.value); },
+            [](auto const& v) { return String::formatted("{}", v); });
+    }
     bool operator==(Variant const&) const;
     bool operator<(Variant const&) const;
 };

--- a/Userland/Libraries/LibWeb/HTML/HTMLHyperlinkElementUtils.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLHyperlinkElementUtils.cpp
@@ -311,7 +311,7 @@ void HTMLHyperlinkElementUtils::set_pathname(StringView pathname)
 
     // 4. Set url's path to the empty list.
     auto url = m_url; // We copy the URL here to follow other browser's behavior of reverting the path change if the parse failed.
-    url->set_paths({});
+    url->set_paths(Vector<String> {});
 
     // 5. Basic URL parse the given value, with url as url and path start state as state override.
     auto result_url = URLParser::basic_parse(pathname, {}, move(url), URLParser::State::PathStart);

--- a/Userland/Libraries/LibWeb/URL/URL.cpp
+++ b/Userland/Libraries/LibWeb/URL/URL.cpp
@@ -366,7 +366,7 @@ void URL::set_pathname(String const& pathname)
 
     // 2. Empty this’s URL’s path.
     auto url = m_url; // We copy the URL here to follow other browser's behavior of reverting the path change if the parse failed.
-    url.set_paths({});
+    url.set_paths(Vector<String> {});
 
     // 3. Basic URL parse the given value with this’s URL as url and path start state as state override.
     auto result_url = URLParser::basic_parse(pathname, {}, move(url), URLParser::State::PathStart);


### PR DESCRIPTION
This changes almost all usages of DeprecatedString to String. Some
exceptions where DeprecatedString is still used are:

- The signatures for the lambdas given to event handlers such as
  on_change
- Arguments to non-FileManager APIs which are called with
  DeprecatedString::formatted()
- Variables which are passed to system calls such as posix_spawn()

Where necessary, system calls have been converted to their Core::System
wrappers to allow for passing String arguments.

This PR also includes some additional String APIs fro AK::URL and LibGUI::Variant.

Contributes to #17128 