### PR TITLE
CMake: Don't recursively include Ladybird/Lagom in buggy CMake versions

### DIFF
--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -538,7 +538,10 @@ if (BUILD_LAGOM)
         add_executable(gzip ../../Userland/Utilities/gzip.cpp)
         target_link_libraries(gzip LibCompress LibCore LibMain)
 
-        if (ENABLE_LAGOM_LADYBIRD)
+        # FIXME: Use PROJECT_IS_TOPLEVEL with cmake 3.21
+        #     Work around bug in JetBrains distributed CMake 3.27.2 where this causes infinite recursion in
+        #     export_components() when called from CLion Nova by checking if we already have Ladybird included
+        if (ENABLE_LAGOM_LADYBIRD AND NOT ladybird_SOURCE_DIR)
             add_serenity_subdirectory(Ladybird)
         endif()
 


### PR DESCRIPTION
Ran into this with the new EAP for CLion Nova. When using Ladybird as source directory, we would recursively look in Ladybird --> Lagom --> Ladybird when exporting components. This seems to be because ENABLE_LAGOM_LADYBIRD is set to ON by Ladybird's CMakeLists and something about their build, when invoked from their IDE, has buggy behavior around the SUBDIRECTORIES directory property.