### PR TITLE
LibDNS: Ensure DNS name and label sizes are within expected limits

### DIFF
--- a/Meta/Lagom/Fuzzers/FuzzDNSPacket.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzDNSPacket.cpp
@@ -9,10 +9,10 @@
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
     AK::set_debug_enabled(false);
-    auto maybe_packet = DNS::Packet::from_raw_packet({ data, size });
-    if (!maybe_packet.has_value())
+    auto packet_or_error = DNS::Packet::from_raw_packet({ data, size });
+    if (packet_or_error.is_error())
         return 0;
 
-    (void)maybe_packet.value().to_byte_buffer();
+    (void)packet_or_error.release_value().to_byte_buffer();
     return 0;
 }

--- a/Userland/Libraries/LibDNS/Name.h
+++ b/Userland/Libraries/LibDNS/Name.h
@@ -17,7 +17,7 @@ public:
     Name() = default;
     Name(DeprecatedString const&);
 
-    static Name parse(ReadonlyBytes data, size_t& offset, size_t recursion_level = 0);
+    static ErrorOr<Name> parse(ReadonlyBytes data, size_t& offset, size_t recursion_level = 0);
 
     size_t serialized_size() const;
     DeprecatedString const& as_string() const { return m_name; }

--- a/Userland/Libraries/LibDNS/Packet.h
+++ b/Userland/Libraries/LibDNS/Packet.h
@@ -24,7 +24,7 @@ class Packet {
 public:
     Packet() = default;
 
-    static Optional<Packet> from_raw_packet(ReadonlyBytes bytes);
+    static ErrorOr<Packet> from_raw_packet(ReadonlyBytes bytes);
     ErrorOr<ByteBuffer> to_byte_buffer() const;
 
     bool is_query() const { return !m_query_or_response; }

--- a/Userland/Services/LookupServer/DNSServer.cpp
+++ b/Userland/Services/LookupServer/DNSServer.cpp
@@ -29,12 +29,7 @@ ErrorOr<void> DNSServer::handle_client()
 {
     sockaddr_in client_address;
     auto buffer = TRY(receive(1024, client_address));
-    auto optional_request = Packet::from_raw_packet(buffer);
-    if (!optional_request.has_value()) {
-        dbgln("Got an invalid DNS packet");
-        return {};
-    }
-    auto& request = optional_request.value();
+    auto request = TRY(Packet::from_raw_packet(buffer));
 
     if (!request.is_query()) {
         dbgln("It's not a request");

--- a/Userland/Services/LookupServer/LookupServer.cpp
+++ b/Userland/Services/LookupServer/LookupServer.cpp
@@ -269,11 +269,11 @@ ErrorOr<Vector<Answer>> LookupServer::lookup(Name const& name, DeprecatedString 
 
     did_get_response = true;
 
-    auto o_response = Packet::from_raw_packet({ response_buffer, nrecv });
-    if (!o_response.has_value())
+    auto response_or_error = Packet::from_raw_packet({ response_buffer, nrecv });
+    if (response_or_error.is_error())
         return Vector<Answer> {};
 
-    auto& response = o_response.value();
+    auto response = response_or_error.release_value();
 
     if (response.id() != request.id()) {
         dbgln("LookupServer: ID mismatch ({} vs {}) :(", response.id(), request.id());


### PR DESCRIPTION
The DNS parser will now fail to parse a packet with any invalid name parts, rather than returning a packet with an empty name.

Previously, the DNS packet parser would happily parse a DNS packet containing an arbitrarily large domain name. We now limit each segment of a domain name to 63 characters and the total domain name length to 253 characters. This is consistent with RFC1035, which specifies that the maximum name length is 255 octets. This includes the initial length byte and final null byte, which are not displayed and account for the 2 byte difference.

This fixes oss fuzz issue: [64145](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=64145)