### PR TITLE
LibGUI: Display commands on CommandPalette's start up

### DIFF
--- a/Userland/Libraries/LibGUI/FilteringProxyModel.cpp
+++ b/Userland/Libraries/LibGUI/FilteringProxyModel.cpp
@@ -94,7 +94,7 @@ void FilteringProxyModel::filter()
 
 void FilteringProxyModel::set_filter_term(StringView term)
 {
-    if (m_filter_term == term)
+    if (m_filter_term == term && !term.is_empty())
         return;
     m_filter_term = term;
     invalidate();


### PR DESCRIPTION
Currently, if we run CommandPalette, it's blank by default and it's not displaying all available commands for the app in which it has been opened. User has to enter something and then delete it to see all commands. This patch makes all available commands being displayed by default on start of CommandPalette, by allowing incoming empty string to be invalidated in FilteringProxyModel, instead of returning instantly.

This basically changes CommandPalette's behavior on startup from the behavior on the left of below image, to the behavior on the right of the image.
![image](https://github.com/SerenityOS/serenity/assets/59984746/c83f2f3e-881d-4b9f-9053-f9cf72abc74e)


