### PR TITLE
LibTest: Bump up MAX_GEN_ATTEMPTS_PER_VALUE to 30

### DIFF
--- a/Userland/Libraries/LibTest/TestCase.h
+++ b/Userland/Libraries/LibTest/TestCase.h
@@ -46,7 +46,7 @@ public:
     {
         using namespace Randomized;
 
-        constexpr u8 MAX_GEN_ATTEMPTS_PER_VALUE = 15;
+        constexpr u8 MAX_GEN_ATTEMPTS_PER_VALUE = 30;
 
         TestFunction test_case_function = [test_function = move(test_function)]() {
             u64 max_randomized_runs = randomized_runs();


### PR DESCRIPTION
The original value 15 was too little: it made our
`weighted_boolean_fair_false` test fail every now and then.

This is because a fair coin (P(false) = 0.5) will hit the same value 15 times in a row with a probability (1/2)^15: around once in a 32k tries.

With the bumped up value, this is now once in 1 billion tries. Should lower the test flakiness enough (if our random number generator is truly uniform), while 30 tries is still an OK amount of computation for randomized tests to do, compared to 15.