### PR TITLE
LibWeb+WebWorker: Implement a first cut of post_message for Workers 

### DIFF
--- a/AK/Span.h
+++ b/AK/Span.h
@@ -322,6 +322,20 @@ using ReadonlySpan = Span<T const>;
 using ReadonlyBytes = ReadonlySpan<u8>;
 using Bytes = Span<u8>;
 
+template<typename T>
+requires(IsTrivial<T>)
+ReadonlyBytes to_readonly_bytes(Span<T> span)
+{
+    return ReadonlyBytes { static_cast<void*>(span.data()), span.size() * sizeof(T) };
+}
+
+template<typename T>
+requires(IsTrivial<T> && !IsConst<T>)
+Bytes to_bytes(Span<T> span)
+{
+    return Bytes { static_cast<void*>(span.data()), span.size() * sizeof(T) };
+}
+
 }
 
 #if USING_AK_GLOBALLY
@@ -329,4 +343,6 @@ using AK::Bytes;
 using AK::ReadonlyBytes;
 using AK::ReadonlySpan;
 using AK::Span;
+using AK::to_bytes;
+using AK::to_readonly_bytes;
 #endif

--- a/Base/res/html/misc/worker.js
+++ b/Base/res/html/misc/worker.js
@@ -1,10 +1,10 @@
 onmessage = evt => {
     console.log("In Worker - Got message:", JSON.stringify(evt.data));
 
-    postMessage(JSON.stringify(evt.data));
+    postMessage(evt.data, null);
 };
 
 console.log("In Worker - Loaded", this);
 console.log("Keys: ", JSON.stringify(Object.keys(this)));
 
-postMessage("loaded");
+postMessage("loaded", null);

--- a/Base/res/html/misc/worker_parent.html
+++ b/Base/res/html/misc/worker_parent.html
@@ -21,7 +21,7 @@
                     .getElementById("btn_hello")
                     .addEventListener("click", function() {
                         console.log("Sending Message");
-                        work.postMessage("Hey buddy!");
+                        work.postMessage({ "msg": "Hey buddy!" });
                     });
             });
         </script>

--- a/Tests/LibWeb/Text/expected/Worker/Worker-echo.txt
+++ b/Tests/LibWeb/Text/expected/Worker/Worker-echo.txt
@@ -1,0 +1,3 @@
+Got message from worker: "loaded"
+Got message from worker: {"msg":"marco"}
+DONE

--- a/Tests/LibWeb/Text/input/Worker/Worker-echo.html
+++ b/Tests/LibWeb/Text/input/Worker/Worker-echo.html
@@ -1,0 +1,18 @@
+<script src="../include.js"></script>
+<script>
+    asyncTest((done) => {
+        let work = new Worker("worker.js");
+        let count = 0;
+        work.onmessage = (evt) => {
+            println("Got message from worker: " + JSON.stringify(evt.data));
+            count++;
+            work.postMessage({"msg": "marco"});
+            if (count === 2) {
+                println("DONE");
+                work.onmessage = null;
+                work.terminate();
+                done();
+            }
+        };
+    });
+</script>

--- a/Tests/LibWeb/Text/input/Worker/worker.js
+++ b/Tests/LibWeb/Text/input/Worker/worker.js
@@ -1,0 +1,4 @@
+onmessage = evt => {
+    postMessage(evt.data, null);
+};
+postMessage("loaded", null);

--- a/Tests/LibWeb/Text/input/include.js
+++ b/Tests/LibWeb/Text/input/include.js
@@ -1,5 +1,11 @@
 var __outputElement = null;
 
+if (globalThis.internals === undefined) {
+    internals = {
+        signalTextTestIsDone: function () {},
+    };
+}
+
 function println(s) {
     __outputElement.appendChild(document.createTextNode(s + "\n"));
 }

