### PR TITLE
LibWeb: Add window.status property

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/Window.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Window.cpp
@@ -863,6 +863,20 @@ void Window::set_name(String const& name)
     navigable()->active_session_history_entry()->document_state->set_navigable_target_name(name);
 }
 
+// https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-window-status
+String Window::status() const
+{
+    // the status attribute on the Window object must, on getting, return the last string it was set to
+    return m_status;
+}
+
+// https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-window-status
+void Window::set_status(String const& status)
+{
+    // on setting, must set itself to the new value.
+    m_status = status;
+}
+
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-location
 JS::NonnullGCPtr<Location> Window::location()
 {

--- a/Userland/Libraries/LibWeb/HTML/Window.h
+++ b/Userland/Libraries/LibWeb/HTML/Window.h
@@ -134,6 +134,8 @@ public:
     JS::NonnullGCPtr<DOM::Document const> document() const;
     String name() const;
     void set_name(String const&);
+    String status() const;
+    void set_status(String const&);
     [[nodiscard]] JS::NonnullGCPtr<Location> location();
     JS::NonnullGCPtr<History> history() const;
     JS::NonnullGCPtr<Navigation> navigation();
@@ -275,6 +277,10 @@ private:
 
     // https://streams.spec.whatwg.org/#byte-length-queuing-strategy-size-function
     JS::GCPtr<WebIDL::CallbackType> m_byte_length_queuing_strategy_size_function;
+
+    // https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-window-status
+    // When the Window object is created, the attribute must be set to the empty string. It does not do anything else.
+    String m_status;
 };
 
 void run_animation_frame_callbacks(DOM::Document&, double now);

--- a/Userland/Libraries/LibWeb/HTML/Window.idl
+++ b/Userland/Libraries/LibWeb/HTML/Window.idl
@@ -24,6 +24,7 @@ interface Window : EventTarget {
     [Replaceable] readonly attribute WindowProxy self;
     [LegacyUnforgeable] readonly attribute Document document;
     attribute DOMString name;
+    attribute DOMString status;
     [PutForwards=href, LegacyUnforgeable] readonly attribute Location location;
     readonly attribute History history;
     readonly attribute Navigation navigation;


### PR DESCRIPTION
This PR adds support for the now deprecated window.status JavaScript property in LibWeb. It is initially set to an empty string on every window, and when modified by the user, it is set to the new value converted to a string. As per the web standards, it does not do anything else.

MDN: https://developer.mozilla.org/en-US/docs/Web/API/Window/status
Spec: https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-window-status