### PR TITLE
LibJS+LibCore+LibTimeZone: Support round-trip parsing of `Date.prototype.to*String` output

### DIFF
--- a/AK/Time.h
+++ b/AK/Time.h
@@ -439,7 +439,14 @@ public:
         this->m_offset = this->m_offset + other;
         return *this;
     }
+
     constexpr UnixDateTime operator-(Duration const& other) const { return UnixDateTime { m_offset - other }; }
+    constexpr UnixDateTime& operator-=(Duration const& other)
+    {
+        m_offset = m_offset - other;
+        return *this;
+    }
+
     // Subtracting two UNIX times yields their time difference.
     constexpr Duration operator-(UnixDateTime const& other) const { return m_offset - other.m_offset; }
 

--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -681,6 +681,8 @@ if (BUILD_LAGOM)
             lagom_test(../../Tests/LibCore/TestLibCorePromise.cpp LIBS LibThreading)
         endif()
 
+        lagom_test(../../Tests/LibCore/TestLibCoreDateTime.cpp LIBS LibTimeZone)
+
         # RegexLibC test POSIX <regex.h> and contains many Serenity extensions
         # It is therefore not reasonable to run it on Lagom, and we only run the Regex test
         lagom_test(../../Tests/LibRegex/Regex.cpp LIBS LibRegex WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../Tests/LibRegex)

