### PR TITLE
LibWeb: Fix bug where viewing resource schemed directory urls crashes

### DIFF
--- a/Base/res/ladybird/directory.html
+++ b/Base/res/ladybird/directory.html
@@ -28,13 +28,13 @@
                 background-size: contain;
             }
             .folder {
-                background-image: url('@resource_directory_url@/icons/32x32/filetype-folder.png');
+                background-image: url('resource://icons/32x32/filetype-folder.png');
             }
             .file {
-                background-image: url('@resource_directory_url@/icons/32x32/filetype-unknown.png');
+                background-image: url('resource://icons/32x32/filetype-unknown.png');
             }
             .open-parent {
-                background-image: url('@resource_directory_url@/icons/16x16/open-parent-directory.png');
+                background-image: url('resource://icons/16x16/open-parent-directory.png');
             }
         </style>
     </head>

--- a/Base/res/ladybird/directory.html
+++ b/Base/res/ladybird/directory.html
@@ -43,7 +43,7 @@
             <span class="folder" style="width: 24px; height: 24px;"></span>
             <h1>Index of @path@</h1>
         </header>
-        <p><a href="file://@parent_path@"><span class="open-parent"></span>Open Parent Directory</a></p>
+        <p><a href="@parent_url@"><span class="open-parent"></span>Open Parent Directory</a></p>
         <hr>
         @contents@
         <hr>

--- a/Base/res/ladybird/error.html
+++ b/Base/res/ladybird/error.html
@@ -16,7 +16,7 @@
     </head>
     <body>
         <header>
-            <img src="@resource_directory_url@/icons/32x32/msgbox-warning.png" alt="Warning" width="24" height="24">
+            <img src="resource://icons/32x32/msgbox-warning.png" alt="Warning" width="24" height="24">
             <h1>Failed to load @failed_url@</h1>
         </header>
     </body>

--- a/Ladybird/Android/src/main/cpp/WebContentService.cpp
+++ b/Ladybird/Android/src/main/cpp/WebContentService.cpp
@@ -72,7 +72,6 @@ ErrorOr<int> service_main(int ipc_socket, int fd_passing_socket)
     Web::HTML::Window::set_internals_object_exposed(is_layout_test_mode);
     Web::Platform::FontPlugin::install(*new Ladybird::FontPlugin(is_layout_test_mode));
 
-    Web::set_resource_directory_url(TRY(String::formatted("file://{}/res", s_serenity_resource_root)));
     Web::set_error_page_url(TRY(String::formatted("file://{}/res/ladybird/error.html", s_serenity_resource_root)));
     Web::set_directory_page_url(TRY(String::formatted("file://{}/res/ladybird/directory.html", s_serenity_resource_root)));
 

--- a/Ladybird/Android/src/main/cpp/WebContentService.cpp
+++ b/Ladybird/Android/src/main/cpp/WebContentService.cpp
@@ -72,9 +72,6 @@ ErrorOr<int> service_main(int ipc_socket, int fd_passing_socket)
     Web::HTML::Window::set_internals_object_exposed(is_layout_test_mode);
     Web::Platform::FontPlugin::install(*new Ladybird::FontPlugin(is_layout_test_mode));
 
-    Web::set_error_page_url(TRY(String::formatted("file://{}/res/ladybird/error.html", s_serenity_resource_root)));
-    Web::set_directory_page_url(TRY(String::formatted("file://{}/res/ladybird/directory.html", s_serenity_resource_root)));
-
     TRY(Web::Bindings::initialize_main_thread_vm());
 
     auto maybe_content_filter_error = load_content_filters();

--- a/Ladybird/WebContent/main.cpp
+++ b/Ladybird/WebContent/main.cpp
@@ -115,9 +115,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     Web::Platform::FontPlugin::install(*new Ladybird::FontPlugin(is_layout_test_mode));
 
-    Web::set_error_page_url(TRY(String::formatted("file://{}/res/ladybird/error.html", s_serenity_resource_root)));
-    Web::set_directory_page_url(TRY(String::formatted("file://{}/res/ladybird/directory.html", s_serenity_resource_root)));
-
     TRY(Web::Bindings::initialize_main_thread_vm());
 
     auto maybe_content_filter_error = load_content_filters();

--- a/Ladybird/WebContent/main.cpp
+++ b/Ladybird/WebContent/main.cpp
@@ -115,7 +115,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     Web::Platform::FontPlugin::install(*new Ladybird::FontPlugin(is_layout_test_mode));
 
