### PR TITLE
LibGfx/ICC: Support for A curves and CLUT in LutAToBTagData::evaluate()

### DIFF
--- a/Userland/Libraries/LibPDF/Function.cpp
+++ b/Userland/Libraries/LibPDF/Function.cpp
@@ -30,6 +30,16 @@ private:
 
     float sample(Vector<int> const& coordinates, size_t r) const
     {
+        // "For a function with multidimensional input (more than one input variable),
+        //  the sample values in the first dimension vary fastest,
+        //  and the values in the last dimension vary slowest.
+        //  For example, for a function f(a, b, c), where a, b, and c vary from 0 to 9 in steps of 1,
+        //  the sample values would appear in this order:
+        //  f(0,0,0), f(1,0,0), ..., f(9,0,0),
+        //  f(0,1,0), f(1,1,0), ..., f(9,1,0),
+        //  f(0,2,0), f(1, 2, 0), ..., f(9, 9, 0),
+        //  f(0, 0, 1), f(1, 0, 1), and so on."
+        // Implied is that functions with multiple outputs store all outputs next to each other.
         size_t stride = 1;
         size_t offset = 0;
         for (size_t i = 0; i < coordinates.size(); ++i) {


### PR DESCRIPTION
`lerp_nd()` is very similar to PDF::SampleFunction::evaluate(). But we
know that the result is a FloatVector3 in the ICC code (at least for
now), so we can save a bunch of redundant computation by returning
all three channels of the LUT at once.

This is enough for images using mAB with A curve / CLUT if the
profile connecting space is PCSXYZ, such as for Upper_Right.jpg
from https://www.color.org/version4html.xalter like so:

    % Build/lagom/icc --name sRGB --reencode-to serenity-sRGB.icc
    % Build/lagom/bin/image -o out.png \
        --convert-to-color-profile serenity-sRGB.icc \
        ~/Downloads/Upper_Right.jpg

---

Also clean up the very similar code in SampleFunction::evaluate().