### PR TITLE
LibWeb: Implement getBoundingClientRect() for inline paintables

### DIFF
--- a/Tests/LibWeb/Text/expected/get-bounding-client-rect.txt
+++ b/Tests/LibWeb/Text/expected/get-bounding-client-rect.txt
@@ -1,1 +1,2 @@
-   {"x":8,"y":500,"width":784,"height":150,"top":500,"right":792,"bottom":650,"left":8}
+ inline   {"x":8,"y":500,"width":784,"height":150,"top":500,"right":792,"bottom":650,"left":8}
+{"x":8,"y":650,"width":41.296875,"height":17.46875,"top":650,"right":49.296875,"bottom":667.46875,"left":8}

--- a/Tests/LibWeb/Text/input/get-bounding-client-rect.html
+++ b/Tests/LibWeb/Text/input/get-bounding-client-rect.html
@@ -9,10 +9,16 @@
     }
 </style>
 <div id="box"></div>
+<a id="inline">inline</a>
 <script src="include.js"></script>
 <script>
     test(() => {
         const rect = document.getElementById("box").getBoundingClientRect();
+        println(JSON.stringify(rect));
+    });
+
+    test(() => {
+        const rect = document.getElementById("inline").getBoundingClientRect();
         println(JSON.stringify(rect));
     });
 </script>

--- a/Userland/Libraries/LibWeb/Painting/InlinePaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/InlinePaintable.cpp
@@ -173,4 +173,32 @@ void InlinePaintable::for_each_fragment(Callback callback) const
     }
 }
 
+CSSPixelRect InlinePaintable::bounding_rect() const
+{
+    auto top = CSSPixels::max();
+    auto left = CSSPixels::max();
+    auto right = CSSPixels::min();
+    auto bottom = CSSPixels::min();
+    auto has_fragments = false;
+    for_each_fragment([&](auto const& fragment, bool, bool) {
+        has_fragments = true;
+        auto fragment_absolute_rect = fragment.absolute_rect();
+        if (fragment_absolute_rect.top() < top)
+            top = fragment_absolute_rect.top();
+        if (fragment_absolute_rect.left() < left)
+            left = fragment_absolute_rect.left();
+        if (fragment_absolute_rect.right() > right)
+            right = fragment_absolute_rect.right();
+        if (fragment_absolute_rect.bottom() > bottom)
+            bottom = fragment_absolute_rect.bottom();
+    });
+
+    if (!has_fragments) {
+        // FIXME: This is adhoc, and we should return rect of empty fragment instead.
+        auto containing_block_position_in_absolute_coordinates = containing_block()->paintable_box()->absolute_position();
+        return { containing_block_position_in_absolute_coordinates, { 0, 0 } };
+    }
+    return { left, top, right - left, bottom - top };
+}
+
 }

--- a/Userland/Libraries/LibWeb/Painting/InlinePaintable.h
+++ b/Userland/Libraries/LibWeb/Painting/InlinePaintable.h
@@ -22,6 +22,8 @@ public:
     Layout::InlineNode const& layout_node() const;
     auto const& box_model() const { return layout_node().box_model(); }
 
+    CSSPixelRect bounding_rect() const;
+
 private:
     InlinePaintable(Layout::InlineNode const&);
 


### PR DESCRIPTION
This fixes the issue that occurred when, after clicking an inline paintable page would always scroll to the top. The problem was that `scroll_an_element_into_view()` relies on `get_bounding_client_rect()` to produce the correct scroll position and for inline paintables we were always returning zero rect before this change.