### PR TITLE
LibJS: Implement missing checks for SharedArrayBuffer and missing steps from the ArrayBuffer transfer proposal

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/ArrayBuffer.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayBuffer.cpp
@@ -201,7 +201,7 @@ size_t array_buffer_byte_length(ArrayBuffer const& array_buffer, ArrayBuffer::Or
 ThrowCompletionOr<void> detach_array_buffer(VM& vm, ArrayBuffer& array_buffer, Optional<Value> key)
 {
     // 1. Assert: IsSharedArrayBuffer(arrayBuffer) is false.
-    // FIXME: Check for shared buffer
+    VERIFY(!array_buffer.is_shared_array_buffer());
 
     // 2. If key is not present, set key to undefined.
     if (!key.has_value())

--- a/Userland/Libraries/LibJS/Runtime/ArrayBufferPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayBufferPrototype.cpp
@@ -278,7 +278,8 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayBufferPrototype::detached_getter)
     auto array_buffer_object = TRY(typed_this_value(vm));
 
     // 3. If IsSharedArrayBuffer(O) is true, throw a TypeError exception.
-    // FIXME: Check for shared buffer
+    if (array_buffer_object->is_shared_array_buffer())
+        return vm.throw_completion<TypeError>(ErrorType::SharedArrayBuffer);
 
     // 4. Return IsDetachedBuffer(O).
     return Value(array_buffer_object->is_detached());

--- a/Userland/Libraries/LibJS/Runtime/ArrayBufferPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayBufferPrototype.cpp
@@ -48,7 +48,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayBufferPrototype::byte_length_getter)
 
     // 3. If IsSharedArrayBuffer(O) is true, throw a TypeError exception.
     if (array_buffer_object->is_shared_array_buffer())
-        return vm.throw_completion<TypeError>(ErrorType::ThisCannotBeSharedArrayBuffer);
+        return vm.throw_completion<TypeError>(ErrorType::SharedArrayBuffer);
 
     // NOTE: These steps are done in byte_length()
     // 4. If IsDetachedBuffer(O) is true, return +0𝔽.
@@ -66,7 +66,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayBufferPrototype::max_byte_length)
 
     // 3. If IsSharedArrayBuffer(O) is true, throw a TypeError exception.
     if (array_buffer_object->is_shared_array_buffer())
-        return vm.throw_completion<TypeError>(ErrorType::ThisCannotBeSharedArrayBuffer);
+        return vm.throw_completion<TypeError>(ErrorType::SharedArrayBuffer);
 
     // 4. If IsDetachedBuffer(O) is true, return +0𝔽.
     if (array_buffer_object->is_detached())
@@ -98,7 +98,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayBufferPrototype::resizable)
 
     // 3. If IsSharedArrayBuffer(O) is true, throw a TypeError exception.
     if (array_buffer_object->is_shared_array_buffer())
-        return vm.throw_completion<TypeError>(ErrorType::ThisCannotBeSharedArrayBuffer);
+        return vm.throw_completion<TypeError>(ErrorType::SharedArrayBuffer);
 
     // 4. If IsFixedLengthArrayBuffer(O) is false, return true; otherwise return false.
     return Value { !array_buffer_object->is_fixed_length() };
@@ -118,7 +118,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayBufferPrototype::resize)
 
     // 3. If IsSharedArrayBuffer(O) is true, throw a TypeError exception.
     if (array_buffer_object->is_shared_array_buffer())
-        return vm.throw_completion<TypeError>(ErrorType::ThisCannotBeSharedArrayBuffer);
+        return vm.throw_completion<TypeError>(ErrorType::SharedArrayBuffer);
 
     // 4. Let newByteLength be ? ToIndex(newLength).
     auto new_byte_length = TRY(new_length.to_index(vm));

--- a/Userland/Libraries/LibJS/Runtime/ArrayBufferPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayBufferPrototype.cpp
@@ -174,7 +174,8 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayBufferPrototype::slice)
     auto array_buffer_object = TRY(typed_this_value(vm));
 
     // 3. If IsSharedArrayBuffer(O) is true, throw a TypeError exception.
-    // FIXME: Check for shared buffer
+    if (array_buffer_object->is_shared_array_buffer())
+        return vm.throw_completion<TypeError>(ErrorType::SharedArrayBuffer);
 
     // 4. If IsDetachedBuffer(O) is true, throw a TypeError exception.
     if (array_buffer_object->is_detached())
