### PR TITLE
LibWeb: Rename painter() to recording_painter() in PaintContext

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.cpp
@@ -128,7 +128,7 @@ void ImageStyleValue::paint(PaintContext& context, DevicePixelRect const& dest_r
 {
     if (auto const* b = bitmap(m_current_frame_index, dest_rect.size().to_type<int>()); b != nullptr) {
         auto scaling_mode = to_gfx_scaling_mode(image_rendering, b->rect(), dest_rect.to_type<int>());
-        context.painter().draw_scaled_immutable_bitmap(dest_rect.to_type<int>(), *b, b->rect(), scaling_mode);
+        context.recording_painter().draw_scaled_immutable_bitmap(dest_rect.to_type<int>(), *b, b->rect(), scaling_mode);
     }
 }
 

--- a/Userland/Libraries/LibWeb/Painting/AudioPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/AudioPaintable.cpp
@@ -48,10 +48,10 @@ void AudioPaintable::paint(PaintContext& context, PaintPhase phase) const
     if (phase != PaintPhase::Foreground)
         return;
 
-    RecordingPainterStateSaver saver { context.painter() };
+    RecordingPainterStateSaver saver { context.recording_painter() };
 
     auto audio_rect = context.rounded_device_rect(absolute_rect());
-    context.painter().add_clip_rect(audio_rect.to_type<int>());
+    context.recording_painter().add_clip_rect(audio_rect.to_type<int>());
 
     ScopedCornerRadiusClip corner_clip { context, audio_rect, normalized_border_radii_data(ShrinkRadiiForBorders::Yes) };
 

--- a/Userland/Libraries/LibWeb/Painting/BackgroundPainting.cpp
+++ b/Userland/Libraries/LibWeb/Painting/BackgroundPainting.cpp
@@ -21,7 +21,7 @@ namespace Web::Painting {
 // https://www.w3.org/TR/css-backgrounds-3/#backgrounds
 void paint_background(PaintContext& context, Layout::NodeWithStyleAndBoxModelMetrics const& layout_node, CSSPixelRect const& border_rect, Color background_color, CSS::ImageRendering image_rendering, Vector<CSS::BackgroundLayerData> const* background_layers, BorderRadiiData const& border_radii)
 {
-    auto& painter = context.painter();
+    auto& painter = context.recording_painter();
 
     struct BackgroundBox {
         CSSPixelRect rect;
@@ -76,7 +76,7 @@ void paint_background(PaintContext& context, Layout::NodeWithStyleAndBoxModelMet
         }
     }
 
-    context.painter().fill_rect_with_rounded_corners(
+    context.recording_painter().fill_rect_with_rounded_corners(
         context.rounded_device_rect(color_box.rect).to_type<int>(),
         background_color,
         color_box.radii.top_left.as_corner(context),

--- a/Userland/Libraries/LibWeb/Painting/BorderRadiusCornerClipper.cpp
+++ b/Userland/Libraries/LibWeb/Painting/BorderRadiusCornerClipper.cpp
@@ -113,10 +113,10 @@ ScopedCornerRadiusClip::ScopedCornerRadiusClip(PaintContext& context, DevicePixe
             .bottom_right = border_radii.bottom_right.as_corner(context),
             .bottom_left = border_radii.bottom_left.as_corner(context)
         };
-        auto clipper = BorderRadiusCornerClipper::create(corner_radii, context.painter().state().translation.map(border_rect.to_type<int>()).to_type<DevicePixels>(), border_radii, corner_clip);
+        auto clipper = BorderRadiusCornerClipper::create(corner_radii, context.recording_painter().state().translation.map(border_rect.to_type<int>()).to_type<DevicePixels>(), border_radii, corner_clip);
         if (!clipper.is_error()) {
             m_corner_clipper = clipper.release_value();
-            m_context.painter().sample_under_corners(*m_corner_clipper);
+            m_context.recording_painter().sample_under_corners(*m_corner_clipper);
         }
     }
 }
@@ -124,7 +124,7 @@ ScopedCornerRadiusClip::ScopedCornerRadiusClip(PaintContext& context, DevicePixe
 ScopedCornerRadiusClip::~ScopedCornerRadiusClip()
 {
     if (m_corner_clipper) {
-        m_context.painter().blit_corner_clipping(*m_corner_clipper);
+        m_context.recording_painter().blit_corner_clipping(*m_corner_clipper);
     }
 }
 

--- a/Userland/Libraries/LibWeb/Painting/ButtonPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/ButtonPaintable.cpp
@@ -59,7 +59,7 @@ void ButtonPaintable::paint(PaintContext& context, PaintPhase phase) const
         }
 
         // Paint button text clipped to button rect
-        auto& painter = context.painter();
+        auto& painter = context.recording_painter();
         painter.save();
         painter.add_clip_rect(button_rect.to_type<int>());
         painter.draw_text(

--- a/Userland/Libraries/LibWeb/Painting/CanvasPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/CanvasPaintable.cpp
@@ -38,7 +38,7 @@ void CanvasPaintable::paint(PaintContext& context, PaintPhase phase) const
             // FIXME: Remove this const_cast.
             const_cast<HTML::HTMLCanvasElement&>(layout_box().dom_node()).present();
             auto scaling_mode = to_gfx_scaling_mode(computed_values().image_rendering(), layout_box().dom_node().bitmap()->rect(), canvas_rect.to_type<int>());
-            context.painter().draw_scaled_bitmap(canvas_rect.to_type<int>(), *layout_box().dom_node().bitmap(), layout_box().dom_node().bitmap()->rect(), scaling_mode);
+            context.recording_painter().draw_scaled_bitmap(canvas_rect.to_type<int>(), *layout_box().dom_node().bitmap(), layout_box().dom_node().bitmap()->rect(), scaling_mode);
         }
     }
 }

--- a/Userland/Libraries/LibWeb/Painting/CheckBoxPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/CheckBoxPaintable.cpp
@@ -134,20 +134,20 @@ void CheckBoxPaintable::paint(PaintContext& context, PaintPhase phase) const
     float smoothness = 1.0f / (max(checkbox_rect.width(), checkbox_rect.height()) / 2);
     if (checkbox.checked() && !checkbox.indeterminate()) {
         auto background_color = enabled ? input_colors.accent : input_colors.mid_gray;
-        context.painter().fill_rect_with_rounded_corners(checkbox_rect, modify_color(background_color), checkbox_radius);
+        context.recording_painter().fill_rect_with_rounded_corners(checkbox_rect, modify_color(background_color), checkbox_radius);
         auto tick_color = increase_contrast(input_colors.base, background_color);
         if (!enabled)
             tick_color = shade(tick_color, 0.5f);
-        context.painter().draw_signed_distance_field(checkbox_rect, tick_color, check_mark_sdf(), smoothness);
+        context.recording_painter().draw_signed_distance_field(checkbox_rect, tick_color, check_mark_sdf(), smoothness);
     } else {
         auto background_color = input_colors.background_color(enabled);
         auto border_thickness = max(1, checkbox_rect.width() / 10);
-        context.painter().fill_rect_with_rounded_corners(checkbox_rect, modify_color(input_colors.border_color(enabled)), checkbox_radius);
-        context.painter().fill_rect_with_rounded_corners(checkbox_rect.shrunken(border_thickness, border_thickness, border_thickness, border_thickness),
+        context.recording_painter().fill_rect_with_rounded_corners(checkbox_rect, modify_color(input_colors.border_color(enabled)), checkbox_radius);
+        context.recording_painter().fill_rect_with_rounded_corners(checkbox_rect.shrunken(border_thickness, border_thickness, border_thickness, border_thickness),
             background_color, max(0, checkbox_radius - border_thickness));
         if (checkbox.indeterminate()) {
             auto dash_color = increase_contrast(input_colors.dark_gray, background_color);
-            context.painter().draw_signed_distance_field(checkbox_rect,
+            context.recording_painter().draw_signed_distance_field(checkbox_rect,
                 modify_color(enabled ? dash_color : shade(dash_color, 0.3f)), check_indeterminate_sdf(), smoothness);
         }
     }

--- a/Userland/Libraries/LibWeb/Painting/FilterPainting.cpp
+++ b/Userland/Libraries/LibWeb/Painting/FilterPainting.cpp
@@ -103,7 +103,7 @@ void apply_backdrop_filter(PaintContext& context, CSSPixelRect const& backdrop_r
     auto backdrop_region = context.rounded_device_rect(backdrop_rect);
 
     ScopedCornerRadiusClip corner_clipper { context, backdrop_region, border_radii_data };
-    context.painter().apply_backdrop_filter(backdrop_region.to_type<int>(), border_radii_data, backdrop_filter);
+    context.recording_painter().apply_backdrop_filter(backdrop_region.to_type<int>(), border_radii_data, backdrop_filter);
 }
 
 }

--- a/Userland/Libraries/LibWeb/Painting/GradientPainting.cpp
+++ b/Userland/Libraries/LibWeb/Painting/GradientPainting.cpp
@@ -148,17 +148,17 @@ RadialGradientData resolve_radial_gradient_data(Layout::NodeWithStyleAndBoxModel
 
 void paint_linear_gradient(PaintContext& context, DevicePixelRect const& gradient_rect, LinearGradientData const& data)
 {
-    context.painter().fill_rect_with_linear_gradient(gradient_rect.to_type<int>(), data);
+    context.recording_painter().fill_rect_with_linear_gradient(gradient_rect.to_type<int>(), data);
 }
 
 void paint_conic_gradient(PaintContext& context, DevicePixelRect const& gradient_rect, ConicGradientData const& data, DevicePixelPoint position)
 {
-    context.painter().fill_rect_with_conic_gradient(gradient_rect.to_type<int>(), data, position.to_type<int>());
+    context.recording_painter().fill_rect_with_conic_gradient(gradient_rect.to_type<int>(), data, position.to_type<int>());
 }
 
 void paint_radial_gradient(PaintContext& context, DevicePixelRect const& gradient_rect, RadialGradientData const& data, DevicePixelPoint center, DevicePixelSize size)
 {
-    context.painter().fill_rect_with_radial_gradient(gradient_rect.to_type<int>(), data, center.to_type<int>(), size.to_type<int>());
+    context.recording_painter().fill_rect_with_radial_gradient(gradient_rect.to_type<int>(), data, center.to_type<int>(), size.to_type<int>());
 }
 
 }

--- a/Userland/Libraries/LibWeb/Painting/ImagePaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/ImagePaintable.cpp
@@ -55,12 +55,12 @@ void ImagePaintable::paint(PaintContext& context, PaintPhase phase) const
         if (layout_box().renders_as_alt_text()) {
             auto& image_element = verify_cast<HTML::HTMLImageElement>(*dom_node());
             auto enclosing_rect = context.enclosing_device_rect(absolute_rect()).to_type<int>();
-            context.painter().set_font(Platform::FontPlugin::the().default_font());
-            context.painter().paint_frame(enclosing_rect, context.palette(), Gfx::FrameStyle::SunkenContainer);
+            context.recording_painter().set_font(Platform::FontPlugin::the().default_font());
+            context.recording_painter().paint_frame(enclosing_rect, context.palette(), Gfx::FrameStyle::SunkenContainer);
             auto alt = image_element.alt();
             if (alt.is_empty())
                 alt = image_element.src();
-            context.painter().draw_text(enclosing_rect, alt, Gfx::TextAlignment::Center, computed_values().color(), Gfx::TextElision::Right);
+            context.recording_painter().draw_text(enclosing_rect, alt, Gfx::TextAlignment::Center, computed_values().color(), Gfx::TextElision::Right);
         } else if (auto bitmap = layout_box().image_provider().current_image_bitmap(image_rect.size().to_type<int>())) {
             ScopedCornerRadiusClip corner_clip { context, image_rect, normalized_border_radii_data(ShrinkRadiiForBorders::Yes) };
             auto image_int_rect = image_rect.to_type<int>();
@@ -175,7 +175,7 @@ void ImagePaintable::paint(PaintContext& context, PaintPhase phase) const
                 (int)scaled_bitmap_height
             };
 
-            context.painter().draw_scaled_immutable_bitmap(draw_rect.intersected(image_int_rect), *bitmap, bitmap_rect.intersected(bitmap_intersect), scaling_mode);
+            context.recording_painter().draw_scaled_immutable_bitmap(draw_rect.intersected(image_int_rect), *bitmap, bitmap_rect.intersected(bitmap_intersect), scaling_mode);
         }
     }
 }

