### PR TITLE
Kernel: Shrink instead of expand sigaltstack range to page boundaries 

### DIFF
--- a/Kernel/Memory/MemoryManager.h
+++ b/Kernel/Memory/MemoryManager.h
@@ -321,4 +321,18 @@ inline ErrorOr<Memory::VirtualRange> expand_range_to_page_boundaries(FlatPtr add
     return Memory::VirtualRange { base, end - base.get() };
 }
 
+inline ErrorOr<Memory::VirtualRange> shrink_range_to_page_boundaries(FlatPtr address, size_t size)
+{
+    if ((address + size) < address)
+        return EINVAL;
+
+    auto base = TRY(Memory::page_round_up(address));
+    auto end = Memory::page_round_down(address + size);
+
+    if (end < base)
+        return EINVAL;
+
+    return Memory::VirtualRange { VirtualAddress(base), end - base };
+}
+
 }

--- a/Kernel/Syscalls/fork.cpp
+++ b/Kernel/Syscalls/fork.cpp
@@ -117,7 +117,6 @@ ErrorOr<FlatPtr> Process::sys$fork(RegisterState& regs)
 
     // A child process created via fork(2) inherits a copy of its parent's alternate signal stack settings.
     child_first_thread->m_alternative_signal_stack = Thread::current()->m_alternative_signal_stack;
-    child_first_thread->m_alternative_signal_stack_size = Thread::current()->m_alternative_signal_stack_size;
 
     auto& child_regs = child_first_thread->m_regs;
 #if ARCH(X86_64)

--- a/Kernel/Tasks/Process.h
+++ b/Kernel/Tasks/Process.h
@@ -688,7 +688,7 @@ private:
 
     ErrorOr<GlobalFutexKey> get_futex_key(FlatPtr user_address, bool shared);
 
-    ErrorOr<void> remap_range_as_stack(FlatPtr address, size_t size);
+    ErrorOr<Memory::VirtualRange> remap_range_as_stack(FlatPtr address, size_t size);
 
     ErrorOr<FlatPtr> open_impl(Userspace<Syscall::SC_open_params const*>);
     ErrorOr<FlatPtr> close_impl(int fd);

--- a/Kernel/Tasks/Thread.h
+++ b/Kernel/Tasks/Thread.h
@@ -884,7 +884,6 @@ public:
     u32 pending_signals() const;
     u32 pending_signals_for_state() const;
 
-    [[nodiscard]] bool has_alternative_signal_stack() const;
     [[nodiscard]] bool is_in_alternative_signal_stack() const;
 
     FPUState& fpu_state() { return m_fpu_state; }
@@ -1177,8 +1176,7 @@ private:
     u32 m_pending_signals { 0 };
     u8 m_currently_handled_signal { 0 };
     u32 m_signal_mask { 0 };
-    FlatPtr m_alternative_signal_stack { 0 };
-    FlatPtr m_alternative_signal_stack_size { 0 };
+    Optional<Memory::VirtualRange> m_alternative_signal_stack;
     SignalBlockerSet m_signal_blocker_set;
     FlatPtr m_kernel_stack_base { 0 };
     FlatPtr m_kernel_stack_top { 0 };


### PR DESCRIPTION
Since the POSIX sigaltstack manpage suggests allocating the stack region using malloc(), and many heap implementations (including ours) store heap chunk metadata in memory just before the vended pointer, we would end up zeroing the metadata, leading to various crashes.