### PR TITLE
LibJS: Don't create `arguments` object due to `o.arguments` access

### DIFF
--- a/Userland/Libraries/LibJS/Parser.h
+++ b/Userland/Libraries/LibJS/Parser.h
@@ -305,6 +305,7 @@ private:
     struct ParserState {
         Lexer lexer;
         Token current_token;
+        bool previous_token_was_period { false };
         Vector<ParserError> errors;
         ScopePusher* current_scope_pusher { nullptr };
 


### PR DESCRIPTION
When deciding whether we need to create a full-blown `arguments` object, we look at various things, starting as early as in the parser.

Until now, if the parser saw the identifier `arguments`, we'd decide that it's enough of a clue that we should create the `arguments` object since somebody is obviously accessing it.

However, that missed the case where someone is just accessing a property named `arguments` on some object. In such cases (`o.arguments`), we now hold off on creating an `arguments` object.

~11% speed-up on Octane/typescript.js :^)