### PR TITLE
LibAccelGfx+LibWeb: Store state of all stacking contexts in GPU painter

### DIFF
--- a/Userland/Libraries/LibAccelGfx/Painter.cpp
+++ b/Userland/Libraries/LibAccelGfx/Painter.cpp
@@ -137,7 +137,7 @@ void main() {
 
 HashMap<u32, GL::Texture> s_immutable_bitmap_texture_cache;
 
-OwnPtr<Painter> Painter::create()
+NonnullOwnPtr<Painter> Painter::create()
 {
     auto& context = Context::the();
     return make<Painter>(context);

--- a/Userland/Libraries/LibAccelGfx/Painter.h
+++ b/Userland/Libraries/LibAccelGfx/Painter.h
@@ -29,7 +29,7 @@ class Painter {
     AK_MAKE_NONMOVABLE(Painter);
 
 public:
-    static OwnPtr<Painter> create();
+    static NonnullOwnPtr<Painter> create();
 
     Painter(Context&);
     ~Painter();

--- a/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorGPU.h
+++ b/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorGPU.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/MaybeOwned.h>
 #include <LibAccelGfx/Painter.h>
 #include <LibWeb/Painting/RecordingPainter.h>
 
@@ -63,15 +64,16 @@ private:
 
     struct StackingContext {
         RefPtr<AccelGfx::Canvas> canvas;
-        OwnPtr<AccelGfx::Painter> painter;
+        MaybeOwned<AccelGfx::Painter> painter;
         float opacity;
         Gfx::IntRect destination;
+        int stacking_context_depth { 0 };
     };
 
-    [[nodiscard]] AccelGfx::Painter const& painter() const { return *stacking_contexts.last().painter; }
-    [[nodiscard]] AccelGfx::Painter& painter() { return *stacking_contexts.last().painter; }
+    [[nodiscard]] AccelGfx::Painter const& painter() const { return *m_stacking_contexts.last().painter; }
+    [[nodiscard]] AccelGfx::Painter& painter() { return *m_stacking_contexts.last().painter; }
 
-    Vector<StackingContext> stacking_contexts;
+    Vector<StackingContext> m_stacking_contexts;
 };
 
 }


### PR DESCRIPTION
This change ensures that the GPU painting executor follows the pattern of the CPU executor, where the state is stored for each stacking context, but a painter is created only for those with opacity.

Fixes crashing on apple.com because now save() and restore() are called on correct painters.