### PR TITLE
LibGfx/ICC: Avoid overflow when creating MultiLocalizedUnicodeTagData

### DIFF
--- a/Userland/Libraries/LibGfx/ICC/TagTypes.cpp
+++ b/Userland/Libraries/LibGfx/ICC/TagTypes.cpp
@@ -1151,7 +1151,10 @@ ErrorOr<NonnullRefPtr<TextDescriptionTagData>> TextDescriptionTagData::from_byte
     u8 macintosh_description_length = *cursor;
     cursor += 1;
 
-    if (macintosh_description_length > 67)
+    Checked<u32> macintosh_description_end = unicode_desciption_end;
+    macintosh_description_end += 3;
+    macintosh_description_end += macintosh_description_length;
+    if (macintosh_description_length > 67 || macintosh_description_end.has_overflow() || macintosh_description_end.value() > bytes.size())
         return Error::from_string_literal("ICC::Profile: textDescriptionType ScriptCode description too long");
 
     u8 const* macintosh_description_data = cursor;


### PR DESCRIPTION
Previously, it was possible for a `MultiLocalizedUnicodeTagData` object with a incorrect length or offset fields to cause a buffer overflow.

This PR also fixes another buffer overflow when creating a `TextDescriptionTagData` object with an incorrect Macintosh ScriptCode description length.

Fixes oss fuzz issue [64079](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=64079)