### PR TITLE
LibJS/JIT: Add more Math builtins

### DIFF
--- a/AK/StdLibExtras.h
+++ b/AK/StdLibExtras.h
@@ -16,7 +16,7 @@
 
 #include <AK/Assertions.h>
 
-#define OFFSET_OF(class, member) (reinterpret_cast<ptrdiff_t>(&reinterpret_cast<class*>(0x1000)->member) - 0x1000)
+#define OFFSET_OF(class, member) __builtin_offsetof(class, member)
 
 namespace AK {
 

--- a/Meta/CMake/common_compile_options.cmake
+++ b/Meta/CMake/common_compile_options.cmake
@@ -6,6 +6,8 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 add_compile_options(-Wall)
 add_compile_options(-Wextra)
 
+add_compile_options(-Wno-invalid-offsetof)
+
 add_compile_options(-Wno-unknown-warning-option)
 add_compile_options(-Wno-unused-command-line-argument)
 

--- a/Userland/Libraries/LibJS/Bytecode/Builtins.h
+++ b/Userland/Libraries/LibJS/Bytecode/Builtins.h
@@ -12,10 +12,11 @@
 namespace JS::Bytecode {
 
 // TitleCaseName, snake_case_name, base, property, argument_count
-#define JS_ENUMERATE_BUILTINS(O)       \
-    O(MathAbs, math_abs, Math, abs, 1) \
-    O(MathLog, math_log, Math, log, 1) \
-    O(MathPow, math_pow, Math, pow, 2) \
+#define JS_ENUMERATE_BUILTINS(O)             \
+    O(MathAbs, math_abs, Math, abs, 1)       \
+    O(MathLog, math_log, Math, log, 1)       \
+    O(MathPow, math_pow, Math, pow, 2)       \
+    O(MathFloor, math_floor, Math, floor, 1) \
     O(MathSqrt, math_sqrt, Math, sqrt, 1)
 
 enum class Builtin {

--- a/Userland/Libraries/LibJS/Bytecode/Builtins.h
+++ b/Userland/Libraries/LibJS/Bytecode/Builtins.h
@@ -14,7 +14,8 @@ namespace JS::Bytecode {
 // TitleCaseName, snake_case_name, base, property, argument_count
 #define JS_ENUMERATE_BUILTINS(O)       \
     O(MathAbs, math_abs, Math, abs, 1) \
-    O(MathLog, math_log, Math, log, 1)
+    O(MathLog, math_log, Math, log, 1) \
+    O(MathSqrt, math_sqrt, Math, sqrt, 1)
 
 enum class Builtin {
 #define DEFINE_BUILTIN_ENUM(name, ...) name,

--- a/Userland/Libraries/LibJS/Bytecode/Builtins.h
+++ b/Userland/Libraries/LibJS/Bytecode/Builtins.h
@@ -15,6 +15,7 @@ namespace JS::Bytecode {
 #define JS_ENUMERATE_BUILTINS(O)       \
     O(MathAbs, math_abs, Math, abs, 1) \
     O(MathLog, math_log, Math, log, 1) \
+    O(MathPow, math_pow, Math, pow, 2) \
     O(MathSqrt, math_sqrt, Math, sqrt, 1)
 
 enum class Builtin {

--- a/Userland/Libraries/LibJS/Bytecode/Builtins.h
+++ b/Userland/Libraries/LibJS/Bytecode/Builtins.h
@@ -12,8 +12,9 @@
 namespace JS::Bytecode {
 
 // TitleCaseName, snake_case_name, base, property, argument_count
-#define JS_ENUMERATE_BUILTINS(O) \
-    O(MathAbs, math_abs, Math, abs, 1)
+#define JS_ENUMERATE_BUILTINS(O)       \
+    O(MathAbs, math_abs, Math, abs, 1) \
+    O(MathLog, math_log, Math, log, 1)
 
 enum class Builtin {
 #define DEFINE_BUILTIN_ENUM(name, ...) name,

--- a/Userland/Libraries/LibJS/Bytecode/Builtins.h
+++ b/Userland/Libraries/LibJS/Bytecode/Builtins.h
@@ -16,6 +16,7 @@ namespace JS::Bytecode {
     O(MathAbs, math_abs, Math, abs, 1)       \
     O(MathLog, math_log, Math, log, 1)       \
     O(MathPow, math_pow, Math, pow, 2)       \
+    O(MathCeil, math_ceil, Math, ceil, 1)    \
     O(MathFloor, math_floor, Math, floor, 1) \
     O(MathSqrt, math_sqrt, Math, sqrt, 1)
 

--- a/Userland/Libraries/LibJS/Bytecode/Builtins.h
+++ b/Userland/Libraries/LibJS/Bytecode/Builtins.h
@@ -16,6 +16,7 @@ namespace JS::Bytecode {
     O(MathAbs, math_abs, Math, abs, 1)       \
     O(MathLog, math_log, Math, log, 1)       \
     O(MathPow, math_pow, Math, pow, 2)       \
+    O(MathExp, math_exp, Math, exp, 1)       \
     O(MathCeil, math_ceil, Math, ceil, 1)    \
     O(MathFloor, math_floor, Math, floor, 1) \
     O(MathRound, math_round, Math, round, 1) \

--- a/Userland/Libraries/LibJS/Bytecode/Builtins.h
+++ b/Userland/Libraries/LibJS/Bytecode/Builtins.h
@@ -18,6 +18,7 @@ namespace JS::Bytecode {
     O(MathPow, math_pow, Math, pow, 2)       \
     O(MathCeil, math_ceil, Math, ceil, 1)    \
     O(MathFloor, math_floor, Math, floor, 1) \
+    O(MathRound, math_round, Math, round, 1) \
     O(MathSqrt, math_sqrt, Math, sqrt, 1)
 
 enum class Builtin {

--- a/Userland/Libraries/LibJS/JIT/Compiler.cpp
+++ b/Userland/Libraries/LibJS/JIT/Compiler.cpp
@@ -2702,6 +2702,19 @@ void Compiler::compile_builtin_math_round(Assembler::Label&, Assembler::Label& e
     m_assembler.jump(end);
 }
 
+static Value cxx_math_exp(VM& vm, Value, Value value)
+{
+    return TRY_OR_SET_EXCEPTION(MathObject::exp_impl(vm, value));
+}
+
+void Compiler::compile_builtin_math_exp(Assembler::Label&, Assembler::Label& end)
+{
+    native_call((void*)cxx_math_exp);
+    store_accumulator(RET);
+    check_exception();
+    m_assembler.jump(end);
+}
+
 void Compiler::compile_builtin_math_abs(Assembler::Label& slow_case, Assembler::Label& end)
 {
     branch_if_int32(ARG2, [&] {

--- a/Userland/Libraries/LibJS/JIT/Compiler.cpp
+++ b/Userland/Libraries/LibJS/JIT/Compiler.cpp
@@ -2650,6 +2650,19 @@ void Compiler::compile_builtin_math_sqrt(Assembler::Label&, Assembler::Label& en
     m_assembler.jump(end);
 }
 
+static Value cxx_math_pow(VM& vm, Value, Value base, Value exponent)
+{
+    return TRY_OR_SET_EXCEPTION(MathObject::pow_impl(vm, base, exponent));
+}
+
+void Compiler::compile_builtin_math_pow(Assembler::Label&, Assembler::Label& end)
+{
+    native_call((void*)cxx_math_pow);
+    store_accumulator(RET);
+    check_exception();
+    m_assembler.jump(end);
+}
+
 void Compiler::compile_builtin_math_abs(Assembler::Label& slow_case, Assembler::Label& end)
 {
     branch_if_int32(ARG2, [&] {

--- a/Userland/Libraries/LibJS/JIT/Compiler.cpp
+++ b/Userland/Libraries/LibJS/JIT/Compiler.cpp
@@ -2663,6 +2663,19 @@ void Compiler::compile_builtin_math_pow(Assembler::Label&, Assembler::Label& end
     m_assembler.jump(end);
 }
 
+static Value cxx_math_floor(VM& vm, Value, Value value)
+{
+    return TRY_OR_SET_EXCEPTION(MathObject::floor_impl(vm, value));
+}
+
+void Compiler::compile_builtin_math_floor(Assembler::Label&, Assembler::Label& end)
+{
+    native_call((void*)cxx_math_floor);
+    store_accumulator(RET);
+    check_exception();
+    m_assembler.jump(end);
+}
+
 void Compiler::compile_builtin_math_abs(Assembler::Label& slow_case, Assembler::Label& end)
 {
     branch_if_int32(ARG2, [&] {

--- a/Userland/Libraries/LibJS/JIT/Compiler.cpp
+++ b/Userland/Libraries/LibJS/JIT/Compiler.cpp
@@ -2637,6 +2637,19 @@ void Compiler::compile_builtin_math_log(Assembler::Label&, Assembler::Label& end
     m_assembler.jump(end);
 }
 
+static Value cxx_math_sqrt(VM& vm, Value, Value value)
+{
+    return TRY_OR_SET_EXCEPTION(MathObject::sqrt_impl(vm, value));
+}
+
+void Compiler::compile_builtin_math_sqrt(Assembler::Label&, Assembler::Label& end)
+{
+    native_call((void*)cxx_math_sqrt);
+    store_accumulator(RET);
+    check_exception();
+    m_assembler.jump(end);
+}
+
 void Compiler::compile_builtin_math_abs(Assembler::Label& slow_case, Assembler::Label& end)
 {
     branch_if_int32(ARG2, [&] {

--- a/Userland/Libraries/LibJS/JIT/Compiler.cpp
+++ b/Userland/Libraries/LibJS/JIT/Compiler.cpp
@@ -2689,6 +2689,19 @@ void Compiler::compile_builtin_math_ceil(Assembler::Label&, Assembler::Label& en
     m_assembler.jump(end);
 }
 
+static Value cxx_math_round(VM& vm, Value, Value value)
+{
+    return TRY_OR_SET_EXCEPTION(MathObject::round_impl(vm, value));
+}
+
+void Compiler::compile_builtin_math_round(Assembler::Label&, Assembler::Label& end)
+{
+    native_call((void*)cxx_math_round);
+    store_accumulator(RET);
+    check_exception();
+    m_assembler.jump(end);
+}
+
 void Compiler::compile_builtin_math_abs(Assembler::Label& slow_case, Assembler::Label& end)
 {
     branch_if_int32(ARG2, [&] {

--- a/Userland/Libraries/LibJS/JIT/Compiler.cpp
+++ b/Userland/Libraries/LibJS/JIT/Compiler.cpp
@@ -2676,6 +2676,19 @@ void Compiler::compile_builtin_math_floor(Assembler::Label&, Assembler::Label& e
     m_assembler.jump(end);
 }
 
+static Value cxx_math_ceil(VM& vm, Value, Value value)
+{
+    return TRY_OR_SET_EXCEPTION(MathObject::ceil_impl(vm, value));
+}
+
+void Compiler::compile_builtin_math_ceil(Assembler::Label&, Assembler::Label& end)
+{
+    native_call((void*)cxx_math_ceil);
+    store_accumulator(RET);
+    check_exception();
+    m_assembler.jump(end);
+}
+
 void Compiler::compile_builtin_math_abs(Assembler::Label& slow_case, Assembler::Label& end)
 {
     branch_if_int32(ARG2, [&] {

--- a/Userland/Libraries/LibJS/JIT/Compiler.cpp
+++ b/Userland/Libraries/LibJS/JIT/Compiler.cpp
@@ -18,6 +18,7 @@
 #include <LibJS/Runtime/ECMAScriptFunctionObject.h>
 #include <LibJS/Runtime/FunctionEnvironment.h>
 #include <LibJS/Runtime/GlobalEnvironment.h>
+#include <LibJS/Runtime/MathObject.h>
 #include <LibJS/Runtime/ObjectEnvironment.h>
 #include <LibJS/Runtime/VM.h>
 #include <LibJS/Runtime/ValueInlines.h>
@@ -2621,6 +2622,19 @@ void Compiler::compile_builtin(Bytecode::Builtin builtin, Assembler::Label& slow
     case Bytecode::Builtin::__Count:
         VERIFY_NOT_REACHED();
     }
+}
+
+static Value cxx_math_log(VM& vm, Value, Value value)
+{
+    return TRY_OR_SET_EXCEPTION(MathObject::log_impl(vm, value));
+}
+
+void Compiler::compile_builtin_math_log(Assembler::Label&, Assembler::Label& end)
+{
+    native_call((void*)cxx_math_log);
+    store_accumulator(RET);
+    check_exception();
+    m_assembler.jump(end);
 }
 
 void Compiler::compile_builtin_math_abs(Assembler::Label& slow_case, Assembler::Label& end)

--- a/Userland/Libraries/LibJS/Runtime/MathObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/MathObject.cpp
@@ -41,7 +41,7 @@ void MathObject::initialize(Realm& realm)
     define_native_function(realm, vm.names.sin, sin, 1, attr);
     define_native_function(realm, vm.names.cos, cos, 1, attr);
     define_native_function(realm, vm.names.tan, tan, 1, attr);
-    define_native_function(realm, vm.names.pow, pow, 2, attr);
+    define_native_function(realm, vm.names.pow, pow, 2, attr, Bytecode::Builtin::MathPow);
     define_native_function(realm, vm.names.exp, exp, 1, attr);
     define_native_function(realm, vm.names.expm1, expm1, 1, attr);
     define_native_function(realm, vm.names.sign, sign, 1, attr);
@@ -729,16 +729,22 @@ JS_DEFINE_NATIVE_FUNCTION(MathObject::min)
 }
 
 // 21.3.2.26 Math.pow ( base, exponent ), https://tc39.es/ecma262/#sec-math.pow
-JS_DEFINE_NATIVE_FUNCTION(MathObject::pow)
+ThrowCompletionOr<Value> MathObject::pow_impl(VM& vm, Value base, Value exponent)
 {
     // Set base to ? ToNumber(base).
-    auto base = TRY(vm.argument(0).to_number(vm));
+    base = TRY(base.to_number(vm));
 
     // 2. Set exponent to ? ToNumber(exponent).
-    auto exponent = TRY(vm.argument(1).to_number(vm));
+    exponent = TRY(exponent.to_number(vm));
 
     // 3. Return Number::exponentiate(base, exponent).
     return JS::exp(vm, base, exponent);
+}
+
+// 21.3.2.26 Math.pow ( base, exponent ), https://tc39.es/ecma262/#sec-math.pow
+JS_DEFINE_NATIVE_FUNCTION(MathObject::pow)
+{
+    return pow_impl(vm, vm.argument(0), vm.argument(1));
 }
 
 // 21.3.2.27 Math.random ( ), https://tc39.es/ecma262/#sec-math.random

--- a/Userland/Libraries/LibJS/Runtime/MathObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/MathObject.cpp
@@ -58,7 +58,7 @@ void MathObject::initialize(Realm& realm)
     define_native_function(realm, vm.names.fround, fround, 1, attr);
     define_native_function(realm, vm.names.hypot, hypot, 2, attr);
     define_native_function(realm, vm.names.imul, imul, 2, attr);
-    define_native_function(realm, vm.names.log, log, 1, attr);
+    define_native_function(realm, vm.names.log, log, 1, attr, Bytecode::Builtin::MathLog);
     define_native_function(realm, vm.names.log2, log2, 1, attr);
     define_native_function(realm, vm.names.log10, log10, 1, attr);
     define_native_function(realm, vm.names.sinh, sinh, 1, attr);
@@ -555,10 +555,10 @@ JS_DEFINE_NATIVE_FUNCTION(MathObject::imul)
 }
 
 // 21.3.2.20 Math.log ( x ), https://tc39.es/ecma262/#sec-math.log
-JS_DEFINE_NATIVE_FUNCTION(MathObject::log)
+ThrowCompletionOr<Value> MathObject::log_impl(VM& vm, Value x)
 {
     // 1. Let n be ? ToNumber(x).
-    auto number = TRY(vm.argument(0).to_number(vm));
+    auto number = TRY(x.to_number(vm));
 
     // 2. If n is NaN or n is +∞𝔽, return n.
     if (number.is_nan() || number.is_positive_infinity())
@@ -578,6 +578,12 @@ JS_DEFINE_NATIVE_FUNCTION(MathObject::log)
 
     // 6. Return an implementation-approximated Number value representing the result of the natural logarithm of ℝ(n).
     return Value(::log(number.as_double()));
+}
+
+// 21.3.2.20 Math.log ( x ), https://tc39.es/ecma262/#sec-math.log
+JS_DEFINE_NATIVE_FUNCTION(MathObject::log)
+{
+    return log_impl(vm, vm.argument(0));
 }
 
 // 21.3.2.21 Math.log1p ( x ), https://tc39.es/ecma262/#sec-math.log1p

--- a/Userland/Libraries/LibJS/Runtime/MathObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/MathObject.cpp
@@ -34,7 +34,7 @@ void MathObject::initialize(Realm& realm)
     define_native_function(realm, vm.names.sqrt, sqrt, 1, attr, Bytecode::Builtin::MathSqrt);
     define_native_function(realm, vm.names.floor, floor, 1, attr, Bytecode::Builtin::MathFloor);
     define_native_function(realm, vm.names.ceil, ceil, 1, attr, Bytecode::Builtin::MathCeil);
-    define_native_function(realm, vm.names.round, round, 1, attr);
+    define_native_function(realm, vm.names.round, round, 1, attr, Bytecode::Builtin::MathRound);
     define_native_function(realm, vm.names.max, max, 2, attr);
     define_native_function(realm, vm.names.min, min, 2, attr);
     define_native_function(realm, vm.names.trunc, trunc, 1, attr);
@@ -770,10 +770,10 @@ JS_DEFINE_NATIVE_FUNCTION(MathObject::random)
 }
 
 // 21.3.2.28 Math.round ( x ), https://tc39.es/ecma262/#sec-math.round
-JS_DEFINE_NATIVE_FUNCTION(MathObject::round)
+ThrowCompletionOr<Value> MathObject::round_impl(VM& vm, Value x)
 {
     // 1. Let n be ? ToNumber(x).
-    auto number = TRY(vm.argument(0).to_number(vm));
+    auto number = TRY(x.to_number(vm));
 
     // 2. If n is not finite or n is an integral Number, return n.
     if (!number.is_finite_number() || number.as_double() == ::trunc(number.as_double()))
@@ -786,6 +786,12 @@ JS_DEFINE_NATIVE_FUNCTION(MathObject::round)
     if (integer - 0.5 > number.as_double())
         integer--;
     return Value(integer);
+}
+
+// 21.3.2.28 Math.round ( x ), https://tc39.es/ecma262/#sec-math.round
+JS_DEFINE_NATIVE_FUNCTION(MathObject::round)
+{
+    return round_impl(vm, vm.argument(0));
 }
 
 // 21.3.2.29 Math.sign ( x ), https://tc39.es/ecma262/#sec-math.sign

--- a/Userland/Libraries/LibJS/Runtime/MathObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/MathObject.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2020-2023, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2020-2023, Linus Groh <linusg@serenityos.org>
  * Copyright (c) 2021, Idan Horowitz <idan.horowitz@serenityos.org>
  * Copyright (c) 2023, Shannon Booth <shannon@serenityos.org>
@@ -31,7 +31,7 @@ void MathObject::initialize(Realm& realm)
     u8 attr = Attribute::Writable | Attribute::Configurable;
     define_native_function(realm, vm.names.abs, abs, 1, attr, Bytecode::Builtin::MathAbs);
     define_native_function(realm, vm.names.random, random, 0, attr);
-    define_native_function(realm, vm.names.sqrt, sqrt, 1, attr);
+    define_native_function(realm, vm.names.sqrt, sqrt, 1, attr, Bytecode::Builtin::MathSqrt);
     define_native_function(realm, vm.names.floor, floor, 1, attr);
     define_native_function(realm, vm.names.ceil, ceil, 1, attr);
     define_native_function(realm, vm.names.round, round, 1, attr);
@@ -821,10 +821,10 @@ JS_DEFINE_NATIVE_FUNCTION(MathObject::sinh)
 }
 
 // 21.3.2.32 Math.sqrt ( x ), https://tc39.es/ecma262/#sec-math.sqrt
-JS_DEFINE_NATIVE_FUNCTION(MathObject::sqrt)
+ThrowCompletionOr<Value> MathObject::sqrt_impl(VM& vm, Value x)
 {
     // Let n be ? ToNumber(x).
-    auto number = TRY(vm.argument(0).to_number(vm));
+    auto number = TRY(x.to_number(vm));
 
     // 2. If n is one of NaN, +0𝔽, -0𝔽, or +∞𝔽, return n.
     if (number.is_nan() || number.as_double() == 0 || number.is_positive_infinity())
@@ -836,6 +836,12 @@ JS_DEFINE_NATIVE_FUNCTION(MathObject::sqrt)
 
     // 4. Return an implementation-approximated Number value representing the result of the square root of ℝ(n).
     return Value(::sqrt(number.as_double()));
+}
+
+// 21.3.2.32 Math.sqrt ( x ), https://tc39.es/ecma262/#sec-math.sqrt
+JS_DEFINE_NATIVE_FUNCTION(MathObject::sqrt)
+{
+    return sqrt_impl(vm, vm.argument(0));
 }
 
 // 21.3.2.33 Math.tan ( x ), https://tc39.es/ecma262/#sec-math.tan

--- a/Userland/Libraries/LibJS/Runtime/MathObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/MathObject.cpp
@@ -32,7 +32,7 @@ void MathObject::initialize(Realm& realm)
     define_native_function(realm, vm.names.abs, abs, 1, attr, Bytecode::Builtin::MathAbs);
     define_native_function(realm, vm.names.random, random, 0, attr);
     define_native_function(realm, vm.names.sqrt, sqrt, 1, attr, Bytecode::Builtin::MathSqrt);
-    define_native_function(realm, vm.names.floor, floor, 1, attr);
+    define_native_function(realm, vm.names.floor, floor, 1, attr, Bytecode::Builtin::MathFloor);
     define_native_function(realm, vm.names.ceil, ceil, 1, attr);
     define_native_function(realm, vm.names.round, round, 1, attr);
     define_native_function(realm, vm.names.max, max, 2, attr);
@@ -456,10 +456,10 @@ JS_DEFINE_NATIVE_FUNCTION(MathObject::expm1)
 }
 
 // 21.3.2.16 Math.floor ( x ), https://tc39.es/ecma262/#sec-math.floor
-JS_DEFINE_NATIVE_FUNCTION(MathObject::floor)
+ThrowCompletionOr<Value> MathObject::floor_impl(VM& vm, Value x)
 {
     // 1. Let n be ? ToNumber(x).
-    auto number = TRY(vm.argument(0).to_number(vm));
+    auto number = TRY(x.to_number(vm));
 
     // 2. If n is not finite or n is either +0𝔽 or -0𝔽, return n.
     if (!number.is_finite_number() || number.as_double() == 0)
@@ -469,6 +469,12 @@ JS_DEFINE_NATIVE_FUNCTION(MathObject::floor)
     // 4. If n is an integral Number, return n.
     // 5. Return the greatest (closest to +∞) integral Number value that is not greater than n.
     return Value(::floor(number.as_double()));
+}
+
+// 21.3.2.16 Math.floor ( x ), https://tc39.es/ecma262/#sec-math.floor
+JS_DEFINE_NATIVE_FUNCTION(MathObject::floor)
+{
+    return floor_impl(vm, vm.argument(0));
 }
 
 // 21.3.2.17 Math.fround ( x ), https://tc39.es/ecma262/#sec-math.fround

--- a/Userland/Libraries/LibJS/Runtime/MathObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/MathObject.cpp
@@ -42,7 +42,7 @@ void MathObject::initialize(Realm& realm)
     define_native_function(realm, vm.names.cos, cos, 1, attr);
     define_native_function(realm, vm.names.tan, tan, 1, attr);
     define_native_function(realm, vm.names.pow, pow, 2, attr, Bytecode::Builtin::MathPow);
-    define_native_function(realm, vm.names.exp, exp, 1, attr);
+    define_native_function(realm, vm.names.exp, exp, 1, attr, Bytecode::Builtin::MathExp);
     define_native_function(realm, vm.names.expm1, expm1, 1, attr);
     define_native_function(realm, vm.names.sign, sign, 1, attr);
     define_native_function(realm, vm.names.clz32, clz32, 1, attr);
@@ -422,10 +422,10 @@ JS_DEFINE_NATIVE_FUNCTION(MathObject::cosh)
 }
 
 // 21.3.2.14 Math.exp ( x ), https://tc39.es/ecma262/#sec-math.exp
-JS_DEFINE_NATIVE_FUNCTION(MathObject::exp)
+ThrowCompletionOr<Value> MathObject::exp_impl(VM& vm, Value x)
 {
     // 1. Let n be ? ToNumber(x).
-    auto number = TRY(vm.argument(0).to_number(vm));
+    auto number = TRY(x.to_number(vm));
 
     // 2. If n is either NaN or +∞𝔽, return n.
     if (number.is_nan() || number.is_positive_infinity())
@@ -441,6 +441,12 @@ JS_DEFINE_NATIVE_FUNCTION(MathObject::exp)
 
     // 5. Return an implementation-approximated Number value representing the result of the exponential function of ℝ(n).
     return Value(::exp(number.as_double()));
+}
+
+// 21.3.2.14 Math.exp ( x ), https://tc39.es/ecma262/#sec-math.exp
+JS_DEFINE_NATIVE_FUNCTION(MathObject::exp)
+{
+    return exp_impl(vm, vm.argument(0));
 }
 
 // 21.3.2.15 Math.expm1 ( x ), https://tc39.es/ecma262/#sec-math.expm1

--- a/Userland/Libraries/LibJS/Runtime/MathObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/MathObject.cpp
@@ -33,7 +33,7 @@ void MathObject::initialize(Realm& realm)
     define_native_function(realm, vm.names.random, random, 0, attr);
     define_native_function(realm, vm.names.sqrt, sqrt, 1, attr, Bytecode::Builtin::MathSqrt);
     define_native_function(realm, vm.names.floor, floor, 1, attr, Bytecode::Builtin::MathFloor);
-    define_native_function(realm, vm.names.ceil, ceil, 1, attr);
+    define_native_function(realm, vm.names.ceil, ceil, 1, attr, Bytecode::Builtin::MathCeil);
     define_native_function(realm, vm.names.round, round, 1, attr);
     define_native_function(realm, vm.names.max, max, 2, attr);
     define_native_function(realm, vm.names.min, min, 2, attr);
@@ -346,10 +346,10 @@ JS_DEFINE_NATIVE_FUNCTION(MathObject::cbrt)
 }
 
 // 21.3.2.10 Math.ceil ( x ), https://tc39.es/ecma262/#sec-math.ceil
-JS_DEFINE_NATIVE_FUNCTION(MathObject::ceil)
+ThrowCompletionOr<Value> MathObject::ceil_impl(VM& vm, Value x)
 {
     // 1. Let n be ? ToNumber(x).
-    auto number = TRY(vm.argument(0).to_number(vm));
+    auto number = TRY(x.to_number(vm));
 
     // 2. If n is not finite or n is either +0𝔽 or -0𝔽, return n.
     if (!number.is_finite_number() || number.as_double() == 0)
@@ -362,6 +362,12 @@ JS_DEFINE_NATIVE_FUNCTION(MathObject::ceil)
     // 4. If n is an integral Number, return n.
     // 5. Return the smallest (closest to -∞) integral Number value that is not less than n.
     return Value(::ceil(number.as_double()));
+}
+
+// 21.3.2.10 Math.ceil ( x ), https://tc39.es/ecma262/#sec-math.ceil
+JS_DEFINE_NATIVE_FUNCTION(MathObject::ceil)
+{
+    return ceil_impl(vm, vm.argument(0));
 }
 
 // 21.3.2.11 Math.clz32 ( x ), https://tc39.es/ecma262/#sec-math.clz32

--- a/Userland/Libraries/LibJS/Runtime/MathObject.h
+++ b/Userland/Libraries/LibJS/Runtime/MathObject.h
@@ -21,6 +21,7 @@ public:
     static ThrowCompletionOr<Value> log_impl(VM&, Value);
     static ThrowCompletionOr<Value> sqrt_impl(VM&, Value);
     static ThrowCompletionOr<Value> pow_impl(VM&, Value base, Value exponent);
+    static ThrowCompletionOr<Value> floor_impl(VM&, Value);
 
 private:
     explicit MathObject(Realm&);

--- a/Userland/Libraries/LibJS/Runtime/MathObject.h
+++ b/Userland/Libraries/LibJS/Runtime/MathObject.h
@@ -22,6 +22,7 @@ public:
     static ThrowCompletionOr<Value> sqrt_impl(VM&, Value);
     static ThrowCompletionOr<Value> pow_impl(VM&, Value base, Value exponent);
     static ThrowCompletionOr<Value> floor_impl(VM&, Value);
+    static ThrowCompletionOr<Value> ceil_impl(VM&, Value);
 
 private:
     explicit MathObject(Realm&);

--- a/Userland/Libraries/LibJS/Runtime/MathObject.h
+++ b/Userland/Libraries/LibJS/Runtime/MathObject.h
@@ -23,6 +23,7 @@ public:
     static ThrowCompletionOr<Value> pow_impl(VM&, Value base, Value exponent);
     static ThrowCompletionOr<Value> floor_impl(VM&, Value);
     static ThrowCompletionOr<Value> ceil_impl(VM&, Value);
+    static ThrowCompletionOr<Value> round_impl(VM&, Value);
 
 private:
     explicit MathObject(Realm&);

--- a/Userland/Libraries/LibJS/Runtime/MathObject.h
+++ b/Userland/Libraries/LibJS/Runtime/MathObject.h
@@ -20,6 +20,7 @@ public:
 
     static ThrowCompletionOr<Value> log_impl(VM&, Value);
     static ThrowCompletionOr<Value> sqrt_impl(VM&, Value);
+    static ThrowCompletionOr<Value> pow_impl(VM&, Value base, Value exponent);
 
 private:
     explicit MathObject(Realm&);

--- a/Userland/Libraries/LibJS/Runtime/MathObject.h
+++ b/Userland/Libraries/LibJS/Runtime/MathObject.h
@@ -18,6 +18,8 @@ public:
     virtual void initialize(Realm&) override;
     virtual ~MathObject() override = default;
 
+    static ThrowCompletionOr<Value> log_impl(VM&, Value);
+
 private:
     explicit MathObject(Realm&);
 

--- a/Userland/Libraries/LibJS/Runtime/MathObject.h
+++ b/Userland/Libraries/LibJS/Runtime/MathObject.h
@@ -24,6 +24,7 @@ public:
     static ThrowCompletionOr<Value> floor_impl(VM&, Value);
     static ThrowCompletionOr<Value> ceil_impl(VM&, Value);
     static ThrowCompletionOr<Value> round_impl(VM&, Value);
+    static ThrowCompletionOr<Value> exp_impl(VM&, Value);
 
 private:
     explicit MathObject(Realm&);

--- a/Userland/Libraries/LibJS/Runtime/MathObject.h
+++ b/Userland/Libraries/LibJS/Runtime/MathObject.h
@@ -19,6 +19,7 @@ public:
     virtual ~MathObject() override = default;
 
     static ThrowCompletionOr<Value> log_impl(VM&, Value);
+    static ThrowCompletionOr<Value> sqrt_impl(VM&, Value);
 
 private:
     explicit MathObject(Realm&);


### PR DESCRIPTION
Note that none of the builtins being added here have machine code fast paths (yet).
We still gain a nice improvement simply by avoiding the heavy function call setup (ExecutionContext, etc)
2.917x on Kraken/audio-oscillator.js is notable :smile:

```
Suite       Test                                   Speedup  Old (Mean ± Range)           New (Mean ± Range)
----------  -----------------------------------  ---------  ---------------------------  ---------------------------
Kraken      ai-astar.js                              1.012  0.860 ± 0.860 … 0.860        0.850 ± 0.850 … 0.850
Kraken      audio-beat-detection.js                  1.045  0.465 ± 0.460 … 0.470        0.445 ± 0.440 … 0.450
Kraken      audio-dft.js                             1      0.345 ± 0.340 … 0.350        0.345 ± 0.340 … 0.350
Kraken      audio-fft.js                             1.062  0.345 ± 0.340 … 0.350        0.325 ± 0.320 … 0.330
Kraken      audio-oscillator.js                      2.917  1.050 ± 1.050 … 1.050        0.360 ± 0.360 … 0.360
Kraken      imaging-darkroom.js                      1.139  3.155 ± 3.060 … 3.250        2.770 ± 2.760 … 2.780
Kraken      imaging-desaturate.js                    1.023  0.670 ± 0.670 … 0.670        0.655 ± 0.650 … 0.660
Kraken      imaging-gaussian-blur.js                 1.021  2.725 ± 2.720 … 2.730        2.670 ± 2.650 … 2.690
Kraken      json-parse-financial.js                  1      0.070 ± 0.070 … 0.070        0.070 ± 0.070 … 0.070
Kraken      json-stringify-tinderbox.js              1.05   0.210 ± 0.210 … 0.210        0.200 ± 0.200 … 0.200
Kraken      stanford-crypto-aes.js                   1.029  0.530 ± 0.530 … 0.530        0.515 ± 0.510 … 0.520
Kraken      stanford-crypto-ccm.js                   1      0.560 ± 0.560 … 0.560        0.560 ± 0.550 … 0.570
Kraken      stanford-crypto-pbkdf2.js                1      0.925 ± 0.920 … 0.930        0.925 ± 0.920 … 0.930
Kraken      stanford-crypto-sha256-iterative.js      0.975  0.390 ± 0.390 … 0.390        0.400 ± 0.400 … 0.400
Octane      box2d.js                                 0.986  2.490 ± 2.490 … 2.490        2.525 ± 2.500 … 2.550
Octane      code-load.js                             0.995  2.105 ± 2.100 … 2.110        2.115 ± 2.110 … 2.120
Octane      crypto.js                                1.004  5.085 ± 5.060 … 5.110        5.065 ± 5.060 … 5.070
Octane      deltablue.js                             1.007  3.060 ± 3.060 … 3.060        3.040 ± 3.020 … 3.060
Octane      earley-boyer.js                          1.019  21.810 ± 21.780 … 21.840     21.405 ± 21.280 … 21.530
Octane      gbemu.js                                 1.009  4.870 ± 4.850 … 4.890        4.825 ± 4.810 … 4.840
Octane      mandreel.js                              1.042  25.635 ± 25.250 … 26.020     24.595 ± 24.410 … 24.780
Octane      navier-stokes.js                         1.002  2.030 ± 2.020 … 2.040        2.025 ± 2.020 … 2.030
Octane      pdfjs.js                                 1.012  3.285 ± 3.280 … 3.290        3.245 ± 3.240 … 3.250
Octane      raytrace.js                              1.022  7.590 ± 7.530 … 7.650        7.425 ± 7.400 … 7.450
Octane      regexp.js                                1.021  24.360 ± 24.350 … 24.370     23.850 ± 23.640 … 24.060
Octane      richards.js                              0.998  2.010 ± 2.010 … 2.010        2.015 ± 2.010 … 2.020
Octane      splay.js                                 1.002  3.110 ± 3.110 … 3.110        3.105 ± 3.080 … 3.130
Octane      typescript.js                            1.031  49.325 ± 48.200 … 50.450     47.850 ± 47.200 … 48.500
Octane      zlib.js                                  1.008  104.045 ± 103.860 … 104.230  103.180 ± 102.130 … 104.230
Kraken      Total                                    1.109  12.300                       11.090
Octane      Total                                    1.018  260.810                      256.265
All Suites  Total                                    1.022  273.110                      267.355
```