### PR TITLE
LibPDF: Implement StitchingFunction

### DIFF
--- a/Userland/Libraries/LibPDF/CommonNames.h
+++ b/Userland/Libraries/LibPDF/CommonNames.h
@@ -22,6 +22,7 @@
     X(BaseFont)                   \
     X(BitsPerComponent)           \
     X(BlackPoint)                 \
+    X(Bounds)                     \
     X(C)                          \
     X(C0)                         \
     X(C1)                         \
@@ -59,6 +60,7 @@
     X(Differences)                \
     X(Domain)                     \
     X(E)                          \
+    X(Encode)                     \
     X(Encoding)                   \
     X(Encrypt)                    \
     X(EncryptMetadata)            \
@@ -83,6 +85,7 @@
     X(FontFile2)                  \
     X(FontFile3)                  \
     X(FunctionType)               \
+    X(Functions)                  \
     X(Gamma)                      \
     X(H)                          \
     X(Height)                     \


### PR DESCRIPTION
We're going to need this once we add support for gradients.

With this and #21818, we have implementations for all PDF function types :^)

(…but SamplingFunction is still a bit incomplete even after #21818.)