### PR TITLE
LibWeb: Improvements to table layout

### DIFF
--- a/Tests/LibWeb/Layout/expected/font-size-legacy.txt
+++ b/Tests/LibWeb/Layout/expected/font-size-legacy.txt
@@ -1,0 +1,14 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x33.46875 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x17.46875 children: inline
+      line 0 width: 24.109375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+        frag 0 from TextNode start: 0, length: 4, rect: [8,11 24.109375x13.09375]
+          "text"
+      InlineNode <font>
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x33.46875]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x17.46875]
+      InlinePaintable (InlineNode<FONT>)
+        TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/internal-alignment.txt
+++ b/Tests/LibWeb/Layout/expected/table/internal-alignment.txt
@@ -1,0 +1,26 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x220 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x204 children: not-inline
+      BlockContainer <div> at (8,8) content-size 784x204 children: not-inline
+        TableWrapper <(anonymous)> at (300,8) content-size 200x204 [BFC] children: not-inline
+          Box <table> at (301,9) content-size 198x202 table-box [TFC] children: not-inline
+            Box <tbody> at (301,9) content-size 194x198 table-row-group children: not-inline
+              Box <tr> at (303,11) content-size 194x198 table-row children: not-inline
+                BlockContainer <td> at (304,85.265625) content-size 192x49.46875 table-cell [BFC] children: not-inline
+                  BlockContainer <p> at (304,101.265625) content-size 192x17.46875 children: inline
+                    line 0 width: 26.25, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                      frag 0 from TextNode start: 0, length: 4, rect: [304,101.265625 26.25x17.46875]
+                        "left"
+                    TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x220]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x204]
+      PaintableWithLines (BlockContainer<DIV>) [8,8 784x204]
+        PaintableWithLines (TableWrapper(anonymous)) [300,8 200x204]
+          PaintableBox (Box<TABLE>) [300,8 200x204]
+            PaintableBox (Box<TBODY>) [301,9 194x198] overflow: [301,9 196x200]
+              PaintableBox (Box<TR>) [303,11 194x198]
+                PaintableWithLines (BlockContainer<TD>) [303,11 194x198]
+                  PaintableWithLines (BlockContainer<P>) [304,101.265625 192x17.46875]
+                    TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/nested-table-alignment.txt
+++ b/Tests/LibWeb/Layout/expected/table/nested-table-alignment.txt
@@ -1,0 +1,32 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x228 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x212 children: not-inline
+      TableWrapper <(anonymous)> at (8,8) content-size 200x212 [BFC] children: not-inline
+        Box <table> at (9,9) content-size 198x210 table-box [TFC] children: not-inline
+          Box <tbody> at (9,9) content-size 194x206 table-row-group children: not-inline
+            Box <tr> at (11,11) content-size 194x206 table-row children: not-inline
+              BlockContainer <td> at (12,12) content-size 192x204 table-cell [BFC] children: not-inline
+                TableWrapper <(anonymous)> at (158.890625,12) content-size 45.109375x204 [BFC] children: not-inline
+                  Box <table> at (159.890625,13) content-size 43.109375x202 table-box [TFC] children: not-inline
+                    Box <tbody> at (159.890625,13) content-size 39.109375x198 table-row-group children: not-inline
+                      Box <tr> at (161.890625,15) content-size 39.109375x198 table-row children: not-inline
+                        BlockContainer <td> at (162.890625,105.265625) content-size 37.109375x17.46875 table-cell [BFC] children: inline
+                          line 0 width: 37.109375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                            frag 0 from TextNode start: 0, length: 5, rect: [162.890625,105.265625 37.109375x17.46875]
+                              "right"
+                          TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x228]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x212]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 200x212]
+        PaintableBox (Box<TABLE>) [8,8 200x212]
+          PaintableBox (Box<TBODY>) [9,9 194x206] overflow: [9,9 196x208]
+            PaintableBox (Box<TR>) [11,11 194x206]
+              PaintableWithLines (BlockContainer<TD>) [11,11 194x206]
+                PaintableWithLines (TableWrapper(anonymous)) [158.890625,12 45.109375x204]
+                  PaintableBox (Box<TABLE>) [158.890625,12 45.109375x204]
+                    PaintableBox (Box<TBODY>) [159.890625,13 39.109375x198] overflow: [159.890625,13 41.109375x200]
+                      PaintableBox (Box<TR>) [161.890625,15 39.109375x198]
+                        PaintableWithLines (BlockContainer<TD>) [161.890625,15 39.109375x198]
+                          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/table-align-center-with-margin.txt
+++ b/Tests/LibWeb/Layout/expected/table/table-align-center-with-margin.txt
@@ -1,0 +1,24 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x312 [BFC] children: not-inline
+    BlockContainer <body> at (8,100) content-size 784x204 children: not-inline
+      TableWrapper <(anonymous)> at (108,100) content-size 89.34375x204 [BFC] children: not-inline
+        Box <table> at (109,101) content-size 87.34375x202 table-box [TFC] children: not-inline
+          Box <tbody> at (109,101) content-size 83.34375x198 table-row-group children: not-inline
+            Box <tr> at (111,103) content-size 83.34375x198 table-row children: not-inline
+              BlockContainer <td> at (112,193.265625) content-size 81.34375x17.46875 table-cell [BFC] children: inline
+                line 0 width: 81.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                  frag 0 from TextNode start: 0, length: 10, rect: [112,193.265625 81.34375x17.46875]
+                    "off-center"
+                TextNode <#text>
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x312]
+    PaintableWithLines (BlockContainer<BODY>) [8,100 784x204]
+      PaintableWithLines (TableWrapper(anonymous)) [108,100 89.34375x204]
+        PaintableBox (Box<TABLE>) [108,100 89.34375x204]
+          PaintableBox (Box<TBODY>) [109,101 83.34375x198] overflow: [109,101 85.34375x200]
+            PaintableBox (Box<TR>) [111,103 83.34375x198]
+              PaintableWithLines (BlockContainer<TD>) [111,103 83.34375x198]
+                TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/table-align-center.txt
+++ b/Tests/LibWeb/Layout/expected/table/table-align-center.txt
@@ -1,0 +1,24 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x220 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x204 children: not-inline
+      TableWrapper <(anonymous)> at (370.1875,8) content-size 59.625x204 [BFC] children: not-inline
+        Box <table> at (371.1875,9) content-size 57.625x202 table-box [TFC] children: not-inline
+          Box <tbody> at (371.1875,9) content-size 53.625x198 table-row-group children: not-inline
+            Box <tr> at (373.1875,11) content-size 53.625x198 table-row children: not-inline
+              BlockContainer <td> at (374.1875,101.265625) content-size 51.625x17.46875 table-cell [BFC] children: inline
+                line 0 width: 51.625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                  frag 0 from TextNode start: 0, length: 6, rect: [374.1875,101.265625 51.625x17.46875]
+                    "center"
+                TextNode <#text>
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x220]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x204]
+      PaintableWithLines (TableWrapper(anonymous)) [370.1875,8 59.625x204]
+        PaintableBox (Box<TABLE>) [370.1875,8 59.625x204]
+          PaintableBox (Box<TBODY>) [371.1875,9 53.625x198] overflow: [371.1875,9 55.625x200]
+            PaintableBox (Box<TR>) [373.1875,11 53.625x198]
+              PaintableWithLines (BlockContainer<TD>) [373.1875,11 53.625x198]
+                TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/table-cellpadding.txt
+++ b/Tests/LibWeb/Layout/expected/table/table-cellpadding.txt
@@ -1,0 +1,38 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x220 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x204 children: not-inline
+      TableWrapper <(anonymous)> at (8,8) content-size 498.1875x204 [BFC] children: not-inline
+        Box <table> at (9,9) content-size 496.1875x202 table-box [TFC] children: not-inline
+          Box <tbody> at (9,9) content-size 488.1875x198 table-row-group children: not-inline
+            Box <tr> at (11,11) content-size 488.1875x198 table-row children: not-inline
+              BlockContainer <td> at (71,71) content-size 26.640625x17.46875 table-cell [BFC] children: inline
+                line 0 width: 26.640625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                  frag 0 from TextNode start: 0, length: 3, rect: [71,71 26.640625x17.46875]
+                    "top"
+                TextNode <#text>
+              BlockContainer <td> at (219.640625,101.265625) content-size 45.4375x17.46875 table-cell [BFC] children: inline
+                line 0 width: 45.4375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                  frag 0 from TextNode start: 0, length: 6, rect: [219.640625,101.265625 45.4375x17.46875]
+                    "middle"
+                TextNode <#text>
+              BlockContainer <td> at (387.078125,131.53125) content-size 56.109375x17.46875 table-cell [BFC] children: inline
+                line 0 width: 56.109375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+                  frag 0 from TextNode start: 0, length: 6, rect: [387.078125,131.53125 56.109375x17.46875]
+                    "bottom"
+                TextNode <#text>
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x220]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x204]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 498.1875x204]
+        PaintableBox (Box<TABLE>) [8,8 498.1875x204]
+          PaintableBox (Box<TBODY>) [9,9 488.1875x198] overflow: [9,9 494.1875x200]
+            PaintableBox (Box<TR>) [11,11 488.1875x198] overflow: [11,11 492.1875x198]
+              PaintableWithLines (BlockContainer<TD>) [11,11 146.640625x198]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [159.640625,11 165.4375x198]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [327.078125,11 176.109375x198]
+                TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/tr-valign.txt
+++ b/Tests/LibWeb/Layout/expected/table/tr-valign.txt
@@ -1,0 +1,24 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x526 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x510 children: not-inline
+      TableWrapper <(anonymous)> at (8,8) content-size 216x510 [BFC] children: not-inline
+        Box <table> at (9,9) content-size 214x508 table-box [TFC] children: not-inline
+          Box <tbody> at (9,9) content-size 208x504 table-row-group children: not-inline
+            Box <tr> at (11,11) content-size 208x504 table-row children: not-inline
+              BlockContainer <td> at (12,12) content-size 102x502 table-cell [BFC] children: not-inline
+                BlockContainer <div> at (13,13) content-size 100x500 children: not-inline
+              BlockContainer <td> at (118,12) content-size 102x102 table-cell [BFC] children: not-inline
+                BlockContainer <div> at (119,13) content-size 100x100 children: inline
+                  TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x526]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x510]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 216x510]
+        PaintableBox (Box<TABLE>) [8,8 216x510]
+          PaintableBox (Box<TBODY>) [9,9 208x504] overflow: [9,9 212x506]
+            PaintableBox (Box<TR>) [11,11 208x504] overflow: [11,11 210x504]
+              PaintableWithLines (BlockContainer<TD>) [11,11 104x504]
+                PaintableWithLines (BlockContainer<DIV>) [12,12 102x502]
+              PaintableWithLines (BlockContainer<TD>) [117,11 104x504]
+                PaintableWithLines (BlockContainer<DIV>) [118,12 102x102]

