### PR TITLE
LibJS: Remove redundant use of `JsonValue::{is,as}_i32()` (-2 +0 diff)

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/JSONObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/JSONObject.cpp
@@ -432,8 +432,6 @@ Value JSONObject::parse_json_value(VM& vm, JsonValue const& value)
         return Value(parse_json_array(vm, value.as_array()));
     if (value.is_null())
         return js_null();
-    if (value.is_i32())
-        return Value(value.as_i32());
     if (value.is_number())
         return Value(value.to_double(0));
     if (value.is_string())


### PR DESCRIPTION
`Value::Value(double)` already converts double to int when it is safe, no need to check for this here explicitly.