### PR TITLE
LibAccelGfx+LibWeb: Fix scrolling in GPU painter

### DIFF
--- a/Userland/Libraries/LibAccelGfx/Painter.h
+++ b/Userland/Libraries/LibAccelGfx/Painter.h
@@ -39,6 +39,7 @@ public:
 
     [[nodiscard]] Gfx::AffineTransform const& transform() const { return state().transform; }
     void set_transform(Gfx::AffineTransform const& transform) { state().transform = transform; }
+    void translate(Gfx::FloatPoint translation) { state().transform.translate(translation); }
 
     void fill_rect(Gfx::FloatRect, Gfx::Color);
     void fill_rect(Gfx::IntRect, Gfx::Color);

--- a/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorGPU.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorGPU.cpp
@@ -75,15 +75,16 @@ CommandResult PaintingCommandExecutorGPU::set_font(Gfx::Font const&)
     return CommandResult::Continue;
 }
 
-CommandResult PaintingCommandExecutorGPU::push_stacking_context(float, bool, Gfx::IntRect const&, Gfx::IntPoint, CSS::ImageRendering, StackingContextTransform, Optional<StackingContextMask>)
+CommandResult PaintingCommandExecutorGPU::push_stacking_context(float, bool, Gfx::IntRect const&, Gfx::IntPoint post_transform_translation, CSS::ImageRendering, StackingContextTransform, Optional<StackingContextMask>)
 {
-    // FIXME
+    painter().save();
+    painter().translate(post_transform_translation.to_type<float>());
     return CommandResult::Continue;
 }
 
 CommandResult PaintingCommandExecutorGPU::pop_stacking_context()
 {
-    // FIXME
+    painter().restore();
     return CommandResult::Continue;
 }
 


### PR DESCRIPTION
With basic PushStackingContext and PopStackingContext commands implementation scrolling works again after changes being made in: https://github.com/SerenityOS/serenity/commit/4e04f81626cf3a5e1bea52ae26bb17f40695ad78