--- a/Userland/Libraries/LibWeb/HTML/Worker.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Worker.cpp
@@ -38,6 +38,7 @@ void Worker::visit_edges(Cell::Visitor& visitor)
     Base::visit_edges(visitor);
     visitor.visit(m_document);
     visitor.visit(m_outside_port);
+    visitor.visit(m_agent);
 }
 
 // https://html.spec.whatwg.org/multipage/workers.html#dom-worker

--- a/Userland/Libraries/LibWeb/HTML/Worker.h
+++ b/Userland/Libraries/LibWeb/HTML/Worker.h
@@ -41,7 +41,7 @@ public:
 
     WebIDL::ExceptionOr<void> terminate();
 
-    void post_message(JS::Value message, JS::Value transfer);
+    WebIDL::ExceptionOr<void> post_message(JS::Value message, JS::Value transfer);
 
     virtual ~Worker() = default;
 
@@ -66,6 +66,13 @@ private:
 
     JS::GCPtr<DOM::Document> m_document;
     JS::GCPtr<MessagePort> m_outside_port;
+    // FIXME: Move tihs state into the message port (and actually use it :) )
+    enum class PortState : u8 {
+        Header,
+        Data,
+        Error,
+    } m_outside_port_state { PortState::Header };
+    size_t m_outside_port_incoming_message_size { 0 };
 
     JS::GCPtr<WorkerAgent> m_agent;
 

--- a/Userland/Libraries/LibWeb/HTML/WorkerAgent.cpp
+++ b/Userland/Libraries/LibWeb/HTML/WorkerAgent.cpp
@@ -109,7 +109,8 @@ WorkerAgent::WorkerAgent(AK::URL url, WorkerOptions const& options)
 
     int fds[2] = {};
     MUST(Core::System::socketpair(AF_LOCAL, SOCK_STREAM, 0, fds));
-    m_message_port_fd = fds[0];
+
+    m_socket = MUST(Core::BufferedLocalSocket::create(MUST(Core::LocalSocket::adopt_fd(fds[0]))));
 
     m_worker_ipc->async_start_dedicated_worker(m_url, options.type, options.credentials, options.name, fds[1]);
 }

--- a/Userland/Libraries/LibWeb/HTML/WorkerAgent.h
+++ b/Userland/Libraries/LibWeb/HTML/WorkerAgent.h
@@ -6,11 +6,10 @@
 
 #pragma once
 
-#include <AK/RefCounted.h>
+#include <LibCore/Socket.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/HTML/MessageEvent.h>
 #include <LibWeb/HTML/MessagePort.h>
-#include <LibWeb/HTML/Scripting/ClassicScript.h>
 #include <LibWeb/HTML/Scripting/WorkerEnvironmentSettingsObject.h>
 #include <LibWeb/HTML/Window.h>
 #include <LibWeb/Worker/WebWorkerClient.h>
@@ -31,12 +30,14 @@ struct WorkerAgent : JS::Cell {
 
     RefPtr<Web::HTML::WebWorkerClient> m_worker_ipc;
 
+    Core::BufferedLocalSocket& socket() const { return *m_socket; }
+
 private:
     WorkerOptions m_worker_options;
     AK::URL m_url;
 
-    // TODO: associate with MessagePorts?
-    int m_message_port_fd;
+    // FIXME: associate with MessagePorts
+    OwnPtr<Core::BufferedLocalSocket> m_socket;
 };
 
 }

--- a/Userland/Libraries/LibWeb/HTML/WorkerGlobalScope.cpp
+++ b/Userland/Libraries/LibWeb/HTML/WorkerGlobalScope.cpp
@@ -4,14 +4,17 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Array.h>
 #include <AK/Vector.h>
 #include <LibWeb/Bindings/DedicatedWorkerExposedInterfaces.h>
-#include <LibWeb/Bindings/ExceptionOrUtils.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Bindings/WorkerGlobalScopePrototype.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/HTML/EventHandler.h>
 #include <LibWeb/HTML/EventNames.h>
