### PR TITLE
LibWeb: Queue a task to proceed after module map entry finishes fetching

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/Scripting/ModuleMap.h
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/ModuleMap.h
@@ -72,6 +72,8 @@ private:
 
     HashMap<ModuleLocationTuple, Entry> m_values;
     HashMap<ModuleLocationTuple, Vector<CallbackFunction>> m_callbacks;
+
+    bool m_firing_callbacks { false };
 };
 
 }


### PR DESCRIPTION
We were doing this synchronously, which was unsafe in that caused us to re-enter the module map entry setting code while iterating over the map's entries.

The fix is simply to do what the spec says and queue up a task. This way the processing gets deferred to a later time.

To avoid stepping into this problem again, I've also added a reentrancy check in ModuleMap.

This fixes a sporadic crash in HTML::ModuleMap::add() caught by ASAN. In particular, this was happening regularly on https://shopify.com/