### PR TITLE
LibPDF: Apply all offsets of TJ operator

### DIFF
--- a/Tests/LibPDF/text.pdf
+++ b/Tests/LibPDF/text.pdf
@@ -1,0 +1,78 @@
+%PDF-1.3
+%µ¶
+
+1 0 obj
+<<
+  /Type /Catalog
+  /Pages 2 0 R
+>>
+endobj
+
+2 0 obj
+<<
+  /Type /Pages
+  /Kids [ 3 0 R ]
+  /Count 1
+>>
+endobj
+
+3 0 obj
+<<
+  /Type /Page
+  /Parent 2 0 R
+  /MediaBox [ 0 0 525 250 ]
+  /Contents 4 0 R
+  /Resources <<
+    /Font <<
+      /F1 5 0 R
+    >>
+  >>
+>>
+endobj
+
+4 0 obj
+<<
+  /Length 236
+>>
+stream
+BT
+/F1 24 Tf
+-30 TL
+40 40 Td
+[ (Hello) -2000 (World) ] TJ T*
+[ (Hello) -1000 -1000 (World) ] TJ T*
+[ (Hello) -1000 ] TJ [ -1000 ] TJ [ (World) ] TJ T*
+(should be the same on all lines:) '
+(The distance between "Hello" and "World") '
+ET
+
+endstream
+endobj
+
+5 0 obj
+<<
+  /Type /Font
+  /Subtype /Type1
+  /Name /F1
+  /BaseFont /Helvetica
+  /Encoding /MacRomanEncoding
+>>
+endobj
+
+xref
+0 6
+0000000000 65536 f 
+0000000016 00000 n 
+0000000070 00000 n 
+0000000136 00000 n 
+0000000291 00000 n 
+0000000581 00000 n 
+
+trailer
+<<
+  /Size 6
+  /Root 1 0 R
+>>
+startxref
+700
+%%EOF

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -518,16 +518,15 @@ RENDERER_HANDLER(text_next_line_show_string_set_spacing)
 RENDERER_HANDLER(text_show_string_array)
 {
     auto elements = MUST(m_document->resolve_to<ArrayObject>(args[0]))->elements();
-    float next_shift = 0.0f;
 
     for (auto& element : elements) {
         if (element.has<int>()) {
-            next_shift = element.get<int>();
-        } else if (element.has<float>()) {
-            next_shift = element.get<float>();
-        } else {
-            auto shift = next_shift / 1000.0f;
+            float shift = (float)element.get<int>() / 1000.0f;
             m_text_matrix.translate(-shift * text_state().font_size * text_state().horizontal_scaling, 0.0f);
+        } else if (element.has<float>()) {
+            float shift = element.get<float>() / 1000.0f;
+            m_text_matrix.translate(-shift * text_state().font_size * text_state().horizontal_scaling, 0.0f);
+        } else {
             auto str = element.get<NonnullRefPtr<Object>>()->cast<StringObject>()->string();
             TRY(show_text(str));
         }


### PR DESCRIPTION
TJ acts on a list of either strings or numbers.
The strings are drawn, and the numbers are treated as offsets.

Previously, we'd only apply the last-seen number as offset when
we saw a string. That had the effect of us ignoring all but the
last number in front of a string, and ignoring numbers at the
end of the list.

Now, we apply all numbers as offsets.
Our rendering of Tests/LibPDF/text.pdf now matches other PDF viewers.