### PR TITLE
Everywhere: Replace `ElfW(type)` macro usage with `Elf_type`

### DIFF
--- a/Kernel/Prekernel/init.cpp
+++ b/Kernel/Prekernel/init.cpp
@@ -99,11 +99,11 @@ extern "C" [[noreturn]] void init()
 
     u8* kernel_image = (u8*)(FlatPtr)kernel_module->start;
     // copy the ELF header and program headers because we might end up overwriting them
-    ElfW(Ehdr) kernel_elf_header = *(ElfW(Ehdr)*)kernel_image;
-    ElfW(Phdr) kernel_program_headers[16];
+    Elf_Ehdr kernel_elf_header = *(Elf_Ehdr*)kernel_image;
+    Elf_Phdr kernel_program_headers[16];
     if (kernel_elf_header.e_phnum > array_size(kernel_program_headers))
         halt();
-    __builtin_memcpy(kernel_program_headers, kernel_image + kernel_elf_header.e_phoff, sizeof(ElfW(Phdr)) * kernel_elf_header.e_phnum);
+    __builtin_memcpy(kernel_program_headers, kernel_image + kernel_elf_header.e_phoff, sizeof(Elf_Phdr) * kernel_elf_header.e_phnum);
 
     FlatPtr kernel_physical_base = 0x200000;
     FlatPtr default_kernel_load_base = KERNEL_MAPPING_BASE + 0x200000;

