### PR TITLE
LibWeb: Stop a bunch of CSS parser crashes from invalid inputs

### DIFF
--- a/Tests/LibWeb/Layout/expected/css-values/rect-non-token-contents-crash.txt
+++ b/Tests/LibWeb/Layout/expected/css-values/rect-non-token-contents-crash.txt
@@ -1,0 +1,12 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x0 children: not-inline
+      BlockContainer <div> at (8,8) content-size 784x0 children: not-inline
+      BlockContainer <(anonymous)> at (8,16) content-size 784x0 children: inline
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x0] overflow: [8,16 784x0]
+      PaintableWithLines (BlockContainer<DIV>) [8,8 784x0]
+      PaintableWithLines (BlockContainer(anonymous)) [8,16 784x0]

--- a/Tests/LibWeb/Layout/expected/grid/grid-area-non-token-parts-crash.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-area-non-token-parts-crash.txt
@@ -1,0 +1,12 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x0 children: not-inline
+      BlockContainer <div> at (8,8) content-size 784x0 children: not-inline
+      BlockContainer <(anonymous)> at (8,16) content-size 784x0 children: inline
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x0] overflow: [8,16 784x0]
+      PaintableWithLines (BlockContainer<DIV>) [8,8 784x0]
+      PaintableWithLines (BlockContainer(anonymous)) [8,16 784x0]

--- a/Tests/LibWeb/Layout/expected/grid/grid-column-non-token-parts-crash.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-column-non-token-parts-crash.txt
@@ -1,0 +1,12 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x0 children: not-inline
+      BlockContainer <div> at (8,8) content-size 784x0 children: not-inline
+      BlockContainer <(anonymous)> at (8,16) content-size 784x0 children: inline
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x0] overflow: [8,16 784x0]
+      PaintableWithLines (BlockContainer<DIV>) [8,8 784x0]
+      PaintableWithLines (BlockContainer(anonymous)) [8,16 784x0]

--- a/Tests/LibWeb/Layout/expected/grid/grid-row-start-non-token-parts-crash.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-row-start-non-token-parts-crash.txt
@@ -1,0 +1,12 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x0 children: not-inline
+      BlockContainer <div> at (8,8) content-size 784x0 children: not-inline
+      BlockContainer <(anonymous)> at (8,16) content-size 784x0 children: inline
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x0] overflow: [8,16 784x0]
+      PaintableWithLines (BlockContainer<DIV>) [8,8 784x0]
+      PaintableWithLines (BlockContainer(anonymous)) [8,16 784x0]

--- a/Tests/LibWeb/Layout/expected/grid/minmax-non-token-contents-crash.txt
+++ b/Tests/LibWeb/Layout/expected/grid/minmax-non-token-contents-crash.txt
@@ -1,0 +1,12 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x0 children: not-inline
+      BlockContainer <div> at (8,8) content-size 784x0 children: not-inline
+      BlockContainer <(anonymous)> at (8,16) content-size 784x0 children: inline
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x0] overflow: [8,16 784x0]
+      PaintableWithLines (BlockContainer<DIV>) [8,8 784x0]
+      PaintableWithLines (BlockContainer(anonymous)) [8,16 784x0]

--- a/Tests/LibWeb/Layout/expected/grid/repeat-non-token-contents-crash.txt
+++ b/Tests/LibWeb/Layout/expected/grid/repeat-non-token-contents-crash.txt
@@ -1,0 +1,12 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x0 children: not-inline
+      BlockContainer <div> at (8,8) content-size 784x0 children: not-inline
+      BlockContainer <(anonymous)> at (8,16) content-size 784x0 children: inline
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x0] overflow: [8,16 784x0]
+      PaintableWithLines (BlockContainer<DIV>) [8,8 784x0]
+      PaintableWithLines (BlockContainer(anonymous)) [8,16 784x0]

--- a/Tests/LibWeb/Layout/input/css-values/rect-non-token-contents-crash.html
+++ b/Tests/LibWeb/Layout/input/css-values/rect-non-token-contents-crash.html
@@ -1,0 +1,1 @@
+<div style="clip: rect({})"></div>

