### PR TITLE
Ladybird/AppKit: Remove theme color changing background color

### DIFF
--- a/Ladybird/AppKit/UI/LadybirdWebView.h
+++ b/Ladybird/AppKit/UI/LadybirdWebView.h
@@ -26,7 +26,6 @@
 - (void)loadURL:(URL const&)url;
 - (void)onLoadStart:(URL const&)url isRedirect:(BOOL)is_redirect;
 - (void)onLoadFinish:(URL const&)url;
-- (void)onThemeColorChange:(Color)color;
 
 - (void)onTitleChange:(DeprecatedString const&)title;
 - (void)onFaviconChange:(Gfx::Bitmap const&)bitmap;

--- a/Ladybird/AppKit/UI/LadybirdWebView.mm
+++ b/Ladybird/AppKit/UI/LadybirdWebView.mm
@@ -668,11 +668,7 @@ static void copy_data_to_clipboard(StringView data, NSPasteboardType pasteboard_
     };
 
     m_web_view_bridge->on_theme_color_change = [self](auto color) {
-        self.backgroundColor = [NSColor colorWithRed:(color.red() / 255.0)
-                                               green:(color.green() / 255.0)
-                                                blue:(color.blue() / 255.0)
-                                               alpha:1.0];
-        [self.observer onThemeColorChange:color];
+        self.backgroundColor = Ladybird::gfx_color_to_ns_color(color);
     };
 
     m_web_view_bridge->on_insert_clipboard_entry = [](auto const& data, auto const&, auto const& mime_type) {

--- a/Ladybird/AppKit/UI/Tab.mm
+++ b/Ladybird/AppKit/UI/Tab.mm
@@ -100,8 +100,6 @@ static constexpr CGFloat const WINDOW_HEIGHT = 800;
                  object:[scroll_view contentView]];
 
         [self setContentView:scroll_view];
-        self.backgroundColor = [NSColor windowBackgroundColor];
-        self.titlebarAppearsTransparent = YES;
     }
 
     return self;
@@ -226,7 +224,6 @@ static constexpr CGFloat const WINDOW_HEIGHT = 800;
 - (void)onLoadStart:(URL const&)url isRedirect:(BOOL)is_redirect
 {
     if (url != self.last_url) {
-        self.backgroundColor = [NSColor windowBackgroundColor];
         self.last_url = url;
     }
 
@@ -256,23 +253,6 @@ static constexpr CGFloat const WINDOW_HEIGHT = 800;
 
     self.title = Ladybird::string_to_ns_string(title);
     [self updateTabTitleAndFavicon];
-}
-
-- (void)onThemeColorChange:(Color)color
-{
-    auto* nscolor = [NSColor colorWithRed:((CGFloat)color.red()) / 255.0
-                                    green:((CGFloat)color.green()) / 255.0
-                                     blue:((CGFloat)color.blue()) / 255.0
-                                    alpha:1.0];
-    CGFloat hue = 0.0;
-    CGFloat saturation = 0.0;
-    CGFloat brightness = 0.0;
-    [nscolor getHue:&hue saturation:&saturation brightness:&brightness alpha:nil];
-    if (brightness > 0.75)
-        brightness = 0.75;
-    nscolor = [NSColor colorWithHue:hue saturation:saturation brightness:brightness alpha:1.0];
-    self.backgroundColor = nscolor;
-    self.titlebarAppearsTransparent = YES;
 }
 
 - (void)onFaviconChange:(Gfx::Bitmap const&)bitmap


### PR DESCRIPTION
~~Use correct readable light/dark theme for top level browser UI when theme color is set. This results in always readable UI. As you can see the system theme is not used anymore it is purely set by the luminance of the theme color.~~

This removes the theme color changing background color because it is annoying.

I also used `gfx_color_to_ns_color` to clean up the code a bit.

This closes #21394 🥳
