### PR TITLE
LibGfx: Actually ensure Cmap subtable offset is within expected range

### DIFF
--- a/Userland/Libraries/LibGfx/Font/OpenType/Cmap.cpp
+++ b/Userland/Libraries/LibGfx/Font/OpenType/Cmap.cpp
@@ -68,7 +68,7 @@ Optional<Cmap::Subtable> Cmap::subtable(u32 index) const
         return {};
     }
     u32 record_offset = (u32)Sizes::TableHeader + index * (u32)Sizes::EncodingRecord;
-    if (record_offset + (u32)Offsets::EncodingRecord_Offset >= m_slice.size())
+    if (record_offset + (u32)Offsets::EncodingRecord_Offset + sizeof(u32) > m_slice.size())
         return {};
     u16 platform_id = be_u16(m_slice.offset(record_offset));
     u16 encoding_id = be_u16(m_slice.offset(record_offset + (u32)Offsets::EncodingRecord_EncodingID));


### PR DESCRIPTION
Our previous check was not sufficient, since it merely checked the first byte of the EncodingRecord offset is within range, while the actual read is 4-byte wide.

Fixes ossfuzz-64165.