### PR TITLE
LibGfx/ICC: Implement forward transform for mft1 and mft2 tags

### DIFF
--- a/Userland/Libraries/LibGfx/ICC/Profile.cpp
+++ b/Userland/Libraries/LibGfx/ICC/Profile.cpp
@@ -1213,12 +1213,14 @@ ErrorOr<FloatVector3> Profile::to_pcs_a_to_b(TagData const& tag_data, ReadonlyBy
     VERIFY(number_of_components_in_color_space(connection_space()) == 3);
 
     switch (tag_data.type()) {
-    case Lut16TagData::Type:
-        // FIXME
-        return Error::from_string_literal("ICC::Profile::to_pcs: AToB*Tag handling for mft2 tags not yet implemented");
-    case Lut8TagData::Type:
-        // FIXME
-        return Error::from_string_literal("ICC::Profile::to_pcs: AToB*Tag handling for mft1 tags not yet implemented");
+    case Lut16TagData::Type: {
+        auto const& a_to_b = static_cast<Lut16TagData const&>(tag_data);
+        return a_to_b.evaluate(data_color_space(), connection_space(), color);
+    }
+    case Lut8TagData::Type: {
+        auto const& a_to_b = static_cast<Lut8TagData const&>(tag_data);
+        return a_to_b.evaluate(data_color_space(), connection_space(), color);
+    }
     case LutAToBTagData::Type: {
         auto const& a_to_b = static_cast<LutAToBTagData const&>(tag_data);
         if (a_to_b.number_of_input_channels() != number_of_components_in_color_space(data_color_space()))

--- a/Userland/Libraries/LibGfx/ICC/TagTypes.h
+++ b/Userland/Libraries/LibGfx/ICC/TagTypes.h
@@ -20,6 +20,21 @@
 
 namespace Gfx::ICC {
 
+// Does one-dimensional linear interpolation over a lookup table.
+// Takes a span of values an x in [0.0, 1.0].
+// Finds the two values in the span closest to x (where x = 0.0 is the span's first element and x = 1.0 the span's last element),
+// and linearly interpolates between those two values, assumes all values are the same amount apart.
+template<class T>
+float lerp_1d(ReadonlySpan<T> values, float x)
+{
+    size_t n = values.size() - 1;
+    size_t i = static_cast<size_t>(x * n);
+    if (i == values.size() - 1)
+        --i;
+
+    return mix(static_cast<float>(values[i]), static_cast<float>(values[i + 1]), x * n - i);
+}
+
 // Does multi-dimensional linear interpolation over a lookup table.
 // `size(i)` should returns the number of samples in the i'th dimension.
 // `sample()` gets a vector where 0 <= i'th coordinate < size(i) and should return the value of the look-up table at that position.
@@ -207,12 +222,7 @@ public:
         if (values().size() == 1)
             return powf(x, values()[0] / (float)0x100);
 
-        size_t n = values().size() - 1;
-        size_t i = static_cast<size_t>(x * n);
-        if (i == values().size() - 1)
-            --i;
-
-        return mix(values()[i] / 65535.f, values()[i + 1] / 65535.f, x * n - i);
+        return lerp_1d(values().span(), x) / 65535.0f;
     }
 
     // y must be in [0..1].

--- a/Userland/Libraries/LibGfx/ICC/TagTypes.h
+++ b/Userland/Libraries/LibGfx/ICC/TagTypes.h
@@ -28,10 +28,7 @@ template<class T>
 float lerp_1d(ReadonlySpan<T> values, float x)
 {
     size_t n = values.size() - 1;
-    size_t i = static_cast<size_t>(x * n);
-    if (i == values.size() - 1)
-        --i;
-
+    size_t i = min(static_cast<size_t>(x * n), n - 1);
     return mix(static_cast<float>(values[i]), static_cast<float>(values[i + 1]), x * n - i);
 }
 


### PR DESCRIPTION
mft1 and mft2 tags are very similar. The only difference is that
mft1 uses an u8 lookup table, while mft2 uses a u16 lookup table.
This means their PCS lookup encodings are different, and mft2 uses a
PCSLAB encoding that's different from other places in the v4 spec.

---

This is a bit of a milestone, since we now have forward transforms for all required tags in the ICC v4 spec. That means we should be able to convert any image containing an ICC profile to a color space we have a reverse transform for (such as our sRGB profile).

There's still a ton missing of course:
* Things are very slow
* We're missing some backwards transforms, so while we can transform _from_ any color space, we can't transform _to_ all of them
* check_lut.jpeg and check_full.jpeg look to saturated, so there are likely bugs (but other files look pretty decent)
* We don't have support for the optional DToBNTag / BToDNTags yet (but lots of software doesn't support that either)

But still, it's a nice milestone :)