### PR TITLE
Kernel/riscv64: Generate Kernel.bin from kernel ELF

### DIFF
--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -806,6 +806,13 @@ if ("${SERENITY_ARCH}" STREQUAL "aarch64")
         COMMAND ${CMAKE_OBJCOPY} -O binary Kernel kernel8.img
         BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/kernel8.img
     )
+elseif ("${SERENITY_ARCH}" STREQUAL "riscv64")
+    add_custom_command(
+        TARGET Kernel POST_BUILD
+        COMMAND ${CMAKE_OBJCOPY} -O binary Kernel Kernel.bin
+        BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/Kernel.bin
+    )
+    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/Kernel.bin" DESTINATION boot)
 endif()
 
 serenity_install_headers(Kernel)


### PR DESCRIPTION
This is necessary for being able to use the qemu `-kernel` option. The QEMU virt machine uses OpenSBI's FW_DYNAMIC feature to pass the kernel entry address, which is the virtual entry point address specified in the kernel ELF. If we instead `objcopy` the kernel into a raw binary, OpenSBI will jump to the physical kernel load address, which is what we want it to do.