### PR TITLE
LibGfx/TIFF: Work on image with more channels (including some transparency support)

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/TIFFLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/TIFFLoader.cpp
@@ -89,14 +89,15 @@ private:
     ErrorOr<Color> read_color(BigEndianInputBitStream& stream)
     {
         auto bits_per_sample = *m_metadata.bits_per_sample();
-        if (m_metadata.samples_per_pixel().value_or(3) == 3) {
+        if (m_metadata.photometric_interpretation() == PhotometricInterpretation::RGB) {
             auto const first_component = TRY(read_component(stream, bits_per_sample[0]));
             auto const second_component = TRY(read_component(stream, bits_per_sample[1]));
             auto const third_component = TRY(read_component(stream, bits_per_sample[2]));
             return Color(first_component, second_component, third_component);
         }
 
-        if (*m_metadata.samples_per_pixel() == 1) {
+        if (*m_metadata.photometric_interpretation() == PhotometricInterpretation::WhiteIsZero
+            || *m_metadata.photometric_interpretation() == PhotometricInterpretation::BlackIsZero) {
             auto luminosity = TRY(read_component(stream, bits_per_sample[0]));
 
             if (m_metadata.photometric_interpretation() == PhotometricInterpretation::WhiteIsZero)
@@ -105,7 +106,7 @@ private:
             return Color(luminosity, luminosity, luminosity);
         }
 
-        return Error::from_string_literal("Unsupported number of sample per pixel");
+        return Error::from_string_literal("Unsupported value for PhotometricInterpretation");
     }
 
     template<CallableAs<ErrorOr<ReadonlyBytes>, u32> StripDecoder>

--- a/Userland/Libraries/LibGfx/TIFFGenerator.py
+++ b/Userland/Libraries/LibGfx/TIFFGenerator.py
@@ -61,6 +61,12 @@ class PhotometricInterpretation(EnumWithExportName):
     CIELab = 8
 
 
+class ExtraSample(EnumWithExportName):
+    Unspecified = 0
+    AssociatedAlpha = 1
+    UnassociatedAlpha = 2
+
+
 tag_fields = ['id', 'types', 'counts', 'default', 'name', 'associated_enum']
 
 Tag = namedtuple(
@@ -81,6 +87,7 @@ known_tags: List[Tag] = [
     Tag('278', [TIFFType.UnsignedShort, TIFFType.UnsignedLong], [1], None, "RowsPerStrip"),
     Tag('279', [TIFFType.UnsignedShort, TIFFType.UnsignedLong], [], None, "StripByteCounts"),
     Tag('317', [TIFFType.UnsignedShort], [1], Predictor.NoPrediction, "Predictor", Predictor),
+    Tag('338', [TIFFType.UnsignedShort], [], None, "ExtraSamples", ExtraSample),
     Tag('34675', [TIFFType.Undefined], [], None, "ICCProfile"),
 ]
 

--- a/Userland/Libraries/LibGfx/TIFFGenerator.py
+++ b/Userland/Libraries/LibGfx/TIFFGenerator.py
@@ -9,7 +9,7 @@ import re
 from enum import Enum
 from collections import namedtuple
 from pathlib import Path
-from typing import List, Optional, Type
+from typing import List, Type
 
 
 class EnumWithExportName(Enum):
@@ -96,7 +96,7 @@ LICENSE = R"""/*
  */"""
 
 
-def export_enum_to_cpp(e: Type[EnumWithExportName], special_name: Optional[str] = None) -> str:
+def export_enum_to_cpp(e: Type[EnumWithExportName]) -> str:
     output = f'enum class {e.export_name()} {{\n'
 
     for entry in e:


### PR DESCRIPTION
The TIFF specification, says that images with more channels than expected should still be interpreted as their PhotometricInterpretation dictate. In other words, let's skip all unexpected channels. This PR implements this logic to stop crashing on `strike.tif` and then implements support for AssociatedAlpha.

![Screenshot from 2023-12-16 21-25-09](https://github.com/SerenityOS/serenity/assets/26030965/a96884c6-9d23-47f5-8d29-e8d494a3f536)
