### PR TITLE
AK+Everywhere: Yeet some libc includes

### DIFF
--- a/AK/Assertions.h
+++ b/AK/Assertions.h
@@ -9,7 +9,6 @@
 #if defined(KERNEL)
 #    include <Kernel/Library/Assertions.h>
 #else
-#    include <assert.h>
 extern "C" __attribute__((noreturn)) void ak_verification_failed(char const*);
 #    define __stringify_helper(x) #x
 #    define __stringify(x) __stringify_helper(x)

--- a/AK/BuiltinWrappers.h
+++ b/AK/BuiltinWrappers.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include "Concepts.h"
+#include <AK/Concepts.h>
 
 namespace AK {
 

--- a/AK/Endian.h
+++ b/AK/Endian.h
@@ -10,30 +10,6 @@
 #include <AK/Forward.h>
 #include <AK/Platform.h>
 
-#if defined(AK_OS_MACOS)
-#    include <libkern/OSByteOrder.h>
-#    include <machine/endian.h>
-
-#    define htobe16(x) OSSwapHostToBigInt16(x)
-#    define htole16(x) OSSwapHostToLittleInt16(x)
-#    define be16toh(x) OSSwapBigToHostInt16(x)
-#    define le16toh(x) OSSwapLittleToHostInt16(x)
-
-#    define htobe32(x) OSSwapHostToBigInt32(x)
-#    define htole32(x) OSSwapHostToLittleInt32(x)
-#    define be32toh(x) OSSwapBigToHostInt32(x)
-#    define le32toh(x) OSSwapLittleToHostInt32(x)
-
-#    define htobe64(x) OSSwapHostToBigInt64(x)
-#    define htole64(x) OSSwapHostToLittleInt64(x)
-#    define be64toh(x) OSSwapBigToHostInt64(x)
-#    define le64toh(x) OSSwapLittleToHostInt64(x)
-
-#    define __BIG_ENDIAN BIG_ENDIAN
-#    define __LITTLE_ENDIAN LITTLE_ENDIAN
-#    define __BYTE_ORDER BYTE_ORDER
-#endif
-
 namespace AK {
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 inline constexpr static bool HostIsLittleEndian = true;

--- a/AK/IDAllocator.h
+++ b/AK/IDAllocator.h
@@ -27,7 +27,7 @@ public:
 
     int allocate()
     {
-        VERIFY(m_allocated_ids.size() < (INT32_MAX - 2));
+        VERIFY(m_allocated_ids.size() < (NumericLimits<i32>::max() - 2));
         int id = 0;
         for (;;) {
             id = static_cast<int>(get_random_uniform(NumericLimits<int>::max()));

--- a/AK/Random.cpp
+++ b/AK/Random.cpp
@@ -17,7 +17,7 @@ u32 get_random_uniform(u32 max_bounds)
     // `arc4random() % max_bounds` would be insufficient. Here we compute the last number of the
     // last "full group". Note that if max_bounds is a divisor of UINT32_MAX,
     // then we end up with UINT32_MAX:
-    const u32 max_usable = UINT32_MAX - (static_cast<u64>(UINT32_MAX) + 1) % max_bounds;
+    const u32 max_usable = NumericLimits<u32>::max() - (1ULL << 32) % max_bounds;
     auto random_value = get_random<u32>();
     for (int i = 0; i < 20 && random_value > max_usable; ++i) {
         // By chance we picked a value from the incomplete group. Note that this group has size at
@@ -34,7 +34,7 @@ u64 get_random_uniform_64(u64 max_bounds)
 {
     // Uses the same algorithm as `get_random_uniform`,
     // by replacing u64 with u128 and u32 with u64.
-    const u64 max_usable = UINT64_MAX - static_cast<u64>((static_cast<u128>(UINT64_MAX) + 1) % max_bounds);
+    const u64 max_usable = NumericLimits<u64>::max() - static_cast<u64>((static_cast<u128>(NumericLimits<u64>::max()) + 1) % max_bounds);
     auto random_value = get_random<u64>();
     for (int i = 0; i < 20 && random_value > max_usable; ++i) {
         random_value = get_random<u64>();

--- a/AK/Types.h
+++ b/AK/Types.h
@@ -34,8 +34,6 @@ using f128 = long double;
 #    endif
 #endif
 
-#ifdef AK_OS_SERENITY
-
 using size_t = __SIZE_TYPE__;
 using ssize_t = AK::Detail::MakeSigned<size_t>;
 
@@ -44,6 +42,8 @@ using ptrdiff_t = __PTRDIFF_TYPE__;
 using intptr_t = __INTPTR_TYPE__;
 using uintptr_t = __UINTPTR_TYPE__;
 
+// FIXME: POSIX API includes in kernel are a giant mess, they won't work without these definitions.
+#ifdef KERNEL
 using uint8_t = u8;
 using uint16_t = u16;
 using uint32_t = u32;
@@ -55,20 +55,6 @@ using int32_t = i32;
 using int64_t = i64;
 
 using pid_t = int;
-
-#else
-#    include <stddef.h>
-#    include <stdint.h>
-#    include <sys/types.h>
-
-#    ifdef __ptrdiff_t
-using __ptrdiff_t = __PTRDIFF_TYPE__;
-#    endif
-
-#    if defined(AK_OS_WINDOWS)
-using ssize_t = AK::Detail::MakeSigned<size_t>;
-using mode_t = unsigned short;
-#    endif
 #endif
 
 using FlatPtr = AK::Detail::Conditional<sizeof(void*) == 8, u64, u32>;

--- a/Meta/Lagom/Fuzzers/EntryShim.cpp
+++ b/Meta/Lagom/Fuzzers/EntryShim.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Types.h>
 #include <fcntl.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -25,7 +26,7 @@ int fuzz_from_file(char const* filename)
 
     size_t file_size = file_stats.st_size;
 
-    uint8_t* file_buffer = (uint8_t*)malloc(file_size);
+    u8* file_buffer = (u8*)malloc(file_size);
 
     if (!file_buffer) {
         fprintf(stderr, "EntryShim: Failed to allocate file buffer\n");
@@ -53,11 +54,11 @@ int fuzz_from_stdin()
 {
     size_t chunk_size = 4096;
 
-    uint8_t* file_buffer = nullptr;
+    u8* file_buffer = nullptr;
     size_t file_size = 0;
 
     while (true) {
-        file_buffer = (uint8_t*)realloc(file_buffer, file_size + chunk_size);
+        file_buffer = (u8*)realloc(file_buffer, file_size + chunk_size);
 
         if (!file_buffer) {
             fprintf(stderr, "EntryShim: Failed to reallocate buffer to a size of %lu bytes\n", file_size + chunk_size);

--- a/Meta/Lagom/Fuzzers/FuzzBMPLoader.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzBMPLoader.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibGfx/ImageFormats/BMPLoader.h>
+#include <stdint.h>
 #include <stdio.h>
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)

--- a/Meta/Lagom/Fuzzers/FuzzBase64Roundtrip.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzBase64Roundtrip.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/Base64.h>
+#include <stdint.h>
 #include <stdio.h>
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)

--- a/Meta/Lagom/Fuzzers/FuzzBrotli.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzBrotli.cpp
@@ -6,6 +6,7 @@
 
 #include <AK/MemoryStream.h>
 #include <LibCompress/Brotli.h>
+#include <stdint.h>
 #include <stdio.h>
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)

--- a/Meta/Lagom/Fuzzers/FuzzCSSParser.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzCSSParser.cpp
@@ -7,6 +7,7 @@
 #include <LibWeb/Bindings/MainThreadVM.h>
 #include <LibWeb/CSS/Parser/Parser.h>
 #include <LibWeb/Platform/EventLoopPluginSerenity.h>
+#include <stdint.h>
 
 namespace {
 

--- a/Meta/Lagom/Fuzzers/FuzzDDSLoader.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzDDSLoader.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibGfx/ImageFormats/DDSLoader.h>
+#include <stdint.h>
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {

--- a/Meta/Lagom/Fuzzers/FuzzDNSPacket.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzDNSPacket.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibDNS/Packet.h>
+#include <stdint.h>
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {

--- a/Meta/Lagom/Fuzzers/FuzzILBMLoader.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzILBMLoader.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibGfx/ImageFormats/ILBMLoader.h>
+#include <stdint.h>
 #include <stdio.h>
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)

--- a/Meta/Lagom/Fuzzers/FuzzJsonParser.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzJsonParser.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/JsonParser.h>
+#include <stdint.h>
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {

--- a/Meta/Lagom/Fuzzers/FuzzLzmaDecompression.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzLzmaDecompression.cpp
@@ -6,6 +6,7 @@
 
 #include <AK/MemoryStream.h>
 #include <LibCompress/Lzma.h>
+#include <stdint.h>
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {

--- a/Meta/Lagom/Fuzzers/FuzzLzmaRoundtrip.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzLzmaRoundtrip.cpp
@@ -6,6 +6,7 @@
 
 #include <AK/MemoryStream.h>
 #include <LibCompress/Lzma.h>
+#include <stdint.h>
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {

--- a/Meta/Lagom/Fuzzers/FuzzMatroskaReader.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzMatroskaReader.cpp
@@ -6,8 +6,9 @@
 
 #include <LibVideo/Containers/Matroska/Reader.h>
 #include <stddef.h>
+#include <stdint.h>
 
-extern "C" int LLVMFuzzerTestOneInput(u8 const* data, size_t size)
+extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
     AK::set_debug_enabled(false);
     auto matroska_reader_result = Video::Matroska::Reader::from_data({ data, size });

--- a/Meta/Lagom/Fuzzers/FuzzQuotedPrintableParser.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzQuotedPrintableParser.cpp
@@ -7,6 +7,7 @@
 #include <AK/Format.h>
 #include <AK/StringView.h>
 #include <LibIMAP/QuotedPrintable.h>
+#include <stdint.h>
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {

--- a/Meta/Lagom/Fuzzers/FuzzSQLParser.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzSQLParser.cpp
@@ -6,6 +6,7 @@
 
 #include <LibSQL/AST/Lexer.h>
 #include <LibSQL/AST/Parser.h>
+#include <stdint.h>
 #include <stdio.h>
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)

--- a/Meta/Lagom/Fuzzers/FuzzTIFFLoader.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzTIFFLoader.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibGfx/ImageFormats/TIFFLoader.h>
+#include <stdint.h>
 #include <stdio.h>
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)

--- a/Meta/Lagom/Fuzzers/FuzzTTF.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzTTF.cpp
@@ -8,7 +8,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
-extern "C" int LLVMFuzzerTestOneInput(u8 const* data, size_t size)
+extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
     AK::set_debug_enabled(false);
     (void)OpenType::Font::try_load_from_externally_owned_memory({ data, size });

--- a/Meta/Lagom/Fuzzers/FuzzTar.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzTar.cpp
@@ -7,6 +7,7 @@
 #include <AK/MemoryStream.h>
 #include <AK/NonnullOwnPtr.h>
 #include <LibArchive/TarStream.h>
+#include <stdint.h>
 #include <stdio.h>
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)

--- a/Meta/Lagom/Fuzzers/FuzzTinyVGLoader.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzTinyVGLoader.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibGfx/ImageFormats/TinyVGLoader.h>
+#include <stdint.h>
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {

--- a/Meta/Lagom/Fuzzers/FuzzURL.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzURL.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/URL.h>
+#include <stdint.h>
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {

--- a/Meta/Lagom/Fuzzers/FuzzVP9Decoder.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzVP9Decoder.cpp
@@ -6,8 +6,9 @@
 
 #include <LibVideo/VP9/Decoder.h>
 #include <stddef.h>
+#include <stdint.h>
 
-extern "C" int LLVMFuzzerTestOneInput(u8 const* data, size_t size)
+extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
     AK::set_debug_enabled(false);
     Video::VP9::Decoder vp9_decoder;

--- a/Meta/Lagom/Fuzzers/FuzzWOFF.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzWOFF.cpp
@@ -6,8 +6,9 @@
 
 #include <LibGfx/Font/WOFF/Font.h>
 #include <stddef.h>
+#include <stdint.h>
 
-extern "C" int LLVMFuzzerTestOneInput(u8 const* data, size_t size)
+extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
     AK::set_debug_enabled(false);
     (void)WOFF::Font::try_load_from_externally_owned_memory({ data, size });

--- a/Meta/Lagom/Fuzzers/FuzzWOFF2.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzWOFF2.cpp
@@ -6,8 +6,9 @@
 
 #include <LibGfx/Font/WOFF2/Font.h>
 #include <stddef.h>
+#include <stdint.h>
 
-extern "C" int LLVMFuzzerTestOneInput(u8 const* data, size_t size)
+extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
     AK::set_debug_enabled(false);
     (void)WOFF2::Font::try_load_from_externally_owned_memory({ data, size });

--- a/Meta/Lagom/Fuzzers/FuzzXML.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzXML.cpp
@@ -5,8 +5,9 @@
  */
 
 #include <LibXML/Parser/Parser.h>
+#include <stdint.h>
 
-extern "C" int LLVMFuzzerTestOneInput(u8 const* data, size_t size)
+extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
     AK::set_debug_enabled(false);
     XML::Parser parser({ data, size });

--- a/Meta/Lagom/Fuzzers/FuzzZlibDecompression.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzZlibDecompression.cpp
@@ -6,6 +6,7 @@
 
 #include <AK/MemoryStream.h>
 #include <LibCompress/Zlib.h>
+#include <stdint.h>
 #include <stdio.h>
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)

--- a/Tests/AK/TestJSON.cpp
+++ b/Tests/AK/TestJSON.cpp
@@ -557,7 +557,7 @@ TEST_CASE(json_value_as_integer)
     EXPECT(negative_value.is_integer<i64>());
 
     // 64-bit only
-    JsonValue very_large_value { INT64_MAX };
+    JsonValue very_large_value { NumericLimits<i64>::max() };
     EXPECT(!very_large_value.is_integer<u8>());
     EXPECT(!very_large_value.is_integer<u16>());
     EXPECT(!very_large_value.is_integer<u32>());

--- a/Tests/LibCrypto/TestBigInteger.cpp
+++ b/Tests/LibCrypto/TestBigInteger.cpp
@@ -57,8 +57,8 @@ TEST_CASE(test_unsigned_bigint_addition_initialization)
 
 TEST_CASE(test_unsigned_bigint_addition_borrow_with_zero)
 {
-    Crypto::UnsignedBigInteger num1({ UINT32_MAX - 3, UINT32_MAX });
-    Crypto::UnsignedBigInteger num2({ UINT32_MAX - 2, 0 });
+    Crypto::UnsignedBigInteger num1({ NumericLimits<u32>::max() - 3, NumericLimits<u32>::max() });
+    Crypto::UnsignedBigInteger num2({ NumericLimits<u32>::max() - 2, 0 });
     Vector<u32> expected_result { 4294967289, 0, 1 };
     EXPECT_EQ(num1.plus(num2).words(), expected_result);
 }
@@ -90,7 +90,7 @@ TEST_CASE(test_unsigned_bigint_basic_add_to_smaller_accumulator)
 
 TEST_CASE(test_unsigned_bigint_add_to_accumulator_with_multiple_carry_levels)
 {
-    Crypto::UnsignedBigInteger num1({ UINT32_MAX - 2, UINT32_MAX });
+    Crypto::UnsignedBigInteger num1({ NumericLimits<u32>::max() - 2, NumericLimits<u32>::max() });
     Crypto::UnsignedBigInteger num2(5);
     Crypto::UnsignedBigIntegerAlgorithms::add_into_accumulator_without_allocation(num1, num2);
     Vector<u32> expected_result { 2, 0, 1 };
@@ -107,7 +107,7 @@ TEST_CASE(test_unsigned_bigint_add_to_accumulator_with_leading_zero)
 
 TEST_CASE(test_unsigned_bigint_add_to_accumulator_with_carry_and_leading_zero)
 {
-    Crypto::UnsignedBigInteger num1({ UINT32_MAX, 0, 0, 0 });
+    Crypto::UnsignedBigInteger num1({ NumericLimits<u32>::max(), 0, 0, 0 });
     Crypto::UnsignedBigInteger num2({ 1, 0 });
     Crypto::UnsignedBigIntegerAlgorithms::add_into_accumulator_without_allocation(num1, num2);
     Vector<u32> expected_result { 0, 1, 0, 0 };
@@ -132,7 +132,7 @@ TEST_CASE(test_unsigned_bigint_simple_subtraction_invalid)
 
 TEST_CASE(test_unsigned_bigint_simple_subtraction_with_borrow)
 {
-    Crypto::UnsignedBigInteger num1(UINT32_MAX);
+    Crypto::UnsignedBigInteger num1(NumericLimits<u32>::max());
     Crypto::UnsignedBigInteger num2(1);
     Crypto::UnsignedBigInteger num3 = num1.plus(num2);
     Crypto::UnsignedBigInteger result = num3.minus(num2);
@@ -549,15 +549,15 @@ TEST_CASE(test_signed_bigint_fibo500)
 
 TEST_CASE(test_signed_addition_edgecase_borrow_with_zero)
 {
-    Crypto::SignedBigInteger num1 { Crypto::UnsignedBigInteger { { UINT32_MAX - 3, UINT32_MAX } }, false };
-    Crypto::SignedBigInteger num2 { Crypto::UnsignedBigInteger { UINT32_MAX - 2 }, false };
+    Crypto::SignedBigInteger num1 { Crypto::UnsignedBigInteger { { NumericLimits<u32>::max() - 3, NumericLimits<u32>::max() } }, false };
+    Crypto::SignedBigInteger num2 { Crypto::UnsignedBigInteger { NumericLimits<u32>::max() - 2 }, false };
     Vector<u32> expected_result { 4294967289, 0, 1 };
     EXPECT_EQ(num1.plus(num2).unsigned_value().words(), expected_result);
 }
 
 TEST_CASE(test_signed_addition_edgecase_addition_to_other_sign)
 {
-    Crypto::SignedBigInteger num1 = INT32_MAX;
+    Crypto::SignedBigInteger num1 = NumericLimits<i32>::max();
     Crypto::SignedBigInteger num2 = num1;
     num2.negate();
     EXPECT_EQ(num1.plus(num2), Crypto::SignedBigInteger { 0 });
@@ -589,7 +589,7 @@ TEST_CASE(test_signed_subtraction_both_negative)
 
 TEST_CASE(test_signed_subtraction_simple_subtraction_with_borrow)
 {
-    Crypto::SignedBigInteger num1(Crypto::UnsignedBigInteger { UINT32_MAX });
+    Crypto::SignedBigInteger num1(Crypto::UnsignedBigInteger { NumericLimits<u32>::max() });
     Crypto::SignedBigInteger num2(1);
     Crypto::SignedBigInteger num3 = num1.plus(num2);
     Crypto::SignedBigInteger result = num2.minus(num3);

--- a/Tests/LibJS/test262-runner.cpp
+++ b/Tests/LibJS/test262-runner.cpp
@@ -23,6 +23,7 @@
 #include <LibJS/Runtime/ValueInlines.h>
 #include <LibJS/Script.h>
 #include <LibJS/SourceTextModule.h>
+#include <assert.h>
 #include <fcntl.h>
 #include <signal.h>
 #include <unistd.h>

--- a/Userland/Libraries/LibArchive/Zip.cpp
+++ b/Userland/Libraries/LibArchive/Zip.cpp
@@ -13,7 +13,7 @@ namespace Archive {
 
 bool Zip::find_end_of_central_directory_offset(ReadonlyBytes buffer, size_t& offset)
 {
-    for (size_t backwards_offset = 0; backwards_offset <= UINT16_MAX; backwards_offset++) // the file may have a trailing comment of an arbitrary 16 bit length
+    for (size_t backwards_offset = 0; backwards_offset <= NumericLimits<u16>::max(); backwards_offset++) // the file may have a trailing comment of an arbitrary 16 bit length
     {
         if (buffer.size() < (sizeof(EndOfCentralDirectory) - sizeof(u8*)) + backwards_offset)
             return false;
@@ -136,8 +136,8 @@ static u16 minimum_version_needed(ZipCompressionMethod method)
 ErrorOr<void> ZipOutputStream::add_member(ZipMember const& member)
 {
     VERIFY(!m_finished);
-    VERIFY(member.name.bytes_as_string_view().length() <= UINT16_MAX);
-    VERIFY(member.compressed_data.size() <= UINT32_MAX);
+    VERIFY(member.name.bytes_as_string_view().length() <= NumericLimits<u16>::max());
+    VERIFY(member.compressed_data.size() <= NumericLimits<u32>::max());
     TRY(m_members.try_append(member));
 
     LocalFileHeader local_file_header {

--- a/Userland/Libraries/LibCompress/Deflate.h
+++ b/Userland/Libraries/LibCompress/Deflate.h
@@ -129,7 +129,7 @@ public:
     static constexpr size_t max_huffman_distances = 32;
     static constexpr size_t min_match_length = 4;   // matches smaller than these are not worth the size of the back reference
     static constexpr size_t max_match_length = 258; // matches longer than these cannot be encoded using huffman codes
-    static constexpr u16 empty_slot = UINT16_MAX;
+    static constexpr u16 empty_slot = NumericLimits<u16>::max();
 
     struct CompressionConstants {
         size_t good_match_length;  // Once we find a match of at least this length (a good enough match) we reduce max_chain to lower processing time
@@ -185,7 +185,7 @@ private:
     };
     static u8 distance_to_base(u16 distance);
     template<size_t Size>
-    static void generate_huffman_lengths(Array<u8, Size>& lengths, Array<u16, Size> const& frequencies, size_t max_bit_length, u16 frequency_cap = UINT16_MAX);
+    static void generate_huffman_lengths(Array<u8, Size>& lengths, Array<u16, Size> const& frequencies, size_t max_bit_length, u16 frequency_cap = NumericLimits<u16>::max());
     size_t huffman_block_length(Array<u8, max_huffman_literals> const& literal_bit_lengths, Array<u8, max_huffman_distances> const& distance_bit_lengths);
     ErrorOr<void> write_huffman(CanonicalCode const& literal_code, Optional<CanonicalCode> const& distance_code);
     static size_t encode_huffman_lengths(Array<u8, max_huffman_literals + max_huffman_distances> const& lengths, size_t lengths_count, Array<code_length_symbol, max_huffman_literals + max_huffman_distances>& encoded_lengths);

--- a/Userland/Libraries/LibCompress/DeflateTables.h
+++ b/Userland/Libraries/LibCompress/DeflateTables.h
@@ -104,7 +104,7 @@ static constexpr size_t code_lengths_code_lengths_order[] { 16, 17, 18, 0, 8, 7,
 
 static consteval Array<u16, 259> generate_length_to_symbol()
 {
-    Array<u16, 259> array = { UINT16_MAX, UINT16_MAX, UINT16_MAX }; // there are 256 valid lengths (3-258) + 3 invalid lengths (0-2)
+    Array<u16, 259> array = { NumericLimits<u16>::max(), NumericLimits<u16>::max(), NumericLimits<u16>::max() }; // there are 256 valid lengths (3-258) + 3 invalid lengths (0-2)
     size_t base_length = 0;
     for (size_t len = 3; len < 259; len++) {
         if (len == packed_length_symbols[base_length + 1].base_length)
@@ -129,7 +129,7 @@ static consteval Array<u16, 256> generate_distance_to_base_lo()
 static constexpr auto distance_to_base_lo = generate_distance_to_base_lo();
 static consteval Array<u16, 256> generate_distance_to_base_hi()
 {
-    Array<u16, 256> array = { UINT16_MAX, UINT16_MAX };
+    Array<u16, 256> array = { NumericLimits<u16>::max(), NumericLimits<u16>::max() };
     size_t base_distance = 16;
     for (size_t dist = 257; dist <= 32 * KiB; dist++) {
         if (dist == packed_distances[base_distance + 1].base_distance)

--- a/Userland/Libraries/LibCompress/Lzma.h
+++ b/Userland/Libraries/LibCompress/Lzma.h
@@ -56,7 +56,7 @@ struct [[gnu::packed]] LzmaHeader {
     u32 unchecked_dictionary_size;
     u64 encoded_uncompressed_size;
 
-    static constexpr u64 placeholder_for_unknown_uncompressed_size = UINT64_MAX;
+    static constexpr u64 placeholder_for_unknown_uncompressed_size = NumericLimits<u64>::max();
 };
 static_assert(sizeof(LzmaHeader) == 13);
 

--- a/Userland/Libraries/LibCore/DirectoryEntry.h
+++ b/Userland/Libraries/LibCore/DirectoryEntry.h
@@ -9,6 +9,7 @@
 #include <AK/ByteString.h>
 #include <AK/StringView.h>
 #include <dirent.h>
+#include <sys/types.h>
 
 namespace Core {
 

--- a/Userland/Libraries/LibCore/File.h
+++ b/Userland/Libraries/LibCore/File.h
@@ -14,6 +14,7 @@
 #include <AK/Stream.h>
 #include <LibCore/Forward.h>
 #include <LibIPC/Forward.h>
+#include <sys/types.h>
 
 namespace Core {
 

--- a/Userland/Libraries/LibCrypto/BigInt/Algorithms/SimpleOperations.cpp
+++ b/Userland/Libraries/LibCrypto/BigInt/Algorithms/SimpleOperations.cpp
@@ -94,7 +94,7 @@ void UnsignedBigIntegerAlgorithms::subtract_without_allocation(
         // If temp < 0, we had an underflow
         borrow = (temp >= 0) ? 0 : 1;
         if (temp < 0) {
-            temp += (UINT32_MAX + 1);
+            temp += (NumericLimits<u32>::max() + 1);
         }
         output.m_words[i] = temp;
     }

--- a/Userland/Libraries/LibCrypto/Curves/Ed25519.cpp
+++ b/Userland/Libraries/LibCrypto/Curves/Ed25519.cpp
@@ -281,7 +281,7 @@ void Ed25519::multiply(u8* result_low, u8* result_high, u8 const* a, u8 const* b
     u32 temp = 0;
     for (u32 i = 0; i < n; i++) {
         for (u32 j = 0; j <= i; j++) {
-            temp += (uint16_t)a[j] * b[i - j];
+            temp += a[j] * b[i - j];
         }
 
         if (result_low != NULL) {
@@ -294,7 +294,7 @@ void Ed25519::multiply(u8* result_low, u8* result_high, u8 const* a, u8 const* b
     if (result_high != NULL) {
         for (u32 i = n; i < (2 * n); i++) {
             for (u32 j = i + 1 - n; j < n; j++) {
-                temp += (uint16_t)a[j] * b[i - j];
+                temp += a[j] * b[i - j];
             }
 
             result_high[i - n] = temp & 0xFF;

--- a/Userland/Libraries/LibCrypto/Curves/SECPxxxr1.h
+++ b/Userland/Libraries/LibCrypto/Curves/SECPxxxr1.h
@@ -197,7 +197,7 @@ public:
 
         // z is the hash
         StorageType z = 0u;
-        for (uint8_t byte : hash) {
+        for (auto byte : hash) {
             z <<= 8;
             z |= byte;
         }

--- a/Userland/Libraries/LibCrypto/Hash/BLAKE2b.cpp
+++ b/Userland/Libraries/LibCrypto/Hash/BLAKE2b.cpp
@@ -42,7 +42,7 @@ BLAKE2b::DigestType BLAKE2b::peek()
     increment_counter_by(m_internal_state.buffer_length);
 
     // Set this as the last block
-    m_internal_state.is_at_last_block = UINT64_MAX;
+    m_internal_state.is_at_last_block = NumericLimits<u64>::max();
 
     // Pad the buffer with zeros
     __builtin_memset(m_internal_state.buffer + m_internal_state.buffer_length, 0, BLAKE2bConstants::blockbytes - m_internal_state.buffer_length);

--- a/Userland/Libraries/LibDNS/Packet.cpp
+++ b/Userland/Libraries/LibDNS/Packet.cpp
@@ -19,14 +19,14 @@ void Packet::add_question(Question const& question)
 {
     m_questions.empend(question);
 
-    VERIFY(m_questions.size() <= UINT16_MAX);
+    VERIFY(m_questions.size() <= NumericLimits<u16>::max());
 }
 
 void Packet::add_answer(Answer const& answer)
 {
     m_answers.empend(answer);
 
-    VERIFY(m_answers.size() <= UINT16_MAX);
+    VERIFY(m_answers.size() <= NumericLimits<u16>::max());
 }
 
 ErrorOr<ByteBuffer> Packet::to_byte_buffer() const

--- a/Userland/Libraries/LibDNS/Packet.h
+++ b/Userland/Libraries/LibDNS/Packet.h
@@ -46,13 +46,13 @@ public:
 
     u16 question_count() const
     {
-        VERIFY(m_questions.size() <= UINT16_MAX);
+        VERIFY(m_questions.size() <= NumericLimits<u16>::max());
         return m_questions.size();
     }
 
     u16 answer_count() const
     {
-        VERIFY(m_answers.size() <= UINT16_MAX);
+        VERIFY(m_answers.size() <= NumericLimits<u16>::max());
         return m_answers.size();
     }
 

--- a/Userland/Libraries/LibDSP/MDCT.h
+++ b/Userland/Libraries/LibDSP/MDCT.h
@@ -26,8 +26,8 @@ public:
 
     void transform(ReadonlySpan<float> data, Span<float> output)
     {
-        assert(N == 2 * data.size());
-        assert(N == output.size());
+        VERIFY(N == 2 * data.size());
+        VERIFY(N == output.size());
         for (size_t n = 0; n < N; n++) {
             output[n] = 0;
             for (size_t k = 0; k < N / 2; k++) {

--- a/Userland/Libraries/LibELF/DynamicLoader.cpp
+++ b/Userland/Libraries/LibELF/DynamicLoader.cpp
@@ -335,7 +335,7 @@ void DynamicLoader::do_lazy_relocations()
 
 void DynamicLoader::load_program_headers()
 {
-    FlatPtr ph_load_start = SIZE_MAX;
+    FlatPtr ph_load_start = NumericLimits<FlatPtr>::max();
     FlatPtr ph_load_end = 0;
 
     // We walk the program header list once to find the requested address ranges of the program.

--- a/Userland/Libraries/LibGUI/Icon.cpp
+++ b/Userland/Libraries/LibGUI/Icon.cpp
@@ -52,7 +52,7 @@ Gfx::Bitmap const* IconImpl::bitmap_for_size(int size) const
     if (it != m_bitmaps.end())
         return it->value.ptr();
 
-    int best_diff_so_far = INT32_MAX;
+    int best_diff_so_far = NumericLimits<i32>::max();
     Gfx::Bitmap const* best_fit = nullptr;
     for (auto& it : m_bitmaps) {
         int abs_diff = abs(it.key - size);

--- a/Userland/Libraries/LibGfx/Bitmap.cpp
+++ b/Userland/Libraries/LibGfx/Bitmap.cpp
@@ -56,7 +56,7 @@ static bool size_would_overflow(BitmapFormat format, IntSize size, int scale_fac
     if (size.width() < 0 || size.height() < 0)
         return true;
     // This check is a bit arbitrary, but should protect us from most shenanigans:
-    if (size.width() >= INT16_MAX || size.height() >= INT16_MAX || scale_factor < 1 || scale_factor > 4)
+    if (size.width() >= NumericLimits<i16>::max() || size.height() >= NumericLimits<i16>::max() || scale_factor < 1 || scale_factor > 4)
         return true;
     // In contrast, this check is absolutely necessary:
     size_t pitch = Bitmap::minimum_pitch(size.width() * scale_factor, format);

--- a/Userland/Libraries/LibGfx/Font/OpenType/Cmap.h
+++ b/Userland/Libraries/LibGfx/Font/OpenType/Cmap.h
@@ -117,7 +117,7 @@ private:
     }
 
     ReadonlyBytes m_slice;
-    u32 m_active_index { UINT32_MAX };
+    u32 m_active_index { NumericLimits<u32>::max() };
 };
 
 }

--- a/Userland/Libraries/LibIDL/Types.h
+++ b/Userland/Libraries/LibIDL/Types.h
@@ -243,7 +243,7 @@ private:
 
 static inline size_t get_shortest_function_length(Vector<Function&> const& overload_set)
 {
-    size_t shortest_length = SIZE_MAX;
+    size_t shortest_length = NumericLimits<size_t>::max();
     for (auto const& function : overload_set)
         shortest_length = min(function.shortest_length(), shortest_length);
     return shortest_length;

--- a/Userland/Libraries/LibJS/Runtime/MathObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/MathObject.cpp
@@ -775,7 +775,7 @@ JS_DEFINE_NATIVE_FUNCTION(MathObject::random)
     // This function returns a Number value with positive sign, greater than or equal to +0𝔽 but strictly less than 1𝔽,
     // chosen randomly or pseudo randomly with approximately uniform distribution over that range, using an
     // implementation-defined algorithm or strategy.
-    double r = (double)get_random<u32>() / (double)UINT32_MAX;
+    double r = (double)get_random<u32>() / (double)NumericLimits<u32>::max();
     return Value(r);
 }
 

--- a/Userland/Libraries/LibWasm/WASI/Wasi.cpp
+++ b/Userland/Libraries/LibWasm/WASI/Wasi.cpp
@@ -16,6 +16,7 @@
 #include <LibWasm/Wasi.h>
 #include <dirent.h>
 #include <fcntl.h>
+#include <stddef.h>
 #include <sys/stat.h>
 #include <time.h>
 #include <unistd.h>

--- a/Userland/Services/LookupServer/LookupServer.cpp
+++ b/Userland/Services/LookupServer/LookupServer.cpp
@@ -249,7 +249,7 @@ ErrorOr<Vector<Answer>> LookupServer::lookup(Name const& name, ByteString const&
 {
     Packet request;
     request.set_is_query();
-    request.set_id(get_random_uniform(UINT16_MAX));
+    request.set_id(get_random_uniform(NumericLimits<u16>::max()));
     Name name_in_question = name;
     if (should_randomize_case == ShouldRandomizeCase::Yes)
         name_in_question.randomize_case();

--- a/Userland/Services/WindowServer/ConnectionFromClient.cpp
+++ b/Userland/Services/WindowServer/ConnectionFromClient.cpp
@@ -477,8 +477,8 @@ Messages::WindowServer::SetWindowRectResponse ConnectionFromClient::set_window_r
         dbgln("ConnectionFromClient: Ignoring SetWindowRect request for fullscreen window");
         return nullptr;
     }
-    if (rect.width() > INT16_MAX || rect.height() > INT16_MAX) {
-        did_misbehave(ByteString::formatted("SetWindowRect: Bad window sizing(width={}, height={}), dimension exceeds INT16_MAX", rect.width(), rect.height()).characters());
+    if (rect.width() > NumericLimits<i16>::max() || rect.height() > NumericLimits<i16>::max()) {
+        did_misbehave(ByteString::formatted("SetWindowRect: Bad window sizing(width={}, height={}), dimension exceeds NumericLimits<i16>::max()", rect.width(), rect.height()).characters());
         return nullptr;
     }
 

--- a/Userland/Utilities/cut.cpp
+++ b/Userland/Utilities/cut.cpp
@@ -16,7 +16,7 @@
 
 struct Range {
     size_t m_from { 1 };
-    size_t m_to { SIZE_MAX };
+    size_t m_to { NumericLimits<size_t>::max() };
 
     [[nodiscard]] bool intersects(Range const& other) const
     {
@@ -73,7 +73,7 @@ static bool expand_list(ByteString& list, Vector<Range>& ranges)
                 return false;
             }
 
-            ranges.append({ index.value(), SIZE_MAX });
+            ranges.append({ index.value(), NumericLimits<size_t>::max() });
         } else {
             auto range = token.split('-', SplitBehavior::KeepEmpty);
             if (range.size() == 2) {

--- a/Userland/Utilities/du.cpp
+++ b/Userland/Utilities/du.cpp
@@ -34,7 +34,7 @@ struct DuOption {
     TimeType time_type = TimeType::NotUsed;
     Vector<ByteString> excluded_patterns;
     u64 block_size = 1024;
-    size_t max_depth = SIZE_MAX;
+    size_t max_depth = NumericLimits<size_t>::max();
 };
 
 struct VisitedFile {

--- a/Userland/Utilities/ping.cpp
+++ b/Userland/Utilities/ping.cpp
@@ -77,7 +77,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                 return false;
 
             auto interval_in_seconds = interval_in_seconds_string.to_number<double>();
-            if (!interval_in_seconds.has_value() || interval_in_seconds.value() <= 0 || interval_in_seconds.value() > UINT32_MAX)
+            if (!interval_in_seconds.has_value() || interval_in_seconds.value() <= 0 || interval_in_seconds.value() > NumericLimits<u32>::max())
                 return false;
 
             auto whole_seconds = static_cast<time_t>(interval_in_seconds.value());
@@ -94,8 +94,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_option(ttl, "Set the TTL (time-to-live) value on the ICMP packets.", nullptr, 't', "ttl");
     args_parser.parse(arguments);
 
-    if (count.has_value() && (count.value() < 1 || count.value() > UINT32_MAX)) {
-        warnln("invalid count argument: '{}': out of range: 1 <= value <= {}", count.value(), UINT32_MAX);
+    if (count.has_value() && (count.value() < 1 || count.value() > NumericLimits<u32>::max())) {
+        warnln("invalid count argument: '{}': out of range: 1 <= value <= {}", count.value(), NumericLimits<u32>::max());
         return 1;
     }
 

--- a/Userland/Utilities/tsort.cpp
+++ b/Userland/Utilities/tsort.cpp
@@ -53,7 +53,7 @@ static void prioritize_nodes(Node& start, NodeMap& node_map, NodeStack& stack, b
     // chains, this function does not call itself recursively. Instead, the recursive
     // algorithm is implemented on a provided stack.
 
-    assert(stack.is_empty());
+    VERIFY(stack.is_empty());
     stack.append(start);
 
     while (!stack.is_empty()) {


### PR DESCRIPTION
I feel like there is a general consensus that we are not supposed to use libc (either Serenity's or host) APIs in C++ code. Despite that, we include libc headers in each and every compilation unit. Unsurprisingly, this leads to accidental uses of C definitions even when C++ alternatives are available. The most notable example of this is INT_MAX family of macros. So, the PR aims to remove some of the libc includes in AK. It addresses 9 includes that do not match `/(AK/|Kernel/)/` and leaves 28 for future patches.

Most of the commits are straightforward to review and are not controversial. `initializer_list` and `AK/Types.h` commits, on the other hand, are controversial. I would like some opinions on whether the proposed solution is the right one.

For the `AK/Types.h`, I investigated using code generator approach instead of guessing. First, it was not trivial to persuade CMake to generate something for AK. Second, it won't work when cross-compiling not for Serenity, since we need to use target libc in generator.