### PR TITLE
LibWeb: Make cookie consent banner on Twinings interactive way sooner

### DIFF
--- a/Userland/Libraries/LibWeb/Bindings/LegacyPlatformObject.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/LegacyPlatformObject.cpp
@@ -126,7 +126,7 @@ WebIDL::ExceptionOr<void> LegacyPlatformObject::invoke_indexed_property_setter(J
 WebIDL::ExceptionOr<void> LegacyPlatformObject::invoke_named_property_setter(String const& property_name, JS::Value value)
 {
     // 1. Let creating be true if P is not a supported property name, and false otherwise.
-    Vector<String> supported_property_names = this->supported_property_names();
+    auto supported_property_names = this->supported_property_names();
     bool creating = !supported_property_names.contains_slow(property_name);
 
     // FIXME: We do not have this information at this point, so converting the value is left as an exercise to the inheritor of LegacyPlatformObject.
@@ -219,8 +219,8 @@ JS::ThrowCompletionOr<bool> LegacyPlatformObject::internal_define_own_property(J
 
         // 1. Let creating be true if P is not a supported property name, and false otherwise.
         // NOTE: This is in it's own variable to enforce the type.
-        Vector<String> supported_property_names = this->supported_property_names();
-        bool creating = !supported_property_names.contains_slow(MUST(String::from_byte_string(property_name_as_string)));
+        auto supported_property_names = this->supported_property_names();
+        bool creating = !supported_property_names.contains_slow(MUST(FlyString::from_deprecated_fly_string(property_name_as_string)));
 
         // 2. If O implements an interface with the [LegacyOverrideBuiltIns] extended attribute or O does not have an own property named P, then:
         // NOTE: Own property lookup has to be done manually instead of using Object::has_own_property, as that would use the overridden internal_get_own_property.
@@ -348,7 +348,7 @@ JS::ThrowCompletionOr<JS::MarkedVector<JS::Value>> LegacyPlatformObject::interna
     // 3. If O supports named properties, then for each P of O’s supported property names that is visible according to the named property visibility algorithm, append P to keys.
     if (supports_named_properties()) {
         for (auto& named_property : supported_property_names()) {
-            if (TRY(WebIDL::is_named_property_exposed_on_object({ this }, named_property.to_byte_string())))
+            if (TRY(WebIDL::is_named_property_exposed_on_object({ this }, named_property.to_deprecated_fly_string())))
                 keys.append(JS::PrimitiveString::create(vm, named_property));
         }
     }
@@ -381,7 +381,7 @@ WebIDL::ExceptionOr<JS::Value> LegacyPlatformObject::named_item_value(FlyString 
     return JS::js_undefined();
 }
 
-Vector<String> LegacyPlatformObject::supported_property_names() const
+Vector<FlyString> LegacyPlatformObject::supported_property_names() const
 {
     return {};
 }

--- a/Userland/Libraries/LibWeb/Bindings/LegacyPlatformObject.h
+++ b/Userland/Libraries/LibWeb/Bindings/LegacyPlatformObject.h
@@ -37,7 +37,7 @@ public:
 
     virtual WebIDL::ExceptionOr<JS::Value> item_value(size_t index) const;
     virtual WebIDL::ExceptionOr<JS::Value> named_item_value(FlyString const& name) const;
-    virtual Vector<String> supported_property_names() const;
+    virtual Vector<FlyString> supported_property_names() const;
     virtual bool is_supported_property_index(u32) const;
 
     // NOTE: These will crash if you make has_named_property_setter return true but do not override these methods.

--- a/Userland/Libraries/LibWeb/DOM/HTMLCollection.cpp
+++ b/Userland/Libraries/LibWeb/DOM/HTMLCollection.cpp
@@ -99,10 +99,10 @@ Element* HTMLCollection::named_item(FlyString const& name_) const
 }
 
 // https://dom.spec.whatwg.org/#ref-for-dfn-supported-property-names
-Vector<String> HTMLCollection::supported_property_names() const
+Vector<FlyString> HTMLCollection::supported_property_names() const
 {
     // 1. Let result be an empty list.
-    Vector<String> result;
+    Vector<FlyString> result;
 
     // 2. For each element represented by the collection, in tree order:
     auto elements = collect_matching_elements();
@@ -119,7 +119,7 @@ Vector<String> HTMLCollection::supported_property_names() const
             if (auto maybe_name = element->attribute(HTML::AttributeNames::name); maybe_name.has_value()) {
                 auto name = maybe_name.release_value();
                 if (!name.is_empty() && !result.contains_slow(name))
-                    result.append(move(name));
+                    result.append(name);
             }
         }
     }

--- a/Userland/Libraries/LibWeb/DOM/HTMLCollection.cpp
+++ b/Userland/Libraries/LibWeb/DOM/HTMLCollection.cpp
@@ -89,7 +89,7 @@ Element* HTMLCollection::named_item(FlyString const& name_) const
     auto elements = collect_matching_elements();
     // 2. Return the first element in the collection for which at least one of the following is true:
     //      - it has an ID which is key;
-    if (auto it = elements.find_if([&](auto& entry) { return entry->deprecated_attribute(HTML::AttributeNames::id) == name; }); it != elements.end())
+    if (auto it = elements.find_if([&](auto& entry) { return entry->id().has_value() && entry->id().value() == name_; }); it != elements.end())
         return *it;
     //      - it is in the HTML namespace and has a name attribute whose value is key;
     if (auto it = elements.find_if([&](auto& entry) { return entry->namespace_uri() == Namespace::HTML && entry->name() == name; }); it != elements.end())
@@ -109,9 +109,9 @@ Vector<FlyString> HTMLCollection::supported_property_names() const
 
     for (auto& element : elements) {
         // 1. If element has an ID which is not in result, append element’s ID to result.
-        if (auto maybe_id = element->attribute(HTML::AttributeNames::id); maybe_id.has_value()) {
-            if (!result.contains_slow(maybe_id.value()))
-                result.append(maybe_id.release_value());
+        if (auto const& id = element->id(); id.has_value()) {
+            if (!result.contains_slow(id.value()))
+                result.append(id.value());
         }
 
         // 2. If element is in the HTML namespace and has a name attribute whose value is neither the empty string nor is in result, append element’s name attribute value to result.

--- a/Userland/Libraries/LibWeb/DOM/HTMLCollection.h
+++ b/Userland/Libraries/LibWeb/DOM/HTMLCollection.h
@@ -46,7 +46,7 @@ public:
 
     virtual WebIDL::ExceptionOr<JS::Value> item_value(size_t index) const override;
     virtual WebIDL::ExceptionOr<JS::Value> named_item_value(FlyString const& name) const override;
-    virtual Vector<String> supported_property_names() const override;
+    virtual Vector<FlyString> supported_property_names() const override;
     virtual bool is_supported_property_index(u32) const override;
 
 protected:

--- a/Userland/Libraries/LibWeb/DOM/NamedNodeMap.cpp
+++ b/Userland/Libraries/LibWeb/DOM/NamedNodeMap.cpp
@@ -49,10 +49,10 @@ bool NamedNodeMap::is_supported_property_index(u32 index) const
 }
 
 // https://dom.spec.whatwg.org/#ref-for-dfn-supported-property-names%E2%91%A0
-Vector<String> NamedNodeMap::supported_property_names() const
+Vector<FlyString> NamedNodeMap::supported_property_names() const
 {
     // 1. Let names be the qualified names of the attributes in this NamedNodeMap object’s attribute list, with duplicates omitted, in order.
-    Vector<String> names;
+    Vector<FlyString> names;
     names.ensure_capacity(m_attributes.size());
 
     for (auto const& attribute : m_attributes) {

--- a/Userland/Libraries/LibWeb/DOM/NamedNodeMap.h
+++ b/Userland/Libraries/LibWeb/DOM/NamedNodeMap.h
@@ -26,7 +26,7 @@ public:
     ~NamedNodeMap() = default;
 
     virtual bool is_supported_property_index(u32 index) const override;
-    virtual Vector<String> supported_property_names() const override;
+    virtual Vector<FlyString> supported_property_names() const override;
     virtual WebIDL::ExceptionOr<JS::Value> item_value(size_t index) const override;
     virtual WebIDL::ExceptionOr<JS::Value> named_item_value(FlyString const& name) const override;
 

--- a/Userland/Libraries/LibWeb/DOM/Node.h
+++ b/Userland/Libraries/LibWeb/DOM/Node.h
@@ -103,6 +103,10 @@ public:
     virtual bool is_html_br_element() const { return false; }
     virtual bool is_html_button_element() const { return false; }
     virtual bool is_html_slot_element() const { return false; }
+    virtual bool is_html_embed_element() const { return false; }
+    virtual bool is_html_object_element() const { return false; }
+    virtual bool is_html_form_element() const { return false; }
+    virtual bool is_html_image_element() const { return false; }
     virtual bool is_navigable_container() const { return false; }
     virtual bool is_lazy_loading() const { return false; }
 

--- a/Userland/Libraries/LibWeb/HTML/DOMStringMap.cpp
+++ b/Userland/Libraries/LibWeb/HTML/DOMStringMap.cpp
@@ -91,13 +91,13 @@ Vector<DOMStringMap::NameValuePair> DOMStringMap::get_name_value_pairs() const
 
 // https://html.spec.whatwg.org/multipage/dom.html#concept-domstringmap-pairs
 // NOTE: There isn't a direct link to this, so the link is to one of the algorithms above it.
-Vector<String> DOMStringMap::supported_property_names() const
+Vector<FlyString> DOMStringMap::supported_property_names() const
 {
     // The supported property names on a DOMStringMap object at any instant are the names of each pair returned from getting the DOMStringMap's name-value pairs at that instant, in the order returned.
-    Vector<String> names;
+    Vector<FlyString> names;
     auto name_value_pairs = get_name_value_pairs();
     for (auto& name_value_pair : name_value_pairs) {
-        names.append(name_value_pair.name.to_string());
+        names.append(name_value_pair.name);
     }
     return names;
 }

--- a/Userland/Libraries/LibWeb/HTML/DOMStringMap.h
+++ b/Userland/Libraries/LibWeb/HTML/DOMStringMap.h
@@ -37,7 +37,7 @@ private:
 
     // ^LegacyPlatformObject
     virtual WebIDL::ExceptionOr<JS::Value> named_item_value(FlyString const&) const override;
-    virtual Vector<String> supported_property_names() const override;
+    virtual Vector<FlyString> supported_property_names() const override;
 
     virtual bool supports_indexed_properties() const override { return false; }
     virtual bool supports_named_properties() const override { return true; }

--- a/Userland/Libraries/LibWeb/HTML/HTMLEmbedElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLEmbedElement.h
@@ -20,7 +20,13 @@ public:
 private:
     HTMLEmbedElement(DOM::Document&, DOM::QualifiedName);
 
+    virtual bool is_html_embed_element() const override { return true; }
     virtual void initialize(JS::Realm&) override;
 };
 
+}
+
+namespace Web::DOM {
+template<>
+inline bool Node::fast_is<HTML::HTMLEmbedElement>() const { return is_html_embed_element(); }
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLFormElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFormElement.h
@@ -90,6 +90,8 @@ public:
 private:
     HTMLFormElement(DOM::Document&, DOM::QualifiedName);
 
+    virtual bool is_html_form_element() const override { return true; }
+
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
 
@@ -121,4 +123,9 @@ private:
     Task const* m_planned_navigation { nullptr };
 };
 
+}
+
+namespace Web::DOM {
+template<>
+inline bool Node::fast_is<HTML::HTMLFormElement>() const { return is_html_form_element(); }
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLImageElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLImageElement.h
@@ -96,6 +96,8 @@ public:
 private:
     HTMLImageElement(DOM::Document&, DOM::QualifiedName);
 
+    virtual bool is_html_image_element() const override { return true; }
+
     virtual void initialize(JS::Realm&) override;
     virtual void finalize() override;
 
@@ -136,4 +138,9 @@ private:
     CSSPixelSize m_last_seen_viewport_size;
 };
 
+}
+
+namespace Web::DOM {
+template<>
+inline bool Node::fast_is<HTML::HTMLImageElement>() const { return is_html_image_element(); }
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLObjectElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLObjectElement.h
@@ -51,6 +51,8 @@ public:
 private:
     HTMLObjectElement(DOM::Document&, DOM::QualifiedName);
 
+    virtual bool is_html_object_element() const override { return true; }
+
     virtual void initialize(JS::Realm&) override;
 
     virtual JS::GCPtr<Layout::Node> create_layout_node(NonnullRefPtr<CSS::StyleProperties>) override;
@@ -86,4 +88,9 @@ private:
     JS::GCPtr<SharedImageRequest> m_image_request;
 };
 