-    Web::set_resource_directory_url(TRY(String::formatted("file://{}/res", s_serenity_resource_root)));
     Web::set_error_page_url(TRY(String::formatted("file://{}/res/ladybird/error.html", s_serenity_resource_root)));
     Web::set_directory_page_url(TRY(String::formatted("file://{}/res/ladybird/directory.html", s_serenity_resource_root)));
 

--- a/Ladybird/WebWorker/main.cpp
+++ b/Ladybird/WebWorker/main.cpp
@@ -49,9 +49,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     VERIFY(fd_passing_socket >= 0);
 
-    Web::set_error_page_url(TRY(String::formatted("file://{}/res/ladybird/error.html", s_serenity_resource_root)));
-    Web::set_directory_page_url(TRY(String::formatted("file://{}/res/ladybird/directory.html", s_serenity_resource_root)));
-
     TRY(Web::Bindings::initialize_main_thread_vm());
 
     auto client = TRY(IPC::take_over_accepted_client_from_system_server<WebWorker::ConnectionFromClient>());

--- a/Ladybird/WebWorker/main.cpp
+++ b/Ladybird/WebWorker/main.cpp
@@ -49,7 +49,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     VERIFY(fd_passing_socket >= 0);
 
-    Web::set_resource_directory_url(TRY(String::formatted("file://{}/res", s_serenity_resource_root)));
     Web::set_error_page_url(TRY(String::formatted("file://{}/res/ladybird/error.html", s_serenity_resource_root)));
     Web::set_directory_page_url(TRY(String::formatted("file://{}/res/ladybird/directory.html", s_serenity_resource_root)));
 

--- a/Userland/Libraries/LibWeb/Loader/GeneratedPagesLoader.cpp
+++ b/Userland/Libraries/LibWeb/Loader/GeneratedPagesLoader.cpp
@@ -9,40 +9,17 @@
 #include <AK/SourceGenerator.h>
 #include <LibCore/DateTime.h>
 #include <LibCore/Directory.h>
