### PR TITLE
LibGUI: Introduce property deserializers to catch errors in GML property values

### DIFF
--- a/Userland/Libraries/LibGUI/BoxLayout.cpp
+++ b/Userland/Libraries/LibGUI/BoxLayout.cpp
@@ -22,7 +22,7 @@ BoxLayout::BoxLayout(Orientation orientation, Margins margins, int spacing)
     , m_orientation(orientation)
 {
     register_property(
-        "orientation", [this] { return m_orientation == Gfx::Orientation::Vertical ? "Vertical" : "Horizontal"; }, nullptr);
+        "orientation"sv, [this] { return m_orientation == Gfx::Orientation::Vertical ? "Vertical" : "Horizontal"; }, nullptr, nullptr);
 }
 
 UISize BoxLayout::preferred_size() const

--- a/Userland/Libraries/LibGUI/CMakeLists.txt
+++ b/Userland/Libraries/LibGUI/CMakeLists.txt
@@ -94,6 +94,7 @@ set(SOURCES
     ProcessChooser.cpp
     Progressbar.cpp
     Property.cpp
+    PropertyDeserializer.cpp
     RadioButton.cpp
     RangeSlider.cpp
     RegularEditingEngine.cpp

--- a/Userland/Libraries/LibGUI/Layout.cpp
+++ b/Userland/Libraries/LibGUI/Layout.cpp
@@ -21,7 +21,8 @@ Layout::Layout(Margins initial_margins, int spacing)
     REGISTER_INT_PROPERTY("spacing", spacing, set_spacing);
     REGISTER_MARGINS_PROPERTY("margins", margins, set_margins);
 
-    register_property("entries",
+    register_property(
+        "entries"sv,
         [this] {
             JsonArray entries_array;
             for (auto& entry : m_entries) {
@@ -37,7 +38,8 @@ Layout::Layout(Margins initial_margins, int spacing)
                 entries_array.must_append(move(entry_object));
             }
             return entries_array;
-        });
+        },
+        nullptr, nullptr);
 }
 
 Layout::~Layout() = default;

--- a/Userland/Libraries/LibGUI/Margins.h
+++ b/Userland/Libraries/LibGUI/Margins.h
@@ -139,30 +139,15 @@ private:
 
 #define REGISTER_MARGINS_PROPERTY(property_name, getter, setter) \
     register_property(                                           \
-        property_name, [this]() {                                  \
-            auto m = getter();                                     \
-            JsonObject margins_object;                             \
-            margins_object.set("left", m.left());                  \
-            margins_object.set("right", m.right());                \
-            margins_object.set("top", m.top());                    \
-            margins_object.set("bottom", m.bottom());              \
-            return margins_object; },                             \
-        [this](auto& value) {                                    \
-            if (!value.is_array())                               \
-                return false;                                    \
-            auto size = value.as_array().size();                 \
-            if (size == 0 || size > 4)                           \
-                return false;                                    \
-            int m[4];                                            \
-            for (size_t i = 0; i < size; ++i)                    \
-                m[i] = value.as_array().at(i).to_i32();          \
-            if (size == 1)                                       \
-                setter({ m[0] });                                \
-            else if (size == 2)                                  \
-                setter({ m[0], m[1] });                          \
-            else if (size == 3)                                  \
-                setter({ m[0], m[1], m[2] });                    \
-            else                                                 \
-                setter({ m[0], m[1], m[2], m[3] });              \
-            return true;                                         \
-        });
+        property_name##sv,                                       \
+        [this]() {                                               \
+            auto m = getter();                                   \
+            JsonObject margins_object;                           \
+            margins_object.set("left", m.left());                \
+            margins_object.set("right", m.right());              \
+            margins_object.set("top", m.top());                  \
+            margins_object.set("bottom", m.bottom());            \
+            return margins_object;                               \
+        },                                                       \
+        ::GUI::PropertyDeserializer<::GUI::Margins> {},          \
+        [this](auto const& value) { return setter(value); });

