### PR TITLE
LIBJS: Call builtins directly in the bytecode interpreter

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/MathObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/MathObject.cpp
@@ -80,10 +80,8 @@ void MathObject::initialize(Realm& realm)
 }
 
 // 21.3.2.1 Math.abs ( x ), https://tc39.es/ecma262/#sec-math.abs
-JS_DEFINE_NATIVE_FUNCTION(MathObject::abs)
+ThrowCompletionOr<Value> MathObject::abs_impl(VM& vm, Value x)
 {
-    auto x = vm.argument(0);
-
     // OPTIMIZATION: Fast path for Int32 values.
     if (x.is_int32())
         return Value(AK::abs(x.as_i32()));
@@ -106,6 +104,12 @@ JS_DEFINE_NATIVE_FUNCTION(MathObject::abs)
     // 5. If n < -0𝔽, return -n.
     // 6. Return n.
     return Value(number.as_double() < 0 ? -number.as_double() : number.as_double());
+}
+
+// 21.3.2.1 Math.abs ( x ), https://tc39.es/ecma262/#sec-math.abs
+JS_DEFINE_NATIVE_FUNCTION(MathObject::abs)
+{
+    return abs_impl(vm, vm.argument(0));
 }
 
 // 21.3.2.2 Math.acos ( x ), https://tc39.es/ecma262/#sec-math.acos

--- a/Userland/Libraries/LibJS/Runtime/MathObject.h
+++ b/Userland/Libraries/LibJS/Runtime/MathObject.h
@@ -25,6 +25,7 @@ public:
     static ThrowCompletionOr<Value> ceil_impl(VM&, Value);
     static ThrowCompletionOr<Value> round_impl(VM&, Value);
     static ThrowCompletionOr<Value> exp_impl(VM&, Value);
+    static ThrowCompletionOr<Value> abs_impl(VM&, Value);
 
 private:
     explicit MathObject(Realm&);

--- a/Userland/Libraries/LibJS/Runtime/Realm.h
+++ b/Userland/Libraries/LibJS/Runtime/Realm.h
@@ -57,6 +57,11 @@ public:
         m_builtins[to_underlying(builtin)] = value;
     }
 
+    Value get_builtin_value(Bytecode::Builtin builtin)
+    {
+        return m_builtins[to_underlying(builtin)];
+    }
+
     static FlatPtr global_environment_offset() { return OFFSET_OF(Realm, m_global_environment); }
     static FlatPtr builtins_offset() { return OFFSET_OF(Realm, m_builtins); }
 


### PR DESCRIPTION
Allows the bytecode interpreter to call the builtins c++ implementation directly without making a javascript call just as the JIT.

Kraken test speedups: imaging-gaussian-blur.js (1.5x) and audio-oscillator.js (1.2x)