### PR TITLE
LibJS/JIT: Remove incorrect check for empty tag

### DIFF
--- a/Userland/Libraries/LibJS/JIT/Compiler.cpp
+++ b/Userland/Libraries/LibJS/JIT/Compiler.cpp
@@ -2428,15 +2428,6 @@ void Compiler::compile_put_by_value(Bytecode::Op::PutByValue const& op)
                 Assembler::Operand::Register(GPR2),
                 Assembler::Operand::Mem64BaseAndOffset(GPR0, 0));
 
-            // if (GPR2.is_empty()) goto slow_case;
-            m_assembler.mov(Assembler::Operand::Register(GPR1), Assembler::Operand::Register(GPR2));
-            m_assembler.shift_right(Assembler::Operand::Register(GPR1), Assembler::Operand::Imm(TAG_SHIFT));
-            m_assembler.jump_if(
-                Assembler::Operand::Register(GPR1),
-                Assembler::Condition::EqualTo,
-                Assembler::Operand::Imm(EMPTY_TAG),
-                slow_case);
-
             // if (GPR2.is_accessor()) goto slow_case;
             m_assembler.mov(Assembler::Operand::Register(GPR1), Assembler::Operand::Register(GPR2));
             m_assembler.shift_right(Assembler::Operand::Register(GPR1), Assembler::Operand::Imm(TAG_SHIFT));


### PR DESCRIPTION
```
Suite       Test                                   Speedup  Old (Mean ± Range)        New (Mean ± Range)
----------  -----------------------------------  ---------  ------------------------  ------------------------
Kraken      ai-astar.js                              1.189  1.197 ± 1.170 … 1.220     1.007 ± 1.000 … 1.010
Kraken      audio-beat-detection.js                  1.312  1.360 ± 1.360 … 1.360     1.037 ± 1.030 … 1.050
Kraken      audio-dft.js                             1.342  0.863 ± 0.860 … 0.870     0.643 ± 0.640 … 0.650
Kraken      audio-fft.js                             1.711  1.243 ± 1.240 … 1.250     0.727 ± 0.720 … 0.730
Kraken      audio-oscillator.js                      1.431  2.677 ± 2.640 … 2.750     1.870 ± 1.850 … 1.890
Kraken      imaging-darkroom.js                      0.962  5.960 ± 5.900 … 6.000     6.197 ± 6.050 … 6.310
Kraken      imaging-desaturate.js                    0.943  1.270 ± 1.230 … 1.290     1.347 ± 1.310 … 1.370
Kraken      imaging-gaussian-blur.js                 0.905  21.230 ± 20.980 … 21.540  23.450 ± 23.200 … 23.630
Kraken      json-parse-financial.js                  0.943  0.110 ± 0.110 … 0.110     0.117 ± 0.110 … 0.120
Kraken      json-stringify-tinderbox.js              0.979  0.313 ± 0.310 … 0.320     0.320 ± 0.320 … 0.320
Kraken      stanford-crypto-aes.js                   0.953  0.937 ± 0.930 … 0.950     0.983 ± 0.970 … 0.990
Kraken      stanford-crypto-ccm.js                   0.99   0.963 ± 0.950 … 0.980     0.973 ± 0.960 … 0.990
Kraken      stanford-crypto-pbkdf2.js                0.996  1.700 ± 1.670 … 1.760     1.707 ± 1.670 … 1.730
Kraken      stanford-crypto-sha256-iterative.js      0.973  0.717 ± 0.710 … 0.720     0.737 ± 0.720 … 0.760
Kraken      Total                                    0.986  40.540                    41.113
All Suites  Total                                    0.986  40.540                    41.113
```