### PR TITLE
LibWeb: Remove redundant flush() call in PaintingCommandExecutorGPU

### DIFF
--- a/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorGPU.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorGPU.cpp
@@ -15,7 +15,6 @@ PaintingCommandExecutorGPU::PaintingCommandExecutorGPU(AccelGfx::Painter& painte
 
 PaintingCommandExecutorGPU::~PaintingCommandExecutorGPU()
 {
-    m_painter.flush();
 }
 
 CommandResult PaintingCommandExecutorGPU::draw_glyph_run(Vector<Gfx::DrawGlyphOrEmoji> const& glyph_run, Color const& color)


### PR DESCRIPTION
Since we already call `Painter::flush()` in `PageHost::paint()` we do not need to do that again in `PaintingCommandExecutorGPU` destructor.

This makes GPU painting run noticeably faster because `flush()` does expensive `glReadPixels()` call.