### PR TITLE
AK: Use fallback builtins for overflow checks in AK::Checked

### DIFF
--- a/AK/Checked.h
+++ b/AK/Checked.h
@@ -348,6 +348,9 @@ public:
     {
 #if __has_builtin(__builtin_add_overflow_p)
         return __builtin_add_overflow_p(u, v, (T)0);
+#elif __has_builtin(__builtin_add_overflow)
+        T result;
+        return __builtin_add_overflow(u, v, &result);
 #else
         Checked checked;
         checked = u;
@@ -385,6 +388,9 @@ public:
     {
 #if __has_builtin(__builtin_mul_overflow_p)
         return __builtin_mul_overflow_p(u, v, (T)0);
+#elif __has_builtin(__builtin_mul_overflow)
+        T result;
+        return __builtin_mul_overflow(u, v, &result);
 #else
         Checked checked;
         checked = u;


### PR DESCRIPTION
If we don't have `__builtin_add_overflow_p()`, we can also try using `__builtin_add_overflow()`. This makes debug builds with Clang significantly faster since they no longer need to use the generic implementation. Same for multiplication.