### PR TITLE
Shell/PosixParser: Correctly parse the OR_IF token

### DIFF
--- a/Userland/Shell/PosixParser.cpp
+++ b/Userland/Shell/PosixParser.cpp
@@ -799,7 +799,7 @@ ErrorOr<RefPtr<AST::Node>> Parser::parse_and_or()
             auto rhs = TRY(parse_pipeline());
             if (!rhs)
                 return RefPtr<AST::Node> {};
-            node = make_ref_counted<AST::And>(
+            node = make_ref_counted<AST::Or>(
                 node->position(),
                 *node,
                 rhs.release_nonnull(),


### PR DESCRIPTION
This fixes an unfortunate typo where we would parse the `OR_IF` token as an `AST::And` node. Now, it is parsed into an `AST::Or` node :^).

This fixes #19324.