### PR TITLE
CMake: Bump CMake minimum up to 3.21 to work around CLion bug

### DIFF
--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.16)
+cmake_minimum_required (VERSION 3.21)
 
 project(
     Lagom
@@ -538,10 +538,10 @@ if (BUILD_LAGOM)
         add_executable(gzip ../../Userland/Utilities/gzip.cpp)
         target_link_libraries(gzip LibCompress LibCore LibMain)
 
-        # FIXME: Use PROJECT_IS_TOPLEVEL with cmake 3.21
-        #     Work around bug in JetBrains distributed CMake 3.27.2 where this causes infinite recursion in
-        #     export_components() when called from CLion Nova by checking if we already have Ladybird included
-        if (ENABLE_LAGOM_LADYBIRD AND NOT ladybird_SOURCE_DIR)
+        # Work around bug in JetBrains distributed CMake 3.27.2 where this causes infinite recursion in
+        # export_components() when called from CLion Nova by checking if we already have Ladybird included
+        # This technically breaks people including Lagom as a submodule and wanting Ladybird targets, but... who? why?
+        if (ENABLE_LAGOM_LADYBIRD AND PROJECT_IS_TOP_LEVEL)
             add_serenity_subdirectory(Ladybird)
         endif()
 


### PR DESCRIPTION
Fix the recursive directory bug in CLion Nova EAP's CMake version in a way that doesn't also break `./Meta/serenity.sh run lagom ladybird`.

This brings the Lagom minimum required closer to the Serenity minimum required. Which is still fine, because the serenity.sh script knows how to build CMake from source if a developer's local copy is too old.