### PR TITLE
LibGfx/TIFF: Ensure baseline tags presence before decoding

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/TIFFLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/TIFFLoader.cpp
@@ -41,6 +41,7 @@ public:
 
     ErrorOr<void> decode_frame()
     {
+        TRY(ensure_baseline_tags_presence(m_metadata));
         auto maybe_error = decode_frame_impl();
 
         if (maybe_error.is_error()) {


### PR DESCRIPTION
This allows us to reject invalid images before trying to decode them. The spec requires more tag to be present[1] but as we don't use them for decoding I don't see the point.

[1] - XResolution, YResolution and ResolutionUnit

---

Solves oss-fuzz issue [64143](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=64143)