### PR TITLE
LibWeb: Move BorderRadiusCornerClipper allocation into CPU executor

### DIFF
--- a/Userland/Libraries/LibWeb/Painting/BorderRadiiData.h
+++ b/Userland/Libraries/LibWeb/Painting/BorderRadiiData.h
@@ -40,6 +40,11 @@ struct CornerRadii {
     CornerRadius top_right;
     CornerRadius bottom_right;
     CornerRadius bottom_left;
+
+    inline bool has_any_radius() const
+    {
+        return top_left || top_right || bottom_right || bottom_left;
+    }
 };
 
 struct BorderRadiiData {

--- a/Userland/Libraries/LibWeb/Painting/BorderRadiusCornerClipper.h
+++ b/Userland/Libraries/LibWeb/Painting/BorderRadiusCornerClipper.h
@@ -18,7 +18,7 @@ enum class CornerClip {
 
 class BorderRadiusCornerClipper : public RefCounted<BorderRadiusCornerClipper> {
 public:
-    static ErrorOr<NonnullRefPtr<BorderRadiusCornerClipper>> create(CornerRadii const&, DevicePixelRect const& border_rect, BorderRadiiData const& border_radii, CornerClip corner_clip = CornerClip::Outside);
+    static ErrorOr<NonnullRefPtr<BorderRadiusCornerClipper>> create(CornerRadii const&, DevicePixelRect const& border_rect, CornerClip corner_clip = CornerClip::Outside);
 
     void sample_under_corners(Gfx::Painter& page_painter);
     void blit_corner_clipping(Gfx::Painter& page_painter);
@@ -63,6 +63,9 @@ struct ScopedCornerRadiusClip {
 private:
     PaintContext& m_context;
     RefPtr<BorderRadiusCornerClipper> m_corner_clipper;
+    u32 m_id;
+    bool m_has_radius { false };
+    Gfx::IntRect m_border_rect;
 };
 
 }

--- a/Userland/Libraries/LibWeb/Painting/PaintContext.h
+++ b/Userland/Libraries/LibWeb/Painting/PaintContext.h
@@ -71,6 +71,8 @@ public:
     CSSPixelPoint scroll_offset() const { return m_scroll_offset; }
     void translate_scroll_offset_by(CSSPixelPoint offset) { m_scroll_offset.translate_by(offset); }
 
+    u32 allocate_corner_clipper_id() { return m_next_corner_clipper_id++; }
+
 private:
     Painting::RecordingPainter& m_recording_painter;
     Palette m_palette;
@@ -80,6 +82,7 @@ private:
     bool m_focus { false };
     CSSPixelPoint m_scroll_offset;
     Gfx::AffineTransform m_svg_transform;
+    u32 m_next_corner_clipper_id { 0 };
 };
 
 }

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.h
@@ -219,7 +219,7 @@ private:
     Optional<CSSPixelRect> mutable m_clip_rect;
 
     mutable bool m_clipping_overflow { false };
-    RefPtr<BorderRadiusCornerClipper> mutable m_overflow_corner_radius_clipper;
+    mutable Optional<u32> m_corner_clipper_id;
 
     Optional<BordersDataWithElementKind> m_override_borders_data;
     Optional<TableCellCoordinates> m_table_cell_coordinates;

--- a/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorCPU.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorCPU.cpp
@@ -414,15 +414,19 @@ CommandResult PaintingCommandExecutorCPU::draw_triangle_wave(Gfx::IntPoint const
     return CommandResult::Continue;
 }
 
-CommandResult PaintingCommandExecutorCPU::sample_under_corners(BorderRadiusCornerClipper& corner_clipper)
+CommandResult PaintingCommandExecutorCPU::sample_under_corners(u32 id, CornerRadii const& corner_radii, Gfx::IntRect const& border_rect, CornerClip corner_clip)
 {
-    corner_clipper.sample_under_corners(painter());
+    m_corner_clippers.resize(id + 1);
+    auto clipper = BorderRadiusCornerClipper::create(corner_radii, border_rect.to_type<DevicePixels>(), corner_clip);
+    m_corner_clippers[id] = clipper.release_value_but_fixme_should_propagate_errors();
+    m_corner_clippers[id]->sample_under_corners(painter());
     return CommandResult::Continue;
 }
 
