### PR TITLE
LibWeb: Make pages with a lot of images display a lot faster

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -299,8 +299,13 @@ public:
 
     void enqueue(JS::SafeFunction<void()> callback)
     {
+        // NOTE: We don't want to flush the queue on every image load, since that would be slow.
+        //       However, we don't want to keep growing the batch forever either.
+        static constexpr size_t max_loads_to_batch_before_flushing = 16;
+
         m_queue.append(move(callback));
-        m_timer->restart();
+        if (m_queue.size() < max_loads_to_batch_before_flushing)
+            m_timer->restart();
     }
 
 private:

--- a/Userland/Libraries/LibWeb/Painting/ImagePaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/ImagePaintable.cpp
@@ -58,8 +58,6 @@ void ImagePaintable::paint(PaintContext& context, PaintPhase phase) const
             context.recording_painter().set_font(Platform::FontPlugin::the().default_font());
             context.recording_painter().paint_frame(enclosing_rect, context.palette(), Gfx::FrameStyle::SunkenContainer);
             auto alt = image_element.get_attribute_value(HTML::AttributeNames::alt);
-            if (alt.is_empty())
-                alt = image_element.get_attribute_value(HTML::AttributeNames::src);
             context.recording_painter().draw_text(enclosing_rect, alt, Gfx::TextAlignment::Center, computed_values().color(), Gfx::TextElision::Right);
         } else if (auto bitmap = layout_box().image_provider().current_image_bitmap(image_rect.size().to_type<int>())) {
             ScopedCornerRadiusClip corner_clip { context, image_rect, normalized_border_radii_data(ShrinkRadiiForBorders::Yes) };


### PR DESCRIPTION
Two fixes:
- Stop wasting time rendering URLs as `img alt` placeholders since they are not useful to anyone, and longer URLs (especially `data:` URLs) can waste a lot of time.
- Put a limit on how many image loads we're willing to batch up & defer before flushing processing. This makes "image gallery" like pages display something interesting *way* sooner.

Here's an example before/after of a 4chan board catalog page. Before these changes, it takes almost 5 seconds before we see images. After changes, it takes ~1.1sec.

https://github.com/SerenityOS/serenity/assets/5954907/5e0be796-9cac-4189-b21d-577abb7d3bee



https://github.com/SerenityOS/serenity/assets/5954907/ddc1e760-9042-4ead-927b-140fa3c7351d

