### PR TITLE
LibWeb: Add missing nullptr check in `HTMLImageElement::bitmap()`

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -125,6 +125,13 @@ RefPtr<Gfx::ImmutableBitmap> HTMLImageElement::immutable_bitmap() const
     return current_image_bitmap();
 }
 
+RefPtr<Gfx::Bitmap const> HTMLImageElement::bitmap() const
+{
+    if (auto immutable_bitmap = this->immutable_bitmap())
+        return immutable_bitmap->bitmap();
+    return {};
+}
+
 Optional<CSSPixels> HTMLImageElement::intrinsic_width() const
 {
     if (auto image_data = m_current_request->image_data())

--- a/Userland/Libraries/LibWeb/HTML/HTMLImageElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLImageElement.h
@@ -40,7 +40,7 @@ public:
     DeprecatedString src() const { return deprecated_attribute(HTML::AttributeNames::src); }
 
     RefPtr<Gfx::ImmutableBitmap> immutable_bitmap() const;
-    RefPtr<Gfx::Bitmap const> bitmap() const { return immutable_bitmap()->bitmap(); }
+    RefPtr<Gfx::Bitmap const> bitmap() const;
 
     unsigned width() const;
     WebIDL::ExceptionOr<void> set_width(unsigned);


### PR DESCRIPTION
Fixes crashing on https://discord.com/login