### PR TITLE
LibWeb+WebWorker: Convert Workers to use MessagePorts for postMessage

### DIFF
--- a/Base/res/html/misc/worker.js
+++ b/Base/res/html/misc/worker.js
@@ -1,10 +1,10 @@
 onmessage = evt => {
     console.log("In Worker - Got message:", JSON.stringify(evt.data));
 
-    postMessage(evt.data, null);
+    postMessage(evt.data);
 };
 
 console.log("In Worker - Loaded", this);
 console.log("Keys: ", JSON.stringify(Object.keys(this)));
 
-postMessage("loaded", null);
+postMessage("loaded");

--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -1,3 +1,1 @@
 [Skipped]
-Text/input/Worker/Worker-echo.html
-

--- a/Tests/LibWeb/Text/expected/Worker/Worker-echo.txt
+++ b/Tests/LibWeb/Text/expected/Worker/Worker-echo.txt
@@ -1,3 +1,4 @@
 Got message from worker: "loaded"
-Got message from worker: {"msg":"marco"}
+Got message from port: "Worker got message port!"
+Got message from port: "Extra Port got message: \"Hello from port2\""
 DONE

--- a/Tests/LibWeb/Text/input/Worker/Worker-echo.html
+++ b/Tests/LibWeb/Text/input/Worker/Worker-echo.html
@@ -2,17 +2,31 @@
 <script>
     asyncTest((done) => {
         let work = new Worker("worker.js");
+        let channel = new MessageChannel();
+
+        function finishTest() {
+            println("DONE");
+            work.onmessage = null;
+            work.terminate();
+            channel.port2.onmessage = null;
+            done();
+        }
         let count = 0;
         work.onmessage = (evt) => {
             println("Got message from worker: " + JSON.stringify(evt.data));
             count++;
-            work.postMessage({"msg": "marco"});
-            if (count === 2) {
-                println("DONE");
-                work.onmessage = null;
-                work.terminate();
-                done();
+            if (count === 3) {
+                finishTest();
             }
         };
+        channel.port2.onmessage = (evt) => {
+            println("Got message from port: " + JSON.stringify(evt.data));
+            channel.port2.postMessage("Hello from port2");
+            count++;
+            if (count === 3) {
+                finishTest();
+            }
+        };
+        work.postMessage({ port: channel.port1 }, { transfer : [channel.port1]});
     });
 </script>

--- a/Tests/LibWeb/Text/input/Worker/worker.js
+++ b/Tests/LibWeb/Text/input/Worker/worker.js
@@ -1,4 +1,14 @@
+let extraPort = null;
+
 onmessage = evt => {
-    postMessage(evt.data, null);
+    if (evt.ports.length > 0) {
+        extraPort = evt.ports[0];
+        extraPort.onmessage = evt => {
+            extraPort.postMessage("Extra Port got message: " + JSON.stringify(evt.data));
+        };
+        extraPort.postMessage("Worker got message port!");
+    } else {
+        postMessage(evt.data);
+    }
 };
-postMessage("loaded", null);
+postMessage("loaded");

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -446,6 +446,7 @@ class Timer;
 class TimeRanges;
 class ToggleEvent;
 class TrackEvent;
+struct TransferDataHolder;
 class TraversableNavigable;
 class VideoTrack;
 class VideoTrackList;

--- a/Userland/Libraries/LibWeb/HTML/MessagePort.h
+++ b/Userland/Libraries/LibWeb/HTML/MessagePort.h
@@ -61,6 +61,8 @@ public:
     virtual WebIDL::ExceptionOr<void> transfer_receiving_steps(HTML::TransferDataHolder&) override;
     virtual HTML::TransferType primary_interface() const override { return HTML::TransferType::MessagePort; }
 
+    void set_worker_event_target(JS::NonnullGCPtr<DOM::EventTarget>);
+
 private:
     explicit MessagePort(JS::Realm&);
 
@@ -91,6 +93,8 @@ private:
         Error,
     } m_socket_state { SocketState::Header };
     size_t m_socket_incoming_message_size { 0 };
