### PR TITLE
LibWeb: Refactor int types in WebContentServer to DevicePixels

### DIFF
--- a/Ladybird/AppKit/UI/LadybirdWebView.mm
+++ b/Ladybird/AppKit/UI/LadybirdWebView.mm
@@ -85,11 +85,11 @@ struct HideCursor {
         auto* delegate = (ApplicationDelegate*)[NSApp delegate];
         auto* screens = [NSScreen screens];
 
-        Vector<Gfx::IntRect> screen_rects;
+        Vector<Web::DevicePixelRect> screen_rects;
         screen_rects.ensure_capacity([screens count]);
 
         for (id screen in screens) {
-            auto screen_rect = Ladybird::ns_rect_to_gfx_rect([screen frame]);
+            auto screen_rect = Ladybird::ns_rect_to_gfx_rect([screen frame]).to_type<Web::DevicePixels>();
             screen_rects.unchecked_append(screen_rect);
         }
 

--- a/Ladybird/AppKit/UI/LadybirdWebViewBridge.h
+++ b/Ladybird/AppKit/UI/LadybirdWebViewBridge.h
@@ -23,7 +23,7 @@ namespace Ladybird {
 
 class WebViewBridge final : public WebView::ViewImplementation {
 public:
-    static ErrorOr<NonnullOwnPtr<WebViewBridge>> create(Vector<Gfx::IntRect> screen_rects, float device_pixel_ratio, WebContentOptions const&, Optional<StringView> webdriver_content_ipc_path, Web::CSS::PreferredColorScheme);
+    static ErrorOr<NonnullOwnPtr<WebViewBridge>> create(Vector<Web::DevicePixelRect> screen_rects, float device_pixel_ratio, WebContentOptions const&, Optional<StringView> webdriver_content_ipc_path, Web::CSS::PreferredColorScheme);
     virtual ~WebViewBridge() override;
 
     float device_pixel_ratio() const { return m_device_pixel_ratio; }
@@ -60,16 +60,16 @@ public:
     Function<void(Gfx::IntPoint)> on_scroll;
 
 private:
-    WebViewBridge(Vector<Gfx::IntRect> screen_rects, float device_pixel_ratio, WebContentOptions const&, Optional<StringView> webdriver_content_ipc_path, Web::CSS::PreferredColorScheme);
+    WebViewBridge(Vector<Web::DevicePixelRect> screen_rects, float device_pixel_ratio, WebContentOptions const&, Optional<StringView> webdriver_content_ipc_path, Web::CSS::PreferredColorScheme);
 
     virtual void update_zoom() override;
-    virtual Gfx::IntRect viewport_rect() const override;
+    virtual Web::DevicePixelRect viewport_rect() const override;
     virtual Gfx::IntPoint to_content_position(Gfx::IntPoint widget_position) const override;
     virtual Gfx::IntPoint to_widget_position(Gfx::IntPoint content_position) const override;
 
     virtual void create_client() override;
 
-    Vector<Gfx::IntRect> m_screen_rects;
+    Vector<Web::DevicePixelRect> m_screen_rects;
     Gfx::IntRect m_viewport_rect;
 
     WebContentOptions m_web_content_options;

--- a/Ladybird/Qt/BrowserWindow.cpp
+++ b/Ladybird/Qt/BrowserWindow.cpp
@@ -704,7 +704,7 @@ void BrowserWindow::resizeEvent(QResizeEvent* event)
     QWidget::resizeEvent(event);
 
     for_each_tab([&](auto& tab) {
-        tab.view().set_window_size({ frameSize().width(), frameSize().height() });
+        tab.view().set_window_size({ frameSize().width() * m_device_pixel_ratio, frameSize().height() * m_device_pixel_ratio });
     });
 }
 
@@ -713,7 +713,7 @@ void BrowserWindow::moveEvent(QMoveEvent* event)
     QWidget::moveEvent(event);
 
     for_each_tab([&](auto& tab) {
-        tab.view().set_window_position({ event->pos().x(), event->pos().y() });
+        tab.view().set_window_position({ event->pos().x() * m_device_pixel_ratio, event->pos().y() * m_device_pixel_ratio });
     });
 }
 

--- a/Ladybird/Qt/WebContentView.cpp
+++ b/Ladybird/Qt/WebContentView.cpp
@@ -484,11 +484,11 @@ void WebContentView::paintEvent(QPaintEvent*)
 
     if (m_client_state.has_usable_bitmap) {
         bitmap = m_client_state.front_bitmap.bitmap.ptr();
-        bitmap_size = m_client_state.front_bitmap.last_painted_size;
+        bitmap_size = m_client_state.front_bitmap.last_painted_size.to_type<int>();
 
     } else {
         bitmap = m_backup_bitmap.ptr();
-        bitmap_size = m_backup_bitmap_size;
+        bitmap_size = m_backup_bitmap_size.to_type<int>();
     }
 
     if (bitmap) {
@@ -518,17 +518,17 @@ void WebContentView::resizeEvent(QResizeEvent* event)
 void WebContentView::set_viewport_rect(Gfx::IntRect rect)
 {
     m_viewport_rect = rect;
-    client().async_set_viewport_rect(rect);
+    client().async_set_viewport_rect(rect.to_type<Web::DevicePixels>());
 }
 
 void WebContentView::set_window_size(Gfx::IntSize size)
 {
-    client().async_set_window_size(size);
+    client().async_set_window_size(size.to_type<Web::DevicePixels>());
 }
 
 void WebContentView::set_window_position(Gfx::IntPoint position)
 {
-    client().async_set_window_position(position);
+    client().async_set_window_position(position.to_type<Web::DevicePixels>());
 }
 
 void WebContentView::set_device_pixel_ratio(double device_pixel_ratio)
@@ -631,12 +631,10 @@ void WebContentView::create_client()
     auto screens = QGuiApplication::screens();
 
     if (!screens.empty()) {
-        Vector<Gfx::IntRect> screen_rects;
-
+        Vector<Web::DevicePixelRect> screen_rects;
         for (auto const& screen : screens) {
             auto geometry = screen->geometry();
-
-            screen_rects.append(Gfx::IntRect(geometry.x(), geometry.y(), geometry.width(), geometry.height()));
+            screen_rects.append(Web::DevicePixelRect(geometry.x(), geometry.y(), geometry.width(), geometry.height()));
         }
 
         // FIXME: Update the screens again when QGuiApplication::screenAdded/Removed signals are emitted
@@ -714,9 +712,9 @@ void WebContentView::update_cursor(Gfx::StandardCursor cursor)
     }
 }
 
-Gfx::IntRect WebContentView::viewport_rect() const
+Web::DevicePixelRect WebContentView::viewport_rect() const
 {
-    return m_viewport_rect;
+    return m_viewport_rect.to_type<Web::DevicePixels>();
 }
 
 Gfx::IntPoint WebContentView::to_content_position(Gfx::IntPoint widget_position) const

--- a/Ladybird/Qt/WebContentView.h
+++ b/Ladybird/Qt/WebContentView.h
@@ -84,7 +84,7 @@ private:
     // ^WebView::ViewImplementation
     virtual void create_client() override;
     virtual void update_zoom() override;
-    virtual Gfx::IntRect viewport_rect() const override;
+    virtual Web::DevicePixelRect viewport_rect() const override;
     virtual Gfx::IntPoint to_content_position(Gfx::IntPoint widget_position) const override;
     virtual Gfx::IntPoint to_widget_position(Gfx::IntPoint content_position) const override;
 

--- a/Meta/Lagom/Tools/CodeGenerators/IPCCompiler/main.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/IPCCompiler/main.cpp
@@ -70,7 +70,7 @@ static bool is_primitive_type(DeprecatedString const& type)
 static bool is_simple_type(DeprecatedString const& type)
 {
     // Small types that it makes sense just to pass by value.
-    return type.is_one_of("Gfx::Color", "Gfx::IntPoint", "Gfx::FloatPoint", "Gfx::IntSize", "Gfx::FloatSize", "Core::File::OpenMode");
+    return type.is_one_of("Gfx::Color", "Gfx::IntPoint", "Gfx::FloatPoint", "Web::DevicePixelPoint", "Gfx::IntSize", "Gfx::FloatSize", "Web::DevicePixelSize", "Core::File::OpenMode");
 }
 
 static bool is_primitive_or_simple_type(DeprecatedString const& type)

--- a/Userland/Libraries/LibWeb/PixelUnits.cpp
+++ b/Userland/Libraries/LibWeb/PixelUnits.cpp
@@ -5,6 +5,8 @@
  */
 
 #include <AK/Math.h>
+#include <LibIPC/Decoder.h>
+#include <LibIPC/Encoder.h>
 #include <LibWeb/PixelUnits.h>
 
 namespace Web {
@@ -22,6 +24,72 @@ double CSSPixels::to_double() const
 int CSSPixels::to_int() const
 {
     return m_value / fixed_point_denominator;
+}
+
+}
+
+namespace IPC {
+
+template<>
+ErrorOr<void> encode(Encoder& encoder, Web::DevicePixels const& value)
+{
+    TRY(encoder.encode(value.value()));
+    return {};
+}
+
+template<>
+ErrorOr<Web::DevicePixels> decode(Decoder& decoder)
+{
+    auto value = TRY(decoder.decode<int>());
+    return Web::DevicePixels(value);
+}
+
+template<>
+ErrorOr<void> encode(Encoder& encoder, Web::DevicePixelPoint const& value)
+{
+    TRY(encoder.encode(value.x()));
+    TRY(encoder.encode(value.y()));
+    return {};
+}
+
+template<>
+ErrorOr<Web::DevicePixelPoint> decode(Decoder& decoder)
+{
+    auto x = TRY(decoder.decode<Web::DevicePixels>());
+    auto y = TRY(decoder.decode<Web::DevicePixels>());
+    return Web::DevicePixelPoint { x, y };
+}
+
+template<>
+ErrorOr<void> encode(Encoder& encoder, Web::DevicePixelSize const& value)
+{
+    TRY(encoder.encode(value.width()));
+    TRY(encoder.encode(value.height()));
+    return {};
+}
+
+template<>
+ErrorOr<Web::DevicePixelSize> decode(Decoder& decoder)
+{
+    auto width = TRY(decoder.decode<Web::DevicePixels>());
+    auto height = TRY(decoder.decode<Web::DevicePixels>());
+    return Web::DevicePixelSize { width, height };
+}
+
+template<>
+ErrorOr<void> encode(Encoder& encoder, Web::DevicePixelRect const& value)
+{
+    TRY(encoder.encode(value.location()));
+    TRY(encoder.encode(value.size()));
+    return {};
+}
+
+template<>
+ErrorOr<Web::DevicePixelRect> decode(Decoder& decoder)
+{
+    auto location = TRY(decoder.decode<Web::DevicePixelPoint>());
+    auto size = TRY(decoder.decode<Web::DevicePixelSize>());
+    return Web::DevicePixelRect { location, size };
 }
 
 }

--- a/Userland/Libraries/LibWeb/PixelUnits.h
+++ b/Userland/Libraries/LibWeb/PixelUnits.h
@@ -15,6 +15,7 @@
 #include <AK/Traits.h>
 #include <LibGfx/Forward.h>
 #include <LibGfx/Rect.h>
+#include <LibIPC/Forward.h>
 #include <math.h>
 
 namespace Web {
@@ -502,5 +503,29 @@ struct Formatter<Web::DevicePixels> : Formatter<Web::DevicePixels::Type> {
         return Formatter<Web::DevicePixels::Type>::format(builder, value.value());
     }
 };
+
+}
+
+namespace IPC {
+
+template<>
+ErrorOr<void> encode(Encoder& encoder, Web::DevicePixels const& value);
+template<>
+ErrorOr<Web::DevicePixels> decode(Decoder& decoder);
+
+template<>
+ErrorOr<void> encode(Encoder& encoder, Web::DevicePixelPoint const& value);
+template<>
+ErrorOr<Web::DevicePixelPoint> decode(Decoder& decoder);
+
+template<>
+ErrorOr<void> encode(Encoder& encoder, Web::DevicePixelSize const& value);
+template<>
+ErrorOr<Web::DevicePixelSize> decode(Decoder& decoder);
+
+template<>
+ErrorOr<void> encode(Encoder& encoder, Web::DevicePixelRect const& value);
+template<>
+ErrorOr<Web::DevicePixelRect> decode(Decoder& decoder);
 
 }

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
@@ -95,7 +95,12 @@ void OutOfProcessWebView::create_client()
 
     client().async_update_system_theme(Gfx::current_system_theme_buffer());
     client().async_update_system_fonts(Gfx::FontDatabase::default_font_query(), Gfx::FontDatabase::fixed_width_font_query(), Gfx::FontDatabase::window_title_font_query());
