### PR TITLE
LibWebView: Avoid trying to break a schemeless URL into renderable parts

### DIFF
--- a/Tests/LibWebView/TestWebViewURL.cpp
+++ b/Tests/LibWebView/TestWebViewURL.cpp
@@ -24,6 +24,10 @@ TEST_CASE(invalid_url)
     EXPECT(!WebView::break_url_into_parts(":/"sv).has_value());
     EXPECT(!WebView::break_url_into_parts("://"sv).has_value());
 
+    EXPECT(!WebView::break_url_into_parts("/"sv).has_value());
+    EXPECT(!WebView::break_url_into_parts("//"sv).has_value());
+    EXPECT(!WebView::break_url_into_parts("/h"sv).has_value());
+
     EXPECT(!WebView::break_url_into_parts("f"sv).has_value());
     EXPECT(!WebView::break_url_into_parts("fi"sv).has_value());
     EXPECT(!WebView::break_url_into_parts("fil"sv).has_value());

--- a/Userland/Libraries/LibWebView/URL.cpp
+++ b/Userland/Libraries/LibWebView/URL.cpp
@@ -144,7 +144,11 @@ Optional<URLParts> break_url_into_parts(StringView url_string)
     if (!url.is_valid())
         return {};
 
-    auto scheme_length = url.scheme().bytes_as_string_view().length();
+    auto const& scheme = url.scheme();
+    auto scheme_length = scheme.bytes_as_string_view().length();
+
+    if (!url_string.starts_with(scheme))
+        return {};
     if (!url_string.substring_view(scheme_length).starts_with("://"sv))
         return {};
 


### PR DESCRIPTION
Fixes #22157