--- a/Tests/LibWeb/Layout/input/grid/grid-area-non-token-parts-crash.html
+++ b/Tests/LibWeb/Layout/input/grid/grid-area-non-token-parts-crash.html
@@ -1,0 +1,1 @@
+<div style="grid-area: {}"></div>

--- a/Tests/LibWeb/Layout/input/grid/grid-column-non-token-parts-crash.html
+++ b/Tests/LibWeb/Layout/input/grid/grid-column-non-token-parts-crash.html
@@ -1,0 +1,1 @@
+<div style="grid-column: {}"></div>

--- a/Tests/LibWeb/Layout/input/grid/grid-row-start-non-token-parts-crash.html
+++ b/Tests/LibWeb/Layout/input/grid/grid-row-start-non-token-parts-crash.html
@@ -1,0 +1,1 @@
+<div style="grid-row-start: {}"></div>

--- a/Tests/LibWeb/Layout/input/grid/minmax-non-token-contents-crash.html
+++ b/Tests/LibWeb/Layout/input/grid/minmax-non-token-contents-crash.html
@@ -1,0 +1,1 @@
+<div style="grid-template-columns: minmax({},{})"></div>

--- a/Tests/LibWeb/Layout/input/grid/repeat-non-token-contents-crash.html
+++ b/Tests/LibWeb/Layout/input/grid/repeat-non-token-contents-crash.html
@@ -1,0 +1,1 @@
+<div style="grid-template-rows: repeat({})"></div>

