### PR TITLE
LibWeb: Support `mask-type` style attribute for SVGs 

### DIFF
--- a/Tests/LibWeb/Ref/svg-alpha-mask-attribute.html
+++ b/Tests/LibWeb/Ref/svg-alpha-mask-attribute.html
@@ -1,0 +1,11 @@
+<link rel="match" href="reference/simple-svg-mask-ref.html" />
+<svg width="120" viewBox="-10 -10 120 120">
+  <defs>
+    <mask id="myMask" mask-type="alpha">
+      <!-- Everything solid pixel (alpha=255) will be visible -->
+      <rect x="50" y="0" width="50" height="100" fill="black" />
+    </mask>
+  </defs>
+  <rect x="-10" y="-10" width="120" height="120" fill="blue" />
+  <rect x="10" y="10" width="80" height="80" fill="red" mask="url(#myMask)" />
+</svg>

--- a/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
@@ -141,7 +141,8 @@ void SVGGraphicsElement::apply_presentational_hints(CSS::StyleProperties& style)
         NamedPropertyID(CSS::PropertyID::Opacity),
         NamedPropertyID(CSS::PropertyID::TextAnchor),
         NamedPropertyID(CSS::PropertyID::FontSize),
-        NamedPropertyID(CSS::PropertyID::Mask)
+        NamedPropertyID(CSS::PropertyID::Mask),
+        NamedPropertyID(CSS::PropertyID::MaskType)
     };
 
     CSS::Parser::ParsingContext parsing_context { document(), CSS::Parser::ParsingContext::Mode::SVGPresentationAttribute };


### PR DESCRIPTION
Progression on [discord](https://discord.com/):

**Before:**

![image](https://github.com/SerenityOS/serenity/assets/11597044/2e8aae8e-ea06-4439-bee2-8cf49b80e9f4)

**After:**

![image](https://github.com/SerenityOS/serenity/assets/11597044/41d0aa16-9b29-40d7-beb0-9dd9012b1ec3)
