### PR TITLE
LibPDF: Start implementing separation color spaces

### DIFF
--- a/Userland/Libraries/LibPDF/CMakeLists.txt
+++ b/Userland/Libraries/LibPDF/CMakeLists.txt
@@ -14,6 +14,7 @@ set(SOURCES
     Fonts/Type0Font.cpp
     Fonts/Type1Font.cpp
     Fonts/Type1FontProgram.cpp
+    Function.cpp
     Interpolation.cpp
     ObjectDerivatives.cpp
     Page.cpp

--- a/Userland/Libraries/LibPDF/ColorSpace.h
+++ b/Userland/Libraries/LibPDF/ColorSpace.h
@@ -10,6 +10,7 @@
 #include <AK/Forward.h>
 #include <LibGfx/Color.h>
 #include <LibGfx/ICC/Profile.h>
+#include <LibPDF/Function.h>
 #include <LibPDF/Value.h>
 
 #define ENUMERATE_COLOR_SPACE_FAMILIES(V) \
@@ -231,7 +232,12 @@ public:
     ColorSpaceFamily const& family() const override { return ColorSpaceFamily::Separation; }
 
 private:
-    SeparationColorSpace() = default;
+    SeparationColorSpace(NonnullRefPtr<ColorSpace>, NonnullRefPtr<Function>);
+
+    DeprecatedString m_name;
+    NonnullRefPtr<ColorSpace> m_alternate_space;
+    NonnullRefPtr<Function> m_tint_transform;
+    Vector<Value> mutable m_tint_output_values;
 };
 
 }

--- a/Userland/Libraries/LibPDF/CommonNames.h
+++ b/Userland/Libraries/LibPDF/CommonNames.h
@@ -55,6 +55,7 @@
     X(DeviceN)                    \
     X(DeviceRGB)                  \
     X(Differences)                \
+    X(Domain)                     \
     X(E)                          \
     X(Encoding)                   \
     X(Encrypt)                    \
@@ -79,6 +80,7 @@
     X(FontFile)                   \
     X(FontFile2)                  \
     X(FontFile3)                  \
+    X(FunctionType)               \
     X(Gamma)                      \
     X(H)                          \
     X(Height)                     \

--- a/Userland/Libraries/LibPDF/CommonNames.h
+++ b/Userland/Libraries/LibPDF/CommonNames.h
@@ -23,6 +23,8 @@
     X(BitsPerComponent)           \
     X(BlackPoint)                 \
     X(C)                          \
+    X(C0)                         \
+    X(C1)                         \
     X(CA)                         \
     X(CCITTFaxDecode)             \
     X(CF)                         \

--- a/Userland/Libraries/LibPDF/Function.cpp
+++ b/Userland/Libraries/LibPDF/Function.cpp
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2023, Nico Weber <thakis@chromium.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibPDF/Function.h>
+
+// PDF 1.7 spec, 3.9 Functions
+
+namespace PDF {
+
+class SampledFunction final : public Function {
+public:
+    virtual PDFErrorOr<ReadonlySpan<float>> evaluate(ReadonlySpan<float>) const override;
+};
+
+PDFErrorOr<ReadonlySpan<float>> SampledFunction::evaluate(ReadonlySpan<float>) const
+{
+    return Error(Error::Type::RenderingUnsupported, "SampledFunction not yet implemented"_string);
+}
+
+class ExponentialInterpolationFunction final : public Function {
+public:
+    virtual PDFErrorOr<ReadonlySpan<float>> evaluate(ReadonlySpan<float>) const override;
+};
+
+PDFErrorOr<ReadonlySpan<float>> ExponentialInterpolationFunction::evaluate(ReadonlySpan<float>) const
+{
+    return Error(Error::Type::RenderingUnsupported, "ExponentialInterpolationFunction not yet implemented"_string);
+}
+
+class StitchingFunction final : public Function {
+public:
+    virtual PDFErrorOr<ReadonlySpan<float>> evaluate(ReadonlySpan<float>) const override;
+};
+
+PDFErrorOr<ReadonlySpan<float>> StitchingFunction::evaluate(ReadonlySpan<float>) const
+{
+    return Error(Error::Type::RenderingUnsupported, "StitchingFunction not yet implemented"_string);
+}
+
+class PostScriptCalculatorFunction final : public Function {
+public:
+    virtual PDFErrorOr<ReadonlySpan<float>> evaluate(ReadonlySpan<float>) const override;
+};
+
+PDFErrorOr<ReadonlySpan<float>> PostScriptCalculatorFunction::evaluate(ReadonlySpan<float>) const
+{
+    return Error(Error::Type::RenderingUnsupported, "PostScriptCalculatorFunction not yet implemented"_string);
+}
+
+PDFErrorOr<NonnullRefPtr<Function>> Function::create(Document*, NonnullRefPtr<Object>)
+{
+    return Error(Error::Type::RenderingUnsupported, "Function creation not yet implemented"_string);
+}
+
+}

--- a/Userland/Libraries/LibPDF/Function.cpp
+++ b/Userland/Libraries/LibPDF/Function.cpp
@@ -4,11 +4,19 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibPDF/CommonNames.h>
+#include <LibPDF/Document.h>
 #include <LibPDF/Function.h>
