### PR TITLE
LibWeb/LibJS: Avoid GC visit of raw pointers where possible

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
@@ -533,7 +533,7 @@ void ECMAScriptFunctionObject::visit_edges(Visitor& visitor)
     m_script_or_module.visit(
         [](Empty) {},
         [&](auto& script_or_module) {
-            visitor.visit(script_or_module.ptr());
+            visitor.visit(script_or_module);
         });
 }
 

--- a/Userland/Libraries/LibWeb/CSS/CSSRule.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSRule.cpp
@@ -19,8 +19,8 @@ CSSRule::CSSRule(JS::Realm& realm)
 void CSSRule::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(m_parent_style_sheet.ptr());
-    visitor.visit(m_parent_rule.ptr());
+    visitor.visit(m_parent_style_sheet);
+    visitor.visit(m_parent_rule);
 }
 
 // https://www.w3.org/TR/cssom/#dom-cssrule-csstext

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleDeclaration.cpp
@@ -70,7 +70,7 @@ ElementInlineCSSStyleDeclaration::ElementInlineCSSStyleDeclaration(DOM::Element&
 void ElementInlineCSSStyleDeclaration::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(m_element.ptr());
+    visitor.visit(m_element);
 }
 
 size_t PropertyOwningCSSStyleDeclaration::length() const

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
@@ -46,7 +46,7 @@ void CSSStyleSheet::initialize(JS::Realm& realm)
 void CSSStyleSheet::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(m_style_sheet_list.ptr());
+    visitor.visit(m_style_sheet_list);
     visitor.visit(m_rules);
     visitor.visit(m_owner_css_rule);
     visitor.visit(m_default_namespace_rule);

--- a/Userland/Libraries/LibWeb/CSS/MediaQueryList.cpp
+++ b/Userland/Libraries/LibWeb/CSS/MediaQueryList.cpp
@@ -37,7 +37,7 @@ void MediaQueryList::initialize(JS::Realm& realm)
 void MediaQueryList::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(m_document.ptr());
+    visitor.visit(m_document);
 }
 
 // https://drafts.csswg.org/cssom-view/#dom-mediaquerylist-media

--- a/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
@@ -58,7 +58,7 @@ ResolvedCSSStyleDeclaration::ResolvedCSSStyleDeclaration(DOM::Element& element)
 void ResolvedCSSStyleDeclaration::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(m_element.ptr());
+    visitor.visit(m_element);
 }
 
 // https://drafts.csswg.org/cssom/#dom-cssstyledeclaration-length

--- a/Userland/Libraries/LibWeb/CSS/Screen.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Screen.cpp
@@ -33,7 +33,7 @@ void Screen::initialize(JS::Realm& realm)
 void Screen::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(m_window.ptr());
+    visitor.visit(m_window);
 }
 
 Gfx::IntRect Screen::screen_rect() const

--- a/Userland/Libraries/LibWeb/CSS/StyleSheetList.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleSheetList.cpp
@@ -85,7 +85,7 @@ void StyleSheetList::visit_edges(Cell::Visitor& visitor)
     Base::visit_edges(visitor);
     visitor.visit(m_document);
     for (auto sheet : m_sheets)
-        visitor.visit(sheet.ptr());
+        visitor.visit(sheet);
 }
 
 // https://www.w3.org/TR/cssom/#ref-for-dfn-supported-property-indices%E2%91%A1

--- a/Userland/Libraries/LibWeb/Crypto/Crypto.cpp
+++ b/Userland/Libraries/LibWeb/Crypto/Crypto.cpp
@@ -74,7 +74,7 @@ WebIDL::ExceptionOr<String> Crypto::random_uuid() const
 void Crypto::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(m_subtle.ptr());
+    visitor.visit(m_subtle);
 }
 
 // https://w3c.github.io/webcrypto/#dfn-generate-a-random-uuid

--- a/Userland/Libraries/LibWeb/DOM/AbortController.cpp
+++ b/Userland/Libraries/LibWeb/DOM/AbortController.cpp
@@ -34,7 +34,7 @@ void AbortController::initialize(JS::Realm& realm)
 void AbortController::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(m_signal.ptr());
