### PR TITLE
LibWeb: Scroll to "nearest" instead of "start" in set_focused_element()

### DIFF
--- a/Tests/LibWeb/Text/expected/scroll-into-view-end.txt
+++ b/Tests/LibWeb/Text/expected/scroll-into-view-end.txt
@@ -1,0 +1,1 @@
+    The page has been scrolled to y: 600

--- a/Tests/LibWeb/Text/expected/scroll-into-view-start.txt
+++ b/Tests/LibWeb/Text/expected/scroll-into-view-start.txt
@@ -1,0 +1,1 @@
+    The page has been scrolled to y: 1000

--- a/Tests/LibWeb/Text/input/scroll-into-view-end.html
+++ b/Tests/LibWeb/Text/input/scroll-into-view-end.html
@@ -1,0 +1,29 @@
+<script src="include.js"></script>
+<style>
+    body {
+        margin: 0;
+    }
+
+    #box {
+        width: 200px;
+        height: 200px;
+        background-color: magenta;
+    }
+</style>
+<div style="height: 1000px"></div>
+<div style="margin-left: 500px" onclick="clickHandler(event)" id="box"></div>
+<div style="height: 1000px"></div>
+<script>
+    function clickHandler(event) {
+        document.getElementById("box").scrollIntoView({ block: "end" });
+    }
+
+    asyncTest(done => {
+        document.addEventListener("scroll", event => {
+            println("The page has been scrolled to y: " + window.scrollY);
+            done();
+        });
+
+        document.getElementById("box").dispatchEvent(new Event("click"));
+    });
+</script>

--- a/Tests/LibWeb/Text/input/scroll-into-view-start.html
+++ b/Tests/LibWeb/Text/input/scroll-into-view-start.html
@@ -1,0 +1,29 @@
+<script src="include.js"></script>
+<style>
+    body {
+        margin: 0;
+    }
+
+    #box {
+        width: 200px;
+        height: 200px;
+        background-color: magenta;
+    }
+</style>
+<div style="height: 1000px"></div>
+<div style="margin-left: 500px" onclick="clickHandler(event)" id="box"></div>
+<div style="height: 1000px"></div>
+<script>
+    function clickHandler(event) {
+        document.getElementById("box").scrollIntoView({ block: "start" });
+    }
+
+    asyncTest(done => {
+        document.addEventListener("scroll", event => {
+            println("The page has been scrolled to y: " + window.scrollY);
+            done();
+        });
+
+        document.getElementById("box").dispatchEvent(new Event("click"));
+    });
+</script>

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -1700,8 +1700,12 @@ void Document::set_focused_element(Element* element)
         m_layout_root->set_needs_display();
 
     // Scroll the viewport if necessary to make the newly focused element visible.
-    if (m_focused_element)
-        (void)m_focused_element->scroll_into_view();
+    if (m_focused_element) {
+        ScrollIntoViewOptions scroll_options;
+        scroll_options.block = Bindings::ScrollLogicalPosition::Nearest;
+        scroll_options.inline_ = Bindings::ScrollLogicalPosition::Nearest;
+        (void)m_focused_element->scroll_into_view(scroll_options);
+    }
 }
 
 void Document::set_active_element(Element* element)

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -255,7 +255,6 @@ public:
     virtual void page_did_layout() { }
     virtual void page_did_request_scroll(i32, i32) { }
     virtual void page_did_request_scroll_to(CSSPixelPoint) { }
-    virtual void page_did_request_scroll_into_view(CSSPixelRect const&) { }
     virtual void page_did_request_alert(String const&) { }
     virtual void page_did_request_confirm(String const&) { }
     virtual void page_did_request_prompt(String const&, String const&) { }

--- a/Userland/Libraries/LibWebView/WebContentClient.cpp
+++ b/Userland/Libraries/LibWebView/WebContentClient.cpp
@@ -125,13 +125,6 @@ void WebContentClient::did_request_scroll_to(Gfx::IntPoint scroll_position)
         m_view.on_scroll_to_point(scroll_position);
 }
 
