### PR TITLE
LibWeb+LibWebView: A couple of scrolling fixes

### DIFF
--- a/Ladybird/AppKit/UI/LadybirdWebView.mm
+++ b/Ladybird/AppKit/UI/LadybirdWebView.mm
@@ -279,7 +279,7 @@ static void copy_data_to_clipboard(StringView data, NSPasteboardType pasteboard_
         [self.observer onFaviconChange:bitmap];
     };
 
-    m_web_view_bridge->on_scroll_to_point = [self](auto position) {
+    m_web_view_bridge->on_scroll = [self](auto position) {
         auto content_rect = [self frame];
         auto document_rect = [[self documentView] frame];
         auto ns_position = Ladybird::gfx_point_to_ns_point(position);

--- a/Ladybird/AppKit/UI/LadybirdWebViewBridge.cpp
+++ b/Ladybird/AppKit/UI/LadybirdWebViewBridge.cpp
@@ -38,7 +38,7 @@ WebViewBridge::WebViewBridge(Vector<Gfx::IntRect> screen_rects, float device_pix
     create_client(WebView::EnableCallgrindProfiling::No);
 
     on_scroll_by_delta = [this](auto x_delta, auto y_delta) {
-        auto position = to_widget_position(m_viewport_rect.location());
+        auto position = m_viewport_rect.location();
         position.set_x(position.x() + x_delta);
         position.set_y(position.y() + y_delta);
 
@@ -62,6 +62,11 @@ WebViewBridge::WebViewBridge(Vector<Gfx::IntRect> screen_rects, float device_pix
 
         if (on_scroll_to_point)
             on_scroll_to_point(position);
+    };
+
+    on_scroll_to_point = [this](auto position) {
+        if (on_scroll)
+            on_scroll(to_widget_position(position));
     };
 }
 

--- a/Ladybird/AppKit/UI/LadybirdWebViewBridge.h
+++ b/Ladybird/AppKit/UI/LadybirdWebViewBridge.h
@@ -56,6 +56,7 @@ public:
     Optional<Paintable> paintable();
 
     Function<void()> on_zoom_level_changed;
+    Function<void(Gfx::IntPoint)> on_scroll;
 
 private:
     WebViewBridge(Vector<Gfx::IntRect> screen_rects, float device_pixel_ratio, Optional<StringView> webdriver_content_ipc_path, Web::CSS::PreferredColorScheme);

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -1669,8 +1669,7 @@ static ErrorOr<void> scroll_an_element_into_view(DOM::Element& target, Bindings:
 
             // AD-HOC:
             auto* page = document.navigable()->traversable_navigable()->page();
-            auto scale = page->client().device_pixels_per_css_pixel();
-            page->client().page_did_request_scroll_to({ position.left() * scale, position.top() * scale });
+            page->client().page_did_request_scroll_to(position.location());
         }
         // If scrolling box is associated with an element
         else {

--- a/Userland/Libraries/LibWebView/InspectorClient.cpp
+++ b/Userland/Libraries/LibWebView/InspectorClient.cpp
@@ -322,6 +322,16 @@ void InspectorClient::maybe_load_inspector()
         let initialTabButton = document.getElementById("dom-tree-button");
         selectTab(initialTabButton, "dom-tree");
 
+        const scrollToElement = (element) => {
+            // Include an offset to prevent the element being placed behind the fixed `tab-controls` header.
+            const offset = 45;
+
+            let position = element.getBoundingClientRect().top;
+            position += window.pageYOffset - offset;
+
+            window.scrollTo(0, position);
+        }
+
         inspector.inspectDOMNodeID = nodeID => {
             let domNodes = document.querySelectorAll(`[data-id="${nodeID}"]`);
             if (domNodes.length !== 1) {
@@ -335,7 +345,7 @@ void InspectorClient::maybe_load_inspector()
             }
 
             inspectDOMNode(domNodes[0]);
-            selectedDOMNode.scrollIntoView({ block: "start", inline: "start" });
+            scrollToElement(selectedDOMNode);
         };
 
         inspector.clearInspectedDOMNode = () => {

--- a/Userland/Services/WebContent/PageHost.cpp
+++ b/Userland/Services/WebContent/PageHost.cpp
@@ -257,7 +257,8 @@ void PageHost::page_did_request_scroll(i32 x_delta, i32 y_delta)
 
 void PageHost::page_did_request_scroll_to(Web::CSSPixelPoint scroll_position)
 {
-    m_client.async_did_request_scroll_to({ scroll_position.x().to_int(), scroll_position.y().to_int() });
+    auto device_scroll_position = page().css_to_device_point(scroll_position);
+    m_client.async_did_request_scroll_to(device_scroll_position.to_type<int>());
 }
 
 void PageHost::page_did_request_scroll_into_view(Web::CSSPixelRect const& rect)


### PR DESCRIPTION
Ran into some funky scrolling behavior in the inspector, seen here:


https://github.com/SerenityOS/serenity/assets/5600524/509d4778-42ac-45a0-a4ce-05c078beafc1


With these, we handle scrolling to the inspected element in the inspector better:


https://github.com/SerenityOS/serenity/assets/5600524/72637ba4-c6d9-461d-b92b-ab8ef5f34b94

