### PR TITLE
LibWeb: Implement border radius corner clipping in GPU painter 

### DIFF
--- a/Userland/Libraries/LibAccelGfx/GL.cpp
+++ b/Userland/Libraries/LibAccelGfx/GL.cpp
@@ -30,6 +30,8 @@ static GLenum to_gl_enum(BlendFactor factor)
         return GL_SRC_ALPHA;
     case BlendFactor::One:
         return GL_ONE;
+    case BlendFactor::Zero:
+        return GL_ZERO;
     case BlendFactor::OneMinusSrcAlpha:
         return GL_ONE_MINUS_SRC_ALPHA;
     }

--- a/Userland/Libraries/LibAccelGfx/GL.h
+++ b/Userland/Libraries/LibAccelGfx/GL.h
@@ -61,6 +61,7 @@ struct Framebuffer {
 void set_viewport(Gfx::IntRect);
 
 enum class BlendFactor {
+    Zero,
     One,
     OneMinusSrcAlpha,
     SrcAlpha,

--- a/Userland/Libraries/LibAccelGfx/Painter.h
+++ b/Userland/Libraries/LibAccelGfx/Painter.h
@@ -34,6 +34,8 @@ public:
     Painter(Context&, NonnullRefPtr<Canvas>);
     ~Painter();
 
+    Canvas const& canvas() { return *m_target_canvas; }
+
     void clear(Gfx::Color);
 
     void save();
@@ -51,6 +53,12 @@ public:
     enum class ScalingMode {
         NearestNeighbor,
         Bilinear,
+    };
+
+    enum class BlendingMode {
+        AlphaAdd,
+        AlphaOverride,
+        AlphaPreserve,
     };
 
     void draw_line(Gfx::IntPoint a, Gfx::IntPoint b, float thickness, Gfx::Color color);
@@ -76,11 +84,12 @@ public:
         float horizontal_radius;
         float vertical_radius;
     };
-    void fill_rect_with_rounded_corners(Gfx::IntRect const& rect, Color const& color, CornerRadius const& top_left_radius, CornerRadius const& top_right_radius, CornerRadius const& bottom_left_radius, CornerRadius const& bottom_right_radius);
-    void fill_rect_with_rounded_corners(Gfx::FloatRect const& rect, Color const& color, CornerRadius const& top_left_radius, CornerRadius const& top_right_radius, CornerRadius const& bottom_left_radius, CornerRadius const& bottom_right_radius);
+    void fill_rect_with_rounded_corners(Gfx::IntRect const& rect, Color const& color, CornerRadius const& top_left_radius, CornerRadius const& top_right_radius, CornerRadius const& bottom_left_radius, CornerRadius const& bottom_right_radius, BlendingMode = BlendingMode::AlphaAdd);
+    void fill_rect_with_rounded_corners(Gfx::FloatRect const& rect, Color const& color, CornerRadius const& top_left_radius, CornerRadius const& top_right_radius, CornerRadius const& bottom_left_radius, CornerRadius const& bottom_right_radius, BlendingMode = BlendingMode::AlphaAdd);
 
     void blit_canvas(Gfx::IntRect const& dst_rect, Canvas const&, float opacity = 1.0f, Optional<Gfx::AffineTransform> affine_transform = {});
     void blit_canvas(Gfx::FloatRect const& dst_rect, Canvas const&, float opacity = 1.0f, Optional<Gfx::AffineTransform> affine_transform = {});
+    void blit_canvas(Gfx::FloatRect const& dst_rect, Canvas const&, Gfx::FloatRect const& src_rect, float opacity = 1.0f, Optional<Gfx::AffineTransform> affine_transform = {}, BlendingMode = BlendingMode::AlphaAdd);
 
     enum class BlurDirection {
         Horizontal,
@@ -101,7 +110,7 @@ private:
     [[nodiscard]] State& state() { return m_state_stack.last(); }
     [[nodiscard]] State const& state() const { return m_state_stack.last(); }
 
-    void blit_scaled_texture(Gfx::FloatRect const& dst_rect, GL::Texture const&, Gfx::FloatRect const& src_rect, ScalingMode, float opacity = 1.0f, Optional<Gfx::AffineTransform> affine_transform = {});
+    void blit_scaled_texture(Gfx::FloatRect const& dst_rect, GL::Texture const&, Gfx::FloatRect const& src_rect, ScalingMode, float opacity = 1.0f, Optional<Gfx::AffineTransform> affine_transform = {}, BlendingMode = BlendingMode::AlphaAdd);
     void blit_blurred_texture(Gfx::FloatRect const& dst_rect, GL::Texture const&, Gfx::FloatRect const& src_rect, int radius, BlurDirection direction, ScalingMode = ScalingMode::NearestNeighbor);
     void bind_target_canvas();
 

--- a/Userland/Libraries/LibWeb/Painting/BorderRadiusCornerClipper.h
+++ b/Userland/Libraries/LibWeb/Painting/BorderRadiusCornerClipper.h
@@ -16,6 +16,21 @@ enum class CornerClip {
     Inside
 };
 
+struct BorderRadiusSamplingConfig {
+    CornerRadii corner_radii;
+    struct CornerLocations {
+        Gfx::IntPoint top_left;
+        Gfx::IntPoint top_right;
+        Gfx::IntPoint bottom_right;
+        Gfx::IntPoint bottom_left;
+    };
+    CornerLocations page_locations;
+    CornerLocations bitmap_locations;
+    Gfx::IntSize corners_bitmap_size;
+};
+
+BorderRadiusSamplingConfig calculate_border_radius_sampling_config(CornerRadii const& corner_radii, Gfx::IntRect const& border_rect);
+
 class BorderRadiusCornerClipper : public RefCounted<BorderRadiusCornerClipper> {
 public:
     static ErrorOr<NonnullRefPtr<BorderRadiusCornerClipper>> create(CornerRadii const&, DevicePixelRect const& border_rect, CornerClip corner_clip = CornerClip::Outside);
@@ -23,22 +38,12 @@ public:
     void sample_under_corners(Gfx::Painter& page_painter);
     void blit_corner_clipping(Gfx::Painter& page_painter);
 
-    struct CornerData {
-        CornerRadii corner_radii;
-        struct CornerLocations {
-            DevicePixelPoint top_left;
-            DevicePixelPoint top_right;
-            DevicePixelPoint bottom_right;
-            DevicePixelPoint bottom_left;
-        };
-        CornerLocations page_locations;
-        CornerLocations bitmap_locations;
-    } m_data;
+    BorderRadiusSamplingConfig m_data;
 
     DevicePixelRect border_rect() const { return m_border_rect; }
 
-    BorderRadiusCornerClipper(CornerData corner_data, NonnullRefPtr<Gfx::Bitmap> corner_bitmap, CornerClip corner_clip, DevicePixelRect const& border_rect)
-        : m_data(move(corner_data))
+    BorderRadiusCornerClipper(BorderRadiusSamplingConfig corner_data, NonnullRefPtr<Gfx::Bitmap> corner_bitmap, CornerClip corner_clip, DevicePixelRect const& border_rect)
+        : m_data(corner_data)
         , m_corner_bitmap(corner_bitmap)
         , m_corner_clip(corner_clip)
         , m_border_rect(border_rect)

--- a/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorGPU.h
+++ b/Userland/Libraries/LibWeb/Painting/PaintingCommandExecutorGPU.h
@@ -71,10 +71,25 @@ private:
         int stacking_context_depth { 0 };
     };
 
+    struct BorderRadiusCornerClipper {
+        RefPtr<AccelGfx::Canvas> corners_sample_canvas;
+
+        Gfx::FloatRect page_top_left_rect;
+        Gfx::FloatRect page_top_right_rect;
+        Gfx::FloatRect page_bottom_right_rect;
+        Gfx::FloatRect page_bottom_left_rect;
+
+        Gfx::FloatRect sample_canvas_top_left_rect;
+        Gfx::FloatRect sample_canvas_top_right_rect;
+        Gfx::FloatRect sample_canvas_bottom_right_rect;
+        Gfx::FloatRect sample_canvas_bottom_left_rect;
+    };
+
     [[nodiscard]] AccelGfx::Painter const& painter() const { return *m_stacking_contexts.last().painter; }
     [[nodiscard]] AccelGfx::Painter& painter() { return *m_stacking_contexts.last().painter; }
 
     Vector<StackingContext> m_stacking_contexts;
+    Vector<OwnPtr<BorderRadiusCornerClipper>> m_corner_clippers;
 };
 
 }


### PR DESCRIPTION
It is implemented in the way identical to how it works in CPU painter:
1. SampleUnderCorners command saves pixels within corners into a
   texture.
2. BlitCornerClipping command uses the texture prepared earlier to
   restore pixels within corners.
