### PR TITLE
LibWeb: Implement ReadableStreamBYOBRequest.respond and ReadableByteStreamController.enqueue

### DIFF
--- a/Tests/LibWeb/Text/expected/Streams/ReadableByteStream-enqueue-respond.txt
+++ b/Tests/LibWeb/Text/expected/Streams/ReadableByteStream-enqueue-respond.txt
@@ -1,0 +1,14 @@
+Enqueuing array 60,61,62,63,64,65,66,67,68,69 onto [object ReadableByteStreamController]
+[object ReadableStreamBYOBRequest] view: '11,12,13,14,15,16'
+Got view of buffer: 60,61,62,63,64,65,66,67,68,69,11,12,13,14,15,16, offset 10, length 6
+[object ReadableStreamBYOBRequest] view: '12,13,14,15,16'
+Got view of buffer: 60,61,62,63,64,65,66,67,68,69,11,12,13,14,15,16, offset 11, length 5
+[object ReadableStreamBYOBRequest] view: '13,14,15,16'
+Got view of buffer: 60,61,62,63,64,65,66,67,68,69,11,12,13,14,15,16, offset 12, length 4
+[object ReadableStreamBYOBRequest] view: '14,15,16'
+Got view of buffer: 60,61,62,63,64,65,66,67,68,69,11,12,13,14,15,16, offset 13, length 3
+[object ReadableStreamBYOBRequest] view: '15,16'
+Got view of buffer: 60,61,62,63,64,65,66,67,68,69,11,12,13,14,15,16, offset 14, length 2
+[object ReadableStreamBYOBRequest] view: '16'
+Got view of buffer: 60,61,62,63,64,65,66,67,68,69,11,12,13,14,15,16, offset 15, length 1
+Final data: 60,61,62,63,64,65,66,67,68,69,11,12,13,14,15,16

--- a/Tests/LibWeb/Text/input/Streams/ReadableByteStream-enqueue-respond.html
+++ b/Tests/LibWeb/Text/input/Streams/ReadableByteStream-enqueue-respond.html
@@ -1,0 +1,43 @@
+<script src="../include.js"></script>
+<script>
+function makeReadableByteStream() {
+  return new ReadableStream({
+    type: "bytes",
+    start(controller) {
+        const array = new Uint8Array([60, 61, 62, 63, 64, 65, 66, 67, 68, 69]);
+        println(`Enqueuing array ${array} onto ${controller}`);
+        controller.enqueue(array);
+    },
+    async pull(controller) {
+      println(`${controller.byobRequest} view: '${controller.byobRequest.view}'`);
+      const v = controller.byobRequest.view;
+      println(`Got view of buffer: ${new Uint8Array(v.buffer)}, offset ${v.byteOffset}, length ${v.byteLength}`);
+      controller.byobRequest.respond(1);
+    },
+  });
+}
+
+asyncTest(async done => {
+  let readableStream = makeReadableByteStream();
+  const reader = readableStream.getReader({ mode: "byob" });
+  let startingAB = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
+  const buffer = await readInto(startingAB);
+  println(`Final data: ${new Uint8Array(buffer)}`);
+  done();
+
+  async function readInto(buffer) {
+    let offset = 0;
+    while (offset < buffer.byteLength) {
+      let u8 = new Uint8Array(buffer, offset, buffer.byteLength - offset)
+      const { value: view, done } = await reader.read(u8);
+      buffer = view.buffer;
+      if (done) {
+        break;
+      }
+      offset += view.byteLength;
+    }
+
+    return buffer;
+  }
+});
+</script>

--- a/Userland/Libraries/LibWeb/Streams/AbstractOperations.cpp
+++ b/Userland/Libraries/LibWeb/Streams/AbstractOperations.cpp
@@ -3736,6 +3736,24 @@ bool is_non_negative_number(JS::Value value)
     return true;
 }
 
