### PR TITLE
Base: Add completion for cd that suggests only directories

### DIFF
--- a/Base/usr/share/shell/completion/builtin.sh
+++ b/Base/usr/share/shell/completion/builtin.sh
@@ -74,3 +74,17 @@ _complete_kill() {
     __complete_job_spec $*[-1]
   }
 }
+
+_complete_cd() {
+    if test $*[-1] = '--' {
+        invariant_offset=0
+        results=${concat_lists .*/ */}
+    } else {
+        invariant_offset=${length "$*[-1]"}
+        results=$(glob "$*[-1]*/")
+    }
+
+    for $results {
+        echo '{"kind":"plain","static_offset":0,"invariant_offset":'"$invariant_offset"',"completion":"'"${remove_suffix / $it}"'","trailing_trivia":"/"}'
+    }
+}

--- a/Base/usr/share/shell/completion/builtin.sh
+++ b/Base/usr/share/shell/completion/builtin.sh
@@ -68,11 +68,11 @@ __complete_job_spec() {
 }
 
 _complete_kill() {
-  if test $*[-1] = '--' {
-    __complete_job_spec ''
-  } else {
-    __complete_job_spec $*[-1]
-  }
+    if test $*[-1] = '--' {
+        __complete_job_spec ''
+    } else {
+        __complete_job_spec $*[-1]
+    }
 }
 
 _complete_cd() {


### PR DESCRIPTION
This adds a completion function for cd that only returns directories, instead of the default completion that also suggests files, which doesn't make sense for cd.

I am still not quite sure about the significance of some of the values in the JSON-object. These values seem to work, but I am open to feedback. :) 

Depends on #21922