### PR TITLE
LibLine: Reset state after invalid character in DSR response

### DIFF
--- a/Userland/Libraries/LibLine/Editor.cpp
+++ b/Userland/Libraries/LibLine/Editor.cpp
@@ -2128,14 +2128,17 @@ Result<Vector<size_t, 2>, Editor::Error> Editor::vt_dsr()
                 continue;
             }
             m_incomplete_data.append(c);
+            state = Free;
             continue;
         case SawBracket:
             if (is_ascii_digit(c)) {
                 state = InFirstCoordinate;
+                coordinate_buffer.clear_with_capacity();
                 coordinate_buffer.append(c);
                 continue;
             }
             m_incomplete_data.append(c);
+            state = Free;
             continue;
         case InFirstCoordinate:
             if (is_ascii_digit(c)) {
@@ -2152,6 +2155,7 @@ Result<Vector<size_t, 2>, Editor::Error> Editor::vt_dsr()
                 continue;
             }
             m_incomplete_data.append(c);
+            state = Free;
             continue;
         case SawSemicolon:
             if (is_ascii_digit(c)) {
@@ -2160,6 +2164,7 @@ Result<Vector<size_t, 2>, Editor::Error> Editor::vt_dsr()
                 continue;
             }
             m_incomplete_data.append(c);
+            state = Free;
             continue;
         case InSecondCoordinate:
             if (is_ascii_digit(c)) {
@@ -2176,6 +2181,7 @@ Result<Vector<size_t, 2>, Editor::Error> Editor::vt_dsr()
                 continue;
             }
             m_incomplete_data.append(c);
+            state = Free;
             continue;
         case SawR:
             m_incomplete_data.append(c);


### PR DESCRIPTION
This is my attempt to fix #21978
If there's any suggestion on how we should fix this issue, please let me know.
Thank you

> While parsing DSR response, we might encounter invalid characters, for example, when we `cat` a binary file. Previously, we just pushed those characters in `m_incomplete_data` buffer, which worked fine until we didn't get a terminating character. We kept increasing coordinate value and crashed in following assertion.