### PR TITLE
LibWeb: Allow input color to give continues updates

### DIFF
--- a/Ladybird/AppKit/UI/LadybirdWebView.mm
+++ b/Ladybird/AppKit/UI/LadybirdWebView.mm
@@ -599,6 +599,8 @@ static void copy_data_to_clipboard(StringView data, NSPasteboardType pasteboard_
         auto* panel = [NSColorPanel sharedColorPanel];
         [panel setColor:Ladybird::gfx_color_to_ns_color(current_color)];
         [panel setShowsAlpha:NO];
+        [panel setTarget:self];
+        [panel setAction:@selector(colorPickerUpdate:)];
 
         NSNotificationCenter* notification_center = [NSNotificationCenter defaultCenter];
         [notification_center addObserver:self
@@ -761,9 +763,14 @@ static void copy_data_to_clipboard(StringView data, NSPasteboardType pasteboard_
         m_web_view_bridge->select_dropdown_closed({});
 }
 
+- (void)colorPickerUpdate:(NSColorPanel*)colorPanel
+{
+    m_web_view_bridge->color_picker_update(Ladybird::ns_color_to_gfx_color(colorPanel.color), Web::HTML::ColorPickerUpdateState::Update);
+}
+
 - (void)colorPickerClosed:(NSNotification*)notification
 {
-    m_web_view_bridge->color_picker_closed(Ladybird::ns_color_to_gfx_color([[NSColorPanel sharedColorPanel] color]));
+    m_web_view_bridge->color_picker_update(Ladybird::ns_color_to_gfx_color([NSColorPanel sharedColorPanel].color), Web::HTML::ColorPickerUpdateState::Closed);
 }
 
 - (NSScrollView*)scrollView

--- a/Ladybird/Qt/Tab.cpp
+++ b/Ladybird/Qt/Tab.cpp
@@ -217,11 +217,14 @@ Tab::Tab(BrowserWindow* window, WebContentOptions const& web_content_options, St
 
         dialog.setWindowTitle("Ladybird");
         dialog.setOption(QColorDialog::ShowAlphaChannel, false);
+        QObject::connect(&dialog, &QColorDialog::currentColorChanged, this, [this](const QColor& color) {
+            view().color_picker_update(Color(color.red(), color.green(), color.blue()), Web::HTML::ColorPickerUpdateState::Update);
+        });
 
         if (dialog.exec() == QDialog::Accepted)
-            view().color_picker_closed(Color(dialog.selectedColor().red(), dialog.selectedColor().green(), dialog.selectedColor().blue()));
+            view().color_picker_update(Color(dialog.selectedColor().red(), dialog.selectedColor().green(), dialog.selectedColor().blue()), Web::HTML::ColorPickerUpdateState::Closed);
         else
-            view().color_picker_closed({});
+            view().color_picker_update({}, Web::HTML::ColorPickerUpdateState::Closed);
 
         m_dialog = nullptr;
     };

--- a/Userland/Applications/Browser/Tab.cpp
+++ b/Userland/Applications/Browser/Tab.cpp
@@ -569,11 +569,14 @@ Tab::Tab(BrowserWindow& window)
 
         dialog.set_icon(window.icon());
         dialog.set_color_has_alpha_channel(false);
+        dialog.on_color_changed = [this](Color color) {
+            view().color_picker_update(color, Web::HTML::ColorPickerUpdateState::Update);
+        };
 
         if (dialog.exec() == GUI::ColorPicker::ExecResult::OK)
-            view().color_picker_closed(dialog.color());
+            view().color_picker_update(dialog.color(), Web::HTML::ColorPickerUpdateState::Closed);
         else
-            view().color_picker_closed({});
+            view().color_picker_update({}, Web::HTML::ColorPickerUpdateState::Closed);
 
         m_dialog = nullptr;
     };

--- a/Userland/Libraries/LibWeb/HTML/ColorPickerUpdateState.h
+++ b/Userland/Libraries/LibWeb/HTML/ColorPickerUpdateState.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2023, Bastiaan van der Plaat <bastiaan.v.d.plaat@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+namespace Web::HTML {
+
+enum class ColorPickerUpdateState {
+    Update,
+    Closed,
+};
+
+}

--- a/Userland/Libraries/LibWeb/Page/Page.cpp
+++ b/Userland/Libraries/LibWeb/Page/Page.cpp
@@ -318,15 +318,17 @@ void Page::did_request_color_picker(WeakPtr<HTML::HTMLInputElement> target, Colo
     }
 }
 
