### PR TITLE
LibWeb: Fix crashing in compute_font_for_style_values on SerenityOS

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -208,7 +208,8 @@ struct StyleComputer::MatchingFontCandidate {
             return font_list;
         }
 
-        font_list->add(*loader_or_typeface.get<Gfx::Typeface const*>()->get_font(point_size));
+        if (auto font = loader_or_typeface.get<Gfx::Typeface const*>()->get_font(point_size))
+            font_list->add(*font);
         return font_list;
     }
 };

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -1894,6 +1894,8 @@ RefPtr<Gfx::FontCascadeList const> StyleComputer::compute_font_for_style_values(
     auto found_font = StyleProperties::font_fallback(monospace, bold);
     if (auto scaled_fallback_font = found_font->with_size(font_size_in_pt)) {
         font_list->add(*scaled_fallback_font);
+    } else {
+        font_list->add(*found_font);
     }
 
     return font_list;


### PR DESCRIPTION
Fixes crashes introduced in https://github.com/SerenityOS/serenity/pull/22236