### PR TITLE
Build fixes and workarounds for Clang trunk

### DIFF
--- a/Ladybird/AppKit/Application/EventLoopImplementation.mm
+++ b/Ladybird/AppKit/Application/EventLoopImplementation.mm
@@ -130,7 +130,7 @@ void CFEventLoopManager::register_notifier(Core::Notifier& notifier)
         break;
     }
 
-    CFSocketContext context { .info = &notifier };
+    CFSocketContext context { .version = 0, .info = &notifier, .retain = nullptr, .release = nullptr, .copyDescription = nullptr };
     auto* socket = CFSocketCreateWithNative(kCFAllocatorDefault, notifier.fd(), notification_type, &socket_notifier, &context);
 
     CFOptionFlags sockopt = CFSocketGetSocketFlags(socket);

--- a/Meta/CMake/common_compile_options.cmake
+++ b/Meta/CMake/common_compile_options.cmake
@@ -24,6 +24,7 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang$")
 
     add_compile_options(-Wno-implicit-const-int-float-conversion)
     add_compile_options(-Wno-user-defined-literals)
+    add_compile_options(-Wno-vla-cxx-extension)
 elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     # Only ignore expansion-to-defined for g++, clang's implementation doesn't complain about function-like macros
     add_compile_options(-Wno-expansion-to-defined)

--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormatConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormatConstructor.cpp
@@ -273,7 +273,7 @@ ThrowCompletionOr<NonnullGCPtr<DateTimeFormat>> create_date_time_format(VM& vm, 
     PropertyKey const* explicit_format_component = nullptr;
 
     // 39. For each row of Table 6, except the header row, in table order, do
-    TRY(for_each_calendar_field(vm, format_options, [&](auto& option, auto const& property, auto const& values) -> ThrowCompletionOr<void> {
+    TRY(for_each_calendar_field(vm, format_options, [&](auto& option, PropertyKey const& property, auto const& values) -> ThrowCompletionOr<void> {
         using ValueType = typename RemoveReference<decltype(option)>::ValueType;
 
         // a. Let prop be the name given in the Property column of the row.

--- a/Userland/Libraries/LibWeb/WebDriver/Capabilities.cpp
+++ b/Userland/Libraries/LibWeb/WebDriver/Capabilities.cpp
@@ -77,7 +77,7 @@ static ErrorOr<JsonObject, Error> validate_capabilities(JsonValue const& capabil
     JsonObject result;
 
     // 3. For each enumerable own property in capability, run the following substeps:
-    TRY(capability.as_object().try_for_each_member([&](auto const& name, auto const& value) -> ErrorOr<void, Error> {
+    TRY(capability.as_object().try_for_each_member([&](auto const& name, JsonValue const& value) -> ErrorOr<void, Error> {
         // a. Let name be the name of the property.
         // b. Let value be the result of getting a property named name from capability.
 

--- a/Userland/Services/RequestServer/ConnectionCache.h
+++ b/Userland/Services/RequestServer/ConnectionCache.h
@@ -137,7 +137,7 @@ ErrorOr<void> recreate_socket_if_needed(T& connection, URL const& url)
 
     if (!connection.socket->is_open() || connection.socket->is_eof()) {
         // Create another socket for the connection.
-        auto set_socket = [&](auto socket) -> ErrorOr<void> {
+        auto set_socket = [&](NonnullOwnPtr<SocketStorageType>&& socket) -> ErrorOr<void> {
             connection.socket = TRY(Core::BufferedSocket<SocketStorageType>::create(move(socket)));
             return {};
         };


### PR DESCRIPTION
This PR works around a compiler bug (https://github.com/llvm/llvm-project/issues/67260) and resolves two improved warnings.

Note that there is still a crash that affects the AppKit chrome. A PR with a fix is on the way: https://github.com/llvm/llvm-project/pull/71321

@ADKaster 