### PR TITLE
LibJS/JIT: Add fastpath for set variable

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -1067,7 +1067,7 @@ Bytecode::CodeGenerationErrorOr<void> FunctionDeclaration::generate_bytecode(Byt
         Bytecode::Generator::SourceLocationScope scope(generator, *this);
         auto index = generator.intern_identifier(name());
         generator.emit<Bytecode::Op::GetVariable>(index, generator.next_environment_variable_cache());
-        generator.emit<Bytecode::Op::SetVariable>(index, Bytecode::Op::SetVariable::InitializationMode::Set, Bytecode::Op::EnvironmentMode::Var);
+        generator.emit<Bytecode::Op::SetVariable>(index, generator.next_environment_variable_cache(), Bytecode::Op::SetVariable::InitializationMode::Set, Bytecode::Op::EnvironmentMode::Var);
     }
     return {};
 }
@@ -1088,7 +1088,7 @@ Bytecode::CodeGenerationErrorOr<void> FunctionExpression::generate_bytecode_with
     generator.emit_new_function(*this, lhs_name);
 
     if (has_name) {
-        generator.emit<Bytecode::Op::SetVariable>(*name_identifier, Bytecode::Op::SetVariable::InitializationMode::Initialize, Bytecode::Op::EnvironmentMode::Lexical);
+        generator.emit<Bytecode::Op::SetVariable>(*name_identifier, generator.next_environment_variable_cache(), Bytecode::Op::SetVariable::InitializationMode::Initialize, Bytecode::Op::EnvironmentMode::Lexical);
         generator.end_variable_scope();
     }
 
@@ -2352,7 +2352,7 @@ Bytecode::CodeGenerationErrorOr<void> TryStatement::generate_bytecode(Bytecode::
                     did_create_variable_scope_for_catch_clause = true;
                     auto parameter_identifier = generator.intern_identifier(parameter);
                     generator.emit<Bytecode::Op::CreateVariable>(parameter_identifier, Bytecode::Op::EnvironmentMode::Lexical, false);
-                    generator.emit<Bytecode::Op::SetVariable>(parameter_identifier, Bytecode::Op::SetVariable::InitializationMode::Initialize);
+                    generator.emit<Bytecode::Op::SetVariable>(parameter_identifier, generator.next_environment_variable_cache(), Bytecode::Op::SetVariable::InitializationMode::Initialize);
                 }
                 return {};
             },
@@ -3180,7 +3180,7 @@ Bytecode::CodeGenerationErrorOr<void> ExportStatement::generate_bytecode(Bytecod
         TRY(generator.emit_named_evaluation_if_anonymous_function(static_cast<ClassExpression const&>(*m_statement), generator.intern_identifier("default"sv)));
 
         if (!static_cast<ClassExpression const&>(*m_statement).has_name())
-            generator.emit<Bytecode::Op::SetVariable>(generator.intern_identifier(ExportStatement::local_name_for_default), Bytecode::Op::SetVariable::InitializationMode::Initialize);
+            generator.emit<Bytecode::Op::SetVariable>(generator.intern_identifier(ExportStatement::local_name_for_default), generator.next_environment_variable_cache(), Bytecode::Op::SetVariable::InitializationMode::Initialize);
 
         return {};
     }
@@ -3188,7 +3188,7 @@ Bytecode::CodeGenerationErrorOr<void> ExportStatement::generate_bytecode(Bytecod
     // ExportDeclaration : export default AssignmentExpression ;
     VERIFY(is<Expression>(*m_statement));
     TRY(generator.emit_named_evaluation_if_anonymous_function(static_cast<Expression const&>(*m_statement), generator.intern_identifier("default"sv)));
-    generator.emit<Bytecode::Op::SetVariable>(generator.intern_identifier(ExportStatement::local_name_for_default), Bytecode::Op::SetVariable::InitializationMode::Initialize);
+    generator.emit<Bytecode::Op::SetVariable>(generator.intern_identifier(ExportStatement::local_name_for_default), generator.next_environment_variable_cache(), Bytecode::Op::SetVariable::InitializationMode::Initialize);
     return {};
 }
 