+#include <LibCore/Resource.h>
 #include <LibCore/System.h>
 #include <LibWeb/Loader/GeneratedPagesLoader.h>
 
 namespace Web {
 
-static String s_error_page_url = "file:///res/ladybird/error.html"_string;
-
-String error_page_url()
-{
-    return s_error_page_url;
-}
-
-void set_error_page_url(String error_page_url)
-{
-    s_error_page_url = error_page_url;
-}
-
-static String s_directory_page_url = "file:///res/ladybird/directory.html"_string;
-
-String directory_page_url()
-{
-    return s_directory_page_url;
-}
-
-void set_directory_page_url(String directory_page_url)
-{
-    s_directory_page_url = directory_page_url;
-}
-
 ErrorOr<String> load_error_page(AK::URL const& url)
 {
     // Generate HTML error page from error template file
     // FIXME: Use an actual templating engine (our own one when it's built, preferably with a way to check these usages at compile time)
-    auto template_path = AK::URL::create_with_url_or_path(error_page_url().to_byte_string()).serialize_path();
+    auto template_path = TRY(Core::Resource::load_from_uri("resource://ladybird/error.html"sv))->filesystem_path();
     auto template_file = TRY(Core::File::open(template_path, Core::File::OpenMode::Read));
     auto template_contents = TRY(template_file->read_until_eof());
     StringBuilder builder;
@@ -83,7 +60,7 @@ ErrorOr<String> load_file_directory_page(AK::URL const& url)
 
     // Generate HTML directory page from directory template file
     // FIXME: Use an actual templating engine (our own one when it's built, preferably with a way to check these usages at compile time)
-    auto template_path = AK::URL::create_with_url_or_path(directory_page_url().to_byte_string()).serialize_path();
+    auto template_path = TRY(Core::Resource::load_from_uri("resource://ladybird/directory.html"sv))->filesystem_path();
     auto template_file = TRY(Core::File::open(template_path, Core::File::OpenMode::Read));
     auto template_contents = TRY(template_file->read_until_eof());
     StringBuilder builder;

--- a/Userland/Libraries/LibWeb/Loader/GeneratedPagesLoader.cpp
+++ b/Userland/Libraries/LibWeb/Loader/GeneratedPagesLoader.cpp
@@ -52,10 +52,10 @@ ErrorOr<String> load_error_page(AK::URL const& url)
     return TRY(String::from_utf8(generator.as_string_view()));
 }
 
-ErrorOr<String> load_file_directory_page(LoadRequest const& request)
+ErrorOr<String> load_file_directory_page(AK::URL const& url)
 {
     // Generate HTML contents entries table
-    auto lexical_path = LexicalPath(request.url().serialize_path());
+    auto lexical_path = LexicalPath(url.serialize_path());
     Core::DirIterator dt(lexical_path.string(), Core::DirIterator::Flags::SkipParentAndBaseDir);
     Vector<ByteString> names;
     while (dt.has_next())
@@ -89,7 +89,7 @@ ErrorOr<String> load_file_directory_page(LoadRequest const& request)
     StringBuilder builder;
     SourceGenerator generator { builder };
     generator.set("path", escape_html_entities(lexical_path.string()));
-    generator.set("parent_path", escape_html_entities(lexical_path.parent().string()));
+    generator.set("parent_url", TRY(String::formatted("file://{}", escape_html_entities(lexical_path.parent().string()))));
     generator.set("contents", contents.to_byte_string());
     generator.append(template_contents);
     return TRY(String::from_utf8(generator.as_string_view()));

--- a/Userland/Libraries/LibWeb/Loader/GeneratedPagesLoader.cpp
+++ b/Userland/Libraries/LibWeb/Loader/GeneratedPagesLoader.cpp
@@ -14,18 +14,6 @@
 
 namespace Web {
 
-static String s_resource_directory_url = "file:///res"_string;
-
-String resource_directory_url()
-{
-    return s_resource_directory_url;
-}
-
-void set_resource_directory_url(String resource_directory_url)
-{
-    s_resource_directory_url = resource_directory_url;
-}
-
 static String s_error_page_url = "file:///res/ladybird/error.html"_string;
 
 String error_page_url()
@@ -59,7 +47,6 @@ ErrorOr<String> load_error_page(AK::URL const& url)
     auto template_contents = TRY(template_file->read_until_eof());
     StringBuilder builder;
     SourceGenerator generator { builder };
-    generator.set("resource_directory_url", resource_directory_url());
     generator.set("failed_url", url.to_byte_string());
     generator.append(template_contents);
     return TRY(String::from_utf8(generator.as_string_view()));
@@ -101,7 +88,6 @@ ErrorOr<String> load_file_directory_page(LoadRequest const& request)
     auto template_contents = TRY(template_file->read_until_eof());
     StringBuilder builder;
     SourceGenerator generator { builder };
-    generator.set("resource_directory_url", resource_directory_url());
     generator.set("path", escape_html_entities(lexical_path.string()));
     generator.set("parent_path", escape_html_entities(lexical_path.parent().string()));
     generator.set("contents", contents.to_byte_string());

--- a/Userland/Libraries/LibWeb/Loader/GeneratedPagesLoader.h
+++ b/Userland/Libraries/LibWeb/Loader/GeneratedPagesLoader.h
@@ -11,8 +11,6 @@
 
 namespace Web {
 
-String resource_directory_url();
-void set_resource_directory_url(String);
 String error_page_url();
 void set_error_page_url(String);
 String directory_page_url();

--- a/Userland/Libraries/LibWeb/Loader/GeneratedPagesLoader.h
+++ b/Userland/Libraries/LibWeb/Loader/GeneratedPagesLoader.h
@@ -11,11 +11,6 @@
 
 namespace Web {
 
-String error_page_url();
-void set_error_page_url(String);
-String directory_page_url();
-void set_directory_page_url(String);
-
 ErrorOr<String> load_error_page(AK::URL const&);
 
 ErrorOr<String> load_file_directory_page(AK::URL const&);

--- a/Userland/Libraries/LibWeb/Loader/GeneratedPagesLoader.h
+++ b/Userland/Libraries/LibWeb/Loader/GeneratedPagesLoader.h
@@ -18,6 +18,6 @@ void set_directory_page_url(String);
 
 ErrorOr<String> load_error_page(AK::URL const&);
 
-ErrorOr<String> load_file_directory_page(LoadRequest const&);
+ErrorOr<String> load_file_directory_page(AK::URL const&);
 
 }


### PR DESCRIPTION
This pr removes the `@resource_directory_url@` template variable and uses the new `resource://` scheme to get to the right icons.

It also adds some code that when viewing a resource schemed directory url a generated directory page is responded instead of the browser crashing on a `VERIFY_NOT_REACH()` in `Resource.cpp`.

I also get the path to the `directory.html` and `error.html` page with resources to reduce code.