### PR TITLE
LibGfx/Path: Round numerator in elliptical_arc_to

### DIFF
--- a/Userland/Libraries/LibGfx/Path.cpp
+++ b/Userland/Libraries/LibGfx/Path.cpp
@@ -127,7 +127,7 @@ void Path::elliptical_arc_to(FloatPoint point, FloatSize radii, float x_axis_rot
     } else {
         double numerator = rx_sq * ry_sq - rx_sq * y1p_sq - ry_sq * x1p_sq;
         double denominator = rx_sq * y1p_sq + ry_sq * x1p_sq;
-        multiplier = AK::sqrt(numerator / denominator);
+        multiplier = AK::sqrt(AK::max(0., numerator) / denominator);
     }
 
     if (large_arc == sweep)


### PR DESCRIPTION
As suggested by @DanShaders this fixes a crash on macOS without messing up with the compiler flags.

This avoids rounding problems which made Ladybird crash with some SVGs on macOS/Clang.

When opening `https://warpdesign.fr/tests/crash.svg` this now display the same thing as Chrome instead of crashing.

Ladybird
<img width="773" alt="Screenshot 2023-11-15 at 10 44 24" src="https://github.com/SerenityOS/serenity/assets/199648/7377fce6-2397-43f3-a11d-cb730d641408">

Chrome
![Screenshot 2023-11-15 at 10 46 44](https://github.com/SerenityOS/serenity/assets/199648/4b93befd-64c0-49b2-9022-3ba5f5be99f8)

Fixes #21723