### PR TITLE
Taskbar/QuickLaunchWidget: Make adding entries easier + reordering

### DIFF
--- a/Base/home/anon/.config/Taskbar.ini
+++ b/Base/home/anon/.config/Taskbar.ini
@@ -1,8 +1,8 @@
 [Clock]
 TimeFormat=%T
 
-[QuickLaunch]
-Browser=Browser.af
-Terminal=Terminal.af
-FileManager=FileManager.af
-TextEditor=TextEditor.af
+[QuickLaunch_Entries]
+Browser=0:Browser.af
+FileManager=1:FileManager.af
+Terminal=2:Terminal.af
+TextEditor=3:TextEditor.af

--- a/Userland/Libraries/LibDesktop/AppFile.cpp
+++ b/Userland/Libraries/LibDesktop/AppFile.cpp
@@ -12,13 +12,23 @@
 #include <LibCore/DirIterator.h>
 #include <LibCore/Process.h>
 #include <LibDesktop/AppFile.h>
+#include <LibFileSystem/FileSystem.h>
 
 namespace Desktop {
 
+DeprecatedString AppFile::app_file_path_for_app(StringView app_name)
+{
+    return DeprecatedString::formatted("{}/{}.af", APP_FILES_DIRECTORY, app_name);
+}
+
+bool AppFile::exists_for_app(StringView app_name)
+{
+    return FileSystem::exists(app_file_path_for_app(app_name));
+}
+
 NonnullRefPtr<AppFile> AppFile::get_for_app(StringView app_name)
 {
-    auto path = DeprecatedString::formatted("{}/{}.af", APP_FILES_DIRECTORY, app_name);
-    return open(path);
+    return open(app_file_path_for_app(app_name));
 }
 
 NonnullRefPtr<AppFile> AppFile::open(StringView path)

--- a/Userland/Libraries/LibDesktop/AppFile.h
+++ b/Userland/Libraries/LibDesktop/AppFile.h
@@ -17,6 +17,10 @@ class AppFile : public RefCounted<AppFile> {
 public:
     static constexpr auto APP_FILES_DIRECTORY = "/res/apps"sv;
 
+    static bool exists_for_app(StringView app_name);
+    static DeprecatedString file_for_app(StringView app_name);
+    static DeprecatedString app_file_path_for_app(StringView app_name);
+
     static NonnullRefPtr<AppFile> get_for_app(StringView app_name);
     static NonnullRefPtr<AppFile> open(StringView path);
     static void for_each(Function<void(NonnullRefPtr<AppFile>)>, StringView directory = APP_FILES_DIRECTORY);

--- a/Userland/Libraries/LibDesktop/CMakeLists.txt
+++ b/Userland/Libraries/LibDesktop/CMakeLists.txt
@@ -10,4 +10,4 @@ set(GENERATED_SOURCES
 )
 
 serenity_lib(LibDesktop desktop)
-target_link_libraries(LibDesktop PRIVATE LibCore LibIPC LibGfx LibGUI)
+target_link_libraries(LibDesktop PRIVATE LibCore LibIPC LibGfx LibGUI LibFileSystem)

--- a/Userland/Libraries/LibGUI/ConnectionToWindowManagerServer.cpp
+++ b/Userland/Libraries/LibGUI/ConnectionToWindowManagerServer.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, the SerenityOS developers.
+ * Copyright (c) 2023, David Ganz <david.g.ganz@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -85,6 +86,12 @@ void ConnectionToWindowManagerServer::keymap_changed(i32 wm_id, DeprecatedString
 {
     if (auto* window = Window::from_window_id(wm_id))
         Core::EventLoop::current().post_event(*window, make<WMKeymapChangedEvent>(wm_id, keymap));
+}
+
+void ConnectionToWindowManagerServer::add_to_quick_launch(i32 wm_id, pid_t pid)
+{
+    if (auto* window = Window::from_window_id(wm_id))
+        Core::EventLoop::current().post_event(*window, make<WMAddToQuickLaunchEvent>(wm_id, pid));
 }
 
 }

--- a/Userland/Libraries/LibGUI/ConnectionToWindowManagerServer.h
+++ b/Userland/Libraries/LibGUI/ConnectionToWindowManagerServer.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, the SerenityOS developers.
+ * Copyright (c) 2023, David Ganz <david.g.ganz@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -38,6 +39,7 @@ private:
     virtual void super_digit_key_pressed(i32, u8) override;
     virtual void workspace_changed(i32, u32, u32) override;
     virtual void keymap_changed(i32, DeprecatedString const&) override;
+    virtual void add_to_quick_launch(i32, pid_t) override;
 };
 
 }

