### PR TITLE
LibIDL: Disallow invalid nullable types; require 'attribute' keyword

### DIFF
--- a/Userland/Libraries/LibIDL/IDLParser.cpp
+++ b/Userland/Libraries/LibIDL/IDLParser.cpp
@@ -272,6 +272,8 @@ void Parser::parse_attribute(HashMap<DeprecatedString, DeprecatedString>& extend
 
     if (lexer.consume_specific("attribute"))
         consume_whitespace();
+    else
+        report_parsing_error("expected 'attribute'"sv, filename, input, lexer.tell());
 
     auto type = parse_type();
     consume_whitespace();


### PR DESCRIPTION
Makes the IDLGenerator reject the syntax errors that are fixed in #21882. Requires that PR to go in first, since otherwise the build would break. 