### PR TITLE
LibGfx: Ensure const-correctness when reading from the GPOS byte stream

### DIFF
--- a/AK/Endian.h
+++ b/AK/Endian.h
@@ -126,7 +126,17 @@ struct Traits<LittleEndian<T>> : public GenericTraits<LittleEndian<T>> {
 };
 
 template<typename T>
+struct Traits<LittleEndian<T> const> : public GenericTraits<LittleEndian<T> const> {
+    static constexpr bool is_trivially_serializable() { return Traits<T>::is_trivially_serializable(); }
+};
+
+template<typename T>
 struct Traits<BigEndian<T>> : public GenericTraits<BigEndian<T>> {
+    static constexpr bool is_trivially_serializable() { return Traits<T>::is_trivially_serializable(); }
+};
+
+template<typename T>
+struct Traits<BigEndian<T> const> : public GenericTraits<BigEndian<T> const> {
     static constexpr bool is_trivially_serializable() { return Traits<T>::is_trivially_serializable(); }
 };
 

--- a/Userland/Libraries/LibGfx/Font/OpenType/Tables.cpp
+++ b/Userland/Libraries/LibGfx/Font/OpenType/Tables.cpp
@@ -526,7 +526,7 @@ ErrorOr<GPOS> GPOS::from_slice(ReadonlyBytes slice)
 
     TRY(stream.seek(header.lookup_list_offset, SeekMode::SetPosition));
     auto const& lookup_list = *TRY(stream.read_in_place<LookupList const>());
-    auto lookup_records = TRY(stream.read_in_place<Offset16>(lookup_list.lookup_count));
+    auto lookup_records = TRY(stream.read_in_place<Offset16 const>(lookup_list.lookup_count));
 
     return GPOS { slice, header, script_list, script_records, feature_list, feature_records, lookup_list, lookup_records };
 }


### PR DESCRIPTION
Fixes #21847