### PR TITLE
LibWeb: Refactor WebContentServer mouse input message to DevicePixel

### DIFF
--- a/Ladybird/AppKit/UI/LadybirdWebViewBridge.cpp
+++ b/Ladybird/AppKit/UI/LadybirdWebViewBridge.cpp
@@ -109,29 +109,29 @@ void WebViewBridge::set_preferred_color_scheme(Web::CSS::PreferredColorScheme co
     client().async_set_preferred_color_scheme(color_scheme);
 }
 
-void WebViewBridge::mouse_wheel_event(Gfx::IntPoint position, Gfx::IntPoint screen_position, GUI::MouseButton button, KeyModifier modifiers, int wheel_delta_x, int wheel_delta_y)
-{
-    client().async_mouse_wheel(to_content_position(position), screen_position, to_underlying(button), to_underlying(button), modifiers, wheel_delta_x, wheel_delta_y);
-}
-
 void WebViewBridge::mouse_down_event(Gfx::IntPoint position, Gfx::IntPoint screen_position, GUI::MouseButton button, KeyModifier modifiers)
 {
-    client().async_mouse_down(to_content_position(position), screen_position, to_underlying(button), to_underlying(button), modifiers);
+    client().async_mouse_down(to_content_position(position).to_type<Web::DevicePixels>(), to_content_position(screen_position).to_type<Web::DevicePixels>(), to_underlying(button), to_underlying(button), modifiers);
 }
 
 void WebViewBridge::mouse_up_event(Gfx::IntPoint position, Gfx::IntPoint screen_position, GUI::MouseButton button, KeyModifier modifiers)
 {
-    client().async_mouse_up(to_content_position(position), screen_position, to_underlying(button), to_underlying(button), modifiers);
+    client().async_mouse_up(to_content_position(position).to_type<Web::DevicePixels>(), to_content_position(screen_position).to_type<Web::DevicePixels>(), to_underlying(button), to_underlying(button), modifiers);
 }
 
 void WebViewBridge::mouse_move_event(Gfx::IntPoint position, Gfx::IntPoint screen_position, GUI::MouseButton button, KeyModifier modifiers)
 {
-    client().async_mouse_move(to_content_position(position), screen_position, 0, to_underlying(button), modifiers);
+    client().async_mouse_move(to_content_position(position).to_type<Web::DevicePixels>(), to_content_position(screen_position).to_type<Web::DevicePixels>(), 0, to_underlying(button), modifiers);
+}
+
+void WebViewBridge::mouse_wheel_event(Gfx::IntPoint position, Gfx::IntPoint screen_position, GUI::MouseButton button, KeyModifier modifiers, int wheel_delta_x, int wheel_delta_y)
+{
+    client().async_mouse_wheel(to_content_position(position).to_type<Web::DevicePixels>(), to_content_position(screen_position).to_type<Web::DevicePixels>(), to_underlying(button), to_underlying(button), modifiers, wheel_delta_x, wheel_delta_y);
 }
 
 void WebViewBridge::mouse_double_click_event(Gfx::IntPoint position, Gfx::IntPoint screen_position, GUI::MouseButton button, KeyModifier modifiers)
 {
-    client().async_doubleclick(to_content_position(position), screen_position, button, to_underlying(button), modifiers);
+    client().async_doubleclick(to_content_position(position).to_type<Web::DevicePixels>(), to_content_position(screen_position).to_type<Web::DevicePixels>(), button, to_underlying(button), modifiers);
 }
 
 void WebViewBridge::key_down_event(KeyCode key_code, KeyModifier modifiers, u32 code_point)

--- a/Ladybird/AppKit/UI/LadybirdWebViewBridge.h
+++ b/Ladybird/AppKit/UI/LadybirdWebViewBridge.h
@@ -41,10 +41,10 @@ public:
     void update_palette();
     void set_preferred_color_scheme(Web::CSS::PreferredColorScheme);
 
-    void mouse_wheel_event(Gfx::IntPoint, Gfx::IntPoint, GUI::MouseButton, KeyModifier, int, int);
     void mouse_down_event(Gfx::IntPoint, Gfx::IntPoint, GUI::MouseButton, KeyModifier);
     void mouse_up_event(Gfx::IntPoint, Gfx::IntPoint, GUI::MouseButton, KeyModifier);
     void mouse_move_event(Gfx::IntPoint, Gfx::IntPoint, GUI::MouseButton, KeyModifier);