--- a/Userland/Libraries/LibGUI/Object.h
+++ b/Userland/Libraries/LibGUI/Object.h
@@ -105,59 +105,49 @@ private:
 
 #define REGISTER_INT_PROPERTY(property_name, getter, setter) \
     register_property(                                       \
-        property_name,                                       \
+        property_name##sv,                                   \
         [this] { return this->getter(); },                   \
-        [this](auto& value) {                                \
-            this->setter(value.template to_number<int>());   \
-            return true;                                     \
-        });
+        ::GUI::PropertyDeserializer<int> {},                 \
+        [this](auto const& value) { return setter(value); });
 
 #define REGISTER_BOOL_PROPERTY(property_name, getter, setter) \
     register_property(                                        \
-        property_name,                                        \
+        property_name##sv,                                    \
         [this] { return this->getter(); },                    \
-        [this](auto& value) {                                 \
-            this->setter(value.to_bool());                    \
-            return true;                                      \
-        });
+        ::GUI::PropertyDeserializer<bool> {},                 \
+        [this](auto const& value) { return setter(value); });
 
-// FIXME: Port JsonValue to the new String class.
-#define REGISTER_STRING_PROPERTY(property_name, getter, setter)                                                               \
-    register_property(                                                                                                        \
-        property_name,                                                                                                        \
-        [this]() { return this->getter().to_byte_string(); },                                                                 \
-        [this](auto& value) {                                                                                                 \
-            this->setter(String::from_byte_string(value.to_byte_string()).release_value_but_fixme_should_propagate_errors()); \
-            return true;                                                                                                      \
-        });
+#define REGISTER_STRING_PROPERTY(property_name, getter, setter) \
+    register_property(                                          \
+        property_name##sv,                                      \
+        [this] { return this->getter().to_byte_string(); },     \
+        ::GUI::PropertyDeserializer<String> {},                 \
+        [this](auto const& value) { return setter(value); });
 
 #define REGISTER_DEPRECATED_STRING_PROPERTY(property_name, getter, setter) \
     register_property(                                                     \
-        property_name,                                                     \
+        property_name##sv,                                                 \
         [this] { return this->getter(); },                                 \
-        [this](auto& value) {                                              \
-            this->setter(value.to_byte_string());                          \
-            return true;                                                   \
-        });
+        ::GUI::PropertyDeserializer<ByteString> {},                        \
+        [this](auto const& value) { return setter(value); });
 
 #define REGISTER_READONLY_STRING_PROPERTY(property_name, getter) \
     register_property(                                           \
-        property_name,                                           \
+        property_name##sv,                                       \
         [this] { return this->getter(); },                       \
-        {});
+        nullptr,                                                 \
+        nullptr);
 
 #define REGISTER_WRITE_ONLY_STRING_PROPERTY(property_name, setter) \
     register_property(                                             \
-        property_name,                                             \
-        {},                                                        \
-        [this](auto& value) {                                      \
-            this->setter(value.to_byte_string());                  \
-            return true;                                           \
-        });
+        property_name##sv,                                         \
+        nullptr,                                                   \
+        ::GUI::PropertyDeserializer<ByteString> {},                \
+        [this](auto const& value) { return setter(value); });
 
 #define REGISTER_READONLY_SIZE_PROPERTY(property_name, getter) \
     register_property(                                         \
-        property_name,                                         \
+        property_name##sv,                                     \
         [this] {                                               \
             auto size = this->getter();                        \
             JsonArray size_array;                              \
@@ -165,43 +155,27 @@ private:
             size_array.must_append(size.height());             \
             return size_array;                                 \
         },                                                     \
-        {});
+        nullptr,                                               \
+        nullptr);
 
