### PR TITLE
Ladybird/Qt: Listen to DPI changes and update WebContentView accordingly

### DIFF
--- a/Ladybird/Qt/BrowserWindow.h
+++ b/Ladybird/Qt/BrowserWindow.h
@@ -70,6 +70,7 @@ public:
     }
 
 public slots:
+    void device_pixel_ratio_changed(qreal dpi);
     void tab_title_changed(int index, QString const&);
     void tab_favicon_changed(int index, QIcon const& icon);
     Tab& new_tab(QString const&, Web::HTML::ActivateTab);
@@ -114,6 +115,9 @@ private:
             callback(tab);
         }
     }
+
+    QScreen* m_current_screen;
+    double m_device_pixel_ratio { 0 };
 
     QTabWidget* m_tabs_container { nullptr };
     Tab* m_current_tab { nullptr };

--- a/Ladybird/Qt/InspectorWidget.h
+++ b/Ladybird/Qt/InspectorWidget.h
@@ -31,10 +31,16 @@ public:
     void select_hovered_node();
     void select_default_node();
 
+public slots:
+    void device_pixel_ratio_changed(qreal dpi);
+
 private:
     void closeEvent(QCloseEvent*) override;
 
     QPoint to_widget_position(Gfx::IntPoint) const;
+
+    QScreen* m_current_screen;
+    double m_device_pixel_ratio { 0 };
 
     WebContentView* m_inspector_view;
     OwnPtr<WebView::InspectorClient> m_inspector_client;

--- a/Ladybird/Qt/WebContentView.h
+++ b/Ladybird/Qt/WebContentView.h
@@ -69,6 +69,7 @@ public:
     void set_viewport_rect(Gfx::IntRect);
     void set_window_size(Gfx::IntSize);
     void set_window_position(Gfx::IntPoint);
+    void set_device_pixel_ratio(double);
 
     enum class PaletteMode {
         Default,
@@ -90,7 +91,6 @@ private:
     void update_viewport_rect();
     void update_cursor(Gfx::StandardCursor cursor);
 
-    qreal m_inverse_pixel_scaling_ratio { 1.0 };
     bool m_should_show_line_box_borders { false };
 
     Gfx::IntRect m_viewport_rect;


### PR DESCRIPTION
This adds support for listening to dpi changes to the Ladybird Qt chrome. Sadly the Qt framework makes it quite hard to listen to dpi changes. You can only listen if the window changes screens and if a specific screens dpi changes. So I have added the code that the window listens to dpi changes and updates all the WebContentViews it has.