### PR TITLE
Userland: Don't leak objects when constructor arguments throw

### DIFF
--- a/Userland/Libraries/LibAudio/Loader.cpp
+++ b/Userland/Libraries/LibAudio/Loader.cpp
@@ -45,13 +45,15 @@ static constexpr LoaderPluginInitializer s_initializers[] = {
 ErrorOr<NonnullRefPtr<Loader>, LoaderError> Loader::create(StringView path)
 {
     auto stream = TRY(Core::MappedFile::map(path, Core::MappedFile::Mode::ReadOnly));
-    return adopt_ref(*new (nothrow) Loader(TRY(Loader::create_plugin(move(stream)))));
+    auto plugin = TRY(Loader::create_plugin(move(stream)));
+    return adopt_ref(*new (nothrow) Loader(move(plugin)));
 }
 
 ErrorOr<NonnullRefPtr<Loader>, LoaderError> Loader::create(ReadonlyBytes buffer)
 {
     auto stream = TRY(try_make<FixedMemoryStream>(buffer));
-    return adopt_ref(*new (nothrow) Loader(TRY(Loader::create_plugin(move(stream)))));
+    auto plugin = TRY(Loader::create_plugin(move(stream)));
+    return adopt_ref(*new (nothrow) Loader(move(plugin)));
 }
 
 ErrorOr<NonnullOwnPtr<LoaderPlugin>, LoaderError> Loader::create_plugin(NonnullOwnPtr<SeekableStream> stream)

--- a/Userland/Libraries/LibChess/UCICommand.cpp
+++ b/Userland/Libraries/LibChess/UCICommand.cpp
@@ -94,9 +94,9 @@ ErrorOr<NonnullOwnPtr<SetOptionCommand>> SetOptionCommand::from_string(StringVie
 
     VERIFY(!name.is_empty());
 
-    return adopt_nonnull_own_or_enomem(new (nothrow) SetOptionCommand(
-        TRY(String::from_utf8(name.string_view().trim_whitespace())),
-        TRY(String::from_utf8(value.string_view().trim_whitespace()))));
+    auto name_string = TRY(String::from_utf8(name.string_view().trim_whitespace()));
+    auto value_string = TRY(String::from_utf8(value.string_view().trim_whitespace()));
+    return adopt_nonnull_own_or_enomem(new (nothrow) SetOptionCommand(name_string, value_string));
 }
 
 ErrorOr<String> SetOptionCommand::to_string() const
@@ -259,10 +259,11 @@ ErrorOr<NonnullOwnPtr<IdCommand>> IdCommand::from_string(StringView command)
         TRY(value.try_append(tokens[i]));
     }
 
+    auto value_string = TRY(value.to_string());
     if (tokens[1] == "name") {
-        return adopt_nonnull_own_or_enomem(new (nothrow) IdCommand(Type::Name, TRY(value.to_string())));
+        return adopt_nonnull_own_or_enomem(new (nothrow) IdCommand(Type::Name, value_string));
     } else if (tokens[1] == "author") {
-        return adopt_nonnull_own_or_enomem(new (nothrow) IdCommand(Type::Author, TRY(value.to_string())));
+        return adopt_nonnull_own_or_enomem(new (nothrow) IdCommand(Type::Author, value_string));
     }
     VERIFY_NOT_REACHED();
 }

--- a/Userland/Libraries/LibGUI/InputBox.cpp
+++ b/Userland/Libraries/LibGUI/InputBox.cpp
@@ -19,14 +19,18 @@ namespace GUI {
 ErrorOr<NonnullRefPtr<InputBox>> InputBox::create(Window* parent_window, String text_value, StringView prompt, StringView title, InputType input_type, RefPtr<Gfx::Bitmap const> icon)
 {
     VERIFY(input_type != InputType::Numeric);
-    auto box = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) InputBox(parent_window, text_value, TRY(String::from_utf8(title)), TRY(String::from_utf8(prompt)), input_type, move(icon))));
+    auto title_string = TRY(String::from_utf8(title));
+    auto prompt_string = TRY(String::from_utf8(prompt));
+    auto box = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) InputBox(parent_window, text_value, title_string, prompt_string, input_type, move(icon))));
     TRY(box->build());
     return box;
 }
 
 ErrorOr<NonnullRefPtr<InputBox>> InputBox::create_numeric(Window* parent_window, int value, StringView title, StringView prompt, RefPtr<Gfx::Bitmap const> icon)
 {
-    auto box = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) InputBox(parent_window, value, TRY(String::from_utf8(title)), TRY(String::from_utf8(prompt)), move(icon))));
+    auto title_string = TRY(String::from_utf8(title));
+    auto prompt_string = TRY(String::from_utf8(prompt));
+    auto box = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) InputBox(parent_window, value, title_string, prompt_string, move(icon))));
     TRY(box->build());
     return box;
 }

--- a/Userland/Shell/Shell.cpp
+++ b/Userland/Shell/Shell.cpp
@@ -420,8 +420,10 @@ ErrorOr<RefPtr<AST::Value const>> Shell::look_up_local_variable(StringView name)
 
 ErrorOr<RefPtr<AST::Value const>> Shell::get_argument(size_t index) const
 {
-    if (index == 0)
-        return adopt_ref(*new AST::StringValue(TRY(String::from_deprecated_string(current_script))));
+    if (index == 0) {
+        auto current_script_string = TRY(String::from_deprecated_string(current_script));
+        return adopt_ref(*new AST::StringValue(current_script_string));
+    }
 
     --index;
     if (auto argv = TRY(look_up_local_variable("ARGV"sv))) {


### PR DESCRIPTION
Similar to d253beb2f72442f6d05e1b4b0711a37bfe68fdc7.

Found with Ali's clang-query script in Shell:

```
for $(find AK Userland -type f -name '*.h' -o -name '*.cpp') {
    in_parallel -j 12 -- clang-query -p \
    Build/lagom/compile_commands.json $it -c \
    'm cxxNewExpr(has(cxxConstructExpr(hasAnyArgument(hasDescendant( \
        allOf(isExpandedFromMacro("TRY"), stmtExpr()))))))' \
    } | grep -v 'matches.' | tee results
```