### PR TITLE
LibWeb: Port Element::attribute_changed from DeprecatedString to String

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Attr.h
+++ b/Userland/Libraries/LibWeb/DOM/Attr.h
@@ -41,7 +41,7 @@ public:
     // Always returns true: https://dom.spec.whatwg.org/#dom-attr-specified
     constexpr bool specified() const { return true; }
 
-    void handle_attribute_changes(Element&, Optional<DeprecatedString> old_value, Optional<DeprecatedString> new_value);
+    void handle_attribute_changes(Element&, Optional<String> const& old_value, Optional<String> const& new_value);
 
 private:
     Attr(Document&, QualifiedName, String value, Element*);

--- a/Userland/Libraries/LibWeb/DOM/CharacterData.cpp
+++ b/Userland/Libraries/LibWeb/DOM/CharacterData.cpp
@@ -74,7 +74,7 @@ WebIDL::ExceptionOr<void> CharacterData::replace_data(size_t offset, size_t coun
         count = length - offset;
 
     // 4. Queue a mutation record of "characterData" for node with null, null, node’s data, « », « », null, and null.
-    queue_mutation_record(MutationType::characterData, {}, {}, m_data.to_deprecated_string(), {}, {}, nullptr, nullptr);
+    queue_mutation_record(MutationType::characterData, {}, {}, m_data, {}, {}, nullptr, nullptr);
 
     // 5. Insert data into node’s data after offset code units.
     // 6. Let delete offset be offset + data’s length.

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -81,11 +81,11 @@ Element::Element(Document& document, DOM::QualifiedName qualified_name)
                 return;
 
             // 2. If value is null and oldValue is the empty string, then return.
-            if (!value.has_value() && old_value == DeprecatedString::empty())
+            if (!value.has_value() && old_value == String {})
                 return;
 
             // 3. If value is the empty string and oldValue is null, then return.
-            if (value == DeprecatedString::empty() && !old_value.has_value())
+            if (value == String {} && !old_value.has_value())
                 return;
 
             // 4. If value is null or the empty string, then set element’s name to the empty string.
@@ -93,7 +93,7 @@ Element::Element(Document& document, DOM::QualifiedName qualified_name)
                 set_slottable_name({});
             // 5. Otherwise, set element’s name to value.
             else
-                set_slottable_name(MUST(String::from_deprecated_string(*value)));
+                set_slottable_name(*value);
 
             // 6. If element is assigned, then run assign slottables for element’s assigned slot.
             if (auto assigned_slot = assigned_slot_internal())
@@ -466,7 +466,7 @@ void Element::add_attribute_change_steps(AttributeChangeSteps steps)
     m_attribute_change_steps.append(move(steps));
 }
 
-void Element::run_attribute_change_steps(FlyString const& local_name, Optional<DeprecatedString> const& old_value, Optional<DeprecatedString> const& value, Optional<FlyString> const& namespace_)
+void Element::run_attribute_change_steps(FlyString const& local_name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_)
 {
     for (auto const& attribute_change_steps : m_attribute_change_steps)
         attribute_change_steps(local_name, old_value, value, namespace_);
@@ -476,17 +476,17 @@ void Element::run_attribute_change_steps(FlyString const& local_name, Optional<D
     invalidate_style_after_attribute_change(local_name);
 }
 
-void Element::attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value)
+void Element::attribute_changed(FlyString const& name, Optional<String> const& value)
 {
-    auto value_or_empty = value.value_or("");
+    auto value_or_empty = value.value_or(String {});
 
     if (name == HTML::AttributeNames::id) {
         if (!value.has_value())
             m_id = {};
         else
-            m_id = MUST(FlyString::from_deprecated_fly_string(value_or_empty));
+            m_id = value_or_empty;
     } else if (name == HTML::AttributeNames::class_) {
-        auto new_classes = value_or_empty.split_view(Infra::is_ascii_whitespace);
+        auto new_classes = value_or_empty.bytes_as_string_view().split_view_if(Infra::is_ascii_whitespace);
         m_classes.clear();
         m_classes.ensure_capacity(new_classes.size());
         for (auto& new_class : new_classes) {

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -147,11 +147,11 @@ public:
     virtual void apply_presentational_hints(CSS::StyleProperties&) const { }
 
     // https://dom.spec.whatwg.org/#concept-element-attributes-change-ext
-    using AttributeChangeSteps = Function<void(FlyString const& local_name, Optional<DeprecatedString> const& old_value, Optional<DeprecatedString> const& value, Optional<FlyString> const& namespace_)>;
+    using AttributeChangeSteps = Function<void(FlyString const& local_name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_)>;
 
     void add_attribute_change_steps(AttributeChangeSteps steps);
-    void run_attribute_change_steps(FlyString const& local_name, Optional<DeprecatedString> const& old_value, Optional<DeprecatedString> const& value, Optional<FlyString> const& namespace_);
-    virtual void attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value);
+    void run_attribute_change_steps(FlyString const& local_name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_);
+    virtual void attribute_changed(FlyString const& name, Optional<String> const& value);
 
     struct [[nodiscard]] RequiredInvalidationAfterStyleChange {
         bool repaint { false };

--- a/Userland/Libraries/LibWeb/DOM/NamedNodeMap.cpp
+++ b/Userland/Libraries/LibWeb/DOM/NamedNodeMap.cpp
@@ -269,7 +269,7 @@ void NamedNodeMap::replace_attribute(Attr& old_attribute, Attr& new_attribute, s
     old_attribute.set_owner_element(nullptr);
 
     // 4. Handle attribute changes for oldAttr with newAttr’s element, oldAttr’s value, and newAttr’s value.
-    old_attribute.handle_attribute_changes(*new_attribute.owner_element(), old_attribute.value().to_deprecated_string(), new_attribute.value().to_deprecated_string());
+    old_attribute.handle_attribute_changes(*new_attribute.owner_element(), old_attribute.value(), new_attribute.value());
 }
 
 // https://dom.spec.whatwg.org/#concept-element-attributes-append
@@ -282,7 +282,7 @@ void NamedNodeMap::append_attribute(Attr& attribute)
     attribute.set_owner_element(&associated_element());
 
     // 3. Handle attribute changes for attribute with element, null, and attribute’s value.
-    attribute.handle_attribute_changes(associated_element(), {}, attribute.value().to_deprecated_string());
+    attribute.handle_attribute_changes(associated_element(), {}, attribute.value());
 }
 
 // https://dom.spec.whatwg.org/#concept-element-attributes-remove
@@ -301,7 +301,7 @@ void NamedNodeMap::remove_attribute_at_index(size_t attribute_index)
     attribute->set_owner_element(nullptr);
 
     // 4. Handle attribute changes for attribute with element, attribute’s value, and null.
-    attribute->handle_attribute_changes(*element, attribute->value().to_deprecated_string(), {});
+    attribute->handle_attribute_changes(*element, attribute->value(), {});
 }
 
 // https://dom.spec.whatwg.org/#concept-element-attributes-remove-by-name

--- a/Userland/Libraries/LibWeb/DOM/Node.h
+++ b/Userland/Libraries/LibWeb/DOM/Node.h
@@ -259,7 +259,7 @@ public:
 
     void add_registered_observer(RegisteredObserver& registered_observer) { m_registered_observer_list.append(registered_observer); }
 
-    void queue_mutation_record(FlyString const& type, Optional<DeprecatedString> attribute_name, Optional<DeprecatedString> attribute_namespace, Optional<DeprecatedString> old_value, Vector<JS::Handle<Node>> added_nodes, Vector<JS::Handle<Node>> removed_nodes, Node* previous_sibling, Node* next_sibling) const;
+    void queue_mutation_record(FlyString const& type, Optional<FlyString> const& attribute_name, Optional<FlyString> const& attribute_namespace, Optional<String> const& old_value, Vector<JS::Handle<Node>> added_nodes, Vector<JS::Handle<Node>> removed_nodes, Node* previous_sibling, Node* next_sibling) const;
 
     // https://dom.spec.whatwg.org/#concept-shadow-including-inclusive-descendant
     template<typename Callback>

--- a/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.cpp
@@ -27,7 +27,7 @@ void HTMLAnchorElement::initialize(JS::Realm& realm)
     set_prototype(&Bindings::ensure_web_prototype<Bindings::HTMLAnchorElementPrototype>(realm, "HTMLAnchorElement"));
 }
 