+#include <LibPDF/ObjectDerivatives.h>
 
 // PDF 1.7 spec, 3.9 Functions
 
 namespace PDF {
+
+struct Bound {
+    float lower;
+    float upper;
+};
 
 class SampledFunction final : public Function {
 public:
@@ -50,9 +58,62 @@ PDFErrorOr<ReadonlySpan<float>> PostScriptCalculatorFunction::evaluate(ReadonlyS
     return Error(Error::Type::RenderingUnsupported, "PostScriptCalculatorFunction not yet implemented"_string);
 }
 
-PDFErrorOr<NonnullRefPtr<Function>> Function::create(Document*, NonnullRefPtr<Object>)
+PDFErrorOr<NonnullRefPtr<Function>> Function::create(Document* document, NonnullRefPtr<Object> object)
 {
-    return Error(Error::Type::RenderingUnsupported, "Function creation not yet implemented"_string);
+    if (!object->is<DictObject>() && !object->is<StreamObject>())
+        return Error { Error::Type::MalformedPDF, "Function object must be dict or stream" };
+
+    auto function_dict = object->is<DictObject>() ? object->cast<DictObject>() : object->cast<StreamObject>()->dict();
+
+    // "TABLE 3.35 Entries common to all function dictionaries"
+
+    if (!function_dict->contains(CommonNames::FunctionType))
+        return Error { Error::Type::MalformedPDF, "Function requires /FunctionType" };
+    auto function_type = TRY(document->resolve_to<int>(function_dict->get_value(CommonNames::FunctionType)));
+
+    if (!function_dict->contains(CommonNames::Domain))
+        return Error { Error::Type::MalformedPDF, "Function requires /Domain" };
+    auto domain_array = TRY(function_dict->get_array(document, CommonNames::Domain));
+    if (domain_array->size() % 2 != 0)
+        return Error { Error::Type::MalformedPDF, "Function /Domain size not multiple of 2" };
+
+    Vector<Bound> domain;
+    for (size_t i = 0; i < domain_array->size(); i += 2) {
+        domain.append({ domain_array->at(i).to_float(), domain_array->at(i + 1).to_float() });
+        if (domain.last().lower > domain.last().upper)
+            return Error { Error::Type::MalformedPDF, "Function /Domain lower bound > upper bound" };
+    }
+
+    // Can't use PDFErrorOr with Optional::map()
+    Optional<Vector<Bound>> optional_range;
+    if (function_dict->contains(CommonNames::Range)) {
+        auto range_array = TRY(function_dict->get_array(document, CommonNames::Range));
+        if (range_array->size() % 2 != 0)
+            return Error { Error::Type::MalformedPDF, "Function /Range size not multiple of 2" };
+
+        Vector<Bound> range;
+        for (size_t i = 0; i < range_array->size(); i += 2) {
+            range.append({ range_array->at(i).to_float(), range_array->at(i + 1).to_float() });
+            if (range.last().lower > range.last().upper)
+                return Error { Error::Type::MalformedPDF, "Function /Range lower bound > upper bound" };
+        }
+        optional_range = move(range);
+    }
+
+    switch (function_type) {
+    case 0:
+        return adopt_ref(*new SampledFunction());
+    // The spec has no entry for `1`.
+    case 2:
+        return adopt_ref(*new ExponentialInterpolationFunction());
+    case 3:
+        return adopt_ref(*new StitchingFunction());
+    case 4:
+        return adopt_ref(*new PostScriptCalculatorFunction());
+    default:
+        dbgln("invalid function type {}", function_type);
+        return Error(Error::Type::MalformedPDF, "Function has unkonwn type"_string);
+    }
 }
 
 }

--- a/Userland/Libraries/LibPDF/Function.h
+++ b/Userland/Libraries/LibPDF/Function.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2023, Nico Weber <thakis@chromium.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Forward.h>
+#include <LibPDF/Value.h>
+
+namespace PDF {
+
+class Function : public RefCounted<Function> {
+public:
+    static PDFErrorOr<NonnullRefPtr<Function>> create(Document*, NonnullRefPtr<Object>);
+    virtual ~Function() = default;
+    virtual PDFErrorOr<ReadonlySpan<float>> evaluate(ReadonlySpan<float>) const = 0;
+};
+
+}

--- a/Userland/Libraries/LibPDF/Reader.h
+++ b/Userland/Libraries/LibPDF/Reader.h
@@ -120,13 +120,13 @@ public:
             move_by(1);
     }
 
-    void move_until(Function<bool(char)> predicate)
+    void move_until(AK::Function<bool(char)> predicate)
     {
         while (!done() && !predicate(peek()))
             move_by(1);
     }
 
-    ALWAYS_INLINE void move_while(Function<bool(char)> predicate)
+    ALWAYS_INLINE void move_while(AK::Function<bool(char)> predicate)
     {
         move_until([&predicate](char t) { return !predicate(t); });
     }


### PR DESCRIPTION
When printing, a separation color space is the name of one ink and an amount.

When drawing to a screen, that amount gets converted by a PDF function to inputs of an alternate color space.

This PR adds the separation color space bits for drawing to a screen, and starts implementing PDF functions. For now, it implements one of four possible function types (the one used in 66% of separation color spaces, in my test set).