### PR TITLE
AK: Ensure assigned-to Strings are dereferenced if needed

### DIFF
--- a/AK/String.cpp
+++ b/AK/String.cpp
@@ -215,10 +215,15 @@ String& String::operator=(String&& other)
 String& String::operator=(String const& other)
 {
     if (&other != this) {
+        if (!is_short_string())
+            m_data->unref();
+
         m_data = other.m_data;
+
         if (!is_short_string())
             m_data->ref();
     }
+
     return *this;
 }
 

--- a/Tests/AK/TestString.cpp
+++ b/Tests/AK/TestString.cpp
@@ -39,6 +39,26 @@ TEST_CASE(move_assignment)
     EXPECT_EQ(string1, "friends!"sv);
 }
 
+TEST_CASE(copy_assignment)
+{
+    auto test = [](auto string1, auto string2) {
+        string1 = string2;
+        EXPECT_EQ(string1, string2);
+    };
+
+    test(String {}, String {});
+    test(String {}, "abc"_string);
+    test(String {}, "long string"_string);
+
+    test("abc"_string, String {});
+    test("abc"_string, "abc"_string);
+    test("abc"_string, "long string"_string);
+
+    test("long string"_string, String {});
+    test("long string"_string, "abc"_string);
+    test("long string"_string, "long string"_string);
+}
+
 TEST_CASE(short_strings)
 {
 #ifdef AK_ARCH_64_BIT


### PR DESCRIPTION
If we assign to an existing non-short string, we must dereference its StringData object to prevent leaking that data.