### PR TITLE
Meta: Add support for QEMU 8.2 audio

### DIFF
--- a/Meta/run.py
+++ b/Meta/run.py
@@ -510,9 +510,15 @@ def setup_audio_backend(config: Configuration):
             capture_output=True,
             encoding="utf-8",
         ).stdout
-        if "-audiodev id=sdl" in qemu_audio_help:
+        if qemu_audio_help == "":
+            qemu_audio_help = run(
+                [str(config.qemu_binary), "-audiodev", "help"],
+                capture_output=True,
+                encoding="utf-8",
+            ).stdout
+        if "sdl" in qemu_audio_help:
             config.audio_backend = "sdl"
-        elif "-audiodev id=pa" in qemu_audio_help:
+        elif "pa" in qemu_audio_help:
             config.audio_backend = "pa,timer-period=2000"
 
     if config.audio_backend is not None:


### PR DESCRIPTION
Still try parsing the now gone `-audio-help` output first, then attempt the new `-audiodev help` if stdout was empty. This fixes support for QEMU 8.2+ audio since `-audio-help` is now an invalid option: https://gitlab.com/qemu-project/qemu/-/commit/69a80279

For reference here's the outputs on Ubuntu 22.04 LTS:
```
$ qemu-system-x86_64 --version
QEMU emulator version 6.2.0 (Debian 1:6.2+dfsg-2ubuntu6.15)
Copyright (c) 2003-2021 Fabrice Bellard and the QEMU Project developers

$ qemu-system-x86_64 -audio-help
Environment variable based configuration deprecated.
Please use the new -audiodev option.

Equivalent -audiodev to your current environment variables:
(Since you didn't specify QEMU_AUDIO_DRV, I'll list all possibilities)
-audiodev id=pa,driver=pa
-audiodev id=alsa,driver=alsa
-audiodev id=jack,driver=jack
-audiodev id=oss,driver=oss
-audiodev id=sdl,driver=sdl
-audiodev id=none,driver=none

$ qemu-system-x86_64 -audiodev help
qemu-system-x86_64: -audiodev help: Help is not available for this option
```

And for me:
```
$ qemu-system-x86_64 --version
QEMU emulator version 8.2.0
Copyright (c) 2003-2023 Fabrice Bellard and the QEMU Project developers

$ qemu-system-x86_64 -audio-help
qemu-system-x86_64: -audio-help: invalid option

$ qemu-system-x86_64 -audiodev help
Available audio drivers:
none
dbus
jack
oss
pa
pipewire
sdl
spice
wav
```