### PR TITLE
LibWeb: Make Window.postMessage closer to the spec

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -42,6 +42,7 @@ static bool is_platform_object(Type const& type)
         "Instance"sv,
         "IntersectionObserverEntry"sv,
         "Memory"sv,
+        "MessagePort"sv,
         "Module"sv,
         "MutationRecord"sv,
         "NamedNodeMap"sv,

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -2061,7 +2061,7 @@ static DeprecatedString generate_constructor_for_idl_type(Type const& type)
     case Type::Kind::Parameterized: {
         auto const& parameterized_type = type.as_parameterized();
         StringBuilder builder;
-        builder.appendff("make_ref_counted<IDL::ParameterizedTypeType>(\"{}\", {}, Vector<NonnullRefPtr<IDL::Type const>> {{", type.name(), type.is_nullable());
+        builder.appendff("make_ref_counted<IDL::ParameterizedType>(\"{}\", {}, Vector<NonnullRefPtr<IDL::Type const>> {{", type.name(), type.is_nullable());
         append_type_list(builder, parameterized_type.parameters());
         builder.append("})"sv);
         return builder.to_deprecated_string();

--- a/Tests/LibWeb/Text/expected/HTML/Window-postMessage.txt
+++ b/Tests/LibWeb/Text/expected/HTML/Window-postMessage.txt
@@ -1,0 +1,100 @@
+    originError instanceof DOMException: true
+originError.name: SyntaxError
+originError.message: Invalid URL for targetOrigin: 'aaaa'
+originError.constructor === window.DOMException: true
+originParsedBeforeSerializeError instanceof DOMException: true
+originParsedBeforeSerializeError.name: SyntaxError
+originParsedBeforeSerializeError.message: Invalid URL for targetOrigin: 'aaaa'
+originParsedBeforeSerializeError.constructor === window.DOMException: true
+serializeError instanceof DOMException: true
+serializeError.name: DataCloneError
+serializeError.message: Unsupported type
+serializeError.constructor === window.DOMException: true
+originIframeError instanceof DOMException: false
+originIframeError instanceof iframe.contentWindow.DOMException: true
+originIframeError.name: SyntaxError
+originIframeError.message: Invalid URL for targetOrigin: 'aaaa'
+originIframeError.constructor === DOMException: false
+originIframeError.constructor === iframe.contentWindow.DOMException: true
+originParsedBeforeSerializeIframeError instanceof DOMException: false
+originParsedBeforeSerializeIframeError instanceof iframe.contentWindow.DOMException: true
+originParsedBeforeSerializeIframeError.name: SyntaxError
+originParsedBeforeSerializeIframeError.message: Invalid URL for targetOrigin: 'aaaa'
+originParsedBeforeSerializeIframeError.constructor === DOMException: false
+originParsedBeforeSerializeIframeError.constructor === iframe.contentWindow.DOMException: true
+serializeIframeError instanceof DOMException: false
+serializeIframeError instanceof iframe.contentWindow.DOMException: true
+serializeIframeError.name: DataCloneError
+serializeIframeError.message: Unsupported type
+serializeIframeError.constructor === DOMException: false
+serializeIframeError.constructor === iframe.contentWindow.DOMException: true
+Message 1 data: undefined
+Message 1 origin: file://
+Message 1 lastEventId: 
+Message 1 source: [object Window]
+Message 1 source === window: true
+Message 1 source === iframe.contentWindow: false
+Message 1 source === blobIframe.contentWindow: false
+Message 2 data: null
+Message 2 origin: file://
+Message 2 lastEventId: 
+Message 2 source: [object Window]
+Message 2 source === window: true
+Message 2 source === iframe.contentWindow: false
+Message 2 source === blobIframe.contentWindow: false
+Message 3 data: true
+Message 3 origin: file://
+Message 3 lastEventId: 
+Message 3 source: [object Window]
+Message 3 source === window: true
+Message 3 source === iframe.contentWindow: false
+Message 3 source === blobIframe.contentWindow: false
+Message 4 data: false
+Message 4 origin: file://
+Message 4 lastEventId: 
+Message 4 source: [object Window]
+Message 4 source === window: true
+Message 4 source === iframe.contentWindow: false
+Message 4 source === blobIframe.contentWindow: false
+Message 5 data: 123
+Message 5 origin: file://
+Message 5 lastEventId: 
+Message 5 source: [object Window]
+Message 5 source === window: true
+Message 5 source === iframe.contentWindow: false
+Message 5 source === blobIframe.contentWindow: false
+Message 6 data: 123.456
+Message 6 origin: file://
+Message 6 lastEventId: 
+Message 6 source: [object Window]
+Message 6 source === window: true
+Message 6 source === iframe.contentWindow: false
+Message 6 source === blobIframe.contentWindow: false
+Message 7 data: 9007199254740991
+Message 7 origin: file://
+Message 7 lastEventId: 
+Message 7 source: [object Window]
+Message 7 source === window: true
+Message 7 source === iframe.contentWindow: false
+Message 7 source === blobIframe.contentWindow: false
+Message 8 data: This is a string
+Message 8 origin: file://
+Message 8 lastEventId: 
+Message 8 source: [object Window]
+Message 8 source === window: true
+Message 8 source === iframe.contentWindow: false
+Message 8 source === blobIframe.contentWindow: false
+Message 9 data: I am from another ~planet~ iframe
+Message 9 origin: file://
+Message 9 lastEventId: 
+Message 9 source: [object Window]
+Message 9 source === window: false
+Message 9 source === iframe.contentWindow: true
+Message 9 source === blobIframe.contentWindow: false
+Message 10 data: All done :^)
+Message 10 origin: file://
+Message 10 lastEventId: 
+Message 10 source: [object Window]
+Message 10 source === window: false
+Message 10 source === iframe.contentWindow: false
+Message 10 source === blobIframe.contentWindow: true

