### PR TITLE
Solitaire: Option to solve the end of the game automatically

### DIFF
--- a/Userland/Games/Solitaire/Game.h
+++ b/Userland/Games/Solitaire/Game.h
@@ -2,6 +2,7 @@
  * Copyright (c) 2020, Till Mayer <till.mayer@web.de>
  * Copyright (c) 2021-2023, Sam Atkins <atkinssj@serenityos.org>
  * Copyright (c) 2022, the SerenityOS developers.
+ * Copyright (c) 2023, David Ganz <david.g.ganz@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -45,10 +46,14 @@ public:
     bool is_auto_collecting() const { return m_auto_collect; }
     void set_auto_collect(bool collect) { m_auto_collect = collect; }
 
+    bool can_solve();
+    void start_solving();
+
     Function<void(uint32_t)> on_score_update;
     Function<void()> on_game_start;
     Function<void(GameOverReason, uint32_t)> on_game_end;
     Function<void(bool)> on_undo_availability_change;
+    Function<void()> on_move;
 
 private:
     Game();
@@ -188,6 +193,7 @@ private:
     void check_for_game_over();
     void clear_hovered_stack();
     void deal_next_card();
+    void step_solve();
 
     virtual void paint_event(GUI::PaintEvent&) override;
     virtual void mousedown_event(GUI::MouseEvent&) override;
@@ -211,6 +217,7 @@ private:
         GameInProgress,
         StartGameOverAnimationNextFrame,
         GameOverAnimation,
+        Solving,
     };
     State m_state { State::WaitingForNewGame };
 

--- a/Userland/Games/Solitaire/Solitaire.gml
+++ b/Userland/Games/Solitaire/Solitaire.gml
@@ -7,6 +7,25 @@
         fill_with_background_color: true
     }
 
+    @GUI::Frame {
+        name: "game_action_bar"
+        fill_with_background_color: true
+        fixed_height: 32
+        layout: @GUI::HorizontalBoxLayout {
+            margins: [3]
+        }
+
+        @GUI::Layout::Spacer {}
+
+        @GUI::Button {
+            name: "solve_button"
+            text: "Solve"
+            fixed_width: 80
+        }
+
+        @GUI::Layout::Spacer {}
+    }
+
     @GUI::Statusbar {
         name: "statusbar"
         segment_count: 3

--- a/Userland/Libraries/LibGUI/Widget.cpp
+++ b/Userland/Libraries/LibGUI/Widget.cpp
@@ -152,15 +152,12 @@ Widget::Widget()
 
     register_property(
         "background_color", [this]() -> JsonValue { return palette().color(background_role()).to_deprecated_string(); },
-        [this](auto& value) {
-            auto c = Color::from_string(value.to_deprecated_string());
-            if (c.has_value()) {
-                auto _palette = palette();
-                _palette.set_color(background_role(), c.value());
-                set_palette(_palette);
-                return true;
-            }
-            return false;
+        [this](JsonValue const& value) {
+            auto color_str = String::from_deprecated_string(value.to_deprecated_string());
+            if (color_str.is_error())
+                return false;
+
+            return set_background_color(color_str.release_value());
         });
 
     register_property(
@@ -1083,6 +1080,22 @@ void Widget::set_foreground_role(ColorRole role)
 {
     m_foreground_role = role;
     update();
+}
+
+bool Widget::set_background_color(String color_str)
+{
+    auto color = Color::from_string(color_str.to_deprecated_string());
+    if (!color.has_value())
+        return false;
+    set_background_color(color.release_value());
+    return true;
+}
+
+void Widget::set_background_color(Gfx::Color color)
+{
+    auto _palette = palette();
+    _palette.set_color(background_role(), color);
+    set_palette(_palette);
 }
 
 Gfx::Palette Widget::palette() const

--- a/Userland/Libraries/LibGUI/Widget.h
+++ b/Userland/Libraries/LibGUI/Widget.h
@@ -254,6 +254,9 @@ public:
     Gfx::ColorRole foreground_role() const { return m_foreground_role; }
     void set_foreground_role(Gfx::ColorRole);
 
+    bool set_background_color(String);
+    void set_background_color(Gfx::Color);
+
     void set_autofill(bool b) { set_fill_with_background_color(b); }
 
     Window* window()


### PR DESCRIPTION
In Solitaire, when all cards are revealed (i.e. the stock stack is empty and all cards on the normal stacks are revealed), solving the game is trivial since you merely need to sort the cards to the foundation stacks. To make this less annoying, the game will now show a button once this condition is met, which will sort the cards automatically.

![serenity_solvitaire_demo](https://github.com/SerenityOS/serenity/assets/66440035/e70774d9-f5d8-4b61-97c1-33d947476eec)