### PR TITLE
LibAccelGfx+LibWeb: Add support for stacking context opacity

### DIFF
--- a/Userland/Libraries/LibAccelGfx/Canvas.h
+++ b/Userland/Libraries/LibAccelGfx/Canvas.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2023, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/RefCounted.h>
+#include <LibAccelGfx/GL.h>
+#include <LibGfx/Rect.h>
+
+namespace AccelGfx {
+
+class Canvas : public RefCounted<Canvas> {
+public:
+    static NonnullRefPtr<Canvas> create(Gfx::IntSize const& size)
+    {
+        return adopt_ref(*new Canvas(size));
+    }
+
+    Gfx::IntSize const& size() const { return m_size; }
+    GL::Framebuffer const& framebuffer() const { return m_framebuffer; }
+
+    void bind()
+    {
+        GL::bind_framebuffer(m_framebuffer);
+    }
+
+    virtual ~Canvas()
+    {
+        GL::delete_framebuffer(m_framebuffer);
+    }
+
+private:
+    Canvas(Gfx::IntSize const& size)
+        : m_size(size)
+        , m_framebuffer(GL::create_framebuffer(size))
+    {
+    }
+
+    Gfx::IntSize m_size;
+    GL::Framebuffer m_framebuffer;
+};
+
+}

--- a/Userland/Libraries/LibAccelGfx/GL.cpp
+++ b/Userland/Libraries/LibAccelGfx/GL.cpp
@@ -114,7 +114,7 @@ Texture create_texture()
     GLuint texture;
     glGenTextures(1, &texture);
     verify_no_error();
-    return { texture };
+    return { texture, {} };
 }
 
 void bind_texture(Texture const& texture)
@@ -123,11 +123,12 @@ void bind_texture(Texture const& texture)
     verify_no_error();
 }
 
-void upload_texture_data(Texture const& texture, Gfx::Bitmap const& bitmap)
+void upload_texture_data(Texture& texture, Gfx::Bitmap const& bitmap)
 {
     VERIFY(bitmap.format() == Gfx::BitmapFormat::BGRx8888 || bitmap.format() == Gfx::BitmapFormat::BGRA8888);
     bind_texture(texture);
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, bitmap.width(), bitmap.height(), 0, GL_BGRA, GL_UNSIGNED_BYTE, bitmap.scanline(0));
+    texture.size = bitmap.size();
     verify_no_error();
 }
 
@@ -231,7 +232,7 @@ Framebuffer create_framebuffer(Gfx::IntSize size)
     GLuint texture;
     glGenTextures(1, &texture);
     glBindTexture(GL_TEXTURE_2D, texture);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, size.width(), size.height(), 0, GL_RGB, GL_UNSIGNED_BYTE, NULL);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, size.width(), size.height(), 0, GL_BGRA, GL_UNSIGNED_BYTE, NULL);
 
     GLuint fbo;
     glGenFramebuffers(1, &fbo);
@@ -244,7 +245,7 @@ Framebuffer create_framebuffer(Gfx::IntSize size)
 
     verify_no_error();
 
-    return { fbo, texture };
+    return { fbo, Texture { texture, size } };
 }
 
 void bind_framebuffer(Framebuffer const& framebuffer)
@@ -257,7 +258,7 @@ void delete_framebuffer(Framebuffer const& framebuffer)
 {
     glBindFramebuffer(GL_FRAMEBUFFER, framebuffer.fbo_id);
     glDeleteFramebuffers(1, &framebuffer.fbo_id);
-    glDeleteTextures(1, &framebuffer.texture_id);
+    delete_texture(framebuffer.texture);
     verify_no_error();
 }
 

--- a/Userland/Libraries/LibAccelGfx/GL.h
+++ b/Userland/Libraries/LibAccelGfx/GL.h
@@ -15,6 +15,7 @@
 #    include <GL/gl.h>
 #endif
 #include <LibGfx/Forward.h>