+
+    JS::GCPtr<DOM::EventTarget> m_worker_event_target;
 };
 
 }

--- a/Userland/Libraries/LibWeb/HTML/Worker.h
+++ b/Userland/Libraries/LibWeb/HTML/Worker.h
@@ -32,8 +32,8 @@ class Worker : public DOM::EventTarget {
     JS_DECLARE_ALLOCATOR(Worker);
 
 public:
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<Worker>> create(String const& script_url, WorkerOptions const options, DOM::Document& document);
-    static WebIDL::ExceptionOr<JS::NonnullGCPtr<Worker>> construct_impl(JS::Realm& realm, String const& script_url, WorkerOptions const options)
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<Worker>> create(String const& script_url, WorkerOptions const& options, DOM::Document& document);
+    static WebIDL::ExceptionOr<JS::NonnullGCPtr<Worker>> construct_impl(JS::Realm& realm, String const& script_url, WorkerOptions const& options)
     {
         auto& window = verify_cast<HTML::Window>(realm.global_object());
         return Worker::create(script_url, options, window.associated_document());
@@ -41,7 +41,7 @@ public:
 
     WebIDL::ExceptionOr<void> terminate();
 
-    WebIDL::ExceptionOr<void> post_message(JS::Value message, JS::Value transfer);
+    WebIDL::ExceptionOr<void> post_message(JS::Value message, StructuredSerializeOptions const&);
 
     virtual ~Worker() = default;
 
@@ -55,7 +55,7 @@ public:
 #undef __ENUMERATE
 
 protected:
-    Worker(String const&, const WorkerOptions, DOM::Document&);
+    Worker(String const&, WorkerOptions const&, DOM::Document&);
 
 private:
     virtual void initialize(JS::Realm&) override;
@@ -66,17 +66,10 @@ private:
 
     JS::GCPtr<DOM::Document> m_document;
     JS::GCPtr<MessagePort> m_outside_port;
-    // FIXME: Move tihs state into the message port (and actually use it :) )
-    enum class PortState : u8 {
-        Header,
-        Data,
-        Error,
-    } m_outside_port_state { PortState::Header };
-    size_t m_outside_port_incoming_message_size { 0 };
 
     JS::GCPtr<WorkerAgent> m_agent;
 
-    void run_a_worker(AK::URL& url, EnvironmentSettingsObject& outside_settings, MessagePort& outside_port, WorkerOptions const& options);
+    void run_a_worker(AK::URL& url, EnvironmentSettingsObject& outside_settings, JS::GCPtr<MessagePort> outside_port, WorkerOptions const& options);
 };
 
 }

--- a/Userland/Libraries/LibWeb/HTML/Worker.idl
+++ b/Userland/Libraries/LibWeb/HTML/Worker.idl
@@ -1,5 +1,6 @@
 #import <DOM/EventTarget.idl>
 #import <DOM/EventHandler.idl>
+#import <HTML/MessagePort.idl>
 
 // https://html.spec.whatwg.org/#worker
 [Exposed=(Window)]
@@ -7,7 +8,9 @@ interface Worker : EventTarget {
     constructor(DOMString scriptURL, optional WorkerOptions options = {});
 
     undefined terminate();
-    undefined postMessage(any message, optional any transfer);
+    // FIXME: IDL overload issue here
+    // FIXME: undefined postMessage(any message, sequence<object> transfer);
+    undefined postMessage(any message, optional StructuredSerializeOptions options = {});
 
     attribute EventHandler onmessage;
     attribute EventHandler onmessageerror;

--- a/Userland/Libraries/LibWeb/HTML/WorkerAgent.h
+++ b/Userland/Libraries/LibWeb/HTML/WorkerAgent.h
@@ -26,18 +26,19 @@ struct WorkerAgent : JS::Cell {
     JS_CELL(Agent, JS::Cell);
     JS_DECLARE_ALLOCATOR(WorkerAgent);
 
-    WorkerAgent(AK::URL url, WorkerOptions const& options);
+    WorkerAgent(AK::URL url, WorkerOptions const& options, JS::GCPtr<MessagePort> outside_port);
 
     RefPtr<Web::HTML::WebWorkerClient> m_worker_ipc;
 
-    Core::BufferedLocalSocket& socket() const { return *m_socket; }
-
 private:
+    virtual void initialize(JS::Realm&) override;
+    virtual void visit_edges(Cell::Visitor&) override;
+
     WorkerOptions m_worker_options;
     AK::URL m_url;
 
-    // FIXME: associate with MessagePorts
-    OwnPtr<Core::BufferedLocalSocket> m_socket;
+    JS::GCPtr<MessagePort> m_message_port;
+    JS::GCPtr<MessagePort> m_outside_port;
 };
 
 }

