### PR TITLE
HexEditor: Change cursor type from blinking caret to black box

### DIFF
--- a/Userland/Applications/HexEditor/HexEditor.cpp
+++ b/Userland/Applications/HexEditor/HexEditor.cpp
@@ -684,17 +684,27 @@ void HexEditor::paint_event(GUI::PaintEvent& event)
             }
             painter.fill_rect(background_rect, background_color_hex);
 
-            if (m_edit_mode == EditMode::Hex) {
+            Gfx::IntRect text_display_rect {
+                frame_thickness() + offset_margin_width() + bytes_per_row() * cell_width() + j * character_width() + 4 * m_padding,
+                frame_thickness() + m_padding + i * line_height(),
+                character_width(),
+                line_height() - m_line_spacing
+            };
+
+            auto draw_cursor_rect = [&]() {
                 if (byte_position == m_position) {
                     Gfx::IntRect cursor_position_rect {
-                        static_cast<int>(hex_display_rect_high_nibble.left() + m_cursor_at_low_nibble * character_width()),
+                        (m_edit_mode == EditMode::Hex) ? static_cast<int>(hex_display_rect_high_nibble.left() + m_cursor_at_low_nibble * character_width()) : text_display_rect.left(),
                         static_cast<int>(frame_thickness() + m_line_spacing / 2 + i * line_height()),
                         static_cast<int>(character_width()),
                         static_cast<int>(line_height())
                     };
                     painter.fill_rect(cursor_position_rect, palette().black());
                 }
-            }
+            };
+
+            if (m_edit_mode == EditMode::Hex)
+                draw_cursor_rect();
 
             if (byte_position == m_position && !edited_flag) {
                 painter.draw_text(hex_display_rect_high_nibble, high_nibble, Gfx::TextAlignment::TopLeft, m_cursor_at_low_nibble ? text_color_hex : palette().selection_text());
@@ -704,12 +714,6 @@ void HexEditor::paint_event(GUI::PaintEvent& event)
                 painter.draw_text(hex_display_rect_low_nibble, low_nibble, Gfx::TextAlignment::TopLeft, text_color_hex);
             }
 
-            Gfx::IntRect text_display_rect {
-                frame_thickness() + offset_margin_width() + bytes_per_row() * cell_width() + j * character_width() + 4 * m_padding,
-                frame_thickness() + m_padding + i * line_height(),
-                character_width(),
-                line_height() - m_line_spacing
-            };
             Gfx::IntRect text_background_rect {
                 frame_thickness() + offset_margin_width() + bytes_per_row() * cell_width() + j * character_width() + 4 * m_padding,
                 frame_thickness() + m_line_spacing / 2 + i * line_height(),
@@ -720,17 +724,8 @@ void HexEditor::paint_event(GUI::PaintEvent& event)
             painter.fill_rect(text_background_rect, background_color_text);
             auto character = String::formatted("{:c}", isprint(cell_value) ? cell_value : '.').release_value_but_fixme_should_propagate_errors();
 
-            if (m_edit_mode == EditMode::Text) {
-                if (byte_position == m_position) {
-                    Gfx::IntRect cursor_position_rect {
-                        text_display_rect.left(),
-                        static_cast<int>(frame_thickness() + m_line_spacing / 2 + i * line_height()),
-                        static_cast<int>(character_width()),
-                        static_cast<int>(line_height())
-                    };
-                    painter.fill_rect(cursor_position_rect, palette().black());
-                }
-            }
+            if (m_edit_mode == EditMode::Text)
+                draw_cursor_rect();
 
             if (byte_position == m_position)
                 painter.draw_text(text_display_rect, character, Gfx::TextAlignment::TopLeft, palette().selection_text());

--- a/Userland/Applications/HexEditor/HexEditor.cpp
+++ b/Userland/Applications/HexEditor/HexEditor.cpp
@@ -40,12 +40,6 @@ HexEditor::HexEditor()
     set_background_role(ColorRole::Base);
     set_foreground_role(ColorRole::BaseText);
     vertical_scrollbar().set_step(line_height());
-
-    m_blink_timer = Core::Timer::create_repeating(500, [this]() {
-        m_cursor_blink_active = !m_cursor_blink_active;
-        update();
-    }).release_value_but_fixme_should_propagate_errors();
-    m_blink_timer->start();
 }
 
 ErrorOr<void> HexEditor::open_new_file(size_t size)