+// https://streams.spec.whatwg.org/#can-transfer-array-buffer
+bool can_transfer_array_buffer(JS::ArrayBuffer const& array_buffer)
+{
+    // 1. Assert: Type(O) is Object.
+    // 2. Assert: O has an [[ArrayBufferData]] internal slot.
+
+    // 3. If ! IsDetachedBuffer(O) is true, return false.
+    if (array_buffer.is_detached())
+        return false;
+
+    // 4. If SameValue(O.[[ArrayBufferDetachKey]], undefined) is false, return false.
+    if (!JS::same_value(array_buffer.detach_key(), JS::js_undefined()))
+        return false;
+
+    // 5. Return true.
+    return true;
+}
+
 // https://streams.spec.whatwg.org/#close-sentinel
 // Non-standard function that implements the "close sentinel" value.
 JS::Value create_close_sentinel()

--- a/Userland/Libraries/LibWeb/Streams/AbstractOperations.h
+++ b/Userland/Libraries/LibWeb/Streams/AbstractOperations.h
@@ -168,6 +168,7 @@ WebIDL::ExceptionOr<void> transform_stream_error_writable_and_unblock_write(Tran
 WebIDL::ExceptionOr<void> transform_stream_set_backpressure(TransformStream&, bool backpressure);
 
 bool is_non_negative_number(JS::Value);
+bool can_transfer_array_buffer(JS::ArrayBuffer const& array_buffer);
 
 JS::Value create_close_sentinel();
 bool is_close_sentinel(JS::Value);

--- a/Userland/Libraries/LibWeb/Streams/AbstractOperations.h
+++ b/Userland/Libraries/LibWeb/Streams/AbstractOperations.h
@@ -82,6 +82,7 @@ JS::GCPtr<ReadableStreamBYOBRequest> readable_byte_stream_controller_get_byob_re
 
 WebIDL::ExceptionOr<void> readable_byte_stream_controller_respond_in_readable_state(ReadableByteStreamController&, u64 bytes_written, PullIntoDescriptor&);
 void readable_byte_stream_controller_respond_in_closed_state(ReadableByteStreamController&, PullIntoDescriptor&);
+WebIDL::ExceptionOr<void> readable_byte_stream_controller_respond_internal(ReadableByteStreamController&, u64 bytes_written);
 
 WebIDL::ExceptionOr<void> readable_stream_enqueue(ReadableStreamController& controller, JS::Value chunk);
 WebIDL::ExceptionOr<void> readable_byte_stream_controller_enqueue(ReadableByteStreamController& controller, JS::Value chunk);

--- a/Userland/Libraries/LibWeb/Streams/AbstractOperations.h
+++ b/Userland/Libraries/LibWeb/Streams/AbstractOperations.h
@@ -81,6 +81,7 @@ WebIDL::ExceptionOr<void> set_up_readable_byte_stream_controller_from_underlying
 JS::GCPtr<ReadableStreamBYOBRequest> readable_byte_stream_controller_get_byob_request(JS::NonnullGCPtr<ReadableByteStreamController>);
 
 WebIDL::ExceptionOr<void> readable_byte_stream_controller_respond_in_readable_state(ReadableByteStreamController&, u64 bytes_written, PullIntoDescriptor&);
+void readable_byte_stream_controller_respond_in_closed_state(ReadableByteStreamController&, PullIntoDescriptor&);
 
 WebIDL::ExceptionOr<void> readable_stream_enqueue(ReadableStreamController& controller, JS::Value chunk);
 WebIDL::ExceptionOr<void> readable_byte_stream_controller_enqueue(ReadableByteStreamController& controller, JS::Value chunk);

--- a/Userland/Libraries/LibWeb/Streams/AbstractOperations.h
+++ b/Userland/Libraries/LibWeb/Streams/AbstractOperations.h
@@ -80,6 +80,8 @@ WebIDL::ExceptionOr<void> set_up_readable_byte_stream_controller(ReadableStream&
 WebIDL::ExceptionOr<void> set_up_readable_byte_stream_controller_from_underlying_source(ReadableStream&, JS::Value underlying_source, UnderlyingSource const& underlying_source_dict, double high_water_mark);
 JS::GCPtr<ReadableStreamBYOBRequest> readable_byte_stream_controller_get_byob_request(JS::NonnullGCPtr<ReadableByteStreamController>);
 
+WebIDL::ExceptionOr<void> readable_byte_stream_controller_respond_in_readable_state(ReadableByteStreamController&, u64 bytes_written, PullIntoDescriptor&);
+
 WebIDL::ExceptionOr<void> readable_stream_enqueue(ReadableStreamController& controller, JS::Value chunk);
 WebIDL::ExceptionOr<void> readable_byte_stream_controller_enqueue(ReadableByteStreamController& controller, JS::Value chunk);
 WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::ArrayBuffer>> transfer_array_buffer(JS::Realm& realm, JS::ArrayBuffer& buffer);

--- a/Userland/Libraries/LibWeb/Streams/AbstractOperations.h
+++ b/Userland/Libraries/LibWeb/Streams/AbstractOperations.h
@@ -78,6 +78,7 @@ WebIDL::ExceptionOr<void> set_up_readable_stream_default_controller_from_underly
 WebIDL::ExceptionOr<void> set_up_readable_stream_controller_with_byte_reading_support(ReadableStream&, Optional<PullAlgorithm>&& = {}, Optional<CancelAlgorithm>&& = {}, double high_water_mark = 0);
 WebIDL::ExceptionOr<void> set_up_readable_byte_stream_controller(ReadableStream&, ReadableByteStreamController&, StartAlgorithm&&, PullAlgorithm&&, CancelAlgorithm&&, double high_water_mark, JS::Value auto_allocate_chunk_size);
 WebIDL::ExceptionOr<void> set_up_readable_byte_stream_controller_from_underlying_source(ReadableStream&, JS::Value underlying_source, UnderlyingSource const& underlying_source_dict, double high_water_mark);
+JS::GCPtr<ReadableStreamBYOBRequest> readable_byte_stream_controller_get_byob_request(JS::NonnullGCPtr<ReadableByteStreamController>);
 
 WebIDL::ExceptionOr<void> readable_stream_enqueue(ReadableStreamController& controller, JS::Value chunk);
 WebIDL::ExceptionOr<void> readable_byte_stream_controller_enqueue(ReadableByteStreamController& controller, JS::Value chunk);

--- a/Userland/Libraries/LibWeb/Streams/AbstractOperations.h
+++ b/Userland/Libraries/LibWeb/Streams/AbstractOperations.h
@@ -83,6 +83,7 @@ JS::GCPtr<ReadableStreamBYOBRequest> readable_byte_stream_controller_get_byob_re
 WebIDL::ExceptionOr<void> readable_byte_stream_controller_respond_in_readable_state(ReadableByteStreamController&, u64 bytes_written, PullIntoDescriptor&);
 void readable_byte_stream_controller_respond_in_closed_state(ReadableByteStreamController&, PullIntoDescriptor&);
 WebIDL::ExceptionOr<void> readable_byte_stream_controller_respond_internal(ReadableByteStreamController&, u64 bytes_written);
+WebIDL::ExceptionOr<void> readable_byte_stream_controller_respond(ReadableByteStreamController&, u64 bytes_written);
 
 WebIDL::ExceptionOr<void> readable_stream_enqueue(ReadableStreamController& controller, JS::Value chunk);
 WebIDL::ExceptionOr<void> readable_byte_stream_controller_enqueue(ReadableByteStreamController& controller, JS::Value chunk);

--- a/Userland/Libraries/LibWeb/Streams/ReadableByteStreamController.cpp
+++ b/Userland/Libraries/LibWeb/Streams/ReadableByteStreamController.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/Streams/AbstractOperations.h>
 #include <LibWeb/Streams/ReadableByteStreamController.h>
 #include <LibWeb/Streams/ReadableStream.h>
 #include <LibWeb/Streams/ReadableStreamBYOBRequest.h>
@@ -20,6 +21,13 @@ Optional<double> ReadableByteStreamController::desired_size() const
 {
     // 1. Return ! ReadableByteStreamControllerGetDesiredSize(this).
     return readable_byte_stream_controller_get_desired_size(*this);
+}
+
+// https://streams.spec.whatwg.org/#rbs-controller-byob-request
+JS::GCPtr<ReadableStreamBYOBRequest> ReadableByteStreamController::byob_request()
+{
+    // 1. Return ! ReadableByteStreamControllerGetBYOBRequest(this).
+    return readable_byte_stream_controller_get_byob_request(*this);
 }
 
 // https://streams.spec.whatwg.org/#rbs-controller-close

--- a/Userland/Libraries/LibWeb/Streams/ReadableByteStreamController.cpp
+++ b/Userland/Libraries/LibWeb/Streams/ReadableByteStreamController.cpp
@@ -1,9 +1,11 @@
 /*
  * Copyright (c) 2023, Matthew Olsson <mattco@serenityos.org>
+ * Copyright (c) 2023, Shannon Booth <shannon@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Streams/ReadableByteStreamController.h>
 #include <LibWeb/Streams/ReadableStream.h>
 #include <LibWeb/Streams/ReadableStreamBYOBRequest.h>
@@ -49,6 +51,12 @@ void ReadableByteStreamController::error(JS::Value error)
 ReadableByteStreamController::ReadableByteStreamController(JS::Realm& realm)
     : Bindings::PlatformObject(realm)
 {
+}
+
+void ReadableByteStreamController::initialize(JS::Realm& realm)
+{
+    Base::initialize(realm);
+    set_prototype(&Bindings::ensure_web_prototype<Bindings::ReadableByteStreamControllerPrototype>(realm, "ReadableByteStreamController"_fly_string));
 }
 
 // https://streams.spec.whatwg.org/#rbs-controller-private-cancel

--- a/Userland/Libraries/LibWeb/Streams/ReadableByteStreamController.h
+++ b/Userland/Libraries/LibWeb/Streams/ReadableByteStreamController.h
@@ -77,9 +77,14 @@ class ReadableByteStreamController : public Bindings::PlatformObject {
 public:
     virtual ~ReadableByteStreamController() override = default;
 
-    JS::GCPtr<ReadableStreamBYOBRequest const> byob_request() const { return m_byob_request; }
-    JS::GCPtr<ReadableStreamBYOBRequest> byob_request() { return m_byob_request; }
+    // IDL getter, returns current [[byobRequest]] (if any), and otherwise the [[byobRequest]] for the next pending pull into request
+    JS::GCPtr<ReadableStreamBYOBRequest> byob_request();
+
     void set_byob_request(JS::GCPtr<ReadableStreamBYOBRequest> request) { m_byob_request = request; }
+
+    // Raw [[byobRequest]] slot
+    JS::GCPtr<ReadableStreamBYOBRequest const> raw_byob_request() const { return m_byob_request; }
+    JS::GCPtr<ReadableStreamBYOBRequest> raw_byob_request() { return m_byob_request; }
 
     Optional<double> desired_size() const;
     WebIDL::ExceptionOr<void> close();

--- a/Userland/Libraries/LibWeb/Streams/ReadableByteStreamController.h
+++ b/Userland/Libraries/LibWeb/Streams/ReadableByteStreamController.h
@@ -130,6 +130,8 @@ private:
 
     virtual void visit_edges(Cell::Visitor&) override;
 
+    virtual void initialize(JS::Realm&) override;
+
     // https://streams.spec.whatwg.org/#readablebytestreamcontroller-autoallocatechunksize
     // A positive integer, when the automatic buffer allocation feature is enabled. In that case, this value specifies the size of buffer to allocate. It is undefined otherwise.
     Optional<u64> m_auto_allocate_chunk_size;

--- a/Userland/Libraries/LibWeb/Streams/ReadableByteStreamController.h
+++ b/Userland/Libraries/LibWeb/Streams/ReadableByteStreamController.h
@@ -89,6 +89,7 @@ public:
     Optional<double> desired_size() const;
     WebIDL::ExceptionOr<void> close();
     void error(JS::Value error);
+    WebIDL::ExceptionOr<void> enqueue(JS::Handle<WebIDL::ArrayBufferView>&);
 
     Optional<u64> const& auto_allocate_chunk_size() { return m_auto_allocate_chunk_size; }
     void set_auto_allocate_chunk_size(Optional<u64> value) { m_auto_allocate_chunk_size = value; }

--- a/Userland/Libraries/LibWeb/Streams/ReadableByteStreamController.idl
+++ b/Userland/Libraries/LibWeb/Streams/ReadableByteStreamController.idl
@@ -8,5 +8,5 @@ interface ReadableByteStreamController {
 
     undefined close();
     undefined error(optional any e);
-    // FIXME: undefined enqueue(ArrayBufferView chunk);
+    undefined enqueue(ArrayBufferView chunk);
 };

--- a/Userland/Libraries/LibWeb/Streams/ReadableStreamBYOBRequest.cpp
+++ b/Userland/Libraries/LibWeb/Streams/ReadableStreamBYOBRequest.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Streams/ReadableByteStreamController.h>
 #include <LibWeb/Streams/ReadableStreamBYOBRequest.h>
 #include <LibWeb/WebIDL/Buffers.h>
@@ -23,6 +24,12 @@ JS::GCPtr<WebIDL::ArrayBufferView> ReadableStreamBYOBRequest::view()
 ReadableStreamBYOBRequest::ReadableStreamBYOBRequest(JS::Realm& realm)
     : Bindings::PlatformObject(realm)
 {
+}
+
+void ReadableStreamBYOBRequest::initialize(JS::Realm& realm)
+{
+    Base::initialize(realm);
+    set_prototype(&Bindings::ensure_web_prototype<Bindings::ReadableStreamBYOBRequestPrototype>(realm, "ReadableStreamBYOBRequest"_fly_string));
 }
 
 void ReadableStreamBYOBRequest::visit_edges(Cell::Visitor& visitor)

--- a/Userland/Libraries/LibWeb/Streams/ReadableStreamBYOBRequest.cpp
+++ b/Userland/Libraries/LibWeb/Streams/ReadableStreamBYOBRequest.cpp
@@ -1,18 +1,20 @@
 /*
  * Copyright (c) 2023, Matthew Olsson <mattco@serenityos.org>
+ * Copyright (c) 2023, Shannon Booth <shannon@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #include <LibWeb/Streams/ReadableByteStreamController.h>
 #include <LibWeb/Streams/ReadableStreamBYOBRequest.h>
+#include <LibWeb/WebIDL/Buffers.h>
 
 namespace Web::Streams {
 
 JS_DEFINE_ALLOCATOR(ReadableStreamBYOBRequest);
 
 // https://streams.spec.whatwg.org/#rs-byob-request-view
-JS::GCPtr<JS::TypedArrayBase> ReadableStreamBYOBRequest::view()
+JS::GCPtr<WebIDL::ArrayBufferView> ReadableStreamBYOBRequest::view()
 {
     // 1. Return this.[[view]].
     return m_view;

--- a/Userland/Libraries/LibWeb/Streams/ReadableStreamBYOBRequest.cpp
+++ b/Userland/Libraries/LibWeb/Streams/ReadableStreamBYOBRequest.cpp
@@ -39,4 +39,24 @@ void ReadableStreamBYOBRequest::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_view);
 }
 
+WebIDL::ExceptionOr<void> ReadableStreamBYOBRequest::respond(u64 bytes_written)
+{
+    // 1. If this.[[controller]] is undefined, throw a TypeError exception.
+    if (!m_controller)
+        return WebIDL::SimpleException { WebIDL::SimpleExceptionType::TypeError, "Controller is undefined"_string };
+
+    // 2. If ! IsDetachedBuffer(this.[[view]].[[ArrayBuffer]]) is true, throw a TypeError exception.
+    if (m_view->viewed_array_buffer()->is_detached())
+        return WebIDL::SimpleException { WebIDL::SimpleExceptionType::TypeError, "Unable to respond to detached ArrayBuffer"_string };
+
+    // 3. Assert: this.[[view]].[[ByteLength]] > 0.
+    VERIFY(m_view->viewed_array_buffer()->byte_length() > 0);
+
+    // 4. Assert: this.[[view]].[[ViewedArrayBuffer]].[[ByteLength]] > 0.
+    VERIFY(m_view->viewed_array_buffer()->byte_length() > 0);
+
+    // 5. Perform ? ReadableByteStreamControllerRespond(this.[[controller]], bytesWritten).
+    return readable_byte_stream_controller_respond(*m_controller, bytes_written);
+}
+
 }

--- a/Userland/Libraries/LibWeb/Streams/ReadableStreamBYOBRequest.h
+++ b/Userland/Libraries/LibWeb/Streams/ReadableStreamBYOBRequest.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2023, Matthew Olsson <mattco@serenityos.org>
+ * Copyright (c) 2023, Shannon Booth <shannon@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -21,11 +22,11 @@ class ReadableStreamBYOBRequest : public Bindings::PlatformObject {
 public:
     virtual ~ReadableStreamBYOBRequest() override = default;
 
-    JS::GCPtr<JS::TypedArrayBase> view();
+    JS::GCPtr<WebIDL::ArrayBufferView> view();
 
     void set_controller(JS::GCPtr<ReadableByteStreamController> value) { m_controller = value; }
 
-    void set_view(JS::GCPtr<JS::TypedArrayBase> value) { m_view = value; }
+    void set_view(JS::GCPtr<WebIDL::ArrayBufferView> value) { m_view = value; }
 
 private:
     explicit ReadableStreamBYOBRequest(JS::Realm&);
@@ -38,7 +39,7 @@ private:
 
     // https://streams.spec.whatwg.org/#readablestreambyobrequest-view
     // A typed array representing the destination region to which the controller can write generated data, or null after the BYOB request has been invalidated.
-    JS::GCPtr<JS::TypedArrayBase> m_view;
+    JS::GCPtr<WebIDL::ArrayBufferView> m_view;
 };
 
 }

--- a/Userland/Libraries/LibWeb/Streams/ReadableStreamBYOBRequest.h
+++ b/Userland/Libraries/LibWeb/Streams/ReadableStreamBYOBRequest.h
@@ -28,6 +28,8 @@ public:
 
     void set_view(JS::GCPtr<WebIDL::ArrayBufferView> value) { m_view = value; }
 
+    WebIDL::ExceptionOr<void> respond(u64 bytes_written);
+
 private:
     explicit ReadableStreamBYOBRequest(JS::Realm&);
 

--- a/Userland/Libraries/LibWeb/Streams/ReadableStreamBYOBRequest.h
+++ b/Userland/Libraries/LibWeb/Streams/ReadableStreamBYOBRequest.h
@@ -31,6 +31,8 @@ public:
 private:
     explicit ReadableStreamBYOBRequest(JS::Realm&);
 
+    virtual void initialize(JS::Realm&) override;
+
     virtual void visit_edges(Cell::Visitor&) override;
 
     // https://streams.spec.whatwg.org/#readablestreambyobrequest-controller

--- a/Userland/Libraries/LibWeb/Streams/ReadableStreamBYOBRequest.idl
+++ b/Userland/Libraries/LibWeb/Streams/ReadableStreamBYOBRequest.idl
@@ -3,6 +3,7 @@
 interface ReadableStreamBYOBRequest {
     readonly attribute ArrayBufferView? view;
 
-    // FIXME: undefined respond([EnforceRange] unsigned long long bytesWritten);
+    // FIXME: Should be unsigned long long
+    undefined respond([EnforceRange] unsigned long bytesWritten);
     // FIXME: undefined respondWithNewView(ArrayBufferView view);
 };

--- a/Userland/Libraries/LibWeb/Streams/ReadableStreamBYOBRequest.idl
+++ b/Userland/Libraries/LibWeb/Streams/ReadableStreamBYOBRequest.idl
@@ -1,8 +1,7 @@
 // https://streams.spec.whatwg.org/#readablestreambyobrequest
 [Exposed=*]
 interface ReadableStreamBYOBRequest {
-    // FIXME: This should be an ArrayBufferView
-    readonly attribute any view;
+    readonly attribute ArrayBufferView? view;
 
     // FIXME: undefined respond([EnforceRange] unsigned long long bytesWritten);
     // FIXME: undefined respondWithNewView(ArrayBufferView view);


### PR DESCRIPTION
This continues the work towards more full / usable support for readable byte streams and BYOB readers, adding support for enqueuing data onto a readable byte stream controller, and responding to a BYOB requests.