### PR TITLE
LibAccelGfx: Skip glyph atlas rebuild if all needed glyphs are present 

### DIFF
--- a/Userland/Libraries/LibAccelGfx/CMakeLists.txt
+++ b/Userland/Libraries/LibAccelGfx/CMakeLists.txt
@@ -3,6 +3,7 @@ include(accelerated_graphics)
 if (HAS_ACCELERATED_GRAPHICS)
     set(SOURCES
         GL.cpp
+        GlyphAtlas.cpp
         Context.cpp
         Painter.cpp
         Program.cpp

--- a/Userland/Libraries/LibAccelGfx/GlyphAtlas.cpp
+++ b/Userland/Libraries/LibAccelGfx/GlyphAtlas.cpp
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2023, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/QuickSort.h>
+#include <LibAccelGfx/GlyphAtlas.h>
+#include <LibGfx/Painter.h>
+
+namespace AccelGfx {
+
+GlyphAtlas& GlyphAtlas::the()
+{
+    static OwnPtr<GlyphAtlas> s_the;
+    if (!s_the)
+        s_the = make<GlyphAtlas>();
+    return *s_the;
+}
+
+void GlyphAtlas::update(HashMap<Gfx::Font const*, HashTable<u32>> const& unique_glyphs)
+{
+    HashMap<GlyphsTextureKey, NonnullRefPtr<Gfx::Bitmap>> glyph_bitmaps;
+    for (auto const& [font, code_points] : unique_glyphs) {
+        for (auto const& code_point : code_points) {
+            auto glyph = font->glyph(code_point);
+            if (glyph.bitmap()) {
+                auto atlas_key = GlyphsTextureKey { font, code_point };
+                glyph_bitmaps.set(atlas_key, *glyph.bitmap());
+            }
+        }
+    }
+
+    if (glyph_bitmaps.is_empty())
+        return;
+
+    Vector<GlyphsTextureKey> glyphs_sorted_by_height;
+    glyphs_sorted_by_height.ensure_capacity(glyph_bitmaps.size());
+    for (auto const& [atlas_key, bitmap] : glyph_bitmaps) {
+        glyphs_sorted_by_height.append(atlas_key);
+    }
+    quick_sort(glyphs_sorted_by_height, [&](auto const& a, auto const& b) {
+        auto const& bitmap_a = *glyph_bitmaps.get(a);
+        auto const& bitmap_b = *glyph_bitmaps.get(b);
+        return bitmap_a->height() > bitmap_b->height();
+    });
+
+    int current_x = 0;
+    int current_y = 0;
+    int row_height = 0;
+    int const texture_width = 512;
+    int const padding = 1;
+    for (auto const& glyphs_texture_key : glyphs_sorted_by_height) {
+        auto const& bitmap = *glyph_bitmaps.get(glyphs_texture_key);
+        if (current_x + bitmap->width() > texture_width) {
+            current_x = 0;
+            current_y += row_height + padding;
+            row_height = 0;
+        }
+        m_glyphs_texture_map.set(glyphs_texture_key, { current_x, current_y, bitmap->width(), bitmap->height() });
+        current_x += bitmap->width() + padding;
+        row_height = max(row_height, bitmap->height());
+    }
+
+    auto glyphs_texture_bitmap = MUST(Gfx::Bitmap::create(Gfx::BitmapFormat::BGRA8888, { texture_width, current_y + row_height }));
+    auto glyphs_texture_painter = Gfx::Painter(*glyphs_texture_bitmap);
+    for (auto const& [glyphs_texture_key, glyph_bitmap] : glyph_bitmaps) {
+        auto rect = m_glyphs_texture_map.get(glyphs_texture_key).value();
+        glyphs_texture_painter.blit({ rect.x(), rect.y() }, glyph_bitmap, glyph_bitmap->rect());
+    }
+
+    GL::upload_texture_data(m_texture, *glyphs_texture_bitmap);
+}
+
+Optional<Gfx::IntRect> GlyphAtlas::get_glyph_rect(Gfx::Font const* font, u32 code_point) const
+{
+    auto atlas_key = GlyphsTextureKey { font, code_point };
+    return m_glyphs_texture_map.get(atlas_key);
+}
+
+}

--- a/Userland/Libraries/LibAccelGfx/GlyphAtlas.h
+++ b/Userland/Libraries/LibAccelGfx/GlyphAtlas.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2023, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/HashMap.h>
+#include <AK/Noncopyable.h>
+#include <LibAccelGfx/GL.h>
+#include <LibGfx/Font/Font.h>
+
+namespace AccelGfx {
+
+class GlyphAtlas {
+    AK_MAKE_NONCOPYABLE(GlyphAtlas);
+
+public:
+    GlyphAtlas()
+        : m_texture(GL::create_texture())
+    {
+    }
+
+    ~GlyphAtlas()
+    {
+        GL::delete_texture(m_texture);
+    }
+
+    static GlyphAtlas& the();
+
+    struct GlyphsTextureKey {
+        Gfx::Font const* font;
+        u32 code_point;
+
+        bool operator==(GlyphsTextureKey const& other) const
+        {
+            return font == other.font && code_point == other.code_point;
+        }
+    };
+
+    void update(HashMap<Gfx::Font const*, HashTable<u32>> const& unique_glyphs);
+    Optional<Gfx::IntRect> get_glyph_rect(Gfx::Font const*, u32 code_point) const;
+
+    GL::Texture const& texture() const { return m_texture; }
+
+private:
+    GL::Texture m_texture;
+    HashMap<GlyphsTextureKey, Gfx::IntRect> m_glyphs_texture_map;
+};
+
+}
+
+namespace AK {
+
+template<>
+struct Traits<AccelGfx::GlyphAtlas::GlyphsTextureKey> : public DefaultTraits<AccelGfx::GlyphAtlas::GlyphsTextureKey> {
+    static unsigned hash(AccelGfx::GlyphAtlas::GlyphsTextureKey const& key)
+    {
+        return pair_int_hash(ptr_hash(key.font), key.code_point);
+    }
+};
+
+}

--- a/Userland/Libraries/LibAccelGfx/Painter.cpp
+++ b/Userland/Libraries/LibAccelGfx/Painter.cpp
@@ -550,11 +550,13 @@ void Painter::restore()
 
 void Painter::set_clip_rect(Gfx::IntRect rect)
 {
+    state().clip_rect = transform().map(rect);
     GL::enable_scissor_test(transform().map(rect));
 }
 
 void Painter::clear_clip_rect()
 {
+    state().clip_rect = { { 0, 0 }, m_target_canvas->size() };
     GL::disable_scissor_test();
 }
 
@@ -569,6 +571,7 @@ void Painter::set_target_canvas(NonnullRefPtr<Canvas> canvas)
     m_target_canvas = canvas;
     canvas->bind();
     GL::set_viewport({ 0, 0, canvas->size().width(), canvas->size().height() });
+    state().clip_rect = { { 0, 0 }, m_target_canvas->size() };
 }
 
 void Painter::flush(Gfx::Bitmap& bitmap)

