### PR TITLE
LibJS: More work towards Octane/zlib.js going brr

### DIFF
--- a/Userland/Libraries/LibJS/JIT/Compiler.h
+++ b/Userland/Libraries/LibJS/JIT/Compiler.h
@@ -168,7 +168,6 @@ private:
     void load_accumulator(Assembler::Reg);
     void store_accumulator(Assembler::Reg);
 
-    void compile_to_boolean(Assembler::Reg dst, Assembler::Reg src);
     void compile_continuation(Optional<Bytecode::Label>, bool is_await);
 
     template<typename Codegen>
@@ -191,6 +190,12 @@ private:
     void branch_if_int32(Assembler::Reg reg, Codegen codegen)
     {
         branch_if_type(reg, INT32_TAG, codegen);
+    }
+
+    template<typename Codegen>
+    void branch_if_boolean(Assembler::Reg reg, Codegen codegen)
+    {
+        branch_if_type(reg, BOOLEAN_TAG, codegen);
     }
 
     template<typename Codegen>

--- a/Userland/Libraries/LibJS/Runtime/Object.h
+++ b/Userland/Libraries/LibJS/Runtime/Object.h
@@ -184,7 +184,6 @@ public:
 
     virtual bool is_dom_node() const { return false; }
     virtual bool is_function() const { return false; }
-    virtual bool is_typed_array() const { return false; }
     virtual bool is_string_object() const { return false; }
     virtual bool is_global_object() const { return false; }
     virtual bool is_proxy_object() const { return false; }
@@ -225,6 +224,9 @@ public:
 
     static FlatPtr has_magical_length_property_offset() { return OFFSET_OF(Object, m_has_magical_length_property); }
 
+    [[nodiscard]] bool is_typed_array() const { return m_is_typed_array; }
+    void set_is_typed_array() { m_is_typed_array = true; }
+
 protected:
     enum class GlobalObjectTag { Tag };
     enum class ConstructWithoutPrototypeTag { Tag };
@@ -243,6 +245,8 @@ protected:
     bool m_has_parameter_map { false };
 
     bool m_has_magical_length_property { false };
+
+    bool m_is_typed_array { false };
 
 private:
     void set_shape(Shape& shape) { m_shape = &shape; }