-void WebContentClient::did_request_scroll_into_view(Gfx::IntRect const& rect)
-{
-    dbgln_if(SPAM_DEBUG, "handle: WebContentClient::DidRequestScrollIntoView! rect={}", rect);
-    if (m_view.on_scroll_into_view)
-        m_view.on_scroll_into_view(rect);
-}
-
 void WebContentClient::did_enter_tooltip_area(Gfx::IntPoint content_position, ByteString const& title)
 {
     if (m_view.on_enter_tooltip_area)

--- a/Userland/Libraries/LibWebView/WebContentClient.h
+++ b/Userland/Libraries/LibWebView/WebContentClient.h
@@ -42,7 +42,6 @@ private:
     virtual void did_change_title(ByteString const&) override;
     virtual void did_request_scroll(i32, i32) override;
     virtual void did_request_scroll_to(Gfx::IntPoint) override;
-    virtual void did_request_scroll_into_view(Gfx::IntRect const&) override;
     virtual void did_enter_tooltip_area(Gfx::IntPoint, ByteString const&) override;
     virtual void did_leave_tooltip_area() override;
     virtual void did_hover_link(AK::URL const&) override;

--- a/Userland/Services/WebContent/PageClient.cpp
+++ b/Userland/Services/WebContent/PageClient.cpp
@@ -285,15 +285,6 @@ void PageClient::page_did_request_scroll_to(Web::CSSPixelPoint scroll_position)
     client().async_did_request_scroll_to(device_scroll_position.to_type<int>());
 }
 
-void PageClient::page_did_request_scroll_into_view(Web::CSSPixelRect const& rect)
-{
-    auto device_pixel_rect = page().enclosing_device_rect(rect);
-    client().async_did_request_scroll_into_view({ device_pixel_rect.x().value(),
-        device_pixel_rect.y().value(),
-        device_pixel_rect.width().value(),
-        device_pixel_rect.height().value() });
-}
-
 void PageClient::page_did_enter_tooltip_area(Web::CSSPixelPoint content_position, ByteString const& title)
 {
     client().async_did_enter_tooltip_area({ content_position.x().to_int(), content_position.y().to_int() }, title);

--- a/Userland/Services/WebContent/PageClient.h
+++ b/Userland/Services/WebContent/PageClient.h
@@ -90,7 +90,6 @@ private:
     virtual Gfx::IntRect page_did_request_fullscreen_window() override;
     virtual void page_did_request_scroll(i32, i32) override;
     virtual void page_did_request_scroll_to(Web::CSSPixelPoint) override;
-    virtual void page_did_request_scroll_into_view(Web::CSSPixelRect const&) override;
     virtual void page_did_enter_tooltip_area(Web::CSSPixelPoint, ByteString const&) override;
     virtual void page_did_leave_tooltip_area() override;
     virtual void page_did_hover_link(const URL&) override;

--- a/Userland/Services/WebContent/WebContentClient.ipc
+++ b/Userland/Services/WebContent/WebContentClient.ipc
@@ -25,7 +25,6 @@ endpoint WebContentClient
     did_change_title(ByteString title) =|
     did_request_scroll(i32 x_delta, i32 y_delta) =|
     did_request_scroll_to(Gfx::IntPoint scroll_position) =|
-    did_request_scroll_into_view(Gfx::IntRect rect) =|
     did_enter_tooltip_area(Gfx::IntPoint content_position, ByteString title) =|
     did_leave_tooltip_area() =|
     did_hover_link(URL url) =|

--- a/Userland/Utilities/headless-browser.cpp
+++ b/Userland/Utilities/headless-browser.cpp
@@ -109,7 +109,22 @@ public:
     }
 
 private:
-    HeadlessWebContentView() = default;
+    HeadlessWebContentView()
+    {
+        on_scroll_to_point = [this](auto position) {
+            auto new_viewport_rect = m_viewport_rect;
+            new_viewport_rect.set_location(position);
+            client().async_set_viewport_rect(new_viewport_rect.to_type<Web::DevicePixels>());
+        };
+
+        on_scroll_by_delta = [this](auto x_delta, auto y_delta) {
+            auto position = m_viewport_rect.location();
+            position.set_x(position.x() + x_delta);
+            position.set_y(position.y() + y_delta);
+            if (on_scroll_to_point)
+                on_scroll_to_point(position);
+        };
+    }
 
     void update_zoom() override { }
     void create_client() override { }


### PR DESCRIPTION
Fixes a bug when after clicking on a button/click the page is scrolled to start of the element.
