### PR TITLE
LibJS: Ensure enlarged ArrayBuffers are filled with zeros

### DIFF
--- a/AK/ByteBuffer.h
+++ b/AK/ByteBuffer.h
@@ -163,9 +163,14 @@ public:
         m_size = 0;
     }
 
-    ALWAYS_INLINE void resize(size_t new_size)
+    enum class ZeroFillNewElements {
+        No,
+        Yes,
+    };
+
+    ALWAYS_INLINE void resize(size_t new_size, ZeroFillNewElements zero_fill_new_elements = ZeroFillNewElements::No)
     {
-        MUST(try_resize(new_size));
+        MUST(try_resize(new_size, zero_fill_new_elements));
     }
 
     void trim(size_t size, bool may_discard_existing_data)
@@ -181,13 +186,18 @@ public:
         MUST(try_ensure_capacity(new_capacity));
     }
 
-    ErrorOr<void> try_resize(size_t new_size)
+    ErrorOr<void> try_resize(size_t new_size, ZeroFillNewElements zero_fill_new_elements = ZeroFillNewElements::No)
     {
         if (new_size <= m_size) {
             trim(new_size, false);
             return {};
         }
         TRY(try_ensure_capacity(new_size));
+
+        if (zero_fill_new_elements == ZeroFillNewElements::Yes) {
+            __builtin_memset(data() + m_size, 0, new_size - m_size);
+        }
+
         m_size = new_size;
         return {};
     }

--- a/Tests/AK/TestByteBuffer.cpp
+++ b/Tests/AK/TestByteBuffer.cpp
@@ -46,6 +46,23 @@ TEST_CASE(byte_buffer_vector_contains_slow_bytes)
     EXPECT_EQ(vector.contains_slow(c), true);
 }
 
+TEST_CASE(zero_fill_new_elements_on_growth)
+{
+    auto buffer = MUST(ByteBuffer::create_uninitialized(5));
+
+    buffer.span().fill(1);
+    EXPECT_EQ(buffer.span(), (Array<u8, 5> { 1, 1, 1, 1, 1 }));
+
+    buffer.resize(8, ByteBuffer::ZeroFillNewElements::Yes);
+    EXPECT_EQ(buffer.span(), (Array<u8, 8> { 1, 1, 1, 1, 1, 0, 0, 0 }));
+
+    buffer.span().fill(2);
+    EXPECT_EQ(buffer.span(), (Array<u8, 8> { 2, 2, 2, 2, 2, 2, 2, 2 }));
+
+    buffer.resize(10, ByteBuffer::ZeroFillNewElements::Yes);
+    EXPECT_EQ(buffer.span(), (Array<u8, 10> { 2, 2, 2, 2, 2, 2, 2, 2, 0, 0 }));
+}
+
 BENCHMARK_CASE(append)
 {
     ByteBuffer bb;

--- a/Userland/Libraries/LibJS/Runtime/VM.cpp
+++ b/Userland/Libraries/LibJS/Runtime/VM.cpp
@@ -149,7 +149,7 @@ VM::VM(OwnPtr<CustomData> custom_data, ErrorMessages error_messages)
 
         // The default implementation of HostResizeArrayBuffer is to return NormalCompletion(unhandled).
 
-        if (auto result = buffer.buffer().try_resize(new_byte_length); result.is_error())
+        if (auto result = buffer.buffer().try_resize(new_byte_length, ByteBuffer::ZeroFillNewElements::Yes); result.is_error())
             return throw_completion<RangeError>(ErrorType::NotEnoughMemoryToAllocate, new_byte_length);
 
         return HandledByHost::Handled;

--- a/Userland/Libraries/LibJS/Tests/builtins/ArrayBuffer/ArrayBuffer.prototype.resize.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/ArrayBuffer/ArrayBuffer.prototype.resize.js
@@ -54,4 +54,38 @@ describe("normal behavior", () => {
             expect(buffer.byteLength).toBe(i);
         }
     });
