### PR TITLE
LibIMAP: Make parsing of atom data fallible

### DIFF
--- a/Userland/Libraries/LibIMAP/Parser.h
+++ b/Userland/Libraries/LibIMAP/Parser.h
@@ -41,7 +41,7 @@ private:
     ErrorOr<void> parse_untagged();
     ErrorOr<void> parse_capability_response();
 
-    StringView parse_atom();
+    ErrorOr<StringView> parse_atom();
     ErrorOr<StringView> parse_quoted_string();
     ErrorOr<StringView> parse_literal_string();
     ErrorOr<StringView> parse_string();


### PR DESCRIPTION
We now return an error where `parse_atom()` would have previously returned an empty StringView. This is consistent with RFC3501, which says that an atom consists of one or more characters.

This prevents a few cases where parsing an invalid atom could lead to an infinite loop.

Fixes oss fuzz issue: [63920](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=63920)