### PR TITLE
LibJS: Stop making shapes unique

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/Executable.h
+++ b/Userland/Libraries/LibJS/Bytecode/Executable.h
@@ -28,11 +28,9 @@ namespace JS::Bytecode {
 struct PropertyLookupCache {
     static FlatPtr shape_offset() { return OFFSET_OF(PropertyLookupCache, shape); }
     static FlatPtr property_offset_offset() { return OFFSET_OF(PropertyLookupCache, property_offset); }
-    static FlatPtr unique_shape_serial_number_offset() { return OFFSET_OF(PropertyLookupCache, unique_shape_serial_number); }
 
     WeakPtr<Shape> shape;
     Optional<u32> property_offset;
-    u64 unique_shape_serial_number { 0 };
 };
 
 struct GlobalVariableCache : public PropertyLookupCache {

--- a/Userland/Libraries/LibJS/JIT/Compiler.cpp
+++ b/Userland/Libraries/LibJS/JIT/Compiler.cpp
@@ -1665,39 +1665,6 @@ void Compiler::compile_get_by_id(Bytecode::Op::GetById const& op)
             Assembler::Operand::Register(GPR1),
             slow_case);
 
-        // (!object->shape().is_unique() || object->shape().unique_shape_serial_number() == cache.unique_shape_serial_number)) {
-        Assembler::Label fast_case;
-
-        // GPR1 = object->shape().is_unique()
-        m_assembler.mov8(
-            Assembler::Operand::Register(GPR1),
-            Assembler::Operand::Mem64BaseAndOffset(GPR2, Shape::is_unique_offset()));
-
-        m_assembler.jump_if(
-            Assembler::Operand::Register(GPR1),
-            Assembler::Condition::EqualTo,
-            Assembler::Operand::Imm(0),
-            fast_case);
-
-        // GPR1 = object->shape().unique_shape_serial_number()
-        m_assembler.mov(
-            Assembler::Operand::Register(GPR1),
-            Assembler::Operand::Mem64BaseAndOffset(GPR2, Shape::unique_shape_serial_number_offset()));
-
-        // GPR2 = cache.unique_shape_serial_number
-        m_assembler.mov(
-            Assembler::Operand::Register(GPR2),
-            Assembler::Operand::Mem64BaseAndOffset(ARG5, Bytecode::PropertyLookupCache::unique_shape_serial_number_offset()));
-
-        // if (GPR1 != GPR2) goto slow_case;
-        m_assembler.jump_if(
-            Assembler::Operand::Register(GPR1),
-            Assembler::Condition::NotEqualTo,
-            Assembler::Operand::Register(GPR2),
-            slow_case);
-
-        fast_case.link(m_assembler);
-
         // return object->get_direct(*cache.property_offset);
         // GPR0 = object
         // GPR1 = *cache.property_offset * sizeof(Value)
@@ -1952,38 +1919,6 @@ void Compiler::compile_get_global(Bytecode::Op::GetGlobal const& op)
         Assembler::Condition::NotEqualTo,
         Assembler::Operand::Register(GPR0),
         slow_case);
-
-    Assembler::Label fast_case {};
-
-    // GPR2 = shape->unique()
-    m_assembler.mov8(
-        Assembler::Operand::Register(GPR2),
-        Assembler::Operand::Mem64BaseAndOffset(GPR0, Shape::is_unique_offset()));
-    // if (!GPR2) goto fast_case;
-    m_assembler.jump_if(
-        Assembler::Operand::Register(GPR2),
-        Assembler::Condition::EqualTo,
-        Assembler::Operand::Imm(0),
-        fast_case);
-
-    // GPR2 = shape->unique_shape_serial_number()
-    m_assembler.mov(
-        Assembler::Operand::Register(GPR2),
-        Assembler::Operand::Mem64BaseAndOffset(GPR0, Shape::unique_shape_serial_number_offset()));
-
-    // GPR0 = cache.unique_shape_serial_number
-    m_assembler.mov(
-        Assembler::Operand::Register(GPR0),
-        Assembler::Operand::Mem64BaseAndOffset(ARG2, Bytecode::PropertyLookupCache::unique_shape_serial_number_offset()));
-
-    // if (GPR2 != GPR0) goto slow_case;
-    m_assembler.jump_if(
-        Assembler::Operand::Register(GPR2),
-        Assembler::Condition::NotEqualTo,
-        Assembler::Operand::Register(GPR0),
-        slow_case);
-
-    fast_case.link(m_assembler);
 
     // accumulator = GPR1->get_direct(*cache.property_offset);
     // GPR0 = GPR1