--- a/Tests/LibWeb/Text/input/HTML/Window-postMessage.html
+++ b/Tests/LibWeb/Text/input/HTML/Window-postMessage.html
@@ -1,0 +1,137 @@
+<body>
+<iframe style="display: none" id="message-iframe" srcdoc="
+<body>
+    <script>
+        window.addEventListener('message', (event) => {
+            window.parent.postMessage(event.data, '*');
+        });
+    </script>
+<body>
+"></iframe>
+<script src="../include.js"></script>
+<script>
+    const iframe = document.getElementById("message-iframe");
+
+    const blobSrcdoc = new Blob([iframe.srcdoc], {
+        type: "text/html",
+    });
+    const iframeSrcdocBlobUrl = URL.createObjectURL(blobSrcdoc);
+
+    const blobIframe = document.createElement("iframe");
+    blobIframe.src = iframeSrcdocBlobUrl;
+    blobIframe.setAttribute("style", "display: none");
+
+    document.body.append(blobIframe);
+
+    let messageCount = 1;
+    window.onmessage = (messageEvent) => {
+        try {
+            println(`Message ${messageCount} data: ${messageEvent.data}`);
+            println(`Message ${messageCount} origin: ${messageEvent.origin}`);
+            println(`Message ${messageCount} lastEventId: ${messageEvent.lastEventId}`);
+            println(`Message ${messageCount} source: ${messageEvent.source}`);
+            println(`Message ${messageCount} source === window: ${messageEvent.source === window}`);
+            println(`Message ${messageCount} source === iframe.contentWindow: ${messageEvent.source === iframe.contentWindow}`);
+            println(`Message ${messageCount} source === blobIframe.contentWindow: ${messageEvent.source === blobIframe.contentWindow}`);
+        } catch (ex) {
+            println(`Accessing attributes of message ${messageCount} threw exception: ${ex}`);
+        }
+        messageCount++;
+
+        if (messageEvent.source === blobIframe.contentWindow && messageEvent.data === "All done :^)")
+        {
+            globalThis.doneCallback();
+        }
+    };
+
+    function performTest() {
+        window.postMessage(undefined, "*");
+        window.postMessage(null, "*");
+        window.postMessage(true, "*");
+        window.postMessage(false, "*");
+        window.postMessage(123, "*");
+        window.postMessage(123.456, "*");
+        window.postMessage(BigInt("0x1fffffffffffff"), "*");
+        window.postMessage("This is a string", "/");
+        window.postMessage("I shouldn't appear, I'm not same origin!", "https://serenityos.org");
+        iframe.contentWindow.postMessage("I am from another ~planet~ iframe", "*");
+        blobIframe.contentWindow.postMessage("All done :^)", iframeSrcdocBlobUrl);
+
+        try {
+            window.postMessage("This is a bad origin string", "aaaa");
+        } catch (originError) {
+            println(`originError instanceof DOMException: ${originError instanceof DOMException}`);
+            println(`originError.name: ${originError.name}`);
+            println(`originError.message: ${originError.message}`);
+            println(`originError.constructor === window.DOMException: ${originError.constructor === window.DOMException}`);
+        }
+
+        try {
+            window.postMessage(document, "aaaa");
+        } catch (originParsedBeforeSerializeError) {
+            println(`originParsedBeforeSerializeError instanceof DOMException: ${originParsedBeforeSerializeError instanceof DOMException}`);
+            println(`originParsedBeforeSerializeError.name: ${originParsedBeforeSerializeError.name}`);
+            println(`originParsedBeforeSerializeError.message: ${originParsedBeforeSerializeError.message}`);
+            println(`originParsedBeforeSerializeError.constructor === window.DOMException: ${originParsedBeforeSerializeError.constructor === window.DOMException}`);
+        }
+
+        try {
+            window.postMessage(document, "*");
+        } catch (serializeError) {
+            println(`serializeError instanceof DOMException: ${serializeError instanceof DOMException}`);
+            println(`serializeError.name: ${serializeError.name}`);
+            println(`serializeError.message: ${serializeError.message}`);
+            println(`serializeError.constructor === window.DOMException: ${serializeError.constructor === window.DOMException}`);
+        }
+
+        try {
+            iframe.contentWindow.postMessage("This is a bad origin string", "aaaa");
+        } catch (originIframeError) {
+            println(`originIframeError instanceof DOMException: ${originIframeError instanceof DOMException}`);
+            println(`originIframeError instanceof iframe.contentWindow.DOMException: ${originIframeError instanceof iframe.contentWindow.DOMException}`);
+            println(`originIframeError.name: ${originIframeError.name}`);
+            println(`originIframeError.message: ${originIframeError.message}`);
+            println(`originIframeError.constructor === DOMException: ${originIframeError.constructor === DOMException}`);
+            println(`originIframeError.constructor === iframe.contentWindow.DOMException: ${originIframeError.constructor === iframe.contentWindow.DOMException}`);
+        }
+
+        try {
+            iframe.contentWindow.postMessage(document, "aaaa");
+        } catch (originParsedBeforeSerializeIframeError) {
+            println(`originParsedBeforeSerializeIframeError instanceof DOMException: ${originParsedBeforeSerializeIframeError instanceof DOMException}`);
+            println(`originParsedBeforeSerializeIframeError instanceof iframe.contentWindow.DOMException: ${originParsedBeforeSerializeIframeError instanceof iframe.contentWindow.DOMException}`);
+            println(`originParsedBeforeSerializeIframeError.name: ${originParsedBeforeSerializeIframeError.name}`);
+            println(`originParsedBeforeSerializeIframeError.message: ${originParsedBeforeSerializeIframeError.message}`);
+            println(`originParsedBeforeSerializeIframeError.constructor === DOMException: ${originParsedBeforeSerializeIframeError.constructor === DOMException}`);
+            println(`originParsedBeforeSerializeIframeError.constructor === iframe.contentWindow.DOMException: ${originParsedBeforeSerializeIframeError.constructor === iframe.contentWindow.DOMException}`);
+        }
+
+        try {
+            iframe.contentWindow.postMessage(document, "*");
+        } catch (serializeIframeError) {
+            println(`serializeIframeError instanceof DOMException: ${serializeIframeError instanceof DOMException}`);
+            println(`serializeIframeError instanceof iframe.contentWindow.DOMException: ${serializeIframeError instanceof iframe.contentWindow.DOMException}`);
+            println(`serializeIframeError.name: ${serializeIframeError.name}`);
+            println(`serializeIframeError.message: ${serializeIframeError.message}`);
+            println(`serializeIframeError.constructor === DOMException: ${serializeIframeError.constructor === DOMException}`);
+            println(`serializeIframeError.constructor === iframe.contentWindow.DOMException: ${serializeIframeError.constructor === iframe.contentWindow.DOMException}`);
+        }
+    }
+
+    asyncTest((done) => {
+        globalThis.doneCallback = done;
+
+        const blobIframeLoadPromise = new Promise(resolve => {
+            blobIframe.onload = () => resolve();
+        });
+
+        const srcdocIframeLoadPromise = new Promise(resolve => {
+            iframe.onload = () => resolve();
+        });
+
+        Promise.all([blobIframeLoadPromise, srcdocIframeLoadPromise]).then(() => {
+            performTest();
+        });
+    });
+</script>
+</body>