-void HTMLAnchorElement::attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value)
+void HTMLAnchorElement::attribute_changed(FlyString const& name, Optional<String> const& value)
 {
     HTMLElement::attribute_changed(name, value);
     if (name == HTML::AttributeNames::href) {

--- a/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.h
@@ -43,7 +43,7 @@ private:
     void run_activation_behavior(Web::DOM::Event const&);
 
     // ^DOM::Element
-    virtual void attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<String> const& value) override;
     virtual i32 default_tab_index_value() const override;
 
     // ^HTML::HTMLHyperlinkElementUtils

--- a/Userland/Libraries/LibWeb/HTML/HTMLAreaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLAreaElement.cpp
@@ -23,7 +23,7 @@ void HTMLAreaElement::initialize(JS::Realm& realm)
     set_prototype(&Bindings::ensure_web_prototype<Bindings::HTMLAreaElementPrototype>(realm, "HTMLAreaElement"));
 }
 
-void HTMLAreaElement::attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value)
+void HTMLAreaElement::attribute_changed(FlyString const& name, Optional<String> const& value)
 {
     HTMLElement::attribute_changed(name, value);
     if (name == HTML::AttributeNames::href) {

--- a/Userland/Libraries/LibWeb/HTML/HTMLAreaElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLAreaElement.h
@@ -26,7 +26,7 @@ private:
     virtual void initialize(JS::Realm&) override;
 
     // ^DOM::Element
-    virtual void attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<String> const& value) override;
     virtual i32 default_tab_index_value() const override;
 
     // ^HTML::HTMLHyperlinkElementUtils

--- a/Userland/Libraries/LibWeb/HTML/HTMLBaseElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLBaseElement.cpp
@@ -43,7 +43,7 @@ void HTMLBaseElement::removed_from(Node* parent)
     document().update_base_element({});
 }
 
-void HTMLBaseElement::attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value)
+void HTMLBaseElement::attribute_changed(FlyString const& name, Optional<String> const& value)
 {
     HTMLElement::attribute_changed(name, value);
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLBaseElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLBaseElement.h
@@ -23,7 +23,7 @@ public:
 
     virtual void inserted() override;
     virtual void removed_from(Node*) override;
-    virtual void attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<String> const& value) override;
 
 private:
     HTMLBaseElement(DOM::Document&, DOM::QualifiedName);

--- a/Userland/Libraries/LibWeb/HTML/HTMLBodyElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLBodyElement.cpp
@@ -55,26 +55,26 @@ void HTMLBodyElement::apply_presentational_hints(CSS::StyleProperties& style) co
     });
 }
 
-void HTMLBodyElement::attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value)
+void HTMLBodyElement::attribute_changed(FlyString const& name, Optional<String> const& value)
 {
     HTMLElement::attribute_changed(name, value);
     if (name.equals_ignoring_ascii_case("link"sv)) {
         // https://html.spec.whatwg.org/multipage/rendering.html#the-page:rules-for-parsing-a-legacy-colour-value-3
-        auto color = parse_legacy_color_value(value.value_or(""));
+        auto color = parse_legacy_color_value(value.value_or(String {}).to_deprecated_string());
         if (color.has_value())
             document().set_link_color(color.value());
     } else if (name.equals_ignoring_ascii_case("alink"sv)) {
         // https://html.spec.whatwg.org/multipage/rendering.html#the-page:rules-for-parsing-a-legacy-colour-value-5
-        auto color = parse_legacy_color_value(value.value_or(""));
+        auto color = parse_legacy_color_value(value.value_or(String {}).to_deprecated_string());
         if (color.has_value())
             document().set_active_link_color(color.value());
     } else if (name.equals_ignoring_ascii_case("vlink"sv)) {
         // https://html.spec.whatwg.org/multipage/rendering.html#the-page:rules-for-parsing-a-legacy-colour-value-4
-        auto color = parse_legacy_color_value(value.value_or(""));
+        auto color = parse_legacy_color_value(value.value_or(String {}).to_deprecated_string());
         if (color.has_value())
             document().set_visited_link_color(color.value());
     } else if (name.equals_ignoring_ascii_case("background"sv)) {
-        m_background_style_value = CSS::ImageStyleValue::create(document().parse_url(value.value_or("")));
+        m_background_style_value = CSS::ImageStyleValue::create(document().parse_url(value.value_or(String {})));
         m_background_style_value->on_animate = [this] {
             if (layout_node()) {
                 layout_node()->set_needs_display();
@@ -83,9 +83,9 @@ void HTMLBodyElement::attribute_changed(FlyString const& name, Optional<Deprecat
     }
 
 #undef __ENUMERATE
-#define __ENUMERATE(attribute_name, event_name)                                                                                          \
-    if (name == HTML::AttributeNames::attribute_name) {                                                                                  \
-        element_event_handler_attribute_changed(event_name, value.map([](auto& v) { return MUST(String::from_deprecated_string(v)); })); \
+#define __ENUMERATE(attribute_name, event_name)                     \
+    if (name == HTML::AttributeNames::attribute_name) {             \
+        element_event_handler_attribute_changed(event_name, value); \
     }
     ENUMERATE_WINDOW_EVENT_HANDLERS(__ENUMERATE)
 #undef __ENUMERATE

--- a/Userland/Libraries/LibWeb/HTML/HTMLBodyElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLBodyElement.h
@@ -20,7 +20,7 @@ class HTMLBodyElement final
 public:
     virtual ~HTMLBodyElement() override;
 
-    virtual void attribute_changed(FlyString const&, Optional<DeprecatedString> const&) override;
+    virtual void attribute_changed(FlyString const&, Optional<String> const&) override;
     virtual void apply_presentational_hints(CSS::StyleProperties&) const override;
 
     // https://www.w3.org/TR/html-aria/#el-body

--- a/Userland/Libraries/LibWeb/HTML/HTMLDetailsElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLDetailsElement.cpp
@@ -41,7 +41,7 @@ void HTMLDetailsElement::initialize(JS::Realm& realm)
     create_shadow_tree(realm).release_value_but_fixme_should_propagate_errors();
 }
 
-void HTMLDetailsElement::attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value)
+void HTMLDetailsElement::attribute_changed(FlyString const& name, Optional<String> const& value)
 {
     Base::attribute_changed(name, value);
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLDetailsElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLDetailsElement.h
@@ -31,7 +31,7 @@ private:
     virtual void visit_edges(Cell::Visitor&) override;
 
     virtual void children_changed() override;
-    virtual void attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<String> const& value) override;
 
     void queue_a_details_toggle_event_task(String old_state, String new_state);
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLElement.cpp
@@ -224,7 +224,7 @@ bool HTMLElement::cannot_navigate() const
     return !is<HTML::HTMLAnchorElement>(this) && !is_connected();
 }
 
-void HTMLElement::attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value)
+void HTMLElement::attribute_changed(FlyString const& name, Optional<String> const& value)
 {
     Element::attribute_changed(name, value);
 
@@ -248,9 +248,9 @@ void HTMLElement::attribute_changed(FlyString const& name, Optional<DeprecatedSt
     // 1. If namespace is not null, or localName is not the name of an event handler content attribute on element, then return.
     // FIXME: Add the namespace part once we support attribute namespaces.
 #undef __ENUMERATE
-#define __ENUMERATE(attribute_name, event_name)                                                                                          \
-    if (name == HTML::AttributeNames::attribute_name) {                                                                                  \
-        element_event_handler_attribute_changed(event_name, value.map([](auto& v) { return MUST(String::from_deprecated_string(v)); })); \
+#define __ENUMERATE(attribute_name, event_name)                     \
+    if (name == HTML::AttributeNames::attribute_name) {             \
+        element_event_handler_attribute_changed(event_name, value); \
     }
     ENUMERATE_GLOBAL_EVENT_HANDLERS(__ENUMERATE)
 #undef __ENUMERATE

--- a/Userland/Libraries/LibWeb/HTML/HTMLElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLElement.h
@@ -70,7 +70,7 @@ protected:
 
     virtual void initialize(JS::Realm&) override;
 
-    virtual void attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<String> const& value) override;
 
     virtual void visit_edges(Cell::Visitor&) override;
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLFrameSetElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFrameSetElement.cpp
@@ -23,14 +23,14 @@ void HTMLFrameSetElement::initialize(JS::Realm& realm)
     set_prototype(&Bindings::ensure_web_prototype<Bindings::HTMLFrameSetElementPrototype>(realm, "HTMLFrameSetElement"));
 }
 
-void HTMLFrameSetElement::attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value)
+void HTMLFrameSetElement::attribute_changed(FlyString const& name, Optional<String> const& value)
 {
     HTMLElement::attribute_changed(name, value);
 
 #undef __ENUMERATE
-#define __ENUMERATE(attribute_name, event_name)                                                                                          \
-    if (name == HTML::AttributeNames::attribute_name) {                                                                                  \
-        element_event_handler_attribute_changed(event_name, value.map([](auto& v) { return MUST(String::from_deprecated_string(v)); })); \
+#define __ENUMERATE(attribute_name, event_name)                     \
+    if (name == HTML::AttributeNames::attribute_name) {             \
+        element_event_handler_attribute_changed(event_name, value); \
     }
     ENUMERATE_WINDOW_EVENT_HANDLERS(__ENUMERATE)
 #undef __ENUMERATE

--- a/Userland/Libraries/LibWeb/HTML/HTMLFrameSetElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFrameSetElement.h
@@ -24,7 +24,7 @@ private:
     HTMLFrameSetElement(DOM::Document&, DOM::QualifiedName);
 
     virtual void initialize(JS::Realm&) override;
-    virtual void attribute_changed(FlyString const&, Optional<DeprecatedString> const&) override;
+    virtual void attribute_changed(FlyString const&, Optional<String> const&) override;
 
     // ^HTML::GlobalEventHandlers
     virtual EventTarget& global_event_handlers_to_event_target(FlyString const& event_name) override;

--- a/Userland/Libraries/LibWeb/HTML/HTMLIFrameElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLIFrameElement.cpp
@@ -33,7 +33,7 @@ JS::GCPtr<Layout::Node> HTMLIFrameElement::create_layout_node(NonnullRefPtr<CSS:
     return heap().allocate_without_realm<Layout::FrameBox>(document(), *this, move(style));
 }
 
-void HTMLIFrameElement::attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value)
+void HTMLIFrameElement::attribute_changed(FlyString const& name, Optional<String> const& value)
 {
     HTMLElement::attribute_changed(name, value);
     if (m_content_navigable)

--- a/Userland/Libraries/LibWeb/HTML/HTMLIFrameElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLIFrameElement.h
@@ -36,7 +36,7 @@ private:
     // ^DOM::Element
     virtual void inserted() override;
     virtual void removed_from(Node*) override;
-    virtual void attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<String> const& value) override;
     virtual i32 default_tab_index_value() const override;
 
     // https://html.spec.whatwg.org/multipage/iframe-embed-object.html#process-the-iframe-attributes

--- a/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -95,16 +95,12 @@ void HTMLImageElement::apply_presentational_hints(CSS::StyleProperties& style) c
     });
 }
 
