### PR TITLE
DisplaySettings: Prevent user from making background non-image type

### DIFF
--- a/Userland/Applications/DisplaySettings/BackgroundSettingsWidget.cpp
+++ b/Userland/Applications/DisplaySettings/BackgroundSettingsWidget.cpp
@@ -104,7 +104,7 @@ ErrorOr<void> BackgroundSettingsWidget::create_frame()
         FileSystemAccessClient::OpenFileOptions options {
             .window_title = "Select Wallpaper"sv,
             .path = "/res/wallpapers"sv,
-            .allowed_file_types = { { GUI::FileTypeFilter::image_files(), GUI::FileTypeFilter::all_files() } }
+            .allowed_file_types = { { GUI::FileTypeFilter::image_files() } }
         };
         auto response = FileSystemAccessClient::Client::the().open_file(window(), options);
         if (response.is_error())


### PR DESCRIPTION
The problem is that if the user selects an non-image file as their background, then at next startup the desktop crashes.

A simple fix of not allowing the user to select non-image file types works for now.

The only problem is if the user has a file with an extension not in the supported list but is in the form of a supported image file.

Please let me know is there is any tests that I can / should implement.

Thanks,
Lachlan Jowett.