+    visitor.visit(m_signal);
 }
 
 // https://dom.spec.whatwg.org/#dom-abortcontroller-abort

--- a/Userland/Libraries/LibWeb/DOM/AbstractRange.cpp
+++ b/Userland/Libraries/LibWeb/DOM/AbstractRange.cpp
@@ -30,8 +30,8 @@ void AbstractRange::initialize(JS::Realm& realm)
 void AbstractRange::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(m_start_container.ptr());
-    visitor.visit(m_end_container.ptr());
+    visitor.visit(m_start_container);
+    visitor.visit(m_end_container);
 }
 
 }

--- a/Userland/Libraries/LibWeb/DOM/Attr.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Attr.cpp
@@ -47,7 +47,7 @@ void Attr::initialize(JS::Realm& realm)
 void Attr::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(m_owner_element.ptr());
+    visitor.visit(m_owner_element);
 }
 
 Element* Attr::owner_element()

--- a/Userland/Libraries/LibWeb/DOM/DOMEventListener.cpp
+++ b/Userland/Libraries/LibWeb/DOM/DOMEventListener.cpp
@@ -16,8 +16,8 @@ DOMEventListener::~DOMEventListener() = default;
 void DOMEventListener::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(callback.ptr());
-    visitor.visit(signal.ptr());
+    visitor.visit(callback);
+    visitor.visit(signal);
 }
 
 }

--- a/Userland/Libraries/LibWeb/DOM/DocumentFragment.cpp
+++ b/Userland/Libraries/LibWeb/DOM/DocumentFragment.cpp
@@ -23,7 +23,7 @@ void DocumentFragment::initialize(JS::Realm& realm)
 void DocumentFragment::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(m_host.ptr());
+    visitor.visit(m_host);
 }
 
 void DocumentFragment::set_host(Web::DOM::Element* element)

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -120,11 +120,11 @@ void Element::visit_edges(Cell::Visitor& visitor)
     Base::visit_edges(visitor);
     SlottableMixin::visit_edges(visitor);
 
-    visitor.visit(m_attributes.ptr());
-    visitor.visit(m_inline_style.ptr());
-    visitor.visit(m_class_list.ptr());
-    visitor.visit(m_shadow_root.ptr());
-    visitor.visit(m_custom_element_definition.ptr());
+    visitor.visit(m_attributes);
+    visitor.visit(m_inline_style);
+    visitor.visit(m_class_list);
+    visitor.visit(m_shadow_root);
+    visitor.visit(m_custom_element_definition);
     for (auto& pseudo_element_layout_node : m_pseudo_element_nodes)
         visitor.visit(pseudo_element_layout_node);
     for (auto& registered_intersection_observers : m_registered_intersection_observers)

--- a/Userland/Libraries/LibWeb/DOM/Event.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Event.cpp
@@ -50,18 +50,18 @@ void Event::initialize(JS::Realm& realm)
 void Event::visit_edges(Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(m_target.ptr());
-    visitor.visit(m_related_target.ptr());
-    visitor.visit(m_current_target.ptr());
+    visitor.visit(m_target);
+    visitor.visit(m_related_target);
+    visitor.visit(m_current_target);
     for (auto& it : m_path) {
-        visitor.visit(it.invocation_target.ptr());
-        visitor.visit(it.shadow_adjusted_target.ptr());
-        visitor.visit(it.related_target.ptr());
+        visitor.visit(it.invocation_target);
+        visitor.visit(it.shadow_adjusted_target);
+        visitor.visit(it.related_target);
         for (auto& itit : it.touch_target_list)
-            visitor.visit(itit.ptr());
+            visitor.visit(itit);
     }
     for (auto& it : m_touch_target_list)
-        visitor.visit(it.ptr());
+        visitor.visit(it);
 }
 
 // https://dom.spec.whatwg.org/#concept-event-path-append