-void HTMLImageElement::attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value)
+void HTMLImageElement::attribute_changed(FlyString const& name, Optional<String> const& value)
 {
     HTMLElement::attribute_changed(name, value);
 
     if (name == HTML::AttributeNames::crossorigin) {
-        if (!value.has_value()) {
-            m_cors_setting = CORSSettingAttribute::NoCORS;
-        } else {
-            m_cors_setting = cors_setting_attribute_from_keyword(String::from_deprecated_string(*value).release_value_but_fixme_should_propagate_errors());
-        }
+        m_cors_setting = cors_setting_attribute_from_keyword(value);
     }
 
     if (name.is_one_of(HTML::AttributeNames::src, HTML::AttributeNames::srcset)) {

--- a/Userland/Libraries/LibWeb/HTML/HTMLImageElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLImageElement.h
@@ -32,7 +32,7 @@ class HTMLImageElement final
 public:
     virtual ~HTMLImageElement() override;
 
-    virtual void attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<String> const& value) override;
 
     DeprecatedString alt() const { return deprecated_attribute(HTML::AttributeNames::alt); }
     DeprecatedString src() const { return deprecated_attribute(HTML::AttributeNames::src); }

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -627,7 +627,7 @@ void HTMLInputElement::did_lose_focus()
     });
 }
 