-    client().async_update_screen_rects(GUI::Desktop::the().rects(), GUI::Desktop::the().main_screen_index());
+
+    Vector<Web::DevicePixelRect> screen_rects;
+    for (auto const& screen_rect : GUI::Desktop::the().rects()) {
+        screen_rects.append(screen_rect.to_type<Web::DevicePixels>());
+    }
+    client().async_update_screen_rects(screen_rects, GUI::Desktop::the().main_screen_index());
 }
 
 void OutOfProcessWebView::paint_event(GUI::PaintEvent& event)
@@ -132,13 +137,13 @@ void OutOfProcessWebView::paint_event(GUI::PaintEvent& event)
 void OutOfProcessWebView::resize_event(GUI::ResizeEvent& event)
 {
     Super::resize_event(event);
-    client().async_set_viewport_rect(Gfx::IntRect({ horizontal_scrollbar().value(), vertical_scrollbar().value() }, available_size()));
+    client().async_set_viewport_rect(Web::DevicePixelRect({ horizontal_scrollbar().value(), vertical_scrollbar().value() }, available_size()));
     handle_resize();
 }
 
-Gfx::IntRect OutOfProcessWebView::viewport_rect() const
+Web::DevicePixelRect OutOfProcessWebView::viewport_rect() const
 {
-    return visible_content_rect();
+    return visible_content_rect().to_type<Web::DevicePixels>();
 }
 
 Gfx::IntPoint OutOfProcessWebView::to_content_position(Gfx::IntPoint widget_position) const
