### PR TITLE
Kernel/riscv64: Add missing input sections to linker script

### DIFF
--- a/Kernel/Arch/riscv64/linker.ld
+++ b/Kernel/Arch/riscv64/linker.ld
@@ -56,13 +56,13 @@ SECTIONS
         *(.init_array)
         end_ctors = .;
 
-        *(.rodata*)
+        *(.srodata* .rodata*)
     } :data
 
     .data ALIGN(4K) :
     {
         start_of_kernel_data = .;
-        *(.data*)
+        *(.sdata* .data*)
         end_of_kernel_data = .;
     } :data
 
@@ -76,7 +76,7 @@ SECTIONS
     .bss ALIGN(4K) (NOLOAD) :
     {
         start_of_bss = .;
-        *(.bss)
+        *(.sbss* .bss*)
         end_of_bss = .;
 
         . = ALIGN(4K);


### PR DESCRIPTION
The linker would otherwise put those sections after `end_of_kernel_image`.
These `.s*` "small data" sections don't seem to exist for x86_64 and aarch64, so only include them in the riscv64 linker script.