### PR TITLE
Browser: Move `BookmarksBarWidget::PerformEditOn` to anon namespace

### DIFF
--- a/Userland/Applications/Browser/BookmarksBarWidget.cpp
+++ b/Userland/Applications/Browser/BookmarksBarWidget.cpp
@@ -27,15 +27,20 @@ namespace Browser {
 
 namespace {
 
+enum class PerformEditOn {
+    NewBookmark,
+    ExistingBookmark
+};
+
 class BookmarkEditor final : public GUI::Dialog {
     C_OBJECT(BookmarkEditor)
 
 public:
     static Vector<JsonValue>
-    edit_bookmark(Window* parent_window, StringView title, StringView url, BookmarksBarWidget::PerformEditOn perform_edit_on)
+    edit_bookmark(Window* parent_window, StringView title, StringView url, PerformEditOn perform_edit_on)
     {
         auto editor = BookmarkEditor::construct(parent_window, title, url);
-        if (perform_edit_on == BookmarksBarWidget::PerformEditOn::NewBookmark) {
+        if (perform_edit_on == PerformEditOn::NewBookmark) {
             editor->set_title("Add Bookmark");
         } else {
             editor->set_title("Edit Bookmark");

--- a/Userland/Applications/Browser/BookmarksBarWidget.h
+++ b/Userland/Applications/Browser/BookmarksBarWidget.h
@@ -32,11 +32,6 @@ public:
         InNewWindow
     };
 
-    enum class PerformEditOn {
-        NewBookmark,
-        ExistingBookmark
-    };
-
     Function<void(DeprecatedString const& url, Open)> on_bookmark_click;
     Function<void(DeprecatedString const&, DeprecatedString const&)> on_bookmark_hover;
     Function<void()> on_bookmark_change;


### PR DESCRIPTION
Since none of `BookmarksBarWidget`'s methods use this enum class any longer, let's just move it to the anonymous namespace so that `BookmarkEditor` can still make use of it.