### PR TITLE
LibWeb: Remove remaining DeprecatedFlyString instances (almost)

### DIFF
--- a/AK/FlyString.cpp
+++ b/AK/FlyString.cpp
@@ -205,4 +205,14 @@ bool FlyString::equals_ignoring_ascii_case(StringView other) const
     return StringUtils::equals_ignoring_ascii_case(bytes_as_string_view(), other);
 }
 
+bool FlyString::starts_with_bytes(StringView bytes, CaseSensitivity case_sensitivity) const
+{
+    return bytes_as_string_view().starts_with(bytes, case_sensitivity);
+}
+
+bool FlyString::ends_with_bytes(StringView bytes, CaseSensitivity case_sensitivity) const
+{
+    return bytes_as_string_view().ends_with(bytes, case_sensitivity);
+}
+
 }

--- a/AK/FlyString.h
+++ b/AK/FlyString.h
@@ -69,6 +69,10 @@ public:
     [[nodiscard]] bool equals_ignoring_ascii_case(FlyString const&) const;
     [[nodiscard]] bool equals_ignoring_ascii_case(StringView) const;
 
+    [[nodiscard]] bool starts_with_bytes(StringView, CaseSensitivity = CaseSensitivity::CaseSensitive) const;
+
+    [[nodiscard]] bool ends_with_bytes(StringView, CaseSensitivity = CaseSensitivity::CaseSensitive) const;
+
     template<typename... Ts>
     [[nodiscard]] ALWAYS_INLINE constexpr bool is_one_of(Ts... strings) const
     {

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleDeclaration.cpp
@@ -27,12 +27,12 @@ void CSSStyleDeclaration::initialize(JS::Realm& realm)
     set_prototype(&Bindings::ensure_web_prototype<Bindings::CSSStyleDeclarationPrototype>(realm, "CSSStyleDeclaration"));
 }
 
-JS::NonnullGCPtr<PropertyOwningCSSStyleDeclaration> PropertyOwningCSSStyleDeclaration::create(JS::Realm& realm, Vector<StyleProperty> properties, HashMap<DeprecatedString, StyleProperty> custom_properties)
+JS::NonnullGCPtr<PropertyOwningCSSStyleDeclaration> PropertyOwningCSSStyleDeclaration::create(JS::Realm& realm, Vector<StyleProperty> properties, HashMap<FlyString, StyleProperty> custom_properties)
 {
     return realm.heap().allocate<PropertyOwningCSSStyleDeclaration>(realm, realm, move(properties), move(custom_properties));
 }
 
-PropertyOwningCSSStyleDeclaration::PropertyOwningCSSStyleDeclaration(JS::Realm& realm, Vector<StyleProperty> properties, HashMap<DeprecatedString, StyleProperty> custom_properties)
+PropertyOwningCSSStyleDeclaration::PropertyOwningCSSStyleDeclaration(JS::Realm& realm, Vector<StyleProperty> properties, HashMap<FlyString, StyleProperty> custom_properties)
     : CSSStyleDeclaration(realm)
     , m_properties(move(properties))
     , m_custom_properties(move(custom_properties))
@@ -55,13 +55,13 @@ String PropertyOwningCSSStyleDeclaration::item(size_t index) const
     return MUST(String::from_utf8(CSS::string_from_property_id(m_properties[index].property_id)));
 }
 
-JS::NonnullGCPtr<ElementInlineCSSStyleDeclaration> ElementInlineCSSStyleDeclaration::create(DOM::Element& element, Vector<StyleProperty> properties, HashMap<DeprecatedString, StyleProperty> custom_properties)
+JS::NonnullGCPtr<ElementInlineCSSStyleDeclaration> ElementInlineCSSStyleDeclaration::create(DOM::Element& element, Vector<StyleProperty> properties, HashMap<FlyString, StyleProperty> custom_properties)
 {
     auto& realm = element.realm();
     return realm.heap().allocate<ElementInlineCSSStyleDeclaration>(realm, element, move(properties), move(custom_properties));
 }
 
