### PR TITLE
LibJS/JIT+LibJIT: Register ELF images for JITted code using the GDB JIT Interface

### DIFF
--- a/Userland/Libraries/LibELF/ELFBuild.cpp
+++ b/Userland/Libraries/LibELF/ELFBuild.cpp
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2023, Jesús Lapastora <cyber.gsuscode@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibELF/ELFBuild.h>
+namespace ELF {
+
+SectionTable::Index StringTable::emit_into_builder(u32 name_index, SectionTable& builder) const noexcept
+{
+    return builder.append(emit_section(name_index));
+}
+
+Section StringTable::emit_section(u32 name_index) const noexcept
+{
+    Elf64_Shdr header {};
+    header.sh_name = name_index;
+    header.sh_type = SHT_STRTAB;
+    header.sh_flags = 0;
+    header.sh_addr = 0;
+    header.sh_link = 0;
+    header.sh_info = 0;
+    header.sh_entsize = 0;
+    header.sh_addralign = 0;
+    return Section(m_data.span(), header);
+}
+
+u32 StringTable::insert(StringView str) noexcept
+{
+    // The offsets for sh_name and st_name are 32-bit unsigned integers, so it
+    // won't make sense to address a string table bigger than what u32 can
+    // provide.
+    VERIFY(m_data.size() < NumericLimits<u32>::max());
+    auto const offset = static_cast<u32>(m_data.size());
+
+    auto const final_size = m_data.size() + str.length() + 1;
+    VERIFY(final_size < NumericLimits<u32>::max());
+
+    m_data.ensure_capacity(m_data.size() + str.length() + 1);
+
+    for (auto ch : str) {
+        VERIFY(ch != 0);
+        m_data.unchecked_append(ch);
+    }
+    m_data.append(0);
+    return offset;
+}
+
+FixedArray<u8> build_elf_image(u64 shstrndx, Elf64_Quarter image_type, ReadonlySpan<Section> sections)
+{
+    Checked<u64> final_image_size = sizeof(Elf64_Ehdr);
+    Vector<u64> section_offsets;
+    section_offsets.ensure_capacity(sections.size());
+
+    auto const sections_begin = final_image_size.value_unchecked();
+    final_image_size += sizeof(Elf64_Shdr) * sections.size();
+
+    for (auto const& section : sections) {
+        auto const offset = final_image_size.value();
+        section_offsets.unchecked_append(offset);
+        if (section.data.has_value()) {
+            final_image_size += section.data.value().size();
+        }
+    }
+
+    auto image = MUST(FixedArray<u8>::create(final_image_size.value()));
+
+    {
+        auto section_headers = Span<Elf64_Shdr> {
+            reinterpret_cast<Elf64_Shdr*>(image.span().offset_pointer(sections_begin)),
+            sections.size(),
+        };
+        for (size_t i = 0; i < sections.size(); ++i) {
+            section_headers[i] = sections[i].header;
+            section_headers[i].sh_offset = section_offsets[i];
+            if (sections[i].data.has_value()) {
+                auto const data = sections[i].data.value();
+                auto const data_in_elf = image.span().slice(section_offsets[i], data.size());
+                data.copy_to(data_in_elf);
+                section_headers[i].sh_size = data.size();
+            }
+        }
+    }
+
+    {
+        auto* const final_elf_hdr = reinterpret_cast<Elf64_Ehdr*>(image.data());
+        final_elf_hdr->e_ident[EI_MAG0] = 0x7f;
+        final_elf_hdr->e_ident[EI_MAG1] = 'E';
+        final_elf_hdr->e_ident[EI_MAG2] = 'L';
+        final_elf_hdr->e_ident[EI_MAG3] = 'F';
+        final_elf_hdr->e_ident[EI_CLASS] = ELFCLASS64;
+        // FIXME: This is platform-dependent. Any big-endian host will write the
+        // data in MSB format, so the EI_DATA field should be set to
+        // ELFDATA2MSB.
+        final_elf_hdr->e_ident[EI_DATA] = ELFDATA2LSB;
+        final_elf_hdr->e_ident[EI_VERSION] = EV_CURRENT;
+        // FIXME: This is platform-dependent. The host must set the OSABI to the
+        // one of the image target.
+        final_elf_hdr->e_ident[EI_OSABI] = ELFOSABI_SYSV;
+        final_elf_hdr->e_ident[EI_ABIVERSION] = 0;
+        auto padding = Bytes {
+            &final_elf_hdr->e_ident[EI_PAD],
+            EI_NIDENT - EI_PAD,
+        };
+        padding.fill(0);
+
+        final_elf_hdr->e_type = image_type;
+        // FIXME: This is platform-dependent. This must be set to the host
+        // architecture.
+        final_elf_hdr->e_machine = EM_AMD64;
+        final_elf_hdr->e_version = EV_CURRENT;
+
+        // Currently segments aren't supported, hence no program headers.
+        // FIXME: Update program header info on ELF header when adding segment
+        // information.
+        final_elf_hdr->e_phoff = 0;
+        final_elf_hdr->e_phnum = 0;
+        final_elf_hdr->e_phentsize = 0;
+
+        final_elf_hdr->e_shoff = sections_begin;
+        final_elf_hdr->e_shnum = sections.size();
+        final_elf_hdr->e_shentsize = sizeof(Section::header);
+
+        // FIXME: This is platform-dependent. The flags field should be in sync
+        // with the architecture flags assumed in the code sections, otherwise
+        // instructions may be misinterpreted.
+        final_elf_hdr->e_flags = 0;
+
+        final_elf_hdr->e_ehsize = sizeof(*final_elf_hdr);
+        final_elf_hdr->e_shstrndx = shstrndx;
+    }
+
+    return image;
+}
+};