--- a/Tests/LibWeb/Layout/input/font-size-legacy.html
+++ b/Tests/LibWeb/Layout/input/font-size-legacy.html
@@ -1,0 +1,1 @@
+<!doctype html><font size="-2">text

--- a/Tests/LibWeb/Layout/input/table/internal-alignment.html
+++ b/Tests/LibWeb/Layout/input/table/internal-alignment.html
@@ -1,0 +1,7 @@
+<!doctype html><style>
+table {
+    height: 200px;
+    width: 200px;
+    border: 1px solid black;
+}
+</style><div align="center"><table><tbody><tr><td><p>left

--- a/Tests/LibWeb/Layout/input/table/nested-table-alignment.html
+++ b/Tests/LibWeb/Layout/input/table/nested-table-alignment.html
@@ -1,0 +1,6 @@
+<!doctype html><style>
+table {
+    height: 200px;
+    border: 1px solid black;
+}
+</style><table width="200px"><td align="right"><table><td>right

--- a/Tests/LibWeb/Layout/input/table/table-align-center-with-margin.html
+++ b/Tests/LibWeb/Layout/input/table/table-align-center-with-margin.html
@@ -1,0 +1,7 @@
+<!doctype html><style>
+table {
+    height: 200px;
+    border: 1px solid black;
+    margin: 100px;
+}
+</style><table align="center"><td>off-center</td>

