### PR TITLE
LibPDF: Implement DeviceNColorSpace

### DIFF
--- a/Userland/Libraries/LibPDF/ColorSpace.cpp
+++ b/Userland/Libraries/LibPDF/ColorSpace.cpp
@@ -621,7 +621,7 @@ PDFErrorOr<NonnullRefPtr<ColorSpace>> IndexedColorSpace::create(Document* docume
     auto base_object = param0.get<NonnullRefPtr<Object>>();
     auto base = TRY(ColorSpace::create(document, base_object));
 
-    if (base->family().name() == ColorSpaceFamily::Pattern.name() || base->family().name() == ColorSpaceFamily::Indexed.name())
+    if (base->family() == ColorSpaceFamily::Pattern || base->family() == ColorSpaceFamily::Indexed)
         return Error { Error::Type::MalformedPDF, "Indexed color space has invalid base color space" };
 
     // "The hival parameter is an integer that specifies the maximum valid index value. In other words,
@@ -713,7 +713,7 @@ PDFErrorOr<NonnullRefPtr<SeparationColorSpace>> SeparationColorSpace::create(Doc
     auto alternate_space = TRY(ColorSpace::create(document, alternate_space_object));
 
     auto family = alternate_space->family();
-    if (family.name() == ColorSpaceFamily::Pattern.name() || family.name() == ColorSpaceFamily::Indexed.name() || family.name() == ColorSpaceFamily::Separation.name() || family.name() == ColorSpaceFamily::DeviceN.name())
+    if (family == ColorSpaceFamily::Pattern || family == ColorSpaceFamily::Indexed || family == ColorSpaceFamily::Separation || family == ColorSpaceFamily::DeviceN)
         return Error { Error::Type::MalformedPDF, "Separation color space has invalid alternate color space" };
 
     // "The tintTransform parameter must be a function"

--- a/Userland/Libraries/LibPDF/ColorSpace.h
+++ b/Userland/Libraries/LibPDF/ColorSpace.h
@@ -44,6 +44,11 @@ public:
     ENUMERATE_COLOR_SPACE_FAMILIES(ENUMERATE)
 #undef ENUMERATE
 
+    bool operator==(ColorSpaceFamily const& other) const
+    {
+        return m_name == other.m_name;
+    }
+
 private:
     DeprecatedFlyString m_name;
     bool m_may_be_specified_directly;

--- a/Userland/Libraries/LibPDF/ColorSpace.h
+++ b/Userland/Libraries/LibPDF/ColorSpace.h
@@ -125,9 +125,13 @@ public:
     ColorSpaceFamily const& family() const override { return ColorSpaceFamily::DeviceN; }
 
 private:
-    DeviceNColorSpace(size_t number_of_components);
+    DeviceNColorSpace(NonnullRefPtr<ColorSpace>, NonnullRefPtr<Function>);
 
-    size_t m_number_of_components { 0 };
+    Vector<DeprecatedString> m_names;
+    NonnullRefPtr<ColorSpace> m_alternate_space;
+    NonnullRefPtr<Function> m_tint_transform;
+    Vector<float> mutable m_tint_input_values;
+    Vector<Value> mutable m_tint_output_values;
 };
 
 class CalGrayColorSpace final : public ColorSpace {


### PR DESCRIPTION
DeviceNColorSpace is very similar to SeparationColorSpace (#21810) except that more than one ink can be mentioned at once.

If `NChannel` is set, it can also be a general multi-channel additive color space.

But the "pass coordinates to tint transform and pass output to alternateSpace" rendering method is still one of the possible valid rendering methods, so let's go with that, since we have the plumbing in place for it. (Evaluating the channels one-by-one is another, and maybe we want to look into other approaches in the future.)