--- a/Userland/Libraries/LibWeb/DOM/EventTarget.cpp
+++ b/Userland/Libraries/LibWeb/DOM/EventTarget.cpp
@@ -67,10 +67,10 @@ void EventTarget::visit_edges(Cell::Visitor& visitor)
     Base::visit_edges(visitor);
 
     for (auto& event_listener : m_event_listener_list)
-        visitor.visit(event_listener.ptr());
+        visitor.visit(event_listener);
 
     for (auto& it : m_event_handler_map)
-        visitor.visit(it.value.ptr());
+        visitor.visit(it.value);
 }
 
 Vector<JS::Handle<DOMEventListener>> EventTarget::event_listener_list()

--- a/Userland/Libraries/LibWeb/DOM/HTMLCollection.cpp
+++ b/Userland/Libraries/LibWeb/DOM/HTMLCollection.cpp
@@ -37,7 +37,7 @@ void HTMLCollection::initialize(JS::Realm& realm)
 void HTMLCollection::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(m_root.ptr());
+    visitor.visit(m_root);
 }
 
 JS::MarkedVector<Element*> HTMLCollection::collect_matching_elements() const

--- a/Userland/Libraries/LibWeb/DOM/IDLEventListener.cpp
+++ b/Userland/Libraries/LibWeb/DOM/IDLEventListener.cpp
@@ -24,7 +24,7 @@ IDLEventListener::IDLEventListener(JS::Realm& realm, JS::NonnullGCPtr<WebIDL::Ca
 void IDLEventListener::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(m_callback.ptr());
+    visitor.visit(m_callback);
 }
 
 }

--- a/Userland/Libraries/LibWeb/DOM/LiveNodeList.cpp
+++ b/Userland/Libraries/LibWeb/DOM/LiveNodeList.cpp
@@ -30,7 +30,7 @@ LiveNodeList::~LiveNodeList() = default;
 void LiveNodeList::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(m_root.ptr());
+    visitor.visit(m_root);
 }
 
 JS::MarkedVector<Node*> LiveNodeList::collection() const

--- a/Userland/Libraries/LibWeb/DOM/MutationObserver.cpp
+++ b/Userland/Libraries/LibWeb/DOM/MutationObserver.cpp
@@ -46,9 +46,9 @@ void MutationObserver::initialize(JS::Realm& realm)
 void MutationObserver::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(m_callback.ptr());
+    visitor.visit(m_callback);
     for (auto& record : m_record_queue)
-        visitor.visit(record.ptr());
+        visitor.visit(record);
 }
 
 // https://dom.spec.whatwg.org/#dom-mutationobserver-observe
@@ -167,7 +167,7 @@ RegisteredObserver::~RegisteredObserver() = default;
 void RegisteredObserver::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(m_observer.ptr());
+    visitor.visit(m_observer);
 }
 
 JS::NonnullGCPtr<TransientRegisteredObserver> TransientRegisteredObserver::create(MutationObserver& observer, MutationObserverInit const& options, RegisteredObserver& source)
@@ -186,7 +186,7 @@ TransientRegisteredObserver::~TransientRegisteredObserver() = default;
 void TransientRegisteredObserver::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(m_source.ptr());
+    visitor.visit(m_source);
 }
 
 }

--- a/Userland/Libraries/LibWeb/DOM/MutationRecord.cpp
+++ b/Userland/Libraries/LibWeb/DOM/MutationRecord.cpp
@@ -42,11 +42,11 @@ void MutationRecord::initialize(JS::Realm& realm)
 void MutationRecord::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(m_target.ptr());
-    visitor.visit(m_added_nodes.ptr());
-    visitor.visit(m_removed_nodes.ptr());
-    visitor.visit(m_previous_sibling.ptr());
-    visitor.visit(m_next_sibling.ptr());
+    visitor.visit(m_target);
+    visitor.visit(m_added_nodes);
+    visitor.visit(m_removed_nodes);
+    visitor.visit(m_previous_sibling);
+    visitor.visit(m_next_sibling);
 }
 
 }