-void HTMLInputElement::attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value)
+void HTMLInputElement::attribute_changed(FlyString const& name, Optional<String> const& value)
 {
     HTMLElement::attribute_changed(name, value);
     if (name == HTML::AttributeNames::checked) {
@@ -643,7 +643,7 @@ void HTMLInputElement::attribute_changed(FlyString const& name, Optional<Depreca
                 set_checked(true, ChangeSource::Programmatic);
         }
     } else if (name == HTML::AttributeNames::type) {
-        m_type = parse_type_attribute(value.value_or(""));
+        m_type = parse_type_attribute(value.value_or(String {}));
     } else if (name == HTML::AttributeNames::value) {
         if (!value.has_value()) {
             if (!m_dirty_value) {
@@ -655,7 +655,7 @@ void HTMLInputElement::attribute_changed(FlyString const& name, Optional<Depreca
             }
         } else {
             if (!m_dirty_value) {
-                m_value = value_sanitization_algorithm(*value);
+                m_value = value_sanitization_algorithm(value->to_deprecated_string());
                 update_placeholder_visibility();
 
                 if (type_state() == TypeAttributeState::Color && m_color_well_element)
@@ -664,12 +664,9 @@ void HTMLInputElement::attribute_changed(FlyString const& name, Optional<Depreca
         }
     } else if (name == HTML::AttributeNames::placeholder) {
         if (m_placeholder_text_node)
-            m_placeholder_text_node->set_data(MUST(String::from_deprecated_string(value.value_or(""))));
+            m_placeholder_text_node->set_data(value.value_or(String {}));
     } else if (name == HTML::AttributeNames::readonly) {
-        if (value.has_value())
-            handle_readonly_attribute(MUST(String::from_deprecated_string(*value)));
-        else
-            handle_readonly_attribute({});
+        handle_readonly_attribute(value);
     }
 }
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -114,7 +114,7 @@ public:
     virtual bool is_focusable() const override { return m_type != TypeAttributeState::Hidden; }
 
     // ^HTMLElement
-    virtual void attribute_changed(FlyString const&, Optional<DeprecatedString> const&) override;
+    virtual void attribute_changed(FlyString const&, Optional<String> const&) override;
 
     // ^FormAssociatedElement
     // https://html.spec.whatwg.org/multipage/forms.html#category-listed

--- a/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
@@ -23,6 +23,7 @@
 #include <LibWeb/HTML/PotentialCORSRequest.h>
 #include <LibWeb/HTML/TraversableNavigable.h>
 #include <LibWeb/Infra/CharacterTypes.h>
+#include <LibWeb/Infra/Strings.h>
 #include <LibWeb/Loader/ResourceLoader.h>
 #include <LibWeb/Page/Page.h>
 #include <LibWeb/Platform/ImageCodecPlugin.h>
@@ -77,7 +78,7 @@ bool HTMLLinkElement::has_loaded_icon() const
     return m_relationship & Relationship::Icon && resource() && resource()->is_loaded() && resource()->has_encoded_data();
 }
 
-void HTMLLinkElement::attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value)
+void HTMLLinkElement::attribute_changed(FlyString const& name, Optional<String> const& value)
 {
     HTMLElement::attribute_changed(name, value);
 
@@ -85,11 +86,11 @@ void HTMLLinkElement::attribute_changed(FlyString const& name, Optional<Deprecat
     if (name == HTML::AttributeNames::rel) {
         m_relationship = 0;
         // Keywords are always ASCII case-insensitive, and must be compared as such.
-        auto lowercased_value = value.value_or("").to_lowercase();
+        auto lowercased_value = MUST(Infra::to_ascii_lowercase(value.value_or(String {})));
         // To determine which link types apply to a link, a, area, or form element,
         // the element's rel attribute must be split on ASCII whitespace.
         // The resulting tokens are the keywords for the link types that apply to that element.
-        auto parts = lowercased_value.split_view(Infra::is_ascii_whitespace);
+        auto parts = lowercased_value.bytes_as_string_view().split_view_if(Infra::is_ascii_whitespace);
         for (auto& part : parts) {
             if (part == "stylesheet"sv)
                 m_relationship |= Relationship::Stylesheet;

--- a/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.h
@@ -41,7 +41,7 @@ private:
     HTMLLinkElement(DOM::Document&, DOM::QualifiedName);
 
     virtual void initialize(JS::Realm&) override;
-    void attribute_changed(FlyString const&, Optional<DeprecatedString> const&) override;
+    void attribute_changed(FlyString const&, Optional<String> const&) override;
 
     // ^ResourceClient
     virtual void resource_did_fail() override;

--- a/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -83,17 +83,14 @@ void HTMLMediaElement::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_fetch_controller);
 }
 
-void HTMLMediaElement::attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value)
+void HTMLMediaElement::attribute_changed(FlyString const& name, Optional<String> const& value)
 {
     Base::attribute_changed(name, value);
 
     if (name == HTML::AttributeNames::src) {
         load_element().release_value_but_fixme_should_propagate_errors();
     } else if (name == HTML::AttributeNames::crossorigin) {
-        if (!value.has_value())
-            m_crossorigin = cors_setting_attribute_from_keyword({});
-        else
-            m_crossorigin = cors_setting_attribute_from_keyword(String::from_deprecated_string(*value).release_value_but_fixme_should_propagate_errors());
+        m_crossorigin = cors_setting_attribute_from_keyword(value);
     } else if (name == HTML::AttributeNames::muted) {
         set_muted(true);
     }

--- a/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.h
@@ -134,7 +134,7 @@ protected:
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
 
-    virtual void attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<String> const& value) override;
     virtual void removed_from(DOM::Node*) override;
     virtual void children_changed() override;
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLObjectElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLObjectElement.cpp
@@ -45,7 +45,7 @@ void HTMLObjectElement::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_image_request);
 }
 
-void HTMLObjectElement::attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value)
+void HTMLObjectElement::attribute_changed(FlyString const& name, Optional<String> const& value)
 {
     NavigableContainer::attribute_changed(name, value);
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLObjectElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLObjectElement.h
@@ -34,7 +34,7 @@ class HTMLObjectElement final
 public:
     virtual ~HTMLObjectElement() override;
 
-    virtual void attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<String> const& value) override;
 
     String data() const;
     void set_data(String const& data) { MUST(set_attribute(HTML::AttributeNames::data, data)); }

--- a/Userland/Libraries/LibWeb/HTML/HTMLOptionElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLOptionElement.cpp
@@ -31,7 +31,7 @@ void HTMLOptionElement::initialize(JS::Realm& realm)
     set_prototype(&Bindings::ensure_web_prototype<Bindings::HTMLOptionElementPrototype>(realm, "HTMLOptionElement"));
 }
 
-void HTMLOptionElement::attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value)
+void HTMLOptionElement::attribute_changed(FlyString const& name, Optional<String> const& value)
 {
     HTMLElement::attribute_changed(name, value);
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLOptionElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLOptionElement.h
@@ -40,7 +40,7 @@ private:
 
     virtual void initialize(JS::Realm&) override;
 
-    void attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value) override;
+    void attribute_changed(FlyString const& name, Optional<String> const& value) override;
 
     void ask_for_a_reset();
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
@@ -45,15 +45,12 @@ void HTMLScriptElement::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_preparation_time_document.ptr());
 }
 
-void HTMLScriptElement::attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value)
+void HTMLScriptElement::attribute_changed(FlyString const& name, Optional<String> const& value)
 {
     Base::attribute_changed(name, value);
 
     if (name == HTML::AttributeNames::crossorigin) {
-        if (!value.has_value())
-            m_crossorigin = cors_setting_attribute_from_keyword({});
-        else
-            m_crossorigin = cors_setting_attribute_from_keyword(String::from_deprecated_string(*value).release_value_but_fixme_should_propagate_errors());
+        m_crossorigin = cors_setting_attribute_from_keyword(value);
     } else if (name == HTML::AttributeNames::referrerpolicy) {
         if (!value.has_value())
             m_referrer_policy.clear();

--- a/Userland/Libraries/LibWeb/HTML/HTMLScriptElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLScriptElement.h
@@ -62,7 +62,7 @@ private:
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
 
-    virtual void attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<String> const& value) override;
 
     // https://html.spec.whatwg.org/multipage/scripting.html#prepare-the-script-element
     void prepare_script();

--- a/Userland/Libraries/LibWeb/HTML/HTMLSlotElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLSlotElement.cpp
@@ -24,11 +24,11 @@ HTMLSlotElement::HTMLSlotElement(DOM::Document& document, DOM::QualifiedName qua
                 return;
 
             // 2. If value is null and oldValue is the empty string, then return.
-            if (!value.has_value() && old_value == DeprecatedString::empty())
+            if (!value.has_value() && old_value == String {})
                 return;
 
             // 3. If value is the empty string and oldValue is null, then return.
-            if (value == DeprecatedString::empty() && !old_value.has_value())
+            if (value == String {} && !old_value.has_value())
                 return;
 
             // 4. If value is null or the empty string, then set element’s name to the empty string.
@@ -36,7 +36,7 @@ HTMLSlotElement::HTMLSlotElement(DOM::Document& document, DOM::QualifiedName qua
                 set_slot_name({});
             // 5. Otherwise, set element’s name to value.
             else
-                set_slot_name(MUST(String::from_deprecated_string(*value)));
+                set_slot_name(*value);
 
             // 6. Run assign slottables for a tree with element’s root.
             DOM::assign_slottables_for_a_tree(root());

--- a/Userland/Libraries/LibWeb/HTML/HTMLVideoElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLVideoElement.cpp
@@ -40,15 +40,12 @@ void HTMLVideoElement::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_fetch_controller);
 }
 
-void HTMLVideoElement::attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value)
+void HTMLVideoElement::attribute_changed(FlyString const& name, Optional<String> const& value)
 {
     Base::attribute_changed(name, value);
 
     if (name == HTML::AttributeNames::poster) {
-        if (!value.has_value())
-            determine_element_poster_frame({}).release_value_but_fixme_should_propagate_errors();
-        else
-            determine_element_poster_frame(*value).release_value_but_fixme_should_propagate_errors();
+        determine_element_poster_frame(value).release_value_but_fixme_should_propagate_errors();
     }
 }
 
