### PR TITLE
LibJS: Implement missing conditional when creating a TypedArray subarray

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/TypedArrayPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/TypedArrayPrototype.cpp
@@ -1846,7 +1846,7 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::subarray)
     MarkedVector<Value> arguments(vm.heap());
 
     // 15. If O.[[ArrayLength]] is auto and end is undefined, then
-    if (typed_array->array_length().is_auto()) {
+    if (typed_array->array_length().is_auto() && end.is_undefined()) {
         // a. Let argumentsList be « buffer, 𝔽(beginByteOffset) ».
         arguments.empend(buffer);
         arguments.empend(begin_byte_offset.value());

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.subarray.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.subarray.js
@@ -57,3 +57,21 @@ test("resizable ArrayBuffer", () => {
         expect(typedArray.subarray(0, 1).byteLength).toBe(0);
     });
 });
+
+test("resizable ArrayBuffer resized during `start` parameter access", () => {
+    TYPED_ARRAYS.forEach(T => {
+        let arrayBuffer = new ArrayBuffer(T.BYTES_PER_ELEMENT * 2, {
+            maxByteLength: T.BYTES_PER_ELEMENT * 4,
+        });
+
+        let badAccessor = {
+            valueOf: () => {
+                arrayBuffer.resize(T.BYTES_PER_ELEMENT * 4);
+                return 0;
+            },
+        };
+
+        let typedArray = new T(arrayBuffer);
+        expect(typedArray.subarray(badAccessor, typedArray.length).length).toBe(2);
+    });
+});


### PR DESCRIPTION
Woops! With this,we now pass all of `test/staging/ArrayBuffer`.

```
Diff Tests:
    test/staging/ArrayBuffer/resizable/subarray-parameter-conversion-grows.js   ❌ -> ✅
    test/staging/ArrayBuffer/resizable/subarray-parameter-conversion-shrinks.js ❌ -> ✅
```