### PR TITLE
LibWeb: Begin implementing the Web Animations spec

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -3225,6 +3225,7 @@ void generate_namespace_implementation(IDL::Interface const& interface, StringBu
 
     generator.append(R"~~~(
 // FIXME: This is a total hack until we can figure out the namespace for a given type somehow.
+using namespace Web::Animations;
 using namespace Web::CSS;
 using namespace Web::DOM;
 using namespace Web::DOMParsing;
@@ -3443,6 +3444,7 @@ void generate_constructor_implementation(IDL::Interface const& interface, String
 
     generator.append(R"~~~(
 // FIXME: This is a total hack until we can figure out the namespace for a given type somehow.
+using namespace Web::Animations;
 using namespace Web::CSS;
 using namespace Web::DOM;
 using namespace Web::DOMParsing;
@@ -3828,6 +3830,7 @@ void generate_prototype_implementation(IDL::Interface const& interface, StringBu
     generator.append(R"~~~(
 
 // FIXME: This is a total hack until we can figure out the namespace for a given type somehow.
+using namespace Web::Animations;
 using namespace Web::Crypto;
 using namespace Web::CSS;
 using namespace Web::DOM;
@@ -3977,6 +3980,7 @@ void generate_iterator_prototype_implementation(IDL::Interface const& interface,
 
     generator.append(R"~~~(
 // FIXME: This is a total hack until we can figure out the namespace for a given type somehow.
+using namespace Web::Animations;
 using namespace Web::CSS;
 using namespace Web::DOM;
 using namespace Web::DOMParsing;
@@ -4109,6 +4113,7 @@ void generate_global_mixin_implementation(IDL::Interface const& interface, Strin
     generator.append(R"~~~(
 
 // FIXME: This is a total hack until we can figure out the namespace for a given type somehow.
+using namespace Web::Animations;
 using namespace Web::Crypto;
 using namespace Web::CSS;
 using namespace Web::DOM;

--- a/Userland/Libraries/LibWeb/Animations/AnimationTimeline.cpp
+++ b/Userland/Libraries/LibWeb/Animations/AnimationTimeline.cpp
@@ -26,6 +26,10 @@ WebIDL::ExceptionOr<void> AnimationTimeline::set_current_time(Optional<double> v
 
 void AnimationTimeline::set_associated_document(JS::GCPtr<DOM::Document> document)
 {
+    if (document)
+        document->associate_with_timeline(*this);
+    if (m_associated_document)
+        m_associated_document->disassociate_with_timeline(*this);
     m_associated_document = document;
 }
 
@@ -39,6 +43,12 @@ bool AnimationTimeline::is_inactive() const
 AnimationTimeline::AnimationTimeline(JS::Realm& realm)
     : Bindings::PlatformObject(realm)
 {
+}
+
+AnimationTimeline::~AnimationTimeline()
+{
+    if (m_associated_document)
+        m_associated_document->disassociate_with_timeline(*this);
 }
 
 void AnimationTimeline::initialize(JS::Realm& realm)

--- a/Userland/Libraries/LibWeb/Animations/AnimationTimeline.cpp
+++ b/Userland/Libraries/LibWeb/Animations/AnimationTimeline.cpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2023, Matthew Olsson <mattco@serenityos.org>.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWeb/Animations/AnimationTimeline.h>
+#include <LibWeb/DOM/Document.h>
+
+namespace Web::Animations {
+
+WebIDL::ExceptionOr<void> AnimationTimeline::set_current_time(Optional<double> value)
+{
+    if (value == m_current_time)
+        return {};
+
+    if (m_is_monotonically_increasing && m_current_time.has_value()) {
+        if (!value.has_value() || value.value() < m_current_time.value())
+            m_is_monotonically_increasing = false;
+    }
+
+    m_current_time = value;
+
+    return {};
+}
+
+void AnimationTimeline::set_associated_document(JS::GCPtr<DOM::Document> document)
+{
+    m_associated_document = document;
+}
+
+// https://www.w3.org/TR/web-animations-1/#inactive-timeline
+bool AnimationTimeline::is_inactive() const
+{
+    // A timeline is considered to be inactive when its time value is unresolved.
+    return !m_current_time.has_value();
+}
+
+AnimationTimeline::AnimationTimeline(JS::Realm& realm)
+    : Bindings::PlatformObject(realm)
+{
+}
+
+void AnimationTimeline::initialize(JS::Realm& realm)
+{
+    Base::initialize(realm);
+    set_prototype(&Bindings::ensure_web_prototype<Bindings::AnimationTimelinePrototype>(realm, "AnimationTimeline"));
+}
+
+void AnimationTimeline::visit_edges(Cell::Visitor& visitor)
+{
+    Base::visit_edges(visitor);
+    visitor.visit(m_associated_document);
+}
+
+}

--- a/Userland/Libraries/LibWeb/Animations/AnimationTimeline.h
+++ b/Userland/Libraries/LibWeb/Animations/AnimationTimeline.h
@@ -30,6 +30,7 @@ public:
 
 protected:
     AnimationTimeline(JS::Realm&);
+    virtual ~AnimationTimeline() override;
 
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;

--- a/Userland/Libraries/LibWeb/Animations/AnimationTimeline.h
+++ b/Userland/Libraries/LibWeb/Animations/AnimationTimeline.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2023, Matthew Olsson <mattco@serenityos.org>.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibWeb/Bindings/PlatformObject.h>
+
+namespace Web::Animations {
+
+// https://www.w3.org/TR/web-animations-1/#animationtimeline
+class AnimationTimeline : public Bindings::PlatformObject {
+    WEB_PLATFORM_OBJECT(AnimationTimeline, Bindings::PlatformObject);
+
+public:
+    Optional<double> current_time() const { return m_current_time; }
+    virtual WebIDL::ExceptionOr<void> set_current_time(Optional<double>);
+
+    JS::GCPtr<DOM::Document> associated_document() const { return m_associated_document; }
+    void set_associated_document(JS::GCPtr<DOM::Document>);
+
+    virtual bool is_inactive() const;
+    bool is_monotonically_increasing() const { return m_is_monotonically_increasing; }
+
+    // https://www.w3.org/TR/web-animations-1/#timeline-time-to-origin-relative-time
+    virtual Optional<double> convert_a_timeline_time_to_an_original_relative_time(Optional<double>) { VERIFY_NOT_REACHED(); }
+    virtual bool can_convert_a_timeline_time_to_an_original_relative_time() const { return false; }
+
+protected:
+    AnimationTimeline(JS::Realm&);
+
+    virtual void initialize(JS::Realm&) override;
+    virtual void visit_edges(Cell::Visitor&) override;
+
+    // https://www.w3.org/TR/web-animations-1/#dom-animationtimeline-currenttime
+    Optional<double> m_current_time {};
+
+    // https://www.w3.org/TR/web-animations-1/#monotonically-increasing-timeline
+    bool m_is_monotonically_increasing { true };
+
+    // https://www.w3.org/TR/web-animations-1/#timeline-associated-with-a-document
+    JS::GCPtr<DOM::Document> m_associated_document {};
+};
+
+}

--- a/Userland/Libraries/LibWeb/Animations/AnimationTimeline.idl
+++ b/Userland/Libraries/LibWeb/Animations/AnimationTimeline.idl
@@ -1,0 +1,5 @@
+// https://www.w3.org/TR/web-animations-1/#animationtimeline
+[Exposed=Window]
+interface AnimationTimeline {
+    readonly attribute double? currentTime;
+};

--- a/Userland/Libraries/LibWeb/Animations/DocumentTimeline.cpp
+++ b/Userland/Libraries/LibWeb/Animations/DocumentTimeline.cpp
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2023, Matthew Olsson <mattco@serenityos.org>.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibJS/Heap/Heap.h>
+#include <LibJS/Runtime/Realm.h>
+#include <LibWeb/Animations/DocumentTimeline.h>
+#include <LibWeb/DOM/Document.h>
+#include <LibWeb/HTML/Window.h>
+#include <LibWeb/WebIDL/ExceptionOr.h>
+
+namespace Web::Animations {
+
+JS::NonnullGCPtr<DocumentTimeline> DocumentTimeline::create(JS::Realm& realm, DOM::Document& document, HighResolutionTime::DOMHighResTimeStamp origin_time)
+{
+    return realm.heap().allocate<DocumentTimeline>(realm, realm, document, origin_time);
+}
+
+// https://www.w3.org/TR/web-animations-1/#dom-documenttimeline-documenttimeline
+WebIDL::ExceptionOr<JS::NonnullGCPtr<DocumentTimeline>> DocumentTimeline::construct_impl(JS::Realm& realm, DocumentTimelineOptions options)
+{
+    // Creates a new DocumentTimeline. The Document with which the timeline is associated is the Document associated
+    // with the Window that is the current global object.
+    auto& window = verify_cast<HTML::Window>(realm.global_object());
+    return create(realm, window.associated_document(), options.origin_time);
+}
+
+// https://www.w3.org/TR/web-animations-1/#ref-for-timeline-time-to-origin-relative-time
+Optional<double> DocumentTimeline::convert_a_timeline_time_to_an_original_relative_time(Optional<double> timeline_time)
+{
+    // To convert a timeline time, timeline time, to an origin-relative time for a document timeline, timeline, return
+    // the sum of the timeline time and timeline’s origin time. If timeline is inactive, return an unresolved time
+    // value.
+    if (is_inactive() || !timeline_time.has_value())
+        return {};
+    return timeline_time.value() + m_origin_time;
+}
+
+// https://www.w3.org/TR/web-animations-1/#origin-time
+WebIDL::ExceptionOr<void> DocumentTimeline::set_current_time(Optional<double> current_time)
+{
+    // A document timeline is a type of timeline that is associated with a document and whose current time is calculated
+    // as a fixed offset from the now timestamp provided each time the update animations and send events procedure is
+    // run. This fixed offset is referred to as the document timeline’s origin time.
+    if (!current_time.has_value())
+        TRY(Base::set_current_time({}));
+    else
+        TRY(Base::set_current_time(current_time.value() - m_origin_time));
+
+    // After a document timeline becomes active, it is monotonically increasing.
+    if (!is_inactive())
+        VERIFY(is_monotonically_increasing());
+
+    return {};
+}
+
+// https://www.w3.org/TR/web-animations-1/#document-timelines
+bool DocumentTimeline::is_inactive() const
+{
+    // A document timeline that is associated with a Document which is not an active document is also considered to be
+    // inactive.
+    return Base::is_inactive() || !associated_document()->is_active();
+}
+
+DocumentTimeline::DocumentTimeline(JS::Realm& realm, DOM::Document& document, HighResolutionTime::DOMHighResTimeStamp origin_time)
+    : AnimationTimeline(realm)
+    , m_origin_time(origin_time)
+{
+    set_associated_document(document);
+}
+
+void DocumentTimeline::initialize(JS::Realm& realm)
+{
+    Base::initialize(realm);
+    set_prototype(&Bindings::ensure_web_prototype<Bindings::DocumentTimelinePrototype>(realm, "DocumentTimeline"));
+}
+
+}

--- a/Userland/Libraries/LibWeb/Animations/DocumentTimeline.h
+++ b/Userland/Libraries/LibWeb/Animations/DocumentTimeline.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2023, Matthew Olsson <mattco@serenityos.org>.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibWeb/Animations/AnimationTimeline.h>
+#include <LibWeb/HighResolutionTime/DOMHighResTimeStamp.h>
+#include <LibWeb/WebIDL/ExceptionOr.h>
+
+namespace Web::Animations {
+
+// https://www.w3.org/TR/web-animations-1/#dictdef-documenttimelineoptions
+struct DocumentTimelineOptions {
+    HighResolutionTime::DOMHighResTimeStamp origin_time { 0.0 };
+};
+
+// https://www.w3.org/TR/web-animations-1/#the-documenttimeline-interface
+class DocumentTimeline : public AnimationTimeline {
+    WEB_PLATFORM_OBJECT(DocumentTimeline, AnimationTimeline);
+
+public:
+    static JS::NonnullGCPtr<DocumentTimeline> create(JS::Realm&, DOM::Document&, HighResolutionTime::DOMHighResTimeStamp origin_time);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<DocumentTimeline>> construct_impl(JS::Realm&, DocumentTimelineOptions options = {});
+
+    virtual WebIDL::ExceptionOr<void> set_current_time(Optional<double> current_time) override;
+    virtual bool is_inactive() const override;
+
+    virtual Optional<double> convert_a_timeline_time_to_an_original_relative_time(Optional<double>) override;
+    virtual bool can_convert_a_timeline_time_to_an_original_relative_time() const override { return true; }
+
+private:
+    DocumentTimeline(JS::Realm&, DOM::Document&, HighResolutionTime::DOMHighResTimeStamp origin_time);
+
+    virtual void initialize(JS::Realm&) override;
+
+    HighResolutionTime::DOMHighResTimeStamp m_origin_time;
+};
+
+}

--- a/Userland/Libraries/LibWeb/Animations/DocumentTimeline.h
+++ b/Userland/Libraries/LibWeb/Animations/DocumentTimeline.h
@@ -33,6 +33,7 @@ public:
 
 private:
     DocumentTimeline(JS::Realm&, DOM::Document&, HighResolutionTime::DOMHighResTimeStamp origin_time);
+    virtual ~DocumentTimeline() override = default;
 
     virtual void initialize(JS::Realm&) override;
 

--- a/Userland/Libraries/LibWeb/Animations/DocumentTimeline.idl
+++ b/Userland/Libraries/LibWeb/Animations/DocumentTimeline.idl
@@ -1,0 +1,13 @@
+#import <Animations/AnimationTimeline.idl>
+#import <HighResolutionTime/DOMHighResTimeStamp.idl>
+
+// https://www.w3.org/TR/web-animations-1/#dictdef-documenttimelineoptions
+dictionary DocumentTimelineOptions {
+  DOMHighResTimeStamp originTime = 0;
+};
+
+// https://www.w3.org/TR/web-animations-1/#documenttimeline
+[Exposed=Window]
+interface DocumentTimeline : AnimationTimeline {
+  constructor(optional DocumentTimelineOptions options = {});
+};

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -3,6 +3,7 @@ include(accelerated_graphics)
 
 set(SOURCES
     Animations/AnimationTimeline.cpp
+    Animations/DocumentTimeline.cpp
     ARIA/AriaData.cpp
     ARIA/ARIAMixin.cpp
     ARIA/Roles.cpp

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -2,6 +2,7 @@ include(libweb_generators)
 include(accelerated_graphics)
 
 set(SOURCES
+    Animations/AnimationTimeline.cpp
     ARIA/AriaData.cpp
     ARIA/ARIAMixin.cpp
     ARIA/Roles.cpp

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -16,6 +16,7 @@
 #include <LibJS/Runtime/Array.h>
 #include <LibJS/Runtime/FunctionObject.h>
 #include <LibJS/Runtime/NativeFunction.h>
+#include <LibWeb/Animations/DocumentTimeline.h>
 #include <LibWeb/Bindings/MainThreadVM.h>
 #include <LibWeb/CSS/MediaQueryList.h>
 #include <LibWeb/CSS/MediaQueryListEvent.h>
@@ -382,6 +383,8 @@ void Document::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_parser);
     visitor.visit(m_lazy_load_intersection_observer);
     visitor.visit(m_visual_viewport);
+
+    visitor.visit(m_default_timeline);
 
     for (auto& script : m_scripts_to_execute_when_parsing_has_finished)
         visitor.visit(script);
@@ -3560,6 +3563,15 @@ void Document::update_for_history_step_application(JS::NonnullGCPtr<HTML::Sessio
 HashMap<AK::URL, HTML::SharedImageRequest*>& Document::shared_image_requests()
 {
     return m_shared_image_requests;
+}
+
+// https://www.w3.org/TR/web-animations-1/#dom-document-timeline
+JS::NonnullGCPtr<Animations::DocumentTimeline> Document::timeline()
+{
+    // The DocumentTimeline object representing the default document timeline.
+    if (!m_default_timeline)
+        m_default_timeline = Animations::DocumentTimeline::create(realm(), *this, static_cast<double>(MonotonicTime::now().milliseconds()));
+    return *m_default_timeline;
 }
 
 }

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -404,6 +404,9 @@ void Document::visit_edges(Cell::Visitor& visitor)
 
     for (auto& observer : m_intersection_observers)
         visitor.visit(observer);
+
+    for (auto& timeline : m_associated_animation_timelines)
+        visitor.visit(timeline);
 }
 
 // https://w3c.github.io/selection-api/#dom-document-getselection
@@ -3572,6 +3575,16 @@ JS::NonnullGCPtr<Animations::DocumentTimeline> Document::timeline()
     if (!m_default_timeline)
         m_default_timeline = Animations::DocumentTimeline::create(realm(), *this, static_cast<double>(MonotonicTime::now().milliseconds()));
     return *m_default_timeline;
+}
+
+void Document::associate_with_timeline(JS::NonnullGCPtr<Animations::AnimationTimeline> timeline)
+{
+    m_associated_animation_timelines.set(timeline);
+}
+
+void Document::disassociate_with_timeline(JS::NonnullGCPtr<Animations::AnimationTimeline> timeline)
+{
+    m_associated_animation_timelines.remove(timeline);
 }
 
 }

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -536,6 +536,9 @@ public:
 
     JS::NonnullGCPtr<Animations::DocumentTimeline> timeline();
 
+    void associate_with_timeline(JS::NonnullGCPtr<Animations::AnimationTimeline>);
+    void disassociate_with_timeline(JS::NonnullGCPtr<Animations::AnimationTimeline>);
+
 protected:
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
@@ -742,6 +745,9 @@ private:
     JS::GCPtr<HTML::SessionHistoryEntry> m_latest_entry;
 
     HashMap<AK::URL, HTML::SharedImageRequest*> m_shared_image_requests;
+
+    // https://www.w3.org/TR/web-animations-1/#timeline-associated-with-a-document
+    HashTable<JS::NonnullGCPtr<Animations::AnimationTimeline>> m_associated_animation_timelines;
 
     // https://www.w3.org/TR/web-animations-1/#document-default-document-timeline
     JS::GCPtr<Animations::DocumentTimeline> m_default_timeline;

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -534,6 +534,8 @@ public:
 
     HashMap<AK::URL, HTML::SharedImageRequest*>& shared_image_requests();
 
+    JS::NonnullGCPtr<Animations::DocumentTimeline> timeline();
+
 protected:
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
@@ -740,6 +742,9 @@ private:
     JS::GCPtr<HTML::SessionHistoryEntry> m_latest_entry;
 
     HashMap<AK::URL, HTML::SharedImageRequest*> m_shared_image_requests;
+
+    // https://www.w3.org/TR/web-animations-1/#document-default-document-timeline
+    JS::GCPtr<Animations::DocumentTimeline> m_default_timeline;
 };
 
 template<>

--- a/Userland/Libraries/LibWeb/DOM/Document.idl
+++ b/Userland/Libraries/LibWeb/DOM/Document.idl
@@ -1,3 +1,4 @@
+#import <Animations/DocumentTimeline.idl>
 #import <CSS/StyleSheetList.idl>
 #import <DOM/Comment.idl>
 #import <DOM/DOMImplementation.idl>
@@ -112,6 +113,9 @@ interface Document : Node {
     [NewObject] TreeWalker createTreeWalker(Node root, optional unsigned long whatToShow = 0xFFFFFFFF, optional NodeFilter? filter = null);
 
     Selection? getSelection();
+
+    // https://www.w3.org/TR/web-animations-1/#extensions-to-the-document-interface
+    readonly attribute DocumentTimeline timeline;
 };
 
 dictionary ElementCreationOptions {

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -28,6 +28,7 @@ class RecordingPainter;
 
 namespace Web::Animations {
 class AnimationTimeline;
+class DocumentTimeline;
 }
 
 namespace Web::ARIA {

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -26,6 +26,10 @@ namespace Web::Painting {
 class RecordingPainter;
 }
 
+namespace Web::Animations {
+class AnimationTimeline;
+}
+
 namespace Web::ARIA {
 class AriaData;
 class ARIAMixin;

--- a/Userland/Libraries/LibWeb/idl_files.cmake
+++ b/Userland/Libraries/LibWeb/idl_files.cmake
@@ -2,6 +2,7 @@
 # It is defined here so that there is no need to go to the Meta directory when adding new idl files
 
 libweb_js_bindings(Animations/AnimationTimeline)
+libweb_js_bindings(Animations/DocumentTimeline)
 libweb_js_bindings(Crypto/Crypto)
 libweb_js_bindings(Crypto/SubtleCrypto)
 libweb_js_bindings(CSS/CSSConditionRule)

--- a/Userland/Libraries/LibWeb/idl_files.cmake
+++ b/Userland/Libraries/LibWeb/idl_files.cmake
@@ -1,6 +1,7 @@
 # This file is included from "Meta/CMake/libweb_data.cmake"
 # It is defined here so that there is no need to go to the Meta directory when adding new idl files
 
+libweb_js_bindings(Animations/AnimationTimeline)
 libweb_js_bindings(Crypto/Crypto)
 libweb_js_bindings(Crypto/SubtleCrypto)
 libweb_js_bindings(CSS/CSSConditionRule)


### PR DESCRIPTION
This PR just includes the `AnimationTimeline` and `DocumentTimeline` IDL objects. These objects are responsible for propagating a particular time through the animation hierarchy, as each animation will have one associated timeline. In practice, the only timeline that will be used is the `DocumentTimeline`, as it's the only inheritor. 

Work towards #21570