### PR TITLE
LibWeb: Run activation behaviour for middle clicks

### DIFF
--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -267,6 +267,8 @@ bool EventHandler::handle_mouseup(CSSPixelPoint position, CSSPixelPoint screen_p
                     run_activation_behavior = node->dispatch_event(UIEvents::MouseEvent::create_from_platform_event(node->realm(), UIEvents::EventNames::click, screen_position, page_offset, client_offset, offset, {}, 1, button, modifiers).release_value_but_fixme_should_propagate_errors());
                 else if (button == GUI::MouseButton::Secondary && !(modifiers & Mod_Shift)) // Allow the user to bypass custom context menus by holding shift, like Firefox.
                     run_activation_behavior = node->dispatch_event(UIEvents::MouseEvent::create_from_platform_event(node->realm(), UIEvents::EventNames::contextmenu, screen_position, page_offset, client_offset, offset, {}, 1, button, modifiers).release_value_but_fixme_should_propagate_errors());
+                else if (button == GUI::MouseButton::Middle)
+                    run_activation_behavior = true;
             }
 
             if (run_activation_behavior) {


### PR DESCRIPTION
After 05dd46f9e36 we no longer ran activation behaviour for middle clicks. This broke the ability to middle click on a link to open it in a new tab.

Fix this by special casing the middle click to run activation behaviour.

(I am not sure this is at all the correct fix here, suggestions open!)