### PR TITLE
LibJS+LibJIT+AK: Compile GetVariable fast path in the JIT

### DIFF
--- a/AK/Optional.h
+++ b/AK/Optional.h
@@ -318,6 +318,9 @@ public:
         }
     }
 
+    static FlatPtr value_offset() { return OFFSET_OF(Optional, m_storage); }
+    static FlatPtr has_value_offset() { return OFFSET_OF(Optional, m_has_value); }
+
 private:
     alignas(T) u8 m_storage[sizeof(T)];
     bool m_has_value { false };

--- a/AK/StdLibExtras.h
+++ b/AK/StdLibExtras.h
@@ -16,6 +16,8 @@
 
 #include <AK/Assertions.h>
 
+#define OFFSET_OF(class, member) (reinterpret_cast<ptrdiff_t>(&reinterpret_cast<class*>(0x1000)->member) - 0x1000)
+
 namespace AK {
 
 template<typename T, typename U>

--- a/AK/Vector.h
+++ b/AK/Vector.h
@@ -811,6 +811,8 @@ public:
             AK::swap(at(i), at(size() - i - 1));
     }
 
+    static FlatPtr outline_buffer_offset() { return OFFSET_OF(Vector, m_outline_buffer); }
+
 private:
     void reset_capacity()
     {

--- a/Userland/Libraries/LibJIT/X86_64/Assembler.h
+++ b/Userland/Libraries/LibJIT/X86_64/Assembler.h
@@ -557,6 +557,20 @@ struct X86_64Assembler {
             emit8(0x0f);
             emit8(0xaf);
             emit_modrm_rm(dest, src);
+        } else if (dest.type == Operand::Type::Reg && src.type == Operand::Type::Imm) {
+            if (src.fits_in_i8()) {
+                emit_rex_for_rm(dest, dest, REX_W::No);
+                emit8(0x6b);
+                emit_modrm_rm(dest, dest);
+                emit8(src.offset_or_immediate);
+            } else if (src.fits_in_i32()) {
+                emit_rex_for_rm(dest, dest, REX_W::No);
+                emit8(0x69);
+                emit_modrm_rm(dest, dest);
+                emit32(src.offset_or_immediate);
+            } else {
+                VERIFY_NOT_REACHED();
+            }
         } else {
             VERIFY_NOT_REACHED();
         }

--- a/Userland/Libraries/LibJS/JIT/Compiler.cpp
+++ b/Userland/Libraries/LibJS/JIT/Compiler.cpp
@@ -1947,6 +1947,10 @@ OwnPtr<NativeExecutable> Compiler::compile(Bytecode::Executable& bytecode_execut
         Assembler::Operand::Register(LOCALS_ARRAY_BASE),
         Assembler::Operand::Register(ARG2));
 
+    compiler.m_assembler.mov(
+        Assembler::Operand::Register(RUNNING_EXECUTION_CONTEXT_BASE),
+        Assembler::Operand::Register(ARG4));
+
     compiler.reload_cached_accumulator();
 
     Assembler::Label normal_entry {};

--- a/Userland/Libraries/LibJS/JIT/Compiler.h
+++ b/Userland/Libraries/LibJS/JIT/Compiler.h
@@ -38,6 +38,7 @@ private:
     static constexpr auto REGISTER_ARRAY_BASE = Assembler::Reg::RBX;
     static constexpr auto LOCALS_ARRAY_BASE = Assembler::Reg::R14;
     static constexpr auto CACHED_ACCUMULATOR = Assembler::Reg::R13;
+    static constexpr auto RUNNING_EXECUTION_CONTEXT_BASE = Assembler::Reg::R15;
 #    endif
 
 #    define JS_ENUMERATE_COMMON_BINARY_OPS_WITHOUT_FAST_PATH(O) \

--- a/Userland/Libraries/LibJS/JIT/Compiler.h
+++ b/Userland/Libraries/LibJS/JIT/Compiler.h
@@ -27,6 +27,7 @@ private:
 #    if ARCH(X86_64)
     static constexpr auto GPR0 = Assembler::Reg::RAX;
     static constexpr auto GPR1 = Assembler::Reg::RCX;
+    static constexpr auto GPR2 = Assembler::Reg::R12;
     static constexpr auto ARG0 = Assembler::Reg::RDI;
     static constexpr auto ARG1 = Assembler::Reg::RSI;
     static constexpr auto ARG2 = Assembler::Reg::RDX;

--- a/Userland/Libraries/LibJS/JIT/NativeExecutable.cpp
+++ b/Userland/Libraries/LibJS/JIT/NativeExecutable.cpp
@@ -118,9 +118,11 @@ void NativeExecutable::dump_disassembly([[maybe_unused]] Bytecode::Executable co
                 if (mapping->bytecode_offset == 0)
                     dbgln("\nBlock {}:", mapping->block_index + 1);
 
-                VERIFY(mapping->bytecode_offset < block.size());
-                auto const& instruction = *reinterpret_cast<Bytecode::Instruction const*>(block.data() + mapping->bytecode_offset);
-                dbgln("{}:{:x} {}:", mapping->block_index + 1, mapping->bytecode_offset, instruction.to_deprecated_string(executable));
+                if (block.size() != 0) {
+                    VERIFY(mapping->bytecode_offset < block.size());
+                    auto const& instruction = *reinterpret_cast<Bytecode::Instruction const*>(block.data() + mapping->bytecode_offset);
+                    dbgln("{}:{:x} {}:", mapping->block_index + 1, mapping->bytecode_offset, instruction.to_deprecated_string(executable));
+                }
             }
         }
 