+    void mouse_wheel_event(Gfx::IntPoint, Gfx::IntPoint, GUI::MouseButton, KeyModifier, int, int);
     void mouse_double_click_event(Gfx::IntPoint, Gfx::IntPoint, GUI::MouseButton, KeyModifier);
 
     void key_down_event(KeyCode, KeyModifier, u32);

--- a/Ladybird/Qt/WebContentView.cpp
+++ b/Ladybird/Qt/WebContentView.cpp
@@ -321,46 +321,19 @@ KeyCode get_keycode_from_qt_keyboard_event(QKeyEvent const& event)
     return Key_Invalid;
 }
 
-void WebContentView::wheelEvent(QWheelEvent* event)
-{
-    if (!event->modifiers().testFlag(Qt::ControlModifier)) {
-        Gfx::IntPoint position(event->position().x() * m_device_pixel_ratio, event->position().y() * m_device_pixel_ratio);
-        Gfx::IntPoint screen_position(event->globalPosition().x() * m_device_pixel_ratio, event->globalPosition().y() * m_device_pixel_ratio);
-        auto button = get_button_from_qt_event(*event);
-        auto buttons = get_buttons_from_qt_event(*event);
-        auto modifiers = get_modifiers_from_qt_mouse_event(*event);
-
-        auto num_pixels = -event->pixelDelta();
-        if (!num_pixels.isNull()) {
-            client().async_mouse_wheel(to_content_position(position), screen_position, button, buttons, modifiers, num_pixels.x(), num_pixels.y());
-        } else {
-            auto num_degrees = -event->angleDelta();
-            float delta_x = -num_degrees.x() / 120;
-            float delta_y = num_degrees.y() / 120;
-            auto step_x = delta_x * QApplication::wheelScrollLines() * m_device_pixel_ratio;
-            auto step_y = delta_y * QApplication::wheelScrollLines() * m_device_pixel_ratio;
-            int scroll_step_size = verticalScrollBar()->singleStep();
-            client().async_mouse_wheel(to_content_position(position), screen_position, button, buttons, modifiers, step_x * scroll_step_size, step_y * scroll_step_size);
-        }
-        event->accept();
-        return;
-    }
-    event->ignore();
-}
-
 void WebContentView::mouseMoveEvent(QMouseEvent* event)
 {
-    Gfx::IntPoint position(event->position().x() * m_device_pixel_ratio, event->position().y() * m_device_pixel_ratio);
-    Gfx::IntPoint screen_position(event->globalPosition().x() * m_device_pixel_ratio, event->globalPosition().y() * m_device_pixel_ratio);
+    Web::DevicePixelPoint position(to_content_position(Gfx::IntPoint { event->position().x(), event->position().y() }) * m_device_pixel_ratio);
+    Web::DevicePixelPoint screen_position(event->globalPosition().x() * m_device_pixel_ratio, event->globalPosition().y() * m_device_pixel_ratio);
     auto buttons = get_buttons_from_qt_event(*event);
     auto modifiers = get_modifiers_from_qt_mouse_event(*event);
-    client().async_mouse_move(to_content_position(position), screen_position, 0, buttons, modifiers);
+    client().async_mouse_move(position, screen_position, 0, buttons, modifiers);
 }
 
 void WebContentView::mousePressEvent(QMouseEvent* event)
 {
-    Gfx::IntPoint position(event->position().x() * m_device_pixel_ratio, event->position().y() * m_device_pixel_ratio);
-    Gfx::IntPoint screen_position(event->globalPosition().x() * m_device_pixel_ratio, event->globalPosition().y() * m_device_pixel_ratio);
+    Web::DevicePixelPoint position(to_content_position(Gfx::IntPoint { event->position().x(), event->position().y() }) * m_device_pixel_ratio);
+    Web::DevicePixelPoint screen_position(event->globalPosition().x() * m_device_pixel_ratio, event->globalPosition().y() * m_device_pixel_ratio);
     auto button = get_button_from_qt_event(*event);
     if (button == 0) {
         // We could not convert Qt buttons to something that Lagom can
@@ -370,13 +343,13 @@ void WebContentView::mousePressEvent(QMouseEvent* event)
     }
     auto modifiers = get_modifiers_from_qt_mouse_event(*event);
     auto buttons = get_buttons_from_qt_event(*event);
-    client().async_mouse_down(to_content_position(position), screen_position, button, buttons, modifiers);
+    client().async_mouse_down(position, screen_position, button, buttons, modifiers);
 }
 
 void WebContentView::mouseReleaseEvent(QMouseEvent* event)
 {
-    Gfx::IntPoint position(event->position().x() * m_device_pixel_ratio, event->position().y() * m_device_pixel_ratio);
-    Gfx::IntPoint screen_position(event->globalPosition().x() * m_device_pixel_ratio, event->globalPosition().y() * m_device_pixel_ratio);
+    Web::DevicePixelPoint position(to_content_position(Gfx::IntPoint { event->position().x(), event->position().y() }) * m_device_pixel_ratio);
+    Web::DevicePixelPoint screen_position(event->globalPosition().x() * m_device_pixel_ratio, event->globalPosition().y() * m_device_pixel_ratio);
     auto button = get_button_from_qt_event(*event);
 
     if (event->button() & Qt::MouseButton::BackButton) {
@@ -395,13 +368,40 @@ void WebContentView::mouseReleaseEvent(QMouseEvent* event)
     }
     auto modifiers = get_modifiers_from_qt_mouse_event(*event);
     auto buttons = get_buttons_from_qt_event(*event);
-    client().async_mouse_up(to_content_position(position), screen_position, button, buttons, modifiers);
+    client().async_mouse_up(position, screen_position, button, buttons, modifiers);
+}
+
+void WebContentView::wheelEvent(QWheelEvent* event)
+{
+    if (!event->modifiers().testFlag(Qt::ControlModifier)) {
+        Web::DevicePixelPoint position(to_content_position(Gfx::IntPoint { event->position().x(), event->position().y() }) * m_device_pixel_ratio);
+        Web::DevicePixelPoint screen_position(event->globalPosition().x() * m_device_pixel_ratio, event->globalPosition().y() * m_device_pixel_ratio);
+        auto button = get_button_from_qt_event(*event);
+        auto buttons = get_buttons_from_qt_event(*event);
+        auto modifiers = get_modifiers_from_qt_mouse_event(*event);
+
+        auto num_pixels = -event->pixelDelta();
+        if (!num_pixels.isNull()) {
+            client().async_mouse_wheel(position, screen_position, button, buttons, modifiers, num_pixels.x(), num_pixels.y());
+        } else {
+            auto num_degrees = -event->angleDelta();
+            float delta_x = -num_degrees.x() / 120;
+            float delta_y = num_degrees.y() / 120;
+            auto step_x = delta_x * QApplication::wheelScrollLines() * m_device_pixel_ratio;
+            auto step_y = delta_y * QApplication::wheelScrollLines() * m_device_pixel_ratio;
+            int scroll_step_size = verticalScrollBar()->singleStep();
+            client().async_mouse_wheel(position, screen_position, button, buttons, modifiers, step_x * scroll_step_size, step_y * scroll_step_size);
+        }
+        event->accept();
+        return;
+    }
+    event->ignore();
 }
 
 void WebContentView::mouseDoubleClickEvent(QMouseEvent* event)
 {
-    Gfx::IntPoint position(event->position().x() * m_device_pixel_ratio, event->position().y() * m_device_pixel_ratio);
-    Gfx::IntPoint screen_position(event->globalPosition().x() * m_device_pixel_ratio, event->globalPosition().y() * m_device_pixel_ratio);
+    Web::DevicePixelPoint position(to_content_position(Gfx::IntPoint { event->position().x(), event->position().y() }) * m_device_pixel_ratio);
+    Web::DevicePixelPoint screen_position(event->globalPosition().x() * m_device_pixel_ratio, event->globalPosition().y() * m_device_pixel_ratio);
     auto button = get_button_from_qt_event(*event);
     if (button == 0) {
         // We could not convert Qt buttons to something that Lagom can
@@ -411,7 +411,7 @@ void WebContentView::mouseDoubleClickEvent(QMouseEvent* event)
     }
     auto modifiers = get_modifiers_from_qt_mouse_event(*event);
     auto buttons = get_buttons_from_qt_event(*event);
-    client().async_doubleclick(to_content_position(position), screen_position, button, buttons, modifiers);
+    client().async_doubleclick(position, screen_position, button, buttons, modifiers);
 }
 
 void WebContentView::dragEnterEvent(QDragEnterEvent* event)

