### PR TITLE
Spider: Highlight cards that can't be moved

### DIFF
--- a/Userland/Games/Spider/CMakeLists.txt
+++ b/Userland/Games/Spider/CMakeLists.txt
@@ -4,15 +4,12 @@ serenity_component(
     TARGETS Spider
 )
 
-stringify_gml(Spider.gml SpiderGML.h spider_gml)
+compile_gml(Spider.gml SpiderGML.cpp spider_gml)
 
 set(SOURCES
     Game.cpp
     main.cpp
-)
-
-set(GENERATED_SOURCES
-    SpiderGML.h
+    SpiderGML.cpp
 )
 
 serenity_app(Spider ICON app-spider)

--- a/Userland/Games/Spider/Game.h
+++ b/Userland/Games/Spider/Game.h
@@ -2,6 +2,7 @@
  * Copyright (c) 2021, Jamie Mansfield <jmansfield@cadixdev.org>
  * Copyright (c) 2022, the SerenityOS developers.
  * Copyright (c) 2022, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2023, David Ganz <david.g.ganz@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -93,6 +94,7 @@ private:
     void move_focused_cards(CardStack& stack);
     void clear_hovered_stack();
     void deal_next_card();
+    void update_disabled_cards();
 
     virtual void paint_event(GUI::PaintEvent&) override;
     virtual void mousedown_event(GUI::MouseEvent&) override;

--- a/Userland/Games/Spider/MainWidget.h
+++ b/Userland/Games/Spider/MainWidget.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2023, the SerenityOS developers
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibGUI/Widget.h>
+
+namespace Spider {
+
+class MainWidget : public GUI::Widget {
+    C_OBJECT_ABSTRACT(MainWidget)
+public:
+    static ErrorOr<NonnullRefPtr<Spider::MainWidget>> try_create();
+    virtual ~MainWidget() override = default;
+
+private:
+    MainWidget() = default;
+};
+
+}