@@ -226,7 +227,8 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayBufferPrototype::slice)
     auto* new_array_buffer_object = static_cast<ArrayBuffer*>(new_array_buffer.ptr());
 
     // 18. If IsSharedArrayBuffer(new) is true, throw a TypeError exception.
-    // FIXME: Check for shared buffer
+    if (new_array_buffer_object->is_shared_array_buffer())
+        return vm.throw_completion<TypeError>(ErrorType::SharedArrayBuffer);
 
     // 19. If IsDetachedBuffer(new) is true, throw a TypeError exception.
     if (new_array_buffer_object->is_detached())

--- a/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
+++ b/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
@@ -224,6 +224,7 @@
     M(RestrictedGlobalProperty, "Cannot declare global property '{}'")                                                                  \
     M(ShadowRealmEvaluateAbruptCompletion, "The evaluated script did not complete normally")                                            \
     M(ShadowRealmWrappedValueNonFunctionObject, "Wrapped value must be primitive or a function object, got {}")                         \
+    M(SharedArrayBuffer, "The array buffer object cannot be a SharedArrayBuffer")                                                       \
     M(SpeciesConstructorDidNotCreate, "Species constructor did not create {}")                                                          \
     M(SpeciesConstructorReturned, "Species constructor returned {}")                                                                    \
     M(StringNonGlobalRegExp, "RegExp argument is non-global")                                                                           \
@@ -298,7 +299,6 @@
     M(TemporalUnknownCriticalAnnotation, "Unknown annotation key in critical annotation: '{}'")                                         \
     M(TemporalZonedDateTimeRoundZeroOrNegativeLengthDay, "Cannot round a ZonedDateTime in a calendar or time zone that has zero or "    \
                                                          "negative length days")                                                        \
-    M(ThisCannotBeSharedArrayBuffer, "|this| cannot be a SharedArrayBuffer")                                                            \
     M(ThisHasNotBeenInitialized, "|this| has not been initialized")                                                                     \
     M(ThisIsAlreadyInitialized, "|this| is already initialized")                                                                        \
     M(ToObjectNullOrUndefined, "ToObject on null or undefined")                                                                         \

--- a/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
+++ b/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
@@ -98,7 +98,7 @@
     M(NotAnObjectOfType, "Not an object of type {}")                                                                                    \
     M(NotAnObjectOrNull, "{} is neither an object nor null")                                                                            \
     M(NotAnObjectOrString, "{} is neither an object nor a string")                                                                      \
-    M(NotASharedArrayBuffer, "The TypedArray's underlying buffer must be a SharedArrayBuffer")                                          \
+    M(NotASharedArrayBuffer, "The array buffer object must be a SharedArrayBuffer")                                                     \
     M(NotAString, "{} is not a string")                                                                                                 \
     M(NotASymbol, "{} is not a symbol")                                                                                                 \
     M(NotImplemented, "TODO({} is not implemented in LibJS)")                                                                           \

--- a/Userland/Libraries/LibJS/Runtime/SharedArrayBufferPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/SharedArrayBufferPrototype.cpp
@@ -40,7 +40,8 @@ JS_DEFINE_NATIVE_FUNCTION(SharedArrayBufferPrototype::byte_length_getter)
     auto array_buffer_object = TRY(typed_this_value(vm));
 
     // 3. If IsSharedArrayBuffer(O) is false, throw a TypeError exception.
-    // FIXME: Check for shared buffer
+    if (!array_buffer_object->is_shared_array_buffer())
+        return vm.throw_completion<TypeError>(ErrorType::NotASharedArrayBuffer);
 
     // 4. Let length be O.[[ArrayBufferByteLength]].
     // 5. Return 𝔽(length).
@@ -60,7 +61,8 @@ JS_DEFINE_NATIVE_FUNCTION(SharedArrayBufferPrototype::slice)
     auto array_buffer_object = TRY(typed_this_value(vm));
 
     // 3. If IsSharedArrayBuffer(O) is false, throw a TypeError exception.
-    // FIXME: Check for shared buffer
+    if (!array_buffer_object->is_shared_array_buffer())
+        return vm.throw_completion<TypeError>(ErrorType::NotASharedArrayBuffer);
 
     // 4. Let len be O.[[ArrayBufferByteLength]].
     auto length = array_buffer_object->byte_length();