--- a/Userland/Libraries/LibGUI/Event.h
+++ b/Userland/Libraries/LibGUI/Event.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2018-2023, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2022, the SerenityOS developers.
+ * Copyright (c) 2023, David Ganz <david.g.ganz@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -73,6 +74,7 @@ public:
         WM_SuperDigitKeyPressed,
         WM_WorkspaceChanged,
         WM_KeymapChanged,
+        WM_AddToQuickLaunch,
         __End_WM_Events,
     };
 
@@ -262,6 +264,20 @@ public:
 
 private:
     const DeprecatedString m_keymap;
+};
+
+class WMAddToQuickLaunchEvent : public WMEvent {
+public:
+    explicit WMAddToQuickLaunchEvent(int client_id, pid_t pid)
+        : WMEvent(Event::Type::WM_AddToQuickLaunch, client_id, 0)
+        , m_pid(pid)
+    {
+    }
+
+    pid_t pid() const { return m_pid; }
+
+private:
+    pid_t m_pid;
 };
 
 class MultiPaintEvent final : public Event {

--- a/Userland/Libraries/LibGUI/Window.cpp
+++ b/Userland/Libraries/LibGUI/Window.cpp
@@ -75,6 +75,7 @@ Window* Window::from_window_id(int window_id)
 Window::Window(Core::EventReceiver* parent)
     : GUI::Object(parent)
     , m_menubar(Menubar::construct())
+    , m_pid(getpid())
 {
     if (parent)
         set_window_mode(WindowMode::Passive);
@@ -154,6 +155,7 @@ void Window::show()
 
     ConnectionToWindowServer::the().async_create_window(
         m_window_id,
+        m_pid,
         m_rect_when_windowless,
         !m_moved_by_client,
         m_has_alpha_channel,

--- a/Userland/Libraries/LibGUI/Window.h
+++ b/Userland/Libraries/LibGUI/Window.h
@@ -332,6 +332,8 @@ private:
     bool m_save_size_and_position_on_close { false };
     StringView m_save_domain;
     StringView m_save_group;
+
+    pid_t m_pid;
 };
 
 }

--- a/Userland/Services/Taskbar/QuickLaunchWidget.cpp
+++ b/Userland/Services/Taskbar/QuickLaunchWidget.cpp
@@ -14,6 +14,7 @@
 #include <LibCore/Process.h>
 #include <LibCore/System.h>
 #include <LibDesktop/Launcher.h>
+#include <LibGUI/Application.h>
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/FileIconProvider.h>
 #include <LibGUI/Menu.h>
@@ -209,6 +210,9 @@ void QuickLaunchWidget::mousemove_event(GUI::MouseEvent& event)
         entry->set_hovered(rect.contains(event.position()));
         if (entry->is_pressed())
             m_dragging = true;
+
+        if (entry->is_hovered())
+            GUI::Application::the()->show_tooltip(String::from_deprecated_string(entry->name()).release_value_but_fixme_should_propagate_errors(), this);
     });
 
     if (m_dragging)

--- a/Userland/Services/Taskbar/QuickLaunchWidget.cpp
+++ b/Userland/Services/Taskbar/QuickLaunchWidget.cpp
@@ -355,6 +355,21 @@ void QuickLaunchWidget::load_entries(bool save)
         entries.append(entry.release_nonnull());
     }
 
+    // backwards compatibility since the group and value-format changed
+    auto old_keys = Config::list_keys(CONFIG_DOMAIN, OLD_CONFIG_GROUP_ENTRIES);
+    if (!old_keys.is_empty()) {
+        for (auto& name : old_keys) {
+            auto path = Config::read_string(CONFIG_DOMAIN, OLD_CONFIG_GROUP_ENTRIES, name);
+            auto entry = QuickLaunchEntry::create_from_path(path);
+            if (!entry)
+                continue;
+
+            entries.append(entry.release_nonnull());
+        }
+
+        Config::remove_group(CONFIG_DOMAIN, OLD_CONFIG_GROUP_ENTRIES);
+    }
+
     m_entries.clear();
     add_entries(move(entries), save);
 }

