### PR TITLE
Kernel: Only unmap prekernel on x86_64

### DIFF
--- a/Kernel/Arch/init.cpp
+++ b/Kernel/Arch/init.cpp
@@ -263,9 +263,9 @@ extern "C" [[noreturn]] UNMAP_AFTER_INIT void init([[maybe_unused]] BootInfo con
     }
     dmesgln("Starting SerenityOS...");
 
+#if ARCH(X86_64)
     MM.unmap_prekernel();
 
-#if ARCH(X86_64)
     // Ensure that the safemem sections are not empty. This could happen if the linker accidentally discards the sections.
     VERIFY(+start_of_safemem_text != +end_of_safemem_text);
     VERIFY(+start_of_safemem_atomic_text != +end_of_safemem_atomic_text);


### PR DESCRIPTION
Other arches don't use the prekernel, so don't try to unmap it on non-x86 platforms.
For some reason, this didn't cause aarch64 to crash, but on riscv64 this would cause a panic.