### PR TITLE
Ports: Update checksum for stpuzzles

### DIFF
--- a/Ports/stpuzzles/package.sh
+++ b/Ports/stpuzzles/package.sh
@@ -5,7 +5,7 @@ version=git
 workdir="${port}-main"
 configopts=("-DCMAKE_TOOLCHAIN_FILE=${SERENITY_BUILD_DIR}/CMakeToolchain.txt")
 files=(
-    "https://github.com/SerenityPorts/stpuzzles/archive/refs/heads/main.zip#31affa1f7d3c3501af4c92155d1d3beba8a5eaa1c9ce6d2e0682dc87f3f5d1e6"
+    "https://github.com/SerenityPorts/stpuzzles/archive/refs/heads/main.zip#dea475333e3826ab1ab63524b15466fd0800c8652297590d0260e09e84b9b225"
 )
 
 configure() {


### PR DESCRIPTION
https://github.com/SerenityPorts/stpuzzles/pull/8 was just merged so we need to update the checksum.

Not sure if there is still a way to completely leave the checksum out? Re: a4d5745e2f378e298d902413e09e03d51ad2f315