### PR TITLE
LibJS/JIT: Add fast-path for float arithmetic

### DIFF
--- a/Userland/Libraries/LibJIT/X86_64/Assembler.h
+++ b/Userland/Libraries/LibJIT/X86_64/Assembler.h
@@ -954,6 +954,17 @@ struct X86_64Assembler {
         }
     }
 
+    void convert_i32_to_double(Operand dst, Operand src)
+    {
+        VERIFY(dst.type == Operand::Type::FReg);
+        VERIFY(src.is_register_or_memory());
+
+        emit8(0xf2);
+        emit8(0x0f);
+        emit8(0x2a);
+        emit_modrm_rm(dst, src);
+    }
+
     void native_call(
         u64 callee,
         Vector<Operand> const& preserved_registers = {},

--- a/Userland/Libraries/LibJIT/X86_64/Assembler.h
+++ b/Userland/Libraries/LibJIT/X86_64/Assembler.h
@@ -929,6 +929,11 @@ struct X86_64Assembler {
             emit8(0x81);
             emit_modrm_slash(5, dst);
             emit32(src.offset_or_immediate);
+        } else if (dst.type == Operand::Type::FReg && src.type == Operand::Type::FReg) {
+            emit8(0xf2);
+            emit8(0x0f);
+            emit8(0x5c);
+            emit_modrm_rm(dst, src);
         } else {
             VERIFY_NOT_REACHED();
         }

--- a/Userland/Libraries/LibJIT/X86_64/Assembler.h
+++ b/Userland/Libraries/LibJIT/X86_64/Assembler.h
@@ -639,6 +639,18 @@ struct X86_64Assembler {
         }
     }
 
