### PR TITLE
LibWeb: De-deprecate some CSS Strings

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/CSSFontFaceRule.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSFontFaceRule.cpp
@@ -63,7 +63,7 @@ String CSSFontFaceRule::serialized() const
         // 2. The result of invoking serialize a comma-separated list on performing serialize a URL or serialize a LOCAL for each source on the source list.
         serialize_a_comma_separated_list(builder, m_font_face.sources(), [&](StringBuilder& builder, FontFace::Source source) -> void {
             if (source.local_or_url.has<AK::URL>()) {
-                serialize_a_url(builder, source.local_or_url.get<AK::URL>().to_deprecated_string());
+                serialize_a_url(builder, MUST(source.local_or_url.get<AK::URL>().to_string()));
             } else {
                 builder.appendff("local({})", source.local_or_url.get<String>());
             }

--- a/Userland/Libraries/LibWeb/CSS/CSSImportRule.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSImportRule.cpp
@@ -65,10 +65,7 @@ String CSSImportRule::serialized() const
     builder.append("@import "sv);
 
     // 2. The result of performing serialize a URL on the rule’s location.
-    // FIXME: Look into the correctness of this serialization
-    builder.append("url("sv);
-    builder.append(m_url.to_deprecated_string());
-    builder.append(')');
+    serialize_a_url(builder, MUST(m_url.to_string()));
 
     // FIXME: 3. If the rule’s associated media list is not empty, a single SPACE (U+0020) followed by the result of performing serialize a media query list on the media list.
 

--- a/Userland/Libraries/LibWeb/CSS/CSSImportRule.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSImportRule.h
@@ -29,7 +29,7 @@ public:
 
     AK::URL const& url() const { return m_url; }
     // FIXME: This should return only the specified part of the url. eg, "stuff/foo.css", not "https://example.com/stuff/foo.css".
-    DeprecatedString href() const { return m_url.to_deprecated_string(); }
+    String href() const { return MUST(m_url.to_string()); }
 
     CSSStyleSheet* loaded_style_sheet() { return m_style_sheet; }
     CSSStyleSheet const* loaded_style_sheet() const { return m_style_sheet; }

--- a/Userland/Libraries/LibWeb/CSS/CSSMediaRule.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSMediaRule.cpp
@@ -39,7 +39,7 @@ void CSSMediaRule::visit_edges(Cell::Visitor& visitor)
 
 String CSSMediaRule::condition_text() const
 {
-    return String::from_deprecated_string(m_media->media_text().to_deprecated_string()).release_value();
+    return m_media->media_text();
 }
 
 void CSSMediaRule::set_condition_text(String const& text)

--- a/Userland/Libraries/LibWeb/CSS/CSSRule.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSRule.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <AK/DeprecatedString.h>
+#include <AK/String.h>
 #include <LibJS/Heap/GCPtr.h>
 #include <LibWeb/Bindings/PlatformObject.h>
 #include <LibWeb/CSS/CSSStyleDeclaration.h>

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleDeclaration.cpp
@@ -317,7 +317,7 @@ String PropertyOwningCSSStyleDeclaration::serialized() const
         // NOTE: There are no shorthands for custom properties.
 
         // 5. Let value be the result of invoking serialize a CSS value of declaration.
-        auto value = declaration.value.value->to_string().to_deprecated_string();
+        auto value = declaration.value.value->to_string();
 
         // 6. Let serialized declaration be the result of invoking serialize a CSS declaration with property name property, value value,
         //    and the important flag set if declaration has its important flag set.
@@ -419,7 +419,7 @@ JS::ThrowCompletionOr<JS::Value> CSSStyleDeclaration::internal_get(JS::PropertyK
     if (property_id == CSS::PropertyID::Invalid)
         return Base::internal_get(name, receiver, cacheable_metadata);
     if (auto maybe_property = property(property_id); maybe_property.has_value())
-        return { JS::PrimitiveString::create(vm(), maybe_property->value->to_string().to_deprecated_string()) };
+        return { JS::PrimitiveString::create(vm(), maybe_property->value->to_string()) };
     return { JS::PrimitiveString::create(vm(), String {}) };
 }
 
@@ -432,7 +432,7 @@ JS::ThrowCompletionOr<bool> CSSStyleDeclaration::internal_set(JS::PropertyKey co
     if (property_id == CSS::PropertyID::Invalid)
         return Base::internal_set(name, value, receiver, cacheable_metadata);
 
-    auto css_text = TRY(value.to_deprecated_string(vm));
+    auto css_text = TRY(value.to_string(vm));
 
     TRY(Bindings::throw_dom_exception_if_needed(vm, [&] { return set_property(property_id, css_text); }));
     return true;

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleRule.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleRule.cpp
@@ -89,10 +89,10 @@ String CSSStyleRule::serialized() const
 }
 
 // https://www.w3.org/TR/cssom/#dom-cssstylerule-selectortext
-DeprecatedString CSSStyleRule::selector_text() const
+String CSSStyleRule::selector_text() const
 {
     // The selectorText attribute, on getting, must return the result of serializing the associated group of selectors.
-    return serialize_a_group_of_selectors(selectors()).to_deprecated_string();
+    return serialize_a_group_of_selectors(selectors());
 }
 
 // https://www.w3.org/TR/cssom/#dom-cssstylerule-selectortext

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleRule.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleRule.h
@@ -28,7 +28,7 @@ public:
 
     virtual Type type() const override { return Type::Style; }
 
-    DeprecatedString selector_text() const;
+    String selector_text() const;
     void set_selector_text(StringView);
 
     CSSStyleDeclaration* style();

--- a/Userland/Libraries/LibWeb/CSS/MediaList.cpp
+++ b/Userland/Libraries/LibWeb/CSS/MediaList.cpp
@@ -119,7 +119,7 @@ WebIDL::ExceptionOr<JS::Value> MediaList::item_value(size_t index) const
 {
     if (index >= m_media.size())
         return JS::js_undefined();
-    return JS::PrimitiveString::create(vm(), m_media[index]->to_string().to_deprecated_string());
+    return JS::PrimitiveString::create(vm(), m_media[index]->to_string());
 }
 
 }

--- a/Userland/Libraries/LibWeb/CSS/MediaQueryList.cpp
+++ b/Userland/Libraries/LibWeb/CSS/MediaQueryList.cpp
@@ -43,9 +43,9 @@ void MediaQueryList::visit_edges(Cell::Visitor& visitor)
 }
 
 // https://drafts.csswg.org/cssom-view/#dom-mediaquerylist-media