--- a/Userland/Games/Spider/Spider.gml
+++ b/Userland/Games/Spider/Spider.gml
@@ -1,4 +1,4 @@
-@GUI::Widget {
+@Spider::MainWidget {
     fill_with_background_color: true
     layout: @GUI::VerticalBoxLayout {}
 

--- a/Userland/Games/Spider/main.cpp
+++ b/Userland/Games/Spider/main.cpp
@@ -7,9 +7,9 @@
  */
 
 #include "Game.h"
+#include "MainWidget.h"
 #include <AK/NumberFormat.h>
 #include <AK/URL.h>
-#include <Games/Spider/SpiderGML.h>
 #include <LibConfig/Client.h>
 #include <LibCore/System.h>
 #include <LibCore/Timer.h>
@@ -116,8 +116,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     if (statistic_display >= StatisticDisplay::__Count)
         update_statistic_display(StatisticDisplay::HighScore);
 
-    auto widget = window->set_main_widget<GUI::Widget>();
-    TRY(widget->load_from_gml(spider_gml));
+    auto widget = TRY(Spider::MainWidget::try_create());
+    window->set_main_widget(widget);
 
     auto& game = *widget->find_descendant_of_type_named<Spider::Game>("game");
     game.set_focus(true);

--- a/Userland/Libraries/LibCards/Card.cpp
+++ b/Userland/Libraries/LibCards/Card.cpp
@@ -2,6 +2,7 @@
  * Copyright (c) 2020, Till Mayer <till.mayer@web.de>
  * Copyright (c) 2022, the SerenityOS developers.
  * Copyright (c) 2022, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2023, David Ganz <david.g.ganz@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -22,6 +23,8 @@ Card::Card(Suit suit, Rank rank)
 
 void Card::paint(GUI::Painter& painter, bool highlighted) const
 {
+    VERIFY(!(highlighted && m_disabled));
+
     auto& card_painter = CardPainter::the();
     auto bitmap = [&]() {
         if (m_inverted)
@@ -29,6 +32,9 @@ void Card::paint(GUI::Painter& painter, bool highlighted) const
         if (highlighted) {
             VERIFY(!m_upside_down);
             return card_painter.card_front_highlighted(m_suit, m_rank);
+        }
+        if (m_disabled) {
+            return m_upside_down ? card_painter.card_back_disabled() : card_painter.card_front_disabled(m_suit, m_rank);
         }
         return m_upside_down ? card_painter.card_back() : card_painter.card_front(m_suit, m_rank);
     }();

--- a/Userland/Libraries/LibCards/Card.h
+++ b/Userland/Libraries/LibCards/Card.h
@@ -2,6 +2,7 @@
  * Copyright (c) 2020, Till Mayer <till.mayer@web.de>
  * Copyright (c) 2022, the SerenityOS developers.
  * Copyright (c) 2022, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2023, David Ganz <david.g.ganz@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -99,6 +100,7 @@ public:
     bool is_upside_down() const { return m_upside_down; }
     bool is_inverted() const { return m_inverted; }
     bool is_previewed() const { return m_previewed; }
+    bool is_disabled() const { return m_disabled; }
     Gfx::Color color() const { return (m_suit == Suit::Diamonds || m_suit == Suit::Hearts) ? Color::Red : Color::Black; }
 
     void set_position(const Gfx::IntPoint p) { m_rect.set_location(p); }
@@ -106,6 +108,7 @@ public:
     void set_upside_down(bool upside_down) { m_upside_down = upside_down; }
     void set_inverted(bool inverted) { m_inverted = inverted; }
     void set_previewed(bool previewed) { m_previewed = previewed; }
+    void set_disabled(bool disabled) { m_disabled = disabled; }
 
     void save_old_position();
 
@@ -125,6 +128,7 @@ private:
     bool m_upside_down { false };
     bool m_inverted { false };
     bool m_previewed { false };
+    bool m_disabled { false };
 };
 
 enum class Shuffle {

--- a/Userland/Libraries/LibCards/CardPainter.h
+++ b/Userland/Libraries/LibCards/CardPainter.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022-2023, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2023, David Ganz <david.g.ganz@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -23,6 +24,8 @@ public:
     NonnullRefPtr<Gfx::Bitmap> card_front_inverted(Suit, Rank);
     NonnullRefPtr<Gfx::Bitmap> card_back_inverted();
     NonnullRefPtr<Gfx::Bitmap> card_front_highlighted(Suit, Rank);
+    NonnullRefPtr<Gfx::Bitmap> card_front_disabled(Suit, Rank);
+    NonnullRefPtr<Gfx::Bitmap> card_back_disabled();
 
     void set_back_image_path(StringView path);
     void set_front_images_set_name(StringView path);
@@ -36,14 +39,17 @@ private:
     void paint_card_back(Gfx::Bitmap&);
     void paint_inverted_card(Gfx::Bitmap& bitmap, Gfx::Bitmap const& source_to_invert);
     void paint_highlighted_card(Gfx::Bitmap& bitmap, Gfx::Bitmap const& source_to_highlight);
+    void paint_disabled_card(Gfx::Bitmap& bitmap, Gfx::Bitmap const& source_to_disable);
 
     Array<RefPtr<Gfx::Bitmap>, to_underlying(Suit::__Count)> m_suit_pips;
     Array<RefPtr<Gfx::Bitmap>, to_underlying(Suit::__Count)> m_suit_pips_flipped_vertically;
     Array<Array<RefPtr<Gfx::Bitmap>, to_underlying(Rank::__Count)>, to_underlying(Suit::__Count)> m_cards;
     Array<Array<RefPtr<Gfx::Bitmap>, to_underlying(Rank::__Count)>, to_underlying(Suit::__Count)> m_cards_inverted;
     Array<Array<RefPtr<Gfx::Bitmap>, to_underlying(Rank::__Count)>, to_underlying(Suit::__Count)> m_cards_highlighted;
+    Array<Array<RefPtr<Gfx::Bitmap>, to_underlying(Rank::__Count)>, to_underlying(Suit::__Count)> m_cards_disabled;
     RefPtr<Gfx::Bitmap> m_card_back;
     RefPtr<Gfx::Bitmap> m_card_back_inverted;
+    RefPtr<Gfx::Bitmap> m_card_back_disabled;
 
     String m_back_image_path;
     String m_front_images_set_name;

--- a/Userland/Libraries/LibCards/CardPainter.h
+++ b/Userland/Libraries/LibCards/CardPainter.h
@@ -32,7 +32,12 @@ public:
     void set_background_color(Color);
 
 private:
+    using PaintCache = Array<Array<RefPtr<Gfx::Bitmap>, to_underlying(Rank::__Count)>, to_underlying(Suit::__Count)>;
+
     CardPainter();
+
+    NonnullRefPtr<Gfx::Bitmap> get_bitmap_or_create(Suit, Rank, PaintCache&, Function<void(Gfx::Bitmap&)>);
+
     NonnullRefPtr<Gfx::Bitmap> create_card_bitmap();
     void paint_card_front(Gfx::Bitmap&, Suit, Rank);
     void paint_card_front_pips(Gfx::Bitmap&, Suit, Rank);
@@ -43,10 +48,12 @@ private:
 
     Array<RefPtr<Gfx::Bitmap>, to_underlying(Suit::__Count)> m_suit_pips;
     Array<RefPtr<Gfx::Bitmap>, to_underlying(Suit::__Count)> m_suit_pips_flipped_vertically;
-    Array<Array<RefPtr<Gfx::Bitmap>, to_underlying(Rank::__Count)>, to_underlying(Suit::__Count)> m_cards;
-    Array<Array<RefPtr<Gfx::Bitmap>, to_underlying(Rank::__Count)>, to_underlying(Suit::__Count)> m_cards_inverted;
-    Array<Array<RefPtr<Gfx::Bitmap>, to_underlying(Rank::__Count)>, to_underlying(Suit::__Count)> m_cards_highlighted;
-    Array<Array<RefPtr<Gfx::Bitmap>, to_underlying(Rank::__Count)>, to_underlying(Suit::__Count)> m_cards_disabled;
+
+    PaintCache m_cards;
+    PaintCache m_cards_inverted;
+    PaintCache m_cards_highlighted;
+    PaintCache m_cards_disabled;
+
     RefPtr<Gfx::Bitmap> m_card_back;
     RefPtr<Gfx::Bitmap> m_card_back_inverted;
     RefPtr<Gfx::Bitmap> m_card_back_disabled;

--- a/Userland/Libraries/LibCards/CardStack.cpp
+++ b/Userland/Libraries/LibCards/CardStack.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020, Till Mayer <till.mayer@web.de>
+ * Copyright (c) 2023, David Ganz <david.g.ganz@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -203,6 +204,57 @@ ErrorOr<void> CardStack::add_all_grabbed_cards(Gfx::IntPoint click_location, Vec
     }
 
     return {};
+}
+
+void CardStack::update_disabled_cards(MovementRule movement_rule)
+{
+    if (m_stack.is_empty())
+        return;
+
+    for (auto& card : m_stack)
+        card->set_disabled(false);
+
+    Optional<size_t> last_valid_card = {};
+    uint8_t last_rank;
+    Color last_color;
+    for (size_t idx = m_stack.size(); idx > 0; idx--) {
+        auto i = idx - 1;
+        auto card = m_stack[i];
+        if (card->is_upside_down()) {
+            if (!last_valid_card.has_value())
+                last_valid_card = i + 1;
+            break;
+        }
+
+        if (i != m_stack.size() - 1) {
+            bool color_valid;
+            switch (movement_rule) {
+            case MovementRule::Alternating:
+                color_valid = card->color() != last_color;
+                break;
+            case MovementRule::Same:
+                color_valid = card->color() == last_color;
+                break;
+            case MovementRule::Any:
+                color_valid = true;
+                break;
+            }
+
+            if (!color_valid || to_underlying(card->rank()) != last_rank + 1) {
+                last_valid_card = i + 1;
+                break;
+            }
+        }
+
+        last_rank = to_underlying(card->rank());
+        last_color = card->color();
+    }
+
+    if (!last_valid_card.has_value())
+        return;
+
+    for (size_t i = 0; i < last_valid_card.value(); i++)
+        m_stack[i]->set_disabled(true);
 }
 
 bool CardStack::is_allowed_to_push(Card const& card, size_t stack_size, MovementRule movement_rule) const

--- a/Userland/Libraries/LibCards/CardStack.h
+++ b/Userland/Libraries/LibCards/CardStack.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020, Till Mayer <till.mayer@web.de>
+ * Copyright (c) 2023, David Ganz <david.g.ganz@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -50,6 +51,8 @@ public:
 
     bool is_allowed_to_push(Card const&, size_t stack_size = 1, MovementRule movement_rule = MovementRule::Alternating) const;
     ErrorOr<void> add_all_grabbed_cards(Gfx::IntPoint click_location, Vector<NonnullRefPtr<Card>>& grabbed, MovementRule movement_rule = MovementRule::Alternating);
+
+    void update_disabled_cards(MovementRule);
 
     bool preview_card(Gfx::IntPoint click_location);
     void clear_card_preview();


### PR DESCRIPTION
Previously, it was sort of difficult to tell which cards can be moved at a glance. Now, the cards that can't be moved are rendered darker, which makes it much easier to tell what can be moved and to where, making the game a bit easier on the eyes!

![image](https://github.com/SerenityOS/serenity/assets/66440035/788c2493-13c1-4567-ac84-51923a99a461)

This is done by rendering a rectangle with a transparent color on top of the card images in `CardPainter`. `Card`s now keep track of whether they are "disabled", in which case they are rendered darker as shown above. I then added a helper in `CardStack` to update that flag depending on a given `MovementRule`. This works by searching for the last card that is in order from the bottom up, and making all cards above disabled.
In addition, I also added a small helper in `CardPainter` that makes painting and accessing the caches a bit easier, and I ported the Spider application to the GML compiler (see #20518)!