### PR TITLE
Calculator: Finish operation-in-progress only on new binary operations

### DIFF
--- a/Userland/Applications/Calculator/Calculator.cpp
+++ b/Userland/Applications/Calculator/Calculator.cpp
@@ -18,12 +18,6 @@ Optional<Crypto::BigFraction> Calculator::operation_with_literal_argument(Operat
         operation = Operation::None; // Don't apply the "%" operation twice
     }
 
-    // If a previous operation is still in progress, finish it
-    // Makes hitting "1+2+3=" equivalent to hitting "1+2=+3="
-    if (m_binary_operation_in_progress != Operation::None) {
-        argument = finish_binary_operation(m_binary_operation_saved_left_side, m_binary_operation_in_progress, argument);
-    }
-
     switch (operation) {
     case Operation::None:
         m_current_value = argument;
@@ -33,6 +27,11 @@ Optional<Crypto::BigFraction> Calculator::operation_with_literal_argument(Operat
     case Operation::Subtract:
     case Operation::Multiply:
     case Operation::Divide:
+        // If a previous operation is still in progress, finish it
+        // Makes hitting "1+2+3=" equivalent to hitting "1+2=+3="
+        if (m_binary_operation_in_progress != Operation::None) {
+            argument = finish_binary_operation(m_binary_operation_saved_left_side, m_binary_operation_in_progress, argument);
+        }
         m_binary_operation_saved_left_side = argument;
         m_binary_operation_in_progress = operation;
         m_current_value = argument;
@@ -45,7 +44,6 @@ Optional<Crypto::BigFraction> Calculator::operation_with_literal_argument(Operat
             break;
         }
         m_current_value = argument.sqrt();
-        clear_operation();
         break;
     case Operation::Inverse:
         if (argument == Crypto::BigFraction {}) {
@@ -54,7 +52,6 @@ Optional<Crypto::BigFraction> Calculator::operation_with_literal_argument(Operat
             break;
         }
         m_current_value = argument.invert();
-        clear_operation();
         break;
     case Operation::Percent:
         m_current_value = argument * Crypto::BigFraction { 1, 100 };
@@ -79,6 +76,9 @@ Optional<Crypto::BigFraction> Calculator::operation_with_literal_argument(Operat
         m_current_value = m_mem;
         break;
     case Operation::Equals:
+        if (m_binary_operation_in_progress != Operation::None) {
+            argument = finish_binary_operation(m_binary_operation_saved_left_side, m_binary_operation_in_progress, argument);
+        }
         m_current_value = argument;
         break;
     }


### PR DESCRIPTION
```
Calculator: Finish operation-in-progress only on new binary operations

Because of this the unary operations got applied to the result of the
operation-in-progress instead of the current argument as shown here:

    `16 + 9 <sqrt> =`
        Previous output: `sqrt(16 + 9)` = `5`
        Expected output: `16 + sqrt(9)` = `19`
```

this also fixes the following bug i found which i didn't mention in the commit message:

- do `5 * 5 = <MS>`
- then `100 - <MR> =` (output: `-75` instead of `75`)

---

should i open issues for bugs even if i have a fix for it ready?