+#include <LibWeb/HTML/MessageEvent.h>
+#include <LibWeb/HTML/Scripting/TemporaryExecutionContext.h>
+#include <LibWeb/HTML/StructuredSerialize.h>
 #include <LibWeb/HTML/WorkerGlobalScope.h>
 #include <LibWeb/HTML/WorkerLocation.h>
 #include <LibWeb/HTML/WorkerNavigator.h>
@@ -50,6 +53,55 @@ void WorkerGlobalScope::visit_edges(Cell::Visitor& visitor)
 
     visitor.visit(m_location);
     visitor.visit(m_navigator);
+}
+
+void WorkerGlobalScope::set_outside_port(NonnullOwnPtr<Core::BufferedLocalSocket> port)
+{
+    m_outside_port = move(port);
+
+    // FIXME: Hide this logic in MessagePort
+    m_outside_port->set_notifications_enabled(true);
+    m_outside_port->on_ready_to_read = [this] {
+        auto& vm = this->vm();
+        auto& realm = this->realm();
+
+        auto num_bytes_ready = MUST(m_outside_port->pending_bytes());
+        switch (m_outside_port_state) {
+        case PortState::Header: {
+            if (num_bytes_ready < 8)
+                break;
+            auto const magic = MUST(m_outside_port->read_value<u32>());
+            if (magic != 0xDEADBEEF) {
+                m_outside_port_state = PortState::Error;
+                break;
+            }
+            m_outside_port_incoming_message_size = MUST(m_outside_port->read_value<u32>());
+            num_bytes_ready -= 8;
+            m_outside_port_state = PortState::Data;
+        }
+            [[fallthrough]];
+        case PortState::Data: {
+            if (num_bytes_ready < m_outside_port_incoming_message_size)
+                break;
+            SerializationRecord rec; // FIXME: Keep in class scope
+            rec.resize(m_outside_port_incoming_message_size / sizeof(u32));
+            MUST(m_outside_port->read_until_filled(to_bytes(rec.span())));
+
+            TemporaryExecutionContext cxt(relevant_settings_object(*this));
+            MessageEventInit event_init {};
+            event_init.data = MUST(structured_deserialize(vm, rec, realm, {}));
+            // FIXME: Fill in the rest of the info from MessagePort
+
+            this->dispatch_event(MessageEvent::create(realm, EventNames::message, event_init));
+
+            m_outside_port_state = PortState::Header;
+            break;
+        }
+        case PortState::Error:
+            VERIFY_NOT_REACHED();
+            break;
+        }
+    };
 }
 
 // https://html.spec.whatwg.org/multipage/workers.html#importing-scripts-and-libraries
@@ -92,6 +144,25 @@ JS::NonnullGCPtr<WorkerNavigator> WorkerGlobalScope::navigator() const
     // The navigator attribute of the WorkerGlobalScope interface must return an instance of the WorkerNavigator interface,
     // which represents the identity and state of the user agent (the client).
     return *m_navigator;
+}
+
+WebIDL::ExceptionOr<void> WorkerGlobalScope::post_message(JS::Value message, JS::Value)
+{
+    auto& realm = this->realm();
+    auto& vm = this->vm();
+
+    // FIXME: Use the with-transfer variant, which should(?) prepend the magic + size at the front
+    auto data = TRY(structured_serialize(vm, message));
+
+    Array<u32, 2> header = { 0xDEADBEEF, static_cast<u32>(data.size() * sizeof(u32)) };
+
+    if (auto const err = m_outside_port->write_until_depleted(to_readonly_bytes(header.span())); err.is_error())
+        return WebIDL::DataCloneError::create(realm, TRY_OR_THROW_OOM(vm, String::formatted("{}", err.error())));
+
+    if (auto const err = m_outside_port->write_until_depleted(to_readonly_bytes(data.span())); err.is_error())
+        return WebIDL::DataCloneError::create(realm, TRY_OR_THROW_OOM(vm, String::formatted("{}", err.error())));
+
+    return {};
 }
 
 #undef __ENUMERATE

