### PR TITLE
LibWebView+WebContent: Drive repainting from WebContent process

### DIFF
--- a/Ladybird/Android/src/main/cpp/WebViewImplementationNative.cpp
+++ b/Ladybird/Android/src/main/cpp/WebViewImplementationNative.cpp
@@ -94,7 +94,6 @@ void WebViewImplementationNative::set_viewport_geometry(int w, int h)
 {
     m_viewport_rect = { { 0, 0 }, { w, h } };
     client().async_set_viewport_rect(m_viewport_rect);
-    request_repaint();
     handle_resize();
 }
 

--- a/Ladybird/AppKit/UI/LadybirdWebViewBridge.cpp
+++ b/Ladybird/AppKit/UI/LadybirdWebViewBridge.cpp
@@ -90,7 +90,6 @@ void WebViewBridge::set_viewport_rect(Gfx::IntRect viewport_rect, ForResize for_
     m_viewport_rect = viewport_rect;
 
     client().async_set_viewport_rect(m_viewport_rect.to_type<Web::DevicePixels>());
-    request_repaint();
 
     if (for_resize == ForResize::Yes) {
         handle_resize();

--- a/Ladybird/Qt/WebContentView.cpp
+++ b/Ladybird/Qt/WebContentView.cpp
@@ -537,7 +537,6 @@ void WebContentView::set_device_pixel_ratio(double device_pixel_ratio)
     client().async_set_device_pixels_per_css_pixel(m_device_pixel_ratio * m_zoom_level);
     update_viewport_rect();
     handle_resize();
-    request_repaint();
 }
 
 void WebContentView::update_viewport_rect()
@@ -547,15 +546,12 @@ void WebContentView::update_viewport_rect()
     Gfx::IntRect rect(max(0, horizontalScrollBar()->value()), max(0, verticalScrollBar()->value()), scaled_width, scaled_height);
 
     set_viewport_rect(rect);
-
-    request_repaint();
 }
 
 void WebContentView::update_zoom()
 {
     client().async_set_device_pixels_per_css_pixel(m_device_pixel_ratio * m_zoom_level);
     update_viewport_rect();
-    request_repaint();
 }
 
 void WebContentView::showEvent(QShowEvent* event)
@@ -743,7 +739,6 @@ bool WebContentView::event(QEvent* event)
 
     if (event->type() == QEvent::PaletteChange) {
         update_palette();
-        request_repaint();
         return QAbstractScrollArea::event(event);
     }
 

--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -522,7 +522,6 @@ bool EventHandler::handle_mousemove(CSSPixelPoint position, CSSPixelPoint screen
                 }
                 document.navigable()->set_needs_display();
             }
-            m_browsing_context->page().client().page_did_change_selection();
         }
     }
 

--- a/Userland/Libraries/LibWeb/Page/Page.cpp
+++ b/Userland/Libraries/LibWeb/Page/Page.cpp
@@ -106,6 +106,14 @@ DevicePixelPoint Page::css_to_device_point(CSSPixelPoint point) const
     };
 }
 
