### PR TITLE
LibJS: Stop converting between Object <-> IteratorRecord all the time

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -1749,16 +1749,11 @@ Bytecode::CodeGenerationErrorOr<void> YieldExpression::generate_bytecode(Bytecod
 
         // 5. Let iterator be iteratorRecord.[[Iterator]].
         auto iterator_register = generator.allocate_register();
-        auto iterator_identifier = generator.intern_identifier("iterator");
-        generator.emit_get_by_id(iterator_identifier);
-        generator.emit<Bytecode::Op::Store>(iterator_register);
+        generator.emit<Bytecode::Op::GetObjectFromIteratorRecord>(iterator_register, iterator_record_register);
 
         // Cache iteratorRecord.[[NextMethod]] for use in step 7.a.i.
         auto next_method_register = generator.allocate_register();
-        auto next_method_identifier = generator.intern_identifier("next");
-        generator.emit<Bytecode::Op::Load>(iterator_record_register);
-        generator.emit_get_by_id(next_method_identifier);
-        generator.emit<Bytecode::Op::Store>(next_method_register);
+        generator.emit<Bytecode::Op::GetNextMethodFromIteratorRecord>(next_method_register, iterator_record_register);
 
         // 6. Let received be NormalCompletion(undefined).
         // See get_received_completion_type_and_value above.

--- a/Userland/Libraries/LibJS/Bytecode/CommonImplementations.h
+++ b/Userland/Libraries/LibJS/Bytecode/CommonImplementations.h
@@ -35,8 +35,6 @@ MarkedVector<Value> argument_list_evaluation(VM&, Value arguments);
 ThrowCompletionOr<void> create_variable(VM&, DeprecatedFlyString const& name, Op::EnvironmentMode, bool is_global, bool is_immutable, bool is_strict);
 ThrowCompletionOr<ECMAScriptFunctionObject*> new_class(VM&, Value super_class, ClassExpression const&, Optional<IdentifierTableIndex> const& lhs_name);
 ThrowCompletionOr<NonnullGCPtr<Object>> super_call_with_argument_array(VM&, Value argument_array, bool is_synthetic);
-Object* iterator_to_object(VM&, IteratorRecord);
-IteratorRecord object_to_iterator(VM&, Object&);
 ThrowCompletionOr<NonnullGCPtr<Array>> iterator_to_array(VM&, Value iterator);
 ThrowCompletionOr<void> append(VM& vm, Value lhs, Value rhs, bool is_spread);
 ThrowCompletionOr<Value> delete_by_id(Bytecode::Interpreter&, Value base, IdentifierTableIndex identifier);

--- a/Userland/Libraries/LibJS/Bytecode/Instruction.h
+++ b/Userland/Libraries/LibJS/Bytecode/Instruction.h
@@ -46,8 +46,10 @@
     O(GetByValueWithThis)              \
     O(GetCalleeAndThisFromEnvironment) \
     O(GetIterator)                     \
+    O(GetObjectFromIteratorRecord)     \
     O(GetMethod)                       \
     O(GetNewTarget)                    \
+    O(GetNextMethodFromIteratorRecord) \
     O(GetImportMeta)                   \
     O(GetObjectPropertyIterator)       \
     O(GetPrivateById)                  \

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -1373,6 +1373,46 @@ private:
     IteratorHint m_hint { IteratorHint::Sync };
 };
 
+class GetObjectFromIteratorRecord final : public Instruction {
+public:
+    GetObjectFromIteratorRecord(Register object, Register iterator_record)
+        : Instruction(Type::GetObjectFromIteratorRecord, sizeof(*this))
+        , m_object(object)
+        , m_iterator_record(iterator_record)
+    {
+    }
+
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    DeprecatedString to_deprecated_string_impl(Bytecode::Executable const&) const;
+
+    Register object() const { return m_object; }
+    Register iterator_record() const { return m_iterator_record; }
+
+private:
+    Register m_object;
+    Register m_iterator_record;
+};
+
+class GetNextMethodFromIteratorRecord final : public Instruction {
+public:
+    GetNextMethodFromIteratorRecord(Register next_method, Register iterator_record)
+        : Instruction(Type::GetNextMethodFromIteratorRecord, sizeof(*this))
+        , m_next_method(next_method)
+        , m_iterator_record(iterator_record)
+    {
+    }
+
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    DeprecatedString to_deprecated_string_impl(Bytecode::Executable const&) const;
+
+    Register next_method() const { return m_next_method; }
+    Register iterator_record() const { return m_iterator_record; }
+
+private:
+    Register m_next_method;
+    Register m_iterator_record;
+};
+
 class GetMethod final : public Instruction {
 public:
     GetMethod(IdentifierTableIndex property)
@@ -1551,7 +1591,6 @@ public:
 private:
     size_t m_index;
 };