+}
+
+namespace Web::DOM {
+template<>
+inline bool Node::fast_is<HTML::HTMLObjectElement>() const { return is_html_object_element(); }
 }

--- a/Userland/Libraries/LibWeb/HTML/MimeTypeArray.cpp
+++ b/Userland/Libraries/LibWeb/HTML/MimeTypeArray.cpp
@@ -28,7 +28,7 @@ void MimeTypeArray::initialize(JS::Realm& realm)
 }
 
 // https://html.spec.whatwg.org/multipage/system-state.html#pdf-viewing-support:support-named-properties-2
-Vector<String> MimeTypeArray::supported_property_names() const
+Vector<FlyString> MimeTypeArray::supported_property_names() const
 {
     // The MimeTypeArray interface supports named properties. If the user agent's PDF viewer supported is true, then they are the PDF viewer mime types. Otherwise, they are the empty list.
     auto const& window = verify_cast<HTML::Window>(HTML::relevant_global_object(*this));
@@ -36,9 +36,9 @@ Vector<String> MimeTypeArray::supported_property_names() const
         return {};
 
     // https://html.spec.whatwg.org/multipage/system-state.html#pdf-viewer-mime-types
-    static Vector<String> const mime_types = {
-        "application/pdf"_string,
-        "text/pdf"_string,
+    static Vector<FlyString> const mime_types = {
+        "application/pdf"_fly_string,
+        "text/pdf"_fly_string,
     };
 
     return mime_types;

--- a/Userland/Libraries/LibWeb/HTML/MimeTypeArray.h
+++ b/Userland/Libraries/LibWeb/HTML/MimeTypeArray.h
@@ -28,7 +28,7 @@ private:
     virtual void initialize(JS::Realm&) override;
 
     // ^Bindings::LegacyPlatformObject
-    virtual Vector<String> supported_property_names() const override;
+    virtual Vector<FlyString> supported_property_names() const override;
     virtual WebIDL::ExceptionOr<JS::Value> item_value(size_t index) const override;
     virtual WebIDL::ExceptionOr<JS::Value> named_item_value(FlyString const& name) const override;
     virtual bool is_supported_property_index(u32) const override;

--- a/Userland/Libraries/LibWeb/HTML/Plugin.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Plugin.cpp
@@ -52,7 +52,7 @@ String Plugin::filename() const
 }
 
 // https://html.spec.whatwg.org/multipage/system-state.html#pdf-viewing-support:support-named-properties-3
-Vector<String> Plugin::supported_property_names() const
+Vector<FlyString> Plugin::supported_property_names() const
 {
     // The Plugin interface supports named properties. If the user agent's PDF viewer supported is true, then they are the PDF viewer mime types. Otherwise, they are the empty list.
     auto const& window = verify_cast<HTML::Window>(HTML::relevant_global_object(*this));
@@ -60,9 +60,9 @@ Vector<String> Plugin::supported_property_names() const
         return {};
 
     // https://html.spec.whatwg.org/multipage/system-state.html#pdf-viewer-mime-types
-    static Vector<String> const mime_types = {
-        "application/pdf"_string,
-        "text/pdf"_string,
+    static Vector<FlyString> const mime_types = {
+        "application/pdf"_fly_string,
+        "text/pdf"_fly_string,
     };
 
     return mime_types;

--- a/Userland/Libraries/LibWeb/HTML/Plugin.h
+++ b/Userland/Libraries/LibWeb/HTML/Plugin.h
@@ -34,7 +34,7 @@ private:
     virtual void initialize(JS::Realm&) override;
 
     // ^Bindings::LegacyPlatformObject
-    virtual Vector<String> supported_property_names() const override;
+    virtual Vector<FlyString> supported_property_names() const override;
     virtual WebIDL::ExceptionOr<JS::Value> item_value(size_t index) const override;
     virtual WebIDL::ExceptionOr<JS::Value> named_item_value(FlyString const& name) const override;
     virtual bool is_supported_property_index(u32) const override;

--- a/Userland/Libraries/LibWeb/HTML/PluginArray.cpp
+++ b/Userland/Libraries/LibWeb/HTML/PluginArray.cpp
@@ -34,7 +34,7 @@ void PluginArray::refresh() const
 }
 
 // https://html.spec.whatwg.org/multipage/system-state.html#pdf-viewing-support:support-named-properties
-Vector<String> PluginArray::supported_property_names() const
+Vector<FlyString> PluginArray::supported_property_names() const
 {
     // The PluginArray interface supports named properties. If the user agent's PDF viewer supported is true, then they are the PDF viewer plugin names. Otherwise, they are the empty list.
     auto const& window = verify_cast<HTML::Window>(HTML::relevant_global_object(*this));
@@ -42,12 +42,12 @@ Vector<String> PluginArray::supported_property_names() const
         return {};
 
     // https://html.spec.whatwg.org/multipage/system-state.html#pdf-viewer-plugin-names
-    static Vector<String> const plugin_names = {
-        "PDF Viewer"_string,
-        "Chrome PDF Viewer"_string,
-        "Chromium PDF Viewer"_string,
-        "Microsoft Edge PDF Viewer"_string,
-        "WebKit built-in PDF"_string,
+    static Vector<FlyString> const plugin_names = {
+        "PDF Viewer"_fly_string,
+        "Chrome PDF Viewer"_fly_string,
+        "Chromium PDF Viewer"_fly_string,
+        "Microsoft Edge PDF Viewer"_fly_string,
+        "WebKit built-in PDF"_fly_string,
     };
 
     return plugin_names;

--- a/Userland/Libraries/LibWeb/HTML/PluginArray.h
+++ b/Userland/Libraries/LibWeb/HTML/PluginArray.h
@@ -29,7 +29,7 @@ private:
     virtual void initialize(JS::Realm&) override;
 
     // ^Bindings::LegacyPlatformObject
-    virtual Vector<String> supported_property_names() const override;
+    virtual Vector<FlyString> supported_property_names() const override;
     virtual WebIDL::ExceptionOr<JS::Value> item_value(size_t index) const override;
     virtual WebIDL::ExceptionOr<JS::Value> named_item_value(FlyString const& name) const override;
     virtual bool is_supported_property_index(u32) const override;

--- a/Userland/Libraries/LibWeb/HTML/Storage.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Storage.cpp
@@ -149,10 +149,10 @@ void Storage::broadcast(StringView key, StringView old_value, StringView new_val
     // FIXME: Implement.
 }
 
-Vector<String> Storage::supported_property_names() const
+Vector<FlyString> Storage::supported_property_names() const
 {
     // The supported property names on a Storage object storage are the result of running get the keys on storage's map.
-    Vector<String> names;
+    Vector<FlyString> names;
     names.ensure_capacity(m_map.size());
     for (auto const& key : m_map.keys())
         names.unchecked_append(key);

--- a/Userland/Libraries/LibWeb/HTML/Storage.h
+++ b/Userland/Libraries/LibWeb/HTML/Storage.h
@@ -40,7 +40,7 @@ private:
     // ^LegacyPlatformObject
     virtual WebIDL::ExceptionOr<JS::Value> named_item_value(FlyString const&) const override;
     virtual WebIDL::ExceptionOr<DidDeletionFail> delete_value(String const&) override;
-    virtual Vector<String> supported_property_names() const override;
+    virtual Vector<FlyString> supported_property_names() const override;
     virtual WebIDL::ExceptionOr<void> set_value_of_named_property(String const& key, JS::Value value) override;
 
     virtual bool supports_indexed_properties() const override { return false; }

--- a/Userland/Libraries/LibWeb/HTML/Window.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Window.cpp
@@ -1506,7 +1506,7 @@ JS::NonnullGCPtr<CustomElementRegistry> Window::custom_elements()
 }
 
 // https://html.spec.whatwg.org/#document-tree-child-navigable-target-name-property-set
-OrderedHashMap<String, JS::NonnullGCPtr<Navigable>> Window::document_tree_child_navigable_target_name_property_set()
+OrderedHashMap<FlyString, JS::NonnullGCPtr<Navigable>> Window::document_tree_child_navigable_target_name_property_set()
 {
     // The document-tree child navigable target name property set of a Window object window is the return value of running these steps:
 
@@ -1514,7 +1514,7 @@ OrderedHashMap<String, JS::NonnullGCPtr<Navigable>> Window::document_tree_child_
     auto children = associated_document().document_tree_child_navigables();
 
     // 2. Let firstNamedChildren be an empty ordered set.
-    OrderedHashMap<String, JS::NonnullGCPtr<Navigable>> first_named_children;
+    OrderedHashMap<FlyString, JS::NonnullGCPtr<Navigable>> first_named_children;
 
     // 3. For each navigable of children:
     for (auto const& navigable : children) {
@@ -1534,7 +1534,7 @@ OrderedHashMap<String, JS::NonnullGCPtr<Navigable>> Window::document_tree_child_
     }
 
     // 4. Let names be an empty ordered set.
-    OrderedHashMap<String, JS::NonnullGCPtr<Navigable>> names;
+    OrderedHashMap<FlyString, JS::NonnullGCPtr<Navigable>> names;
 
     // 5. For each navigable of firstNamedChildren:
     for (auto const& [name, navigable] : first_named_children) {

--- a/Userland/Libraries/LibWeb/HTML/Window.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Window.cpp
@@ -1548,7 +1548,7 @@ OrderedHashMap<String, JS::NonnullGCPtr<Navigable>> Window::document_tree_child_
 }
 
 // https://html.spec.whatwg.org/#named-access-on-the-window-object
-Vector<String> Window::supported_property_names()
+Vector<FlyString> Window::supported_property_names()
 {
     // The Window object supports named properties.
     // The supported property names of a Window object window at any moment consist of the following,
@@ -1575,13 +1575,7 @@ Vector<String> Window::supported_property_names()
         return IterationDecision::Continue;
     });
 
-    Vector<String> names;
-    names.ensure_capacity(property_names.size());
-    for (auto const& name : property_names) {
-        names.append(name.to_string());
-    }
-
-    return names;
+    return property_names.values();
 }
 
 // https://html.spec.whatwg.org/#named-access-on-the-window-object

--- a/Userland/Libraries/LibWeb/HTML/Window.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Window.cpp
@@ -1554,7 +1554,7 @@ Vector<String> Window::supported_property_names()
     // The supported property names of a Window object window at any moment consist of the following,
     // in tree order according to the element that contributed them, ignoring later duplicates:
 
-    HashTable<String> property_names;
+    HashTable<FlyString> property_names;
 
     // - window's document-tree child navigable target name property set;
     auto child_navigable_property_set = document_tree_child_navigable_target_name_property_set();
@@ -1570,15 +1570,15 @@ Vector<String> Window::supported_property_names()
             if (auto const& name = element.attribute(AttributeNames::name); name.has_value())
                 property_names.set(name.value(), AK::HashSetExistingEntryBehavior::Keep);
         }
-        if (auto const& name = element.attribute(AttributeNames::id); name.has_value())
-            property_names.set(name.value(), AK::HashSetExistingEntryBehavior::Keep);
+        if (auto const& name = element.id(); name.has_value())
+            property_names.set(name.value().to_string(), AK::HashSetExistingEntryBehavior::Keep);
         return IterationDecision::Continue;
     });
 
     Vector<String> names;
     names.ensure_capacity(property_names.size());
     for (auto const& name : property_names) {
-        names.append(name);
+        names.append(name.to_string());
     }
 
     return names;

