### PR TITLE
LibPDF: Detect DCT images correctly

### DIFF
--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -830,7 +830,8 @@ PDFErrorOr<NonnullRefPtr<Gfx::Bitmap>> Renderer::load_image(NonnullRefPtr<Stream
         if (filter_object->is<NameObject>())
             return filter_object->cast<NameObject>()->name() == name;
         auto filters = filter_object->cast<ArrayObject>();
-        return MUST(filters->get_name_at(m_document, 0))->name() == name;
+        auto last_filter_index = filters->elements().size() - 1;
+        return MUST(filters->get_name_at(m_document, last_filter_index))->name() == name;
     };
     if (TRY(is_filter(CommonNames::JPXDecode))) {
         return Error(Error::Type::RenderingUnsupported, "JPXDecode filter");


### PR DESCRIPTION
Let's turn:
![ThinkingInPostScript.pdf_p1_before](https://github.com/SerenityOS/serenity/assets/26030965/61e0566a-075a-4bfd-8aad-db0f884aa8f4)

Into:
![ThinkingInPostScript.pdf_p1_after](https://github.com/SerenityOS/serenity/assets/26030965/44e8679a-ce87-457c-956b-72a36ce67343)

Disclaimer: these two needs LZW patches first, if you want to see them too, contact your local maintainer and ask them to merge #21896 <sup><sub>and a follow-up PR</sub></sup>