### PR TITLE
LibWeb: Port CSSNamespaceRule to FlyString

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/CSSNamespaceRule.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSNamespaceRule.cpp
@@ -16,16 +16,16 @@ namespace Web::CSS {
 
 JS_DEFINE_ALLOCATOR(CSSNamespaceRule);
 
-CSSNamespaceRule::CSSNamespaceRule(JS::Realm& realm, Optional<DeprecatedString> prefix, StringView namespace_uri)
+CSSNamespaceRule::CSSNamespaceRule(JS::Realm& realm, Optional<FlyString> prefix, FlyString namespace_uri)
     : CSSRule(realm)
-    , m_namespace_uri(namespace_uri)
-    , m_prefix(prefix.value_or(""sv))
+    , m_namespace_uri(move(namespace_uri))
+    , m_prefix(prefix.value_or(""_fly_string))
 {
 }
 
-JS::NonnullGCPtr<CSSNamespaceRule> CSSNamespaceRule::create(JS::Realm& realm, Optional<DeprecatedString> prefix, AK::StringView namespace_uri)
+JS::NonnullGCPtr<CSSNamespaceRule> CSSNamespaceRule::create(JS::Realm& realm, Optional<FlyString> prefix, FlyString namespace_uri)
 {
-    return realm.heap().allocate<CSSNamespaceRule>(realm, realm, prefix, namespace_uri);
+    return realm.heap().allocate<CSSNamespaceRule>(realm, realm, move(prefix), move(namespace_uri));
 }
 
 void CSSNamespaceRule::initialize(JS::Realm& realm)

--- a/Userland/Libraries/LibWeb/CSS/CSSNamespaceRule.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSNamespaceRule.h
@@ -15,24 +15,24 @@ class CSSNamespaceRule final : public CSSRule {
     JS_DECLARE_ALLOCATOR(CSSNamespaceRule);
 
 public:
-    [[nodiscard]] static JS::NonnullGCPtr<CSSNamespaceRule> create(JS::Realm&, Optional<DeprecatedString> prefix, StringView namespace_uri);
+    [[nodiscard]] static JS::NonnullGCPtr<CSSNamespaceRule> create(JS::Realm&, Optional<FlyString> prefix, FlyString namespace_uri);
 
     virtual ~CSSNamespaceRule() = default;
 
-    void set_namespace_uri(DeprecatedString value) { m_namespace_uri = move(value); }
-    DeprecatedString namespace_uri() const { return m_namespace_uri; }
-    void set_prefix(DeprecatedString value) { m_prefix = move(value); }
-    DeprecatedString prefix() const { return m_prefix; }
+    void set_namespace_uri(FlyString value) { m_namespace_uri = move(value); }
+    FlyString const& namespace_uri() const { return m_namespace_uri; }
+    void set_prefix(FlyString value) { m_prefix = move(value); }
+    FlyString const& prefix() const { return m_prefix; }
     virtual Type type() const override { return Type::Namespace; }
 
 private:
-    CSSNamespaceRule(JS::Realm&, Optional<DeprecatedString> prefix, StringView namespace_uri);
+    CSSNamespaceRule(JS::Realm&, Optional<FlyString> prefix, FlyString namespace_uri);
 
     virtual void initialize(JS::Realm&) override;
 
     virtual String serialized() const override;
-    DeprecatedString m_namespace_uri;
-    DeprecatedString m_prefix;
+    FlyString m_namespace_uri;
+    FlyString m_prefix;
 };
 
 }

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
@@ -149,7 +149,7 @@ void CSSStyleSheet::set_style_sheet_list(Badge<StyleSheetList>, StyleSheetList* 
 Optional<FlyString> CSSStyleSheet::default_namespace() const
 {
     if (m_default_namespace_rule)
-        return MUST(FlyString::from_deprecated_fly_string(m_default_namespace_rule->namespace_uri()));
+        return m_default_namespace_rule->namespace_uri();
 
     return {};
 }
@@ -158,7 +158,7 @@ Optional<FlyString> CSSStyleSheet::namespace_uri(StringView namespace_prefix) co
 {
     return m_namespace_rules.get(namespace_prefix)
         .map([](JS::GCPtr<CSSNamespaceRule> namespace_) {
-            return MUST(FlyString::from_deprecated_fly_string(namespace_->namespace_uri()));
+            return namespace_->namespace_uri();
         });
 }
 
@@ -189,7 +189,7 @@ void CSSStyleSheet::recalculate_namespaces()
         if (!namespace_rule.namespace_uri().is_empty() && namespace_rule.prefix().is_empty())
             m_default_namespace_rule = namespace_rule;
 
-        m_namespace_rules.set(FlyString::from_deprecated_fly_string(namespace_rule.prefix()).release_value_but_fixme_should_propagate_errors(), namespace_rule);
+        m_namespace_rules.set(namespace_rule.prefix(), namespace_rule);
     }
 }
 

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -1358,18 +1358,18 @@ CSSRule* Parser::convert_to_rule(NonnullRefPtr<Rule> rule)
             token_stream.skip_whitespace();
 
             auto token = token_stream.next_token();
-            Optional<DeprecatedString> prefix = {};
+            Optional<FlyString> prefix = {};
             if (token.is(Token::Type::Ident)) {
-                prefix = token.token().ident().bytes_as_string_view();
+                prefix = token.token().ident();
                 token_stream.skip_whitespace();
                 token = token_stream.next_token();
             }
 
-            DeprecatedString namespace_uri;
+            FlyString namespace_uri;
             if (token.is(Token::Type::String)) {
-                namespace_uri = token.token().string();
+                namespace_uri = MUST(FlyString::from_utf8(token.token().string()));
             } else if (auto url = parse_url_function(token); url.has_value()) {
-                namespace_uri = url.value().to_deprecated_string();
+                namespace_uri = MUST(FlyString::from_deprecated_fly_string(url.value().to_deprecated_string()));
             } else {
                 dbgln_if(CSS_PARSER_DEBUG, "CSSParser: @namespace rule invalid; discarding.");
                 return {};


### PR DESCRIPTION
This removes a performance problem where we'd convert the style sheet's default namespace from DeprecatedFlyString to FlyString once per rule during selector matching.

The conversion now happens once, during CSS parse. It should eventually be removed from there as well, but one step at a time. :^)