-DeprecatedString MediaQueryList::media() const
+String MediaQueryList::media() const
 {
-    return serialize_a_media_query_list(m_media).to_deprecated_string();
+    return serialize_a_media_query_list(m_media);
 }
 
 // https://drafts.csswg.org/cssom-view/#dom-mediaquerylist-matches

--- a/Userland/Libraries/LibWeb/CSS/MediaQueryList.h
+++ b/Userland/Libraries/LibWeb/CSS/MediaQueryList.h
@@ -22,7 +22,7 @@ public:
 
     virtual ~MediaQueryList() override = default;
 
-    DeprecatedString media() const;
+    String media() const;
     bool matches() const;
     bool evaluate();
 

--- a/Userland/Libraries/LibWeb/CSS/Serialize.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Serialize.cpp
@@ -113,7 +113,7 @@ void serialize_a_url(StringBuilder& builder, StringView url)
     // To serialize a URL means to create a string represented by "url(",
     // followed by the serialization of the URL as a string, followed by ")".
     builder.append("url("sv);
-    serialize_a_string(builder, url.to_deprecated_string());
+    serialize_a_string(builder, url);
     builder.append(')');
 }
 
@@ -123,7 +123,7 @@ void serialize_a_local(StringBuilder& builder, StringView path)
     // To serialize a LOCAL means to create a string represented by "local(",
     // followed by the serialization of the LOCAL as a string, followed by ")".
     builder.append("local("sv);
-    serialize_a_string(builder, path.to_deprecated_string());
+    serialize_a_string(builder, path);
     builder.append(')');
 }
 

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -2374,7 +2374,7 @@ void StyleComputer::load_fonts_from_sheet(CSSStyleSheet const& sheet)
         for (auto& source : font_face.sources()) {
             // FIXME: These should be loaded relative to the stylesheet URL instead of the document URL.
             if (source.local_or_url.has<AK::URL>())
-                urls.append(m_document->parse_url(source.local_or_url.get<AK::URL>().to_deprecated_string()));
+                urls.append(m_document->parse_url(MUST(source.local_or_url.get<AK::URL>().to_string())));
             // FIXME: Handle local()
         }
 

