### PR TITLE
LibWeb: Use UTF-16 code unit offsets and lengths in CharacterData

### DIFF
--- a/Tests/LibWeb/Text/expected/DOM/Text-methods.txt
+++ b/Tests/LibWeb/Text/expected/DOM/Text-methods.txt
@@ -1,0 +1,6 @@
+text.data = '🙃', length = 2
+text.data = '🙃🙃', length = 4
+text.data = '🙃hi🙃🙃', length = 8
+text.data = '🙃i🙃🙃', length = 7
+text.data = '🙃replaced!', length = 11
+repla

--- a/Tests/LibWeb/Text/input/DOM/Text-methods.html
+++ b/Tests/LibWeb/Text/input/DOM/Text-methods.html
@@ -1,0 +1,20 @@
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        function dumpText(text) {
+            println(`text.data = '${text.data}', length = ${text.length}`);
+        }
+
+        let text = new Text('🙃');
+        dumpText(text);
+        text.appendData('🙃')
+        dumpText(text);
+        text.insertData(2, 'hi🙃')
+        dumpText(text);
+        text.deleteData(2, 1)
+        dumpText(text);
+        text.replaceData(2, 5, 'replaced!')
+        dumpText(text);
+        println(text.substringData(2, 5))
+    });
+</script>

--- a/Userland/Libraries/LibWeb/DOM/CharacterData.h
+++ b/Userland/Libraries/LibWeb/DOM/CharacterData.h
@@ -13,6 +13,7 @@
 
 namespace Web::DOM {
 
+// https://dom.spec.whatwg.org/#characterdata
 class CharacterData
     : public Node
     , public ChildNode<CharacterData>
@@ -26,14 +27,18 @@ public:
     String const& data() const { return m_data; }
     void set_data(String const&);
 
-    // FIXME: This should be in UTF-16 code units, not byte size.
-    unsigned length() const { return m_data.bytes().size(); }
+    unsigned length_in_utf16_code_units() const
+    {
+        // FIXME: This is inefficient!
+        auto utf16_data = MUST(AK::utf8_to_utf16(m_data));
+        return Utf16View { utf16_data }.length_in_code_units();
+    }
 
-    WebIDL::ExceptionOr<String> substring_data(size_t offset, size_t count) const;
+    WebIDL::ExceptionOr<String> substring_data(size_t offset_in_utf16_code_units, size_t count_in_utf16_code_units) const;
     WebIDL::ExceptionOr<void> append_data(String const&);
-    WebIDL::ExceptionOr<void> insert_data(size_t offset, String const&);
-    WebIDL::ExceptionOr<void> delete_data(size_t offset, size_t count);
-    WebIDL::ExceptionOr<void> replace_data(size_t offset, size_t count, String const&);
+    WebIDL::ExceptionOr<void> insert_data(size_t offset_in_utf16_code_units, String const&);
+    WebIDL::ExceptionOr<void> delete_data(size_t offset_in_utf16_code_units, size_t count_in_utf16_code_units);
+    WebIDL::ExceptionOr<void> replace_data(size_t offset_in_utf16_code_units, size_t count_in_utf16_code_units, String const&);
 
 protected:
     CharacterData(Document&, NodeType, String const&);

--- a/Userland/Libraries/LibWeb/DOM/CharacterData.idl
+++ b/Userland/Libraries/LibWeb/DOM/CharacterData.idl
@@ -6,7 +6,7 @@
 [Exposed=Window]
 interface CharacterData : Node {
     [LegacyNullToEmptyString] attribute DOMString data;
-    readonly attribute unsigned long length;
+    [ImplementedAs=length_in_utf16_code_units] readonly attribute unsigned long length;
 
     DOMString substringData(unsigned long offset, unsigned long count);
     undefined appendData(DOMString data);

--- a/Userland/Libraries/LibWeb/DOM/Node.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Node.cpp
@@ -1492,11 +1492,8 @@ size_t Node::length() const
         return 0;
 
     // 2. If node is a CharacterData node, then return node’s data’s length.
-    if (is_character_data()) {
-        auto* character_data_node = verify_cast<CharacterData>(this);
-        // FIXME: This should be in UTF-16 code units, not byte size.
-        return character_data_node->data().bytes().size();
-    }
+    if (is_character_data())
+        return verify_cast<CharacterData>(*this).length_in_utf16_code_units();
 
     // 3. Return the number of node’s children.
     return child_count();


### PR DESCRIPTION
We were previously assuming that the input offsets and lengths were all in raw byte offsets into a UTF-8 string. While internally our String representation may be in UTF-8 from the external world it is seen as UTF-16, with code unit offsets passed through, and used as the returned length.

Beforehand, the insert-delete test included in this commit would crash ladybird, and `new Text('🙃').length` would return `4` instead of `2`.

The implementation here is very inefficient, I am sure there is a much smarter way to write it so that we would not need a conversion from UTF-8 to a UTF-16 string (and then back again).

Fixes: #20971