### PR TITLE
LibLine: Remove duplicate members in `CompletionSuggestion`

### DIFF
--- a/Userland/Libraries/LibCodeComprehension/Shell/ShellComprehensionEngine.cpp
+++ b/Userland/Libraries/LibCodeComprehension/Shell/ShellComprehensionEngine.cpp
@@ -150,7 +150,7 @@ Vector<CodeComprehension::AutocompleteResultEntry> ShellComprehensionEngine::get
     auto completions = const_cast<::Shell::AST::Node*>(document.node.ptr())->complete_for_editor(shell(), offset_in_file, hit_test).release_value_but_fixme_should_propagate_errors();
     Vector<CodeComprehension::AutocompleteResultEntry> entries;
     for (auto& completion : completions)
-        entries.append({ completion.text_string, completion.input_offset });
+        entries.append({ completion.text_string(), completion.input_offset });
 
     return entries;
 }

--- a/Userland/Libraries/LibLine/Editor.cpp
+++ b/Userland/Libraries/LibLine/Editor.cpp
@@ -1176,7 +1176,7 @@ ErrorOr<void> Editor::handle_read_event()
             m_chars_touched_in_the_middle++;
 
             for (auto& view : completion_result.insert)
-                insert(view);
+                insert(view.as_string());
 
             auto stderr_stream = TRY(Core::File::standard_error());
             TRY(reposition_cursor(*stderr_stream));

--- a/Userland/Libraries/LibLine/SuggestionManager.h
+++ b/Userland/Libraries/LibLine/SuggestionManager.h
@@ -8,14 +8,13 @@
 
 #include <AK/DeprecatedString.h>
 #include <AK/Forward.h>
