### PR TITLE
LibWeb: Bring URL parsing wrappers to spec

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
+++ b/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
@@ -275,7 +275,7 @@ static inline bool matches_pseudo_class(CSS::Selector::SimpleSelector::PseudoCla
         if (!matches_link_pseudo_class(element))
             return false;
         auto document_url = element.document().url();
-        AK::URL target_url = element.document().parse_url(element.attribute(HTML::AttributeNames::href).value_or({}));
+        AK::URL target_url = element.document().encoding_parse_url(element.attribute(HTML::AttributeNames::href).value_or({}));
         if (target_url.fragment().has_value())
             return document_url.equals(target_url, AK::URL::ExcludeFragment::No);
         return document_url.equals(target_url, AK::URL::ExcludeFragment::Yes);

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -2374,7 +2374,7 @@ void StyleComputer::load_fonts_from_sheet(CSSStyleSheet const& sheet)
         for (auto& source : font_face.sources()) {
             // FIXME: These should be loaded relative to the stylesheet URL instead of the document URL.
             if (source.local_or_url.has<AK::URL>())
-                urls.append(m_document->parse_url(source.local_or_url.get<AK::URL>().to_deprecated_string()));
+                urls.append(m_document->encoding_parse_url(source.local_or_url.get<AK::URL>().to_deprecated_string()));
             // FIXME: Handle local()
         }
 

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -925,6 +925,20 @@ AK::URL Document::encoding_parse_url(StringView url) const
     return URL::parse(url, base_url);
 }
 
