### PR TITLE
LibWeb: Don't get stuck in TreeWalker.nextNode() when current detached

### DIFF
--- a/Tests/LibWeb/Text/expected/DOM/TreeWalker-nextNode-with-detached-currentNode.txt
+++ b/Tests/LibWeb/Text/expected/DOM/TreeWalker-nextNode-with-detached-currentNode.txt
@@ -1,0 +1,1 @@
+PASS (Didn't get stuck)

--- a/Tests/LibWeb/Text/input/DOM/TreeWalker-nextNode-with-detached-currentNode.html
+++ b/Tests/LibWeb/Text/input/DOM/TreeWalker-nextNode-with-detached-currentNode.html
@@ -1,0 +1,13 @@
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const fragment = document.createDocumentFragment();
+        fragment.appendChild(document.createTextNode("hello"));
+
+        const walker = document.createTreeWalker(document, 0);
+        walker.currentNode = fragment;
+
+        walker.nextNode();
+        println("PASS (Didn't get stuck)");
+    });
+</script>

--- a/Userland/Libraries/LibWeb/DOM/TreeWalker.cpp
+++ b/Userland/Libraries/LibWeb/DOM/TreeWalker.cpp
@@ -221,6 +221,13 @@ JS::ThrowCompletionOr<JS::GCPtr<Node>> TreeWalker::next_node()
 
             // 4. Set temporary to temporary’s parent.
             temporary = temporary->parent();
+
+            // NON-STANDARD: If temporary is null, then return null.
+            //               This prevents us from infinite looping if the current node is not connected.
+            //               Spec bug: https://github.com/whatwg/dom/issues/1102
+            if (temporary == nullptr) {
+                return nullptr;
+            }
         }
 
         // 5. Set result to the result of filtering node within this.


### PR DESCRIPTION
This fixes a hang on https://reddit.com/

Spec bug: https://github.com/whatwg/dom/issues/1102