### PR TITLE
AK+Everywhere: Disallow calling {String,FlyString}::from_utf8 on String/FlyString

### DIFF
--- a/AK/FlyString.h
+++ b/AK/FlyString.h
@@ -22,7 +22,7 @@ public:
 
     static ErrorOr<FlyString> from_utf8(StringView);
     template<typename T>
-    requires(IsOneOf<RemoveCVReference<T>, DeprecatedString, DeprecatedFlyString>)
+    requires(IsOneOf<RemoveCVReference<T>, DeprecatedString, DeprecatedFlyString, FlyString, String>)
     static ErrorOr<String> from_utf8(T&&) = delete;
 
     FlyString(String const&);

--- a/AK/String.h
+++ b/AK/String.h
@@ -67,7 +67,7 @@ public:
     // Creates a new String from a sequence of UTF-8 encoded code points.
     static ErrorOr<String> from_utf8(StringView);
     template<typename T>
-    requires(IsOneOf<RemoveCVReference<T>, DeprecatedString, DeprecatedFlyString>)
+    requires(IsOneOf<RemoveCVReference<T>, DeprecatedString, DeprecatedFlyString, FlyString, String>)
     static ErrorOr<String> from_utf8(T&&) = delete;
 
     // Creates a new String by reading byte_count bytes from a UTF-8 encoded Stream.

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -421,7 +421,7 @@ NonnullRefPtr<Rule> Parser::consume_an_at_rule(TokenStream<T>& tokens)
 
     // Create a new at-rule with its name set to the value of the current input token, its prelude initially set to an empty list, and its value initially set to nothing.
     // NOTE: We create the Rule fully initialized when we return it instead.
-    auto at_rule_name = FlyString::from_utf8(((Token)name_ident).at_keyword()).release_value_but_fixme_should_propagate_errors();
+    auto at_rule_name = ((Token)name_ident).at_keyword();
     Vector<ComponentValue> prelude;
     RefPtr<Block> block;
 
@@ -704,7 +704,7 @@ NonnullRefPtr<Function> Parser::consume_a_function(TokenStream<T>& tokens)
     // Create a function with its name equal to the value of the current input token
     // and with its value initially set to an empty list.
     // NOTE: We create the Function fully initialized when we return it instead.
-    auto function_name = FlyString::from_utf8(((Token)name_ident).function()).release_value_but_fixme_should_propagate_errors();
+    auto function_name = ((Token)name_ident).function();
     Vector<ComponentValue> function_values;
 
     // Repeatedly consume the next input token and process it as follows:
@@ -759,7 +759,7 @@ Optional<Declaration> Parser::consume_a_declaration(TokenStream<T>& tokens)
     // Create a new declaration with its name set to the value of the current input token
     // and its value initially set to the empty list.
     // NOTE: We create a fully-initialized Declaration just before returning it instead.
-    auto declaration_name = FlyString::from_utf8(((Token)token).ident()).release_value_but_fixme_should_propagate_errors();
+    auto declaration_name = ((Token)token).ident();
     Vector<ComponentValue> declaration_values;
     Important declaration_important = Important::No;
 
@@ -6064,7 +6064,7 @@ Optional<Parser::PropertyAndValue> Parser::parse_css_value_for_properties(Readon
         // Custom idents
         if (auto property = any_property_accepts_type(property_ids, ValueType::CustomIdent); property.has_value()) {
             (void)tokens.next_token();
-            return PropertyAndValue { *property, CustomIdentStyleValue::create(MUST(FlyString::from_utf8(peek_token.token().ident()))) };
+            return PropertyAndValue { *property, CustomIdentStyleValue::create(peek_token.token().ident()) };
         }
     }
 
@@ -6726,7 +6726,7 @@ bool Parser::expand_variables(DOM::Element& element, Optional<Selector::PseudoEl
             TokenStream source_function_contents { source_function.values() };
             if (!expand_variables(element, pseudo_element, property_name, dependencies, source_function_contents, function_values))
                 return false;
-            NonnullRefPtr<Function> function = Function::create(FlyString::from_utf8(source_function.name()).release_value_but_fixme_should_propagate_errors(), move(function_values));
+            NonnullRefPtr<Function> function = Function::create(source_function.name(), move(function_values));
             dest.empend(function);
             continue;
         }