-#define REGISTER_RECT_PROPERTY(property_name, getter, setter)                       \
-    register_property(                                                              \
-        property_name,                                                              \
-        [this] {                                                                    \
-            auto rect = this->getter();                                             \
-            JsonObject rect_object;                                                 \
-            rect_object.set("x"sv, rect.x());                                       \
-            rect_object.set("y"sv, rect.y());                                       \
-            rect_object.set("width"sv, rect.width());                               \
-            rect_object.set("height"sv, rect.height());                             \
-            return rect_object;                                                     \
-        },                                                                          \
-        [this](auto& value) {                                                       \
-            Gfx::IntRect rect;                                                      \
-            if (value.is_object()) {                                                \
-                rect.set_x(value.as_object().get_i32("x"sv).value_or(0));           \
-                rect.set_y(value.as_object().get_i32("y"sv).value_or(0));           \
-                rect.set_width(value.as_object().get_i32("width"sv).value_or(0));   \
-                rect.set_height(value.as_object().get_i32("height"sv).value_or(0)); \
-            } else if (value.is_array() && value.as_array().size() == 4) {          \
-                rect.set_x(value.as_array()[0].to_i32());                           \
-                rect.set_y(value.as_array()[1].to_i32());                           \
-                rect.set_width(value.as_array()[2].to_i32());                       \
-                rect.set_height(value.as_array()[3].to_i32());                      \
-            } else {                                                                \
-                return false;                                                       \
-            }                                                                       \
-            setter(rect);                                                           \
-                                                                                    \
-            return true;                                                            \
-        });
+#define REGISTER_RECT_PROPERTY(property_name, getter, setter) \
+    register_property(                                        \
+        property_name##sv,                                    \
+        [this] {                                              \
+            auto rect = this->getter();                       \
+            JsonObject rect_object;                           \
+            rect_object.set("x"sv, rect.x());                 \
+            rect_object.set("y"sv, rect.y());                 \
+            rect_object.set("width"sv, rect.width());         \
+            rect_object.set("height"sv, rect.height());       \
+            return rect_object;                               \
+        },                                                    \
+        ::GUI::PropertyDeserializer<Gfx::IntRect> {},         \
+        [this](auto const& value) { return setter(value); });
 
 #define REGISTER_SIZE_PROPERTY(property_name, getter, setter) \
     register_property(                                        \
-        property_name,                                        \
+        property_name##sv,                                    \
         [this] {                                              \
             auto size = this->getter();                       \
             JsonArray size_array;                             \
@@ -209,49 +183,41 @@ private:
             size_array.must_append(size.height());            \
             return size_array;                                \
         },                                                    \
-        [this](auto& value) {                                 \
-            if (!value.is_array())                            \
-                return false;                                 \
-            Gfx::IntSize size;                                \
-            size.set_width(value.as_array()[0].to_i32());     \
-            size.set_height(value.as_array()[1].to_i32());    \
-            setter(size);                                     \
-            return true;                                      \
-        });
+        ::GUI::PropertyDeserializer<Gfx::IntSize> {},         \
+        [this](auto const& value) { return setter(value); });
 
