### PR TITLE
LibJS: Instantiate primitive array expressions using a single operation

### DIFF
--- a/Userland/Libraries/LibJS/AST.h
+++ b/Userland/Libraries/LibJS/AST.h
@@ -1133,31 +1133,46 @@ private:
     Vector<NonnullRefPtr<Expression const>> m_expressions;
 };
 
-class BooleanLiteral final : public Expression {
+class PrimitiveLiteral : public Expression {
+public:
+    virtual Value value() const = 0;
+
+protected:
+    explicit PrimitiveLiteral(SourceRange source_range)
+        : Expression(move(source_range))
+    {
+    }
+};
+
+class BooleanLiteral final : public PrimitiveLiteral {
 public:
     explicit BooleanLiteral(SourceRange source_range, bool value)
-        : Expression(move(source_range))
+        : PrimitiveLiteral(move(source_range))
         , m_value(value)
     {
     }
 
     virtual void dump(int indent) const override;
     virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode(Bytecode::Generator&) const override;
+
+    virtual Value value() const override { return Value(m_value); }
 
 private:
     bool m_value { false };
 };
 
-class NumericLiteral final : public Expression {
+class NumericLiteral final : public PrimitiveLiteral {
 public:
     explicit NumericLiteral(SourceRange source_range, double value)
-        : Expression(move(source_range))
+        : PrimitiveLiteral(move(source_range))
         , m_value(value)
     {
     }
 
     virtual void dump(int indent) const override;
     virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode(Bytecode::Generator&) const override;
+
+    virtual Value value() const override { return m_value; }
 
 private:
     Value m_value;
@@ -1197,15 +1212,17 @@ private:
     DeprecatedString m_value;
 };
 
-class NullLiteral final : public Expression {
+class NullLiteral final : public PrimitiveLiteral {
 public:
     explicit NullLiteral(SourceRange source_range)
-        : Expression(move(source_range))
+        : PrimitiveLiteral(move(source_range))
     {
     }
 
     virtual void dump(int indent) const override;
     virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode(Bytecode::Generator&) const override;
+
+    virtual Value value() const override { return js_null(); }
 };
 
 class RegExpLiteral final : public Expression {

--- a/Userland/Libraries/LibJS/AST.h
+++ b/Userland/Libraries/LibJS/AST.h
@@ -1133,18 +1133,10 @@ private:
     Vector<NonnullRefPtr<Expression const>> m_expressions;
 };
 
-class Literal : public Expression {
-protected:
-    explicit Literal(SourceRange source_range)
-        : Expression(move(source_range))
-    {
-    }
-};
-
-class BooleanLiteral final : public Literal {
+class BooleanLiteral final : public Expression {
 public:
     explicit BooleanLiteral(SourceRange source_range, bool value)
-        : Literal(move(source_range))
+        : Expression(move(source_range))
         , m_value(value)
     {
     }
@@ -1156,10 +1148,10 @@ private:
     bool m_value { false };
 };
 
-class NumericLiteral final : public Literal {
+class NumericLiteral final : public Expression {
 public:
     explicit NumericLiteral(SourceRange source_range, double value)
-        : Literal(move(source_range))
+        : Expression(move(source_range))
         , m_value(value)
     {
     }
@@ -1171,10 +1163,10 @@ private:
     Value m_value;
 };
 
-class BigIntLiteral final : public Literal {
+class BigIntLiteral final : public Expression {
 public:
     explicit BigIntLiteral(SourceRange source_range, DeprecatedString value)
-        : Literal(move(source_range))
+        : Expression(move(source_range))
         , m_value(move(value))
     {
     }
@@ -1186,10 +1178,10 @@ private:
     DeprecatedString m_value;
 };
 
-class StringLiteral final : public Literal {
+class StringLiteral final : public Expression {
 public:
     explicit StringLiteral(SourceRange source_range, DeprecatedString value)
-        : Literal(move(source_range))
+        : Expression(move(source_range))
         , m_value(move(value))
     {
     }
@@ -1205,10 +1197,10 @@ private:
     DeprecatedString m_value;
 };
 
-class NullLiteral final : public Literal {
+class NullLiteral final : public Expression {
 public:
     explicit NullLiteral(SourceRange source_range)
-        : Literal(move(source_range))
+        : Expression(move(source_range))
     {
     }
 
@@ -1216,10 +1208,10 @@ public:
     virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode(Bytecode::Generator&) const override;
 };
 
-class RegExpLiteral final : public Literal {
+class RegExpLiteral final : public Expression {
 public:
     RegExpLiteral(SourceRange source_range, regex::Parser::Result parsed_regex, DeprecatedString parsed_pattern, regex::RegexOptions<ECMAScriptFlags> parsed_flags, DeprecatedString pattern, DeprecatedString flags)
-        : Literal(move(source_range))
+        : Expression(move(source_range))
         , m_parsed_regex(move(parsed_regex))
         , m_parsed_pattern(move(parsed_pattern))
         , m_parsed_flags(parsed_flags)

--- a/Userland/Libraries/LibJS/Bytecode/Instruction.h
+++ b/Userland/Libraries/LibJS/Bytecode/Instruction.h
@@ -86,6 +86,7 @@
     O(NewClass)                        \
     O(NewFunction)                     \
     O(NewObject)                       \
+    O(NewPrimitiveArray)               \
     O(NewRegExp)                       \
     O(NewString)                       \
     O(NewTypeError)                    \

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -605,6 +605,15 @@ ThrowCompletionOr<void> NewArray::execute_impl(Bytecode::Interpreter& interprete
     return {};
 }
 
+ThrowCompletionOr<void> NewPrimitiveArray::execute_impl(Bytecode::Interpreter& interpreter) const
+{
+    auto array = MUST(Array::create(interpreter.realm(), 0));
+    for (size_t i = 0; i < m_values.size(); i++)
+        array->indexed_properties().put(i, m_values[i], default_attributes);
+    interpreter.accumulator() = array;
+    return {};
+}
+
 ThrowCompletionOr<void> Append::execute_impl(Bytecode::Interpreter& interpreter) const
 {
     return append(interpreter.vm(), interpreter.reg(m_lhs), interpreter.accumulator(), m_is_spread);
@@ -1304,6 +1313,11 @@ DeprecatedString NewArray::to_deprecated_string_impl(Bytecode::Executable const&
         builder.appendff(" [{}-{}]", m_elements[0], m_elements[1]);
     }
     return builder.to_deprecated_string();
+}
+
+DeprecatedString NewPrimitiveArray::to_deprecated_string_impl(Bytecode::Executable const&) const
+{
+    return DeprecatedString::formatted("NewPrimitiveArray {}"sv, m_values.span());
 }
 
 DeprecatedString Append::to_deprecated_string_impl(Bytecode::Executable const&) const

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <AK/FixedArray.h>
 #include <AK/StdLibExtras.h>
 #include <LibCrypto/BigInt/SignedBigInteger.h>
 #include <LibJS/Bytecode/Builtins.h>
@@ -311,6 +312,23 @@ public:
 private:
     size_t m_element_count { 0 };
     Register m_elements[];
+};
+
+class NewPrimitiveArray final : public Instruction {
+public:
+    explicit NewPrimitiveArray(FixedArray<Value> values)
+        : Instruction(Type::NewPrimitiveArray, sizeof(*this))
+        , m_values(move(values))
+    {
+    }
+
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    DeprecatedString to_deprecated_string_impl(Bytecode::Executable const&) const;
+
+    ReadonlySpan<Value> values() const { return m_values.span(); }
+
+private:
+    FixedArray<Value> m_values;
 };
 
 class Append final : public Instruction {

--- a/Userland/Libraries/LibJS/JIT/Compiler.cpp
+++ b/Userland/Libraries/LibJS/JIT/Compiler.cpp
@@ -1528,6 +1528,28 @@ void Compiler::compile_new_array(Bytecode::Op::NewArray const& op)
     store_accumulator(RET);
 }
 
+static Value cxx_new_primitive_array(VM& vm, Value* values, size_t element_count)
+{
+    auto& realm = *vm.current_realm();
+    auto array = MUST(Array::create(realm, 0));
+    for (size_t i = 0; i < element_count; ++i) {
+        array->indexed_properties().put(i, values[i], default_attributes);
+    }
+    return array;
+}
+
+void Compiler::compile_new_primitive_array(Bytecode::Op::NewPrimitiveArray const& op)
+{
+    m_assembler.mov(
+        Assembler::Operand::Register(ARG1),
+        Assembler::Operand::Imm(bit_cast<u64>(op.values().data())));
+    m_assembler.mov(
+        Assembler::Operand::Register(ARG2),
+        Assembler::Operand::Imm(op.values().size()));
+    native_call((void*)cxx_new_primitive_array);
+    store_accumulator(RET);
+}
+
 void Compiler::compile_new_function(Bytecode::Op::NewFunction const& op)
 {
     m_assembler.mov(

--- a/Userland/Libraries/LibJS/JIT/Compiler.h
+++ b/Userland/Libraries/LibJS/JIT/Compiler.h
@@ -92,6 +92,7 @@ private:
         O(NewString, new_string)                                                 \
         O(NewObject, new_object)                                                 \
         O(NewArray, new_array)                                                   \
+        O(NewPrimitiveArray, new_primitive_array)                                \
         O(NewFunction, new_function)                                             \
         O(NewRegExp, new_regexp)                                                 \
         O(NewBigInt, new_bigint)                                                 \


### PR DESCRIPTION
This will not meaningfully affect short array literals, but it does give us a bit of extra perf when evaluating huge array expressions like in the Kraken imaging-* tests (where it eliminates KiBs of generated code)

```
Suite    Test                                   Speedup  Old (Mean ± Range)     New (Mean ± Range)
-------  -----------------------------------  ---------  ---------------------  ---------------------
Kraken   ai-astar.js                              1.011  1.144 ± 1.140 … 1.150  1.132 ± 1.120 … 1.140
Kraken   audio-beat-detection.js                  1.008  0.960 ± 0.950 … 0.980  0.952 ± 0.940 … 0.970
Kraken   audio-dft.js                             1.003  0.652 ± 0.650 … 0.660  0.650 ± 0.640 … 0.660
Kraken   audio-fft.js                             0.997  0.708 ± 0.690 … 0.720  0.710 ± 0.690 … 0.730
Kraken   audio-oscillator.js                      0.97   1.920 ± 1.900 … 1.940  1.980 ± 1.950 … 2.020
Kraken   imaging-darkroom.js                      1.05   6.084 ± 6.030 … 6.210  5.796 ± 5.710 … 5.950
Kraken   imaging-desaturate.js                    1.148  1.348 ± 1.300 … 1.370  1.174 ± 1.120 … 1.260
Kraken   imaging-gaussian-blur.js                 1.21   5.848 ± 4.970 … 9.080  4.834 ± 4.780 … 4.880
Kraken   json-parse-financial.js                  1      0.128 ± 0.120 … 0.130  0.128 ± 0.120 … 0.130
Kraken   json-stringify-tinderbox.js              1.006  0.328 ± 0.320 … 0.330  0.326 ± 0.320 … 0.330
Kraken   stanford-crypto-aes.js                   1.037  1.002 ± 1.000 … 1.010  0.966 ± 0.960 … 0.970
Kraken   stanford-crypto-ccm.js                   1.024  1.014 ± 1.000 … 1.030  0.990 ± 0.980 … 1.000
Kraken   stanford-crypto-pbkdf2.js                1.002  1.806 ± 1.790 … 1.850  1.802 ± 1.790 … 1.810
Kraken   stanford-crypto-sha256-iterative.js      0.985  0.780 ± 0.770 … 0.790  0.792 ± 0.790 … 0.800
```