+DevicePixelRect Page::css_to_device_rect(CSSPixelRect rect) const
+{
+    return {
+        rect.location().to_type<double>() * client().device_pixels_per_css_pixel(),
+        rect.size().to_type<double>() * client().device_pixels_per_css_pixel(),
+    };
+}
+
 CSSPixelRect Page::device_to_css_rect(DevicePixelRect rect) const
 {
     auto scale = client().device_pixels_per_css_pixel();

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -70,6 +70,7 @@ public:
 
     CSSPixelPoint device_to_css_point(DevicePixelPoint) const;
     DevicePixelPoint css_to_device_point(CSSPixelPoint) const;
+    DevicePixelRect css_to_device_rect(CSSPixelRect) const;
     CSSPixelRect device_to_css_rect(DevicePixelRect) const;
     DevicePixelRect enclosing_device_rect(CSSPixelRect) const;
     DevicePixelRect rounded_device_rect(CSSPixelRect) const;
@@ -238,7 +239,6 @@ public:
     virtual void page_did_create_new_document(Web::DOM::Document&) { }
     virtual void page_did_destroy_document(Web::DOM::Document&) { }
     virtual void page_did_finish_loading(const AK::URL&) { }
-    virtual void page_did_change_selection() { }
     virtual void page_did_request_cursor_change(Gfx::StandardCursor) { }
     virtual void page_did_request_context_menu(CSSPixelPoint) { }
     virtual void page_did_request_link_context_menu(CSSPixelPoint, AK::URL const&, [[maybe_unused]] ByteString const& target, [[maybe_unused]] unsigned modifiers) { }

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
@@ -210,7 +210,6 @@ void OutOfProcessWebView::theme_change_event(GUI::ThemeChangeEvent& event)
 {
     Super::theme_change_event(event);
     client().async_update_system_theme(Gfx::current_system_theme_buffer());
-    request_repaint();
 }
 
 void OutOfProcessWebView::screen_rects_change_event(GUI::ScreenRectsChangeEvent& event)
@@ -225,7 +224,6 @@ void OutOfProcessWebView::screen_rects_change_event(GUI::ScreenRectsChangeEvent&
 void OutOfProcessWebView::did_scroll()
 {
     client().async_set_viewport_rect(visible_content_rect().to_type<Web::DevicePixels>());
-    request_repaint();
 }
 
 ByteString OutOfProcessWebView::dump_layout_tree()

--- a/Userland/Libraries/LibWebView/ViewImplementation.h
+++ b/Userland/Libraries/LibWebView/ViewImplementation.h
@@ -39,8 +39,6 @@ public:
     String const& handle() const { return m_client_state.client_handle; }
 
     void server_did_paint(Badge<WebContentClient>, i32 bitmap_id, Gfx::IntSize size);
-    void server_did_invalidate_content_rect(Badge<WebContentClient>, Gfx::IntRect rect);
-    void server_did_change_selection(Badge<WebContentClient>);
 
     void load(AK::URL const&);
     void load_html(StringView);
@@ -195,7 +193,6 @@ protected:
     };
     void resize_backing_stores_if_needed(WindowResizeInProgress);
 
-    void request_repaint();
     void handle_resize();
 
     virtual void create_client() { }
@@ -204,7 +201,6 @@ protected:
 
     struct SharedBitmap {
         i32 id { -1 };
-        i32 pending_paints { 0 };
         Web::DevicePixelSize last_painted_size;
         RefPtr<Gfx::Bitmap> bitmap;
     };
@@ -216,7 +212,6 @@ protected:
         SharedBitmap back_bitmap;
         i32 next_bitmap_id { 0 };
         bool has_usable_bitmap { false };
-        bool got_repaint_requests_while_painting { false };
     } m_client_state;
 
     AK::URL m_url;

--- a/Userland/Libraries/LibWebView/WebContentClient.cpp
+++ b/Userland/Libraries/LibWebView/WebContentClient.cpp
@@ -68,20 +68,6 @@ void WebContentClient::did_request_refresh()
         m_view.on_refresh();
 }
 
