### PR TITLE
LibTimeZone: Update to TZDB version 2023d

### DIFF
--- a/Meta/CMake/time_zone_data.cmake
+++ b/Meta/CMake/time_zone_data.cmake
@@ -2,7 +2,7 @@ include(${CMAKE_CURRENT_LIST_DIR}/utils.cmake)
 
 set(TZDB_PATH "${SERENITY_CACHE_DIR}/TZDB" CACHE PATH "Download location for TZDB files")
 
-set(TZDB_VERSION 2023c)
+set(TZDB_VERSION 2023d)
 set(TZDB_VERSION_FILE "${TZDB_PATH}/version.txt")
 
 set(TZDB_ZIP_URL "https://data.iana.org/time-zones/releases/tzdata${TZDB_VERSION}.tar.gz")

--- a/Meta/gn/secondary/Userland/Libraries/LibTimeZone/BUILD.gn
+++ b/Meta/gn/secondary/Userland/Libraries/LibTimeZone/BUILD.gn
@@ -13,7 +13,7 @@ tzdb_cache = cache_path + "TZDB/"
 
 if (enable_timezone_database_download) {
   download_file("timezone_database_download") {
-    version = "2023c"
+    version = "2023d"
     url =
         "https://data.iana.org/time-zones/releases/tzdata" + version + ".tar.gz"
     cache = tzdb_cache


### PR DESCRIPTION
https://mm.icann.org/pipermail/tz-announce/2023-December/000080.html