@@ -6748,13 +6748,13 @@ bool Parser::expand_variables(DOM::Element& element, Optional<Selector::PseudoEl
         // but rebuilding it every time.
         if (custom_property_name == property_name)
             return false;
-        auto parent = get_dependency_node(FlyString::from_utf8(property_name).release_value_but_fixme_should_propagate_errors());
-        auto child = get_dependency_node(FlyString::from_utf8(custom_property_name).release_value_but_fixme_should_propagate_errors());
+        auto parent = get_dependency_node(MUST(FlyString::from_utf8(property_name)));
+        auto child = get_dependency_node(custom_property_name);
         parent->add_child(child);
         if (parent->has_cycles())
             return false;
 
-        if (auto custom_property_value = get_custom_property(element, pseudo_element, FlyString::from_utf8(custom_property_name).release_value_but_fixme_should_propagate_errors())) {
+        if (auto custom_property_value = get_custom_property(element, pseudo_element, custom_property_name)) {
             VERIFY(custom_property_value->is_unresolved());
             TokenStream custom_property_tokens { custom_property_value->as_unresolved().values() };
             if (!expand_variables(element, pseudo_element, custom_property_name, dependencies, custom_property_tokens, dest))
@@ -6867,7 +6867,7 @@ bool Parser::substitute_attr_function(DOM::Element& element, StringView property
     // - Attribute type (optional)
     auto attribute_type = "string"_fly_string;
     if (attr_contents.peek_token().is(Token::Type::Ident)) {
-        attribute_type = MUST(FlyString::from_utf8(attr_contents.next_token().token().ident()));
+        attribute_type = attr_contents.next_token().token().ident();
         attr_contents.skip_whitespace();
     }
 

--- a/Userland/Libraries/LibWeb/CSS/Parser/SelectorParsing.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/SelectorParsing.cpp
@@ -295,8 +295,8 @@ Parser::ParseErrorOr<Selector::SimpleSelector> Parser::parse_attribute_simple_se
         dbgln_if(CSS_PARSER_DEBUG, "Expected a string or ident for the value to match attribute against, got: '{}'", value_part.to_debug_string());
         return ParseError::SyntaxError;
     }
-    auto value_string_view = value_part.token().is(Token::Type::Ident) ? value_part.token().ident() : value_part.token().string();
-    simple_selector.attribute().value = String::from_utf8(value_string_view).release_value_but_fixme_should_propagate_errors();
+    auto const& value_string = value_part.token().is(Token::Type::Ident) ? value_part.token().ident() : value_part.token().string();
+    simple_selector.attribute().value = value_string.to_string();
 
     attribute_tokens.skip_whitespace();
     // Handle case-sensitivity suffixes. https://www.w3.org/TR/selectors-4/#attribute-case

--- a/Userland/Libraries/LibWeb/CSS/Parser/SelectorParsing.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/SelectorParsing.cpp
@@ -142,8 +142,8 @@ Optional<Selector::SimpleSelector::QualifiedName> Parser::parse_selector_qualifi
     };
     auto get_name = [](ComponentValue const& token) {
         if (token.is_delim('*'))
-            return FlyString::from_utf8("*"sv);
-        return FlyString::from_utf8(token.token().ident());
+            return "*"_fly_string;
+        return token.token().ident();
     };
 
     // There are 3 possibilities here:
@@ -167,7 +167,7 @@ Optional<Selector::SimpleSelector::QualifiedName> Parser::parse_selector_qualifi
             transaction.commit();
             return Selector::SimpleSelector::QualifiedName {
                 .namespace_type = Selector::SimpleSelector::QualifiedName::NamespaceType::None,
-                .name = get_name(name_token).release_value_but_fixme_should_propagate_errors(),
+                .name = get_name(name_token),
             };
         }
         return {};
@@ -179,8 +179,8 @@ Optional<Selector::SimpleSelector::QualifiedName> Parser::parse_selector_qualifi
     if (tokens.peek_token().is_delim('|') && is_name(tokens.peek_token(1))) {
         // Case 2: `<namespace>|<name>`
         (void)tokens.next_token(); // `|`
-        auto namespace_ = get_name(first_token).release_value_but_fixme_should_propagate_errors();
-        auto name = get_name(tokens.next_token()).release_value_but_fixme_should_propagate_errors();
+        auto namespace_ = get_name(first_token);
+        auto name = get_name(tokens.next_token());
 
         if (allow_wildcard_name == AllowWildcardName::No && name == "*"sv)
             return {};
@@ -205,7 +205,7 @@ Optional<Selector::SimpleSelector::QualifiedName> Parser::parse_selector_qualifi
     transaction.commit();
     return Selector::SimpleSelector::QualifiedName {
         .namespace_type = Selector::SimpleSelector::QualifiedName::NamespaceType::Default,
-        .name = get_name(name_token).release_value_but_fixme_should_propagate_errors(),
+        .name = get_name(name_token),
     };
 }
 
@@ -550,7 +550,7 @@ Parser::ParseErrorOr<Selector::SimpleSelector> Parser::parse_pseudo_simple_selec
                 }
 
                 auto language_string = language_token.is(Token::Type::String) ? language_token.token().string() : language_token.token().ident();
-                languages.append(MUST(FlyString::from_utf8(language_string)));
+                languages.append(language_string);
 
                 language_token_stream.skip_whitespace();
                 if (language_token_stream.has_next_token()) {
@@ -629,7 +629,7 @@ Parser::ParseErrorOr<Optional<Selector::SimpleSelector>> Parser::parse_simple_se
             }
             return Selector::SimpleSelector {
                 .type = Selector::SimpleSelector::Type::Class,
-                .value = Selector::SimpleSelector::Name { FlyString::from_utf8(class_name_value.token().ident()).release_value_but_fixme_should_propagate_errors() }
+                .value = Selector::SimpleSelector::Name { class_name_value.token().ident() }
             };
         }
         case '>':
