### PR TITLE
LibWeb: Parse remaining grid properties using TokenStream

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -5673,12 +5673,11 @@ RefPtr<StyleValue> Parser::parse_grid_area_shorthand_value(TokenStream<Component
         { GridTrackPlacementStyleValue::create(row_start), GridTrackPlacementStyleValue::create(column_start), GridTrackPlacementStyleValue::create(row_end), GridTrackPlacementStyleValue::create(column_end) });
 }
 
-RefPtr<StyleValue> Parser::parse_grid_shorthand_value(Vector<ComponentValue> const& component_value)
+RefPtr<StyleValue> Parser::parse_grid_shorthand_value(TokenStream<ComponentValue>& tokens)
 {
     // <'grid-template'> |
     // FIXME: <'grid-template-rows'> / [ auto-flow && dense? ] <'grid-auto-columns'>? |
     // FIXME: [ auto-flow && dense? ] <'grid-auto-rows'>? / <'grid-template-columns'>
-    TokenStream tokens { component_value };
     return parse_grid_track_size_list_shorthand_value(PropertyID::Grid, tokens);
 }
 
@@ -5895,7 +5894,7 @@ Parser::ParseErrorOr<NonnullRefPtr<StyleValue>> Parser::parse_css_value(Property
             return parsed_value.release_nonnull();
         return ParseError::SyntaxError;
     case PropertyID::Grid:
-        if (auto parsed_value = parse_grid_shorthand_value(component_values))
+        if (auto parsed_value = parse_grid_shorthand_value(tokens); parsed_value && !tokens.has_next_token())
             return parsed_value.release_nonnull();
         return ParseError::SyntaxError;
     case PropertyID::GridTemplate:

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -259,7 +259,7 @@ private:
     RefPtr<StyleValue> parse_transform_value(TokenStream<ComponentValue>&);
     RefPtr<StyleValue> parse_transform_origin_value(TokenStream<ComponentValue>&);
     RefPtr<StyleValue> parse_grid_track_size_list(Vector<ComponentValue> const&, bool allow_separate_line_name_blocks = false);
-    RefPtr<StyleValue> parse_grid_auto_track_sizes(Vector<ComponentValue> const&);
+    RefPtr<StyleValue> parse_grid_auto_track_sizes(TokenStream<ComponentValue>&);
     RefPtr<GridAutoFlowStyleValue> parse_grid_auto_flow_value(TokenStream<ComponentValue>&);
     RefPtr<StyleValue> parse_grid_track_size_list_shorthand_value(PropertyID, Vector<ComponentValue> const&);
     RefPtr<StyleValue> parse_grid_track_placement(TokenStream<ComponentValue>&);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -258,7 +258,7 @@ private:
     RefPtr<StyleValue> parse_easing_value(TokenStream<ComponentValue>&);
     RefPtr<StyleValue> parse_transform_value(TokenStream<ComponentValue>&);
     RefPtr<StyleValue> parse_transform_origin_value(TokenStream<ComponentValue>&);
-    RefPtr<StyleValue> parse_grid_track_size_list(Vector<ComponentValue> const&, bool allow_separate_line_name_blocks = false);
+    RefPtr<StyleValue> parse_grid_track_size_list(TokenStream<ComponentValue>&, bool allow_separate_line_name_blocks = false);
     RefPtr<StyleValue> parse_grid_auto_track_sizes(TokenStream<ComponentValue>&);
     RefPtr<GridAutoFlowStyleValue> parse_grid_auto_flow_value(TokenStream<ComponentValue>&);
     RefPtr<StyleValue> parse_grid_track_size_list_shorthand_value(PropertyID, Vector<ComponentValue> const&);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -266,7 +266,7 @@ private:
     RefPtr<StyleValue> parse_grid_track_placement_shorthand_value(PropertyID, TokenStream<ComponentValue>&);
     RefPtr<StyleValue> parse_grid_template_areas_value(TokenStream<ComponentValue>&);
     RefPtr<StyleValue> parse_grid_area_shorthand_value(TokenStream<ComponentValue>&);
-    RefPtr<StyleValue> parse_grid_shorthand_value(Vector<ComponentValue> const&);
+    RefPtr<StyleValue> parse_grid_shorthand_value(TokenStream<ComponentValue>&);
 
     OwnPtr<CalculationNode> parse_a_calculation(Vector<ComponentValue> const&);
 

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -261,7 +261,7 @@ private:
     RefPtr<StyleValue> parse_grid_track_size_list(TokenStream<ComponentValue>&, bool allow_separate_line_name_blocks = false);
     RefPtr<StyleValue> parse_grid_auto_track_sizes(TokenStream<ComponentValue>&);
     RefPtr<GridAutoFlowStyleValue> parse_grid_auto_flow_value(TokenStream<ComponentValue>&);
-    RefPtr<StyleValue> parse_grid_track_size_list_shorthand_value(PropertyID, Vector<ComponentValue> const&);
+    RefPtr<StyleValue> parse_grid_track_size_list_shorthand_value(PropertyID, TokenStream<ComponentValue>&);
     RefPtr<StyleValue> parse_grid_track_placement(TokenStream<ComponentValue>&);
     RefPtr<StyleValue> parse_grid_track_placement_shorthand_value(PropertyID, TokenStream<ComponentValue>&);
     RefPtr<StyleValue> parse_grid_template_areas_value(TokenStream<ComponentValue>&);


### PR DESCRIPTION
Builds on #22439.

These turned out to be easier than I expected. While converting these, I did notice a fair number of places we don't follow the spec fully, but I'll sort that out later. This is still just about making the parsing code more consistent and less confusing and error prone. (Hopefully!)