### PR TITLE
Kernel: fix panic for Nagel's algorithm

### DIFF
--- a/Kernel/Net/TCPSocket.cpp
+++ b/Kernel/Net/TCPSocket.cpp
@@ -220,7 +220,7 @@ ErrorOr<size_t> TCPSocket::protocol_send(UserOrKernelBuffer const& data, size_t 
     // FIXME: Make this configurable via TCP_NODELAY.
     auto has_unacked_data = m_unacked_packets.with_shared([&](auto const& packets) { return packets.size > 0; });
     if (has_unacked_data && data_length < mss)
-        return 0;
+        return set_so_error(EAGAIN);
 
     data_length = min(data_length, mss);
     TRY(send_tcp_packet(TCPFlags::PSH | TCPFlags::ACK, &data, data_length, &routing_decision));


### PR DESCRIPTION
It seems like the current implementation returns 0 in case we do not have enough data for a whole packet yet. The 0 value gets propagated to the return value of the syscall which according to the spec should return non-zero values for non-errors cases. This causes panic, as there is a VERIFY guard checking that more than > 0 bytes are written if no error has occurred.

Fixes https://github.com/SerenityOS/serenity/issues/21320