--- a/Userland/Libraries/LibAccelGfx/Painter.h
+++ b/Userland/Libraries/LibAccelGfx/Painter.h
@@ -14,6 +14,7 @@
 #include <LibAccelGfx/Context.h>
 #include <LibAccelGfx/Forward.h>
 #include <LibAccelGfx/GL.h>
+#include <LibAccelGfx/GlyphAtlas.h>
 #include <LibAccelGfx/Program.h>
 #include <LibGfx/AffineTransform.h>
 #include <LibGfx/Font/Font.h>
@@ -29,7 +30,6 @@ class Painter {
 
 public:
     static OwnPtr<Painter> create();
-    static OwnPtr<Painter> create_with_glyphs_texture_from_painter(Painter const& painter);
 
     Painter(Context&);
     ~Painter();
@@ -59,18 +59,6 @@ public:
 
     void draw_scaled_immutable_bitmap(Gfx::IntRect const& dst_rect, Gfx::ImmutableBitmap const&, Gfx::IntRect const& src_rect, ScalingMode = ScalingMode::NearestNeighbor);
     void draw_scaled_immutable_bitmap(Gfx::FloatRect const& dst_rect, Gfx::ImmutableBitmap const&, Gfx::FloatRect const& src_rect, ScalingMode = ScalingMode::NearestNeighbor);
-
-    void prepare_glyph_texture(HashMap<Gfx::Font const*, HashTable<u32>> const& unique_glyphs);
-
-    struct GlyphsTextureKey {
-        Gfx::Font const* font;
-        u32 code_point;
-
-        bool operator==(GlyphsTextureKey const& other) const
-        {
-            return font == other.font && code_point == other.code_point;
-        }
-    };
 
     void draw_glyph_run(Vector<Gfx::DrawGlyphOrEmoji> const& glyph_run, Color const& color);
 
@@ -118,22 +106,6 @@ private:
     Program m_rounded_rectangle_program;
     Program m_blit_program;
     Program m_linear_gradient_program;
-
-    HashMap<GlyphsTextureKey, Gfx::IntRect> m_glyphs_texture_map;
-    Gfx::IntSize m_glyphs_texture_size;
-    GL::Texture m_glyphs_texture;
-};
-
-}
-
-namespace AK {
-
-template<>
-struct Traits<AccelGfx::Painter::GlyphsTextureKey> : public DefaultTraits<AccelGfx::Painter::GlyphsTextureKey> {
-    static unsigned hash(AccelGfx::Painter::GlyphsTextureKey const& key)
-    {
-        return pair_int_hash(ptr_hash(key.font), key.code_point);
-    }
 };
 
 }

