### PR TITLE
LibWeb: Add missing paintable null check in get_bounding_client_rect()

### DIFF
--- a/Tests/LibWeb/Text/expected/get-bounding-client-rect-display-none.txt
+++ b/Tests/LibWeb/Text/expected/get-bounding-client-rect-display-none.txt
@@ -1,0 +1,1 @@
+   {"x":0,"y":0,"width":0,"height":0,"top":0,"right":0,"bottom":0,"left":0}

--- a/Tests/LibWeb/Text/input/get-bounding-client-rect-display-none.html
+++ b/Tests/LibWeb/Text/input/get-bounding-client-rect-display-none.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<style type="text/css">
+    #box { display: none; }
+</style>
+<div id="box"></div>
+<script src="include.js"></script>
+<script>
+    test(() => {
+        const rect = document.getElementById("box").getBoundingClientRect();
+        println(JSON.stringify(rect));
+    });
+</script>

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -852,7 +852,10 @@ JS::NonnullGCPtr<Geometry::DOMRect> Element::get_bounding_client_rect() const
         return Geometry::DOMRect::create(realm(), absolute_rect.to_type<float>());
     }
 
-    dbgln("FIXME: Failed to get bounding client rect for element ({})", debug_description());
+    if (paintable) {
+        dbgln("FIXME: Failed to get bounding client rect for element ({})", debug_description());
+    }
+
     return Geometry::DOMRect::construct_impl(realm(), 0, 0, 0, 0).release_value_but_fixme_should_propagate_errors();
 }
 

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -844,7 +844,8 @@ JS::NonnullGCPtr<Geometry::DOMRect> Element::get_bounding_client_rect() const
         return Geometry::DOMRect::create(realm(), absolute_rect.to_type<float>());
     }
 
-    if (auto const* paintable = this->paintable(); is<Painting::InlinePaintable>(*paintable)) {
+    auto const* paintable = this->paintable();
+    if (paintable && is<Painting::InlinePaintable>(*paintable)) {
         auto const& inline_paintable = static_cast<Painting::InlinePaintable const&>(*paintable);
         auto absolute_rect = inline_paintable.bounding_rect();
         absolute_rect.translate_by(-viewport_offset.x(), -viewport_offset.y());


### PR DESCRIPTION
Fixes crashing on https://github.com/