### PR TITLE
LibGfx/TIFF: Support String-based tags

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/TIFFLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/TIFFLoader.cpp
@@ -378,6 +378,9 @@ private:
         case Type::ASCII:
         case Type::UTF8: {
             Vector<Value, 1> result;
+            // NOTE: No need to include the null terminator
+            if (count > 0)
+                --count;
             auto string_data = TRY(ByteBuffer::create_uninitialized(count));
             TRY(m_stream->read_until_filled(string_data));
             result.empend(TRY(String::from_utf8(StringView { string_data.bytes() })));

--- a/Userland/Libraries/LibGfx/TIFFGenerator.py
+++ b/Userland/Libraries/LibGfx/TIFFGenerator.py
@@ -104,6 +104,8 @@ def tiff_type_to_cpp(t: TIFFType, without_promotion: bool = False) -> str:
     # Note that the Value<> type doesn't include u16 for this reason
     if not without_promotion:
         t = promote_type(t)
+    if t in [TIFFType.ASCII, TIFFType.UTF8]:
+        return 'String'
     if t == TIFFType.Undefined:
         return 'ByteBuffer'
     if t == TIFFType.UnsignedShort:
@@ -119,7 +121,7 @@ def is_container(t: TIFFType) -> bool:
         An example of that are ASCII strings defined as N * byte. Let's intercept that and generate
         a nice API instead of Vector<u8>.
     """
-    return t in [TIFFType.Byte, TIFFType.Undefined]
+    return t in [TIFFType.ASCII, TIFFType.Byte, TIFFType.Undefined, TIFFType.UTF8]
 
 
 def export_promoter() -> str:


### PR DESCRIPTION
The second commit fixes the ⧄ that you can see on both images of #22139