### PR TITLE
Ladybird+LibWebView: Ensure existing Inspector widgets inspect the page

### DIFF
--- a/Base/res/ladybird/inspector.js
+++ b/Base/res/ladybird/inspector.js
@@ -85,6 +85,19 @@ const scrollToElement = element => {
     window.scrollTo(0, position);
 };
 
+inspector.reset = () => {
+    let domTree = document.getElementById("dom-tree");
+    domTree.innerHTML = "";
+
+    let accessibilityTree = document.getElementById("accessibility-tree");
+    accessibilityTree.innerHTML = "";
+
+    selectedDOMNode = null;
+    pendingEditDOMNode = null;
+
+    inspector.clearConsoleOutput();
+};
+
 inspector.loadDOMTree = tree => {
     let domTree = document.getElementById("dom-tree");
     domTree.innerHTML = atob(tree);

--- a/Ladybird/Qt/Tab.cpp
+++ b/Ladybird/Qt/Tab.cpp
@@ -750,6 +750,8 @@ void Tab::show_inspector_window(InspectorTarget inspector_target)
 {
     if (!m_inspector_widget)
         m_inspector_widget = new InspectorWidget(this, view());
+    else
+        m_inspector_widget->inspect();
 
     m_inspector_widget->show();
     m_inspector_widget->activateWindow();

--- a/Userland/Applications/Browser/Tab.cpp
+++ b/Userland/Applications/Browser/Tab.cpp
@@ -923,6 +923,8 @@ void Tab::show_inspector_window(Browser::Tab::InspectorTarget inspector_target)
         };
 
         m_dom_inspector_widget = window->set_main_widget<InspectorWidget>(*m_web_content_view);
+    } else {
+        m_dom_inspector_widget->inspect();
     }
 
     if (inspector_target == InspectorTarget::HoveredElement) {

--- a/Userland/Libraries/LibWebView/InspectorClient.cpp
+++ b/Userland/Libraries/LibWebView/InspectorClient.cpp
@@ -181,12 +181,13 @@ void InspectorClient::inspect()
 
 void InspectorClient::reset()
 {
+    static constexpr auto script = "inspector.reset();"sv;
+    m_inspector_web_view.run_javascript(script);
+
     m_body_node_id.clear();
     m_pending_selection.clear();
-
     m_dom_tree_loaded = false;
 
-    clear_console_output();
     m_highest_notified_message_index = -1;
     m_highest_received_message_index = -1;
     m_waiting_for_messages = false;

--- a/Userland/Libraries/LibWebView/InspectorClient.cpp
+++ b/Userland/Libraries/LibWebView/InspectorClient.cpp
@@ -174,7 +174,9 @@ InspectorClient::~InspectorClient()
 
 void InspectorClient::inspect()
 {
-    m_dom_tree_loaded = false;
+    if (m_dom_tree_loaded)
+        return;
+
     m_content_web_view.inspect_dom_tree();
     m_content_web_view.inspect_accessibility_tree();
 }


### PR DESCRIPTION
A couple fixes related to navigating to new pages with an existing Inspector widget.