+// https://html.spec.whatwg.org/multipage/urls-and-fetching.html#encoding-parsing-and-serializing-a-url
+Optional<DeprecatedString> Document::encoding_parse_and_serialize_url(StringView url) const
+{
+    // 1. Let url be the result of encoding-parsing a URL given url, relative to environment.
+    auto parsed_url = encoding_parse_url(url);
+
+    // 2. If url is failure, then return failure.
+    if (!parsed_url.is_valid())
+        return {};
+
+    // 3. Return the result of applying the URL serializer to url.
+    return parsed_url.serialize();
+}
+
 void Document::set_needs_layout()
 {
     if (m_needs_layout)

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -939,6 +939,16 @@ Optional<DeprecatedString> Document::encoding_parse_and_serialize_url(StringView
     return parsed_url.serialize();
 }
 
+// https://html.spec.whatwg.org/multipage/urls-and-fetching.html#parse-a-url
+AK::URL Document::parse_url(StringView url) const
+{
+    // 1. Let baseURL be environment's base URL, if environment is a Document object; otherwise environment's API base URL.
+    auto base_url = this->base_url();
+
+    // 2. Return the result of applying the URL parser to url, with baseURL.
+    return URL::parse(url, base_url);
+}
+
 void Document::set_needs_layout()
 {
     if (m_needs_layout)

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -120,7 +120,7 @@ public:
     HTML::CrossOriginOpenerPolicy const& cross_origin_opener_policy() const { return m_cross_origin_opener_policy; }
     void set_cross_origin_opener_policy(HTML::CrossOriginOpenerPolicy policy) { m_cross_origin_opener_policy = move(policy); }
 
-    AK::URL parse_url(StringView) const;
+    AK::URL encoding_parse_url(StringView) const;
 
     CSS::StyleComputer& style_computer() { return *m_style_computer; }
     const CSS::StyleComputer& style_computer() const { return *m_style_computer; }

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -122,6 +122,7 @@ public:
 
     AK::URL encoding_parse_url(StringView) const;
     Optional<DeprecatedString> encoding_parse_and_serialize_url(StringView) const;
+    AK::URL parse_url(StringView) const;
 
     CSS::StyleComputer& style_computer() { return *m_style_computer; }
     const CSS::StyleComputer& style_computer() const { return *m_style_computer; }

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -121,6 +121,7 @@ public:
     void set_cross_origin_opener_policy(HTML::CrossOriginOpenerPolicy policy) { m_cross_origin_opener_policy = move(policy); }
 
     AK::URL encoding_parse_url(StringView) const;
+    Optional<DeprecatedString> encoding_parse_and_serialize_url(StringView) const;
 
     CSS::StyleComputer& style_computer() { return *m_style_computer; }
     const CSS::StyleComputer& style_computer() const { return *m_style_computer; }

--- a/Userland/Libraries/LibWeb/HTML/HTMLBodyElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLBodyElement.cpp
@@ -76,7 +76,7 @@ void HTMLBodyElement::attribute_changed(FlyString const& name, Optional<String> 
         if (color.has_value())
             document().set_visited_link_color(color.value());
     } else if (name.equals_ignoring_ascii_case("background"sv)) {
-        m_background_style_value = CSS::ImageStyleValue::create(document().parse_url(value.value_or(String {})));
+        m_background_style_value = CSS::ImageStyleValue::create(document().encoding_parse_url(value.value_or(String {})));
         m_background_style_value->on_animate = [this] {
             if (layout_node()) {
                 layout_node()->set_needs_display();

--- a/Userland/Libraries/LibWeb/HTML/HTMLFormElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFormElement.cpp
@@ -164,9 +164,10 @@ WebIDL::ExceptionOr<void> HTMLFormElement::submit_form(JS::NonnullGCPtr<HTMLElem
     if (action.is_empty())
         action = form_document->url_string();
 
-    // 14. Parse a URL given action, relative to the submitter element's node document. If this fails, return.
-    // 15. Let parsed action be the resulting URL record.
-    auto parsed_action = document().parse_url(action);
+    // 14. Let parsed action be the result of encoding-parsing a URL given action, relative to submitter's node document.
+    auto parsed_action = document().encoding_parse_url(action);
+
+    // 15. If parsed action is failure, then return.
     if (!parsed_action.is_valid()) {
         dbgln("Failed to submit form: Invalid URL: {}", action);
         return {};

--- a/Userland/Libraries/LibWeb/HTML/HTMLHyperlinkElementUtils.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLHyperlinkElementUtils.cpp
@@ -27,6 +27,8 @@ void HTMLHyperlinkElementUtils::reinitialize_url() const
 // https://html.spec.whatwg.org/multipage/links.html#concept-hyperlink-url-set
 void HTMLHyperlinkElementUtils::set_the_url()
 {
+    // FIXME: Modernize these spec steps.
+
     // 1. If this element's href content attribute is absent, set this element's url to null.
     auto href_content_attribute = hyperlink_element_utils_href();
     if (!href_content_attribute.has_value()) {
@@ -36,7 +38,7 @@ void HTMLHyperlinkElementUtils::set_the_url()
 
     // 2. Otherwise, parse this element's href content attribute value relative to this element's node document.
     //    If parsing is successful, set this element's url to the result; otherwise, set this element's url to null.
-    m_url = hyperlink_element_utils_document().parse_url(*href_content_attribute);
+    m_url = hyperlink_element_utils_document().encoding_parse_url(*href_content_attribute);
 }
 
 // https://html.spec.whatwg.org/multipage/links.html#dom-hyperlink-origin
@@ -497,7 +499,8 @@ void HTMLHyperlinkElementUtils::follow_the_hyperlink(Optional<String> hyperlink_
         return;
 
     // 8. Parse a URL given subject's href attribute, relative to subject's node document.
-    auto url = hyperlink_element_utils_document().parse_url(href());
+    // FIXME: Modernize step to use https://html.spec.whatwg.org/multipage/urls-and-fetching.html#encoding-parsing-and-serializing-a-url
+    auto url = hyperlink_element_utils_document().encoding_parse_url(href());
 
     // 9. If that is successful, let url be the resulting URL string.
     //    Otherwise, if parsing the URL failed, then return.

--- a/Userland/Libraries/LibWeb/HTML/HTMLHyperlinkElementUtils.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLHyperlinkElementUtils.cpp
@@ -498,31 +498,27 @@ void HTMLHyperlinkElementUtils::follow_the_hyperlink(Optional<String> hyperlink_
     if (!target_navigable)
         return;
 
-    // 8. Parse a URL given subject's href attribute, relative to subject's node document.
-    // FIXME: Modernize step to use https://html.spec.whatwg.org/multipage/urls-and-fetching.html#encoding-parsing-and-serializing-a-url
-    auto url = hyperlink_element_utils_document().encoding_parse_url(href());
+    // 8. Let urlString be the result of encoding-parsing-and-serializing a URL given subject's href attribute value, relative to subject's node document.
+    auto url_string = hyperlink_element_utils_document().encoding_parse_and_serialize_url(href());
 
-    // 9. If that is successful, let url be the resulting URL string.
-    //    Otherwise, if parsing the URL failed, then return.
-    if (!url.is_valid())
+    // 9. If urlString is failure, then return.
+    if (!url_string.has_value())
         return;
 
-    // 10. If that is successful, let URL be the resulting URL string.
-    auto url_string = url.to_deprecated_string();
-
-    // 12. If hyperlinkSuffix is non-null, then append it to URL.
+    // 10. If hyperlinkSuffix is non-null, then append it to urlString.
     if (hyperlink_suffix.has_value()) {
         StringBuilder url_builder;
-        url_builder.append(url_string);
+        url_builder.append(*url_string);
         url_builder.append(*hyperlink_suffix);
 
         url_string = url_builder.to_deprecated_string();
     }
 
+    // FIXME: 11. Let referrerPolicy be the current state of subject's referrerpolicy content attribute.
     // FIXME: 12. If subject's link types includes the noreferrer keyword, then set referrerPolicy to "no-referrer".
 
     // 13. Navigate targetNavigable to url using subject's node document, with referrerPolicy set to referrerPolicy.
-    MUST(target_navigable->navigate({ .url = url, .source_document = hyperlink_element_utils_document() }));
+    MUST(target_navigable->navigate({ .url = *url_string, .source_document = hyperlink_element_utils_document() }));
 }
 
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -366,7 +366,8 @@ ErrorOr<void> HTMLImageElement::update_the_image_data(bool restart_animations, b
         // 1. Parse selected source, relative to the element's node document.
         //    If that is not successful, then abort this inner set of steps.
         //    Otherwise, let urlString be the resulting URL string.
-        auto url_string = document().parse_url(selected_source.value().to_deprecated_string());
+        // FIXME: Modernize step to use https://html.spec.whatwg.org/multipage/urls-and-fetching.html#encoding-parsing-and-serializing-a-url
+        auto url_string = document().encoding_parse_url(selected_source.value().to_deprecated_string());
         if (!url_string.is_valid())
             goto after_step_7;
 
@@ -465,7 +466,8 @@ after_step_7:
         }
 
         // 12. Parse selected source, relative to the element's node document, and let urlString be the resulting URL string.
-        auto url_string = document().parse_url(selected_source.value().url.to_deprecated_string());
+        // FIXME: Modernize step to use https://html.spec.whatwg.org/multipage/urls-and-fetching.html#encoding-parsing-and-serializing-a-url
+        auto url_string = document().encoding_parse_url(selected_source.value().url.to_deprecated_string());
         // If that is not successful, then:
         if (!url_string.is_valid()) {
             // 1. Abort the image request for the current request and the pending request.
@@ -691,7 +693,8 @@ void HTMLImageElement::react_to_changes_in_the_environment()
 
     // 6. ⌛ Parse selected source, relative to the element's node document,
     //       and let urlString be the resulting URL string. If that is not successful, then return.
-    auto url_string = document().parse_url(selected_source.value());
+    // FIXME: Modernize step to use https://html.spec.whatwg.org/multipage/urls-and-fetching.html#encoding-parsing-and-serializing-a-url
+    auto url_string = document().encoding_parse_url(selected_source.value());
     if (!url_string.is_valid())
         return;
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
@@ -62,14 +62,14 @@ void HTMLLinkElement::inserted()
     if (m_relationship & Relationship::Preload) {
         // FIXME: Respect the "as" attribute.
         LoadRequest request;
-        request.set_url(document().parse_url(deprecated_attribute(HTML::AttributeNames::href)));
+        request.set_url(document().encoding_parse_url(deprecated_attribute(HTML::AttributeNames::href)));
         set_resource(ResourceLoader::the().load_resource(Resource::Type::Generic, request));
     } else if (m_relationship & Relationship::DNSPrefetch) {
-        ResourceLoader::the().prefetch_dns(document().parse_url(deprecated_attribute(HTML::AttributeNames::href)));
+        ResourceLoader::the().prefetch_dns(document().encoding_parse_url(deprecated_attribute(HTML::AttributeNames::href)));
     } else if (m_relationship & Relationship::Preconnect) {
-        ResourceLoader::the().preconnect(document().parse_url(deprecated_attribute(HTML::AttributeNames::href)));
+        ResourceLoader::the().preconnect(document().encoding_parse_url(deprecated_attribute(HTML::AttributeNames::href)));
     } else if (m_relationship & Relationship::Icon) {
-        auto favicon_url = document().parse_url(href());
+        auto favicon_url = document().encoding_parse_url(href());
         auto favicon_request = LoadRequest::create_for_url_on_page(favicon_url, document().page());
         set_resource(ResourceLoader::the().load_resource(Resource::Type::Generic, favicon_request));
     }
@@ -485,7 +485,7 @@ WebIDL::ExceptionOr<void> HTMLLinkElement::load_fallback_favicon_if_needed(JS::N
     //    synchronous flag is set, credentials mode is "include", and whose use-URL-credentials flag is set.
     // NOTE: Fetch requests no longer have a synchronous flag, see https://github.com/whatwg/fetch/pull/1165
     auto request = Fetch::Infrastructure::Request::create(vm);
-    request->set_url(document->parse_url("/favicon.ico"sv));
+    request->set_url(document->encoding_parse_url("/favicon.ico"sv));
     request->set_client(&document->relevant_settings_object());
     request->set_destination(Fetch::Infrastructure::Request::Destination::Image);
     request->set_credentials_mode(Fetch::Infrastructure::Request::CredentialsMode::Include);

--- a/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -585,10 +585,14 @@ public:
             return {};
         }
 
+        // 3. ⌛ If candidate has a media attribute whose value does not match the environment, then end the synchronous
+        //    section, and jump down to the failed with elements step below.
+        // FIXME: This spec step was missing from our implementation. Include it and modernize the spec steps below.
+
         // 3. ⌛ Let urlString and urlRecord be the resulting URL string and the resulting URL record, respectively, that
         //    would have resulted from parsing the URL specified by candidate's src attribute's value relative to the
         //    candidate's node document when the src attribute was last changed.
-        auto url_record = m_candidate->document().parse_url(candiate_src);
+        auto url_record = m_candidate->document().encoding_parse_url(candiate_src);
         auto url_string = TRY_OR_THROW_OOM(vm, String::from_deprecated_string(url_record.to_deprecated_string()));
 
         // 4. ⌛ If urlString was not obtained successfully, then end the synchronous section, and jump down to the failed
@@ -831,11 +835,11 @@ WebIDL::ExceptionOr<void> HTMLMediaElement::select_resource()
             return {};
         }
 
-        // 2. ⌛ Let urlString and urlRecord be the resulting URL string and the resulting URL record, respectively, that would have resulted from parsing
-        //    the URL specified by the src attribute's value relative to the media element's node document when the src attribute was last changed.
-        auto url_record = document().parse_url(source);
+        // 2. ⌛ Let urlRecord be the result of encoding-parsing a URL given the src attribute's value, relative to the media element's node document
+        //    when the src attribute was last changed.
+        auto url_record = document().encoding_parse_url(source);
 
-        // 3. ⌛ If urlString was obtained successfully, set the currentSrc attribute to urlString.
+        // 3. ⌛ If urlRecord is not failure, then set the currentSrc attribute to the result of applying the URL serializer to urlRecord.
         if (url_record.is_valid())
             m_current_src = TRY_OR_THROW_OOM(vm, String::from_deprecated_string(url_record.to_deprecated_string()));
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
@@ -358,10 +358,10 @@ void HTMLScriptElement::prepare_script()
         // 4. Set el's from an external file to true.
         m_from_an_external_file = true;
 
-        // 5. Parse src relative to el's node document.
-        auto url = document().parse_url(src);
+        // 5. Let url be the result of encoding-parsing a URL given src, relative to el's node document.
+        auto url = document().encoding_parse_url(src);
 
-        // 6. If the previous step failed, then queue an element task on the DOM manipulation task source given el to fire an event named error at el, and return. Otherwise, let url be the resulting URL record.
+        // 6. If url is failure, then queue an element task on the DOM manipulation task source given el to fire an event named error at el, and return.
         if (!url.is_valid()) {
             dbgln("HTMLScriptElement: Refusing to run script because the src URL '{}' is invalid.", url);
             queue_an_element_task(HTML::Task::Source::DOMManipulation, [this] {

--- a/Userland/Libraries/LibWeb/HTML/HTMLTableCellElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableCellElement.cpp
@@ -79,7 +79,7 @@ void HTMLTableCellElement::apply_presentational_hints(CSS::StyleProperties& styl
                 style.set_property(CSS::PropertyID::Height, parsed_value.release_nonnull());
             return;
         } else if (name == HTML::AttributeNames::background) {
-            if (auto parsed_value = document().parse_url(value); parsed_value.is_valid())
+            if (auto parsed_value = document().encoding_parse_url(value); parsed_value.is_valid())
                 style.set_property(CSS::PropertyID::BackgroundImage, CSS::ImageStyleValue::create(parsed_value));
             return;
         }

--- a/Userland/Libraries/LibWeb/HTML/HTMLTableRowElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableRowElement.cpp
@@ -49,7 +49,7 @@ void HTMLTableRowElement::apply_presentational_hints(CSS::StyleProperties& style
                 style.set_property(CSS::PropertyID::BackgroundColor, CSS::ColorStyleValue::create(color.value()));
             return;
         } else if (name == HTML::AttributeNames::background) {
-            if (auto parsed_value = document().parse_url(value); parsed_value.is_valid())
+            if (auto parsed_value = document().encoding_parse_url(value); parsed_value.is_valid())
                 style.set_property(CSS::PropertyID::BackgroundImage, CSS::ImageStyleValue::create(parsed_value));
             return;
         } else if (name == HTML::AttributeNames::valign) {

--- a/Userland/Libraries/LibWeb/HTML/HTMLVideoElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLVideoElement.cpp
@@ -142,15 +142,16 @@ WebIDL::ExceptionOr<void> HTMLVideoElement::determine_element_poster_frame(Optio
     if (!poster.has_value() || poster->is_empty())
         return {};
 
-    // 3. Parse the poster attribute's value relative to the element's node document. If this fails, then there is no
-    //    poster frame; return.
-    auto url_record = document().parse_url(*poster);
+    // 3. Let url be the result of encoding-parsing a URL given the poster attribute's value, relative to the element's node document.
+    auto url_record = document().encoding_parse_url(*poster);
+
+    // 4. If url is failure, then return.
     if (!url_record.is_valid())
         return {};
 
-    // 4. Let request be a new request whose URL is the resulting URL record, client is the element's node document's
-    //    relevant settings object, destination is "image", initiator type is "video", credentials mode is "include",
-    //    and whose use-URL-credentials flag is set.
+    // 5. Let request be a new request whose URL is url, client is the element's node document's relevant settings object,
+    //    destination is "image", initiator type is "video", credentials mode is "include", and whose use-URL-credentials
+    //    flag is set.
     auto request = Fetch::Infrastructure::Request::create(vm);
     request->set_url(move(url_record));
     request->set_client(&document().relevant_settings_object());
@@ -159,7 +160,7 @@ WebIDL::ExceptionOr<void> HTMLVideoElement::determine_element_poster_frame(Optio
     request->set_credentials_mode(Fetch::Infrastructure::Request::CredentialsMode::Include);
     request->set_use_url_credentials(true);
 
-    // 5. Fetch request. This must delay the load event of the element's node document.
+    // 6. Fetch request. This must delay the load event of the element's node document.
     Fetch::Infrastructure::FetchAlgorithms::Input fetch_algorithms_input {};
     m_load_event_delayer.emplace(document());
 

--- a/Userland/Libraries/LibWeb/HTML/History.cpp
+++ b/Userland/Libraries/LibWeb/HTML/History.cpp
@@ -170,18 +170,14 @@ WebIDL::ExceptionOr<void> History::shared_history_push_replace_state(JS::Value v
 
     // 6. If url is not null or the empty string, then:
     if (url.has_value() && !url->is_empty()) {
+        // 1. Set newURL to the result of encoding-parsing a URL given url, relative to the relevant settings object of history.
+        new_url = relevant_settings_object(*this).encoding_parse_url(url->to_deprecated_string());
 
-        // 1. Parse url, relative to the relevant settings object of history.
-        auto parsed_url = relevant_settings_object(*this).parse_url(url->to_deprecated_string());
-
-        // 2. If that fails, then throw a "SecurityError" DOMException.
-        if (!parsed_url.is_valid())
+        // 2. If newURL is failure, then throw a "SecurityError" DOMException.
+        if (!new_url.is_valid())
             return WebIDL::SecurityError::create(realm(), "Cannot pushState or replaceState to incompatible URL"_fly_string);
 
-        // 3. Set newURL to the resulting URL record.
-        new_url = parsed_url;
-
-        // 4. If document cannot have its URL rewritten to newURL, then throw a "SecurityError" DOMException.
+        // 3. If document cannot have its URL rewritten to newURL, then throw a "SecurityError" DOMException.
         if (!can_have_its_url_rewritten(document, new_url))
             return WebIDL::SecurityError::create(realm(), "Cannot pushState or replaceState to incompatible URL"_fly_string);
     }

--- a/Userland/Libraries/LibWeb/HTML/Location.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Location.cpp
@@ -385,13 +385,15 @@ WebIDL::ExceptionOr<void> Location::replace(String const& url)
     if (!relevant_document())
         return {};
 
-    // 2. Parse url relative to the entry settings object. If that failed, throw a "SyntaxError" DOMException.
-    auto replace_url = entry_settings_object().parse_url(url);
-    if (!replace_url.is_valid())
+    // 2. Let urlRecord be the result of encoding-parsing a URL given url, relative to the entry settings object.
+    auto url_record = entry_settings_object().encoding_parse_url(url);
+
+    // 3. If urlRecord is failure, then throw a "SyntaxError" DOMException.
+    if (!url_record.is_valid())
         return WebIDL::SyntaxError::create(realm(), MUST(String::formatted("Invalid URL '{}'", url)));
 
-    // 3. Location-object navigate this to the resulting URL record given "replace".
-    TRY(navigate(replace_url, HistoryHandlingBehavior::Replace));
+    // 4. Location-object navigate this to urlRecord given "replace".
+    TRY(navigate(url_record, HistoryHandlingBehavior::Replace));
 
     return {};
 }
@@ -409,7 +411,7 @@ WebIDL::ExceptionOr<void> Location::assign(String const& url)
         return WebIDL::SecurityError::create(realm(), "Location's relevant document is not same origin-domain with the entry settings object's origin"_fly_string);
 
     // 3. Parse url relative to the entry settings object. If that failed, throw a "SyntaxError" DOMException.
-    auto assign_url = entry_settings_object().parse_url(url);
+    auto assign_url = entry_settings_object().encoding_parse_url(url);
     if (!assign_url.is_valid())
         return WebIDL::SyntaxError::create(realm(), MUST(String::formatted("Invalid URL '{}'", url)));
 

--- a/Userland/Libraries/LibWeb/HTML/Location.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Location.cpp
@@ -130,12 +130,14 @@ WebIDL::ExceptionOr<void> Location::set_href(String const& new_href)
     if (!relevant_document)
         return {};
 
-    // 2. Parse the given value relative to the entry settings object. If that failed, throw a TypeError exception.
-    auto href_url = window.associated_document().parse_url(new_href.to_deprecated_string());
+    // 2. Let url be the result of encoding-parsing a URL given the given value, relative to the entry settings object.
+    auto href_url = window.associated_document().encoding_parse_url(new_href.to_deprecated_string());
+
+    // 3. If url is failure, then throw a "SyntaxError" DOMException.
     if (!href_url.is_valid())
         return vm.throw_completion<JS::URIError>(TRY_OR_THROW_OOM(vm, String::formatted("Invalid URL '{}'", new_href)));
 
-    // 3. Location-object navigate given the resulting URL record.
+    // 4. Location-object navigate this to url.
     TRY(navigate(href_url));
 
     return {};

--- a/Userland/Libraries/LibWeb/HTML/NavigableContainer.cpp
+++ b/Userland/Libraries/LibWeb/HTML/NavigableContainer.cpp
@@ -191,14 +191,15 @@ Optional<AK::URL> NavigableContainer::shared_attribute_processing_steps_for_ifra
     // 1. Let url be the URL record about:blank.
     auto url = AK::URL("about:blank");
 
-    // 2. If element has a src attribute specified, and its value is not the empty string,
-    //    then parse the value of that attribute relative to element's node document.
-    //    If this is successful, then set url to the resulting URL record.
+    // 2. If element has a src attribute specified, and its value is not the empty string, then:
     auto src_attribute_value = deprecated_attribute(HTML::AttributeNames::src);
     if (!src_attribute_value.is_empty()) {
-        auto parsed_src = document().parse_url(src_attribute_value);
-        if (parsed_src.is_valid())
-            url = parsed_src;
+        // 1. Let maybeURL be the result of encoding-parsing a URL given that attribute's value, relative to element's node document.
+        auto maybe_url = document().encoding_parse_url(src_attribute_value);
+
+        // 2. If maybeURL is not failure, then set url to maybeURL.
+        if (maybe_url.is_valid())
+            url = maybe_url;
     }
 
     // 3. If the inclusive ancestor navigables of element's node navigable contains a navigable

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Environments.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Environments.cpp
@@ -192,6 +192,16 @@ Optional<DeprecatedString> EnvironmentSettingsObject::encoding_parse_and_seriali
     return parsed_url.serialize();
 }
 
+// https://html.spec.whatwg.org/multipage/urls-and-fetching.html#parse-a-url
+AK::URL EnvironmentSettingsObject::parse_url(StringView url)
+{
+    // 1. Let baseURL be environment's base URL, if environment is a Document object; otherwise environment's API base URL.
+    auto base_url = api_base_url();
+
+    // 2. Return the result of applying the URL parser to url, with baseURL.
+    return URL::parse(url, base_url);
+}
+
 // https://html.spec.whatwg.org/multipage/webappapis.html#clean-up-after-running-a-callback
 void EnvironmentSettingsObject::clean_up_after_running_callback()
 {

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Environments.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Environments.cpp
@@ -16,6 +16,7 @@
 #include <LibWeb/HTML/WorkerGlobalScope.h>
 #include <LibWeb/Page/Page.h>
 #include <LibWeb/SecureContexts/AbstractOperations.h>
+#include <LibWeb/URL/URL.h>
 
 namespace Web::HTML {
 
@@ -159,20 +160,22 @@ void EnvironmentSettingsObject::prepare_to_run_callback()
         context->skip_when_determining_incumbent_counter++;
 }
 
-// https://html.spec.whatwg.org/multipage/urls-and-fetching.html#parse-a-url
-AK::URL EnvironmentSettingsObject::parse_url(StringView url)
+// https://html.spec.whatwg.org/multipage/urls-and-fetching.html#encoding-parsing-and-serializing-a-url
+AK::URL EnvironmentSettingsObject::encoding_parse_url(StringView url)
 {
-    // 1. Let encoding be document's character encoding, if document was given, and environment settings object's API URL character encoding otherwise.
-    // FIXME: Pass in environment settings object's API URL character encoding.
+    // 1. Let encoding be UTF-8.
+    // 2. If environment is a Document object, then set encoding to environment's character encoding.
+    // 3. Otherwise, if environment's relevant global object is a Window object, set encoding to
+    //    environment's relevant global object's associated Document's character encoding.
+    // FIXME: Currently, the URL parser assumes we are only working with UTF-8. Implement
+    //        these spec steps once it's able to support different encodings.
 
-    // 2. Let baseURL be document's base URL, if document was given, and environment settings object's API base URL otherwise.
+    // 4. Let baseURL be environment's base URL, if environment is a Document object; otherwise
+    //    environment's API base URL.
     auto base_url = api_base_url();
 
-    // 3. Let urlRecord be the result of applying the URL parser to url, with baseURL and encoding.
-    // 4. If urlRecord is failure, then return failure.
-    // 5. Let urlString be the result of applying the URL serializer to urlRecord.
-    // 6. Return urlString as the resulting URL string and urlRecord as the resulting URL record.
-    return base_url.complete_url(url);
+    // 5. Return the result of applying the URL parser to url, with baseURL and encoding.
+    return URL::parse(url, base_url);
 }
 
 // https://html.spec.whatwg.org/multipage/webappapis.html#clean-up-after-running-a-callback

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Environments.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Environments.cpp
@@ -178,6 +178,20 @@ AK::URL EnvironmentSettingsObject::encoding_parse_url(StringView url)
     return URL::parse(url, base_url);
 }
 
+// https://html.spec.whatwg.org/multipage/urls-and-fetching.html#encoding-parsing-and-serializing-a-url
+Optional<DeprecatedString> EnvironmentSettingsObject::encoding_parse_and_serialize_url(StringView url)
+{
+    // 1. Let url be the result of encoding-parsing a URL given url, relative to environment.
+    auto parsed_url = encoding_parse_url(url);
+
+    // 2. If url is failure, then return failure.
+    if (!parsed_url.is_valid())
+        return {};
+
+    // 3. Return the result of applying the URL serializer to url.
+    return parsed_url.serialize();
+}
+
 // https://html.spec.whatwg.org/multipage/webappapis.html#clean-up-after-running-a-callback
 void EnvironmentSettingsObject::clean_up_after_running_callback()
 {

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Environments.h
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Environments.h
@@ -85,6 +85,7 @@ struct EnvironmentSettingsObject
 
     AK::URL encoding_parse_url(StringView);
     Optional<DeprecatedString> encoding_parse_and_serialize_url(StringView);
+    AK::URL parse_url(StringView);
 
     JS::Realm& realm();
     JS::Object& global_object();

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Environments.h
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Environments.h
@@ -83,7 +83,7 @@ struct EnvironmentSettingsObject
     // https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-cross-origin-isolated-capability
     virtual CanUseCrossOriginIsolatedAPIs cross_origin_isolated_capability() = 0;
 
-    AK::URL parse_url(StringView);
+    AK::URL encoding_parse_url(StringView);
 
     JS::Realm& realm();
     JS::Object& global_object();

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Environments.h
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Environments.h
@@ -84,6 +84,7 @@ struct EnvironmentSettingsObject
     virtual CanUseCrossOriginIsolatedAPIs cross_origin_isolated_capability() = 0;
 
     AK::URL encoding_parse_url(StringView);
+    Optional<DeprecatedString> encoding_parse_and_serialize_url(StringView);
 
     JS::Realm& realm();
     JS::Object& global_object();

--- a/Userland/Libraries/LibWeb/HTML/Window.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Window.cpp
@@ -376,7 +376,8 @@ WebIDL::ExceptionOr<JS::GCPtr<WindowProxy>> Window::open_impl(StringView url, St
 
         // 4. If url is not the empty string, then set urlRecord to the result of encoding-parsing a URL given url, relative to the entry settings object.
         if (!url.is_empty()) {
-            url_record = entry_settings_object().parse_url(url);
+            url_record = entry_settings_object().encoding_parse_url(url);
+
             // 5. If urlRecord is failure, then throw a "SyntaxError" DOMException.
             if (!url_record.is_valid())
                 return WebIDL::SyntaxError::create(realm(), "URL is not valid"_fly_string);
@@ -398,7 +399,7 @@ WebIDL::ExceptionOr<JS::GCPtr<WindowProxy>> Window::open_impl(StringView url, St
         // 1. If url is not the empty string, then:
         if (!url.is_empty()) {
             // 1. Let urlRecord be the result of encoding-parsing a URL url, relative to the entry settings object.
-            auto url_record = entry_settings_object().parse_url(url);
+            auto url_record = entry_settings_object().encoding_parse_url(url);
 
             // 2. If urlRecord is failure, then throw a "SyntaxError" DOMException.
             if (!url_record.is_valid())

--- a/Userland/Libraries/LibWeb/HTML/Worker.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Worker.cpp
@@ -44,6 +44,8 @@ void Worker::visit_edges(Cell::Visitor& visitor)
 // https://html.spec.whatwg.org/multipage/workers.html#dom-worker
 WebIDL::ExceptionOr<JS::NonnullGCPtr<Worker>> Worker::create(String const& script_url, WorkerOptions const options, DOM::Document& document)
 {
+    // FIXME: Modernize these spec steps.
+
     dbgln_if(WEB_WORKER_DEBUG, "WebWorker: Creating worker with script_url = {}", script_url);
 
     // Returns a new Worker object. scriptURL will be fetched and executed in the background,
@@ -61,7 +63,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Worker>> Worker::create(String const& scrip
     auto& outside_settings = document.relevant_settings_object();
 
     // 3. Parse the scriptURL argument relative to outside settings.
-    auto url = document.parse_url(script_url.to_deprecated_string());
+    auto url = document.encoding_parse_url(script_url.to_deprecated_string());
 
     // 4. If this fails, throw a "SyntaxError" DOMException.
     if (!url.is_valid()) {

--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -282,7 +282,7 @@ bool EventHandler::handle_mouseup(CSSPixelPoint position, CSSPixelPoint screen_p
                 if (JS::GCPtr<HTML::HTMLAnchorElement const> link = node->enclosing_link_element()) {
                     JS::NonnullGCPtr<DOM::Document> document = *m_browsing_context->active_document();
                     auto href = link->href();
-                    auto url = document->parse_url(href);
+                    auto url = document->encoding_parse_url(href);
                     dbgln("Web::EventHandler: Clicking on a link to {}", url);
                     if (button == GUI::MouseButton::Middle) {
                         if (auto* page = m_browsing_context->page())
@@ -294,14 +294,14 @@ bool EventHandler::handle_mouseup(CSSPixelPoint position, CSSPixelPoint screen_p
                 } else if (button == GUI::MouseButton::Secondary) {
                     if (is<HTML::HTMLImageElement>(*node)) {
                         auto& image_element = verify_cast<HTML::HTMLImageElement>(*node);
-                        auto image_url = image_element.document().parse_url(image_element.src());
+                        auto image_url = image_element.document().encoding_parse_url(image_element.src());
                         if (auto* page = m_browsing_context->page())
                             page->client().page_did_request_image_context_menu(m_browsing_context->to_top_level_position(position), image_url, "", modifiers, image_element.bitmap());
                     } else if (is<HTML::HTMLMediaElement>(*node)) {
                         auto& media_element = verify_cast<HTML::HTMLMediaElement>(*node);
 
                         Page::MediaContextMenu menu {
-                            .media_url = media_element.document().parse_url(media_element.current_src()),
+                            .media_url = media_element.document().encoding_parse_url(media_element.current_src()),
                             .is_video = is<HTML::HTMLVideoElement>(*node),
                             .is_playing = media_element.potentially_playing(),
                             .is_muted = media_element.muted(),
@@ -537,7 +537,7 @@ bool EventHandler::handle_mousemove(CSSPixelPoint position, CSSPixelPoint screen
                 page->client().page_did_leave_tooltip_area();
             }
             if (is_hovering_link)
-                page->client().page_did_hover_link(document.parse_url(hovered_link_element->href()));
+                page->client().page_did_hover_link(document.encoding_parse_url(hovered_link_element->href()));
             else
                 page->client().page_did_unhover_link();
         }

--- a/Userland/Libraries/LibWeb/SVG/SVGGradientElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGGradientElement.cpp
@@ -96,7 +96,7 @@ JS::GCPtr<SVGGradientElement const> SVGGradientElement::linked_gradient() const
 
     auto link = has_attribute(AttributeNames::href) ? deprecated_get_attribute(AttributeNames::href) : deprecated_get_attribute("xlink:href"sv);
     if (auto href = link; !href.is_empty()) {
-        auto url = document().parse_url(href);
+        auto url = document().encoding_parse_url(href);
         auto id = url.fragment();
         if (!id.has_value() || id->is_empty())
             return {};

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -484,7 +484,7 @@ void ConnectionFromClient::debug_request(DeprecatedString const& request, Deprec
                 load_html("<h1>Failed to find &lt;link rel=&quot;match&quot; /&gt; in ref test page!</h1> Make sure you added it.");
             } else {
                 auto link = maybe_link.release_value();
-                auto url = document->parse_url(link->deprecated_get_attribute(Web::HTML::AttributeNames::href));
+                auto url = document->encoding_parse_url(link->deprecated_get_attribute(Web::HTML::AttributeNames::href));
                 load_url(url);
             }
         }


### PR DESCRIPTION
This PR aims to resolve #22022 by accomplishing the following set of goals below:

- [x] Rename `parse_url()` -> `encoding_parse_url()` in `DOM::Document` and  `HTML::EnvironmentSettingsObject` and reimplement it to spec
- [x] Find all areas where `encoding_parse_url()` needs to be used and integrate it with existing code
- [x] Implement the `encoding_parse_and_serialize_url()` algo for both `Document` and `EnvironmentSettingsObject`
- [x] Implement the `parse_url()` algo for both `Document` and `EnvironmentSettingsObject` (again)