### PR TITLE
LibWeb: Ignore document's box during overflow clip rect calculation

### DIFF
--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -406,6 +406,10 @@ BorderRadiiData PaintableBox::normalized_border_radii_data(ShrinkRadiiForBorders
 
 Optional<CSSPixelRect> PaintableBox::calculate_overflow_clipped_rect() const
 {
+    if (layout_node().is_viewport()) {
+        return {};
+    }
+
     if (!m_clip_rect.has_value()) {
         // NOTE: stacking context should not be crossed while aggregating rectangle to
         // clip `overflow: hidden` because intersecting rectangles with different


### PR DESCRIPTION
Reduction of bug:
```html
<!DOCTYPE html><style>
html {
    overflow-x: hidden;
    overflow-y: scroll;
}
div {
    background: orange;
    height: 1000px;
    width: 500px;
}
</style><body><div>
```

Fixes https://github.com/SerenityOS/serenity/issues/21690 and painting on many other websites (null.com, servo.org).