@@ -210,12 +215,16 @@ void OutOfProcessWebView::theme_change_event(GUI::ThemeChangeEvent& event)
 
 void OutOfProcessWebView::screen_rects_change_event(GUI::ScreenRectsChangeEvent& event)
 {
-    client().async_update_screen_rects(event.rects(), event.main_screen_index());
+    Vector<Web::DevicePixelRect> screen_rects;
+    for (auto const& screen_rect : event.rects()) {
+        screen_rects.append(screen_rect.to_type<Web::DevicePixels>());
+    }
+    client().async_update_screen_rects(screen_rects, event.main_screen_index());
 }
 
 void OutOfProcessWebView::did_scroll()
 {
-    client().async_set_viewport_rect(visible_content_rect());
+    client().async_set_viewport_rect(visible_content_rect().to_type<Web::DevicePixels>());
     request_repaint();
 }
 
@@ -261,12 +270,12 @@ void OutOfProcessWebView::connect_to_webdriver(DeprecatedString const& webdriver
 
 void OutOfProcessWebView::set_window_position(Gfx::IntPoint position)
 {
-    client().async_set_window_position(position);
+    client().async_set_window_position(position.to_type<Web::DevicePixels>());
 }
 
 void OutOfProcessWebView::set_window_size(Gfx::IntSize size)
 {
-    client().async_set_window_size(size);
+    client().async_set_window_size(size.to_type<Web::DevicePixels>());
 }
 
 void OutOfProcessWebView::focusin_event(GUI::FocusEvent&)

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.h
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.h
@@ -81,7 +81,7 @@ private:
     virtual void create_client() override;
     virtual void update_zoom() override;
 
-    virtual Gfx::IntRect viewport_rect() const override;
+    virtual Web::DevicePixelRect viewport_rect() const override;
     virtual Gfx::IntPoint to_content_position(Gfx::IntPoint widget_position) const override;
     virtual Gfx::IntPoint to_widget_position(Gfx::IntPoint content_position) const override;
 

--- a/Userland/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Userland/Libraries/LibWebView/ViewImplementation.cpp
@@ -55,7 +55,7 @@ void ViewImplementation::server_did_paint(Badge<WebContentClient>, i32 bitmap_id
 
     m_client_state.has_usable_bitmap = true;
     m_client_state.back_bitmap.pending_paints--;
-    m_client_state.back_bitmap.last_painted_size = size;
+    m_client_state.back_bitmap.last_painted_size = size.to_type<Web::DevicePixels>();
     swap(m_client_state.back_bitmap, m_client_state.front_bitmap);
 
     // We don't need the backup bitmap anymore, so drop it.
@@ -310,7 +310,7 @@ void ViewImplementation::resize_backing_stores_if_needed(WindowResizeInProgress 
     if (viewport_rect.is_empty())
         return;
 
-    Gfx::IntSize minimum_needed_size;
+    Web::DevicePixelSize minimum_needed_size;
 
     if (window_resize_in_progress == WindowResizeInProgress::Yes) {
         // Pad the minimum needed size so that we don't have to keep reallocating backing stores while the window is being resized.
@@ -323,8 +323,8 @@ void ViewImplementation::resize_backing_stores_if_needed(WindowResizeInProgress 
     }
 
     auto reallocate_backing_store_if_needed = [&](SharedBitmap& backing_store) {
-        if (!backing_store.bitmap || !backing_store.bitmap->size().contains(minimum_needed_size)) {
-            if (auto new_bitmap_or_error = Gfx::Bitmap::create_shareable(Gfx::BitmapFormat::BGRA8888, minimum_needed_size); !new_bitmap_or_error.is_error()) {
+        if (!backing_store.bitmap || !backing_store.bitmap->size().contains(minimum_needed_size.to_type<int>())) {
+            if (auto new_bitmap_or_error = Gfx::Bitmap::create_shareable(Gfx::BitmapFormat::BGRA8888, minimum_needed_size.to_type<int>()); !new_bitmap_or_error.is_error()) {
                 if (backing_store.bitmap)
                     client().async_remove_backing_store(backing_store.id);
 

--- a/Userland/Libraries/LibWebView/ViewImplementation.h
+++ b/Userland/Libraries/LibWebView/ViewImplementation.h
@@ -174,7 +174,7 @@ public:
     Function<void(i32, Gfx::IntPoint, String const&, Optional<String> const&, Optional<Attribute> const&)> on_inspector_requested_dom_tree_context_menu;
     Function<void(String const&)> on_inspector_executed_console_script;
 
-    virtual Gfx::IntRect viewport_rect() const = 0;
+    virtual Web::DevicePixelRect viewport_rect() const = 0;
     virtual Gfx::IntPoint to_content_position(Gfx::IntPoint widget_position) const = 0;
     virtual Gfx::IntPoint to_widget_position(Gfx::IntPoint content_position) const = 0;
 
@@ -205,7 +205,7 @@ protected:
     struct SharedBitmap {
         i32 id { -1 };
         i32 pending_paints { 0 };
-        Gfx::IntSize last_painted_size;
+        Web::DevicePixelSize last_painted_size;
         RefPtr<Gfx::Bitmap> bitmap;
     };
 
@@ -227,7 +227,7 @@ protected:
     RefPtr<Core::Timer> m_backing_store_shrink_timer;
 
     RefPtr<Gfx::Bitmap> m_backup_bitmap;
-    Gfx::IntSize m_backup_bitmap_size;
+    Web::DevicePixelSize m_backup_bitmap_size;
 
     size_t m_crash_count = 0;
     RefPtr<Core::Timer> m_repeated_crash_timer;

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -107,7 +107,7 @@ void ConnectionFromClient::update_system_fonts(DeprecatedString const& default_f
     Gfx::FontDatabase::set_window_title_font_query(window_title_font_query);
 }
 
-void ConnectionFromClient::update_screen_rects(Vector<Gfx::IntRect> const& rects, u32 main_screen)
+void ConnectionFromClient::update_screen_rects(Vector<Web::DevicePixelRect> const& rects, u32 main_screen)
 {
     page().set_screen_rects(rects, main_screen);
 }
@@ -135,10 +135,10 @@ void ConnectionFromClient::load_html(DeprecatedString const& html)
     page().page().load_html(html);
 }
 
-void ConnectionFromClient::set_viewport_rect(Gfx::IntRect const& rect)
+void ConnectionFromClient::set_viewport_rect(Web::DevicePixelRect const& rect)
 {
     dbgln_if(SPAM_DEBUG, "handle: WebContentServer::SetViewportRect: rect={}", rect);
-    page().set_viewport_rect(rect.to_type<Web::DevicePixels>());
+    page().set_viewport_rect(rect);
 }
 
 void ConnectionFromClient::add_backing_store(i32 backing_store_id, Gfx::ShareableBitmap const& bitmap)
@@ -152,7 +152,7 @@ void ConnectionFromClient::remove_backing_store(i32 backing_store_id)
     m_pending_paint_requests.remove_all_matching([backing_store_id](auto& pending_repaint_request) { return pending_repaint_request.bitmap_id == backing_store_id; });
 }
 
-void ConnectionFromClient::paint(Gfx::IntRect const& content_rect, i32 backing_store_id)
+void ConnectionFromClient::paint(Web::DevicePixelRect const& content_rect, i32 backing_store_id)
 {
     for (auto& pending_paint : m_pending_paint_requests) {
         if (pending_paint.bitmap_id == backing_store_id) {
@@ -175,8 +175,8 @@ void ConnectionFromClient::paint(Gfx::IntRect const& content_rect, i32 backing_s
 void ConnectionFromClient::flush_pending_paint_requests()
 {
     for (auto& pending_paint : m_pending_paint_requests) {
-        page().paint(pending_paint.content_rect.to_type<Web::DevicePixels>(), *pending_paint.bitmap);
-        async_did_paint(pending_paint.content_rect, pending_paint.bitmap_id);
+        page().paint(pending_paint.content_rect, *pending_paint.bitmap);
+        async_did_paint(pending_paint.content_rect.to_type<int>(), pending_paint.bitmap_id);
     }
     m_pending_paint_requests.clear();
 }
@@ -981,14 +981,14 @@ void ConnectionFromClient::set_device_pixels_per_css_pixel(float device_pixels_p
     page().set_device_pixels_per_css_pixel(device_pixels_per_css_pixel);
 }
 
-void ConnectionFromClient::set_window_position(Gfx::IntPoint position)
+void ConnectionFromClient::set_window_position(Web::DevicePixelPoint position)
 {
-    page().set_window_position(position.to_type<Web::DevicePixels>());
+    page().set_window_position(position);
 }
 
-void ConnectionFromClient::set_window_size(Gfx::IntSize size)
+void ConnectionFromClient::set_window_size(Web::DevicePixelSize size)
 {
-    page().set_window_size(size.to_type<Web::DevicePixels>());
+    page().set_window_size(size);
 }
 
 Messages::WebContentServer::GetLocalStorageEntriesResponse ConnectionFromClient::get_local_storage_entries()

--- a/Userland/Services/WebContent/ConnectionFromClient.h
+++ b/Userland/Services/WebContent/ConnectionFromClient.h
@@ -55,11 +55,11 @@ private:
     virtual void connect_to_webdriver(DeprecatedString const& webdriver_ipc_path) override;
     virtual void update_system_theme(Core::AnonymousBuffer const&) override;
     virtual void update_system_fonts(DeprecatedString const&, DeprecatedString const&, DeprecatedString const&) override;
-    virtual void update_screen_rects(Vector<Gfx::IntRect> const&, u32) override;
+    virtual void update_screen_rects(Vector<Web::DevicePixelRect> const&, u32) override;
     virtual void load_url(URL const&) override;
     virtual void load_html(DeprecatedString const&) override;
-    virtual void paint(Gfx::IntRect const&, i32) override;
-    virtual void set_viewport_rect(Gfx::IntRect const&) override;
+    virtual void paint(Web::DevicePixelRect const&, i32) override;
+    virtual void set_viewport_rect(Web::DevicePixelRect const&) override;
     virtual void mouse_down(Gfx::IntPoint, Gfx::IntPoint, unsigned, unsigned, unsigned) override;
     virtual void mouse_move(Gfx::IntPoint, Gfx::IntPoint, unsigned, unsigned, unsigned) override;
     virtual void mouse_up(Gfx::IntPoint, Gfx::IntPoint, unsigned, unsigned, unsigned) override;
@@ -97,8 +97,8 @@ private:
     virtual void set_has_focus(bool) override;
     virtual void set_is_scripting_enabled(bool) override;
     virtual void set_device_pixels_per_css_pixel(float) override;
-    virtual void set_window_position(Gfx::IntPoint) override;
-    virtual void set_window_size(Gfx::IntSize) override;
+    virtual void set_window_position(Web::DevicePixelPoint) override;
+    virtual void set_window_size(Web::DevicePixelSize) override;
     virtual void handle_file_return(i32 error, Optional<IPC::File> const& file, i32 request_id) override;
     virtual void set_system_visibility_state(bool visible) override;
 
@@ -138,7 +138,7 @@ private:
 
     NonnullOwnPtr<PageHost> m_page_host;
     struct PaintRequest {
-        Gfx::IntRect content_rect;
+        Web::DevicePixelRect content_rect;
         NonnullRefPtr<Gfx::Bitmap> bitmap;
         i32 bitmap_id { -1 };
     };

--- a/Userland/Services/WebContent/PageClient.h
+++ b/Userland/Services/WebContent/PageClient.h
@@ -33,7 +33,7 @@ public:
 
     void set_palette_impl(Gfx::PaletteImpl&);
     void set_viewport_rect(Web::DevicePixelRect const&);
-    void set_screen_rects(Vector<Gfx::IntRect, 4> const& rects, size_t main_screen_index) { m_screen_rect = rects[main_screen_index].to_type<Web::DevicePixels>(); }
+    void set_screen_rects(Vector<Web::DevicePixelRect, 4> const& rects, size_t main_screen_index) { m_screen_rect = rects[main_screen_index]; }
     void set_device_pixels_per_css_pixel(float device_pixels_per_css_pixel) { m_device_pixels_per_css_pixel = device_pixels_per_css_pixel; }
     void set_preferred_color_scheme(Web::CSS::PreferredColorScheme);
     void set_should_show_line_box_borders(bool b) { m_should_show_line_box_borders = b; }

--- a/Userland/Services/WebContent/WebContentServer.ipc
+++ b/Userland/Services/WebContent/WebContentServer.ipc
@@ -17,7 +17,7 @@ endpoint WebContentServer
 
     update_system_theme(Core::AnonymousBuffer theme_buffer) =|
     update_system_fonts(DeprecatedString default_font_query, DeprecatedString fixed_width_font_query, DeprecatedString window_title_font_query) =|
-    update_screen_rects(Vector<Gfx::IntRect> rects, u32 main_screen_index) =|
+    update_screen_rects(Vector<Web::DevicePixelRect> rects, u32 main_screen_index) =|
 
     load_url(URL url) =|
     load_html(DeprecatedString html) =|
@@ -25,8 +25,8 @@ endpoint WebContentServer
     add_backing_store(i32 backing_store_id, Gfx::ShareableBitmap bitmap) =|
     remove_backing_store(i32 backing_store_id) =|
 
-    paint(Gfx::IntRect content_rect, i32 backing_store_id) =|
-    set_viewport_rect(Gfx::IntRect rect) =|
+    paint(Web::DevicePixelRect content_rect, i32 backing_store_id) =|
+    set_viewport_rect(Web::DevicePixelRect rect) =|
 
     mouse_down(Gfx::IntPoint position, Gfx::IntPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers) =|
     mouse_move(Gfx::IntPoint position, Gfx::IntPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers) =|
@@ -79,8 +79,8 @@ endpoint WebContentServer
     set_is_scripting_enabled(bool is_scripting_enabled) =|
     set_device_pixels_per_css_pixel(float device_pixels_per_css_pixel) =|
 
-    set_window_position(Gfx::IntPoint position) =|
-    set_window_size(Gfx::IntSize size) =|
+    set_window_position(Web::DevicePixelPoint position) =|
+    set_window_size(Web::DevicePixelSize size) =|
 
     get_local_storage_entries() => (OrderedHashMap<String,String> entries)
     get_session_storage_entries() => (OrderedHashMap<String,String> entries)

--- a/Userland/Utilities/headless-browser.cpp
+++ b/Userland/Utilities/headless-browser.cpp
@@ -74,8 +74,8 @@ public:
         view->client().async_update_system_fonts(Gfx::FontDatabase::default_font_query(), Gfx::FontDatabase::fixed_width_font_query(), Gfx::FontDatabase::window_title_font_query());
 
         view->m_viewport_rect = { { 0, 0 }, window_size };
-        view->client().async_set_viewport_rect(view->m_viewport_rect);
-        view->client().async_set_window_size(window_size);
+        view->client().async_set_viewport_rect(view->m_viewport_rect.to_type<Web::DevicePixels>());
+        view->client().async_set_window_size(window_size.to_type<Web::DevicePixels>());
 
         if (!web_driver_ipc_path.is_empty())
             view->client().async_connect_to_webdriver(web_driver_ipc_path);
@@ -114,7 +114,7 @@ private:
     void update_zoom() override { }
     void create_client() override { }
 
-    virtual Gfx::IntRect viewport_rect() const override { return m_viewport_rect; }
+    virtual Web::DevicePixelRect viewport_rect() const override { return m_viewport_rect.to_type<Web::DevicePixels>(); }
     virtual Gfx::IntPoint to_content_position(Gfx::IntPoint widget_position) const override { return widget_position; }
     virtual Gfx::IntPoint to_widget_position(Gfx::IntPoint content_position) const override { return content_position; }
 


### PR DESCRIPTION
This is work towards clarifying the int types in WebContent IPC. Most IPC calls already used DevicePixels from `PageClient.h` into LibWeb I want to extend that to the chrome to make it more explicit if a value contains real pixels (DevicePixels) or scaled pixels (CSSPixels).