### PR TITLE
LibWeb: Output audio in stereo regardless of the encoded channel count

### DIFF
--- a/Userland/Libraries/LibAudio/PlaybackStreamSerenity.cpp
+++ b/Userland/Libraries/LibAudio/PlaybackStreamSerenity.cpp
@@ -10,8 +10,12 @@
 
 namespace Audio {
 
-ErrorOr<NonnullRefPtr<PlaybackStream>> PlaybackStreamSerenity::create(OutputState initial_state, u32 sample_rate, [[maybe_unused]] u8 channels, [[maybe_unused]] u32 target_latency_ms, AudioDataRequestCallback&& data_request_callback)
+ErrorOr<NonnullRefPtr<PlaybackStream>> PlaybackStreamSerenity::create(OutputState initial_state, u32 sample_rate, u8 channels, [[maybe_unused]] u32 target_latency_ms, AudioDataRequestCallback&& data_request_callback)
 {
+    // ConnectionToServer can only handle stereo audio currently. If it is able to accept mono audio
+    // later, this can be removed.
+    VERIFY(channels == 2);
+
     VERIFY(data_request_callback);
     auto connection = TRY(ConnectionToServer::try_create());
     if (auto result = connection->try_set_self_sample_rate(sample_rate); result.is_error())

--- a/Userland/Libraries/LibWeb/Platform/AudioCodecPluginAgnostic.cpp
+++ b/Userland/Libraries/LibWeb/Platform/AudioCodecPluginAgnostic.cpp
@@ -37,8 +37,10 @@ ErrorOr<NonnullOwnPtr<AudioCodecPluginAgnostic>> AudioCodecPluginAgnostic::creat
     auto plugin = TRY(adopt_nonnull_own_or_enomem(new (nothrow) AudioCodecPluginAgnostic(loader, duration, move(update_timer))));
 
     constexpr u32 latency_ms = 100;
+    // FIXME: Audio loaders are hard-coded to output stereo audio. Once that changes, the channel count provided
+    //        below should be retrieved from the audio loader instead of being hard-coded to 2.
     RefPtr<Audio::PlaybackStream> output = TRY(Audio::PlaybackStream::create(
-        Audio::OutputState::Suspended, loader->sample_rate(), loader->num_channels(), latency_ms,
+        Audio::OutputState::Suspended, loader->sample_rate(), /* channels = */ 2, latency_ms,
         [&plugin = *plugin, loader](Bytes buffer, Audio::PcmSampleFormat format, size_t sample_count) -> ReadonlyBytes {
             VERIFY(format == Audio::PcmSampleFormat::Float32);
             auto samples = loader->get_more_samples(sample_count).release_value_but_fixme_should_propagate_errors();


### PR DESCRIPTION
Audio loaders currently always output two channels, even if they were encoded as mono. Therefore, we have to hardcode the channel count in our audio plugin to avoid crashing until we can handle mono or multi-channel audio better.

Fixes #21898

I've also added an assertion that prevents us from creating Serenity playback streams with a channel count other than 2, since the audio server doesn't know about non-stereo audio.