### PR TITLE
LibPDF: Baby steps toward better inline image support

### DIFF
--- a/Userland/Libraries/LibPDF/Parser.cpp
+++ b/Userland/Libraries/LibPDF/Parser.cpp
@@ -557,12 +557,13 @@ PDFErrorOr<Vector<Operator>> Parser::parse_operators()
                 // FIXME: Check for ASCIIHexDecode and ASCII85Decode.
                 m_reader.consume(1);
 
-                // FIXME: `EI` can be part of the image data, e.g. on page 3 of 0000450.pdf of 0000.zip of the RGBA dataset.
                 while (!m_reader.done()) {
-                    if (m_reader.matches("EI")) {
+                    // FIXME: Should we allow EI after matches_delimiter() too?
+                    bool expecting_ei = m_reader.matches_whitespace();
+                    m_reader.consume();
+                    if (expecting_ei && m_reader.matches("EI")) {
                         break;
                     }
-                    m_reader.consume();
                 }
 
                 if (m_reader.done())

--- a/Userland/Libraries/LibPDF/Parser.cpp
+++ b/Userland/Libraries/LibPDF/Parser.cpp
@@ -558,6 +558,7 @@ PDFErrorOr<Vector<Operator>> Parser::parse_operators()
                 m_reader.consume(1);
 
                 // FIMXE: PDF 2.0 added support for `/L` / `/Length` in inline image dicts. If that's present, we don't have to scan for `EI`.
+                auto stream_start = m_reader.offset();
                 while (!m_reader.done()) {
                     // FIXME: Should we allow EI after matches_delimiter() too?
                     bool expecting_ei = m_reader.matches_whitespace();
@@ -570,11 +571,17 @@ PDFErrorOr<Vector<Operator>> Parser::parse_operators()
                 if (m_reader.done())
                     return error("operator stream ended inside inline image");
 
+                // Points one past the end of the stream data.
+                // FIXME: If we add matches_delimiter() to expecting_ei above, this has to be 1 larger in the delimiter case.
+                auto stream_end = m_reader.offset();
+
                 m_reader.consume(2); // "EI"
                 m_reader.consume_whitespace();
 
+                auto stream_bytes = m_reader.bytes().slice(stream_start, stream_end - stream_start);
                 // FIXME: Do more with inline images than just skipping them.
                 (void)map;
+                (void)stream_bytes;
             }
 
             operators.append(Operator(operator_type, move(operator_args)));

--- a/Userland/Libraries/LibPDF/Parser.cpp
+++ b/Userland/Libraries/LibPDF/Parser.cpp
@@ -548,6 +548,15 @@ PDFErrorOr<Vector<Operator>> Parser::parse_operators()
                 if (!operator_args.is_empty())
                     return error("operator args not empty on start of inline image");
 
+                HashMap<DeprecatedFlyString, Value> map = TRY(parse_dict_contents_until("ID"));
+                m_reader.consume(2); // "ID"
+
+                // "Unless the image uses ASCIIHexDecode or ASCII85Decode as one of its filters,
+                // the ID operator should be followed by a single white-space character,
+                // and the next character is interpreted as the first byte of image data."
+                // FIXME: Check for ASCIIHexDecode and ASCII85Decode.
+                m_reader.consume(1);
+
                 // FIXME: `EI` can be part of the image data, e.g. on page 3 of 0000450.pdf of 0000.zip of the RGBA dataset.
                 while (!m_reader.done()) {
                     if (m_reader.matches("EI")) {
@@ -563,6 +572,7 @@ PDFErrorOr<Vector<Operator>> Parser::parse_operators()
                 m_reader.consume_whitespace();
 
                 // FIXME: Do more with inline images than just skipping them.
+                (void)map;
             }
 
             operators.append(Operator(operator_type, move(operator_args)));

--- a/Userland/Libraries/LibPDF/Parser.cpp
+++ b/Userland/Libraries/LibPDF/Parser.cpp
@@ -557,6 +557,7 @@ PDFErrorOr<Vector<Operator>> Parser::parse_operators()
                 // FIXME: Check for ASCIIHexDecode and ASCII85Decode.
                 m_reader.consume(1);
 
+                // FIMXE: PDF 2.0 added support for `/L` / `/Length` in inline image dicts. If that's present, we don't have to scan for `EI`.
                 while (!m_reader.done()) {
                     // FIXME: Should we allow EI after matches_delimiter() too?
                     bool expecting_ei = m_reader.matches_whitespace();

--- a/Userland/Libraries/LibPDF/Parser.h
+++ b/Userland/Libraries/LibPDF/Parser.h
@@ -53,6 +53,7 @@ public:
     PDFErrorOr<DeprecatedString> parse_literal_string();
     PDFErrorOr<DeprecatedString> parse_hex_string();
     PDFErrorOr<NonnullRefPtr<ArrayObject>> parse_array();
+    PDFErrorOr<HashMap<DeprecatedFlyString, Value>> parse_dict_contents_until(char const*);
     PDFErrorOr<NonnullRefPtr<DictObject>> parse_dict();
     PDFErrorOr<NonnullRefPtr<StreamObject>> parse_stream(NonnullRefPtr<DictObject> dict);
     PDFErrorOr<Vector<Operator>> parse_operators();


### PR DESCRIPTION
This only adds some scaffolding, but it does reduce the number of crashes on 0000.pdf from 9 to 8, and the number of unique crash stacks from 6 to 5 (due to the third commit).