### PR TITLE
LibWeb: History pushState/replaceState race crash

### DIFF
--- a/Tests/LibWeb/Text/expected/navigation/history-replace-push-state-race.txt
+++ b/Tests/LibWeb/Text/expected/navigation/history-replace-push-state-race.txt
@@ -1,0 +1,1 @@
+test done!

--- a/Tests/LibWeb/Text/input/navigation/history-replace-push-state-race.html
+++ b/Tests/LibWeb/Text/input/navigation/history-replace-push-state-race.html
@@ -1,0 +1,16 @@
+<script src="../include.js"></script>
+<script>
+    asyncTest(done => {
+
+        history.replaceState({}, "hello", "history-replace-push-state-race.html");
+        history.replaceState({}, "hello", "history-replace-push-state-race.html");
+
+        // this test checks a regression for a crash in `finalize_a_same_document_navigation`
+        // when `target_navigable->get_session_history_entries()` does not contain `entry_to_replace` exactly.
+        //
+        // history.replaceState is one possible trigger for the crash.
+
+        println("test done!");
+        done();
+    });
+</script>

--- a/Userland/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Navigable.cpp
@@ -1877,6 +1877,9 @@ void perform_url_and_history_update_steps(DOM::Document& document, AK::URL new_u
         // 1. Finalize a same-document navigation given traversable, navigable, newEntry, and entryToReplace.
         finalize_a_same_document_navigation(*traversable, *navigable, new_entry, entry_to_replace);
     });
+
+    // FIXME: Implement synchronous session history steps.
+    traversable->process_session_history_traversal_queue();
 }
 
 void Navigable::scroll_offset_did_change()

--- a/Userland/Libraries/LibWeb/HTML/NavigableContainer.cpp
+++ b/Userland/Libraries/LibWeb/HTML/NavigableContainer.cpp
@@ -215,9 +215,6 @@ Optional<AK::URL> NavigableContainer::shared_attribute_processing_steps_for_ifra
     // 4. If url matches about:blank and initialInsertion is true, then perform the URL and history update steps given element's content navigable's active document and url.
     if (url_matches_about_blank(url) && initial_insertion) {
         perform_url_and_history_update_steps(*m_content_navigable->active_document(), url);
-        // NOTE: Not in the spec but we need to make sure that "apply the history step" for initial navigation to about:blank
-        //       is applied before subsequent navigation.
-        navigable()->traversable_navigable()->process_session_history_traversal_queue();
     }
 
     // 5. Return url.


### PR DESCRIPTION
bumped in the same crash as https://github.com/SerenityOS/serenity/issues/21355
```
543/674: VERIFICATION FAILED: i < m_size at /Users/vladimir/workspace/serenity/Meta/Lagom/../../AK/Vector.h:148
0   liblagom-core.0.0.0.dylib           0x00000001016e5c24 ak_verification_failed + 216
1   liblagom-web.0.0.0.dylib            0x0000000102a1eff8 Web::HTML::finalize_a_same_document_navigation(JS::NonnullGCPtr<Web::HTML::TraversableNavigable>, JS::NonnullGCPtr<Web::HTML::Navigable>, JS::NonnullGCPtr<Web::HTML::SessionHistoryEntry>, JS::GCPtr<Web::HTML::SessionHistoryEntry>) + 140
2   liblagom-web.0.0.0.dylib            0x0000000102a1f548 AK::Function<void ()>::CallableWrapper<Web::HTML::SessionHistoryTraversalQueue::SessionHistoryTraversalQueue()::'lambda'()>::call() + 156
3
```

when doing:
open ladybird to the default page, enter "llama.cpp", press "github", observe github search loading and then crashing.  

this solution was suggested here
https://github.com/SerenityOS/serenity/pull/21761#issuecomment-1793327765

added a test, it crashes without the fix and passes with.

also have doubts maybe there are other solutions(but i know very little),  
in the spec they acknowledge race conditions are possible in history handling here,
https://html.spec.whatwg.org/multipage/browsing-the-web.html#finalize-a-same-document-navigation
```
This is used by both [fragment navigations](https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate-fragid) and by the [URL and history update steps](https://html.spec.whatwg.org/multipage/browsing-the-web.html#url-and-history-update-steps), which are the only synchronous updates to session history. By virtue of being synchronous, those algorithms are performed outside of the [top-level traversable](https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-traversable)'s [session history traversal queue](https://html.spec.whatwg.org/multipage/document-sequences.html#tn-session-history-traversal-queue). This puts them out of sync with the [top-level traversable](https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-traversable)'s [current session history step](https://html.spec.whatwg.org/multipage/document-sequences.html#tn-current-session-history-step), so this algorithm is used to resolve conflicts due to race conditions.
```

our code in `finalize_a_same_document_navigation` currently does
```
*(target_entries.find(*entry_to_replace)) = target_entry;
```

briefly checked how servo and chromium are checking/finding history entries, they seem to care about `SessionHistoryEntry` (or analogs) navigation id and url being equal, not the whole struct, so maybe that is something to explore?

but happy if this is merged too,

thank you!