### PR TITLE
LibJS/JIT: Add fast path for number comparisons

### DIFF
--- a/Userland/Libraries/LibJS/JIT/Compiler.h
+++ b/Userland/Libraries/LibJS/JIT/Compiler.h
@@ -48,13 +48,16 @@ private:
         O(Mod, mod)                                             \
         O(In, in)                                               \
         O(InstanceOf, instance_of)                              \
-        O(GreaterThan, greater_than)                            \
-        O(GreaterThanEquals, greater_than_equals)               \
-        O(LessThanEquals, less_than_equals)                     \
         O(LooselyInequals, abstract_inequals)                   \
         O(LooselyEquals, abstract_equals)                       \
         O(StrictlyInequals, typed_inequals)                     \
         O(StrictlyEquals, typed_equals)
+
+#    define JS_ENUMERATE_COMPARISON_OPS(O)                           \
+        O(LessThan, less_than, SignedLessThan)                       \
+        O(LessThanEquals, less_than_equals, SignedLessThanOrEqualTo) \
+        O(GreaterThan, greater_than, SignedGreaterThan)              \
+        O(GreaterThanEquals, greater_than_equals, SignedGreaterThanOrEqualTo)
 
 #    define JS_ENUMERATE_NEW_BUILTIN_ERROR_BYTECODE_OPS(O) \
         O(NewTypeError, new_type_error, TypeError)


### PR DESCRIPTION
So far only `less_than` was using a fast path. This commits uses the same path for `less_than_equals`, `greater_than` and `greater_than_equals`.

PS: Thanks for the awesome YouTube series, I learned quite a lot!