--- a/Userland/Libraries/LibWeb/Painting/InlinePaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/InlinePaintable.cpp
@@ -31,7 +31,7 @@ Layout::InlineNode const& InlinePaintable::layout_node() const
 
 void InlinePaintable::paint(PaintContext& context, PaintPhase phase) const
 {
-    auto& painter = context.painter();
+    auto& painter = context.recording_painter();
 
     if (phase == PaintPhase::Background) {
         auto top_left_border_radius = computed_values().border_top_left_radius();
@@ -134,9 +134,9 @@ void InlinePaintable::paint(PaintContext& context, PaintPhase phase) const
 
                 border_radii_data.inflate(outline_data->top.width + outline_offset_y, outline_data->right.width + outline_offset_x, outline_data->bottom.width + outline_offset_y, outline_data->left.width + outline_offset_x);
                 borders_rect.inflate(outline_data->top.width + outline_offset_y, outline_data->right.width + outline_offset_x, outline_data->bottom.width + outline_offset_y, outline_data->left.width + outline_offset_x);
-                context.painter().paint_borders(context.rounded_device_rect(borders_rect), border_radii_data.as_corners(context), outline_data->to_device_pixels(context));
+                context.recording_painter().paint_borders(context.rounded_device_rect(borders_rect), border_radii_data.as_corners(context), outline_data->to_device_pixels(context));
             } else {
-                context.painter().paint_borders(context.rounded_device_rect(borders_rect), border_radii_data.as_corners(context), borders_data.to_device_pixels(context));
+                context.recording_painter().paint_borders(context.rounded_device_rect(borders_rect), border_radii_data.as_corners(context), borders_data.to_device_pixels(context));
             }
 
             return IterationDecision::Continue;

--- a/Userland/Libraries/LibWeb/Painting/MarkerPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/MarkerPaintable.cpp
@@ -68,13 +68,13 @@ void MarkerPaintable::paint(PaintContext& context, PaintPhase phase) const
 
     switch (layout_box().list_style_type()) {
     case CSS::ListStyleType::Square:
-        context.painter().fill_rect(device_marker_rect.to_type<int>(), color);
+        context.recording_painter().fill_rect(device_marker_rect.to_type<int>(), color);
         break;
     case CSS::ListStyleType::Circle:
-        context.painter().draw_ellipse(device_marker_rect.to_type<int>(), color, 1);
+        context.recording_painter().draw_ellipse(device_marker_rect.to_type<int>(), color, 1);
         break;
     case CSS::ListStyleType::Disc:
-        context.painter().fill_ellipse(device_marker_rect.to_type<int>(), color);
+        context.recording_painter().fill_ellipse(device_marker_rect.to_type<int>(), color);
         break;
     case CSS::ListStyleType::DisclosureClosed: {
         // https://drafts.csswg.org/css-counter-styles-3/#disclosure-closed
@@ -87,7 +87,7 @@ void MarkerPaintable::paint(PaintContext& context, PaintPhase phase) const
         path.line_to({ left + sin_60_deg * (right - left), (top + bottom) / 2 });
         path.line_to({ left, bottom });
         path.close();
-        context.painter().fill_path({ .path = path, .color = color, .winding_rule = Gfx::Painter::WindingRule::EvenOdd });
+        context.recording_painter().fill_path({ .path = path, .color = color, .winding_rule = Gfx::Painter::WindingRule::EvenOdd });
         break;
     }
     case CSS::ListStyleType::DisclosureOpen: {
@@ -101,7 +101,7 @@ void MarkerPaintable::paint(PaintContext& context, PaintPhase phase) const
         path.line_to({ right, top });
         path.line_to({ (left + right) / 2, top + sin_60_deg * (bottom - top) });
         path.close();
-        context.painter().fill_path({ .path = path, .color = color, .winding_rule = Gfx::Painter::WindingRule::EvenOdd });
+        context.recording_painter().fill_path({ .path = path, .color = color, .winding_rule = Gfx::Painter::WindingRule::EvenOdd });
         break;
     }
     case CSS::ListStyleType::Decimal:
@@ -117,7 +117,7 @@ void MarkerPaintable::paint(PaintContext& context, PaintPhase phase) const
             break;
         // FIXME: This should use proper text layout logic!
         // This does not line up with the text in the <li> element which looks very sad :(
-        context.painter().draw_text(device_enclosing.to_type<int>(), *text, layout_box().scaled_font(context), Gfx::TextAlignment::Center, color);
+        context.recording_painter().draw_text(device_enclosing.to_type<int>(), *text, layout_box().scaled_font(context), Gfx::TextAlignment::Center, color);
         break;
     }
     case CSS::ListStyleType::None:

--- a/Userland/Libraries/LibWeb/Painting/MediaPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/MediaPaintable.cpp
@@ -61,7 +61,7 @@ void MediaPaintable::fill_triangle(RecordingPainter& painter, Gfx::IntPoint loca
 void MediaPaintable::paint_media_controls(PaintContext& context, HTML::HTMLMediaElement const& media_element, DevicePixelRect media_rect, Optional<DevicePixelPoint> const& mouse_position) const
 {
     auto components = compute_control_bar_components(context, media_element, media_rect);
-    context.painter().fill_rect(components.control_box_rect.to_type<int>(), control_box_color.with_alpha(0xd0));
+    context.recording_painter().fill_rect(components.control_box_rect.to_type<int>(), control_box_color.with_alpha(0xd0));
 
     paint_control_bar_playback_button(context, media_element, components, mouse_position);
     paint_control_bar_timeline(context, media_element, components);
@@ -155,7 +155,7 @@ void MediaPaintable::paint_control_bar_playback_button(PaintContext& context, HT
             { 0, static_cast<int>(playback_button_size) },
         } };
 
-        fill_triangle(context.painter(), playback_button_location.to_type<int>(), play_button_coordinates, playback_button_color);
+        fill_triangle(context.recording_painter(), playback_button_location.to_type<int>(), play_button_coordinates, playback_button_color);
     } else {
         DevicePixelRect pause_button_left_rect {
             playback_button_location,
@@ -166,8 +166,8 @@ void MediaPaintable::paint_control_bar_playback_button(PaintContext& context, HT
             { playback_button_size / 3, playback_button_size }
         };
 
-        context.painter().fill_rect(pause_button_left_rect.to_type<int>(), playback_button_color);
-        context.painter().fill_rect(pause_button_right_rect.to_type<int>(), playback_button_color);
+        context.recording_painter().fill_rect(pause_button_left_rect.to_type<int>(), playback_button_color);
+        context.recording_painter().fill_rect(pause_button_right_rect.to_type<int>(), playback_button_color);
     }
 }
 
@@ -182,11 +182,11 @@ void MediaPaintable::paint_control_bar_timeline(PaintContext& context, HTML::HTM
 
     auto timeline_past_rect = components.timeline_rect;
     timeline_past_rect.set_width(timeline_button_offset_x);
-    context.painter().fill_rect(timeline_past_rect.to_type<int>(), control_highlight_color.lightened());
+    context.recording_painter().fill_rect(timeline_past_rect.to_type<int>(), control_highlight_color.lightened());
 
     auto timeline_future_rect = components.timeline_rect;
     timeline_future_rect.take_from_left(timeline_button_offset_x);
-    context.painter().fill_rect(timeline_future_rect.to_type<int>(), Color::Black);
+    context.recording_painter().fill_rect(timeline_future_rect.to_type<int>(), Color::Black);
 }
 
 void MediaPaintable::paint_control_bar_timestamp(PaintContext& context, Components const& components)
@@ -194,7 +194,7 @@ void MediaPaintable::paint_control_bar_timestamp(PaintContext& context, Componen
     if (components.timestamp_rect.is_empty())
         return;
 
-    context.painter().draw_text(components.timestamp_rect.to_type<int>(), components.timestamp, *components.timestamp_font, Gfx::TextAlignment::CenterLeft, Color::White);
+    context.recording_painter().draw_text(components.timestamp_rect.to_type<int>(), components.timestamp, *components.timestamp_font, Gfx::TextAlignment::CenterLeft, Color::White);
 }
 
 void MediaPaintable::paint_control_bar_speaker(PaintContext& context, HTML::HTMLMediaElement const& media_element, Components const& components, Optional<DevicePixelPoint> const& mouse_position)
@@ -227,18 +227,18 @@ void MediaPaintable::paint_control_bar_speaker(PaintContext& context, HTML::HTML
     path.line_to(device_point(0, 11));
     path.line_to(device_point(0, 4));
     path.close();
-    context.painter().fill_path({ .path = path, .color = speaker_button_color, .winding_rule = Gfx::Painter::WindingRule::EvenOdd });
+    context.recording_painter().fill_path({ .path = path, .color = speaker_button_color, .winding_rule = Gfx::Painter::WindingRule::EvenOdd });
 
     path.clear();
     path.move_to(device_point(13, 3));
     path.quadratic_bezier_curve_to(device_point(16, 7.5), device_point(13, 12));
     path.move_to(device_point(14, 0));
     path.quadratic_bezier_curve_to(device_point(20, 7.5), device_point(14, 15));
-    context.painter().stroke_path({ .path = path, .color = speaker_button_color, .thickness = 1 });
+    context.recording_painter().stroke_path({ .path = path, .color = speaker_button_color, .thickness = 1 });
 
     if (media_element.muted()) {
-        context.painter().draw_line(device_point(0, 0).to_type<int>(), device_point(20, 15).to_type<int>(), Color::Red, 2);
-        context.painter().draw_line(device_point(0, 15).to_type<int>(), device_point(20, 0).to_type<int>(), Color::Red, 2);
+        context.recording_painter().draw_line(device_point(0, 0).to_type<int>(), device_point(20, 15).to_type<int>(), Color::Red, 2);
+        context.recording_painter().draw_line(device_point(0, 15).to_type<int>(), device_point(20, 0).to_type<int>(), Color::Red, 2);
     }
 }
 
@@ -252,11 +252,11 @@ void MediaPaintable::paint_control_bar_volume(PaintContext& context, HTML::HTMLM
 
     auto volume_lower_rect = components.volume_scrub_rect;
     volume_lower_rect.set_width(volume_button_offset_x);
-    context.painter().fill_rect_with_rounded_corners(volume_lower_rect.to_type<int>(), control_highlight_color.lightened(), 4);
+    context.recording_painter().fill_rect_with_rounded_corners(volume_lower_rect.to_type<int>(), control_highlight_color.lightened(), 4);
 
     auto volume_higher_rect = components.volume_scrub_rect;
     volume_higher_rect.take_from_left(volume_button_offset_x);
-    context.painter().fill_rect_with_rounded_corners(volume_higher_rect.to_type<int>(), Color::Black, 4);
+    context.recording_painter().fill_rect_with_rounded_corners(volume_higher_rect.to_type<int>(), Color::Black, 4);
 
     auto volume_button_rect = components.volume_scrub_rect;
     volume_button_rect.shrink(components.volume_scrub_rect.width() - components.volume_button_size, components.volume_scrub_rect.height() - components.volume_button_size);
@@ -264,7 +264,7 @@ void MediaPaintable::paint_control_bar_volume(PaintContext& context, HTML::HTMLM
 
     auto volume_is_hovered = rect_is_hovered(media_element, components.volume_rect, mouse_position, HTML::HTMLMediaElement::MouseTrackingComponent::Volume);
     auto volume_color = control_button_color(volume_is_hovered);
-    context.painter().fill_ellipse(volume_button_rect.to_type<int>(), volume_color);
+    context.recording_painter().fill_ellipse(volume_button_rect.to_type<int>(), volume_color);
 }
 
 MediaPaintable::DispatchEventOfSameName MediaPaintable::handle_mousedown(Badge<EventHandler>, CSSPixelPoint position, unsigned button, unsigned)

--- a/Userland/Libraries/LibWeb/Painting/NestedBrowsingContextPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/NestedBrowsingContextPaintable.cpp
@@ -48,23 +48,23 @@ void NestedBrowsingContextPaintable::paint(PaintContext& context, PaintPhase pha
         if (!hosted_paint_tree)
             return;
 
-        context.painter().save();
+        context.recording_painter().save();
         auto old_viewport_rect = context.device_viewport_rect();
 
-        context.painter().add_clip_rect(clip_rect.to_type<int>());
+        context.recording_painter().add_clip_rect(clip_rect.to_type<int>());
 
         auto absolute_device_rect = context.enclosing_device_rect(absolute_rect);
-        context.painter().translate(absolute_device_rect.x().value(), absolute_device_rect.y().value());
+        context.recording_painter().translate(absolute_device_rect.x().value(), absolute_device_rect.y().value());
 
         context.set_device_viewport_rect({ {}, context.enclosing_device_size(layout_box().dom_node().content_navigable()->size()) });
         const_cast<ViewportPaintable*>(hosted_paint_tree)->paint_all_phases(context);
 
         context.set_device_viewport_rect(old_viewport_rect);
-        context.painter().restore();
+        context.recording_painter().restore();
 
         if constexpr (HIGHLIGHT_FOCUSED_FRAME_DEBUG) {
             if (layout_box().dom_node().nested_browsing_context()->is_focused_context()) {
-                context.painter().draw_rect(clip_rect.to_type<int>(), Color::Cyan);
+                context.recording_painter().draw_rect(clip_rect.to_type<int>(), Color::Cyan);
             }
         }
     }

--- a/Userland/Libraries/LibWeb/Painting/PaintContext.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintContext.cpp
@@ -9,8 +9,8 @@
 
 namespace Web {
 
-PaintContext::PaintContext(Painting::RecordingPainter& painter, Palette const& palette, double device_pixels_per_css_pixel)
-    : m_painter(painter)
+PaintContext::PaintContext(Painting::RecordingPainter& recording_painter, Palette const& palette, double device_pixels_per_css_pixel)
+    : m_recording_painter(recording_painter)
     , m_palette(palette)
     , m_device_pixels_per_css_pixel(device_pixels_per_css_pixel)
 {

--- a/Userland/Libraries/LibWeb/Painting/PaintContext.h
+++ b/Userland/Libraries/LibWeb/Painting/PaintContext.h
@@ -20,7 +20,7 @@ class PaintContext {
 public:
     PaintContext(Painting::RecordingPainter& painter, Palette const& palette, double device_pixels_per_css_pixel);
 
-    Painting::RecordingPainter& painter() const { return m_painter; }
+    Painting::RecordingPainter& recording_painter() const { return m_recording_painter; }
     Palette const& palette() const { return m_palette; }
 
     bool should_show_line_box_borders() const { return m_should_show_line_box_borders; }
@@ -72,7 +72,7 @@ public:
     void translate_scroll_offset_by(CSSPixelPoint offset) { m_scroll_offset.translate_by(offset); }
 
 private:
-    Painting::RecordingPainter& m_painter;
+    Painting::RecordingPainter& m_recording_painter;
     Palette m_palette;
     double m_device_pixels_per_css_pixel { 0 };
     DevicePixelRect m_device_viewport_rect;

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -193,8 +193,8 @@ void PaintableBox::before_paint(PaintContext& context, [[maybe_unused]] PaintPha
 
     auto clip_rect = get_clip_rect();
     if (clip_rect.has_value()) {
-        context.painter().save();
-        context.painter().add_clip_rect(clip_rect->to_type<int>());
+        context.recording_painter().save();
+        context.recording_painter().add_clip_rect(clip_rect->to_type<int>());
     }
 }
 
@@ -204,7 +204,7 @@ void PaintableBox::after_paint(PaintContext& context, [[maybe_unused]] PaintPhas
         return;
 
     if (get_clip_rect().has_value())
-        context.painter().restore();
+        context.recording_painter().restore();
 }
 
 void PaintableBox::paint(PaintContext& context, PaintPhase phase) const
@@ -246,7 +246,7 @@ void PaintableBox::paint(PaintContext& context, PaintPhase phase) const
             border_radius_data.inflate(outline_width + outline_offset_y, outline_width + outline_offset_x, outline_width + outline_offset_y, outline_width + outline_offset_x);
             borders_rect.inflate(outline_width + outline_offset_y, outline_width + outline_offset_x, outline_width + outline_offset_y, outline_width + outline_offset_x);
 
-            context.painter().paint_borders(context.rounded_device_rect(borders_rect), border_radius_data.as_corners(context), borders_data->to_device_pixels(context));
+            context.recording_painter().paint_borders(context.rounded_device_rect(borders_rect), border_radius_data.as_corners(context), borders_data->to_device_pixels(context));
         }
     }
 
@@ -265,8 +265,8 @@ void PaintableBox::paint(PaintContext& context, PaintPhase phase) const
 
         auto paint_inspector_rect = [&](CSSPixelRect const& rect, Color color) {
             auto device_rect = context.enclosing_device_rect(rect).to_type<int>();
-            context.painter().fill_rect(device_rect, Color(color).with_alpha(100));
-            context.painter().draw_rect(device_rect, Color(color));
+            context.recording_painter().fill_rect(device_rect, Color(color).with_alpha(100));
+            context.recording_painter().draw_rect(device_rect, Color(color));
         };
 
         paint_inspector_rect(margin_rect, Color::Yellow);
@@ -289,9 +289,9 @@ void PaintableBox::paint(PaintContext& context, PaintPhase phase) const
         size_text_rect.set_width(CSSPixels::nearest_value_for(font.width(size_text)) + 4);
         size_text_rect.set_height(CSSPixels::nearest_value_for(font.pixel_size()) + 4);
         auto size_text_device_rect = context.enclosing_device_rect(size_text_rect).to_type<int>();
-        context.painter().fill_rect(size_text_device_rect, context.palette().color(Gfx::ColorRole::Tooltip));
-        context.painter().draw_rect(size_text_device_rect, context.palette().threed_shadow1());
-        context.painter().draw_text(size_text_device_rect, size_text, font, Gfx::TextAlignment::Center, context.palette().color(Gfx::ColorRole::TooltipText));
+        context.recording_painter().fill_rect(size_text_device_rect, context.palette().color(Gfx::ColorRole::Tooltip));
+        context.recording_painter().draw_rect(size_text_device_rect, context.palette().threed_shadow1());
+        context.recording_painter().draw_text(size_text_device_rect, size_text, font, Gfx::TextAlignment::Center, context.palette().color(Gfx::ColorRole::TooltipText));
     }
 }
 
@@ -313,7 +313,7 @@ void PaintableBox::paint_border(PaintContext& context) const
         .bottom = box_model().border.bottom == 0 ? CSS::BorderData() : computed_values().border_bottom(),
         .left = box_model().border.left == 0 ? CSS::BorderData() : computed_values().border_left(),
     };
