### PR TITLE
Kernel/Syscalls: Allow root to ptrace any process

### DIFF
--- a/Kernel/Syscalls/ptrace.cpp
+++ b/Kernel/Syscalls/ptrace.cpp
@@ -42,8 +42,7 @@ static ErrorOr<FlatPtr> handle_ptrace(Kernel::Syscall::SC_ptrace_params const& p
 
     auto peer_credentials = peer->process().credentials();
     auto caller_credentials = caller.credentials();
-    if ((peer_credentials->uid() != caller_credentials->euid())
-        || (peer_credentials->uid() != peer_credentials->euid())) // Disallow tracing setuid processes
+    if (!caller_credentials->is_superuser() && ((peer_credentials->uid() != caller_credentials->euid()) || (peer_credentials->uid() != peer_credentials->euid()))) // Disallow tracing setuid processes
         return EACCES;
 
     if (!peer->process().is_dumpable())


### PR DESCRIPTION
Previously root (euid=0) was not able to ptrace any dumpable process as expected. This change fixes this.