### PR TITLE
AK: Completely disable rich debug formats on Windows

### DIFF
--- a/AK/Format.cpp
+++ b/AK/Format.cpp
@@ -1209,7 +1209,7 @@ void vdbg(StringView fmtstr, TypeErasedFormatParams& params, bool newline)
         } else {
             builder.appendff("\033[34;1m[Kernel]\033[0m: ");
         }
-#else
+#elif !defined(AK_OS_WINDOWS)
         auto process_name = process_name_for_logging();
         if (!process_name.is_empty()) {
             struct timespec ts = {};


### PR DESCRIPTION
Half the functions used are not readily available on windows, instead of creating more ifdef soup, this commit simply disables the rich debug stuff on windows.

cc @ADKaster 