### PR TITLE
LibWeb: Restore painter state if push_stacking_context() has failed

### DIFF
--- a/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorCPU.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorCPU.cpp
@@ -166,6 +166,7 @@ CommandResult PaintingCommandExecutorCPU::push_stacking_context(
         //       with execution of commands outside of this stacking context.
         // FIXME: Change the get_region_bitmap() API to return ErrorOr<Optional<Bitmap>> and exit the execution of commands here
         //        if we run out of memory.
+        painter().restore();
         return CommandResult::SkipStackingContext;
     }
 


### PR DESCRIPTION
If `SkipStackingContext` is returned we also need to restore saved painter state because corresponding pop_stacking_context command that is supposed to do that will be skipped.

Fixes https://github.com/SerenityOS/serenity/issues/22092