### PR TITLE
Meta: Globally disable floating point contraction

### DIFF
--- a/Meta/CMake/common_compile_options.cmake
+++ b/Meta/CMake/common_compile_options.cmake
@@ -12,6 +12,8 @@ add_compile_options(-Wno-unused-command-line-argument)
 add_compile_options(-fdiagnostics-color=always)
 add_compile_options(-fno-exceptions)
 
+add_compile_options(-ffp-contract=off)
+
 if (NOT CMAKE_HOST_SYSTEM_NAME MATCHES SerenityOS)
     # FIXME: Something makes this go crazy and flag unused variables that aren't flagged as such when building with the toolchain.
     #        Disable -Werror for now.

--- a/Meta/gn/build/BUILD.gn
+++ b/Meta/gn/build/BUILD.gn
@@ -84,6 +84,8 @@ config("compiler_defaults") {
   }
   cflags += [ "-fdiagnostics-color" ]
 
+  cflags += [ "-ffp-contract=off" ]
+
   if (use_lld) {
     ldflags += [ "-Wl,--color-diagnostics" ]
   }


### PR DESCRIPTION
FP contraction is a standard-conforming behavior which allows the compiler to calculate intermediate results of expressions containing floating point numbers with a greater precision than the expression type allows. And in theory, it enables additional optimizations, such as replacing `a * b + c` with `fma(a, b, c)`.

Unfortunately, it is extremely hard to predict when the contraction will happen. For example, Clang 17 on x86_64 with the default options will use FMA only for constant-folded non-constexpr expressions. So, in practice, FP contraction leads to hard-to-find bugs and inconsistencies between executables compiled with different toolchains or for different OSes. And we had two instances of this happening last week.

Since we did not ever used -mfma on x86_64, this patch can only possibly regress performance on Apple ARM devices, where FMA is enabled by default. However, this regression will likely be negligible since the difference would be one additional add instruction, which would be then likely executed in parallel with something else.