### PR TITLE
LibAudio: Speed up WavWriter by buffering output data

### DIFF
--- a/Userland/Libraries/LibAudio/WavWriter.cpp
+++ b/Userland/Libraries/LibAudio/WavWriter.cpp
@@ -33,7 +33,8 @@ WavWriter::~WavWriter()
 
 ErrorOr<void> WavWriter::set_file(StringView path)
 {
-    m_file = TRY(Core::File::open(path, Core::File::OpenMode::Write));
+    auto file = TRY(Core::File::open(path, Core::File::OpenMode::Write));
+    m_file = TRY(Core::OutputBufferedFile::create(move(file)));
     TRY(m_file->seek(44, SeekMode::SetPosition));
     m_finalized = false;
     return {};

--- a/Userland/Libraries/LibAudio/WavWriter.h
+++ b/Userland/Libraries/LibAudio/WavWriter.h
@@ -33,7 +33,6 @@ public:
     u32 sample_rate() const { return m_sample_rate; }
     u16 num_channels() const { return m_num_channels; }
     PcmSampleFormat sample_format() const { return m_sample_format; }
-    Core::File& file() const { return *m_file; }
 
     ErrorOr<void> set_file(StringView path);
     void set_num_channels(int num_channels) { m_num_channels = num_channels; }
@@ -42,7 +41,7 @@ public:
 
 private:
     ErrorOr<void> write_header();
-    OwnPtr<Core::File> m_file;
+    OwnPtr<Core::OutputBufferedFile> m_file;
     bool m_finalized { false };
 
     u32 m_sample_rate;


### PR DESCRIPTION
We were calling write syscall twice for every sample, which effectively hurt the writer's performance.

With this change exporting a melody in the Piano app now takes less than a second, which previously took about 20 seconds on my machine.

Additionally, I've removed an unused `WavWriter::file()` getter.