--- a/Userland/Libraries/LibELF/ELFBuild.h
+++ b/Userland/Libraries/LibELF/ELFBuild.h
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 2023, Jesús Lapastora <cyber.gsuscode@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+// Collection of utilities to produce an in-memory ELF file in the same format
+// as the host.
+
+#include <AK/FixedArray.h>
+#include <AK/Span.h>
+#include <AK/Vector.h>
+#include <LibELF/ELFABI.h>
+
+namespace ELF {
+
+// Represents an ELF Section that is optionally bound to some data.
+struct Section {
+    Elf64_Shdr header;
+    Optional<ReadonlyBytes> data {};
+
+    explicit Section(Elf64_Shdr header)
+        : header(header)
+    {
+    }
+    Section(ReadonlyBytes data, Elf64_Shdr header)
+        : header(header)
+        , data(data)
+    {
+    }
+};
+
+// Receives a list of sections, and writes the following layout:
+// <elf layout> <section headers> <section data>
+//
+// Both the section headers & the data for those sections will be written in the
+// exact order as they appear in the list.
+// If a `Section` contains data, then its `sh_offset` is set to the offset in
+// the final image, and `sh_size` to the size of the specified data. `Section`s
+// that do not contain data will have their `sh_offset` set to the end offset of
+// the section that comes right before them.
+//
+// Notes on the ELF Header:
+// The elf header is mostly filled by this function. It needs help in a couple
+// of fields: `e_shstrndx` and `e_type`.
+//
+// - `shstrndx` is the index of the `Section` that contains the section name
+// string table.
+// - `image_type` is the image file type: ET_CORE, ET_REL, ET_EXEC, etc.
+FixedArray<u8> build_elf_image(u64 shstrndx, Elf64_Quarter image_type, ReadonlySpan<Section> sections);
+
+// Takes care of tracking section header indices and their order
+struct SectionTable {
+
+    struct Index {
+        u64 index;
+
+        constexpr explicit Index(u64 index)
+            : index(index)
+        {
+        }
+
+        constexpr u64 raw_index() const noexcept { return index; }
+    };
+
+    ReadonlySpan<Section> span() const noexcept { return m_sections.span(); }
+
+    // Appends a default-intialized header with no data. The client is
+    // responsible for initializing the header before producing the final image.
+    Index reserve() noexcept
+    {
+        return append(Section(Elf64_Shdr()));
+    }
+
+    // Appends a Section and returns the index to refer to it.
+    Index append(Section section) noexcept
+    {
+        auto const index = m_sections.size();
+        m_sections.append(move(section));
+        return Index(index);
+    }
+    template<typename... Args>
+    Index empend(Args&&... args) noexcept
+    {
+        auto const index = m_sections.size();
+        m_sections.empend(forward<Args>(args)...);
+        return Index(index);
+    }
+
+    // Calls `header_builder` with a reference to the Section header, so that
+    // the builder can initialize it.
+    // Returns the index for the section.
+    template<typename Builder>
+    Index build_nobits(Builder header_builder)
+    {
+        auto index = reserve();
+        build_nobits_at(index, move(header_builder));
+        return index;
+    }
+
+    // Creates a null section header. Useful for avoiding index 0 for the text
+    // section, since if we use 0 for its index then symbols that relate to
+    // .text will be misinterpreted as related to an 'undefined' section.
+    Index build_null()
+    {
+        Elf64_Shdr header {};
+        header.sh_type = SHT_NULL;
+        header.sh_name = 0;
+        return empend(header);
+    }
+
+    // Same as `build_nobits`, but writes an already reserved header instead of
+    // creating a new one.
+    template<typename Builder>
+    void build_nobits_at(Index at, Builder header_builder)
+    {
+        Elf64_Shdr header {};
+        header.sh_type = SHT_NOBITS;
+        header_builder(header);
+        new (&m_sections[at.raw_index()]) Section(header);
+    }
+
+    // Reinterprets `typed_data` as a byte slice, and calls `header_builder`
+    // with a reference to the Section header to be initialized.
+    // Sets the header's `sh_entsize` to `sizeof(T)` before calling the builder,
+    // so it can be overridden if required.
+    // Returns the index for the section.
+    template<typename T, typename Builder>
+    Index build(ReadonlySpan<T> typed_data, Builder header_builder)
+    {
+        auto index = reserve();
+        build_at(index, move(typed_data), move(header_builder));
+        return index;
+    }
+
+    // Same as `build`, but writes an already reserved header instead of
+    // creating a new one.
+    template<typename T, typename Builder>
+    void build_at(Index at, ReadonlySpan<T> typed_data, Builder header_builder)
+    {
+        Elf64_Shdr header {};
+        header.sh_entsize = sizeof(T);
+        header_builder(static_cast<Elf64_Shdr&>(header));
+        ReadonlyBytes data = ReadonlyBytes {
+            reinterpret_cast<u8 const*>(typed_data.offset(0)),
+            typed_data.size() * sizeof(T),
+        };
+        new (&m_sections[at.raw_index()]) Section(data, header);
+    }
+
+    // Makes header editing available after construction. The reference is valid
+    // until another header is added.
+    Elf64_Shdr& header_at(Index index) noexcept { return m_sections[index.raw_index()].header; }
+
+private:
+    Vector<Section> m_sections;
+};
+
+struct StringTable {
+    // Inserts the given string into the table, giving back the offset it begins
+    // at. The string must not contain any zeroes.
+    u32 insert(StringView str) noexcept;
+
+    // Emits the section information for the current state, so that it can be
+    // merged into an ELF image.
+    Section emit_section(u32 name_index) const noexcept;
+
+    // Like `emit_section`, but writes the section directly into the builder.
+    // Returns the index for the section.
+    SectionTable::Index emit_into_builder(u32 name_index, SectionTable& builder) const noexcept;
+
+private:
+    Vector<u8> m_data;
+};
+
+};