@@ -2294,39 +2229,6 @@ void Compiler::compile_put_by_id(Bytecode::Op::PutById const& op)
                 Assembler::Condition::NotEqualTo,
                 Assembler::Operand::Register(GPR1),
                 slow_case);
-
-            // (!object->shape().is_unique() || object->shape().unique_shape_serial_number() == cache.unique_shape_serial_number)) {
-            Assembler::Label fast_case;
-
-            // GPR1 = object->shape().is_unique()
-            m_assembler.mov8(
-                Assembler::Operand::Register(GPR1),
-                Assembler::Operand::Mem64BaseAndOffset(GPR2, Shape::is_unique_offset()));
-
-            m_assembler.jump_if(
-                Assembler::Operand::Register(GPR1),
-                Assembler::Condition::EqualTo,
-                Assembler::Operand::Imm(0),
-                fast_case);
-
-            // GPR1 = object->shape().unique_shape_serial_number()
-            m_assembler.mov(
-                Assembler::Operand::Register(GPR1),
-                Assembler::Operand::Mem64BaseAndOffset(GPR2, Shape::unique_shape_serial_number_offset()));
-
-            // GPR2 = cache.unique_shape_serial_number
-            m_assembler.mov(
-                Assembler::Operand::Register(GPR2),
-                Assembler::Operand::Mem64BaseAndOffset(ARG5, Bytecode::PropertyLookupCache::unique_shape_serial_number_offset()));
-
-            // if (GPR1 != GPR2) goto slow_case;
-            m_assembler.jump_if(
-                Assembler::Operand::Register(GPR1),
-                Assembler::Condition::NotEqualTo,
-                Assembler::Operand::Register(GPR2),
-                slow_case);
-
-            fast_case.link(m_assembler);
 
             // object->put_direct(*cache.property_offset, value);
             // GPR0 = object

--- a/Userland/Libraries/LibJS/Runtime/GlobalObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/GlobalObject.cpp
@@ -92,7 +92,6 @@ JS_DEFINE_ALLOCATOR(GlobalObject);
 GlobalObject::GlobalObject(Realm& realm)
     : Object(GlobalObjectTag::Tag, realm)
 {
-    ensure_shape_is_unique();
     Object::set_prototype(realm.intrinsics().object_prototype());
 }
 

--- a/Userland/Libraries/LibJS/Runtime/Object.h
+++ b/Userland/Libraries/LibJS/Runtime/Object.h
@@ -49,7 +49,6 @@ struct CacheablePropertyMetadata {
     };
     Type type { Type::NotCacheable };
     Optional<u32> property_offset;
-    u64 unique_shape_serial_number { 0 };
 };
 
 class Object : public Cell {
@@ -214,8 +213,6 @@ public:
     Shape const& shape() const { return *m_shape; }
 
     static FlatPtr shape_offset() { return OFFSET_OF(Object, m_shape); }
-
-    void ensure_shape_is_unique();
 
     template<typename T>
     bool fast_is() const = delete;

--- a/Userland/Libraries/LibJS/Runtime/Shape.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Shape.cpp
@@ -135,10 +135,10 @@ void Shape::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_prototype);
     visitor.visit(m_previous);
     m_property_key.visit_edges(visitor);
-    if (m_property_table) {
-        for (auto& it : *m_property_table)
-            it.key.visit_edges(visitor);
-    }
+
+    // NOTE: We don't need to mark the keys in the property table, since they are guaranteed
+    //       to also be marked by the chain of shapes leading up to this one.
+
     visitor.ignore(m_prototype_transitions);
 
     // FIXME: The forward transition keys should be weak, but we have to mark them for now in case they go stale.

--- a/Userland/Libraries/LibJS/Runtime/Shape.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Shape.cpp
@@ -126,6 +126,12 @@ void Shape::visit_edges(Cell::Visitor& visitor)
             it.key.visit_edges(visitor);
     }
     visitor.ignore(m_prototype_transitions);
+
+    // FIXME: The forward transition keys should be weak, but we have to mark them for now in case they go stale.
+    if (m_forward_transitions) {
+        for (auto& it : *m_forward_transitions)
+            it.key.property_key.visit_edges(visitor);
+    }
 }
 
 Optional<PropertyMetadata> Shape::lookup(StringOrSymbol const& property_key) const


### PR DESCRIPTION
We previously had a concept of unique shapes, which meant that they
couldn't be shared between multiple objects.
    
Object shapes became unique in three situations:
    
- They were the shape of the global object.
- They had more than 100 properties added to them.
- They had one or more properties deleted from them.
    
Unfortunately, unique shapes presented an annoying problem for inline
caches, and we added a "unique shape serial number" for being able to
tell that a unique shape had been mutated.
    