@@ -108,7 +110,8 @@ JS_DEFINE_NATIVE_FUNCTION(SharedArrayBufferPrototype::slice)
     auto* new_array_buffer_object = static_cast<ArrayBuffer*>(new_array_buffer.ptr());
 
     // 17. If IsSharedArrayBuffer(new) is true, throw a TypeError exception.
-    // FIXME: Check for shared buffer
+    if (!new_array_buffer_object->is_shared_array_buffer())
+        return vm.throw_completion<TypeError>(ErrorType::NotASharedArrayBuffer);
 
     // 18. If new.[[ArrayBufferData]] is O.[[ArrayBufferData]], throw a TypeError exception.
     if (new_array_buffer == array_buffer_object)

--- a/Userland/Libraries/LibJS/Tests/builtins/ArrayBuffer/ArrayBuffer.prototype.detached.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/ArrayBuffer/ArrayBuffer.prototype.detached.js
@@ -1,0 +1,30 @@
+describe("errors", () => {
+    test("called on non-ArrayBuffer object", () => {
+        expect(() => {
+            ArrayBuffer.prototype.detached;
+        }).toThrowWithMessage(TypeError, "Not an object of type ArrayBuffer");
+    });
+
+    test("called on SharedArrayBuffer object", () => {
+        let detached = Object.getOwnPropertyDescriptor(ArrayBuffer.prototype, "detached");
+        let getter = detached.get;
+
+        expect(() => {
+            getter.call(new SharedArrayBuffer());
+        }).toThrowWithMessage(TypeError, "The array buffer object cannot be a SharedArrayBuffer");
+    });
+});
+
+describe("normal behavior", () => {
+    test("not detached", () => {
+        let buffer = new ArrayBuffer();
+        expect(buffer.detached).toBeFalse();
+    });
+
+    test("detached", () => {
+        let buffer = new ArrayBuffer();
+        detachArrayBuffer(buffer);
+
+        expect(buffer.detached).toBeTrue();
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/ArrayBuffer/ArrayBuffer.prototype.slice.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/ArrayBuffer/ArrayBuffer.prototype.slice.js
@@ -1,3 +1,11 @@
+describe("errors", () => {
+    test("called on SharedArrayBuffer object", () => {
+        expect(() => {
+            ArrayBuffer.prototype.slice.call(new SharedArrayBuffer());
+        }).toThrowWithMessage(TypeError, "The array buffer object cannot be a SharedArrayBuffer");
+    });
+});
+
 test("single parameter", () => {
     const buffer = new ArrayBuffer(16);
     const fullView = new Int32Array(buffer);

--- a/Userland/Libraries/LibJS/Tests/builtins/ArrayBuffer/ArrayBuffer.prototype.transfer.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/ArrayBuffer/ArrayBuffer.prototype.transfer.js
@@ -1,0 +1,76 @@
+describe("errors", () => {
+    test("called on non-ArrayBuffer object", () => {
+        expect(() => {
+            ArrayBuffer.prototype.transfer(Symbol.hasInstance);
+        }).toThrowWithMessage(TypeError, "Not an object of type ArrayBuffer");
+    });
+
+    test("called on SharedArrayBuffer object", () => {
+        expect(() => {
+            ArrayBuffer.prototype.transfer.call(new SharedArrayBuffer());
+        }).toThrowWithMessage(TypeError, "The array buffer object cannot be a SharedArrayBuffer");
+    });
+
+    test("detached buffer", () => {
+        let buffer = new ArrayBuffer(5);
+        detachArrayBuffer(buffer);
+
+        expect(() => {
+            buffer.transfer();
+        }).toThrowWithMessage(TypeError, "ArrayBuffer is detached");
+    });
+});
+
+const readBuffer = buffer => {
+    let array = new Uint8Array(buffer, 0, buffer.byteLength / Uint8Array.BYTES_PER_ELEMENT);
+    let values = [];
+
+    for (let value of array) {
+        values.push(Number(value));
+    }
+
+    return values;
+};
+
+const writeBuffer = (buffer, values) => {
+    let array = new Uint8Array(buffer, 0, buffer.byteLength / Uint8Array.BYTES_PER_ELEMENT);
+    array.set(values);
+};
+
+describe("normal behavior", () => {
+    test("old buffer is detached", () => {
+        let buffer = new ArrayBuffer(5);
+        let newBuffer = buffer.transfer();
+
+        expect(buffer.detached).toBeTrue();
+        expect(newBuffer.detached).toBeFalse();
+    });
+
+    test("resizability is preserved", () => {
+        let buffer = new ArrayBuffer(5, { maxByteLength: 10 });
+        let newBuffer = buffer.transfer();
+
+        expect(buffer.resizable).toBeTrue();
+        expect(newBuffer.resizable).toBeTrue();
+    });
+
+    test("data is transferred", () => {
+        let buffer = new ArrayBuffer(5);
+        writeBuffer(buffer, [1, 2, 3, 4, 5]);
+
+        let newBuffer = buffer.transfer();
+        const values = readBuffer(newBuffer);
+
+        expect(values).toEqual([1, 2, 3, 4, 5]);
+    });
+
+    test("length may be limited", () => {
+        let buffer = new ArrayBuffer(5);
+        writeBuffer(buffer, [1, 2, 3, 4, 5]);
+
+        let newBuffer = buffer.transfer(3);
+        const values = readBuffer(newBuffer);
+
+        expect(values).toEqual([1, 2, 3]);
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/ArrayBuffer/ArrayBuffer.prototype.transferToFixedLength.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/ArrayBuffer/ArrayBuffer.prototype.transferToFixedLength.js
@@ -1,0 +1,76 @@
+describe("errors", () => {
+    test("called on non-ArrayBuffer object", () => {
+        expect(() => {
+            ArrayBuffer.prototype.transferToFixedLength(Symbol.hasInstance);
+        }).toThrowWithMessage(TypeError, "Not an object of type ArrayBuffer");
+    });
+
+    test("called on SharedArrayBuffer object", () => {
+        expect(() => {
+            ArrayBuffer.prototype.transferToFixedLength.call(new SharedArrayBuffer());
+        }).toThrowWithMessage(TypeError, "The array buffer object cannot be a SharedArrayBuffer");
+    });
+
+    test("detached buffer", () => {
+        let buffer = new ArrayBuffer(5);
+        detachArrayBuffer(buffer);
+
+        expect(() => {
+            buffer.transferToFixedLength();
+        }).toThrowWithMessage(TypeError, "ArrayBuffer is detached");
+    });
+});
+
+const readBuffer = buffer => {
+    let array = new Uint8Array(buffer, 0, buffer.byteLength / Uint8Array.BYTES_PER_ELEMENT);
+    let values = [];
+
+    for (let value of array) {
+        values.push(Number(value));
+    }
+
+    return values;
+};
+
+const writeBuffer = (buffer, values) => {
+    let array = new Uint8Array(buffer, 0, buffer.byteLength / Uint8Array.BYTES_PER_ELEMENT);
+    array.set(values);
+};
+
+describe("normal behavior", () => {
+    test("old buffer is detached", () => {
+        let buffer = new ArrayBuffer(5);
+        let newBuffer = buffer.transferToFixedLength();
+
+        expect(buffer.detached).toBeTrue();
+        expect(newBuffer.detached).toBeFalse();
+    });
+
+    test("resizability is not preserved", () => {
+        let buffer = new ArrayBuffer(5, { maxByteLength: 10 });
+        let newBuffer = buffer.transferToFixedLength();
+
+        expect(buffer.resizable).toBeTrue();
+        expect(newBuffer.resizable).toBeFalse();
+    });
+
+    test("data is transferred", () => {
+        let buffer = new ArrayBuffer(5);
+        writeBuffer(buffer, [1, 2, 3, 4, 5]);
+
+        let newBuffer = buffer.transferToFixedLength();
+        const values = readBuffer(newBuffer);
+
+        expect(values).toEqual([1, 2, 3, 4, 5]);
+    });
+
+    test("length may be limited", () => {
+        let buffer = new ArrayBuffer(5);
+        writeBuffer(buffer, [1, 2, 3, 4, 5]);
+
+        let newBuffer = buffer.transferToFixedLength(3);
+        const values = readBuffer(newBuffer);
+
+        expect(values).toEqual([1, 2, 3]);
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Atomics/Atomics.wait.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Atomics/Atomics.wait.js
@@ -31,10 +31,7 @@ describe("errors", () => {
         expect(() => {
             const typedArray = new Int32Array(4);
             Atomics.wait(typedArray, 0, 0, 0);
-        }).toThrowWithMessage(
-            TypeError,
-            "The TypedArray's underlying buffer must be a SharedArrayBuffer"
-        );
+        }).toThrowWithMessage(TypeError, "The array buffer object must be a SharedArrayBuffer");
     });
 
     test("invalid index", () => {

--- a/Userland/Libraries/LibJS/Tests/builtins/Atomics/Atomics.waitAsync.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Atomics/Atomics.waitAsync.js
@@ -31,10 +31,7 @@ describe("errors", () => {
         expect(() => {
             const typedArray = new Int32Array(4);
             Atomics.waitAsync(typedArray, 0, 0, 0);
-        }).toThrowWithMessage(
-            TypeError,
-            "The TypedArray's underlying buffer must be a SharedArrayBuffer"
-        );
+        }).toThrowWithMessage(TypeError, "The array buffer object must be a SharedArrayBuffer");
     });
 
     test("invalid index", () => {

--- a/Userland/Libraries/LibJS/Tests/builtins/SharedArrayBuffer/SharedArrayBuffer.prototype.byteLength.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/SharedArrayBuffer/SharedArrayBuffer.prototype.byteLength.js
@@ -1,3 +1,18 @@
+describe("errors", () => {
+    test("called on non-SharedArrayBuffer object", () => {
+        expect(() => {
+            SharedArrayBuffer.prototype.byteLength;
+        }).toThrowWithMessage(TypeError, "Not an object of type SharedArrayBuffer");
+
+        let byteLength = Object.getOwnPropertyDescriptor(SharedArrayBuffer.prototype, "byteLength");
+        let getter = byteLength.get;
+
+        expect(() => {
+            getter.call(new ArrayBuffer());
+        }).toThrowWithMessage(TypeError, "The array buffer object must be a SharedArrayBuffer");
+    });
+});
+
 test("basic functionality", () => {
     expect(new SharedArrayBuffer().byteLength).toBe(0);
     expect(new SharedArrayBuffer(1).byteLength).toBe(1);

--- a/Userland/Libraries/LibJS/Tests/builtins/SharedArrayBuffer/SharedArrayBuffer.prototype.slice.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/SharedArrayBuffer/SharedArrayBuffer.prototype.slice.js
@@ -1,3 +1,15 @@
+describe("errors", () => {
+    test("called on non-SharedArrayBuffer object", () => {
+        expect(() => {
+            SharedArrayBuffer.prototype.slice(Symbol.hasInstance);
+        }).toThrowWithMessage(TypeError, "Not an object of type SharedArrayBuffer");
+
+        expect(() => {
+            SharedArrayBuffer.prototype.slice.call(new ArrayBuffer());
+        }).toThrowWithMessage(TypeError, "The array buffer object must be a SharedArrayBuffer");
+    });
+});
+
 test("single parameter", () => {
     const buffer = new SharedArrayBuffer(16);
     const fullView = new Int32Array(buffer);


### PR DESCRIPTION
We now pass all tests in `test/built-ins/ArrayBuffer`, `test/built-ins/DataView`, `test/built-ins/TypedArray`, and `test/built-ins/TypedArrayConstructors`.

```
Diff Tests:
+11 ✅    -11 ❌

test/built-ins/ArrayBuffer/prototype/detached/this-is-sharedarraybuffer-resizable.js    ❌ -> ✅
test/built-ins/ArrayBuffer/prototype/detached/this-is-sharedarraybuffer.js              ❌ -> ✅
test/built-ins/ArrayBuffer/prototype/slice/this-is-sharedarraybuffer.js                 ❌ -> ✅
test/built-ins/ArrayBuffer/prototype/transfer/from-resizable-to-larger.js               ❌ -> ✅
test/built-ins/ArrayBuffer/prototype/transfer/from-resizable-to-same.js                 ❌ -> ✅
test/built-ins/ArrayBuffer/prototype/transfer/from-resizable-to-smaller.js              ❌ -> ✅
test/built-ins/ArrayBuffer/prototype/transfer/from-resizable-to-zero.js                 ❌ -> ✅
test/built-ins/ArrayBuffer/prototype/transfer/this-is-sharedarraybuffer.js              ❌ -> ✅
test/built-ins/ArrayBuffer/prototype/transferToFixedLength/this-is-sharedarraybuffer.js ❌ -> ✅
test/built-ins/SharedArrayBuffer/prototype/byteLength/this-is-arraybuffer.js            ❌ -> ✅
test/built-ins/SharedArrayBuffer/prototype/slice/this-is-arraybuffer.js                 ❌ -> ✅
```