### PR TITLE
man6: Updating manpages for different games, Chess, ColorLines and GameOfLife

### DIFF
--- a/Base/usr/share/man/man6/Chess.md
+++ b/Base/usr/share/man/man6/Chess.md
@@ -12,6 +12,10 @@ $ Chess
 
 ## Description
 
-Chess is an implementation of the 15th century board game. 
+Chess is an implementation of the 15th century board game played on an 8x8 grid by two opponents, each commanding an army of 16 pieces with distinct movements and powers.
+
+The objective is simple yet complex: to outmaneuver and checkmate the opponent's king, putting it in a position where it cannot escape capture. Every move requires calculated planning, anticipating your adversary's tactics, and adapting strategies to gain positional advantage or execute tactical strikes.
+
+It's easy to pick up and play but incredibly hard to master.
 
 The game can either be played against another human or against the ChessEngine service.

--- a/Base/usr/share/man/man6/ColorLines.md
+++ b/Base/usr/share/man/man6/ColorLines.md
@@ -17,3 +17,6 @@ ColorLines is a classic game.
 Click a marble, then click an empty square to move. 
 You can only move along unblocked paths.
 Build rows of 5 or more marbles of the same color to score. 
+
+The aim of the game is to arrange balls of the same color in vertical, horizontal or diagonal lines. Once line has five or more balls of same color, that line is removed from the board and you earn score points.
+To move a ball click on it to select, then click on destination square. After each turn three new balls randomly added to the board. The game is over when the board is filled up.

--- a/Base/usr/share/man/man6/GameOfLife.md
+++ b/Base/usr/share/man/man6/GameOfLife.md
@@ -14,6 +14,8 @@ $ GameOfLife
 
 GameOfLife is an implementation of John Conway's Game of Life.
 
+Wikipedia: https://en.wikipedia.org/wiki/Conway%27s_Game_of_Life
+
 The game is a cellular automaton where each cell is either dead (grey) or alive (yellow) and will change state in the next tick if any of the following rules are fulfilled:
 
 * An alive cell will die by underpopulation if it has fewer than two neighbors.

--- a/Userland/Libraries/LibAudio/VorbisComment.cpp
+++ b/Userland/Libraries/LibAudio/VorbisComment.cpp
@@ -178,9 +178,9 @@ ErrorOr<void> write_vorbis_comment(Metadata const& metadata, Stream& target)
     auto vorbis_user_comments = TRY(make_vorbis_user_comments(metadata));
     TRY(target.write_value<LittleEndian<u32>>(vorbis_user_comments.size()));
     for (auto const& field : vorbis_user_comments) {
-        auto const serialized_field = TRY(String::formatted("{}={}", field.field_name, field.contents)).bytes();
-        TRY(target.write_value<LittleEndian<u32>>(serialized_field.size()));
-        TRY(target.write_until_depleted(serialized_field));
+        auto const serialized_field = TRY(String::formatted("{}={}", field.field_name, field.contents));
+        TRY(target.write_value<LittleEndian<u32>>(serialized_field.bytes().size()));
+        TRY(target.write_until_depleted(serialized_field.bytes()));
     }
 
     return {};


### PR DESCRIPTION
Updated manpages for 3 games that were specified here in this issue: https://github.com/SerenityOS/serenity/issues/21091

Chess: Updated manpage for Chess to more accurately describe the game itself
ColorLines: Updated manpage to more accurately describe the game's goals and how to play it
GameOfLife: Added link to the Wikipedia page in the manpage