-void Page::color_picker_closed(Optional<Color> picked_color)
+void Page::color_picker_update(Optional<Color> picked_color, HTML::ColorPickerUpdateState state)
 {
     if (m_pending_non_blocking_dialog == PendingNonBlockingDialog::ColorPicker) {
-        m_pending_non_blocking_dialog = PendingNonBlockingDialog::None;
+        if (state == HTML::ColorPickerUpdateState::Closed)
+            m_pending_non_blocking_dialog = PendingNonBlockingDialog::None;
 
         if (m_pending_non_blocking_dialog_target) {
             auto& input_element = verify_cast<HTML::HTMLInputElement>(*m_pending_non_blocking_dialog_target);
             input_element.did_pick_color(move(picked_color));
-            m_pending_non_blocking_dialog_target.clear();
+            if (state == HTML::ColorPickerUpdateState::Closed)
+                m_pending_non_blocking_dialog_target.clear();
         }
     }
 }

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -30,6 +30,7 @@
 #include <LibWeb/Cookie/Cookie.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/HTML/ActivateTab.h>
+#include <LibWeb/HTML/ColorPickerUpdateState.h>
 #include <LibWeb/HTML/SelectItem.h>
 #include <LibWeb/Loader/FileRequest.h>
 #include <LibWeb/PixelUnits.h>
@@ -127,7 +128,7 @@ public:
     void accept_dialog();
 
     void did_request_color_picker(WeakPtr<HTML::HTMLInputElement> target, Color current_color);
-    void color_picker_closed(Optional<Color> picked_color);
+    void color_picker_update(Optional<Color> picked_color, HTML::ColorPickerUpdateState state);
 
     void did_request_select_dropdown(WeakPtr<HTML::HTMLSelectElement> target, Web::CSSPixelPoint content_position, Web::CSSPixels minimum_width, Vector<Web::HTML::SelectItem> items);
     void select_dropdown_closed(Optional<String> value);

--- a/Userland/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Userland/Libraries/LibWebView/ViewImplementation.cpp
@@ -260,9 +260,9 @@ void ViewImplementation::prompt_closed(Optional<String> response)
     client().async_prompt_closed(move(response));
 }
 
-void ViewImplementation::color_picker_closed(Optional<Color> picked_color)
+void ViewImplementation::color_picker_update(Optional<Color> picked_color, Web::HTML::ColorPickerUpdateState state)
 {
-    client().async_color_picker_closed(picked_color);
+    client().async_color_picker_update(picked_color, state);
 }
 
 void ViewImplementation::select_dropdown_closed(Optional<String> value)

--- a/Userland/Libraries/LibWebView/ViewImplementation.h
+++ b/Userland/Libraries/LibWebView/ViewImplementation.h
@@ -15,6 +15,7 @@
 #include <LibGfx/StandardCursor.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/HTML/ActivateTab.h>
+#include <LibWeb/HTML/ColorPickerUpdateState.h>
 #include <LibWeb/HTML/SelectItem.h>
 #include <LibWebView/Forward.h>
 #include <LibWebView/WebContentClient.h>
@@ -85,7 +86,7 @@ public:
     void alert_closed();
     void confirm_closed(bool accepted);
     void prompt_closed(Optional<String> response);