--- a/Userland/Libraries/LibWeb/HTML/Window.h
+++ b/Userland/Libraries/LibWeb/HTML/Window.h
@@ -201,7 +201,7 @@ public:
     static void set_inspector_object_exposed(bool);
     static void set_internals_object_exposed(bool);
 
-    [[nodiscard]] OrderedHashMap<String, JS::NonnullGCPtr<Navigable>> document_tree_child_navigable_target_name_property_set();
+    [[nodiscard]] OrderedHashMap<FlyString, JS::NonnullGCPtr<Navigable>> document_tree_child_navigable_target_name_property_set();
 
     [[nodiscard]] Vector<FlyString> supported_property_names();
     [[nodiscard]] WebIDL::ExceptionOr<JS::Value> named_item_value(FlyString const&);

--- a/Userland/Libraries/LibWeb/HTML/Window.h
+++ b/Userland/Libraries/LibWeb/HTML/Window.h
@@ -203,7 +203,7 @@ public:
 
     [[nodiscard]] OrderedHashMap<String, JS::NonnullGCPtr<Navigable>> document_tree_child_navigable_target_name_property_set();
 
-    [[nodiscard]] Vector<String> supported_property_names();
+    [[nodiscard]] Vector<FlyString> supported_property_names();
     [[nodiscard]] WebIDL::ExceptionOr<JS::Value> named_item_value(FlyString const&);
 
 private:

--- a/Userland/Libraries/LibWeb/WebIDL/AbstractOperations.cpp
+++ b/Userland/Libraries/LibWeb/WebIDL/AbstractOperations.cpp
@@ -317,7 +317,7 @@ JS::ThrowCompletionOr<bool> is_named_property_exposed_on_object(Variant<Bindings
 
     // 1. If P is not a supported property name of O, then return false.
     // NOTE: This is in it's own variable to enforce the type.
-    Vector<String> supported_property_names = variant.visit([](auto* o) { return o->supported_property_names(); });
+    auto supported_property_names = variant.visit([](auto* o) { return o->supported_property_names(); });
     auto property_key_string = MUST(String::from_byte_string(property_key.to_string()));
     if (!supported_property_names.contains_slow(property_key_string))
         return false;


### PR DESCRIPTION
Here's a bundle of changes that lower how long takes before the cookie consent banner is active on https://twinings.co.uk/ from 22 seconds to 10 seconds (after hitting enter in the location bar)