+    void mul(Operand dest, Operand src)
+    {
+        if (dest.type == Operand::Type::FReg && src.type == Operand::Type::FReg) {
+            emit8(0xf2);
+            emit8(0x0f);
+            emit8(0x59);
+            emit_modrm_rm(dest, src);
+        } else {
+            VERIFY_NOT_REACHED();
+        }
+    }
+
     void mul32(Operand dest, Operand src, Optional<Label&> overflow_label)
     {
         // imul32 dest, src (32-bit signed)

--- a/Userland/Libraries/LibJIT/X86_64/Assembler.h
+++ b/Userland/Libraries/LibJIT/X86_64/Assembler.h
@@ -135,10 +135,15 @@ struct X86_64Assembler {
         UnsignedGreaterThanOrEqualTo = 0x3,
         UnsignedLessThan = 0x2,
         UnsignedLessThanOrEqualTo = 0x6,
+        ParityEven = 0xA,
+        ParityOdd = 0xB,
         SignedGreaterThan = 0xF,
         SignedGreaterThanOrEqualTo = 0xD,
         SignedLessThan = 0xC,
         SignedLessThanOrEqualTo = 0xE,
+
+        Unordered = ParityEven,
+        NotUnordered = ParityOdd,
     };
 
     static constexpr u8 encode_reg(Reg reg)
@@ -521,6 +526,13 @@ struct X86_64Assembler {
             emit8(0x81);
             emit_modrm_slash(7, lhs);
             emit32(rhs.offset_or_immediate);
+        } else if (lhs.type == Operand::Type::FReg && (rhs.type == Operand::Type::FReg || rhs.type == Operand::Type::Mem64BaseAndOffset)) {
+            // ucomisd lhs, rhs
+            emit8(0x66);
+            emit_rex_for_mr(lhs, rhs, REX_W::No);
+            emit8(0x0f);
+            emit8(0x2e);
+            emit_modrm_mr(lhs, rhs);
         } else {
             VERIFY_NOT_REACHED();
         }

--- a/Userland/Libraries/LibJIT/X86_64/Assembler.h
+++ b/Userland/Libraries/LibJIT/X86_64/Assembler.h
@@ -878,6 +878,11 @@ struct X86_64Assembler {
             emit8(0x81);
             emit_modrm_slash(0, dst);
             emit32(src.offset_or_immediate);
+        } else if (dst.type == Operand::Type::FReg && src.type == Operand::Type::FReg) {
+            emit8(0xf2);
+            emit8(0x0f);
+            emit8(0x58);
+            emit_modrm_rm(dst, src);
         } else {
             VERIFY_NOT_REACHED();
         }

--- a/Userland/Libraries/LibJS/JIT/Compiler.cpp
+++ b/Userland/Libraries/LibJS/JIT/Compiler.cpp
@@ -695,36 +695,29 @@ void Compiler::compile_mul(Bytecode::Op::Mul const& op)
     load_vm_register(ARG1, op.lhs());
     load_accumulator(ARG2);
 
-    Assembler::Label end {};
-    Assembler::Label slow_case {};
-
-    branch_if_both_int32(ARG1, ARG2, [&] {
-        // GPR0 = ARG1 * ARG2 (32-bit)
-        // if (overflow) goto slow_case;
-        m_assembler.mov(
-            Assembler::Operand::Register(GPR0),
-            Assembler::Operand::Register(ARG1));
-        m_assembler.mul32(
-            Assembler::Operand::Register(GPR0),
-            Assembler::Operand::Register(ARG2),
-            slow_case);
-
-        // accumulator = GPR0 | SHIFTED_INT32_TAG;
-        m_assembler.mov(
-            Assembler::Operand::Register(GPR1),
-            Assembler::Operand::Imm(SHIFTED_INT32_TAG));
-        m_assembler.bitwise_or(
-            Assembler::Operand::Register(GPR0),
-            Assembler::Operand::Register(GPR1));
-        store_accumulator(GPR0);
-        m_assembler.jump(end);
-    });
-
-    slow_case.link(m_assembler);
-    native_call((void*)cxx_mul);
-    store_accumulator(RET);
-    check_exception();
-    end.link(m_assembler);
+    branch_if_both_numbers(
+        ARG1, ARG2,
+        [&](auto lhs, auto rhs, auto& slow_case) {
+            m_assembler.mul32(
+                Assembler::Operand::Register(lhs),
+                Assembler::Operand::Register(rhs),
+                slow_case);
+            return lhs; },
+        [&](auto lhs, auto rhs) {
+            m_assembler.mul(
+                Assembler::Operand::FloatRegister(lhs),
+                Assembler::Operand::FloatRegister(rhs));
+            return lhs; },
+        [&](auto lhs, auto rhs) {
+            m_assembler.mov(
+                Assembler::Operand::Register(ARG1),
+                Assembler::Operand::Register(lhs));
+            m_assembler.mov(
+                Assembler::Operand::Register(ARG2),
+                Assembler::Operand::Register(rhs));
+            native_call((void*)cxx_mul);
+            return RET;
+        });
 }
 
 #    define DO_COMPILE_COMPARISON_OP(TitleCaseName, snake_case_name, AssemblerCondition) \

--- a/Userland/Libraries/LibJS/JIT/Compiler.cpp
+++ b/Userland/Libraries/LibJS/JIT/Compiler.cpp
@@ -660,36 +660,29 @@ void Compiler::compile_sub(Bytecode::Op::Sub const& op)
     load_vm_register(ARG1, op.lhs());
     load_accumulator(ARG2);
 
-    Assembler::Label end {};
-    Assembler::Label slow_case {};
-
-    branch_if_both_int32(ARG1, ARG2, [&] {
-        // GPR0 = ARG1 + ARG2 (32-bit)
-        // if (overflow) goto slow_case;
-        m_assembler.mov(
-            Assembler::Operand::Register(GPR0),
-            Assembler::Operand::Register(ARG1));
-        m_assembler.sub32(
-            Assembler::Operand::Register(GPR0),
-            Assembler::Operand::Register(ARG2),
-            slow_case);
-
-        // accumulator = GPR0 | SHIFTED_INT32_TAG;
-        m_assembler.mov(
-            Assembler::Operand::Register(GPR1),
-            Assembler::Operand::Imm(SHIFTED_INT32_TAG));
-        m_assembler.bitwise_or(
-            Assembler::Operand::Register(GPR0),
-            Assembler::Operand::Register(GPR1));
-        store_accumulator(GPR0);
-        m_assembler.jump(end);
-    });
-
-    slow_case.link(m_assembler);
-    native_call((void*)cxx_sub);
-    store_accumulator(RET);
-    check_exception();
-    end.link(m_assembler);
+    branch_if_both_numbers(
+        ARG1, ARG2,
+        [&](auto lhs, auto rhs, auto& slow_case) {
+            m_assembler.sub32(
+                Assembler::Operand::Register(lhs),
+                Assembler::Operand::Register(rhs),
+                slow_case);
+            return lhs; },
+        [&](auto lhs, auto rhs) {
+            m_assembler.sub(
+                Assembler::Operand::FloatRegister(lhs),
+                Assembler::Operand::FloatRegister(rhs));
+            return lhs; },
+        [&](auto lhs, auto rhs) {
+            m_assembler.mov(
+                Assembler::Operand::Register(ARG1),
+                Assembler::Operand::Register(lhs));
+            m_assembler.mov(
+                Assembler::Operand::Register(ARG2),
+                Assembler::Operand::Register(rhs));
+            native_call((void*)cxx_sub);
+            return RET;
+        });
 }
 
 static Value cxx_mul(VM& vm, Value lhs, Value rhs)