--- a/Userland/Libraries/LibJIT/CMakeLists.txt
+++ b/Userland/Libraries/LibJIT/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(SOURCES
     Assembler.cpp
+    GDB.cpp
 )
 
 serenity_lib(LibJIT jit)

--- a/Userland/Libraries/LibJIT/CMakeLists.txt
+++ b/Userland/Libraries/LibJIT/CMakeLists.txt
@@ -2,6 +2,14 @@ set(SOURCES
     Assembler.cpp
     GDB.cpp
 )
+if(NOT APPLE AND NOT WIN32 AND NOT EMSCRIPTEN)
+    list(APPEND SOURCES GDBElf.cpp)
+else()
+    list(APPEND SOURCES GDBUnsupported.cpp)
+endif()
 
 serenity_lib(LibJIT jit)
+if(NOT APPLE AND NOT WIN32 AND NOT EMSCRIPTEN)
+    target_link_libraries(LibJIT PRIVATE LibELF)
+endif()
 target_link_libraries(LibJIT PRIVATE LibCore)

--- a/Userland/Libraries/LibJIT/GDB.cpp
+++ b/Userland/Libraries/LibJIT/GDB.cpp
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2023, Jesús Lapastora <cyber.gsuscode@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Checked.h>
+#include <AK/OwnPtr.h>
+#include <AK/Span.h>
+#include <LibJIT/GDB.h>
+
+namespace JIT::GDB {
+
+// Declarations from https://sourceware.org/gdb/current/onlinedocs/gdb.html/Declarations.html#Declarations.
+enum class JitActions : u32 {
+    NoAction = 0,
+    RegisterFn = 1,
+    UnregisterFn = 2,
+};
+
+struct JitCodeEntry {
+    JitCodeEntry* next_entry;
+    JitCodeEntry* prev_entry;
+    char const* symfile_addr;
+    u64 symfile_size;
+};
+
+struct JitDescriptor {
+    u32 version;
+    JitActions action_flag;
+    JitCodeEntry* relevant_entry;
+    JitCodeEntry* first_entry;
+};
+extern "C" {
+
+// GDB puts a breakpoint in this function.
+// Use an __asm__ statement to prevent compilers from inlining/removing this
+// function.
+// From V8:
+// https://github.com/v8/v8/blob/1c7d3a94fc051e0fd69584b930faab448026941e/src/diagnostics/gdb-jit.cc#L1742
+void __attribute__((noinline)) __jit_debug_register_code();
+void __attribute__((noinline)) __jit_debug_register_code() { __asm__(""); }
+
+// Make sure to specify the version statically, because the debugger may check
+// the version before we can set it.
+// NOTE: If the JIT is multi-threaded, then it is important that the JIT synchronize any modifications to this global data properly, which can easily be done by putting a global mutex around modifications to these structures.
+JitDescriptor __jit_debug_descriptor = { 1, JitActions::NoAction, nullptr, nullptr };
+}
+
+static JitCodeEntry* find_code_entry(ReadonlyBytes data)
+{
+    auto const search_addr = bit_cast<uintptr_t>(data.offset(0));
+    for (JitCodeEntry* curr = __jit_debug_descriptor.first_entry; curr != NULL; curr = curr->next_entry) {
+        auto const entry_addr = bit_cast<uintptr_t>(curr->symfile_addr);
+        if (entry_addr == search_addr) {
+            VERIFY(curr->symfile_size == data.size());
+            return curr;
+        }
+    }
+    return NULL;
+}
+
+void unregister_from_gdb(ReadonlyBytes data)
+{
+    // Following steps from:
+    // https://sourceware.org/gdb/current/onlinedocs/gdb.html/Unregistering-Code.html#Unregistering-Code
+    auto may_have_entry = AK::adopt_own_if_nonnull(find_code_entry(data));
+    VERIFY(may_have_entry);
+    auto entry = may_have_entry.release_nonnull();
+    if (entry->prev_entry) {
+        entry->prev_entry->next_entry = entry->next_entry;
+    }
+    if (entry->next_entry) {
+        entry->next_entry->prev_entry = entry->prev_entry;
+    }
+    if (entry == __jit_debug_descriptor.first_entry) {
+        __jit_debug_descriptor.first_entry = entry->next_entry;
+    }
+    __jit_debug_descriptor.relevant_entry = entry;
+    __jit_debug_descriptor.action_flag = JitActions::UnregisterFn;
+    __jit_debug_register_code();
+}
+
+void register_into_gdb(ReadonlyBytes data)
+{
+    // Following steps from:
+    // https://sourceware.org/gdb/current/onlinedocs/gdb.html/Registering-Code.html#Registering-Code
+    auto* const leaked_entry = make<JitCodeEntry>().leak_ptr();
+
+    // Add it to the linked list in the JIT descriptor.
+    leaked_entry->symfile_addr = reinterpret_cast<char const*>(data.data());
+    leaked_entry->symfile_size = data.size();
+    leaked_entry->next_entry = __jit_debug_descriptor.first_entry;
+    leaked_entry->prev_entry = NULL;
+    if (__jit_debug_descriptor.first_entry) {
+        VERIFY(__jit_debug_descriptor.first_entry->prev_entry == nullptr);
+        __jit_debug_descriptor.first_entry->prev_entry = leaked_entry;
+    }
+    __jit_debug_descriptor.first_entry = leaked_entry;
+    __jit_debug_descriptor.relevant_entry = leaked_entry;
+    __jit_debug_descriptor.action_flag = JitActions::RegisterFn;
+    __jit_debug_register_code();
+}
+}

