### PR TITLE
LibAccelGfx+LibWeb: Explicitly pass OpenGL context to Painter

### DIFF
--- a/Userland/Libraries/LibAccelGfx/Context.cpp
+++ b/Userland/Libraries/LibAccelGfx/Context.cpp
@@ -16,14 +16,6 @@
 
 namespace AccelGfx {
 
-Context& Context::the()
-{
-    static OwnPtr<Context> s_the;
-    if (!s_the)
-        s_the = Context::create();
-    return *s_the;
-}
-
 #ifdef AK_OS_MACOS
 static void make_context_cgl()
 {

--- a/Userland/Libraries/LibAccelGfx/Context.h
+++ b/Userland/Libraries/LibAccelGfx/Context.h
@@ -20,8 +20,6 @@ namespace AccelGfx {
 
 class Context {
 public:
-    static Context& the();
-
     static OwnPtr<Context> create();
 
     Context()

--- a/Userland/Libraries/LibAccelGfx/Painter.cpp
+++ b/Userland/Libraries/LibAccelGfx/Painter.cpp
@@ -170,9 +170,8 @@ void main() {
 
 HashMap<u32, GL::Texture> s_immutable_bitmap_texture_cache;
 
-NonnullOwnPtr<Painter> Painter::create()
+NonnullOwnPtr<Painter> Painter::create(Context& context)
 {
-    auto& context = Context::the();
     return make<Painter>(context);
 }
 

--- a/Userland/Libraries/LibAccelGfx/Painter.h
+++ b/Userland/Libraries/LibAccelGfx/Painter.h
@@ -29,7 +29,7 @@ class Painter {
     AK_MAKE_NONMOVABLE(Painter);
 
 public:
-    static NonnullOwnPtr<Painter> create();
+    static NonnullOwnPtr<Painter> create(Context&);
 
     Painter(Context&);
     ~Painter();

--- a/Userland/Libraries/LibAccelGfx/Painter.h
+++ b/Userland/Libraries/LibAccelGfx/Painter.h
@@ -29,9 +29,9 @@ class Painter {
     AK_MAKE_NONMOVABLE(Painter);
 
 public:
-    static NonnullOwnPtr<Painter> create(Context&);
+    static NonnullOwnPtr<Painter> create(Context&, NonnullRefPtr<Canvas>);
 
-    Painter(Context&);
+    Painter(Context&, NonnullRefPtr<Canvas>);
     ~Painter();
 
     void clear(Gfx::Color);
@@ -67,7 +67,6 @@ public:
     void set_clip_rect(Gfx::IntRect);
     void clear_clip_rect();
 
-    void set_target_canvas(NonnullRefPtr<Canvas>);
     void flush(Gfx::Bitmap&);
 
     void fill_rect_with_linear_gradient(Gfx::IntRect const&, ReadonlySpan<Gfx::ColorStop>, float angle, Optional<float> repeat_length = {});
@@ -110,7 +109,7 @@ private:
 
     Vector<State, 1> m_state_stack;
 
-    RefPtr<Canvas> m_target_canvas;
+    NonnullRefPtr<Canvas> m_target_canvas;
 
     Program m_rectangle_program;
     Program m_rounded_rectangle_program;

--- a/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorGPU.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorGPU.cpp
@@ -13,9 +13,8 @@ PaintingCommandExecutorGPU::PaintingCommandExecutorGPU(AccelGfx::Context& contex
     : m_target_bitmap(bitmap)
     , m_context(context)
 {
-    auto painter = AccelGfx::Painter::create(m_context);
     auto canvas = AccelGfx::Canvas::create(bitmap.size());
-    painter->set_target_canvas(canvas);
+    auto painter = AccelGfx::Painter::create(m_context, canvas);
     m_stacking_contexts.append({ .canvas = canvas,
         .painter = move(painter),
         .opacity = 1.0f,
@@ -115,9 +114,8 @@ CommandResult PaintingCommandExecutorGPU::push_stacking_context(float opacity, b
     final_transform.multiply(stacking_context_transform);
     final_transform.multiply(inverse_origin_translation);
     if (opacity < 1 || !stacking_context_transform.is_identity_or_translation()) {
-        auto painter = AccelGfx::Painter::create(m_context);
         auto canvas = AccelGfx::Canvas::create(source_paintable_rect.size());
-        painter->set_target_canvas(canvas);
+        auto painter = AccelGfx::Painter::create(m_context, canvas);
         painter->translate(-source_paintable_rect.location().to_type<float>());
         painter->clear(Color::Transparent);
         m_stacking_contexts.append({ .canvas = canvas,
@@ -169,8 +167,7 @@ CommandResult PaintingCommandExecutorGPU::paint_inner_box_shadow(PaintOuterBoxSh
 CommandResult PaintingCommandExecutorGPU::paint_text_shadow(int blur_radius, Gfx::IntRect const& shadow_bounding_rect, Gfx::IntRect const& text_rect, Span<Gfx::DrawGlyphOrEmoji const> glyph_run, Color const& color, int fragment_baseline, Gfx::IntPoint const& draw_location)
 {
     auto text_shadow_canvas = AccelGfx::Canvas::create(shadow_bounding_rect.size());
-    auto text_shadow_painter = AccelGfx::Painter::create(m_context);
-    text_shadow_painter->set_target_canvas(text_shadow_canvas);
+    auto text_shadow_painter = AccelGfx::Painter::create(m_context, text_shadow_canvas);
     text_shadow_painter->clear(color.with_alpha(0));
 
     Gfx::FloatRect const shadow_location { draw_location, shadow_bounding_rect.size() };
@@ -183,8 +180,7 @@ CommandResult PaintingCommandExecutorGPU::paint_text_shadow(int blur_radius, Gfx
     }
 
     auto horizontal_blur_canvas = AccelGfx::Canvas::create(shadow_bounding_rect.size());
-    auto horizontal_blur_painter = AccelGfx::Painter::create(m_context);
-    horizontal_blur_painter->set_target_canvas(horizontal_blur_canvas);
+    auto horizontal_blur_painter = AccelGfx::Painter::create(m_context, horizontal_blur_canvas);
     horizontal_blur_painter->clear(color.with_alpha(0));
     horizontal_blur_painter->blit_blurred_canvas(shadow_bounding_rect.to_type<float>(), *text_shadow_canvas, blur_radius, AccelGfx::Painter::BlurDirection::Horizontal);
     painter().blit_blurred_canvas(shadow_location, *horizontal_blur_canvas, blur_radius, AccelGfx::Painter::BlurDirection::Vertical);

--- a/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorGPU.h
+++ b/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorGPU.h
@@ -55,11 +55,12 @@ public:
     bool needs_update_immutable_bitmap_texture_cache() const override { return true; }
     void update_immutable_bitmap_texture_cache(HashMap<u32, Gfx::ImmutableBitmap const*>&) override;
 
-    PaintingCommandExecutorGPU(Gfx::Bitmap& bitmap);
+    PaintingCommandExecutorGPU(AccelGfx::Context&, Gfx::Bitmap& bitmap);
     ~PaintingCommandExecutorGPU() override;
 
 private:
     Gfx::Bitmap& m_target_bitmap;
+    AccelGfx::Context& m_context;
 
     struct StackingContext {
         RefPtr<AccelGfx::Canvas> canvas;

--- a/Userland/Services/WebContent/PageClient.cpp
+++ b/Userland/Services/WebContent/PageClient.cpp
@@ -55,6 +55,12 @@ PageClient::PageClient(PageHost& owner, u64 id)
         client().async_did_invalidate_content_rect({ m_invalidation_rect.x().value(), m_invalidation_rect.y().value(), m_invalidation_rect.width().value(), m_invalidation_rect.height().value() });
         m_invalidation_rect = {};
     });
+
+#ifdef HAS_ACCELERATED_GRAPHICS
+    if (s_use_gpu_painter) {
+        m_accelerated_graphics_context = AccelGfx::Context::create();
+    }
+#endif
 }
 
 void PageClient::visit_edges(JS::Cell::Visitor& visitor)
@@ -169,7 +175,7 @@ void PageClient::paint(Web::DevicePixelRect const& content_rect, Gfx::Bitmap& ta
 
     if (s_use_gpu_painter) {
 #ifdef HAS_ACCELERATED_GRAPHICS
-        Web::Painting::PaintingCommandExecutorGPU painting_command_executor(target);
+        Web::Painting::PaintingCommandExecutorGPU painting_command_executor(*m_accelerated_graphics_context, target);
         recording_painter.execute(painting_command_executor);
 #else
         static bool has_warned_about_configuration = false;

--- a/Userland/Services/WebContent/PageClient.h
+++ b/Userland/Services/WebContent/PageClient.h
@@ -14,6 +14,10 @@
 #include <LibWeb/PixelUnits.h>
 #include <WebContent/Forward.h>
 
+#ifdef HAS_ACCELERATED_GRAPHICS
+#    include <LibAccelGfx/Context.h>
+#endif
+
 namespace WebContent {
 
 class PageClient final : public Web::PageClient {
@@ -151,6 +155,10 @@ private:
     Web::CSS::PreferredColorScheme m_preferred_color_scheme { Web::CSS::PreferredColorScheme::Auto };
 
     RefPtr<WebDriverConnection> m_webdriver;
+
+#ifdef HAS_ACCELERATED_GRAPHICS
+    OwnPtr<AccelGfx::Context> m_accelerated_graphics_context;
+#endif
 };
 
 }


### PR DESCRIPTION
Let's not assume there is one global OpenGL context because it might
change once we will start creating >1 page inside single WebContent
process or contexts for WebGL.