### PR TITLE
LibWeb: Stop shadowing location_url

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Navigable.cpp
@@ -869,7 +869,7 @@ static WebIDL::ExceptionOr<Variant<Empty, NavigationParams, NonFetchSchemeNaviga
         //       This is because we care about the same-originness of the embedded content against the parent context, not the navigation source.
 
         // 14. Set locationURL to response's location URL given currentURL's fragment.
-        auto location_url = response_holder->response()->location_url(current_url.fragment());
+        location_url = response_holder->response()->location_url(current_url.fragment());
 
         VERIFY(!location_url.is_error());
 


### PR DESCRIPTION
This is a bug. The value set here needs to be visible to later steps.