### PR TITLE
LibWeb: Add support for the meta key modifier

### DIFF
--- a/Userland/Libraries/LibWeb/UIEvents/KeyboardEvent.cpp
+++ b/Userland/Libraries/LibWeb/UIEvents/KeyboardEvent.cpp
@@ -582,7 +582,7 @@ JS::NonnullGCPtr<KeyboardEvent> KeyboardEvent::create_from_platform_event(JS::Re
     event_init.ctrl_key = modifiers & Mod_Ctrl;
     event_init.shift_key = modifiers & Mod_Shift;
     event_init.alt_key = modifiers & Mod_Alt;
-    event_init.meta_key = false; // FIXME: Implement meta key
+    event_init.meta_key = modifiers & Mod_Super;
     event_init.repeat = false;
     event_init.is_composing = false;
     event_init.key_code = key_code;

--- a/Userland/Libraries/LibWeb/UIEvents/MouseEvent.cpp
+++ b/Userland/Libraries/LibWeb/UIEvents/MouseEvent.cpp
@@ -29,7 +29,7 @@ MouseEvent::MouseEvent(JS::Realm& realm, FlyString const& event_name, MouseEvent
     , m_ctrl_key(modifiers & Mod_Ctrl)
     , m_shift_key(modifiers & Mod_Shift)
     , m_alt_key(modifiers & Mod_Alt)
-    , m_meta_key(false) // FIXME: Implement meta key
+    , m_meta_key(modifiers & Mod_Super)
     , m_movement_x(event_init.movement_x)
     , m_movement_y(event_init.movement_y)
     , m_button(event_init.button)


### PR DESCRIPTION
Today I found out that `Mod_Super` exists, so let's use that for the meta key in LibWeb!