### PR TITLE
LibJS/JIT: Support the EnterObjectEnvironment instruction + minor cleanups

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -2397,7 +2397,7 @@ Bytecode::CodeGenerationErrorOr<void> TryStatement::generate_bytecode(Bytecode::
 
     auto& target_block = generator.make_block();
     generator.switch_to_basic_block(saved_block);
-    generator.emit<Bytecode::Op::EnterUnwindContext>(Bytecode::Label { target_block }, handler_target, finalizer_target);
+    generator.emit<Bytecode::Op::EnterUnwindContext>(Bytecode::Label { target_block });
     generator.start_boundary(Bytecode::Generator::BlockBoundaryType::Unwind);
     if (m_finalizer)
         generator.start_boundary(Bytecode::Generator::BlockBoundaryType::ReturnToFinally);

--- a/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -2337,6 +2337,8 @@ Bytecode::CodeGenerationErrorOr<void> TryStatement::generate_bytecode(Bytecode::
         auto& handler_block = generator.make_block();
         generator.switch_to_basic_block(handler_block);
 
+        generator.emit<Bytecode::Op::Catch>();
+
         if (!m_finalizer)
             generator.emit<Bytecode::Op::LeaveUnwindContext>();
 

--- a/Userland/Libraries/LibJS/Bytecode/Instruction.h
+++ b/Userland/Libraries/LibJS/Bytecode/Instruction.h
@@ -24,6 +24,7 @@
     O(BlockDeclarationInstantiation)   \
     O(Call)                            \
     O(CallWithArgumentArray)           \
+    O(Catch)                           \
     O(ConcatString)                    \
     O(ContinuePendingUnwind)           \
     O(CopyObjectExcludingProperties)   \

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -515,22 +515,22 @@ ThrowCompletionOr<void> Store::execute_impl(Bytecode::Interpreter&) const
     __builtin_unreachable();
 }
 
-static ThrowCompletionOr<Value> abstract_inequals(VM& vm, Value src1, Value src2)
+static ThrowCompletionOr<Value> loosely_inequals(VM& vm, Value src1, Value src2)
 {
     return Value(!TRY(is_loosely_equal(vm, src1, src2)));
 }
 
-static ThrowCompletionOr<Value> abstract_equals(VM& vm, Value src1, Value src2)
+static ThrowCompletionOr<Value> loosely_equals(VM& vm, Value src1, Value src2)
 {
     return Value(TRY(is_loosely_equal(vm, src1, src2)));
 }
 
-static ThrowCompletionOr<Value> typed_inequals(VM&, Value src1, Value src2)
+static ThrowCompletionOr<Value> strict_inequals(VM&, Value src1, Value src2)
 {
     return Value(!is_strictly_equal(src1, src2));
 }
 
-static ThrowCompletionOr<Value> typed_equals(VM&, Value src1, Value src2)
+static ThrowCompletionOr<Value> strict_equals(VM&, Value src1, Value src2)
 {
     return Value(is_strictly_equal(src1, src2));
 }

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -1572,9 +1572,7 @@ DeprecatedString ThrowIfNullish::to_deprecated_string_impl(Bytecode::Executable 
 
 DeprecatedString EnterUnwindContext::to_deprecated_string_impl(Bytecode::Executable const&) const
 {
-    auto handler_string = m_handler_target.has_value() ? DeprecatedString::formatted("{}", *m_handler_target) : "<empty>";
-    auto finalizer_string = m_finalizer_target.has_value() ? DeprecatedString::formatted("{}", *m_finalizer_target) : "<empty>";
-    return DeprecatedString::formatted("EnterUnwindContext handler:{} finalizer:{} entry:{}", handler_string, finalizer_string, m_entry_point);
+    return DeprecatedString::formatted("EnterUnwindContext entry:{}", m_entry_point);
 }
 
 DeprecatedString ScheduleJump::to_deprecated_string_impl(Bytecode::Executable const&) const

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.h
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.h
@@ -74,6 +74,7 @@ public:
 
     void enter_unwind_context();
     void leave_unwind_context();
+    void catch_exception();
 
     Executable& current_executable() { return *m_current_executable; }
     Executable const& current_executable() const { return *m_current_executable; }

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.h
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.h
@@ -76,6 +76,8 @@ public:
     void leave_unwind_context();
     void catch_exception();
 
+    void enter_object_environment(Object&);
+
     Executable& current_executable() { return *m_current_executable; }
     Executable const& current_executable() const { return *m_current_executable; }
     BasicBlock const& current_block() const { return *m_current_block; }

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -92,10 +92,10 @@ private:
     O(GreaterThanEquals, greater_than_equals) \
     O(LessThan, less_than)                    \
     O(LessThanEquals, less_than_equals)       \
-    O(LooselyInequals, abstract_inequals)     \
-    O(LooselyEquals, abstract_equals)         \
-    O(StrictlyInequals, typed_inequals)       \
-    O(StrictlyEquals, typed_equals)           \
+    O(LooselyInequals, loosely_inequals)      \
+    O(LooselyEquals, loosely_equals)          \
+    O(StrictlyInequals, strict_inequals)      \
+    O(StrictlyEquals, strict_equals)          \
     O(BitwiseAnd, bitwise_and)                \
     O(BitwiseOr, bitwise_or)                  \
     O(BitwiseXor, bitwise_xor)                \

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -407,6 +407,17 @@ public:
     DeprecatedString to_deprecated_string_impl(Bytecode::Executable const&) const;
 };
 
+class Catch final : public Instruction {
+public:
+    explicit Catch()
+        : Instruction(Type::Catch, sizeof(*this))
+    {
+    }
+
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    DeprecatedString to_deprecated_string_impl(Bytecode::Executable const&) const;
+};
+
 class CreateVariable final : public Instruction {
 public:
     explicit CreateVariable(IdentifierTableIndex identifier, EnvironmentMode mode, bool is_immutable, bool is_global = false, bool is_strict = false)

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -1192,11 +1192,9 @@ class EnterUnwindContext final : public Instruction {
 public:
     constexpr static bool IsTerminator = true;
 
-    EnterUnwindContext(Label entry_point, Optional<Label> handler_target, Optional<Label> finalizer_target)
+    EnterUnwindContext(Label entry_point)
         : Instruction(Type::EnterUnwindContext, sizeof(*this))
         , m_entry_point(move(entry_point))
-        , m_handler_target(move(handler_target))
-        , m_finalizer_target(move(finalizer_target))
     {
     }
 
@@ -1204,13 +1202,9 @@ public:
     DeprecatedString to_deprecated_string_impl(Bytecode::Executable const&) const;
 
     auto& entry_point() const { return m_entry_point; }
-    auto& handler_target() const { return m_handler_target; }
-    auto& finalizer_target() const { return m_finalizer_target; }
 
 private:
     Label m_entry_point;
-    Optional<Label> m_handler_target;
-    Optional<Label> m_finalizer_target;
 };
 
 class ScheduleJump final : public Instruction {

--- a/Userland/Libraries/LibJS/JIT/Compiler.cpp
+++ b/Userland/Libraries/LibJS/JIT/Compiler.cpp
@@ -577,22 +577,22 @@ void Compiler::compile_throw(Bytecode::Op::Throw const&)
     check_exception();
 }
 
-static ThrowCompletionOr<Value> abstract_inequals(VM& vm, Value src1, Value src2)
+static ThrowCompletionOr<Value> loosely_inequals(VM& vm, Value src1, Value src2)
 {
     return Value(!TRY(is_loosely_equal(vm, src1, src2)));
 }
 
-static ThrowCompletionOr<Value> abstract_equals(VM& vm, Value src1, Value src2)
+static ThrowCompletionOr<Value> loosely_equals(VM& vm, Value src1, Value src2)
 {
     return Value(TRY(is_loosely_equal(vm, src1, src2)));
 }
 
-static ThrowCompletionOr<Value> typed_inequals(VM&, Value src1, Value src2)
+static ThrowCompletionOr<Value> strict_inequals(VM&, Value src1, Value src2)
 {
     return Value(!is_strictly_equal(src1, src2));
 }
 
-static ThrowCompletionOr<Value> typed_equals(VM&, Value src1, Value src2)
+static ThrowCompletionOr<Value> strict_equals(VM&, Value src1, Value src2)
 {
     return Value(is_strictly_equal(src1, src2));
 }

--- a/Userland/Libraries/LibJS/JIT/Compiler.cpp
+++ b/Userland/Libraries/LibJS/JIT/Compiler.cpp
@@ -1988,6 +1988,20 @@ void Compiler::compile_leave_lexical_environment(Bytecode::Op::LeaveLexicalEnvir
     native_call((void*)cxx_leave_lexical_environment);
 }
 
+static Value cxx_enter_object_environment(VM& vm, Value value)
+{
+    auto object = TRY_OR_SET_EXCEPTION(value.to_object(vm));
+    vm.bytecode_interpreter().enter_object_environment(*object);
+    return {};
+}
+
+void Compiler::compile_enter_object_environment(Bytecode::Op::EnterObjectEnvironment const&)
+{
+    load_accumulator(ARG1);
+    native_call((void*)cxx_enter_object_environment);
+    check_exception();
+}
+
 static Value cxx_concat_string(VM& vm, Value lhs, Value rhs)
 {
     auto string = TRY_OR_SET_EXCEPTION(rhs.to_primitive_string(vm));

--- a/Userland/Libraries/LibJS/JIT/Compiler.h
+++ b/Userland/Libraries/LibJS/JIT/Compiler.h
@@ -86,6 +86,7 @@ private:
         O(Catch, catch)                                                          \
         O(CreateLexicalEnvironment, create_lexical_environment)                  \
         O(LeaveLexicalEnvironment, leave_lexical_environment)                    \
+        O(EnterObjectEnvironment, enter_object_environment)                      \
         O(ToNumeric, to_numeric)                                                 \
         O(ResolveThisBinding, resolve_this_binding)                              \
         O(Return, return)                                                        \

--- a/Userland/Libraries/LibJS/JIT/Compiler.h
+++ b/Userland/Libraries/LibJS/JIT/Compiler.h
@@ -83,6 +83,7 @@ private:
         O(EnterUnwindContext, enter_unwind_context)                              \
         O(LeaveUnwindContext, leave_unwind_context)                              \
         O(Throw, throw)                                                          \
+        O(Catch, catch)                                                          \
         O(CreateLexicalEnvironment, create_lexical_environment)                  \
         O(LeaveLexicalEnvironment, leave_lexical_environment)                    \
         O(ToNumeric, to_numeric)                                                 \

--- a/Userland/Libraries/LibJS/JIT/Compiler.h
+++ b/Userland/Libraries/LibJS/JIT/Compiler.h
@@ -50,10 +50,10 @@ private:
         O(Mod, mod)                                             \
         O(In, in)                                               \
         O(InstanceOf, instance_of)                              \
-        O(LooselyInequals, abstract_inequals)                   \
-        O(LooselyEquals, abstract_equals)                       \
-        O(StrictlyInequals, typed_inequals)                     \
-        O(StrictlyEquals, typed_equals)
+        O(LooselyInequals, loosely_inequals)                    \
+        O(LooselyEquals, loosely_equals)                        \
+        O(StrictlyInequals, strict_inequals)                    \
+        O(StrictlyEquals, strict_equals)
 
 #    define JS_ENUMERATE_COMPARISON_OPS(O)                           \
         O(LessThan, less_than, SignedLessThan)                       \


### PR DESCRIPTION
This allows us to JIT code that uses the `with` statement.