--- a/Userland/Libraries/LibJIT/GDB.h
+++ b/Userland/Libraries/LibJIT/GDB.h
@@ -6,10 +6,23 @@
 
 #pragma once
 
+#include <AK/FixedArray.h>
 #include <AK/Span.h>
+#include <AK/StringView.h>
 
 namespace JIT::GDB {
 
 void register_into_gdb(ReadonlyBytes data);
 void unregister_from_gdb(ReadonlyBytes data);
+
+// Build a GDB compatible image to register with the GDB JIT Interface.
+// Returns Optional since the platform may not be supported.
+// The `code` must be the region of memory that will be executed, since the
+// image will hold direct references to addresses within the code. This way GDB
+// will be able to identify the code region and insert breakpoints into it.
+// Both `file_symbol_name` and `code_symbol_name` will end up in the symbol
+// table of the image. They represent a file name for the image and a name for
+// the region of code that is being executed.
+Optional<FixedArray<u8>> build_gdb_image(ReadonlyBytes code, StringView file_symbol_name, StringView code_symbol_name);
+
 }

--- a/Userland/Libraries/LibJIT/GDB.h
+++ b/Userland/Libraries/LibJIT/GDB.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2023, Jesús Lapastora <cyber.gsuscode@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Span.h>
+
+namespace JIT::GDB {
+
+void register_into_gdb(ReadonlyBytes data);
+void unregister_from_gdb(ReadonlyBytes data);
+}