-    context.painter().paint_borders(context.rounded_device_rect(absolute_border_box_rect()), normalized_border_radii_data().as_corners(context), borders_data.to_device_pixels(context));
+    context.recording_painter().paint_borders(context.rounded_device_rect(absolute_border_box_rect()), normalized_border_radii_data().as_corners(context), borders_data.to_device_pixels(context));
 }
 
 void PaintableBox::paint_backdrop_filter(PaintContext& context) const
@@ -439,14 +439,14 @@ void PaintableBox::before_children_paint(PaintContext& context, PaintPhase) cons
 {
     auto scroll_offset = -this->scroll_offset();
     context.translate_scroll_offset_by(scroll_offset);
-    context.painter().translate({ context.enclosing_device_pixels(scroll_offset.x()), context.enclosing_device_pixels(scroll_offset.y()) });
+    context.recording_painter().translate({ context.enclosing_device_pixels(scroll_offset.x()), context.enclosing_device_pixels(scroll_offset.y()) });
 }
 
 void PaintableBox::after_children_paint(PaintContext& context, PaintPhase) const
 {
     auto scroll_offset = this->scroll_offset();
     context.translate_scroll_offset_by(scroll_offset);
-    context.painter().translate({ context.enclosing_device_pixels(scroll_offset.x()), context.enclosing_device_pixels(scroll_offset.y()) });
+    context.recording_painter().translate({ context.enclosing_device_pixels(scroll_offset.x()), context.enclosing_device_pixels(scroll_offset.y()) });
 }
 
 void PaintableBox::apply_clip_overflow_rect(PaintContext& context, PaintPhase phase) const
