### PR TITLE
 LibPDF: Add basic tiled, coloured pattern rendering 

### DIFF
--- a/Meta/Lagom/Contrib/MacPDF/MacPDFView.mm
+++ b/Meta/Lagom/Contrib/MacPDF/MacPDFView.mm
@@ -29,7 +29,7 @@ static PDF::PDFErrorOr<NonnullRefPtr<Gfx::Bitmap>> render(PDF::Document& documen
 
     auto bitmap = TRY(Gfx::Bitmap::create(Gfx::BitmapFormat::BGRx8888, page_size));
 
-    auto errors = PDF::Renderer::render(document, page, bitmap, PDF::RenderingPreferences {});
+    auto errors = PDF::Renderer::render(document, page, bitmap, Color::White, PDF::RenderingPreferences {});
     if (errors.is_error()) {
         for (auto const& error : errors.error().errors())
             NSLog(@"warning: %@", @(error.message().characters()));

--- a/Tests/LibPDF/CMakeLists.txt
+++ b/Tests/LibPDF/CMakeLists.txt
@@ -15,6 +15,7 @@ set(TEST_FILES
     non-linearized.pdf
     oss-fuzz-testcase-62065.pdf
     password-is-sup.pdf
+    pattern.pdf
     text.pdf
     type1.pdf
     type3.pdf

--- a/Tests/LibPDF/pattern.pdf
+++ b/Tests/LibPDF/pattern.pdf
@@ -1,0 +1,126 @@
+%PDF-1.7
+%µ¶
+
+1 0 obj
+<</Pages 3 0 R/Type/Catalog>>
+endobj
+
+3 0 obj
+<</Count 1/Kids[5 0 R]/Type/Pages>>
+endobj
+
+5 0 obj
+<</Type/Page/Parent 3 0 R/Resources 10 0 R/Contents 30 0 R/MediaBox[0 0 225 225]>>
+endobj
+
+10 0 obj
+<</Pattern<</P1 15 0 R>>/Font<</F1 20 0 R>>>>
+endobj
+
+15 0 obj
+<</Type/Pattern/PatternType 1/PaintType 1/TilingType 2/BBox[0 0 100 100]/XStep 100/YStep 100/Matrix[.4 0 0 .4 0 0]/Length 632>>
+stream
+BT % Begin text object
+0.0 -0.05 TD % Move text position
+/F1 1 Tf % Set text font and size
+55 0 0 55 7.1771 10.4414 Tm % Set text matrix
+0 Tc % Set character spacing
+0 Tw % Set word spacing
+1.0 0.0 0.0 rg % Set nonstroking colour to red
+( a ) Tj % Show spade glyph
+0.7478 -0.007 TD % Move text position
+0.0 1.0 0.0 rg % Set nonstroking colour to green
+( b ) Tj % Show heart glyph
+-0.7323 0.7813 TD % Move text position
+0.0 0.0 1.0 rg % Set nonstroking colour to blue
+( c ) Tj % Show diamond glyph
+0.6913 0.007 TD % Move text position
+0.0 0.0 0.0 rg % Set nonstroking colour to black
+( d ) Tj % Show club glyph
+ET % End text object
+
+
+endstream
+endobj
+
+20 0 obj
+<</Type/Font/Subtype/Type1/Encoding 21 0 R/BaseFont/Helvevtica>>
+endobj
+
+21 0 obj
+<</Type/Encoding/Differences[1/a109/a110/a111/a112]>>
+endobj
+
+30 0 obj
+<</Length 1086>>
+stream
+0.0 G % Set stroking colour to black
+1.0 1.0 0.0 rg % Set nonstroking colour to yellow
+25 175 175 -150 re % Construct rectangular path
+f % Fill path
+/Pattern cs % Set pattern colour space
+/P1 scn % Set pattern as nonstroking colour
+99.92 49.92 m % Start new path
+99.92 77.52 77.52 99.92 49.92 99.92 c % Construct lower-left circle
+22.32 99.92 -0.08 77.52 -0.08 49.92 c
+-0.08 22.32 22.32 -0.08 49.92 -0.08 c
+77.52 -0.08 99.92 22.32 99.92 49.92 c
+B % Fill and stroke path
+224.96 49.92 m % Start new path
+224.96 77.52 202.56 99.92 174.96 99.92 c % Construct lower-right circle
+147.36 99.92 124.96 77.52 124.96 49.92 c
+124.96 22.32 147.36 -0.08 174.96 -0.08 c
+202.56 -0.08 224.96 22.32 224.96 49.92 c
+B % Fill and stroke path
+87.56 201.70 m % Start new path
+63.66 187.90 55.46 157.32 69.26 133.40 c % Construct upper circle
+83.06 109.50 113.66 101.30 137.56 115.10 c
+161.46 128.90 169.66 159.50 155.86 183.40 c
+142.06 207.30 111.46 215.50 87.56 201.70 c
+B % Fill and stroke path
+50 50 m % Start new path
+175 50 l % Construct triangular path
+112.5 158.253 l
+b % Close, fill, and stroke path 
+endstream
+endobj
+
+xref
+0 31
+0000000002 00001 f 
+0000000016 00000 n 
+0000000004 00003 f 
+0000000062 00000 n 
+0000000006 00003 f 
+0000000114 00000 n 
+0000000007 00003 f 
+0000000008 00003 f 
+0000000009 00003 f 
+0000000011 00003 f 
+0000000213 00000 n 
+0000000012 00003 f 
+0000000013 00003 f 
+0000000014 00003 f 
+0000000016 00003 f 
+0000000276 00000 n 
+0000000017 00003 f 
+0000000018 00003 f 
+0000000019 00003 f 
+0000000022 00003 f 
+0000001071 00000 n 
+0000001153 00000 n 
+0000000023 00003 f 
+0000000024 00003 f 
+0000000025 00003 f 
+0000000026 00003 f 
+0000000027 00003 f 
+0000000028 00003 f 
+0000000029 00003 f 
+0000000000 00003 f 
+0000001224 00000 n 
+
+trailer
+<</Size 31/Root 1 0 R>>
+startxref
+2362
+%%EOF

--- a/Userland/Applications/PDFViewer/PDFViewer.cpp
+++ b/Userland/Applications/PDFViewer/PDFViewer.cpp
@@ -319,7 +319,7 @@ PDF::PDFErrorOr<NonnullRefPtr<Gfx::Bitmap>> PDFViewer::render_page(u32 page_inde
     auto& page_size = m_page_dimension_cache.render_info[page_index].size;
     auto bitmap = TRY(Gfx::Bitmap::create(Gfx::BitmapFormat::BGRA8888, page_size.to_type<int>()));
 
-    auto maybe_errors = PDF::Renderer::render(*m_document, page, bitmap, m_rendering_preferences);
+    auto maybe_errors = PDF::Renderer::render(*m_document, page, bitmap, Color::White, m_rendering_preferences);
     if (maybe_errors.is_error()) {
         auto errors = maybe_errors.release_error();
         on_render_errors(page_index, errors);

--- a/Userland/Libraries/LibGfx/PaintStyle.h
+++ b/Userland/Libraries/LibGfx/PaintStyle.h
@@ -83,6 +83,63 @@ private:
     IntPoint m_offset;
 };
 
+class RepeatingBitmapPaintStyle : public Gfx::PaintStyle {
+public:
+    static ErrorOr<NonnullRefPtr<RepeatingBitmapPaintStyle>> create(Gfx::Bitmap const& bitmap, Gfx::IntPoint steps, Color fallback)
+    {
+        return adopt_nonnull_ref_or_enomem(new (nothrow) RepeatingBitmapPaintStyle(bitmap, steps, fallback));
+    }
+
+    virtual Color sample_color(Gfx::IntPoint point) const override
+    {
+        point.set_x(point.x() % m_steps.x());
+        point.set_y(point.y() % m_steps.y());
+        if (point.x() < 0 || point.y() < 0 || point.x() >= m_bitmap->width() || point.y() >= m_bitmap->height())
+            return m_fallback;
+        auto px = m_bitmap->get_pixel(point);
+        return px;
+    }
+
+private:
+    RepeatingBitmapPaintStyle(Gfx::Bitmap const& bitmap, Gfx::IntPoint steps, Color fallback)
+        : m_bitmap(bitmap)
+        , m_steps(steps)
+        , m_fallback(fallback)
+    {
+    }
+
+    NonnullRefPtr<Gfx::Bitmap const> m_bitmap;
+    Gfx::IntPoint m_steps;
+    Color m_fallback;
+};
+
+class OffsetPaintStyle : public Gfx::PaintStyle {
+public:
+    static ErrorOr<NonnullRefPtr<OffsetPaintStyle>> create(RefPtr<PaintStyle> other, Gfx::AffineTransform transform)
+    {
+        return adopt_nonnull_ref_or_enomem(new (nothrow) OffsetPaintStyle(move(other), transform));
+    }
+
+    virtual void paint(Gfx::IntRect physical_bounding_box, PaintFunction paint) const override
+    {
+        m_other->paint(m_transform.map(physical_bounding_box), [=, this, paint = move(paint)](SamplerFunction sampler) {
+            paint([=, this, sampler = move(sampler)](Gfx::IntPoint point) {
+                return sampler(m_transform.map(point));
+            });
+        });
+    }
+
+private:
+    OffsetPaintStyle(RefPtr<PaintStyle> other, Gfx::AffineTransform transform)
+        : m_other(move(other))
+        , m_transform(transform)
+    {
+    }
+
+    RefPtr<PaintStyle> m_other;
+    Gfx::AffineTransform m_transform;
+};
+
 class GradientPaintStyle : public PaintStyle {
 public:
     ErrorOr<void> add_color_stop(float position, Color color, Optional<float> transition_hint = {})

--- a/Userland/Libraries/LibPDF/ColorSpace.cpp
+++ b/Userland/Libraries/LibPDF/ColorSpace.cpp
@@ -45,7 +45,7 @@ PDFErrorOr<NonnullRefPtr<ColorSpace>> ColorSpace::create(Document* document, Non
     return Error { Error::Type::MalformedPDF, "Color space must be name or array" };
 }
 
-PDFErrorOr<NonnullRefPtr<ColorSpace>> ColorSpace::create(DeprecatedFlyString const& name, Renderer&)
+PDFErrorOr<NonnullRefPtr<ColorSpace>> ColorSpace::create(DeprecatedFlyString const& name, Renderer& renderer)
 {
     // Simple color spaces with no parameters, which can be specified directly
     if (name == CommonNames::DeviceGray)
@@ -55,7 +55,7 @@ PDFErrorOr<NonnullRefPtr<ColorSpace>> ColorSpace::create(DeprecatedFlyString con
     if (name == CommonNames::DeviceCMYK)
         return DeviceCMYKColorSpace::the();
     if (name == CommonNames::Pattern)
-        return Error::rendering_unsupported_error("Pattern color spaces not yet implemented");
+        return PatternColorSpace::create(renderer);
     VERIFY_NOT_REACHED();
 }
 
@@ -85,9 +85,6 @@ PDFErrorOr<NonnullRefPtr<ColorSpace>> ColorSpace::create(Document* document, Non
 
     if (color_space_name == CommonNames::Lab)
         return TRY(LabColorSpace::create(document, move(parameters)));
-
-    if (color_space_name == CommonNames::Pattern)
-        return Error::rendering_unsupported_error("Pattern color spaces not yet implemented");
 
     if (color_space_name == CommonNames::Separation)
         return TRY(SeparationColorSpace::create(document, move(parameters), renderer));
@@ -772,5 +769,105 @@ PDFErrorOr<ColorOrStyle> SeparationColorSpace::style(ReadonlySpan<Value> argumen
 Vector<float> SeparationColorSpace::default_decode() const
 {
     return { 0.0f, 1.0f };
+}
+NonnullRefPtr<PatternColorSpace> PatternColorSpace::create(Renderer& renderer)
+{
+    return adopt_ref(*new PatternColorSpace(renderer));
+}
+
+PDFErrorOr<ColorOrStyle> PatternColorSpace::style(ReadonlySpan<Value> arguments) const
+{
+    VERIFY(arguments.size() >= 1);
+
+    auto resources = m_renderer.m_page.resources;
+
+    auto pattern_resource = resources->get_value(CommonNames::Pattern);
+    auto doc_pattern_dict = pattern_resource.get<NonnullRefPtr<Object>>()->cast<DictObject>();
+
+    auto const& pattern_name = arguments.last().get<NonnullRefPtr<Object>>()->cast<NameObject>()->name();
+    if (!doc_pattern_dict->contains(pattern_name))
+        return Error::malformed_error("Pattern dictionary does not contain pattern {}", pattern_name);
+
+    auto const pattern = TRY(m_renderer.m_document->resolve_to<StreamObject>(doc_pattern_dict->get_value(pattern_name)));
+
+    auto const type = pattern->dict()->get(CommonNames::Type)->get<NonnullRefPtr<Object>>()->cast<NameObject>();
+    if (type->name() != CommonNames::Pattern)
+        return Error::rendering_unsupported_error("Unsupported pattern type {}", type->name());
+
+    auto const pattern_type = pattern->dict()->get(CommonNames::PatternType)->get_u16();
+    if (pattern_type != 1)
+        return Error::rendering_unsupported_error("Unsupported pattern type {}", pattern_type);
+
+    auto const pattern_paint_type = pattern->dict()->get("PaintType")->get_u16();
+    if (pattern_paint_type != 1)
+        return Error::rendering_unsupported_error("Unsupported pattern paint type {}", pattern_paint_type);
+
+    Vector<Value> pattern_matrix;
+    if (pattern->dict()->contains(CommonNames::Matrix)) {
+        pattern_matrix = pattern->dict()->get_array(m_renderer.m_document, CommonNames::Matrix).value()->elements();
+    } else {
+        pattern_matrix = Vector { Value { 1 }, Value { 0 }, Value { 0 }, Value { 1 }, Value { 0 }, Value { 0 } };
+    }
+
+    auto pattern_bounding_box = pattern->dict()->get_array(m_renderer.m_document, "BBox").value()->elements();
+    auto pattern_transform = Gfx::AffineTransform(
+        pattern_matrix[0].to_float(),
+        pattern_matrix[1].to_float(),
+        pattern_matrix[2].to_float(),
+        pattern_matrix[3].to_float(),
+        pattern_matrix[4].to_float(),
+        pattern_matrix[5].to_float());
+
+    // To get the device space size for the bitmap, apply the pattern transform to the pattern space bounding box, and then apply the initial ctm.
+    // NB: the pattern pattern_matrix maps pattern space to the default (initial) coordinate space of the page. (i.e cannot be updated via cm).
+
+    auto initial_ctm = Gfx::AffineTransform(m_renderer.m_graphics_state_stack.first().ctm);
+    initial_ctm.set_translation(0, 0);
+    initial_ctm.set_scale(initial_ctm.x_scale(), initial_ctm.y_scale());
+
+    auto pattern_space_lower_left = Gfx::FloatPoint { pattern_bounding_box[0].to_int(), pattern_bounding_box[1].to_int() };
+    auto pattern_space_upper_right = Gfx::FloatPoint { pattern_bounding_box[2].to_int(), pattern_bounding_box[3].to_int() };
+
+    auto device_space_lower_left = initial_ctm.map(pattern_transform.map(pattern_space_lower_left));
+    auto device_space_upper_right = initial_ctm.map(pattern_transform.map(pattern_space_upper_right));
+
+    auto bitmap_width = (int)device_space_upper_right.x() - (int)device_space_lower_left.x();
+    auto bitmap_height = (int)device_space_upper_right.y() - (int)device_space_lower_left.y();
+
+    auto pattern_cell = TRY(Gfx::Bitmap::create(Gfx::BitmapFormat::BGRA8888, { bitmap_width, bitmap_height }));
+    auto page = Page(m_renderer.m_page);
+    page.media_box = Rectangle {
+        pattern_space_lower_left.x(), pattern_space_lower_left.y(),
+        pattern_space_upper_right.x(), pattern_space_upper_right.y()
+    };
+    page.crop_box = page.media_box;
+
+    auto pattern_renderer = Renderer(m_renderer.m_document, page, pattern_cell, {}, m_renderer.m_rendering_preferences);
+
+    auto operators = TRY(Parser::parse_operators(m_renderer.m_document, pattern->bytes()));
+    for (auto& op : operators)
+        TRY(pattern_renderer.handle_operator(op, resources));
+
+    auto x_steps = pattern->dict()->get("XStep").value_or(bitmap_width).to_int();
+    auto y_steps = pattern->dict()->get("YStep").value_or(bitmap_height).to_int();
+
+    auto device_space_steps = initial_ctm.map(pattern_transform.map(Gfx::IntPoint { x_steps, y_steps }));
+
+    NonnullRefPtr<Gfx::PaintStyle> style = MUST(Gfx::RepeatingBitmapPaintStyle::create(
+        *pattern_cell,
+        device_space_steps,
+        {}));
+
+    return style;
+}
+int PatternColorSpace::number_of_components() const
+{
+    // Not permitted
+    VERIFY_NOT_REACHED();
+}
+Vector<float> PatternColorSpace::default_decode() const
+{
+    // Not permitted
+    VERIFY_NOT_REACHED();
 }
 }

--- a/Userland/Libraries/LibPDF/ColorSpace.h
+++ b/Userland/Libraries/LibPDF/ColorSpace.h
@@ -252,4 +252,24 @@ private:
     NonnullRefPtr<Function> m_tint_transform;
     Vector<Value> mutable m_tint_output_values;
 };
+
+class PatternColorSpace final : public ColorSpace {
+public:
+    static NonnullRefPtr<PatternColorSpace> create(Renderer& renderer);
+    ~PatternColorSpace() override = default;
+
+    PDFErrorOr<ColorOrStyle> style(ReadonlySpan<Value> arguments) const override;
+    int number_of_components() const override;
+    Vector<float> default_decode() const override;
+    ColorSpaceFamily const& family() const override { return ColorSpaceFamily::Pattern; }
+
+private:
+    PatternColorSpace(Renderer& renderer)
+        : m_renderer(renderer)
+    {
+    }
+
+    Renderer& m_renderer;
+};
+
 }

--- a/Userland/Libraries/LibPDF/ColorSpace.h
+++ b/Userland/Libraries/LibPDF/ColorSpace.h
@@ -10,6 +10,7 @@
 #include <AK/Forward.h>
 #include <LibGfx/Color.h>
 #include <LibGfx/ICC/Profile.h>
+#include <LibGfx/PaintStyle.h>
 #include <LibPDF/Function.h>
 #include <LibPDF/Value.h>
 
@@ -27,6 +28,9 @@
     V(DeviceN, false)
 
 namespace PDF {
+
+typedef Variant<Gfx::Color, NonnullRefPtr<Gfx::PaintStyle>> ColorOrStyle;
+class Renderer;
 
 class ColorSpaceFamily {
 public:
@@ -62,7 +66,7 @@ public:
 
     virtual ~ColorSpace() = default;
 
-    virtual PDFErrorOr<Color> color(ReadonlySpan<Value> arguments) const = 0;
+    virtual PDFErrorOr<ColorOrStyle> style(ReadonlySpan<Value> arguments) const = 0;
     virtual int number_of_components() const = 0;
     virtual Vector<float> default_decode() const = 0; // "TABLE 4.40 Default Decode arrays"
     virtual ColorSpaceFamily const& family() const = 0;
@@ -74,7 +78,7 @@ public:
 
     ~DeviceGrayColorSpace() override = default;
 
-    PDFErrorOr<Color> color(ReadonlySpan<Value> arguments) const override;
+    PDFErrorOr<ColorOrStyle> style(ReadonlySpan<Value> arguments) const override;
     int number_of_components() const override { return 1; }
     Vector<float> default_decode() const override;
     ColorSpaceFamily const& family() const override { return ColorSpaceFamily::DeviceGray; }
@@ -89,7 +93,7 @@ public:
 
     ~DeviceRGBColorSpace() override = default;
 
-    PDFErrorOr<Color> color(ReadonlySpan<Value> arguments) const override;
+    PDFErrorOr<ColorOrStyle> style(ReadonlySpan<Value> arguments) const override;
     int number_of_components() const override { return 3; }
     Vector<float> default_decode() const override;
     ColorSpaceFamily const& family() const override { return ColorSpaceFamily::DeviceRGB; }
@@ -104,7 +108,7 @@ public:
 
     ~DeviceCMYKColorSpace() override = default;
 
-    PDFErrorOr<Color> color(ReadonlySpan<Value> arguments) const override;
+    PDFErrorOr<ColorOrStyle> style(ReadonlySpan<Value> arguments) const override;
     int number_of_components() const override { return 4; }
     Vector<float> default_decode() const override;
     ColorSpaceFamily const& family() const override { return ColorSpaceFamily::DeviceCMYK; }
@@ -119,7 +123,7 @@ public:
 
     ~DeviceNColorSpace() override = default;
 
-    PDFErrorOr<Color> color(ReadonlySpan<Value> arguments) const override;
+    PDFErrorOr<ColorOrStyle> style(ReadonlySpan<Value> arguments) const override;
     int number_of_components() const override;
     Vector<float> default_decode() const override;
     ColorSpaceFamily const& family() const override { return ColorSpaceFamily::DeviceN; }
@@ -140,7 +144,7 @@ public:
 
     ~CalGrayColorSpace() override = default;
 
-    PDFErrorOr<Color> color(ReadonlySpan<Value> arguments) const override;
+    PDFErrorOr<ColorOrStyle> style(ReadonlySpan<Value> arguments) const override;
     int number_of_components() const override { return 1; }
     Vector<float> default_decode() const override;
     ColorSpaceFamily const& family() const override { return ColorSpaceFamily::CalGray; }
@@ -159,7 +163,7 @@ public:
 
     ~CalRGBColorSpace() override = default;
 
-    PDFErrorOr<Color> color(ReadonlySpan<Value> arguments) const override;
+    PDFErrorOr<ColorOrStyle> style(ReadonlySpan<Value> arguments) const override;
     int number_of_components() const override { return 3; }
     Vector<float> default_decode() const override;
     ColorSpaceFamily const& family() const override { return ColorSpaceFamily::CalRGB; }
@@ -179,7 +183,7 @@ public:
 
     ~ICCBasedColorSpace() override = default;
 
-    PDFErrorOr<Color> color(ReadonlySpan<Value> arguments) const override;
+    PDFErrorOr<ColorOrStyle> style(ReadonlySpan<Value> arguments) const override;
     int number_of_components() const override;
     Vector<float> default_decode() const override;
     ColorSpaceFamily const& family() const override { return ColorSpaceFamily::ICCBased; }
@@ -197,7 +201,7 @@ public:
 
     ~LabColorSpace() override = default;
 
-    PDFErrorOr<Color> color(ReadonlySpan<Value> arguments) const override;
+    PDFErrorOr<ColorOrStyle> style(ReadonlySpan<Value> arguments) const override;
     int number_of_components() const override { return 3; }
     Vector<float> default_decode() const override;
     ColorSpaceFamily const& family() const override { return ColorSpaceFamily::Lab; }
@@ -216,7 +220,7 @@ public:
 
     ~IndexedColorSpace() override = default;
 
-    PDFErrorOr<Color> color(ReadonlySpan<Value> arguments) const override;
+    PDFErrorOr<ColorOrStyle> style(ReadonlySpan<Value> arguments) const override;
     int number_of_components() const override { return 1; }
     Vector<float> default_decode() const override;
     ColorSpaceFamily const& family() const override { return ColorSpaceFamily::Indexed; }
@@ -235,7 +239,7 @@ public:
 
     ~SeparationColorSpace() override = default;
 
-    PDFErrorOr<Color> color(ReadonlySpan<Value> arguments) const override;
+    PDFErrorOr<ColorOrStyle> style(ReadonlySpan<Value> arguments) const override;
     int number_of_components() const override { return 1; }
     Vector<float> default_decode() const override;
     ColorSpaceFamily const& family() const override { return ColorSpaceFamily::Separation; }
@@ -248,5 +252,4 @@ private:
     NonnullRefPtr<Function> m_tint_transform;
     Vector<Value> mutable m_tint_output_values;
 };
-
 }

--- a/Userland/Libraries/LibPDF/ColorSpace.h
+++ b/Userland/Libraries/LibPDF/ColorSpace.h
@@ -60,9 +60,9 @@ private:
 
 class ColorSpace : public RefCounted<ColorSpace> {
 public:
-    static PDFErrorOr<NonnullRefPtr<ColorSpace>> create(Document*, NonnullRefPtr<Object>);
-    static PDFErrorOr<NonnullRefPtr<ColorSpace>> create(DeprecatedFlyString const&);
-    static PDFErrorOr<NonnullRefPtr<ColorSpace>> create(Document*, NonnullRefPtr<ArrayObject>);
+    static PDFErrorOr<NonnullRefPtr<ColorSpace>> create(Document*, NonnullRefPtr<Object>, Renderer&);
+    static PDFErrorOr<NonnullRefPtr<ColorSpace>> create(DeprecatedFlyString const&, Renderer&);
+    static PDFErrorOr<NonnullRefPtr<ColorSpace>> create(Document*, NonnullRefPtr<ArrayObject>, Renderer&);
 
     virtual ~ColorSpace() = default;
 
@@ -119,7 +119,7 @@ private:
 
 class DeviceNColorSpace final : public ColorSpace {
 public:
-    static PDFErrorOr<NonnullRefPtr<DeviceNColorSpace>> create(Document*, Vector<Value>&& parameters);
+    static PDFErrorOr<NonnullRefPtr<DeviceNColorSpace>> create(Document*, Vector<Value>&& parameters, Renderer&);
 
     ~DeviceNColorSpace() override = default;
 
@@ -179,7 +179,7 @@ private:
 
 class ICCBasedColorSpace final : public ColorSpace {
 public:
-    static PDFErrorOr<NonnullRefPtr<ColorSpace>> create(Document*, Vector<Value>&& parameters);
+    static PDFErrorOr<NonnullRefPtr<ColorSpace>> create(Document*, Vector<Value>&& parameters, Renderer&);
 
     ~ICCBasedColorSpace() override = default;
 
@@ -216,7 +216,7 @@ private:
 
 class IndexedColorSpace final : public ColorSpace {
 public:
-    static PDFErrorOr<NonnullRefPtr<ColorSpace>> create(Document*, Vector<Value>&& parameters);
+    static PDFErrorOr<NonnullRefPtr<ColorSpace>> create(Document*, Vector<Value>&& parameters, Renderer&);
 
     ~IndexedColorSpace() override = default;
 
@@ -235,7 +235,7 @@ private:
 
 class SeparationColorSpace final : public ColorSpace {
 public:
-    static PDFErrorOr<NonnullRefPtr<SeparationColorSpace>> create(Document*, Vector<Value>&& parameters);
+    static PDFErrorOr<NonnullRefPtr<SeparationColorSpace>> create(Document*, Vector<Value>&& parameters, Renderer&);
 
     ~SeparationColorSpace() override = default;
 

--- a/Userland/Libraries/LibPDF/CommonNames.h
+++ b/Userland/Libraries/LibPDF/CommonNames.h
@@ -138,8 +138,10 @@
     X(Outlines)                   \
     X(P)                          \
     X(Pages)                      \
+    X(PaintType)                  \
     X(Parent)                     \
     X(Pattern)                    \
+    X(PatternType)                \
     X(Perms)                      \
     X(Predictor)                  \
     X(Prev)                       \

--- a/Userland/Libraries/LibPDF/Parser.cpp
+++ b/Userland/Libraries/LibPDF/Parser.cpp
@@ -519,6 +519,8 @@ PDFErrorOr<Vector<Operator>> Parser::parse_operators()
 
     while (!m_reader.done()) {
         parse_comment();
+        if (m_reader.done())
+            break;
         auto ch = m_reader.peek();
         if (is_operator_char_start(ch)) {
             auto operator_start = m_reader.offset();

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -293,6 +293,12 @@ RENDERER_HANDLER(path_append_rect)
 
 void Renderer::begin_path_paint()
 {
+    if (state().paint_style.has<NonnullRefPtr<Gfx::PaintStyle>>()) {
+        VERIFY(!m_original_paint_style);
+        m_original_paint_style = state().paint_style.get<NonnullRefPtr<Gfx::PaintStyle>>();
+        auto translation = Gfx::AffineTransform().translate(m_current_path.bounding_box().x(), m_current_path.bounding_box().y());
+        state().paint_style = { MUST(Gfx::OffsetPaintStyle::create(state().paint_style.get<NonnullRefPtr<Gfx::PaintStyle>>(), translation)) };
+    }
     auto bounding_box = state().clipping_paths.current.bounding_box();
     m_painter.clear_clip_rect();
     if (m_rendering_preferences.show_clipping_paths) {
@@ -306,6 +312,11 @@ void Renderer::end_path_paint()
     m_current_path.clear();
     m_painter.clear_clip_rect();
     state().clipping_paths.current = state().clipping_paths.next;
+
+    if (m_original_paint_style) {
+        state().paint_style = m_original_paint_style.release_nonnull();
+        m_original_paint_style = nullptr;
+    }
 }
 
 RENDERER_HANDLER(path_stroke)

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -45,9 +45,9 @@ private:
     size_t m_starting_stack_depth;
 };
 
-PDFErrorsOr<void> Renderer::render(Document& document, Page const& page, RefPtr<Gfx::Bitmap> bitmap, RenderingPreferences rendering_preferences)
+PDFErrorsOr<void> Renderer::render(Document& document, Page const& page, RefPtr<Gfx::Bitmap> bitmap, Color background_color, RenderingPreferences rendering_preferences)
 {
-    return Renderer(document, page, bitmap, rendering_preferences).render();
+    return Renderer(document, page, bitmap, background_color, rendering_preferences).render();
 }
 
 static void rect_path(Gfx::Path& path, float x, float y, float width, float height)
@@ -73,7 +73,7 @@ static Gfx::Path rect_path(Gfx::Rect<T> const& rect)
     return path;
 }
 
-Renderer::Renderer(RefPtr<Document> document, Page const& page, RefPtr<Gfx::Bitmap> bitmap, RenderingPreferences rendering_preferences)
+Renderer::Renderer(RefPtr<Document> document, Page const& page, RefPtr<Gfx::Bitmap> bitmap, Color background_color, RenderingPreferences rendering_preferences)
     : m_document(document)
     , m_bitmap(bitmap)
     , m_page(page)
@@ -104,7 +104,7 @@ Renderer::Renderer(RefPtr<Document> document, Page const& page, RefPtr<Gfx::Bitm
     auto initial_clipping_path = rect_path(userspace_matrix.map(Gfx::FloatRect(0, 0, width, height)));
     m_graphics_state_stack.append(GraphicsState { userspace_matrix, { initial_clipping_path, initial_clipping_path } });
 
-    m_bitmap->fill(Gfx::Color::NamedColor::White);
+    m_bitmap->fill(background_color);
 }
 
 PDFErrorsOr<void> Renderer::render()

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -1059,7 +1059,7 @@ PDFErrorOr<NonnullRefPtr<ColorSpace>> Renderer::get_color_space_from_resources(V
     if (!maybe_color_space_family.is_error()) {
         auto color_space_family = maybe_color_space_family.release_value();
         if (color_space_family.may_be_specified_directly()) {
-            return ColorSpace::create(color_space_name);
+            return ColorSpace::create(color_space_name, *this);
         }
     }
     auto color_space_resource_dict = TRY(resources->get_dict(m_document, CommonNames::ColorSpace));
@@ -1072,7 +1072,7 @@ PDFErrorOr<NonnullRefPtr<ColorSpace>> Renderer::get_color_space_from_resources(V
 
 PDFErrorOr<NonnullRefPtr<ColorSpace>> Renderer::get_color_space_from_document(NonnullRefPtr<Object> color_space_object)
 {
-    return ColorSpace::create(m_document, color_space_object);
+    return ColorSpace::create(m_document, color_space_object, *this);
 }
 
 Gfx::AffineTransform const& Renderer::calculate_text_rendering_matrix() const

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -616,14 +616,8 @@ RENDERER_HANDLER(set_stroking_color)
 
 RENDERER_HANDLER(set_stroking_color_extended)
 {
-    // FIXME: Handle Pattern color spaces
-    auto last_arg = args.last();
-    if (last_arg.has<NonnullRefPtr<Object>>() && last_arg.get<NonnullRefPtr<Object>>()->is<NameObject>()) {
-        dbgln("pattern space {}", last_arg.get<NonnullRefPtr<Object>>()->cast<NameObject>()->name());
-        return Error::rendering_unsupported_error("Pattern color spaces not yet implemented");
-    }
-
-    state().stroke_style = TRY(state().stroke_color_space->style(args));
+    // FIXME: Pattern color spaces might need extra resources
+    state().paint_style = TRY(state().paint_color_space->style(args));
     return {};
 }
 
@@ -635,13 +629,7 @@ RENDERER_HANDLER(set_painting_color)
 
 RENDERER_HANDLER(set_painting_color_extended)
 {
-    // FIXME: Handle Pattern color spaces
-    auto last_arg = args.last();
-    if (last_arg.has<NonnullRefPtr<Object>>() && last_arg.get<NonnullRefPtr<Object>>()->is<NameObject>()) {
-        dbgln("pattern space {}", last_arg.get<NonnullRefPtr<Object>>()->cast<NameObject>()->name());
-        return Error::rendering_unsupported_error("Pattern color spaces not yet implemented");
-    }
-
+    // FIXME: Pattern color spaces might need extra resources
     state().paint_style = TRY(state().paint_color_space->style(args));
     return {};
 }

--- a/Userland/Libraries/LibPDF/Renderer.h
+++ b/Userland/Libraries/LibPDF/Renderer.h
@@ -97,6 +97,8 @@ struct RenderingPreferences {
 };
 
 class Renderer {
+    friend class PatternColorSpace;
+
 public:
     static PDFErrorsOr<void> render(Document&, Page const&, RefPtr<Gfx::Bitmap>, Color background_color, RenderingPreferences preferences);
 

--- a/Userland/Libraries/LibPDF/Renderer.h
+++ b/Userland/Libraries/LibPDF/Renderer.h
@@ -98,7 +98,7 @@ struct RenderingPreferences {
 
 class Renderer {
 public:
-    static PDFErrorsOr<void> render(Document&, Page const&, RefPtr<Gfx::Bitmap>, RenderingPreferences preferences);
+    static PDFErrorsOr<void> render(Document&, Page const&, RefPtr<Gfx::Bitmap>, Color background_color, RenderingPreferences preferences);
 
     struct FontCacheKey {
         NonnullRefPtr<DictObject> font_dictionary;
@@ -115,7 +115,7 @@ public:
     PDFErrorOr<void> render_type3_glyph(Gfx::FloatPoint, StreamObject const&, Gfx::AffineTransform const&, Optional<NonnullRefPtr<DictObject>>);
 
 private:
-    Renderer(RefPtr<Document>, Page const&, RefPtr<Gfx::Bitmap>, RenderingPreferences);
+    Renderer(RefPtr<Document>, Page const&, RefPtr<Gfx::Bitmap>, Color background_color, RenderingPreferences);
 
     PDFErrorsOr<void> render();
 

--- a/Userland/Libraries/LibPDF/Renderer.h
+++ b/Userland/Libraries/LibPDF/Renderer.h
@@ -74,8 +74,8 @@ struct GraphicsState {
     ClippingPaths clipping_paths;
     RefPtr<ColorSpace> stroke_color_space { DeviceGrayColorSpace::the() };
     RefPtr<ColorSpace> paint_color_space { DeviceGrayColorSpace::the() };
-    Gfx::Color stroke_color { Gfx::Color::NamedColor::Black };
-    Gfx::Color paint_color { Gfx::Color::NamedColor::Black };
+    ColorOrStyle stroke_style { Color::Black };
+    ColorOrStyle paint_style { Color::Black };
     DeprecatedString color_rendering_intent { "RelativeColorimetric"sv };
     float flatness_tolerance { 0.0f };
     float line_width { 1.0f };
@@ -286,8 +286,16 @@ struct Formatter<PDF::GraphicsState> : Formatter<StringView> {
         StringBuilder builder;
         builder.append("GraphicsState {\n"sv);
         builder.appendff("  ctm={}\n", state.ctm);
-        builder.appendff("  stroke_color={}\n", state.stroke_color);
-        builder.appendff("  paint_color={}\n", state.paint_color);
+        if (state.stroke_style.has<Color>()) {
+            builder.appendff("  stroke_style={}\n", state.stroke_style.get<Color>());
+        } else {
+            builder.appendff("  stroke_style={}\n", state.stroke_style.get<NonnullRefPtr<Gfx::PaintStyle>>());
+        }
+        if (state.paint_style.has<Color>()) {
+            builder.appendff("  paint_style={}\n", state.paint_style.get<Color>());
+        } else {
+            builder.appendff("  paint_style={}\n", state.paint_style.get<NonnullRefPtr<Gfx::PaintStyle>>());
+        }
         builder.appendff("  color_rendering_intent={}\n", state.color_rendering_intent);
         builder.appendff("  flatness_tolerance={}\n", state.flatness_tolerance);
         builder.appendff("  line_width={}\n", state.line_width);

--- a/Userland/Libraries/LibPDF/Renderer.h
+++ b/Userland/Libraries/LibPDF/Renderer.h
@@ -173,6 +173,8 @@ private:
     Gfx::AffineTransform mutable m_text_rendering_matrix;
 
     HashMap<FontCacheKey, NonnullRefPtr<PDFFont>> m_font_cache;
+    // Used to offset the PaintStyle's origin when rendering a pattern.
+    RefPtr<Gfx::PaintStyle> m_original_paint_style;
 };
 
 }

--- a/Userland/Utilities/pdf.cpp
+++ b/Userland/Utilities/pdf.cpp
@@ -55,7 +55,7 @@ static PDF::PDFErrorOr<NonnullRefPtr<Gfx::Bitmap>> render_page(PDF::Document& do
 
     auto bitmap = TRY(Gfx::Bitmap::create(Gfx::BitmapFormat::BGRx8888, page_size));
 
-    auto errors = PDF::Renderer::render(document, page, bitmap, PDF::RenderingPreferences {});
+    auto errors = PDF::Renderer::render(document, page, bitmap, Color::White, PDF::RenderingPreferences {});
     if (errors.is_error()) {
         for (auto const& error : errors.error().errors())
             warnln("warning: {}", error.message());
@@ -128,7 +128,7 @@ static PDF::PDFErrorOr<void> print_debugging_stats(PDF::Document& document, bool
         auto page = TRY(document.get_page(page_number - 1));
         auto page_size = Gfx::IntSize { 200, round_to<int>(200 * page.media_box.height() / page.media_box.width()) };
         auto bitmap = TRY(Gfx::Bitmap::create(Gfx::BitmapFormat::BGRx8888, page_size));
-        auto errors = PDF::Renderer::render(document, page, bitmap, PDF::RenderingPreferences {});
+        auto errors = PDF::Renderer::render(document, page, bitmap, Color::White, PDF::RenderingPreferences {});
         if (errors.is_error()) {
             for (auto const& error : errors.error().errors())
                 diags_to_pages.ensure(error.message()).append(page_number);


### PR DESCRIPTION
PDF.js vs LibPDF :)


<img width="761" height="715" alt="Tests/LibPDF/pattern.pdf_p1_ref_pdfjs" src="https://github.com/user-attachments/assets/7f80c608-0b64-4fd7-91c1-8eade6980e27" />
<img width="1020" height="715" alt="Tests/LibPDF/pattern.pdf_p1_step1" src="https://github.com/user-attachments/assets/78a282b9-33b4-411c-8af7-c3f30f2212d8" />

So I've added some basic pattern rendering to LibPDF, mainly targeting Adobe's example on p176 of the spec (pictured above). There's a couple structural-y changes that I'm not too sure about:

  - Changing all the ColorSpaces to output PaintStyles instead of Colors: This is so the pattern space can output a PaintStyle that generates the bitmap, but it is a bit overkill for the normal device spaces that have to output a SolidColorPaintStyle.
  - The PatternColorSpace sort of blends in with the Renderer code a bit since it has to render the pattern, so I decided to make it a friend class and pass in a reference to Renderer. Not too sure how to structure it tbh.

Also my C++ is a bit rusty (in more ways than one) so let me know if there's better ways to do things :) 