### PR TITLE
headless-browser: Await `on_load_finish()` while running Text tests

### DIFF
--- a/Userland/Utilities/headless-browser.cpp
+++ b/Userland/Utilities/headless-browser.cpp
@@ -215,7 +215,6 @@ static ErrorOr<TestResult> run_dump_test(HeadlessWebContentView& view, StringVie
     }));
 
     auto url = URL::create_with_file_scheme(TRY(FileSystem::real_path(input_path)).to_byte_string());
-    view.load(url);
 
     String result;
     auto did_finish_test = false;
@@ -252,6 +251,8 @@ static ErrorOr<TestResult> run_dump_test(HeadlessWebContentView& view, StringVie
                 loop.quit(0);
         };
     }
+
+    view.load(url);
 
     timeout_timer->start();
     loop.exec();


### PR DESCRIPTION
Before this change, it was possible for a text test to finish before on_load_finish() was triggered, resulting in the subsequent test receiving the load event from the previous test.