### PR TITLE
WindowServer: Better resize behavior for fixed size and aspect ratio windows

### DIFF
--- a/Userland/Services/WindowServer/Overlays.cpp
+++ b/Userland/Services/WindowServer/Overlays.cpp
@@ -316,13 +316,21 @@ void WindowGeometryOverlay::window_rect_changed()
         if (m_last_updated != new_update_state) {
             m_last_updated = new_update_state;
 
+            StringBuilder builder;
+            builder.append(geometry_rect.to_byte_string());
+
             if (!window->size_increment().is_empty()) {
                 int width_steps = (window->width() - window->base_size().width()) / window->size_increment().width();
                 int height_steps = (window->height() - window->base_size().height()) / window->size_increment().height();
-                m_label = ByteString::formatted("{} ({}x{})", geometry_rect, width_steps, height_steps);
-            } else {
-                m_label = geometry_rect.to_byte_string();
+                builder.append(ByteString::formatted(" ({}x{})", width_steps, height_steps));
             }
+
+            if (window->resize_aspect_ratio().has_value()) {
+                auto ratio = window->resize_aspect_ratio().value();
+                builder.append(ByteString::formatted(" 🔒{}:{}", ratio.width(), ratio.height()));
+            }
+
+            m_label = builder.to_byte_string();
             m_label_rect = Gfx::IntRect { 0, 0, static_cast<int>(ceilf(wm.font().width(m_label))) + 16, wm.font().pixel_size_rounded_up() + 10 };
 
             m_ideal_overlay_rect = calculate_ideal_overlay_rect();

--- a/Userland/Services/WindowServer/WindowFrame.cpp
+++ b/Userland/Services/WindowServer/WindowFrame.cpp
@@ -986,6 +986,26 @@ void WindowFrame::latch_window_to_screen_edge(ResizeDirection resize_direction)
         || resize_direction == ResizeDirection::DownLeft)
         window_rect.inflate(0, 0, 0, frame_rect.left() - screen_rect.left());
 
+    // If required, maintain fixed aspect ratio by scaling the other dimension appropriately
+    if (m_window.resize_aspect_ratio().has_value()) {
+        auto& ratio = m_window.resize_aspect_ratio().value();
+
+        if (window_rect.width() == m_window.rect().width()) {
+            // Up or Down
+            window_rect.set_width(window_rect.height() * ratio.width() / ratio.height());
+        } else {
+            // Left, Right, UpLeft, UpRight, DownLeft or DownRight
+            window_rect.set_height(window_rect.width() * ratio.height() / ratio.width());
+
+            // Match bottom corner of the frame and the screen
+            if (resize_direction == ResizeDirection::DownLeft
+                || resize_direction == ResizeDirection::DownRight) {
+                auto new_frame_rect = frame_rect_for_window(m_window, window_rect);
+                window_rect.translate_by(0, screen_rect.bottom() - new_frame_rect.bottom());
+            }
+        }
+    }
+
     m_window.set_rect(window_rect);
 }
 

--- a/Userland/Services/WindowServer/WindowManager.cpp
+++ b/Userland/Services/WindowServer/WindowManager.cpp
@@ -860,9 +860,10 @@ bool WindowManager::process_ongoing_window_move(MouseEvent& event)
                 m_move_window_origin = m_move_window->position();
             }
         } else {
+            bool has_fixed_aspect_ratio = m_move_window->resize_aspect_ratio().has_value();
             bool is_resizable = m_move_window->is_resizable();
             auto tile_window = m_system_effects.tile_window();
-            bool allow_tile = is_resizable && tile_window != TileWindow::Never;
+            bool allow_tile = !has_fixed_aspect_ratio && is_resizable && tile_window != TileWindow::Never;
             auto pixels_moved_from_start = event.position().pixels_moved(m_move_origin);
 
             auto apply_window_tile = [&](WindowTileType tile_type) {


### PR DESCRIPTION
It has been over a month since stalebot closed #21393 so here it is again.

---

#### WindowServer: Show disallowed cursor when resizing fixed-size window

```
If the window is not resizable and you try to resize it (hovering over
borders or Super+Secondary-click) the disallowed cursor will be shown.

This conveys to the user that the window is not resizable.
```

#### Hovering over the borders:
![mouse](https://github.com/SerenityOS/serenity/assets/70647861/fdf3830e-2a7a-4ae4-8ceb-6644ebb14003)

#### Doing Super+Secondary-click:
![key](https://github.com/SerenityOS/serenity/assets/70647861/e39ae285-0a84-4772-abb4-4833d45efda2)

Bug/feature: For the keyboard shortcut scenario the disallowed cursor will turn into arrow cursor immediately on mouse movements even though the Super and Secondary mouse button is held down.

A side-effect:
- Before `m_resize_candidate` was only ever a window that was resizable. But now it can also be window that cannot be resized. So only the former ones can turn into `m_resize_window`s.

I used the disallowed cursor for now but a resize cursor with a lock/cross on it would be cool too. (that's why I kept the direction info that gets passed to `set_resize_candidate()`.

---

#### WindowServer: Handle latching fix-aspect-ratio window to the screen edge
```
    Double-clicking the edges of a window results in the edge being extended
    until it latches to the screen edge. This used to violate the fixed
    aspect ratio property of certain windows because of only extending the
    window in one dimension.

    This commit adds a special case to the latching logic that makes sure to
    also extend the other dimension of the window such that the fixed aspect
    ratio is maintained.
```

Might not be the best way to solve this but it does behaves as normal windows do.

I also tried some alternatives: Not doing anything; Only moving the window and not resizing. But those may not be the expected behaviour.

---

#### WindowServer: Don't show tile overlay for fixed aspect ratio windows

```
    Windows with fixed aspect ratio cannot be tiled so the tile overlay
    shouldn't be shown.
```

---

#### WindowServer: Show fixed aspect ratio in the resize overlay

Terminal modified to have fixed aspect ratio.
 
![image](https://github.com/SerenityOS/serenity/assets/70647861/58cb247a-8c8f-4e88-9e61-9b97b3c6db3f)
