### PR TITLE
head(1): Fix typo in flag name

### DIFF
--- a/Base/usr/share/man/man1/head.md
+++ b/Base/usr/share/man/man1/head.md
@@ -22,7 +22,7 @@ With no `file`, or when `file` is `-`, read standard input.
 ## Options
 
 * `-n` `--number=NUM`: Number of lines to print (default 10)
-* `-b` `--bytes=NUM`: Number of bytes to print
+* `-c` `--bytes=NUM`: Number of bytes to print
 * `-q` `--quiet`: Never print filenames
 * `-v` `--verbose`: Always print filenames
 


### PR DESCRIPTION
The shorthand for the ‘--bytes’ flag is ‘-c’, not ‘-b’.
