### PR TITLE
LibLine: Capture the current origin immediately after ^C

### DIFF
--- a/Userland/Libraries/LibLine/Editor.cpp
+++ b/Userland/Libraries/LibLine/Editor.cpp
@@ -622,7 +622,6 @@ ErrorOr<void> Editor::interrupted()
         TRY(reposition_cursor(*stderr_stream, true));
         if (TRY(m_suggestion_display->cleanup()))
             TRY(reposition_cursor(*stderr_stream, true));
-        TRY(stderr_stream->write_until_depleted("\n"sv.bytes()));
     }
     m_buffer.clear();
     m_chars_touched_in_the_middle = buffer().size();
@@ -817,7 +816,7 @@ void Editor::handle_interrupt_event()
 
     m_previous_interrupt_was_handled_as_interrupt = true;
 
-    fprintf(stderr, "^C");
+    fprintf(stderr, "^C\r\n");
     fflush(stderr);
 
     if (on_interrupt_handled)
@@ -826,6 +825,7 @@ void Editor::handle_interrupt_event()
     m_buffer.clear();
     m_chars_touched_in_the_middle = buffer().size();
     m_cursor = 0;
+    set_origin(false);
 
     finish();
 }


### PR DESCRIPTION
Otherwise a subsequent event (^C or resize) will make LibLine use the previous origin instead of the real current one.
(fix for the bug #21765 was trying to fix)