### PR TITLE
ppc64le: Add in ARCH macro, LibJS Value.h, and LibWeb ResourceLoader.h

### DIFF
--- a/AK/Platform.h
+++ b/AK/Platform.h
@@ -29,6 +29,12 @@
 #    define AK_IS_ARCH_AARCH64() 0
 #endif
 
+#if defined(__powerpc64__) && defined(__LITTLE_ENDIAN__)
+#    define AK_IS_ARCH_PPC64LE() 1
+#else
+#    define AK_IS_ARCH_PPC64LE() 0
+#endif
+
 #if defined(__riscv) && __riscv_xlen == 64
 #    define AK_IS_ARCH_RISCV64() 1
 #else
@@ -138,6 +144,12 @@
 #    define VALIDATE_IS_AARCH64()
 #else
 #    define VALIDATE_IS_AARCH64() static_assert(false, "Trying to include aarch64 only header on non aarch64 platform");
+#endif
+
+#if ARCH(PPC64LE)
+#    define VALIDATE_IS_PPC64LE()
+#else
+#    define VALIDATE_IS_PPC64LE() static_assert(false, "Trying to include ppc64le only header on non ppc64le platform");
 #endif
 
 #if ARCH(RISCV64)

--- a/Userland/Libraries/LibJS/Runtime/Value.h
+++ b/Userland/Libraries/LibJS/Runtime/Value.h
@@ -429,7 +429,7 @@ public:
         // For 32-bit system the pointer fully fits so we can just return it directly.
         static_assert(sizeof(void*) == sizeof(u32));
         return static_cast<FlatPtr>(encoded & 0xffff'ffff);
-#elif ARCH(X86_64) || ARCH(RISCV64)
+#elif ARCH(X86_64) || ARCH(RISCV64) || ARCH(PPC64LE)
         // For x86_64 and riscv64 the top 16 bits should be sign extending the "real" top bit (47th).
         // So first shift the top 16 bits away then using the right shift it sign extends the top 16 bits.
         return static_cast<FlatPtr>((static_cast<i64>(encoded << 16)) >> 16);

--- a/Userland/Libraries/LibWeb/Loader/ResourceLoader.h
+++ b/Userland/Libraries/LibWeb/Loader/ResourceLoader.h
@@ -24,6 +24,8 @@ namespace Web {
 #    define CPU_STRING "AArch64"
 #elif ARCH(I386)
 #    define CPU_STRING "x86"
+#elif ARCH(PPC64LE)
+#    define CPU_STRING "Power"
 #elif ARCH(RISCV64)
 #    define CPU_STRING "RISC-V 64"
 #else


### PR DESCRIPTION
With this Ladybird can be built on ppc64le

Fixes: #22338