### PR TITLE
pdf+test_pdf.py: Tweak output of test_pdf.py

### DIFF
--- a/Meta/test_pdf.py
+++ b/Meta/test_pdf.py
@@ -14,7 +14,9 @@ One of those zip files in unzipped makes for a good input folder.
 
 import argparse
 import collections
+import dataclasses
 import glob
+import json
 import multiprocessing
 import os
 import random
@@ -24,6 +26,14 @@ import subprocess
 
 Result = collections.namedtuple(
              'Result', ['filename', 'returncode', 'stdout', 'stderr'])
+
+
+@dataclasses.dataclass
+class Issues:
+    filenames: [str]
+    filename_to_issues: {str: [int]}
+    num_pages: int
+    count: int
 
 
 def elide_aslr(s):
@@ -36,7 +46,7 @@ def elide_parser_offset(s):
 
 def test_pdf(filename):
     pdf_path = os.path.join(os.path.dirname(__file__), '../Build/lagom/bin/pdf')
-    r = subprocess.run([pdf_path, '--debugging-stats', filename],
+    r = subprocess.run([pdf_path, '--debugging-stats', '--json', filename],
                        capture_output=True)
     return Result(filename, r.returncode, r.stdout,
                   elide_parser_offset(elide_aslr(r.stderr)))
@@ -60,15 +70,29 @@ def main():
     results = multiprocessing.Pool().map(test_pdf, files)
 
     num_files_without_issues = 0
+    num_files_with_password = 0
+    num_files_with_issues = 0
     failed_files = []
     num_crashes = 0
     stack_to_files = {}
+    issues = {}
     for r in results:
-        print(r.filename)
-        print(r.stdout.decode('utf-8'))
         if r.returncode == 0:
-            if b'no issues found' in r.stdout:
+            if b'PDF requires password' in r.stderr:
+                num_files_with_password += 1
+                continue
+
+            j = json.loads(r.stdout.decode('utf-8'))
+            if not j['issues']:
                 num_files_without_issues += 1
+            else:
+                num_files_with_issues += 1
+                for diag in j['issues']:
+                    issue = issues.setdefault(diag, Issues([], {}, 0, 0))
+                    issue.filenames.append(r.filename)
+                    issue.filename_to_issues[r.filename] = j['issues'][diag]
+                    issue.num_pages += len(j['issues'][diag])
+                    issue.count += sum(a * b for (a, b) in j['issues'][diag])
             continue
         if r.returncode == 1:
             failed_files.append(r.filename)
@@ -76,20 +100,32 @@ def main():
             num_crashes += 1
             stack_to_files.setdefault(r.stderr, []).append(r.filename)
 
-    print('Top 5 crashiest stacks')
+    percent = 100 * num_files_with_issues / len(results)
+    print(f'{len(issues)} distinct issues, in {num_files_with_issues} files ({percent}%):')
+    issue_keys = list(issues.keys())
+    issue_keys.sort(reverse=True, key=lambda x: len(issues[x].filenames))
+    for issue_key in issue_keys:
+        issue = issues[issue_key]
+        print(issue_key, end='')
+        print(f', in {len(issue.filenames)} files, on {issue.num_pages} pages, {issue.count} times')
+        filenames = sorted(issue.filenames, reverse=True, key=lambda x: len(issue.filename_to_issues[x]))
+        for filename in filenames:
+            page_counts = issue.filename_to_issues[filename]
+            page_counts = ' '.join([f'{page} ({count}x)' if count > 1 else f'{page}' for (page, count) in page_counts])
+            print(f'  {filename} {page_counts}')
+        print()
+    print()
+
+    print('Stacks:')
     keys = list(stack_to_files.keys())
     keys.sort(key=lambda x: len(stack_to_files[x]), reverse=True)
-    for stack in reversed(keys[:5]):
+    for stack in reversed(keys):
         files = stack_to_files[stack]
         print(stack.decode('utf-8', 'backslashreplace'), end='')
         print(f'In {len(files)} files:')
         for file in files:
             print(f'    {file}')
         print()
-
-    percent = 100 * num_files_without_issues / len(results)
-    print(f'{num_files_without_issues} files without issues ({percent:.1f}%)')
-    print()
 
     percent = 100 * num_crashes / len(results)
     print(f'{num_crashes} crashes ({percent:.1f}%)')
@@ -100,6 +136,15 @@ def main():
     print(f'{len(failed_files)} failed to open ({percent:.1f}%)')
     for f in failed_files:
         print(f'    {f}')
+    print()
+
+    percent = 100 * num_files_with_password / len(results)
+    print(f'{num_files_with_password} files with password ({percent:.1f}%)')
+    print()
+
+    percent = 100 * num_files_without_issues / len(results)
+    print(f'{num_files_without_issues} files without issues ({percent:.1f}%)')
+    print()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The main change is that it now groups by feature first, filename second instead of the other way round.

To make this easier, give `pdf` a `--json` flag to control the `-debugging-stats` output.

Demo:

```% time Meta/test_pdf.py -n 20 ~/Downloads/0000
11 distinct issues, in 13 files (65.0%):
Rendering of feature not supported: Type0 font CIDFontType2 not implemented yet, in 7 files, on 26 pages, 2283 times
  /Users/thakis/Downloads/0000/0000994.pdf 2 4 (2x) 5 (3x) 8 (9x) 9 (4x) 11 (6x) 12 (7x) 13 (11x) 14 (9x) 15 (9x) 16 (10x) 17 (9x) 18 (10x) 19 (9x) 20 (8x)
  /Users/thakis/Downloads/0000/0000641.pdf 1 (91x) 2 (128x) 3 (16x) 4 (18x)
  /Users/thakis/Downloads/0000/0000405.pdf 1 (16x) 2 (14x) 3 (10x)
  /Users/thakis/Downloads/0000/0000834.pdf 1 (138x)
  /Users/thakis/Downloads/0000/0000765.pdf 1 (44x)
  /Users/thakis/Downloads/0000/0000778.pdf 1 (41x)
  /Users/thakis/Downloads/0000/0000793.pdf 1 (8x)

Rendering of feature not supported: Can't draw text because an invalid font was in use, in 3 files, on 4 pages, 26 times
  /Users/thakis/Downloads/0000/0000940.pdf 1 (4x) 2 (4x)
  /Users/thakis/Downloads/0000/0000262.pdf 1
  /Users/thakis/Downloads/0000/0000233.pdf 1 (13x)

Internal error while processing PDF file: Offset past the end of the stream memory, in 2 files, on 3 pages, 61 times
  /Users/thakis/Downloads/0000/0000940.pdf 1 (40x) 2 (10x)
  /Users/thakis/Downloads/0000/0000262.pdf 1

Rendering of feature not supported: Type0 font CIDFontType0 not implemented yet, in 2 files, on 2 pages, 301 times
  /Users/thakis/Downloads/0000/0000552.pdf 1 (300x)
  /Users/thakis/Downloads/0000/0000405.pdf 1

Rendering of feature not supported: Type0 font subtype 2: support for stream cid maps not yet implemented, in 2 files, on 4 pages, 311 times
  /Users/thakis/Downloads/0000/0000071.pdf 1 (63x) 2 (60x) 3 (34x)
  /Users/thakis/Downloads/0000/0000233.pdf 1 (26x)

Rendering of feature not supported: draw operation: compatibility_begin, in 1 files, on 1 pages, 461 times
  /Users/thakis/Downloads/0000/0000552.pdf 1 (461x)

Rendering of feature not supported: draw operation: compatibility_end, in 1 files, on 1 pages, 461 times
  /Users/thakis/Downloads/0000/0000552.pdf 1 (461x)

Rendering of feature not supported: Type0 font: support for general Encodings not yet implemented, in 1 files, on 1 pages, 16 times
  /Users/thakis/Downloads/0000/0000552.pdf 1 (16x)

Internal error while processing PDF file: ICC::Profile::to_pcs: AToB*Tag handling for mft2 tags not yet implemented, in 1 files, on 1 pages, 2 times
  /Users/thakis/Downloads/0000/0000793.pdf 1 (2x)

Rendering of feature not supported: Pattern color spaces not yet implemented, in 1 files, on 1 pages, 2 times
  /Users/thakis/Downloads/0000/0000233.pdf 1 (2x)

Rendering of feature not supported: CCITTFaxDecode Filter is unsupported, in 1 files, on 18 pages, 171 times
  /Users/thakis/Downloads/0000/0000773.pdf 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18


Stacks:
0 crashes (0.0%)
0 distinct crash stacks

0 failed to open (0.0%)

0 files with password (0.0%)

7 files without issues (35.0%)

Meta/test_pdf.py -n 20 ~/Downloads/0000  3.24s user 0.71s system 296% cpu 1.331 total
```