--- a/Userland/Libraries/LibWeb/HTML/WorkerGlobalScope.idl
+++ b/Userland/Libraries/LibWeb/HTML/WorkerGlobalScope.idl
@@ -18,6 +18,11 @@ interface WorkerGlobalScope : EventTarget {
     attribute EventHandler ononline;
     attribute EventHandler onrejectionhandled;
     attribute EventHandler onunhandledrejection;
+
+    // FIXME: This belongs on the subclasses of WorkerGlobalScope
+    undefined postMessage(any message, any transfer);
+    attribute EventHandler onmessage;
+    attribute EventHandler onmessageerror;
 };
 
 WorkerGlobalScope includes WindowOrWorkerGlobalScope;

--- a/Userland/Services/WebWorker/ConnectionFromClient.cpp
+++ b/Userland/Services/WebWorker/ConnectionFromClient.cpp
@@ -52,9 +52,9 @@ Web::Page const& ConnectionFromClient::page() const
     return m_page_host->page();
 }
 
-void ConnectionFromClient::start_dedicated_worker(AK::URL const& url, String const& type, String const&, String const&, IPC::File const&)
+void ConnectionFromClient::start_dedicated_worker(AK::URL const& url, String const& type, String const&, String const&, IPC::File const& implicit_port)
 {
-    m_worker_host = make_ref_counted<DedicatedWorkerHost>(page(), url, type);
+    m_worker_host = make_ref_counted<DedicatedWorkerHost>(page(), url, type, implicit_port.take_fd());
 
     m_worker_host->run();
 }

--- a/Userland/Services/WebWorker/ConnectionFromClient.cpp
+++ b/Userland/Services/WebWorker/ConnectionFromClient.cpp
@@ -12,7 +12,9 @@ namespace WebWorker {
 
 void ConnectionFromClient::die()
 {
-    // FIXME: Do something here (shutdown process/script gracefully?)
+    // FIXME: When handling multiple workers in the same process,
+    //     this logic needs to be smarter (only when all workers are dead, etc).
+    Core::EventLoop::current().quit(0);
 }
 
 void ConnectionFromClient::request_file(Web::FileRequest request)

--- a/Userland/Services/WebWorker/DedicatedWorkerHost.h
+++ b/Userland/Services/WebWorker/DedicatedWorkerHost.h
@@ -8,7 +8,6 @@
 
 #include <AK/RefCounted.h>
 #include <AK/URL.h>
-#include <LibJS/Runtime/VM.h>
 #include <LibWeb/Bindings/MainThreadVM.h>
 #include <LibWeb/Forward.h>
 
@@ -22,7 +21,6 @@ public:
     void run();
 
 private:
-    NonnullRefPtr<JS::VM> m_worker_vm;
     RefPtr<Web::HTML::WorkerDebugConsoleClient> m_console;
     Web::Page& m_page;
 

--- a/Userland/Services/WebWorker/DedicatedWorkerHost.h
+++ b/Userland/Services/WebWorker/DedicatedWorkerHost.h
@@ -15,7 +15,7 @@ namespace WebWorker {
 
 class DedicatedWorkerHost : public RefCounted<DedicatedWorkerHost> {
 public:
-    explicit DedicatedWorkerHost(Web::Page&, AK::URL url, String type);
+    explicit DedicatedWorkerHost(Web::Page&, AK::URL url, String type, int outside_port);
     ~DedicatedWorkerHost();
 
     void run();
@@ -26,6 +26,8 @@ private:
 
     AK::URL m_url;
     String m_type;
+
+    int m_outside_port { -1 };
 };
 
 }


### PR DESCRIPTION
This implementation completely ignores MessagePorts, and manually plumbs
data through LocalSockets.