### PR TITLE
LibAccelGfx+LibWeb: Add texture cache for immutable bitmaps

### DIFF
--- a/Userland/Libraries/LibAccelGfx/Painter.h
+++ b/Userland/Libraries/LibAccelGfx/Painter.h
@@ -57,6 +57,9 @@ public:
     void draw_scaled_bitmap(Gfx::FloatRect const& dst_rect, Gfx::Bitmap const&, Gfx::FloatRect const& src_rect, ScalingMode = ScalingMode::NearestNeighbor);
     void draw_scaled_bitmap(Gfx::IntRect const& dst_rect, Gfx::Bitmap const&, Gfx::IntRect const& src_rect, ScalingMode = ScalingMode::NearestNeighbor);
 
+    void draw_scaled_immutable_bitmap(Gfx::IntRect const& dst_rect, Gfx::ImmutableBitmap const&, Gfx::IntRect const& src_rect, ScalingMode = ScalingMode::NearestNeighbor);
+    void draw_scaled_immutable_bitmap(Gfx::FloatRect const& dst_rect, Gfx::ImmutableBitmap const&, Gfx::FloatRect const& src_rect, ScalingMode = ScalingMode::NearestNeighbor);
+
     void prepare_glyph_texture(HashMap<Gfx::Font const*, HashTable<u32>> const& unique_glyphs);
 
     struct GlyphsTextureKey {
@@ -89,6 +92,8 @@ public:
 
     void blit_canvas(Gfx::IntRect const& dst_rect, Canvas const&, float opacity = 1.0f);
     void blit_canvas(Gfx::FloatRect const& dst_rect, Canvas const&, float opacity = 1.0f);
+
+    void update_immutable_bitmap_texture_cache(HashMap<u32, Gfx::ImmutableBitmap const*>&);
 
 private:
     Context& m_context;

--- a/Userland/Libraries/LibGfx/CMakeLists.txt
+++ b/Userland/Libraries/LibGfx/CMakeLists.txt
@@ -60,6 +60,7 @@ set(SOURCES
     ImageFormats/WebPLoader.cpp
     ImageFormats/WebPLoaderLossless.cpp
     ImageFormats/WebPLoaderLossy.cpp
+    ImmutableBitmap.cpp
     Painter.cpp
     Palette.cpp
     Path.cpp

--- a/Userland/Libraries/LibGfx/Forward.h
+++ b/Userland/Libraries/LibGfx/Forward.h
@@ -9,6 +9,7 @@
 namespace Gfx {
 
 class Bitmap;
+class ImmutableBitmap;
 class CharacterBitmap;
 class Color;
 

--- a/Userland/Libraries/LibGfx/ImmutableBitmap.cpp
+++ b/Userland/Libraries/LibGfx/ImmutableBitmap.cpp
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2023, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibGfx/ImmutableBitmap.h>
+
+namespace Gfx {
+
+static size_t s_next_immutable_bitmap_id = 0;
+
+NonnullRefPtr<ImmutableBitmap> ImmutableBitmap::create(NonnullRefPtr<Bitmap> bitmap)
+{
+    return adopt_ref(*new ImmutableBitmap(move(bitmap)));
+}
+
+ImmutableBitmap::ImmutableBitmap(NonnullRefPtr<Bitmap> bitmap)
+    : m_bitmap(move(bitmap))
+    , m_id(s_next_immutable_bitmap_id++)
+{
+}
+
+}

--- a/Userland/Libraries/LibGfx/ImmutableBitmap.h
+++ b/Userland/Libraries/LibGfx/ImmutableBitmap.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2023, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Forward.h>
+#include <AK/RefCounted.h>
+#include <LibGfx/Bitmap.h>
+#include <LibGfx/Forward.h>
+#include <LibGfx/Rect.h>
+
+namespace Gfx {
+
+class ImmutableBitmap final : public RefCounted<ImmutableBitmap> {
+public:
+    static NonnullRefPtr<ImmutableBitmap> create(NonnullRefPtr<Bitmap> bitmap);
+
+    ~ImmutableBitmap() = default;
+
+    Bitmap const& bitmap() const { return *m_bitmap; }
+
+    size_t width() const { return m_bitmap->width(); }
+    size_t height() const { return m_bitmap->height(); }
+
+    IntRect rect() const { return m_bitmap->rect(); }
+    IntSize size() const { return m_bitmap->size(); }
+
+    size_t id() const { return m_id; }
+
+private:
+    NonnullRefPtr<Bitmap> m_bitmap;
+    size_t m_id;
+
+    explicit ImmutableBitmap(NonnullRefPtr<Bitmap> bitmap);
+};
+
+}

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.cpp
@@ -91,7 +91,7 @@ bool ImageStyleValue::is_paintable() const
     return image_data();
 }
 
-Gfx::Bitmap const* ImageStyleValue::bitmap(size_t frame_index, Gfx::IntSize size) const
+Gfx::ImmutableBitmap const* ImageStyleValue::bitmap(size_t frame_index, Gfx::IntSize size) const
 {
     if (auto image_data = this->image_data())
         return image_data->bitmap(frame_index, size);
@@ -128,7 +128,7 @@ void ImageStyleValue::paint(PaintContext& context, DevicePixelRect const& dest_r
 {
     if (auto const* b = bitmap(m_current_frame_index, dest_rect.size().to_type<int>()); b != nullptr) {
         auto scaling_mode = to_gfx_scaling_mode(image_rendering, b->rect(), dest_rect.to_type<int>());
-        context.painter().draw_scaled_bitmap(dest_rect.to_type<int>(), *b, b->rect(), scaling_mode);
+        context.painter().draw_scaled_immutable_bitmap(dest_rect.to_type<int>(), *b, b->rect(), scaling_mode);
     }
 }
 

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.h
@@ -56,7 +56,7 @@ private:
     JS::GCPtr<HTML::SharedImageRequest> m_image_request;
 
     void animate();
-    Gfx::Bitmap const* bitmap(size_t frame_index, Gfx::IntSize = {}) const;
+    Gfx::ImmutableBitmap const* bitmap(size_t frame_index, Gfx::IntSize = {}) const;
 
     AK::URL m_url;
     WeakPtr<DOM::Document> m_document;

--- a/Userland/Libraries/LibWeb/HTML/AnimatedBitmapDecodedImageData.cpp
+++ b/Userland/Libraries/LibWeb/HTML/AnimatedBitmapDecodedImageData.cpp
@@ -23,7 +23,7 @@ AnimatedBitmapDecodedImageData::AnimatedBitmapDecodedImageData(Vector<Frame>&& f
 
 AnimatedBitmapDecodedImageData::~AnimatedBitmapDecodedImageData() = default;
 
-RefPtr<Gfx::Bitmap const> AnimatedBitmapDecodedImageData::bitmap(size_t frame_index, Gfx::IntSize) const
+RefPtr<Gfx::ImmutableBitmap> AnimatedBitmapDecodedImageData::bitmap(size_t frame_index, Gfx::IntSize) const
 {
     if (frame_index >= m_frames.size())
         return nullptr;

--- a/Userland/Libraries/LibWeb/HTML/AnimatedBitmapDecodedImageData.h
+++ b/Userland/Libraries/LibWeb/HTML/AnimatedBitmapDecodedImageData.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <LibGfx/ImmutableBitmap.h>
 #include <LibWeb/HTML/DecodedImageData.h>
 
 namespace Web::HTML {
@@ -13,14 +14,14 @@ namespace Web::HTML {
 class AnimatedBitmapDecodedImageData final : public DecodedImageData {
 public:
     struct Frame {
-        RefPtr<Gfx::Bitmap const> bitmap;
+        RefPtr<Gfx::ImmutableBitmap> bitmap;
         int duration { 0 };
     };
 
     static ErrorOr<NonnullRefPtr<AnimatedBitmapDecodedImageData>> create(Vector<Frame>&&, size_t loop_count, bool animated);
     virtual ~AnimatedBitmapDecodedImageData() override;
 
-    virtual RefPtr<Gfx::Bitmap const> bitmap(size_t frame_index, Gfx::IntSize = {}) const override;
+    virtual RefPtr<Gfx::ImmutableBitmap> bitmap(size_t frame_index, Gfx::IntSize = {}) const override;
     virtual int frame_duration(size_t frame_index) const override;
 
     virtual size_t frame_count() const override { return m_frames.size(); }

--- a/Userland/Libraries/LibWeb/HTML/DecodedImageData.h
+++ b/Userland/Libraries/LibWeb/HTML/DecodedImageData.h
@@ -18,7 +18,7 @@ class DecodedImageData : public RefCounted<DecodedImageData> {
 public:
     virtual ~DecodedImageData();
 
-    virtual RefPtr<Gfx::Bitmap const> bitmap(size_t frame_index, Gfx::IntSize = {}) const = 0;
+    virtual RefPtr<Gfx::ImmutableBitmap> bitmap(size_t frame_index, Gfx::IntSize = {}) const = 0;
     virtual int frame_duration(size_t frame_index) const = 0;
 
     virtual size_t frame_count() const = 0;

--- a/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -120,7 +120,7 @@ JS::GCPtr<Layout::Node> HTMLImageElement::create_layout_node(NonnullRefPtr<CSS::
     return heap().allocate_without_realm<Layout::ImageBox>(document(), *this, move(style), *this);
 }
 
-RefPtr<Gfx::Bitmap const> HTMLImageElement::bitmap() const
+RefPtr<Gfx::ImmutableBitmap> HTMLImageElement::immutable_bitmap() const
 {
     return current_image_bitmap();
 }
@@ -146,7 +146,7 @@ Optional<CSSPixelFraction> HTMLImageElement::intrinsic_aspect_ratio() const
     return {};
 }
 
-RefPtr<Gfx::Bitmap const> HTMLImageElement::current_image_bitmap(Gfx::IntSize size) const
+RefPtr<Gfx::ImmutableBitmap> HTMLImageElement::current_image_bitmap(Gfx::IntSize size) const
 {
     if (auto data = m_current_request->image_data())
         return data->bitmap(m_current_frame_index, size);

--- a/Userland/Libraries/LibWeb/HTML/HTMLImageElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLImageElement.h
@@ -9,6 +9,7 @@
 #include <AK/ByteBuffer.h>
 #include <AK/OwnPtr.h>
 #include <LibGfx/Forward.h>
+#include <LibGfx/ImmutableBitmap.h>
 #include <LibJS/Heap/HeapFunction.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/DocumentLoadEventDelayer.h>
@@ -38,7 +39,8 @@ public:
     DeprecatedString alt() const { return deprecated_attribute(HTML::AttributeNames::alt); }
     DeprecatedString src() const { return deprecated_attribute(HTML::AttributeNames::src); }
 
-    RefPtr<Gfx::Bitmap const> bitmap() const;
+    RefPtr<Gfx::ImmutableBitmap> immutable_bitmap() const;
+    RefPtr<Gfx::Bitmap const> bitmap() const { return immutable_bitmap()->bitmap(); }
 
     unsigned width() const;
     WebIDL::ExceptionOr<void> set_width(unsigned);
@@ -89,7 +91,7 @@ public:
     virtual Optional<CSSPixels> intrinsic_width() const override;
     virtual Optional<CSSPixels> intrinsic_height() const override;
     virtual Optional<CSSPixelFraction> intrinsic_aspect_ratio() const override;
-    virtual RefPtr<Gfx::Bitmap const> current_image_bitmap(Gfx::IntSize = {}) const override;
+    virtual RefPtr<Gfx::ImmutableBitmap> current_image_bitmap(Gfx::IntSize = {}) const override;
     virtual void set_visible_in_viewport(bool) override;
 
     void set_lazy_load_resumption_steps(Function<void()>);

--- a/Userland/Libraries/LibWeb/HTML/HTMLObjectElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLObjectElement.cpp
@@ -382,7 +382,7 @@ Optional<CSSPixelFraction> HTMLObjectElement::intrinsic_aspect_ratio() const
     return {};
 }
 
-RefPtr<Gfx::Bitmap const> HTMLObjectElement::current_image_bitmap(Gfx::IntSize size) const
+RefPtr<Gfx::ImmutableBitmap> HTMLObjectElement::current_image_bitmap(Gfx::IntSize size) const
 {
     if (auto image_data = this->image_data())
         return image_data->bitmap(0, size);

--- a/Userland/Libraries/LibWeb/HTML/HTMLObjectElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLObjectElement.h
@@ -76,7 +76,7 @@ private:
     virtual Optional<CSSPixels> intrinsic_width() const override;
     virtual Optional<CSSPixels> intrinsic_height() const override;
     virtual Optional<CSSPixelFraction> intrinsic_aspect_ratio() const override;
-    virtual RefPtr<Gfx::Bitmap const> current_image_bitmap(Gfx::IntSize = {}) const override;
+    virtual RefPtr<Gfx::ImmutableBitmap> current_image_bitmap(Gfx::IntSize = {}) const override;
     virtual void set_visible_in_viewport(bool) override;
 
     Representation m_representation { Representation::Unknown };

--- a/Userland/Libraries/LibWeb/HTML/SharedImageRequest.cpp
+++ b/Userland/Libraries/LibWeb/HTML/SharedImageRequest.cpp
@@ -159,7 +159,7 @@ void SharedImageRequest::handle_successful_fetch(AK::URL const& url_string, Stri
         Vector<AnimatedBitmapDecodedImageData::Frame> frames;
         for (auto& frame : result.value().frames) {
             frames.append(AnimatedBitmapDecodedImageData::Frame {
-                .bitmap = frame.bitmap,
+                .bitmap = Gfx::ImmutableBitmap::create(*frame.bitmap),
                 .duration = static_cast<int>(frame.duration),
             });
         }

--- a/Userland/Libraries/LibWeb/Layout/ImageProvider.h
+++ b/Userland/Libraries/LibWeb/Layout/ImageProvider.h
@@ -19,7 +19,7 @@ public:
     virtual Optional<CSSPixels> intrinsic_height() const = 0;
     virtual Optional<CSSPixelFraction> intrinsic_aspect_ratio() const = 0;
 
-    virtual RefPtr<Gfx::Bitmap const> current_image_bitmap(Gfx::IntSize) const = 0;
+    virtual RefPtr<Gfx::ImmutableBitmap> current_image_bitmap(Gfx::IntSize) const = 0;
     virtual void set_visible_in_viewport(bool) = 0;
 };
 

--- a/Userland/Libraries/LibWeb/Painting/ImagePaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/ImagePaintable.cpp
@@ -175,7 +175,7 @@ void ImagePaintable::paint(PaintContext& context, PaintPhase phase) const
                 (int)scaled_bitmap_height
             };
 
-            context.painter().draw_scaled_bitmap(draw_rect.intersected(image_int_rect), *bitmap, bitmap_rect.intersected(bitmap_intersect), scaling_mode);
+            context.painter().draw_scaled_immutable_bitmap(draw_rect.intersected(image_int_rect), *bitmap, bitmap_rect.intersected(bitmap_intersect), scaling_mode);
         }
     }
 }

--- a/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorCPU.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorCPU.cpp
@@ -64,6 +64,13 @@ CommandResult PaintingCommandExecutorCPU::draw_scaled_bitmap(Gfx::IntRect const&
     return CommandResult::Continue;
 }
 
+CommandResult PaintingCommandExecutorCPU::draw_scaled_immutable_bitmap(Gfx::IntRect const& dst_rect, Gfx::ImmutableBitmap const& immutable_bitmap, Gfx::IntRect const& src_rect, Gfx::Painter::ScalingMode scaling_mode)
+{
+    auto& painter = this->painter();
+    painter.draw_scaled_bitmap(dst_rect, immutable_bitmap.bitmap(), src_rect, 1, scaling_mode);
+    return CommandResult::Continue;
+}
+
 CommandResult PaintingCommandExecutorCPU::set_clip_rect(Gfx::IntRect const& rect)
 {
     auto& painter = this->painter();

--- a/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorCPU.h
+++ b/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorCPU.h
@@ -17,6 +17,7 @@ public:
     CommandResult draw_text(Gfx::IntRect const& rect, String const& raw_text, Gfx::TextAlignment alignment, Color const&, Gfx::TextElision, Gfx::TextWrapping, Optional<NonnullRefPtr<Gfx::Font>> const&) override;
     CommandResult fill_rect(Gfx::IntRect const& rect, Color const&) override;
     CommandResult draw_scaled_bitmap(Gfx::IntRect const& dst_rect, Gfx::Bitmap const& bitmap, Gfx::IntRect const& src_rect, Gfx::Painter::ScalingMode scaling_mode) override;
+    CommandResult draw_scaled_immutable_bitmap(Gfx::IntRect const& dst_rect, Gfx::ImmutableBitmap const&, Gfx::IntRect const& src_rect, Gfx::Painter::ScalingMode scaling_mode) override;
     CommandResult set_clip_rect(Gfx::IntRect const& rect) override;
     CommandResult clear_clip_rect() override;
     CommandResult set_font(Gfx::Font const&) override;

--- a/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorCPU.h
+++ b/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorCPU.h
@@ -52,6 +52,9 @@ public:
     bool needs_prepare_glyphs_texture() const override { return false; }
     void prepare_glyph_texture(HashMap<Gfx::Font const*, HashTable<u32>> const&) override {};
 
+    bool needs_update_immutable_bitmap_texture_cache() const override { return false; }
+    void update_immutable_bitmap_texture_cache(HashMap<u32, Gfx::ImmutableBitmap const*>&) override {};
+
     PaintingCommandExecutorCPU(Gfx::Bitmap& bitmap);
 
 private:

--- a/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorGPU.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorGPU.cpp
@@ -67,7 +67,7 @@ CommandResult PaintingCommandExecutorGPU::draw_scaled_bitmap(Gfx::IntRect const&
 
 CommandResult PaintingCommandExecutorGPU::draw_scaled_immutable_bitmap(Gfx::IntRect const& dst_rect, Gfx::ImmutableBitmap const& immutable_bitmap, Gfx::IntRect const& src_rect, Gfx::Painter::ScalingMode scaling_mode)
 {
-    painter().draw_scaled_bitmap(dst_rect, immutable_bitmap.bitmap(), src_rect, to_accelgfx_scaling_mode(scaling_mode));
+    painter().draw_scaled_immutable_bitmap(dst_rect, immutable_bitmap, src_rect, to_accelgfx_scaling_mode(scaling_mode));
     return CommandResult::Continue;
 }
 
@@ -314,6 +314,11 @@ bool PaintingCommandExecutorGPU::would_be_fully_clipped_by_painter(Gfx::IntRect)
 void PaintingCommandExecutorGPU::prepare_glyph_texture(HashMap<Gfx::Font const*, HashTable<u32>> const& unique_glyphs)
 {
     painter().prepare_glyph_texture(unique_glyphs);
+}
+
+void PaintingCommandExecutorGPU::update_immutable_bitmap_texture_cache(HashMap<u32, Gfx::ImmutableBitmap const*>& immutable_bitmaps)
+{
+    painter().update_immutable_bitmap_texture_cache(immutable_bitmaps);
 }
 
 }

--- a/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorGPU.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorGPU.cpp
@@ -44,25 +44,30 @@ CommandResult PaintingCommandExecutorGPU::fill_rect(Gfx::IntRect const& rect, Co
     return CommandResult::Continue;
 }
 
-CommandResult PaintingCommandExecutorGPU::draw_scaled_bitmap(Gfx::IntRect const& dst_rect, Gfx::Bitmap const& bitmap, Gfx::IntRect const& src_rect, Gfx::Painter::ScalingMode scaling_mode)
+static AccelGfx::Painter::ScalingMode to_accelgfx_scaling_mode(Gfx::Painter::ScalingMode scaling_mode)
 {
-    // FIXME: We should avoid using Gfx::Painter specific enums in painting commands
-    AccelGfx::Painter::ScalingMode accel_scaling_mode;
     switch (scaling_mode) {
     case Gfx::Painter::ScalingMode::NearestNeighbor:
     case Gfx::Painter::ScalingMode::BoxSampling:
     case Gfx::Painter::ScalingMode::SmoothPixels:
     case Gfx::Painter::ScalingMode::None:
-        accel_scaling_mode = AccelGfx::Painter::ScalingMode::NearestNeighbor;
-        break;
+        return AccelGfx::Painter::ScalingMode::NearestNeighbor;
     case Gfx::Painter::ScalingMode::BilinearBlend:
-        accel_scaling_mode = AccelGfx::Painter::ScalingMode::Bilinear;
-        break;
+        return AccelGfx::Painter::ScalingMode::Bilinear;
     default:
         VERIFY_NOT_REACHED();
     }
+}
 
-    painter().draw_scaled_bitmap(dst_rect, bitmap, src_rect, accel_scaling_mode);
+CommandResult PaintingCommandExecutorGPU::draw_scaled_bitmap(Gfx::IntRect const& dst_rect, Gfx::Bitmap const& bitmap, Gfx::IntRect const& src_rect, Gfx::Painter::ScalingMode scaling_mode)
+{
+    painter().draw_scaled_bitmap(dst_rect, bitmap, src_rect, to_accelgfx_scaling_mode(scaling_mode));
+    return CommandResult::Continue;
+}
+
+CommandResult PaintingCommandExecutorGPU::draw_scaled_immutable_bitmap(Gfx::IntRect const& dst_rect, Gfx::ImmutableBitmap const& immutable_bitmap, Gfx::IntRect const& src_rect, Gfx::Painter::ScalingMode scaling_mode)
+{
+    painter().draw_scaled_bitmap(dst_rect, immutable_bitmap.bitmap(), src_rect, to_accelgfx_scaling_mode(scaling_mode));
     return CommandResult::Continue;
 }
 

--- a/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorGPU.h
+++ b/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorGPU.h
@@ -52,6 +52,9 @@ public:
     virtual bool needs_prepare_glyphs_texture() const override { return true; }
     void prepare_glyph_texture(HashMap<Gfx::Font const*, HashTable<u32>> const&) override;
 
+    bool needs_update_immutable_bitmap_texture_cache() const override { return true; }
+    void update_immutable_bitmap_texture_cache(HashMap<u32, Gfx::ImmutableBitmap const*>&) override;
+
     PaintingCommandExecutorGPU(Gfx::Bitmap& bitmap);
     ~PaintingCommandExecutorGPU() override;
 

--- a/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorGPU.h
+++ b/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorGPU.h
@@ -17,6 +17,7 @@ public:
     CommandResult draw_text(Gfx::IntRect const& rect, String const& raw_text, Gfx::TextAlignment alignment, Color const&, Gfx::TextElision, Gfx::TextWrapping, Optional<NonnullRefPtr<Gfx::Font>> const&) override;
     CommandResult fill_rect(Gfx::IntRect const& rect, Color const&) override;
     CommandResult draw_scaled_bitmap(Gfx::IntRect const& dst_rect, Gfx::Bitmap const& bitmap, Gfx::IntRect const& src_rect, Gfx::Painter::ScalingMode scaling_mode) override;
+    CommandResult draw_scaled_immutable_bitmap(Gfx::IntRect const& dst_rect, Gfx::ImmutableBitmap const&, Gfx::IntRect const& src_rect, Gfx::Painter::ScalingMode scaling_mode) override;
     CommandResult set_clip_rect(Gfx::IntRect const& rect) override;
     CommandResult clear_clip_rect() override;
     CommandResult set_font(Gfx::Font const&) override;

--- a/Userland/Libraries/LibWeb/Painting/RecordingPainter.cpp
+++ b/Userland/Libraries/LibWeb/Painting/RecordingPainter.cpp
@@ -425,6 +425,17 @@ void RecordingPainter::execute(PaintingCommandExecutor& executor)
         executor.prepare_glyph_texture(unique_glyphs);
     }
 
+    if (executor.needs_update_immutable_bitmap_texture_cache()) {
+        HashMap<u32, Gfx::ImmutableBitmap const*> immutable_bitmaps;
+        for (auto const& command : m_painting_commands) {
+            if (command.has<DrawScaledImmutableBitmap>()) {
+                auto const& immutable_bitmap = command.get<DrawScaledImmutableBitmap>().bitmap;
+                immutable_bitmaps.set(immutable_bitmap->id(), immutable_bitmap.ptr());
+            }
+        }
+        executor.update_immutable_bitmap_texture_cache(immutable_bitmaps);
+    }
+
     size_t next_command_index = 0;
     while (next_command_index < m_painting_commands.size()) {
         auto& command = m_painting_commands[next_command_index++];

--- a/Userland/Libraries/LibWeb/Painting/RecordingPainter.cpp
+++ b/Userland/Libraries/LibWeb/Painting/RecordingPainter.cpp
@@ -157,6 +157,16 @@ void RecordingPainter::draw_scaled_bitmap(Gfx::IntRect const& dst_rect, Gfx::Bit
     });
 }
 
+void RecordingPainter::draw_scaled_immutable_bitmap(Gfx::IntRect const& dst_rect, Gfx::ImmutableBitmap const& bitmap, Gfx::IntRect const& src_rect, Gfx::Painter::ScalingMode scaling_mode)
+{
+    push_command(DrawScaledImmutableBitmap {
+        .dst_rect = state().translation.map(dst_rect),
+        .bitmap = bitmap,
+        .src_rect = src_rect,
+        .scaling_mode = scaling_mode,
+    });
+}
+
 void RecordingPainter::draw_line(Gfx::IntPoint from, Gfx::IntPoint to, Color color, int thickness, Gfx::Painter::LineStyle style, Color alternate_color)
 {
     push_command(DrawLine {
@@ -435,6 +445,9 @@ void RecordingPainter::execute(PaintingCommandExecutor& executor)
             },
             [&](DrawScaledBitmap const& command) {
                 return executor.draw_scaled_bitmap(command.dst_rect, command.bitmap, command.src_rect, command.scaling_mode);
+            },
+            [&](DrawScaledImmutableBitmap const& command) {
+                return executor.draw_scaled_immutable_bitmap(command.dst_rect, command.bitmap, command.src_rect, command.scaling_mode);
             },
             [&](SetClipRect const& command) {
                 return executor.set_clip_rect(command.rect);

--- a/Userland/Libraries/LibWeb/Painting/RecordingPainter.h
+++ b/Userland/Libraries/LibWeb/Painting/RecordingPainter.h
@@ -396,6 +396,9 @@ public:
 
     virtual bool needs_prepare_glyphs_texture() const { return false; }
     virtual void prepare_glyph_texture(HashMap<Gfx::Font const*, HashTable<u32>> const& unique_glyphs) = 0;
+
+    virtual bool needs_update_immutable_bitmap_texture_cache() const = 0;
+    virtual void update_immutable_bitmap_texture_cache(HashMap<u32, Gfx::ImmutableBitmap const*>&) = 0;
 };
 
 class RecordingPainter {

--- a/Userland/Libraries/LibWeb/Painting/RecordingPainter.h
+++ b/Userland/Libraries/LibWeb/Painting/RecordingPainter.h
@@ -15,6 +15,7 @@
 #include <LibGfx/Forward.h>
 #include <LibGfx/Gradients.h>
 #include <LibGfx/GrayscaleBitmap.h>
+#include <LibGfx/ImmutableBitmap.h>
 #include <LibGfx/PaintStyle.h>
 #include <LibGfx/Painter.h>
 #include <LibGfx/Palette.h>
@@ -70,6 +71,15 @@ struct FillRect {
 struct DrawScaledBitmap {
     Gfx::IntRect dst_rect;
     NonnullRefPtr<Gfx::Bitmap> bitmap;
+    Gfx::IntRect src_rect;
+    Gfx::Painter::ScalingMode scaling_mode;
+
+    [[nodiscard]] Gfx::IntRect bounding_rect() const { return dst_rect; }
+};
+
+struct DrawScaledImmutableBitmap {
+    Gfx::IntRect dst_rect;
+    NonnullRefPtr<Gfx::ImmutableBitmap> bitmap;
     Gfx::IntRect src_rect;
     Gfx::Painter::ScalingMode scaling_mode;
 
@@ -314,6 +324,7 @@ using PaintingCommand = Variant<
     DrawText,
     FillRect,
     DrawScaledBitmap,
+    DrawScaledImmutableBitmap,
     SetClipRect,
     ClearClipRect,
     SetFont,
@@ -351,6 +362,7 @@ public:
     virtual CommandResult draw_text(Gfx::IntRect const&, String const&, Gfx::TextAlignment alignment, Color const&, Gfx::TextElision, Gfx::TextWrapping, Optional<NonnullRefPtr<Gfx::Font>> const&) = 0;
     virtual CommandResult fill_rect(Gfx::IntRect const&, Color const&) = 0;
     virtual CommandResult draw_scaled_bitmap(Gfx::IntRect const& dst_rect, Gfx::Bitmap const& bitmap, Gfx::IntRect const& src_rect, Gfx::Painter::ScalingMode scaling_mode) = 0;
+    virtual CommandResult draw_scaled_immutable_bitmap(Gfx::IntRect const& dst_rect, Gfx::ImmutableBitmap const&, Gfx::IntRect const& src_rect, Gfx::Painter::ScalingMode scaling_mode) = 0;
     virtual CommandResult set_clip_rect(Gfx::IntRect const& rect) = 0;
     virtual CommandResult clear_clip_rect() = 0;
     virtual CommandResult set_font(Gfx::Font const& font) = 0;
@@ -435,6 +447,7 @@ public:
     void draw_rect(Gfx::IntRect const& rect, Color color, bool rough = false);
 
     void draw_scaled_bitmap(Gfx::IntRect const& dst_rect, Gfx::Bitmap const& bitmap, Gfx::IntRect const& src_rect, Gfx::Painter::ScalingMode scaling_mode = Gfx::Painter::ScalingMode::NearestNeighbor);
+    void draw_scaled_immutable_bitmap(Gfx::IntRect const& dst_rect, Gfx::ImmutableBitmap const& bitmap, Gfx::IntRect const& src_rect, Gfx::Painter::ScalingMode scaling_mode = Gfx::Painter::ScalingMode::NearestNeighbor);
 
     void draw_line(Gfx::IntPoint from, Gfx::IntPoint to, Color color, int thickness = 1, Gfx::Painter::LineStyle style = Gfx::Painter::LineStyle::Solid, Color alternate_color = Color::Transparent);
 

--- a/Userland/Libraries/LibWeb/SVG/SVGDecodedImageData.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGDecodedImageData.h
@@ -16,7 +16,7 @@ public:
     static ErrorOr<NonnullRefPtr<SVGDecodedImageData>> create(Page&, AK::URL const&, ByteBuffer encoded_svg);
     virtual ~SVGDecodedImageData() override;
 
-    virtual RefPtr<Gfx::Bitmap const> bitmap(size_t frame_index, Gfx::IntSize) const override;
+    virtual RefPtr<Gfx::ImmutableBitmap> bitmap(size_t frame_index, Gfx::IntSize) const override;
 
     virtual Optional<CSSPixels> intrinsic_width() const override;
     virtual Optional<CSSPixels> intrinsic_height() const override;
@@ -34,8 +34,8 @@ private:
     class SVGPageClient;
     SVGDecodedImageData(NonnullOwnPtr<Page>, NonnullOwnPtr<SVGPageClient>, JS::Handle<DOM::Document>, JS::Handle<SVG::SVGSVGElement>);
 
-    void render(Gfx::IntSize) const;
-    mutable RefPtr<Gfx::Bitmap> m_bitmap;
+    RefPtr<Gfx::Bitmap> render(Gfx::IntSize) const;
+    mutable RefPtr<Gfx::ImmutableBitmap> m_immutable_bitmap;
 
     NonnullOwnPtr<Page> m_page;
     NonnullOwnPtr<SVGPageClient> m_page_client;


### PR DESCRIPTION
This change introduces a texture cache for immutable bitmaps in the
GPU painter. The cache is persisted across page repaints, so now, on
page scroll repaint, in many cases, we won't need to upload any new
textures. Also, if the same image is painted more than once on a page,
its texture will only be uploaded once.

Generally, the GPU painter works much faster with this change on all
pages that have images.