### PR TITLE
LibWeb: Don't assume IO.unobserve() called on observed element

### DIFF
--- a/Tests/LibWeb/Text/expected/IntersectionObserver/unobserve-element-without-matching-observe.txt
+++ b/Tests/LibWeb/Text/expected/IntersectionObserver/unobserve-element-without-matching-observe.txt
@@ -1,0 +1,1 @@
+   PASS! (Didn't crash)

--- a/Tests/LibWeb/Text/input/IntersectionObserver/unobserve-element-without-matching-observe.html
+++ b/Tests/LibWeb/Text/input/IntersectionObserver/unobserve-element-without-matching-observe.html
@@ -1,0 +1,10 @@
+<body>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        let observer = new IntersectionObserver(function() {});
+        let div = document.createElement("div");
+        observer.unobserve(div);
+        println("PASS! (Didn't crash)");
+    });
+</script>

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -2086,7 +2086,8 @@ void Element::register_intersection_observer(Badge<IntersectionObserver::Interse
 
 void Element::unregister_intersection_observer(Badge<IntersectionObserver::IntersectionObserver>, JS::NonnullGCPtr<IntersectionObserver::IntersectionObserver> observer)
 {
-    VERIFY(m_registered_intersection_observers);
+    if (!m_registered_intersection_observers)
+        return;
     m_registered_intersection_observers->remove_first_matching([&observer](IntersectionObserver::IntersectionObserverRegistration const& entry) {
         return entry.observer == observer;
     });

--- a/Userland/Libraries/LibWeb/IntersectionObserver/IntersectionObserver.cpp
+++ b/Userland/Libraries/LibWeb/IntersectionObserver/IntersectionObserver.cpp
@@ -53,17 +53,17 @@ IntersectionObserver::IntersectionObserver(JS::Realm& realm, JS::GCPtr<WebIDL::C
     , m_thresholds(move(thresholds))
 {
     intersection_root().visit([this](auto& node) {
-        node->document().register_intersection_observer({}, *this);
+        m_document = node->document();
     });
+    m_document->register_intersection_observer({}, *this);
 }
 
 IntersectionObserver::~IntersectionObserver() = default;
 
 void IntersectionObserver::finalize()
 {
-    intersection_root().visit([this](auto& node) {
-        node->document().unregister_intersection_observer({}, *this);
-    });
+    if (m_document)
+        m_document->unregister_intersection_observer({}, *this);
 }
 
 void IntersectionObserver::initialize(JS::Realm& realm)

--- a/Userland/Libraries/LibWeb/IntersectionObserver/IntersectionObserver.h
+++ b/Userland/Libraries/LibWeb/IntersectionObserver/IntersectionObserver.h
@@ -83,6 +83,9 @@ private:
 
     // https://www.w3.org/TR/intersection-observer/#dom-intersectionobserver-observationtargets-slot
     Vector<JS::NonnullGCPtr<DOM::Element>> m_observation_targets;
+
+    // AD-HOC: This is the document where we've registered the IntersectionObserver.
+    WeakPtr<DOM::Document> m_document;
 };
 
 }


### PR DESCRIPTION
It's perfectly possible for JavaScript to call unobserve() on an element
that hasn't been observed. Let's stop asserting if that happens. :^)
    
Fixes #22020