### PR TITLE
Kernel/FS: Fix check-then-act concurrency bug in FileSystem/Inode

### DIFF
--- a/Kernel/FileSystem/Ext2FS/Inode.cpp
+++ b/Kernel/FileSystem/Ext2FS/Inode.cpp
@@ -494,6 +494,9 @@ InodeMetadata Ext2FSInode::metadata() const
 ErrorOr<void> Ext2FSInode::flush_metadata()
 {
     MutexLocker locker(m_inode_lock);
+    if (!is_metadata_dirty())
+        return {};
+
     dbgln_if(EXT2_DEBUG, "Ext2FSInode[{}]::flush_metadata(): Flushing inode", identifier());
     TRY(fs().write_ext2_inode(index(), m_raw_inode));
     if (is_directory()) {

--- a/Kernel/FileSystem/Inode.cpp
+++ b/Kernel/FileSystem/Inode.cpp
@@ -39,15 +39,13 @@ void Inode::sync_all()
     });
 
     for (auto& inode : inodes) {
-        VERIFY(inode->is_metadata_dirty());
         (void)inode->flush_metadata();
     }
 }
 
 void Inode::sync()
 {
-    if (is_metadata_dirty())
-        (void)flush_metadata();
+    (void)flush_metadata();
     auto result = fs().flush_writes();
     if (result.is_error()) {
         // TODO: Figure out how to propagate error to a higher function.


### PR DESCRIPTION
When the FileSystem does a sync, it gathers up all the inodes with dirty metadata into a vector. The inode mutex is not held while checking the inode dirty bit, which can lead to a kernel panic due to concurrent inode modifications.

Fixes: #21796

This is my first Serenity contribution, so let me know if I'm missing something important!