--- a/Userland/Services/Taskbar/QuickLaunchWidget.h
+++ b/Userland/Services/Taskbar/QuickLaunchWidget.h
@@ -20,7 +20,6 @@ namespace Taskbar {
 
 class QuickLaunchEntry {
 public:
-    static OwnPtr<QuickLaunchEntry> create_from_config_value(StringView path);
     static OwnPtr<QuickLaunchEntry> create_from_path(StringView path);
 
     virtual ~QuickLaunchEntry() = default;
@@ -86,7 +85,7 @@ public:
 
     virtual ErrorOr<void> launch() const override;
     virtual GUI::Icon icon() const override;
-    virtual DeprecatedString name() const override;
+    virtual DeprecatedString name() const override { return m_path; }
     virtual DeprecatedString file_name_to_watch() const override { return m_path; }
 
     virtual DeprecatedString path() override { return m_path; }
@@ -103,8 +102,9 @@ public:
     static ErrorOr<NonnullRefPtr<QuickLaunchWidget>> create();
     virtual ~QuickLaunchWidget() override = default;
 
-    void load_entries(bool save = true);
+    ErrorOr<bool> add_from_pid(pid_t pid);
 
+protected:
     virtual void config_key_was_removed(StringView, StringView, StringView) override;
     virtual void config_string_did_change(StringView, StringView, StringView, StringView) override;
 
@@ -120,17 +120,18 @@ public:
 
     virtual void paint_event(GUI::PaintEvent&) override;
 
-    ErrorOr<bool> add_from_pid(pid_t pid);
-
 private:
     static constexpr StringView CONFIG_DOMAIN = "Taskbar"sv;
     static constexpr StringView CONFIG_GROUP_ENTRIES = "QuickLaunch_Entries"sv;
     static constexpr int BUTTON_SIZE = 24;
 
     explicit QuickLaunchWidget();
-    ErrorOr<void> add_or_adjust_button(DeprecatedString const&, NonnullOwnPtr<QuickLaunchEntry>, bool save = true);
+
     ErrorOr<void> create_context_menu();
-    void add_quick_launch_buttons(Vector<NonnullOwnPtr<QuickLaunchEntry>> entries, bool save = true);
+
+    void load_entries(bool save = true);
+    ErrorOr<void> update_entry(DeprecatedString const&, NonnullOwnPtr<QuickLaunchEntry>, bool save = true);
+    void add_entries(Vector<NonnullOwnPtr<QuickLaunchEntry>> entries, bool save = true);
 
     template<typename Callback>
     void for_each_entry(Callback);

--- a/Userland/Services/Taskbar/QuickLaunchWidget.h
+++ b/Userland/Services/Taskbar/QuickLaunchWidget.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, Fabian Blatz <fabianblatz@gmail.com>
+ * Copyright (c) 2023, David Ganz <david.g.ganz@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -88,6 +89,8 @@ public:
 
     virtual void drag_enter_event(GUI::DragEvent&) override;
     virtual void drop_event(GUI::DropEvent&) override;
+
+    ErrorOr<bool> add_from_pid(pid_t pid);
 
 private:
     explicit QuickLaunchWidget();

--- a/Userland/Services/Taskbar/QuickLaunchWidget.h
+++ b/Userland/Services/Taskbar/QuickLaunchWidget.h
@@ -138,6 +138,8 @@ private:
 
     void resize();
 
+    void repaint();
+
     void set_or_insert_entry(NonnullOwnPtr<QuickLaunchEntry>, bool save = true);
     void remove_entry(DeprecatedString const&, bool save = true);
     void recalculate_order();

--- a/Userland/Services/Taskbar/QuickLaunchWidget.h
+++ b/Userland/Services/Taskbar/QuickLaunchWidget.h
@@ -123,6 +123,7 @@ protected:
 private:
     static constexpr StringView CONFIG_DOMAIN = "Taskbar"sv;
     static constexpr StringView CONFIG_GROUP_ENTRIES = "QuickLaunch_Entries"sv;
+    static constexpr StringView OLD_CONFIG_GROUP_ENTRIES = "QuickLaunch"sv;
     static constexpr int BUTTON_SIZE = 24;
 
     explicit QuickLaunchWidget();

--- a/Userland/Services/Taskbar/QuickLaunchWidget.h
+++ b/Userland/Services/Taskbar/QuickLaunchWidget.h
@@ -125,6 +125,11 @@ private:
 
     void set_or_insert_entry(NonnullOwnPtr<QuickLaunchEntry>);
     void remove_entry(DeprecatedString const&);
+    void recalculate_order();
+
+    bool m_dragging { false };
+    Gfx::IntPoint m_mouse_pos;
+    int m_grab_offset { 0 };
 
     RefPtr<GUI::Menu> m_context_menu;
     RefPtr<GUI::Action> m_context_menu_default_action;

--- a/Userland/Services/Taskbar/QuickLaunchWidget.h
+++ b/Userland/Services/Taskbar/QuickLaunchWidget.h
@@ -14,6 +14,7 @@
 #include <LibDesktop/AppFile.h>
 #include <LibGUI/Button.h>
 #include <LibGUI/Frame.h>
+#include <LibGfx/Rect.h>
 
 namespace Taskbar {
 
@@ -27,6 +28,16 @@ public:
 
     static OwnPtr<QuickLaunchEntry> create_from_config_value(StringView path);
     static OwnPtr<QuickLaunchEntry> create_from_path(StringView path);
+
+    bool is_hovered() const { return m_hovered; }
+    void set_hovered(bool hovered) { m_hovered = hovered; }
+
+    void set_pressed(bool pressed) { m_pressed = pressed; }
+    bool is_pressed() const { return m_pressed; }
+
+private:
+    bool m_hovered { false };
+    bool m_pressed { false };
 };
 
 class QuickLaunchEntryAppFile : public QuickLaunchEntry {
@@ -90,18 +101,37 @@ public:
     virtual void drag_enter_event(GUI::DragEvent&) override;
     virtual void drop_event(GUI::DropEvent&) override;
 
+    virtual void mousedown_event(GUI::MouseEvent&) override;
+    virtual void mousemove_event(GUI::MouseEvent&) override;
+    virtual void mouseup_event(GUI::MouseEvent&) override;
+    virtual void context_menu_event(GUI::ContextMenuEvent&) override;
+
+    virtual void leave_event(Core::Event&) override;
+
+    virtual void paint_event(GUI::PaintEvent&) override;
+
     ErrorOr<bool> add_from_pid(pid_t pid);
 
 private:
     explicit QuickLaunchWidget();
-    ErrorOr<void> add_or_adjust_button(DeprecatedString const&, NonnullOwnPtr<QuickLaunchEntry>&&);
+    ErrorOr<void> add_or_adjust_button(DeprecatedString const&, NonnullOwnPtr<QuickLaunchEntry>);
     ErrorOr<void> create_context_menu();
-    ErrorOr<void> add_quick_launch_buttons(Vector<NonnullOwnPtr<QuickLaunchEntry>> entries);
+    void add_quick_launch_buttons(Vector<NonnullOwnPtr<QuickLaunchEntry>> entries);
+
+    template<typename Callback>
+    void for_each_entry(Callback);
+
+    void resize();
+
+    void set_or_insert_entry(NonnullOwnPtr<QuickLaunchEntry>);
+    void remove_entry(DeprecatedString const&);
 
     RefPtr<GUI::Menu> m_context_menu;
     RefPtr<GUI::Action> m_context_menu_default_action;
     DeprecatedString m_context_menu_app_name;
     RefPtr<Core::FileWatcher> m_watcher;
+
+    Vector<NonnullOwnPtr<QuickLaunchEntry>> m_entries;
 };
 
 }

--- a/Userland/Services/WindowServer/ConnectionFromClient.cpp
+++ b/Userland/Services/WindowServer/ConnectionFromClient.cpp
@@ -611,7 +611,7 @@ Window* ConnectionFromClient::window_from_id(i32 window_id)
     return it->value.ptr();
 }
 