--- a/Userland/Libraries/LibWeb/HTML/MessageEvent.cpp
+++ b/Userland/Libraries/LibWeb/HTML/MessageEvent.cpp
@@ -24,6 +24,7 @@ MessageEvent::MessageEvent(JS::Realm& realm, FlyString const& event_name, Messag
     , m_data(event_init.data)
     , m_origin(event_init.origin)
     , m_last_event_id(event_init.last_event_id)
+    , m_source(event_init.source)
 {
 }
 
@@ -39,6 +40,14 @@ void MessageEvent::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
     visitor.visit(m_data);
+}
+
+Variant<JS::Handle<WindowProxy>, JS::Handle<MessagePort>, Empty> MessageEvent::source() const
+{
+    if (!m_source.has_value())
+        return Empty {};
+
+    return m_source.value().downcast<JS::Handle<WindowProxy>, JS::Handle<MessagePort>>();
 }
 
 }

--- a/Userland/Libraries/LibWeb/HTML/MessageEvent.h
+++ b/Userland/Libraries/LibWeb/HTML/MessageEvent.h
@@ -12,10 +12,14 @@
 
 namespace Web::HTML {
 
+// FIXME: Include ServiceWorker
+using MessageEventSource = Variant<JS::Handle<WindowProxy>, JS::Handle<MessagePort>>;
+
 struct MessageEventInit : public DOM::EventInit {
     JS::Value data { JS::js_null() };
     String origin;
     String last_event_id;
+    Optional<MessageEventSource> source;
 };
 
 class MessageEvent : public DOM::Event {
@@ -31,6 +35,7 @@ public:
     JS::Value data() const { return m_data; }
     String const& origin() const { return m_origin; }
     String const& last_event_id() const { return m_last_event_id; }
+    Variant<JS::Handle<WindowProxy>, JS::Handle<MessagePort>, Empty> source() const;
 
 private:
     virtual void initialize(JS::Realm&) override;
@@ -39,6 +44,7 @@ private:
     JS::Value m_data;
     String m_origin;
     String m_last_event_id;
+    Optional<MessageEventSource> m_source;
 };
 
 }

