### PR TITLE
AK+Applications: Return value from JsonObject::get_double more often (and fix Inspector on Serenity)

### DIFF
--- a/AK/JsonObject.cpp
+++ b/AK/JsonObject.cpp
@@ -135,19 +135,19 @@ Optional<JsonArray const&> JsonObject::get_array(StringView key) const
 }
 
 #if !defined(KERNEL)
-Optional<double> JsonObject::get_double(StringView key) const
+Optional<double> JsonObject::get_double_with_precision_loss(StringView key) const
 {
     auto maybe_value = get(key);
-    if (maybe_value.has_value() && maybe_value->is_double())
-        return maybe_value->as_double();
+    if (maybe_value.has_value() && maybe_value->is_number())
+        return maybe_value->to_number<double>();
     return {};
 }
 
-Optional<float> JsonObject::get_float(StringView key) const
+Optional<float> JsonObject::get_float_with_precision_loss(StringView key) const
 {
     auto maybe_value = get(key);
-    if (maybe_value.has_value() && maybe_value->is_double())
-        return static_cast<float>(maybe_value->as_double());
+    if (maybe_value.has_value() && maybe_value->is_number())
+        return maybe_value->to_number<float>();
     return {};
 }
 #endif

--- a/AK/JsonObject.h
+++ b/AK/JsonObject.h
@@ -85,8 +85,8 @@ public:
     Optional<JsonArray const&> get_array(StringView key) const;
 
 #if !defined(KERNEL)
-    Optional<double> get_double(StringView key) const;
-    Optional<float> get_float(StringView key) const;
+    Optional<double> get_double_with_precision_loss(StringView key) const;
+    Optional<float> get_float_with_precision_loss(StringView key) const;
 #endif
 
     void set(DeprecatedString const& key, JsonValue value);

--- a/Userland/Applications/Browser/InspectorWidget.cpp
+++ b/Userland/Applications/Browser/InspectorWidget.cpp
@@ -183,21 +183,21 @@ void InspectorWidget::update_node_box_model(StringView node_box_sizing_json)
     auto json_value = json_or_error.release_value();
     auto const& json_object = json_value.as_object();
 
-    m_node_box_sizing.margin.top = Web::CSSPixels(json_object.get_float("margin_top"sv).value_or(0));
-    m_node_box_sizing.margin.right = Web::CSSPixels(json_object.get_float("margin_right"sv).value_or(0));
-    m_node_box_sizing.margin.bottom = Web::CSSPixels(json_object.get_float("margin_bottom"sv).value_or(0));
-    m_node_box_sizing.margin.left = Web::CSSPixels(json_object.get_float("margin_left"sv).value_or(0));
-    m_node_box_sizing.padding.top = Web::CSSPixels(json_object.get_float("padding_top"sv).value_or(0));
-    m_node_box_sizing.padding.right = Web::CSSPixels(json_object.get_float("padding_right"sv).value_or(0));
-    m_node_box_sizing.padding.bottom = Web::CSSPixels(json_object.get_float("padding_bottom"sv).value_or(0));
-    m_node_box_sizing.padding.left = Web::CSSPixels(json_object.get_float("padding_left"sv).value_or(0));
-    m_node_box_sizing.border.top = Web::CSSPixels(json_object.get_float("border_top"sv).value_or(0));
-    m_node_box_sizing.border.right = Web::CSSPixels(json_object.get_float("border_right"sv).value_or(0));
-    m_node_box_sizing.border.bottom = Web::CSSPixels(json_object.get_float("border_bottom"sv).value_or(0));
-    m_node_box_sizing.border.left = Web::CSSPixels(json_object.get_float("border_left"sv).value_or(0));
+    m_node_box_sizing.margin.top = Web::CSSPixels(json_object.get_float_with_precision_loss("margin_top"sv).value_or(0));
+    m_node_box_sizing.margin.right = Web::CSSPixels(json_object.get_float_with_precision_loss("margin_right"sv).value_or(0));
+    m_node_box_sizing.margin.bottom = Web::CSSPixels(json_object.get_float_with_precision_loss("margin_bottom"sv).value_or(0));
+    m_node_box_sizing.margin.left = Web::CSSPixels(json_object.get_float_with_precision_loss("margin_left"sv).value_or(0));
+    m_node_box_sizing.padding.top = Web::CSSPixels(json_object.get_float_with_precision_loss("padding_top"sv).value_or(0));
+    m_node_box_sizing.padding.right = Web::CSSPixels(json_object.get_float_with_precision_loss("padding_right"sv).value_or(0));
+    m_node_box_sizing.padding.bottom = Web::CSSPixels(json_object.get_float_with_precision_loss("padding_bottom"sv).value_or(0));
+    m_node_box_sizing.padding.left = Web::CSSPixels(json_object.get_float_with_precision_loss("padding_left"sv).value_or(0));
+    m_node_box_sizing.border.top = Web::CSSPixels(json_object.get_float_with_precision_loss("border_top"sv).value_or(0));
+    m_node_box_sizing.border.right = Web::CSSPixels(json_object.get_float_with_precision_loss("border_right"sv).value_or(0));
+    m_node_box_sizing.border.bottom = Web::CSSPixels(json_object.get_float_with_precision_loss("border_bottom"sv).value_or(0));
+    m_node_box_sizing.border.left = Web::CSSPixels(json_object.get_float_with_precision_loss("border_left"sv).value_or(0));
 
-    m_element_size_view->set_node_content_width(json_object.get_float("content_width"sv).value_or(0));
-    m_element_size_view->set_node_content_height(json_object.get_float("content_height"sv).value_or(0));
+    m_element_size_view->set_node_content_width(json_object.get_float_with_precision_loss("content_width"sv).value_or(0));
+    m_element_size_view->set_node_content_height(json_object.get_float_with_precision_loss("content_height"sv).value_or(0));
     m_element_size_view->set_box_model(m_node_box_sizing);
 }
 

--- a/Userland/Applications/Maps/FavoritesPanel.cpp
+++ b/Userland/Applications/Maps/FavoritesPanel.cpp
@@ -64,8 +64,8 @@ void FavoritesPanel::load_favorites()
     Vector<GUI::JsonArrayModel::FieldSpec> favorites_fields;
     favorites_fields.empend("name", "Name"_string, Gfx::TextAlignment::CenterLeft, [](JsonObject const& object) -> GUI::Variant {
         DeprecatedString name = object.get_deprecated_string("name"sv).release_value();
-        double latitude = object.get_double("latitude"sv).release_value();
-        double longitude = object.get_double("longitude"sv).release_value();
+        double latitude = object.get_double_with_precision_loss("latitude"sv).release_value();
+        double longitude = object.get_double_with_precision_loss("longitude"sv).release_value();
         return DeprecatedString::formatted("{}\n{:.5}, {:.5}", name, latitude, longitude);
     });
     favorites_fields.empend("latitude", "Latitude"_string, Gfx::TextAlignment::CenterLeft);


### PR DESCRIPTION
Previously, we were returning an empty optional if key contained a numerical value which was not stored as double. Stop doing that and rename the method to signify the change in the behavior.

Apparently, this fixes bug in an InspectorWidget in Ladybird on Serenity: it showed 0 for element's boxes with integer sizes.

-------

Other `get_x` methods fail if numerical value stored in `JsonValue` is out of range for the expected type. So method rename, while not strictly necessary, makes JsonObject API somewhat more consistent.  It also now explicitly signify possible precision loss, which aligns with my plans of enabling FP conversion warnings and making all FP precision casts explicit.

The patch also removes one more user of questionable `JsonValue::{is,as}_{double,i32,u32,i64,u64}` APIs.