-ElementInlineCSSStyleDeclaration::ElementInlineCSSStyleDeclaration(DOM::Element& element, Vector<StyleProperty> properties, HashMap<DeprecatedString, StyleProperty> custom_properties)
+ElementInlineCSSStyleDeclaration::ElementInlineCSSStyleDeclaration(DOM::Element& element, Vector<StyleProperty> properties, HashMap<FlyString, StyleProperty> custom_properties)
     : PropertyOwningCSSStyleDeclaration(element.realm(), move(properties), move(custom_properties))
     , m_element(element.make_weak_ptr<DOM::Element>())
 {
@@ -446,7 +446,7 @@ void PropertyOwningCSSStyleDeclaration::empty_the_declarations()
     m_custom_properties.clear();
 }
 
-void PropertyOwningCSSStyleDeclaration::set_the_declarations(Vector<StyleProperty> properties, HashMap<DeprecatedString, StyleProperty> custom_properties)
+void PropertyOwningCSSStyleDeclaration::set_the_declarations(Vector<StyleProperty> properties, HashMap<FlyString, StyleProperty> custom_properties)
 {
     m_properties = move(properties);
     m_custom_properties = move(custom_properties);

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleDeclaration.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleDeclaration.h
@@ -54,7 +54,7 @@ class PropertyOwningCSSStyleDeclaration : public CSSStyleDeclaration {
 
 public:
     [[nodiscard]] static JS::NonnullGCPtr<PropertyOwningCSSStyleDeclaration>
-    create(JS::Realm&, Vector<StyleProperty>, HashMap<DeprecatedString, StyleProperty> custom_properties);
+    create(JS::Realm&, Vector<StyleProperty>, HashMap<FlyString, StyleProperty> custom_properties);
 
     virtual ~PropertyOwningCSSStyleDeclaration() override = default;
 
@@ -67,20 +67,20 @@ public:
     virtual WebIDL::ExceptionOr<String> remove_property(PropertyID) override;
 
     Vector<StyleProperty> const& properties() const { return m_properties; }
-    HashMap<DeprecatedString, StyleProperty> const& custom_properties() const { return m_custom_properties; }
-    Optional<StyleProperty> custom_property(DeprecatedString const& custom_property_name) const { return m_custom_properties.get(custom_property_name); }
+    HashMap<FlyString, StyleProperty> const& custom_properties() const { return m_custom_properties; }
+    Optional<StyleProperty> custom_property(FlyString const& custom_property_name) const { return m_custom_properties.get(custom_property_name); }
     size_t custom_property_count() const { return m_custom_properties.size(); }
 
     virtual DeprecatedString serialized() const final override;
     virtual WebIDL::ExceptionOr<void> set_css_text(StringView) override;
 
 protected:
-    PropertyOwningCSSStyleDeclaration(JS::Realm&, Vector<StyleProperty>, HashMap<DeprecatedString, StyleProperty>);
+    PropertyOwningCSSStyleDeclaration(JS::Realm&, Vector<StyleProperty>, HashMap<FlyString, StyleProperty>);
 
     virtual void update_style_attribute() { }
 
     void empty_the_declarations();
-    void set_the_declarations(Vector<StyleProperty> properties, HashMap<DeprecatedString, StyleProperty> custom_properties);
+    void set_the_declarations(Vector<StyleProperty> properties, HashMap<FlyString, StyleProperty> custom_properties);
 
 private:
     bool set_a_css_declaration(PropertyID, NonnullRefPtr<StyleValue const>, Important);
@@ -88,14 +88,14 @@ private:
     virtual void visit_edges(Cell::Visitor&) override;
 
     Vector<StyleProperty> m_properties;
-    HashMap<DeprecatedString, StyleProperty> m_custom_properties;
+    HashMap<FlyString, StyleProperty> m_custom_properties;
 };
 
 class ElementInlineCSSStyleDeclaration final : public PropertyOwningCSSStyleDeclaration {
     WEB_PLATFORM_OBJECT(ElementInlineCSSStyleDeclaration, PropertyOwningCSSStyleDeclaration);
 
 public:
-    [[nodiscard]] static JS::NonnullGCPtr<ElementInlineCSSStyleDeclaration> create(DOM::Element&, Vector<StyleProperty>, HashMap<DeprecatedString, StyleProperty> custom_properties);
+    [[nodiscard]] static JS::NonnullGCPtr<ElementInlineCSSStyleDeclaration> create(DOM::Element&, Vector<StyleProperty>, HashMap<FlyString, StyleProperty> custom_properties);
 
     virtual ~ElementInlineCSSStyleDeclaration() override = default;
 
@@ -107,7 +107,7 @@ public:
     virtual WebIDL::ExceptionOr<void> set_css_text(StringView) override;
 
 private:
-    ElementInlineCSSStyleDeclaration(DOM::Element&, Vector<StyleProperty> properties, HashMap<DeprecatedString, StyleProperty> custom_properties);
+    ElementInlineCSSStyleDeclaration(DOM::Element&, Vector<StyleProperty> properties, HashMap<FlyString, StyleProperty> custom_properties);
 
     virtual void visit_edges(Cell::Visitor&) override;
 

--- a/Userland/Libraries/LibWeb/CSS/Parser/Declaration.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Declaration.h
@@ -19,7 +19,7 @@ public:
     Declaration(FlyString name, Vector<ComponentValue> values, Important);
     ~Declaration();
 
-    StringView name() const { return m_name; }
+    FlyString const& name() const { return m_name; }
     Vector<ComponentValue> const& values() const { return m_values; }
     Important importance() const { return m_important; }
 

--- a/Userland/Libraries/LibWeb/CSS/Parser/MediaParsing.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/MediaParsing.cpp
@@ -261,12 +261,12 @@ Optional<MediaFeature> Parser::parse_media_feature(TokenStream<ComponentValue>& 
                 return MediaFeatureName { MediaFeatureName::Type::Normal, id.value() };
             }
 
-            if (allow_min_max_prefix && (name.starts_with("min-"sv, CaseSensitivity::CaseInsensitive) || name.starts_with("max-"sv, CaseSensitivity::CaseInsensitive))) {
-                auto adjusted_name = name.substring_view(4);
+            if (allow_min_max_prefix && (name.starts_with_bytes("min-"sv, CaseSensitivity::CaseInsensitive) || name.starts_with_bytes("max-"sv, CaseSensitivity::CaseInsensitive))) {
+                auto adjusted_name = name.bytes_as_string_view().substring_view(4);
                 if (auto id = media_feature_id_from_string(adjusted_name); id.has_value() && media_feature_type_is_range(id.value())) {
                     transaction.commit();
                     return MediaFeatureName {
-                        name.starts_with("min-"sv, CaseSensitivity::CaseInsensitive) ? MediaFeatureName::Type::Min : MediaFeatureName::Type::Max,
+                        name.starts_with_bytes("min-"sv, CaseSensitivity::CaseInsensitive) ? MediaFeatureName::Type::Min : MediaFeatureName::Type::Max,
                         id.value()
                     };
                 }

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -1574,7 +1574,7 @@ CSSRule* Parser::convert_to_rule(NonnullRefPtr<Rule> rule)
             auto token = token_stream.next_token();
             Optional<DeprecatedString> prefix = {};
             if (token.is(Token::Type::Ident)) {
-                prefix = token.token().ident();
+                prefix = token.token().ident().bytes_as_string_view();
                 token_stream.skip_whitespace();
                 token = token_stream.next_token();
             }
@@ -2446,7 +2446,7 @@ Optional<Color> Parser::parse_color(ComponentValue const& component_value)
         else {
             if (!cv.is(Token::Type::Ident))
                 return {};
-            serialization = cv.token().ident();
+            serialization = cv.token().ident().bytes_as_string_view();
         }
 
         // 4. If serialization does not consist of three or six characters, return an error.
@@ -4178,7 +4178,7 @@ RefPtr<StyleValue> Parser::parse_font_family_value(TokenStream<ComponentValue>& 
                 (void)tokens.next_token(); // Comma
                 continue;
             }
-            current_name_parts.append(tokens.next_token().token().ident());
+            current_name_parts.append(tokens.next_token().token().ident().bytes_as_string_view());
             continue;
         }
 
@@ -4270,7 +4270,7 @@ CSSRule* Parser::parse_font_face_rule(TokenStream<ComponentValue>& tokens)
                         had_syntax_error = true;
                         break;
                     }
-                    font_family_parts.append(part.token().ident());
+                    font_family_parts.append(part.token().ident().bytes_as_string_view());
                     continue;
                 }
 
@@ -6800,7 +6800,7 @@ bool Parser::expand_variables(DOM::Element& element, Optional<Selector::PseudoEl
         if (!custom_property_name_token.is(Token::Type::Ident))
             return false;
         auto custom_property_name = custom_property_name_token.token().ident();
-        if (!custom_property_name.starts_with("--"sv))
+        if (!custom_property_name.bytes_as_string_view().starts_with("--"sv))
             return false;
 
         // Detect dependency cycles. https://www.w3.org/TR/css-variables-1/#cycles

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -1667,15 +1667,15 @@ PropertyOwningCSSStyleDeclaration* Parser::convert_to_style_declaration(Vector<D
 
 Optional<StyleProperty> Parser::convert_to_style_property(Declaration const& declaration)
 {
-    auto property_name = declaration.name();
+    auto const& property_name = declaration.name();
     auto property_id = property_id_from_string(property_name);
 
     if (!property_id.has_value()) {
-        if (property_name.starts_with("--"sv)) {
+        if (property_name.bytes_as_string_view().starts_with("--"sv)) {
             property_id = PropertyID::Custom;
         } else if (has_ignored_vendor_prefix(property_name)) {
             return {};
-        } else if (!property_name.starts_with('-')) {
+        } else if (!property_name.bytes_as_string_view().starts_with('-')) {
             dbgln_if(CSS_PARSER_DEBUG, "Unrecognized CSS property '{}'", property_name);
             return {};
         }
@@ -6735,12 +6735,12 @@ NonnullRefPtr<StyleValue> Parser::resolve_unresolved_style_value(DOM::Element& e
 static RefPtr<StyleValue const> get_custom_property(DOM::Element const& element, Optional<CSS::Selector::PseudoElement> pseudo_element, FlyString const& custom_property_name)
 {
     if (pseudo_element.has_value()) {
-        if (auto it = element.custom_properties(pseudo_element).find(custom_property_name.to_string().to_deprecated_string()); it != element.custom_properties(pseudo_element).end())
+        if (auto it = element.custom_properties(pseudo_element).find(custom_property_name.to_string()); it != element.custom_properties(pseudo_element).end())
             return it->value.value;
     }
 
     for (auto const* current_element = &element; current_element; current_element = current_element->parent_element()) {
-        if (auto it = current_element->custom_properties({}).find(custom_property_name.to_string().to_deprecated_string()); it != current_element->custom_properties({}).end())
+        if (auto it = current_element->custom_properties({}).find(custom_property_name.to_string()); it != current_element->custom_properties({}).end())
             return it->value.value;
     }
     return nullptr;

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -299,7 +299,7 @@ private:
 
     struct PropertiesAndCustomProperties {
         Vector<StyleProperty> properties;
-        HashMap<DeprecatedString, StyleProperty> custom_properties;
+        HashMap<FlyString, StyleProperty> custom_properties;
     };
 
     PropertiesAndCustomProperties extract_properties(Vector<DeclarationOrAtRule> const&);

--- a/Userland/Libraries/LibWeb/CSS/Parser/SelectorParsing.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/SelectorParsing.cpp
@@ -729,10 +729,10 @@ Optional<Selector::SimpleSelector::ANPlusBPattern> Parser::parse_a_n_plus_b_patt
         if (!value.is(Token::Type::Ident))
             return false;
         auto ident = value.token().ident();
-        if (!ident.starts_with("n-"sv, CaseSensitivity::CaseInsensitive))
+        if (!ident.starts_with_bytes("n-"sv, CaseSensitivity::CaseInsensitive))
             return false;
-        for (size_t i = 2; i < ident.length(); ++i) {
-            if (!is_ascii_digit(ident[i]))
+        for (size_t i = 2; i < ident.bytes_as_string_view().length(); ++i) {
+            if (!is_ascii_digit(ident.bytes_as_string_view()[i]))
                 return false;
         }
         return true;
@@ -741,12 +741,12 @@ Optional<Selector::SimpleSelector::ANPlusBPattern> Parser::parse_a_n_plus_b_patt
         if (!value.is(Token::Type::Ident))
             return false;
         auto ident = value.token().ident();
-        if (!ident.starts_with("-n-"sv, CaseSensitivity::CaseInsensitive))
+        if (!ident.starts_with_bytes("-n-"sv, CaseSensitivity::CaseInsensitive))
             return false;
-        if (ident.length() == 3)
+        if (ident.bytes_as_string_view().length() == 3)
             return false;
-        for (size_t i = 3; i < ident.length(); ++i) {
-            if (!is_ascii_digit(ident[i]))
+        for (size_t i = 3; i < ident.bytes_as_string_view().length(); ++i) {
+            if (!is_ascii_digit(ident.bytes_as_string_view()[i]))
                 return false;
         }
         return true;
@@ -844,7 +844,7 @@ Optional<Selector::SimpleSelector::ANPlusBPattern> Parser::parse_a_n_plus_b_patt
     }
     // <dashndashdigit-ident>
     if (is_dashndashdigit_ident(first_value)) {
-        auto maybe_b = first_value.token().ident().substring_view(2).to_int();
+        auto maybe_b = first_value.token().ident().bytes_as_string_view().substring_view(2).to_int();
         if (maybe_b.has_value()) {
             transaction.commit();
             return Selector::SimpleSelector::ANPlusBPattern { -1, maybe_b.value() };
@@ -957,7 +957,7 @@ Optional<Selector::SimpleSelector::ANPlusBPattern> Parser::parse_a_n_plus_b_patt
 
     // '+'?† <ndashdigit-ident>
     if (is_ndashdigit_ident(first_after_plus)) {
-        auto maybe_b = first_after_plus.token().ident().substring_view(1).to_int();
+        auto maybe_b = first_after_plus.token().ident().bytes_as_string_view().substring_view(1).to_int();
         if (maybe_b.has_value()) {
             transaction.commit();
             return Selector::SimpleSelector::ANPlusBPattern { 1, maybe_b.value() };

--- a/Userland/Libraries/LibWeb/CSS/Parser/Token.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Token.h
@@ -59,10 +59,10 @@ public:
     Type type() const { return m_type; }
     bool is(Type type) const { return m_type == type; }
 
-    StringView ident() const
+    FlyString const& ident() const
     {
         VERIFY(m_type == Type::Ident);
-        return m_value.bytes_as_string_view();
+        return m_value;
     }
 
     StringView function() const

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -724,7 +724,7 @@ static ErrorOr<void> cascade_custom_properties(DOM::Element& element, Optional<C
             needed_capacity += inline_style->custom_properties().size();
     }
 
-    HashMap<DeprecatedFlyString, StyleProperty> custom_properties;
+    HashMap<FlyString, StyleProperty> custom_properties;
     TRY(custom_properties.try_ensure_capacity(needed_capacity));
 
     for (auto const& matching_rule : matching_rules) {

--- a/Userland/Libraries/LibWeb/CSS/StyleProperty.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperty.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <AK/DeprecatedString.h>
+#include <AK/FlyString.h>
 #include <LibWeb/CSS/PropertyID.h>
 
 namespace Web::CSS {
@@ -22,7 +22,7 @@ struct StyleProperty {
     Important important { Important::No };
     CSS::PropertyID property_id;
     NonnullRefPtr<StyleValue const> value;
-    DeprecatedString custom_name {};
+    FlyString custom_name {};
 };
 
 }

--- a/Userland/Libraries/LibWeb/DOM/Attr.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Attr.cpp
@@ -115,7 +115,7 @@ void Attr::handle_attribute_changes(Element& element, Optional<DeprecatedString>
     }
 
     // 3. Run the attribute change steps with element, attribute’s local name, oldValue, newValue, and attribute’s namespace.
-    element.run_attribute_change_steps(local_name(), old_value, new_value, deprecated_namespace_uri);
+    element.run_attribute_change_steps(local_name(), old_value, new_value, namespace_uri());
 }
 
 }

--- a/Userland/Libraries/LibWeb/DOM/DOMImplementation.cpp
+++ b/Userland/Libraries/LibWeb/DOM/DOMImplementation.cpp
@@ -140,7 +140,7 @@ JS::NonnullGCPtr<Document> DOMImplementation::create_html_document(Optional<Stri
 WebIDL::ExceptionOr<JS::NonnullGCPtr<DocumentType>> DOMImplementation::create_document_type(String const& qualified_name, String const& public_id, String const& system_id)
 {
     // 1. Validate qualifiedName.
-    TRY(Document::validate_qualified_name(realm(), qualified_name.to_deprecated_string()));
+    TRY(Document::validate_qualified_name(realm(), qualified_name));
 
     // 2. Return a new doctype, with qualifiedName as its name, publicId as its public ID, and systemId as its system ID, and with its node document set to the associated document of this.
     auto document_type = DocumentType::create(document());

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -1,13 +1,13 @@
 /*
  * Copyright (c) 2018-2023, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2021-2023, Linus Groh <linusg@serenityos.org>
+ * Copyright (c) 2023, Shannon Booth <shannon@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #pragma once
 
-#include <AK/DeprecatedFlyString.h>
 #include <AK/DeprecatedString.h>
 #include <AK/Function.h>
 #include <AK/HashMap.h>
@@ -408,10 +408,10 @@ public:
     static bool is_valid_name(String const&);
 
     struct PrefixAndTagName {
-        DeprecatedFlyString prefix;
-        DeprecatedFlyString tag_name;
+        FlyString prefix;
+        FlyString tag_name;
     };
-    static WebIDL::ExceptionOr<PrefixAndTagName> validate_qualified_name(JS::Realm&, DeprecatedString const& qualified_name);
+    static WebIDL::ExceptionOr<PrefixAndTagName> validate_qualified_name(JS::Realm&, FlyString const& qualified_name);
 
     JS::NonnullGCPtr<NodeIterator> create_node_iterator(Node& root, unsigned what_to_show, JS::GCPtr<NodeFilter>);
     JS::NonnullGCPtr<TreeWalker> create_tree_walker(Node& root, unsigned what_to_show, JS::GCPtr<NodeFilter>);

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -1918,7 +1918,7 @@ void Element::set_computed_css_values(RefPtr<CSS::StyleProperties> style)
     m_computed_css_values = move(style);
 }
 
-void Element::set_custom_properties(Optional<CSS::Selector::PseudoElement> pseudo_element, HashMap<DeprecatedFlyString, CSS::StyleProperty> custom_properties)
+void Element::set_custom_properties(Optional<CSS::Selector::PseudoElement> pseudo_element, HashMap<FlyString, CSS::StyleProperty> custom_properties)
 {
     if (!pseudo_element.has_value()) {
         m_custom_properties = move(custom_properties);
@@ -1927,7 +1927,7 @@ void Element::set_custom_properties(Optional<CSS::Selector::PseudoElement> pseud
     m_pseudo_element_custom_properties[to_underlying(pseudo_element.value())] = move(custom_properties);
 }
 
-HashMap<DeprecatedFlyString, CSS::StyleProperty> const& Element::custom_properties(Optional<CSS::Selector::PseudoElement> pseudo_element) const
+HashMap<FlyString, CSS::StyleProperty> const& Element::custom_properties(Optional<CSS::Selector::PseudoElement> pseudo_element) const
 {
     if (!pseudo_element.has_value())
         return m_custom_properties;

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -75,7 +75,7 @@ Element::Element(Document& document, DOM::QualifiedName qualified_name)
     // https://dom.spec.whatwg.org/#ref-for-concept-element-attributes-change-ext①
     add_attribute_change_steps([this](auto const& local_name, auto const& old_value, auto const& value, auto const& namespace_) {
         // 1. If localName is slot and namespace is null, then:
-        if (local_name == HTML::AttributeNames::slot && namespace_.is_null()) {
+        if (local_name == HTML::AttributeNames::slot && !namespace_.has_value()) {
             // 1. If value is oldValue, then return.
             if (value == old_value)
                 return;
@@ -466,7 +466,7 @@ void Element::add_attribute_change_steps(AttributeChangeSteps steps)
     m_attribute_change_steps.append(move(steps));
 }
 
-void Element::run_attribute_change_steps(FlyString const& local_name, Optional<DeprecatedString> const& old_value, Optional<DeprecatedString> const& value, DeprecatedFlyString const& namespace_)
+void Element::run_attribute_change_steps(FlyString const& local_name, Optional<DeprecatedString> const& old_value, Optional<DeprecatedString> const& value, Optional<FlyString> const& namespace_)
 {
     for (auto const& attribute_change_steps : m_attribute_change_steps)
         attribute_change_steps(local_name, old_value, value, namespace_);

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -155,7 +155,7 @@ DeprecatedString Element::deprecated_get_attribute(StringView name) const
 }
 
 // https://dom.spec.whatwg.org/#concept-element-attributes-get-value
-DeprecatedString Element::get_attribute_value(StringView local_name, DeprecatedFlyString const& namespace_) const
+DeprecatedString Element::get_attribute_value(FlyString const& local_name, Optional<FlyString> const& namespace_) const
 {
     // 1. Let attr be the result of getting an attribute given namespace, localName, and element.
     auto const* attribute = m_attributes->get_attribute_ns(namespace_, local_name);

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/DeprecatedFlyString.h>
 #include <AK/DeprecatedString.h>
 #include <LibWeb/ARIA/ARIAMixin.h>
 #include <LibWeb/Bindings/ElementPrototype.h>
@@ -205,8 +204,8 @@ public:
     ShadowRoot const* shadow_root_internal() const { return m_shadow_root.ptr(); }
     void set_shadow_root(JS::GCPtr<ShadowRoot>);
 
-    void set_custom_properties(Optional<CSS::Selector::PseudoElement>, HashMap<DeprecatedFlyString, CSS::StyleProperty> custom_properties);
-    [[nodiscard]] HashMap<DeprecatedFlyString, CSS::StyleProperty> const& custom_properties(Optional<CSS::Selector::PseudoElement>) const;
+    void set_custom_properties(Optional<CSS::Selector::PseudoElement>, HashMap<FlyString, CSS::StyleProperty> custom_properties);
+    [[nodiscard]] HashMap<FlyString, CSS::StyleProperty> const& custom_properties(Optional<CSS::Selector::PseudoElement>) const;
 
     int queue_an_element_task(HTML::Task::Source, JS::SafeFunction<void()>);
 
@@ -400,8 +399,8 @@ private:
     JS::GCPtr<ShadowRoot> m_shadow_root;
 
     RefPtr<CSS::StyleProperties> m_computed_css_values;
-    HashMap<DeprecatedFlyString, CSS::StyleProperty> m_custom_properties;
-    Array<HashMap<DeprecatedFlyString, CSS::StyleProperty>, to_underlying(CSS::Selector::PseudoElement::PseudoElementCount)> m_pseudo_element_custom_properties;
+    HashMap<FlyString, CSS::StyleProperty> m_custom_properties;
+    Array<HashMap<FlyString, CSS::StyleProperty>, to_underlying(CSS::Selector::PseudoElement::PseudoElementCount)> m_pseudo_element_custom_properties;
 
     Vector<FlyString> m_classes;
     Optional<Dir> m_dir;

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -103,7 +103,7 @@ public:
     // FIXME: This should be taking a 'FlyString const&' / 'Optional<FlyString> const&'
     Optional<String> get_attribute(StringView name) const;
     DeprecatedString deprecated_get_attribute(StringView name) const;
-    DeprecatedString get_attribute_value(StringView local_name, DeprecatedFlyString const& namespace_ = {}) const;
+    DeprecatedString get_attribute_value(FlyString const& local_name, Optional<FlyString> const& namespace_ = {}) const;
 
     WebIDL::ExceptionOr<void> set_attribute(FlyString const& name, String const& value);
 

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -146,10 +146,10 @@ public:
     virtual void apply_presentational_hints(CSS::StyleProperties&) const { }
 
     // https://dom.spec.whatwg.org/#concept-element-attributes-change-ext
-    using AttributeChangeSteps = Function<void(FlyString const& /*local_name*/, Optional<DeprecatedString> const& /*old_value*/, Optional<DeprecatedString> const& /*value*/, DeprecatedFlyString const& /*namespace_*/)>;
+    using AttributeChangeSteps = Function<void(FlyString const& local_name, Optional<DeprecatedString> const& old_value, Optional<DeprecatedString> const& value, Optional<FlyString> const& namespace_)>;
 
     void add_attribute_change_steps(AttributeChangeSteps steps);
-    void run_attribute_change_steps(FlyString const& local_name, Optional<DeprecatedString> const& old_value, Optional<DeprecatedString> const& value, DeprecatedFlyString const& namespace_);
+    void run_attribute_change_steps(FlyString const& local_name, Optional<DeprecatedString> const& old_value, Optional<DeprecatedString> const& value, Optional<FlyString> const& namespace_);
     virtual void attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value);
 
     struct [[nodiscard]] RequiredInvalidationAfterStyleChange {

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -434,6 +434,6 @@ private:
 template<>
 inline bool Node::fast_is<Element>() const { return is_element(); }
 
-WebIDL::ExceptionOr<QualifiedName> validate_and_extract(JS::Realm&, Optional<FlyString> namespace_, DeprecatedFlyString qualified_name);
+WebIDL::ExceptionOr<QualifiedName> validate_and_extract(JS::Realm&, Optional<FlyString> namespace_, FlyString const& qualified_name);
 
 }

--- a/Userland/Libraries/LibWeb/DOM/HTMLCollection.h
+++ b/Userland/Libraries/LibWeb/DOM/HTMLCollection.h
@@ -7,7 +7,6 @@
 
 #pragma once
 
-#include <AK/DeprecatedFlyString.h>
 #include <AK/Function.h>
 #include <LibJS/Heap/GCPtr.h>
 #include <LibWeb/Bindings/LegacyPlatformObject.h>

--- a/Userland/Libraries/LibWeb/HTML/HTMLSlotElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLSlotElement.cpp
@@ -18,7 +18,7 @@ HTMLSlotElement::HTMLSlotElement(DOM::Document& document, DOM::QualifiedName qua
     // https://dom.spec.whatwg.org/#ref-for-concept-element-attributes-change-ext
     add_attribute_change_steps([this](auto const& local_name, auto const& old_value, auto const& value, auto const& namespace_) {
         // 1. If element is a slot, localName is name, and namespace is null, then:
-        if (local_name == AttributeNames::name && namespace_.is_null()) {
+        if (local_name == AttributeNames::name && !namespace_.has_value()) {
             // 1. If value is oldValue, then return.
             if (value == old_value)
                 return;

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -545,14 +545,14 @@ Messages::WebContentServer::InspectDomNodeResponse ConnectionFromClient::inspect
         auto serialize_custom_properties_json = [](Web::DOM::Element const& element, Optional<Web::CSS::Selector::PseudoElement> pseudo_element) -> DeprecatedString {
             StringBuilder builder;
             auto serializer = MUST(JsonObjectSerializer<>::try_create(builder));
-            HashTable<DeprecatedString> seen_properties;
+            HashTable<FlyString> seen_properties;
 
             auto const* element_to_check = &element;
             while (element_to_check) {
                 for (auto const& property : element_to_check->custom_properties(pseudo_element)) {
                     if (!seen_properties.contains(property.key)) {
                         seen_properties.set(property.key);
-                        MUST(serializer.add(property.key, property.value.value->to_string().to_deprecated_string()));
+                        MUST(serializer.add(property.key, property.value.value->to_string()));
                     }
                 }
 


### PR DESCRIPTION
After these changes, there are only two explicit usages of DeprecatedFlyString left in LibWeb. The two left are used as a result of LibJS's DeprecatedString usage, and should fall away with LibJS porting.