### PR TITLE
AK+Everwhere: Migrate String classes from `to_{uint,int,float,double}` to `to_number<T>`

### DIFF
--- a/AK/ByteString.cpp
+++ b/AK/ByteString.cpp
@@ -158,42 +158,6 @@ ByteBuffer ByteString::to_byte_buffer() const
     return ByteBuffer::copy(bytes()).release_value_but_fixme_should_propagate_errors();
 }
 
-template<typename T>
-Optional<T> ByteString::to_int(TrimWhitespace trim_whitespace) const
-{
-    return StringUtils::convert_to_int<T>(view(), trim_whitespace);
-}
-
-template Optional<i8> ByteString::to_int(TrimWhitespace) const;
-template Optional<i16> ByteString::to_int(TrimWhitespace) const;
-template Optional<i32> ByteString::to_int(TrimWhitespace) const;
-template Optional<long> ByteString::to_int(TrimWhitespace) const;
-template Optional<long long> ByteString::to_int(TrimWhitespace) const;
-
-template<typename T>
-Optional<T> ByteString::to_uint(TrimWhitespace trim_whitespace) const
-{
-    return StringUtils::convert_to_uint<T>(view(), trim_whitespace);
-}
-
-template Optional<u8> ByteString::to_uint(TrimWhitespace) const;
-template Optional<u16> ByteString::to_uint(TrimWhitespace) const;
-template Optional<u32> ByteString::to_uint(TrimWhitespace) const;
-template Optional<unsigned long> ByteString::to_uint(TrimWhitespace) const;
-template Optional<unsigned long long> ByteString::to_uint(TrimWhitespace) const;
-
-#ifndef KERNEL
-Optional<double> ByteString::to_double(TrimWhitespace trim_whitespace) const
-{
-    return StringUtils::convert_to_floating_point<double>(*this, trim_whitespace);
-}
-
-Optional<float> ByteString::to_float(TrimWhitespace trim_whitespace) const
-{
-    return StringUtils::convert_to_floating_point<float>(*this, trim_whitespace);
-}
-#endif
-
 bool ByteString::starts_with(StringView str, CaseSensitivity case_sensitivity) const
 {
     return StringUtils::starts_with(*this, str, case_sensitivity);

--- a/AK/ByteString.h
+++ b/AK/ByteString.h
@@ -110,15 +110,6 @@ public:
     [[nodiscard]] bool matches(StringView mask, CaseSensitivity = CaseSensitivity::CaseInsensitive) const;
     [[nodiscard]] bool matches(StringView mask, Vector<MaskSpan>&, CaseSensitivity = CaseSensitivity::CaseInsensitive) const;
 
-    template<typename T = int>
-    [[nodiscard]] Optional<T> to_int(TrimWhitespace = TrimWhitespace::Yes) const;
-    template<typename T = unsigned>
-    [[nodiscard]] Optional<T> to_uint(TrimWhitespace = TrimWhitespace::Yes) const;
-#ifndef KERNEL
-    [[nodiscard]] Optional<double> to_double(TrimWhitespace = TrimWhitespace::Yes) const;
-    [[nodiscard]] Optional<float> to_float(TrimWhitespace = TrimWhitespace::Yes) const;
-#endif
-
     template<Arithmetic T>
     Optional<T> to_number(TrimWhitespace trim_whitespace = TrimWhitespace::Yes) const
     {

--- a/AK/ByteString.h
+++ b/AK/ByteString.h
@@ -119,6 +119,12 @@ public:
     [[nodiscard]] Optional<float> to_float(TrimWhitespace = TrimWhitespace::Yes) const;
 #endif
 
+    template<Arithmetic T>
+    Optional<T> to_number(TrimWhitespace trim_whitespace = TrimWhitespace::Yes) const
+    {
+        return view().to_number<T>(trim_whitespace);
+    }
+
     [[nodiscard]] ByteString to_lowercase() const;
     [[nodiscard]] ByteString to_uppercase() const;
     [[nodiscard]] ByteString to_snakecase() const;

--- a/AK/DeprecatedFlyString.cpp
+++ b/AK/DeprecatedFlyString.cpp
@@ -71,40 +71,6 @@ DeprecatedFlyString::DeprecatedFlyString(StringView string)
     }
 }
 
-template<typename T>
-Optional<T> DeprecatedFlyString::to_int(TrimWhitespace trim_whitespace) const
-{
-    return StringUtils::convert_to_int<T>(view(), trim_whitespace);
-}
-
-template Optional<i8> DeprecatedFlyString::to_int(TrimWhitespace) const;
-template Optional<i16> DeprecatedFlyString::to_int(TrimWhitespace) const;
-template Optional<i32> DeprecatedFlyString::to_int(TrimWhitespace) const;
-template Optional<i64> DeprecatedFlyString::to_int(TrimWhitespace) const;
-
-template<typename T>
-Optional<T> DeprecatedFlyString::to_uint(TrimWhitespace trim_whitespace) const
-{
-    return StringUtils::convert_to_uint<T>(view(), trim_whitespace);
-}
-
-template Optional<u8> DeprecatedFlyString::to_uint(TrimWhitespace) const;
-template Optional<u16> DeprecatedFlyString::to_uint(TrimWhitespace) const;
-template Optional<u32> DeprecatedFlyString::to_uint(TrimWhitespace) const;
-template Optional<u64> DeprecatedFlyString::to_uint(TrimWhitespace) const;
-
-#ifndef KERNEL
-Optional<double> DeprecatedFlyString::to_double(TrimWhitespace trim_whitespace) const
-{
-    return StringUtils::convert_to_floating_point<double>(view(), trim_whitespace);
-}
-
-Optional<float> DeprecatedFlyString::to_float(TrimWhitespace trim_whitespace) const
-{
-    return StringUtils::convert_to_floating_point<float>(view(), trim_whitespace);
-}
-#endif
-
 bool DeprecatedFlyString::equals_ignoring_ascii_case(StringView other) const
 {
     return StringUtils::equals_ignoring_ascii_case(view(), other);

--- a/AK/DeprecatedFlyString.h
+++ b/AK/DeprecatedFlyString.h
@@ -75,15 +75,6 @@ public:
         return view().to_number<T>(trim_whitespace);
     }
 
-    template<typename T = int>
-    Optional<T> to_int(TrimWhitespace = TrimWhitespace::Yes) const;
-    template<typename T = unsigned>
-    Optional<T> to_uint(TrimWhitespace = TrimWhitespace::Yes) const;
-#ifndef KERNEL
-    Optional<double> to_double(TrimWhitespace = TrimWhitespace::Yes) const;
-    Optional<float> to_float(TrimWhitespace = TrimWhitespace::Yes) const;
-#endif
-
     bool equals_ignoring_ascii_case(StringView) const;
     bool starts_with(StringView, CaseSensitivity = CaseSensitivity::CaseSensitive) const;
     bool ends_with(StringView, CaseSensitivity = CaseSensitivity::CaseSensitive) const;

--- a/AK/DeprecatedFlyString.h
+++ b/AK/DeprecatedFlyString.h
@@ -69,6 +69,12 @@ public:
 
     DeprecatedFlyString to_lowercase() const;
 
+    template<Arithmetic T>
+    Optional<T> to_number(TrimWhitespace trim_whitespace = TrimWhitespace::Yes) const
+    {
+        return view().to_number<T>(trim_whitespace);
+    }
+
     template<typename T = int>
     Optional<T> to_int(TrimWhitespace = TrimWhitespace::Yes) const;
     template<typename T = unsigned>

--- a/AK/IPv4Address.h
+++ b/AK/IPv4Address.h
@@ -108,19 +108,19 @@ public:
         u32 d {};
 
         if (parts.size() == 1) {
-            d = parts[0].to_uint().value_or(256);
+            d = parts[0].to_number<u32>().value_or(256);
         } else if (parts.size() == 2) {
-            a = parts[0].to_uint().value_or(256);
-            d = parts[1].to_uint().value_or(256);
+            a = parts[0].to_number<u32>().value_or(256);
+            d = parts[1].to_number<u32>().value_or(256);
         } else if (parts.size() == 3) {
-            a = parts[0].to_uint().value_or(256);
-            b = parts[1].to_uint().value_or(256);
-            d = parts[2].to_uint().value_or(256);
+            a = parts[0].to_number<u32>().value_or(256);
+            b = parts[1].to_number<u32>().value_or(256);
+            d = parts[2].to_number<u32>().value_or(256);
         } else if (parts.size() == 4) {
-            a = parts[0].to_uint().value_or(256);
-            b = parts[1].to_uint().value_or(256);
-            c = parts[2].to_uint().value_or(256);
-            d = parts[3].to_uint().value_or(256);
+            a = parts[0].to_number<u32>().value_or(256);
+            b = parts[1].to_number<u32>().value_or(256);
+            c = parts[2].to_number<u32>().value_or(256);
+            d = parts[3].to_number<u32>().value_or(256);
         } else {
             return {};
         }

--- a/AK/JsonParser.cpp
+++ b/AK/JsonParser.cpp
@@ -278,13 +278,13 @@ ErrorOr<JsonValue> JsonParser::parse_number()
 
     StringView number_string(number_buffer.data(), number_buffer.size());
 
-    auto to_unsigned_result = number_string.to_uint<u64>();
+    auto to_unsigned_result = number_string.to_number<u64>();
     if (to_unsigned_result.has_value()) {
         if (*to_unsigned_result <= NumericLimits<u32>::max())
             return JsonValue((u32)*to_unsigned_result);
 
         return JsonValue(*to_unsigned_result);
-    } else if (auto signed_number = number_string.to_int<i64>(); signed_number.has_value()) {
+    } else if (auto signed_number = number_string.to_number<i64>(); signed_number.has_value()) {
 
         if (*signed_number <= NumericLimits<i32>::max())
             return JsonValue((i32)*signed_number);

--- a/AK/String.h
+++ b/AK/String.h
@@ -181,14 +181,7 @@ public:
     template<Arithmetic T>
     Optional<T> to_number(TrimWhitespace trim_whitespace = TrimWhitespace::Yes) const
     {
-#ifndef KERNEL
-        if constexpr (IsFloatingPoint<T>)
-            return StringUtils::convert_to_floating_point<T>(bytes_as_string_view(), trim_whitespace);
-#endif
-        if constexpr (IsSigned<T>)
-            return StringUtils::convert_to_int<T>(bytes_as_string_view(), trim_whitespace);
-        else
-            return StringUtils::convert_to_uint<T>(bytes_as_string_view(), trim_whitespace);
+        return bytes_as_string_view().to_number<T>(trim_whitespace);
     }
 
     static ErrorOr<String> vformatted(StringView fmtstr, TypeErasedFormatParams&);

--- a/AK/StringView.cpp
+++ b/AK/StringView.cpp
@@ -222,40 +222,7 @@ bool StringView::copy_characters_to_buffer(char* buffer, size_t buffer_size) con
     return characters_to_copy == m_length;
 }
 
-template<typename T>
-Optional<T> StringView::to_int() const
-{
-    return StringUtils::convert_to_int<T>(*this);
-}
-
-template Optional<i8> StringView::to_int() const;
-template Optional<i16> StringView::to_int() const;
-template Optional<i32> StringView::to_int() const;
-template Optional<long> StringView::to_int() const;
-template Optional<long long> StringView::to_int() const;
-
-template<typename T>
-Optional<T> StringView::to_uint() const
-{
-    return StringUtils::convert_to_uint<T>(*this);
-}
-
-template Optional<u8> StringView::to_uint() const;
-template Optional<u16> StringView::to_uint() const;
-template Optional<u32> StringView::to_uint() const;
-template Optional<unsigned long> StringView::to_uint() const;
-template Optional<unsigned long long> StringView::to_uint() const;
-
 #ifndef KERNEL
-Optional<double> StringView::to_double(TrimWhitespace trim_whitespace) const
-{
-    return StringUtils::convert_to_floating_point<double>(*this, trim_whitespace);
-}
-
-Optional<float> StringView::to_float(TrimWhitespace trim_whitespace) const
-{
-    return StringUtils::convert_to_floating_point<float>(*this, trim_whitespace);
-}
 
 bool StringView::operator==(ByteString const& string) const
 {

--- a/AK/StringView.h
+++ b/AK/StringView.h
@@ -219,15 +219,6 @@ public:
     // following newline.".
     [[nodiscard]] Vector<StringView> lines(bool consider_cr = true) const;
 
-    template<typename T = int>
-    Optional<T> to_int() const;
-    template<typename T = unsigned>
-    Optional<T> to_uint() const;
-#ifndef KERNEL
-    Optional<double> to_double(TrimWhitespace trim_whitespace = TrimWhitespace::Yes) const;
-    Optional<float> to_float(TrimWhitespace trim_whitespace = TrimWhitespace::Yes) const;
-#endif
-
     // Create a new substring view of this string view, starting either at the beginning of
     // the given substring view, or after its end, and continuing until the end of this string
     // view (that is, for the remaining part of its length). For example,

--- a/AK/StringView.h
+++ b/AK/StringView.h
@@ -353,6 +353,19 @@ public:
         }());
     }
 
+    template<Arithmetic T>
+    Optional<T> to_number(TrimWhitespace trim_whitespace = TrimWhitespace::Yes) const
+    {
+#ifndef KERNEL
+        if constexpr (IsFloatingPoint<T>)
+            return StringUtils::convert_to_floating_point<T>(*this, trim_whitespace);
+#endif
+        if constexpr (IsSigned<T>)
+            return StringUtils::convert_to_int<T>(*this, trim_whitespace);
+        else
+            return StringUtils::convert_to_uint<T>(*this, trim_whitespace);
+    }
+
 private:
     friend class ByteString;
     char const* m_characters { nullptr };

--- a/AK/URLParser.cpp
+++ b/AK/URLParser.cpp
@@ -124,7 +124,7 @@ static Optional<ParsedIPv4Number> parse_ipv4_number(StringView input)
     if (radix == 8)
         maybe_output = StringUtils::convert_to_uint_from_octal(input);
     else if (radix == 10)
-        maybe_output = input.to_uint();
+        maybe_output = input.to_number<u32>();
     else if (radix == 16)
         maybe_output = StringUtils::convert_to_uint_from_hex(input);
     else
