### PR TITLE
LibWeb+LibJS: Use JS::GCPtr for pointers to GC-allocated objects

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/BasicBlock.h
+++ b/Userland/Libraries/LibJS/Bytecode/BasicBlock.h
@@ -14,7 +14,7 @@
 namespace JS::Bytecode {
 
 struct UnwindInfo {
-    Executable const* executable;
+    JS::GCPtr<Executable const> executable;
     JS::GCPtr<Environment> lexical_environment;
 
     bool handler_called { false };

--- a/Userland/Libraries/LibJS/CyclicModule.cpp
+++ b/Userland/Libraries/LibJS/CyclicModule.cpp
@@ -40,8 +40,8 @@ void GraphLoadingState::visit_edges(Cell::Visitor& visitor)
     Base::visit_edges(visitor);
     visitor.visit(promise_capability);
     visitor.visit(host_defined);
-    for (auto* module : visited)
-        visitor.visit(*module);
+    for (auto module : visited)
+        visitor.visit(module);
 }
 
 // 16.2.1.5.1 LoadRequestedModules ( [ hostDefined ] ), https://tc39.es/ecma262/#sec-LoadRequestedModules
@@ -54,7 +54,7 @@ PromiseCapability& CyclicModule::load_requested_modules(GCPtr<GraphLoadingState:
     auto promise_capability = MUST(new_promise_capability(vm(), vm().current_realm()->intrinsics().promise_constructor()));
 
     // 3. Let state be the GraphLoadingState Record { [[IsLoading]]: true, [[PendingModulesCount]]: 1, [[Visited]]: « », [[PromiseCapability]]: pc, [[HostDefined]]: hostDefined }.
-    auto state = heap().allocate_without_realm<GraphLoadingState>(promise_capability, true, 1, HashTable<CyclicModule*> {}, move(host_defined));
+    auto state = heap().allocate_without_realm<GraphLoadingState>(promise_capability, true, 1, HashTable<JS::GCPtr<CyclicModule>> {}, move(host_defined));
 
     // 4. Perform InnerModuleLoading(state, module).
     inner_module_loading(state);

--- a/Userland/Libraries/LibJS/Module.h
+++ b/Userland/Libraries/LibJS/Module.h
@@ -71,11 +71,11 @@ public:
     GCPtr<PromiseCapability> promise_capability; // [[PromiseCapability]]
     bool is_loading { false };                   // [[IsLoading]]
     size_t pending_module_count { 0 };           // [[PendingModulesCount]]
-    HashTable<CyclicModule*> visited;            // [[Visited]]
+    HashTable<JS::GCPtr<CyclicModule>> visited;  // [[Visited]]
     GCPtr<HostDefined> host_defined;             // [[HostDefined]]
 
 private:
-    GraphLoadingState(GCPtr<PromiseCapability> promise_capability, bool is_loading, size_t pending_module_count, HashTable<CyclicModule*> visited, GCPtr<HostDefined> host_defined)
+    GraphLoadingState(GCPtr<PromiseCapability> promise_capability, bool is_loading, size_t pending_module_count, HashTable<JS::GCPtr<CyclicModule>> visited, GCPtr<HostDefined> host_defined)
         : promise_capability(move(promise_capability))
         , is_loading(is_loading)
         , pending_module_count(pending_module_count)

--- a/Userland/Libraries/LibWeb/Bindings/MainThreadVM.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/MainThreadVM.cpp
@@ -462,7 +462,7 @@ ErrorOr<void> initialize_main_thread_vm()
         auto destination = Fetch::Infrastructure::Request::Destination::Script;
 
         // 11. Let fetchClient be settingsObject.
-        Optional<HTML::EnvironmentSettingsObject&> fetch_client = *settings_object;
+        JS::NonnullGCPtr fetch_client { *settings_object };
 
         // 12. If loadState is not undefined, then:
         if (load_state) {

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -3587,7 +3587,7 @@ void Document::update_for_history_step_application(JS::NonnullGCPtr<HTML::Sessio
     }
 }
 
-HashMap<AK::URL, HTML::SharedImageRequest*>& Document::shared_image_requests()
+HashMap<AK::URL, JS::GCPtr<HTML::SharedImageRequest>>& Document::shared_image_requests()
 {
     return m_shared_image_requests;
 }

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -535,7 +535,7 @@ public:
 
     void update_for_history_step_application(JS::NonnullGCPtr<HTML::SessionHistoryEntry>, bool do_not_reactive, size_t script_history_length, size_t script_history_index);
 
-    HashMap<AK::URL, HTML::SharedImageRequest*>& shared_image_requests();
+    HashMap<AK::URL, JS::GCPtr<HTML::SharedImageRequest>>& shared_image_requests();
 
     JS::NonnullGCPtr<Animations::DocumentTimeline> timeline();
 
@@ -754,7 +754,7 @@ private:
     // https://html.spec.whatwg.org/multipage/browsing-the-web.html#latest-entry
     JS::GCPtr<HTML::SessionHistoryEntry> m_latest_entry;
 
-    HashMap<AK::URL, HTML::SharedImageRequest*> m_shared_image_requests;
+    HashMap<AK::URL, JS::GCPtr<HTML::SharedImageRequest>> m_shared_image_requests;
 
     // https://www.w3.org/TR/web-animations-1/#timeline-associated-with-a-document
     HashTable<JS::NonnullGCPtr<Animations::AnimationTimeline>> m_associated_animation_timelines;

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Fetching.h
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Fetching.h
@@ -58,10 +58,10 @@ class FetchContext : public JS::GraphLoadingState::HostDefined {
     JS_CELL(FetchContext, JS::GraphLoadingState::HostDefined);
 
 public:
-    JS::Value parse_error;                                   // [[ParseError]]
-    Fetch::Infrastructure::Request::Destination destination; // [[Destination]]
-    JS::GCPtr<JS::Promise> perform_fetch;                    // [[PerformFetch]]
-    EnvironmentSettingsObject& fetch_client;                 // [[FetchClient]]
+    JS::Value parse_error;                                    // [[ParseError]]
+    Fetch::Infrastructure::Request::Destination destination;  // [[Destination]]
+    JS::GCPtr<JS::Promise> perform_fetch;                     // [[PerformFetch]]
+    JS::NonnullGCPtr<EnvironmentSettingsObject> fetch_client; // [[FetchClient]]
 
 private:
     FetchContext(JS::Value parse_error, Fetch::Infrastructure::Request::Destination destination, JS::GCPtr<JS::Promise> perform_fetch, EnvironmentSettingsObject& fetch_client)

--- a/Userland/Libraries/LibWeb/Loader/LoadRequest.h
+++ b/Userland/Libraries/LibWeb/Loader/LoadRequest.h
@@ -43,7 +43,7 @@ public:
     void start_timer() { m_load_timer.start(); }
     Duration load_time() const { return m_load_timer.elapsed_time(); }
 
-    Optional<Page&>& page() { return m_page; }
+    JS::GCPtr<Page> page() { return m_page; }
     void set_page(Page& page) { m_page = page; }
 
     unsigned hash() const
@@ -79,7 +79,7 @@ private:
     HashMap<DeprecatedString, DeprecatedString, CaseInsensitiveStringTraits> m_headers;
     ByteBuffer m_body;
     Core::ElapsedTimer m_load_timer;
-    Optional<Page&> m_page;
+    JS::GCPtr<Page> m_page;
     bool m_main_resource { false };
 };
 

--- a/Userland/Libraries/LibWeb/Loader/LoadRequest.h
+++ b/Userland/Libraries/LibWeb/Loader/LoadRequest.h
@@ -43,7 +43,7 @@ public:
     void start_timer() { m_load_timer.start(); }
     Duration load_time() const { return m_load_timer.elapsed_time(); }
 
-    JS::GCPtr<Page> page() { return m_page; }
+    JS::GCPtr<Page> page() { return m_page.ptr(); }
     void set_page(Page& page) { m_page = page; }
 
     unsigned hash() const
@@ -79,7 +79,7 @@ private:
     HashMap<DeprecatedString, DeprecatedString, CaseInsensitiveStringTraits> m_headers;
     ByteBuffer m_body;
     Core::ElapsedTimer m_load_timer;
-    JS::GCPtr<Page> m_page;
+    JS::Handle<Page> m_page;
     bool m_main_resource { false };
 };
 

--- a/Userland/Libraries/LibWeb/Loader/ResourceLoader.cpp
+++ b/Userland/Libraries/LibWeb/Loader/ResourceLoader.cpp
@@ -231,8 +231,8 @@ void ResourceLoader::load(LoadRequest& request, SuccessCallback success_callback
     }
 
     if (url.scheme() == "file") {
-        if (request.page().has_value())
-            m_page = request.page().value();
+        if (request.page())
+            m_page = request.page();
 
         if (!m_page.has_value()) {
             log_failure(request, "INTERNAL ERROR: No Page for request");
@@ -302,7 +302,7 @@ void ResourceLoader::load(LoadRequest& request, SuccessCallback success_callback
             success_callback(data, response_headers, {});
         });
 
-        m_page->client().request_file(move(file_request));
+        (*m_page)->client().request_file(move(file_request));
 
         ++m_pending_loads;
         if (on_load_counter_change)
@@ -348,9 +348,9 @@ void ResourceLoader::load(LoadRequest& request, SuccessCallback success_callback
             if (on_load_counter_change)
                 on_load_counter_change();
 
-            if (request.page().has_value()) {
+            if (request.page()) {
                 if (auto set_cookie = response_headers.get("Set-Cookie"); set_cookie.has_value())
-                    store_response_cookies(request.page().value(), request.url(), *set_cookie);
+                    store_response_cookies(*request.page(), request.url(), *set_cookie);
                 if (auto cache_control = response_headers.get("cache-control"); cache_control.has_value()) {
                     if (cache_control.value().contains("no-store"sv)) {
                         s_resource_cache.remove(request);

--- a/Userland/Libraries/LibWeb/Loader/ResourceLoader.h
+++ b/Userland/Libraries/LibWeb/Loader/ResourceLoader.h
@@ -144,7 +144,7 @@ private:
     NonnullRefPtr<ResourceLoaderConnector> m_connector;
     String m_user_agent;
     String m_platform;
-    Optional<Page&> m_page {};
+    Optional<JS::GCPtr<Page>> m_page {};
 };
 
 }

--- a/Userland/Libraries/LibWeb/Streams/ReadableStreamBYOBReader.cpp
+++ b/Userland/Libraries/LibWeb/Streams/ReadableStreamBYOBReader.cpp
@@ -74,14 +74,14 @@ public:
     virtual void on_chunk(JS::Value chunk) override
     {
         // 1. Resolve promise with «[ "value" → chunk, "done" → false ]».
-        WebIDL::resolve_promise(m_realm, m_promise, JS::create_iterator_result_object(m_realm.vm(), chunk, false));
+        WebIDL::resolve_promise(m_realm, m_promise, JS::create_iterator_result_object(m_realm->vm(), chunk, false));
     }
 
     // close steps, given chunk
     virtual void on_close(JS::Value chunk) override
     {
         // 1. Resolve promise with «[ "value" → chunk, "done" → true ]».
-        WebIDL::resolve_promise(m_realm, m_promise, JS::create_iterator_result_object(m_realm.vm(), chunk, true));
+        WebIDL::resolve_promise(m_realm, m_promise, JS::create_iterator_result_object(m_realm->vm(), chunk, true));
     }
 
     // error steps, given e
@@ -99,7 +99,7 @@ private:
         visitor.visit(m_promise);
     }
 
-    JS::Realm& m_realm;
+    JS::NonnullGCPtr<JS::Realm> m_realm;
     WebIDL::Promise& m_promise;
 };
 

--- a/Userland/Libraries/LibWeb/Streams/ReadableStreamDefaultReader.cpp
+++ b/Userland/Libraries/LibWeb/Streams/ReadableStreamDefaultReader.cpp
@@ -126,12 +126,12 @@ public:
 
     virtual void on_chunk(JS::Value chunk) override
     {
-        WebIDL::resolve_promise(m_realm, m_promise, JS::create_iterator_result_object(m_realm.vm(), chunk, false));
+        WebIDL::resolve_promise(m_realm, m_promise, JS::create_iterator_result_object(m_realm->vm(), chunk, false));
     }
 
     virtual void on_close() override
     {
-        WebIDL::resolve_promise(m_realm, m_promise, JS::create_iterator_result_object(m_realm.vm(), JS::js_undefined(), true));
+        WebIDL::resolve_promise(m_realm, m_promise, JS::create_iterator_result_object(m_realm->vm(), JS::js_undefined(), true));
     }
 
     virtual void on_error(JS::Value error) override
@@ -147,7 +147,7 @@ private:
         visitor.visit(m_promise);
     }
 
-    JS::Realm& m_realm;
+    JS::NonnullGCPtr<JS::Realm> m_realm;
     WebIDL::Promise& m_promise;
 };
 

--- a/Userland/Libraries/LibWeb/Streams/ReadableStreamDefaultReader.h
+++ b/Userland/Libraries/LibWeb/Streams/ReadableStreamDefaultReader.h
@@ -53,8 +53,8 @@ private:
     virtual void visit_edges(Visitor&) override;
 
     JS::VM& m_vm;
-    JS::Realm& m_realm;
-    ReadableStreamDefaultReader& m_reader;
+    JS::NonnullGCPtr<JS::Realm> m_realm;
+    JS::NonnullGCPtr<ReadableStreamDefaultReader> m_reader;
     ByteBuffer m_bytes;
     SuccessSteps m_success_steps;
     FailureSteps m_failure_steps;

--- a/Userland/Libraries/LibWeb/Streams/ReadableStreamGenericReader.h
+++ b/Userland/Libraries/LibWeb/Streams/ReadableStreamGenericReader.h
@@ -42,7 +42,7 @@ protected:
     // A ReadableStream instance that owns this reader
     JS::GCPtr<ReadableStream> m_stream;
 
-    JS::Realm& m_realm;
+    JS::NonnullGCPtr<JS::Realm> m_realm;
 };
 
 }


### PR DESCRIPTION
Fixes warnings found by LibJSGCVerifier