### PR TITLE
LibJS+LibJIT+LibWeb: Add GetByValue fast path for simple array access

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -2490,8 +2490,6 @@ private:
     virtual JS::ThrowCompletionOr<bool> internal_set_prototype_of(JS::Object* prototype) override;
     virtual JS::ThrowCompletionOr<bool> internal_prevent_extensions() override;
 
-    virtual bool may_interfere_with_indexed_property_access() const final { return true; }
-
     JS::Realm& m_realm; // [[Realm]]
 };
 )~~~");
@@ -2511,7 +2509,7 @@ static void generate_named_properties_object_definitions(IDL::Interface const& i
 #include <LibWeb/WebIDL/AbstractOperations.h>
 
 @named_properties_class@::@named_properties_class@(JS::Realm& realm)
-  : JS::Object(realm, nullptr)
+  : JS::Object(realm, nullptr, MayInterfereWithIndexedPropertyAccess::Yes)
   , m_realm(realm)
 {
 }

--- a/Userland/Libraries/LibJS/JIT/Compiler.cpp
+++ b/Userland/Libraries/LibJS/JIT/Compiler.cpp
@@ -1208,9 +1208,121 @@ void Compiler::compile_get_by_value(Bytecode::Op::GetByValue const& op)
 {
     load_vm_register(ARG1, op.base());
     load_accumulator(ARG2);
+
+    Assembler::Label end {};
+    Assembler::Label slow_case {};
+
+    branch_if_object(ARG1, [&] {
+        branch_if_int32(ARG2, [&] {
+            // if (ARG2 < 0) goto slow_case;
+            m_assembler.mov(
+                Assembler::Operand::Register(GPR0),
+                Assembler::Operand::Register(ARG2));
+            m_assembler.sign_extend_32_to_64_bits(GPR0);
+            m_assembler.jump_if(
+                Assembler::Operand::Register(GPR0),
+                Assembler::Condition::SignedLessThan,
+                Assembler::Operand::Imm(0),
+                slow_case);
+
+            // GPR0 = extract_pointer(ARG1)
+            extract_object_pointer(GPR0, ARG1);
+
+            // if (object->may_interfere_with_indexed_property_access()) goto slow_case;
+            m_assembler.mov8(
+                Assembler::Operand::Register(GPR1),
+                Assembler::Operand::Mem64BaseAndOffset(GPR0, Object::may_interfere_with_indexed_property_access_offset()));
+            m_assembler.jump_if(
+                Assembler::Operand::Register(GPR1),
+                Assembler::Condition::NotEqualTo,
+                Assembler::Operand::Imm(0),
+                slow_case);
+
+            // GPR0 = object->indexed_properties().storage()
+            m_assembler.mov(
+                Assembler::Operand::Register(GPR0),
+                Assembler::Operand::Mem64BaseAndOffset(GPR0, Object::indexed_properties_offset() + IndexedProperties::storage_offset()));
+
+            // if (GPR0 == nullptr) goto slow_case;
+            m_assembler.jump_if(
+                Assembler::Operand::Register(GPR0),
+                Assembler::Condition::EqualTo,
+                Assembler::Operand::Imm(0),
+                slow_case);
+
+            // if (!GPR0->is_simple_storage()) goto slow_case;
+            m_assembler.mov8(
+                Assembler::Operand::Register(GPR1),
+                Assembler::Operand::Mem64BaseAndOffset(GPR0, IndexedPropertyStorage::is_simple_storage_offset()));
+            m_assembler.jump_if(
+                Assembler::Operand::Register(GPR1),
+                Assembler::Condition::EqualTo,
+                Assembler::Operand::Imm(0),
+                slow_case);
+
+            // GPR2 = extract_int32(ARG2)
+            m_assembler.mov32(
+                Assembler::Operand::Register(GPR2),
+                Assembler::Operand::Register(ARG2));
+
+            // if (GPR2 >= GPR0->array_like_size()) goto slow_case;
+            m_assembler.mov(
+                Assembler::Operand::Register(GPR1),
+                Assembler::Operand::Mem64BaseAndOffset(GPR0, SimpleIndexedPropertyStorage::array_size_offset()));
+            m_assembler.jump_if(
+                Assembler::Operand::Register(GPR2),
+                Assembler::Condition::SignedGreaterThanOrEqualTo,
+                Assembler::Operand::Register(GPR1),
+                slow_case);
+
+            // GPR0 = GPR0->elements().outline_buffer()
+            m_assembler.mov(
+                Assembler::Operand::Register(GPR0),
+                Assembler::Operand::Mem64BaseAndOffset(GPR0, SimpleIndexedPropertyStorage::elements_offset() + Vector<Value>::outline_buffer_offset()));
+
+            // GPR2 *= sizeof(Value)
+            m_assembler.mul32(
+                Assembler::Operand::Register(GPR2),
+                Assembler::Operand::Imm(sizeof(Value)),
+                slow_case);
+
+            // GPR0 = GPR0[GPR2]
+            m_assembler.add(
+                Assembler::Operand::Register(GPR0),
+                Assembler::Operand::Register(GPR2));
+            m_assembler.mov(
+                Assembler::Operand::Register(GPR0),
+                Assembler::Operand::Mem64BaseAndOffset(GPR0, 0));
+
+            // if (GPR0.is_empty()) goto slow_case;
+            m_assembler.mov(Assembler::Operand::Register(GPR1), Assembler::Operand::Register(GPR0));
+            m_assembler.shift_right(Assembler::Operand::Register(GPR1), Assembler::Operand::Imm(TAG_SHIFT));
+            m_assembler.jump_if(
+                Assembler::Operand::Register(GPR1),
+                Assembler::Condition::EqualTo,
+                Assembler::Operand::Imm(EMPTY_TAG),
+                slow_case);
+
+            // if (GPR0.is_accessor()) goto slow_case;
+            m_assembler.mov(Assembler::Operand::Register(GPR1), Assembler::Operand::Register(GPR0));
+            m_assembler.shift_right(Assembler::Operand::Register(GPR1), Assembler::Operand::Imm(TAG_SHIFT));
+            m_assembler.jump_if(
+                Assembler::Operand::Register(GPR1),
+                Assembler::Condition::EqualTo,
+                Assembler::Operand::Imm(ACCESSOR_TAG),
+                slow_case);
+
+            // accumulator = GPR0;
+            store_accumulator(GPR0);
+            m_assembler.jump(end);
+        });
+    });
+
+    slow_case.link(m_assembler);
     native_call((void*)cxx_get_by_value);
     store_accumulator(RET);
     check_exception();
+    end.link(m_assembler);
 }
 
 static Value cxx_get_global(VM& vm, DeprecatedFlyString const& identifier, Bytecode::GlobalVariableCache& cache)

--- a/Userland/Libraries/LibJS/Runtime/ArgumentsObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArgumentsObject.cpp
@@ -11,7 +11,7 @@
 namespace JS {
 
 ArgumentsObject::ArgumentsObject(Realm& realm, Environment& environment)
-    : Object(ConstructWithPrototypeTag::Tag, realm.intrinsics().object_prototype())
+    : Object(ConstructWithPrototypeTag::Tag, realm.intrinsics().object_prototype(), MayInterfereWithIndexedPropertyAccess::Yes)
     , m_environment(environment)
 {
 }

--- a/Userland/Libraries/LibJS/Runtime/ArgumentsObject.h
+++ b/Userland/Libraries/LibJS/Runtime/ArgumentsObject.h
@@ -27,8 +27,6 @@ public:
     virtual ThrowCompletionOr<bool> internal_set(PropertyKey const&, Value value, Value receiver, CacheablePropertyMetadata*) override;
     virtual ThrowCompletionOr<bool> internal_delete(PropertyKey const&) override;
 
-    virtual bool may_interfere_with_indexed_property_access() const final { return true; }
-
     // [[ParameterMap]]
     Object& parameter_map() { return *m_parameter_map; }
 

--- a/Userland/Libraries/LibJS/Runtime/FunctionObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/FunctionObject.cpp
@@ -13,13 +13,13 @@
 
 namespace JS {
 
-FunctionObject::FunctionObject(Realm& realm, Object* prototype)
-    : Object(realm, prototype)
+FunctionObject::FunctionObject(Realm& realm, Object* prototype, MayInterfereWithIndexedPropertyAccess may_interfere_with_indexed_property_access)
+    : Object(realm, prototype, may_interfere_with_indexed_property_access)
 {
 }
 
-FunctionObject::FunctionObject(Object& prototype)
-    : Object(ConstructWithPrototypeTag::Tag, prototype)
+FunctionObject::FunctionObject(Object& prototype, MayInterfereWithIndexedPropertyAccess may_interfere_with_indexed_property_access)
+    : Object(ConstructWithPrototypeTag::Tag, prototype, may_interfere_with_indexed_property_access)
 {
 }
 

--- a/Userland/Libraries/LibJS/Runtime/FunctionObject.h
+++ b/Userland/Libraries/LibJS/Runtime/FunctionObject.h
@@ -41,8 +41,8 @@ public:
     virtual Vector<DeprecatedFlyString> const& local_variables_names() const { VERIFY_NOT_REACHED(); }
 
 protected:
-    explicit FunctionObject(Realm&, Object* prototype);
-    explicit FunctionObject(Object& prototype);
+    explicit FunctionObject(Realm&, Object* prototype, MayInterfereWithIndexedPropertyAccess = MayInterfereWithIndexedPropertyAccess::No);
+    explicit FunctionObject(Object& prototype, MayInterfereWithIndexedPropertyAccess = MayInterfereWithIndexedPropertyAccess::No);
 
 private:
     virtual bool is_function() const override { return true; }

--- a/Userland/Libraries/LibJS/Runtime/IndexedProperties.cpp
+++ b/Userland/Libraries/LibJS/Runtime/IndexedProperties.cpp
@@ -14,7 +14,8 @@ constexpr const size_t SPARSE_ARRAY_HOLE_THRESHOLD = 200;
 constexpr const size_t LENGTH_SETTER_GENERIC_STORAGE_THRESHOLD = 4 * MiB;
 
 SimpleIndexedPropertyStorage::SimpleIndexedPropertyStorage(Vector<Value>&& initial_values)
-    : m_array_size(initial_values.size())
+    : IndexedPropertyStorage(IsSimpleStorage::Yes)
+    , m_array_size(initial_values.size())
     , m_packed_elements(move(initial_values))
 {
 }
@@ -83,6 +84,7 @@ bool SimpleIndexedPropertyStorage::set_array_like_size(size_t new_size)
 }
 
 GenericIndexedPropertyStorage::GenericIndexedPropertyStorage(SimpleIndexedPropertyStorage&& storage)
+    : IndexedPropertyStorage(IsSimpleStorage::No)
 {
     m_array_size = storage.array_like_size();
     for (size_t i = 0; i < storage.m_packed_elements.size(); ++i) {

--- a/Userland/Libraries/LibJS/Runtime/IndexedProperties.h
+++ b/Userland/Libraries/LibJS/Runtime/IndexedProperties.h
@@ -46,6 +46,8 @@ public:
 
     bool is_simple_storage() const { return m_is_simple_storage; }
 
+    static FlatPtr is_simple_storage_offset() { return OFFSET_OF(IndexedPropertyStorage, m_is_simple_storage); }
+
 protected:
     explicit IndexedPropertyStorage(IsSimpleStorage is_simple_storage)
         : m_is_simple_storage(is_simple_storage == IsSimpleStorage::Yes) {};

--- a/Userland/Libraries/LibJS/Runtime/IndexedProperties.h
+++ b/Userland/Libraries/LibJS/Runtime/IndexedProperties.h
@@ -74,6 +74,8 @@ public:
 
     Vector<Value> const& elements() const { return m_packed_elements; }
 
+    static FlatPtr elements_offset() { return OFFSET_OF(SimpleIndexedPropertyStorage, m_packed_elements); }
+
 private:
     friend GenericIndexedPropertyStorage;
 
@@ -171,6 +173,8 @@ public:
                 callback(element.value.value);
         }
     }
+
+    static FlatPtr storage_offset() { return OFFSET_OF(IndexedProperties, m_storage); }
 
 private:
     void switch_to_generic_storage();

--- a/Userland/Libraries/LibJS/Runtime/IndexedProperties.h
+++ b/Userland/Libraries/LibJS/Runtime/IndexedProperties.h
@@ -76,6 +76,7 @@ public:
 
     Vector<Value> const& elements() const { return m_packed_elements; }
 
+    static FlatPtr array_size_offset() { return OFFSET_OF(SimpleIndexedPropertyStorage, m_array_size); }
     static FlatPtr elements_offset() { return OFFSET_OF(SimpleIndexedPropertyStorage, m_packed_elements); }
 
 private:

--- a/Userland/Libraries/LibJS/Runtime/ModuleNamespaceObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ModuleNamespaceObject.cpp
@@ -11,7 +11,7 @@
 namespace JS {
 
 ModuleNamespaceObject::ModuleNamespaceObject(Realm& realm, Module* module, Vector<DeprecatedFlyString> exports)
-    : Object(ConstructWithPrototypeTag::Tag, realm.intrinsics().object_prototype())
+    : Object(ConstructWithPrototypeTag::Tag, realm.intrinsics().object_prototype(), MayInterfereWithIndexedPropertyAccess::Yes)
     , m_module(module)
     , m_exports(move(exports))
 {

--- a/Userland/Libraries/LibJS/Runtime/ModuleNamespaceObject.h
+++ b/Userland/Libraries/LibJS/Runtime/ModuleNamespaceObject.h
@@ -31,8 +31,6 @@ public:
     virtual ThrowCompletionOr<MarkedVector<Value>> internal_own_property_keys() const override;
     virtual void initialize(Realm&) override;
 
-    virtual bool may_interfere_with_indexed_property_access() const final { return true; }
-
 private:
     ModuleNamespaceObject(Realm&, Module* module, Vector<DeprecatedFlyString> exports);
 

--- a/Userland/Libraries/LibJS/Runtime/Object.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Object.cpp
@@ -35,18 +35,21 @@ NonnullGCPtr<Object> Object::create(Realm& realm, Object* prototype)
     return realm.heap().allocate<Object>(realm, ConstructWithPrototypeTag::Tag, *prototype);
 }
 
-Object::Object(GlobalObjectTag, Realm& realm)
+Object::Object(GlobalObjectTag, Realm& realm, MayInterfereWithIndexedPropertyAccess may_interfere_with_indexed_property_access)
+    : m_may_interfere_with_indexed_property_access(may_interfere_with_indexed_property_access == MayInterfereWithIndexedPropertyAccess::Yes)
 {
     // This is the global object
     m_shape = heap().allocate_without_realm<Shape>(realm);
 }
 
-Object::Object(ConstructWithoutPrototypeTag, Realm& realm)
+Object::Object(ConstructWithoutPrototypeTag, Realm& realm, MayInterfereWithIndexedPropertyAccess may_interfere_with_indexed_property_access)
+    : m_may_interfere_with_indexed_property_access(may_interfere_with_indexed_property_access == MayInterfereWithIndexedPropertyAccess::Yes)
 {
     m_shape = heap().allocate_without_realm<Shape>(realm);
 }
 
-Object::Object(Realm& realm, Object* prototype)
+Object::Object(Realm& realm, Object* prototype, MayInterfereWithIndexedPropertyAccess may_interfere_with_indexed_property_access)
+    : m_may_interfere_with_indexed_property_access(may_interfere_with_indexed_property_access == MayInterfereWithIndexedPropertyAccess::Yes)
 {
     m_shape = realm.intrinsics().empty_object_shape();
     VERIFY(m_shape);
@@ -54,15 +57,17 @@ Object::Object(Realm& realm, Object* prototype)
         set_prototype(prototype);
 }
 
-Object::Object(ConstructWithPrototypeTag, Object& prototype)
+Object::Object(ConstructWithPrototypeTag, Object& prototype, MayInterfereWithIndexedPropertyAccess may_interfere_with_indexed_property_access)
+    : m_may_interfere_with_indexed_property_access(may_interfere_with_indexed_property_access == MayInterfereWithIndexedPropertyAccess::Yes)
 {
     m_shape = prototype.shape().realm().intrinsics().empty_object_shape();
     VERIFY(m_shape);
     set_prototype(&prototype);
 }
 
-Object::Object(Shape& shape)
-    : m_shape(&shape)
+Object::Object(Shape& shape, MayInterfereWithIndexedPropertyAccess may_interfere_with_indexed_property_access)
+    : m_may_interfere_with_indexed_property_access(may_interfere_with_indexed_property_access == MayInterfereWithIndexedPropertyAccess::Yes)
+    , m_shape(&shape)
 {
     m_storage.resize(shape.property_count());
 }

--- a/Userland/Libraries/LibJS/Runtime/Object.h
+++ b/Userland/Libraries/LibJS/Runtime/Object.h
@@ -218,6 +218,8 @@ public:
 
     void set_prototype(Object*);
 
+    static FlatPtr may_interfere_with_indexed_property_access_offset() { return OFFSET_OF(Object, m_may_interfere_with_indexed_property_access); }
+
 protected:
     enum class GlobalObjectTag { Tag };
     enum class ConstructWithoutPrototypeTag { Tag };

--- a/Userland/Libraries/LibJS/Runtime/Object.h
+++ b/Userland/Libraries/LibJS/Runtime/Object.h
@@ -76,6 +76,11 @@ public:
         Yes,
     };
 
+    enum class MayInterfereWithIndexedPropertyAccess {
+        No,
+        Yes,
+    };
+
     // Please DO NOT make up your own non-standard methods unless you
     // have a very good reason to do so. If any object abstract
     // operation from the spec is missing, add it instead.
@@ -139,7 +144,7 @@ public:
     //       to customize access to indexed properties (properties where the name is a positive integer)
     //       must return true for this, to opt out of optimizations that rely on assumptions that
     //       might not hold when property access behaves differently.
-    virtual bool may_interfere_with_indexed_property_access() const { return false; }
+    bool may_interfere_with_indexed_property_access() const { return m_may_interfere_with_indexed_property_access; }
 
     ThrowCompletionOr<bool> ordinary_set_with_own_descriptor(PropertyKey const&, Value, Value, Optional<PropertyDescriptor>, CacheablePropertyMetadata* = nullptr);
 
@@ -218,11 +223,11 @@ protected:
     enum class ConstructWithoutPrototypeTag { Tag };
     enum class ConstructWithPrototypeTag { Tag };
 
-    Object(GlobalObjectTag, Realm&);
-    Object(ConstructWithoutPrototypeTag, Realm&);
-    Object(Realm&, Object* prototype);
-    Object(ConstructWithPrototypeTag, Object& prototype);
-    explicit Object(Shape&);
+    Object(GlobalObjectTag, Realm&, MayInterfereWithIndexedPropertyAccess = MayInterfereWithIndexedPropertyAccess::No);
+    Object(ConstructWithoutPrototypeTag, Realm&, MayInterfereWithIndexedPropertyAccess = MayInterfereWithIndexedPropertyAccess::No);
+    Object(Realm&, Object* prototype, MayInterfereWithIndexedPropertyAccess = MayInterfereWithIndexedPropertyAccess::No);
+    Object(ConstructWithPrototypeTag, Object& prototype, MayInterfereWithIndexedPropertyAccess = MayInterfereWithIndexedPropertyAccess::No);
+    explicit Object(Shape&, MayInterfereWithIndexedPropertyAccess = MayInterfereWithIndexedPropertyAccess::No);
 
     // [[Extensible]]
     bool m_is_extensible { true };
@@ -235,6 +240,8 @@ private:
 
     Object* prototype() { return shape().prototype(); }
     Object const* prototype() const { return shape().prototype(); }
+
+    bool m_may_interfere_with_indexed_property_access { false };
 
     // True if this object has lazily allocated intrinsic properties.
     bool m_has_intrinsic_accessors { false };

--- a/Userland/Libraries/LibJS/Runtime/Object.h
+++ b/Userland/Libraries/LibJS/Runtime/Object.h
@@ -219,6 +219,7 @@ public:
     void set_prototype(Object*);
 
     static FlatPtr may_interfere_with_indexed_property_access_offset() { return OFFSET_OF(Object, m_may_interfere_with_indexed_property_access); }
+    static FlatPtr indexed_properties_offset() { return OFFSET_OF(Object, m_indexed_properties); }
 
 protected:
     enum class GlobalObjectTag { Tag };

--- a/Userland/Libraries/LibJS/Runtime/ProxyObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ProxyObject.cpp
@@ -22,7 +22,7 @@ NonnullGCPtr<ProxyObject> ProxyObject::create(Realm& realm, Object& target, Obje
 }
 
 ProxyObject::ProxyObject(Object& target, Object& handler, Object& prototype)
-    : FunctionObject(prototype)
+    : FunctionObject(prototype, MayInterfereWithIndexedPropertyAccess::Yes)
     , m_target(target)
     , m_handler(handler)
 {

--- a/Userland/Libraries/LibJS/Runtime/ProxyObject.h
+++ b/Userland/Libraries/LibJS/Runtime/ProxyObject.h
@@ -45,8 +45,6 @@ public:
     virtual ThrowCompletionOr<Value> internal_call(Value this_argument, MarkedVector<Value> arguments_list) override;
     virtual ThrowCompletionOr<NonnullGCPtr<Object>> internal_construct(MarkedVector<Value> arguments_list, FunctionObject& new_target) override;
 
-    virtual bool may_interfere_with_indexed_property_access() const final { return true; }
-
 private:
     ProxyObject(Object& target, Object& handler, Object& prototype);
 

--- a/Userland/Libraries/LibJS/Runtime/StringObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/StringObject.cpp
@@ -30,7 +30,7 @@ NonnullGCPtr<StringObject> StringObject::create(Realm& realm, PrimitiveString& p
 }
 
 StringObject::StringObject(PrimitiveString& string, Object& prototype)
-    : Object(ConstructWithPrototypeTag::Tag, prototype)
+    : Object(ConstructWithPrototypeTag::Tag, prototype, MayInterfereWithIndexedPropertyAccess::Yes)
     , m_string(string)
 {
 }

--- a/Userland/Libraries/LibJS/Runtime/StringObject.h
+++ b/Userland/Libraries/LibJS/Runtime/StringObject.h
@@ -30,8 +30,6 @@ private:
     virtual ThrowCompletionOr<bool> internal_define_own_property(PropertyKey const&, PropertyDescriptor const&) override;
     virtual ThrowCompletionOr<MarkedVector<Value>> internal_own_property_keys() const override;
 
-    virtual bool may_interfere_with_indexed_property_access() const final { return true; }
-
     virtual bool is_string_object() const final { return true; }
     virtual void visit_edges(Visitor&) override;
 

--- a/Userland/Libraries/LibJS/Runtime/TypedArray.cpp
+++ b/Userland/Libraries/LibJS/Runtime/TypedArray.cpp
@@ -459,7 +459,7 @@ void TypedArrayBase::visit_edges(Visitor& visitor)
     }                                                                                                                       \
                                                                                                                             \
     PrototypeName::PrototypeName(Object& prototype)                                                                         \
-        : Object(ConstructWithPrototypeTag::Tag, prototype)                                                                 \
+        : Object(ConstructWithPrototypeTag::Tag, prototype, MayInterfereWithIndexedPropertyAccess::Yes)                     \
     {                                                                                                                       \
     }                                                                                                                       \
                                                                                                                             \

--- a/Userland/Libraries/LibJS/Runtime/TypedArray.h
+++ b/Userland/Libraries/LibJS/Runtime/TypedArray.h
@@ -62,7 +62,7 @@ public:
 
 protected:
     TypedArrayBase(Object& prototype, IntrinsicConstructor intrinsic_constructor)
-        : Object(ConstructWithPrototypeTag::Tag, prototype)
+        : Object(ConstructWithPrototypeTag::Tag, prototype, MayInterfereWithIndexedPropertyAccess::Yes)
         , m_intrinsic_constructor(intrinsic_constructor)
     {
     }
@@ -413,8 +413,6 @@ public:
         // 5. Return keys.
         return { move(keys) };
     }
-
-    virtual bool may_interfere_with_indexed_property_access() const final { return true; }
 
     ReadonlySpan<UnderlyingBufferDataType> data() const
     {

--- a/Userland/Libraries/LibWeb/Bindings/LegacyPlatformObject.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/LegacyPlatformObject.cpp
@@ -12,7 +12,7 @@
 namespace Web::Bindings {
 
 LegacyPlatformObject::LegacyPlatformObject(JS::Realm& realm)
-    : PlatformObject(realm)
+    : PlatformObject(realm, MayInterfereWithIndexedPropertyAccess::Yes)
 {
 }
 

--- a/Userland/Libraries/LibWeb/Bindings/LegacyPlatformObject.h
+++ b/Userland/Libraries/LibWeb/Bindings/LegacyPlatformObject.h
@@ -29,8 +29,6 @@ public:
     virtual JS::ThrowCompletionOr<bool> internal_prevent_extensions() override;
     virtual JS::ThrowCompletionOr<JS::MarkedVector<JS::Value>> internal_own_property_keys() const override;
 
-    virtual bool may_interfere_with_indexed_property_access() const final { return true; }
-
     enum class IgnoreNamedProps {
         No,
         Yes,

--- a/Userland/Libraries/LibWeb/Bindings/PlatformObject.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/PlatformObject.cpp
@@ -11,13 +11,13 @@
 
 namespace Web::Bindings {
 
-PlatformObject::PlatformObject(JS::Realm& realm)
-    : JS::Object(realm, nullptr)
+PlatformObject::PlatformObject(JS::Realm& realm, MayInterfereWithIndexedPropertyAccess may_interfere_with_indexed_property_access)
+    : JS::Object(realm, nullptr, may_interfere_with_indexed_property_access)
 {
 }
 
-PlatformObject::PlatformObject(JS::Object& prototype)
-    : JS::Object(ConstructWithPrototypeTag::Tag, prototype)
+PlatformObject::PlatformObject(JS::Object& prototype, MayInterfereWithIndexedPropertyAccess may_interfere_with_indexed_property_access)
+    : JS::Object(ConstructWithPrototypeTag::Tag, prototype, may_interfere_with_indexed_property_access)
 {
 }
 

--- a/Userland/Libraries/LibWeb/Bindings/PlatformObject.h
+++ b/Userland/Libraries/LibWeb/Bindings/PlatformObject.h
@@ -40,8 +40,8 @@ public:
     [[nodiscard]] virtual bool implements_interface(DeprecatedString const&) const { return false; }
 
 protected:
-    explicit PlatformObject(JS::Realm&);
-    explicit PlatformObject(JS::Object& prototype);
+    explicit PlatformObject(JS::Realm&, MayInterfereWithIndexedPropertyAccess = MayInterfereWithIndexedPropertyAccess::No);
+    explicit PlatformObject(JS::Object& prototype, MayInterfereWithIndexedPropertyAccess = MayInterfereWithIndexedPropertyAccess::No);
 };
 
 }

--- a/Userland/Libraries/LibWeb/DOM/EventTarget.cpp
+++ b/Userland/Libraries/LibWeb/DOM/EventTarget.cpp
@@ -38,8 +38,8 @@
 
 namespace Web::DOM {
 
-EventTarget::EventTarget(JS::Realm& realm)
-    : PlatformObject(realm)
+EventTarget::EventTarget(JS::Realm& realm, MayInterfereWithIndexedPropertyAccess may_interfere_with_indexed_property_access)
+    : PlatformObject(realm, may_interfere_with_indexed_property_access)
 {
 }
 

--- a/Userland/Libraries/LibWeb/DOM/EventTarget.h
+++ b/Userland/Libraries/LibWeb/DOM/EventTarget.h
@@ -59,7 +59,7 @@ public:
     bool has_event_listeners() const;
 
 protected:
-    explicit EventTarget(JS::Realm&);
+    explicit EventTarget(JS::Realm&, MayInterfereWithIndexedPropertyAccess = MayInterfereWithIndexedPropertyAccess::No);
 
     void element_event_handler_attribute_changed(FlyString const& local_name, Optional<String> const& value);
 

--- a/Userland/Libraries/LibWeb/HTML/AudioTrackList.cpp
+++ b/Userland/Libraries/LibWeb/HTML/AudioTrackList.cpp
@@ -14,7 +14,7 @@
 namespace Web::HTML {
 
 AudioTrackList::AudioTrackList(JS::Realm& realm)
-    : DOM::EventTarget(realm)
+    : DOM::EventTarget(realm, MayInterfereWithIndexedPropertyAccess::Yes)
     , m_audio_tracks(realm.heap())
 {
 }

--- a/Userland/Libraries/LibWeb/HTML/AudioTrackList.h
+++ b/Userland/Libraries/LibWeb/HTML/AudioTrackList.h
@@ -51,8 +51,6 @@ private:
     virtual void initialize(JS::Realm&) override;
     virtual JS::ThrowCompletionOr<Optional<JS::PropertyDescriptor>> internal_get_own_property(JS::PropertyKey const& property_name) const override;
 
-    virtual bool may_interfere_with_indexed_property_access() const final { return true; }
-
     JS::MarkedVector<JS::NonnullGCPtr<AudioTrack>> m_audio_tracks;
 };
 

--- a/Userland/Libraries/LibWeb/HTML/Location.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Location.cpp
@@ -24,7 +24,7 @@ namespace Web::HTML {
 
 // https://html.spec.whatwg.org/multipage/history.html#the-location-interface
 Location::Location(JS::Realm& realm)
-    : PlatformObject(realm)
+    : PlatformObject(realm, MayInterfereWithIndexedPropertyAccess::Yes)
 {
 }
 

--- a/Userland/Libraries/LibWeb/HTML/Location.h
+++ b/Userland/Libraries/LibWeb/HTML/Location.h
@@ -64,8 +64,6 @@ public:
     virtual JS::ThrowCompletionOr<bool> internal_delete(JS::PropertyKey const&) override;
     virtual JS::ThrowCompletionOr<JS::MarkedVector<JS::Value>> internal_own_property_keys() const override;
 
-    virtual bool may_interfere_with_indexed_property_access() const final { return true; }
-
     HTML::CrossOriginPropertyDescriptorMap const& cross_origin_property_descriptor_map() const { return m_cross_origin_property_descriptor_map; }
     HTML::CrossOriginPropertyDescriptorMap& cross_origin_property_descriptor_map() { return m_cross_origin_property_descriptor_map; }
 

--- a/Userland/Libraries/LibWeb/HTML/VideoTrackList.cpp
+++ b/Userland/Libraries/LibWeb/HTML/VideoTrackList.cpp
@@ -14,7 +14,7 @@
 namespace Web::HTML {
 
 VideoTrackList::VideoTrackList(JS::Realm& realm)
-    : DOM::EventTarget(realm)
+    : DOM::EventTarget(realm, MayInterfereWithIndexedPropertyAccess::Yes)
     , m_video_tracks(realm.heap())
 {
 }

--- a/Userland/Libraries/LibWeb/HTML/VideoTrackList.h
+++ b/Userland/Libraries/LibWeb/HTML/VideoTrackList.h
@@ -44,8 +44,6 @@ private:
     virtual void initialize(JS::Realm&) override;
     virtual JS::ThrowCompletionOr<Optional<JS::PropertyDescriptor>> internal_get_own_property(JS::PropertyKey const& property_name) const override;
 
-    virtual bool may_interfere_with_indexed_property_access() const final { return true; }
-
     JS::MarkedVector<JS::NonnullGCPtr<VideoTrack>> m_video_tracks;
 };
 

--- a/Userland/Libraries/LibWeb/HTML/WindowProxy.cpp
+++ b/Userland/Libraries/LibWeb/HTML/WindowProxy.cpp
@@ -22,7 +22,7 @@ namespace Web::HTML {
 
 // 7.4 The WindowProxy exotic object, https://html.spec.whatwg.org/multipage/window-object.html#the-windowproxy-exotic-object
 WindowProxy::WindowProxy(JS::Realm& realm)
-    : JS::Object(realm, nullptr)
+    : JS::Object(realm, nullptr, MayInterfereWithIndexedPropertyAccess::Yes)
 {
 }
 

--- a/Userland/Libraries/LibWeb/HTML/WindowProxy.h
+++ b/Userland/Libraries/LibWeb/HTML/WindowProxy.h
@@ -31,8 +31,6 @@ public:
     virtual JS::ThrowCompletionOr<bool> internal_delete(JS::PropertyKey const&) override;
     virtual JS::ThrowCompletionOr<JS::MarkedVector<JS::Value>> internal_own_property_keys() const override;
 
-    virtual bool may_interfere_with_indexed_property_access() const final { return true; }
-
     JS::GCPtr<Window> window() const { return m_window; }
     void set_window(JS::NonnullGCPtr<Window>);
 


### PR DESCRIPTION
```
Suite    Test                                   Speedup  Old (Mean ± Range)        New (Mean ± Range)
-------  -----------------------------------  ---------  ------------------------  ------------------------
Kraken   ai-astar.js                              1.161  5.190 ± 5.160 … 5.210     4.470 ± 4.180 … 4.730
Kraken   audio-beat-detection.js                  1.327  2.897 ± 2.760 … 2.990     2.183 ± 2.150 … 2.250
Kraken   audio-dft.js                             1.539  2.760 ± 2.720 … 2.830     1.793 ± 1.710 … 1.890
Kraken   audio-fft.js                             1.325  2.733 ± 2.670 … 2.840     2.063 ± 2.010 … 2.150
Kraken   audio-oscillator.js                      1.149  4.437 ± 4.380 … 4.540     3.860 ± 3.690 … 4.000
Kraken   imaging-darkroom.js                      1.004  8.027 ± 7.870 … 8.120     7.997 ± 7.880 … 8.120
Kraken   imaging-desaturate.js                    1.364  4.007 ± 3.920 … 4.160     2.937 ± 2.800 … 3.070
Kraken   imaging-gaussian-blur.js                 1.131  34.343 ± 33.360 … 35.320  30.363 ± 29.500 … 31.910
Kraken   json-parse-financial.js                  1.083  0.130 ± 0.120 … 0.140     0.120 ± 0.120 … 0.120
Kraken   json-stringify-tinderbox.js              1.103  0.393 ± 0.340 … 0.470     0.357 ± 0.330 … 0.400
Kraken   stanford-crypto-aes.js                   1.296  1.387 ± 1.310 … 1.450     1.070 ± 1.050 … 1.100
Kraken   stanford-crypto-ccm.js                   1.224  1.313 ± 1.210 … 1.480     1.073 ± 1.040 … 1.090
Kraken   stanford-crypto-pbkdf2.js                1.092  2.097 ± 2.050 … 2.160     1.920 ± 1.820 … 1.990
Kraken   stanford-crypto-sha256-iterative.js      1.078  0.873 ± 0.790 … 0.930     0.810 ± 0.770 … 0.840
```