### PR TITLE
LibWebView: Allow editing the DOM through the Inspector WebView

### DIFF
--- a/Base/res/html/inspector/inspector.css
+++ b/Base/res/html/inspector/inspector.css
@@ -137,6 +137,11 @@ details > :not(:first-child) {
     padding: 1px;
 }
 
+.dom-editor {
+    width: fit-content;
+    outline: none;
+}
+
 @media (prefers-color-scheme: dark) {
     .hoverable:hover {
         background-color: #31383e;

--- a/Meta/gn/secondary/Userland/Libraries/LibWebView/BUILD.gn
+++ b/Meta/gn/secondary/Userland/Libraries/LibWebView/BUILD.gn
@@ -116,6 +116,7 @@ shared_library("LibWebView") {
     "//Userland/Libraries/LibWeb",
   ]
   sources = [
+    "Attribute.cpp",
     "CookieJar.cpp",
     "Database.cpp",
     "History.cpp",

--- a/Tests/LibWeb/Layout/expected/shadow-tree-removed-from-dom-receives-event.txt
+++ b/Tests/LibWeb/Layout/expected/shadow-tree-removed-from-dom-receives-event.txt
@@ -1,0 +1,20 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x17.46875 children: not-inline
+      BlockContainer <div#container> at (8,8) content-size 784x17.46875 children: inline
+        line 0 width: 43.421875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+          frag 0 from TextNode start: 0, length: 5, rect: [8,8 43.421875x17.46875]
+            "Pass!"
+        InlineNode <span>
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (8,25.46875) content-size 784x0 children: inline
+        TextNode <#text>
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x17.46875]
+      PaintableWithLines (BlockContainer<DIV>#container) [8,8 784x17.46875]
+        InlinePaintable (InlineNode<SPAN>)
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,25.46875 784x0]

--- a/Tests/LibWeb/Layout/input/shadow-tree-removed-from-dom-receives-event.html
+++ b/Tests/LibWeb/Layout/input/shadow-tree-removed-from-dom-receives-event.html
@@ -1,0 +1,14 @@
+<div id=container>
+    <details open>
+        <summary>summary</summary>
+        <span id=node></span>
+    </details>
+</div>
+<script type="text/javascript">
+    let node = document.getElementById("node");
+
+    let container = document.getElementById("container");
+    container.innerHTML = "<span>Pass!</span>";
+
+    node.click();
+</script>

--- a/Tests/LibWeb/Text/expected/input-blur.txt
+++ b/Tests/LibWeb/Text/expected/input-blur.txt
@@ -1,0 +1,2 @@
+   focus
+blur

--- a/Tests/LibWeb/Text/expected/input-click-to-unfocus.txt
+++ b/Tests/LibWeb/Text/expected/input-click-to-unfocus.txt
@@ -1,0 +1,2 @@
+   focus
+blur

--- a/Tests/LibWeb/Text/expected/input-commit-on-unfocus.txt
+++ b/Tests/LibWeb/Text/expected/input-commit-on-unfocus.txt
@@ -1,0 +1,2 @@
+wfh :^)   wfh :^)
+blur

--- a/Tests/LibWeb/Text/input/input-blur.html
+++ b/Tests/LibWeb/Text/input/input-blur.html
@@ -1,0 +1,18 @@
+<input id=input type=text>
+<script src="include.js"></script>
+<script>
+    test(() => {
+        let input = document.getElementById("input");
+
+        input.addEventListener("focus", () => {
+            println("focus");
+        });
+
+        input.addEventListener("blur", () => {
+            println("blur");
+        });
+
+        input.focus();
+        input.blur();
+    })
+</script>

--- a/Tests/LibWeb/Text/input/input-click-to-unfocus.html
+++ b/Tests/LibWeb/Text/input/input-click-to-unfocus.html
@@ -1,0 +1,23 @@
+<input id=input type=text>
+<script src="include.js"></script>
+<script>
+    test(() => {
+        let input = document.getElementById("input");
+
+        input.addEventListener("focus", () => {
+            println("focus");
+        });
+
+        input.addEventListener("blur", () => {
+            println("blur");
+        });
+
+        input.focus();
+
+        const rect = input.getBoundingClientRect();
+        const x = rect.x + rect.width;
+        const y = rect.y + rect.height;
+
+        internals.click(x + 10, y + 10);
+    })
+</script>

