### PR TITLE
LibAccelGfx: Use wrapping functions with error check for OpenGL calls

### DIFF
--- a/Userland/Libraries/LibAccelGfx/CMakeLists.txt
+++ b/Userland/Libraries/LibAccelGfx/CMakeLists.txt
@@ -2,6 +2,7 @@ include(accelerated_graphics)
 
 if (HAS_ACCELERATED_GRAPHICS)
     set(SOURCES
+        GL.cpp
         Canvas.cpp
         Context.cpp
         Painter.cpp

--- a/Userland/Libraries/LibAccelGfx/Canvas.cpp
+++ b/Userland/Libraries/LibAccelGfx/Canvas.cpp
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include "Canvas.h"
-#include <GL/gl.h>
+#include <LibAccelGfx/Canvas.h>
+#include <LibAccelGfx/GL.h>
 #include <LibGfx/Bitmap.h>
 
 namespace AccelGfx {
@@ -28,13 +28,12 @@ void Canvas::initialize()
 {
     m_surface = m_context.create_surface(width(), height());
     m_context.set_active_surface(m_surface);
-    glViewport(0, 0, width(), height());
+    GL::set_viewport({ 0, 0, width(), height() });
 }
 
 void Canvas::flush()
 {
-    glPixelStorei(GL_PACK_ALIGNMENT, 1);
-    glReadPixels(0, 0, width(), height(), GL_BGRA, GL_UNSIGNED_BYTE, m_bitmap->scanline(0));
+    GL::read_pixels({ 0, 0, width(), height() }, *m_bitmap);
 }
 
 Canvas::~Canvas()

--- a/Userland/Libraries/LibAccelGfx/GL.h
+++ b/Userland/Libraries/LibAccelGfx/GL.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2023, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Vector.h>
+#include <GL/gl.h>
+#include <LibGfx/Forward.h>
+
+namespace AccelGfx::GL {
+
+enum class ShaderType {
+    Vertex,
+    Fragment,
+};
+
+struct Shader {
+    GLuint id;
+};
+
+struct Program {
+    GLuint id;
+};
+
+struct VertexAttribute {
+    GLint id;
+};
+
+struct Uniform {
+    GLint id;
+};
+
+struct Texture {
+    GLuint id;
+};
+
+void set_viewport(Gfx::IntRect);
+void enable_blending();
+
+void read_pixels(Gfx::IntRect, Gfx::Bitmap&);
+
+Shader create_shader(ShaderType type, char const* source);
+Program create_program(Shader const& vertex_shader, Shader const& fragment_shader);
+void use_program(Program const&);
+VertexAttribute get_attribute_location(Program const&, char const* name);
+Uniform get_uniform_location(Program const&, char const* name);
+void delete_program(Program const&);
+
+Texture create_texture();
+void bind_texture(Texture const&);
+void upload_texture_data(Texture const& texture, Gfx::Bitmap const& bitmap);
+void delete_texture(Texture const&);
+
+void set_uniform(Uniform const& uniform, float, float, float, float);
+void set_vertex_attribute(VertexAttribute const& attribute, Span<float> values, int number_of_components);
+
+enum class ScalingMode {
+    Nearest,
+    Linear,
+};
+void set_texture_scale_mode(ScalingMode);
+
+void clear_color(Gfx::Color const&);
+
+enum class DrawPrimitive {
+    Triangles,
+    TriangleFan,
+};
+
+void draw_arrays(DrawPrimitive, size_t count);
+
+}

--- a/Userland/Libraries/LibAccelGfx/Painter.h
+++ b/Userland/Libraries/LibAccelGfx/Painter.h
@@ -12,6 +12,7 @@
 #include <AK/Vector.h>
 #include <LibAccelGfx/Canvas.h>
 #include <LibAccelGfx/Forward.h>
+#include <LibAccelGfx/GL.h>
 #include <LibAccelGfx/Program.h>
 #include <LibGfx/AffineTransform.h>
 #include <LibGfx/Font/Font.h>
@@ -89,7 +90,7 @@ private:
 
     HashMap<GlyphsTextureKey, Gfx::IntRect> m_glyphs_texture_map;
     Gfx::IntSize m_glyphs_texture_size;
-    GLuint m_glyphs_texture;
+    GL::Texture m_glyphs_texture;
 };
 
 }

--- a/Userland/Libraries/LibAccelGfx/Program.h
+++ b/Userland/Libraries/LibAccelGfx/Program.h
@@ -7,7 +7,7 @@
 #pragma once
 
 #include <AK/Noncopyable.h>
-#include <GL/gl.h>
+#include <LibAccelGfx/GL.h>
 
 namespace AccelGfx {
 
@@ -18,18 +18,18 @@ public:
     static Program create(char const* vertex_shader_source, char const* fragment_shader_source);
 
     void use();
-    GLuint get_attribute_location(char const* name);
-    GLuint get_uniform_location(char const* name);
+    GL::VertexAttribute get_attribute_location(char const* name);
+    GL::Uniform get_uniform_location(char const* name);
 
     ~Program();
 
 private:
-    Program(GLuint id)
-        : m_id(id)
+    Program(GL::Program program)
+        : m_program(program)
     {
     }
 
-    GLuint m_id { 0 };
+    GL::Program m_program;
 };
 
 }


### PR DESCRIPTION
This change introduces GL.h with error check wrappers for all the OpenGL functions we used so far.

For now, the error check is simply:
`VERIFY(glGetError() == GL_NO_ERROR);`
but that is better than continuing execution after encounting an error.