### PR TITLE
LibWeb: Fix null pointer dereference in DOM::Node::remove()

### DIFF
--- a/Tests/LibWeb/Text/expected/MutationObserver/removing-a-node.txt
+++ b/Tests/LibWeb/Text/expected/MutationObserver/removing-a-node.txt
@@ -1,0 +1,1 @@
+   PASS! (Didn't crash)

--- a/Tests/LibWeb/Text/input/MutationObserver/removing-a-node.html
+++ b/Tests/LibWeb/Text/input/MutationObserver/removing-a-node.html
@@ -1,0 +1,13 @@
+<body>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        let observer = new MutationObserver(function() {});
+        observer.observe(document.body, { attributes: true, childList: true, subtree: true });
+
+        let div = document.createElement("div");
+        document.body.appendChild(div);
+        div.remove();
+        println("PASS! (Didn't crash)");
+    });
+</script>

--- a/Userland/Libraries/LibWeb/DOM/Node.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Node.cpp
@@ -693,7 +693,7 @@ void Node::remove(bool suppress_observers)
         for (auto& registered : *inclusive_ancestor->m_registered_observer_list) {
             if (registered->options().subtree) {
                 auto transient_observer = TransientRegisteredObserver::create(registered->observer(), registered->options(), registered);
-                m_registered_observer_list->append(move(transient_observer));
+                add_registered_observer(move(transient_observer));
             }
         }
     }


### PR DESCRIPTION
Instead of blindly dereferencing m_registered_observer_list, just use the add_registered_observer() helper.

Fixes #22005