--- a/Tests/LibWeb/Text/input/input-commit-on-unfocus.html
+++ b/Tests/LibWeb/Text/input/input-commit-on-unfocus.html
@@ -1,0 +1,18 @@
+<input id=input type=text>
+<script src="include.js"></script>
+<script>
+    test(() => {
+        let input = document.getElementById("input");
+
+        input.addEventListener("change", () => {
+            println(input.value);
+        });
+
+        input.addEventListener("blur", () => {
+            println("blur");
+        });
+
+        internals.sendText(input, "wfh :^)");
+        input.blur();
+    })
+</script>

--- a/Tests/LibWeb/Text/input/input-commit.html
+++ b/Tests/LibWeb/Text/input/input-commit.html
@@ -1,12 +1,11 @@
 <input id=input type=text>
 <script src="include.js"></script>
 <script>
-    asyncTest((done) => {
+    test(() => {
         let input = document.getElementById("input");
 
         input.addEventListener("change", () => {
             println(input.value);
-            done();
         });
 
         internals.sendText(input, "wfh :^)");

--- a/Userland/Libraries/LibWeb/DOM/Node.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Node.cpp
@@ -1259,8 +1259,7 @@ bool Node::is_shadow_including_descendant_of(Node const& other) const
 
     // and A’s root’s host is a shadow-including inclusive descendant of B.
     auto& shadow_root = verify_cast<ShadowRoot>(root());
-    // NOTE: While host is nullable because of inheriting from DocumentFragment, shadow roots always have a host.
-    return shadow_root.host()->is_shadow_including_inclusive_descendant_of(other);
+    return shadow_root.host() && shadow_root.host()->is_shadow_including_inclusive_descendant_of(other);
 }
 
 // https://dom.spec.whatwg.org/#concept-shadow-including-inclusive-descendant

--- a/Userland/Libraries/LibWeb/HTML/Focus.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Focus.cpp
@@ -212,6 +212,7 @@ void run_focusing_steps(DOM::Node* new_focus_target, DOM::Node* fallback_target,
     run_focus_update_steps(old_chain, new_chain, new_focus_target);
 }
 
+// https://html.spec.whatwg.org/multipage/interaction.html#unfocusing-steps
 void run_unfocusing_steps(DOM::Node* old_focus_target)
 {
     // NOTE: The unfocusing steps do not always result in the focus changing, even when applied to the currently focused
@@ -254,11 +255,9 @@ void run_unfocusing_steps(DOM::Node* old_focus_target)
     auto old_chain = focus_chain(top_level_browsing_context->currently_focused_area());
 
     // 5. If old focus target is not one of the entries in old chain, then return.
-    for (auto& node : old_chain) {
-        if (old_focus_target != node) {
-            return;
-        }
-    }
+    auto it = old_chain.find_if([&](auto const& node) { return old_focus_target == node; });
+    if (it == old_chain.end())
+        return;
 
     // 6. If old focus target is not a focusable area, then return.
     if (!old_focus_target->is_focusable())

--- a/Userland/Libraries/LibWeb/HTML/Focus.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Focus.cpp
@@ -91,6 +91,8 @@ static void run_focus_update_steps(Vector<JS::Handle<DOM::Node>> old_chain, Vect
         // FIXME: This isn't entirely right.
         if (is<DOM::Element>(*entry))
             entry->document().set_focused_element(&static_cast<DOM::Element&>(*entry));
+        else if (is<DOM::Document>(*entry))
+            entry->document().set_focused_element(static_cast<DOM::Document&>(*entry).document_element());
 
         JS::GCPtr<DOM::EventTarget> focus_event_target;
         if (is<DOM::Element>(*entry)) {
@@ -268,7 +270,7 @@ void run_unfocusing_steps(DOM::Node* old_focus_target)
 
     // 8. If topDocument's node navigable has system focus, then run the focusing steps for topDocument's viewport.
     if (top_document->navigable()->traversable_navigable()->system_visibility_state() == HTML::VisibilityState::Visible) {
-        // FIXME: run the focusing steps for topDocument's viewport (??)
+        run_focusing_steps(top_document);
     } else {
         // FIXME: Otherwise, apply any relevant platform-specific conventions for removing system focus from
         // topDocument's browsing context, and run the focus update steps with old chain, an empty list, and null

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -433,10 +433,8 @@ void HTMLInputElement::commit_pending_changes()
 
     m_has_uncommitted_changes = false;
 
-    queue_an_element_task(HTML::Task::Source::UserInteraction, [this] {
-        auto change_event = DOM::Event::create(realm(), HTML::EventNames::change, { .bubbles = true });
-        dispatch_event(change_event);
-    });
+    auto change_event = DOM::Event::create(realm(), HTML::EventNames::change, { .bubbles = true });
+    dispatch_event(change_event);
 }
 
 void HTMLInputElement::update_placeholder_visibility()

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -1340,4 +1340,47 @@ void HTMLInputElement::activation_behavior(DOM::Event const&)
     run_input_activation_behavior().release_value_but_fixme_should_propagate_errors();
 }
 
+bool HTMLInputElement::has_input_activation_behavior() const
+{
+    switch (type_state()) {
+    case TypeAttributeState::Checkbox:
+    case TypeAttributeState::Color:
+    case TypeAttributeState::FileUpload:
+    case TypeAttributeState::ImageButton:
+    case TypeAttributeState::RadioButton:
+    case TypeAttributeState::ResetButton:
+    case TypeAttributeState::SubmitButton:
+        return true;
+    default:
+        return false;
+    }
+}
+
+// https://html.spec.whatwg.org/multipage/input.html#the-input-element:event-change-2
+bool HTMLInputElement::change_event_applies() const
+{
+    switch (type_state()) {
+    case TypeAttributeState::Checkbox:
+    case TypeAttributeState::Color:
+    case TypeAttributeState::Date:
+    case TypeAttributeState::Email:
+    case TypeAttributeState::FileUpload:
+    case TypeAttributeState::LocalDateAndTime:
+    case TypeAttributeState::Month:
+    case TypeAttributeState::Number:
+    case TypeAttributeState::Password:
+    case TypeAttributeState::RadioButton:
+    case TypeAttributeState::Range:
+    case TypeAttributeState::Search:
+    case TypeAttributeState::Telephone:
+    case TypeAttributeState::Text:
+    case TypeAttributeState::Time:
+    case TypeAttributeState::URL:
+    case TypeAttributeState::Week:
+        return true;
+    default:
+        return false;
+    }
+}
+
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -158,6 +158,9 @@ public:
     virtual bool has_activation_behavior() const override;
     virtual void activation_behavior(DOM::Event const&) override;
 
+    bool has_input_activation_behavior() const;
+    bool change_event_applies() const;
+
 private:
     HTMLInputElement(DOM::Document&, DOM::QualifiedName);
 

--- a/Userland/Libraries/LibWeb/Internals/Inspector.cpp
+++ b/Userland/Libraries/LibWeb/Internals/Inspector.cpp
@@ -9,6 +9,7 @@
 #include <LibWeb/Bindings/InspectorPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/CSS/Selector.h>
+#include <LibWeb/DOM/NamedNodeMap.h>
 #include <LibWeb/HTML/BrowsingContext.h>
 #include <LibWeb/HTML/Window.h>
 #include <LibWeb/Internals/Inspector.h>
@@ -45,6 +46,24 @@ void Inspector::inspect_dom_node(i32 node_id, Optional<i32> const& pseudo_elemen
             return static_cast<Web::CSS::Selector::PseudoElement>(value);
         }));
     }
+}
+
+void Inspector::set_dom_node_text(i32 node_id, String const& text)
+{
+    if (auto* page = global_object().browsing_context()->page())
+        page->client().inspector_did_set_dom_node_text(node_id, text);
+}
+
+void Inspector::set_dom_node_tag(i32 node_id, String const& tag)
+{
+    if (auto* page = global_object().browsing_context()->page())
+        page->client().inspector_did_set_dom_node_tag(node_id, tag);
+}
+
+void Inspector::replace_dom_node_attribute(i32 node_id, String const& name, JS::NonnullGCPtr<DOM::NamedNodeMap> replacement_attributes)
+{
+    if (auto* page = global_object().browsing_context()->page())
+        page->client().inspector_did_replace_dom_node_attribute(node_id, name, replacement_attributes);
 }
 
 void Inspector::execute_console_script(String const& script)

--- a/Userland/Libraries/LibWeb/Internals/Inspector.h
+++ b/Userland/Libraries/LibWeb/Internals/Inspector.h
@@ -21,6 +21,10 @@ public:
     void inspector_loaded();
     void inspect_dom_node(i32 node_id, Optional<i32> const& pseudo_element);
 
+    void set_dom_node_text(i32 node_id, String const& text);
+    void set_dom_node_tag(i32 node_id, String const& tag);
+    void replace_dom_node_attribute(i32 node_id, String const& name, JS::NonnullGCPtr<DOM::NamedNodeMap> replacement_attributes);
+
     void execute_console_script(String const& script);
 
 private:

--- a/Userland/Libraries/LibWeb/Internals/Inspector.idl
+++ b/Userland/Libraries/LibWeb/Internals/Inspector.idl
@@ -1,7 +1,13 @@
+#import <DOM/NamedNodeMap.idl>
+
 [Exposed=Nobody] interface Inspector {
 
     undefined inspectorLoaded();
     undefined inspectDOMNode(long nodeID, optional long pseudoElement);
+
+    undefined setDOMNodeText(long nodeID, DOMString text);
+    undefined setDOMNodeTag(long nodeID, DOMString tag);
+    undefined replaceDOMNodeAttribute(long nodeID, DOMString name, NamedNodeMap replacementAttributes);
 
     undefined executeConsoleScript(DOMString script);
 

--- a/Userland/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Userland/Libraries/LibWeb/Internals/Internals.cpp
@@ -84,6 +84,16 @@ void Internals::commit_text()
     page->handle_keydown(Key_Return, 0, 0);
 }
 
+void Internals::click(double x, double y)
+{
+    auto* page = global_object().browsing_context()->page();
+    if (!page)
+        return;
+
+    page->handle_mousedown({ x, y }, { x, y }, 1, 0, 0);
+    page->handle_mouseup({ x, y }, { x, y }, 1, 0, 0);
+}
+
 WebIDL::ExceptionOr<bool> Internals::dispatch_user_activated_event(DOM::EventTarget& target, DOM::Event& event)
 {
     event.set_is_trusted(true);

--- a/Userland/Libraries/LibWeb/Internals/Internals.h
+++ b/Userland/Libraries/LibWeb/Internals/Internals.h
@@ -25,6 +25,8 @@ public:
     void send_text(HTML::HTMLElement&, String const&);
     void commit_text();
 
+    void click(double x, double y);
+
     WebIDL::ExceptionOr<bool> dispatch_user_activated_event(DOM::EventTarget&, DOM::Event& event);
 
 private:

--- a/Userland/Libraries/LibWeb/Internals/Internals.idl
+++ b/Userland/Libraries/LibWeb/Internals/Internals.idl
@@ -10,6 +10,8 @@
     undefined sendText(HTMLElement target, DOMString text);
     undefined commitText();
 
+    undefined click(double x, double y);
+
     boolean dispatchUserActivatedEvent(EventTarget target, Event event);
 
 };

--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -409,6 +409,9 @@ bool EventHandler::handle_mousedown(CSSPixelPoint position, CSSPixelPoint screen
                 // If we didn't focus anything, place the document text cursor at the mouse position.
                 // FIXME: This is all rather strange. Find a better solution.
                 if (!did_focus_something) {
+                    if (auto* focused_element = document->focused_element())
+                        HTML::run_unfocusing_steps(focused_element);
+
                     auto& realm = document->realm();
                     m_browsing_context->set_cursor_position(DOM::Position::create(realm, *paintable->dom_node(), result->index_in_node));
                     if (auto selection = document->get_selection()) {

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -265,6 +265,9 @@ public:
 
     virtual void inspector_did_load() { }
     virtual void inspector_did_select_dom_node([[maybe_unused]] i32 node_id, [[maybe_unused]] Optional<CSS::Selector::PseudoElement> const& pseudo_element) { }
+    virtual void inspector_did_set_dom_node_text([[maybe_unused]] i32 node_id, [[maybe_unused]] String const& text) { }
+    virtual void inspector_did_set_dom_node_tag([[maybe_unused]] i32 node_id, [[maybe_unused]] String const& tag) { }
+    virtual void inspector_did_replace_dom_node_attribute([[maybe_unused]] i32 node_id, [[maybe_unused]] String const& name, [[maybe_unused]] JS::NonnullGCPtr<DOM::NamedNodeMap> replacement_attributes) {};
     virtual void inspector_did_execute_console_script([[maybe_unused]] String const& script) { }
 
 protected:

--- a/Userland/Libraries/LibWebView/Attribute.cpp
+++ b/Userland/Libraries/LibWebView/Attribute.cpp
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2023, Tim Flynn <trflynn89@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibIPC/Decoder.h>
+#include <LibIPC/Encoder.h>
+#include <LibWebView/Attribute.h>
+
+template<>
+ErrorOr<void> IPC::encode(Encoder& encoder, WebView::Attribute const& attribute)
+{
+    TRY(encoder.encode(attribute.name));
+    TRY(encoder.encode(attribute.value));
+    return {};
+}
+
+template<>
+ErrorOr<WebView::Attribute> IPC::decode(Decoder& decoder)
+{
+    auto name = TRY(decoder.decode<String>());
+    auto value = TRY(decoder.decode<String>());
+
+    return WebView::Attribute { move(name), move(value) };
+}

--- a/Userland/Libraries/LibWebView/Attribute.h
+++ b/Userland/Libraries/LibWebView/Attribute.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2023, Tim Flynn <trflynn89@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/String.h>
+#include <LibIPC/Forward.h>
+
+namespace WebView {
+
+struct Attribute {
+    String name;
+    String value;
+};
+
+}
+
+namespace IPC {
+
+template<>
+ErrorOr<void> encode(Encoder&, WebView::Attribute const&);
+
+template<>
+ErrorOr<WebView::Attribute> decode(Decoder&);
+
+}

--- a/Userland/Libraries/LibWebView/CMakeLists.txt
+++ b/Userland/Libraries/LibWebView/CMakeLists.txt
@@ -1,6 +1,7 @@
 include(${SerenityOS_SOURCE_DIR}/Meta/CMake/public_suffix.cmake)
 
 set(SOURCES
+    Attribute.cpp
     CookieJar.cpp
     Database.cpp
     History.cpp

--- a/Userland/Libraries/LibWebView/Forward.h
+++ b/Userland/Libraries/LibWebView/Forward.h
@@ -18,6 +18,7 @@ class OutOfProcessWebView;
 class ViewImplementation;
 class WebContentClient;
 
+struct Attribute;
 struct CookieStorageKey;
 struct SearchEngine;
 

--- a/Userland/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Userland/Libraries/LibWebView/ViewImplementation.cpp
@@ -181,6 +181,21 @@ i32 ViewImplementation::get_hovered_node_id()
     return client().get_hovered_node_id();
 }
 
+void ViewImplementation::set_dom_node_text(i32 node_id, String text)
+{
+    client().async_set_dom_node_text(node_id, move(text));
+}
+
+Optional<i32> ViewImplementation::set_dom_node_tag(i32 node_id, String name)
+{
+    return client().set_dom_node_tag(node_id, move(name));
+}
+
+void ViewImplementation::replace_dom_node_attribute(i32 node_id, String name, Vector<Attribute> replacement_attributes)
+{
+    client().async_replace_dom_node_attribute(node_id, move(name), move(replacement_attributes));
+}
+
 void ViewImplementation::debug_request(DeprecatedString const& request, DeprecatedString const& argument)
 {
     client().async_debug_request(request, argument);

--- a/Userland/Libraries/LibWebView/ViewImplementation.h
+++ b/Userland/Libraries/LibWebView/ViewImplementation.h
@@ -153,6 +153,9 @@ public:
     Function<void(String const&, String const&, String const&)> on_insert_clipboard_entry;
     Function<void()> on_inspector_loaded;
     Function<void(i32, Optional<Web::CSS::Selector::PseudoElement> const&)> on_inspector_selected_dom_node;
+    Function<void(i32, String const&)> on_inspector_set_dom_node_text;
+    Function<void(i32, String const&)> on_inspector_set_dom_node_tag;
+    Function<void(i32, String const&, Vector<Attribute> const&)> on_inspector_replaced_dom_node_attribute;
     Function<void(String const&)> on_inspector_executed_console_script;
 
     virtual Gfx::IntRect viewport_rect() const = 0;

--- a/Userland/Libraries/LibWebView/ViewImplementation.h
+++ b/Userland/Libraries/LibWebView/ViewImplementation.h
@@ -63,6 +63,10 @@ public:
     void clear_inspected_dom_node();
     i32 get_hovered_node_id();
 
+    void set_dom_node_text(i32 node_id, String text);
+    Optional<i32> set_dom_node_tag(i32 node_id, String name);
+    void replace_dom_node_attribute(i32 node_id, String name, Vector<Attribute> replacement_attributes);
+
     void debug_request(DeprecatedString const& request, DeprecatedString const& argument = {});
 
     void run_javascript(StringView);

--- a/Userland/Libraries/LibWebView/WebContentClient.cpp
+++ b/Userland/Libraries/LibWebView/WebContentClient.cpp
@@ -414,6 +414,24 @@ void WebContentClient::inspector_did_select_dom_node(i32 node_id, Optional<Web::
         m_view.on_inspector_selected_dom_node(node_id, pseudo_element);
 }
 
+void WebContentClient::inspector_did_set_dom_node_text(i32 node_id, String const& text)
+{
+    if (m_view.on_inspector_set_dom_node_text)
+        m_view.on_inspector_set_dom_node_text(node_id, text);
+}
+
+void WebContentClient::inspector_did_set_dom_node_tag(i32 node_id, String const& tag)
+{
+    if (m_view.on_inspector_set_dom_node_tag)
+        m_view.on_inspector_set_dom_node_tag(node_id, tag);
+}
+
+void WebContentClient::inspector_did_replace_dom_node_attribute(i32 node_id, String const& name, Vector<Attribute> const& replacement_attributes)
+{
+    if (m_view.on_inspector_replaced_dom_node_attribute)
+        m_view.on_inspector_replaced_dom_node_attribute(node_id, name, replacement_attributes);
+}
+
 void WebContentClient::inspector_did_execute_console_script(String const& script)
 {
     if (m_view.on_inspector_executed_console_script)

--- a/Userland/Libraries/LibWebView/WebContentClient.h
+++ b/Userland/Libraries/LibWebView/WebContentClient.h
@@ -88,6 +88,9 @@ private:
     virtual void did_insert_clipboard_entry(String const& data, String const& presentation_style, String const& mime_type) override;
     virtual void inspector_did_load() override;
     virtual void inspector_did_select_dom_node(i32 node_id, Optional<Web::CSS::Selector::PseudoElement> const& pseudo_element) override;
+    virtual void inspector_did_set_dom_node_text(i32 node_id, String const& text) override;
+    virtual void inspector_did_set_dom_node_tag(i32 node_id, String const& tag) override;
+    virtual void inspector_did_replace_dom_node_attribute(i32 node_id, String const& name, Vector<Attribute> const& replacement_attributes) override;
     virtual void inspector_did_execute_console_script(String const& script) override;
 
     ViewImplementation& m_view;

--- a/Userland/Services/WebContent/ConnectionFromClient.h
+++ b/Userland/Services/WebContent/ConnectionFromClient.h
@@ -17,6 +17,7 @@
 #include <LibWeb/Forward.h>
 #include <LibWeb/Loader/FileRequest.h>
 #include <LibWeb/Platform/Timer.h>
+#include <LibWebView/Forward.h>
 #include <WebContent/Forward.h>
 #include <WebContent/WebContentClientEndpoint.h>
 #include <WebContent/WebContentConsoleClient.h>
@@ -74,6 +75,11 @@ private:
     virtual Messages::WebContentServer::InspectDomNodeResponse inspect_dom_node(i32 node_id, Optional<Web::CSS::Selector::PseudoElement> const& pseudo_element) override;
     virtual void inspect_accessibility_tree() override;
     virtual Messages::WebContentServer::GetHoveredNodeIdResponse get_hovered_node_id() override;
+
+    virtual void set_dom_node_text(i32 node_id, String const& text) override;
+    virtual Messages::WebContentServer::SetDomNodeTagResponse set_dom_node_tag(i32 node_id, String const& name) override;
+    virtual void replace_dom_node_attribute(i32 node_id, String const& name, Vector<WebView::Attribute> const& replacement_attributes) override;
+
     virtual Messages::WebContentServer::DumpLayoutTreeResponse dump_layout_tree() override;
     virtual Messages::WebContentServer::DumpPaintTreeResponse dump_paint_tree() override;
     virtual Messages::WebContentServer::DumpTextResponse dump_text() override;

--- a/Userland/Services/WebContent/PageClient.cpp
+++ b/Userland/Services/WebContent/PageClient.cpp
@@ -10,6 +10,8 @@
 #include <LibGfx/SystemTheme.h>
 #include <LibWeb/CSS/SystemColor.h>
 #include <LibWeb/Cookie/ParsedCookie.h>
+#include <LibWeb/DOM/Attr.h>
+#include <LibWeb/DOM/NamedNodeMap.h>
 #include <LibWeb/HTML/BrowsingContext.h>
 #include <LibWeb/HTML/TraversableNavigable.h>
 #include <LibWeb/Layout/Viewport.h>
@@ -17,6 +19,7 @@
 #include <LibWeb/Painting/PaintingCommandExecutorCPU.h>
 #include <LibWeb/Painting/ViewportPaintable.h>
 #include <LibWeb/Platform/Timer.h>
+#include <LibWebView/Attribute.h>
 #include <WebContent/ConnectionFromClient.h>
 #include <WebContent/PageClient.h>
 #include <WebContent/PageHost.h>
@@ -506,6 +509,31 @@ void PageClient::inspector_did_load()
 void PageClient::inspector_did_select_dom_node(i32 node_id, Optional<Web::CSS::Selector::PseudoElement> const& pseudo_element)
 {
     client().async_inspector_did_select_dom_node(node_id, pseudo_element);
+}
+
+void PageClient::inspector_did_set_dom_node_text(i32 node_id, String const& text)
+{
+    client().async_inspector_did_set_dom_node_text(node_id, text);
+}
+
+void PageClient::inspector_did_set_dom_node_tag(i32 node_id, String const& tag)
+{
+    client().async_inspector_did_set_dom_node_tag(node_id, tag);
+}
+
+void PageClient::inspector_did_replace_dom_node_attribute(i32 node_id, String const& name, JS::NonnullGCPtr<Web::DOM::NamedNodeMap> replacement_attributes)
+{
+    Vector<WebView::Attribute> attributes;
+    attributes.ensure_capacity(replacement_attributes->length());
+
+    for (size_t i = 0; i < replacement_attributes->length(); ++i) {
+        auto const* attribute = replacement_attributes->item(i);
+        VERIFY(attribute);
+
+        attributes.empend(attribute->name().to_string(), attribute->value());
+    }
+
+    client().async_inspector_did_replace_dom_node_attribute(node_id, name, move(attributes));
 }
 
 void PageClient::inspector_did_execute_console_script(String const& script)

--- a/Userland/Services/WebContent/PageClient.h
+++ b/Userland/Services/WebContent/PageClient.h
@@ -120,6 +120,9 @@ private:
     virtual void page_did_insert_clipboard_entry(String data, String presentation_style, String mime_type) override;
     virtual void inspector_did_load() override;
     virtual void inspector_did_select_dom_node(i32 node_id, Optional<Web::CSS::Selector::PseudoElement> const& pseudo_element) override;
+    virtual void inspector_did_set_dom_node_text(i32 node_id, String const& text) override;
+    virtual void inspector_did_set_dom_node_tag(i32 node_id, String const& tag) override;
+    virtual void inspector_did_replace_dom_node_attribute(i32 node_id, String const& name, JS::NonnullGCPtr<Web::DOM::NamedNodeMap> replacement_attributes) override;
     virtual void inspector_did_execute_console_script(String const& script) override;
 
     Web::Layout::Viewport* layout_root();

--- a/Userland/Services/WebContent/WebContentClient.ipc
+++ b/Userland/Services/WebContent/WebContentClient.ipc
@@ -7,6 +7,7 @@
 #include <LibWeb/CSS/Selector.h>
 #include <LibWeb/HTML/ActivateTab.h>
 #include <LibWeb/Page/Page.h>
+#include <LibWebView/Attribute.h>
 
 endpoint WebContentClient
 {
@@ -72,6 +73,9 @@ endpoint WebContentClient
 
     inspector_did_load() =|
     inspector_did_select_dom_node(i32 node_id, Optional<Web::CSS::Selector::PseudoElement> pseudo_element) =|
+    inspector_did_set_dom_node_text(i32 node_id, String text) =|
+    inspector_did_set_dom_node_tag(i32 node_id, String tag) =|
+    inspector_did_replace_dom_node_attribute(i32 node_id, String name, Vector<WebView::Attribute> replacement_attributes) =|
     inspector_did_execute_console_script(String script) =|
 
 }

--- a/Userland/Services/WebContent/WebContentServer.ipc
+++ b/Userland/Services/WebContent/WebContentServer.ipc
@@ -6,6 +6,7 @@
 #include <LibWeb/CSS/PreferredColorScheme.h>
 #include <LibWeb/CSS/Selector.h>
 #include <LibWeb/WebDriver/ExecuteScript.h>
+#include <LibWebView/Attribute.h>
 
 endpoint WebContentServer
 {
@@ -44,6 +45,10 @@ endpoint WebContentServer
     get_hovered_node_id() => (i32 node_id)
     js_console_input(DeprecatedString js_source) =|
     js_console_request_messages(i32 start_index) =|
+
+    set_dom_node_text(i32 node_id, String text) =|
+    set_dom_node_tag(i32 node_id, String name) => (Optional<i32> node_id)
+    replace_dom_node_attribute(i32 node_id, String name, Vector<WebView::Attribute> replacement_attributes) =|
 
     take_document_screenshot() => (Gfx::ShareableBitmap data)
 


### PR DESCRIPTION
This allows a limited amount of DOM manipulation through the Inspector.
Users may edit node tag names, text content, and attributes. To initiate
an edit, double-click the tag/text/attribute of interest.

To remove an attribute, begin editing the attribute and remove all of
its text. To add an attribute, begin editing an existing attribute and
add the new attribute's text before or after the existing attribute's
text. This isn't going to be the final UX, but works for now just as a
consequence of how attribute changes are implemented. A future patch
will add more explicit add/delete actions.


https://github.com/SerenityOS/serenity/assets/5600524/af59af66-5c92-484a-9063-6125c7f660f5