--- a/Kernel/Syscalls/mmap.cpp
+++ b/Kernel/Syscalls/mmap.cpp
@@ -56,7 +56,7 @@ static bool should_make_executable_exception_for_dynamic_loader(bool make_readab
     auto const& inode_vm = static_cast<Memory::InodeVMObject const&>(region.vmobject());
     auto const& inode = inode_vm.inode();
 
-    ElfW(Ehdr) header;
+    Elf_Ehdr header;
     auto buffer = UserOrKernelBuffer::for_kernel_buffer((u8*)&header);
     auto result = inode.read_bytes(0, sizeof(header), buffer, nullptr);
     if (result.is_error() || result.value() != sizeof(header))

--- a/Kernel/Tasks/Process.h
+++ b/Kernel/Tasks/Process.h
@@ -503,7 +503,7 @@ public:
 
     ErrorOr<void> exec(NonnullOwnPtr<KString> path, Vector<NonnullOwnPtr<KString>> arguments, Vector<NonnullOwnPtr<KString>> environment, Thread*& new_main_thread, InterruptsState& previous_interrupts_state, int recursion_depth = 0);
 
-    ErrorOr<LoadResult> load(Memory::AddressSpace& new_space, NonnullRefPtr<OpenFileDescription> main_program_description, RefPtr<OpenFileDescription> interpreter_description, const ElfW(Ehdr) & main_program_header, Optional<size_t> minimum_stack_size = {});
+    ErrorOr<LoadResult> load(Memory::AddressSpace& new_space, NonnullRefPtr<OpenFileDescription> main_program_description, RefPtr<OpenFileDescription> interpreter_description, Elf_Ehdr const& main_program_header, Optional<size_t> minimum_stack_size = {});
 
     void terminate_due_to_signal(u8 signal);
     ErrorOr<void> send_signal(u8 signal, Process* sender);
@@ -664,12 +664,12 @@ private:
     bool create_perf_events_buffer_if_needed();
     void delete_perf_events_buffer();
 
-    ErrorOr<void> do_exec(NonnullRefPtr<OpenFileDescription> main_program_description, Vector<NonnullOwnPtr<KString>> arguments, Vector<NonnullOwnPtr<KString>> environment, RefPtr<OpenFileDescription> interpreter_description, Thread*& new_main_thread, InterruptsState& previous_interrupts_state, const ElfW(Ehdr) & main_program_header, Optional<size_t> minimum_stack_size = {});
+    ErrorOr<void> do_exec(NonnullRefPtr<OpenFileDescription> main_program_description, Vector<NonnullOwnPtr<KString>> arguments, Vector<NonnullOwnPtr<KString>> environment, RefPtr<OpenFileDescription> interpreter_description, Thread*& new_main_thread, InterruptsState& previous_interrupts_state, Elf_Ehdr const& main_program_header, Optional<size_t> minimum_stack_size = {});
     ErrorOr<FlatPtr> do_write(OpenFileDescription&, UserOrKernelBuffer const&, size_t, Optional<off_t> = {});
 
     ErrorOr<FlatPtr> do_statvfs(FileSystem const& path, Custody const*, statvfs* buf);
 
-    ErrorOr<RefPtr<OpenFileDescription>> find_elf_interpreter_for_executable(StringView path, ElfW(Ehdr) const& main_executable_header, size_t main_executable_header_size, size_t file_size, Optional<size_t>& minimum_stack_size);
+    ErrorOr<RefPtr<OpenFileDescription>> find_elf_interpreter_for_executable(StringView path, Elf_Ehdr const& main_executable_header, size_t main_executable_header_size, size_t file_size, Optional<size_t>& minimum_stack_size);
 
     ErrorOr<void> do_kill(Process&, int signal);
     ErrorOr<void> do_killpg(ProcessGroupID pgrp, int signal);

--- a/Userland/Libraries/LibC/link.h
+++ b/Userland/Libraries/LibC/link.h
@@ -13,10 +13,10 @@
 __BEGIN_DECLS
 
 struct dl_phdr_info {
-    ElfW(Addr) dlpi_addr;
+    Elf_Addr dlpi_addr;
     char const* dlpi_name;
-    const ElfW(Phdr) * dlpi_phdr;
-    ElfW(Half) dlpi_phnum;
+    Elf_Phdr const* dlpi_phdr;
+    Elf_Half dlpi_phnum;
 };
 
 int dl_iterate_phdr(int (*callback)(struct dl_phdr_info* info, size_t size, void* data), void* data);

--- a/Userland/Libraries/LibELF/DynamicLinker.cpp
+++ b/Userland/Libraries/LibELF/DynamicLinker.cpp
@@ -244,7 +244,7 @@ static int __dl_iterate_phdr(DlIteratePhdrCallbackFunction callback, void* data)
     for (auto& it : s_global_objects) {
         auto& object = it.value;
         auto info = dl_phdr_info {
-            .dlpi_addr = (ElfW(Addr))object->base_address().as_ptr(),
+            .dlpi_addr = (Elf_Addr)object->base_address().as_ptr(),
             .dlpi_name = object->filepath().characters(),
             .dlpi_phdr = object->program_headers(),
             .dlpi_phnum = object->program_header_count()

--- a/Userland/Libraries/LibELF/DynamicLoader.cpp
+++ b/Userland/Libraries/LibELF/DynamicLoader.cpp
@@ -55,7 +55,7 @@ Result<NonnullRefPtr<DynamicLoader>, DlErrorMessage> DynamicLoader::try_create(i
 
     VERIFY(stat.st_size >= 0);
     auto size = static_cast<size_t>(stat.st_size);
-    if (size < sizeof(ElfW(Ehdr)))
+    if (size < sizeof(Elf_Ehdr))
         return DlErrorMessage { DeprecatedString::formatted("File {} has invalid ELF header", filepath) };
 
     DeprecatedString file_mmap_name = DeprecatedString::formatted("ELF_DYN: {}", filepath);
@@ -132,7 +132,7 @@ bool DynamicLoader::validate()
     if (!image().is_valid())
         return false;
 
-    auto* elf_header = (ElfW(Ehdr)*)m_file_data;
+    auto* elf_header = (Elf_Ehdr*)m_file_data;
     if (!validate_elf_header(*elf_header, m_file_size))
         return false;
     auto result_or_error = validate_program_headers(*elf_header, m_file_size, { m_file_data, m_file_size });

--- a/Userland/Libraries/LibELF/DynamicLoader.h
+++ b/Userland/Libraries/LibELF/DynamicLoader.h
@@ -98,7 +98,7 @@ private:
 
     class ProgramHeaderRegion {
     public:
-        void set_program_header(const ElfW(Phdr) & header) { m_program_header = header; }
+        void set_program_header(Elf_Phdr const& header) { m_program_header = header; }
 
         // Information from ELF Program header
         u32 type() const { return m_program_header.p_type; }
@@ -117,7 +117,7 @@ private:
         bool is_relro() const { return type() == PT_GNU_RELRO; }
 
     private:
-        ElfW(Phdr) m_program_header; // Explicitly a copy of the PHDR in the image
+        Elf_Phdr m_program_header; // Explicitly a copy of the PHDR in the image
     };
 
     // Stage 1

--- a/Userland/Libraries/LibELF/DynamicObject.h
+++ b/Userland/Libraries/LibELF/DynamicObject.h
@@ -21,7 +21,7 @@ namespace ELF {
 class DynamicObject : public RefCounted<DynamicObject> {
 public:
     static NonnullRefPtr<DynamicObject> create(DeprecatedString const& filepath, VirtualAddress base_address, VirtualAddress dynamic_section_address);
-    static char const* name_for_dtag(ElfW(Sword) d_tag);
+    static char const* name_for_dtag(Elf_Sword d_tag);
 
     ~DynamicObject();
     void dump() const;
@@ -35,24 +35,24 @@ public:
 
     class DynamicEntry {
     public:
-        explicit DynamicEntry(const ElfW(Dyn) & dyn)
+        explicit DynamicEntry(Elf_Dyn const& dyn)
             : m_dyn(dyn)
         {
         }
 
         ~DynamicEntry() = default;
 
-        ElfW(Sword) tag() const { return m_dyn.d_tag; }
-        ElfW(Addr) ptr() const { return m_dyn.d_un.d_ptr; }
-        ElfW(Word) val() const { return m_dyn.d_un.d_val; }
+        Elf_Sword tag() const { return m_dyn.d_tag; }
+        Elf_Addr ptr() const { return m_dyn.d_un.d_ptr; }
+        Elf_Word val() const { return m_dyn.d_un.d_val; }
 
     private:
-        const ElfW(Dyn) & m_dyn;
+        Elf_Dyn const& m_dyn;
     };
 
     class Symbol {
     public:
-        Symbol(DynamicObject const& dynamic, unsigned index, const ElfW(Sym) & sym)
+        Symbol(DynamicObject const& dynamic, unsigned index, Elf_Sym const& sym)
             : m_dynamic(dynamic)
             , m_sym(sym)
             , m_index(index)
@@ -92,7 +92,7 @@ public:
 
     private:
         DynamicObject const& m_dynamic;
-        const ElfW(Sym) & m_sym;
+        Elf_Sym const& m_sym;
         unsigned const m_index;
     };
 
@@ -153,7 +153,7 @@ public:
 
     class Relocation {
     public:
-        Relocation(DynamicObject const& dynamic, const ElfW(Rela) & rel, unsigned offset_in_section, bool addend_used)
+        Relocation(DynamicObject const& dynamic, Elf_Rela const& rel, unsigned offset_in_section, bool addend_used)
             : m_dynamic(dynamic)
             , m_rel(rel)
             , m_offset_in_section(offset_in_section)
@@ -191,7 +191,7 @@ public:
 
     private:
         DynamicObject const& m_dynamic;
-        const ElfW(Rela) & m_rel;
+        Elf_Rela const& m_rel;
         unsigned const m_offset_in_section;
         bool const m_addend_used;
     };
@@ -246,7 +246,7 @@ public:
 
     typedef void (*InitializationFunction)();
     typedef void (*FinalizationFunction)();
-    typedef ElfW(Addr) (*IfuncResolver)();
+    typedef Elf_Addr (*IfuncResolver)();
 
     bool has_init_section() const { return m_init_offset != 0; }
     bool has_init_array_section() const { return m_init_array_offset != 0; }
@@ -295,8 +295,8 @@ public:
     void set_tls_offset(FlatPtr offset) { m_tls_offset = offset; }
     void set_tls_size(FlatPtr size) { m_tls_size = size; }
 
-    ElfW(Half) program_header_count() const;
-    const ElfW(Phdr) * program_headers() const;
+    Elf_Half program_header_count() const;
+    Elf_Phdr const* program_headers() const;
 
     template<VoidFunction<StringView> F>
     void for_each_needed_library(F) const;
@@ -334,8 +334,8 @@ public:
 private:
     explicit DynamicObject(DeprecatedString const& filepath, VirtualAddress base_address, VirtualAddress dynamic_section_address);
 
-    StringView symbol_string_table_string(ElfW(Word)) const;
-    char const* raw_symbol_string_table_string(ElfW(Word)) const;
+    StringView symbol_string_table_string(Elf_Word) const;
+    char const* raw_symbol_string_table_string(Elf_Word) const;
     void parse();
 
     DeprecatedString m_filepath;
@@ -363,7 +363,7 @@ private:
     FlatPtr m_symbol_table_offset { 0 };
     size_t m_size_of_symbol_table_entry { 0 };
 
-    ElfW(Sword) m_procedure_linkage_table_relocation_type { -1 };
+    Elf_Sword m_procedure_linkage_table_relocation_type { -1 };
     FlatPtr m_plt_relocation_offset_location { 0 }; // offset of PLT relocations, at end of relocations
     size_t m_size_of_plt_relocation_entry_list { 0 };
     Optional<FlatPtr> m_procedure_linkage_table_offset;
@@ -383,14 +383,14 @@ private:
     bool m_is_pie { false };
 
     // DT_FLAGS
-    ElfW(Word) m_dt_flags { 0 };
+    Elf_Word m_dt_flags { 0 };
 
     bool m_has_soname { false };
-    ElfW(Word) m_soname_index { 0 }; // Index into dynstr table for SONAME
+    Elf_Word m_soname_index { 0 }; // Index into dynstr table for SONAME
     bool m_has_rpath { false };
-    ElfW(Word) m_rpath_index { 0 }; // Index into dynstr table for RPATH
+    Elf_Word m_rpath_index { 0 }; // Index into dynstr table for RPATH
     bool m_has_runpath { false };
-    ElfW(Word) m_runpath_index { 0 }; // Index into dynstr table for RUNPATH
+    Elf_Word m_runpath_index { 0 }; // Index into dynstr table for RUNPATH
 
     Optional<FlatPtr> m_tls_offset;
     Optional<FlatPtr> m_tls_size;
@@ -428,7 +428,7 @@ inline void DynamicObject::for_each_relr_relocation(F f) const
     VERIFY(section.entry_size() == sizeof(FlatPtr));
     VERIFY(section.size() >= section.entry_size() * section.entry_count());
 
-    auto* entries = reinterpret_cast<ElfW(Relr)*>(section.address().get());
+    auto* entries = reinterpret_cast<Elf_Relr*>(section.address().get());
     auto base = base_address().get();
     FlatPtr patch_addr = 0;
     for (unsigned i = 0; i < section.entry_count(); ++i) {
@@ -458,7 +458,7 @@ inline void DynamicObject::for_each_symbol(F func) const
 template<IteratorFunction<DynamicObject::DynamicEntry&> F>
 inline void DynamicObject::for_each_dynamic_entry(F func) const
 {
-    auto* dyns = reinterpret_cast<const ElfW(Dyn)*>(m_dynamic_address.as_ptr());
+    auto* dyns = reinterpret_cast<Elf_Dyn const*>(m_dynamic_address.as_ptr());
     for (unsigned i = 0;; ++i) {
         auto&& dyn = DynamicEntry(dyns[i]);
         if (dyn.tag() == DT_NULL)
@@ -483,7 +483,7 @@ inline void DynamicObject::for_each_needed_library(F func) const
     for_each_dynamic_entry([func, this](auto entry) {
         if (entry.tag() != DT_NEEDED)
             return;
-        ElfW(Word) offset = entry.val();
+        Elf_Word offset = entry.val();
         func(symbol_string_table_string(offset));
     });
 }

--- a/Userland/Libraries/LibELF/ELFABI.h
+++ b/Userland/Libraries/LibELF/ELFABI.h
@@ -761,6 +761,7 @@ struct elf_args {
 #    define Elf_Sym Elf32_Sym
 #    define Elf_Rel Elf32_Rel
 #    define Elf_RelA Elf32_Rela
+#    define Elf_Rela Elf32_Rela
 #    define Elf_Relr Elf32_Relr
 #    define Elf_Dyn Elf32_Dyn
 #    define Elf_Half Elf32_Half
@@ -789,6 +790,7 @@ struct elf_args {
 #    define Elf_Sym Elf64_Sym
 #    define Elf_Rel Elf64_Rel
 #    define Elf_RelA Elf64_Rela
+#    define Elf_Rela Elf64_Rela
 #    define Elf_Relr Elf64_Relr
 #    define Elf_Dyn Elf64_Dyn
 #    define Elf_Half Elf64_Half

--- a/Userland/Libraries/LibELF/ELFABI.h
+++ b/Userland/Libraries/LibELF/ELFABI.h
@@ -41,6 +41,8 @@
 
 #define ElfW(type) Elf64_##type
 
+#define ELFSIZE 64
+
 typedef uint8_t Elf_Byte;
 
 typedef uint32_t Elf32_Addr; /* Unsigned program address */

--- a/Userland/Libraries/LibELF/Image.cpp
+++ b/Userland/Libraries/LibELF/Image.cpp
@@ -121,7 +121,7 @@ unsigned Image::program_header_count() const
 
 bool Image::parse()
 {
-    if (m_size < sizeof(ElfW(Ehdr)) || !validate_elf_header(header(), m_size, m_verbose_logging)) {
+    if (m_size < sizeof(Elf_Ehdr) || !validate_elf_header(header(), m_size, m_verbose_logging)) {
         if (m_verbose_logging)
             dbgln("ELF::Image::parse(): ELF Header not valid");
         m_valid = false;
@@ -198,31 +198,31 @@ char const* Image::raw_data(unsigned offset) const
     return reinterpret_cast<char const*>(m_buffer) + offset;
 }
 
-const ElfW(Ehdr) & Image::header() const
+Elf_Ehdr const& Image::header() const
 {
-    VERIFY(m_size >= sizeof(ElfW(Ehdr)));
-    return *reinterpret_cast<const ElfW(Ehdr)*>(raw_data(0));
+    VERIFY(m_size >= sizeof(Elf_Ehdr));
+    return *reinterpret_cast<Elf_Ehdr const*>(raw_data(0));
 }
 
-const ElfW(Phdr) & Image::program_header_internal(unsigned index) const
+Elf_Phdr const& Image::program_header_internal(unsigned index) const
 {
     VERIFY(m_valid);
     VERIFY(index < header().e_phnum);
-    return *reinterpret_cast<const ElfW(Phdr)*>(raw_data(header().e_phoff + (index * sizeof(ElfW(Phdr)))));
+    return *reinterpret_cast<Elf_Phdr const*>(raw_data(header().e_phoff + (index * sizeof(Elf_Phdr))));
 }
 
-const ElfW(Shdr) & Image::section_header(unsigned index) const
+Elf_Shdr const& Image::section_header(unsigned index) const
 {
     VERIFY(m_valid);
     VERIFY(index < header().e_shnum);
-    return *reinterpret_cast<const ElfW(Shdr)*>(raw_data(header().e_shoff + (index * header().e_shentsize)));
+    return *reinterpret_cast<Elf_Shdr const*>(raw_data(header().e_shoff + (index * header().e_shentsize)));
 }
 
 Image::Symbol Image::symbol(unsigned index) const
 {
     VERIFY(m_valid);
     VERIFY(index < symbol_count());
-    auto* raw_syms = reinterpret_cast<const ElfW(Sym)*>(raw_data(section(m_symbol_table_section_index).offset()));
+    auto* raw_syms = reinterpret_cast<Elf_Sym const*>(raw_data(section(m_symbol_table_section_index).offset()));
     return Symbol(*this, index, raw_syms[index]);
 }
 
@@ -243,7 +243,7 @@ Image::ProgramHeader Image::program_header(unsigned index) const
 Image::Relocation Image::RelocationSection::relocation(unsigned index) const
 {
     VERIFY(index < relocation_count());
-    auto* rels = reinterpret_cast<const ElfW(Rel)*>(m_image.raw_data(offset()));
+    auto* rels = reinterpret_cast<Elf_Rel const*>(m_image.raw_data(offset()));
     return Relocation(m_image, rels[index]);
 }
 
@@ -272,7 +272,7 @@ Optional<Image::Section> Image::lookup_section(StringView name) const
     return {};
 }
 
-Optional<StringView> Image::object_file_type_to_string(ElfW(Half) type)
+Optional<StringView> Image::object_file_type_to_string(Elf_Half type)
 {
     switch (type) {
     case ET_NONE:
@@ -290,7 +290,7 @@ Optional<StringView> Image::object_file_type_to_string(ElfW(Half) type)
     }
 }
 
-Optional<StringView> Image::object_machine_type_to_string(ElfW(Half) type)
+Optional<StringView> Image::object_machine_type_to_string(Elf_Half type)
 {
     switch (type) {
     case ET_NONE:

--- a/Userland/Libraries/LibELF/Image.h
+++ b/Userland/Libraries/LibELF/Image.h
@@ -44,7 +44,7 @@ public:
 
     class Symbol {
     public:
-        Symbol(Image const& image, unsigned index, const ElfW(Sym) & sym)
+        Symbol(Image const& image, unsigned index, Elf_Sym const& sym)
             : m_image(image)
             , m_sym(sym)
             , m_index(index)
@@ -72,7 +72,7 @@ public:
 
     private:
         Image const& m_image;
-        const ElfW(Sym) & m_sym;
+        Elf_Sym const& m_sym;
         unsigned const m_index;
     };
 
@@ -98,11 +98,11 @@ public:
         bool is_writable() const { return flags() & PF_W; }
         bool is_executable() const { return flags() & PF_X; }
         char const* raw_data() const { return m_image.raw_data(m_program_header.p_offset); }
-        ElfW(Phdr) raw_header() const { return m_program_header; }
+        Elf_Phdr raw_header() const { return m_program_header; }
 
     private:
         Image const& m_image;
-        const ElfW(Phdr) & m_program_header;
+        Elf_Phdr const& m_program_header;
         unsigned m_program_header_index { 0 };
     };
 
@@ -133,7 +133,7 @@ public:
     protected:
         friend class RelocationSection;
         Image const& m_image;
-        const ElfW(Shdr) & m_section_header;
+        Elf_Shdr const& m_section_header;
         unsigned m_section_index;
     };
 
@@ -152,7 +152,7 @@ public:
 
     class Relocation {
     public:
-        Relocation(Image const& image, const ElfW(Rel) & rel)
+        Relocation(Image const& image, Elf_Rel const& rel)
             : m_image(image)
             , m_rel(rel)
         {
@@ -173,7 +173,7 @@ public:
 
     private:
         Image const& m_image;
-        const ElfW(Rel) & m_rel;
+        Elf_Rel const& m_rel;
     };
 
     unsigned symbol_count() const;
@@ -214,8 +214,8 @@ public:
     FlatPtr base_address() const { return (FlatPtr)m_buffer; }
     size_t size() const { return m_size; }
 
-    static Optional<StringView> object_file_type_to_string(ElfW(Half) type);
-    static Optional<StringView> object_machine_type_to_string(ElfW(Half) type);
+    static Optional<StringView> object_file_type_to_string(Elf_Half type);
+    static Optional<StringView> object_machine_type_to_string(Elf_Half type);
     static Optional<StringView> object_abi_type_to_string(Elf_Byte type);
 
     bool has_symbols() const { return symbol_count(); }
@@ -227,9 +227,9 @@ public:
 
 private:
     char const* raw_data(unsigned offset) const;
-    const ElfW(Ehdr) & header() const;
-    const ElfW(Shdr) & section_header(unsigned) const;
-    const ElfW(Phdr) & program_header_internal(unsigned) const;
+    Elf_Ehdr const& header() const;
+    Elf_Shdr const& section_header(unsigned) const;
+    Elf_Phdr const& program_header_internal(unsigned) const;
     StringView table_string(unsigned offset) const;
     StringView section_header_table_string(unsigned offset) const;
     StringView section_index_to_string(unsigned index) const;

--- a/Userland/Libraries/LibELF/Validation.cpp
+++ b/Userland/Libraries/LibELF/Validation.cpp
@@ -18,7 +18,7 @@
 
 namespace ELF {
 
-bool validate_elf_header(ElfW(Ehdr) const& elf_header, size_t file_size, bool verbose)
+bool validate_elf_header(Elf_Ehdr const& elf_header, size_t file_size, bool verbose)
 {
     if (!IS_ELF(elf_header)) {
         if (verbose)
@@ -80,9 +80,9 @@ bool validate_elf_header(ElfW(Ehdr) const& elf_header, size_t file_size, bool ve
         return false;
     }
 
-    if (sizeof(ElfW(Ehdr)) != elf_header.e_ehsize) {
+    if (sizeof(Elf_Ehdr) != elf_header.e_ehsize) {
         if (verbose)
-            dbgln("File has incorrect ELF header size..? ({}), expected ({})!", elf_header.e_ehsize, sizeof(ElfW(Ehdr)));
+            dbgln("File has incorrect ELF header size..? ({}), expected ({})!", elf_header.e_ehsize, sizeof(Elf_Ehdr));
         return false;
     }
 
@@ -134,15 +134,15 @@ bool validate_elf_header(ElfW(Ehdr) const& elf_header, size_t file_size, bool ve
         }
     }
 
-    if (0 != elf_header.e_phnum && sizeof(ElfW(Phdr)) != elf_header.e_phentsize) {
+    if (0 != elf_header.e_phnum && sizeof(Elf_Phdr) != elf_header.e_phentsize) {
         if (verbose)
-            dbgln("File has incorrect program header size..? ({}), expected ({}).", elf_header.e_phentsize, sizeof(ElfW(Phdr)));
+            dbgln("File has incorrect program header size..? ({}), expected ({}).", elf_header.e_phentsize, sizeof(Elf_Phdr));
         return false;
     }
 
-    if (sizeof(ElfW(Shdr)) != elf_header.e_shentsize) {
+    if (sizeof(Elf_Shdr) != elf_header.e_shentsize) {
         if (verbose)
-            dbgln("File has incorrect section header size..? ({}), expected ({}).", elf_header.e_shentsize, sizeof(ElfW(Shdr)));
+            dbgln("File has incorrect section header size..? ({}), expected ({}).", elf_header.e_shentsize, sizeof(Elf_Shdr));
         return false;
     }
 
@@ -199,7 +199,7 @@ bool validate_elf_header(ElfW(Ehdr) const& elf_header, size_t file_size, bool ve
     return true;
 }
 
-ErrorOr<bool> validate_program_headers(ElfW(Ehdr) const& elf_header, size_t file_size, ReadonlyBytes buffer, StringBuilder* interpreter_path_builder, Optional<size_t>* requested_stack_size, bool verbose)
+ErrorOr<bool> validate_program_headers(Elf_Ehdr const& elf_header, size_t file_size, ReadonlyBytes buffer, StringBuilder* interpreter_path_builder, Optional<size_t>* requested_stack_size, bool verbose)
 {
     Checked<size_t> total_size_of_program_headers = elf_header.e_phnum;
     total_size_of_program_headers *= elf_header.e_phentsize;
@@ -226,7 +226,7 @@ ErrorOr<bool> validate_program_headers(ElfW(Ehdr) const& elf_header, size_t file
     }
 
     size_t num_program_headers = elf_header.e_phnum;
-    auto program_header_begin = (const ElfW(Phdr)*)buffer.offset(elf_header.e_phoff);
+    auto program_header_begin = (Elf_Phdr const*)buffer.offset(elf_header.e_phoff);
 
     for (size_t header_index = 0; header_index < num_program_headers; ++header_index) {
         auto& program_header = program_header_begin[header_index];

--- a/Userland/Libraries/LibELF/Validation.h
+++ b/Userland/Libraries/LibELF/Validation.h
@@ -11,7 +11,7 @@
 
 namespace ELF {
 
-bool validate_elf_header(ElfW(Ehdr) const& elf_header, size_t file_size, bool verbose = true);
-ErrorOr<bool> validate_program_headers(ElfW(Ehdr) const& elf_header, size_t file_size, ReadonlyBytes buffer, StringBuilder* interpreter_path_builder = nullptr, Optional<size_t>* requested_stack_size = nullptr, bool verbose = true);
+bool validate_elf_header(Elf_Ehdr const& elf_header, size_t file_size, bool verbose = true);
+ErrorOr<bool> validate_program_headers(Elf_Ehdr const& elf_header, size_t file_size, ReadonlyBytes buffer, StringBuilder* interpreter_path_builder = nullptr, Optional<size_t>* requested_stack_size = nullptr, bool verbose = true);
 
 } // end namespace ELF

--- a/Userland/Utilities/file.cpp
+++ b/Userland/Utilities/file.cpp
@@ -129,12 +129,12 @@ static ErrorOr<Optional<String>> elf_details(StringView description, StringView 
         return OptionalNone {};
 
     StringBuilder interpreter_path_builder;
-    auto result_or_error = ELF::validate_program_headers(*(const ElfW(Ehdr)*)elf_data.data(), elf_data.size(), elf_data, &interpreter_path_builder);
+    auto result_or_error = ELF::validate_program_headers(*(Elf_Ehdr const*)elf_data.data(), elf_data.size(), elf_data, &interpreter_path_builder);
     if (result_or_error.is_error() || !result_or_error.value())
         return OptionalNone {};
     auto interpreter_path = interpreter_path_builder.string_view();
 
-    auto& header = *reinterpret_cast<const ElfW(Ehdr)*>(elf_data.data());
+    auto& header = *reinterpret_cast<Elf_Ehdr const*>(elf_data.data());
 
     auto bitness = header.e_ident[EI_CLASS] == ELFCLASS64 ? "64" : "32";
     auto byteorder = header.e_ident[EI_DATA] == ELFDATA2LSB ? "LSB" : "MSB";

--- a/Userland/Utilities/ldd.cpp
+++ b/Userland/Utilities/ldd.cpp
@@ -110,7 +110,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     }
 
     StringBuilder interpreter_path_builder;
-    auto result_or_error = ELF::validate_program_headers(*(const ElfW(Ehdr)*)elf_image_data.data(), elf_image_data.size(), elf_image_data, &interpreter_path_builder);
+    auto result_or_error = ELF::validate_program_headers(*(Elf_Ehdr const*)elf_image_data.data(), elf_image_data.size(), elf_image_data, &interpreter_path_builder);
     if (result_or_error.is_error() || !result_or_error.value()) {
         warnln("Invalid ELF headers");
         return -1;

--- a/Userland/Utilities/readelf.cpp
+++ b/Userland/Utilities/readelf.cpp
@@ -22,7 +22,7 @@
 #include <stdio.h>
 #include <unistd.h>
 
-static char const* object_program_header_type_to_string(ElfW(Word) type)
+static char const* object_program_header_type_to_string(Elf_Word type)
 {
     switch (type) {
     case PT_NULL:
@@ -66,7 +66,7 @@ static char const* object_program_header_type_to_string(ElfW(Word) type)
     }
 }
 
-static char const* object_section_header_type_to_string(ElfW(Word) type)
+static char const* object_section_header_type_to_string(Elf_Word type)
 {
     switch (type) {
     case SHT_NULL:
@@ -138,7 +138,7 @@ static char const* object_section_header_type_to_string(ElfW(Word) type)
     }
 }
 
-static char const* object_symbol_type_to_string(ElfW(Word) type)
+static char const* object_symbol_type_to_string(Elf_Word type)
 {
     switch (type) {
     case STT_NOTYPE:
@@ -164,7 +164,7 @@ static char const* object_symbol_type_to_string(ElfW(Word) type)
     }
 }
 
-static char const* object_symbol_binding_to_string(ElfW(Word) type)
+static char const* object_symbol_binding_to_string(Elf_Word type)
 {
     switch (type) {
     case STB_LOCAL:
@@ -184,7 +184,7 @@ static char const* object_symbol_binding_to_string(ElfW(Word) type)
     }
 }
 
-static char const* object_relocation_type_to_string(ElfW(Half) machine, ElfW(Word) type)
+static char const* object_relocation_type_to_string(Elf_Half machine, Elf_Word type)
 {
 #define ENUMERATE_RELOCATION(name) \
     case name:                     \
@@ -280,14 +280,14 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     }
 
     StringBuilder interpreter_path_builder;
-    auto result_or_error = ELF::validate_program_headers(*(const ElfW(Ehdr)*)elf_image_data.data(), elf_image_data.size(), elf_image_data, &interpreter_path_builder);
+    auto result_or_error = ELF::validate_program_headers(*(Elf_Ehdr const*)elf_image_data.data(), elf_image_data.size(), elf_image_data, &interpreter_path_builder);
     if (result_or_error.is_error() || !result_or_error.value()) {
         warnln("Invalid ELF headers");
         return -1;
     }
     auto interpreter_path = interpreter_path_builder.string_view();
 
-    auto& header = *reinterpret_cast<const ElfW(Ehdr)*>(elf_image_data.data());
+    auto& header = *reinterpret_cast<Elf_Ehdr const*>(elf_image_data.data());
 
     RefPtr<ELF::DynamicObject> object = nullptr;
 


### PR DESCRIPTION
This works around a `clang-format-17` bug which caused certain usages to
be misformatted and fail to compile.

Fixes https://github.com/SerenityOS/serenity/issues/8315