@@ -471,11 +471,11 @@ void PaintableBox::apply_clip_overflow_rect(PaintContext& context, PaintPhase ph
         return;
 
     if (!m_clipping_overflow) {
-        context.painter().save();
+        context.recording_painter().save();
         auto scroll_offset = context.scroll_offset();
-        context.painter().translate({ -context.enclosing_device_pixels(scroll_offset.x()), -context.enclosing_device_pixels(scroll_offset.y()) });
-        context.painter().add_clip_rect(context.enclosing_device_rect(*clip_rect).to_type<int>());
-        context.painter().translate({ context.enclosing_device_pixels(scroll_offset.x()), context.enclosing_device_pixels(scroll_offset.y()) });
+        context.recording_painter().translate({ -context.enclosing_device_pixels(scroll_offset.x()), -context.enclosing_device_pixels(scroll_offset.y()) });
+        context.recording_painter().add_clip_rect(context.enclosing_device_rect(*clip_rect).to_type<int>());
+        context.recording_painter().translate({ context.enclosing_device_pixels(scroll_offset.x()), context.enclosing_device_pixels(scroll_offset.y()) });
         m_clipping_overflow = true;
     }
 
@@ -488,13 +488,13 @@ void PaintableBox::apply_clip_overflow_rect(PaintContext& context, PaintPhase ph
             .bottom_left = border_radii_data.bottom_left.as_corner(context)
         };
         if (border_radii_data.has_any_radius()) {
-            auto corner_clipper = BorderRadiusCornerClipper::create(corner_radii, context.painter().state().translation.map(context.rounded_device_rect(*clip_rect).to_type<int>()).to_type<DevicePixels>(), border_radii_data, CornerClip::Outside);
+            auto corner_clipper = BorderRadiusCornerClipper::create(corner_radii, context.recording_painter().state().translation.map(context.rounded_device_rect(*clip_rect).to_type<int>()).to_type<DevicePixels>(), border_radii_data, CornerClip::Outside);
             if (corner_clipper.is_error()) {
                 dbgln("Failed to create overflow border-radius corner clipper: {}", corner_clipper.error());
                 return;
             }
             m_overflow_corner_radius_clipper = corner_clipper.release_value();
-            context.painter().sample_under_corners(*m_overflow_corner_radius_clipper);
+            context.recording_painter().sample_under_corners(*m_overflow_corner_radius_clipper);
         }
     }
 }
