### PR TITLE
Shell: Improve directory glob expansion

### DIFF
--- a/Userland/Shell/Builtin.cpp
+++ b/Userland/Shell/Builtin.cpp
@@ -685,7 +685,7 @@ ErrorOr<int> Shell::builtin_glob(Main::Arguments arguments)
         return 1;
 
     for (auto& glob : globs) {
-        for (auto& expanded : expand_globs(glob, cwd))
+        for (auto& expanded : TRY(expand_globs(glob, cwd)))
             outln("{}", expanded);
     }
 

--- a/Userland/Shell/Shell.cpp
+++ b/Userland/Shell/Shell.cpp
@@ -309,7 +309,7 @@ Vector<DeprecatedString> Shell::expand_globs(Vector<StringView> path_segments, S
         if (is_glob_directory)
             first_segment = first_segment.substring_view(0, first_segment.length() - 1);
 
-        Core::DirIterator di(base, Core::DirIterator::SkipParentAndBaseDir);
+        Core::DirIterator di(base);
         if (di.has_error())
             return {};
 

--- a/Userland/Shell/Shell.h
+++ b/Userland/Shell/Shell.h
@@ -294,7 +294,6 @@ public:
     static SpecialCharacterEscapeMode special_character_escape_mode(u32 c, EscapeMode);
 
     static bool is_glob(StringView);
-    static Vector<StringView> split_path(StringView);
 
     enum class ExecutableOnly {
         Yes,

--- a/Userland/Shell/Shell.h
+++ b/Userland/Shell/Shell.h
@@ -182,7 +182,7 @@ public:
     DeprecatedString prompt() const;
 
     static DeprecatedString expand_tilde(StringView expression);
-    static Vector<DeprecatedString> expand_globs(StringView path, StringView base);
+    static ErrorOr<Vector<DeprecatedString>> expand_globs(StringView path, StringView base);
     static Vector<DeprecatedString> expand_globs(Vector<StringView> path_segments, StringView base);
     ErrorOr<Vector<AST::Command>> expand_aliases(Vector<AST::Command>);
     DeprecatedString resolve_path(DeprecatedString) const;


### PR DESCRIPTION
These changes ensure that the glob `*/` only expands to directories, and that the parent and base directories are also included in the glob `.*`, which is in line with how POSIX handle globs. 

They also include a bunch of error propagation improvements in Shell. Please let me know if these don't belong in this PR, then I'll put them in a separate PR. :)