### PR TITLE
Tests: Add a type3 test pdf

### DIFF
--- a/Tests/LibPDF/type3.pdf
+++ b/Tests/LibPDF/type3.pdf
@@ -1,0 +1,95 @@
+%PDF-1.7
+%µ¶
+
+1 0 obj
+<</Info 10 0 R/Pages 2 0 R/Type/Catalog>>
+endobj
+
+2 0 obj
+<</Type/Pages/Kids[3 0 R]/Count 1>>
+endobj
+
+3 0 obj
+<</Contents 4 0 R/Type/Page/Resources<</Font<</F1 5 0 R/F2 6 0 R>>>>/Rotate 0/MediaBox[0 0 525 250]/Parent 2 0 R>>
+endobj
+
+4 0 obj
+<</Length 150>>
+stream
+BT
+/F1 24 Tf
+30 TL
+40 220 Td
+(There should be 5 triangles facing right) '
+(with colors blue green blue green blue:) '
+0 0 1 rg
+/F2 24 Tf
+(ababa) '
+ET
+
+endstream
+endobj
+
+5 0 obj
+<</Type/Font/Subtype/Type1/Name/F1/BaseFont/Helvetica/Encoding/MacRomanEncoding>>
+endobj
+
+6 0 obj
+<</Type/Font/Subtype/Type3/Name/F2/FontBBox[0 0 0 0]/FontMatrix[.1 0 0 .1 0 0]/CharProcs<</a 7 0 R/b 8 0 R>>/Encoding/MacRomanEncoding/FirstChar 97/LastChar 98/Widths[10 10]/Resources<<>>>>
+endobj
+
+7 0 obj
+<</Length 54>>
+stream
+10 0 0 0 10 10 d1
+1 0 0 rg
+0 0 m
+8 5 l
+0 10 l
+0 0 l
+f
+
+endstream
+endobj
+
+8 0 obj
+<</Length 44>>
+stream
+10 0 d0
+0 1 0 rg
+0 0 m
+8 5 l
+0 10 l
+0 0 l
+f
+
+endstream
+endobj
+
+9 0 obj
+<</Producer(macOS Version 13.5.2 \(Build 22G91\) Quartz PDFContext, AppendMode 1.1)/ModDate(D:20231118163949Z00'00')>>
+endobj
+
+10 0 obj
+9 0 R
+endobj
+
+xref
+0 11
+0000000000 65536 f 
+0000000016 00000 n 
+0000000074 00000 n 
+0000000126 00000 n 
+0000000257 00000 n 
+0000000457 00000 n 
+0000000555 00000 n 
+0000000761 00000 n 
+0000000864 00000 n 
+0000000957 00000 n 
+0000001092 00000 n 
+
+trailer
+<</Size 11/Info 10 0 R/Root 1 0 R/ID[()<E0167852D61B9B3AA6919AB85E3DD297>]>>
+startxref
+1115
+%%EOF


### PR DESCRIPTION
A manual test, but better than nothing.

I hand-wrote the file, and used mutool to fix up xref and stream lengths:

    mutool clean Tests/LibPDF/type3.pdf Tests/LibPDF/type3.pdf

The file contains one `d1` character which per spec shouldn't contain color statements, and if it does it should be ignored, and one `d0` character which can contain color.

The text then sets a color before rendering the text.

Per spec, the text color should affect the `d1` character but not the `d0` one. We get this wrong, but so does Preview.app. (PDFium gets it right.)

But independent of the colors, just rendering the glyphs at all at the right position is already good :^)