### PR TITLE
LibPDF: Tolerate an indirect object as dict for CIE-based color spaces

### DIFF
--- a/Userland/Libraries/LibPDF/ColorSpace.cpp
+++ b/Userland/Libraries/LibPDF/ColorSpace.cpp
@@ -314,7 +314,7 @@ PDFErrorOr<NonnullRefPtr<CalGrayColorSpace>> CalGrayColorSpace::create(Document*
     if (parameters.size() != 1)
         return Error { Error::Type::MalformedPDF, "Gray color space expects one parameter" };
 
-    auto param = parameters[0];
+    auto param = TRY(document->resolve(parameters[0]));
     if (!param.has<NonnullRefPtr<Object>>() || !param.get<NonnullRefPtr<Object>>()->is<DictObject>())
         return Error { Error::Type::MalformedPDF, "Gray color space expects a dict parameter" };
 
@@ -384,7 +384,7 @@ PDFErrorOr<NonnullRefPtr<CalRGBColorSpace>> CalRGBColorSpace::create(Document* d
     if (parameters.size() != 1)
         return Error { Error::Type::MalformedPDF, "RGB color space expects one parameter" };
 
-    auto param = parameters[0];
+    auto param = TRY(document->resolve(parameters[0]));
     if (!param.has<NonnullRefPtr<Object>>() || !param.get<NonnullRefPtr<Object>>()->is<DictObject>())
         return Error { Error::Type::MalformedPDF, "RGB color space expects a dict parameter" };
 
@@ -554,7 +554,7 @@ PDFErrorOr<NonnullRefPtr<LabColorSpace>> LabColorSpace::create(Document* documen
     if (parameters.size() != 1)
         return Error { Error::Type::MalformedPDF, "Lab color space expects one parameter" };
 
-    auto param = parameters[0];
+    auto param = TRY(document->resolve(parameters[0]));
     if (!param.has<NonnullRefPtr<Object>>() || !param.get<NonnullRefPtr<Object>>()->is<DictObject>())
         return Error { Error::Type::MalformedPDF, "Lab color space expects a dict parameter" };
 


### PR DESCRIPTION
Namely, for CalGrayColorSpace, CalRGBColorSpace, LabColorSpace.

Fixes a crash rendering any page of Adobe's 5014.CIDFont_Spec.pdf (which uses CalRGBColorSpace with an indirect dict: The dict is object `92 0`, and many color spaces are inline objects referring to it).