### PR TITLE
LibPDF: Various fixes related to indexed bitmaps

### DIFF
--- a/Userland/Libraries/LibPDF/ColorSpace.cpp
+++ b/Userland/Libraries/LibPDF/ColorSpace.cpp
@@ -649,6 +649,8 @@ PDFErrorOr<NonnullRefPtr<ColorSpace>> IndexedColorSpace::create(Document* docume
     // "The hival parameter is an integer that specifies the maximum valid index value. In other words,
     // the color table is to be indexed by integers in the range 0 to hival. hival can be no greater than 255"
     auto hival = TRY(document->resolve_to<int>(parameters[1]));
+    if (hival < 0 || hival > 255)
+        return Error { Error::Type::MalformedPDF, "Indexed color space hival out of range" };
 
     // "The color table is defined by the lookup parameter, which can be either a stream or (in PDF 1.2) a byte string.
     //  It provides the mapping between index values and the corresponding colors in the base color space.

--- a/Userland/Libraries/LibPDF/ColorSpace.cpp
+++ b/Userland/Libraries/LibPDF/ColorSpace.cpp
@@ -669,8 +669,15 @@ PDFErrorOr<NonnullRefPtr<ColorSpace>> IndexedColorSpace::create(Document* docume
         return Error { Error::Type::MalformedPDF, "Indexed color space expects stream or string for third arg" };
     }
 
-    if (static_cast<int>(lookup.size()) != (hival + 1) * base->number_of_components())
+    size_t needed_size = (hival + 1) * base->number_of_components();
+    if (lookup.size() - 1 == needed_size) {
+        // FIXME: Could do this if lookup.size() > needed_size generally, but so far I've only seen files that had one byte too much.
+        lookup.resize(needed_size);
+    }
+    if (lookup.size() != needed_size) {
+        dbgln("lookup size {} doesn't match hival {} and base components {}", lookup.size(), hival, base->number_of_components());
         return Error { Error::Type::MalformedPDF, "Indexed color space lookup table doesn't match size" };
+    }
 
     auto color_space = adopt_ref(*new IndexedColorSpace(move(base)));
     color_space->m_hival = hival;


### PR DESCRIPTION
After #22185, some images that previously (incorrectly) decoded successfully started to fail to decode. The first commit fixes that. The second fixes some slanted images. The third makes a few more images show up. The fourth is a no-op in practice.