@@ -653,7 +653,7 @@ Parser::ParseErrorOr<Optional<Selector::SimpleSelector>> Parser::parse_simple_se
         }
         return Selector::SimpleSelector {
             .type = Selector::SimpleSelector::Type::Id,
-            .value = Selector::SimpleSelector::Name { FlyString::from_utf8(first_value.token().hash_value()).release_value_but_fixme_should_propagate_errors() }
+            .value = Selector::SimpleSelector::Name { first_value.token().hash_value() }
         };
     }
 

--- a/Userland/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.cpp
+++ b/Userland/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.cpp
@@ -343,7 +343,7 @@ void WindowOrWorkerGlobalScopeMixin::queue_performance_entry(JS::NonnullGCPtr<Pe
         //    or whose type member equals to entryType:
         auto iterator = registered_observer->options_list().find_if([&entry_type](PerformanceTimeline::PerformanceObserverInit const& entry) {
             if (entry.entry_types.has_value())
-                return entry.entry_types->contains_slow(String::from_utf8(entry_type).release_value_but_fixme_should_propagate_errors());
+                return entry.entry_types->contains_slow(entry_type.to_string());
 
             VERIFY(entry.type.has_value());
             return entry.type.value() == entry_type;

--- a/Userland/Services/DeviceMapper/DeviceEventLoop.cpp
+++ b/Userland/Services/DeviceMapper/DeviceEventLoop.cpp
@@ -131,7 +131,7 @@ ErrorOr<void> DeviceEventLoop::register_new_device(DeviceNodeFamily::Type unix_d
     }
     auto allocated_suffix_index = possible_allocated_suffix_index.release_value();
 
-    auto path = TRY(String::from_utf8(path_pattern));
+    auto path = path_pattern;
     if (match.path_pattern.contains("%digit"sv)) {
         auto replacement = TRY(build_suffix_with_numbers(allocated_suffix_index));
         path = TRY(path.replace("%digit"sv, replacement, ReplaceMode::All));

--- a/Userland/Shell/ImmediateFunctions.cpp
+++ b/Userland/Shell/ImmediateFunctions.cpp
@@ -256,7 +256,7 @@ ErrorOr<RefPtr<AST::Node>> Shell::immediate_remove_suffix(AST::ImmediateExpressi
     Vector<NonnullRefPtr<AST::Node>> nodes;
 
     for (auto& value_str : values) {
-        String removed = TRY(String::from_utf8(value_str));
+        String removed = value_str;
 
         if (value_str.bytes_as_string_view().ends_with(suffix_str))
             removed = TRY(removed.substring_from_byte_offset(0, value_str.bytes_as_string_view().length() - suffix_str.bytes_as_string_view().length()));
@@ -288,7 +288,7 @@ ErrorOr<RefPtr<AST::Node>> Shell::immediate_remove_prefix(AST::ImmediateExpressi
     Vector<NonnullRefPtr<AST::Node>> nodes;
 
     for (auto& value_str : values) {
-        String removed = TRY(String::from_utf8(value_str));
+        String removed = value_str;
 
         if (value_str.bytes_as_string_view().starts_with(prefix_str))
             removed = TRY(removed.substring_from_byte_offset(prefix_str.bytes_as_string_view().length()));

--- a/Userland/Shell/PosixParser.cpp
+++ b/Userland/Shell/PosixParser.cpp
@@ -213,7 +213,7 @@ void Parser::handle_heredoc_contents()
 
             return make_ref_counted<AST::StringLiteral>(
                 token.position.value_or(empty_position()),
-                TRY(String::from_utf8(token.value)),
+                token.value,
                 AST::StringLiteral::EnclosureType::None);
         }();
 
@@ -929,7 +929,7 @@ ErrorOr<RefPtr<AST::Node>> Parser::parse_function_definition()
 
     return make_ref_counted<AST::FunctionDeclaration>(
         name.position.value_or(empty_position()).with_end(peek().position.value_or(empty_position())),
-        AST::NameWithPosition { TRY(String::from_utf8(name.value)), name.position.value_or(empty_position()) },
+        AST::NameWithPosition { name.value, name.position.value_or(empty_position()) },
         Vector<AST::NameWithPosition> {},
         body.release_nonnull());
 }
@@ -1603,7 +1603,7 @@ ErrorOr<RefPtr<AST::Node>> Parser::parse_word()
                     token.position.value_or(empty_position()),
                     make_ref_counted<AST::StringLiteral>(
                         token.position.value_or(empty_position()),
-                        TRY(String::from_utf8(x.source_expression)),
+                        x.source_expression,
                         AST::StringLiteral::EnclosureType::DoubleQuotes)),
             },
             Optional<AST::Position> {});


### PR DESCRIPTION
I was working on https://github.com/SerenityOS/serenity/issues/21959 and noticed from_utf8 being called in some cases when we already had a FlyString/String.

A lot of this in the CSS Parser I had accidentally introduced in 6813dcaff8bdf164e0fb37567d36f6667c915627, assuming that this wouldn't compile. This MR fixes up all instances of that, and prevents such code from compiling in the future.