### PR TITLE
Ladybird: Install required html and inspector files in the CMake build

### DIFF
--- a/Ladybird/cmake/InstallRules.cmake
+++ b/Ladybird/cmake/InstallRules.cmake
@@ -95,9 +95,9 @@ install(
 )
 
 install(DIRECTORY
-    "${SERENITY_SOURCE_DIR}/Base/res/html"
     "${SERENITY_SOURCE_DIR}/Base/res/fonts"
     "${SERENITY_SOURCE_DIR}/Base/res/icons"
+    "${SERENITY_SOURCE_DIR}/Base/res/ladybird"
     "${SERENITY_SOURCE_DIR}/Base/res/themes"
     "${SERENITY_SOURCE_DIR}/Base/res/color-palettes"
     "${SERENITY_SOURCE_DIR}/Base/res/cursor-themes"


### PR DESCRIPTION
Companion to 05c8d5ba5727f106058722e6e7642b16ee18e7c7 which moved the files to Base/res/ladybird, and d81c531322c8413cb80aa6ef02943d5e97334705 which installed them in the GN build on macOS.