### PR TITLE
LibPDF: Fix decoding of IndexedColorSpace for palette sizes != 255

### DIFF
--- a/Userland/Libraries/LibPDF/ColorSpace.cpp
+++ b/Userland/Libraries/LibPDF/ColorSpace.cpp
@@ -689,7 +689,7 @@ PDFErrorOr<Color> IndexedColorSpace::color(ReadonlySpan<Value> arguments) const
 
 Vector<float> IndexedColorSpace::default_decode() const
 {
-    return { 0.0, static_cast<float>(m_hival) };
+    return { 0.0, 255.0 };
 }
 
 PDFErrorOr<NonnullRefPtr<SeparationColorSpace>> SeparationColorSpace::create(Document* document, Vector<Value>&& parameters)


### PR DESCRIPTION
Previously, we were scaling palette indices from 0..(palette_size - 1) to 0..255 before using them as index into the palette. Instead, do not scale palette indices before using them as indices.

(Renderer::load_image() uses `component_value_decoders.empend( .0f, 255.0f, dmin, dmax)`, so to get an identity mapping, we have to return `0, 255` from IndexedColorSpace::default_decode()).

Fixes rendering of the gradient on page 5 of 0000277.pdf.