### PR TITLE
LibTLS: Do not defer flushing alert packets

### DIFF
--- a/Userland/Libraries/LibTLS/Record.cpp
+++ b/Userland/Libraries/LibTLS/Record.cpp
@@ -32,11 +32,11 @@ ByteBuffer TLSv12::build_alert(bool critical, u8 code)
 void TLSv12::alert(AlertLevel level, AlertDescription code)
 {
     auto the_alert = build_alert(level == AlertLevel::FATAL, (u8)code);
-    write_packet(the_alert);
+    write_packet(the_alert, true);
     MUST(flush());
 }
 
-void TLSv12::write_packet(ByteBuffer& packet)
+void TLSv12::write_packet(ByteBuffer& packet, bool immediately)
 {
     auto schedule_or_perform_flush = [&](bool immediate) {
         if (m_context.connection_status > ConnectionStatus::Disconnected) {
@@ -61,7 +61,7 @@ void TLSv12::write_packet(ByteBuffer& packet)
         // Toooooo bad, drop the record on the ground.
         return;
     }
-    schedule_or_perform_flush(false);
+    schedule_or_perform_flush(immediately);
 }
 
 void TLSv12::update_packet(ByteBuffer& packet)

--- a/Userland/Libraries/LibTLS/TLSv12.h
+++ b/Userland/Libraries/LibTLS/TLSv12.h
@@ -361,7 +361,7 @@ private:
     void update_packet(ByteBuffer& packet);
     void update_hash(ReadonlyBytes in, size_t header_size);
 
-    void write_packet(ByteBuffer& packet);
+    void write_packet(ByteBuffer& packet, bool immediately = false);
 
     ByteBuffer build_client_key_exchange();
     ByteBuffer build_server_key_exchange();


### PR DESCRIPTION
There's a good chance the TLS socket instance will be deleted before the deferred invocation fires, and there's no real reason to defer flushes of alerts anyway as they are usually sent on errors. Fixes #21800.