### PR TITLE
AK: Reject BitStream reads beyond EOF

### DIFF
--- a/AK/BitStream.h
+++ b/AK/BitStream.h
@@ -29,8 +29,8 @@ public:
     {
         if (m_current_byte.has_value() && is_aligned_to_byte_boundary()) {
             bytes[0] = m_current_byte.release_value();
-            // FIXME: This accidentally slices off the first byte of the returned span.
-            return m_stream->read_some(bytes.slice(1));
+            auto freshly_read_bytes = TRY(m_stream->read_some(bytes.slice(1)));
+            return bytes.trim(1 + freshly_read_bytes.size());
         }
         align_to_byte_boundary();
         return m_stream->read_some(bytes);

--- a/AK/BitStream.h
+++ b/AK/BitStream.h
@@ -156,7 +156,7 @@ public:
         FillWithZero,
     };
 
-    explicit LittleEndianInputBitStream(MaybeOwned<Stream> stream, UnsatisfiableReadBehavior unsatisfiable_read_behavior = UnsatisfiableReadBehavior::FillWithZero)
+    explicit LittleEndianInputBitStream(MaybeOwned<Stream> stream, UnsatisfiableReadBehavior unsatisfiable_read_behavior = UnsatisfiableReadBehavior::Reject)
         : LittleEndianBitStream(move(stream))
         , m_unsatisfiable_read_behavior(unsatisfiable_read_behavior)
     {

--- a/Userland/Libraries/LibGfx/ImageFormats/WebPLoaderLossless.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/WebPLoaderLossless.cpp
@@ -26,7 +26,7 @@ ErrorOr<VP8LHeader> decode_webp_chunk_VP8L_header(ReadonlyBytes vp8l_data)
         return Error::from_string_literal("WebPImageDecoderPlugin: VP8L chunk too small");
 
     FixedMemoryStream memory_stream { vp8l_data.trim(5) };
-    LittleEndianInputBitStream bit_stream { MaybeOwned<Stream>(memory_stream) };
+    LittleEndianInputBitStream bit_stream { MaybeOwned<Stream>(memory_stream), LittleEndianInputBitStream::UnsatisfiableReadBehavior::FillWithZero };
 
     u8 signature = TRY(bit_stream.read_bits(8));
     if (signature != 0x2f)
@@ -931,7 +931,7 @@ ErrorOr<NonnullRefPtr<Bitmap>> ColorIndexingTransform::transform(NonnullRefPtr<B
 ErrorOr<NonnullRefPtr<Bitmap>> decode_webp_chunk_VP8L_contents(VP8LHeader const& vp8l_header)
 {
     FixedMemoryStream memory_stream { vp8l_header.lossless_data };
-    LittleEndianInputBitStream bit_stream { MaybeOwned<Stream>(memory_stream) };
+    LittleEndianInputBitStream bit_stream { MaybeOwned<Stream>(memory_stream), LittleEndianInputBitStream::UnsatisfiableReadBehavior::FillWithZero };
 
     // image-stream = optional-transform spatially-coded-image
 


### PR DESCRIPTION
With the exception of [WebP](https://chromium.googlesource.com/webm/libwebp/+/24d7f9cb6ef1ef90a04d7b6c15d3477813f75ee0/src/utils/bit_reader_utils.c#220), being able to read null bits beyond the end of a Stream is almost always unintentional and can lead to infinite loops if `0` isn't the "end of stream" symbol by accident.

Fixes #21869.
Fixes [oss-fuzz issue 58046](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=58046).
Fixes [oss-fuzz issue 62111](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=62111).
Supersedes #18448.