### PR TITLE
LibWeb: Scroll to the top after navigating to a new document

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -3578,6 +3578,11 @@ void Document::update_for_history_step_application(JS::NonnullGCPtr<HTML::Sessio
     // 6. If documentIsNew is true, then:
     if (document_is_new) {
         // FIXME: 1. Try to scroll to the fragment for document.
+        // FIXME: According to the spec we should only scroll here if document has no parser or parsing has stopped.
+        //        It should be ok to remove this after we implement navigation events and scrolling will happen in
+        //        "process scroll behavior".
+        scroll_to_the_fragment();
+
         // FIXME: 2. At this point scripts may run for the newly-created document document.
     }
 

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -1742,16 +1742,14 @@ Document::IndicatedPart Document::determine_the_indicated_part() const
     // For an HTML document document, the following processing model must be followed to determine its indicated part:
 
     // 1. Let fragment be document's URL's fragment.
-    VERIFY(url().fragment().has_value());
-
-    auto fragment = url().fragment().value();
+    auto fragment = url().fragment();
 
     // 2. If fragment is the empty string, then return the special value top of the document.
-    if (fragment.is_empty())
+    if (!fragment.has_value() || fragment->is_empty())
         return Document::TopOfTheDocument {};
 
     // 3. Let potentialIndicatedElement be the result of finding a potential indicated element given document and fragment.
-    auto* potential_indicated_element = find_a_potential_indicated_element(fragment);
+    auto* potential_indicated_element = find_a_potential_indicated_element(*fragment);
 
     // 4. If potentialIndicatedElement is not null, then return potentialIndicatedElement.
     if (potential_indicated_element)
@@ -1759,7 +1757,7 @@ Document::IndicatedPart Document::determine_the_indicated_part() const
 
     // 5. Let fragmentBytes be the result of percent-decoding fragment.
     // 6. Let decodedFragment be the result of running UTF-8 decode without BOM on fragmentBytes.
-    auto decoded_fragment = AK::URL::percent_decode(fragment);
+    auto decoded_fragment = AK::URL::percent_decode(*fragment);
 
     // 7. Set potentialIndicatedElement to the result of finding a potential indicated element given document and decodedFragment.
     potential_indicated_element = find_a_potential_indicated_element(MUST(FlyString::from_deprecated_fly_string(decoded_fragment)));


### PR DESCRIPTION
This change fixes a bug with running tests where, if one of the
previous tests changes the scroll position, all subsequent tests that
rely on the scroll position will fail. This is because the headless
browser never resets the viewport offset.