### PR TITLE
LibJS: Don't use Handle<Value> for JS::Object private fields

### DIFF
--- a/Userland/Libraries/LibJS/AST.cpp
+++ b/Userland/Libraries/LibJS/AST.cpp
@@ -201,13 +201,13 @@ ThrowCompletionOr<ClassElement::ClassValue> ClassMethod::class_element_evaluatio
         switch (kind()) {
         case Kind::Method:
             set_function_name();
-            return ClassValue { PrivateElement { private_name, PrivateElement::Kind::Method, make_handle(method_value) } };
+            return ClassValue { PrivateElement { private_name, PrivateElement::Kind::Method, method_value } };
         case Kind::Getter:
             set_function_name("get");
-            return ClassValue { PrivateElement { private_name, PrivateElement::Kind::Accessor, make_handle(Value(Accessor::create(vm, &method_function, nullptr))) } };
+            return ClassValue { PrivateElement { private_name, PrivateElement::Kind::Accessor, Value(Accessor::create(vm, &method_function, nullptr)) } };
         case Kind::Setter:
             set_function_name("set");
-            return ClassValue { PrivateElement { private_name, PrivateElement::Kind::Accessor, make_handle(Value(Accessor::create(vm, nullptr, &method_function))) } };
+            return ClassValue { PrivateElement { private_name, PrivateElement::Kind::Accessor, Value(Accessor::create(vm, nullptr, &method_function)) } };
         default:
             VERIFY_NOT_REACHED();
         }
@@ -392,11 +392,11 @@ ThrowCompletionOr<ECMAScriptFunctionObject*> ClassExpression::create_class_const
                 if (existing.key == private_element.key) {
                     VERIFY(existing.kind == PrivateElement::Kind::Accessor);
                     VERIFY(private_element.kind == PrivateElement::Kind::Accessor);
-                    auto& accessor = private_element.value.value().as_accessor();
+                    auto& accessor = private_element.value.as_accessor();
                     if (!accessor.getter())
-                        existing.value.value().as_accessor().set_setter(accessor.setter());
+                        existing.value.as_accessor().set_setter(accessor.setter());
                     else
-                        existing.value.value().as_accessor().set_getter(accessor.getter());
+                        existing.value.as_accessor().set_getter(accessor.getter());
                     added_to_existing = true;
                 }
             }

--- a/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
@@ -538,6 +538,9 @@ void ECMAScriptFunctionObject::visit_edges(Visitor& visitor)
             visitor.visit(property_key_ptr->as_symbol());
     }
 
+    for (auto& private_element : m_private_methods)
+        visitor.visit(private_element.value);
+
     m_script_or_module.visit(
         [](Empty) {},
         [&](auto& script_or_module) {

--- a/Userland/Libraries/LibJS/Runtime/Object.h
+++ b/Userland/Libraries/LibJS/Runtime/Object.h
@@ -37,7 +37,7 @@ struct PrivateElement {
 
     PrivateName key;
     Kind kind { Kind::Field };
-    Handle<Value> value;
+    Value value;
 };
 
 // Non-standard: This is information optionally returned by object property access functions.


### PR DESCRIPTION
There's no reason to use handles here, we can just mark private element values from Object::visit_edges().