### PR TITLE
LibPDF: Add test for SampledFunction and fix bugs found by it

### DIFF
--- a/Tests/LibPDF/TestPDF.cpp
+++ b/Tests/LibPDF/TestPDF.cpp
@@ -131,7 +131,7 @@ TEST_CASE(sampled)
     EXPECT_EQ(MUST(f1->evaluate(Vector<float> { 0.75f })), Vector<float> { 5.0f });
     EXPECT_EQ(MUST(f1->evaluate(Vector<float> { 1.0f })), Vector<float> { 0.0f });
 
-    auto f2 = MUST(make_sampled_function(Vector<u8> { { 0, 255, 0, 255, 0, 255 } }, { 0.0f, 1.0f }, { 0.0f, 10.0f, 0.0f, 8.0f }, { 3 }));
+    auto f2 = MUST(make_sampled_function(Vector<u8> { { 0, 255, 255, 0, 0, 255 } }, { 0.0f, 1.0f }, { 0.0f, 10.0f, 0.0f, 8.0f }, { 3 }));
     EXPECT_EQ(MUST(f2->evaluate(Vector<float> { 0.0f })), (Vector<float> { 0.0f, 8.0f }));
     EXPECT_EQ(MUST(f2->evaluate(Vector<float> { 0.25f })), (Vector<float> { 5.0f, 4.0f }));
     EXPECT_EQ(MUST(f2->evaluate(Vector<float> { 0.5f })), (Vector<float> { 10.0f, 0.0f }));

--- a/Userland/Libraries/LibPDF/Function.cpp
+++ b/Userland/Libraries/LibPDF/Function.cpp
@@ -178,10 +178,10 @@ PDFErrorOr<ReadonlySpan<float>> SampledFunction::evaluate(ReadonlySpan<float> x)
         else
             e0 = e1 - 1.0f;
     }
-    size_t plane_size = m_sizes[0];
+    size_t plane_size = m_range.size();
     for (size_t i = 0; i < m_range.size(); ++i) {
-        float s0 = m_sample_data[(size_t)e0 + i * plane_size];
-        float s1 = m_sample_data[(size_t)e1 + i * plane_size];
+        float s0 = m_sample_data[(size_t)e0 * plane_size + i];
+        float s1 = m_sample_data[(size_t)e1 * plane_size + i];
         float r0 = interpolate(ec, e0, e1, s0, s1);
         r0 = interpolate(r0, 0.0f, 255.0f, m_decode[i].lower, m_decode[i].upper);
         m_outputs[i] = clamp(r0, m_range[i].lower, m_range[i].upper);


### PR DESCRIPTION
* SampledFunction now keeps the StreamObject it gets data from alive (doesn't matter too much in practice, but does matter in the test, where nothing else keeps the stream alive).

* If a sample is an integer, we would previously sample that value twice and then divide by zero when interpolating. Make sure to sample 1 unit apart.