--- a/Userland/Libraries/LibWeb/CSS/Parser/GradientParsing.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/GradientParsing.cpp
@@ -497,7 +497,7 @@ RefPtr<StyleValue> Parser::parse_radial_gradient_function(ComponentValue const& 
         return nullptr;
 
     auto& token = tokens.peek_token();
-    if (token.is(Token::Type::Ident) && token.token().ident().equals_ignoring_ascii_case("at"sv)) {
+    if (token.is_ident("at"sv)) {
         (void)tokens.next_token();
         auto position = parse_position_value(tokens);
         if (!position)

--- a/Userland/Libraries/LibWeb/CSS/Parser/MediaParsing.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/MediaParsing.cpp
@@ -114,7 +114,7 @@ NonnullRefPtr<MediaQuery> Parser::parse_media_query(TokenStream<ComponentValue>&
         return media_query;
 
     // `[ and <media-condition-without-or> ]?`
-    if (auto maybe_and = tokens.next_token(); maybe_and.is(Token::Type::Ident) && maybe_and.token().ident().equals_ignoring_ascii_case("and"sv)) {
+    if (auto maybe_and = tokens.next_token(); maybe_and.is_ident("and"sv)) {
         if (auto media_condition = parse_media_condition(tokens, MediaCondition::AllowOr::No)) {
             tokens.skip_whitespace();
             if (tokens.has_next_token())
@@ -143,7 +143,7 @@ OwnPtr<MediaCondition> Parser::parse_media_condition(TokenStream<ComponentValue>
         tokens.skip_whitespace();
 
         auto& first_token = tokens.next_token();
-        if (first_token.is(Token::Type::Ident) && first_token.token().ident().equals_ignoring_ascii_case("not"sv)) {
+        if (first_token.is_ident("not"sv)) {
             if (auto child_condition = parse_media_condition(tokens, MediaCondition::AllowOr::Yes)) {
                 local_transaction.commit();
                 return MediaCondition::from_not(child_condition.release_nonnull());
@@ -158,7 +158,7 @@ OwnPtr<MediaCondition> Parser::parse_media_condition(TokenStream<ComponentValue>
         tokens.skip_whitespace();
 
         auto& first = tokens.next_token();
-        if (first.is(Token::Type::Ident) && first.token().ident().equals_ignoring_ascii_case(combinator)) {
+        if (first.is_ident(combinator)) {
             tokens.skip_whitespace();
             if (auto media_in_parens = parse_media_in_parens(tokens)) {
                 local_transaction.commit();

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -5520,18 +5520,17 @@ RefPtr<StyleValue> Parser::parse_grid_track_size_list_shorthand_value(PropertyID
 RefPtr<StyleValue> Parser::parse_grid_area_shorthand_value(Vector<ComponentValue> const& component_values)
 {
     auto tokens = TokenStream { component_values };
-    Token current_token;
 
     auto parse_placement_tokens = [&](Vector<ComponentValue>& placement_tokens, bool check_for_delimiter = true) -> void {
-        current_token = tokens.next_token().token();
+        auto current_token = tokens.next_token();
         while (true) {
-            if (check_for_delimiter && current_token.is(Token::Type::Delim) && current_token.delim() == "/"sv)
+            if (check_for_delimiter && current_token.is_delim('/'))
                 break;
             placement_tokens.append(current_token);
             tokens.skip_whitespace();
             if (!tokens.has_next_token())
                 break;
-            current_token = tokens.next_token().token();
+            current_token = tokens.next_token();
         }
     };
 

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -5102,14 +5102,14 @@ Optional<CSS::GridRepeat> Parser::parse_repeat(Vector<ComponentValue> const& com
     part_one_tokens.skip_whitespace();
     if (!part_one_tokens.has_next_token())
         return {};
-    auto current_token = part_one_tokens.next_token().token();
+    auto& current_token = part_one_tokens.next_token();
 
     auto repeat_count = 0;
-    if (current_token.is(Token::Type::Number) && current_token.number().is_integer() && current_token.number_value() > 0)
-        repeat_count = current_token.number_value();
-    else if (current_token.is(Token::Type::Ident) && current_token.ident().equals_ignoring_ascii_case("auto-fill"sv))
+    if (current_token.is(Token::Type::Number) && current_token.token().number().is_integer() && current_token.token().number_value() > 0)
+        repeat_count = current_token.token().number_value();
+    else if (current_token.is_ident("auto-fill"sv))
         is_auto_fill = true;
-    else if (current_token.is(Token::Type::Ident) && current_token.ident().equals_ignoring_ascii_case("auto-fit"sv))
+    else if (current_token.is_ident("auto-fit"sv))
         is_auto_fit = true;
 
     // The second argument is a track list, which is repeated that number of times.

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -295,7 +295,7 @@ Optional<Supports::Feature> Parser::parse_supports_feature(TokenStream<Component
     }
 
     // `<supports-selector-fn>`
-    if (first_token.is_function() && first_token.function().name().equals_ignoring_ascii_case("selector"sv)) {
+    if (first_token.is_function("selector"sv)) {
         // FIXME: Parsing and then converting back to a string is weird.
         StringBuilder builder;
         for (auto const& item : first_token.function().values())
@@ -1163,7 +1163,7 @@ Optional<AK::URL> Parser::parse_url_function(ComponentValue const& component_val
         auto url_string = component_value.token().url();
         return convert_string_to_url(url_string);
     }
-    if (component_value.is_function() && component_value.function().name().equals_ignoring_ascii_case("url"sv)) {
+    if (component_value.is_function("url"sv)) {
         auto const& function_values = component_value.function().values();
         // FIXME: Handle url-modifiers. https://www.w3.org/TR/css-values-4/#url-modifiers
         for (size_t i = 0; i < function_values.size(); ++i) {
@@ -2093,14 +2093,11 @@ Optional<Color> Parser::parse_rgb_or_hsl_color(StringView function_name, Vector<
 // https://www.w3.org/TR/CSS2/visufx.html#value-def-shape
 RefPtr<StyleValue> Parser::parse_rect_value(ComponentValue const& component_value)
 {
-    if (!component_value.is_function())
-        return nullptr;
-    auto const& function = component_value.function();
-    if (!function.name().equals_ignoring_ascii_case("rect"sv))
+    if (!component_value.is_function("rect"sv))
         return nullptr;
 
     Vector<Length, 4> params;
-    auto tokens = TokenStream { function.values() };
+    auto tokens = TokenStream { component_value.function().values() };
 
     enum class CommaRequirement {
         Unknown,
@@ -4311,7 +4308,7 @@ Vector<FontFace::Source> Parser::parse_font_face_src(TokenStream<ComponentValue>
             continue;
         }
 
-        if (first.is_function() && first.function().name().equals_ignoring_ascii_case("local"sv)) {
+        if (first.is_function("local"sv)) {
             if (first.function().values().is_empty()) {
                 continue;
             }

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -176,7 +176,7 @@ OwnPtr<Supports::Condition> Parser::parse_supports_condition(TokenStream<Compone
 
     auto const& peeked_token = tokens.peek_token();
     // `not <supports-in-parens>`
-    if (peeked_token.is(Token::Type::Ident) && peeked_token.token().ident().equals_ignoring_ascii_case("not"sv)) {
+    if (peeked_token.is_ident("not"sv)) {
         tokens.next_token();
         tokens.skip_whitespace();
         auto child = parse_supports_in_parens(tokens);
@@ -788,7 +788,7 @@ Optional<Declaration> Parser::consume_a_declaration(TokenStream<T>& tokens)
         Optional<size_t> important_index;
         for (size_t i = declaration_values.size() - 1; i > 0; i--) {
             auto value = declaration_values[i];
-            if (value.is(Token::Type::Ident) && Infra::is_ascii_case_insensitive_match(value.token().ident(), "important"sv)) {
+            if (value.is_ident("important"sv)) {
                 important_index = i;
                 break;
             }
@@ -1578,7 +1578,7 @@ Optional<Dimension> Parser::parse_dimension(ComponentValue const& component_valu
 
 Optional<LengthOrCalculated> Parser::parse_source_size_value(ComponentValue const& component_value)
 {
-    if (component_value.is(Token::Type::Ident) && component_value.token().ident().equals_ignoring_ascii_case("auto"sv)) {
+    if (component_value.is_ident("auto"sv)) {
         return LengthOrCalculated { Length::make_auto() };
     }
 
@@ -1689,7 +1689,7 @@ Optional<UnicodeRange> Parser::parse_unicode_range(TokenStream<ComponentValue>& 
 
     // All options start with 'u'/'U'.
     auto const& u = tokens.next_token();
-    if (!(u.is(Token::Type::Ident) && u.token().ident().equals_ignoring_ascii_case("u"sv))) {
+    if (!u.is_ident("u"sv)) {
         dbgln_if(CSS_PARSER_DEBUG, "CSSParser: <urange> does not start with 'u'");
         return {};
     }
@@ -3371,8 +3371,7 @@ RefPtr<StyleValue> Parser::parse_single_shadow_value(TokenStream<ComponentValue>
             continue;
         }
 
-        if (allow_inset_keyword == AllowInsetKeyword::Yes
-            && token.is(Token::Type::Ident) && token.token().ident().equals_ignoring_ascii_case("inset"sv)) {
+        if (allow_inset_keyword == AllowInsetKeyword::Yes && token.is_ident("inset"sv)) {
             if (placement.has_value())
                 return nullptr;
             placement = ShadowPlacement::Inner;
@@ -3946,7 +3945,7 @@ RefPtr<StyleValue> Parser::parse_font_value(Vector<ComponentValue> const& compon
 
     while (tokens.has_next_token()) {
         auto& peek_token = tokens.peek_token();
-        if (peek_token.is(Token::Type::Ident) && value_id_from_string(peek_token.token().ident()) == ValueID::Normal) {
+        if (peek_token.is_ident("normal"sv)) {
             normal_count++;
             (void)tokens.next_token();
             continue;
@@ -4337,7 +4336,7 @@ RefPtr<StyleValue> Parser::parse_list_style_value(Vector<ComponentValue> const& 
 
     auto tokens = TokenStream { component_values };
     while (tokens.has_next_token()) {
-        if (auto peek = tokens.peek_token(); peek.is(Token::Type::Ident) && peek.token().ident().equals_ignoring_ascii_case("none"sv)) {
+        if (auto peek = tokens.peek_token(); peek.is_ident("none"sv)) {
             (void)tokens.next_token();
             found_nones++;
             continue;
@@ -4779,7 +4778,7 @@ RefPtr<StyleValue> Parser::parse_transform_value(Vector<ComponentValue> const& c
         tokens.skip_whitespace();
         auto const& part = tokens.next_token();
 
-        if (part.is(Token::Type::Ident) && part.token().ident().equals_ignoring_ascii_case("none"sv)) {
+        if (part.is_ident("none"sv)) {
             if (!transformations.is_empty())
                 return nullptr;
             tokens.skip_whitespace();
@@ -5206,7 +5205,7 @@ Optional<CSS::ExplicitGridTrack> Parser::parse_track_sizing_function(ComponentVa
             return CSS::ExplicitGridTrack(GridSize(LengthPercentage(maybe_calculated.release_nonnull())));
         }
         return {};
-    } else if (token.is(Token::Type::Ident) && token.token().ident().equals_ignoring_ascii_case("auto"sv)) {
+    } else if (token.is_ident("auto"sv)) {
         return CSS::ExplicitGridTrack(GridSize(Length::make_auto()));
     } else if (token.is_block()) {
         return {};

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -5431,26 +5431,26 @@ RefPtr<StyleValue> Parser::parse_grid_track_placement_shorthand_value(PropertyID
     auto end_property = (property_id == PropertyID::GridColumn) ? PropertyID::GridColumnEnd : PropertyID::GridRowEnd;
 
     auto tokens = TokenStream { component_values };
-    auto current_token = tokens.next_token().token();
+    auto current_token = tokens.next_token();
 
     Vector<ComponentValue> track_start_placement_tokens;
     while (true) {
-        if (current_token.is(Token::Type::Delim) && current_token.delim() == "/"sv)
+        if (current_token.is_delim('/'))
             break;
         track_start_placement_tokens.append(current_token);
         if (!tokens.has_next_token())
             break;
-        current_token = tokens.next_token().token();
+        current_token = tokens.next_token();
     }
 
     Vector<ComponentValue> track_end_placement_tokens;
     if (tokens.has_next_token()) {
-        current_token = tokens.next_token().token();
+        current_token = tokens.next_token();
         while (true) {
             track_end_placement_tokens.append(current_token);
             if (!tokens.has_next_token())
                 break;
-            current_token = tokens.next_token().token();
+            current_token = tokens.next_token();
         }
     }
 

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -2122,8 +2122,8 @@ RefPtr<StyleValue> Parser::parse_rect_value(ComponentValue const& component_valu
 
         // <top>, <right>, <bottom>, and <left> may either have a <length> value or 'auto'.
         // Negative lengths are permitted.
-        auto current_token = tokens.next_token().token();
-        if (current_token.is(Token::Type::Ident) && current_token.ident().equals_ignoring_ascii_case("auto"sv)) {
+        auto& current_token = tokens.next_token();
+        if (current_token.is_ident("auto"sv)) {
             params.append(Length::make_auto());
         } else {
             auto maybe_length = parse_length(current_token);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -5030,14 +5030,13 @@ Optional<CSS::GridSize> Parser::parse_grid_size(ComponentValue const& component_
 
         return {};
     }
-    auto token = component_value.token();
-    if (token.is(Token::Type::Ident) && token.ident().equals_ignoring_ascii_case("auto"sv))
+    if (component_value.is_ident("auto"sv))
         return GridSize::make_auto();
-    if (token.is(Token::Type::Ident) && token.ident().equals_ignoring_ascii_case("max-content"sv))
+    if (component_value.is_ident("max-content"sv))
         return GridSize(GridSize::Type::MaxContent);
-    if (token.is(Token::Type::Ident) && token.ident().equals_ignoring_ascii_case("min-content"sv))
+    if (component_value.is_ident("min-content"sv))
         return GridSize(GridSize::Type::MinContent);
-    auto dimension = parse_dimension(token);
+    auto dimension = parse_dimension(component_value);
     if (!dimension.has_value())
         return {};
     if (dimension->is_length())

--- a/Userland/Libraries/LibWeb/CSS/Parser/SelectorParsing.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/SelectorParsing.cpp
@@ -439,7 +439,7 @@ Parser::ParseErrorOr<Selector::SimpleSelector> Parser::parse_pseudo_simple_selec
 
             // Parse the `of <selector-list>` syntax
             auto const& maybe_of = tokens.next_token();
-            if (!(maybe_of.is(Token::Type::Ident) && maybe_of.token().ident().equals_ignoring_ascii_case("of"sv)))
+            if (!maybe_of.is_ident("of"sv))
                 return ParseError::SyntaxError;
 
             tokens.skip_whitespace();
@@ -678,18 +678,6 @@ Optional<Selector::SimpleSelector::ANPlusBPattern> Parser::parse_a_n_plus_b_patt
         return {};
     };
 
-    auto is_n = [](ComponentValue const& value) -> bool {
-        return value.is(Token::Type::Ident) && value.token().ident().equals_ignoring_ascii_case("n"sv);
-    };
-    auto is_ndash = [](ComponentValue const& value) -> bool {
-        return value.is(Token::Type::Ident) && value.token().ident().equals_ignoring_ascii_case("n-"sv);
-    };
-    auto is_dashn = [](ComponentValue const& value) -> bool {
-        return value.is(Token::Type::Ident) && value.token().ident().equals_ignoring_ascii_case("-n"sv);
-    };
-    auto is_dashndash = [](ComponentValue const& value) -> bool {
-        return value.is(Token::Type::Ident) && value.token().ident().equals_ignoring_ascii_case("-n-"sv);
-    };
     auto is_sign = [](ComponentValue const& value) -> bool {
         return value.is(Token::Type::Delim) && (value.token().delim() == '+' || value.token().delim() == '-');
     };
@@ -855,7 +843,7 @@ Optional<Selector::SimpleSelector::ANPlusBPattern> Parser::parse_a_n_plus_b_patt
     // -n
     // -n <signed-integer>
     // -n ['+' | '-'] <signless-integer>
-    if (is_dashn(first_value)) {
+    if (first_value.is_ident("-n"sv)) {
         values.skip_whitespace();
 
         // -n <signed-integer>
@@ -884,7 +872,7 @@ Optional<Selector::SimpleSelector::ANPlusBPattern> Parser::parse_a_n_plus_b_patt
         return Selector::SimpleSelector::ANPlusBPattern { -1, 0 };
     }
     // -n- <signless-integer>
-    if (is_dashndash(first_value)) {
+    if (first_value.is_ident("-n-"sv)) {
         values.skip_whitespace();
         auto const& second_value = values.next_token();
         if (is_signless_integer(second_value)) {
@@ -913,7 +901,7 @@ Optional<Selector::SimpleSelector::ANPlusBPattern> Parser::parse_a_n_plus_b_patt
     // '+'?† n
     // '+'?† n <signed-integer>
     // '+'?† n ['+' | '-'] <signless-integer>
-    if (is_n(first_after_plus)) {
+    if (first_after_plus.is_ident("n"sv)) {
         values.skip_whitespace();
 
         // '+'?† n <signed-integer>
@@ -943,7 +931,7 @@ Optional<Selector::SimpleSelector::ANPlusBPattern> Parser::parse_a_n_plus_b_patt
     }
 
     // '+'?† n- <signless-integer>
-    if (is_ndash(first_after_plus)) {
+    if (first_after_plus.is_ident("n-"sv)) {
         values.skip_whitespace();
         auto const& second_value = values.next_token();
         if (is_signless_integer(second_value)) {


### PR DESCRIPTION
It's rare that we'd encounter invalid CSS in the wild, but we shouldn't crash when we do!

This fixes several cases where we blindly get the Token from a ComponentValue, without checking that it's holding a Token first.

Also, use the `is_function("..."sv)` and `is_ident("..."sv)` helper methods more, which is what made me notice the incorrectness in the first place. They simplify things so the code is more readable.