### PR TITLE
LibWeb: Delay calculating glyph positions until painting commands run

### DIFF
--- a/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorCPU.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorCPU.cpp
@@ -24,18 +24,9 @@ PaintingCommandExecutorCPU::PaintingCommandExecutorCPU(Gfx::Bitmap& bitmap)
         .scaling_mode = {} });
 }
 
-CommandResult PaintingCommandExecutorCPU::draw_glyph_run(Vector<Gfx::DrawGlyphOrEmoji> const& glyph_run, Color const& color)
+CommandResult PaintingCommandExecutorCPU::draw_glyph_run(Gfx::FloatPoint baseline_start, String text, Gfx::Font const& font, Color const& color)
 {
-    auto& painter = this->painter();
-    for (auto& glyph_or_emoji : glyph_run) {
-        if (glyph_or_emoji.has<Gfx::DrawGlyph>()) {
-            auto& glyph = glyph_or_emoji.get<Gfx::DrawGlyph>();
-            painter.draw_glyph(glyph.position, glyph.code_point, *glyph.font, color);
-        } else {
-            auto& emoji = glyph_or_emoji.get<Gfx::DrawEmoji>();
-            painter.draw_emoji(emoji.position, *emoji.emoji, *emoji.font);
-        }
-    }
+    painter().draw_text_run(baseline_start, Utf8View(text), font, color);
     return CommandResult::Continue;
 }
 

--- a/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorCPU.h
+++ b/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorCPU.h
@@ -13,7 +13,7 @@ namespace Web::Painting {
 
 class PaintingCommandExecutorCPU : public PaintingCommandExecutor {
 public:
-    CommandResult draw_glyph_run(Vector<Gfx::DrawGlyphOrEmoji> const& glyph_run, Color const&) override;
+    CommandResult draw_glyph_run(Gfx::FloatPoint, String, Gfx::Font const&, Color const&) override;
     CommandResult draw_text(Gfx::IntRect const& rect, String const& raw_text, Gfx::TextAlignment alignment, Color const&, Gfx::TextElision, Gfx::TextWrapping, Optional<NonnullRefPtr<Gfx::Font>> const&) override;
     CommandResult fill_rect(Gfx::IntRect const& rect, Color const&) override;
     CommandResult draw_scaled_bitmap(Gfx::IntRect const& dst_rect, Gfx::Bitmap const& bitmap, Gfx::IntRect const& src_rect, Gfx::Painter::ScalingMode scaling_mode) override;

--- a/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorGPU.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorGPU.cpp
@@ -27,8 +27,9 @@ PaintingCommandExecutorGPU::~PaintingCommandExecutorGPU()
     painter().flush(m_target_bitmap);
 }
 
-CommandResult PaintingCommandExecutorGPU::draw_glyph_run(Vector<Gfx::DrawGlyphOrEmoji> const& glyph_run, Color const& color)
+CommandResult PaintingCommandExecutorGPU::draw_glyph_run(Gfx::FloatPoint baseline_start, String text, Gfx::Font const& font, Color const& color)
 {
+    auto glyph_run = Gfx::get_glyph_run(baseline_start, Utf8View(text), font);
     painter().draw_glyph_run(glyph_run, color);
     return CommandResult::Continue;
 }

--- a/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorGPU.h
+++ b/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorGPU.h
@@ -14,7 +14,7 @@ namespace Web::Painting {
 
 class PaintingCommandExecutorGPU : public PaintingCommandExecutor {
 public:
-    CommandResult draw_glyph_run(Vector<Gfx::DrawGlyphOrEmoji> const& glyph_run, Color const&) override;
+    CommandResult draw_glyph_run(Gfx::FloatPoint, String, Gfx::Font const&, Color const&) override;
     CommandResult draw_text(Gfx::IntRect const& rect, String const& raw_text, Gfx::TextAlignment alignment, Color const&, Gfx::TextElision, Gfx::TextWrapping, Optional<NonnullRefPtr<Gfx::Font>> const&) override;
     CommandResult fill_rect(Gfx::IntRect const& rect, Color const&) override;
     CommandResult draw_scaled_bitmap(Gfx::IntRect const& dst_rect, Gfx::Bitmap const& bitmap, Gfx::IntRect const& src_rect, Gfx::Painter::ScalingMode scaling_mode) override;

--- a/Userland/Libraries/LibWeb/Painting/RecordingPainter.h
+++ b/Userland/Libraries/LibWeb/Painting/RecordingPainter.h
@@ -42,7 +42,9 @@ enum class CommandResult {
 };
 
 struct DrawGlyphRun {
-    Vector<Gfx::DrawGlyphOrEmoji> glyph_run;
+    Gfx::FloatPoint baseline_start;
+    String text;
+    NonnullRefPtr<Gfx::Font> font;
     Color color;
     Gfx::IntRect rect;
 
@@ -358,7 +360,7 @@ class PaintingCommandExecutor {
 public:
     virtual ~PaintingCommandExecutor() = default;
 
-    virtual CommandResult draw_glyph_run(Vector<Gfx::DrawGlyphOrEmoji> const& glyph_run, Color const&) = 0;
+    virtual CommandResult draw_glyph_run(Gfx::FloatPoint, String, Gfx::Font const&, Color const&) = 0;
     virtual CommandResult draw_text(Gfx::IntRect const&, String const&, Gfx::TextAlignment alignment, Color const&, Gfx::TextElision, Gfx::TextWrapping, Optional<NonnullRefPtr<Gfx::Font>> const&) = 0;
     virtual CommandResult fill_rect(Gfx::IntRect const&, Color const&) = 0;
     virtual CommandResult draw_scaled_bitmap(Gfx::IntRect const& dst_rect, Gfx::Bitmap const& bitmap, Gfx::IntRect const& src_rect, Gfx::Painter::ScalingMode scaling_mode) = 0;


### PR DESCRIPTION
With this change, we avoid measuring glyph widths and kernings until painting commands are executed, making painting visibly faster on large documents where most of the text is usually not visible in the viewport