### PR TITLE
LibWeb: Implement functions required for calculating AnimationEffect's transformed progress

### DIFF
--- a/Userland/Libraries/LibWeb/Animations/Animation.cpp
+++ b/Userland/Libraries/LibWeb/Animations/Animation.cpp
@@ -44,8 +44,38 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Animation>> Animation::construct_impl(JS::R
 // https://www.w3.org/TR/web-animations-1/#animation-set-the-associated-effect-of-an-animation
 void Animation::set_effect(JS::GCPtr<AnimationEffect> new_effect)
 {
-    // FIXME: Implement
-    (void)new_effect;
+    // Setting this attribute updates the object’s associated effect using the procedure to set the associated effect of
+    // an animation.
+
+    // 1. Let old effect be the current associated effect of animation, if any.
+    auto old_effect = m_effect;
+
+    // 2. If new effect is the same object as old effect, abort this procedure.
+    if (new_effect == old_effect)
+        return;
+
+    // FIXME: 3. If animation has a pending pause task, reschedule that task to run as soon as animation is ready.
+
+    // FIXME: 4. If animation has a pending play task, reschedule that task to run as soon as animation is ready to play
+    //           new effect.
+
+    // 5. If new effect is not null and if new effect is the associated effect of another animation, previous animation,
+    //    run the procedure to set the associated effect of an animation (this procedure) on previous animation passing
+    //    null as new effect.
+    if (new_effect && new_effect->associated_animation() != this) {
+        if (auto animation = new_effect->associated_animation())
+            animation->set_effect({});
+    }
+
+    // 6. Let the associated effect of animation be new effect.
+    if (new_effect)
+        new_effect->set_associated_animation(this);
+    if (m_effect)
+        m_effect->set_associated_animation({});
+    m_effect = new_effect;
+
+    // FIXME: 7. Run the procedure to update an animation’s finished state for animation with the did seek flag set to
+    //           false, and the synchronously notify flag set to false.
 }
 
 // https://www.w3.org/TR/web-animations-1/#animation-set-the-timeline-of-an-animation

--- a/Userland/Libraries/LibWeb/Animations/AnimationEffect.cpp
+++ b/Userland/Libraries/LibWeb/Animations/AnimationEffect.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibJS/Runtime/VM.h>
+#include <LibWeb/Animations/Animation.h>
 #include <LibWeb/Animations/AnimationEffect.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/WebIDL/ExceptionOr.h>
@@ -149,6 +150,16 @@ WebIDL::ExceptionOr<void> AnimationEffect::update_timing(OptionalEffectTiming ti
         m_easing_function = timing.easing.value();
 
     return {};
+}
+
+// https://www.w3.org/TR/web-animations-1/#animation-direction
+AnimationDirection AnimationEffect::animation_direction() const
+{
+    // "backwards" if the effect is associated with an animation and the associated animation’s playback rate is less
+    // than zero; in all other cases, the animation direction is "forwards".
+    if (m_associated_animation && m_associated_animation->playback_rate() < 0.0)
+        return AnimationDirection::Backwards;
+    return AnimationDirection::Forwards;
 }
 
 AnimationEffect::AnimationEffect(JS::Realm& realm)

--- a/Userland/Libraries/LibWeb/Animations/AnimationEffect.cpp
+++ b/Userland/Libraries/LibWeb/Animations/AnimationEffect.cpp
@@ -200,6 +200,20 @@ double AnimationEffect::active_duration() const
     return m_iteration_duration.get<double>() * m_iteration_count;
 }
 
