### PR TITLE
LibJS: Remove dedicated iterator result instructions in favor of GetById

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/Generator.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.cpp
@@ -584,4 +584,14 @@ void Generator::emit_get_by_id_with_this(IdentifierTableIndex id, Register this_
     emit<Op::GetByIdWithThis>(id, this_reg, m_next_property_lookup_cache++);
 }
 
+void Generator::emit_iterator_value()
+{
+    emit_get_by_id(intern_identifier("value"sv));
+}
+
+void Generator::emit_iterator_complete()
+{
+    emit_get_by_id(intern_identifier("done"sv));
+}
+
 }

--- a/Userland/Libraries/LibJS/Bytecode/Generator.h
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.h
@@ -234,6 +234,9 @@ public:
     void emit_get_by_id(IdentifierTableIndex);
     void emit_get_by_id_with_this(IdentifierTableIndex, Register);
 
+    void emit_iterator_value();
+    void emit_iterator_complete();
+
     [[nodiscard]] size_t next_global_variable_cache() { return m_next_global_variable_cache++; }
     [[nodiscard]] size_t next_environment_variable_cache() { return m_next_environment_variable_cache++; }
     [[nodiscard]] size_t next_property_lookup_cache() { return m_next_property_lookup_cache++; }

--- a/Userland/Libraries/LibJS/Bytecode/Instruction.h
+++ b/Userland/Libraries/LibJS/Bytecode/Instruction.h
@@ -65,8 +65,6 @@
     O(InstanceOf)                      \
     O(IteratorClose)                   \
     O(IteratorNext)                    \
-    O(IteratorResultDone)              \
-    O(IteratorResultValue)             \
     O(IteratorToArray)                 \
     O(Jump)                            \
     O(JumpConditional)                 \

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -1287,25 +1287,6 @@ ThrowCompletionOr<void> IteratorNext::execute_impl(Bytecode::Interpreter& interp
     return {};
 }
 
