### PR TITLE
LibCrypto: Some clean-up of the SECP256r1 curve implementation

### DIFF
--- a/Userland/Libraries/LibCrypto/Curves/SECP256r1.cpp
+++ b/Userland/Libraries/LibCrypto/Curves/SECP256r1.cpp
@@ -240,15 +240,13 @@ static constexpr u256 modular_add_order(u256 const& left, u256 const& right, boo
     u256 output = left.addc(right, carry);
 
     // If there is a carry, subtract n by adding 2^256 - n
-    bool did_carry = carry;
+    u256 addend = select(0u, REDUCE_ORDER, carry);
     carry = false;
-    u256 temp_output = output.addc(REDUCE_ORDER, carry);
-    output = select(output, temp_output, did_carry);
+    output = output.addc(addend, carry);
 
     // If there is still a carry, subtract n by adding 2^256 - n
-    did_carry = carry;
-    temp_output = output + REDUCE_ORDER;
-    return select(output, temp_output, did_carry);
+    addend = select(0u, REDUCE_ORDER, carry);
+    return output + addend;
 }
 
 static constexpr u256 modular_multiply_order(u256 const& left, u256 const& right)

--- a/Userland/Libraries/LibCrypto/Curves/SECP256r1.cpp
+++ b/Userland/Libraries/LibCrypto/Curves/SECP256r1.cpp
@@ -124,14 +124,12 @@ static constexpr u256 modular_add(u256 const& left, u256 const& right, bool carr
     u256 output = left.addc(right, carry);
 
     // If there is a carry, subtract p by adding 2^256 - p
-    u64 t = carry;
+    u256 addend = select(0u, REDUCE_PRIME, carry);
     carry = false;
-    u256 addend { u128 { t, -(t << 32) }, u128 { -t, (t << 32) - (t << 1) } };
     output = output.addc(addend, carry);
 
     // If there is still a carry, subtract p by adding 2^256 - p
-    t = carry;
-    addend = { u128 { t, -(t << 32) }, u128 { -t, (t << 32) - (t << 1) } };
+    addend = select(0u, REDUCE_PRIME, carry);
     return output + addend;
 }
 
@@ -141,14 +139,12 @@ static constexpr u256 modular_sub(u256 const& left, u256 const& right)
     u256 output = left.subc(right, borrow);
 
     // If there is a borrow, add p by subtracting 2^256 - p
-    u64 t = borrow;
+    u256 sub = select(0u, REDUCE_PRIME, borrow);
     borrow = false;
-    u256 sub { u128 { t, -(t << 32) }, u128 { -t, (t << 32) - (t << 1) } };
     output = output.subc(sub, borrow);
 
     // If there is still a borrow, add p by subtracting 2^256 - p
-    t = borrow;
-    sub = { u128 { t, -(t << 32) }, u128 { -t, (t << 32) - (t << 1) } };
+    sub = select(0u, REDUCE_PRIME, borrow);
     return output - sub;
 }
 

--- a/Userland/Libraries/LibCrypto/Curves/SECP256r1.cpp
+++ b/Userland/Libraries/LibCrypto/Curves/SECP256r1.cpp
@@ -52,6 +52,9 @@ static constexpr u256 A { { 0xfffffffffffffffcull, 0x00000000ffffffffull, 0x0000
 static constexpr u256 B { { 0x3bce3c3e27d2604bull, 0x651d06b0cc53b0f6ull, 0xb3ebbd55769886bcull, 0x5ac635d8aa3a93e7ull } };
 static constexpr u256 ORDER { { 0xf3b9cac2fc632551ull, 0xbce6faada7179e84ull, 0xffffffffffffffffull, 0xffffffff00000000ull } };
 
+// Verify that A = -3 mod p, which is required for some optimizations
+static_assert(A == PRIME - 3);
+
 // Precomputed helper values for reduction and Montgomery multiplication
 static constexpr u256 REDUCE_PRIME = u256 { 0 } - PRIME;
 static constexpr u256 REDUCE_ORDER = u256 { 0 } - ORDER;

--- a/Userland/Libraries/LibCrypto/Curves/SECP256r1.cpp
+++ b/Userland/Libraries/LibCrypto/Curves/SECP256r1.cpp
@@ -408,6 +408,8 @@ static void convert_jacobian_to_affine(JacobianPoint& point)
     temp = modular_multiply(temp, point.z);
     temp = modular_inverse(temp);
     point.y = modular_multiply(point.y, temp);
+    // Z' = 1
+    point.z = to_montgomery(1u);
 }
 
 static bool is_point_on_curve(JacobianPoint const& point)
@@ -426,7 +428,7 @@ static bool is_point_on_curve(JacobianPoint const& point)
     temp = modular_sub(temp, to_montgomery(B));
     temp = modular_reduce(temp);
 
-    return temp.is_zero_constant_time();
+    return temp.is_zero_constant_time() && point.z.is_equal_to_constant_time(to_montgomery(1u));
 }
 
 ErrorOr<ByteBuffer> SECP256r1::generate_private_key()