--- a/Userland/Libraries/LibWeb/DOM/NamedNodeMap.cpp
+++ b/Userland/Libraries/LibWeb/DOM/NamedNodeMap.cpp
@@ -34,9 +34,9 @@ void NamedNodeMap::initialize(JS::Realm& realm)
 void NamedNodeMap::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(m_element.ptr());
+    visitor.visit(m_element);
     for (auto& attribute : m_attributes)
-        visitor.visit(attribute.ptr());
+        visitor.visit(attribute);
 }
 
 // https://dom.spec.whatwg.org/#ref-for-dfn-supported-property-indices%E2%91%A3

--- a/Userland/Libraries/LibWeb/DOM/Node.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Node.cpp
@@ -92,12 +92,12 @@ void Node::finalize()
 void Node::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(m_document.ptr());
-    visitor.visit(m_parent.ptr());
-    visitor.visit(m_first_child.ptr());
-    visitor.visit(m_last_child.ptr());
-    visitor.visit(m_next_sibling.ptr());
-    visitor.visit(m_previous_sibling.ptr());
+    visitor.visit(m_document);
+    visitor.visit(m_parent);
+    visitor.visit(m_first_child);
+    visitor.visit(m_last_child);
+    visitor.visit(m_next_sibling);
+    visitor.visit(m_previous_sibling);
     visitor.visit(m_child_nodes);
 
     visitor.visit(m_layout_node);

--- a/Userland/Libraries/LibWeb/DOM/NodeIterator.cpp
+++ b/Userland/Libraries/LibWeb/DOM/NodeIterator.cpp
@@ -36,12 +36,12 @@ void NodeIterator::finalize()
 void NodeIterator::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(m_filter.ptr());
-    visitor.visit(m_root.ptr());
-    visitor.visit(m_reference.node.ptr());
+    visitor.visit(m_filter);
+    visitor.visit(m_root);
+    visitor.visit(m_reference.node);
 
     if (m_traversal_pointer.has_value())
-        visitor.visit(m_traversal_pointer->node.ptr());
+        visitor.visit(m_traversal_pointer->node);
 }
 
 // https://dom.spec.whatwg.org/#dom-document-createnodeiterator

--- a/Userland/Libraries/LibWeb/DOM/TreeWalker.cpp
+++ b/Userland/Libraries/LibWeb/DOM/TreeWalker.cpp
@@ -31,9 +31,9 @@ void TreeWalker::initialize(JS::Realm& realm)
 void TreeWalker::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(m_filter.ptr());
-    visitor.visit(m_root.ptr());
-    visitor.visit(m_current.ptr());
+    visitor.visit(m_filter);
+    visitor.visit(m_root);
+    visitor.visit(m_current);
 }
 
 // https://dom.spec.whatwg.org/#dom-document-createtreewalker

--- a/Userland/Libraries/LibWeb/Geometry/DOMQuad.cpp
+++ b/Userland/Libraries/LibWeb/Geometry/DOMQuad.cpp
@@ -79,10 +79,10 @@ void DOMQuad::initialize(JS::Realm& realm)
 void DOMQuad::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(m_p1.ptr());
-    visitor.visit(m_p2.ptr());
-    visitor.visit(m_p3.ptr());
-    visitor.visit(m_p4.ptr());
+    visitor.visit(m_p1);
+    visitor.visit(m_p2);
+    visitor.visit(m_p3);
+    visitor.visit(m_p4);
 }
 
 }

--- a/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
+++ b/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
@@ -49,7 +49,7 @@ void CanvasRenderingContext2D::initialize(JS::Realm& realm)
 void CanvasRenderingContext2D::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(m_element.ptr());
+    visitor.visit(m_element);
 }
 
 HTMLCanvasElement& CanvasRenderingContext2D::canvas_element()

--- a/Userland/Libraries/LibWeb/HTML/DOMStringMap.cpp
+++ b/Userland/Libraries/LibWeb/HTML/DOMStringMap.cpp
@@ -35,7 +35,7 @@ void DOMStringMap::initialize(JS::Realm& realm)
 void DOMStringMap::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(m_associated_element.ptr());
