### PR TITLE
LibJS: Caching for PutById and JIT fast paths for PutById&GetById

### DIFF
--- a/AK/Weakable.h
+++ b/AK/Weakable.h
@@ -42,6 +42,8 @@ public:
 
     void revoke() { m_ptr = nullptr; }
 
+    static FlatPtr ptr_offset() { return OFFSET_OF(WeakLink, m_ptr); }
+
 private:
     template<typename T>
     explicit WeakLink(T& weakable)

--- a/Userland/Applications/Spreadsheet/JSIntegration.cpp
+++ b/Userland/Applications/Spreadsheet/JSIntegration.cpp
@@ -129,7 +129,7 @@ JS::ThrowCompletionOr<JS::Value> SheetGlobalObject::internal_get(const JS::Prope
     return Base::internal_get(property_name, receiver);
 }
 
-JS::ThrowCompletionOr<bool> SheetGlobalObject::internal_set(const JS::PropertyKey& property_name, JS::Value value, JS::Value receiver)
+JS::ThrowCompletionOr<bool> SheetGlobalObject::internal_set(const JS::PropertyKey& property_name, JS::Value value, JS::Value receiver, JS::CacheablePropertyMetadata*)
 {
     if (property_name.is_string()) {
         if (auto pos = m_sheet.parse_cell_name(property_name.as_string()); pos.has_value()) {

--- a/Userland/Applications/Spreadsheet/JSIntegration.h
+++ b/Userland/Applications/Spreadsheet/JSIntegration.h
@@ -29,7 +29,7 @@ public:
 
     virtual JS::ThrowCompletionOr<bool> internal_has_property(JS::PropertyKey const& name) const override;
     virtual JS::ThrowCompletionOr<JS::Value> internal_get(JS::PropertyKey const&, JS::Value receiver, JS::CacheablePropertyMetadata*) const override;
-    virtual JS::ThrowCompletionOr<bool> internal_set(JS::PropertyKey const&, JS::Value value, JS::Value receiver) override;
+    virtual JS::ThrowCompletionOr<bool> internal_set(JS::PropertyKey const&, JS::Value value, JS::Value receiver, JS::CacheablePropertyMetadata*) override;
 
     JS_DECLARE_NATIVE_FUNCTION(get_real_cell_contents);
     JS_DECLARE_NATIVE_FUNCTION(set_real_cell_contents);

--- a/Userland/Libraries/LibJIT/X86_64/Assembler.h
+++ b/Userland/Libraries/LibJIT/X86_64/Assembler.h
@@ -619,6 +619,23 @@ struct X86_64Assembler {
         }
     }
 
+    void shift_left(Operand dest, Optional<Operand> count)
+    {
+        VERIFY(dest.type == Operand::Type::Reg);
+        if (count.has_value()) {
+            VERIFY(count->type == Operand::Type::Imm);
+            VERIFY(count->fits_in_u8());
+            emit_rex_for_slash(dest, REX_W::Yes);
+            emit8(0xc1);
+            emit_modrm_slash(4, dest);
+            emit8(count->offset_or_immediate);
+        } else {
+            emit_rex_for_slash(dest, REX_W::Yes);
+            emit8(0xd3);
+            emit_modrm_slash(4, dest);
+        }
+    }
+
     void shift_left32(Operand dest, Optional<Operand> count)
     {
         VERIFY(dest.type == Operand::Type::Reg);
@@ -650,6 +667,23 @@ struct X86_64Assembler {
             emit_rex_for_slash(dest, REX_W::No);
             emit8(0xd3);
             emit_modrm_slash(5, dest);
+        }
+    }
+
+    void arithmetic_right_shift(Operand dest, Optional<Operand> count)
+    {
+        VERIFY(dest.type == Operand::Type::Reg);
+        if (count.has_value()) {
+            VERIFY(count->type == Operand::Type::Imm);
+            VERIFY(count->fits_in_u8());
+            emit_rex_for_slash(dest, REX_W::Yes);
+            emit8(0xc1);
+            emit_modrm_slash(7, dest);
+            emit8(count->offset_or_immediate);
+        } else {
+            emit_rex_for_slash(dest, REX_W::Yes);
+            emit8(0xd3);
+            emit_modrm_slash(7, dest);
         }
     }
 

--- a/Userland/Libraries/LibJS/Bytecode/CommonImplementations.h
+++ b/Userland/Libraries/LibJS/Bytecode/CommonImplementations.h
@@ -16,7 +16,7 @@ ThrowCompletionOr<NonnullGCPtr<Object>> base_object_for_get(VM&, Value base_valu
 ThrowCompletionOr<Value> get_by_id(VM&, DeprecatedFlyString const& property, Value base_value, Value this_value, PropertyLookupCache&);
 ThrowCompletionOr<Value> get_by_value(VM&, Value base_value, Value property_key_value);
 ThrowCompletionOr<Value> get_global(Bytecode::Interpreter&, DeprecatedFlyString const& identifier, GlobalVariableCache&);
-ThrowCompletionOr<void> put_by_property_key(VM&, Value base, Value this_value, Value value, PropertyKey name, Op::PropertyKind kind);
+ThrowCompletionOr<void> put_by_property_key(VM&, Value base, Value this_value, Value value, PropertyKey name, Op::PropertyKind kind, PropertyLookupCache* = nullptr);
 ThrowCompletionOr<Value> perform_call(Interpreter&, Value this_value, Op::CallType, Value callee, MarkedVector<Value> argument_values);
 ThrowCompletionOr<void> throw_if_needed_for_call(Interpreter&, Value callee, Op::CallType, Optional<StringTableIndex> const& expression_string);
 ThrowCompletionOr<Value> typeof_variable(VM&, DeprecatedFlyString const&);

--- a/Userland/Libraries/LibJS/Bytecode/Executable.h
+++ b/Userland/Libraries/LibJS/Bytecode/Executable.h
@@ -24,6 +24,10 @@ class NativeExecutable;
 namespace JS::Bytecode {
 
 struct PropertyLookupCache {
+    static FlatPtr shape_offset() { return OFFSET_OF(PropertyLookupCache, shape); }
+    static FlatPtr property_offset_offset() { return OFFSET_OF(PropertyLookupCache, property_offset); }
+    static FlatPtr unique_shape_serial_number_offset() { return OFFSET_OF(PropertyLookupCache, unique_shape_serial_number); }
+
     WeakPtr<Shape> shape;
     Optional<u32> property_offset;
     u64 unique_shape_serial_number { 0 };

--- a/Userland/Libraries/LibJS/Bytecode/Generator.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.cpp
@@ -297,7 +297,7 @@ CodeGenerationErrorOr<void> Generator::emit_store_to_reference(JS::ASTNode const
             } else {
                 // 3. Let propertyKey be StringValue of IdentifierName.
                 auto identifier_table_ref = intern_identifier(verify_cast<Identifier>(expression.property()).string());
-                emit<Bytecode::Op::PutByIdWithThis>(super_reference.base, super_reference.this_value, identifier_table_ref);
+                emit<Bytecode::Op::PutByIdWithThis>(super_reference.base, super_reference.this_value, identifier_table_ref, Bytecode::Op::PropertyKind::KeyValue, next_property_lookup_cache());
             }
         } else {
             TRY(expression.object().generate_bytecode(*this));
@@ -314,7 +314,7 @@ CodeGenerationErrorOr<void> Generator::emit_store_to_reference(JS::ASTNode const
             } else if (expression.property().is_identifier()) {
                 emit<Bytecode::Op::Load>(value_reg);
                 auto identifier_table_ref = intern_identifier(verify_cast<Identifier>(expression.property()).string());
-                emit<Bytecode::Op::PutById>(object_reg, identifier_table_ref);
+                emit<Bytecode::Op::PutById>(object_reg, identifier_table_ref, Bytecode::Op::PropertyKind::KeyValue, next_property_lookup_cache());
             } else if (expression.property().is_private_identifier()) {
                 emit<Bytecode::Op::Load>(value_reg);
                 auto identifier_table_ref = intern_identifier(verify_cast<PrivateIdentifier>(expression.property()).string());

--- a/Userland/Libraries/LibJS/Bytecode/Generator.h
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.h
@@ -236,6 +236,7 @@ public:
 
     [[nodiscard]] size_t next_global_variable_cache() { return m_next_global_variable_cache++; }
     [[nodiscard]] size_t next_environment_variable_cache() { return m_next_environment_variable_cache++; }
+    [[nodiscard]] size_t next_property_lookup_cache() { return m_next_property_lookup_cache++; }
 
 private:
     enum class JumpType {

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -811,7 +811,8 @@ ThrowCompletionOr<void> PutById::execute_impl(Bytecode::Interpreter& interpreter
     auto value = interpreter.accumulator();
     auto base = interpreter.reg(m_base);
     PropertyKey name = interpreter.current_executable().get_identifier(m_property);
-    TRY(put_by_property_key(vm, base, base, value, name, m_kind));
+    auto& cache = interpreter.current_executable().property_lookup_caches[m_cache_index];
+    TRY(put_by_property_key(vm, base, base, value, name, m_kind, &cache));
     interpreter.accumulator() = value;
     return {};
 }
@@ -823,7 +824,8 @@ ThrowCompletionOr<void> PutByIdWithThis::execute_impl(Bytecode::Interpreter& int
     auto value = interpreter.accumulator();
     auto base = interpreter.reg(m_base);
     PropertyKey name = interpreter.current_executable().get_identifier(m_property);
-    TRY(put_by_property_key(vm, base, interpreter.reg(m_this_value), value, name, m_kind));
+    auto& cache = interpreter.current_executable().property_lookup_caches[m_cache_index];
+    TRY(put_by_property_key(vm, base, interpreter.reg(m_this_value), value, name, m_kind, &cache));
     interpreter.accumulator() = value;
     return {};
 }

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -668,11 +668,12 @@ enum class PropertyKind {
 
 class PutById final : public Instruction {
 public:
-    explicit PutById(Register base, IdentifierTableIndex property, PropertyKind kind = PropertyKind::KeyValue)
+    explicit PutById(Register base, IdentifierTableIndex property, PropertyKind kind, u32 cache_index)
         : Instruction(Type::PutById, sizeof(*this))
         , m_base(base)
         , m_property(property)
         , m_kind(kind)
+        , m_cache_index(cache_index)
     {
     }
 
@@ -682,21 +683,24 @@ public:
     Register base() const { return m_base; }
     IdentifierTableIndex property() const { return m_property; }
     PropertyKind kind() const { return m_kind; }
+    u32 cache_index() const { return m_cache_index; }
 
 private:
     Register m_base;
     IdentifierTableIndex m_property;
     PropertyKind m_kind;
+    u32 m_cache_index { 0 };
 };
 
 class PutByIdWithThis final : public Instruction {
 public:
-    PutByIdWithThis(Register base, Register this_value, IdentifierTableIndex property, PropertyKind kind = PropertyKind::KeyValue)
+    PutByIdWithThis(Register base, Register this_value, IdentifierTableIndex property, PropertyKind kind, u32 cache_index)
         : Instruction(Type::PutByIdWithThis, sizeof(*this))
         , m_base(base)
         , m_this_value(this_value)
         , m_property(property)
         , m_kind(kind)
+        , m_cache_index(cache_index)
     {
     }
 
@@ -707,12 +711,14 @@ public:
     Register this_value() const { return m_this_value; }
     IdentifierTableIndex property() const { return m_property; }
     PropertyKind kind() const { return m_kind; }
+    u32 cache_index() const { return m_cache_index; }
 
 private:
     Register m_base;
     Register m_this_value;
     IdentifierTableIndex m_property;
     PropertyKind m_kind;
+    u32 m_cache_index { 0 };
 };
 
 class PutPrivateById final : public Instruction {

--- a/Userland/Libraries/LibJS/JIT/Compiler.h
+++ b/Userland/Libraries/LibJS/JIT/Compiler.h
@@ -27,7 +27,7 @@ private:
 #    if ARCH(X86_64)
     static constexpr auto GPR0 = Assembler::Reg::RAX;
     static constexpr auto GPR1 = Assembler::Reg::RCX;
-    static constexpr auto GPR2 = Assembler::Reg::R12;
+    static constexpr auto GPR2 = Assembler::Reg::R13;
     static constexpr auto ARG0 = Assembler::Reg::RDI;
     static constexpr auto ARG1 = Assembler::Reg::RSI;
     static constexpr auto ARG2 = Assembler::Reg::RDX;
@@ -38,7 +38,7 @@ private:
     static constexpr auto STACK_POINTER = Assembler::Reg::RSP;
     static constexpr auto REGISTER_ARRAY_BASE = Assembler::Reg::RBX;
     static constexpr auto LOCALS_ARRAY_BASE = Assembler::Reg::R14;
-    static constexpr auto CACHED_ACCUMULATOR = Assembler::Reg::R13;
+    static constexpr auto CACHED_ACCUMULATOR = Assembler::Reg::R12;
     static constexpr auto RUNNING_EXECUTION_CONTEXT_BASE = Assembler::Reg::R15;
 #    endif
 
@@ -171,7 +171,21 @@ private:
     void jump_if_int32(Assembler::Reg, Assembler::Label&);
 
     template<typename Codegen>
-    void branch_if_int32(Assembler::Reg, Codegen);
+    void branch_if_type(Assembler::Reg, u16 type_tag, Codegen);
+
+    template<typename Codegen>
+    void branch_if_int32(Assembler::Reg reg, Codegen codegen)
+    {
+        branch_if_type(reg, INT32_TAG, codegen);
+    }
+
+    template<typename Codegen>
+    void branch_if_object(Assembler::Reg reg, Codegen codegen)
+    {
+        branch_if_type(reg, OBJECT_TAG, codegen);
+    }
+
+    void extract_object_pointer(Assembler::Reg dst_object, Assembler::Reg src_value);
 
     template<typename Codegen>
     void branch_if_both_int32(Assembler::Reg, Assembler::Reg, Codegen);

--- a/Userland/Libraries/LibJS/Runtime/ArgumentsObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArgumentsObject.cpp
@@ -52,7 +52,7 @@ ThrowCompletionOr<Value> ArgumentsObject::internal_get(PropertyKey const& proper
 }
 
 // 10.4.4.4 [[Set]] ( P, V, Receiver ), https://tc39.es/ecma262/#sec-arguments-exotic-objects-set-p-v-receiver
-ThrowCompletionOr<bool> ArgumentsObject::internal_set(PropertyKey const& property_key, Value value, Value receiver)
+ThrowCompletionOr<bool> ArgumentsObject::internal_set(PropertyKey const& property_key, Value value, Value receiver, CacheablePropertyMetadata*)
 {
     bool is_mapped = false;
 

--- a/Userland/Libraries/LibJS/Runtime/ArgumentsObject.h
+++ b/Userland/Libraries/LibJS/Runtime/ArgumentsObject.h
@@ -24,7 +24,7 @@ public:
     virtual ThrowCompletionOr<Optional<PropertyDescriptor>> internal_get_own_property(PropertyKey const&) const override;
     virtual ThrowCompletionOr<bool> internal_define_own_property(PropertyKey const&, PropertyDescriptor const&) override;
     virtual ThrowCompletionOr<Value> internal_get(PropertyKey const&, Value receiver, CacheablePropertyMetadata*) const override;
-    virtual ThrowCompletionOr<bool> internal_set(PropertyKey const&, Value value, Value receiver) override;
+    virtual ThrowCompletionOr<bool> internal_set(PropertyKey const&, Value value, Value receiver, CacheablePropertyMetadata*) override;
     virtual ThrowCompletionOr<bool> internal_delete(PropertyKey const&) override;
 
     virtual bool may_interfere_with_indexed_property_access() const final { return true; }

--- a/Userland/Libraries/LibJS/Runtime/ModuleNamespaceObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ModuleNamespaceObject.cpp
@@ -182,7 +182,7 @@ ThrowCompletionOr<Value> ModuleNamespaceObject::internal_get(PropertyKey const& 
 }
 
 // 10.4.6.9 [[Set]] ( P, V, Receiver ), https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-set-p-v-receiver
-ThrowCompletionOr<bool> ModuleNamespaceObject::internal_set(PropertyKey const&, Value, Value)
+ThrowCompletionOr<bool> ModuleNamespaceObject::internal_set(PropertyKey const&, Value, Value, CacheablePropertyMetadata*)
 {
     // 1. Return false.
     return false;

--- a/Userland/Libraries/LibJS/Runtime/ModuleNamespaceObject.h
+++ b/Userland/Libraries/LibJS/Runtime/ModuleNamespaceObject.h
@@ -26,7 +26,7 @@ public:
     virtual ThrowCompletionOr<bool> internal_define_own_property(PropertyKey const&, PropertyDescriptor const&) override;
     virtual ThrowCompletionOr<bool> internal_has_property(PropertyKey const&) const override;
     virtual ThrowCompletionOr<Value> internal_get(PropertyKey const&, Value receiver, CacheablePropertyMetadata* = nullptr) const override;
-    virtual ThrowCompletionOr<bool> internal_set(PropertyKey const&, Value value, Value receiver) override;
+    virtual ThrowCompletionOr<bool> internal_set(PropertyKey const&, Value value, Value receiver, CacheablePropertyMetadata*) override;
     virtual ThrowCompletionOr<bool> internal_delete(PropertyKey const&) override;
     virtual ThrowCompletionOr<MarkedVector<Value>> internal_own_property_keys() const override;
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/Object.h
+++ b/Userland/Libraries/LibJS/Runtime/Object.h
@@ -195,12 +195,16 @@ public:
     Value get_direct(size_t index) const { return m_storage[index]; }
     void put_direct(size_t index, Value value) { m_storage[index] = value; }
 
+    static FlatPtr storage_offset() { return OFFSET_OF(Object, m_storage); }
+
     IndexedProperties const& indexed_properties() const { return m_indexed_properties; }
     IndexedProperties& indexed_properties() { return m_indexed_properties; }
     void set_indexed_property_elements(Vector<Value>&& values) { m_indexed_properties = IndexedProperties(move(values)); }
 
     Shape& shape() { return *m_shape; }
     Shape const& shape() const { return *m_shape; }
+
+    static FlatPtr shape_offset() { return OFFSET_OF(Object, m_shape); }
 
     void ensure_shape_is_unique();
 

--- a/Userland/Libraries/LibJS/Runtime/Object.h
+++ b/Userland/Libraries/LibJS/Runtime/Object.h
@@ -131,7 +131,7 @@ public:
     virtual ThrowCompletionOr<bool> internal_define_own_property(PropertyKey const&, PropertyDescriptor const&);
     virtual ThrowCompletionOr<bool> internal_has_property(PropertyKey const&) const;
     virtual ThrowCompletionOr<Value> internal_get(PropertyKey const&, Value receiver, CacheablePropertyMetadata* = nullptr) const;
-    virtual ThrowCompletionOr<bool> internal_set(PropertyKey const&, Value value, Value receiver);
+    virtual ThrowCompletionOr<bool> internal_set(PropertyKey const&, Value value, Value receiver, CacheablePropertyMetadata* = nullptr);
     virtual ThrowCompletionOr<bool> internal_delete(PropertyKey const&);
     virtual ThrowCompletionOr<MarkedVector<Value>> internal_own_property_keys() const;
 
@@ -141,7 +141,7 @@ public:
     //       might not hold when property access behaves differently.
     virtual bool may_interfere_with_indexed_property_access() const { return false; }
 
-    ThrowCompletionOr<bool> ordinary_set_with_own_descriptor(PropertyKey const&, Value, Value, Optional<PropertyDescriptor>);
+    ThrowCompletionOr<bool> ordinary_set_with_own_descriptor(PropertyKey const&, Value, Value, Optional<PropertyDescriptor>, CacheablePropertyMetadata* = nullptr);
 
     // 10.4.7 Immutable Prototype Exotic Objects, https://tc39.es/ecma262/#sec-immutable-prototype-exotic-objects
 
@@ -193,6 +193,7 @@ public:
     virtual void visit_edges(Cell::Visitor&) override;
 
     Value get_direct(size_t index) const { return m_storage[index]; }
+    void put_direct(size_t index, Value value) { m_storage[index] = value; }
 
     IndexedProperties const& indexed_properties() const { return m_indexed_properties; }
     IndexedProperties& indexed_properties() { return m_indexed_properties; }

--- a/Userland/Libraries/LibJS/Runtime/ProxyObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ProxyObject.cpp
@@ -525,7 +525,7 @@ ThrowCompletionOr<Value> ProxyObject::internal_get(PropertyKey const& property_k
 }
 
 // 10.5.9 [[Set]] ( P, V, Receiver ), https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-set-p-v-receiver
-ThrowCompletionOr<bool> ProxyObject::internal_set(PropertyKey const& property_key, Value value, Value receiver)
+ThrowCompletionOr<bool> ProxyObject::internal_set(PropertyKey const& property_key, Value value, Value receiver, CacheablePropertyMetadata*)
 {
     auto& vm = this->vm();
 

--- a/Userland/Libraries/LibJS/Runtime/ProxyObject.h
+++ b/Userland/Libraries/LibJS/Runtime/ProxyObject.h
@@ -39,7 +39,7 @@ public:
     virtual ThrowCompletionOr<bool> internal_define_own_property(PropertyKey const&, PropertyDescriptor const&) override;
     virtual ThrowCompletionOr<bool> internal_has_property(PropertyKey const&) const override;
     virtual ThrowCompletionOr<Value> internal_get(PropertyKey const&, Value receiver, CacheablePropertyMetadata*) const override;
-    virtual ThrowCompletionOr<bool> internal_set(PropertyKey const&, Value value, Value receiver) override;
+    virtual ThrowCompletionOr<bool> internal_set(PropertyKey const&, Value value, Value receiver, CacheablePropertyMetadata*) override;
     virtual ThrowCompletionOr<bool> internal_delete(PropertyKey const&) override;
     virtual ThrowCompletionOr<MarkedVector<Value>> internal_own_property_keys() const override;
     virtual ThrowCompletionOr<Value> internal_call(Value this_argument, MarkedVector<Value> arguments_list) override;

--- a/Userland/Libraries/LibJS/Runtime/Shape.h
+++ b/Userland/Libraries/LibJS/Runtime/Shape.h
@@ -57,6 +57,8 @@ public:
     void add_property_without_transition(PropertyKey const&, PropertyAttributes);
 
     bool is_unique() const { return m_unique; }
+    static FlatPtr is_unique_offset() { return OFFSET_OF(Shape, m_unique); }
+
     Shape* create_unique_clone() const;
 
     Realm& realm() const { return m_realm; }
@@ -80,6 +82,7 @@ public:
     void reconfigure_property_in_unique_shape(StringOrSymbol const& property_key, PropertyAttributes attributes);
 
     [[nodiscard]] u64 unique_shape_serial_number() const { return m_unique_shape_serial_number; }
+    static FlatPtr unique_shape_serial_number_offset() { return OFFSET_OF(Shape, m_unique_shape_serial_number); }
 
 private:
     explicit Shape(Realm&);
@@ -106,7 +109,7 @@ private:
 
     PropertyAttributes m_attributes { 0 };
     TransitionType m_transition_type : 6 { TransitionType::Invalid };
-    bool m_unique : 1 { false };
+    bool m_unique { false };
 
     // Since unique shapes never change identity, inline caches use this incrementing serial number
     // to know whether its property table has been modified since last time we checked.

--- a/Userland/Libraries/LibJS/Runtime/TypedArray.h
+++ b/Userland/Libraries/LibJS/Runtime/TypedArray.h
@@ -314,7 +314,7 @@ public:
     }
 
     // 10.4.5.5 [[Set]] ( P, V, Receiver ), https://tc39.es/ecma262/#sec-integer-indexed-exotic-objects-set-p-v-receiver
-    virtual ThrowCompletionOr<bool> internal_set(PropertyKey const& property_key, Value value, Value receiver) override
+    virtual ThrowCompletionOr<bool> internal_set(PropertyKey const& property_key, Value value, Value receiver, CacheablePropertyMetadata*) override
     {
         VERIFY(!value.is_empty());
         VERIFY(!receiver.is_empty());

--- a/Userland/Libraries/LibWeb/Bindings/LegacyPlatformObject.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/LegacyPlatformObject.cpp
@@ -156,7 +156,7 @@ JS::ThrowCompletionOr<Optional<JS::PropertyDescriptor>> LegacyPlatformObject::in
 }
 
 // https://webidl.spec.whatwg.org/#legacy-platform-object-set
-JS::ThrowCompletionOr<bool> LegacyPlatformObject::internal_set(JS::PropertyKey const& property_name, JS::Value value, JS::Value receiver)
+JS::ThrowCompletionOr<bool> LegacyPlatformObject::internal_set(JS::PropertyKey const& property_name, JS::Value value, JS::Value receiver, JS::CacheablePropertyMetadata*)
 {
     auto& vm = this->vm();
 

--- a/Userland/Libraries/LibWeb/Bindings/LegacyPlatformObject.h
+++ b/Userland/Libraries/LibWeb/Bindings/LegacyPlatformObject.h
@@ -23,7 +23,7 @@ public:
     virtual ~LegacyPlatformObject() override;
 
     virtual JS::ThrowCompletionOr<Optional<JS::PropertyDescriptor>> internal_get_own_property(JS::PropertyKey const&) const override;
-    virtual JS::ThrowCompletionOr<bool> internal_set(JS::PropertyKey const&, JS::Value, JS::Value) override;
+    virtual JS::ThrowCompletionOr<bool> internal_set(JS::PropertyKey const&, JS::Value, JS::Value, JS::CacheablePropertyMetadata*) override;
     virtual JS::ThrowCompletionOr<bool> internal_define_own_property(JS::PropertyKey const&, JS::PropertyDescriptor const&) override;
     virtual JS::ThrowCompletionOr<bool> internal_delete(JS::PropertyKey const&) override;
     virtual JS::ThrowCompletionOr<bool> internal_prevent_extensions() override;

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleDeclaration.cpp
@@ -419,14 +419,14 @@ JS::ThrowCompletionOr<JS::Value> CSSStyleDeclaration::internal_get(JS::PropertyK
     return { JS::PrimitiveString::create(vm(), String {}) };
 }
 
-JS::ThrowCompletionOr<bool> CSSStyleDeclaration::internal_set(JS::PropertyKey const& name, JS::Value value, JS::Value receiver)
+JS::ThrowCompletionOr<bool> CSSStyleDeclaration::internal_set(JS::PropertyKey const& name, JS::Value value, JS::Value receiver, JS::CacheablePropertyMetadata* cacheable_metadata)
 {
     auto& vm = this->vm();
     if (!name.is_string())
-        return Base::internal_set(name, value, receiver);
+        return Base::internal_set(name, value, receiver, cacheable_metadata);
     auto property_id = property_id_from_name(name.to_string());
     if (property_id == CSS::PropertyID::Invalid)
-        return Base::internal_set(name, value, receiver);
+        return Base::internal_set(name, value, receiver, cacheable_metadata);
 
     auto css_text = TRY(value.to_deprecated_string(vm));
 

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleDeclaration.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleDeclaration.h
@@ -42,7 +42,7 @@ public:
 
     virtual JS::ThrowCompletionOr<bool> internal_has_property(JS::PropertyKey const& name) const override;
     virtual JS::ThrowCompletionOr<JS::Value> internal_get(JS::PropertyKey const&, JS::Value receiver, JS::CacheablePropertyMetadata*) const override;
-    virtual JS::ThrowCompletionOr<bool> internal_set(JS::PropertyKey const&, JS::Value value, JS::Value receiver) override;
+    virtual JS::ThrowCompletionOr<bool> internal_set(JS::PropertyKey const&, JS::Value value, JS::Value receiver, JS::CacheablePropertyMetadata*) override;
 
 protected:
     explicit CSSStyleDeclaration(JS::Realm&);

--- a/Userland/Libraries/LibWeb/HTML/Location.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Location.cpp
@@ -507,13 +507,13 @@ JS::ThrowCompletionOr<JS::Value> Location::internal_get(JS::PropertyKey const& p
 }
 
 // 7.10.5.8 [[Set]] ( P, V, Receiver ), https://html.spec.whatwg.org/multipage/history.html#location-set
-JS::ThrowCompletionOr<bool> Location::internal_set(JS::PropertyKey const& property_key, JS::Value value, JS::Value receiver)
+JS::ThrowCompletionOr<bool> Location::internal_set(JS::PropertyKey const& property_key, JS::Value value, JS::Value receiver, JS::CacheablePropertyMetadata* cacheable_metadata)
 {
     auto& vm = this->vm();
 
     // 1. If IsPlatformObjectSameOrigin(this) is true, then return ? OrdinarySet(this, P, V, Receiver).
     if (HTML::is_platform_object_same_origin(*this))
-        return JS::Object::internal_set(property_key, value, receiver);
+        return JS::Object::internal_set(property_key, value, receiver, cacheable_metadata);
 
     // 2. Return ? CrossOriginSet(this, P, V, Receiver).
     return HTML::cross_origin_set(vm, static_cast<JS::Object&>(*this), property_key, value, receiver);

--- a/Userland/Libraries/LibWeb/HTML/Location.h
+++ b/Userland/Libraries/LibWeb/HTML/Location.h
@@ -60,7 +60,7 @@ public:
     virtual JS::ThrowCompletionOr<Optional<JS::PropertyDescriptor>> internal_get_own_property(JS::PropertyKey const&) const override;
     virtual JS::ThrowCompletionOr<bool> internal_define_own_property(JS::PropertyKey const&, JS::PropertyDescriptor const&) override;
     virtual JS::ThrowCompletionOr<JS::Value> internal_get(JS::PropertyKey const&, JS::Value receiver, JS::CacheablePropertyMetadata*) const override;
-    virtual JS::ThrowCompletionOr<bool> internal_set(JS::PropertyKey const&, JS::Value value, JS::Value receiver) override;
+    virtual JS::ThrowCompletionOr<bool> internal_set(JS::PropertyKey const&, JS::Value value, JS::Value receiver, JS::CacheablePropertyMetadata*) override;
     virtual JS::ThrowCompletionOr<bool> internal_delete(JS::PropertyKey const&) override;
     virtual JS::ThrowCompletionOr<JS::MarkedVector<JS::Value>> internal_own_property_keys() const override;
 

--- a/Userland/Libraries/LibWeb/HTML/WindowProxy.cpp
+++ b/Userland/Libraries/LibWeb/HTML/WindowProxy.cpp
@@ -169,7 +169,7 @@ JS::ThrowCompletionOr<JS::Value> WindowProxy::internal_get(JS::PropertyKey const
 }
 
 // 7.4.8 [[Set]] ( P, V, Receiver ), https://html.spec.whatwg.org/multipage/window-object.html#windowproxy-set
-JS::ThrowCompletionOr<bool> WindowProxy::internal_set(JS::PropertyKey const& property_key, JS::Value value, JS::Value receiver)
+JS::ThrowCompletionOr<bool> WindowProxy::internal_set(JS::PropertyKey const& property_key, JS::Value value, JS::Value receiver, JS::CacheablePropertyMetadata*)
 {
     auto& vm = this->vm();
 

--- a/Userland/Libraries/LibWeb/HTML/WindowProxy.h
+++ b/Userland/Libraries/LibWeb/HTML/WindowProxy.h
@@ -27,7 +27,7 @@ public:
     virtual JS::ThrowCompletionOr<Optional<JS::PropertyDescriptor>> internal_get_own_property(JS::PropertyKey const&) const override;
     virtual JS::ThrowCompletionOr<bool> internal_define_own_property(JS::PropertyKey const&, JS::PropertyDescriptor const&) override;
     virtual JS::ThrowCompletionOr<JS::Value> internal_get(JS::PropertyKey const&, JS::Value receiver, JS::CacheablePropertyMetadata*) const override;
-    virtual JS::ThrowCompletionOr<bool> internal_set(JS::PropertyKey const&, JS::Value value, JS::Value receiver) override;
+    virtual JS::ThrowCompletionOr<bool> internal_set(JS::PropertyKey const&, JS::Value value, JS::Value receiver, JS::CacheablePropertyMetadata*) override;
     virtual JS::ThrowCompletionOr<bool> internal_delete(JS::PropertyKey const&) override;
     virtual JS::ThrowCompletionOr<JS::MarkedVector<JS::Value>> internal_own_property_keys() const override;
 


### PR DESCRIPTION
Some really nice speedups:

```
Suite       Test                                   Speedup  Old (Mean ± Range)           New (Mean ± Range)
----------  -----------------------------------  ---------  ---------------------------  ---------------------------
SunSpider   3d-cube.js                               1      0.040 ± 0.040 … 0.040        0.040 ± 0.040 … 0.040
SunSpider   3d-morph.js                              1      0.050 ± 0.050 … 0.050        0.050 ± 0.050 … 0.050
SunSpider   3d-raytrace.js                           1.167  0.070 ± 0.070 … 0.070        0.060 ± 0.060 … 0.060
SunSpider   access-binary-trees.js                   1      0.080 ± 0.080 … 0.080        0.080 ± 0.080 … 0.080
SunSpider   access-fannkuch.js                       1      0.040 ± 0.040 … 0.040        0.040 ± 0.040 … 0.040
SunSpider   access-nbody.js                          2.333  0.070 ± 0.070 … 0.070        0.030 ± 0.030 … 0.030
SunSpider   access-nsieve.js                         1      0.020 ± 0.020 … 0.020        0.020 ± 0.020 … 0.020
SunSpider   bitops-3bit-bits-in-byte.js              1      0.040 ± 0.040 … 0.040        0.040 ± 0.040 … 0.040
SunSpider   bitops-bits-in-byte.js                   1      0.030 ± 0.030 … 0.030        0.030 ± 0.030 … 0.030
SunSpider   bitops-bitwise-and.js                    1      0.280 ± 0.280 … 0.280        0.280 ± 0.280 … 0.280
SunSpider   bitops-nsieve-bits.js                    1      0.020 ± 0.020 … 0.020        0.020 ± 0.020 … 0.020
SunSpider   controlflow-recursive.js                 1      0.120 ± 0.120 … 0.120        0.120 ± 0.120 … 0.120
SunSpider   crypto-aes.js                            1      0.050 ± 0.050 … 0.050        0.050 ± 0.050 … 0.050
SunSpider   crypto-md5.js                            1      0.040 ± 0.040 … 0.040        0.040 ± 0.040 … 0.040
SunSpider   crypto-sha1.js                           1      0.040 ± 0.040 … 0.040        0.040 ± 0.040 … 0.040
SunSpider   date-format-tofte.js                     1.591  0.350 ± 0.350 … 0.350        0.220 ± 0.210 … 0.230
SunSpider   date-format-xparb.js                     0.929  0.065 ± 0.060 … 0.070        0.070 ± 0.070 … 0.070
SunSpider   math-cordic.js                           1      0.080 ± 0.080 … 0.080        0.080 ± 0.080 … 0.080
SunSpider   math-partial-sums.js                     1      0.110 ± 0.110 … 0.110        0.110 ± 0.110 … 0.110
SunSpider   math-spectral-norm.js                    0.833  0.050 ± 0.050 … 0.050        0.060 ± 0.060 … 0.060
SunSpider   regexp-dna.js                            1.037  0.425 ± 0.410 … 0.440        0.410 ± 0.410 … 0.410
SunSpider   string-base64.js                         0.8    0.040 ± 0.040 … 0.040        0.050 ± 0.050 … 0.050
SunSpider   string-fasta.js                          1      0.360 ± 0.360 … 0.360        0.360 ± 0.360 … 0.360
SunSpider   string-tagcloud.js                       1.254  0.370 ± 0.290 … 0.450        0.295 ± 0.290 … 0.300
SunSpider   string-unpack-code.js                    0.957  0.440 ± 0.440 … 0.440        0.460 ± 0.450 … 0.470
SunSpider   string-validate-input.js                 1      0.080 ± 0.080 … 0.080        0.080 ± 0.080 … 0.080
Kraken      ai-astar.js                              1.17   3.070 ± 3.060 … 3.080        2.625 ± 2.600 … 2.650
Kraken      audio-beat-detection.js                  1.003  1.835 ± 1.830 … 1.840        1.830 ± 1.830 … 1.830
Kraken      audio-dft.js                             1.116  1.680 ± 1.670 … 1.690        1.505 ± 1.500 … 1.510
Kraken      audio-fft.js                             0.991  1.705 ± 1.700 … 1.710        1.720 ± 1.720 … 1.720
Kraken      audio-oscillator.js                      1.095  2.425 ± 2.420 … 2.430        2.215 ± 2.200 … 2.230
Kraken      imaging-darkroom.js                      1.045  5.040 ± 4.980 … 5.100        4.825 ± 4.820 … 4.830
Kraken      imaging-desaturate.js                    1.004  2.575 ± 2.570 … 2.580        2.565 ± 2.560 … 2.570
Kraken      imaging-gaussian-blur.js                 1.079  20.085 ± 19.320 … 20.850     18.615 ± 18.570 … 18.660
Kraken      json-parse-financial.js                  1      0.070 ± 0.070 … 0.070        0.070 ± 0.070 … 0.070
Kraken      json-stringify-tinderbox.js              1.048  0.220 ± 0.220 … 0.220        0.210 ± 0.210 … 0.210
Kraken      stanford-crypto-aes.js                   0.988  0.830 ± 0.830 … 0.830        0.840 ± 0.840 … 0.840
Kraken      stanford-crypto-ccm.js                   1      0.765 ± 0.750 … 0.780        0.765 ± 0.760 … 0.770
Kraken      stanford-crypto-pbkdf2.js                1.008  1.210 ± 1.210 … 1.210        1.200 ± 1.200 … 1.200
Kraken      stanford-crypto-sha256-iterative.js      0.96   0.480 ± 0.480 … 0.480        0.500 ± 0.500 … 0.500
Octane      box2d.js                                 1.23   4.285 ± 4.280 … 4.290        3.485 ± 3.480 … 3.490
Octane      code-load.js                             0.955  2.105 ± 2.100 … 2.110        2.205 ± 2.190 … 2.220
Octane      crypto.js                                1.016  6.280 ± 6.250 … 6.310        6.180 ± 6.150 … 6.210
Octane      deltablue.js                             0.998  3.060 ± 3.060 … 3.060        3.065 ± 3.020 … 3.110
Octane      earley-boyer.js                          1.247  31.065 ± 30.960 … 31.170     24.920 ± 24.900 … 24.940
Octane      gbemu.js                                 1.379  6.350 ± 6.340 … 6.360        4.605 ± 4.590 … 4.620
Octane      mandreel.js                              0.982  28.575 ± 28.570 … 28.580     29.085 ± 28.920 … 29.250
Octane      navier-stokes.js                         0.98   3.185 ± 3.130 … 3.240        3.250 ± 3.180 … 3.320
Octane      pdfjs.js                                 1.052  4.025 ± 3.960 … 4.090        3.825 ± 3.790 … 3.860
Octane      raytrace.js                              1.054  8.655 ± 8.530 … 8.780        8.215 ± 8.200 … 8.230
Octane      regexp.js                                1.025  27.325 ± 27.310 … 27.340     26.655 ± 26.610 … 26.700
Octane      richards.js                              1.005  2.030 ± 2.030 … 2.030        2.020 ± 2.020 … 2.020
Octane      splay.js                                 1.036  3.175 ± 3.170 … 3.180        3.065 ± 3.060 … 3.070
Octane      typescript.js                            1.194  71.855 ± 71.690 … 72.020     60.180 ± 60.030 … 60.330
Octane      zlib.js                                  1.005  113.545 ± 112.550 … 114.540  112.955 ± 112.690 … 113.220
SunSpider   Total                                    1.072  3.360                        3.135
Kraken      Total                                    1.063  41.990                       39.485
Octane      Total                                    1.074  315.515                      293.710
All Suites  Total                                    1.073  360.865                      336.330
```