### PR TITLE
LibWeb: Add input number up down UI buttons

### DIFF
--- a/Tests/LibWeb/Layout/expected/input-element-with-display-inline.txt
+++ b/Tests/LibWeb/Layout/expected/input-element-with-display-inline.txt
@@ -5,7 +5,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         frag 0 from BlockContainer start: 0, length: 0, rect: [11,11 200x25.84375]
       BlockContainer <input> at (11,11) content-size 200x25.84375 inline-block [BFC] children: not-inline
         Box <div> at (13,12) content-size 196x23.84375 flex-container(row) [FFC] children: not-inline
-          BlockContainer <div> at (14,13) content-size 0x21.84375 flex-item [BFC] children: inline
+          BlockContainer <div> at (14,13) content-size 194x21.84375 flex-item [BFC] children: inline
             TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
@@ -13,4 +13,4 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [9,9 782x29.84375]
       PaintableWithLines (BlockContainer<INPUT>) [10,10 202x27.84375]
         PaintableBox (Box<DIV>) [11,11 200x25.84375]
-          PaintableWithLines (BlockContainer<DIV>) [13,12 2x23.84375]
+          PaintableWithLines (BlockContainer<DIV>) [13,12 196x23.84375]

--- a/Tests/LibWeb/Layout/expected/input-text-node-invalidation-on-value-change.txt
+++ b/Tests/LibWeb/Layout/expected/input-text-node-invalidation-on-value-change.txt
@@ -1,22 +1,22 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
-    BlockContainer <body> at (8,8) content-size 784x21.46875 children: inline
-      line 0 width: 191.875, height: 21.46875, bottom: 21.46875, baseline: 13.53125
-        frag 0 from BlockContainer start: 0, length: 0, rect: [9,9 189.875x19.46875]
-      BlockContainer <input#foo> at (9,9) content-size 189.875x19.46875 inline-block [BFC] children: not-inline
-        Box <div> at (11,10) content-size 185.875x17.46875 flex-container(row) [FFC] children: not-inline
-          BlockContainer <div> at (11,10) content-size 49.734375x17.46875 flex-item [BFC] children: inline
-            line 0 width: 49.734375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
-              frag 0 from TextNode start: 0, length: 4, rect: [11,10 49.734375x17.46875]
+  BlockContainer <html> at (0,0) content-size 800x41.84375 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x25.84375 children: inline
+      line 0 width: 202, height: 25.84375, bottom: 25.84375, baseline: 16.921875
+        frag 0 from BlockContainer start: 0, length: 0, rect: [9,9 200x23.84375]
+      BlockContainer <input#foo> at (9,9) content-size 200x23.84375 inline-block [BFC] children: not-inline
+        Box <div> at (11,10) content-size 196x21.84375 flex-container(row) [FFC] children: not-inline
+          BlockContainer <div> at (11,10) content-size 196x21.84375 flex-item [BFC] children: inline
+            line 0 width: 62.171875, height: 21.84375, bottom: 21.84375, baseline: 16.921875
+              frag 0 from TextNode start: 0, length: 4, rect: [11,10 62.171875x21.84375]
                 "PASS"
             TextNode <#text>
       TextNode <#text>
       TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
-    PaintableWithLines (BlockContainer<BODY>) [8,8 784x21.46875]
-      PaintableWithLines (BlockContainer<INPUT>#foo) [8,8 191.875x21.46875]
-        PaintableBox (Box<DIV>) [9,9 189.875x19.46875]
-          PaintableWithLines (BlockContainer<DIV>) [11,10 49.734375x17.46875]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x41.84375]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x25.84375]
+      PaintableWithLines (BlockContainer<INPUT>#foo) [8,8 202x25.84375]
+        PaintableBox (Box<DIV>) [9,9 200x23.84375]
+          PaintableWithLines (BlockContainer<DIV>) [11,10 196x21.84375]
             TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/input/input-text-node-invalidation-on-value-change.html
+++ b/Tests/LibWeb/Layout/input/input-text-node-invalidation-on-value-change.html
@@ -1,4 +1,11 @@
-<input id="foo">
+<!DOCTYPE html><html><head><style>
+* {
+    font: 20px 'SerenitySans';
+}
+input {
+    width: 200px;
+}
+</style></head><body><input id="foo">
 <script>
     let foo = document.getElementById("foo");
     foo.value = "FAIL";


### PR DESCRIPTION
We now have the `stepUp()` and `stepDown()` functions, so lets use them in the `input[type=number]` element with up and down buttons. All other browsers have such up & down buttons for number fields so I have added them.

I used again inline SVG's for icons like I did in my pending select pr, is this something that we want or do we need some SVG file loading from res with the `resource://` scheme that would be better I think.

# Demo Video
https://github.com/SerenityOS/serenity/assets/19894029/7fd9a668-214c-4441-b504-0e4c3cfb1d70

*There is a bug with the cursor, I will look into that in the future*