--- a/Userland/Libraries/LibJS/Bytecode/CommonImplementations.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/CommonImplementations.cpp
@@ -264,10 +264,13 @@ ThrowCompletionOr<void> set_variable(
     DeprecatedFlyString const& name,
     Value value,
     Op::EnvironmentMode mode,
-    Op::SetVariable::InitializationMode initialization_mode)
+    Op::SetVariable::InitializationMode initialization_mode,
+    EnvironmentVariableCache& cache)
 {
     auto environment = mode == Op::EnvironmentMode::Lexical ? vm.running_execution_context().lexical_environment : vm.running_execution_context().variable_environment;
     auto reference = TRY(vm.resolve_binding(name, environment));
+    if (reference.environment_coordinate().has_value())
+        cache = reference.environment_coordinate();
     switch (initialization_mode) {
     case Op::SetVariable::InitializationMode::Initialize:
         TRY(reference.initialize_referenced_binding(vm, value));

--- a/Userland/Libraries/LibJS/Bytecode/CommonImplementations.h
+++ b/Userland/Libraries/LibJS/Bytecode/CommonImplementations.h
@@ -20,7 +20,7 @@ ThrowCompletionOr<void> put_by_property_key(VM&, Value base, Value this_value, V
 ThrowCompletionOr<Value> perform_call(Interpreter&, Value this_value, Op::CallType, Value callee, MarkedVector<Value> argument_values);
 ThrowCompletionOr<void> throw_if_needed_for_call(Interpreter&, Value callee, Op::CallType, Optional<StringTableIndex> const& expression_string);
 ThrowCompletionOr<Value> typeof_variable(VM&, DeprecatedFlyString const&);
-ThrowCompletionOr<void> set_variable(VM&, DeprecatedFlyString const&, Value, Op::EnvironmentMode, Op::SetVariable::InitializationMode);
+ThrowCompletionOr<void> set_variable(VM&, DeprecatedFlyString const&, Value, Op::EnvironmentMode, Op::SetVariable::InitializationMode, EnvironmentVariableCache&);
 Value new_function(VM&, FunctionExpression const&, Optional<IdentifierTableIndex> const& lhs_name, Optional<Register> const& home_object);
 ThrowCompletionOr<void> put_by_value(VM&, Value base, Value property_key_value, Value value, Op::PropertyKind);
 ThrowCompletionOr<Value> get_variable(Bytecode::Interpreter&, DeprecatedFlyString const& name, EnvironmentVariableCache&);

--- a/Userland/Libraries/LibJS/Bytecode/Generator.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.cpp
@@ -414,7 +414,7 @@ void Generator::emit_set_variable(JS::Identifier const& identifier, Bytecode::Op
     if (identifier.is_local()) {
         emit<Bytecode::Op::SetLocal>(identifier.local_variable_index());
     } else {
-        emit<Bytecode::Op::SetVariable>(intern_identifier(identifier.string()), initialization_mode, mode);
+        emit<Bytecode::Op::SetVariable>(intern_identifier(identifier.string()), next_environment_variable_cache(), initialization_mode, mode);
     }
 }
 

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -771,7 +771,12 @@ ThrowCompletionOr<void> SetVariable::execute_impl(Bytecode::Interpreter& interpr
 {
     auto& vm = interpreter.vm();
     auto const& name = interpreter.current_executable().get_identifier(m_identifier);
-    TRY(set_variable(vm, name, interpreter.accumulator(), m_mode, m_initialization_mode));
+    TRY(set_variable(vm,
+        name,
+        interpreter.accumulator(),
+        m_mode,
+        m_initialization_mode,
+        interpreter.current_executable().environment_variable_caches[m_cache_index]));
     return {};
 }
 

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -453,11 +453,12 @@ public:
         Initialize,
         Set,
     };
-    explicit SetVariable(IdentifierTableIndex identifier, InitializationMode initialization_mode = InitializationMode::Set, EnvironmentMode mode = EnvironmentMode::Lexical)
+    explicit SetVariable(IdentifierTableIndex identifier, u32 cache_index, InitializationMode initialization_mode = InitializationMode::Set, EnvironmentMode mode = EnvironmentMode::Lexical)
         : Instruction(Type::SetVariable, sizeof(*this))
         , m_identifier(identifier)
         , m_mode(mode)
         , m_initialization_mode(initialization_mode)
+        , m_cache_index(cache_index)
     {
     }
 
@@ -467,11 +468,13 @@ public:
     IdentifierTableIndex identifier() const { return m_identifier; }
     EnvironmentMode mode() const { return m_mode; }
     InitializationMode initialization_mode() const { return m_initialization_mode; }
+    u32 cache_index() const { return m_cache_index; }
 
 private:
     IdentifierTableIndex m_identifier;
     EnvironmentMode m_mode;
     InitializationMode m_initialization_mode { InitializationMode::Set };
+    u32 m_cache_index { 0 };
 };
 
 class SetLocal final : public Instruction {

--- a/Userland/Libraries/LibJS/Runtime/ExecutionContext.h
+++ b/Userland/Libraries/LibJS/Runtime/ExecutionContext.h
@@ -32,6 +32,7 @@ struct ExecutionContext {
 
     static FlatPtr realm_offset() { return OFFSET_OF(ExecutionContext, realm); }
     static FlatPtr lexical_environment_offset() { return OFFSET_OF(ExecutionContext, lexical_environment); }
+    static FlatPtr variable_environment_offset() { return OFFSET_OF(ExecutionContext, variable_environment); }
 
 private:
     explicit ExecutionContext(MarkedVector<Value> existing_arguments, MarkedVector<Value> existing_local_variables);


### PR DESCRIPTION
This one was hard to benchmark for me again, since the benchmarks didn't have meaningful differences (i might need to lock the CPU frequency or something). So here is a synthetic benchmark:
```js
for(let n = 0.0; n < 1000000000; n+=2) {
}
```
PR:
```
Benchmark 1: js ./test.js
  Time (mean ± σ):      3.422 s ±  0.019 s    [User: 3.411 s, System: 0.002 s]
  Range (min … max):    3.401 s …  3.466 s    10 runs
```
Master:
```
Benchmark 1: js ./test.js
  Time (mean ± σ):     21.617 s ±  0.277 s    [User: 21.538 s, System: 0.007 s]
  Range (min … max):   21.305 s … 22.208 s    10 runs
  ```