### PR TITLE
Shell: Avoid infinite loop when parsing heredoc entry in POSIX mode

### DIFF
--- a/Userland/Shell/PosixLexer.cpp
+++ b/Userland/Shell/PosixLexer.cpp
@@ -250,7 +250,7 @@ ErrorOr<Lexer::ReductionResult> Lexer::reduce_operator()
     auto result = TRY(reduce(Reduction::Start));
     tokens.extend(move(result.tokens));
 
-    while (expect_heredoc_entry && tokens.size() == 1) {
+    while (expect_heredoc_entry && tokens.size() == 1 && result.next_reduction != Reduction::None) {
         result = TRY(reduce(result.next_reduction));
         tokens.extend(move(result.tokens));
     }


### PR DESCRIPTION
Previously, the shell would enter an infinite loop when attempting to parse a heredoc entry within a `$(` command substitution.

For example, when entering the following into the shell: `$(cat << EOF )`, typing the closing parenthesis would cause the  infinite loop.

Using heredocs in POSIX mode causes the shell to crash at the moment (see #21837). This PR doesn't affect that behavior.

This fixes* oss fuzz issue: [63093](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=63093)

\* Running the test case through the fuzzer with this fix applied results in [this memory leak](https://gist.github.com/tcl3/77f66c0d22d639f18a4ca78a5b3f5556). I'm not sure if this has anything to do with my change, as testing with something simpler doesn't cause a memory leak.