### PR TITLE
LibGUI: Fix debug line causing crash when drag event has no mime data

### DIFF
--- a/Userland/Libraries/LibGUI/AbstractView.cpp
+++ b/Userland/Libraries/LibGUI/AbstractView.cpp
@@ -791,7 +791,7 @@ void AbstractView::drag_enter_event(DragEvent& event)
     //       We might be able to reduce event traffic by communicating the set of drag-accepting
     //       rects in this widget to the windowing system somehow.
     event.accept();
-    dbgln_if(DRAG_DEBUG, "accepting drag of {}", event.mime_types().first());
+    dbgln_if(DRAG_DEBUG, "accepting drag of {}", event.mime_types());
 }
 
 void AbstractView::drag_move_event(DragEvent& event)


### PR DESCRIPTION
Resolves #10618.

Simply put, this is caused by a debug line that calls `Vector::first()` which fails a `VERIFY()` check when its provided an empty vector.

Because of how old this issue is, I had to do the following:

1. Rewrite the reproducible that was provided to the following modern version:
```cpp
#include "LibGUI/ConnectionToWindowServer.h"
#include <AK/StringBuilder.h>
#include <LibCore/MimeData.h>
#include <LibGUI/Action.h>
#include <LibGUI/Application.h>
#include <LibGUI/BoxLayout.h>
#include <LibGUI/Button.h>
#include <LibGUI/Event.h>
#include <LibGUI/Icon.h>
#include <LibGUI/Label.h>
#include <LibGUI/Menu.h>
#include <LibGUI/MessageBox.h>
#include <LibGUI/Widget.h>
#include <LibGUI/Window.h>
#include <ctype.h>
#include <stdio.h>
#include <string.h>
#include <sys/stat.h>
#include <sys/types.h>
#include <unistd.h>

ErrorOr<int> serenity_main(Main::Arguments args)
{
    auto app = TRY(GUI::Application::create(args));

    auto window = GUI::Window::construct();

    window->set_title("TestWindowServer");
    window->set_resizable(true);
    window->set_window_type(GUI::WindowType::Normal);
    window->set_fullscreen(false);

    auto main_widget = window->set_main_widget<GUI::Widget>();
    main_widget->set_fill_with_background_color(true);

    main_widget->set_layout<GUI::VerticalBoxLayout>();
    auto* layout = main_widget->layout();
    layout->set_margins({ 4, 4, 4, 4 });

    auto& label = main_widget->add<GUI::Label>();
    label.set_text("Hello friends"_string);

    window->show();

    GUI::ConnectionToWindowServer::the().start_drag("hello friends!", {}, {}); // <-- crash

    return app->exec();
}
```
2. Include a `#define DRAG_DEBUG 1` above the `#include`s in `LibGUI/AbstractView.cpp` so that the debug lines can be executed.

3. Modify the following if-statement removing the "is holding primary mouse button" check that was added long after this issue was made:
https://github.com/SerenityOS/serenity/blob/41a3c19cfecd490fb2a14a8365d8ad051c604669/Userland/Services/WindowServer/ConnectionFromClient.cpp#L874-L878

And by doing the above I was able to see the same assertion failure:
```console
. . .
5.322 ClipboardHistory.Applet(39): Unable to load clipboard history: open: No such file or directory (errno=2)
5.816 [#0 VFS Sync Task(4:4)]: Ext2FS: Flushed 15 blocks to disk
9.536 FileManager (Desktop)(32): VERIFICATION FAILED: i < m_size at ././AK/Vector.h:139
9.538 [FileManager (Desktop)(32:32)]: CRASH: CPU #0 Illegal instruction in userspace
9.538 [#0 FileManager (Desktop)(32:32)]: Exception code: 0000 (isr: 0000)
9.538 [#0 FileManager (Desktop)(32:32)]:     pc=0x0023:0x00000006bd7bac28 rflags=0x0000000000010206
9.538 [#0 FileManager (Desktop)(32:32)]:  stack=0x0000001199b99260
9.538 [#0 FileManager (Desktop)(32:32)]:    rax=0x0000000000000000 rbx=0x00000006bd8992e8 rcx=0x0000001b50ae202b rdx=0x0000001199b99108
9.538 [#0 FileManager (Desktop)(32:32)]:    rbp=0x0000001199b992a0 rsp=0x00000020142dfef0 rsi=0x0000001199b99108 rdi=0x000000000000006e
9.538 [#0 FileManager (Desktop)(32:32)]:     r8=0x000000000000006d  r9=0x0000000000000000 r10=0x000000062735fe78 r11=0x0000000000000212
9.538 [#0 FileManager (Desktop)(32:32)]:    r12=0x0000001199b99380 r13=0x00000006273dee38 r14=0x0000000d198d0830 r15=0x0000000b8da70be0
9.538 [#0 FileManager (Desktop)(32:32)]:    cr0=0x0000000080010013 cr2=0x00000020130a1000 cr3=0x000000000b288000 cr4=0x0000000000340ee0
9.538 [#0 FileManager (Desktop)(32:32)]: 0x00000006bd7bac28  (?)
. . .
```