### PR TITLE
Shell: Allow to parse command interactively when hitting Enter key

### DIFF
--- a/Userland/Shell/Shell.cpp
+++ b/Userland/Shell/Shell.cpp
@@ -2149,7 +2149,7 @@ bool Shell::has_history_event(StringView source)
 void Shell::setup_keybinds()
 {
     m_editor->register_key_input_callback('\n', [this](Line::Editor& editor) {
-        auto ast = parse(editor.line(), false);
+        auto ast = parse(editor.line(), m_is_interactive);
         if (ast && ast->is_syntax_error() && ast->syntax_error_node().is_continuable())
             return true;
 


### PR DESCRIPTION
Fixes #21884 
Look like we forgot to pass `m_is_interactive` when we parse command every time user hit Enter, that produces inconsistent  AST.

Here's the AST dump for `echo !*` after it get parsed:
```
339.128 Shell(41:41): echo !*
339.128 Shell(41:41): Execute at 0:7 (from 0.0 to 0.7)
339.135 Shell(41:41):   Sequence at 0:7 (from 0.0 to 0.7)
339.135 Shell(41:41):     CastToCommand at 0:7 (from 0.0 to 0.7)
339.143 Shell(41:41):       ListConcatenate at 0:7 (from 0.0 to 0.7)
339.148 Shell(41:41):         BarewordLiteral at 0:4 (from 0.0 to 0.4)
339.153 Shell(41:41):           echo
339.153 Shell(41:41):         Glob at 5:7 (from 0.5 to 0.7)
339.160 Shell(41:41):           !*
339.160 Shell(41:41): --------------------
339.165 Shell(41:41): echo !*
339.168 Shell(41:41): Execute at 0:7 (from 0.0 to 0.7)
339.173 Shell(41:41):   Sequence at 0:7 (from 0.0 to 0.7)
339.173 Shell(41:41):     CastToCommand at 0:7 (from 0.0 to 0.7)
339.182 Shell(41:41):       ListConcatenate at 0:7 (from 0.0 to 0.7)
339.187 Shell(41:41):         BarewordLiteral at 0:4 (from 0.0 to 0.4)
339.193 Shell(41:41):           echo
339.193 Shell(41:41):         HistoryEvent at 5:7 (from 0.5 to 0.7)
339.201 Shell(41:41):           Event Selector
339.201 Shell(41:41):             StartingStringLookup
339.212 Shell(41:41):               0()
339.212 Shell(41:41):           Word Selector
339.224 Shell(41:41):             Range Start
339.224 Shell(41:41):               Index 1
339.230 Shell(41:41):             Range End
339.234 Shell(41:41):               Last
```

And here's for `echo !$`:
```
383.279 Shell(41:41): --------------------
383.285 Shell(41:41): echo !$
383.287 Shell(41:41): Execute at 0:7 (from 0.0 to 0.7)
383.292 Shell(41:41):   Sequence at 0:7 (from 0.0 to 0.7)
383.296 Shell(41:41):     CastToCommand at 0:7 (from 0.0 to 0.7)
383.300 Shell(41:41):       ListConcatenate at 0:7 (from 0.0 to 0.7)
383.309 Shell(41:41):         BarewordLiteral at 0:4 (from 0.0 to 0.4)
383.309 Shell(41:41):           echo
383.318 Shell(41:41):         HistoryEvent at 5:7 (from 0.5 to 0.7)
383.318 Shell(41:41):           Event Selector
383.326 Shell(41:41):             StartingStringLookup
383.326 Shell(41:41):               0()
383.333 Shell(41:41):           Word Selector
383.336 Shell(41:41):             Direct Address
383.343 Shell(41:41):               Last
383.709 Shell(41:41): --------------------
383.714 Shell(41:41): echo !$
383.717 Shell(41:41): Execute at 0:7 (from 0.0 to 0.7)
383.722 Shell(41:41):   Sequence at 0:7 (from 0.0 to 0.7)
383.727 Shell(41:41):     CastToCommand at 0:7 (from 0.0 to 0.7)
383.732 Shell(41:41):       ListConcatenate at 0:7 (from 0.0 to 0.7)
383.737 Shell(41:41):         BarewordLiteral at 0:4 (from 0.0 to 0.4)
383.737 Shell(41:41):           echo
383.745 Shell(41:41):         Juxtaposition at 5:7 (from 0.5 to 0.7)
383.750 Shell(41:41):           BarewordLiteral at 5:6 (from 0.5 to 0.6)
383.756 Shell(41:41):             !
383.756 Shell(41:41):           SyntaxError at 6:7 (from 0.6 to 0.7)
383.762 Shell(41:41):             (Error text)
383.766 Shell(41:41):               Expected a command
383.770 Shell(41:41):             (Can be recovered from)
383.773 Shell(41:41):               true
383.773 Shell(41:41): --------------------
```