### PR TITLE
LibPDF: Eliminate reference cycle between OutlineItem parent/children

### DIFF
--- a/Userland/Libraries/LibPDF/Document.h
+++ b/Userland/Libraries/LibPDF/Document.h
@@ -36,8 +36,9 @@ struct Destination {
     Vector<Optional<float>> parameters;
 };
 
-struct OutlineItem final : public RefCounted<OutlineItem> {
-    RefPtr<OutlineItem> parent;
+struct OutlineItem final : public RefCounted<OutlineItem>
+    , public Weakable<OutlineItem> {
+    WeakPtr<OutlineItem> parent;
     Vector<NonnullRefPtr<OutlineItem>> children;
     DeprecatedString title; // Already converted to UTF-8.
     i32 count { 0 };


### PR DESCRIPTION
Since all parents held a reference pointer to their children, and all children held reference pointers to their parents, both objects would never get free'd once the document was no longer being used.

Fixes ossfuzz-63833.