### PR TITLE
LibAccelGfx: Set blending for alpha separately to be sum of src and dst

### DIFF
--- a/Userland/Libraries/LibAccelGfx/GL.cpp
+++ b/Userland/Libraries/LibAccelGfx/GL.cpp
@@ -36,10 +36,10 @@ static GLenum to_gl_enum(BlendFactor factor)
     VERIFY_NOT_REACHED();
 }
 
-void enable_blending(BlendFactor source, BlendFactor destination)
+void enable_blending(BlendFactor source, BlendFactor destination, BlendFactor source_alpha, BlendFactor destination_alpha)
 {
     glEnable(GL_BLEND);
-    glBlendFunc(to_gl_enum(source), to_gl_enum(destination));
+    glBlendFuncSeparate(to_gl_enum(source), to_gl_enum(destination), to_gl_enum(source_alpha), to_gl_enum(destination_alpha));
     verify_no_error();
 }
 

--- a/Userland/Libraries/LibAccelGfx/GL.h
+++ b/Userland/Libraries/LibAccelGfx/GL.h
@@ -65,7 +65,7 @@ enum class BlendFactor {
     OneMinusSrcAlpha,
     SrcAlpha,
 };
-void enable_blending(BlendFactor source, BlendFactor destination);
+void enable_blending(BlendFactor source, BlendFactor destination, BlendFactor source_alpha, BlendFactor destination_alpha);
 
 void read_pixels(Gfx::IntRect, Gfx::Bitmap&);
 

--- a/Userland/Libraries/LibAccelGfx/Painter.cpp
+++ b/Userland/Libraries/LibAccelGfx/Painter.cpp
@@ -205,7 +205,7 @@ void Painter::fill_rect(Gfx::FloatRect rect, Gfx::Color color)
 
     GL::set_uniform(color_uniform, red, green, blue, alpha);
     GL::set_vertex_attribute(position_attribute, 0, 2);
-    GL::enable_blending(GL::BlendFactor::SrcAlpha, GL::BlendFactor::OneMinusSrcAlpha);
+    GL::enable_blending(GL::BlendFactor::SrcAlpha, GL::BlendFactor::OneMinusSrcAlpha, GL::BlendFactor::One, GL::BlendFactor::One);
     GL::draw_arrays(GL::DrawPrimitive::TriangleFan, 4);
 
     GL::delete_buffer(vbo);
@@ -254,7 +254,7 @@ void Painter::fill_rect_with_rounded_corners(Gfx::FloatRect const& rect, Color c
     auto bottom_right_corner_radius_uniform = m_rounded_rectangle_program.get_uniform_location("uBottomRightRadius");
     GL::set_uniform(bottom_right_corner_radius_uniform, bottom_right_radius.horizontal_radius, bottom_right_radius.vertical_radius);
 
-    GL::enable_blending(GL::BlendFactor::SrcAlpha, GL::BlendFactor::OneMinusSrcAlpha);
+    GL::enable_blending(GL::BlendFactor::SrcAlpha, GL::BlendFactor::OneMinusSrcAlpha, GL::BlendFactor::One, GL::BlendFactor::One);
     GL::draw_arrays(GL::DrawPrimitive::TriangleFan, 4);
 
     GL::delete_buffer(vbo);
@@ -297,7 +297,7 @@ void Painter::draw_line(Gfx::FloatPoint a, Gfx::FloatPoint b, float thickness, C
 
     GL::set_uniform(color_uniform, red, green, blue, alpha);
     GL::set_vertex_attribute(position_attribute, 0, 2);
-    GL::enable_blending(GL::BlendFactor::SrcAlpha, GL::BlendFactor::OneMinusSrcAlpha);
+    GL::enable_blending(GL::BlendFactor::SrcAlpha, GL::BlendFactor::OneMinusSrcAlpha, GL::BlendFactor::One, GL::BlendFactor::One);
     GL::draw_arrays(GL::DrawPrimitive::TriangleFan, 4);
 
     GL::delete_buffer(vbo);
@@ -438,7 +438,7 @@ void Painter::draw_glyph_run(Vector<Gfx::DrawGlyphOrEmoji> const& glyph_run, Col
 
     GL::set_uniform(color_uniform, red, green, blue, alpha);
     GL::set_vertex_attribute(position_attribute, 0, 4);
-    GL::enable_blending(GL::BlendFactor::SrcAlpha, GL::BlendFactor::OneMinusSrcAlpha);
+    GL::enable_blending(GL::BlendFactor::SrcAlpha, GL::BlendFactor::OneMinusSrcAlpha, GL::BlendFactor::One, GL::BlendFactor::One);
     GL::draw_arrays(GL::DrawPrimitive::Triangles, vertices.size() / 4);
 
     GL::delete_buffer(vbo);
@@ -535,7 +535,7 @@ void Painter::fill_rect_with_linear_gradient(Gfx::FloatRect const& rect, Readonl
     GL::bind_buffer(vbo_colors);
     GL::set_vertex_attribute(color_attribute, 0, 4);
 
-    GL::enable_blending(GL::BlendFactor::One, GL::BlendFactor::OneMinusSrcAlpha);
+    GL::enable_blending(GL::BlendFactor::One, GL::BlendFactor::OneMinusSrcAlpha, GL::BlendFactor::One, GL::BlendFactor::One);
     GL::draw_arrays(GL::DrawPrimitive::Triangles, vertices.size() / 2);
 
     GL::delete_buffer(vbo_vertices);
@@ -659,7 +659,7 @@ void Painter::blit_scaled_texture(Gfx::FloatRect const& dst_rect, GL::Texture co
     auto scaling_mode_gl = to_gl_scaling_mode(scaling_mode);
     GL::set_texture_scale_mode(scaling_mode_gl);
 
-    GL::enable_blending(GL::BlendFactor::SrcAlpha, GL::BlendFactor::OneMinusSrcAlpha);
+    GL::enable_blending(GL::BlendFactor::SrcAlpha, GL::BlendFactor::OneMinusSrcAlpha, GL::BlendFactor::One, GL::BlendFactor::One);
 
     GL::draw_arrays(GL::DrawPrimitive::TriangleFan, 4);
 


### PR DESCRIPTION
With this change we match blending in LibGfx and it fixes rendering on all websites that use opacity < 1.

Webpage that renders text and box using rgba(0, 0, 0, 0.5) color.

Before:
<img width="515" alt="Screenshot 2023-12-04 at 18 23 03" src="https://github.com/SerenityOS/serenity/assets/45686940/dd96303c-a84f-4fda-bd10-788da6c9a72e">

After:
<img width="510" alt="Screenshot 2023-12-04 at 18 28 36" src="https://github.com/SerenityOS/serenity/assets/45686940/4143fc63-a2ea-4250-b304-4306104cd0e1">
