### PR TITLE
LibJS: Add common fast paths for GetByValue and PutByValue with TypedArray

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/TypedArray.h
+++ b/Userland/Libraries/LibJS/Runtime/TypedArray.h
@@ -32,6 +32,13 @@ public:
         Number,
     };
 
+    enum class Kind {
+#define __JS_ENUMERATE(ClassName, snake_name, PrototypeName, ConstructorName, Type) \
+    ClassName,
+        JS_ENUMERATE_TYPED_ARRAYS
+#undef __JS_ENUMERATE
+    };
+
     using IntrinsicConstructor = NonnullGCPtr<TypedArrayConstructor> (Intrinsics::*)();
 
     u32 array_length() const { return m_array_length; }
@@ -48,6 +55,7 @@ public:
 
     virtual size_t element_size() const = 0;
     virtual DeprecatedFlyString const& element_name() const = 0;
+    virtual Kind kind() const = 0;
 
     // 25.1.2.6 IsUnclampedIntegerElementType ( type ), https://tc39.es/ecma262/#sec-isunclampedintegerelementtype
     virtual bool is_unclamped_integer_element_type() const = 0;
@@ -472,6 +480,7 @@ ThrowCompletionOr<double> compare_typed_array_elements(VM&, Value x, Value y, Fu
         static ThrowCompletionOr<NonnullGCPtr<ClassName>> create(Realm&, u32 length);                             \
         static NonnullGCPtr<ClassName> create(Realm&, u32 length, ArrayBuffer& buffer);                           \
         virtual DeprecatedFlyString const& element_name() const override;                                         \
+        virtual Kind kind() const override { return Kind::ClassName; }                                            \
                                                                                                                   \
     protected:                                                                                                    \
         ClassName(Object& prototype, u32 length, ArrayBuffer& array_buffer);                                      \


### PR DESCRIPTION
Solid improvement on Octane (`gbemu.js`, `mandreel.js` and `zlib.js` specifically)

```
Suite       Test                                   Speedup  Old (Mean ± Range)           New (Mean ± Range)
----------  -----------------------------------  ---------  ---------------------------  ------------------------
Kraken      ai-astar.js                              0.994  0.850 ± 0.850 … 0.850        0.855 ± 0.840 … 0.870
Kraken      audio-beat-detection.js                  1      0.445 ± 0.440 … 0.450        0.445 ± 0.440 … 0.450
Kraken      audio-dft.js                             1      0.345 ± 0.340 … 0.350        0.345 ± 0.340 … 0.350
Kraken      audio-fft.js                             1.016  0.325 ± 0.320 … 0.330        0.320 ± 0.320 … 0.320
Kraken      audio-oscillator.js                      1      0.360 ± 0.360 … 0.360        0.360 ± 0.360 … 0.360
Kraken      imaging-darkroom.js                      1      2.770 ± 2.760 … 2.780        2.770 ± 2.730 … 2.810
Kraken      imaging-desaturate.js                    1      0.655 ± 0.650 … 0.660        0.655 ± 0.650 … 0.660
Kraken      imaging-gaussian-blur.js                 1      2.670 ± 2.650 … 2.690        2.670 ± 2.670 … 2.670
Kraken      json-parse-financial.js                  1      0.070 ± 0.070 … 0.070        0.070 ± 0.070 … 0.070
Kraken      json-stringify-tinderbox.js              1      0.200 ± 0.200 … 0.200        0.200 ± 0.200 … 0.200
Kraken      stanford-crypto-aes.js                   0.99   0.515 ± 0.510 … 0.520        0.520 ± 0.520 … 0.520
Kraken      stanford-crypto-ccm.js                   1.037  0.560 ± 0.550 … 0.570        0.540 ± 0.540 … 0.540
Kraken      stanford-crypto-pbkdf2.js                1.016  0.925 ± 0.920 … 0.930        0.910 ± 0.900 … 0.920
Kraken      stanford-crypto-sha256-iterative.js      0.988  0.400 ± 0.400 … 0.400        0.405 ± 0.400 … 0.410
Octane      box2d.js                                 1.008  2.525 ± 2.500 … 2.550        2.505 ± 2.500 … 2.510
Octane      code-load.js                             1.007  2.115 ± 2.110 … 2.120        2.100 ± 2.100 … 2.100
Octane      crypto.js                                1      5.065 ± 5.060 … 5.070        5.065 ± 5.050 … 5.080
Octane      deltablue.js                             0.99   3.040 ± 3.020 … 3.060        3.070 ± 3.070 … 3.070
Octane      earley-boyer.js                          1.003  21.405 ± 21.280 … 21.530     21.340 ± 21.310 … 21.370
Octane      gbemu.js                                 1.369  4.825 ± 4.810 … 4.840        3.525 ± 3.520 … 3.530
Octane      mandreel.js                              1.154  24.595 ± 24.410 … 24.780     21.310 ± 21.180 … 21.440
Octane      navier-stokes.js                         0.998  2.025 ± 2.020 … 2.030        2.030 ± 2.020 … 2.040
Octane      pdfjs.js                                 1.032  3.245 ± 3.240 … 3.250        3.145 ± 3.140 … 3.150
Octane      raytrace.js                              0.996  7.425 ± 7.400 … 7.450        7.455 ± 7.390 … 7.520
Octane      regexp.js                                0.967  23.850 ± 23.640 … 24.060     24.670 ± 24.490 … 24.850
Octane      richards.js                              1.002  2.015 ± 2.010 … 2.020        2.010 ± 2.010 … 2.010
Octane      splay.js                                 0.984  3.105 ± 3.080 … 3.130        3.155 ± 3.140 … 3.170
Octane      typescript.js                            0.949  47.850 ± 47.200 … 48.500     50.420 ± 48.810 … 52.030
Octane      zlib.js                                  1.329  103.180 ± 102.130 … 104.230  77.620 ± 76.820 … 78.420
Kraken      Total                                    1.002  11.090                       11.065
Octane      Total                                    1.117  256.265                      229.420
All Suites  Total                                    1.112  267.355                      240.485
```