### PR TITLE
CrashReporter: Port CrashReporter to GML Compiler

### DIFF
--- a/Userland/Applications/CrashReporter/CMakeLists.txt
+++ b/Userland/Applications/CrashReporter/CMakeLists.txt
@@ -4,15 +4,12 @@ serenity_component(
     TARGETS CrashReporter
 )
 
-stringify_gml(CrashReporterWindow.gml CrashReporterWindowGML.h crash_reporter_window_gml)
+compile_gml(CrashReporterWindow.gml CrashReporterWindowGML.cpp)
 
 
 set(SOURCES
+    CrashReporterWindowGML.cpp
     main.cpp
-)
-
-set(GENERATED_SOURCES
-    CrashReporterWindowGML.h
 )
 
 serenity_app(CrashReporter ICON app-crash-reporter)

--- a/Userland/Applications/CrashReporter/CrashReporterWindow.gml
+++ b/Userland/Applications/CrashReporter/CrashReporterWindow.gml
@@ -1,4 +1,4 @@
-@GUI::Widget {
+@CrashReporter::MainWidget {
     fill_with_background_color: true
     layout: @GUI::VerticalBoxLayout {
         margins: [4]

--- a/Userland/Applications/CrashReporter/MainWidget.h
+++ b/Userland/Applications/CrashReporter/MainWidget.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2023, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibGUI/Widget.h>
+
+namespace CrashReporter {
+
+class MainWidget final : public GUI::Widget {
+    C_OBJECT(MainWidget)
+
+public:
+    static ErrorOr<NonnullRefPtr<MainWidget>> try_create();
+    virtual ~MainWidget() override = default;
+
+private:
+    MainWidget() = default;
+};
+
+}

--- a/Userland/Applications/CrashReporter/main.cpp
+++ b/Userland/Applications/CrashReporter/main.cpp
@@ -6,11 +6,11 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include "MainWidget.h"
 #include <AK/LexicalPath.h>
 #include <AK/StringBuilder.h>
 #include <AK/Types.h>
 #include <AK/URL.h>
-#include <Applications/CrashReporter/CrashReporterWindowGML.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/System.h>
 #include <LibCoredump/Backtrace.h>
@@ -208,8 +208,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             unlink_coredump(coredump_path);
     };
 
-    auto widget = window->set_main_widget<GUI::Widget>();
-    TRY(widget->load_from_gml(crash_reporter_window_gml));
+    auto widget = TRY(CrashReporter::MainWidget::try_create());
+    window->set_main_widget(widget);
 
     auto& icon_image_widget = *widget->find_descendant_of_type_named<GUI::ImageWidget>("icon");
     icon_image_widget.set_bitmap(GUI::FileIconProvider::icon_for_executable(executable_path).bitmap_for_size(32));

--- a/Userland/Libraries/LibGUI/Progressbar.h
+++ b/Userland/Libraries/LibGUI/Progressbar.h
@@ -30,6 +30,7 @@ public:
 
     ByteString text() const { return m_text; }
     void set_text(ByteString text) { m_text = move(text); }
+    void set_text(String const& text) { m_text = ByteString(text); }
 
     enum Format {
         NoText,


### PR DESCRIPTION
- Contributes towards: https://github.com/SerenityOS/serenity/issues/20518
- The reason for https://github.com/SerenityOS/serenity/pull/22442/commits/efca4991e7e9c645494ac66583102a90df6336df commit is that the compiler was complaining about `ByteString` and `String` types being incompatible