### PR TITLE
LibWeb: Implement Structured{De}SerializeWithTransfer for transferables

### DIFF
--- a/Tests/LibWeb/Text/expected/Messaging/Messaging-basic-channel.txt
+++ b/Tests/LibWeb/Text/expected/Messaging/Messaging-basic-channel.txt
@@ -1,0 +1,7 @@
+FIXME: Order of messages is incorrect
+Port1: "Hello"
+Port1: {"foo":"bar","baz":[1,2,3,4]}
+Port1: "DONE"
+Port2: "Hello"
+Port2: {"foo":"bar","baz":[1,2,3,4]}
+Port2: "DONE"

--- a/Tests/LibWeb/Text/input/Messaging/Messaging-basic-channel.html
+++ b/Tests/LibWeb/Text/input/Messaging/Messaging-basic-channel.html
@@ -1,0 +1,24 @@
+<script src="../include.js"></script>
+<script>
+    asyncTest(done => {
+        let channel = new MessageChannel();
+
+        channel.port1.onmessage = (event) => {
+            println("Port1: " + JSON.stringify(event.data));
+            channel.port1.postMessage(event.data);
+        };
+
+        channel.port2.onmessage = (event) => {
+            println("Port2: " + JSON.stringify(event.data));
+            if (event.data === "DONE") {
+                done();
+            }
+        };
+
+        // FIXME: These should be output in the order: Port1: A, Port2: A, Port1: B, Port2: B, ...
+        println("FIXME: Order of messages is incorrect");
+        channel.port2.postMessage("Hello");
+        channel.port2.postMessage({ foo: "bar", baz: [ 1, 2, 3, 4 ] });
+        channel.port2.postMessage("DONE");
+    });
+</script>

--- a/Userland/Libraries/LibWeb/Bindings/Intrinsics.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/Intrinsics.cpp
@@ -27,4 +27,9 @@ void Intrinsics::visit_edges(JS::Cell::Visitor& visitor)
     visitor.visit(m_realm);
 }
 
+bool Intrinsics::is_exposed(StringView name) const
+{
+    return m_constructors.contains(name) || m_prototypes.contains(name) || m_namespaces.contains(name);
+}
+
 }

--- a/Userland/Libraries/LibWeb/Bindings/Intrinsics.h
+++ b/Userland/Libraries/LibWeb/Bindings/Intrinsics.h
@@ -57,6 +57,8 @@ public:
         return *m_constructors.find(class_name)->value;
     }
 
+    bool is_exposed(StringView name) const;
+
 private:
     virtual void visit_edges(JS::Cell::Visitor&) override;
 

--- a/Userland/Libraries/LibWeb/Bindings/Transferable.h
+++ b/Userland/Libraries/LibWeb/Bindings/Transferable.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2023, Andrew Kaster <akaster@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Vector.h>
+#include <LibIPC/Forward.h>
+#include <LibWeb/HTML/StructuredSerialize.h>
+#include <LibWeb/WebIDL/ExceptionOr.h>
+
+namespace Web::Bindings {
+
+// https://html.spec.whatwg.org/multipage/structured-data.html#transferable-objects
+class Transferable {
+public:
+    virtual ~Transferable() = default;
+
+    // NOTE: It is an error to call Base::transfer_steps in your impl
+    virtual WebIDL::ExceptionOr<void> transfer_steps(HTML::TransferDataHolder&) = 0;
+
+    // NOTE: It is an error to call Base::transfer_receiving_steps in your impl
+    virtual WebIDL::ExceptionOr<void> transfer_receiving_steps(HTML::TransferDataHolder const&) = 0;
+
+    virtual HTML::TransferType primary_interface() const = 0;
+
+    bool is_detached() const { return m_detached; }
+    void set_detached(bool b) { m_detached = b; }
+
+private:
+    // https://html.spec.whatwg.org/multipage/structured-data.html#detached
+    bool m_detached = false;
+};
+
+}

--- a/Userland/Libraries/LibWeb/HTML/MessagePort.cpp
+++ b/Userland/Libraries/LibWeb/HTML/MessagePort.cpp
@@ -40,6 +40,47 @@ void MessagePort::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_remote_port);
 }
 
