### PR TITLE
LibWeb: Hide more debug messages behind SPAM_DEBUG

### DIFF
--- a/Userland/Libraries/LibWeb/Loader/ResourceLoader.cpp
+++ b/Userland/Libraries/LibWeb/Loader/ResourceLoader.cpp
@@ -166,12 +166,12 @@ void ResourceLoader::load(LoadRequest& request, SuccessCallback success_callback
     auto id = resource_id++;
     auto url_for_logging = sanitized_url_for_logging(url);
     emit_signpost(DeprecatedString::formatted("Starting load: {}", url_for_logging), id);
-    dbgln("ResourceLoader: Starting load of: \"{}\"", url_for_logging);
+    dbgln_if(SPAM_DEBUG, "ResourceLoader: Starting load of: \"{}\"", url_for_logging);
 
     auto const log_success = [url_for_logging, id](auto const& request) {
         auto load_time_ms = request.load_time().to_milliseconds();
         emit_signpost(DeprecatedString::formatted("Finished load: {}", url_for_logging), id);
-        dbgln("ResourceLoader: Finished load of: \"{}\", Duration: {}ms", url_for_logging, load_time_ms);
+        dbgln_if(SPAM_DEBUG, "ResourceLoader: Finished load of: \"{}\", Duration: {}ms", url_for_logging, load_time_ms);
     };
 
     auto const log_failure = [url_for_logging, id](auto const& request, auto const& error_message) {

--- a/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
+++ b/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
@@ -9,6 +9,7 @@
  */
 
 #include <AK/ByteBuffer.h>
+#include <AK/Debug.h>
 #include <AK/GenericLexer.h>
 #include <AK/QuickSort.h>
 #include <LibJS/Runtime/ArrayBuffer.h>
@@ -700,7 +701,7 @@ WebIDL::ExceptionOr<void> XMLHttpRequest::send(Optional<DocumentOrXMLHttpRequest
     // 10. Set this’s send() flag.
     m_send = true;
 
-    dbgln("{}XHR send from {} to {}", m_synchronous ? "\033[33;1mSynchronous\033[0m " : "", HTML::relevant_settings_object(*this).creation_url, m_request_url);
+    dbgln_if(SPAM_DEBUG, "{}XHR send from {} to {}", m_synchronous ? "\033[33;1mSynchronous\033[0m " : "", HTML::relevant_settings_object(*this).creation_url, m_request_url);
 
     // 11. If this’s synchronous flag is unset, then:
     if (!m_synchronous) {


### PR DESCRIPTION
These two patches has the result of reducing the number of lines produced by 

` SERENITY_SOURCE_DIR=$PWD ./Build/lagom/bin/headless-browser -R $PWD/Tests/LibWeb 2>&1 | wc -l`

from 2471 to 677 on my machine.

Note that when piping to wc -l, we actually get a newline for each test. in a terminal, it goes to like, 20 lines.

```
Running 659 tests...
1/659: Layout/input/aspect-ratio-auto.htmlFontDatabase::load_all_fonts_from_uri('file:///home/andrew/.local/share/fonts'): open: No such file or directory (errno=2)
397/659: Layout/input/css-namespace-tag-name-selector.htmlPotential FIXME: Creating unknown generic element 'a' in namespace 'http://www.w3.org/2000/svg'
Potential FIXME: Creating unknown generic element 'a' in namespace 'http://www.w3.org/1998/Math/MathML'
508/659: Text/input/XML/parser-namespace.htmlPotential FIXME: Creating unknown generic element 'random' in namespace 'some.random/namespace'
Potential FIXME: Creating unknown generic element 'inner' in namespace 'some.random/namespace'
515/659: Text/input/HTML/get-innerHTML.htmlFIXME: Unsupported external fetch of SVGScriptElement!
FIXME: Unsupported external fetch of SVGScriptElement!
571/659: Text/input/link-element-rel-preload-load-event.htmlResourceLoader: Failed load of: "file:///home/andrew/serenity/Tests/LibWeb/Text/input/this-file-does-not-exist-and-so-is-invalid.css", Error: No such file or directory (errno=2), Duration: 0ms
580/659: Text/input/SVG/svg-href-qualified-name.htmlFIXME: Unsupported external fetch of SVGScriptElement!
FIXME: Unsupported external fetch of SVGScriptElement!
584/659: Text/input/XHR/XMLHttpRequest-responseXML-gives-XMLDocument.htmlPotential FIXME: Creating unknown generic element 'lol' in namespace ''
642/659: Ref/border-radius.htmlResourceLoader: Failed load of: "file:///home/andrew/serenity/Tests/LibWeb/Ref/car.png", Error: No such file or directory (errno=2), Duration: 0ms
645/659: Ref/svg-file-matches-html-file.svgPotential FIXME: Creating unknown generic element 'link' in namespace 'http://www.w3.org/2000/svg'
Done!
==================================================
Pass: 658, Fail: 0, Skipped: 1, Timeout: 0
==================================================
Skipped: /home/andrew/serenity/Tests/LibWeb/Text/input/Worker/Worker-echo.html
```

I haven't figured out how to get the dbglns to always start on a newline yet, my terminal fu is not good enough.
