### PR TITLE
Help: Adjust default window size

### DIFF
--- a/Userland/Applications/Help/main.cpp
+++ b/Userland/Applications/Help/main.cpp
@@ -58,7 +58,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto window = GUI::Window::construct();
     window->set_icon(app_icon.bitmap_for_size(16));
     window->set_title("Help");
-    window->resize(570, 500);
+    window->resize(800, 500);
 
     auto main_widget = TRY(MainWidget::try_create());
     window->set_main_widget(main_widget);


### PR DESCRIPTION
Tiny thing that's bugged me whilst working on manpages:

Help's original default window was too narrow for comfortably reading anything but the smallest documentation, so a wider default is a nice UI improvement.

**Before:**
<img width="1136" alt="Before" src="https://github.com/SerenityOS/serenity/assets/7754483/b8dfbbf2-63f5-4e01-8780-f8450decea51">

**After:**
<img width="1136" alt="After" src="https://github.com/SerenityOS/serenity/assets/7754483/8fa2c296-47d7-4f66-8261-8ed766e4a8bf">
