### PR TITLE
LibWeb/MimeSniff: Add a few more MIME type sniffing algos

### DIFF
--- a/Userland/Libraries/LibWeb/MimeSniff/Resource.h
+++ b/Userland/Libraries/LibWeb/MimeSniff/Resource.h
@@ -14,7 +14,8 @@ enum class SniffingContext {
     None,
     Browsing,
     Image,
-    AudioOrVideo
+    AudioOrVideo,
+    Font,
 };
 
 struct SniffingConfiguration {
@@ -44,6 +45,7 @@ private:
     ErrorOr<void> context_specific_sniffing_algorithm(SniffingContext sniffing_context);
     ErrorOr<void> rules_for_sniffing_images_specifically();
     ErrorOr<void> rules_for_sniffing_audio_or_video_specifically();
+    ErrorOr<void> rules_for_sniffing_fonts_specifically();
 
     // https://mimesniff.spec.whatwg.org/#supplied-mime-type
     // A supplied MIME type, the MIME type determined by the supplied MIME type detection algorithm.

--- a/Userland/Libraries/LibWeb/MimeSniff/Resource.h
+++ b/Userland/Libraries/LibWeb/MimeSniff/Resource.h
@@ -42,6 +42,9 @@ private:
     void read_the_resource_header(ReadonlyBytes data);
     ErrorOr<void> supplied_mime_type_detection_algorithm(StringView scheme, Optional<MimeType> supplied_type);
     ErrorOr<void> mime_type_sniffing_algorithm();
+
+    ErrorOr<void> rules_for_distinguishing_if_a_resource_is_text_or_binary();
+
     ErrorOr<void> context_specific_sniffing_algorithm(SniffingContext sniffing_context);
     ErrorOr<void> rules_for_sniffing_images_specifically();
     ErrorOr<void> rules_for_sniffing_audio_or_video_specifically();


### PR DESCRIPTION
Adds font-specific context sniffing and rules for distinguishing if a resource is text or binary.