@@ -126,7 +123,7 @@ void HTMLVideoElement::on_seek(double position, MediaSeekMode seek_mode)
 }
 
 // https://html.spec.whatwg.org/multipage/media.html#attr-video-poster
-WebIDL::ExceptionOr<void> HTMLVideoElement::determine_element_poster_frame(Optional<StringView> const& poster)
+WebIDL::ExceptionOr<void> HTMLVideoElement::determine_element_poster_frame(Optional<String> const& poster)
 {
     auto& realm = this->realm();
     auto& vm = realm.vm();

--- a/Userland/Libraries/LibWeb/HTML/HTMLVideoElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLVideoElement.h
@@ -47,7 +47,7 @@ private:
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
 
-    virtual void attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<String> const& value) override;
 
     virtual JS::GCPtr<Layout::Node> create_layout_node(NonnullRefPtr<CSS::StyleProperties>) override;
 
@@ -55,7 +55,7 @@ private:
     virtual void on_paused() override;
     virtual void on_seek(double, MediaSeekMode) override;
 
-    WebIDL::ExceptionOr<void> determine_element_poster_frame(Optional<StringView> const& poster);
+    WebIDL::ExceptionOr<void> determine_element_poster_frame(Optional<String> const& poster);
 
     JS::GCPtr<HTML::VideoTrack> m_video_track;
     VideoFrame m_current_frame;

--- a/Userland/Libraries/LibWeb/SVG/SVGCircleElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGCircleElement.cpp
@@ -22,18 +22,18 @@ void SVGCircleElement::initialize(JS::Realm& realm)
     set_prototype(&Bindings::ensure_web_prototype<Bindings::SVGCircleElementPrototype>(realm, "SVGCircleElement"));
 }
 
-void SVGCircleElement::attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value)
+void SVGCircleElement::attribute_changed(FlyString const& name, Optional<String> const& value)
 {
     SVGGeometryElement::attribute_changed(name, value);
 
     if (name == SVG::AttributeNames::cx) {
-        m_center_x = AttributeParser::parse_coordinate(value.value_or(""));
+        m_center_x = AttributeParser::parse_coordinate(value.value_or(String {}));
         m_path.clear();
     } else if (name == SVG::AttributeNames::cy) {
-        m_center_y = AttributeParser::parse_coordinate(value.value_or(""));
+        m_center_y = AttributeParser::parse_coordinate(value.value_or(String {}));
         m_path.clear();
     } else if (name == SVG::AttributeNames::r) {
-        m_radius = AttributeParser::parse_positive_length(value.value_or(""));
+        m_radius = AttributeParser::parse_positive_length(value.value_or(String {}));
         m_path.clear();
     }
 }

--- a/Userland/Libraries/LibWeb/SVG/SVGCircleElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGCircleElement.h
@@ -17,7 +17,7 @@ class SVGCircleElement final : public SVGGeometryElement {
 public:
     virtual ~SVGCircleElement() override = default;
 
-    virtual void attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<String> const& value) override;
 
     virtual Gfx::Path& get_path() override;
 

--- a/Userland/Libraries/LibWeb/SVG/SVGElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGElement.cpp
@@ -34,7 +34,7 @@ void SVGElement::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_dataset);
 }
 
-void SVGElement::attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value)
+void SVGElement::attribute_changed(FlyString const& name, Optional<String> const& value)
 {
     Base::attribute_changed(name, value);
 

--- a/Userland/Libraries/LibWeb/SVG/SVGElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGElement.h
@@ -17,7 +17,7 @@ class SVGElement : public DOM::Element {
 public:
     virtual bool requires_svg_container() const override { return true; }
 
-    virtual void attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<String> const& value) override;
 
     virtual void children_changed() override;
     virtual void inserted() override;

--- a/Userland/Libraries/LibWeb/SVG/SVGEllipseElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGEllipseElement.cpp
@@ -22,21 +22,21 @@ void SVGEllipseElement::initialize(JS::Realm& realm)
     set_prototype(&Bindings::ensure_web_prototype<Bindings::SVGEllipseElementPrototype>(realm, "SVGEllipseElement"));
 }
 
-void SVGEllipseElement::attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value)
+void SVGEllipseElement::attribute_changed(FlyString const& name, Optional<String> const& value)
 {
     SVGGeometryElement::attribute_changed(name, value);
 
     if (name == SVG::AttributeNames::cx) {
-        m_center_x = AttributeParser::parse_coordinate(value.value_or(""));
+        m_center_x = AttributeParser::parse_coordinate(value.value_or(String {}));
         m_path.clear();
     } else if (name == SVG::AttributeNames::cy) {
-        m_center_y = AttributeParser::parse_coordinate(value.value_or(""));
+        m_center_y = AttributeParser::parse_coordinate(value.value_or(String {}));
         m_path.clear();
     } else if (name == SVG::AttributeNames::rx) {
-        m_radius_x = AttributeParser::parse_positive_length(value.value_or(""));
+        m_radius_x = AttributeParser::parse_positive_length(value.value_or(String {}));
         m_path.clear();
     } else if (name == SVG::AttributeNames::ry) {
-        m_radius_y = AttributeParser::parse_positive_length(value.value_or(""));
+        m_radius_y = AttributeParser::parse_positive_length(value.value_or(String {}));
         m_path.clear();
     }
 }

--- a/Userland/Libraries/LibWeb/SVG/SVGEllipseElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGEllipseElement.h
@@ -17,7 +17,7 @@ class SVGEllipseElement final : public SVGGeometryElement {
 public:
     virtual ~SVGEllipseElement() override = default;
 
-    virtual void attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<String> const& value) override;
 
     virtual Gfx::Path& get_path() override;
 

