### PR TITLE
LibJS: Don't hang when parsing invalid destructuring assignment target

### DIFF
--- a/Userland/Libraries/LibJS/Parser.cpp
+++ b/Userland/Libraries/LibJS/Parser.cpp
@@ -3061,12 +3061,14 @@ RefPtr<BindingPattern const> Parser::parse_binding_pattern(Parser::AllowDuplicat
             if (allow_member_expressions == AllowMemberExpressions::Yes && is_rest) {
                 auto expression_position = position();
                 auto expression = parse_expression(2, Associativity::Right, { TokenType::Equals });
-                if (is<MemberExpression>(*expression))
+                if (is<MemberExpression>(*expression)) {
                     alias = static_ptr_cast<MemberExpression const>(expression);
-                else if (is<Identifier>(*expression))
+                } else if (is<Identifier>(*expression)) {
                     name = static_ptr_cast<Identifier const>(expression);
-                else
+                } else {
                     syntax_error("Invalid destructuring assignment target", expression_position);
+                    return {};
+                }
             } else if (match_identifier_name() || match(TokenType::StringLiteral) || match(TokenType::NumericLiteral) || match(TokenType::BigIntLiteral)) {
                 if (match(TokenType::StringLiteral) || match(TokenType::NumericLiteral))
                     needs_alias = true;
@@ -3099,16 +3101,19 @@ RefPtr<BindingPattern const> Parser::parse_binding_pattern(Parser::AllowDuplicat
                     auto expression_position = position();
                     auto expression = parse_expression(2, Associativity::Right, { TokenType::Equals });
                     if (is<ArrayExpression>(*expression) || is<ObjectExpression>(*expression)) {
-                        if (auto synthesized_binding_pattern = synthesize_binding_pattern(*expression))
+                        if (auto synthesized_binding_pattern = synthesize_binding_pattern(*expression)) {
                             alias = synthesized_binding_pattern.release_nonnull();
-                        else
+                        } else {
                             syntax_error("Invalid destructuring assignment target", expression_position);
+                            return {};
+                        }
                     } else if (is<MemberExpression>(*expression)) {
                         alias = static_ptr_cast<MemberExpression const>(expression);
                     } else if (is<Identifier>(*expression)) {
                         alias = static_ptr_cast<Identifier const>(expression);
                     } else {
                         syntax_error("Invalid destructuring assignment target", expression_position);
+                        return {};
                     }
                 } else if (match(TokenType::CurlyOpen) || match(TokenType::BracketOpen)) {
                     auto binding_pattern = parse_binding_pattern(allow_duplicates, allow_member_expressions);
@@ -3131,16 +3136,19 @@ RefPtr<BindingPattern const> Parser::parse_binding_pattern(Parser::AllowDuplicat
                 auto expression = parse_expression(2, Associativity::Right, { TokenType::Equals });
 
                 if (is<ArrayExpression>(*expression) || is<ObjectExpression>(*expression)) {
-                    if (auto synthesized_binding_pattern = synthesize_binding_pattern(*expression))
+                    if (auto synthesized_binding_pattern = synthesize_binding_pattern(*expression)) {
                         alias = synthesized_binding_pattern.release_nonnull();
-                    else
+                    } else {
                         syntax_error("Invalid destructuring assignment target", expression_position);
+                        return {};
+                    }
                 } else if (is<MemberExpression>(*expression)) {
                     alias = static_ptr_cast<MemberExpression const>(expression);
                 } else if (is<Identifier>(*expression)) {
                     alias = static_ptr_cast<Identifier const>(expression);
                 } else {
                     syntax_error("Invalid destructuring assignment target", expression_position);
+                    return {};
                 }
             } else if (match(TokenType::BracketOpen) || match(TokenType::CurlyOpen)) {
                 auto pattern = parse_binding_pattern(allow_duplicates, allow_member_expressions);

--- a/Userland/Libraries/LibJS/Tests/parser-invalid-destructuring-assignment-target.js
+++ b/Userland/Libraries/LibJS/Tests/parser-invalid-destructuring-assignment-target.js
@@ -1,0 +1,5 @@
+test("Assigning to an invalid destructuring assignment target should fail immediately", () => {
+    expect(() => {
+        eval("[[function=a{1,}=");
+    }).toThrow(SyntaxError);
+});


### PR DESCRIPTION
Previously, certain crafted input could cause the JS parser to hang, as it repeatedly tried to parse an EOF token after hitting an "invalid destructuring assignment target" error. This change ensures that we stop parsing after hitting this error condition.

I was able to reduce the oss fuzz test case to the following JS snippet:

```js
[[function=a{1,}=
```
I wasn't able to come up with a more realistic example though; not all cases where this error was hit would cause the parser to hang.

By including this snippet in a HTML page, Ladybird would also hang:

```html
<html><script>[[function=a{1,}=</script>this text should appear</html>
```

There is no change to test262 parser tests output, but none of the tests seem to hit the code path I changed.

This fixes oss fuzz issue: [62881](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=62881)