+    visitor.visit(m_associated_element);
 }
 
 // https://html.spec.whatwg.org/multipage/dom.html#concept-domstringmap-pairs

--- a/Userland/Libraries/LibWeb/HTML/HTMLCanvasElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLCanvasElement.cpp
@@ -46,10 +46,10 @@ void HTMLCanvasElement::visit_edges(Cell::Visitor& visitor)
     Base::visit_edges(visitor);
     m_context.visit(
         [&](JS::NonnullGCPtr<CanvasRenderingContext2D>& context) {
-            visitor.visit(context.ptr());
+            visitor.visit(context);
         },
         [&](JS::NonnullGCPtr<WebGL::WebGLRenderingContext>& context) {
-            visitor.visit(context.ptr());
+            visitor.visit(context);
         },
         [](Empty) {
         });

--- a/Userland/Libraries/LibWeb/HTML/HTMLElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLElement.cpp
@@ -54,7 +54,7 @@ void HTMLElement::initialize(JS::Realm& realm)
 void HTMLElement::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(m_dataset.ptr());
+    visitor.visit(m_dataset);
 }
 
 // https://html.spec.whatwg.org/multipage/dom.html#dom-dir

--- a/Userland/Libraries/LibWeb/HTML/HTMLFormElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFormElement.cpp
@@ -49,7 +49,7 @@ void HTMLFormElement::visit_edges(Cell::Visitor& visitor)
     Base::visit_edges(visitor);
     visitor.visit(m_elements);
     for (auto& element : m_associated_elements)
-        visitor.visit(element.ptr());
+        visitor.visit(element);
 }
 
 // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#concept-form-submit

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -62,7 +62,7 @@ void HTMLInputElement::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_placeholder_element);
     visitor.visit(m_placeholder_text_node);
     visitor.visit(m_color_well_element);
-    visitor.visit(m_legacy_pre_activation_behavior_checked_element_in_group.ptr());
+    visitor.visit(m_legacy_pre_activation_behavior_checked_element_in_group);
     visitor.visit(m_selected_files);
 }
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
@@ -40,9 +40,9 @@ void HTMLScriptElement::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
     if (auto* script = m_result.get_pointer<JS::NonnullGCPtr<Script>>())
-        visitor.visit(script->ptr());
-    visitor.visit(m_parser_document.ptr());
-    visitor.visit(m_preparation_time_document.ptr());
+        visitor.visit(*script);
+    visitor.visit(m_parser_document);
+    visitor.visit(m_preparation_time_document);
 }
 
 void HTMLScriptElement::attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value)

--- a/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
@@ -29,7 +29,7 @@ void HTMLSelectElement::initialize(JS::Realm& realm)
 void HTMLSelectElement::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(m_options.ptr());
+    visitor.visit(m_options);
 }
 
 // https://html.spec.whatwg.org/multipage/form-elements.html#dom-select-options

--- a/Userland/Libraries/LibWeb/HTML/HTMLTemplateElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTemplateElement.cpp
@@ -29,7 +29,7 @@ void HTMLTemplateElement::initialize(JS::Realm& realm)
 void HTMLTemplateElement::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(m_content.ptr());
+    visitor.visit(m_content);
 }
 
 // https://html.spec.whatwg.org/multipage/scripting.html#the-template-element:concept-node-adopt-ext

--- a/Userland/Libraries/LibWeb/HTML/History.cpp
+++ b/Userland/Libraries/LibWeb/HTML/History.cpp
@@ -35,7 +35,7 @@ void History::initialize(JS::Realm& realm)
 void History::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(m_associated_document.ptr());
+    visitor.visit(m_associated_document);
 }
 
 // https://html.spec.whatwg.org/multipage/history.html#dom-history-pushstate

--- a/Userland/Libraries/LibWeb/HTML/ImageData.cpp
+++ b/Userland/Libraries/LibWeb/HTML/ImageData.cpp
@@ -49,7 +49,7 @@ void ImageData::initialize(JS::Realm& realm)
 void ImageData::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(m_data.ptr());
