### PR TITLE
LibWebView: A couple Inspector fixes and QoL improvements

### DIFF
--- a/Base/res/ladybird/inspector.css
+++ b/Base/res/ladybird/inspector.css
@@ -204,6 +204,14 @@ details > :not(:first-child) {
         color: cyan;
     }
 
+    .console-message {
+        color: lightskyblue;
+    }
+
+    .console-warning {
+        color: orange;
+    }
+
     .console-input {
         background-color: rgb(57, 57, 57);
     }
@@ -216,6 +224,14 @@ details > :not(:first-child) {
 @media (prefers-color-scheme: light) {
     .console-prompt {
         color: blue;
+    }
+
+    .console-message {
+        color: blue;
+    }
+
+    .console-warning {
+        color: darkorange;
     }
 
     .console-input {

--- a/Base/res/ladybird/inspector.js
+++ b/Base/res/ladybird/inspector.js
@@ -262,10 +262,9 @@ const editDOMNode = domNode => {
     }
 
     const domNodeID = selectedDOMNode.dataset.id;
+    const type = domNode.dataset.nodeType;
 
     const handleChange = value => {
-        const type = domNode.dataset.nodeType;
-
         if (type === "text" || type === "comment") {
             inspector.setDOMNodeText(domNodeID, value);
         } else if (type === "tag") {
@@ -282,7 +281,12 @@ const editDOMNode = domNode => {
     };
 
     let editor = createDOMEditor(handleChange, cancelChange);
-    editor.value = domNode.innerText;
+
+    if (type === "text") {
+        editor.value = domNode.dataset.text;
+    } else {
+        editor.value = domNode.innerText;
+    }
 
     domNode.parentNode.replaceChild(editor, domNode);
 };

--- a/Userland/Libraries/LibWebView/InspectorClient.cpp
+++ b/Userland/Libraries/LibWebView/InspectorClient.cpp
@@ -501,8 +501,10 @@ String InspectorClient::generate_dom_tree(JsonObject const& dom_tree)
             auto comment = node.get_deprecated_string("data"sv).release_value();
             comment = escape_html_entities(comment);
 
-            builder.appendff("<span data-node-type=\"comment\" class=\"hoverable editable comment\" {}>", data_attributes.string_view());
-            builder.appendff("&lt;!--{}--&gt;", comment);
+            builder.appendff("<span class=\"hoverable comment\" {}>", data_attributes.string_view());
+            builder.append("<span>&lt;!--</span>"sv);
+            builder.appendff("<span data-node-type=\"comment\" class=\"editable\">{}</span>", comment);
+            builder.append("<span>--&gt;</span>"sv);
             builder.append("</span>"sv);
             return;
         }

--- a/Userland/Libraries/LibWebView/InspectorClient.cpp
+++ b/Userland/Libraries/LibWebView/InspectorClient.cpp
@@ -484,16 +484,15 @@ String InspectorClient::generate_dom_tree(JsonObject const& dom_tree)
             auto deprecated_text = node.get_deprecated_string("text"sv).release_value();
             deprecated_text = escape_html_entities(deprecated_text);
 
-            if (auto text = MUST(Web::Infra::strip_and_collapse_whitespace(deprecated_text)); text.is_empty()) {
-                builder.appendff("<span class=\"hoverable internal\" {}>", data_attributes.string_view());
-                builder.append(name);
-                builder.append("</span>"sv);
-            } else {
-                builder.appendff("<span data-node-type=\"text\" class=\"hoverable editable\" {}>", data_attributes.string_view());
-                builder.append(text);
-                builder.append("</span>"sv);
-            }
+            auto text = MUST(Web::Infra::strip_and_collapse_whitespace(deprecated_text));
+            builder.appendff("<span data-node-type=\"text\" data-text=\"{}\" class=\"hoverable editable\" {}>", text, data_attributes.string_view());
 
+            if (text.is_empty())
+                builder.appendff("<span class=\"internal\">{}</span>", name);
+            else
+                builder.append(text);
+
+            builder.append("</span>"sv);
             return;
         }
 

--- a/Userland/Libraries/LibWebView/InspectorClient.h
+++ b/Userland/Libraries/LibWebView/InspectorClient.h
@@ -53,6 +53,8 @@ private:
     void handle_console_messages(i32 start_index, ReadonlySpan<DeprecatedString> message_types, ReadonlySpan<DeprecatedString> messages);
 
     void append_console_source(StringView);
+    void append_console_message(StringView);
+    void append_console_warning(StringView);
     void append_console_output(StringView);
     void clear_console_output();
 

--- a/Userland/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Userland/Libraries/LibWebView/ViewImplementation.cpp
@@ -5,7 +5,6 @@
  */
 
 #include <AK/Error.h>
-#include <AK/LexicalPath.h>
 #include <AK/String.h>
 #include <LibCore/DateTime.h>
 #include <LibCore/StandardPaths.h>
@@ -394,7 +393,7 @@ void ViewImplementation::handle_web_content_process_crash()
     load_html(builder.to_deprecated_string());
 }
 
-static ErrorOr<void> save_screenshot(Gfx::ShareableBitmap const& bitmap)
+static ErrorOr<LexicalPath> save_screenshot(Gfx::ShareableBitmap const& bitmap)
 {
     if (!bitmap.is_valid())
         return Error::from_string_view("Failed to take a screenshot"sv);
@@ -407,10 +406,10 @@ static ErrorOr<void> save_screenshot(Gfx::ShareableBitmap const& bitmap)
     auto screenshot_file = TRY(Core::File::open(path.string(), Core::File::OpenMode::Write));
     TRY(screenshot_file->write_until_depleted(encoded));
 
-    return {};
+    return path;
 }
 
-ErrorOr<void> ViewImplementation::take_screenshot(ScreenshotType type)
+ErrorOr<LexicalPath> ViewImplementation::take_screenshot(ScreenshotType type)
 {
     Gfx::ShareableBitmap bitmap;
 
@@ -424,16 +423,13 @@ ErrorOr<void> ViewImplementation::take_screenshot(ScreenshotType type)
         break;
     }
 
-    TRY(save_screenshot(bitmap));
-    return {};
+    return save_screenshot(bitmap);
 }
 