@@ -506,11 +506,11 @@ void PaintableBox::clear_clip_overflow_rect(PaintContext& context, PaintPhase ph
 
     // FIXME: Support more overflow variations.
     if (m_clipping_overflow) {
-        context.painter().restore();
+        context.recording_painter().restore();
         m_clipping_overflow = false;
     }
     if (m_overflow_corner_radius_clipper) {
-        context.painter().blit_corner_clipping(*m_overflow_corner_radius_clipper);
+        context.recording_painter().blit_corner_clipping(*m_overflow_corner_radius_clipper);
         m_overflow_corner_radius_clipper = nullptr;
     }
 }
@@ -546,12 +546,12 @@ static void paint_cursor_if_needed(PaintContext& context, Layout::TextNode const
 
     auto cursor_device_rect = context.rounded_device_rect(cursor_rect).to_type<int>();
 
-    context.painter().draw_rect(cursor_device_rect, text_node.computed_values().color());
+    context.recording_painter().draw_rect(cursor_device_rect, text_node.computed_values().color());
 }
 
 static void paint_text_decoration(PaintContext& context, Layout::Node const& text_node, Layout::LineBoxFragment const& fragment)
 {
-    auto& painter = context.painter();
+    auto& painter = context.recording_painter();
     auto& font = fragment.layout_node().font();
     auto fragment_box = fragment.absolute_rect();
     CSSPixels glyph_height = CSSPixels::nearest_value_for(font.pixel_size());
@@ -633,14 +633,14 @@ static void paint_text_decoration(PaintContext& context, Layout::Node const& tex
 
 static void paint_text_fragment(PaintContext& context, Layout::TextNode const& text_node, Layout::LineBoxFragment const& fragment, PaintPhase phase)
 {
-    auto& painter = context.painter();
+    auto& painter = context.recording_painter();
 
     if (phase == PaintPhase::Foreground) {
         auto fragment_absolute_rect = fragment.absolute_rect();
         auto fragment_absolute_device_rect = context.enclosing_device_rect(fragment_absolute_rect);
 
         if (text_node.document().inspected_layout_node() == &text_node)
-            context.painter().draw_rect(fragment_absolute_device_rect.to_type<int>(), Color::Magenta);
+            context.recording_painter().draw_rect(fragment_absolute_device_rect.to_type<int>(), Color::Magenta);
 
         auto text = text_node.text_for_rendering();
 
@@ -678,12 +678,12 @@ void PaintableWithLines::paint(PaintContext& context, PaintPhase phase) const
     RefPtr<BorderRadiusCornerClipper> corner_clipper;
 
     if (should_clip_overflow) {
-        context.painter().save();
+        context.recording_painter().save();
         // FIXME: Handle overflow-x and overflow-y being different values.
         auto clip_box = context.rounded_device_rect(absolute_padding_box_rect());
-        context.painter().add_clip_rect(clip_box.to_type<int>());
+        context.recording_painter().add_clip_rect(clip_box.to_type<int>());
         auto scroll_offset = context.rounded_device_point(this->scroll_offset());
-        context.painter().translate(-scroll_offset.to_type<int>());
+        context.recording_painter().translate(-scroll_offset.to_type<int>());
 
         auto border_radii = normalized_border_radii_data(ShrinkRadiiForBorders::Yes);
         CornerRadii corner_radii {
@@ -693,10 +693,10 @@ void PaintableWithLines::paint(PaintContext& context, PaintPhase phase) const
             .bottom_left = border_radii.bottom_left.as_corner(context)
         };
         if (border_radii.has_any_radius()) {
-            auto clipper = BorderRadiusCornerClipper::create(corner_radii, context.painter().state().translation.map(clip_box.to_type<int>()).to_type<DevicePixels>(), border_radii);
+            auto clipper = BorderRadiusCornerClipper::create(corner_radii, context.recording_painter().state().translation.map(clip_box.to_type<int>()).to_type<DevicePixels>(), border_radii);
             if (!clipper.is_error()) {
                 corner_clipper = clipper.release_value();
-                context.painter().sample_under_corners(*corner_clipper);
+                context.recording_painter().sample_under_corners(*corner_clipper);
             }
         }
     }
@@ -722,7 +722,7 @@ void PaintableWithLines::paint(PaintContext& context, PaintPhase phase) const
                                 layer.spread_distance.to_px(layout_box()),
                                 ShadowPlacement::Outer);
                         }
-                        context.painter().set_font(fragment.layout_node().font());
+                        context.recording_painter().set_font(fragment.layout_node().font());
                         paint_text_shadow(context, fragment, resolved_shadow_data);
                     }
                 }
