### PR TITLE
LibJS/JIT: Resolve various pointers at JIT time

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/CommonImplementations.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/CommonImplementations.cpp
@@ -18,9 +18,8 @@
 
 namespace JS::Bytecode {
 
-ThrowCompletionOr<NonnullGCPtr<Object>> base_object_for_get(Bytecode::Interpreter& interpreter, Value base_value)
+ThrowCompletionOr<NonnullGCPtr<Object>> base_object_for_get(VM& vm, Value base_value)
 {
-    auto& vm = interpreter.vm();
     if (base_value.is_object())
         return base_value.as_object();
 
@@ -35,10 +34,9 @@ ThrowCompletionOr<NonnullGCPtr<Object>> base_object_for_get(Bytecode::Interprete
     return base_value.to_object(vm);
 }
 
-ThrowCompletionOr<Value> get_by_id(Bytecode::Interpreter& interpreter, DeprecatedFlyString const& property, Value base_value, Value this_value, u32 cache_index)
+ThrowCompletionOr<Value> get_by_id(VM& vm, DeprecatedFlyString const& property, Value base_value, Value this_value, u32 cache_index)
 {
-    auto& vm = interpreter.vm();
-    auto& cache = interpreter.current_executable().property_lookup_caches[cache_index];
+    auto& cache = vm.bytecode_interpreter().current_executable().property_lookup_caches[cache_index];
 
     if (base_value.is_string()) {
         auto string_value = TRY(base_value.as_string().get(vm, property));
@@ -46,7 +44,7 @@ ThrowCompletionOr<Value> get_by_id(Bytecode::Interpreter& interpreter, Deprecate
             return *string_value;
     }
 
-    auto base_obj = TRY(base_object_for_get(interpreter, base_value));
+    auto base_obj = TRY(base_object_for_get(vm, base_value));
 
     // OPTIMIZATION: If the shape of the object hasn't changed, we can use the cached property offset.
     // NOTE: Unique shapes don't change identity, so we compare their serial numbers instead.
@@ -68,10 +66,9 @@ ThrowCompletionOr<Value> get_by_id(Bytecode::Interpreter& interpreter, Deprecate
     return value;
 }
 
-ThrowCompletionOr<Value> get_by_value(Bytecode::Interpreter& interpreter, Value base_value, Value property_key_value)
+ThrowCompletionOr<Value> get_by_value(VM& vm, Value base_value, Value property_key_value)
 {
-    auto& vm = interpreter.vm();
-    auto object = TRY(base_object_for_get(interpreter, base_value));
+    auto object = TRY(base_object_for_get(vm, base_value));
 
     // OPTIMIZATION: Fast path for simple Int32 indexes in array-like objects.
     if (property_key_value.is_int32()

--- a/Userland/Libraries/LibJS/Bytecode/CommonImplementations.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/CommonImplementations.cpp
@@ -34,10 +34,8 @@ ThrowCompletionOr<NonnullGCPtr<Object>> base_object_for_get(VM& vm, Value base_v
     return base_value.to_object(vm);
 }
 
-ThrowCompletionOr<Value> get_by_id(VM& vm, DeprecatedFlyString const& property, Value base_value, Value this_value, u32 cache_index)
+ThrowCompletionOr<Value> get_by_id(VM& vm, DeprecatedFlyString const& property, Value base_value, Value this_value, PropertyLookupCache& cache)
 {
-    auto& cache = vm.bytecode_interpreter().current_executable().property_lookup_caches[cache_index];
-
     if (base_value.is_string()) {
         auto string_value = TRY(base_value.as_string().get(vm, property));
         if (string_value.has_value())

--- a/Userland/Libraries/LibJS/Bytecode/CommonImplementations.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/CommonImplementations.cpp
@@ -35,14 +35,13 @@ ThrowCompletionOr<NonnullGCPtr<Object>> base_object_for_get(Bytecode::Interprete
     return base_value.to_object(vm);
 }
 
-ThrowCompletionOr<Value> get_by_id(Bytecode::Interpreter& interpreter, IdentifierTableIndex property, Value base_value, Value this_value, u32 cache_index)
+ThrowCompletionOr<Value> get_by_id(Bytecode::Interpreter& interpreter, DeprecatedFlyString const& property, Value base_value, Value this_value, u32 cache_index)
 {
     auto& vm = interpreter.vm();
-    auto const& name = interpreter.current_executable().get_identifier(property);
     auto& cache = interpreter.current_executable().property_lookup_caches[cache_index];
 
     if (base_value.is_string()) {
-        auto string_value = TRY(base_value.as_string().get(vm, name));
+        auto string_value = TRY(base_value.as_string().get(vm, property));
         if (string_value.has_value())
             return *string_value;
     }
@@ -58,7 +57,7 @@ ThrowCompletionOr<Value> get_by_id(Bytecode::Interpreter& interpreter, Identifie
     }
 
     CacheablePropertyMetadata cacheable_metadata;
-    auto value = TRY(base_obj->internal_get(name, this_value, &cacheable_metadata));
+    auto value = TRY(base_obj->internal_get(property, this_value, &cacheable_metadata));
 
     if (cacheable_metadata.type == CacheablePropertyMetadata::Type::OwnProperty) {
         cache.shape = shape;

--- a/Userland/Libraries/LibJS/Bytecode/CommonImplementations.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/CommonImplementations.cpp
@@ -308,26 +308,25 @@ ThrowCompletionOr<void> put_by_value(VM& vm, Value base, Value property_key_valu
     return {};
 }
 
-ThrowCompletionOr<Value> get_variable(Bytecode::Interpreter& interpreter, DeprecatedFlyString const& name, u32 cache_index)
+ThrowCompletionOr<Value> get_variable(Bytecode::Interpreter& interpreter, DeprecatedFlyString const& name, EnvironmentVariableCache& cache)
 {
     auto& vm = interpreter.vm();
 
-    auto& cached_environment_coordinate = interpreter.current_executable().environment_variable_caches[cache_index];
-    if (cached_environment_coordinate.has_value()) {
+    if (cache.has_value()) {
         auto environment = vm.running_execution_context().lexical_environment;
-        for (size_t i = 0; i < cached_environment_coordinate->hops; ++i)
+        for (size_t i = 0; i < cache->hops; ++i)
             environment = environment->outer_environment();
         VERIFY(environment);
         VERIFY(environment->is_declarative_environment());
         if (!environment->is_permanently_screwed_by_eval()) {
-            return TRY(verify_cast<DeclarativeEnvironment>(*environment).get_binding_value_direct(vm, cached_environment_coordinate.value().index, vm.in_strict_mode()));
+            return TRY(verify_cast<DeclarativeEnvironment>(*environment).get_binding_value_direct(vm, cache.value().index, vm.in_strict_mode()));
         }
-        cached_environment_coordinate = {};
+        cache = {};
     }
 
     auto reference = TRY(vm.resolve_binding(name));
     if (reference.environment_coordinate().has_value())
-        cached_environment_coordinate = reference.environment_coordinate();
+        cache = reference.environment_coordinate();
     return TRY(reference.get_value(vm));
 }
 

--- a/Userland/Libraries/LibJS/Bytecode/CommonImplementations.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/CommonImplementations.cpp
@@ -89,12 +89,11 @@ ThrowCompletionOr<Value> get_by_value(VM& vm, Value base_value, Value property_k
     return TRY(object->internal_get(property_key, base_value));
 }
 
-ThrowCompletionOr<Value> get_global(Bytecode::Interpreter& interpreter, DeprecatedFlyString const& identifier, u32 cache_index)
+ThrowCompletionOr<Value> get_global(Bytecode::Interpreter& interpreter, DeprecatedFlyString const& identifier, GlobalVariableCache& cache)
 {
     auto& vm = interpreter.vm();
     auto& realm = *vm.current_realm();
 
-    auto& cache = interpreter.current_executable().global_variable_caches[cache_index];
     auto& binding_object = realm.global_environment().object_record().binding_object();
     auto& declarative_record = realm.global_environment().declarative_record();
 

--- a/Userland/Libraries/LibJS/Bytecode/CommonImplementations.h
+++ b/Userland/Libraries/LibJS/Bytecode/CommonImplementations.h
@@ -15,7 +15,7 @@ namespace JS::Bytecode {
 ThrowCompletionOr<NonnullGCPtr<Object>> base_object_for_get(Bytecode::Interpreter&, Value base_value);
 ThrowCompletionOr<Value> get_by_id(Bytecode::Interpreter&, DeprecatedFlyString const& property, Value base_value, Value this_value, u32 cache_index);
 ThrowCompletionOr<Value> get_by_value(Bytecode::Interpreter&, Value base_value, Value property_key_value);
-ThrowCompletionOr<Value> get_global(Bytecode::Interpreter&, IdentifierTableIndex, u32 cache_index);
+ThrowCompletionOr<Value> get_global(Bytecode::Interpreter&, DeprecatedFlyString const& identifier, u32 cache_index);
 ThrowCompletionOr<void> put_by_property_key(VM&, Value base, Value this_value, Value value, PropertyKey name, Op::PropertyKind kind);
 ThrowCompletionOr<Value> perform_call(Interpreter&, Value this_value, Op::CallType, Value callee, MarkedVector<Value> argument_values);
 ThrowCompletionOr<void> throw_if_needed_for_call(Interpreter&, Value callee, Op::CallType, Optional<StringTableIndex> const& expression_string);

--- a/Userland/Libraries/LibJS/Bytecode/CommonImplementations.h
+++ b/Userland/Libraries/LibJS/Bytecode/CommonImplementations.h
@@ -23,7 +23,7 @@ ThrowCompletionOr<Value> typeof_variable(VM&, DeprecatedFlyString const&);
 ThrowCompletionOr<void> set_variable(VM&, DeprecatedFlyString const&, Value, Op::EnvironmentMode, Op::SetVariable::InitializationMode);
 Value new_function(VM&, FunctionExpression const&, Optional<IdentifierTableIndex> const& lhs_name, Optional<Register> const& home_object);
 ThrowCompletionOr<void> put_by_value(VM&, Value base, Value property_key_value, Value value, Op::PropertyKind);
-ThrowCompletionOr<Value> get_variable(Bytecode::Interpreter&, DeprecatedFlyString const& name, u32 cache_index);
+ThrowCompletionOr<Value> get_variable(Bytecode::Interpreter&, DeprecatedFlyString const& name, EnvironmentVariableCache&);
 
 struct CalleeAndThis {
     Value callee;

--- a/Userland/Libraries/LibJS/Bytecode/CommonImplementations.h
+++ b/Userland/Libraries/LibJS/Bytecode/CommonImplementations.h
@@ -12,9 +12,9 @@
 
 namespace JS::Bytecode {
 
-ThrowCompletionOr<NonnullGCPtr<Object>> base_object_for_get(Bytecode::Interpreter&, Value base_value);
-ThrowCompletionOr<Value> get_by_id(Bytecode::Interpreter&, DeprecatedFlyString const& property, Value base_value, Value this_value, u32 cache_index);
-ThrowCompletionOr<Value> get_by_value(Bytecode::Interpreter&, Value base_value, Value property_key_value);
+ThrowCompletionOr<NonnullGCPtr<Object>> base_object_for_get(VM&, Value base_value);
+ThrowCompletionOr<Value> get_by_id(VM&, DeprecatedFlyString const& property, Value base_value, Value this_value, u32 cache_index);
+ThrowCompletionOr<Value> get_by_value(VM&, Value base_value, Value property_key_value);
 ThrowCompletionOr<Value> get_global(Bytecode::Interpreter&, DeprecatedFlyString const& identifier, u32 cache_index);
 ThrowCompletionOr<void> put_by_property_key(VM&, Value base, Value this_value, Value value, PropertyKey name, Op::PropertyKind kind);
 ThrowCompletionOr<Value> perform_call(Interpreter&, Value this_value, Op::CallType, Value callee, MarkedVector<Value> argument_values);

--- a/Userland/Libraries/LibJS/Bytecode/CommonImplementations.h
+++ b/Userland/Libraries/LibJS/Bytecode/CommonImplementations.h
@@ -13,7 +13,7 @@
 namespace JS::Bytecode {
 
 ThrowCompletionOr<NonnullGCPtr<Object>> base_object_for_get(VM&, Value base_value);
-ThrowCompletionOr<Value> get_by_id(VM&, DeprecatedFlyString const& property, Value base_value, Value this_value, u32 cache_index);
+ThrowCompletionOr<Value> get_by_id(VM&, DeprecatedFlyString const& property, Value base_value, Value this_value, PropertyLookupCache&);
 ThrowCompletionOr<Value> get_by_value(VM&, Value base_value, Value property_key_value);
 ThrowCompletionOr<Value> get_global(Bytecode::Interpreter&, DeprecatedFlyString const& identifier, u32 cache_index);
 ThrowCompletionOr<void> put_by_property_key(VM&, Value base, Value this_value, Value value, PropertyKey name, Op::PropertyKind kind);

--- a/Userland/Libraries/LibJS/Bytecode/CommonImplementations.h
+++ b/Userland/Libraries/LibJS/Bytecode/CommonImplementations.h
@@ -15,7 +15,7 @@ namespace JS::Bytecode {
 ThrowCompletionOr<NonnullGCPtr<Object>> base_object_for_get(VM&, Value base_value);
 ThrowCompletionOr<Value> get_by_id(VM&, DeprecatedFlyString const& property, Value base_value, Value this_value, PropertyLookupCache&);
 ThrowCompletionOr<Value> get_by_value(VM&, Value base_value, Value property_key_value);
-ThrowCompletionOr<Value> get_global(Bytecode::Interpreter&, DeprecatedFlyString const& identifier, u32 cache_index);
+ThrowCompletionOr<Value> get_global(Bytecode::Interpreter&, DeprecatedFlyString const& identifier, GlobalVariableCache&);
 ThrowCompletionOr<void> put_by_property_key(VM&, Value base, Value this_value, Value value, PropertyKey name, Op::PropertyKind kind);
 ThrowCompletionOr<Value> perform_call(Interpreter&, Value this_value, Op::CallType, Value callee, MarkedVector<Value> argument_values);
 ThrowCompletionOr<void> throw_if_needed_for_call(Interpreter&, Value callee, Op::CallType, Optional<StringTableIndex> const& expression_string);

--- a/Userland/Libraries/LibJS/Bytecode/CommonImplementations.h
+++ b/Userland/Libraries/LibJS/Bytecode/CommonImplementations.h
@@ -13,7 +13,7 @@
 namespace JS::Bytecode {
 
 ThrowCompletionOr<NonnullGCPtr<Object>> base_object_for_get(Bytecode::Interpreter&, Value base_value);
-ThrowCompletionOr<Value> get_by_id(Bytecode::Interpreter&, IdentifierTableIndex, Value base_value, Value this_value, u32 cache_index);
+ThrowCompletionOr<Value> get_by_id(Bytecode::Interpreter&, DeprecatedFlyString const& property, Value base_value, Value this_value, u32 cache_index);
 ThrowCompletionOr<Value> get_by_value(Bytecode::Interpreter&, Value base_value, Value property_key_value);
 ThrowCompletionOr<Value> get_global(Bytecode::Interpreter&, IdentifierTableIndex, u32 cache_index);
 ThrowCompletionOr<void> put_by_property_key(VM&, Value base, Value this_value, Value value, PropertyKey name, Op::PropertyKind kind);

--- a/Userland/Libraries/LibJS/Bytecode/Executable.h
+++ b/Userland/Libraries/LibJS/Bytecode/Executable.h
@@ -33,6 +33,8 @@ struct GlobalVariableCache : public PropertyLookupCache {
     u64 environment_serial_number { 0 };
 };
 
+using EnvironmentVariableCache = Optional<EnvironmentCoordinate>;
+
 struct SourceRecord {
     u32 source_start_offset {};
     u32 source_end_offset {};
@@ -57,7 +59,7 @@ public:
     DeprecatedFlyString name;
     Vector<PropertyLookupCache> property_lookup_caches;
     Vector<GlobalVariableCache> global_variable_caches;
-    Vector<Optional<EnvironmentCoordinate>> environment_variable_caches;
+    Vector<EnvironmentVariableCache> environment_variable_caches;
     Vector<NonnullOwnPtr<BasicBlock>> basic_blocks;
     NonnullOwnPtr<StringTable> string_table;
     NonnullOwnPtr<IdentifierTable> identifier_table;

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -760,7 +760,8 @@ ThrowCompletionOr<void> SetLocal::execute_impl(Bytecode::Interpreter&) const
 ThrowCompletionOr<void> GetById::execute_impl(Bytecode::Interpreter& interpreter) const
 {
     auto base_value = interpreter.accumulator();
-    interpreter.accumulator() = TRY(get_by_id(interpreter.vm(), interpreter.current_executable().get_identifier(m_property), base_value, base_value, m_cache_index));
+    auto& cache = interpreter.current_executable().property_lookup_caches[m_cache_index];
+    interpreter.accumulator() = TRY(get_by_id(interpreter.vm(), interpreter.current_executable().get_identifier(m_property), base_value, base_value, cache));
     return {};
 }
 
@@ -768,7 +769,8 @@ ThrowCompletionOr<void> GetByIdWithThis::execute_impl(Bytecode::Interpreter& int
 {
     auto base_value = interpreter.accumulator();
     auto this_value = interpreter.reg(m_this_value);
-    interpreter.accumulator() = TRY(get_by_id(interpreter.vm(), interpreter.current_executable().get_identifier(m_property), base_value, this_value, m_cache_index));
+    auto& cache = interpreter.current_executable().property_lookup_caches[m_cache_index];
+    interpreter.accumulator() = TRY(get_by_id(interpreter.vm(), interpreter.current_executable().get_identifier(m_property), base_value, this_value, cache));
     return {};
 }
 

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -760,7 +760,7 @@ ThrowCompletionOr<void> SetLocal::execute_impl(Bytecode::Interpreter&) const
 ThrowCompletionOr<void> GetById::execute_impl(Bytecode::Interpreter& interpreter) const
 {
     auto base_value = interpreter.accumulator();
-    interpreter.accumulator() = TRY(get_by_id(interpreter, interpreter.current_executable().get_identifier(m_property), base_value, base_value, m_cache_index));
+    interpreter.accumulator() = TRY(get_by_id(interpreter.vm(), interpreter.current_executable().get_identifier(m_property), base_value, base_value, m_cache_index));
     return {};
 }
 
@@ -768,7 +768,7 @@ ThrowCompletionOr<void> GetByIdWithThis::execute_impl(Bytecode::Interpreter& int
 {
     auto base_value = interpreter.accumulator();
     auto this_value = interpreter.reg(m_this_value);
-    interpreter.accumulator() = TRY(get_by_id(interpreter, interpreter.current_executable().get_identifier(m_property), base_value, this_value, m_cache_index));
+    interpreter.accumulator() = TRY(get_by_id(interpreter.vm(), interpreter.current_executable().get_identifier(m_property), base_value, this_value, m_cache_index));
     return {};
 }
 
@@ -1071,7 +1071,7 @@ ThrowCompletionOr<void> Await::execute_impl(Bytecode::Interpreter& interpreter) 
 
 ThrowCompletionOr<void> GetByValue::execute_impl(Bytecode::Interpreter& interpreter) const
 {
-    interpreter.accumulator() = TRY(get_by_value(interpreter, interpreter.reg(m_base), interpreter.accumulator()));
+    interpreter.accumulator() = TRY(get_by_value(interpreter.vm(), interpreter.reg(m_base), interpreter.accumulator()));
     return {};
 }
 

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -760,7 +760,7 @@ ThrowCompletionOr<void> SetLocal::execute_impl(Bytecode::Interpreter&) const
 ThrowCompletionOr<void> GetById::execute_impl(Bytecode::Interpreter& interpreter) const
 {
     auto base_value = interpreter.accumulator();
-    interpreter.accumulator() = TRY(get_by_id(interpreter, m_property, base_value, base_value, m_cache_index));
+    interpreter.accumulator() = TRY(get_by_id(interpreter, interpreter.current_executable().get_identifier(m_property), base_value, base_value, m_cache_index));
     return {};
 }
 
@@ -768,7 +768,7 @@ ThrowCompletionOr<void> GetByIdWithThis::execute_impl(Bytecode::Interpreter& int
 {
     auto base_value = interpreter.accumulator();
     auto this_value = interpreter.reg(m_this_value);
-    interpreter.accumulator() = TRY(get_by_id(interpreter, m_property, base_value, this_value, m_cache_index));
+    interpreter.accumulator() = TRY(get_by_id(interpreter, interpreter.current_executable().get_identifier(m_property), base_value, this_value, m_cache_index));
     return {};
 }
 

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -697,7 +697,10 @@ ThrowCompletionOr<void> GetCalleeAndThisFromEnvironment::execute_impl(Bytecode::
 
 ThrowCompletionOr<void> GetGlobal::execute_impl(Bytecode::Interpreter& interpreter) const
 {
-    interpreter.accumulator() = TRY(get_global(interpreter, interpreter.current_executable().get_identifier(m_identifier), m_cache_index));
+    interpreter.accumulator() = TRY(get_global(
+        interpreter,
+        interpreter.current_executable().get_identifier(m_identifier),
+        interpreter.current_executable().global_variable_caches[m_cache_index]));
     return {};
 }
 

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -697,7 +697,7 @@ ThrowCompletionOr<void> GetCalleeAndThisFromEnvironment::execute_impl(Bytecode::
 
 ThrowCompletionOr<void> GetGlobal::execute_impl(Bytecode::Interpreter& interpreter) const
 {
-    interpreter.accumulator() = TRY(get_global(interpreter, m_identifier, m_cache_index));
+    interpreter.accumulator() = TRY(get_global(interpreter, interpreter.current_executable().get_identifier(m_identifier), m_cache_index));
     return {};
 }
 

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -683,7 +683,10 @@ ThrowCompletionOr<void> ConcatString::execute_impl(Bytecode::Interpreter& interp
 
 ThrowCompletionOr<void> GetVariable::execute_impl(Bytecode::Interpreter& interpreter) const
 {
-    interpreter.accumulator() = TRY(get_variable(interpreter, interpreter.current_executable().get_identifier(m_identifier), m_cache_index));
+    interpreter.accumulator() = TRY(get_variable(
+        interpreter,
+        interpreter.current_executable().get_identifier(m_identifier),
+        interpreter.current_executable().environment_variable_caches[m_cache_index]));
     return {};
 }
 

--- a/Userland/Libraries/LibJS/JIT/Compiler.cpp
+++ b/Userland/Libraries/LibJS/JIT/Compiler.cpp
@@ -970,9 +970,9 @@ void Compiler::compile_get_global(Bytecode::Op::GetGlobal const& op)
     check_exception();
 }
 
-static Value cxx_get_variable(VM& vm, DeprecatedFlyString const& name, u32 cache_index)
+static Value cxx_get_variable(VM& vm, DeprecatedFlyString const& name, Bytecode::EnvironmentVariableCache& cache)
 {
-    return TRY_OR_SET_EXCEPTION(Bytecode::get_variable(vm.bytecode_interpreter(), name, cache_index));
+    return TRY_OR_SET_EXCEPTION(Bytecode::get_variable(vm.bytecode_interpreter(), name, cache));
 }
 
 void Compiler::compile_get_variable(Bytecode::Op::GetVariable const& op)
@@ -982,7 +982,7 @@ void Compiler::compile_get_variable(Bytecode::Op::GetVariable const& op)
         Assembler::Operand::Imm(bit_cast<u64>(&m_bytecode_executable.get_identifier(op.identifier()))));
     m_assembler.mov(
         Assembler::Operand::Register(ARG2),
-        Assembler::Operand::Imm(op.cache_index()));
+        Assembler::Operand::Imm(bit_cast<u64>(&m_bytecode_executable.environment_variable_caches[op.cache_index()])));
     native_call((void*)cxx_get_variable);
     store_accumulator(RET);
     check_exception();

--- a/Userland/Libraries/LibJS/JIT/Compiler.cpp
+++ b/Userland/Libraries/LibJS/JIT/Compiler.cpp
@@ -919,7 +919,7 @@ void Compiler::compile_new_class(Bytecode::Op::NewClass const& op)
     store_accumulator(RET);
 }
 
-static Value cxx_get_by_id(VM& vm, Value base, Bytecode::IdentifierTableIndex property, u32 cache_index)
+static Value cxx_get_by_id(VM& vm, Value base, DeprecatedFlyString const& property, u32 cache_index)
 {
     return TRY_OR_SET_EXCEPTION(Bytecode::get_by_id(vm.bytecode_interpreter(), property, base, base, cache_index));
 }
@@ -929,7 +929,7 @@ void Compiler::compile_get_by_id(Bytecode::Op::GetById const& op)
     load_accumulator(ARG1);
     m_assembler.mov(
         Assembler::Operand::Register(ARG2),
-        Assembler::Operand::Imm(op.property().value()));
+        Assembler::Operand::Imm(bit_cast<u64>(&m_bytecode_executable.get_identifier(op.property()))));
     m_assembler.mov(
         Assembler::Operand::Register(ARG3),
         Assembler::Operand::Imm(op.cache_index()));
@@ -1575,7 +1575,7 @@ void Compiler::compile_resolve_super_base(Bytecode::Op::ResolveSuperBase const&)
     check_exception();
 }
 
-static Value cxx_get_by_id_with_this(VM& vm, Bytecode::IdentifierTableIndex property, Value base_value, Value this_value, u32 cache_index)
+static Value cxx_get_by_id_with_this(VM& vm, DeprecatedFlyString const& property, Value base_value, Value this_value, u32 cache_index)
 {
     return TRY_OR_SET_EXCEPTION(get_by_id(vm.bytecode_interpreter(), property, base_value, this_value, cache_index));
 }
@@ -1584,7 +1584,7 @@ void Compiler::compile_get_by_id_with_this(Bytecode::Op::GetByIdWithThis const& 
 {
     m_assembler.mov(
         Assembler::Operand::Register(ARG1),
-        Assembler::Operand::Imm(op.property().value()));
+        Assembler::Operand::Imm(bit_cast<u64>(&m_bytecode_executable.get_identifier(op.property()))));
     load_accumulator(ARG2);
     load_vm_register(ARG3, op.this_value());
     m_assembler.mov(

--- a/Userland/Libraries/LibJS/JIT/Compiler.cpp
+++ b/Userland/Libraries/LibJS/JIT/Compiler.cpp
@@ -952,9 +952,9 @@ void Compiler::compile_get_by_value(Bytecode::Op::GetByValue const& op)
     check_exception();
 }
 
-static Value cxx_get_global(VM& vm, DeprecatedFlyString const& identifier, u32 cache_index)
+static Value cxx_get_global(VM& vm, DeprecatedFlyString const& identifier, Bytecode::GlobalVariableCache& cache)
 {
-    return TRY_OR_SET_EXCEPTION(Bytecode::get_global(vm.bytecode_interpreter(), identifier, cache_index));
+    return TRY_OR_SET_EXCEPTION(Bytecode::get_global(vm.bytecode_interpreter(), identifier, cache));
 }
 
 void Compiler::compile_get_global(Bytecode::Op::GetGlobal const& op)
@@ -964,7 +964,7 @@ void Compiler::compile_get_global(Bytecode::Op::GetGlobal const& op)
         Assembler::Operand::Imm(bit_cast<u64>(&m_bytecode_executable.get_identifier(op.identifier()))));
     m_assembler.mov(
         Assembler::Operand::Register(ARG2),
-        Assembler::Operand::Imm(op.cache_index()));
+        Assembler::Operand::Imm(bit_cast<u64>(&m_bytecode_executable.global_variable_caches[op.cache_index()])));
     native_call((void*)cxx_get_global);
     store_accumulator(RET);
     check_exception();

--- a/Userland/Libraries/LibJS/JIT/Compiler.cpp
+++ b/Userland/Libraries/LibJS/JIT/Compiler.cpp
@@ -921,7 +921,7 @@ void Compiler::compile_new_class(Bytecode::Op::NewClass const& op)
 
 static Value cxx_get_by_id(VM& vm, Value base, DeprecatedFlyString const& property, u32 cache_index)
 {
-    return TRY_OR_SET_EXCEPTION(Bytecode::get_by_id(vm.bytecode_interpreter(), property, base, base, cache_index));
+    return TRY_OR_SET_EXCEPTION(Bytecode::get_by_id(vm, property, base, base, cache_index));
 }
 
 void Compiler::compile_get_by_id(Bytecode::Op::GetById const& op)
@@ -940,7 +940,7 @@ void Compiler::compile_get_by_id(Bytecode::Op::GetById const& op)
 
 static Value cxx_get_by_value(VM& vm, Value base, Value property)
 {
-    return TRY_OR_SET_EXCEPTION(Bytecode::get_by_value(vm.bytecode_interpreter(), base, property));
+    return TRY_OR_SET_EXCEPTION(Bytecode::get_by_value(vm, base, property));
 }
 
 void Compiler::compile_get_by_value(Bytecode::Op::GetByValue const& op)
@@ -1577,7 +1577,7 @@ void Compiler::compile_resolve_super_base(Bytecode::Op::ResolveSuperBase const&)
 
 static Value cxx_get_by_id_with_this(VM& vm, DeprecatedFlyString const& property, Value base_value, Value this_value, u32 cache_index)
 {
-    return TRY_OR_SET_EXCEPTION(get_by_id(vm.bytecode_interpreter(), property, base_value, this_value, cache_index));
+    return TRY_OR_SET_EXCEPTION(Bytecode::get_by_id(vm, property, base_value, this_value, cache_index));
 }
 
 void Compiler::compile_get_by_id_with_this(Bytecode::Op::GetByIdWithThis const& op)

--- a/Userland/Libraries/LibJS/JIT/Compiler.cpp
+++ b/Userland/Libraries/LibJS/JIT/Compiler.cpp
@@ -919,9 +919,9 @@ void Compiler::compile_new_class(Bytecode::Op::NewClass const& op)
     store_accumulator(RET);
 }
 
-static Value cxx_get_by_id(VM& vm, Value base, DeprecatedFlyString const& property, u32 cache_index)
+static Value cxx_get_by_id(VM& vm, Value base, DeprecatedFlyString const& property, Bytecode::PropertyLookupCache& cache)
 {
-    return TRY_OR_SET_EXCEPTION(Bytecode::get_by_id(vm, property, base, base, cache_index));
+    return TRY_OR_SET_EXCEPTION(Bytecode::get_by_id(vm, property, base, base, cache));
 }
 
 void Compiler::compile_get_by_id(Bytecode::Op::GetById const& op)
@@ -932,7 +932,7 @@ void Compiler::compile_get_by_id(Bytecode::Op::GetById const& op)
         Assembler::Operand::Imm(bit_cast<u64>(&m_bytecode_executable.get_identifier(op.property()))));
     m_assembler.mov(
         Assembler::Operand::Register(ARG3),
-        Assembler::Operand::Imm(op.cache_index()));
+        Assembler::Operand::Imm(bit_cast<u64>(&m_bytecode_executable.property_lookup_caches[op.cache_index()])));
     native_call((void*)cxx_get_by_id);
     store_accumulator(RET);
     check_exception();
@@ -1575,9 +1575,9 @@ void Compiler::compile_resolve_super_base(Bytecode::Op::ResolveSuperBase const&)
     check_exception();
 }
 
-static Value cxx_get_by_id_with_this(VM& vm, DeprecatedFlyString const& property, Value base_value, Value this_value, u32 cache_index)
+static Value cxx_get_by_id_with_this(VM& vm, DeprecatedFlyString const& property, Value base_value, Value this_value, Bytecode::PropertyLookupCache& cache)
 {
-    return TRY_OR_SET_EXCEPTION(Bytecode::get_by_id(vm, property, base_value, this_value, cache_index));
+    return TRY_OR_SET_EXCEPTION(Bytecode::get_by_id(vm, property, base_value, this_value, cache));
 }
 
 void Compiler::compile_get_by_id_with_this(Bytecode::Op::GetByIdWithThis const& op)
@@ -1589,7 +1589,7 @@ void Compiler::compile_get_by_id_with_this(Bytecode::Op::GetByIdWithThis const& 
     load_vm_register(ARG3, op.this_value());
     m_assembler.mov(
         Assembler::Operand::Register(ARG4),
-        Assembler::Operand::Imm(op.cache_index()));
+        Assembler::Operand::Imm(bit_cast<u64>(&m_bytecode_executable.property_lookup_caches[op.cache_index()])));
     native_call((void*)cxx_get_by_id_with_this);
     store_accumulator(RET);
     check_exception();

--- a/Userland/Libraries/LibJS/JIT/Compiler.cpp
+++ b/Userland/Libraries/LibJS/JIT/Compiler.cpp
@@ -952,7 +952,7 @@ void Compiler::compile_get_by_value(Bytecode::Op::GetByValue const& op)
     check_exception();
 }
 
-static Value cxx_get_global(VM& vm, Bytecode::IdentifierTableIndex identifier, u32 cache_index)
+static Value cxx_get_global(VM& vm, DeprecatedFlyString const& identifier, u32 cache_index)
 {
     return TRY_OR_SET_EXCEPTION(Bytecode::get_global(vm.bytecode_interpreter(), identifier, cache_index));
 }
@@ -961,7 +961,7 @@ void Compiler::compile_get_global(Bytecode::Op::GetGlobal const& op)
 {
     m_assembler.mov(
         Assembler::Operand::Register(ARG1),
-        Assembler::Operand::Imm(op.identifier().value()));
+        Assembler::Operand::Imm(bit_cast<u64>(&m_bytecode_executable.get_identifier(op.identifier()))));
     m_assembler.mov(
         Assembler::Operand::Register(ARG2),
         Assembler::Operand::Imm(op.cache_index()));


### PR DESCRIPTION
Instead of passing identifier and cache indexes from jitted code to C++ helpers, resolve them to pointer addresses directly in the JIT compiler instead.

Looks like 1-3% speed-ups across the board on Kraken and Octane :^)