-#define REGISTER_ENUM_PROPERTY(property_name, getter, setter, EnumType, ...) \
-    register_property(                                                       \
-        property_name,                                                       \
-        [this]() -> JsonValue {                                              \
-            struct {                                                         \
-                EnumType enum_value;                                         \
-                ByteString string_value;                                     \
-            } options[] = { __VA_ARGS__ };                                   \
-            auto enum_value = getter();                                      \
-            for (size_t i = 0; i < array_size(options); ++i) {               \
-                auto& option = options[i];                                   \
-                if (enum_value == option.enum_value)                         \
-                    return option.string_value;                              \
-            }                                                                \
-            return JsonValue();                                              \
-        },                                                                   \
-        [this](auto& value) {                                                \
-            struct {                                                         \
-                EnumType enum_value;                                         \
-                ByteString string_value;                                     \
-            } options[] = { __VA_ARGS__ };                                   \
-            if (!value.is_string())                                          \
-                return false;                                                \
-            auto string_value = value.as_string();                           \
-            for (size_t i = 0; i < array_size(options); ++i) {               \
-                auto& option = options[i];                                   \
-                if (string_value == option.string_value) {                   \
-                    setter(option.enum_value);                               \
-                    return true;                                             \
-                }                                                            \
-            }                                                                \
-            return false;                                                    \
-        })
+#define REGISTER_ENUM_PROPERTY(property_name, getter, setter, EnumType, ...)                 \
+    register_property(                                                                       \
+        property_name##sv,                                                                   \
+        [this]() -> JsonValue {                                                              \
+            struct {                                                                         \
+                EnumType enum_value;                                                         \
+                ByteString string_value;                                                     \
+            } options[] = { __VA_ARGS__ };                                                   \
+            auto enum_value = getter();                                                      \
+            for (size_t i = 0; i < array_size(options); ++i) {                               \
+                auto const& option = options[i];                                             \
+                if (enum_value == option.enum_value)                                         \
+                    return option.string_value;                                              \
+            }                                                                                \
+            VERIFY_NOT_REACHED();                                                            \
+        },                                                                                   \
+        [](JsonValue const& value) -> ErrorOr<EnumType> {                                    \
+            if (!value.is_string())                                                          \
+                return Error::from_string_literal("String is expected");                     \
+            auto string = value.as_string();                                                 \
+            struct {                                                                         \
+                EnumType enum_value;                                                         \
+                ByteString string_value;                                                     \
+            } options[] = { __VA_ARGS__ };                                                   \
+            for (size_t i = 0; i < array_size(options); ++i) {                               \
+                auto const& option = options[i];                                             \
+                if (string == option.string_value)                                           \
+                    return option.enum_value;                                                \
+            }                                                                                \
+            return Error::from_string_literal("Value is not a valid option for " #EnumType); \
+        },                                                                                   \
+        [this](auto const& value) { return setter(value); })
 
 #define REGISTER_TEXT_ALIGNMENT_PROPERTY(property_name, getter, setter) \
     REGISTER_ENUM_PROPERTY(                                             \

--- a/Userland/Libraries/LibGUI/Object.h
+++ b/Userland/Libraries/LibGUI/Object.h
@@ -58,8 +58,6 @@ public:
 protected:
     explicit Object(Core::EventReceiver* parent = nullptr);
 
-    void register_property(ByteString const& name, Function<JsonValue()> getter, Function<bool(JsonValue const&)> setter = nullptr);
-
     template<typename Getter, typename Deserializer, typename Setter>
     void register_property(StringView name, Getter&& getter, Deserializer&& deserializer, Setter&& setter)
     {
@@ -98,6 +96,8 @@ protected:
     }
 
 private:
+    void register_property(ByteString const& name, Function<JsonValue()> getter, Function<bool(JsonValue const&)> setter = nullptr);
+
     HashMap<ByteString, NonnullOwnPtr<Property>> m_properties;
 };
 

--- a/Userland/Libraries/LibGUI/PropertyDeserializer.cpp
+++ b/Userland/Libraries/LibGUI/PropertyDeserializer.cpp
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2023, Dan Klishch <danilklishch@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "PropertyDeserializer.h"
+#include <AK/JsonObject.h>
+#include <AK/String.h>
+#include <LibGfx/Rect.h>
+
+namespace GUI {
+
+template<>
+ErrorOr<bool> PropertyDeserializer<bool>::operator()(JsonValue const& value) const
+{
+    if (value.is_bool())
+        return value.as_bool();
+    return Error::from_string_literal("Boolean is expected");
+}
+
+template<>
+ErrorOr<String> PropertyDeserializer<String>::operator()(JsonValue const& value) const
+{
+    if (value.is_string()) {
+        // FIXME: Port JsonValue to the new String class.
+        return String::from_deprecated_string(value.as_string());
+    }
+    return Error::from_string_literal("UTF-8 string is expected");
+}
+
+template<>
+ErrorOr<DeprecatedString> PropertyDeserializer<DeprecatedString>::operator()(JsonValue const& value) const
+{
+    if (value.is_string())
+        return value.as_string();
+    return Error::from_string_literal("String is expected");
+}
+
+template<>
+ErrorOr<Gfx::IntRect> PropertyDeserializer<Gfx::IntRect>::operator()(JsonValue const& value) const
+{
+    if (!value.is_object() && !(value.is_array() && value.as_array().size() == 4))
+        return Error::from_string_literal("An array with 4 integers or an object is expected");
+
+    Gfx::IntRect rect;
+
+    Optional<int> x;
+    Optional<int> y;
+    Optional<int> width;
+    Optional<int> height;
+
+    if (value.is_object()) {
+        auto const& object = value.as_object();
+
+        if (object.size() != 4 || !object.has("x"sv) || !object.has("y"sv) || !object.has("width"sv) || !object.has("height"sv))
+            return Error::from_string_literal("Object with keys \"x\", \"y\", \"width\", and \"height\" is expected");
+
+        x = object.get_i32("x"sv);
+        y = object.get_i32("y"sv);
+        width = object.get_i32("width"sv);
+        height = object.get_i32("height"sv);
+    } else {
+        auto const& array = value.as_array();
+
+        auto get_i32 = [](JsonValue const& value) -> Optional<int> {
+            if (value.is_integer<i32>())
+                return value.to_i32();
+            return {};
+        };
+
+        x = get_i32(array[0]);
+        y = get_i32(array[1]);
+        width = get_i32(array[2]);
+        height = get_i32(array[3]);
+    }
+
+    if (!x.has_value())
+        return Error::from_string_literal("X coordinate must be an integer");
+    if (!y.has_value())
+        return Error::from_string_literal("Y coordinate must be an integer");
+    if (!width.has_value())
+        return Error::from_string_literal("Width must be an integer");
+    if (!height.has_value())
+        return Error::from_string_literal("Height must be an integer");
+
+    rect.set_x(x.value());
+    rect.set_y(y.value());
+    rect.set_width(width.value());
+    rect.set_height(height.value());
+
+    return rect;
+}
+
+template<>
+ErrorOr<Gfx::IntSize> PropertyDeserializer<Gfx::IntSize>::operator()(JsonValue const& value) const
+{
+    if (!value.is_array() || value.as_array().size() != 2)
+        return Error::from_string_literal("Expected array with 2 integers");
+
+    auto const& array = value.as_array();
+
+    auto const& width = array[0];
+    if (!width.is_integer<i32>())
+        return Error::from_string_literal("Width must be an integer");
+    auto const& height = array[1];
+    if (!height.is_integer<i32>())
+        return Error::from_string_literal("Height must be an integer");
+
+    Gfx::IntSize size;
+    size.set_width(width.to_i32());
+    size.set_height(height.to_i32());
+
+    return size;
+}
+
+};

--- a/Userland/Libraries/LibGUI/PropertyDeserializer.cpp
+++ b/Userland/Libraries/LibGUI/PropertyDeserializer.cpp
@@ -24,13 +24,13 @@ ErrorOr<String> PropertyDeserializer<String>::operator()(JsonValue const& value)
 {
     if (value.is_string()) {
         // FIXME: Port JsonValue to the new String class.
-        return String::from_deprecated_string(value.as_string());
+        return String::from_byte_string(value.as_string());
     }
     return Error::from_string_literal("UTF-8 string is expected");
 }
 
 template<>
-ErrorOr<DeprecatedString> PropertyDeserializer<DeprecatedString>::operator()(JsonValue const& value) const
+ErrorOr<ByteString> PropertyDeserializer<ByteString>::operator()(JsonValue const& value) const
 {
     if (value.is_string())
         return value.as_string();

--- a/Userland/Libraries/LibGUI/PropertyDeserializer.h
+++ b/Userland/Libraries/LibGUI/PropertyDeserializer.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2023, Dan Klishch <danilklishch@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/JsonValue.h>
+#include <LibGfx/Forward.h>
+
+namespace GUI {
+
+template<typename T>
+struct PropertyDeserializer {
+    ErrorOr<T> operator()(JsonValue const& value) const;
+};
+
+template<Integral T>
+requires(!IsSame<T, bool>)
+struct PropertyDeserializer<T> {
+    ErrorOr<T> operator()(JsonValue const& value) const
+    {
+        if (!value.is_integer<T>())
+            return Error::from_string_literal("Value is either not an integer or out of range for requested type");
+        return value.to_number<T>();
+    }
+};
+
+}

--- a/Userland/Libraries/LibGUI/TabWidget.cpp
+++ b/Userland/Libraries/LibGUI/TabWidget.cpp
@@ -37,18 +37,7 @@ TabWidget::TabWidget()
         { TabPosition::Bottom, "Bottom" },
         { TabPosition::Left, "Left" },
         { TabPosition::Right, "Right" }, );
-
-    register_property(
-        "text_alignment",
-        [this] { return Gfx::to_string(text_alignment()); },
-        [this](auto& value) {
-            auto alignment = Gfx::text_alignment_from_string(value.to_byte_string());
-            if (alignment.has_value()) {
-                set_text_alignment(alignment.value());
-                return true;
-            }
-            return false;
-        });
+    REGISTER_TEXT_ALIGNMENT_PROPERTY("text_alignment", text_alignment, set_text_alignment);
 }
 
 ErrorOr<void> TabWidget::try_add_widget(Widget& widget)

