### PR TITLE
LibWeb: Remove exit for javascript urls in anchor activation_behavior()

### DIFF
--- a/Tests/LibWeb/Text/expected/anchor-element-with-javascript-url-href.txt
+++ b/Tests/LibWeb/Text/expected/anchor-element-with-javascript-url-href.txt
@@ -1,0 +1,1 @@
+  link clicked!

--- a/Tests/LibWeb/Text/input/anchor-element-with-javascript-url-href.html
+++ b/Tests/LibWeb/Text/input/anchor-element-with-javascript-url-href.html
@@ -1,0 +1,14 @@
+<script src="include.js"></script>
+<script>
+function javascript_navigation_callback() {
+    println("link clicked!");
+    window.done();
+}
+</script>
+<a id="test-link" href="javascript:javascript_navigation_callback()"></a>
+<script>
+    asyncTest((done) => {
+        document.getElementById("test-link").click();
+        window.done = done;
+    });
+</script>

--- a/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.cpp
@@ -57,11 +57,6 @@ void HTMLAnchorElement::activation_behavior(Web::DOM::Event const&)
     if (href().is_empty())
         return;
 
-    // AD-HOC: follow_the_hyperlink currently doesn't navigate properly with javascript urls
-    // EventHandler::handle_mouseup performs the navigation steps for javascript urls instead
-    if (href().starts_with_bytes("javascript:"sv))
-        return;
-
     // 2. Let hyperlinkSuffix be null.
     Optional<String> hyperlink_suffix {};
 


### PR DESCRIPTION
This early return is no longer needed because Navigable::navigate() can process `javascript:` urls.

Fixes https://github.com/SerenityOS/serenity/issues/22052