### PR TITLE
LibWeb: Let Document have a direct GCPtr to its containing Web::Page

### DIFF
--- a/Tests/LibWeb/Text/expected/HTML/img-src-in-innerHTML-crash.txt
+++ b/Tests/LibWeb/Text/expected/HTML/img-src-in-innerHTML-crash.txt
@@ -1,0 +1,2 @@
+PASS! (Didn't crash)
+data:text/png,

--- a/Tests/LibWeb/Text/input/HTML/img-src-in-innerHTML-crash.html
+++ b/Tests/LibWeb/Text/input/HTML/img-src-in-innerHTML-crash.html
@@ -1,0 +1,9 @@
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        let e = document.createElement("div");
+        e.innerHTML = "<img src='data:text/png,'>";
+        println("PASS! (Didn't crash)");
+        println(e.firstChild.src);
+    });
+</script>

--- a/Userland/Libraries/LibWeb/Bindings/HostDefined.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/HostDefined.cpp
@@ -9,6 +9,7 @@
 #include <LibWeb/Bindings/HostDefined.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/Scripting/Environments.h>
+#include <LibWeb/Page/Page.h>
 
 namespace Web::Bindings {
 
@@ -17,6 +18,7 @@ void HostDefined::visit_edges(JS::Cell::Visitor& visitor)
     JS::Realm::HostDefined::visit_edges(visitor);
     visitor.visit(environment_settings_object);
     visitor.visit(intrinsics);
+    visitor.visit(page);
 }
 
 }

