### PR TITLE
LibWebView: Request repaint after replacing backing stores

### DIFF
--- a/Userland/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Userland/Libraries/LibWebView/ViewImplementation.cpp
@@ -321,8 +321,11 @@ void ViewImplementation::resize_backing_stores_if_needed(WindowResizeInProgress 
     auto& front_bitmap = m_client_state.front_bitmap;
     auto& back_bitmap = m_client_state.back_bitmap;
 
-    if (front_bitmap.id != old_front_bitmap_id || back_bitmap.id != old_back_bitmap_id)
-        client().async_add_backing_store(front_bitmap.id, front_bitmap.bitmap->to_shareable_bitmap(), back_bitmap.id, back_bitmap.bitmap->to_shareable_bitmap());
+    if (front_bitmap.id != old_front_bitmap_id || back_bitmap.id != old_back_bitmap_id) {
+        client().async_add_backing_store(front_bitmap.id, front_bitmap.bitmap->to_shareable_bitmap(), back_bitmap.id,
+            back_bitmap.bitmap->to_shareable_bitmap());
+        client().async_set_viewport_rect(viewport_rect);
+    }
 }
 
 void ViewImplementation::handle_web_content_process_crash()


### PR DESCRIPTION
Fixes a bug when the Qt client does not repaint after resizing when the following sequence of IPC calls happens:

1. In the resize handler, the client sends set_viewport_rect to WebContent.
2. WebContent starts repainting in response to the changed viewport size.
3. In the resize handler, the client updates backing stores and sends new ids and shared bitmaps to WebContent using the add_backing_store call.
4. WebContent sends an acknowledgment to the client that painting finished using the old id.
5. The client discards the repaint because it expects a new backing store id.