### PR TITLE
LibWeb: Remove some FIXME's for serialization of HTML attributes

### DIFF
--- a/Tests/LibWeb/Text/expected/HTML/get-innerHTML.txt
+++ b/Tests/LibWeb/Text/expected/HTML/get-innerHTML.txt
@@ -1,0 +1,10 @@
+            
+  <ol reversed="" xml:myattribute=""></ol>
+  <ol xmlns:somename=""></ol>
+  <svg xmlns="http://www.w3.org/2000/svg">
+    <script xlink:href="test"></script>
+    <script href="test"></script>
+    <script id="script" madeup:thing="test" xmlns="5"></script>
+  </svg>
+  <label xml:lang="en-US" class="struct"></label>
+

--- a/Tests/LibWeb/Text/input/HTML/get-innerHTML.html
+++ b/Tests/LibWeb/Text/input/HTML/get-innerHTML.html
@@ -1,0 +1,17 @@
+<div id="id1">
+  <ol reversed xml:myattribute></ol>
+  <ol xmlns:somename></ol>
+  <svg xmlns="http://www.w3.org/2000/svg">
+    <script xlink:href="test"></script>
+    <script href="test"></script>
+    <script id="script" madeup:thing="test"></script>
+  </svg>
+  <label xml:lang="en-US" class="struct"></label>
+</div>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        document.getElementById('script').setAttributeNS("http://www.w3.org/2000/xmlns/", "xmlns", "5");
+        println(document.getElementById('id1').innerHTML);
+    });
+</script>

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -1885,12 +1885,17 @@ void Element::set_prefix(Optional<FlyString> value)
     m_qualified_name.set_prefix(move(value));
 }
 
+void Element::for_each_attribute(Function<void(Attr const&)> callback) const
+{
+    for (size_t i = 0; i < m_attributes->length(); ++i)
+        callback(*m_attributes->item(i));
+}
+
 void Element::for_each_attribute(Function<void(FlyString const&, DeprecatedString const&)> callback) const
 {
-    for (size_t i = 0; i < m_attributes->length(); ++i) {
-        auto const* attribute = m_attributes->item(i);
-        callback(attribute->name(), attribute->value().to_deprecated_string());
-    }
+    for_each_attribute([&callback](Attr const& attr) {
+        callback(attr.name(), attr.value().to_deprecated_string());
+    });
 }
 
 Layout::NodeWithStyle* Element::layout_node()

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -137,6 +137,8 @@ public:
     int client_width() const;
     int client_height() const;
 
+    void for_each_attribute(Function<void(Attr const&)>) const;
+
     void for_each_attribute(Function<void(FlyString const&, DeprecatedString const&)>) const;
 
     bool has_class(FlyString const&, CaseSensitivity = CaseSensitivity::CaseSensitive) const;

