### PR TITLE
LibWeb: Flesh out "scroll a target into view" spec implementation

### DIFF
--- a/Tests/LibWeb/Text/expected/get-bounding-client-rect.txt
+++ b/Tests/LibWeb/Text/expected/get-bounding-client-rect.txt
@@ -1,0 +1,1 @@
+   {"x":8,"y":500,"width":784,"height":150,"top":500,"right":792,"bottom":650,"left":8}

--- a/Tests/LibWeb/Text/input/get-bounding-client-rect.html
+++ b/Tests/LibWeb/Text/input/get-bounding-client-rect.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<style type="text/css">
+    #box {
+        margin-top: 500px;
+        padding-top: 100px;
+        background-color: navy;
+        width: 100%;
+        height: 50px;
+    }
+</style>
+<div id="box"></div>
+<script src="include.js"></script>
+<script>
+    test(() => {
+        const rect = document.getElementById("box").getBoundingClientRect();
+        println(JSON.stringify(rect));
+    });
+</script>

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -868,7 +868,7 @@ JS::NonnullGCPtr<Geometry::DOMRect> Element::get_bounding_client_rect() const
     VERIFY(document().navigable());
     auto viewport_offset = document().navigable()->viewport_scroll_offset();
 
-    return Geometry::DOMRect::create(realm(), paintable_box->absolute_rect().translated(-viewport_offset.x(), -viewport_offset.y()).to_type<float>());
+    return Geometry::DOMRect::create(realm(), paintable_box->absolute_border_box_rect().translated(-viewport_offset.x(), -viewport_offset.y()).to_type<float>());
 }
 
 // https://drafts.csswg.org/cssom-view/#dom-element-getclientrects


### PR DESCRIPTION
This change fixes regressed Acid2 test and now we at least can see the face after clicking "Take The Acid2 Test" link.