+    visitor.visit(m_data);
 }
 
 unsigned ImageData::width() const

--- a/Userland/Libraries/LibWeb/HTML/MessageChannel.cpp
+++ b/Userland/Libraries/LibWeb/HTML/MessageChannel.cpp
@@ -34,8 +34,8 @@ MessageChannel::~MessageChannel() = default;
 void MessageChannel::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(m_port1.ptr());
-    visitor.visit(m_port2.ptr());
+    visitor.visit(m_port1);
+    visitor.visit(m_port2);
 }
 
 void MessageChannel::initialize(JS::Realm& realm)

--- a/Userland/Libraries/LibWeb/HTML/MessagePort.cpp
+++ b/Userland/Libraries/LibWeb/HTML/MessagePort.cpp
@@ -35,7 +35,7 @@ void MessagePort::initialize(JS::Realm& realm)
 void MessagePort::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(m_remote_port.ptr());
+    visitor.visit(m_remote_port);
 }
 
 void MessagePort::disentangle()

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Script.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Script.cpp
@@ -20,7 +20,7 @@ Script::~Script() = default;
 
 void Script::visit_host_defined_self(JS::Cell::Visitor& visitor)
 {
-    visitor.visit(this);
+    visitor.visit(*this);
 }
 
 void Script::visit_edges(Visitor& visitor)

--- a/Userland/Libraries/LibWeb/HTML/Scripting/WindowEnvironmentSettingsObject.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/WindowEnvironmentSettingsObject.cpp
@@ -23,7 +23,7 @@ WindowEnvironmentSettingsObject::~WindowEnvironmentSettingsObject() = default;
 void WindowEnvironmentSettingsObject::visit_edges(JS::Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(m_window.ptr());
+    visitor.visit(m_window);
 }
 
 // https://html.spec.whatwg.org/multipage/window-object.html#set-up-a-window-environment-settings-object

--- a/Userland/Libraries/LibWeb/HTML/SubmitEvent.cpp
+++ b/Userland/Libraries/LibWeb/HTML/SubmitEvent.cpp
@@ -36,7 +36,7 @@ void SubmitEvent::initialize(JS::Realm& realm)
 void SubmitEvent::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(m_submitter.ptr());
+    visitor.visit(m_submitter);
 }
 
 }

--- a/Userland/Libraries/LibWeb/HTML/Timer.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Timer.cpp
@@ -30,7 +30,7 @@ Timer::Timer(JS::Object& window_or_worker_global_scope, i32 milliseconds, JS::No
 void Timer::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(m_window_or_worker_global_scope.ptr());
+    visitor.visit(m_window_or_worker_global_scope);
     visitor.visit(m_callback);
 }
 

--- a/Userland/Libraries/LibWeb/HTML/Window.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Window.cpp
@@ -109,10 +109,10 @@ void Window::visit_edges(JS::Cell::Visitor& visitor)
     Base::visit_edges(visitor);
     WindowOrWorkerGlobalScopeMixin::visit_edges(visitor);
 
-    visitor.visit(m_associated_document.ptr());
-    visitor.visit(m_current_event.ptr());
-    visitor.visit(m_performance.ptr());
-    visitor.visit(m_screen.ptr());
+    visitor.visit(m_associated_document);
+    visitor.visit(m_current_event);
+    visitor.visit(m_performance);
+    visitor.visit(m_screen);
     visitor.visit(m_location);
     visitor.visit(m_crypto);
     visitor.visit(m_navigator);

--- a/Userland/Libraries/LibWeb/HTML/WindowProxy.cpp
+++ b/Userland/Libraries/LibWeb/HTML/WindowProxy.cpp
@@ -258,7 +258,7 @@ JS::ThrowCompletionOr<JS::MarkedVector<JS::Value>> WindowProxy::internal_own_pro
 void WindowProxy::visit_edges(JS::Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(m_window.ptr());
+    visitor.visit(m_window);
 }
 
 void WindowProxy::set_window(JS::NonnullGCPtr<Window> window)

