### PR TITLE
AK: Fix bugs in Complex += -= + - * / operators

### DIFF
--- a/AK/Complex.h
+++ b/AK/Complex.h
@@ -83,7 +83,7 @@ public:
     template<AK::Concepts::Arithmetic U>
     constexpr Complex<T> operator+=(U const& x)
     {
-        m_real += x.real();
+        m_real += x;
         return *this;
     }
 
@@ -98,7 +98,7 @@ public:
     template<AK::Concepts::Arithmetic U>
     constexpr Complex<T> operator-=(U const& x)
     {
-        m_real -= x.real();
+        m_real -= x;
         return *this;
     }
 
@@ -224,7 +224,7 @@ private:
 
 // reverse associativity operators for scalars
 template<AK::Concepts::Arithmetic T, AK::Concepts::Arithmetic U>
-constexpr Complex<T> operator+(U const& b, Complex<T> const& a)
+constexpr Complex<T> operator+(U const& a, Complex<T> const& b)
 {
     Complex<T> x = a;
     x += b;
@@ -232,7 +232,7 @@ constexpr Complex<T> operator+(U const& b, Complex<T> const& a)
 }
 
 template<AK::Concepts::Arithmetic T, AK::Concepts::Arithmetic U>
-constexpr Complex<T> operator-(U const& b, Complex<T> const& a)
+constexpr Complex<T> operator-(U const& a, Complex<T> const& b)
 {
     Complex<T> x = a;
     x -= b;
@@ -240,7 +240,7 @@ constexpr Complex<T> operator-(U const& b, Complex<T> const& a)
 }
 
 template<AK::Concepts::Arithmetic T, AK::Concepts::Arithmetic U>
-constexpr Complex<T> operator*(U const& b, Complex<T> const& a)
+constexpr Complex<T> operator*(U const& a, Complex<T> const& b)
 {
     Complex<T> x = a;
     x *= b;
@@ -248,7 +248,7 @@ constexpr Complex<T> operator*(U const& b, Complex<T> const& a)
 }
 
 template<AK::Concepts::Arithmetic T, AK::Concepts::Arithmetic U>
-constexpr Complex<T> operator/(U const& b, Complex<T> const& a)
+constexpr Complex<T> operator/(U const& a, Complex<T> const& b)
 {
     Complex<T> x = a;
     x /= b;

--- a/Tests/AK/TestComplex.cpp
+++ b/Tests/AK/TestComplex.cpp
@@ -42,3 +42,29 @@ TEST_CASE(Complex)
     EXPECT_APPROXIMATE(cexp(Complex<double>(0., 1.) * M_PI).real(), -1.);
 #endif
 }
+
+TEST_CASE(real_operators_regression)
+{
+    {
+        auto c = Complex(0., 0.);
+        c += 1;
+        EXPECT_EQ(c.real(), 1);
+    }
+    {
+        auto c = Complex(0., 0.);
+        c -= 1;
+        EXPECT_EQ(c.real(), -1);
+    }
+    {
+        auto c1 = Complex(1., 1.);
+        auto c2 = 1 - c1;
+        EXPECT_EQ(c2.real(), 0);
+        EXPECT_EQ(c2.imag(), -1);
+    }
+    {
+        auto c1 = Complex(1., 1.);
+        auto c2 = 1 / c1;
+        EXPECT_EQ(c2.real(), 0.5);
+        EXPECT_EQ(c2.imag(), -0.5);
+    }
+}


### PR DESCRIPTION
There were two issues:

1) the `C+=R` and `C-=R` operators expected arithmetic types to have `.real()`

2) the `R+C`, `R-C`, `R*C` and `R/C` operators applied the operation in wrong
   order (did `C+R`, `C-R`, `C*R` and `C/R` instead). This wouldn't matter for
   `+` and `*` which are commutative, but is incorrect for `-` and `/`.