@@ -118,7 +112,6 @@ void HexEditor::set_position(size_t position)
 
     m_position = position;
     m_cursor_at_low_nibble = false;
-    reset_cursor_blink_state();
     scroll_position_into_view(position);
     update_status();
 }
@@ -131,7 +124,6 @@ void HexEditor::set_selection(size_t position, size_t length)
     m_cursor_at_low_nibble = false;
     m_selection_start = position;
     m_selection_end = position + length;
-    reset_cursor_blink_state();
     scroll_position_into_view(position);
     update_status();
 }
@@ -430,7 +422,6 @@ void HexEditor::keydown_event(GUI::KeyEvent& event)
         } else
             m_selection_start = m_selection_end = m_position = new_position;
         m_cursor_at_low_nibble = false;
-        reset_cursor_blink_state();
         scroll_position_into_view(m_position);
         update();
         update_status();
@@ -536,7 +527,6 @@ ErrorOr<void> HexEditor::hex_mode_keydown_event(GUI::KeyEvent& event)
             m_cursor_at_low_nibble = false;
         }
 
-        reset_cursor_blink_state();
         update();
         update_status();
         did_change();
@@ -563,7 +553,6 @@ ErrorOr<void> HexEditor::text_mode_keydown_event(GUI::KeyEvent& event)
         m_position++;
     m_cursor_at_low_nibble = false;
 
-    reset_cursor_blink_state();
     update();
     update_status();
     did_change();