--- a/Userland/Libraries/LibWeb/SVG/SVGGradientElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGGradientElement.cpp
@@ -17,15 +17,15 @@ SVGGradientElement::SVGGradientElement(DOM::Document& document, DOM::QualifiedNa
 {
 }
 
-void SVGGradientElement::attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value)
+void SVGGradientElement::attribute_changed(FlyString const& name, Optional<String> const& value)
 {
     SVGElement::attribute_changed(name, value);
     if (name == AttributeNames::gradientUnits) {
-        m_gradient_units = AttributeParser::parse_units(value.value_or(""));
+        m_gradient_units = AttributeParser::parse_units(value.value_or(String {}));
     } else if (name == AttributeNames::spreadMethod) {
-        m_spread_method = AttributeParser::parse_spread_method(value.value_or(""));
+        m_spread_method = AttributeParser::parse_spread_method(value.value_or(String {}));
     } else if (name == AttributeNames::gradientTransform) {
-        if (auto transform_list = AttributeParser::parse_transform(value.value_or("")); transform_list.has_value()) {
+        if (auto transform_list = AttributeParser::parse_transform(value.value_or(String {})); transform_list.has_value()) {
             m_gradient_transform = transform_from_transform_list(*transform_list);
         } else {
             m_gradient_transform = {};

--- a/Userland/Libraries/LibWeb/SVG/SVGGradientElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGGradientElement.h
@@ -40,7 +40,7 @@ class SVGGradientElement : public SVGElement {
 public:
     virtual ~SVGGradientElement() override = default;
 
-    virtual void attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<String> const& value) override;
 
     virtual Optional<Gfx::PaintStyle const&> to_gfx_paint_style(SVGPaintContext const&) const = 0;
 

--- a/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
@@ -32,11 +32,11 @@ void SVGGraphicsElement::initialize(JS::Realm& realm)
     set_prototype(&Bindings::ensure_web_prototype<Bindings::SVGGraphicsElementPrototype>(realm, "SVGGraphicsElement"));
 }
 
-void SVGGraphicsElement::attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value)
+void SVGGraphicsElement::attribute_changed(FlyString const& name, Optional<String> const& value)
 {
     SVGElement::attribute_changed(name, value);
     if (name == "transform"sv) {
-        auto transform_list = AttributeParser::parse_transform(value.value_or(""));
+        auto transform_list = AttributeParser::parse_transform(value.value_or(String {}));
         if (transform_list.has_value())
             m_transform = transform_from_transform_list(*transform_list);
     }

--- a/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.h
@@ -24,7 +24,7 @@ class SVGGraphicsElement : public SVGElement {
 public:
     virtual void apply_presentational_hints(CSS::StyleProperties&) const override;
 
-    virtual void attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<String> const& value) override;
 
     Optional<Gfx::Color> fill_color() const;
     Optional<FillRule> fill_rule() const;

--- a/Userland/Libraries/LibWeb/SVG/SVGLineElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGLineElement.cpp
@@ -22,21 +22,21 @@ void SVGLineElement::initialize(JS::Realm& realm)
     set_prototype(&Bindings::ensure_web_prototype<Bindings::SVGLineElementPrototype>(realm, "SVGLineElement"));
 }
 
-void SVGLineElement::attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value)
+void SVGLineElement::attribute_changed(FlyString const& name, Optional<String> const& value)
 {
     SVGGeometryElement::attribute_changed(name, value);
 
     if (name == SVG::AttributeNames::x1) {
-        m_x1 = AttributeParser::parse_coordinate(value.value_or(""));
+        m_x1 = AttributeParser::parse_coordinate(value.value_or(String {}));
         m_path.clear();
     } else if (name == SVG::AttributeNames::y1) {
-        m_y1 = AttributeParser::parse_coordinate(value.value_or(""));
+        m_y1 = AttributeParser::parse_coordinate(value.value_or(String {}));
         m_path.clear();
     } else if (name == SVG::AttributeNames::x2) {
-        m_x2 = AttributeParser::parse_coordinate(value.value_or(""));
+        m_x2 = AttributeParser::parse_coordinate(value.value_or(String {}));
         m_path.clear();
     } else if (name == SVG::AttributeNames::y2) {
-        m_y2 = AttributeParser::parse_coordinate(value.value_or(""));
+        m_y2 = AttributeParser::parse_coordinate(value.value_or(String {}));
         m_path.clear();
     }
 }

--- a/Userland/Libraries/LibWeb/SVG/SVGLineElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGLineElement.h
@@ -17,7 +17,7 @@ class SVGLineElement final : public SVGGeometryElement {
 public:
     virtual ~SVGLineElement() override = default;
 
-    virtual void attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<String> const& value) override;
 
     virtual Gfx::Path& get_path() override;
 

--- a/Userland/Libraries/LibWeb/SVG/SVGLinearGradientElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGLinearGradientElement.cpp
@@ -24,22 +24,22 @@ void SVGLinearGradientElement::initialize(JS::Realm& realm)
     set_prototype(&Bindings::ensure_web_prototype<Bindings::SVGLinearGradientElementPrototype>(realm, "SVGLinearGradientElement"));
 }
 
-void SVGLinearGradientElement::attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value)
+void SVGLinearGradientElement::attribute_changed(FlyString const& name, Optional<String> const& value)
 {
     SVGGradientElement::attribute_changed(name, value);
 
     // FIXME: Should allow for `<number-percentage> | <length>` for x1, x2, y1, y2
     if (name == SVG::AttributeNames::x1) {
-        m_x1 = AttributeParser::parse_number_percentage(value.value_or(""));
+        m_x1 = AttributeParser::parse_number_percentage(value.value_or(String {}));
         m_paint_style = nullptr;
     } else if (name == SVG::AttributeNames::y1) {
-        m_y1 = AttributeParser::parse_number_percentage(value.value_or(""));
+        m_y1 = AttributeParser::parse_number_percentage(value.value_or(String {}));
         m_paint_style = nullptr;
     } else if (name == SVG::AttributeNames::x2) {
-        m_x2 = AttributeParser::parse_number_percentage(value.value_or(""));
+        m_x2 = AttributeParser::parse_number_percentage(value.value_or(String {}));
         m_paint_style = nullptr;
     } else if (name == SVG::AttributeNames::y2) {
-        m_y2 = AttributeParser::parse_number_percentage(value.value_or(""));
+        m_y2 = AttributeParser::parse_number_percentage(value.value_or(String {}));
         m_paint_style = nullptr;
     }
 }

--- a/Userland/Libraries/LibWeb/SVG/SVGLinearGradientElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGLinearGradientElement.h
@@ -18,7 +18,7 @@ class SVGLinearGradientElement : public SVGGradientElement {
 public:
     virtual ~SVGLinearGradientElement() override = default;
 
-    virtual void attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<String> const& value) override;
 
     virtual Optional<Gfx::PaintStyle const&> to_gfx_paint_style(SVGPaintContext const&) const override;
 

--- a/Userland/Libraries/LibWeb/SVG/SVGMaskElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGMaskElement.cpp
@@ -31,13 +31,13 @@ JS::GCPtr<Layout::Node> SVGMaskElement::create_layout_node(NonnullRefPtr<CSS::St
     return heap().allocate_without_realm<Layout::SVGGraphicsBox>(document(), *this, move(style));
 }
 
-void SVGMaskElement::attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value)
+void SVGMaskElement::attribute_changed(FlyString const& name, Optional<String> const& value)
 {
     SVGGraphicsElement::attribute_changed(name, value);
     if (name == AttributeNames::maskUnits) {
-        m_mask_units = AttributeParser::parse_units(value.value_or(""));
+        m_mask_units = AttributeParser::parse_units(value.value_or(String {}));
     } else if (name == AttributeNames::maskContentUnits) {
-        m_mask_content_units = AttributeParser::parse_units(value.value_or(""));
+        m_mask_content_units = AttributeParser::parse_units(value.value_or(String {}));
     }
 }
 

--- a/Userland/Libraries/LibWeb/SVG/SVGMaskElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGMaskElement.h
@@ -17,7 +17,7 @@ class SVGMaskElement final : public SVGGraphicsElement {
 public:
     virtual ~SVGMaskElement() override;
 
-    virtual void attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<String> const& value) override;
 
     virtual JS::GCPtr<Layout::Node> create_layout_node(NonnullRefPtr<CSS::StyleProperties>) override;
 

--- a/Userland/Libraries/LibWeb/SVG/SVGPathElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGPathElement.cpp
@@ -93,12 +93,12 @@ void SVGPathElement::initialize(JS::Realm& realm)
     set_prototype(&Bindings::ensure_web_prototype<Bindings::SVGPathElementPrototype>(realm, "SVGPathElement"));
 }
 
-void SVGPathElement::attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value)
+void SVGPathElement::attribute_changed(FlyString const& name, Optional<String> const& value)
 {
     SVGGeometryElement::attribute_changed(name, value);
 
     if (name == "d") {
-        m_instructions = AttributeParser::parse_path_data(value.value_or(""));
+        m_instructions = AttributeParser::parse_path_data(value.value_or(String {}));
         m_path.clear();
     }
 }

