### PR TITLE
LibRegex: Support non-ASCII case-insensitive character comparisons

### DIFF
--- a/AK/Utf16View.h
+++ b/AK/Utf16View.h
@@ -57,6 +57,8 @@ private:
 
 class Utf16View {
 public:
+    using Iterator = Utf16CodePointIterator;
+
     static bool is_high_surrogate(u16);
     static bool is_low_surrogate(u16);
     static u32 decode_surrogate_pair(u16 high_surrogate, u16 low_surrogate);

--- a/Tests/LibRegex/Regex.cpp
+++ b/Tests/LibRegex/Regex.cpp
@@ -14,12 +14,12 @@
 #include <LibRegex/RegexMatcher.h>
 #include <stdio.h>
 
-static ECMAScriptOptions match_test_api_options(const ECMAScriptOptions options)
+static ECMAScriptOptions match_test_api_options(ECMAScriptOptions const options)
 {
     return options;
 }
 
-static PosixOptions match_test_api_options(const PosixOptions options)
+static PosixOptions match_test_api_options(PosixOptions const options)
 {
     return options;
 }

--- a/Tests/LibRegex/Regex.cpp
+++ b/Tests/LibRegex/Regex.cpp
@@ -757,6 +757,18 @@ TEST_CASE(ECMA262_unicode_match)
         { "(?<\\ud835\\udcd1\\ud835\\udcfb\\ud835\\udcf8\\ud835\\udd00\\ud835\\udcf7>brown)"sv, "brown"sv, true, ECMAScriptFlags::Unicode },
         { "^\\s+$"sv, space_and_line_terminators },
         { "^\\s+$"sv, space_and_line_terminators, true, ECMAScriptFlags::Unicode },
+        { "[\\u0390]"sv, "\u1fd3"sv, false, ECMAScriptFlags::Unicode },
+        { "[\\u1fd3]"sv, "\u0390"sv, false, ECMAScriptFlags::Unicode },
+        { "[\\u0390]"sv, "\u1fd3"sv, true, combine_flags(ECMAScriptFlags::Unicode, ECMAScriptFlags::Insensitive) },
+        { "[\\u1fd3]"sv, "\u0390"sv, true, combine_flags(ECMAScriptFlags::Unicode, ECMAScriptFlags::Insensitive) },
+        { "[\\u03b0]"sv, "\u1fe3"sv, false, ECMAScriptFlags::Unicode },
+        { "[\\u1fe3]"sv, "\u03b0"sv, false, ECMAScriptFlags::Unicode },
+        { "[\\u03b0]"sv, "\u1fe3"sv, true, combine_flags(ECMAScriptFlags::Unicode, ECMAScriptFlags::Insensitive) },
+        { "[\\u1fe3]"sv, "\u03b0"sv, true, combine_flags(ECMAScriptFlags::Unicode, ECMAScriptFlags::Insensitive) },
+        { "[\\ufb05]"sv, "\ufb06"sv, false, ECMAScriptFlags::Unicode },
+        { "[\\ufb06]"sv, "\ufb05"sv, false, ECMAScriptFlags::Unicode },
+        { "[\\ufb05]"sv, "\ufb06"sv, true, combine_flags(ECMAScriptFlags::Unicode, ECMAScriptFlags::Insensitive) },
+        { "[\\ufb06]"sv, "\ufb05"sv, true, combine_flags(ECMAScriptFlags::Unicode, ECMAScriptFlags::Insensitive) },
     };
 
     for (auto& test : tests) {

--- a/Userland/Libraries/LibUnicode/CharacterTypes.h
+++ b/Userland/Libraries/LibUnicode/CharacterTypes.h
@@ -60,6 +60,9 @@ ErrorOr<DeprecatedString> to_unicode_uppercase_full(StringView, Optional<StringV
 ErrorOr<String> to_unicode_titlecase_full(StringView, Optional<StringView> const& locale = {}, TrailingCodePointTransformation trailing_code_point_transformation = TrailingCodePointTransformation::Lowercase);
 ErrorOr<String> to_unicode_casefold_full(StringView);
 
+template<typename ViewType>
+bool equals_ignoring_case(ViewType, ViewType);
+
 Optional<GeneralCategory> general_category_from_string(StringView);
 bool code_point_has_general_category(u32 code_point, GeneralCategory general_category);
 

--- a/Userland/Libraries/LibUnicode/String.cpp
+++ b/Userland/Libraries/LibUnicode/String.cpp
@@ -6,7 +6,6 @@
 
 #include <AK/String.h>
 #include <AK/StringBuilder.h>
-#include <AK/Utf32View.h>
 #include <AK/Utf8View.h>
 #include <LibUnicode/CharacterTypes.h>
 #include <LibUnicode/UnicodeUtils.h>
@@ -43,60 +42,9 @@ ErrorOr<String> String::to_casefold() const
     return builder.to_string();
 }
 
-class CasefoldStringComparator {
-public:
-    explicit CasefoldStringComparator(Utf8View string)
-        : m_string(string)
-        , m_it(m_string.begin())
-    {
-    }
-
-    bool has_more_data() const
-    {
-        return !m_casefolded_code_points.is_empty() || (m_it != m_string.end());
-    }
-
-    u32 next_code_point()
-    {
-        VERIFY(has_more_data());
-
-        if (m_casefolded_code_points.is_empty()) {
-            m_current_code_point = *m_it;
-            ++m_it;
-
-            m_casefolded_code_points = Unicode::Detail::casefold_code_point(m_current_code_point);
-            VERIFY(!m_casefolded_code_points.is_empty()); // Must at least contain the provided code point.
-        }
-
-        auto code_point = m_casefolded_code_points[0];
-        m_casefolded_code_points = m_casefolded_code_points.substring_view(1);
-
-        return code_point;
-    }
-
-private:
-    Utf8View m_string;
-    Utf8CodePointIterator m_it;
-
-    u32 m_current_code_point { 0 };
-    Utf32View m_casefolded_code_points;
-};
-
-// https://www.unicode.org/versions/Unicode15.0.0/ch03.pdf#G34145
 bool String::equals_ignoring_case(String const& other) const
 {
-    // A string X is a caseless match for a string Y if and only if:
-    //     toCasefold(X) = toCasefold(Y)
-
-    CasefoldStringComparator lhs { code_points() };
-    CasefoldStringComparator rhs { other.code_points() };
-
-    while (lhs.has_more_data() && rhs.has_more_data()) {
-        if (lhs.next_code_point() != rhs.next_code_point())
-            return false;
-    }
-
-    return !lhs.has_more_data() && !rhs.has_more_data();
+    return Unicode::equals_ignoring_case(code_points(), other.code_points());
 }
 
 }


### PR DESCRIPTION
```
Diff Tests:
    test/built-ins/RegExp/unicode_full_case_folding.js     ❌ -> ✅
    test/language/literals/regexp/u-case-mapping.js        ❌ -> ✅
```