--- a/Userland/Libraries/LibWeb/HTML/WorkerGlobalScope.h
+++ b/Userland/Libraries/LibWeb/HTML/WorkerGlobalScope.h
@@ -73,7 +73,7 @@ public:
     ENUMERATE_WORKER_GLOBAL_SCOPE_EVENT_HANDLERS(__ENUMERATE)
 #undef __ENUMERATE
 
-    WebIDL::ExceptionOr<void> post_message(JS::Value message, JS::Value transfer);
+    WebIDL::ExceptionOr<void> post_message(JS::Value message, StructuredSerializeOptions const&);
 
     // Non-IDL public methods
 
@@ -84,14 +84,14 @@ public:
     //            this is not problematic as it cannot be observed from script.
     void set_location(JS::NonnullGCPtr<WorkerLocation> loc) { m_location = move(loc); }
 
-    void set_outside_port(NonnullOwnPtr<Core::BufferedLocalSocket> port);
+    void set_internal_port(JS::NonnullGCPtr<MessagePort> port);
 
     void initialize_web_interfaces(Badge<WorkerEnvironmentSettingsObject>);
 
-    Web::Page* page() { return &m_page; }
+    Web::Page* page() { return m_page.ptr(); }
 
 protected:
-    explicit WorkerGlobalScope(JS::Realm&, Web::Page&);
+    explicit WorkerGlobalScope(JS::Realm&, JS::NonnullGCPtr<Web::Page>);
 
 private:
     virtual void visit_edges(Cell::Visitor&) override;
@@ -99,13 +99,8 @@ private:
     JS::GCPtr<WorkerLocation> m_location;
     JS::GCPtr<WorkerNavigator> m_navigator;
 
-    OwnPtr<Core::BufferedLocalSocket> m_outside_port;
-    enum class PortState : u8 {
-        Header,
-        Data,
-        Error,
-    } m_outside_port_state { PortState::Header };
-    size_t m_outside_port_incoming_message_size { 0 };
+    JS::NonnullGCPtr<Web::Page> m_page;
+    JS::GCPtr<MessagePort> m_internal_port;
 
     // FIXME: Add all these internal slots
 
@@ -138,8 +133,6 @@ private:
 
     // https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-cross-origin-isolated-capability
     bool m_cross_origin_isolated_capability { false };
-
-    Web::Page& m_page;
 };
 
 }

--- a/Userland/Libraries/LibWeb/HTML/WorkerGlobalScope.idl
+++ b/Userland/Libraries/LibWeb/HTML/WorkerGlobalScope.idl
@@ -3,6 +3,7 @@
 #import <HTML/WindowOrWorkerGlobalScope.idl>
 #import <HTML/WorkerLocation.idl>
 #import <HTML/WorkerNavigator.idl>
+#import <HTML/MessagePort.idl>
 
 // https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope
 [Exposed=Worker]
@@ -19,8 +20,9 @@ interface WorkerGlobalScope : EventTarget {
     attribute EventHandler onrejectionhandled;
     attribute EventHandler onunhandledrejection;
 
-    // FIXME: This belongs on the subclasses of WorkerGlobalScope
-    undefined postMessage(any message, any transfer);
+    // FIXME: IDL overload issue here
+    // FIXME: undefined postMessage(any message, sequence<object> transfer);
+    undefined postMessage(any message, optional StructuredSerializeOptions options = {});
     attribute EventHandler onmessage;
     attribute EventHandler onmessageerror;
 };

