### PR TITLE
Kernel: Mark cloned volatile purgeable AnonymousVMOjects as purged

### DIFF
--- a/Kernel/Memory/AnonymousVMObject.cpp
+++ b/Kernel/Memory/AnonymousVMObject.cpp
@@ -24,6 +24,7 @@ ErrorOr<NonnullLockRefPtr<VMObject>> AnonymousVMObject::try_clone()
         // object, effectively "pre-purging" it in the child process.
         auto clone = TRY(try_create_purgeable_with_size(size(), AllocationStrategy::None));
         clone->m_volatile = true;
+        clone->m_was_purged = true;
         return clone;
     }
 


### PR DESCRIPTION
Our existing AnonymousVMObject cloning flow contains an optimization wherein purgeable VMObjects which are marked volatile during the clone are created as a new zero-filled VMObject (as if it was purged), which lets us skip the expensive COW process.

Unfortunately, one crucial part was missing: Marking the cloned region as purged, (which is the value returned from madvise when unmarking the region as volatile) so the userland logic was left unaware of the effective zero-ing of their memory region, resulting in odd behaviour and crashes in places like our malloc's large allocation support.

Fixes #22334.