### PR TITLE
LibAccelGfx+LibWeb: Add basic support for linear gradients painting

### DIFF
--- a/Userland/Libraries/LibAccelGfx/Painter.h
+++ b/Userland/Libraries/LibAccelGfx/Painter.h
@@ -17,6 +17,7 @@
 #include <LibGfx/AffineTransform.h>
 #include <LibGfx/Font/Font.h>
 #include <LibGfx/Forward.h>
+#include <LibGfx/Gradients.h>
 #include <LibGfx/TextLayout.h>
 
 namespace AccelGfx {
@@ -73,6 +74,9 @@ public:
     void set_target_bitmap(Gfx::Bitmap&);
     void flush();
 
+    void fill_rect_with_linear_gradient(Gfx::IntRect const&, ReadonlySpan<Gfx::ColorStop>, float angle, Optional<float> repeat_length = {});
+    void fill_rect_with_linear_gradient(Gfx::FloatRect const&, ReadonlySpan<Gfx::ColorStop>, float angle, Optional<float> repeat_length = {});
+
 private:
     Context& m_context;
 
@@ -89,6 +93,7 @@ private:
 
     Program m_rectangle_program;
     Program m_blit_program;
+    Program m_linear_gradient_program;
 
     HashMap<GlyphsTextureKey, Gfx::IntRect> m_glyphs_texture_map;
     Gfx::IntSize m_glyphs_texture_size;

--- a/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorGPU.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorGPU.cpp
@@ -99,9 +99,9 @@ CommandResult PaintingCommandExecutorGPU::pop_stacking_context_with_mask(Gfx::In
     return CommandResult::Continue;
 }
 
-CommandResult PaintingCommandExecutorGPU::paint_linear_gradient(Gfx::IntRect const&, Web::Painting::LinearGradientData const&)
+CommandResult PaintingCommandExecutorGPU::paint_linear_gradient(Gfx::IntRect const& rect, Web::Painting::LinearGradientData const& data)
 {
-    // FIXME
+    painter().fill_rect_with_linear_gradient(rect, data.color_stops.list, data.gradient_angle, data.color_stops.repeat_length);
     return CommandResult::Continue;
 }
 


### PR DESCRIPTION
Linear gradient painting is implemented in the following way:
1. The rectangle is divided into segments where each segment represents a simple linear gradient between an adjacent pair of stops.
2. Each quad is filled separately using a fragment shader that interpolates between two colors.

For now `angle` and `repeat_length` parameters are ignored.