--- a/Tests/LibWeb/Layout/input/table/table-align-center.html
+++ b/Tests/LibWeb/Layout/input/table/table-align-center.html
@@ -1,0 +1,6 @@
+<!doctype html><style>
+table {
+    height: 200px;
+    border: 1px solid black;
+}
+</style><table align="center"><td>center</td>

--- a/Tests/LibWeb/Layout/input/table/table-cellpadding.html
+++ b/Tests/LibWeb/Layout/input/table/table-cellpadding.html
@@ -1,0 +1,6 @@
+<!doctype html><style>
+table {
+    height: 200px;
+    border: 1px solid black;
+}
+</style><table cellpadding="60"><td valign=top>top</td><td valign=middle>middle</td><td valign=bottom>bottom</td>

--- a/Tests/LibWeb/Layout/input/table/tr-valign.html
+++ b/Tests/LibWeb/Layout/input/table/tr-valign.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html><style>
+table {
+    height: 200px;
+    width: 200px;
+    border: 1px solid black;
+}
+div {
+    width: 100px;
+    border: 1px solid black;
+}
+</style><table><tr valign="top"><td><div style="height: 500px"></div></td><td><div style="height: 100px">

--- a/Tests/LibWeb/Ref/body-link-attribute.html
+++ b/Tests/LibWeb/Ref/body-link-attribute.html
@@ -1,0 +1,4 @@
+<!doctype html>
+<link rel="match" href="reference/body-link-attribute-ref.html" />
+<body link="#FF0000">
+<a href="about:blank">link