--- a/Userland/Libraries/LibJS/JIT/NativeExecutable.cpp
+++ b/Userland/Libraries/LibJS/JIT/NativeExecutable.cpp
@@ -43,11 +43,12 @@ void NativeExecutable::run(VM& vm, size_t entry_point) const
         VERIFY(entry_point_address != 0);
     }
 
-    typedef void (*JITCode)(VM&, Value* registers, Value* locals, FlatPtr entry_point_address);
+    typedef void (*JITCode)(VM&, Value* registers, Value* locals, FlatPtr entry_point_address, ExecutionContext&);
     ((JITCode)m_code)(vm,
         vm.bytecode_interpreter().registers().data(),
         vm.running_execution_context().local_variables.data(),
-        entry_point_address);
+        entry_point_address,
+        vm.running_execution_context());
 }
 
 #if ARCH(X86_64)

--- a/Userland/Libraries/LibJS/Runtime/DeclarativeEnvironment.h
+++ b/Userland/Libraries/LibJS/Runtime/DeclarativeEnvironment.h
@@ -19,6 +19,9 @@ class DeclarativeEnvironment : public Environment {
     JS_ENVIRONMENT(DeclarativeEnvironment, Environment);
 
     struct Binding {
+        static FlatPtr value_offset() { return OFFSET_OF(Binding, value); }
+        static FlatPtr initialized_offset() { return OFFSET_OF(Binding, initialized); }
+
         DeprecatedFlyString name;
         Value value;
         bool strict { false };
@@ -66,6 +69,8 @@ public:
     }
 
     [[nodiscard]] u64 environment_serial_number() const { return m_environment_serial_number; }
+
+    static FlatPtr bindings_offset() { return OFFSET_OF(DeclarativeEnvironment, m_bindings); }
 
 private:
     ThrowCompletionOr<Value> get_binding_value_direct(VM&, Binding&, bool strict);

--- a/Userland/Libraries/LibJS/Runtime/Environment.h
+++ b/Userland/Libraries/LibJS/Runtime/Environment.h
@@ -57,6 +57,9 @@ public:
     bool is_permanently_screwed_by_eval() const { return m_permanently_screwed_by_eval; }
     void set_permanently_screwed_by_eval();
 
+    static FlatPtr is_permanently_screwed_by_eval_offset() { return OFFSET_OF(Environment, m_permanently_screwed_by_eval); }
+    static FlatPtr outer_environment_offset() { return OFFSET_OF(Environment, m_outer_environment); }
+
 protected:
     explicit Environment(Environment* parent);
 

--- a/Userland/Libraries/LibJS/Runtime/EnvironmentCoordinate.h
+++ b/Userland/Libraries/LibJS/Runtime/EnvironmentCoordinate.h
@@ -15,6 +15,9 @@ struct EnvironmentCoordinate {
     u32 hops { invalid_marker };
     u32 index { invalid_marker };
 
+    static FlatPtr hops_offset() { return OFFSET_OF(EnvironmentCoordinate, hops); }
+    static FlatPtr index_offset() { return OFFSET_OF(EnvironmentCoordinate, index); }
+
     bool is_valid() const { return hops != invalid_marker && index != invalid_marker; }
 
     static constexpr u32 invalid_marker = 0xfffffffe;

--- a/Userland/Libraries/LibJS/Runtime/ExecutionContext.h
+++ b/Userland/Libraries/LibJS/Runtime/ExecutionContext.h
@@ -30,6 +30,8 @@ struct ExecutionContext {
 
     void visit_edges(Cell::Visitor&);
 
+    static FlatPtr lexical_environment_offset() { return OFFSET_OF(ExecutionContext, lexical_environment); }
+
 private:
     explicit ExecutionContext(MarkedVector<Value> existing_arguments, MarkedVector<Value> existing_local_variables);
 


### PR DESCRIPTION
When we have a cached `EnvironmentCoordinate` for a `GetVariable` instruction, we can stay in machine code and avoid the expensive call to C++.

20% speed-up on Octane/zlib.js :^)