### PR TITLE
LibLine: Use grapheme clusters for cursor management / tiny boog fix

### DIFF
--- a/Userland/Libraries/LibLine/CMakeLists.txt
+++ b/Userland/Libraries/LibLine/CMakeLists.txt
@@ -7,4 +7,4 @@ set(SOURCES
 )
 
 serenity_lib(LibLine line)
-target_link_libraries(LibLine PRIVATE LibCore)
+target_link_libraries(LibLine PRIVATE LibCore LibUnicode)

--- a/Userland/Libraries/LibLine/Editor.cpp
+++ b/Userland/Libraries/LibLine/Editor.cpp
@@ -384,7 +384,7 @@ void Editor::insert(StringView string_view)
         insert(ch);
 }
 
-void Editor::insert(const u32 cp)
+void Editor::insert(u32 const cp)
 {
     StringBuilder builder;
     builder.append(Utf32View(&cp, 1));
@@ -842,7 +842,7 @@ ErrorOr<void> Editor::handle_read_event()
 
     auto prohibit_scope = prohibit_input();
 
-    char keybuf[16];
+    char keybuf[1024];
     ssize_t nread = 0;
 
     if (!m_incomplete_data.size())
@@ -1235,10 +1235,11 @@ ErrorOr<void> Editor::handle_read_event()
         insert(code_point);
     }
 
-    if (consumed_code_points == m_incomplete_data.size()) {
+    if (consumed_code_points == valid_bytes) {
         m_incomplete_data.clear();
     } else {
-        for (size_t i = 0; i < consumed_code_points; ++i)
+        auto bytes_to_drop = input_view.byte_offset_of(consumed_code_points + 1);
+        for (size_t i = 0; i < bytes_to_drop; ++i)
             m_incomplete_data.take_first();
     }
 

--- a/Userland/Libraries/LibLine/Editor.h
+++ b/Userland/Libraries/LibLine/Editor.h
@@ -161,7 +161,7 @@ public:
     void register_key_input_callback(Key key, Function<bool(Editor&)> callback) { register_key_input_callback(Vector<Key> { key }, move(callback)); }
 
     static StringMetrics actual_rendered_string_metrics(StringView, RedBlackTree<u32, Optional<Style::Mask>> const& masks = {}, Optional<size_t> maximum_line_width = {});
-    static StringMetrics actual_rendered_string_metrics(Utf32View const&, RedBlackTree<u32, Optional<Style::Mask>> const& masks = {});
+    static StringMetrics actual_rendered_string_metrics(Utf32View const&, RedBlackTree<u32, Optional<Style::Mask>> const& masks = {}, Optional<size_t> maximum_line_width = {});
 
     Function<Vector<CompletionSuggestion>(Editor const&)> on_tab_complete;
     Function<void(Utf32View, Editor&)> on_paste;

--- a/Userland/Libraries/LibLine/StringMetrics.h
+++ b/Userland/Libraries/LibLine/StringMetrics.h
@@ -27,6 +27,7 @@ struct StringMetrics {
     };
 
     Vector<LineMetrics> line_metrics;
+    Vector<size_t> grapheme_breaks {};
     size_t total_length { 0 };
     size_t max_line_length { 0 };
 


### PR DESCRIPTION
This makes using the line editor much nicer when multi-code-point graphemes are present in the input (e.g. flag emojis, or some cjk glyphs), and avoids messing up the buffer when deleting text, or cursoring around.

Note that serenity's terminal seems to not like multi-code-point emojis (see #22297),  so the utility of this change is limited until that issue is fixed.