--- a/Tests/LibWeb/Ref/reference/body-link-attribute-ref.html
+++ b/Tests/LibWeb/Ref/reference/body-link-attribute-ref.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<link rel="match" href="reference/body-link-attribute.html-ref" />
+<style>
+a {
+  color: #FF0000;
+}
+</style>
+<a href="about:blank">link

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/IdentifierStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/IdentifierStyleValue.cpp
@@ -194,8 +194,6 @@ Color IdentifierStyleValue::to_color(Optional<Layout::NodeWithStyle const&> node
         return SystemColor::highlight();
     case ValueID::Highlighttext:
         return SystemColor::highlight_text();
-    case ValueID::Linktext:
-        return SystemColor::link_text();
     case ValueID::Mark:
         return SystemColor::mark();
     case ValueID::Marktext:
@@ -216,7 +214,7 @@ Color IdentifierStyleValue::to_color(Optional<Layout::NodeWithStyle const&> node
     }
 
     auto& document = node->document();
-    if (id() == CSS::ValueID::LibwebLink)
+    if (id() == CSS::ValueID::LibwebLink || id() == ValueID::Linktext)
         return document.link_color();
 
     if (!document.page())

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -17,6 +17,7 @@
 #include <LibWeb/CSS/ResolvedCSSStyleDeclaration.h>
 #include <LibWeb/CSS/SelectorEngine.h>
 #include <LibWeb/CSS/StyleComputer.h>
+#include <LibWeb/CSS/StyleValues/IdentifierStyleValue.h>
 #include <LibWeb/CSS/StyleValues/NumberStyleValue.h>
 #include <LibWeb/DOM/Attr.h>
 #include <LibWeb/DOM/DOMTokenList.h>
@@ -45,6 +46,7 @@
 #include <LibWeb/HTML/HTMLOptionElement.h>
 #include <LibWeb/HTML/HTMLSelectElement.h>
 #include <LibWeb/HTML/HTMLStyleElement.h>
+#include <LibWeb/HTML/HTMLTableElement.h>
 #include <LibWeb/HTML/HTMLTextAreaElement.h>
 #include <LibWeb/HTML/Numbers.h>
 #include <LibWeb/HTML/Parser/HTMLParser.h>
@@ -551,6 +553,14 @@ Element::RequiredInvalidationAfterStyleChange Element::recompute_style()
 
     // FIXME propagate errors
     auto new_computed_css_values = MUST(document().style_computer().compute_style(*this));
+
+    // Tables must not inherit -libweb-* values for text-align.
+    // FIXME: Find the spec for this.
+    if (is<HTML::HTMLTableElement>(*this)) {
+        auto text_align = new_computed_css_values->text_align();
+        if (text_align.has_value() && (text_align.value() == CSS::TextAlign::LibwebLeft || text_align.value() == CSS::TextAlign::LibwebCenter || text_align.value() == CSS::TextAlign::LibwebRight))
+            new_computed_css_values->set_property(CSS::PropertyID::TextAlign, CSS::IdentifierStyleValue::create(CSS::ValueID::Start));
+    }
 
     RequiredInvalidationAfterStyleChange invalidation;
     if (m_computed_css_values)

--- a/Userland/Libraries/LibWeb/HTML/HTMLFontElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFontElement.cpp
@@ -4,15 +4,99 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/GenericLexer.h>
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/CSS/Parser/Parser.h>
+#include <LibWeb/CSS/Parser/ParsingContext.h>
 #include <LibWeb/CSS/StyleProperties.h>
 #include <LibWeb/CSS/StyleValues/ColorStyleValue.h>
 #include <LibWeb/HTML/HTMLFontElement.h>
 #include <LibWeb/HTML/Parser/HTMLParser.h>
+#include <LibWeb/Infra/CharacterTypes.h>
 
 namespace Web::HTML {
 
 JS_DEFINE_ALLOCATOR(HTMLFontElement);
+
+enum class Mode {
+    RelativePlus,
+    RelativeMinus,
+    Absolute,
+};
+
+// https://html.spec.whatwg.org/multipage/rendering.html#rules-for-parsing-a-legacy-font-size
+static Optional<CSS::ValueID> parse_legacy_font_size(StringView string)
+{
+    // 1. Let input be the attribute's value.
+    // 2. Let position be a pointer into input, initially pointing at the start of the string.
+    GenericLexer lexer { string };
+
+    // 3. Skip ASCII whitespace within input given position.
+    lexer.ignore_while(Web::Infra::is_ascii_whitespace);
+
+    // 4. If position is past the end of input, there is no presentational hint. Return.
+    if (lexer.is_eof())
+        return {};
+
+    // 5. If the character at position is a U+002B PLUS SIGN character (+), then let mode be relative-plus, and advance position to the next character. Otherwise, if the character at position is a U+002D HYPHEN-MINUS character (-), then let mode be relative-minus, and advance position to the next character. Otherwise, let mode be absolute.
+    Mode mode { Mode::Absolute };
+
+    if (lexer.peek() == '+') {
+        mode = Mode::RelativePlus;
+        lexer.consume();
+    } else if (lexer.peek() == '-') {
+        mode = Mode::RelativeMinus;
+        lexer.consume();
+    }
+
+    // 6. Collect a sequence of code points that are ASCII digits from input given position, and let the resulting sequence be digits.
+    size_t start_index = lexer.tell();
+    lexer.consume_while(is_ascii_digit);
+    size_t end_index = lexer.tell();
+    auto digits = lexer.input().substring_view(start_index, end_index - start_index);
+    auto value_or_empty = AK::StringUtils::convert_to_int<i32>(digits);
+
+    // 7. If digits is the empty string, there is no presentational hint. Return.
+    if (!value_or_empty.has_value())
+        return {};
+
+    // 8. Interpret digits as a base-ten integer. Let value be the resulting number.
+    auto value = value_or_empty.release_value();
+
+    // 9. If mode is relative-plus, then increment value by 3. If mode is relative-minus, then let value be the result of subtracting value from 3.
+    if (mode == Mode::RelativePlus)
+        value += 3;
+    else if (mode == Mode::RelativeMinus)
+        value = 3 - value;
+
+    // 10. If value is greater than 7, let it be 7.
+    if (value > 7)
+        value = 7;
+
+    // 11. If value is less than 1, let it be 1.
+    if (value < 1)
+        value = 1;
+
+    // 12. Set 'font-size' to the keyword corresponding to the value of value according to the following table:
+    switch (value) {
+    case 1:
+        return CSS::ValueID::XSmall;
+    case 2:
+        return CSS::ValueID::Small;
+    case 3:
+        return CSS::ValueID::Medium;
+    case 4:
+        return CSS::ValueID::Large;
+    case 5:
+        return CSS::ValueID::XLarge;
+    case 6:
+        return CSS::ValueID::XxLarge;
+    case 7:
+        return CSS::ValueID::XxxLarge;
+    default:
+        VERIFY_NOT_REACHED();
+    }
+}
 
 HTMLFontElement::HTMLFontElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : HTMLElement(document, move(qualified_name))
@@ -35,6 +119,14 @@ void HTMLFontElement::apply_presentational_hints(CSS::StyleProperties& style) co
             auto color = parse_legacy_color_value(value);
             if (color.has_value())
                 style.set_property(CSS::PropertyID::Color, CSS::ColorStyleValue::create(color.value()));
+        } else if (name.equals_ignoring_ascii_case("size"sv)) {
+            // When a font element has a size attribute, the user agent is expected to use the following steps, known as the rules for parsing a legacy font size, to treat the attribute as a presentational hint setting the element's 'font-size' property:
+            auto font_size_or_empty = parse_legacy_font_size(value);
+            if (font_size_or_empty.has_value()) {
+                auto font_size = string_from_value_id(font_size_or_empty.release_value());
+                if (auto parsed_value = parse_css_value(CSS::Parser::ParsingContext { document() }, font_size, CSS::PropertyID::FontSize))
+                    style.set_property(CSS::PropertyID::FontSize, parsed_value.release_nonnull());
+            }
         }
     });
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLTableCellElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableCellElement.cpp
@@ -85,7 +85,16 @@ void HTMLTableCellElement::apply_presentational_hints(CSS::StyleProperties& styl
         }
     });
     auto const& table_element = table_containing_cell(*this);
