### PR TITLE
Tests: Don't include LibWebView test if LibWeb is disabled

### DIFF
--- a/Tests/LibWebView/CMakeLists.txt
+++ b/Tests/LibWebView/CMakeLists.txt
@@ -1,3 +1,5 @@
+if (ENABLE_LAGOM_LIBWEB)
+
 set(TEST_SOURCES
     TestWebViewURL.cpp
 )
@@ -5,3 +7,5 @@ set(TEST_SOURCES
 foreach(source IN LISTS TEST_SOURCES)
     serenity_test("${source}" LibWebView LIBS LibWebView)
 endforeach()
+
+endif()


### PR DESCRIPTION
This unbreaks ENABLE_LAGOM_LIBWEB=OFF again.