+#include <LibGfx/Rect.h>
 
 namespace AccelGfx::GL {
 
@@ -41,6 +42,7 @@ struct Uniform {
 
 struct Texture {
     GLuint id;
+    Optional<Gfx::IntSize> size;
 };
 
 struct Buffer {
@@ -53,7 +55,7 @@ struct VertexArray {
 
 struct Framebuffer {
     GLuint fbo_id;
-    GLuint texture_id;
+    GL::Texture texture;
 };
 
 void set_viewport(Gfx::IntRect);
@@ -70,7 +72,7 @@ void delete_program(Program const&);
 
 Texture create_texture();
 void bind_texture(Texture const&);
-void upload_texture_data(Texture const& texture, Gfx::Bitmap const& bitmap);
+void upload_texture_data(Texture& texture, Gfx::Bitmap const& bitmap);
 void delete_texture(Texture const&);
 
 void set_uniform(Uniform const& uniform, float, float);

--- a/Userland/Libraries/LibAccelGfx/Painter.cpp
+++ b/Userland/Libraries/LibAccelGfx/Painter.cpp
@@ -144,10 +144,10 @@ OwnPtr<Painter> Painter::create()
 
 Painter::Painter(Context& context)
     : m_context(context)
-    , m_rectangle_program(Program::create(vertex_shader_source, solid_color_fragment_shader_source))
-    , m_rounded_rectangle_program(Program::create(vertex_shader_source, rect_with_rounded_corners_fragment_shader_source))
-    , m_blit_program(Program::create(blit_vertex_shader_source, blit_fragment_shader_source))
-    , m_linear_gradient_program(Program::create(linear_gradient_vertex_shader_source, linear_gradient_fragment_shader_source))
+    , m_rectangle_program(Program::create(Program::Name::RectangleProgram, vertex_shader_source, solid_color_fragment_shader_source))
+    , m_rounded_rectangle_program(Program::create(Program::Name::RoundedRectangleProgram, vertex_shader_source, rect_with_rounded_corners_fragment_shader_source))
+    , m_blit_program(Program::create(Program::Name::BlitProgram, blit_vertex_shader_source, blit_fragment_shader_source))
+    , m_linear_gradient_program(Program::create(Program::Name::LinearGradientProgram, linear_gradient_vertex_shader_source, linear_gradient_fragment_shader_source))
     , m_glyphs_texture(GL::create_texture())
 {
     m_state_stack.empend(State());

--- a/Userland/Libraries/LibAccelGfx/Painter.h
+++ b/Userland/Libraries/LibAccelGfx/Painter.h
@@ -29,6 +29,7 @@ class Painter {
 
 public:
     static OwnPtr<Painter> create();
+    static OwnPtr<Painter> create_with_glyphs_texture_from_painter(Painter const& painter);
 
     Painter(Context&);
     ~Painter();
@@ -86,6 +87,9 @@ public:
     void fill_rect_with_rounded_corners(Gfx::IntRect const& rect, Color const& color, CornerRadius const& top_left_radius, CornerRadius const& top_right_radius, CornerRadius const& bottom_left_radius, CornerRadius const& bottom_right_radius);
     void fill_rect_with_rounded_corners(Gfx::FloatRect const& rect, Color const& color, CornerRadius const& top_left_radius, CornerRadius const& top_right_radius, CornerRadius const& bottom_left_radius, CornerRadius const& bottom_right_radius);
 
+    void blit_canvas(Gfx::IntRect const& dst_rect, Canvas const&, float opacity = 1.0f);
+    void blit_canvas(Gfx::FloatRect const& dst_rect, Canvas const&, float opacity = 1.0f);
+
 private:
     Context& m_context;
 
@@ -96,6 +100,7 @@ private:
     [[nodiscard]] State& state() { return m_state_stack.last(); }
     [[nodiscard]] State const& state() const { return m_state_stack.last(); }
 
+    void blit_scaled_texture(Gfx::FloatRect const& dst_rect, GL::Texture const&, Gfx::FloatRect const& src_rect, ScalingMode, float opacity = 1.0f);
     void bind_target_canvas();
 
     [[nodiscard]] Gfx::FloatRect to_clip_space(Gfx::FloatRect const& screen_rect) const;

--- a/Userland/Libraries/LibAccelGfx/Painter.h
+++ b/Userland/Libraries/LibAccelGfx/Painter.h
@@ -10,6 +10,7 @@
 #include <AK/HashMap.h>
 #include <AK/Noncopyable.h>
 #include <AK/Vector.h>
+#include <LibAccelGfx/Canvas.h>
 #include <LibAccelGfx/Context.h>
 #include <LibAccelGfx/Forward.h>
 #include <LibAccelGfx/GL.h>
@@ -72,8 +73,8 @@ public:
     void set_clip_rect(Gfx::IntRect);
     void clear_clip_rect();
 
-    void set_target_bitmap(Gfx::Bitmap&);
-    void flush();
+    void set_target_canvas(NonnullRefPtr<Canvas>);
+    void flush(Gfx::Bitmap&);
 
     void fill_rect_with_linear_gradient(Gfx::IntRect const&, ReadonlySpan<Gfx::ColorStop>, float angle, Optional<float> repeat_length = {});
     void fill_rect_with_linear_gradient(Gfx::FloatRect const&, ReadonlySpan<Gfx::ColorStop>, float angle, Optional<float> repeat_length = {});
@@ -95,9 +96,13 @@ private:
     [[nodiscard]] State& state() { return m_state_stack.last(); }
     [[nodiscard]] State const& state() const { return m_state_stack.last(); }
 
+    void bind_target_canvas();
+
     [[nodiscard]] Gfx::FloatRect to_clip_space(Gfx::FloatRect const& screen_rect) const;
 
     Vector<State, 1> m_state_stack;
+
+    RefPtr<Canvas> m_target_canvas;
 
     Program m_rectangle_program;
     Program m_rounded_rectangle_program;
@@ -107,9 +112,6 @@ private:
     HashMap<GlyphsTextureKey, Gfx::IntRect> m_glyphs_texture_map;
     Gfx::IntSize m_glyphs_texture_size;
     GL::Texture m_glyphs_texture;
-
-    Optional<Gfx::Bitmap&> m_target_bitmap;
-    Optional<GL::Framebuffer> m_target_framebuffer;
 };
 
 }

--- a/Userland/Libraries/LibAccelGfx/Program.cpp
+++ b/Userland/Libraries/LibAccelGfx/Program.cpp
@@ -11,12 +11,19 @@
 
 namespace AccelGfx {
 
-Program Program::create(char const* vertex_shader_source, char const* fragment_shader_source)
+Optional<GL::Program> programs_cache[to_underlying(Program::Name::ProgramCount)];
+
+Program Program::create(Name name, char const* vertex_shader_source, char const* fragment_shader_source)
 {
+    if (programs_cache[to_underlying(name)].has_value()) {
+        return Program { *programs_cache[to_underlying(name)] };
+    }
+
     auto vertex_shader = GL::create_shader(GL::ShaderType::Vertex, vertex_shader_source);
     auto fragment_shader = GL::create_shader(GL::ShaderType::Fragment, fragment_shader_source);
 
     auto program = GL::create_program(vertex_shader, fragment_shader);
+    programs_cache[to_underlying(name)] = program;
 
     return Program { program };
 }
@@ -34,11 +41,6 @@ GL::VertexAttribute Program::get_attribute_location(char const* name)
 GL::Uniform Program::get_uniform_location(char const* name)
 {
     return GL::get_uniform_location(m_program, name);
-}
-
-Program::~Program()
-{
-    GL::delete_program(m_program);
 }
 
 }

--- a/Userland/Libraries/LibAccelGfx/Program.h
+++ b/Userland/Libraries/LibAccelGfx/Program.h
@@ -15,13 +15,19 @@ class Program {
     AK_MAKE_NONCOPYABLE(Program);
 
 public:
-    static Program create(char const* vertex_shader_source, char const* fragment_shader_source);
+    enum class Name {
+        RectangleProgram,
+        RoundedRectangleProgram,
+        BlitProgram,
+        LinearGradientProgram,
+        ProgramCount,
+    };
+
+    static Program create(Name name, char const* vertex_shader_source, char const* fragment_shader_source);
 
     void use();
     GL::VertexAttribute get_attribute_location(char const* name);
     GL::Uniform get_uniform_location(char const* name);
-
-    ~Program();
 
 private:
     Program(GL::Program program)

--- a/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorGPU.h
+++ b/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorGPU.h
@@ -51,13 +51,23 @@ public:
     virtual bool needs_prepare_glyphs_texture() const override { return true; }
     void prepare_glyph_texture(HashMap<Gfx::Font const*, HashTable<u32>> const&) override;
 
-    PaintingCommandExecutorGPU(AccelGfx::Painter& painter);
+    PaintingCommandExecutorGPU(Gfx::Bitmap& bitmap);
     ~PaintingCommandExecutorGPU() override;
 
 private:
-    AccelGfx::Painter& painter() { return m_painter; }
+    Gfx::Bitmap& m_target_bitmap;
 
-    AccelGfx::Painter& m_painter;
+    struct StackingContext {
+        RefPtr<AccelGfx::Canvas> canvas;
+        OwnPtr<AccelGfx::Painter> painter;
+        float opacity;
+        Gfx::IntRect destination;
+    };
+
+    [[nodiscard]] AccelGfx::Painter const& painter() const { return *stacking_contexts.last().painter; }
+    [[nodiscard]] AccelGfx::Painter& painter() { return *stacking_contexts.last().painter; }
+
+    Vector<StackingContext> stacking_contexts;
 };
 
 }

--- a/Userland/Services/WebContent/PageHost.cpp
+++ b/Userland/Services/WebContent/PageHost.cpp
@@ -164,10 +164,10 @@ void PageHost::paint(Web::DevicePixelRect const& content_rect, Gfx::Bitmap& targ
 
     if (s_use_gpu_painter) {
 #ifdef HAS_ACCELERATED_GRAPHICS
-        m_accelerated_painter->set_target_bitmap(target);
+        m_accelerated_painter->set_target_canvas(AccelGfx::Canvas::create(target.size()));
         Web::Painting::PaintingCommandExecutorGPU painting_command_executor(*m_accelerated_painter);
         recording_painter.execute(painting_command_executor);
-        m_accelerated_painter->flush();
+        m_accelerated_painter->flush(target);
 #endif
     } else {
         Web::Painting::PaintingCommandExecutorCPU painting_command_executor(target);

--- a/Userland/Services/WebContent/PageHost.cpp
+++ b/Userland/Services/WebContent/PageHost.cpp
@@ -43,12 +43,6 @@ PageHost::PageHost(ConnectionFromClient& client)
         m_client.async_did_invalidate_content_rect({ m_invalidation_rect.x().value(), m_invalidation_rect.y().value(), m_invalidation_rect.width().value(), m_invalidation_rect.height().value() });
         m_invalidation_rect = {};
     });
-
-    if (s_use_gpu_painter) {
-#ifdef HAS_ACCELERATED_GRAPHICS
-        m_accelerated_painter = AccelGfx::Painter::create();
-#endif
-    }
 }
 
 PageHost::~PageHost() = default;
@@ -164,10 +158,8 @@ void PageHost::paint(Web::DevicePixelRect const& content_rect, Gfx::Bitmap& targ
 
     if (s_use_gpu_painter) {
 #ifdef HAS_ACCELERATED_GRAPHICS
-        m_accelerated_painter->set_target_canvas(AccelGfx::Canvas::create(target.size()));
-        Web::Painting::PaintingCommandExecutorGPU painting_command_executor(*m_accelerated_painter);
+        Web::Painting::PaintingCommandExecutorGPU painting_command_executor(target);
         recording_painter.execute(painting_command_executor);
-        m_accelerated_painter->flush(target);
 #endif
     } else {
         Web::Painting::PaintingCommandExecutorCPU painting_command_executor(target);

--- a/Userland/Services/WebContent/PageHost.h
+++ b/Userland/Services/WebContent/PageHost.h
@@ -141,10 +141,6 @@ private:
     Web::CSS::PreferredColorScheme m_preferred_color_scheme { Web::CSS::PreferredColorScheme::Auto };
 
     RefPtr<WebDriverConnection> m_webdriver;
-
-#ifdef HAS_ACCELERATED_GRAPHICS
-    OwnPtr<AccelGfx::Painter> m_accelerated_painter;
-#endif
 };
 
 }


### PR DESCRIPTION
For each stacking context with an opacity less than 1, we create a
separate framebuffer. We then blit the texture attached to this
framebuffer with the specified opacity.

To avoid the performance overhead of reading pixels from the texture
into Gfx::Bitmap, a new method that allows for direct blitting from
the texture is introduced, named blit_scaled_texture().
