### PR TITLE
LibWeb/CSS: Fix stack use after scope in matches_attribute()

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
+++ b/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
@@ -151,7 +151,8 @@ static inline bool matches_attribute(CSS::Selector::SimpleSelector::Attribute co
             // This selector is always false is match value is empty.
             return false;
         }
-        auto const view = element.attribute(attribute_name).value_or({}).bytes_as_string_view().split_view(' ');
+        auto attribute_value = element.attribute(attribute_name).value_or({});
+        auto const view = attribute_value.bytes_as_string_view().split_view(' ');
         auto const size = view.size();
         for (size_t i = 0; i < size; ++i) {
             auto const value = view.at(i);


### PR DESCRIPTION
If a short string is used for the attribute value, then the result of:
```cpp
auto const view = element.attribute(attribute_name).value_or({})
    .bytes_as_string_view().split_view(' ');
```
is an array of string views pointing into a temporarily allocated string.

With this change we keep string on stack until the end of scope.

Page that allows to reproduce the problem.
```html
<!DOCTYPE html><style>
    div[data-info~="a"] {
        background-color: yellow;
    }
</style><div data-info="a">a</div>
```