### PR TITLE
LibWeb: Make DOM elements use less memory

### DIFF
--- a/Userland/Libraries/LibWeb/Bindings/MainThreadVM.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/MainThreadVM.cpp
@@ -608,9 +608,11 @@ void queue_mutation_observer_microtask(DOM::Document const& document)
                 if (node.is_null())
                     continue;
 
-                node->registered_observers_list().remove_all_matching([&mutation_observer](DOM::RegisteredObserver& registered_observer) {
-                    return is<DOM::TransientRegisteredObserver>(registered_observer) && static_cast<DOM::TransientRegisteredObserver&>(registered_observer).observer().ptr() == mutation_observer.ptr();
-                });
+                if (node->registered_observer_list()) {
+                    node->registered_observer_list()->remove_all_matching([&mutation_observer](DOM::RegisteredObserver& registered_observer) {
+                        return is<DOM::TransientRegisteredObserver>(registered_observer) && static_cast<DOM::TransientRegisteredObserver&>(registered_observer).observer().ptr() == mutation_observer.ptr();
+                    });
+                }
             }
 
             // 4. If records is not empty, then invoke mo’s callback with « records, mo », and mo. If this throws an exception, catch it, and report the exception.

--- a/Userland/Libraries/LibWeb/Bindings/MainThreadVM.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/MainThreadVM.cpp
@@ -675,12 +675,14 @@ void invoke_custom_element_reactions(Vector<JS::Handle<DOM::Element>>& element_q
         auto element = element_queue.take_first();
 
         // 2. Let reactions be element's custom element reaction queue.
-        auto& reactions = element->custom_element_reaction_queue();
+        auto* reactions = element->custom_element_reaction_queue();
 
         // 3. Repeat until reactions is empty:
-        while (!reactions.is_empty()) {
+        if (!reactions)
+            continue;
+        while (!reactions->is_empty()) {
             // 1. Remove the first element of reactions, and let reaction be that element. Switch on reaction's type:
-            auto reaction = reactions.take_first();
+            auto reaction = reactions->take_first();
 
             auto maybe_exception = reaction.visit(
                 [&](DOM::CustomElementUpgradeReaction const& custom_element_upgrade_reaction) -> JS::ThrowCompletionOr<void> {

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -2050,20 +2050,27 @@ void Element::set_computed_css_values(RefPtr<CSS::StyleProperties> style)
     m_computed_css_values = move(style);
 }
 
+auto Element::pseudo_element_custom_properties() const -> PseudoElementCustomProperties&
+{
+    if (!m_pseudo_element_custom_properties)
+        m_pseudo_element_custom_properties = make<PseudoElementCustomProperties>();
+    return *m_pseudo_element_custom_properties;
+}
+
 void Element::set_custom_properties(Optional<CSS::Selector::PseudoElement> pseudo_element, HashMap<FlyString, CSS::StyleProperty> custom_properties)
 {
     if (!pseudo_element.has_value()) {
         m_custom_properties = move(custom_properties);
         return;
     }
-    m_pseudo_element_custom_properties[to_underlying(pseudo_element.value())] = move(custom_properties);
+    pseudo_element_custom_properties()[to_underlying(pseudo_element.value())] = move(custom_properties);
 }
 
 HashMap<FlyString, CSS::StyleProperty> const& Element::custom_properties(Optional<CSS::Selector::PseudoElement> pseudo_element) const
 {
     if (!pseudo_element.has_value())
         return m_custom_properties;
-    return m_pseudo_element_custom_properties[to_underlying(pseudo_element.value())];
+    return pseudo_element_custom_properties()[to_underlying(pseudo_element.value())];
 }
 
 // https://drafts.csswg.org/cssom-view/#dom-element-scroll

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -1811,7 +1811,7 @@ void Element::enqueue_an_element_on_the_appropriate_element_queue()
 void Element::enqueue_a_custom_element_upgrade_reaction(HTML::CustomElementDefinition& custom_element_definition)
 {
     // 1. Add a new upgrade reaction to element's custom element reaction queue, with custom element definition definition.
-    m_custom_element_reaction_queue.append(CustomElementUpgradeReaction { .custom_element_definition = custom_element_definition });
+    ensure_custom_element_reaction_queue().append(CustomElementUpgradeReaction { .custom_element_definition = custom_element_definition });
 
     // 2. Enqueue an element on the appropriate element queue given element.
     enqueue_an_element_on_the_appropriate_element_queue();
@@ -1846,7 +1846,7 @@ void Element::enqueue_a_custom_element_callback_reaction(FlyString const& callba
     }
 
     // 5. Add a new callback reaction to element's custom element reaction queue, with callback function callback and arguments args.
-    m_custom_element_reaction_queue.append(CustomElementCallbackReaction { .callback = callback_iterator->value, .arguments = move(arguments) });
+    ensure_custom_element_reaction_queue().append(CustomElementCallbackReaction { .callback = callback_iterator->value, .arguments = move(arguments) });
 
     // 6. Enqueue an element on the appropriate element queue given element.
     enqueue_an_element_on_the_appropriate_element_queue();
@@ -1929,7 +1929,7 @@ JS::ThrowCompletionOr<void> Element::upgrade_element(JS::NonnullGCPtr<HTML::Cust
         m_custom_element_definition = nullptr;
 
         // 2. Empty element's custom element reaction queue.
-        m_custom_element_reaction_queue.clear();
+        m_custom_element_reaction_queue = nullptr;
 
         // 3. Rethrow the exception (thus terminating this algorithm).
         return maybe_exception.release_error();
@@ -2269,6 +2269,13 @@ void Element::attribute_change_steps(FlyString const& local_name, Optional<Strin
         // 7. Run assign a slot for element.
         assign_a_slot(JS::NonnullGCPtr { *this });
     }
+}
+
+auto Element::ensure_custom_element_reaction_queue() -> CustomElementReactionQueue&
+{
+    if (!m_custom_element_reaction_queue)
+        m_custom_element_reaction_queue = make<CustomElementReactionQueue>();
+    return *m_custom_element_reaction_queue;
 }
 
 }

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -402,7 +402,10 @@ private:
 
     RefPtr<CSS::StyleProperties> m_computed_css_values;
     HashMap<FlyString, CSS::StyleProperty> m_custom_properties;
-    Array<HashMap<FlyString, CSS::StyleProperty>, to_underlying(CSS::Selector::PseudoElement::PseudoElementCount)> m_pseudo_element_custom_properties;
+
+    using PseudoElementCustomProperties = Array<HashMap<FlyString, CSS::StyleProperty>, to_underlying(CSS::Selector::PseudoElement::PseudoElementCount)>;
+    mutable OwnPtr<PseudoElementCustomProperties> m_pseudo_element_custom_properties;
+    PseudoElementCustomProperties& pseudo_element_custom_properties() const;
 
     Vector<FlyString> m_classes;
     Optional<Dir> m_dir;

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -325,8 +325,10 @@ public:
     void enqueue_a_custom_element_upgrade_reaction(HTML::CustomElementDefinition& custom_element_definition);
     void enqueue_a_custom_element_callback_reaction(FlyString const& callback_name, JS::MarkedVector<JS::Value> arguments);
 
-    Vector<Variant<CustomElementUpgradeReaction, CustomElementCallbackReaction>>& custom_element_reaction_queue() { return m_custom_element_reaction_queue; }
-    Vector<Variant<CustomElementUpgradeReaction, CustomElementCallbackReaction>> const& custom_element_reaction_queue() const { return m_custom_element_reaction_queue; }
+    using CustomElementReactionQueue = Vector<Variant<CustomElementUpgradeReaction, CustomElementCallbackReaction>>;
+    CustomElementReactionQueue* custom_element_reaction_queue() { return m_custom_element_reaction_queue; }
+    CustomElementReactionQueue const* custom_element_reaction_queue() const { return m_custom_element_reaction_queue; }
+    CustomElementReactionQueue& ensure_custom_element_reaction_queue();
 
     JS::ThrowCompletionOr<void> upgrade_element(JS::NonnullGCPtr<HTML::CustomElementDefinition> custom_element_definition);
     void try_to_upgrade();
@@ -416,7 +418,7 @@ private:
     // https://html.spec.whatwg.org/multipage/custom-elements.html#custom-element-reaction-queue
     // All elements have an associated custom element reaction queue, initially empty. Each item in the custom element reaction queue is of one of two types:
     // NOTE: See the structs at the top of this header.
-    Vector<Variant<CustomElementUpgradeReaction, CustomElementCallbackReaction>> m_custom_element_reaction_queue;
+    OwnPtr<CustomElementReactionQueue> m_custom_element_reaction_queue;
 
     // https://dom.spec.whatwg.org/#concept-element-custom-element-state
     CustomElementState m_custom_element_state { CustomElementState::Undefined };

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -412,7 +412,8 @@ private:
 
     Optional<FlyString> m_id;
 
-    Array<JS::GCPtr<Layout::Node>, to_underlying(CSS::Selector::PseudoElement::PseudoElementCount)> m_pseudo_element_nodes;
+    using PseudoElementLayoutNodes = Array<JS::GCPtr<Layout::Node>, to_underlying(CSS::Selector::PseudoElement::PseudoElementCount)>;
+    OwnPtr<PseudoElementLayoutNodes> m_pseudo_element_nodes;
 
     // https://html.spec.whatwg.org/multipage/custom-elements.html#custom-element-reaction-queue
     // All elements have an associated custom element reaction queue, initially empty. Each item in the custom element reaction queue is of one of two types:

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -147,9 +147,8 @@ public:
     virtual void apply_presentational_hints(CSS::StyleProperties&) const { }
 
     // https://dom.spec.whatwg.org/#concept-element-attributes-change-ext
-    using AttributeChangeSteps = Function<void(FlyString const& local_name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_)>;
+    virtual void attribute_change_steps(FlyString const& local_name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_);
 
-    void add_attribute_change_steps(AttributeChangeSteps steps);
     void run_attribute_change_steps(FlyString const& local_name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_);
     virtual void attribute_changed(FlyString const& name, Optional<String> const& value);
 
@@ -395,7 +394,6 @@ private:
     FlyString m_html_uppercased_qualified_name;
 
     JS::GCPtr<NamedNodeMap> m_attributes;
-    Vector<AttributeChangeSteps> m_attribute_change_steps;
     JS::GCPtr<CSS::ElementInlineCSSStyleDeclaration> m_inline_style;
     JS::GCPtr<DOMTokenList> m_class_list;
     JS::GCPtr<ShadowRoot> m_shadow_root;

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -429,7 +429,7 @@ private:
 
     // https://www.w3.org/TR/intersection-observer/#dom-element-registeredintersectionobservers-slot
     // Element objects have an internal [[RegisteredIntersectionObservers]] slot, which is initialized to an empty list.
-    Vector<IntersectionObserver::IntersectionObserverRegistration> m_registered_intersection_observers;
+    OwnPtr<Vector<IntersectionObserver::IntersectionObserverRegistration>> m_registered_intersection_observers;
 
     Array<CSSPixelPoint, 3> m_scroll_offset;
 };

--- a/Userland/Libraries/LibWeb/DOM/EventDispatcher.cpp
+++ b/Userland/Libraries/LibWeb/DOM/EventDispatcher.cpp
@@ -242,7 +242,7 @@ bool EventDispatcher::dispatch(JS::NonnullGCPtr<EventTarget> target, Event& even
         bool is_activation_event = is<UIEvents::MouseEvent>(event) && event.type() == HTML::EventNames::click;
 
         // 5. If isActivationEvent is true and target has activation behavior, then set activationTarget to target.
-        if (is_activation_event && target->activation_behavior)
+        if (is_activation_event && target->has_activation_behavior())
             activation_target = target;
 
         // 6. Let slottable be target, if target is a slottable and is assigned, and null otherwise.
@@ -293,7 +293,7 @@ bool EventDispatcher::dispatch(JS::NonnullGCPtr<EventTarget> target, Event& even
             if (is<HTML::Window>(parent)
                 || (is<Node>(parent) && verify_cast<Node>(*target).root().is_shadow_including_inclusive_ancestor_of(verify_cast<Node>(*parent)))) {
                 // 1. If isActivationEvent is true, event’s bubbles attribute is true, activationTarget is null, and parent has activation behavior, then set activationTarget to parent.
-                if (is_activation_event && event.bubbles() && !activation_target && parent->activation_behavior)
+                if (is_activation_event && event.bubbles() && !activation_target && parent->has_activation_behavior())
                     activation_target = parent;
 
                 // 2. Append to an event path with event, parent, null, relatedTarget, touchTargets, and slot-in-closed-tree.
@@ -309,7 +309,7 @@ bool EventDispatcher::dispatch(JS::NonnullGCPtr<EventTarget> target, Event& even
                 target = *parent;
 
                 // 1. If isActivationEvent is true, activationTarget is null, and target has activation behavior, then set activationTarget to target.
-                if (is_activation_event && !activation_target && target->activation_behavior)
+                if (is_activation_event && !activation_target && target->has_activation_behavior())
                     activation_target = target;
 
                 // 2. Append to an event path with event, parent, target, relatedTarget, touchTargets, and slot-in-closed-tree.

--- a/Userland/Libraries/LibWeb/DOM/EventTarget.cpp
+++ b/Userland/Libraries/LibWeb/DOM/EventTarget.cpp
@@ -816,4 +816,13 @@ bool EventTarget::has_event_listeners() const
     return !m_event_listener_list.is_empty();
 }
 
+bool EventTarget::has_activation_behavior() const
+{
+    return false;
+}
+
+void EventTarget::activation_behavior(Event const&)
+{
+}
+
 }

--- a/Userland/Libraries/LibWeb/DOM/EventTarget.h
+++ b/Userland/Libraries/LibWeb/DOM/EventTarget.h
@@ -68,11 +68,16 @@ protected:
     virtual void visit_edges(Cell::Visitor&) override;
 
 private:
-    Vector<JS::NonnullGCPtr<DOMEventListener>> m_event_listener_list;
+    struct Data {
+        Vector<JS::NonnullGCPtr<DOMEventListener>> event_listener_list;
 
-    // https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-map
-    // Spec Note: The order of the entries of event handler map could be arbitrary. It is not observable through any algorithms that operate on the map.
-    HashMap<FlyString, JS::GCPtr<HTML::EventHandler>> m_event_handler_map;
+        // https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-map
+        // Spec Note: The order of the entries of event handler map could be arbitrary. It is not observable through any algorithms that operate on the map.
+        HashMap<FlyString, JS::GCPtr<HTML::EventHandler>> event_handler_map;
+    };
+
+    Data& ensure_data();
+    OwnPtr<Data> m_data;
 
     WebIDL::CallbackType* get_current_value_of_event_handler(FlyString const& name);
     void activate_event_handler(FlyString const& name, HTML::EventHandler& event_handler);

--- a/Userland/Libraries/LibWeb/DOM/EventTarget.h
+++ b/Userland/Libraries/LibWeb/DOM/EventTarget.h
@@ -45,7 +45,8 @@ public:
 
     Vector<JS::Handle<DOMEventListener>> event_listener_list();
 
-    Function<void(Event const&)> activation_behavior;
+    virtual bool has_activation_behavior() const;
+    virtual void activation_behavior(Event const&);
 
     // NOTE: These only exist for checkbox and radio input elements.
     virtual void legacy_pre_activation_behavior() { }

--- a/Userland/Libraries/LibWeb/DOM/Node.h
+++ b/Userland/Libraries/LibWeb/DOM/Node.h
@@ -254,10 +254,10 @@ public:
 
     size_t length() const;
 
-    auto& registered_observers_list() { return m_registered_observer_list; }
-    auto const& registered_observers_list() const { return m_registered_observer_list; }
+    auto& registered_observer_list() { return m_registered_observer_list; }
+    auto const& registered_observer_list() const { return m_registered_observer_list; }
 
-    void add_registered_observer(RegisteredObserver& registered_observer) { m_registered_observer_list.append(registered_observer); }
+    void add_registered_observer(RegisteredObserver&);
 
     void queue_mutation_record(FlyString const& type, Optional<FlyString> const& attribute_name, Optional<FlyString> const& attribute_namespace, Optional<String> const& old_value, Vector<JS::Handle<Node>> added_nodes, Vector<JS::Handle<Node>> removed_nodes, Node* previous_sibling, Node* next_sibling) const;
 
@@ -693,7 +693,7 @@ protected:
 
     // https://dom.spec.whatwg.org/#registered-observer-list
     // "Nodes have a strong reference to registered observers in their registered observer list." https://dom.spec.whatwg.org/#garbage-collection
-    Vector<JS::NonnullGCPtr<RegisteredObserver>> m_registered_observer_list;
+    OwnPtr<Vector<JS::NonnullGCPtr<RegisteredObserver>>> m_registered_observer_list;
 
     void build_accessibility_tree(AccessibilityTreeNode& parent);
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.cpp
@@ -16,9 +16,6 @@ JS_DEFINE_ALLOCATOR(HTMLAnchorElement);
 HTMLAnchorElement::HTMLAnchorElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : HTMLElement(document, move(qualified_name))
 {
-    activation_behavior = [this](auto const& event) {
-        run_activation_behavior(event);
-    };
 }
 
 HTMLAnchorElement::~HTMLAnchorElement() = default;
@@ -47,7 +44,12 @@ WebIDL::ExceptionOr<void> HTMLAnchorElement::set_hyperlink_element_utils_href(St
     return set_attribute(HTML::AttributeNames::href, move(href));
 }
 
-void HTMLAnchorElement::run_activation_behavior(Web::DOM::Event const&)
+bool HTMLAnchorElement::has_activation_behavior() const
+{
+    return true;
+}
+
+void HTMLAnchorElement::activation_behavior(Web::DOM::Event const&)
 {
     // The activation behavior of an a element element given an event event is:
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.h
@@ -41,7 +41,8 @@ private:
 
     virtual void initialize(JS::Realm&) override;
 
-    void run_activation_behavior(Web::DOM::Event const&);
+    virtual bool has_activation_behavior() const override;
+    virtual void activation_behavior(Web::DOM::Event const&) override;
 
     // ^DOM::Element
     virtual void attribute_changed(FlyString const& name, Optional<String> const& value) override;

--- a/Userland/Libraries/LibWeb/HTML/HTMLButtonElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLButtonElement.cpp
@@ -15,40 +15,6 @@ JS_DEFINE_ALLOCATOR(HTMLButtonElement);
 HTMLButtonElement::HTMLButtonElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : HTMLElement(document, move(qualified_name))
 {
-    // https://html.spec.whatwg.org/multipage/form-elements.html#the-button-element:activation-behaviour
-    activation_behavior = [this](auto&) {
-        // 1. If element is disabled, then return.
-        if (!enabled())
-            return;
-
-        // 2. If element does not have a form owner, then return.
-        if (!form())
-            return;
-
-        // 3. If element's node document is not fully active, then return.
-        if (!this->document().is_fully_active())
-            return;
-
-        // 4. Switch on element's type attribute's state:
-        switch (type_state()) {
-        case TypeAttributeState::Submit:
-            // Submit Button
-            // Submit element's form owner from element.
-            form()->submit_form(*this).release_value_but_fixme_should_propagate_errors();
-            break;
-        case TypeAttributeState::Reset:
-            // Reset Button
-            // Reset element's form owner.
-            form()->reset_form();
-            break;
-        case TypeAttributeState::Button:
-            // Button
-            // Do nothing.
-            break;
-        default:
-            VERIFY_NOT_REACHED();
-        }
-    };
 }
 
 HTMLButtonElement::~HTMLButtonElement() = default;
@@ -99,6 +65,47 @@ DeprecatedString HTMLButtonElement::value() const
     if (!has_attribute(AttributeNames::value))
         return DeprecatedString::empty();
     return deprecated_attribute(AttributeNames::value);
+}
+
+bool HTMLButtonElement::has_activation_behavior() const
+{
+    return true;
+}
+
+void HTMLButtonElement::activation_behavior(DOM::Event const&)
+{
+    // https://html.spec.whatwg.org/multipage/form-elements.html#the-button-element:activation-behaviour
+    // 1. If element is disabled, then return.
+    if (!enabled())
+        return;
+
+    // 2. If element does not have a form owner, then return.
+    if (!form())
+        return;
+
+    // 3. If element's node document is not fully active, then return.
+    if (!this->document().is_fully_active())
+        return;
+
+    // 4. Switch on element's type attribute's state:
+    switch (type_state()) {
+    case TypeAttributeState::Submit:
+        // Submit Button
+        // Submit element's form owner from element.
+        form()->submit_form(*this).release_value_but_fixme_should_propagate_errors();
+        break;
+    case TypeAttributeState::Reset:
+        // Reset Button
+        // Reset element's form owner.
+        form()->reset_form();
+        break;
+    case TypeAttributeState::Button:
+        // Button
+        // Do nothing.
+        break;
+    default:
+        VERIFY_NOT_REACHED();
+    }
 }
 
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLButtonElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLButtonElement.h
@@ -67,6 +67,9 @@ public:
 
     virtual DeprecatedString value() const override;
 
+    virtual bool has_activation_behavior() const override;
+    virtual void activation_behavior(DOM::Event const&) override;
+
 private:
     virtual bool is_html_button_element() const override { return true; }
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLElement.h
@@ -81,14 +81,14 @@ private:
     // ^HTML::GlobalEventHandlers
     virtual DOM::EventTarget& global_event_handlers_to_event_target(FlyString const&) override { return *this; }
 
+    JS::GCPtr<DOMStringMap> m_dataset;
+
     enum class ContentEditableState {
         True,
         False,
         Inherit,
     };
     ContentEditableState m_content_editable_state { ContentEditableState::Inherit };
-
-    JS::GCPtr<DOMStringMap> m_dataset;
 
     // https://html.spec.whatwg.org/multipage/interaction.html#locked-for-focus
     bool m_locked_for_focus { false };

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -38,14 +38,6 @@ HTMLInputElement::HTMLInputElement(DOM::Document& document, DOM::QualifiedName q
     : HTMLElement(document, move(qualified_name))
     , m_value(DeprecatedString::empty())
 {
-    activation_behavior = [this](auto&) {
-        // The activation behavior for input elements are these steps:
-
-        // FIXME: 1. If this element is not mutable and is not in the Checkbox state and is not in the Radio state, then return.
-
-        // 2. Run this element's input activation behavior, if any, and do nothing otherwise.
-        run_input_activation_behavior().release_value_but_fixme_should_propagate_errors();
-    };
 }
 
 HTMLInputElement::~HTMLInputElement() = default;
@@ -1284,4 +1276,20 @@ bool HTMLInputElement::is_submit_button() const
     return type_state() == TypeAttributeState::SubmitButton
         || type_state() == TypeAttributeState::ImageButton;
 }
+
+bool HTMLInputElement::has_activation_behavior() const
+{
+    return true;
+}
+
+void HTMLInputElement::activation_behavior(DOM::Event const&)
+{
+    // The activation behavior for input elements are these steps:
+
+    // FIXME: 1. If this element is not mutable and is not in the Checkbox state and is not in the Radio state, then return.
+
+    // 2. Run this element's input activation behavior, if any, and do nothing otherwise.
+    run_input_activation_behavior().release_value_but_fixme_should_propagate_errors();
+}
+
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -149,6 +149,9 @@ public:
     JS::GCPtr<Element> placeholder_element() { return m_placeholder_element; }
     JS::GCPtr<Element const> placeholder_element() const { return m_placeholder_element; }
 
+    virtual bool has_activation_behavior() const override;
+    virtual void activation_behavior(DOM::Event const&) override;
+
 private:
     HTMLInputElement(DOM::Document&, DOM::QualifiedName);
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLSlotElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLSlotElement.cpp
@@ -17,33 +17,6 @@ JS_DEFINE_ALLOCATOR(HTMLSlotElement);
 HTMLSlotElement::HTMLSlotElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : HTMLElement(document, move(qualified_name))
 {
-    // https://dom.spec.whatwg.org/#ref-for-concept-element-attributes-change-ext
-    add_attribute_change_steps([this](auto const& local_name, auto const& old_value, auto const& value, auto const& namespace_) {
-        // 1. If element is a slot, localName is name, and namespace is null, then:
-        if (local_name == AttributeNames::name && !namespace_.has_value()) {
-            // 1. If value is oldValue, then return.
-            if (value == old_value)
-                return;
-
-            // 2. If value is null and oldValue is the empty string, then return.
-            if (!value.has_value() && old_value == String {})
-                return;
-
-            // 3. If value is the empty string and oldValue is null, then return.
-            if (value == String {} && !old_value.has_value())
-                return;
-
-            // 4. If value is null or the empty string, then set element’s name to the empty string.
-            if (!value.has_value())
-                set_slot_name({});
-            // 5. Otherwise, set element’s name to value.
-            else
-                set_slot_name(*value);
-
-            // 6. Run assign slottables for a tree with element’s root.
-            DOM::assign_slottables_for_a_tree(root());
-        }
-    });
 }
 
 HTMLSlotElement::~HTMLSlotElement() = default;
@@ -140,6 +113,37 @@ void HTMLSlotElement::assign(Vector<SlottableHandle> nodes)
 
     // 5. Run assign slottables for a tree for this's root.
     assign_slottables_for_a_tree(root());
+}
+
+// https://dom.spec.whatwg.org/#ref-for-concept-element-attributes-change-ext
+void HTMLSlotElement::attribute_change_steps(FlyString const& local_name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_)
+{
+    Base::attribute_change_steps(local_name, old_value, value, namespace_);
+
+    // 1. If element is a slot, localName is name, and namespace is null, then:
+    if (local_name == AttributeNames::name && !namespace_.has_value()) {
+        // 1. If value is oldValue, then return.
+        if (value == old_value)
+            return;
+
+        // 2. If value is null and oldValue is the empty string, then return.
+        if (!value.has_value() && old_value == String {})
+            return;
+
+        // 3. If value is the empty string and oldValue is null, then return.
+        if (value == String {} && !old_value.has_value())
+            return;
+
+        // 4. If value is null or the empty string, then set element’s name to the empty string.
+        if (!value.has_value())
+            set_slot_name({});
+        // 5. Otherwise, set element’s name to value.
+        else
+            set_slot_name(*value);
+
+        // 6. Run assign slottables for a tree with element’s root.
+        DOM::assign_slottables_for_a_tree(root());
+    }
 }
 
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLSlotElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLSlotElement.h
@@ -45,6 +45,8 @@ private:
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(JS::Cell::Visitor&) override;
 
+    virtual void attribute_change_steps(FlyString const& local_name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
+
     // https://html.spec.whatwg.org/multipage/scripting.html#manually-assigned-nodes
     Vector<DOM::Slottable> m_manually_assigned_nodes;
 };

--- a/Userland/Libraries/LibWeb/HTML/HTMLSummaryElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLSummaryElement.cpp
@@ -15,22 +15,29 @@ JS_DEFINE_ALLOCATOR(HTMLSummaryElement);
 HTMLSummaryElement::HTMLSummaryElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : HTMLElement(document, move(qualified_name))
 {
-    activation_behavior = [this](auto&) {
-        // The activation behavior of summary elements is to run the following steps:
+}
 
-        // 1. If this summary element is not the summary for its parent details, then return.
-        if (!is_summary_for_its_parent_details())
-            return;
+bool HTMLSummaryElement::has_activation_behavior() const
+{
+    return true;
+}
 
-        // 2. Let parent be this summary element's parent.
-        auto* parent = this->parent_element();
+void HTMLSummaryElement::activation_behavior(DOM::Event const&)
+{
+    // The activation behavior of summary elements is to run the following steps:
 
-        // 3. If the open attribute is present on parent, then remove it. Otherwise, set parent's open attribute to the empty string.
-        if (parent->has_attribute(HTML::AttributeNames::open))
-            parent->remove_attribute(HTML::AttributeNames::open);
-        else
-            parent->set_attribute(HTML::AttributeNames::open, String {}).release_value_but_fixme_should_propagate_errors();
-    };
+    // 1. If this summary element is not the summary for its parent details, then return.
+    if (!is_summary_for_its_parent_details())
+        return;
+
+    // 2. Let parent be this summary element's parent.
+    auto* parent = this->parent_element();
+
+    // 3. If the open attribute is present on parent, then remove it. Otherwise, set parent's open attribute to the empty string.
+    if (parent->has_attribute(HTML::AttributeNames::open))
+        parent->remove_attribute(HTML::AttributeNames::open);
+    else
+        parent->set_attribute(HTML::AttributeNames::open, String {}).release_value_but_fixme_should_propagate_errors();
 }
 
 // https://html.spec.whatwg.org/multipage/interactive-elements.html#summary-for-its-parent-details

--- a/Userland/Libraries/LibWeb/HTML/HTMLSummaryElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLSummaryElement.h
@@ -23,6 +23,9 @@ public:
 
     bool is_summary_for_its_parent_details();
 
+    virtual bool has_activation_behavior() const override;
+    virtual void activation_behavior(DOM::Event const&) override;
+
 private:
     HTMLSummaryElement(DOM::Document&, DOM::QualifiedName);
 


### PR DESCRIPTION
tl;dr a bunch of incremental changes that add up to making `HTMLDivElement` take 456 bytes (down from 896 bytes, so just over 50% reduction in size)

Given that each HeapBlock has 4032 bytes of usable space, this means we can fit 8 divs per block now, up from 4 before.