### PR TITLE
LibGfx/TIFF: Add support for one PhotometricInterpretation tag

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/TIFFLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/TIFFLoader.cpp
@@ -97,7 +97,11 @@ private:
         }
 
         if (*m_metadata.samples_per_pixel() == 1) {
-            auto const luminosity = TRY(read_component(stream, bits_per_sample[0]));
+            auto luminosity = TRY(read_component(stream, bits_per_sample[0]));
+
+            if (m_metadata.photometric_interpretation() == PhotometricInterpretation::WhiteIsZero)
+                luminosity = ~luminosity;
+
             return Color(luminosity, luminosity, luminosity);
         }
 

--- a/Userland/Libraries/LibGfx/TIFFGenerator.py
+++ b/Userland/Libraries/LibGfx/TIFFGenerator.py
@@ -50,6 +50,17 @@ class Compression(EnumWithExportName):
     PackBits = 32773
 
 
+class PhotometricInterpretation(EnumWithExportName):
+    WhiteIsZero = 0
+    BlackIsZero = 1
+    RGB = 2
+    RGBPalette = 3
+    TransparencyMask = 4
+    CMYK = 5
+    YCbCr = 6
+    CIELab = 8
+
+
 tag_fields = ['id', 'types', 'counts', 'default', 'name', 'associated_enum']
 
 Tag = namedtuple(
@@ -64,6 +75,7 @@ known_tags: List[Tag] = [
     Tag('257', [TIFFType.UnsignedShort, TIFFType.UnsignedLong], [1], None, "ImageHeight"),
     Tag('258', [TIFFType.UnsignedShort], [], None, "BitsPerSample"),
     Tag('259', [TIFFType.UnsignedShort], [1], None, "Compression", Compression),
+    Tag('262', [TIFFType.UnsignedShort], [1], None, "PhotometricInterpretation", PhotometricInterpretation),
     Tag('273', [TIFFType.UnsignedShort, TIFFType.UnsignedLong], [], None, "StripOffsets"),
     Tag('277', [TIFFType.UnsignedShort], [1], None, "SamplesPerPixel"),
     Tag('278', [TIFFType.UnsignedShort, TIFFType.UnsignedLong], [1], None, "RowsPerStrip"),


### PR DESCRIPTION
This allows us to successfully decode `cramps.tiff` from https://libtiff.gitlab.io/libtiff/images.html


![Screenshot from 2023-12-02 17-17-04](https://github.com/SerenityOS/serenity/assets/26030965/ab631848-03c0-4555-a20f-8f151c8878bf)
