### PR TITLE
CI: Disable running aarch64 tests in CI for now

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -237,7 +237,7 @@ jobs:
         run: ninja install && ninja qemu-image
 
       - name: Run On-Target Tests
-        if: ${{ matrix.debug-options == 'NORMAL_DEBUG' }}
+        if: ${{ matrix.debug-options == 'NORMAL_DEBUG' && matrix.arch != 'aarch64' }}
         working-directory: ${{ github.workspace }}/Build/${{ matrix.arch }}
         env:
           SERENITY_QEMU_CPU: "max,vmx=off"


### PR DESCRIPTION
These tests almost always fail, and all we do is try to boot. Disable it for now until it can pass more reliably. Note we still compile aarch64, so the build shouldn't break unnoticed.