--- a/Userland/Libraries/LibWeb/CSS/StyleSheet.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleSheet.h
@@ -39,7 +39,7 @@ public:
         return m_media;
     }
 
-    void set_media(DeprecatedString media)
+    void set_media(String media)
     {
         m_media->set_media_text(media);
     }

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.cpp
@@ -100,7 +100,7 @@ Gfx::ImmutableBitmap const* ImageStyleValue::bitmap(size_t frame_index, Gfx::Int
 
 String ImageStyleValue::to_string() const
 {
-    return serialize_a_url(m_url.to_deprecated_string());
+    return serialize_a_url(MUST(m_url.to_string()));
 }
 
 bool ImageStyleValue::equals(StyleValue const& other) const

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/ShadowStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/ShadowStyleValue.cpp
@@ -14,7 +14,7 @@ namespace Web::CSS {
 String ShadowStyleValue::to_string() const
 {
     StringBuilder builder;
-    builder.appendff("{} {} {} {} {}", m_properties.color.to_deprecated_string(), m_properties.offset_x->to_string(), m_properties.offset_y->to_string(), m_properties.blur_radius->to_string(), m_properties.spread_distance->to_string());
+    builder.appendff("{} {} {} {} {}", m_properties.color.to_string(), m_properties.offset_x->to_string(), m_properties.offset_y->to_string(), m_properties.blur_radius->to_string(), m_properties.spread_distance->to_string());
     if (m_properties.placement == ShadowPlacement::Inner)
         builder.append(" inset"sv);
     return MUST(builder.to_string());

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/URLStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/URLStyleValue.h
@@ -27,7 +27,7 @@ public:
 
     virtual String to_string() const override
     {
-        return serialize_a_url(m_url.to_deprecated_string());
+        return serialize_a_url(MUST(m_url.to_string()));
     }
 
 private:

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -2181,7 +2181,7 @@ void Document::evaluate_media_queries_and_report_changes()
 
         if (did_match != now_matches) {
             CSS::MediaQueryListEventInit init;
-            init.media = String::from_deprecated_string(media_query_list->media()).release_value_but_fixme_should_propagate_errors();
+            init.media = media_query_list->media();
             init.matches = now_matches;
             auto event = CSS::MediaQueryListEvent::create(realm(), HTML::EventNames::change, init);
             event->set_is_trusted(true);

--- a/Userland/Libraries/LibWeb/DOM/StyleElementUtils.cpp
+++ b/Userland/Libraries/LibWeb/DOM/StyleElementUtils.cpp
@@ -95,7 +95,7 @@ void StyleElementUtils::create_a_css_style_sheet(DOM::Document& document, Deprec
     sheet.set_owner_css_rule(owner_rule);
     sheet.set_owner_node(owner_node);
     sheet.set_type(MUST(String::from_deprecated_string(type)));
-    sheet.set_media(move(media));
+    sheet.set_media(MUST(String::from_deprecated_string(media)));
     sheet.set_title(MUST(String::from_deprecated_string(title)));
     sheet.set_alternate(alternate);
     sheet.set_origin_clean(origin_clean);

--- a/Userland/Libraries/LibWeb/DOM/StyleElementUtils.cpp
+++ b/Userland/Libraries/LibWeb/DOM/StyleElementUtils.cpp
@@ -61,10 +61,12 @@ void StyleElementUtils::update_a_style_block(DOM::Element& style_element)
     // 6. Create a CSS style sheet with the following properties...
     create_a_css_style_sheet(
         style_element.document(),
-        "text/css"sv,
+        "text/css"_string,
         &style_element,
-        style_element.deprecated_attribute(HTML::AttributeNames::media),
-        style_element.in_a_document_tree() ? style_element.deprecated_attribute(HTML::AttributeNames::title) : DeprecatedString::empty(),
+        style_element.attribute(HTML::AttributeNames::media).value_or({}),
+        style_element.in_a_document_tree()
+            ? style_element.attribute(HTML::AttributeNames::title).value_or({})
+            : String {},
         false,
         true,
         {},
@@ -86,7 +88,7 @@ void StyleElementUtils::remove_a_css_style_sheet(DOM::Document& document, CSS::C
 }
 
 // https://www.w3.org/TR/cssom/#create-a-css-style-sheet
-void StyleElementUtils::create_a_css_style_sheet(DOM::Document& document, DeprecatedString type, DOM::Element* owner_node, DeprecatedString media, DeprecatedString title, bool alternate, bool origin_clean, Optional<DeprecatedString> location, CSS::CSSStyleSheet* parent_style_sheet, CSS::CSSRule* owner_rule, CSS::CSSStyleSheet& sheet)
+void StyleElementUtils::create_a_css_style_sheet(DOM::Document& document, String type, DOM::Element* owner_node, String media, String title, bool alternate, bool origin_clean, Optional<String> location, CSS::CSSStyleSheet* parent_style_sheet, CSS::CSSRule* owner_rule, CSS::CSSStyleSheet& sheet)
 {
     // 1. Create a new CSS style sheet object and set its properties as specified.
     // FIXME: We receive `sheet` from the caller already. This is weird.
@@ -94,15 +96,12 @@ void StyleElementUtils::create_a_css_style_sheet(DOM::Document& document, Deprec
     sheet.set_parent_css_style_sheet(parent_style_sheet);
     sheet.set_owner_css_rule(owner_rule);
     sheet.set_owner_node(owner_node);
-    sheet.set_type(MUST(String::from_deprecated_string(type)));
-    sheet.set_media(MUST(String::from_deprecated_string(media)));
-    sheet.set_title(MUST(String::from_deprecated_string(title)));
+    sheet.set_type(move(type));
+    sheet.set_media(move(media));
+    sheet.set_title(move(title));
     sheet.set_alternate(alternate);
     sheet.set_origin_clean(origin_clean);
-    if (!location.has_value())
-        sheet.set_location({});
-    else
-        sheet.set_location(MUST(String::from_deprecated_string(*location)));
+    sheet.set_location(move(location));
 
     // 2. Then run the add a CSS style sheet steps for the newly created CSS style sheet.
     add_a_css_style_sheet(document, sheet);

--- a/Userland/Libraries/LibWeb/DOM/StyleElementUtils.h
+++ b/Userland/Libraries/LibWeb/DOM/StyleElementUtils.h
@@ -20,7 +20,7 @@ public:
 
 private:
     void remove_a_css_style_sheet(DOM::Document& document, CSS::CSSStyleSheet& sheet);
-    void create_a_css_style_sheet(DOM::Document& document, DeprecatedString type, DOM::Element* owner_node, DeprecatedString media, DeprecatedString title, bool alternate, bool origin_clean, Optional<DeprecatedString> location, CSS::CSSStyleSheet* parent_style_sheet, CSS::CSSRule* owner_rule, CSS::CSSStyleSheet& sheet);
+    void create_a_css_style_sheet(DOM::Document& document, String type, DOM::Element* owner_node, String media, String title, bool alternate, bool origin_clean, Optional<String> location, CSS::CSSStyleSheet* parent_style_sheet, CSS::CSSRule* owner_rule, CSS::CSSStyleSheet& sheet);
     void add_a_css_style_sheet(DOM::Document& document, CSS::CSSStyleSheet& sheet);
 
     // https://www.w3.org/TR/cssom/#associated-css-style-sheet

--- a/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
@@ -369,7 +369,7 @@ void HTMLLinkElement::process_stylesheet_resource(bool success, Fetch::Infrastru
 
                 if (m_loaded_style_sheet) {
                     m_loaded_style_sheet->set_owner_node(this);
-                    m_loaded_style_sheet->set_media(deprecated_attribute(HTML::AttributeNames::media));
+                    m_loaded_style_sheet->set_media(attribute(HTML::AttributeNames::media).value_or({}));
                     document().style_sheets().add_sheet(*m_loaded_style_sheet);
                 } else {
                     dbgln_if(CSS_LOADER_DEBUG, "HTMLLinkElement: Failed to parse stylesheet: {}", resource()->url());


### PR DESCRIPTION
Assuming CLion isn't lying to me, this is all the uses of `Deprecated[Fly]String` in the LibWeb/CSS dir except for the Parser. (And also in `create_a_css_style_sheet()`, which maybe should be in the CSS dir too but that's a side issue.) No functional changes, just less deprecation.

It did mean I came across this, which made me chuckle:
```c++
return String::from_deprecated_string(m_media->media_text().to_deprecated_string()).release_value();
```