+#include <AK/String.h>
 #include <AK/Utf32View.h>
 #include <AK/Utf8View.h>
 #include <LibLine/Style.h>
 
 namespace Line {
 
-// FIXME: These objects are pretty heavy since they store two copies of text
-//        somehow get rid of one.
 struct CompletionSuggestion {
 private:
     struct ForSearchTag {
@@ -30,8 +29,8 @@ public:
     {
     }
 
-    CompletionSuggestion(DeprecatedString const& completion, ForSearchTag)
-        : text_string(completion)
+    CompletionSuggestion(StringView completion, ForSearchTag)
+        : text(MUST(String::from_utf8(completion)))
     {
     }
 
@@ -44,12 +43,12 @@ public:
 
     bool operator==(CompletionSuggestion const& suggestion) const
     {
-        return suggestion.text_string == text_string;
+        return suggestion.text == text;
     }
 
-    Vector<u32> text;
-    Vector<u32> trailing_trivia;
-    Vector<u32> display_trivia;
+    String text;
+    String trailing_trivia;
+    String display_trivia;
     Style style;
     size_t start_index { 0 };
     size_t input_offset { 0 };
@@ -57,11 +56,11 @@ public:
     size_t invariant_offset { 0 };
     bool allow_commit_without_listing { true };
 
-    Utf32View text_view;
-    Utf32View trivia_view;
-    Utf32View display_trivia_view;
-    DeprecatedString text_string;
-    DeprecatedString display_trivia_string;
+    Utf8View text_view() const { return text.code_points(); }
+    Utf8View trivia_view() const { return trailing_trivia.code_points(); }
+    Utf8View display_trivia_view() const { return display_trivia.code_points(); }
+    StringView text_string() const { return text.bytes_as_string_view(); }
+    StringView display_trivia_string() const { return display_trivia.bytes_as_string_view(); }
     bool is_valid { false };
 };
 
@@ -101,7 +100,7 @@ public:
         // This bit of data will be removed, but restored if the suggestion is rejected.
         size_t static_offset_from_cursor { 0 };
 
-        Vector<Utf32View> insert {};
+        Vector<Utf8View> insert {};
 
         Optional<Style> style_to_apply {};
 

--- a/Userland/Libraries/LibLine/XtermSuggestionDisplay.cpp
+++ b/Userland/Libraries/LibLine/XtermSuggestionDisplay.cpp
@@ -26,9 +26,9 @@ ErrorOr<void> XtermSuggestionDisplay::display(SuggestionManager const& manager)
 
     manager.set_start_index(0);
     TRY(manager.for_each_suggestion([&](auto& suggestion, auto) {
-        longest_suggestion_length = max(longest_suggestion_length, suggestion.text_view.length() + suggestion.display_trivia_view.length());
-        longest_suggestion_byte_length = max(longest_suggestion_byte_length, suggestion.text_string.length() + suggestion.display_trivia_string.length());
-        longest_suggestion_byte_length_without_trivia = max(longest_suggestion_byte_length_without_trivia, suggestion.text_string.length());
+        longest_suggestion_length = max(longest_suggestion_length, suggestion.text_view().length() + suggestion.display_trivia_view().length());
+        longest_suggestion_byte_length = max(longest_suggestion_byte_length, suggestion.text_string().length() + suggestion.display_trivia_string().length());
+        longest_suggestion_byte_length_without_trivia = max(longest_suggestion_byte_length_without_trivia, suggestion.text_string().length());
         return IterationDecision::Continue;
     }));
 
@@ -65,9 +65,9 @@ ErrorOr<void> XtermSuggestionDisplay::display(SuggestionManager const& manager)
         manager.set_start_index(0);
         size_t page_start = 0;
         TRY(manager.for_each_suggestion([&](auto& suggestion, auto index) {
-            size_t next_column = num_printed + suggestion.text_view.length() + longest_suggestion_length + 2;
+            size_t next_column = num_printed + suggestion.text_view().length() + longest_suggestion_length + 2;
             if (next_column > m_num_columns) {
-                auto lines = (suggestion.text_view.length() + m_num_columns - 1) / m_num_columns;
+                auto lines = (suggestion.text_view().length() + m_num_columns - 1) / m_num_columns;
                 lines_used += lines;
                 num_printed = 0;
             }
@@ -94,10 +94,10 @@ ErrorOr<void> XtermSuggestionDisplay::display(SuggestionManager const& manager)
 
     manager.set_start_index(m_pages[page_index].start);
     TRY(manager.for_each_suggestion([&](auto& suggestion, auto index) -> ErrorOr<IterationDecision> {
-        size_t next_column = num_printed + suggestion.text_view.length() + longest_suggestion_length + 2;
+        size_t next_column = num_printed + suggestion.text_view().length() + longest_suggestion_length + 2;
 
         if (next_column > m_num_columns) {
-            auto lines = (suggestion.text_view.length() + m_num_columns - 1) / m_num_columns;
+            auto lines = (suggestion.text_view().length() + m_num_columns - 1) / m_num_columns;
             lines_used += lines;
             TRY(stderr_stream->write_until_depleted("\n"sv.bytes()));
             num_printed = 0;
@@ -115,10 +115,10 @@ ErrorOr<void> XtermSuggestionDisplay::display(SuggestionManager const& manager)
 
         if (spans_entire_line) {
             num_printed += m_num_columns;
-            TRY(stderr_stream->write_until_depleted(suggestion.text_string.bytes()));
-            TRY(stderr_stream->write_until_depleted(suggestion.display_trivia_string.bytes()));
+            TRY(stderr_stream->write_until_depleted(suggestion.text_string().bytes()));
+            TRY(stderr_stream->write_until_depleted(suggestion.display_trivia_string().bytes()));
         } else {
-            auto field = DeprecatedString::formatted("{: <{}}  {}", suggestion.text_string, longest_suggestion_byte_length_without_trivia, suggestion.display_trivia_string);
+            auto field = DeprecatedString::formatted("{: <{}}  {}", suggestion.text_string(), longest_suggestion_byte_length_without_trivia, suggestion.display_trivia_string());
             TRY(stderr_stream->write_until_depleted(DeprecatedString::formatted("{: <{}}", field, longest_suggestion_byte_length + 2).bytes()));
             num_printed += longest_suggestion_length + 2;
         }

--- a/Userland/Shell/AST.cpp
+++ b/Userland/Shell/AST.cpp
@@ -349,7 +349,7 @@ ErrorOr<Vector<Line::CompletionSuggestion>> Node::complete_for_editor(Shell& she
         auto set_results_trivia = [enclosure_type](Vector<Line::CompletionSuggestion>&& suggestions) {
             if (enclosure_type != StringLiteral::EnclosureType::None) {
                 for (auto& entry : suggestions)
-                    entry.trailing_trivia = { static_cast<u32>(enclosure_type == StringLiteral::EnclosureType::SingleQuotes ? '\'' : '"') };
+                    entry.trailing_trivia = String::from_code_point(static_cast<u32>(enclosure_type == StringLiteral::EnclosureType::SingleQuotes ? '\'' : '"'));
             }
             return suggestions;
         };

--- a/Userland/Shell/Shell.cpp
+++ b/Userland/Shell/Shell.cpp
@@ -1657,7 +1657,7 @@ Vector<Line::CompletionSuggestion> Shell::complete_path(StringView base, StringV
 
     // The results of DirIterator are in the order they appear on-disk.
     // Instead, return suggestions in lexicographical order.
-    quick_sort(suggestions, [](auto& a, auto& b) { return a.text_string < b.text_string; });
+    quick_sort(suggestions, [](auto& a, auto& b) { return a.text_string() < b.text_string(); });
 
     return suggestions;
 }


### PR DESCRIPTION
Previously, we stored two representations of the same string in `CompletionSuggestion` object: one for the bytes and the other for the code points corresponding to those bytes. To minimize duplication, this patch combine both representations into a single UTF-8 string, which is already supported by our new String class.

Following this update, we successfully reduce the size of each object from 376 bytes to 256 bytes