### PR TITLE
Base+Documentation: Correct some outdated paths

### DIFF
--- a/Base/usr/share/man/man7/Audio-subsystem.md
+++ b/Base/usr/share/man/man7/Audio-subsystem.md
@@ -82,7 +82,7 @@ SerenityOS's audio system uses a variety of sample rates in different layers of 
 
 * [/dev/audio](help://man/4/audio)
 * AudioApplet and AudioServer have settings which are managed by ConfigServer.
-* `/tmp/user/%uid/portal/audio`: AudioServer's client IPC socket
+* `/tmp/session/%sid/portal/audio`: AudioServer's client IPC socket
 
 ## See also
 

--- a/Base/usr/share/man/man8/sysctl.md
+++ b/Base/usr/share/man/man8/sysctl.md
@@ -26,7 +26,7 @@ Available parameters are listed under /sys/kernel/conf/.
 
 ## Files
 
-* `/proc/sys` - source of kernel parameters
+* `/sys/kernel/conf` - source of kernel parameters
 
 ## Examples
 

--- a/Documentation/Browser/ProcessArchitecture.md
+++ b/Documentation/Browser/ProcessArchitecture.md
@@ -31,7 +31,7 @@ This process can decode images (PNG, JPEG, BMP, ICO, PBM, etc.) into bitmaps. Ea
 ### How processes are spawned
 
 To get a fresh **WebContent** process, anyone with the suitable file system permissions can spawn one by connecting to
-the socket at `/tmp/user/%sid/portal/webcontent`, with `%sid` being the current login session id. This socket is managed
+the socket at `/tmp/session/%sid/portal/webcontent`, with `%sid` being the current login session id. This socket is managed
 by **
 SystemServer** and will spawn a new instance of **WebContent** for every connection.
 


### PR DESCRIPTION
Stumbled upon the outdated `sysctl` variable path and found more outdated paths during a quick check.