### PR TITLE
CI: Lower the timeout for Lagom tests to 1 hour

### DIFF
--- a/Meta/Azure/Lagom.yml
+++ b/Meta/Azure/Lagom.yml
@@ -152,6 +152,7 @@ jobs:
           ninja test
         displayName: 'Test'
         workingDirectory: $(Build.SourcesDirectory)/Meta/Lagom/Build
+        timeoutInMinutes: 60
         env:
           SERENITY_SOURCE_DIR: '$(Build.SourcesDirectory)'
           CTEST_OUTPUT_ON_FAILURE: 1


### PR DESCRIPTION
We set the job-level timeout to 0, which means "max value" (6 hours). In the Serenity build, we do the same, but then limit the Test step to just 1 hour to prevent hung tests from hogging CI resources. When a job-level timeout was added to Lagom, the Test step timeout was forgotten.