### PR TITLE
LibWeb: Reject improperly encoded XML documents as not well-formed

### DIFF
--- a/Userland/Libraries/LibTextCodec/Decoder.h
+++ b/Userland/Libraries/LibTextCodec/Decoder.h
@@ -18,6 +18,7 @@ namespace TextCodec {
 class Decoder {
 public:
     virtual ErrorOr<void> process(StringView, Function<ErrorOr<void>(u32)> on_code_point) = 0;
+    virtual bool validate(StringView);
     virtual ErrorOr<String> to_utf8(StringView);
 
 protected:
@@ -27,18 +28,21 @@ protected:
 class UTF8Decoder final : public Decoder {
 public:
     virtual ErrorOr<void> process(StringView, Function<ErrorOr<void>(u32)> on_code_point) override;
+    virtual bool validate(StringView) override;
     virtual ErrorOr<String> to_utf8(StringView) override;
 };
 
 class UTF16BEDecoder final : public Decoder {
 public:
     virtual ErrorOr<void> process(StringView, Function<ErrorOr<void>(u32)> on_code_point) override;
+    virtual bool validate(StringView) override;
     virtual ErrorOr<String> to_utf8(StringView) override;
 };
 
 class UTF16LEDecoder final : public Decoder {
 public:
     virtual ErrorOr<void> process(StringView, Function<ErrorOr<void>(u32)> on_code_point) override;
+    virtual bool validate(StringView) override;
     virtual ErrorOr<String> to_utf8(StringView) override;
 };
 

--- a/Userland/Libraries/LibWeb/DOM/DocumentLoading.cpp
+++ b/Userland/Libraries/LibWeb/DOM/DocumentLoading.cpp
@@ -159,6 +159,9 @@ bool build_xml_document(DOM::Document& document, ByteBuffer const& data, Optiona
         decoder = TextCodec::decoder_for(encoding);
     }
     VERIFY(decoder.has_value());
+    // Well-formed XML documents contain only properly encoded characters
+    if (!decoder->validate(data))
+        return false;
     auto source = decoder->to_utf8(data).release_value_but_fixme_should_propagate_errors();
     XML::Parser parser(source, { .resolve_external_resource = resolve_xml_resource });
     XMLDocumentBuilder builder { document };

--- a/Userland/Libraries/LibWeb/DOM/DocumentLoading.h
+++ b/Userland/Libraries/LibWeb/DOM/DocumentLoading.h
@@ -11,8 +11,8 @@
 
 namespace Web {
 
-bool build_xml_document(DOM::Document& document, ByteBuffer const& data);
-bool parse_document(DOM::Document& document, ByteBuffer const& data);
+bool build_xml_document(DOM::Document& document, ByteBuffer const& data, Optional<String> content_encoding);
+bool parse_document(DOM::Document& document, ByteBuffer const& data, Optional<String> content_encoding);
 JS::GCPtr<DOM::Document> load_document(Optional<HTML::NavigationParams> navigation_params);
 JS::GCPtr<DOM::Document> create_document_for_inline_content(JS::GCPtr<HTML::Navigable> navigable, Optional<String> navigation_id, StringView content_html);
 

--- a/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
+++ b/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
@@ -319,7 +319,7 @@ void XMLHttpRequest::set_document_response()
     // 6. Otherwise, let document be a document that represents the result of running the XML parser with XML scripting support disabled on xhr’s received bytes. If that fails (unsupported character encoding, namespace well-formedness error, etc.), then return null.
     else {
         document = DOM::XMLDocument::create(realm(), m_response->url().value_or({}));
-        if (!Web::build_xml_document(*document, m_received_bytes)) {
+        if (!Web::build_xml_document(*document, m_received_bytes, {})) {
             m_response_object = Empty {};
             return;
         }


### PR DESCRIPTION
Resolves #21779.