### PR TITLE
LibWeb: Start converting all StyleValue parsing over to TokenStream

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -3316,10 +3316,8 @@ RefPtr<StyleValue> Parser::parse_border_radius_shorthand_value(TokenStream<Compo
         { move(top_left_radius), move(top_right_radius), move(bottom_right_radius), move(bottom_left_radius) });
 }
 
-RefPtr<StyleValue> Parser::parse_shadow_value(Vector<ComponentValue> const& component_values, AllowInsetKeyword allow_inset_keyword)
+RefPtr<StyleValue> Parser::parse_shadow_value(TokenStream<ComponentValue>& tokens, AllowInsetKeyword allow_inset_keyword)
 {
-    TokenStream tokens { component_values };
-
     // "none"
     if (contains_single_none_ident(tokens))
         return parse_identifier_value(tokens.next_token());
@@ -5792,7 +5790,7 @@ Parser::ParseErrorOr<NonnullRefPtr<StyleValue>> Parser::parse_css_value(Property
             return parsed_value.release_nonnull();
         return ParseError::SyntaxError;
     case PropertyID::BoxShadow:
-        if (auto parsed_value = parse_shadow_value(component_values, AllowInsetKeyword::Yes))
+        if (auto parsed_value = parse_shadow_value(tokens, AllowInsetKeyword::Yes); parsed_value && !tokens.has_next_token())
             return parsed_value.release_nonnull();
         return ParseError::SyntaxError;
     case PropertyID::Content:
@@ -5920,7 +5918,7 @@ Parser::ParseErrorOr<NonnullRefPtr<StyleValue>> Parser::parse_css_value(Property
         return ParseError::SyntaxError;
     }
     case PropertyID::TextShadow:
-        if (auto parsed_value = parse_shadow_value(component_values, AllowInsetKeyword::No))
+        if (auto parsed_value = parse_shadow_value(tokens, AllowInsetKeyword::No); parsed_value && !tokens.has_next_token())
             return parsed_value.release_nonnull();
         return ParseError::SyntaxError;
     case PropertyID::Transform:

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -5563,9 +5563,9 @@ RefPtr<StyleValue> Parser::parse_grid_track_size_list_shorthand_value(PropertyID
         { parsed_template_areas_values.release_nonnull(), parsed_template_rows_values.release_nonnull(), parsed_template_columns_values.release_nonnull() });
 }
 
-RefPtr<StyleValue> Parser::parse_grid_area_shorthand_value(Vector<ComponentValue> const& component_values)
+RefPtr<StyleValue> Parser::parse_grid_area_shorthand_value(TokenStream<ComponentValue>& tokens)
 {
-    auto tokens = TokenStream { component_values };
+    auto transaction = tokens.begin_transaction();
 
     auto parse_placement_tokens = [&](Vector<ComponentValue>& placement_tokens, bool check_for_delimiter = true) -> void {
         auto current_token = tokens.next_token();
@@ -5635,6 +5635,7 @@ RefPtr<StyleValue> Parser::parse_grid_area_shorthand_value(Vector<ComponentValue
     else
         column_end = row_end;
 
+    transaction.commit();
     return ShorthandStyleValue::create(PropertyID::GridArea,
         { PropertyID::GridRowStart, PropertyID::GridColumnStart, PropertyID::GridRowEnd, PropertyID::GridColumnEnd },
         { GridTrackPlacementStyleValue::create(row_start), GridTrackPlacementStyleValue::create(column_start), GridTrackPlacementStyleValue::create(row_end), GridTrackPlacementStyleValue::create(column_end) });
@@ -5821,7 +5822,7 @@ Parser::ParseErrorOr<NonnullRefPtr<StyleValue>> Parser::parse_css_value(Property
             return parsed_value.release_nonnull();
         return ParseError::SyntaxError;
     case PropertyID::GridArea:
-        if (auto parsed_value = parse_grid_area_shorthand_value(component_values))
+        if (auto parsed_value = parse_grid_area_shorthand_value(tokens); parsed_value && !tokens.has_next_token())
             return parsed_value.release_nonnull();
         return ParseError::SyntaxError;
     case PropertyID::GridAutoFlow:

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -5814,11 +5814,10 @@ Parser::ParseErrorOr<NonnullRefPtr<StyleValue>> Parser::parse_css_value(Property
         if (auto parsed_value = parse_font_value(tokens); parsed_value && !tokens.has_next_token())
             return parsed_value.release_nonnull();
         return ParseError::SyntaxError;
-    case PropertyID::FontFamily: {
-        if (auto parsed_value = parse_font_family_value(tokens))
+    case PropertyID::FontFamily:
+        if (auto parsed_value = parse_font_family_value(tokens); parsed_value && !tokens.has_next_token())
             return parsed_value.release_nonnull();
         return ParseError::SyntaxError;
-    }
     case PropertyID::GridColumn:
         if (auto parsed_value = parse_grid_track_placement_shorthand_value(property_id, component_values))
             return parsed_value.release_nonnull();

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -265,7 +265,7 @@ private:
     RefPtr<StyleValue> parse_grid_track_placement(Vector<ComponentValue> const&);
     RefPtr<StyleValue> parse_grid_track_placement_shorthand_value(PropertyID, TokenStream<ComponentValue>&);
     RefPtr<StyleValue> parse_grid_template_areas_value(Vector<ComponentValue> const&);
-    RefPtr<StyleValue> parse_grid_area_shorthand_value(Vector<ComponentValue> const&);
+    RefPtr<StyleValue> parse_grid_area_shorthand_value(TokenStream<ComponentValue>&);
     RefPtr<StyleValue> parse_grid_shorthand_value(Vector<ComponentValue> const&);
 
     OwnPtr<CalculationNode> parse_a_calculation(Vector<ComponentValue> const&);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -237,7 +237,7 @@ private:
     RefPtr<StyleValue> parse_content_value(TokenStream<ComponentValue>&);
     RefPtr<StyleValue> parse_display_value(TokenStream<ComponentValue>&);
     RefPtr<StyleValue> parse_flex_value(TokenStream<ComponentValue>&);
-    RefPtr<StyleValue> parse_flex_flow_value(Vector<ComponentValue> const&);
+    RefPtr<StyleValue> parse_flex_flow_value(TokenStream<ComponentValue>&);
     RefPtr<StyleValue> parse_font_value(Vector<ComponentValue> const&);
     RefPtr<StyleValue> parse_font_family_value(TokenStream<ComponentValue>&);
     RefPtr<StyleValue> parse_list_style_value(Vector<ComponentValue> const&);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -263,7 +263,7 @@ private:
     [[nodiscard]] RefPtr<GridAutoFlowStyleValue> parse_grid_auto_flow_value(Vector<ComponentValue> const&);
     RefPtr<StyleValue> parse_grid_track_size_list_shorthand_value(PropertyID, Vector<ComponentValue> const&);
     RefPtr<StyleValue> parse_grid_track_placement(Vector<ComponentValue> const&);
-    RefPtr<StyleValue> parse_grid_track_placement_shorthand_value(PropertyID, Vector<ComponentValue> const&);
+    RefPtr<StyleValue> parse_grid_track_placement_shorthand_value(PropertyID, TokenStream<ComponentValue>&);
     RefPtr<StyleValue> parse_grid_template_areas_value(Vector<ComponentValue> const&);
     RefPtr<StyleValue> parse_grid_area_shorthand_value(Vector<ComponentValue> const&);
     RefPtr<StyleValue> parse_grid_shorthand_value(Vector<ComponentValue> const&);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -238,7 +238,7 @@ private:
     RefPtr<StyleValue> parse_display_value(TokenStream<ComponentValue>&);
     RefPtr<StyleValue> parse_flex_value(TokenStream<ComponentValue>&);
     RefPtr<StyleValue> parse_flex_flow_value(TokenStream<ComponentValue>&);
-    RefPtr<StyleValue> parse_font_value(Vector<ComponentValue> const&);
+    RefPtr<StyleValue> parse_font_value(TokenStream<ComponentValue>&);
     RefPtr<StyleValue> parse_font_family_value(TokenStream<ComponentValue>&);
     RefPtr<StyleValue> parse_list_style_value(Vector<ComponentValue> const&);
     RefPtr<StyleValue> parse_math_depth_value(Vector<ComponentValue> const&);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -236,7 +236,7 @@ private:
     RefPtr<StyleValue> parse_border_radius_shorthand_value(TokenStream<ComponentValue>&);
     RefPtr<StyleValue> parse_content_value(TokenStream<ComponentValue>&);
     RefPtr<StyleValue> parse_display_value(TokenStream<ComponentValue>&);
-    RefPtr<StyleValue> parse_flex_value(Vector<ComponentValue> const&);
+    RefPtr<StyleValue> parse_flex_value(TokenStream<ComponentValue>&);
     RefPtr<StyleValue> parse_flex_flow_value(Vector<ComponentValue> const&);
     RefPtr<StyleValue> parse_font_value(Vector<ComponentValue> const&);
     RefPtr<StyleValue> parse_font_family_value(TokenStream<ComponentValue>&);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -260,7 +260,7 @@ private:
     RefPtr<StyleValue> parse_transform_origin_value(Vector<ComponentValue> const&);
     RefPtr<StyleValue> parse_grid_track_size_list(Vector<ComponentValue> const&, bool allow_separate_line_name_blocks = false);
     RefPtr<StyleValue> parse_grid_auto_track_sizes(Vector<ComponentValue> const&);
-    [[nodiscard]] RefPtr<GridAutoFlowStyleValue> parse_grid_auto_flow_value(Vector<ComponentValue> const&);
+    RefPtr<GridAutoFlowStyleValue> parse_grid_auto_flow_value(TokenStream<ComponentValue>&);
     RefPtr<StyleValue> parse_grid_track_size_list_shorthand_value(PropertyID, Vector<ComponentValue> const&);
     RefPtr<StyleValue> parse_grid_track_placement(Vector<ComponentValue> const&);
     RefPtr<StyleValue> parse_grid_track_placement_shorthand_value(PropertyID, TokenStream<ComponentValue>&);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -231,7 +231,7 @@ private:
     RefPtr<StyleValue> parse_single_background_position_x_or_y_value(TokenStream<ComponentValue>&, PropertyID);
     RefPtr<StyleValue> parse_single_background_repeat_value(TokenStream<ComponentValue>&);
     RefPtr<StyleValue> parse_single_background_size_value(TokenStream<ComponentValue>&);
-    RefPtr<StyleValue> parse_border_value(PropertyID, Vector<ComponentValue> const&);
+    RefPtr<StyleValue> parse_border_value(PropertyID, TokenStream<ComponentValue>&);
     RefPtr<StyleValue> parse_border_radius_value(TokenStream<ComponentValue>&);
     RefPtr<StyleValue> parse_border_radius_shorthand_value(TokenStream<ComponentValue>&);
     RefPtr<StyleValue> parse_content_value(TokenStream<ComponentValue>&);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -251,7 +251,7 @@ private:
         No,
         Yes,
     };
-    RefPtr<StyleValue> parse_shadow_value(Vector<ComponentValue> const&, AllowInsetKeyword);
+    RefPtr<StyleValue> parse_shadow_value(TokenStream<ComponentValue>&, AllowInsetKeyword);
     RefPtr<StyleValue> parse_single_shadow_value(TokenStream<ComponentValue>&, AllowInsetKeyword);
     RefPtr<StyleValue> parse_text_decoration_value(Vector<ComponentValue> const&);
     RefPtr<StyleValue> parse_text_decoration_line_value(TokenStream<ComponentValue>&);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -231,8 +231,8 @@ private:
     RefPtr<StyleValue> parse_single_background_repeat_value(TokenStream<ComponentValue>&);
     RefPtr<StyleValue> parse_single_background_size_value(TokenStream<ComponentValue>&);
     RefPtr<StyleValue> parse_border_value(PropertyID, Vector<ComponentValue> const&);
-    RefPtr<StyleValue> parse_border_radius_value(Vector<ComponentValue> const&);
-    RefPtr<StyleValue> parse_border_radius_shorthand_value(Vector<ComponentValue> const&);
+    RefPtr<StyleValue> parse_border_radius_value(TokenStream<ComponentValue>&);
+    RefPtr<StyleValue> parse_border_radius_shorthand_value(TokenStream<ComponentValue>&);
     RefPtr<StyleValue> parse_content_value(Vector<ComponentValue> const&);
     RefPtr<StyleValue> parse_display_value(Vector<ComponentValue> const&);
     RefPtr<StyleValue> parse_flex_value(Vector<ComponentValue> const&);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -233,7 +233,7 @@ private:
     RefPtr<StyleValue> parse_border_value(PropertyID, Vector<ComponentValue> const&);
     RefPtr<StyleValue> parse_border_radius_value(TokenStream<ComponentValue>&);
     RefPtr<StyleValue> parse_border_radius_shorthand_value(TokenStream<ComponentValue>&);
-    RefPtr<StyleValue> parse_content_value(Vector<ComponentValue> const&);
+    RefPtr<StyleValue> parse_content_value(TokenStream<ComponentValue>&);
     RefPtr<StyleValue> parse_display_value(Vector<ComponentValue> const&);
     RefPtr<StyleValue> parse_flex_value(Vector<ComponentValue> const&);
     RefPtr<StyleValue> parse_flex_flow_value(Vector<ComponentValue> const&);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -225,7 +225,7 @@ private:
     RefPtr<StyleValue> parse_simple_comma_separated_value_list(PropertyID, TokenStream<ComponentValue>&);
 
     RefPtr<StyleValue> parse_filter_value_list_value(Vector<ComponentValue> const&);
-    RefPtr<StyleValue> parse_aspect_ratio_value(Vector<ComponentValue> const&);
+    RefPtr<StyleValue> parse_aspect_ratio_value(TokenStream<ComponentValue>&);
     RefPtr<StyleValue> parse_background_value(Vector<ComponentValue> const&);
     RefPtr<StyleValue> parse_single_background_position_x_or_y_value(TokenStream<ComponentValue>&, PropertyID);
     RefPtr<StyleValue> parse_single_background_repeat_value(TokenStream<ComponentValue>&);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -234,7 +234,7 @@ private:
     RefPtr<StyleValue> parse_border_radius_value(TokenStream<ComponentValue>&);
     RefPtr<StyleValue> parse_border_radius_shorthand_value(TokenStream<ComponentValue>&);
     RefPtr<StyleValue> parse_content_value(TokenStream<ComponentValue>&);
-    RefPtr<StyleValue> parse_display_value(Vector<ComponentValue> const&);
+    RefPtr<StyleValue> parse_display_value(TokenStream<ComponentValue>&);
     RefPtr<StyleValue> parse_flex_value(Vector<ComponentValue> const&);
     RefPtr<StyleValue> parse_flex_flow_value(Vector<ComponentValue> const&);
     RefPtr<StyleValue> parse_font_value(Vector<ComponentValue> const&);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -220,11 +220,12 @@ private:
         BackgroundPosition,
     };
     RefPtr<PositionStyleValue> parse_position_value(TokenStream<ComponentValue>&, PositionParsingMode = PositionParsingMode::Normal);
+    RefPtr<StyleValue> parse_filter_value_list_value(TokenStream<ComponentValue>&);
+
     template<typename ParseFunction>
     RefPtr<StyleValue> parse_comma_separated_value_list(TokenStream<ComponentValue>&, ParseFunction);
     RefPtr<StyleValue> parse_simple_comma_separated_value_list(PropertyID, TokenStream<ComponentValue>&);
 
-    RefPtr<StyleValue> parse_filter_value_list_value(Vector<ComponentValue> const&);
     RefPtr<StyleValue> parse_aspect_ratio_value(TokenStream<ComponentValue>&);
     RefPtr<StyleValue> parse_background_value(Vector<ComponentValue> const&);
     RefPtr<StyleValue> parse_single_background_position_x_or_y_value(TokenStream<ComponentValue>&, PropertyID);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -264,7 +264,7 @@ private:
     RefPtr<StyleValue> parse_grid_track_size_list_shorthand_value(PropertyID, Vector<ComponentValue> const&);
     RefPtr<StyleValue> parse_grid_track_placement(Vector<ComponentValue> const&);
     RefPtr<StyleValue> parse_grid_track_placement_shorthand_value(PropertyID, TokenStream<ComponentValue>&);
-    RefPtr<StyleValue> parse_grid_template_areas_value(Vector<ComponentValue> const&);
+    RefPtr<StyleValue> parse_grid_template_areas_value(TokenStream<ComponentValue>&);
     RefPtr<StyleValue> parse_grid_area_shorthand_value(TokenStream<ComponentValue>&);
     RefPtr<StyleValue> parse_grid_shorthand_value(Vector<ComponentValue> const&);
 

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -221,8 +221,8 @@ private:
     };
     RefPtr<PositionStyleValue> parse_position_value(TokenStream<ComponentValue>&, PositionParsingMode = PositionParsingMode::Normal);
     template<typename ParseFunction>
-    RefPtr<StyleValue> parse_comma_separated_value_list(Vector<ComponentValue> const&, ParseFunction);
-    RefPtr<StyleValue> parse_simple_comma_separated_value_list(PropertyID, Vector<ComponentValue> const&);
+    RefPtr<StyleValue> parse_comma_separated_value_list(TokenStream<ComponentValue>&, ParseFunction);
+    RefPtr<StyleValue> parse_simple_comma_separated_value_list(PropertyID, TokenStream<ComponentValue>&);
 
     RefPtr<StyleValue> parse_filter_value_list_value(Vector<ComponentValue> const&);
     RefPtr<StyleValue> parse_aspect_ratio_value(Vector<ComponentValue> const&);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -227,7 +227,7 @@ private:
     RefPtr<StyleValue> parse_simple_comma_separated_value_list(PropertyID, TokenStream<ComponentValue>&);
 
     RefPtr<StyleValue> parse_aspect_ratio_value(TokenStream<ComponentValue>&);
-    RefPtr<StyleValue> parse_background_value(Vector<ComponentValue> const&);
+    RefPtr<StyleValue> parse_background_value(TokenStream<ComponentValue>&);
     RefPtr<StyleValue> parse_single_background_position_x_or_y_value(TokenStream<ComponentValue>&, PropertyID);
     RefPtr<StyleValue> parse_single_background_repeat_value(TokenStream<ComponentValue>&);
     RefPtr<StyleValue> parse_single_background_size_value(TokenStream<ComponentValue>&);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -245,7 +245,7 @@ private:
     RefPtr<StyleValue> parse_place_content_value(Vector<ComponentValue> const&);
     RefPtr<StyleValue> parse_place_items_value(Vector<ComponentValue> const&);
     RefPtr<StyleValue> parse_place_self_value(Vector<ComponentValue> const&);
-    RefPtr<StyleValue> parse_quotes_value(Vector<ComponentValue> const&);
+    RefPtr<StyleValue> parse_quotes_value(TokenStream<ComponentValue>&);
     enum class AllowInsetKeyword {
         No,
         Yes,

--- a/Userland/Libraries/LibWeb/CSS/Properties.json
+++ b/Userland/Libraries/LibWeb/CSS/Properties.json
@@ -1127,9 +1127,9 @@
   },
   "grid-template-areas": {
     "inherited": false,
-    "initial": "auto",
+    "initial": "none",
     "valid-identifiers": [
-      "auto"
+      "none"
     ],
     "valid-types": [
       "string"


### PR DESCRIPTION
The goal is that everything consistently uses TokenStreams. Right now, some places use streams, and others take an individual ComponentValue or a Vector of them. This means we have code where we mostly use streams but then have to manually pull tokens out and remember whether we consumed them or not. This has repeatedly led to bugs, so let's finally fix that.

This is a very small step, from what I got done today. I like the "parse using a stream, then treat it as a failure if we have any unconsumed tokens left over" pattern though.