--- a/Userland/Libraries/LibGUI/UIDimensions.h
+++ b/Userland/Libraries/LibGUI/UIDimensions.h
@@ -296,58 +296,44 @@ inline auto clamp<GUI::UIDimension>(GUI::UIDimension const& input, GUI::UIDimens
 
 }
 
-#define REGISTER_UI_DIMENSION_PROPERTY(property_name, getter, setter)         \
-    register_property(                                                        \
-        property_name,                                                        \
-        [this] {                                                              \
-            return this->getter().as_json_value();                            \
-        },                                                                    \
-        [this](auto& value) {                                                 \
-            auto result = GUI::UIDimension::construct_from_json_value(value); \
-            if (result.has_value())                                           \
-                this->setter(result.value());                                 \
-            return result.has_value();                                        \
-        });
+#define REGISTER_UI_DIMENSION_PROPERTY(property_name, getter, setter) \
+    register_property(                                                \
+        property_name##sv,                                            \
+        [this] {                                                      \
+            return this->getter().as_json_value();                    \
+        },                                                            \
+        ::GUI::PropertyDeserializer<::GUI::UIDimension> {},           \
+        [this](auto const& value) { return setter(value); });
 
 #define REGISTER_READONLY_UI_DIMENSION_PROPERTY(property_name, getter) \
     register_property(                                                 \
-        property_name,                                                 \
+        property_name##sv,                                             \
         [this] {                                                       \
             return this->getter().as_json_value();                     \
-        });
+        },                                                             \
+        nullptr, nullptr);
 