-CommandResult PaintingCommandExecutorCPU::blit_corner_clipping(BorderRadiusCornerClipper& corner_clipper)
+CommandResult PaintingCommandExecutorCPU::blit_corner_clipping(u32 id)
 {
-    corner_clipper.blit_corner_clipping(painter());
+    m_corner_clippers[id]->blit_corner_clipping(painter());
+    m_corner_clippers[id] = nullptr;
     return CommandResult::Continue;
 }
 

--- a/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorCPU.h
+++ b/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorCPU.h
@@ -43,8 +43,8 @@ public:
     CommandResult paint_radial_gradient(Gfx::IntRect const& rect, Web::Painting::RadialGradientData const& radial_gradient_data, Gfx::IntPoint const& center, Gfx::IntSize const& size) override;
     CommandResult paint_conic_gradient(Gfx::IntRect const& rect, Web::Painting::ConicGradientData const& conic_gradient_data, Gfx::IntPoint const& position) override;
     CommandResult draw_triangle_wave(Gfx::IntPoint const& p1, Gfx::IntPoint const& p2, Color const&, int amplitude, int thickness) override;
-    CommandResult sample_under_corners(BorderRadiusCornerClipper&) override;
-    CommandResult blit_corner_clipping(BorderRadiusCornerClipper&) override;
+    CommandResult sample_under_corners(u32 id, CornerRadii const&, Gfx::IntRect const&, CornerClip) override;
+    CommandResult blit_corner_clipping(u32 id) override;
     CommandResult paint_borders(DevicePixelRect const& border_rect, CornerRadii const& corner_radii, BordersDataDevicePixels const& borders_data) override;
 
     bool would_be_fully_clipped_by_painter(Gfx::IntRect) const override;
@@ -59,6 +59,7 @@ public:
 
 private:
     Gfx::Bitmap& m_target_bitmap;
