### PR TITLE
LibWeb: Use offset of nearest scrollable ancestor for positioned boxes

### DIFF
--- a/Tests/LibWeb/Ref/positioned-elements-in-scroll-container.html
+++ b/Tests/LibWeb/Ref/positioned-elements-in-scroll-container.html
@@ -1,0 +1,73 @@
+<html>
+<link rel="match" href="reference/positioned-elements-in-scroll-container-ref.html" />
+<style>
+    * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+    }
+
+    html {
+        height: 100%;
+        position: relative;
+    }
+
+    body {
+        height: 100%;
+    }
+
+    article {
+        overflow-x: scroll;
+        overflow-y: scroll;
+        width: 500px;
+        height: 500px;
+        border: 1px solid black;
+    }
+
+    .card {
+        margin: 2rem;
+        height: 30rem;
+        background-color: #bbb;
+        position: relative; /* is not positioned in the reference html */
+    }
+</style>
+<main>
+    <article id="scrollcontainer">
+        <h1>Fly away to victory!</h1>
+
+        <div>
+            <p>
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+                tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+                quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+                consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat
+                non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+            </p>
+
+            <div class="card">A card!</div>
+
+            <p>
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+                tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+                quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+                consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat
+                non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+            </p>
+            <p>
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+                tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+                quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+                consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat
+                non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+            </p>
+        </div>
+    </article>
+</main>
+<script>
+    const scrollContainer = document.getElementById("scrollcontainer");
+    scrollContainer.scrollTop = 100;
+</script>
+</html>

--- a/Tests/LibWeb/Ref/reference/positioned-elements-in-scroll-container-ref.html
+++ b/Tests/LibWeb/Ref/reference/positioned-elements-in-scroll-container-ref.html
@@ -1,0 +1,71 @@
+<html>
+<link rel="match" href="reference/positioned-elements-in-scroll-container-ref.html" />
+<style>
+    * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+    }
+
+    html {
+        height: 100%;
+        position: relative;
+    }
+
+    body {
+        height: 100%;
+    }
+
+    article {
+        overflow-x: scroll;
+        overflow-y: scroll;
+        width: 500px;
+        height: 500px;
+        border: 1px solid black;
+        z-index: 1;
+    }
+
+    .card {
+        margin: 2rem;
+        height: 30rem;
+        background-color: #bbb;
+    }
+</style>
+<main>
+    <article id="scrollcontainer">
+        <h1>Fly away to victory!</h1>
+
+        <p>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+            incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
+            exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute
+            irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+            pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia
+            deserunt mollit anim id est laborum.
+        </p>
+
+        <div class="card">A card!</div>
+
+        <p>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+            incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
+            exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute
+            irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+            pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia
+            deserunt mollit anim id est laborum.
+        </p>
+        <p>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+            incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
+            exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute
+            irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+            pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia
+            deserunt mollit anim id est laborum.
+        </p>
+    </article>
+</main>
+<script>
+    const scrollContainer = document.getElementById("scrollcontainer");
+    scrollContainer.scrollTop = 100;
+</script>
+</html>

--- a/Userland/Libraries/LibWeb/Painting/Paintable.h
+++ b/Userland/Libraries/LibWeb/Painting/Paintable.h
@@ -117,6 +117,9 @@ public:
     virtual void before_children_paint(PaintContext&, PaintPhase) const { }
     virtual void after_children_paint(PaintContext&, PaintPhase) const { }
 
+    virtual void apply_scroll_offset(PaintContext&, PaintPhase) const { }
+    virtual void reset_scroll_offset(PaintContext&, PaintPhase) const { }
+
     virtual void apply_clip_overflow_rect(PaintContext&, PaintPhase) const { }
     virtual void clear_clip_overflow_rect(PaintContext&, PaintPhase) const { }
 

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -430,14 +430,14 @@ Optional<CSSPixelRect> PaintableBox::calculate_overflow_clipped_rect() const
     return m_clip_rect;
 }
 
-void PaintableBox::before_children_paint(PaintContext& context, PaintPhase) const
+void PaintableBox::apply_scroll_offset(PaintContext& context, PaintPhase) const
 {
     auto scroll_offset = -this->scroll_offset();
     context.translate_scroll_offset_by(scroll_offset);
     context.recording_painter().translate({ context.enclosing_device_pixels(scroll_offset.x()), context.enclosing_device_pixels(scroll_offset.y()) });
 }
 