--- a/Userland/Libraries/LibWeb/Bindings/HostDefined.h
+++ b/Userland/Libraries/LibWeb/Bindings/HostDefined.h
@@ -14,9 +14,10 @@
 namespace Web::Bindings {
 
 struct HostDefined : public JS::Realm::HostDefined {
-    HostDefined(JS::NonnullGCPtr<HTML::EnvironmentSettingsObject> eso, JS::NonnullGCPtr<Intrinsics> intrinsics)
+    HostDefined(JS::NonnullGCPtr<HTML::EnvironmentSettingsObject> eso, JS::NonnullGCPtr<Intrinsics> intrinsics, JS::NonnullGCPtr<Page> page)
         : environment_settings_object(eso)
         , intrinsics(intrinsics)
+        , page(page)
     {
     }
     virtual ~HostDefined() override = default;
@@ -24,11 +25,17 @@ struct HostDefined : public JS::Realm::HostDefined {
 
     JS::NonnullGCPtr<HTML::EnvironmentSettingsObject> environment_settings_object;
     JS::NonnullGCPtr<Intrinsics> intrinsics;
+    JS::NonnullGCPtr<Page> page;
 };
 
 [[nodiscard]] inline HTML::EnvironmentSettingsObject& host_defined_environment_settings_object(JS::Realm& realm)
 {
     return *verify_cast<HostDefined>(realm.host_defined())->environment_settings_object;
+}
+
+[[nodiscard]] inline Page& host_defined_page(JS::Realm& realm)
+{
+    return *verify_cast<HostDefined>(realm.host_defined())->page;
 }
 
 }

--- a/Userland/Libraries/LibWeb/CSS/CSSImportRule.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSImportRule.cpp
@@ -33,7 +33,7 @@ CSSImportRule::CSSImportRule(AK::URL url, DOM::Document& document)
     , m_document(document)
 {
     dbgln_if(CSS_LOADER_DEBUG, "CSSImportRule: Loading import URL: {}", m_url);
-    auto request = LoadRequest::create_for_url_on_page(m_url, document.page());
+    auto request = LoadRequest::create_for_url_on_page(m_url, &document.page());
 
     // NOTE: Mark this rule as delaying the document load event *before* calling set_resource()
     //       as it may trigger a synchronous resource_did_load() callback.

--- a/Userland/Libraries/LibWeb/CSS/MediaQuery.cpp
+++ b/Userland/Libraries/LibWeb/CSS/MediaQuery.cpp
@@ -165,7 +165,7 @@ bool MediaFeature::compare(HTML::Window const& window, MediaFeatureValue left, C
             left_px = left.length().absolute_length_to_px();
             right_px = right.length().absolute_length_to_px();
         } else {
-            auto viewport_rect = window.page()->web_exposed_screen_area();
+            auto viewport_rect = window.page().web_exposed_screen_area();
 
             auto const& initial_font = window.associated_document().style_computer().initial_font();
             Gfx::FontPixelMetrics const& initial_font_metrics = initial_font.pixel_metrics();

--- a/Userland/Libraries/LibWeb/CSS/Screen.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Screen.cpp
@@ -40,7 +40,7 @@ void Screen::visit_edges(Cell::Visitor& visitor)
 
 Gfx::IntRect Screen::screen_rect() const
 {
-    auto screen_rect_in_css_pixels = window().page()->web_exposed_screen_area();
+    auto screen_rect_in_css_pixels = window().page().web_exposed_screen_area();
     return {
         screen_rect_in_css_pixels.x().to_int(),
         screen_rect_in_css_pixels.y().to_int(),

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -2334,11 +2334,8 @@ NonnullOwnPtr<StyleComputer::RuleCache> StyleComputer::make_rule_cache_for_casca
 
 void StyleComputer::build_rule_cache()
 {
-    // FIXME: How are we sometimes calculating style before the Document has a Page?
-    if (document().page()) {
-        if (auto user_style_source = document().page()->user_style(); user_style_source.has_value()) {
-            m_user_style_sheet = JS::make_handle(parse_css_stylesheet(CSS::Parser::ParsingContext(document()), user_style_source.value()));
-        }
+    if (auto user_style_source = document().page().user_style(); user_style_source.has_value()) {
+        m_user_style_sheet = JS::make_handle(parse_css_stylesheet(CSS::Parser::ParsingContext(document()), user_style_source.value()));
     }
 
     m_author_rule_cache = make_rule_cache_for_cascade_origin(CascadeOrigin::Author);

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/IdentifierStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/IdentifierStyleValue.cpp
@@ -217,10 +217,7 @@ Color IdentifierStyleValue::to_color(Optional<Layout::NodeWithStyle const&> node
     if (id() == CSS::ValueID::LibwebLink || id() == ValueID::Linktext)
         return document.link_color();
 
-    if (!document.page())
-        return {};
-
-    auto palette = document.page()->palette();
+    auto palette = document.page().palette();
     switch (id()) {
     case CSS::ValueID::LibwebPaletteDesktopBackground:
         return palette.color(ColorRole::DesktopBackground);

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.cpp
@@ -32,7 +32,7 @@ void ImageStyleValue::load_any_resources(DOM::Document& document)
         return;
     m_document = &document;
 
-    m_image_request = HTML::SharedImageRequest::get_or_create(document.realm(), *document.page(), m_url);
+    m_image_request = HTML::SharedImageRequest::get_or_create(document.realm(), document.page(), m_url);
     m_image_request->add_callbacks(
         [this, weak_this = make_weak_ptr()] {
             if (!weak_this)

--- a/Userland/Libraries/LibWeb/Clipboard/Clipboard.cpp
+++ b/Userland/Libraries/LibWeb/Clipboard/Clipboard.cpp
@@ -113,8 +113,7 @@ static void write_blobs_and_option_to_clipboard(JS::Realm& realm, ReadonlySpan<J
         auto payload = MUST(TextCodec::convert_input_to_utf8_using_given_decoder_unless_there_is_a_byte_order_mark(*decoder, item->bytes()));
 
         // 4. Insert payload and presentationStyle into the system clipboard using formatString as the native clipboard format.
-        if (auto* page = window.page())
-            page->client().page_did_insert_clipboard_entry(move(payload), move(presentation_style), move(format_string));
+        window.page().client().page_did_insert_clipboard_entry(move(payload), move(presentation_style), move(format_string));
     }
 
     // FIXME: 3. Write web custom formats given webCustomFormats.

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -236,6 +236,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Document>> Document::create_and_initialize(
         // FIXME: Why do we assume `creation_url` is non-empty here? Is this a spec bug?
         // FIXME: Why do we assume `top_level_creation_url` is non-empty here? Is this a spec bug?
         HTML::WindowEnvironmentSettingsObject::setup(
+            browsing_context->page(),
             creation_url.value(),
             move(realm_execution_context),
             navigation_params.reserved_environment.visit(
@@ -321,6 +322,7 @@ JS::NonnullGCPtr<Document> Document::create(JS::Realm& realm, AK::URL const& url
 
 Document::Document(JS::Realm& realm, const AK::URL& url)
     : ParentNode(realm, *this, NodeType::DOCUMENT_NODE)
+    , m_page(Bindings::host_defined_page(realm))
     , m_style_computer(make<CSS::StyleComputer>(*this))
     , m_url(url)
 {
@@ -353,6 +355,7 @@ void Document::initialize(JS::Realm& realm)
 void Document::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
+    visitor.visit(m_page);
     visitor.visit(m_window);
     visitor.visit(m_layout_root);
     visitor.visit(m_style_sheets);
@@ -1908,12 +1911,12 @@ void Document::update_readiness(HTML::DocumentReadyState readiness_value)
 
 Page* Document::page()
 {
-    return m_browsing_context ? &m_browsing_context->page() : nullptr;
+    return m_page;
 }
 
 Page const* Document::page() const
 {
-    return m_browsing_context ? &m_browsing_context->page() : nullptr;
+    return m_page;
 }
 
 EventTarget* Document::get_parent(Event const& event)

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -181,8 +181,8 @@ public:
 
     void set_browsing_context(HTML::BrowsingContext*);
 
-    Page* page();
-    Page const* page() const;
+    Page& page();
+    Page const& page() const;
 
     Color background_color() const;
     Vector<CSS::BackgroundLayerData> const* background_layers() const;

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -572,6 +572,7 @@ private:
 
     Element* find_a_potential_indicated_element(FlyString const& fragment) const;
 
+    JS::NonnullGCPtr<Page> m_page;
     OwnPtr<CSS::StyleComputer> m_style_computer;
     JS::GCPtr<CSS::StyleSheetList> m_style_sheets;
     JS::GCPtr<Node> m_hovered_node;

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -1188,22 +1188,16 @@ void Element::set_scroll_left(double x)
     // 8. If the element is the root element invoke scroll() on window with x as first argument and scrollY on window as second argument, and terminate these steps.
     if (document.document_element() == this) {
         // FIXME: Implement this in terms of invoking scroll() on window.
-        if (auto* page = document.page()) {
-            if (document.browsing_context() == &page->top_level_browsing_context())
-                page->client().page_did_request_scroll_to({ static_cast<float>(x), static_cast<float>(window->scroll_y()) });
-        }
-
+        if (document.browsing_context() == &document.page().top_level_browsing_context())
+            document.page().client().page_did_request_scroll_to({ static_cast<float>(x), static_cast<float>(window->scroll_y()) });
         return;
     }
 
     // 9. If the element is the body element, document is in quirks mode, and the element is not potentially scrollable, invoke scroll() on window with x as first argument and scrollY on window as second argument, and terminate these steps.
     if (document.body() == this && document.in_quirks_mode() && !is_potentially_scrollable()) {
         // FIXME: Implement this in terms of invoking scroll() on window.
-        if (auto* page = document.page()) {
-            if (document.browsing_context() == &page->top_level_browsing_context())
-                page->client().page_did_request_scroll_to({ static_cast<float>(x), static_cast<float>(window->scroll_y()) });
-        }
-
+        if (document.browsing_context() == &document.page().top_level_browsing_context())
+            document.page().client().page_did_request_scroll_to({ static_cast<float>(x), static_cast<float>(window->scroll_y()) });
         return;
     }
 
@@ -1256,22 +1250,16 @@ void Element::set_scroll_top(double y)
     // 8. If the element is the root element invoke scroll() on window with scrollX on window as first argument and y as second argument, and terminate these steps.
     if (document.document_element() == this) {
         // FIXME: Implement this in terms of invoking scroll() on window.
-        if (auto* page = document.page()) {
-            if (document.browsing_context() == &page->top_level_browsing_context())
-                page->client().page_did_request_scroll_to({ static_cast<float>(window->scroll_x()), static_cast<float>(y) });
-        }
-
+        if (document.browsing_context() == &document.page().top_level_browsing_context())
+            document.page().client().page_did_request_scroll_to({ static_cast<float>(window->scroll_x()), static_cast<float>(y) });
         return;
     }
 
     // 9. If the element is the body element, document is in quirks mode, and the element is not potentially scrollable, invoke scroll() on window with scrollX as first argument and y as second argument, and terminate these steps.
     if (document.body() == this && document.in_quirks_mode() && !is_potentially_scrollable()) {
         // FIXME: Implement this in terms of invoking scroll() on window.
-        if (auto* page = document.page()) {
-            if (document.browsing_context() == &page->top_level_browsing_context())
-                page->client().page_did_request_scroll_to({ static_cast<float>(window->scroll_x()), static_cast<float>(y) });
-        }
-
+        if (document.browsing_context() == &document.page().top_level_browsing_context())
+            document.page().client().page_did_request_scroll_to({ static_cast<float>(window->scroll_x()), static_cast<float>(y) });
         return;
     }
 

--- a/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
@@ -1722,19 +1722,13 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<PendingResponse>> nonstandard_resource_load
 
     auto request = fetch_params.request();
 
-    Page* page = nullptr;
-    auto& global_object = realm.global_object();
-    if (is<HTML::Window>(global_object))
-        page = static_cast<HTML::Window&>(global_object).page();
-    else if (is<HTML::WorkerGlobalScope>(global_object))
-        page = static_cast<HTML::WorkerGlobalScope&>(global_object).page();
+    auto& page = Bindings::host_defined_page(realm);
 
     // NOTE: Using LoadRequest::create_for_url_on_page here will unconditionally add cookies as long as there's a page available.
     //       However, it is up to http_network_or_cache_fetch to determine if cookies should be added to the request.
     LoadRequest load_request;
     load_request.set_url(request->current_url());
-    if (page)
-        load_request.set_page(*page);
+    load_request.set_page(page);
     load_request.set_method(DeprecatedString::copy(request->method()));
     for (auto const& header : *request->header_list())
         load_request.set_header(DeprecatedString::copy(header.name), DeprecatedString::copy(header.value));

--- a/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
@@ -1425,10 +1425,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<PendingResponse>> http_network_or_cache_fet
                     auto document = Bindings::host_defined_environment_settings_object(realm).responsible_document();
                     if (!document)
                         return DeprecatedString::empty();
-                    auto* page = document->page();
-                    if (!page)
-                        return DeprecatedString::empty();
-                    return page->client().page_did_request_cookie(http_request->current_url(), Cookie::Source::Http);
+                    return document->page().client().page_did_request_cookie(http_request->current_url(), Cookie::Source::Http);
                 })();
 
                 // 2. If cookies is not the empty string, then append (`Cookie`, cookies) to httpRequest’s header list.

--- a/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
@@ -175,6 +175,7 @@ WebIDL::ExceptionOr<BrowsingContext::BrowsingContextAndDocument> BrowsingContext
 
     // 12. Set up a window environment settings object with about:blank, realm execution context, null, topLevelCreationURL, and topLevelOrigin.
     WindowEnvironmentSettingsObject::setup(
+        page,
         AK::URL("about:blank"),
         move(realm_execution_context),
         {},

--- a/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -57,7 +57,7 @@ void HTMLImageElement::initialize(JS::Realm& realm)
     Base::initialize(realm);
     set_prototype(&Bindings::ensure_web_prototype<Bindings::HTMLImageElementPrototype>(realm, "HTMLImageElement"_fly_string));
 
-    m_current_request = ImageRequest::create(realm, *document().page());
+    m_current_request = ImageRequest::create(realm, document().page());
 }
 
 void HTMLImageElement::adopted_from(DOM::Document& old_document)
@@ -385,7 +385,7 @@ ErrorOr<void> HTMLImageElement::update_the_image_data(bool restart_animations, b
             m_pending_request = nullptr;
 
             // 4. Let current request be a new image request whose image data is that of the entry and whose state is completely available.
-            m_current_request = ImageRequest::create(realm(), *document().page());
+            m_current_request = ImageRequest::create(realm(), document().page());
             m_current_request->set_image_data(entry->image_data);
             m_current_request->set_state(ImageRequest::State::CompletelyAvailable);
 
@@ -512,7 +512,7 @@ after_step_7:
         //         multiple image elements (as well as CSS background-images, etc.)
 
         // 16. Set image request to a new image request whose current URL is urlString.
-        auto image_request = ImageRequest::create(realm(), *document().page());
+        auto image_request = ImageRequest::create(realm(), document().page());
         image_request->set_current_url(realm(), url_string);
 
         // 17. If current request's state is unavailable or broken, then set the current request to image request.
@@ -707,7 +707,7 @@ void HTMLImageElement::react_to_changes_in_the_environment()
         key.origin = document().origin();
 
     // 11. ⌛ Let image request be a new image request whose current URL is urlString
-    auto image_request = ImageRequest::create(realm(), *document().page());
+    auto image_request = ImageRequest::create(realm(), document().page());
     image_request->set_current_url(realm(), url_string);
 
     // 12. ⌛ Let the element's pending request be image request.

--- a/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
@@ -70,7 +70,7 @@ void HTMLLinkElement::inserted()
         ResourceLoader::the().preconnect(document().parse_url(deprecated_attribute(HTML::AttributeNames::href)));
     } else if (m_relationship & Relationship::Icon) {
         auto favicon_url = document().parse_url(href());
-        auto favicon_request = LoadRequest::create_for_url_on_page(favicon_url, document().page());
+        auto favicon_request = LoadRequest::create_for_url_on_page(favicon_url, &document().page());
         set_resource(ResourceLoader::the().load_resource(Resource::Type::Generic, favicon_request));
     }
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLMetaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMetaElement.cpp
@@ -57,9 +57,6 @@ void HTMLMetaElement::inserted()
     auto name = attribute(AttributeNames::name);
     auto content = attribute(AttributeNames::content);
     if (name.has_value() && name->bytes_as_string_view().equals_ignoring_ascii_case("theme-color"sv) && content.has_value()) {
-        auto* page = document().page();
-        if (!page)
-            return;
         auto context = CSS::Parser::ParsingContext { document() };
 
         // 2. For each element in candidate elements:
@@ -82,7 +79,7 @@ void HTMLMetaElement::inserted()
         auto color = css_value->as_color().color();
 
         // 4. If color is not failure, then return color.
-        page->client().page_did_change_theme_color(color);
+        document().page().client().page_did_change_theme_color(color);
         return;
     }
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLObjectElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLObjectElement.cpp
@@ -138,7 +138,7 @@ void HTMLObjectElement::queue_element_task_to_run_object_representation_steps()
             }
 
             // 4. Let request be a new request whose URL is the resulting URL record, client is the element's node document's relevant settings object, destination is "object", credentials mode is "include", mode is "navigate", and whose use-URL-credentials flag is set.
-            auto request = LoadRequest::create_for_url_on_page(url, document().page());
+            auto request = LoadRequest::create_for_url_on_page(url, &document().page());
 
             // 5. Fetch request, with processResponseEndOfBody given response res set to finalize and report timing with res, the element's node document's relevant global object, and "object".
             //    Fetching the resource must delay the load event of the element's node document until the task that is queued by the networking task source once the resource has been fetched (defined next) has been run.
@@ -316,7 +316,7 @@ void HTMLObjectElement::load_image()
     // NOTE: This currently reloads the image instead of reusing the resource we've already downloaded.
     auto data = deprecated_attribute(HTML::AttributeNames::data);
     auto url = document().parse_url(data);
-    m_image_request = HTML::SharedImageRequest::get_or_create(realm(), *document().page(), url);
+    m_image_request = HTML::SharedImageRequest::get_or_create(realm(), document().page(), url);
     m_image_request->add_callbacks(
         [this] {
             run_object_representation_completed_steps(Representation::Image);

--- a/Userland/Libraries/LibWeb/HTML/MimeTypeArray.cpp
+++ b/Userland/Libraries/LibWeb/HTML/MimeTypeArray.cpp
@@ -32,8 +32,7 @@ Vector<String> MimeTypeArray::supported_property_names() const
 {
     // The MimeTypeArray interface supports named properties. If the user agent's PDF viewer supported is true, then they are the PDF viewer mime types. Otherwise, they are the empty list.
     auto const& window = verify_cast<HTML::Window>(HTML::relevant_global_object(*this));
-    VERIFY(window.page());
-    if (!window.page()->pdf_viewer_supported())
+    if (!window.page().pdf_viewer_supported())
         return {};
 
     // https://html.spec.whatwg.org/multipage/system-state.html#pdf-viewer-mime-types

--- a/Userland/Libraries/LibWeb/HTML/NavigableContainer.cpp
+++ b/Userland/Libraries/LibWeb/HTML/NavigableContainer.cpp
@@ -69,9 +69,8 @@ WebIDL::ExceptionOr<void> NavigableContainer::create_new_child_navigable()
     VERIFY(group);
 
     // 3. Let browsingContext and document be the result of creating a new browsing context and document given element's node document, element, and group.
-    auto* page = document().page();
-    VERIFY(page);
-    auto [browsing_context, document] = TRY(BrowsingContext::create_a_new_browsing_context_and_document(*page, this->document(), *this, *group));
+    auto& page = document().page();
+    auto [browsing_context, document] = TRY(BrowsingContext::create_a_new_browsing_context_and_document(page, this->document(), *this, *group));
 
     // 4. Let targetName be null.
     Optional<String> target_name;

--- a/Userland/Libraries/LibWeb/HTML/Navigator.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Navigator.cpp
@@ -42,7 +42,7 @@ bool Navigator::pdf_viewer_enabled() const
     // The NavigatorPlugins mixin's pdfViewerEnabled getter steps are to return the user agent's PDF viewer supported.
     // NOTE: The NavigatorPlugins mixin should only be exposed on the Window object.
     auto const& window = verify_cast<HTML::Window>(HTML::current_global_object());
-    return window.page()->pdf_viewer_supported();
+    return window.page().pdf_viewer_supported();
 }
 
 // https://w3c.github.io/webdriver/#dfn-webdriver
@@ -52,7 +52,7 @@ bool Navigator::webdriver() const
 
     // NOTE: The NavigatorAutomationInformation interface should not be exposed on WorkerNavigator.
     auto const& window = verify_cast<HTML::Window>(HTML::current_global_object());
-    return window.page()->is_webdriver_active();
+    return window.page().is_webdriver_active();
 }
 
 void Navigator::visit_edges(Cell::Visitor& visitor)

--- a/Userland/Libraries/LibWeb/HTML/Plugin.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Plugin.cpp
@@ -56,8 +56,7 @@ Vector<String> Plugin::supported_property_names() const
 {
     // The Plugin interface supports named properties. If the user agent's PDF viewer supported is true, then they are the PDF viewer mime types. Otherwise, they are the empty list.
     auto const& window = verify_cast<HTML::Window>(HTML::relevant_global_object(*this));
-    VERIFY(window.page());
-    if (!window.page()->pdf_viewer_supported())
+    if (!window.page().pdf_viewer_supported())
         return {};
 
     // https://html.spec.whatwg.org/multipage/system-state.html#pdf-viewer-mime-types

--- a/Userland/Libraries/LibWeb/HTML/PluginArray.cpp
+++ b/Userland/Libraries/LibWeb/HTML/PluginArray.cpp
@@ -38,8 +38,7 @@ Vector<String> PluginArray::supported_property_names() const
 {
     // The PluginArray interface supports named properties. If the user agent's PDF viewer supported is true, then they are the PDF viewer plugin names. Otherwise, they are the empty list.
     auto const& window = verify_cast<HTML::Window>(HTML::relevant_global_object(*this));
-    VERIFY(window.page());
-    if (!window.page()->pdf_viewer_supported())
+    if (!window.page().pdf_viewer_supported())
         return {};
 
     // https://html.spec.whatwg.org/multipage/system-state.html#pdf-viewer-plugin-names

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Environments.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Environments.cpp
@@ -292,7 +292,7 @@ bool EnvironmentSettingsObject::is_scripting_enabled() const
     // The user has not disabled scripting for settings at this time. (User agents may provide users with the option to disable scripting globally, or in a finer-grained manner, e.g., on a per-origin basis, down to the level of individual environment settings objects.)
     auto document = const_cast<EnvironmentSettingsObject&>(*this).responsible_document();
     VERIFY(document);
-    if (!document->page() || !document->page()->is_scripting_enabled())
+    if (!document->page().is_scripting_enabled())
         return false;
 
     // FIXME: Either settings's global object is not a Window object, or settings's global object's associated Document's active sandboxing flag set does not have its sandboxed scripts browsing context flag set.

--- a/Userland/Libraries/LibWeb/HTML/Scripting/WindowEnvironmentSettingsObject.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/WindowEnvironmentSettingsObject.cpp
@@ -29,7 +29,7 @@ void WindowEnvironmentSettingsObject::visit_edges(JS::Cell::Visitor& visitor)
 }
 
 // https://html.spec.whatwg.org/multipage/window-object.html#set-up-a-window-environment-settings-object
-void WindowEnvironmentSettingsObject::setup(AK::URL const& creation_url, NonnullOwnPtr<JS::ExecutionContext> execution_context, Optional<Environment> reserved_environment, AK::URL top_level_creation_url, Origin top_level_origin)
+void WindowEnvironmentSettingsObject::setup(Page& page, AK::URL const& creation_url, NonnullOwnPtr<JS::ExecutionContext> execution_context, Optional<Environment> reserved_environment, AK::URL top_level_creation_url, Origin top_level_origin)
 {
     // 1. Let realm be the value of execution context's Realm component.
     auto realm = execution_context->realm;
@@ -74,7 +74,7 @@ void WindowEnvironmentSettingsObject::setup(AK::URL const& creation_url, Nonnull
     // 7. Set realm's [[HostDefined]] field to settings object.
     // Non-Standard: We store the ESO next to the web intrinsics in a custom HostDefined object
     auto intrinsics = realm->heap().allocate<Bindings::Intrinsics>(*realm, *realm);
-    auto host_defined = make<Bindings::HostDefined>(settings_object, intrinsics);
+    auto host_defined = make<Bindings::HostDefined>(settings_object, intrinsics, page);
     realm->set_host_defined(move(host_defined));
 
     // Non-Standard: We cannot fully initialize window object until *after* the we set up

--- a/Userland/Libraries/LibWeb/HTML/Scripting/WindowEnvironmentSettingsObject.h
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/WindowEnvironmentSettingsObject.h
@@ -16,7 +16,7 @@ class WindowEnvironmentSettingsObject final : public EnvironmentSettingsObject {
     JS_DECLARE_ALLOCATOR(WindowEnvironmentSettingsObject);
 
 public:
-    static void setup(AK::URL const& creation_url, NonnullOwnPtr<JS::ExecutionContext>, Optional<Environment>, AK::URL top_level_creation_url, Origin top_level_origin);
+    static void setup(Page&, AK::URL const& creation_url, NonnullOwnPtr<JS::ExecutionContext>, Optional<Environment>, AK::URL top_level_creation_url, Origin top_level_origin);
 
     virtual ~WindowEnvironmentSettingsObject() override;
 

--- a/Userland/Libraries/LibWeb/HTML/Scripting/WorkerEnvironmentSettingsObject.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/WorkerEnvironmentSettingsObject.cpp
@@ -11,7 +11,7 @@ namespace Web::HTML {
 
 JS_DEFINE_ALLOCATOR(WorkerEnvironmentSettingsObject);
 
-JS::NonnullGCPtr<WorkerEnvironmentSettingsObject> WorkerEnvironmentSettingsObject::setup(NonnullOwnPtr<JS::ExecutionContext> execution_context /* FIXME: null or an environment reservedEnvironment, a URL topLevelCreationURL, and an origin topLevelOrigin */)
+JS::NonnullGCPtr<WorkerEnvironmentSettingsObject> WorkerEnvironmentSettingsObject::setup(JS::NonnullGCPtr<Page> page, NonnullOwnPtr<JS::ExecutionContext> execution_context /* FIXME: null or an environment reservedEnvironment, a URL topLevelCreationURL, and an origin topLevelOrigin */)
 {
     auto realm = execution_context->realm;
     VERIFY(realm);
@@ -22,7 +22,7 @@ JS::NonnullGCPtr<WorkerEnvironmentSettingsObject> WorkerEnvironmentSettingsObjec
     settings_object->target_browsing_context = nullptr;
 
     auto intrinsics = realm->heap().allocate<Bindings::Intrinsics>(*realm, *realm);
-    auto host_defined = make<Bindings::HostDefined>(settings_object, intrinsics);
+    auto host_defined = make<Bindings::HostDefined>(settings_object, intrinsics, page);
     realm->set_host_defined(move(host_defined));
 
     // Non-Standard: We cannot fully initialize worker object until *after* the we set up

--- a/Userland/Libraries/LibWeb/HTML/Scripting/WorkerEnvironmentSettingsObject.h
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/WorkerEnvironmentSettingsObject.h
@@ -24,7 +24,7 @@ public:
     {
     }
 
-    static JS::NonnullGCPtr<WorkerEnvironmentSettingsObject> setup(NonnullOwnPtr<JS::ExecutionContext> execution_context /* FIXME: null or an environment reservedEnvironment, a URL topLevelCreationURL, and an origin topLevelOrigin */);
+    static JS::NonnullGCPtr<WorkerEnvironmentSettingsObject> setup(JS::NonnullGCPtr<Page> page, NonnullOwnPtr<JS::ExecutionContext> execution_context /* FIXME: null or an environment reservedEnvironment, a URL topLevelCreationURL, and an origin topLevelOrigin */);
 
     virtual ~WorkerEnvironmentSettingsObject() override = default;
 

--- a/Userland/Libraries/LibWeb/HTML/Window.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Window.cpp
@@ -429,12 +429,12 @@ bool Window::dispatch_event(DOM::Event& event)
 
 Page* Window::page()
 {
-    return associated_document().page();
+    return &associated_document().page();
 }
 
 Page const* Window::page() const
 {
-    return associated_document().page();
+    return &associated_document().page();
 }
 
 Optional<CSS::MediaFeatureValue> Window::query_media_feature(CSS::MediaFeatureID media_feature) const

--- a/Userland/Libraries/LibWeb/HTML/Window.h
+++ b/Userland/Libraries/LibWeb/HTML/Window.h
@@ -77,8 +77,8 @@ public:
     // ^JS::Object
     virtual JS::ThrowCompletionOr<bool> internal_set_prototype_of(JS::Object* prototype) override;
 
-    Page* page();
-    Page const* page() const;
+    Page& page();
+    Page const& page() const;
 
     // https://html.spec.whatwg.org/multipage/window-object.html#concept-document-window
     DOM::Document const& associated_document() const { return *m_associated_document; }

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -752,7 +752,7 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& computed_style)
                 VERIFY_NOT_REACHED();
             };
 
-            border.width = snap_a_length_as_a_border_width(document().page()->client().device_pixels_per_css_pixel(), resolve_border_width());
+            border.width = snap_a_length_as_a_border_width(document().page().client().device_pixels_per_css_pixel(), resolve_border_width());
         }
     };
 

--- a/Userland/Libraries/LibWeb/SVG/SVGTitleElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGTitleElement.cpp
@@ -33,16 +33,14 @@ void SVGTitleElement::children_changed()
 {
     Base::children_changed();
 
-    auto* page = document().page();
-    if (!page)
-        return;
-    if (document().browsing_context() != &page->top_level_browsing_context())
+    auto& page = document().page();
+    if (document().browsing_context() != &page.top_level_browsing_context())
         return;
 
     auto* document_element = document().document_element();
 
     if (document_element == parent() && is<SVGElement>(document_element))
-        page->client().page_did_change_title(document().title().to_deprecated_string());
+        page.client().page_did_change_title(document().title().to_deprecated_string());
 }
 
 }

--- a/Userland/Services/WebWorker/DedicatedWorkerHost.cpp
+++ b/Userland/Services/WebWorker/DedicatedWorkerHost.cpp
@@ -55,7 +55,7 @@ void DedicatedWorkerHost::run()
 
     // 9. Set up a worker environment settings object with realm execution context,
     //    outside settings, and unsafeWorkerCreationTime, and let inside settings be the result.
-    auto inner_settings = Web::HTML::WorkerEnvironmentSettingsObject::setup(move(realm_execution_context));
+    auto inner_settings = Web::HTML::WorkerEnvironmentSettingsObject::setup(m_page, move(realm_execution_context));
 
     auto& console_object = *inner_settings->realm().intrinsics().console_object();
     m_console = adopt_ref(*new Web::HTML::WorkerDebugConsoleClient(console_object.console()));


### PR DESCRIPTION
With this change, `Document` now always has a Web::Page. This means we no
longer rely on the breakable link between `Document` and `BrowsingContext`
to find a relevant `Web::Page`.
    
Fixes #22290