### PR TITLE
HexEditor: Don't allow to go outside document's size with PageDown key

### DIFF
--- a/Userland/Applications/HexEditor/HexEditor.cpp
+++ b/Userland/Applications/HexEditor/HexEditor.cpp
@@ -420,6 +420,8 @@ void HexEditor::keydown_event(GUI::KeyEvent& event)
 
     auto move_and_update_cursor_by = [&](i64 cursor_location_change) {
         size_t new_position = m_position + cursor_location_change;
+        VERIFY(new_position < m_document->size());
+
         if (event.modifiers() & Mod_Shift) {
             size_t selection_pivot = m_position == m_selection_end ? m_selection_start : m_selection_end;
             m_position = new_position;

--- a/Userland/Applications/HexEditor/HexEditor.cpp
+++ b/Userland/Applications/HexEditor/HexEditor.cpp
@@ -474,7 +474,7 @@ void HexEditor::keydown_event(GUI::KeyEvent& event)
     }
 
     if (event.key() == KeyCode::Key_PageDown) {
-        auto cursor_location_change = min(bytes_per_row() * floor(visible_content_rect().height() / line_height()), m_document->size() - m_position);
+        auto cursor_location_change = min(bytes_per_row() * floor(visible_content_rect().height() / line_height()), (m_document->size() - 1) - m_position);
         if (cursor_location_change > 0)
             move_and_update_cursor_by(cursor_location_change);
         return;
@@ -500,7 +500,7 @@ ErrorOr<void> HexEditor::hex_mode_keydown_event(GUI::KeyEvent& event)
         if (m_document->size() == 0)
             return {};
 
-        VERIFY(m_position <= m_document->size());
+        VERIFY(m_position < m_document->size());
 
         auto old_value = m_document->get(m_position).value;
 

--- a/Userland/Applications/HexEditor/HexEditor.cpp
+++ b/Userland/Applications/HexEditor/HexEditor.cpp
@@ -360,7 +360,7 @@ void HexEditor::mousemove_event(GUI::MouseEvent& event)
                 return;
 
             m_selection_end = offset;
-            m_position = offset;
+            m_position = (offset + 1 > m_document->size()) ? offset - 1 : offset;
             scroll_position_into_view(offset);
         }
 
@@ -375,7 +375,7 @@ void HexEditor::mousemove_event(GUI::MouseEvent& event)
                 return;
 
             m_selection_end = offset;
-            m_position = offset;
+            m_position = (offset + 1 > m_document->size()) ? offset - 1 : offset;
             scroll_position_into_view(offset);
         }
         update_status();

--- a/Userland/Applications/HexEditor/HexEditor.cpp
+++ b/Userland/Applications/HexEditor/HexEditor.cpp
@@ -477,7 +477,13 @@ void HexEditor::keydown_event(GUI::KeyEvent& event)
         move_and_update_cursor_by(-m_position);
         return;
     }
-    
+
+    if (event.key() == KeyCode::Key_End) {
+        if (m_position + 1 < m_document->size())
+            move_and_update_cursor_by(m_document->size() - m_position - 1);
+        return;
+    }
+
     if (event.key() == KeyCode::Key_PageDown) {
         auto cursor_location_change = min(bytes_per_row() * floor(visible_content_rect().height() / line_height()), (m_document->size() - 1) - m_position);
         if (cursor_location_change > 0)

--- a/Userland/Applications/HexEditor/HexEditor.cpp
+++ b/Userland/Applications/HexEditor/HexEditor.cpp
@@ -545,6 +545,7 @@ ErrorOr<void> HexEditor::hex_mode_keydown_event(GUI::KeyEvent& event)
             if (m_position + 1 < m_document->size())
                 m_position++;
             m_cursor_at_low_nibble = false;
+            m_selection_start = m_selection_end = m_position;
         }
 
         reset_cursor_blink_state();
@@ -573,6 +574,7 @@ ErrorOr<void> HexEditor::text_mode_keydown_event(GUI::KeyEvent& event)
     if (m_position + 1 < m_document->size())
         m_position++;
     m_cursor_at_low_nibble = false;
+    m_selection_start = m_selection_end = m_position;
 
     reset_cursor_blink_state();
     update();

--- a/Userland/Applications/HexEditor/HexEditor.cpp
+++ b/Userland/Applications/HexEditor/HexEditor.cpp
@@ -473,6 +473,11 @@ void HexEditor::keydown_event(GUI::KeyEvent& event)
         return;
     }
 
+    if (event.key() == KeyCode::Key_Home) {
+        move_and_update_cursor_by(-m_position);
+        return;
+    }
+    
     if (event.key() == KeyCode::Key_PageDown) {
         auto cursor_location_change = min(bytes_per_row() * floor(visible_content_rect().height() / line_height()), (m_document->size() - 1) - m_position);
         if (cursor_location_change > 0)


### PR DESCRIPTION
Currently, if you go to either edit mode (text or hex), and try to go to the end of the document with PageDown button on keyboard, you are allowed to go outside max allowed size. For example, if document is of size 210, you're allowed to go to index 210, which is 211th element (counting from 0). If you try inserting anything on that index, app simply crashes.

This patch fixes it by including 0th index in size, in the `cursor_location_change` variable in PageDown event.

Also a couple of smaller patches:
+ added support for moving to the beginning and end of the document with Home/End key.
+ now if user types a byte, `Selection Start` and `Selection End` labels are being updated
+ made a similar change (as to PageDown key) to not allow going outside document's size, but while user selects bytes including the last byte in the document