+    Vector<RefPtr<BorderRadiusCornerClipper>> m_corner_clippers;
 
     struct StackingContext {
         MaybeOwned<Gfx::Painter> painter;

--- a/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorGPU.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorGPU.cpp
@@ -299,13 +299,13 @@ CommandResult PaintingCommandExecutorGPU::draw_triangle_wave(Gfx::IntPoint const
     return CommandResult::Continue;
 }
 
-CommandResult PaintingCommandExecutorGPU::sample_under_corners(BorderRadiusCornerClipper&)
+CommandResult PaintingCommandExecutorGPU::sample_under_corners(u32, CornerRadii const&, Gfx::IntRect const&, CornerClip)
 {
     // FIXME
     return CommandResult::Continue;
 }
 
-CommandResult PaintingCommandExecutorGPU::blit_corner_clipping(BorderRadiusCornerClipper&)
+CommandResult PaintingCommandExecutorGPU::blit_corner_clipping(u32)
 {
     // FIXME
     return CommandResult::Continue;

--- a/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorGPU.h
+++ b/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorGPU.h
@@ -44,8 +44,8 @@ public:
     CommandResult paint_radial_gradient(Gfx::IntRect const& rect, Web::Painting::RadialGradientData const& radial_gradient_data, Gfx::IntPoint const& center, Gfx::IntSize const& size) override;
     CommandResult paint_conic_gradient(Gfx::IntRect const& rect, Web::Painting::ConicGradientData const& conic_gradient_data, Gfx::IntPoint const& position) override;
     CommandResult draw_triangle_wave(Gfx::IntPoint const& p1, Gfx::IntPoint const& p2, Color const&, int amplitude, int thickness) override;
-    CommandResult sample_under_corners(BorderRadiusCornerClipper&) override;
-    CommandResult blit_corner_clipping(BorderRadiusCornerClipper&) override;
+    CommandResult sample_under_corners(u32 id, CornerRadii const&, Gfx::IntRect const&, CornerClip) override;
+    CommandResult blit_corner_clipping(u32) override;
     CommandResult paint_borders(DevicePixelRect const& border_rect, CornerRadii const& corner_radii, BordersDataDevicePixels const& borders_data) override;
 
     bool would_be_fully_clipped_by_painter(Gfx::IntRect) const override;

--- a/Userland/Libraries/LibWeb/Painting/RecordingPainter.h
+++ b/Userland/Libraries/LibWeb/Painting/RecordingPainter.h
@@ -299,13 +299,17 @@ struct DrawTriangleWave {
 };
 
 struct SampleUnderCorners {
-    NonnullRefPtr<BorderRadiusCornerClipper> corner_clipper;
+    u32 id;
+    CornerRadii corner_radii;
+    Gfx::IntRect border_rect;
+    CornerClip corner_clip;
 
     [[nodiscard]] Gfx::IntRect bounding_rect() const;
 };
 
 struct BlitCornerClipping {
-    NonnullRefPtr<BorderRadiusCornerClipper> corner_clipper;
+    u32 id;
+    Gfx::IntRect border_rect;
 
     [[nodiscard]] Gfx::IntRect bounding_rect() const;
 };
@@ -387,8 +391,8 @@ public:
     virtual CommandResult apply_backdrop_filter(Gfx::IntRect const& backdrop_region, Web::CSS::ResolvedBackdropFilter const& backdrop_filter) = 0;
     virtual CommandResult draw_rect(Gfx::IntRect const& rect, Color const&, bool rough) = 0;
     virtual CommandResult draw_triangle_wave(Gfx::IntPoint const& p1, Gfx::IntPoint const& p2, Color const& color, int amplitude, int thickness) = 0;
-    virtual CommandResult sample_under_corners(BorderRadiusCornerClipper&) = 0;
-    virtual CommandResult blit_corner_clipping(BorderRadiusCornerClipper&) = 0;
+    virtual CommandResult sample_under_corners(u32 id, CornerRadii const&, Gfx::IntRect const&, CornerClip) = 0;
+    virtual CommandResult blit_corner_clipping(u32 id) = 0;
     virtual CommandResult paint_borders(DevicePixelRect const& border_rect, CornerRadii const& corner_radii, BordersDataDevicePixels const& borders_data) = 0;
 
     virtual bool would_be_fully_clipped_by_painter(Gfx::IntRect) const = 0;
@@ -482,8 +486,8 @@ public:
     void push_stacking_context(PushStackingContextParams params);
     void pop_stacking_context();
 
-    void sample_under_corners(NonnullRefPtr<BorderRadiusCornerClipper> corner_clipper);
-    void blit_corner_clipping(NonnullRefPtr<BorderRadiusCornerClipper> corner_clipper);
+    void sample_under_corners(u32 id, CornerRadii corner_radii, Gfx::IntRect border_rect, CornerClip corner_clip);
+    void blit_corner_clipping(u32 id, Gfx::IntRect border_rect);
 
     void paint_progressbar(Gfx::IntRect frame_rect, Gfx::IntRect progress_rect, Palette palette, int min, int max, int value, StringView text);
     void paint_frame(Gfx::IntRect rect, Palette palette, Gfx::FrameStyle style);

--- a/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -181,17 +181,11 @@ void StackingContext::paint_child(PaintContext& context, StackingContext const& 
     auto parent_paintable = child.paintable_box().parent();
     if (parent_paintable)
         parent_paintable->before_children_paint(context, PaintPhase::Foreground);
-    auto containing_block = child.paintable_box().containing_block();
-    auto* containing_block_paintable = containing_block ? containing_block->paintable() : nullptr;
-    if (containing_block_paintable)
-        containing_block_paintable->apply_clip_overflow_rect(context, PaintPhase::Foreground);
 
     child.paint(context);
 
     if (parent_paintable)
         parent_paintable->after_children_paint(context, PaintPhase::Foreground);
-    if (containing_block_paintable)
-        containing_block_paintable->clear_clip_overflow_rect(context, PaintPhase::Foreground);
 }
 
 void StackingContext::paint_internal(PaintContext& context) const
@@ -259,8 +253,14 @@ void StackingContext::paint_internal(PaintContext& context) const
     for (auto* child : m_children) {
         if (!child->paintable_box().is_positioned())
             continue;
+        auto containing_block = child->paintable_box().containing_block();
+        auto const* containing_block_paintable = containing_block ? containing_block->paintable() : nullptr;
+        if (containing_block_paintable)
+            containing_block_paintable->apply_clip_overflow_rect(context, PaintPhase::Foreground);
         if (child->paintable_box().computed_values().z_index().has_value() && child->paintable_box().computed_values().z_index().value() >= 1)
             paint_child(context, *child);
+        if (containing_block_paintable)
+            containing_block_paintable->clear_clip_overflow_rect(context, PaintPhase::Foreground);
     }
 
     paint_node(paintable_box(), context, PaintPhase::Outline);


### PR DESCRIPTION
BorderRadiusCornerClipper usage to clip border radius is specific to
CPU painter so it should not be stored in painting commands.

Also with this change bitmaps for corner sampling are allocated during
painting commands replaying instead of commands recording.