+
+    if (auto padding = table_element.padding()) {
+        style.set_property(CSS::PropertyID::PaddingTop, CSS::LengthStyleValue::create(CSS::Length::make_px(padding)));
+        style.set_property(CSS::PropertyID::PaddingBottom, CSS::LengthStyleValue::create(CSS::Length::make_px(padding)));
+        style.set_property(CSS::PropertyID::PaddingLeft, CSS::LengthStyleValue::create(CSS::Length::make_px(padding)));
+        style.set_property(CSS::PropertyID::PaddingRight, CSS::LengthStyleValue::create(CSS::Length::make_px(padding)));
+    }
+
     auto border = table_element.border();
+
     if (!border)
         return;
     auto apply_border_style = [&](CSS::PropertyID style_property, CSS::PropertyID width_property, CSS::PropertyID color_property) {

--- a/Userland/Libraries/LibWeb/HTML/HTMLTableCellElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableCellElement.cpp
@@ -60,6 +60,10 @@ void HTMLTableCellElement::apply_presentational_hints(CSS::StyleProperties& styl
         if (name == HTML::AttributeNames::align) {
             if (value.equals_ignoring_ascii_case("center"sv) || value.equals_ignoring_ascii_case("middle"sv)) {
                 style.set_property(CSS::PropertyID::TextAlign, CSS::IdentifierStyleValue::create(CSS::ValueID::LibwebCenter));
+            } else if (value.equals_ignoring_ascii_case("left"sv)) {
+                style.set_property(CSS::PropertyID::TextAlign, CSS::IdentifierStyleValue::create(CSS::ValueID::LibwebLeft));
+            } else if (value.equals_ignoring_ascii_case("right"sv)) {
+                style.set_property(CSS::PropertyID::TextAlign, CSS::IdentifierStyleValue::create(CSS::ValueID::LibwebRight));
             } else {
                 if (auto parsed_value = parse_css_value(CSS::Parser::ParsingContext { document() }, value.view(), CSS::PropertyID::TextAlign))
                     style.set_property(CSS::PropertyID::TextAlign, parsed_value.release_nonnull());

--- a/Userland/Libraries/LibWeb/HTML/HTMLTableElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableElement.cpp
@@ -16,6 +16,7 @@
 #include <LibWeb/HTML/HTMLTableColElement.h>
 #include <LibWeb/HTML/HTMLTableElement.h>
 #include <LibWeb/HTML/HTMLTableRowElement.h>
+#include <LibWeb/HTML/Numbers.h>
 #include <LibWeb/HTML/Parser/HTMLParser.h>
 #include <LibWeb/Namespace.h>
 
@@ -98,6 +99,19 @@ void HTMLTableElement::apply_presentational_hints(CSS::StyleProperties& style) c
             apply_border_style(CSS::PropertyID::BorderBottomStyle, CSS::PropertyID::BorderBottomWidth, CSS::PropertyID::BorderBottomColor);
         }
     });
+}
+
+void HTMLTableElement::attribute_changed(FlyString const& name, Optional<String> const& value)
+{
+    Base::attribute_changed(name, value);
+    if (name == HTML::AttributeNames::cellpadding) {
+        if (value.has_value())
+            m_padding = max(0, parse_integer(value.value()).value_or(0));
+        else
+            m_padding = 1;
+
+        return;
+    }
 }
 
 // https://html.spec.whatwg.org/multipage/tables.html#dom-table-caption