+// https://html.spec.whatwg.org/multipage/web-messaging.html#message-ports:transfer-steps
+WebIDL::ExceptionOr<void> MessagePort::transfer_steps(HTML::TransferDataHolder&)
+{
+    // 1. Set value's has been shipped flag to true.
+    m_has_been_shipped = true;
+
+    // FIXME: 2. Set dataHolder.[[PortMessageQueue]] to value's port message queue.
+    // FIXME: Support delivery of messages that haven't been delivered yet on the other side
+
+    // 3. If value is entangled with another port remotePort, then:
+    if (is_entangled()) {
+        // 1. Set remotePort's has been shipped flag to true.
+        m_remote_port->m_has_been_shipped = true;
+
+        // 2. Set dataHolder.[[RemotePort]] to remotePort.
+        // FIXME: Append an IPC::File to the dataHolder
+    }
+
+    // 4. Otherwise, set dataHolder.[[RemotePort]] to null.
+    else {
+        // FIXME: Note in the dataHolder that there are no fds
+    }
+
+    return {};
+}
+
+WebIDL::ExceptionOr<void> MessagePort::transfer_receiving_steps(HTML::TransferDataHolder const&)
+{
+    // 1. Set value's has been shipped flag to true.
+    m_has_been_shipped = true;
+
+    // FIXME 2. Move all the tasks that are to fire message events in dataHolder.[[PortMessageQueue]] to the port message queue of value,
+    //     if any, leaving value's port message queue in its initial disabled state, and, if value's relevant global object is a Window,
+    //     associating the moved tasks with value's relevant global object's associated Document.
+
+    // FIXME: 3. If dataHolder.[[RemotePort]] is not null, then entangle dataHolder.[[RemotePort]] and value.
+    //     (This will disentangle dataHolder.[[RemotePort]] from the original port that was transferred.)
+
+    return {};
+}
+
 void MessagePort::disentangle()
 {
     m_remote_port->m_remote_port = nullptr;
@@ -112,7 +153,7 @@ void MessagePort::start()
 void MessagePort::close()
 {
     // 1. Set this MessagePort object's [[Detached]] internal slot value to true.
-    m_detached = true;
+    set_detached(true);
 
     // 2. If this MessagePort object is entangled, disentangle it.
     if (is_entangled())

--- a/Userland/Libraries/LibWeb/HTML/MessagePort.h
+++ b/Userland/Libraries/LibWeb/HTML/MessagePort.h
@@ -8,6 +8,7 @@
 
 #include <AK/RefCounted.h>
 #include <AK/Weakable.h>
+#include <LibWeb/Bindings/Transferable.h>
 #include <LibWeb/DOM/EventTarget.h>
 #include <LibWeb/Forward.h>
 
@@ -23,7 +24,8 @@ struct StructuredSerializeOptions {
 };
 
 // https://html.spec.whatwg.org/multipage/web-messaging.html#message-ports
-class MessagePort final : public DOM::EventTarget {
+class MessagePort final : public DOM::EventTarget
+    , public Bindings::Transferable {
     WEB_PLATFORM_OBJECT(MessagePort, DOM::EventTarget);
     JS_DECLARE_ALLOCATOR(MessagePort);
 
@@ -49,6 +51,11 @@ public:
     ENUMERATE_MESSAGE_PORT_EVENT_HANDLERS(__ENUMERATE)
 #undef __ENUMERATE
 
+    // ^Transferable
+    virtual WebIDL::ExceptionOr<void> transfer_steps(HTML::TransferDataHolder&) override;
+    virtual WebIDL::ExceptionOr<void> transfer_receiving_steps(HTML::TransferDataHolder const&) override;
+    virtual HTML::TransferType primary_interface() const override { return HTML::TransferType::MessagePort; }
+
 private:
     explicit MessagePort(JS::Realm&);
 
@@ -63,9 +70,6 @@ private:
 
     // https://html.spec.whatwg.org/multipage/web-messaging.html#has-been-shipped
     bool m_has_been_shipped { false };
-
-    // This is TransferableObject.[[Detached]]
-    bool m_detached { false };
 };
 
 }

--- a/Userland/Libraries/LibWeb/HTML/StructuredSerialize.h
+++ b/Userland/Libraries/LibWeb/HTML/StructuredSerialize.h
@@ -50,6 +50,7 @@ WebIDL::ExceptionOr<SerializationRecord> structured_serialize_internal(JS::VM& v
 
 WebIDL::ExceptionOr<JS::Value> structured_deserialize(JS::VM& vm, SerializationRecord const& serialized, JS::Realm& target_realm, Optional<DeserializationMemory>);
 
-// TODO: structured_[de]serialize_with_transfer
+WebIDL::ExceptionOr<SerializedTransferRecord> structured_serialize_with_transfer(JS::VM& vm, JS::Value value, JS::MarkedVector<JS::Value> transfer_list);
+WebIDL::ExceptionOr<DeserializedTransferRecord> structured_deserialize_with_transfer(JS::VM& vm, SerializedTransferRecord const&);
 
 }

--- a/Userland/Libraries/LibWeb/HTML/StructuredSerialize.h
+++ b/Userland/Libraries/LibWeb/HTML/StructuredSerialize.h
@@ -10,6 +10,7 @@
 #include <AK/Result.h>
 #include <AK/Types.h>
 #include <AK/Vector.h>
+#include <LibIPC/Forward.h>
 #include <LibJS/Forward.h>
 #include <LibWeb/WebIDL/ExceptionOr.h>
 
@@ -23,6 +24,25 @@ namespace Web::HTML {
 using SerializationRecord = Vector<u32>;
 using SerializationMemory = HashMap<JS::Handle<JS::Value>, u32>;
 using DeserializationMemory = JS::MarkedVector<JS::Value>;
+
+struct TransferDataHolder {
+    Vector<u8> data;
+    Vector<IPC::File> fds;
+};
+
+struct SerializedTransferRecord {
+    SerializationRecord serialized;
+    Vector<TransferDataHolder> transfer_data_holders;
+};
+
+struct DeserializedTransferRecord {
+    JS::Value deserialized;
+    JS::MarkedVector<JS::Value> transferred_values;
+};
+
+enum class TransferType : u8 {
+    MessagePort,
+};
 
 WebIDL::ExceptionOr<SerializationRecord> structured_serialize(JS::VM& vm, JS::Value);
 WebIDL::ExceptionOr<SerializationRecord> structured_serialize_for_storage(JS::VM& vm, JS::Value);


### PR DESCRIPTION
- Add a basic message channel test
- Start implementing the transfer steps for MessagePorts
- Add a first cut of the structured_serialize_with_transfer and structured_deserialize_with_transfer methods