@@ -735,8 +735,8 @@ void PaintableWithLines::paint(PaintContext& context, PaintPhase phase) const
             auto fragment_absolute_rect = fragment.absolute_rect();
             auto fragment_absolute_device_rect = context.enclosing_device_rect(fragment_absolute_rect);
             if (context.should_show_line_box_borders()) {
-                context.painter().draw_rect(fragment_absolute_device_rect.to_type<int>(), Color::Green);
-                context.painter().draw_line(
+                context.recording_painter().draw_rect(fragment_absolute_device_rect.to_type<int>(), Color::Green);
+                context.recording_painter().draw_line(
                     context.rounded_device_point(fragment_absolute_rect.top_left().translated(0, fragment.baseline())).to_type<int>(),
                     context.rounded_device_point(fragment_absolute_rect.top_right().translated(-1, fragment.baseline())).to_type<int>(), Color::Red);
             }
@@ -746,9 +746,9 @@ void PaintableWithLines::paint(PaintContext& context, PaintPhase phase) const
     }
 
     if (should_clip_overflow) {
-        context.painter().restore();
+        context.recording_painter().restore();
         if (corner_clipper)
-            context.painter().blit_corner_clipping(*corner_clipper);
+            context.recording_painter().blit_corner_clipping(*corner_clipper);
     }
 }
 

--- a/Userland/Libraries/LibWeb/Painting/ProgressPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/ProgressPaintable.cpp
@@ -34,7 +34,7 @@ void ProgressPaintable::paint(PaintContext& context, PaintPhase phase) const
         auto min_frame_thickness = context.rounded_device_pixels(3);
         auto frame_thickness = min(min(progress_rect.width(), progress_rect.height()) / 6, min_frame_thickness);
 
