### PR TITLE
LibJS: Implement TypedArray.{from,to} from the TypedArray base class

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/TypedArray.cpp
+++ b/Userland/Libraries/LibJS/Runtime/TypedArray.cpp
@@ -516,6 +516,10 @@ void TypedArrayBase::visit_edges(Visitor& visitor)
         auto& vm = this->vm();                                                                                              \
         Base::initialize(realm);                                                                                            \
                                                                                                                             \
+        /* NOTE: This is as these functions should be implemented by the TypedArrayConstructor, and not be defined here */  \
+        storage_delete(vm.names.from);                                                                                      \
+        storage_delete(vm.names.of);                                                                                        \
+                                                                                                                            \
         /* 23.2.6.2 TypedArray.prototype, https://tc39.es/ecma262/#sec-typedarray.prototype */                              \
         define_direct_property(vm.names.prototype, realm.intrinsics().snake_name##_prototype(), 0);                         \
                                                                                                                             \

--- a/Userland/Libraries/LibJS/Runtime/TypedArrayConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/TypedArrayConstructor.cpp
@@ -31,6 +31,7 @@ void TypedArrayConstructor::initialize(Realm& realm)
     // 23.2.2.3 %TypedArray%.prototype, https://tc39.es/ecma262/#sec-%typedarray%.prototype
     define_direct_property(vm.names.prototype, realm.intrinsics().typed_array_prototype(), 0);
 
+    // NOTE: If adding more native_functions here, remove them from TypedArray.cpp ConstructorName::initialize (as they should be inherited)
     u8 attr = Attribute::Writable | Attribute::Configurable;
     define_native_function(realm, vm.names.from, from, 1, attr);
     define_native_function(realm, vm.names.of, of, 0, attr);

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.from.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.from.js
@@ -27,3 +27,11 @@ test("basic functionality", () => {
         expect(newTypedArray[2]).toBe(3n);
     });
 });
+
+test("is inherited from TypedArray base class", () => {
+    TYPED_ARRAYS.forEach(T1 => {
+        TYPED_ARRAYS.forEach(T2 => {
+            expect(T1.from).toBe(T2.from);
+        });
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.js
@@ -390,3 +390,10 @@ test("source is not the same value as the receiver, and the index is invalid", (
         expect(receiver[2]).toBeUndefined();
     });
 });
+
+test("inherit functions from TypedArray instead of being implemented directly", () => {
+    TYPED_ARRAYS.forEach(T => {
+        expect(T.hasOwnProperty("from")).toBe(false);
+        expect(T.hasOwnProperty("to")).toBe(false);
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.of.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.of.js
@@ -27,3 +27,11 @@ test("basic functionality", () => {
         expect(newTypedArray[2]).toBe(3n);
     });
 });
+
+test("is inherited from TypedArray base class", () => {
+    TYPED_ARRAYS.forEach(T1 => {
+        TYPED_ARRAYS.forEach(T2 => {
+            expect(T1.of).toBe(T2.of);
+        });
+    });
+});


### PR DESCRIPTION
We were previously defining it in each TypedArray derived class as their own function instead of allowing it to be inherited from the TypedArray constructor.

Diff Tests:
    +4 ✅    -4 ❌