--- a/Userland/Libraries/LibWeb/HTML/MessageEvent.h
+++ b/Userland/Libraries/LibWeb/HTML/MessageEvent.h
@@ -17,8 +17,8 @@ using MessageEventSource = Variant<JS::Handle<WindowProxy>, JS::Handle<MessagePo
 
 struct MessageEventInit : public DOM::EventInit {
     JS::Value data { JS::js_null() };
-    String origin;
-    String last_event_id;
+    String origin {};
+    String last_event_id {};
     Optional<MessageEventSource> source;
 };
 

--- a/Userland/Libraries/LibWeb/HTML/MessageEvent.idl
+++ b/Userland/Libraries/LibWeb/HTML/MessageEvent.idl
@@ -1,4 +1,8 @@
 #import <DOM/Event.idl>
+#import <HTML/MessagePort.idl>
+
+// FIXME: typedef (WindowProxy or MessagePort or ServiceWorker) MessageEventSource;
+typedef (WindowProxy or MessagePort) MessageEventSource;
 
 // https://html.spec.whatwg.org/multipage/comms.html#messageevent
 [Exposed=(Window,Worker)]
@@ -8,7 +12,7 @@ interface MessageEvent : Event {
     readonly attribute any data;
     readonly attribute USVString origin;
     readonly attribute DOMString lastEventId;
-    // FIXME: readonly attribute MessageEventSource? source;
+    readonly attribute MessageEventSource? source;
     // FIXME: readonly attribute FrozenArray<MessagePort> ports;
 };
 
