### PR TITLE
LibWeb: Bring HTMLElement.offset{Left,Top,Parent} closer to spec

### DIFF
--- a/Tests/LibWeb/Text/expected/HTML/HTMLElement-offsetFoo-in-table-cell.txt
+++ b/Tests/LibWeb/Text/expected/HTML/HTMLElement-offsetFoo-in-table-cell.txt
@@ -1,0 +1,21 @@
+   
+nodeName: CANVAS
+offsetTop: 0
+offsetLeft: 0
+offsetParent: [object HTMLTableCellElement]
+
+nodeName: TD
+offsetTop: 2
+offsetLeft: 2
+offsetParent: [object HTMLTableElement]
+
+nodeName: TABLE
+offsetTop: 100
+offsetLeft: 50
+offsetParent: [object HTMLBodyElement]
+
+nodeName: BODY
+offsetTop: 0
+offsetLeft: 0
+offsetParent: null
+

--- a/Tests/LibWeb/Text/input/HTML/HTMLElement-offsetFoo-in-table-cell.html
+++ b/Tests/LibWeb/Text/input/HTML/HTMLElement-offsetFoo-in-table-cell.html
@@ -1,0 +1,26 @@
+<style>
+* {
+    margin: 0;
+    padding: 0;
+}
+table {
+    position: relative;
+    top: 100px;
+    left: 50px;
+}
+</style><table><tr><td><canvas id="c"></canvas></td></tr></table>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const c = document.getElementById("c");
+        println("");
+
+        for (let n = c; n; n = n.offsetParent) {
+            println("nodeName: " + n.nodeName);
+            println("offsetTop: " + n.offsetTop);
+            println("offsetLeft: " + n.offsetLeft);
+            println("offsetParent: " + n.offsetParent);
+            println("");
+        }
+    });
+</script>

--- a/Userland/Libraries/LibWeb/HTML/HTMLElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLElement.h
@@ -44,6 +44,7 @@ public:
     int offset_left() const;
     int offset_width() const;
     int offset_height() const;
+    JS::GCPtr<Element> offset_parent() const;
 
     bool cannot_navigate() const;
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLElement.idl
@@ -37,7 +37,7 @@ interface HTMLElement : Element {
     // FIXME: [CEReactions] attribute DOMString? popover;
 
     // https://drafts.csswg.org/cssom-view/#extensions-to-the-htmlelement-interface
-    // FIXME: readonly attribute Element? offsetParent;
+    readonly attribute Element? offsetParent;
     readonly attribute long offsetTop;
     readonly attribute long offsetLeft;
     readonly attribute long offsetWidth;


### PR DESCRIPTION
(Or rather, bring offsetLeft and offsetTop closer to spec, and implement the previously-missing offsetParent)

This makes mouse inputs on https://nerget.com/fluidSim/ work properly.