### PR TITLE
LibLine: Reset `m_times_tab_pressed` in interrupt handling code

### DIFF
--- a/Userland/Libraries/LibLine/Editor.cpp
+++ b/Userland/Libraries/LibLine/Editor.cpp
@@ -620,8 +620,10 @@ ErrorOr<void> Editor::interrupted()
     {
         auto stderr_stream = TRY(Core::File::standard_error());
         TRY(reposition_cursor(*stderr_stream, true));
-        if (TRY(m_suggestion_display->cleanup()))
+        if (TRY(m_suggestion_display->cleanup())) {
+            m_times_tab_pressed = 0;
             TRY(reposition_cursor(*stderr_stream, true));
+        }
         TRY(stderr_stream->write_until_depleted("\r"sv.bytes()));
     }
     m_buffer.clear();


### PR DESCRIPTION
We forgot to reset all the variables that keep track of suggestion state, resulting in an underflow value when calculating the lines to display completion suggestions later.

Setting `m_times_tab_pressed` to 0 apparently forces it to recalculate the those variables and seems to fix the problem.

Fixes #22128