### PR TITLE
Meta: Add RISC-V support to run.py

### DIFF
--- a/Meta/run.py
+++ b/Meta/run.py
@@ -405,8 +405,8 @@ def setup_virtualization_support(config: Configuration):
     if provided_virtualization_enable is not None:
         config.virtualization_support = provided_virtualization_enable == "1"
     else:
-        if (config.kvm_usable and config.architecture != Arch.Aarch64 and os.uname().machine != Arch.Aarch64.value) or (
-            config.qemu_kind == QEMUKind.NativeWindows and config.architecture != Arch.Aarch64
+        if (config.kvm_usable and config.architecture == Arch.x86_64 and os.uname().machine == Arch.x86_64.value) or (
+            config.qemu_kind == QEMUKind.NativeWindows and config.architecture == Arch.x86_64
         ):
             config.virtualization_support = True
 
@@ -459,7 +459,7 @@ def setup_cpu(config: Configuration):
 
 
 def setup_cpu_count(config: Configuration):
-    if config.architecture == Arch.Aarch64:
+    if config.architecture != Arch.x86_64:
         return
 
     provided_cpu_count = environ.get("SERENITY_CPUS")

--- a/Meta/run.py
+++ b/Meta/run.py
@@ -694,6 +694,11 @@ def setup_kernel(config: Configuration):
 def setup_machine_devices(config: Configuration):
     # TODO: Maybe disable SPICE everwhere except the default machine?
 
+    if config.qemu_kind != QEMUKind.NativeWindows:
+        config.extra_arguments.extend(["-qmp", "unix:qmp-sock,server,nowait"])
+
+    config.extra_arguments.extend(["-name", "SerenityOS", "-d", "guest_errors"])
+
     # Architecture specifics.
     if config.architecture == Arch.Aarch64:
         config.qemu_machine = "raspi3b"
@@ -803,11 +808,6 @@ def setup_machine_devices(config: Configuration):
             config.network_default_device = f"{config.ethernet_device_type},netdev=br0"
         case MachineType.QEMUGrub | MachineType.QEMUExtLinux:
             config.kernel_cmdline = []
-
-    if config.qemu_kind != QEMUKind.NativeWindows:
-        config.extra_arguments.extend(["-qmp", "unix:qmp-sock,server,nowait"])
-
-    config.extra_arguments.extend(["-name", "SerenityOS", "-d", "guest_errors"])
 
 
 def assemble_arguments(config: Configuration) -> list[str | Path]:


### PR DESCRIPTION
This PR adds initial support for RISC-V in run.py, so `serenity.sh run riscv64` should work now!

Note: The current `Processor::halt` placeholder in `pre_init` seems to cause an an absolute jump when using GCC, so you will get a lot of `Invalid read at addr 0x2000211C98, size 2, region '(null)', reason: rejected` when using the gnu toolchain.

I am not entirely happy how architectures are handled in run.py, but this should be good enough for now (we can always refactor later!)