--- a/Userland/Libraries/LibWeb/DOM/Node.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Node.cpp
@@ -1333,7 +1333,7 @@ WebIDL::ExceptionOr<DeprecatedString> Node::serialize_fragment(DOMParsing::Requi
 
     // 2. If context document is an HTML document, return an HTML serialization of node.
     if (context_document.is_html_document())
-        return HTML::HTMLParser::serialize_html_fragment(*this);
+        return HTML::HTMLParser::serialize_html_fragment(*this).to_deprecated_string();
 
     // 3. Otherwise, context document is an XML document; return an XML serialization of node passing the flag require well-formed.
     return DOMParsing::serialize_node_to_xml_string(*this, require_well_formed);

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
@@ -665,10 +665,7 @@ JS::NonnullGCPtr<DOM::Element> HTMLParser::create_element_for(HTMLToken const& t
     auto const& local_name = token.tag_name();
 
     // 5. Let is be the value of the "is" attribute in the given token, if such an attribute exists, or null otherwise.
-    auto is_value_deprecated_string = token.attribute(AttributeNames::is);
-    Optional<String> is_value;
-    if (!is_value_deprecated_string.is_null())
-        is_value = String::from_utf8(is_value_deprecated_string).release_value_but_fixme_should_propagate_errors();
+    auto is_value = token.attribute(AttributeNames::is);
 
     // 6. Let definition be the result of looking up a custom element definition given document, given namespace, local name, and is.
     auto definition = document->lookup_custom_element_definition(namespace_, local_name, is_value);
@@ -2286,7 +2283,7 @@ void HTMLParser::handle_in_body(HTMLToken& token)
 
         // If the token does not have an attribute with the name "type", or if it does, but that attribute's value is not an ASCII case-insensitive match for the string "hidden", then: set the frameset-ok flag to "not ok".
         auto type_attribute = token.attribute(HTML::AttributeNames::type);
-        if (type_attribute.is_null() || !type_attribute.equals_ignoring_ascii_case("hidden"sv)) {
+        if (!type_attribute.has_value() || !type_attribute->equals_ignoring_ascii_case("hidden"sv)) {
             m_frameset_ok = false;
         }
         return;
@@ -3285,7 +3282,7 @@ void HTMLParser::handle_in_table(HTMLToken& token)
         // or if it does, but that attribute's value is not an ASCII case-insensitive match for the string "hidden",
         // then: act as described in the "anything else" entry below.
         auto type_attribute = token.attribute(HTML::AttributeNames::type);
-        if (type_attribute.is_null() || !type_attribute.equals_ignoring_ascii_case("hidden"sv)) {
+        if (!type_attribute.has_value() || !type_attribute->equals_ignoring_ascii_case("hidden"sv)) {
             goto AnythingElse;
         }
 

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
@@ -4303,33 +4303,29 @@ String HTMLParser::serialize_html_fragment(DOM::Node const& node)
             // 4. For each attribute that the element has, append a U+0020 SPACE character, the attribute's serialized name as described below, a U+003D EQUALS SIGN character (=),
             //    a U+0022 QUOTATION MARK character ("), the attribute's value, escaped as described below in attribute mode, and a second U+0022 QUOTATION MARK character (").
             //    NOTE: The order of attributes is implementation-defined. The only constraint is that the order must be stable.
-            element.for_each_attribute([&](auto& name, auto& value) {
+            element.for_each_attribute([&](auto const& attribute) {
                 builder.append(' ');
 
                 // An attribute's serialized name for the purposes of the previous paragraph must be determined as follows:
 
-                // FIXME: -> If the attribute has no namespace:
-                //              The attribute's serialized name is the attribute's local name.
-                //           (We currently always do this)
-                builder.append(name);
-
-                // FIXME: -> If the attribute is in the XML namespace:
-                //             The attribute's serialized name is the string "xml:" followed by the attribute's local name.
-
-                // FIXME: -> If the attribute is in the XMLNS namespace and the attribute's local name is xmlns:
-                //             The attribute's serialized name is the string "xmlns".
-
-                // FIXME: -> If the attribute is in the XMLNS namespace and the attribute's local name is not xmlns:
-                //             The attribute's serialized name is the string "xmlns:" followed by the attribute's local name.
-
-                // FIXME: -> If the attribute is in the XLink namespace:
-                //             The attribute's serialized name is the string "xlink:" followed by the attribute's local name.
-
-                // FIXME: -> If the attribute is in some other namespace:
-                //             The attribute's serialized name is the attribute's qualified name.
+                // NOTE: As far as I can tell, these steps are equivalent to just using the qualified name.
+                //
+                // -> If the attribute has no namespace:
+                //         The attribute's serialized name is the attribute's local name.
+                // -> If the attribute is in the XML namespace:
+                //         The attribute's serialized name is the string "xml:" followed by the attribute's local name.
+                // -> If the attribute is in the XMLNS namespace and the attribute's local name is xmlns:
+                //         The attribute's serialized name is the string "xmlns".
+                // -> If the attribute is in the XMLNS namespace and the attribute's local name is not xmlns:
+                //         The attribute's serialized name is the string "xmlns:" followed by the attribute's local name.
+                // -> If the attribute is in the XLink namespace:
+                //         The attribute's serialized name is the string "xlink:" followed by the attribute's local name.
+                // -> If the attribute is in some other namespace:
+                //         The attribute's serialized name is the attribute's qualified name.
+                builder.append(attribute.name());
 
                 builder.append("=\""sv);
-                builder.append(escape_string(value, AttributeMode::Yes));
+                builder.append(escape_string(attribute.value(), AttributeMode::Yes));
                 builder.append('"');
             });
 

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
@@ -3849,19 +3849,19 @@ JS::NonnullGCPtr<HTMLParser> HTMLParser::create(DOM::Document& document, StringV
 }
 
 // https://html.spec.whatwg.org/multipage/parsing.html#html-fragment-serialisation-algorithm
-DeprecatedString HTMLParser::serialize_html_fragment(DOM::Node const& node)
+String HTMLParser::serialize_html_fragment(DOM::Node const& node)
 {
     // The algorithm takes as input a DOM Element, Document, or DocumentFragment referred to as the node.
     VERIFY(node.is_element() || node.is_document() || node.is_document_fragment());
     JS::NonnullGCPtr<DOM::Node const> actual_node = node;
 
     if (is<DOM::Element>(node)) {
-        auto& element = verify_cast<DOM::Element>(node);
+        auto const& element = verify_cast<DOM::Element>(node);
 
         // 1. If the node serializes as void, then return the empty string.
         //    (NOTE: serializes as void is defined only on elements in the spec)
         if (element.serializes_as_void())
-            return DeprecatedString::empty();
+            return String {};
 
         // 3. If the node is a template element, then let the node instead be the template element's template contents (a DocumentFragment node).
         //    (NOTE: This is out of order of the spec to avoid another dynamic cast. The second step just creates a string builder, so it shouldn't matter)
@@ -3874,7 +3874,7 @@ DeprecatedString HTMLParser::serialize_html_fragment(DOM::Node const& node)
         Yes,
     };
 
-    auto escape_string = [](StringView string, AttributeMode attribute_mode) -> DeprecatedString {
+    auto escape_string = [](StringView string, AttributeMode attribute_mode) -> String {
         // https://html.spec.whatwg.org/multipage/parsing.html#escapingString
         StringBuilder builder;
         for (auto code_point : Utf8View { string }) {
@@ -3895,7 +3895,7 @@ DeprecatedString HTMLParser::serialize_html_fragment(DOM::Node const& node)
             else
                 builder.append_code_point(code_point);
         }
-        return builder.to_deprecated_string();
+        return MUST(builder.to_string());
     };
 
     // 2. Let s be a string, and initialize it to the empty string.
@@ -4048,7 +4048,7 @@ DeprecatedString HTMLParser::serialize_html_fragment(DOM::Node const& node)
     });
 
     // 5. Return s.
-    return builder.to_deprecated_string();
+    return MUST(builder.to_string());
 }
 
 // https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#current-dimension-value

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.h
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.h
@@ -58,7 +58,7 @@ public:
     DOM::Document& document();
 
     static Vector<JS::Handle<DOM::Node>> parse_html_fragment(DOM::Element& context_element, StringView);
-    static DeprecatedString serialize_html_fragment(DOM::Node const& node);
+    static String serialize_html_fragment(DOM::Node const& node);
 
     enum class InsertionMode {
 #define __ENUMERATE_INSERTION_MODE(mode) mode,

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.h
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.h
@@ -245,7 +245,7 @@ public:
         }
     }
 
-    StringView attribute(FlyString const& attribute_name) const
+    Optional<String> attribute(FlyString const& attribute_name) const
     {
         if (auto result = raw_attribute(attribute_name); result.has_value())
             return result->value;
@@ -268,7 +268,7 @@ public:
 
     bool has_attribute(FlyString const& attribute_name) const
     {
-        return !attribute(attribute_name).is_null();
+        return attribute(attribute_name).has_value();
     }
 
     void adjust_tag_name(FlyString const& old_name, FlyString const& new_name)


### PR DESCRIPTION
I started these changes trying to figure out why some namespaces weren't being set on some attributes like I expected. I didn't figure out what was causing that, and in that investigation, ended up adding some spec comments to the HTML parser, and removing some FIXME's for how attributes are serialized (as far as I can tell, we already serialize these properly). So here's that PR!