### PR TITLE
LibJS: Some optimizations for nwex.de to render faster

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/AbstractOperations.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AbstractOperations.cpp
@@ -87,6 +87,10 @@ ThrowCompletionOr<NonnullGCPtr<Object>> construct_impl(VM&, FunctionObject& func
 // 7.3.19 LengthOfArrayLike ( obj ), https://tc39.es/ecma262/#sec-lengthofarraylike
 ThrowCompletionOr<size_t> length_of_array_like(VM& vm, Object const& object)
 {
+    // OPTIMIZATION: For Array objects with a magical "length" property, it should always reflect the size of indexed property storage.
+    if (object.has_magical_length_property())
+        return object.indexed_properties().array_like_size();
+
     // 1. Return ℝ(? ToLength(? Get(obj, "length"))).
     return TRY(object.get(vm.names.length)).to_length(vm);
 }

--- a/Userland/Libraries/LibJS/Runtime/ArrayIterator.h
+++ b/Userland/Libraries/LibJS/Runtime/ArrayIterator.h
@@ -28,11 +28,15 @@ private:
 
     ArrayIterator(Value array, Object::PropertyKind iteration_kind, Object& prototype);
 
+    virtual bool is_array_iterator() const override { return true; }
     virtual void visit_edges(Cell::Visitor&) override;
 
     Value m_array;
     Object::PropertyKind m_iteration_kind;
     size_t m_index { 0 };
 };
+
+template<>
+inline bool Object::fast_is<ArrayIterator>() const { return is_array_iterator(); }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Object.h
+++ b/Userland/Libraries/LibJS/Runtime/Object.h
@@ -191,6 +191,7 @@ public:
     virtual bool is_native_function() const { return false; }
     virtual bool is_ecmascript_function_object() const { return false; }
     virtual bool is_iterator_record() const { return false; }
+    virtual bool is_array_iterator() const { return false; }
 
     // B.3.7 The [[IsHTMLDDA]] Internal Slot, https://tc39.es/ecma262/#sec-IsHTMLDDA-internal-slot
     virtual bool is_htmldda() const { return false; }

--- a/Userland/Libraries/LibJS/Runtime/Object.h
+++ b/Userland/Libraries/LibJS/Runtime/Object.h
@@ -224,6 +224,7 @@ public:
     static FlatPtr may_interfere_with_indexed_property_access_offset() { return OFFSET_OF(Object, m_may_interfere_with_indexed_property_access); }
     static FlatPtr indexed_properties_offset() { return OFFSET_OF(Object, m_indexed_properties); }
 
+    [[nodiscard]] bool has_magical_length_property() const { return m_has_magical_length_property; }
     static FlatPtr has_magical_length_property_offset() { return OFFSET_OF(Object, m_has_magical_length_property); }
 
     [[nodiscard]] bool is_typed_array() const { return m_is_typed_array; }


### PR DESCRIPTION
See individual commits for details.

Time spent in `render()` on https://nwex.de/
Before: 5.017 sec
After: 4.677 sec
