### PR TITLE
Ladybird/AppKit: Invert the horizontal delta scroll value 

### DIFF
--- a/Ladybird/AppKit/UI/LadybirdWebView.mm
+++ b/Ladybird/AppKit/UI/LadybirdWebView.mm
@@ -1099,7 +1099,7 @@ static void copy_data_to_clipboard(StringView data, NSPasteboardType pasteboard_
 - (void)scrollWheel:(NSEvent*)event
 {
     auto [position, screen_position, button, modifiers] = Ladybird::ns_event_to_mouse_event(event, self, GUI::MouseButton::Middle);
-    CGFloat delta_x = [event scrollingDeltaX];
+    CGFloat delta_x = -[event scrollingDeltaX];
     CGFloat delta_y = -[event scrollingDeltaY];
     if (![event hasPreciseScrollingDeltas]) {
         delta_x *= [self scrollView].horizontalLineScroll;

--- a/Meta/gn/build/BUILD.gn
+++ b/Meta/gn/build/BUILD.gn
@@ -126,6 +126,8 @@ config("compiler_defaults") {
     ]
   }
 
+  cflags += [ "-Wno-invalid-offsetof" ]
+
   if (use_lld) {
     ldflags += [ "-fuse-ld=lld" ]
   }

--- a/Meta/gn/secondary/Userland/Libraries/LibWeb/WebIDL/BUILD.gn
+++ b/Meta/gn/secondary/Userland/Libraries/LibWeb/WebIDL/BUILD.gn
@@ -3,6 +3,7 @@ source_set("WebIDL") {
   deps = [ "//Userland/Libraries/LibWeb:all_generated" ]
   sources = [
     "AbstractOperations.cpp",
+    "Buffers.cpp",
     "CallbackType.cpp",
     "DOMException.cpp",
     "OverloadResolution.cpp",


### PR DESCRIPTION
This matches the negation of the vertical scroll delta value. This makes
the scroll events behave as follows on macOS:

Natural scrolling enabled:
* Scrolling up on the trackpad scrolls down on the page.
* Scrolling right on the trackpad scrolls left on the page.

Natural scrolling disabled:
* Scrolling up on the trackpad scrolls up on the page.
* Scrolling right on the trackpad scrolls right on the page.

Fixes #21749