--- a/Ladybird/Qt/WebContentView.h
+++ b/Ladybird/Qt/WebContentView.h
@@ -49,10 +49,10 @@ public:
 
     virtual void paintEvent(QPaintEvent*) override;
     virtual void resizeEvent(QResizeEvent*) override;
-    virtual void wheelEvent(QWheelEvent*) override;
     virtual void mouseMoveEvent(QMouseEvent*) override;
     virtual void mousePressEvent(QMouseEvent*) override;
     virtual void mouseReleaseEvent(QMouseEvent*) override;
+    virtual void wheelEvent(QWheelEvent*) override;
     virtual void mouseDoubleClickEvent(QMouseEvent*) override;
     virtual void dragEnterEvent(QDragEnterEvent*) override;
     virtual void dropEvent(QDropEvent*) override;

--- a/Meta/Lagom/Tools/CodeGenerators/IPCCompiler/main.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/IPCCompiler/main.cpp
@@ -70,7 +70,7 @@ static bool is_primitive_type(DeprecatedString const& type)
 static bool is_simple_type(DeprecatedString const& type)
 {
     // Small types that it makes sense just to pass by value.
-    return type.is_one_of("Gfx::Color", "Gfx::IntPoint", "Gfx::FloatPoint", "Web::DevicePixelPoint", "Gfx::IntSize", "Gfx::FloatSize", "Web::DevicePixelSize", "Core::File::OpenMode");
+    return type.is_one_of("Gfx::Color", "Web::DevicePixels", "Gfx::IntPoint", "Gfx::FloatPoint", "Web::DevicePixelPoint", "Gfx::IntSize", "Gfx::FloatSize", "Web::DevicePixelSize", "Core::File::OpenMode");
 }
 
 static bool is_primitive_or_simple_type(DeprecatedString const& type)

