### PR TITLE
LibIDL+LibWeb: Resolve distinguishing argument index at build time

### DIFF
--- a/Userland/Libraries/LibIDL/Types.cpp
+++ b/Userland/Libraries/LibIDL/Types.cpp
@@ -293,30 +293,6 @@ bool Type::is_json(Interface const& interface) const
     return false;
 }
 
-// https://webidl.spec.whatwg.org/#dfn-distinguishing-argument-index
-int EffectiveOverloadSet::distinguishing_argument_index()
-{
-    for (auto argument_index = 0u; argument_index < m_argument_count; ++argument_index) {
-        bool found_indistinguishable = false;
-
-        for (auto first_item_index = 0u; first_item_index < m_items.size(); ++first_item_index) {
-            for (auto second_item_index = first_item_index + 1; second_item_index < m_items.size(); ++second_item_index) {
-                if (!m_items[first_item_index].types[argument_index]->is_distinguishable_from(m_items[second_item_index].types[argument_index])) {
-                    found_indistinguishable = true;
-                    break;
-                }
-            }
-            if (found_indistinguishable)
-                break;
-        }
-
-        if (!found_indistinguishable)
-            return argument_index;
-    }
-
-    VERIFY_NOT_REACHED();
-}
-
 void EffectiveOverloadSet::remove_all_other_entries()
 {
     Vector<Item> new_items;

--- a/Userland/Libraries/LibIDL/Types.h
+++ b/Userland/Libraries/LibIDL/Types.h
@@ -415,9 +415,9 @@ public:
         Vector<Optionality> optionality_values;
     };
 
-    EffectiveOverloadSet(Vector<Item> items)
+    EffectiveOverloadSet(Vector<Item> items, size_t distinguishing_argument_index)
         : m_items(move(items))
-        , m_argument_count(m_items.is_empty() ? 0 : m_items.first().types.size())
+        , m_distinguishing_argument_index(distinguishing_argument_index)
     {
     }
 
@@ -433,7 +433,7 @@ public:
     bool is_empty() const { return m_items.is_empty(); }
     size_t size() const { return m_items.size(); }
 
-    int distinguishing_argument_index();
+    size_t distinguishing_argument_index() const { return m_distinguishing_argument_index; }
 
     template<typename Matches>
     bool has_overload_with_matching_argument_at_index(size_t index, Matches matches)
@@ -454,7 +454,7 @@ public:
 private:
     // FIXME: This should be an "ordered set".
     Vector<Item> m_items;
-    size_t m_argument_count;
+    size_t m_distinguishing_argument_index { 0 };
 
     Optional<size_t> m_last_matching_item_index;
 };

--- a/Userland/Libraries/LibIDL/Types.h
+++ b/Userland/Libraries/LibIDL/Types.h
@@ -134,7 +134,7 @@ public:
     bool is_sequence() const { return is_parameterized() && m_name == "sequence"; }
 
     // https://webidl.spec.whatwg.org/#dfn-distinguishable
-    bool is_distinguishable_from(Type const& other) const;
+    bool is_distinguishable_from(Interface const&, Type const& other) const;
 
     bool is_json(Interface const&) const;
 

--- a/Userland/Libraries/LibWeb/WebIDL/OverloadResolution.cpp
+++ b/Userland/Libraries/LibWeb/WebIDL/OverloadResolution.cpp
@@ -56,6 +56,8 @@ static bool has_overload_with_argument_type_or_subtype_matching(IDL::EffectiveOv
 // https://webidl.spec.whatwg.org/#es-overloads
 JS::ThrowCompletionOr<ResolvedOverload> resolve_overload(JS::VM& vm, IDL::EffectiveOverloadSet& overloads)
 {
+    // FIXME: The vast majority of this algorithm can be (and must be, in order to resolve the dictionary
+    //  related FIXMEs below) evaluated at code-generation time.
     // 1. Let maxarg be the length of the longest type list of the entries in S.
     // 2. Let n be the size of args.
     // 3. Initialize argcount to be min(maxarg, n).


### PR DESCRIPTION
Aside from the obvious performance benefits, this will allow us to properly handle dictionary types. (whose dictionary-ness is only known at build-time)

Much of the rest of the overload resolution algorithm steps can (and should) be evaluated at build-time as well, but this is a good first step.