### PR TITLE
LibWeb: Survive and partially parse importmap

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/Scripting/ImportMap.h
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/ImportMap.h
@@ -23,6 +23,8 @@ public:
     HashMap<AK::URL, ModuleSpecifierMap> const& scopes() const { return m_scopes; }
     HashMap<AK::URL, ModuleSpecifierMap>& scopes() { return m_scopes; }
 
+    bool is_empty() const { return m_imports.is_empty() && m_scopes.is_empty(); }
+
 private:
     ModuleSpecifierMap m_imports;
     HashMap<AK::URL, ModuleSpecifierMap> m_scopes;

--- a/Userland/Libraries/LibWeb/HTML/Window.h
+++ b/Userland/Libraries/LibWeb/HTML/Window.h
@@ -11,7 +11,10 @@
 #include <AK/RefPtr.h>
 #include <AK/TypeCasts.h>
 #include <AK/URL.h>
+#include <AK/Variant.h>
+#include <LibJS/Heap/GCPtr.h>
 #include <LibJS/Heap/Heap.h>
+#include <LibJS/Runtime/Error.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Bindings/WindowGlobalMixin.h>
 #include <LibWeb/DOM/EventTarget.h>
@@ -91,6 +94,8 @@ public:
     JS::GCPtr<Navigable> navigable() const;
 
     ImportMap const& import_map() const { return m_import_map; }
+
+    void register_an_import_map(Variant<ImportMap, JS::NonnullGCPtr<JS::TypeError>>& import_map_or_error_to_rethrow);
 
     bool import_maps_allowed() const { return m_import_maps_allowed; }
     void set_import_maps_allowed(bool import_maps_allowed) { m_import_maps_allowed = import_maps_allowed; }


### PR DESCRIPTION
Improves #21794. 

The first commit gets https://node-projects.github.io/web-component-designer-demo/index.html to load into a broken state rather than crash the browsers.

<img width="1134" alt="image" src="https://github.com/SerenityOS/serenity/assets/3193447/ccacbada-622e-4f02-9e20-c4b2a6f671e3">

The second commit begins parsing the importmap but I was unable to test further due to an assert at `Userland/Libraries/LibWeb/HTML/Scripting/ModuleScript.cpp:136` trying to execute a module.

There are a few bits in the spec that I'm not sure about the correct way to handle. Specifically the phrase 'error to rethrow' which I added dbglns and early returns for instead. There didn't seem to be nearby infrastructure to do that so I'm not sure what the correct approach is.