### PR TITLE
LibWeb: (partially) Implement ReadableStreamBYOBReader::read

### DIFF
--- a/Tests/LibWeb/Text/expected/Streams/ReadableStreamBYOBReader-read.txt
+++ b/Tests/LibWeb/Text/expected/Streams/ReadableStreamBYOBReader-read.txt
@@ -1,0 +1,3 @@
+About to read! [object ReadableStreamBYOBReader]
+Total bytes: 34
+'This is some data to be read! 🦬'

--- a/Tests/LibWeb/Text/input/Streams/ReadableStreamBYOBReader-read.html
+++ b/Tests/LibWeb/Text/input/Streams/ReadableStreamBYOBReader-read.html
@@ -1,0 +1,31 @@
+<script src="../include.js"></script>
+<script>
+ asyncTest(async done => {
+    const array = ['This is some data to be read! 🦬'];
+    let blob = new Blob(array);
+
+    const stream = blob.stream();
+    const reader = stream.getReader({ mode: "byob" });
+
+    let buffer = new ArrayBuffer(200);
+    let bytesReceived = 0;
+    let offset = 0;
+
+    println(`About to read! ${reader}`);
+
+    while (true) {
+      let result = await reader.read(new Uint8Array(buffer, offset, buffer.byteLength - offset));
+
+      if (result.done) {
+        println(`Total bytes: ${bytesReceived}`);
+        println(`'${new TextDecoder().decode(result.value.buffer.slice(0, bytesReceived))}'`);
+        done();
+        return;
+      }
+
+      buffer = result.value.buffer;
+      offset += result.value.byteLength;
+      bytesReceived += result.value.byteLength;
+    }
+  });
+</script>

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -598,6 +598,7 @@ class ReadableStreamBYOBRequest;
 class ReadableStreamDefaultController;
 class ReadableStreamDefaultReader;
 class ReadableStreamGenericReaderMixin;
+class ReadIntoRequest;
 class ReadRequest;
 class TransformStream;
 class TransformStreamDefaultController;

--- a/Userland/Libraries/LibWeb/Streams/AbstractOperations.cpp
+++ b/Userland/Libraries/LibWeb/Streams/AbstractOperations.cpp
@@ -358,6 +358,19 @@ void readable_stream_add_read_request(ReadableStream& stream, JS::NonnullGCPtr<R
     stream.reader()->get<JS::NonnullGCPtr<ReadableStreamDefaultReader>>()->read_requests().append(read_request);
 }
 
