### PR TITLE
Kernel/riscv64: Specify correct alignment for `FPUState` struct

### DIFF
--- a/Kernel/Arch/riscv64/FPUState.h
+++ b/Kernel/Arch/riscv64/FPUState.h
@@ -13,7 +13,9 @@ VALIDATE_IS_RISCV64()
 
 namespace Kernel {
 
-struct FPUState {
+// This struct will get pushed on the stack by the signal handling code.
+// Therefore, it has to be aligned to a 16-byte boundary.
+struct [[gnu::aligned(16)]] FPUState {
     u64 f[32];
     u64 fcsr;
 };


### PR DESCRIPTION
The [signal handling code](https://github.com/SerenityOS/serenity/blob/master/Kernel/Tasks/Process.cpp#L465) (and possibly other code as well) expects this struct to have an alignment of 16 bytes, as it pushes this struct on the stack.

Other architectures already specify the correct alignment, I just probably missed that when I first added this struct.