### PR TITLE
PixelPaint: Some small fixes

### DIFF
--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -430,6 +430,9 @@ void ImageEditor::mousemove_event(GUI::MouseEvent& event)
         return;
     }
 
+    if (active_tool() == nullptr)
+        return;
+
     auto image_event = event_with_pan_and_scale_applied(event);
     if (on_image_mouse_position_change) {
         on_image_mouse_position_change(image_event.position());

--- a/Userland/Applications/PixelPaint/ToolboxWidget.cpp
+++ b/Userland/Applications/PixelPaint/ToolboxWidget.cpp
@@ -70,9 +70,12 @@ void ToolboxWidget::setup_tools()
         tool->set_action(action);
         m_tools.append(move(tool));
         if (is_default_tool) {
-            VERIFY(m_active_tool == nullptr);
-            m_active_tool = m_tools[m_tools.size() - 1];
             action->set_checked(true);
+            auto default_tool_index = m_tools.size() - 1;
+            deferred_invoke([&, default_tool_index]() {
+                VERIFY(m_active_tool == nullptr);
+                on_tool_selection(m_tools[default_tool_index]);
+            });
         }
     };
 


### PR DESCRIPTION
This pr fixes the following two issues:
- crash when the mouse is moved while a images is beeing loaded
- initial tool selection does not show the tool properties

For details see individual commits.