--- a/Userland/Libraries/LibWeb/Worker/WebWorkerServer.ipc
+++ b/Userland/Libraries/LibWeb/Worker/WebWorkerServer.ipc
@@ -1,9 +1,10 @@
 #include <AK/URL.h>
 #include <LibIPC/File.h>
+#include <LibWeb/HTML/StructuredSerialize.h>
 
 endpoint WebWorkerServer {
 
-    start_dedicated_worker(URL url, String type, String credentials, String name, IPC::File message_port) =|
+    start_dedicated_worker(URL url, String type, String credentials, String name, Web::HTML::TransferDataHolder message_port) =|
 
     handle_file_return(i32 error, Optional<IPC::File> file, i32 request_id) =|
 }

--- a/Userland/Services/WebWorker/ConnectionFromClient.cpp
+++ b/Userland/Services/WebWorker/ConnectionFromClient.cpp
@@ -52,11 +52,12 @@ Web::Page const& ConnectionFromClient::page() const
     return m_page_host->page();
 }
 
-void ConnectionFromClient::start_dedicated_worker(AK::URL const& url, String const& type, String const&, String const&, IPC::File const& implicit_port)
+void ConnectionFromClient::start_dedicated_worker(AK::URL const& url, String const& type, String const&, String const&, Web::HTML::TransferDataHolder const& implicit_port)
 {
-    m_worker_host = make_ref_counted<DedicatedWorkerHost>(page(), url, type, implicit_port.take_fd());
-
-    m_worker_host->run();
+    m_worker_host = make_ref_counted<DedicatedWorkerHost>(url, type);
+    // FIXME: Yikes, const_cast to move? Feels like a LibIPC bug.
+    //     We should be able to move non-copyable types from a Message type.
+    m_worker_host->run(page(), move(const_cast<Web::HTML::TransferDataHolder&>(implicit_port)));
 }
 
 void ConnectionFromClient::handle_file_return(i32 error, Optional<IPC::File> const& file, i32 request_id)

--- a/Userland/Services/WebWorker/ConnectionFromClient.h
+++ b/Userland/Services/WebWorker/ConnectionFromClient.h
@@ -39,7 +39,7 @@ private:
     Web::Page& page();
     Web::Page const& page() const;
 
-    virtual void start_dedicated_worker(AK::URL const& url, String const&, String const&, String const&, IPC::File const&) override;
+    virtual void start_dedicated_worker(AK::URL const& url, String const&, String const&, String const&, Web::HTML::TransferDataHolder const&) override;
     virtual void handle_file_return(i32 error, Optional<IPC::File> const& file, i32 request_id) override;
 
     JS::Handle<PageHost> m_page_host;

--- a/Userland/Services/WebWorker/DedicatedWorkerHost.h
+++ b/Userland/Services/WebWorker/DedicatedWorkerHost.h
@@ -10,24 +10,22 @@
 #include <AK/URL.h>
 #include <LibWeb/Bindings/MainThreadVM.h>
 #include <LibWeb/Forward.h>
+#include <LibWeb/HTML/StructuredSerialize.h>
 
 namespace WebWorker {
 
 class DedicatedWorkerHost : public RefCounted<DedicatedWorkerHost> {
 public:
-    explicit DedicatedWorkerHost(Web::Page&, AK::URL url, String type, int outside_port);
+    explicit DedicatedWorkerHost(AK::URL url, String type);
     ~DedicatedWorkerHost();
 
-    void run();
+    void run(JS::NonnullGCPtr<Web::Page>, Web::HTML::TransferDataHolder message_port_data);
 
 private:
     RefPtr<Web::HTML::WorkerDebugConsoleClient> m_console;
-    Web::Page& m_page;
 
     AK::URL m_url;
     String m_type;
-
-    int m_outside_port { -1 };
 };
 
 }


### PR DESCRIPTION
This aligns Workers and Window and MessagePorts to all use the same mechanism for transferring serialized messages across realms.

It also allows transferring more message ports into a worker.

Re-enable the Worker-echo test, as none of the MessagePort tests have themselves been flaky, and those are now using the same underlying implementation.