### PR TITLE
MacPDF: Three outline fixes

### DIFF
--- a/Meta/Lagom/Contrib/MacPDF/MacPDFOutlineViewDataSource.mm
+++ b/Meta/Lagom/Contrib/MacPDF/MacPDFOutlineViewDataSource.mm
@@ -60,7 +60,7 @@
 {
     if (_groupName)
         return _groupName;
-    return [NSString stringWithFormat:@"%s", _item->title.characters()]; // FIXME: encoding?
+    return [NSString stringWithUTF8String:_item->title.characters()];
 }
 @end
 

--- a/Meta/Lagom/Contrib/MacPDF/MacPDFOutlineViewDataSource.mm
+++ b/Meta/Lagom/Contrib/MacPDF/MacPDFOutlineViewDataSource.mm
@@ -60,7 +60,12 @@
 {
     if (_groupName)
         return _groupName;
-    return [NSString stringWithUTF8String:_item->title.characters()];
+    NSString* title = [NSString stringWithUTF8String:_item->title.characters()];
+
+    // Newlines confuse NSOutlineView, at least in sidebar style (even with `usesSingleLineMode` set to YES on the cell view's text field).
+    title = [[title componentsSeparatedByCharactersInSet:[NSCharacterSet newlineCharacterSet]] componentsJoinedByString:@" "];
+
+    return title;
 }
 @end
 

--- a/Meta/Lagom/Contrib/MacPDF/MacPDFWindowController.mm
+++ b/Meta/Lagom/Contrib/MacPDF/MacPDFWindowController.mm
@@ -230,6 +230,7 @@
 
         NSTextField* textField = [NSTextField labelWithString:@""];
         textField.lineBreakMode = NSLineBreakByTruncatingTail;
+        textField.allowsExpansionToolTips = YES;
 
         // https://stackoverflow.com/a/29725553/551986
         // "If your cell view is an NSTableCellView, that class also responds to -setObjectValue:. [...]


### PR DESCRIPTION
* Use correct(ish) encoding
* Show tooltip with full title when it's elided
* Less janky look for outline titles with newlines