-ThrowCompletionOr<void> IteratorResultDone::execute_impl(Bytecode::Interpreter& interpreter) const
-{
-    auto& vm = interpreter.vm();
-    auto iterator_result = TRY(interpreter.accumulator().to_object(vm));
-
-    auto complete = TRY(iterator_complete(vm, iterator_result));
-    interpreter.accumulator() = Value(complete);
-    return {};
-}
-
-ThrowCompletionOr<void> IteratorResultValue::execute_impl(Bytecode::Interpreter& interpreter) const
-{
-    auto& vm = interpreter.vm();
-    auto iterator_result = TRY(interpreter.accumulator().to_object(vm));
-
-    interpreter.accumulator() = TRY(iterator_value(vm, iterator_result));
-    return {};
-}
-
 ThrowCompletionOr<void> NewClass::execute_impl(Bytecode::Interpreter& interpreter) const
 {
     interpreter.accumulator() = TRY(new_class(interpreter.vm(), interpreter.accumulator(), m_class_expression, m_lhs_name));
@@ -1766,16 +1747,6 @@ DeprecatedString AsyncIteratorClose::to_deprecated_string_impl(Bytecode::Executa
 DeprecatedString IteratorNext::to_deprecated_string_impl(Executable const&) const
 {
     return "IteratorNext";
-}
-
-DeprecatedString IteratorResultDone::to_deprecated_string_impl(Executable const&) const
-{
-    return "IteratorResultDone";
-}
-
-DeprecatedString IteratorResultValue::to_deprecated_string_impl(Executable const&) const
-{
-    return "IteratorResultValue";
 }
 
 DeprecatedString ResolveThisBinding::to_deprecated_string_impl(Bytecode::Executable const&) const

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -1492,28 +1492,6 @@ public:
     DeprecatedString to_deprecated_string_impl(Bytecode::Executable const&) const;
 };
 
-class IteratorResultDone final : public Instruction {
-public:
-    IteratorResultDone()
-        : Instruction(Type::IteratorResultDone, sizeof(*this))
-    {
-    }
-
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
-    DeprecatedString to_deprecated_string_impl(Bytecode::Executable const&) const;
-};
-
-class IteratorResultValue final : public Instruction {
-public:
-    IteratorResultValue()
-        : Instruction(Type::IteratorResultValue, sizeof(*this))
-    {
-    }
-
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
-    DeprecatedString to_deprecated_string_impl(Bytecode::Executable const&) const;
-};
-
 class ResolveThisBinding final : public Instruction {
 public:
     explicit ResolveThisBinding()

--- a/Userland/Libraries/LibJS/JIT/Compiler.cpp
+++ b/Userland/Libraries/LibJS/JIT/Compiler.cpp
@@ -3111,20 +3111,6 @@ void Compiler::compile_iterator_next(Bytecode::Op::IteratorNext const&)
     check_exception();
 }
 
-static Value cxx_iterator_result_done(VM& vm, Value iterator)
-{
-    auto iterator_result = TRY_OR_SET_EXCEPTION(iterator.to_object(vm));
-    return Value(TRY_OR_SET_EXCEPTION(iterator_complete(vm, iterator_result)));
-}
-
-void Compiler::compile_iterator_result_done(Bytecode::Op::IteratorResultDone const&)
-{
-    load_accumulator(ARG1);
-    native_call((void*)cxx_iterator_result_done);
-    store_accumulator(RET);
-    check_exception();
-}
-
 static Value cxx_throw_if_not_object(VM& vm, Value value)
 {
     if (!value.is_object())
@@ -3150,20 +3136,6 @@ void Compiler::compile_throw_if_nullish(Bytecode::Op::ThrowIfNullish const&)
 {
     load_accumulator(ARG1);
     native_call((void*)cxx_throw_if_nullish);
-    check_exception();
-}
-
-static Value cxx_iterator_result_value(VM& vm, Value iterator)
-{
-    auto iterator_result = TRY_OR_SET_EXCEPTION(iterator.to_object(vm));
-    return TRY_OR_SET_EXCEPTION(iterator_value(vm, iterator_result));
-}
-
-void Compiler::compile_iterator_result_value(Bytecode::Op::IteratorResultValue const&)
-{
-    load_accumulator(ARG1);
-    native_call((void*)cxx_iterator_result_value);
-    store_accumulator(RET);
     check_exception();
 }
 

--- a/Userland/Libraries/LibJS/JIT/Compiler.h
+++ b/Userland/Libraries/LibJS/JIT/Compiler.h
@@ -117,10 +117,8 @@ private:
         O(GetObjectFromIteratorRecord, get_object_from_iterator_record)          \
         O(GetNextMethodFromIteratorRecord, get_next_method_from_iterator_record) \
         O(IteratorNext, iterator_next)                                           \
-        O(IteratorResultDone, iterator_result_done)                              \
         O(ThrowIfNotObject, throw_if_not_object)                                 \
         O(ThrowIfNullish, throw_if_nullish)                                      \
-        O(IteratorResultValue, iterator_result_value)                            \
         O(IteratorClose, iterator_close)                                         \
         O(IteratorToArray, iterator_to_array)                                    \
         O(Append, append)                                                        \


### PR DESCRIPTION
When iterating over an iterable, we get back a JS object with the fields "value" and "done".

Before this change, we've had two dedicated instructions for retrieving the two fields: IteratorResultValue and IteratorResultDone. These had no fast path whatsoever and just did a generic [[Get]] access to fetch the corresponding property values.

By replacing the instructions with GetById("value") and GetById("done"), they instantly get caching and JIT fast paths for free, making iterating over iterables much faster. :^)

26% speed-up on this microbenchmark:

    function go(a) {
        for (const p of a) {
        }
    }
    const a = [];
    a.length = 1_000_000;
    go(a);