-void ConnectionFromClient::create_window(i32 window_id, Gfx::IntRect const& rect,
+void ConnectionFromClient::create_window(i32 window_id, i32 process_id, Gfx::IntRect const& rect,
     bool auto_position, bool has_alpha_channel, bool minimizable, bool closeable, bool resizable,
     bool fullscreen, bool frameless, bool forced_shadow,
     float alpha_hit_threshold, Gfx::IntSize base_size, Gfx::IntSize size_increment,
@@ -642,7 +642,7 @@ void ConnectionFromClient::create_window(i32 window_id, Gfx::IntRect const& rect
         return;
     }
 
-    auto window = Window::construct(*this, (WindowType)type, (WindowMode)mode, window_id, minimizable, closeable, frameless, resizable, fullscreen, parent_window);
+    auto window = Window::construct(*this, (WindowType)type, (WindowMode)mode, window_id, process_id, minimizable, closeable, frameless, resizable, fullscreen, parent_window);
 
     if (auto* blocker = window->blocking_modal_window(); blocker && mode == to_underlying(WindowMode::Blocking)) {
         did_misbehave("CreateWindow with illegal mode: Reciprocally blocked");

--- a/Userland/Services/WindowServer/ConnectionFromClient.h
+++ b/Userland/Services/WindowServer/ConnectionFromClient.h
@@ -102,7 +102,7 @@ private:
     virtual void update_menu_item(i32, i32, i32, DeprecatedString const&, bool, bool, bool, bool, bool, DeprecatedString const&, Gfx::ShareableBitmap const&) override;
     virtual void remove_menu_item(i32 menu_id, i32 identifier) override;
     virtual void flash_menubar_menu(i32, i32) override;
-    virtual void create_window(i32, Gfx::IntRect const&, bool, bool, bool,
+    virtual void create_window(i32, i32, Gfx::IntRect const&, bool, bool, bool,
         bool, bool, bool, bool, bool, float, Gfx::IntSize, Gfx::IntSize, Gfx::IntSize,
         Optional<Gfx::IntSize> const&, i32, i32, DeprecatedString const&, i32, Gfx::IntRect const&) override;
     virtual Messages::WindowServer::DestroyWindowResponse destroy_window(i32) override;

--- a/Userland/Services/WindowServer/Window.cpp
+++ b/Userland/Services/WindowServer/Window.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2023, David Ganz <david.g.ganz@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -743,6 +744,13 @@ void Window::ensure_window_menu()
             m_window_menu->add_item(make<MenuItem>(*m_window_menu, MenuItem::Type::Separator));
         }
 
+        auto add_to_quick_launch_item = make<MenuItem>(*m_window_menu, (unsigned)WindowMenuAction::AddToQuickLaunch, "&Add to Quick Launch");
+        m_window_menu_add_to_quick_launch_item = add_to_quick_launch_item.ptr();
+        m_window_menu_add_to_quick_launch_item->set_icon(&pin_icon());
+        m_window_menu->add_item(move(add_to_quick_launch_item));
+
+        m_window_menu->add_item(make<MenuItem>(*m_window_menu, MenuItem::Type::Separator));
+
         auto close_item = make<MenuItem>(*m_window_menu, (unsigned)WindowMenuAction::Close, "&Close");
         m_window_menu_close_item = close_item.ptr();
         m_window_menu_close_item->set_icon(&close_icon());
@@ -790,6 +798,11 @@ void Window::handle_window_menu_action(WindowMenuAction action)
         auto new_is_checked = !item.is_checked();
         item.set_checked(new_is_checked);
         WindowManager::the().set_always_on_top(*this, new_is_checked);
+        break;
+    }
+    case WindowMenuAction::AddToQuickLaunch: {
+        if (m_process_id.has_value())
+            WindowManager::the().on_add_to_quick_launch(m_process_id.value());
         break;
     }
     }

--- a/Userland/Services/WindowServer/Window.cpp
+++ b/Userland/Services/WindowServer/Window.cpp
@@ -94,7 +94,7 @@ Window::Window(Core::EventReceiver& parent, WindowType type)
     frame().window_was_constructed({});
 }
 
