### PR TITLE
LibPDF: Update font size after getting font from cache

### DIFF
--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -433,8 +433,11 @@ RENDERER_HANDLER(text_set_leading)
 PDFErrorOr<NonnullRefPtr<PDFFont>> Renderer::get_font(FontCacheKey const& key)
 {
     auto it = m_font_cache.find(key);
-    if (it != m_font_cache.end())
+    if (it != m_font_cache.end()) {
+        // Update the potentially-stale size set in text_set_matrix_and_line_matrix().
+        it->value->set_font_size(key.font_size);
         return it->value;
+    }
 
     auto font = TRY(PDFFont::create(m_document, key.font_dictionary, key.font_size));
     m_font_cache.set(key, font);


### PR DESCRIPTION
Page 1 of 0000277.pdf does:

    BT 22 0 0 22  59  28 Tm /TT2 1 Tf
        (Presented at Photonics West OPTO, February 17, 2016) Tj ET
    BT 32 0 0 32 269 426 Tm /TT1 1 Tf
        (Robert W. Boyd) Tj ET
    BT 22 0 0 22 253 357 Tm /TT2 1 Tf
        (Department of Physics and) Tj ET
    BT 22 0 0 22 105 326 Tm /TT2 1 Tf
        (Max-Planck Centre for Extreme and Quantum Photonics) Tj ET

Every line begins a text operation, then updates the font matrix,
selects a font (TT2, TT1, TT2, TT1), draws some text and ends the text
operation.

`Tm` (which sets the font matrix) contains a scale, and uses that
to update the font size of the currently-active font (cf #20084).
But in this file, we `Tm` first and `Tf` (font selection) second,
so this updates the size of the old font. So when we pull it out
of the cache again on line 3, it would still have the old size
from the `Tm` on line 2.

(The whole text scaling logic in LibPDF imho needs a rethink; the
current approach also causes issues with zero-width glyphs which
currently lead to divisions by zero. But that's for another PR.)

Fixes another regression from c8510b58a366320 (which I've accidentally
referred to by 2340e834cd in another commit).