### PR TITLE
LibWeb: Don't reject worker scripts with a JavaScript MIME type

### DIFF
--- a/Meta/gn/secondary/Ladybird/BUILD.gn
+++ b/Meta/gn/secondary/Ladybird/BUILD.gn
@@ -61,6 +61,7 @@ executable("ladybird_executable") {
     "WebContent",
     "WebDriver",
     "WebSocket",
+    "WebWorker",
   ]
   deps = [
     "//AK",
@@ -193,6 +194,7 @@ if (current_os == "mac") {
       "WebContent",
       "WebDriver",
       "WebSocket",
+      "WebWorker",
     ]
     sources = [
       "$root_out_dir/bin/ImageDecoder",
@@ -202,6 +204,7 @@ if (current_os == "mac") {
       "$root_out_dir/bin/WebContent",
       "$root_out_dir/bin/WebDriver",
       "$root_out_dir/bin/WebSocket",
+      "$root_out_dir/bin/WebWorker",
       "$root_out_dir/bin/headless-browser",
     ]
     outputs = [ "{{bundle_executable_dir}}/{{source_file_part}}" ]

--- a/Meta/gn/secondary/Ladybird/WebWorker/BUILD.gn
+++ b/Meta/gn/secondary/Ladybird/WebWorker/BUILD.gn
@@ -1,0 +1,31 @@
+executable("WebWorker") {
+  configs += [ "//Ladybird:ladybird_config" ]
+  include_dirs = [
+    "//Userland/Libraries",
+    "//Userland/Services",
+  ]
+  deps = [
+    "//AK",
+    "//Userland/Libraries/LibCore",
+    "//Userland/Libraries/LibFileSystem",
+    "//Userland/Libraries/LibGfx",
+    "//Userland/Libraries/LibIPC",
+    "//Userland/Libraries/LibImageDecoderClient",
+    "//Userland/Libraries/LibJS",
+    "//Userland/Libraries/LibLocale",
+    "//Userland/Libraries/LibMain",
+    "//Userland/Libraries/LibProtocol",
+    "//Userland/Libraries/LibWeb",
+    "//Userland/Libraries/LibWeb:WebWorkerClientEndpoint",
+    "//Userland/Libraries/LibWeb:WebWorkerServerEndpoint",
+    "//Userland/Libraries/LibWebView",
+  ]
+  sources = [
+    "//Ladybird/HelperProcess.cpp",
+    "//Ladybird/Utilities.cpp",
+    "//Userland/Services/WebWorker/ConnectionFromClient.cpp",
+    "//Userland/Services/WebWorker/DedicatedWorkerHost.cpp",
+    "//Userland/Services/WebWorker/PageHost.cpp",
+    "main.cpp",
+  ]
+}

--- a/Meta/gn/secondary/Userland/Libraries/LibWeb/BUILD.gn
+++ b/Meta/gn/secondary/Userland/Libraries/LibWeb/BUILD.gn
@@ -37,6 +37,28 @@ idl_sources_targets = [
   ":global_idl_bindings_sources",
 ]
 
+compiled_action("WebWorkerClientEndpoint") {
+  tool = "//Meta/Lagom/Tools/CodeGenerators/IPCCompiler"
+  inputs = [ "//Userland/Libraries/LibWeb/Worker/WebWorkerClient.ipc" ]
+  outputs = [ "$root_gen_dir/LibWeb/Worker/WebWorkerClientEndpoint.h" ]
+  args = [
+    rebase_path(inputs[0], root_build_dir),
+    "-o",
+    rebase_path(outputs[0], root_build_dir),
+  ]
+}
+
+compiled_action("WebWorkerServerEndpoint") {
+  tool = "//Meta/Lagom/Tools/CodeGenerators/IPCCompiler"
+  inputs = [ "//Userland/Libraries/LibWeb/Worker/WebWorkerServer.ipc" ]
+  outputs = [ "$root_gen_dir/LibWeb/Worker/WebWorkerServerEndpoint.h" ]
+  args = [
+    rebase_path(inputs[0], root_build_dir),
+    "-o",
+    rebase_path(outputs[0], root_build_dir),
+  ]
+}
+
 compiled_action("generate_window_or_worker_interfaces") {
   tool = "//Meta/Lagom/Tools/CodeGenerators/LibWeb:GenerateWindowOrWorkerInterfaces"
   inputs = standard_idl_files + iterable_idl_files + namespace_idl_files +
@@ -246,6 +268,8 @@ embed_as_string_view("generate_quirks_mode_stylesheet_source") {
 
 source_set("all_generated") {
   generated_deps = [
+    ":WebWorkerClientEndpoint",
+    ":WebWorkerServerEndpoint",
     ":generate_aria_roles",
     ":generate_css_easing_functions",
     ":generate_css_enums",
@@ -332,6 +356,7 @@ shared_library("LibWeb") {
            "WebGL",
            "WebIDL",
            "WebSockets",
+           "Worker",
            "XHR",
            "XLink",
            "XML",

--- a/Meta/gn/secondary/Userland/Libraries/LibWeb/HTML/BUILD.gn
+++ b/Meta/gn/secondary/Userland/Libraries/LibWeb/HTML/BUILD.gn
@@ -159,6 +159,7 @@ source_set("HTML") {
     "WindowOrWorkerGlobalScope.cpp",
     "WindowProxy.cpp",
     "Worker.cpp",
+    "WorkerAgent.cpp",
     "WorkerDebugConsoleClient.cpp",
     "WorkerGlobalScope.cpp",
     "WorkerLocation.cpp",

--- a/Meta/gn/secondary/Userland/Libraries/LibWeb/HTML/Scripting/BUILD.gn
+++ b/Meta/gn/secondary/Userland/Libraries/LibWeb/HTML/Scripting/BUILD.gn
@@ -11,5 +11,6 @@ source_set("Scripting") {
     "Script.cpp",
     "TemporaryExecutionContext.cpp",
     "WindowEnvironmentSettingsObject.cpp",
+    "WorkerEnvironmentSettingsObject.cpp",
   ]
 }

--- a/Meta/gn/secondary/Userland/Libraries/LibWeb/Worker/BUILD.gn
+++ b/Meta/gn/secondary/Userland/Libraries/LibWeb/Worker/BUILD.gn
@@ -1,0 +1,5 @@
+source_set("Worker") {
+  configs += [ "//Userland/Libraries/LibWeb:configs" ]
+  deps = [ "//Userland/Libraries/LibWeb:all_generated" ]
+  sources = [ "WebWorkerClient.cpp" ]
+}


### PR DESCRIPTION
The condition for checking if a script has a JS MIME type is currently
flipped. Extract the check to a local to make it a bit easier to reason
about at quick glance.

Seen trying to login to https://www.strava.com/login which uses web workers (still can't log in due to a 500 error 😞)