### PR TITLE
Mandelbrot: Modernize code by using the FileSystemAccessClient

### DIFF
--- a/Userland/Demos/Mandelbrot/CMakeLists.txt
+++ b/Userland/Demos/Mandelbrot/CMakeLists.txt
@@ -8,4 +8,4 @@ set(SOURCES
 )
 
 serenity_app(Mandelbrot ICON app-mandelbrot)
-target_link_libraries(Mandelbrot PRIVATE LibGUI LibCore LibGfx LibMain)
+target_link_libraries(Mandelbrot PRIVATE LibCore LibFileSystemAccessClient LibGfx LibGUI LibMain)


### PR DESCRIPTION
This allows us to stop using raw `FILE*` and reintroduce `unveil` calls.