--- a/Userland/Libraries/LibAccelGfx/Painter.h
+++ b/Userland/Libraries/LibAccelGfx/Painter.h
@@ -43,6 +43,8 @@ public:
     void set_transform(Gfx::AffineTransform const& transform) { state().transform = transform; }
     void translate(Gfx::FloatPoint translation) { state().transform.translate(translation); }
 
+    Gfx::IntRect const& clip_rect() const { return state().clip_rect; }
+
     void fill_rect(Gfx::FloatRect, Gfx::Color);
     void fill_rect(Gfx::IntRect, Gfx::Color);
 
@@ -88,6 +90,7 @@ private:
 
     struct State {
         Gfx::AffineTransform transform;
+        Gfx::IntRect clip_rect;
     };
 
     [[nodiscard]] State& state() { return m_state_stack.last(); }

--- a/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorGPU.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorGPU.cpp
@@ -306,10 +306,10 @@ CommandResult PaintingCommandExecutorGPU::paint_borders(DevicePixelRect const& b
     return CommandResult::Continue;
 }
 
-bool PaintingCommandExecutorGPU::would_be_fully_clipped_by_painter(Gfx::IntRect) const
+bool PaintingCommandExecutorGPU::would_be_fully_clipped_by_painter(Gfx::IntRect rect) const
 {
-    // FIXME
-    return false;
+    auto translation = painter().transform().translation().to_type<int>();
+    return !painter().clip_rect().intersects(rect.translated(translation));
 }
 
 void PaintingCommandExecutorGPU::prepare_glyph_texture(HashMap<Gfx::Font const*, HashTable<u32>> const& unique_glyphs)

--- a/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorGPU.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorGPU.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibAccelGfx/GlyphAtlas.h>
 #include <LibWeb/Painting/PaintingCommandExecutorGPU.h>
 
 namespace Web::Painting {
@@ -92,7 +93,7 @@ CommandResult PaintingCommandExecutorGPU::set_font(Gfx::Font const&)
 CommandResult PaintingCommandExecutorGPU::push_stacking_context(float opacity, bool, Gfx::IntRect const& source_paintable_rect, Gfx::IntPoint post_transform_translation, CSS::ImageRendering, StackingContextTransform, Optional<StackingContextMask>)
 {
     if (opacity < 1) {
-        auto painter = AccelGfx::Painter::create_with_glyphs_texture_from_painter(this->painter());
+        auto painter = AccelGfx::Painter::create();
         auto canvas = AccelGfx::Canvas::create(source_paintable_rect.size());
         painter->set_target_canvas(canvas);
         painter->translate(-source_paintable_rect.location().to_type<float>());
@@ -313,7 +314,7 @@ bool PaintingCommandExecutorGPU::would_be_fully_clipped_by_painter(Gfx::IntRect)
 
 void PaintingCommandExecutorGPU::prepare_glyph_texture(HashMap<Gfx::Font const*, HashTable<u32>> const& unique_glyphs)
 {
-    painter().prepare_glyph_texture(unique_glyphs);
+    AccelGfx::GlyphAtlas::the().update(unique_glyphs);
 }
 
 void PaintingCommandExecutorGPU::update_immutable_bitmap_texture_cache(HashMap<u32, Gfx::ImmutableBitmap const*>& immutable_bitmaps)


### PR DESCRIPTION
This change noticeably improves GPU painter performance on many websites.