--- a/Userland/Libraries/LibWeb/SVG/SVGPathElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGPathElement.h
@@ -19,7 +19,7 @@ class SVGPathElement final : public SVGGeometryElement {
 public:
     virtual ~SVGPathElement() override = default;
 
-    virtual void attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<String> const& value) override;
 
     virtual Gfx::Path& get_path() override;
 

--- a/Userland/Libraries/LibWeb/SVG/SVGPolygonElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGPolygonElement.cpp
@@ -22,12 +22,12 @@ void SVGPolygonElement::initialize(JS::Realm& realm)
     set_prototype(&Bindings::ensure_web_prototype<Bindings::SVGPolygonElementPrototype>(realm, "SVGPolygonElement"));
 }
 
-void SVGPolygonElement::attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value)
+void SVGPolygonElement::attribute_changed(FlyString const& name, Optional<String> const& value)
 {
     SVGGeometryElement::attribute_changed(name, value);
 
     if (name == SVG::AttributeNames::points) {
-        m_points = AttributeParser::parse_points(value.value_or(""));
+        m_points = AttributeParser::parse_points(value.value_or(String {}));
         m_path.clear();
     }
 }

--- a/Userland/Libraries/LibWeb/SVG/SVGPolygonElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGPolygonElement.h
@@ -16,7 +16,7 @@ class SVGPolygonElement final : public SVGGeometryElement {
 public:
     virtual ~SVGPolygonElement() override = default;
 
-    virtual void attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<String> const& value) override;
 
     virtual Gfx::Path& get_path() override;
 

--- a/Userland/Libraries/LibWeb/SVG/SVGPolylineElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGPolylineElement.cpp
@@ -22,12 +22,12 @@ void SVGPolylineElement::initialize(JS::Realm& realm)
     set_prototype(&Bindings::ensure_web_prototype<Bindings::SVGPolylineElementPrototype>(realm, "SVGPolylineElement"));
 }
 
-void SVGPolylineElement::attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value)
+void SVGPolylineElement::attribute_changed(FlyString const& name, Optional<String> const& value)
 {
     SVGGeometryElement::attribute_changed(name, value);
 
     if (name == SVG::AttributeNames::points) {
-        m_points = AttributeParser::parse_points(value.value_or(""));
+        m_points = AttributeParser::parse_points(value.value_or(String {}));
         m_path.clear();
     }
 }

--- a/Userland/Libraries/LibWeb/SVG/SVGPolylineElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGPolylineElement.h
@@ -16,7 +16,7 @@ class SVGPolylineElement final : public SVGGeometryElement {
 public:
     virtual ~SVGPolylineElement() override = default;
 
-    virtual void attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<String> const& value) override;
 
     virtual Gfx::Path& get_path() override;
 

--- a/Userland/Libraries/LibWeb/SVG/SVGRadialGradientElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGRadialGradientElement.cpp
@@ -21,29 +21,29 @@ void SVGRadialGradientElement::initialize(JS::Realm& realm)
     set_prototype(&Bindings::ensure_web_prototype<Bindings::SVGRadialGradientElementPrototype>(realm, "SVGRadialGradientElement"));
 }
 
-void SVGRadialGradientElement::attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value)
+void SVGRadialGradientElement::attribute_changed(FlyString const& name, Optional<String> const& value)
 {
     SVGGradientElement::attribute_changed(name, value);
 
     // FIXME: These are <length> or <coordinate> in the spec, but all examples seem to allow percentages
     // and unitless values.
     if (name == SVG::AttributeNames::cx) {
-        m_cx = AttributeParser::parse_number_percentage(value.value_or(""));
+        m_cx = AttributeParser::parse_number_percentage(value.value_or(String {}));
         m_paint_style = nullptr;
     } else if (name == SVG::AttributeNames::cy) {
-        m_cy = AttributeParser::parse_number_percentage(value.value_or(""));
+        m_cy = AttributeParser::parse_number_percentage(value.value_or(String {}));
         m_paint_style = nullptr;
     } else if (name == SVG::AttributeNames::fx) {
-        m_fx = AttributeParser::parse_number_percentage(value.value_or(""));
+        m_fx = AttributeParser::parse_number_percentage(value.value_or(String {}));
         m_paint_style = nullptr;
     } else if (name == SVG::AttributeNames::fy) {
-        m_fy = AttributeParser::parse_number_percentage(value.value_or(""));
+        m_fy = AttributeParser::parse_number_percentage(value.value_or(String {}));
         m_paint_style = nullptr;
     } else if (name == SVG::AttributeNames::fr) {
-        m_fr = AttributeParser::parse_number_percentage(value.value_or(""));
+        m_fr = AttributeParser::parse_number_percentage(value.value_or(String {}));
         m_paint_style = nullptr;
     } else if (name == SVG::AttributeNames::r) {
-        m_r = AttributeParser::parse_number_percentage(value.value_or(""));
+        m_r = AttributeParser::parse_number_percentage(value.value_or(String {}));
         m_paint_style = nullptr;
     }
 }

--- a/Userland/Libraries/LibWeb/SVG/SVGRadialGradientElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGRadialGradientElement.h
@@ -18,7 +18,7 @@ class SVGRadialGradientElement : public SVGGradientElement {
 public:
     virtual ~SVGRadialGradientElement() override = default;
 
-    virtual void attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<String> const& value) override;
 
     virtual Optional<Gfx::PaintStyle const&> to_gfx_paint_style(SVGPaintContext const&) const override;
 

--- a/Userland/Libraries/LibWeb/SVG/SVGRectElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGRectElement.cpp
@@ -24,27 +24,27 @@ void SVGRectElement::initialize(JS::Realm& realm)
     set_prototype(&Bindings::ensure_web_prototype<Bindings::SVGRectElementPrototype>(realm, "SVGRectElement"));
 }
 
-void SVGRectElement::attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value)
+void SVGRectElement::attribute_changed(FlyString const& name, Optional<String> const& value)
 {
     SVGGeometryElement::attribute_changed(name, value);
 
     if (name == SVG::AttributeNames::x) {
-        m_x = AttributeParser::parse_coordinate(value.value_or(""));
+        m_x = AttributeParser::parse_coordinate(value.value_or(String {}));
         m_path.clear();
     } else if (name == SVG::AttributeNames::y) {
-        m_y = AttributeParser::parse_coordinate(value.value_or(""));
+        m_y = AttributeParser::parse_coordinate(value.value_or(String {}));
         m_path.clear();
     } else if (name == SVG::AttributeNames::width) {
-        m_width = AttributeParser::parse_positive_length(value.value_or(""));
+        m_width = AttributeParser::parse_positive_length(value.value_or(String {}));
         m_path.clear();
     } else if (name == SVG::AttributeNames::height) {
-        m_height = AttributeParser::parse_positive_length(value.value_or(""));
+        m_height = AttributeParser::parse_positive_length(value.value_or(String {}));
         m_path.clear();
     } else if (name == SVG::AttributeNames::rx) {
-        m_radius_x = AttributeParser::parse_length(value.value_or(""));
+        m_radius_x = AttributeParser::parse_length(value.value_or(String {}));
         m_path.clear();
     } else if (name == SVG::AttributeNames::ry) {
-        m_radius_y = AttributeParser::parse_length(value.value_or(""));
+        m_radius_y = AttributeParser::parse_length(value.value_or(String {}));
         m_path.clear();
     }
 }

--- a/Userland/Libraries/LibWeb/SVG/SVGRectElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGRectElement.h
@@ -17,7 +17,7 @@ class SVGRectElement final : public SVGGeometryElement {
 public:
     virtual ~SVGRectElement() override = default;
 
-    virtual void attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<String> const& value) override;
 
     virtual Gfx::Path& get_path() override;
 

