### PR TITLE
LibWeb: Redo "tracks maximize" if initial run is over max-size in GFC

### DIFF
--- a/Tests/LibWeb/Layout/expected/grid/max-width-grid-container-wrapper-in-max-content.txt
+++ b/Tests/LibWeb/Layout/expected/grid/max-width-grid-container-wrapper-in-max-content.txt
@@ -1,0 +1,35 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x121.15625 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x105.15625 children: not-inline
+      BlockContainer <div.wrapper> at (8,8) content-size 270x105.15625 children: not-inline
+        Box <div.constrained> at (8,8) content-size 270x105.15625 [GFC] children: not-inline
+          BlockContainer <(anonymous)> at (8,8) content-size 270x105.15625 [BFC] children: inline
+            line 0 width: 261.0625, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+              frag 0 from TextNode start: 1, length: 35, rect: [8,8 261.0625x17.46875]
+                "hello hello hello hello hello hello"
+            line 1 width: 261.0625, height: 17.9375, bottom: 35.40625, baseline: 13.53125
+              frag 0 from TextNode start: 37, length: 35, rect: [8,25 261.0625x17.46875]
+                "hello hello hello hello hello hello"
+            line 2 width: 261.0625, height: 18.40625, bottom: 53.34375, baseline: 13.53125
+              frag 0 from TextNode start: 73, length: 35, rect: [8,42 261.0625x17.46875]
+                "hello hello hello hello hello hello"
+            line 3 width: 261.0625, height: 17.875, bottom: 70.28125, baseline: 13.53125
+              frag 0 from TextNode start: 109, length: 35, rect: [8,60 261.0625x17.46875]
+                "hello hello hello hello hello hello"
+            line 4 width: 261.0625, height: 18.34375, bottom: 88.21875, baseline: 13.53125
+              frag 0 from TextNode start: 145, length: 35, rect: [8,77 261.0625x17.46875]
+                "hello hello hello hello hello hello"
+            line 5 width: 81.6875, height: 17.8125, bottom: 105.15625, baseline: 13.53125
+              frag 0 from TextNode start: 181, length: 11, rect: [8,95 81.6875x17.46875]
+                "hello hello"
+            TextNode <#text>
+          BlockContainer <div> at (8,113.15625) content-size 270x0 [BFC] children: not-inline
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x121.15625]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x105.15625]
+      PaintableWithLines (BlockContainer<DIV>.wrapper) [8,8 270x105.15625]
+        PaintableBox (Box<DIV>.constrained) [8,8 270x105.15625]
+          PaintableWithLines (BlockContainer(anonymous)) [8,8 270x105.15625]
+            TextPaintable (TextNode<#text>)
+          PaintableWithLines (BlockContainer<DIV>) [8,113.15625 270x0]

--- a/Tests/LibWeb/Layout/input/grid/max-width-grid-container-wrapper-in-max-content.html
+++ b/Tests/LibWeb/Layout/input/grid/max-width-grid-container-wrapper-in-max-content.html
@@ -1,0 +1,14 @@
+<!doctype html><style>
+* { outline: 1px solid black; } 
+.constrained {
+    max-width: 270px;
+    display: grid;
+}
+.wrapper {
+    background: yellow;
+    width: max-content;
+}
+</style><body><div class="wrapper"><div class="constrained">
+hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello
+hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello hello
+<div></div></div></div>

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.h
@@ -269,10 +269,13 @@ private:
     void resolve_intrinsic_track_sizes(AvailableSpace const&, GridDimension const);
     void increase_sizes_to_accommodate_spanning_items_crossing_content_sized_tracks(AvailableSpace const&, GridDimension const, size_t span);
     void increase_sizes_to_accommodate_spanning_items_crossing_flexible_tracks(GridDimension const);
-    void maximize_tracks(AvailableSpace const&, GridDimension const);
+    void maximize_tracks_using_available_size(AvailableSpace const& available_space, GridDimension const dimension);
+    void maximize_tracks(GridDimension const);
     void expand_flexible_tracks(AvailableSpace const&, GridDimension const);
     void stretch_auto_tracks(AvailableSpace const&, GridDimension const);
     void run_track_sizing(AvailableSpace const&, GridDimension const);
+
+    CSSPixels calculate_grid_container_maximum_size(GridDimension const) const;
 
     CSS::Size const& get_item_preferred_size(GridItem const&, GridDimension const) const;
 


### PR DESCRIPTION
Implements missing "redo" step defined in the spec.