### PR TITLE
Kernel: Reject loading ELF files with no loadable segments

### DIFF
--- a/Kernel/Syscalls/execve.cpp
+++ b/Kernel/Syscalls/execve.cpp
@@ -201,6 +201,10 @@ static ErrorOr<RequiredLoadRange> get_required_load_range(OpenFileDescription& p
             range.end = region_end;
     });
 
+    // If there's nothing to load, there's nothing to execute
+    if (range.start == range.end)
+        return EINVAL;
+
     VERIFY(range.end > range.start);
     return range;
 }


### PR DESCRIPTION
If there's no loadable segments then there can't be any code to execute either. This resolves a crash these kinds of ELF files would cause from the directly following VERIFY statement.

Resolves #22294.