### PR TITLE
LibWebView: Add an Inspector context menu to instigate editing the DOM tree

### DIFF
--- a/Base/res/ladybird/inspector.js
+++ b/Base/res/ladybird/inspector.js
@@ -208,6 +208,7 @@ const createDOMEditor = (onHandleChange, onCancelChange) => {
     const handleChange = () => {
         input.removeEventListener("change", handleChange);
         input.removeEventListener("blur", cancelChange);
+        input.removeEventListener("keydown", handleInput);
 
         try {
             onHandleChange(input.value);
@@ -219,13 +220,24 @@ const createDOMEditor = (onHandleChange, onCancelChange) => {
     const cancelChange = () => {
         input.removeEventListener("change", handleChange);
         input.removeEventListener("blur", cancelChange);
+        input.removeEventListener("keydown", handleInput);
 
         selectedDOMNode.classList.add("selected");
         onCancelChange(input);
     };
 
+    const handleInput = event => {
+        const ESCAPE_KEYCODE = 27;
+
+        if (event.keyCode === ESCAPE_KEYCODE) {
+            cancelChange();
+            event.preventDefault();
+        }
+    };
+
     input.addEventListener("change", handleChange);
     input.addEventListener("blur", cancelChange);
+    input.addEventListener("keydown", handleInput);
 
     setTimeout(() => {
         input.focus();

--- a/Ladybird/Qt/InspectorWidget.h
+++ b/Ladybird/Qt/InspectorWidget.h
@@ -7,8 +7,12 @@
 #pragma once
 
 #include "WebContentView.h"
+#include <LibGfx/Point.h>
 #include <LibWebView/Forward.h>
 #include <QWidget>
+
+class QAction;
+class QMenu;
 
 namespace Ladybird {
 
@@ -30,8 +34,19 @@ public:
 private:
     void closeEvent(QCloseEvent*) override;
 
+    QPoint to_widget_position(Gfx::IntPoint) const;
+
     WebContentView* m_inspector_view;
     OwnPtr<WebView::InspectorClient> m_inspector_client;
+
+    QMenu* m_dom_node_text_context_menu { nullptr };
+    QMenu* m_dom_node_tag_context_menu { nullptr };
+    QMenu* m_dom_node_attribute_context_menu { nullptr };
+
+    QAction* m_edit_node_action { nullptr };
+    QAction* m_delete_node_action { nullptr };
+    QAction* m_add_attribute_action { nullptr };
+    QAction* m_remove_attribute_action { nullptr };
 };
 
 }

--- a/Userland/Applications/Browser/InspectorWidget.cpp
+++ b/Userland/Applications/Browser/InspectorWidget.cpp
@@ -7,7 +7,9 @@
  */
 
 #include "InspectorWidget.h"
+#include <LibGUI/Action.h>
 #include <LibGUI/BoxLayout.h>
+#include <LibGUI/Menu.h>
 #include <LibWebView/InspectorClient.h>
 #include <LibWebView/OutOfProcessWebView.h>
 
@@ -25,6 +27,48 @@ InspectorWidget::InspectorWidget(WebView::OutOfProcessWebView& content_view)
 
     m_inspector_view = add<WebView::OutOfProcessWebView>();
     m_inspector_client = make<WebView::InspectorClient>(content_view, *m_inspector_view);
+
+    m_edit_node_action = GUI::Action::create("&Edit node"sv, [this](auto&) { m_inspector_client->context_menu_edit_dom_node(); });
+    m_delete_node_action = GUI::Action::create("&Delete node"sv, [this](auto&) { m_inspector_client->context_menu_remove_dom_node(); });
+    m_add_attribute_action = GUI::Action::create("&Add attribute"sv, [this](auto&) { m_inspector_client->context_menu_add_dom_node_attribute(); });
+    m_remove_attribute_action = GUI::Action::create("&Remove attribute"sv, [this](auto&) { m_inspector_client->context_menu_remove_dom_node_attribute(); });
+
+    m_dom_node_text_context_menu = GUI::Menu::construct();
+    m_dom_node_text_context_menu->add_action(*m_edit_node_action);
+    m_dom_node_text_context_menu->add_separator();
+    m_dom_node_text_context_menu->add_action(*m_delete_node_action);
+
+    m_dom_node_tag_context_menu = GUI::Menu::construct();
+    m_dom_node_tag_context_menu->add_action(*m_edit_node_action);
+    m_dom_node_tag_context_menu->add_separator();
+    m_dom_node_tag_context_menu->add_action(*m_add_attribute_action);
+    m_dom_node_tag_context_menu->add_action(*m_delete_node_action);
+
+    m_dom_node_attribute_context_menu = GUI::Menu::construct();
+    m_dom_node_attribute_context_menu->add_action(*m_edit_node_action);
+    m_dom_node_attribute_context_menu->add_action(*m_remove_attribute_action);
+    m_dom_node_attribute_context_menu->add_separator();
+    m_dom_node_attribute_context_menu->add_action(*m_add_attribute_action);
+    m_dom_node_attribute_context_menu->add_action(*m_delete_node_action);
+
+    m_inspector_client->on_requested_dom_node_text_context_menu = [this](auto position) {
+        m_edit_node_action->set_text("&Edit text");
+
+        m_dom_node_text_context_menu->popup(to_widget_position(position));
+    };
+
+    m_inspector_client->on_requested_dom_node_tag_context_menu = [this](auto position, auto const& tag) {
+        m_edit_node_action->set_text(DeprecatedString::formatted("&Edit \"{}\"", tag));
+
+        m_dom_node_tag_context_menu->popup(to_widget_position(position));
+    };
+
+    m_inspector_client->on_requested_dom_node_attribute_context_menu = [this](auto position, auto const& attribute) {
+        m_edit_node_action->set_text(DeprecatedString::formatted("&Edit attribute \"{}\"", attribute));
+        m_remove_attribute_action->set_text(DeprecatedString::formatted("&Remove attribute \"{}\"", attribute));
+
+        m_dom_node_attribute_context_menu->popup(to_widget_position(position));
+    };
 
     m_inspector_view->set_focus(true);
 }
@@ -49,6 +93,11 @@ void InspectorWidget::select_default_node()
 void InspectorWidget::select_hovered_node()
 {
     m_inspector_client->select_hovered_node();
+}
+
+Gfx::IntPoint InspectorWidget::to_widget_position(Gfx::IntPoint position) const
+{
+    return m_inspector_view->screen_relative_rect().location().translated(position);
 }
 
 }

--- a/Userland/Applications/Browser/InspectorWidget.h
+++ b/Userland/Applications/Browser/InspectorWidget.h
@@ -30,8 +30,19 @@ public:
 private:
     explicit InspectorWidget(WebView::OutOfProcessWebView& content_view);
 
+    Gfx::IntPoint to_widget_position(Gfx::IntPoint) const;
+
     RefPtr<WebView::OutOfProcessWebView> m_inspector_view;
     OwnPtr<WebView::InspectorClient> m_inspector_client;
+
+    RefPtr<GUI::Menu> m_dom_node_text_context_menu;
+    RefPtr<GUI::Menu> m_dom_node_tag_context_menu;
+    RefPtr<GUI::Menu> m_dom_node_attribute_context_menu;
+
+    RefPtr<GUI::Action> m_edit_node_action;
+    RefPtr<GUI::Action> m_delete_node_action;
+    RefPtr<GUI::Action> m_add_attribute_action;
+    RefPtr<GUI::Action> m_remove_attribute_action;
 };
 
 }

--- a/Userland/Libraries/LibWeb/Internals/Inspector.cpp
+++ b/Userland/Libraries/LibWeb/Internals/Inspector.cpp
@@ -61,6 +61,11 @@ void Inspector::replace_dom_node_attribute(i32 node_id, String const& name, JS::
     global_object().browsing_context()->page().client().inspector_did_replace_dom_node_attribute(node_id, name, replacement_attributes);
 }
 
+void Inspector::request_dom_tree_context_menu(i32 node_id, i32 client_x, i32 client_y, String const& type, Optional<String> const& tag_or_attribute_name)
+{
+    global_object().browsing_context()->page().client().inspector_did_request_dom_tree_context_menu(node_id, { client_x, client_y }, type, tag_or_attribute_name);
+}
+
 void Inspector::execute_console_script(String const& script)
 {
     global_object().browsing_context()->page().client().inspector_did_execute_console_script(script);

--- a/Userland/Libraries/LibWeb/Internals/Inspector.cpp
+++ b/Userland/Libraries/LibWeb/Internals/Inspector.cpp
@@ -56,6 +56,11 @@ void Inspector::set_dom_node_tag(i32 node_id, String const& tag)
     global_object().browsing_context()->page().client().inspector_did_set_dom_node_tag(node_id, tag);
 }
 
+void Inspector::add_dom_node_attributes(i32 node_id, JS::NonnullGCPtr<DOM::NamedNodeMap> attributes)
+{
+    global_object().browsing_context()->page().client().inspector_did_add_dom_node_attributes(node_id, attributes);
+}
+
 void Inspector::replace_dom_node_attribute(i32 node_id, String const& name, JS::NonnullGCPtr<DOM::NamedNodeMap> replacement_attributes)
 {
     global_object().browsing_context()->page().client().inspector_did_replace_dom_node_attribute(node_id, name, replacement_attributes);

--- a/Userland/Libraries/LibWeb/Internals/Inspector.h
+++ b/Userland/Libraries/LibWeb/Internals/Inspector.h
@@ -25,6 +25,8 @@ public:
     void set_dom_node_tag(i32 node_id, String const& tag);
     void replace_dom_node_attribute(i32 node_id, String const& name, JS::NonnullGCPtr<DOM::NamedNodeMap> replacement_attributes);
 
+    void request_dom_tree_context_menu(i32 node_id, i32 client_x, i32 client_y, String const& type, Optional<String> const& tag_or_attribute_name);
+
     void execute_console_script(String const& script);
 
 private:

--- a/Userland/Libraries/LibWeb/Internals/Inspector.h
+++ b/Userland/Libraries/LibWeb/Internals/Inspector.h
@@ -23,6 +23,7 @@ public:
 
     void set_dom_node_text(i32 node_id, String const& text);
     void set_dom_node_tag(i32 node_id, String const& tag);
+    void add_dom_node_attributes(i32 node_id, JS::NonnullGCPtr<DOM::NamedNodeMap> attributes);
     void replace_dom_node_attribute(i32 node_id, String const& name, JS::NonnullGCPtr<DOM::NamedNodeMap> replacement_attributes);
 
     void request_dom_tree_context_menu(i32 node_id, i32 client_x, i32 client_y, String const& type, Optional<String> const& tag_or_attribute_name);

--- a/Userland/Libraries/LibWeb/Internals/Inspector.idl
+++ b/Userland/Libraries/LibWeb/Internals/Inspector.idl
@@ -9,6 +9,8 @@
     undefined setDOMNodeTag(long nodeID, DOMString tag);
     undefined replaceDOMNodeAttribute(long nodeID, DOMString name, NamedNodeMap replacementAttributes);
 
+    undefined requestDOMTreeContextMenu(long nodeID, long clientX, long clientY, DOMString type, DOMString? tagOrAttributeName);
+
     undefined executeConsoleScript(DOMString script);
 
 };

--- a/Userland/Libraries/LibWeb/Internals/Inspector.idl
+++ b/Userland/Libraries/LibWeb/Internals/Inspector.idl
@@ -7,6 +7,7 @@
 
     undefined setDOMNodeText(long nodeID, DOMString text);
     undefined setDOMNodeTag(long nodeID, DOMString tag);
+    undefined addDOMNodeAttributes(long nodeID, NamedNodeMap attributes);
     undefined replaceDOMNodeAttribute(long nodeID, DOMString name, NamedNodeMap replacementAttributes);
 
     undefined requestDOMTreeContextMenu(long nodeID, long clientX, long clientY, DOMString type, DOMString? tagOrAttributeName);

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -274,7 +274,8 @@ public:
     virtual void inspector_did_select_dom_node([[maybe_unused]] i32 node_id, [[maybe_unused]] Optional<CSS::Selector::PseudoElement> const& pseudo_element) { }
     virtual void inspector_did_set_dom_node_text([[maybe_unused]] i32 node_id, [[maybe_unused]] String const& text) { }
     virtual void inspector_did_set_dom_node_tag([[maybe_unused]] i32 node_id, [[maybe_unused]] String const& tag) { }
-    virtual void inspector_did_replace_dom_node_attribute([[maybe_unused]] i32 node_id, [[maybe_unused]] String const& name, [[maybe_unused]] JS::NonnullGCPtr<DOM::NamedNodeMap> replacement_attributes) {};
+    virtual void inspector_did_replace_dom_node_attribute([[maybe_unused]] i32 node_id, [[maybe_unused]] String const& name, [[maybe_unused]] JS::NonnullGCPtr<DOM::NamedNodeMap> replacement_attributes) { }
+    virtual void inspector_did_request_dom_tree_context_menu([[maybe_unused]] i32 node_id, [[maybe_unused]] CSSPixelPoint position, [[maybe_unused]] String const& type, [[maybe_unused]] Optional<String> const& tag_or_attribute_name) { }
     virtual void inspector_did_execute_console_script([[maybe_unused]] String const& script) { }
 
 protected:

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -274,6 +274,7 @@ public:
     virtual void inspector_did_select_dom_node([[maybe_unused]] i32 node_id, [[maybe_unused]] Optional<CSS::Selector::PseudoElement> const& pseudo_element) { }
     virtual void inspector_did_set_dom_node_text([[maybe_unused]] i32 node_id, [[maybe_unused]] String const& text) { }
     virtual void inspector_did_set_dom_node_tag([[maybe_unused]] i32 node_id, [[maybe_unused]] String const& tag) { }
+    virtual void inspector_did_add_dom_node_attributes([[maybe_unused]] i32 node_id, [[maybe_unused]] JS::NonnullGCPtr<DOM::NamedNodeMap> attributes) { }
     virtual void inspector_did_replace_dom_node_attribute([[maybe_unused]] i32 node_id, [[maybe_unused]] String const& name, [[maybe_unused]] JS::NonnullGCPtr<DOM::NamedNodeMap> replacement_attributes) { }
     virtual void inspector_did_request_dom_tree_context_menu([[maybe_unused]] i32 node_id, [[maybe_unused]] CSSPixelPoint position, [[maybe_unused]] String const& type, [[maybe_unused]] Optional<String> const& tag_or_attribute_name) { }
     virtual void inspector_did_execute_console_script([[maybe_unused]] String const& script) { }

--- a/Userland/Libraries/LibWebView/InspectorClient.cpp
+++ b/Userland/Libraries/LibWebView/InspectorClient.cpp
@@ -81,6 +81,26 @@ InspectorClient::InspectorClient(ViewImplementation& content_web_view, ViewImple
         m_content_web_view.js_console_request_messages(0);
     };
 
+    m_inspector_web_view.on_inspector_requested_dom_tree_context_menu = [this](auto node_id, auto position, auto const& type, auto const& tag_or_attribute_name) {
+        m_context_menu_dom_node_id = node_id;
+        m_context_menu_tag_or_attribute_name = tag_or_attribute_name;
+
+        if (type.is_one_of("text"sv, "comment"sv)) {
+            if (on_requested_dom_node_text_context_menu)
+                on_requested_dom_node_text_context_menu(position);
+        } else if (type == "tag"sv) {
+            VERIFY(m_context_menu_tag_or_attribute_name.has_value());
+
+            if (on_requested_dom_node_tag_context_menu)
+                on_requested_dom_node_tag_context_menu(position, *m_context_menu_tag_or_attribute_name);
+        } else if (type == "attribute"sv) {
+            VERIFY(m_context_menu_tag_or_attribute_name.has_value());
+
+            if (on_requested_dom_node_attribute_context_menu)
+                on_requested_dom_node_attribute_context_menu(position, *m_context_menu_tag_or_attribute_name);
+        }
+    };
+
     m_inspector_web_view.on_inspector_selected_dom_node = [this](auto node_id, auto const& pseudo_element) {
         auto inspected_node_properties = m_content_web_view.inspect_dom_node(node_id, pseudo_element);
 

--- a/Userland/Libraries/LibWebView/InspectorClient.h
+++ b/Userland/Libraries/LibWebView/InspectorClient.h
@@ -26,6 +26,11 @@ public:
     void select_default_node();
     void clear_selection();
 
+    void context_menu_edit_dom_node();
+    void context_menu_remove_dom_node();
+    void context_menu_add_dom_node_attribute();
+    void context_menu_remove_dom_node_attribute();
+
     Function<void(Gfx::IntPoint)> on_requested_dom_node_text_context_menu;
     Function<void(Gfx::IntPoint, String const&)> on_requested_dom_node_tag_context_menu;
     Function<void(Gfx::IntPoint, String const&)> on_requested_dom_node_attribute_context_menu;

--- a/Userland/Libraries/LibWebView/InspectorClient.h
+++ b/Userland/Libraries/LibWebView/InspectorClient.h
@@ -4,8 +4,10 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Function.h>
 #include <AK/JsonValue.h>
 #include <AK/StringView.h>
+#include <LibGfx/Point.h>
 #include <LibWebView/ViewImplementation.h>
 
 #pragma once
@@ -23,6 +25,10 @@ public:
     void select_hovered_node();
     void select_default_node();
     void clear_selection();
+
+    Function<void(Gfx::IntPoint)> on_requested_dom_node_text_context_menu;
+    Function<void(Gfx::IntPoint, String const&)> on_requested_dom_node_tag_context_menu;
+    Function<void(Gfx::IntPoint, String const&)> on_requested_dom_node_attribute_context_menu;
 
 private:
     void load_inspector();
@@ -49,6 +55,9 @@ private:
     Optional<i32> m_pending_selection;
 
     bool m_dom_tree_loaded { false };
+
+    Optional<i32> m_context_menu_dom_node_id;
+    Optional<String> m_context_menu_tag_or_attribute_name;
 
     i32 m_highest_notified_message_index { -1 };
     i32 m_highest_received_message_index { -1 };

--- a/Userland/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Userland/Libraries/LibWebView/ViewImplementation.cpp
@@ -191,6 +191,11 @@ Optional<i32> ViewImplementation::set_dom_node_tag(i32 node_id, String name)
     return client().set_dom_node_tag(node_id, move(name));
 }
 
+void ViewImplementation::add_dom_node_attributes(i32 node_id, Vector<Attribute> attributes)
+{
+    client().async_add_dom_node_attributes(node_id, move(attributes));
+}
+
 void ViewImplementation::replace_dom_node_attribute(i32 node_id, String name, Vector<Attribute> replacement_attributes)
 {
     client().async_replace_dom_node_attribute(node_id, move(name), move(replacement_attributes));

--- a/Userland/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Userland/Libraries/LibWebView/ViewImplementation.cpp
@@ -201,6 +201,11 @@ void ViewImplementation::replace_dom_node_attribute(i32 node_id, String name, Ve
     client().async_replace_dom_node_attribute(node_id, move(name), move(replacement_attributes));
 }
 
+void ViewImplementation::remove_dom_node(i32 node_id)
+{
+    client().async_remove_dom_node(node_id);
+}
+
 void ViewImplementation::debug_request(DeprecatedString const& request, DeprecatedString const& argument)
 {
     client().async_debug_request(request, argument);

--- a/Userland/Libraries/LibWebView/ViewImplementation.h
+++ b/Userland/Libraries/LibWebView/ViewImplementation.h
@@ -67,6 +67,7 @@ public:
     Optional<i32> set_dom_node_tag(i32 node_id, String name);
     void add_dom_node_attributes(i32 node_id, Vector<Attribute> attributes);
     void replace_dom_node_attribute(i32 node_id, String name, Vector<Attribute> replacement_attributes);
+    void remove_dom_node(i32 node_id);
 
     void debug_request(DeprecatedString const& request, DeprecatedString const& argument = {});
 

--- a/Userland/Libraries/LibWebView/ViewImplementation.h
+++ b/Userland/Libraries/LibWebView/ViewImplementation.h
@@ -156,6 +156,7 @@ public:
     Function<void(i32, String const&)> on_inspector_set_dom_node_text;
     Function<void(i32, String const&)> on_inspector_set_dom_node_tag;
     Function<void(i32, String const&, Vector<Attribute> const&)> on_inspector_replaced_dom_node_attribute;
+    Function<void(i32, Gfx::IntPoint, String const&, Optional<String> const&)> on_inspector_requested_dom_tree_context_menu;
     Function<void(String const&)> on_inspector_executed_console_script;
 
     virtual Gfx::IntRect viewport_rect() const = 0;

--- a/Userland/Libraries/LibWebView/ViewImplementation.h
+++ b/Userland/Libraries/LibWebView/ViewImplementation.h
@@ -155,6 +155,7 @@ public:
     Function<void(i32, Optional<Web::CSS::Selector::PseudoElement> const&)> on_inspector_selected_dom_node;
     Function<void(i32, String const&)> on_inspector_set_dom_node_text;
     Function<void(i32, String const&)> on_inspector_set_dom_node_tag;
+    Function<void(i32, Vector<Attribute> const&)> on_inspector_added_dom_node_attributes;
     Function<void(i32, String const&, Vector<Attribute> const&)> on_inspector_replaced_dom_node_attribute;
     Function<void(i32, Gfx::IntPoint, String const&, Optional<String> const&)> on_inspector_requested_dom_tree_context_menu;
     Function<void(String const&)> on_inspector_executed_console_script;

--- a/Userland/Libraries/LibWebView/ViewImplementation.h
+++ b/Userland/Libraries/LibWebView/ViewImplementation.h
@@ -65,6 +65,7 @@ public:
 
     void set_dom_node_text(i32 node_id, String text);
     Optional<i32> set_dom_node_tag(i32 node_id, String name);
+    void add_dom_node_attributes(i32 node_id, Vector<Attribute> attributes);
     void replace_dom_node_attribute(i32 node_id, String name, Vector<Attribute> replacement_attributes);
 
     void debug_request(DeprecatedString const& request, DeprecatedString const& argument = {});

--- a/Userland/Libraries/LibWebView/WebContentClient.cpp
+++ b/Userland/Libraries/LibWebView/WebContentClient.cpp
@@ -426,6 +426,12 @@ void WebContentClient::inspector_did_set_dom_node_tag(i32 node_id, String const&
         m_view.on_inspector_set_dom_node_tag(node_id, tag);
 }
 
+void WebContentClient::inspector_did_add_dom_node_attributes(i32 node_id, Vector<Attribute> const& attributes)
+{
+    if (m_view.on_inspector_added_dom_node_attributes)
+        m_view.on_inspector_added_dom_node_attributes(node_id, attributes);
+}
+
 void WebContentClient::inspector_did_replace_dom_node_attribute(i32 node_id, String const& name, Vector<Attribute> const& replacement_attributes)
 {
     if (m_view.on_inspector_replaced_dom_node_attribute)

--- a/Userland/Libraries/LibWebView/WebContentClient.cpp
+++ b/Userland/Libraries/LibWebView/WebContentClient.cpp
@@ -432,6 +432,12 @@ void WebContentClient::inspector_did_replace_dom_node_attribute(i32 node_id, Str
         m_view.on_inspector_replaced_dom_node_attribute(node_id, name, replacement_attributes);
 }
 
+void WebContentClient::inspector_did_request_dom_tree_context_menu(i32 node_id, Gfx::IntPoint position, String const& type, Optional<String> const& tag_or_attribute_name)
+{
+    if (m_view.on_inspector_requested_dom_tree_context_menu)
+        m_view.on_inspector_requested_dom_tree_context_menu(node_id, m_view.to_widget_position(position), type, tag_or_attribute_name);
+}
+
 void WebContentClient::inspector_did_execute_console_script(String const& script)
 {
     if (m_view.on_inspector_executed_console_script)

--- a/Userland/Libraries/LibWebView/WebContentClient.h
+++ b/Userland/Libraries/LibWebView/WebContentClient.h
@@ -91,6 +91,7 @@ private:
     virtual void inspector_did_set_dom_node_text(i32 node_id, String const& text) override;
     virtual void inspector_did_set_dom_node_tag(i32 node_id, String const& tag) override;
     virtual void inspector_did_replace_dom_node_attribute(i32 node_id, String const& name, Vector<Attribute> const& replacement_attributes) override;
+    virtual void inspector_did_request_dom_tree_context_menu(i32 node_id, Gfx::IntPoint position, String const& type, Optional<String> const& tag_or_attribute_name) override;
     virtual void inspector_did_execute_console_script(String const& script) override;
 
     ViewImplementation& m_view;

--- a/Userland/Libraries/LibWebView/WebContentClient.h
+++ b/Userland/Libraries/LibWebView/WebContentClient.h
@@ -90,6 +90,7 @@ private:
     virtual void inspector_did_select_dom_node(i32 node_id, Optional<Web::CSS::Selector::PseudoElement> const& pseudo_element) override;
     virtual void inspector_did_set_dom_node_text(i32 node_id, String const& text) override;
     virtual void inspector_did_set_dom_node_tag(i32 node_id, String const& tag) override;
+    virtual void inspector_did_add_dom_node_attributes(i32 node_id, Vector<Attribute> const& attributes) override;
     virtual void inspector_did_replace_dom_node_attribute(i32 node_id, String const& name, Vector<Attribute> const& replacement_attributes) override;
     virtual void inspector_did_request_dom_tree_context_menu(i32 node_id, Gfx::IntPoint position, String const& type, Optional<String> const& tag_or_attribute_name) override;
     virtual void inspector_did_execute_console_script(String const& script) override;

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -33,6 +33,7 @@
 #include <LibWeb/HTML/Storage.h>
 #include <LibWeb/HTML/TraversableNavigable.h>
 #include <LibWeb/HTML/Window.h>
+#include <LibWeb/Infra/Strings.h>
 #include <LibWeb/Layout/Viewport.h>
 #include <LibWeb/Loader/ContentFilter.h>
 #include <LibWeb/Loader/ProxyMappings.h>
@@ -705,10 +706,17 @@ void ConnectionFromClient::replace_dom_node_attribute(i32 node_id, String const&
         return;
 
     auto& element = static_cast<Web::DOM::Element&>(*dom_node);
-    element.remove_attribute(name);
+    bool should_remove_attribute = true;
 
-    for (auto const& attribute : replacement_attributes)
+    for (auto const& attribute : replacement_attributes) {
+        if (should_remove_attribute && Web::Infra::is_ascii_case_insensitive_match(name, attribute.name))
+            should_remove_attribute = false;
+
         element.set_attribute(attribute.name, attribute.value).release_value_but_fixme_should_propagate_errors();
+    }
+
+    if (should_remove_attribute)
+        element.remove_attribute(name);
 }
 
 void ConnectionFromClient::remove_dom_node(i32 node_id)

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -711,6 +711,24 @@ void ConnectionFromClient::replace_dom_node_attribute(i32 node_id, String const&
         element.set_attribute(attribute.name, attribute.value).release_value_but_fixme_should_propagate_errors();
 }
 
+void ConnectionFromClient::remove_dom_node(i32 node_id)
+{
+    auto* active_document = page().page().top_level_browsing_context().active_document();
+    if (!active_document)
+        return;
+
+    auto* dom_node = Web::DOM::Node::from_unique_id(node_id);
+    if (!dom_node)
+        return;
+
+    dom_node->remove();
+
+    // FIXME: When nodes are removed from the DOM, the associated layout nodes become stale and still
+    //        remain in the layout tree. This has to be fixed, this just causes everything to be recomputed
+    //        which really hurts performance.
+    active_document->force_layout();
+}
+
 void ConnectionFromClient::initialize_js_console(Badge<PageClient>, Web::DOM::Document& document)
 {
     auto& realm = document.realm();

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -686,6 +686,18 @@ Messages::WebContentServer::SetDomNodeTagResponse ConnectionFromClient::set_dom_
     return new_element->unique_id();
 }
 
+void ConnectionFromClient::add_dom_node_attributes(i32 node_id, Vector<WebView::Attribute> const& attributes)
+{
+    auto* dom_node = Web::DOM::Node::from_unique_id(node_id);
+    if (!dom_node || !dom_node->is_element())
+        return;
+
+    auto& element = static_cast<Web::DOM::Element&>(*dom_node);
+
+    for (auto const& attribute : attributes)
+        element.set_attribute(attribute.name, attribute.value).release_value_but_fixme_should_propagate_errors();
+}
+
 void ConnectionFromClient::replace_dom_node_attribute(i32 node_id, String const& name, Vector<WebView::Attribute> const& replacement_attributes)
 {
     auto* dom_node = Web::DOM::Node::from_unique_id(node_id);

--- a/Userland/Services/WebContent/ConnectionFromClient.h
+++ b/Userland/Services/WebContent/ConnectionFromClient.h
@@ -80,6 +80,7 @@ private:
     virtual Messages::WebContentServer::SetDomNodeTagResponse set_dom_node_tag(i32 node_id, String const& name) override;
     virtual void add_dom_node_attributes(i32 node_id, Vector<WebView::Attribute> const& attributes) override;
     virtual void replace_dom_node_attribute(i32 node_id, String const& name, Vector<WebView::Attribute> const& replacement_attributes) override;
+    virtual void remove_dom_node(i32 node_id) override;
 
     virtual Messages::WebContentServer::DumpLayoutTreeResponse dump_layout_tree() override;
     virtual Messages::WebContentServer::DumpPaintTreeResponse dump_paint_tree() override;

--- a/Userland/Services/WebContent/ConnectionFromClient.h
+++ b/Userland/Services/WebContent/ConnectionFromClient.h
@@ -78,6 +78,7 @@ private:
 
     virtual void set_dom_node_text(i32 node_id, String const& text) override;
     virtual Messages::WebContentServer::SetDomNodeTagResponse set_dom_node_tag(i32 node_id, String const& name) override;
+    virtual void add_dom_node_attributes(i32 node_id, Vector<WebView::Attribute> const& attributes) override;
     virtual void replace_dom_node_attribute(i32 node_id, String const& name, Vector<WebView::Attribute> const& replacement_attributes) override;
 
     virtual Messages::WebContentServer::DumpLayoutTreeResponse dump_layout_tree() override;

--- a/Userland/Services/WebContent/PageClient.cpp
+++ b/Userland/Services/WebContent/PageClient.cpp
@@ -533,19 +533,29 @@ void PageClient::inspector_did_set_dom_node_tag(i32 node_id, String const& tag)
     client().async_inspector_did_set_dom_node_tag(node_id, tag);
 }
 
-void PageClient::inspector_did_replace_dom_node_attribute(i32 node_id, String const& name, JS::NonnullGCPtr<Web::DOM::NamedNodeMap> replacement_attributes)
+static Vector<WebView::Attribute> named_node_map_to_vector(JS::NonnullGCPtr<Web::DOM::NamedNodeMap> map)
 {
     Vector<WebView::Attribute> attributes;
-    attributes.ensure_capacity(replacement_attributes->length());
+    attributes.ensure_capacity(map->length());
 
-    for (size_t i = 0; i < replacement_attributes->length(); ++i) {
-        auto const* attribute = replacement_attributes->item(i);
+    for (size_t i = 0; i < map->length(); ++i) {
+        auto const* attribute = map->item(i);
         VERIFY(attribute);
 
         attributes.empend(attribute->name().to_string(), attribute->value());
     }
 
-    client().async_inspector_did_replace_dom_node_attribute(node_id, name, move(attributes));
+    return attributes;
+}
+
+void PageClient::inspector_did_add_dom_node_attributes(i32 node_id, JS::NonnullGCPtr<Web::DOM::NamedNodeMap> attributes)
+{
+    client().async_inspector_did_add_dom_node_attributes(node_id, named_node_map_to_vector(attributes));
+}
+
+void PageClient::inspector_did_replace_dom_node_attribute(i32 node_id, String const& name, JS::NonnullGCPtr<Web::DOM::NamedNodeMap> replacement_attributes)
+{
+    client().async_inspector_did_replace_dom_node_attribute(node_id, name, named_node_map_to_vector(replacement_attributes));
 }
 
 void PageClient::inspector_did_request_dom_tree_context_menu(i32 node_id, Web::CSSPixelPoint position, String const& type, Optional<String> const& tag_or_attribute_name)

--- a/Userland/Services/WebContent/PageClient.cpp
+++ b/Userland/Services/WebContent/PageClient.cpp
@@ -548,6 +548,11 @@ void PageClient::inspector_did_replace_dom_node_attribute(i32 node_id, String co
     client().async_inspector_did_replace_dom_node_attribute(node_id, name, move(attributes));
 }
 
+void PageClient::inspector_did_request_dom_tree_context_menu(i32 node_id, Web::CSSPixelPoint position, String const& type, Optional<String> const& tag_or_attribute_name)
+{
+    client().async_inspector_did_request_dom_tree_context_menu(node_id, page().css_to_device_point(position).to_type<int>(), type, tag_or_attribute_name);
+}
+
 void PageClient::inspector_did_execute_console_script(String const& script)
 {
     client().async_inspector_did_execute_console_script(script);

--- a/Userland/Services/WebContent/PageClient.h
+++ b/Userland/Services/WebContent/PageClient.h
@@ -125,6 +125,7 @@ private:
     virtual void inspector_did_select_dom_node(i32 node_id, Optional<Web::CSS::Selector::PseudoElement> const& pseudo_element) override;
     virtual void inspector_did_set_dom_node_text(i32 node_id, String const& text) override;
     virtual void inspector_did_set_dom_node_tag(i32 node_id, String const& tag) override;
+    virtual void inspector_did_add_dom_node_attributes(i32 node_id, JS::NonnullGCPtr<Web::DOM::NamedNodeMap> attributes) override;
     virtual void inspector_did_replace_dom_node_attribute(i32 node_id, String const& name, JS::NonnullGCPtr<Web::DOM::NamedNodeMap> replacement_attributes) override;
     virtual void inspector_did_request_dom_tree_context_menu(i32 node_id, Web::CSSPixelPoint position, String const& type, Optional<String> const& tag_or_attribute_name) override;
     virtual void inspector_did_execute_console_script(String const& script) override;

--- a/Userland/Services/WebContent/PageClient.h
+++ b/Userland/Services/WebContent/PageClient.h
@@ -126,6 +126,7 @@ private:
     virtual void inspector_did_set_dom_node_text(i32 node_id, String const& text) override;
     virtual void inspector_did_set_dom_node_tag(i32 node_id, String const& tag) override;
     virtual void inspector_did_replace_dom_node_attribute(i32 node_id, String const& name, JS::NonnullGCPtr<Web::DOM::NamedNodeMap> replacement_attributes) override;
+    virtual void inspector_did_request_dom_tree_context_menu(i32 node_id, Web::CSSPixelPoint position, String const& type, Optional<String> const& tag_or_attribute_name) override;
     virtual void inspector_did_execute_console_script(String const& script) override;
 
     Web::Layout::Viewport* layout_root();

--- a/Userland/Services/WebContent/WebContentClient.ipc
+++ b/Userland/Services/WebContent/WebContentClient.ipc
@@ -75,6 +75,7 @@ endpoint WebContentClient
     inspector_did_select_dom_node(i32 node_id, Optional<Web::CSS::Selector::PseudoElement> pseudo_element) =|
     inspector_did_set_dom_node_text(i32 node_id, String text) =|
     inspector_did_set_dom_node_tag(i32 node_id, String tag) =|
+    inspector_did_add_dom_node_attributes(i32 node_id, Vector<WebView::Attribute> attributes) =|
     inspector_did_replace_dom_node_attribute(i32 node_id, String name, Vector<WebView::Attribute> replacement_attributes) =|
     inspector_did_request_dom_tree_context_menu(i32 node_id, Gfx::IntPoint position, String type, Optional<String> tag_or_attribute_name) =|
     inspector_did_execute_console_script(String script) =|

--- a/Userland/Services/WebContent/WebContentClient.ipc
+++ b/Userland/Services/WebContent/WebContentClient.ipc
@@ -76,6 +76,7 @@ endpoint WebContentClient
     inspector_did_set_dom_node_text(i32 node_id, String text) =|
     inspector_did_set_dom_node_tag(i32 node_id, String tag) =|
     inspector_did_replace_dom_node_attribute(i32 node_id, String name, Vector<WebView::Attribute> replacement_attributes) =|
+    inspector_did_request_dom_tree_context_menu(i32 node_id, Gfx::IntPoint position, String type, Optional<String> tag_or_attribute_name) =|
     inspector_did_execute_console_script(String script) =|
 
 }

--- a/Userland/Services/WebContent/WebContentServer.ipc
+++ b/Userland/Services/WebContent/WebContentServer.ipc
@@ -50,6 +50,7 @@ endpoint WebContentServer
     set_dom_node_tag(i32 node_id, String name) => (Optional<i32> node_id)
     add_dom_node_attributes(i32 node_id, Vector<WebView::Attribute> attributes) =|
     replace_dom_node_attribute(i32 node_id, String name, Vector<WebView::Attribute> replacement_attributes) =|
+    remove_dom_node(i32 node_id) =|
 
     take_document_screenshot() => (Gfx::ShareableBitmap data)
 

--- a/Userland/Services/WebContent/WebContentServer.ipc
+++ b/Userland/Services/WebContent/WebContentServer.ipc
@@ -48,6 +48,7 @@ endpoint WebContentServer
 
     set_dom_node_text(i32 node_id, String text) =|
     set_dom_node_tag(i32 node_id, String name) => (Optional<i32> node_id)
+    add_dom_node_attributes(i32 node_id, Vector<WebView::Attribute> attributes) =|
     replace_dom_node_attribute(i32 node_id, String name, Vector<WebView::Attribute> replacement_attributes) =|
 
     take_document_screenshot() => (Gfx::ShareableBitmap data)


### PR DESCRIPTION
This lets you:
* Remove DOM nodes
* Add DOM attributes
* Remove DOM attributes
* Instigate editing DOM node text/tag/attribute as an alternative to double-clicking

https://github.com/SerenityOS/serenity/assets/5600524/9f54e9fc-975c-4292-9816-3de70ada7559

