### PR TITLE
LibWeb: Improve word selection

### DIFF
--- a/AK/DeprecatedString.cpp
+++ b/AK/DeprecatedString.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/ByteBuffer.h>
+#include <AK/CharacterTypes.h>
 #include <AK/DeprecatedFlyString.h>
 #include <AK/DeprecatedString.h>
 #include <AK/Format.h>
@@ -353,6 +354,28 @@ DeprecatedString DeprecatedString::reverse() const
         reversed_string.append(characters()[i]);
     }
     return reversed_string.to_deprecated_string();
+}
+
+unsigned DeprecatedString::start_of_word(unsigned index) const
+{
+    // Start from one before the index position to prevent selecting only spaces between words, caused by the addition below.
+    // This also helps us dealing with cases where index is equal to the string length.
+    for (int i = index - 1; i >= 0; --i) {
+        if (AK::is_ascii_space((*this)[i])) {
+            // Don't include the space in the selection
+            return i + 1;
+        }
+    }
+    return 0;
+}
+
+unsigned DeprecatedString::end_of_word(unsigned index) const
+{
+    for (size_t i = index; i < this->length(); ++i) {
+        if (AK::is_ascii_space((*this)[i]))
+            return i;
+    }
+    return this->length();
 }
 
 DeprecatedString escape_html_entities(StringView html)

--- a/AK/DeprecatedString.h
+++ b/AK/DeprecatedString.h
@@ -303,6 +303,9 @@ public:
         }());
     }
 
+    [[nodiscard]] unsigned start_of_word(unsigned index) const;
+    [[nodiscard]] unsigned end_of_word(unsigned index) const;
+
 private:
     NonnullRefPtr<StringImpl const> m_impl;
 };

--- a/Userland/Libraries/LibWeb/Page/EventHandler.h
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.h
@@ -58,6 +58,7 @@ private:
     JS::NonnullGCPtr<HTML::BrowsingContext> m_browsing_context;
 
     bool m_in_mouse_selection { false };
+    bool m_in_mouse_word_selection { false };
 
     WeakPtr<Layout::Node> m_mouse_event_tracking_layout_node;
 


### PR DESCRIPTION
This improves the word selection feature, triggered by double clicking text. Previously, this only allowed you to select a single word at once, moving your cursor while the mouse was still pressed did not have any effect. Now if you move your cursor with the mouse pressed, other words will actually also be selected, as is common in many other applications.

https://github.com/SerenityOS/serenity/assets/48161361/e2d2c024-6f74-44a5-b0f9-10b49c2f7d88