### PR TITLE
LibWeb: Fix crash in decode_favicon for navigable with no page

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -1900,9 +1900,8 @@ void Document::update_readiness(HTML::DocumentReadyState readiness_value)
     dispatch_event(Event::create(realm(), HTML::EventNames::readystatechange));
 
     if (readiness_value == HTML::DocumentReadyState::Complete && is_active() && navigable()->is_traversable()) {
-        HTML::HTMLLinkElement::load_fallback_favicon_if_needed(*this).release_value_but_fixme_should_propagate_errors();
-
         if (auto* page = navigable()->traversable_navigable()->page()) {
+            HTML::HTMLLinkElement::load_fallback_favicon_if_needed(*this).release_value_but_fixme_should_propagate_errors();
             page->client().page_did_finish_loading(url());
         }
     }

--- a/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
@@ -453,7 +453,7 @@ static bool decode_favicon(ReadonlyBytes favicon_data, AK::URL const& favicon_ur
     auto favicon_bitmap = decoded_image->frames[0].bitmap;
     dbgln_if(IMAGE_DECODER_DEBUG, "Decoded favicon, {}", favicon_bitmap->size());
 
-    if (navigable && navigable->is_traversable())
+    if (navigable && navigable->is_traversable() && navigable->traversable_navigable()->page())
         navigable->traversable_navigable()->page()->client().page_did_change_favicon(*favicon_bitmap);
 
     return favicon_bitmap;


### PR DESCRIPTION
Regressed in: 19313945f2300f698cc04f0a7e4cbb255c32b4a0

We were performing a null check on the navigable page in Document::update_readiness, but the same null check was not being performed when loading the navigable. It is enough to simply move the call to HTMLLinkElement::load_fallback_favicon_if_needed inside of the existing null check of the page to fix the crash on https://mozilla.org when hovering over the 'Firefox Browser' tab in the menu, but it seems safer to perform this check in decode_favicon as well.

Fixes: #22091

Draft as I try to figure out how to write a test for this (and also to try convince myself that this is the right fix).