### PR TITLE
headless-browser: Add flag to dump screenshots of failing ref-tests

### DIFF
--- a/Ladybird/CMakeLists.txt
+++ b/Ladybird/CMakeLists.txt
@@ -260,7 +260,7 @@ include(CTest)
 if (BUILD_TESTING)
     add_test(
         NAME LibWeb
-        COMMAND ${CMAKE_CURRENT_BINARY_DIR}/../bin/headless-browser --resources "${SERENITY_SOURCE_DIR}/Base/res" --run-tests ${SERENITY_SOURCE_DIR}/Tests/LibWeb
+        COMMAND ${CMAKE_CURRENT_BINARY_DIR}/../bin/headless-browser --resources "${SERENITY_SOURCE_DIR}/Base/res" --run-tests ${SERENITY_SOURCE_DIR}/Tests/LibWeb --dump-failed-ref-tests
     )
     add_test(
         NAME WPT

--- a/Meta/Azure/Lagom.yml
+++ b/Meta/Azure/Lagom.yml
@@ -159,6 +159,17 @@ jobs:
           UBSAN_OPTIONS: 'print_stacktrace=1:print_summary=1:halt_on_error=1'
           TESTS_ONLY: 1
 
+      # Detect if any test dumps exist, which enables the next step to publish them as an artifact.
+      - bash: |
+          if [[ -d $(Build.SourcesDirectory)/Meta/Lagom/Build/Ladybird/test-dumps ]]; then
+            echo "##vso[task.setvariable variable=TestDumpsExist]true"
+          fi
+        condition: always()
+
+      - publish: $(Build.SourcesDirectory)/Meta/Lagom/Build/Ladybird/test-dumps
+        artifact: 'test-dumps-${{ parameters.os }}-${{ parameters.fuzzer }}'
+        condition: eq(variables.TestDumpsExist, 'true')
+
     - ${{ if and(eq(parameters.fuzzer, 'NoFuzz'), eq(parameters.os, 'Linux') ) }}:
       - script: |
           ./run.sh


### PR DESCRIPTION
![image](https://github.com/SerenityOS/serenity/assets/222642/b6c67bfc-d45c-4583-906b-16d632865bca)

When the `--dump-failed-ref-tests` flag is provided, screenshots of the actual and reference pages will be placed in
`Build/lagom/ladbybird/test-dumps`. This makes it a lot easier to spot what's wrong with a failing test. :^)