### PR TITLE
Kernel: Make RAMFS pass along the inode type when traversing as a dir

### DIFF
--- a/Kernel/FileSystem/RAMFS/FileSystem.cpp
+++ b/Kernel/FileSystem/RAMFS/FileSystem.cpp
@@ -37,4 +37,27 @@ unsigned RAMFS::next_inode_index()
     return m_next_inode_index++;
 }
 
+u8 RAMFS::internal_file_type_to_directory_entry_type(DirectoryEntryView const& entry) const
+{
+    switch (static_cast<FileType>(entry.file_type)) {
+    case FileType::Directory:
+        return DT_DIR;
+    case FileType::Character:
+        return DT_CHR;
+    case FileType::Block:
+        return DT_BLK;
+    case FileType::Regular:
+        return DT_REG;
+    case FileType::FIFO:
+        return DT_FIFO;
+    case FileType::Link:
+        return DT_LNK;
+    case FileType::Socket:
+        return DT_SOCK;
+    case FileType::Unknown:
+    default:
+        return DT_UNKNOWN;
+    }
+}
+
 }

--- a/Kernel/FileSystem/RAMFS/FileSystem.h
+++ b/Kernel/FileSystem/RAMFS/FileSystem.h
@@ -27,6 +27,19 @@ public:
 
     virtual Inode& root_inode() override;
 
+    virtual u8 internal_file_type_to_directory_entry_type(DirectoryEntryView const& entry) const override;
+
+    enum class FileType : u8 {
+        Directory,
+        Character,
+        Block,
+        Regular,
+        FIFO,
+        Link,
+        Socket,
+        Unknown,
+    };
+
 private:
     RAMFS();
 

--- a/Userland/Libraries/LibCore/DirectoryEntry.cpp
+++ b/Userland/Libraries/LibCore/DirectoryEntry.cpp
@@ -11,7 +11,7 @@ namespace Core {
 
 static DirectoryEntry::Type directory_entry_type_from_stat(mode_t st_mode)
 {
-    switch (st_mode) {
+    switch (st_mode & S_IFMT) {
     case S_IFIFO:
         return DirectoryEntry::Type::NamedPipe;
     case S_IFCHR:


### PR DESCRIPTION
- Fixes `echo /tmp/*/`
- Fixes a tiny boog in `Core::DirectoryEntry`