--- a/Userland/Libraries/LibJS/JIT/Compiler.h
+++ b/Userland/Libraries/LibJS/JIT/Compiler.h
@@ -34,6 +34,8 @@ private:
     static constexpr auto ARG3 = Assembler::Reg::RCX;
     static constexpr auto ARG4 = Assembler::Reg::R8;
     static constexpr auto ARG5 = Assembler::Reg::R9;
+    static constexpr auto FPR0 = Assembler::Reg::XMM0;
+    static constexpr auto FPR1 = Assembler::Reg::XMM1;
     static constexpr auto RET = Assembler::Reg::RAX;
     static constexpr auto STACK_POINTER = Assembler::Reg::RSP;
     static constexpr auto REGISTER_ARRAY_BASE = Assembler::Reg::RBX;
@@ -186,9 +188,15 @@ private:
     }
 
     void extract_object_pointer(Assembler::Reg dst_object, Assembler::Reg src_value);
+    void convert_to_double(Assembler::Reg dst, Assembler::Reg src, Assembler::Reg nan, Assembler::Reg temp, Assembler::Label& not_number);
 
     template<typename Codegen>
     void branch_if_both_int32(Assembler::Reg, Assembler::Reg, Codegen);
+
+    void jump_if_not_double(Assembler::Reg reg, Assembler::Reg nan, Assembler::Reg temp, Assembler::Label&);
+
+    template<typename CodegenI32, typename CodegenDouble, typename CodegenValue>
+    void branch_if_both_numbers(Assembler::Reg lhs, Assembler::Reg rhs, CodegenI32, CodegenDouble, CodegenValue);
 
     explicit Compiler(Bytecode::Executable& bytecode_executable)
         : m_bytecode_executable(bytecode_executable)

--- a/Userland/Libraries/LibX86/Instruction.h
+++ b/Userland/Libraries/LibX86/Instruction.h
@@ -296,6 +296,7 @@ extern InstructionDescriptor s_table[3][256];
 extern InstructionDescriptor s_0f_table[3][256];
 extern InstructionDescriptor s_sse_table_np[256];
 extern InstructionDescriptor s_sse_table_66[256];
+extern InstructionDescriptor s_sse_table_f2[256];
 extern InstructionDescriptor s_sse_table_f3[256];
 
 struct Prefix {
@@ -1066,7 +1067,9 @@ ALWAYS_INLINE Instruction::Instruction(InstructionStreamType& stream, ProcessorM
     }
 
     if (m_descriptor->format == __SSE) {
-        if (m_rep_prefix == 0xF3) {
+        if (m_rep_prefix == 0xF2) {
+            m_descriptor = &s_sse_table_f2[m_sub_op];
+        } else if (m_rep_prefix == 0xF3) {
             m_descriptor = &s_sse_table_f3[m_sub_op];
         } else if (m_has_operand_size_override_prefix) {
             // This was unset while parsing the prefix initially


### PR DESCRIPTION
- [x] Introduce floating point registers.
- [x] Add a fast path for double+double path
- [x] Add a fast path for double-double path
- [x] Add a fast path for double*double path