### PR TITLE
LibWeb: Some select element fixes

### DIFF
--- a/Base/res/html/misc/select.html
+++ b/Base/res/html/misc/select.html
@@ -4,6 +4,16 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Select showcase</title>
+    <style>
+        .custom {
+            border: 1px solid rgba(0, 0, 0, 0.5);
+            border-radius: 8px;
+            appearance: none;
+            padding: 8px 16px;
+            background-color: #088;
+            color: #fff;
+        }
+    </style>
 </head>
 <body>
     <p>Basic select:</p>
@@ -31,6 +41,17 @@
             <option value="six">Six</option>
         </select>
         Value: <span id="b-value">?</span>
+    </p>
+
+    <p>Basic select with custom styling:</p>
+    <p>
+        <select class="custom">
+            <option value="one">One</option>
+            <option value="two">Two</option>
+            <option value="three">Three</option>
+            <option value="four">Four</option>
+            <option value="five">Five</option>
+        </select>
     </p>
 
     <p>Basic select with option groups and separators:</p>

--- a/Ladybird/Qt/Tab.cpp
+++ b/Ladybird/Qt/Tab.cpp
@@ -234,7 +234,7 @@ Tab::Tab(BrowserWindow* window, WebContentOptions const& web_content_options, St
 
     view().on_request_select_dropdown = [this](Gfx::IntPoint content_position, i32 minimum_width, Vector<Web::HTML::SelectItem> items) {
         m_select_dropdown->clear();
-        m_select_dropdown->setMinimumWidth(minimum_width);
+        m_select_dropdown->setMinimumWidth(minimum_width / view().device_pixel_ratio());
         for (auto const& item : items) {
             select_dropdown_add_item(m_select_dropdown, item);
         }

--- a/Tests/LibWeb/Text/expected/css/getComputedStyle-print-all.txt
+++ b/Tests/LibWeb/Text/expected/css/getComputedStyle-print-all.txt
@@ -1,3 +1,4 @@
+-webkit-appearance: auto
 accent-color: auto
 align-content: stretch
 align-items: normal

--- a/Userland/Libraries/LibWeb/CSS/Default.css
+++ b/Userland/Libraries/LibWeb/CSS/Default.css
@@ -62,10 +62,6 @@ button:hover, input[type=submit]:hover, input[type=button]:hover, input[type=res
     background-color: #e5e0d7;
 }
 
-select {
-    padding-right: 2px;
-}
-
 option {
     display: none;
 }

--- a/Userland/Libraries/LibWeb/CSS/Properties.json
+++ b/Userland/Libraries/LibWeb/CSS/Properties.json
@@ -1,4 +1,10 @@
 {
+  "-webkit-appearance": {
+    "logical-alias-for": [
+      "appearance"
+    ],
+    "max-values": 1
+  },
   "accent-color": {
     "inherited": true,
     "initial": "auto",

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -395,6 +395,8 @@ static void set_property_expanding_shorthands(StyleProperties& style, CSS::Prope
             return PropertyID::Left;
         case PropertyID::InsetInlineEnd:
             return PropertyID::Right;
+        case PropertyID::WebkitAppearance:
+            return PropertyID::Appearance;
         default:
             return {};
         }

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -573,6 +573,7 @@ Element::RequiredInvalidationAfterStyleChange Element::recompute_style()
         return invalidation;
 
     m_computed_css_values = move(new_computed_css_values);
+    computed_css_values_changed();
 
     if (!invalidation.rebuild_layout_tree && layout_node()) {
         // If we're keeping the layout tree, we can just apply the new style to the existing layout tree.
@@ -2043,6 +2044,7 @@ size_t Element::attribute_list_size() const
 void Element::set_computed_css_values(RefPtr<CSS::StyleProperties> style)
 {
     m_computed_css_values = move(style);
+    computed_css_values_changed();
 }
 
 auto Element::pseudo_element_custom_properties() const -> PseudoElementCustomProperties&

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -386,6 +386,8 @@ protected:
     virtual void children_changed() override;
     virtual i32 default_tab_index_value() const;
 
+    virtual void computed_css_values_changed() { }
+
     virtual void visit_edges(Cell::Visitor&) override;
 
     virtual bool id_reference_exists(String const&) const override;

--- a/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.h
@@ -89,12 +89,15 @@ private:
     // ^DOM::Element
     virtual i32 default_tab_index_value() const override;
 
+    virtual void computed_css_values_changed() override;
+
     void create_shadow_tree_if_needed();
     void update_inner_text_element();
 
     JS::GCPtr<HTMLOptionsCollection> m_options;
     bool m_is_open { false };
     JS::GCPtr<DOM::Element> m_inner_text_element;
+    JS::GCPtr<DOM::Element> m_chevron_icon_element;
 };
 
 }

--- a/Userland/Libraries/LibWebView/WebContentClient.cpp
+++ b/Userland/Libraries/LibWebView/WebContentClient.cpp
@@ -380,7 +380,7 @@ void WebContentClient::did_request_color_picker(Color const& current_color)
 void WebContentClient::did_request_select_dropdown(Gfx::IntPoint content_position, i32 minimum_width, Vector<Web::HTML::SelectItem> const& items)
 {
     if (m_view.on_request_select_dropdown)
-        m_view.on_request_select_dropdown(m_view.to_widget_position(content_position), m_view.to_widget_position(Gfx::IntPoint { minimum_width, 0 }).x(), items);
+        m_view.on_request_select_dropdown(content_position, minimum_width, items);
 }
 
 void WebContentClient::did_finish_handling_input_event(bool event_was_accepted)


### PR DESCRIPTION
With these changes the select element dropdown position on a scrolled page is better in the Qt chrome. On the AppKit chrome it is still bugged but more things are a little broken with that chrome.

Also the select element now supports the `appearance: none;` css property so custom styled select boxes now look some what better, for example https://bulma.io/documentation/form/select/ now doesn't contain the internal chevron icon.