--- a/Userland/Libraries/LibJS/Runtime/TypedArray.cpp
+++ b/Userland/Libraries/LibJS/Runtime/TypedArray.cpp
@@ -444,7 +444,8 @@ void TypedArrayBase::visit_edges(Visitor& visitor)
                                                                                                                             \
     ClassName::ClassName(Object& prototype, u32 length, ArrayBuffer& array_buffer)                                          \
         : TypedArray(prototype,                                                                                             \
-            bit_cast<TypedArrayBase::IntrinsicConstructor>(&Intrinsics::snake_name##_constructor), length, array_buffer)    \
+            bit_cast<TypedArrayBase::IntrinsicConstructor>(&Intrinsics::snake_name##_constructor),                          \
+            length, array_buffer, Kind::ClassName)                                                                          \
     {                                                                                                                       \
         if constexpr (#ClassName##sv.is_one_of("BigInt64Array", "BigUint64Array"))                                          \
             m_content_type = ContentType::BigInt;                                                                           \

--- a/Userland/Libraries/LibJS/Runtime/TypedArray.h
+++ b/Userland/Libraries/LibJS/Runtime/TypedArray.h
@@ -75,6 +75,7 @@ protected:
         , m_kind(kind)
         , m_intrinsic_constructor(intrinsic_constructor)
     {
+        set_is_typed_array();
     }
 
     u32 m_array_length { 0 };
@@ -463,9 +464,6 @@ protected:
         m_array_length = array_length;
         m_byte_length = m_viewed_array_buffer->byte_length();
     }
-
-private:
-    virtual bool is_typed_array() const final { return true; }
 };
 
 ThrowCompletionOr<TypedArrayBase*> typed_array_create(VM&, FunctionObject& constructor, MarkedVector<Value> arguments);


### PR DESCRIPTION
Basically, some more streamlined fast paths for `Int8Array`, `Int16Array`, `Int32Array`, `Uint8Array`, `Uint16Array` and `Uint32Array`.

Solid 1.675x speed-up on zlib.js :^)

```
Suite       Test                                   Speedup  Old (Mean ± Range)        New (Mean ± Range)
----------  -----------------------------------  ---------  ------------------------  ------------------------
Kraken      ai-astar.js                              1.054  0.875 ± 0.870 … 0.880     0.830 ± 0.830 … 0.830
Kraken      audio-beat-detection.js                  1.045  0.460 ± 0.460 … 0.460     0.440 ± 0.440 … 0.440
Kraken      audio-dft.js                             1.059  0.360 ± 0.360 … 0.360     0.340 ± 0.340 … 0.340
Kraken      audio-fft.js                             1.031  0.330 ± 0.330 … 0.330     0.320 ± 0.320 … 0.320
Kraken      audio-oscillator.js                      1.014  0.360 ± 0.360 … 0.360     0.355 ± 0.350 … 0.360
Kraken      imaging-darkroom.js                      1.027  2.895 ± 2.890 … 2.900     2.820 ± 2.810 … 2.830
Kraken      imaging-desaturate.js                    1.079  0.680 ± 0.680 … 0.680     0.630 ± 0.630 … 0.630
Kraken      imaging-gaussian-blur.js                 0.98   2.745 ± 2.740 … 2.750     2.800 ± 2.800 … 2.800
Kraken      json-parse-financial.js                  1      0.070 ± 0.070 … 0.070     0.070 ± 0.070 … 0.070
Kraken      json-stringify-tinderbox.js              0.955  0.210 ± 0.210 … 0.210     0.220 ± 0.210 … 0.230
Kraken      stanford-crypto-aes.js                   1.049  0.540 ± 0.540 … 0.540     0.515 ± 0.510 … 0.520
Kraken      stanford-crypto-ccm.js                   1.018  0.560 ± 0.560 … 0.560     0.550 ± 0.550 … 0.550
Kraken      stanford-crypto-pbkdf2.js                1.005  0.915 ± 0.910 … 0.920     0.910 ± 0.910 … 0.910
Kraken      stanford-crypto-sha256-iterative.js      1.026  0.400 ± 0.400 … 0.400     0.390 ± 0.390 … 0.390
Octane      box2d.js                                 1.024  2.555 ± 2.550 … 2.560     2.495 ± 2.490 … 2.500
Octane      code-load.js                             0.991  2.095 ± 2.090 … 2.100     2.115 ± 2.110 … 2.120
Octane      crypto.js                                1.009  5.145 ± 5.140 … 5.150     5.100 ± 5.060 … 5.140
Octane      deltablue.js                             1.003  3.075 ± 3.050 … 3.100     3.065 ± 3.060 … 3.070
Octane      earley-boyer.js                          1.023  21.985 ± 21.980 … 21.990  21.495 ± 21.480 … 21.510
Octane      gbemu.js                                 1.104  3.665 ± 3.660 … 3.670     3.320 ± 3.310 … 3.330
Octane      mandreel.js                              1.224  22.340 ± 22.250 … 22.430  18.250 ± 18.240 … 18.260
Octane      navier-stokes.js                         0.995  2.025 ± 2.020 … 2.030     2.035 ± 2.030 … 2.040
Octane      pdfjs.js                                 1.072  3.290 ± 3.280 … 3.300     3.070 ± 3.070 … 3.070
Octane      raytrace.js                              1.038  7.685 ± 7.660 … 7.710     7.405 ± 7.400 … 7.410
Octane      regexp.js                                1.023  24.890 ± 24.810 … 24.970  24.330 ± 24.320 … 24.340
Octane      richards.js                              1.005  2.020 ± 2.010 … 2.030     2.010 ± 2.010 … 2.010
Octane      splay.js                                 1.041  3.210 ± 3.210 … 3.210     3.085 ± 3.070 … 3.100
Octane      typescript.js                            1.003  49.715 ± 48.680 … 50.750  49.545 ± 48.950 … 50.140
Octane      zlib.js                                  1.675  82.405 ± 81.690 … 83.120  49.190 ± 49.140 … 49.240
Kraken      Total                                    1.019  11.400                    11.190
Octane      Total                                    1.201  236.100                   196.510
All Suites  Total                                    1.192  247.500                   207.700
```