### PR TITLE
LibJS: Bunch of things to make function calls faster

### DIFF
--- a/Userland/Applications/Spreadsheet/Workbook.h
+++ b/Userland/Applications/Spreadsheet/Workbook.h
@@ -47,7 +47,7 @@ private:
     NonnullOwnPtr<JS::ExecutionContext> m_root_execution_context;
 
     JS::GCPtr<WorkbookObject> m_workbook_object;
-    JS::ExecutionContext m_main_execution_context;
+    NonnullOwnPtr<JS::ExecutionContext> m_main_execution_context;
     GUI::Window& m_parent_window;
 
     DeprecatedString m_current_filename;

--- a/Userland/Libraries/LibJS/AST.cpp
+++ b/Userland/Libraries/LibJS/AST.cpp
@@ -1666,7 +1666,7 @@ void ScopeNode::block_declaration_instantiation(VM& vm, Environment* environment
 
             // iii. Perform ! env.InitializeBinding(fn, fo). NOTE: This step is replaced in section B.3.2.6.
             if (function_declaration.name_identifier()->is_local()) {
-                vm.running_execution_context().local_variables[function_declaration.name_identifier()->local_variable_index()] = function;
+                vm.running_execution_context().local(function_declaration.name_identifier()->local_variable_index()) = function;
             } else {
                 VERIFY(is<DeclarativeEnvironment>(*environment));
                 static_cast<DeclarativeEnvironment&>(*environment).initialize_or_set_mutable_binding({}, vm, function_declaration.name(), function);

--- a/Userland/Libraries/LibJS/AST.h
+++ b/Userland/Libraries/LibJS/AST.h
@@ -155,11 +155,11 @@ public:
     {
     }
 
-    Bytecode::Executable const* bytecode_executable() const { return m_bytecode_executable; }
-    void set_bytecode_executable(Bytecode::Executable const* bytecode_executable) { m_bytecode_executable = bytecode_executable; }
+    Bytecode::Executable* bytecode_executable() const { return m_bytecode_executable; }
+    void set_bytecode_executable(Bytecode::Executable* bytecode_executable) { m_bytecode_executable = make_handle(bytecode_executable); }
 
 private:
-    RefPtr<Bytecode::Executable> m_bytecode_executable;
+    Handle<Bytecode::Executable> m_bytecode_executable;
 };
 
 // 14.13 Labelled Statements, https://tc39.es/ecma262/#sec-labelled-statements
@@ -685,7 +685,7 @@ struct FunctionParameter {
     Variant<NonnullRefPtr<Identifier const>, NonnullRefPtr<BindingPattern const>> binding;
     RefPtr<Expression const> default_value;
     bool is_rest { false };
-    RefPtr<Bytecode::Executable> bytecode_executable {};
+    Handle<Bytecode::Executable> bytecode_executable {};
 };
 
 class FunctionNode {

--- a/Userland/Libraries/LibJS/Bytecode/CommonImplementations.h
+++ b/Userland/Libraries/LibJS/Bytecode/CommonImplementations.h
@@ -17,7 +17,7 @@ ThrowCompletionOr<Value> get_by_id(VM&, DeprecatedFlyString const& property, Val
 ThrowCompletionOr<Value> get_by_value(VM&, Value base_value, Value property_key_value);
 ThrowCompletionOr<Value> get_global(Bytecode::Interpreter&, DeprecatedFlyString const& identifier, GlobalVariableCache&);
 ThrowCompletionOr<void> put_by_property_key(VM&, Value base, Value this_value, Value value, PropertyKey name, Op::PropertyKind kind, PropertyLookupCache* = nullptr);
-ThrowCompletionOr<Value> perform_call(Interpreter&, Value this_value, Op::CallType, Value callee, MarkedVector<Value> argument_values);
+ThrowCompletionOr<Value> perform_call(Interpreter&, Value this_value, Op::CallType, Value callee, ReadonlySpan<Value> argument_values);
 ThrowCompletionOr<void> throw_if_needed_for_call(Interpreter&, Value callee, Op::CallType, Optional<StringTableIndex> const& expression_string);
 ThrowCompletionOr<Value> typeof_variable(VM&, DeprecatedFlyString const&);
 ThrowCompletionOr<void> set_variable(VM&, DeprecatedFlyString const&, Value, Op::EnvironmentMode, Op::SetVariable::InitializationMode, EnvironmentVariableCache&);

--- a/Userland/Libraries/LibJS/Bytecode/Executable.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Executable.cpp
@@ -13,6 +13,8 @@
 
 namespace JS::Bytecode {
 
+JS_DEFINE_ALLOCATOR(Executable);
+
 Executable::Executable(
     NonnullOwnPtr<IdentifierTable> identifier_table,
     NonnullOwnPtr<StringTable> string_table,

--- a/Userland/Libraries/LibJS/Bytecode/Executable.h
+++ b/Userland/Libraries/LibJS/Bytecode/Executable.h
@@ -15,6 +15,8 @@
 #include <LibJS/Bytecode/Label.h>
 #include <LibJS/Bytecode/StringTable.h>
 #include <LibJS/Forward.h>
+#include <LibJS/Heap/Cell.h>
+#include <LibJS/Heap/CellAllocator.h>
 #include <LibJS/Runtime/EnvironmentCoordinate.h>
 
 namespace JS::JIT {
@@ -46,7 +48,10 @@ struct SourceRecord {
     u32 source_end_offset {};
 };
 
-class Executable final : public RefCounted<Executable> {
+class Executable final : public Cell {
+    JS_CELL(Executable, Cell);
+    JS_DECLARE_ALLOCATOR(Executable);
+
 public:
     Executable(
         NonnullOwnPtr<IdentifierTable>,
@@ -60,7 +65,7 @@ public:
         Vector<NonnullOwnPtr<BasicBlock>>,
         bool is_strict_mode);
 
-    ~Executable();
+    virtual ~Executable() override;
 
     DeprecatedFlyString name;
     Vector<PropertyLookupCache> property_lookup_caches;

--- a/Userland/Libraries/LibJS/Bytecode/Generator.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.cpp
@@ -11,6 +11,7 @@
 #include <LibJS/Bytecode/Instruction.h>
 #include <LibJS/Bytecode/Op.h>
 #include <LibJS/Bytecode/Register.h>
+#include <LibJS/Runtime/VM.h>
 
 namespace JS::Bytecode {
 
@@ -21,7 +22,7 @@ Generator::Generator()
 {
 }
 
-CodeGenerationErrorOr<NonnullRefPtr<Executable>> Generator::generate(ASTNode const& node, FunctionKind enclosing_function_kind)
+CodeGenerationErrorOr<NonnullGCPtr<Executable>> Generator::generate(VM& vm, ASTNode const& node, FunctionKind enclosing_function_kind)
 {
     Generator generator;
     generator.switch_to_basic_block(generator.make_block());
@@ -57,7 +58,7 @@ CodeGenerationErrorOr<NonnullRefPtr<Executable>> Generator::generate(ASTNode con
     else if (is<FunctionExpression>(node))
         is_strict_mode = static_cast<FunctionExpression const&>(node).is_strict_mode();
 
-    auto executable = adopt_ref(*new Executable(
+    auto executable = vm.heap().allocate_without_realm<Executable>(
         move(generator.m_identifier_table),
         move(generator.m_string_table),
         move(generator.m_regex_table),
@@ -67,7 +68,7 @@ CodeGenerationErrorOr<NonnullRefPtr<Executable>> Generator::generate(ASTNode con
         generator.m_next_environment_variable_cache,
         generator.m_next_register,
         move(generator.m_root_basic_blocks),
-        is_strict_mode));
+        is_strict_mode);
 
     return executable;
 }

--- a/Userland/Libraries/LibJS/Bytecode/Generator.h
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.h
@@ -30,7 +30,7 @@ public:
         Function,
         Block,
     };
-    static CodeGenerationErrorOr<NonnullRefPtr<Executable>> generate(ASTNode const&, FunctionKind = FunctionKind::Normal);
+    static CodeGenerationErrorOr<NonnullGCPtr<Executable>> generate(VM&, ASTNode const&, FunctionKind = FunctionKind::Normal);
 
     Register allocate_register();
 

--- a/Userland/Libraries/LibJS/Bytecode/Instruction.h
+++ b/Userland/Libraries/LibJS/Bytecode/Instruction.h
@@ -187,7 +187,7 @@ private:
     u8 const* m_begin { nullptr };
     u8 const* m_end { nullptr };
     u8 const* m_ptr { nullptr };
-    RefPtr<Executable const> m_executable;
+    GCPtr<Executable const> m_executable;
 };
 
 }

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -105,7 +105,7 @@ ThrowCompletionOr<Value> Interpreter::run(Script& script_record, JS::GCPtr<Envir
 
     // 13. If result.[[Type]] is normal, then
     if (result.type() == Completion::Type::Normal) {
-        auto executable_result = JS::Bytecode::Generator::generate(script);
+        auto executable_result = JS::Bytecode::Generator::generate(vm, script);
 
         if (executable_result.is_error()) {
             if (auto error_string = executable_result.error().to_string(); error_string.is_error())
@@ -451,9 +451,9 @@ void Interpreter::enter_object_environment(Object& object)
     vm().running_execution_context().lexical_environment = new_object_environment(object, true, old_environment);
 }
 
-ThrowCompletionOr<NonnullRefPtr<Bytecode::Executable>> compile(VM& vm, ASTNode const& node, FunctionKind kind, DeprecatedFlyString const& name)
+ThrowCompletionOr<NonnullGCPtr<Bytecode::Executable>> compile(VM& vm, ASTNode const& node, FunctionKind kind, DeprecatedFlyString const& name)
 {
-    auto executable_result = Bytecode::Generator::generate(node, kind);
+    auto executable_result = Bytecode::Generator::generate(vm, node, kind);
     if (executable_result.is_error())
         return vm.throw_completion<InternalError>(ErrorType::NotImplemented, TRY_OR_THROW_OOM(vm, executable_result.error().to_string()));
 

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.h
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.h
@@ -115,6 +115,6 @@ private:
 
 extern bool g_dump_bytecode;
 
-ThrowCompletionOr<NonnullRefPtr<Bytecode::Executable>> compile(VM&, ASTNode const& no, JS::FunctionKind kind, DeprecatedFlyString const& name);
+ThrowCompletionOr<NonnullGCPtr<Bytecode::Executable>> compile(VM&, ASTNode const& no, JS::FunctionKind kind, DeprecatedFlyString const& name);
 
 }

--- a/Userland/Libraries/LibJS/Console.cpp
+++ b/Userland/Libraries/LibJS/Console.cpp
@@ -142,9 +142,9 @@ ThrowCompletionOr<Value> Console::trace()
     // NOTE: -2 to skip the console.trace() execution context
     for (ssize_t i = execution_context_stack.size() - 2; i >= 0; --i) {
         auto const& function_name = execution_context_stack[i]->function_name;
-        trace.stack.append(function_name.is_empty()
+        trace.stack.append((!function_name || function_name->is_empty())
                 ? "<anonymous>"_string
-                : TRY_OR_THROW_OOM(vm, String::from_deprecated_string(function_name)));
+                : function_name->utf8_string());
     }
 
     // 2. Optionally, let formattedData be the result of Formatter(data), and incorporate formattedData as a label for trace.

--- a/Userland/Libraries/LibJS/Heap/Heap.cpp
+++ b/Userland/Libraries/LibJS/Heap/Heap.cpp
@@ -450,6 +450,9 @@ void Heap::mark_live_cells(HashMap<Cell*, HeapRoot> const& roots)
 
     MarkingVisitor visitor(*this, roots);
 
+    for (auto& execution_context : m_execution_contexts)
+        execution_context.visit_edges(visitor);
+
     vm().bytecode_interpreter().visit_edges(visitor);
 
     visitor.mark_all_live_cells();

--- a/Userland/Libraries/LibJS/Heap/Heap.h
+++ b/Userland/Libraries/LibJS/Heap/Heap.h
@@ -23,6 +23,7 @@
 #include <LibJS/Heap/Internals.h>
 #include <LibJS/Heap/MarkedVector.h>
 #include <LibJS/Runtime/Completion.h>
+#include <LibJS/Runtime/ExecutionContext.h>
 #include <LibJS/Runtime/WeakContainer.h>
 
 namespace JS {
@@ -76,6 +77,9 @@ public:
 
     void did_create_weak_container(Badge<WeakContainer>, WeakContainer&);
     void did_destroy_weak_container(Badge<WeakContainer>, WeakContainer&);
+
+    void did_create_execution_context(Badge<ExecutionContext>, ExecutionContext&);
+    void did_destroy_execution_context(Badge<ExecutionContext>, ExecutionContext&);
 
     BlockAllocator& block_allocator() { return m_block_allocator; }
 
@@ -144,6 +148,7 @@ private:
     HandleImpl::List m_handles;
     MarkedVectorBase::List m_marked_vectors;
     WeakContainer::List m_weak_containers;
+    ExecutionContext::List m_execution_contexts;
 
     Vector<GCPtr<Cell>> m_uprooted_cells;
 
@@ -189,6 +194,18 @@ inline void Heap::did_destroy_weak_container(Badge<WeakContainer>, WeakContainer
 {
     VERIFY(m_weak_containers.contains(set));
     m_weak_containers.remove(set);
+}
+
+inline void Heap::did_create_execution_context(Badge<ExecutionContext>, ExecutionContext& set)
+{
+    VERIFY(!m_execution_contexts.contains(set));
+    m_execution_contexts.append(set);
+}
+
+inline void Heap::did_destroy_execution_context(Badge<ExecutionContext>, ExecutionContext& set)
+{
+    VERIFY(m_execution_contexts.contains(set));
+    m_execution_contexts.remove(set);
 }
 
 }

--- a/Userland/Libraries/LibJS/JIT/Compiler.cpp
+++ b/Userland/Libraries/LibJS/JIT/Compiler.cpp
@@ -2507,12 +2507,8 @@ static Value cxx_call(VM& vm, Value callee, u32 first_argument_index, u32 argume
 {
     TRY_OR_SET_EXCEPTION(throw_if_needed_for_call(vm.bytecode_interpreter(), callee, call_type, expression_string));
 
-    MarkedVector<Value> argument_values(vm.heap());
-    argument_values.ensure_capacity(argument_count);
-    for (u32 i = 0; i < argument_count; ++i) {
-        argument_values.unchecked_append(vm.bytecode_interpreter().reg(Bytecode::Register { first_argument_index + i }));
-    }
-    return TRY_OR_SET_EXCEPTION(perform_call(vm.bytecode_interpreter(), this_value, call_type, callee, move(argument_values)));
+    auto argument_values = vm.bytecode_interpreter().registers().slice(first_argument_index, argument_count);
+    return TRY_OR_SET_EXCEPTION(perform_call(vm.bytecode_interpreter(), this_value, call_type, callee, argument_values));
 }
 
 Assembler::Reg Compiler::argument_register(u32 index)

--- a/Userland/Libraries/LibJS/JIT/NativeExecutable.cpp
+++ b/Userland/Libraries/LibJS/JIT/NativeExecutable.cpp
@@ -46,7 +46,7 @@ void NativeExecutable::run(VM& vm, size_t entry_point) const
     typedef void (*JITCode)(VM&, Value* registers, Value* locals, FlatPtr entry_point_address, ExecutionContext&);
     ((JITCode)m_code)(vm,
         vm.bytecode_interpreter().registers().data(),
-        vm.running_execution_context().local_variables.data(),
+        vm.running_execution_context().locals.data(),
         entry_point_address,
         vm.running_execution_context());
 }

--- a/Userland/Libraries/LibJS/Runtime/AbstractOperations.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AbstractOperations.cpp
@@ -679,7 +679,7 @@ ThrowCompletionOr<Value> perform_eval(VM& vm, Value x, CallerMode strict_caller,
 
     // 29. If result.[[Type]] is normal, then
     //     a. Set result to the result of evaluating body.
-    auto executable_result = Bytecode::Generator::generate(program);
+    auto executable_result = Bytecode::Generator::generate(vm, program);
     if (executable_result.is_error())
         return vm.throw_completion<InternalError>(ErrorType::NotImplemented, TRY_OR_THROW_OOM(vm, executable_result.error().to_string()));
 

--- a/Userland/Libraries/LibJS/Runtime/AbstractOperations.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AbstractOperations.cpp
@@ -638,31 +638,31 @@ ThrowCompletionOr<Value> perform_eval(VM& vm, Value x, CallerMode strict_caller,
     // FIXME: We don't have this concept yet.
 
     // 20. Let evalContext be a new ECMAScript code execution context.
-    ExecutionContext eval_context(vm.heap());
+    auto eval_context = ExecutionContext::create(vm.heap());
 
     // 21. Set evalContext's Function to null.
     // NOTE: This was done in the construction of eval_context.
 
     // 22. Set evalContext's Realm to evalRealm.
-    eval_context.realm = &eval_realm;
+    eval_context->realm = &eval_realm;
 
     // 23. Set evalContext's ScriptOrModule to runningContext's ScriptOrModule.
-    eval_context.script_or_module = running_context.script_or_module;
+    eval_context->script_or_module = running_context.script_or_module;
 
     // 24. Set evalContext's VariableEnvironment to varEnv.
-    eval_context.variable_environment = variable_environment;
+    eval_context->variable_environment = variable_environment;
 
     // 25. Set evalContext's LexicalEnvironment to lexEnv.
-    eval_context.lexical_environment = lexical_environment;
+    eval_context->lexical_environment = lexical_environment;
 
     // 26. Set evalContext's PrivateEnvironment to privateEnv.
-    eval_context.private_environment = private_environment;
+    eval_context->private_environment = private_environment;
 
     // NOTE: This isn't in the spec, but we require it.
-    eval_context.is_strict_mode = strict_eval;
+    eval_context->is_strict_mode = strict_eval;
 
     // 27. Push evalContext onto the execution context stack; evalContext is now the running execution context.
-    TRY(vm.push_execution_context(eval_context, {}));
+    TRY(vm.push_execution_context(*eval_context, {}));
 
     // NOTE: We use a ScopeGuard to automatically pop the execution context when any of the `TRY`s below return a throw completion.
     ScopeGuard pop_guard = [&] {
@@ -1025,7 +1025,7 @@ ThrowCompletionOr<void> eval_declaration_instantiation(VM& vm, Program const& pr
 }
 
 // 10.4.4.6 CreateUnmappedArgumentsObject ( argumentsList ), https://tc39.es/ecma262/#sec-createunmappedargumentsobject
-Object* create_unmapped_arguments_object(VM& vm, Span<Value> arguments)
+Object* create_unmapped_arguments_object(VM& vm, ReadonlySpan<Value> arguments)
 {
     auto& realm = *vm.current_realm();
 
@@ -1065,7 +1065,7 @@ Object* create_unmapped_arguments_object(VM& vm, Span<Value> arguments)
 }
 
 // 10.4.4.7 CreateMappedArgumentsObject ( func, formals, argumentsList, env ), https://tc39.es/ecma262/#sec-createmappedargumentsobject
-Object* create_mapped_arguments_object(VM& vm, FunctionObject& function, Vector<FunctionParameter> const& formals, Span<Value> arguments, Environment& environment)
+Object* create_mapped_arguments_object(VM& vm, FunctionObject& function, Vector<FunctionParameter> const& formals, ReadonlySpan<Value> arguments, Environment& environment)
 {
     auto& realm = *vm.current_realm();
 

--- a/Userland/Libraries/LibJS/Runtime/AbstractOperations.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AbstractOperations.cpp
@@ -47,46 +47,40 @@ ThrowCompletionOr<Value> require_object_coercible(VM& vm, Value value)
 }
 
 // 7.3.14 Call ( F, V [ , argumentsList ] ), https://tc39.es/ecma262/#sec-call
-ThrowCompletionOr<Value> call_impl(VM& vm, Value function, Value this_value, Optional<MarkedVector<Value>> arguments_list)
+ThrowCompletionOr<Value> call_impl(VM& vm, Value function, Value this_value, ReadonlySpan<Value> arguments_list)
 {
     // 1. If argumentsList is not present, set argumentsList to a new empty List.
-    if (!arguments_list.has_value())
-        arguments_list = MarkedVector<Value> { vm.heap() };
 
     // 2. If IsCallable(F) is false, throw a TypeError exception.
     if (!function.is_function())
         return vm.throw_completion<TypeError>(ErrorType::NotAFunction, function.to_string_without_side_effects());
 
     // 3. Return ? F.[[Call]](V, argumentsList).
-    return function.as_function().internal_call(this_value, move(*arguments_list));
+    return function.as_function().internal_call(this_value, arguments_list);
 }
 
-ThrowCompletionOr<Value> call_impl(VM& vm, FunctionObject& function, Value this_value, Optional<MarkedVector<Value>> arguments_list)
+ThrowCompletionOr<Value> call_impl(VM&, FunctionObject& function, Value this_value, ReadonlySpan<Value> arguments_list)
 {
     // 1. If argumentsList is not present, set argumentsList to a new empty List.
-    if (!arguments_list.has_value())
-        arguments_list = MarkedVector<Value> { vm.heap() };
 
     // 2. If IsCallable(F) is false, throw a TypeError exception.
     // Note: Called with a FunctionObject ref
 
     // 3. Return ? F.[[Call]](V, argumentsList).
-    return function.internal_call(this_value, move(*arguments_list));
+    return function.internal_call(this_value, arguments_list);
 }
 
 // 7.3.15 Construct ( F [ , argumentsList [ , newTarget ] ] ), https://tc39.es/ecma262/#sec-construct
-ThrowCompletionOr<NonnullGCPtr<Object>> construct_impl(VM& vm, FunctionObject& function, Optional<MarkedVector<Value>> arguments_list, FunctionObject* new_target)
+ThrowCompletionOr<NonnullGCPtr<Object>> construct_impl(VM&, FunctionObject& function, ReadonlySpan<Value> arguments_list, FunctionObject* new_target)
 {
     // 1. If newTarget is not present, set newTarget to F.
     if (!new_target)
         new_target = &function;
 
     // 2. If argumentsList is not present, set argumentsList to a new empty List.
-    if (!arguments_list.has_value())
-        arguments_list = MarkedVector<Value> { vm.heap() };
 
     // 3. Return ? F.[[Construct]](argumentsList, newTarget).
-    return function.internal_construct(move(*arguments_list), *new_target);
+    return function.internal_construct(arguments_list, *new_target);
 }
 
 // 7.3.19 LengthOfArrayLike ( obj ), https://tc39.es/ecma262/#sec-lengthofarraylike

--- a/Userland/Libraries/LibJS/Runtime/AbstractOperations.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AbstractOperations.cpp
@@ -691,7 +691,7 @@ ThrowCompletionOr<Value> perform_eval(VM& vm, Value x, CallerMode strict_caller,
     if (result_or_error.value.is_error())
         return result_or_error.value.release_error();
 
-    auto& result = result_or_error.frame->registers[0];
+    auto& result = result_or_error.frame->registers()[0];
     if (!result.is_empty())
         eval_result = result;
 

--- a/Userland/Libraries/LibJS/Runtime/AbstractOperations.h
+++ b/Userland/Libraries/LibJS/Runtime/AbstractOperations.h
@@ -39,8 +39,8 @@ ThrowCompletionOr<void> initialize_bound_name(VM&, DeprecatedFlyString const&, V
 bool is_compatible_property_descriptor(bool extensible, PropertyDescriptor const&, Optional<PropertyDescriptor> const& current);
 bool validate_and_apply_property_descriptor(Object*, PropertyKey const&, bool extensible, PropertyDescriptor const&, Optional<PropertyDescriptor> const& current);
 ThrowCompletionOr<Object*> get_prototype_from_constructor(VM&, FunctionObject const& constructor, NonnullGCPtr<Object> (Intrinsics::*intrinsic_default_prototype)());
-Object* create_unmapped_arguments_object(VM&, Span<Value> arguments);
-Object* create_mapped_arguments_object(VM&, FunctionObject&, Vector<FunctionParameter> const&, Span<Value> arguments, Environment&);
+Object* create_unmapped_arguments_object(VM&, ReadonlySpan<Value> arguments);
+Object* create_mapped_arguments_object(VM&, FunctionObject&, Vector<FunctionParameter> const&, ReadonlySpan<Value> arguments, Environment&);
 
 struct DisposableResource {
     Value resource_value;

--- a/Userland/Libraries/LibJS/Runtime/Array.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Array.cpp
@@ -63,6 +63,24 @@ NonnullGCPtr<Array> Array::create_from(Realm& realm, Vector<Value> const& elemen
     return array;
 }
 
+NonnullGCPtr<Array> Array::create_from(Realm& realm, ReadonlySpan<Value> const& elements)
+{
+    // 1. Let array be ! ArrayCreate(0).
+    auto array = MUST(Array::create(realm, 0));
+
+    // 2. Let n be 0.
+    // 3. For each element e of elements, do
+    for (u32 n = 0; n < elements.size(); ++n) {
+        // a. Perform ! CreateDataPropertyOrThrow(array, ! ToString(𝔽(n)), e).
+        MUST(array->create_data_property_or_throw(n, elements[n]));
+
+        // b. Set n to n + 1.
+    }
+
+    // 4. Return array.
+    return array;
+}
+
 Array::Array(Object& prototype)
     : Object(ConstructWithPrototypeTag::Tag, prototype)
 {

--- a/Userland/Libraries/LibJS/Runtime/Array.h
+++ b/Userland/Libraries/LibJS/Runtime/Array.h
@@ -26,6 +26,7 @@ class Array : public Object {
 public:
     static ThrowCompletionOr<NonnullGCPtr<Array>> create(Realm&, u64 length, Object* prototype = nullptr);
     static NonnullGCPtr<Array> create_from(Realm&, Vector<Value> const&);
+    static NonnullGCPtr<Array> create_from(Realm&, ReadonlySpan<Value> const&);
 
     // Non-standard but equivalent to CreateArrayFromList.
     template<typename T>

--- a/Userland/Libraries/LibJS/Runtime/AsyncFunctionConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AsyncFunctionConstructor.cpp
@@ -45,7 +45,9 @@ ThrowCompletionOr<NonnullGCPtr<Object>> AsyncFunctionConstructor::construct(Func
     auto* constructor = vm.active_function_object();
 
     // 2. Let args be the argumentsList that was passed to this function by [[Call]] or [[Construct]].
-    auto& args = vm.running_execution_context().arguments;
+    MarkedVector<Value> args(heap());
+    for (auto argument : vm.running_execution_context().arguments)
+        args.append(argument);
 
     // 3. Return CreateDynamicFunction(C, NewTarget, async, args).
     return *TRY(FunctionConstructor::create_dynamic_function(vm, *constructor, &new_target, FunctionKind::Async, args));

--- a/Userland/Libraries/LibJS/Runtime/AsyncFunctionDriverWrapper.h
+++ b/Userland/Libraries/LibJS/Runtime/AsyncFunctionDriverWrapper.h
@@ -39,7 +39,7 @@ private:
     NonnullGCPtr<Promise> m_top_level_promise;
     GCPtr<Promise> m_current_promise { nullptr };
     Handle<AsyncFunctionDriverWrapper> m_self_handle;
-    Optional<ExecutionContext> m_suspended_execution_context;
+    OwnPtr<ExecutionContext> m_suspended_execution_context;
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/AsyncGenerator.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AsyncGenerator.cpp
@@ -16,7 +16,7 @@ namespace JS {
 
 JS_DEFINE_ALLOCATOR(AsyncGenerator);
 
-ThrowCompletionOr<NonnullGCPtr<AsyncGenerator>> AsyncGenerator::create(Realm& realm, Value initial_value, ECMAScriptFunctionObject* generating_function, NonnullOwnPtr<ExecutionContext> execution_context, Bytecode::CallFrame frame)
+ThrowCompletionOr<NonnullGCPtr<AsyncGenerator>> AsyncGenerator::create(Realm& realm, Value initial_value, ECMAScriptFunctionObject* generating_function, NonnullOwnPtr<ExecutionContext> execution_context, NonnullOwnPtr<Bytecode::CallFrame> frame)
 {
     auto& vm = realm.vm();
     // This is "g1.prototype" in figure-2 (https://tc39.es/ecma262/img/figure-2.png)
@@ -45,7 +45,7 @@ void AsyncGenerator::visit_edges(Cell::Visitor& visitor)
     }
     visitor.visit(m_generating_function);
     visitor.visit(m_previous_value);
-    if (m_frame.has_value())
+    if (m_frame)
         m_frame->visit_edges(visitor);
     visitor.visit(m_current_promise);
 }
@@ -192,18 +192,18 @@ void AsyncGenerator::execute(VM& vm, Completion completion)
         VERIFY(!m_generating_function->bytecode_executable()->basic_blocks.find_if([next_block](auto& block) { return block == next_block; }).is_end());
 
         Bytecode::CallFrame* frame = nullptr;
-        if (m_frame.has_value())
-            frame = &m_frame.value();
+        if (m_frame)
+            frame = m_frame.ptr();
 
         if (frame)
-            frame->registers[0] = completion_object;
+            frame->registers()[0] = completion_object;
         else
             bytecode_interpreter.accumulator() = completion_object;
 
         auto next_result = bytecode_interpreter.run_and_return_frame(*m_generating_function->bytecode_executable(), next_block, frame);
 
-        if (!m_frame.has_value())
-            m_frame = move(*next_result.frame);
+        if (!m_frame)
+            m_frame = move(next_result.frame);
 
         auto result_value = move(next_result.value);
         if (!result_value.is_throw_completion()) {

--- a/Userland/Libraries/LibJS/Runtime/AsyncGenerator.h
+++ b/Userland/Libraries/LibJS/Runtime/AsyncGenerator.h
@@ -28,7 +28,7 @@ public:
         Completed,
     };
 
-    static ThrowCompletionOr<NonnullGCPtr<AsyncGenerator>> create(Realm&, Value, ECMAScriptFunctionObject*, NonnullOwnPtr<ExecutionContext>, Bytecode::CallFrame);
+    static ThrowCompletionOr<NonnullGCPtr<AsyncGenerator>> create(Realm&, Value, ECMAScriptFunctionObject*, NonnullOwnPtr<ExecutionContext>, NonnullOwnPtr<Bytecode::CallFrame>);
 
     virtual ~AsyncGenerator() override = default;
 
@@ -60,7 +60,7 @@ private:
 
     GCPtr<ECMAScriptFunctionObject> m_generating_function;
     Value m_previous_value;
-    Optional<Bytecode::CallFrame> m_frame;
+    OwnPtr<Bytecode::CallFrame> m_frame;
     GCPtr<Promise> m_current_promise;
 };
 

--- a/Userland/Libraries/LibJS/Runtime/AsyncGenerator.h
+++ b/Userland/Libraries/LibJS/Runtime/AsyncGenerator.h
@@ -28,7 +28,7 @@ public:
         Completed,
     };
 
-    static ThrowCompletionOr<NonnullGCPtr<AsyncGenerator>> create(Realm&, Value, ECMAScriptFunctionObject*, ExecutionContext, Bytecode::CallFrame);
+    static ThrowCompletionOr<NonnullGCPtr<AsyncGenerator>> create(Realm&, Value, ECMAScriptFunctionObject*, NonnullOwnPtr<ExecutionContext>, Bytecode::CallFrame);
 
     virtual ~AsyncGenerator() override = default;
 
@@ -44,7 +44,7 @@ public:
     Optional<String> const& generator_brand() const { return m_generator_brand; }
 
 private:
-    AsyncGenerator(Realm&, Object& prototype, ExecutionContext);
+    AsyncGenerator(Realm&, Object& prototype, NonnullOwnPtr<ExecutionContext>);
 
     virtual void visit_edges(Cell::Visitor&) override;
 
@@ -53,10 +53,10 @@ private:
 
     // At the time of constructing an AsyncGenerator, we still need to point to an
     // execution context on the stack, but later need to 'adopt' it.
-    State m_async_generator_state { State::SuspendedStart }; // [[AsyncGeneratorState]]
-    ExecutionContext m_async_generator_context;              // [[AsyncGeneratorContext]]
-    Vector<AsyncGeneratorRequest> m_async_generator_queue;   // [[AsyncGeneratorQueue]]
-    Optional<String> m_generator_brand;                      // [[GeneratorBrand]]
+    State m_async_generator_state { State::SuspendedStart };   // [[AsyncGeneratorState]]
+    NonnullOwnPtr<ExecutionContext> m_async_generator_context; // [[AsyncGeneratorContext]]
+    Vector<AsyncGeneratorRequest> m_async_generator_queue;     // [[AsyncGeneratorQueue]]
+    Optional<String> m_generator_brand;                        // [[GeneratorBrand]]
 
     GCPtr<ECMAScriptFunctionObject> m_generating_function;
     Value m_previous_value;

--- a/Userland/Libraries/LibJS/Runtime/AsyncGeneratorFunctionConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AsyncGeneratorFunctionConstructor.cpp
@@ -46,7 +46,9 @@ ThrowCompletionOr<NonnullGCPtr<Object>> AsyncGeneratorFunctionConstructor::const
     auto* constructor = vm.active_function_object();
 
     // 2. Let args be the argumentsList that was passed to this function by [[Call]] or [[Construct]].
-    auto& args = vm.running_execution_context().arguments;
+    MarkedVector<Value> args(heap());
+    for (auto argument : vm.running_execution_context().arguments)
+        args.append(argument);
 
     // 3. Return ? CreateDynamicFunction(C, NewTarget, asyncGenerator, args).
     return *TRY(FunctionConstructor::create_dynamic_function(vm, *constructor, &new_target, FunctionKind::AsyncGenerator, args));

--- a/Userland/Libraries/LibJS/Runtime/BoundFunction.h
+++ b/Userland/Libraries/LibJS/Runtime/BoundFunction.h
@@ -20,8 +20,8 @@ public:
 
     virtual ~BoundFunction() override = default;
 
-    virtual ThrowCompletionOr<Value> internal_call(Value this_argument, MarkedVector<Value> arguments_list) override;
-    virtual ThrowCompletionOr<NonnullGCPtr<Object>> internal_construct(MarkedVector<Value> arguments_list, FunctionObject& new_target) override;
+    virtual ThrowCompletionOr<Value> internal_call(Value this_argument, ReadonlySpan<Value> arguments_list) override;
+    virtual ThrowCompletionOr<NonnullGCPtr<Object>> internal_construct(ReadonlySpan<Value> arguments_list, FunctionObject& new_target) override;
 
     virtual DeprecatedFlyString const& name() const override { return m_name; }
     virtual bool is_strict_mode() const override { return m_bound_target_function->is_strict_mode(); }

--- a/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
@@ -914,7 +914,7 @@ ThrowCompletionOr<void> ECMAScriptFunctionObject::function_declaration_instantia
 
     if (is<DeclarativeEnvironment>(*lex_environment))
         static_cast<DeclarativeEnvironment*>(lex_environment.ptr())->shrink_to_fit();
-    if (is<DeclarativeEnvironment>(*var_environment))
+    if (lex_environment != var_environment && is<DeclarativeEnvironment>(*var_environment))
         static_cast<DeclarativeEnvironment*>(var_environment.ptr())->shrink_to_fit();
 
     // 37. Return unused.

--- a/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
@@ -361,7 +361,7 @@ void ECMAScriptFunctionObject::initialize(Realm& realm)
 }
 
 // 10.2.1 [[Call]] ( thisArgument, argumentsList ), https://tc39.es/ecma262/#sec-ecmascript-function-objects-call-thisargument-argumentslist
-ThrowCompletionOr<Value> ECMAScriptFunctionObject::internal_call(Value this_argument, MarkedVector<Value> arguments_list)
+ThrowCompletionOr<Value> ECMAScriptFunctionObject::internal_call(Value this_argument, ReadonlySpan<Value> arguments_list)
 {
     auto& vm = this->vm();
 
@@ -373,7 +373,7 @@ ThrowCompletionOr<Value> ECMAScriptFunctionObject::internal_call(Value this_argu
     callee_context.local_variables.resize(m_local_variables_names.size());
 
     // Non-standard
-    callee_context.arguments.extend(move(arguments_list));
+    callee_context.arguments.append(arguments_list.data(), arguments_list.size());
     callee_context.instruction_stream_iterator = vm.bytecode_interpreter().instruction_stream_iterator();
 
     // 2. Let calleeContext be PrepareForOrdinaryCall(F, undefined).
@@ -420,7 +420,7 @@ ThrowCompletionOr<Value> ECMAScriptFunctionObject::internal_call(Value this_argu
 }
 
 // 10.2.2 [[Construct]] ( argumentsList, newTarget ), https://tc39.es/ecma262/#sec-ecmascript-function-objects-construct-argumentslist-newtarget
-ThrowCompletionOr<NonnullGCPtr<Object>> ECMAScriptFunctionObject::internal_construct(MarkedVector<Value> arguments_list, FunctionObject& new_target)
+ThrowCompletionOr<NonnullGCPtr<Object>> ECMAScriptFunctionObject::internal_construct(ReadonlySpan<Value> arguments_list, FunctionObject& new_target)
 {
     auto& vm = this->vm();
 
@@ -443,7 +443,7 @@ ThrowCompletionOr<NonnullGCPtr<Object>> ECMAScriptFunctionObject::internal_const
     callee_context.local_variables.resize(m_local_variables_names.size());
 
     // Non-standard
-    callee_context.arguments.extend(move(arguments_list));
+    callee_context.arguments.append(arguments_list.data(), arguments_list.size());
     callee_context.instruction_stream_iterator = vm.bytecode_interpreter().instruction_stream_iterator();
 
     // 4. Let calleeContext be PrepareForOrdinaryCall(F, newTarget).

--- a/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
@@ -869,31 +869,33 @@ ThrowCompletionOr<void> ECMAScriptFunctionObject::function_declaration_instantia
     // 33. Let lexDeclarations be the LexicallyScopedDeclarations of code.
     // 34. For each element d of lexDeclarations, do
     // NOTE: Due to the use of MUST in the callback, an exception should not result from `for_each_lexically_scoped_declaration`.
-    MUST(scope_body->for_each_lexically_scoped_declaration([&](Declaration const& declaration) {
-        // NOTE: Due to the use of MUST with `create_immutable_binding` and `create_mutable_binding` below,
-        //       an exception should not result from `for_each_bound_name`.
+    if (scope_body->has_lexical_declarations()) {
+        MUST(scope_body->for_each_lexically_scoped_declaration([&](Declaration const& declaration) {
+            // NOTE: Due to the use of MUST with `create_immutable_binding` and `create_mutable_binding` below,
+            //       an exception should not result from `for_each_bound_name`.
 
-        // a. NOTE: A lexically declared name cannot be the same as a function/generator declaration, formal parameter, or a var name. Lexically declared names are only instantiated here but not initialized.
+            // a. NOTE: A lexically declared name cannot be the same as a function/generator declaration, formal parameter, or a var name. Lexically declared names are only instantiated here but not initialized.
 
-        // b. For each element dn of the BoundNames of d, do
-        MUST(declaration.for_each_bound_identifier([&](auto const& id) {
-            if (id.is_local()) {
-                // NOTE: Local variables are supported only in bytecode interpreter
-                return;
-            }
+            // b. For each element dn of the BoundNames of d, do
+            MUST(declaration.for_each_bound_identifier([&](auto const& id) {
+                if (id.is_local()) {
+                    // NOTE: Local variables are supported only in bytecode interpreter
+                    return;
+                }
 
-            // i. If IsConstantDeclaration of d is true, then
-            if (declaration.is_constant_declaration()) {
-                // 1. Perform ! lexEnv.CreateImmutableBinding(dn, true).
-                MUST(lex_environment->create_immutable_binding(vm, id.string(), true));
-            }
-            // ii. Else,
-            else {
-                // 1. Perform ! lexEnv.CreateMutableBinding(dn, false).
-                MUST(lex_environment->create_mutable_binding(vm, id.string(), false));
-            }
+                // i. If IsConstantDeclaration of d is true, then
+                if (declaration.is_constant_declaration()) {
+                    // 1. Perform ! lexEnv.CreateImmutableBinding(dn, true).
+                    MUST(lex_environment->create_immutable_binding(vm, id.string(), true));
+                }
+                // ii. Else,
+                else {
+                    // 1. Perform ! lexEnv.CreateMutableBinding(dn, false).
+                    MUST(lex_environment->create_mutable_binding(vm, id.string(), false));
+                }
+            }));
         }));
-    }));
+    }
 
     // 35. Let privateEnv be the PrivateEnvironment of calleeContext.
     auto private_environment = callee_context.private_environment;

--- a/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
@@ -704,7 +704,7 @@ ThrowCompletionOr<void> ECMAScriptFunctionObject::function_declaration_instantia
                     if (value_and_frame.value.is_error())
                         return value_and_frame.value.release_error();
                     // Resulting value is in the accumulator.
-                    argument_value = value_and_frame.frame->registers.at(0);
+                    argument_value = value_and_frame.frame->registers()[0];
                 } else {
                     argument_value = js_undefined();
                 }
@@ -1225,11 +1225,11 @@ Completion ECMAScriptFunctionObject::ordinary_call_evaluate_body()
         return { Completion::Type::Return, result.value_or(js_undefined()), {} };
 
     if (m_kind == FunctionKind::AsyncGenerator) {
-        auto async_generator_object = TRY(AsyncGenerator::create(realm, result, this, vm.running_execution_context().copy(), move(*result_and_frame.frame)));
+        auto async_generator_object = TRY(AsyncGenerator::create(realm, result, this, vm.running_execution_context().copy(), result_and_frame.frame.release_nonnull()));
         return { Completion::Type::Return, async_generator_object, {} };
     }
 
-    auto generator_object = TRY(GeneratorObject::create(realm, result, this, vm.running_execution_context().copy(), move(*result_and_frame.frame)));
+    auto generator_object = TRY(GeneratorObject::create(realm, result, this, vm.running_execution_context().copy(), result_and_frame.frame.release_nonnull()));
 
     // NOTE: Async functions are entirely transformed to generator functions, and wrapped in a custom driver that returns a promise
     //       See AwaitExpression::generate_bytecode() for the transformation.

--- a/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
@@ -527,6 +527,10 @@ void ECMAScriptFunctionObject::visit_edges(Visitor& visitor)
     visitor.visit(m_realm);
     visitor.visit(m_home_object);
 
+    visitor.visit(m_bytecode_executable);
+    for (auto& executable : m_default_parameter_bytecode_executables)
+        visitor.visit(executable);
+
     for (auto& field : m_fields) {
         if (auto* property_key_ptr = field.name.get_pointer<PropertyKey>(); property_key_ptr && property_key_ptr->is_symbol())
             visitor.visit(property_key_ptr->as_symbol());

--- a/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
@@ -681,7 +681,7 @@ ThrowCompletionOr<void> ECMAScriptFunctionObject::function_declaration_instantia
     // 26. Else,
     //     a. Perform ? IteratorBindingInitialization of formals with arguments iteratorRecord and env.
     // NOTE: The spec makes an iterator here to do IteratorBindingInitialization but we just do it manually
-    auto execution_context_arguments = vm.running_execution_context().arguments;
+    auto const& execution_context_arguments = vm.running_execution_context().arguments;
 
     size_t default_parameter_index = 0;
     for (size_t i = 0; i < m_formal_parameters.size(); ++i) {

--- a/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
@@ -333,8 +333,10 @@ void ECMAScriptFunctionObject::initialize(Realm& realm)
     //       which must give the properties in chronological order which in this case is the order they
     //       are defined in the spec.
 
+    m_name_string = PrimitiveString::create(vm, m_name);
+
     MUST(define_property_or_throw(vm.names.length, { .value = Value(m_function_length), .writable = false, .enumerable = false, .configurable = true }));
-    MUST(define_property_or_throw(vm.names.name, { .value = PrimitiveString::create(vm, m_name.is_null() ? "" : m_name), .writable = false, .enumerable = false, .configurable = true }));
+    MUST(define_property_or_throw(vm.names.name, { .value = m_name_string, .writable = false, .enumerable = false, .configurable = true }));
 
     if (!m_is_arrow_function) {
         Object* prototype = nullptr;
@@ -936,7 +938,7 @@ ThrowCompletionOr<void> ECMAScriptFunctionObject::prepare_for_ordinary_call(Exec
 
     // 3. Set the Function of calleeContext to F.
     callee_context.function = this;
-    callee_context.function_name = m_name;
+    callee_context.function_name = m_name_string;
 
     // 4. Let calleeRealm be F.[[Realm]].
     auto callee_realm = m_realm;
@@ -1243,6 +1245,7 @@ void ECMAScriptFunctionObject::set_name(DeprecatedFlyString const& name)
     VERIFY(!name.is_null());
     auto& vm = this->vm();
     m_name = name;
-    MUST(define_property_or_throw(vm.names.name, { .value = PrimitiveString::create(vm, m_name), .writable = false, .enumerable = false, .configurable = true }));
+    m_name_string = PrimitiveString::create(vm, m_name);
+    MUST(define_property_or_throw(vm.names.name, { .value = m_name_string, .writable = false, .enumerable = false, .configurable = true }));
 }
 }

--- a/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.h
+++ b/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.h
@@ -112,8 +112,8 @@ private:
     ThrowCompletionOr<void> function_declaration_instantiation();
 
     DeprecatedFlyString m_name;
-    RefPtr<Bytecode::Executable> m_bytecode_executable;
-    Vector<NonnullRefPtr<Bytecode::Executable>> m_default_parameter_bytecode_executables;
+    GCPtr<Bytecode::Executable> m_bytecode_executable;
+    Vector<NonnullGCPtr<Bytecode::Executable>> m_default_parameter_bytecode_executables;
     i32 m_function_length { 0 };
     Vector<DeprecatedFlyString> m_local_variables_names;
 

--- a/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.h
+++ b/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.h
@@ -44,8 +44,8 @@ public:
     virtual void initialize(Realm&) override;
     virtual ~ECMAScriptFunctionObject() override = default;
 
-    virtual ThrowCompletionOr<Value> internal_call(Value this_argument, MarkedVector<Value> arguments_list) override;
-    virtual ThrowCompletionOr<NonnullGCPtr<Object>> internal_construct(MarkedVector<Value> arguments_list, FunctionObject& new_target) override;
+    virtual ThrowCompletionOr<Value> internal_call(Value this_argument, ReadonlySpan<Value> arguments_list) override;
+    virtual ThrowCompletionOr<NonnullGCPtr<Object>> internal_construct(ReadonlySpan<Value> arguments_list, FunctionObject& new_target) override;
 
     void make_method(Object& home_object);
 

--- a/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.h
+++ b/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.h
@@ -112,6 +112,8 @@ private:
     ThrowCompletionOr<void> function_declaration_instantiation();
 
     DeprecatedFlyString m_name;
+    GCPtr<PrimitiveString> m_name_string;
+
     GCPtr<Bytecode::Executable> m_bytecode_executable;
     Vector<NonnullGCPtr<Bytecode::Executable>> m_default_parameter_bytecode_executables;
     i32 m_function_length { 0 };

--- a/Userland/Libraries/LibJS/Runtime/Error.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Error.cpp
@@ -85,7 +85,7 @@ void Error::populate_stack()
         if (element.source_range.has_value())
             range = element.source_range.value();
         TracebackFrame frame {
-            .function_name = context->function_name,
+            .function_name = context->function_name ? context->function_name->deprecated_string() : "",
             .source_range_storage = range,
         };
 

--- a/Userland/Libraries/LibJS/Runtime/ExecutionContext.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ExecutionContext.cpp
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibJS/Bytecode/Executable.h>
 #include <LibJS/Runtime/ExecutionContext.h>
 #include <LibJS/Runtime/FunctionObject.h>
 
@@ -50,6 +51,8 @@ void ExecutionContext::visit_edges(Cell::Visitor& visitor)
     visitor.visit(private_environment);
     visitor.visit(context_owner);
     visitor.visit(this_value);
+    if (instruction_stream_iterator.has_value())
+        visitor.visit(const_cast<Bytecode::Executable*>(instruction_stream_iterator.value().executable()));
     script_or_module.visit(
         [](Empty) {},
         [&](auto& script_or_module) {

--- a/Userland/Libraries/LibJS/Runtime/ExecutionContext.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ExecutionContext.cpp
@@ -53,6 +53,7 @@ void ExecutionContext::visit_edges(Cell::Visitor& visitor)
     visitor.visit(this_value);
     if (instruction_stream_iterator.has_value())
         visitor.visit(const_cast<Bytecode::Executable*>(instruction_stream_iterator.value().executable()));
+    visitor.visit(function_name);
     script_or_module.visit(
         [](Empty) {},
         [&](auto& script_or_module) {

--- a/Userland/Libraries/LibJS/Runtime/ExecutionContext.h
+++ b/Userland/Libraries/LibJS/Runtime/ExecutionContext.h
@@ -49,7 +49,7 @@ public:
     GCPtr<Cell> context_owner;
 
     Optional<Bytecode::InstructionStreamIterator> instruction_stream_iterator;
-    DeprecatedFlyString function_name;
+    GCPtr<PrimitiveString> function_name;
     Value this_value;
     MarkedVector<Value> arguments;
     MarkedVector<Value> local_variables;

--- a/Userland/Libraries/LibJS/Runtime/ExecutionContext.h
+++ b/Userland/Libraries/LibJS/Runtime/ExecutionContext.h
@@ -55,7 +55,7 @@ public:
     MarkedVector<Value> local_variables;
     bool is_strict_mode { false };
 
-    RefPtr<Bytecode::Executable> executable;
+    GCPtr<Bytecode::Executable> executable;
 
     // https://html.spec.whatwg.org/multipage/webappapis.html#skip-when-determining-incumbent-counter
     // FIXME: Move this out of LibJS (e.g. by using the CustomData concept), as it's used exclusively by LibWeb.

--- a/Userland/Libraries/LibJS/Runtime/FunctionConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/FunctionConstructor.cpp
@@ -268,7 +268,9 @@ ThrowCompletionOr<NonnullGCPtr<Object>> FunctionConstructor::construct(FunctionO
     auto* constructor = vm.active_function_object();
 
     // 2. Let args be the argumentsList that was passed to this function by [[Call]] or [[Construct]].
-    auto& args = vm.running_execution_context().arguments;
+    MarkedVector<Value> args(heap());
+    for (auto argument : vm.running_execution_context().arguments)
+        args.append(argument);
 
     // 3. Return ? CreateDynamicFunction(C, NewTarget, normal, args).
     return *TRY(create_dynamic_function(vm, *constructor, &new_target, FunctionKind::Normal, args));

--- a/Userland/Libraries/LibJS/Runtime/FunctionObject.h
+++ b/Userland/Libraries/LibJS/Runtime/FunctionObject.h
@@ -23,8 +23,8 @@ public:
 
     // Table 7: Additional Essential Internal Methods of Function Objects, https://tc39.es/ecma262/#table-additional-essential-internal-methods-of-function-objects
 
-    virtual ThrowCompletionOr<Value> internal_call(Value this_argument, MarkedVector<Value> arguments_list) = 0;
-    virtual ThrowCompletionOr<NonnullGCPtr<Object>> internal_construct([[maybe_unused]] MarkedVector<Value> arguments_list, [[maybe_unused]] FunctionObject& new_target) { VERIFY_NOT_REACHED(); }
+    virtual ThrowCompletionOr<Value> internal_call(Value this_argument, ReadonlySpan<Value> arguments_list) = 0;
+    virtual ThrowCompletionOr<NonnullGCPtr<Object>> internal_construct([[maybe_unused]] ReadonlySpan<Value> arguments_list, [[maybe_unused]] FunctionObject& new_target) { VERIFY_NOT_REACHED(); }
 
     virtual DeprecatedFlyString const& name() const = 0;
 

--- a/Userland/Libraries/LibJS/Runtime/FunctionPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/FunctionPrototype.cpp
@@ -98,8 +98,7 @@ JS_DEFINE_NATIVE_FUNCTION(FunctionPrototype::bind)
 
     Vector<Value> arguments;
     if (vm.argument_count() > 1) {
-        arguments = vm.running_execution_context().arguments;
-        arguments.remove(0);
+        arguments.append(vm.running_execution_context().arguments.span().slice(1).data(), vm.argument_count() - 1);
     }
 
     // 3. Let F be ? BoundFunctionCreate(Target, thisArg, args).

--- a/Userland/Libraries/LibJS/Runtime/FunctionPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/FunctionPrototype.h
@@ -18,7 +18,7 @@ public:
     virtual void initialize(Realm&) override;
     virtual ~FunctionPrototype() override = default;
 
-    virtual ThrowCompletionOr<Value> internal_call(Value this_argument, MarkedVector<Value> arguments_list) override;
+    virtual ThrowCompletionOr<Value> internal_call(Value this_argument, ReadonlySpan<Value> arguments_list) override;
     virtual DeprecatedFlyString const& name() const override { return m_name; }
 
 private:

--- a/Userland/Libraries/LibJS/Runtime/GeneratorFunctionConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/GeneratorFunctionConstructor.cpp
@@ -44,7 +44,9 @@ ThrowCompletionOr<NonnullGCPtr<Object>> GeneratorFunctionConstructor::construct(
     auto* constructor = vm.active_function_object();
 
     // 2. Let args be the argumentsList that was passed to this function by [[Call]] or [[Construct]].
-    auto& args = vm.running_execution_context().arguments;
+    MarkedVector<Value> args(heap());
+    for (auto argument : vm.running_execution_context().arguments)
+        args.append(argument);
 
     // 3. Return ? CreateDynamicFunction(C, NewTarget, generator, args).
     return *TRY(FunctionConstructor::create_dynamic_function(vm, *constructor, &new_target, FunctionKind::Generator, args));

--- a/Userland/Libraries/LibJS/Runtime/GeneratorObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/GeneratorObject.cpp
@@ -16,7 +16,7 @@ namespace JS {
 
 JS_DEFINE_ALLOCATOR(GeneratorObject);
 
-ThrowCompletionOr<NonnullGCPtr<GeneratorObject>> GeneratorObject::create(Realm& realm, Value initial_value, ECMAScriptFunctionObject* generating_function, NonnullOwnPtr<ExecutionContext> execution_context, Bytecode::CallFrame frame)
+ThrowCompletionOr<NonnullGCPtr<GeneratorObject>> GeneratorObject::create(Realm& realm, Value initial_value, ECMAScriptFunctionObject* generating_function, NonnullOwnPtr<ExecutionContext> execution_context, NonnullOwnPtr<Bytecode::CallFrame> frame)
 {
     auto& vm = realm.vm();
     // This is "g1.prototype" in figure-2 (https://tc39.es/ecma262/img/figure-2.png)
@@ -49,7 +49,7 @@ void GeneratorObject::visit_edges(Cell::Visitor& visitor)
     Base::visit_edges(visitor);
     visitor.visit(m_generating_function);
     visitor.visit(m_previous_value);
-    if (m_frame.has_value())
+    if (m_frame)
         m_frame->visit_edges(visitor);
 }
 
@@ -113,11 +113,11 @@ ThrowCompletionOr<Value> GeneratorObject::execute(VM& vm, Completion const& comp
     VERIFY(!m_generating_function->bytecode_executable()->basic_blocks.find_if([next_block](auto& block) { return block == next_block; }).is_end());
 
     Bytecode::CallFrame* frame = nullptr;
-    if (m_frame.has_value())
-        frame = &m_frame.value();
+    if (m_frame)
+        frame = m_frame;
 
     if (frame)
-        frame->registers[0] = completion_object;
+        frame->registers()[0] = completion_object;
     else
         bytecode_interpreter.accumulator() = completion_object;
 
@@ -125,8 +125,8 @@ ThrowCompletionOr<Value> GeneratorObject::execute(VM& vm, Completion const& comp
 
     vm.pop_execution_context();
 
-    if (!m_frame.has_value())
-        m_frame = move(*next_result.frame);
+    if (!m_frame)
+        m_frame = move(next_result.frame);
 
     auto result_value = move(next_result.value);
     if (result_value.is_throw_completion()) {

--- a/Userland/Libraries/LibJS/Runtime/GeneratorObject.h
+++ b/Userland/Libraries/LibJS/Runtime/GeneratorObject.h
@@ -17,7 +17,7 @@ class GeneratorObject : public Object {
     JS_DECLARE_ALLOCATOR(GeneratorObject);
 
 public:
-    static ThrowCompletionOr<NonnullGCPtr<GeneratorObject>> create(Realm&, Value, ECMAScriptFunctionObject*, ExecutionContext, Bytecode::CallFrame);
+    static ThrowCompletionOr<NonnullGCPtr<GeneratorObject>> create(Realm&, Value, ECMAScriptFunctionObject*, NonnullOwnPtr<ExecutionContext>, Bytecode::CallFrame);
     virtual ~GeneratorObject() override = default;
     void visit_edges(Cell::Visitor&) override;
 
@@ -34,13 +34,13 @@ public:
     void set_generator_state(GeneratorState generator_state) { m_generator_state = generator_state; }
 
 protected:
-    GeneratorObject(Realm&, Object& prototype, ExecutionContext, Optional<StringView> generator_brand = {});
+    GeneratorObject(Realm&, Object& prototype, NonnullOwnPtr<ExecutionContext>, Optional<StringView> generator_brand = {});
 
     ThrowCompletionOr<GeneratorState> validate(VM&, Optional<StringView> const& generator_brand);
     virtual ThrowCompletionOr<Value> execute(VM&, JS::Completion const& completion);
 
 private:
-    ExecutionContext m_execution_context;
+    NonnullOwnPtr<ExecutionContext> m_execution_context;
     GCPtr<ECMAScriptFunctionObject> m_generating_function;
     Value m_previous_value;
     Optional<Bytecode::CallFrame> m_frame;

--- a/Userland/Libraries/LibJS/Runtime/GeneratorObject.h
+++ b/Userland/Libraries/LibJS/Runtime/GeneratorObject.h
@@ -17,7 +17,7 @@ class GeneratorObject : public Object {
     JS_DECLARE_ALLOCATOR(GeneratorObject);
 
 public:
-    static ThrowCompletionOr<NonnullGCPtr<GeneratorObject>> create(Realm&, Value, ECMAScriptFunctionObject*, NonnullOwnPtr<ExecutionContext>, Bytecode::CallFrame);
+    static ThrowCompletionOr<NonnullGCPtr<GeneratorObject>> create(Realm&, Value, ECMAScriptFunctionObject*, NonnullOwnPtr<ExecutionContext>, NonnullOwnPtr<Bytecode::CallFrame>);
     virtual ~GeneratorObject() override = default;
     void visit_edges(Cell::Visitor&) override;
 
@@ -43,7 +43,7 @@ private:
     NonnullOwnPtr<ExecutionContext> m_execution_context;
     GCPtr<ECMAScriptFunctionObject> m_generating_function;
     Value m_previous_value;
-    Optional<Bytecode::CallFrame> m_frame;
+    OwnPtr<Bytecode::CallFrame> m_frame;
     GeneratorState m_generator_state { GeneratorState::SuspendedStart };
     Optional<StringView> m_generator_brand;
 };

--- a/Userland/Libraries/LibJS/Runtime/JobCallback.cpp
+++ b/Userland/Libraries/LibJS/Runtime/JobCallback.cpp
@@ -18,13 +18,13 @@ JobCallback make_job_callback(FunctionObject& callback)
 }
 
 // 9.5.3 HostCallJobCallback ( jobCallback, V, argumentsList ), https://tc39.es/ecma262/#sec-hostcalljobcallback
-ThrowCompletionOr<Value> call_job_callback(VM& vm, JobCallback& job_callback, Value this_value, MarkedVector<Value> arguments_list)
+ThrowCompletionOr<Value> call_job_callback(VM& vm, JobCallback& job_callback, Value this_value, ReadonlySpan<Value> arguments_list)
 {
     // 1. Assert: IsCallable(jobCallback.[[Callback]]) is true.
     VERIFY(!job_callback.callback.is_null());
 
     // 2. Return ? Call(jobCallback.[[Callback]], V, argumentsList).
-    return call(vm, job_callback.callback.cell(), this_value, move(arguments_list));
+    return call(vm, job_callback.callback.cell(), this_value, arguments_list);
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/JobCallback.h
+++ b/Userland/Libraries/LibJS/Runtime/JobCallback.h
@@ -23,6 +23,6 @@ struct JobCallback {
 };
 
 JobCallback make_job_callback(FunctionObject& callback);
-ThrowCompletionOr<Value> call_job_callback(VM&, JobCallback&, Value this_value, MarkedVector<Value> arguments_list);
+ThrowCompletionOr<Value> call_job_callback(VM&, JobCallback&, Value this_value, ReadonlySpan<Value> arguments_list);
 
 }

--- a/Userland/Libraries/LibJS/Runtime/NativeFunction.cpp
+++ b/Userland/Libraries/LibJS/Runtime/NativeFunction.cpp
@@ -121,11 +121,11 @@ ThrowCompletionOr<Value> NativeFunction::internal_call(Value this_argument, Read
     // NOTE: We don't support this concept yet.
 
     // 3. Let calleeContext be a new execution context.
-    ExecutionContext callee_context(heap());
+    auto callee_context = ExecutionContext::create(heap());
 
     // 4. Set the Function of calleeContext to F.
-    callee_context.function = this;
-    callee_context.function_name = m_name_string;
+    callee_context->function = this;
+    callee_context->function_name = m_name_string;
 
     // 5. Let calleeRealm be F.[[Realm]].
     auto callee_realm = m_realm;
@@ -139,29 +139,29 @@ ThrowCompletionOr<Value> NativeFunction::internal_call(Value this_argument, Read
     VERIFY(callee_realm);
 
     // 6. Set the Realm of calleeContext to calleeRealm.
-    callee_context.realm = callee_realm;
+    callee_context->realm = callee_realm;
 
     // 7. Set the ScriptOrModule of calleeContext to null.
     // Note: This is already the default value.
 
     // 8. Perform any necessary implementation-defined initialization of calleeContext.
-    callee_context.this_value = this_argument;
-    callee_context.arguments.append(arguments_list.data(), arguments_list.size());
-    callee_context.instruction_stream_iterator = vm.bytecode_interpreter().instruction_stream_iterator();
+    callee_context->this_value = this_argument;
+    callee_context->arguments.append(arguments_list.data(), arguments_list.size());
+    callee_context->instruction_stream_iterator = vm.bytecode_interpreter().instruction_stream_iterator();
 
-    callee_context.lexical_environment = caller_context.lexical_environment;
-    callee_context.variable_environment = caller_context.variable_environment;
+    callee_context->lexical_environment = caller_context.lexical_environment;
+    callee_context->variable_environment = caller_context.variable_environment;
     // Note: Keeping the private environment is probably only needed because of async methods in classes
     //       calling async_block_start which goes through a NativeFunction here.
-    callee_context.private_environment = caller_context.private_environment;
+    callee_context->private_environment = caller_context.private_environment;
 
     // NOTE: This is a LibJS specific hack for NativeFunction to inherit the strictness of its caller.
-    callee_context.is_strict_mode = vm.in_strict_mode();
+    callee_context->is_strict_mode = vm.in_strict_mode();
 
     // </8.> --------------------------------------------------------------------------
 
     // 9. Push calleeContext onto the execution context stack; calleeContext is now the running execution context.
-    TRY(vm.push_execution_context(callee_context, {}));
+    TRY(vm.push_execution_context(*callee_context, {}));
 
     // 10. Let result be the Completion Record that is the result of evaluating F in a manner that conforms to the specification of F. thisArgument is the this value, argumentsList provides the named parameters, and the NewTarget value is undefined.
     auto result = call();
@@ -185,11 +185,11 @@ ThrowCompletionOr<NonnullGCPtr<Object>> NativeFunction::internal_construct(Reado
     // NOTE: We don't support this concept yet.
 
     // 3. Let calleeContext be a new execution context.
-    ExecutionContext callee_context(heap());
+    auto callee_context = ExecutionContext::create(heap());
 
     // 4. Set the Function of calleeContext to F.
-    callee_context.function = this;
-    callee_context.function_name = m_name_string;
+    callee_context->function = this;
+    callee_context->function_name = m_name_string;
 
     // 5. Let calleeRealm be F.[[Realm]].
     auto callee_realm = m_realm;
@@ -203,25 +203,25 @@ ThrowCompletionOr<NonnullGCPtr<Object>> NativeFunction::internal_construct(Reado
     VERIFY(callee_realm);
 
     // 6. Set the Realm of calleeContext to calleeRealm.
-    callee_context.realm = callee_realm;
+    callee_context->realm = callee_realm;
 
     // 7. Set the ScriptOrModule of calleeContext to null.
     // Note: This is already the default value.
 
     // 8. Perform any necessary implementation-defined initialization of calleeContext.
-    callee_context.arguments.append(arguments_list.data(), arguments_list.size());
-    callee_context.instruction_stream_iterator = vm.bytecode_interpreter().instruction_stream_iterator();
+    callee_context->arguments.append(arguments_list.data(), arguments_list.size());
+    callee_context->instruction_stream_iterator = vm.bytecode_interpreter().instruction_stream_iterator();
 
-    callee_context.lexical_environment = caller_context.lexical_environment;
-    callee_context.variable_environment = caller_context.variable_environment;
+    callee_context->lexical_environment = caller_context.lexical_environment;
+    callee_context->variable_environment = caller_context.variable_environment;
 
     // NOTE: This is a LibJS specific hack for NativeFunction to inherit the strictness of its caller.
-    callee_context.is_strict_mode = vm.in_strict_mode();
+    callee_context->is_strict_mode = vm.in_strict_mode();
 
     // </8.> --------------------------------------------------------------------------
 
     // 9. Push calleeContext onto the execution context stack; calleeContext is now the running execution context.
-    TRY(vm.push_execution_context(callee_context, {}));
+    TRY(vm.push_execution_context(*callee_context, {}));
 
     // 10. Let result be the Completion Record that is the result of evaluating F in a manner that conforms to the specification of F. The this value is uninitialized, argumentsList provides the named parameters, and newTarget provides the NewTarget value.
     auto result = construct(new_target);

--- a/Userland/Libraries/LibJS/Runtime/NativeFunction.cpp
+++ b/Userland/Libraries/LibJS/Runtime/NativeFunction.cpp
@@ -17,6 +17,20 @@ namespace JS {
 
 JS_DEFINE_ALLOCATOR(NativeFunction);
 
+void NativeFunction::initialize(Realm& realm)
+{
+    Base::initialize(realm);
+    m_name_string = PrimitiveString::create(vm(), m_name);
+}
+
+void NativeFunction::visit_edges(Cell::Visitor& visitor)
+{
+    Base::visit_edges(visitor);
+    visitor.visit(m_native_function);
+    visitor.visit(m_realm);
+    visitor.visit(m_name_string);
+}
+
 // 10.3.3 CreateBuiltinFunction ( behaviour, length, name, additionalInternalSlotsList [ , realm [ , prototype [ , prefix ] ] ] ), https://tc39.es/ecma262/#sec-createbuiltinfunction
 // NOTE: This doesn't consider additionalInternalSlotsList, which is rarely used, and can either be implemented using only the `function` lambda, or needs a NativeFunction subclass.
 NonnullGCPtr<NativeFunction> NativeFunction::create(Realm& allocating_realm, Function<ThrowCompletionOr<Value>(VM&)> behaviour, i32 length, PropertyKey const& name, Optional<Realm*> realm, Optional<Object*> prototype, Optional<StringView> const& prefix)
@@ -111,7 +125,7 @@ ThrowCompletionOr<Value> NativeFunction::internal_call(Value this_argument, Read
 
     // 4. Set the Function of calleeContext to F.
     callee_context.function = this;
-    callee_context.function_name = m_name;
+    callee_context.function_name = m_name_string;
 
     // 5. Let calleeRealm be F.[[Realm]].
     auto callee_realm = m_realm;
@@ -175,7 +189,7 @@ ThrowCompletionOr<NonnullGCPtr<Object>> NativeFunction::internal_construct(Reado
 
     // 4. Set the Function of calleeContext to F.
     callee_context.function = this;
-    callee_context.function_name = m_name;
+    callee_context.function_name = m_name_string;
 
     // 5. Let calleeRealm be F.[[Realm]].
     auto callee_realm = m_realm;

--- a/Userland/Libraries/LibJS/Runtime/NativeFunction.cpp
+++ b/Userland/Libraries/LibJS/Runtime/NativeFunction.cpp
@@ -96,7 +96,7 @@ NativeFunction::NativeFunction(DeprecatedFlyString name, Object& prototype)
 // these good candidates for a bit of code duplication :^)
 
 // 10.3.1 [[Call]] ( thisArgument, argumentsList ), https://tc39.es/ecma262/#sec-built-in-function-objects-call-thisargument-argumentslist
-ThrowCompletionOr<Value> NativeFunction::internal_call(Value this_argument, MarkedVector<Value> arguments_list)
+ThrowCompletionOr<Value> NativeFunction::internal_call(Value this_argument, ReadonlySpan<Value> arguments_list)
 {
     auto& vm = this->vm();
 
@@ -132,7 +132,7 @@ ThrowCompletionOr<Value> NativeFunction::internal_call(Value this_argument, Mark
 
     // 8. Perform any necessary implementation-defined initialization of calleeContext.
     callee_context.this_value = this_argument;
-    callee_context.arguments.extend(move(arguments_list));
+    callee_context.arguments.append(arguments_list.data(), arguments_list.size());
     callee_context.instruction_stream_iterator = vm.bytecode_interpreter().instruction_stream_iterator();
 
     callee_context.lexical_environment = caller_context.lexical_environment;
@@ -160,7 +160,7 @@ ThrowCompletionOr<Value> NativeFunction::internal_call(Value this_argument, Mark
 }
 
 // 10.3.2 [[Construct]] ( argumentsList, newTarget ), https://tc39.es/ecma262/#sec-built-in-function-objects-construct-argumentslist-newtarget
-ThrowCompletionOr<NonnullGCPtr<Object>> NativeFunction::internal_construct(MarkedVector<Value> arguments_list, FunctionObject& new_target)
+ThrowCompletionOr<NonnullGCPtr<Object>> NativeFunction::internal_construct(ReadonlySpan<Value> arguments_list, FunctionObject& new_target)
 {
     auto& vm = this->vm();
 
@@ -195,7 +195,7 @@ ThrowCompletionOr<NonnullGCPtr<Object>> NativeFunction::internal_construct(Marke
     // Note: This is already the default value.
 
     // 8. Perform any necessary implementation-defined initialization of calleeContext.
-    callee_context.arguments.extend(move(arguments_list));
+    callee_context.arguments.append(arguments_list.data(), arguments_list.size());
     callee_context.instruction_stream_iterator = vm.bytecode_interpreter().instruction_stream_iterator();
 
     callee_context.lexical_environment = caller_context.lexical_environment;

--- a/Userland/Libraries/LibJS/Runtime/NativeFunction.h
+++ b/Userland/Libraries/LibJS/Runtime/NativeFunction.h
@@ -26,8 +26,8 @@ public:
 
     virtual ~NativeFunction() override = default;
 
-    virtual ThrowCompletionOr<Value> internal_call(Value this_argument, MarkedVector<Value> arguments_list) override;
-    virtual ThrowCompletionOr<NonnullGCPtr<Object>> internal_construct(MarkedVector<Value> arguments_list, FunctionObject& new_target) override;
+    virtual ThrowCompletionOr<Value> internal_call(Value this_argument, ReadonlySpan<Value> arguments_list) override;
+    virtual ThrowCompletionOr<NonnullGCPtr<Object>> internal_construct(ReadonlySpan<Value> arguments_list, FunctionObject& new_target) override;
 
     // Used for [[Call]] / [[Construct]]'s "...result of evaluating F in a manner that conforms to the specification of F".
     // Needs to be overridden by all NativeFunctions without an m_native_function.

--- a/Userland/Libraries/LibJS/Runtime/NativeFunction.h
+++ b/Userland/Libraries/LibJS/Runtime/NativeFunction.h
@@ -48,16 +48,14 @@ protected:
     NativeFunction(DeprecatedFlyString name, JS::GCPtr<JS::HeapFunction<ThrowCompletionOr<Value>(VM&)>>, Object& prototype);
     explicit NativeFunction(Object& prototype);
 
-    virtual void visit_edges(Cell::Visitor& visitor) override
-    {
-        Base::visit_edges(visitor);
-        visitor.visit(m_native_function);
-    }
+    virtual void initialize(Realm&) override;
+    virtual void visit_edges(Cell::Visitor& visitor) override;
 
 private:
     virtual bool is_native_function() const final { return true; }
 
     DeprecatedFlyString m_name;
+    GCPtr<PrimitiveString> m_name_string;
     Optional<DeprecatedFlyString> m_initial_name; // [[InitialName]]
     JS::GCPtr<JS::HeapFunction<ThrowCompletionOr<Value>(VM&)>> m_native_function;
     GCPtr<Realm> m_realm;

--- a/Userland/Libraries/LibJS/Runtime/PrimitiveString.cpp
+++ b/Userland/Libraries/LibJS/Runtime/PrimitiveString.cpp
@@ -223,6 +223,8 @@ NonnullGCPtr<PrimitiveString> PrimitiveString::create(VM& vm, DeprecatedString s
 
 NonnullGCPtr<PrimitiveString> PrimitiveString::create(VM& vm, DeprecatedFlyString const& string)
 {
+    if (string.is_empty())
+        return vm.empty_string();
     return create(vm, *string.impl());
 }
 

--- a/Userland/Libraries/LibJS/Runtime/ProxyObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ProxyObject.cpp
@@ -774,7 +774,7 @@ ThrowCompletionOr<MarkedVector<Value>> ProxyObject::internal_own_property_keys()
 }
 
 // 10.5.12 [[Call]] ( thisArgument, argumentsList ), https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-call-thisargument-argumentslist
-ThrowCompletionOr<Value> ProxyObject::internal_call(Value this_argument, MarkedVector<Value> arguments_list)
+ThrowCompletionOr<Value> ProxyObject::internal_call(Value this_argument, ReadonlySpan<Value> arguments_list)
 {
     auto& vm = this->vm();
     auto& realm = *vm.current_realm();
@@ -797,7 +797,7 @@ ThrowCompletionOr<Value> ProxyObject::internal_call(Value this_argument, MarkedV
     // 6. If trap is undefined, then
     if (!trap) {
         // a. Return ? Call(target, thisArgument, argumentsList).
-        return call(vm, m_target, this_argument, move(arguments_list));
+        return call(vm, m_target, this_argument, arguments_list);
     }
 
     // 7. Let argArray be CreateArrayFromList(argumentsList).
@@ -818,7 +818,7 @@ bool ProxyObject::has_constructor() const
 }
 
 // 10.5.13 [[Construct]] ( argumentsList, newTarget ), https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-construct-argumentslist-newtarget
-ThrowCompletionOr<NonnullGCPtr<Object>> ProxyObject::internal_construct(MarkedVector<Value> arguments_list, FunctionObject& new_target)
+ThrowCompletionOr<NonnullGCPtr<Object>> ProxyObject::internal_construct(ReadonlySpan<Value> arguments_list, FunctionObject& new_target)
 {
     auto& vm = this->vm();
     auto& realm = *vm.current_realm();
@@ -842,7 +842,7 @@ ThrowCompletionOr<NonnullGCPtr<Object>> ProxyObject::internal_construct(MarkedVe
     // 7. If trap is undefined, then
     if (!trap) {
         // a. Return ? Construct(target, argumentsList, newTarget).
-        return construct(vm, static_cast<FunctionObject&>(*m_target), move(arguments_list), &new_target);
+        return construct(vm, static_cast<FunctionObject&>(*m_target), arguments_list, &new_target);
     }
 
     // 8. Let argArray be CreateArrayFromList(argumentsList).

--- a/Userland/Libraries/LibJS/Runtime/ProxyObject.h
+++ b/Userland/Libraries/LibJS/Runtime/ProxyObject.h
@@ -43,8 +43,8 @@ public:
     virtual ThrowCompletionOr<bool> internal_set(PropertyKey const&, Value value, Value receiver, CacheablePropertyMetadata*) override;
     virtual ThrowCompletionOr<bool> internal_delete(PropertyKey const&) override;
     virtual ThrowCompletionOr<MarkedVector<Value>> internal_own_property_keys() const override;
-    virtual ThrowCompletionOr<Value> internal_call(Value this_argument, MarkedVector<Value> arguments_list) override;
-    virtual ThrowCompletionOr<NonnullGCPtr<Object>> internal_construct(MarkedVector<Value> arguments_list, FunctionObject& new_target) override;
+    virtual ThrowCompletionOr<Value> internal_call(Value this_argument, ReadonlySpan<Value> arguments_list) override;
+    virtual ThrowCompletionOr<NonnullGCPtr<Object>> internal_construct(ReadonlySpan<Value> arguments_list, FunctionObject& new_target) override;
 
 private:
     ProxyObject(Object& target, Object& handler, Object& prototype);

--- a/Userland/Libraries/LibJS/Runtime/Realm.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Realm.cpp
@@ -42,7 +42,7 @@ ThrowCompletionOr<NonnullOwnPtr<ExecutionContext>> Realm::initialize_host_define
     auto realm = MUST_OR_THROW_OOM(Realm::create(vm));
 
     // 2. Let newContext be a new execution context.
-    auto new_context = make<ExecutionContext>(vm.heap());
+    auto new_context = ExecutionContext::create(vm.heap());
 
     // 3. Set the Function of newContext to null.
     new_context->function = nullptr;

--- a/Userland/Libraries/LibJS/Runtime/ReflectObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ReflectObject.cpp
@@ -61,7 +61,7 @@ JS_DEFINE_NATIVE_FUNCTION(ReflectObject::apply)
 
     // 3. Perform PrepareForTailCall().
     // 4. Return ? Call(target, thisArgument, args).
-    return TRY(call(vm, target.as_function(), this_argument, move(args)));
+    return TRY(call(vm, target.as_function(), this_argument, args.span()));
 }
 
 // 28.1.2 Reflect.construct ( target, argumentsList [ , newTarget ] ), https://tc39.es/ecma262/#sec-reflect.construct
@@ -86,7 +86,7 @@ JS_DEFINE_NATIVE_FUNCTION(ReflectObject::construct)
     auto args = TRY(create_list_from_array_like(vm, arguments_list));
 
     // 5. Return ? Construct(target, args, newTarget).
-    return TRY(JS::construct(vm, target.as_function(), move(args), &new_target.as_function()));
+    return TRY(JS::construct(vm, target.as_function(), args.span(), &new_target.as_function()));
 }
 
 // 28.1.3 Reflect.defineProperty ( target, propertyKey, attributes ), https://tc39.es/ecma262/#sec-reflect.defineproperty

--- a/Userland/Libraries/LibJS/Runtime/RegExpPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/RegExpPrototype.cpp
@@ -777,7 +777,7 @@ JS_DEFINE_NATIVE_FUNCTION(RegExpPrototype::symbol_replace)
             }
 
             // iii. Let replValue be ? Call(replaceValue, undefined, replacerArgs).
-            auto replace_result = TRY(call(vm, replace_value.as_function(), js_undefined(), move(replacer_args)));
+            auto replace_result = TRY(call(vm, replace_value.as_function(), js_undefined(), replacer_args.span()));
 
             // iv. Let replacement be ? ToString(replValue).
             replacement = TRY(replace_result.to_string(vm));

--- a/Userland/Libraries/LibJS/Runtime/ShadowRealm.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ShadowRealm.cpp
@@ -185,7 +185,7 @@ ThrowCompletionOr<Value> perform_shadow_realm_eval(VM& vm, StringView source_tex
                 result = value_and_frame.value.release_error();
             } else {
                 // Resulting value is in the accumulator.
-                result = value_and_frame.frame->registers.at(0).value_or(js_undefined());
+                result = value_and_frame.frame->registers()[0].value_or(js_undefined());
             }
         }
     }

--- a/Userland/Libraries/LibJS/Runtime/ShadowRealm.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ShadowRealm.cpp
@@ -22,7 +22,7 @@ namespace JS {
 
 JS_DEFINE_ALLOCATOR(ShadowRealm);
 
-ShadowRealm::ShadowRealm(Realm& shadow_realm, ExecutionContext execution_context, Object& prototype)
+ShadowRealm::ShadowRealm(Realm& shadow_realm, NonnullOwnPtr<ExecutionContext> execution_context, Object& prototype)
     : Object(ConstructWithPrototypeTag::Tag, prototype)
     , m_shadow_realm(shadow_realm)
     , m_execution_context(move(execution_context))
@@ -143,28 +143,28 @@ ThrowCompletionOr<Value> perform_shadow_realm_eval(VM& vm, StringView source_tex
     // NOTE: We don't support this concept yet.
 
     // 9. Let evalContext be a new ECMAScript code execution context.
-    auto eval_context = ExecutionContext { vm.heap() };
+    auto eval_context = ExecutionContext::create(vm.heap());
 
     // 10. Set evalContext's Function to null.
-    eval_context.function = nullptr;
+    eval_context->function = nullptr;
 
     // 11. Set evalContext's Realm to evalRealm.
-    eval_context.realm = &eval_realm;
+    eval_context->realm = &eval_realm;
 
     // 12. Set evalContext's ScriptOrModule to null.
     // Note: This is already the default value.
 
     // 13. Set evalContext's VariableEnvironment to varEnv.
-    eval_context.variable_environment = variable_environment;
+    eval_context->variable_environment = variable_environment;
 
     // 14. Set evalContext's LexicalEnvironment to lexEnv.
-    eval_context.lexical_environment = lexical_environment;
+    eval_context->lexical_environment = lexical_environment;
 
     // Non-standard
-    eval_context.is_strict_mode = strict_eval;
+    eval_context->is_strict_mode = strict_eval;
 
     // 15. Push evalContext onto the execution context stack; evalContext is now the running execution context.
-    TRY(vm.push_execution_context(eval_context, {}));
+    TRY(vm.push_execution_context(*eval_context, {}));
 
     // 16. Let result be Completion(EvalDeclarationInstantiation(body, varEnv, lexEnv, null, strictEval)).
     auto eval_result = eval_declaration_instantiation(vm, program, variable_environment, lexical_environment, nullptr, strict_eval);

--- a/Userland/Libraries/LibJS/Runtime/ShadowRealm.h
+++ b/Userland/Libraries/LibJS/Runtime/ShadowRealm.h
@@ -22,17 +22,17 @@ public:
 
     [[nodiscard]] Realm const& shadow_realm() const { return m_shadow_realm; }
     [[nodiscard]] Realm& shadow_realm() { return m_shadow_realm; }
-    [[nodiscard]] ExecutionContext const& execution_context() const { return m_execution_context; }
-    [[nodiscard]] ExecutionContext& execution_context() { return m_execution_context; }
+    [[nodiscard]] ExecutionContext const& execution_context() const { return *m_execution_context; }
+    [[nodiscard]] ExecutionContext& execution_context() { return *m_execution_context; }
 
 private:
-    ShadowRealm(Realm&, ExecutionContext, Object& prototype);
+    ShadowRealm(Realm&, NonnullOwnPtr<ExecutionContext>, Object& prototype);
 
     virtual void visit_edges(Visitor&) override;
 
     // 3.5 Properties of ShadowRealm Instances, https://tc39.es/proposal-shadowrealm/#sec-properties-of-shadowrealm-instances
-    NonnullGCPtr<Realm> m_shadow_realm;   // [[ShadowRealm]]
-    ExecutionContext m_execution_context; // [[ExecutionContext]]
+    NonnullGCPtr<Realm> m_shadow_realm;                  // [[ShadowRealm]]
+    NonnullOwnPtr<ExecutionContext> m_execution_context; // [[ExecutionContext]]
 };
 
 ThrowCompletionOr<void> copy_name_and_length(VM&, FunctionObject& function, FunctionObject& target, Optional<StringView> prefix = {}, Optional<unsigned> arg_count = {});

--- a/Userland/Libraries/LibJS/Runtime/ShadowRealmConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ShadowRealmConstructor.cpp
@@ -47,13 +47,13 @@ ThrowCompletionOr<NonnullGCPtr<Object>> ShadowRealmConstructor::construct(Functi
     auto realm = MUST_OR_THROW_OOM(Realm::create(vm));
 
     // 5. Let context be a new execution context.
-    auto context = ExecutionContext { vm.heap() };
+    auto context = ExecutionContext::create(vm.heap());
 
     // 6. Set the Function of context to null.
-    context.function = nullptr;
+    context->function = nullptr;
 
     // 7. Set the Realm of context to realmRec.
-    context.realm = realm;
+    context->realm = realm;
 
     // 8. Set the ScriptOrModule of context to null.
     // Note: This is already the default value.

--- a/Userland/Libraries/LibJS/Runtime/TypedArray.cpp
+++ b/Userland/Libraries/LibJS/Runtime/TypedArray.cpp
@@ -322,7 +322,7 @@ ThrowCompletionOr<TypedArrayBase*> typed_array_create(VM& vm, FunctionObject& co
     if (!arguments.is_empty())
         first_argument = arguments[0];
     // 1. Let newTypedArray be ? Construct(constructor, argumentList).
-    auto new_typed_array = TRY(construct(vm, constructor, move(arguments)));
+    auto new_typed_array = TRY(construct(vm, constructor, arguments.span()));
 
     // 2. Perform ? ValidateTypedArray(newTypedArray).
     if (!new_typed_array->is_typed_array())

--- a/Userland/Libraries/LibJS/Runtime/VM.cpp
+++ b/Userland/Libraries/LibJS/Runtime/VM.cpp
@@ -285,7 +285,7 @@ ThrowCompletionOr<Value> VM::execute_ast_node(ASTNode const& node)
     auto result_or_error = bytecode_interpreter().run_and_return_frame(*executable, nullptr);
     if (result_or_error.value.is_error())
         return result_or_error.value.release_error();
-    return result_or_error.frame->registers[0];
+    return result_or_error.frame->registers()[0];
 }
 
 // 13.15.5.3 Runtime Semantics: PropertyDestructuringAssignmentEvaluation, https://tc39.es/ecma262/#sec-runtime-semantics-propertydestructuringassignmentevaluation

--- a/Userland/Libraries/LibJS/Runtime/VM.cpp
+++ b/Userland/Libraries/LibJS/Runtime/VM.cpp
@@ -749,9 +749,9 @@ void VM::dump_backtrace() const
         auto& frame = m_execution_context_stack[i];
         if (frame->instruction_stream_iterator.has_value() && frame->instruction_stream_iterator->source_code()) {
             auto source_range = frame->instruction_stream_iterator->source_range().realize();
-            dbgln("-> {} @ {}:{},{}", frame->function_name, source_range.filename(), source_range.start.line, source_range.start.column);
+            dbgln("-> {} @ {}:{},{}", frame->function_name ? frame->function_name->utf8_string() : ""_string, source_range.filename(), source_range.start.line, source_range.start.column);
         } else {
-            dbgln("-> {}", frame->function_name);
+            dbgln("-> {}", frame->function_name ? frame->function_name->utf8_string() : ""_string);
         }
     }
 }

--- a/Userland/Libraries/LibJS/Runtime/VM.cpp
+++ b/Userland/Libraries/LibJS/Runtime/VM.cpp
@@ -78,8 +78,8 @@ VM::VM(OwnPtr<CustomData> custom_data, ErrorMessages error_messages)
         promise_rejection_tracker(promise, operation);
     };
 
-    host_call_job_callback = [this](JobCallback& job_callback, Value this_value, MarkedVector<Value> arguments) {
-        return call_job_callback(*this, job_callback, this_value, move(arguments));
+    host_call_job_callback = [this](JobCallback& job_callback, Value this_value, ReadonlySpan<Value> arguments) {
+        return call_job_callback(*this, job_callback, this_value, arguments);
     };
 
     host_enqueue_finalization_registry_cleanup_job = [this](FinalizationRegistry& finalization_registry) {

--- a/Userland/Libraries/LibJS/Runtime/VM.cpp
+++ b/Userland/Libraries/LibJS/Runtime/VM.cpp
@@ -199,31 +199,6 @@ void VM::gather_roots(HashMap<Cell*, HeapRoot>& roots)
     for (auto string : m_single_ascii_character_strings)
         roots.set(string, HeapRoot { .type = HeapRoot::Type::VM });
 
-    auto gather_roots_from_execution_context_stack = [&roots](Vector<ExecutionContext*> const& stack) {
-        for (auto& execution_context : stack) {
-            if (execution_context->this_value.is_cell())
-                roots.set(&execution_context->this_value.as_cell(), { .type = HeapRoot::Type::VM });
-            for (auto& argument : execution_context->arguments) {
-                if (argument.is_cell())
-                    roots.set(&argument.as_cell(), HeapRoot { .type = HeapRoot::Type::VM });
-            }
-            roots.set(execution_context->lexical_environment, HeapRoot { .type = HeapRoot::Type::VM });
-            roots.set(execution_context->variable_environment, HeapRoot { .type = HeapRoot::Type::VM });
-            roots.set(execution_context->private_environment, HeapRoot { .type = HeapRoot::Type::VM });
-            if (auto context_owner = execution_context->context_owner)
-                roots.set(context_owner, HeapRoot { .type = HeapRoot::Type::VM });
-            execution_context->script_or_module.visit(
-                [](Empty) {},
-                [&](auto& script_or_module) {
-                    roots.set(script_or_module.ptr(), HeapRoot { .type = HeapRoot::Type::VM });
-                });
-        }
-    };
-
-    gather_roots_from_execution_context_stack(m_execution_context_stack);
-    for (auto& saved_stack : m_saved_execution_context_stacks)
-        gather_roots_from_execution_context_stack(saved_stack);
-
 #define __JS_ENUMERATE(SymbolName, snake_name) \
     roots.set(m_well_known_symbols.snake_name, HeapRoot { .type = HeapRoot::Type::VM });
     JS_ENUMERATE_WELL_KNOWN_SYMBOLS

--- a/Userland/Libraries/LibJS/Runtime/VM.h
+++ b/Userland/Libraries/LibJS/Runtime/VM.h
@@ -150,8 +150,7 @@ public:
     {
         if (m_execution_context_stack.is_empty())
             return {};
-        auto& arguments = running_execution_context().arguments;
-        return index < arguments.size() ? arguments[index] : js_undefined();
+        return running_execution_context().argument(index);
     }
 
     Value this_value() const

--- a/Userland/Libraries/LibJS/Runtime/VM.h
+++ b/Userland/Libraries/LibJS/Runtime/VM.h
@@ -243,7 +243,7 @@ public:
     void enable_default_host_import_module_dynamically_hook();
 
     Function<void(Promise&, Promise::RejectionOperation)> host_promise_rejection_tracker;
-    Function<ThrowCompletionOr<Value>(JobCallback&, Value, MarkedVector<Value>)> host_call_job_callback;
+    Function<ThrowCompletionOr<Value>(JobCallback&, Value, ReadonlySpan<Value>)> host_call_job_callback;
     Function<void(FinalizationRegistry&)> host_enqueue_finalization_registry_cleanup_job;
     Function<void(Function<ThrowCompletionOr<Value>()>, Realm*)> host_enqueue_promise_job;
     Function<JobCallback(FunctionObject&)> host_make_job_callback;

--- a/Userland/Libraries/LibJS/Runtime/Value.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Value.cpp
@@ -2505,7 +2505,10 @@ ThrowCompletionOr<Value> Value::invoke_internal(VM& vm, PropertyKey const& prope
     auto function = TRY(get(vm, property_key));
 
     // 3. Return ? Call(func, V, argumentsList).
-    return call(vm, function, *this, move(arguments));
+    ReadonlySpan<Value> argument_list;
+    if (arguments.has_value())
+        argument_list = arguments.value().span();
+    return call(vm, function, *this, argument_list);
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Value.h
+++ b/Userland/Libraries/LibJS/Runtime/Value.h
@@ -343,6 +343,12 @@ public:
         return *extract_pointer<Cell>();
     }
 
+    Cell& as_cell() const
+    {
+        VERIFY(is_cell());
+        return *extract_pointer<Cell>();
+    }
+
     Accessor& as_accessor()
     {
         VERIFY(is_accessor());

--- a/Userland/Libraries/LibJS/Runtime/WrappedFunction.cpp
+++ b/Userland/Libraries/LibJS/Runtime/WrappedFunction.cpp
@@ -62,11 +62,11 @@ ThrowCompletionOr<Value> WrappedFunction::internal_call(Value this_argument, Rea
     // NOTE: No-op, kept by the VM in its execution context stack.
 
     // 2. Let calleeContext be PrepareForWrappedFunctionCall(F).
-    ExecutionContext callee_context { vm.heap() };
-    prepare_for_wrapped_function_call(*this, callee_context);
+    auto callee_context = ExecutionContext::create(vm.heap());
+    prepare_for_wrapped_function_call(*this, *callee_context);
 
     // 3. Assert: calleeContext is now the running execution context.
-    VERIFY(&vm.running_execution_context() == &callee_context);
+    VERIFY(&vm.running_execution_context() == callee_context);
 
     // 4. Let result be OrdinaryWrappedFunctionCall(F, thisArgument, argumentsList).
     auto result = ordinary_wrapped_function_call(*this, this_argument, arguments_list);

--- a/Userland/Libraries/LibJS/Runtime/WrappedFunction.cpp
+++ b/Userland/Libraries/LibJS/Runtime/WrappedFunction.cpp
@@ -54,7 +54,7 @@ void WrappedFunction::visit_edges(Visitor& visitor)
 }
 
 // 2.1 [[Call]] ( thisArgument, argumentsList ), https://tc39.es/proposal-shadowrealm/#sec-wrapped-function-exotic-objects-call-thisargument-argumentslist
-ThrowCompletionOr<Value> WrappedFunction::internal_call(Value this_argument, MarkedVector<Value> arguments_list)
+ThrowCompletionOr<Value> WrappedFunction::internal_call(Value this_argument, ReadonlySpan<Value> arguments_list)
 {
     auto& vm = this->vm();
 
@@ -82,7 +82,7 @@ ThrowCompletionOr<Value> WrappedFunction::internal_call(Value this_argument, Mar
 }
 
 // 2.2 OrdinaryWrappedFunctionCall ( F: a wrapped function exotic object, thisArgument: an ECMAScript language value, argumentsList: a List of ECMAScript language values, ), https://tc39.es/proposal-shadowrealm/#sec-ordinary-wrapped-function-call
-ThrowCompletionOr<Value> ordinary_wrapped_function_call(WrappedFunction const& function, Value this_argument, MarkedVector<Value> const& arguments_list)
+ThrowCompletionOr<Value> ordinary_wrapped_function_call(WrappedFunction const& function, Value this_argument, ReadonlySpan<Value> arguments_list)
 {
     auto& vm = function.vm();
 
@@ -118,7 +118,7 @@ ThrowCompletionOr<Value> ordinary_wrapped_function_call(WrappedFunction const& f
     auto wrapped_this_argument = TRY(get_wrapped_value(vm, *target_realm, this_argument));
 
     // 9. Let result be the Completion Record of Call(target, wrappedThisArgument, wrappedArgs).
-    auto result = call(vm, &target, wrapped_this_argument, move(wrapped_args));
+    auto result = call(vm, &target, wrapped_this_argument, wrapped_args.span());
 
     // 10. If result.[[Type]] is normal or result.[[Type]] is return, then
     if (!result.is_throw_completion()) {

--- a/Userland/Libraries/LibJS/Runtime/WrappedFunction.h
+++ b/Userland/Libraries/LibJS/Runtime/WrappedFunction.h
@@ -20,7 +20,7 @@ public:
 
     virtual ~WrappedFunction() = default;
 
-    virtual ThrowCompletionOr<Value> internal_call(Value this_argument, MarkedVector<Value> arguments_list) override;
+    virtual ThrowCompletionOr<Value> internal_call(Value this_argument, ReadonlySpan<Value> arguments_list) override;
 
     // FIXME: Remove this (and stop inventing random internal slots that shouldn't exist, jeez)
     virtual DeprecatedFlyString const& name() const override { return m_wrapped_target_function->name(); }
@@ -40,7 +40,7 @@ private:
     NonnullGCPtr<Realm> m_realm;                            // [[Realm]]
 };
 
-ThrowCompletionOr<Value> ordinary_wrapped_function_call(WrappedFunction const&, Value this_argument, MarkedVector<Value> const& arguments_list);
+ThrowCompletionOr<Value> ordinary_wrapped_function_call(WrappedFunction const&, Value this_argument, ReadonlySpan<Value> arguments_list);
 void prepare_for_wrapped_function_call(WrappedFunction const&, ExecutionContext& callee_context);
 
 }

--- a/Userland/Libraries/LibJS/SourceTextModule.cpp
+++ b/Userland/Libraries/LibJS/SourceTextModule.cpp
@@ -708,7 +708,7 @@ ThrowCompletionOr<void> SourceTextModule::execute_module(VM& vm, GCPtr<PromiseCa
                 result = value_and_frame.value.release_error();
             } else {
                 // Resulting value is in the accumulator.
-                result = value_and_frame.frame->registers.at(0).value_or(js_undefined());
+                result = value_and_frame.frame->registers()[0].value_or(js_undefined());
             }
         }
 

--- a/Userland/Libraries/LibJS/SourceTextModule.h
+++ b/Userland/Libraries/LibJS/SourceTextModule.h
@@ -41,13 +41,13 @@ private:
 
     virtual void visit_edges(Cell::Visitor&) override;
 
-    NonnullRefPtr<Program> m_ecmascript_code;      // [[ECMAScriptCode]]
-    ExecutionContext m_execution_context;          // [[Context]]
-    GCPtr<Object> m_import_meta;                   // [[ImportMeta]]
-    Vector<ImportEntry> m_import_entries;          // [[ImportEntries]]
-    Vector<ExportEntry> m_local_export_entries;    // [[LocalExportEntries]]
-    Vector<ExportEntry> m_indirect_export_entries; // [[IndirectExportEntries]]
-    Vector<ExportEntry> m_star_export_entries;     // [[StarExportEntries]]
+    NonnullRefPtr<Program> m_ecmascript_code;            // [[ECMAScriptCode]]
+    NonnullOwnPtr<ExecutionContext> m_execution_context; // [[Context]]
+    GCPtr<Object> m_import_meta;                         // [[ImportMeta]]
+    Vector<ImportEntry> m_import_entries;                // [[ImportEntries]]
+    Vector<ExportEntry> m_local_export_entries;          // [[LocalExportEntries]]
+    Vector<ExportEntry> m_indirect_export_entries;       // [[IndirectExportEntries]]
+    Vector<ExportEntry> m_star_export_entries;           // [[StarExportEntries]]
 
     RefPtr<ExportStatement const> m_default_export; // Note: Not from the spec
 };

--- a/Userland/Libraries/LibJS/SyntheticModule.cpp
+++ b/Userland/Libraries/LibJS/SyntheticModule.cpp
@@ -79,25 +79,25 @@ ThrowCompletionOr<Promise*> SyntheticModule::evaluate(VM& vm)
     // FIXME: We don't have suspend yet.
 
     // 2. Let moduleContext be a new ECMAScript code execution context.
-    ExecutionContext module_context { vm.heap() };
+    auto module_context = ExecutionContext::create(vm.heap());
 
     // 3. Set the Function of moduleContext to null.
     // Note: This is the default value.
 
     // 4. Set the Realm of moduleContext to module.[[Realm]].
-    module_context.realm = &realm();
+    module_context->realm = &realm();
 
     // 5. Set the ScriptOrModule of moduleContext to module.
-    module_context.script_or_module = NonnullGCPtr<Module>(*this);
+    module_context->script_or_module = NonnullGCPtr<Module>(*this);
 
     // 6. Set the VariableEnvironment of moduleContext to module.[[Environment]].
-    module_context.variable_environment = environment();
+    module_context->variable_environment = environment();
 
     // 7. Set the LexicalEnvironment of moduleContext to module.[[Environment]].
-    module_context.lexical_environment = environment();
+    module_context->lexical_environment = environment();
 
     // 8. Push moduleContext on to the execution context stack; moduleContext is now the running execution context.
-    TRY(vm.push_execution_context(module_context, {}));
+    TRY(vm.push_execution_context(*module_context, {}));
 
     // 9. Let result be the result of performing module.[[EvaluationSteps]](module).
     auto result = m_evaluation_steps(*this);

--- a/Userland/Libraries/LibWeb/WebAssembly/WebAssembly.cpp
+++ b/Userland/Libraries/LibWeb/WebAssembly/WebAssembly.cpp
@@ -193,7 +193,7 @@ JS::ThrowCompletionOr<size_t> instantiate_module(JS::VM& vm, Wasm::Module const&
                             for (auto& entry : arguments)
                                 argument_values.append(to_js_value(vm, entry));
 
-                            auto result = TRY(JS::call(vm, function, JS::js_undefined(), move(argument_values)));
+                            auto result = TRY(JS::call(vm, function, JS::js_undefined(), argument_values.span()));
                             if (type.results().is_empty())
                                 return Wasm::Result { Vector<Wasm::Value> {} };
 

--- a/Userland/Libraries/LibWeb/WebIDL/AbstractOperations.cpp
+++ b/Userland/Libraries/LibWeb/WebIDL/AbstractOperations.cpp
@@ -175,7 +175,7 @@ JS::Completion call_user_object_operation(WebIDL::CallbackType& callback, Deprec
     // 12. Let callResult be Call(X, thisArg, esArgs).
     VERIFY(actual_function_object);
     auto& vm = object->vm();
-    auto call_result = JS::call(vm, verify_cast<JS::FunctionObject>(*actual_function_object), this_argument.value(), move(args));
+    auto call_result = JS::call(vm, verify_cast<JS::FunctionObject>(*actual_function_object), this_argument.value(), args.span());
 
     // 13. If callResult is an abrupt completion, set completion to callResult and jump to the step labeled return.
     if (call_result.is_throw_completion()) {
@@ -233,7 +233,7 @@ JS::Completion invoke_callback(WebIDL::CallbackType& callback, Optional<JS::Valu
 
     // 11. Let callResult be Call(F, thisArg, esArgs).
     auto& vm = function_object->vm();
-    auto call_result = JS::call(vm, verify_cast<JS::FunctionObject>(*function_object), this_argument.value(), move(args));
+    auto call_result = JS::call(vm, verify_cast<JS::FunctionObject>(*function_object), this_argument.value(), args.span());
 
     // 12. If callResult is an abrupt completion, set completion to callResult and jump to the step labeled return.
     if (call_result.is_throw_completion()) {
@@ -280,7 +280,7 @@ JS::Completion construct(WebIDL::CallbackType& callback, JS::MarkedVector<JS::Va
 
     // 10. Let callResult be Completion(Construct(F, esArgs)).
     auto& vm = function_object->vm();
-    auto call_result = JS::construct(vm, verify_cast<JS::FunctionObject>(*function_object), move(args));
+    auto call_result = JS::construct(vm, verify_cast<JS::FunctionObject>(*function_object), args.span());
 
     // 11. If callResult is an abrupt completion, set completion to callResult and jump to the step labeled return.
     if (call_result.is_throw_completion()) {


### PR DESCRIPTION
Quick summary:
- Make `ExecutionContext` heap-allocated
- Keep `ExecutionContext` in an intrusive list and let `Heap` mark all contexts without using `MarkedVector` in them
- Combine `Bytecode::CallFrame` allocation with register storage
- Avoid various unnecessary things

Pretty solid results. Some highlights:
1.514x faster on Octane/deltablue.js
1.169x faster on Octane/gbemu.js
1.147x faster on Kraken/imaging-darkroom.js
1.134x faster on Octane/typescript.js
1.110x faster on Octane/mandreel.js

```
Suite       Test                                   Speedup  Old (Mean ± Range)        New (Mean ± Range)
----------  -----------------------------------  ---------  ------------------------  ------------------------
Kraken      ai-astar.js                              1.03   0.855 ± 0.840 … 0.870     0.830 ± 0.830 … 0.830
Kraken      audio-beat-detection.js                  0.967  0.440 ± 0.440 … 0.440     0.455 ± 0.450 … 0.460
Kraken      audio-dft.js                             1.045  0.345 ± 0.340 … 0.350     0.330 ± 0.330 … 0.330
Kraken      audio-fft.js                             0.985  0.320 ± 0.320 … 0.320     0.325 ± 0.320 … 0.330
Kraken      audio-oscillator.js                      1      0.360 ± 0.360 … 0.360     0.360 ± 0.360 … 0.360
Kraken      imaging-darkroom.js                      1.147  2.845 ± 2.840 … 2.850     2.480 ± 2.460 … 2.500
Kraken      imaging-desaturate.js                    0.985  0.640 ± 0.640 … 0.640     0.650 ± 0.650 … 0.650
Kraken      imaging-gaussian-blur.js                 0.993  2.815 ± 2.810 … 2.820     2.835 ± 2.830 … 2.840
Kraken      json-parse-financial.js                  1      0.070 ± 0.070 … 0.070     0.070 ± 0.070 … 0.070
Kraken      json-stringify-tinderbox.js              1      0.210 ± 0.210 … 0.210     0.210 ± 0.210 … 0.210
Kraken      stanford-crypto-aes.js                   1.051  0.520 ± 0.520 … 0.520     0.495 ± 0.490 … 0.500
Kraken      stanford-crypto-ccm.js                   1.047  0.560 ± 0.560 … 0.560     0.535 ± 0.530 … 0.540
Kraken      stanford-crypto-pbkdf2.js                1.04   0.920 ± 0.920 … 0.920     0.885 ± 0.870 … 0.900
Kraken      stanford-crypto-sha256-iterative.js      1.039  0.400 ± 0.400 … 0.400     0.385 ± 0.380 … 0.390
Octane      box2d.js                                 1.11   2.520 ± 2.520 … 2.520     2.270 ± 2.250 … 2.290
Octane      code-load.js                             0.986  2.100 ± 2.100 … 2.100     2.130 ± 2.130 … 2.130
Octane      crypto.js                                0.999  5.100 ± 5.090 … 5.110     5.105 ± 5.080 … 5.130
Octane      deltablue.js                             1.514  3.080 ± 3.080 … 3.080     2.035 ± 2.030 … 2.040
Octane      earley-boyer.js                          1.09   21.710 ± 21.670 … 21.750  19.910 ± 19.770 … 20.050
Octane      gbemu.js                                 1.169  3.360 ± 3.350 … 3.370     2.875 ± 2.850 … 2.900
Octane      mandreel.js                              1.11   18.420 ± 18.380 … 18.460  16.600 ± 16.560 … 16.640
Octane      navier-stokes.js                         1.002  2.035 ± 2.030 … 2.040     2.030 ± 2.030 … 2.030
Octane      pdfjs.js                                 1.08   3.175 ± 3.160 … 3.190     2.940 ± 2.930 … 2.950
Octane      raytrace.js                              1.086  7.560 ± 7.550 … 7.570     6.960 ± 6.870 … 7.050
Octane      regexp.js                                1.041  25.055 ± 24.990 … 25.120  24.065 ± 24.060 … 24.070
Octane      richards.js                              1.002  2.020 ± 2.020 … 2.020     2.015 ± 2.010 … 2.020
Octane      splay.js                                 1.05   3.175 ± 3.170 … 3.180     3.025 ± 3.020 … 3.030
Octane      typescript.js                            1.134  49.380 ± 48.830 … 49.930  43.560 ± 43.360 … 43.760
Octane      zlib.js                                  1.001  50.155 ± 50.110 … 50.200  50.080 ± 49.900 … 50.260
Kraken      Total                                    1.042  11.300                    10.845
Octane      Total                                    1.071  198.845                   185.600
All Suites  Total                                    1.07   210.145                   196.445
```