### PR TITLE
LibGfx/TIFF: Discard extra channels

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/TIFFLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/TIFFLoader.cpp
@@ -90,14 +90,15 @@ private:
     ErrorOr<Color> read_color(BigEndianInputBitStream& stream)
     {
         auto bits_per_sample = *m_metadata.bits_per_sample();
-        if (m_metadata.samples_per_pixel().value_or(3) == 3) {
+        if (m_metadata.photometric_interpretation() == PhotometricInterpretation::RGB) {
             auto const first_component = TRY(read_component(stream, bits_per_sample[0]));
             auto const second_component = TRY(read_component(stream, bits_per_sample[1]));
             auto const third_component = TRY(read_component(stream, bits_per_sample[2]));
             return Color(first_component, second_component, third_component);
         }
 
-        if (*m_metadata.samples_per_pixel() == 1) {
+        if (*m_metadata.photometric_interpretation() == PhotometricInterpretation::WhiteIsZero
+            || *m_metadata.photometric_interpretation() == PhotometricInterpretation::BlackIsZero) {
             auto luminosity = TRY(read_component(stream, bits_per_sample[0]));
 
             if (m_metadata.photometric_interpretation() == PhotometricInterpretation::WhiteIsZero)
@@ -106,7 +107,7 @@ private:
             return Color(luminosity, luminosity, luminosity);
         }
 
-        return Error::from_string_literal("Unsupported number of sample per pixel");
+        return Error::from_string_literal("Unsupported value for PhotometricInterpretation");
     }
 
     template<CallableAs<ErrorOr<ReadonlyBytes>, u32> StripDecoder>

--- a/Userland/Libraries/LibGfx/ImageFormats/TIFFLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/TIFFLoader.cpp
@@ -87,13 +87,38 @@ private:
         return NumericLimits<u8>::max() * value / ((1 << bits) - 1);
     }
 
+    u8 samples_for_photometric_interpretation() const
+    {
+        switch (*m_metadata.photometric_interpretation()) {
+        case PhotometricInterpretation::WhiteIsZero:
+        case PhotometricInterpretation::BlackIsZero:
+            return 1;
+        case PhotometricInterpretation::RGB:
+            return 3;
+        default:
+            TODO();
+        }
+    }
+
     ErrorOr<Color> read_color(BigEndianInputBitStream& stream)
     {
         auto bits_per_sample = *m_metadata.bits_per_sample();
+
+        // Section 7: Additional Baseline TIFF Requirements
+        // Some TIFF files may have more components per pixel than you think. A Baseline TIFF reader must skip over
+        // them gracefully, using the values of the SamplesPerPixel and BitsPerSample fields.
+        auto discard_unknown_channels = [&]() -> ErrorOr<void> {
+            auto const unknown_channels = *m_metadata.samples_per_pixel() - samples_for_photometric_interpretation();
+            for (u8 i = bits_per_sample.size() - unknown_channels; i < bits_per_sample.size(); ++i)
+                TRY(read_component(stream, bits_per_sample[i]));
+            return {};
+        };
+
         if (m_metadata.photometric_interpretation() == PhotometricInterpretation::RGB) {
             auto const first_component = TRY(read_component(stream, bits_per_sample[0]));
             auto const second_component = TRY(read_component(stream, bits_per_sample[1]));
             auto const third_component = TRY(read_component(stream, bits_per_sample[2]));
+            TRY(discard_unknown_channels());
             return Color(first_component, second_component, third_component);
         }
 
@@ -104,6 +129,7 @@ private:
             if (m_metadata.photometric_interpretation() == PhotometricInterpretation::WhiteIsZero)
                 luminosity = ~luminosity;
 
+            TRY(discard_unknown_channels());
             return Color(luminosity, luminosity, luminosity);
         }
 

--- a/Userland/Libraries/LibGfx/TIFFGenerator.py
+++ b/Userland/Libraries/LibGfx/TIFFGenerator.py
@@ -9,7 +9,7 @@ import re
 from enum import Enum
 from collections import namedtuple
 from pathlib import Path
-from typing import List, Optional, Type
+from typing import List, Type
 
 
 class EnumWithExportName(Enum):
@@ -132,7 +132,7 @@ LICENSE = R"""/*
  */"""
 
 
-def export_enum_to_cpp(e: Type[EnumWithExportName], special_name: Optional[str] = None) -> str:
+def export_enum_to_cpp(e: Type[EnumWithExportName]) -> str:
     output = f'enum class {e.export_name()} {{\n'
 
     for entry in e:


### PR DESCRIPTION
Commits are from #22343

As per the specification, TIFF readers should gracefully skip samples that they are not able to interpret.