-    void color_picker_closed(Optional<Color> picked_color);
+    void color_picker_update(Optional<Color> picked_color, Web::HTML::ColorPickerUpdateState state);
     void select_dropdown_closed(Optional<String> value);
 
     void toggle_media_play_state();

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -1044,9 +1044,9 @@ void ConnectionFromClient::prompt_closed(Optional<String> const& response)
     page().page().prompt_closed(response);
 }
 
-void ConnectionFromClient::color_picker_closed(Optional<Color> const& picked_color)
+void ConnectionFromClient::color_picker_update(Optional<Color> const& picked_color, Web::HTML::ColorPickerUpdateState const& state)
 {
-    page().page().color_picker_closed(picked_color);
+    page().page().color_picker_update(picked_color, state);
 }
 
 void ConnectionFromClient::select_dropdown_closed(Optional<String> const& value)

--- a/Userland/Services/WebContent/ConnectionFromClient.h
+++ b/Userland/Services/WebContent/ConnectionFromClient.h
@@ -109,7 +109,7 @@ private:
     virtual void alert_closed() override;
     virtual void confirm_closed(bool accepted) override;
     virtual void prompt_closed(Optional<String> const& response) override;
-    virtual void color_picker_closed(Optional<Color> const& picked_color) override;
+    virtual void color_picker_update(Optional<Color> const& picked_color, Web::HTML::ColorPickerUpdateState const& state) override;
     virtual void select_dropdown_closed(Optional<String> const& value) override;
 
     virtual void toggle_media_play_state() override;

--- a/Userland/Services/WebContent/PageClient.cpp
+++ b/Userland/Services/WebContent/PageClient.cpp
@@ -403,9 +403,9 @@ void PageClient::prompt_closed(Optional<String> response)
     page().prompt_closed(move(response));
 }
 
-void PageClient::color_picker_closed(Optional<Color> picked_color)
+void PageClient::color_picker_update(Optional<Color> picked_color, Web::HTML::ColorPickerUpdateState state)
 {
-    page().color_picker_closed(picked_color);
+    page().color_picker_update(picked_color, state);
 }
 
 void PageClient::select_dropdown_closed(Optional<String> value)

--- a/Userland/Services/WebContent/PageClient.h
+++ b/Userland/Services/WebContent/PageClient.h
@@ -56,7 +56,7 @@ public:
     void alert_closed();
     void confirm_closed(bool accepted);
     void prompt_closed(Optional<String> response);
-    void color_picker_closed(Optional<Color> picked_color);
+    void color_picker_update(Optional<Color> picked_color, Web::HTML::ColorPickerUpdateState state);
     void select_dropdown_closed(Optional<String> value);
 
     [[nodiscard]] Gfx::Color background_color() const;

--- a/Userland/Services/WebContent/WebContentServer.ipc
+++ b/Userland/Services/WebContent/WebContentServer.ipc
@@ -5,6 +5,7 @@
 #include <LibGfx/ShareableBitmap.h>
 #include <LibWeb/CSS/PreferredColorScheme.h>
 #include <LibWeb/CSS/Selector.h>
+#include <LibWeb/HTML/ColorPickerUpdateState.h>
 #include <LibWeb/WebDriver/ExecuteScript.h>
 #include <LibWebView/Attribute.h>
 
@@ -92,7 +93,7 @@ endpoint WebContentServer
     alert_closed() =|
     confirm_closed(bool accepted) =|
     prompt_closed(Optional<String> response) =|
-    color_picker_closed(Optional<Color> picked_color) =|
+    color_picker_update(Optional<Color> picked_color, Web::HTML::ColorPickerUpdateState state) =|
     select_dropdown_closed(Optional<String> value) =|
 
     toggle_media_play_state() =|


### PR DESCRIPTION
The input color picker currently only sends an color value back on the picker close. This pr changes that so that the color picker can give a continues stream of update color value like other browser do.

# Demo video
https://github.com/SerenityOS/serenity/assets/19894029/1c1b820f-2841-4600-9228-cac0316e427f