--- a/Tests/LibCore/CMakeLists.txt
+++ b/Tests/LibCore/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(TEST_SOURCES
     TestLibCoreArgsParser.cpp
+    TestLibCoreDateTime.cpp
     TestLibCoreDeferredInvoke.cpp
     TestLibCoreFilePermissionsMask.cpp
     TestLibCoreFileWatcher.cpp
@@ -13,6 +14,7 @@ foreach(source IN LISTS TEST_SOURCES)
     serenity_test("${source}" LibCore)
 endforeach()
 
+target_link_libraries(TestLibCoreDateTime PRIVATE LibTimeZone)
 target_link_libraries(TestLibCorePromise PRIVATE LibThreading)
 # NOTE: Required because of the LocalServer tests
 target_link_libraries(TestLibCoreStream PRIVATE LibThreading)

--- a/Tests/LibCore/TestLibCoreDateTime.cpp
+++ b/Tests/LibCore/TestLibCoreDateTime.cpp
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2023, Tim Flynn <trflynn89@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Optional.h>
+#include <AK/String.h>
+#include <AK/StringView.h>
+#include <LibCore/DateTime.h>
+#include <LibCore/System.h>
+#include <LibTest/TestCase.h>
+#include <time.h>
+
+class TimeZoneGuard {
+public:
+    explicit TimeZoneGuard(StringView time_zone)
+    {
+        if (auto const* current_time_zone = getenv("TZ"))
+            m_time_zone = MUST(String::from_utf8({ current_time_zone, strlen(current_time_zone) }));
+
+        update(time_zone);
+    }
+
+    ~TimeZoneGuard()
+    {
+        if (m_time_zone.has_value())
+            TRY_OR_FAIL(Core::System::setenv("TZ"sv, *m_time_zone, true));
+        else
+            TRY_OR_FAIL(Core::System::unsetenv("TZ"sv));
+
+        tzset();
+    }
+
+    void update(StringView time_zone)
+    {
+        TRY_OR_FAIL(Core::System::setenv("TZ"sv, time_zone, true));
+        tzset();
+    }
+
+private:
+    Optional<String> m_time_zone;
+};
+
+TEST_CASE(parse_time_zone_name)
+{
+    EXPECT(!Core::DateTime::parse("%Z"sv, ""sv).has_value());
+    EXPECT(!Core::DateTime::parse("%Z"sv, "123"sv).has_value());
+    EXPECT(!Core::DateTime::parse("%Z"sv, "notatimezone"sv).has_value());
+
+    auto test = [](auto format, auto time, u32 year, u32 month, u32 day, u32 hour, u32 minute) {
+        auto result = Core::DateTime::parse(format, time);
+        VERIFY(result.has_value());
+
+        EXPECT_EQ(year, result->year());
+        EXPECT_EQ(month, result->month());
+        EXPECT_EQ(day, result->day());
+        EXPECT_EQ(hour, result->hour());
+        EXPECT_EQ(minute, result->minute());
+    };
+
+    TimeZoneGuard guard { "UTC"sv };
+    test("%Y/%m/%d %R %Z"sv, "2023/01/23 10:50 UTC"sv, 2023, 01, 23, 10, 50);
+    test("%Y/%m/%d %R %Z"sv, "2023/01/23 10:50 America/New_York"sv, 2023, 01, 23, 15, 50);
+    test("%Y/%m/%d %R %Z"sv, "2023/01/23 10:50 Europe/Paris"sv, 2023, 01, 23, 9, 50);
+    test("%Y/%m/%d %R %Z"sv, "2023/01/23 10:50 Australia/Perth"sv, 2023, 01, 23, 2, 50);
+
+    guard.update("America/New_York"sv);
+    test("%Y/%m/%d %R %Z"sv, "2023/01/23 10:50 UTC"sv, 2023, 01, 23, 5, 50);
+    test("%Y/%m/%d %R %Z"sv, "2023/01/23 10:50 America/New_York"sv, 2023, 01, 23, 10, 50);
+    test("%Y/%m/%d %R %Z"sv, "2023/01/23 10:50 Europe/Paris"sv, 2023, 01, 23, 4, 50);
+    test("%Y/%m/%d %R %Z"sv, "2023/01/23 10:50 Australia/Perth"sv, 2023, 01, 22, 21, 50);
+
+    guard.update("Europe/Paris"sv);
+    test("%Y/%m/%d %R %Z"sv, "2023/01/23 10:50 UTC"sv, 2023, 01, 23, 11, 50);
+    test("%Y/%m/%d %R %Z"sv, "2023/01/23 10:50 America/New_York"sv, 2023, 01, 23, 16, 50);
+    test("%Y/%m/%d %R %Z"sv, "2023/01/23 10:50 Europe/Paris"sv, 2023, 01, 23, 10, 50);
+    test("%Y/%m/%d %R %Z"sv, "2023/01/23 10:50 Australia/Perth"sv, 2023, 01, 23, 3, 50);
+
+    guard.update("Australia/Perth"sv);
+    test("%Y/%m/%d %R %Z"sv, "2023/01/23 10:50 UTC"sv, 2023, 01, 23, 18, 50);
+    test("%Y/%m/%d %R %Z"sv, "2023/01/23 10:50 America/New_York"sv, 2023, 01, 23, 23, 50);
+    test("%Y/%m/%d %R %Z"sv, "2023/01/23 10:50 Europe/Paris"sv, 2023, 01, 23, 17, 50);
+    test("%Y/%m/%d %R %Z"sv, "2023/01/23 10:50 Australia/Perth"sv, 2023, 01, 23, 10, 50);
+}

--- a/Userland/Libraries/LibCore/DateTime.cpp
+++ b/Userland/Libraries/LibCore/DateTime.cpp
@@ -512,6 +512,24 @@ Optional<DateTime> DateTime::parse(StringView format, StringView string)
 
             tm_represents_utc_time = true;
             break;
+        case '+': {
+            Optional<char> next_format_character;
+
+            if (format_pos + 1 < format.length()) {
+                next_format_character = format[format_pos + 1];
+
+                // Disallow another formatter directly after %+. This is to avoid ambiguity when parsing a string like
+                // "ignoreJan" with "%+%b", as it would be non-trivial to know that where the %b field begins.
+                if (next_format_character == '%')
+                    return {};
+            }
+
+            auto discarded = string_lexer.consume_until([&](auto ch) { return ch == next_format_character; });
+            if (discarded.is_empty())
+                return {};
+
+            break;
+        }
         case '%':
             consume('%');
             break;

--- a/Userland/Libraries/LibCore/DateTime.cpp
+++ b/Userland/Libraries/LibCore/DateTime.cpp
@@ -284,7 +284,7 @@ DeprecatedString DateTime::to_deprecated_string(StringView format) const
     return MUST(to_string(format)).to_deprecated_string();
 }
 
