### PR TITLE
LibJS/JIT: Continue to outer `finally` before returning

### DIFF
--- a/Userland/Libraries/LibJS/Tests/try-return-finally.js
+++ b/Userland/Libraries/LibJS/Tests/try-return-finally.js
@@ -9,3 +9,18 @@ test("return from try followed by finally with function call inside", () => {
 
     expect(value).toBe(1);
 });
+
+test("return from outer finally with nested unwind contexts", () => {
+    let value = (() => {
+        try {
+            try {
+                return 1;
+            } finally {
+            }
+        } finally {
+            return 2;
+        }
+    })();
+
+    expect(value).toBe(2);
+});


### PR DESCRIPTION
Fixes #21854