### PR TITLE
LibWeb: Ensure DocumentObserver `document_completely_loaded()` is called

### DIFF
--- a/Tests/LibWeb/Ref/reference/svg-use-defined-earlier.html
+++ b/Tests/LibWeb/Ref/reference/svg-use-defined-earlier.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<svg style="display: none">
+  <symbol id="earlier-reference">
+    <rect x="0" y="0" width="64" height="64" fill="green" />
+  </symbol>
+</svg>
+<div>
+  <svg width="100" height="100">
+    <use xlink:href="#earlier-reference"></use>
+  </svg>
+</div>

--- a/Tests/LibWeb/Ref/svg-use-defined-later.html
+++ b/Tests/LibWeb/Ref/svg-use-defined-later.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<link rel="match" href="reference/svg-use-defined-earlier.html" />
+<div>
+  <svg width="100" height="100">
+    <use xlink:href="#later-reference"></use>
+  </svg>
+</div>
+<svg style="display: none">
+  <symbol id="later-reference">
+    <rect x="0" y="0" width="64" height="64" fill="green" />
+  </symbol>
+</svg>

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -1940,6 +1940,14 @@ void Document::completely_finish_loading()
     if (!navigable())
         return;
 
+    ScopeGuard notify_observers = [this] {
+        auto observers_to_notify = m_document_observers.values();
+        for (auto& document_observer : observers_to_notify) {
+            if (document_observer->document_completely_loaded())
+                document_observer->document_completely_loaded()->function()();
+        }
+    };
+
     // 1. Assert: document's browsing context is non-null.
     VERIFY(browsing_context());
 
@@ -1967,12 +1975,6 @@ void Document::completely_finish_loading()
         container->queue_an_element_task(HTML::Task::Source::DOMManipulation, [container] {
             container->dispatch_event(DOM::Event::create(container->realm(), HTML::EventNames::load));
         });
-    }
-
-    auto observers_to_notify = m_document_observers.values();
-    for (auto& document_observer : observers_to_notify) {
-        if (document_observer->document_completely_loaded())
-            document_observer->document_completely_loaded()->function()();
     }
 }
 


### PR DESCRIPTION
This stopped being called for anything without a navigable container after 76a97d8, due to the early return. This broke SVG `<use>` elements that reference elements defined later in the document.