-Optional<DateTime> DateTime::parse(StringView format, DeprecatedString const& string)
+Optional<DateTime> DateTime::parse(StringView format, StringView string)
 {
     unsigned format_pos = 0;
 

--- a/Userland/Libraries/LibCore/DateTime.h
+++ b/Userland/Libraries/LibCore/DateTime.h
@@ -37,7 +37,7 @@ public:
     static DateTime create(int year, int month = 1, int day = 1, int hour = 0, int minute = 0, int second = 0);
     static DateTime now();
     static DateTime from_timestamp(time_t);
-    static Optional<DateTime> parse(StringView format, DeprecatedString const& string);
+    static Optional<DateTime> parse(StringView format, StringView string);
 
     bool operator<(DateTime const& other) const { return m_timestamp < other.m_timestamp; }
     bool operator==(DateTime const& other) const { return m_timestamp == other.m_timestamp; }

--- a/Userland/Libraries/LibCore/System.cpp
+++ b/Userland/Libraries/LibCore/System.cpp
@@ -1639,6 +1639,19 @@ ErrorOr<void> setenv(StringView name, StringView value, bool overwrite)
     return {};
 }
 
+ErrorOr<void> unsetenv(StringView name)
+{
+    auto builder = TRY(StringBuilder::create());
+    TRY(builder.try_append(name));
+    TRY(builder.try_append('\0'));
+
+    // Note the explicit null terminator above.
+    auto rc = ::unsetenv(builder.string_view().characters_without_null_termination());
+    if (rc < 0)
+        return Error::from_errno(errno);
+    return {};
+}
+
 ErrorOr<void> putenv(StringView env)
 {
 #ifdef AK_OS_SERENITY

--- a/Userland/Libraries/LibCore/System.h
+++ b/Userland/Libraries/LibCore/System.h
@@ -229,6 +229,7 @@ ErrorOr<void> setgroups(ReadonlySpan<gid_t>);
 ErrorOr<void> mknod(StringView pathname, mode_t mode, dev_t dev);
 ErrorOr<void> mkfifo(StringView pathname, mode_t mode);
 ErrorOr<void> setenv(StringView, StringView, bool);
+ErrorOr<void> unsetenv(StringView);
 ErrorOr<void> putenv(StringView);
 ErrorOr<int> posix_openpt(int flags);
 ErrorOr<void> grantpt(int fildes);

--- a/Userland/Libraries/LibJS/CMakeLists.txt
+++ b/Userland/Libraries/LibJS/CMakeLists.txt
@@ -267,7 +267,7 @@ set(SOURCES
 )
 
 serenity_lib(LibJS js)
-target_link_libraries(LibJS PRIVATE LibCore LibCrypto LibFileSystem LibRegex LibSyntax LibLocale LibUnicode LibJIT)
+target_link_libraries(LibJS PRIVATE LibCore LibCrypto LibFileSystem LibRegex LibSyntax LibLocale LibUnicode LibTimeZone LibJIT)
 if("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "x86_64")
     target_link_libraries(LibJS PRIVATE LibX86)
 endif()

--- a/Userland/Libraries/LibJS/Runtime/DateConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/DateConstructor.cpp
@@ -159,12 +159,14 @@ static double parse_date_string(DeprecatedString const& date_string)
     //        Both Chrome and Firefox seem to support "4/17/2019 11:08 PM +0000" with most parts
     //        being optional, however this is not clearly documented anywhere.
     static constexpr auto extra_formats = AK::Array {
-        "%a %b %e %T %z %Y"sv, // "Wed Apr 17 23:08:53 +0000 2019"
-        "%m/%e/%Y"sv,          // "4/17/2019"
-        "%m/%e/%Y %R %z"sv,    // "12/05/2022 10:00 -0800"
-        "%Y/%m/%e %R"sv,       // "2014/11/14 13:05"
-        "%Y-%m-%e %R"sv,       // "2014-11-14 13:05"
-        "%B %e, %Y %T"sv,      //  "June 5, 2023 17:00:00"
+        "%a %b %d %Y %T GMT%z (%+)"sv, // "Tue Nov 07 2023 10:05:55 GMT-0500 (Eastern Standard Time)"
+        "%a, %d %b %Y %T %Z"sv,        // "Tue, 07 Nov 2023 15:05:55 GMT"
+        "%a %b %e %T %z %Y"sv,         // "Wed Apr 17 23:08:53 +0000 2019"
+        "%m/%e/%Y"sv,                  // "4/17/2019"
+        "%m/%e/%Y %R %z"sv,            // "12/05/2022 10:00 -0800"
+        "%Y/%m/%e %R"sv,               // "2014/11/14 13:05"
+        "%Y-%m-%e %R"sv,               // "2014-11-14 13:05"
+        "%B %e, %Y %T"sv,              //  "June 5, 2023 17:00:00"
     };
 
     for (auto const& format : extra_formats) {

--- a/Userland/Libraries/LibJS/Runtime/DateConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/DateConstructor.cpp
@@ -148,15 +148,6 @@ static double parse_simplified_iso8601(DeprecatedString const& iso_8601)
     return time_clip(time_ms);
 }
 
-static constexpr AK::Array<StringView, 6> extra_formats = {
-    "%a %b %e %T %z %Y"sv,
-    "%m/%e/%Y"sv,
-    "%m/%e/%Y %R %z"sv,
-    "%Y/%m/%e %R"sv,
-    "%Y-%m-%e %R"sv,
-    "%B %e, %Y %T"sv,
-};
-
 static double parse_date_string(DeprecatedString const& date_string)
 {
     auto value = parse_simplified_iso8601(date_string);
@@ -164,14 +155,18 @@ static double parse_date_string(DeprecatedString const& date_string)
         return value;
 
     // Date.parse() is allowed to accept an arbitrary number of implementation-defined formats.
-    // Parse formats of this type: "Wed Apr 17 23:08:53 +0000 2019"
-    // And: "4/17/2019"
-    // And: "12/05/2022 10:00 -0800"
-    // And: "2014/11/14 13:05" or "2014-11-14 13:05"
-    // And: "June 5, 2023 17:00:00"
     // FIXME: Exactly what timezone and which additional formats we should support is unclear.
     //        Both Chrome and Firefox seem to support "4/17/2019 11:08 PM +0000" with most parts
     //        being optional, however this is not clearly documented anywhere.
+    static constexpr auto extra_formats = AK::Array {
+        "%a %b %e %T %z %Y"sv, // "Wed Apr 17 23:08:53 +0000 2019"
+        "%m/%e/%Y"sv,          // "4/17/2019"
+        "%m/%e/%Y %R %z"sv,    // "12/05/2022 10:00 -0800"
+        "%Y/%m/%e %R"sv,       // "2014/11/14 13:05"
+        "%Y-%m-%e %R"sv,       // "2014-11-14 13:05"
+        "%B %e, %Y %T"sv,      //  "June 5, 2023 17:00:00"
+    };
+
     for (auto const& format : extra_formats) {
         auto maybe_datetime = Core::DateTime::parse(format, date_string);
         if (maybe_datetime.has_value())

--- a/Userland/Libraries/LibJS/Tests/builtins/Date/Date.parse.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Date/Date.parse.js
@@ -119,3 +119,67 @@ test("Month dd, yy hh:mm:ss extension", () => {
     expectStringToGiveDate("May 30, 2023 17:00:00", 2023, 5, 30, 17, 0, 0);
     expectStringToGiveDate("June 5, 2023 17:00:00", 2023, 6, 5, 17, 0, 0);
 });
+
+test("Date.prototype.toString extension", () => {
+    function expectStringToGiveDate(input, fullYear, month, dayInMonth, hours) {
+        const date = new Date(Date.parse(input));
+        expect(date.getFullYear()).toBe(fullYear);
+        expect(date.getMonth() + 1).toBe(month);
+        expect(date.getDate()).toBe(dayInMonth);
+        expect(date.getHours()).toBe(hours);
+    }
+
+    const time1 = "Tue Nov 07 2023 10:00:00 GMT-0500 (Eastern Standard Time)";
+    const time2 = "Tue Nov 07 2023 10:00:00 GMT+0100 (Central European Standard Time)";
+    const time3 = "Tue Nov 07 2023 10:00:00 GMT+0800 (Australian Western Standard Time)";
+
+    const originalTimeZone = setTimeZone("UTC");
+    expectStringToGiveDate(time1, 2023, 11, 7, 15);
+    expectStringToGiveDate(time2, 2023, 11, 7, 9);
+    expectStringToGiveDate(time3, 2023, 11, 7, 2);
+
+    setTimeZone("America/New_York");
+    expectStringToGiveDate(time1, 2023, 11, 7, 10);
+    expectStringToGiveDate(time2, 2023, 11, 7, 4);
+    expectStringToGiveDate(time3, 2023, 11, 6, 21);
+
+    setTimeZone("Australia/Perth");
+    expectStringToGiveDate(time1, 2023, 11, 7, 23);
+    expectStringToGiveDate(time2, 2023, 11, 7, 17);
+    expectStringToGiveDate(time3, 2023, 11, 7, 10);
+
+    // FIXME: Create a scoped time zone helper when bytecode supports the `using` declaration.
+    setTimeZone(originalTimeZone);
+});
+
+test("Date.prototype.toUTCString extension", () => {
+    function expectStringToGiveDate(input, fullYear, month, dayInMonth, hours) {
+        const date = new Date(Date.parse(input));
+        expect(date.getFullYear()).toBe(fullYear);
+        expect(date.getMonth() + 1).toBe(month);
+        expect(date.getDate()).toBe(dayInMonth);
+        expect(date.getHours()).toBe(hours);
+    }
+
+    const time = "Tue, 07 Nov 2023 15:00:00 GMT";
+
+    const originalTimeZone = setTimeZone("UTC");
+    expectStringToGiveDate(time, 2023, 11, 7, 15);
+
+    setTimeZone("America/New_York");
+    expectStringToGiveDate(time, 2023, 11, 7, 10);
+
+    setTimeZone("Australia/Perth");
+    expectStringToGiveDate(time, 2023, 11, 7, 23);
+
+    // FIXME: Create a scoped time zone helper when bytecode supports the `using` declaration.
+    setTimeZone(originalTimeZone);
+});
+
+test("Round trip Date.prototype.to*String", () => {
+    const epoch = new Date(0);
+
+    expect(Date.parse(epoch.toString())).toBe(epoch.valueOf());
+    expect(Date.parse(epoch.toISOString())).toBe(epoch.valueOf());
+    expect(Date.parse(epoch.toUTCString())).toBe(epoch.valueOf());
+});

--- a/Userland/Libraries/LibTimeZone/CMakeLists.txt
+++ b/Userland/Libraries/LibTimeZone/CMakeLists.txt
@@ -2,6 +2,7 @@ include(${SerenityOS_SOURCE_DIR}/Meta/CMake/time_zone_data.cmake)
 
 set(SOURCES
     ${TIME_ZONE_DATA_SOURCES}
+    DateTime.cpp
     TimeZone.cpp
 )
 set(GENERATED_SOURCES ${CURRENT_LIB_GENERATED})

--- a/Userland/Libraries/LibTimeZone/DateTime.cpp
+++ b/Userland/Libraries/LibTimeZone/DateTime.cpp
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2023, Tim Flynn <trflynn89@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/GenericLexer.h>
+#include <LibTimeZone/DateTime.h>
+#include <LibTimeZone/TimeZone.h>
+
+namespace Core {
+
+Optional<StringView> parse_time_zone_name(GenericLexer& lexer)
+{
+    auto start_position = lexer.tell();
+
+    Optional<StringView> canonicalized_time_zone;
+
+    lexer.ignore_until([&](auto) {
+        auto time_zone = lexer.input().substring_view(start_position, lexer.tell() - start_position + 1);
+
+        canonicalized_time_zone = TimeZone::canonicalize_time_zone(time_zone);
+        return canonicalized_time_zone.has_value();
+    });
+
+    if (canonicalized_time_zone.has_value())
+        lexer.ignore();
+
+    return canonicalized_time_zone;
+}
+
+void apply_time_zone_offset(StringView time_zone, UnixDateTime& time)
+{
+    if (auto offset = TimeZone::get_time_zone_offset(time_zone, time); offset.has_value())
+        time -= Duration::from_seconds(offset->seconds);
+}
+
+}

--- a/Userland/Libraries/LibTimeZone/DateTime.h
+++ b/Userland/Libraries/LibTimeZone/DateTime.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2023, Tim Flynn <trflynn89@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Optional.h>
+#include <AK/StringView.h>
+#include <AK/Time.h>
+
+// This file contains definitions of Core::DateTime methods which require TZDB data.
+namespace Core {
+
+Optional<StringView> parse_time_zone_name(GenericLexer&);
+void apply_time_zone_offset(StringView time_zone, UnixDateTime& time);
+
+}


### PR DESCRIPTION
All in the name of:
```
Diff Tests:
    test/built-ins/Date/parse/zero.js  ❌ -> ✅
```

This extends `Core::DateTime::parse` to support parsing time zone names and wildcard-skipping characters, and adds implementation-defined format string to `Date.parse` in LibJS to parse the output of `Date.prototype.toString` and `Date.prototype.toUTCString`.