### PR TITLE
LibWeb: Remove now-unneeded TypedArray OOM propagation

### DIFF
--- a/Userland/Libraries/LibWeb/WebIDL/AbstractOperations.cpp
+++ b/Userland/Libraries/LibWeb/WebIDL/AbstractOperations.cpp
@@ -77,7 +77,7 @@ ErrorOr<ByteBuffer> get_buffer_source_copy(JS::Object const& buffer_source)
 
     // 9. For i in the range offset to offset + length − 1, inclusive, set bytes[i − offset] to ! GetValueFromBuffer(esArrayBuffer, i, Uint8, true, Unordered).
     for (u64 i = offset; i < offset + length; ++i) {
-        auto value = es_array_buffer->get_value<u8>(i, true, JS::ArrayBuffer::Unordered).release_allocated_value_but_fixme_should_propagate_errors();
+        auto value = es_array_buffer->get_value<u8>(i, true, JS::ArrayBuffer::Unordered);
         bytes[i - offset] = static_cast<u8>(value.as_double());
     }
 


### PR DESCRIPTION
No longer throws after abcf71a8ca169d8dec43c7da4028349d57c45e55.