### PR TITLE
LibJS+LibWeb: Add JS::Value constructor for ``JS::Handle<T>``

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -1707,7 +1707,7 @@ static void generate_wrap_statement(SourceGenerator& generator, ByteString const
 )~~~");
     } else if (type.name() == "ArrayBufferView" || type.name() == "BufferSource") {
         scoped_generator.append(R"~~~(
-    @result_expression@ JS::Value(const_cast<JS::Object*>(@value@->raw_object().ptr()));
+    @result_expression@ JS::Value(@value@->raw_object());
 )~~~");
     } else if (is<IDL::UnionType>(type)) {
         auto& union_type = verify_cast<IDL::UnionType>(type);

--- a/Userland/Libraries/LibJS/Runtime/Value.h
+++ b/Userland/Libraries/LibJS/Runtime/Value.h
@@ -287,6 +287,12 @@ public:
     {
     }
 
+    template<typename T>
+    Value(Handle<T> const& ptr)
+        : Value(ptr.ptr())
+    {
+    }
+
     double as_double() const
     {
         VERIFY(is_number());

--- a/Userland/Libraries/LibWeb/HTML/MessageEvent.cpp
+++ b/Userland/Libraries/LibWeb/HTML/MessageEvent.cpp
@@ -59,7 +59,7 @@ JS::NonnullGCPtr<JS::Object> MessageEvent::ports() const
     if (!m_ports_array) {
         Vector<JS::Value> port_vector;
         for (auto const& port : m_ports) {
-            port_vector.append(JS::Value(port.ptr()));
+            port_vector.append(port);
         }
         m_ports_array = JS::Array::create_from(realm(), port_vector);
         MUST(m_ports_array->set_integrity_level(IntegrityLevel::Frozen));

--- a/Userland/Libraries/LibWeb/HTML/StructuredSerialize.cpp
+++ b/Userland/Libraries/LibWeb/HTML/StructuredSerialize.cpp
@@ -942,7 +942,7 @@ WebIDL::ExceptionOr<SerializedTransferRecord> structured_serialize_with_transfer
         // FIXME: 2. If transferable has an [[ArrayBufferData]] internal slot and IsSharedArrayBuffer(transferable) is true, then throw a "DataCloneError" DOMException.
 
         // 3. If memory[transferable] exists, then throw a "DataCloneError" DOMException.
-        auto transferable_value = JS::Value(transferable.ptr());
+        auto transferable_value = JS::Value(transferable);
         if (memory.contains(transferable_value)) {
             return WebIDL::DataCloneError::create(*vm.current_realm(), "Cannot transfer value twice"_fly_string);
         }

--- a/Userland/Libraries/LibWeb/Streams/ReadableStream.cpp
+++ b/Userland/Libraries/LibWeb/Streams/ReadableStream.cpp
@@ -28,7 +28,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<ReadableStream>> ReadableStream::construct_
     auto readable_stream = realm.heap().allocate<ReadableStream>(realm, realm);
 
     // 1. If underlyingSource is missing, set it to null.
-    auto underlying_source = underlying_source_object.has_value() ? JS::Value(underlying_source_object.value().ptr()) : JS::js_null();
+    auto underlying_source = underlying_source_object.has_value() ? JS::Value(underlying_source_object.value()) : JS::js_null();
 
     // 2. Let underlyingSourceDict be underlyingSource, converted to an IDL value of type UnderlyingSource.
     auto underlying_source_dict = TRY(UnderlyingSource::from_value(vm, underlying_source));

--- a/Userland/Libraries/LibWeb/Streams/TransformStream.cpp
+++ b/Userland/Libraries/LibWeb/Streams/TransformStream.cpp
@@ -25,7 +25,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<TransformStream>> TransformStream::construc
     auto stream = realm.heap().allocate<TransformStream>(realm, realm);
 
     // 1. If transformer is missing, set it to null.
-    auto transformer = transformer_object.has_value() ? JS::Value { transformer_object.value().ptr() } : JS::js_null();
+    auto transformer = transformer_object.has_value() ? JS::Value { transformer_object.value() } : JS::js_null();
 
     // 2. Let transformerDict be transformer, converted to an IDL value of type Transformer.
     auto transformer_dict = TRY(Transformer::from_value(vm, transformer));

--- a/Userland/Libraries/LibWeb/Streams/WritableStream.cpp
+++ b/Userland/Libraries/LibWeb/Streams/WritableStream.cpp
@@ -26,7 +26,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<WritableStream>> WritableStream::construct_
     auto writable_stream = realm.heap().allocate<WritableStream>(realm, realm);
 
     // 1. If underlyingSink is missing, set it to null.
-    auto underlying_sink = underlying_sink_object.has_value() ? JS::Value(underlying_sink_object.value().ptr()) : JS::js_null();
+    auto underlying_sink = underlying_sink_object.has_value() ? JS::Value(underlying_sink_object.value()) : JS::js_null();
 
     // 2. Let underlyingSinkDict be underlyingSink, converted to an IDL value of type UnderlyingSink.
     auto underlying_sink_dict = TRY(UnderlyingSink::from_value(vm, underlying_sink));

--- a/Userland/Libraries/LibWeb/WebIDL/DOMException.h
+++ b/Userland/Libraries/LibWeb/WebIDL/DOMException.h
@@ -133,7 +133,7 @@ namespace Web {
 
 inline JS::Completion throw_completion(JS::NonnullGCPtr<WebIDL::DOMException> exception)
 {
-    return JS::throw_completion(JS::Value(static_cast<JS::Object*>(exception.ptr())));
+    return JS::throw_completion(JS::Value(exception));
 }
 
 }


### PR DESCRIPTION
Similar to the constructors for ``JS::{Nonnull}GCPtr<T>``, this helper avoids unnecessary .ptr() clutter when we want to construct Values.