-ErrorOr<void> ViewImplementation::take_dom_node_screenshot(i32 node_id)
+ErrorOr<LexicalPath> ViewImplementation::take_dom_node_screenshot(i32 node_id)
 {
     auto bitmap = client().take_dom_node_screenshot(node_id);
-    TRY(save_screenshot(bitmap));
-
-    return {};
+    return save_screenshot(bitmap);
 }
 
 void ViewImplementation::set_user_style_sheet(String source)

--- a/Userland/Libraries/LibWebView/ViewImplementation.h
+++ b/Userland/Libraries/LibWebView/ViewImplementation.h
@@ -9,6 +9,7 @@
 
 #include <AK/Forward.h>
 #include <AK/Function.h>
+#include <AK/LexicalPath.h>
 #include <AK/String.h>
 #include <LibGfx/Forward.h>
 #include <LibGfx/StandardCursor.h>
@@ -95,8 +96,8 @@ public:
         Visible,
         Full,
     };
-    ErrorOr<void> take_screenshot(ScreenshotType);
-    ErrorOr<void> take_dom_node_screenshot(i32);
+    ErrorOr<LexicalPath> take_screenshot(ScreenshotType);
+    ErrorOr<LexicalPath> take_dom_node_screenshot(i32);
 
     void set_user_style_sheet(String source);
     // Load Native.css as the User style sheet, which attempts to make WebView content look as close to

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -851,7 +851,7 @@ Messages::WebContentServer::TakeDocumentScreenshotResponse ConnectionFromClient:
 {
     auto* document = page().page().top_level_browsing_context().active_document();
     if (!document || !document->document_element())
-        return { {} };
+        return Gfx::ShareableBitmap {};
 
     auto const& content_size = page().content_size();
     Web::DevicePixelRect rect { { 0, 0 }, content_size };
@@ -859,21 +859,21 @@ Messages::WebContentServer::TakeDocumentScreenshotResponse ConnectionFromClient:
     auto bitmap = Gfx::Bitmap::create(Gfx::BitmapFormat::BGRA8888, rect.size().to_type<int>()).release_value_but_fixme_should_propagate_errors();
     page().paint(rect, *bitmap);
 
-    return { bitmap->to_shareable_bitmap() };
+    return bitmap->to_shareable_bitmap();
 }
 
 Messages::WebContentServer::TakeDomNodeScreenshotResponse ConnectionFromClient::take_dom_node_screenshot(i32 node_id)
 {
     auto* dom_node = Web::DOM::Node::from_unique_id(node_id);
     if (!dom_node || !dom_node->paintable_box())
-        return { {} };
+        return Gfx::ShareableBitmap {};
 
     auto rect = page().page().enclosing_device_rect(dom_node->paintable_box()->absolute_border_box_rect());
 
     auto bitmap = Gfx::Bitmap::create(Gfx::BitmapFormat::BGRA8888, rect.size().to_type<int>()).release_value_but_fixme_should_propagate_errors();
     page().paint(rect, *bitmap, { .paint_overlay = Web::PaintOptions::PaintOverlay::No });
 
-    return { bitmap->to_shareable_bitmap() };
+    return bitmap->to_shareable_bitmap();
 }
 
 Messages::WebContentServer::GetSelectedTextResponse ConnectionFromClient::get_selected_text()


### PR DESCRIPTION
* After taking a screenshot, log the path to saved image to the Inspector console
* Fix editing of DOM comments
* Allow editing empty DOM text nodes


https://github.com/SerenityOS/serenity/assets/5600524/05dff3d7-dd84-4da9-8e59-8f8828b3dcd7

