### PR TITLE
Documentation: Added llvm dependency to Arch Linux

### DIFF
--- a/Documentation/BuildInstructions.md
+++ b/Documentation/BuildInstructions.md
@@ -65,7 +65,7 @@ for details.
 ### Arch Linux / Manjaro
 
 ```console
-sudo pacman -S --needed base-devel cmake curl mpfr libmpc gmp e2fsprogs ninja qemu-desktop qemu-system-aarch64 ccache rsync unzip
+sudo pacman -S --needed base-devel cmake curl mpfr libmpc gmp e2fsprogs llvm ninja qemu-desktop qemu-system-aarch64 ccache rsync unzip
 ```
 Optional: `fuse2fs` for [building images without root](https://github.com/SerenityOS/serenity/pull/11224).
 

--- a/Documentation/BuildInstructionsLadybird.md
+++ b/Documentation/BuildInstructionsLadybird.md
@@ -21,7 +21,7 @@ sudo apt install qt6-wayland
 On Arch Linux/Manjaro:
 
 ```
-sudo pacman -S --needed base-devel cmake libgl ninja qt6-base qt6-tools qt6-wayland qt6-multimedia ccache
+sudo pacman -S --needed base-devel cmake libgl llvm ninja qt6-base qt6-tools qt6-wayland qt6-multimedia ccache
 ```
 
 On Fedora or derivatives:


### PR DESCRIPTION
Prevents an error complaining about missing llvm-ar when trying to build lagom:
```
$ Meta/serenity.sh rebuild-toolchain
...
$ Meta/serenity.sh build
[0/10] Performing build step for 'lagom'
[0/2] Re-checking globbed directories...
[2/2819] Linking CXX static library lib/liblagom-main.a
FAILED: lib/liblagom-main.a 
: && /usr/bin/cmake -E rm -f lib/liblagom-main.a && /usr/bin/llvm-ar qc lib/liblagom-main.a  Userland/Libraries/LibMain/CMakeFiles/LibMain.dir/Main.cpp.o && /usr/bin/llvm-ranlib lib/liblagom-main.a && :
/bin/sh: line 1: /usr/bin/llvm-ar: No such file or directory
```