### PR TITLE
LibJS: Skip an always-false branch in the JIT to_boolean slow case

### DIFF
--- a/Userland/Libraries/LibJS/JIT/Compiler.cpp
+++ b/Userland/Libraries/LibJS/JIT/Compiler.cpp
@@ -175,7 +175,7 @@ void Compiler::compile_jump(Bytecode::Op::Jump const& op)
 
 static bool cxx_to_boolean(VM&, Value value)
 {
-    return value.to_boolean();
+    return value.to_boolean_slow_case();
 }
 
 void Compiler::compile_to_boolean(Assembler::Reg dst, Assembler::Reg src)

--- a/Userland/Libraries/LibJS/Runtime/Value.h
+++ b/Userland/Libraries/LibJS/Runtime/Value.h
@@ -439,8 +439,9 @@ public:
         return static_cast<i32>(m_value.encoded & 0xFFFFFFFF);
     }
 
-private:
     bool to_boolean_slow_case() const;
+
+private:
     ThrowCompletionOr<Value> to_number_slow_case(VM&) const;
     ThrowCompletionOr<Value> to_numeric_slow_case(VM&) const;
     ThrowCompletionOr<Value> to_primitive_slow_case(VM&, PreferredType) const;


### PR DESCRIPTION
I don't think this would have an observable difference on any normal benchmark, but the always-false branch seemed sad