--- a/Userland/Libraries/LibCrypto/Curves/SECP256r1.cpp
+++ b/Userland/Libraries/LibCrypto/Curves/SECP256r1.cpp
@@ -189,46 +189,16 @@ static constexpr u256 modular_inverse(u256 const& value)
 {
     // Modular inverse modulo the curve prime can be computed using Fermat's little theorem: a^(p-2) mod p = a^-1 mod p.
     // Calculating a^(p-2) mod p can be done using the square-and-multiply exponentiation method, as p-2 is constant.
-    //
-    // p-2 = 2^256 - 2^224 + 2^192 + 2^96 - 3, or written as binary:
-    // 1111111111111111111111111111111100000000000000000000000000000001
-    // 0000000000000000000000000000000000000000000000000000000000000000
-    // 0000000000000000000000000000000011111111111111111111111111111111
-    // 1111111111111111111111111111111111111111111111111111111111111101
-
     u256 base = value;
+    u256 result = to_montgomery(1u);
+    u256 prime_minus_2 = PRIME - 2u;
 
-    // 1
-    u256 result = value;
-    base = modular_square(base);
-
-    // 0
-    base = modular_square(base);
-
-    // 94*1
-    for (auto i = 0; i < 94; i++) {
-        result = modular_multiply(result, base);
+    for (size_t i = 0; i < 256; i++) {
+        if ((prime_minus_2 & 1u) == 1u) {
+            result = modular_multiply(result, base);
+        }
         base = modular_square(base);
-    }
-
-    // 96*0
-    for (auto i = 0; i < 96; i++) {
-        base = modular_square(base);
-    }
-
-    // 1
-    result = modular_multiply(result, base);
-    base = modular_square(base);
-
-    // 31*0
-    for (auto i = 0; i < 31; i++) {
-        base = modular_square(base);
-    }
-
-    // 32*1
-    for (auto i = 0; i < 32; i++) {
-        result = modular_multiply(result, base);
-        base = modular_square(base);
+        prime_minus_2 >>= 1u;
     }
 
     return result;

--- a/Userland/Libraries/LibCrypto/Curves/SECP256r1.cpp
+++ b/Userland/Libraries/LibCrypto/Curves/SECP256r1.cpp
@@ -69,7 +69,7 @@ static u256 import_big_endian(ReadonlyBytes data)
     u64 b = AK::convert_between_host_and_big_endian(ByteReader::load64(data.offset_pointer(2 * sizeof(u64))));
     u64 a = AK::convert_between_host_and_big_endian(ByteReader::load64(data.offset_pointer(3 * sizeof(u64))));
 
-    return u256 { u128 { a, b }, u128 { c, d } };
+    return u256 { { a, b, c, d } };
 }
 
 static void export_big_endian(u256 const& value, Bytes data)


### PR DESCRIPTION
This PR contains some clean-up of the SECP256r1 curve implementation that I did a while ago. These clean-ups are mostly to improve readability and to make the code more generic in preparation for the SECP384r1 implementation.

Most significantly, the large list of `u256` constants at the top of the file is now reduced to 4 constants, which are taken directly from the curve specification. All the other constants are now calculated instead.