-#define REGISTER_UI_SIZE_PROPERTY(property_name, getter, setter)               \
-    register_property(                                                         \
-        property_name,                                                         \
-        [this] {                                                               \
-            auto size = this->getter();                                        \
-            JsonObject size_object;                                            \
-            size_object.set("width"sv, size.width().as_json_value());          \
-            size_object.set("height"sv, size.height().as_json_value());        \
-            return size_object;                                                \
-        },                                                                     \
-        [this](auto& value) {                                                  \
-            if (!value.is_object())                                            \
-                return false;                                                  \
-            auto result_width = GUI::UIDimension::construct_from_json_value(   \
-                value.as_object().get("width"sv).value_or({}));                \
-            auto result_height = GUI::UIDimension::construct_from_json_value(  \
-                value.as_object().get("height"sv).value_or({}));               \
-            if (result_width.has_value() && result_height.has_value()) {       \
-                GUI::UISize size(result_width.value(), result_height.value()); \
-                setter(size);                                                  \
-                return true;                                                   \
-            }                                                                  \
-            return false;                                                      \
-        });
+#define REGISTER_UI_SIZE_PROPERTY(property_name, getter, setter)        \
+    register_property(                                                  \
+        property_name##sv,                                              \
+        [this] {                                                        \
+            auto size = this->getter();                                 \
+            JsonObject size_object;                                     \
+            size_object.set("width"sv, size.width().as_json_value());   \
+            size_object.set("height"sv, size.height().as_json_value()); \
+            return size_object;                                         \
+        },                                                              \
+        ::GUI::PropertyDeserializer<::GUI::UISize> {},                  \
+        [this](auto const& value) { return setter(value); });
 
 #define REGISTER_READONLY_UI_SIZE_PROPERTY(property_name, getter)     \
     register_property(                                                \
-        property_name,                                                \
+        property_name##sv,                                            \
         [this] {                                                      \
             auto size = this->getter();                               \
             JsonObject size_object;                                   \
             size_object.set("width", size.width().as_json_value());   \
             size_object.set("height", size.height().as_json_value()); \
             return size_object;                                       \
-        });
+        },                                                            \
+        nullptr, nullptr);

