### PR TITLE
LibWeb: Check for invalid SVG viewBox sizes 

### DIFF
--- a/Tests/LibWeb/Layout/expected/svg/svg-with-zero-sized-viewBox.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-with-zero-sized-viewBox.txt
@@ -1,0 +1,16 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x100 children: inline
+      line 0 width: 100, height: 100, bottom: 100, baseline: 100
+        frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,8 100x100]
+      SVGSVGBox <svg> at (8,8) content-size 100x100 [SVG] children: inline
+        TextNode <#text>
+        SVGTextBox <text> (not painted) children: inline
+          TextNode <#text>
+        TextNode <#text>
+      TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x100]
+      SVGSVGPaintable (SVGSVGBox<svg>) [8,8 100x100]

--- a/Tests/LibWeb/Layout/input/svg/svg-with-zero-sized-viewBox.html
+++ b/Tests/LibWeb/Layout/input/svg/svg-with-zero-sized-viewBox.html
@@ -1,0 +1,3 @@
+<svg width="100" height="100" viewBox="0 0 0 0">
+  <text>Hello!</text>
+</svg>

--- a/Userland/Libraries/LibWeb/Layout/SVGFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/SVGFormattingContext.cpp
@@ -215,8 +215,6 @@ void SVGFormattingContext::run(Box const& box, LayoutMode layout_mode, Available
             } else if (is<SVGTextBox>(descendant)) {
                 auto& text_element = static_cast<SVG::SVGTextPositioningElement&>(dom_node);
 
-                // FIXME: Support arbitrary path transforms for fonts.
-                // FIMXE: This assumes transform->x_scale() == transform->y_scale().
                 auto& font = graphics_box.font();
                 auto text_contents = text_element.text_contents();
                 Utf8View text_utf8 { text_contents };


### PR DESCRIPTION
Now https://www.fandom.com/fancentral/home loads and displays:
![image](https://github.com/SerenityOS/serenity/assets/11597044/5209aafa-9186-4149-8fa5-48d7e0d2f06a)
...before hanging... but progress :)