### PR TITLE
LibJS/JIT: Make the JIT available again

### DIFF
--- a/Userland/Libraries/LibJIT/Assembler.h
+++ b/Userland/Libraries/LibJIT/Assembler.h
@@ -6,13 +6,14 @@
 
 #pragma once
 
-#include <LibJIT/X86_64/Assembler.h>
+#include <AK/Platform.h>
 
-namespace JIT {
 #if ARCH(X86_64)
+#    include <LibJIT/X86_64/Assembler.h>
 #    define JIT_ARCH_SUPPORTED 1
-typedef X86_64Assembler Assembler;
+namespace JIT {
+using Assembler = X86_64Assembler;
+}
 #else
 #    undef JIT_ARCH_SUPPORTED
 #endif
-}

--- a/Userland/Libraries/LibJS/JIT/Compiler.h
+++ b/Userland/Libraries/LibJS/JIT/Compiler.h
@@ -8,12 +8,12 @@
 #pragma once
 
 #include <AK/Platform.h>
+#include <LibJIT/Assembler.h>
+#include <LibJS/Bytecode/Executable.h>
+#include <LibJS/Bytecode/Op.h>
 #include <LibJS/JIT/NativeExecutable.h>
 
 #ifdef JIT_ARCH_SUPPORTED
-#    include <LibJIT/Assembler.h>
-#    include <LibJS/Bytecode/Executable.h>
-#    include <LibJS/Bytecode/Op.h>
 
 namespace JS::JIT {
 


### PR DESCRIPTION
#21679 inadvertently disabled the JIT on all platforms because it made the inclusion of the Assembler header dependent on a macro from that header.