### PR TITLE
LibTLS: Implement the `extended_master_secret` extension

### DIFF
--- a/Userland/Libraries/LibCrypto/Hash/HashManager.h
+++ b/Userland/Libraries/LibCrypto/Hash/HashManager.h
@@ -215,6 +215,15 @@ public:
         return m_kind == kind;
     }
 
+    inline Manager copy() const
+    {
+        Manager result;
+        result.m_algorithm = m_algorithm;
+        result.m_kind = m_kind;
+        result.m_pre_init_buffer = m_pre_init_buffer;
+        return result;
+    }
+
 private:
     using AlgorithmVariant = Variant<Empty, BLAKE2b, MD5, SHA1, SHA256, SHA384, SHA512>;
     AlgorithmVariant m_algorithm {};

--- a/Userland/Libraries/LibTLS/HandshakeClient.cpp
+++ b/Userland/Libraries/LibTLS/HandshakeClient.cpp
@@ -198,11 +198,6 @@ void TLSv12::build_rsa_pre_master_secret(PacketBuilder& builder)
         print_buffer(outbuf);
     }
 
-    if (!compute_master_secret_from_pre_master_secret(bytes)) {
-        dbgln("oh noes we could not derive a master key :(");
-        return;
-    }
-
     builder.append_u24(outbuf.size() + 2);
     builder.append((u16)outbuf.size());
     builder.append(outbuf);
@@ -243,11 +238,6 @@ void TLSv12::build_dhe_rsa_pre_master_secret(PacketBuilder& builder)
         dbgln("dh_random: {}", dh_random.to_base_deprecated(16));
         dbgln("dh_Yc: {:hex-dump}", (ReadonlyBytes)dh_Yc_bytes);
         dbgln("premaster key: {:hex-dump}", (ReadonlyBytes)m_context.premaster_key);
-    }
-
-    if (!compute_master_secret_from_pre_master_secret(48)) {
-        dbgln("oh noes we could not derive a master key :(");
-        return;
     }
 
     builder.append_u24(dh_key_size + 2);
@@ -295,11 +285,6 @@ void TLSv12::build_ecdhe_rsa_pre_master_secret(PacketBuilder& builder)
         dbgln("client private key: {:hex-dump}", (ReadonlyBytes)private_key);
         dbgln("client public key:  {:hex-dump}", (ReadonlyBytes)public_key);
         dbgln("premaster key:      {:hex-dump}", (ReadonlyBytes)m_context.premaster_key);
-    }
-
-    if (!compute_master_secret_from_pre_master_secret(48)) {
-        dbgln("oh noes we could not derive a master key :(");
-        return;
     }
 
     builder.append_u24(public_key.size() + 1);
@@ -413,6 +398,10 @@ ByteBuffer TLSv12::build_client_key_exchange()
     auto packet = builder.build();
 
     update_packet(packet);
+
+    if (!compute_master_secret_from_pre_master_secret(48)) {
+        dbgln("oh noes we could not derive a master key :(");
+    }
 
     return packet;
 }

--- a/Userland/Libraries/LibTLS/HandshakeServer.cpp
+++ b/Userland/Libraries/LibTLS/HandshakeServer.cpp
@@ -189,6 +189,9 @@ ssize_t TLSv12::handle_server_hello(ReadonlyBytes buffer, WritePacketStage& writ
             // uncompressed points. Therefore, this extension can be safely ignored as it should always inform us
             // that the server supports uncompressed points.
             res += extension_length;
+        } else if (extension_type == ExtensionType::EXTENDED_MASTER_SECRET) {
+            m_context.extensions.extended_master_secret = true;
+            res += extension_length;
         } else {
             dbgln("Encountered unknown extension {} with length {}", enum_to_string(extension_type), extension_length);
             res += extension_length;

--- a/Userland/Libraries/LibTLS/TLSv12.h
+++ b/Userland/Libraries/LibTLS/TLSv12.h
@@ -181,6 +181,7 @@ struct Options {
     OPTION_WITH_DEFAULTS(Function<void(AlertDescription)>, alert_handler, [](auto) {})
     OPTION_WITH_DEFAULTS(Function<void()>, finish_callback, [] {})
     OPTION_WITH_DEFAULTS(Function<Vector<Certificate>()>, certificate_provider, [] { return Vector<Certificate> {}; })
+    OPTION_WITH_DEFAULTS(bool, enable_extended_master_secret, true)
 
 #undef OPTION_WITH_DEFAULTS
 };
@@ -232,6 +233,7 @@ struct Context {
     struct {
         // Server Name Indicator
         DeprecatedString SNI; // I hate your existence
+        bool extended_master_secret { false };
     } extensions;
 
     u8 request_client_certificate { 0 };


### PR DESCRIPTION
While trying to figure out why a specific website was not working with LibTLS, I got convinced that we were missing an extension which the server required. The `extended_master_secret` extension was the only one not implemented in LibTLS, which was implemented in curl. So, I implemented this extension for LibTLS. In the end this extension was not actually the problem, but now we have an implementation anyway. :^)

The only thing I'm not quite sure about is adding the `copy()` method to `Crypto::Hash::Manager`. This is required as I need `m_context.handshake_hash` without modifying it. If there is a nicer way I would love to change this.  