### PR TITLE
LibJS/Bytecode: Check if eval function is a function

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/CommonImplementations.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/CommonImplementations.cpp
@@ -218,7 +218,8 @@ static Completion throw_type_error_for_callee(Bytecode::Interpreter& interpreter
 
 ThrowCompletionOr<void> throw_if_needed_for_call(Interpreter& interpreter, Value callee, Op::CallType call_type, Optional<StringTableIndex> const& expression_string)
 {
-    if (call_type == Op::CallType::Call && !callee.is_function())
+    if ((call_type == Op::CallType::Call || call_type == Op::CallType::DirectEval)
+        && !callee.is_function())
         return throw_type_error_for_callee(interpreter, callee, "function"sv, expression_string);
     if (call_type == Op::CallType::Construct && !callee.is_constructor())
         return throw_type_error_for_callee(interpreter, callee, "constructor"sv, expression_string);

--- a/Userland/Libraries/LibJS/Tests/eval-aliasing.js
+++ b/Userland/Libraries/LibJS/Tests/eval-aliasing.js
@@ -13,3 +13,8 @@ test("variable named 'eval' pointing to real eval works as a direct eval", funct
     var eval = globalThis.eval;
     expect(eval("testValue")).toEqual("inner");
 });
+
+test("variable named 'eval' pointing to a non-function raises a TypeError", function () {
+    var eval = "borked";
+    expect(() => eval("something").toThrowWithMessage(TypeError, "borked is not a function"));
+});


### PR DESCRIPTION
When overriding 'eval' to a non-function value, the interpreter would
crash. Now it handles this case swiftly, throwing a TypeError.