-void WebContentClient::did_invalidate_content_rect(Gfx::IntRect const& content_rect)
-{
-    dbgln_if(SPAM_DEBUG, "handle: WebContentClient::DidInvalidateContentRect! content_rect={}", content_rect);
-
-    // FIXME: Figure out a way to coalesce these messages to reduce unnecessary painting
-    m_view.server_did_invalidate_content_rect({}, content_rect);
-}
-
-void WebContentClient::did_change_selection()
-{
-    dbgln_if(SPAM_DEBUG, "handle: WebContentClient::DidChangeSelection!");
-    m_view.server_did_change_selection({});
-}
-
 void WebContentClient::did_request_cursor_change(i32 cursor_type)
 {
     if (cursor_type < 0 || cursor_type >= (i32)Gfx::StandardCursor::__Count) {

--- a/Userland/Libraries/LibWebView/WebContentClient.h
+++ b/Userland/Libraries/LibWebView/WebContentClient.h
@@ -35,8 +35,6 @@ private:
     virtual void did_request_navigate_back() override;
     virtual void did_request_navigate_forward() override;
     virtual void did_request_refresh() override;
-    virtual void did_invalidate_content_rect(Gfx::IntRect const&) override;
-    virtual void did_change_selection() override;
     virtual void did_request_cursor_change(i32) override;
     virtual void did_layout(Gfx::IntSize) override;
     virtual void did_change_title(ByteString const&) override;

--- a/Userland/Services/WebContent/PageClient.h
+++ b/Userland/Services/WebContent/PageClient.h
@@ -28,6 +28,8 @@ public:
 
     static void set_use_gpu_painter();
 
+    void schedule_repaint();
+
     virtual Web::Page& page() override { return *m_page; }
     virtual Web::Page const& page() const override { return *m_page; }
 
@@ -75,7 +77,6 @@ private:
     virtual double device_pixels_per_css_pixel() const override { return m_device_pixels_per_css_pixel; }
     virtual Web::CSS::PreferredColorScheme preferred_color_scheme() const override { return m_preferred_color_scheme; }
     virtual void page_did_invalidate(Web::CSSPixelRect const&) override;
-    virtual void page_did_change_selection() override;
     virtual void page_did_request_cursor_change(Gfx::StandardCursor) override;
     virtual void page_did_layout() override;
     virtual void page_did_change_title(ByteString const&) override;
@@ -149,8 +150,8 @@ private:
     bool m_should_show_line_box_borders { false };
     bool m_has_focus { false };
 
-    RefPtr<Web::Platform::Timer> m_invalidation_coalescing_timer;
-    Web::DevicePixelRect m_invalidation_rect;
+    RefPtr<Web::Platform::Timer> m_repaint_timer;
+
     Web::CSS::PreferredColorScheme m_preferred_color_scheme { Web::CSS::PreferredColorScheme::Auto };
 
     RefPtr<WebDriverConnection> m_webdriver;

--- a/Userland/Services/WebContent/WebContentClient.ipc
+++ b/Userland/Services/WebContent/WebContentClient.ipc
@@ -17,9 +17,7 @@ endpoint WebContentClient
     did_request_navigate_back() =|
     did_request_navigate_forward() =|
     did_request_refresh() =|
-    did_paint(Gfx::IntRect content_rect, i32 bitmap_id) =|
-    did_invalidate_content_rect(Gfx::IntRect content_rect) =|
-    did_change_selection() =|
+    did_paint(Gfx::IntRect content_rect, i32 bitmap_id) => ()
     did_request_cursor_change(i32 cursor_type) =|
     did_layout(Gfx::IntSize content_size) =|
     did_change_title(ByteString title) =|

--- a/Userland/Services/WebContent/WebContentServer.ipc
+++ b/Userland/Services/WebContent/WebContentServer.ipc
@@ -22,10 +22,8 @@ endpoint WebContentServer
     load_url(URL url) =|
     load_html(ByteString html) =|
 
-    add_backing_store(i32 backing_store_id, Gfx::ShareableBitmap bitmap) =|
-    remove_backing_store(i32 backing_store_id) =|
+    add_backing_store(i32 front_bitmap_id, Gfx::ShareableBitmap front_bitmap, i32 back_bitmap_id, Gfx::ShareableBitmap back_bitmap) =|
 
-    paint(Web::DevicePixelRect content_rect, i32 backing_store_id) =|
     set_viewport_rect(Web::DevicePixelRect rect) =|
 
     mouse_down(Web::DevicePixelPoint position, Web::DevicePixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers) =|


### PR DESCRIPTION
With this change, chrome no longer has to ask the WebContent process to paint the next frame into a specified bitmap. Instead, it allocates bitmaps and sends them to WebContent, which then lets chrome know when the painting is done.

This work is a preparation to move the execution of painting commands into a separate thread. Now, it is much easier to start working on the next frame while the current one is still rendering. This is because WebContent does not have to inform chrome that the current frame is ready before it can request the next frame.

Additionally, as a side bonus, we can now eliminate the did_invalidate_content_rect and did_change_selection IPC calls. These were used solely for the purpose of informing chrome that it needed to request a repaint.