@@ -422,6 +436,11 @@ WebIDL::ExceptionOr<void> HTMLTableElement::delete_row(long index)
 unsigned int HTMLTableElement::border() const
 {
     return parse_border(deprecated_attribute(HTML::AttributeNames::border));
+}
+
+unsigned int HTMLTableElement::padding() const
+{
+    return m_padding;
 }
 
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLTableElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableElement.cpp
@@ -61,6 +61,15 @@ void HTMLTableElement::apply_presentational_hints(CSS::StyleProperties& style) c
                 style.set_property(CSS::PropertyID::Height, parsed_value.release_nonnull());
             return;
         }
+        if (name == HTML::AttributeNames::align) {
+            if (value.equals_ignoring_ascii_case("center"sv)) {
+                style.set_property(CSS::PropertyID::MarginLeft, CSS::IdentifierStyleValue::create(CSS::ValueID::Auto));
+                style.set_property(CSS::PropertyID::MarginRight, CSS::IdentifierStyleValue::create(CSS::ValueID::Auto));
+            } else if (auto parsed_value = parse_css_value(CSS::Parser::ParsingContext { document() }, value.view(), CSS::PropertyID::Float)) {
+                style.set_property(CSS::PropertyID::Float, parsed_value.release_nonnull());
+            }
+            return;
+        }
         if (name == HTML::AttributeNames::bgcolor) {
             // https://html.spec.whatwg.org/multipage/rendering.html#tables-2:rules-for-parsing-a-legacy-colour-value
             auto color = parse_legacy_color_value(value);

--- a/Userland/Libraries/LibWeb/HTML/HTMLTableElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableElement.h
@@ -47,6 +47,7 @@ public:
     virtual Optional<ARIA::Role> default_role() const override { return ARIA::Role::table; }
 
     unsigned border() const;
+    unsigned padding() const;
 
 private:
     HTMLTableElement(DOM::Document&, DOM::QualifiedName);
@@ -57,9 +58,11 @@ private:
     virtual void visit_edges(Cell::Visitor&) override;
 
     virtual void apply_presentational_hints(CSS::StyleProperties&) const override;
+    virtual void attribute_changed(FlyString const& name, Optional<String> const& value) override;
 
     JS::GCPtr<DOM::HTMLCollection> mutable m_rows;
     JS::GCPtr<DOM::HTMLCollection> mutable m_t_bodies;
+    unsigned m_padding { 1 };
 };
 
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLTableRowElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableRowElement.cpp
@@ -5,8 +5,11 @@
  */
 
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/CSS/Parser/Parser.h>
+#include <LibWeb/CSS/Parser/ParsingContext.h>
 #include <LibWeb/CSS/StyleProperties.h>
 #include <LibWeb/CSS/StyleValues/ColorStyleValue.h>
