### PR TITLE
LibAccelGfx+WebContent: Add GPU painter support on macOS

### DIFF
--- a/Meta/CMake/accelerated_graphics.cmake
+++ b/Meta/CMake/accelerated_graphics.cmake
@@ -12,3 +12,8 @@ if (OPENGL_FOUND)
 else()
     set(HAS_ACCELERATED_GRAPHICS OFF CACHE BOOL "" FORCE)
 endif()
+
+if (APPLE)
+    set(HAS_ACCELERATED_GRAPHICS ON CACHE BOOL "" FORCE)
+    set(ACCEL_GFX_LIBS "-framework OpenGL" CACHE STRING "" FORCE)
+endif()

--- a/Userland/Libraries/LibAccelGfx/Context.h
+++ b/Userland/Libraries/LibAccelGfx/Context.h
@@ -9,10 +9,12 @@
 #include <AK/Assertions.h>
 #include <AK/OwnPtr.h>
 
+#ifndef AK_OS_MACOS
 // Make sure egl.h doesn't give us definitions from X11 headers
-#define EGL_NO_X11
-#include <EGL/egl.h>
-#undef EGL_NO_X11
+#    define EGL_NO_X11
+#    include <EGL/egl.h>
+#    undef EGL_NO_X11
+#endif
 
 namespace AccelGfx {
 
@@ -22,17 +24,9 @@ public:
 
     static OwnPtr<Context> create();
 
-    Context(EGLDisplay egl_display, EGLContext egl_context, EGLConfig egl_config)
-        : m_egl_display(egl_display)
-        , m_egl_context(egl_context)
-        , m_egl_config(egl_config)
+    Context()
     {
     }
-
-private:
-    EGLDisplay m_egl_display { nullptr };
-    EGLContext m_egl_context { nullptr };
-    EGLConfig m_egl_config { nullptr };
 };
 
 }

--- a/Userland/Libraries/LibAccelGfx/GL.h
+++ b/Userland/Libraries/LibAccelGfx/GL.h
@@ -7,7 +7,13 @@
 #pragma once
 
 #include <AK/Vector.h>
-#include <GL/gl.h>
+#ifdef AK_OS_MACOS
+#    define GL_SILENCE_DEPRECATION
+#    include <OpenGL/OpenGL.h>
+#    include <OpenGL/gl3.h>
+#else
+#    include <GL/gl.h>
+#endif
 #include <LibGfx/Forward.h>
 
 namespace AccelGfx::GL {

--- a/Userland/Libraries/LibAccelGfx/Painter.cpp
+++ b/Userland/Libraries/LibAccelGfx/Painter.cpp
@@ -75,7 +75,7 @@ in vec2 vTextureCoord;
 uniform sampler2D uSampler;
 out vec4 fragColor;
 void main() {
-    fragColor = texture2D(uSampler, vTextureCoord) * uColor;
+    fragColor = texture(uSampler, vTextureCoord) * uColor;
 }
 )";
 


### PR DESCRIPTION
With these changes it is now possible to create OpenGL context on macOS and run GPU-painter. For now only QT client has a CLI param that turns it on though.

@ADKaster could you have a look please?