### PR TITLE
LibWeb: Remove DeprecatedString usage from HTMLScriptElement's `text`

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/HTMLScriptElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLScriptElement.h
@@ -55,8 +55,8 @@ public:
     void unmark_as_already_started(Badge<DOM::Range>);
     void unmark_as_parser_inserted(Badge<DOM::Range>);
 
-    String text() { return MUST(String::from_deprecated_string(child_text_content())); }
-    void set_text(String const& text) { string_replace_all(text.to_deprecated_string()); }
+    String text() { return child_text_content(); }
+    void set_text(String const& text) { string_replace_all(text); }
 
 private:
     HTMLScriptElement(DOM::Document&, DOM::QualifiedName);


### PR DESCRIPTION
There was some awkward timing between these APIs being added and the methods they use being ported to String.