### PR TITLE
LibPDF: Tolerate 0-sized Subrs in PS1 font subprograms

### DIFF
--- a/Userland/Libraries/LibPDF/Fonts/PS1FontProgram.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/PS1FontProgram.cpp
@@ -107,7 +107,7 @@ PDFErrorOr<Vector<ByteBuffer>> PS1FontProgram::parse_subroutines(Reader& reader)
         return error("Expected array length");
 
     auto length = TRY(parse_int(reader));
-    VERIFY(length > 0);
+    VERIFY(length >= 0);
 
     Vector<ByteBuffer> array;
     TRY(array.try_resize(length));

--- a/Userland/Libraries/LibPDF/Fonts/PS1FontProgram.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/PS1FontProgram.cpp
@@ -114,8 +114,7 @@ PDFErrorOr<Vector<ByteBuffer>> PS1FontProgram::parse_subroutines(Reader& reader)
 
     while (reader.remaining()) {
         auto word = TRY(parse_word(reader));
-        if (word.is_empty())
-            VERIFY(0);
+        VERIFY(!word.is_empty());
 
         if (word == "dup") {
             auto index = TRY(parse_int(reader));


### PR DESCRIPTION
This regressed in 2b3a41be74a3e8 in #18031.

Fixes a crash rendering page 2 and onward of
https://pyx-project.org/presentation_dantemv35_en.pdf