-
 }
 
 namespace JS::Bytecode {

--- a/Userland/Libraries/LibJS/Forward.h
+++ b/Userland/Libraries/LibJS/Forward.h
@@ -187,7 +187,7 @@ struct ImportEntry;
 class ImportStatement;
 class Identifier;
 class Intrinsics;
-struct IteratorRecord;
+class IteratorRecord;
 class MemberExpression;
 class MetaProperty;
 class Module;

--- a/Userland/Libraries/LibJS/JIT/Compiler.h
+++ b/Userland/Libraries/LibJS/JIT/Compiler.h
@@ -114,6 +114,8 @@ private:
         O(BlockDeclarationInstantiation, block_declaration_instantiation)        \
         O(SuperCallWithArgumentArray, super_call_with_argument_array)            \
         O(GetIterator, get_iterator)                                             \
+        O(GetObjectFromIteratorRecord, get_object_from_iterator_record)          \
+        O(GetNextMethodFromIteratorRecord, get_next_method_from_iterator_record) \
         O(IteratorNext, iterator_next)                                           \
         O(IteratorResultDone, iterator_result_done)                              \
         O(ThrowIfNotObject, throw_if_not_object)                                 \

--- a/Userland/Libraries/LibJS/Runtime/ArrayConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayConstructor.cpp
@@ -338,7 +338,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayConstructor::from_async)
         }
 
         // e. Let iteratorRecord be undefined.
-        Optional<IteratorRecord> iterator_record;
+        GCPtr<IteratorRecord> iterator_record;
 
         // f. If usingAsyncIterator is not undefined, then
         if (using_async_iterator) {
@@ -354,7 +354,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayConstructor::from_async)
         }
 
         // h. If iteratorRecord is not undefined, then
-        if (iterator_record.has_value()) {
+        if (iterator_record) {
             GCPtr<Object> array;
 
             // i. If IsConstructor(C) is true, then
@@ -377,7 +377,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayConstructor::from_async)
                     auto error = vm.throw_completion<TypeError>(ErrorType::ArrayMaxSize);
 
                     // b. Return ? AsyncIteratorClose(iteratorRecord, error).
-                    return *TRY(async_iterator_close(vm, iterator_record.value(), move(error)));
+                    return *TRY(async_iterator_close(vm, *iterator_record, move(error)));
                 }
 
                 // 2. Let Pk be ! ToString(𝔽(k)).
@@ -433,7 +433,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayConstructor::from_async)
 
                     // b. IfAbruptCloseAsyncIterator(mappedValue, iteratorRecord).
                     if (mapped_value_or_error.is_error()) {
-                        TRY(async_iterator_close(vm, iterator_record.value(), mapped_value_or_error));
+                        TRY(async_iterator_close(vm, *iterator_record, mapped_value_or_error));
                         return mapped_value_or_error;
                     }
 
@@ -442,7 +442,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayConstructor::from_async)
 
                     // d. IfAbruptCloseAsyncIterator(mappedValue, iteratorRecord).
                     if (mapped_value_or_error.is_error()) {
-                        TRY(async_iterator_close(vm, iterator_record.value(), mapped_value_or_error));
+                        TRY(async_iterator_close(vm, *iterator_record, mapped_value_or_error));
                         return mapped_value_or_error;
                     }
 
@@ -458,7 +458,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayConstructor::from_async)
 
                 // 9. If defineStatus is an abrupt completion, return ? AsyncIteratorClose(iteratorRecord, defineStatus).
                 if (define_status.is_error())
-                    return *TRY(iterator_close(vm, iterator_record.value(), define_status.release_error()));
+                    return *TRY(iterator_close(vm, *iterator_record, define_status.release_error()));
 
                 // 10. Set k to k + 1.
             }