+// https://www.w3.org/TR/web-animations-1/#before-active-boundary-time
+double AnimationEffect::before_active_boundary_time() const
+{
+    // max(min(start delay, end time), 0)
+    return max(min(m_start_delay, end_time()), 0.0);
+}
+
+// https://www.w3.org/TR/web-animations-1/#active-after-boundary-time
+double AnimationEffect::after_active_boundary_time() const
+{
+    // max(min(start delay + active duration, end time), 0)
+    return max(min(m_start_delay + active_duration(), end_time()), 0.0);
+}
+
 AnimationEffect::AnimationEffect(JS::Realm& realm)
     : Bindings::PlatformObject(realm)
 {

--- a/Userland/Libraries/LibWeb/Animations/AnimationEffect.h
+++ b/Userland/Libraries/LibWeb/Animations/AnimationEffect.h
@@ -97,6 +97,8 @@ public:
     double end_time() const;
     Optional<double> local_time() const;
     double active_duration() const;
+    Optional<double> active_time() const;
+    Optional<double> active_time_using_fill(Bindings::FillMode) const;
 
     double before_active_boundary_time() const;
     double after_active_boundary_time() const;

--- a/Userland/Libraries/LibWeb/Animations/AnimationEffect.h
+++ b/Userland/Libraries/LibWeb/Animations/AnimationEffect.h
@@ -49,6 +49,11 @@ struct ComputedEffectTiming : public EffectTiming {
     Optional<double> current_iteration;
 };
 
+enum class AnimationDirection {
+    Forwards,
+    Backwards,
+};
+
 // https://www.w3.org/TR/web-animations-1/#the-animationeffect-interface
 class AnimationEffect : public Bindings::PlatformObject {
     WEB_PLATFORM_OBJECT(AnimationEffect, Bindings::PlatformObject);
@@ -86,6 +91,8 @@ public:
 
     JS::GCPtr<Animation> associated_animation() const { return m_associated_animation; }
     void set_associated_animation(JS::GCPtr<Animation> value) { m_associated_animation = value; }
+
+    AnimationDirection animation_direction() const;
 
 protected:
     AnimationEffect(JS::Realm&);

--- a/Userland/Libraries/LibWeb/Animations/AnimationEffect.h
+++ b/Userland/Libraries/LibWeb/Animations/AnimationEffect.h
@@ -84,6 +84,9 @@ public:
     String const& easing_function() const { return m_easing_function; }
     void set_easing_function(String easing_function) { m_easing_function = move(easing_function); }
 
+    JS::GCPtr<Animation> associated_animation() const { return m_associated_animation; }
+    void set_associated_animation(JS::GCPtr<Animation> value) { m_associated_animation = value; }
+
 protected:
     AnimationEffect(JS::Realm&);
 
@@ -112,6 +115,9 @@ protected:
 
     // https://www.w3.org/TR/css-easing-1/#easing-function
     String m_easing_function { "linear"_string };
+
+    // https://www.w3.org/TR/web-animations-1/#animation-associated-effect
+    JS::GCPtr<Animation> m_associated_animation {};
 };
 
 }

--- a/Userland/Libraries/LibWeb/Animations/AnimationEffect.h
+++ b/Userland/Libraries/LibWeb/Animations/AnimationEffect.h
@@ -98,6 +98,9 @@ public:
     Optional<double> local_time() const;
     double active_duration() const;
 
+    double before_active_boundary_time() const;
+    double after_active_boundary_time() const;
+
 protected:
     AnimationEffect(JS::Realm&);
 

--- a/Userland/Libraries/LibWeb/Animations/AnimationEffect.h
+++ b/Userland/Libraries/LibWeb/Animations/AnimationEffect.h
@@ -101,6 +101,19 @@ public:
     double before_active_boundary_time() const;
     double after_active_boundary_time() const;
 
+    bool is_in_the_before_phase() const;
+    bool is_in_the_after_phase() const;
+    bool is_in_the_active_phase() const;
+    bool is_in_the_idle_phase() const;
+
+    enum class Phase {
+        Before,
+        Active,
+        After,
+        Idle,
+    };
+    Phase phase() const;
+
 protected:
     AnimationEffect(JS::Realm&);
 

--- a/Userland/Libraries/LibWeb/Animations/AnimationEffect.h
+++ b/Userland/Libraries/LibWeb/Animations/AnimationEffect.h
@@ -116,6 +116,12 @@ public:
     };
     Phase phase() const;
 
+    Optional<double> overall_progress() const;
+    Optional<double> directed_progress() const;
+    AnimationDirection current_direction() const;
+    Optional<double> simple_iteration_progress() const;
+    Optional<double> current_iteration() const;
+
 protected:
     AnimationEffect(JS::Realm&);
 

--- a/Userland/Libraries/LibWeb/Animations/AnimationEffect.h
+++ b/Userland/Libraries/LibWeb/Animations/AnimationEffect.h
@@ -94,6 +94,10 @@ public:
 
     AnimationDirection animation_direction() const;
 
+    double end_time() const;
+    Optional<double> local_time() const;
+    double active_duration() const;
+
 protected:
     AnimationEffect(JS::Realm&);
 


### PR DESCRIPTION
These are precursor functions for `transformed_progress()`, which is the value that is actually used for CSS value interpolation. I chose to save that implementation for the next PR since it requires the timing function. 

Work towards #21570 