-        context.painter().paint_progressbar(
+        context.recording_painter().paint_progressbar(
             progress_rect.to_type<int>(),
             progress_rect.shrunken(frame_thickness, frame_thickness).to_type<int>(),
             context.palette(),

--- a/Userland/Libraries/LibWeb/Painting/RadioButtonPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/RadioButtonPaintable.cpp
@@ -40,7 +40,7 @@ void RadioButtonPaintable::paint(PaintContext& context, PaintPhase phase) const
     auto draw_circle = [&](auto const& rect, Color color) {
         // Note: Doing this is a bit more forgiving than draw_circle() which will round to the nearset even radius.
         // This will fudge it (which works better here).
-        context.painter().fill_rect_with_rounded_corners(rect, color, rect.width() / 2);
+        context.recording_painter().fill_rect_with_rounded_corners(rect, color, rect.width() / 2);
     };
 
     auto shrink_all = [&](auto const& rect, int amount) {

--- a/Userland/Libraries/LibWeb/Painting/SVGPathPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/SVGPathPaintable.cpp
@@ -65,7 +65,7 @@ void SVGPathPaintable::paint(PaintContext& context, PaintPhase phase) const
     auto svg_element_rect = svg_element->paintable_box()->absolute_rect();
 
     // FIXME: This should not be trucated to an int.
-    RecordingPainterStateSaver save_painter { context.painter() };
+    RecordingPainterStateSaver save_painter { context.recording_painter() };
 
     auto offset = context.floored_device_point(svg_element_rect.location()).to_type<int>().to_type<float>();
     auto maybe_view_box = geometry_element.view_box();
@@ -101,7 +101,7 @@ void SVGPathPaintable::paint(PaintContext& context, PaintPhase phase) const
     auto fill_opacity = geometry_element.fill_opacity().value_or(1);
     auto winding_rule = to_gfx_winding_rule(geometry_element.fill_rule().value_or(SVG::FillRule::Nonzero));
     if (auto paint_style = geometry_element.fill_paint_style(paint_context); paint_style.has_value()) {
-        context.painter().fill_path({
+        context.recording_painter().fill_path({
             .path = closed_path(),
             .paint_style = *paint_style,
             .winding_rule = winding_rule,
@@ -109,7 +109,7 @@ void SVGPathPaintable::paint(PaintContext& context, PaintPhase phase) const
             .translation = offset,
         });
     } else if (auto fill_color = geometry_element.fill_color(); fill_color.has_value()) {
-        context.painter().fill_path({
+        context.recording_painter().fill_path({
             .path = closed_path(),
             .color = fill_color->with_opacity(fill_opacity),
             .winding_rule = winding_rule,
@@ -123,7 +123,7 @@ void SVGPathPaintable::paint(PaintContext& context, PaintPhase phase) const
     float stroke_thickness = geometry_element.stroke_width().value_or(1) * viewbox_scale;
 
     if (auto paint_style = geometry_element.stroke_paint_style(paint_context); paint_style.has_value()) {
-        context.painter().stroke_path({
+        context.recording_painter().stroke_path({
             .path = path,
             .paint_style = *paint_style,
             .thickness = stroke_thickness,
@@ -131,7 +131,7 @@ void SVGPathPaintable::paint(PaintContext& context, PaintPhase phase) const
             .translation = offset,
         });
     } else if (auto stroke_color = geometry_element.stroke_color(); stroke_color.has_value()) {
-        context.painter().stroke_path({
+        context.recording_painter().stroke_path({
             .path = path,
             .color = stroke_color->with_opacity(stroke_opacity),
             .thickness = stroke_thickness,

--- a/Userland/Libraries/LibWeb/Painting/SVGSVGPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/SVGSVGPaintable.cpp
@@ -29,9 +29,8 @@ void SVGSVGPaintable::before_children_paint(PaintContext& context, PaintPhase ph
     PaintableBox::before_children_paint(context, phase);
     if (phase != PaintPhase::Foreground)
         return;
-
-    context.painter().save();
-    context.painter().add_clip_rect(context.enclosing_device_rect(absolute_rect()).to_type<int>());
+    context.recording_painter().save();
+    context.recording_painter().add_clip_rect(context.enclosing_device_rect(absolute_rect()).to_type<int>());
 }
 
 void SVGSVGPaintable::after_children_paint(PaintContext& context, PaintPhase phase) const
@@ -39,8 +38,7 @@ void SVGSVGPaintable::after_children_paint(PaintContext& context, PaintPhase pha
     PaintableBox::after_children_paint(context, phase);
     if (phase != PaintPhase::Foreground)
         return;
-
-    context.painter().restore();
+    context.recording_painter().restore();
 }
 
 }

--- a/Userland/Libraries/LibWeb/Painting/ShadowPainting.cpp
+++ b/Userland/Libraries/LibWeb/Painting/ShadowPainting.cpp
@@ -551,7 +551,7 @@ void paint_box_shadow(PaintContext& context,
         }
 
         auto params = PaintOuterBoxShadowParams {
-            .painter = context.painter(),
+            .painter = context.recording_painter(),
             .content_rect = bordered_content_rect,
             .border_radii = border_radii,
             .box_shadow_data = box_shadow_data,
@@ -564,16 +564,16 @@ void paint_box_shadow(PaintContext& context,
             .offset_y = offset_y,
             .blur_radius = blur_radius,
             .spread_distance = spread_distance,
-            .device_content_rect = context.painter().state().translation.map(device_content_rect.to_type<int>()).to_type<DevicePixels>(),
+            .device_content_rect = context.recording_painter().state().translation.map(device_content_rect.to_type<int>()).to_type<DevicePixels>(),
         };
 
         if (box_shadow_data.placement == ShadowPlacement::Inner) {
             params.border_radii.shrink(borders_data.top.width, borders_data.right.width, borders_data.bottom.width, borders_data.left.width);
             ScopedCornerRadiusClip corner_clipper { context, device_content_rect, params.border_radii, CornerClip::Outside };
-            context.painter().paint_inner_box_shadow_params(params);
+            context.recording_painter().paint_inner_box_shadow_params(params);
         } else {
             ScopedCornerRadiusClip corner_clipper { context, device_content_rect, border_radii, CornerClip::Inside };
-            context.painter().paint_outer_box_shadow_params(params);
+            context.recording_painter().paint_outer_box_shadow_params(params);
         }
     }
 }
@@ -613,7 +613,7 @@ void paint_text_shadow(PaintContext& context, Layout::LineBoxFragment const& fra
             draw_rect.y() + offset_y - margin
         };
 
-        context.painter().paint_text_shadow(blur_radius, bounding_rect, text_rect, text, font, layer.color, fragment_baseline, draw_location);
+        context.recording_painter().paint_text_shadow(blur_radius, bounding_rect, text_rect, text, font, layer.color, fragment_baseline, draw_location);
     }
 }
 

--- a/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -300,7 +300,7 @@ void StackingContext::paint(PaintContext& context) const
     if (opacity == 0.0f)
         return;
 
-    RecordingPainterStateSaver saver(context.painter());
+    RecordingPainterStateSaver saver(context.recording_painter());
 
     auto to_device_pixels_scale = float(context.device_pixels_per_css_pixel());
     RecordingPainter::PushStackingContextParams push_stacking_context_params {
@@ -325,9 +325,9 @@ void StackingContext::paint(PaintContext& context) const
         };
     }
 
-    context.painter().push_stacking_context(push_stacking_context_params);
+    context.recording_painter().push_stacking_context(push_stacking_context_params);
     paint_internal(context);
-    context.painter().pop_stacking_context();
+    context.recording_painter().pop_stacking_context();
 }
 
 Gfx::FloatPoint StackingContext::compute_transform_origin() const

--- a/Userland/Libraries/LibWeb/Painting/TableBordersPainting.cpp
+++ b/Userland/Libraries/LibWeb/Painting/TableBordersPainting.cpp
@@ -284,12 +284,12 @@ static void paint_collected_edges(PaintContext& context, Vector<BorderEdgePainti
             : border_edge_painting_info.rect.bottom_left();
 
         if (border_style == CSS::LineStyle::Dotted) {
-            context.painter().draw_line(p1.to_type<int>(), p2.to_type<int>(), color, width.value(), Gfx::Painter::LineStyle::Dotted);
+            context.recording_painter().draw_line(p1.to_type<int>(), p2.to_type<int>(), color, width.value(), Gfx::Painter::LineStyle::Dotted);
         } else if (border_style == CSS::LineStyle::Dashed) {
-            context.painter().draw_line(p1.to_type<int>(), p2.to_type<int>(), color, width.value(), Gfx::Painter::LineStyle::Dashed);
+            context.recording_painter().draw_line(p1.to_type<int>(), p2.to_type<int>(), color, width.value(), Gfx::Painter::LineStyle::Dashed);
         } else {
             // FIXME: Support the remaining line styles instead of rendering them as solid.
-            context.painter().fill_rect(Gfx::IntRect(border_edge_painting_info.rect.location(), border_edge_painting_info.rect.size()), color);
+            context.recording_painter().fill_rect(Gfx::IntRect(border_edge_painting_info.rect.location(), border_edge_painting_info.rect.size()), color);
         }
     }
 }
@@ -351,7 +351,7 @@ static void paint_separate_cell_borders(PaintableBox const& cell_box, HashMap<Ce
         .left = cell_box.box_model().border.left == 0 ? CSS::BorderData() : cell_box.computed_values().border_left(),
     };
     auto cell_rect = cell_coordinates_to_device_rect.get({ cell_box.table_cell_coordinates()->row_index, cell_box.table_cell_coordinates()->column_index }).value();
-    context.painter().paint_borders(cell_rect, cell_box.normalized_border_radii_data().as_corners(context), borders_data.to_device_pixels(context));
+    context.recording_painter().paint_borders(cell_rect, cell_box.normalized_border_radii_data().as_corners(context), borders_data.to_device_pixels(context));
 }
 
 void paint_table_borders(PaintContext& context, PaintableBox const& table_paintable)
@@ -436,7 +436,7 @@ void paint_table_borders(PaintContext& context, PaintableBox const& table_painta
                 .bottom = cell_box.box_model().border.bottom == 0 ? CSS::BorderData() : cell_box.computed_values().border_bottom(),
                 .left = cell_box.box_model().border.left == 0 ? CSS::BorderData() : cell_box.computed_values().border_left(),
             };
-            context.painter().paint_borders(context.rounded_device_rect(cell_box.absolute_border_box_rect()), cell_box.normalized_border_radii_data().as_corners(context), borders_data.to_device_pixels(context));
+            context.recording_painter().paint_borders(context.rounded_device_rect(cell_box.absolute_border_box_rect()), cell_box.normalized_border_radii_data().as_corners(context), borders_data.to_device_pixels(context));
         }
     }
 }

--- a/Userland/Libraries/LibWeb/Painting/VideoPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/VideoPaintable.cpp
@@ -57,10 +57,10 @@ void VideoPaintable::paint(PaintContext& context, PaintPhase phase) const
     if (phase != PaintPhase::Foreground)
         return;
 
-    RecordingPainterStateSaver saver { context.painter() };
+    RecordingPainterStateSaver saver { context.recording_painter() };
 
     auto video_rect = context.rounded_device_rect(absolute_rect());
-    context.painter().add_clip_rect(video_rect.to_type<int>());
+    context.recording_painter().add_clip_rect(video_rect.to_type<int>());
 
     ScopedCornerRadiusClip corner_clip { context, video_rect, normalized_border_radii_data(ShrinkRadiiForBorders::Yes) };
 
@@ -129,12 +129,12 @@ void VideoPaintable::paint(PaintContext& context, PaintPhase phase) const
 
     auto paint_frame = [&](auto const& frame) {
         auto scaling_mode = to_gfx_scaling_mode(computed_values().image_rendering(), frame->rect(), video_rect.to_type<int>());
-        context.painter().draw_scaled_bitmap(video_rect.to_type<int>(), *frame, frame->rect(), scaling_mode);
+        context.recording_painter().draw_scaled_bitmap(video_rect.to_type<int>(), *frame, frame->rect(), scaling_mode);
     };
 
     auto paint_transparent_black = [&]() {
         static constexpr auto transparent_black = Gfx::Color::from_argb(0x00'00'00'00);
-        context.painter().fill_rect(video_rect.to_type<int>(), transparent_black);
+        context.recording_painter().fill_rect(video_rect.to_type<int>(), transparent_black);
     };
 
     auto paint_loaded_video_controls = [&]() {
@@ -210,8 +210,8 @@ void VideoPaintable::paint_placeholder_video_controls(PaintContext& context, Dev
     auto playback_button_is_hovered = mouse_position.has_value() && control_box_rect.contains(*mouse_position);
     auto playback_button_color = control_button_color(playback_button_is_hovered);
 
-    context.painter().fill_ellipse(control_box_rect.to_type<int>(), control_box_color);
-    fill_triangle(context.painter(), playback_button_location.to_type<int>(), play_button_coordinates, playback_button_color);
+    context.recording_painter().fill_ellipse(control_box_rect.to_type<int>(), control_box_color);
+    fill_triangle(context.recording_painter(), playback_button_location.to_type<int>(), play_button_coordinates, playback_button_color);
 }
 
 }

--- a/Userland/Libraries/LibWeb/Painting/ViewportPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/ViewportPaintable.cpp
@@ -53,7 +53,7 @@ void ViewportPaintable::build_stacking_context_tree()
 void ViewportPaintable::paint_all_phases(PaintContext& context)
 {
     build_stacking_context_tree_if_needed();
-    context.painter().translate(-context.device_viewport_rect().location().to_type<int>());
+    context.recording_painter().translate(-context.device_viewport_rect().location().to_type<int>());
     stacking_context()->paint(context);
 }
 


### PR DESCRIPTION
Using recording_painter() as a name is less misleading, indicating the painter in stacking context traversal doesn't perform actual painting commands.