### PR TITLE
AK: Ban JsonValue from the kernel and remove ifdef guards

### DIFF
--- a/Kernel/FileSystem/ProcFS/ProcessExposed.cpp
+++ b/Kernel/FileSystem/ProcFS/ProcessExposed.cpp
@@ -6,7 +6,6 @@
 
 #include <AK/JsonArraySerializer.h>
 #include <AK/JsonObjectSerializer.h>
-#include <AK/JsonValue.h>
 #include <Kernel/Devices/TTY/TTY.h>
 #include <Kernel/FileSystem/Custody.h>
 #include <Kernel/FileSystem/ProcFS/Inode.h>


### PR DESCRIPTION
JsonValue can store JsonObject which uses DS for keys, so it is not safe to use it in the kernel even with the double/String guards.