+// https://streams.spec.whatwg.org/#readable-stream-add-read-into-request
+void readable_stream_add_read_into_request(ReadableStream& stream, JS::NonnullGCPtr<ReadIntoRequest> read_into_request)
+{
+    // 1. Assert: stream.[[reader]] implements ReadableStreamBYOBReader.
+    VERIFY(stream.reader().has_value() && stream.reader()->has<JS::NonnullGCPtr<ReadableStreamBYOBReader>>());
+
+    // 2. Assert: stream.[[state]] is "readable" or "closed".
+    VERIFY(stream.is_readable() || stream.is_closed());
+
+    // 3. Append readRequest to stream.[[reader]].[[readIntoRequests]].
+    stream.reader()->get<JS::NonnullGCPtr<ReadableStreamBYOBReader>>()->read_into_requests().append(read_into_request);
+}
+
 // https://streams.spec.whatwg.org/#readable-stream-reader-generic-cancel
 WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>> readable_stream_reader_generic_cancel(ReadableStreamGenericReaderMixin& reader, JS::Value reason)
 {

--- a/Userland/Libraries/LibWeb/Streams/AbstractOperations.cpp
+++ b/Userland/Libraries/LibWeb/Streams/AbstractOperations.cpp
@@ -1935,9 +1935,11 @@ WebIDL::ExceptionOr<void> readable_byte_stream_controller_enqueue(ReadableByteSt
     }
     // 10. Otherwise, if ! ReadableStreamHasBYOBReader(stream) is true,
     else if (readable_stream_has_byob_reader(*stream)) {
-        // FIXME: 1. Perform ! ReadableByteStreamControllerEnqueueChunkToQueue(controller, transferredBuffer, byteOffset, byteLength).
-        // FIXME: 2. Perform ! ReadableByteStreamControllerProcessPullIntoDescriptorsUsingQueue(controller).
-        TODO();
+        // 1. Perform ! ReadableByteStreamControllerEnqueueChunkToQueue(controller, transferredBuffer, byteOffset, byteLength).
+        readable_byte_stream_controller_enqueue_chunk_to_queue(controller, transferred_buffer, byte_offset, byte_length);
+
+        // 2. Perform ! ReadableByteStreamControllerProcessPullIntoDescriptorsUsingQueue(controller).
+        readable_byte_stream_controller_process_pull_into_descriptors_using_queue(controller);
     }
     // 11. Otherwise,
     else {

--- a/Userland/Libraries/LibWeb/Streams/AbstractOperations.cpp
+++ b/Userland/Libraries/LibWeb/Streams/AbstractOperations.cpp
@@ -493,6 +493,19 @@ void readable_stream_byob_reader_error_read_into_requests(ReadableStreamBYOBRead
     }
 }
 
+// https://streams.spec.whatwg.org/#readable-byte-stream-controller-fill-head-pull-into-descriptor
+void readable_byte_stream_controller_fill_head_pull_into_descriptor(ReadableByteStreamController const& controller, u64 size, PullIntoDescriptor& pull_into_descriptor)
+{
+    // 1. Assert: either controller.[[pendingPullIntos]] is empty, or controller.[[pendingPullIntos]][0] is pullIntoDescriptor.
+    VERIFY(controller.pending_pull_intos().is_empty() || &controller.pending_pull_intos().first() == &pull_into_descriptor);
+
+    // 2. Assert: controller.[[byobRequest]] is null.
+    VERIFY(!controller.byob_request());
+
+    // 3. Set pullIntoDescriptor’s bytes filled to bytes filled + size.
+    pull_into_descriptor.bytes_filled += size;
+}
+
 // https://streams.spec.whatwg.org/#readable-stream-default-reader-read
 WebIDL::ExceptionOr<void> readable_stream_default_reader_read(ReadableStreamDefaultReader& reader, ReadRequest& read_request)
 {

--- a/Userland/Libraries/LibWeb/Streams/AbstractOperations.cpp
+++ b/Userland/Libraries/LibWeb/Streams/AbstractOperations.cpp
@@ -811,6 +811,28 @@ void readable_byte_stream_controller_pull_into(ReadableByteStreamController& con
     MUST(readable_byte_stream_controller_call_pull_if_needed(controller));
 }
 
+// https://streams.spec.whatwg.org/#readable-stream-byob-reader-read
+void readable_stream_byob_reader_read(ReadableStreamBYOBReader& reader, JS::Value view, ReadIntoRequest& read_into_request)
+{
+    // 1. Let stream be reader.[[stream]].
+    auto stream = reader.stream();
+
+    // 2. Assert: stream is not undefined.
+    VERIFY(stream);
+
+    // 3. Set stream.[[disturbed]] to true.
+    stream->set_disturbed(true);
+
+    // 4. If stream.[[state]] is "errored", perform readIntoRequest’s error steps given stream.[[storedError]].
+    if (stream->is_errored()) {
+        read_into_request.on_error(stream->stored_error());
+    }
+    // 5. Otherwise, perform ! ReadableByteStreamControllerPullInto(stream.[[controller]], view, readIntoRequest).
+    else {
+        readable_byte_stream_controller_pull_into(*stream->controller()->get<JS::NonnullGCPtr<ReadableByteStreamController>>(), view, read_into_request);
+    }
+}
+
 // https://streams.spec.whatwg.org/#abstract-opdef-readablestreamdefaultreaderrelease
 WebIDL::ExceptionOr<void> readable_stream_default_reader_release(ReadableStreamDefaultReader& reader)
 {

--- a/Userland/Libraries/LibWeb/Streams/AbstractOperations.cpp
+++ b/Userland/Libraries/LibWeb/Streams/AbstractOperations.cpp
@@ -1664,7 +1664,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::ArrayBuffer>> transfer_array_buffer(JS:
     TRY(JS::detach_array_buffer(vm, buffer));
 
     // 5. Return a new ArrayBuffer object, created in the current Realm, whose [[ArrayBufferData]] internal slot value is arrayBufferData and whose [[ArrayBufferByteLength]] internal slot value is arrayBufferByteLength.
-    return JS::ArrayBuffer::create(realm, array_buffer);
+    return JS::ArrayBuffer::create(realm, move(array_buffer));
 }
 
 // https://streams.spec.whatwg.org/#abstract-opdef-readablebytestreamcontrollerenqueuedetachedpullintotoqueue

--- a/Userland/Libraries/LibWeb/Streams/AbstractOperations.cpp
+++ b/Userland/Libraries/LibWeb/Streams/AbstractOperations.cpp
@@ -346,7 +346,7 @@ void readable_stream_error(ReadableStream& stream, JS::Value error)
 }
 
 // https://streams.spec.whatwg.org/#readable-stream-add-read-request
-void readable_stream_add_read_request(ReadableStream& stream, ReadRequest& read_request)
+void readable_stream_add_read_request(ReadableStream& stream, JS::NonnullGCPtr<ReadRequest> read_request)
 {
     // 1. Assert: stream.[[reader]] implements ReadableStreamDefaultReader.
     VERIFY(stream.reader().has_value() && stream.reader()->has<JS::NonnullGCPtr<ReadableStreamDefaultReader>>());

--- a/Userland/Libraries/LibWeb/Streams/AbstractOperations.cpp
+++ b/Userland/Libraries/LibWeb/Streams/AbstractOperations.cpp
@@ -527,6 +527,30 @@ WebIDL::ExceptionOr<void> readable_stream_default_reader_read(ReadableStreamDefa
     return {};
 }
 
+// https://streams.spec.whatwg.org/#readable-byte-stream-controller-convert-pull-into-descriptor
+JS::Value readable_byte_stream_controller_convert_pull_into_descriptor(JS::Realm& realm, PullIntoDescriptor const& pull_into_descriptor)
+{
+    auto& vm = realm.vm();
+
+    // 1. Let bytesFilled be pullIntoDescriptor’s bytes filled.
+    auto bytes_filled = pull_into_descriptor.bytes_filled;
+
+    // 2. Let elementSize be pullIntoDescriptor’s element size.
+    auto element_size = pull_into_descriptor.element_size;
+
+    // 3. Assert: bytesFilled ≤ pullIntoDescriptor’s byte length.
+    VERIFY(bytes_filled <= pull_into_descriptor.byte_length);
+
+    // 4. Assert: bytesFilled mod elementSize is 0.
+    VERIFY(bytes_filled % element_size == 0);
+
+    // 5. Let buffer be ! TransferArrayBuffer(pullIntoDescriptor’s buffer).
+    auto buffer = MUST(transfer_array_buffer(realm, pull_into_descriptor.buffer));
+
+    // 6. Return ! Construct(pullIntoDescriptor’s view constructor, « buffer, pullIntoDescriptor’s byte offset, bytesFilled ÷ elementSize »).
+    return MUST(JS::construct(vm, *pull_into_descriptor.view_constructor, buffer, JS::Value(pull_into_descriptor.byte_offset), JS::Value(bytes_filled / element_size)));
+}
+
 // https://streams.spec.whatwg.org/#abstract-opdef-readablestreamdefaultreaderrelease
 WebIDL::ExceptionOr<void> readable_stream_default_reader_release(ReadableStreamDefaultReader& reader)
 {

--- a/Userland/Libraries/LibWeb/Streams/AbstractOperations.h
+++ b/Userland/Libraries/LibWeb/Streams/AbstractOperations.h
@@ -93,6 +93,7 @@ void readable_byte_stream_controller_clear_pending_pull_intos(ReadableByteStream
 WebIDL::ExceptionOr<void> readable_byte_stream_controller_close(ReadableByteStreamController&);
 void readable_byte_stream_controller_error(ReadableByteStreamController&, JS::Value error);
 WebIDL::ExceptionOr<void> readable_byte_stream_controller_fill_read_request_from_queue(ReadableByteStreamController&, JS::NonnullGCPtr<ReadRequest>);
+bool readable_byte_stream_controller_fill_pull_into_descriptor_from_queue(ReadableByteStreamController&, PullIntoDescriptor&);
 Optional<double> readable_byte_stream_controller_get_desired_size(ReadableByteStreamController const&);
 WebIDL::ExceptionOr<void> readable_byte_stream_controller_handle_queue_drain(ReadableByteStreamController&);
 void readable_byte_stream_controller_invalidate_byob_request(ReadableByteStreamController&);

--- a/Userland/Libraries/LibWeb/Streams/AbstractOperations.h
+++ b/Userland/Libraries/LibWeb/Streams/AbstractOperations.h
@@ -54,6 +54,7 @@ WebIDL::ExceptionOr<void> readable_stream_reader_generic_release(ReadableStreamG
 void readable_stream_default_reader_error_read_requests(ReadableStreamDefaultReader&, JS::Value error);
 void readable_stream_byob_reader_error_read_into_requests(ReadableStreamBYOBReader&, JS::Value error);
 JS::Value readable_byte_stream_controller_convert_pull_into_descriptor(JS::Realm&, PullIntoDescriptor const&);
+void readable_byte_stream_controller_pull_into(ReadableByteStreamController&, JS::Value view_value, ReadIntoRequest&);
 void readable_byte_stream_controller_fill_head_pull_into_descriptor(ReadableByteStreamController const&, u64 size, PullIntoDescriptor&);
 
 WebIDL::ExceptionOr<void> readable_stream_default_reader_read(ReadableStreamDefaultReader&, ReadRequest&);

--- a/Userland/Libraries/LibWeb/Streams/AbstractOperations.h
+++ b/Userland/Libraries/LibWeb/Streams/AbstractOperations.h
@@ -81,6 +81,7 @@ WebIDL::ExceptionOr<void> readable_stream_enqueue(ReadableStreamController& cont
 WebIDL::ExceptionOr<void> readable_byte_stream_controller_enqueue(ReadableByteStreamController& controller, JS::Value chunk);
 WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::ArrayBuffer>> transfer_array_buffer(JS::Realm& realm, JS::ArrayBuffer& buffer);
 WebIDL::ExceptionOr<void> readable_byte_stream_controller_enqueue_detached_pull_into_queue(ReadableByteStreamController& controller, PullIntoDescriptor& pull_into_descriptor);
+void readable_byte_stream_controller_commit_pull_into_descriptor(ReadableStream&, PullIntoDescriptor const&);
 WebIDL::ExceptionOr<void> readable_byte_stream_controller_process_read_requests_using_queue(ReadableByteStreamController& controller);
 void readable_byte_stream_controller_enqueue_chunk_to_queue(ReadableByteStreamController& controller, JS::NonnullGCPtr<JS::ArrayBuffer> buffer, u32 byte_offset, u32 byte_length);
 WebIDL::ExceptionOr<void> readable_byte_stream_controller_enqueue_cloned_chunk_to_queue(ReadableByteStreamController& controller, JS::ArrayBuffer& buffer, u64 byte_offset, u64 byte_length);

--- a/Userland/Libraries/LibWeb/Streams/AbstractOperations.h
+++ b/Userland/Libraries/LibWeb/Streams/AbstractOperations.h
@@ -39,6 +39,7 @@ void readable_stream_close(ReadableStream&);
 void readable_stream_error(ReadableStream&, JS::Value error);
 void readable_stream_add_read_request(ReadableStream&, ReadRequest&);
 WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>> readable_stream_cancel(ReadableStream&, JS::Value reason);
+void readable_stream_fulfill_read_into_request(ReadableStream&, JS::Value chunk, bool done);
 void readable_stream_fulfill_read_request(ReadableStream&, JS::Value chunk, bool done);
 size_t readable_stream_get_num_read_into_requests(ReadableStream const&);
 size_t readable_stream_get_num_read_requests(ReadableStream const&);

--- a/Userland/Libraries/LibWeb/Streams/AbstractOperations.h
+++ b/Userland/Libraries/LibWeb/Streams/AbstractOperations.h
@@ -37,7 +37,7 @@ WebIDL::ExceptionOr<double> extract_high_water_mark(QueuingStrategy const&, doub
 
 void readable_stream_close(ReadableStream&);
 void readable_stream_error(ReadableStream&, JS::Value error);
-void readable_stream_add_read_request(ReadableStream&, ReadRequest&);
+void readable_stream_add_read_request(ReadableStream&, JS::NonnullGCPtr<ReadRequest>);
 WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>> readable_stream_cancel(ReadableStream&, JS::Value reason);
 void readable_stream_fulfill_read_into_request(ReadableStream&, JS::Value chunk, bool done);
 void readable_stream_fulfill_read_request(ReadableStream&, JS::Value chunk, bool done);

--- a/Userland/Libraries/LibWeb/Streams/AbstractOperations.h
+++ b/Userland/Libraries/LibWeb/Streams/AbstractOperations.h
@@ -53,6 +53,7 @@ WebIDL::ExceptionOr<void> readable_stream_reader_generic_release(ReadableStreamG
 
 void readable_stream_default_reader_error_read_requests(ReadableStreamDefaultReader&, JS::Value error);
 void readable_stream_byob_reader_error_read_into_requests(ReadableStreamBYOBReader&, JS::Value error);
+JS::Value readable_byte_stream_controller_convert_pull_into_descriptor(JS::Realm&, PullIntoDescriptor const&);
 
 WebIDL::ExceptionOr<void> readable_stream_default_reader_read(ReadableStreamDefaultReader&, ReadRequest&);
 WebIDL::ExceptionOr<void> readable_stream_default_reader_release(ReadableStreamDefaultReader&);

--- a/Userland/Libraries/LibWeb/Streams/AbstractOperations.h
+++ b/Userland/Libraries/LibWeb/Streams/AbstractOperations.h
@@ -55,6 +55,7 @@ void readable_stream_default_reader_error_read_requests(ReadableStreamDefaultRea
 void readable_stream_byob_reader_error_read_into_requests(ReadableStreamBYOBReader&, JS::Value error);
 JS::Value readable_byte_stream_controller_convert_pull_into_descriptor(JS::Realm&, PullIntoDescriptor const&);
 void readable_byte_stream_controller_pull_into(ReadableByteStreamController&, JS::Value view_value, ReadIntoRequest&);
+void readable_stream_byob_reader_read(ReadableStreamBYOBReader&, JS::Value view, ReadIntoRequest&);
 void readable_byte_stream_controller_fill_head_pull_into_descriptor(ReadableByteStreamController const&, u64 size, PullIntoDescriptor&);
 
 WebIDL::ExceptionOr<void> readable_stream_default_reader_read(ReadableStreamDefaultReader&, ReadRequest&);

--- a/Userland/Libraries/LibWeb/Streams/AbstractOperations.h
+++ b/Userland/Libraries/LibWeb/Streams/AbstractOperations.h
@@ -38,6 +38,7 @@ WebIDL::ExceptionOr<double> extract_high_water_mark(QueuingStrategy const&, doub
 void readable_stream_close(ReadableStream&);
 void readable_stream_error(ReadableStream&, JS::Value error);
 void readable_stream_add_read_request(ReadableStream&, JS::NonnullGCPtr<ReadRequest>);
+void readable_stream_add_read_into_request(ReadableStream&, JS::NonnullGCPtr<ReadIntoRequest>);
 WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>> readable_stream_cancel(ReadableStream&, JS::Value reason);
 void readable_stream_fulfill_read_into_request(ReadableStream&, JS::Value chunk, bool done);
 void readable_stream_fulfill_read_request(ReadableStream&, JS::Value chunk, bool done);

--- a/Userland/Libraries/LibWeb/Streams/AbstractOperations.h
+++ b/Userland/Libraries/LibWeb/Streams/AbstractOperations.h
@@ -54,6 +54,7 @@ WebIDL::ExceptionOr<void> readable_stream_reader_generic_release(ReadableStreamG
 void readable_stream_default_reader_error_read_requests(ReadableStreamDefaultReader&, JS::Value error);
 void readable_stream_byob_reader_error_read_into_requests(ReadableStreamBYOBReader&, JS::Value error);
 JS::Value readable_byte_stream_controller_convert_pull_into_descriptor(JS::Realm&, PullIntoDescriptor const&);
+void readable_byte_stream_controller_fill_head_pull_into_descriptor(ReadableByteStreamController const&, u64 size, PullIntoDescriptor&);
 
 WebIDL::ExceptionOr<void> readable_stream_default_reader_read(ReadableStreamDefaultReader&, ReadRequest&);
 WebIDL::ExceptionOr<void> readable_stream_default_reader_release(ReadableStreamDefaultReader&);

--- a/Userland/Libraries/LibWeb/Streams/AbstractOperations.h
+++ b/Userland/Libraries/LibWeb/Streams/AbstractOperations.h
@@ -83,6 +83,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::ArrayBuffer>> transfer_array_buffer(JS:
 WebIDL::ExceptionOr<void> readable_byte_stream_controller_enqueue_detached_pull_into_queue(ReadableByteStreamController& controller, PullIntoDescriptor& pull_into_descriptor);
 void readable_byte_stream_controller_commit_pull_into_descriptor(ReadableStream&, PullIntoDescriptor const&);
 WebIDL::ExceptionOr<void> readable_byte_stream_controller_process_read_requests_using_queue(ReadableByteStreamController& controller);
+void readable_byte_stream_controller_process_pull_into_descriptors_using_queue(ReadableByteStreamController&);
 void readable_byte_stream_controller_enqueue_chunk_to_queue(ReadableByteStreamController& controller, JS::NonnullGCPtr<JS::ArrayBuffer> buffer, u32 byte_offset, u32 byte_length);
 WebIDL::ExceptionOr<void> readable_byte_stream_controller_enqueue_cloned_chunk_to_queue(ReadableByteStreamController& controller, JS::ArrayBuffer& buffer, u64 byte_offset, u64 byte_length);
 PullIntoDescriptor readable_byte_stream_controller_shift_pending_pull_into(ReadableByteStreamController& controller);

--- a/Userland/Libraries/LibWeb/Streams/ReadableByteStreamController.h
+++ b/Userland/Libraries/LibWeb/Streams/ReadableByteStreamController.h
@@ -76,6 +76,7 @@ class ReadableByteStreamController : public Bindings::PlatformObject {
 public:
     virtual ~ReadableByteStreamController() override = default;
 
+    JS::GCPtr<ReadableStreamBYOBRequest const> byob_request() const { return m_byob_request; }
     JS::GCPtr<ReadableStreamBYOBRequest> byob_request() { return m_byob_request; }
     void set_byob_request(JS::GCPtr<ReadableStreamBYOBRequest> request) { m_byob_request = request; }
 
@@ -102,6 +103,7 @@ public:
     void set_pulling(bool value) { m_pulling = value; }
 
     SinglyLinkedList<PullIntoDescriptor>& pending_pull_intos() { return m_pending_pull_intos; }
+    SinglyLinkedList<PullIntoDescriptor> const& pending_pull_intos() const { return m_pending_pull_intos; }
 
     SinglyLinkedList<ReadableByteStreamQueueEntry>& queue() { return m_queue; }
 

--- a/Userland/Libraries/LibWeb/Streams/ReadableStreamBYOBReader.cpp
+++ b/Userland/Libraries/LibWeb/Streams/ReadableStreamBYOBReader.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <LibJS/Runtime/PromiseCapability.h>
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Streams/AbstractOperations.h>
 #include <LibWeb/Streams/ReadableStream.h>
 #include <LibWeb/Streams/ReadableStreamBYOBReader.h>
@@ -17,6 +18,12 @@ ReadableStreamBYOBReader::ReadableStreamBYOBReader(JS::Realm& realm)
     : Bindings::PlatformObject(realm)
     , ReadableStreamGenericReaderMixin(realm)
 {
+}
+
+void ReadableStreamBYOBReader::initialize(JS::Realm& realm)
+{
+    Base::initialize(realm);
+    set_prototype(&Bindings::ensure_web_prototype<Bindings::ReadableStreamBYOBReaderPrototype>(realm, "ReadableStreamBYOBReader"));
 }
 
 // https://streams.spec.whatwg.org/#byob-reader-constructor

--- a/Userland/Libraries/LibWeb/Streams/ReadableStreamBYOBReader.cpp
+++ b/Userland/Libraries/LibWeb/Streams/ReadableStreamBYOBReader.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <LibJS/Runtime/PromiseCapability.h>
+#include <LibJS/Runtime/TypedArray.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Streams/AbstractOperations.h>
 #include <LibWeb/Streams/ReadableStream.h>
@@ -56,4 +57,101 @@ void ReadableStreamBYOBReader::visit_edges(Cell::Visitor& visitor)
         visitor.visit(request);
 }
 
+class BYOBReaderReadIntoRequest : public ReadIntoRequest {
+    JS_CELL(BYOBReaderReadIntoRequest, ReadIntoRequest);
+
+public:
+    BYOBReaderReadIntoRequest(JS::Realm& realm, WebIDL::Promise& promise)
+        : m_realm(realm)
+        , m_promise(promise)
+    {
+    }
+
+    // chunk steps, given chunk
+    virtual void on_chunk(JS::Value chunk) override
+    {
+        // 1. Resolve promise with «[ "value" → chunk, "done" → false ]».
+        WebIDL::resolve_promise(m_realm, m_promise, JS::create_iterator_result_object(m_realm.vm(), chunk, false));
+    }
+
+    // close steps, given chunk
+    virtual void on_close(JS::Value chunk) override
+    {
+        // 1. Resolve promise with «[ "value" → chunk, "done" → true ]».
+        WebIDL::resolve_promise(m_realm, m_promise, JS::create_iterator_result_object(m_realm.vm(), chunk, true));
+    }
+
+    // error steps, given e
+    virtual void on_error(JS::Value error) override
+    {
+        // 1. Reject promise with e.
+        WebIDL::reject_promise(m_realm, m_promise, error);
+    }
+
+private:
+    virtual void visit_edges(Visitor& visitor) override
+    {
+        Base::visit_edges(visitor);
+        visitor.visit(m_realm);
+        visitor.visit(m_promise);
+    }
+
+    JS::Realm& m_realm;
+    WebIDL::Promise& m_promise;
+};
+
+// https://streams.spec.whatwg.org/#byob-reader-read
+WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> ReadableStreamBYOBReader::read(JS::Value view_value)
+{
+    auto& realm = this->realm();
+
+    // FIXME: Support DataViews
+    auto& view = verify_cast<JS::TypedArrayBase>(view_value.as_object());
+
+    // 1. If view.[[ByteLength]] is 0, return a promise rejected with a TypeError exception.
+    if (view.byte_length() == 0) {
+        auto exception = JS::TypeError::create(realm, "Cannot read in an empty buffer"sv);
+        auto promise_capability = WebIDL::create_rejected_promise(realm, exception);
+        return JS::NonnullGCPtr { verify_cast<JS::Promise>(*promise_capability->promise()) };
+    }
+
+    // 2. If view.[[ViewedArrayBuffer]].[[ArrayBufferByteLength]] is 0, return a promise rejected with a TypeError exception.
+    if (view.viewed_array_buffer()->byte_length() == 0) {
+        auto exception = JS::TypeError::create(realm, "Cannot read in an empty buffer"sv);
+        auto promise_capability = WebIDL::create_rejected_promise(realm, exception);
+        return JS::NonnullGCPtr { verify_cast<JS::Promise>(*promise_capability->promise()) };
+    }
+
+    // 3. If ! IsDetachedBuffer(view.[[ViewedArrayBuffer]]) is true, return a promise rejected with a TypeError exception.
+    if (view.viewed_array_buffer()->is_detached()) {
+        auto exception = JS::TypeError::create(realm, "Cannot read in a detached buffer"sv);
+        auto promise_capability = WebIDL::create_rejected_promise(realm, exception);
+        return JS::NonnullGCPtr { verify_cast<JS::Promise>(*promise_capability->promise()) };
+    }
+
+    // 4. If this.[[stream]] is undefined, return a promise rejected with a TypeError exception.
+    if (!m_stream) {
+        auto exception = JS::TypeError::create(realm, "Cannot read from an empty stream"sv);
+        auto promise_capability = WebIDL::create_rejected_promise(realm, exception);
+        return JS::NonnullGCPtr { verify_cast<JS::Promise>(*promise_capability->promise()) };
+    }
+
+    // 5. Let promise be a new promise.
+    auto promise_capability = WebIDL::create_promise(realm);
+
+    // 6. Let readIntoRequest be a new read-into request with the following items:
+    //    chunk steps, given chunk
+    //        Resolve promise with «[ "value" → chunk, "done" → false ]».
+    //    close steps, given chunk
+    //        Resolve promise with «[ "value" → chunk, "done" → true ]».
+    //    error steps, given e
+    //        Reject promise with e.
+    auto read_into_request = heap().allocate_without_realm<BYOBReaderReadIntoRequest>(realm, promise_capability);
+
+    // 7. Perform ! ReadableStreamBYOBReaderRead(this, view, readIntoRequest).
+    readable_stream_byob_reader_read(*this, view_value, *read_into_request);
+
+    // 8. Return promise.
+    return JS::NonnullGCPtr { verify_cast<JS::Promise>(*promise_capability->promise()) };
+}
 }

--- a/Userland/Libraries/LibWeb/Streams/ReadableStreamBYOBReader.h
+++ b/Userland/Libraries/LibWeb/Streams/ReadableStreamBYOBReader.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2023, Matthew Olsson <mattco@serenityos.org>
+ * Copyright (c) 2023, Shannon Booth <shannon@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -49,6 +50,8 @@ public:
 
 private:
     explicit ReadableStreamBYOBReader(JS::Realm&);
+
+    virtual void initialize(JS::Realm&) override;
 
     virtual void visit_edges(Cell::Visitor&) override;
 

--- a/Userland/Libraries/LibWeb/Streams/ReadableStreamBYOBReader.h
+++ b/Userland/Libraries/LibWeb/Streams/ReadableStreamBYOBReader.h
@@ -44,6 +44,8 @@ public:
 
     virtual ~ReadableStreamBYOBReader() override = default;
 
+    WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> read(JS::Value);
+
     void release_lock();
 
     Vector<JS::NonnullGCPtr<ReadIntoRequest>>& read_into_requests() { return m_read_into_requests; }

--- a/Userland/Libraries/LibWeb/Streams/ReadableStreamBYOBReader.idl
+++ b/Userland/Libraries/LibWeb/Streams/ReadableStreamBYOBReader.idl
@@ -1,4 +1,5 @@
 #import <Streams/ReadableStream.idl>
+#import <Streams/ReadableStreamDefaultReader.idl>
 #import <Streams/ReadableStreamGenericReader.idl>
 
 // https://streams.spec.whatwg.org/#readablestreambyobreader
@@ -6,7 +7,9 @@
 interface ReadableStreamBYOBReader {
     constructor(ReadableStream stream);
 
-    // FIXME: Promise<ReadableStreamReadResult> read(ArrayBufferView view);
+    // FIXME: This should accept an ArrayBufferView
+    Promise<ReadableStreamReadResult> read(any view);
+
     undefined releaseLock();
 };
 ReadableStreamBYOBReader includes ReadableStreamGenericReader;


### PR DESCRIPTION
This series of commits builds up to implementing reading into TypedArray buffers for BYOB streams (data views are still to be supported). I've been slowly chipping away at this in other MRs for a while - this MR finally gets us to the level where we can start adding tests for our BYOB support.