--- a/Userland/Libraries/LibJIT/GDBElf.cpp
+++ b/Userland/Libraries/LibJIT/GDBElf.cpp
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2023, Jesús Lapastora <cyber.gsuscode@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibELF/ELFBuild.h>
+#include <LibJIT/GDB.h>
+
+namespace JIT::GDB {
+
+Optional<FixedArray<u8>> build_gdb_image(ReadonlyBytes code, StringView file_symbol_name, StringView code_symbol_name)
+{
+    Vector<Elf64_Sym> symbols;
+    ELF::StringTable section_names;
+    ELF::StringTable symbol_names;
+    ELF::SectionTable sections;
+
+    auto const null_section = sections.build_null();
+
+    // empty name so that its name in the dump isn't confused with '.text'.
+    sections.header_at(null_section).sh_name = section_names.insert(""sv);
+
+    // Build .text as a NOBITS section since the code isn't loaded inside the
+    // image. The image just holds the addresses for the executable region.
+    auto const text = sections.build_nobits([&](Elf64_Shdr& text) {
+        text.sh_name = section_names.insert(".text"sv);
+        text.sh_flags = SHF_EXECINSTR | SHF_ALLOC;
+        text.sh_addr = bit_cast<u64>(code.offset(0));
+        text.sh_size = code.size();
+        text.sh_link = 0;
+        text.sh_info = 0;
+        text.sh_addralign = 1;
+        text.sh_entsize = 0;
+    });
+
+    // Without this, GDB won't show the symbol names for our code.
+    Elf64_Sym file;
+    {
+        file.st_name = symbol_names.insert(file_symbol_name);
+        file.st_info = ELF64_ST_INFO(STB_GLOBAL, STT_FILE);
+        file.st_other = STV_DEFAULT;
+        file.st_shndx = SHN_ABS;
+        file.st_value = 0;
+        file.st_size = code.size();
+    }
+    symbols.append(file);
+
+    // The index of the first symbol that does not have a `STB_LOCAL` binding.
+    // Note that all non-local bindings must come before all local bindings.
+    auto const first_non_local_symbol_index = symbols.size();
+    Elf64_Sym code_sym;
+    {
+        code_sym.st_name = symbol_names.insert(code_symbol_name);
+        code_sym.st_info = ELF64_ST_INFO(STB_GLOBAL, STT_FUNC);
+        code_sym.st_other = STV_DEFAULT;
+        code_sym.st_shndx = text.index,
+        code_sym.st_value = 0; // 0 bytes relative to .text
+        code_sym.st_size = code.size();
+    }
+    symbols.append(code_sym);
+
+    auto const strtab = symbol_names.emit_into_builder(
+        section_names.insert(".strtab"sv), sections);
+
+    sections.build<Elf64_Sym>(symbols.span(),
+        [&section_names, first_non_local_symbol_index, strtab](Elf64_Shdr& symtab) {
+            symtab.sh_name = section_names.insert(".symtab"sv);
+            symtab.sh_type = SHT_SYMTAB;
+            symtab.sh_flags = 0;
+            symtab.sh_addr = 0;
+            symtab.sh_info = first_non_local_symbol_index;
+            symtab.sh_link = strtab.raw_index();
+            symtab.sh_addralign = 0;
+        });
+
+    // Make sure we find where the name for .shstrtab resides before we insert
+    // it into the image.
+    auto const shstrtab_name_index = section_names.insert(".shstrtab"sv);
+    auto const shstrtab = section_names.emit_into_builder(
+        shstrtab_name_index, sections);
+
+    // Set the type to an "object" file, as GDB seems to request it:
+    // https://sourceware.org/gdb/current/onlinedocs/gdb.html/Registering-Code.html#Registering-Code
+    return ELF::build_elf_image(shstrtab.raw_index(), ET_REL, sections.span());
+}
+}

