### PR TITLE
CMake: Don't try to enable install options if no languages are enabled

### DIFF
--- a/Meta/CMake/lagom_install_options.cmake
+++ b/Meta/CMake/lagom_install_options.cmake
@@ -1,5 +1,11 @@
 include_guard()
 
+# Skip trying to setup install rules if no languages are enabled, such as in the Superbuild.
+get_property(languages GLOBAL PROPERTY ENABLED_LANGUAGES)
+if (NONE IN_LIST languages)
+    return()
+endif()
+
 include(GNUInstallDirs) # make sure to include before we mess w/RPATH
 
 # Mirror the structure of the installed tree to ensure that rpaths


### PR DESCRIPTION
This removes a CMake dev warning when building serenity via the Superbuild.