### PR TITLE
LibPDF: Add an initial implementation of type 3 glyph rendering

### DIFF
--- a/Userland/Libraries/LibPDF/CMakeLists.txt
+++ b/Userland/Libraries/LibPDF/CMakeLists.txt
@@ -14,6 +14,7 @@ set(SOURCES
     Fonts/Type0Font.cpp
     Fonts/Type1Font.cpp
     Fonts/Type1FontProgram.cpp
+    Fonts/Type3Font.cpp
     Function.cpp
     Interpolation.cpp
     ObjectDerivatives.cpp

--- a/Userland/Libraries/LibPDF/CommonNames.h
+++ b/Userland/Libraries/LibPDF/CommonNames.h
@@ -37,6 +37,7 @@
     X(CIDFontType2)               \
     X(CIDSystemInfo)              \
     X(CIDToGIDMap)                \
+    X(CharProcs)                  \
     X(Colors)                     \
     X(ColorSpace)                 \
     X(Columns)                    \
@@ -86,6 +87,7 @@
     X(FontFile)                   \
     X(FontFile2)                  \
     X(FontFile3)                  \
+    X(FontMatrix)                 \
     X(FunctionType)               \
     X(Functions)                  \
     X(Gamma)                      \

--- a/Userland/Libraries/LibPDF/Fonts/PDFFont.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/PDFFont.cpp
@@ -41,9 +41,11 @@ PDFErrorOr<NonnullRefPtr<PDFFont>> PDFFont::create(Document* document, NonnullRe
         font = adopt_ref(*new Type1Font());
     } else if (subtype == "TrueType") {
         font = adopt_ref(*new TrueTypeFont());
-    } else if (subtype == "Type0")
+    } else if (subtype == "Type0") {
         font = adopt_ref(*new Type0Font());
-    else {
+    } else if (subtype == "Type3") {
+        return Error { Error::Type::RenderingUnsupported, "Type3 fonts not yet implemented" };
+    } else {
         dbgln_if(PDF_DEBUG, "Unhandled font subtype: {}", subtype);
         return Error::internal_error("Unhandled font subtype");
     }

--- a/Userland/Libraries/LibPDF/Fonts/PDFFont.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/PDFFont.cpp
@@ -12,6 +12,7 @@
 #include <LibPDF/Fonts/TrueTypeFont.h>
 #include <LibPDF/Fonts/Type0Font.h>
 #include <LibPDF/Fonts/Type1Font.h>
+#include <LibPDF/Fonts/Type3Font.h>
 
 namespace PDF {
 
@@ -44,7 +45,7 @@ PDFErrorOr<NonnullRefPtr<PDFFont>> PDFFont::create(Document* document, NonnullRe
     } else if (subtype == "Type0") {
         font = adopt_ref(*new Type0Font());
     } else if (subtype == "Type3") {
-        return Error { Error::Type::RenderingUnsupported, "Type3 fonts not yet implemented" };
+        font = adopt_ref(*new Type3Font());
     } else {
         dbgln_if(PDF_DEBUG, "Unhandled font subtype: {}", subtype);
         return Error::internal_error("Unhandled font subtype");

--- a/Userland/Libraries/LibPDF/Fonts/PDFFont.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/PDFFont.cpp
@@ -54,9 +54,8 @@ PDFErrorOr<NonnullRefPtr<PDFFont>> PDFFont::create(Document* document, NonnullRe
     return font.release_nonnull();
 }
 
-PDFErrorOr<void> PDFFont::initialize(Document* document, NonnullRefPtr<DictObject> const& dict, float)
+PDFErrorOr<void> PDFFont::initialize(Document*, NonnullRefPtr<DictObject> const&, float)
 {
-    m_base_font_name = TRY(dict->get_name(document, CommonNames::BaseFont))->name();
     return {};
 }
 

--- a/Userland/Libraries/LibPDF/Fonts/PDFFont.h
+++ b/Userland/Libraries/LibPDF/Fonts/PDFFont.h
@@ -23,14 +23,9 @@ public:
     virtual void set_font_size(float font_size) = 0;
     virtual PDFErrorOr<Gfx::FloatPoint> draw_string(Gfx::Painter&, Gfx::FloatPoint, DeprecatedString const&, Color const&, float font_size, float character_spacing, float word_spacing, float horizontal_scaling) = 0;
 
-    DeprecatedFlyString base_font_name() const { return m_base_font_name; }
-
 protected:
     virtual PDFErrorOr<void> initialize(Document* document, NonnullRefPtr<DictObject> const& dict, float font_size);
     static PDFErrorOr<NonnullRefPtr<Gfx::Font>> replacement_for(StringView name, float font_size);
-
-private:
-    DeprecatedFlyString m_base_font_name;
 };
 
 }

--- a/Userland/Libraries/LibPDF/Fonts/PDFFont.h
+++ b/Userland/Libraries/LibPDF/Fonts/PDFFont.h
@@ -16,12 +16,6 @@ namespace PDF {
 
 class PDFFont : public RefCounted<PDFFont> {
 public:
-    enum class Type {
-        Type0,
-        Type1,
-        TrueType
-    };
-
     static PDFErrorOr<NonnullRefPtr<PDFFont>> create(Document*, NonnullRefPtr<DictObject> const&, float font_size);
 
     virtual ~PDFFont() = default;
@@ -29,7 +23,6 @@ public:
     virtual void set_font_size(float font_size) = 0;
     virtual PDFErrorOr<Gfx::FloatPoint> draw_string(Gfx::Painter&, Gfx::FloatPoint, DeprecatedString const&, Color const&, float font_size, float character_spacing, float word_spacing, float horizontal_scaling) = 0;
 
-    virtual Type type() const = 0;
     DeprecatedFlyString base_font_name() const { return m_base_font_name; }
 
 protected:

--- a/Userland/Libraries/LibPDF/Fonts/PDFFont.h
+++ b/Userland/Libraries/LibPDF/Fonts/PDFFont.h
@@ -14,6 +14,8 @@
 
 namespace PDF {
 
+class Renderer;
+
 class PDFFont : public RefCounted<PDFFont> {
 public:
     static PDFErrorOr<NonnullRefPtr<PDFFont>> create(Document*, NonnullRefPtr<DictObject> const&, float font_size);
@@ -21,7 +23,7 @@ public:
     virtual ~PDFFont() = default;
 
     virtual void set_font_size(float font_size) = 0;
-    virtual PDFErrorOr<Gfx::FloatPoint> draw_string(Gfx::Painter&, Gfx::FloatPoint, DeprecatedString const&, Color const&, float font_size, float character_spacing, float word_spacing, float horizontal_scaling) = 0;
+    virtual PDFErrorOr<Gfx::FloatPoint> draw_string(Gfx::Painter&, Gfx::FloatPoint, DeprecatedString const&, Renderer const&) = 0;
 
 protected:
     virtual PDFErrorOr<void> initialize(Document* document, NonnullRefPtr<DictObject> const& dict, float font_size);

--- a/Userland/Libraries/LibPDF/Fonts/SimpleFont.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/SimpleFont.cpp
@@ -58,7 +58,7 @@ PDFErrorOr<Gfx::FloatPoint> SimpleFont::draw_string(Gfx::Painter& painter, Gfx::
         else
             glyph_width = m_missing_width;
 
-        draw_glyph(painter, glyph_position, glyph_width, char_code, paint_color);
+        TRY(draw_glyph(painter, glyph_position, glyph_width, char_code, paint_color));
 
         auto tx = glyph_width;
         tx += character_spacing;

--- a/Userland/Libraries/LibPDF/Fonts/SimpleFont.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/SimpleFont.cpp
@@ -52,11 +52,11 @@ PDFErrorOr<Gfx::FloatPoint> SimpleFont::draw_string(Gfx::Painter& painter, Gfx::
         // and use the default width for the given font otherwise.
         float glyph_width;
         if (auto width = m_widths.get(char_code); width.has_value())
-            glyph_width = font_size * width.value() / 1000.0f;
+            glyph_width = font_size * width.value() * m_font_matrix.x_scale();
         else if (auto width = get_glyph_width(char_code); width.has_value())
             glyph_width = width.value();
         else
-            glyph_width = m_missing_width;
+            glyph_width = m_missing_width; // FIXME: times m_font_matrix.x_scale() probably?
 
         TRY(draw_glyph(painter, glyph_position, glyph_width, char_code, paint_color));
 

--- a/Userland/Libraries/LibPDF/Fonts/SimpleFont.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/SimpleFont.cpp
@@ -48,8 +48,6 @@ PDFErrorOr<void> SimpleFont::initialize(Document* document, NonnullRefPtr<DictOb
 
 PDFErrorOr<Gfx::FloatPoint> SimpleFont::draw_string(Gfx::Painter& painter, Gfx::FloatPoint glyph_position, DeprecatedString const& string, Renderer const& renderer)
 {
-    Color const& paint_color = renderer.state().paint_color;
-
     auto const& text_rendering_matrix = renderer.calculate_text_rendering_matrix();
     auto font_size = text_rendering_matrix.x_scale() * renderer.text_state().font_size;
 
@@ -68,7 +66,7 @@ PDFErrorOr<Gfx::FloatPoint> SimpleFont::draw_string(Gfx::Painter& painter, Gfx::
         else
             glyph_width = m_missing_width; // FIXME: times m_font_matrix.x_scale() probably?
 
-        TRY(draw_glyph(painter, glyph_position, glyph_width, char_code, paint_color));
+        TRY(draw_glyph(painter, glyph_position, glyph_width, char_code, renderer));
 
         auto tx = glyph_width;
         tx += character_spacing;

--- a/Userland/Libraries/LibPDF/Fonts/SimpleFont.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/SimpleFont.cpp
@@ -11,6 +11,7 @@
 #include <LibPDF/Fonts/SimpleFont.h>
 #include <LibPDF/Fonts/TrueTypeFont.h>
 #include <LibPDF/Fonts/Type1Font.h>
+#include <LibPDF/Renderer.h>
 
 namespace PDF {
 
@@ -45,8 +46,17 @@ PDFErrorOr<void> SimpleFont::initialize(Document* document, NonnullRefPtr<DictOb
     return {};
 }
 
-PDFErrorOr<Gfx::FloatPoint> SimpleFont::draw_string(Gfx::Painter& painter, Gfx::FloatPoint glyph_position, DeprecatedString const& string, Color const& paint_color, float font_size, float character_spacing, float word_spacing, float horizontal_scaling)
+PDFErrorOr<Gfx::FloatPoint> SimpleFont::draw_string(Gfx::Painter& painter, Gfx::FloatPoint glyph_position, DeprecatedString const& string, Renderer const& renderer)
 {
+    Color const& paint_color = renderer.state().paint_color;
+
+    auto const& text_rendering_matrix = renderer.calculate_text_rendering_matrix();
+    auto font_size = text_rendering_matrix.x_scale() * renderer.text_state().font_size;
+
+    auto character_spacing = text_rendering_matrix.x_scale() * renderer.text_state().character_spacing;
+    auto word_spacing = text_rendering_matrix.x_scale() * renderer.text_state().word_spacing;
+    auto horizontal_scaling = renderer.text_state().horizontal_scaling;
+
     for (auto char_code : string.bytes()) {
         // Use the width specified in the font's dictionary if available,
         // and use the default width for the given font otherwise.

--- a/Userland/Libraries/LibPDF/Fonts/SimpleFont.h
+++ b/Userland/Libraries/LibPDF/Fonts/SimpleFont.h
@@ -18,7 +18,7 @@ public:
 protected:
     PDFErrorOr<void> initialize(Document* document, NonnullRefPtr<DictObject> const& dict, float font_size) override;
     virtual Optional<float> get_glyph_width(u8 char_code) const = 0;
-    virtual PDFErrorOr<void> draw_glyph(Gfx::Painter& painter, Gfx::FloatPoint point, float width, u8 char_code, Color color) = 0;
+    virtual PDFErrorOr<void> draw_glyph(Gfx::Painter& painter, Gfx::FloatPoint point, float width, u8 char_code, Renderer const&) = 0;
     RefPtr<Encoding>& encoding() { return m_encoding; }
     RefPtr<Encoding> const& encoding() const { return m_encoding; }
 

--- a/Userland/Libraries/LibPDF/Fonts/SimpleFont.h
+++ b/Userland/Libraries/LibPDF/Fonts/SimpleFont.h
@@ -22,11 +22,18 @@ protected:
     RefPtr<Encoding>& encoding() { return m_encoding; }
     RefPtr<Encoding> const& encoding() const { return m_encoding; }
 
+    Gfx::AffineTransform& font_matrix() { return m_font_matrix; }
+
 private:
     RefPtr<Encoding> m_encoding;
     RefPtr<StreamObject> m_to_unicode;
     HashMap<u8, u16> m_widths;
     u16 m_missing_width { 0 };
+
+    // "For all font types except Type 3, the units of glyph space are one-thousandth of a unit of text space;
+    // for a Type 3 font, the transformation from glyph space to text space is defined by a font matrix specified
+    // in an explicit FontMatrix entry in the font."
+    Gfx::AffineTransform m_font_matrix { 1.0f / 1000.0f, 0, 0, 1.0f / 1000.0f, 0, 0 };
 };
 
 }

--- a/Userland/Libraries/LibPDF/Fonts/SimpleFont.h
+++ b/Userland/Libraries/LibPDF/Fonts/SimpleFont.h
@@ -18,7 +18,7 @@ public:
 protected:
     PDFErrorOr<void> initialize(Document* document, NonnullRefPtr<DictObject> const& dict, float font_size) override;
     virtual Optional<float> get_glyph_width(u8 char_code) const = 0;
-    virtual void draw_glyph(Gfx::Painter& painter, Gfx::FloatPoint point, float width, u8 char_code, Color color) = 0;
+    virtual PDFErrorOr<void> draw_glyph(Gfx::Painter& painter, Gfx::FloatPoint point, float width, u8 char_code, Color color) = 0;
     RefPtr<Encoding>& encoding() { return m_encoding; }
     RefPtr<Encoding> const& encoding() const { return m_encoding; }
 

--- a/Userland/Libraries/LibPDF/Fonts/SimpleFont.h
+++ b/Userland/Libraries/LibPDF/Fonts/SimpleFont.h
@@ -13,7 +13,7 @@ namespace PDF {
 
 class SimpleFont : public PDFFont {
 public:
-    PDFErrorOr<Gfx::FloatPoint> draw_string(Gfx::Painter&, Gfx::FloatPoint, DeprecatedString const&, Color const&, float font_size, float character_spacing, float word_spacing, float horizontal_scaling) override;
+    PDFErrorOr<Gfx::FloatPoint> draw_string(Gfx::Painter&, Gfx::FloatPoint, DeprecatedString const&, Renderer const&) override;
 
 protected:
     PDFErrorOr<void> initialize(Document* document, NonnullRefPtr<DictObject> const& dict, float font_size) override;

--- a/Userland/Libraries/LibPDF/Fonts/TrueTypeFont.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/TrueTypeFont.cpp
@@ -45,11 +45,12 @@ void TrueTypeFont::set_font_size(float font_size)
     m_font = m_font->with_size((font_size * POINTS_PER_INCH) / DEFAULT_DPI);
 }
 
-void TrueTypeFont::draw_glyph(Gfx::Painter& painter, Gfx::FloatPoint point, float, u8 char_code, Color color)
+PDFErrorOr<void> TrueTypeFont::draw_glyph(Gfx::Painter& painter, Gfx::FloatPoint point, float, u8 char_code, Color color)
 {
     // Account for the reversed font baseline
     auto position = point.translated(0, -m_font->baseline());
     painter.draw_glyph(position, char_code, *m_font, color);
+    return {};
 }
 
 }

--- a/Userland/Libraries/LibPDF/Fonts/TrueTypeFont.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/TrueTypeFont.cpp
@@ -10,6 +10,7 @@
 #include <LibGfx/Painter.h>
 #include <LibPDF/CommonNames.h>
 #include <LibPDF/Fonts/TrueTypeFont.h>
+#include <LibPDF/Renderer.h>
 
 namespace PDF {
 
@@ -47,8 +48,10 @@ void TrueTypeFont::set_font_size(float font_size)
     m_font = m_font->with_size((font_size * POINTS_PER_INCH) / DEFAULT_DPI);
 }
 
-PDFErrorOr<void> TrueTypeFont::draw_glyph(Gfx::Painter& painter, Gfx::FloatPoint point, float, u8 char_code, Color color)
+PDFErrorOr<void> TrueTypeFont::draw_glyph(Gfx::Painter& painter, Gfx::FloatPoint point, float, u8 char_code, Renderer const& renderer)
 {
+    auto color = renderer.state().paint_color;
+
     // Account for the reversed font baseline
     auto position = point.translated(0, -m_font->baseline());
     painter.draw_glyph(position, char_code, *m_font, color);

--- a/Userland/Libraries/LibPDF/Fonts/TrueTypeFont.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/TrueTypeFont.cpp
@@ -17,6 +17,8 @@ PDFErrorOr<void> TrueTypeFont::initialize(Document* document, NonnullRefPtr<Dict
 {
     TRY(SimpleFont::initialize(document, dict, font_size));
 
+    m_base_font_name = TRY(dict->get_name(document, CommonNames::BaseFont))->name();
+
     // If there's an embedded font program we use that; otherwise we try to find a replacement font
     if (dict->contains(CommonNames::FontDescriptor)) {
         auto descriptor = MUST(dict->get_dict(document, CommonNames::FontDescriptor));

--- a/Userland/Libraries/LibPDF/Fonts/TrueTypeFont.h
+++ b/Userland/Libraries/LibPDF/Fonts/TrueTypeFont.h
@@ -16,7 +16,7 @@ class TrueTypeFont : public SimpleFont {
 public:
     Optional<float> get_glyph_width(u8 char_code) const override;
     void set_font_size(float font_size) override;
-    void draw_glyph(Gfx::Painter&, Gfx::FloatPoint, float, u8, Color) override;
+    PDFErrorOr<void> draw_glyph(Gfx::Painter&, Gfx::FloatPoint, float, u8, Color) override;
 
 protected:
     PDFErrorOr<void> initialize(Document*, NonnullRefPtr<DictObject> const&, float font_size) override;

--- a/Userland/Libraries/LibPDF/Fonts/TrueTypeFont.h
+++ b/Userland/Libraries/LibPDF/Fonts/TrueTypeFont.h
@@ -16,7 +16,7 @@ class TrueTypeFont : public SimpleFont {
 public:
     Optional<float> get_glyph_width(u8 char_code) const override;
     void set_font_size(float font_size) override;
-    PDFErrorOr<void> draw_glyph(Gfx::Painter&, Gfx::FloatPoint, float, u8, Color) override;
+    PDFErrorOr<void> draw_glyph(Gfx::Painter&, Gfx::FloatPoint, float, u8, Renderer const&) override;
 
     DeprecatedFlyString base_font_name() const { return m_base_font_name; }
 

--- a/Userland/Libraries/LibPDF/Fonts/TrueTypeFont.h
+++ b/Userland/Libraries/LibPDF/Fonts/TrueTypeFont.h
@@ -17,7 +17,6 @@ public:
     Optional<float> get_glyph_width(u8 char_code) const override;
     void set_font_size(float font_size) override;
     void draw_glyph(Gfx::Painter&, Gfx::FloatPoint, float, u8, Color) override;
-    Type type() const override { return PDFFont::Type::TrueType; }
 
 protected:
     PDFErrorOr<void> initialize(Document*, NonnullRefPtr<DictObject> const&, float font_size) override;

--- a/Userland/Libraries/LibPDF/Fonts/TrueTypeFont.h
+++ b/Userland/Libraries/LibPDF/Fonts/TrueTypeFont.h
@@ -18,10 +18,13 @@ public:
     void set_font_size(float font_size) override;
     PDFErrorOr<void> draw_glyph(Gfx::Painter&, Gfx::FloatPoint, float, u8, Color) override;
 
+    DeprecatedFlyString base_font_name() const { return m_base_font_name; }
+
 protected:
     PDFErrorOr<void> initialize(Document*, NonnullRefPtr<DictObject> const&, float font_size) override;
 
 private:
+    DeprecatedFlyString m_base_font_name;
     RefPtr<Gfx::Font> m_font;
 };
 

--- a/Userland/Libraries/LibPDF/Fonts/Type0Font.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/Type0Font.cpp
@@ -95,6 +95,8 @@ PDFErrorOr<void> Type0Font::initialize(Document* document, NonnullRefPtr<DictObj
 {
     TRY(PDFFont::initialize(document, dict, font_size));
 
+    m_base_font_name = TRY(dict->get_name(document, CommonNames::BaseFont))->name();
+
     // FIXME: Support arbitrary CMaps
     auto cmap_value = TRY(dict->get_object(document, CommonNames::Encoding));
     if (!cmap_value->is<NameObject>() || cmap_value->cast<NameObject>()->name() != CommonNames::IdentityH)

--- a/Userland/Libraries/LibPDF/Fonts/Type0Font.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/Type0Font.cpp
@@ -13,15 +13,15 @@ namespace PDF {
 class CIDFontType {
 public:
     virtual ~CIDFontType() = default;
-    virtual PDFErrorOr<Gfx::FloatPoint> draw_string(Gfx::Painter&, Gfx::FloatPoint, DeprecatedString const&, Color const&, float, float, float, float) = 0;
+    virtual PDFErrorOr<Gfx::FloatPoint> draw_string(Gfx::Painter&, Gfx::FloatPoint, DeprecatedString const&) = 0;
 };
 
 class CIDFontType0 : public CIDFontType {
 public:
-    PDFErrorOr<Gfx::FloatPoint> draw_string(Gfx::Painter&, Gfx::FloatPoint, DeprecatedString const&, Color const&, float, float, float, float) override;
+    PDFErrorOr<Gfx::FloatPoint> draw_string(Gfx::Painter&, Gfx::FloatPoint, DeprecatedString const&) override;
 };
 
-PDFErrorOr<Gfx::FloatPoint> CIDFontType0::draw_string(Gfx::Painter&, Gfx::FloatPoint, DeprecatedString const&, Color const&, float, float, float, float)
+PDFErrorOr<Gfx::FloatPoint> CIDFontType0::draw_string(Gfx::Painter&, Gfx::FloatPoint, DeprecatedString const&)
 {
     // ISO 32000 (PDF 2.0) 9.7.4.2 Glyph selection in CIDFonts
     // "When the CIDFont contains an embedded font program that is represented in the Compact Font Format (CFF),
@@ -39,7 +39,7 @@ class CIDFontType2 : public CIDFontType {
 public:
     static PDFErrorOr<NonnullOwnPtr<CIDFontType2>> create(Document*, NonnullRefPtr<DictObject> const& descendant, float font_size);
 
-    PDFErrorOr<Gfx::FloatPoint> draw_string(Gfx::Painter&, Gfx::FloatPoint, DeprecatedString const&, Color const&, float, float, float, float) override;
+    PDFErrorOr<Gfx::FloatPoint> draw_string(Gfx::Painter&, Gfx::FloatPoint, DeprecatedString const&) override;
 };
 
 PDFErrorOr<NonnullOwnPtr<CIDFontType2>> CIDFontType2::create(Document* document, NonnullRefPtr<DictObject> const& descendant, float font_size)
@@ -70,7 +70,7 @@ PDFErrorOr<NonnullOwnPtr<CIDFontType2>> CIDFontType2::create(Document* document,
     return TRY(adopt_nonnull_own_or_enomem(new (nothrow) CIDFontType2()));
 }
 
-PDFErrorOr<Gfx::FloatPoint> CIDFontType2::draw_string(Gfx::Painter&, Gfx::FloatPoint, DeprecatedString const&, Color const&, float, float, float, float)
+PDFErrorOr<Gfx::FloatPoint> CIDFontType2::draw_string(Gfx::Painter&, Gfx::FloatPoint, DeprecatedString const&)
 {
     // ISO 32000 (PDF 2.0) 9.7.4.2 Glyph selection in CIDFonts
     // "For Type 2, the CIDFont program is actually a TrueType font program, which has no native notion of CIDs.
@@ -175,7 +175,7 @@ void Type0Font::set_font_size(float)
 {
 }
 
-PDFErrorOr<Gfx::FloatPoint> Type0Font::draw_string(Gfx::Painter& painter, Gfx::FloatPoint glyph_position, DeprecatedString const& string, Color const& paint_color, float font_size, float character_spacing, float word_spacing, float horizontal_scaling)
+PDFErrorOr<Gfx::FloatPoint> Type0Font::draw_string(Gfx::Painter& painter, Gfx::FloatPoint glyph_position, DeprecatedString const& string, Renderer const&)
 {
     // Type0 fonts map bytes to character IDs ("CIDs"), and then CIDs to glyphs.
 
@@ -196,7 +196,7 @@ PDFErrorOr<Gfx::FloatPoint> Type0Font::draw_string(Gfx::Painter& painter, Gfx::F
 
     // FIXME: Map string data to CIDs, then call m_cid_font_type with CIDs.
 
-    return m_cid_font_type->draw_string(painter, glyph_position, string, paint_color, font_size, character_spacing, word_spacing, horizontal_scaling);
+    return m_cid_font_type->draw_string(painter, glyph_position, string);
 }
 
 }

--- a/Userland/Libraries/LibPDF/Fonts/Type0Font.h
+++ b/Userland/Libraries/LibPDF/Fonts/Type0Font.h
@@ -27,7 +27,6 @@ public:
 
     void set_font_size(float font_size) override;
     PDFErrorOr<Gfx::FloatPoint> draw_string(Gfx::Painter&, Gfx::FloatPoint pos, DeprecatedString const&, Color const&, float, float, float, float) override;
-    Type type() const override { return PDFFont::Type::Type0; }
 
 protected:
     PDFErrorOr<void> initialize(Document*, NonnullRefPtr<DictObject> const&, float) override;

--- a/Userland/Libraries/LibPDF/Fonts/Type0Font.h
+++ b/Userland/Libraries/LibPDF/Fonts/Type0Font.h
@@ -26,7 +26,7 @@ public:
     ~Type0Font();
 
     void set_font_size(float font_size) override;
-    PDFErrorOr<Gfx::FloatPoint> draw_string(Gfx::Painter&, Gfx::FloatPoint pos, DeprecatedString const&, Color const&, float, float, float, float) override;
+    PDFErrorOr<Gfx::FloatPoint> draw_string(Gfx::Painter&, Gfx::FloatPoint, DeprecatedString const&, Renderer const&) override;
 
     DeprecatedFlyString base_font_name() const { return m_base_font_name; }
 

--- a/Userland/Libraries/LibPDF/Fonts/Type0Font.h
+++ b/Userland/Libraries/LibPDF/Fonts/Type0Font.h
@@ -28,12 +28,15 @@ public:
     void set_font_size(float font_size) override;
     PDFErrorOr<Gfx::FloatPoint> draw_string(Gfx::Painter&, Gfx::FloatPoint pos, DeprecatedString const&, Color const&, float, float, float, float) override;
 
+    DeprecatedFlyString base_font_name() const { return m_base_font_name; }
+
 protected:
     PDFErrorOr<void> initialize(Document*, NonnullRefPtr<DictObject> const&, float) override;
 
 private:
     float get_char_width(u16 char_code) const;
 
+    DeprecatedFlyString m_base_font_name;
     CIDSystemInfo m_system_info;
     HashMap<u16, u16> m_widths;
     u16 m_missing_width;

--- a/Userland/Libraries/LibPDF/Fonts/Type1Font.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/Type1Font.cpp
@@ -10,6 +10,7 @@
 #include <LibPDF/Fonts/CFF.h>
 #include <LibPDF/Fonts/PS1FontProgram.h>
 #include <LibPDF/Fonts/Type1Font.h>
+#include <LibPDF/Renderer.h>
 
 namespace PDF {
 
@@ -64,8 +65,10 @@ void Type1Font::set_font_size(float font_size)
         m_font = m_font->with_size((font_size * POINTS_PER_INCH) / DEFAULT_DPI);
 }
 
-PDFErrorOr<void> Type1Font::draw_glyph(Gfx::Painter& painter, Gfx::FloatPoint point, float width, u8 char_code, Color color)
+PDFErrorOr<void> Type1Font::draw_glyph(Gfx::Painter& painter, Gfx::FloatPoint point, float width, u8 char_code, Renderer const& renderer)
 {
+    auto color = renderer.state().paint_color;
+
     if (!m_font_program) {
         // Account for the reversed font baseline
         auto position = point.translated(0, -m_font->baseline());

--- a/Userland/Libraries/LibPDF/Fonts/Type1Font.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/Type1Font.cpp
@@ -17,6 +17,8 @@ PDFErrorOr<void> Type1Font::initialize(Document* document, NonnullRefPtr<DictObj
 {
     TRY(SimpleFont::initialize(document, dict, font_size));
 
+    m_base_font_name = TRY(dict->get_name(document, CommonNames::BaseFont))->name();
+
     // auto is_standard_font = is_standard_latin_font(font->base_font_name());
 
     // If there's an embedded font program we use that; otherwise we try to find a replacement font

--- a/Userland/Libraries/LibPDF/Fonts/Type1Font.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/Type1Font.cpp
@@ -62,13 +62,13 @@ void Type1Font::set_font_size(float font_size)
         m_font = m_font->with_size((font_size * POINTS_PER_INCH) / DEFAULT_DPI);
 }
 
-void Type1Font::draw_glyph(Gfx::Painter& painter, Gfx::FloatPoint point, float width, u8 char_code, Color color)
+PDFErrorOr<void> Type1Font::draw_glyph(Gfx::Painter& painter, Gfx::FloatPoint point, float width, u8 char_code, Color color)
 {
     if (!m_font_program) {
         // Account for the reversed font baseline
         auto position = point.translated(0, -m_font->baseline());
         painter.draw_glyph(position, char_code, *m_font, color);
-        return;
+        return {};
     }
 
     auto effective_encoding = encoding();
@@ -95,5 +95,6 @@ void Type1Font::draw_glyph(Gfx::Painter& painter, Gfx::FloatPoint point, float w
     painter.blit_filtered(glyph_position.blit_position, *bitmap, bitmap->rect(), [color](Color pixel) -> Color {
         return pixel.multiply(color);
     });
+    return {};
 }
 }

--- a/Userland/Libraries/LibPDF/Fonts/Type1Font.h
+++ b/Userland/Libraries/LibPDF/Fonts/Type1Font.h
@@ -24,7 +24,7 @@ class Type1Font : public SimpleFont {
 public:
     Optional<float> get_glyph_width(u8 char_code) const override;
     void set_font_size(float font_size) override;
-    PDFErrorOr<void> draw_glyph(Gfx::Painter& painter, Gfx::FloatPoint point, float width, u8 char_code, Color color) override;
+    PDFErrorOr<void> draw_glyph(Gfx::Painter& painter, Gfx::FloatPoint point, float width, u8 char_code, Renderer const&) override;
 
     DeprecatedFlyString base_font_name() const { return m_base_font_name; }
 

--- a/Userland/Libraries/LibPDF/Fonts/Type1Font.h
+++ b/Userland/Libraries/LibPDF/Fonts/Type1Font.h
@@ -24,7 +24,7 @@ class Type1Font : public SimpleFont {
 public:
     Optional<float> get_glyph_width(u8 char_code) const override;
     void set_font_size(float font_size) override;
-    void draw_glyph(Gfx::Painter& painter, Gfx::FloatPoint point, float width, u8 char_code, Color color) override;
+    PDFErrorOr<void> draw_glyph(Gfx::Painter& painter, Gfx::FloatPoint point, float width, u8 char_code, Color color) override;
 
 protected:
     PDFErrorOr<void> initialize(Document*, NonnullRefPtr<DictObject> const&, float font_size) override;

--- a/Userland/Libraries/LibPDF/Fonts/Type1Font.h
+++ b/Userland/Libraries/LibPDF/Fonts/Type1Font.h
@@ -25,7 +25,6 @@ public:
     Optional<float> get_glyph_width(u8 char_code) const override;
     void set_font_size(float font_size) override;
     void draw_glyph(Gfx::Painter& painter, Gfx::FloatPoint point, float width, u8 char_code, Color color) override;
-    Type type() const override { return PDFFont::Type::Type1; }
 
 protected:
     PDFErrorOr<void> initialize(Document*, NonnullRefPtr<DictObject> const&, float font_size) override;

--- a/Userland/Libraries/LibPDF/Fonts/Type1Font.h
+++ b/Userland/Libraries/LibPDF/Fonts/Type1Font.h
@@ -26,10 +26,13 @@ public:
     void set_font_size(float font_size) override;
     PDFErrorOr<void> draw_glyph(Gfx::Painter& painter, Gfx::FloatPoint point, float width, u8 char_code, Color color) override;
 
+    DeprecatedFlyString base_font_name() const { return m_base_font_name; }
+
 protected:
     PDFErrorOr<void> initialize(Document*, NonnullRefPtr<DictObject> const&, float font_size) override;
 
 private:
+    DeprecatedFlyString m_base_font_name;
     RefPtr<Type1FontProgram> m_font_program;
     RefPtr<Gfx::Font> m_font;
     HashMap<Type1GlyphCacheKey, RefPtr<Gfx::Bitmap>> m_glyph_cache;

--- a/Userland/Libraries/LibPDF/Fonts/Type3Font.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/Type3Font.cpp
@@ -14,7 +14,32 @@ PDFErrorOr<void> Type3Font::initialize(Document* document, NonnullRefPtr<DictObj
 {
     TRY(SimpleFont::initialize(document, dict, font_size));
 
-    // FIXME: /CharProcs, /FontBBox, /FontMatrix, /Resources
+    // "TABLE 5.9 Entries in a Type 3 font dictionary"
+
+    if (!dict->contains(CommonNames::CharProcs))
+        return Error { Error::Type::MalformedPDF, "Type3 font missing /CharProcs" };
+    auto char_procs = TRY(document->resolve_to<DictObject>(dict->get_value(CommonNames::CharProcs)));
+    for (auto const& [name, value] : char_procs->map())
+        m_char_procs.set(name, TRY(document->resolve_to<StreamObject>(value)));
+
+    if (!dict->contains(CommonNames::FontMatrix))
+        return Error { Error::Type::MalformedPDF, "Type3 font missing /FontMatrix" };
+    auto font_matrix_object = TRY(document->resolve_to<ArrayObject>(dict->get_value(CommonNames::FontMatrix)));
+    if (font_matrix_object->size() != 6)
+        return Error { Error::Type::MalformedPDF, "Type3 font /FontMatrix must have 6 elements" };
+    font_matrix() = Gfx::AffineTransform {
+        TRY(document->resolve(font_matrix_object->at(0))).to_float(),
+        TRY(document->resolve(font_matrix_object->at(1))).to_float(),
+        TRY(document->resolve(font_matrix_object->at(2))).to_float(),
+        TRY(document->resolve(font_matrix_object->at(3))).to_float(),
+        TRY(document->resolve(font_matrix_object->at(4))).to_float(),
+        TRY(document->resolve(font_matrix_object->at(5))).to_float(),
+    };
+
+    if (dict->contains(CommonNames::Resources))
+        m_resources = TRY(document->resolve_to<DictObject>(dict->get_value(CommonNames::Resources)));
+
+    // FIXME: /FontBBox
 
     return {};
 }
@@ -28,8 +53,25 @@ void Type3Font::set_font_size(float)
 {
 }
 
-PDFErrorOr<void> Type3Font::draw_glyph(Gfx::Painter&, Gfx::FloatPoint, float, u8, Color)
+PDFErrorOr<void> Type3Font::draw_glyph(Gfx::Painter&, Gfx::FloatPoint, float, u8 char_code, Color)
 {
+    // "For each character code shown by a text-showing operator that uses a Type 3 font,
+    //  the consumer application does the following:""
+
+    // "1. Looks up the character code in the font’s Encoding entry, as described in Sec-
+    //  tion 5.5.5, “Character Encoding,” to obtain a character name."
+    auto char_name = encoding()->get_name(char_code);
+
+    // "2. Looks up the character name in the font’s CharProcs dictionary to obtain a
+    //  stream object containing a glyph description. (If the name is not present as a
+    //  key in CharProcs, no glyph is painted.)"
+    auto char_proc = m_char_procs.get(char_name);
+    if (!char_proc.has_value())
+        return {};
+
+    // "3. Invokes the glyph description, as described below."
+    // FIXME
+
     return Error { Error::Type::RenderingUnsupported, "Type3 fonts not yet implemented" };
 }
 }

--- a/Userland/Libraries/LibPDF/Fonts/Type3Font.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/Type3Font.cpp
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2023, Nico Weber <thakis@chromium.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibGfx/Painter.h>
+#include <LibPDF/CommonNames.h>
+#include <LibPDF/Fonts/Type3Font.h>
+
+namespace PDF {
+
+PDFErrorOr<void> Type3Font::initialize(Document* document, NonnullRefPtr<DictObject> const& dict, float font_size)
+{
+    TRY(SimpleFont::initialize(document, dict, font_size));
+
+    // FIXME: /CharProcs, /FontBBox, /FontMatrix, /Resources
+
+    return {};
+}
+
+Optional<float> Type3Font::get_glyph_width(u8) const
+{
+    return OptionalNone {};
+}
+
+void Type3Font::set_font_size(float)
+{
+}
+
+PDFErrorOr<void> Type3Font::draw_glyph(Gfx::Painter&, Gfx::FloatPoint, float, u8, Color)
+{
+    return Error { Error::Type::RenderingUnsupported, "Type3 fonts not yet implemented" };
+}
+}

--- a/Userland/Libraries/LibPDF/Fonts/Type3Font.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/Type3Font.cpp
@@ -53,7 +53,7 @@ void Type3Font::set_font_size(float)
 {
 }
 
-PDFErrorOr<void> Type3Font::draw_glyph(Gfx::Painter&, Gfx::FloatPoint, float, u8 char_code, Color)
+PDFErrorOr<void> Type3Font::draw_glyph(Gfx::Painter&, Gfx::FloatPoint, float, u8 char_code, Renderer const&)
 {
     // "For each character code shown by a text-showing operator that uses a Type 3 font,
     //  the consumer application does the following:""

--- a/Userland/Libraries/LibPDF/Fonts/Type3Font.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/Type3Font.cpp
@@ -55,8 +55,9 @@ void Type3Font::set_font_size(float)
 
 PDFErrorOr<void> Type3Font::draw_glyph(Gfx::Painter&, Gfx::FloatPoint, float, u8 char_code, Renderer const&)
 {
+    // PDF 1.7 spec, 5.5.4 Type 3 Fonts:
     // "For each character code shown by a text-showing operator that uses a Type 3 font,
-    //  the consumer application does the following:""
+    //  the consumer application does the following:"
 
     // "1. Looks up the character code in the font’s Encoding entry, as described in Sec-
     //  tion 5.5.5, “Character Encoding,” to obtain a character name."

--- a/Userland/Libraries/LibPDF/Fonts/Type3Font.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/Type3Font.cpp
@@ -7,6 +7,7 @@
 #include <LibGfx/Painter.h>
 #include <LibPDF/CommonNames.h>
 #include <LibPDF/Fonts/Type3Font.h>
+#include <LibPDF/Renderer.h>
 
 namespace PDF {
 
@@ -53,7 +54,7 @@ void Type3Font::set_font_size(float)
 {
 }
 
-PDFErrorOr<void> Type3Font::draw_glyph(Gfx::Painter&, Gfx::FloatPoint, float, u8 char_code, Renderer const&)
+PDFErrorOr<void> Type3Font::draw_glyph(Gfx::Painter&, Gfx::FloatPoint point, float, u8 char_code, Renderer const& renderer)
 {
     // PDF 1.7 spec, 5.5.4 Type 3 Fonts:
     // "For each character code shown by a text-showing operator that uses a Type 3 font,
@@ -71,8 +72,9 @@ PDFErrorOr<void> Type3Font::draw_glyph(Gfx::Painter&, Gfx::FloatPoint, float, u8
         return {};
 
     // "3. Invokes the glyph description, as described below."
-    // FIXME
-
-    return Error { Error::Type::RenderingUnsupported, "Type3 fonts not yet implemented" };
+    // The Gfx::Painter isn't used because `renderer` paints to it already.
+    // FIXME: Do color things dependent on if the glyph data starts with d0 or d1.
+    // FIXME: Glyph caching.
+    return const_cast<Renderer&>(renderer).render_type3_glyph(point, *char_proc.value(), font_matrix(), m_resources);
 }
 }

--- a/Userland/Libraries/LibPDF/Fonts/Type3Font.h
+++ b/Userland/Libraries/LibPDF/Fonts/Type3Font.h
@@ -18,6 +18,11 @@ public:
 
 protected:
     PDFErrorOr<void> initialize(Document*, NonnullRefPtr<DictObject> const&, float font_size) override;
+
+private:
+    HashMap<DeprecatedFlyString, NonnullRefPtr<StreamObject>> m_char_procs;
+    Gfx::AffineTransform m_font_matrix;
+    Optional<NonnullRefPtr<DictObject>> m_resources;
 };
 
 }

--- a/Userland/Libraries/LibPDF/Fonts/Type3Font.h
+++ b/Userland/Libraries/LibPDF/Fonts/Type3Font.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2023, Nico Weber <thakis@chromium.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibPDF/Fonts/SimpleFont.h>
+
+namespace PDF {
+
+class Type3Font : public SimpleFont {
+public:
+    Optional<float> get_glyph_width(u8 char_code) const override;
+    void set_font_size(float font_size) override;
+    PDFErrorOr<void> draw_glyph(Gfx::Painter& painter, Gfx::FloatPoint point, float width, u8 char_code, Color color) override;
+
+protected:
+    PDFErrorOr<void> initialize(Document*, NonnullRefPtr<DictObject> const&, float font_size) override;
+};
+
+}

--- a/Userland/Libraries/LibPDF/Fonts/Type3Font.h
+++ b/Userland/Libraries/LibPDF/Fonts/Type3Font.h
@@ -14,7 +14,7 @@ class Type3Font : public SimpleFont {
 public:
     Optional<float> get_glyph_width(u8 char_code) const override;
     void set_font_size(float font_size) override;
-    PDFErrorOr<void> draw_glyph(Gfx::Painter& painter, Gfx::FloatPoint point, float width, u8 char_code, Color color) override;
+    PDFErrorOr<void> draw_glyph(Gfx::Painter& painter, Gfx::FloatPoint point, float width, u8 char_code, Renderer const&) override;
 
 protected:
     PDFErrorOr<void> initialize(Document*, NonnullRefPtr<DictObject> const&, float font_size) override;

--- a/Userland/Libraries/LibPDF/Parser.cpp
+++ b/Userland/Libraries/LibPDF/Parser.cpp
@@ -520,17 +520,20 @@ PDFErrorOr<Vector<Operator>> Parser::parse_operators()
     Vector<Operator> operators;
     Vector<Value> operator_args;
 
-    constexpr static auto is_operator_char = [](char ch) {
+    constexpr static auto is_operator_char_start = [](char ch) {
         return isalpha(ch) || ch == '*' || ch == '\'' || ch == '"';
+    };
+    constexpr static auto is_operator_char_continuation = [](char ch) {
+        return is_operator_char_start(ch) || ch == '0' || ch == '1';
     };
 
     m_reader.consume_whitespace();
 
     while (!m_reader.done()) {
         auto ch = m_reader.peek();
-        if (is_operator_char(ch)) {
+        if (is_operator_char_start(ch)) {
             auto operator_start = m_reader.offset();
-            while (is_operator_char(ch)) {
+            while (is_operator_char_continuation(ch)) {
                 m_reader.consume();
                 if (m_reader.done())
                     break;

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -559,8 +559,17 @@ RENDERER_HANDLER(text_show_string_array)
     return {};
 }
 
-RENDERER_TODO(type3_font_set_glyph_width)
-RENDERER_TODO(type3_font_set_glyph_width_and_bbox)
+RENDERER_HANDLER(type3_font_set_glyph_width)
+{
+    // FIXME: Do something with this.
+    return {};
+}
+
+RENDERER_HANDLER(type3_font_set_glyph_width_and_bbox)
+{
+    // FIXME: Do something with this.
+    return {};
+}
 
 RENDERER_HANDLER(set_stroking_space)
 {

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -802,12 +802,10 @@ PDFErrorOr<void> Renderer::show_text(DeprecatedString const& string)
     if (!text_state().font)
         return Error::rendering_unsupported_error("Can't draw text because an invalid font was in use");
 
-    auto& text_rendering_matrix = calculate_text_rendering_matrix();
-
-    auto font_size = text_rendering_matrix.x_scale() * text_state().font_size;
+    auto const& text_rendering_matrix = calculate_text_rendering_matrix();
 
     auto start_position = text_rendering_matrix.map(Gfx::FloatPoint { 0.0f, 0.0f });
-    auto end_position = TRY(text_state().font->draw_string(m_painter, start_position, string, state().paint_color, font_size, text_state().character_spacing * text_rendering_matrix.x_scale(), text_state().word_spacing * text_rendering_matrix.x_scale(), text_state().horizontal_scaling));
+    auto end_position = TRY(text_state().font->draw_string(m_painter, start_position, string, *this));
 
     // Update text matrix
     auto delta_x = end_position.x() - start_position.x();
@@ -983,7 +981,7 @@ PDFErrorOr<NonnullRefPtr<ColorSpace>> Renderer::get_color_space_from_document(No
     return ColorSpace::create(m_document, color_space_object);
 }
 
-Gfx::AffineTransform const& Renderer::calculate_text_rendering_matrix()
+Gfx::AffineTransform const& Renderer::calculate_text_rendering_matrix() const
 {
     if (m_text_rendering_matrix_is_dirty) {
         m_text_rendering_matrix = Gfx::AffineTransform(

--- a/Userland/Libraries/LibPDF/Renderer.h
+++ b/Userland/Libraries/LibPDF/Renderer.h
@@ -150,6 +150,8 @@ private:
 
     PDFErrorOr<NonnullRefPtr<PDFFont>> get_font(FontCacheKey const&, Optional<NonnullRefPtr<DictObject>> extra_resources);
 
+    class ScopedState;
+
     RefPtr<Document> m_document;
     RefPtr<Gfx::Bitmap> m_bitmap;
     Page const& m_page;

--- a/Userland/Libraries/LibPDF/Renderer.h
+++ b/Userland/Libraries/LibPDF/Renderer.h
@@ -107,6 +107,10 @@ public:
         bool operator==(FontCacheKey const&) const = default;
     };
 
+    ALWAYS_INLINE GraphicsState const& state() const { return m_graphics_state_stack.last(); }
+    ALWAYS_INLINE TextState const& text_state() const { return state().text_state; }
+
+    Gfx::AffineTransform const& calculate_text_rendering_matrix() const;
 private:
     Renderer(RefPtr<Document>, Page const&, RefPtr<Gfx::Bitmap>, RenderingPreferences);
 
@@ -130,9 +134,7 @@ private:
     PDFErrorOr<NonnullRefPtr<ColorSpace>> get_color_space_from_resources(Value const&, NonnullRefPtr<DictObject>);
     PDFErrorOr<NonnullRefPtr<ColorSpace>> get_color_space_from_document(NonnullRefPtr<Object>);
 
-    ALWAYS_INLINE GraphicsState const& state() const { return m_graphics_state_stack.last(); }
     ALWAYS_INLINE GraphicsState& state() { return m_graphics_state_stack.last(); }
-    ALWAYS_INLINE TextState const& text_state() const { return state().text_state; }
     ALWAYS_INLINE TextState& text_state() { return state().text_state; }
 
     template<typename T>
@@ -144,7 +146,6 @@ private:
     template<typename T>
     ALWAYS_INLINE Gfx::Rect<T> map(Gfx::Rect<T>) const;
 
-    Gfx::AffineTransform const& calculate_text_rendering_matrix();
     Gfx::AffineTransform calculate_image_space_transformation(int width, int height);
 
     PDFErrorOr<NonnullRefPtr<PDFFont>> get_font(FontCacheKey const&, Optional<NonnullRefPtr<DictObject>> extra_resources);
@@ -161,8 +162,8 @@ private:
     Gfx::AffineTransform m_text_matrix;
     Gfx::AffineTransform m_text_line_matrix;
 
-    bool m_text_rendering_matrix_is_dirty { true };
-    Gfx::AffineTransform m_text_rendering_matrix;
+    bool mutable m_text_rendering_matrix_is_dirty { true };
+    Gfx::AffineTransform mutable m_text_rendering_matrix;
 
     HashMap<FontCacheKey, NonnullRefPtr<PDFFont>> m_font_cache;
 };

--- a/Userland/Libraries/LibPDF/Renderer.h
+++ b/Userland/Libraries/LibPDF/Renderer.h
@@ -111,6 +111,9 @@ public:
     ALWAYS_INLINE TextState const& text_state() const { return state().text_state; }
 
     Gfx::AffineTransform const& calculate_text_rendering_matrix() const;
+
+    PDFErrorOr<void> render_type3_glyph(Gfx::FloatPoint, StreamObject const&, Gfx::AffineTransform const&, Optional<NonnullRefPtr<DictObject>>);
+
 private:
     Renderer(RefPtr<Document>, Page const&, RefPtr<Gfx::Bitmap>, RenderingPreferences);
 


### PR DESCRIPTION
This is a very inefficient implementation: Every time a type 3 font
glyph is drawn, we parse its operator stream and execute all the
operators therein.

We'll want to instead cache the glyphs in bitmaps (at least in most
cases), like we do for other fonts. But it's a good first step, and
all the coordinate math seems to work in the files I've tested.

Good test files from pdfa dataset 0000.zip:

- `0000559.pdf` page 1 (and 2): Has a non-default font matrix;
  text appears mirrored if the font matrix isn't handled correctly

- `0000425.pdf`, page 1: Draws several glyphs in a single run;
  glyphs overlap if Renderer::render_type3_glyph() ignores the
  passed-in point

- `0000211.pdf`, any page: Uses type 3 glyphs for all text.
  Good perf test (already "reasonably fast")

- `0000521.pdf`, page 5 (or 7 or or 16): The little red flag in the
  purple box is a type 3 font glyph, and it's colored (which in part
  means the first operator is `d0`, while all the other documents above
  use `d1`)

---

…and some refactoring along the way.

Type 3 fonts are fonts where each glyph is a PDF stream with PDF drawing operators. This leads to a somewhat weird structure where Renderer calls into the font machinery, which for type 3 fonts then eventually ends up calling back into Renderer. And the coordinate math is somewhat awkwardly split between Renderer and SimpleFont  – but that was the case previously too, and it's not getting much worse in this PR. But I should probably factor that better in the future.