### PR TITLE
LibGfx: Eliminate multiplication integer overflow in planar_to_chunky

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/ILBMLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/ILBMLoader.cpp
@@ -153,7 +153,7 @@ static ErrorOr<ByteBuffer> planar_to_chunky(ReadonlyBytes bitplanes, ILBMLoading
     auto chunky = TRY(ByteBuffer::create_zeroed(static_cast<size_t>(width) * height));
 
     for (u16 y = 0; y < height; y++) {
-        size_t scanline = y * width;
+        size_t scanline = static_cast<size_t>(y) * width;
         for (u8 p = 0; p < planes; p++) {
             u8 const plane_mask = 1 << p;
             size_t offset_base = (pitch * planes * y) + (p * pitch);


### PR DESCRIPTION
Multiplying two u16s will result in a i32 sized result, which will overflow to negative values for large input values.

Fixes ossfuzz-64198.