### PR TITLE
LibJS: Add a builtin for Math.abs

### DIFF
--- a/Meta/gn/secondary/Userland/Libraries/LibJS/BUILD.gn
+++ b/Meta/gn/secondary/Userland/Libraries/LibJS/BUILD.gn
@@ -25,6 +25,7 @@ shared_library("LibJS") {
     "AST.cpp",
     "Bytecode/ASTCodegen.cpp",
     "Bytecode/BasicBlock.cpp",
+    "Bytecode/Builtins.cpp",
     "Bytecode/CodeGenerationError.cpp",
     "Bytecode/CommonImplementations.cpp",
     "Bytecode/Executable.cpp",

--- a/Userland/Libraries/LibJIT/X86_64/Assembler.h
+++ b/Userland/Libraries/LibJIT/X86_64/Assembler.h
@@ -582,6 +582,15 @@ struct X86_64Assembler {
         emit_modrm_slash(0, dst);
     }
 
+    void mov_if(Condition condition, Operand dst, Operand src)
+    {
+        VERIFY(dst.type == Operand::Type::Reg && src.type == Operand::Type::Reg);
+        emit_rex_for_rm(dst, src, REX_W::Yes);
+        emit8(0x0f);
+        emit8(0x40 | to_underlying(condition));
+        emit_modrm_rm(dst, src);
+    }
+
     void sign_extend_32_to_64_bits(Reg reg)
     {
         mov32(Operand::Register(reg), Operand::Register(reg), Extension::SignExtend);
@@ -987,6 +996,14 @@ struct X86_64Assembler {
         if (overflow_label.has_value()) {
             jump_if(Condition::Overflow, *overflow_label);
         }
+    }
+
+    void neg32(Operand reg)
+    {
+        VERIFY(reg.type == Operand::Type::Reg);
+        emit_rex_for_slash(reg, REX_W::No);
+        emit8(0xf7);
+        emit_modrm_slash(3, reg);
     }
 
     void convert_i32_to_double(Operand dst, Operand src)

--- a/Userland/Libraries/LibJS/Bytecode/Builtins.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Builtins.cpp
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2023, Simon Wanner <simon@skyrising.xyz>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibJS/AST.h>
+#include <LibJS/Bytecode/Builtins.h>
+
+namespace JS::Bytecode {
+
+Optional<Builtin> get_builtin(MemberExpression const& expression)
+{
+    if (expression.is_computed() || !expression.object().is_identifier() || !expression.property().is_identifier())
+        return {};
+    auto base_name = static_cast<Identifier const&>(expression.object()).string();
+    auto property_name = static_cast<Identifier const&>(expression.property()).string();
+#define CHECK_MEMBER_BUILTIN(name, snake_case_name, base, property, ...) \
+    if (base_name == #base##sv && property_name == #property##sv)        \
+        return Builtin::name;
+    JS_ENUMERATE_BUILTINS(CHECK_MEMBER_BUILTIN)
+#undef CHECK_MEMBER_BUILTIN
+    return {};
+}
+
+}

--- a/Userland/Libraries/LibJS/Bytecode/Builtins.h
+++ b/Userland/Libraries/LibJS/Bytecode/Builtins.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2023, Simon Wanner <simon@skyrising.xyz>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Format.h>
+#include <LibJS/Forward.h>
+
+namespace JS::Bytecode {
+
+// TitleCaseName, snake_case_name, base, property, argument_count
+#define JS_ENUMERATE_BUILTINS(O)
+
+enum class Builtin {
+#define DEFINE_BUILTIN_ENUM(name, ...) name,
+    JS_ENUMERATE_BUILTINS(DEFINE_BUILTIN_ENUM)
+#undef DEFINE_BUILTIN_ENUM
+        __Count,
+};
+
+static StringView builtin_name(Builtin value)
+{
+    switch (value) {
+#define DEFINE_BUILTIN_CASE(name, snake_case_name, base, property, ...) \
+    case Builtin::name:                                                 \
+        return #base "." #property##sv;
+        JS_ENUMERATE_BUILTINS(DEFINE_BUILTIN_CASE)
+#undef DEFINE_BUILTIN_CASE
+    case Builtin::__Count:
+        VERIFY_NOT_REACHED();
+    }
+    VERIFY_NOT_REACHED();
+}
+
+inline size_t builtin_argument_count(Builtin value)
+{
+    switch (value) {
+#define DEFINE_BUILTIN_CASE(name, snake_case_name, base, property, arg_count, ...) \
+    case Builtin::name:                                                            \
+        return arg_count;
+        JS_ENUMERATE_BUILTINS(DEFINE_BUILTIN_CASE)
+#undef DEFINE_BUILTIN_CASE
+    case Builtin::__Count:
+        VERIFY_NOT_REACHED();
+    }
+    VERIFY_NOT_REACHED();
+}
+
+Optional<Builtin> get_builtin(MemberExpression const& expression);
+
+}
+
+namespace AK {
+
+template<>
+struct Formatter<JS::Bytecode::Builtin> : Formatter<StringView> {
+    ErrorOr<void> format(FormatBuilder& builder, JS::Bytecode::Builtin value)
+    {
+        return Formatter<StringView>::format(builder, builtin_name(value));
+    }
+};
+
+}

--- a/Userland/Libraries/LibJS/Bytecode/Builtins.h
+++ b/Userland/Libraries/LibJS/Bytecode/Builtins.h
@@ -12,7 +12,8 @@
 namespace JS::Bytecode {
 
 // TitleCaseName, snake_case_name, base, property, argument_count
-#define JS_ENUMERATE_BUILTINS(O)
+#define JS_ENUMERATE_BUILTINS(O) \
+    O(MathAbs, math_abs, Math, abs, 1)
 
 enum class Builtin {
 #define DEFINE_BUILTIN_ENUM(name, ...) name,

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -1514,6 +1514,8 @@ static StringView call_type_to_string(CallType type)
 DeprecatedString Call::to_deprecated_string_impl(Bytecode::Executable const& executable) const
 {
     auto type = call_type_to_string(m_type);
+    if (m_builtin.has_value())
+        return DeprecatedString::formatted("Call{} callee:{}, this:{}, first_arg:{} (builtin {})", type, m_callee, m_this_value, m_first_argument, m_builtin.value());
     if (m_expression_string.has_value())
         return DeprecatedString::formatted("Call{} callee:{}, this:{}, first_arg:{} ({})", type, m_callee, m_this_value, m_first_argument, executable.get_string(m_expression_string.value()));
     return DeprecatedString::formatted("Call{} callee:{}, this:{}, first_arg:{}", type, m_callee, m_first_argument, m_this_value);

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -10,6 +10,7 @@
 
 #include <AK/StdLibExtras.h>
 #include <LibCrypto/BigInt/SignedBigInteger.h>
+#include <LibJS/Bytecode/Builtins.h>
 #include <LibJS/Bytecode/IdentifierTable.h>
 #include <LibJS/Bytecode/Instruction.h>
 #include <LibJS/Bytecode/Label.h>
@@ -984,7 +985,7 @@ enum class CallType {
 
 class Call final : public Instruction {
 public:
-    Call(CallType type, Register callee, Register this_value, Register first_argument, u32 argument_count, Optional<StringTableIndex> expression_string = {})
+    Call(CallType type, Register callee, Register this_value, Register first_argument, u32 argument_count, Optional<StringTableIndex> expression_string = {}, Optional<Builtin> builtin = {})
         : Instruction(Type::Call, sizeof(*this))
         , m_callee(callee)
         , m_this_value(this_value)
@@ -992,6 +993,7 @@ public:
         , m_argument_count(argument_count)
         , m_type(type)
         , m_expression_string(expression_string)
+        , m_builtin(builtin)
     {
     }
 
@@ -1003,6 +1005,8 @@ public:
     Register first_argument() const { return m_first_argument; }
     u32 argument_count() const { return m_argument_count; }
 
+    Optional<Builtin> const& builtin() const { return m_builtin; }
+
     ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
     DeprecatedString to_deprecated_string_impl(Bytecode::Executable const&) const;
 
@@ -1013,6 +1017,7 @@ private:
     u32 m_argument_count { 0 };
     CallType m_type;
     Optional<StringTableIndex> m_expression_string;
+    Optional<Builtin> m_builtin;
 };
 
 class CallWithArgumentArray final : public Instruction {

--- a/Userland/Libraries/LibJS/CMakeLists.txt
+++ b/Userland/Libraries/LibJS/CMakeLists.txt
@@ -2,6 +2,7 @@ set(SOURCES
     AST.cpp
     Bytecode/ASTCodegen.cpp
     Bytecode/BasicBlock.cpp
+    Bytecode/Builtins.cpp
     Bytecode/CodeGenerationError.cpp
     Bytecode/CommonImplementations.cpp
     Bytecode/Executable.cpp

--- a/Userland/Libraries/LibJS/Forward.h
+++ b/Userland/Libraries/LibJS/Forward.h
@@ -303,6 +303,7 @@ class MarkedVector;
 
 namespace Bytecode {
 class BasicBlock;
+enum class Builtin;
 class Executable;
 class Generator;
 class Instruction;

--- a/Userland/Libraries/LibJS/JIT/Compiler.h
+++ b/Userland/Libraries/LibJS/JIT/Compiler.h
@@ -9,6 +9,7 @@
 
 #include <AK/Platform.h>
 #include <LibJIT/Assembler.h>
+#include <LibJS/Bytecode/Builtins.h>
 #include <LibJS/Bytecode/Executable.h>
 #include <LibJS/Bytecode/Op.h>
 #include <LibJS/JIT/NativeExecutable.h>
@@ -43,6 +44,8 @@ private:
     static constexpr auto CACHED_ACCUMULATOR = Assembler::Reg::R12;
     static constexpr auto RUNNING_EXECUTION_CONTEXT_BASE = Assembler::Reg::R15;
 #    endif
+
+    static Assembler::Reg argument_register(u32);
 
 #    define JS_ENUMERATE_COMMON_BINARY_OPS_WITHOUT_FAST_PATH(O) \
         O(Div, div)                                             \
@@ -146,6 +149,12 @@ private:
 
     JS_ENUMERATE_IMPLEMENTED_JIT_OPS(DECLARE_COMPILE_OP)
 #    undef DECLARE_COMPILE_OP
+
+    void compile_builtin(Bytecode::Builtin, Assembler::Label& slow_case, Assembler::Label& end);
+#    define DECLARE_COMPILE_BUILTIN(name, snake_case_name, ...) \
+        void compile_builtin_##snake_case_name(Assembler::Label& slow_case, Assembler::Label& end);
+    JS_ENUMERATE_BUILTINS(DECLARE_COMPILE_BUILTIN)
+#    undef DECLARE_COMPILE_BUILTIN
 
     void store_vm_register(Bytecode::Register, Assembler::Reg);
     void load_vm_register(Assembler::Reg, Bytecode::Register);

--- a/Userland/Libraries/LibJS/Runtime/MathObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/MathObject.cpp
@@ -27,7 +27,7 @@ void MathObject::initialize(Realm& realm)
     auto& vm = this->vm();
     Base::initialize(realm);
     u8 attr = Attribute::Writable | Attribute::Configurable;
-    define_native_function(realm, vm.names.abs, abs, 1, attr);
+    define_native_function(realm, vm.names.abs, abs, 1, attr, Bytecode::Builtin::MathAbs);
     define_native_function(realm, vm.names.random, random, 0, attr);
     define_native_function(realm, vm.names.sqrt, sqrt, 1, attr);
     define_native_function(realm, vm.names.floor, floor, 1, attr);

--- a/Userland/Libraries/LibJS/Runtime/Object.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Object.cpp
@@ -1269,10 +1269,12 @@ Value Object::get_without_side_effects(PropertyKey const& property_key) const
     return {};
 }
 
-void Object::define_native_function(Realm& realm, PropertyKey const& property_key, Function<ThrowCompletionOr<Value>(VM&)> native_function, i32 length, PropertyAttributes attribute)
+void Object::define_native_function(Realm& realm, PropertyKey const& property_key, Function<ThrowCompletionOr<Value>(VM&)> native_function, i32 length, PropertyAttributes attribute, Optional<Bytecode::Builtin> builtin)
 {
     auto function = NativeFunction::create(realm, move(native_function), length, property_key, &realm);
     define_direct_property(property_key, function, attribute);
+    if (builtin.has_value())
+        realm.define_builtin(builtin.value(), function);
 }
 
 // 20.1.2.3.1 ObjectDefineProperties ( O, Properties ), https://tc39.es/ecma262/#sec-objectdefineproperties

--- a/Userland/Libraries/LibJS/Runtime/Object.h
+++ b/Userland/Libraries/LibJS/Runtime/Object.h
@@ -177,7 +177,7 @@ public:
     using IntrinsicAccessor = Value (*)(Realm&);
     void define_intrinsic_accessor(PropertyKey const&, PropertyAttributes attributes, IntrinsicAccessor accessor);
 
-    void define_native_function(Realm&, PropertyKey const&, Function<ThrowCompletionOr<Value>(VM&)>, i32 length, PropertyAttributes attributes);
+    void define_native_function(Realm&, PropertyKey const&, Function<ThrowCompletionOr<Value>(VM&)>, i32 length, PropertyAttributes attributes, Optional<Bytecode::Builtin> builtin = {});
     void define_native_accessor(Realm&, PropertyKey const&, Function<ThrowCompletionOr<Value>(VM&)> getter, Function<ThrowCompletionOr<Value>(VM&)> setter, PropertyAttributes attributes);
 
     virtual bool is_dom_node() const { return false; }

--- a/Userland/Libraries/LibJS/Runtime/Realm.h
+++ b/Userland/Libraries/LibJS/Runtime/Realm.h
@@ -11,8 +11,10 @@
 #include <AK/OwnPtr.h>
 #include <AK/StringView.h>
 #include <AK/Weakable.h>
+#include <LibJS/Bytecode/Builtins.h>
 #include <LibJS/Heap/Cell.h>
 #include <LibJS/Runtime/Intrinsics.h>
+#include <LibJS/Runtime/Value.h>
 
 namespace JS {
 
@@ -48,7 +50,13 @@ public:
     HostDefined* host_defined() { return m_host_defined; }
     void set_host_defined(OwnPtr<HostDefined> host_defined) { m_host_defined = move(host_defined); }
 
+    void define_builtin(Bytecode::Builtin builtin, Value value)
+    {
+        m_builtins[to_underlying(builtin)] = value;
+    }
+
     static FlatPtr global_environment_offset() { return OFFSET_OF(Realm, m_global_environment); }
+    static FlatPtr builtins_offset() { return OFFSET_OF(Realm, m_builtins); }
 
 private:
     Realm() = default;
@@ -59,6 +67,7 @@ private:
     GCPtr<Object> m_global_object;                 // [[GlobalObject]]
     GCPtr<GlobalEnvironment> m_global_environment; // [[GlobalEnv]]
     OwnPtr<HostDefined> m_host_defined;            // [[HostDefined]]
+    AK::Array<Value, to_underlying(Bytecode::Builtin::__Count)> m_builtins;
 };
 
 }


### PR DESCRIPTION
I originally planned the name "intrinsic", but that term is already used by ECMA-262 and having two different kinds of intrinsics stored on the Realm would have been confusing.

```
Suite       Test                                   Speedup  Old (Mean ± Range)           New (Mean ± Range)
----------  -----------------------------------  ---------  ---------------------------  ------------------------
SunSpider   3d-cube.js                               1      0.020 ± 0.020 … 0.020        0.020 ± 0.020 … 0.020
SunSpider   3d-morph.js                              1      0.040 ± 0.040 … 0.040        0.040 ± 0.040 … 0.040
SunSpider   3d-raytrace.js                           1.071  0.050 ± 0.050 … 0.050        0.047 ± 0.040 … 0.050
SunSpider   access-binary-trees.js                   1      0.073 ± 0.070 … 0.080        0.073 ± 0.070 … 0.080
SunSpider   access-fannkuch.js                       1      0.010 ± 0.010 … 0.010        0.010 ± 0.010 … 0.010
SunSpider   access-nbody.js                          1      0.010 ± 0.010 … 0.010        0.010 ± 0.010 … 0.010
SunSpider   access-nsieve.js                                0.000 ± 0.000 … 0.000        0.000 ± 0.000 … 0.000 (no clue what's going on here)
SunSpider   bitops-3bit-bits-in-byte.js              1      0.030 ± 0.030 … 0.030        0.030 ± 0.030 … 0.030
SunSpider   bitops-bits-in-byte.js                   0.778  0.023 ± 0.020 … 0.030        0.030 ± 0.030 … 0.030
SunSpider   bitops-bitwise-and.js                    1.029  0.350 ± 0.340 … 0.360        0.340 ± 0.330 … 0.350
SunSpider   bitops-nsieve-bits.js                    1      0.010 ± 0.010 … 0.010        0.010 ± 0.010 … 0.010
SunSpider   controlflow-recursive.js                 1      0.110 ± 0.110 … 0.110        0.110 ± 0.110 … 0.110
SunSpider   crypto-aes.js                            1      0.020 ± 0.020 … 0.020        0.020 ± 0.020 … 0.020
SunSpider   crypto-md5.js                            1.222  0.037 ± 0.030 … 0.040        0.030 ± 0.030 … 0.030
SunSpider   crypto-sha1.js                           1      0.030 ± 0.030 … 0.030        0.030 ± 0.030 … 0.030
SunSpider   date-format-tofte.js                     0.986  0.233 ± 0.230 … 0.240        0.237 ± 0.230 … 0.240
SunSpider   date-format-xparb.js                     1      0.060 ± 0.060 … 0.060        0.060 ± 0.060 … 0.060
SunSpider   math-cordic.js                           1.067  0.053 ± 0.050 … 0.060        0.050 ± 0.050 … 0.050
SunSpider   math-partial-sums.js                     0.923  0.120 ± 0.120 … 0.120        0.130 ± 0.130 … 0.130
SunSpider   math-spectral-norm.js                    0.9    0.030 ± 0.030 … 0.030        0.033 ± 0.030 … 0.040
SunSpider   regexp-dna.js                            1.01   0.350 ± 0.340 … 0.360        0.347 ± 0.340 … 0.350
SunSpider   string-base64.js                         1      0.040 ± 0.040 … 0.040        0.040 ± 0.040 … 0.040
SunSpider   string-fasta.js                          1.019  0.357 ± 0.350 … 0.360        0.350 ± 0.340 … 0.360
SunSpider   string-tagcloud.js                       1.015  0.220 ± 0.210 … 0.230        0.217 ± 0.210 … 0.220
SunSpider   string-unpack-code.js                    0.958  0.380 ± 0.370 … 0.390        0.397 ± 0.380 … 0.420
SunSpider   string-validate-input.js                 1      0.060 ± 0.060 … 0.060        0.060 ± 0.060 … 0.060
Kraken      ai-astar.js                              1.016  0.630 ± 0.610 … 0.660        0.620 ± 0.610 … 0.630
Kraken      audio-beat-detection.js                  1.123  0.487 ± 0.480 … 0.490        0.433 ± 0.420 … 0.440
Kraken      audio-dft.js                             1      0.337 ± 0.330 … 0.350        0.337 ± 0.330 … 0.340
Kraken      audio-fft.js                             1.01   0.333 ± 0.330 … 0.340        0.330 ± 0.320 … 0.340
Kraken      audio-oscillator.js                      0.987  0.977 ± 0.910 … 1.080        0.990 ± 0.960 … 1.040
Kraken      imaging-darkroom.js                      1.022  3.277 ± 3.160 … 3.350        3.207 ± 3.120 … 3.370
Kraken      imaging-desaturate.js                    0.98   0.650 ± 0.630 … 0.680        0.663 ± 0.650 … 0.680
Kraken  !!! imaging-gaussian-blur.js                 7.239  12.933 ± 12.590 … 13.530     1.787 ± 1.730 … 1.890
Kraken      json-parse-financial.js                  1      0.070 ± 0.070 … 0.070        0.070 ± 0.070 … 0.070
Kraken      json-stringify-tinderbox.js              0.969  0.210 ± 0.210 … 0.210        0.217 ± 0.210 … 0.220
Kraken      stanford-crypto-aes.js                   1      0.527 ± 0.510 … 0.540        0.527 ± 0.520 … 0.530
Kraken      stanford-crypto-ccm.js                   0.982  0.557 ± 0.550 … 0.560        0.567 ± 0.560 … 0.570
Kraken      stanford-crypto-pbkdf2.js                0.984  1.030 ± 1.010 … 1.040        1.047 ± 1.030 … 1.060
Kraken      stanford-crypto-sha256-iterative.js      0.993  0.470 ± 0.460 … 0.480        0.473 ± 0.460 … 0.490
Octane      box2d.js                                 0.952  2.373 ± 2.320 … 2.420        2.493 ± 2.420 … 2.590
Octane      code-load.js                             1.006  2.117 ± 2.110 … 2.120        2.103 ± 2.090 … 2.110
Octane      crypto.js                                0.997  5.083 ± 5.050 … 5.110        5.100 ± 5.070 … 5.120
Octane      deltablue.js                             1.004  3.060 ± 3.030 … 3.090        3.047 ± 3.020 … 3.060
Octane      earley-boyer.js                          1.004  29.497 ± 29.370 … 29.650     29.390 ± 29.070 … 29.670
Octane      gbemu.js                                 1.048  4.797 ± 4.790 … 4.810        4.577 ± 4.200 … 4.790
Octane      mandreel.js                              1.019  24.290 ± 23.940 … 24.800     23.847 ± 23.650 … 24.040
Octane      navier-stokes.js                         0.997  2.020 ± 2.010 … 2.030        2.027 ± 2.020 … 2.030
Octane      pdfjs.js                                 0.983  3.743 ± 3.710 … 3.780        3.807 ± 3.780 … 3.830
Octane      raytrace.js                              1.002  8.193 ± 8.080 … 8.270        8.180 ± 8.170 … 8.200
Octane      regexp.js                                0.977  23.693 ± 23.470 … 23.900     24.243 ± 24.170 … 24.290
Octane      richards.js                              1.002  2.013 ± 2.010 … 2.020        2.010 ± 2.010 … 2.010
Octane      splay.js                                 1.007  3.000 ± 2.950 … 3.030        2.980 ± 2.960 … 3.020
Octane      typescript.js                            0.981  50.147 ± 49.000 … 51.430     51.097 ± 50.200 … 52.000
Octane      zlib.js                                  1.057  104.150 ± 103.280 … 105.090  98.523 ± 98.370 … 98.620
SunSpider   Total                                    0.999  2.717                        2.720
Kraken      Total                                    1.996  22.487                       11.267
Octane      Total                                    1.018  268.177                      263.423
All Suites  Total                                    1.058  293.380                      277.410
```