### PR TITLE
Userland: Make bit-fields compatible with MSVC C++ ABI

### DIFF
--- a/Meta/CMake/common_compile_options.cmake
+++ b/Meta/CMake/common_compile_options.cmake
@@ -16,6 +16,10 @@ add_compile_options(-fno-exceptions)
 
 add_compile_options(-ffp-contract=off)
 
+if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "18")
+    add_compile_options(-Wpadded-bitfield)
+endif()
+
 if (NOT CMAKE_HOST_SYSTEM_NAME MATCHES SerenityOS)
     # FIXME: Something makes this go crazy and flag unused variables that aren't flagged as such when building with the toolchain.
     #        Disable -Werror for now.

--- a/Userland/Libraries/LibJS/Heap/Cell.h
+++ b/Userland/Libraries/LibJS/Heap/Cell.h
@@ -37,7 +37,7 @@ public:
     bool is_marked() const { return m_mark; }
     void set_marked(bool b) { m_mark = b; }
 
-    enum class State {
+    enum class State : bool {
         Live,
         Dead,
     };

--- a/Userland/Libraries/LibJS/Runtime/Shape.h
+++ b/Userland/Libraries/LibJS/Runtime/Shape.h
@@ -109,7 +109,7 @@ private:
     u32 m_property_count { 0 };
 
     PropertyAttributes m_attributes { 0 };
-    TransitionType m_transition_type : 6 { TransitionType::Invalid };
+    TransitionType m_transition_type { TransitionType::Invalid };
     bool m_unique { false };
 
     // Since unique shapes never change identity, inline caches use this incrementing serial number

--- a/Userland/Libraries/LibWasm/Wasi.h
+++ b/Userland/Libraries/LibWasm/Wasi.h
@@ -237,7 +237,8 @@ struct Rights {
         bool sock_shutdown : 1;
         bool sock_accept : 1;
 
-        u64 _unused : 34;
+        u8 _unused1 : 2;
+        u32 _unused2 : 32;
     };
 
     static_assert(sizeof(Bits) == sizeof(CompatibleType));
@@ -331,7 +332,9 @@ struct FDFlags {
         bool nonblock : 1;
         bool rsync : 1;
         bool sync : 1;
-        u16 _unused : 11;
+
+        u8 _unused1 : 3;
+        u8 _unused2 : 8;
     };
     static_assert(sizeof(Bits) == sizeof(CompatibleType));
 
@@ -369,7 +372,9 @@ struct FSTFlags {
         bool atim_now : 1;
         bool mtim : 1;
         bool mtim_now : 1;
-        u16 _unused : 12;
+
+        u8 _unused1 : 4;
+        u8 _unused2 : 8;
     };
 
     static_assert(sizeof(Bits) == sizeof(CompatibleType));
@@ -390,7 +395,10 @@ struct LookupFlags {
 
     struct Bits {
         bool symlink_follow : 1;
-        u32 _unused : 31;
+
+        u8 _unused1 : 7;
+        u8 _unused2 : 8;
+        u16 _unused3 : 16;
     };
 
     static_assert(sizeof(Bits) == sizeof(CompatibleType));
@@ -415,7 +423,8 @@ struct OFlags {
         bool excl : 1;
         bool trunc : 1;
 
-        u16 _unused : 12;
+        u8 _unused1 : 4;
+        u8 _unused2 : 8;
     };
 
     static_assert(sizeof(Bits) == sizeof(CompatibleType));
@@ -465,7 +474,8 @@ struct EventRWFlags {
     struct Bits {
         bool fd_readwrite_hangup : 1;
 
-        u16 _unused : 15;
+        u8 _unused1 : 7;
+        u8 _unused2 : 8;
     };
 
     static_assert(sizeof(Bits) == sizeof(CompatibleType));
@@ -510,7 +520,8 @@ struct SubClockFlags {
     struct Bits {
         bool subscription_clock_abstime : 1;
 
-        u16 _unused : 15;
+        u8 _unused1 : 7;
+        u8 _unused2 : 8;
     };
     static_assert(sizeof(Bits) == sizeof(CompatibleType));
 
@@ -610,7 +621,8 @@ struct RIFlags {
         bool recv_peek : 1;
         bool recv_waitall : 1;
 
-        u16 _unused : 14;
+        u8 _unused1 : 6;
+        u8 _unused2 : 8;
     };
     static_assert(sizeof(Bits) == sizeof(CompatibleType));
 
@@ -629,7 +641,8 @@ struct ROFlags {
     struct Bits {
         bool recv_data_truncated : 1;
 
-        u16 _unused : 15;
+        u8 _unused1 : 7;
+        u8 _unused2 : 8;
     };
     static_assert(sizeof(Bits) == sizeof(CompatibleType));
 

--- a/Userland/Libraries/LibX86/Instruction.h
+++ b/Userland/Libraries/LibX86/Instruction.h
@@ -607,8 +607,10 @@ private:
 
     u8 m_mod : 2 { 0 };
     u8 m_reg : 4 { 0 };
+    u8 : 2;
     u8 m_rm : 4 { 0 };
     u8 m_sib_scale : 2 { 0 };
+    u8 : 2;
     u8 m_sib_index : 4 { 0 };
     u8 m_sib_base : 4 { 0 };
     u8 m_displacement_bytes { 0 };


### PR DESCRIPTION
This would be a temporary solution until someone (most probably me) implements `[[gnu::gcc_struct]]` on `x86_64-pc-windows-msvc` in clang.