@@ -684,7 +673,7 @@ void HexEditor::paint_event(GUI::PaintEvent& event)
             painter.draw_text(hex_display_rect, line, Gfx::TextAlignment::TopLeft, text_color);
 
             if (m_edit_mode == EditMode::Hex) {
-                if (byte_position == m_position && m_cursor_blink_active) {
+                if (byte_position == m_position) {
                     Gfx::IntRect cursor_position_rect {
                         static_cast<int>(hex_display_rect.left() + m_cursor_at_low_nibble * character_width()),
                         hex_display_rect.top(),
@@ -730,7 +719,7 @@ void HexEditor::paint_event(GUI::PaintEvent& event)
             painter.draw_text(text_display_rect, character, Gfx::TextAlignment::TopLeft, text_color);
 
             if (m_edit_mode == EditMode::Text) {
-                if (byte_position == m_position && m_cursor_blink_active) {
+                if (byte_position == m_position) {
                     Gfx::IntRect cursor_position_rect {
                         text_display_rect.left(), text_display_rect.top(), 2, text_display_rect.height()
                     };
@@ -855,12 +844,6 @@ Vector<Match> HexEditor::find_all_strings(size_t min_length)
     return matches;
 }
 
-void HexEditor::reset_cursor_blink_state()
-{
-    m_cursor_blink_active = true;
-    m_blink_timer->restart();
-}
-
 ErrorOr<void> HexEditor::did_complete_action(size_t position, u8 old_value, u8 new_value)
 {
     if (old_value == new_value)
@@ -890,7 +873,6 @@ bool HexEditor::undo()
         return false;
 
     m_undo_stack.undo();
-    reset_cursor_blink_state();
     update();
     update_status();
     did_change();
@@ -903,7 +885,6 @@ bool HexEditor::redo()
         return false;
 
     m_undo_stack.redo();
-    reset_cursor_blink_state();
     update();
     update_status();
     did_change();

--- a/Userland/Applications/HexEditor/HexEditor.cpp
+++ b/Userland/Applications/HexEditor/HexEditor.cpp
@@ -154,7 +154,7 @@ ErrorOr<void> HexEditor::save()
     return {};
 }
 
-size_t HexEditor::selection_size()
+size_t HexEditor::selection_size() const
 {
     if (!has_selection())
         return 0;
@@ -636,12 +636,20 @@ void HexEditor::paint_event(GUI::PaintEvent& event)
             bool const selection_inbetween_end_start = byte_position >= m_selection_end && byte_position < m_selection_start;
             bool const highlight_flag = selection_inbetween_start_end || selection_inbetween_end_start;
 
-            Gfx::IntRect hex_display_rect {
+            Gfx::IntRect hex_display_rect_high_nibble {
                 frame_thickness() + offset_margin_width() + j * cell_width() + 2 * m_padding,
                 frame_thickness() + m_padding + i * line_height(),
-                cell_width(),
+                cell_width() / 2,
                 line_height() - m_line_spacing
             };
+
+            Gfx::IntRect hex_display_rect_low_nibble {
+                static_cast<int>(hex_display_rect_high_nibble.x() + character_width()),
+                hex_display_rect_high_nibble.y(),
+                hex_display_rect_high_nibble.width(),
+                hex_display_rect_high_nibble.height()
+            };
+
             Gfx::IntRect background_rect {
                 frame_thickness() + offset_margin_width() + j * cell_width() + 1 * m_padding,
                 frame_thickness() + m_line_spacing / 2 + i * line_height(),
@@ -651,6 +659,8 @@ void HexEditor::paint_event(GUI::PaintEvent& event)
 
             u8 const cell_value = m_document->get(byte_position).value;
             auto line = String::formatted("{:02X}", cell_value).release_value_but_fixme_should_propagate_errors();
+            auto high_nibble = line.substring_from_byte_offset(0, 1).release_value_but_fixme_should_propagate_errors();
+            auto low_nibble = line.substring_from_byte_offset(1).release_value_but_fixme_should_propagate_errors();
 
             Gfx::Color background_color = palette().color(background_role());
             Gfx::Color text_color = [&]() -> Gfx::Color {
@@ -663,25 +673,31 @@ void HexEditor::paint_event(GUI::PaintEvent& event)
 
             if (highlight_flag) {
                 background_color = edited_flag ? palette().selection().inverted() : palette().selection();
-                text_color = edited_flag ? palette().selection_text().inverted() : palette().selection_text();
+                text_color = edited_flag ? text_color : palette().selection_text();
             } else if (byte_position == m_position && m_edit_mode == EditMode::Text) {
                 background_color = palette().inactive_selection();
                 text_color = palette().inactive_selection_text();
             }
             painter.fill_rect(background_rect, background_color);
 
-            painter.draw_text(hex_display_rect, line, Gfx::TextAlignment::TopLeft, text_color);
-
             if (m_edit_mode == EditMode::Hex) {
                 if (byte_position == m_position) {
                     Gfx::IntRect cursor_position_rect {
-                        static_cast<int>(hex_display_rect.left() + m_cursor_at_low_nibble * character_width()),
-                        hex_display_rect.top(),
-                        2,
-                        hex_display_rect.height()
+                        static_cast<int>(hex_display_rect_high_nibble.left() + m_cursor_at_low_nibble * character_width()),
+                        static_cast<int>(frame_thickness() + m_line_spacing / 2 + i * line_height()),
+                        static_cast<int>(character_width()),
+                        static_cast<int>(line_height())
                     };
-                    painter.fill_rect(cursor_position_rect, palette().text_cursor());
+                    painter.fill_rect(cursor_position_rect, palette().black());
                 }
+            }
+
+            if (byte_position == m_position && !edited_flag) {
+                painter.draw_text(hex_display_rect_high_nibble, high_nibble, Gfx::TextAlignment::TopLeft, m_cursor_at_low_nibble ? text_color : palette().selection_text());
+                painter.draw_text(hex_display_rect_low_nibble, low_nibble, Gfx::TextAlignment::TopLeft, m_cursor_at_low_nibble ? palette().selection_text() : text_color);
+            } else {
+                painter.draw_text(hex_display_rect_high_nibble, high_nibble, Gfx::TextAlignment::TopLeft, text_color);
+                painter.draw_text(hex_display_rect_low_nibble, low_nibble, Gfx::TextAlignment::TopLeft, text_color);
             }
 
             Gfx::IntRect text_display_rect {
@@ -716,16 +732,23 @@ void HexEditor::paint_event(GUI::PaintEvent& event)
 
             painter.fill_rect(text_background_rect, background_color);
             auto character = String::formatted("{:c}", isprint(cell_value) ? cell_value : '.').release_value_but_fixme_should_propagate_errors();
-            painter.draw_text(text_display_rect, character, Gfx::TextAlignment::TopLeft, text_color);
 
             if (m_edit_mode == EditMode::Text) {
                 if (byte_position == m_position) {
                     Gfx::IntRect cursor_position_rect {
-                        text_display_rect.left(), text_display_rect.top(), 2, text_display_rect.height()
+                        text_display_rect.left(),
+                        static_cast<int>(frame_thickness() + m_line_spacing / 2 + i * line_height()),
+                        static_cast<int>(character_width()),
+                        static_cast<int>(line_height())
                     };
-                    painter.fill_rect(cursor_position_rect, palette().text_cursor());
+                    painter.fill_rect(cursor_position_rect, palette().black());
                 }
             }
+
+            if (byte_position == m_position)
+                painter.draw_text(text_display_rect, character, Gfx::TextAlignment::TopLeft, palette().selection_text());
+            else
+                painter.draw_text(text_display_rect, character, Gfx::TextAlignment::TopLeft, text_color);
         }
     }
 }

--- a/Userland/Applications/HexEditor/HexEditor.cpp
+++ b/Userland/Applications/HexEditor/HexEditor.cpp
@@ -352,7 +352,7 @@ void HexEditor::mousemove_event(GUI::MouseEvent& event)
                 return;
 
             m_selection_end = offset;
-            m_position = offset;
+            m_position = (m_selection_end <= m_selection_start) ? offset : offset - 1;
             scroll_position_into_view(offset);
         }
 
@@ -367,7 +367,7 @@ void HexEditor::mousemove_event(GUI::MouseEvent& event)
                 return;
 
             m_selection_end = offset;
-            m_position = offset;
+            m_position = (m_selection_end <= m_selection_start) ? offset : offset - 1;
             scroll_position_into_view(offset);
         }
         update_status();

--- a/Userland/Applications/HexEditor/HexEditor.cpp
+++ b/Userland/Applications/HexEditor/HexEditor.cpp
@@ -662,23 +662,27 @@ void HexEditor::paint_event(GUI::PaintEvent& event)
             auto high_nibble = line.substring_from_byte_offset(0, 1).release_value_but_fixme_should_propagate_errors();
             auto low_nibble = line.substring_from_byte_offset(1).release_value_but_fixme_should_propagate_errors();
 
-            Gfx::Color background_color = palette().color(background_role());
-            Gfx::Color text_color = [&]() -> Gfx::Color {
+            Gfx::Color background_color_hex = palette().color(background_role());
+            Gfx::Color background_color_text = background_color_hex;
+            Gfx::Color text_color_hex = [&]() -> Gfx::Color {
                 if (edited_flag)
                     return Color::Red;
                 if (cell_value == 0x00)
                     return palette().color(ColorRole::PlaceholderText);
                 return palette().color(foreground_role());
             }();
+            Gfx::Color text_color_text = text_color_hex;
 
             if (highlight_flag) {
-                background_color = edited_flag ? palette().selection().inverted() : palette().selection();
-                text_color = edited_flag ? text_color : palette().selection_text();
-            } else if (byte_position == m_position && m_edit_mode == EditMode::Text) {
-                background_color = palette().inactive_selection();
-                text_color = palette().inactive_selection_text();
+                background_color_hex = background_color_text = edited_flag ? palette().selection().inverted() : palette().selection();
+                text_color_hex = text_color_text = edited_flag ? text_color_hex : palette().selection_text();
+            } else if (byte_position == m_position) {
+                background_color_hex = (m_edit_mode == EditMode::Hex) ? background_color_hex : palette().inactive_selection();
+                text_color_hex = (m_edit_mode == EditMode::Hex) ? text_color_text : palette().inactive_selection_text();
+                background_color_text = (m_edit_mode == EditMode::Text) ? background_color_text : palette().inactive_selection();
+                text_color_text = (m_edit_mode == EditMode::Text) ? text_color_text : palette().inactive_selection_text();
             }
-            painter.fill_rect(background_rect, background_color);
+            painter.fill_rect(background_rect, background_color_hex);
 
             if (m_edit_mode == EditMode::Hex) {
                 if (byte_position == m_position) {
@@ -693,11 +697,11 @@ void HexEditor::paint_event(GUI::PaintEvent& event)
             }
 
             if (byte_position == m_position && !edited_flag) {
-                painter.draw_text(hex_display_rect_high_nibble, high_nibble, Gfx::TextAlignment::TopLeft, m_cursor_at_low_nibble ? text_color : palette().selection_text());
-                painter.draw_text(hex_display_rect_low_nibble, low_nibble, Gfx::TextAlignment::TopLeft, m_cursor_at_low_nibble ? palette().selection_text() : text_color);
+                painter.draw_text(hex_display_rect_high_nibble, high_nibble, Gfx::TextAlignment::TopLeft, m_cursor_at_low_nibble ? text_color_hex : palette().selection_text());
+                painter.draw_text(hex_display_rect_low_nibble, low_nibble, Gfx::TextAlignment::TopLeft, m_cursor_at_low_nibble ? palette().selection_text() : text_color_hex);
             } else {
-                painter.draw_text(hex_display_rect_high_nibble, high_nibble, Gfx::TextAlignment::TopLeft, text_color);
-                painter.draw_text(hex_display_rect_low_nibble, low_nibble, Gfx::TextAlignment::TopLeft, text_color);
+                painter.draw_text(hex_display_rect_high_nibble, high_nibble, Gfx::TextAlignment::TopLeft, text_color_hex);
+                painter.draw_text(hex_display_rect_low_nibble, low_nibble, Gfx::TextAlignment::TopLeft, text_color_hex);
             }
 
             Gfx::IntRect text_display_rect {
@@ -713,24 +717,7 @@ void HexEditor::paint_event(GUI::PaintEvent& event)
                 line_height()
             };
 
-            background_color = palette().color(background_role());
-            text_color = [&]() -> Gfx::Color {
-                if (edited_flag)
-                    return Color::Red;
-                if (cell_value == 0x00)
-                    return palette().color(ColorRole::PlaceholderText);
-                return palette().color(foreground_role());
-            }();
-
-            if (highlight_flag) {
-                background_color = edited_flag ? palette().selection().inverted() : palette().selection();
-                text_color = edited_flag ? palette().selection_text().inverted() : palette().selection_text();
-            } else if (byte_position == m_position && m_edit_mode == EditMode::Hex) {
-                background_color = palette().inactive_selection();
-                text_color = palette().inactive_selection_text();
-            }
-
-            painter.fill_rect(text_background_rect, background_color);
+            painter.fill_rect(text_background_rect, background_color_text);
             auto character = String::formatted("{:c}", isprint(cell_value) ? cell_value : '.').release_value_but_fixme_should_propagate_errors();
 
             if (m_edit_mode == EditMode::Text) {
@@ -748,7 +735,7 @@ void HexEditor::paint_event(GUI::PaintEvent& event)
             if (byte_position == m_position)
                 painter.draw_text(text_display_rect, character, Gfx::TextAlignment::TopLeft, palette().selection_text());
             else
-                painter.draw_text(text_display_rect, character, Gfx::TextAlignment::TopLeft, text_color);
+                painter.draw_text(text_display_rect, character, Gfx::TextAlignment::TopLeft, text_color_text);
         }
     }
 }

--- a/Userland/Applications/HexEditor/HexEditor.h
+++ b/Userland/Applications/HexEditor/HexEditor.h
@@ -46,7 +46,7 @@ public:
 
     void select_all();
     bool has_selection() const { return m_selection_start < m_selection_end && m_document->size() > 0; }
-    size_t selection_size();
+    size_t selection_size() const;
     size_t selection_start_offset() const { return m_selection_start; }
     bool copy_selected_text_to_clipboard();
     bool copy_selected_hex_to_clipboard();

--- a/Userland/Applications/HexEditor/HexEditor.h
+++ b/Userland/Applications/HexEditor/HexEditor.h
@@ -84,8 +84,6 @@ private:
     size_t m_position { 0 };
     bool m_cursor_at_low_nibble { false };
     EditMode m_edit_mode { Hex };
-    RefPtr<Core::Timer> m_blink_timer;
-    bool m_cursor_blink_active { false };
     NonnullOwnPtr<HexDocument> m_document;
     GUI::UndoStack m_undo_stack;
 
@@ -108,6 +106,4 @@ private:
     void did_change();
     ErrorOr<void> did_complete_action(size_t position, u8 old_value, u8 new_value);
     ErrorOr<void> did_complete_action(size_t position, ByteBuffer&& old_values, ByteBuffer&& new_values);
-
-    void reset_cursor_blink_state();
 };


### PR DESCRIPTION
Discussion regarding this change was moved in this PR: https://github.com/SerenityOS/serenity/pull/22211, and also on #Userland channel, on serenity's discord.

These series of patches change cursor type from caret to black box for both Hex and Text modes, because right now the way how blinking caret looks like is more closer to "insert" mode in similar editors, whereas the real behavior of this cursor is more of a "replace" mode seen in similar editors like GHex.

There have also been fixed crashes when selecting last bytes with mouse and then writing something. Now the cursor is being moved to the last byte of selection, instead of moving the cursor to the byte one after last selected byte.