This patch gets rid of the concept of unique shapes, simplifying all
the caching code, since inline caches can now simply perform a shape
check and then we're good.
    
To make this possible, we now have the concept of delete transitions,
which occur when a property is deleted from a shape.

Looks generally positive on benchmarks, with notable improvements on
Kraken/audio-oscillator (1.103x) and Kraken/imaging-gaussian-blur (1.316x)

```
Suite       Test                                   Speedup  Old (Mean ± Range)        New (Mean ± Range)
----------  -----------------------------------  ---------  ------------------------  ------------------------
Kraken      ai-astar.js                              1.05   0.845 ± 0.840 … 0.850     0.805 ± 0.800 … 0.810
Kraken      audio-beat-detection.js                  1.034  0.460 ± 0.460 … 0.460     0.445 ± 0.440 … 0.450
Kraken      audio-dft.js                             1      0.340 ± 0.340 … 0.340     0.340 ± 0.340 … 0.340
Kraken      audio-fft.js                             1.063  0.335 ± 0.330 … 0.340     0.315 ± 0.310 … 0.320
Kraken      audio-oscillator.js                      1.103  0.430 ± 0.430 … 0.430     0.390 ± 0.390 … 0.390
Kraken      imaging-darkroom.js                      0.996  2.830 ± 2.810 … 2.850     2.840 ± 2.830 … 2.850
Kraken      imaging-desaturate.js                    1.032  0.640 ± 0.640 … 0.640     0.620 ± 0.620 … 0.620
Kraken      imaging-gaussian-blur.js                 1.316  2.810 ± 2.810 … 2.810     2.135 ± 2.130 … 2.140
Kraken      json-parse-financial.js                  0.933  0.070 ± 0.070 … 0.070     0.075 ± 0.070 … 0.080
Kraken      json-stringify-tinderbox.js              1      0.220 ± 0.220 … 0.220     0.220 ± 0.220 … 0.220
Kraken      stanford-crypto-aes.js                   1.009  0.565 ± 0.560 … 0.570     0.560 ± 0.560 … 0.560
Kraken      stanford-crypto-ccm.js                   1.009  0.590 ± 0.590 … 0.590     0.585 ± 0.580 … 0.590
Kraken      stanford-crypto-pbkdf2.js                1.005  0.975 ± 0.970 … 0.980     0.970 ± 0.970 … 0.970
Kraken      stanford-crypto-sha256-iterative.js      1      0.430 ± 0.430 … 0.430     0.430 ± 0.430 … 0.430
Octane      box2d.js                                 1.079  2.525 ± 2.520 … 2.530     2.340 ± 2.340 … 2.340
Octane      code-load.js                             1.007  2.145 ± 2.130 … 2.160     2.130 ± 2.130 … 2.130
Octane      crypto.js                                1.008  5.105 ± 5.060 … 5.150     5.065 ± 5.060 … 5.070
Octane      deltablue.js                             0.992  3.035 ± 3.030 … 3.040     3.060 ± 3.050 … 3.070
Octane      earley-boyer.js                          1.011  21.855 ± 21.840 … 21.870  21.620 ± 21.580 … 21.660
Octane      gbemu.js                                 1.03   3.260 ± 3.250 … 3.270     3.165 ± 3.160 … 3.170
Octane      mandreel.js                              1.016  18.270 ± 18.200 … 18.340  17.980 ± 17.930 … 18.030
Octane      navier-stokes.js                         1.002  2.025 ± 2.010 … 2.040     2.020 ± 2.010 … 2.030
Octane      pdfjs.js                                 0.89   3.385 ± 3.380 … 3.390     3.805 ± 3.800 … 3.810
Octane      raytrace.js                              1.039  8.070 ± 8.060 … 8.080     7.770 ± 7.760 … 7.780
Octane      regexp.js                                1.011  26.100 ± 26.100 … 26.100  25.815 ± 25.720 … 25.910
Octane      richards.js                              1.002  2.015 ± 2.010 … 2.020     2.010 ± 2.010 … 2.010
Octane      splay.js                                 1.019  3.160 ± 3.150 … 3.170     3.100 ± 3.100 … 3.100
Octane      typescript.js                            1.016  47.245 ± 47.130 … 47.360  46.500 ± 46.130 … 46.870
Octane      zlib.js                                  0.957  49.300 ± 49.170 … 49.430  51.540 ± 51.440 … 51.640
Kraken      Total                                    1.075  11.540                    10.730
Octane      Total                                    0.998  197.495                   197.920
All Suites  Total                                    1.002  209.035                   208.650
```