### PR TITLE
LibJS/JIT: Collect number of native function calls during runtime

### DIFF
--- a/Userland/Libraries/LibJIT/X86_64/Assembler.h
+++ b/Userland/Libraries/LibJIT/X86_64/Assembler.h
@@ -859,6 +859,21 @@ struct X86_64Assembler {
         }
     }
 
+    void inc64(Operand op, Optional<Label&> overflow_label)
+    {
+        if (op.is_register_or_memory()) {
+            emit_rex_for_slash(op, REX_W::Yes);
+            emit8(0xff);
+            emit_modrm_slash(0, op);
+        } else {
+            VERIFY_NOT_REACHED();
+        }
+
+        if (overflow_label.has_value()) {
+            jump_if(Condition::Overflow, *overflow_label);
+        }
+    }
+
     void dec32(Operand op, Optional<Label&> overflow_label)
     {
         if (op.is_register_or_memory()) {

--- a/Userland/Libraries/LibJS/JIT/Compiler.cpp
+++ b/Userland/Libraries/LibJS/JIT/Compiler.cpp
@@ -12,6 +12,7 @@
 #include <LibJS/Bytecode/Interpreter.h>
 #include <LibJS/Bytecode/RegexTable.h>
 #include <LibJS/JIT/Compiler.h>
+#include <LibJS/JIT/RuntimeStats.h>
 #include <LibJS/Runtime/AbstractOperations.h>
 #include <LibJS/Runtime/Array.h>
 #include <LibJS/Runtime/DeclarativeEnvironment.h>
@@ -2594,6 +2595,10 @@ void Compiler::jump_to_exit()
 
 void Compiler::native_call(void* function_address, Vector<Assembler::Operand> const& stack_arguments)
 {
+#    if COLLECT_RUNTIME_STATS
+    m_assembler.mov(Assembler::Operand::Register(GPR0), Assembler::Operand::Imm((u64)&s_runtime_stats));
+    m_assembler.inc64(Assembler::Operand::Mem64BaseAndOffset(GPR0, RuntimeStats::native_calls_offset()), Optional<Assembler::Label&>());
+#    endif
     // NOTE: We don't preserve caller-saved registers when making a native call.
     //       This means that they may have changed after we return from the call.
     m_assembler.native_call(bit_cast<u64>(function_address), { Assembler::Operand::Register(ARG0) }, stack_arguments);

--- a/Userland/Libraries/LibJS/JIT/NativeExecutable.h
+++ b/Userland/Libraries/LibJS/JIT/NativeExecutable.h
@@ -31,6 +31,8 @@ public:
     NativeExecutable(void* code, size_t size, Vector<BytecodeMapping>);
     ~NativeExecutable();
 
+    void reset_stats();
+    void dump_stats() const;
     void run(VM&, size_t entry_point) const;
     void dump_disassembly(Bytecode::Executable const& executable) const;
     BytecodeMapping const& find_mapping_entry(size_t native_offset) const;
@@ -41,6 +43,7 @@ public:
 private:
     void* m_code { nullptr };
     size_t m_size { 0 };
+    size_t m_native_calls { 0 };
     Vector<BytecodeMapping> m_mapping;
     Vector<FlatPtr> m_block_entry_points;
     mutable OwnPtr<Bytecode::InstructionStreamIterator> m_instruction_stream_iterator;

--- a/Userland/Libraries/LibJS/JIT/RuntimeStats.h
+++ b/Userland/Libraries/LibJS/JIT/RuntimeStats.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2023, Stephan Vedder <stephan.vedder@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Platform.h>
+
+#define COLLECT_RUNTIME_STATS 0
+
+namespace JS::JIT {
+struct RuntimeStats {
+    u64 native_calls { 0 };
+
+    static FlatPtr native_calls_offset() { return OFFSET_OF(RuntimeStats, native_calls); }
+};
+
+#if COLLECT_RUNTIME_STATS
+extern RuntimeStats s_runtime_stats;
+#endif
+}


### PR DESCRIPTION
Can be extended with more useful statistics later on. The amount of native calls is quite interesting for performance, since that relates to the amount of fastpaths taken