### PR TITLE
LibCompress: Fix reaching end-of-stream without collecting the required number of bits

### DIFF
--- a/Userland/Libraries/LibCompress/Deflate.cpp
+++ b/Userland/Libraries/LibCompress/Deflate.cpp
@@ -374,7 +374,7 @@ void DeflateDecompressor::close()
 ErrorOr<ByteBuffer> DeflateDecompressor::decompress_all(ReadonlyBytes bytes)
 {
     FixedMemoryStream memory_stream { bytes };
-    LittleEndianInputBitStream bit_stream { MaybeOwned<Stream>(memory_stream) };
+    LittleEndianInputBitStream bit_stream { MaybeOwned<Stream>(memory_stream), LittleEndianInputBitStream::FillWithZero };
     auto deflate_stream = TRY(DeflateDecompressor::construct(MaybeOwned<LittleEndianInputBitStream>(bit_stream)));
     AllocatingMemoryStream output_stream;
 

--- a/Userland/Libraries/LibCompress/Zlib.cpp
+++ b/Userland/Libraries/LibCompress/Zlib.cpp
@@ -28,7 +28,7 @@ ErrorOr<NonnullOwnPtr<ZlibDecompressor>> ZlibDecompressor::create(MaybeOwned<Str
     if (header.as_u16 % 31 != 0)
         return Error::from_string_literal("Zlib error correction code does not match");
 
-    auto bit_stream = make<LittleEndianInputBitStream>(move(stream));
+    auto bit_stream = make<LittleEndianInputBitStream>(move(stream), LittleEndianInputBitStream::FillWithZero);
     auto deflate_stream = TRY(Compress::DeflateDecompressor::construct(move(bit_stream)));
 
     return adopt_nonnull_own_or_enomem(new (nothrow) ZlibDecompressor(header, move(deflate_stream)));


### PR DESCRIPTION
This Fix #22130