--- a/Userland/Libraries/LibWeb/HTML/WorkerGlobalScope.cpp
+++ b/Userland/Libraries/LibWeb/HTML/WorkerGlobalScope.cpp
@@ -46,8 +46,8 @@ void WorkerGlobalScope::visit_edges(Cell::Visitor& visitor)
     Base::visit_edges(visitor);
     WindowOrWorkerGlobalScopeMixin::visit_edges(visitor);
 
-    visitor.visit(m_location.ptr());
-    visitor.visit(m_navigator.ptr());
+    visitor.visit(m_location);
+    visitor.visit(m_navigator);
 }
 
 // https://html.spec.whatwg.org/multipage/workers.html#importing-scripts-and-libraries

--- a/Userland/Libraries/LibWeb/HighResolutionTime/Performance.cpp
+++ b/Userland/Libraries/LibWeb/HighResolutionTime/Performance.cpp
@@ -36,8 +36,8 @@ void Performance::initialize(JS::Realm& realm)
 void Performance::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(m_window.ptr());
-    visitor.visit(m_timing.ptr());
+    visitor.visit(m_window);
+    visitor.visit(m_timing);
 }
 
 JS::GCPtr<NavigationTiming::PerformanceTiming> Performance::timing()

--- a/Userland/Libraries/LibWeb/NavigationTiming/PerformanceTiming.cpp
+++ b/Userland/Libraries/LibWeb/NavigationTiming/PerformanceTiming.cpp
@@ -25,7 +25,7 @@ void PerformanceTiming::initialize(JS::Realm& realm)
 void PerformanceTiming::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(m_window.ptr());
+    visitor.visit(m_window);
 }
 
 }

--- a/Userland/Libraries/LibWeb/PerformanceTimeline/PerformanceObserver.cpp
+++ b/Userland/Libraries/LibWeb/PerformanceTimeline/PerformanceObserver.cpp
@@ -38,7 +38,7 @@ void PerformanceObserver::initialize(JS::Realm& realm)
 void PerformanceObserver::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(m_callback.ptr());
+    visitor.visit(m_callback);
     for (auto& entry : m_observer_buffer)
         visitor.visit(entry);
 }

--- a/Userland/Libraries/LibWeb/SVG/SVGAnimatedLength.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGAnimatedLength.cpp
@@ -34,8 +34,8 @@ void SVGAnimatedLength::initialize(JS::Realm& realm)
 void SVGAnimatedLength::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(m_base_val.ptr());
-    visitor.visit(m_anim_val.ptr());
+    visitor.visit(m_base_val);
+    visitor.visit(m_anim_val);
 }
 
 }

--- a/Userland/Libraries/LibWeb/UIEvents/UIEvent.cpp
+++ b/Userland/Libraries/LibWeb/UIEvents/UIEvent.cpp
@@ -42,7 +42,7 @@ void UIEvent::initialize(JS::Realm& realm)
 void UIEvent::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(m_view.ptr());
+    visitor.visit(m_view);
 }
 
 }

--- a/Userland/Libraries/LibWeb/URL/URL.cpp
+++ b/Userland/Libraries/LibWeb/URL/URL.cpp
@@ -91,7 +91,7 @@ void URL::initialize(JS::Realm& realm)
 void URL::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(m_query.ptr());
+    visitor.visit(m_query);
 }
 
 // https://w3c.github.io/FileAPI/#dfn-createObjectURL

--- a/Userland/Libraries/LibWeb/WebGL/WebGLRenderingContextBase.cpp
+++ b/Userland/Libraries/LibWeb/WebGL/WebGLRenderingContextBase.cpp
@@ -26,7 +26,7 @@ WebGLRenderingContextBase::~WebGLRenderingContextBase() = default;
 void WebGLRenderingContextBase::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(m_canvas_element.ptr());
+    visitor.visit(m_canvas_element);
 }
 
 #define RETURN_WITH_WEBGL_ERROR_IF(condition, error)                         \


### PR DESCRIPTION
This is mostly motivated for aesthetics, but also helps avoid some null
checks when we have a NonnullGCPtr<T> or in some cases a T&.