### PR TITLE
WebWorker: Log URL and reason for Worker script load failure

### DIFF
--- a/Userland/Services/WebWorker/DedicatedWorkerHost.cpp
+++ b/Userland/Services/WebWorker/DedicatedWorkerHost.cpp
@@ -132,7 +132,7 @@ void DedicatedWorkerHost::run()
     };
     auto perform_fetch = Web::HTML::create_perform_the_fetch_hook(inner_settings->heap(), move(perform_fetch_function));
 
-    auto on_complete_function = [inner_settings, worker_global_scope, outside_port = m_outside_port](JS::GCPtr<Web::HTML::Script> script) {
+    auto on_complete_function = [inner_settings, worker_global_scope, outside_port = m_outside_port, url = m_url](JS::GCPtr<Web::HTML::Script> script) {
         auto& realm = inner_settings->realm();
         // 1. If script is null or if script's error to rethrow is non-null, then:
         if (!script || !script->error_to_rethrow().is_null()) {
@@ -141,7 +141,7 @@ void DedicatedWorkerHost::run()
             // FIXME 2. Run the environment discarding steps for inside settings.
 
             // 3. Abort these steps.
-            dbgln("Didn't get my script :(");
+            dbgln("DedicatedWorkerHost: Unable to fetch script {} because {}", url, script ? script->error_to_rethrow().to_string_without_side_effects() : "script was null"_string);
             return;
         }
 


### PR DESCRIPTION
Now, a load of `chat.openai.com` gives information that a blob url is the reason for failure to load the page:

```
ResourceLoader: Starting load of: "https://chat.openai.com/"
ResourceLoader: Failed load of: "https://chat.openai.com/", Error: Load failed: 403, Duration: 129ms
ResourceLoader: Starting load of: "https://chat.openai.com/cdn-cgi/challenge-platform/h/b/orchestrate/chl_page/v1?ray=830774141f30538c"
HTMLScriptElement: Refusing to run script because the src URL ':' is invalid.
ResourceLoader: Finished load of: "https://chat.openai.com/cdn-cgi/challenge-platform/h/b/orchestrate/chl_page/v1?ray=830774141f30538c", Duration: 4985ms
ResourceLoader: Starting load of: "https://chat.openai.com/favicon.ico"
ResourceLoader: Failed load of: "https://chat.openai.com/favicon.ico", Error: Load failed: 403, Duration: 29ms
----> DedicatedWorkerHost: Unable to fetch script blob:https://chat.openai.com/9a1ac00c-ba2e-4e12-88ed-122ab296be4f because script was null
Could not decode favicon https://chat.openai.com/favicon.ico
Loaded 141 of 141 (100%) provided CA Certificates
Loaded 141 of 141 (100%) provided CA Certificates
```