### PR TITLE
LibWeb+BindingsGenerator: Use `get_attribute_value` for reflected strings 

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -2445,16 +2445,9 @@ static void collect_attribute_values_of_an_inheritance_stack(SourceGenerator& fu
 
             if (attribute.extended_attributes.contains("Reflect")) {
                 if (attribute.type->name() != "boolean") {
-                    // FIXME: This should be calling Element::get_attribute_value: https://dom.spec.whatwg.org/#concept-element-attributes-get-value
-                    if (attribute.type->is_nullable()) {
-                        attribute_generator.append(R"~~~(
-    auto @attribute.return_value_name@ = impl->attribute(HTML::AttributeNames::@attribute.reflect_name@);
+                    attribute_generator.append(R"~~~(
+    auto @attribute.return_value_name@ = impl->get_attribute_value(HTML::AttributeNames::@attribute.reflect_name@);
 )~~~");
-                    } else {
-                        attribute_generator.append(R"~~~(
-    auto @attribute.return_value_name@ = impl->attribute(HTML::AttributeNames::@attribute.reflect_name@).value_or(String {});
-)~~~");
-                    }
                 } else {
                     attribute_generator.append(R"~~~(
     auto @attribute.return_value_name@ = impl->has_attribute(HTML::AttributeNames::@attribute.reflect_name@);
@@ -3044,16 +3037,9 @@ JS_DEFINE_NATIVE_FUNCTION(@class_name@::@attribute.getter_callback@)
                     // FIXME: 7. If contentAttributeValue corresponds to a state of attributeDefinition with no associated keyword value, then return null.
                 }
             } else if (attribute.type->name() != "boolean") {
-                // FIXME: This should be calling Element::get_attribute_value: https://dom.spec.whatwg.org/#concept-element-attributes-get-value
-                if (attribute.type->is_nullable()) {
-                    attribute_generator.append(R"~~~(
-    auto retval = impl->attribute(HTML::AttributeNames::@attribute.reflect_name@);
+                attribute_generator.append(R"~~~(
+    auto retval = impl->get_attribute_value(HTML::AttributeNames::@attribute.reflect_name@);
 )~~~");
-                } else {
-                    attribute_generator.append(R"~~~(
-    auto retval = impl->attribute(HTML::AttributeNames::@attribute.reflect_name@).value_or(String {});
-)~~~");
-                }
             } else {
                 attribute_generator.append(R"~~~(
     auto retval = impl->has_attribute(HTML::AttributeNames::@attribute.reflect_name@);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -75,6 +75,7 @@
 #include <LibWeb/CSS/StyleValues/UnresolvedStyleValue.h>
 #include <LibWeb/CSS/StyleValues/UnsetStyleValue.h>
 #include <LibWeb/Dump.h>
+#include <LibWeb/Infra/CharacterTypes.h>
 #include <LibWeb/Infra/Strings.h>
 
 static void log_parse_error(SourceLocation const& location = SourceLocation::current())
@@ -6976,11 +6977,11 @@ bool Parser::substitute_attr_function(DOM::Element& element, StringView property
             // with leading and trailing ASCII whitespace stripped. (No CSS parsing of the value is performed.)
             // If the attribute value, after trimming, is the empty string, there is instead no substitution value.
             // If the <custom-ident>’s value is a CSS-wide keyword or `default`, there is instead no substitution value.
-            auto substitution_value = attribute_value.trim_whitespace();
+            auto substitution_value = MUST(attribute_value.trim(Infra::ASCII_WHITESPACE));
             if (!substitution_value.is_empty()
                 && !substitution_value.equals_ignoring_ascii_case("default"sv)
                 && !is_css_wide_keyword(substitution_value)) {
-                dest.empend(Token::create_ident(MUST(FlyString::from_deprecated_fly_string(substitution_value))));
+                dest.empend(Token::create_ident(substitution_value));
                 return true;
             }
         } else if (attribute_type.equals_ignoring_ascii_case("length"_fly_string)) {
@@ -7016,7 +7017,7 @@ bool Parser::substitute_attr_function(DOM::Element& element, StringView property
             // The substitution value is a CSS string, whose value is the literal value of the attribute.
             // (No CSS parsing or "cleanup" of the value is performed.)
             // No value triggers fallback.
-            dest.empend(Token::create_string(MUST(FlyString::from_deprecated_fly_string(attribute_value))));
+            dest.empend(Token::create_string(attribute_value));
             return true;
         } else if (attribute_type.equals_ignoring_ascii_case("time"_fly_string)) {
             // Parse a component value from the attribute’s value.
@@ -7033,7 +7034,7 @@ bool Parser::substitute_attr_function(DOM::Element& element, StringView property
             // The substitution value is a CSS <url> value, whose url is the literal value of the attribute.
             // (No CSS parsing or "cleanup" of the value is performed.)
             // No value triggers fallback.
-            dest.empend(Token::create_url(MUST(FlyString::from_deprecated_fly_string(attribute_value))));
+            dest.empend(Token::create_url(attribute_value));
             return true;
         } else {
             // Dimension units

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -130,17 +130,17 @@ ByteString Element::deprecated_get_attribute(StringView name) const
 }
 
 // https://dom.spec.whatwg.org/#concept-element-attributes-get-value
-ByteString Element::get_attribute_value(FlyString const& local_name, Optional<FlyString> const& namespace_) const
+String Element::get_attribute_value(FlyString const& local_name, Optional<FlyString> const& namespace_) const
 {
     // 1. Let attr be the result of getting an attribute given namespace, localName, and element.
     auto const* attribute = m_attributes->get_attribute_ns(namespace_, local_name);
 
     // 2. If attr is null, then return the empty string.
     if (!attribute)
-        return ByteString::empty();
+        return String {};
 
     // 3. Return attr’s value.
-    return attribute->value().to_byte_string();
+    return attribute->value();
 }
 
 // https://dom.spec.whatwg.org/#dom-element-getattributenode

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -103,7 +103,7 @@ public:
     // FIXME: This should be taking a 'FlyString const&' / 'Optional<FlyString> const&'
     Optional<String> get_attribute(StringView name) const;
     ByteString deprecated_get_attribute(StringView name) const;
-    ByteString get_attribute_value(FlyString const& local_name, Optional<FlyString> const& namespace_ = {}) const;
+    String get_attribute_value(FlyString const& local_name, Optional<FlyString> const& namespace_ = {}) const;
 
     WebIDL::ExceptionOr<void> set_attribute(FlyString const& name, String const& value);
 


### PR DESCRIPTION
Per:

https://dom.spec.whatwg.org/#concept-reflect

We should be calling `get_attribute_value` for reflected IDL strings.
No functional change as nowhere is performing a reflect on a nullable
type, and just ends up simplifying the code.