-Window::Window(ConnectionFromClient& client, WindowType window_type, WindowMode window_mode, int window_id, bool minimizable, bool closeable, bool frameless, bool resizable, bool fullscreen, Window* parent_window)
+Window::Window(ConnectionFromClient& client, WindowType window_type, WindowMode window_mode, int window_id, int process_id, bool minimizable, bool closeable, bool frameless, bool resizable, bool fullscreen, Window* parent_window)
     : Core::EventReceiver(&client)
     , m_client(&client)
     , m_type(window_type)
@@ -108,6 +108,7 @@ Window::Window(ConnectionFromClient& client, WindowType window_type, WindowMode 
     , m_client_id(client.client_id())
     , m_icon(default_window_icon())
     , m_frame(*this)
+    , m_process_id(process_id)
 {
     if (parent_window)
         set_parent_window(*parent_window);

--- a/Userland/Services/WindowServer/Window.h
+++ b/Userland/Services/WindowServer/Window.h
@@ -374,7 +374,7 @@ public:
     void send_move_event_to_client();
 
 private:
-    Window(ConnectionFromClient&, WindowType, WindowMode, int window_id, bool minimizable, bool closeable, bool frameless, bool resizable, bool fullscreen, Window* parent_window = nullptr);
+    Window(ConnectionFromClient&, WindowType, WindowMode, int window_id, int process_id, bool minimizable, bool closeable, bool frameless, bool resizable, bool fullscreen, Window* parent_window = nullptr);
     Window(Core::EventReceiver&, WindowType);
 
     virtual void event(Core::Event&) override;
@@ -459,6 +459,8 @@ private:
     bool m_should_show_menubar { true };
     WindowStack* m_window_stack { nullptr };
     RefPtr<Animation> m_animation;
+
+    Optional<pid_t> m_process_id {};
 
 public:
     using List = IntrusiveList<&Window::m_list_node>;

--- a/Userland/Services/WindowServer/Window.h
+++ b/Userland/Services/WindowServer/Window.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2023, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2023, David Ganz <david.g.ganz@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -63,6 +64,7 @@ enum class WindowMenuAction {
     Close,
     Move,
     ToggleAlwaysOnTop,
+    AddToQuickLaunch,
 };
 
 enum class WindowMenuDefaultAction {
@@ -455,6 +457,7 @@ private:
     MenuItem* m_window_menu_close_item { nullptr };
     MenuItem* m_window_menu_always_on_top_item { nullptr };
     MenuItem* m_window_menu_menubar_visibility_item { nullptr };
+    MenuItem* m_window_menu_add_to_quick_launch_item { nullptr };
     Optional<int> m_progress;
     bool m_should_show_menubar { true };
     WindowStack* m_window_stack { nullptr };

--- a/Userland/Services/WindowServer/WindowManager.cpp
+++ b/Userland/Services/WindowServer/WindowManager.cpp
@@ -765,6 +765,14 @@ void WindowManager::stop_tile_window_animation()
     m_tile_window_overlay_animation = nullptr;
 }
 
+void WindowManager::on_add_to_quick_launch(pid_t pid)
+{
+    for_each_window_manager([&](WMConnectionFromClient& conn) {
+        conn.async_add_to_quick_launch(conn.window_id(), pid);
+        return IterationDecision::Continue;
+    });
+}
+
 void WindowManager::show_tile_window_overlay(Window& window, Screen const& cursor_screen, WindowTileType tile_type)
 {
     m_move_window_suggested_tile = tile_type;

--- a/Userland/Services/WindowServer/WindowManager.h
+++ b/Userland/Services/WindowServer/WindowManager.h
@@ -344,6 +344,8 @@ public:
     void start_tile_window_animation(Gfx::IntRect const&);
     void stop_tile_window_animation();
 
+    void on_add_to_quick_launch(pid_t);
+
 private:
     explicit WindowManager(Gfx::PaletteImpl&);
 

--- a/Userland/Services/WindowServer/WindowManagerClient.ipc
+++ b/Userland/Services/WindowServer/WindowManagerClient.ipc
@@ -13,4 +13,5 @@ endpoint WindowManagerClient
     super_digit_key_pressed(i32 wm_id, u8 digit) =|
     workspace_changed(i32 wm_id, u32 row, u32 column) =|
     keymap_changed(i32 wm_id, [UTF8] DeprecatedString keymap) =|
+    add_to_quick_launch(i32 wm_id, i32 process_id) =|
 }

--- a/Userland/Services/WindowServer/WindowServer.ipc
+++ b/Userland/Services/WindowServer/WindowServer.ipc
@@ -44,6 +44,7 @@ endpoint WindowServer
 
     create_window(
         i32 window_id,
+        i32 process_id,
         Gfx::IntRect rect,
         bool auto_position,
         bool has_alpha_channel,


### PR DESCRIPTION
This PR improves the `QuickLaunchWidget` in the Taskbar. Mainly, you can now add applications to Quick Launch via the "Add to Quick Launch" action in the context menu of their windows. In addition, it is now possible to reorder the Quick Launch entries.

![serenity_quick_launch_demo](https://github.com/SerenityOS/serenity/assets/66440035/70b15166-4428-4b89-b27e-6bbbc58a98de)

For the window action I am passing the PID of the process that created the window to `WindowServer` in the `create_window()` IPC route, after which it is stored in `WindowServer::Window`. Then, when clicking the context menu action, an `AddToQuickLaunch` event is sent with the PID from the window. The Taskbar receives the event and forwards the PID to `QuickLaunchWidget`. It finally uses `/sys/kernel/processes` to get the required information for the PID and adds it to its entries.

For the reordering I had to change the way Quick Launch entries are stored in the config: They are now an index with a path, so that we can later reconstruct the order from the config entries. To stay backwards compatible, the application still understands the old format.