### PR TITLE
LibPDF: Tolerate comment after last dict item and before drawing operators

### DIFF
--- a/Userland/Libraries/LibPDF/Parser.cpp
+++ b/Userland/Libraries/LibPDF/Parser.cpp
@@ -425,9 +425,9 @@ PDFErrorOr<NonnullRefPtr<DictObject>> Parser::parse_dict()
     HashMap<DeprecatedFlyString, Value> map;
 
     while (!m_reader.done()) {
+        parse_comment();
         if (m_reader.matches(">>"))
             break;
-        parse_comment();
         auto name = TRY(parse_name())->name();
         auto value = TRY(parse_value());
         map.set(name, value);

--- a/Userland/Libraries/LibPDF/Parser.cpp
+++ b/Userland/Libraries/LibPDF/Parser.cpp
@@ -530,6 +530,7 @@ PDFErrorOr<Vector<Operator>> Parser::parse_operators()
     m_reader.consume_whitespace();
 
     while (!m_reader.done()) {
+        parse_comment();
         auto ch = m_reader.peek();
         if (is_operator_char_start(ch)) {
             auto operator_start = m_reader.offset();


### PR DESCRIPTION
Necessary to be able to open and render
https://github.com/pdf-association/pdf20examples/blob/master/pdf20-utf8-test.pdf