### PR TITLE
LibJS/JIT: Add more fast paths

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/Executable.h
+++ b/Userland/Libraries/LibJS/Bytecode/Executable.h
@@ -34,6 +34,8 @@ struct PropertyLookupCache {
 };
 
 struct GlobalVariableCache : public PropertyLookupCache {
+    static FlatPtr environment_serial_number_offset() { return OFFSET_OF(GlobalVariableCache, environment_serial_number); }
+
     u64 environment_serial_number { 0 };
 };
 

--- a/Userland/Libraries/LibJS/JIT/Compiler.cpp
+++ b/Userland/Libraries/LibJS/JIT/Compiler.cpp
@@ -1906,6 +1906,126 @@ void Compiler::compile_put_by_value(Bytecode::Op::PutByValue const& op)
 {
     load_vm_register(ARG1, op.base());
     load_vm_register(ARG2, op.property());
+
+    Assembler::Label end {};
+    Assembler::Label slow_case {};
+
+    branch_if_object(ARG1, [&] {
+        branch_if_int32(ARG2, [&] {
+            // if (ARG2 < 0) goto slow_case;
+            m_assembler.mov(
+                Assembler::Operand::Register(GPR0),
+                Assembler::Operand::Register(ARG2));
+            m_assembler.sign_extend_32_to_64_bits(GPR0);
+            m_assembler.jump_if(
+                Assembler::Operand::Register(GPR0),
+                Assembler::Condition::SignedLessThan,
+                Assembler::Operand::Imm(0),
+                slow_case);
+
+            // GPR0 = extract_pointer(ARG1)
+            extract_object_pointer(GPR0, ARG1);
+
+            // if (object->may_interfere_with_indexed_property_access()) goto slow_case;
+            m_assembler.mov8(
+                Assembler::Operand::Register(GPR1),
+                Assembler::Operand::Mem64BaseAndOffset(GPR0, Object::may_interfere_with_indexed_property_access_offset()));
+            m_assembler.jump_if(
+                Assembler::Operand::Register(GPR1),
+                Assembler::Condition::NotEqualTo,
+                Assembler::Operand::Imm(0),
+                slow_case);
+
+            // GPR0 = object->indexed_properties().storage()
+            m_assembler.mov(
+                Assembler::Operand::Register(GPR0),
+                Assembler::Operand::Mem64BaseAndOffset(GPR0, Object::indexed_properties_offset() + IndexedProperties::storage_offset()));
+
+            // if (GPR0 == nullptr) goto slow_case;
+            m_assembler.jump_if(
+                Assembler::Operand::Register(GPR0),
+                Assembler::Condition::EqualTo,
+                Assembler::Operand::Imm(0),
+                slow_case);
+
+            // if (!GPR0->is_simple_storage()) goto slow_case;
+            m_assembler.mov8(
+                Assembler::Operand::Register(GPR1),
+                Assembler::Operand::Mem64BaseAndOffset(GPR0, IndexedPropertyStorage::is_simple_storage_offset()));
+            m_assembler.jump_if(
+                Assembler::Operand::Register(GPR1),
+                Assembler::Condition::EqualTo,
+                Assembler::Operand::Imm(0),
+                slow_case);
+
+            // GPR2 = extract_int32(ARG2)
+            m_assembler.mov32(
+                Assembler::Operand::Register(GPR2),
+                Assembler::Operand::Register(ARG2));
+
+            // if (GPR2 >= GPR0->array_like_size()) goto slow_case;
+            m_assembler.mov(
+                Assembler::Operand::Register(GPR1),
+                Assembler::Operand::Mem64BaseAndOffset(GPR0, SimpleIndexedPropertyStorage::array_size_offset()));
+            m_assembler.jump_if(
+                Assembler::Operand::Register(GPR2),
+                Assembler::Condition::SignedGreaterThanOrEqualTo,
+                Assembler::Operand::Register(GPR1),
+                slow_case);
+
+            // GPR0 = GPR0->elements().outline_buffer()
+            m_assembler.mov(
+                Assembler::Operand::Register(GPR0),
+                Assembler::Operand::Mem64BaseAndOffset(GPR0, SimpleIndexedPropertyStorage::elements_offset() + Vector<Value>::outline_buffer_offset()));
+
+            // GPR2 *= sizeof(Value)
+            m_assembler.mul32(
+                Assembler::Operand::Register(GPR2),
+                Assembler::Operand::Imm(sizeof(Value)),
+                slow_case);
+
+            // GPR0 = &GRP0[GPR2]
+            // GPR2 = *GPR0
+            m_assembler.add(
+                Assembler::Operand::Register(GPR0),
+                Assembler::Operand::Register(GPR2));
+            m_assembler.mov(
+                Assembler::Operand::Register(GPR2),
+                Assembler::Operand::Mem64BaseAndOffset(GPR0, 0));
+
+            // if (GPR2.is_empty()) goto slow_case;
+            m_assembler.mov(Assembler::Operand::Register(GPR1), Assembler::Operand::Register(GPR2));
+            m_assembler.shift_right(Assembler::Operand::Register(GPR1), Assembler::Operand::Imm(TAG_SHIFT));
+            m_assembler.jump_if(
+                Assembler::Operand::Register(GPR1),
+                Assembler::Condition::EqualTo,
+                Assembler::Operand::Imm(EMPTY_TAG),
+                slow_case);
+
+            // if (GPR2.is_accessor()) goto slow_case;
+            m_assembler.mov(Assembler::Operand::Register(GPR1), Assembler::Operand::Register(GPR2));
+            m_assembler.shift_right(Assembler::Operand::Register(GPR1), Assembler::Operand::Imm(TAG_SHIFT));
+            m_assembler.jump_if(
+                Assembler::Operand::Register(GPR1),
+                Assembler::Condition::EqualTo,
+                Assembler::Operand::Imm(ACCESSOR_TAG),
+                slow_case);
+
+            // GRP1 will clobber ARG3 in X86, so load it later.
+            load_accumulator(ARG3);
+
+            // *GPR0 = value
+            m_assembler.mov(
+                Assembler::Operand::Mem64BaseAndOffset(GPR0, 0),
+                Assembler::Operand::Register(ARG3));
+
+            // accumulator = ARG3;
+            store_accumulator(ARG3);
+            m_assembler.jump(end);
+        });
+    });
+
+    slow_case.link(m_assembler);
     load_accumulator(ARG3);
     m_assembler.mov(
         Assembler::Operand::Register(ARG4),
@@ -1913,6 +2033,7 @@ void Compiler::compile_put_by_value(Bytecode::Op::PutByValue const& op)
     native_call((void*)cxx_put_by_value);
     store_accumulator(RET);
     check_exception();
+    end.link(m_assembler);
 }
 
 static Value cxx_call(VM& vm, Value callee, u32 first_argument_index, u32 argument_count, Value this_value, Bytecode::Op::CallType call_type, Optional<Bytecode::StringTableIndex> const& expression_string)

--- a/Userland/Libraries/LibJS/JIT/Compiler.h
+++ b/Userland/Libraries/LibJS/JIT/Compiler.h
@@ -49,10 +49,7 @@ private:
         O(Exp, exp)                                             \
         O(Mod, mod)                                             \
         O(In, in)                                               \
-        O(InstanceOf, instance_of)                              \
-        O(LooselyInequals, loosely_inequals)                    \
-        O(StrictlyInequals, strict_inequals)                    \
-        O(StrictlyEquals, strict_equals)
+        O(InstanceOf, instance_of)
 
 #    define JS_ENUMERATE_COMPARISON_OPS(O)                           \
         O(LessThan, less_than, SignedLessThan)                       \
@@ -163,6 +160,10 @@ private:
 
     void compile_to_boolean(Assembler::Reg dst, Assembler::Reg src);
     void compile_continuation(Optional<Bytecode::Label>, bool is_await);
+
+    template<typename Codegen>
+    void branch_if_same_type_for_equality(Assembler::Reg, Assembler::Reg, Codegen);
+    void compile_is_strictly_equal(Assembler::Reg, Assembler::Reg, Assembler::Label& slow_case);
 
     void check_exception();
     void handle_exception();

--- a/Userland/Libraries/LibJS/Runtime/DeclarativeEnvironment.h
+++ b/Userland/Libraries/LibJS/Runtime/DeclarativeEnvironment.h
@@ -71,6 +71,7 @@ public:
     [[nodiscard]] u64 environment_serial_number() const { return m_environment_serial_number; }
 
     static FlatPtr bindings_offset() { return OFFSET_OF(DeclarativeEnvironment, m_bindings); }
+    static FlatPtr environment_serial_number_offset() { return OFFSET_OF(DeclarativeEnvironment, m_environment_serial_number); }
 
 private:
     ThrowCompletionOr<Value> get_binding_value_direct(VM&, Binding&, bool strict);

--- a/Userland/Libraries/LibJS/Runtime/ExecutionContext.h
+++ b/Userland/Libraries/LibJS/Runtime/ExecutionContext.h
@@ -30,6 +30,7 @@ struct ExecutionContext {
 
     void visit_edges(Cell::Visitor&);
 
+    static FlatPtr realm_offset() { return OFFSET_OF(ExecutionContext, realm); }
     static FlatPtr lexical_environment_offset() { return OFFSET_OF(ExecutionContext, lexical_environment); }
 
 private:

--- a/Userland/Libraries/LibJS/Runtime/GlobalEnvironment.h
+++ b/Userland/Libraries/LibJS/Runtime/GlobalEnvironment.h
@@ -37,6 +37,9 @@ public:
     ThrowCompletionOr<void> create_global_var_binding(DeprecatedFlyString const& name, bool can_be_deleted);
     ThrowCompletionOr<void> create_global_function_binding(DeprecatedFlyString const& name, Value, bool can_be_deleted);
 
+    static FlatPtr object_record_offset() { return OFFSET_OF(GlobalEnvironment, m_object_record); }
+    static FlatPtr declarative_record_offset() { return OFFSET_OF(GlobalEnvironment, m_declarative_record); }
+
 private:
     GlobalEnvironment(Object&, Object& this_value);
 

--- a/Userland/Libraries/LibJS/Runtime/ObjectEnvironment.h
+++ b/Userland/Libraries/LibJS/Runtime/ObjectEnvironment.h
@@ -41,6 +41,8 @@ public:
     // [[IsWithEnvironment]], Indicates whether this Environment Record is created for a with statement.
     bool is_with_environment() const { return m_with_environment; }
 
+    static FlatPtr binding_object_offset() { return OFFSET_OF(ObjectEnvironment, m_binding_object); }
+
 private:
     ObjectEnvironment(Object& binding_object, IsWithEnvironment, Environment* outer_environment);
 

--- a/Userland/Libraries/LibJS/Runtime/Realm.h
+++ b/Userland/Libraries/LibJS/Runtime/Realm.h
@@ -48,6 +48,8 @@ public:
     HostDefined* host_defined() { return m_host_defined; }
     void set_host_defined(OwnPtr<HostDefined> host_defined) { m_host_defined = move(host_defined); }
 
+    static FlatPtr global_environment_offset() { return OFFSET_OF(Realm, m_global_environment); }
+
 private:
     Realm() = default;
 


### PR DESCRIPTION
Some modest speedups over a few benchmarks
```
Suite    Test                                   Speedup  Old (Mean ± Range)        New (Mean ± Range)
-------  -----------------------------------  ---------  ------------------------  ------------------------
Kraken   ai-astar.js                              0.876  1.360 ± 1.320 … 1.410     1.553 ± 1.440 … 1.730
Kraken   audio-beat-detection.js                  1.126  1.603 ± 1.590 … 1.620     1.423 ± 1.380 … 1.480
Kraken   audio-dft.js                             0.996  0.903 ± 0.860 … 0.940     0.907 ± 0.860 … 0.940
Kraken   audio-fft.js                             1.3    1.503 ± 1.380 … 1.740     1.157 ± 1.100 … 1.210
Kraken   audio-oscillator.js                      1.057  3.233 ± 3.170 … 3.290     3.060 ± 2.880 … 3.150
Kraken   imaging-darkroom.js                      1.044  7.123 ± 6.910 … 7.280     6.820 ± 6.740 … 6.860
Kraken   imaging-desaturate.js                    1.529  2.013 ± 1.960 … 2.120     1.317 ± 1.260 … 1.420
Kraken   imaging-gaussian-blur.js                 1.147  27.343 ± 26.970 … 27.910  23.833 ± 23.560 … 24.310
Kraken   json-parse-financial.js                  0.976  0.137 ± 0.120 … 0.170     0.140 ± 0.130 … 0.150
Kraken   json-stringify-tinderbox.js              1.059  0.360 ± 0.330 … 0.420     0.340 ± 0.330 … 0.360
Kraken   stanford-crypto-aes.js                   0.928  1.120 ± 1.020 … 1.220     1.207 ± 1.150 … 1.280
Kraken   stanford-crypto-ccm.js                   1.033  1.157 ± 1.050 … 1.300     1.120 ± 1.100 … 1.150
Kraken   stanford-crypto-pbkdf2.js                1.067  1.960 ± 1.840 … 2.140     1.837 ± 1.730 … 2.020
Kraken   stanford-crypto-sha256-iterative.js      0.947  0.780 ± 0.750 … 0.810     0.823 ± 0.750 … 0.890
```