### PR TITLE
LibPDF+Tests: Add a PDF rendering test

### DIFF
--- a/Tests/LibPDF/CMakeLists.txt
+++ b/Tests/LibPDF/CMakeLists.txt
@@ -3,7 +3,7 @@ set(TEST_SOURCES
 )
 
 foreach(source IN LISTS TEST_SOURCES)
-    serenity_test("${source}" LibPDF LIBS LibCore LibPDF)
+    serenity_test("${source}" LibPDF LIBS LibCore LibGfx LibPDF)
 endforeach()
 
 set(TEST_FILES

--- a/Userland/Libraries/LibPDF/ColorSpace.cpp
+++ b/Userland/Libraries/LibPDF/ColorSpace.cpp
@@ -302,6 +302,9 @@ constexpr Array<float, 3> convert_to_srgb(Array<float, 3> xyz)
     };
 
     auto linear_srgb = matrix_multiply(conversion_matrix, xyz);
+    linear_srgb[0] = clamp(linear_srgb[0], 0.0f, 1.0f);
+    linear_srgb[1] = clamp(linear_srgb[1], 0.0f, 1.0f);
+    linear_srgb[2] = clamp(linear_srgb[2], 0.0f, 1.0f);
 
     // FIXME: Use the real sRGB curve by replacing this function with Gfx::ICC::sRGB().from_pcs().
     return { pow(linear_srgb[0], 1.0f / 2.2f), pow(linear_srgb[1], 1.0f / 2.2f), pow(linear_srgb[2], 1.0f / 2.2f) };


### PR DESCRIPTION
Having some rendering test coverage is motivated by #22362, but this
test wouldn't have found the crashes over there (since colorspaces.pdf
does not contain pattern color spaces). Still, good to have some
in-repo test coverage of PDF rendering.

Also fix an UBSan report that the test produced.
(I think it's relatively benign in practice.)