### PR TITLE
LibVideo/VP9: Ensure range decoder size is within expected range

### DIFF
--- a/Userland/Libraries/LibVideo/VP9/Context.h
+++ b/Userland/Libraries/LibVideo/VP9/Context.h
@@ -61,6 +61,9 @@ public:
 
     DecoderErrorOr<BooleanDecoder> create_range_decoder(size_t size)
     {
+        if (size > stream->remaining())
+            return DecoderError::corrupted("Range decoder size invalid"sv);
+
         auto compressed_header_data = ReadonlyBytes(stream_data.data() + stream->offset(), size);
 
         // 9.2.1: The Boolean decoding process specified in section 9.2.2 is invoked to read a marker syntax element from the


### PR DESCRIPTION
This fixes oss fuzz issue: [60262](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=60262)