@@ -16,6 +20,6 @@ dictionary MessageEventInit : EventInit {
     any data = null;
     USVString origin = "";
     DOMString lastEventId = "";
-    // FIXME: MessageEventSource? source = null;
+    MessageEventSource? source = null;
     // FIXME: sequence<MessagePort> ports = [];
 };

--- a/Userland/Libraries/LibWeb/HTML/Window.h
+++ b/Userland/Libraries/LibWeb/HTML/Window.h
@@ -38,6 +38,11 @@ struct ScrollToOptions : public ScrollOptions {
     Optional<double> top;
 };
 
+// https://html.spec.whatwg.org/multipage/nav-history-apis.html#windowpostmessageoptions
+struct WindowPostMessageOptions : public StructuredSerializeOptions {
+    String target_origin { "/"_string };
+};
+
 class Window final
     : public DOM::EventTarget
     , public GlobalEventHandlers
@@ -146,7 +151,8 @@ public:
     bool confirm(Optional<String> const& message);
     Optional<String> prompt(Optional<String> const& message, Optional<String> const& default_);
 
-    void post_message(JS::Value message, String const&);
+    WebIDL::ExceptionOr<void> post_message(JS::Value message, String const&, Vector<JS::Handle<JS::Object>> const&);
+    WebIDL::ExceptionOr<void> post_message(JS::Value message, WindowPostMessageOptions const&);
 
     Variant<JS::Handle<DOM::Event>, JS::Value> event() const;
 
@@ -214,6 +220,8 @@ private:
         Vector<JS::NonnullGCPtr<DOM::Element>> elements;
     };
     NamedObjects named_objects(StringView name);
+
+    WebIDL::ExceptionOr<void> window_post_message_steps(JS::Value, WindowPostMessageOptions const&);
 
     // https://html.spec.whatwg.org/multipage/window-object.html#concept-document-window
     JS::GCPtr<DOM::Document> m_associated_document;

--- a/Userland/Libraries/LibWeb/HTML/Window.idl
+++ b/Userland/Libraries/LibWeb/HTML/Window.idl
@@ -52,9 +52,8 @@ interface Window : EventTarget {
     boolean confirm(optional DOMString message = "");
     DOMString? prompt(optional DOMString message = "", optional DOMString default = "");
 
-    undefined postMessage(any message, USVString targetOrigin);
-    // FIXME: undefined postMessage(any message, USVString targetOrigin, optional sequence<object> transfer = []);
-    // FIXME: undefined postMessage(any message, optional WindowPostMessageOptions options = {});
+    undefined postMessage(any message, USVString targetOrigin, optional sequence<object> transfer = []);
+    undefined postMessage(any message, optional WindowPostMessageOptions options = {});
 
     // https://dom.spec.whatwg.org/#interface-window-extensions
     [Replaceable] readonly attribute (Event or undefined) event; // legacy
@@ -121,4 +120,8 @@ dictionary ScrollOptions {
 dictionary ScrollToOptions : ScrollOptions {
     unrestricted double left;
     unrestricted double top;
+};
+
+dictionary WindowPostMessageOptions : StructuredSerializeOptions {
+    USVString targetOrigin = "/";
 };


### PR DESCRIPTION
The main issues are using Structured{Serialize,Deserailize} instead of
Structured{Serialize,Deserialize}WithTransfer and the temporary
execution context usage for StructuredDeserialize.

Allows Discord to load once again, as it uses a postMessage scheduler
to render components, including the main App component. The callback
checked the (previously) non-existent source attribute of the
MessageEvent and returned if it was not the main window.

Fixes the Twitch cookie consent banner saying "failed integrity check"
for unknown reasons, but presumably related to the source and origin
attributes.