### PR TITLE
LibLine: Use the correct loop conditions for erase_character_forwards()

### DIFF
--- a/Userland/Libraries/LibLine/InternalFunctions.cpp
+++ b/Userland/Libraries/LibLine/InternalFunctions.cpp
@@ -168,7 +168,7 @@ void Editor::erase_character_forwards()
     auto end_of_next_grapheme = closest_cursor_left_offset + 1 >= m_cached_buffer_metrics.grapheme_breaks.size()
         ? m_buffer.size()
         : m_cached_buffer_metrics.grapheme_breaks[closest_cursor_left_offset + 1];
-    for (; m_cursor < end_of_next_grapheme;)
+    for (auto cursor = m_cursor; cursor < end_of_next_grapheme; ++cursor)
         remove_at_index(m_cursor);
     m_refresh_needed = true;
 }


### PR DESCRIPTION
Prior to this commit, the loop would continue forever and try to remove the same index every time, eventually hitting a VERIFY and crashing.