### PR TITLE
LibWeb/Painting: Remove command to paint progress bar

### DIFF
--- a/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorCPU.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorCPU.cpp
@@ -339,14 +339,6 @@ CommandResult PaintingCommandExecutorCPU::draw_signed_distance_field(Gfx::IntRec
     return CommandResult::Continue;
 }
 
-CommandResult PaintingCommandExecutorCPU::paint_progressbar(Gfx::IntRect const& frame_rect, Gfx::IntRect const& progress_rect, Palette const& palette, int min, int max, int value, StringView const& text)
-{
-    auto& painter = this->painter();
-    Gfx::StylePainter::paint_progressbar(painter, progress_rect, palette, min, max, value, text);
-    Gfx::StylePainter::paint_frame(painter, frame_rect, palette, Gfx::FrameStyle::RaisedBox);
-    return CommandResult::Continue;
-}
-
 CommandResult PaintingCommandExecutorCPU::paint_frame(Gfx::IntRect const& rect, Palette const& palette, Gfx::FrameStyle style)
 {
     Gfx::StylePainter::paint_frame(painter(), rect, palette, style);

--- a/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorCPU.h
+++ b/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorCPU.h
@@ -36,7 +36,6 @@ public:
     CommandResult fill_ellipse(Gfx::IntRect const& rect, Color const& color, Gfx::AntiAliasingPainter::BlendMode blend_mode) override;
     CommandResult draw_line(Color const&, Gfx::IntPoint const& from, Gfx::IntPoint const& to, int thickness, Gfx::Painter::LineStyle style, Color const& alternate_color) override;
     CommandResult draw_signed_distance_field(Gfx::IntRect const& rect, Color const&, Gfx::GrayscaleBitmap const& sdf, float smoothing) override;
-    CommandResult paint_progressbar(Gfx::IntRect const& frame_rect, Gfx::IntRect const& progress_rect, Palette const& palette, int min, int max, int value, StringView const& text) override;
     CommandResult paint_frame(Gfx::IntRect const& rect, Palette const&, Gfx::FrameStyle) override;
     CommandResult apply_backdrop_filter(Gfx::IntRect const& backdrop_region, Web::CSS::ResolvedBackdropFilter const& backdrop_filter) override;
     CommandResult draw_rect(Gfx::IntRect const& rect, Color const&, bool rough) override;

--- a/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorGPU.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorGPU.cpp
@@ -257,12 +257,6 @@ CommandResult PaintingCommandExecutorGPU::draw_signed_distance_field(Gfx::IntRec
     return CommandResult::Continue;
 }
 
-CommandResult PaintingCommandExecutorGPU::paint_progressbar(Gfx::IntRect const&, Gfx::IntRect const&, Palette const&, int, int, int, StringView const&)
-{
-    // FIXME
-    return CommandResult::Continue;
-}
-
 CommandResult PaintingCommandExecutorGPU::paint_frame(Gfx::IntRect const&, Palette const&, Gfx::FrameStyle)
 {
     // FIXME

--- a/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorGPU.h
+++ b/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorGPU.h
@@ -37,7 +37,6 @@ public:
     CommandResult fill_ellipse(Gfx::IntRect const& rect, Color const& color, Gfx::AntiAliasingPainter::BlendMode blend_mode) override;
     CommandResult draw_line(Color const&, Gfx::IntPoint const& from, Gfx::IntPoint const& to, int thickness, Gfx::Painter::LineStyle style, Color const& alternate_color) override;
     CommandResult draw_signed_distance_field(Gfx::IntRect const& rect, Color const&, Gfx::GrayscaleBitmap const& sdf, float smoothing) override;
-    CommandResult paint_progressbar(Gfx::IntRect const& frame_rect, Gfx::IntRect const& progress_rect, Palette const& palette, int min, int max, int value, StringView const& text) override;
     CommandResult paint_frame(Gfx::IntRect const& rect, Palette const&, Gfx::FrameStyle) override;
     CommandResult apply_backdrop_filter(Gfx::IntRect const& backdrop_region, Web::CSS::ResolvedBackdropFilter const& backdrop_filter) override;
     CommandResult draw_rect(Gfx::IntRect const& rect, Color const&, bool rough) override;

--- a/Userland/Libraries/LibWeb/Painting/RecordingPainter.cpp
+++ b/Userland/Libraries/LibWeb/Painting/RecordingPainter.cpp
@@ -307,19 +307,6 @@ void RecordingPainter::pop_stacking_context()
     m_state_stack.take_last();
 }
 
-void RecordingPainter::paint_progressbar(Gfx::IntRect frame_rect, Gfx::IntRect progress_rect, Palette palette, int min, int max, int value, StringView text)
-{
-    push_command(PaintProgressbar {
-        .frame_rect = state().translation.map(frame_rect),
-        .progress_rect = state().translation.map(progress_rect),
-        .palette = palette,
-        .min = min,
-        .max = max,
-        .value = value,
-        .text = text,
-    });
-}
-
 void RecordingPainter::paint_frame(Gfx::IntRect rect, Palette palette, Gfx::FrameStyle style)
 {
     push_command(PaintFrame { state().translation.map(rect), palette, style });
@@ -528,9 +515,6 @@ void RecordingPainter::execute(PaintingCommandExecutor& executor)
             },
             [&](DrawSignedDistanceField const& command) {
                 return executor.draw_signed_distance_field(command.rect, command.color, command.sdf, command.smoothing);
-            },
-            [&](PaintProgressbar const& command) {
-                return executor.paint_progressbar(command.frame_rect, command.progress_rect, command.palette, command.min, command.max, command.value, command.text);
             },
             [&](PaintFrame const& command) {
                 return executor.paint_frame(command.rect, command.palette, command.style);

--- a/Userland/Libraries/LibWeb/Painting/RecordingPainter.h
+++ b/Userland/Libraries/LibWeb/Painting/RecordingPainter.h
@@ -237,18 +237,6 @@ struct DrawSignedDistanceField {
     [[nodiscard]] Gfx::IntRect bounding_rect() const { return rect; }
 };
 
-struct PaintProgressbar {
-    Gfx::IntRect frame_rect;
-    Gfx::IntRect progress_rect;
-    Palette palette;
-    int min;
-    int max;
-    int value;
-    StringView text;
-
-    [[nodiscard]] Gfx::IntRect bounding_rect() const { return frame_rect; }
-};
-
 struct PaintFrame {
     Gfx::IntRect rect;
     Palette palette;
@@ -348,7 +336,6 @@ using PaintingCommand = Variant<
     FillEllipse,
     DrawLine,
     DrawSignedDistanceField,
-    PaintProgressbar,
     PaintFrame,
     ApplyBackdropFilter,
     DrawRect,
@@ -386,7 +373,6 @@ public:
     virtual CommandResult fill_ellipse(Gfx::IntRect const&, Color const&, Gfx::AntiAliasingPainter::BlendMode blend_mode) = 0;
     virtual CommandResult draw_line(Color const& color, Gfx::IntPoint const& from, Gfx::IntPoint const& to, int thickness, Gfx::Painter::LineStyle, Color const& alternate_color) = 0;
     virtual CommandResult draw_signed_distance_field(Gfx::IntRect const& rect, Color const&, Gfx::GrayscaleBitmap const&, float smoothing) = 0;
-    virtual CommandResult paint_progressbar(Gfx::IntRect const& frame_rect, Gfx::IntRect const& progress_rect, Palette const& palette, int min, int max, int value, StringView const& text) = 0;
     virtual CommandResult paint_frame(Gfx::IntRect const& rect, Palette const&, Gfx::FrameStyle) = 0;
     virtual CommandResult apply_backdrop_filter(Gfx::IntRect const& backdrop_region, Web::CSS::ResolvedBackdropFilter const& backdrop_filter) = 0;
     virtual CommandResult draw_rect(Gfx::IntRect const& rect, Color const&, bool rough) = 0;
@@ -489,7 +475,6 @@ public:
     void sample_under_corners(u32 id, CornerRadii corner_radii, Gfx::IntRect border_rect, CornerClip corner_clip);
     void blit_corner_clipping(u32 id, Gfx::IntRect border_rect);
 
-    void paint_progressbar(Gfx::IntRect frame_rect, Gfx::IntRect progress_rect, Palette palette, int min, int max, int value, StringView text);
     void paint_frame(Gfx::IntRect rect, Palette palette, Gfx::FrameStyle style);
 
     void apply_backdrop_filter(Gfx::IntRect const& backdrop_region, BorderRadiiData const& border_radii_data, CSS::ResolvedBackdropFilter const& backdrop_filter);


### PR DESCRIPTION
It is no longer used because we started using shadow dom for progress element.