### PR TITLE
LibJS/JIT: Enable execution from block 0

### DIFF
--- a/Userland/Libraries/LibJS/JIT/NativeExecutable.cpp
+++ b/Userland/Libraries/LibJS/JIT/NativeExecutable.cpp
@@ -37,11 +37,8 @@ NativeExecutable::~NativeExecutable()
 
 void NativeExecutable::run(VM& vm, size_t entry_point) const
 {
-    FlatPtr entry_point_address = 0;
-    if (entry_point != 0) {
-        entry_point_address = m_block_entry_points[entry_point];
-        VERIFY(entry_point_address != 0);
-    }
+    FlatPtr entry_point_address = m_block_entry_points[entry_point];
+    VERIFY(entry_point_address != 0);
 
     typedef void (*JITCode)(VM&, Value* registers, Value* locals, FlatPtr entry_point_address, ExecutionContext&);
     ((JITCode)m_code)(vm,
@@ -189,5 +186,4 @@ Optional<UnrealizedSourceRange> NativeExecutable::get_source_range(Bytecode::Exe
     }
     return {};
 }
-
 }


### PR DESCRIPTION
For some reason, block 0 wasn't being taken into account when looking at
entry points. When entry_point is 0, entry_point_address is set to 0 too, which causes a fault when running an empty file.