### PR TITLE
LibGfx/GIF: Extract the LZW decoder

### DIFF
--- a/AK/MemoryStream.cpp
+++ b/AK/MemoryStream.cpp
@@ -12,9 +12,9 @@
 
 namespace AK {
 
-FixedMemoryStream::FixedMemoryStream(Bytes bytes, bool writing_enabled)
+FixedMemoryStream::FixedMemoryStream(Bytes bytes, Mode mode)
     : m_bytes(bytes)
-    , m_writing_enabled(writing_enabled)
+    , m_writing_enabled(mode == Mode::ReadWrite)
 {
 }
 

--- a/AK/MemoryStream.h
+++ b/AK/MemoryStream.h
@@ -18,7 +18,12 @@ namespace AK {
 /// using a single read/write head.
 class FixedMemoryStream : public SeekableStream {
 public:
-    explicit FixedMemoryStream(Bytes bytes, bool writing_enabled = true);
+    enum class Mode {
+        ReadOnly,
+        ReadWrite,
+    };
+
+    explicit FixedMemoryStream(Bytes bytes, Mode mode = Mode::ReadWrite);
     explicit FixedMemoryStream(ReadonlyBytes bytes);
 
     virtual bool is_eof() const override;

--- a/Tests/AK/TestMemoryStream.cpp
+++ b/Tests/AK/TestMemoryStream.cpp
@@ -259,7 +259,7 @@ TEST_CASE(fixed_memory_read_in_place)
     EXPECT_EQ(characters, some_words.bytes());
     EXPECT(readonly_stream.is_eof());
 
-    FixedMemoryStream mutable_stream { Bytes { const_cast<u8*>(some_words.bytes().data()), some_words.bytes().size() }, true };
+    FixedMemoryStream mutable_stream { Bytes { const_cast<u8*>(some_words.bytes().data()), some_words.bytes().size() }, FixedMemoryStream::Mode::ReadWrite };
     // Trying to read mutable values from a mutable stream should succeed.
     TRY_OR_FAIL(mutable_stream.read_in_place<u8>(1));
     EXPECT_EQ(mutable_stream.offset(), 1u);

--- a/Tests/LibCore/TestLibCoreMappedFile.cpp
+++ b/Tests/LibCore/TestLibCoreMappedFile.cpp
@@ -27,7 +27,7 @@ TEST_CASE(mapped_file_open)
         TRY_OR_FAIL(maybe_file.value()->write_until_depleted(text.bytes()));
     }
 
-    auto maybe_file = Core::MappedFile::map("/tmp/file-open-test.txt"sv, Core::MappedFile::OpenMode::ReadWrite);
+    auto maybe_file = Core::MappedFile::map("/tmp/file-open-test.txt"sv, Core::MappedFile::Mode::ReadWrite);
     if (maybe_file.is_error()) {
         warnln("Failed to open the file: {}", strerror(maybe_file.error().code()));
         VERIFY_NOT_REACHED();
@@ -46,7 +46,7 @@ constexpr auto expected_buffer_contents = "&lt;small&gt;(Please consider transla
 
 TEST_CASE(mapped_file_read_bytes)
 {
-    auto file = TRY_OR_FAIL(Core::MappedFile::map("/usr/Tests/LibCore/long_lines.txt"sv, Core::MappedFile::OpenMode::ReadOnly));
+    auto file = TRY_OR_FAIL(Core::MappedFile::map("/usr/Tests/LibCore/long_lines.txt"sv, Core::MappedFile::Mode::ReadOnly));
 
     auto buffer = TRY_OR_FAIL(ByteBuffer::create_uninitialized(131));
 
@@ -63,7 +63,7 @@ constexpr auto expected_seek_contents3 = "levels of advanc"sv;
 
 TEST_CASE(mapped_file_seeking_around)
 {
-    auto file = TRY_OR_FAIL(Core::MappedFile::map("/usr/Tests/LibCore/long_lines.txt"sv, Core::MappedFile::OpenMode::ReadOnly));
+    auto file = TRY_OR_FAIL(Core::MappedFile::map("/usr/Tests/LibCore/long_lines.txt"sv, Core::MappedFile::Mode::ReadOnly));
 
     EXPECT_EQ(file->size().release_value(), 8702ul);
 
@@ -89,7 +89,7 @@ TEST_CASE(mapped_file_seeking_around)
 
 BENCHMARK_CASE(file_tell)
 {
-    auto file = TRY_OR_FAIL(Core::MappedFile::map("/usr/Tests/LibCore/10kb.txt"sv, Core::MappedFile::OpenMode::ReadOnly));
+    auto file = TRY_OR_FAIL(Core::MappedFile::map("/usr/Tests/LibCore/10kb.txt"sv, Core::MappedFile::Mode::ReadOnly));
     auto expected_file_offset = 0u;
     auto ten_byte_buffer = TRY_OR_FAIL(ByteBuffer::create_uninitialized(1));
     for (auto i = 0u; i < 4000; ++i) {

--- a/Userland/Libraries/LibAudio/Loader.cpp
+++ b/Userland/Libraries/LibAudio/Loader.cpp
@@ -44,7 +44,7 @@ static constexpr LoaderPluginInitializer s_initializers[] = {
 
 ErrorOr<NonnullRefPtr<Loader>, LoaderError> Loader::create(StringView path)
 {
-    auto stream = TRY(Core::MappedFile::map(path, Core::MappedFile::OpenMode::ReadOnly));
+    auto stream = TRY(Core::MappedFile::map(path, Core::MappedFile::Mode::ReadOnly));
     return adopt_ref(*new (nothrow) Loader(TRY(Loader::create_plugin(move(stream)))));
 }
 

--- a/Userland/Libraries/LibCompress/LZWDecoder.h
+++ b/Userland/Libraries/LibCompress/LZWDecoder.h
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2018-2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2022, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Debug.h>
+#include <AK/Format.h>
+#include <AK/IntegralMath.h>
+#include <AK/Vector.h>
+
+namespace Compress {
+
+class LZWDecoder {
+private:
+    static constexpr int max_code_size = 12;
+
+public:
+    explicit LZWDecoder(Vector<u8> const& lzw_bytes, u8 min_code_size)
+        : m_lzw_bytes(lzw_bytes)
+        , m_code_size(min_code_size)
+        , m_original_code_size(min_code_size)
+        , m_table_capacity(AK::exp2<u32>(min_code_size))
+    {
+        init_code_table();
+    }
+
+    u16 add_control_code()
+    {
+        u16 const control_code = m_code_table.size();
+        m_code_table.append(Vector<u8> {});
+        m_original_code_table.append(Vector<u8> {});
+        if (m_code_table.size() >= m_table_capacity && m_code_size < max_code_size) {
+            ++m_code_size;
+            ++m_original_code_size;
+            m_table_capacity *= 2;
+        }
+        return control_code;
+    }
+
+    void reset()
+    {
+        m_code_table.clear();
+        m_code_table.extend(m_original_code_table);
+        m_code_size = m_original_code_size;
+        m_table_capacity = AK::exp2<u32>(m_code_size);
+        m_output.clear();
+    }
+
+    ErrorOr<u16> next_code()
+    {
+        size_t current_byte_index = m_current_bit_index / 8;
+        if (current_byte_index >= m_lzw_bytes.size()) {
+            return Error::from_string_literal("LZWDecoder tries to read ouf of bounds");
+        }
+
+        // Extract the code bits using a 32-bit mask to cover the possibility that if
+        // the current code size > 9 bits then the code can span 3 bytes.
+        u8 current_bit_offset = m_current_bit_index % 8;
+        u32 mask = (u32)(m_table_capacity - 1) << current_bit_offset;
+
+        // Make a padded copy of the final bytes in the data to ensure we don't read past the end.
+        if (current_byte_index + sizeof(mask) > m_lzw_bytes.size()) {
+            u8 padded_last_bytes[sizeof(mask)] = { 0 };
+            for (int i = 0; current_byte_index + i < m_lzw_bytes.size(); ++i) {
+                padded_last_bytes[i] = m_lzw_bytes[current_byte_index + i];
+            }
+            u32 const* addr = (u32 const*)&padded_last_bytes;
+            m_current_code = (*addr & mask) >> current_bit_offset;
+        } else {
+            u32 tmp_word;
+            memcpy(&tmp_word, &m_lzw_bytes.at(current_byte_index), sizeof(u32));
+            m_current_code = (tmp_word & mask) >> current_bit_offset;
+        }
+
+        if (m_current_code > m_code_table.size()) {
+            dbgln_if(GIF_DEBUG, "Corrupted LZW stream, invalid code: {} at bit index {}, code table size: {}",
+                m_current_code,
+                m_current_bit_index,
+                m_code_table.size());
+            return Error::from_string_literal("Corrupted LZW stream, invalid code");
+        } else if (m_current_code == m_code_table.size() && m_output.is_empty()) {
+            dbgln_if(GIF_DEBUG, "Corrupted LZW stream, valid new code but output buffer is empty: {} at bit index {}, code table size: {}",
+                m_current_code,
+                m_current_bit_index,
+                m_code_table.size());
+            return Error::from_string_literal("Corrupted LZW stream, valid new code but output buffer is empty");
+        }
+
+        m_current_bit_index += m_code_size;
+
+        return m_current_code;
+    }
+
+    Vector<u8>& get_output()
+    {
+        VERIFY(m_current_code <= m_code_table.size());
+        if (m_current_code < m_code_table.size()) {
+            Vector<u8> new_entry = m_output;
+            m_output = m_code_table.at(m_current_code);
+            new_entry.append(m_output[0]);
+            extend_code_table(new_entry);
+        } else if (m_current_code == m_code_table.size()) {
+            VERIFY(!m_output.is_empty());
+            m_output.append(m_output[0]);
+            extend_code_table(m_output);
+        }
+        return m_output;
+    }
+
+private:
+    void init_code_table()
+    {
+        m_code_table.ensure_capacity(m_table_capacity);
+        for (u16 i = 0; i < m_table_capacity; ++i) {
+            m_code_table.unchecked_append({ (u8)i });
+        }
+        m_original_code_table = m_code_table;
+    }
+
+    void extend_code_table(Vector<u8> const& entry)
+    {
+        if (entry.size() > 1 && m_code_table.size() < 4096) {
+            m_code_table.append(entry);
+            if (m_code_table.size() >= m_table_capacity && m_code_size < max_code_size) {
+                ++m_code_size;
+                m_table_capacity *= 2;
+            }
+        }
+    }
+
+    Vector<u8> const& m_lzw_bytes;
+
+    int m_current_bit_index { 0 };
+
+    Vector<Vector<u8>> m_code_table {};
+    Vector<Vector<u8>> m_original_code_table {};
+
+    u8 m_code_size { 0 };
+    u8 m_original_code_size { 0 };
+
+    u32 m_table_capacity { 0 };
+
+    u16 m_current_code { 0 };
+    Vector<u8> m_output {};
+};
+
+}

--- a/Userland/Libraries/LibCore/MappedFile.h
+++ b/Userland/Libraries/LibCore/MappedFile.h
@@ -22,15 +22,9 @@ class MappedFile : public FixedMemoryStream {
     AK_MAKE_NONMOVABLE(MappedFile);
 
 public:
-    // Reflects a simplified version of mmap protection and flags.
-    enum class OpenMode {
-        ReadOnly,
-        ReadWrite,
-    };
-
-    static ErrorOr<NonnullOwnPtr<MappedFile>> map(StringView path, OpenMode mode = OpenMode::ReadOnly);
+    static ErrorOr<NonnullOwnPtr<MappedFile>> map(StringView path, Mode mode = Mode::ReadOnly);
     static ErrorOr<NonnullOwnPtr<MappedFile>> map_from_file(NonnullOwnPtr<Core::File>, StringView path);
-    static ErrorOr<NonnullOwnPtr<MappedFile>> map_from_fd_and_close(int fd, StringView path, OpenMode mode = OpenMode::ReadOnly);
+    static ErrorOr<NonnullOwnPtr<MappedFile>> map_from_fd_and_close(int fd, StringView path, Mode mode = Mode::ReadOnly);
     virtual ~MappedFile();
 
     // Non-stream APIs for using MappedFile as a simple POSIX API wrapper.
@@ -39,7 +33,7 @@ public:
     ReadonlyBytes bytes() const { return { m_data, m_size }; }
 
 private:
-    explicit MappedFile(void*, size_t, OpenMode);
+    explicit MappedFile(void*, size_t, Mode);
 
     void* m_data { nullptr };
     size_t m_size { 0 };

--- a/Userland/Libraries/LibGfx/ImageFormats/GIFLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/GIFLoader.cpp
@@ -13,6 +13,7 @@
 #include <AK/Memory.h>
 #include <AK/MemoryStream.h>
 #include <AK/Try.h>
+#include <LibCompress/LZWDecoder.h>
 #include <LibGfx/ImageFormats/GIFLoader.h>
 #include <string.h>
 
@@ -110,141 +111,6 @@ static ErrorOr<GIFFormat> decode_gif_header(Stream& stream)
     return Error::from_string_literal("GIF header unknown");
 }
 
-class LZWDecoder {
-private:
-    static constexpr int max_code_size = 12;
-
-public:
-    explicit LZWDecoder(Vector<u8> const& lzw_bytes, u8 min_code_size)
-        : m_lzw_bytes(lzw_bytes)
-        , m_code_size(min_code_size)
-        , m_original_code_size(min_code_size)
-        , m_table_capacity(AK::exp2<u32>(min_code_size))
-    {
-        init_code_table();
-    }
-
-    u16 add_control_code()
-    {
-        u16 const control_code = m_code_table.size();
-        m_code_table.append(Vector<u8> {});
-        m_original_code_table.append(Vector<u8> {});
-        if (m_code_table.size() >= m_table_capacity && m_code_size < max_code_size) {
-
-            ++m_code_size;
-            ++m_original_code_size;
-            m_table_capacity *= 2;
-        }
-        return control_code;
-    }
-
-    void reset()
-    {
-        m_code_table.clear();
-        m_code_table.extend(m_original_code_table);
-        m_code_size = m_original_code_size;
-        m_table_capacity = AK::exp2<u32>(m_code_size);
-        m_output.clear();
-    }
-
-    ErrorOr<u16> next_code()
-    {
-        size_t current_byte_index = m_current_bit_index / 8;
-        if (current_byte_index >= m_lzw_bytes.size()) {
-            return Error::from_string_literal("LZWDecoder tries to read ouf of bounds");
-        }
-
-        // Extract the code bits using a 32-bit mask to cover the possibility that if
-        // the current code size > 9 bits then the code can span 3 bytes.
-        u8 current_bit_offset = m_current_bit_index % 8;
-        u32 mask = (u32)(m_table_capacity - 1) << current_bit_offset;
-
-        // Make a padded copy of the final bytes in the data to ensure we don't read past the end.
-        if (current_byte_index + sizeof(mask) > m_lzw_bytes.size()) {
-            u8 padded_last_bytes[sizeof(mask)] = { 0 };
-            for (int i = 0; current_byte_index + i < m_lzw_bytes.size(); ++i) {
-                padded_last_bytes[i] = m_lzw_bytes[current_byte_index + i];
-            }
-            u32 const* addr = (u32 const*)&padded_last_bytes;
-            m_current_code = (*addr & mask) >> current_bit_offset;
-        } else {
-            u32 tmp_word;
-            memcpy(&tmp_word, &m_lzw_bytes.at(current_byte_index), sizeof(u32));
-            m_current_code = (tmp_word & mask) >> current_bit_offset;
-        }
-
-        if (m_current_code > m_code_table.size()) {
-            dbgln_if(GIF_DEBUG, "Corrupted LZW stream, invalid code: {} at bit index {}, code table size: {}",
-                m_current_code,
-                m_current_bit_index,
-                m_code_table.size());
-            return Error::from_string_literal("Corrupted LZW stream, invalid code");
-        } else if (m_current_code == m_code_table.size() && m_output.is_empty()) {
-            dbgln_if(GIF_DEBUG, "Corrupted LZW stream, valid new code but output buffer is empty: {} at bit index {}, code table size: {}",
-                m_current_code,
-                m_current_bit_index,
-                m_code_table.size());
-            return Error::from_string_literal("Corrupted LZW stream, valid new code but output buffer is empty");
-        }
-
-        m_current_bit_index += m_code_size;
-
-        return m_current_code;
-    }
-
-    Vector<u8>& get_output()
-    {
-        VERIFY(m_current_code <= m_code_table.size());
-        if (m_current_code < m_code_table.size()) {
-            Vector<u8> new_entry = m_output;
-            m_output = m_code_table.at(m_current_code);
-            new_entry.append(m_output[0]);
-            extend_code_table(new_entry);
-        } else if (m_current_code == m_code_table.size()) {
-            VERIFY(!m_output.is_empty());
-            m_output.append(m_output[0]);
-            extend_code_table(m_output);
-        }
-        return m_output;
-    }
-
-private:
-    void init_code_table()
-    {
-        m_code_table.ensure_capacity(m_table_capacity);
-        for (u16 i = 0; i < m_table_capacity; ++i) {
-            m_code_table.unchecked_append({ (u8)i });
-        }
-        m_original_code_table = m_code_table;
-    }
-
-    void extend_code_table(Vector<u8> const& entry)
-    {
-        if (entry.size() > 1 && m_code_table.size() < 4096) {
-            m_code_table.append(entry);
-            if (m_code_table.size() >= m_table_capacity && m_code_size < max_code_size) {
-                ++m_code_size;
-                m_table_capacity *= 2;
-            }
-        }
-    }
-
-    Vector<u8> const& m_lzw_bytes;
-
-    int m_current_bit_index { 0 };
-
-    Vector<Vector<u8>> m_code_table {};
-    Vector<Vector<u8>> m_original_code_table {};
-
-    u8 m_code_size { 0 };
-    u8 m_original_code_size { 0 };
-
-    u32 m_table_capacity { 0 };
-
-    u16 m_current_code { 0 };
-    Vector<u8> m_output {};
-};
-
 static void copy_frame_buffer(Bitmap& dest, Bitmap const& src)
 {
     VERIFY(dest.size_in_bytes() == src.size_in_bytes());
@@ -317,7 +183,7 @@ static ErrorOr<void> decode_frame(GIFLoadingContext& context, size_t frame_index
         if (image->lzw_min_code_size > 8)
             return Error::from_string_literal("LZW minimum code size is greater than 8");
 
-        LZWDecoder decoder(image->lzw_encoded_bytes, image->lzw_min_code_size);
+        Compress::LZWDecoder decoder(image->lzw_encoded_bytes, image->lzw_min_code_size);
 
         // Add GIF-specific control codes
         int const clear_code = decoder.add_control_code();

--- a/Userland/Libraries/LibGfx/ImageFormats/GIFLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/GIFLoader.cpp
@@ -46,7 +46,7 @@ struct GIFImageDescriptor {
     bool transparent { false };
     bool user_input { false };
 
-    const IntRect rect() const
+    IntRect rect() const
     {
         return { this->x, this->y, this->width, this->height };
     }
@@ -126,7 +126,7 @@ public:
 
     u16 add_control_code()
     {
-        const u16 control_code = m_code_table.size();
+        u16 const control_code = m_code_table.size();
         m_code_table.append(Vector<u8> {});
         m_original_code_table.append(Vector<u8> {});
         if (m_code_table.size() >= m_table_capacity && m_code_size < max_code_size) {
@@ -258,7 +258,7 @@ static void clear_rect(Bitmap& bitmap, IntRect const& rect, Color color)
         return;
 
     ARGB32* dst = bitmap.scanline(intersection_rect.top()) + intersection_rect.left();
-    const size_t dst_skip = bitmap.pitch() / sizeof(ARGB32);
+    size_t const dst_skip = bitmap.pitch() / sizeof(ARGB32);
 
     for (int i = intersection_rect.height() - 1; i >= 0; --i) {
         fast_u32_fill(dst, color.value(), intersection_rect.width());


### PR DESCRIPTION
These commits are preliminary work towards LZW support in TIFF. As we are two PRs away from being in the state of adding LZW to the TIFF decoder, I decided to split independent changes.

This PR is fairly simple, it moves the LZW decoder to its own file and use LittleEndianInputBitStream instead of manually implementing the logic.