+#include <LibWeb/CSS/StyleValues/IdentifierStyleValue.h>
 #include <LibWeb/CSS/StyleValues/ImageStyleValue.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/ElementFactory.h>
@@ -48,6 +51,10 @@ void HTMLTableRowElement::apply_presentational_hints(CSS::StyleProperties& style
         } else if (name == HTML::AttributeNames::background) {
             if (auto parsed_value = document().parse_url(value); parsed_value.is_valid())
                 style.set_property(CSS::PropertyID::BackgroundImage, CSS::ImageStyleValue::create(parsed_value));
+            return;
+        } else if (name == HTML::AttributeNames::valign) {
+            if (auto parsed_value = parse_css_value(CSS::Parser::ParsingContext { document() }, value.view(), CSS::PropertyID::VerticalAlign))
+                style.set_property(CSS::PropertyID::VerticalAlign, parsed_value.release_nonnull());
             return;
         }
     });


### PR DESCRIPTION
Visual progression on http://www.slackware.com:

Before:
![before](https://github.com/SerenityOS/serenity/assets/114500360/704f9956-88f6-4cb2-9f03-ef5d1d4faeab)
After:
![after](https://github.com/SerenityOS/serenity/assets/114500360/120ed2ee-31e4-4041-9864-a4b2dcc10428)
