### PR TITLE
LibJS/JIT: Fast paths for object==object and Array.length

### DIFF
--- a/Userland/Libraries/LibJS/JIT/Compiler.h
+++ b/Userland/Libraries/LibJS/JIT/Compiler.h
@@ -51,7 +51,6 @@ private:
         O(In, in)                                               \
         O(InstanceOf, instance_of)                              \
         O(LooselyInequals, loosely_inequals)                    \
-        O(LooselyEquals, loosely_equals)                        \
         O(StrictlyInequals, strict_inequals)                    \
         O(StrictlyEquals, strict_equals)
 

--- a/Userland/Libraries/LibJS/Runtime/Array.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Array.cpp
@@ -64,6 +64,7 @@ NonnullGCPtr<Array> Array::create_from(Realm& realm, Vector<Value> const& elemen
 Array::Array(Object& prototype)
     : Object(ConstructWithPrototypeTag::Tag, prototype)
 {
+    m_has_magical_length_property = true;
 }
 
 // 10.4.2.4 ArraySetLength ( A, Desc ), https://tc39.es/ecma262/#sec-arraysetlength

--- a/Userland/Libraries/LibJS/Runtime/Object.h
+++ b/Userland/Libraries/LibJS/Runtime/Object.h
@@ -221,6 +221,8 @@ public:
     static FlatPtr may_interfere_with_indexed_property_access_offset() { return OFFSET_OF(Object, m_may_interfere_with_indexed_property_access); }
     static FlatPtr indexed_properties_offset() { return OFFSET_OF(Object, m_indexed_properties); }
 
+    static FlatPtr has_magical_length_property_offset() { return OFFSET_OF(Object, m_has_magical_length_property); }
+
 protected:
     enum class GlobalObjectTag { Tag };
     enum class ConstructWithoutPrototypeTag { Tag };
@@ -237,6 +239,8 @@ protected:
 
     // [[ParameterMap]]
     bool m_has_parameter_map { false };
+
+    bool m_has_magical_length_property { false };
 
 private:
     void set_shape(Shape& shape) { m_shape = &shape; }


### PR DESCRIPTION
Combined, these yield a strong ~2.7x speed-up on Kraken/ai-astar.js :^)