--- a/Userland/Libraries/LibJIT/GDBUnsupported.cpp
+++ b/Userland/Libraries/LibJIT/GDBUnsupported.cpp
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2023, Jesús Lapastora <cyber.gsuscode@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibJIT/GDB.h>
+
+namespace JIT::GDB {
+Optional<FixedArray<u8>> build_gdb_image(ReadonlyBytes, StringView, StringView)
+{
+    return {};
+}
+}

--- a/Userland/Libraries/LibJS/JIT/Compiler.cpp
+++ b/Userland/Libraries/LibJS/JIT/Compiler.cpp
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/FixedArray.h>
 #include <AK/OwnPtr.h>
 #include <AK/Platform.h>
 #include <LibJIT/GDB.h>
@@ -3772,7 +3773,11 @@ OwnPtr<NativeExecutable> Compiler::compile(Bytecode::Executable& bytecode_execut
         compiler.m_output.size(),
     };
 
-    auto gdb_object = ::JIT::GDB::build_gdb_image(code, "LibJS JIT"sv, "LibJS JITted code"sv);
+    Optional<FixedArray<u8>> gdb_object {};
+
+    if (getenv("LIBJS_JIT_GDB")) {
+        gdb_object = ::JIT::GDB::build_gdb_image(code, "LibJS JIT"sv, "LibJS JITted code"sv);
+    }
 
     auto executable = make<NativeExecutable>(executable_memory, compiler.m_output.size(), mapping, move(gdb_object));
     if constexpr (DUMP_JIT_DISASSEMBLY)

