### PR TITLE
LibLine: Avoid returning reference to cached suggestion

### DIFF
--- a/Userland/Libraries/LibLine/SuggestionManager.cpp
+++ b/Userland/Libraries/LibLine/SuggestionManager.cpp
@@ -76,9 +76,10 @@ void SuggestionManager::previous()
 
 CompletionSuggestion const& SuggestionManager::suggest()
 {
-    m_last_shown_suggestion = m_suggestions[m_next_suggestion_index];
+    auto const& suggestion = m_suggestions[m_next_suggestion_index];
     m_selected_suggestion_index = m_next_suggestion_index;
-    return m_last_shown_suggestion;
+    m_last_shown_suggestion = suggestion;
+    return suggestion;
 }
 
 void SuggestionManager::set_current_suggestion_initiation_index(size_t index)


### PR DESCRIPTION
This caused a dangling reference down the line, which lead to funny things like the following:
    > cd Bui[tab]
    > cd Bui^@^@

By returning a direct reference to the suggestion in question, we can be sure that the referenced object is alive until the next suggestion cycle.