+
+    test("enlarged buffers filled with zeros", () => {
+        let buffer = new ArrayBuffer(5, { maxByteLength: 10 });
+
+        const readBuffer = () => {
+            let array = new Uint8Array(buffer, 0, buffer.byteLength / Uint8Array.BYTES_PER_ELEMENT);
+            let values = [];
+
+            for (let value of array) {
+                values.push(Number(value));
+            }
+
+            return values;
+        };
+
+        const writeBuffer = values => {
+            let array = new Uint8Array(buffer, 0, buffer.byteLength / Uint8Array.BYTES_PER_ELEMENT);
+            array.set(values);
+        };
+
+        expect(readBuffer()).toEqual([0, 0, 0, 0, 0]);
+
+        writeBuffer([1, 2, 3, 4, 5]);
+        expect(readBuffer()).toEqual([1, 2, 3, 4, 5]);
+
+        buffer.resize(8);
+        expect(readBuffer()).toEqual([1, 2, 3, 4, 5, 0, 0, 0]);
+
+        writeBuffer([1, 2, 3, 4, 5, 6, 7, 8]);
+        expect(readBuffer()).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
+
+        buffer.resize(10);
+        expect(readBuffer()).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 0, 0]);
+    });
 });

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.every.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.every.js
@@ -13,36 +13,6 @@ const TYPED_ARRAYS = [
 const BIGINT_TYPED_ARRAYS = [BigUint64Array, BigInt64Array];
 
 describe("errors", () => {
-    test("ArrayBuffer out of bounds", () => {
-        TYPED_ARRAYS.forEach(T => {
-            let arrayBuffer = new ArrayBuffer(T.BYTES_PER_ELEMENT * 2, {
-                maxByteLength: T.BYTES_PER_ELEMENT * 4,
-            });
-
-            let typedArray = new T(arrayBuffer, T.BYTES_PER_ELEMENT, 1);
-            arrayBuffer.resize(T.BYTES_PER_ELEMENT);
-
-            expect(() => {
-                typedArray.every(value => value === 0);
-            }).toThrowWithMessage(
-                TypeError,
-                "TypedArray contains a property which references a value at an index not contained within its buffer's bounds"
-            );
-        });
-    });
-});
-
-test("length is 1", () => {
-    TYPED_ARRAYS.forEach(T => {
-        expect(T.prototype.every).toHaveLength(1);
-    });
-
-    BIGINT_TYPED_ARRAYS.forEach(T => {
-        expect(T.prototype.every).toHaveLength(1);
-    });
-});
-
-describe("errors", () => {
     function errorTests(T) {
         test(`requires at least one argument (${T.name})`, () => {
             expect(() => {
@@ -58,10 +28,36 @@ describe("errors", () => {
                 new T().every(undefined);
             }).toThrowWithMessage(TypeError, "undefined is not a function");
         });
+
+        test(`ArrayBuffer out of bounds  (${T.name})`, () => {
+            let arrayBuffer = new ArrayBuffer(T.BYTES_PER_ELEMENT * 2, {
+                maxByteLength: T.BYTES_PER_ELEMENT * 4,
+            });
+
+            let typedArray = new T(arrayBuffer, T.BYTES_PER_ELEMENT, 1);
+            arrayBuffer.resize(T.BYTES_PER_ELEMENT);
+
+            expect(() => {
+                typedArray.every(value => value === 0);
+            }).toThrowWithMessage(
+                TypeError,
+                "TypedArray contains a property which references a value at an index not contained within its buffer's bounds"
+            );
+        });
     }
 
     TYPED_ARRAYS.forEach(T => errorTests(T));
     BIGINT_TYPED_ARRAYS.forEach(T => errorTests(T));
+});
+
+test("length is 1", () => {
+    TYPED_ARRAYS.forEach(T => {
+        expect(T.prototype.every).toHaveLength(1);
+    });
+
+    BIGINT_TYPED_ARRAYS.forEach(T => {
+        expect(T.prototype.every).toHaveLength(1);
+    });
 });
 
 test("basic functionality", () => {

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.set.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.set.js
@@ -16,14 +16,26 @@ const BIGINT_TYPED_ARRAYS = [
 ];
 
 describe("errors", () => {
-    test("ArrayBuffer out of bounds", () => {
-        TYPED_ARRAYS.forEach(T => {
-            let arrayBuffer = new ArrayBuffer(T.array.BYTES_PER_ELEMENT * 2, {
-                maxByteLength: T.array.BYTES_PER_ELEMENT * 4,
+    function argumentErrorTests(T) {
+        test(`requires at least one argument (${T.name})`, () => {
+            expect(() => {
+                new T().set();
+            }).toThrowWithMessage(TypeError, "ToObject on null or undefined");
+        });
+
+        test(`source array in bounds (${T.name})`, () => {
+            expect(() => {
+                new T().set([0]);
+            }).toThrowWithMessage(RangeError, "Overflow or out of bounds in target length");
+        });
+
+        test(`ArrayBuffer out of bounds  (${T.name})`, () => {
+            let arrayBuffer = new ArrayBuffer(T.BYTES_PER_ELEMENT * 2, {
+                maxByteLength: T.BYTES_PER_ELEMENT * 4,
             });
 
-            let typedArray = new T.array(arrayBuffer, T.array.BYTES_PER_ELEMENT, 1);
-            arrayBuffer.resize(T.array.BYTES_PER_ELEMENT);
+            let typedArray = new T(arrayBuffer, T.BYTES_PER_ELEMENT, 1);
+            arrayBuffer.resize(T.BYTES_PER_ELEMENT);
 
             expect(() => {
                 typedArray.set([0]);
@@ -33,13 +45,16 @@ describe("errors", () => {
             );
 
             expect(() => {
-                typedArray.set(new T.array());
+                typedArray.set(new T());
             }).toThrowWithMessage(
                 TypeError,
                 "TypedArray contains a property which references a value at an index not contained within its buffer's bounds"
             );
         });
-    });
+    }
+
+    TYPED_ARRAYS.forEach(({ array: T }) => argumentErrorTests(T));
+    BIGINT_TYPED_ARRAYS.forEach(({ array: T }) => argumentErrorTests(T));
 });
 
 // FIXME: Write out a full test suite for this function. This currently only performs a single regression test.
@@ -129,23 +144,4 @@ test("detached buffer", () => {
 
         expect(typedArray.length).toBe(0);
     });
-});
-
-describe("errors", () => {
-    function argumentErrorTests(T) {
-        test(`requires at least one argument (${T.name})`, () => {
-            expect(() => {
-                new T().set();
-            }).toThrowWithMessage(TypeError, "ToObject on null or undefined");
-        });
-
-        test(`source array in bounds (${T.name})`, () => {
-            expect(() => {
-                new T().set([0]);
-            }).toThrowWithMessage(RangeError, "Overflow or out of bounds in target length");
-        });
-    }
-
-    TYPED_ARRAYS.forEach(({ array: T }) => argumentErrorTests(T));
-    BIGINT_TYPED_ARRAYS.forEach(({ array: T }) => argumentErrorTests(T));
 });

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.some.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.some.js
@@ -13,36 +13,6 @@ const TYPED_ARRAYS = [
 const BIGINT_TYPED_ARRAYS = [BigUint64Array, BigInt64Array];
 
 describe("errors", () => {
-    test("ArrayBuffer out of bounds", () => {
-        TYPED_ARRAYS.forEach(T => {
-            let arrayBuffer = new ArrayBuffer(T.BYTES_PER_ELEMENT * 2, {
-                maxByteLength: T.BYTES_PER_ELEMENT * 4,
-            });
-
-            let typedArray = new T(arrayBuffer, T.BYTES_PER_ELEMENT, 1);
-            arrayBuffer.resize(T.BYTES_PER_ELEMENT);
-
-            expect(() => {
-                typedArray.some(value => value === 0);
-            }).toThrowWithMessage(
-                TypeError,
-                "TypedArray contains a property which references a value at an index not contained within its buffer's bounds"
-            );
-        });
-    });
-});
-
-test("length is 1", () => {
-    TYPED_ARRAYS.forEach(T => {
-        expect(T.prototype.some).toHaveLength(1);
-    });
-
-    BIGINT_TYPED_ARRAYS.forEach(T => {
-        expect(T.prototype.some).toHaveLength(1);
-    });
-});
-
-describe("errors", () => {
     function errorTests(T) {
         test(`requires at least one argument (${T.name})`, () => {
             expect(() => {
@@ -58,10 +28,36 @@ describe("errors", () => {
                 new T().some(undefined);
             }).toThrowWithMessage(TypeError, "undefined is not a function");
         });
+
+        test(`ArrayBuffer out of bounds  (${T.name})`, () => {
+            let arrayBuffer = new ArrayBuffer(T.BYTES_PER_ELEMENT * 2, {
+                maxByteLength: T.BYTES_PER_ELEMENT * 4,
+            });
+
+            let typedArray = new T(arrayBuffer, T.BYTES_PER_ELEMENT, 1);
+            arrayBuffer.resize(T.BYTES_PER_ELEMENT);
+
+            expect(() => {
+                typedArray.some(value => value === 0);
+            }).toThrowWithMessage(
+                TypeError,
+                "TypedArray contains a property which references a value at an index not contained within its buffer's bounds"
+            );
+        });
     }
 
     TYPED_ARRAYS.forEach(T => errorTests(T));
     BIGINT_TYPED_ARRAYS.forEach(T => errorTests(T));
+});
+
+test("length is 1", () => {
+    TYPED_ARRAYS.forEach(T => {
+        expect(T.prototype.some).toHaveLength(1);
+    });
+
+    BIGINT_TYPED_ARRAYS.forEach(T => {
+        expect(T.prototype.some).toHaveLength(1);
+    });
 });
 
 test("basic functionality", () => {

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.toSorted.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.toSorted.js
@@ -13,6 +13,38 @@ const TYPED_ARRAYS = [
 const BIGINT_TYPED_ARRAYS = [BigUint64Array, BigInt64Array];
 
 describe("errors", () => {
+    test("null or undefined this value", () => {
+        TYPED_ARRAYS.forEach(T => {
+            expect(() => {
+                T.prototype.toSorted.call();
+            }).toThrowWithMessage(TypeError, "ToObject on null or undefined");
+
+            expect(() => {
+                T.prototype.toSorted.call(undefined);
+            }).toThrowWithMessage(TypeError, "ToObject on null or undefined");
+
+            expect(() => {
+                T.prototype.toSorted.call(null);
+            }).toThrowWithMessage(TypeError, "ToObject on null or undefined");
+        });
+
+        BIGINT_TYPED_ARRAYS.forEach(T => {});
+    });
+
+    test("invalid compare function", () => {
+        TYPED_ARRAYS.forEach(T => {
+            expect(() => {
+                new T([]).toSorted("foo");
+            }).toThrowWithMessage(TypeError, "foo is not a function");
+        });
+
+        BIGINT_TYPED_ARRAYS.forEach(T => {
+            expect(() => {
+                new T([]).toSorted("foo");
+            }).toThrowWithMessage(TypeError, "foo is not a function");
+        });
+    });
+
     test("ArrayBuffer out of bounds", () => {
         TYPED_ARRAYS.forEach(T => {
             let arrayBuffer = new ArrayBuffer(T.BYTES_PER_ELEMENT * 2, {
@@ -88,39 +120,5 @@ test("detached buffer", () => {
         expect(sortedTypedArray[0]).toBe(1);
         expect(sortedTypedArray[1]).toBe(2);
         expect(sortedTypedArray[2]).toBe(3);
-    });
-});
-
-describe("errors", () => {
-    test("null or undefined this value", () => {
-        TYPED_ARRAYS.forEach(T => {
-            expect(() => {
-                T.prototype.toSorted.call();
-            }).toThrowWithMessage(TypeError, "ToObject on null or undefined");
-
-            expect(() => {
-                T.prototype.toSorted.call(undefined);
-            }).toThrowWithMessage(TypeError, "ToObject on null or undefined");
-
-            expect(() => {
-                T.prototype.toSorted.call(null);
-            }).toThrowWithMessage(TypeError, "ToObject on null or undefined");
-        });
-
-        BIGINT_TYPED_ARRAYS.forEach(T => {});
-    });
-
-    test("invalid compare function", () => {
-        TYPED_ARRAYS.forEach(T => {
-            expect(() => {
-                new T([]).toSorted("foo");
-            }).toThrowWithMessage(TypeError, "foo is not a function");
-        });
-
-        BIGINT_TYPED_ARRAYS.forEach(T => {
-            expect(() => {
-                new T([]).toSorted("foo");
-            }).toThrowWithMessage(TypeError, "foo is not a function");
-        });
     });
 });


### PR DESCRIPTION
Otherwise, the newly allocated bytes are uninitialized, causing UB when
reading from the buffer immediately after an enlarging resize.

```
Diff Tests:
    +17 ✅    -17 ❌   

    test/built-ins/TypedArray/prototype/set/BigInt/typedarray-arg-set-values-same-buffer-same-type-resized.js ❌ -> ✅
    test/built-ins/TypedArray/prototype/set/typedarray-arg-set-values-same-buffer-same-type-resized.js        ❌ -> ✅
    test/staging/ArrayBuffer/resizable/access-out-of-bounds-typed-array.js                                    ❌ -> ✅
    test/staging/ArrayBuffer/resizable/at.js                                                                  ❌ -> ✅
    test/staging/ArrayBuffer/resizable/destructuring.js                                                       ❌ -> ✅
    test/staging/ArrayBuffer/resizable/entries-keys-values-grow-mid-iteration.js                              ❌ -> ✅
    test/staging/ArrayBuffer/resizable/function-apply.js                                                      ❌ -> ✅
    test/staging/ArrayBuffer/resizable/iterate-typed-array-and-grow-just-before-iteration-would-end.js        ❌ -> ✅
    test/staging/ArrayBuffer/resizable/iterate-typed-array-and-grow-mid-iteration.js                          ❌ -> ✅
    test/staging/ArrayBuffer/resizable/object-define-property-define-properties.js                            ❌ -> ✅
    test/staging/ArrayBuffer/resizable/object-define-property-parameter-conversion-grows.js                   ❌ -> ✅
    test/staging/ArrayBuffer/resizable/set-grow-target-mid-iteration.js                                       ❌ -> ✅
    test/staging/ArrayBuffer/resizable/set-source-length-getter-grows-target.js                               ❌ -> ✅
    test/staging/ArrayBuffer/resizable/set-with-resizable-target.js                                           ❌ -> ✅
    test/staging/ArrayBuffer/resizable/slice.js                                                               ❌ -> ✅
    test/staging/ArrayBuffer/resizable/sort-callback-grows.js                                                 ❌ -> ✅
    test/staging/ArrayBuffer/resizable/test-fill.js                                                           ❌ -> ✅
```