### PR TITLE
FATFS: Add Support for FAT16/FAT12 File Systems

### DIFF
--- a/Kernel/FileSystem/FATFS/Definitions.h
+++ b/Kernel/FileSystem/FATFS/Definitions.h
@@ -45,7 +45,7 @@ struct [[gnu::packed]] DOS3BIOSParameterBlock {
     u32 sector_count_32bit; // 0x020 -- end of DOS 3.31 BPB.
 };
 // 11 is the boot jump/OEM identifier prefix prior to the official BPB.
-static_assert(sizeof(DOS3BIOSParameterBlock) == 11 + 25);
+static_assert(AssertSize<DOS3BIOSParameterBlock, 11 + 25>());
 
 struct [[gnu::packed]] DOS4BIOSParameterBlock {
     // Begins at sector offset 0x024.
@@ -56,7 +56,7 @@ struct [[gnu::packed]] DOS4BIOSParameterBlock {
     char volume_label_string[11];
     char file_system_type[8];
 };
-static_assert(sizeof(DOS4BIOSParameterBlock) == 26);
+static_assert(AssertSize<DOS4BIOSParameterBlock, 26>());
 
 struct [[gnu::packed]] DOS7BIOSParameterBlock {
     // Begins at sector offset 0x024.
@@ -74,7 +74,7 @@ struct [[gnu::packed]] DOS7BIOSParameterBlock {
     char volume_label_string[11];
     char file_system_type[8];
 };
-static_assert(sizeof(DOS7BIOSParameterBlock) == 54);
+static_assert(AssertSize<DOS7BIOSParameterBlock, 54>());
 
 enum DOSBIOSParameterBlockVersion {
     DOS_BPB_UNKNOWN,
@@ -116,7 +116,7 @@ struct [[gnu::packed]] FATEntry {
     u16 first_cluster_low;
     u32 file_size;
 };
-static_assert(sizeof(FATEntry) == 32);
+static_assert(AssertSize<FATEntry, 32>());
 
 struct [[gnu::packed]] FATLongFileNameEntry {
     u8 entry_index;
@@ -128,6 +128,6 @@ struct [[gnu::packed]] FATLongFileNameEntry {
     u16 zero;
     u16 characters3[2];
 };
-static_assert(sizeof(FATLongFileNameEntry) == 32);
+static_assert(AssertSize<FATLongFileNameEntry, 32>());
 
 }

--- a/Kernel/FileSystem/FATFS/Definitions.h
+++ b/Kernel/FileSystem/FATFS/Definitions.h
@@ -9,27 +9,60 @@
 #include <AK/DOSPackedTime.h>
 #include <AK/EnumBits.h>
 #include <AK/Types.h>
+#include <Kernel/Library/KBuffer.h>
 
 namespace Kernel {
 
-struct [[gnu::packed]] FAT32BootRecord {
+// This structure represents the DOS 3.31 BIOS Partition Block.
+// While DOS 3.31 predates FAT verions 12/16/32 (the versions supported by this driver),
+// the fields in this block are common with the DOS 4 and DOS 7 BIOS Parameter blocks.
+// This structure will be followed by an "Extended BIOS Partition Block" (EBPB).
+//
+// The DOS 4 EBPB is *typically* used by FAT 12/16 file systems, while the DOS 7 EBPB
+// is *typically* used by FAT 32. _However_, any combination is possible, as the FAT
+// version is only determined by the number of clusters.
+//
+// Note that the DOS 4 and DOS 7 EBPB extensions are incompatible with each other
+// (contain fields in different orders and of different lenghts) and do not contain
+// an explicit indication to differentiate them.
+// This driver uses heuristics to identify the EBPB version (based on the signature bytes
+// and sector counts).
+// FIXME: Consider also using the MBR parition type field in the future.
+struct [[gnu::packed]] DOS3BIOSParameterBlock {
     u8 boot_jump[3];
     char oem_identifier[8];
-    u16 bytes_per_sector;
+    u16 bytes_per_sector; // Offset 0x0B -- beginning of DOS 3.31 BPB.
     u8 sectors_per_cluster;
     u16 reserved_sector_count;
     u8 fat_count;
     u16 root_directory_entry_count;
-    u16 unused1;
+    u16 sector_count_16bit;
     u8 media_descriptor_type;
-    u16 unused2;
+    u16 sectors_per_fat_16bit;
     u16 sectors_per_track;
     u16 head_count;
     u32 hidden_sector_count;
-    u32 sector_count;
-    u32 sectors_per_fat;
+    u32 sector_count_32bit; // 0x020 -- end of DOS 3.31 BPB.
+};
+// 11 is the boot jump/OEM identifier prefix prior to the official BPB.
+static_assert(sizeof(DOS3BIOSParameterBlock) == 11 + 25);
+
+struct [[gnu::packed]] DOS4BIOSParameterBlock {
+    // Begins at sector offset 0x024.
+    u8 drive_number; // 0x024
+    u8 flags;
+    u8 signature;
+    u32 volume_id;
+    char volume_label_string[11];
+    char file_system_type[8];
+};
+static_assert(sizeof(DOS4BIOSParameterBlock) == 26);
+
+struct [[gnu::packed]] DOS7BIOSParameterBlock {
+    // Begins at sector offset 0x024.
+    u32 sectors_per_fat_32bit; // 0x024
     u16 flags;
-    u16 fat_version;
+    u16 fat_version; // Expected value 0x2b2a.
     u32 root_directory_cluster;
     u16 fs_info_sector;
     u16 backup_boot_sector;
@@ -39,9 +72,22 @@ struct [[gnu::packed]] FAT32BootRecord {
     u8 signature;
     u32 volume_id;
     char volume_label_string[11];
-    char system_identifier_string[8];
+    char file_system_type[8];
 };
-static_assert(sizeof(FAT32BootRecord) == 90);
+static_assert(sizeof(DOS7BIOSParameterBlock) == 54);
+
+enum DOSBIOSParameterBlockVersion {
+    DOS_BPB_UNKNOWN,
+    DOS_BPB_3, // Version 3.4.
+    DOS_BPB_4, // Version 4.0
+    DOS_BPB_7  // Version 7.0
+};
+
+enum class FATVersion {
+    FAT12,
+    FAT16,
+    FAT32,
+};
 
 enum class FATAttributes : u8 {
     ReadOnly = 0x01,

--- a/Kernel/FileSystem/FATFS/FileSystem.cpp
+++ b/Kernel/FileSystem/FATFS/FileSystem.cpp
@@ -10,6 +10,85 @@
 
 namespace Kernel {
 
+DOSBIOSParameterBlockVersion DOSBIOSParameterBlock::bpb_version() const
+{
+    bool dos3_valid = m_dos4_block->signature == 0x28;
+    bool dos4_valid = m_dos4_block->signature == 0x29;
+    bool dos7_valid = m_dos7_block->signature == 0x28 || m_dos7_block->signature == 0x29;
+    // A DOS 7 EBPB should _never_ contain the values 0x28 or 0x29 at
+    // the offset associated with `m_dos4_block->signature`
+    // (aka `m_dos7_block->sectors_per_fat_32bit`) due to the maximum number of
+    // clusters ensuring the number of sectors per fat will not exceed 0x200000.
+    // As a result, it should be safe to determine BPB version through the
+    // signature fields by checking the DOS 4 signature offset prior to the DOS 7 one.
+    //
+    // With a DOS 3 or DOS 4 EBPB, the DOS 7 signature offset references uninitialized
+    // space. While unlikely to be set to a valid signature value, it is not implausible.
+    // We warn the user here, but because it does not represent an invalid FS configuration,
+    // do not error.
+    if ((dos3_valid || dos4_valid) && dos7_valid)
+        dbgln("FATFS: DOS 4 and DOS 7 EBPB signatures detected, EBPB/FAT version detection may be incorrect.");
+
+    if (dos3_valid)
+        return DOS_BPB_3;
+    else if (dos4_valid)
+        return DOS_BPB_4;
+    else if (dos7_valid)
+        return DOS_BPB_7;
+    else
+        return DOS_BPB_UNKNOWN;
+}
+
+DOS3BIOSParameterBlock const* DOSBIOSParameterBlock::common_bpb() const
+{
+    return m_common_block;
+}
+
+DOS4BIOSParameterBlock const* DOSBIOSParameterBlock::dos4_bpb() const
+{
+    // Only return parameter block if signature indicates this portion of the block is filled out.
+    if (m_dos4_block->signature == 0x28 || m_dos4_block->signature == 0x29)
+        return m_dos4_block;
+    else
+        return nullptr;
+}
+
+DOS7BIOSParameterBlock const* DOSBIOSParameterBlock::dos7_bpb() const
+{
+    // Only return parameter block if signature indicates this portion of the block is filled out.
+    if (m_dos7_block->signature == 0x28 || m_dos7_block->signature == 0x29)
+        return m_dos7_block;
+    else
+        return nullptr;
+}
+
+u16 DOSBIOSParameterBlock::sectors_per_fat() const
+{
+    return common_bpb()->sectors_per_fat_16bit != 0 ? common_bpb()->sectors_per_fat_16bit : m_dos7_block->sectors_per_fat_32bit;
+}
+
+u32 DOSBIOSParameterBlock::sector_count() const
+{
+    if (common_bpb()->sector_count_16bit != 0) {
+        // The `16bit` field is only used on partitions smaller than 32 MB,
+        // and never for FAT32.
+        // It is set to `0` when the 32 bit field contains the sector count.
+        return common_bpb()->sector_count_16bit;
+    } else {
+        return common_bpb()->sector_count_32bit;
+        // FIXME: If this is 0 for a FAT32 EBPB with a signature of 0x29,
+        // read 0x052, which is a 64-bit wide sector count.
+    }
+}
+
+u8 DOSBIOSParameterBlock::signature() const
+{
+    if (bpb_version() == DOS_BPB_3 || bpb_version() == DOS_BPB_4)
+        return m_dos4_block->signature;
+    else
+        return m_dos7_block->signature;
+}
+
 ErrorOr<NonnullRefPtr<FileSystem>> FATFS::try_create(OpenFileDescription& file_description, ReadonlyBytes)
 {
     return TRY(adopt_nonnull_ref_or_enomem(new (nothrow) FATFS(file_description)));
@@ -34,46 +113,126 @@ ErrorOr<void> FATFS::initialize_while_locked()
     m_boot_record = TRY(KBuffer::try_create_with_size("FATFS: Boot Record"sv, m_device_block_size));
     auto boot_record_buffer = UserOrKernelBuffer::for_kernel_buffer(m_boot_record->data());
     TRY(raw_read(0, boot_record_buffer));
+    m_parameter_block = TRY(adopt_nonnull_own_or_enomem(new (nothrow) DOSBIOSParameterBlock(m_boot_record)));
+
+    // Alias for extended BPB.
+    DOSBIOSParameterBlock& ebpb = *m_parameter_block;
+    // Alias for block of common parameters in BPB.
+    DOS3BIOSParameterBlock const* block = ebpb.common_bpb();
 
     if constexpr (FAT_DEBUG) {
-        dbgln("FATFS: oem_identifier: {}", boot_record()->oem_identifier);
-        dbgln("FATFS: bytes_per_sector: {}", boot_record()->bytes_per_sector);
-        dbgln("FATFS: sectors_per_cluster: {}", boot_record()->sectors_per_cluster);
-        dbgln("FATFS: reserved_sector_count: {}", boot_record()->reserved_sector_count);
-        dbgln("FATFS: fat_count: {}", boot_record()->fat_count);
-        dbgln("FATFS: root_directory_entry_count: {}", boot_record()->root_directory_entry_count);
-        dbgln("FATFS: media_descriptor_type: {}", boot_record()->media_descriptor_type);
-        dbgln("FATFS: sectors_per_track: {}", boot_record()->sectors_per_track);
-        dbgln("FATFS: head_count: {}", boot_record()->head_count);
-        dbgln("FATFS: hidden_sector_count: {}", boot_record()->hidden_sector_count);
-        dbgln("FATFS: sector_count: {}", boot_record()->sector_count);
-        dbgln("FATFS: sectors_per_fat: {}", boot_record()->sectors_per_fat);
-        dbgln("FATFS: flags: {}", boot_record()->flags);
-        dbgln("FATFS: fat_version: {}", boot_record()->fat_version);
-        dbgln("FATFS: root_directory_cluster: {}", boot_record()->root_directory_cluster);
-        dbgln("FATFS: fs_info_sector: {}", boot_record()->fs_info_sector);
-        dbgln("FATFS: backup_boot_sector: {}", boot_record()->backup_boot_sector);
-        dbgln("FATFS: drive_number: {}", boot_record()->drive_number);
-        dbgln("FATFS: volume_id: {}", boot_record()->volume_id);
+        dbgln("FATFS: oem_identifier: {}", block->oem_identifier);
+        dbgln("FATFS: bytes_per_sector: {}", block->bytes_per_sector);
+        dbgln("FATFS: sectors_per_cluster: {}", block->sectors_per_cluster);
+        dbgln("FATFS: reserved_sector_count: {}", block->reserved_sector_count);
+        dbgln("FATFS: fat_count: {}", block->fat_count);
+        dbgln("FATFS: root_directory_entry_count: {}", block->root_directory_entry_count);
+        dbgln("FATFS: media_descriptor_type: {}", block->media_descriptor_type);
+        dbgln("FATFS: sectors_per_track: {}", block->sectors_per_track);
+        dbgln("FATFS: head_count: {}", block->head_count);
+        dbgln("FATFS: hidden_sector_count: {}", block->hidden_sector_count);
+        dbgln("FATFS: sector_count: {}", ebpb.sector_count());
+        dbgln("FATFS: sectors_per_fat: {}", ebpb.sectors_per_fat());
+
+        auto ebpb_version = ebpb.bpb_version();
+        if (ebpb_version == DOSBIOSParameterBlockVersion::DOS_BPB_7) {
+            DOS7BIOSParameterBlock const* dos7_boot_record = ebpb.dos7_bpb();
+            dbgln("FATFS: EBPB: DOS 7");
+            dbgln("FATFS: flags: {}", dos7_boot_record->flags);
+            dbgln("FATFS: fat_version: {}", dos7_boot_record->fat_version);
+            dbgln("FATFS: root_directory_cluster: {}", dos7_boot_record->root_directory_cluster);
+            dbgln("FATFS: fs_info_sector: {}", dos7_boot_record->fs_info_sector);
+            dbgln("FATFS: backup_boot_sector: {}", dos7_boot_record->backup_boot_sector);
+            dbgln("FATFS: drive_number: {}", dos7_boot_record->drive_number);
+            dbgln("FATFS: volume_id: {}", dos7_boot_record->volume_id);
+        } else if (ebpb_version == DOSBIOSParameterBlockVersion::DOS_BPB_3 || ebpb_version == DOSBIOSParameterBlockVersion::DOS_BPB_4) {
+            DOS4BIOSParameterBlock const* dos4_boot_record = ebpb.dos4_bpb();
+            if (ebpb_version == DOSBIOSParameterBlockVersion::DOS_BPB_3) {
+                dbgln("FATFS: EBPB: DOS 3.4");
+            } else if (ebpb_version == DOSBIOSParameterBlockVersion::DOS_BPB_4) {
+                dbgln("FATFS: EBPB: DOS 4");
+            }
+            dbgln("FATFS: drive_number: {}", dos4_boot_record->drive_number);
+            dbgln("FATFS: flags: {}", dos4_boot_record->flags);
+            dbgln("FATFS: volume_id: {}", dos4_boot_record->volume_id);
+
+            // volume_label_string and file_system_type are only valid when
+            // ebpb_version == DOSBIOSParameterBlockVersion::DOS4.
+        }
     }
 
-    if (boot_record()->signature != signature_1 && boot_record()->signature != signature_2) {
+    if (ebpb.signature() != signature_1 && ebpb.signature() != signature_2) {
         dbgln("FATFS: Invalid signature");
         return EINVAL;
     }
 
-    m_device_block_size = boot_record()->bytes_per_sector;
+    DOS3BIOSParameterBlock const* ebpb_block = ebpb.common_bpb();
+    // The number of data area sectors is what DOS/Windows used to determine
+    // if a partition was a FAT12, FAT16, or FAT32 file system.
+    // From "FAT Type Determination" section of Microsoft FAT Specification
+    // (fatgen103.doc):
+    //     The FAT type—one of FAT12, FAT16, or FAT32—is determined by the count
+    //     of clusters on the volume and nothing else.
+    //
+    // The following calculations are based on the equations provided in this
+    // section.
+
+    // "RootDirSectors" from MS FAT Specification. This is calculated as:
+    //     Number of bytes occupied by root directory area (0 on FAT32)
+    //         +
+    //     Bytes to fill final sector (ie, round up)
+    // Converted into sector count (by dividing by bytes per sector).
+    u32 root_directory_sectors = ((ebpb_block->root_directory_entry_count * sizeof(FATEntry)) + (ebpb_block->bytes_per_sector - 1)) / ebpb_block->bytes_per_sector;
+
+    // "DataSec" from MS FAT Specification.
+    u32 data_area_sectors = ebpb.sector_count() - ((ebpb_block->reserved_sector_count) + (ebpb_block->fat_count * ebpb.sectors_per_fat()) + root_directory_sectors);
+
+    // CountofClusters from MS FAT Specification.
+    u32 data_area_clusters = data_area_sectors / ebpb_block->sectors_per_cluster;
+
+    // Cluster thresholds and operators as defined in MS FAT Specification.
+    if (data_area_clusters < 4085) {
+        dbgln("FATFS: Detected FAT12 with {} data area clusters", data_area_clusters);
+        m_fat_version = FATVersion::FAT12;
+    } else if (data_area_clusters < 65525) {
+        dbgln("FATFS: Detected FAT16 with {} data area clusters", data_area_clusters);
+        m_fat_version = FATVersion::FAT16;
+    } else {
+        dbgln("FATFS: Assuming FAT32 with {} data area clusters", data_area_clusters);
+        m_fat_version = FATVersion::FAT32;
+    }
+
+    m_device_block_size = ebpb_block->bytes_per_sector;
     set_logical_block_size(m_device_block_size);
 
-    u32 root_directory_sectors = ((boot_record()->root_directory_entry_count * sizeof(FATEntry)) + (m_device_block_size - 1)) / m_device_block_size;
-    m_first_data_sector = boot_record()->reserved_sector_count + (boot_record()->fat_count * boot_record()->sectors_per_fat) + root_directory_sectors;
+    m_first_data_sector = block->reserved_sector_count + (block->fat_count * ebpb.sectors_per_fat()) + root_directory_sectors;
 
     TRY(BlockBasedFileSystem::initialize_while_locked());
 
     FATEntry root_entry {};
 
-    root_entry.first_cluster_low = boot_record()->root_directory_cluster & 0xFFFF;
-    root_entry.first_cluster_high = boot_record()->root_directory_cluster >> 16;
+    if (m_fat_version == FATVersion::FAT32) {
+        // FAT32 stores the root directory within the FAT (at the clusters specified
+        // in the boot record), as opposed to the root directory area
+        // (as done by FAT 12/16).
+
+        DOS7BIOSParameterBlock const* boot_record = ebpb.dos7_bpb();
+        // Ensure we have a DOS7 BPB (so that we can find the root directory cluster).
+        if (boot_record == nullptr) {
+            dbgln("FATFS: Non-DOS7 BPB for FAT32 FS.");
+            return EINVAL;
+        }
+        root_entry.first_cluster_low = boot_record->root_directory_cluster & 0xFFFF;
+        root_entry.first_cluster_high = boot_record->root_directory_cluster >> 16;
+    } else {
+        // FAT12/FAT16.
+        // Use cluster = 0 as a signal to `first_block_of_cluster()` to look in the
+        // root directory area for the root entry.
+        // Clusters 0 and 1 hold special values, and will never be used to store file
+        // data.
+        root_entry.first_cluster_low = 0;
+        root_entry.first_cluster_high = 0;
+    }
 
     root_entry.attributes = FATAttributes::Directory;
     m_root_inode = TRY(FATInode::create(*this, root_entry));
@@ -86,9 +245,29 @@ Inode& FATFS::root_inode()
     return *m_root_inode;
 }
 
-BlockBasedFileSystem::BlockIndex FATFS::first_block_of_cluster(u32 cluster) const
+FatBlockSpan FATFS::first_block_of_cluster(u32 cluster) const
 {
-    return ((cluster - first_data_cluster) * boot_record()->sectors_per_cluster) + m_first_data_sector;
+    // For FAT12/16, we use a value of cluster 0 to indicate this is a cluster for the root directory.
+    // Cluster 0 and cluster 1 hold special values (cluster 0 holds the FAT ID, and cluster 1
+    // the "end of chain marker"), neither of which will be present in the table or associated
+    // with any file.
+    // "Entries with the Volume Label flag, subdirectory ".." pointing to the FAT12 and FAT16 root, and empty files with size 0 should have first cluster 0."
+    // --Wikipedia
+    //
+    DOSBIOSParameterBlock ebpb(m_boot_record);
+    DOS3BIOSParameterBlock const* ebpb_block = ebpb.common_bpb();
+    if (m_fat_version != FATVersion::FAT32 && cluster == 0) {
+        // Root directory area follows the FATs after the reserved sectors.
+        return FatBlockSpan {
+            ebpb_block->reserved_sector_count + (ebpb_block->fat_count * ebpb.sectors_per_fat()),
+            (ebpb_block->root_directory_entry_count * sizeof(FATEntry)) / ebpb_block->bytes_per_sector
+        };
+    } else {
+        return FatBlockSpan {
+            ((cluster - first_data_cluster) * ebpb_block->sectors_per_cluster) + m_first_data_sector,
+            ebpb_block->sectors_per_cluster
+        };
+    }
 }
 
 u8 FATFS::internal_file_type_to_directory_entry_type(DirectoryEntryView const& entry) const

--- a/Kernel/FileSystem/FATFS/Inode.h
+++ b/Kernel/FileSystem/FATFS/Inode.h
@@ -30,8 +30,7 @@ public:
 private:
     FATInode(FATFS&, FATEntry, NonnullOwnPtr<KString> filename);
 
-    // Number of bytes used to store a cluster within the table.
-    size_t cluster_size() const;
+    size_t fat_offset_for_cluster(u32 cluster) const;
 
     // Returns cluster number value that indicates the end of the chain
     // has been reached. Any cluster value >= this value indicates this
@@ -39,7 +38,7 @@ private:
     u32 end_of_chain_marker() const;
 
     // Reads the cluster number located at the offset within the table.
-    u32 cluster_number(KBuffer const& fat_sector, u32 entry_offset) const;
+    u32 cluster_number(KBuffer const& fat_sector, u32 entry_cluster_number, u32 entry_offset) const;
 
     static constexpr u8 end_entry_byte = 0x00;
     static constexpr u8 unused_entry_byte = 0xE5;


### PR DESCRIPTION
# FATFS: Add Support for FAT16/FAT12 File Systems

This PR extends the FATFS driver to support FAT 12 and FAT 16 versions of the FAT file system.

> Why?

Why not! But also, this enables use of the [QEMU VVFAT virtual drive](https://en.wikibooks.org/wiki/QEMU/Devices/Storage#Virtual_FAT_filesystem_(VVFAT)), which makes it really easy to share files between the host and guest:
```sh
SERENITY_BOOT_DRIVE="$SERENITY_BOOT_DRIVE -drive file=fat:16:rw:$SCRIPT_DIR/../Documentation/"
```
<img width="1136" alt="image" src="https://github.com/SerenityOS/serenity/assets/1073184/9dd062ee-4810-4074-b38e-780bed99fa8d">

Note that this is still pretty slow driver. The driver doesn't do any caching, and frequently reads _all_ blocks associated with a file. There's a lot of room for optimization with some light caching of the FAT table and being more selective about which sectors/blocks are read.

## PR Overview
 * e834897b822d412b08bf0d2ca5f24480bed01074: Add support for different versions of the DOS BIOS Parameter Block. This is a majority of the change.
 * f795ebc4e111cbd3be8cdebc209e0e3391957f7, 6f1f506f3d6abd540dc1fff333dc2727438164ff: Support for FAT16/FAT12 clusters. Once the above was in-place, this is was fairly minor.
 * 70d156d5f7172b63585ee130a1be814b20f6f53b: Resolve existing bug where files would not be truncated to their size, and instead would return all of the sectors within the cluster associated with the file.

### DOS BIOS Parameter Block (BPB)
The DOS BIOS Parameter Block (BPB) is the header of a FAT file system, and stored in the first sector. It contains the parameters required to locate and read the data in the file system. There are multiple versions of the BPB, with the DOS 4 and DOS 7 being the versions used by (modern) FAT File Systems. These are called "Extended BPBs" (EBPBs) because they extend the original BPB. The DOS 4 BPB is typically used by FAT12/16 file systems, and DOS 7 used by FAT32, but other combinations are possible.

The DOS 4 and DOS 7 EBPBs have a common set of initial fields, the DOS 3.31 BPB. Following the fields defined in the DOS 3.31 BPB (the first 25 bytes), they diverge in field location/definition. I found the Wikipedia [DOS Parameter Block](https://en.wikipedia.org/wiki/BIOS_parameter_block) and [Design of the FAT File System pages](https://en.wikipedia.org/wiki/Design_of_the_FAT_file_system#Boot_Sector) very helpful references.

Commit e834897b822d412b08bf0d2ca5f24480bed01074 introduces support for these different BPB versions through the creation of a `DOSBIOSParameterBlock` class that abstracts the common fields into accessors, and provides structs that interpret the BPB sector as either EBPB.

Another major difference between FAT12/16 and FAT32 is that in FAT12/16, the root directory entries are _not_ stored in the FAT, but instead in sectors following the FAT. This necessitated special handling of the root entry inode, because it is not associated with a cluster number, but instead the root directory regtion. `FATFS::first_block_of_cluster()` was extended to support with, with a sentinel value of `cluster == 0` to signify the root directory entry.

### FAT12/FAT16 FAT Cluster Support
Beyond the above differences, the FAT table itself differs between each FAT version. These (fairly trivial) changes to support parsing cluster numbers from 12-bit and 16-bit values were implemented in f795ebc4e111cbd3be8cdebc209e0e3391957f7, 6f1f506f3d6abd540dc1fff333dc2727438164ff.

# Testing
I created FAT 12, FAT 16, and FAT 32 file system images using `mkfs.vfat` (as in #16754).

For devs on macOS, these can be populated with `hdiutil`:
```
$ hdiutil attach fat16.img
# Add files to "/Volumes/NO\ NAME/"
$ hdiutil detach /Volumes/NO\ NAME/
```

These were added to qemu with the following change to run.sh:
```
+SERENITY_BOOT_DRIVE="$SERENITY_BOOT_DRIVE -drive file=$SCRIPT_DIR/../fat32.img,format=raw,index=1,media=disk"
+SERENITY_BOOT_DRIVE="$SERENITY_BOOT_DRIVE -drive file=$SCRIPT_DIR/../fat16.img,format=raw,index=2,media=disk"
+SERENITY_BOOT_DRIVE="$SERENITY_BOOT_DRIVE -drive file=$SCRIPT_DIR/../fat12.img,format=raw,index=3,media=disk"
```

Mounting a file system will detect the FAT file system version, EBPB version, and print the decoded BPB data:
```
2330.586 [#0 mount(69:69)]: FATFSs: oem_identifier: mkfs.fat
2330.586 [#0 mount(69:69)]: FATFS: bytes_per_sector: 512
2330.586 [#0 mount(69:69)]: FATFS: sectors_per_cluster: 4
2330.586 [#0 mount(69:69)]: FATFS: reserved_sector_count: 4
2330.586 [#0 mount(69:69)]: FATFS: fat_count: 2
2330.586 [#0 mount(69:69)]: FATFS: root_directory_entry_count: 512
2330.586 [#0 mount(69:69)]: FATFS: media_descriptor_type: 248
2330.586 [#0 mount(69:69)]: FATFS: sectors_per_track: 32
2330.586 [#0 mount(69:69)]: FATFS: head_count: 2
2330.586 [#0 mount(69:69)]: FATFS: hidden_sector_count: 0
2330.586 [#0 mount(69:69)]: FATFS: sector_count: 20480
2330.586 [#0 mount(69:69)]: FATFS: sectors_per_fat: 20
2330.586 [#0 mount(69:69)]: FATFS: EBPB: DOS 4
2330.586 [#0 mount(69:69)]: FATFS: drive_number: 128
2330.586 [#0 mount(69:69)]: FATFS: flags: 0
2330.586 [#0 mount(69:69)]: FATFS: volume_id: 1231697288
2330.586 [#0 mount(69:69)]: FATFS: Detected FAT16 with 5101 data area clusters
2330.598 [#0 mount(69:69)]: FATFS: Creating inode 48059 with filename "."
```

## QEMU vvfat disk
A much more stressing and useful test environment was the QEMU vvfat driver, which creates a FAT "disk" out of a host directory.

The vvfat driver has many options/modes, but the most useful are:
 * floppy: Present drive as a floppy disk, meaning there is no MBR partitioning scheme, and instead _just_ the FAT file system. When the `vvfat` drive is added with the `:floppy:` option, the drive block device (ie `/dev/hda`) can be mounted directly.
 * `:floppy:` not specified: Present drive as a hard disk. This disk contains an MBR and a single partition. Creation of block devices for MBR partitions isn't happening automatically, but can be created with `mknod`.
 * `:12:`, `:16:`, `:32:` to specify FAT version: Control the FAT version that QEMU uses when creating the drive. There is a QEMU bug mixing `:12:floppy:` (the resulting sector count for the drive is considered FAT12), and QEMU very loudly reports that FAT32 is untested, but otherwise it is effective.

I created a md5sum verification file on my host:
```
$ cd Documentation/
$ md5sum *.md */*.md > Documentation.md5
```

and then compared the checksum of each file within SerenityOS:
```
$ mkdir fat
$ mknod /dev/hdap0 b 100 0  # When using a hard-disk vvfat drive, not "floppy"
$ mount -t fat /dev/hdap0 fat
$ cd fat
$ md5sum --check Documentation.md5
```
<img width="599" alt="image" src="https://github.com/SerenityOS/serenity/assets/1073184/75f7dca3-4c10-4dd4-8e15-edd24f20b302">
