### PR TITLE
LibWeb: Make private `RecordingPainter::state()`

### DIFF
--- a/Userland/Libraries/LibWeb/Painting/BorderRadiusCornerClipper.cpp
+++ b/Userland/Libraries/LibWeb/Painting/BorderRadiusCornerClipper.cpp
@@ -117,7 +117,7 @@ ScopedCornerRadiusClip::ScopedCornerRadiusClip(PaintContext& context, DevicePixe
         .bottom_right = border_radii.bottom_right.as_corner(context),
         .bottom_left = border_radii.bottom_left.as_corner(context)
     };
-    m_context.recording_painter().sample_under_corners(m_id, corner_radii, context.recording_painter().state().translation.map(border_rect.to_type<int>()), corner_clip);
+    m_context.recording_painter().sample_under_corners(m_id, corner_radii, border_rect.to_type<int>(), corner_clip);
 }
 
 ScopedCornerRadiusClip::~ScopedCornerRadiusClip()

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -485,7 +485,7 @@ void PaintableBox::apply_clip_overflow_rect(PaintContext& context, PaintPhase ph
         if (border_radii_data.has_any_radius()) {
             VERIFY(!m_corner_clipper_id.has_value());
             m_corner_clipper_id = context.allocate_corner_clipper_id();
-            context.recording_painter().sample_under_corners(*m_corner_clipper_id, corner_radii, context.recording_painter().state().translation.map(context.rounded_device_rect(*clip_rect).to_type<int>()), CornerClip::Outside);
+            context.recording_painter().sample_under_corners(*m_corner_clipper_id, corner_radii, context.rounded_device_rect(*clip_rect).to_type<int>(), CornerClip::Outside);
         }
     }
 }
@@ -503,7 +503,7 @@ void PaintableBox::clear_clip_overflow_rect(PaintContext& context, PaintPhase ph
     if (m_corner_clipper_id.has_value()) {
         VERIFY(m_corner_clipper_id.has_value());
         auto clip_rect = this->calculate_overflow_clipped_rect();
-        context.recording_painter().blit_corner_clipping(*m_corner_clipper_id, context.recording_painter().state().translation.map(context.rounded_device_rect(*clip_rect).to_type<int>()));
+        context.recording_painter().blit_corner_clipping(*m_corner_clipper_id, context.rounded_device_rect(*clip_rect).to_type<int>());
         m_corner_clipper_id = {};
     }
 }
@@ -677,7 +677,6 @@ void PaintableWithLines::paint(PaintContext& context, PaintPhase phase) const
     Optional<u32> corner_clip_id;
 
     auto clip_box = context.rounded_device_rect(absolute_padding_box_rect());
-    auto border_radius_clip_rect = context.recording_painter().state().translation.map(clip_box.to_type<int>());
 
     if (should_clip_overflow) {
         context.recording_painter().save();
@@ -695,7 +694,7 @@ void PaintableWithLines::paint(PaintContext& context, PaintPhase phase) const
         };
         if (border_radii.has_any_radius()) {
             corner_clip_id = context.allocate_corner_clipper_id();
-            context.recording_painter().sample_under_corners(*corner_clip_id, corner_radii, border_radius_clip_rect, CornerClip::Outside);
+            context.recording_painter().sample_under_corners(*corner_clip_id, corner_radii, clip_box.to_type<int>(), CornerClip::Outside);
         }
     }
 
@@ -746,7 +745,7 @@ void PaintableWithLines::paint(PaintContext& context, PaintPhase phase) const
     if (should_clip_overflow) {
         context.recording_painter().restore();
         if (corner_clip_id.has_value()) {
-            context.recording_painter().blit_corner_clipping(*corner_clip_id, border_radius_clip_rect);
+            context.recording_painter().blit_corner_clipping(*corner_clip_id, clip_box.to_type<int>());
             corner_clip_id = {};
         }
     }

--- a/Userland/Libraries/LibWeb/Painting/RecordingPainter.cpp
+++ b/Userland/Libraries/LibWeb/Painting/RecordingPainter.cpp
@@ -29,13 +29,13 @@ void RecordingPainter::sample_under_corners(u32 id, CornerRadii corner_radii, Gf
     push_command(SampleUnderCorners {
         id,
         corner_radii,
-        border_rect,
+        border_rect = state().translation.map(border_rect),
         corner_clip });
 }
 
 void RecordingPainter::blit_corner_clipping(u32 id, Gfx::IntRect border_rect)
 {
-    push_command(BlitCornerClipping { id, border_rect });
+    push_command(BlitCornerClipping { id, border_rect = state().translation.map(border_rect) });
 }
 
 void RecordingPainter::fill_rect(Gfx::IntRect const& rect, Color color)
@@ -323,6 +323,7 @@ void RecordingPainter::apply_backdrop_filter(Gfx::IntRect const& backdrop_region
 
 void RecordingPainter::paint_outer_box_shadow_params(PaintOuterBoxShadowParams params)
 {
+    params.device_content_rect = state().translation.map(params.device_content_rect.to_type<int>()).to_type<DevicePixels>();
     push_command(PaintOuterBoxShadow {
         .outer_box_shadow_params = params,
     });

--- a/Userland/Libraries/LibWeb/Painting/RecordingPainter.h
+++ b/Userland/Libraries/LibWeb/Painting/RecordingPainter.h
@@ -498,6 +498,7 @@ public:
         m_state_stack.append(State());
     }
 
+private:
     struct State {
         Gfx::AffineTransform translation;
         Optional<Gfx::IntRect> clip_rect;
@@ -505,7 +506,6 @@ public:
     State& state() { return m_state_stack.last(); }
     State const& state() const { return m_state_stack.last(); }
 
-private:
     void push_command(PaintingCommand command)
     {
         m_painting_commands.append(command);

--- a/Userland/Libraries/LibWeb/Painting/ShadowPainting.cpp
+++ b/Userland/Libraries/LibWeb/Painting/ShadowPainting.cpp
@@ -564,7 +564,7 @@ void paint_box_shadow(PaintContext& context,
             .offset_y = offset_y,
             .blur_radius = blur_radius,
             .spread_distance = spread_distance,
-            .device_content_rect = context.recording_painter().state().translation.map(device_content_rect.to_type<int>()).to_type<DevicePixels>(),
+            .device_content_rect = device_content_rect,
         };
 
         if (box_shadow_data.placement == ShadowPlacement::Inner) {


### PR DESCRIPTION
Removes usage of `RecordingPainter::state()` and makes it private.

No behavior change intended.