--- a/Userland/Libraries/LibWeb/Page/Page.cpp
+++ b/Userland/Libraries/LibWeb/Page/Page.cpp
@@ -138,11 +138,6 @@ DevicePixelRect Page::rounded_device_rect(CSSPixelRect rect) const
     };
 }
 
-bool Page::handle_mousewheel(DevicePixelPoint position, DevicePixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers, int wheel_delta_x, int wheel_delta_y)
-{
-    return top_level_browsing_context().event_handler().handle_mousewheel(device_to_css_point(position), device_to_css_point(screen_position), button, buttons, modifiers, wheel_delta_x, wheel_delta_y);
-}
-
 bool Page::handle_mouseup(DevicePixelPoint position, DevicePixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers)
 {
     return top_level_browsing_context().event_handler().handle_mouseup(device_to_css_point(position), device_to_css_point(screen_position), button, buttons, modifiers);
@@ -156,6 +151,11 @@ bool Page::handle_mousedown(DevicePixelPoint position, DevicePixelPoint screen_p
 bool Page::handle_mousemove(DevicePixelPoint position, DevicePixelPoint screen_position, unsigned buttons, unsigned modifiers)
 {
     return top_level_browsing_context().event_handler().handle_mousemove(device_to_css_point(position), device_to_css_point(screen_position), buttons, modifiers);
+}
+
+bool Page::handle_mousewheel(DevicePixelPoint position, DevicePixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers, DevicePixels wheel_delta_x, DevicePixels wheel_delta_y)
+{
+    return top_level_browsing_context().event_handler().handle_mousewheel(device_to_css_point(position), device_to_css_point(screen_position), button, buttons, modifiers, wheel_delta_x.value(), wheel_delta_y.value());
 }
 
 bool Page::handle_doubleclick(DevicePixelPoint position, DevicePixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers)

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -77,7 +77,7 @@ public:
     bool handle_mouseup(DevicePixelPoint, DevicePixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers);
     bool handle_mousedown(DevicePixelPoint, DevicePixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers);
     bool handle_mousemove(DevicePixelPoint, DevicePixelPoint screen_position, unsigned buttons, unsigned modifiers);
-    bool handle_mousewheel(DevicePixelPoint, DevicePixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers, int wheel_delta_x, int wheel_delta_y);
+    bool handle_mousewheel(DevicePixelPoint, DevicePixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers, DevicePixels wheel_delta_x, DevicePixels wheel_delta_y);
     bool handle_doubleclick(DevicePixelPoint, DevicePixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers);
 
     bool handle_keydown(KeyCode, unsigned modifiers, u32 code_point);

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
@@ -337,25 +337,26 @@ void OutOfProcessWebView::process_next_input_event()
             }
         },
         [this](GUI::MouseEvent const& event) {
-            auto screen_position = event.position() + (window()->position() + relative_position());
+            auto position = to_content_position(event.position()).to_type<Web::DevicePixels>();
+            auto screen_position = (event.position() + (window()->position() + relative_position())).to_type<Web::DevicePixels>();
             switch (event.type()) {
             case GUI::Event::Type::MouseDown:
-                client().async_mouse_down(to_content_position(event.position()), screen_position, event.button(), event.buttons(), event.modifiers());
+                client().async_mouse_down(position, screen_position, event.button(), event.buttons(), event.modifiers());
                 break;
             case GUI::Event::Type::MouseUp:
-                client().async_mouse_up(to_content_position(event.position()), screen_position, event.button(), event.buttons(), event.modifiers());
+                client().async_mouse_up(position, screen_position, event.button(), event.buttons(), event.modifiers());
                 break;
             case GUI::Event::Type::MouseMove:
-                client().async_mouse_move(to_content_position(event.position()), screen_position, event.button(), event.buttons(), event.modifiers());
+                client().async_mouse_move(position, screen_position, event.button(), event.buttons(), event.modifiers());
                 break;
             case GUI::Event::Type::MouseWheel: {
                 // FIXME: This wheel delta step size multiplier is used to remain the old scroll behaviour, in future use system step size.
                 constexpr int scroll_step_size = 24;
-                client().async_mouse_wheel(to_content_position(event.position()), screen_position, event.button(), event.buttons(), event.modifiers(), event.wheel_delta_x() * scroll_step_size, event.wheel_delta_y() * scroll_step_size);
+                client().async_mouse_wheel(position, screen_position, event.button(), event.buttons(), event.modifiers(), event.wheel_delta_x() * scroll_step_size, event.wheel_delta_y() * scroll_step_size);
                 break;
             }
             case GUI::Event::Type::MouseDoubleClick:
-                client().async_doubleclick(to_content_position(event.position()), screen_position, event.button(), event.buttons(), event.modifiers());
+                client().async_doubleclick(position, screen_position, event.button(), event.buttons(), event.modifiers());
                 break;
             default:
                 dbgln("Unrecognized mouse event type in OOPWV input event queue: {}", event.type());

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -192,14 +192,12 @@ void ConnectionFromClient::process_next_input_event()
             switch (event.type) {
             case QueuedMouseEvent::Type::MouseDown:
                 report_finished_handling_input_event(page().page().handle_mousedown(
-                    event.position.to_type<Web::DevicePixels>(),
-                    event.screen_position.to_type<Web::DevicePixels>(),
+                    event.position, event.screen_position,
                     event.button, event.buttons, event.modifiers));
                 break;
             case QueuedMouseEvent::Type::MouseUp:
                 report_finished_handling_input_event(page().page().handle_mouseup(
-                    event.position.to_type<Web::DevicePixels>(),
-                    event.screen_position.to_type<Web::DevicePixels>(),
+                    event.position, event.screen_position,
                     event.button, event.buttons, event.modifiers));
                 break;
             case QueuedMouseEvent::Type::MouseMove:
@@ -209,14 +207,12 @@ void ConnectionFromClient::process_next_input_event()
                     report_finished_handling_input_event(false);
                 }
                 report_finished_handling_input_event(page().page().handle_mousemove(
-                    event.position.to_type<Web::DevicePixels>(),
-                    event.screen_position.to_type<Web::DevicePixels>(),
+                    event.position, event.screen_position,
                     event.buttons, event.modifiers));
                 break;
             case QueuedMouseEvent::Type::DoubleClick:
                 report_finished_handling_input_event(page().page().handle_doubleclick(
-                    event.position.to_type<Web::DevicePixels>(),
-                    event.screen_position.to_type<Web::DevicePixels>(),
+                    event.position, event.screen_position,
                     event.button, event.buttons, event.modifiers));
                 break;
             case QueuedMouseEvent::Type::MouseWheel:
@@ -224,9 +220,9 @@ void ConnectionFromClient::process_next_input_event()
                     report_finished_handling_input_event(false);
                 }
                 report_finished_handling_input_event(page().page().handle_mousewheel(
-                    event.position.to_type<Web::DevicePixels>(),
-                    event.screen_position.to_type<Web::DevicePixels>(),
-                    event.button, event.buttons, event.modifiers, event.wheel_delta_x, event.wheel_delta_y));
+                    event.position, event.screen_position,
+                    event.button, event.buttons, event.modifiers,
+                    event.wheel_delta_x, event.wheel_delta_y));
                 break;
             }
         },
