### PR TITLE
Ladybird/AppKit: Remove explicit application activation

### DIFF
--- a/Documentation/BuildInstructionsLadybird.md
+++ b/Documentation/BuildInstructionsLadybird.md
@@ -156,10 +156,19 @@ To automatically run in gdb:
 ninja -C Build/ladybird debug
 ```
 
-To run without ninja rule:
+To run without ninja rule on non-macOS systems:
 ```
 export SERENITY_SOURCE_DIR=$(realpath ../)
-./Build/ladybird/bin/Ladybird # or, in macOS: open ./Build/ladybird/bin/Ladybird.app
+./Build/ladybird/bin/Ladybird
+```
+
+To run without ninja rule on macOS:
+```
+export SERENITY_SOURCE_DIR=$(realpath ../)
+open -W --stdout $(tty) --stderr $(tty) ./Build/ladybird/bin/Ladybird.app
+
+# Or to launch with arguments:
+open -W --stdout $(tty) --stderr $(tty) ./Build/ladybird/bin/Ladybird.app --args https://ladybird.dev
 ```
 
 ### Debugging with CLion

--- a/Ladybird/AppKit/main.mm
+++ b/Ladybird/AppKit/main.mm
@@ -67,7 +67,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                                webdriverContentIPCPath:webdriver_content_ipc_path];
 
     [NSApp setDelegate:delegate];
-    [NSApp activateIgnoringOtherApps:YES];
 
     return event_loop.exec();
 }


### PR DESCRIPTION
We call `[NSApp activateIgnoringOtherApps:YES]` to ensure the application
is brought into view and focused when launched from a terminal. But in
a macOS environment, we're better off using the `open` command to launch
the application (in which case, it does take foreground focus).