### PR TITLE
LibWeb: Ignore "display: contents" boxes while inserting inline nodes

### DIFF
--- a/Tests/LibWeb/Layout/expected/display-contents-with-in-children.txt
+++ b/Tests/LibWeb/Layout/expected/display-contents-with-in-children.txt
@@ -1,0 +1,12 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x17.46875 [BFC] children: inline
+    line 0 width: 51.75, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+      frag 0 from TextNode start: 0, length: 7, rect: [0,0 51.75x17.46875]
+        "whf :^)"
+    InlineNode <span>
+      TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x17.46875]
+    InlinePaintable (InlineNode<SPAN>)
+      TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/input/display-contents-with-in-children.html
+++ b/Tests/LibWeb/Layout/input/display-contents-with-in-children.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html><style> body { display: contents; }
+</style><body><span>whf :^)</span></body>

--- a/Userland/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -148,8 +148,15 @@ void TreeBuilder::insert_node_into_inline_or_block_ancestor(Layout::Node& node, 
         return;
 
     if (display.is_inline_outside()) {
-        // Inlines can be inserted into the nearest ancestor.
-        auto& insertion_point = insertion_parent_for_inline_node(m_ancestor_stack.last());
+        // Inlines can be inserted into the nearest ancestor without "display: contents".
+        auto& nearest_ancestor_without_display_contents = [&]() -> Layout::NodeWithStyle& {
+            for (auto& ancestor : m_ancestor_stack.in_reverse()) {
+                if (!ancestor->display().is_contents())
+                    return ancestor;
+            }
+            VERIFY_NOT_REACHED();
+        }();
+        auto& insertion_point = insertion_parent_for_inline_node(nearest_ancestor_without_display_contents);
         if (mode == AppendOrPrepend::Prepend)
             insertion_point.prepend_child(node);
         else


### PR DESCRIPTION
With this change "display: contents" ancestors are not considered as insertion point for inline nodes similar to how we already ignore them for non-inline nodes.

Fixes https://github.com/SerenityOS/serenity/issues/22396