@@ -1292,10 +1292,11 @@ URL URLParser::basic_parse(StringView raw_input, Optional<URL> const& base_url, 
                 // 1. If buffer is not the empty string, then:
                 if (!buffer.is_empty()) {
                     // 1. Let port be the mathematical integer value that is represented by buffer in radix-10 using ASCII digits for digits with values 0 through 9.
-                    auto port = buffer.string_view().to_uint();
+                    auto port = buffer.string_view().to_number<u16>();
 
                     // 2. If port is greater than 2^16 − 1, port-out-of-range validation error, return failure.
-                    if (!port.has_value() || port.value() > 65535) {
+                    // NOTE: This is done by to_number.
+                    if (!port.has_value()) {
                         report_validation_error();
                         return {};
                     }

--- a/Base/usr/share/man/man2/readlink.md
+++ b/Base/usr/share/man/man2/readlink.md
@@ -55,9 +55,9 @@ pid_t read_pid_using_readlink()
 
 ErrorOr<pid_t> read_pid_using_core_file()
 {
-    auto target = TRY(File::read_link("/proc/self"sv));
-    auto pid = target.to_uint();
-    ASSERT(pid.has_value());
+    auto target = TRY(FileSystem::read_link("/proc/self"sv));
+    auto pid = target.to_number<pid_t>();
+    VERIFY(pid.has_value());
     return pid.value();
 }
 ```

--- a/Kernel/Boot/CommandLine.cpp
+++ b/Kernel/Boot/CommandLine.cpp
@@ -316,7 +316,7 @@ Vector<NonnullOwnPtr<KString>> CommandLine::userspace_init_args() const
 UNMAP_AFTER_INIT size_t CommandLine::switch_to_tty() const
 {
     auto const default_tty = lookup("switch_to_tty"sv).value_or("1"sv);
-    auto switch_tty_number = default_tty.to_uint();
+    auto switch_tty_number = default_tty.to_number<unsigned>();
     if (switch_tty_number.has_value() && switch_tty_number.value() >= 1) {
         return switch_tty_number.value() - 1;
     }

--- a/Kernel/Devices/Storage/StorageManagement.cpp
+++ b/Kernel/Devices/Storage/StorageManagement.cpp
@@ -248,7 +248,7 @@ UNMAP_AFTER_INIT Optional<unsigned> StorageManagement::extract_boot_device_parti
         PANIC("StorageManagement: Invalid root boot parameter.");
     }
 
-    auto parameter_number = parameter_view.substring_view(partition_number_prefix.length()).to_uint<unsigned>();
+    auto parameter_number = parameter_view.substring_view(partition_number_prefix.length()).to_number<unsigned>();
     if (!parameter_number.has_value()) {
         PANIC("StorageManagement: Invalid root boot parameter.");
     }
@@ -268,7 +268,7 @@ UNMAP_AFTER_INIT Array<unsigned, 3> StorageManagement::extract_boot_device_addre
             return;
         if (parts_count > 2)
             return;
-        auto parameter_number = parameter_view.to_uint<unsigned>();
+        auto parameter_number = parameter_view.to_number<unsigned>();
         if (!parameter_number.has_value()) {
             parse_failure = true;
             return;

--- a/Kernel/FileSystem/DevPtsFS/Inode.cpp
+++ b/Kernel/FileSystem/DevPtsFS/Inode.cpp
@@ -70,7 +70,7 @@ ErrorOr<NonnullRefPtr<Inode>> DevPtsFSInode::lookup(StringView name)
     if (name == "." || name == "..")
         return *this;
 
-    auto pty_index = name.to_uint();
+    auto pty_index = name.to_number<unsigned>();
     if (!pty_index.has_value())
         return ENOENT;
 

--- a/Kernel/FileSystem/ProcFS/Inode.cpp
+++ b/Kernel/FileSystem/ProcFS/Inode.cpp
@@ -159,7 +159,7 @@ ErrorOr<NonnullRefPtr<Inode>> ProcFSInode::lookup_as_root_directory(StringView n
     if (name == "self"sv)
         return procfs().get_inode({ fsid(), 2 });
 
-    auto pid = name.to_uint<unsigned>();
+    auto pid = name.to_number<unsigned>();
     if (!pid.has_value())
         return ESRCH;
     auto actual_pid = pid.value();

--- a/Kernel/FileSystem/ProcFS/ProcessExposed.cpp
+++ b/Kernel/FileSystem/ProcFS/ProcessExposed.cpp
@@ -79,7 +79,7 @@ ErrorOr<void> Process::traverse_stacks_directory(FileSystemID fsid, Function<Err
 
 ErrorOr<NonnullRefPtr<Inode>> Process::lookup_stacks_directory(ProcFS& procfs, StringView name) const
 {
-    auto maybe_needle = name.to_uint();
+    auto maybe_needle = name.to_number<unsigned>();
     if (!maybe_needle.has_value())
         return ENOENT;
     auto needle = maybe_needle.release_value();
@@ -120,7 +120,7 @@ ErrorOr<void> Process::traverse_children_directory(FileSystemID fsid, Function<E
 
 ErrorOr<NonnullRefPtr<Inode>> Process::lookup_children_directory(ProcFS& procfs, StringView name) const
 {
-    auto maybe_pid = name.to_uint();
+    auto maybe_pid = name.to_number<unsigned>();
     if (!maybe_pid.has_value())
         return ENOENT;
 
@@ -173,7 +173,7 @@ ErrorOr<void> Process::traverse_file_descriptions_directory(FileSystemID fsid, F
 
 ErrorOr<NonnullRefPtr<Inode>> Process::lookup_file_descriptions_directory(ProcFS& procfs, StringView name) const
 {
-    auto maybe_index = name.to_uint();
+    auto maybe_index = name.to_number<unsigned>();
     if (!maybe_index.has_value())
         return ENOENT;
 

--- a/Meta/Lagom/Tools/CodeGenerators/JSSpecCompiler/Parser/CppASTConverter.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/JSSpecCompiler/Parser/CppASTConverter.cpp
@@ -122,7 +122,7 @@ template<>
 NullableTree CppASTConverter::convert_node(Cpp::NumericLiteral const& literal)
 {
     // TODO: Numerical literals are not limited to i64.
-    return make_ref_counted<MathematicalConstant>(literal.value().to_int<i64>().value());
+    return make_ref_counted<MathematicalConstant>(literal.value().to_number<i64>().value());
 }
 
 template<>

--- a/Meta/Lagom/Tools/CodeGenerators/JSSpecCompiler/Parser/TextParser.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/JSSpecCompiler/Parser/TextParser.cpp
@@ -254,7 +254,7 @@ ParseErrorOr<Tree> TextParser::parse_expression()
             if (token.type == TokenType::Identifier) {
                 expression = make_ref_counted<UnresolvedReference>(token.data);
             } else if (token.type == TokenType::Number) {
-                expression = make_ref_counted<MathematicalConstant>(token.data.to_int<i64>().value());
+                expression = make_ref_counted<MathematicalConstant>(token.data.to_number<i64>().value());
             } else if (token.type == TokenType::String) {
                 expression = make_ref_counted<StringLiteral>(token.data);
             } else {

--- a/Meta/Lagom/Tools/CodeGenerators/LibEDID/GeneratePnpIDs.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibEDID/GeneratePnpIDs.cpp
@@ -26,19 +26,19 @@ static ErrorOr<ApprovalDate> parse_approval_date(StringView date)
     if (parts.size() != 3)
         return Error::from_string_literal("Failed to parse approval date parts (mm/dd/yyyy)");
 
-    auto month = parts[0].to_uint();
+    auto month = parts[0].to_number<unsigned>();
     if (!month.has_value())
         return Error::from_string_literal("Failed to parse month from approval date");
     if (month.value() == 0 || month.value() > 12)
         return Error::from_string_literal("Invalid month in approval date");
 
-    auto day = parts[1].to_uint();
+    auto day = parts[1].to_number<unsigned>();
     if (!day.has_value())
         return Error::from_string_literal("Failed to parse day from approval date");
     if (day.value() == 0 || day.value() > 31)
         return Error::from_string_literal("Invalid day in approval date");
 
-    auto year = parts[2].to_uint();
+    auto year = parts[2].to_number<unsigned>();
     if (!year.has_value())
         return Error::from_string_literal("Failed to parse year from approval date");
     if (year.value() < 1900 || year.value() > 2999)

--- a/Meta/Lagom/Tools/CodeGenerators/LibLocale/GenerateDateTimeFormatData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibLocale/GenerateDateTimeFormatData.cpp
@@ -652,7 +652,7 @@ static ErrorOr<void> parse_week_data(ByteString core_path, CLDR& cldr)
     auto const& weekend_end_object = week_data_object.get_object("weekendEnd"sv).value();
 
     minimum_days_object.for_each_member([&](auto const& region, auto const& value) {
-        auto minimum_days = value.as_string().template to_uint<u8>();
+        auto minimum_days = value.as_string().template to_number<u8>();
         cldr.minimum_days.set(region, *minimum_days);
 
         if (!cldr.minimum_days_regions.contains_slow(region))
@@ -1279,7 +1279,7 @@ static void parse_calendar_symbols(Calendar& calendar, JsonObject const& calenda
         auto symbol_lists = create_symbol_lists(2);
 
         auto append_symbol = [&](auto& symbols, auto const& key, auto symbol) {
-            if (auto key_index = key.to_uint(); key_index.has_value())
+            if (auto key_index = key.template to_number<unsigned>(); key_index.has_value())
                 symbols[*key_index] = cldr.unique_strings.ensure(move(symbol));
         };
 
@@ -1303,7 +1303,7 @@ static void parse_calendar_symbols(Calendar& calendar, JsonObject const& calenda
         auto symbol_lists = create_symbol_lists(12);
 
         auto append_symbol = [&](auto& symbols, auto const& key, auto symbol) {
-            auto key_index = key.to_uint().value() - 1;
+            auto key_index = key.template to_number<unsigned>().value() - 1;
             symbols[key_index] = cldr.unique_strings.ensure(move(symbol));
         };
 
@@ -1611,7 +1611,7 @@ static ErrorOr<void> parse_day_periods(ByteString core_path, CLDR& cldr)
         VERIFY(time.substring_view(hour_end_index) == ":00"sv);
 
         auto hour = time.substring_view(0, hour_end_index);
-        return hour.template to_uint<u8>().value();
+        return hour.template to_number<u8>().value();
     };
 
     auto parse_day_period = [&](auto const& symbol, auto const& ranges) -> Optional<DayPeriod> {

--- a/Meta/Lagom/Tools/CodeGenerators/LibLocale/GenerateNumberFormatData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibLocale/GenerateNumberFormatData.cpp
@@ -441,7 +441,7 @@ static ErrorOr<void> parse_number_systems(ByteString locale_numbers_path, CLDR& 
             auto patterns = value.as_string().split(';');
             NumberFormat format {};
 
-            if (auto type = split_key[0].template to_uint<u64>(); type.has_value()) {
+            if (auto type = split_key[0].template to_number<u64>(); type.has_value()) {
                 VERIFY(*type % 10 == 0);
                 format.magnitude = static_cast<u8>(log10(*type));
 
@@ -580,7 +580,7 @@ static ErrorOr<void> parse_number_systems(ByteString locale_numbers_path, CLDR& 
         locale.number_systems.append(system_index);
     }
 
-    locale.minimum_grouping_digits = minimum_grouping_digits.template to_uint<u8>().value();
+    locale.minimum_grouping_digits = minimum_grouping_digits.template to_number<u8>().value();
     return {};
 }
 

--- a/Meta/Lagom/Tools/CodeGenerators/LibLocale/GeneratePluralRulesData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibLocale/GeneratePluralRulesData.cpp
@@ -245,7 +245,7 @@ static Relation parse_relation(StringView relation)
         auto symbol = lhs.substring_view(0, *index);
         VERIFY(symbol.length() == 1);
 
-        auto modulus = lhs.substring_view(*index + modulus_operator.length()).to_uint();
+        auto modulus = lhs.substring_view(*index + modulus_operator.length()).to_number<unsigned>();
         VERIFY(modulus.has_value());
 
         parsed.symbol = symbol[0];
@@ -257,15 +257,15 @@ static Relation parse_relation(StringView relation)
 
     rhs.for_each_split_view(set_operator, SplitBehavior::Nothing, [&](auto set) {
         if (auto index = set.find(range_operator); index.has_value()) {
-            auto range_begin = set.substring_view(0, *index).to_uint();
+            auto range_begin = set.substring_view(0, *index).template to_number<unsigned>();
             VERIFY(range_begin.has_value());
 
-            auto range_end = set.substring_view(*index + range_operator.length()).to_uint();
+            auto range_end = set.substring_view(*index + range_operator.length()).template to_number<unsigned>();
             VERIFY(range_end.has_value());
 
             parsed.comparators.empend(Array { *range_begin, *range_end });
         } else {
-            auto value = set.to_uint();
+            auto value = set.template to_number<unsigned>();
             VERIFY(value.has_value());
 
             parsed.comparators.empend(*value);

--- a/Meta/Lagom/Tools/CodeGenerators/LibTimeZone/GenerateTimeZoneData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibTimeZone/GenerateTimeZoneData.cpp
@@ -172,7 +172,7 @@ static Optional<DateTime> parse_date_time(ReadonlySpan<StringView> segments)
         return {};
 
     DateTime date_time {};
-    date_time.year = segments[0].to_uint().value();
+    date_time.year = segments[0].to_number<unsigned>().value();
 
     if (segments.size() > 1)
         date_time.month = find_index(short_month_names.begin(), short_month_names.end(), segments[1]) + 1;
@@ -186,15 +186,15 @@ static Optional<DateTime> parse_date_time(ReadonlySpan<StringView> segments)
             date_time.after_weekday = find_index(short_day_names.begin(), short_day_names.end(), weekday);
 
             auto day = segments[2].substring_view(*index + ">="sv.length());
-            date_time.day = day.to_uint().value();
+            date_time.day = day.to_number<unsigned>().value();
         } else if (auto index = segments[2].find("<="sv); index.has_value()) {
             auto weekday = segments[2].substring_view(0, *index);
             date_time.before_weekday = find_index(short_day_names.begin(), short_day_names.end(), weekday);
 
             auto day = segments[2].substring_view(*index + "<="sv.length());
-            date_time.day = day.to_uint().value();
+            date_time.day = day.to_number<unsigned>().value();
         } else {
-            date_time.day = segments[2].to_uint().value();
+            date_time.day = segments[2].to_number<unsigned>().value();
         }
     }
 
@@ -202,9 +202,9 @@ static Optional<DateTime> parse_date_time(ReadonlySpan<StringView> segments)
         // FIXME: Some times end with a letter, e.g. "2:00u" and "2:00s". Figure out what this means and handle it.
         auto time_segments = segments[3].split_view(':');
 
-        date_time.hour = time_segments[0].to_int().value();
-        date_time.minute = time_segments.size() > 1 ? time_segments[1].substring_view(0, 2).to_uint().value() : 0;
-        date_time.second = time_segments.size() > 2 ? time_segments[2].substring_view(0, 2).to_uint().value() : 0;
+        date_time.hour = time_segments[0].to_number<int>().value();
+        date_time.minute = time_segments.size() > 1 ? time_segments[1].substring_view(0, 2).to_number<unsigned>().value() : 0;
+        date_time.second = time_segments.size() > 2 ? time_segments[2].substring_view(0, 2).to_number<unsigned>().value() : 0;
     }
 
     return date_time;
@@ -214,9 +214,9 @@ static i64 parse_time_offset(StringView segment)
 {
     auto segments = segment.split_view(':');
 
-    i64 hours = segments[0].to_int().value();
-    i64 minutes = segments.size() > 1 ? segments[1].to_uint().value() : 0;
-    i64 seconds = segments.size() > 2 ? segments[2].to_uint().value() : 0;
+    i64 hours = segments[0].to_number<int>().value();
+    i64 minutes = segments.size() > 1 ? segments[1].to_number<unsigned>().value() : 0;
+    i64 seconds = segments.size() > 2 ? segments[2].to_number<unsigned>().value() : 0;
 
     i64 sign = ((hours < 0) || (segments[0] == "-0"sv)) ? -1 : 1;
     return (hours * 3600) + sign * ((minutes * 60) + seconds);
@@ -309,12 +309,12 @@ static void parse_rule(StringView rule_line, TimeZoneData& time_zone_data)
 
     DaylightSavingsOffset dst_offset {};
     dst_offset.offset = parse_time_offset(segments[8]);
-    dst_offset.year_from = segments[2].to_uint().value();
+    dst_offset.year_from = segments[2].to_number<unsigned>().value();
 
     if (segments[3] == "only")
         dst_offset.year_to = dst_offset.year_from;
     else if (segments[3] != "max"sv)
-        dst_offset.year_to = segments[3].to_uint().value();
+        dst_offset.year_to = segments[3].to_number<unsigned>().value();
 
     auto in_effect = Array { "0"sv, segments[5], segments[6], segments[7] };
     dst_offset.in_effect = parse_date_time(in_effect).release_value();
@@ -369,22 +369,22 @@ static ErrorOr<void> parse_time_zone_coordinates(Core::InputBufferedFile& file, 
 
         if (coordinate.length() == 5) {
             // ±DDMM
-            parsed.degrees = coordinate.substring_view(0, 3).to_int().value();
-            parsed.minutes = coordinate.substring_view(3).to_int().value();
+            parsed.degrees = coordinate.substring_view(0, 3).template to_number<int>().value();
+            parsed.minutes = coordinate.substring_view(3).template to_number<int>().value();
         } else if (coordinate.length() == 6) {
             // ±DDDMM
-            parsed.degrees = coordinate.substring_view(0, 4).to_int().value();
-            parsed.minutes = coordinate.substring_view(4).to_int().value();
+            parsed.degrees = coordinate.substring_view(0, 4).template to_number<int>().value();
+            parsed.minutes = coordinate.substring_view(4).template to_number<int>().value();
         } else if (coordinate.length() == 7) {
             // ±DDMMSS
-            parsed.degrees = coordinate.substring_view(0, 3).to_int().value();
-            parsed.minutes = coordinate.substring_view(3, 2).to_int().value();
-            parsed.seconds = coordinate.substring_view(5).to_int().value();
+            parsed.degrees = coordinate.substring_view(0, 3).template to_number<int>().value();
+            parsed.minutes = coordinate.substring_view(3, 2).template to_number<int>().value();
+            parsed.seconds = coordinate.substring_view(5).template to_number<int>().value();
         } else if (coordinate.length() == 8) {
             // ±DDDDMMSS
-            parsed.degrees = coordinate.substring_view(0, 4).to_int().value();
-            parsed.minutes = coordinate.substring_view(4, 2).to_int().value();
-            parsed.seconds = coordinate.substring_view(6).to_int().value();
+            parsed.degrees = coordinate.substring_view(0, 4).template to_number<int>().value();
+            parsed.minutes = coordinate.substring_view(4, 2).template to_number<int>().value();
+            parsed.seconds = coordinate.substring_view(6).template to_number<int>().value();
         } else {
             VERIFY_NOT_REACHED();
         }

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -675,7 +675,7 @@ static void generate_to_cpp(SourceGenerator& generator, ParameterType& parameter
     else
         @cpp_name@ = JS::js_null();
 )~~~");
-                } else if (optional_default_value->to_int().has_value() || optional_default_value->to_uint().has_value()) {
+                } else if (optional_default_value->to_number<int>().has_value() || optional_default_value->to_number<unsigned>().has_value()) {
                     scoped_generator.append(R"~~~(
     else
         @cpp_name@ = JS::Value(@parameter.optional_default_value@);
@@ -1428,7 +1428,7 @@ static void generate_to_cpp(SourceGenerator& generator, ParameterType& parameter
                         union_generator.append(R"~~~(
     @union_type@ @cpp_name@ = @js_name@@js_suffix@.is_undefined() ? TRY(@js_name@@js_suffix@_to_dictionary(@js_name@@js_suffix@)) : TRY(@js_name@@js_suffix@_to_variant(@js_name@@js_suffix@));
 )~~~");
-                    } else if (optional_default_value->to_int().has_value() || optional_default_value->to_uint().has_value()) {
+                    } else if (optional_default_value->to_number<int>().has_value() || optional_default_value->to_number<unsigned>().has_value()) {
                         union_generator.append(R"~~~(
     @union_type@ @cpp_name@ = @js_name@@js_suffix@.is_undefined() ? @parameter.optional_default_value@ : TRY(@js_name@@js_suffix@_to_variant(@js_name@@js_suffix@));
 )~~~");

--- a/Meta/Lagom/Tools/CodeGenerators/StateMachineGenerator/main.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/StateMachineGenerator/main.cpp
@@ -92,7 +92,7 @@ parse_state_machine(StringView input)
             if (lexer.next_is('\\')) {
                 num = (int)lexer.consume_escaped_character('\\');
             } else {
-                num = lexer.consume_until('\'').to_int().value();
+                num = lexer.consume_until('\'').to_number<int>().value();
                 lexer.ignore();
             }
             lexer.consume_specific('\'');

--- a/Tests/AK/TestByteString.cpp
+++ b/Tests/AK/TestByteString.cpp
@@ -125,8 +125,8 @@ TEST_CASE(repeated)
 
 TEST_CASE(to_int)
 {
-    EXPECT_EQ(ByteString("123").to_int().value(), 123);
-    EXPECT_EQ(ByteString("-123").to_int().value(), -123);
+    EXPECT_EQ(ByteString("123").to_number<int>().value(), 123);
+    EXPECT_EQ(ByteString("-123").to_number<int>().value(), -123);
 }
 
 TEST_CASE(to_lowercase)

--- a/Tests/AK/TestFloatingPointParsing.cpp
+++ b/Tests/AK/TestFloatingPointParsing.cpp
@@ -578,14 +578,14 @@ TEST_CASE(invalid_hex_floats)
     EXPECT_HEX_PARSE_TO_VALUE_AND_CONSUME_CHARS("0xCAPE", 0xCAp0, 4);
 }
 
-#define BENCHMARK_DOUBLE_PARSING(value, iterations)     \
-    do {                                                \
-        auto data = #value##sv;                         \
-        auto true_result = value;                       \
-        for (int i = 0; i < iterations * 10'000; ++i) { \
-            AK::taint_for_optimizer(data);              \
-            EXPECT_EQ(data.to_double(), true_result);   \
-        }                                               \
+#define BENCHMARK_DOUBLE_PARSING(value, iterations)           \
+    do {                                                      \
+        auto data = #value##sv;                               \
+        auto true_result = value;                             \
+        for (int i = 0; i < iterations * 10'000; ++i) {       \
+            AK::taint_for_optimizer(data);                    \
+            EXPECT_EQ(data.to_number<double>(), true_result); \
+        }                                                     \
     } while (false)
 
 BENCHMARK_CASE(one)

--- a/Tests/AK/TestHashMap.cpp
+++ b/Tests/AK/TestHashMap.cpp
@@ -157,7 +157,7 @@ TEST_CASE(many_strings)
     }
     EXPECT_EQ(strings.size(), 999u);
     for (auto& it : strings) {
-        EXPECT_EQ(it.key.to_int().value(), it.value);
+        EXPECT_EQ(it.key.to_number<int>().value(), it.value);
     }
     for (int i = 0; i < 999; ++i) {
         EXPECT_EQ(strings.remove(ByteString::number(i)), true);

--- a/Tests/AK/TestQueue.cpp
+++ b/Tests/AK/TestQueue.cpp
@@ -52,7 +52,7 @@ TEST_CASE(order)
     }
 
     for (int i = 0; i < 10000; ++i) {
-        EXPECT_EQ(strings.dequeue().to_int().value(), i);
+        EXPECT_EQ(strings.dequeue().to_number<int>().value(), i);
     }
 
     EXPECT(strings.is_empty());

--- a/Userland/Applets/ClipboardHistory/ClipboardHistoryModel.cpp
+++ b/Userland/Applets/ClipboardHistory/ClipboardHistoryModel.cpp
@@ -41,7 +41,7 @@ ErrorOr<String> ClipboardHistoryModel::column_name(int column) const
 
 static StringView bpp_for_format_resilient(ByteString format)
 {
-    unsigned format_uint = format.to_uint().value_or(static_cast<unsigned>(Gfx::BitmapFormat::Invalid));
+    unsigned format_uint = format.to_number<unsigned>().value_or(static_cast<unsigned>(Gfx::BitmapFormat::Invalid));
     // Cannot use Gfx::Bitmap::bpp_for_format here, as we have to accept invalid enum values.
     switch (static_cast<Gfx::BitmapFormat>(format_uint)) {
     case Gfx::BitmapFormat::BGRx8888:
@@ -79,10 +79,10 @@ GUI::Variant ClipboardHistoryModel::data(const GUI::ModelIndex& index, GUI::Mode
         }
         if (data_and_type.mime_type.starts_with("glyph/"sv)) {
             StringBuilder builder;
-            auto count = data_and_type.metadata.get("count").value().to_uint().value_or(0);
-            auto start = data_and_type.metadata.get("start").value().to_uint().value_or(0);
-            auto width = data_and_type.metadata.get("width").value().to_uint().value_or(0);
-            auto height = data_and_type.metadata.get("height").value().to_uint().value_or(0);
+            auto count = data_and_type.metadata.get("count").value().to_number<unsigned>().value_or(0);
+            auto start = data_and_type.metadata.get("start").value().to_number<unsigned>().value_or(0);
+            auto width = data_and_type.metadata.get("width").value().to_number<unsigned>().value_or(0);
+            auto height = data_and_type.metadata.get("height").value().to_number<unsigned>().value_or(0);
             if (count > 1) {
                 builder.appendff("U+{:04X}..U+{:04X} ({} glyphs) [{}x{}]", start, start + count - 1, count, width, height);
             } else {

--- a/Userland/Applications/3DFileViewer/WavefrontOBJLoader.cpp
+++ b/Userland/Applications/3DFileViewer/WavefrontOBJLoader.cpp
@@ -13,12 +13,12 @@
 
 static inline GLuint get_index_value(StringView& representation)
 {
-    return representation.to_uint().value_or(1) - 1;
+    return representation.to_number<GLuint>().value_or(1) - 1;
 }
 
 static ErrorOr<GLfloat> parse_float(StringView string)
 {
-    auto maybe_float = string.to_float(TrimWhitespace::No);
+    auto maybe_float = string.to_number<GLfloat>(TrimWhitespace::No);
     if (!maybe_float.has_value())
         return Error::from_string_literal("Wavefront: Expected floating point value when parsing TexCoord line");
 

--- a/Userland/Applications/Debugger/main.cpp
+++ b/Userland/Applications/Debugger/main.cpp
@@ -61,7 +61,7 @@ static bool handle_disassemble_command(ByteString const& command, FlatPtr first_
     auto parts = command.split(' ');
     size_t number_of_instructions_to_disassemble = 5;
     if (parts.size() == 2) {
-        auto number = parts[1].to_uint();
+        auto number = parts[1].to_number<unsigned>();
         if (!number.has_value())
             return false;
         number_of_instructions_to_disassemble = number.value();
@@ -142,7 +142,7 @@ static bool handle_breakpoint_command(ByteString const& command)
         auto source_arguments = argument.split(':');
         if (source_arguments.size() != 2)
             return false;
-        auto line = source_arguments[1].to_uint();
+        auto line = source_arguments[1].to_number<unsigned>();
         if (!line.has_value())
             return false;
         auto file = source_arguments[0];

--- a/Userland/Applications/FileManager/FileOperationProgressWidget.cpp
+++ b/Userland/Applications/FileManager/FileOperationProgressWidget.cpp
@@ -106,12 +106,12 @@ FileOperationProgressWidget::FileOperationProgressWidget(FileOperation operation
         if (parts[0] == "PROGRESS"sv) {
             VERIFY(parts.size() >= 8);
             did_progress(
-                parts[3].to_uint().value_or(0),
-                parts[4].to_uint().value_or(0),
-                parts[1].to_uint().value_or(0),
-                parts[2].to_uint().value_or(0),
-                parts[5].to_uint().value_or(0),
-                parts[6].to_uint().value_or(0),
+                parts[3].to_number<unsigned>().value_or(0),
+                parts[4].to_number<unsigned>().value_or(0),
+                parts[1].to_number<unsigned>().value_or(0),
+                parts[2].to_number<unsigned>().value_or(0),
+                parts[5].to_number<unsigned>().value_or(0),
+                parts[6].to_number<unsigned>().value_or(0),
                 parts[7]);
         }
     };

--- a/Userland/Applications/FontEditor/MainWidget.cpp
+++ b/Userland/Applications/FontEditor/MainWidget.cpp
@@ -1057,11 +1057,11 @@ void MainWidget::paste_glyphs()
     if (!mime_type.starts_with("glyph/x-fonteditor"sv))
         return;
 
-    auto glyph_count = metadata.get("count").value().to_uint().value_or(0);
+    auto glyph_count = metadata.get("count").value().to_number<unsigned>().value_or(0);
     if (!glyph_count)
         return;
 
-    auto height = metadata.get("height").value().to_uint().value_or(0);
+    auto height = metadata.get("height").value().to_number<unsigned>().value_or(0);
     if (!height)
         return;
 

--- a/Userland/Applications/Maps/SearchPanel.cpp
+++ b/Userland/Applications/Maps/SearchPanel.cpp
@@ -96,17 +96,17 @@ void SearchPanel::search(StringView query)
             // FIXME: Handle JSON parsing errors
             auto const& json_place = json_places.at(i).as_object();
 
-            MapWidget::LatLng latlng = { json_place.get_byte_string("lat"sv).release_value().to_double().release_value(),
-                json_place.get_byte_string("lon"sv).release_value().to_double().release_value() };
+            MapWidget::LatLng latlng = { json_place.get_byte_string("lat"sv).release_value().to_number<double>().release_value(),
+                json_place.get_byte_string("lon"sv).release_value().to_number<double>().release_value() };
             String name = MUST(String::formatted("{}\n{:.5}, {:.5}", json_place.get_byte_string("display_name"sv).release_value(), latlng.latitude, latlng.longitude));
 
             // Calculate the right zoom level for bounding box
             auto const& json_boundingbox = json_place.get_array("boundingbox"sv);
             MapWidget::LatLngBounds bounds = {
-                { json_boundingbox->at(0).as_string().to_double().release_value(),
-                    json_boundingbox->at(2).as_string().to_double().release_value() },
-                { json_boundingbox->at(1).as_string().to_double().release_value(),
-                    json_boundingbox->at(3).as_string().to_double().release_value() }
+                { json_boundingbox->at(0).as_string().to_number<double>().release_value(),
+                    json_boundingbox->at(2).as_string().to_number<double>().release_value() },
+                { json_boundingbox->at(1).as_string().to_number<double>().release_value(),
+                    json_boundingbox->at(3).as_string().to_number<double>().release_value() }
             };
 
             m_places.append({ name, latlng, bounds.get_zoom() });

--- a/Userland/Applications/Maps/main.cpp
+++ b/Userland/Applications/Maps/main.cpp
@@ -60,8 +60,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     // Map widget
     Maps::UsersMapWidget::Options options {};
-    options.center.latitude = Config::read_string("Maps"sv, "MapView"sv, "CenterLatitude"sv, "30"sv).to_double().value_or(30.0);
-    options.center.longitude = Config::read_string("Maps"sv, "MapView"sv, "CenterLongitude"sv, "0"sv).to_double().value_or(0.0);
+    options.center.latitude = Config::read_string("Maps"sv, "MapView"sv, "CenterLatitude"sv, "30"sv).to_number<double>().value_or(30.0);
+    options.center.longitude = Config::read_string("Maps"sv, "MapView"sv, "CenterLongitude"sv, "0"sv).to_number<double>().value_or(0.0);
     options.zoom = Config::read_i32("Maps"sv, "MapView"sv, "Zoom"sv, MAP_ZOOM_DEFAULT);
     auto& map_widget = main_widget.add<Maps::UsersMapWidget>(options);
     map_widget.set_frame_style(Gfx::FrameStyle::SunkenContainer);

--- a/Userland/Applications/PDFViewer/NumericInput.cpp
+++ b/Userland/Applications/PDFViewer/NumericInput.cpp
@@ -12,7 +12,7 @@ NumericInput::NumericInput()
     set_text("0"sv);
 
     on_change = [&] {
-        auto number_opt = text().to_int();
+        auto number_opt = text().to_number<int>();
         if (number_opt.has_value()) {
             set_current_number(number_opt.value(), GUI::AllowCallback::No);
             return;
@@ -26,7 +26,7 @@ NumericInput::NumericInput()
             first = false;
         }
 
-        auto new_number_opt = builder.to_byte_string().to_int();
+        auto new_number_opt = builder.to_byte_string().to_number<int>();
         if (!new_number_opt.has_value()) {
             m_needs_text_reset = true;
             return;

--- a/Userland/Applications/PixelPaint/EditGuideDialog.cpp
+++ b/Userland/Applications/PixelPaint/EditGuideDialog.cpp
@@ -80,7 +80,7 @@ Optional<float> EditGuideDialog::offset_as_pixel(ImageEditor const& editor)
 {
     float offset = 0;
     if (m_offset.ends_with('%')) {
-        auto percentage = m_offset.substring_view(0, m_offset.length() - 1).to_int();
+        auto percentage = m_offset.substring_view(0, m_offset.length() - 1).to_number<int>();
         if (!percentage.has_value())
             return {};
 
@@ -89,7 +89,7 @@ Optional<float> EditGuideDialog::offset_as_pixel(ImageEditor const& editor)
         else if (orientation() == PixelPaint::Guide::Orientation::Vertical)
             offset = editor.image().size().width() * ((double)percentage.value() / 100.0);
     } else {
-        auto parsed_int = m_offset.to_int();
+        auto parsed_int = m_offset.to_number<int>();
         if (!parsed_int.has_value())
             return {};
         offset = parsed_int.value();

--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -927,7 +927,7 @@ ByteString ImageEditor::generate_unique_layer_name(ByteString const& original_la
 
     auto after_copy_suffix_view = original_layer_name.substring_view(copy_suffix_index.value() + copy_string_view.length());
     if (!after_copy_suffix_view.is_empty()) {
-        auto after_copy_suffix_number = after_copy_suffix_view.trim_whitespace().to_int();
+        auto after_copy_suffix_number = after_copy_suffix_view.trim_whitespace().to_number<int>();
         if (!after_copy_suffix_number.has_value())
             return ByteString::formatted("{}{}", original_layer_name, copy_string_view);
     }

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -370,8 +370,8 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
         auto layer_x_position = data_and_type.metadata.get("pixelpaint-layer-x");
         auto layer_y_position = data_and_type.metadata.get("pixelpaint-layer-y");
         if (layer_x_position.has_value() && layer_y_position.has_value()) {
-            auto x = layer_x_position.value().to_int();
-            auto y = layer_y_position.value().to_int();
+            auto x = layer_x_position.value().to_number<int>();
+            auto y = layer_y_position.value().to_number<int>();
             if (x.has_value() && x.value()) {
                 auto pasted_layer_location = Gfx::IntPoint { x.value(), y.value() };
 
@@ -1211,7 +1211,7 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
             }
         }
 
-        auto zoom_level_optional = value.view().trim("%"sv, TrimMode::Right).to_int();
+        auto zoom_level_optional = value.view().trim("%"sv, TrimMode::Right).to_number<int>();
         if (!zoom_level_optional.has_value()) {
             // Indicate that a parse-error occurred by resetting the text to the current state.
             editor->on_scale_change(editor->scale());

--- a/Userland/Applications/PixelPaint/Tools/EllipseTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/EllipseTool.cpp
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2019-2023, Shannon Booth <shannon@serenityos.org>
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2021, Mustafa Quraish <mustafa@serenityos.org>
  * Copyright (c) 2022, the SerenityOS developers.
@@ -188,8 +189,8 @@ NonnullRefPtr<GUI::Widget> EllipseTool::get_properties_widget()
         m_aspect_w_textbox->set_fixed_height(20);
         m_aspect_w_textbox->set_fixed_width(25);
         m_aspect_w_textbox->on_change = [this] {
-            auto x = m_aspect_w_textbox->text().to_int().value_or(0);
-            auto y = m_aspect_h_textbox->text().to_int().value_or(0);
+            auto x = m_aspect_w_textbox->text().to_number<int>().value_or(0);
+            auto y = m_aspect_h_textbox->text().to_number<int>().value_or(0);
             if (x > 0 && y > 0) {
                 m_aspect_ratio = (float)x / (float)y;
             } else {

--- a/Userland/Applications/PixelPaint/Tools/RectangleTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/RectangleTool.cpp
@@ -237,8 +237,8 @@ NonnullRefPtr<GUI::Widget> RectangleTool::get_properties_widget()
         m_aspect_w_textbox->set_fixed_height(20);
         m_aspect_w_textbox->set_fixed_width(25);
         m_aspect_w_textbox->on_change = [this] {
-            auto x = m_aspect_w_textbox->text().to_int().value_or(0);
-            auto y = m_aspect_h_textbox->text().to_int().value_or(0);
+            auto x = m_aspect_w_textbox->text().to_number<int>().value_or(0);
+            auto y = m_aspect_h_textbox->text().to_number<int>().value_or(0);
             if (x > 0 && y > 0) {
                 m_aspect_ratio = (float)x / (float)y;
             } else {

--- a/Userland/Applications/Presenter/Presentation.cpp
+++ b/Userland/Applications/Presenter/Presentation.cpp
@@ -148,12 +148,12 @@ ErrorOr<Gfx::IntSize> Presentation::parse_presentation_size(JsonObject const& me
         return Error::from_string_view("Width or aspect in incorrect format"sv);
 
     // We intentionally discard floating-point data here. If you need more resolution, just use a larger width.
-    auto const width = maybe_width->to_int();
+    auto const width = maybe_width->to_number<int>();
     auto const aspect_parts = maybe_aspect->split_view(':');
     if (aspect_parts.size() != 2)
         return Error::from_string_view("Aspect specification must have the exact format `width:height`"sv);
-    auto aspect_width = aspect_parts[0].to_int<int>();
-    auto aspect_height = aspect_parts[1].to_int<int>();
+    auto aspect_width = aspect_parts[0].to_number<int>();
+    auto aspect_height = aspect_parts[1].to_number<int>();
     if (!aspect_width.has_value() || !aspect_height.has_value() || aspect_width.value() == 0 || aspect_height.value() == 0)
         return Error::from_string_view("Aspect width and height must be non-zero integers"sv);
 

--- a/Userland/Applications/SoundPlayer/M3UParser.cpp
+++ b/Userland/Applications/SoundPlayer/M3UParser.cpp
@@ -70,7 +70,7 @@ NonnullOwnPtr<Vector<M3UEntry>> M3UParser::parse(bool include_extended_info)
             VERIFY(separator.has_value());
             auto seconds = ext_inf.value().substring_view(0, separator.value());
             VERIFY(!seconds.is_whitespace() && !seconds.is_null() && !seconds.is_empty());
-            metadata_for_next_file.track_length_in_seconds = seconds.to_uint();
+            metadata_for_next_file.track_length_in_seconds = seconds.to_number<unsigned>();
             auto display_name = ext_inf.value().substring_view(seconds.length() + 1);
             VERIFY(!display_name.is_empty() && !display_name.is_null() && !display_name.is_empty());
             metadata_for_next_file.track_display_title = display_name;

--- a/Userland/Applications/Spreadsheet/Cell.cpp
+++ b/Userland/Applications/Spreadsheet/Cell.cpp
@@ -79,7 +79,7 @@ CellType const& Cell::type() const
         return *m_type;
 
     if (m_kind == LiteralString) {
-        if (m_data.to_int().has_value())
+        if (m_data.to_number<int>().has_value())
             return *CellType::get_by_name("Numeric"sv);
     }
 

--- a/Userland/Applications/Spreadsheet/Spreadsheet.cpp
+++ b/Userland/Applications/Spreadsheet/Spreadsheet.cpp
@@ -204,7 +204,7 @@ Optional<Position> Sheet::parse_cell_name(StringView name) const
     if (it == m_columns.end())
         return {};
 
-    return Position { it.index(), row.to_uint().value() };
+    return Position { it.index(), row.to_number<unsigned>().value() };
 }
 
 Optional<size_t> Sheet::column_index(StringView column_name) const

--- a/Userland/DevTools/HackStudio/Debugger/VariablesModel.cpp
+++ b/Userland/DevTools/HackStudio/Debugger/VariablesModel.cpp
@@ -112,7 +112,7 @@ static Optional<u32> string_to_variable_value(StringView string_value, Debug::De
     }
 
     if (variable.type_name == "int") {
-        auto value = string_value.to_int();
+        auto value = string_value.to_number<int>();
         if (value.has_value())
             return value.value();
         return {};

--- a/Userland/Libraries/LibArchive/TarStream.h
+++ b/Userland/Libraries/LibArchive/TarStream.h
@@ -90,7 +90,7 @@ inline ErrorOr<void> TarInputStream::for_each_extended_header(F func)
         Optional<size_t> length_end_index = file_contents.find(' ');
         if (!length_end_index.has_value())
             return Error::from_string_literal("Malformed extended header: No length found.");
-        Optional<unsigned int> length = file_contents.substring_view(0, length_end_index.value()).to_uint();
+        Optional<unsigned> length = file_contents.substring_view(0, length_end_index.value()).to_number<unsigned>();
         if (!length.has_value())
             return Error::from_string_literal("Malformed extended header: Could not parse length.");
 

--- a/Userland/Libraries/LibC/grp.cpp
+++ b/Userland/Libraries/LibC/grp.cpp
@@ -88,7 +88,7 @@ static bool parse_grpdb_entry(char* buffer, size_t buffer_size, struct group& gr
     auto& gid_string = parts[2];
     StringView members_string = parts[3];
 
-    auto gid = gid_string.to_uint();
+    auto gid = gid_string.to_number<gid_t>();
     if (!gid.has_value()) {
         warnln("parse_grpdb_entry(): Malformed GID on line {}", s_line_number);
         return false;

--- a/Userland/Libraries/LibC/netdb.cpp
+++ b/Userland/Libraries/LibC/netdb.cpp
@@ -767,7 +767,7 @@ static bool fill_getproto_buffers(char const* line, ssize_t read)
     }
     __getproto_name_buffer = split_line[0];
 
-    auto number = split_line[1].to_int();
+    auto number = split_line[1].to_number<int>();
     if (!number.has_value())
         return false;
 

--- a/Userland/Libraries/LibC/pwd.cpp
+++ b/Userland/Libraries/LibC/pwd.cpp
@@ -88,12 +88,12 @@ static bool parse_pwddb_entry(char* raw_line, struct passwd& passwd_entry)
     auto& dir = parts[5];
     auto& shell = parts[6];
 
-    auto uid = uid_string.to_uint();
+    auto uid = uid_string.to_number<uid_t>();
     if (!uid.has_value()) {
         dbgln("getpwent(): Malformed UID on line {}", s_line_number);
         return false;
     }
-    auto gid = gid_string.to_uint();
+    auto gid = gid_string.to_number<gid_t>();
     if (!gid.has_value()) {
         dbgln("getpwent(): Malformed GID on line {}", s_line_number);
         return false;

--- a/Userland/Libraries/LibC/scanf.cpp
+++ b/Userland/Libraries/LibC/scanf.cpp
@@ -410,7 +410,7 @@ extern "C" int vsscanf(char const* input, char const* format, va_list ap)
         [[maybe_unused]] int width_specifier = 0;
         if (format_lexer.next_is(isdigit)) {
             auto width_digits = format_lexer.consume_while([](char c) { return isdigit(c); });
-            width_specifier = width_digits.to_int().value();
+            width_specifier = width_digits.to_number<int>().value();
             // FIXME: Actually use width specifier
         }
 

--- a/Userland/Libraries/LibC/shadow.cpp
+++ b/Userland/Libraries/LibC/shadow.cpp
@@ -79,7 +79,7 @@ static bool parse_shadow_entry(ByteString const& line)
     auto& expire_string = parts[7];
     auto& flag_string = parts[8];
 
-    auto lstchg = lstchg_string.to_int();
+    auto lstchg = lstchg_string.to_number<int>();
     if (!lstchg.has_value()) {
         dbgln("getspent(): Malformed lstchg on line {}", s_line_number);
         return false;
@@ -87,7 +87,7 @@ static bool parse_shadow_entry(ByteString const& line)
 
     if (min_string.is_empty())
         min_string = "-1"sv;
-    auto min_value = min_string.to_int();
+    auto min_value = min_string.to_number<int>();
     if (!min_value.has_value()) {
         dbgln("getspent(): Malformed min value on line {}", s_line_number);
         return false;
@@ -95,7 +95,7 @@ static bool parse_shadow_entry(ByteString const& line)
 
     if (max_string.is_empty())
         max_string = "-1"sv;
-    auto max_value = max_string.to_int();
+    auto max_value = max_string.to_number<int>();
     if (!max_value.has_value()) {
         dbgln("getspent(): Malformed max value on line {}", s_line_number);
         return false;
@@ -103,7 +103,7 @@ static bool parse_shadow_entry(ByteString const& line)
 
     if (warn_string.is_empty())
         warn_string = "-1"sv;
-    auto warn = warn_string.to_int();
+    auto warn = warn_string.to_number<int>();
     if (!warn.has_value()) {
         dbgln("getspent(): Malformed warn on line {}", s_line_number);
         return false;
@@ -111,7 +111,7 @@ static bool parse_shadow_entry(ByteString const& line)
 
     if (inact_string.is_empty())
         inact_string = "-1"sv;
-    auto inact = inact_string.to_int();
+    auto inact = inact_string.to_number<int>();
     if (!inact.has_value()) {
         dbgln("getspent(): Malformed inact on line {}", s_line_number);
         return false;
@@ -119,7 +119,7 @@ static bool parse_shadow_entry(ByteString const& line)
 
     if (expire_string.is_empty())
         expire_string = "-1"sv;
-    auto expire = expire_string.to_int();
+    auto expire = expire_string.to_number<int>();
     if (!expire.has_value()) {
         dbgln("getspent(): Malformed expire on line {}", s_line_number);
         return false;
@@ -127,7 +127,7 @@ static bool parse_shadow_entry(ByteString const& line)
 
     if (flag_string.is_empty())
         flag_string = "0"sv;
-    auto flag = flag_string.to_int();
+    auto flag = flag_string.to_number<int>();
     if (!flag.has_value()) {
         dbgln("getspent(): Malformed flag on line {}", s_line_number);
         return false;

--- a/Userland/Libraries/LibChess/UCICommand.cpp
+++ b/Userland/Libraries/LibChess/UCICommand.cpp
@@ -161,31 +161,31 @@ ErrorOr<NonnullOwnPtr<GoCommand>> GoCommand::from_string(StringView command)
             go_command->ponder = true;
         } else if (tokens[i] == "wtime") {
             VERIFY(i++ < tokens.size());
-            go_command->wtime = tokens[i].to_int().value();
+            go_command->wtime = tokens[i].to_number<int>().value();
         } else if (tokens[i] == "btime") {
             VERIFY(i++ < tokens.size());
-            go_command->btime = tokens[i].to_int().value();
+            go_command->btime = tokens[i].to_number<int>().value();
         } else if (tokens[i] == "winc") {
             VERIFY(i++ < tokens.size());
-            go_command->winc = tokens[i].to_int().value();
+            go_command->winc = tokens[i].to_number<int>().value();
         } else if (tokens[i] == "binc") {
             VERIFY(i++ < tokens.size());
-            go_command->binc = tokens[i].to_int().value();
+            go_command->binc = tokens[i].to_number<int>().value();
         } else if (tokens[i] == "movestogo") {
             VERIFY(i++ < tokens.size());
-            go_command->movestogo = tokens[i].to_int().value();
+            go_command->movestogo = tokens[i].to_number<int>().value();
         } else if (tokens[i] == "depth") {
             VERIFY(i++ < tokens.size());
-            go_command->depth = tokens[i].to_int().value();
+            go_command->depth = tokens[i].to_number<int>().value();
         } else if (tokens[i] == "nodes") {
             VERIFY(i++ < tokens.size());
-            go_command->nodes = tokens[i].to_int().value();
+            go_command->nodes = tokens[i].to_number<int>().value();
         } else if (tokens[i] == "mate") {
             VERIFY(i++ < tokens.size());
-            go_command->mate = tokens[i].to_int().value();
+            go_command->mate = tokens[i].to_number<int>().value();
         } else if (tokens[i] == "movetime") {
             VERIFY(i++ < tokens.size());
-            go_command->movetime = tokens[i].to_int().value();
+            go_command->movetime = tokens[i].to_number<int>().value();
         } else if (tokens[i] == "infinite") {
             go_command->infinite = true;
         }
@@ -344,7 +344,7 @@ ErrorOr<NonnullOwnPtr<InfoCommand>> InfoCommand::from_string(StringView command)
     auto info_command = TRY(try_make<InfoCommand>());
 
     auto parse_integer_token = [](StringView value_token) -> ErrorOr<int> {
-        auto value_as_integer = value_token.to_int();
+        auto value_as_integer = value_token.to_number<int>();
         if (!value_as_integer.has_value())
             return Error::from_string_literal("Expected integer token");
 

--- a/Userland/Libraries/LibCore/ArgsParser.cpp
+++ b/Userland/Libraries/LibCore/ArgsParser.cpp
@@ -500,11 +500,7 @@ void ArgsParser::add_option(I& value, char const* help_string, char const* long_
         short_name,
         value_name,
         [&value](StringView view) -> ErrorOr<bool> {
-            Optional<I> opt;
-            if constexpr (IsSigned<I>)
-                opt = view.to_int<I>();
-            else
-                opt = view.to_uint<I>();
+            Optional<I> opt = view.to_number<I>();
             value = opt.value_or(0);
             return opt.has_value();
         },
@@ -530,7 +526,7 @@ void ArgsParser::add_option(double& value, char const* help_string, char const* 
         short_name,
         value_name,
         [&value](StringView s) -> ErrorOr<bool> {
-            auto opt = s.to_double();
+            auto opt = s.to_number<double>();
             value = opt.value_or(0.0);
             return opt.has_value();
         },
@@ -548,7 +544,7 @@ void ArgsParser::add_option(Optional<double>& value, char const* help_string, ch
         short_name,
         value_name,
         [&value](StringView s) -> ErrorOr<bool> {
-            value = s.to_double();
+            value = s.to_number<double>();
             return value.has_value();
         },
         hide_mode,
@@ -565,7 +561,7 @@ void ArgsParser::add_option(Optional<size_t>& value, char const* help_string, ch
         short_name,
         value_name,
         [&value](StringView s) -> ErrorOr<bool> {
-            value = AK::StringUtils::convert_to_uint<size_t>(s);
+            value = s.to_number<size_t>();
             return value.has_value();
         },
         hide_mode,
@@ -676,11 +672,7 @@ void ArgsParser::add_positional_argument(I& value, char const* help_string, char
         required == Required::Yes ? 1 : 0,
         1,
         [&value](StringView view) -> ErrorOr<bool> {
-            Optional<I> opt;
-            if constexpr (IsSigned<I>)
-                opt = view.to_int<I>();
-            else
-                opt = view.to_uint<I>();
+            Optional<I> opt = view.to_number<I>();
             value = opt.value_or(0);
             return opt.has_value();
         },
@@ -705,7 +697,7 @@ void ArgsParser::add_positional_argument(double& value, char const* help_string,
         required == Required::Yes ? 1 : 0,
         1,
         [&value](StringView s) -> ErrorOr<bool> {
-            auto opt = s.to_double();
+            auto opt = s.to_number<double>();
             value = opt.value_or(0.0);
             return opt.has_value();
         }

--- a/Userland/Libraries/LibCore/ConfigFile.h
+++ b/Userland/Libraries/LibCore/ConfigFile.h
@@ -55,10 +55,7 @@ public:
         if (!has_key(group, key))
             return default_value;
 
-        if constexpr (IsSigned<T>)
-            return read_entry(group, key, "").to_int<T>().value_or(default_value);
-        else
-            return read_entry(group, key, "").to_uint<T>().value_or(default_value);
+        return read_entry(group, key, "").to_number<T>().value_or(default_value);
     }
 
     void write_entry(ByteString const& group, ByteString const& key, ByteString const& value);

--- a/Userland/Libraries/LibCore/Process.cpp
+++ b/Userland/Libraries/LibCore/Process.cpp
@@ -209,7 +209,7 @@ ErrorOr<bool> Process::is_being_debugged()
         auto const parts = line.split_view(':');
         if (parts.size() < 2 || parts[0] != "TracerPid"sv)
             continue;
-        auto tracer_pid = parts[1].to_uint<u32>();
+        auto tracer_pid = parts[1].to_number<u32>();
         return (tracer_pid != 0UL);
     }
     return false;

--- a/Userland/Libraries/LibCore/SystemServerTakeover.cpp
+++ b/Userland/Libraries/LibCore/SystemServerTakeover.cpp
@@ -27,7 +27,7 @@ static void parse_sockets_from_system_server()
     for (auto const socket : StringView { sockets, strlen(sockets) }.split_view(';')) {
         auto params = socket.split_view(':');
         VERIFY(params.size() == 2);
-        s_overtaken_sockets.set(params[0].to_byte_string(), params[1].to_int().value());
+        s_overtaken_sockets.set(params[0].to_byte_string(), params[1].to_number<int>().value());
     }
 
     s_overtaken_sockets_parsed = true;

--- a/Userland/Libraries/LibCrypto/ASN1/ASN1.cpp
+++ b/Userland/Libraries/LibCrypto/ASN1/ASN1.cpp
@@ -123,16 +123,16 @@ Optional<Core::DateTime> parse_utc_time(StringView time)
 {
     // YYMMDDhhmm[ss]Z or YYMMDDhhmm[ss](+|-)hhmm
     GenericLexer lexer(time);
-    auto year_in_century = lexer.consume(2).to_uint();
-    auto month = lexer.consume(2).to_uint();
-    auto day = lexer.consume(2).to_uint();
-    auto hour = lexer.consume(2).to_uint();
-    auto minute = lexer.consume(2).to_uint();
+    auto year_in_century = lexer.consume(2).to_number<unsigned>();
+    auto month = lexer.consume(2).to_number<unsigned>();
+    auto day = lexer.consume(2).to_number<unsigned>();
+    auto hour = lexer.consume(2).to_number<unsigned>();
+    auto minute = lexer.consume(2).to_number<unsigned>();
     Optional<unsigned> seconds, offset_hours, offset_minutes;
     [[maybe_unused]] bool negative_offset = false;
 
     if (lexer.next_is(is_any_of("0123456789"sv))) {
-        seconds = lexer.consume(2).to_uint();
+        seconds = lexer.consume(2).to_number<unsigned>();
         if (!seconds.has_value()) {
             return {};
         }
@@ -142,8 +142,8 @@ Optional<Core::DateTime> parse_utc_time(StringView time)
         lexer.consume();
     } else if (lexer.next_is(is_any_of("+-"sv))) {
         negative_offset = lexer.consume() == '-';
-        offset_hours = lexer.consume(2).to_uint();
-        offset_minutes = lexer.consume(2).to_uint();
+        offset_hours = lexer.consume(2).to_number<unsigned>();
+        offset_minutes = lexer.consume(2).to_number<unsigned>();
         if (!offset_hours.has_value() || !offset_minutes.has_value()) {
             return {};
         }
@@ -171,10 +171,10 @@ Optional<Core::DateTime> parse_generalized_time(StringView time)
 {
     // YYYYMMDDhh[mm[ss[.fff]]] or YYYYMMDDhh[mm[ss[.fff]]]Z or YYYYMMDDhh[mm[ss[.fff]]](+|-)hhmm
     GenericLexer lexer(time);
-    auto year = lexer.consume(4).to_uint();
-    auto month = lexer.consume(2).to_uint();
-    auto day = lexer.consume(2).to_uint();
-    auto hour = lexer.consume(2).to_uint();
+    auto year = lexer.consume(4).to_number<unsigned>();
+    auto month = lexer.consume(2).to_number<unsigned>();
+    auto day = lexer.consume(2).to_number<unsigned>();
+    auto hour = lexer.consume(2).to_number<unsigned>();
     Optional<unsigned> minute, seconds, milliseconds, offset_hours, offset_minutes;
     [[maybe_unused]] bool negative_offset = false;
     if (!lexer.is_eof()) {
@@ -182,7 +182,7 @@ Optional<Core::DateTime> parse_generalized_time(StringView time)
             goto done_parsing;
 
         if (!lexer.next_is(is_any_of("+-"sv))) {
-            minute = lexer.consume(2).to_uint();
+            minute = lexer.consume(2).to_number<unsigned>();
             if (!minute.has_value()) {
                 return {};
             }
@@ -191,7 +191,7 @@ Optional<Core::DateTime> parse_generalized_time(StringView time)
         }
 
         if (!lexer.next_is(is_any_of("+-"sv))) {
-            seconds = lexer.consume(2).to_uint();
+            seconds = lexer.consume(2).to_number<unsigned>();
             if (!seconds.has_value()) {
                 return {};
             }
@@ -200,7 +200,7 @@ Optional<Core::DateTime> parse_generalized_time(StringView time)
         }
 
         if (lexer.consume_specific('.')) {
-            milliseconds = lexer.consume(3).to_uint();
+            milliseconds = lexer.consume(3).to_number<unsigned>();
             if (!milliseconds.has_value()) {
                 return {};
             }
@@ -210,8 +210,8 @@ Optional<Core::DateTime> parse_generalized_time(StringView time)
 
         if (lexer.next_is(is_any_of("+-"sv))) {
             negative_offset = lexer.consume() == '-';
-            offset_hours = lexer.consume(2).to_uint();
-            offset_minutes = lexer.consume(2).to_uint();
+            offset_hours = lexer.consume(2).to_number<unsigned>();
+            offset_minutes = lexer.consume(2).to_number<unsigned>();
             if (!offset_hours.has_value() || !offset_minutes.has_value()) {
                 return {};
             }

--- a/Userland/Libraries/LibDiff/Hunks.cpp
+++ b/Userland/Libraries/LibDiff/Hunks.cpp
@@ -50,7 +50,7 @@ bool Parser::consume_line_number(size_t& number)
 {
     auto line = consume_while(is_ascii_digit);
 
-    auto maybe_number = line.to_uint<size_t>();
+    auto maybe_number = line.to_number<size_t>();
     if (!maybe_number.has_value())
         return false;
 

--- a/Userland/Libraries/LibGUI/AbstractTableView.cpp
+++ b/Userland/Libraries/LibGUI/AbstractTableView.cpp
@@ -417,7 +417,7 @@ void AbstractTableView::set_visible_columns(StringView column_names)
         column_header().set_section_visible(column, false);
 
     column_names.for_each_split_view(',', SplitBehavior::Nothing, [&, this](StringView column_id_string) {
-        if (auto column = column_id_string.to_int(); column.has_value()) {
+        if (auto column = column_id_string.to_number<int>(); column.has_value()) {
             column_header().set_section_visible(column.value(), true);
         }
     });

--- a/Userland/Libraries/LibGUI/Clipboard.cpp
+++ b/Userland/Libraries/LibGUI/Clipboard.cpp
@@ -79,23 +79,23 @@ RefPtr<Gfx::Bitmap> Clipboard::DataAndType::as_bitmap() const
     if (mime_type != "image/x-serenityos")
         return nullptr;
 
-    auto width = metadata.get("width").value_or("0").to_uint();
+    auto width = metadata.get("width").value_or("0").to_number<unsigned>();
     if (!width.has_value() || width.value() == 0)
         return nullptr;
 
-    auto height = metadata.get("height").value_or("0").to_uint();
+    auto height = metadata.get("height").value_or("0").to_number<unsigned>();
     if (!height.has_value() || height.value() == 0)
         return nullptr;
 
-    auto scale = metadata.get("scale").value_or("0").to_uint();
+    auto scale = metadata.get("scale").value_or("0").to_number<unsigned>();
     if (!scale.has_value() || scale.value() == 0)
         return nullptr;
 
-    auto pitch = metadata.get("pitch").value_or("0").to_uint();
+    auto pitch = metadata.get("pitch").value_or("0").to_number<unsigned>();
     if (!pitch.has_value() || pitch.value() == 0)
         return nullptr;
 
-    auto format = metadata.get("format").value_or("0").to_uint();
+    auto format = metadata.get("format").value_or("0").to_number<unsigned>();
     if (!format.has_value() || format.value() == 0)
         return nullptr;
 

--- a/Userland/Libraries/LibGUI/SpinBox.cpp
+++ b/Userland/Libraries/LibGUI/SpinBox.cpp
@@ -24,7 +24,7 @@ SpinBox::SpinBox()
         if (!weak_this)
             return;
 
-        auto value = m_editor->text().to_uint();
+        auto value = m_editor->text().to_number<unsigned>();
         if (!value.has_value() && m_editor->text().length() > 0)
             m_editor->do_delete();
     };
@@ -81,7 +81,7 @@ void SpinBox::set_value_from_current_text()
     if (m_editor->text().is_empty())
         return;
 
-    auto value = m_editor->text().to_int();
+    auto value = m_editor->text().to_number<int>();
     if (value.has_value())
         set_value(value.value());
     else

--- a/Userland/Libraries/LibGUI/ValueSlider.cpp
+++ b/Userland/Libraries/LibGUI/ValueSlider.cpp
@@ -35,7 +35,7 @@ ValueSlider::ValueSlider(Gfx::Orientation orientation, String suffix)
         ByteString value = m_textbox->text();
         if (value.ends_with(m_suffix, AK::CaseSensitivity::CaseInsensitive))
             value = value.substring_view(0, value.length() - m_suffix.bytes_as_string_view().length());
-        auto integer_value = value.to_int();
+        auto integer_value = value.to_number<int>();
         if (integer_value.has_value())
             AbstractSlider::set_value(integer_value.value());
     };

--- a/Userland/Libraries/LibGUI/Variant.h
+++ b/Userland/Libraries/LibGUI/Variant.h
@@ -120,10 +120,7 @@ public:
             [](FloatingPoint auto v) { return (T)v; },
             [](Detail::Boolean v) -> T { return v.value ? 1 : 0; },
             [](ByteString const& v) {
-                if constexpr (IsUnsigned<T>)
-                    return v.to_uint<T>().value_or(0u);
-                else
-                    return v.to_int<T>().value_or(0);
+                return v.to_number<T>().value_or(0);
             },
             [](Enum auto const&) -> T { return 0; },
             [](OneOf<Gfx::IntPoint, Gfx::IntRect, Gfx::IntSize, Color, NonnullRefPtr<Gfx::Font const>, NonnullRefPtr<Gfx::Bitmap const>, GUI::Icon> auto const&) -> T { return 0; });

--- a/Userland/Libraries/LibGUI/Window.cpp
+++ b/Userland/Libraries/LibGUI/Window.cpp
@@ -142,10 +142,10 @@ void Window::show()
         auto parts = StringView { launch_origin_rect_string, strlen(launch_origin_rect_string) }.split_view(',');
         if (parts.size() == 4) {
             launch_origin_rect = Gfx::IntRect {
-                parts[0].to_int().value_or(0),
-                parts[1].to_int().value_or(0),
-                parts[2].to_int().value_or(0),
-                parts[3].to_int().value_or(0),
+                parts[0].to_number<int>().value_or(0),
+                parts[1].to_number<int>().value_or(0),
+                parts[2].to_number<int>().value_or(0),
+                parts[3].to_number<int>().value_or(0),
             };
         }
         unsetenv("__libgui_launch_origin_rect");

--- a/Userland/Libraries/LibGemini/Job.cpp
+++ b/Userland/Libraries/LibGemini/Job.cpp
@@ -167,7 +167,7 @@ void Job::on_socket_connected()
             auto first_part = view.substring_view(0, space_index);
             auto second_part = view.substring_view(space_index + 1);
 
-            auto status = first_part.to_uint();
+            auto status = first_part.to_number<unsigned>();
             if (!status.has_value()) {
                 dbgln("Job: Expected numeric status code");
                 m_state = State::Failed;

--- a/Userland/Libraries/LibGfx/Color.cpp
+++ b/Userland/Libraries/LibGfx/Color.cpp
@@ -49,9 +49,9 @@ static Optional<Color> parse_rgb_color(StringView string)
     if (parts.size() != 3)
         return {};
 
-    auto r = parts[0].to_double().map(AK::clamp_to<u8, double>);
-    auto g = parts[1].to_double().map(AK::clamp_to<u8, double>);
-    auto b = parts[2].to_double().map(AK::clamp_to<u8, double>);
+    auto r = parts[0].to_number<double>().map(AK::clamp_to<u8, double>);
+    auto g = parts[1].to_number<double>().map(AK::clamp_to<u8, double>);
+    auto b = parts[2].to_number<double>().map(AK::clamp_to<u8, double>);
 
     if (!r.has_value() || !g.has_value() || !b.has_value())
         return {};
@@ -70,9 +70,9 @@ static Optional<Color> parse_rgba_color(StringView string)
     if (parts.size() != 4)
         return {};
 
-    auto r = parts[0].to_double().map(AK::clamp_to<u8, double>);
-    auto g = parts[1].to_double().map(AK::clamp_to<u8, double>);
-    auto b = parts[2].to_double().map(AK::clamp_to<u8, double>);
+    auto r = parts[0].to_number<double>().map(AK::clamp_to<u8, double>);
+    auto g = parts[1].to_number<double>().map(AK::clamp_to<u8, double>);
+    auto b = parts[2].to_number<double>().map(AK::clamp_to<u8, double>);
 
     double alpha = 0;
     auto alpha_str = parts[3].trim_whitespace();

--- a/Userland/Libraries/LibGfx/CursorParams.cpp
+++ b/Userland/Libraries/LibGfx/CursorParams.cpp
@@ -37,7 +37,7 @@ CursorParams CursorParams::parse_from_filename(StringView cursor_path, Gfx::IntP
             }
             if (k == i)
                 return {};
-            auto parsed_number = params_str.substring_view(i, k - i).to_uint();
+            auto parsed_number = params_str.substring_view(i, k - i).to_number<unsigned>();
             if (!parsed_number.has_value())
                 return {};
             i = k;

--- a/Userland/Libraries/LibGfx/Font/FontDatabase.cpp
+++ b/Userland/Libraries/LibGfx/Font/FontDatabase.cpp
@@ -180,9 +180,9 @@ RefPtr<Gfx::Font> FontDatabase::get_by_name(StringView name)
     if (it == m_private->full_name_to_font_map.end()) {
         auto parts = name.split_view(" "sv);
         if (parts.size() >= 4) {
-            auto slope = parts.take_last().to_int().value_or(0);
-            auto weight = parts.take_last().to_int().value_or(0);
-            auto size = parts.take_last().to_int().value_or(0);
+            auto slope = parts.take_last().to_number<int>().value_or(0);
+            auto weight = parts.take_last().to_number<int>().value_or(0);
+            auto size = parts.take_last().to_number<int>().value_or(0);
             auto family = MUST(String::join(' ', parts));
             return get(family, size, weight, Gfx::FontWidth::Normal, slope);
         }

--- a/Userland/Libraries/LibHTTP/HttpRequest.cpp
+++ b/Userland/Libraries/LibHTTP/HttpRequest.cpp
@@ -183,7 +183,7 @@ ErrorOr<HttpRequest, HttpRequest::ParseError> HttpRequest::from_raw_request(Read
                 commit_and_advance_to(current_header.value, next_state);
 
                 if (current_header.name.equals_ignoring_ascii_case("Content-Length"sv))
-                    content_length = current_header.value.to_uint();
+                    content_length = current_header.value.to_number<unsigned>();
 
                 headers.append(move(current_header));
                 break;

--- a/Userland/Libraries/LibHTTP/Job.cpp
+++ b/Userland/Libraries/LibHTTP/Job.cpp
@@ -263,7 +263,7 @@ void Job::on_socket_connected()
             auto http_minor_version = parse_ascii_digit(parts[0][7]);
             m_legacy_connection = http_major_version < 1 || (http_major_version == 1 && http_minor_version == 0);
 
-            auto code = parts[1].to_uint();
+            auto code = parts[1].to_number<unsigned>();
             if (!code.has_value()) {
                 dbgln("Job: Expected numeric HTTP status");
                 return deferred_invoke([this] { did_fail(Core::NetworkJob::Error::ProtocolFailed); });
@@ -312,7 +312,7 @@ void Job::on_socket_connected()
                 // We've reached the end of the headers, there's a possibility that the server
                 // responds with nothing (content-length = 0 with normal encoding); if that's the case,
                 // quit early as we won't be reading anything anyway.
-                if (auto result = m_headers.get("Content-Length"sv).value_or(""sv).to_uint(); result.has_value()) {
+                if (auto result = m_headers.get("Content-Length"sv).value_or(""sv).to_number<unsigned>(); result.has_value()) {
                     if (result.value() == 0 && !m_headers.get("Transfer-Encoding"sv).value_or(""sv).view().trim_whitespace().equals_ignoring_ascii_case("chunked"sv))
                         return finish_up();
                 }
@@ -370,7 +370,7 @@ void Job::on_socket_connected()
                 dbgln_if(JOB_DEBUG, "Content-Encoding {} detected, cannot stream output :(", value);
                 m_can_stream_response = false;
             } else if (name.equals_ignoring_ascii_case("Content-Length"sv)) {
-                auto length = value.to_uint<u64>();
+                auto length = value.to_number<u64>();
                 if (length.has_value())
                     m_content_length = length.value();
             }

--- a/Userland/Libraries/LibIMAP/Parser.cpp
+++ b/Userland/Libraries/LibIMAP/Parser.cpp
@@ -123,8 +123,8 @@ Optional<unsigned> Parser::try_parse_number()
 
     auto number = StringView(m_buffer.data() + m_position - number_matched, number_matched);
 
-    dbgln_if(IMAP_PARSER_DEBUG, "p: {}, ret \"{}\"", m_position, number.to_uint());
-    return number.to_uint();
+    dbgln_if(IMAP_PARSER_DEBUG, "p: {}, ret \"{}\"", m_position, number.to_number<unsigned>());
+    return number.to_number<unsigned>();
 }
 
 ErrorOr<unsigned> Parser::parse_number()

--- a/Userland/Libraries/LibJS/Runtime/AbstractOperations.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AbstractOperations.cpp
@@ -1199,7 +1199,7 @@ CanonicalIndex canonical_numeric_index_string(PropertyKey const& property_key, C
         return CanonicalIndex(CanonicalIndex::Type::Undefined, 0);
 
     // 2. Let n be ! ToNumber(argument).
-    auto maybe_double = argument.to_double(AK::TrimWhitespace::No);
+    auto maybe_double = argument.to_number<double>(AK::TrimWhitespace::No);
     if (!maybe_double.has_value())
         return CanonicalIndex(CanonicalIndex::Type::Undefined, 0);
 

--- a/Userland/Libraries/LibJS/Runtime/Date.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Date.cpp
@@ -377,7 +377,7 @@ static i64 clip_bigint_to_sane_time(Crypto::SignedBigInteger const& value)
         return NumericLimits<i64>::max();
 
     // FIXME: Can we do this without string conversion?
-    return value.to_base_deprecated(10).to_int<i64>().value();
+    return value.to_base_deprecated(10).to_number<i64>().value();
 }
 
 // 21.4.1.20 GetNamedTimeZoneEpochNanoseconds ( timeZoneIdentifier, year, month, day, hour, minute, second, millisecond, microsecond, nanosecond ), https://tc39.es/ecma262/#sec-getnamedtimezoneepochnanoseconds

--- a/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.cpp
@@ -647,7 +647,7 @@ Vector<PatternPartition> partition_number_pattern(VM& vm, NumberFormat& number_f
         else if ((part.starts_with("unitIdentifier:"sv)) && (number_format.style() == NumberFormat::Style::Unit)) {
             // Note: Our implementation combines "unitPrefix" and "unitSuffix" into one field, "unitIdentifier".
 
-            auto identifier_index = part.substring_view("unitIdentifier:"sv.length()).to_uint();
+            auto identifier_index = part.substring_view("unitIdentifier:"sv.length()).to_number<unsigned>();
             VERIFY(identifier_index.has_value());
 
             // i. Let unit be numberFormat.[[Unit]].
@@ -862,7 +862,7 @@ Vector<PatternPartition> partition_notation_sub_pattern(NumberFormat& number_for
             else if (part.starts_with("compactIdentifier:"sv)) {
                 // Note: Our implementation combines "compactSymbol" and "compactName" into one field, "compactIdentifier".
 
-                auto identifier_index = part.substring_view("compactIdentifier:"sv.length()).to_uint();
+                auto identifier_index = part.substring_view("compactIdentifier:"sv.length()).to_number<unsigned>();
                 VERIFY(identifier_index.has_value());
 
                 // 1. Let compactSymbol be an ILD string representing exponent in short form, which may depend on x in languages having different plural forms. The implementation must be able to provide this string, or else the pattern would not have a "{compactSymbol}" placeholder.
@@ -1034,7 +1034,7 @@ static RawPrecisionResult to_raw_precision_function(MathematicalValue const& num
 
         result.number = result.number.divided_by(10);
 
-        if (mode == PreferredResult::GreaterThanNumber && digit.to_uint().value() != 0)
+        if (mode == PreferredResult::GreaterThanNumber && digit.to_number<unsigned>().value() != 0)
             result.number = result.number.plus(1);
     }
 
@@ -1183,7 +1183,7 @@ static RawFixedResult to_raw_fixed_function(MathematicalValue const& number, int
 
         result.number = result.number.multiplied_by(10);
 
-        if (mode == PreferredResult::GreaterThanNumber && digit.to_uint().value() != 0)
+        if (mode == PreferredResult::GreaterThanNumber && digit.to_number<unsigned>().value() != 0)
             result.number = result.number.plus(1);
     }
 

--- a/Userland/Libraries/LibJS/Runtime/Intl/PluralRules.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/PluralRules.cpp
@@ -23,7 +23,7 @@ PluralRules::PluralRules(Object& prototype)
 ::Locale::PluralOperands get_operands(StringView string)
 {
     // 1.Let n be ! ToNumber(s).
-    auto number = string.to_double(AK::TrimWhitespace::Yes).release_value();
+    auto number = string.to_number<double>(AK::TrimWhitespace::Yes).release_value();
 
     // 2. Assert: n is finite.
     VERIFY(isfinite(number));
@@ -57,7 +57,7 @@ PluralRules::PluralRules(Object& prototype)
             return static_cast<u64>(fabs(value));
         },
         [](StringView value) {
-            auto value_as_int = value.template to_int<i64>().value();
+            auto value_as_int = value.template to_number<i64>().value();
             return static_cast<u64>(value_as_int);
         });
 
@@ -65,7 +65,7 @@ PluralRules::PluralRules(Object& prototype)
     auto fraction_digit_count = fraction_slice.length();
 
     // 8. Let f be ! ToNumber(fracSlice).
-    auto fraction = fraction_slice.is_empty() ? 0u : fraction_slice.template to_uint<u64>().value();
+    auto fraction = fraction_slice.is_empty() ? 0u : fraction_slice.template to_number<u64>().value();
 
     // 9. Let significantFracSlice be the value of fracSlice stripped of trailing "0".
     auto significant_fraction_slice = fraction_slice.trim("0"sv, TrimMode::Right);
@@ -74,7 +74,7 @@ PluralRules::PluralRules(Object& prototype)
     auto significant_fraction_digit_count = significant_fraction_slice.length();
 
     // 11. Let significantFrac be ! ToNumber(significantFracSlice).
-    auto significant_fraction = significant_fraction_slice.is_empty() ? 0u : significant_fraction_slice.template to_uint<u64>().value();
+    auto significant_fraction = significant_fraction_slice.is_empty() ? 0u : significant_fraction_slice.template to_number<u64>().value();
 
     // 12. Return a new Record { [[Number]]: abs(n), [[IntegerDigits]]: i, [[FractionDigits]]: f, [[NumberOfFractionDigits]]: fracDigitCount, [[FractionDigitsWithoutTrailing]]: significantFrac, [[NumberOfFractionDigitsWithoutTrailing]]: significantFracDigitCount }.
     return ::Locale::PluralOperands {

--- a/Userland/Libraries/LibJS/Runtime/PropertyKey.h
+++ b/Userland/Libraries/LibJS/Runtime/PropertyKey.h
@@ -136,7 +136,7 @@ public:
             return false;
         }
 
-        auto property_index = m_string.to_uint(TrimWhitespace::No);
+        auto property_index = m_string.to_number<unsigned>(TrimWhitespace::No);
         if (!property_index.has_value() || property_index.value() == NumericLimits<u32>::max()) {
             m_string_may_be_number = false;
             return false;

--- a/Userland/Libraries/LibJS/Runtime/Temporal/AbstractOperations.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/AbstractOperations.cpp
@@ -1276,22 +1276,22 @@ ThrowCompletionOr<ISODateTime> parse_iso_date_time(VM& vm, ParseResult const& pa
     //    a. Let monthMV be 1.
     // 9. Else,
     //    a. Let monthMV be ! ToIntegerOrInfinity(CodePointsToString(month)).
-    auto month_mv = *month.value_or("1"sv).to_uint<u8>();
+    auto month_mv = *month.value_or("1"sv).to_number<u8>();
 
     // 10. If day is empty, then
     //    a. Let dayMV be 1.
     // 11. Else,
     //    a. Let dayMV be ! ToIntegerOrInfinity(CodePointsToString(day)).
-    auto day_mv = *day.value_or("1"sv).to_uint<u8>();
+    auto day_mv = *day.value_or("1"sv).to_number<u8>();
 
     // 12. Let hourMV be ! ToIntegerOrInfinity(CodePointsToString(hour)).
-    auto hour_mv = *hour.value_or("0"sv).to_uint<u8>();
+    auto hour_mv = *hour.value_or("0"sv).to_number<u8>();
 
     // 13. Let minuteMV be ! ToIntegerOrInfinity(CodePointsToString(minute)).
-    auto minute_mv = *minute.value_or("0"sv).to_uint<u8>();
+    auto minute_mv = *minute.value_or("0"sv).to_number<u8>();
 
     // 14. Let secondMV be ! ToIntegerOrInfinity(CodePointsToString(second)).
-    auto second_mv = *second.value_or("0"sv).to_uint<u8>();
+    auto second_mv = *second.value_or("0"sv).to_number<u8>();
 
     // 15. If secondMV is 60, then
     if (second_mv == 60) {
@@ -1532,19 +1532,19 @@ ThrowCompletionOr<DurationRecord> parse_temporal_duration_string(VM& vm, StringV
     auto f_seconds_part = parse_result->duration_seconds_fraction;
 
     // 4. Let yearsMV be ! ToIntegerOrInfinity(CodePointsToString(years)).
-    auto years = years_part.value_or("0"sv).to_double().release_value();
+    auto years = years_part.value_or("0"sv).to_number<double>().release_value();
 
     // 5. Let monthsMV be ! ToIntegerOrInfinity(CodePointsToString(months)).
-    auto months = months_part.value_or("0"sv).to_double().release_value();
+    auto months = months_part.value_or("0"sv).to_number<double>().release_value();
 
     // 6. Let weeksMV be ! ToIntegerOrInfinity(CodePointsToString(weeks)).
-    auto weeks = weeks_part.value_or("0"sv).to_double().release_value();
+    auto weeks = weeks_part.value_or("0"sv).to_number<double>().release_value();
 
     // 7. Let daysMV be ! ToIntegerOrInfinity(CodePointsToString(days)).
-    auto days = days_part.value_or("0"sv).to_double().release_value();
+    auto days = days_part.value_or("0"sv).to_number<double>().release_value();
 
     // 8. Let hoursMV be ! ToIntegerOrInfinity(CodePointsToString(hours)).
-    auto hours = hours_part.value_or("0"sv).to_double().release_value();
+    auto hours = hours_part.value_or("0"sv).to_number<double>().release_value();
 
     double minutes;
 
@@ -1561,12 +1561,12 @@ ThrowCompletionOr<DurationRecord> parse_temporal_duration_string(VM& vm, StringV
         auto f_hours_scale = (double)f_hours_digits.length();
 
         // d. Let minutesMV be ! ToIntegerOrInfinity(fHoursDigits) / 10^fHoursScale × 60.
-        minutes = f_hours_digits.to_double().release_value() / pow(10., f_hours_scale) * 60;
+        minutes = f_hours_digits.to_number<double>().release_value() / pow(10., f_hours_scale) * 60;
     }
     // 10. Else,
     else {
         // a. Let minutesMV be ! ToIntegerOrInfinity(CodePointsToString(minutes)).
-        minutes = minutes_part.value_or("0"sv).to_double().release_value();
+        minutes = minutes_part.value_or("0"sv).to_number<double>().release_value();
     }
 
     double seconds;
@@ -1584,12 +1584,12 @@ ThrowCompletionOr<DurationRecord> parse_temporal_duration_string(VM& vm, StringV
         auto f_minutes_scale = (double)f_minutes_digits.length();
 
         // d. Let secondsMV be ! ToIntegerOrInfinity(fMinutesDigits) / 10^fMinutesScale × 60.
-        seconds = f_minutes_digits.to_double().release_value() / pow(10, f_minutes_scale) * 60;
+        seconds = f_minutes_digits.to_number<double>().release_value() / pow(10, f_minutes_scale) * 60;
     }
     // 12. Else if seconds is not empty, then
     else if (seconds_part.has_value()) {
         // a. Let secondsMV be ! ToIntegerOrInfinity(CodePointsToString(seconds)).
-        seconds = seconds_part.value_or("0"sv).to_double().release_value();
+        seconds = seconds_part.value_or("0"sv).to_number<double>().release_value();
     }
     // 13. Else,
     else {
@@ -1608,7 +1608,7 @@ ThrowCompletionOr<DurationRecord> parse_temporal_duration_string(VM& vm, StringV
         auto f_seconds_scale = (double)f_seconds_digits.length();
 
         // c. Let millisecondsMV be ! ToIntegerOrInfinity(fSecondsDigits) / 10^fSecondsScale × 1000.
-        milliseconds = f_seconds_digits.to_double().release_value() / pow(10, f_seconds_scale) * 1000;
+        milliseconds = f_seconds_digits.to_number<double>().release_value() / pow(10, f_seconds_scale) * 1000;
     }
     // 15. Else,
     else {

--- a/Userland/Libraries/LibJS/Runtime/Temporal/InstantPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/InstantPrototype.cpp
@@ -69,7 +69,7 @@ JS_DEFINE_NATIVE_FUNCTION(InstantPrototype::epoch_seconds_getter)
     auto [s, _] = ns.big_integer().divided_by(Crypto::UnsignedBigInteger { 1'000'000'000 });
 
     // 5. Return 𝔽(s).
-    return Value((double)s.to_base_deprecated(10).to_int<i64>().value());
+    return Value((double)s.to_base_deprecated(10).to_number<i64>().value());
 }
 
 // 8.3.4 get Temporal.Instant.prototype.epochMilliseconds, https://tc39.es/proposal-temporal/#sec-get-temporal.instant.prototype.epochmilliseconds
@@ -86,7 +86,7 @@ JS_DEFINE_NATIVE_FUNCTION(InstantPrototype::epoch_milliseconds_getter)
     auto [ms, _] = ns.big_integer().divided_by(Crypto::UnsignedBigInteger { 1'000'000 });
 
     // 5. Return 𝔽(ms).
-    return Value((double)ms.to_base_deprecated(10).to_int<i64>().value());
+    return Value((double)ms.to_base_deprecated(10).to_number<i64>().value());
 }
 
 // 8.3.5 get Temporal.Instant.prototype.epochMicroseconds, https://tc39.es/proposal-temporal/#sec-get-temporal.instant.prototype.epochmicroseconds

--- a/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTimePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTimePrototype.cpp
@@ -360,7 +360,7 @@ JS_DEFINE_NATIVE_FUNCTION(ZonedDateTimePrototype::epoch_seconds_getter)
     auto s = ns.big_integer().divided_by(Crypto::UnsignedBigInteger { 1'000'000'000 }).quotient;
 
     // 5. Return 𝔽(s).
-    return Value((double)s.to_base_deprecated(10).to_int<i64>().value());
+    return Value((double)s.to_base_deprecated(10).to_number<i64>().value());
 }
 
 // 6.3.16 get Temporal.ZonedDateTime.prototype.epochMilliseconds, https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.epochmilliseconds
@@ -377,7 +377,7 @@ JS_DEFINE_NATIVE_FUNCTION(ZonedDateTimePrototype::epoch_milliseconds_getter)
     auto ms = ns.big_integer().divided_by(Crypto::UnsignedBigInteger { 1'000'000 }).quotient;
 
     // 5. Return 𝔽(ms).
-    return Value((double)ms.to_base_deprecated(10).to_int<i64>().value());
+    return Value((double)ms.to_base_deprecated(10).to_number<i64>().value());
 }
 
 // 6.3.17 get Temporal.ZonedDateTime.prototype.epochMicroseconds, https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.epochmicroseconds

--- a/Userland/Libraries/LibJS/Runtime/Value.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Value.cpp
@@ -677,7 +677,7 @@ double string_to_number(StringView string)
         return bigint.to_double();
     }
 
-    auto maybe_double = text.to_double(AK::TrimWhitespace::No);
+    auto maybe_double = text.to_number<double>(AK::TrimWhitespace::No);
     if (!maybe_double.has_value())
         return NAN;
 

--- a/Userland/Libraries/LibJS/Token.cpp
+++ b/Userland/Libraries/LibJS/Token.cpp
@@ -82,7 +82,7 @@ double Token::double_value() const
         }
     }
     // This should always be a valid double
-    return value_string.to_double().release_value();
+    return value_string.to_number<double>().release_value();
 }
 
 static u32 hex2int(char x)

--- a/Userland/Libraries/LibLine/Editor.cpp
+++ b/Userland/Libraries/LibLine/Editor.cpp
@@ -263,7 +263,7 @@ ErrorOr<Vector<Editor::HistoryEntry>> Editor::try_load_history(StringView path)
     Vector<HistoryEntry> history;
     for (auto& str : hist.split_view("\n\n"sv)) {
         auto it = str.find("::"sv).value_or(0);
-        auto time = str.substring_view(0, it).to_int<time_t>().value_or(0);
+        auto time = str.substring_view(0, it).to_number<time_t>().value_or(0);
         auto string = str.substring_view(it == 0 ? it : it + 2);
         history.append({ string, time });
     }
@@ -945,7 +945,7 @@ ErrorOr<void> Editor::handle_read_event()
             m_state = m_previous_free_state;
             auto is_in_paste = m_state == InputState::Paste;
             for (auto& parameter : ByteString::copy(csi_parameter_bytes).split(';')) {
-                if (auto value = parameter.to_uint(); value.has_value())
+                if (auto value = parameter.to_number<unsigned>(); value.has_value())
                     csi_parameters.append(value.value());
                 else
                     csi_parameters.append(0);
@@ -2140,7 +2140,7 @@ Result<Vector<size_t, 2>, Editor::Error> Editor::vt_dsr()
                 continue;
             }
             if (c == ';') {
-                auto maybe_row = StringView { coordinate_buffer.data(), coordinate_buffer.size() }.to_uint();
+                auto maybe_row = StringView { coordinate_buffer.data(), coordinate_buffer.size() }.to_number<unsigned>();
                 if (!maybe_row.has_value())
                     has_error = true;
                 row = maybe_row.value_or(1u);
@@ -2166,7 +2166,7 @@ Result<Vector<size_t, 2>, Editor::Error> Editor::vt_dsr()
                 continue;
             }
             if (c == 'R') {
-                auto maybe_column = StringView { coordinate_buffer.data(), coordinate_buffer.size() }.to_uint();
+                auto maybe_column = StringView { coordinate_buffer.data(), coordinate_buffer.size() }.to_number<unsigned>();
                 if (!maybe_column.has_value())
                     has_error = true;
                 col = maybe_column.value_or(1u);

--- a/Userland/Libraries/LibManual/Node.cpp
+++ b/Userland/Libraries/LibManual/Node.cpp
@@ -88,7 +88,7 @@ ErrorOr<NonnullRefPtr<Node const>> Node::try_find_from_help_url(URL const& url)
         return Error::from_string_view("Bad help page URL"sv);
 
     auto const section = url.path_segment_at_index(0);
-    auto maybe_section_number = section.to_uint();
+    auto maybe_section_number = section.to_number<unsigned>();
     if (!maybe_section_number.has_value())
         return Error::from_string_view("Bad section number"sv);
     auto section_number = maybe_section_number.value();

--- a/Userland/Libraries/LibManual/SectionNode.cpp
+++ b/Userland/Libraries/LibManual/SectionNode.cpp
@@ -18,7 +18,7 @@ namespace Manual {
 
 ErrorOr<NonnullRefPtr<SectionNode>> SectionNode::try_create_from_number(StringView section)
 {
-    auto maybe_section_number = section.to_uint<u32>();
+    auto maybe_section_number = section.to_number<u32>();
     if (!maybe_section_number.has_value())
         return Error::from_string_literal("Section is not a number");
     auto section_number = maybe_section_number.release_value();

--- a/Userland/Libraries/LibMarkdown/List.cpp
+++ b/Userland/Libraries/LibMarkdown/List.cpp
@@ -121,7 +121,7 @@ OwnPtr<List> List::parse(LineIterator& lines)
                 continue;
             if (ch == '.' || ch == ')')
                 if (i + 1 < line.length() && line[i + 1] == ' ') {
-                    auto maybe_start_number = line.substring_view(offset, i - offset).to_uint<size_t>();
+                    auto maybe_start_number = line.substring_view(offset, i - offset).to_number<size_t>();
                     if (!maybe_start_number.has_value())
                         break;
                     if (first)

--- a/Userland/Libraries/LibMarkdown/Text.cpp
+++ b/Userland/Libraries/LibMarkdown/Text.cpp
@@ -643,7 +643,7 @@ NonnullOwnPtr<Text::Node> Text::parse_link(Vector<Token>::ConstIterator& tokens)
 
         auto width_string = dimensions.substring_view(1, *dimension_seperator - 1);
         if (!width_string.is_empty()) {
-            auto width = width_string.to_int();
+            auto width = width_string.to_number<int>();
             if (!width.has_value())
                 return false;
             image_width = width;
@@ -652,7 +652,7 @@ NonnullOwnPtr<Text::Node> Text::parse_link(Vector<Token>::ConstIterator& tokens)
         auto height_start = *dimension_seperator + 1;
         if (height_start < dimensions.length()) {
             auto height_string = dimensions.substring_view(height_start);
-            auto height = height_string.to_int();
+            auto height = height_string.to_number<int>();
             if (!height.has_value())
                 return false;
             image_height = height;

--- a/Userland/Libraries/LibPDF/Fonts/PS1FontProgram.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/PS1FontProgram.cpp
@@ -127,7 +127,7 @@ PDFErrorOr<Vector<ByteBuffer>> PS1FontProgram::parse_subroutines(Reader& reader)
                 return error("Array index out of bounds");
 
             if (isdigit(entry[0])) {
-                auto maybe_encrypted_size = entry.to_int();
+                auto maybe_encrypted_size = entry.to_number<int>();
                 if (!maybe_encrypted_size.has_value())
                     return error("Malformed array");
                 auto rd = TRY(parse_word(reader));
@@ -191,7 +191,7 @@ PDFErrorOr<float> PS1FontProgram::parse_float(Reader& reader)
 
 PDFErrorOr<int> PS1FontProgram::parse_int(Reader& reader)
 {
-    auto maybe_int = TRY(parse_word(reader)).to_int();
+    auto maybe_int = TRY(parse_word(reader)).to_number<int>();
     if (!maybe_int.has_value())
         return error("Invalid int");
     return maybe_int.value();

--- a/Userland/Libraries/LibRegex/RegexMatcher.h
+++ b/Userland/Libraries/LibRegex/RegexMatcher.h
@@ -135,7 +135,7 @@ public:
                         continue;
                     }
                     auto number = lexer.consume_while(isdigit);
-                    if (auto index = number.to_uint(); index.has_value() && result.n_capture_groups >= index.value()) {
+                    if (auto index = number.to_number<unsigned>(); index.has_value() && result.n_capture_groups >= index.value()) {
                         builder.append(result.capture_group_matches[i][index.value() - 1].view.to_byte_string());
                     } else {
                         builder.appendff("\\{}", number);

--- a/Userland/Libraries/LibSQL/SQLClient.cpp
+++ b/Userland/Libraries/LibSQL/SQLClient.cpp
@@ -129,7 +129,7 @@ static ErrorOr<bool> should_launch_server(ByteString const& pid_path)
             return contents.release_error();
         }
 
-        pid = StringView { contents.value() }.to_int<pid_t>();
+        pid = StringView { contents.value() }.to_number<pid_t>();
     }
 
     if (!pid.has_value()) {

--- a/Userland/Libraries/LibSQL/Value.cpp
+++ b/Userland/Libraries/LibSQL/Value.cpp
@@ -241,7 +241,7 @@ Optional<double> Value::to_double() const
         return {};
 
     return m_value->visit(
-        [](ByteString const& value) -> Optional<double> { return value.to_double(); },
+        [](ByteString const& value) -> Optional<double> { return value.to_number<double>(); },
         [](Integer auto value) -> Optional<double> { return static_cast<double>(value); },
         [](double value) -> Optional<double> { return value; },
         [](bool value) -> Optional<double> { return static_cast<double>(value); },

--- a/Userland/Libraries/LibSQL/Value.h
+++ b/Userland/Libraries/LibSQL/Value.h
@@ -87,10 +87,7 @@ public:
 
         return m_value->visit(
             [](ByteString const& value) -> Optional<T> {
-                if constexpr (IsSigned<T>)
-                    return value.to_int<T>();
-                else
-                    return value.to_uint<T>();
+                return value.to_number<T>();
             },
             [](Integer auto value) -> Optional<T> {
                 if (!AK::is_within_range<T>(value))

--- a/Userland/Libraries/LibSymbolication/Symbolication.cpp
+++ b/Userland/Libraries/LibSymbolication/Symbolication.cpp
@@ -52,7 +52,7 @@ Optional<FlatPtr> kernel_base()
 
         auto kernel_base_str = ByteString { file_content.value(), NoChomp };
         using AddressType = u64;
-        auto maybe_kernel_base = kernel_base_str.to_uint<AddressType>();
+        auto maybe_kernel_base = kernel_base_str.to_number<AddressType>();
         if (!maybe_kernel_base.has_value()) {
             s_kernel_base_state = KernelBaseState::Invalid;
             return {};

--- a/Userland/Libraries/LibVT/Terminal.cpp
+++ b/Userland/Libraries/LibVT/Terminal.cpp
@@ -1248,7 +1248,7 @@ void Terminal::execute_osc_sequence(OscParameters parameters, u8 last_byte)
         return;
     }
 
-    auto command_number = stringview_ify(0).to_uint();
+    auto command_number = stringview_ify(0).to_number<unsigned>();
     if (!command_number.has_value()) {
         unimplemented_osc_sequence(parameters, last_byte);
         return;
@@ -1288,9 +1288,9 @@ void Terminal::execute_osc_sequence(OscParameters parameters, u8 last_byte)
         if (parameters.size() < 2)
             dbgln("Atttempted to set window progress but gave too few parameters");
         else if (parameters.size() == 2)
-            m_client.set_window_progress(stringview_ify(1).to_int().value_or(-1), 0);
+            m_client.set_window_progress(stringview_ify(1).to_number<int>().value_or(-1), 0);
         else
-            m_client.set_window_progress(stringview_ify(1).to_int().value_or(-1), stringview_ify(2).to_int().value_or(0));
+            m_client.set_window_progress(stringview_ify(1).to_number<int>().value_or(-1), stringview_ify(2).to_number<int>().value_or(0));
         break;
     default:
         unimplemented_osc_sequence(parameters, last_byte);

--- a/Userland/Libraries/LibWasm/AbstractMachine/Validator.cpp
+++ b/Userland/Libraries/LibWasm/AbstractMachine/Validator.cpp
@@ -3858,7 +3858,7 @@ ByteString Validator::Errors::find_instruction_name(SourceLocation const& locati
     if (!index.has_value() || !end_index.has_value())
         return ByteString::formatted("{}", location);
 
-    auto opcode = location.function_name().substring_view(index.value() + 1, end_index.value() - index.value() - 1).to_uint();
+    auto opcode = location.function_name().substring_view(index.value() + 1, end_index.value() - index.value() - 1).to_number<unsigned>();
     if (!opcode.has_value())
         return ByteString::formatted("{}", location);
 

--- a/Userland/Libraries/LibWeb/ARIA/AriaData.cpp
+++ b/Userland/Libraries/LibWeb/ARIA/AriaData.cpp
@@ -99,14 +99,14 @@ Optional<i32> AriaData::parse_integer(Optional<String> const& value)
 {
     if (!value.has_value())
         return {};
-    return value->bytes_as_string_view().to_int();
+    return value->bytes_as_string_view().to_number<i32>();
 }
 
 Optional<f64> AriaData::parse_number(Optional<String> const& value)
 {
     if (!value.has_value())
         return {};
-    return value->bytes_as_string_view().to_double(TrimWhitespace::Yes);
+    return value->to_number<double>(TrimWhitespace::Yes);
 }
 
 Optional<String> AriaData::aria_active_descendant_or_default() const

--- a/Userland/Libraries/LibWeb/CSS/Parser/SelectorParsing.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/SelectorParsing.cpp
@@ -835,7 +835,7 @@ Optional<Selector::SimpleSelector::ANPlusBPattern> Parser::parse_a_n_plus_b_patt
     if (is_ndashdigit_dimension(first_value)) {
         auto const& dimension = first_value.token();
         int a = dimension.dimension_value_int();
-        auto maybe_b = dimension.dimension_unit().bytes_as_string_view().substring_view(1).to_int();
+        auto maybe_b = dimension.dimension_unit().bytes_as_string_view().substring_view(1).to_number<int>();
         if (maybe_b.has_value()) {
             transaction.commit();
             return Selector::SimpleSelector::ANPlusBPattern { a, maybe_b.value() };
@@ -845,7 +845,7 @@ Optional<Selector::SimpleSelector::ANPlusBPattern> Parser::parse_a_n_plus_b_patt
     }
     // <dashndashdigit-ident>
     if (is_dashndashdigit_ident(first_value)) {
-        auto maybe_b = first_value.token().ident().bytes_as_string_view().substring_view(2).to_int();
+        auto maybe_b = first_value.token().ident().bytes_as_string_view().substring_view(2).to_number<int>();
         if (maybe_b.has_value()) {
             transaction.commit();
             return Selector::SimpleSelector::ANPlusBPattern { -1, maybe_b.value() };
@@ -958,7 +958,7 @@ Optional<Selector::SimpleSelector::ANPlusBPattern> Parser::parse_a_n_plus_b_patt
 
     // '+'?† <ndashdigit-ident>
     if (is_ndashdigit_ident(first_after_plus)) {
-        auto maybe_b = first_after_plus.token().ident().bytes_as_string_view().substring_view(1).to_int();
+        auto maybe_b = first_after_plus.token().ident().bytes_as_string_view().substring_view(1).to_number<int>();
         if (maybe_b.has_value()) {
             transaction.commit();
             return Selector::SimpleSelector::ANPlusBPattern { 1, maybe_b.value() };

--- a/Userland/Libraries/LibWeb/CSS/Parser/Tokenizer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Tokenizer.cpp
@@ -578,7 +578,7 @@ double Tokenizer::convert_a_string_to_a_number(StringView string)
 {
     // FIXME: We already found the whole part, fraction part and exponent during
     //        validation, we could probably skip
-    return string.to_double(AK::TrimWhitespace::No).release_value();
+    return string.to_number<double>(AK::TrimWhitespace::No).release_value();
 }
 
 // https://www.w3.org/TR/css-syntax-3/#consume-name

--- a/Userland/Libraries/LibWeb/Cookie/ParsedCookie.cpp
+++ b/Userland/Libraries/LibWeb/Cookie/ParsedCookie.cpp
@@ -167,7 +167,7 @@ void on_max_age_attribute(ParsedCookie& parsed_cookie, StringView attribute_valu
         return;
 
     // Let delta-seconds be the attribute-value converted to an integer.
-    if (auto delta_seconds = attribute_value.to_int(); delta_seconds.has_value()) {
+    if (auto delta_seconds = attribute_value.to_number<int>(); delta_seconds.has_value()) {
         if (*delta_seconds <= 0) {
             // If delta-seconds is less than or equal to zero (0), let expiry-time be the earliest representable date and time.
             parsed_cookie.expiry_time_from_max_age_attribute = UnixDateTime::earliest();
@@ -251,7 +251,7 @@ Optional<UnixDateTime> parse_date_time(StringView date_string)
         if (!all_of(token, isdigit))
             return false;
 
-        if (auto converted = token.to_uint(); converted.has_value()) {
+        if (auto converted = token.to_number<unsigned>(); converted.has_value()) {
             result = *converted;
             return true;
         }

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Headers.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Headers.cpp
@@ -342,11 +342,11 @@ ErrorOr<HeaderList::ExtractLengthResult> HeaderList::extract_length() const
     }
 
     // 5. If candidateValue is the empty string or has a code point that is not an ASCII digit, then return null.
-    // NOTE: to_uint does this for us.
+    // NOTE: to_number does this for us.
     // 6. Return candidateValue, interpreted as decimal number.
     // NOTE: The spec doesn't say anything about trimming here, so we don't trim. If it contains a space, step 5 will cause us to return null.
     // FIXME: This will return an empty Optional if it cannot fit into a u64, is this correct?
-    auto conversion_result = AK::StringUtils::convert_to_uint<u64>(candidate_value.value(), TrimWhitespace::No);
+    auto conversion_result = candidate_value.value().to_number<u64>(TrimWhitespace::No);
     if (!conversion_result.has_value())
         return Empty {};
     return ExtractLengthResult { conversion_result.release_value() };
@@ -851,7 +851,7 @@ Optional<RangeHeaderValue> parse_single_range_header_value(ReadonlyBytes value)
     auto range_start = lexer.consume_while(is_ascii_digit);
 
     // 5. Let rangeStartValue be rangeStart, interpreted as decimal number, if rangeStart is not the empty string; otherwise null.
-    auto range_start_value = range_start.to_uint<u64>();
+    auto range_start_value = range_start.to_number<u64>();
 
     // 6. If the code point at position within data is not U+002D (-), then return failure.
     // 7. Advance position by 1.
@@ -862,7 +862,7 @@ Optional<RangeHeaderValue> parse_single_range_header_value(ReadonlyBytes value)
     auto range_end = lexer.consume_while(is_ascii_digit);
 
     // 9. Let rangeEndValue be rangeEnd, interpreted as decimal number, if rangeEnd is not the empty string; otherwise null.
-    auto range_end_value = range_end.to_uint<u64>();
+    auto range_end_value = range_end.to_number<u64>();
 
     // 10. If position is not past the end of data, then return failure.
     if (!lexer.is_eof())

--- a/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -176,7 +176,7 @@ unsigned HTMLImageElement::width() const
 
     // NOTE: This step seems to not be in the spec, but all browsers do it.
     auto width_attr = deprecated_get_attribute(HTML::AttributeNames::width);
-    if (auto converted = width_attr.to_uint(); converted.has_value())
+    if (auto converted = width_attr.to_number<unsigned>(); converted.has_value())
         return *converted;
 
     // ...or else the density-corrected intrinsic width and height of the image, in CSS pixels,
@@ -204,7 +204,7 @@ unsigned HTMLImageElement::height() const
 
     // NOTE: This step seems to not be in the spec, but all browsers do it.
     auto height_attr = deprecated_get_attribute(HTML::AttributeNames::height);
-    if (auto converted = height_attr.to_uint(); converted.has_value())
+    if (auto converted = height_attr.to_number<unsigned>(); converted.has_value())
         return *converted;
 
     // ...or else the density-corrected intrinsic height and height of the image, in CSS pixels,

--- a/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
@@ -192,7 +192,7 @@ Optional<ARIA::Role> HTMLSelectElement::default_role() const
     if (has_attribute(AttributeNames::multiple))
         return ARIA::Role::listbox;
     if (has_attribute(AttributeNames::size)) {
-        auto size_attribute = deprecated_attribute(AttributeNames::size).to_int();
+        auto size_attribute = deprecated_attribute(AttributeNames::size).to_number<int>();
         if (size_attribute.has_value() && size_attribute.value() > 1)
             return ARIA::Role::listbox;
     }

--- a/Userland/Libraries/LibWeb/HTML/HTMLTableElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableElement.cpp
@@ -46,7 +46,7 @@ void HTMLTableElement::visit_edges(Cell::Visitor& visitor)
 
 static unsigned parse_border(ByteString const& value)
 {
-    return value.to_uint().value_or(0);
+    return value.to_number<unsigned>().value_or(0);
 }
 
 void HTMLTableElement::apply_presentational_hints(CSS::StyleProperties& style) const

--- a/Userland/Libraries/LibWeb/HTML/Numbers.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Numbers.cpp
@@ -84,7 +84,7 @@ Optional<u32> parse_non_negative_integer(StringView string)
 Optional<double> parse_floating_point_number(StringView string)
 {
     // FIXME: Implement spec compliant floating point number parsing
-    auto maybe_double = MUST(String::from_utf8(string)).to_number<double>(TrimWhitespace::Yes);
+    auto maybe_double = string.to_number<double>(TrimWhitespace::Yes);
     if (!maybe_double.has_value())
         return {};
     if (!isfinite(maybe_double.value()))

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
@@ -4475,7 +4475,7 @@ RefPtr<CSS::StyleValue> parse_dimension_value(StringView string)
         number_string.append(*position);
         ++position;
     }
-    auto integer_value = number_string.string_view().to_int();
+    auto integer_value = number_string.string_view().to_number<int>();
 
     // 6. If position is past the end of input, then return value as a length.
     if (position == input.end())

--- a/Userland/Libraries/LibWeb/HTML/SourceSet.cpp
+++ b/Userland/Libraries/LibWeb/HTML/SourceSet.cpp
@@ -269,8 +269,8 @@ descriptor_parser:
         auto last_character = descriptor.bytes_as_string_view().bytes().last();
         auto descriptor_without_last_character = descriptor.bytes_as_string_view().substring_view(0, descriptor.bytes_as_string_view().length() - 1);
 
-        auto as_int = descriptor_without_last_character.to_int<i32>();
-        auto as_float = descriptor_without_last_character.to_float();
+        auto as_int = descriptor_without_last_character.to_number<i32>();
+        auto as_float = descriptor_without_last_character.to_number<float>();
 
         // - If the descriptor consists of a valid non-negative integer followed by a U+0077 LATIN SMALL LETTER W character
         if (last_character == 'w' && as_int.has_value()) {

--- a/Userland/Libraries/LibWeb/HTML/Window.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Window.cpp
@@ -235,7 +235,7 @@ static T parse_boolean_feature(StringView value)
         return T::Yes;
 
     // 4. Let parsed be the result of parsing value as an integer.
-    auto parsed = value.to_int<i64>();
+    auto parsed = value.to_number<i64>();
 
     // 5. If parsed is an error, then set it to 0.
     if (!parsed.has_value())

--- a/Userland/Libraries/LibWeb/Layout/FrameBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FrameBox.cpp
@@ -24,8 +24,8 @@ void FrameBox::prepare_for_replaced_layout()
     VERIFY(dom_node().nested_browsing_context());
 
     // FIXME: Do proper error checking, etc.
-    set_natural_width(dom_node().deprecated_attribute(HTML::AttributeNames::width).to_int().value_or(300));
-    set_natural_height(dom_node().deprecated_attribute(HTML::AttributeNames::height).to_int().value_or(150));
+    set_natural_width(dom_node().deprecated_attribute(HTML::AttributeNames::width).to_number<int>().value_or(300));
+    set_natural_height(dom_node().deprecated_attribute(HTML::AttributeNames::height).to_number<int>().value_or(150));
 }
 
 void FrameBox::did_set_content_size()

--- a/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -72,7 +72,7 @@ void TableFormattingContext::compute_constrainedness()
                 m_columns[column_index].is_constrained = true;
             }
             auto const& col_node = static_cast<HTML::HTMLTableColElement const&>(*column_box.dom_node());
-            unsigned span = col_node.deprecated_attribute(HTML::AttributeNames::span).to_uint().value_or(1);
+            unsigned span = col_node.deprecated_attribute(HTML::AttributeNames::span).to_number<unsigned>().value_or(1);
             column_index += span;
         });
     });
@@ -189,7 +189,7 @@ void TableFormattingContext::compute_outer_content_sizes()
             // The outer max-content width of a table-column or table-column-group is max(min-width, min(max-width, width)).
             m_columns[column_index].max_size = max(min_width, min(max_width, width));
             auto const& col_node = static_cast<HTML::HTMLTableColElement const&>(*column_box.dom_node());
-            unsigned span = col_node.deprecated_attribute(HTML::AttributeNames::span).to_uint().value_or(1);
+            unsigned span = col_node.deprecated_attribute(HTML::AttributeNames::span).to_number<unsigned>().value_or(1);
             column_index += span;
         });
     });
@@ -1380,7 +1380,7 @@ void TableFormattingContext::BorderConflictFinder::collect_conflicting_col_eleme
         for (auto* child_of_column_group = child->first_child(); child_of_column_group; child_of_column_group = child_of_column_group->next_sibling()) {
             VERIFY(child_of_column_group->display().is_table_column());
             auto const& col_node = static_cast<HTML::HTMLTableColElement const&>(*child_of_column_group->dom_node());
-            unsigned span = col_node.deprecated_attribute(HTML::AttributeNames::span).to_uint().value_or(1);
+            unsigned span = col_node.deprecated_attribute(HTML::AttributeNames::span).to_number<unsigned>().value_or(1);
             for (size_t i = column_index; i < column_index + span; ++i) {
                 m_col_elements_by_index[i] = child_of_column_group;
             }
@@ -1744,7 +1744,7 @@ void TableFormattingContext::initialize_intrinsic_percentages_from_rows_or_colum
             m_columns[column_index].has_intrinsic_percentage = computed_values.max_width().is_percentage() || computed_values.width().is_percentage();
             m_columns[column_index].intrinsic_percentage = min(width_percentage, max_width_percentage);
             auto const& col_node = static_cast<HTML::HTMLTableColElement const&>(*column_box.dom_node());
-            unsigned span = col_node.deprecated_attribute(HTML::AttributeNames::span).to_uint().value_or(1);
+            unsigned span = col_node.deprecated_attribute(HTML::AttributeNames::span).to_number<unsigned>().value_or(1);
             column_index += span;
         });
     });

--- a/Userland/Libraries/LibWeb/SVG/ViewBox.cpp
+++ b/Userland/Libraries/LibWeb/SVG/ViewBox.cpp
@@ -30,7 +30,7 @@ Optional<ViewBox> try_parse_view_box(StringView string)
     while (!lexer.is_eof()) {
         lexer.consume_while([](auto ch) { return is_ascii_space(ch); });
         auto token = lexer.consume_until([](auto ch) { return is_ascii_space(ch) && ch != ','; });
-        auto maybe_number = token.to_float();
+        auto maybe_number = token.to_number<float>();
         if (!maybe_number.has_value())
             return {};
         switch (state) {

--- a/Userland/Libraries/LibWeb/WebDriver/Client.cpp
+++ b/Userland/Libraries/LibWeb/WebDriver/Client.cpp
@@ -253,7 +253,7 @@ ErrorOr<JsonValue, Client::WrappedError> Client::read_body_as_json()
 
     for (auto const& header : m_request->headers()) {
         if (header.name.equals_ignoring_ascii_case("Content-Length"sv)) {
-            content_length = header.value.to_uint<size_t>(TrimWhitespace::Yes).value_or(0);
+            content_length = header.value.to_number<size_t>(TrimWhitespace::Yes).value_or(0);
             break;
         }
     }

--- a/Userland/Libraries/LibXML/Parser/Parser.cpp
+++ b/Userland/Libraries/LibXML/Parser/Parser.cpp
@@ -799,7 +799,7 @@ ErrorOr<Variant<Parser::EntityReference, ByteString>, ParseError> Parser::parse_
             auto decimal = TRY(expect_many(
                 ranges_for_search<Range('0', '9')>(),
                 "any of [0-9]"sv));
-            code_point = decimal.to_uint<u32>();
+            code_point = decimal.to_number<u32>();
         }
 
         if (!code_point.has_value() || !s_characters.contains(*code_point))

--- a/Userland/Services/FileOperation/main.cpp
+++ b/Userland/Services/FileOperation/main.cpp
@@ -358,7 +358,7 @@ ByteString deduplicate_destination_file_name(ByteString const& destination)
     auto last_hyphen_index = title_without_counter.find_last('-');
     if (last_hyphen_index.has_value()) {
         auto counter_string = title_without_counter.substring_view(*last_hyphen_index + 1);
-        auto last_counter = counter_string.to_uint();
+        auto last_counter = counter_string.to_number<unsigned>();
         if (last_counter.has_value()) {
             next_counter = *last_counter + 1;
             title_without_counter = title_without_counter.substring_view(0, *last_hyphen_index);

--- a/Userland/Services/LaunchServer/Launcher.cpp
+++ b/Userland/Services/LaunchServer/Launcher.cpp
@@ -397,7 +397,7 @@ bool Launcher::open_file_url(const URL& url)
         url.query()->bytes_as_string_view().for_each_split_view('&', SplitBehavior::Nothing, [&](auto parameter) {
             auto pair = parameter.split_view('=');
             if (pair.size() == 2 && pair[0] == "line_number") {
-                auto line = pair[1].to_int();
+                auto line = pair[1].template to_number<int>();
                 if (line.has_value())
                     // TextEditor uses file:line:col to open a file at a specific line number
                     filepath = ByteString::formatted("{}:{}", filepath, line.value());

--- a/Userland/Services/Taskbar/QuickLaunchWidget.cpp
+++ b/Userland/Services/Taskbar/QuickLaunchWidget.cpp
@@ -339,7 +339,7 @@ void QuickLaunchWidget::load_entries(bool save)
         auto value = Config::read_string(CONFIG_DOMAIN, CONFIG_GROUP_ENTRIES, name);
         auto values = value.split(':');
 
-        config_entries.append({ values[0].to_int().release_value(), values[1] });
+        config_entries.append({ values[0].to_number<int>().release_value(), values[1] });
     }
 
     quick_sort(config_entries, [](ConfigEntry const& a, ConfigEntry const& b) {

--- a/Userland/Services/WebContent/WebDriverConnection.cpp
+++ b/Userland/Services/WebContent/WebDriverConnection.cpp
@@ -150,7 +150,7 @@ static ErrorOr<Web::DOM::Element*, Web::WebDriver::Error> get_known_connected_el
 {
     // NOTE: The whole concept of "connected elements" is not implemented yet. See get_or_create_a_web_element_reference().
     //       For now the element is only represented by its ID.
-    auto element = element_id.to_int();
+    auto element = element_id.to_number<int>();
     if (!element.has_value())
         return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidArgument, "Element ID is not an integer");
 
@@ -197,7 +197,7 @@ static ErrorOr<Web::DOM::ShadowRoot*, Web::WebDriver::Error> get_known_shadow_ro
 {
     // NOTE: The whole concept of "known shadow roots" is not implemented yet. See get_or_create_a_shadow_root_reference().
     //       For now the shadow root is only represented by its ID.
-    auto shadow_root = shadow_id.to_int();
+    auto shadow_root = shadow_id.to_number<int>();
     if (!shadow_root.has_value())
         return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidArgument, "Shadow ID is not an integer");
 

--- a/Userland/Services/WebDriver/Client.cpp
+++ b/Userland/Services/WebDriver/Client.cpp
@@ -39,7 +39,7 @@ Client::~Client() = default;
 
 ErrorOr<NonnullRefPtr<Session>, Web::WebDriver::Error> Client::find_session_with_id(StringView session_id)
 {
-    auto session_id_or_error = session_id.to_uint<>();
+    auto session_id_or_error = session_id.to_number<unsigned>();
     if (!session_id_or_error.has_value())
         return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidSessionId, "Invalid session id");
 

--- a/Userland/Shell/AST.cpp
+++ b/Userland/Shell/AST.cpp
@@ -177,7 +177,7 @@ static ErrorOr<String> resolve_slices(RefPtr<Shell> shell, String&& input_value,
 
         size_t i = 0;
         for (auto& value : index_values) {
-            auto maybe_index = value.bytes_as_string_view().to_int();
+            auto maybe_index = value.bytes_as_string_view().to_number<int>();
             if (!maybe_index.has_value()) {
                 shell->raise_error(Shell::ShellError::InvalidSliceContentsError, ByteString::formatted("Invalid value in slice index {}: {} (expected a number)", i, value), slice->position());
                 return move(input_value);
@@ -227,7 +227,7 @@ static ErrorOr<Vector<String>> resolve_slices(RefPtr<Shell> shell, Vector<String
 
         size_t i = 0;
         for (auto& value : index_values) {
-            auto maybe_index = value.bytes_as_string_view().to_int();
+            auto maybe_index = value.to_number<int>();
             if (!maybe_index.has_value()) {
                 shell->raise_error(Shell::ShellError::InvalidSliceContentsError, ByteString::formatted("Invalid value in slice index {}: {} (expected a number)", i, value), slice->position());
                 return move(values);
@@ -2697,8 +2697,8 @@ ErrorOr<RefPtr<Value>> Range::run(RefPtr<Shell> shell)
                     values.append(make_ref_counted<StringValue>(TRY(builder.to_string())));
                 } else {
                     // Could be two numbers?
-                    auto start_int = start_str.bytes_as_string_view().to_int();
-                    auto end_int = end_str.bytes_as_string_view().to_int();
+                    auto start_int = start_str.to_number<int>();
+                    auto end_int = end_str.to_number<int>();
                     if (start_int.has_value() && end_int.has_value()) {
                         auto start = start_int.value();
                         auto end = end_int.value();

--- a/Userland/Shell/Builtin.cpp
+++ b/Userland/Shell/Builtin.cpp
@@ -298,7 +298,7 @@ ErrorOr<int> Shell::builtin_bg(Main::Arguments arguments)
         .max_values = 1,
         .accept_value = [&](StringView value) -> bool {
             // Check if it's a pid (i.e. literal integer)
-            if (auto number = value.to_uint(); number.has_value()) {
+            if (auto number = value.to_number<unsigned>(); number.has_value()) {
                 job_id = number.value();
                 is_pid = true;
                 return true;
@@ -705,7 +705,7 @@ ErrorOr<int> Shell::builtin_fg(Main::Arguments arguments)
         .max_values = 1,
         .accept_value = [&](StringView value) -> bool {
             // Check if it's a pid (i.e. literal integer)
-            if (auto number = value.to_uint(); number.has_value()) {
+            if (auto number = value.to_number<unsigned>(); number.has_value()) {
                 job_id = number.value();
                 is_pid = true;
                 return true;
@@ -776,7 +776,7 @@ ErrorOr<int> Shell::builtin_disown(Main::Arguments arguments)
         .max_values = INT_MAX,
         .accept_value = [&](StringView value) -> bool {
             // Check if it's a pid (i.e. literal integer)
-            if (auto number = value.to_uint(); number.has_value()) {
+            if (auto number = value.to_number<unsigned>(); number.has_value()) {
                 job_ids.append(number.value());
                 id_is_pid.append(true);
                 return true;
@@ -1237,7 +1237,7 @@ ErrorOr<int> Shell::builtin_wait(Main::Arguments arguments)
         .max_values = INT_MAX,
         .accept_value = [&](StringView value) -> bool {
             // Check if it's a pid (i.e. literal integer)
-            if (auto number = value.to_uint(); number.has_value()) {
+            if (auto number = value.to_number<unsigned>(); number.has_value()) {
                 job_ids.append(number.value());
                 id_is_pid.append(true);
                 return true;
@@ -1543,14 +1543,14 @@ ErrorOr<int> Shell::builtin_argsparser_parse(Main::Arguments arguments)
         case Type::String:
             return AST::make_ref_counted<AST::StringValue>(TRY(String::from_utf8(value)));
         case Type::I32:
-            if (auto number = value.to_int(); number.has_value())
+            if (auto number = value.to_number<int>(); number.has_value())
                 return AST::make_ref_counted<AST::StringValue>(TRY(String::number(*number)));
 
             warnln("Invalid value for type i32: {}", value);
             return OptionalNone {};
         case Type::U32:
         case Type::Size:
-            if (auto number = value.to_uint(); number.has_value())
+            if (auto number = value.to_number<unsigned>(); number.has_value())
                 return AST::make_ref_counted<AST::StringValue>(TRY(String::number(*number)));
 
             warnln("Invalid value for type u32|size: {}", value);
@@ -1860,7 +1860,7 @@ ErrorOr<int> Shell::builtin_argsparser_parse(Main::Arguments arguments)
                 return false;
             }
 
-            auto number = value.to_uint();
+            auto number = value.to_number<unsigned>();
             if (!number.has_value()) {
                 warnln("Invalid value for --min: '{}', expected a non-negative number", value);
                 return false;
@@ -1888,7 +1888,7 @@ ErrorOr<int> Shell::builtin_argsparser_parse(Main::Arguments arguments)
                 return false;
             }
 
-            auto number = value.to_uint();
+            auto number = value.to_number<unsigned>();
             if (!number.has_value()) {
                 warnln("Invalid value for --max: '{}', expected a non-negative number", value);
                 return false;

--- a/Userland/Shell/ImmediateFunctions.cpp
+++ b/Userland/Shell/ImmediateFunctions.cpp
@@ -1052,7 +1052,7 @@ ErrorOr<RefPtr<AST::Node>> Shell::immediate_math(AST::ImmediateExpression& invok
                 view.byte_offset_of(it) - *integer_or_word_start_offset);
 
             if (all_of(integer_or_word, is_ascii_digit))
-                tokens.append(*integer_or_word.as_string().to_int());
+                tokens.append(*integer_or_word.as_string().to_number<int>());
             else
                 tokens.append(TRY(expression.substring_from_byte_offset_with_shared_superstring(*integer_or_word_start_offset, integer_or_word.length())));
 
@@ -1239,7 +1239,7 @@ ErrorOr<RefPtr<AST::Node>> Shell::immediate_math(AST::ImmediateExpression& invok
         auto integer_or_word = view.substring_view(*integer_or_word_start_offset);
 
         if (all_of(integer_or_word, is_ascii_digit))
-            tokens.append(*integer_or_word.as_string().to_int());
+            tokens.append(*integer_or_word.as_string().to_number<int>());
         else
             tokens.append(TRY(expression.substring_from_byte_offset_with_shared_superstring(*integer_or_word_start_offset, integer_or_word.length())));
 
@@ -1262,7 +1262,7 @@ ErrorOr<RefPtr<AST::Node>> Shell::immediate_math(AST::ImmediateExpression& invok
                     builder.join(' ', TRY(const_cast<AST::Value&>(*value).resolve_as_list(const_cast<Shell&>(*this))));
                     resolved_name = TRY(builder.to_string());
 
-                    auto integer = resolved_name.bytes_as_string_view().to_int<i64>();
+                    auto integer = resolved_name.to_number<i64>();
                     if (integer.has_value())
                         return *integer;
                 }

--- a/Userland/Shell/Parser.cpp
+++ b/Userland/Shell/Parser.cpp
@@ -1165,7 +1165,7 @@ RefPtr<AST::Node> Parser::parse_redirection()
     if (number.is_empty()) {
         pipe_fd = -1;
     } else {
-        auto fd = number.to_int();
+        auto fd = number.to_number<int>();
         pipe_fd = fd.value_or(-1);
     }
 
@@ -1200,7 +1200,7 @@ RefPtr<AST::Node> Parser::parse_redirection()
             if (number.is_empty()) {
                 dest_pipe_fd = -1;
             } else {
-                auto fd = number.to_int();
+                auto fd = number.to_number<int>();
                 dest_pipe_fd = fd.value_or(-1);
             }
             auto redir = create<AST::Fd2FdRedirection>(pipe_fd, dest_pipe_fd); // Redirection Fd2Fd
@@ -1791,7 +1791,7 @@ RefPtr<AST::Node> Parser::parse_history_designator()
                 selector.event.kind = AST::HistorySelector::EventKind::IndexFromEnd;
             else
                 selector.event.kind = AST::HistorySelector::EventKind::IndexFromStart;
-            auto number = abs(selector.event.text.bytes_as_string_view().to_int().value_or(0));
+            auto number = abs(selector.event.text.to_number<int>().value_or(0));
             if (number != 0)
                 selector.event.index = number - 1;
             else
@@ -1819,7 +1819,7 @@ RefPtr<AST::Node> Parser::parse_history_designator()
         ssize_t offset = -1;
         if (isdigit(c)) {
             auto num = consume_while(is_digit);
-            auto value = num.to_uint();
+            auto value = num.to_number<unsigned>();
             if (!value.has_value())
                 return {};
             word_selector_kind = AST::HistorySelector::WordSelectorKind::Index;

--- a/Userland/Shell/PosixParser.cpp
+++ b/Userland/Shell/PosixParser.cpp
@@ -2084,7 +2084,7 @@ ErrorOr<RefPtr<AST::Node>> Parser::parse_io_redirect()
     Optional<int> io_number;
 
     if (peek().type == Token::Type::IoNumber)
-        io_number = consume().value.bytes_as_string_view().to_int();
+        io_number = consume().value.to_number<int>();
 
     if (auto io_file = TRY(parse_io_file(start_position, io_number)))
         return io_file;
@@ -2194,7 +2194,7 @@ ErrorOr<RefPtr<AST::Node>> Parser::parse_io_file(AST::Position start_position, O
                     source_fd);
             }
 
-            auto maybe_target_fd = text.bytes_as_string_view().to_int();
+            auto maybe_target_fd = text.to_number<int>();
             if (maybe_target_fd.has_value()) {
                 auto target_fd = maybe_target_fd.release_value();
                 if (is_less)

--- a/Userland/Shell/Shell.cpp
+++ b/Userland/Shell/Shell.cpp
@@ -137,7 +137,7 @@ ByteString Shell::prompt() const
             if (next_char != 'w' && next_char != 'W')
                 continue;
 
-            auto const max_component_count = number_string.to_uint().value();
+            auto const max_component_count = number_string.to_number<unsigned>().value();
 
             ByteString const home_path = getenv("HOME");
 
@@ -412,7 +412,7 @@ ErrorOr<RefPtr<AST::Value const>> Shell::look_up_local_variable(StringView name)
     if (auto* frame = find_frame_containing_local_variable(name))
         return frame->local_variables.get(name).value();
 
-    if (auto index = name.to_uint(); index.has_value())
+    if (auto index = name.to_number<unsigned>(); index.has_value())
         return get_argument(index.value());
 
     return nullptr;
@@ -2620,7 +2620,7 @@ Optional<int> Shell::resolve_job_spec(StringView str)
         return {};
 
     // %number -> job id <number>
-    if (auto number = str.substring_view(1).to_uint(); number.has_value())
+    if (auto number = str.substring_view(1).to_number<unsigned>(); number.has_value())
         return number.value();
 
     // '%?str' -> iterate jobs and pick one with `str' in its command
@@ -2647,7 +2647,7 @@ void Shell::timer_event(Core::TimerEvent& event)
     auto const* autosave_env_ptr = getenv("HISTORY_AUTOSAVE_TIME_MS");
     auto option = autosave_env_ptr != NULL ? StringView { autosave_env_ptr, strlen(autosave_env_ptr) } : StringView {};
 
-    auto time = option.to_uint();
+    auto time = option.to_number<unsigned>();
     if (!time.has_value() || time.value() == 0) {
         m_history_autosave_time.clear();
         stop_timer();

--- a/Userland/Utilities/asctl.cpp
+++ b/Userland/Utilities/asctl.cpp
@@ -105,7 +105,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             }
             auto& variable = command_arguments[i];
             if (variable.is_one_of("v"sv, "volume"sv)) {
-                auto volume = command_arguments[++i].to_int();
+                auto volume = command_arguments[++i].to_number<int>();
                 if (!volume.has_value()) {
                     warnln("Error: {} is not an integer volume", command_arguments[i - 1]);
                     return 1;
@@ -128,7 +128,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                 }
                 values_to_set.set(AudioVariable::Mute, mute);
             } else if (variable.is_one_of("r"sv, "samplerate"sv)) {
-                auto sample_rate = command_arguments[++i].to_int();
+                auto sample_rate = command_arguments[++i].to_number<int>();
                 if (!sample_rate.has_value()) {
                     warnln("Error: {} is not an integer sample rate", command_arguments[i - 1]);
                     return 1;

--- a/Userland/Utilities/bt.cpp
+++ b/Userland/Utilities/bt.cpp
@@ -33,7 +33,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     }
 
     while (iterator.has_next()) {
-        pid_t tid = iterator.next_path().to_int().value();
+        pid_t tid = iterator.next_path().to_number<pid_t>().value();
         outln("thread: {}", tid);
         outln("frames:");
         auto symbols = Symbolication::symbolicate_thread(pid, tid);

--- a/Userland/Utilities/chgrp.cpp
+++ b/Userland/Utilities/chgrp.cpp
@@ -31,7 +31,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         return 1;
     }
 
-    auto number = gid_arg.to_uint();
+    auto number = gid_arg.to_number<unsigned>();
     if (number.has_value()) {
         new_gid = number.value();
     } else {

--- a/Userland/Utilities/chown.cpp
+++ b/Userland/Utilities/chown.cpp
@@ -44,7 +44,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         return 1;
     }
 
-    auto number = parts[0].to_uint();
+    auto number = parts[0].to_number<uid_t>();
     if (number.has_value()) {
         new_uid = number.value();
     } else {
@@ -57,7 +57,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     }
 
     if (parts.size() == 2) {
-        auto number = parts[1].to_uint();
+        auto number = parts[1].to_number<gid_t>();
         if (number.has_value()) {
             new_gid = number.value();
         } else {

--- a/Userland/Utilities/cut.cpp
+++ b/Userland/Utilities/cut.cpp
@@ -49,7 +49,7 @@ static bool expand_list(ByteString& list, Vector<Range>& ranges)
         }
 
         if (token[0] == '-') {
-            auto index = token.substring(1, token.length() - 1).to_uint();
+            auto index = token.substring(1, token.length() - 1).to_number<unsigned>();
             if (!index.has_value()) {
                 warnln("cut: invalid byte/character position '{}'", token);
                 return false;
@@ -62,7 +62,7 @@ static bool expand_list(ByteString& list, Vector<Range>& ranges)
 
             ranges.append({ 1, index.value() });
         } else if (token[token.length() - 1] == '-') {
-            auto index = token.substring(0, token.length() - 1).to_uint();
+            auto index = token.substring(0, token.length() - 1).to_number<unsigned>();
             if (!index.has_value()) {
                 warnln("cut: invalid byte/character position '{}'", token);
                 return false;
@@ -77,13 +77,13 @@ static bool expand_list(ByteString& list, Vector<Range>& ranges)
         } else {
             auto range = token.split('-', SplitBehavior::KeepEmpty);
             if (range.size() == 2) {
-                auto index1 = range[0].to_uint();
+                auto index1 = range[0].to_number<unsigned>();
                 if (!index1.has_value()) {
                     warnln("cut: invalid byte/character position '{}'", range[0]);
                     return false;
                 }
 
-                auto index2 = range[1].to_uint();
+                auto index2 = range[1].to_number<unsigned>();
                 if (!index2.has_value()) {
                     warnln("cut: invalid byte/character position '{}'", range[1]);
                     return false;
@@ -99,7 +99,7 @@ static bool expand_list(ByteString& list, Vector<Range>& ranges)
 
                 ranges.append({ index1.value(), index2.value() });
             } else if (range.size() == 1) {
-                auto index = range[0].to_uint();
+                auto index = range[0].to_number<unsigned>();
                 if (!index.has_value()) {
                     warnln("cut: invalid byte/character position '{}'", range[0]);
                     return false;

--- a/Userland/Utilities/date.cpp
+++ b/Userland/Utilities/date.cpp
@@ -31,7 +31,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.parse(arguments);
 
     if (!set_date.is_empty()) {
-        auto number = set_date.to_uint();
+        auto number = set_date.to_number<unsigned>();
 
         if (!number.has_value()) {
             warnln("date: Invalid timestamp value");

--- a/Userland/Utilities/dd.cpp
+++ b/Userland/Utilities/dd.cpp
@@ -116,7 +116,7 @@ static int handle_size_arguments(size_t& numeric_value, StringView argument)
         break;
     }
 
-    Optional<unsigned> numeric_optional = value.to_uint();
+    Optional<unsigned> numeric_optional = value.to_number<unsigned>();
     if (!numeric_optional.has_value()) {
         warnln("Invalid size-value: {}", value);
         return -1;

--- a/Userland/Utilities/errno.cpp
+++ b/Userland/Utilities/errno.cpp
@@ -55,7 +55,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         return 0;
     }
 
-    if (auto maybe_error_code = keyword.to_int(); maybe_error_code.has_value()) {
+    if (auto maybe_error_code = keyword.to_number<int>(); maybe_error_code.has_value()) {
         auto error_code = maybe_error_code.value();
         auto error = strerror(error_code);
         if (error == "Unknown error"sv) {

--- a/Userland/Utilities/expr.cpp
+++ b/Userland/Utilities/expr.cpp
@@ -90,7 +90,7 @@ private:
         case Type::Integer:
             return as_integer;
         case Type::String:
-            if (auto converted = as_string.to_int(); converted.has_value())
+            if (auto converted = as_string.to_number<int>(); converted.has_value())
                 return converted.value();
             fail("Not an integer: '{}'", as_string);
         }
@@ -371,7 +371,7 @@ private:
     {
         if (m_op == StringOperation::Substring || m_op == StringOperation::Match) {
             auto substr = string();
-            if (auto integer = substr.to_int(); integer.has_value())
+            if (auto integer = substr.to_number<int>(); integer.has_value())
                 return integer.value();
             else
                 fail("Not an integer: '{}'", substr);

--- a/Userland/Utilities/find.cpp
+++ b/Userland/Utilities/find.cpp
@@ -133,7 +133,7 @@ public:
             arg = arg.substring_view(1);
         }
 
-        auto maybe_value = arg.to_uint<T>();
+        auto maybe_value = arg.to_number<T>();
         if (!maybe_value.has_value())
             return Error::from_errno(EINVAL);
 
@@ -192,7 +192,7 @@ public:
     MaxDepthCommand(char const* arg)
     {
         auto max_depth_string = StringView { arg, strlen(arg) };
-        auto maybe_max_depth = max_depth_string.to_uint<u32>();
+        auto maybe_max_depth = max_depth_string.to_number<u32>();
         if (!maybe_max_depth.has_value())
             fatal_error("-maxdepth: '{}' is not a valid non-negative integer", arg);
 
@@ -210,7 +210,7 @@ public:
     MinDepthCommand(char const* arg)
     {
         auto min_depth_string = StringView { arg, strlen(arg) };
-        auto maybe_min_depth = min_depth_string.to_uint<u32>();
+        auto maybe_min_depth = min_depth_string.to_number<u32>();
         if (!maybe_min_depth.has_value())
             fatal_error("-mindepth: '{}' is not a valid non-negative integer", arg);
 
@@ -296,7 +296,7 @@ public:
             m_uid = passwd->pw_uid;
         } else {
             // Attempt to parse it as decimal UID.
-            auto number = StringView { arg, strlen(arg) }.to_uint<uid_t>();
+            auto number = StringView { arg, strlen(arg) }.to_number<uid_t>();
             if (!number.has_value())
                 fatal_error("Invalid user: \033[1m{}", arg);
             m_uid = number.value();
@@ -320,7 +320,7 @@ public:
             m_gid = gr->gr_gid;
         } else {
             // Attempt to parse it as decimal GID.
-            auto number = StringView { arg, strlen(arg) }.to_uint<gid_t>();
+            auto number = StringView { arg, strlen(arg) }.to_number<gid_t>();
             if (!number.has_value())
                 fatal_error("Invalid group: \033[1m{}", arg);
             m_gid = number.value();

--- a/Userland/Utilities/id.cpp
+++ b/Userland/Utilities/id.cpp
@@ -50,7 +50,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     Optional<Core::Account> account;
     if (!user_str.is_empty()) {
-        if (auto user_id = user_str.to_uint(); user_id.has_value())
+        if (auto user_id = user_str.to_number<uid_t>(); user_id.has_value())
             account = TRY(Core::Account::from_uid(user_id.value(), Core::Account::Read::PasswdOnly));
         else
             account = TRY(Core::Account::from_name(user_str, Core::Account::Read::PasswdOnly));

--- a/Userland/Utilities/json.cpp
+++ b/Userland/Utilities/json.cpp
@@ -141,7 +141,7 @@ JsonValue query(JsonValue const& value, Vector<StringView>& key_parts, size_t ke
     if (value.is_object()) {
         result = value.as_object().get(key).value_or({});
     } else if (value.is_array()) {
-        auto key_as_index = key.to_int();
+        auto key_as_index = key.to_number<int>();
         if (key_as_index.has_value())
             result = value.as_array().at(key_as_index.value());
     }

--- a/Userland/Utilities/kill.cpp
+++ b/Userland/Utilities/kill.cpp
@@ -61,7 +61,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         }
 
         if (!number.has_value())
-            number = strings[1].substring_view(1).to_uint();
+            number = strings[1].substring_view(1).to_number<unsigned>();
 
         if (!number.has_value()) {
             warnln("'{}' is not a valid signal name or number", &strings[1][1]);
@@ -69,7 +69,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         }
         signum = number.value();
     }
-    auto pid_opt = strings[pid_argi].to_int();
+    auto pid_opt = strings[pid_argi].to_number<pid_t>();
     if (!pid_opt.has_value()) {
         warnln("'{}' is not a valid PID", strings[pid_argi]);
         return 3;

--- a/Userland/Utilities/killall.cpp
+++ b/Userland/Utilities/killall.cpp
@@ -56,7 +56,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         }
 
         if (!number.has_value())
-            number = arguments.strings[1].substring_view(1).to_uint();
+            number = arguments.strings[1].substring_view(1).to_number<unsigned>();
 
         if (!number.has_value()) {
             warnln("'{}' is not a valid signal name or number", &arguments.argv[1][1]);

--- a/Userland/Utilities/less.cpp
+++ b/Userland/Utilities/less.cpp
@@ -616,7 +616,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
         auto const& sequence = sequence_value.value();
 
-        if (sequence.to_uint().has_value()) {
+        if (sequence.to_number<unsigned>().has_value()) {
             modifier_buffer.append(sequence);
         } else {
             if (sequence == "" || sequence == "q" || sequence == "Q") {
@@ -624,28 +624,28 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             } else if (sequence == "j" || sequence == "\e[B" || sequence == "\n") {
                 if (!emulate_more) {
                     if (!modifier_buffer.is_empty())
-                        pager.down_n(modifier_buffer.to_byte_string().to_uint().value_or(1));
+                        pager.down_n(modifier_buffer.to_byte_string().to_number<unsigned>().value_or(1));
                     else
                         pager.down();
                 }
             } else if (sequence == "k" || sequence == "\e[A") {
                 if (!emulate_more) {
                     if (!modifier_buffer.is_empty())
-                        pager.up_n(modifier_buffer.to_byte_string().to_uint().value_or(1));
+                        pager.up_n(modifier_buffer.to_byte_string().to_number<unsigned>().value_or(1));
                     else
                         pager.up();
                 }
             } else if (sequence == "g") {
                 if (!emulate_more) {
                     if (!modifier_buffer.is_empty())
-                        pager.go_to_line(modifier_buffer.to_byte_string().to_uint().value());
+                        pager.go_to_line(modifier_buffer.to_byte_string().to_number<unsigned>().value());
                     else
                         pager.top();
                 }
             } else if (sequence == "G") {
                 if (!emulate_more) {
                     if (!modifier_buffer.is_empty())
-                        pager.go_to_line(modifier_buffer.to_byte_string().to_uint().value());
+                        pager.go_to_line(modifier_buffer.to_byte_string().to_number<unsigned>().value());
                     else
                         pager.bottom();
                 }

--- a/Userland/Utilities/lsof.cpp
+++ b/Userland/Utilities/lsof.cpp
@@ -136,7 +136,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     }
     {
         // try convert UID to int
-        auto arg = ByteString(arg_uid).to_int();
+        auto arg = ByteString(arg_uid).to_number<int>();
         if (arg.has_value())
             arg_uid_int = arg.value();
     }

--- a/Userland/Utilities/mknod.cpp
+++ b/Userland/Utilities/mknod.cpp
@@ -60,8 +60,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         return 1;
     }
 
-    auto maybe_major = major_string.to_int();
-    auto maybe_minor = minor_string.to_int();
+    auto maybe_major = major_string.to_number<int>();
+    auto maybe_minor = minor_string.to_number<int>();
     dev_t device;
     if (type == 'p') {
         if (maybe_major.has_value() || maybe_minor.has_value()) {

--- a/Userland/Utilities/pgrep.cpp
+++ b/Userland/Utilities/pgrep.cpp
@@ -48,7 +48,7 @@ ErrorOr<int> serenity_main(Main::Arguments args)
         .short_name = 'O',
         .value_name = "seconds",
         .accept_value = [&display_if_older_than](StringView seconds_string) {
-            auto number = seconds_string.to_uint<u64>();
+            auto number = seconds_string.to_number<u64>();
 
             if (number.has_value() && number.value() <= NumericLimits<i64>::max()) {
                 auto now_time = UnixDateTime::now();
@@ -66,7 +66,7 @@ ErrorOr<int> serenity_main(Main::Arguments args)
         .value_name = "uid-list",
         .accept_value = [&uids_to_filter_by](StringView comma_separated_users) {
             for (auto user_string : comma_separated_users.split_view(',')) {
-                auto maybe_uid = user_string.to_uint<uid_t>();
+                auto maybe_uid = user_string.to_number<uid_t>();
                 if (maybe_uid.has_value()) {
                     uids_to_filter_by.set(maybe_uid.value());
                 } else {

--- a/Userland/Utilities/pidof.cpp
+++ b/Userland/Utilities/pidof.cpp
@@ -71,7 +71,7 @@ ErrorOr<int> serenity_main(Main::Arguments args)
                 return true;
             }
 
-            auto number = omit_pid_value.to_uint();
+            auto number = omit_pid_value.template to_number<pid_t>();
             if (!number.has_value())
                 return false;
 

--- a/Userland/Utilities/ping.cpp
+++ b/Userland/Utilities/ping.cpp
@@ -76,7 +76,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             if (interval_in_seconds_string.is_empty())
                 return false;
 
-            auto interval_in_seconds = interval_in_seconds_string.to_double();
+            auto interval_in_seconds = interval_in_seconds_string.to_number<double>();
             if (!interval_in_seconds.has_value() || interval_in_seconds.value() <= 0 || interval_in_seconds.value() > UINT32_MAX)
                 return false;
 

--- a/Userland/Utilities/pixelflut.cpp
+++ b/Userland/Utilities/pixelflut.cpp
@@ -43,7 +43,7 @@ ErrorOr<NonnullRefPtr<Client>> Client::create(StringView image_path, StringView 
 {
     // Extract hostname and port and connect to server.
     auto parts = server.split_view(':');
-    auto maybe_port = parts.take_last().to_uint();
+    auto maybe_port = parts.take_last().to_number<unsigned>();
     if (!maybe_port.has_value())
         return Error::from_string_view("Invalid port number"sv);
 
@@ -60,8 +60,8 @@ ErrorOr<NonnullRefPtr<Client>> Client::create(StringView image_path, StringView 
         return Error::from_string_view("Server didn't return size correctly"sv);
 
     auto size_parts = size_line.split_view(' ');
-    auto maybe_width = size_parts[1].to_uint();
-    auto maybe_height = size_parts[2].to_uint();
+    auto maybe_width = size_parts[1].to_number<unsigned>();
+    auto maybe_height = size_parts[2].to_number<unsigned>();
     if (!maybe_width.has_value() || !maybe_height.has_value())
         return Error::from_string_view("Width or height invalid"sv);
 

--- a/Userland/Utilities/pkill.cpp
+++ b/Userland/Utilities/pkill.cpp
@@ -50,7 +50,7 @@ ErrorOr<int> serenity_main(Main::Arguments args)
         .short_name = 'O',
         .value_name = "seconds",
         .accept_value = [&display_if_older_than](StringView seconds_string) {
-            auto number = seconds_string.to_uint<u64>();
+            auto number = seconds_string.to_number<u64>();
 
             if (number.has_value() && number.value() <= NumericLimits<i64>::max()) {
                 auto now_time = UnixDateTime::now();
@@ -72,7 +72,7 @@ ErrorOr<int> serenity_main(Main::Arguments args)
 
             if (is_ascii_alpha(signal_string[0]))
                 signal = getsignalbyname(&signal_string[0]);
-            else if (auto maybe_signal = signal_string.to_int(); maybe_signal.has_value())
+            else if (auto maybe_signal = signal_string.to_number<int>(); maybe_signal.has_value())
                 signal = maybe_signal.value();
 
             if (signal <= 0 || signal >= NSIG)
@@ -89,7 +89,7 @@ ErrorOr<int> serenity_main(Main::Arguments args)
         .value_name = "uid-list",
         .accept_value = [&uids_to_filter_by](StringView comma_separated_users) {
             for (auto user_string : comma_separated_users.split_view(',')) {
-                auto maybe_uid = user_string.to_uint<uid_t>();
+                auto maybe_uid = user_string.to_number<uid_t>();
                 if (maybe_uid.has_value()) {
                     uids_to_filter_by.set(maybe_uid.value());
                 } else {

--- a/Userland/Utilities/pmemdump.cpp
+++ b/Userland/Utilities/pmemdump.cpp
@@ -22,10 +22,10 @@
 static bool try_set_offset_and_length_parameters(ByteString const& arg_offset, ByteString const& arg_length, u64& offset, u64& length)
 {
     // TODO: Add support for hex values
-    auto possible_offset = arg_offset.to_uint<u64>();
+    auto possible_offset = arg_offset.to_number<u64>();
     if (!possible_offset.has_value())
         return false;
-    auto possible_length = arg_length.to_uint<u64>();
+    auto possible_length = arg_length.to_number<u64>();
     if (!possible_length.has_value())
         return false;
     offset = possible_offset.value();

--- a/Userland/Utilities/profile.cpp
+++ b/Userland/Utilities/profile.cpp
@@ -130,5 +130,5 @@ static Optional<pid_t> determine_pid_to_profile(StringView pid_argument, bool al
     }
 
     // pid_argument is guaranteed to have a value
-    return pid_argument.to_int();
+    return pid_argument.to_number<pid_t>();
 }

--- a/Userland/Utilities/ps.cpp
+++ b/Userland/Utilities/ps.cpp
@@ -248,21 +248,21 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     }));
     args_parser.add_option(make_list_option(pid_list, "Show processes with a matching PID. (Comma- or space-separated list)", nullptr, 'p', "pid-list", [&](StringView pid_string) {
         provided_filtering_option = true;
-        auto pid = pid_string.to_int();
+        auto pid = pid_string.to_number<int>();
         if (!pid.has_value())
             warnln("Could not parse '{}' as a PID.", pid_string);
         return pid;
     }));
     args_parser.add_option(make_list_option(parent_pid_list, "Show processes with a matching PPID. (Comma- or space-separated list.)", "ppid", {}, "pid-list", [&](StringView pid_string) {
         provided_filtering_option = true;
-        auto pid = pid_string.to_int();
+        auto pid = pid_string.to_number<int>();
         if (!pid.has_value())
             warnln("Could not parse '{}' as a PID.", pid_string);
         return pid;
     }));
     args_parser.add_option(make_list_option(pid_list, "Show processes with a matching PID. (Comma- or space-separated list.) Processes will be listed in the order given.", nullptr, 'q', "pid-list", [&](StringView pid_string) {
         provided_quick_pid_list = true;
-        auto pid = pid_string.to_int();
+        auto pid = pid_string.to_number<int>();
         if (!pid.has_value())
             warnln("Could not parse '{}' as a PID.", pid_string);
         return pid;
@@ -278,7 +278,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     }));
     args_parser.add_option(make_list_option(uid_list, "Show processes with a matching user ID or login name. (Comma- or space-separated list.)", nullptr, 'u', "user-list", [&](StringView user_string) -> Optional<uid_t> {
         provided_filtering_option = true;
-        if (auto uid = user_string.to_uint<uid_t>(); uid.has_value()) {
+        if (auto uid = user_string.to_number<uid_t>(); uid.has_value()) {
             return uid.value();
         }
 

--- a/Userland/Utilities/route.cpp
+++ b/Userland/Utilities/route.cpp
@@ -182,7 +182,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         }
 
         Optional<IPv4Address> genmask;
-        if (auto cidr_int = cidr.to_int(); cidr_int.has_value())
+        if (auto cidr_int = cidr.to_number<int>(); cidr_int.has_value())
             genmask = AK::IPv4Address::netmask_from_cidr(cidr_int.value());
         else
             genmask = AK::IPv4Address::from_string(value_netmask_address);

--- a/Userland/Utilities/seq.cpp
+++ b/Userland/Utilities/seq.cpp
@@ -28,7 +28,7 @@ static void print_usage(FILE* stream)
 
 static double get_double(char const* name, StringView d_string, size_t* number_of_decimals)
 {
-    auto d = d_string.to_double();
+    auto d = d_string.to_number<double>();
     if (!d.has_value()) {
         warnln("{}: invalid argument \"{}\"", name, d_string);
         print_usage(stderr);

--- a/Userland/Utilities/sort.cpp
+++ b/Userland/Utilities/sort.cpp
@@ -82,7 +82,7 @@ static ErrorOr<void> load_file(Options const& options, StringView filename, Stri
             }
         }
 
-        Line l = { key, key.to_int().value_or(0), line, options.numeric };
+        Line l = { key, key.to_number<int>().value_or(0), line, options.numeric };
 
         if (!options.unique || !seen.contains(l)) {
             lines.append(l);

--- a/Userland/Utilities/stty.cpp
+++ b/Userland/Utilities/stty.cpp
@@ -298,14 +298,14 @@ Result<void, int> apply_modes(size_t parameter_count, char** raw_parameters, ter
         parameters.append(StringView { raw_parameters[i], strlen(raw_parameters[i]) });
 
     auto parse_baud = [&](size_t idx) -> Optional<speed_t> {
-        auto maybe_numeric_value = parameters[idx].to_uint<uint32_t>();
+        auto maybe_numeric_value = parameters[idx].to_number<uint32_t>();
         if (maybe_numeric_value.has_value())
             return numeric_value_to_speed(maybe_numeric_value.value());
         return {};
     };
 
     auto parse_number = [&](size_t idx) -> Optional<cc_t> {
-        return parameters[idx].to_uint<cc_t>();
+        return parameters[idx].to_number<cc_t>();
     };
 
     auto looks_like_stty_readable = [&](size_t idx) {
@@ -355,7 +355,7 @@ Result<void, int> apply_modes(size_t parameter_count, char** raw_parameters, ter
             }
             return value;
         } else if (is_ascii_digit(parameters[idx][0])) {
-            auto maybe_value = parameters[idx].to_uint<cc_t>();
+            auto maybe_value = parameters[idx].to_number<cc_t>();
             if (!maybe_value.has_value()) {
                 warnln("Invalid decimal character code {}", parameters[idx]);
                 return {};

--- a/Userland/Utilities/syscall.cpp
+++ b/Userland/Utilities/syscall.cpp
@@ -175,7 +175,7 @@ static FlatPtr parse_from(ArgIter& iter)
         return parse_parameter_buffer(iter);
 
     // Is it a number?
-    if (auto l = this_arg_string.to_uint(); l.has_value())
+    if (auto l = this_arg_string.to_number<unsigned>(); l.has_value())
         return *l;
 
     // Then it must be a string:

--- a/Userland/Utilities/test.cpp
+++ b/Userland/Utilities/test.cpp
@@ -306,8 +306,8 @@ public:
     NumericCompare(ByteString lhs, ByteString rhs, Mode mode)
         : m_mode(mode)
     {
-        auto lhs_option = lhs.trim_whitespace().to_int();
-        auto rhs_option = rhs.trim_whitespace().to_int();
+        auto lhs_option = lhs.trim_whitespace().to_number<int>();
+        auto rhs_option = rhs.trim_whitespace().to_number<int>();
 
         if (!lhs_option.has_value())
             fatal_error("expected integer expression: '%s'", lhs.characters());

--- a/Userland/Utilities/top.cpp
+++ b/Userland/Utilities/top.cpp
@@ -179,7 +179,7 @@ static void parse_args(Main::Arguments arguments, TopOption& top_option)
         .short_name = 'p',
         .accept_value = [&pids](auto comma_separated_pids) {
             for (auto pid : comma_separated_pids.split_view(',')) {
-                auto maybe_integer = pid.to_int();
+                auto maybe_integer = pid.template to_number<pid_t>();
                 if (!maybe_integer.has_value())
                     return false;
 

--- a/Userland/Utilities/touch.cpp
+++ b/Userland/Utilities/touch.cpp
@@ -54,7 +54,7 @@ static void parse_time(StringView input_time, timespec& atime, timespec& mtime)
         auto literal = lexer.consume(2);
         if (literal.length() < 2)
             err("invalid time format '{}' -- expected 2 digits per parameter", input_time);
-        auto maybe_parameter = literal.to_uint();
+        auto maybe_parameter = literal.to_number<unsigned>();
         if (maybe_parameter.has_value())
             parameters.append(maybe_parameter.value());
         else
@@ -102,7 +102,7 @@ static void parse_datetime(StringView input_datetime, timespec& atime, timespec&
     StringView time_zone;
 
     auto lex_number = [&](unsigned& value, size_t n) {
-        auto maybe_value = lexer.consume(n).to_uint();
+        auto maybe_value = lexer.consume(n).to_number<unsigned>();
         if (!maybe_value.has_value())
             err("invalid datetime format '{}' -- expected number at index {}", input_datetime, lexer.tell());
         else

--- a/Userland/Utilities/truncate.cpp
+++ b/Userland/Utilities/truncate.cpp
@@ -76,7 +76,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             }
         }
 
-        auto size_opt = resize.to_int<off_t>();
+        auto size_opt = resize.to_number<off_t>();
         if (!size_opt.has_value() || Checked<off_t>::multiplication_would_overflow(size_opt.value(), multiplier)) {
             args_parser.print_usage(stderr, arguments.strings[0]);
             return 1;

--- a/Userland/Utilities/useradd.cpp
+++ b/Userland/Utilities/useradd.cpp
@@ -31,7 +31,7 @@ constexpr auto DEFAULT_SHELL = "/bin/sh"sv;
 
 static Optional<gid_t> group_string_to_gid(StringView group)
 {
-    auto maybe_gid = group.to_uint<gid_t>();
+    auto maybe_gid = group.to_number<gid_t>();
     auto maybe_group_or_error = maybe_gid.has_value()
         ? Core::System::getgrgid(maybe_gid.value())
         : Core::System::getgrnam(group);

--- a/Userland/Utilities/usermod.cpp
+++ b/Userland/Utilities/usermod.cpp
@@ -17,7 +17,7 @@
 
 static Optional<gid_t> group_string_to_gid(StringView group)
 {
-    auto maybe_gid = group.to_uint<gid_t>();
+    auto maybe_gid = group.to_number<gid_t>();
     auto maybe_group_or_error = maybe_gid.has_value()
         ? Core::System::getgrgid(maybe_gid.value())
         : Core::System::getgrnam(group);

--- a/Userland/Utilities/wasm.cpp
+++ b/Userland/Utilities/wasm.cpp
@@ -122,7 +122,7 @@ static bool pre_interpret_hook(Wasm::Configuration& config, Wasm::InstructionPoi
                     warnln("print what memory?");
                     continue;
                 }
-                auto value = args[2].to_uint<u64>();
+                auto value = args[2].to_number<u64>();
                 if (!value.has_value()) {
                     warnln("invalid memory index {}", args[2]);
                     continue;
@@ -144,7 +144,7 @@ static bool pre_interpret_hook(Wasm::Configuration& config, Wasm::InstructionPoi
                     warnln("print what function?");
                     continue;
                 }
-                auto value = args[2].to_uint<u64>();
+                auto value = args[2].to_number<u64>();
                 if (!value.has_value()) {
                     warnln("invalid function index {}", args[2]);
                     continue;
@@ -170,7 +170,7 @@ static bool pre_interpret_hook(Wasm::Configuration& config, Wasm::InstructionPoi
                 continue;
             }
             Optional<Wasm::FunctionAddress> address;
-            auto index = args[1].to_uint<u64>();
+            auto index = args[1].to_number<u64>();
             if (index.has_value()) {
                 address = config.frame().module().functions()[index.value()];
             } else {
@@ -203,7 +203,7 @@ static bool pre_interpret_hook(Wasm::Configuration& config, Wasm::InstructionPoi
             Vector<u64> values_to_push;
             Vector<Wasm::Value> values;
             for (size_t index = 2; index < args.size(); ++index)
-                values_to_push.append(args[index].to_uint().value_or(0));
+                values_to_push.append(args[index].to_number<u64>().value_or(0));
             for (auto& param : type.parameters())
                 values.append(Wasm::Value { param, values_to_push.take_last() });
 
@@ -332,7 +332,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         .short_name = 0,
         .value_name = "u64",
         .accept_value = [&](StringView str) -> bool {
-            if (auto v = str.to_uint<u64>(); v.has_value()) {
+            if (auto v = str.to_number<u64>(); v.has_value()) {
                 values_to_push.append(v.value());
                 return true;
             }


### PR DESCRIPTION
I noticed that `AK::String` has `to_number<T>`, which is different to the other String classes, which provide various `to_{uint,int,float,double}` functions.

It seems like a good thing to have the same number conversion API for all of our String classes, so this MR does that. Since `to_number<T>` is more generic than the  `to_{uint,int,float,double}` method, this also has the benefit of resulting in over 100 lines less code.