### PR TITLE
LibJS: Cache compiled Bytecode::Executable on AST function node

### DIFF
--- a/Userland/Libraries/LibJS/AST.cpp
+++ b/Userland/Libraries/LibJS/AST.cpp
@@ -1930,6 +1930,11 @@ FunctionNode::FunctionNode(RefPtr<Identifier const> name, DeprecatedString sourc
 
 FunctionNode::~FunctionNode() = default;
 
+bool FunctionNode::has_cached_bytecode_executable() const
+{
+    return m_bytecode_executable;
+}
+
 RefPtr<Bytecode::Executable> FunctionNode::cached_bytecode_executable() const
 {
     return m_bytecode_executable;

--- a/Userland/Libraries/LibJS/AST.h
+++ b/Userland/Libraries/LibJS/AST.h
@@ -700,6 +700,7 @@ public:
     bool is_arrow_function() const { return m_is_arrow_function; }
     FunctionKind kind() const { return m_kind; }
 
+    [[nodiscard]] bool has_cached_bytecode_executable() const;
     [[nodiscard]] RefPtr<Bytecode::Executable> cached_bytecode_executable() const;
     void set_cached_bytecode_executable(RefPtr<Bytecode::Executable> executable) const;
 

--- a/Userland/Libraries/LibJS/Bytecode/CommonImplementations.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/CommonImplementations.cpp
@@ -292,7 +292,7 @@ Value new_function(VM& vm, FunctionExpression const& function_node, Optional<Ide
             name = vm.bytecode_interpreter().current_executable().get_identifier(lhs_name.value());
         value = function_node.instantiate_ordinary_function_expression(vm, name);
     } else {
-        value = ECMAScriptFunctionObject::create(*vm.current_realm(), function_node.name(), function_node.source_text(), function_node.body(), function_node.parameters(), function_node.function_length(), function_node.local_variables_names(), vm.lexical_environment(), vm.running_execution_context().private_environment, function_node.kind(), function_node.is_strict_mode(), function_node.might_need_arguments_object(), function_node.contains_direct_call_to_eval(), function_node.is_arrow_function());
+        value = ECMAScriptFunctionObject::create(*vm.current_realm(), function_node, function_node.name(), function_node.source_text(), function_node.body(), function_node.parameters(), function_node.function_length(), function_node.local_variables_names(), vm.lexical_environment(), vm.running_execution_context().private_environment, function_node.kind(), function_node.is_strict_mode(), function_node.might_need_arguments_object(), function_node.contains_direct_call_to_eval(), function_node.is_arrow_function());
     }
 
     if (home_object.has_value()) {

--- a/Userland/Libraries/LibJS/Runtime/AbstractOperations.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AbstractOperations.cpp
@@ -972,7 +972,7 @@ ThrowCompletionOr<void> eval_declaration_instantiation(VM& vm, Program const& pr
     for (auto& declaration : functions_to_initialize.in_reverse()) {
         // a. Let fn be the sole element of the BoundNames of f.
         // b. Let fo be InstantiateFunctionObject of f with arguments lexEnv and privateEnv.
-        auto function = ECMAScriptFunctionObject::create(realm, declaration.name(), declaration.source_text(), declaration.body(), declaration.parameters(), declaration.function_length(), declaration.local_variables_names(), lexical_environment, private_environment, declaration.kind(), declaration.is_strict_mode(), declaration.might_need_arguments_object());
+        auto function = ECMAScriptFunctionObject::create(realm, declaration, declaration.name(), declaration.source_text(), declaration.body(), declaration.parameters(), declaration.function_length(), declaration.local_variables_names(), lexical_environment, private_environment, declaration.kind(), declaration.is_strict_mode(), declaration.might_need_arguments_object());
 
         // c. If varEnv is a global Environment Record, then
         if (global_var_environment) {

--- a/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
@@ -1187,8 +1187,15 @@ Completion ECMAScriptFunctionObject::ordinary_call_evaluate_body()
             return declaration_result.release_error();
     }
 
-    if (!m_bytecode_executable)
-        m_bytecode_executable = TRY(Bytecode::compile(vm, *m_ecmascript_code, m_kind, m_name));
+    if (!m_bytecode_executable) {
+        if (m_function_node && m_function_node->has_cached_bytecode_executable()) {
+            m_bytecode_executable = m_function_node->cached_bytecode_executable();
+        } else {
+            m_bytecode_executable = TRY(Bytecode::compile(vm, *m_ecmascript_code, m_kind, m_name));
+            if (m_function_node)
+                m_function_node->set_cached_bytecode_executable(*m_bytecode_executable);
+        }
+    }
 
     if (m_kind == FunctionKind::Async) {
         if (declaration_result.is_throw_completion()) {

--- a/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.h
+++ b/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.h
@@ -38,8 +38,42 @@ public:
         Global,
     };
 
-    static NonnullGCPtr<ECMAScriptFunctionObject> create(Realm&, DeprecatedFlyString name, DeprecatedString source_text, Statement const& ecmascript_code, Vector<FunctionParameter> parameters, i32 m_function_length, Vector<DeprecatedFlyString> local_variables_names, Environment* parent_environment, PrivateEnvironment* private_environment, FunctionKind, bool is_strict, bool might_need_arguments_object = true, bool contains_direct_call_to_eval = true, bool is_arrow_function = false, Variant<PropertyKey, PrivateName, Empty> class_field_initializer_name = {});
-    static NonnullGCPtr<ECMAScriptFunctionObject> create(Realm&, DeprecatedFlyString name, Object& prototype, DeprecatedString source_text, Statement const& ecmascript_code, Vector<FunctionParameter> parameters, i32 m_function_length, Vector<DeprecatedFlyString> local_variables_names, Environment* parent_environment, PrivateEnvironment* private_environment, FunctionKind, bool is_strict, bool might_need_arguments_object = true, bool contains_direct_call_to_eval = true, bool is_arrow_function = false, Variant<PropertyKey, PrivateName, Empty> class_field_initializer_name = {});
+    static NonnullGCPtr<ECMAScriptFunctionObject> create(
+        Realm&,
+        RefPtr<FunctionNode const>,
+        DeprecatedFlyString name,
+        DeprecatedString source_text,
+        Statement const& ecmascript_code,
+        Vector<FunctionParameter> parameters,
+        i32 m_function_length,
+        Vector<DeprecatedFlyString> local_variables_names,
+        Environment* parent_environment,
+        PrivateEnvironment* private_environment,
+        FunctionKind,
+        bool is_strict,
+        bool might_need_arguments_object = true,
+        bool contains_direct_call_to_eval = true,
+        bool is_arrow_function = false,
+        Variant<PropertyKey, PrivateName, Empty> class_field_initializer_name = {});
+
+    static NonnullGCPtr<ECMAScriptFunctionObject> create(
+        Realm&,
+        RefPtr<FunctionNode const>,
+        DeprecatedFlyString name,
+        Object& prototype,
+        DeprecatedString source_text,
+        Statement const& ecmascript_code,
+        Vector<FunctionParameter> parameters,
+        i32 m_function_length,
+        Vector<DeprecatedFlyString> local_variables_names,
+        Environment* parent_environment,
+        PrivateEnvironment* private_environment,
+        FunctionKind,
+        bool is_strict,
+        bool might_need_arguments_object = true,
+        bool contains_direct_call_to_eval = true,
+        bool is_arrow_function = false,
+        Variant<PropertyKey, PrivateName, Empty> class_field_initializer_name = {});
 
     virtual void initialize(Realm&) override;
     virtual ~ECMAScriptFunctionObject() override = default;
@@ -101,7 +135,7 @@ protected:
     virtual Completion ordinary_call_evaluate_body();
 
 private:
-    ECMAScriptFunctionObject(DeprecatedFlyString name, DeprecatedString source_text, Statement const& ecmascript_code, Vector<FunctionParameter> parameters, i32 m_function_length, Vector<DeprecatedFlyString> local_variables_names, Environment* parent_environment, PrivateEnvironment* private_environment, Object& prototype, FunctionKind, bool is_strict, bool might_need_arguments_object, bool contains_direct_call_to_eval, bool is_arrow_function, Variant<PropertyKey, PrivateName, Empty> class_field_initializer_name);
+    ECMAScriptFunctionObject(RefPtr<FunctionNode const>, DeprecatedFlyString name, DeprecatedString source_text, Statement const& ecmascript_code, Vector<FunctionParameter> parameters, i32 m_function_length, Vector<DeprecatedFlyString> local_variables_names, Environment* parent_environment, PrivateEnvironment* private_environment, Object& prototype, FunctionKind, bool is_strict, bool might_need_arguments_object, bool contains_direct_call_to_eval, bool is_arrow_function, Variant<PropertyKey, PrivateName, Empty> class_field_initializer_name);
 
     virtual bool is_ecmascript_function_object() const override { return true; }
     virtual void visit_edges(Visitor&) override;
@@ -157,6 +191,8 @@ private:
     size_t m_function_environment_bindings_count { 0 };
     size_t m_var_environment_bindings_count { 0 };
     size_t m_lex_environment_bindings_count { 0 };
+
+    RefPtr<FunctionNode const> m_function_node;
 };
 
 template<>

--- a/Userland/Libraries/LibJS/Runtime/FunctionConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/FunctionConstructor.cpp
@@ -218,7 +218,7 @@ ThrowCompletionOr<ECMAScriptFunctionObject*> FunctionConstructor::create_dynamic
     PrivateEnvironment* private_environment = nullptr;
 
     // 28. Let F be OrdinaryFunctionCreate(proto, sourceText, parameters, body, non-lexical-this, env, privateEnv).
-    auto function = ECMAScriptFunctionObject::create(realm, "anonymous", *prototype, move(source_text), expr->body(), expr->parameters(), expr->function_length(), expr->local_variables_names(), &environment, private_environment, expr->kind(), expr->is_strict_mode(), expr->might_need_arguments_object(), contains_direct_call_to_eval);
+    auto function = ECMAScriptFunctionObject::create(realm, nullptr, "anonymous", *prototype, move(source_text), expr->body(), expr->parameters(), expr->function_length(), expr->local_variables_names(), &environment, private_environment, expr->kind(), expr->is_strict_mode(), expr->might_need_arguments_object(), contains_direct_call_to_eval);
 
     // FIXME: Remove the name argument from create() and do this instead.
     // 29. Perform SetFunctionName(F, "anonymous").

--- a/Userland/Libraries/LibJS/SourceTextModule.cpp
+++ b/Userland/Libraries/LibJS/SourceTextModule.cpp
@@ -492,7 +492,7 @@ ThrowCompletionOr<void> SourceTextModule::initialize_environment(VM& vm)
                 DeprecatedFlyString function_name = function_declaration.name();
                 if (function_name == ExportStatement::local_name_for_default)
                     function_name = "default"sv;
-                auto function = ECMAScriptFunctionObject::create(realm(), function_name, function_declaration.source_text(), function_declaration.body(), function_declaration.parameters(), function_declaration.function_length(), function_declaration.local_variables_names(), environment, private_environment, function_declaration.kind(), function_declaration.is_strict_mode(), function_declaration.might_need_arguments_object(), function_declaration.contains_direct_call_to_eval());
+                auto function = ECMAScriptFunctionObject::create(realm(), function_declaration, function_name, function_declaration.source_text(), function_declaration.body(), function_declaration.parameters(), function_declaration.function_length(), function_declaration.local_variables_names(), environment, private_environment, function_declaration.kind(), function_declaration.is_strict_mode(), function_declaration.might_need_arguments_object(), function_declaration.contains_direct_call_to_eval());
 
                 // 2. Perform ! env.InitializeBinding(dn, fo, normal).
                 MUST(environment->initialize_binding(vm, name, function, Environment::InitializeBindingHint::Normal));

--- a/Userland/Libraries/LibWeb/DOM/EventTarget.cpp
+++ b/Userland/Libraries/LibWeb/DOM/EventTarget.cpp
@@ -486,7 +486,7 @@ WebIDL::CallbackType* EventTarget::get_current_value_of_event_handler(FlyString 
 
         //  6. Return scope. (NOTE: Not necessary)
 
-        auto function = JS::ECMAScriptFunctionObject::create(realm, name.to_deprecated_fly_string(), builder.to_deprecated_string(), program->body(), program->parameters(), program->function_length(), program->local_variables_names(), scope, nullptr, JS::FunctionKind::Normal, program->is_strict_mode(), program->might_need_arguments_object(), is_arrow_function);
+        auto function = JS::ECMAScriptFunctionObject::create(realm, program, name.to_deprecated_fly_string(), builder.to_deprecated_string(), program->body(), program->parameters(), program->function_length(), program->local_variables_names(), scope, nullptr, JS::FunctionKind::Normal, program->is_strict_mode(), program->might_need_arguments_object(), is_arrow_function);
 
         // 10. Remove settings object's realm execution context from the JavaScript execution context stack.
         VERIFY(vm.execution_context_stack().last() == &settings_object.realm_execution_context());

--- a/Userland/Libraries/LibWeb/WebDriver/ExecuteScript.cpp
+++ b/Userland/Libraries/LibWeb/WebDriver/ExecuteScript.cpp
@@ -265,7 +265,7 @@ static JS::ThrowCompletionOr<JS::Value> execute_a_function_body(Web::Page& page,
     //    The result of parsing global scope above.
     // strict
     //    The result of parsing strict above.
-    auto function = JS::ECMAScriptFunctionObject::create(realm, "", move(source_text), function_expression->body(), function_expression->parameters(), function_expression->function_length(), function_expression->local_variables_names(), &global_scope, nullptr, function_expression->kind(), function_expression->is_strict_mode(), function_expression->might_need_arguments_object(), contains_direct_call_to_eval);
+    auto function = JS::ECMAScriptFunctionObject::create(realm, nullptr, "", move(source_text), function_expression->body(), function_expression->parameters(), function_expression->function_length(), function_expression->local_variables_names(), &global_scope, nullptr, function_expression->kind(), function_expression->is_strict_mode(), function_expression->might_need_arguments_object(), contains_direct_call_to_eval);
 
     // 9. Let completion be Function.[[Call]](window, parameters) with function as the this value.
     // NOTE: This is not entirely clear, but I don't think they mean actually passing `function` as


### PR DESCRIPTION
This allows us to cache executables for nested functions, avoiding recompilation (both bytecode and JIT).
    
Basically, a scenario like this:
    
    function foo() {
        function bar() {
        }
    }
    
Before this change, `bar` would be recompiled every time `foo` was called. This no longer happens :^)

Some really nice progressions on Octane:

```
Suite       Test                                   Speedup  Old (Mean ± Range)           New (Mean ± Range)
----------  -----------------------------------  ---------  ---------------------------  ---------------------------
Kraken      ai-astar.js                              1.011  0.890 ± 0.880 … 0.900        0.880 ± 0.880 … 0.880
Kraken      audio-beat-detection.js                  0.98   0.500 ± 0.500 … 0.500        0.510 ± 0.500 … 0.520
Kraken      audio-dft.js                             1.027  0.375 ± 0.370 … 0.380        0.365 ± 0.360 … 0.370
Kraken      audio-fft.js                             1      0.370 ± 0.360 … 0.380        0.370 ± 0.370 … 0.370
Kraken      audio-oscillator.js                      1.056  1.045 ± 1.040 … 1.050        0.990 ± 0.990 … 0.990
Kraken      imaging-darkroom.js                      1.001  3.570 ± 3.550 … 3.590        3.565 ± 3.560 … 3.570
Kraken      imaging-desaturate.js                    1.117  0.765 ± 0.700 … 0.830        0.685 ± 0.680 … 0.690
Kraken      imaging-gaussian-blur.js                 0.964  2.780 ± 2.760 … 2.800        2.885 ± 2.830 … 2.940
Kraken      json-parse-financial.js                  1      0.080 ± 0.080 … 0.080        0.080 ± 0.080 … 0.080
Kraken      json-stringify-tinderbox.js              1.045  0.230 ± 0.230 … 0.230        0.220 ± 0.220 … 0.220
Kraken      stanford-crypto-aes.js                   0.983  0.595 ± 0.590 … 0.600        0.605 ± 0.600 … 0.610
Kraken      stanford-crypto-ccm.js                   1.008  0.625 ± 0.620 … 0.630        0.620 ± 0.620 … 0.620
Kraken      stanford-crypto-pbkdf2.js                0.981  1.030 ± 1.020 … 1.040        1.050 ± 1.050 … 1.050
Kraken      stanford-crypto-sha256-iterative.js      1      0.450 ± 0.450 … 0.450        0.450 ± 0.450 … 0.450
Octane      box2d.js                                 0.934  3.210 ± 3.210 … 3.210        3.435 ± 3.160 … 3.710
Octane      code-load.js                             1.012  2.145 ± 2.140 … 2.150        2.120 ± 2.120 … 2.120
Octane      crypto.js                                0.993  5.130 ± 5.120 … 5.140        5.165 ± 5.160 … 5.170
Octane      deltablue.js                             0.985  3.055 ± 3.050 … 3.060        3.100 ± 3.090 … 3.110
Octane      earley-boyer.js                          1.3    31.625 ± 31.400 … 31.850     24.325 ± 24.120 … 24.530
Octane      gbemu.js                                 1      4.385 ± 4.340 … 4.430        4.385 ± 4.330 … 4.440
Octane      mandreel.js                              1.02   27.780 ± 27.730 … 27.830     27.235 ± 27.040 … 27.430
Octane      navier-stokes.js                         0.993  2.035 ± 2.030 … 2.040        2.050 ± 2.050 … 2.050
Octane      pdfjs.js                                 1.008  3.740 ± 3.740 … 3.740        3.710 ± 3.710 … 3.710
Octane      raytrace.js                              1.019  8.345 ± 8.330 … 8.360        8.190 ± 8.160 … 8.220
Octane      regexp.js                                0.989  27.120 ± 27.100 … 27.140     27.430 ± 27.420 … 27.440
Octane      richards.js                              1      2.025 ± 2.020 … 2.030        2.025 ± 2.020 … 2.030
Octane      splay.js                                 1.005  3.170 ± 3.170 … 3.170        3.155 ± 3.150 … 3.160
Octane      typescript.js                            1.068  60.010 ± 59.910 … 60.110     56.165 ± 54.970 … 57.360
Octane      zlib.js                                  1.035  112.235 ± 112.070 … 112.400  108.390 ± 108.140 … 108.640
Kraken      Total                                    1.002  13.305                       13.275
Octane      Total                                    1.054  296.010                      280.880
All Suites  Total                                    1.052  309.315                      294.155
```