### PR TITLE
LibJS+LibWeb: Implement the resizable ArrayBuffer proposal

### DIFF
--- a/Meta/gn/secondary/Tests/LibJS/BUILD.gn
+++ b/Meta/gn/secondary/Tests/LibJS/BUILD.gn
@@ -10,7 +10,20 @@ unittest("test-js") {
   ]
 }
 
+executable("test262-runner") {
+  sources = [ "test262-runner.cpp" ]
+  include_dirs = [ "//Userland/Libraries" ]
+  deps = [
+    "//AK",
+    "//Userland/Libraries/LibCore",
+    "//Userland/Libraries/LibJS",
+  ]
+}
+
 group("LibJS") {
-  deps = [ ":test-js" ]
   testonly = true
+  deps = [
+    ":test-js",
+    ":test262-runner",
+  ]
 }

--- a/Meta/gn/secondary/Userland/Libraries/LibJS/BUILD.gn
+++ b/Meta/gn/secondary/Userland/Libraries/LibJS/BUILD.gn
@@ -58,6 +58,7 @@ shared_library("LibJS") {
     "ParserError.cpp",
     "Print.cpp",
     "Runtime/AbstractOperations.cpp",
+    "Runtime/Accessor.cpp",
     "Runtime/Agent.cpp",
     "Runtime/AggregateError.cpp",
     "Runtime/AggregateErrorConstructor.cpp",

--- a/Userland/Libraries/LibJS/Bytecode/CommonImplementations.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/CommonImplementations.cpp
@@ -23,7 +23,7 @@ namespace JS::Bytecode {
 // NOTE: This function assumes that the index is valid within the TypedArray,
 //       and that the TypedArray is not detached.
 template<typename T>
-inline Value fast_integer_indexed_element_get(TypedArrayBase& typed_array, u32 index)
+inline Value fast_typed_array_get_element(TypedArrayBase& typed_array, u32 index)
 {
     Checked<u32> offset_into_array_buffer = index;
     offset_into_array_buffer *= sizeof(T);
@@ -41,7 +41,7 @@ inline Value fast_integer_indexed_element_get(TypedArrayBase& typed_array, u32 i
 // NOTE: This function assumes that the index is valid within the TypedArray,
 //       and that the TypedArray is not detached.
 template<typename T>
-inline void fast_integer_indexed_element_set(TypedArrayBase& typed_array, u32 index, T value)
+inline void fast_typed_array_set_element(TypedArrayBase& typed_array, u32 index, T value)
 {
     Checked<u32> offset_into_array_buffer = index;
     offset_into_array_buffer *= sizeof(T);
@@ -117,23 +117,22 @@ ThrowCompletionOr<Value> get_by_value(VM& vm, Value base_value, Value property_k
         // For typed arrays:
         if (object.is_typed_array()) {
             auto& typed_array = static_cast<TypedArrayBase&>(object);
-
             if (!typed_array.viewed_array_buffer()->is_detached() && index < typed_array.array_length()) {
                 switch (typed_array.kind()) {
                 case TypedArrayBase::Kind::Uint8Array:
-                    return fast_integer_indexed_element_get<u8>(typed_array, index);
+                    return fast_typed_array_get_element<u8>(typed_array, index);
                 case TypedArrayBase::Kind::Uint16Array:
-                    return fast_integer_indexed_element_get<u16>(typed_array, index);
+                    return fast_typed_array_get_element<u16>(typed_array, index);
                 case TypedArrayBase::Kind::Uint32Array:
-                    return fast_integer_indexed_element_get<u32>(typed_array, index);
+                    return fast_typed_array_get_element<u32>(typed_array, index);
                 case TypedArrayBase::Kind::Int8Array:
-                    return fast_integer_indexed_element_get<i8>(typed_array, index);
+                    return fast_typed_array_get_element<i8>(typed_array, index);
                 case TypedArrayBase::Kind::Int16Array:
-                    return fast_integer_indexed_element_get<i16>(typed_array, index);
+                    return fast_typed_array_get_element<i16>(typed_array, index);
                 case TypedArrayBase::Kind::Int32Array:
-                    return fast_integer_indexed_element_get<i32>(typed_array, index);
+                    return fast_typed_array_get_element<i32>(typed_array, index);
                 case TypedArrayBase::Kind::Uint8ClampedArray:
-                    return fast_integer_indexed_element_get<u8>(typed_array, index);
+                    return fast_typed_array_get_element<u8>(typed_array, index);
                 default:
                     // FIXME: Support more TypedArray kinds.
                     break;
@@ -144,7 +143,7 @@ ThrowCompletionOr<Value> get_by_value(VM& vm, Value base_value, Value property_k
             switch (typed_array.kind()) {
 #define __JS_ENUMERATE(ClassName, snake_name, PrototypeName, ConstructorName, Type) \
     case TypedArrayBase::Kind::ClassName:                                           \
-        return integer_indexed_element_get<Type>(typed_array, canonical_index);
+        return typed_array_get_element<Type>(typed_array, canonical_index);
                 JS_ENUMERATE_TYPED_ARRAYS
 #undef __JS_ENUMERATE
             }
@@ -399,25 +398,25 @@ ThrowCompletionOr<void> put_by_value(VM& vm, Value base, Value property_key_valu
             if (!typed_array.viewed_array_buffer()->is_detached() && index < typed_array.array_length() && value.is_int32()) {
                 switch (typed_array.kind()) {
                 case TypedArrayBase::Kind::Uint8Array:
-                    fast_integer_indexed_element_set<u8>(typed_array, index, static_cast<u8>(value.as_i32()));
+                    fast_typed_array_set_element<u8>(typed_array, index, static_cast<u8>(value.as_i32()));
                     return {};
                 case TypedArrayBase::Kind::Uint16Array:
-                    fast_integer_indexed_element_set<u16>(typed_array, index, static_cast<u16>(value.as_i32()));
+                    fast_typed_array_set_element<u16>(typed_array, index, static_cast<u16>(value.as_i32()));
                     return {};
                 case TypedArrayBase::Kind::Uint32Array:
-                    fast_integer_indexed_element_set<u32>(typed_array, index, static_cast<u32>(value.as_i32()));
+                    fast_typed_array_set_element<u32>(typed_array, index, static_cast<u32>(value.as_i32()));
                     return {};
                 case TypedArrayBase::Kind::Int8Array:
-                    fast_integer_indexed_element_set<i8>(typed_array, index, static_cast<i8>(value.as_i32()));
+                    fast_typed_array_set_element<i8>(typed_array, index, static_cast<i8>(value.as_i32()));
                     return {};
                 case TypedArrayBase::Kind::Int16Array:
-                    fast_integer_indexed_element_set<i16>(typed_array, index, static_cast<i16>(value.as_i32()));
+                    fast_typed_array_set_element<i16>(typed_array, index, static_cast<i16>(value.as_i32()));
                     return {};
                 case TypedArrayBase::Kind::Int32Array:
-                    fast_integer_indexed_element_set<i32>(typed_array, index, value.as_i32());
+                    fast_typed_array_set_element<i32>(typed_array, index, value.as_i32());
                     return {};
                 case TypedArrayBase::Kind::Uint8ClampedArray:
-                    fast_integer_indexed_element_set<u8>(typed_array, index, clamp(value.as_i32(), 0, 255));
+                    fast_typed_array_set_element<u8>(typed_array, index, clamp(value.as_i32(), 0, 255));
                     return {};
                 default:
                     // FIXME: Support more TypedArray kinds.
@@ -428,7 +427,7 @@ ThrowCompletionOr<void> put_by_value(VM& vm, Value base, Value property_key_valu
             switch (typed_array.kind()) {
 #define __JS_ENUMERATE(ClassName, snake_name, PrototypeName, ConstructorName, Type) \
     case TypedArrayBase::Kind::ClassName:                                           \
-        return integer_indexed_element_set<Type>(typed_array, canonical_index, value);
+        return typed_array_set_element<Type>(typed_array, canonical_index, value);
                 JS_ENUMERATE_TYPED_ARRAYS
 #undef __JS_ENUMERATE
             }

--- a/Userland/Libraries/LibJS/Runtime/ArrayBuffer.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayBuffer.cpp
@@ -138,7 +138,7 @@ void copy_data_block_bytes(ByteBuffer& to_block, u64 to_index, ByteBuffer const&
     // 7. Return unused.
 }
 
-// 25.1.2.1 AllocateArrayBuffer ( constructor, byteLength ), https://tc39.es/ecma262/#sec-allocatearraybuffer
+// 25.1.3.1 AllocateArrayBuffer ( constructor, byteLength [ , maxByteLength ] ), https://tc39.es/ecma262/#sec-allocatearraybuffer
 ThrowCompletionOr<ArrayBuffer*> allocate_array_buffer(VM& vm, FunctionObject& constructor, size_t byte_length)
 {
     // 1. Let obj be ? OrdinaryCreateFromConstructor(constructor, "%ArrayBuffer.prototype%", « [[ArrayBufferData]], [[ArrayBufferByteLength]], [[ArrayBufferDetachKey]] »).
@@ -156,7 +156,7 @@ ThrowCompletionOr<ArrayBuffer*> allocate_array_buffer(VM& vm, FunctionObject& co
     return obj.ptr();
 }
 
-// 25.1.2.3 DetachArrayBuffer ( arrayBuffer [ , key ] ), https://tc39.es/ecma262/#sec-detacharraybuffer
+// 25.1.3.4 DetachArrayBuffer ( arrayBuffer [ , key ] ), https://tc39.es/ecma262/#sec-detacharraybuffer
 ThrowCompletionOr<void> detach_array_buffer(VM& vm, ArrayBuffer& array_buffer, Optional<Value> key)
 {
     // 1. Assert: IsSharedArrayBuffer(arrayBuffer) is false.
@@ -178,7 +178,7 @@ ThrowCompletionOr<void> detach_array_buffer(VM& vm, ArrayBuffer& array_buffer, O
     return {};
 }
 
-// 25.1.2.4 CloneArrayBuffer ( srcBuffer, srcByteOffset, srcLength, cloneConstructor ), https://tc39.es/ecma262/#sec-clonearraybuffer
+// 25.1.3.5 CloneArrayBuffer ( srcBuffer, srcByteOffset, srcLength, cloneConstructor ), https://tc39.es/ecma262/#sec-clonearraybuffer
 ThrowCompletionOr<ArrayBuffer*> clone_array_buffer(VM& vm, ArrayBuffer& source_buffer, size_t source_byte_offset, size_t source_length)
 {
     auto& realm = *vm.current_realm();
@@ -249,7 +249,7 @@ ThrowCompletionOr<ArrayBuffer*> array_buffer_copy_and_detach(VM& vm, ArrayBuffer
     return new_buffer;
 }
 
-// 25.2.1.1 AllocateSharedArrayBuffer ( constructor, byteLength ), https://tc39.es/ecma262/#sec-allocatesharedarraybuffer
+// 25.2.2.1 AllocateSharedArrayBuffer ( constructor, byteLength [ , maxByteLength ] ), https://tc39.es/ecma262/#sec-allocatesharedarraybuffer
 ThrowCompletionOr<NonnullGCPtr<ArrayBuffer>> allocate_shared_array_buffer(VM& vm, FunctionObject& constructor, size_t byte_length)
 {
     // 1. Let obj be ? OrdinaryCreateFromConstructor(constructor, "%SharedArrayBuffer.prototype%", « [[ArrayBufferData]], [[ArrayBufferByteLength]] »).

--- a/Userland/Libraries/LibJS/Runtime/ArrayBuffer.h
+++ b/Userland/Libraries/LibJS/Runtime/ArrayBuffer.h
@@ -77,7 +77,7 @@ public:
 
     void detach_buffer() { m_data_block.byte_buffer = Empty {}; }
 
-    // 25.1.2.2 IsDetachedBuffer ( arrayBuffer ), https://tc39.es/ecma262/#sec-isdetachedbuffer
+    // 25.1.3.3 IsDetachedBuffer ( arrayBuffer ), https://tc39.es/ecma262/#sec-isdetachedbuffer
     bool is_detached() const
     {
         // 1. If arrayBuffer.[[ArrayBufferData]] is null, return true.
@@ -87,7 +87,7 @@ public:
         return false;
     }
 
-    // 25.2.1.2 IsSharedArrayBuffer ( obj ), https://tc39.es/ecma262/#sec-issharedarraybuffer
+    // 25.2.2.2 IsSharedArrayBuffer ( obj ), https://tc39.es/ecma262/#sec-issharedarraybuffer
     bool is_shared_array_buffer() const
     {
         // 1. Let bufferData be obj.[[ArrayBufferData]].
@@ -134,7 +134,7 @@ ThrowCompletionOr<ArrayBuffer*> clone_array_buffer(VM&, ArrayBuffer& source_buff
 ThrowCompletionOr<ArrayBuffer*> array_buffer_copy_and_detach(VM&, ArrayBuffer& array_buffer, Value new_length, PreserveResizability preserve_resizability);
 ThrowCompletionOr<NonnullGCPtr<ArrayBuffer>> allocate_shared_array_buffer(VM&, FunctionObject& constructor, size_t byte_length);
 
-// 25.1.2.9 RawBytesToNumeric ( type, rawBytes, isLittleEndian ), https://tc39.es/ecma262/#sec-rawbytestonumeric
+// 25.1.3.13 RawBytesToNumeric ( type, rawBytes, isLittleEndian ), https://tc39.es/ecma262/#sec-rawbytestonumeric
 template<typename T>
 static Value raw_bytes_to_numeric(VM& vm, Bytes raw_value, bool is_little_endian)
 {
@@ -206,7 +206,7 @@ static Value raw_bytes_to_numeric(VM& vm, Bytes raw_value, bool is_little_endian
     }
 }
 
-// Implementation for 25.1.2.10 GetValueFromBuffer, used in TypedArray<T>::get_value_from_buffer(), https://tc39.es/ecma262/#sec-getvaluefrombuffer
+// 25.1.3.15 GetValueFromBuffer ( arrayBuffer, byteIndex, type, isTypedArray, order [ , isLittleEndian ] ), https://tc39.es/ecma262/#sec-getvaluefrombuffer
 template<typename T>
 Value ArrayBuffer::get_value(size_t byte_index, [[maybe_unused]] bool is_typed_array, Order, bool is_little_endian)
 {
@@ -252,7 +252,7 @@ Value ArrayBuffer::get_value(size_t byte_index, [[maybe_unused]] bool is_typed_a
     return raw_bytes_to_numeric<T>(vm, raw_value, is_little_endian);
 }
 
-// 25.1.2.11 NumericToRawBytes ( type, value, isLittleEndian ), https://tc39.es/ecma262/#sec-numerictorawbytes
+// 25.1.3.16 NumericToRawBytes ( type, value, isLittleEndian ), https://tc39.es/ecma262/#sec-numerictorawbytes
 template<typename T>
 static void numeric_to_raw_bytes(VM& vm, Value value, bool is_little_endian, Bytes raw_bytes)
 {
@@ -317,7 +317,7 @@ static void numeric_to_raw_bytes(VM& vm, Value value, bool is_little_endian, Byt
     }
 }
 
-// 25.1.2.12 SetValueInBuffer ( arrayBuffer, byteIndex, type, value, isTypedArray, order [ , isLittleEndian ] ), https://tc39.es/ecma262/#sec-setvalueinbuffer
+// 25.1.3.17 SetValueInBuffer ( arrayBuffer, byteIndex, type, value, isTypedArray, order [ , isLittleEndian ] ), https://tc39.es/ecma262/#sec-setvalueinbuffer
 template<typename T>
 void ArrayBuffer::set_value(size_t byte_index, Value value, [[maybe_unused]] bool is_typed_array, Order, bool is_little_endian)
 {
@@ -363,7 +363,7 @@ void ArrayBuffer::set_value(size_t byte_index, Value value, [[maybe_unused]] boo
     // 10. Return unused.
 }
 
-// 25.1.2.13 GetModifySetValueInBuffer ( arrayBuffer, byteIndex, type, value, op [ , isLittleEndian ] ), https://tc39.es/ecma262/#sec-getmodifysetvalueinbuffer
+// 25.1.3.18 GetModifySetValueInBuffer ( arrayBuffer, byteIndex, type, value, op [ , isLittleEndian ] ), https://tc39.es/ecma262/#sec-getmodifysetvalueinbuffer
 template<typename T>
 Value ArrayBuffer::get_modify_set_value(size_t byte_index, Value value, ReadWriteModifyFunction operation, bool is_little_endian)
 {

--- a/Userland/Libraries/LibJS/Runtime/ArrayBufferConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayBufferConstructor.cpp
@@ -26,19 +26,19 @@ void ArrayBufferConstructor::initialize(Realm& realm)
     auto& vm = this->vm();
     Base::initialize(realm);
 
-    // 25.1.4.2 ArrayBuffer.prototype, https://tc39.es/ecma262/#sec-arraybuffer.prototype
+    // 25.1.5.2 ArrayBuffer.prototype, https://tc39.es/ecma262/#sec-arraybuffer.prototype
     define_direct_property(vm.names.prototype, realm.intrinsics().array_buffer_prototype(), 0);
 
     u8 attr = Attribute::Writable | Attribute::Configurable;
     define_native_function(realm, vm.names.isView, is_view, 1, attr);
 
-    // 25.1.5.4 ArrayBuffer.prototype [ @@toStringTag ], https://tc39.es/ecma262/#sec-arraybuffer.prototype-@@tostringtag
+    // 25.1.6.7 ArrayBuffer.prototype [ @@toStringTag ], https://tc39.es/ecma262/#sec-arraybuffer.prototype-@@tostringtag
     define_native_accessor(realm, vm.well_known_symbol_species(), symbol_species_getter, {}, Attribute::Configurable);
 
     define_direct_property(vm.names.length, Value(1), Attribute::Configurable);
 }
 
-// 25.1.3.1 ArrayBuffer ( length ), https://tc39.es/ecma262/#sec-arraybuffer-length
+// 25.1.4.1 ArrayBuffer ( length [ , options ] ), https://tc39.es/ecma262/#sec-arraybuffer-length
 ThrowCompletionOr<Value> ArrayBufferConstructor::call()
 {
     auto& vm = this->vm();
@@ -47,7 +47,7 @@ ThrowCompletionOr<Value> ArrayBufferConstructor::call()
     return vm.throw_completion<TypeError>(ErrorType::ConstructorWithoutNew, vm.names.ArrayBuffer);
 }
 
-// 25.1.3.1 ArrayBuffer ( length ), https://tc39.es/ecma262/#sec-arraybuffer-length
+// 25.1.4.1 ArrayBuffer ( length [ , options ] ), https://tc39.es/ecma262/#sec-arraybuffer-length
 ThrowCompletionOr<NonnullGCPtr<Object>> ArrayBufferConstructor::construct(FunctionObject& new_target)
 {
     auto& vm = this->vm();
@@ -68,7 +68,7 @@ ThrowCompletionOr<NonnullGCPtr<Object>> ArrayBufferConstructor::construct(Functi
     return *TRY(allocate_array_buffer(vm, new_target, byte_length_or_error.release_value()));
 }
 
-// 25.1.4.1 ArrayBuffer.isView ( arg ), https://tc39.es/ecma262/#sec-arraybuffer.isview
+// 25.1.5.1 ArrayBuffer.isView ( arg ), https://tc39.es/ecma262/#sec-arraybuffer.isview
 JS_DEFINE_NATIVE_FUNCTION(ArrayBufferConstructor::is_view)
 {
     auto arg = vm.argument(0);
@@ -87,7 +87,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayBufferConstructor::is_view)
     return Value(false);
 }
 
-// 25.1.4.3 get ArrayBuffer [ @@species ], https://tc39.es/ecma262/#sec-get-arraybuffer-@@species
+// 25.1.5.3 get ArrayBuffer [ @@species ], https://tc39.es/ecma262/#sec-get-arraybuffer-@@species
 JS_DEFINE_NATIVE_FUNCTION(ArrayBufferConstructor::symbol_species_getter)
 {
     // 1. Return the this value.

--- a/Userland/Libraries/LibJS/Runtime/ArrayBufferConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayBufferConstructor.cpp
@@ -52,8 +52,11 @@ ThrowCompletionOr<NonnullGCPtr<Object>> ArrayBufferConstructor::construct(Functi
 {
     auto& vm = this->vm();
 
+    auto length = vm.argument(0);
+    auto options = vm.argument(1);
+
     // 2. Let byteLength be ? ToIndex(length).
-    auto byte_length_or_error = vm.argument(0).to_index(vm);
+    auto byte_length_or_error = length.to_index(vm);
 
     if (byte_length_or_error.is_error()) {
         auto error = byte_length_or_error.release_error();
@@ -64,8 +67,11 @@ ThrowCompletionOr<NonnullGCPtr<Object>> ArrayBufferConstructor::construct(Functi
         return error;
     }
 
-    // 3. Return ? AllocateArrayBuffer(NewTarget, byteLength).
-    return *TRY(allocate_array_buffer(vm, new_target, byte_length_or_error.release_value()));
+    // 3. Let requestedMaxByteLength be ? GetArrayBufferMaxByteLengthOption(options).
+    auto requested_max_byte_length = TRY(get_array_buffer_max_byte_length_option(vm, options));
+
+    // 3. Return ? AllocateArrayBuffer(NewTarget, byteLength, requestedMaxByteLength).
+    return *TRY(allocate_array_buffer(vm, new_target, byte_length_or_error.release_value(), requested_max_byte_length));
 }
 
 // 25.1.5.1 ArrayBuffer.isView ( arg ), https://tc39.es/ecma262/#sec-arraybuffer.isview

--- a/Userland/Libraries/LibJS/Runtime/ArrayBufferPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayBufferPrototype.cpp
@@ -27,6 +27,9 @@ void ArrayBufferPrototype::initialize(Realm& realm)
     Base::initialize(realm);
     u8 attr = Attribute::Writable | Attribute::Configurable;
     define_native_accessor(realm, vm.names.byteLength, byte_length_getter, {}, Attribute::Configurable);
+    define_native_accessor(realm, vm.names.maxByteLength, max_byte_length, {}, Attribute::Configurable);
+    define_native_accessor(realm, vm.names.resizable, resizable, {}, Attribute::Configurable);
+    define_native_function(realm, vm.names.resize, resize, 1, attr);
     define_native_function(realm, vm.names.slice, slice, 2, attr);
     define_native_accessor(realm, vm.names.detached, detached_getter, {}, Attribute::Configurable);
     define_native_function(realm, vm.names.transfer, transfer, 0, attr);
@@ -52,6 +55,110 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayBufferPrototype::byte_length_getter)
     // 5. Let length be O.[[ArrayBufferByteLength]].
     // 6. Return 𝔽(length).
     return Value(array_buffer_object->byte_length());
+}
+
+// 25.1.6.3 get ArrayBuffer.prototype.maxByteLength, https://tc39.es/ecma262/#sec-get-arraybuffer.prototype.maxbytelength
+JS_DEFINE_NATIVE_FUNCTION(ArrayBufferPrototype::max_byte_length)
+{
+    // 1. Let O be the this value.
+    // 2. Perform ? RequireInternalSlot(O, [[ArrayBufferData]]).
+    auto array_buffer_object = TRY(typed_this_value(vm));
+
+    // 3. If IsSharedArrayBuffer(O) is true, throw a TypeError exception.
+    if (array_buffer_object->is_shared_array_buffer())
+        return vm.throw_completion<TypeError>(ErrorType::ThisCannotBeSharedArrayBuffer);
+
+    // 4. If IsDetachedBuffer(O) is true, return +0𝔽.
+    if (array_buffer_object->is_detached())
+        return Value { 0 };
+
+    size_t length = 0;
+
+    // 5. If IsFixedLengthArrayBuffer(O) is true, then
+    if (array_buffer_object->is_fixed_length()) {
+        // a. Let length be O.[[ArrayBufferByteLength]].
+        length = array_buffer_object->byte_length();
+    }
+    // 6. Else,
+    else {
+        // a. Let length be O.[[ArrayBufferMaxByteLength]].
+        length = array_buffer_object->max_byte_length();
+    }
+
+    // 7. Return 𝔽(length).
+    return Value { length };
+}
+
+// 25.1.6.4 get ArrayBuffer.prototype.resizable, https://tc39.es/ecma262/#sec-get-arraybuffer.prototype.resizable
+JS_DEFINE_NATIVE_FUNCTION(ArrayBufferPrototype::resizable)
+{
+    // 1. Let O be the this value.
+    // 2. Perform ? RequireInternalSlot(O, [[ArrayBufferData]]).
+    auto array_buffer_object = TRY(typed_this_value(vm));
+
+    // 3. If IsSharedArrayBuffer(O) is true, throw a TypeError exception.
+    if (array_buffer_object->is_shared_array_buffer())
+        return vm.throw_completion<TypeError>(ErrorType::ThisCannotBeSharedArrayBuffer);
+
+    // 4. If IsFixedLengthArrayBuffer(O) is false, return true; otherwise return false.
+    return Value { !array_buffer_object->is_fixed_length() };
+}
+
+// 25.1.6.5 ArrayBuffer.prototype.resize ( newLength ), https://tc39.es/ecma262/#sec-arraybuffer.prototype.resize
+JS_DEFINE_NATIVE_FUNCTION(ArrayBufferPrototype::resize)
+{
+    auto new_length = vm.argument(0);
+
+    // 1. Let O be the this value.
+    auto array_buffer_object = TRY(typed_this_value(vm));
+
+    // 2. Perform ? RequireInternalSlot(O, [[ArrayBufferMaxByteLength]]).
+    if (array_buffer_object->is_fixed_length())
+        return vm.throw_completion<TypeError>(ErrorType::FixedArrayBuffer);
+
+    // 3. If IsSharedArrayBuffer(O) is true, throw a TypeError exception.
+    if (array_buffer_object->is_shared_array_buffer())
+        return vm.throw_completion<TypeError>(ErrorType::ThisCannotBeSharedArrayBuffer);
+
+    // 4. Let newByteLength be ? ToIndex(newLength).
+    auto new_byte_length = TRY(new_length.to_index(vm));
+
+    // 5. If IsDetachedBuffer(O) is true, throw a TypeError exception.
+    if (array_buffer_object->is_detached())
+        return vm.throw_completion<TypeError>(ErrorType::DetachedArrayBuffer);
+
+    // 6. If newByteLength > O.[[ArrayBufferMaxByteLength]], throw a RangeError exception.
+    if (new_byte_length > array_buffer_object->max_byte_length())
+        return vm.throw_completion<RangeError>(ErrorType::ByteLengthExceedsMaxByteLength, new_byte_length, array_buffer_object->max_byte_length());
+
+    // 7. Let hostHandled be ? HostResizeArrayBuffer(O, newByteLength).
+    auto host_handled = TRY(vm.host_resize_array_buffer(array_buffer_object, new_byte_length));
+
+    // 8. If hostHandled is handled, return undefined.
+    if (host_handled == HandledByHost::Handled)
+        return js_undefined();
+
+    // 9. Let oldBlock be O.[[ArrayBufferData]].
+    auto const& old_block = array_buffer_object->buffer();
+
+    // 10. Let newBlock be ? CreateByteDataBlock(newByteLength).
+    auto new_block = TRY(create_byte_data_block(vm, new_byte_length));
+
+    // 11. Let copyLength be min(newByteLength, O.[[ArrayBufferByteLength]]).
+    auto copy_length = min(new_byte_length, array_buffer_object->byte_length());
+
+    // 12. Perform CopyDataBlockBytes(newBlock, 0, oldBlock, 0, copyLength).
+    copy_data_block_bytes(new_block.buffer(), 0, old_block, 0, copy_length);
+
+    // 13. NOTE: Neither creation of the new Data Block nor copying from the old Data Block are observable. Implementations may implement this method as in-place growth or shrinkage.
+
+    // 14. Set O.[[ArrayBufferData]] to newBlock.
+    array_buffer_object->set_data_block(move(new_block));
+
+    // 15. Set O.[[ArrayBufferByteLength]] to newByteLength.
+
+    // 16. Return undefined.
+    return js_undefined();
 }
 
 // 25.1.6.6 ArrayBuffer.prototype.slice ( start, end ), https://tc39.es/ecma262/#sec-arraybuffer.prototype.slice
@@ -133,7 +240,8 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayBufferPrototype::slice)
     if (new_array_buffer_object->byte_length() < new_length)
         return vm.throw_completion<TypeError>(ErrorType::SpeciesConstructorReturned, "an ArrayBuffer smaller than requested");
 
-    // 22. NOTE: Side-effects of the above steps may have detached O.
+    // 22. NOTE: Side-effects of the above steps may have detached or resized O.
+
     // 23. If IsDetachedBuffer(O) is true, throw a TypeError exception.
     if (array_buffer_object->is_detached())
         return vm.throw_completion<TypeError>(ErrorType::DetachedArrayBuffer);
@@ -144,10 +252,19 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayBufferPrototype::slice)
     // 25. Let toBuf be new.[[ArrayBufferData]].
     auto& to_buf = new_array_buffer_object->buffer();
 
-    // 26. Perform CopyDataBlockBytes(toBuf, 0, fromBuf, first, newLen).
-    copy_data_block_bytes(to_buf, 0, from_buf, first, new_length);
+    // 26. Let currentLen be O.[[ArrayBufferByteLength]].
+    auto current_length = array_buffer_object->byte_length();
 
-    // 27. Return new.
+    // 27. If first < currentLen, then
+    if (first < current_length) {
+        // a. Let count be min(newLen, currentLen - first).
+        auto count = min(new_length, current_length - first);
+
+        // b. Perform CopyDataBlockBytes(toBuf, 0, fromBuf, first, count).
+        copy_data_block_bytes(to_buf, 0, from_buf, first, count);
+    }
+
+    // 28. Return new.
     return new_array_buffer_object;
 }
 

--- a/Userland/Libraries/LibJS/Runtime/ArrayBufferPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/ArrayBufferPrototype.h
@@ -23,6 +23,9 @@ private:
     explicit ArrayBufferPrototype(Realm&);
 
     JS_DECLARE_NATIVE_FUNCTION(byte_length_getter);
+    JS_DECLARE_NATIVE_FUNCTION(max_byte_length);
+    JS_DECLARE_NATIVE_FUNCTION(resizable);
+    JS_DECLARE_NATIVE_FUNCTION(resize);
     JS_DECLARE_NATIVE_FUNCTION(slice);
     JS_DECLARE_NATIVE_FUNCTION(detached_getter);
     JS_DECLARE_NATIVE_FUNCTION(transfer);

--- a/Userland/Libraries/LibJS/Runtime/ArrayBufferPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/ArrayBufferPrototype.h
@@ -22,11 +22,11 @@ public:
 private:
     explicit ArrayBufferPrototype(Realm&);
 
+    JS_DECLARE_NATIVE_FUNCTION(byte_length_getter);
     JS_DECLARE_NATIVE_FUNCTION(slice);
+    JS_DECLARE_NATIVE_FUNCTION(detached_getter);
     JS_DECLARE_NATIVE_FUNCTION(transfer);
     JS_DECLARE_NATIVE_FUNCTION(transfer_to_fixed_length);
-    JS_DECLARE_NATIVE_FUNCTION(byte_length_getter);
-    JS_DECLARE_NATIVE_FUNCTION(detached_getter);
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/AtomicsObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AtomicsObject.cpp
@@ -83,7 +83,7 @@ static ThrowCompletionOr<size_t> validate_atomic_access(VM& vm, TypedArrayBase& 
     return (access_index * element_size) + offset;
 }
 
-// 25.4.2.11 AtomicReadModifyWrite ( typedArray, index, value, op ), https://tc39.es/ecma262/#sec-atomicreadmodifywrite
+// 25.4.2.17 AtomicReadModifyWrite ( typedArray, index, value, op ), https://tc39.es/ecma262/#sec-atomicreadmodifywrite
 static ThrowCompletionOr<Value> atomic_read_modify_write(VM& vm, TypedArrayBase& typed_array, Value index, Value value, ReadWriteModifyFunction operation)
 {
     // 1. Let buffer be ? ValidateIntegerTypedArray(typedArray).
@@ -216,11 +216,11 @@ void AtomicsObject::initialize(Realm& realm)
     define_native_function(realm, vm.names.notify, notify, 3, attr);
     define_native_function(realm, vm.names.xor_, xor_, 3, attr);
 
-    // 25.4.15 Atomics [ @@toStringTag ], https://tc39.es/ecma262/#sec-atomics-@@tostringtag
+    // 25.4.17 Atomics [ @@toStringTag ], https://tc39.es/ecma262/#sec-atomics-@@tostringtag
     define_direct_property(vm.well_known_symbol_to_string_tag(), PrimitiveString::create(vm, "Atomics"_string), Attribute::Configurable);
 }
 
-// 25.4.3 Atomics.add ( typedArray, index, value ), https://tc39.es/ecma262/#sec-atomics.add
+// 25.4.4 Atomics.add ( typedArray, index, value ), https://tc39.es/ecma262/#sec-atomics.add
 JS_DEFINE_NATIVE_FUNCTION(AtomicsObject::add)
 {
     auto* typed_array = TRY(typed_array_from(vm, vm.argument(0)));
@@ -236,7 +236,7 @@ JS_DEFINE_NATIVE_FUNCTION(AtomicsObject::add)
     VERIFY_NOT_REACHED();
 }
 
-// 25.4.4 Atomics.and ( typedArray, index, value ), https://tc39.es/ecma262/#sec-atomics.and
+// 25.4.5 Atomics.and ( typedArray, index, value ), https://tc39.es/ecma262/#sec-atomics.and
 JS_DEFINE_NATIVE_FUNCTION(AtomicsObject::and_)
 {
     auto* typed_array = TRY(typed_array_from(vm, vm.argument(0)));
@@ -252,7 +252,7 @@ JS_DEFINE_NATIVE_FUNCTION(AtomicsObject::and_)
     VERIFY_NOT_REACHED();
 }
 
-// Implementation of 25.4.5 Atomics.compareExchange ( typedArray, index, expectedValue, replacementValue ), https://tc39.es/ecma262/#sec-atomics.compareexchange
+// 25.4.6 Atomics.compareExchange ( typedArray, index, expectedValue, replacementValue ), https://tc39.es/ecma262/#sec-atomics.compareexchange
 template<typename T>
 static ThrowCompletionOr<Value> atomic_compare_exchange_impl(VM& vm, TypedArrayBase& typed_array)
 {
@@ -331,7 +331,7 @@ static ThrowCompletionOr<Value> atomic_compare_exchange_impl(VM& vm, TypedArrayB
     return raw_bytes_to_numeric<T>(vm, raw_bytes_read, is_little_endian);
 }
 
-// 25.4.5 Atomics.compareExchange ( typedArray, index, expectedValue, replacementValue ), https://tc39.es/ecma262/#sec-atomics.compareexchange
+// 25.4.6 Atomics.compareExchange ( typedArray, index, expectedValue, replacementValue ), https://tc39.es/ecma262/#sec-atomics.compareexchange
 JS_DEFINE_NATIVE_FUNCTION(AtomicsObject::compare_exchange)
 {
     auto* typed_array = TRY(typed_array_from(vm, vm.argument(0)));
@@ -345,7 +345,7 @@ JS_DEFINE_NATIVE_FUNCTION(AtomicsObject::compare_exchange)
     VERIFY_NOT_REACHED();
 }
 
-// 25.4.6 Atomics.exchange ( typedArray, index, value ), https://tc39.es/ecma262/#sec-atomics.exchange
+// 25.4.7 Atomics.exchange ( typedArray, index, value ), https://tc39.es/ecma262/#sec-atomics.exchange
 JS_DEFINE_NATIVE_FUNCTION(AtomicsObject::exchange)
 {
     auto* typed_array = TRY(typed_array_from(vm, vm.argument(0)));
@@ -361,7 +361,7 @@ JS_DEFINE_NATIVE_FUNCTION(AtomicsObject::exchange)
     VERIFY_NOT_REACHED();
 }
 
-// 25.4.7 Atomics.isLockFree ( size ), https://tc39.es/ecma262/#sec-atomics.islockfree
+// 25.4.8 Atomics.isLockFree ( size ), https://tc39.es/ecma262/#sec-atomics.islockfree
 JS_DEFINE_NATIVE_FUNCTION(AtomicsObject::is_lock_free)
 {
     auto size = TRY(vm.argument(0).to_integer_or_infinity(vm));
@@ -376,7 +376,7 @@ JS_DEFINE_NATIVE_FUNCTION(AtomicsObject::is_lock_free)
     return Value(false);
 }
 
-// 25.4.8 Atomics.load ( typedArray, index ), https://tc39.es/ecma262/#sec-atomics.load
+// 25.4.9 Atomics.load ( typedArray, index ), https://tc39.es/ecma262/#sec-atomics.load
 JS_DEFINE_NATIVE_FUNCTION(AtomicsObject::load)
 {
     // 1. Let buffer be ? ValidateIntegerTypedArray(typedArray).
@@ -397,7 +397,7 @@ JS_DEFINE_NATIVE_FUNCTION(AtomicsObject::load)
     return typed_array->get_value_from_buffer(indexed_position, ArrayBuffer::Order::SeqCst, true);
 }
 
-// 25.4.9 Atomics.or ( typedArray, index, value ), https://tc39.es/ecma262/#sec-atomics.or
+// 25.4.10 Atomics.or ( typedArray, index, value ), https://tc39.es/ecma262/#sec-atomics.or
 JS_DEFINE_NATIVE_FUNCTION(AtomicsObject::or_)
 {
     auto* typed_array = TRY(typed_array_from(vm, vm.argument(0)));
@@ -413,7 +413,7 @@ JS_DEFINE_NATIVE_FUNCTION(AtomicsObject::or_)
     VERIFY_NOT_REACHED();
 }
 
-// 25.4.10 Atomics.store ( typedArray, index, value ), https://tc39.es/ecma262/#sec-atomics.store
+// 25.4.11 Atomics.store ( typedArray, index, value ), https://tc39.es/ecma262/#sec-atomics.store
 JS_DEFINE_NATIVE_FUNCTION(AtomicsObject::store)
 {
     // 1. Let buffer be ? ValidateIntegerTypedArray(typedArray).
@@ -447,7 +447,7 @@ JS_DEFINE_NATIVE_FUNCTION(AtomicsObject::store)
     return value_to_set;
 }
 
-// 25.4.11 Atomics.sub ( typedArray, index, value ), https://tc39.es/ecma262/#sec-atomics.sub
+// 25.4.12 Atomics.sub ( typedArray, index, value ), https://tc39.es/ecma262/#sec-atomics.sub
 JS_DEFINE_NATIVE_FUNCTION(AtomicsObject::sub)
 {
     auto* typed_array = TRY(typed_array_from(vm, vm.argument(0)));
@@ -532,7 +532,7 @@ JS_DEFINE_NATIVE_FUNCTION(AtomicsObject::notify)
     return vm.throw_completion<InternalError>(ErrorType::NotImplemented, "SharedArrayBuffer"sv);
 }
 
-// 25.4.14 Atomics.xor ( typedArray, index, value ), https://tc39.es/ecma262/#sec-atomics.xor
+// 25.4.16 Atomics.xor ( typedArray, index, value ), https://tc39.es/ecma262/#sec-atomics.xor
 JS_DEFINE_NATIVE_FUNCTION(AtomicsObject::xor_)
 {
     auto* typed_array = TRY(typed_array_from(vm, vm.argument(0)));

--- a/Userland/Libraries/LibJS/Runtime/AtomicsObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AtomicsObject.cpp
@@ -27,89 +27,118 @@ namespace JS {
 
 JS_DEFINE_ALLOCATOR(AtomicsObject);
 
-// 25.4.2.1 ValidateIntegerTypedArray ( typedArray [ , waitable ] ), https://tc39.es/ecma262/#sec-validateintegertypedarray
-static ThrowCompletionOr<ArrayBuffer*> validate_integer_typed_array(VM& vm, TypedArrayBase& typed_array, bool waitable = false)
+// 25.4.2.1 ValidateIntegerTypedArray ( typedArray, waitable ), https://tc39.es/ecma262/#sec-validateintegertypedarray
+static ThrowCompletionOr<TypedArrayWithBufferWitness> validate_integer_typed_array(VM& vm, TypedArrayBase const& typed_array, bool waitable)
 {
-    // 1. If waitable is not present, set waitable to false.
+    // 1. Let taRecord be ? ValidateTypedArray(typedArray, unordered).
+    auto typed_array_record = TRY(validate_typed_array(vm, typed_array, ArrayBuffer::Order::Unordered));
 
-    // 2. Perform ? ValidateTypedArray(typedArray).
-    TRY(validate_typed_array(vm, typed_array));
-
-    // 3. Let buffer be typedArray.[[ViewedArrayBuffer]].
-    auto* buffer = typed_array.viewed_array_buffer();
+    // 2. NOTE: Bounds checking is not a synchronizing operation when typedArray's backing buffer is a growable SharedArrayBuffer.
 
     auto const& type_name = typed_array.element_name();
 
-    // 4. If waitable is true, then
+    // 3. If waitable is true, then
     if (waitable) {
-        // a. If typedArray.[[TypedArrayName]] is not "Int32Array" or "BigInt64Array", throw a TypeError exception.
+        // a. If typedArray.[[TypedArrayName]] is neither "Int32Array" nor "BigInt64Array", throw a TypeError exception.
         if ((type_name != vm.names.Int32Array.as_string()) && (type_name != vm.names.BigInt64Array.as_string()))
             return vm.throw_completion<TypeError>(ErrorType::TypedArrayTypeIsNot, type_name, "Int32 or BigInt64"sv);
     }
-    // 5. Else,
+    // 4. Else,
     else {
         // a. Let type be TypedArrayElementType(typedArray).
+
         // b. If IsUnclampedIntegerElementType(type) is false and IsBigIntElementType(type) is false, throw a TypeError exception.
         if (!typed_array.is_unclamped_integer_element_type() && !typed_array.is_bigint_element_type())
             return vm.throw_completion<TypeError>(ErrorType::TypedArrayTypeIsNot, type_name, "an unclamped integer or BigInt"sv);
     }
 
-    // 6. Return buffer.
-    return buffer;
+    // 5. Return taRecord.
+    return typed_array_record;
 }
 
-// 25.4.2.2 ValidateAtomicAccess ( typedArray, requestIndex ), https://tc39.es/ecma262/#sec-validateatomicaccess
-static ThrowCompletionOr<size_t> validate_atomic_access(VM& vm, TypedArrayBase& typed_array, Value request_index)
+// 25.4.2.2 ValidateAtomicAccess ( taRecord, requestIndex ), https://tc39.es/ecma262/#sec-validateatomicaccess
+static ThrowCompletionOr<size_t> validate_atomic_access(VM& vm, TypedArrayWithBufferWitness const& typed_array_record, Value request_index)
 {
-    // 1. Let length be typedArray.[[ArrayLength]].
-    auto length = typed_array.array_length();
+    // 1. Let length be TypedArrayLength(taRecord).
+    auto length = typed_array_length(typed_array_record);
 
     // 2. Let accessIndex be ? ToIndex(requestIndex).
-    auto access_index = TRY(request_index.to_index(vm));
-
     // 3. Assert: accessIndex ≥ 0.
+    auto access_index = TRY(request_index.to_index(vm));
 
     // 4. If accessIndex ≥ length, throw a RangeError exception.
     if (access_index >= length)
-        return vm.throw_completion<RangeError>(ErrorType::IndexOutOfRange, access_index, typed_array.array_length());
+        return vm.throw_completion<RangeError>(ErrorType::IndexOutOfRange, access_index, length);
 
-    // 5. Let elementSize be TypedArrayElementSize(typedArray).
+    // 5. Let typedArray be taRecord.[[Object]].
+    auto const& typed_array = *typed_array_record.object;
+
+    // 6. Let elementSize be TypedArrayElementSize(typedArray).
     auto element_size = typed_array.element_size();
 
-    // 6. Let offset be typedArray.[[ByteOffset]].
+    // 7. Let offset be typedArray.[[ByteOffset]].
     auto offset = typed_array.byte_offset();
 
-    // 7. Return (accessIndex × elementSize) + offset.
+    // 8. Return (accessIndex × elementSize) + offset.
     return (access_index * element_size) + offset;
+}
+
+// 25.4.3.3 ValidateAtomicAccessOnIntegerTypedArray ( typedArray, requestIndex [ , waitable ] ), https://tc39.es/ecma262/#sec-validateatomicaccessonintegertypedarray
+static ThrowCompletionOr<size_t> validate_atomic_access_on_integer_typed_array(VM& vm, TypedArrayBase const& typed_array, Value request_index, bool waitable = false)
+{
+    // 1. If waitable is not present, set waitable to false.
+
+    // 2. Let taRecord be ? ValidateIntegerTypedArray(typedArray, waitable).
+    auto typed_array_record = TRY(validate_integer_typed_array(vm, typed_array, waitable));
+
+    // 3. Return ? ValidateAtomicAccess(taRecord, requestIndex).
+    return TRY(validate_atomic_access(vm, typed_array_record, request_index));
+}
+
+// 25.4.3.4 RevalidateAtomicAccess ( typedArray, byteIndexInBuffer ), https://tc39.es/ecma262/#sec-revalidateatomicaccess
+static ThrowCompletionOr<void> revalidate_atomic_access(VM& vm, TypedArrayBase const& typed_array, size_t byte_index_in_buffer)
+{
+    // 1. Let taRecord be MakeTypedArrayWithBufferWitnessRecord(typedArray, unordered).
+    auto typed_array_record = make_typed_array_with_buffer_witness_record(typed_array, ArrayBuffer::Order::Unordered);
+
+    // 2. NOTE: Bounds checking is not a synchronizing operation when typedArray's backing buffer is a growable SharedArrayBuffer.
+    // 3. If IsTypedArrayOutOfBounds(taRecord) is true, throw a TypeError exception.
+    if (is_typed_array_out_of_bounds(typed_array_record))
+        return vm.throw_completion<TypeError>(ErrorType::BufferOutOfBounds, "TypedArray"sv);
+
+    // 4. Assert: byteIndexInBuffer ≥ typedArray.[[ByteOffset]].
+    VERIFY(byte_index_in_buffer >= typed_array.byte_offset());
+
+    // 5. If byteIndexInBuffer ≥ taRecord.[[CachedBufferByteLength]], throw a RangeError exception.
+    if (byte_index_in_buffer >= typed_array_record.cached_buffer_byte_length.length())
+        return vm.throw_completion<RangeError>(ErrorType::IndexOutOfRange, byte_index_in_buffer, typed_array_record.cached_buffer_byte_length.length());
+
+    // 6. Return unused.
+    return {};
 }
 
 // 25.4.2.17 AtomicReadModifyWrite ( typedArray, index, value, op ), https://tc39.es/ecma262/#sec-atomicreadmodifywrite
 static ThrowCompletionOr<Value> atomic_read_modify_write(VM& vm, TypedArrayBase& typed_array, Value index, Value value, ReadWriteModifyFunction operation)
 {
-    // 1. Let buffer be ? ValidateIntegerTypedArray(typedArray).
-    auto* buffer = TRY(validate_integer_typed_array(vm, typed_array));
-
-    // 2. Let indexedPosition be ? ValidateAtomicAccess(typedArray, index).
-    auto indexed_position = TRY(validate_atomic_access(vm, typed_array, index));
+    // 1. Let byteIndexInBuffer be ? ValidateAtomicAccessOnIntegerTypedArray(typedArray, index).
+    auto byte_index_in_buffer = TRY(validate_atomic_access_on_integer_typed_array(vm, typed_array, index));
 
     Value value_to_set;
 
-    // 3. If typedArray.[[ContentType]] is BigInt, let v be ? ToBigInt(value).
+    // 2. If typedArray.[[ContentType]] is bigint, let v be ? ToBigInt(value).
     if (typed_array.content_type() == TypedArrayBase::ContentType::BigInt)
         value_to_set = TRY(value.to_bigint(vm));
-    // 4. Otherwise, let v be 𝔽(? ToIntegerOrInfinity(value)).
+    // 3. Otherwise, let v be 𝔽(? ToIntegerOrInfinity(value)).
     else
         value_to_set = Value(TRY(value.to_integer_or_infinity(vm)));
 
-    // 5. If IsDetachedBuffer(buffer) is true, throw a TypeError exception.
-    if (buffer->is_detached())
-        return vm.throw_completion<TypeError>(ErrorType::DetachedArrayBuffer);
+    // 4. Perform ? RevalidateAtomicAccess(typedArray, byteIndexInBuffer).
+    TRY(revalidate_atomic_access(vm, typed_array, byte_index_in_buffer));
 
-    // 6. NOTE: The above check is not redundant with the check in ValidateIntegerTypedArray because the call to ToBigInt or ToIntegerOrInfinity on the preceding lines can have arbitrary side effects, which could cause the buffer to become detached.
-
-    // 7. Let elementType be TypedArrayElementType(typedArray).
-    // 8. Return GetModifySetValueInBuffer(buffer, indexedPosition, elementType, v, op).
-    return typed_array.get_modify_set_value_in_buffer(indexed_position, value_to_set, move(operation));
+    // 5. Let buffer be typedArray.[[ViewedArrayBuffer]].
+    // 6. Let elementType be TypedArrayElementType(typedArray).
+    // 7. Return GetModifySetValueInBuffer(buffer, byteIndexInBuffer, elementType, v, op).
+    return typed_array.get_modify_set_value_in_buffer(byte_index_in_buffer, value_to_set, move(operation));
 }
 
 enum class WaitMode {
@@ -120,17 +149,18 @@ enum class WaitMode {
 // 25.4.3.14 DoWait ( mode, typedArray, index, value, timeout ), https://tc39.es/ecma262/#sec-dowait
 static ThrowCompletionOr<Value> do_wait(VM& vm, WaitMode mode, TypedArrayBase& typed_array, Value index_value, Value expected_value, Value timeout_value)
 {
-    // 1. Let iieoRecord be ? ValidateIntegerTypedArray(typedArray, true).
-    // 2. Let buffer be iieoRecord.[[Object]].[[ViewedArrayBuffer]].
-    // FIXME: An IIEO record is a new structure from the resizable array buffer proposal. Use it when the proposal is implemented.
-    auto* buffer = TRY(validate_integer_typed_array(vm, typed_array, true));
+    // 1. Let taRecord be ? ValidateIntegerTypedArray(typedArray, true).
+    auto typed_array_record = TRY(validate_integer_typed_array(vm, typed_array, true));
+
+    // 2. Let buffer be taRecord.[[Object]].[[ViewedArrayBuffer]].
+    auto* buffer = typed_array_record.object->viewed_array_buffer();
 
     // 3. If IsSharedArrayBuffer(buffer) is false, throw a TypeError exception.
     if (!buffer->is_shared_array_buffer())
         return vm.throw_completion<TypeError>(ErrorType::NotASharedArrayBuffer);
 
-    // 4. Let i be ? ValidateAtomicAccess(iieoRecord, index).
-    auto index = TRY(validate_atomic_access(vm, typed_array, index_value));
+    // 4. Let i be ? ValidateAtomicAccess(taRecord, index).
+    auto index = TRY(validate_atomic_access(vm, typed_array_record, index_value));
 
     // 5. Let arrayTypeName be typedArray.[[TypedArrayName]].
     auto const& array_type_name = typed_array.element_name();
@@ -254,80 +284,77 @@ JS_DEFINE_NATIVE_FUNCTION(AtomicsObject::and_)
 
 // 25.4.6 Atomics.compareExchange ( typedArray, index, expectedValue, replacementValue ), https://tc39.es/ecma262/#sec-atomics.compareexchange
 template<typename T>
-static ThrowCompletionOr<Value> atomic_compare_exchange_impl(VM& vm, TypedArrayBase& typed_array)
+static ThrowCompletionOr<Value> atomic_compare_exchange_impl(VM& vm, TypedArrayBase& typed_array, Value index, Value expected_value, Value replacement_value)
 {
-    // 1. Let buffer be ? ValidateIntegerTypedArray(typedArray).
-    auto* buffer = TRY(validate_integer_typed_array(vm, typed_array));
+    // 1. Let byteIndexInBuffer be ? ValidateAtomicAccessOnIntegerTypedArray(typedArray, index).
+    auto byte_index_in_buffer = TRY(validate_atomic_access_on_integer_typed_array(vm, typed_array, index));
 
-    // 2. Let block be buffer.[[ArrayBufferData]].
+    // 2. Let buffer be typedArray.[[ViewedArrayBuffer]].
+    auto* buffer = typed_array.viewed_array_buffer();
+
+    // 3. Let block be buffer.[[ArrayBufferData]].
     auto& block = buffer->buffer();
-
-    // 3. Let indexedPosition be ? ValidateAtomicAccess(typedArray, index).
-    auto indexed_position = TRY(validate_atomic_access(vm, typed_array, vm.argument(1)));
 
     Value expected;
     Value replacement;
 
-    // 4. If typedArray.[[ContentType]] is BigInt, then
+    // 4. If typedArray.[[ContentType]] is bigint, then
     if (typed_array.content_type() == TypedArrayBase::ContentType::BigInt) {
         // a. Let expected be ? ToBigInt(expectedValue).
-        expected = TRY(vm.argument(2).to_bigint(vm));
+        expected = TRY(expected_value.to_bigint(vm));
 
         // b. Let replacement be ? ToBigInt(replacementValue).
-        replacement = TRY(vm.argument(3).to_bigint(vm));
+        replacement = TRY(replacement_value.to_bigint(vm));
     }
     // 5. Else,
     else {
         // a. Let expected be 𝔽(? ToIntegerOrInfinity(expectedValue)).
-        expected = Value(TRY(vm.argument(2).to_integer_or_infinity(vm)));
+        expected = Value(TRY(expected_value.to_integer_or_infinity(vm)));
 
         // b. Let replacement be 𝔽(? ToIntegerOrInfinity(replacementValue)).
-        replacement = Value(TRY(vm.argument(3).to_integer_or_infinity(vm)));
+        replacement = Value(TRY(replacement_value.to_integer_or_infinity(vm)));
     }
 
-    // 6. If IsDetachedBuffer(buffer) is true, throw a TypeError exception.
-    if (buffer->is_detached())
-        return vm.template throw_completion<TypeError>(ErrorType::DetachedArrayBuffer);
+    // 6. Perform ? RevalidateAtomicAccess(typedArray, byteIndexInBuffer).
+    TRY(revalidate_atomic_access(vm, typed_array, byte_index_in_buffer));
 
-    // 7. NOTE: The above check is not redundant with the check in ValidateIntegerTypedArray because the call to ToBigInt or ToIntegerOrInfinity on the preceding lines can have arbitrary side effects, which could cause the buffer to become detached.
+    // 7. Let elementType be TypedArrayElementType(typedArray).
+    // 8. Let elementSize be TypedArrayElementSize(typedArray).
 
-    // 8. Let elementType be TypedArrayElementType(typedArray).
-    // 9. Let elementSize be TypedArrayElementSize(typedArray).
+    // 9. Let isLittleEndian be the value of the [[LittleEndian]] field of the surrounding agent's Agent Record.
+    static constexpr bool is_little_endian = AK::HostIsLittleEndian;
 
-    // 10. Let isLittleEndian be the value of the [[LittleEndian]] field of the surrounding agent's Agent Record.
-    constexpr bool is_little_endian = AK::HostIsLittleEndian;
-
-    // 11. Let expectedBytes be NumericToRawBytes(elementType, expected, isLittleEndian).
+    // 10. Let expectedBytes be NumericToRawBytes(elementType, expected, isLittleEndian).
     auto expected_bytes = MUST(ByteBuffer::create_uninitialized(sizeof(T)));
     numeric_to_raw_bytes<T>(vm, expected, is_little_endian, expected_bytes);
 
-    // 12. Let replacementBytes be NumericToRawBytes(elementType, replacement, isLittleEndian).
+    // 11. Let replacementBytes be NumericToRawBytes(elementType, replacement, isLittleEndian).
     auto replacement_bytes = MUST(ByteBuffer::create_uninitialized(sizeof(T)));
     numeric_to_raw_bytes<T>(vm, replacement, is_little_endian, replacement_bytes);
 
     // FIXME: Implement SharedArrayBuffer case.
-    // 13. If IsSharedArrayBuffer(buffer) is true, then
-    //     a-i.
-    // 14. Else,
+    // 12. If IsSharedArrayBuffer(buffer) is true, then
+    //     a. Let rawBytesRead be AtomicCompareExchangeInSharedBlock(block, byteIndexInBuffer, elementSize, expectedBytes, replacementBytes).
+    // 13. Else,
 
-    // a. Let rawBytesRead be a List of length elementSize whose elements are the sequence of elementSize bytes starting with block[indexedPosition].
+    // a. Let rawBytesRead be a List of length elementSize whose elements are the sequence of elementSize bytes starting with block[byteIndexInBuffer].
     // FIXME: Propagate errors.
-    auto raw_bytes_read = MUST(block.slice(indexed_position, sizeof(T)));
+    auto raw_bytes_read = MUST(block.slice(byte_index_in_buffer, sizeof(T)));
 
     // b. If ByteListEqual(rawBytesRead, expectedBytes) is true, then
-    //    i. Store the individual bytes of replacementBytes into block, starting at block[indexedPosition].
+    //    i. Store the individual bytes of replacementBytes into block, starting at block[byteIndexInBuffer].
     if constexpr (IsFloatingPoint<T>) {
         VERIFY_NOT_REACHED();
     } else {
         using U = Conditional<IsSame<ClampedU8, T>, u8, T>;
 
-        auto* v = reinterpret_cast<U*>(block.span().slice(indexed_position).data());
+        auto* v = reinterpret_cast<U*>(block.span().slice(byte_index_in_buffer).data());
         auto* e = reinterpret_cast<U*>(expected_bytes.data());
         auto* r = reinterpret_cast<U*>(replacement_bytes.data());
         (void)AK::atomic_compare_exchange_strong(v, *e, *r);
     }
 
-    // 15. Return RawBytesToNumeric(elementType, rawBytesRead, isLittleEndian).
+    // 14. Return RawBytesToNumeric(elementType, rawBytesRead, isLittleEndian).
     return raw_bytes_to_numeric<T>(vm, raw_bytes_read, is_little_endian);
 }
 
@@ -335,10 +362,13 @@ static ThrowCompletionOr<Value> atomic_compare_exchange_impl(VM& vm, TypedArrayB
 JS_DEFINE_NATIVE_FUNCTION(AtomicsObject::compare_exchange)
 {
     auto* typed_array = TRY(typed_array_from(vm, vm.argument(0)));
+    auto index = vm.argument(1);
+    auto expected_value = vm.argument(2);
+    auto replacement_value = vm.argument(3);
 
 #define __JS_ENUMERATE(ClassName, snake_name, PrototypeName, ConstructorName, Type) \
     if (is<ClassName>(typed_array))                                                 \
-        return TRY(atomic_compare_exchange_impl<Type>(vm, *typed_array));
+        return TRY(atomic_compare_exchange_impl<Type>(vm, *typed_array, index, expected_value, replacement_value));
     JS_ENUMERATE_TYPED_ARRAYS
 #undef __JS_ENUMERATE
 
@@ -379,22 +409,19 @@ JS_DEFINE_NATIVE_FUNCTION(AtomicsObject::is_lock_free)
 // 25.4.9 Atomics.load ( typedArray, index ), https://tc39.es/ecma262/#sec-atomics.load
 JS_DEFINE_NATIVE_FUNCTION(AtomicsObject::load)
 {
-    // 1. Let buffer be ? ValidateIntegerTypedArray(typedArray).
     auto* typed_array = TRY(typed_array_from(vm, vm.argument(0)));
-    TRY(validate_integer_typed_array(vm, *typed_array));
+    auto index = vm.argument(1);
 
-    // 2. Let indexedPosition be ? ValidateAtomicAccess(typedArray, index).
-    auto indexed_position = TRY(validate_atomic_access(vm, *typed_array, vm.argument(1)));
+    // 1. Let byteIndexInBuffer be ? ValidateAtomicAccessOnIntegerTypedArray(typedArray, index).
+    auto byte_index_in_buffer = TRY(validate_atomic_access_on_integer_typed_array(vm, *typed_array, index));
 
-    // 3. If IsDetachedBuffer(buffer) is true, throw a TypeError exception.
-    if (typed_array->viewed_array_buffer()->is_detached())
-        return vm.throw_completion<TypeError>(ErrorType::DetachedArrayBuffer);
+    // 2. Perform ? RevalidateAtomicAccess(typedArray, byteIndexInBuffer).
+    TRY(revalidate_atomic_access(vm, *typed_array, byte_index_in_buffer));
 
-    // 4. NOTE: The above check is not redundant with the check in ValidateIntegerTypedArray because the call to ValidateAtomicAccess on the preceding line can have arbitrary side effects, which could cause the buffer to become detached.
-
-    // 5. Let elementType be TypedArrayElementType(typedArray).
-    // 6. Return GetValueFromBuffer(buffer, indexedPosition, elementType, true, SeqCst).
-    return typed_array->get_value_from_buffer(indexed_position, ArrayBuffer::Order::SeqCst, true);
+    // 3. Let buffer be typedArray.[[ViewedArrayBuffer]].
+    // 4. Let elementType be TypedArrayElementType(typedArray).
+    // 5. Return GetValueFromBuffer(buffer, byteIndexInBuffer, elementType, true, seq-cst).
+    return typed_array->get_value_from_buffer(byte_index_in_buffer, ArrayBuffer::Order::SeqCst, true);
 }
 
 // 25.4.10 Atomics.or ( typedArray, index, value ), https://tc39.es/ecma262/#sec-atomics.or
@@ -416,35 +443,30 @@ JS_DEFINE_NATIVE_FUNCTION(AtomicsObject::or_)
 // 25.4.11 Atomics.store ( typedArray, index, value ), https://tc39.es/ecma262/#sec-atomics.store
 JS_DEFINE_NATIVE_FUNCTION(AtomicsObject::store)
 {
-    // 1. Let buffer be ? ValidateIntegerTypedArray(typedArray).
     auto* typed_array = TRY(typed_array_from(vm, vm.argument(0)));
-    TRY(validate_integer_typed_array(vm, *typed_array));
-
-    // 2. Let indexedPosition be ? ValidateAtomicAccess(typedArray, index).
-    auto indexed_position = TRY(validate_atomic_access(vm, *typed_array, vm.argument(1)));
-
+    auto index = vm.argument(1);
     auto value = vm.argument(2);
-    Value value_to_set;
 
-    // 3. If typedArray.[[ContentType]] is BigInt, let v be ? ToBigInt(value).
+    // 1. Let byteIndexInBuffer be ? ValidateAtomicAccessOnIntegerTypedArray(typedArray, index).
+    auto byte_index_in_buffer = TRY(validate_atomic_access_on_integer_typed_array(vm, *typed_array, index));
+
+    // 2. If typedArray.[[ContentType]] is bigint, let v be ? ToBigInt(value).
     if (typed_array->content_type() == TypedArrayBase::ContentType::BigInt)
-        value_to_set = TRY(value.to_bigint(vm));
-    // 4. Otherwise, let v be 𝔽(? ToIntegerOrInfinity(value)).
+        value = TRY(value.to_bigint(vm));
+    // 3. Otherwise, let v be 𝔽(? ToIntegerOrInfinity(value)).
     else
-        value_to_set = Value(TRY(value.to_integer_or_infinity(vm)));
+        value = Value(TRY(value.to_integer_or_infinity(vm)));
 
-    // 5. If IsDetachedBuffer(buffer) is true, throw a TypeError exception.
-    if (typed_array->viewed_array_buffer()->is_detached())
-        return vm.throw_completion<TypeError>(ErrorType::DetachedArrayBuffer);
+    // 4. Perform ? RevalidateAtomicAccess(typedArray, byteIndexInBuffer).
+    TRY(revalidate_atomic_access(vm, *typed_array, byte_index_in_buffer));
 
-    // 6. NOTE: The above check is not redundant with the check in ValidateIntegerTypedArray because the call to ToBigInt or ToIntegerOrInfinity on the preceding lines can have arbitrary side effects, which could cause the buffer to become detached.
+    // 5. Let buffer be typedArray.[[ViewedArrayBuffer]].
+    // 6. Let elementType be TypedArrayElementType(typedArray).
+    // 7. Perform SetValueInBuffer(buffer, byteIndexInBuffer, elementType, v, true, seq-cst).
+    typed_array->set_value_in_buffer(byte_index_in_buffer, value, ArrayBuffer::Order::SeqCst, true);
 
-    // 7. Let elementType be TypedArrayElementType(typedArray).
-    // 8. Perform SetValueInBuffer(buffer, indexedPosition, elementType, v, true, SeqCst).
-    typed_array->set_value_in_buffer(indexed_position, value_to_set, ArrayBuffer::Order::SeqCst, true);
-
-    // 9. Return v.
-    return value_to_set;
+    // 8. Return v.
+    return value;
 }
 
 // 25.4.12 Atomics.sub ( typedArray, index, value ), https://tc39.es/ecma262/#sec-atomics.sub
@@ -495,9 +517,7 @@ JS_DEFINE_NATIVE_FUNCTION(AtomicsObject::notify)
     auto count_value = vm.argument(2);
 
     // 1. Let byteIndexInBuffer be ? ValidateAtomicAccessOnIntegerTypedArray(typedArray, index, true).
-    // FIXME: ValidateAtomicAccessOnIntegerTypedArray is a new AO from the resizable array buffer proposal. Use it when the proposal is implemented.
-    TRY(validate_integer_typed_array(vm, *typed_array, true));
-    auto byte_index_in_buffer = TRY(validate_atomic_access(vm, *typed_array, index));
+    auto byte_index_in_buffer = TRY(validate_atomic_access_on_integer_typed_array(vm, *typed_array, index, true));
 
     // 2. If count is undefined, then
     double count = 0.0;

--- a/Userland/Libraries/LibJS/Runtime/ByteLength.h
+++ b/Userland/Libraries/LibJS/Runtime/ByteLength.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2023, Tim Flynn <trflynn89@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Types.h>
+#include <AK/Variant.h>
+
+namespace JS {
+
+class ByteLength {
+public:
+    static ByteLength auto_() { return { Auto {} }; }
+    static ByteLength detached() { return { Detached {} }; }
+
+    ByteLength(u32 length)
+        : m_length(length)
+    {
+    }
+
+    bool is_auto() const { return m_length.has<Auto>(); }
+    bool is_detached() const { return m_length.has<Detached>(); }
+
+    u32 length() const
+    {
+        VERIFY(m_length.has<u32>());
+        return m_length.get<u32>();
+    }
+
+private:
+    struct Auto { };
+    struct Detached { };
+
+    using Length = Variant<Auto, Detached, u32>;
+
+    ByteLength(Length length)
+        : m_length(move(length))
+    {
+    }
+
+    Length m_length;
+};
+
+}

--- a/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
+++ b/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
@@ -351,6 +351,7 @@ namespace JS {
     P(leftContext)                           \
     P(map)                                   \
     P(max)                                   \
+    P(maxByteLength)                         \
     P(maximize)                              \
     P(mergeFields)                           \
     P(message)                               \
@@ -426,6 +427,8 @@ namespace JS {
     P(reject)                                \
     P(relativeTo)                            \
     P(repeat)                                \
+    P(resizable)                             \
+    P(resize)                                \
     P(resolve)                               \
     P(resolvedOptions)                       \
     P(reverse)                               \

--- a/Userland/Libraries/LibJS/Runtime/DataView.cpp
+++ b/Userland/Libraries/LibJS/Runtime/DataView.cpp
@@ -10,15 +10,15 @@ namespace JS {
 
 JS_DEFINE_ALLOCATOR(DataView);
 
-NonnullGCPtr<DataView> DataView::create(Realm& realm, ArrayBuffer* viewed_buffer, size_t byte_length, size_t byte_offset)
+NonnullGCPtr<DataView> DataView::create(Realm& realm, ArrayBuffer* viewed_buffer, ByteLength byte_length, size_t byte_offset)
 {
-    return realm.heap().allocate<DataView>(realm, viewed_buffer, byte_length, byte_offset, realm.intrinsics().data_view_prototype());
+    return realm.heap().allocate<DataView>(realm, viewed_buffer, move(byte_length), byte_offset, realm.intrinsics().data_view_prototype());
 }
 
-DataView::DataView(ArrayBuffer* viewed_buffer, size_t byte_length, size_t byte_offset, Object& prototype)
+DataView::DataView(ArrayBuffer* viewed_buffer, ByteLength byte_length, size_t byte_offset, Object& prototype)
     : Object(ConstructWithPrototypeTag::Tag, prototype)
     , m_viewed_array_buffer(viewed_buffer)
-    , m_byte_length(byte_length)
+    , m_byte_length(move(byte_length))
     , m_byte_offset(byte_offset)
 {
 }
@@ -27,6 +27,98 @@ void DataView::visit_edges(Visitor& visitor)
 {
     Base::visit_edges(visitor);
     visitor.visit(m_viewed_array_buffer);
+}
+
+// 25.3.1.2 MakeDataViewWithBufferWitnessRecord ( obj, order ), https://tc39.es/ecma262/#sec-makedataviewwithbufferwitnessrecord
+DataViewWithBufferWitness make_data_view_with_buffer_witness_record(DataView const& data_view, ArrayBuffer::Order order)
+{
+    // 1. Let buffer be obj.[[ViewedArrayBuffer]].
+    auto* buffer = data_view.viewed_array_buffer();
+
+    ByteLength byte_length { 0 };
+
+    // 2. If IsDetachedBuffer(buffer) is true, then
+    if (buffer->is_detached()) {
+        // a. Let byteLength be detached.
+        byte_length = ByteLength::detached();
+    }
+    // 3. Else,
+    else {
+        // a. Let byteLength be ArrayBufferByteLength(buffer, order).
+        byte_length = array_buffer_byte_length(*buffer, order);
+    }
+
+    // 4. Return the DataView With Buffer Witness Record { [[Object]]: obj, [[CachedBufferByteLength]]: byteLength }.
+    return { .object = data_view, .cached_buffer_byte_length = move(byte_length) };
+}
+
+// 25.3.1.3 GetViewByteLength ( viewRecord ), https://tc39.es/ecma262/#sec-getviewbytelength
+u32 get_view_byte_length(DataViewWithBufferWitness const& view_record)
+{
+    // 1. Assert: IsViewOutOfBounds(viewRecord) is false.
+    VERIFY(!is_view_out_of_bounds(view_record));
+
+    // 2. Let view be viewRecord.[[Object]].
+    auto const& view = *view_record.object;
+
+    // 3. If view.[[ByteLength]] is not auto, return view.[[ByteLength]].
+    if (!view.byte_length().is_auto())
+        return view.byte_length().length();
+
+    // 4. Assert: IsFixedLengthArrayBuffer(view.[[ViewedArrayBuffer]]) is false.
+    VERIFY(!view.viewed_array_buffer()->is_fixed_length());
+
+    // 5. Let byteOffset be view.[[ByteOffset]].
+    auto byte_offset = view.byte_offset();
+
+    // 6. Let byteLength be viewRecord.[[CachedBufferByteLength]].
+    auto const& byte_length = view_record.cached_buffer_byte_length;
+
+    // 7. Assert: byteLength is not detached.
+    VERIFY(!byte_length.is_detached());
+
+    // 8. Return byteLength - byteOffset.
+    return byte_length.length() - byte_offset;
+}
+
+// 25.3.1.4 IsViewOutOfBounds ( viewRecord ), https://tc39.es/ecma262/#sec-isviewoutofbounds
+bool is_view_out_of_bounds(DataViewWithBufferWitness const& view_record)
+{
+    // 1. Let view be viewRecord.[[Object]].
+    auto const& view = *view_record.object;
+
+    // 2. Let bufferByteLength be viewRecord.[[CachedBufferByteLength]].
+    auto const& buffer_byte_length = view_record.cached_buffer_byte_length;
+
+    // 3. Assert: IsDetachedBuffer(view.[[ViewedArrayBuffer]]) is true if and only if bufferByteLength is detached.
+    VERIFY(view.viewed_array_buffer()->is_detached() == buffer_byte_length.is_detached());
+
+    // 4. If bufferByteLength is detached, return true.
+    if (buffer_byte_length.is_detached())
+        return true;
+
+    // 5. Let byteOffsetStart be view.[[ByteOffset]].
+    auto byte_offset_start = view.byte_offset();
+    u32 byte_offset_end = 0;
+
+    // 6. If view.[[ByteLength]] is auto, then
+    if (view.byte_length().is_auto()) {
+        // a. Let byteOffsetEnd be bufferByteLength.
+        byte_offset_end = buffer_byte_length.length();
+    }
+    // 7. Else,
+    else {
+        // a. Let byteOffsetEnd be byteOffsetStart + view.[[ByteLength]].
+        byte_offset_end = byte_offset_start + view.byte_length().length();
+    }
+
+    // 8. If byteOffsetStart > bufferByteLength or byteOffsetEnd > bufferByteLength, return true.
+    if ((byte_offset_start > buffer_byte_length.length()) || (byte_offset_end > buffer_byte_length.length()))
+        return true;
+
+    // 9. NOTE: 0-length DataViews are not considered out-of-bounds.
+    // 10. Return false.
+    return false;
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/DataView.h
+++ b/Userland/Libraries/LibJS/Runtime/DataView.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <LibJS/Runtime/ArrayBuffer.h>
+#include <LibJS/Runtime/ByteLength.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/Object.h>
 
@@ -17,22 +18,32 @@ class DataView : public Object {
     JS_DECLARE_ALLOCATOR(DataView);
 
 public:
-    static NonnullGCPtr<DataView> create(Realm&, ArrayBuffer*, size_t byte_length, size_t byte_offset);
+    static NonnullGCPtr<DataView> create(Realm&, ArrayBuffer*, ByteLength byte_length, size_t byte_offset);
 
     virtual ~DataView() override = default;
 
     ArrayBuffer* viewed_array_buffer() const { return m_viewed_array_buffer; }
-    size_t byte_length() const { return m_byte_length; }
+    ByteLength const& byte_length() const { return m_byte_length; }
     size_t byte_offset() const { return m_byte_offset; }
 
 private:
-    DataView(ArrayBuffer*, size_t byte_length, size_t byte_offset, Object& prototype);
+    DataView(ArrayBuffer*, ByteLength byte_length, size_t byte_offset, Object& prototype);
 
     virtual void visit_edges(Visitor& visitor) override;
 
     GCPtr<ArrayBuffer> m_viewed_array_buffer;
-    size_t m_byte_length { 0 };
+    ByteLength m_byte_length { 0 };
     size_t m_byte_offset { 0 };
 };
+
+// 25.3.1.1 DataView With Buffer Witness Records, https://tc39.es/ecma262/#sec-dataview-with-buffer-witness-records
+struct DataViewWithBufferWitness {
+    NonnullGCPtr<DataView const> object;  // [[Object]]
+    ByteLength cached_buffer_byte_length; // [[CachedBufferByteLength]]
+};
+
+DataViewWithBufferWitness make_data_view_with_buffer_witness_record(DataView const&, ArrayBuffer::Order);
+u32 get_view_byte_length(DataViewWithBufferWitness const&);
+bool is_view_out_of_bounds(DataViewWithBufferWitness const&);
 
 }

--- a/Userland/Libraries/LibJS/Runtime/DataViewConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/DataViewConstructor.cpp
@@ -63,42 +63,71 @@ ThrowCompletionOr<NonnullGCPtr<Object>> DataViewConstructor::construct(FunctionO
     if (array_buffer.is_detached())
         return vm.throw_completion<TypeError>(ErrorType::DetachedArrayBuffer);
 
-    // 5. Let bufferByteLength be buffer.[[ArrayBufferByteLength]].
-    auto buffer_byte_length = array_buffer.byte_length();
+    // 5. Let bufferByteLength be ArrayBufferByteLength(buffer, seq-cst).
+    auto buffer_byte_length = array_buffer_byte_length(array_buffer, ArrayBuffer::Order::SeqCst);
 
     // 6. If offset > bufferByteLength, throw a RangeError exception.
     if (offset > buffer_byte_length)
         return vm.throw_completion<RangeError>(ErrorType::DataViewOutOfRangeByteOffset, offset, buffer_byte_length);
 
-    size_t view_byte_length;
+    // 7. Let bufferIsFixedLength be IsFixedLengthArrayBuffer(buffer).
+    auto buffer_is_fixed_length = array_buffer.is_fixed_length();
 
-    // 7. If byteLength is undefined, then
+    ByteLength view_byte_length { 0 };
+
+    // 8. If byteLength is undefined, then
     if (byte_length.is_undefined()) {
-        // a. Let viewByteLength be bufferByteLength - offset.
-        view_byte_length = buffer_byte_length - offset;
+        // a. If bufferIsFixedLength is true, then
+        if (buffer_is_fixed_length) {
+            // i. Let viewByteLength be bufferByteLength - offset.
+            view_byte_length = buffer_byte_length - offset;
+        }
+        // b. Else,
+        else {
+            // i. Let viewByteLength be auto.
+            view_byte_length = ByteLength::auto_();
+        }
     }
-    // 8. Else,
+    // 9. Else,
     else {
         // a. Let viewByteLength be ? ToIndex(byteLength).
         view_byte_length = TRY(byte_length.to_index(vm));
 
         // b. If offset + viewByteLength > bufferByteLength, throw a RangeError exception.
-        auto const checked_add = AK::make_checked(view_byte_length) + AK::make_checked(offset);
+        auto checked_add = AK::make_checked(offset) + AK::make_checked(static_cast<size_t>(view_byte_length.length()));
+
         if (checked_add.has_overflow() || checked_add.value() > buffer_byte_length)
             return vm.throw_completion<RangeError>(ErrorType::InvalidLength, vm.names.DataView);
     }
 
-    // 9. Let O be ? OrdinaryCreateFromConstructor(NewTarget, "%DataView.prototype%", « [[DataView]], [[ViewedArrayBuffer]], [[ByteLength]], [[ByteOffset]] »).
-    // 11. Set O.[[ViewedArrayBuffer]] to buffer.
-    // 12. Set O.[[ByteLength]] to viewByteLength.
-    // 13. Set O.[[ByteOffset]] to offset.
-    auto data_view = TRY(ordinary_create_from_constructor<DataView>(vm, new_target, &Intrinsics::data_view_prototype, &array_buffer, view_byte_length, offset));
+    // 10. Let O be ? OrdinaryCreateFromConstructor(NewTarget, "%DataView.prototype%", « [[DataView]], [[ViewedArrayBuffer]], [[ByteLength]], [[ByteOffset]] »).
+    auto data_view = TRY(ordinary_create_from_constructor<DataView>(vm, new_target, &Intrinsics::data_view_prototype, &array_buffer, move(view_byte_length), offset));
 
-    // 10. If IsDetachedBuffer(buffer) is true, throw a TypeError exception.
+    // 11. If IsDetachedBuffer(buffer) is true, throw a TypeError exception.
     if (array_buffer.is_detached())
         return vm.throw_completion<TypeError>(ErrorType::DetachedArrayBuffer);
 
-    // 14. Return O.
+    // 12. Set bufferByteLength to ArrayBufferByteLength(buffer, seq-cst).
+    buffer_byte_length = array_buffer_byte_length(array_buffer, ArrayBuffer::Order::SeqCst);
+
+    // 13. If offset > bufferByteLength, throw a RangeError exception.
+    if (offset > buffer_byte_length)
+        return vm.throw_completion<RangeError>(ErrorType::DataViewOutOfRangeByteOffset, offset, buffer_byte_length);
+
+    // 14. If byteLength is not undefined, then
+    if (!byte_length.is_undefined()) {
+        // a. If offset + viewByteLength > bufferByteLength, throw a RangeError exception.
+        auto checked_add = AK::make_checked(offset) + AK::make_checked(static_cast<size_t>(view_byte_length.length()));
+
+        if (checked_add.has_overflow() || checked_add.value() > buffer_byte_length)
+            return vm.throw_completion<RangeError>(ErrorType::InvalidLength, vm.names.DataView);
+    }
+
+    // 15. Set O.[[ViewedArrayBuffer]] to buffer.
+    // 16. Set O.[[ByteLength]] to viewByteLength.
+    // 17. Set O.[[ByteOffset]] to offset.
+
+    // 18. Return O.
     return data_view;
 }
 

--- a/Userland/Libraries/LibJS/Runtime/DataViewPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/DataViewPrototype.cpp
@@ -53,7 +53,7 @@ void DataViewPrototype::initialize(Realm& realm)
     define_direct_property(vm.well_known_symbol_to_string_tag(), PrimitiveString::create(vm, vm.names.DataView.as_string()), Attribute::Configurable);
 }
 
-// 25.3.1.1 GetViewValue ( view, requestIndex, isLittleEndian, type ), https://tc39.es/ecma262/#sec-getviewvalue
+// 25.3.1.5 GetViewValue ( view, requestIndex, isLittleEndian, type ), https://tc39.es/ecma262/#sec-getviewvalue
 template<typename T>
 static ThrowCompletionOr<Value> get_view_value(VM& vm, Value request_index, Value is_little_endian)
 {
@@ -98,7 +98,7 @@ static ThrowCompletionOr<Value> get_view_value(VM& vm, Value request_index, Valu
     return buffer->get_value<T>(buffer_index.value(), false, ArrayBuffer::Order::Unordered, little_endian);
 }
 
-// 25.3.1.2 SetViewValue ( view, requestIndex, isLittleEndian, type, value ), https://tc39.es/ecma262/#sec-setviewvalue
+// 25.3.1.6 SetViewValue ( view, requestIndex, isLittleEndian, type, value ), https://tc39.es/ecma262/#sec-setviewvalue
 template<typename T>
 static ThrowCompletionOr<Value> set_view_value(VM& vm, Value request_index, Value is_little_endian, Value value)
 {

--- a/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
+++ b/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
@@ -18,6 +18,7 @@
     M(BigIntFromNonIntegral, "Cannot convert non-integral number to BigInt")                                                            \
     M(BigIntInvalidValue, "Invalid value for BigInt: {}")                                                                               \
     M(BindingNotInitialized, "Binding {} is not initialized")                                                                           \
+    M(ByteLengthExceedsMaxByteLength, "ArrayBuffer byte length of {} exceeds the max byte length of {}")                                \
     M(CallStackSizeExceeded, "Call stack size limit exceeded")                                                                          \
     M(CannotDeclareGlobalFunction, "Cannot declare global function of name '{}'")                                                       \
     M(CannotDeclareGlobalVariable, "Cannot declare global variable of name '{}'")                                                       \
@@ -37,6 +38,7 @@
     M(DivisionByZero, "Division by zero")                                                                                               \
     M(DynamicImportNotAllowed, "Dynamic Imports are not allowed")                                                                       \
     M(FinalizationRegistrySameTargetAndValue, "Target and held value must not be the same")                                             \
+    M(FixedArrayBuffer, "ArrayBuffer is not resizable")                                                                                 \
     M(GetCapabilitiesExecutorCalledMultipleTimes, "GetCapabilitiesExecutor was called multiple times")                                  \
     M(GeneratorAlreadyExecuting, "Generator is already executing")                                                                      \
     M(GeneratorBrandMismatch, "Generator brand '{}' does not match generator brand '{}')")                                              \

--- a/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
+++ b/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
@@ -18,6 +18,7 @@
     M(BigIntFromNonIntegral, "Cannot convert non-integral number to BigInt")                                                            \
     M(BigIntInvalidValue, "Invalid value for BigInt: {}")                                                                               \
     M(BindingNotInitialized, "Binding {} is not initialized")                                                                           \
+    M(BufferOutOfBounds, "{} contains a property which references a value at an index not contained within its buffer's bounds")        \
     M(ByteLengthExceedsMaxByteLength, "ArrayBuffer byte length of {} exceeds the max byte length of {}")                                \
     M(CallStackSizeExceeded, "Call stack size limit exceeded")                                                                          \
     M(CannotDeclareGlobalFunction, "Cannot declare global function of name '{}'")                                                       \

--- a/Userland/Libraries/LibJS/Runtime/SharedArrayBufferConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/SharedArrayBufferConstructor.cpp
@@ -26,16 +26,16 @@ void SharedArrayBufferConstructor::initialize(Realm& realm)
     auto& vm = this->vm();
     Base::initialize(realm);
 
-    // 25.2.4.2 SharedArrayBuffer.prototype, https://tc39.es/ecma262/#sec-sharedarraybuffer.prototype
+    // 25.2.4.1 SharedArrayBuffer.prototype, https://tc39.es/ecma262/#sec-sharedarraybuffer.prototype
     define_direct_property(vm.names.prototype, realm.intrinsics().shared_array_buffer_prototype(), 0);
 
-    // 25.2.4.4 SharedArrayBuffer.prototype [ @@toStringTag ], https://tc39.es/ecma262/#sec-sharedarraybuffer.prototype.toString
+    // 25.2.5.7 SharedArrayBuffer.prototype [ @@toStringTag ], https://tc39.es/ecma262/#sec-sharedarraybuffer.prototype.toString
     define_native_accessor(realm, vm.well_known_symbol_species(), symbol_species_getter, {}, Attribute::Configurable);
 
     define_direct_property(vm.names.length, Value(1), Attribute::Configurable);
 }
 
-// 25.2.2.1 SharedArrayBuffer ( length ), https://tc39.es/ecma262/#sec-sharedarraybuffer-length
+// 25.2.3.1 SharedArrayBuffer ( length [ , options ] ), https://tc39.es/ecma262/#sec-sharedarraybuffer-length
 ThrowCompletionOr<Value> SharedArrayBufferConstructor::call()
 {
     auto& vm = this->vm();
@@ -44,7 +44,7 @@ ThrowCompletionOr<Value> SharedArrayBufferConstructor::call()
     return vm.throw_completion<TypeError>(ErrorType::ConstructorWithoutNew, vm.names.SharedArrayBuffer);
 }
 
-// 25.2.2.1 SharedArrayBuffer ( length ), https://tc39.es/ecma262/#sec-sharedarraybuffer-length
+// 25.2.3.1 SharedArrayBuffer ( length [ , options ] ), https://tc39.es/ecma262/#sec-sharedarraybuffer-length
 ThrowCompletionOr<NonnullGCPtr<Object>> SharedArrayBufferConstructor::construct(FunctionObject& new_target)
 {
     auto& vm = this->vm();
@@ -65,7 +65,7 @@ ThrowCompletionOr<NonnullGCPtr<Object>> SharedArrayBufferConstructor::construct(
     return *TRY(allocate_shared_array_buffer(vm, new_target, byte_length_or_error.release_value()));
 }
 
-// 25.2.3.2 get SharedArrayBuffer [ @@species ], https://tc39.es/ecma262/#sec-sharedarraybuffer-@@species
+// 25.2.4.2 get SharedArrayBuffer [ @@species ], https://tc39.es/ecma262/#sec-sharedarraybuffer-@@species
 JS_DEFINE_NATIVE_FUNCTION(SharedArrayBufferConstructor::symbol_species_getter)
 {
     // 1. Return the this value.

--- a/Userland/Libraries/LibJS/Runtime/SharedArrayBufferPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/SharedArrayBufferPrototype.cpp
@@ -28,11 +28,11 @@ void SharedArrayBufferPrototype::initialize(Realm& realm)
     define_native_accessor(realm, vm.names.byteLength, byte_length_getter, {}, Attribute::Configurable);
     define_native_function(realm, vm.names.slice, slice, 2, attr);
 
-    // 25.2.4.4 SharedArrayBuffer.prototype [ @@toStringTag ], https://tc39.es/ecma262/#sec-sharedarraybuffer.prototype.toString
+    // 25.2.5.7 SharedArrayBuffer.prototype [ @@toStringTag ], https://tc39.es/ecma262/#sec-sharedarraybuffer.prototype.toString
     define_direct_property(vm.well_known_symbol_to_string_tag(), PrimitiveString::create(vm, vm.names.SharedArrayBuffer.as_string()), Attribute::Configurable);
 }
 
-// 25.2.4.1 get SharedArrayBuffer.prototype.byteLength, https://tc39.es/ecma262/#sec-get-sharedarraybuffer.prototype.bytelength
+// 25.2.5.1 get SharedArrayBuffer.prototype.byteLength, https://tc39.es/ecma262/#sec-get-sharedarraybuffer.prototype.bytelength
 JS_DEFINE_NATIVE_FUNCTION(SharedArrayBufferPrototype::byte_length_getter)
 {
     // 1. Let O be the this value.
@@ -47,7 +47,7 @@ JS_DEFINE_NATIVE_FUNCTION(SharedArrayBufferPrototype::byte_length_getter)
     return Value(array_buffer_object->byte_length());
 }
 
-// 25.2.4.3 SharedArrayBuffer.prototype.slice ( start, end ), https://tc39.es/ecma262/#sec-sharedarraybuffer.prototype.slice
+// 25.2.5.6 SharedArrayBuffer.prototype.slice ( start, end ), https://tc39.es/ecma262/#sec-sharedarraybuffer.prototype.slice
 JS_DEFINE_NATIVE_FUNCTION(SharedArrayBufferPrototype::slice)
 {
     auto& realm = *vm.current_realm();

--- a/Userland/Libraries/LibJS/Runtime/TypedArray.cpp
+++ b/Userland/Libraries/LibJS/Runtime/TypedArray.cpp
@@ -28,25 +28,6 @@ ThrowCompletionOr<TypedArrayBase*> typed_array_from(VM& vm, Value typed_array_va
     return static_cast<TypedArrayBase*>(this_object.ptr());
 }
 
-// 23.2.4.4 ValidateTypedArray ( O ), https://tc39.es/ecma262/#sec-validatetypedarray
-ThrowCompletionOr<void> validate_typed_array(VM& vm, TypedArrayBase& typed_array)
-{
-    // 1. Perform ? RequireInternalSlot(O, [[TypedArrayName]]).
-    if (!typed_array.is_typed_array())
-        return vm.throw_completion<TypeError>(ErrorType::NotAnObjectOfType, "TypedArray");
-
-    // 2. Assert: O has a [[ViewedArrayBuffer]] internal slot.
-
-    // 3. Let buffer be O.[[ViewedArrayBuffer]].
-    auto* buffer = typed_array.viewed_array_buffer();
-
-    // 4. If IsDetachedBuffer(buffer) is true, throw a TypeError exception.
-    if (buffer->is_detached())
-        return vm.throw_completion<TypeError>(ErrorType::DetachedArrayBuffer);
-
-    return {};
-}
-
 // 22.2.5.1.3 InitializeTypedArrayFromArrayBuffer, https://tc39.es/ecma262/#sec-initializetypedarrayfromarraybuffer
 static ThrowCompletionOr<void> initialize_typed_array_from_array_buffer(VM& vm, TypedArrayBase& typed_array, ArrayBuffer& array_buffer, Value byte_offset, Value length)
 {
@@ -60,101 +41,122 @@ static ThrowCompletionOr<void> initialize_typed_array_from_array_buffer(VM& vm, 
     if (offset % element_size != 0)
         return vm.throw_completion<RangeError>(ErrorType::TypedArrayInvalidByteOffset, typed_array.class_name(), element_size, offset);
 
-    size_t new_length { 0 };
+    // 4. Let bufferIsFixedLength be IsFixedLengthArrayBuffer(buffer).
+    auto buffer_is_fixed_length = array_buffer.is_fixed_length();
 
-    // 4. If length is not undefined, then
+    size_t new_length { 0 };
+    // 5. If length is not undefined, then
     if (!length.is_undefined()) {
         // a. Let newLength be ? ToIndex(length).
         new_length = TRY(length.to_index(vm));
     }
 
-    // 5. If IsDetachedBuffer(buffer) is true, throw a TypeError exception.
+    // 6. If IsDetachedBuffer(buffer) is true, throw a TypeError exception.
     if (array_buffer.is_detached())
         return vm.throw_completion<TypeError>(ErrorType::DetachedArrayBuffer);
 
-    // 6. Let bufferByteLength be buffer.[[ArrayBufferByteLength]].
-    auto buffer_byte_length = array_buffer.byte_length();
+    // 7. Let bufferByteLength be ArrayBufferByteLength(buffer, seq-cst).
+    auto buffer_byte_length = array_buffer_byte_length(array_buffer, ArrayBuffer::Order::SeqCst);
 
-    Checked<size_t> new_byte_length;
-
-    // 7. If length is undefined, then
-    if (length.is_undefined()) {
-        // a. If bufferByteLength modulo elementSize ≠ 0, throw a RangeError exception.
-        if (buffer_byte_length % element_size != 0)
-            return vm.throw_completion<RangeError>(ErrorType::TypedArrayInvalidBufferLength, typed_array.class_name(), element_size, buffer_byte_length);
-
-        // b. Let newByteLength be bufferByteLength - offset.
-        // c. If newByteLength < 0, throw a RangeError exception.
+    // 8. If length is undefined and bufferIsFixedLength is false, then
+    if (length.is_undefined() && !buffer_is_fixed_length) {
+        // a. If offset > bufferByteLength, throw a RangeError exception.
         if (offset > buffer_byte_length)
             return vm.throw_completion<RangeError>(ErrorType::TypedArrayOutOfRangeByteOffset, offset, buffer_byte_length);
-        new_byte_length = buffer_byte_length;
-        new_byte_length -= offset;
+
+        // b. Set O.[[ByteLength]] to auto.
+        typed_array.set_byte_length(ByteLength::auto_());
+
+        // c. Set O.[[ArrayLength]] to auto.
+        typed_array.set_array_length(ByteLength::auto_());
     }
-    // 8. Else,
+    // 9. Else,
     else {
-        // a. Let newByteLength be newLength × elementSize.
-        new_byte_length = new_length;
-        new_byte_length *= element_size;
+        Checked<u32> new_byte_length;
 
-        // b. If offset + newByteLength > bufferByteLength, throw a RangeError exception.
-        Checked<size_t> new_byte_end = new_byte_length;
-        new_byte_end += offset;
+        // a. If length is undefined, then
+        if (length.is_undefined()) {
+            // i. If bufferByteLength modulo elementSize ≠ 0, throw a RangeError exception.
+            if (modulo(buffer_byte_length, element_size) != 0)
+                return vm.throw_completion<RangeError>(ErrorType::TypedArrayInvalidBufferLength, typed_array.class_name(), element_size, buffer_byte_length);
 
-        if (new_byte_end.has_overflow())
-            return vm.throw_completion<RangeError>(ErrorType::InvalidLength, "typed array");
+            // ii. Let newByteLength be bufferByteLength - offset.
+            new_byte_length = buffer_byte_length;
+            new_byte_length -= offset;
 
-        if (new_byte_end.value() > buffer_byte_length)
-            return vm.throw_completion<RangeError>(ErrorType::TypedArrayOutOfRangeByteOffsetOrLength, offset, new_byte_end.value(), buffer_byte_length);
+            // iii. If newByteLength < 0, throw a RangeError exception.
+            if (new_byte_length.has_overflow())
+                return vm.throw_completion<RangeError>(ErrorType::TypedArrayOutOfRangeByteOffset, offset, buffer_byte_length);
+        }
+        // b. Else,
+        else {
+            // i. Let newByteLength be newLength × elementSize.
+            new_byte_length = new_length;
+            new_byte_length *= element_size;
+
+            // ii. If offset + newByteLength > bufferByteLength, throw a RangeError exception.
+            Checked<u32> new_byte_end = offset;
+            new_byte_end += new_byte_length;
+
+            if (new_byte_end.has_overflow())
+                return vm.throw_completion<RangeError>(ErrorType::InvalidLength, "typed array");
+            if (new_byte_end.value() > buffer_byte_length)
+                return vm.throw_completion<RangeError>(ErrorType::TypedArrayOutOfRangeByteOffsetOrLength, offset, new_byte_end.value(), buffer_byte_length);
+        }
+
+        // c. Set O.[[ByteLength]] to newByteLength.
+        typed_array.set_byte_length(new_byte_length.value());
+
+        // d. Set O.[[ArrayLength]] to newByteLength / elementSize.
+        typed_array.set_array_length(new_byte_length.value() / element_size);
     }
 
-    if (new_byte_length.has_overflow())
-        return vm.throw_completion<RangeError>(ErrorType::InvalidLength, "typed array");
-
-    // 9. Set O.[[ViewedArrayBuffer]] to buffer.
+    // 10. Set O.[[ViewedArrayBuffer]] to buffer.
     typed_array.set_viewed_array_buffer(&array_buffer);
-
-    // 10. Set O.[[ByteLength]] to newByteLength.
-    typed_array.set_byte_length(new_byte_length.value());
 
     // 11. Set O.[[ByteOffset]] to offset.
     typed_array.set_byte_offset(offset);
 
-    // 12. Set O.[[ArrayLength]] to newByteLength / elementSize.
-    typed_array.set_array_length(new_byte_length.value() / element_size);
-
-    // 13. Return unused.
+    // 12. Return unused.
     return {};
 }
 
 // 23.2.5.1.2 InitializeTypedArrayFromTypedArray ( O, srcArray ), https://tc39.es/ecma262/#sec-initializetypedarrayfromtypedarray
 template<typename T>
-static ThrowCompletionOr<void> initialize_typed_array_from_typed_array(VM& vm, TypedArray<T>& dest_array, TypedArrayBase& src_array)
+static ThrowCompletionOr<void> initialize_typed_array_from_typed_array(VM& vm, TypedArray<T>& typed_array, TypedArrayBase& source_array)
 {
     auto& realm = *vm.current_realm();
 
     // 1. Let srcData be srcArray.[[ViewedArrayBuffer]].
-    auto* src_data = src_array.viewed_array_buffer();
-    VERIFY(src_data);
+    auto* source_data = source_array.viewed_array_buffer();
+    VERIFY(source_data);
 
-    // 2. If IsDetachedBuffer(srcData) is true, throw a TypeError exception.
-    if (src_data->is_detached())
-        return vm.template throw_completion<TypeError>(ErrorType::DetachedArrayBuffer);
+    // 2. Let elementType be TypedArrayElementType(O).
+    auto const& element_type = typed_array.element_name();
 
-    // 3. Let elementType be TypedArrayElementType(O).
-    // 4. Let elementSize be TypedArrayElementSize(O).
-    auto element_size = dest_array.element_size();
+    // 3. Let elementSize be TypedArrayElementSize(O).
+    auto element_size = typed_array.element_size();
 
-    // 5. Let srcType be TypedArrayElementType(srcArray).
-    // 6. Let srcElementSize be TypedArrayElementSize(srcArray).
-    auto src_element_size = src_array.element_size();
+    // 4. Let srcType be TypedArrayElementType(srcArray).
+    auto const& source_type = source_array.element_name();
 
-    // 7. Let srcByteOffset be srcArray.[[ByteOffset]].
-    auto src_byte_offset = src_array.byte_offset();
+    // 5. Let srcElementSize be TypedArrayElementSize(srcArray).
+    auto source_element_size = source_array.element_size();
 
-    // 8. Let elementLength be srcArray.[[ArrayLength]].
-    auto element_length = src_array.array_length();
+    // 6. Let srcByteOffset be srcArray.[[ByteOffset]].
+    auto source_byte_offset = source_array.byte_offset();
 
-    // 9. Let byteLength be elementSize × elementLength.
+    // 7. Let srcRecord be MakeTypedArrayWithBufferWitnessRecord(srcArray, seq-cst).
+    auto source_record = make_typed_array_with_buffer_witness_record(source_array, ArrayBuffer::Order::SeqCst);
+
+    // 8. If IsTypedArrayOutOfBounds(srcRecord) is true, throw a TypeError exception.
+    if (is_typed_array_out_of_bounds(source_record))
+        return vm.throw_completion<TypeError>(ErrorType::BufferOutOfBounds, "TypedArray"sv);
+
+    // 9. Let elementLength be TypedArrayLength(srcRecord).
+    auto element_length = typed_array_length(source_record);
+
+    // 10. Let byteLength be elementSize × elementLength.
     Checked<size_t> byte_length = element_size;
     byte_length *= element_length;
     if (byte_length.has_overflow())
@@ -162,41 +164,37 @@ static ThrowCompletionOr<void> initialize_typed_array_from_typed_array(VM& vm, T
 
     ArrayBuffer* data = nullptr;
 
-    // 10. If elementType is the same as srcType, then
-    if (dest_array.element_name() == src_array.element_name()) {
+    // 11. If elementType is srcType, then
+    if (element_type == source_type) {
         // a. Let data be ? CloneArrayBuffer(srcData, srcByteOffset, byteLength).
-        data = TRY(clone_array_buffer(vm, *src_data, src_byte_offset, byte_length.value()));
+        data = TRY(clone_array_buffer(vm, *source_data, source_byte_offset, byte_length.value()));
     }
-    // 11. Else,
+    // 12. Else,
     else {
-        // a. Let data be ? AllocateArrayBuffer(bufferConstructor, byteLength).
+        // a. Let data be ? AllocateArrayBuffer(%ArrayBuffer%, byteLength).
         data = TRY(allocate_array_buffer(vm, realm.intrinsics().array_buffer_constructor(), byte_length.value()));
 
-        // b. If IsDetachedBuffer(srcData) is true, throw a TypeError exception.
-        if (src_data->is_detached())
-            return vm.template throw_completion<TypeError>(ErrorType::DetachedArrayBuffer);
+        // b. If srcArray.[[ContentType]] is not O.[[ContentType]], throw a TypeError exception.
+        if (source_array.content_type() != typed_array.content_type())
+            return vm.template throw_completion<TypeError>(ErrorType::TypedArrayContentTypeMismatch, typed_array.class_name(), source_array.class_name());
 
-        // c. If srcArray.[[ContentType]] ≠ O.[[ContentType]], throw a TypeError exception.
-        if (src_array.content_type() != dest_array.content_type())
-            return vm.template throw_completion<TypeError>(ErrorType::TypedArrayContentTypeMismatch, dest_array.class_name(), src_array.class_name());
+        // c. Let srcByteIndex be srcByteOffset.
+        u64 source_byte_index = source_byte_offset;
 
-        // d. Let srcByteIndex be srcByteOffset.
-        u64 src_byte_index = src_byte_offset;
-
-        // e. Let targetByteIndex be 0.
+        // d. Let targetByteIndex be 0.
         u64 target_byte_index = 0;
 
-        // f. Let count be elementLength.
-        // g. Repeat, while count > 0,
+        // e. Let count be elementLength.
+        // f. Repeat, while count > 0,
         for (u32 i = 0; i < element_length; ++i) {
-            // i. Let value be GetValueFromBuffer(srcData, srcByteIndex, srcType, true, Unordered).
-            auto value = src_array.get_value_from_buffer(src_byte_index, ArrayBuffer::Order::Unordered);
+            // i. Let value be GetValueFromBuffer(srcData, srcByteIndex, srcType, true, unordered).
+            auto value = source_array.get_value_from_buffer(source_byte_index, ArrayBuffer::Order::Unordered);
 
-            // ii. Perform SetValueInBuffer(data, targetByteIndex, elementType, value, true, Unordered).
+            // ii. Perform SetValueInBuffer(data, targetByteIndex, elementType, value, true, unordered).
             data->template set_value<T>(target_byte_index, value, true, ArrayBuffer::Order::Unordered);
 
             // iii. Set srcByteIndex to srcByteIndex + srcElementSize.
-            src_byte_index += src_element_size;
+            source_byte_index += source_element_size;
 
             // iv. Set targetByteIndex to targetByteIndex + elementSize.
             target_byte_index += element_size;
@@ -205,19 +203,19 @@ static ThrowCompletionOr<void> initialize_typed_array_from_typed_array(VM& vm, T
         }
     }
 
-    // 12. Set O.[[ViewedArrayBuffer]] to data.
-    dest_array.set_viewed_array_buffer(data);
+    // 13. Set O.[[ViewedArrayBuffer]] to data.
+    typed_array.set_viewed_array_buffer(data);
 
-    // 13. Set O.[[ByteLength]] to byteLength.
-    dest_array.set_byte_length(byte_length.value());
+    // 14. Set O.[[ByteLength]] to byteLength.
+    typed_array.set_byte_length(byte_length.value());
 
-    // 14. Set O.[[ByteOffset]] to 0.
-    dest_array.set_byte_offset(0);
+    // 15. Set O.[[ByteOffset]] to 0.
+    typed_array.set_byte_offset(0);
 
-    // 15. Set O.[[ArrayLength]] to elementLength.
-    dest_array.set_array_length(element_length);
+    // 16. Set O.[[ArrayLength]] to elementLength.
+    typed_array.set_array_length(element_length);
 
-    // 16. Return unused.
+    // 17. Return unused.
     return {};
 }
 
@@ -318,27 +316,32 @@ static ThrowCompletionOr<void> initialize_typed_array_from_list(VM& vm, TypedArr
 // 23.2.4.2 TypedArrayCreate ( constructor, argumentList ), https://tc39.es/ecma262/#typedarray-create
 ThrowCompletionOr<TypedArrayBase*> typed_array_create(VM& vm, FunctionObject& constructor, MarkedVector<Value> arguments)
 {
-    Optional<Value> first_argument;
-    if (!arguments.is_empty())
-        first_argument = arguments[0];
+    Optional<double> first_argument;
+    if (arguments.size() == 1 && arguments[0].is_number())
+        first_argument = arguments[0].as_double();
+
     // 1. Let newTypedArray be ? Construct(constructor, argumentList).
     auto new_typed_array = TRY(construct(vm, constructor, arguments.span()));
 
-    // 2. Perform ? ValidateTypedArray(newTypedArray).
-    if (!new_typed_array->is_typed_array())
-        return vm.throw_completion<TypeError>(ErrorType::NotAnObjectOfType, "TypedArray");
-    auto& typed_array = *static_cast<TypedArrayBase*>(new_typed_array.ptr());
-    TRY(validate_typed_array(vm, typed_array));
+    // 2. Let taRecord be ? ValidateTypedArray(newTypedArray, seq-cst).
+    auto typed_array_record = TRY(validate_typed_array(vm, *new_typed_array, ArrayBuffer::Order::SeqCst));
 
-    // 3. If argumentList is a List of a single Number, then
-    if (first_argument.has_value() && first_argument->is_number()) {
-        // a. If newTypedArray.[[ArrayLength]] < ℝ(argumentList[0]), throw a TypeError exception.
-        if (typed_array.array_length() < first_argument->as_double())
+    // 3. If the number of elements in argumentList is 1 and argumentList[0] is a Number, then
+    if (first_argument.has_value()) {
+        // a. If IsTypedArrayOutOfBounds(taRecord) is true, throw a TypeError exception.
+        if (is_typed_array_out_of_bounds(typed_array_record))
+            return vm.throw_completion<TypeError>(ErrorType::BufferOutOfBounds, "TypedArray"sv);
+
+        // b. Let length be TypedArrayLength(taRecord).
+        auto length = typed_array_length(typed_array_record);
+
+        // c. If length < ℝ(argumentList[0]), throw a TypeError exception.
+        if (length < *first_argument)
             return vm.throw_completion<TypeError>(ErrorType::InvalidLength, "typed array");
     }
 
     // 4. Return newTypedArray.
-    return &typed_array;
+    return static_cast<TypedArrayBase*>(new_typed_array.ptr());
 }
 
 // 23.2.4.3 TypedArrayCreateSameType ( exemplar, argumentList ), https://tc39.es/ecma262/#sec-typedarray-create-same-type
@@ -356,6 +359,27 @@ ThrowCompletionOr<TypedArrayBase*> typed_array_create_same_type(VM& vm, TypedArr
     // 4. Assert: result.[[ContentType]] is exemplar.[[ContentType]].
     // 5. Return result.
     return result;
+}
+
+// 23.2.4.4 ValidateTypedArray ( O ), https://tc39.es/ecma262/#sec-validatetypedarray
+ThrowCompletionOr<TypedArrayWithBufferWitness> validate_typed_array(VM& vm, Object const& object, ArrayBuffer::Order order)
+{
+    // 1. Perform ? RequireInternalSlot(O, [[TypedArrayName]]).
+    if (!object.is_typed_array())
+        return vm.throw_completion<TypeError>(ErrorType::NotAnObjectOfType, "TypedArray");
+
+    // 2. Assert: O has a [[ViewedArrayBuffer]] internal slot.
+    auto const& typed_array = static_cast<TypedArrayBase const&>(object);
+
+    // 3. Let taRecord be MakeTypedArrayWithBufferWitnessRecord(O, order).
+    auto typed_array_record = make_typed_array_with_buffer_witness_record(typed_array, order);
+
+    // 4. If IsTypedArrayOutOfBounds(taRecord) is true, throw a TypeError exception.
+    if (is_typed_array_out_of_bounds(typed_array_record))
+        return vm.throw_completion<TypeError>(ErrorType::BufferOutOfBounds, "TypedArray"sv);
+
+    // 5. Return taRecord.
+    return typed_array_record;
 }
 
 // 23.2.4.7 CompareTypedArrayElements ( x, y, comparefn ), https://tc39.es/ecma262/#sec-typedarray-create-same-type
@@ -562,5 +586,163 @@ void TypedArrayBase::visit_edges(Visitor& visitor)
     JS_DEFINE_TYPED_ARRAY(ClassName, snake_name, PrototypeName, ConstructorName, ArrayType);
 JS_ENUMERATE_TYPED_ARRAYS
 #undef __JS_ENUMERATE
+
+// 10.4.5.9 MakeTypedArrayWithBufferWitnessRecord ( obj, order ), https://tc39.es/ecma262/#sec-maketypedarraywithbufferwitnessrecord
+TypedArrayWithBufferWitness make_typed_array_with_buffer_witness_record(TypedArrayBase const& typed_array, ArrayBuffer::Order order)
+{
+    // 1. Let buffer be obj.[[ViewedArrayBuffer]].
+    auto* buffer = typed_array.viewed_array_buffer();
+
+    ByteLength byte_length { 0 };
+
+    // 2. If IsDetachedBuffer(buffer) is true, then
+    if (buffer->is_detached()) {
+        // a. Let byteLength be detached.
+        byte_length = ByteLength::detached();
+    }
+    // 3. Else,
+    else {
+        // a. Let byteLength be ArrayBufferByteLength(buffer, order).
+        byte_length = array_buffer_byte_length(*buffer, order);
+    }
+
+    // 4. Return the TypedArray With Buffer Witness Record { [[Object]]: obj, [[CachedBufferByteLength]]: byteLength }.
+    return { .object = typed_array, .cached_buffer_byte_length = move(byte_length) };
+}
+
+// 10.4.5.11 TypedArrayByteLength ( taRecord ), https://tc39.es/ecma262/#sec-typedarraybytelength
+u32 typed_array_byte_length(TypedArrayWithBufferWitness const& typed_array_record)
+{
+    // 1. If IsTypedArrayOutOfBounds(taRecord) is true, return 0.
+    if (is_typed_array_out_of_bounds(typed_array_record))
+        return 0;
+
+    // 2. Let length be TypedArrayLength(taRecord).
+    auto length = typed_array_length(typed_array_record);
+
+    // 3. If length = 0, return 0.
+    if (length == 0)
+        return 0;
+
+    // 4. Let O be taRecord.[[Object]].
+    auto object = typed_array_record.object;
+
+    // 5. If O.[[ByteLength]] is not auto, return O.[[ByteLength]].
+    if (!object->byte_length().is_auto())
+        return object->byte_length().length();
+
+    // 6. Let elementSize be TypedArrayElementSize(O).
+    auto element_size = object->element_size();
+
+    // 7. Return length × elementSize.
+    return length * element_size;
+}
+
+// 10.4.5.12 TypedArrayLength ( taRecord ), https://tc39.es/ecma262/#sec-typedarraylength
+u32 typed_array_length(TypedArrayWithBufferWitness const& typed_array_record)
+{
+    // 1. Assert: IsTypedArrayOutOfBounds(taRecord) is false.
+    VERIFY(!is_typed_array_out_of_bounds(typed_array_record));
+
+    // 2. Let O be taRecord.[[Object]].
+    auto object = typed_array_record.object;
+
+    // 3. If O.[[ArrayLength]] is not auto, return O.[[ArrayLength]].
+    if (!object->array_length().is_auto())
+        return object->array_length().length();
+
+    // 4. Assert: IsFixedLengthArrayBuffer(O.[[ViewedArrayBuffer]]) is false.
+    VERIFY(!object->viewed_array_buffer()->is_fixed_length());
+
+    // 5. Let byteOffset be O.[[ByteOffset]].
+    auto byte_offset = object->byte_offset();
+
+    // 6. Let elementSize be TypedArrayElementSize(O).
+    auto element_size = object->element_size();
+
+    // 7. Let byteLength be taRecord.[[CachedBufferByteLength]].
+    auto const& byte_length = typed_array_record.cached_buffer_byte_length;
+
+    // 8. Assert: byteLength is not detached.
+    VERIFY(!byte_length.is_detached());
+
+    // 9. Return floor((byteLength - byteOffset) / elementSize).
+    return (byte_length.length() - byte_offset) / element_size;
+}
+
+// 10.4.5.13 IsTypedArrayOutOfBounds ( taRecord ), https://tc39.es/ecma262/#sec-istypedarrayoutofbounds
+bool is_typed_array_out_of_bounds(TypedArrayWithBufferWitness const& typed_array_record)
+{
+    // 1. Let O be taRecord.[[Object]].
+    auto object = typed_array_record.object;
+
+    // 2. Let bufferByteLength be taRecord.[[CachedBufferByteLength]].
+    auto const& buffer_byte_length = typed_array_record.cached_buffer_byte_length;
+
+    // 3. Assert: IsDetachedBuffer(O.[[ViewedArrayBuffer]]) is true if and only if bufferByteLength is detached.
+    VERIFY(object->viewed_array_buffer()->is_detached() == buffer_byte_length.is_detached());
+
+    // 4. If bufferByteLength is detached, return true.
+    if (buffer_byte_length.is_detached())
+        return true;
+
+    // 5. Let byteOffsetStart be O.[[ByteOffset]].
+    auto byte_offset_start = object->byte_offset();
+    u32 byte_offset_end = 0;
+
+    // 6. If O.[[ArrayLength]] is auto, then
+    if (object->array_length().is_auto()) {
+        // a. Let byteOffsetEnd be bufferByteLength.
+        byte_offset_end = buffer_byte_length.length();
+    }
+    // 7. Else,
+    else {
+        // a. Let elementSize be TypedArrayElementSize(O).
+        auto element_size = object->element_size();
+
+        // b. Let byteOffsetEnd be byteOffsetStart + O.[[ArrayLength]] × elementSize.
+        byte_offset_end = byte_offset_start + object->array_length().length() * element_size;
+    }
+
+    // 8. If byteOffsetStart > bufferByteLength or byteOffsetEnd > bufferByteLength, return true.
+    if ((byte_offset_start > buffer_byte_length.length()) || (byte_offset_end > buffer_byte_length.length()))
+        return true;
+
+    // 9. NOTE: 0-length TypedArrays are not considered out-of-bounds.
+    // 10. Return false.
+    return false;
+}
+
+// 10.4.5.14 IsValidIntegerIndex ( O, index ), https://tc39.es/ecma262/#sec-isvalidintegerindex
+bool is_valid_integer_index(TypedArrayBase const& typed_array, CanonicalIndex property_index)
+{
+    // 1. If IsDetachedBuffer(O.[[ViewedArrayBuffer]]) is true, return false.
+    if (typed_array.viewed_array_buffer()->is_detached())
+        return false;
+
+    // 2. If IsIntegralNumber(index) is false, return false.
+    // 3. If index is -0𝔽, return false.
+    if (!property_index.is_index())
+        return false;
+
+    // 4. Let taRecord be MakeTypedArrayWithBufferWitnessRecord(O, unordered).
+    auto typed_array_record = make_typed_array_with_buffer_witness_record(typed_array, ArrayBuffer::Unordered);
+
+    // NOTE: Bounds checking is not a synchronizing operation when O's backing buffer is a growable SharedArrayBuffer.
+
+    // 6. If IsTypedArrayOutOfBounds(taRecord) is true, return false.
+    if (is_typed_array_out_of_bounds(typed_array_record))
+        return false;
+
+    // 7. Let length be TypedArrayLength(taRecord).
+    auto length = typed_array_length(typed_array_record);
+
+    // 8. If ℝ(index) < 0 or ℝ(index) ≥ length, return false.
+    if (property_index.as_index() >= length)
+        return false;
+
+    // 9. Return true.
+    return true;
+}
 
 }

--- a/Userland/Libraries/LibJS/Runtime/TypedArray.h
+++ b/Userland/Libraries/LibJS/Runtime/TypedArray.h
@@ -58,15 +58,15 @@ public:
     virtual size_t element_size() const = 0;
     virtual DeprecatedFlyString const& element_name() const = 0;
 
-    // 25.1.2.6 IsUnclampedIntegerElementType ( type ), https://tc39.es/ecma262/#sec-isunclampedintegerelementtype
+    // 25.1.3.10 IsUnclampedIntegerElementType ( type ), https://tc39.es/ecma262/#sec-isunclampedintegerelementtype
     virtual bool is_unclamped_integer_element_type() const = 0;
-    // 25.1.2.7 IsBigIntElementType ( type ), https://tc39.es/ecma262/#sec-isbigintelementtype
+    // 25.1.3.11 IsBigIntElementType ( type ), https://tc39.es/ecma262/#sec-isbigintelementtype
     virtual bool is_bigint_element_type() const = 0;
-    // 25.1.2.10 GetValueFromBuffer ( arrayBuffer, byteIndex, type, isTypedArray, order [ , isLittleEndian ] ), https://tc39.es/ecma262/#sec-getvaluefrombuffer
+    // 25.1.3.15 GetValueFromBuffer ( arrayBuffer, byteIndex, type, isTypedArray, order [ , isLittleEndian ] ), https://tc39.es/ecma262/#sec-getvaluefrombuffer
     virtual Value get_value_from_buffer(size_t byte_index, ArrayBuffer::Order, bool is_little_endian = true) const = 0;
-    // 25.1.2.12 SetValueInBuffer ( arrayBuffer, byteIndex, type, value, isTypedArray, order [ , isLittleEndian ] ), https://tc39.es/ecma262/#sec-setvalueinbuffer
+    // 25.1.3.17 SetValueInBuffer ( arrayBuffer, byteIndex, type, value, isTypedArray, order [ , isLittleEndian ] ), https://tc39.es/ecma262/#sec-setvalueinbuffer
     virtual void set_value_in_buffer(size_t byte_index, Value, ArrayBuffer::Order, bool is_little_endian = true) = 0;
-    // 25.1.2.13 GetModifySetValueInBuffer ( arrayBuffer, byteIndex, type, value, op [ , isLittleEndian ] ), https://tc39.es/ecma262/#sec-getmodifysetvalueinbuffer
+    // 25.1.3.18 GetModifySetValueInBuffer ( arrayBuffer, byteIndex, type, value, op ), https://tc39.es/ecma262/#sec-getmodifysetvalueinbuffer
     virtual Value get_modify_set_value_in_buffer(size_t byte_index, Value value, ReadWriteModifyFunction operation, bool is_little_endian = true) = 0;
 
 protected:
@@ -90,7 +90,7 @@ private:
     virtual void visit_edges(Visitor&) override;
 };
 
-// 10.4.5.9 IsValidIntegerIndex ( O, index ), https://tc39.es/ecma262/#sec-isvalidintegerindex
+// 10.4.5.14 IsValidIntegerIndex ( O, index ), https://tc39.es/ecma262/#sec-isvalidintegerindex
 inline bool is_valid_integer_index(TypedArrayBase const& typed_array, CanonicalIndex property_index)
 {
     // 1. If IsDetachedBuffer(O.[[ViewedArrayBuffer]]) is true, return false.
@@ -110,7 +110,7 @@ inline bool is_valid_integer_index(TypedArrayBase const& typed_array, CanonicalI
     return true;
 }
 
-// 10.4.5.10 IntegerIndexedElementGet ( O, index ), https://tc39.es/ecma262/#sec-integerindexedelementget
+// 10.4.5.15 IntegerIndexedElementGet ( O, index ), https://tc39.es/ecma262/#sec-integerindexedelementget
 template<typename T>
 inline ThrowCompletionOr<Value> integer_indexed_element_get(TypedArrayBase const& typed_array, CanonicalIndex property_index)
 {
@@ -138,7 +138,7 @@ inline ThrowCompletionOr<Value> integer_indexed_element_get(TypedArrayBase const
     return typed_array.viewed_array_buffer()->template get_value<T>(indexed_position.value(), true, ArrayBuffer::Order::Unordered);
 }
 
-// 10.4.5.11 IntegerIndexedElementSet ( O, index, value ), https://tc39.es/ecma262/#sec-integerindexedelementset
+// 10.4.5.16 IntegerIndexedElementSet ( O, index, value ), https://tc39.es/ecma262/#sec-integerindexedelementset
 // NOTE: In error cases, the function will return as if it succeeded.
 template<typename T>
 inline ThrowCompletionOr<void> integer_indexed_element_set(TypedArrayBase& typed_array, CanonicalIndex property_index, Value value)

--- a/Userland/Libraries/LibJS/Runtime/TypedArrayPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/TypedArrayPrototype.cpp
@@ -81,67 +81,14 @@ static ThrowCompletionOr<TypedArrayBase*> typed_array_from_this(VM& vm)
     return typed_array_from(vm, this_value);
 }
 
-static ThrowCompletionOr<TypedArrayBase*> validate_typed_array_from_this(VM& vm)
-{
-    auto* typed_array = TRY(typed_array_from_this(vm));
-
-    TRY(validate_typed_array(vm, *typed_array));
-
-    return typed_array;
-}
-
-static ThrowCompletionOr<FunctionObject*> callback_from_args(VM& vm, ByteString const& name)
+static ThrowCompletionOr<NonnullGCPtr<FunctionObject>> callback_from_args(VM& vm, StringView prototype_name)
 {
     if (vm.argument_count() < 1)
-        return vm.throw_completion<TypeError>(ErrorType::TypedArrayPrototypeOneArg, name);
+        return vm.throw_completion<TypeError>(ErrorType::TypedArrayPrototypeOneArg, prototype_name);
     auto callback = vm.argument(0);
     if (!callback.is_function())
-        return vm.throw_completion<TypeError>(ErrorType::NotAFunction, callback.to_string_without_side_effects());
-    return &callback.as_function();
-}
-
-static ThrowCompletionOr<void> for_each_item(VM& vm, ByteString const& name, Function<IterationDecision(size_t index, Value value, Value callback_result)> callback)
-{
-    auto* typed_array = TRY(validate_typed_array_from_this(vm));
-
-    auto initial_length = typed_array->array_length();
-
-    auto* callback_function = TRY(callback_from_args(vm, name));
-
-    auto this_value = vm.argument(1);
-
-    for (size_t i = 0; i < initial_length; ++i) {
-        auto value = TRY(typed_array->get(i));
-
-        auto callback_result = TRY(call(vm, *callback_function, this_value, value, Value((i32)i), typed_array));
-
-        if (callback(i, value, callback_result) == IterationDecision::Break)
-            break;
-    }
-
-    return {};
-}
-
-static ThrowCompletionOr<void> for_each_item_from_last(VM& vm, ByteString const& name, Function<IterationDecision(size_t index, Value value, Value callback_result)> callback)
-{
-    auto* typed_array = TRY(validate_typed_array_from_this(vm));
-
-    auto initial_length = typed_array->array_length();
-
-    auto* callback_function = TRY(callback_from_args(vm, name));
-
-    auto this_value = vm.argument(1);
-
-    for (ssize_t i = (ssize_t)initial_length - 1; i >= 0; --i) {
-        auto value = TRY(typed_array->get(i));
-
-        auto callback_result = TRY(call(vm, *callback_function, this_value, value, Value((i32)i), typed_array));
-
-        if (callback(i, value, callback_result) == IterationDecision::Break)
-            break;
-    }
-
-    return {};
+        return vm.throw_completion<TypeError>(ErrorType::NotAFunction, callback);
+    return callback.as_function();
 }
 
 // 23.2.4.1 TypedArraySpeciesCreate ( exemplar, argumentList ), https://tc39.es/ecma262/#typedarray-species-create
@@ -170,39 +117,43 @@ static ThrowCompletionOr<TypedArrayBase*> typed_array_species_create(VM& vm, Typ
 // 23.2.3.1 %TypedArray%.prototype.at ( index ), https://tc39.es/ecma262/#sec-%typedarray%.prototype.at
 JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::at)
 {
-    // 1. Let O be the this value.
-    // 2. Perform ? ValidateTypedArray(O).
-    auto* typed_array = TRY(validate_typed_array_from_this(vm));
+    auto index = vm.argument(0);
 
-    // 3. Let len be O.[[ArrayLength]].
-    auto length = typed_array->array_length();
+    // 1. Let O be the this value.
+    auto* typed_array = TRY(typed_array_from_this(vm));
+
+    // 2. Let taRecord be ? ValidateTypedArray(O, seq-cst).
+    auto typed_array_record = TRY(validate_typed_array(vm, *typed_array, ArrayBuffer::Order::SeqCst));
+
+    // 3. Let len be TypedArrayLength(taRecord).
+    auto length = typed_array_length(typed_array_record);
 
     // 4. Let relativeIndex be ? ToIntegerOrInfinity(index).
-    auto relative_index = TRY(vm.argument(0).to_integer_or_infinity(vm));
+    auto relative_index = TRY(index.to_integer_or_infinity(vm));
 
-    if (Value(relative_index).is_infinity())
+    if (Value { relative_index }.is_infinity())
         return js_undefined();
 
-    Checked<size_t> index { 0 };
+    Checked<size_t> k_checked { 0 };
 
     // 5. If relativeIndex ≥ 0, then
     if (relative_index >= 0) {
         // a. Let k be relativeIndex.
-        index += relative_index;
+        k_checked += relative_index;
     }
     // 6. Else,
     else {
         // a. Let k be len + relativeIndex.
-        index += length;
-        index -= -relative_index;
+        k_checked += length;
+        k_checked -= -relative_index;
     }
 
     // 7. If k < 0 or k ≥ len, return undefined.
-    if (index.has_overflow() || index.value() >= length)
+    if (k_checked.has_overflow() || k_checked.value() >= length)
         return js_undefined();
 
     // 8. Return ! Get(O, ! ToString(𝔽(k))).
-    return MUST(typed_array->get(index.value()));
+    return MUST(typed_array->get(k_checked.value()));
 }
 
 // 23.2.3.2 get %TypedArray%.prototype.buffer, https://tc39.es/ecma262/#sec-get-%typedarray%.prototype.buffer
@@ -210,9 +161,9 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::buffer_getter)
 {
     // 1. Let O be the this value.
     // 2. Perform ? RequireInternalSlot(O, [[TypedArrayName]]).
+    // 3. Assert: O has a [[ViewedArrayBuffer]] internal slot.
     auto* typed_array = TRY(typed_array_from_this(vm));
 
-    // 3. Assert: O has a [[ViewedArrayBuffer]] internal slot.
     // 4. Let buffer be O.[[ViewedArrayBuffer]].
     auto* buffer = typed_array->viewed_array_buffer();
     VERIFY(buffer);
@@ -226,22 +177,17 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::byte_length_getter)
 {
     // 1. Let O be the this value.
     // 2. Perform ? RequireInternalSlot(O, [[TypedArrayName]]).
+    // 3. Assert: O has a [[ViewedArrayBuffer]] internal slot.
     auto* typed_array = TRY(typed_array_from_this(vm));
 
-    // 3. Assert: O has a [[ViewedArrayBuffer]] internal slot.
-    // 4. Let buffer be O.[[ViewedArrayBuffer]].
-    auto* buffer = typed_array->viewed_array_buffer();
-    VERIFY(buffer);
+    // 4. Let taRecord be MakeTypedArrayWithBufferWitnessRecord(O, seq-cst).
+    auto typed_array_record = make_typed_array_with_buffer_witness_record(*typed_array, ArrayBuffer::Order::SeqCst);
 
-    // 5. If IsDetachedBuffer(buffer) is true, return +0𝔽.
-    if (buffer->is_detached())
-        return Value(0);
+    // 5. Let size be TypedArrayByteLength(taRecord).
+    auto size = typed_array_byte_length(typed_array_record);
 
-    // 6. Let size be O.[[ByteLength]].
-    auto size = typed_array->byte_length();
-
-    // 7. Return 𝔽(size).
-    return Value(size);
+    // 6. Return 𝔽(size).
+    return Value { size };
 }
 
 // 23.2.3.4 get %TypedArray%.prototype.byteOffset, https://tc39.es/ecma262/#sec-get-%typedarray%.prototype.byteoffset
@@ -249,81 +195,91 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::byte_offset_getter)
 {
     // 1. Let O be the this value.
     // 2. Perform ? RequireInternalSlot(O, [[TypedArrayName]]).
+    // 3. Assert: O has a [[ViewedArrayBuffer]] internal slot.
     auto* typed_array = TRY(typed_array_from_this(vm));
 
-    // 3. Assert: O has a [[ViewedArrayBuffer]] internal slot.
-    // 4. Let buffer be O.[[ViewedArrayBuffer]].
-    auto* buffer = typed_array->viewed_array_buffer();
-    VERIFY(buffer);
+    // 4. Let taRecord be MakeTypedArrayWithBufferWitnessRecord(O, seq-cst).
+    auto typed_array_record = make_typed_array_with_buffer_witness_record(*typed_array, ArrayBuffer::Order::SeqCst);
 
-    // 5. If IsDetachedBuffer(buffer) is true, return +0𝔽.
-    if (buffer->is_detached())
-        return Value(0);
+    // 5. If IsTypedArrayOutOfBounds(taRecord) is true, return +0𝔽.
+    if (is_typed_array_out_of_bounds(typed_array_record))
+        return Value { 0 };
 
     // 6. Let offset be O.[[ByteOffset]].
     auto offset = typed_array->byte_offset();
 
     // 7. Return 𝔽(offset).
-    return Value(offset);
+    return Value { offset };
 }
 
 // 23.2.3.6 %TypedArray%.prototype.copyWithin ( target, start [ , end ] ), https://tc39.es/ecma262/#sec-%typedarray%.prototype.copywithin
 JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::copy_within)
 {
-    // 1. Let O be the this value.
-    // 2. Perform ? ValidateTypedArray(O).
-    auto* typed_array = TRY(validate_typed_array_from_this(vm));
+    auto target = vm.argument(0);
+    auto start = vm.argument(1);
+    auto end = vm.argument(2);
 
-    // 3. Let len be O.[[ArrayLength]].
-    auto length = typed_array->array_length();
+    // 1. Let O be the this value.
+    auto* typed_array = TRY(typed_array_from_this(vm));
+
+    // 2. Let taRecord be ? ValidateTypedArray(O, seq-cst).
+    auto typed_array_record = TRY(validate_typed_array(vm, *typed_array, ArrayBuffer::Order::SeqCst));
+
+    // 3. Let len be TypedArrayLength(taRecord).
+    auto length = typed_array_length(typed_array_record);
 
     // 4. Let relativeTarget be ? ToIntegerOrInfinity(target).
-    auto relative_target = TRY(vm.argument(0).to_integer_or_infinity(vm));
+    auto relative_target = TRY(target.to_integer_or_infinity(vm));
 
     double to;
-    if (Value(relative_target).is_negative_infinity()) {
-        // 5. If relativeTarget is -∞, let to be 0.
+    // 5. If relativeTarget = -∞, let to be 0.
+    if (Value { relative_target }.is_negative_infinity()) {
         to = 0.0;
-    } else if (relative_target < 0) {
-        // 6. Else if relativeTarget < 0, let to be max(len + relativeTarget, 0)
+    }
+    // 6. Else if relativeTarget < 0, let to be max(len + relativeTarget, 0).
+    else if (relative_target < 0) {
         to = max(length + relative_target, 0.0);
-    } else {
-        // 7. Else, let to be min(relativeTarget, len).
+    }
+    // 7. Else, let to be min(relativeTarget, len).
+    else {
         to = min(relative_target, (double)length);
     }
 
     // 8. Let relativeStart be ? ToIntegerOrInfinity(start).
-    auto relative_start = TRY(vm.argument(1).to_integer_or_infinity(vm));
+    auto relative_start = TRY(start.to_integer_or_infinity(vm));
 
     double from;
-    if (Value(relative_start).is_negative_infinity()) {
-        // 9. If relativeStart is -∞, let from be 0.
+    // 9. If relativeStart = -∞, let from be 0.
+    if (Value { relative_start }.is_negative_infinity()) {
         from = 0.0;
-    } else if (relative_start < 0) {
-        // 10. Else if relativeStart < 0, let from be max(len + relativeStart, 0).
+    }
+    // 10. Else if relativeStart < 0, let from be max(len + relativeStart, 0).
+    else if (relative_start < 0) {
         from = max(length + relative_start, 0.0);
-    } else {
-        // 11. Else, let from be min(relativeStart, len).
+    }
+    // 11. Else, let from be min(relativeStart, len).
+    else {
         from = min(relative_start, (double)length);
     }
 
     double relative_end;
-
     // 12. If end is undefined, let relativeEnd be len; else let relativeEnd be ? ToIntegerOrInfinity(end).
-    if (vm.argument(2).is_undefined())
+    if (end.is_undefined())
         relative_end = length;
     else
-        relative_end = TRY(vm.argument(2).to_integer_or_infinity(vm));
+        relative_end = TRY(end.to_integer_or_infinity(vm));
 
     double final;
-    if (Value(relative_end).is_negative_infinity()) {
-        // 13. If relativeEnd is -∞, let final be 0.
+    // 13. If relativeEnd = -∞, let final be 0.
+    if (Value { relative_end }.is_negative_infinity()) {
         final = 0.0;
-    } else if (relative_end < 0) {
-        // 14. Else if relativeEnd < 0, let final be max(len + relativeEnd, 0).
+    }
+    // 14. Else if relativeEnd < 0, let final be max(len + relativeEnd, 0).
+    else if (relative_end < 0) {
         final = max(length + relative_end, 0.0);
-    } else {
-        // 15. Else, let final be min(relativeEnd, len).
+    }
+    // 15. Else, let final be min(relativeEnd, len).
+    else {
         final = min(relative_end, (double)length);
     }
 
@@ -335,22 +291,36 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::copy_within)
         // a. NOTE: The copying must be performed in a manner that preserves the bit-level encoding of the source data.
 
         // b. Let buffer be O.[[ViewedArrayBuffer]].
-        auto buffer = typed_array->viewed_array_buffer();
+        auto* buffer = typed_array->viewed_array_buffer();
 
-        // c. If IsDetachedBuffer(buffer) is true, throw a TypeError exception.
-        if (buffer->is_detached())
-            return vm.throw_completion<TypeError>(ErrorType::DetachedArrayBuffer);
+        // c. Set taRecord to MakeTypedArrayWithBufferWitnessRecord(O, seq-cst).
+        typed_array_record = make_typed_array_with_buffer_witness_record(*typed_array, ArrayBuffer::Order::SeqCst);
 
-        // d. Let elementSize be TypedArrayElementSize(O).
+        // d. If IsTypedArrayOutOfBounds(taRecord) is true, throw a TypeError exception.
+        if (is_typed_array_out_of_bounds(typed_array_record))
+            return vm.throw_completion<TypeError>(ErrorType::BufferOutOfBounds, "TypedArray"sv);
+
+        // e. Set len to TypedArrayLength(taRecord).
+        length = typed_array_length(typed_array_record);
+
+        // f. Let elementSize be TypedArrayElementSize(O).
         auto element_size = typed_array->element_size();
 
-        // e. Let byteOffset be O.[[ByteOffset]].
+        // g. Let byteOffset be O.[[ByteOffset]].
         auto byte_offset = typed_array->byte_offset();
 
-        // FIXME: Not exactly sure what we should do when overflow occurs.
-        //        Just return as if succeeded for now. (This goes for steps g to j)
+        // FIXME: Not exactly sure what we should do when overflow occurs. Just return as if succeeded for now.
 
-        // f. Let toByteIndex be to × elementSize + byteOffset.
+        // h. Let bufferByteLimit be len × elementSize + byteOffset.
+        Checked<size_t> buffer_byte_limit_checked = static_cast<size_t>(length);
+        buffer_byte_limit_checked *= element_size;
+        buffer_byte_limit_checked += byte_offset;
+        if (buffer_byte_limit_checked.has_overflow()) {
+            dbgln("TypedArrayPrototype::copy_within: buffer_byte_limit overflowed, returning as if succeeded.");
+            return typed_array;
+        }
+
+        // i. Let toByteIndex be to × elementSize + byteOffset.
         Checked<size_t> to_byte_index_checked = static_cast<size_t>(to);
         to_byte_index_checked *= element_size;
         to_byte_index_checked += byte_offset;
@@ -359,23 +329,24 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::copy_within)
             return typed_array;
         }
 
-        // g. Let fromByteIndex be from × elementSize + byteOffset.
+        // j. Let fromByteIndex be from × elementSize + byteOffset.
         Checked<size_t> from_byte_index_checked = static_cast<size_t>(from);
         from_byte_index_checked *= element_size;
         from_byte_index_checked += byte_offset;
         if (from_byte_index_checked.has_overflow()) {
-            dbgln("TypedArrayPrototype::copy_within: from_byte_index_checked overflowed, returning as if succeeded.");
+            dbgln("TypedArrayPrototype::copy_within: from_byte_index overflowed, returning as if succeeded.");
             return typed_array;
         }
 
-        // h. Let countBytes be count × elementSize.
+        // k. Let countBytes be count × elementSize.
         Checked<size_t> count_bytes_checked = static_cast<size_t>(count);
         count_bytes_checked *= element_size;
         if (count_bytes_checked.has_overflow()) {
-            dbgln("TypedArrayPrototype::copy_within: count_bytes_checked overflowed, returning as if succeeded.");
+            dbgln("TypedArrayPrototype::copy_within: count_bytes overflowed, returning as if succeeded.");
             return typed_array;
         }
 
+        auto buffer_byte_limit = buffer_byte_limit_checked.value();
         auto to_byte_index = to_byte_index_checked.value();
         auto from_byte_index = from_byte_index_checked.value();
         auto count_bytes = count_bytes_checked.value();
@@ -389,11 +360,10 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::copy_within)
 
         i8 direction;
 
-        // i. If fromByteIndex < toByteIndex and toByteIndex < fromByteIndex + countBytes, then
+        // l. If fromByteIndex < toByteIndex and toByteIndex < fromByteIndex + countBytes, then
         if (from_byte_index < to_byte_index && to_byte_index < from_plus_count.value()) {
             // i. Let direction be -1.
             direction = -1;
-
             // ii. Set fromByteIndex to fromByteIndex + countBytes - 1.
             from_byte_index = from_plus_count.value() - 1;
 
@@ -407,27 +377,36 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::copy_within)
             // iii. Set toByteIndex to toByteIndex + countBytes - 1.
             to_byte_index = to_plus_count.value() - 1;
         }
-        // j. Else,
+        // m. Else,
         else {
             // i. Let direction be 1.
             direction = 1;
         }
 
-        // k. Repeat, while countBytes > 0,
-        for (; count_bytes > 0; --count_bytes) {
-            // i. Let value be GetValueFromBuffer(buffer, fromByteIndex, Uint8, true, Unordered).
-            auto value = buffer->get_value<u8>(from_byte_index, true, ArrayBuffer::Order::Unordered);
+        // n. Repeat, while countBytes > 0,
+        while (count_bytes > 0) {
+            // i. If fromByteIndex < bufferByteLimit and toByteIndex < bufferByteLimit, then
+            if (from_byte_index < buffer_byte_limit && to_byte_index < buffer_byte_limit) {
+                // 1. Let value be GetValueFromBuffer(buffer, fromByteIndex, uint8, true, unordered).
+                auto value = buffer->get_value<u8>(from_byte_index, true, ArrayBuffer::Order::Unordered);
 
-            // ii. Perform SetValueInBuffer(buffer, toByteIndex, Uint8, value, true, Unordered).
-            buffer->set_value<u8>(to_byte_index, value, true, ArrayBuffer::Order::Unordered);
+                // 2. Perform SetValueInBuffer(buffer, toByteIndex, uint8, value, true, unordered).
+                buffer->set_value<u8>(to_byte_index, value, true, ArrayBuffer::Order::Unordered);
 
-            // iii. Set fromByteIndex to fromByteIndex + direction.
-            from_byte_index += direction;
+                // 3. Set fromByteIndex to fromByteIndex + direction.
+                from_byte_index += direction;
 
-            // iv. Set toByteIndex to toByteIndex + direction.
-            to_byte_index += direction;
+                // 4. Set toByteIndex to toByteIndex + direction.
+                to_byte_index += direction;
 
-            // v. Set countBytes to countBytes - 1.
+                // 5. Set countBytes to countBytes - 1.
+                --count_bytes;
+            }
+            // ii. Else,
+            else {
+                // 1. Set countBytes to 0.
+                count_bytes = 0;
+            }
         }
     }
 
@@ -441,8 +420,10 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::entries)
     auto& realm = *vm.current_realm();
 
     // 1. Let O be the this value.
-    // 2. Perform ? ValidateTypedArray(O).
-    auto* typed_array = TRY(validate_typed_array_from_this(vm));
+    auto* typed_array = TRY(typed_array_from_this(vm));
+
+    // 2. Perform ? ValidateTypedArray(O, seq-cst).
+    (void)TRY(validate_typed_array(vm, *typed_array, ArrayBuffer::Order::SeqCst));
 
     // 3. Return CreateArrayIterator(O, key+value).
     return ArrayIterator::create(realm, typed_array, Object::PropertyKind::KeyAndValue);
@@ -451,41 +432,72 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::entries)
 // 23.2.3.8 %TypedArray%.prototype.every ( callbackfn [ , thisArg ] ), https://tc39.es/ecma262/#sec-%typedarray%.prototype.every
 JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::every)
 {
-    auto result = true;
-    TRY(for_each_item(vm, "every", [&](auto, auto, auto callback_result) {
-        if (!callback_result.to_boolean()) {
-            result = false;
-            return IterationDecision::Break;
-        }
-        return IterationDecision::Continue;
-    }));
-    return Value(result);
+    auto this_arg = vm.argument(1);
+
+    // 1. Let O be the this value.
+    auto* typed_array = TRY(typed_array_from_this(vm));
+
+    // 2. Let taRecord be ? ValidateTypedArray(O, seq-cst).
+    auto typed_array_record = TRY(validate_typed_array(vm, *typed_array, ArrayBuffer::Order::SeqCst));
+
+    // 3. Let len be TypedArrayLength(taRecord).
+    auto length = typed_array_length(typed_array_record);
+
+    // 4. If IsCallable(callbackfn) is false, throw a TypeError exception.
+    auto callback_function = TRY(callback_from_args(vm, "every"sv));
+
+    // 5. Let k be 0.
+    // 6. Repeat, while k < len,
+    for (size_t k = 0; k < length; ++k) {
+        // a. Let Pk be ! ToString(𝔽(k)).
+        PropertyKey property_key { k };
+
+        // b. Let kValue be ! Get(O, Pk).
+        auto value = MUST(typed_array->get(property_key));
+
+        // c. Let testResult be ToBoolean(? Call(callbackfn, thisArg, « kValue, 𝔽(k), O »)).
+        auto test_result = TRY(call(vm, *callback_function, this_arg, value, Value { k }, typed_array)).to_boolean();
+
+        // d. If testResult is false, return false.
+        if (!test_result)
+            return false;
+
+        // e. Set k to k + 1.
+    }
+
+    // 7. Return true.
+    return true;
 }
 
 // 23.2.3.9 %TypedArray%.prototype.fill ( value [ , start [ , end ] ] ), https://tc39.es/ecma262/#sec-%typedarray%.prototype.fill
 JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::fill)
 {
+    auto value = vm.argument(0);
+    auto start = vm.argument(1);
+    auto end = vm.argument(2);
+
     // 1. Let O be the this value.
-    // 2. Perform ? ValidateTypedArray(O).
-    auto typed_array = TRY(validate_typed_array_from_this(vm));
+    auto* typed_array = TRY(typed_array_from_this(vm));
 
-    // 3. Let len be O.[[ArrayLength]].
-    auto length = typed_array->array_length();
+    // 2. Let taRecord be ? ValidateTypedArray(O, seq-cst).
+    auto typed_array_record = TRY(validate_typed_array(vm, *typed_array, ArrayBuffer::Order::SeqCst));
 
-    Value value;
+    // 3. Let len be TypedArrayLength(taRecord).
+    auto length = typed_array_length(typed_array_record);
+
     // 4. If O.[[ContentType]] is BigInt, set value to ? ToBigInt(value).
     if (typed_array->content_type() == TypedArrayBase::ContentType::BigInt)
-        value = TRY(vm.argument(0).to_bigint(vm));
+        value = TRY(value.to_bigint(vm));
     // 5. Otherwise, set value to ? ToNumber(value).
     else
-        value = TRY(vm.argument(0).to_number(vm));
+        value = TRY(value.to_number(vm));
 
     // 6. Let relativeStart be ? ToIntegerOrInfinity(start).
-    auto relative_start = TRY(vm.argument(1).to_integer_or_infinity(vm));
+    auto relative_start = TRY(start.to_integer_or_infinity(vm));
 
     u32 k;
-    // 7. If relativeStart is -∞, let k be 0.
-    if (Value(relative_start).is_negative_infinity())
+    // 7. If relativeStart = -∞, let k be 0.
+    if (Value { relative_start }.is_negative_infinity())
         k = 0;
     // 8. Else if relativeStart < 0, let k be max(len + relativeStart, 0).
     else if (relative_start < 0)
@@ -494,16 +506,16 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::fill)
     else
         k = min(relative_start, length);
 
-    // 10. If end is undefined, let relativeEnd be len; else let relativeEnd be ? ToIntegerOrInfinity(end).
     double relative_end;
-    if (vm.argument(2).is_undefined())
+    // 10. If end is undefined, let relativeEnd be len; else let relativeEnd be ? ToIntegerOrInfinity(end).
+    if (end.is_undefined())
         relative_end = length;
     else
-        relative_end = TRY(vm.argument(2).to_integer_or_infinity(vm));
+        relative_end = TRY(end.to_integer_or_infinity(vm));
 
     u32 final;
-    // 11. If relativeEnd is -∞, let final be 0.
-    if (Value(relative_end).is_negative_infinity())
+    // 11. If relativeEnd = -∞, let final be 0.
+    if (Value { relative_end }.is_negative_infinity())
         final = 0;
     // 12. Else if relativeEnd < 0, let final be max(len + relativeEnd, 0).
     else if (relative_end < 0)
@@ -512,57 +524,73 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::fill)
     else
         final = min(relative_end, length);
 
-    // 14. If IsDetachedBuffer(O.[[ViewedArrayBuffer]]) is true, throw a TypeError exception.
-    if (typed_array->viewed_array_buffer()->is_detached())
-        return vm.throw_completion<TypeError>(ErrorType::DetachedArrayBuffer);
+    // 14. Set taRecord to MakeTypedArrayWithBufferWitnessRecord(O, seq-cst).
+    typed_array_record = TRY(validate_typed_array(vm, *typed_array, ArrayBuffer::Order::SeqCst));
 
-    // 15. Repeat, while k < final,
-    for (; k < final; ++k) {
+    // 15. If IsTypedArrayOutOfBounds(taRecord) is true, throw a TypeError exception.
+    if (is_typed_array_out_of_bounds(typed_array_record))
+        return vm.throw_completion<TypeError>(ErrorType::BufferOutOfBounds, "TypedArray"sv);
+
+    // 16. Set len to TypedArrayLength(taRecord).
+    length = typed_array_length(typed_array_record);
+
+    // 17. Set final to min(final, len).
+    final = min(final, length);
+
+    // 18. Repeat, while k < final,
+    while (k < final) {
         // a. Let Pk be ! ToString(𝔽(k)).
+        PropertyKey property_key { k };
+
         // b. Perform ! Set(O, Pk, value, true).
-        MUST(typed_array->set(k, value, Object::ShouldThrowExceptions::Yes));
+        MUST(typed_array->set(property_key, value, Object::ShouldThrowExceptions::Yes));
 
         // c. Set k to k + 1.
+        ++k;
     }
 
-    // 16. Return O.
+    // 19. Return O.
     return typed_array;
 }
 
 // 23.2.3.10 %TypedArray%.prototype.filter ( callbackfn [ , thisArg ] ), https://tc39.es/ecma262/#sec-%typedarray%.prototype.filter
 JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::filter)
 {
-    // 1. Let O be the this value.
-    // 2. Perform ? ValidateTypedArray(O).
-    auto* typed_array = TRY(validate_typed_array_from_this(vm));
+    auto this_arg = vm.argument(1);
 
-    // 3. Let len be O.[[ArrayLength]].
-    auto initial_length = typed_array->array_length();
+    // 1. Let O be the this value.
+    auto* typed_array = TRY(typed_array_from_this(vm));
+
+    // 2. Let taRecord be ? ValidateTypedArray(O, seq-cst).
+    auto typed_array_record = TRY(validate_typed_array(vm, *typed_array, ArrayBuffer::Order::SeqCst));
+
+    // 3. Let len be TypedArrayLength(taRecord).
+    auto length = typed_array_length(typed_array_record);
 
     // 4. If IsCallable(callbackfn) is false, throw a TypeError exception.
-    auto* callback_function = TRY(callback_from_args(vm, "filter"));
+    auto callback_function = TRY(callback_from_args(vm, "filter"sv));
 
     // 5. Let kept be a new empty List.
-    MarkedVector<Value> kept(vm.heap());
+    MarkedVector<Value> kept { vm.heap() };
 
-    // 7. Let captured be 0.
+    // 6. Let captured be 0.
     size_t captured = 0;
 
-    auto this_value = vm.argument(1);
-
-    // 5. Let k be 0.
+    // 7. Let k be 0.
     // 8. Repeat, while k < len,
-    for (size_t i = 0; i < initial_length; ++i) {
+    for (size_t k = 0; k < length; ++k) {
         // a. Let Pk be ! ToString(𝔽(k)).
+        PropertyKey property_key { k };
+
         // b. Let kValue be ! Get(O, Pk).
-        auto value = MUST(typed_array->get(i));
+        auto value = MUST(typed_array->get(property_key));
 
         // c. Let selected be ToBoolean(? Call(callbackfn, thisArg, « kValue, 𝔽(k), O »)).
-        auto callback_result = TRY(call(vm, *callback_function, this_value, value, Value((i32)i), typed_array)).to_boolean();
+        auto selected = TRY(call(vm, *callback_function, this_arg, value, Value { k }, typed_array)).to_boolean();
 
         // d. If selected is true, then
-        if (callback_result) {
-            // i. Append kValue to the end of kept.
+        if (selected) {
+            // i. Append kValue to kept.
             kept.append(value);
 
             // ii. Set captured to captured + 1.
@@ -593,97 +621,218 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::filter)
     return filter_array;
 }
 
+enum class Direction {
+    Ascending,
+    Descending,
+};
+
+struct FoundValue {
+    Value index_to_value() const
+    {
+        if (!index.has_value())
+            return Value { -1 };
+        return Value { *index };
+    }
+
+    Optional<u32> index; // [[Index]]
+    Value value;         // [[Value]]
+};
+
+// 23.1.3.12.1 FindViaPredicate ( O, len, direction, predicate, thisArg ), https://tc39.es/ecma262/#sec-findviapredicate
+static ThrowCompletionOr<FoundValue> find_via_predicate(VM& vm, TypedArrayBase const& typed_array, u32 length, Direction direction, Value this_arg, StringView prototype_name)
+{
+    // 1. If IsCallable(predicate) is false, throw a TypeError exception.
+    auto predicate = TRY(callback_from_args(vm, prototype_name));
+
+    Vector<u32> indices;
+    indices.ensure_capacity(length);
+
+    // 2. If direction is ascending, then
+    if (direction == Direction::Ascending) {
+        // a. Let indices be a List of the integers in the interval from 0 (inclusive) to len (exclusive), in ascending order.
+        for (u32 i = 0; i < length; ++i)
+            indices.unchecked_append(i);
+    }
+    // 3. Else,
+    else {
+        // a. Let indices be a List of the integers in the interval from 0 (inclusive) to len (exclusive), in descending order.
+        for (u32 i = length; i > 0; --i)
+            indices.unchecked_append(i - 1);
+    }
+
+    // 4. For each integer k of indices, do
+    for (auto k : indices) {
+        // a. Let Pk be ! ToString(𝔽(k)).
+        PropertyKey property_key { k };
+
+        // b. NOTE: If O is a TypedArray, the following invocation of Get will return a normal completion.
+
+        // c. Let kValue be ? Get(O, Pk).
+        auto value = TRY(typed_array.get(property_key));
+
+        // d. Let testResult be ? Call(predicate, thisArg, « kValue, 𝔽(k), O »).
+        auto test_result = TRY(call(vm, *predicate, this_arg, value, Value { k }, &typed_array));
+
+        // e. If ToBoolean(testResult) is true, return the Record { [[Index]]: 𝔽(k), [[Value]]: kValue }.
+        if (test_result.to_boolean())
+            return FoundValue { k, value };
+    }
+
+    // 5. Return the Record { [[Index]]: -1𝔽, [[Value]]: undefined }.
+    return FoundValue { {}, js_undefined() };
+}
+
 // 23.2.3.11 %TypedArray%.prototype.find ( predicate [ , thisArg ] ), https://tc39.es/ecma262/#sec-%typedarray%.prototype.find
 JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::find)
 {
-    auto result = js_undefined();
-    TRY(for_each_item(vm, "find", [&](auto, auto value, auto callback_result) {
-        if (callback_result.to_boolean()) {
-            result = value;
-            return IterationDecision::Break;
-        }
-        return IterationDecision::Continue;
-    }));
-    return result;
+    auto this_arg = vm.argument(1);
+
+    // 1. Let O be the this value.
+    auto* typed_array = TRY(typed_array_from_this(vm));
+
+    // 2. Let taRecord be ? ValidateTypedArray(O, seq-cst).
+    auto typed_array_record = TRY(validate_typed_array(vm, *typed_array, ArrayBuffer::Order::SeqCst));
+
+    // 3. Let len be TypedArrayLength(taRecord).
+    auto length = typed_array_length(typed_array_record);
+
+    // 4. Let findRec be ? FindViaPredicate(O, len, ascending, predicate, thisArg).
+    auto find_record = TRY(find_via_predicate(vm, *typed_array, length, Direction::Ascending, this_arg, "find"sv));
+
+    // 5. Return findRec.[[Value]].
+    return find_record.value;
 }
 
 // 23.2.3.12 %TypedArray%.prototype.findIndex ( predicate [ , thisArg ] ), https://tc39.es/ecma262/#sec-%typedarray%.prototype.findindex
 JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::find_index)
 {
-    auto result_index = -1;
-    TRY(for_each_item(vm, "findIndex", [&](auto index, auto, auto callback_result) {
-        if (callback_result.to_boolean()) {
-            result_index = index;
-            return IterationDecision::Break;
-        }
-        return IterationDecision::Continue;
-    }));
-    return Value(result_index);
+    auto this_arg = vm.argument(1);
+
+    // 1. Let O be the this value.
+    auto* typed_array = TRY(typed_array_from_this(vm));
+
+    // 2. Let taRecord be ? ValidateTypedArray(O, seq-cst).
+    auto typed_array_record = TRY(validate_typed_array(vm, *typed_array, ArrayBuffer::Order::SeqCst));
+
+    // 3. Let len be TypedArrayLength(taRecord).
+    auto length = typed_array_length(typed_array_record);
+
+    // 4. Let findRec be ? FindViaPredicate(O, len, ascending, predicate, thisArg).
+    auto find_record = TRY(find_via_predicate(vm, *typed_array, length, Direction::Ascending, this_arg, "findIndex"sv));
+
+    // 5. Return findRec.[[Index]].
+    return find_record.index_to_value();
 }
 
 // 23.2.3.13 %TypedArray%.prototype.findLast ( predicate [ , thisArg ] ), https://tc39.es/ecma262/#sec-%typedarray%.prototype.findlast
 JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::find_last)
 {
-    auto result = js_undefined();
-    TRY(for_each_item_from_last(vm, "findLast", [&](auto, auto value, auto callback_result) {
-        if (callback_result.to_boolean()) {
-            result = value;
-            return IterationDecision::Break;
-        }
-        return IterationDecision::Continue;
-    }));
-    return result;
+    auto this_arg = vm.argument(1);
+
+    // 1. Let O be the this value.
+    auto* typed_array = TRY(typed_array_from_this(vm));
+
+    // 2. Let taRecord be ? ValidateTypedArray(O, seq-cst).
+    auto typed_array_record = TRY(validate_typed_array(vm, *typed_array, ArrayBuffer::Order::SeqCst));
+
+    // 3. Let len be TypedArrayLength(taRecord).
+    auto length = typed_array_length(typed_array_record);
+
+    // 4. Let findRec be ? FindViaPredicate(O, len, descending, predicate, thisArg).
+    auto find_record = TRY(find_via_predicate(vm, *typed_array, length, Direction::Descending, this_arg, "findLast"sv));
+
+    // 5. Return findRec.[[Value]].
+    return find_record.value;
 }
 
 // 23.2.3.14 %TypedArray%.prototype.findLastIndex ( predicate [ , thisArg ] ), https://tc39.es/ecma262/#sec-%typedarray%.prototype.findlastindex
 JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::find_last_index)
 {
-    auto result_index = -1;
-    TRY(for_each_item_from_last(vm, "findLastIndex", [&](auto index, auto, auto callback_result) {
-        if (callback_result.to_boolean()) {
-            result_index = index;
-            return IterationDecision::Break;
-        }
-        return IterationDecision::Continue;
-    }));
-    return Value(result_index);
+    auto this_arg = vm.argument(1);
+
+    // 1. Let O be the this value.
+    auto* typed_array = TRY(typed_array_from_this(vm));
+
+    // 2. Let taRecord be ? ValidateTypedArray(O, seq-cst).
+    auto typed_array_record = TRY(validate_typed_array(vm, *typed_array, ArrayBuffer::Order::SeqCst));
+
+    // 3. Let len be TypedArrayLength(taRecord).
+    auto length = typed_array_length(typed_array_record);
+
+    // 4. Let findRec be ? FindViaPredicate(O, len, descending, predicate, thisArg).
+    auto find_record = TRY(find_via_predicate(vm, *typed_array, length, Direction::Descending, this_arg, "findLastIndex"sv));
+
+    // 5. Return findRec.[[Index]].
+    return find_record.index_to_value();
 }
 
 // 23.2.3.15 %TypedArray%.prototype.forEach ( callbackfn [ , thisArg ] ), https://tc39.es/ecma262/#sec-%typedarray%.prototype.foreach
 JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::for_each)
 {
-    TRY(for_each_item(vm, "forEach", [](auto, auto, auto) {
-        return IterationDecision::Continue;
-    }));
+    auto this_arg = vm.argument(1);
+
+    // 1. Let O be the this value.
+    auto* typed_array = TRY(typed_array_from_this(vm));
+
+    // 2. Let taRecord be ? ValidateTypedArray(O, seq-cst).
+    auto typed_array_record = TRY(validate_typed_array(vm, *typed_array, ArrayBuffer::Order::SeqCst));
+
+    // 3. Let len be TypedArrayLength(taRecord).
+    auto length = typed_array_length(typed_array_record);
+
+    // 4. If IsCallable(callbackfn) is false, throw a TypeError exception.
+    auto callback_function = TRY(callback_from_args(vm, "forEach"sv));
+
+    // 5. Let k be 0.
+    // 6. Repeat, while k < len,
+    for (size_t k = 0; k < length; ++k) {
+        // a. Let Pk be ! ToString(𝔽(k)).
+        PropertyKey property_key { k };
+
+        // b. Let kValue be ! Get(O, Pk).
+        auto value = MUST(typed_array->get(property_key));
+
+        // c. Perform ? Call(callbackfn, thisArg, « kValue, 𝔽(k), O »).
+        TRY(call(vm, *callback_function, this_arg, value, Value { k }, typed_array));
+
+        // d. Set k to k + 1.
+    }
+
+    // 7. Return undefined.
     return js_undefined();
 }
 
 // 23.2.3.16 %TypedArray%.prototype.includes ( searchElement [ , fromIndex ] ), https://tc39.es/ecma262/#sec-%typedarray%.prototype.includes
 JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::includes)
 {
+    auto search_element = vm.argument(0);
+    auto from_index = vm.argument(1);
+
     // 1. Let O be the this value.
-    // 2. Perform ? ValidateTypedArray(O).
-    auto typed_array = TRY(validate_typed_array_from_this(vm));
+    auto* typed_array = TRY(typed_array_from_this(vm));
 
-    // 3. Let len be O.[[ArrayLength]].
-    auto length = typed_array->array_length();
+    // 2. Let taRecord be ? ValidateTypedArray(O, seq-cst).
+    auto typed_array_record = TRY(validate_typed_array(vm, *typed_array, ArrayBuffer::Order::SeqCst));
 
-    // 4. If len is 0, return false.
+    // 3. Let len be TypedArrayLength(taRecord).
+    auto length = typed_array_length(typed_array_record);
+
+    // 4. If len = 0, return false.
     if (length == 0)
-        return Value(false);
+        return Value { false };
 
     // 5. Let n be ? ToIntegerOrInfinity(fromIndex).
-    auto n = TRY(vm.argument(1).to_integer_or_infinity(vm));
+    auto n = TRY(from_index.to_integer_or_infinity(vm));
 
     // 6. Assert: If fromIndex is undefined, then n is 0.
-    if (vm.argument(1).is_undefined())
+    if (from_index.is_undefined())
         VERIFY(n == 0);
 
-    auto value_n = Value(n);
-    // 7. If n is +∞, return false.
+    Value value_n { n };
+    // 7. If n = +∞, return false.
     if (value_n.is_positive_infinity())
-        return Value(false);
-    // 8. Else if n is -∞, set n to 0.
+        return Value { false };
+    // 8. Else if n = -∞, set n to 0.
     else if (value_n.is_negative_infinity())
         n = 0;
 
@@ -696,57 +845,63 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::includes)
     // 10. Else,
     else {
         // a. Let k be len + n.
-        auto relative_k = length + n;
+        auto relative_k = length + n; // Ensures we dont overflow `k`.
 
         // b. If k < 0, set k to 0.
         if (relative_k < 0)
             relative_k = 0;
+
         k = relative_k;
     }
 
-    auto search_element = vm.argument(0);
     // 11. Repeat, while k < len,
-    for (; k < length; ++k) {
+    while (k < length) {
         // a. Let elementK be ! Get(O, ! ToString(𝔽(k))).
         auto element_k = MUST(typed_array->get(k));
 
         // b. If SameValueZero(searchElement, elementK) is true, return true.
         if (same_value_zero(search_element, element_k))
-            return Value(true);
+            return Value { true };
 
         // c. Set k to k + 1.
+        ++k;
     }
 
     // 12. Return false.
-    return Value(false);
+    return Value { false };
 }
 
 // 23.2.3.17 %TypedArray%.prototype.indexOf ( searchElement [ , fromIndex ] ), https://tc39.es/ecma262/#sec-%typedarray%.prototype.indexof
 JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::index_of)
 {
+    auto search_element = vm.argument(0);
+    auto from_index = vm.argument(1);
+
     // 1. Let O be the this value.
-    // 2. Perform ? ValidateTypedArray(O).
-    auto typed_array = TRY(validate_typed_array_from_this(vm));
+    auto* typed_array = TRY(typed_array_from_this(vm));
 
-    // 3. Let len be O.[[ArrayLength]].
-    auto length = typed_array->array_length();
+    // 2. Let taRecord be ? ValidateTypedArray(O, seq-cst).
+    auto typed_array_record = TRY(validate_typed_array(vm, *typed_array, ArrayBuffer::Order::SeqCst));
 
-    // 4. If len is 0, return -1𝔽.
+    // 3. Let len be TypedArrayLength(taRecord).
+    auto length = typed_array_length(typed_array_record);
+
+    // 4. If len = 0, return -1𝔽.
     if (length == 0)
-        return Value(-1);
+        return Value { -1 };
 
     // 5. Let n be ? ToIntegerOrInfinity(fromIndex).
-    auto n = TRY(vm.argument(1).to_integer_or_infinity(vm));
+    auto n = TRY(from_index.to_integer_or_infinity(vm));
 
     // 6. Assert: If fromIndex is undefined, then n is 0.
-    if (vm.argument(1).is_undefined())
+    if (from_index.is_undefined())
         VERIFY(n == 0);
 
-    auto value_n = Value(n);
-    // 7. If n is +∞, return -1𝔽.
+    Value value_n { n };
+    // 7. If n = +∞, return -1𝔽.
     if (value_n.is_positive_infinity())
-        return Value(-1);
-    // 8. Else if n is -∞, set n to 0.
+        return Value { -1 };
+    // 8. Else if n = -∞, set n to 0.
     else if (value_n.is_negative_infinity())
         n = 0;
 
@@ -764,12 +919,12 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::index_of)
         // b. If k < 0, set k to 0.
         if (relative_k < 0)
             relative_k = 0;
+
         k = relative_k;
     }
 
     // 11. Repeat, while k < len,
-    auto search_element = vm.argument(0);
-    for (; k < length; ++k) {
+    while (k < length) {
         // a. Let kPresent be ! HasProperty(O, ! ToString(𝔽(k))).
         auto k_present = MUST(typed_array->has_property(k));
 
@@ -778,52 +933,60 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::index_of)
             // i. Let elementK be ! Get(O, ! ToString(𝔽(k))).
             auto element_k = MUST(typed_array->get(k));
 
-            // ii. Let same be IsStrictlyEqual(searchElement, elementK).
-            // iii. If same is true, return 𝔽(k).
+            // ii. If IsStrictlyEqual(searchElement, elementK) is true, return 𝔽(k).
             if (is_strictly_equal(search_element, element_k))
-                return Value(k);
+                return Value { k };
         }
 
         // c. Set k to k + 1.
+        ++k;
     }
 
     // 12. Return -1𝔽.
-    return Value(-1);
+    return Value { -1 };
 }
 
 // 23.2.3.18 %TypedArray%.prototype.join ( separator ), https://tc39.es/ecma262/#sec-%typedarray%.prototype.join
 JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::join)
 {
-    // 1. Let O be the this value.
-    // 2. Perform ? ValidateTypedArray(O).
-    auto* typed_array = TRY(validate_typed_array_from_this(vm));
+    auto separator = vm.argument(0);
 
-    // 3. Let len be O.[[ArrayLength]].
-    auto length = typed_array->array_length();
+    // 1. Let O be the this value.
+    auto* typed_array = TRY(typed_array_from_this(vm));
+
+    // 2. Let taRecord be ? ValidateTypedArray(O, seq-cst).
+    auto typed_array_record = TRY(validate_typed_array(vm, *typed_array, ArrayBuffer::Order::SeqCst));
+
+    // 3. Let len be TypedArrayLength(taRecord).
+    auto length = typed_array_length(typed_array_record);
+
+    String sep {};
 
     // 4. If separator is undefined, let sep be ",".
+    if (separator.is_undefined())
+        sep = String::from_code_point(',');
     // 5. Else, let sep be ? ToString(separator).
-    ByteString separator = ",";
-    if (!vm.argument(0).is_undefined())
-        separator = TRY(vm.argument(0).to_byte_string(vm));
+    else
+        sep = TRY(separator.to_string(vm));
 
     // 6. Let R be the empty String.
     StringBuilder builder;
 
     // 7. Let k be 0.
     // 8. Repeat, while k < len,
-    for (size_t i = 0; i < length; ++i) {
+    for (size_t k = 0; k < length; ++k) {
         // a. If k > 0, set R to the string-concatenation of R and sep.
-        if (i > 0)
-            builder.append(separator);
+        if (k > 0)
+            builder.append(sep);
 
         // b. Let element be ! Get(O, ! ToString(𝔽(k))).
-        auto element = MUST(typed_array->get(i));
+        auto element = MUST(typed_array->get(k));
+
+        String next {};
 
         // c. If element is undefined, let next be the empty String; otherwise, let next be ! ToString(element).
-        if (element.is_undefined())
-            continue;
-        auto next = MUST(element.to_byte_string(vm));
+        if (!element.is_undefined())
+            next = MUST(element.to_string(vm));
 
         // d. Set R to the string-concatenation of R and next.
         builder.append(next);
@@ -832,7 +995,7 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::join)
     }
 
     // 9. Return R.
-    return PrimitiveString::create(vm, builder.to_byte_string());
+    return PrimitiveString::create(vm, MUST(builder.to_string()));
 }
 
 // 23.2.3.19 %TypedArray%.prototype.keys ( ), https://tc39.es/ecma262/#sec-%typedarray%.prototype.keys
@@ -841,8 +1004,10 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::keys)
     auto& realm = *vm.current_realm();
 
     // 1. Let O be the this value.
-    // 2. Perform ? ValidateTypedArray(O).
-    auto* typed_array = TRY(validate_typed_array_from_this(vm));
+    auto* typed_array = TRY(typed_array_from_this(vm));
+
+    // 2. Perform ? ValidateTypedArray(O, seq-cst).
+    (void)TRY(validate_typed_array(vm, *typed_array, ArrayBuffer::Order::SeqCst));
 
     // 3. Return CreateArrayIterator(O, key).
     return ArrayIterator::create(realm, typed_array, Object::PropertyKind::Key);
@@ -855,18 +1020,19 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::last_index_of)
     auto from_index = vm.argument(1);
 
     // 1. Let O be the this value.
-    // 2. Perform ? ValidateTypedArray(O).
-    auto* typed_array = TRY(validate_typed_array_from_this(vm));
+    auto* typed_array = TRY(typed_array_from_this(vm));
 
-    // 3. Let len be O.[[ArrayLength]].
-    auto length = typed_array->array_length();
+    // 2. Let taRecord be ? ValidateTypedArray(O, seq-cst).
+    auto typed_array_record = TRY(validate_typed_array(vm, *typed_array, ArrayBuffer::Order::SeqCst));
+
+    // 3. Let len be TypedArrayLength(taRecord).
+    auto length = typed_array_length(typed_array_record);
 
     // 4. If len = 0, return -1𝔽.
     if (length == 0)
-        return Value(-1);
+        return Value { -1 };
 
     double n;
-
     // 5. If fromIndex is present, let n be ? ToIntegerOrInfinity(fromIndex); else let n be len - 1.
     if (vm.argument_count() > 1)
         n = TRY(from_index.to_integer_or_infinity(vm));
@@ -874,11 +1040,10 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::last_index_of)
         n = length - 1;
 
     // 6. If n = -∞, return -1𝔽.
-    if (Value(n).is_negative_infinity())
-        return Value(-1);
+    if (Value { n }.is_negative_infinity())
+        return Value { -1 };
 
     i32 k;
-
     // 7. If n ≥ 0, then
     if (n >= 0) {
         // a. Let k be min(n, len - 1).
@@ -887,14 +1052,16 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::last_index_of)
     // 8. Else,
     else {
         // a. Let k be len + n.
-        auto relative_k = length + n;
-        if (relative_k < 0) // ensures we dont underflow `k`
+        auto relative_k = length + n; // Ensures we dont overflow `k`.
+
+        if (relative_k < 0)
             relative_k = -1;
+
         k = relative_k;
     }
 
     // 9. Repeat, while k ≥ 0,
-    for (; k >= 0; --k) {
+    while (k >= 0) {
         // a. Let kPresent be ! HasProperty(O, ! ToString(𝔽(k))).
         auto k_present = MUST(typed_array->has_property(k));
 
@@ -905,14 +1072,15 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::last_index_of)
 
             // ii. If IsStrictlyEqual(searchElement, elementK) is true, return 𝔽(k).
             if (is_strictly_equal(search_element, element_k))
-                return Value(k);
+                return Value { k };
         }
 
         // c. Set k to k - 1.
+        --k;
     }
 
     // 10. Return -1𝔽.
-    return Value(-1);
+    return Value { -1 };
 }
 
 // 23.2.3.21 get %TypedArray%.prototype.length, https://tc39.es/ecma262/#sec-get-%typedarray%.prototype.length
@@ -920,76 +1088,83 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::length_getter)
 {
     // 1. Let O be the this value.
     // 2. Perform ? RequireInternalSlot(O, [[TypedArrayName]]).
+    // 3. Assert: O has [[ViewedArrayBuffer]] and [[ArrayLength]] internal slots.
     auto* typed_array = TRY(typed_array_from_this(vm));
 
-    // 3. Assert: O has [[ViewedArrayBuffer]] and [[ArrayLength]] internal slots.
-    // 4. Let buffer be O.[[ViewedArrayBuffer]].
-    auto* buffer = typed_array->viewed_array_buffer();
-    VERIFY(buffer);
+    // 4. Let taRecord be MakeTypedArrayWithBufferWitnessRecord(O, seq-cst).
+    auto typed_array_record = make_typed_array_with_buffer_witness_record(*typed_array, ArrayBuffer::Order::SeqCst);
 
-    // 5. If IsDetachedBuffer(buffer) is true, return +0𝔽.
-    if (buffer->is_detached())
-        return Value(0);
+    // 5. If IsTypedArrayOutOfBounds(taRecord) is true, return +0𝔽.
+    if (is_typed_array_out_of_bounds(typed_array_record))
+        return Value { 0 };
 
-    // 6. Let length be O.[[ArrayLength]].
-    auto length = typed_array->array_length();
+    // 6. Let length be TypedArrayLength(taRecord).
+    auto length = typed_array_length(typed_array_record);
 
     // 7. Return 𝔽(length).
-    return Value(length);
+    return Value { length };
 }
 
 // 23.2.3.22 %TypedArray%.prototype.map ( callbackfn [ , thisArg ] ), https://tc39.es/ecma262/#sec-%typedarray%.prototype.map
 JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::map)
 {
-    // 1. Let O be the this value.
-    // 2. Perform ? ValidateTypedArray(O).
-    auto* typed_array = TRY(validate_typed_array_from_this(vm));
+    auto this_arg = vm.argument(1);
 
-    // 3. Let len be O.[[ArrayLength]].
-    auto initial_length = typed_array->array_length();
+    // 1. Let O be the this value.
+    auto* typed_array = TRY(typed_array_from_this(vm));
+
+    // 2. Let taRecord be ? ValidateTypedArray(O, seq-cst).
+    auto typed_array_record = TRY(validate_typed_array(vm, *typed_array, ArrayBuffer::Order::SeqCst));
+
+    // 3. Let len be TypedArrayLength(taRecord).
+    auto length = typed_array_length(typed_array_record);
 
     // 4. If IsCallable(callbackfn) is false, throw a TypeError exception.
-    auto* callback_function = TRY(callback_from_args(vm, "map"));
+    auto callback_function = TRY(callback_from_args(vm, "map"sv));
 
     // 5. Let A be ? TypedArraySpeciesCreate(O, « 𝔽(len) »).
     MarkedVector<Value> arguments(vm.heap());
-    arguments.empend(initial_length);
-    auto* return_array = TRY(typed_array_species_create(vm, *typed_array, move(arguments)));
-
-    auto this_value = vm.argument(1);
+    arguments.empend(length);
+    auto* array = TRY(typed_array_species_create(vm, *typed_array, move(arguments)));
 
     // 6. Let k be 0.
     // 7. Repeat, while k < len,
-    for (size_t i = 0; i < initial_length; ++i) {
+    for (size_t k = 0; k < length; ++k) {
         // a. Let Pk be ! ToString(𝔽(k)).
+        PropertyKey property_key { k };
+
         // b. Let kValue be ! Get(O, Pk).
-        auto value = MUST(typed_array->get(i));
+        auto value = MUST(typed_array->get(property_key));
 
         // c. Let mappedValue be ? Call(callbackfn, thisArg, « kValue, 𝔽(k), O »).
-        auto mapped_value = TRY(call(vm, *callback_function, this_value, value, Value((i32)i), typed_array));
+        auto mapped_value = TRY(call(vm, *callback_function, this_arg, value, Value { k }, typed_array));
 
         // d. Perform ? Set(A, Pk, mappedValue, true).
-        TRY(return_array->set(i, mapped_value, Object::ShouldThrowExceptions::Yes));
+        TRY(array->set(property_key, mapped_value, Object::ShouldThrowExceptions::Yes));
 
         // e. Set k to k + 1.
     }
 
     // 8. Return A.
-    return return_array;
+    return array;
 }
 
 // 23.2.3.23 %TypedArray%.prototype.reduce ( callbackfn [ , initialValue ] ), https://tc39.es/ecma262/#sec-%typedarray%.prototype.reduce
 JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::reduce)
 {
-    // 1. Let O be the this value.
-    // 2. Perform ? ValidateTypedArray(O).
-    auto* typed_array = TRY(validate_typed_array_from_this(vm));
+    auto initial_value = vm.argument(1);
 
-    // 3. Let len be O.[[ArrayLength]].
-    auto length = typed_array->array_length();
+    // 1. Let O be the this value.
+    auto* typed_array = TRY(typed_array_from_this(vm));
+
+    // 2. Let taRecord be ? ValidateTypedArray(O, seq-cst).
+    auto typed_array_record = TRY(validate_typed_array(vm, *typed_array, ArrayBuffer::Order::SeqCst));
+
+    // 3. Let len be TypedArrayLength(taRecord).
+    auto length = typed_array_length(typed_array_record);
 
     // 4. If IsCallable(callbackfn) is false, throw a TypeError exception.
-    auto* callback_function = TRY(callback_from_args(vm, vm.names.reduce.as_string()));
+    auto callback_function = TRY(callback_from_args(vm, "reduce"sv));
 
     // 5. If len = 0 and initialValue is not present, throw a TypeError exception.
     if (length == 0 && vm.argument_count() <= 1)
@@ -999,87 +1174,101 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::reduce)
     u32 k = 0;
 
     // 7. Let accumulator be undefined.
-    Value accumulator;
+    auto accumulator = js_undefined();
 
     // 8. If initialValue is present, then
     if (vm.argument_count() > 1) {
         // a. Set accumulator to initialValue.
-        accumulator = vm.argument(1);
+        accumulator = initial_value;
     }
     // 9. Else,
     else {
         // a. Let Pk be ! ToString(𝔽(k)).
+        PropertyKey property_key { k };
+
         // b. Set accumulator to ! Get(O, Pk).
-        accumulator = MUST(typed_array->get(k));
+        accumulator = MUST(typed_array->get(property_key));
 
         // c. Set k to k + 1.
         ++k;
     }
 
     // 10. Repeat, while k < len,
-    for (; k < length; ++k) {
+    while (k < length) {
         // a. Let Pk be ! ToString(𝔽(k)).
+        PropertyKey property_key { k };
+
         // b. Let kValue be ! Get(O, Pk).
-        auto k_value = MUST(typed_array->get(k));
+        auto value = MUST(typed_array->get(k));
 
         // c. Set accumulator to ? Call(callbackfn, undefined, « accumulator, kValue, 𝔽(k), O »).
-        accumulator = TRY(call(vm, *callback_function, js_undefined(), accumulator, k_value, Value(k), typed_array));
+        accumulator = TRY(call(vm, *callback_function, js_undefined(), accumulator, value, Value { k }, typed_array));
 
         // d. Set k to k + 1.
+        ++k;
     }
 
     // 11. Return accumulator.
     return accumulator;
 }
 
-// 23.2.3.24 %TypedArray%.prototype.reduceRight ( callbackfn [ , initialValue ] ), https://tc39.es/ecma262/#sec-%typedarray%.prototype.reduce
+// 23.2.3.24 %TypedArray%.prototype.reduceRight ( callbackfn [ , initialValue ] ), https://tc39.es/ecma262/#sec-%typedarray%.prototype.reduceright
 JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::reduce_right)
 {
-    // 1. Let O be the this value.
-    // 2. Perform ? ValidateTypedArray(O).
-    auto* typed_array = TRY(validate_typed_array_from_this(vm));
+    auto initial_value = vm.argument(1);
 
-    // 3. Let len be O.[[ArrayLength]].
-    auto length = typed_array->array_length();
+    // 1. Let O be the this value.
+    auto* typed_array = TRY(typed_array_from_this(vm));
+
+    // 2. Let taRecord be ? ValidateTypedArray(O, seq-cst).
+    auto typed_array_record = TRY(validate_typed_array(vm, *typed_array, ArrayBuffer::Order::SeqCst));
+
+    // 3. Let len be TypedArrayLength(taRecord).
+    auto length = typed_array_length(typed_array_record);
 
     // 4. If IsCallable(callbackfn) is false, throw a TypeError exception.
-    auto* callback_function = TRY(callback_from_args(vm, vm.names.reduce.as_string()));
+    auto callback_function = TRY(callback_from_args(vm, "reduceRight"sv));
 
-    // 5. If len is 0 and initialValue is not present, throw a TypeError exception.
+    // 5. If len = 0 and initialValue is not present, throw a TypeError exception.
     if (length == 0 && vm.argument_count() <= 1)
         return vm.throw_completion<TypeError>(ErrorType::ReduceNoInitial);
 
     // 6. Let k be len - 1.
-    i32 k = (i32)length - 1;
+    auto k = static_cast<i32>(length) - 1;
 
     // 7. Let accumulator be undefined.
-    Value accumulator;
+    auto accumulator = js_undefined();
 
     // 8. If initialValue is present, then
     if (vm.argument_count() > 1) {
         // a. Set accumulator to initialValue.
-        accumulator = vm.argument(1);
+        accumulator = initial_value;
     }
     // 9. Else,
     else {
         // a. Let Pk be ! ToString(𝔽(k)).
+        PropertyKey property_key { k };
+
         // b. Set accumulator to ! Get(O, Pk).
-        accumulator = MUST(typed_array->get(k));
+        accumulator = MUST(typed_array->get(property_key));
 
         // c. Set k to k - 1.
         --k;
     }
 
     // 10. Repeat, while k ≥ 0,
-    for (; k >= 0; --k) {
+    while (k >= 0) {
         // a. Let Pk be ! ToString(𝔽(k)).
+        PropertyKey property_key { k };
+
         // b. Let kValue be ! Get(O, Pk).
-        auto k_value = MUST(typed_array->get(k));
+        auto value = MUST(typed_array->get(k));
 
         // c. Set accumulator to ? Call(callbackfn, undefined, « accumulator, kValue, 𝔽(k), O »).
-        accumulator = TRY(call(vm, *callback_function, js_undefined(), accumulator, k_value, Value(k), typed_array));
+        accumulator = TRY(call(vm, *callback_function, js_undefined(), accumulator, value, Value { k }, typed_array));
 
         // d. Set k to k - 1.
+        --k;
     }
 
     // 11. Return accumulator.
@@ -1090,34 +1279,40 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::reduce_right)
 JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::reverse)
 {
     // 1. Let O be the this value.
-    // 2. Perform ? ValidateTypedArray(O).
-    auto* typed_array = TRY(validate_typed_array_from_this(vm));
+    auto* typed_array = TRY(typed_array_from_this(vm));
 
-    // 3. Let len be O.[[ArrayLength]].
-    auto length = typed_array->array_length();
+    // 2. Let taRecord be ? ValidateTypedArray(O, seq-cst).
+    auto typed_array_record = TRY(validate_typed_array(vm, *typed_array, ArrayBuffer::Order::SeqCst));
+
+    // 3. Let len be TypedArrayLength(taRecord).
+    auto length = typed_array_length(typed_array_record);
 
     // 4. Let middle be floor(len / 2).
     auto middle = length / 2;
 
     // 5. Let lower be 0.
     // 6. Repeat, while lower ≠ middle,
-    for (size_t lower = 0; lower != middle; ++lower) {
+    for (u32 lower = 0; lower != middle; ++lower) {
         // a. Let upper be len - lower - 1.
         auto upper = length - lower - 1;
 
         // b. Let upperP be ! ToString(𝔽(upper)).
-        // d. Let lowerValue be ! Get(O, lowerP).
-        auto lower_value = MUST(typed_array->get(lower));
+        PropertyKey upper_property_key { upper };
 
         // c. Let lowerP be ! ToString(𝔽(lower)).
+        PropertyKey lower_property_key { lower };
+
+        // d. Let lowerValue be ! Get(O, lowerP).
+        auto lower_value = MUST(typed_array->get(lower_property_key));
+
         // e. Let upperValue be ! Get(O, upperP).
-        auto upper_value = MUST(typed_array->get(upper));
+        auto upper_value = MUST(typed_array->get(upper_property_key));
 
         // f. Perform ! Set(O, lowerP, upperValue, true).
-        MUST(typed_array->set(lower, upper_value, Object::ShouldThrowExceptions::Yes));
+        MUST(typed_array->set(lower_property_key, upper_value, Object::ShouldThrowExceptions::Yes));
 
         // g. Perform ! Set(O, upperP, lowerValue, true).
-        MUST(typed_array->set(upper, lower_value, Object::ShouldThrowExceptions::Yes));
+        MUST(typed_array->set(upper_property_key, lower_value, Object::ShouldThrowExceptions::Yes));
 
         // h. Set lower to lower + 1.
     }
@@ -1127,68 +1322,74 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::reverse)
 }
 
 // 23.2.3.26.1 SetTypedArrayFromTypedArray ( target, targetOffset, source ), https://tc39.es/ecma262/#sec-settypedarrayfromtypedarray
-static ThrowCompletionOr<void> set_typed_array_from_typed_array(VM& vm, TypedArrayBase& target, double target_offset, TypedArrayBase& source)
+static ThrowCompletionOr<void> set_typed_array_from_typed_array(VM& vm, TypedArrayBase& target, double target_offset, TypedArrayBase const& source)
 {
     // 1. Let targetBuffer be target.[[ViewedArrayBuffer]].
     auto* target_buffer = target.viewed_array_buffer();
 
-    // 2. If IsDetachedBuffer(targetBuffer) is true, throw a TypeError exception.
-    if (target_buffer->is_detached())
-        return vm.throw_completion<TypeError>(ErrorType::DetachedArrayBuffer);
+    // 2. Let targetRecord be MakeTypedArrayWithBufferWitnessRecord(target, seq-cst)
+    auto target_record = make_typed_array_with_buffer_witness_record(target, ArrayBuffer::Order::SeqCst);
 
-    // 3. Let targetLength be target.[[ArrayLength]].
-    auto target_length = target.array_length();
+    // 3. If IsTypedArrayOutOfBounds(targetRecord) is true, throw a TypeError exception.
+    if (is_typed_array_out_of_bounds(target_record))
+        return vm.throw_completion<TypeError>(ErrorType::BufferOutOfBounds, "TypedArray"sv);
 
-    // 4. Let srcBuffer be source.[[ViewedArrayBuffer]].
+    // 4. Let targetLength be TypedArrayLength(targetRecord).
+    auto target_length = typed_array_length(target_record);
+
+    // 5. Let srcBuffer be source.[[ViewedArrayBuffer]].
     auto* source_buffer = source.viewed_array_buffer();
 
-    // 5. If IsDetachedBuffer(srcBuffer) is true, throw a TypeError exception.
-    if (source_buffer->is_detached())
-        return vm.throw_completion<TypeError>(ErrorType::DetachedArrayBuffer);
+    // 6. Let srcRecord be MakeTypedArrayWithBufferWitnessRecord(source, seq-cst).
+    auto source_record = make_typed_array_with_buffer_witness_record(source, ArrayBuffer::Order::SeqCst);
 
-    // 6. Let targetType be TypedArrayElementType(target).
-    // 7. Let targetElementSize be TypedArrayElementSize(target).
+    // 7. If IsTypedArrayOutOfBounds(srcRecord) is true, throw a TypeError exception.
+    if (is_typed_array_out_of_bounds(source_record))
+        return vm.throw_completion<TypeError>(ErrorType::BufferOutOfBounds, "TypedArray"sv);
+
+    // 8. Let srcLength be TypedArrayLength(srcRecord).
+    auto source_length = typed_array_length(source_record);
+
+    // 9. Let targetType be TypedArrayElementType(target).
+    // 10. Let targetElementSize be TypedArrayElementSize(target).
     auto target_element_size = target.element_size();
 
-    // 8. Let targetByteOffset be target.[[ByteOffset]].
+    // 11. Let targetByteOffset be target.[[ByteOffset]].
     auto target_byte_offset = target.byte_offset();
 
-    // 9. Let srcType be TypedArrayElementType(source).
-    // 10. Let srcElementSize be TypedArrayElementSize(source).
+    // 12. Let srcType be TypedArrayElementType(source).
+    // 13. Let srcElementSize be TypedArrayElementSize(source).
     auto source_element_size = source.element_size();
 
-    // 11. Let srcLength be source.[[ArrayLength]].
-    auto source_length = source.array_length();
-
-    // 12. Let srcByteOffset be source.[[ByteOffset]].
+    // 14. Let srcByteOffset be source.[[ByteOffset]].
     auto source_byte_offset = source.byte_offset();
 
-    // 13. If targetOffset is +∞, throw a RangeError exception.
-    if (isinf(target_offset))
+    // 15. If targetOffset = +∞, throw a RangeError exception.
+    if (Value { target_offset }.is_positive_infinity())
         return vm.throw_completion<RangeError>(ErrorType::TypedArrayInvalidTargetOffset, "finite");
 
-    // 14. If srcLength + targetOffset > targetLength, throw a RangeError exception.
+    // 16. If srcLength + targetOffset > targetLength, throw a RangeError exception.
     Checked<size_t> checked = source_length;
     checked += static_cast<u32>(target_offset);
     if (checked.has_overflow() || checked.value() > target_length)
         return vm.throw_completion<RangeError>(ErrorType::TypedArrayOverflowOrOutOfBounds, "target length");
 
-    // 15. If target.[[ContentType]] ≠ source.[[ContentType]], throw a TypeError exception.
+    // 17. If target.[[ContentType]] is not source.[[ContentType]], throw a TypeError exception.
     if (target.content_type() != source.content_type())
         return vm.throw_completion<TypeError>(ErrorType::TypedArrayInvalidCopy, target.class_name(), source.class_name());
 
-    // FIXME: 16. If both IsSharedArrayBuffer(srcBuffer) and IsSharedArrayBuffer(targetBuffer) are true, then
-    // FIXME: a. If srcBuffer.[[ArrayBufferData]] and targetBuffer.[[ArrayBufferData]] are the same Shared Data Block values, let same be true; else let same be false.
+    auto same_shared_array_buffer = false;
 
-    // 17. Else, let same be SameValue(srcBuffer, targetBuffer).
-    auto same = same_value(source_buffer, target_buffer);
+    // 18. If IsSharedArrayBuffer(srcBuffer) is true, IsSharedArrayBuffer(targetBuffer) is true, and srcBuffer.[[ArrayBufferData]] is targetBuffer.[[ArrayBufferData]], let sameSharedArrayBuffer be true; otherwise, let sameSharedArrayBuffer be false.
+    if (source_buffer->is_shared_array_buffer() && target_buffer->is_shared_array_buffer() && (&source_buffer->buffer() == &target_buffer->buffer()))
+        same_shared_array_buffer = true;
 
     size_t source_byte_index = 0;
 
-    // 18. If same is true, then
-    if (same) {
-        // a. Let srcByteLength be source.[[ByteLength]].
-        auto source_byte_length = source.byte_length();
+    // 19. If SameValue(srcBuffer, targetBuffer) is true or sameSharedArrayBuffer is true, then
+    if (same_shared_array_buffer || same_value(source_buffer, target_buffer)) {
+        // a. Let srcByteLength be TypedArrayByteLength(srcRecord).
+        auto source_byte_length = typed_array_byte_length(source_record);
 
         // b. Set srcBuffer to ? CloneArrayBuffer(srcBuffer, srcByteOffset, srcByteLength).
         source_buffer = TRY(clone_array_buffer(vm, *source_buffer, source_byte_offset, source_byte_length));
@@ -1196,12 +1397,13 @@ static ThrowCompletionOr<void> set_typed_array_from_typed_array(VM& vm, TypedArr
         // c. Let srcByteIndex be 0.
         source_byte_index = 0;
     }
-    // 19. Else, let srcByteIndex be srcByteOffset.
+    // 20. Else,
     else {
+        // a. Let srcByteIndex be srcByteOffset.
         source_byte_index = source_byte_offset;
     }
 
-    // 20. Let targetByteIndex be targetOffset × targetElementSize + targetByteOffset.
+    // 21. Let targetByteIndex be targetOffset × targetElementSize + targetByteOffset.
     Checked<size_t> checked_target_byte_index(static_cast<size_t>(target_offset));
     checked_target_byte_index *= target_element_size;
     checked_target_byte_index += target_byte_offset;
@@ -1209,7 +1411,7 @@ static ThrowCompletionOr<void> set_typed_array_from_typed_array(VM& vm, TypedArr
         return vm.throw_completion<RangeError>(ErrorType::TypedArrayOverflow, "target byte index");
     auto target_byte_index = checked_target_byte_index.value();
 
-    // 21. Let limit be targetByteIndex + targetElementSize × srcLength.
+    // 22. Let limit be targetByteIndex + targetElementSize × srcLength.
     Checked<size_t> checked_limit(source_length);
     checked_limit *= target_element_size;
     checked_limit += target_byte_index;
@@ -1217,9 +1419,9 @@ static ThrowCompletionOr<void> set_typed_array_from_typed_array(VM& vm, TypedArr
         return vm.throw_completion<RangeError>(ErrorType::TypedArrayOverflow, "target limit");
     auto limit = checked_limit.value();
 
-    // 22. If srcType is the same as targetType, then
+    // 23. If srcType is targetType, then
     if (source.element_name() == target.element_name()) {
-        // a. NOTE: If srcType and targetType are the same, the transfer must be performed in a manner that preserves the bit-level encoding of the source data.
+        // a. NOTE: The transfer must be performed in a manner that preserves the bit-level encoding of the source data.
         // b. Repeat, while targetByteIndex < limit,
         //     i. Let value be GetValueFromBuffer(srcBuffer, srcByteIndex, Uint8, true, Unordered).
         //     ii. Perform SetValueInBuffer(targetBuffer, targetByteIndex, Uint8, value, true, Unordered).
@@ -1227,46 +1429,49 @@ static ThrowCompletionOr<void> set_typed_array_from_typed_array(VM& vm, TypedArr
         //     iv. Set targetByteIndex to targetByteIndex + 1.
         target_buffer->buffer().overwrite(target_byte_index, source_buffer->buffer().data() + source_byte_index, limit - target_byte_index);
     }
-    // 23. Else,
+    // 24. Else,
     else {
         // a. Repeat, while targetByteIndex < limit,
         while (target_byte_index < limit) {
             // i. Let value be GetValueFromBuffer(srcBuffer, srcByteIndex, srcType, true, Unordered).
             auto value = source.get_value_from_buffer(source_byte_index, ArrayBuffer::Unordered);
+
             // ii. Perform SetValueInBuffer(targetBuffer, targetByteIndex, targetType, value, true, Unordered).
             target.set_value_in_buffer(target_byte_index, value, ArrayBuffer::Unordered);
+
             // iii. Set srcByteIndex to srcByteIndex + srcElementSize.
             source_byte_index += source_element_size;
+
             // iv. Set targetByteIndex to targetByteIndex + targetElementSize.
-            target_byte_index += target.element_size();
+            target_byte_index += target_element_size;
         }
     }
 
-    // 24. Return unused.
+    // 25. Return unused.
     return {};
 }
 
 // 23.2.3.26.2 SetTypedArrayFromArrayLike ( target, targetOffset, source ), https://tc39.es/ecma262/#sec-settypedarrayfromarraylike
 static ThrowCompletionOr<void> set_typed_array_from_array_like(VM& vm, TypedArrayBase& target, double target_offset, Value source)
 {
-    // 1. Let targetBuffer be target.[[ViewedArrayBuffer]].
-    auto* target_buffer = target.viewed_array_buffer();
+    // 1. Let targetRecord be MakeTypedArrayWithBufferWitnessRecord(target, seq-cst)
+    auto target_record = make_typed_array_with_buffer_witness_record(target, ArrayBuffer::Order::SeqCst);
 
-    // 2. If IsDetachedBuffer(targetBuffer) is true, throw a TypeError exception.
-    if (target_buffer->is_detached())
-        return vm.throw_completion<TypeError>(ErrorType::DetachedArrayBuffer);
+    // 2. If IsTypedArrayOutOfBounds(targetRecord) is true, throw a TypeError exception.
+    if (is_typed_array_out_of_bounds(target_record))
+        return vm.throw_completion<TypeError>(ErrorType::BufferOutOfBounds, "TypedArray"sv);
 
-    // 3. Let targetLength be target.[[ArrayLength]].
-    auto target_length = target.array_length();
+    // 3. Let targetLength be TypedArrayLength(targetRecord).
+    auto target_length = typed_array_length(target_record);
 
     // 4. Let src be ? ToObject(source).
-    auto src = TRY(source.to_object(vm));
+    auto source_object = TRY(source.to_object(vm));
 
     // 5. Let srcLength be ? LengthOfArrayLike(src).
-    auto source_length = TRY(length_of_array_like(vm, src));
+    auto source_length = TRY(length_of_array_like(vm, source_object));
 
-    // 6. If targetOffset is +∞, throw a RangeError exception.
-    if (isinf(target_offset))
+    // 6. If targetOffset = +∞, throw a RangeError exception.
+    if (Value { target_offset }.is_positive_infinity())
         return vm.throw_completion<RangeError>(ErrorType::TypedArrayInvalidTargetOffset, "finite");
 
     // 7. If srcLength + targetOffset > targetLength, throw a RangeError exception.
@@ -1281,8 +1486,10 @@ static ThrowCompletionOr<void> set_typed_array_from_array_like(VM& vm, TypedArra
     // 9. Repeat, while k < srcLength,
     while (k < source_length) {
         // a. Let Pk be ! ToString(𝔽(k)).
+        PropertyKey property_key { k };
+
         // b. Let value be ? Get(src, Pk).
-        auto value = TRY(src->get(k));
+        auto value = TRY(source_object->get(property_key));
 
         // c. Let targetIndex be 𝔽(targetOffset + k).
         // NOTE: We verify above that target_offset + source_length is valid, so this cannot fail.
@@ -1308,15 +1515,15 @@ static ThrowCompletionOr<void> set_typed_array_from_array_like(VM& vm, TypedArra
 JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::set)
 {
     auto source = vm.argument(0);
+    auto offset = vm.argument(1);
 
     // 1. Let target be the this value.
     // 2. Perform ? RequireInternalSlot(target, [[TypedArrayName]]).
+    // 3. Assert: target has a [[ViewedArrayBuffer]] internal slot.
     auto* typed_array = TRY(typed_array_from_this(vm));
 
-    // 3. Assert: target has a [[ViewedArrayBuffer]] internal slot.
-
     // 4. Let targetOffset be ? ToIntegerOrInfinity(offset).
-    auto target_offset = TRY(vm.argument(1).to_integer_or_infinity(vm));
+    auto target_offset = TRY(offset.to_integer_or_infinity(vm));
 
     // 5. If targetOffset < 0, throw a RangeError exception.
     if (target_offset < 0)
@@ -1346,19 +1553,20 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::slice)
     auto end = vm.argument(1);
 
     // 1. Let O be the this value.
-    // 2. Perform ? ValidateTypedArray(O).
-    auto* typed_array = TRY(validate_typed_array_from_this(vm));
+    auto* typed_array = TRY(typed_array_from_this(vm));
 
-    // 3. Let len be O.[[ArrayLength]].
-    auto length = typed_array->array_length();
+    // 2. Let taRecord be ? ValidateTypedArray(O, seq-cst).
+    auto typed_array_record = TRY(validate_typed_array(vm, *typed_array, ArrayBuffer::Order::SeqCst));
+
+    // 3. Let len be TypedArrayLength(taRecord).
+    auto length = typed_array_length(typed_array_record);
 
     // 4. Let relativeStart be ? ToIntegerOrInfinity(start).
     auto relative_start = TRY(start.to_integer_or_infinity(vm));
 
     i32 k = 0;
-
-    // 5. If relativeStart is -∞, let k be 0.
-    if (Value(relative_start).is_negative_infinity())
+    // 5. If relativeStart = -∞, let k be 0.
+    if (Value { relative_start }.is_negative_infinity())
         k = 0;
     // 6. Else if relativeStart < 0, let k be max(len + relativeStart, 0).
     else if (relative_start < 0)
@@ -1368,7 +1576,6 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::slice)
         k = min(relative_start, length);
 
     double relative_end = 0;
-
     // 8. If end is undefined, let relativeEnd be len; else let relativeEnd be ? ToIntegerOrInfinity(end).
     if (end.is_undefined())
         relative_end = length;
@@ -1376,9 +1583,8 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::slice)
         relative_end = TRY(end.to_integer_or_infinity(vm));
 
     i32 final = 0;
-
     // 9. If relativeEnd is -∞, let final be 0.
-    if (Value(relative_end).is_negative_infinity())
+    if (Value { relative_end }.is_negative_infinity())
         final = 0;
     // 10. Else if relativeEnd < 0, let final be max(len + relativeEnd, 0).
     else if (relative_end < 0)
@@ -1393,122 +1599,174 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::slice)
     // 13. Let A be ? TypedArraySpeciesCreate(O, « 𝔽(count) »).
     MarkedVector<Value> arguments(vm.heap());
     arguments.empend(count);
-    auto* new_array = TRY(typed_array_species_create(vm, *typed_array, move(arguments)));
+    auto* array = TRY(typed_array_species_create(vm, *typed_array, move(arguments)));
 
     // 14. If count > 0, then
     if (count > 0) {
-        // a. If IsDetachedBuffer(O.[[ViewedArrayBuffer]]) is true, throw a TypeError exception.
-        if (typed_array->viewed_array_buffer()->is_detached())
-            return vm.throw_completion<TypeError>(ErrorType::DetachedArrayBuffer);
+        // a. Set taRecord to MakeTypedArrayWithBufferWitnessRecord(O, seq-cst).
+        typed_array_record = make_typed_array_with_buffer_witness_record(*typed_array, ArrayBuffer::Order::SeqCst);
 
-        // b. Let srcType be TypedArrayElementType(O).
-        // c. Let targetType be TypedArrayElementType(A).
+        // b. If IsTypedArrayOutOfBounds(taRecord) is true, throw a TypeError exception.
+        if (is_typed_array_out_of_bounds(typed_array_record))
+            return vm.throw_completion<TypeError>(ErrorType::BufferOutOfBounds, "TypedArray"sv);
 
-        // d. If srcType is different from targetType, then
-        if (typed_array->element_name() != new_array->element_name()) {
-            // i. Let n be 0.
-            // ii. Repeat, while k < final,
-            for (i32 n = 0; k < final; ++k, ++n) {
-                // 1. Let Pk be ! ToString(𝔽(k)).
-                // 2. Let kValue be ! Get(O, Pk).
-                auto k_value = MUST(typed_array->get(k));
+        // c. Set len to TypedArrayLength(taRecord).
+        length = typed_array_length(typed_array_record);
 
-                // 3. Perform ! Set(A, ! ToString(𝔽(n)), kValue, true).
-                MUST(new_array->set(n, k_value, Object::ShouldThrowExceptions::Yes));
+        // d. Set final to min(final, len).
+        final = min(final, length);
 
-                // 4. Set k to k + 1.
-                // 5. Set n to n + 1.
-            }
-        }
-        // e. Else,
-        else {
-            // i. Let srcBuffer be O.[[ViewedArrayBuffer]].
+        // FIXME: Spec issue: If the TypedArray length changed, the count must also be updated.
+        //        https://github.com/tc39/ecma262/issues/3248
+        count = max(final - k, 0);
+
+        // e. Let srcType be TypedArrayElementType(O).
+        // f. Let targetType be TypedArrayElementType(A).
+
+        // g. If srcType is targetType, then
+        if (typed_array->element_name() == array->element_name()) {
+            // i. NOTE: The transfer must be performed in a manner that preserves the bit-level encoding of the source data.
+
+            // ii. Let srcBuffer be O.[[ViewedArrayBuffer]].
             auto& source_buffer = *typed_array->viewed_array_buffer();
 
-            // ii. Let targetBuffer be A.[[ViewedArrayBuffer]].
-            auto& target_buffer = *new_array->viewed_array_buffer();
+            // iii. Let targetBuffer be A.[[ViewedArrayBuffer]].
+            auto& target_buffer = *array->viewed_array_buffer();
 
-            // iii. Let elementSize be TypedArrayElementSize(O).
+            // iv. Let elementSize be TypedArrayElementSize(O).
             auto element_size = typed_array->element_size();
-
-            // iv. NOTE: If srcType and targetType are the same, the transfer must be performed in a manner that preserves the bit-level encoding of the source data.
 
             // v. Let srcByteOffset be O.[[ByteOffset]].
             auto source_byte_offset = typed_array->byte_offset();
 
-            // vi. Let targetByteIndex be A.[[ByteOffset]].
-            auto target_byte_index = new_array->byte_offset();
-
-            // vii. Let srcByteIndex be (k × elementSize) + srcByteOffset.
+            // vi. Let srcByteIndex be (k × elementSize) + srcByteOffset.
             Checked<u32> source_byte_index = k;
             source_byte_index *= element_size;
             source_byte_index += source_byte_offset;
             if (source_byte_index.has_overflow()) {
                 dbgln("TypedArrayPrototype::slice: source_byte_index overflowed, returning as if succeeded.");
-                return new_array;
+                return array;
             }
 
-            // viii. Let limit be targetByteIndex + count × elementSize.
-            Checked<u32> limit = count;
+            // vii. Let targetByteIndex be A.[[ByteOffset]].
+            auto target_byte_index = array->byte_offset();
+
+            // viii. Let limit be targetByteIndex + min(count, len) × elementSize.
+            Checked<u32> limit = min(count, length);
             limit *= element_size;
             limit += target_byte_index;
             if (limit.has_overflow()) {
                 dbgln("TypedArrayPrototype::slice: limit overflowed, returning as if succeeded.");
-                return new_array;
+                return array;
             }
 
             // ix. Repeat, while targetByteIndex < limit,
-            for (; target_byte_index < limit.value(); ++source_byte_index, ++target_byte_index) {
-                // 1. Let value be GetValueFromBuffer(srcBuffer, srcByteIndex, Uint8, true, Unordered).
+            while (target_byte_index < limit) {
+                // 1. Let value be GetValueFromBuffer(srcBuffer, srcByteIndex, uint8, true, unordered).
                 auto value = source_buffer.get_value<u8>(source_byte_index.value(), true, ArrayBuffer::Unordered);
 
-                // 2. Perform SetValueInBuffer(targetBuffer, targetByteIndex, Uint8, value, true, Unordered).
+                // 2. Perform SetValueInBuffer(targetBuffer, targetByteIndex, uint8, value, true, unordered).
                 target_buffer.set_value<u8>(target_byte_index, value, true, ArrayBuffer::Unordered);
 
                 // 3. Set srcByteIndex to srcByteIndex + 1.
+                ++source_byte_index;
+
                 // 4. Set targetByteIndex to targetByteIndex + 1.
+                ++target_byte_index;
+            }
+        }
+        // h. Else,
+        else {
+            // i. Let n be 0.
+            u32 n = 0;
+
+            // ii. Repeat, while k < final,
+            while (k < final) {
+                // 1. Let Pk be ! ToString(𝔽(k)).
+                PropertyKey property_key { k };
+
+                // 2. Let kValue be ! Get(O, Pk).
+                auto value = MUST(typed_array->get(property_key));
+
+                // 3. Perform ! Set(A, ! ToString(𝔽(n)), kValue, true).
+                MUST(array->set(n, value, Object::ShouldThrowExceptions::Yes));
+
+                // 4. Set k to k + 1.
+                ++k;
+
+                // 5. Set n to n + 1.
+                ++n;
             }
         }
     }
 
     // 15. Return A.
-    return new_array;
+    return array;
 }
 
 // 23.2.3.28 %TypedArray%.prototype.some ( callbackfn [ , thisArg ] ), https://tc39.es/ecma262/#sec-%typedarray%.prototype.some
 JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::some)
 {
-    auto result = false;
-    TRY(for_each_item(vm, "some", [&](auto, auto, auto callback_result) {
-        if (callback_result.to_boolean()) {
-            result = true;
-            return IterationDecision::Break;
-        }
-        return IterationDecision::Continue;
-    }));
-    return Value(result);
+    auto this_arg = vm.argument(1);
+
+    // 1. Let O be the this value.
+    auto* typed_array = TRY(typed_array_from_this(vm));
+
+    // 2. Let taRecord be ? ValidateTypedArray(O, seq-cst).
+    auto typed_array_record = TRY(validate_typed_array(vm, *typed_array, ArrayBuffer::Order::SeqCst));
+
+    // 3. Let len be TypedArrayLength(taRecord).
+    auto length = typed_array_length(typed_array_record);
+
+    // 4. If IsCallable(callbackfn) is false, throw a TypeError exception.
+    auto callback_function = TRY(callback_from_args(vm, "some"sv));
+
+    // 5. Let k be 0.
+    // 6. Repeat, while k < len,
+    for (size_t k = 0; k < length; ++k) {
+        // a. Let Pk be ! ToString(𝔽(k)).
+        PropertyKey property_key { k };
+
+        // b. Let kValue be ! Get(O, Pk).
+        auto value = MUST(typed_array->get(property_key));
+
+        // c. Let testResult be ToBoolean(? Call(callbackfn, thisArg, « kValue, 𝔽(k), O »)).
+        auto test_result = TRY(call(vm, *callback_function, this_arg, value, Value { k }, typed_array)).to_boolean();
+
+        // d. If testResult is true, return true.
+        if (test_result)
+            return true;
+
+        // e. Set k to k + 1.
+    }
+
+    // 7. Return false.
+    return false;
 }
 
 // 23.2.3.29 %TypedArray%.prototype.sort ( comparefn ), https://tc39.es/ecma262/#sec-%typedarray%.prototype.sort
 JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::sort)
 {
+    auto compare_function = vm.argument(0);
+
     // 1. If comparefn is not undefined and IsCallable(comparefn) is false, throw a TypeError exception.
-    auto compare_fn = vm.argument(0);
-    if (!compare_fn.is_undefined() && !compare_fn.is_function())
-        return vm.throw_completion<TypeError>(ErrorType::NotAFunction, compare_fn.to_string_without_side_effects());
+    if (!compare_function.is_undefined() && !compare_function.is_function())
+        return vm.throw_completion<TypeError>(ErrorType::NotAFunction, compare_function);
 
     // 2. Let obj be the this value.
-    // 3. Perform ? ValidateTypedArray(obj).
-    auto* typed_array = TRY(validate_typed_array_from_this(vm));
+    auto* typed_array = TRY(typed_array_from_this(vm));
 
-    // 4. Let len be obj.[[ArrayLength]].
-    auto length = typed_array->array_length();
+    // 3. Let taRecord be ? ValidateTypedArray(obj, seq-cst).
+    auto typed_array_record = TRY(validate_typed_array(vm, *typed_array, ArrayBuffer::Order::SeqCst));
+
+    // 4. Let len be TypedArrayLength(taRecord).
+    auto length = typed_array_length(typed_array_record);
 
     // 5. NOTE: The following closure performs a numeric comparison rather than the string comparison used in 23.1.3.30.
     // 6. Let SortCompare be a new Abstract Closure with parameters (x, y) that captures comparefn and performs the following steps when called:
     Function<ThrowCompletionOr<double>(Value, Value)> sort_compare = [&](auto x, auto y) -> ThrowCompletionOr<double> {
         // a. Return ? CompareTypedArrayElements(x, y, comparefn).
-        return TRY(compare_typed_array_elements(vm, x, y, compare_fn.is_undefined() ? nullptr : &compare_fn.as_function()));
+        return TRY(compare_typed_array_elements(vm, x, y, compare_function.is_undefined() ? nullptr : &compare_function.as_function()));
     };
 
     // 7. Let sortedList be ? SortIndexedProperties(obj, len, SortCompare, read-through-holes).
@@ -1519,6 +1777,7 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::sort)
     for (size_t j = 0; j < length; j++) {
         // a. Perform ! Set(obj, ! ToString(𝔽(j)), sortedList[j], true).
         MUST(typed_array->set(j, sorted_list[j], Object::ShouldThrowExceptions::Yes));
+
         // b. Set j to j + 1.
     }
 
@@ -1534,21 +1793,32 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::subarray)
 
     // 1. Let O be the this value.
     // 2. Perform ? RequireInternalSlot(O, [[TypedArrayName]]).
+    // 3. Assert: O has a [[ViewedArrayBuffer]] internal slot.
     auto* typed_array = TRY(typed_array_from_this(vm));
 
-    // 3. Assert: O has a [[ViewedArrayBuffer]] internal slot.
     // 4. Let buffer be O.[[ViewedArrayBuffer]].
     auto* buffer = typed_array->viewed_array_buffer();
 
-    // 5. Let srcLength be O.[[ArrayLength]].
-    auto source_length = typed_array->array_length();
+    // 5. Let srcRecord be MakeTypedArrayWithBufferWitnessRecord(O, seq-cst).
+    auto source_record = make_typed_array_with_buffer_witness_record(*typed_array, ArrayBuffer::Order::SeqCst);
 
-    // 6. Let relativeBegin be ? ToIntegerOrInfinity(begin).
+    u32 source_length = 0;
+    // 6. If IsTypedArrayOutOfBounds(srcRecord) is true, then
+    if (is_typed_array_out_of_bounds(source_record)) {
+        // a. Let srcLength be 0.
+        source_length = 0;
+    }
+    // 7. Else,
+    else {
+        // a. Let srcLength be TypedArrayLength(srcRecord).
+        source_length = typed_array_length(source_record);
+    }
+
+    // 8. Let relativeBegin be ? ToIntegerOrInfinity(begin).
     auto relative_begin = TRY(begin.to_integer_or_infinity(vm));
 
     i32 begin_index = 0;
-
-    // 7. If relativeBegin is -∞, let beginIndex be 0.
+    // 7. If relativeBegin = -∞, let beginIndex be 0.
     if (Value(relative_begin).is_negative_infinity())
         begin_index = 0;
     // 8. Else if relativeBegin < 0, let beginIndex be max(srcLength + relativeBegin, 0).
@@ -1558,47 +1828,59 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::subarray)
     else
         begin_index = min(relative_begin, source_length);
 
-    double relative_end = 0;
+    // 12. Let elementSize be TypedArrayElementSize(O).
+    auto element_size = typed_array->element_size();
 
-    // 10. If end is undefined, let relativeEnd be srcLength; else let relativeEnd be ? ToIntegerOrInfinity(end).
-    if (end.is_undefined())
-        relative_end = source_length;
-    else
-        relative_end = TRY(end.to_integer_or_infinity(vm));
+    // 13. Let srcByteOffset be O.[[ByteOffset]].
+    auto source_byte_offset = typed_array->byte_offset();
 
-    i32 end_index = 0;
-
-    // 11. If relativeEnd is -∞, let endIndex be 0.
-    if (Value(relative_end).is_negative_infinity())
-        end_index = 0;
-    // 12. Else if relativeEnd < 0, let endIndex be max(srcLength + relativeEnd, 0).
-    else if (relative_end < 0)
-        end_index = max(source_length + relative_end, 0);
-    // 13. Else, let endIndex be min(relativeEnd, srcLength).
-    else
-        end_index = min(relative_end, source_length);
-
-    // 14. Let newLength be max(endIndex - beginIndex, 0).
-    auto new_length = max(end_index - begin_index, 0);
-
-    // 15. Let elementSize be TypedArrayElementSize(O).
-    // 16. Let srcByteOffset be O.[[ByteOffset]].
-    // 17. Let beginByteOffset be srcByteOffset + beginIndex × elementSize.
+    // 14. Let beginByteOffset be srcByteOffset + beginIndex × elementSize.
     Checked<u32> begin_byte_offset = begin_index;
-    begin_byte_offset *= typed_array->element_size();
-    begin_byte_offset += typed_array->byte_offset();
+    begin_byte_offset *= element_size;
+    begin_byte_offset += source_byte_offset;
     if (begin_byte_offset.has_overflow()) {
         dbgln("TypedArrayPrototype::begin_byte_offset: limit overflowed, returning as if succeeded.");
         return typed_array;
     }
 
-    // 18. Let argumentsList be « buffer, 𝔽(beginByteOffset), 𝔽(newLength) ».
     MarkedVector<Value> arguments(vm.heap());
-    arguments.empend(buffer);
-    arguments.empend(begin_byte_offset.value());
-    arguments.empend(new_length);
 
-    // 19. Return ? TypedArraySpeciesCreate(O, argumentsList).
+    // 15. If O.[[ArrayLength]] is auto and end is undefined, then
+    if (typed_array->array_length().is_auto()) {
+        // a. Let argumentsList be « buffer, 𝔽(beginByteOffset) ».
+        arguments.empend(buffer);
+        arguments.empend(begin_byte_offset.value());
+    }
+    // 16. Else,
+    else {
+        double relative_end = 0;
+        // a. If end is undefined, let relativeEnd be srcLength; else let relativeEnd be ? ToIntegerOrInfinity(end).
+        if (end.is_undefined())
+            relative_end = source_length;
+        else
+            relative_end = TRY(end.to_integer_or_infinity(vm));
+
+        i32 end_index = 0;
+        // 11. If relativeEnd = -∞, let endIndex be 0.
+        if (Value(relative_end).is_negative_infinity())
+            end_index = 0;
+        // 12. Else if relativeEnd < 0, let endIndex be max(srcLength + relativeEnd, 0).
+        else if (relative_end < 0)
+            end_index = max(source_length + relative_end, 0);
+        // 13. Else, let endIndex be min(relativeEnd, srcLength).
+        else
+            end_index = min(relative_end, source_length);
+
+        // e. Let newLength be max(endIndex - beginIndex, 0).
+        auto new_length = max(end_index - begin_index, 0);
+
+        // f. Let argumentsList be « buffer, 𝔽(beginByteOffset), 𝔽(newLength) ».
+        arguments.empend(buffer);
+        arguments.empend(begin_byte_offset.value());
+        arguments.empend(new_length);
+    }
+
+    // 17. Return ? TypedArraySpeciesCreate(O, argumentsList).
     return TRY(typed_array_species_create(vm, *typed_array, move(arguments)));
 }
 
@@ -1611,15 +1893,15 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::to_locale_string)
 
     // This function is not generic. ValidateTypedArray is applied to the this value prior to evaluating the algorithm.
     // If its result is an abrupt completion that exception is thrown instead of evaluating the algorithm.
-    auto* typed_array = TRY(validate_typed_array_from_this(vm));
 
     // 1. Let array be ? ToObject(this value).
-    // NOTE: Handled by ValidateTypedArray
+    auto* typed_array = TRY(typed_array_from_this(vm));
 
     // 2. Let len be ? ToLength(? Get(array, "length")).
     // The implementation of the algorithm may be optimized with the knowledge that the this value is an object that
     // has a fixed length and whose integer-indexed properties are not sparse.
-    auto length = typed_array->array_length();
+    auto typed_array_record = TRY(validate_typed_array(vm, *typed_array, ArrayBuffer::Order::SeqCst));
+    auto length = typed_array_length(typed_array_record);
 
     // 3. Let separator be the implementation-defined list-separator String value appropriate for the host environment's current locale (such as ", ").
     constexpr auto separator = ',';
@@ -1649,7 +1931,7 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::to_locale_string)
             builder.append(locale_string);
         }
 
-        // d. Increase k by 1.
+        // d. Set k to k + 1.
     }
 
     // 7. Return R.
@@ -1660,82 +1942,84 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::to_locale_string)
 JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::to_reversed)
 {
     // 1. Let O be the this value.
-    // 2. Perform ? ValidateTypedArray(O).
-    auto* typed_array = TRY(validate_typed_array_from_this(vm));
+    auto* typed_array = TRY(typed_array_from_this(vm));
 
-    // 3. Let length be O.[[ArrayLength]].
-    auto length = typed_array->array_length();
+    // 2. Let taRecord be ? ValidateTypedArray(O, seq-cst).
+    auto typed_array_record = TRY(validate_typed_array(vm, *typed_array, ArrayBuffer::Order::SeqCst));
+
+    // 3. Let length be TypedArrayLength(taRecord).
+    auto length = typed_array_length(typed_array_record);
 
     // 4. Let A be ? TypedArrayCreateSameType(O, « 𝔽(length) »).
     MarkedVector<Value> arguments(vm.heap());
     arguments.empend(length);
-    auto* return_array = TRY(typed_array_create_same_type(vm, *typed_array, move(arguments)));
+    auto* array = TRY(typed_array_create_same_type(vm, *typed_array, move(arguments)));
 
     // 5. Let k be 0.
-    // 6. Repeat, while k < length
-    for (size_t k = 0; k < length; k++) {
+    // 6. Repeat, while k < length,
+    for (size_t k = 0; k < length; ++k) {
         // a. Let from be ! ToString(𝔽(length - k - 1)).
-        auto from = PropertyKey { length - k - 1 };
+        PropertyKey from { length - k - 1 };
 
         // b. Let Pk be ! ToString(𝔽(k)).
-        auto property_key = PropertyKey { k };
+        PropertyKey property_key { k };
 
         // c. Let fromValue be ! Get(O, from).
         auto from_value = MUST(typed_array->get(from));
 
         // d. Perform ! Set(A, Pk, fromValue, true).
-        MUST(return_array->set(property_key, from_value, Object::ShouldThrowExceptions::Yes));
+        MUST(array->set(property_key, from_value, Object::ShouldThrowExceptions::Yes));
 
         // e. Set k to k + 1.
     }
 
     // 7. Return A.
-    return return_array;
+    return array;
 }
 
 // 23.2.3.33 %TypedArray%.prototype.toSorted ( comparefn ), https://tc39.es/ecma262/#sec-%typedarray%.prototype.tosorted
 JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::to_sorted)
 {
-    auto comparefn = vm.argument(0);
+    auto compare_function = vm.argument(0);
 
     // 1. If comparefn is not undefined and IsCallable(comparefn) is false, throw a TypeError exception.
-    if (!comparefn.is_undefined() && !comparefn.is_function())
-        return vm.throw_completion<TypeError>(ErrorType::NotAFunction, comparefn);
+    if (!compare_function.is_undefined() && !compare_function.is_function())
+        return vm.throw_completion<TypeError>(ErrorType::NotAFunction, compare_function);
 
     // 2. Let O be the this value.
-    auto object = TRY(vm.this_value().to_object(vm));
+    auto* typed_array = TRY(typed_array_from_this(vm));
 
-    // 3. Perform ? ValidateTypedArray(O).
-    auto* typed_array = TRY(validate_typed_array_from_this(vm));
+    // 3. Let taRecord be ? ValidateTypedArray(O, seq-cst).
+    auto typed_array_record = TRY(validate_typed_array(vm, *typed_array, ArrayBuffer::Order::SeqCst));
 
-    // 4. Let len be O.[[ArrayLength]].
-    auto length = typed_array->array_length();
+    // 4. Let len be TypedArrayLength(taRecord).
+    auto length = typed_array_length(typed_array_record);
 
     // 5. Let A be ? TypedArrayCreateSameType(O, « 𝔽(len) »).
     MarkedVector<Value> arguments(vm.heap());
     arguments.empend(length);
-    auto* return_array = TRY(typed_array_create_same_type(vm, *typed_array, move(arguments)));
+    auto* array = TRY(typed_array_create_same_type(vm, *typed_array, move(arguments)));
 
-    // 6. NOTE: The following closure performs a numeric comparison rather than the string comparison used in  Array.prototype.toSorted
-    // 7. Let SortCompare be a new Abstract Closure with parameters (x, y) that captures comparefn and performs the following steps when called:
+    // 6. NOTE: The following closure performs a numeric comparison rather than the string comparison used in 23.1.3.34.
     Function<ThrowCompletionOr<double>(Value, Value)> sort_compare = [&](auto x, auto y) -> ThrowCompletionOr<double> {
         // a. Return ? CompareTypedArrayElements(x, y, comparefn).
-        return TRY(compare_typed_array_elements(vm, x, y, comparefn.is_undefined() ? nullptr : &comparefn.as_function()));
+        return TRY(compare_typed_array_elements(vm, x, y, compare_function.is_undefined() ? nullptr : &compare_function.as_function()));
     };
 
     // 8. Let sortedList be ? SortIndexedProperties(O, len, SortCompare, read-through-holes).
-    auto sorted_list = TRY(sort_indexed_properties(vm, object, length, sort_compare, Holes::ReadThroughHoles));
+    auto sorted_list = TRY(sort_indexed_properties(vm, *typed_array, length, sort_compare, Holes::ReadThroughHoles));
 
     // 9. Let j be 0.
     // 10. Repeat, while j < len,
     for (size_t j = 0; j < length; j++) {
         // a. Perform ! Set(A, ! ToString(𝔽(j)), sortedList[j], true).
-        MUST(return_array->set(j, sorted_list[j], Object::ShouldThrowExceptions::Yes));
+        MUST(array->set(j, sorted_list[j], Object::ShouldThrowExceptions::Yes));
+
         // b. Set j to j + 1.
     }
 
     // 11. Return A.
-    return return_array;
+    return array;
 }
 
 // 23.2.3.35 %TypedArray%.prototype.values ( ), https://tc39.es/ecma262/#sec-%typedarray%.prototype.values
@@ -1744,8 +2028,10 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::values)
     auto& realm = *vm.current_realm();
 
     // 1. Let O be the this value.
-    // 2. Perform ? ValidateTypedArray(O).
-    auto* typed_array = TRY(validate_typed_array_from_this(vm));
+    auto* typed_array = TRY(typed_array_from_this(vm));
+
+    // 2. Perform ? ValidateTypedArray(O, seq-cst).
+    (void)TRY(validate_typed_array(vm, *typed_array, ArrayBuffer::Order::SeqCst));
 
     // 3. Return CreateArrayIterator(O, value).
     return ArrayIterator::create(realm, typed_array, Object::PropertyKind::Value);
@@ -1758,11 +2044,13 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::with)
     auto value = vm.argument(1);
 
     // 1. Let O be the this value.
-    // 2. Perform ? ValidateTypedArray(O).
-    auto* typed_array = TRY(validate_typed_array_from_this(vm));
+    auto* typed_array = TRY(typed_array_from_this(vm));
 
-    // 3. Let len be O.[[ArrayLength]].
-    auto length = typed_array->array_length();
+    // 2. Let taRecord be ? ValidateTypedArray(O, seq-cst).
+    auto typed_array_record = TRY(validate_typed_array(vm, *typed_array, ArrayBuffer::Order::SeqCst));
+
+    // 3. Let len be TypedArrayLength(taRecord).
+    auto length = typed_array_length(typed_array_record);
 
     // 4. Let relativeIndex be ? ToIntegerOrInfinity(index).
     auto relative_index = TRY(index.to_integer_or_infinity(vm));
@@ -1771,6 +2059,7 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::with)
     // 5. If relativeIndex ≥ 0, let actualIndex be relativeIndex.
     if (relative_index >= 0)
         actual_index = relative_index;
+    // 6. Else, let actualIndex be len + relativeIndex.
     else
         actual_index = length + relative_index;
 
@@ -1789,13 +2078,13 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::with)
     // 10. Let A be ? TypedArrayCreateSameType(O, « 𝔽(len) »).
     MarkedVector<Value> arguments(vm.heap());
     arguments.empend(length);
-    auto* return_array = TRY(typed_array_create_same_type(vm, *typed_array, move(arguments)));
+    auto* array = TRY(typed_array_create_same_type(vm, *typed_array, move(arguments)));
 
     // 11. Let k be 0.
     // 12. Repeat, while k < len,
     for (size_t k = 0; k < length; k++) {
         // a. Let Pk be ! ToString(𝔽(k)).
-        auto property_key = PropertyKey { k };
+        PropertyKey property_key { k };
 
         Value from_value;
         // b. If k is actualIndex, let fromValue be numericValue.
@@ -1806,13 +2095,13 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::with)
             from_value = MUST(typed_array->get(property_key));
 
         // d. Perform ! Set(A, Pk, fromValue, true).
-        MUST(return_array->set(property_key, from_value, Object::ShouldThrowExceptions::Yes));
+        MUST(array->set(property_key, from_value, Object::ShouldThrowExceptions::Yes));
 
         // e. Set k to k + 1.
     }
 
     // 13. Return A.
-    return return_array;
+    return array;
 }
 
 // 23.2.3.38 get %TypedArray%.prototype [ @@toStringTag ], https://tc39.es/ecma262/#sec-get-%typedarray%.prototype-@@tostringtag

--- a/Userland/Libraries/LibJS/Runtime/TypedArrayPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/TypedArrayPrototype.cpp
@@ -1288,11 +1288,11 @@ static ThrowCompletionOr<void> set_typed_array_from_array_like(VM& vm, TypedArra
         // NOTE: We verify above that target_offset + source_length is valid, so this cannot fail.
         auto target_index = MUST(CanonicalIndex::from_double(vm, CanonicalIndex::Type::Index, target_offset + k));
 
-        // d. Perform ? IntegerIndexedElementSet(target, targetIndex, value).
+        // d. Perform ? TypedArraySetElement(target, targetIndex, value).
         // FIXME: This is very awkward.
 #define __JS_ENUMERATE(ClassName, snake_name, PrototypeName, ConstructorName, Type) \
     if (is<ClassName>(target))                                                      \
-        TRY(integer_indexed_element_set<Type>(target, target_index, value));
+        TRY(typed_array_set_element<Type>(target, target_index, value));
         JS_ENUMERATE_TYPED_ARRAYS
 #undef __JS_ENUMERATE
 

--- a/Userland/Libraries/LibJS/Runtime/VM.h
+++ b/Userland/Libraries/LibJS/Runtime/VM.h
@@ -32,6 +32,11 @@ namespace JS {
 class Identifier;
 struct BindingPattern;
 
+enum class HandledByHost {
+    Handled,
+    Unhandled,
+};
+
 class VM : public RefCounted<VM> {
 public:
     struct CustomData {
@@ -252,6 +257,7 @@ public:
     Function<JobCallback(FunctionObject&)> host_make_job_callback;
     Function<ThrowCompletionOr<void>(Realm&)> host_ensure_can_compile_strings;
     Function<ThrowCompletionOr<void>(Object&)> host_ensure_can_add_private_element;
+    Function<ThrowCompletionOr<HandledByHost>(ArrayBuffer&, size_t)> host_resize_array_buffer;
 
     // Execute a specific AST node either in AST or BC interpreter, depending on which one is enabled by default.
     // NOTE: This is meant as a temporary stopgap until everything is bytecode.

--- a/Userland/Libraries/LibJS/Tests/builtins/ArrayBuffer/ArrayBuffer.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/ArrayBuffer/ArrayBuffer.js
@@ -17,3 +17,18 @@ test("ArrayBuffer size limit", () => {
         new ArrayBuffer(2 ** 53);
     }).toThrowWithMessage(RangeError, "Invalid array buffer length");
 });
+
+test("invalid ArrayBuffer maximum size option", () => {
+    expect(() => {
+        new ArrayBuffer(10, { maxByteLength: -1 });
+    }).toThrowWithMessage(RangeError, "Index must be a positive integer");
+});
+
+test("ArrayBuffer size exceeds maximum size", () => {
+    expect(() => {
+        new ArrayBuffer(10, { maxByteLength: 5 });
+    }).toThrowWithMessage(
+        RangeError,
+        "ArrayBuffer byte length of 10 exceeds the max byte length of 5"
+    );
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/ArrayBuffer/ArrayBuffer.prototype.maxByteLength.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/ArrayBuffer/ArrayBuffer.prototype.maxByteLength.js
@@ -1,0 +1,29 @@
+describe("errors", () => {
+    test("called on non-ArrayBuffer object", () => {
+        expect(() => {
+            ArrayBuffer.prototype.maxByteLength;
+        }).toThrowWithMessage(TypeError, "Not an object of type ArrayBuffer");
+    });
+});
+
+describe("normal behavior", () => {
+    test("detached buffer", () => {
+        let buffer = new ArrayBuffer(5);
+        detachArrayBuffer(buffer);
+        expect(buffer.maxByteLength).toBe(0);
+
+        buffer = new ArrayBuffer(5, { maxByteLength: 10 });
+        detachArrayBuffer(buffer);
+        expect(buffer.maxByteLength).toBe(0);
+    });
+
+    test("fixed buffer", () => {
+        let buffer = new ArrayBuffer(5);
+        expect(buffer.maxByteLength).toBe(5);
+    });
+
+    test("resizable buffer", () => {
+        let buffer = new ArrayBuffer(5, { maxByteLength: 10 });
+        expect(buffer.maxByteLength).toBe(10);
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/ArrayBuffer/ArrayBuffer.prototype.resizable.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/ArrayBuffer/ArrayBuffer.prototype.resizable.js
@@ -1,0 +1,19 @@
+describe("errors", () => {
+    test("called on non-ArrayBuffer object", () => {
+        expect(() => {
+            ArrayBuffer.prototype.resizable;
+        }).toThrowWithMessage(TypeError, "Not an object of type ArrayBuffer");
+    });
+});
+
+describe("normal behavior", () => {
+    test("fixed buffer", () => {
+        let buffer = new ArrayBuffer(5);
+        expect(buffer.resizable).toBeFalse();
+    });
+
+    test("resizable buffer", () => {
+        let buffer = new ArrayBuffer(5, { maxByteLength: 10 });
+        expect(buffer.resizable).toBeTrue();
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/ArrayBuffer/ArrayBuffer.prototype.resize.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/ArrayBuffer/ArrayBuffer.prototype.resize.js
@@ -1,0 +1,57 @@
+describe("errors", () => {
+    test("called on non-ArrayBuffer object", () => {
+        expect(() => {
+            ArrayBuffer.prototype.resize(10);
+        }).toThrowWithMessage(TypeError, "Not an object of type ArrayBuffer");
+    });
+
+    test("fixed buffer", () => {
+        let buffer = new ArrayBuffer(5);
+        detachArrayBuffer(buffer);
+
+        expect(() => {
+            buffer.resize(10);
+        }).toThrowWithMessage(TypeError, "ArrayBuffer is not resizable");
+    });
+
+    test("detached buffer", () => {
+        let buffer = new ArrayBuffer(5, { maxByteLength: 10 });
+        detachArrayBuffer(buffer);
+
+        expect(() => {
+            buffer.resize(10);
+        }).toThrowWithMessage(TypeError, "ArrayBuffer is detached");
+    });
+
+    test("invalid new byte length", () => {
+        let buffer = new ArrayBuffer(5, { maxByteLength: 10 });
+
+        expect(() => {
+            buffer.resize(-1);
+        }).toThrowWithMessage(RangeError, "Index must be a positive integer");
+    });
+
+    test("new byte length exceeds maximum size", () => {
+        let buffer = new ArrayBuffer(5, { maxByteLength: 10 });
+
+        expect(() => {
+            buffer.resize(11);
+        }).toThrowWithMessage(
+            RangeError,
+            "ArrayBuffer byte length of 11 exceeds the max byte length of 10"
+        );
+    });
+});
+
+describe("normal behavior", () => {
+    test("resizable buffer", () => {
+        let buffer = new ArrayBuffer(5, { maxByteLength: 10 });
+        expect(buffer.byteLength).toBe(5);
+        expect(buffer.maxByteLength).toBe(10);
+
+        for (let i = 0; i <= buffer.maxByteLength; ++i) {
+            buffer.resize(i);
+            expect(buffer.byteLength).toBe(i);
+        }
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Atomics/Atomics.notify.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Atomics/Atomics.notify.js
@@ -11,7 +11,10 @@ describe("errors", () => {
             detachArrayBuffer(typedArray.buffer);
 
             Atomics.notify(typedArray, 0, 0);
-        }).toThrowWithMessage(TypeError, "ArrayBuffer is detached");
+        }).toThrowWithMessage(
+            TypeError,
+            "TypedArray contains a property which references a value at an index not contained within its buffer's bounds"
+        );
     });
 
     test("invalid TypedArray type", () => {

--- a/Userland/Libraries/LibJS/Tests/builtins/Atomics/Atomics.wait.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Atomics/Atomics.wait.js
@@ -11,7 +11,10 @@ describe("errors", () => {
             detachArrayBuffer(typedArray.buffer);
 
             Atomics.wait(typedArray, 0, 0, 0);
-        }).toThrowWithMessage(TypeError, "ArrayBuffer is detached");
+        }).toThrowWithMessage(
+            TypeError,
+            "TypedArray contains a property which references a value at an index not contained within its buffer's bounds"
+        );
     });
 
     test("invalid TypedArray type", () => {

--- a/Userland/Libraries/LibJS/Tests/builtins/Atomics/Atomics.waitAsync.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Atomics/Atomics.waitAsync.js
@@ -11,7 +11,10 @@ describe("errors", () => {
             detachArrayBuffer(typedArray.buffer);
 
             Atomics.waitAsync(typedArray, 0, 0, 0);
-        }).toThrowWithMessage(TypeError, "ArrayBuffer is detached");
+        }).toThrowWithMessage(
+            TypeError,
+            "TypedArray contains a property which references a value at an index not contained within its buffer's bounds"
+        );
     });
 
     test("invalid TypedArray type", () => {

--- a/Userland/Libraries/LibJS/Tests/builtins/DataView/DataView.prototype.byteLength.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/DataView/DataView.prototype.byteLength.js
@@ -1,7 +1,36 @@
-test("basic functionality", () => {
-    const buffer = new ArrayBuffer(124);
-    expect(new DataView(buffer).byteLength).toBe(124);
-    expect(new DataView(buffer, 0, 1).byteLength).toBe(1);
-    expect(new DataView(buffer, 0, 64).byteLength).toBe(64);
-    expect(new DataView(buffer, 0, 123).byteLength).toBe(123);
+describe("errors", () => {
+    test("called on non-DataView object", () => {
+        expect(() => {
+            DataView.prototype.byteLength;
+        }).toThrowWithMessage(TypeError, "Not an object of type DataView");
+    });
+
+    test("detached buffer", () => {
+        let buffer = new ArrayBuffer(5, { maxByteLength: 10 });
+        let view = new DataView(buffer);
+        detachArrayBuffer(buffer);
+
+        expect(() => {
+            view.byteLength;
+        }).toThrowWithMessage(
+            TypeError,
+            "DataView contains a property which references a value at an index not contained within its buffer's bounds"
+        );
+    });
+});
+
+describe("normal behavior", () => {
+    test("basic functionality", () => {
+        let buffer = new ArrayBuffer(124);
+        expect(new DataView(buffer).byteLength).toBe(124);
+        expect(new DataView(buffer, 0, 1).byteLength).toBe(1);
+        expect(new DataView(buffer, 0, 64).byteLength).toBe(64);
+        expect(new DataView(buffer, 0, 123).byteLength).toBe(123);
+
+        buffer = new ArrayBuffer(5, { maxByteLength: 10 });
+        expect(new DataView(buffer).byteLength).toBe(5);
+        expect(new DataView(buffer, 0).byteLength).toBe(5);
+        expect(new DataView(buffer, 3).byteLength).toBe(2);
+        expect(new DataView(buffer, 5).byteLength).toBe(0);
+    });
 });

--- a/Userland/Libraries/LibJS/Tests/builtins/DataView/DataView.prototype.byteOffset.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/DataView/DataView.prototype.byteOffset.js
@@ -1,7 +1,30 @@
-test("basic functionality", () => {
-    const buffer = new ArrayBuffer(124);
-    expect(new DataView(buffer).byteOffset).toBe(0);
-    expect(new DataView(buffer, 1).byteOffset).toBe(1);
-    expect(new DataView(buffer, 64).byteOffset).toBe(64);
-    expect(new DataView(buffer, 123).byteOffset).toBe(123);
+describe("errors", () => {
+    test("called on non-DataView object", () => {
+        expect(() => {
+            DataView.prototype.byteOffset;
+        }).toThrowWithMessage(TypeError, "Not an object of type DataView");
+    });
+
+    test("detached buffer", () => {
+        let buffer = new ArrayBuffer(5, { maxByteLength: 10 });
+        let view = new DataView(buffer);
+        detachArrayBuffer(buffer);
+
+        expect(() => {
+            view.byteOffset;
+        }).toThrowWithMessage(
+            TypeError,
+            "DataView contains a property which references a value at an index not contained within its buffer's bounds"
+        );
+    });
+});
+
+describe("normal behavior", () => {
+    test("basic functionality", () => {
+        const buffer = new ArrayBuffer(124);
+        expect(new DataView(buffer).byteOffset).toBe(0);
+        expect(new DataView(buffer, 1).byteOffset).toBe(1);
+        expect(new DataView(buffer, 64).byteOffset).toBe(64);
+        expect(new DataView(buffer, 123).byteOffset).toBe(123);
+    });
 });

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.at.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.at.js
@@ -12,6 +12,26 @@ const TYPED_ARRAYS = [
 
 const BIGINT_TYPED_ARRAYS = [BigUint64Array, BigInt64Array];
 
+describe("errors", () => {
+    test("ArrayBuffer out of bounds", () => {
+        TYPED_ARRAYS.forEach(T => {
+            let arrayBuffer = new ArrayBuffer(T.BYTES_PER_ELEMENT * 2, {
+                maxByteLength: T.BYTES_PER_ELEMENT * 4,
+            });
+
+            let typedArray = new T(arrayBuffer, T.BYTES_PER_ELEMENT, 1);
+            arrayBuffer.resize(T.BYTES_PER_ELEMENT);
+
+            expect(() => {
+                typedArray.at(0);
+            }).toThrowWithMessage(
+                TypeError,
+                "TypedArray contains a property which references a value at an index not contained within its buffer's bounds"
+            );
+        });
+    });
+});
+
 test("basic functionality", () => {
     TYPED_ARRAYS.forEach(T => {
         expect(T.prototype.at).toHaveLength(1);

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.byteLength.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.byteLength.js
@@ -24,3 +24,17 @@ test("basic functionality", () => {
         expect(typedArray.byteLength).toBe(T.expected);
     });
 });
+
+test("resizable ArrayBuffer", () => {
+    TYPED_ARRAYS.forEach(T => {
+        let arrayBuffer = new ArrayBuffer(T.array.BYTES_PER_ELEMENT * 2, {
+            maxByteLength: T.array.BYTES_PER_ELEMENT * 4,
+        });
+
+        let typedArray = new T.array(arrayBuffer, T.array.BYTES_PER_ELEMENT, 1);
+        expect(typedArray.byteLength).toBe(T.array.BYTES_PER_ELEMENT);
+
+        arrayBuffer.resize(T.array.BYTES_PER_ELEMENT);
+        expect(typedArray.byteLength).toBe(0);
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.byteOffset.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.byteOffset.js
@@ -33,3 +33,17 @@ test("basic functionality", () => {
         expect(arrayFromOffset[1]).toBe(!isBigIntArray ? 3 : 3n);
     });
 });
+
+test("resizable ArrayBuffer", () => {
+    TYPED_ARRAYS.forEach(T => {
+        let arrayBuffer = new ArrayBuffer(T.BYTES_PER_ELEMENT * 2, {
+            maxByteLength: T.BYTES_PER_ELEMENT * 4,
+        });
+
+        let typedArray = new T(arrayBuffer, T.BYTES_PER_ELEMENT, 1);
+        expect(typedArray.byteOffset).toBe(T.BYTES_PER_ELEMENT);
+
+        arrayBuffer.resize(T.BYTES_PER_ELEMENT);
+        expect(typedArray.byteOffset).toBe(0);
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.copyWithin.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.copyWithin.js
@@ -12,6 +12,26 @@ const TYPED_ARRAYS = [
 
 const BIGINT_TYPED_ARRAYS = [BigUint64Array, BigInt64Array];
 
+describe("errors", () => {
+    test("ArrayBuffer out of bounds", () => {
+        TYPED_ARRAYS.forEach(T => {
+            let arrayBuffer = new ArrayBuffer(T.BYTES_PER_ELEMENT * 2, {
+                maxByteLength: T.BYTES_PER_ELEMENT * 4,
+            });
+
+            let typedArray = new T(arrayBuffer, T.BYTES_PER_ELEMENT, 1);
+            arrayBuffer.resize(T.BYTES_PER_ELEMENT);
+
+            expect(() => {
+                typedArray.copyWithin(0, 0);
+            }).toThrowWithMessage(
+                TypeError,
+                "TypedArray contains a property which references a value at an index not contained within its buffer's bounds"
+            );
+        });
+    });
+});
+
 test("length is 2", () => {
     TYPED_ARRAYS.forEach(T => {
         expect(T.prototype.copyWithin).toHaveLength(2);

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.entries.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.entries.js
@@ -12,6 +12,26 @@ const TYPED_ARRAYS = [
 
 const BIGINT_TYPED_ARRAYS = [BigUint64Array, BigInt64Array];
 
+describe("errors", () => {
+    test("ArrayBuffer out of bounds", () => {
+        TYPED_ARRAYS.forEach(T => {
+            let arrayBuffer = new ArrayBuffer(T.BYTES_PER_ELEMENT * 2, {
+                maxByteLength: T.BYTES_PER_ELEMENT * 4,
+            });
+
+            let typedArray = new T(arrayBuffer, T.BYTES_PER_ELEMENT, 1);
+            arrayBuffer.resize(T.BYTES_PER_ELEMENT);
+
+            expect(() => {
+                typedArray.entries();
+            }).toThrowWithMessage(
+                TypeError,
+                "TypedArray contains a property which references a value at an index not contained within its buffer's bounds"
+            );
+        });
+    });
+});
+
 test("length is 0", () => {
     TYPED_ARRAYS.forEach(T => {
         expect(T.prototype.entries).toHaveLength(0);

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.every.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.every.js
@@ -12,6 +12,26 @@ const TYPED_ARRAYS = [
 
 const BIGINT_TYPED_ARRAYS = [BigUint64Array, BigInt64Array];
 
+describe("errors", () => {
+    test("ArrayBuffer out of bounds", () => {
+        TYPED_ARRAYS.forEach(T => {
+            let arrayBuffer = new ArrayBuffer(T.BYTES_PER_ELEMENT * 2, {
+                maxByteLength: T.BYTES_PER_ELEMENT * 4,
+            });
+
+            let typedArray = new T(arrayBuffer, T.BYTES_PER_ELEMENT, 1);
+            arrayBuffer.resize(T.BYTES_PER_ELEMENT);
+
+            expect(() => {
+                typedArray.every(value => value === 0);
+            }).toThrowWithMessage(
+                TypeError,
+                "TypedArray contains a property which references a value at an index not contained within its buffer's bounds"
+            );
+        });
+    });
+});
+
 test("length is 1", () => {
     TYPED_ARRAYS.forEach(T => {
         expect(T.prototype.every).toHaveLength(1);

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.fill.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.fill.js
@@ -12,6 +12,26 @@ const TYPED_ARRAYS = [
 
 const BIGINT_TYPED_ARRAYS = [BigUint64Array, BigInt64Array];
 
+describe("errors", () => {
+    test("ArrayBuffer out of bounds", () => {
+        TYPED_ARRAYS.forEach(T => {
+            let arrayBuffer = new ArrayBuffer(T.BYTES_PER_ELEMENT * 2, {
+                maxByteLength: T.BYTES_PER_ELEMENT * 4,
+            });
+
+            let typedArray = new T(arrayBuffer, T.BYTES_PER_ELEMENT, 1);
+            arrayBuffer.resize(T.BYTES_PER_ELEMENT);
+
+            expect(() => {
+                typedArray.fill(0);
+            }).toThrowWithMessage(
+                TypeError,
+                "TypedArray contains a property which references a value at an index not contained within its buffer's bounds"
+            );
+        });
+    });
+});
+
 test("basic functionality", () => {
     TYPED_ARRAYS.forEach(T => {
         expect(T.prototype.fill).toHaveLength(1);

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.filter.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.filter.js
@@ -38,6 +38,22 @@ describe("errors", () => {
                 new T().filter(undefined);
             }).toThrowWithMessage(TypeError, "undefined is not a function");
         });
+
+        test(`ArrayBuffer out of bounds (${T.name})`, () => {
+            let arrayBuffer = new ArrayBuffer(T.BYTES_PER_ELEMENT * 2, {
+                maxByteLength: T.BYTES_PER_ELEMENT * 4,
+            });
+
+            let typedArray = new T(arrayBuffer, T.BYTES_PER_ELEMENT, 1);
+            arrayBuffer.resize(T.BYTES_PER_ELEMENT);
+
+            expect(() => {
+                typedArray.filter(value => value === 0);
+            }).toThrowWithMessage(
+                TypeError,
+                "TypedArray contains a property which references a value at an index not contained within its buffer's bounds"
+            );
+        });
     }
 
     TYPED_ARRAYS.forEach(T => argumentErrorTests(T));

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.find.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.find.js
@@ -38,6 +38,22 @@ describe("errors", () => {
                 new T().find(undefined);
             }).toThrowWithMessage(TypeError, "undefined is not a function");
         });
+
+        test(`ArrayBuffer out of bounds (${T.name})`, () => {
+            let arrayBuffer = new ArrayBuffer(T.BYTES_PER_ELEMENT * 2, {
+                maxByteLength: T.BYTES_PER_ELEMENT * 4,
+            });
+
+            let typedArray = new T(arrayBuffer, T.BYTES_PER_ELEMENT, 1);
+            arrayBuffer.resize(T.BYTES_PER_ELEMENT);
+
+            expect(() => {
+                typedArray.find(value => value === 0);
+            }).toThrowWithMessage(
+                TypeError,
+                "TypedArray contains a property which references a value at an index not contained within its buffer's bounds"
+            );
+        });
     }
 
     TYPED_ARRAYS.forEach(T => errorTests(T));

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.findIndex.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.findIndex.js
@@ -38,6 +38,22 @@ describe("errors", () => {
                 new T().findIndex(undefined);
             }).toThrowWithMessage(TypeError, "undefined is not a function");
         });
+
+        test(`ArrayBuffer out of bounds (${T.name})`, () => {
+            let arrayBuffer = new ArrayBuffer(T.BYTES_PER_ELEMENT * 2, {
+                maxByteLength: T.BYTES_PER_ELEMENT * 4,
+            });
+
+            let typedArray = new T(arrayBuffer, T.BYTES_PER_ELEMENT, 1);
+            arrayBuffer.resize(T.BYTES_PER_ELEMENT);
+
+            expect(() => {
+                typedArray.findIndex(value => value === 0);
+            }).toThrowWithMessage(
+                TypeError,
+                "TypedArray contains a property which references a value at an index not contained within its buffer's bounds"
+            );
+        });
     }
 
     TYPED_ARRAYS.forEach(T => errorTests(T));

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.findLast.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.findLast.js
@@ -38,6 +38,22 @@ describe("errors", () => {
                 new T().findLast(undefined);
             }).toThrowWithMessage(TypeError, "undefined is not a function");
         });
+
+        test(`ArrayBuffer out of bounds (${T.name})`, () => {
+            let arrayBuffer = new ArrayBuffer(T.BYTES_PER_ELEMENT * 2, {
+                maxByteLength: T.BYTES_PER_ELEMENT * 4,
+            });
+
+            let typedArray = new T(arrayBuffer, T.BYTES_PER_ELEMENT, 1);
+            arrayBuffer.resize(T.BYTES_PER_ELEMENT);
+
+            expect(() => {
+                typedArray.findLast(value => value === 0);
+            }).toThrowWithMessage(
+                TypeError,
+                "TypedArray contains a property which references a value at an index not contained within its buffer's bounds"
+            );
+        });
     }
 
     TYPED_ARRAYS.forEach(T => errorTests(T));

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.findLastIndex.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.findLastIndex.js
@@ -38,6 +38,22 @@ describe("errors", () => {
                 new T().findLastIndex(undefined);
             }).toThrowWithMessage(TypeError, "undefined is not a function");
         });
+
+        test(`ArrayBuffer out of bounds (${T.name})`, () => {
+            let arrayBuffer = new ArrayBuffer(T.BYTES_PER_ELEMENT * 2, {
+                maxByteLength: T.BYTES_PER_ELEMENT * 4,
+            });
+
+            let typedArray = new T(arrayBuffer, T.BYTES_PER_ELEMENT, 1);
+            arrayBuffer.resize(T.BYTES_PER_ELEMENT);
+
+            expect(() => {
+                typedArray.findLastIndex(value => value === 0);
+            }).toThrowWithMessage(
+                TypeError,
+                "TypedArray contains a property which references a value at an index not contained within its buffer's bounds"
+            );
+        });
     }
 
     TYPED_ARRAYS.forEach(T => errorTests(T));

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.forEach.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.forEach.js
@@ -38,6 +38,22 @@ describe("errors", () => {
                 new T().forEach(undefined);
             }).toThrowWithMessage(TypeError, "undefined is not a function");
         });
+
+        test(`ArrayBuffer out of bounds (${T.name})`, () => {
+            let arrayBuffer = new ArrayBuffer(T.BYTES_PER_ELEMENT * 2, {
+                maxByteLength: T.BYTES_PER_ELEMENT * 4,
+            });
+
+            let typedArray = new T(arrayBuffer, T.BYTES_PER_ELEMENT, 1);
+            arrayBuffer.resize(T.BYTES_PER_ELEMENT);
+
+            expect(() => {
+                typedArray.forEach(() => {});
+            }).toThrowWithMessage(
+                TypeError,
+                "TypedArray contains a property which references a value at an index not contained within its buffer's bounds"
+            );
+        });
     }
 
     TYPED_ARRAYS.forEach(T => errorTests(T));

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.includes.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.includes.js
@@ -12,6 +12,26 @@ const TYPED_ARRAYS = [
 
 const BIGINT_TYPED_ARRAYS = [BigUint64Array, BigInt64Array];
 
+describe("errors", () => {
+    test("ArrayBuffer out of bounds", () => {
+        TYPED_ARRAYS.forEach(T => {
+            let arrayBuffer = new ArrayBuffer(T.BYTES_PER_ELEMENT * 2, {
+                maxByteLength: T.BYTES_PER_ELEMENT * 4,
+            });
+
+            let typedArray = new T(arrayBuffer, T.BYTES_PER_ELEMENT, 1);
+            arrayBuffer.resize(T.BYTES_PER_ELEMENT);
+
+            expect(() => {
+                typedArray.includes(0);
+            }).toThrowWithMessage(
+                TypeError,
+                "TypedArray contains a property which references a value at an index not contained within its buffer's bounds"
+            );
+        });
+    });
+});
+
 test("basic functionality", () => {
     TYPED_ARRAYS.forEach(T => {
         expect(T.prototype.includes).toHaveLength(1);

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.indexOf.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.indexOf.js
@@ -12,6 +12,26 @@ const TYPED_ARRAYS = [
 
 const BIGINT_TYPED_ARRAYS = [BigUint64Array, BigInt64Array];
 
+describe("errors", () => {
+    test("ArrayBuffer out of bounds", () => {
+        TYPED_ARRAYS.forEach(T => {
+            let arrayBuffer = new ArrayBuffer(T.BYTES_PER_ELEMENT * 2, {
+                maxByteLength: T.BYTES_PER_ELEMENT * 4,
+            });
+
+            let typedArray = new T(arrayBuffer, T.BYTES_PER_ELEMENT, 1);
+            arrayBuffer.resize(T.BYTES_PER_ELEMENT);
+
+            expect(() => {
+                typedArray.indexOf(0);
+            }).toThrowWithMessage(
+                TypeError,
+                "TypedArray contains a property which references a value at an index not contained within its buffer's bounds"
+            );
+        });
+    });
+});
+
 test("basic functionality", () => {
     TYPED_ARRAYS.forEach(T => {
         expect(T.prototype.indexOf).toHaveLength(1);

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.keys.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.keys.js
@@ -12,6 +12,26 @@ const TYPED_ARRAYS = [
 
 const BIGINT_TYPED_ARRAYS = [BigUint64Array, BigInt64Array];
 
+describe("errors", () => {
+    test("ArrayBuffer out of bounds", () => {
+        TYPED_ARRAYS.forEach(T => {
+            let arrayBuffer = new ArrayBuffer(T.BYTES_PER_ELEMENT * 2, {
+                maxByteLength: T.BYTES_PER_ELEMENT * 4,
+            });
+
+            let typedArray = new T(arrayBuffer, T.BYTES_PER_ELEMENT, 1);
+            arrayBuffer.resize(T.BYTES_PER_ELEMENT);
+
+            expect(() => {
+                typedArray.keys();
+            }).toThrowWithMessage(
+                TypeError,
+                "TypedArray contains a property which references a value at an index not contained within its buffer's bounds"
+            );
+        });
+    });
+});
+
 test("length is 0", () => {
     TYPED_ARRAYS.forEach(T => {
         expect(T.prototype.keys).toHaveLength(0);

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.lastIndexOf.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.lastIndexOf.js
@@ -12,6 +12,26 @@ const TYPED_ARRAYS = [
 
 const BIGINT_TYPED_ARRAYS = [BigUint64Array, BigInt64Array];
 
+describe("errors", () => {
+    test("ArrayBuffer out of bounds", () => {
+        TYPED_ARRAYS.forEach(T => {
+            let arrayBuffer = new ArrayBuffer(T.BYTES_PER_ELEMENT * 2, {
+                maxByteLength: T.BYTES_PER_ELEMENT * 4,
+            });
+
+            let typedArray = new T(arrayBuffer, T.BYTES_PER_ELEMENT, 1);
+            arrayBuffer.resize(T.BYTES_PER_ELEMENT);
+
+            expect(() => {
+                typedArray.lastIndexOf(0);
+            }).toThrowWithMessage(
+                TypeError,
+                "TypedArray contains a property which references a value at an index not contained within its buffer's bounds"
+            );
+        });
+    });
+});
+
 test("basic functionality", () => {
     TYPED_ARRAYS.forEach(T => {
         expect(T.prototype.lastIndexOf).toHaveLength(1);

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.length.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.length.js
@@ -19,3 +19,17 @@ test("basic functionality", () => {
         expect(typedArray.length).toBe(42);
     });
 });
+
+test("resizable ArrayBuffer", () => {
+    TYPED_ARRAYS.forEach(T => {
+        let arrayBuffer = new ArrayBuffer(T.BYTES_PER_ELEMENT * 2, {
+            maxByteLength: T.BYTES_PER_ELEMENT * 4,
+        });
+
+        let typedArray = new T(arrayBuffer, T.BYTES_PER_ELEMENT, 1);
+        expect(typedArray.length).toBe(1);
+
+        arrayBuffer.resize(T.BYTES_PER_ELEMENT);
+        expect(typedArray.length).toBe(0);
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.map.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.map.js
@@ -38,6 +38,22 @@ describe("errors", () => {
                 new T().map(undefined);
             }).toThrowWithMessage(TypeError, "undefined is not a function");
         });
+
+        test(`ArrayBuffer out of bounds (${T.name})`, () => {
+            let arrayBuffer = new ArrayBuffer(T.BYTES_PER_ELEMENT * 2, {
+                maxByteLength: T.BYTES_PER_ELEMENT * 4,
+            });
+
+            let typedArray = new T(arrayBuffer, T.BYTES_PER_ELEMENT, 1);
+            arrayBuffer.resize(T.BYTES_PER_ELEMENT);
+
+            expect(() => {
+                typedArray.map(value => value);
+            }).toThrowWithMessage(
+                TypeError,
+                "TypedArray contains a property which references a value at an index not contained within its buffer's bounds"
+            );
+        });
     }
 
     TYPED_ARRAYS.forEach(T => argumentErrorTests(T));

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.reduce.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.reduce.js
@@ -12,6 +12,26 @@ const TYPED_ARRAYS = [
 
 const BIGINT_TYPED_ARRAYS = [BigUint64Array, BigInt64Array];
 
+describe("errors", () => {
+    test("ArrayBuffer out of bounds", () => {
+        TYPED_ARRAYS.forEach(T => {
+            let arrayBuffer = new ArrayBuffer(T.BYTES_PER_ELEMENT * 2, {
+                maxByteLength: T.BYTES_PER_ELEMENT * 4,
+            });
+
+            let typedArray = new T(arrayBuffer, T.BYTES_PER_ELEMENT, 1);
+            arrayBuffer.resize(T.BYTES_PER_ELEMENT);
+
+            expect(() => {
+                typedArray.reduce((accumulator, value) => accumulator + value);
+            }).toThrowWithMessage(
+                TypeError,
+                "TypedArray contains a property which references a value at an index not contained within its buffer's bounds"
+            );
+        });
+    });
+});
+
 test("basic functionality", () => {
     TYPED_ARRAYS.forEach(T => {
         expect(T.prototype.reduce).toHaveLength(1);

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.reduceRight.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.reduceRight.js
@@ -12,6 +12,26 @@ const TYPED_ARRAYS = [
 
 const BIGINT_TYPED_ARRAYS = [BigUint64Array, BigInt64Array];
 
+describe("errors", () => {
+    test("ArrayBuffer out of bounds", () => {
+        TYPED_ARRAYS.forEach(T => {
+            let arrayBuffer = new ArrayBuffer(T.BYTES_PER_ELEMENT * 2, {
+                maxByteLength: T.BYTES_PER_ELEMENT * 4,
+            });
+
+            let typedArray = new T(arrayBuffer, T.BYTES_PER_ELEMENT, 1);
+            arrayBuffer.resize(T.BYTES_PER_ELEMENT);
+
+            expect(() => {
+                typedArray.reduceRight((accumulator, value) => accumulator + value);
+            }).toThrowWithMessage(
+                TypeError,
+                "TypedArray contains a property which references a value at an index not contained within its buffer's bounds"
+            );
+        });
+    });
+});
+
 test("basic functionality", () => {
     TYPED_ARRAYS.forEach(T => {
         expect(T.prototype.reduceRight).toHaveLength(1);

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.reverse.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.reverse.js
@@ -12,6 +12,26 @@ const TYPED_ARRAYS = [
 
 const BIGINT_TYPED_ARRAYS = [BigUint64Array, BigInt64Array];
 
+describe("errors", () => {
+    test("ArrayBuffer out of bounds", () => {
+        TYPED_ARRAYS.forEach(T => {
+            let arrayBuffer = new ArrayBuffer(T.BYTES_PER_ELEMENT * 2, {
+                maxByteLength: T.BYTES_PER_ELEMENT * 4,
+            });
+
+            let typedArray = new T(arrayBuffer, T.BYTES_PER_ELEMENT, 1);
+            arrayBuffer.resize(T.BYTES_PER_ELEMENT);
+
+            expect(() => {
+                typedArray.reverse();
+            }).toThrowWithMessage(
+                TypeError,
+                "TypedArray contains a property which references a value at an index not contained within its buffer's bounds"
+            );
+        });
+    });
+});
+
 test("length is 0", () => {
     TYPED_ARRAYS.forEach(T => {
         expect(T.prototype.reverse).toHaveLength(0);

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.set.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.set.js
@@ -15,6 +15,33 @@ const BIGINT_TYPED_ARRAYS = [
     { array: BigInt64Array, maxUnsignedInteger: 2n ** 63n - 1n },
 ];
 
+describe("errors", () => {
+    test("ArrayBuffer out of bounds", () => {
+        TYPED_ARRAYS.forEach(T => {
+            let arrayBuffer = new ArrayBuffer(T.array.BYTES_PER_ELEMENT * 2, {
+                maxByteLength: T.array.BYTES_PER_ELEMENT * 4,
+            });
+
+            let typedArray = new T.array(arrayBuffer, T.array.BYTES_PER_ELEMENT, 1);
+            arrayBuffer.resize(T.array.BYTES_PER_ELEMENT);
+
+            expect(() => {
+                typedArray.set([0]);
+            }).toThrowWithMessage(
+                TypeError,
+                "TypedArray contains a property which references a value at an index not contained within its buffer's bounds"
+            );
+
+            expect(() => {
+                typedArray.set(new T.array());
+            }).toThrowWithMessage(
+                TypeError,
+                "TypedArray contains a property which references a value at an index not contained within its buffer's bounds"
+            );
+        });
+    });
+});
+
 // FIXME: Write out a full test suite for this function. This currently only performs a single regression test.
 describe("normal behavior", () => {
     // Previously, we didn't apply source's byte offset on the code path for setting a typed array

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.slice.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.slice.js
@@ -12,6 +12,26 @@ const TYPED_ARRAYS = [
 
 const BIGINT_TYPED_ARRAYS = [BigUint64Array, BigInt64Array];
 
+describe("errors", () => {
+    test("ArrayBuffer out of bounds", () => {
+        TYPED_ARRAYS.forEach(T => {
+            let arrayBuffer = new ArrayBuffer(T.BYTES_PER_ELEMENT * 2, {
+                maxByteLength: T.BYTES_PER_ELEMENT * 4,
+            });
+
+            let typedArray = new T(arrayBuffer, T.BYTES_PER_ELEMENT, 1);
+            arrayBuffer.resize(T.BYTES_PER_ELEMENT);
+
+            expect(() => {
+                typedArray.slice(0, 1);
+            }).toThrowWithMessage(
+                TypeError,
+                "TypedArray contains a property which references a value at an index not contained within its buffer's bounds"
+            );
+        });
+    });
+});
+
 test("basic functionality", () => {
     TYPED_ARRAYS.forEach(T => {
         expect(T.prototype.slice).toHaveLength(2);

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.some.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.some.js
@@ -12,6 +12,26 @@ const TYPED_ARRAYS = [
 
 const BIGINT_TYPED_ARRAYS = [BigUint64Array, BigInt64Array];
 
+describe("errors", () => {
+    test("ArrayBuffer out of bounds", () => {
+        TYPED_ARRAYS.forEach(T => {
+            let arrayBuffer = new ArrayBuffer(T.BYTES_PER_ELEMENT * 2, {
+                maxByteLength: T.BYTES_PER_ELEMENT * 4,
+            });
+
+            let typedArray = new T(arrayBuffer, T.BYTES_PER_ELEMENT, 1);
+            arrayBuffer.resize(T.BYTES_PER_ELEMENT);
+
+            expect(() => {
+                typedArray.some(value => value === 0);
+            }).toThrowWithMessage(
+                TypeError,
+                "TypedArray contains a property which references a value at an index not contained within its buffer's bounds"
+            );
+        });
+    });
+});
+
 test("length is 1", () => {
     TYPED_ARRAYS.forEach(T => {
         expect(T.prototype.some).toHaveLength(1);

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.sort.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.sort.js
@@ -12,6 +12,26 @@ const TYPED_ARRAYS = [
 
 const BIGINT_TYPED_ARRAYS = [BigUint64Array, BigInt64Array];
 
+describe("errors", () => {
+    test("ArrayBuffer out of bounds", () => {
+        TYPED_ARRAYS.forEach(T => {
+            let arrayBuffer = new ArrayBuffer(T.BYTES_PER_ELEMENT * 2, {
+                maxByteLength: T.BYTES_PER_ELEMENT * 4,
+            });
+
+            let typedArray = new T(arrayBuffer, T.BYTES_PER_ELEMENT, 1);
+            arrayBuffer.resize(T.BYTES_PER_ELEMENT);
+
+            expect(() => {
+                typedArray.sort();
+            }).toThrowWithMessage(
+                TypeError,
+                "TypedArray contains a property which references a value at an index not contained within its buffer's bounds"
+            );
+        });
+    });
+});
+
 test("basic functionality", () => {
     TYPED_ARRAYS.forEach(T => {
         expect(T.prototype.sort).toHaveLength(1);

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.subarray.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.subarray.js
@@ -43,3 +43,17 @@ test("basic functionality", () => {
         expect(typedArray[1]).toBe(4n);
     });
 });
+
+test("resizable ArrayBuffer", () => {
+    TYPED_ARRAYS.forEach(T => {
+        let arrayBuffer = new ArrayBuffer(T.BYTES_PER_ELEMENT * 2, {
+            maxByteLength: T.BYTES_PER_ELEMENT * 4,
+        });
+
+        let typedArray = new T(arrayBuffer, T.BYTES_PER_ELEMENT, 1);
+        expect(typedArray.subarray(0, 1).byteLength).toBe(T.BYTES_PER_ELEMENT);
+
+        arrayBuffer.resize(T.BYTES_PER_ELEMENT);
+        expect(typedArray.subarray(0, 1).byteLength).toBe(0);
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.toLocaleString.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.toLocaleString.js
@@ -12,6 +12,26 @@ const TYPED_ARRAYS = [
 
 const BIGINT_TYPED_ARRAYS = [BigUint64Array, BigInt64Array];
 
+describe("errors", () => {
+    test("ArrayBuffer out of bounds", () => {
+        TYPED_ARRAYS.forEach(T => {
+            let arrayBuffer = new ArrayBuffer(T.BYTES_PER_ELEMENT * 2, {
+                maxByteLength: T.BYTES_PER_ELEMENT * 4,
+            });
+
+            let typedArray = new T(arrayBuffer, T.BYTES_PER_ELEMENT, 1);
+            arrayBuffer.resize(T.BYTES_PER_ELEMENT);
+
+            expect(() => {
+                typedArray.toLocaleString();
+            }).toThrowWithMessage(
+                TypeError,
+                "TypedArray contains a property which references a value at an index not contained within its buffer's bounds"
+            );
+        });
+    });
+});
+
 test("basic functionality", () => {
     TYPED_ARRAYS.forEach(T => {
         expect(T.prototype.toLocaleString).toHaveLength(0);

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.toReversed.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.toReversed.js
@@ -12,6 +12,26 @@ const TYPED_ARRAYS = [
 
 const BIGINT_TYPED_ARRAYS = [BigUint64Array, BigInt64Array];
 
+describe("errors", () => {
+    test("ArrayBuffer out of bounds", () => {
+        TYPED_ARRAYS.forEach(T => {
+            let arrayBuffer = new ArrayBuffer(T.BYTES_PER_ELEMENT * 2, {
+                maxByteLength: T.BYTES_PER_ELEMENT * 4,
+            });
+
+            let typedArray = new T(arrayBuffer, T.BYTES_PER_ELEMENT, 1);
+            arrayBuffer.resize(T.BYTES_PER_ELEMENT);
+
+            expect(() => {
+                typedArray.toReversed();
+            }).toThrowWithMessage(
+                TypeError,
+                "TypedArray contains a property which references a value at an index not contained within its buffer's bounds"
+            );
+        });
+    });
+});
+
 test("length is 0", () => {
     TYPED_ARRAYS.forEach(T => {
         expect(T.prototype.toReversed).toHaveLength(0);

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.toSorted.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.toSorted.js
@@ -12,6 +12,26 @@ const TYPED_ARRAYS = [
 
 const BIGINT_TYPED_ARRAYS = [BigUint64Array, BigInt64Array];
 
+describe("errors", () => {
+    test("ArrayBuffer out of bounds", () => {
+        TYPED_ARRAYS.forEach(T => {
+            let arrayBuffer = new ArrayBuffer(T.BYTES_PER_ELEMENT * 2, {
+                maxByteLength: T.BYTES_PER_ELEMENT * 4,
+            });
+
+            let typedArray = new T(arrayBuffer, T.BYTES_PER_ELEMENT, 1);
+            arrayBuffer.resize(T.BYTES_PER_ELEMENT);
+
+            expect(() => {
+                typedArray.toSorted();
+            }).toThrowWithMessage(
+                TypeError,
+                "TypedArray contains a property which references a value at an index not contained within its buffer's bounds"
+            );
+        });
+    });
+});
+
 test("basic functionality", () => {
     TYPED_ARRAYS.forEach(T => {
         expect(T.prototype.toSorted).toHaveLength(1);

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.values.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.values.js
@@ -12,6 +12,26 @@ const TYPED_ARRAYS = [
 
 const BIGINT_TYPED_ARRAYS = [BigUint64Array, BigInt64Array];
 
+describe("errors", () => {
+    test("ArrayBuffer out of bounds", () => {
+        TYPED_ARRAYS.forEach(T => {
+            let arrayBuffer = new ArrayBuffer(T.BYTES_PER_ELEMENT * 2, {
+                maxByteLength: T.BYTES_PER_ELEMENT * 4,
+            });
+
+            let typedArray = new T(arrayBuffer, T.BYTES_PER_ELEMENT, 1);
+            arrayBuffer.resize(T.BYTES_PER_ELEMENT);
+
+            expect(() => {
+                typedArray.values();
+            }).toThrowWithMessage(
+                TypeError,
+                "TypedArray contains a property which references a value at an index not contained within its buffer's bounds"
+            );
+        });
+    });
+});
+
 test("length is 0", () => {
     TYPED_ARRAYS.forEach(T => {
         expect(T.prototype.values).toHaveLength(0);

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.with.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.with.js
@@ -48,6 +48,24 @@ describe("errors", () => {
             }).toThrowWithMessage(RangeError, "Invalid integer index: -inf");
         });
     });
+
+    test("ArrayBuffer out of bounds", () => {
+        TYPED_ARRAYS.forEach(T => {
+            let arrayBuffer = new ArrayBuffer(T.BYTES_PER_ELEMENT * 2, {
+                maxByteLength: T.BYTES_PER_ELEMENT * 4,
+            });
+
+            let typedArray = new T(arrayBuffer, T.BYTES_PER_ELEMENT, 1);
+            arrayBuffer.resize(T.BYTES_PER_ELEMENT);
+
+            expect(() => {
+                typedArray.with(0, 0);
+            }).toThrowWithMessage(
+                TypeError,
+                "TypedArray contains a property which references a value at an index not contained within its buffer's bounds"
+            );
+        });
+    });
 });
 
 describe("normal behavior", () => {


### PR DESCRIPTION
https://github.com/tc39/ecma262/commit/a9ae96e

The spec has since received a few editorial updates which are included here.

```
Diff Tests:
    +261 ✅    -261 ❌
```

<details>
  <summary>Full diff report</summary>
  <pre>
Diff Tests:
    test/built-ins/Array/prototype/every/callbackfn-resize-arraybuffer.js                                                        ❌ -> ✅
    test/built-ins/Array/prototype/filter/callbackfn-resize-arraybuffer.js                                                       ❌ -> ✅
    test/built-ins/Array/prototype/find/callbackfn-resize-arraybuffer.js                                                         ❌ -> ✅
    test/built-ins/Array/prototype/findIndex/callbackfn-resize-arraybuffer.js                                                    ❌ -> ✅
    test/built-ins/Array/prototype/findLast/callbackfn-resize-arraybuffer.js                                                     ❌ -> ✅
    test/built-ins/Array/prototype/findLastIndex/callbackfn-resize-arraybuffer.js                                                ❌ -> ✅
    test/built-ins/Array/prototype/forEach/callbackfn-resize-arraybuffer.js                                                      ❌ -> ✅
    test/built-ins/Array/prototype/map/callbackfn-resize-arraybuffer.js                                                          ❌ -> ✅
    test/built-ins/Array/prototype/some/callbackfn-resize-arraybuffer.js                                                         ❌ -> ✅
    test/built-ins/ArrayBuffer/options-maxbytelength-diminuitive.js                                                              ❌ -> ✅
    test/built-ins/ArrayBuffer/options-maxbytelength-excessive.js                                                                ❌ -> ✅
    test/built-ins/ArrayBuffer/options-maxbytelength-negative.js                                                                 ❌ -> ✅
    test/built-ins/ArrayBuffer/options-maxbytelength-object.js                                                                   ❌ -> ✅
    test/built-ins/ArrayBuffer/options-maxbytelength-poisoned.js                                                                 ❌ -> ✅
    test/built-ins/ArrayBuffer/options-maxbytelength-undefined.js                                                                ❌ -> ✅
    test/built-ins/ArrayBuffer/options-non-object.js                                                                             ❌ -> ✅
    test/built-ins/ArrayBuffer/prototype/maxByteLength/detached-buffer.js                                                        ❌ -> ✅
    test/built-ins/ArrayBuffer/prototype/maxByteLength/invoked-as-accessor.js                                                    ❌ -> ✅
    test/built-ins/ArrayBuffer/prototype/maxByteLength/invoked-as-func.js                                                        ❌ -> ✅
    test/built-ins/ArrayBuffer/prototype/maxByteLength/length.js                                                                 ❌ -> ✅
    test/built-ins/ArrayBuffer/prototype/maxByteLength/name.js                                                                   ❌ -> ✅
    test/built-ins/ArrayBuffer/prototype/maxByteLength/prop-desc.js                                                              ❌ -> ✅
    test/built-ins/ArrayBuffer/prototype/maxByteLength/return-maxbytelength-non-resizable.js                                     ❌ -> ✅
    test/built-ins/ArrayBuffer/prototype/maxByteLength/return-maxbytelength-resizable.js                                         ❌ -> ✅
    test/built-ins/ArrayBuffer/prototype/maxByteLength/this-has-no-arraybufferdata-internal.js                                   ❌ -> ✅
    test/built-ins/ArrayBuffer/prototype/maxByteLength/this-is-not-object.js                                                     ❌ -> ✅
    test/built-ins/ArrayBuffer/prototype/maxByteLength/this-is-sharedarraybuffer.js                                              ❌ -> ✅
    test/built-ins/ArrayBuffer/prototype/resizable/detached-buffer.js                                                            ❌ -> ✅
    test/built-ins/ArrayBuffer/prototype/resizable/invoked-as-accessor.js                                                        ❌ -> ✅
    test/built-ins/ArrayBuffer/prototype/resizable/invoked-as-func.js                                                            ❌ -> ✅
    test/built-ins/ArrayBuffer/prototype/resizable/length.js                                                                     ❌ -> ✅
    test/built-ins/ArrayBuffer/prototype/resizable/name.js                                                                       ❌ -> ✅
    test/built-ins/ArrayBuffer/prototype/resizable/prop-desc.js                                                                  ❌ -> ✅
    test/built-ins/ArrayBuffer/prototype/resizable/return-resizable.js                                                           ❌ -> ✅
    test/built-ins/ArrayBuffer/prototype/resizable/this-has-no-arraybufferdata-internal.js                                       ❌ -> ✅
    test/built-ins/ArrayBuffer/prototype/resizable/this-is-not-object.js                                                         ❌ -> ✅
    test/built-ins/ArrayBuffer/prototype/resizable/this-is-sharedarraybuffer.js                                                  ❌ -> ✅
    test/built-ins/ArrayBuffer/prototype/resize/descriptor.js                                                                    ❌ -> ✅
    test/built-ins/ArrayBuffer/prototype/resize/extensible.js                                                                    ❌ -> ✅
    test/built-ins/ArrayBuffer/prototype/resize/length.js                                                                        ❌ -> ✅
    test/built-ins/ArrayBuffer/prototype/resize/name.js                                                                          ❌ -> ✅
    test/built-ins/ArrayBuffer/prototype/resize/new-length-excessive.js                                                          ❌ -> ✅
    test/built-ins/ArrayBuffer/prototype/resize/new-length-negative.js                                                           ❌ -> ✅
    test/built-ins/ArrayBuffer/prototype/resize/new-length-non-number.js                                                         ❌ -> ✅
    test/built-ins/ArrayBuffer/prototype/resize/nonconstructor.js                                                                ❌ -> ✅
    test/built-ins/ArrayBuffer/prototype/resize/resize-grow.js                                                                   ❌ -> ✅
    test/built-ins/ArrayBuffer/prototype/resize/resize-same-size-zero-explicit.js                                                ❌ -> ✅
    test/built-ins/ArrayBuffer/prototype/resize/resize-same-size-zero-implicit.js                                                ❌ -> ✅
    test/built-ins/ArrayBuffer/prototype/resize/resize-same-size.js                                                              ❌ -> ✅
    test/built-ins/ArrayBuffer/prototype/resize/resize-shrink-zero-explicit.js                                                   ❌ -> ✅
    test/built-ins/ArrayBuffer/prototype/resize/resize-shrink-zero-implicit.js                                                   ❌ -> ✅
    test/built-ins/ArrayBuffer/prototype/resize/resize-shrink.js                                                                 ❌ -> ✅
    test/built-ins/ArrayBuffer/prototype/resize/this-is-detached.js                                                              ❌ -> ✅
    test/built-ins/ArrayBuffer/prototype/resize/this-is-not-arraybuffer-object.js                                                ❌ -> ✅
    test/built-ins/ArrayBuffer/prototype/resize/this-is-not-object.js                                                            ❌ -> ✅
    test/built-ins/ArrayBuffer/prototype/resize/this-is-not-resizable-arraybuffer-object.js                                      ❌ -> ✅
    test/built-ins/ArrayBuffer/prototype/transfer/from-fixed-to-larger.js                                                        ❌ -> ✅
    test/built-ins/ArrayBuffer/prototype/transfer/from-fixed-to-same.js                                                          ❌ -> ✅
    test/built-ins/ArrayBuffer/prototype/transfer/from-fixed-to-smaller.js                                                       ❌ -> ✅
    test/built-ins/ArrayBuffer/prototype/transfer/from-fixed-to-zero.js                                                          ❌ -> ✅
    test/built-ins/ArrayBuffer/prototype/transferToFixedLength/from-fixed-to-larger.js                                           ❌ -> ✅
    test/built-ins/ArrayBuffer/prototype/transferToFixedLength/from-fixed-to-same.js                                             ❌ -> ✅
    test/built-ins/ArrayBuffer/prototype/transferToFixedLength/from-fixed-to-smaller.js                                          ❌ -> ✅
    test/built-ins/ArrayBuffer/prototype/transferToFixedLength/from-fixed-to-zero.js                                             ❌ -> ✅
    test/built-ins/ArrayBuffer/prototype/transferToFixedLength/from-resizable-to-larger.js                                       ❌ -> ✅
    test/built-ins/ArrayBuffer/prototype/transferToFixedLength/from-resizable-to-same.js                                         ❌ -> ✅
    test/built-ins/ArrayBuffer/prototype/transferToFixedLength/from-resizable-to-smaller.js                                      ❌ -> ✅
    test/built-ins/ArrayBuffer/prototype/transferToFixedLength/from-resizable-to-zero.js                                         ❌ -> ✅
    test/built-ins/DataView/custom-proto-access-resizes-buffer-invalid-by-length.js                                              ❌ -> ✅
    test/built-ins/DataView/custom-proto-access-resizes-buffer-invalid-by-offset.js                                              ❌ -> ✅
    test/built-ins/DataView/custom-proto-access-resizes-buffer-valid-by-length.js                                                ❌ -> ✅
    test/built-ins/DataView/custom-proto-access-resizes-buffer-valid-by-offset.js                                                ❌ -> ✅
    test/built-ins/DataView/prototype/byteLength/resizable-array-buffer-auto.js                                                  ❌ -> ✅
    test/built-ins/DataView/prototype/byteLength/resizable-array-buffer-fixed.js                                                 ❌ -> ✅
    test/built-ins/DataView/prototype/byteOffset/resizable-array-buffer-auto.js                                                  ❌ -> ✅
    test/built-ins/DataView/prototype/byteOffset/resizable-array-buffer-fixed.js                                                 ❌ -> ✅
    test/built-ins/DataView/prototype/getBigInt64/resizable-buffer.js                                                            ❌ -> ✅
    test/built-ins/DataView/prototype/getBigUint64/resizable-buffer.js                                                           ❌ -> ✅
    test/built-ins/DataView/prototype/getFloat32/resizable-buffer.js                                                             ❌ -> ✅
    test/built-ins/DataView/prototype/getFloat64/resizable-buffer.js                                                             ❌ -> ✅
    test/built-ins/DataView/prototype/getInt16/resizable-buffer.js                                                               ❌ -> ✅
    test/built-ins/DataView/prototype/getInt32/resizable-buffer.js                                                               ❌ -> ✅
    test/built-ins/DataView/prototype/getInt8/resizable-buffer.js                                                                ❌ -> ✅
    test/built-ins/DataView/prototype/getUint16/resizable-buffer.js                                                              ❌ -> ✅
    test/built-ins/DataView/prototype/getUint32/resizable-buffer.js                                                              ❌ -> ✅
    test/built-ins/DataView/prototype/getUint8/resizable-buffer.js                                                               ❌ -> ✅
    test/built-ins/DataView/prototype/setBigInt64/resizable-buffer.js                                                            ❌ -> ✅
    test/built-ins/DataView/prototype/setBigUint64/resizable-buffer.js                                                           ❌ -> ✅
    test/built-ins/DataView/prototype/setFloat32/resizable-buffer.js                                                             ❌ -> ✅
    test/built-ins/DataView/prototype/setFloat64/resizable-buffer.js                                                             ❌ -> ✅
    test/built-ins/DataView/prototype/setInt16/resizable-buffer.js                                                               ❌ -> ✅
    test/built-ins/DataView/prototype/setInt32/resizable-buffer.js                                                               ❌ -> ✅
    test/built-ins/DataView/prototype/setInt8/resizable-buffer.js                                                                ❌ -> ✅
    test/built-ins/DataView/prototype/setUint16/resizable-buffer.js                                                              ❌ -> ✅
    test/built-ins/DataView/prototype/setUint32/resizable-buffer.js                                                              ❌ -> ✅
    test/built-ins/DataView/prototype/setUint8/resizable-buffer.js                                                               ❌ -> ✅
    test/built-ins/TypedArray/prototype/at/BigInt/return-abrupt-from-this-out-of-bounds.js                                       ❌ -> ✅
    test/built-ins/TypedArray/prototype/at/return-abrupt-from-this-out-of-bounds.js                                              ❌ -> ✅
    test/built-ins/TypedArray/prototype/byteLength/BigInt/resizable-array-buffer-auto.js                                         ❌ -> ✅
    test/built-ins/TypedArray/prototype/byteLength/BigInt/resizable-array-buffer-fixed.js                                        ❌ -> ✅
    test/built-ins/TypedArray/prototype/byteLength/resizable-array-buffer-auto.js                                                ❌ -> ✅
    test/built-ins/TypedArray/prototype/byteLength/resizable-array-buffer-fixed.js                                               ❌ -> ✅
    test/built-ins/TypedArray/prototype/byteOffset/BigInt/resizable-array-buffer-auto.js                                         ❌ -> ✅
    test/built-ins/TypedArray/prototype/byteOffset/BigInt/resizable-array-buffer-fixed.js                                        ❌ -> ✅
    test/built-ins/TypedArray/prototype/byteOffset/resizable-array-buffer-auto.js                                                ❌ -> ✅
    test/built-ins/TypedArray/prototype/byteOffset/resizable-array-buffer-fixed.js                                               ❌ -> ✅
    test/built-ins/TypedArray/prototype/copyWithin/BigInt/return-abrupt-from-this-out-of-bounds.js                               ❌ -> ✅
    test/built-ins/TypedArray/prototype/copyWithin/return-abrupt-from-this-out-of-bounds.js                                      ❌ -> ✅
    test/built-ins/TypedArray/prototype/entries/BigInt/return-abrupt-from-this-out-of-bounds.js                                  ❌ -> ✅
    test/built-ins/TypedArray/prototype/entries/return-abrupt-from-this-out-of-bounds.js                                         ❌ -> ✅
    test/built-ins/TypedArray/prototype/every/BigInt/return-abrupt-from-this-out-of-bounds.js                                    ❌ -> ✅
    test/built-ins/TypedArray/prototype/every/callbackfn-resize.js                                                               ❌ -> ✅
    test/built-ins/TypedArray/prototype/every/return-abrupt-from-this-out-of-bounds.js                                           ❌ -> ✅
    test/built-ins/TypedArray/prototype/fill/BigInt/return-abrupt-from-this-out-of-bounds.js                                     ❌ -> ✅
    test/built-ins/TypedArray/prototype/fill/return-abrupt-from-this-out-of-bounds.js                                            ❌ -> ✅
    test/built-ins/TypedArray/prototype/filter/BigInt/return-abrupt-from-this-out-of-bounds.js                                   ❌ -> ✅
    test/built-ins/TypedArray/prototype/filter/BigInt/speciesctor-destination-resizable.js                                       ❌ -> ✅
    test/built-ins/TypedArray/prototype/filter/BigInt/speciesctor-get-species-custom-ctor-length-throws-resizable-arraybuffer.js ❌ -> ✅
    test/built-ins/TypedArray/prototype/filter/callbackfn-resize.js                                                              ❌ -> ✅
    test/built-ins/TypedArray/prototype/filter/return-abrupt-from-this-out-of-bounds.js                                          ❌ -> ✅
    test/built-ins/TypedArray/prototype/filter/speciesctor-destination-resizable.js                                              ❌ -> ✅
    test/built-ins/TypedArray/prototype/filter/speciesctor-get-species-custom-ctor-length-throws-resizable-arraybuffer.js        ❌ -> ✅
    test/built-ins/TypedArray/prototype/find/BigInt/return-abrupt-from-this-out-of-bounds.js                                     ❌ -> ✅
    test/built-ins/TypedArray/prototype/find/callbackfn-resize.js                                                                ❌ -> ✅
    test/built-ins/TypedArray/prototype/find/return-abrupt-from-this-out-of-bounds.js                                            ❌ -> ✅
    test/built-ins/TypedArray/prototype/findIndex/BigInt/return-abrupt-from-this-out-of-bounds.js                                ❌ -> ✅
    test/built-ins/TypedArray/prototype/findIndex/callbackfn-resize.js                                                           ❌ -> ✅
    test/built-ins/TypedArray/prototype/findIndex/return-abrupt-from-this-out-of-bounds.js                                       ❌ -> ✅
    test/built-ins/TypedArray/prototype/findLast/BigInt/return-abrupt-from-this-out-of-bounds.js                                 ❌ -> ✅
    test/built-ins/TypedArray/prototype/findLast/callbackfn-resize.js                                                            ❌ -> ✅
    test/built-ins/TypedArray/prototype/findLast/return-abrupt-from-this-out-of-bounds.js                                        ❌ -> ✅
    test/built-ins/TypedArray/prototype/findLastIndex/BigInt/return-abrupt-from-this-out-of-bounds.js                            ❌ -> ✅
    test/built-ins/TypedArray/prototype/findLastIndex/callbackfn-resize.js                                                       ❌ -> ✅
    test/built-ins/TypedArray/prototype/findLastIndex/return-abrupt-from-this-out-of-bounds.js                                   ❌ -> ✅
    test/built-ins/TypedArray/prototype/forEach/BigInt/return-abrupt-from-this-out-of-bounds.js                                  ❌ -> ✅
    test/built-ins/TypedArray/prototype/forEach/callbackfn-resize.js                                                             ❌ -> ✅
    test/built-ins/TypedArray/prototype/forEach/return-abrupt-from-this-out-of-bounds.js                                         ❌ -> ✅
    test/built-ins/TypedArray/prototype/includes/BigInt/return-abrupt-from-this-out-of-bounds.js                                 ❌ -> ✅
    test/built-ins/TypedArray/prototype/includes/return-abrupt-from-this-out-of-bounds.js                                        ❌ -> ✅
    test/built-ins/TypedArray/prototype/indexOf/BigInt/return-abrupt-from-this-out-of-bounds.js                                  ❌ -> ✅
    test/built-ins/TypedArray/prototype/indexOf/return-abrupt-from-this-out-of-bounds.js                                         ❌ -> ✅
    test/built-ins/TypedArray/prototype/join/BigInt/return-abrupt-from-this-out-of-bounds.js                                     ❌ -> ✅
    test/built-ins/TypedArray/prototype/join/return-abrupt-from-this-out-of-bounds.js                                            ❌ -> ✅
    test/built-ins/TypedArray/prototype/keys/BigInt/return-abrupt-from-this-out-of-bounds.js                                     ❌ -> ✅
    test/built-ins/TypedArray/prototype/keys/return-abrupt-from-this-out-of-bounds.js                                            ❌ -> ✅
    test/built-ins/TypedArray/prototype/lastIndexOf/BigInt/return-abrupt-from-this-out-of-bounds.js                              ❌ -> ✅
    test/built-ins/TypedArray/prototype/lastIndexOf/return-abrupt-from-this-out-of-bounds.js                                     ❌ -> ✅
    test/built-ins/TypedArray/prototype/length/BigInt/resizable-array-buffer-auto.js                                             ❌ -> ✅
    test/built-ins/TypedArray/prototype/length/BigInt/resizable-array-buffer-fixed.js                                            ❌ -> ✅
    test/built-ins/TypedArray/prototype/length/resizable-array-buffer-auto.js                                                    ❌ -> ✅
    test/built-ins/TypedArray/prototype/length/resizable-array-buffer-fixed.js                                                   ❌ -> ✅
    test/built-ins/TypedArray/prototype/map/BigInt/return-abrupt-from-this-out-of-bounds.js                                      ❌ -> ✅
    test/built-ins/TypedArray/prototype/map/BigInt/speciesctor-destination-resizable.js                                          ❌ -> ✅
    test/built-ins/TypedArray/prototype/map/BigInt/speciesctor-get-species-custom-ctor-length-throws-resizable-arraybuffer.js    ❌ -> ✅
    test/built-ins/TypedArray/prototype/map/callbackfn-resize.js                                                                 ❌ -> ✅
    test/built-ins/TypedArray/prototype/map/return-abrupt-from-this-out-of-bounds.js                                             ❌ -> ✅
    test/built-ins/TypedArray/prototype/map/speciesctor-destination-resizable.js                                                 ❌ -> ✅
    test/built-ins/TypedArray/prototype/map/speciesctor-get-species-custom-ctor-length-throws-resizable-arraybuffer.js           ❌ -> ✅
    test/built-ins/TypedArray/prototype/reduce/BigInt/return-abrupt-from-this-out-of-bounds.js                                   ❌ -> ✅
    test/built-ins/TypedArray/prototype/reduce/return-abrupt-from-this-out-of-bounds.js                                          ❌ -> ✅
    test/built-ins/TypedArray/prototype/reduceRight/BigInt/return-abrupt-from-this-out-of-bounds.js                              ❌ -> ✅
    test/built-ins/TypedArray/prototype/reduceRight/return-abrupt-from-this-out-of-bounds.js                                     ❌ -> ✅
    test/built-ins/TypedArray/prototype/reverse/BigInt/return-abrupt-from-this-out-of-bounds.js                                  ❌ -> ✅
    test/built-ins/TypedArray/prototype/reverse/return-abrupt-from-this-out-of-bounds.js                                         ❌ -> ✅
    test/built-ins/TypedArray/prototype/set/BigInt/typedarray-arg-set-values-same-buffer-same-type-resized.js                    ❌ -> ✅
    test/built-ins/TypedArray/prototype/set/BigInt/typedarray-arg-target-out-of-bounds.js                                        ❌ -> ✅
    test/built-ins/TypedArray/prototype/set/typedarray-arg-set-values-same-buffer-same-type-resized.js                           ❌ -> ✅
    test/built-ins/TypedArray/prototype/set/typedarray-arg-target-out-of-bounds.js                                               ❌ -> ✅
    test/built-ins/TypedArray/prototype/slice/BigInt/return-abrupt-from-this-out-of-bounds.js                                    ❌ -> ✅
    test/built-ins/TypedArray/prototype/slice/BigInt/speciesctor-destination-resizable.js                                        ❌ -> ✅
    test/built-ins/TypedArray/prototype/slice/BigInt/speciesctor-get-species-custom-ctor-length-throws-resizable-arraybuffer.js  ❌ -> ✅
    test/built-ins/TypedArray/prototype/slice/return-abrupt-from-this-out-of-bounds.js                                           ❌ -> ✅
    test/built-ins/TypedArray/prototype/slice/speciesctor-destination-resizable.js                                               ❌ -> ✅
    test/built-ins/TypedArray/prototype/slice/speciesctor-get-species-custom-ctor-length-throws-resizable-arraybuffer.js         ❌ -> ✅
    test/built-ins/TypedArray/prototype/some/BigInt/return-abrupt-from-this-out-of-bounds.js                                     ❌ -> ✅
    test/built-ins/TypedArray/prototype/some/callbackfn-resize.js                                                                ❌ -> ✅
    test/built-ins/TypedArray/prototype/some/return-abrupt-from-this-out-of-bounds.js                                            ❌ -> ✅
    test/built-ins/TypedArray/prototype/sort/BigInt/return-abrupt-from-this-out-of-bounds.js                                     ❌ -> ✅
    test/built-ins/TypedArray/prototype/sort/return-abrupt-from-this-out-of-bounds.js                                            ❌ -> ✅
    test/built-ins/TypedArray/prototype/toLocaleString/BigInt/return-abrupt-from-this-out-of-bounds.js                           ❌ -> ✅
    test/built-ins/TypedArray/prototype/toLocaleString/return-abrupt-from-this-out-of-bounds.js                                  ❌ -> ✅
    test/built-ins/TypedArray/prototype/values/BigInt/return-abrupt-from-this-out-of-bounds.js                                   ❌ -> ✅
    test/built-ins/TypedArray/prototype/values/return-abrupt-from-this-out-of-bounds.js                                          ❌ -> ✅
    test/built-ins/TypedArrayConstructors/internals/HasProperty/resizable-array-buffer-auto.js                                   ❌ -> ✅
    test/built-ins/TypedArrayConstructors/internals/HasProperty/resizable-array-buffer-fixed.js                                  ❌ -> ✅
    test/built-ins/TypedArrayConstructors/internals/OwnPropertyKeys/integer-indexes-resizable-array-buffer-auto.js               ❌ -> ✅
    test/built-ins/TypedArrayConstructors/internals/OwnPropertyKeys/integer-indexes-resizable-array-buffer-fixed.js              ❌ -> ✅
    test/staging/ArrayBuffer/resizable/array-fill-parameter-conversion-resizes.js                                                ❌ -> ✅
    test/staging/ArrayBuffer/resizable/array-sort-with-default-comparison.js                                                     ❌ -> ✅
    test/staging/ArrayBuffer/resizable/at-parameter-conversion-resizes.js                                                        ❌ -> ✅
    test/staging/ArrayBuffer/resizable/construct-from-typed-array.js                                                             ❌ -> ✅
    test/staging/ArrayBuffer/resizable/copy-within-parameter-conversion-grows.js                                                 ❌ -> ✅
    test/staging/ArrayBuffer/resizable/copy-within-parameter-conversion-shrinks.js                                               ❌ -> ✅
    test/staging/ArrayBuffer/resizable/entries-keys-values-grow-mid-iteration.js                                                 ❌ -> ✅
    test/staging/ArrayBuffer/resizable/entries-keys-values-shrink-mid-iteration.js                                               ❌ -> ✅
    test/staging/ArrayBuffer/resizable/entries-keys-values.js                                                                    ❌ -> ✅
    test/staging/ArrayBuffer/resizable/every-grow-mid-iteration.js                                                               ❌ -> ✅
    test/staging/ArrayBuffer/resizable/every-shrink-mid-iteration.js                                                             ❌ -> ✅
    test/staging/ArrayBuffer/resizable/every-some.js                                                                             ❌ -> ✅
    test/staging/ArrayBuffer/resizable/filter-grow-mid-iteration.js                                                              ❌ -> ✅
    test/staging/ArrayBuffer/resizable/filter-shrink-mid-iteration.js                                                            ❌ -> ✅
    test/staging/ArrayBuffer/resizable/filter.js                                                                                 ❌ -> ✅
    test/staging/ArrayBuffer/resizable/find-find-index-find-last-find-last-index.js                                              ❌ -> ✅
    test/staging/ArrayBuffer/resizable/find-grow-mid-iteration.js                                                                ❌ -> ✅
    test/staging/ArrayBuffer/resizable/find-index-grow-mid-iteration.js                                                          ❌ -> ✅
    test/staging/ArrayBuffer/resizable/find-index-shrink-mid-iteration.js                                                        ❌ -> ✅
    test/staging/ArrayBuffer/resizable/find-last-grow-mid-iteration.js                                                           ❌ -> ✅
    test/staging/ArrayBuffer/resizable/find-last-index-grow-mid-iteration.js                                                     ❌ -> ✅
    test/staging/ArrayBuffer/resizable/find-last-index-shrink-mid-iteration.js                                                   ❌ -> ✅
    test/staging/ArrayBuffer/resizable/find-last-shrink-mid-iteration.js                                                         ❌ -> ✅
    test/staging/ArrayBuffer/resizable/find-shrink-mid-iteration.js                                                              ❌ -> ✅
    test/staging/ArrayBuffer/resizable/for-each-reduce-reduce-right-grow-mid-iteration.js                                        ❌ -> ✅
    test/staging/ArrayBuffer/resizable/for-each-reduce-reduce-right-shrink-mid-iteration.js                                      ❌ -> ✅
    test/staging/ArrayBuffer/resizable/for-each-reduce-reduce-right.js                                                           ❌ -> ✅
    test/staging/ArrayBuffer/resizable/includes-parameter-conversion-resizes.js                                                  ❌ -> ✅
    test/staging/ArrayBuffer/resizable/includes.js                                                                               ❌ -> ✅
    test/staging/ArrayBuffer/resizable/index-of-last-index-of.js                                                                 ❌ -> ✅
    test/staging/ArrayBuffer/resizable/index-of-parameter-conversion-grows.js                                                    ❌ -> ✅
    test/staging/ArrayBuffer/resizable/index-of-parameter-conversion-shrinks.js                                                  ❌ -> ✅
    test/staging/ArrayBuffer/resizable/iterate-typed-array-and-grow-just-before-iteration-would-end.js                           ❌ -> ✅
    test/staging/ArrayBuffer/resizable/iterate-typed-array-and-grow-mid-iteration.js                                             ❌ -> ✅
    test/staging/ArrayBuffer/resizable/iterate-typed-array-and-shrink-mid-iteration.js                                           ❌ -> ✅
    test/staging/ArrayBuffer/resizable/iterate-typed-array-and-shrink-to-zero-mid-iteration.js                                   ❌ -> ✅
    test/staging/ArrayBuffer/resizable/join-parameter-conversion-grows.js                                                        ❌ -> ✅
    test/staging/ArrayBuffer/resizable/join-parameter-conversion-shrinks.js                                                      ❌ -> ✅
    test/staging/ArrayBuffer/resizable/join-to-locale-string.js                                                                  ❌ -> ✅
    test/staging/ArrayBuffer/resizable/last-index-of-parameter-conversion-grows.js                                               ❌ -> ✅
    test/staging/ArrayBuffer/resizable/last-index-of-parameter-conversion-shrinks.js                                             ❌ -> ✅
    test/staging/ArrayBuffer/resizable/length-tracking-1.js                                                                      ❌ -> ✅
    test/staging/ArrayBuffer/resizable/length-tracking-2.js                                                                      ❌ -> ✅
    test/staging/ArrayBuffer/resizable/map-grow-mid-iteration.js                                                                 ❌ -> ✅
    test/staging/ArrayBuffer/resizable/map-shrink-mid-iteration.js                                                               ❌ -> ✅
    test/staging/ArrayBuffer/resizable/map-species-create-grows.js                                                               ❌ -> ✅
    test/staging/ArrayBuffer/resizable/map-species-create-shrinks.js                                                             ❌ -> ✅
    test/staging/ArrayBuffer/resizable/object-define-property-parameter-conversion-grows.js                                      ❌ -> ✅
    test/staging/ArrayBuffer/resizable/object-freeze.js                                                                          ❌ -> ✅
    test/staging/ArrayBuffer/resizable/oobbehaves-like-detached.js                                                               ❌ -> ✅
    test/staging/ArrayBuffer/resizable/out-of-bounds-typed-array-and-has.js                                                      ❌ -> ✅
    test/staging/ArrayBuffer/resizable/reverse.js                                                                                ❌ -> ✅
    test/staging/ArrayBuffer/resizable/set-grow-target-mid-iteration.js                                                          ❌ -> ✅
    test/staging/ArrayBuffer/resizable/set-shrink-target-mid-iteration.js                                                        ❌ -> ✅
    test/staging/ArrayBuffer/resizable/set-source-length-getter-grows-target.js                                                  ❌ -> ✅
    test/staging/ArrayBuffer/resizable/set-source-length-getter-shrinks-target.js                                                ❌ -> ✅
    test/staging/ArrayBuffer/resizable/set-with-resizable-source.js                                                              ❌ -> ✅
    test/staging/ArrayBuffer/resizable/slice-parameter-conversion-grows.js                                                       ❌ -> ✅
    test/staging/ArrayBuffer/resizable/slice-parameter-conversion-shrinks.js                                                     ❌ -> ✅
    test/staging/ArrayBuffer/resizable/slice-species-create-resizes.js                                                           ❌ -> ✅
    test/staging/ArrayBuffer/resizable/some-grow-mid-iteration.js                                                                ❌ -> ✅
    test/staging/ArrayBuffer/resizable/some-shrink-mid-iteration.js                                                              ❌ -> ✅
    test/staging/ArrayBuffer/resizable/sort-callback-grows.js                                                                    ❌ -> ✅
    test/staging/ArrayBuffer/resizable/sort-callback-shrinks.js                                                                  ❌ -> ✅
    test/staging/ArrayBuffer/resizable/sort-with-custom-comparison.js                                                            ❌ -> ✅
    test/staging/ArrayBuffer/resizable/sort-with-default-comparison.js                                                           ❌ -> ✅
    test/staging/ArrayBuffer/resizable/subarray.js                                                                               ❌ -> ✅
    test/staging/ArrayBuffer/resizable/test-copy-within.js                                                                       ❌ -> ✅
    test/staging/ArrayBuffer/resizable/test-fill.js                                                                              ❌ -> ✅
    test/staging/ArrayBuffer/resizable/test-map.js                                                                               ❌ -> ✅
    test/staging/ArrayBuffer/resizable/to-locale-string-number-prototype-to-locale-string-grows.js                               ❌ -> ✅
    test/staging/ArrayBuffer/resizable/to-locale-string-number-prototype-to-locale-string-shrinks.js                             ❌ -> ✅
    test/staging/ArrayBuffer/resizable/typed-array-length-when-resized-out-of-bounds-1.js                                        ❌ -> ✅
    test/staging/ArrayBuffer/resizable/typed-array-length-when-resized-out-of-bounds-2.js                                        ❌ -> ✅
  </pre>
</details>