### PR TITLE
Chess+GamesSettings: Be more resilient to missing chess-piece graphics

### DIFF
--- a/Userland/Applications/GamesSettings/ChessSettingsWidget.cpp
+++ b/Userland/Applications/GamesSettings/ChessSettingsWidget.cpp
@@ -92,12 +92,12 @@ public:
 
     virtual ~ChessGamePreview() = default;
 
-    ErrorOr<void> set_piece_set_name(DeprecatedString const& piece_set_name)
+    ErrorOr<void> set_piece_set_name(String piece_set_name)
     {
-        if (m_piece_set_name == piece_set_name.view())
+        if (m_piece_set_name == piece_set_name)
             return {};
 
-        m_piece_set_name = TRY(String::from_deprecated_string(piece_set_name));
+        m_piece_set_name = move(piece_set_name);
         m_piece_images.clear();
 
         m_piece_images.set({ Chess::Color::White, Chess::Type::Pawn }, TRY(load_piece_image(m_piece_set_name, "white-pawn.png"sv)));
@@ -255,7 +255,7 @@ ErrorOr<void> ChessSettingsWidget::initialize()
     m_piece_set_combobox->set_text(piece_set_name, GUI::AllowCallback::No);
     m_piece_set_combobox->on_change = [&](auto& value, auto&) {
         set_modified(true);
-        m_preview->set_piece_set_name(value).release_value_but_fixme_should_propagate_errors();
+        m_preview->set_piece_set_name(MUST(String::from_deprecated_string(value))).release_value_but_fixme_should_propagate_errors();
     };
 
     m_board_theme_combobox = find_descendant_of_type_named<GUI::ComboBox>("board_theme");
@@ -282,7 +282,7 @@ ErrorOr<void> ChessSettingsWidget::initialize()
         set_modified(true);
     };
 
-    TRY(m_preview->set_piece_set_name(piece_set_name));
+    TRY(m_preview->set_piece_set_name(TRY(String::from_deprecated_string(piece_set_name))));
     m_preview->set_dark_square_color(board_theme.dark_square_color);
     m_preview->set_light_square_color(board_theme.light_square_color);
     m_preview->set_show_coordinates(show_coordinates);
@@ -303,7 +303,7 @@ void ChessSettingsWidget::reset_default_values()
     // FIXME: `set_text()` on a combobox doesn't trigger the `on_change` callback, but it probably should!
     //        Until then, we have to manually tell the preview to update.
     m_piece_set_combobox->set_text("Classic");
-    (void)m_preview->set_piece_set_name("Classic");
+    m_preview->set_piece_set_name("Classic"_string).release_value_but_fixme_should_propagate_errors();
     auto& board_theme = get_board_theme("Beige"sv);
     m_board_theme_combobox->set_text(board_theme.name);
     m_preview->set_dark_square_color(board_theme.dark_square_color);

--- a/Userland/Games/Chess/ChessWidget.h
+++ b/Userland/Games/Chess/ChessWidget.h
@@ -139,6 +139,7 @@ private:
     Color m_marking_secondary_color { Color::from_argb(0x6655dd55) };
     Chess::Color m_side { Chess::Color::White };
     HashMap<Chess::Piece, RefPtr<Gfx::Bitmap const>> m_pieces;
+    bool m_any_piece_images_are_missing { false };
     Chess::Square m_moving_square { 50, 50 };
     Gfx::IntPoint m_drag_point;
     bool m_dragging_piece { false };


### PR DESCRIPTION
### Before:
*Imagine an explosion here. It crashes.*

### After:
![image](https://github.com/SerenityOS/serenity/assets/222642/a55df940-1db3-487f-b62d-2465a0b44d8a)

Gets rid of a couple of fixmes in GamesSettings where we had errors we couldn't do anything with.