### PR TITLE
LibJS: Introduce "dictionary" mode for object shapes

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/Shape.h
+++ b/Userland/Libraries/LibJS/Runtime/Shape.h
@@ -49,15 +49,27 @@ public:
         Configure,
         Prototype,
         Delete,
+        CacheableDictionary,
+        UncacheableDictionary,
     };
 
     Shape* create_put_transition(StringOrSymbol const&, PropertyAttributes attributes);
     Shape* create_configure_transition(StringOrSymbol const&, PropertyAttributes attributes);
     Shape* create_prototype_transition(Object* new_prototype);
     [[nodiscard]] NonnullGCPtr<Shape> create_delete_transition(StringOrSymbol const&);
+    [[nodiscard]] NonnullGCPtr<Shape> create_cacheable_dictionary_transition();
+    [[nodiscard]] NonnullGCPtr<Shape> create_uncacheable_dictionary_transition();
 
     void add_property_without_transition(StringOrSymbol const&, PropertyAttributes);
     void add_property_without_transition(PropertyKey const&, PropertyAttributes);
+
+    void remove_property_without_transition(StringOrSymbol const&, u32 offset);
+    void set_property_attributes_without_transition(StringOrSymbol const&, PropertyAttributes);
+
+    [[nodiscard]] bool is_cacheable() const { return m_cacheable; }
+    [[nodiscard]] bool is_dictionary() const { return m_dictionary; }
+    [[nodiscard]] bool is_cacheable_dictionary() const { return m_dictionary && m_cacheable; }
+    [[nodiscard]] bool is_uncacheable_dictionary() const { return m_dictionary && !m_cacheable; }
 
     Realm& realm() const { return m_realm; }
 
@@ -103,6 +115,9 @@ private:
 
     PropertyAttributes m_attributes { 0 };
     TransitionType m_transition_type { TransitionType::Invalid };
+
+    bool m_dictionary { false };
+    bool m_cacheable { true };
 };
 
 }

--- a/Userland/Libraries/LibJS/Tests/builtins/Object/Object.freeze.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Object/Object.freeze.js
@@ -75,3 +75,11 @@ test("does not override frozen function name", () => {
     const obj = Object.freeze({ name: func });
     expect(obj.name()).toBe(12);
 });
+
+test("freeze with huge number of properties doesn't crash", () => {
+    const o = {};
+    for (let i = 0; i < 50_000; ++i) {
+        o["prop" + i] = 1;
+    }
+    Object.freeze(o);
+});


### PR DESCRIPTION
This is similar to "unique" shapes, which were removed in commit 3d92c26445d15d13599de5d20d2227a968fd675a.

The key difference is that dictionary shapes don't have a serial number, but instead have a "cacheable" flag.

Shapes become dictionaries after 64 transitions have occurred, at which point no further transitions occur.

As long as properties are only added to a dictionary shape, it remains cacheable. (Since if we've cached the shape pointer in an IC somewhere, we know the IC is still valid.)

Deleting a property from a dictionary shape causes it to become an uncacheable dictionary.

Note that deleting a property from a non-dictionary shape still performs a delete transition.

This fixes an issue on Discord where Object.freeze() would eventually OOM us, since they add more than 16000 properties to a single object before freezing it.

It also yields a 15% speedup on Octane/pdfjs.js :^)