--- a/Userland/Libraries/LibJS/Runtime/AsyncFromSyncIterator.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AsyncFromSyncIterator.cpp
@@ -13,12 +13,12 @@ namespace JS {
 
 JS_DEFINE_ALLOCATOR(AsyncFromSyncIterator);
 
-NonnullGCPtr<AsyncFromSyncIterator> AsyncFromSyncIterator::create(Realm& realm, IteratorRecord sync_iterator_record)
+NonnullGCPtr<AsyncFromSyncIterator> AsyncFromSyncIterator::create(Realm& realm, NonnullGCPtr<IteratorRecord> sync_iterator_record)
 {
     return realm.heap().allocate<AsyncFromSyncIterator>(realm, realm, sync_iterator_record);
 }
 
-AsyncFromSyncIterator::AsyncFromSyncIterator(Realm& realm, IteratorRecord sync_iterator_record)
+AsyncFromSyncIterator::AsyncFromSyncIterator(Realm& realm, NonnullGCPtr<IteratorRecord> sync_iterator_record)
     : Object(ConstructWithPrototypeTag::Tag, realm.intrinsics().async_from_sync_iterator_prototype())
     , m_sync_iterator_record(sync_iterator_record)
 {
@@ -27,8 +27,7 @@ AsyncFromSyncIterator::AsyncFromSyncIterator(Realm& realm, IteratorRecord sync_i
 void AsyncFromSyncIterator::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(m_sync_iterator_record.iterator);
-    visitor.visit(m_sync_iterator_record.next_method);
+    visitor.visit(m_sync_iterator_record);
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/AsyncFromSyncIterator.h
+++ b/Userland/Libraries/LibJS/Runtime/AsyncFromSyncIterator.h
@@ -18,7 +18,7 @@ class AsyncFromSyncIterator final : public Object {
     JS_DECLARE_ALLOCATOR(AsyncFromSyncIterator);
 
 public:
-    static NonnullGCPtr<AsyncFromSyncIterator> create(Realm&, IteratorRecord sync_iterator_record);
+    static NonnullGCPtr<AsyncFromSyncIterator> create(Realm&, NonnullGCPtr<IteratorRecord> sync_iterator_record);
 
     virtual ~AsyncFromSyncIterator() override = default;
 
@@ -28,9 +28,9 @@ public:
     IteratorRecord const& sync_iterator_record() const { return m_sync_iterator_record; }
 
 private:
-    AsyncFromSyncIterator(Realm&, IteratorRecord sync_iterator_record);
+    AsyncFromSyncIterator(Realm&, NonnullGCPtr<IteratorRecord> sync_iterator_record);
 
-    IteratorRecord m_sync_iterator_record; // [[SyncIteratorRecord]]
+    NonnullGCPtr<IteratorRecord> m_sync_iterator_record; // [[SyncIteratorRecord]]
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/AsyncFromSyncIteratorPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AsyncFromSyncIteratorPrototype.cpp
@@ -199,7 +199,7 @@ JS_DEFINE_NATIVE_FUNCTION(AsyncFromSyncIteratorPrototype::throw_)
 }
 
 // 27.1.4.1 CreateAsyncFromSyncIterator ( syncIteratorRecord ), https://tc39.es/ecma262/#sec-createasyncfromsynciterator
-IteratorRecord create_async_from_sync_iterator(VM& vm, IteratorRecord sync_iterator_record)
+NonnullGCPtr<IteratorRecord> create_async_from_sync_iterator(VM& vm, NonnullGCPtr<IteratorRecord> sync_iterator_record)
 {
     auto& realm = *vm.current_realm();
 
@@ -211,7 +211,7 @@ IteratorRecord create_async_from_sync_iterator(VM& vm, IteratorRecord sync_itera
     auto next_method = MUST(async_iterator->get(vm.names.next));
 
     // 4. Let iteratorRecord be the Iterator Record { [[Iterator]]: asyncIterator, [[NextMethod]]: nextMethod, [[Done]]: false }.
-    auto iterator_record = IteratorRecord { .iterator = async_iterator, .next_method = next_method, .done = false };
+    auto iterator_record = vm.heap().allocate<IteratorRecord>(realm, realm, async_iterator, next_method, false);
 
     // 5. Return iteratorRecord.
     return iterator_record;

--- a/Userland/Libraries/LibJS/Runtime/AsyncFromSyncIteratorPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/AsyncFromSyncIteratorPrototype.h
@@ -31,6 +31,6 @@ private:
     JS_DECLARE_NATIVE_FUNCTION(throw_);
 };
 
-IteratorRecord create_async_from_sync_iterator(VM&, IteratorRecord sync_iterator);
+NonnullGCPtr<IteratorRecord> create_async_from_sync_iterator(VM&, NonnullGCPtr<IteratorRecord> sync_iterator);
 
 }

--- a/Userland/Libraries/LibJS/Runtime/IteratorConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/IteratorConstructor.cpp
@@ -70,12 +70,12 @@ JS_DEFINE_NATIVE_FUNCTION(IteratorConstructor::from)
     auto iterator_record = TRY(get_iterator_flattenable(vm, object, StringHandling::IterateStrings));
 
     // 2. Let hasInstance be ? OrdinaryHasInstance(%Iterator%, iteratorRecord.[[Iterator]]).
-    auto has_instance = TRY(ordinary_has_instance(vm, iterator_record.iterator, realm.intrinsics().iterator_constructor()));
+    auto has_instance = TRY(ordinary_has_instance(vm, iterator_record->iterator, realm.intrinsics().iterator_constructor()));
 
     // 3. If hasInstance is true, then
     if (has_instance.is_boolean() && has_instance.as_bool()) {
         // a. Return iteratorRecord.[[Iterator]].
-        return iterator_record.iterator;
+        return iterator_record->iterator;
     }
 
     // 4. Let wrapper be OrdinaryObjectCreate(%WrapForValidIteratorPrototype%, « [[Iterated]] »).

--- a/Userland/Libraries/LibJS/Runtime/IteratorHelper.cpp
+++ b/Userland/Libraries/LibJS/Runtime/IteratorHelper.cpp
@@ -13,12 +13,12 @@ namespace JS {
 
 JS_DEFINE_ALLOCATOR(IteratorHelper);
 
-ThrowCompletionOr<NonnullGCPtr<IteratorHelper>> IteratorHelper::create(Realm& realm, IteratorRecord underlying_iterator, Closure closure, Optional<AbruptClosure> abrupt_closure)
+ThrowCompletionOr<NonnullGCPtr<IteratorHelper>> IteratorHelper::create(Realm& realm, NonnullGCPtr<IteratorRecord> underlying_iterator, Closure closure, Optional<AbruptClosure> abrupt_closure)
 {
     return realm.heap().allocate<IteratorHelper>(realm, realm, realm.intrinsics().iterator_helper_prototype(), move(underlying_iterator), move(closure), move(abrupt_closure));
 }
 
-IteratorHelper::IteratorHelper(Realm& realm, Object& prototype, IteratorRecord underlying_iterator, Closure closure, Optional<AbruptClosure> abrupt_closure)
+IteratorHelper::IteratorHelper(Realm& realm, Object& prototype, NonnullGCPtr<IteratorRecord> underlying_iterator, Closure closure, Optional<AbruptClosure> abrupt_closure)
     : GeneratorObject(realm, prototype, realm.vm().running_execution_context().copy(), "Iterator Helper"sv)
     , m_underlying_iterator(move(underlying_iterator))
     , m_closure(move(closure))
@@ -29,7 +29,7 @@ IteratorHelper::IteratorHelper(Realm& realm, Object& prototype, IteratorRecord u
 void IteratorHelper::visit_edges(Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(m_underlying_iterator.iterator);
+    visitor.visit(m_underlying_iterator);
 }
 
 Value IteratorHelper::result(Value value)

--- a/Userland/Libraries/LibJS/Runtime/IteratorHelper.h
+++ b/Userland/Libraries/LibJS/Runtime/IteratorHelper.h
@@ -22,7 +22,7 @@ public:
     using Closure = JS::SafeFunction<ThrowCompletionOr<Value>(VM&, IteratorHelper&)>;
     using AbruptClosure = JS::SafeFunction<ThrowCompletionOr<Value>(VM&, IteratorHelper&, Completion const&)>;
 
-    static ThrowCompletionOr<NonnullGCPtr<IteratorHelper>> create(Realm&, IteratorRecord, Closure, Optional<AbruptClosure> = {});
+    static ThrowCompletionOr<NonnullGCPtr<IteratorHelper>> create(Realm&, NonnullGCPtr<IteratorRecord>, Closure, Optional<AbruptClosure> = {});
 
     IteratorRecord const& underlying_iterator() const { return m_underlying_iterator; }
 
@@ -33,12 +33,12 @@ public:
     ThrowCompletionOr<Value> close_result(VM&, Completion);
 
 private:
-    IteratorHelper(Realm&, Object& prototype, IteratorRecord, Closure, Optional<AbruptClosure>);
+    IteratorHelper(Realm&, Object& prototype, NonnullGCPtr<IteratorRecord>, Closure, Optional<AbruptClosure>);
 
     virtual void visit_edges(Visitor&) override;
     virtual ThrowCompletionOr<Value> execute(VM&, JS::Completion const& completion) override;
 
-    IteratorRecord m_underlying_iterator; // [[UnderlyingIterator]]
+    NonnullGCPtr<IteratorRecord> m_underlying_iterator; // [[UnderlyingIterator]]
     Closure m_closure;
     Optional<AbruptClosure> m_abrupt_closure;
 

--- a/Userland/Libraries/LibJS/Runtime/Object.h
+++ b/Userland/Libraries/LibJS/Runtime/Object.h
@@ -189,6 +189,7 @@ public:
     virtual bool is_proxy_object() const { return false; }
     virtual bool is_native_function() const { return false; }
     virtual bool is_ecmascript_function_object() const { return false; }
+    virtual bool is_iterator_record() const { return false; }
 
     // B.3.7 The [[IsHTMLDDA]] Internal Slot, https://tc39.es/ecma262/#sec-IsHTMLDDA-internal-slot
     virtual bool is_htmldda() const { return false; }

--- a/Userland/Libraries/LibJS/Runtime/PromiseConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/PromiseConstructor.cpp
@@ -333,7 +333,7 @@ JS_DEFINE_NATIVE_FUNCTION(PromiseConstructor::all)
     // 8. If result is an abrupt completion, then
     if (result.is_error()) {
         // a. If iteratorRecord.[[Done]] is false, set result to Completion(IteratorClose(iteratorRecord, result)).
-        if (!iterator_record.done)
+        if (!iterator_record->done)
             result = iterator_close(vm, iterator_record, result.release_error());
 
         // b. IfAbruptRejectPromise(result, promiseCapability).
@@ -367,7 +367,7 @@ JS_DEFINE_NATIVE_FUNCTION(PromiseConstructor::all_settled)
     // 8. If result is an abrupt completion, then
     if (result.is_error()) {
         // a. If iteratorRecord.[[Done]] is false, set result to Completion(IteratorClose(iteratorRecord, result)).
-        if (!iterator_record.done)
+        if (!iterator_record->done)
             result = iterator_close(vm, iterator_record, result.release_error());
 
         // b. IfAbruptRejectPromise(result, promiseCapability).
@@ -401,7 +401,7 @@ JS_DEFINE_NATIVE_FUNCTION(PromiseConstructor::any)
     // 8. If result is an abrupt completion, then
     if (result.is_error()) {
         // a. If iteratorRecord.[[Done]] is false, set result to Completion(IteratorClose(iteratorRecord, result)).
-        if (!iterator_record.done)
+        if (!iterator_record->done)
             result = iterator_close(vm, iterator_record, result.release_error());
 
         // b. IfAbruptRejectPromise(result, promiseCapability).
@@ -435,7 +435,7 @@ JS_DEFINE_NATIVE_FUNCTION(PromiseConstructor::race)
     // 8. If result is an abrupt completion, then
     if (result.is_error()) {
         // a. If iteratorRecord.[[Done]] is false, set result to Completion(IteratorClose(iteratorRecord, result)).
-        if (!iterator_record.done)
+        if (!iterator_record->done)
             result = iterator_close(vm, iterator_record, result.release_error());
 
         // b. IfAbruptRejectPromise(result, promiseCapability).

--- a/Userland/Libraries/LibJS/Runtime/VM.cpp
+++ b/Userland/Libraries/LibJS/Runtime/VM.cpp
@@ -226,7 +226,7 @@ ThrowCompletionOr<void> VM::binding_initialization(NonnullRefPtr<BindingPattern 
         auto result = iterator_binding_initialization(*target, iterator_record, environment);
 
         // 3. If iteratorRecord.[[Done]] is false, return ? IteratorClose(iteratorRecord, result).
-        if (!iterator_record.done) {
+        if (!iterator_record->done) {
             // iterator_close() always returns a Completion, which ThrowCompletionOr will interpret as a throw
             // completion. So only return the result of iterator_close() if it is indeed a throw completion.
             auto completion = result.is_throw_completion() ? result.release_error() : normal_completion({});


### PR DESCRIPTION
This patch makes IteratorRecord an Object. Although it's not exposed to author code, this does allow us to store it in a VM register.

Now that we can store it in a VM register, we don't need to convert it back and forth between IteratorRecord and Object when accessing it from bytecode.

The big win here is avoiding 3 [[Get]] accesses on every iteration step of for..of loops. There are also a bunch of smaller efficiencies gained.

20% speed-up on this microbenchmark:

    function go(a) {
        for (const p of a) {
        }
    }
    const a = [];
    a.length = 1_000_000;
    go(a);