### PR TITLE
LibWeb: Limit scroll position by overflow area in Window::scroll()

### DIFF
--- a/Tests/LibWeb/Text/expected/window-scrollTo.txt
+++ b/Tests/LibWeb/Text/expected/window-scrollTo.txt
@@ -1,0 +1,1 @@
+  The page has been scrolled to y: 1616

--- a/Tests/LibWeb/Text/input/window-scrollTo.html
+++ b/Tests/LibWeb/Text/input/window-scrollTo.html
@@ -1,0 +1,28 @@
+<style>
+    div {
+        width: 1000px;
+        height: 1000px;
+        border: 50px solid magenta;
+    }
+
+    #a {
+        background-color: yellow;
+    }
+
+    #b {
+        background-color: blue;
+    }
+</style>
+<script src="include.js"></script>
+<script>
+    asyncTest(done => {
+        document.addEventListener("scroll", (event) => {
+            println("The page has been scrolled to y: " + window.scrollY);
+            done();
+        });
+
+        window.scrollTo(0, 2000);
+    });
+</script>
+<div id="a"></div>
+<div id="b"></div>


### PR DESCRIPTION
This change fixes "vertical shift" in inspector.