-void PaintableBox::after_children_paint(PaintContext& context, PaintPhase) const
+void PaintableBox::reset_scroll_offset(PaintContext& context, PaintPhase) const
 {
     auto scroll_offset = this->scroll_offset();
     context.translate_scroll_offset_by(scroll_offset);

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -850,4 +850,15 @@ Optional<HitTestResult> PaintableWithLines::hit_test(CSSPixelPoint position, Hit
     return {};
 }
 
+PaintableBox const* PaintableBox::nearest_scrollable_ancestor() const
+{
+    auto* ancestor = parent();
+    while (ancestor) {
+        if (ancestor->is_paintable_box() && static_cast<PaintableBox const*>(ancestor)->has_scrollable_overflow())
+            return static_cast<PaintableBox const*>(ancestor);
+        ancestor = ancestor->parent();
+    }
+    return nullptr;
+}
+
 }

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.h
@@ -133,8 +133,8 @@ public:
     DOM::Document const& document() const { return layout_box().document(); }
     DOM::Document& document() { return layout_box().document(); }
 
-    virtual void before_children_paint(PaintContext&, PaintPhase) const override;
-    virtual void after_children_paint(PaintContext&, PaintPhase) const override;
+    virtual void apply_scroll_offset(PaintContext&, PaintPhase) const override;
+    virtual void reset_scroll_offset(PaintContext&, PaintPhase) const override;
 
     virtual void apply_clip_overflow_rect(PaintContext&, PaintPhase) const override;
     virtual void clear_clip_overflow_rect(PaintContext&, PaintPhase) const override;

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.h
@@ -191,6 +191,8 @@ public:
     BorderRadiiData const& border_radii_data() const { return m_border_radii_data; }
     void set_border_radii_data(BorderRadiiData const& border_radii_data) { m_border_radii_data = border_radii_data; }
 
+    PaintableBox const* nearest_scrollable_ancestor() const;
+
 protected:
     explicit PaintableBox(Layout::Box const&);
 

--- a/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -226,6 +226,13 @@ void StackingContext::paint_internal(PaintContext& context) const
                 : TraversalDecision::Continue;
         }
 
+        // Apply scroll offset of nearest scrollable ancestor before painting the positioned descendant.
+        PaintableBox const* nearest_scrollable_ancestor = nullptr;
+        if (paintable.is_paintable_box())
+            nearest_scrollable_ancestor = static_cast<PaintableBox const&>(paintable).nearest_scrollable_ancestor();
+        if (nearest_scrollable_ancestor)
+            nearest_scrollable_ancestor->apply_scroll_offset(context, PaintPhase::Foreground);
+
         // At this point, `paintable_box` is a positioned descendant with z-index: auto.
         // FIXME: This is basically duplicating logic found elsewhere in this same function. Find a way to make this more elegant.
         auto exit_decision = TraversalDecision::Continue;
@@ -246,6 +253,9 @@ void StackingContext::paint_internal(PaintContext& context) const
             parent_paintable->after_children_paint(context, PaintPhase::Foreground);
         if (containing_block_paintable)
             containing_block_paintable->clear_clip_overflow_rect(context, PaintPhase::Foreground);
+
+        if (nearest_scrollable_ancestor)
+            nearest_scrollable_ancestor->reset_scroll_offset(context, PaintPhase::Foreground);
 
         return exit_decision;
     });

--- a/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -90,6 +90,7 @@ void StackingContext::paint_node_as_stacking_context(Paintable const& paintable,
 
 void StackingContext::paint_descendants(PaintContext& context, Paintable const& paintable, StackingContextPaintPhase phase)
 {
+    paintable.apply_scroll_offset(context, to_paint_phase(phase));
     paintable.before_children_paint(context, to_paint_phase(phase));
     paintable.apply_clip_overflow_rect(context, to_paint_phase(phase));
 
@@ -174,6 +175,7 @@ void StackingContext::paint_descendants(PaintContext& context, Paintable const& 
 
     paintable.clear_clip_overflow_rect(context, to_paint_phase(phase));
     paintable.after_children_paint(context, to_paint_phase(phase));
+    paintable.reset_scroll_offset(context, to_paint_phase(phase));
 }
 
 void StackingContext::paint_child(PaintContext& context, StackingContext const& child)


### PR DESCRIPTION
Because positioned descendants are painted out-of-order we need to
separately apply offset of nearest scrollable box for them.

Fixes https://github.com/SerenityOS/serenity/issues/20554