### PR TITLE
AK: Print timestamp, process name, and pid on all platforms

### DIFF
--- a/AK/Format.h
+++ b/AK/Format.h
@@ -691,6 +691,7 @@ void dbgln(CheckedFormatString<Parameters...>&& fmtstr, Parameters const&... par
 inline void dbgln() { dbgln(""); }
 
 void set_debug_enabled(bool);
+void set_rich_debug_enabled(bool);
 
 #ifdef KERNEL
 void vdmesgln(StringView fmtstr, TypeErasedFormatParams&);

--- a/Ladybird/AppKit/main.mm
+++ b/Ladybird/AppKit/main.mm
@@ -27,6 +27,8 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
+    AK::set_rich_debug_enabled(true);
+
     [Application sharedApplication];
 
     Core::EventLoopManager::install(*new Ladybird::CFEventLoopManager);

--- a/Ladybird/ImageDecoder/main.cpp
+++ b/Ladybird/ImageDecoder/main.cpp
@@ -14,6 +14,8 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
+    AK::set_rich_debug_enabled(true);
+
     int fd_passing_socket { -1 };
     StringView serenity_resource_root;
 

--- a/Ladybird/Qt/main.cpp
+++ b/Ladybird/Qt/main.cpp
@@ -87,6 +87,8 @@ public:
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
+    AK::set_rich_debug_enabled(true);
+
     LadybirdApplication app(arguments.argc, arguments.argv);
 
     Core::EventLoopManager::install(*new Ladybird::EventLoopManagerQt);

--- a/Ladybird/RequestServer/main.cpp
+++ b/Ladybird/RequestServer/main.cpp
@@ -36,6 +36,8 @@ ErrorOr<String> find_certificates(StringView serenity_resource_root)
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
+    AK::set_rich_debug_enabled(true);
+
     int fd_passing_socket { -1 };
     StringView serenity_resource_root;
 

--- a/Ladybird/SQLServer/main.cpp
+++ b/Ladybird/SQLServer/main.cpp
@@ -15,6 +15,8 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
+    AK::set_rich_debug_enabled(true);
+
     DeprecatedString pid_file;
 
     Core::ArgsParser args_parser;

--- a/Ladybird/WebContent/main.cpp
+++ b/Ladybird/WebContent/main.cpp
@@ -50,6 +50,8 @@ static ErrorOr<void> initialize_lagom_networking();
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
+    AK::set_rich_debug_enabled(true);
+
 #if defined(HAVE_QT)
     QCoreApplication app(arguments.argc, arguments.argv);
 

--- a/Ladybird/WebDriver/main.cpp
+++ b/Ladybird/WebDriver/main.cpp
@@ -55,6 +55,8 @@ static ErrorOr<pid_t> launch_headless_browser(DeprecatedString const& socket_pat
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
+    AK::set_rich_debug_enabled(true);
+
     auto listen_address = "0.0.0.0"sv;
     int port = 8000;
 

--- a/Ladybird/WebSocket/main.cpp
+++ b/Ladybird/WebSocket/main.cpp
@@ -32,6 +32,8 @@ ErrorOr<String> find_certificates(StringView serenity_resource_root)
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
+    AK::set_rich_debug_enabled(true);
+
     int fd_passing_socket { -1 };
     StringView serenity_resource_root;
 

--- a/Ladybird/WebWorker/main.cpp
+++ b/Ladybird/WebWorker/main.cpp
@@ -30,6 +30,8 @@ static ErrorOr<void> initialize_lagom_networking();
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
+    AK::set_rich_debug_enabled(true);
+
     int fd_passing_socket { -1 };
 
     Core::ArgsParser args_parser;


### PR DESCRIPTION
This requires duplicating some logic from Core::Process::get_name() into AK, which seems unfortunate. But for now, this greatly improves the log messages for testing Ladybird on Linux.

Example dbgln output with this patch:

```
1317422.228 WebContent(1477609): FontDatabase::load_all_fonts_from_uri('file:///home/andrew/.local/share/fonts'): open: No such file or directory (errno=2)
1317422.244 WebContent(1477609): ResourceLoader: Starting load of: "https://chat.openai.com/"
1317422.376 WebContent(1477609): ResourceLoader: Failed load of: "https://chat.openai.com/", Error: Load failed: 403, Duration: 133ms
1317422.388 WebContent(1477609): ResourceLoader: Starting load of: "https://chat.openai.com/cdn-cgi/challenge-platform/h/b/orchestrate/chl_page/v1?ray=8327de841f365200"
1317422.396 WebContent(1477609): HTMLScriptElement: Refusing to run script because the src URL ':' is invalid.
1317422.548 WebContent(1477609): ResourceLoader: Finished load of: "https://chat.openai.com/cdn-cgi/challenge-platform/h/b/orchestrate/chl_page/v1?ray=8327de841f365200", Duration: 161ms
1317422.720 WebContent(1477609): ResourceLoader: Starting load of: "https://chat.openai.com/favicon.ico"
1317422.740 WebContent(1477609): ResourceLoader: Failed load of: "https://chat.openai.com/favicon.ico", Error: Load failed: 403, Duration: 21ms
1317422.748 WebWorker(1477622): DedicatedWorkerHost: Unable to fetch script blob:https://chat.openai.com/7fb1aa64-837a-4bc7-89bf-1651462baaf8 because script was null
1317422.748 WebContent(1477609): Could not decode favicon https://chat.openai.com/favicon.ico
1317422.756 WebSocket(1477624): Loaded 141 of 141 (100%) provided CA Certificates
1317422.756 RequestServer(1477623): Loaded 141 of 141 (100%) provided CA Certificates
```