### PR TITLE
LibCrypto: Fix verification of SECP384r1 certificate with SHA256 hash

### DIFF
--- a/Userland/Libraries/LibCrypto/Curves/SECPxxxr1.h
+++ b/Userland/Libraries/LibCrypto/Curves/SECPxxxr1.h
@@ -196,8 +196,11 @@ public:
         }
 
         // z is the hash
-        AK::FixedMemoryStream hash_stream { hash };
-        StorageType z = TRY(hash_stream.read_value<BigEndian<StorageType>>());
+        StorageType z = 0u;
+        for (uint8_t byte : hash) {
+            z <<= 8;
+            z |= byte;
+        }
 
         AK::FixedMemoryStream pubkey_stream { pubkey };
         JacobianPoint pubkey_point = TRY(read_uncompressed_point(pubkey_stream));

--- a/Userland/Libraries/LibTLS/TLSv12.cpp
+++ b/Userland/Libraries/LibTLS/TLSv12.cpp
@@ -208,7 +208,7 @@ void TLSv12::set_root_certificates(Vector<Certificate> certificates)
 
     for (auto& cert : certificates) {
         if (!cert.is_valid()) {
-            dbgln("Certificate for {} by {} is invalid, things may or may not work!", cert.subject.common_name(), cert.issuer.common_name());
+            dbgln("Certificate for {} is invalid, things may or may not work!", cert.subject.to_string());
         }
         // FIXME: Figure out what we should do when our root certs are invalid.
 


### PR DESCRIPTION
There are some websites (for example https://www.valleiautogroep.nl/) which supply SECP384r1 certificates where the signature is over a SHA256 hash. With the current implementation of the verify method this would fail as it expected the hash size to equal the curve size. With this PR we now accept any hash size in the verify method.

Additionally I have included a small change to the logging of invalid root certificates so that it actually logs the subject of the root certificate which is invalid. Instead of just printing "Certificate for  by  is invalid, ...".