### PR TITLE
LibJS: Miscellaneous fixes

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -976,7 +976,12 @@ Bytecode::CodeGenerationErrorOr<void> ObjectExpression::generate_bytecode(Byteco
             if (property_kind == Bytecode::Op::PropertyKind::ProtoSetter) {
                 TRY(property->value().generate_bytecode(generator));
             } else if (property_kind != Bytecode::Op::PropertyKind::Spread) {
-                auto name = generator.intern_identifier(string_literal.value());
+                DeprecatedString identifier = string_literal.value();
+                if (property_kind == Bytecode::Op::PropertyKind::Getter)
+                    identifier = DeprecatedString::formatted("get {}", identifier);
+                else if (property_kind == Bytecode::Op::PropertyKind::Setter)
+                    identifier = DeprecatedString::formatted("set {}", identifier);
+                auto name = generator.intern_identifier(identifier);
                 TRY(generator.emit_named_evaluation_if_anonymous_function(property->value(), name));
             }
 

--- a/Userland/Libraries/LibJS/Parser.cpp
+++ b/Userland/Libraries/LibJS/Parser.cpp
@@ -1643,7 +1643,7 @@ Parser::PrimaryExpressionParseResult Parser::parse_primary_expression()
         return { move(expression) };
     }
     case TokenType::This:
-        consume();
+        consume_and_allow_division();
         return { create_ast_node<ThisExpression>({ m_source_code, rule_start.position(), position() }) };
     case TokenType::Class:
         return { parse_class_expression(false) };

--- a/Userland/Libraries/LibJS/Runtime/VM.cpp
+++ b/Userland/Libraries/LibJS/Runtime/VM.cpp
@@ -1174,10 +1174,8 @@ static Optional<UnrealizedSourceRange> get_source_range(ExecutionContext const* 
     // JIT frame
     for (auto address : native_stack) {
         auto range = native_executable->get_source_range(*context->executable, address);
-        if (range.has_value()) {
-            auto realized = range->realize();
+        if (range.has_value())
             return range;
-        }
     }
 
     return {};

--- a/Userland/Libraries/LibJS/Tests/builtins/Symbol/Symbol.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Symbol/Symbol.js
@@ -23,5 +23,5 @@ test("setting new properties on a symbol is an error in strict mode", () => {
     var symbol = Symbol("foo");
     expect(() => {
         symbol.bar = 42;
-    }).toThrowWithMessage(TypeError, "Cannot set property 'bar' of Symbol(foo)");
+    }).toThrowWithMessage(TypeError, "Cannot set property 'bar' of symbol 'Symbol(foo)'");
 });

--- a/Userland/Libraries/LibJS/Tests/object-basic.js
+++ b/Userland/Libraries/LibJS/Tests/object-basic.js
@@ -221,13 +221,13 @@ describe("naming of anon functions", () => {
         expect({ func() {} }.func.name).toBe("func");
     });
 
-    test.xfail("getter has name", () => {
+    test("getter has name", () => {
         expect(Object.getOwnPropertyDescriptor({ get func() {} }, "func").get.name).toBe(
             "get func"
         );
     });
 
-    test.xfail("setter has name", () => {
+    test("setter has name", () => {
         expect(Object.getOwnPropertyDescriptor({ set func(v) {} }, "func").set.name).toBe(
             "set func"
         );

--- a/Userland/Libraries/LibJS/Tests/strict-mode-errors.js
+++ b/Userland/Libraries/LibJS/Tests/strict-mode-errors.js
@@ -1,23 +1,19 @@
 "use strict";
 
-test.xfail("basic functionality", () => {
-    [true, false, "foo", 123].forEach(primitive => {
+test("basic functionality", () => {
+    [true, false, "foo", 123, 123n, null, undefined].forEach(primitive => {
+        let description = `${typeof primitive} '${primitive}${
+            typeof primitive == "bigint" ? "n" : ""
+        }'`;
+        if (primitive == null) description = String(primitive);
         expect(() => {
             primitive.foo = "bar";
-        }).toThrowWithMessage(TypeError, `Cannot set property 'foo' of ${primitive}`);
+        }).toThrowWithMessage(TypeError, `Cannot set property 'foo' of ${description}`);
         expect(() => {
             primitive[Symbol.hasInstance] = 123;
         }).toThrowWithMessage(
             TypeError,
-            `Cannot set property 'Symbol(Symbol.hasInstance)' of ${primitive}`
+            `Cannot set property 'Symbol(Symbol.hasInstance)' of ${description}`
         );
-    });
-    [null, undefined].forEach(primitive => {
-        expect(() => {
-            primitive.foo = "bar";
-        }).toThrowWithMessage(TypeError, `${primitive} cannot be converted to an object`);
-        expect(() => {
-            primitive[Symbol.hasInstance] = 123;
-        }).toThrowWithMessage(TypeError, `${primitive} cannot be converted to an object`);
     });
 });

--- a/Userland/Libraries/LibJS/Tests/syntax/slash-after-block.js
+++ b/Userland/Libraries/LibJS/Tests/syntax/slash-after-block.js
@@ -45,4 +45,8 @@ test("slash token resolution in lexer", () => {
     expect("yield / b/").not.toEval();
     expect("function* foo() { yield / b }").not.toEval();
     expect("function* foo() { yield / b/ }").toEval();
+
+    expect("this / 1").toEval();
+    expect("this / 1 /").not.toEval();
+    expect("this / 1 / 1").toEval();
 });


### PR DESCRIPTION
- Removes accidental `source_range.realize()`
- Allows `this / 10`
- Assigns name of `{get func() {}}` properly
- Improves error for `(123).foo = "bar"` and friends