### PR TITLE
LibWeb: Select dropdown menu position fixes

### DIFF
--- a/Ladybird/Qt/Tab.cpp
+++ b/Ladybird/Qt/Tab.cpp
@@ -341,7 +341,7 @@ Tab::Tab(BrowserWindow* window, WebContentOptions const& web_content_options, St
     m_page_context_menu->addAction(&m_window->view_source_action());
     m_page_context_menu->addAction(&m_window->inspect_dom_node_action());
 
-    view().on_context_menu_request = [this, search_selected_text_action](Gfx::IntPoint) {
+    view().on_context_menu_request = [this, search_selected_text_action](Gfx::IntPoint content_position) {
         auto selected_text = Settings::the()->enable_search()
             ? view().selected_text_with_whitespace_collapsed()
             : OptionalNone {};
@@ -355,8 +355,7 @@ Tab::Tab(BrowserWindow* window, WebContentOptions const& web_content_options, St
             search_selected_text_action->setVisible(false);
         }
 
-        auto screen_position = QCursor::pos();
-        m_page_context_menu->exec(screen_position);
+        m_page_context_menu->exec(view().mapToGlobal(QPoint(content_position.x(), content_position.y()) / view().device_pixel_ratio()));
     };
 
     auto* open_link_action = new QAction("&Open", this);
@@ -385,7 +384,7 @@ Tab::Tab(BrowserWindow* window, WebContentOptions const& web_content_options, St
     m_link_context_menu->addSeparator();
     m_link_context_menu->addAction(&m_window->inspect_dom_node_action());
 
-    view().on_link_context_menu_request = [this](auto const& url, Gfx::IntPoint) {
+    view().on_link_context_menu_request = [this](auto const& url, Gfx::IntPoint content_position) {
         m_link_context_menu_url = url;
 
         switch (WebView::url_type(url)) {
@@ -400,8 +399,7 @@ Tab::Tab(BrowserWindow* window, WebContentOptions const& web_content_options, St
             break;
         }
 
-        auto screen_position = QCursor::pos();
-        m_link_context_menu->exec(screen_position);
+        m_link_context_menu->exec(view().mapToGlobal(QPoint(content_position.x(), content_position.y()) / view().device_pixel_ratio()));
     };
 
     auto* open_image_action = new QAction("&Open Image", this);
@@ -450,12 +448,11 @@ Tab::Tab(BrowserWindow* window, WebContentOptions const& web_content_options, St
     m_image_context_menu->addSeparator();
     m_image_context_menu->addAction(&m_window->inspect_dom_node_action());
 
-    view().on_image_context_menu_request = [this](auto& image_url, Gfx::IntPoint, Gfx::ShareableBitmap const& shareable_bitmap) {
+    view().on_image_context_menu_request = [this](auto& image_url, Gfx::IntPoint content_position, Gfx::ShareableBitmap const& shareable_bitmap) {
         m_image_context_menu_url = image_url;
         m_image_context_menu_bitmap = shareable_bitmap;
 
-        auto screen_position = QCursor::pos();
-        m_image_context_menu->exec(screen_position);
+        m_image_context_menu->exec(view().mapToGlobal(QPoint(content_position.x(), content_position.y()) / view().device_pixel_ratio()));
     };
 
     m_media_context_menu_play_icon = load_icon_from_uri("resource://icons/16x16/play.png"sv);
@@ -549,7 +546,7 @@ Tab::Tab(BrowserWindow* window, WebContentOptions const& web_content_options, St
     m_video_context_menu->addSeparator();
     m_video_context_menu->addAction(&m_window->inspect_dom_node_action());
 
-    view().on_media_context_menu_request = [this](Gfx::IntPoint, Web::Page::MediaContextMenu const& menu) {
+    view().on_media_context_menu_request = [this](Gfx::IntPoint content_position, Web::Page::MediaContextMenu const& menu) {
         m_media_context_menu_url = menu.media_url;
 
         if (menu.is_playing) {
@@ -571,8 +568,7 @@ Tab::Tab(BrowserWindow* window, WebContentOptions const& web_content_options, St
         m_media_context_menu_controls_action->setChecked(menu.has_user_agent_controls);
         m_media_context_menu_loop_action->setChecked(menu.is_looping);
 
-        auto screen_position = QCursor::pos();
-
+        auto screen_position = view().mapToGlobal(QPoint(content_position.x(), content_position.y()) / view().device_pixel_ratio());
         if (menu.is_video)
             m_video_context_menu->exec(screen_position);
         else

--- a/Ladybird/Qt/Tab.cpp
+++ b/Ladybird/Qt/Tab.cpp
@@ -239,7 +239,7 @@ Tab::Tab(BrowserWindow* window, WebContentOptions const& web_content_options, St
             select_dropdown_add_item(m_select_dropdown, item);
         }
 
-        m_select_dropdown->exec(mapToGlobal(QPoint(content_position.x(), content_position.y())));
+        m_select_dropdown->exec(view().mapToGlobal(QPoint(content_position.x(), content_position.y()) / view().device_pixel_ratio()));
     };
 
     QObject::connect(focus_location_editor_action, &QAction::triggered, this, &Tab::focus_location_editor);

--- a/Ladybird/Qt/WebContentView.cpp
+++ b/Ladybird/Qt/WebContentView.cpp
@@ -338,8 +338,8 @@ void WebContentView::wheelEvent(QWheelEvent* event)
             auto num_degrees = -event->angleDelta();
             float delta_x = -num_degrees.x() / 120;
             float delta_y = num_degrees.y() / 120;
-            auto step_x = delta_x * QApplication::wheelScrollLines() * devicePixelRatio();
-            auto step_y = delta_y * QApplication::wheelScrollLines() * devicePixelRatio();
+            auto step_x = delta_x * QApplication::wheelScrollLines() * m_device_pixel_ratio;
+            auto step_y = delta_y * QApplication::wheelScrollLines() * m_device_pixel_ratio;
             int scroll_step_size = verticalScrollBar()->singleStep();
             client().async_mouse_wheel(to_content_position(position), screen_position, button, buttons, modifiers, step_x * scroll_step_size, step_y * scroll_step_size);
         }

--- a/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
@@ -298,7 +298,8 @@ void HTMLSelectElement::activation_behavior(DOM::Event const&)
     // Request select dropdown
     auto weak_element = make_weak_ptr<HTMLSelectElement>();
     auto rect = get_bounding_client_rect();
-    document().browsing_context()->top_level_browsing_context()->page().did_request_select_dropdown(weak_element, Gfx::IntPoint { rect->x(), rect->y() }, rect->width(), items);
+    auto position = document().browsing_context()->to_top_level_position(Web::CSSPixelPoint { rect->x(), rect->y() });
+    document().browsing_context()->top_level_browsing_context()->page().did_request_select_dropdown(weak_element, position, CSSPixels(rect->width()), items);
     set_is_open(true);
 }
 

--- a/Userland/Libraries/LibWeb/Page/Page.cpp
+++ b/Userland/Libraries/LibWeb/Page/Page.cpp
@@ -331,7 +331,7 @@ void Page::color_picker_closed(Optional<Color> picked_color)
     }
 }
 
-void Page::did_request_select_dropdown(WeakPtr<HTML::HTMLSelectElement> target, Gfx::IntPoint content_position, i32 minimum_width, Vector<Web::HTML::SelectItem> items)
+void Page::did_request_select_dropdown(WeakPtr<HTML::HTMLSelectElement> target, Web::CSSPixelPoint content_position, Web::CSSPixels minimum_width, Vector<Web::HTML::SelectItem> items)
 {
     if (m_pending_non_blocking_dialog == PendingNonBlockingDialog::None) {
         m_pending_non_blocking_dialog = PendingNonBlockingDialog::Select;

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -129,7 +129,7 @@ public:
     void did_request_color_picker(WeakPtr<HTML::HTMLInputElement> target, Color current_color);
     void color_picker_closed(Optional<Color> picked_color);
 
-    void did_request_select_dropdown(WeakPtr<HTML::HTMLSelectElement> target, Gfx::IntPoint content_position, i32 minimum_width, Vector<Web::HTML::SelectItem> items);
+    void did_request_select_dropdown(WeakPtr<HTML::HTMLSelectElement> target, Web::CSSPixelPoint content_position, Web::CSSPixels minimum_width, Vector<Web::HTML::SelectItem> items);
     void select_dropdown_closed(Optional<String> value);
 
     enum class PendingNonBlockingDialog {
@@ -277,7 +277,7 @@ public:
     // https://html.spec.whatwg.org/multipage/input.html#show-the-picker,-if-applicable
     virtual void page_did_request_file_picker(WeakPtr<DOM::EventTarget>, [[maybe_unused]] bool multiple) {};
     virtual void page_did_request_color_picker([[maybe_unused]] Color current_color) {};
-    virtual void page_did_request_select_dropdown([[maybe_unused]] Gfx::IntPoint content_position, [[maybe_unused]] i32 minimum_width, [[maybe_unused]] Vector<Web::HTML::SelectItem> items) {};
+    virtual void page_did_request_select_dropdown([[maybe_unused]] Web::CSSPixelPoint content_position, [[maybe_unused]] Web::CSSPixels minimum_width, [[maybe_unused]] Vector<Web::HTML::SelectItem> items) {};
 
     virtual void page_did_finish_text_test() {};
 

--- a/Userland/Libraries/LibWebView/ViewImplementation.h
+++ b/Userland/Libraries/LibWebView/ViewImplementation.h
@@ -50,6 +50,7 @@ public:
     void zoom_out();
     void reset_zoom();
     float zoom_level() const { return m_zoom_level; }
+    float device_pixel_ratio() const { return m_device_pixel_ratio; }
 
     void set_preferred_color_scheme(Web::CSS::PreferredColorScheme);
 

--- a/Userland/Libraries/LibWebView/WebContentClient.cpp
+++ b/Userland/Libraries/LibWebView/WebContentClient.cpp
@@ -387,7 +387,7 @@ void WebContentClient::did_request_color_picker(Color const& current_color)
 void WebContentClient::did_request_select_dropdown(Gfx::IntPoint content_position, i32 minimum_width, Vector<Web::HTML::SelectItem> const& items)
 {
     if (m_view.on_request_select_dropdown)
-        m_view.on_request_select_dropdown(content_position, minimum_width, items);
+        m_view.on_request_select_dropdown(m_view.to_widget_position(content_position), m_view.to_widget_position(Gfx::IntPoint { minimum_width, 0 }).x(), items);
 }
 
 void WebContentClient::did_finish_handling_input_event(bool event_was_accepted)

--- a/Userland/Services/WebContent/PageClient.cpp
+++ b/Userland/Services/WebContent/PageClient.cpp
@@ -509,9 +509,9 @@ void PageClient::page_did_request_color_picker(Color current_color)
     client().async_did_request_color_picker(current_color);
 }
 
-void PageClient::page_did_request_select_dropdown(Gfx::IntPoint content_position, i32 minimum_width, Vector<Web::HTML::SelectItem> items)
+void PageClient::page_did_request_select_dropdown(Web::CSSPixelPoint content_position, Web::CSSPixels minimum_width, Vector<Web::HTML::SelectItem> items)
 {
-    client().async_did_request_select_dropdown(content_position, minimum_width, items);
+    client().async_did_request_select_dropdown(page().css_to_device_point(content_position).to_type<int>(), minimum_width * device_pixels_per_css_pixel(), items);
 }
 
 void PageClient::page_did_change_theme_color(Gfx::Color color)

--- a/Userland/Services/WebContent/PageClient.h
+++ b/Userland/Services/WebContent/PageClient.h
@@ -119,7 +119,7 @@ private:
     virtual void page_did_close_browsing_context(Web::HTML::BrowsingContext const&) override;
     virtual void request_file(Web::FileRequest) override;
     virtual void page_did_request_color_picker(Color current_color) override;
-    virtual void page_did_request_select_dropdown(Gfx::IntPoint content_position, i32 minimum_width, Vector<Web::HTML::SelectItem> items) override;
+    virtual void page_did_request_select_dropdown(Web::CSSPixelPoint content_position, Web::CSSPixels minimum_width, Vector<Web::HTML::SelectItem> items) override;
     virtual void page_did_finish_text_test() override;
     virtual void page_did_change_theme_color(Gfx::Color color) override;
     virtual void page_did_insert_clipboard_entry(String data, String presentation_style, String mime_type) override;


### PR DESCRIPTION
The coordinates systems in the `WebContentClient.ipc` are super vague and I'm working on refactoring it to `DevicePixel` and `CSSPixels` units. But that is quite a lot of work so here is the first small batch of changes.

This pr fixes some bugs with the Ladybird Qt chrome and makes the request_select_dropdown API more similar to the other context menu API's.

NOTE FOR REVIEWER: The Qt chrome currently doesn't listen for dpi changes (multi monitor setup) so it will only use the dpi read on init. These are more abstract changes so feel free to ask questions if you don't understand a change.