### PR TITLE
LibPDF+LibGfx: Don't invert CMYK channels in JPEG data in PDFs

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/JPEGLoader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEGLoader.h
@@ -16,10 +16,22 @@ struct JPEGLoadingContext;
 
 // For the specification, see: https://www.w3.org/Graphics/JPEG/itu-t81.pdf
 
+struct JPEGDecoderOptions {
+    enum class CMYK {
+        // For standalone jpeg files.
+        Normal,
+
+        // For jpeg data embedded in PDF files.
+        PDF,
+    };
+    CMYK cmyk { CMYK::Normal };
+};
+
 class JPEGImageDecoderPlugin : public ImageDecoderPlugin {
 public:
     static bool sniff(ReadonlyBytes);
     static ErrorOr<NonnullOwnPtr<ImageDecoderPlugin>> create(ReadonlyBytes);
+    static ErrorOr<NonnullOwnPtr<ImageDecoderPlugin>> create_with_options(ReadonlyBytes, JPEGDecoderOptions = {});
 
     virtual ~JPEGImageDecoderPlugin() override;
     virtual IntSize size() override;

--- a/Userland/Libraries/LibPDF/Filter.cpp
+++ b/Userland/Libraries/LibPDF/Filter.cpp
@@ -271,7 +271,7 @@ PDFErrorOr<ByteBuffer> Filter::decode_jbig2(ReadonlyBytes)
 PDFErrorOr<ByteBuffer> Filter::decode_dct(ReadonlyBytes bytes)
 {
     if (Gfx::JPEGImageDecoderPlugin::sniff({ bytes.data(), bytes.size() })) {
-        auto decoder = TRY(Gfx::JPEGImageDecoderPlugin::create({ bytes.data(), bytes.size() }));
+        auto decoder = TRY(Gfx::JPEGImageDecoderPlugin::create_with_options({ bytes.data(), bytes.size() }, { .cmyk = Gfx::JPEGDecoderOptions::CMYK::PDF }));
         auto frame = TRY(decoder->frame(0));
         return TRY(frame.image->serialize_to_byte_buffer());
     }


### PR DESCRIPTION
This is a hack: Ideally we'd have a CMYK Bitmap pixel format, and we'd convert to rgb at blit time. Then we could also apply color profiles (which for CMYK images are CMYK-based).

Also, the colors for our CMYK->RGB conversion are off for PDFs, and we have distinct codepaths for this in Gfx::Color (for paths) and JPEGs. So when we fix that, we'll have to fix it in two places.

But this doesn't require a lot of code and it's a huge visual progression, so let's go with it for now.