--- a/Userland/Libraries/LibWeb/SVG/SVGSVGElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGSVGElement.cpp
@@ -61,14 +61,14 @@ void SVGSVGElement::apply_presentational_hints(CSS::StyleProperties& style) cons
     }
 }
 
-void SVGSVGElement::attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value)
+void SVGSVGElement::attribute_changed(FlyString const& name, Optional<String> const& value)
 {
     SVGGraphicsElement::attribute_changed(name, value);
 
     if (name.equals_ignoring_ascii_case(SVG::AttributeNames::viewBox))
-        m_view_box = try_parse_view_box(value.value_or(""));
+        m_view_box = try_parse_view_box(value.value_or(String {}));
     if (name.equals_ignoring_ascii_case(SVG::AttributeNames::preserveAspectRatio))
-        m_preserve_aspect_ratio = AttributeParser::parse_preserve_aspect_ratio(value.value_or(""));
+        m_preserve_aspect_ratio = AttributeParser::parse_preserve_aspect_ratio(value.value_or(String {}));
     if (name.equals_ignoring_ascii_case(SVG::AttributeNames::width) || name.equals_ignoring_ascii_case(SVG::AttributeNames::height))
         update_fallback_view_box_for_svg_as_image();
 }

--- a/Userland/Libraries/LibWeb/SVG/SVGSVGElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGSVGElement.h
@@ -36,7 +36,7 @@ private:
 
     virtual bool is_svg_svg_element() const override { return true; }
 
-    virtual void attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<String> const& value) override;
 
     void update_fallback_view_box_for_svg_as_image();
 

--- a/Userland/Libraries/LibWeb/SVG/SVGStopElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGStopElement.cpp
@@ -19,11 +19,11 @@ SVGStopElement::SVGStopElement(DOM::Document& document, DOM::QualifiedName quali
 {
 }
 
-void SVGStopElement::attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value)
+void SVGStopElement::attribute_changed(FlyString const& name, Optional<String> const& value)
 {
     SVGElement::attribute_changed(name, value);
     if (name == SVG::AttributeNames::offset) {
-        m_offset = AttributeParser::parse_number_percentage(value.value_or(""));
+        m_offset = AttributeParser::parse_number_percentage(value.value_or(String {}));
     }
 }
 

--- a/Userland/Libraries/LibWeb/SVG/SVGStopElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGStopElement.h
@@ -19,7 +19,7 @@ class SVGStopElement final : public SVGElement {
 public:
     virtual ~SVGStopElement() override = default;
 
-    virtual void attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<String> const& value) override;
 
     JS::NonnullGCPtr<SVGAnimatedNumber> offset() const;
 

--- a/Userland/Libraries/LibWeb/SVG/SVGSymbolElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGSymbolElement.cpp
@@ -39,11 +39,11 @@ void SVGSymbolElement::apply_presentational_hints(CSS::StyleProperties& style) c
     }
 }
 
-void SVGSymbolElement::attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value)
+void SVGSymbolElement::attribute_changed(FlyString const& name, Optional<String> const& value)
 {
     Base::attribute_changed(name, value);
     if (name.equals_ignoring_ascii_case(SVG::AttributeNames::viewBox))
-        m_view_box = try_parse_view_box(value.value_or(""));
+        m_view_box = try_parse_view_box(value.value_or(String {}));
 }
 
 bool SVGSymbolElement::is_direct_child_of_use_shadow_tree() const

--- a/Userland/Libraries/LibWeb/SVG/SVGSymbolElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGSymbolElement.h
@@ -29,7 +29,7 @@ private:
 
     bool is_direct_child_of_use_shadow_tree() const;
 
-    virtual void attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<String> const& value) override;
 
     Optional<ViewBox> m_view_box;
 };

--- a/Userland/Libraries/LibWeb/SVG/SVGTextPositioningElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGTextPositioningElement.cpp
@@ -28,18 +28,18 @@ void SVGTextPositioningElement::initialize(JS::Realm& realm)
     set_prototype(&Bindings::ensure_web_prototype<Bindings::SVGTextPositioningElementPrototype>(realm, "SVGTextPositioningElement"));
 }
 
-void SVGTextPositioningElement::attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value)
+void SVGTextPositioningElement::attribute_changed(FlyString const& name, Optional<String> const& value)
 {
     SVGGraphicsElement::attribute_changed(name, value);
 
     if (name == SVG::AttributeNames::x) {
-        m_x = AttributeParser::parse_coordinate(value.value_or("")).value_or(m_x);
+        m_x = AttributeParser::parse_coordinate(value.value_or(String {})).value_or(m_x);
     } else if (name == SVG::AttributeNames::y) {
-        m_y = AttributeParser::parse_coordinate(value.value_or("")).value_or(m_y);
+        m_y = AttributeParser::parse_coordinate(value.value_or(String {})).value_or(m_y);
     } else if (name == SVG::AttributeNames::dx) {
-        m_dx = AttributeParser::parse_coordinate(value.value_or("")).value_or(m_dx);
+        m_dx = AttributeParser::parse_coordinate(value.value_or(String {})).value_or(m_dx);
     } else if (name == SVG::AttributeNames::dy) {
-        m_dy = AttributeParser::parse_coordinate(value.value_or("")).value_or(m_dy);
+        m_dy = AttributeParser::parse_coordinate(value.value_or(String {})).value_or(m_dy);
     }
 }
 

--- a/Userland/Libraries/LibWeb/SVG/SVGTextPositioningElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGTextPositioningElement.h
@@ -16,7 +16,7 @@ class SVGTextPositioningElement : public SVGTextContentElement {
     WEB_PLATFORM_OBJECT(SVGTextPositioningElement, SVGTextContentElement);
 
 public:
-    virtual void attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<String> const& value) override;
 
     Gfx::FloatPoint get_offset() const;
 

--- a/Userland/Libraries/LibWeb/SVG/SVGUseElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGUseElement.cpp
@@ -45,18 +45,18 @@ void SVGUseElement::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_document_observer);
 }
 
-void SVGUseElement::attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value)
+void SVGUseElement::attribute_changed(FlyString const& name, Optional<String> const& value)
 {
     Base::attribute_changed(name, value);
 
     // https://svgwg.org/svg2-draft/struct.html#UseLayout
     if (name == SVG::AttributeNames::x) {
-        m_x = AttributeParser::parse_coordinate(value.value_or(""));
+        m_x = AttributeParser::parse_coordinate(value.value_or(String {}));
     } else if (name == SVG::AttributeNames::y) {
-        m_y = AttributeParser::parse_coordinate(value.value_or(""));
+        m_y = AttributeParser::parse_coordinate(value.value_or(String {}));
     } else if (name == SVG::AttributeNames::href) {
         // FIXME: Support the xlink:href attribute as a fallback
-        m_referenced_id = parse_id_from_href(value.value_or(""));
+        m_referenced_id = parse_id_from_href(value.value_or(String {}).to_deprecated_string());
 
         clone_element_tree_as_our_shadow_tree(referenced_element());
     }

--- a/Userland/Libraries/LibWeb/SVG/SVGUseElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGUseElement.h
@@ -20,7 +20,7 @@ class SVGUseElement final : public SVGGraphicsElement {
 public:
     virtual ~SVGUseElement() override = default;
 
-    virtual void attribute_changed(FlyString const& name, Optional<DeprecatedString> const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<String> const& value) override;
 
     virtual void inserted() override;
 


### PR DESCRIPTION
Which as you would expect has a bunch of fallout, but also results in a whole lot of awkward conversions falling away.