### PR TITLE
LibJS: Segregate GC-allocated objects by type

### DIFF
--- a/Userland/Libraries/LibJS/CMakeLists.txt
+++ b/Userland/Libraries/LibJS/CMakeLists.txt
@@ -34,6 +34,7 @@ set(SOURCES
     ParserError.cpp
     Print.cpp
     Runtime/AbstractOperations.cpp
+    Runtime/Accessor.cpp
     Runtime/AggregateError.cpp
     Runtime/AggregateErrorConstructor.cpp
     Runtime/AggregateErrorPrototype.cpp

--- a/Userland/Libraries/LibJS/Contrib/Test262/262Object.cpp
+++ b/Userland/Libraries/LibJS/Contrib/Test262/262Object.cpp
@@ -21,6 +21,8 @@
 
 namespace JS::Test262 {
 
+JS_DEFINE_ALLOCATOR($262Object);
+
 $262Object::$262Object(Realm& realm)
     : Object(Object::ConstructWithoutPrototypeTag::Tag, realm)
 {

--- a/Userland/Libraries/LibJS/Contrib/Test262/262Object.h
+++ b/Userland/Libraries/LibJS/Contrib/Test262/262Object.h
@@ -15,6 +15,7 @@ namespace JS::Test262 {
 
 class $262Object final : public Object {
     JS_OBJECT($262Object, Object);
+    JS_DECLARE_ALLOCATOR($262Object);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Contrib/Test262/AgentObject.cpp
+++ b/Userland/Libraries/LibJS/Contrib/Test262/AgentObject.cpp
@@ -12,6 +12,8 @@
 
 namespace JS::Test262 {
 
+JS_DEFINE_ALLOCATOR(AgentObject);
+
 AgentObject::AgentObject(Realm& realm)
     : Object(Object::ConstructWithoutPrototypeTag::Tag, realm)
 {

--- a/Userland/Libraries/LibJS/Contrib/Test262/AgentObject.h
+++ b/Userland/Libraries/LibJS/Contrib/Test262/AgentObject.h
@@ -13,6 +13,7 @@ namespace JS::Test262 {
 
 class AgentObject final : public Object {
     JS_OBJECT(AgentObject, Object);
+    JS_DECLARE_ALLOCATOR(AgentObject);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Contrib/Test262/GlobalObject.cpp
+++ b/Userland/Libraries/LibJS/Contrib/Test262/GlobalObject.cpp
@@ -14,6 +14,8 @@
 
 namespace JS::Test262 {
 
+JS_DEFINE_ALLOCATOR(GlobalObject);
+
 void GlobalObject::initialize(Realm& realm)
 {
     Base::initialize(realm);

--- a/Userland/Libraries/LibJS/Contrib/Test262/GlobalObject.h
+++ b/Userland/Libraries/LibJS/Contrib/Test262/GlobalObject.h
@@ -13,6 +13,7 @@ namespace JS::Test262 {
 
 class GlobalObject final : public JS::GlobalObject {
     JS_OBJECT(GlobalObject, JS::GlobalObject);
+    JS_DECLARE_ALLOCATOR(GlobalObject);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Contrib/Test262/IsHTMLDDA.cpp
+++ b/Userland/Libraries/LibJS/Contrib/Test262/IsHTMLDDA.cpp
@@ -9,6 +9,8 @@
 
 namespace JS::Test262 {
 
+JS_DEFINE_ALLOCATOR(IsHTMLDDA);
+
 IsHTMLDDA::IsHTMLDDA(Realm& realm)
     // NativeFunction without prototype is currently not possible (only due to the lack of a ctor that supports it)
     : NativeFunction("IsHTMLDDA", realm.intrinsics().function_prototype())

--- a/Userland/Libraries/LibJS/Contrib/Test262/IsHTMLDDA.h
+++ b/Userland/Libraries/LibJS/Contrib/Test262/IsHTMLDDA.h
@@ -12,6 +12,7 @@ namespace JS::Test262 {
 
 class IsHTMLDDA final : public NativeFunction {
     JS_OBJECT(IsHTMLDDA, NativeFunction);
+    JS_DECLARE_ALLOCATOR(IsHTMLDDA);
 
 public:
     virtual ~IsHTMLDDA() override = default;

--- a/Userland/Libraries/LibJS/CyclicModule.cpp
+++ b/Userland/Libraries/LibJS/CyclicModule.cpp
@@ -15,6 +15,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(CyclicModule);
+
 CyclicModule::CyclicModule(Realm& realm, StringView filename, bool has_top_level_await, Vector<ModuleRequest> requested_modules, Script::HostDefined* host_defined)
     : Module(realm, filename, host_defined)
     , m_requested_modules(move(requested_modules))

--- a/Userland/Libraries/LibJS/CyclicModule.h
+++ b/Userland/Libraries/LibJS/CyclicModule.h
@@ -42,6 +42,7 @@ struct GraphLoadingState {
 // 16.2.1.5 Cyclic Module Records, https://tc39.es/ecma262/#cyclic-module-record
 class CyclicModule : public Module {
     JS_CELL(CyclicModule, Module);
+    JS_DECLARE_ALLOCATOR(CyclicModule);
 
 public:
     // Note: Do not call these methods directly unless you are HostResolveImportedModule.

--- a/Userland/Libraries/LibJS/Heap/CellAllocator.h
+++ b/Userland/Libraries/LibJS/Heap/CellAllocator.h
@@ -11,6 +11,12 @@
 #include <LibJS/Forward.h>
 #include <LibJS/Heap/HeapBlock.h>
 
+#define JS_DECLARE_ALLOCATOR(ClassName) \
+    static JS::TypeIsolatingCellAllocator<ClassName> cell_allocator;
+
+#define JS_DEFINE_ALLOCATOR(ClassName) \
+    JS::TypeIsolatingCellAllocator<ClassName> ClassName::cell_allocator;
+
 namespace JS {
 
 class CellAllocator {
@@ -40,11 +46,19 @@ public:
     void block_did_become_usable(Badge<Heap>, HeapBlock&);
 
 private:
-    const size_t m_cell_size;
+    size_t const m_cell_size;
 
     using BlockList = IntrusiveList<&HeapBlock::m_list_node>;
     BlockList m_full_blocks;
     BlockList m_usable_blocks;
+};
+
+template<typename T>
+class TypeIsolatingCellAllocator {
+public:
+    using CellType = T;
+
+    CellAllocator allocator { sizeof(T) };
 };
 
 }

--- a/Userland/Libraries/LibJS/Heap/Heap.cpp
+++ b/Userland/Libraries/LibJS/Heap/Heap.cpp
@@ -70,17 +70,7 @@ Heap::~Heap()
     collect_garbage(CollectionType::CollectEverything);
 }
 
-ALWAYS_INLINE CellAllocator& Heap::allocator_for_size(size_t cell_size)
-{
-    for (auto& allocator : m_allocators) {
-        if (allocator->cell_size() >= cell_size)
-            return *allocator;
-    }
-    dbgln("Cannot get CellAllocator for cell size {}, largest available is {}!", cell_size, m_allocators.last()->cell_size());
-    VERIFY_NOT_REACHED();
-}
-
-Cell* Heap::allocate_cell(size_t size)
+void Heap::will_allocate(size_t size)
 {
     if (should_collect_on_every_allocation()) {
         m_allocated_bytes_since_last_gc = 0;
@@ -91,8 +81,6 @@ Cell* Heap::allocate_cell(size_t size)
     }
 
     m_allocated_bytes_since_last_gc += size;
-    auto& allocator = allocator_for_size(size);
-    return allocator.allocate_cell(*this);
 }
 
 static void add_possible_value(HashMap<FlatPtr, HeapRoot>& possible_pointers, FlatPtr data, HeapRoot origin, FlatPtr min_block_address, FlatPtr max_block_address)

--- a/Userland/Libraries/LibJS/Heap/Internals.h
+++ b/Userland/Libraries/LibJS/Heap/Internals.h
@@ -33,7 +33,7 @@ class HeapBlockBase {
     AK_MAKE_NONCOPYABLE(HeapBlockBase);
 
 public:
-    static constexpr auto block_size = 16 * KiB;
+    static constexpr auto block_size = 4 * KiB;
     static HeapBlockBase* from_cell(Cell const* cell)
     {
         return reinterpret_cast<HeapBlockBase*>(bit_cast<FlatPtr>(cell) & ~(HeapBlockBase::block_size - 1));

--- a/Userland/Libraries/LibJS/Module.cpp
+++ b/Userland/Libraries/LibJS/Module.cpp
@@ -15,6 +15,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(Module);
+
 Module::Module(Realm& realm, DeprecatedString filename, Script::HostDefined* host_defined)
     : m_realm(realm)
     , m_host_defined(host_defined)

--- a/Userland/Libraries/LibJS/Module.h
+++ b/Userland/Libraries/LibJS/Module.h
@@ -58,6 +58,7 @@ struct ResolvedBinding {
 // 16.2.1.4 Abstract Module Records, https://tc39.es/ecma262/#sec-abstract-module-records
 class Module : public Cell {
     JS_CELL(Module, Cell);
+    JS_DECLARE_ALLOCATOR(Module);
 
 public:
     virtual ~Module() override;

--- a/Userland/Libraries/LibJS/Runtime/Accessor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Accessor.cpp
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2023, Andreas Kling <kling@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibJS/Runtime/Accessor.h>
+
+namespace JS {
+
+JS_DEFINE_ALLOCATOR(Accessor);
+
+}

--- a/Userland/Libraries/LibJS/Runtime/Accessor.h
+++ b/Userland/Libraries/LibJS/Runtime/Accessor.h
@@ -15,6 +15,7 @@ namespace JS {
 
 class Accessor final : public Cell {
     JS_CELL(Accessor, Cell);
+    JS_DECLARE_ALLOCATOR(Accessor);
 
 public:
     static NonnullGCPtr<Accessor> create(VM& vm, FunctionObject* getter, FunctionObject* setter)

--- a/Userland/Libraries/LibJS/Runtime/AggregateError.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AggregateError.cpp
@@ -10,6 +10,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(AggregateError);
+
 NonnullGCPtr<AggregateError> AggregateError::create(Realm& realm)
 {
     return realm.heap().allocate<AggregateError>(realm, realm.intrinsics().aggregate_error_prototype());

--- a/Userland/Libraries/LibJS/Runtime/AggregateError.h
+++ b/Userland/Libraries/LibJS/Runtime/AggregateError.h
@@ -13,6 +13,7 @@ namespace JS {
 
 class AggregateError : public Error {
     JS_OBJECT(AggregateError, Error);
+    JS_DECLARE_ALLOCATOR(AggregateError);
 
 public:
     static NonnullGCPtr<AggregateError> create(Realm&);

--- a/Userland/Libraries/LibJS/Runtime/AggregateErrorConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AggregateErrorConstructor.cpp
@@ -14,6 +14,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(AggregateErrorConstructor);
+
 AggregateErrorConstructor::AggregateErrorConstructor(Realm& realm)
     : NativeFunction(static_cast<Object&>(*realm.intrinsics().error_constructor()))
 {

--- a/Userland/Libraries/LibJS/Runtime/AggregateErrorConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/AggregateErrorConstructor.h
@@ -12,6 +12,7 @@ namespace JS {
 
 class AggregateErrorConstructor final : public NativeFunction {
     JS_OBJECT(AggregateErrorConstructor, NativeFunction);
+    JS_DECLARE_ALLOCATOR(AggregateErrorConstructor);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/AggregateErrorPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AggregateErrorPrototype.cpp
@@ -10,6 +10,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(AggregateErrorPrototype);
+
 AggregateErrorPrototype::AggregateErrorPrototype(Realm& realm)
     : Object(ConstructWithPrototypeTag::Tag, realm.intrinsics().error_prototype())
 {

--- a/Userland/Libraries/LibJS/Runtime/AggregateErrorPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/AggregateErrorPrototype.h
@@ -12,6 +12,7 @@ namespace JS {
 
 class AggregateErrorPrototype final : public Object {
     JS_OBJECT(AggregateErrorPrototype, Object);
+    JS_DECLARE_ALLOCATOR(AggregateErrorPrototype);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/ArgumentsObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArgumentsObject.cpp
@@ -10,6 +10,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(ArgumentsObject);
+
 ArgumentsObject::ArgumentsObject(Realm& realm, Environment& environment)
     : Object(ConstructWithPrototypeTag::Tag, realm.intrinsics().object_prototype(), MayInterfereWithIndexedPropertyAccess::Yes)
     , m_environment(environment)

--- a/Userland/Libraries/LibJS/Runtime/ArgumentsObject.h
+++ b/Userland/Libraries/LibJS/Runtime/ArgumentsObject.h
@@ -14,6 +14,7 @@ namespace JS {
 
 class ArgumentsObject final : public Object {
     JS_OBJECT(ArgumentsObject, Object);
+    JS_DECLARE_ALLOCATOR(ArgumentsObject);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/Array.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Array.cpp
@@ -17,6 +17,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(Array);
+
 // 10.4.2.2 ArrayCreate ( length [ , proto ] ), https://tc39.es/ecma262/#sec-arraycreate
 ThrowCompletionOr<NonnullGCPtr<Array>> Array::create(Realm& realm, u64 length, Object* prototype)
 {

--- a/Userland/Libraries/LibJS/Runtime/Array.h
+++ b/Userland/Libraries/LibJS/Runtime/Array.h
@@ -21,6 +21,7 @@ namespace JS {
 
 class Array : public Object {
     JS_OBJECT(Array, Object);
+    JS_DECLARE_ALLOCATOR(Array);
 
 public:
     static ThrowCompletionOr<NonnullGCPtr<Array>> create(Realm&, u64 length, Object* prototype = nullptr);

--- a/Userland/Libraries/LibJS/Runtime/ArrayBuffer.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayBuffer.cpp
@@ -11,6 +11,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(ArrayBuffer);
+
 ThrowCompletionOr<NonnullGCPtr<ArrayBuffer>> ArrayBuffer::create(Realm& realm, size_t byte_length)
 {
     auto buffer = ByteBuffer::create_zeroed(byte_length);

--- a/Userland/Libraries/LibJS/Runtime/ArrayBuffer.h
+++ b/Userland/Libraries/LibJS/Runtime/ArrayBuffer.h
@@ -48,6 +48,7 @@ struct DataBlock {
 
 class ArrayBuffer : public Object {
     JS_OBJECT(ArrayBuffer, Object);
+    JS_DECLARE_ALLOCATOR(ArrayBuffer);
 
 public:
     static ThrowCompletionOr<NonnullGCPtr<ArrayBuffer>> create(Realm&, size_t);

--- a/Userland/Libraries/LibJS/Runtime/ArrayBufferConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayBufferConstructor.cpp
@@ -14,6 +14,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(ArrayBufferConstructor);
+
 ArrayBufferConstructor::ArrayBufferConstructor(Realm& realm)
     : NativeFunction(realm.vm().names.ArrayBuffer.as_string(), realm.intrinsics().function_prototype())
 {

--- a/Userland/Libraries/LibJS/Runtime/ArrayBufferConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/ArrayBufferConstructor.h
@@ -12,6 +12,7 @@ namespace JS {
 
 class ArrayBufferConstructor final : public NativeFunction {
     JS_OBJECT(ArrayBufferConstructor, NativeFunction);
+    JS_DECLARE_ALLOCATOR(ArrayBufferConstructor);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/ArrayBufferPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayBufferPrototype.cpp
@@ -14,6 +14,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(ArrayBufferPrototype);
+
 ArrayBufferPrototype::ArrayBufferPrototype(Realm& realm)
     : PrototypeObject(realm.intrinsics().object_prototype())
 {

--- a/Userland/Libraries/LibJS/Runtime/ArrayBufferPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/ArrayBufferPrototype.h
@@ -13,6 +13,7 @@ namespace JS {
 
 class ArrayBufferPrototype final : public PrototypeObject<ArrayBufferPrototype, ArrayBuffer> {
     JS_PROTOTYPE_OBJECT(ArrayBufferPrototype, ArrayBuffer, ArrayBuffer);
+    JS_DECLARE_ALLOCATOR(ArrayBufferPrototype);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/ArrayConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayConstructor.cpp
@@ -22,6 +22,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(ArrayConstructor);
+
 ArrayConstructor::ArrayConstructor(Realm& realm)
     : NativeFunction(realm.vm().names.Array.as_string(), realm.intrinsics().function_prototype())
 {

--- a/Userland/Libraries/LibJS/Runtime/ArrayConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/ArrayConstructor.h
@@ -12,6 +12,7 @@ namespace JS {
 
 class ArrayConstructor final : public NativeFunction {
     JS_OBJECT(ArrayConstructor, NativeFunction);
+    JS_DECLARE_ALLOCATOR(ArrayConstructor);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/ArrayIterator.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayIterator.cpp
@@ -9,6 +9,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(ArrayIterator);
+
 NonnullGCPtr<ArrayIterator> ArrayIterator::create(Realm& realm, Value array, Object::PropertyKind iteration_kind)
 {
     return realm.heap().allocate<ArrayIterator>(realm, array, iteration_kind, realm.intrinsics().array_iterator_prototype());

--- a/Userland/Libraries/LibJS/Runtime/ArrayIterator.h
+++ b/Userland/Libraries/LibJS/Runtime/ArrayIterator.h
@@ -12,6 +12,7 @@ namespace JS {
 
 class ArrayIterator final : public Object {
     JS_OBJECT(ArrayIterator, Object);
+    JS_DECLARE_ALLOCATOR(ArrayIterator);
 
 public:
     static NonnullGCPtr<ArrayIterator> create(Realm&, Value array, Object::PropertyKind iteration_kind);

--- a/Userland/Libraries/LibJS/Runtime/ArrayIteratorPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayIteratorPrototype.cpp
@@ -14,6 +14,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(ArrayIteratorPrototype);
+
 ArrayIteratorPrototype::ArrayIteratorPrototype(Realm& realm)
     : PrototypeObject(realm.intrinsics().iterator_prototype())
 {

--- a/Userland/Libraries/LibJS/Runtime/ArrayIteratorPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/ArrayIteratorPrototype.h
@@ -13,6 +13,7 @@ namespace JS {
 
 class ArrayIteratorPrototype final : public PrototypeObject<ArrayIteratorPrototype, ArrayIterator> {
     JS_PROTOTYPE_OBJECT(ArrayIteratorPrototype, ArrayIterator, ArrayIterator);
+    JS_DECLARE_ALLOCATOR(ArrayIteratorPrototype);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/ArrayPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayPrototype.cpp
@@ -27,6 +27,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(ArrayPrototype);
+
 static HashTable<NonnullGCPtr<Object>> s_array_join_seen_objects;
 
 ArrayPrototype::ArrayPrototype(Realm& realm)

--- a/Userland/Libraries/LibJS/Runtime/ArrayPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/ArrayPrototype.h
@@ -13,6 +13,7 @@ namespace JS {
 
 class ArrayPrototype final : public Array {
     JS_OBJECT(ArrayPrototype, Array);
+    JS_DECLARE_ALLOCATOR(ArrayPrototype);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/AsyncFromSyncIterator.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AsyncFromSyncIterator.cpp
@@ -11,6 +11,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(AsyncFromSyncIterator);
+
 NonnullGCPtr<AsyncFromSyncIterator> AsyncFromSyncIterator::create(Realm& realm, IteratorRecord sync_iterator_record)
 {
     return realm.heap().allocate<AsyncFromSyncIterator>(realm, realm, sync_iterator_record);

--- a/Userland/Libraries/LibJS/Runtime/AsyncFromSyncIterator.h
+++ b/Userland/Libraries/LibJS/Runtime/AsyncFromSyncIterator.h
@@ -15,6 +15,7 @@ namespace JS {
 // 27.1.4.3 Properties of Async-from-Sync Iterator Instances, https://tc39.es/ecma262/#sec-properties-of-async-from-sync-iterator-instances
 class AsyncFromSyncIterator final : public Object {
     JS_OBJECT(AsyncFromSyncIterator, Object);
+    JS_DECLARE_ALLOCATOR(AsyncFromSyncIterator);
 
 public:
     static NonnullGCPtr<AsyncFromSyncIterator> create(Realm&, IteratorRecord sync_iterator_record);

--- a/Userland/Libraries/LibJS/Runtime/AsyncFromSyncIteratorPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AsyncFromSyncIteratorPrototype.cpp
@@ -14,6 +14,8 @@
 
 namespace JS {
 
+JS_DECLARE_ALLOCATOR(AsyncFromSyncIteratorPrototype);
+
 AsyncFromSyncIteratorPrototype::AsyncFromSyncIteratorPrototype(Realm& realm)
     : PrototypeObject(realm.intrinsics().async_iterator_prototype())
 {

--- a/Userland/Libraries/LibJS/Runtime/AsyncFromSyncIteratorPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/AsyncFromSyncIteratorPrototype.h
@@ -17,6 +17,7 @@ namespace JS {
 // 27.1.4.2 The %AsyncFromSyncIteratorPrototype% Object, https://tc39.es/ecma262/#sec-%asyncfromsynciteratorprototype%-object
 class AsyncFromSyncIteratorPrototype final : public PrototypeObject<AsyncFromSyncIteratorPrototype, AsyncFromSyncIterator> {
     JS_PROTOTYPE_OBJECT(AsyncFromSyncIteratorPrototype, AsyncFromSyncIterator, AsyncFromSyncIterator);
+    JS_DECLARE_ALLOCATOR(AsyncFromSyncIteratorPrototype);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/AsyncFunctionConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AsyncFunctionConstructor.cpp
@@ -12,6 +12,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(AsyncFunctionConstructor);
+
 AsyncFunctionConstructor::AsyncFunctionConstructor(Realm& realm)
     : NativeFunction(realm.vm().names.AsyncFunction.as_string(), realm.intrinsics().function_constructor())
 {

--- a/Userland/Libraries/LibJS/Runtime/AsyncFunctionConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/AsyncFunctionConstructor.h
@@ -12,6 +12,7 @@ namespace JS {
 
 class AsyncFunctionConstructor final : public NativeFunction {
     JS_OBJECT(AsyncFunctionConstructor, NativeFunction);
+    JS_DECLARE_ALLOCATOR(AsyncFunctionConstructor);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/AsyncFunctionDriverWrapper.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AsyncFunctionDriverWrapper.cpp
@@ -15,6 +15,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(AsyncFunctionDriverWrapper);
+
 NonnullGCPtr<Promise> AsyncFunctionDriverWrapper::create(Realm& realm, GeneratorObject* generator_object)
 {
     auto top_level_promise = Promise::create(realm);

--- a/Userland/Libraries/LibJS/Runtime/AsyncFunctionDriverWrapper.h
+++ b/Userland/Libraries/LibJS/Runtime/AsyncFunctionDriverWrapper.h
@@ -16,6 +16,7 @@ namespace JS {
 
 class AsyncFunctionDriverWrapper final : public Promise {
     JS_OBJECT(AsyncFunctionDriverWrapper, Promise);
+    JS_DECLARE_ALLOCATOR(AsyncFunctionDriverWrapper);
 
 public:
     enum class IsInitialExecution {

--- a/Userland/Libraries/LibJS/Runtime/AsyncFunctionPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AsyncFunctionPrototype.cpp
@@ -9,6 +9,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(AsyncFunctionPrototype);
+
 AsyncFunctionPrototype::AsyncFunctionPrototype(Realm& realm)
     : Object(ConstructWithPrototypeTag::Tag, realm.intrinsics().function_prototype())
 {

--- a/Userland/Libraries/LibJS/Runtime/AsyncFunctionPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/AsyncFunctionPrototype.h
@@ -12,6 +12,7 @@ namespace JS {
 
 class AsyncFunctionPrototype final : public Object {
     JS_OBJECT(AsyncFunctionPrototype, Object);
+    JS_DECLARE_ALLOCATOR(AsyncFunctionPrototype);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/AsyncGenerator.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AsyncGenerator.cpp
@@ -14,6 +14,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(AsyncGenerator);
+
 ThrowCompletionOr<NonnullGCPtr<AsyncGenerator>> AsyncGenerator::create(Realm& realm, Value initial_value, ECMAScriptFunctionObject* generating_function, ExecutionContext execution_context, Bytecode::CallFrame frame)
 {
     auto& vm = realm.vm();

--- a/Userland/Libraries/LibJS/Runtime/AsyncGenerator.h
+++ b/Userland/Libraries/LibJS/Runtime/AsyncGenerator.h
@@ -17,6 +17,7 @@ namespace JS {
 // 27.6.2 Properties of AsyncGenerator Instances, https://tc39.es/ecma262/#sec-properties-of-asyncgenerator-intances
 class AsyncGenerator final : public Object {
     JS_OBJECT(AsyncGenerator, Object);
+    JS_DECLARE_ALLOCATOR(AsyncGenerator);
 
 public:
     enum class State {

--- a/Userland/Libraries/LibJS/Runtime/AsyncGeneratorFunctionConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AsyncGeneratorFunctionConstructor.cpp
@@ -12,6 +12,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(AsyncGeneratorFunctionConstructor);
+
 AsyncGeneratorFunctionConstructor::AsyncGeneratorFunctionConstructor(Realm& realm)
     : NativeFunction(realm.vm().names.AsyncGeneratorFunction.as_string(), realm.intrinsics().function_prototype())
 {

--- a/Userland/Libraries/LibJS/Runtime/AsyncGeneratorFunctionConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/AsyncGeneratorFunctionConstructor.h
@@ -12,6 +12,7 @@ namespace JS {
 
 class AsyncGeneratorFunctionConstructor final : public NativeFunction {
     JS_OBJECT(AsyncGeneratorFunctionConstructor, NativeFunction);
+    JS_DECLARE_ALLOCATOR(AsyncGeneratorFunctionConstructor);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/AsyncGeneratorFunctionPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AsyncGeneratorFunctionPrototype.cpp
@@ -11,6 +11,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(AsyncGeneratorFunctionPrototype);
+
 AsyncGeneratorFunctionPrototype::AsyncGeneratorFunctionPrototype(Realm& realm)
     : PrototypeObject(realm.intrinsics().function_prototype())
 {

--- a/Userland/Libraries/LibJS/Runtime/AsyncGeneratorFunctionPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/AsyncGeneratorFunctionPrototype.h
@@ -12,6 +12,7 @@ namespace JS {
 
 class AsyncGeneratorFunctionPrototype final : public PrototypeObject<AsyncGeneratorFunctionPrototype, AsyncGeneratorFunction> {
     JS_PROTOTYPE_OBJECT(AsyncGeneratorFunctionPrototype, AsyncGeneratorFunction, AsyncGeneratorFunction);
+    JS_DECLARE_ALLOCATOR(AsyncGeneratorFunctionPrototype);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/AsyncGeneratorPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AsyncGeneratorPrototype.cpp
@@ -12,6 +12,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(AsyncGeneratorPrototype);
+
 // 27.6.1 Properties of the AsyncGenerator Prototype Object, https://tc39.es/ecma262/#sec-properties-of-asyncgenerator-prototype
 AsyncGeneratorPrototype::AsyncGeneratorPrototype(Realm& realm)
     : PrototypeObject(realm.intrinsics().async_iterator_prototype())

--- a/Userland/Libraries/LibJS/Runtime/AsyncGeneratorPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/AsyncGeneratorPrototype.h
@@ -14,6 +14,7 @@ namespace JS {
 
 class AsyncGeneratorPrototype final : public PrototypeObject<AsyncGeneratorPrototype, AsyncGenerator> {
     JS_PROTOTYPE_OBJECT(AsyncGeneratorPrototype, AsyncGenerator, AsyncGenerator)
+    JS_DECLARE_ALLOCATOR(AsyncGeneratorPrototype);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/AsyncIteratorPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AsyncIteratorPrototype.cpp
@@ -8,6 +8,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(AsyncIteratorPrototype);
+
 AsyncIteratorPrototype::AsyncIteratorPrototype(Realm& realm)
     : Object(ConstructWithPrototypeTag::Tag, realm.intrinsics().object_prototype())
 {

--- a/Userland/Libraries/LibJS/Runtime/AsyncIteratorPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/AsyncIteratorPrototype.h
@@ -12,6 +12,7 @@ namespace JS {
 
 class AsyncIteratorPrototype final : public Object {
     JS_OBJECT(AsyncIteratorPrototype, Object)
+    JS_DECLARE_ALLOCATOR(AsyncIteratorPrototype);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/AtomicsObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AtomicsObject.cpp
@@ -23,6 +23,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(AtomicsObject);
+
 // 25.4.2.1 ValidateIntegerTypedArray ( typedArray [ , waitable ] ), https://tc39.es/ecma262/#sec-validateintegertypedarray
 static ThrowCompletionOr<ArrayBuffer*> validate_integer_typed_array(VM& vm, TypedArrayBase& typed_array, bool waitable = false)
 {

--- a/Userland/Libraries/LibJS/Runtime/AtomicsObject.h
+++ b/Userland/Libraries/LibJS/Runtime/AtomicsObject.h
@@ -12,6 +12,7 @@ namespace JS {
 
 class AtomicsObject : public Object {
     JS_OBJECT(AtomicsObject, Object);
+    JS_DECLARE_ALLOCATOR(AtomicsObject);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/BigInt.cpp
+++ b/Userland/Libraries/LibJS/Runtime/BigInt.cpp
@@ -11,6 +11,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(BigInt);
+
 NonnullGCPtr<BigInt> BigInt::create(VM& vm, Crypto::SignedBigInteger big_integer)
 {
     return vm.heap().allocate_without_realm<BigInt>(move(big_integer));

--- a/Userland/Libraries/LibJS/Runtime/BigInt.h
+++ b/Userland/Libraries/LibJS/Runtime/BigInt.h
@@ -11,11 +11,13 @@
 #include <AK/StringView.h>
 #include <LibCrypto/BigInt/SignedBigInteger.h>
 #include <LibJS/Heap/Cell.h>
+#include <LibJS/Heap/CellAllocator.h>
 
 namespace JS {
 
 class BigInt final : public Cell {
     JS_CELL(BigInt, Cell);
+    JS_DECLARE_ALLOCATOR(BigInt);
 
 public:
     [[nodiscard]] static NonnullGCPtr<BigInt> create(VM&, Crypto::SignedBigInteger);

--- a/Userland/Libraries/LibJS/Runtime/BigIntConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/BigIntConstructor.cpp
@@ -15,6 +15,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(BigIntConstructor);
+
 static const Crypto::SignedBigInteger BIGINT_ONE { 1 };
 
 BigIntConstructor::BigIntConstructor(Realm& realm)

--- a/Userland/Libraries/LibJS/Runtime/BigIntConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/BigIntConstructor.h
@@ -12,6 +12,7 @@ namespace JS {
 
 class BigIntConstructor final : public NativeFunction {
     JS_OBJECT(BigIntConstructor, NativeFunction);
+    JS_DECLARE_ALLOCATOR(BigIntConstructor);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/BigIntObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/BigIntObject.cpp
@@ -9,6 +9,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(BigIntObject);
+
 NonnullGCPtr<BigIntObject> BigIntObject::create(Realm& realm, BigInt& bigint)
 {
     return realm.heap().allocate<BigIntObject>(realm, bigint, realm.intrinsics().bigint_prototype());

--- a/Userland/Libraries/LibJS/Runtime/BigIntObject.h
+++ b/Userland/Libraries/LibJS/Runtime/BigIntObject.h
@@ -13,6 +13,7 @@ namespace JS {
 
 class BigIntObject final : public Object {
     JS_OBJECT(BigIntObject, Object);
+    JS_DECLARE_ALLOCATOR(BigIntObject);
 
 public:
     static NonnullGCPtr<BigIntObject> create(Realm&, BigInt&);

--- a/Userland/Libraries/LibJS/Runtime/BigIntPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/BigIntPrototype.cpp
@@ -17,6 +17,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(BigIntPrototype);
+
 BigIntPrototype::BigIntPrototype(Realm& realm)
     : Object(ConstructWithPrototypeTag::Tag, realm.intrinsics().object_prototype())
 {

--- a/Userland/Libraries/LibJS/Runtime/BigIntPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/BigIntPrototype.h
@@ -12,6 +12,7 @@ namespace JS {
 
 class BigIntPrototype final : public Object {
     JS_OBJECT(BigIntPrototype, Object);
+    JS_DECLARE_ALLOCATOR(BigIntPrototype);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/BooleanConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/BooleanConstructor.cpp
@@ -13,6 +13,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(BooleanConstructor);
+
 BooleanConstructor::BooleanConstructor(Realm& realm)
     : NativeFunction(realm.vm().names.Boolean.as_string(), realm.intrinsics().function_prototype())
 {

--- a/Userland/Libraries/LibJS/Runtime/BooleanConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/BooleanConstructor.h
@@ -12,6 +12,7 @@ namespace JS {
 
 class BooleanConstructor final : public NativeFunction {
     JS_OBJECT(BooleanConstructor, NativeFunction);
+    JS_DECLARE_ALLOCATOR(BooleanConstructor);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/BooleanObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/BooleanObject.cpp
@@ -9,6 +9,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(BooleanObject);
+
 NonnullGCPtr<BooleanObject> BooleanObject::create(Realm& realm, bool value)
 {
     return realm.heap().allocate<BooleanObject>(realm, value, realm.intrinsics().boolean_prototype());

--- a/Userland/Libraries/LibJS/Runtime/BooleanObject.h
+++ b/Userland/Libraries/LibJS/Runtime/BooleanObject.h
@@ -12,6 +12,7 @@ namespace JS {
 
 class BooleanObject : public Object {
     JS_OBJECT(BooleanObject, Object);
+    JS_DECLARE_ALLOCATOR(BooleanObject);
 
 public:
     static NonnullGCPtr<BooleanObject> create(Realm&, bool);

--- a/Userland/Libraries/LibJS/Runtime/BooleanPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/BooleanPrototype.cpp
@@ -13,6 +13,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(BooleanPrototype);
+
 BooleanPrototype::BooleanPrototype(Realm& realm)
     : BooleanObject(false, realm.intrinsics().object_prototype())
 {

--- a/Userland/Libraries/LibJS/Runtime/BooleanPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/BooleanPrototype.h
@@ -12,6 +12,7 @@ namespace JS {
 
 class BooleanPrototype final : public BooleanObject {
     JS_OBJECT(BooleanPrototype, BooleanObject);
+    JS_DECLARE_ALLOCATOR(BooleanPrototype);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/BoundFunction.cpp
+++ b/Userland/Libraries/LibJS/Runtime/BoundFunction.cpp
@@ -11,6 +11,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(BoundFunction);
+
 // 10.4.1.3 BoundFunctionCreate ( targetFunction, boundThis, boundArgs ), https://tc39.es/ecma262/#sec-boundfunctioncreate
 ThrowCompletionOr<NonnullGCPtr<BoundFunction>> BoundFunction::create(Realm& realm, FunctionObject& target_function, Value bound_this, Vector<Value> bound_arguments)
 {

--- a/Userland/Libraries/LibJS/Runtime/BoundFunction.h
+++ b/Userland/Libraries/LibJS/Runtime/BoundFunction.h
@@ -13,6 +13,7 @@ namespace JS {
 
 class BoundFunction final : public FunctionObject {
     JS_OBJECT(BoundFunction, FunctionObject);
+    JS_DECLARE_ALLOCATOR(BoundFunction);
 
 public:
     static ThrowCompletionOr<NonnullGCPtr<BoundFunction>> create(Realm&, FunctionObject& target_function, Value bound_this, Vector<Value> bound_arguments);

--- a/Userland/Libraries/LibJS/Runtime/ConsoleObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ConsoleObject.cpp
@@ -12,6 +12,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(ConsoleObject);
+
 ConsoleObject::ConsoleObject(Realm& realm)
     : Object(ConstructWithPrototypeTag::Tag, realm.intrinsics().object_prototype())
     , m_console(make<Console>(realm))

--- a/Userland/Libraries/LibJS/Runtime/ConsoleObject.h
+++ b/Userland/Libraries/LibJS/Runtime/ConsoleObject.h
@@ -12,6 +12,7 @@ namespace JS {
 
 class ConsoleObject final : public Object {
     JS_OBJECT(ConsoleObject, Object);
+    JS_DECLARE_ALLOCATOR(ConsoleObject);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/DataView.cpp
+++ b/Userland/Libraries/LibJS/Runtime/DataView.cpp
@@ -8,6 +8,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(DataView);
+
 NonnullGCPtr<DataView> DataView::create(Realm& realm, ArrayBuffer* viewed_buffer, size_t byte_length, size_t byte_offset)
 {
     return realm.heap().allocate<DataView>(realm, viewed_buffer, byte_length, byte_offset, realm.intrinsics().data_view_prototype());

--- a/Userland/Libraries/LibJS/Runtime/DataView.h
+++ b/Userland/Libraries/LibJS/Runtime/DataView.h
@@ -14,6 +14,7 @@ namespace JS {
 
 class DataView : public Object {
     JS_OBJECT(DataView, Object);
+    JS_DECLARE_ALLOCATOR(DataView);
 
 public:
     static NonnullGCPtr<DataView> create(Realm&, ArrayBuffer*, size_t byte_length, size_t byte_offset);

--- a/Userland/Libraries/LibJS/Runtime/DataViewConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/DataViewConstructor.cpp
@@ -14,6 +14,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(DataViewConstructor);
+
 DataViewConstructor::DataViewConstructor(Realm& realm)
     : NativeFunction(realm.vm().names.DataView.as_string(), realm.intrinsics().function_prototype())
 {

--- a/Userland/Libraries/LibJS/Runtime/DataViewConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/DataViewConstructor.h
@@ -12,6 +12,7 @@ namespace JS {
 
 class DataViewConstructor final : public NativeFunction {
     JS_OBJECT(DataViewConstructor, NativeFunction);
+    JS_DECLARE_ALLOCATOR(DataViewConstructor);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/DataViewPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/DataViewPrototype.cpp
@@ -11,6 +11,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(DataViewPrototype);
+
 DataViewPrototype::DataViewPrototype(Realm& realm)
     : PrototypeObject(realm.intrinsics().object_prototype())
 {

--- a/Userland/Libraries/LibJS/Runtime/DataViewPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/DataViewPrototype.h
@@ -13,6 +13,7 @@ namespace JS {
 
 class DataViewPrototype final : public PrototypeObject<DataViewPrototype, DataView> {
     JS_PROTOTYPE_OBJECT(DataViewPrototype, DataView, DataView);
+    JS_DECLARE_ALLOCATOR(DataViewPrototype);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/Date.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Date.cpp
@@ -17,6 +17,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(Date);
+
 static Crypto::SignedBigInteger const s_one_billion_bigint { 1'000'000'000 };
 static Crypto::SignedBigInteger const s_one_million_bigint { 1'000'000 };
 static Crypto::SignedBigInteger const s_one_thousand_bigint { 1'000 };

--- a/Userland/Libraries/LibJS/Runtime/Date.h
+++ b/Userland/Libraries/LibJS/Runtime/Date.h
@@ -14,6 +14,7 @@ namespace JS {
 
 class Date final : public Object {
     JS_OBJECT(Date, Object);
+    JS_DECLARE_ALLOCATOR(Date);
 
 public:
     static NonnullGCPtr<Date> create(Realm&, double date_value);

--- a/Userland/Libraries/LibJS/Runtime/DateConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/DateConstructor.cpp
@@ -23,6 +23,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(DateConstructor);
+
 // 21.4.3.2 Date.parse ( string ), https://tc39.es/ecma262/#sec-date.parse
 static double parse_simplified_iso8601(DeprecatedString const& iso_8601)
 {

--- a/Userland/Libraries/LibJS/Runtime/DateConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/DateConstructor.h
@@ -12,6 +12,7 @@ namespace JS {
 
 class DateConstructor final : public NativeFunction {
     JS_OBJECT(DateConstructor, NativeFunction);
+    JS_DECLARE_ALLOCATOR(DateConstructor);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/DatePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/DatePrototype.cpp
@@ -30,6 +30,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(DatePrototype);
+
 DatePrototype::DatePrototype(Realm& realm)
     : PrototypeObject(realm.intrinsics().object_prototype())
 {

--- a/Userland/Libraries/LibJS/Runtime/DatePrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/DatePrototype.h
@@ -13,6 +13,7 @@ namespace JS {
 
 class DatePrototype final : public PrototypeObject<DatePrototype, Date> {
     JS_PROTOTYPE_OBJECT(DatePrototype, Date, Date);
+    JS_DECLARE_ALLOCATOR(DatePrototype);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/DeclarativeEnvironment.cpp
+++ b/Userland/Libraries/LibJS/Runtime/DeclarativeEnvironment.cpp
@@ -13,6 +13,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(DeclarativeEnvironment);
+
 DeclarativeEnvironment* DeclarativeEnvironment::create_for_per_iteration_bindings(Badge<ForStatement>, DeclarativeEnvironment& other, size_t bindings_size)
 {
     auto bindings = other.m_bindings.span().slice(0, bindings_size);

--- a/Userland/Libraries/LibJS/Runtime/DeclarativeEnvironment.h
+++ b/Userland/Libraries/LibJS/Runtime/DeclarativeEnvironment.h
@@ -17,6 +17,7 @@ namespace JS {
 
 class DeclarativeEnvironment : public Environment {
     JS_ENVIRONMENT(DeclarativeEnvironment, Environment);
+    JS_DECLARE_ALLOCATOR(DeclarativeEnvironment);
 
     struct Binding {
         static FlatPtr value_offset() { return OFFSET_OF(Binding, value); }

--- a/Userland/Libraries/LibJS/Runtime/DisposableStack.cpp
+++ b/Userland/Libraries/LibJS/Runtime/DisposableStack.cpp
@@ -8,6 +8,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(DisposableStack);
+
 DisposableStack::DisposableStack(Vector<DisposableResource> stack, Object& prototype)
     : Object(ConstructWithPrototypeTag::Tag, prototype)
     , m_disposable_resource_stack(move(stack))

--- a/Userland/Libraries/LibJS/Runtime/DisposableStack.h
+++ b/Userland/Libraries/LibJS/Runtime/DisposableStack.h
@@ -13,6 +13,7 @@ namespace JS {
 
 class DisposableStack final : public Object {
     JS_OBJECT(DisposableStack, Object);
+    JS_DECLARE_ALLOCATOR(DisposableStack);
 
 public:
     virtual ~DisposableStack() override = default;

--- a/Userland/Libraries/LibJS/Runtime/DisposableStackConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/DisposableStackConstructor.cpp
@@ -10,6 +10,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(DisposableStackConstructor);
+
 DisposableStackConstructor::DisposableStackConstructor(Realm& realm)
     : NativeFunction(realm.vm().names.DisposableStack.as_string(), realm.intrinsics().function_prototype())
 {

--- a/Userland/Libraries/LibJS/Runtime/DisposableStackConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/DisposableStackConstructor.h
@@ -12,6 +12,7 @@ namespace JS {
 
 class DisposableStackConstructor final : public NativeFunction {
     JS_OBJECT(DisposableStackConstructor, NativeFunction);
+    JS_DECLARE_ALLOCATOR(DisposableStackConstructor);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/DisposableStackPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/DisposableStackPrototype.cpp
@@ -12,6 +12,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(DisposableStackPrototype);
+
 DisposableStackPrototype::DisposableStackPrototype(Realm& realm)
     : PrototypeObject(realm.intrinsics().object_prototype())
 {

--- a/Userland/Libraries/LibJS/Runtime/DisposableStackPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/DisposableStackPrototype.h
@@ -13,6 +13,7 @@ namespace JS {
 
 class DisposableStackPrototype final : public PrototypeObject<DisposableStackPrototype, DisposableStack> {
     JS_PROTOTYPE_OBJECT(DisposableStackPrototype, DisposableStack, DisposableStack);
+    JS_DECLARE_ALLOCATOR(DisposableStackPrototype);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
@@ -31,6 +31,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(ECMAScriptFunctionObject);
+
 NonnullGCPtr<ECMAScriptFunctionObject> ECMAScriptFunctionObject::create(Realm& realm, DeprecatedFlyString name, DeprecatedString source_text, Statement const& ecmascript_code, Vector<FunctionParameter> parameters, i32 m_function_length, Vector<DeprecatedFlyString> local_variables_names, Environment* parent_environment, PrivateEnvironment* private_environment, FunctionKind kind, bool is_strict, bool might_need_arguments_object, bool contains_direct_call_to_eval, bool is_arrow_function, Variant<PropertyKey, PrivateName, Empty> class_field_initializer_name)
 {
     Object* prototype = nullptr;

--- a/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.h
+++ b/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.h
@@ -24,6 +24,7 @@ void async_function_start(VM&, PromiseCapability const&, T const& async_function
 // 10.2 ECMAScript Function Objects, https://tc39.es/ecma262/#sec-ecmascript-function-objects
 class ECMAScriptFunctionObject final : public FunctionObject {
     JS_OBJECT(ECMAScriptFunctionObject, FunctionObject);
+    JS_DECLARE_ALLOCATOR(ECMAScriptFunctionObject);
 
 public:
     enum class ConstructorKind : u8 {

--- a/Userland/Libraries/LibJS/Runtime/Error.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Error.cpp
@@ -15,6 +15,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(Error);
+
 SourceRange const& TracebackFrame::source_range() const
 {
     if (auto* unrealized = source_range_storage.get_pointer<UnrealizedSourceRange>()) {
@@ -156,6 +158,7 @@ String Error::stack_string(CompactTraceback compact) const
 }
 
 #define __JS_ENUMERATE(ClassName, snake_name, PrototypeName, ConstructorName, ArrayType)                   \
+    JS_DEFINE_ALLOCATOR(ClassName);                                                                        \
     NonnullGCPtr<ClassName> ClassName::create(Realm& realm)                                                \
     {                                                                                                      \
         return realm.heap().allocate<ClassName>(realm, realm.intrinsics().snake_name##_prototype());       \

--- a/Userland/Libraries/LibJS/Runtime/Error.h
+++ b/Userland/Libraries/LibJS/Runtime/Error.h
@@ -29,6 +29,7 @@ enum CompactTraceback {
 
 class Error : public Object {
     JS_OBJECT(Error, Object);
+    JS_DECLARE_ALLOCATOR(Error);
 
 public:
     static NonnullGCPtr<Error> create(Realm&);
@@ -57,6 +58,7 @@ private:
 #define DECLARE_NATIVE_ERROR(ClassName, snake_name, PrototypeName, ConstructorName) \
     class ClassName final : public Error {                                          \
         JS_OBJECT(ClassName, Error);                                                \
+        JS_DECLARE_ALLOCATOR(ClassName);                                            \
                                                                                     \
     public:                                                                         \
         static NonnullGCPtr<ClassName> create(Realm&);                              \

--- a/Userland/Libraries/LibJS/Runtime/ErrorConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ErrorConstructor.cpp
@@ -11,6 +11,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(ErrorConstructor);
+
 ErrorConstructor::ErrorConstructor(Realm& realm)
     : NativeFunction(realm.vm().names.Error.as_string(), realm.intrinsics().function_prototype())
 {
@@ -62,6 +64,7 @@ ThrowCompletionOr<NonnullGCPtr<Object>> ErrorConstructor::construct(FunctionObje
 }
 
 #define __JS_ENUMERATE(ClassName, snake_name, PrototypeName, ConstructorName, ArrayType)                                    \
+    JS_DEFINE_ALLOCATOR(ConstructorName);                                                                                   \
     ConstructorName::ConstructorName(Realm& realm)                                                                          \
         : NativeFunction(realm.vm().names.ClassName.as_string(), realm.intrinsics().error_constructor())                    \
     {                                                                                                                       \

--- a/Userland/Libraries/LibJS/Runtime/ErrorConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/ErrorConstructor.h
@@ -13,6 +13,7 @@ namespace JS {
 
 class ErrorConstructor final : public NativeFunction {
     JS_OBJECT(ErrorConstructor, NativeFunction);
+    JS_DECLARE_ALLOCATOR(ErrorConstructor);
 
 public:
     virtual void initialize(Realm&) override;
@@ -30,6 +31,7 @@ private:
 #define DECLARE_NATIVE_ERROR_CONSTRUCTOR(ClassName, snake_name, PrototypeName, ConstructorName)         \
     class ConstructorName final : public NativeFunction {                                               \
         JS_OBJECT(ConstructorName, NativeFunction);                                                     \
+        JS_DECLARE_ALLOCATOR(ConstructorName);                                                          \
                                                                                                         \
     public:                                                                                             \
         virtual void initialize(Realm&) override;                                                       \

--- a/Userland/Libraries/LibJS/Runtime/ErrorPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ErrorPrototype.cpp
@@ -14,6 +14,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(ErrorPrototype);
+
 ErrorPrototype::ErrorPrototype(Realm& realm)
     : PrototypeObject(realm.intrinsics().object_prototype())
 {

--- a/Userland/Libraries/LibJS/Runtime/ErrorPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/ErrorPrototype.h
@@ -14,6 +14,7 @@ namespace JS {
 
 class ErrorPrototype final : public PrototypeObject<ErrorPrototype, Error> {
     JS_PROTOTYPE_OBJECT(ErrorPrototype, Error, Error);
+    JS_DECLARE_ALLOCATOR(ErrorPrototype);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/FinalizationRegistry.cpp
+++ b/Userland/Libraries/LibJS/Runtime/FinalizationRegistry.cpp
@@ -9,6 +9,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(FinalizationRegistry);
+
 FinalizationRegistry::FinalizationRegistry(Realm& realm, JobCallback cleanup_callback, Object& prototype)
     : Object(ConstructWithPrototypeTag::Tag, prototype)
     , WeakContainer(heap())

--- a/Userland/Libraries/LibJS/Runtime/FinalizationRegistry.h
+++ b/Userland/Libraries/LibJS/Runtime/FinalizationRegistry.h
@@ -21,6 +21,7 @@ class FinalizationRegistry final
     : public Object
     , public WeakContainer {
     JS_OBJECT(FinalizationRegistry, Object);
+    JS_DECLARE_ALLOCATOR(FinalizationRegistry);
 
 public:
     virtual ~FinalizationRegistry() override = default;

--- a/Userland/Libraries/LibJS/Runtime/FinalizationRegistryConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/FinalizationRegistryConstructor.cpp
@@ -13,6 +13,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(FinalizationRegistryConstructor);
+
 FinalizationRegistryConstructor::FinalizationRegistryConstructor(Realm& realm)
     : NativeFunction(realm.vm().names.FinalizationRegistry.as_string(), realm.intrinsics().function_prototype())
 {

--- a/Userland/Libraries/LibJS/Runtime/FinalizationRegistryConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/FinalizationRegistryConstructor.h
@@ -12,6 +12,7 @@ namespace JS {
 
 class FinalizationRegistryConstructor final : public NativeFunction {
     JS_OBJECT(FinalizationRegistryConstructor, NativeFunction);
+    JS_DECLARE_ALLOCATOR(FinalizationRegistryConstructor);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/FinalizationRegistryPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/FinalizationRegistryPrototype.cpp
@@ -10,6 +10,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(FinalizationRegistryPrototype);
+
 FinalizationRegistryPrototype::FinalizationRegistryPrototype(Realm& realm)
     : PrototypeObject(realm.intrinsics().object_prototype())
 {

--- a/Userland/Libraries/LibJS/Runtime/FinalizationRegistryPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/FinalizationRegistryPrototype.h
@@ -13,6 +13,7 @@ namespace JS {
 
 class FinalizationRegistryPrototype final : public PrototypeObject<FinalizationRegistryPrototype, FinalizationRegistry> {
     JS_PROTOTYPE_OBJECT(FinalizationRegistryPrototype, FinalizationRegistry, FinalizationRegistry);
+    JS_DECLARE_ALLOCATOR(FinalizationRegistryPrototype);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/FunctionConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/FunctionConstructor.cpp
@@ -18,6 +18,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(FunctionConstructor);
+
 FunctionConstructor::FunctionConstructor(Realm& realm)
     : NativeFunction(realm.vm().names.Function.as_string(), realm.intrinsics().function_prototype())
 {

--- a/Userland/Libraries/LibJS/Runtime/FunctionConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/FunctionConstructor.h
@@ -13,6 +13,7 @@ namespace JS {
 
 class FunctionConstructor final : public NativeFunction {
     JS_OBJECT(FunctionConstructor, NativeFunction);
+    JS_DECLARE_ALLOCATOR(FunctionConstructor);
 
 public:
     static ThrowCompletionOr<ECMAScriptFunctionObject*> create_dynamic_function(VM&, FunctionObject& constructor, FunctionObject* new_target, FunctionKind kind, MarkedVector<Value> const& args);

--- a/Userland/Libraries/LibJS/Runtime/FunctionEnvironment.cpp
+++ b/Userland/Libraries/LibJS/Runtime/FunctionEnvironment.cpp
@@ -11,6 +11,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(FunctionEnvironment);
+
 FunctionEnvironment::FunctionEnvironment(Environment* parent_environment)
     : DeclarativeEnvironment(parent_environment)
 {

--- a/Userland/Libraries/LibJS/Runtime/FunctionEnvironment.h
+++ b/Userland/Libraries/LibJS/Runtime/FunctionEnvironment.h
@@ -13,6 +13,7 @@ namespace JS {
 
 class FunctionEnvironment final : public DeclarativeEnvironment {
     JS_ENVIRONMENT(FunctionEnvironment, DeclarativeEnvironment);
+    JS_DECLARE_ALLOCATOR(FunctionEnvironment);
 
 public:
     enum class ThisBindingStatus : u8 {

--- a/Userland/Libraries/LibJS/Runtime/FunctionPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/FunctionPrototype.cpp
@@ -19,6 +19,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(FunctionPrototype);
+
 FunctionPrototype::FunctionPrototype(Realm& realm)
     : FunctionObject(realm.intrinsics().object_prototype())
 {

--- a/Userland/Libraries/LibJS/Runtime/FunctionPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/FunctionPrototype.h
@@ -12,6 +12,7 @@ namespace JS {
 
 class FunctionPrototype final : public FunctionObject {
     JS_OBJECT(FunctionPrototype, FunctionObject);
+    JS_DECLARE_ALLOCATOR(FunctionPrototype);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/GeneratorFunctionConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/GeneratorFunctionConstructor.cpp
@@ -11,6 +11,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(GeneratorFunctionConstructor);
+
 GeneratorFunctionConstructor::GeneratorFunctionConstructor(Realm& realm)
     : NativeFunction(static_cast<Object&>(realm.intrinsics().function_constructor()))
 {

--- a/Userland/Libraries/LibJS/Runtime/GeneratorFunctionConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/GeneratorFunctionConstructor.h
@@ -13,6 +13,7 @@ namespace JS {
 // 27.3.1 %GeneratorFunction%, https://tc39.es/ecma262/#sec-generatorfunction-constructor
 class GeneratorFunctionConstructor final : public NativeFunction {
     JS_OBJECT(GeneratorFunctionConstructor, NativeFunction);
+    JS_DECLARE_ALLOCATOR(GeneratorFunctionConstructor);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/GeneratorFunctionPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/GeneratorFunctionPrototype.cpp
@@ -10,6 +10,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(GeneratorFunctionPrototype);
+
 GeneratorFunctionPrototype::GeneratorFunctionPrototype(Realm& realm)
     : Object(ConstructWithPrototypeTag::Tag, realm.intrinsics().function_prototype())
 {

--- a/Userland/Libraries/LibJS/Runtime/GeneratorFunctionPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/GeneratorFunctionPrototype.h
@@ -14,6 +14,7 @@ namespace JS {
 // 27.3.3 %GeneratorFunction.prototype%, https://tc39.es/ecma262/#sec-properties-of-the-generatorfunction-prototype-object
 class GeneratorFunctionPrototype final : public Object {
     JS_OBJECT(GeneratorFunctionPrototype, Object);
+    JS_DECLARE_ALLOCATOR(GeneratorFunctionPrototype);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/GeneratorObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/GeneratorObject.cpp
@@ -14,6 +14,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(GeneratorObject);
+
 ThrowCompletionOr<NonnullGCPtr<GeneratorObject>> GeneratorObject::create(Realm& realm, Value initial_value, ECMAScriptFunctionObject* generating_function, ExecutionContext execution_context, Bytecode::CallFrame frame)
 {
     auto& vm = realm.vm();

--- a/Userland/Libraries/LibJS/Runtime/GeneratorObject.h
+++ b/Userland/Libraries/LibJS/Runtime/GeneratorObject.h
@@ -14,6 +14,7 @@ namespace JS {
 
 class GeneratorObject : public Object {
     JS_OBJECT(GeneratorObject, Object);
+    JS_DECLARE_ALLOCATOR(GeneratorObject);
 
 public:
     static ThrowCompletionOr<NonnullGCPtr<GeneratorObject>> create(Realm&, Value, ECMAScriptFunctionObject*, ExecutionContext, Bytecode::CallFrame);

--- a/Userland/Libraries/LibJS/Runtime/GeneratorPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/GeneratorPrototype.cpp
@@ -9,6 +9,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(GeneratorPrototype);
+
 GeneratorPrototype::GeneratorPrototype(Realm& realm)
     : PrototypeObject(realm.intrinsics().iterator_prototype())
 {

--- a/Userland/Libraries/LibJS/Runtime/GeneratorPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/GeneratorPrototype.h
@@ -14,6 +14,7 @@ namespace JS {
 // 27.5.1 Properties of the Generator Prototype Object, https://tc39.es/ecma262/#sec-properties-of-generator-prototype
 class GeneratorPrototype final : public PrototypeObject<GeneratorPrototype, GeneratorObject> {
     JS_PROTOTYPE_OBJECT(GeneratorPrototype, GeneratorObject, Generator);
+    JS_DECLARE_ALLOCATOR(GeneratorPrototype);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/GlobalEnvironment.cpp
+++ b/Userland/Libraries/LibJS/Runtime/GlobalEnvironment.cpp
@@ -14,6 +14,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(GlobalEnvironment);
+
 // 9.1.2.5 NewGlobalEnvironment ( G, thisValue ), https://tc39.es/ecma262/#sec-newglobalenvironment
 GlobalEnvironment::GlobalEnvironment(Object& global_object, Object& this_value)
     : Environment(nullptr)

--- a/Userland/Libraries/LibJS/Runtime/GlobalEnvironment.h
+++ b/Userland/Libraries/LibJS/Runtime/GlobalEnvironment.h
@@ -12,6 +12,7 @@ namespace JS {
 
 class GlobalEnvironment final : public Environment {
     JS_ENVIRONMENT(GlobalEnvironment, Environment);
+    JS_DECLARE_ALLOCATOR(GlobalEnvironment);
 
 public:
     virtual bool has_this_binding() const final { return true; }

--- a/Userland/Libraries/LibJS/Runtime/GlobalObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/GlobalObject.cpp
@@ -87,6 +87,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(GlobalObject);
+
 GlobalObject::GlobalObject(Realm& realm)
     : Object(GlobalObjectTag::Tag, realm)
 {

--- a/Userland/Libraries/LibJS/Runtime/GlobalObject.h
+++ b/Userland/Libraries/LibJS/Runtime/GlobalObject.h
@@ -15,6 +15,7 @@ namespace JS {
 
 class GlobalObject : public Object {
     JS_OBJECT(GlobalObject, Object);
+    JS_DECLARE_ALLOCATOR(GlobalObject);
 
     friend class Intrinsics;
 

--- a/Userland/Libraries/LibJS/Runtime/Intl/Collator.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/Collator.cpp
@@ -8,6 +8,8 @@
 
 namespace JS::Intl {
 
+JS_DEFINE_ALLOCATOR(Collator);
+
 // 10 Collator Objects, https://tc39.es/ecma402/#collator-objects
 Collator::Collator(Object& prototype)
     : Object(ConstructWithPrototypeTag::Tag, prototype)

--- a/Userland/Libraries/LibJS/Runtime/Intl/Collator.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/Collator.h
@@ -16,6 +16,7 @@ namespace JS::Intl {
 
 class Collator final : public Object {
     JS_OBJECT(Collator, Object);
+    JS_DECLARE_ALLOCATOR(Collator);
 
 public:
     enum class Usage {

--- a/Userland/Libraries/LibJS/Runtime/Intl/CollatorCompareFunction.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/CollatorCompareFunction.cpp
@@ -11,6 +11,8 @@
 
 namespace JS::Intl {
 
+JS_DEFINE_ALLOCATOR(CollatorCompareFunction);
+
 NonnullGCPtr<CollatorCompareFunction> CollatorCompareFunction::create(Realm& realm, Collator& collator)
 {
     return realm.heap().allocate<CollatorCompareFunction>(realm, realm, collator);

--- a/Userland/Libraries/LibJS/Runtime/Intl/CollatorCompareFunction.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/CollatorCompareFunction.h
@@ -12,6 +12,7 @@ namespace JS::Intl {
 
 class CollatorCompareFunction : public NativeFunction {
     JS_OBJECT(CollatorCompareFunction, NativeFunction);
+    JS_DECLARE_ALLOCATOR(CollatorCompareFunction);
 
 public:
     static NonnullGCPtr<CollatorCompareFunction> create(Realm&, Collator&);

--- a/Userland/Libraries/LibJS/Runtime/Intl/CollatorConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/CollatorConstructor.cpp
@@ -14,6 +14,8 @@
 
 namespace JS::Intl {
 
+JS_DEFINE_ALLOCATOR(CollatorConstructor);
+
 // 10.1.2 InitializeCollator ( collator, locales, options ), https://tc39.es/ecma402/#sec-initializecollator
 static ThrowCompletionOr<NonnullGCPtr<Collator>> initialize_collator(VM& vm, Collator& collator, Value locales_value, Value options_value)
 {

--- a/Userland/Libraries/LibJS/Runtime/Intl/CollatorConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/CollatorConstructor.h
@@ -12,6 +12,7 @@ namespace JS::Intl {
 
 class CollatorConstructor final : public NativeFunction {
     JS_OBJECT(CollatorConstructor, NativeFunction);
+    JS_DECLARE_ALLOCATOR(CollatorConstructor);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/Intl/CollatorPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/CollatorPrototype.cpp
@@ -11,6 +11,8 @@
 
 namespace JS::Intl {
 
+JS_DEFINE_ALLOCATOR(CollatorPrototype);
+
 // 10.3 Properties of the Intl.Collator Prototype Object, https://tc39.es/ecma402/#sec-properties-of-the-intl-collator-prototype-object
 CollatorPrototype::CollatorPrototype(Realm& realm)
     : PrototypeObject(realm.intrinsics().object_prototype())

--- a/Userland/Libraries/LibJS/Runtime/Intl/CollatorPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/CollatorPrototype.h
@@ -13,6 +13,7 @@ namespace JS::Intl {
 
 class CollatorPrototype final : public PrototypeObject<CollatorPrototype, Collator> {
     JS_PROTOTYPE_OBJECT(CollatorPrototype, Collator, Collator);
+    JS_DECLARE_ALLOCATOR(CollatorPrototype);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.cpp
@@ -24,6 +24,8 @@
 
 namespace JS::Intl {
 
+JS_DEFINE_ALLOCATOR(DateTimeFormat);
+
 static Crypto::SignedBigInteger const s_one_million_bigint { 1'000'000 };
 
 // 11 DateTimeFormat Objects, https://tc39.es/ecma402/#datetimeformat-objects

--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.h
@@ -23,6 +23,7 @@ class DateTimeFormat final
     : public Object
     , public ::Locale::CalendarPattern {
     JS_OBJECT(DateTimeFormat, Object);
+    JS_DECLARE_ALLOCATOR(DateTimeFormat);
 
     using Patterns = ::Locale::CalendarPattern;
 

--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormatConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormatConstructor.cpp
@@ -17,6 +17,8 @@
 
 namespace JS::Intl {
 
+JS_DEFINE_ALLOCATOR(DateTimeFormatConstructor);
+
 // 11.1 The Intl.DateTimeFormat Constructor, https://tc39.es/ecma402/#sec-intl-datetimeformat-constructor
 DateTimeFormatConstructor::DateTimeFormatConstructor(Realm& realm)
     : NativeFunction(realm.vm().names.DateTimeFormat.as_string(), realm.intrinsics().function_prototype())

--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormatConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormatConstructor.h
@@ -12,6 +12,7 @@ namespace JS::Intl {
 
 class DateTimeFormatConstructor final : public NativeFunction {
     JS_OBJECT(DateTimeFormatConstructor, NativeFunction);
+    JS_DECLARE_ALLOCATOR(DateTimeFormatConstructor);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormatFunction.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormatFunction.cpp
@@ -14,6 +14,8 @@
 
 namespace JS::Intl {
 
+JS_DEFINE_ALLOCATOR(DateTimeFormatFunction);
+
 // 11.5.4 DateTime Format Functions, https://tc39.es/ecma402/#sec-datetime-format-functions
 NonnullGCPtr<DateTimeFormatFunction> DateTimeFormatFunction::create(Realm& realm, DateTimeFormat& date_time_format)
 {

--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormatFunction.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormatFunction.h
@@ -14,6 +14,7 @@ namespace JS::Intl {
 
 class DateTimeFormatFunction final : public NativeFunction {
     JS_OBJECT(DateTimeFormatFunction, NativeFunction);
+    JS_DECLARE_ALLOCATOR(DateTimeFormatFunction);
 
 public:
     static NonnullGCPtr<DateTimeFormatFunction> create(Realm&, DateTimeFormat&);

--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormatPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormatPrototype.cpp
@@ -14,6 +14,8 @@
 
 namespace JS::Intl {
 
+JS_DEFINE_ALLOCATOR(DateTimeFormatPrototype);
+
 // 11.3 Properties of the Intl.DateTimeFormat Prototype Object, https://tc39.es/ecma402/#sec-properties-of-intl-datetimeformat-prototype-object
 DateTimeFormatPrototype::DateTimeFormatPrototype(Realm& realm)
     : PrototypeObject(realm.intrinsics().object_prototype())

--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormatPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormatPrototype.h
@@ -13,6 +13,7 @@ namespace JS::Intl {
 
 class DateTimeFormatPrototype final : public PrototypeObject<DateTimeFormatPrototype, DateTimeFormat> {
     JS_PROTOTYPE_OBJECT(DateTimeFormatPrototype, DateTimeFormat, Intl.DateTimeFormat);
+    JS_DECLARE_ALLOCATOR(DateTimeFormatPrototype);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/Intl/DisplayNames.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DisplayNames.cpp
@@ -10,6 +10,8 @@
 
 namespace JS::Intl {
 
+JS_DEFINE_ALLOCATOR(DisplayNames);
+
 // 12 DisplayNames Objects, https://tc39.es/ecma402/#intl-displaynames-objects
 DisplayNames::DisplayNames(Object& prototype)
     : Object(ConstructWithPrototypeTag::Tag, prototype)

--- a/Userland/Libraries/LibJS/Runtime/Intl/DisplayNames.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DisplayNames.h
@@ -16,6 +16,7 @@ namespace JS::Intl {
 
 class DisplayNames final : public Object {
     JS_OBJECT(DisplayNames, Object);
+    JS_DECLARE_ALLOCATOR(DisplayNames);
 
     enum class Type {
         Invalid,

--- a/Userland/Libraries/LibJS/Runtime/Intl/DisplayNamesConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DisplayNamesConstructor.cpp
@@ -15,6 +15,8 @@
 
 namespace JS::Intl {
 
+JS_DEFINE_ALLOCATOR(DisplayNamesConstructor);
+
 // 12.1 The Intl.DisplayNames Constructor, https://tc39.es/ecma402/#sec-intl-displaynames-constructor
 DisplayNamesConstructor::DisplayNamesConstructor(Realm& realm)
     : NativeFunction(realm.vm().names.DisplayNames.as_string(), realm.intrinsics().function_prototype())

--- a/Userland/Libraries/LibJS/Runtime/Intl/DisplayNamesConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DisplayNamesConstructor.h
@@ -12,6 +12,7 @@ namespace JS::Intl {
 
 class DisplayNamesConstructor final : public NativeFunction {
     JS_OBJECT(DisplayNamesConstructor, NativeFunction);
+    JS_DECLARE_ALLOCATOR(DisplayNamesConstructor);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/Intl/DisplayNamesPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DisplayNamesPrototype.cpp
@@ -13,6 +13,8 @@
 
 namespace JS::Intl {
 
+JS_DEFINE_ALLOCATOR(DisplayNamesPrototype);
+
 // 12.3 Properties of the Intl.DisplayNames Prototype Object, https://tc39.es/ecma402/#sec-properties-of-intl-displaynames-prototype-object
 DisplayNamesPrototype::DisplayNamesPrototype(Realm& realm)
     : PrototypeObject(realm.intrinsics().object_prototype())

--- a/Userland/Libraries/LibJS/Runtime/Intl/DisplayNamesPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DisplayNamesPrototype.h
@@ -13,6 +13,7 @@ namespace JS::Intl {
 
 class DisplayNamesPrototype final : public PrototypeObject<DisplayNamesPrototype, DisplayNames> {
     JS_PROTOTYPE_OBJECT(DisplayNamesPrototype, DisplayNames, Intl.DisplayNames);
+    JS_DECLARE_ALLOCATOR(DisplayNamesPrototype);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/Intl/DurationFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DurationFormat.cpp
@@ -20,6 +20,8 @@
 
 namespace JS::Intl {
 
+JS_DEFINE_ALLOCATOR(DurationFormat);
+
 // 1 DurationFormat Objects, https://tc39.es/proposal-intl-duration-format/#durationformat-objects
 DurationFormat::DurationFormat(Object& prototype)
     : Object(ConstructWithPrototypeTag::Tag, prototype)

--- a/Userland/Libraries/LibJS/Runtime/Intl/DurationFormat.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DurationFormat.h
@@ -17,6 +17,7 @@ namespace JS::Intl {
 
 class DurationFormat final : public Object {
     JS_OBJECT(DurationFormat, Object);
+    JS_DECLARE_ALLOCATOR(DurationFormat);
 
 public:
     enum class Style {

--- a/Userland/Libraries/LibJS/Runtime/Intl/DurationFormatConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DurationFormatConstructor.cpp
@@ -14,6 +14,8 @@
 
 namespace JS::Intl {
 
+JS_DEFINE_ALLOCATOR(DurationFormatConstructor);
+
 // 1.2 The Intl.DurationFormat Constructor, https://tc39.es/proposal-intl-duration-format/#sec-intl-durationformat-constructor
 DurationFormatConstructor::DurationFormatConstructor(Realm& realm)
     : NativeFunction(realm.vm().names.DurationFormat.as_string(), realm.intrinsics().function_prototype())

--- a/Userland/Libraries/LibJS/Runtime/Intl/DurationFormatConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DurationFormatConstructor.h
@@ -12,6 +12,7 @@ namespace JS::Intl {
 
 class DurationFormatConstructor final : public NativeFunction {
     JS_OBJECT(DurationFormatConstructor, NativeFunction);
+    JS_DECLARE_ALLOCATOR(DurationFormatConstructor);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/Intl/DurationFormatPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DurationFormatPrototype.cpp
@@ -12,6 +12,8 @@
 
 namespace JS::Intl {
 
+JS_DEFINE_ALLOCATOR(DurationFormatPrototype);
+
 // 1.4 Properties of the Intl.DurationFormat Prototype Object, https://tc39.es/proposal-intl-duration-format/#sec-properties-of-intl-durationformat-prototype-object
 DurationFormatPrototype::DurationFormatPrototype(Realm& realm)
     : PrototypeObject(realm.intrinsics().object_prototype())

--- a/Userland/Libraries/LibJS/Runtime/Intl/DurationFormatPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DurationFormatPrototype.h
@@ -13,6 +13,7 @@ namespace JS::Intl {
 
 class DurationFormatPrototype final : public PrototypeObject<DurationFormatPrototype, DurationFormat> {
     JS_PROTOTYPE_OBJECT(DurationFormatPrototype, DurationFormat, Intl.DurationFormat);
+    JS_DECLARE_ALLOCATOR(DurationFormatPrototype);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/Intl/Intl.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/Intl.cpp
@@ -26,6 +26,8 @@
 
 namespace JS::Intl {
 
+JS_DEFINE_ALLOCATOR(Intl);
+
 // 8 The Intl Object, https://tc39.es/ecma402/#intl-object
 Intl::Intl(Realm& realm)
     : Object(ConstructWithPrototypeTag::Tag, realm.intrinsics().object_prototype())

--- a/Userland/Libraries/LibJS/Runtime/Intl/Intl.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/Intl.h
@@ -12,6 +12,7 @@ namespace JS::Intl {
 
 class Intl final : public Object {
     JS_OBJECT(Intl, Object);
+    JS_DECLARE_ALLOCATOR(Intl);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/Intl/ListFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/ListFormat.cpp
@@ -12,6 +12,8 @@
 
 namespace JS::Intl {
 
+JS_DEFINE_ALLOCATOR(ListFormat);
+
 // 13 ListFormat Objects, https://tc39.es/ecma402/#listformat-objects
 ListFormat::ListFormat(Object& prototype)
     : Object(ConstructWithPrototypeTag::Tag, prototype)

--- a/Userland/Libraries/LibJS/Runtime/Intl/ListFormat.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/ListFormat.h
@@ -19,6 +19,7 @@ namespace JS::Intl {
 
 class ListFormat final : public Object {
     JS_OBJECT(ListFormat, Object);
+    JS_DECLARE_ALLOCATOR(ListFormat);
 
 public:
     enum class Type {

--- a/Userland/Libraries/LibJS/Runtime/Intl/ListFormatConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/ListFormatConstructor.cpp
@@ -14,6 +14,8 @@
 
 namespace JS::Intl {
 
+JS_DEFINE_ALLOCATOR(ListFormatConstructor);
+
 // 13.1 The Intl.ListFormat Constructor, https://tc39.es/ecma402/#sec-intl-listformat-constructor
 ListFormatConstructor::ListFormatConstructor(Realm& realm)
     : NativeFunction(realm.vm().names.ListFormat.as_string(), realm.intrinsics().function_prototype())

--- a/Userland/Libraries/LibJS/Runtime/Intl/ListFormatConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/ListFormatConstructor.h
@@ -12,6 +12,7 @@ namespace JS::Intl {
 
 class ListFormatConstructor final : public NativeFunction {
     JS_OBJECT(ListFormatConstructor, NativeFunction);
+    JS_DECLARE_ALLOCATOR(ListFormatConstructor);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/Intl/ListFormatPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/ListFormatPrototype.cpp
@@ -12,6 +12,8 @@
 
 namespace JS::Intl {
 
+JS_DEFINE_ALLOCATOR(ListFormatPrototype);
+
 // 13.3 Properties of the Intl.ListFormat Prototype Object, https://tc39.es/ecma402/#sec-properties-of-intl-listformat-prototype-object
 ListFormatPrototype::ListFormatPrototype(Realm& realm)
     : PrototypeObject(realm.intrinsics().object_prototype())

--- a/Userland/Libraries/LibJS/Runtime/Intl/ListFormatPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/ListFormatPrototype.h
@@ -13,6 +13,7 @@ namespace JS::Intl {
 
 class ListFormatPrototype final : public PrototypeObject<ListFormatPrototype, ListFormat> {
     JS_PROTOTYPE_OBJECT(ListFormatPrototype, ListFormat, Intl.ListFormat);
+    JS_DECLARE_ALLOCATOR(ListFormatPrototype);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/Intl/Locale.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/Locale.cpp
@@ -14,6 +14,8 @@
 
 namespace JS::Intl {
 
+JS_DEFINE_ALLOCATOR(Locale);
+
 NonnullGCPtr<Locale> Locale::create(Realm& realm, ::Locale::LocaleID locale_id)
 {
     auto locale = realm.heap().allocate<Locale>(realm, realm.intrinsics().intl_locale_prototype());

--- a/Userland/Libraries/LibJS/Runtime/Intl/Locale.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/Locale.h
@@ -20,6 +20,7 @@ namespace JS::Intl {
 
 class Locale final : public Object {
     JS_OBJECT(Locale, Object);
+    JS_DECLARE_ALLOCATOR(Locale);
 
 public:
     static NonnullGCPtr<Locale> create(Realm&, ::Locale::LocaleID);

--- a/Userland/Libraries/LibJS/Runtime/Intl/LocaleConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/LocaleConstructor.cpp
@@ -16,6 +16,8 @@
 
 namespace JS::Intl {
 
+JS_DEFINE_ALLOCATOR(LocaleConstructor);
+
 struct LocaleAndKeys {
     String locale;
     Optional<String> ca;

--- a/Userland/Libraries/LibJS/Runtime/Intl/LocaleConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/LocaleConstructor.h
@@ -12,6 +12,7 @@ namespace JS::Intl {
 
 class LocaleConstructor final : public NativeFunction {
     JS_OBJECT(LocaleConstructor, NativeFunction);
+    JS_DECLARE_ALLOCATOR(LocaleConstructor);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/Intl/LocalePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/LocalePrototype.cpp
@@ -13,6 +13,8 @@
 
 namespace JS::Intl {
 
+JS_DEFINE_ALLOCATOR(LocalePrototype);
+
 // 14.3 Properties of the Intl.Locale Prototype Object, https://tc39.es/ecma402/#sec-properties-of-intl-locale-prototype-object
 LocalePrototype::LocalePrototype(Realm& realm)
     : PrototypeObject(realm.intrinsics().object_prototype())

--- a/Userland/Libraries/LibJS/Runtime/Intl/LocalePrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/LocalePrototype.h
@@ -13,6 +13,7 @@ namespace JS::Intl {
 
 class LocalePrototype final : public PrototypeObject<LocalePrototype, Locale> {
     JS_PROTOTYPE_OBJECT(LocalePrototype, Locale, Intl.Locale);
+    JS_DECLARE_ALLOCATOR(LocalePrototype);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.cpp
@@ -22,6 +22,9 @@
 
 namespace JS::Intl {
 
+JS_DEFINE_ALLOCATOR(NumberFormatBase);
+JS_DEFINE_ALLOCATOR(NumberFormat);
+
 NumberFormatBase::NumberFormatBase(Object& prototype)
     : Object(ConstructWithPrototypeTag::Tag, prototype)
 {

--- a/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.h
@@ -19,6 +19,7 @@ namespace JS::Intl {
 
 class NumberFormatBase : public Object {
     JS_OBJECT(NumberFormatBase, Object);
+    JS_DECLARE_ALLOCATOR(NumberFormatBase);
 
 public:
     enum class RoundingType {
@@ -129,6 +130,7 @@ private:
 
 class NumberFormat final : public NumberFormatBase {
     JS_OBJECT(NumberFormat, NumberFormatBase);
+    JS_DECLARE_ALLOCATOR(NumberFormat);
 
 public:
     enum class Style {

--- a/Userland/Libraries/LibJS/Runtime/Intl/NumberFormatConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/NumberFormatConstructor.cpp
@@ -13,6 +13,8 @@
 
 namespace JS::Intl {
 
+JS_DEFINE_ALLOCATOR(NumberFormatConstructor);
+
 // 15.1 The Intl.NumberFormat Constructor, https://tc39.es/ecma402/#sec-intl-numberformat-constructor
 NumberFormatConstructor::NumberFormatConstructor(Realm& realm)
     : NativeFunction(realm.vm().names.NumberFormat.as_string(), realm.intrinsics().function_prototype())

--- a/Userland/Libraries/LibJS/Runtime/Intl/NumberFormatConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/NumberFormatConstructor.h
@@ -13,6 +13,7 @@ namespace JS::Intl {
 
 class NumberFormatConstructor final : public NativeFunction {
     JS_OBJECT(NumberFormatConstructor, NativeFunction);
+    JS_DECLARE_ALLOCATOR(NumberFormatConstructor);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/Intl/NumberFormatPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/NumberFormatPrototype.cpp
@@ -13,6 +13,8 @@
 
 namespace JS::Intl {
 
+JS_DEFINE_ALLOCATOR(NumberFormatPrototype);
+
 // 15.3 Properties of the Intl.NumberFormat Prototype Object, https://tc39.es/ecma402/#sec-properties-of-intl-numberformat-prototype-object
 NumberFormatPrototype::NumberFormatPrototype(Realm& realm)
     : PrototypeObject(realm.intrinsics().object_prototype())

--- a/Userland/Libraries/LibJS/Runtime/Intl/NumberFormatPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/NumberFormatPrototype.h
@@ -13,6 +13,7 @@ namespace JS::Intl {
 
 class NumberFormatPrototype final : public PrototypeObject<NumberFormatPrototype, NumberFormat> {
     JS_PROTOTYPE_OBJECT(NumberFormatPrototype, NumberFormat, Intl.NumberFormat);
+    JS_DECLARE_ALLOCATOR(NumberFormatPrototype);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/Intl/PluralRules.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/PluralRules.cpp
@@ -11,6 +11,8 @@
 
 namespace JS::Intl {
 
+JS_DEFINE_ALLOCATOR(PluralRules);
+
 // 16 PluralRules Objects, https://tc39.es/ecma402/#pluralrules-objects
 PluralRules::PluralRules(Object& prototype)
     : NumberFormatBase(prototype)

--- a/Userland/Libraries/LibJS/Runtime/Intl/PluralRules.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/PluralRules.h
@@ -17,6 +17,7 @@ namespace JS::Intl {
 
 class PluralRules final : public NumberFormatBase {
     JS_OBJECT(PluralRules, NumberFormatBase);
+    JS_DECLARE_ALLOCATOR(PluralRules);
 
 public:
     virtual ~PluralRules() override = default;

--- a/Userland/Libraries/LibJS/Runtime/Intl/PluralRulesConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/PluralRulesConstructor.cpp
@@ -15,6 +15,8 @@
 
 namespace JS::Intl {
 
+JS_DEFINE_ALLOCATOR(PluralRulesConstructor);
+
 // 16.1 The Intl.PluralRules Constructor, https://tc39.es/ecma402/#sec-intl-pluralrules-constructor
 PluralRulesConstructor::PluralRulesConstructor(Realm& realm)
     : NativeFunction(realm.vm().names.PluralRules.as_string(), realm.intrinsics().function_prototype())

--- a/Userland/Libraries/LibJS/Runtime/Intl/PluralRulesConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/PluralRulesConstructor.h
@@ -12,6 +12,7 @@ namespace JS::Intl {
 
 class PluralRulesConstructor final : public NativeFunction {
     JS_OBJECT(PluralRulesConstructor, NativeFunction);
+    JS_DECLARE_ALLOCATOR(PluralRulesConstructor);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/Intl/PluralRulesPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/PluralRulesPrototype.cpp
@@ -13,6 +13,8 @@
 
 namespace JS::Intl {
 
+JS_DEFINE_ALLOCATOR(PluralRulesPrototype);
+
 // 16.3 Properties of the Intl.PluralRules Prototype Object, https://tc39.es/ecma402/#sec-properties-of-intl-pluralrules-prototype-object
 PluralRulesPrototype::PluralRulesPrototype(Realm& realm)
     : PrototypeObject(realm.intrinsics().object_prototype())

--- a/Userland/Libraries/LibJS/Runtime/Intl/PluralRulesPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/PluralRulesPrototype.h
@@ -13,6 +13,7 @@ namespace JS::Intl {
 
 class PluralRulesPrototype final : public PrototypeObject<PluralRulesPrototype, PluralRules> {
     JS_PROTOTYPE_OBJECT(PluralRulesPrototype, PluralRules, Intl.PluralRules);
+    JS_DECLARE_ALLOCATOR(PluralRulesPrototype);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormat.cpp
@@ -15,6 +15,8 @@
 
 namespace JS::Intl {
 
+JS_DEFINE_ALLOCATOR(RelativeTimeFormat);
+
 // 17 RelativeTimeFormat Objects, https://tc39.es/ecma402/#relativetimeformat-objects
 RelativeTimeFormat::RelativeTimeFormat(Object& prototype)
     : Object(ConstructWithPrototypeTag::Tag, prototype)

--- a/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormat.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormat.h
@@ -19,6 +19,7 @@ namespace JS::Intl {
 
 class RelativeTimeFormat final : public Object {
     JS_OBJECT(RelativeTimeFormat, Object);
+    JS_DECLARE_ALLOCATOR(RelativeTimeFormat);
 
 public:
     enum class Numeric {

--- a/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormatConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormatConstructor.cpp
@@ -18,6 +18,8 @@
 
 namespace JS::Intl {
 
+JS_DEFINE_ALLOCATOR(RelativeTimeFormatConstructor);
+
 // 17.1 The Intl.RelativeTimeFormat Constructor, https://tc39.es/ecma402/#sec-intl-relativetimeformat-constructor
 RelativeTimeFormatConstructor::RelativeTimeFormatConstructor(Realm& realm)
     : NativeFunction(realm.vm().names.RelativeTimeFormat.as_string(), realm.intrinsics().function_prototype())

--- a/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormatConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormatConstructor.h
@@ -12,6 +12,7 @@ namespace JS::Intl {
 
 class RelativeTimeFormatConstructor final : public NativeFunction {
     JS_OBJECT(RelativeTimeFormatConstructor, NativeFunction);
+    JS_DECLARE_ALLOCATOR(RelativeTimeFormatConstructor);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormatPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormatPrototype.cpp
@@ -11,6 +11,8 @@
 
 namespace JS::Intl {
 
+JS_DEFINE_ALLOCATOR(RelativeTimeFormatPrototype);
+
 // 17.3 Properties of the Intl.RelativeTimeFormat Prototype Object, https://tc39.es/ecma402/#sec-properties-of-intl-relativetimeformat-prototype-object
 RelativeTimeFormatPrototype::RelativeTimeFormatPrototype(Realm& realm)
     : PrototypeObject(realm.intrinsics().object_prototype())

--- a/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormatPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormatPrototype.h
@@ -13,6 +13,7 @@ namespace JS::Intl {
 
 class RelativeTimeFormatPrototype final : public PrototypeObject<RelativeTimeFormatPrototype, RelativeTimeFormat> {
     JS_PROTOTYPE_OBJECT(RelativeTimeFormatPrototype, RelativeTimeFormat, Intl.RelativeTimeFormat);
+    JS_DECLARE_ALLOCATOR(RelativeTimeFormatPrototype);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/Intl/SegmentIterator.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/SegmentIterator.cpp
@@ -10,6 +10,8 @@
 
 namespace JS::Intl {
 
+JS_DEFINE_ALLOCATOR(SegmentIterator);
+
 // 18.6.1 CreateSegmentIterator ( segmenter, string ), https://tc39.es/ecma402/#sec-createsegmentsobject
 NonnullGCPtr<SegmentIterator> SegmentIterator::create(Realm& realm, Segmenter& segmenter, Utf16View const& string, Segments const& segments)
 {

--- a/Userland/Libraries/LibJS/Runtime/Intl/SegmentIterator.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/SegmentIterator.h
@@ -14,6 +14,7 @@ namespace JS::Intl {
 
 class SegmentIterator final : public Object {
     JS_OBJECT(SegmentIterator, Object);
+    JS_DECLARE_ALLOCATOR(SegmentIterator);
 
 public:
     static NonnullGCPtr<SegmentIterator> create(Realm&, Segmenter&, Utf16View const&, Segments const&);

--- a/Userland/Libraries/LibJS/Runtime/Intl/SegmentIteratorPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/SegmentIteratorPrototype.cpp
@@ -12,6 +12,8 @@
 
 namespace JS::Intl {
 
+JS_DEFINE_ALLOCATOR(SegmentIteratorPrototype);
+
 // 18.6.2 The %SegmentIteratorPrototype% Object, https://tc39.es/ecma402/#sec-%segmentiteratorprototype%-object
 SegmentIteratorPrototype::SegmentIteratorPrototype(Realm& realm)
     : PrototypeObject(realm.intrinsics().iterator_prototype())

--- a/Userland/Libraries/LibJS/Runtime/Intl/SegmentIteratorPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/SegmentIteratorPrototype.h
@@ -13,6 +13,7 @@ namespace JS::Intl {
 
 class SegmentIteratorPrototype final : public PrototypeObject<SegmentIteratorPrototype, SegmentIterator> {
     JS_PROTOTYPE_OBJECT(SegmentIteratorPrototype, SegmentIterator, SegmentIterator);
+    JS_DECLARE_ALLOCATOR(SegmentIteratorPrototype);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/Intl/Segmenter.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/Segmenter.cpp
@@ -12,6 +12,8 @@
 
 namespace JS::Intl {
 
+JS_DEFINE_ALLOCATOR(Segmenter);
+
 // 18 Segmenter Objects, https://tc39.es/ecma402/#segmenter-objects
 Segmenter::Segmenter(Object& prototype)
     : Object(ConstructWithPrototypeTag::Tag, prototype)

--- a/Userland/Libraries/LibJS/Runtime/Intl/Segmenter.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/Segmenter.h
@@ -14,6 +14,7 @@ namespace JS::Intl {
 
 class Segmenter final : public Object {
     JS_OBJECT(Segmenter, Object);
+    JS_DECLARE_ALLOCATOR(Segmenter);
 
 public:
     enum class SegmenterGranularity {

--- a/Userland/Libraries/LibJS/Runtime/Intl/SegmenterConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/SegmenterConstructor.cpp
@@ -15,6 +15,8 @@
 
 namespace JS::Intl {
 
+JS_DEFINE_ALLOCATOR(SegmenterConstructor);
+
 // 18.1 The Intl.Segmenter Constructor, https://tc39.es/ecma402/#sec-intl-segmenter-constructor
 SegmenterConstructor::SegmenterConstructor(Realm& realm)
     : NativeFunction(realm.vm().names.Segmenter.as_string(), realm.intrinsics().function_prototype())

--- a/Userland/Libraries/LibJS/Runtime/Intl/SegmenterConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/SegmenterConstructor.h
@@ -12,6 +12,7 @@ namespace JS::Intl {
 
 class SegmenterConstructor final : public NativeFunction {
     JS_OBJECT(SegmenterConstructor, NativeFunction);
+    JS_DECLARE_ALLOCATOR(SegmenterConstructor);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/Intl/SegmenterPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/SegmenterPrototype.cpp
@@ -11,6 +11,8 @@
 
 namespace JS::Intl {
 
+JS_DEFINE_ALLOCATOR(SegmenterPrototype);
+
 // 18.3 Properties of the Intl.Segmenter Prototype Object, https://tc39.es/ecma402/#sec-properties-of-intl-segmenter-prototype-object
 SegmenterPrototype::SegmenterPrototype(Realm& realm)
     : PrototypeObject(realm.intrinsics().object_prototype())

--- a/Userland/Libraries/LibJS/Runtime/Intl/SegmenterPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/SegmenterPrototype.h
@@ -13,6 +13,7 @@ namespace JS::Intl {
 
 class SegmenterPrototype final : public PrototypeObject<SegmenterPrototype, Segmenter> {
     JS_PROTOTYPE_OBJECT(SegmenterPrototype, Segmenter, Segmenter);
+    JS_DECLARE_ALLOCATOR(SegmenterPrototype);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/Intl/Segments.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/Segments.cpp
@@ -10,6 +10,8 @@
 
 namespace JS::Intl {
 
+JS_DEFINE_ALLOCATOR(Segments);
+
 // 18.5.1 CreateSegmentsObject ( segmenter, string ), https://tc39.es/ecma402/#sec-createsegmentsobject
 NonnullGCPtr<Segments> Segments::create(Realm& realm, Segmenter& segmenter, Utf16String string)
 {

--- a/Userland/Libraries/LibJS/Runtime/Intl/Segments.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/Segments.h
@@ -14,6 +14,7 @@ namespace JS::Intl {
 
 class Segments final : public Object {
     JS_OBJECT(Segments, Object);
+    JS_DECLARE_ALLOCATOR(Segments);
 
 public:
     static NonnullGCPtr<Segments> create(Realm&, Segmenter&, Utf16String);

--- a/Userland/Libraries/LibJS/Runtime/Intl/SegmentsPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/SegmentsPrototype.cpp
@@ -11,6 +11,8 @@
 
 namespace JS::Intl {
 
+JS_DEFINE_ALLOCATOR(SegmentsPrototype);
+
 // 18.5.2 The %SegmentsPrototype% Object, https://tc39.es/ecma402/#sec-%segmentsprototype%-object
 SegmentsPrototype::SegmentsPrototype(Realm& realm)
     : PrototypeObject(realm.intrinsics().object_prototype())

--- a/Userland/Libraries/LibJS/Runtime/Intl/SegmentsPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/SegmentsPrototype.h
@@ -13,6 +13,7 @@ namespace JS::Intl {
 
 class SegmentsPrototype final : public PrototypeObject<SegmentsPrototype, Segments> {
     JS_PROTOTYPE_OBJECT(SegmentsPrototype, Segments, Segments);
+    JS_DECLARE_ALLOCATOR(SegmentsPrototype);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/Intrinsics.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intrinsics.cpp
@@ -133,6 +133,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(Intrinsics);
+
 static void initialize_constructor(VM& vm, PropertyKey const& property_key, Object& constructor, Object* prototype, PropertyAttributes constructor_property_attributes = Attribute::Writable | Attribute::Configurable)
 {
     constructor.define_direct_property(vm.names.name, PrimitiveString::create(vm, property_key.as_string()), Attribute::Configurable);

--- a/Userland/Libraries/LibJS/Runtime/Intrinsics.h
+++ b/Userland/Libraries/LibJS/Runtime/Intrinsics.h
@@ -13,6 +13,7 @@ namespace JS {
 
 class Intrinsics final : public Cell {
     JS_CELL(Intrinsics, Cell);
+    JS_DECLARE_ALLOCATOR(Intrinsics);
 
 public:
     static ThrowCompletionOr<NonnullGCPtr<Intrinsics>> create(Realm&);

--- a/Userland/Libraries/LibJS/Runtime/Iterator.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Iterator.cpp
@@ -16,6 +16,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(Iterator);
+
 NonnullGCPtr<Iterator> Iterator::create(Realm& realm, Object& prototype, IteratorRecord iterated)
 {
     return realm.heap().allocate<Iterator>(realm, prototype, move(iterated));

--- a/Userland/Libraries/LibJS/Runtime/Iterator.h
+++ b/Userland/Libraries/LibJS/Runtime/Iterator.h
@@ -25,6 +25,7 @@ struct IteratorRecord {
 
 class Iterator : public Object {
     JS_OBJECT(Iterator, Object);
+    JS_DECLARE_ALLOCATOR(Iterator);
 
 public:
     static NonnullGCPtr<Iterator> create(Realm&, Object& prototype, IteratorRecord iterated);

--- a/Userland/Libraries/LibJS/Runtime/IteratorConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/IteratorConstructor.cpp
@@ -14,6 +14,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(IteratorConstructor);
+
 // 3.1.1.1 The Iterator Constructor, https://tc39.es/proposal-iterator-helpers/#sec-iterator-constructor
 IteratorConstructor::IteratorConstructor(Realm& realm)
     : Base(realm.vm().names.Iterator.as_string(), realm.intrinsics().function_prototype())

--- a/Userland/Libraries/LibJS/Runtime/IteratorConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/IteratorConstructor.h
@@ -13,6 +13,7 @@ namespace JS {
 
 class IteratorConstructor : public NativeFunction {
     JS_OBJECT(IteratorConstructor, NativeFunction);
+    JS_DECLARE_ALLOCATOR(IteratorConstructor);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/IteratorHelper.cpp
+++ b/Userland/Libraries/LibJS/Runtime/IteratorHelper.cpp
@@ -11,6 +11,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(IteratorHelper);
+
 ThrowCompletionOr<NonnullGCPtr<IteratorHelper>> IteratorHelper::create(Realm& realm, IteratorRecord underlying_iterator, Closure closure, Optional<AbruptClosure> abrupt_closure)
 {
     return realm.heap().allocate<IteratorHelper>(realm, realm, realm.intrinsics().iterator_helper_prototype(), move(underlying_iterator), move(closure), move(abrupt_closure));

--- a/Userland/Libraries/LibJS/Runtime/IteratorHelper.h
+++ b/Userland/Libraries/LibJS/Runtime/IteratorHelper.h
@@ -16,6 +16,7 @@ namespace JS {
 
 class IteratorHelper final : public GeneratorObject {
     JS_OBJECT(IteratorHelper, GeneratorObject);
+    JS_DECLARE_ALLOCATOR(IteratorHelper);
 
 public:
     using Closure = JS::SafeFunction<ThrowCompletionOr<Value>(VM&, IteratorHelper&)>;

--- a/Userland/Libraries/LibJS/Runtime/IteratorHelperPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/IteratorHelperPrototype.cpp
@@ -10,6 +10,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(IteratorHelperPrototype);
+
 IteratorHelperPrototype::IteratorHelperPrototype(Realm& realm)
     : PrototypeObject(realm.intrinsics().iterator_prototype())
 {

--- a/Userland/Libraries/LibJS/Runtime/IteratorHelperPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/IteratorHelperPrototype.h
@@ -13,6 +13,7 @@ namespace JS {
 
 class IteratorHelperPrototype final : public PrototypeObject<IteratorHelperPrototype, IteratorHelper> {
     JS_PROTOTYPE_OBJECT(IteratorHelperPrototype, IteratorHelper, IteratorHelper);
+    JS_DECLARE_ALLOCATOR(IteratorHelperPrototype);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/IteratorPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/IteratorPrototype.cpp
@@ -16,6 +16,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(IteratorPrototype);
+
 // 27.1.2 The %IteratorPrototype% Object, https://tc39.es/ecma262/#sec-%iteratorprototype%-object
 IteratorPrototype::IteratorPrototype(Realm& realm)
     : PrototypeObject(realm.intrinsics().object_prototype())
@@ -311,6 +313,7 @@ JS_DEFINE_NATIVE_FUNCTION(IteratorPrototype::drop)
 
 class FlatMapIterator : public Cell {
     JS_CELL(FlatMapIterator, Cell);
+    JS_DECLARE_ALLOCATOR(FlatMapIterator);
 
 public:
     ThrowCompletionOr<Value> next(VM& vm, IteratorRecord const& iterated, IteratorHelper& iterator, FunctionObject& mapper)
@@ -421,6 +424,8 @@ private:
 
     Optional<IteratorRecord> m_inner_iterator;
 };
+
+JS_DEFINE_ALLOCATOR(FlatMapIterator);
 
 // 3.1.3.6 Iterator.prototype.flatMap ( mapper ), https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.flatmap
 JS_DEFINE_NATIVE_FUNCTION(IteratorPrototype::flat_map)

--- a/Userland/Libraries/LibJS/Runtime/IteratorPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/IteratorPrototype.h
@@ -13,6 +13,7 @@ namespace JS {
 
 class IteratorPrototype : public PrototypeObject<IteratorPrototype, Iterator> {
     JS_PROTOTYPE_OBJECT(IteratorPrototype, Iterator, Iterator);
+    JS_DECLARE_ALLOCATOR(IteratorPrototype);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/JSONObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/JSONObject.cpp
@@ -27,6 +27,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(JSONObject);
+
 JSONObject::JSONObject(Realm& realm)
     : Object(ConstructWithPrototypeTag::Tag, realm.intrinsics().object_prototype())
 {

--- a/Userland/Libraries/LibJS/Runtime/JSONObject.h
+++ b/Userland/Libraries/LibJS/Runtime/JSONObject.h
@@ -12,6 +12,7 @@ namespace JS {
 
 class JSONObject final : public Object {
     JS_OBJECT(JSONObject, Object);
+    JS_DECLARE_ALLOCATOR(JSONObject);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/Map.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Map.cpp
@@ -8,6 +8,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(Map);
+
 NonnullGCPtr<Map> Map::create(Realm& realm)
 {
     return realm.heap().allocate<Map>(realm, realm.intrinsics().map_prototype());

--- a/Userland/Libraries/LibJS/Runtime/Map.h
+++ b/Userland/Libraries/LibJS/Runtime/Map.h
@@ -17,6 +17,7 @@ namespace JS {
 
 class Map : public Object {
     JS_OBJECT(Map, Object);
+    JS_DECLARE_ALLOCATOR(Map);
 
 public:
     static NonnullGCPtr<Map> create(Realm&);

--- a/Userland/Libraries/LibJS/Runtime/MapConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/MapConstructor.cpp
@@ -14,6 +14,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(MapConstructor);
+
 MapConstructor::MapConstructor(Realm& realm)
     : NativeFunction(realm.vm().names.Map.as_string(), realm.intrinsics().function_prototype())
 {

--- a/Userland/Libraries/LibJS/Runtime/MapConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/MapConstructor.h
@@ -12,6 +12,7 @@ namespace JS {
 
 class MapConstructor final : public NativeFunction {
     JS_OBJECT(MapConstructor, NativeFunction);
+    JS_DECLARE_ALLOCATOR(MapConstructor);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/MapIterator.cpp
+++ b/Userland/Libraries/LibJS/Runtime/MapIterator.cpp
@@ -9,6 +9,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(MapIterator);
+
 NonnullGCPtr<MapIterator> MapIterator::create(Realm& realm, Map& map, Object::PropertyKind iteration_kind)
 {
     return realm.heap().allocate<MapIterator>(realm, map, iteration_kind, realm.intrinsics().map_iterator_prototype());

--- a/Userland/Libraries/LibJS/Runtime/MapIterator.h
+++ b/Userland/Libraries/LibJS/Runtime/MapIterator.h
@@ -14,6 +14,7 @@ namespace JS {
 
 class MapIterator final : public Object {
     JS_OBJECT(MapIterator, Object);
+    JS_DECLARE_ALLOCATOR(MapIterator);
 
 public:
     static NonnullGCPtr<MapIterator> create(Realm&, Map& map, Object::PropertyKind iteration_kind);

--- a/Userland/Libraries/LibJS/Runtime/MapIteratorPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/MapIteratorPrototype.cpp
@@ -13,6 +13,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(MapIteratorPrototype);
+
 MapIteratorPrototype::MapIteratorPrototype(Realm& realm)
     : PrototypeObject(realm.intrinsics().iterator_prototype())
 {

--- a/Userland/Libraries/LibJS/Runtime/MapIteratorPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/MapIteratorPrototype.h
@@ -13,6 +13,7 @@ namespace JS {
 
 class MapIteratorPrototype final : public PrototypeObject<MapIteratorPrototype, MapIterator> {
     JS_PROTOTYPE_OBJECT(MapIteratorPrototype, MapIterator, MapIterator);
+    JS_DECLARE_ALLOCATOR(MapIteratorPrototype);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/MapPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/MapPrototype.cpp
@@ -12,6 +12,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(MapPrototype);
+
 MapPrototype::MapPrototype(Realm& realm)
     : PrototypeObject(realm.intrinsics().object_prototype())
 {

--- a/Userland/Libraries/LibJS/Runtime/MapPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/MapPrototype.h
@@ -13,6 +13,7 @@ namespace JS {
 
 class MapPrototype final : public PrototypeObject<MapPrototype, Map> {
     JS_PROTOTYPE_OBJECT(MapPrototype, Map, Map);
+    JS_DECLARE_ALLOCATOR(MapPrototype);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/MathObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/MathObject.cpp
@@ -17,6 +17,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(MathObject);
+
 MathObject::MathObject(Realm& realm)
     : Object(ConstructWithPrototypeTag::Tag, realm.intrinsics().object_prototype())
 {

--- a/Userland/Libraries/LibJS/Runtime/MathObject.h
+++ b/Userland/Libraries/LibJS/Runtime/MathObject.h
@@ -12,6 +12,7 @@ namespace JS {
 
 class MathObject final : public Object {
     JS_OBJECT(MathObject, Object);
+    JS_DECLARE_ALLOCATOR(MathObject);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/ModuleEnvironment.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ModuleEnvironment.cpp
@@ -11,6 +11,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(ModuleEnvironment);
+
 // 9.1.2.6 NewModuleEnvironment ( E ), https://tc39.es/ecma262/#sec-newmoduleenvironment
 ModuleEnvironment::ModuleEnvironment(Environment* outer_environment)
     : DeclarativeEnvironment(outer_environment)

--- a/Userland/Libraries/LibJS/Runtime/ModuleEnvironment.h
+++ b/Userland/Libraries/LibJS/Runtime/ModuleEnvironment.h
@@ -15,6 +15,7 @@ namespace JS {
 // 9.1.1.5 Module Environment Records, https://tc39.es/ecma262/#sec-module-environment-records
 class ModuleEnvironment final : public DeclarativeEnvironment {
     JS_ENVIRONMENT(ModuleEnvironment, DeclarativeEnvironment);
+    JS_DECLARE_ALLOCATOR(ModuleEnvironment);
 
 public:
     // Note: Module Environment Records support all of the declarative Environment Record methods listed

--- a/Userland/Libraries/LibJS/Runtime/ModuleNamespaceObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ModuleNamespaceObject.cpp
@@ -10,6 +10,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(ModuleNamespaceObject);
+
 ModuleNamespaceObject::ModuleNamespaceObject(Realm& realm, Module* module, Vector<DeprecatedFlyString> exports)
     : Object(ConstructWithPrototypeTag::Tag, realm.intrinsics().object_prototype(), MayInterfereWithIndexedPropertyAccess::Yes)
     , m_module(module)

--- a/Userland/Libraries/LibJS/Runtime/ModuleNamespaceObject.h
+++ b/Userland/Libraries/LibJS/Runtime/ModuleNamespaceObject.h
@@ -14,6 +14,7 @@ namespace JS {
 
 class ModuleNamespaceObject final : public Object {
     JS_OBJECT(ModuleNamespaceObject, Object);
+    JS_DECLARE_ALLOCATOR(ModuleNamespaceObject);
 
 public:
     // 10.4.6 Module Namespace Exotic Objects, https://tc39.es/ecma262/#sec-module-namespace-exotic-objects

--- a/Userland/Libraries/LibJS/Runtime/NativeFunction.cpp
+++ b/Userland/Libraries/LibJS/Runtime/NativeFunction.cpp
@@ -15,6 +15,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(NativeFunction);
+
 // 10.3.3 CreateBuiltinFunction ( behaviour, length, name, additionalInternalSlotsList [ , realm [ , prototype [ , prefix ] ] ] ), https://tc39.es/ecma262/#sec-createbuiltinfunction
 // NOTE: This doesn't consider additionalInternalSlotsList, which is rarely used, and can either be implemented using only the `function` lambda, or needs a NativeFunction subclass.
 NonnullGCPtr<NativeFunction> NativeFunction::create(Realm& allocating_realm, Function<ThrowCompletionOr<Value>(VM&)> behaviour, i32 length, PropertyKey const& name, Optional<Realm*> realm, Optional<Object*> prototype, Optional<StringView> const& prefix)

--- a/Userland/Libraries/LibJS/Runtime/NativeFunction.h
+++ b/Userland/Libraries/LibJS/Runtime/NativeFunction.h
@@ -18,6 +18,7 @@ namespace JS {
 
 class NativeFunction : public FunctionObject {
     JS_OBJECT(NativeFunction, FunctionObject);
+    JS_DECLARE_ALLOCATOR(NativeFunction);
 
 public:
     static NonnullGCPtr<NativeFunction> create(Realm&, Function<ThrowCompletionOr<Value>(VM&)> behaviour, i32 length, PropertyKey const& name, Optional<Realm*> = {}, Optional<Object*> prototype = {}, Optional<StringView> const& prefix = {});

--- a/Userland/Libraries/LibJS/Runtime/NumberConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/NumberConstructor.cpp
@@ -24,6 +24,8 @@ constexpr double const MIN_SAFE_INTEGER_VALUE { -(__builtin_exp2(53) - 1) };
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(NumberConstructor);
+
 NumberConstructor::NumberConstructor(Realm& realm)
     : NativeFunction(realm.vm().names.Number.as_string(), realm.intrinsics().function_prototype())
 {

--- a/Userland/Libraries/LibJS/Runtime/NumberConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/NumberConstructor.h
@@ -12,6 +12,7 @@ namespace JS {
 
 class NumberConstructor final : public NativeFunction {
     JS_OBJECT(NumberConstructor, NativeFunction);
+    JS_DECLARE_ALLOCATOR(NumberConstructor);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/NumberObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/NumberObject.cpp
@@ -9,6 +9,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(NumberObject);
+
 NonnullGCPtr<NumberObject> NumberObject::create(Realm& realm, double value)
 {
     return realm.heap().allocate<NumberObject>(realm, value, realm.intrinsics().number_prototype());

--- a/Userland/Libraries/LibJS/Runtime/NumberObject.h
+++ b/Userland/Libraries/LibJS/Runtime/NumberObject.h
@@ -12,6 +12,7 @@ namespace JS {
 
 class NumberObject : public Object {
     JS_OBJECT(NumberObject, Object);
+    JS_DECLARE_ALLOCATOR(NumberObject);
 
 public:
     static NonnullGCPtr<NumberObject> create(Realm&, double);

--- a/Userland/Libraries/LibJS/Runtime/NumberPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/NumberPrototype.cpp
@@ -22,6 +22,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(NumberPrototype);
+
 static constexpr AK::Array<u8, 37> max_precision_for_radix = {
     // clang-format off
     0,  0,  52, 32, 26, 22, 20, 18, 17, 16,

--- a/Userland/Libraries/LibJS/Runtime/NumberPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/NumberPrototype.h
@@ -12,6 +12,7 @@ namespace JS {
 
 class NumberPrototype final : public NumberObject {
     JS_OBJECT(NumberPrototype, NumberObject);
+    JS_DECLARE_ALLOCATOR(NumberPrototype);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/Object.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Object.cpp
@@ -23,6 +23,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(Object);
+
 static HashMap<GCPtr<Object const>, HashMap<DeprecatedFlyString, Object::IntrinsicAccessor>> s_intrinsics;
 
 // 10.1.12 OrdinaryObjectCreate ( proto [ , additionalInternalSlotsList ] ), https://tc39.es/ecma262/#sec-ordinaryobjectcreate

--- a/Userland/Libraries/LibJS/Runtime/Object.h
+++ b/Userland/Libraries/LibJS/Runtime/Object.h
@@ -12,6 +12,7 @@
 #include <AK/StringView.h>
 #include <LibJS/Forward.h>
 #include <LibJS/Heap/Cell.h>
+#include <LibJS/Heap/CellAllocator.h>
 #include <LibJS/Heap/MarkedVector.h>
 #include <LibJS/Runtime/Completion.h>
 #include <LibJS/Runtime/IndexedProperties.h>
@@ -53,6 +54,7 @@ struct CacheablePropertyMetadata {
 
 class Object : public Cell {
     JS_CELL(Object, Cell);
+    JS_DECLARE_ALLOCATOR(Object);
 
 public:
     static NonnullGCPtr<Object> create(Realm&, Object* prototype);

--- a/Userland/Libraries/LibJS/Runtime/ObjectConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ObjectConstructor.cpp
@@ -17,6 +17,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(ObjectConstructor);
+
 ObjectConstructor::ObjectConstructor(Realm& realm)
     : NativeFunction(realm.vm().names.Object.as_string(), realm.intrinsics().function_prototype())
 {

--- a/Userland/Libraries/LibJS/Runtime/ObjectConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/ObjectConstructor.h
@@ -13,6 +13,7 @@ namespace JS {
 
 class ObjectConstructor final : public NativeFunction {
     JS_OBJECT(ObjectConstructor, NativeFunction);
+    JS_DECLARE_ALLOCATOR(ObjectConstructor);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/ObjectEnvironment.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ObjectEnvironment.cpp
@@ -11,6 +11,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(ObjectEnvironment);
+
 ObjectEnvironment::ObjectEnvironment(Object& binding_object, IsWithEnvironment is_with_environment, Environment* outer_environment)
     : Environment(outer_environment)
     , m_binding_object(binding_object)

--- a/Userland/Libraries/LibJS/Runtime/ObjectEnvironment.h
+++ b/Userland/Libraries/LibJS/Runtime/ObjectEnvironment.h
@@ -12,6 +12,7 @@ namespace JS {
 
 class ObjectEnvironment final : public Environment {
     JS_ENVIRONMENT(ObjectEnvironment, Environment);
+    JS_DECLARE_ALLOCATOR(ObjectEnvironment);
 
 public:
     enum class IsWithEnvironment {

--- a/Userland/Libraries/LibJS/Runtime/ObjectPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ObjectPrototype.cpp
@@ -21,6 +21,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(ObjectPrototype);
+
 ObjectPrototype::ObjectPrototype(Realm& realm)
     : Object(Object::ConstructWithoutPrototypeTag::Tag, realm)
 {

--- a/Userland/Libraries/LibJS/Runtime/ObjectPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/ObjectPrototype.h
@@ -13,6 +13,7 @@ namespace JS {
 
 class ObjectPrototype final : public Object {
     JS_OBJECT(ObjectPrototype, Object);
+    JS_DECLARE_ALLOCATOR(ObjectPrototype);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/PrimitiveString.cpp
+++ b/Userland/Libraries/LibJS/Runtime/PrimitiveString.cpp
@@ -19,6 +19,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(PrimitiveString);
+
 PrimitiveString::PrimitiveString(PrimitiveString& lhs, PrimitiveString& rhs)
     : m_is_rope(true)
     , m_lhs(&lhs)

--- a/Userland/Libraries/LibJS/Runtime/PrimitiveString.h
+++ b/Userland/Libraries/LibJS/Runtime/PrimitiveString.h
@@ -13,6 +13,7 @@
 #include <AK/StringView.h>
 #include <LibJS/Forward.h>
 #include <LibJS/Heap/Cell.h>
+#include <LibJS/Heap/CellAllocator.h>
 #include <LibJS/Runtime/Completion.h>
 #include <LibJS/Runtime/Utf16String.h>
 #include <LibJS/Runtime/Value.h>
@@ -21,6 +22,7 @@ namespace JS {
 
 class PrimitiveString final : public Cell {
     JS_CELL(PrimitiveString, Cell);
+    JS_DECLARE_ALLOCATOR(PrimitiveString);
 
 public:
     [[nodiscard]] static NonnullGCPtr<PrimitiveString> create(VM&, Utf16String);

--- a/Userland/Libraries/LibJS/Runtime/PrivateEnvironment.cpp
+++ b/Userland/Libraries/LibJS/Runtime/PrivateEnvironment.cpp
@@ -8,6 +8,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(PrivateEnvironment);
+
 PrivateEnvironment::PrivateEnvironment(PrivateEnvironment* parent)
     : m_outer_environment(parent)
     , m_unique_id(s_next_id++)

--- a/Userland/Libraries/LibJS/Runtime/PrivateEnvironment.h
+++ b/Userland/Libraries/LibJS/Runtime/PrivateEnvironment.h
@@ -10,6 +10,7 @@
 #include <AK/StringView.h>
 #include <AK/Vector.h>
 #include <LibJS/Heap/Cell.h>
+#include <LibJS/Heap/CellAllocator.h>
 
 namespace JS {
 
@@ -29,6 +30,7 @@ struct PrivateName {
 
 class PrivateEnvironment : public Cell {
     JS_CELL(PrivateEnvironment, Cell);
+    JS_DECLARE_ALLOCATOR(PrivateEnvironment);
 
 public:
     PrivateName resolve_private_identifier(DeprecatedFlyString const& identifier) const;

--- a/Userland/Libraries/LibJS/Runtime/Promise.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Promise.cpp
@@ -19,6 +19,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(Promise);
+
 // 27.2.4.7.1 PromiseResolve ( C, x ), https://tc39.es/ecma262/#sec-promise-resolve
 ThrowCompletionOr<Object*> promise_resolve(VM& vm, Object& constructor, Value value)
 {

--- a/Userland/Libraries/LibJS/Runtime/Promise.h
+++ b/Userland/Libraries/LibJS/Runtime/Promise.h
@@ -15,6 +15,7 @@ ThrowCompletionOr<Object*> promise_resolve(VM&, Object& constructor, Value);
 
 class Promise : public Object {
     JS_OBJECT(Promise, Object);
+    JS_DECLARE_ALLOCATOR(Promise);
 
 public:
     enum class State {

--- a/Userland/Libraries/LibJS/Runtime/PromiseCapability.cpp
+++ b/Userland/Libraries/LibJS/Runtime/PromiseCapability.cpp
@@ -11,6 +11,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(PromiseCapability);
+
 NonnullGCPtr<PromiseCapability> PromiseCapability::create(VM& vm, NonnullGCPtr<Object> promise, NonnullGCPtr<FunctionObject> resolve, NonnullGCPtr<FunctionObject> reject)
 {
     return vm.heap().allocate_without_realm<PromiseCapability>(promise, resolve, reject);
@@ -34,6 +36,7 @@ void PromiseCapability::visit_edges(Cell::Visitor& visitor)
 namespace {
 struct ResolvingFunctions final : public Cell {
     JS_CELL(ResolvingFunctions, Cell);
+    JS_DECLARE_ALLOCATOR(ResolvingFunctions);
 
     Value resolve { js_undefined() };
     Value reject { js_undefined() };
@@ -45,6 +48,7 @@ struct ResolvingFunctions final : public Cell {
         visitor.visit(reject);
     }
 };
+JS_DEFINE_ALLOCATOR(ResolvingFunctions);
 }
 
 // 27.2.1.5 NewPromiseCapability ( C ), https://tc39.es/ecma262/#sec-newpromisecapability

--- a/Userland/Libraries/LibJS/Runtime/PromiseCapability.h
+++ b/Userland/Libraries/LibJS/Runtime/PromiseCapability.h
@@ -15,6 +15,7 @@ namespace JS {
 // 27.2.1.1 PromiseCapability Records, https://tc39.es/ecma262/#sec-promisecapability-records
 class PromiseCapability final : public Cell {
     JS_CELL(PromiseCapability, Cell);
+    JS_DECLARE_ALLOCATOR(PromiseCapability);
 
 public:
     static NonnullGCPtr<PromiseCapability> create(VM& vm, NonnullGCPtr<Object> promise, NonnullGCPtr<FunctionObject> resolve, NonnullGCPtr<FunctionObject> reject);

--- a/Userland/Libraries/LibJS/Runtime/PromiseConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/PromiseConstructor.cpp
@@ -19,6 +19,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(PromiseConstructor);
+
 // 27.2.4.1.1 GetPromiseResolve ( promiseConstructor ), https://tc39.es/ecma262/#sec-getpromiseresolve
 static ThrowCompletionOr<Value> get_promise_resolve(VM& vm, Value constructor)
 {

--- a/Userland/Libraries/LibJS/Runtime/PromiseConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/PromiseConstructor.h
@@ -12,6 +12,7 @@ namespace JS {
 
 class PromiseConstructor final : public NativeFunction {
     JS_OBJECT(PromiseConstructor, NativeFunction);
+    JS_DECLARE_ALLOCATOR(PromiseConstructor);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/PromisePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/PromisePrototype.cpp
@@ -15,6 +15,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(PromisePrototype);
+
 PromisePrototype::PromisePrototype(Realm& realm)
     : PrototypeObject(realm.intrinsics().object_prototype())
 {

--- a/Userland/Libraries/LibJS/Runtime/PromisePrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/PromisePrototype.h
@@ -12,6 +12,7 @@ namespace JS {
 
 class PromisePrototype final : public PrototypeObject<PromisePrototype, Promise> {
     JS_PROTOTYPE_OBJECT(PromisePrototype, Promise, Promise);
+    JS_DECLARE_ALLOCATOR(PromisePrototype);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/PromiseReaction.cpp
+++ b/Userland/Libraries/LibJS/Runtime/PromiseReaction.cpp
@@ -10,6 +10,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(PromiseReaction);
+
 NonnullGCPtr<PromiseReaction> PromiseReaction::create(VM& vm, Type type, GCPtr<PromiseCapability> capability, Optional<JobCallback> handler)
 {
     return vm.heap().allocate_without_realm<PromiseReaction>(type, capability, move(handler));

--- a/Userland/Libraries/LibJS/Runtime/PromiseReaction.h
+++ b/Userland/Libraries/LibJS/Runtime/PromiseReaction.h
@@ -16,6 +16,7 @@ namespace JS {
 // 27.2.1.2 PromiseReaction Records, https://tc39.es/ecma262/#sec-promisereaction-records
 class PromiseReaction final : public Cell {
     JS_CELL(PromiseReaction, Cell);
+    JS_DECLARE_ALLOCATOR(PromiseReaction);
 
 public:
     enum class Type {

--- a/Userland/Libraries/LibJS/Runtime/PromiseResolvingElementFunctions.cpp
+++ b/Userland/Libraries/LibJS/Runtime/PromiseResolvingElementFunctions.cpp
@@ -13,6 +13,13 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(RemainingElements);
+JS_DEFINE_ALLOCATOR(PromiseValueList);
+JS_DEFINE_ALLOCATOR(PromiseResolvingElementFunction);
+JS_DEFINE_ALLOCATOR(PromiseAllResolveElementFunction);
+JS_DEFINE_ALLOCATOR(PromiseAllSettledRejectElementFunction);
+JS_DEFINE_ALLOCATOR(PromiseAnyRejectElementFunction);
+
 void PromiseValueList::visit_edges(Visitor& visitor)
 {
     Base::visit_edges(visitor);

--- a/Userland/Libraries/LibJS/Runtime/PromiseResolvingElementFunctions.h
+++ b/Userland/Libraries/LibJS/Runtime/PromiseResolvingElementFunctions.h
@@ -14,6 +14,7 @@ namespace JS {
 
 struct RemainingElements final : public Cell {
     JS_CELL(RemainingElements, Cell);
+    JS_DECLARE_ALLOCATOR(RemainingElements);
 
     u64 value { 0 };
 
@@ -28,6 +29,7 @@ private:
 
 class PromiseValueList final : public Cell {
     JS_CELL(PromiseValueList, Cell);
+    JS_DECLARE_ALLOCATOR(PromiseValueList);
 
 public:
     Vector<Value>& values() { return m_values; }
@@ -42,7 +44,8 @@ private:
 };
 
 class PromiseResolvingElementFunction : public NativeFunction {
-    JS_OBJECT(PromiseResolvingFunction, NativeFunction);
+    JS_OBJECT(PromiseResolvingElementFunction, NativeFunction);
+    JS_DECLARE_ALLOCATOR(PromiseResolvingElementFunction);
 
 public:
     virtual void initialize(Realm&) override;
@@ -68,7 +71,8 @@ private:
 
 // 27.2.4.1.3 Promise.all Resolve Element Functions, https://tc39.es/ecma262/#sec-promise.all-resolve-element-functions
 class PromiseAllResolveElementFunction final : public PromiseResolvingElementFunction {
-    JS_OBJECT(PromiseResolvingFunction, NativeFunction);
+    JS_OBJECT(PromiseAllResolveElementFunction, NativeFunction);
+    JS_DECLARE_ALLOCATOR(PromiseAllResolveElementFunction);
 
 public:
     static NonnullGCPtr<PromiseAllResolveElementFunction> create(Realm&, size_t, PromiseValueList&, NonnullGCPtr<PromiseCapability const>, RemainingElements&);
@@ -98,7 +102,8 @@ private:
 
 // 27.2.4.2.3 Promise.allSettled Reject Element Functions, https://tc39.es/ecma262/#sec-promise.allsettled-reject-element-functions
 class PromiseAllSettledRejectElementFunction final : public PromiseResolvingElementFunction {
-    JS_OBJECT(PromiseResolvingFunction, PromiseResolvingElementFunction);
+    JS_OBJECT(PromiseAllSettledRejectElementFunction, PromiseResolvingElementFunction);
+    JS_DECLARE_ALLOCATOR(PromiseAllSettledRejectElementFunction);
 
 public:
     static NonnullGCPtr<PromiseAllSettledRejectElementFunction> create(Realm&, size_t, PromiseValueList&, NonnullGCPtr<PromiseCapability const>, RemainingElements&);
@@ -113,7 +118,8 @@ private:
 
 // 27.2.4.3.2 Promise.any Reject Element Functions, https://tc39.es/ecma262/#sec-promise.any-reject-element-functions
 class PromiseAnyRejectElementFunction final : public PromiseResolvingElementFunction {
-    JS_OBJECT(PromiseResolvingFunction, PromiseResolvingElementFunction);
+    JS_OBJECT(PromiseAnyRejectElementFunction, PromiseResolvingElementFunction);
+    JS_DECLARE_ALLOCATOR(PromiseAnyRejectElementFunction);
 
 public:
     static NonnullGCPtr<PromiseAnyRejectElementFunction> create(Realm&, size_t, PromiseValueList&, NonnullGCPtr<PromiseCapability const>, RemainingElements&);

--- a/Userland/Libraries/LibJS/Runtime/PromiseResolvingFunction.cpp
+++ b/Userland/Libraries/LibJS/Runtime/PromiseResolvingFunction.cpp
@@ -11,6 +11,9 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(AlreadyResolved);
+JS_DEFINE_ALLOCATOR(PromiseResolvingFunction);
+
 NonnullGCPtr<PromiseResolvingFunction> PromiseResolvingFunction::create(Realm& realm, Promise& promise, AlreadyResolved& already_resolved, FunctionType function)
 {
     return realm.heap().allocate<PromiseResolvingFunction>(realm, promise, already_resolved, move(function), realm.intrinsics().function_prototype());

--- a/Userland/Libraries/LibJS/Runtime/PromiseResolvingFunction.h
+++ b/Userland/Libraries/LibJS/Runtime/PromiseResolvingFunction.h
@@ -13,6 +13,7 @@ namespace JS {
 
 struct AlreadyResolved final : public Cell {
     JS_CELL(AlreadyResolved, Cell);
+    JS_DECLARE_ALLOCATOR(AlreadyResolved);
 
     bool value { false };
 
@@ -24,6 +25,7 @@ protected:
 
 class PromiseResolvingFunction final : public NativeFunction {
     JS_OBJECT(PromiseResolvingFunction, NativeFunction);
+    JS_DECLARE_ALLOCATOR(PromiseResolvingFunction);
 
 public:
     using FunctionType = Function<Value(VM&, Promise&, AlreadyResolved&)>;

--- a/Userland/Libraries/LibJS/Runtime/ProxyConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ProxyConstructor.cpp
@@ -13,6 +13,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(ProxyConstructor);
+
 // 10.5.14 ProxyCreate ( target, handler ), https://tc39.es/ecma262/#sec-proxycreate
 static ThrowCompletionOr<ProxyObject*> proxy_create(VM& vm, Value target, Value handler)
 {

--- a/Userland/Libraries/LibJS/Runtime/ProxyConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/ProxyConstructor.h
@@ -13,6 +13,7 @@ namespace JS {
 
 class ProxyConstructor final : public NativeFunction {
     JS_OBJECT(ProxyConstructor, NativeFunction);
+    JS_DECLARE_ALLOCATOR(ProxyConstructor);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/ProxyObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ProxyObject.cpp
@@ -16,6 +16,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(ProxyObject);
+
 NonnullGCPtr<ProxyObject> ProxyObject::create(Realm& realm, Object& target, Object& handler)
 {
     return realm.heap().allocate<ProxyObject>(realm, target, handler, realm.intrinsics().object_prototype());

--- a/Userland/Libraries/LibJS/Runtime/ProxyObject.h
+++ b/Userland/Libraries/LibJS/Runtime/ProxyObject.h
@@ -14,6 +14,7 @@ namespace JS {
 
 class ProxyObject final : public FunctionObject {
     JS_OBJECT(ProxyObject, FunctionObject);
+    JS_DECLARE_ALLOCATOR(ProxyObject);
 
 public:
     static NonnullGCPtr<ProxyObject> create(Realm&, Object& target, Object& handler);

--- a/Userland/Libraries/LibJS/Runtime/Realm.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Realm.cpp
@@ -14,6 +14,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(Realm);
+
 // 9.3.1 CreateRealm ( ), https://tc39.es/ecma262/#sec-createrealm
 ThrowCompletionOr<NonnullGCPtr<Realm>> Realm::create(VM& vm)
 {

--- a/Userland/Libraries/LibJS/Runtime/Realm.h
+++ b/Userland/Libraries/LibJS/Runtime/Realm.h
@@ -13,6 +13,7 @@
 #include <AK/Weakable.h>
 #include <LibJS/Bytecode/Builtins.h>
 #include <LibJS/Heap/Cell.h>
+#include <LibJS/Heap/CellAllocator.h>
 #include <LibJS/Runtime/Intrinsics.h>
 #include <LibJS/Runtime/Value.h>
 
@@ -23,6 +24,7 @@ class Realm final
     : public Cell
     , public Weakable<Realm> {
     JS_CELL(Realm, Cell);
+    JS_DECLARE_ALLOCATOR(Realm);
 
 public:
     struct HostDefined {

--- a/Userland/Libraries/LibJS/Runtime/ReflectObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ReflectObject.cpp
@@ -15,6 +15,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(ReflectObject);
+
 ReflectObject::ReflectObject(Realm& realm)
     : Object(ConstructWithPrototypeTag::Tag, realm.intrinsics().object_prototype())
 {

--- a/Userland/Libraries/LibJS/Runtime/ReflectObject.h
+++ b/Userland/Libraries/LibJS/Runtime/ReflectObject.h
@@ -12,6 +12,7 @@ namespace JS {
 
 class ReflectObject final : public Object {
     JS_OBJECT(ReflectObject, Object);
+    JS_DECLARE_ALLOCATOR(ReflectObject);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/RegExpConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/RegExpConstructor.cpp
@@ -12,6 +12,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(RegExpConstructor);
+
 RegExpConstructor::RegExpConstructor(Realm& realm)
     : NativeFunction(realm.vm().names.RegExp.as_string(), realm.intrinsics().function_prototype())
 {

--- a/Userland/Libraries/LibJS/Runtime/RegExpConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/RegExpConstructor.h
@@ -13,6 +13,7 @@ namespace JS {
 
 class RegExpConstructor final : public NativeFunction {
     JS_OBJECT(RegExpConstructor, NativeFunction);
+    JS_DECLARE_ALLOCATOR(RegExpConstructor);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/RegExpObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/RegExpObject.cpp
@@ -16,6 +16,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(RegExpObject);
+
 Result<regex::RegexOptions<ECMAScriptFlags>, DeprecatedString> regex_flags_from_string(StringView flags)
 {
     bool d = false, g = false, i = false, m = false, s = false, u = false, y = false, v = false;

--- a/Userland/Libraries/LibJS/Runtime/RegExpObject.h
+++ b/Userland/Libraries/LibJS/Runtime/RegExpObject.h
@@ -25,6 +25,7 @@ ThrowCompletionOr<DeprecatedString> parse_regex_pattern(VM& vm, StringView patte
 
 class RegExpObject : public Object {
     JS_OBJECT(RegExpObject, Object);
+    JS_DECLARE_ALLOCATOR(RegExpObject);
 
 public:
     // JS regexps are all 'global' by default as per our definition, but the "global" flag enables "stateful".

--- a/Userland/Libraries/LibJS/Runtime/RegExpPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/RegExpPrototype.cpp
@@ -23,6 +23,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(RegExpPrototype);
+
 RegExpPrototype::RegExpPrototype(Realm& realm)
     : PrototypeObject(realm.intrinsics().object_prototype())
 {

--- a/Userland/Libraries/LibJS/Runtime/RegExpPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/RegExpPrototype.h
@@ -17,6 +17,7 @@ size_t advance_string_index(Utf16View const& string, size_t index, bool unicode)
 
 class RegExpPrototype final : public PrototypeObject<RegExpPrototype, RegExpObject> {
     JS_PROTOTYPE_OBJECT(RegExpPrototype, RegExpObject, RegExp);
+    JS_DECLARE_ALLOCATOR(RegExpPrototype);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/RegExpStringIterator.cpp
+++ b/Userland/Libraries/LibJS/Runtime/RegExpStringIterator.cpp
@@ -9,6 +9,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(RegExpStringIterator);
+
 // 22.2.9.1 CreateRegExpStringIterator ( R, S, global, fullUnicode ), https://tc39.es/ecma262/#sec-createregexpstringiterator
 NonnullGCPtr<RegExpStringIterator> RegExpStringIterator::create(Realm& realm, Object& regexp_object, Utf16String string, bool global, bool unicode)
 {

--- a/Userland/Libraries/LibJS/Runtime/RegExpStringIterator.h
+++ b/Userland/Libraries/LibJS/Runtime/RegExpStringIterator.h
@@ -14,6 +14,7 @@ namespace JS {
 
 class RegExpStringIterator final : public Object {
     JS_OBJECT(RegExpStringIterator, Object);
+    JS_DECLARE_ALLOCATOR(RegExpStringIterator);
 
 public:
     static NonnullGCPtr<RegExpStringIterator> create(Realm&, Object& regexp_object, Utf16String string, bool global, bool unicode);

--- a/Userland/Libraries/LibJS/Runtime/RegExpStringIteratorPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/RegExpStringIteratorPrototype.cpp
@@ -12,6 +12,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(RegExpStringIteratorPrototype);
+
 RegExpStringIteratorPrototype::RegExpStringIteratorPrototype(Realm& realm)
     : PrototypeObject(realm.intrinsics().iterator_prototype())
 {

--- a/Userland/Libraries/LibJS/Runtime/RegExpStringIteratorPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/RegExpStringIteratorPrototype.h
@@ -13,6 +13,7 @@ namespace JS {
 
 class RegExpStringIteratorPrototype final : public PrototypeObject<RegExpStringIteratorPrototype, RegExpStringIterator> {
     JS_PROTOTYPE_OBJECT(RegExpStringIteratorPrototype, RegExpStringIterator, RegExpStringIterator);
+    JS_DECLARE_ALLOCATOR(RegExpStringIteratorPrototype);
 
 public:
     virtual ~RegExpStringIteratorPrototype() override = default;

--- a/Userland/Libraries/LibJS/Runtime/Set.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Set.cpp
@@ -8,6 +8,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(Set);
+
 NonnullGCPtr<Set> Set::create(Realm& realm)
 {
     return realm.heap().allocate<Set>(realm, realm.intrinsics().set_prototype());

--- a/Userland/Libraries/LibJS/Runtime/Set.h
+++ b/Userland/Libraries/LibJS/Runtime/Set.h
@@ -15,6 +15,7 @@ namespace JS {
 
 class Set : public Object {
     JS_OBJECT(Set, Object);
+    JS_DECLARE_ALLOCATOR(Set);
 
 public:
     static NonnullGCPtr<Set> create(Realm&);

--- a/Userland/Libraries/LibJS/Runtime/SetConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/SetConstructor.cpp
@@ -13,6 +13,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(SetConstructor);
+
 SetConstructor::SetConstructor(Realm& realm)
     : NativeFunction(realm.vm().names.Set.as_string(), realm.intrinsics().function_prototype())
 {

--- a/Userland/Libraries/LibJS/Runtime/SetConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/SetConstructor.h
@@ -12,6 +12,7 @@ namespace JS {
 
 class SetConstructor final : public NativeFunction {
     JS_OBJECT(SetConstructor, NativeFunction);
+    JS_DECLARE_ALLOCATOR(SetConstructor);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/SetIterator.cpp
+++ b/Userland/Libraries/LibJS/Runtime/SetIterator.cpp
@@ -9,6 +9,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(SetIterator);
+
 NonnullGCPtr<SetIterator> SetIterator::create(Realm& realm, Set& set, Object::PropertyKind iteration_kind)
 {
     return realm.heap().allocate<SetIterator>(realm, set, iteration_kind, realm.intrinsics().set_iterator_prototype());

--- a/Userland/Libraries/LibJS/Runtime/SetIterator.h
+++ b/Userland/Libraries/LibJS/Runtime/SetIterator.h
@@ -14,6 +14,7 @@ namespace JS {
 
 class SetIterator final : public Object {
     JS_OBJECT(SetIterator, Object);
+    JS_DECLARE_ALLOCATOR(SetIterator);
 
 public:
     static NonnullGCPtr<SetIterator> create(Realm&, Set& set, Object::PropertyKind iteration_kind);

--- a/Userland/Libraries/LibJS/Runtime/SetIteratorPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/SetIteratorPrototype.cpp
@@ -13,6 +13,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(SetIteratorPrototype);
+
 SetIteratorPrototype::SetIteratorPrototype(Realm& realm)
     : PrototypeObject(realm.intrinsics().iterator_prototype())
 {

--- a/Userland/Libraries/LibJS/Runtime/SetIteratorPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/SetIteratorPrototype.h
@@ -13,6 +13,7 @@ namespace JS {
 
 class SetIteratorPrototype final : public PrototypeObject<SetIteratorPrototype, SetIterator> {
     JS_PROTOTYPE_OBJECT(SetIteratorPrototype, SetIterator, SetIterator);
+    JS_DECLARE_ALLOCATOR(SetIteratorPrototype);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/ShadowRealm.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ShadowRealm.cpp
@@ -20,6 +20,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(ShadowRealm);
+
 ShadowRealm::ShadowRealm(Realm& shadow_realm, ExecutionContext execution_context, Object& prototype)
     : Object(ConstructWithPrototypeTag::Tag, prototype)
     , m_shadow_realm(shadow_realm)

--- a/Userland/Libraries/LibJS/Runtime/ShadowRealm.h
+++ b/Userland/Libraries/LibJS/Runtime/ShadowRealm.h
@@ -15,6 +15,7 @@ namespace JS {
 
 class ShadowRealm final : public Object {
     JS_OBJECT(ShadowRealm, Object);
+    JS_DECLARE_ALLOCATOR(ShadowRealm);
 
 public:
     virtual ~ShadowRealm() override = default;

--- a/Userland/Libraries/LibJS/Runtime/ShadowRealmConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ShadowRealmConstructor.cpp
@@ -10,6 +10,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(ShadowRealmConstructor);
+
 // 3.2 The ShadowRealm Constructor, https://tc39.es/proposal-shadowrealm/#sec-shadowrealm-constructor
 ShadowRealmConstructor::ShadowRealmConstructor(Realm& realm)
     : NativeFunction(realm.vm().names.ShadowRealm.as_string(), realm.intrinsics().function_prototype())

--- a/Userland/Libraries/LibJS/Runtime/ShadowRealmConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/ShadowRealmConstructor.h
@@ -12,6 +12,7 @@ namespace JS {
 
 class ShadowRealmConstructor final : public NativeFunction {
     JS_OBJECT(ShadowRealmConstructor, NativeFunction);
+    JS_DECLARE_ALLOCATOR(ShadowRealmConstructor);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/ShadowRealmPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ShadowRealmPrototype.cpp
@@ -10,6 +10,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(ShadowRealmPrototype);
+
 // 3.4 Properties of the ShadowRealm Prototype Object, https://tc39.es/proposal-shadowrealm/#sec-properties-of-the-shadowrealm-prototype-object
 ShadowRealmPrototype::ShadowRealmPrototype(Realm& realm)
     : PrototypeObject(realm.intrinsics().object_prototype())

--- a/Userland/Libraries/LibJS/Runtime/ShadowRealmPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/ShadowRealmPrototype.h
@@ -13,6 +13,7 @@ namespace JS {
 
 class ShadowRealmPrototype final : public PrototypeObject<ShadowRealmPrototype, ShadowRealm> {
     JS_PROTOTYPE_OBJECT(ShadowRealmPrototype, ShadowRealm, ShadowRealm);
+    JS_DECLARE_ALLOCATOR(ShadowRealmPrototype);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/Shape.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Shape.cpp
@@ -10,6 +10,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(Shape);
+
 Shape* Shape::create_unique_clone() const
 {
     auto new_shape = heap().allocate_without_realm<Shape>(m_realm);

--- a/Userland/Libraries/LibJS/Runtime/Shape.h
+++ b/Userland/Libraries/LibJS/Runtime/Shape.h
@@ -38,6 +38,7 @@ class Shape final
     : public Cell
     , public Weakable<Shape> {
     JS_CELL(Shape, Cell);
+    JS_DECLARE_ALLOCATOR(Shape);
 
 public:
     virtual ~Shape() override = default;

--- a/Userland/Libraries/LibJS/Runtime/SharedArrayBufferConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/SharedArrayBufferConstructor.cpp
@@ -14,6 +14,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(SharedArrayBufferConstructor);
+
 SharedArrayBufferConstructor::SharedArrayBufferConstructor(Realm& realm)
     : NativeFunction(realm.vm().names.SharedArrayBuffer.as_string(), realm.intrinsics().function_prototype())
 {

--- a/Userland/Libraries/LibJS/Runtime/SharedArrayBufferConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/SharedArrayBufferConstructor.h
@@ -12,6 +12,7 @@ namespace JS {
 
 class SharedArrayBufferConstructor final : public NativeFunction {
     JS_OBJECT(SharedArrayBufferConstructor, NativeFunction);
+    JS_DECLARE_ALLOCATOR(SharedArrayBufferConstructor);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/SharedArrayBufferPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/SharedArrayBufferPrototype.cpp
@@ -12,6 +12,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(SharedArrayBufferPrototype);
+
 SharedArrayBufferPrototype::SharedArrayBufferPrototype(Realm& realm)
     : PrototypeObject(realm.intrinsics().object_prototype())
 {

--- a/Userland/Libraries/LibJS/Runtime/SharedArrayBufferPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/SharedArrayBufferPrototype.h
@@ -13,6 +13,7 @@ namespace JS {
 
 class SharedArrayBufferPrototype final : public PrototypeObject<SharedArrayBufferPrototype, ArrayBuffer> {
     JS_PROTOTYPE_OBJECT(SharedArrayBufferPrototype, ArrayBuffer, SharedArrayBuffer);
+    JS_DECLARE_ALLOCATOR(SharedArrayBufferPrototype);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/StringConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/StringConstructor.cpp
@@ -18,6 +18,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(StringConstructor);
+
 StringConstructor::StringConstructor(Realm& realm)
     : NativeFunction(realm.vm().names.String.as_string(), realm.intrinsics().function_prototype())
 {

--- a/Userland/Libraries/LibJS/Runtime/StringConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/StringConstructor.h
@@ -12,6 +12,7 @@ namespace JS {
 
 class StringConstructor final : public NativeFunction {
     JS_OBJECT(StringConstructor, NativeFunction);
+    JS_DECLARE_ALLOCATOR(StringConstructor);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/StringIterator.cpp
+++ b/Userland/Libraries/LibJS/Runtime/StringIterator.cpp
@@ -10,6 +10,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(StringIterator);
+
 NonnullGCPtr<StringIterator> StringIterator::create(Realm& realm, String string)
 {
     return realm.heap().allocate<StringIterator>(realm, move(string), realm.intrinsics().string_iterator_prototype());

--- a/Userland/Libraries/LibJS/Runtime/StringIterator.h
+++ b/Userland/Libraries/LibJS/Runtime/StringIterator.h
@@ -14,6 +14,7 @@ namespace JS {
 
 class StringIterator final : public Object {
     JS_OBJECT(StringIterator, Object);
+    JS_DECLARE_ALLOCATOR(StringIterator);
 
 public:
     static NonnullGCPtr<StringIterator> create(Realm&, String string);

--- a/Userland/Libraries/LibJS/Runtime/StringIteratorPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/StringIteratorPrototype.cpp
@@ -12,6 +12,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(StringIteratorPrototype);
+
 StringIteratorPrototype::StringIteratorPrototype(Realm& realm)
     : PrototypeObject(realm.intrinsics().iterator_prototype())
 {

--- a/Userland/Libraries/LibJS/Runtime/StringIteratorPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/StringIteratorPrototype.h
@@ -14,6 +14,7 @@ namespace JS {
 
 class StringIteratorPrototype final : public PrototypeObject<StringIteratorPrototype, StringIterator> {
     JS_PROTOTYPE_OBJECT(StringIteratorPrototype, StringIterator, StringIterator);
+    JS_DECLARE_ALLOCATOR(StringIteratorPrototype);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/StringObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/StringObject.cpp
@@ -14,6 +14,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(StringObject);
+
 // 10.4.3.4 StringCreate ( value, prototype ), https://tc39.es/ecma262/#sec-stringcreate
 NonnullGCPtr<StringObject> StringObject::create(Realm& realm, PrimitiveString& primitive_string, Object& prototype)
 {

--- a/Userland/Libraries/LibJS/Runtime/StringObject.h
+++ b/Userland/Libraries/LibJS/Runtime/StringObject.h
@@ -12,6 +12,7 @@ namespace JS {
 
 class StringObject : public Object {
     JS_OBJECT(StringObject, Object);
+    JS_DECLARE_ALLOCATOR(StringObject);
 
 public:
     [[nodiscard]] static NonnullGCPtr<StringObject> create(Realm&, PrimitiveString&, Object& prototype);

--- a/Userland/Libraries/LibJS/Runtime/StringPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/StringPrototype.cpp
@@ -34,6 +34,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(StringPrototype);
+
 static ThrowCompletionOr<String> utf8_string_from(VM& vm)
 {
     auto this_value = TRY(require_object_coercible(vm, vm.this_value()));

--- a/Userland/Libraries/LibJS/Runtime/StringPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/StringPrototype.h
@@ -23,6 +23,7 @@ ThrowCompletionOr<String> trim_string(VM&, Value string, TrimMode where);
 
 class StringPrototype final : public StringObject {
     JS_OBJECT(StringPrototype, StringObject);
+    JS_DECLARE_ALLOCATOR(StringPrototype);
 
 public:
     explicit StringPrototype(Realm&);

--- a/Userland/Libraries/LibJS/Runtime/SuppressedError.cpp
+++ b/Userland/Libraries/LibJS/Runtime/SuppressedError.cpp
@@ -10,6 +10,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(SuppressedError);
+
 NonnullGCPtr<SuppressedError> SuppressedError::create(Realm& realm)
 {
     return realm.heap().allocate<SuppressedError>(realm, realm.intrinsics().suppressed_error_prototype());

--- a/Userland/Libraries/LibJS/Runtime/SuppressedError.h
+++ b/Userland/Libraries/LibJS/Runtime/SuppressedError.h
@@ -12,6 +12,7 @@ namespace JS {
 
 class SuppressedError : public Error {
     JS_OBJECT(SuppressedError, Error);
+    JS_DECLARE_ALLOCATOR(SuppressedError);
 
 public:
     static NonnullGCPtr<SuppressedError> create(Realm&);

--- a/Userland/Libraries/LibJS/Runtime/SuppressedErrorConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/SuppressedErrorConstructor.cpp
@@ -14,6 +14,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(SuppressedErrorConstructor);
+
 SuppressedErrorConstructor::SuppressedErrorConstructor(Realm& realm)
     : NativeFunction(static_cast<Object&>(realm.intrinsics().error_constructor()))
 {

--- a/Userland/Libraries/LibJS/Runtime/SuppressedErrorConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/SuppressedErrorConstructor.h
@@ -12,6 +12,7 @@ namespace JS {
 
 class SuppressedErrorConstructor final : public NativeFunction {
     JS_OBJECT(SuppressedErrorConstructor, NativeFunction);
+    JS_DECLARE_ALLOCATOR(SuppressedErrorConstructor);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/SuppressedErrorPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/SuppressedErrorPrototype.cpp
@@ -10,6 +10,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(SuppressedErrorPrototype);
+
 SuppressedErrorPrototype::SuppressedErrorPrototype(Realm& realm)
     : Object(ConstructWithPrototypeTag::Tag, realm.intrinsics().error_prototype())
 {

--- a/Userland/Libraries/LibJS/Runtime/SuppressedErrorPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/SuppressedErrorPrototype.h
@@ -12,6 +12,7 @@ namespace JS {
 
 class SuppressedErrorPrototype final : public Object {
     JS_OBJECT(SuppressedErrorPrototype, Object);
+    JS_DECLARE_ALLOCATOR(SuppressedErrorPrototype);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/Symbol.h
+++ b/Userland/Libraries/LibJS/Runtime/Symbol.h
@@ -14,6 +14,7 @@ namespace JS {
 
 class Symbol final : public Cell {
     JS_CELL(Symbol, Cell);
+    JS_DECLARE_ALLOCATOR(Symbol);
 
 public:
     [[nodiscard]] static NonnullGCPtr<Symbol> create(VM&, Optional<String> description, bool is_global);

--- a/Userland/Libraries/LibJS/Runtime/SymbolConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/SymbolConstructor.cpp
@@ -11,6 +11,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(SymbolConstructor);
+
 SymbolConstructor::SymbolConstructor(Realm& realm)
     : NativeFunction(realm.vm().names.Symbol.as_string(), realm.intrinsics().function_prototype())
 {

--- a/Userland/Libraries/LibJS/Runtime/SymbolConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/SymbolConstructor.h
@@ -12,6 +12,7 @@ namespace JS {
 
 class SymbolConstructor final : public NativeFunction {
     JS_OBJECT(SymbolConstructor, NativeFunction);
+    JS_DECLARE_ALLOCATOR(SymbolConstructor);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/SymbolObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/SymbolObject.cpp
@@ -10,6 +10,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(SymbolObject);
+
 NonnullGCPtr<SymbolObject> SymbolObject::create(Realm& realm, Symbol& primitive_symbol)
 {
     return realm.heap().allocate<SymbolObject>(realm, primitive_symbol, realm.intrinsics().symbol_prototype());

--- a/Userland/Libraries/LibJS/Runtime/SymbolObject.h
+++ b/Userland/Libraries/LibJS/Runtime/SymbolObject.h
@@ -13,6 +13,7 @@ namespace JS {
 
 class SymbolObject : public Object {
     JS_OBJECT(SymbolObject, Object);
+    JS_DECLARE_ALLOCATOR(SymbolObject);
 
 public:
     static NonnullGCPtr<SymbolObject> create(Realm&, Symbol&);

--- a/Userland/Libraries/LibJS/Runtime/SymbolPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/SymbolPrototype.cpp
@@ -18,6 +18,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(SymbolPrototype);
+
 SymbolPrototype::SymbolPrototype(Realm& realm)
     : Object(ConstructWithPrototypeTag::Tag, realm.intrinsics().object_prototype())
 {

--- a/Userland/Libraries/LibJS/Runtime/SymbolPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/SymbolPrototype.h
@@ -12,6 +12,7 @@ namespace JS {
 
 class SymbolPrototype final : public Object {
     JS_OBJECT(SymbolPrototype, Object);
+    JS_DECLARE_ALLOCATOR(SymbolPrototype);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/Temporal/Calendar.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/Calendar.cpp
@@ -27,6 +27,8 @@
 
 namespace JS::Temporal {
 
+JS_DEFINE_ALLOCATOR(Calendar);
+
 // 12 Temporal.Calendar Objects, https://tc39.es/proposal-temporal/#sec-temporal-calendar-objects
 Calendar::Calendar(String identifier, Object& prototype)
     : Object(ConstructWithPrototypeTag::Tag, prototype)

--- a/Userland/Libraries/LibJS/Runtime/Temporal/Calendar.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/Calendar.h
@@ -18,6 +18,7 @@ namespace JS::Temporal {
 
 class Calendar final : public Object {
     JS_OBJECT(Calendar, Object);
+    JS_DECLARE_ALLOCATOR(Calendar);
 
 public:
     virtual ~Calendar() override = default;

--- a/Userland/Libraries/LibJS/Runtime/Temporal/CalendarConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/CalendarConstructor.cpp
@@ -10,6 +10,8 @@
 
 namespace JS::Temporal {
 
+JS_DEFINE_ALLOCATOR(CalendarConstructor);
+
 // 12.2 The Temporal.Calendar Constructor, https://tc39.es/proposal-temporal/#sec-temporal-calendar-constructor
 CalendarConstructor::CalendarConstructor(Realm& realm)
     : NativeFunction(realm.vm().names.Calendar.as_string(), realm.intrinsics().function_prototype())

--- a/Userland/Libraries/LibJS/Runtime/Temporal/CalendarConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/CalendarConstructor.h
@@ -12,6 +12,7 @@ namespace JS::Temporal {
 
 class CalendarConstructor final : public NativeFunction {
     JS_OBJECT(CalendarConstructor, NativeFunction);
+    JS_DECLARE_ALLOCATOR(CalendarConstructor);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/Temporal/CalendarPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/CalendarPrototype.cpp
@@ -19,6 +19,8 @@
 
 namespace JS::Temporal {
 
+JS_DEFINE_ALLOCATOR(CalendarPrototype);
+
 [[nodiscard]] static i32 iso_year(Object& temporal_object);
 [[nodiscard]] static u8 iso_month(Object& temporal_object);
 [[nodiscard]] static u8 iso_day(Object& temporal_object);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/CalendarPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/CalendarPrototype.h
@@ -13,6 +13,7 @@ namespace JS::Temporal {
 
 class CalendarPrototype final : public PrototypeObject<CalendarPrototype, Calendar> {
     JS_PROTOTYPE_OBJECT(CalendarPrototype, Calendar, Temporal.Calendar);
+    JS_DECLARE_ALLOCATOR(CalendarPrototype);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/Temporal/Duration.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/Duration.cpp
@@ -23,6 +23,8 @@
 
 namespace JS::Temporal {
 
+JS_DEFINE_ALLOCATOR(Duration);
+
 // 7 Temporal.Duration Objects, https://tc39.es/proposal-temporal/#sec-temporal-duration-objects
 Duration::Duration(double years, double months, double weeks, double days, double hours, double minutes, double seconds, double milliseconds, double microseconds, double nanoseconds, Object& prototype)
     : Object(ConstructWithPrototypeTag::Tag, prototype)

--- a/Userland/Libraries/LibJS/Runtime/Temporal/Duration.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/Duration.h
@@ -19,6 +19,7 @@ namespace JS::Temporal {
 
 class Duration final : public Object {
     JS_OBJECT(Duration, Object);
+    JS_DECLARE_ALLOCATOR(Duration);
 
 public:
     virtual ~Duration() override = default;

--- a/Userland/Libraries/LibJS/Runtime/Temporal/DurationConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/DurationConstructor.h
@@ -12,6 +12,7 @@ namespace JS::Temporal {
 
 class DurationConstructor final : public NativeFunction {
     JS_OBJECT(DurationConstructor, NativeFunction);
+    JS_DECLARE_ALLOCATOR(DurationConstructor);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/Temporal/DurationPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/DurationPrototype.cpp
@@ -14,6 +14,8 @@
 
 namespace JS::Temporal {
 
+JS_DEFINE_ALLOCATOR(DurationPrototype);
+
 // 7.3 Properties of the Temporal.Duration Prototype Object, https://tc39.es/proposal-temporal/#sec-properties-of-the-temporal-duration-prototype-object
 DurationPrototype::DurationPrototype(Realm& realm)
     : PrototypeObject(realm.intrinsics().object_prototype())

--- a/Userland/Libraries/LibJS/Runtime/Temporal/DurationPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/DurationPrototype.h
@@ -13,6 +13,7 @@ namespace JS::Temporal {
 
 class DurationPrototype final : public PrototypeObject<DurationPrototype, Duration> {
     JS_PROTOTYPE_OBJECT(DurationPrototype, Duration, Temporal.Duration);
+    JS_DECLARE_ALLOCATOR(DurationPrototype);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/Temporal/Instant.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/Instant.cpp
@@ -22,6 +22,8 @@
 
 namespace JS::Temporal {
 
+JS_DEFINE_ALLOCATOR(Instant);
+
 // 8 Temporal.Instant Objects, https://tc39.es/proposal-temporal/#sec-temporal-instant-objects
 Instant::Instant(BigInt const& nanoseconds, Object& prototype)
     : Object(ConstructWithPrototypeTag::Tag, prototype)

--- a/Userland/Libraries/LibJS/Runtime/Temporal/Instant.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/Instant.h
@@ -18,6 +18,7 @@ namespace JS::Temporal {
 
 class Instant final : public Object {
     JS_OBJECT(Instant, Object);
+    JS_DECLARE_ALLOCATOR(Instant);
 
 public:
     virtual ~Instant() override = default;

--- a/Userland/Libraries/LibJS/Runtime/Temporal/InstantConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/InstantConstructor.cpp
@@ -13,6 +13,8 @@
 
 namespace JS::Temporal {
 
+JS_DEFINE_ALLOCATOR(InstantConstructor);
+
 // 8.1 The Temporal.Instant Constructor, https://tc39.es/proposal-temporal/#sec-temporal-instant-constructor
 InstantConstructor::InstantConstructor(Realm& realm)
     : NativeFunction(realm.vm().names.Instant.as_string(), realm.intrinsics().function_prototype())

--- a/Userland/Libraries/LibJS/Runtime/Temporal/InstantConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/InstantConstructor.h
@@ -12,6 +12,7 @@ namespace JS::Temporal {
 
 class InstantConstructor final : public NativeFunction {
     JS_OBJECT(InstantConstructor, NativeFunction);
+    JS_DECLARE_ALLOCATOR(InstantConstructor);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/Temporal/InstantPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/InstantPrototype.cpp
@@ -18,6 +18,8 @@
 
 namespace JS::Temporal {
 
+JS_DEFINE_ALLOCATOR(InstantPrototype);
+
 // 8.3 Properties of the Temporal.Instant Prototype Object, https://tc39.es/proposal-temporal/#sec-properties-of-the-temporal-instant-prototype-object
 InstantPrototype::InstantPrototype(Realm& realm)
     : PrototypeObject(realm.intrinsics().object_prototype())

--- a/Userland/Libraries/LibJS/Runtime/Temporal/InstantPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/InstantPrototype.h
@@ -13,6 +13,7 @@ namespace JS::Temporal {
 
 class InstantPrototype final : public PrototypeObject<InstantPrototype, Instant> {
     JS_PROTOTYPE_OBJECT(InstantPrototype, Instant, Temporal.Instant);
+    JS_DECLARE_ALLOCATOR(InstantPrototype);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/Temporal/Now.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/Now.cpp
@@ -20,6 +20,8 @@
 
 namespace JS::Temporal {
 
+JS_DEFINE_ALLOCATOR(Now);
+
 // 2 The Temporal.Now Object, https://tc39.es/proposal-temporal/#sec-temporal-now-object
 Now::Now(Realm& realm)
     : Object(ConstructWithPrototypeTag::Tag, realm.intrinsics().object_prototype())

--- a/Userland/Libraries/LibJS/Runtime/Temporal/Now.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/Now.h
@@ -13,6 +13,7 @@ namespace JS::Temporal {
 
 class Now final : public Object {
     JS_OBJECT(Now, Object);
+    JS_DECLARE_ALLOCATOR(Now);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDate.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDate.cpp
@@ -22,6 +22,8 @@
 
 namespace JS::Temporal {
 
+JS_DEFINE_ALLOCATOR(PlainDate);
+
 // 3 Temporal.PlainDate Objects, https://tc39.es/proposal-temporal/#sec-temporal-plaindate-objects
 PlainDate::PlainDate(i32 year, u8 month, u8 day, Object& calendar, Object& prototype)
     : Object(ConstructWithPrototypeTag::Tag, prototype)

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDate.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDate.h
@@ -16,6 +16,7 @@ namespace JS::Temporal {
 
 class PlainDate final : public Object {
     JS_OBJECT(PlainDate, Object);
+    JS_DECLARE_ALLOCATOR(PlainDate);
 
 public:
     virtual ~PlainDate() override = default;

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateConstructor.cpp
@@ -14,6 +14,8 @@
 
 namespace JS::Temporal {
 
+JS_DEFINE_ALLOCATOR(PlainDateConstructor);
+
 // 3.1 The Temporal.PlainDate Constructor, https://tc39.es/proposal-temporal/#sec-temporal-plaindate-constructor
 PlainDateConstructor::PlainDateConstructor(Realm& realm)
     : NativeFunction(realm.vm().names.PlainDate.as_string(), realm.intrinsics().function_prototype())

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateConstructor.h
@@ -12,6 +12,7 @@ namespace JS::Temporal {
 
 class PlainDateConstructor final : public NativeFunction {
     JS_OBJECT(PlainDateConstructor, NativeFunction);
+    JS_DECLARE_ALLOCATOR(PlainDateConstructor);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDatePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDatePrototype.cpp
@@ -19,6 +19,8 @@
 
 namespace JS::Temporal {
 
+JS_DEFINE_ALLOCATOR(PlainDatePrototype);
+
 // 3.3 Properties of the Temporal.PlainDate Prototype Object, https://tc39.es/proposal-temporal/#sec-properties-of-the-temporal-plaindate-prototype-object
 PlainDatePrototype::PlainDatePrototype(Realm& realm)
     : PrototypeObject(realm.intrinsics().object_prototype())

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDatePrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDatePrototype.h
@@ -13,6 +13,7 @@ namespace JS::Temporal {
 
 class PlainDatePrototype final : public PrototypeObject<PlainDatePrototype, PlainDate> {
     JS_PROTOTYPE_OBJECT(PlainDatePrototype, PlainDate, Temporal.PlainDate);
+    JS_DECLARE_ALLOCATOR(PlainDatePrototype);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTime.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTime.cpp
@@ -23,6 +23,8 @@
 
 namespace JS::Temporal {
 
+JS_DEFINE_ALLOCATOR(PlainDateTime);
+
 // 5 Temporal.PlainDateTime Objects, https://tc39.es/proposal-temporal/#sec-temporal-plaindatetime-objects
 PlainDateTime::PlainDateTime(i32 iso_year, u8 iso_month, u8 iso_day, u8 iso_hour, u8 iso_minute, u8 iso_second, u16 iso_millisecond, u16 iso_microsecond, u16 iso_nanosecond, Object& calendar, Object& prototype)
     : Object(ConstructWithPrototypeTag::Tag, prototype)

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTime.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTime.h
@@ -17,6 +17,7 @@ namespace JS::Temporal {
 
 class PlainDateTime final : public Object {
     JS_OBJECT(PlainDateTime, Object);
+    JS_DECLARE_ALLOCATOR(PlainDateTime);
 
 public:
     virtual ~PlainDateTime() override = default;

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimeConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimeConstructor.cpp
@@ -14,6 +14,8 @@
 
 namespace JS::Temporal {
 
+JS_DEFINE_ALLOCATOR(PlainDateTimeConstructor);
+
 // 5.1 The Temporal.PlainDateTime Constructor, https://tc39.es/proposal-temporal/#sec-temporal-plaindatetime-constructor
 PlainDateTimeConstructor::PlainDateTimeConstructor(Realm& realm)
     : NativeFunction(realm.vm().names.PlainDateTime.as_string(), realm.intrinsics().function_prototype())

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimeConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimeConstructor.h
@@ -12,6 +12,7 @@ namespace JS::Temporal {
 
 class PlainDateTimeConstructor final : public NativeFunction {
     JS_OBJECT(PlainDateTimeConstructor, NativeFunction);
+    JS_DECLARE_ALLOCATOR(PlainDateTimeConstructor);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.cpp
@@ -20,6 +20,8 @@
 
 namespace JS::Temporal {
 
+JS_DEFINE_ALLOCATOR(PlainDateTimePrototype);
+
 // 5.3 Properties of the Temporal.PlainDateTime Prototype Object, https://tc39.es/proposal-temporal/#sec-properties-of-the-temporal-plaindatetime-prototype-object
 PlainDateTimePrototype::PlainDateTimePrototype(Realm& realm)
     : PrototypeObject(realm.intrinsics().object_prototype())

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.h
@@ -13,6 +13,7 @@ namespace JS::Temporal {
 
 class PlainDateTimePrototype final : public PrototypeObject<PlainDateTimePrototype, PlainDateTime> {
     JS_PROTOTYPE_OBJECT(PlainDateTimePrototype, PlainDateTime, Temporal.PlainDateTime);
+    JS_DECLARE_ALLOCATOR(PlainDateTimePrototype);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainMonthDay.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainMonthDay.cpp
@@ -18,6 +18,8 @@
 
 namespace JS::Temporal {
 
+JS_DEFINE_ALLOCATOR(PlainMonthDay);
+
 // 10 Temporal.PlainMonthDay Objects, https://tc39.es/proposal-temporal/#sec-temporal-plainmonthday-objects
 PlainMonthDay::PlainMonthDay(u8 iso_month, u8 iso_day, i32 iso_year, Object& calendar, Object& prototype)
     : Object(ConstructWithPrototypeTag::Tag, prototype)

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainMonthDay.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainMonthDay.h
@@ -12,6 +12,7 @@ namespace JS::Temporal {
 
 class PlainMonthDay final : public Object {
     JS_OBJECT(PlainMonthDay, Object);
+    JS_DECLARE_ALLOCATOR(PlainMonthDay);
 
 public:
     virtual ~PlainMonthDay() override = default;

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainMonthDayConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainMonthDayConstructor.cpp
@@ -13,6 +13,8 @@
 
 namespace JS::Temporal {
 
+JS_DEFINE_ALLOCATOR(PlainMonthDayConstructor);
+
 // 10.1 The Temporal.PlainMonthDay Constructor, https://tc39.es/proposal-temporal/#sec-temporal-plainmonthday-constructor
 PlainMonthDayConstructor::PlainMonthDayConstructor(Realm& realm)
     : NativeFunction(realm.vm().names.PlainMonthDay.as_string(), realm.intrinsics().function_prototype())

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainMonthDayConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainMonthDayConstructor.h
@@ -12,6 +12,7 @@ namespace JS::Temporal {
 
 class PlainMonthDayConstructor final : public NativeFunction {
     JS_OBJECT(PlainMonthDayConstructor, NativeFunction);
+    JS_DECLARE_ALLOCATOR(PlainMonthDayConstructor);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainMonthDayPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainMonthDayPrototype.cpp
@@ -14,6 +14,8 @@
 
 namespace JS::Temporal {
 
+JS_DEFINE_ALLOCATOR(PlainMonthDayPrototype);
+
 // 10.3 Properties of the Temporal.PlainMonthDay Prototype Object, https://tc39.es/proposal-temporal/#sec-properties-of-the-temporal-plainmonthday-prototype-object
 PlainMonthDayPrototype::PlainMonthDayPrototype(Realm& realm)
     : PrototypeObject(realm.intrinsics().object_prototype())

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainMonthDayPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainMonthDayPrototype.h
@@ -13,6 +13,7 @@ namespace JS::Temporal {
 
 class PlainMonthDayPrototype final : public PrototypeObject<PlainMonthDayPrototype, PlainMonthDay> {
     JS_PROTOTYPE_OBJECT(PlainMonthDayPrototype, PlainMonthDay, Temporal.PlainMonthDay);
+    JS_DECLARE_ALLOCATOR(PlainMonthDayPrototype);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainTime.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainTime.cpp
@@ -22,6 +22,8 @@
 
 namespace JS::Temporal {
 
+JS_DEFINE_ALLOCATOR(PlainTime);
+
 // 4 Temporal.PlainTime Objects, https://tc39.es/proposal-temporal/#sec-temporal-plaintime-objects
 PlainTime::PlainTime(u8 iso_hour, u8 iso_minute, u8 iso_second, u16 iso_millisecond, u16 iso_microsecond, u16 iso_nanosecond, Calendar& calendar, Object& prototype)
     : Object(ConstructWithPrototypeTag::Tag, prototype)

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainTime.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainTime.h
@@ -17,6 +17,7 @@ namespace JS::Temporal {
 
 class PlainTime final : public Object {
     JS_OBJECT(PlainDateTime, Object);
+    JS_DECLARE_ALLOCATOR(PlainTime);
 
 public:
     virtual ~PlainTime() override = default;

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainTimeConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainTimeConstructor.cpp
@@ -12,6 +12,8 @@
 
 namespace JS::Temporal {
 
+JS_DEFINE_ALLOCATOR(PlainTimeConstructor);
+
 // 4.1 The Temporal.PlainTime Constructor, https://tc39.es/proposal-temporal/#sec-temporal-plaintime-constructor
 PlainTimeConstructor::PlainTimeConstructor(Realm& realm)
     : NativeFunction(realm.vm().names.PlainTime.as_string(), realm.intrinsics().function_prototype())

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainTimeConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainTimeConstructor.h
@@ -12,6 +12,7 @@ namespace JS::Temporal {
 
 class PlainTimeConstructor final : public NativeFunction {
     JS_OBJECT(PlainTimeConstructor, NativeFunction);
+    JS_DECLARE_ALLOCATOR(PlainTimeConstructor);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainTimePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainTimePrototype.cpp
@@ -19,6 +19,8 @@
 
 namespace JS::Temporal {
 
+JS_DEFINE_ALLOCATOR(PlainTimePrototype);
+
 // 4.3 Properties of the Temporal.PlainTime Prototype Object, https://tc39.es/proposal-temporal/#sec-properties-of-the-temporal-plaintime-prototype-object
 PlainTimePrototype::PlainTimePrototype(Realm& realm)
     : PrototypeObject(realm.intrinsics().object_prototype())

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainTimePrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainTimePrototype.h
@@ -13,6 +13,7 @@ namespace JS::Temporal {
 
 class PlainTimePrototype final : public PrototypeObject<PlainTimePrototype, PlainTime> {
     JS_PROTOTYPE_OBJECT(PlainTimePrototype, PlainTime, Temporal.PlainTime);
+    JS_DECLARE_ALLOCATOR(PlainTimePrototype);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonth.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonth.cpp
@@ -17,6 +17,8 @@
 
 namespace JS::Temporal {
 
+JS_DEFINE_ALLOCATOR(PlainYearMonth);
+
 // 9 Temporal.PlainYearMonth Objects, https://tc39.es/proposal-temporal/#sec-temporal-plainyearmonth-objects
 PlainYearMonth::PlainYearMonth(i32 iso_year, u8 iso_month, u8 iso_day, Object& calendar, Object& prototype)
     : Object(ConstructWithPrototypeTag::Tag, prototype)

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonth.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonth.h
@@ -13,6 +13,7 @@ namespace JS::Temporal {
 
 class PlainYearMonth final : public Object {
     JS_OBJECT(PlainYearMonth, Object);
+    JS_DECLARE_ALLOCATOR(PlainYearMonth);
 
 public:
     virtual ~PlainYearMonth() override = default;

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonthConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonthConstructor.cpp
@@ -14,6 +14,8 @@
 
 namespace JS::Temporal {
 
+JS_DEFINE_ALLOCATOR(PlainYearMonthConstructor);
+
 // 9.1 The Temporal.PlainYearMonth Constructor, https://tc39.es/proposal-temporal/#sec-temporal-plainyearmonth-constructor
 PlainYearMonthConstructor::PlainYearMonthConstructor(Realm& realm)
     : NativeFunction(realm.vm().names.PlainYearMonth.as_string(), realm.intrinsics().function_prototype())

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonthConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonthConstructor.h
@@ -12,6 +12,7 @@ namespace JS::Temporal {
 
 class PlainYearMonthConstructor final : public NativeFunction {
     JS_OBJECT(PlainYearMonthConstructor, NativeFunction);
+    JS_DECLARE_ALLOCATOR(PlainYearMonthConstructor);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonthPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonthPrototype.cpp
@@ -16,6 +16,8 @@
 
 namespace JS::Temporal {
 
+JS_DEFINE_ALLOCATOR(PlainYearMonthPrototype);
+
 // 9.3 Properties of the Temporal.PlainYearMonth Prototype Object, https://tc39.es/proposal-temporal/#sec-properties-of-the-temporal-plainyearmonth-prototype-object
 PlainYearMonthPrototype::PlainYearMonthPrototype(Realm& realm)
     : PrototypeObject(realm.intrinsics().object_prototype())

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonthPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonthPrototype.h
@@ -13,6 +13,7 @@ namespace JS::Temporal {
 
 class PlainYearMonthPrototype final : public PrototypeObject<PlainYearMonthPrototype, PlainYearMonth> {
     JS_PROTOTYPE_OBJECT(PlainYearMonthPrototype, PlainYearMonth, Temporal.PlainYearMonth);
+    JS_DECLARE_ALLOCATOR(PlainYearMonthPrototype);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/Temporal/Temporal.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/Temporal.cpp
@@ -20,6 +20,8 @@
 
 namespace JS::Temporal {
 
+JS_DEFINE_ALLOCATOR(Temporal);
+
 // 1 The Temporal Object, https://tc39.es/proposal-temporal/#sec-temporal-objects
 Temporal::Temporal(Realm& realm)
     : Object(ConstructWithPrototypeTag::Tag, realm.intrinsics().object_prototype())

--- a/Userland/Libraries/LibJS/Runtime/Temporal/Temporal.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/Temporal.h
@@ -12,6 +12,7 @@ namespace JS::Temporal {
 
 class Temporal final : public Object {
     JS_OBJECT(Temporal, Object);
+    JS_DECLARE_ALLOCATOR(Temporal);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/Temporal/TimeZone.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/TimeZone.cpp
@@ -22,6 +22,8 @@
 
 namespace JS::Temporal {
 
+JS_DEFINE_ALLOCATOR(TimeZone);
+
 // 11 Temporal.TimeZone Objects, https://tc39.es/proposal-temporal/#sec-temporal-timezone-objects
 TimeZone::TimeZone(Object& prototype)
     : Object(ConstructWithPrototypeTag::Tag, prototype)

--- a/Userland/Libraries/LibJS/Runtime/Temporal/TimeZone.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/TimeZone.h
@@ -15,6 +15,7 @@ namespace JS::Temporal {
 
 class TimeZone final : public Object {
     JS_OBJECT(TimeZone, Object);
+    JS_DECLARE_ALLOCATOR(TimeZone);
 
 public:
     // Needs to store values in the range -8.64 * 10^13 to 8.64 * 10^13

--- a/Userland/Libraries/LibJS/Runtime/Temporal/TimeZoneConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/TimeZoneConstructor.cpp
@@ -11,6 +11,8 @@
 
 namespace JS::Temporal {
 
+JS_DEFINE_ALLOCATOR(TimeZoneConstructor);
+
 // 11.2 The Temporal.TimeZone Constructor, https://tc39.es/proposal-temporal/#sec-temporal-timezone-constructor
 TimeZoneConstructor::TimeZoneConstructor(Realm& realm)
     : NativeFunction(realm.vm().names.TimeZone.as_string(), realm.intrinsics().function_prototype())

--- a/Userland/Libraries/LibJS/Runtime/Temporal/TimeZoneConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/TimeZoneConstructor.h
@@ -12,6 +12,7 @@ namespace JS::Temporal {
 
 class TimeZoneConstructor final : public NativeFunction {
     JS_OBJECT(TimeZoneConstructor, NativeFunction);
+    JS_DECLARE_ALLOCATOR(TimeZoneConstructor);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/Temporal/TimeZonePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/TimeZonePrototype.cpp
@@ -17,6 +17,8 @@
 
 namespace JS::Temporal {
 
+JS_DEFINE_ALLOCATOR(TimeZonePrototype);
+
 // 11.4 Properties of the Temporal.TimeZone Prototype Object, https://tc39.es/proposal-temporal/#sec-properties-of-the-temporal-timezone-prototype-object
 TimeZonePrototype::TimeZonePrototype(Realm& realm)
     : PrototypeObject(realm.intrinsics().object_prototype())

--- a/Userland/Libraries/LibJS/Runtime/Temporal/TimeZonePrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/TimeZonePrototype.h
@@ -13,6 +13,7 @@ namespace JS::Temporal {
 
 class TimeZonePrototype final : public PrototypeObject<TimeZonePrototype, TimeZone> {
     JS_PROTOTYPE_OBJECT(TimeZonePrototype, TimeZone, Temporal.TimeZone);
+    JS_DECLARE_ALLOCATOR(TimeZonePrototype);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTime.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTime.cpp
@@ -20,6 +20,8 @@
 
 namespace JS::Temporal {
 
+JS_DEFINE_ALLOCATOR(ZonedDateTime);
+
 // 6 Temporal.ZonedDateTime Objects, https://tc39.es/proposal-temporal/#sec-temporal-zoneddatetime-objects
 ZonedDateTime::ZonedDateTime(BigInt const& nanoseconds, Object& time_zone, Object& calendar, Object& prototype)
     : Object(ConstructWithPrototypeTag::Tag, prototype)

--- a/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTime.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTime.h
@@ -14,6 +14,7 @@ namespace JS::Temporal {
 
 class ZonedDateTime final : public Object {
     JS_OBJECT(ZonedDateTime, Object);
+    JS_DECLARE_ALLOCATOR(ZonedDateTime);
 
 public:
     virtual ~ZonedDateTime() override = default;

--- a/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTimeConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTimeConstructor.cpp
@@ -15,6 +15,8 @@
 
 namespace JS::Temporal {
 
+JS_DEFINE_ALLOCATOR(ZonedDateTimeConstructor);
+
 // 6.1 The Temporal.ZonedDateTime Constructor, https://tc39.es/proposal-temporal/#sec-temporal-zoneddatetime-constructor
 ZonedDateTimeConstructor::ZonedDateTimeConstructor(Realm& realm)
     : NativeFunction(realm.vm().names.ZonedDateTime.as_string(), realm.intrinsics().function_prototype())

--- a/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTimeConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTimeConstructor.h
@@ -12,6 +12,7 @@ namespace JS::Temporal {
 
 class ZonedDateTimeConstructor final : public NativeFunction {
     JS_OBJECT(ZonedDateTimeConstructor, NativeFunction);
+    JS_DECLARE_ALLOCATOR(ZonedDateTimeConstructor);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTimePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTimePrototype.cpp
@@ -20,6 +20,8 @@
 
 namespace JS::Temporal {
 
+JS_DEFINE_ALLOCATOR(ZonedDateTimePrototype);
+
 // 6.3 Properties of the Temporal.ZonedDateTime Prototype Object, https://tc39.es/proposal-temporal/#sec-properties-of-the-temporal-zoneddatetime-prototype-object
 ZonedDateTimePrototype::ZonedDateTimePrototype(Realm& realm)
     : PrototypeObject(realm.intrinsics().object_prototype())

--- a/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTimePrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTimePrototype.h
@@ -13,6 +13,7 @@ namespace JS::Temporal {
 
 class ZonedDateTimePrototype final : public PrototypeObject<ZonedDateTimePrototype, ZonedDateTime> {
     JS_PROTOTYPE_OBJECT(ZonedDateTimePrototype, ZonedDateTime, Temporal.ZonedDateTime);
+    JS_DECLARE_ALLOCATOR(ZonedDateTimePrototype);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/TypedArray.cpp
+++ b/Userland/Libraries/LibJS/Runtime/TypedArray.cpp
@@ -421,6 +421,9 @@ void TypedArrayBase::visit_edges(Visitor& visitor)
 }
 
 #define JS_DEFINE_TYPED_ARRAY(ClassName, snake_name, PrototypeName, ConstructorName, Type)                                  \
+    JS_DEFINE_ALLOCATOR(ClassName);                                                                                         \
+    JS_DEFINE_ALLOCATOR(PrototypeName);                                                                                     \
+    JS_DEFINE_ALLOCATOR(ConstructorName);                                                                                   \
     ThrowCompletionOr<NonnullGCPtr<ClassName>> ClassName::create(Realm& realm, u32 length, FunctionObject& new_target)      \
     {                                                                                                                       \
         auto* prototype = TRY(get_prototype_from_constructor(realm.vm(), new_target, &Intrinsics::snake_name##_prototype)); \

--- a/Userland/Libraries/LibJS/Runtime/TypedArray.h
+++ b/Userland/Libraries/LibJS/Runtime/TypedArray.h
@@ -464,6 +464,7 @@ ThrowCompletionOr<double> compare_typed_array_elements(VM&, Value x, Value y, Fu
 #define JS_DECLARE_TYPED_ARRAY(ClassName, snake_name, PrototypeName, ConstructorName, Type)                       \
     class ClassName : public TypedArray<Type> {                                                                   \
         JS_OBJECT(ClassName, TypedArray);                                                                         \
+        JS_DECLARE_ALLOCATOR(ClassName);                                                                          \
                                                                                                                   \
     public:                                                                                                       \
         virtual ~ClassName();                                                                                     \
@@ -477,6 +478,7 @@ ThrowCompletionOr<double> compare_typed_array_elements(VM&, Value x, Value y, Fu
     };                                                                                                            \
     class PrototypeName final : public Object {                                                                   \
         JS_OBJECT(PrototypeName, Object);                                                                         \
+        JS_DECLARE_ALLOCATOR(PrototypeName);                                                                      \
                                                                                                                   \
     public:                                                                                                       \
         virtual void initialize(Realm&) override;                                                                 \
@@ -487,6 +489,7 @@ ThrowCompletionOr<double> compare_typed_array_elements(VM&, Value x, Value y, Fu
     };                                                                                                            \
     class ConstructorName final : public TypedArrayConstructor {                                                  \
         JS_OBJECT(ConstructorName, TypedArrayConstructor);                                                        \
+        JS_DECLARE_ALLOCATOR(ConstructorName);                                                                    \
                                                                                                                   \
     public:                                                                                                       \
         virtual void initialize(Realm&) override;                                                                 \

--- a/Userland/Libraries/LibJS/Runtime/TypedArrayConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/TypedArrayConstructor.cpp
@@ -11,6 +11,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(TypedArrayConstructor);
+
 TypedArrayConstructor::TypedArrayConstructor(DeprecatedFlyString const& name, Object& prototype)
     : NativeFunction(name, prototype)
 {

--- a/Userland/Libraries/LibJS/Runtime/TypedArrayConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/TypedArrayConstructor.h
@@ -12,6 +12,7 @@ namespace JS {
 
 class TypedArrayConstructor : public NativeFunction {
     JS_OBJECT(TypedArrayConstructor, NativeFunction);
+    JS_DECLARE_ALLOCATOR(TypedArrayConstructor);
 
 public:
     explicit TypedArrayConstructor(Realm&);

--- a/Userland/Libraries/LibJS/Runtime/TypedArrayPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/TypedArrayPrototype.cpp
@@ -17,6 +17,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(TypedArrayPrototype);
+
 TypedArrayPrototype::TypedArrayPrototype(Realm& realm)
     : Object(ConstructWithPrototypeTag::Tag, realm.intrinsics().object_prototype())
 {

--- a/Userland/Libraries/LibJS/Runtime/TypedArrayPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/TypedArrayPrototype.h
@@ -13,6 +13,7 @@ namespace JS {
 
 class TypedArrayPrototype final : public Object {
     JS_OBJECT(TypedArrayPrototype, Object);
+    JS_DECLARE_ALLOCATOR(TypedArrayPrototype);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/WeakMap.cpp
+++ b/Userland/Libraries/LibJS/Runtime/WeakMap.cpp
@@ -8,6 +8,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(WeakMap);
+
 NonnullGCPtr<WeakMap> WeakMap::create(Realm& realm)
 {
     return realm.heap().allocate<WeakMap>(realm, realm.intrinsics().weak_map_prototype());

--- a/Userland/Libraries/LibJS/Runtime/WeakMap.h
+++ b/Userland/Libraries/LibJS/Runtime/WeakMap.h
@@ -17,6 +17,7 @@ class WeakMap final
     : public Object
     , public WeakContainer {
     JS_OBJECT(WeakMap, Object);
+    JS_DECLARE_ALLOCATOR(WeakMap);
 
 public:
     static NonnullGCPtr<WeakMap> create(Realm&);

--- a/Userland/Libraries/LibJS/Runtime/WeakMapConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/WeakMapConstructor.cpp
@@ -13,6 +13,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(WeakMapConstructor);
+
 WeakMapConstructor::WeakMapConstructor(Realm& realm)
     : NativeFunction(realm.vm().names.WeakMap.as_string(), realm.intrinsics().function_prototype())
 {

--- a/Userland/Libraries/LibJS/Runtime/WeakMapConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/WeakMapConstructor.h
@@ -12,6 +12,7 @@ namespace JS {
 
 class WeakMapConstructor final : public NativeFunction {
     JS_OBJECT(WeakMapConstructor, NativeFunction);
+    JS_DECLARE_ALLOCATOR(WeakMapConstructor);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/WeakMapPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/WeakMapPrototype.cpp
@@ -11,6 +11,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(WeakMapPrototype);
+
 WeakMapPrototype::WeakMapPrototype(Realm& realm)
     : PrototypeObject(realm.intrinsics().object_prototype())
 {

--- a/Userland/Libraries/LibJS/Runtime/WeakMapPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/WeakMapPrototype.h
@@ -13,6 +13,7 @@ namespace JS {
 
 class WeakMapPrototype final : public PrototypeObject<WeakMapPrototype, WeakMap> {
     JS_PROTOTYPE_OBJECT(WeakMapPrototype, WeakMap, WeakMap);
+    JS_DECLARE_ALLOCATOR(WeakMapPrototype);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/WeakRef.cpp
+++ b/Userland/Libraries/LibJS/Runtime/WeakRef.cpp
@@ -8,6 +8,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(WeakRef);
+
 NonnullGCPtr<WeakRef> WeakRef::create(Realm& realm, Object& value)
 {
     return realm.heap().allocate<WeakRef>(realm, value, realm.intrinsics().weak_ref_prototype());

--- a/Userland/Libraries/LibJS/Runtime/WeakRef.h
+++ b/Userland/Libraries/LibJS/Runtime/WeakRef.h
@@ -16,6 +16,7 @@ class WeakRef final
     : public Object
     , public WeakContainer {
     JS_OBJECT(WeakRef, Object);
+    JS_DECLARE_ALLOCATOR(WeakRef);
 
 public:
     static NonnullGCPtr<WeakRef> create(Realm&, Object&);

--- a/Userland/Libraries/LibJS/Runtime/WeakRefConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/WeakRefConstructor.cpp
@@ -12,6 +12,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(WeakRefConstructor);
+
 WeakRefConstructor::WeakRefConstructor(Realm& realm)
     : NativeFunction(realm.vm().names.WeakRef.as_string(), realm.intrinsics().function_prototype())
 {

--- a/Userland/Libraries/LibJS/Runtime/WeakRefConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/WeakRefConstructor.h
@@ -12,6 +12,7 @@ namespace JS {
 
 class WeakRefConstructor final : public NativeFunction {
     JS_OBJECT(WeakRefConstructor, NativeFunction);
+    JS_DECLARE_ALLOCATOR(WeakRefConstructor);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/WeakRefPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/WeakRefPrototype.cpp
@@ -9,6 +9,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(WeakRefPrototype);
+
 WeakRefPrototype::WeakRefPrototype(Realm& realm)
     : PrototypeObject(realm.intrinsics().object_prototype())
 {

--- a/Userland/Libraries/LibJS/Runtime/WeakRefPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/WeakRefPrototype.h
@@ -13,6 +13,7 @@ namespace JS {
 
 class WeakRefPrototype final : public PrototypeObject<WeakRefPrototype, WeakRef> {
     JS_PROTOTYPE_OBJECT(WeakRefPrototype, WeakRef, WeakRef);
+    JS_DECLARE_ALLOCATOR(WeakRefPrototype);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/WeakSet.cpp
+++ b/Userland/Libraries/LibJS/Runtime/WeakSet.cpp
@@ -8,6 +8,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(WeakSet);
+
 NonnullGCPtr<WeakSet> WeakSet::create(Realm& realm)
 {
     return realm.heap().allocate<WeakSet>(realm, realm.intrinsics().weak_set_prototype());

--- a/Userland/Libraries/LibJS/Runtime/WeakSet.h
+++ b/Userland/Libraries/LibJS/Runtime/WeakSet.h
@@ -17,6 +17,7 @@ class WeakSet final
     : public Object
     , public WeakContainer {
     JS_OBJECT(WeakSet, Object);
+    JS_DECLARE_ALLOCATOR(WeakSet);
 
 public:
     static NonnullGCPtr<WeakSet> create(Realm&);

--- a/Userland/Libraries/LibJS/Runtime/WeakSetConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/WeakSetConstructor.cpp
@@ -13,6 +13,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(WeakSetConstructor);
+
 WeakSetConstructor::WeakSetConstructor(Realm& realm)
     : NativeFunction(realm.vm().names.WeakSet.as_string(), realm.intrinsics().function_prototype())
 {

--- a/Userland/Libraries/LibJS/Runtime/WeakSetConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/WeakSetConstructor.h
@@ -12,6 +12,7 @@ namespace JS {
 
 class WeakSetConstructor final : public NativeFunction {
     JS_OBJECT(WeakSetConstructor, NativeFunction);
+    JS_DECLARE_ALLOCATOR(WeakSetConstructor);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/WeakSetPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/WeakSetPrototype.cpp
@@ -11,6 +11,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(WeakSetPrototype);
+
 WeakSetPrototype::WeakSetPrototype(Realm& realm)
     : PrototypeObject(realm.intrinsics().object_prototype())
 {

--- a/Userland/Libraries/LibJS/Runtime/WeakSetPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/WeakSetPrototype.h
@@ -13,6 +13,7 @@ namespace JS {
 
 class WeakSetPrototype final : public PrototypeObject<WeakSetPrototype, WeakSet> {
     JS_PROTOTYPE_OBJECT(WeakSetPrototype, WeakSet, WeakSet);
+    JS_DECLARE_ALLOCATOR(WeakSetPrototype);
 
 public:
     virtual void initialize(Realm&) override;

--- a/Userland/Libraries/LibJS/Runtime/WrappedFunction.cpp
+++ b/Userland/Libraries/LibJS/Runtime/WrappedFunction.cpp
@@ -10,6 +10,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(WrappedFunction);
+
 // 3.1.1 WrappedFunctionCreate ( callerRealm: a Realm Record, Target: a function object, ), https://tc39.es/proposal-shadowrealm/#sec-wrappedfunctioncreate
 ThrowCompletionOr<NonnullGCPtr<WrappedFunction>> WrappedFunction::create(Realm& realm, Realm& caller_realm, FunctionObject& target)
 {

--- a/Userland/Libraries/LibJS/Runtime/WrappedFunction.h
+++ b/Userland/Libraries/LibJS/Runtime/WrappedFunction.h
@@ -13,6 +13,7 @@ namespace JS {
 
 class WrappedFunction final : public FunctionObject {
     JS_OBJECT(WrappedFunction, FunctionObject);
+    JS_DECLARE_ALLOCATOR(WrappedFunction);
 
 public:
     static ThrowCompletionOr<NonnullGCPtr<WrappedFunction>> create(Realm&, Realm& caller_realm, FunctionObject& target_function);

--- a/Userland/Libraries/LibJS/Script.cpp
+++ b/Userland/Libraries/LibJS/Script.cpp
@@ -12,6 +12,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(Script);
+
 // 16.1.5 ParseScript ( sourceText, realm, hostDefined ), https://tc39.es/ecma262/#sec-parse-script
 Result<NonnullGCPtr<Script>, Vector<ParserError>> Script::parse(StringView source_text, Realm& realm, StringView filename, HostDefined* host_defined, size_t line_number_offset)
 {

--- a/Userland/Libraries/LibJS/Script.h
+++ b/Userland/Libraries/LibJS/Script.h
@@ -17,6 +17,7 @@ namespace JS {
 // 16.1.4 Script Records, https://tc39.es/ecma262/#sec-script-records
 class Script final : public Cell {
     JS_CELL(Script, Cell);
+    JS_DECLARE_ALLOCATOR(Script);
 
 public:
     struct HostDefined {

--- a/Userland/Libraries/LibJS/SourceTextModule.cpp
+++ b/Userland/Libraries/LibJS/SourceTextModule.cpp
@@ -16,6 +16,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(SourceTextModule);
+
 // 2.7 Static Semantics: AssertClauseToAssertions, https://tc39.es/proposal-import-assertions/#sec-assert-clause-to-assertions
 static Vector<ModuleRequest::Assertion> assert_clause_to_assertions(Vector<ModuleRequest::Assertion> const& source_assertions, Vector<DeprecatedString> const& supported_import_assertions)
 {

--- a/Userland/Libraries/LibJS/SourceTextModule.h
+++ b/Userland/Libraries/LibJS/SourceTextModule.h
@@ -16,6 +16,7 @@ namespace JS {
 // 16.2.1.6 Source Text Module Records, https://tc39.es/ecma262/#sec-source-text-module-records
 class SourceTextModule final : public CyclicModule {
     JS_CELL(SourceTextModule, CyclicModule);
+    JS_DECLARE_ALLOCATOR(SourceTextModule);
 
 public:
     static Result<NonnullGCPtr<SourceTextModule>, Vector<ParserError>> parse(StringView source_text, Realm&, StringView filename = {}, Script::HostDefined* host_defined = nullptr);

--- a/Userland/Libraries/LibJS/SyntheticModule.cpp
+++ b/Userland/Libraries/LibJS/SyntheticModule.cpp
@@ -13,6 +13,8 @@
 
 namespace JS {
 
+JS_DEFINE_ALLOCATOR(SyntheticModule);
+
 // 1.2.1 CreateSyntheticModule ( exportNames, evaluationSteps, realm, hostDefined ), https://tc39.es/proposal-json-modules/#sec-createsyntheticmodule
 SyntheticModule::SyntheticModule(Vector<DeprecatedFlyString> export_names, SyntheticModule::EvaluationFunction evaluation_steps, Realm& realm, StringView filename)
     : Module(realm, filename)

--- a/Userland/Libraries/LibJS/SyntheticModule.h
+++ b/Userland/Libraries/LibJS/SyntheticModule.h
@@ -13,6 +13,7 @@ namespace JS {
 // 1.2 Synthetic Module Records, https://tc39.es/proposal-json-modules/#sec-synthetic-module-records
 class SyntheticModule final : public Module {
     JS_CELL(SyntheticModule, Module);
+    JS_DECLARE_ALLOCATOR(SyntheticModule);
 
 public:
     using EvaluationFunction = Function<ThrowCompletionOr<void>(SyntheticModule&)>;


### PR DESCRIPTION
This patch adds two macros to declare per-type allocators:        
        
- `JS_DECLARE_ALLOCATOR(TypeName)`
- `JS_DEFINE_ALLOCATOR(TypeName)`
        
When used, they add a type-specific `CellAllocator` that the `Heap` will        
delegate allocation requests to.        
        
The result of this is that GC objects of the same type always end up        
within the same `HeapBlock`, drastically reducing the ability to perform        
type confusion attacks.        
        
It also improves `HeapBlock` utilization, since each block now has cells        
sized exactly to the type used within that block. (Previously we only        
had a handful of block sizes available, and most GC allocations ended        
up with a large amount of slack in their tails.)        
        
There is a small performance hit from this, but I'm sure we can make        
up for it elsewhere.        
        
Note that the old size-based allocators still exist, and we fall back        
to them for any type that doesn't have its own `CellAllocator`.        