--- a/Userland/Libraries/LibGUI/Widget.h
+++ b/Userland/Libraries/LibGUI/Widget.h
@@ -254,7 +254,6 @@ public:
     Gfx::ColorRole foreground_role() const { return m_foreground_role; }
     void set_foreground_role(Gfx::ColorRole);
 
-    bool set_background_color(String);
     void set_background_color(Gfx::Color);
 
     void set_autofill(bool b) { set_fill_with_background_color(b); }

--- a/Userland/Libraries/LibGUI/Window.cpp
+++ b/Userland/Libraries/LibGUI/Window.cpp
@@ -85,16 +85,12 @@ Window::Window(Core::EventReceiver* parent)
     m_floating_rect = { -5000, -5000, 0, 0 };
     m_title_when_windowless = "GUI::Window";
 
-    register_property(
-        "title",
-        [this] { return title(); },
-        [this](auto& value) {
-            set_title(value.to_byte_string());
-            return true;
-        });
+    REGISTER_DEPRECATED_STRING_PROPERTY("title", title, set_title)
 
-    register_property("visible", [this] { return is_visible(); });
-    register_property("active", [this] { return is_active(); });
+    register_property(
+        "visible"sv, [this] { return is_visible(); }, nullptr, nullptr);
+    register_property(
+        "active"sv, [this] { return is_active(); }, nullptr, nullptr);
 
     REGISTER_BOOL_PROPERTY("minimizable", is_minimizable, set_minimizable);
     REGISTER_BOOL_PROPERTY("resizable", is_resizable, set_resizable);


### PR DESCRIPTION
Yes, I know, I am generally not really interested in Serenity-specific stuff. And yes, I know, I was porting `DeprecatedString` to `StringBase`. But suddenly task stack became really deep:
 - port `DeprecatedString` to `StringBase`
 - remove references to `StringImpl`
 - port `JsonValue` to `Variant` and `StringBase`
 - remove odd `T JsonValue::to_something(T default_value)` API
 - make LibGUI not use this API
 - do something so that GMLPlayground will not instantly crash on invalid input

Property deserializer is a small class which converts JsonValue to a required type while doing robust error checking at the same time. And previously that error checking in deserializing was basically "if something is supposed to be int but is not, a developer definitely wanted 0 there". What's more, if someone addresses one new error propagation FIXME I left, we will be able to show nice errors in GMLPlayground in real time.

I am aware of existence of GMLCompiler but AFAIC Film's intention is to continue using JSON input in GMLPlayground.

CC @kleinesfilmroellchen 

Also, logging for discarded errors tells me that somewhere in DisplaySettings there is an invalid text_alignment value :)