### PR TITLE
LibPDF: Use PNG unfilter code from LibGfx

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/PNGLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/PNGLoader.cpp
@@ -698,18 +698,18 @@ static ErrorOr<void> decode_png_bitmap_simple(PNGLoadingContext& context, ByteBu
     Streamer streamer(decompression_buffer.data(), decompression_buffer.size());
 
     for (int y = 0; y < context.height; ++y) {
-        PNG::FilterType filter;
-        if (!streamer.read(filter)) {
+        u8 filter_byte;
+        if (!streamer.read(filter_byte)) {
             context.state = PNGLoadingContext::State::Error;
             return Error::from_string_literal("PNGImageDecoderPlugin: Decoding failed");
         }
 
-        if (to_underlying(filter) > 4) {
+        if (filter_byte > 4) {
             context.state = PNGLoadingContext::State::Error;
             return Error::from_string_literal("PNGImageDecoderPlugin: Invalid PNG filter");
         }
 
-        context.scanlines.append({ filter });
+        context.scanlines.append({ MUST(PNG::filter_type(filter_byte)) });
         auto& scanline_buffer = context.scanlines.last().data;
         auto row_size = context.compute_row_size_for_width(context.width);
         if (row_size.has_overflow())
@@ -784,18 +784,18 @@ static ErrorOr<void> decode_adam7_pass(PNGLoadingContext& context, Streamer& str
         return {};
 
     for (int y = 0; y < subimage_context.height; ++y) {
-        PNG::FilterType filter;
-        if (!streamer.read(filter)) {
+        u8 filter_byte;
+        if (!streamer.read(filter_byte)) {
             context.state = PNGLoadingContext::State::Error;
             return Error::from_string_literal("PNGImageDecoderPlugin: Decoding failed");
         }
 
-        if (to_underlying(filter) > 4) {
+        if (filter_byte > 4) {
             context.state = PNGLoadingContext::State::Error;
             return Error::from_string_literal("PNGImageDecoderPlugin: Invalid PNG filter");
         }
 
-        subimage_context.scanlines.append({ filter });
+        subimage_context.scanlines.append({ MUST(PNG::filter_type(filter_byte)) });
         auto& scanline_buffer = subimage_context.scanlines.last().data;
 
         auto row_size = context.compute_row_size_for_width(subimage_context.width);

--- a/Userland/Libraries/LibGfx/ImageFormats/PNGLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/PNGLoader.cpp
@@ -11,7 +11,6 @@
 #include <AK/Vector.h>
 #include <LibCompress/Zlib.h>
 #include <LibGfx/ImageFormats/PNGLoader.h>
-#include <LibGfx/ImageFormats/PNGShared.h>
 #include <LibGfx/Painter.h>
 
 namespace Gfx {
@@ -290,7 +289,7 @@ union [[gnu::packed]] Pixel {
 };
 static_assert(AssertSize<Pixel, 4>());
 
-static void unfilter_scanline(PNG::FilterType filter, Bytes scanline_data, ReadonlyBytes previous_scanlines_data, u8 bytes_per_complete_pixel)
+void PNGImageDecoderPlugin::unfilter_scanline(PNG::FilterType filter, Bytes scanline_data, ReadonlyBytes previous_scanlines_data, u8 bytes_per_complete_pixel)
 {
     VERIFY(filter != PNG::FilterType::None);
 
@@ -431,7 +430,7 @@ NEVER_INLINE FLATTEN static ErrorOr<void> unfilter(PNGLoadingContext& context)
             context.scanlines[y].data.copy_to(scanline_data_slice);
             context.scanlines[y].data = scanline_data_slice;
 
-            unfilter_scanline(context.scanlines[y].filter, scanline_data_slice, previous_scanlines_data, bytes_per_complete_pixel);
+            PNGImageDecoderPlugin::unfilter_scanline(context.scanlines[y].filter, scanline_data_slice, previous_scanlines_data, bytes_per_complete_pixel);
 
             data_start += bytes_per_scanline;
         }

--- a/Userland/Libraries/LibGfx/ImageFormats/PNGLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/PNGLoader.cpp
@@ -291,9 +291,9 @@ static_assert(AssertSize<Pixel, 4>());
 
 void PNGImageDecoderPlugin::unfilter_scanline(PNG::FilterType filter, Bytes scanline_data, ReadonlyBytes previous_scanlines_data, u8 bytes_per_complete_pixel)
 {
-    VERIFY(filter != PNG::FilterType::None);
-
     switch (filter) {
+    case PNG::FilterType::None:
+        break;
     case PNG::FilterType::Sub:
         // This loop starts at bytes_per_complete_pixel because all bytes before that are
         // guaranteed to have no valid byte at index (i - bytes_per_complete pixel).
@@ -327,8 +327,6 @@ void PNGImageDecoderPlugin::unfilter_scanline(PNG::FilterType filter, Bytes scan
             scanline_data[i] += PNG::paeth_predictor(left, above, upper_left);
         }
         break;
-    default:
-        VERIFY_NOT_REACHED();
     }
 }
 

--- a/Userland/Libraries/LibGfx/ImageFormats/PNGLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/PNGLoader.cpp
@@ -325,19 +325,7 @@ static void unfilter_scanline(PNG::FilterType filter, Bytes scanline_data, Reado
             u8 left = (i < bytes_per_complete_pixel) ? 0 : scanline_data[i - bytes_per_complete_pixel];
             u8 above = previous_scanlines_data[i];
             u8 upper_left = (i < bytes_per_complete_pixel) ? 0 : previous_scanlines_data[i - bytes_per_complete_pixel];
-            i32 predictor = left + above - upper_left;
-            u32 predictor_left = abs(predictor - left);
-            u32 predictor_above = abs(predictor - above);
-            u32 predictor_upper_left = abs(predictor - upper_left);
-            u8 nearest;
-            if (predictor_left <= predictor_above && predictor_left <= predictor_upper_left) {
-                nearest = left;
-            } else if (predictor_above <= predictor_upper_left) {
-                nearest = above;
-            } else {
-                nearest = upper_left;
-            }
-            scanline_data[i] += nearest;
+            scanline_data[i] += PNG::paeth_predictor(left, above, upper_left);
         }
         break;
     default:

--- a/Userland/Libraries/LibGfx/ImageFormats/PNGLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/PNGLoader.cpp
@@ -416,7 +416,7 @@ NEVER_INLINE FLATTEN static ErrorOr<void> unfilter(PNGLoadingContext& context)
     // (three samples, two bytes per sample); for color type 0 with a bit depth of 2,
     // bpp is equal to 1 (rounding up); for color type 4 with a bit depth of 16, bpp
     // is equal to 4 (two-byte grayscale sample, plus two-byte alpha sample)."
-    u8 bytes_per_complete_pixel = (context.bit_depth + 7) / 8 * context.channels;
+    u8 bytes_per_complete_pixel = ceil_div(context.bit_depth, (u8)8) * context.channels;
 
     u8 dummy_scanline_bytes[bytes_per_scanline];
     memset(dummy_scanline_bytes, 0, sizeof(dummy_scanline_bytes));

--- a/Userland/Libraries/LibGfx/ImageFormats/PNGLoader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/PNGLoader.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <LibGfx/ImageFormats/ImageDecoder.h>
+#include <LibGfx/ImageFormats/PNGShared.h>
 
 namespace Gfx {
 
@@ -27,6 +28,8 @@ public:
     virtual size_t first_animated_frame_index() override;
     virtual ErrorOr<ImageFrameDescriptor> frame(size_t index, Optional<IntSize> ideal_size = {}) override;
     virtual ErrorOr<Optional<ReadonlyBytes>> icc_data() override;
+
+    static void unfilter_scanline(PNG::FilterType filter, Bytes scanline_data, ReadonlyBytes previous_scanlines_data, u8 bytes_per_complete_pixel);
 
 private:
     PNGImageDecoderPlugin(u8 const*, size_t);

--- a/Userland/Libraries/LibGfx/ImageFormats/PNGShared.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/PNGShared.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/Array.h>
+#include <AK/Error.h>
 #include <AK/SIMD.h>
 
 namespace Gfx::PNG {
@@ -31,6 +32,13 @@ enum class FilterType : u8 {
     Average,
     Paeth,
 };
+
+inline ErrorOr<FilterType> filter_type(u8 byte)
+{
+    if (byte <= 4)
+        return static_cast<FilterType>(byte);
+    return Error::from_string_literal("PNGImageDecoderPlugin: Invalid PNG filter");
+}
 
 // https://www.w3.org/TR/PNG/#9Filter-type-4-Paeth
 ALWAYS_INLINE u8 paeth_predictor(u8 a, u8 b, u8 c)

--- a/Userland/Libraries/LibPDF/Filter.cpp
+++ b/Userland/Libraries/LibPDF/Filter.cpp
@@ -220,7 +220,7 @@ PDFErrorOr<ByteBuffer> Filter::handle_lzw_and_flate_parameters(ByteBuffer buffer
         return AK::Error::from_string_literal("Invalid predictor value");
 
     // Rows are always a whole number of bytes long, starting with an algorithm tag
-    size_t const bytes_per_row = AK::ceil_div(columns * colors * bits_per_component, 8) + 1;
+    size_t const bytes_per_row = ceil_div(columns * colors * bits_per_component, 8) + 1;
     if (buffer.size() % bytes_per_row)
         return AK::Error::from_string_literal("Flate input data is not divisible into columns");
 

--- a/Userland/Libraries/LibPDF/Filter.cpp
+++ b/Userland/Libraries/LibPDF/Filter.cpp
@@ -9,6 +9,7 @@
 #include <LibCompress/Deflate.h>
 #include <LibCompress/LZWDecoder.h>
 #include <LibGfx/ImageFormats/JPEGLoader.h>
+#include <LibGfx/ImageFormats/PNGShared.h>
 #include <LibPDF/CommonNames.h>
 #include <LibPDF/Filter.h>
 #include <LibPDF/Reader.h>
@@ -191,15 +192,7 @@ PDFErrorOr<ByteBuffer> Filter::decode_png_prediction(Bytes bytes, int bytes_per_
                     upper_left = previous_row[i - 1];
                 }
                 u8 above = previous_row[i];
-                u8 p = left + above - upper_left;
-
-                int left_distance = abs(p - left);
-                int above_distance = abs(p - above);
-                int upper_left_distance = abs(p - upper_left);
-
-                u8 paeth = min(left_distance, min(above_distance, upper_left_distance));
-
-                row[i] += paeth;
+                row[i] += Gfx::PNG::paeth_predictor(left, above, upper_left);
             }
             break;
         default:

--- a/Userland/Libraries/LibPDF/Filter.h
+++ b/Userland/Libraries/LibPDF/Filter.h
@@ -20,7 +20,7 @@ public:
 private:
     static PDFErrorOr<ByteBuffer> decode_ascii_hex(ReadonlyBytes bytes);
     static PDFErrorOr<ByteBuffer> decode_ascii85(ReadonlyBytes bytes);
-    static PDFErrorOr<ByteBuffer> decode_png_prediction(Bytes bytes, size_t bytes_per_row);
+    static PDFErrorOr<ByteBuffer> decode_png_prediction(Bytes bytes, size_t bytes_per_row, size_t bytes_per_pixel);
     static PDFErrorOr<ByteBuffer> decode_lzw(ReadonlyBytes bytes, int predictor, int columns, int colors, int bits_per_component, int early_change);
     static PDFErrorOr<ByteBuffer> decode_flate(ReadonlyBytes bytes, int predictor, int columns, int colors, int bits_per_component);
     static PDFErrorOr<ByteBuffer> decode_run_length(ReadonlyBytes bytes);

--- a/Userland/Libraries/LibPDF/Filter.h
+++ b/Userland/Libraries/LibPDF/Filter.h
@@ -20,7 +20,7 @@ public:
 private:
     static PDFErrorOr<ByteBuffer> decode_ascii_hex(ReadonlyBytes bytes);
     static PDFErrorOr<ByteBuffer> decode_ascii85(ReadonlyBytes bytes);
-    static PDFErrorOr<ByteBuffer> decode_png_prediction(Bytes bytes, int bytes_per_row);
+    static PDFErrorOr<ByteBuffer> decode_png_prediction(Bytes bytes, size_t bytes_per_row);
     static PDFErrorOr<ByteBuffer> decode_lzw(ReadonlyBytes bytes, int predictor, int columns, int colors, int bits_per_component, int early_change);
     static PDFErrorOr<ByteBuffer> decode_flate(ReadonlyBytes bytes, int predictor, int columns, int colors, int bits_per_component);
     static PDFErrorOr<ByteBuffer> decode_run_length(ReadonlyBytes bytes);


### PR DESCRIPTION
C O D E   R E U S E, and also fixes a bug where the copy in LibPDF did this incorrectly.

Incrementally makes the LibPDF version look more like the LibGfx version until they look pretty similar and it's clear what the bug is, then switches LibPDF over to the LibGfx version in the last commit.