### PR TITLE
Some more 32-bit & Hurd fixes

### DIFF
--- a/Userland/Libraries/LibJS/CMakeLists.txt
+++ b/Userland/Libraries/LibJS/CMakeLists.txt
@@ -271,4 +271,10 @@ target_link_libraries(LibJS PRIVATE LibCore LibCrypto LibFileSystem LibRegex Lib
 if("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "x86_64")
     target_link_libraries(LibJS PRIVATE LibX86)
 endif()
+
+# TODO: This is probably also needed on RISC-V.
+if("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "i.86.*")
+    target_link_libraries(LibJS PRIVATE atomic)
+endif()
+
 target_compile_options(LibJS PRIVATE -fno-omit-frame-pointer)

--- a/Userland/Libraries/LibJS/Runtime/AtomicsObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AtomicsObject.cpp
@@ -4,6 +4,14 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+// This file explicitly implements support for JS Atomics API, which can
+// involve slow (non-lock-free) atomic ops.
+#include <AK/Platform.h>
+
+#ifdef AK_COMPILER_CLANG
+#    pragma clang diagnostic ignored "-Watomic-alignment"
+#endif
+
 #include <AK/Atomic.h>
 #include <AK/ByteBuffer.h>
 #include <AK/Endian.h>

--- a/Userland/Services/WebContent/PageHost.cpp
+++ b/Userland/Services/WebContent/PageHost.cpp
@@ -21,7 +21,7 @@
 #include <WebContent/WebContentClientEndpoint.h>
 #include <WebContent/WebDriverConnection.h>
 
-#ifdef AK_OS_LINUX
+#ifdef HAS_ACCELERATED_GRAPHICS
 #    include <LibWeb/Painting/PaintingCommandExecutorGPU.h>
 #endif
 


### PR DESCRIPTION
These few tiny changes make the Qt Ladybird build and somewhat work for me on 32-bit Debian GNU/Hurd!

If you want to reproduce my results, I'm actually building with the following additional patch:

```patch
diff --git a/Meta/CMake/lagom_compile_options.cmake b/Meta/CMake/lagom_compile_options.cmake
index 40f646766c..9db1d514a4 100644
--- a/Meta/CMake/lagom_compile_options.cmake
+++ b/Meta/CMake/lagom_compile_options.cmake
@@ -6,6 +6,7 @@ add_compile_options(-fsigned-char)
 add_compile_options(-g1)
 add_compile_options(-ggnu-pubnames)
 add_compile_options(-O2)
+add_compile_options(-mstack-alignment=16)
 if (NOT WIN32)
     add_compile_options(-fPIC)
 endif()
diff --git a/Userland/Libraries/LibCore/System.cpp b/Userland/Libraries/LibCore/System.cpp
index 935a4b73f5..e4d241dabe 100644
--- a/Userland/Libraries/LibCore/System.cpp
+++ b/Userland/Libraries/LibCore/System.cpp
@@ -519,6 +519,15 @@ ErrorOr<int> anon_create([[maybe_unused]] size_t size, [[maybe_unused]] int opti
         TRY(close(fd));
         return Error::from_errno(saved_errno);
     }
+#elif defined(__GNU__)
+    file_t dir = file_name_lookup("/tmp", O_DIRECTORY, 0);
+    VERIFY(dir);
+    file_t file;
+    int err = dir_mkfile(dir, 0, 0777, &file);
+    VERIFY(err == 0);
+    err = mach_port_deallocate(mach_task_self(), dir);
+    VERIFY(err == 0);
+    fd = openport(file, O_CLOEXEC | O_IGNORE_CTTY);
 #elif defined(SHM_ANON)
     fd = shm_open(SHM_ANON, O_RDWR | O_CREAT | options, 0600);
     if (fd < 0)
```

`-mstack-alignment=16` is needed because apparently by default Clang doesn't understand that it needs to 16-align the stack pointer; this will hopefully get fixed on the LLVM side eventually. The `anon_create()` implementation is needed because apparently my `SHM_ANON` support was released as a part of glibc 2.38, and Debian still has 2.37; I don't know whether this second implementation is wanted in Serenity upstream, but I had to use it for now.

![Ladybird on the Hurd screenshot](https://github.com/SerenityOS/serenity/assets/10091584/f8045f1b-7184-4df9-b23f-a994bfb95606)

This is what I get when I run it: the Qt UI loads, the WebContent gets spawned, it successfully fetches and parses the page. Yet all I see is black where the web view should be.