### PR TITLE
Shell: Add path shortening in prompt formatting option

### DIFF
--- a/Base/usr/share/man/man7/Shell-vars.md
+++ b/Base/usr/share/man/man7/Shell-vars.md
@@ -61,7 +61,7 @@ The value of this variable is used to generate a prompt, the following escape se
 - `\\h`: the current hostname
 - `\\p`: the string '$' (or '#' if the user is 'root')
 - `\\u`: the current username
-- `\\w`: a collapsed path (relative to home) to the current directory
+- `\\w`: a collapsed path (relative to home) to the current directory. If an integer follows the `\\`, it specifies the number of trailing components of the path to show
 - `\\X`: reset style (foreground and background color, etc)
 - `\\t`: current time in the 24-hour format HH:MM:SS
 - `\\T`: current time in the 12-hour format HH:MM

--- a/Base/usr/share/man/man7/Shell-vars.md
+++ b/Base/usr/share/man/man7/Shell-vars.md
@@ -61,7 +61,7 @@ The value of this variable is used to generate a prompt, the following escape se
 - `\\h`: the current hostname
 - `\\p`: the string '$' (or '#' if the user is 'root')
 - `\\u`: the current username
-- `\\w`: a collapsed path (relative to home) to the current directory. If an integer follows the `\\`, it specifies the number of trailing components of the path to show
+- `\\w`, `\\W`: a collapsed path (relative to home) to the current directory. If an integer follows the `\\`, it specifies the number of trailing components of the path to show; if 'w' is used instead of 'W', removed components are shown with ellipsis ("...")
 - `\\X`: reset style (foreground and background color, etc)
 - `\\t`: current time in the 24-hour format HH:MM:SS
 - `\\T`: current time in the 12-hour format HH:MM

--- a/Base/usr/share/man/man7/Shell-vars.md
+++ b/Base/usr/share/man/man7/Shell-vars.md
@@ -63,13 +63,13 @@ The value of this variable is used to generate a prompt, the following escape se
 - `\\u`: the current username
 - `\\w`: a collapsed path (relative to home) to the current directory
 - `\\X`: reset style (foreground and background color, etc)
-- `\\t`: Current time in the 24-hour format HH:MM:SS
-- `\\T`: Current time in the 12-hour format HH:MM
-- `\\@`: Current time in the 12-hour format HH:MM AM/PM
-- `\\D{format}`: Current time, where the string _format_ is passed on to `Core::DateTime::to_string`. If _format_ is empty, a default format string is chosen.
-- `\\j`: The number of jobs currently managed by the shell
-- `\\!`: The history number of the next command to be run
-- `\\\\`: A backslash
+- `\\t`: current time in the 24-hour format HH:MM:SS
+- `\\T`: current time in the 12-hour format HH:MM
+- `\\@`: current time in the 12-hour format HH:MM AM/PM
+- `\\D{format}`: current time, where the string _format_ is passed on to `Core::DateTime::to_string`. If _format_ is empty, a default format string is chosen.
+- `\\j`: the number of jobs currently managed by the shell
+- `\\!`: the history number of the next command to be run
+- `\\\\`: a backslash
 
 Any other escaped character shall be ignored.
 


### PR DESCRIPTION
This PR makes it possible for the `$PROMPT` formatting option `\w`, which normally shows the current working directory, to shorten the path if an integer is provided after the backslash.

The way the path is shortened is based on whether 'w' or 'W' is used in the option. This is a mixture of how [Bash ](https://www.gnu.org/software/bash/manual/bash.html#Controlling-the-Prompt)and [Zsh](https://zsh.sourceforge.io/Doc/Release/Prompt-Expansion.html) implement this feature.

![Screenshot](https://github.com/SerenityOS/serenity/assets/58829763/fa0de878-000a-4c61-b19e-9c7699cc4461)