### PR TITLE
LibGUI: Render thumbnails out of process

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/IPCCompiler/main.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/IPCCompiler/main.cpp
@@ -514,8 +514,10 @@ void do_message_for_proxy(SourceGenerator message_generator, Endpoint const& end
             message_generator.append(";");
         } else if (is_try) {
             message_generator.append(R"~~~();
-        if (!result)
-            return IPC::ErrorCode::PeerDisconnected;)~~~");
+        if (!result) {
+            m_connection.shutdown();
+            return IPC::ErrorCode::PeerDisconnected;
+        })~~~");
             if (inner_return_type != "void") {
                 message_generator.appendln(R"~~~(
         return move(*result);)~~~");

--- a/Userland/Applications/ImageViewer/ViewWidget.cpp
+++ b/Userland/Applications/ImageViewer/ViewWidget.cpp
@@ -237,7 +237,7 @@ ErrorOr<void> ViewWidget::try_open_file(String const& path, Core::File& file)
         // Use out-of-process decoding for raster formats.
         auto client = TRY(ImageDecoderClient::Client::try_create());
         auto mime_type = Core::guess_mime_type_based_on_filename(path);
-        auto decoded_image = client->decode_image(file_data, mime_type);
+        auto decoded_image = client->decode_image(file_data, OptionalNone {}, mime_type);
         if (!decoded_image.has_value()) {
             return Error::from_string_literal("Failed to decode image");
         }

--- a/Userland/Applications/PixelPaint/Image.cpp
+++ b/Userland/Applications/PixelPaint/Image.cpp
@@ -57,7 +57,7 @@ ErrorOr<NonnullRefPtr<Gfx::Bitmap>> Image::decode_bitmap(ReadonlyBytes bitmap_da
     auto optional_mime_type = guessed_mime_type.map([](auto mime_type) { return mime_type.to_byte_string(); });
 
     // FIXME: Find a way to avoid the memory copying here.
-    auto maybe_decoded_image = client->decode_image(bitmap_data, optional_mime_type);
+    auto maybe_decoded_image = client->decode_image(bitmap_data, OptionalNone {}, optional_mime_type);
     if (!maybe_decoded_image.has_value())
         return Error::from_string_literal("Image decode failed");
 

--- a/Userland/Libraries/LibCore/EventLoop.cpp
+++ b/Userland/Libraries/LibCore/EventLoop.cpp
@@ -54,6 +54,8 @@ bool EventLoop::is_running()
 
 EventLoop& EventLoop::current()
 {
+    if (event_loop_stack().is_empty())
+        dbgln("No EventLoop is present, unable to return current one!");
     return event_loop_stack().last();
 }
 

--- a/Userland/Libraries/LibGUI/CMakeLists.txt
+++ b/Userland/Libraries/LibGUI/CMakeLists.txt
@@ -151,5 +151,5 @@ set(GENERATED_SOURCES
 )
 
 serenity_lib(LibGUI gui)
-target_link_libraries(LibGUI PRIVATE LibCore LibFileSystem LibGfx LibIPC LibThreading LibRegex LibConfig LibUnicode)
+target_link_libraries(LibGUI PRIVATE LibCore LibFileSystem LibGfx LibImageDecoderClient LibIPC LibThreading LibRegex LibConfig LibUnicode)
 target_link_libraries(LibGUI PUBLIC LibSyntax)

--- a/Userland/Libraries/LibImageDecoderClient/Client.cpp
+++ b/Userland/Libraries/LibImageDecoderClient/Client.cpp
@@ -20,7 +20,7 @@ void Client::die()
         on_death();
 }
 
-Optional<DecodedImage> Client::decode_image(ReadonlyBytes encoded_data, Optional<ByteString> mime_type)
+Optional<DecodedImage> Client::decode_image(ReadonlyBytes encoded_data, Optional<Gfx::IntSize> ideal_size, Optional<ByteString> mime_type)
 {
     if (encoded_data.is_empty())
         return {};
@@ -33,7 +33,7 @@ Optional<DecodedImage> Client::decode_image(ReadonlyBytes encoded_data, Optional
     auto encoded_buffer = encoded_buffer_or_error.release_value();
 
     memcpy(encoded_buffer.data<void>(), encoded_data.data(), encoded_data.size());
-    auto response_or_error = try_decode_image(move(encoded_buffer), mime_type);
+    auto response_or_error = try_decode_image(move(encoded_buffer), ideal_size, mime_type);
 
     if (response_or_error.is_error()) {
         dbgln("ImageDecoder died heroically");

--- a/Userland/Libraries/LibImageDecoderClient/Client.h
+++ b/Userland/Libraries/LibImageDecoderClient/Client.h
@@ -32,7 +32,7 @@ class Client final
 public:
     Client(NonnullOwnPtr<Core::LocalSocket>);
 
-    Optional<DecodedImage> decode_image(ReadonlyBytes, Optional<ByteString> mime_type = {});
+    Optional<DecodedImage> decode_image(ReadonlyBytes, Optional<Gfx::IntSize> ideal_size = {}, Optional<ByteString> mime_type = {});
 
     Function<void()> on_death;
 

--- a/Userland/Services/ImageDecoder/ConnectionFromClient.h
+++ b/Userland/Services/ImageDecoder/ConnectionFromClient.h
@@ -26,7 +26,7 @@ public:
 private:
     explicit ConnectionFromClient(NonnullOwnPtr<Core::LocalSocket>);
 
-    virtual Messages::ImageDecoderServer::DecodeImageResponse decode_image(Core::AnonymousBuffer const&, Optional<ByteString> const& mime_type) override;
+    virtual Messages::ImageDecoderServer::DecodeImageResponse decode_image(Core::AnonymousBuffer const&, Optional<Gfx::IntSize> const& ideal_size, Optional<ByteString> const& mime_type) override;
 };
 
 }

--- a/Userland/Services/ImageDecoder/ImageDecoderServer.ipc
+++ b/Userland/Services/ImageDecoder/ImageDecoderServer.ipc
@@ -3,5 +3,5 @@
 
 endpoint ImageDecoderServer
 {
-    decode_image(Core::AnonymousBuffer data, Optional<ByteString> mime_type) => (bool is_animated, u32 loop_count, Vector<Gfx::ShareableBitmap> bitmaps, Vector<u32> durations)
+    decode_image(Core::AnonymousBuffer data, Optional<Gfx::IntSize> ideal_size, Optional<ByteString> mime_type) => (bool is_animated, u32 loop_count, Vector<Gfx::ShareableBitmap> bitmaps, Vector<u32> durations)
 }


### PR DESCRIPTION
Process separation is a great way to prevent malicious users to crash
the GUI with images file that makes one of our decoder crash.

It also makes life easier when developing image decoders.