--- a/Userland/Libraries/LibJS/JIT/Compiler.cpp
+++ b/Userland/Libraries/LibJS/JIT/Compiler.cpp
@@ -1,12 +1,14 @@
 /*
  * Copyright (c) 2023, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2023, Simon Wanner <simon@skyrising.xyz>
+ * Copyright (c) 2023, Jesús Lapastora <cyber.gsuscode@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #include <AK/OwnPtr.h>
 #include <AK/Platform.h>
+#include <LibJIT/GDB.h>
 #include <LibJS/Bytecode/CommonImplementations.h>
 #include <LibJS/Bytecode/Instruction.h>
 #include <LibJS/Bytecode/Interpreter.h>
@@ -3765,7 +3767,14 @@ OwnPtr<NativeExecutable> Compiler::compile(Bytecode::Executable& bytecode_execut
         dbgln("\033[32;1mJIT compilation succeeded!\033[0m {}", bytecode_executable.name);
     }
 
-    auto executable = make<NativeExecutable>(executable_memory, compiler.m_output.size(), mapping);
+    auto const code = ReadonlyBytes {
+        executable_memory,
+        compiler.m_output.size(),
+    };
+
+    auto gdb_object = ::JIT::GDB::build_gdb_image(code, "LibJS JIT"sv, "LibJS JITted code"sv);
+
+    auto executable = make<NativeExecutable>(executable_memory, compiler.m_output.size(), mapping, move(gdb_object));
     if constexpr (DUMP_JIT_DISASSEMBLY)
         executable->dump_disassembly(bytecode_executable);
     return executable;

--- a/Userland/Libraries/LibJS/JIT/NativeExecutable.h
+++ b/Userland/Libraries/LibJS/JIT/NativeExecutable.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/FixedArray.h>
 #include <AK/Noncopyable.h>
 #include <AK/Types.h>
 #include <LibJS/Bytecode/Instruction.h>
@@ -28,7 +29,7 @@ class NativeExecutable {
     AK_MAKE_NONMOVABLE(NativeExecutable);
 
 public:
-    NativeExecutable(void* code, size_t size, Vector<BytecodeMapping>);
+    NativeExecutable(void* code, size_t size, Vector<BytecodeMapping>, Optional<FixedArray<u8>> gdb_object = {});
     ~NativeExecutable();
 
     void run(VM&, size_t entry_point) const;
@@ -44,6 +45,7 @@ private:
     Vector<BytecodeMapping> m_mapping;
     Vector<FlatPtr> m_block_entry_points;
     mutable OwnPtr<Bytecode::InstructionStreamIterator> m_instruction_stream_iterator;
+    Optional<FixedArray<u8>> m_gdb_object;
 };
 
 }


### PR DESCRIPTION
This is a MVP that allows the JIT in LibJS to register an ELF file with the GDB
JIT Interface, so that GDB can point to symbols created at runtime. Currently the
registered ELF image only has the bare minimum so that the JITted code section is
recognized with a symbol.

Through LibJIT I've added infrastructure to help with adding sections and
strings, and LibJS/JIT contains an example of both how to use those APIs and how
to create a symbol table.

I've omitted emitting DWARF and `.eh_header` sections for the moment since I'm
having trouble understanding how they work and how to integrate them into the
JIT.

The code for emitting the ELF metadata currently assumes an `X86_64` LSB target.

The following is a screenshot of GDB showing a backtrace after an `ud2` has been executed:
![scn](https://github.com/SerenityOS/serenity/assets/54634335/e3522a3e-c5c0-431c-9fb6-1ea131065c54)
