### PR TITLE
LibGfx: Cache family, width, weight, and slope for OpenType fonts

### DIFF
--- a/Userland/Libraries/LibGfx/Font/OpenType/Font.h
+++ b/Userland/Libraries/LibGfx/Font/OpenType/Font.h
@@ -138,6 +138,11 @@ private:
 
     mutable HashMap<u32, i16> m_kerning_cache;
 
+    Optional<String> mutable m_family;
+    Optional<u16> mutable m_width;
+    Optional<u16> mutable m_weight;
+    Optional<u8> mutable m_slope;
+
     GlyphPage const& glyph_page(size_t page_index) const;
     void populate_glyph_page(GlyphPage&, size_t page_index) const;
 };

--- a/Userland/Libraries/LibGfx/Font/OpenType/Font.h
+++ b/Userland/Libraries/LibGfx/Font/OpenType/Font.h
@@ -132,11 +132,11 @@ private:
     };
 
     // Fast cache for GlyphPage #0 (code points 0-255) to avoid hash lookups for all of ASCII and Latin-1.
-    mutable OwnPtr<GlyphPage> m_glyph_page_zero;
+    OwnPtr<GlyphPage> mutable m_glyph_page_zero;
 
-    mutable HashMap<size_t, NonnullOwnPtr<GlyphPage>> m_glyph_pages;
+    HashMap<size_t, NonnullOwnPtr<GlyphPage>> mutable m_glyph_pages;
 
-    mutable HashMap<u32, i16> m_kerning_cache;
+    HashMap<u32, i16> mutable m_kerning_cache;
 
     Optional<String> mutable m_family;
     Optional<u16> mutable m_width;


### PR DESCRIPTION
These properties could be cached in the font object once they are decoded from the table for the first time to make subsequent access faster.

This change makes `Node::scaled_font()` in LibWeb go down from 6% to 1.5% in my profiles because building a font cache key is now a lot cheaper.