### PR TITLE
LibGfx: Use the FourCC struct for OpenType tags

### DIFF
--- a/Userland/Libraries/LibGfx/Font/OpenType/DataTypes.h
+++ b/Userland/Libraries/LibGfx/Font/OpenType/DataTypes.h
@@ -11,6 +11,7 @@
 
 #include <AK/Endian.h>
 #include <AK/Types.h>
+#include <LibGfx/FourCC.h>
 
 // https://learn.microsoft.com/en-us/typography/opentype/spec/otff#data-types
 namespace OpenType {
@@ -39,7 +40,7 @@ struct [[gnu::packed]] LongDateTime {
 };
 static_assert(AssertSize<LongDateTime, 8>());
 
-using Tag = BigEndian<u32>;
+using Tag = Gfx::FourCC;
 
 using Offset16 = BigEndian<u16>;
 // FIXME: Offset24

--- a/Userland/Libraries/LibGfx/Font/OpenType/Tables.cpp
+++ b/Userland/Libraries/LibGfx/Font/OpenType/Tables.cpp
@@ -16,16 +16,6 @@
 
 namespace OpenType {
 
-static u32 be_u32(u8 const* ptr)
-{
-    return (((u32)ptr[0]) << 24) | (((u32)ptr[1]) << 16) | (((u32)ptr[2]) << 8) | ((u32)ptr[3]);
-}
-
-static u32 tag_from_str(char const* str)
-{
-    return be_u32((u8 const*)str);
-}
-
 ErrorOr<Head> Head::from_slice(ReadonlyBytes slice)
 {
     if (slice.size() < sizeof(FontHeaderTable))
@@ -576,7 +566,7 @@ Optional<i16> GPOS::glyph_kerning(u16 left_glyph_id, u16 right_glyph_id) const
 
     Optional<Offset16> kern_feature_offset;
     for (auto const& feature_record : m_feature_records) {
-        if (feature_record.feature_tag == tag_from_str("kern")) {
+        if (feature_record.feature_tag == Tag("kern")) {
             kern_feature_offset = feature_record.feature_offset;
             break;
         }

--- a/Userland/Libraries/LibGfx/Font/WOFF/Font.cpp
+++ b/Userland/Libraries/LibGfx/Font/WOFF/Font.cpp
@@ -36,7 +36,7 @@ static_assert(AssertSize<Header, 44>());
 
 // https://www.w3.org/TR/WOFF/#TableDirectory
 struct [[gnu::packed]] TableDirectoryEntry {
-    BigEndian<u32> tag;           // 4-byte sfnt table identifier.
+    OpenType::Tag tag;            // 4-byte sfnt table identifier.
     BigEndian<u32> offset;        // Offset to the data, from beginning of WOFF file.
     BigEndian<u32> comp_length;   // Length of the compressed data, excluding padding.
     BigEndian<u32> orig_length;   // Length of the uncompressed table, excluding padding.

--- a/Userland/Libraries/LibGfx/FourCC.h
+++ b/Userland/Libraries/LibGfx/FourCC.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2023, Sam Atkins <atkinssj@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+namespace Gfx {
+
+struct FourCC {
+    constexpr FourCC(char const* name)
+    {
+        cc[0] = name[0];
+        cc[1] = name[1];
+        cc[2] = name[2];
+        cc[3] = name[3];
+    }
+
+    bool operator==(FourCC const&) const = default;
+    bool operator!=(FourCC const&) const = default;
+
+    char cc[4];
+};
+
+}

--- a/Userland/Libraries/LibGfx/FourCC.h
+++ b/Userland/Libraries/LibGfx/FourCC.h
@@ -8,8 +8,10 @@
 
 namespace Gfx {
 
-struct FourCC {
-    constexpr FourCC(char const* name)
+struct [[gnu::packed]] FourCC {
+    FourCC() = default;
+
+    constexpr FourCC(char const name[4])
     {
         cc[0] = name[0];
         cc[1] = name[1];
@@ -19,6 +21,14 @@ struct FourCC {
 
     bool operator==(FourCC const&) const = default;
     bool operator!=(FourCC const&) const = default;
+
+    u32 to_u32() const
+    {
+        return (static_cast<u8>(cc[0]) << 24)
+            | (static_cast<u8>(cc[1]) << 16)
+            | (static_cast<u8>(cc[2]) << 8)
+            | static_cast<u8>(cc[3]);
+    }
 
     char cc[4];
 };

--- a/Userland/Libraries/LibGfx/ImageFormats/ILBMLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/ILBMLoader.cpp
@@ -8,6 +8,7 @@
 #include <AK/Debug.h>
 #include <AK/Endian.h>
 #include <AK/FixedArray.h>
+#include <LibGfx/FourCC.h>
 #include <LibGfx/ImageFormats/ILBMLoader.h>
 
 namespace Gfx {

--- a/Userland/Libraries/LibGfx/ImageFormats/ImageDecoder.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/ImageDecoder.h
@@ -84,19 +84,4 @@ private:
     NonnullOwnPtr<ImageDecoderPlugin> mutable m_plugin;
 };
 
-struct FourCC {
-    constexpr FourCC(char const* name)
-    {
-        cc[0] = name[0];
-        cc[1] = name[1];
-        cc[2] = name[2];
-        cc[3] = name[3];
-    }
-
-    bool operator==(FourCC const&) const = default;
-    bool operator!=(FourCC const&) const = default;
-
-    char cc[4];
-};
-
 }

--- a/Userland/Libraries/LibGfx/ImageFormats/WebPLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/WebPLoader.cpp
@@ -9,6 +9,7 @@
 #include <AK/Format.h>
 #include <AK/MemoryStream.h>
 #include <AK/Vector.h>
+#include <LibGfx/FourCC.h>
 #include <LibGfx/ImageFormats/WebPLoader.h>
 #include <LibGfx/ImageFormats/WebPLoaderLossless.h>
 #include <LibGfx/ImageFormats/WebPLoaderLossy.h>


### PR DESCRIPTION
A fairly minor change, but does make the code a little nicer.