### PR TITLE
LibUnicode: Use weak symbols to provide default IDNA defintions

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateIDNAData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateIDNAData.cpp
@@ -106,13 +106,7 @@ static ErrorOr<void> generate_idna_data_header(Core::InputBufferedFile& file, ID
     generator.append(R"~~~(
 #pragma once
 
-#include <AK/Optional.h>
-#include <LibUnicode/IDNA.h>
-
 namespace Unicode::IDNA {
-
-Optional<Mapping> get_idna_mapping(u32 code_point);
-
 }
 )~~~");
 
@@ -128,11 +122,12 @@ static ErrorOr<void> generate_idna_data_implementation(Core::InputBufferedFile& 
     generator.set("idna_table_size", TRY(String::number(idna_data.mapping_table.size())));
 
     generator.append(R"~~~(
-
 #include <AK/BinarySearch.h>
+#include <AK/Optional.h>
 #include <AK/Utf32View.h>
-#include <LibUnicode/IDNAData.h>
 #include <LibUnicode/CharacterTypes.h>
+#include <LibUnicode/IDNA.h>
+#include <LibUnicode/IDNAData.h>
 
 namespace Unicode::IDNA {
 

--- a/Userland/Libraries/LibUnicode/IDNA.cpp
+++ b/Userland/Libraries/LibUnicode/IDNA.cpp
@@ -18,14 +18,7 @@
 
 namespace Unicode::IDNA {
 
-#if not ENABLE_UNICODE_DATA
-
-Optional<Mapping> get_idna_mapping(u32)
-{
-    return {};
-}
-
-#endif
+Optional<Mapping> __attribute__((weak)) get_idna_mapping(u32) { return {}; }
 
 struct ProcessingResult {
     Vector<String> result {};

--- a/Userland/Libraries/LibUnicode/IDNA.h
+++ b/Userland/Libraries/LibUnicode/IDNA.h
@@ -73,5 +73,6 @@ struct ToAsciiOptions {
 };
 
 ErrorOr<String> to_ascii(Utf8View domain_name, ToAsciiOptions const& = {});
+Optional<Mapping> get_idna_mapping(u32 code_point);
 
 }

--- a/Userland/Libraries/LibUnicode/UnicodeUtils.cpp
+++ b/Userland/Libraries/LibUnicode/UnicodeUtils.cpp
@@ -266,7 +266,7 @@ ErrorOr<void> build_uppercase_string([[maybe_unused]] Utf8View code_points, [[ma
 }
 
 // https://www.unicode.org/versions/Unicode15.0.0/ch03.pdf#G34078
-ErrorOr<void> build_titlecase_string([[maybe_unused]] Utf8View code_points, [[maybe_unused]] StringBuilder& builder, [[maybe_unused]] Optional<StringView> const& locale, TrailingCodePointTransformation trailing_code_point_transformation)
+ErrorOr<void> build_titlecase_string([[maybe_unused]] Utf8View code_points, [[maybe_unused]] StringBuilder& builder, [[maybe_unused]] Optional<StringView> const& locale, [[maybe_unused]] TrailingCodePointTransformation trailing_code_point_transformation)
 {
 #if ENABLE_UNICODE_DATA
     // toTitlecase(X): Find the word boundaries in X according to Unicode Standard Annex #29,


### PR DESCRIPTION
Rather than using `#ifdef` blocks, update the fallback IDNA definitions to
use weak symbols to match the rest of LibUnicode / LibLocale.

(Neglected to realize this while reviewing #19414)