@@ -245,7 +241,7 @@ void ConnectionFromClient::process_next_input_event()
         m_input_event_queue_timer->start();
 }
 
-void ConnectionFromClient::mouse_down(Gfx::IntPoint position, Gfx::IntPoint screen_position, unsigned int button, unsigned int buttons, unsigned int modifiers)
+void ConnectionFromClient::mouse_down(Web::DevicePixelPoint position, Web::DevicePixelPoint screen_position, unsigned int button, unsigned int buttons, unsigned int modifiers)
 {
     enqueue_input_event(
         QueuedMouseEvent {
@@ -258,7 +254,7 @@ void ConnectionFromClient::mouse_down(Gfx::IntPoint position, Gfx::IntPoint scre
         });
 }
 
-void ConnectionFromClient::mouse_move(Gfx::IntPoint position, Gfx::IntPoint screen_position, [[maybe_unused]] unsigned int button, unsigned int buttons, unsigned int modifiers)
+void ConnectionFromClient::mouse_move(Web::DevicePixelPoint position, Web::DevicePixelPoint screen_position, [[maybe_unused]] unsigned int button, unsigned int buttons, unsigned int modifiers)
 {
     auto event = QueuedMouseEvent {
         .type = QueuedMouseEvent::Type::MouseMove,
@@ -281,7 +277,7 @@ void ConnectionFromClient::mouse_move(Gfx::IntPoint position, Gfx::IntPoint scre
     enqueue_input_event(move(event));
 }
 
-void ConnectionFromClient::mouse_up(Gfx::IntPoint position, Gfx::IntPoint screen_position, unsigned int button, unsigned int buttons, unsigned int modifiers)
+void ConnectionFromClient::mouse_up(Web::DevicePixelPoint position, Web::DevicePixelPoint screen_position, unsigned int button, unsigned int buttons, unsigned int modifiers)
 {
     enqueue_input_event(
         QueuedMouseEvent {
@@ -294,7 +290,7 @@ void ConnectionFromClient::mouse_up(Gfx::IntPoint position, Gfx::IntPoint screen
         });
 }
 
-void ConnectionFromClient::mouse_wheel(Gfx::IntPoint position, Gfx::IntPoint screen_position, unsigned int button, unsigned int buttons, unsigned int modifiers, i32 wheel_delta_x, i32 wheel_delta_y)
+void ConnectionFromClient::mouse_wheel(Web::DevicePixelPoint position, Web::DevicePixelPoint screen_position, unsigned int button, unsigned int buttons, unsigned int modifiers, Web::DevicePixels wheel_delta_x, Web::DevicePixels wheel_delta_y)
 {
     auto event = QueuedMouseEvent {
         .type = QueuedMouseEvent::Type::MouseWheel,
@@ -322,7 +318,7 @@ void ConnectionFromClient::mouse_wheel(Gfx::IntPoint position, Gfx::IntPoint scr
     enqueue_input_event(move(event));
 }
 
-void ConnectionFromClient::doubleclick(Gfx::IntPoint position, Gfx::IntPoint screen_position, unsigned int button, unsigned int buttons, unsigned int modifiers)
+void ConnectionFromClient::doubleclick(Web::DevicePixelPoint position, Web::DevicePixelPoint screen_position, unsigned int button, unsigned int buttons, unsigned int modifiers)
 {
     enqueue_input_event(
         QueuedMouseEvent {

--- a/Userland/Services/WebContent/ConnectionFromClient.h
+++ b/Userland/Services/WebContent/ConnectionFromClient.h
@@ -60,11 +60,11 @@ private:
     virtual void load_html(DeprecatedString const&) override;
     virtual void paint(Web::DevicePixelRect const&, i32) override;
     virtual void set_viewport_rect(Web::DevicePixelRect const&) override;
-    virtual void mouse_down(Gfx::IntPoint, Gfx::IntPoint, unsigned, unsigned, unsigned) override;
-    virtual void mouse_move(Gfx::IntPoint, Gfx::IntPoint, unsigned, unsigned, unsigned) override;
-    virtual void mouse_up(Gfx::IntPoint, Gfx::IntPoint, unsigned, unsigned, unsigned) override;
-    virtual void mouse_wheel(Gfx::IntPoint, Gfx::IntPoint, unsigned, unsigned, unsigned, i32, i32) override;
-    virtual void doubleclick(Gfx::IntPoint, Gfx::IntPoint, unsigned, unsigned, unsigned) override;
+    virtual void mouse_down(Web::DevicePixelPoint, Web::DevicePixelPoint, unsigned, unsigned, unsigned) override;
+    virtual void mouse_move(Web::DevicePixelPoint, Web::DevicePixelPoint, unsigned, unsigned, unsigned) override;
+    virtual void mouse_up(Web::DevicePixelPoint, Web::DevicePixelPoint, unsigned, unsigned, unsigned) override;
+    virtual void mouse_wheel(Web::DevicePixelPoint, Web::DevicePixelPoint, unsigned, unsigned, unsigned, Web::DevicePixels, Web::DevicePixels) override;
+    virtual void doubleclick(Web::DevicePixelPoint, Web::DevicePixelPoint, unsigned, unsigned, unsigned) override;
     virtual void key_down(i32, unsigned, u32) override;
     virtual void key_up(i32, unsigned, u32) override;
     virtual void add_backing_store(i32, Gfx::ShareableBitmap const&) override;
@@ -164,13 +164,13 @@ private:
             DoubleClick,
         };
         Type type {};
-        Gfx::IntPoint position {};
-        Gfx::IntPoint screen_position {};
+        Web::DevicePixelPoint position {};
+        Web::DevicePixelPoint screen_position {};
         unsigned button {};
         unsigned buttons {};
         unsigned modifiers {};
-        int wheel_delta_x {};
-        int wheel_delta_y {};
+        Web::DevicePixels wheel_delta_x {};
+        Web::DevicePixels wheel_delta_y {};
         size_t coalesced_event_count { 0 };
     };
 

--- a/Userland/Services/WebContent/WebContentServer.ipc
+++ b/Userland/Services/WebContent/WebContentServer.ipc
@@ -28,11 +28,11 @@ endpoint WebContentServer
     paint(Web::DevicePixelRect content_rect, i32 backing_store_id) =|
     set_viewport_rect(Web::DevicePixelRect rect) =|
 
-    mouse_down(Gfx::IntPoint position, Gfx::IntPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers) =|
-    mouse_move(Gfx::IntPoint position, Gfx::IntPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers) =|
-    mouse_up(Gfx::IntPoint position, Gfx::IntPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers) =|
-    mouse_wheel(Gfx::IntPoint position, Gfx::IntPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers, i32 wheel_delta_x, i32 wheel_delta_y) =|
-    doubleclick(Gfx::IntPoint position, Gfx::IntPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers) =|
+    mouse_down(Web::DevicePixelPoint position, Web::DevicePixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers) =|
+    mouse_move(Web::DevicePixelPoint position, Web::DevicePixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers) =|
+    mouse_up(Web::DevicePixelPoint position, Web::DevicePixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers) =|
+    mouse_wheel(Web::DevicePixelPoint position, Web::DevicePixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers, Web::DevicePixels wheel_delta_x, Web::DevicePixels wheel_delta_y) =|
+    doubleclick(Web::DevicePixelPoint position, Web::DevicePixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers) =|
 
     key_down(i32 key, unsigned modifiers, u32 code_point) =|
     key_up(i32 key, unsigned modifiers, u32 code_point) =|


### PR DESCRIPTION
These changes convert to positions types of the mouse events in `WebContentServer.ipc` to DevicePixelPoint. This makes the IPC API more clear that unscaled / raw pixel coordinates are used. 

With these changes are all coordinates in `WebContentServer.ipc` are 'fixed'.