### PR TITLE
LibJS: Only consider VM-accessible execution contexts as strong roots

### DIFF
--- a/Userland/Libraries/LibJS/Heap/Heap.cpp
+++ b/Userland/Libraries/LibJS/Heap/Heap.cpp
@@ -450,9 +450,6 @@ void Heap::mark_live_cells(HashMap<Cell*, HeapRoot> const& roots)
 
     MarkingVisitor visitor(*this, roots);
 
-    for (auto& execution_context : m_execution_contexts)
-        execution_context.visit_edges(visitor);
-
     vm().bytecode_interpreter().visit_edges(visitor);
 
     visitor.mark_all_live_cells();

--- a/Userland/Libraries/LibJS/Heap/Heap.h
+++ b/Userland/Libraries/LibJS/Heap/Heap.h
@@ -148,7 +148,6 @@ private:
     HandleImpl::List m_handles;
     MarkedVectorBase::List m_marked_vectors;
     WeakContainer::List m_weak_containers;
-    ExecutionContext::List m_execution_contexts;
 
     Vector<GCPtr<Cell>> m_uprooted_cells;
 
@@ -194,18 +193,6 @@ inline void Heap::did_destroy_weak_container(Badge<WeakContainer>, WeakContainer
 {
     VERIFY(m_weak_containers.contains(set));
     m_weak_containers.remove(set);
-}
-
-inline void Heap::did_create_execution_context(Badge<ExecutionContext>, ExecutionContext& set)
-{
-    VERIFY(!m_execution_contexts.contains(set));
-    m_execution_contexts.append(set);
-}
-
-inline void Heap::did_destroy_execution_context(Badge<ExecutionContext>, ExecutionContext& set)
-{
-    VERIFY(m_execution_contexts.contains(set));
-    m_execution_contexts.remove(set);
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/AsyncFunctionDriverWrapper.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AsyncFunctionDriverWrapper.cpp
@@ -192,6 +192,8 @@ void AsyncFunctionDriverWrapper::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_top_level_promise);
     if (m_current_promise)
         visitor.visit(m_current_promise);
+    if (m_suspended_execution_context)
+        m_suspended_execution_context->visit_edges(visitor);
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/AsyncGenerator.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AsyncGenerator.cpp
@@ -48,6 +48,7 @@ void AsyncGenerator::visit_edges(Cell::Visitor& visitor)
     if (m_frame)
         m_frame->visit_edges(visitor);
     visitor.visit(m_current_promise);
+    m_async_generator_context->visit_edges(visitor);
 }
 
 // 27.6.3.4 AsyncGeneratorEnqueue ( generator, completion, promiseCapability ), https://tc39.es/ecma262/#sec-asyncgeneratorenqueue

--- a/Userland/Libraries/LibJS/Runtime/ExecutionContext.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ExecutionContext.cpp
@@ -21,12 +21,10 @@ NonnullOwnPtr<ExecutionContext> ExecutionContext::create(Heap& heap)
 ExecutionContext::ExecutionContext(Heap& heap)
     : m_heap(heap)
 {
-    m_heap.did_create_execution_context({}, *this);
 }
 
 ExecutionContext::~ExecutionContext()
 {
-    m_heap.did_destroy_execution_context({}, *this);
 }
 
 NonnullOwnPtr<ExecutionContext> ExecutionContext::copy() const

--- a/Userland/Libraries/LibJS/Runtime/GeneratorObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/GeneratorObject.cpp
@@ -51,6 +51,7 @@ void GeneratorObject::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_previous_value);
     if (m_frame)
         m_frame->visit_edges(visitor);
+    m_execution_context->visit_edges(visitor);
 }
 
 // 27.5.3.2 GeneratorValidate ( generator, generatorBrand ), https://tc39.es/ecma262/#sec-generatorvalidate

--- a/Userland/Libraries/LibJS/SourceTextModule.cpp
+++ b/Userland/Libraries/LibJS/SourceTextModule.cpp
@@ -120,6 +120,7 @@ void SourceTextModule::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
     visitor.visit(m_import_meta);
+    m_execution_context->visit_edges(visitor);
 }
 
 // 16.2.1.6.1 ParseModule ( sourceText, realm, hostDefined ), https://tc39.es/ecma262/#sec-parsemodule

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Environments.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Environments.cpp
@@ -45,6 +45,7 @@ void EnvironmentSettingsObject::visit_edges(Cell::Visitor& visitor)
     visitor.visit(target_browsing_context);
     visitor.visit(m_module_map);
     visitor.ignore(m_outstanding_rejected_promises_weak_set);
+    m_realm_execution_context->visit_edges(visitor);
 }
 
 JS::ExecutionContext& EnvironmentSettingsObject::realm_execution_context()


### PR DESCRIPTION
Partially reverts 3dc5f467a8200b7c4043cf01d78b08745ddf8528 to fix GC memory leak that happens because we treated all execution contexts as strong roots.