### PR TITLE
FileManager: Conditionally display the "ICC profile:" line

### DIFF
--- a/Userland/Applications/FileManager/PropertiesWindow.cpp
+++ b/Userland/Applications/FileManager/PropertiesWindow.cpp
@@ -442,7 +442,7 @@ ErrorOr<void> PropertiesWindow::create_image_tab(GUI::TabWidget& tab_widget, Non
         } else {
             auto icc_profile = icc_profile_or_error.release_value();
 
-            tab.find_descendant_of_type_named<GUI::Label>("image_has_icc_profile")->set_text("See below"_string);
+            tab.find_descendant_of_type_named<GUI::Widget>("image_has_icc_line")->set_visible(false);
             tab.find_descendant_of_type_named<GUI::Label>("image_icc_profile")->set_text(icc_profile->tag_string_data(Gfx::ICC::profileDescriptionTag).value_or({}));
             tab.find_descendant_of_type_named<GUI::Label>("image_icc_copyright")->set_text(icc_profile->tag_string_data(Gfx::ICC::copyrightTag).value_or({}));
             tab.find_descendant_of_type_named<GUI::Label>("image_icc_color_space")->set_text(TRY(String::from_utf8(data_color_space_name(icc_profile->data_color_space()))));

--- a/Userland/Applications/FileManager/PropertiesWindowImageTab.gml
+++ b/Userland/Applications/FileManager/PropertiesWindowImageTab.gml
@@ -68,6 +68,7 @@
         }
 
         @GUI::Widget {
+            name: "image_has_icc_line"
             layout: @GUI::HorizontalBoxLayout {
                 spacing: 12
             }


### PR DESCRIPTION
If the "ICC Profile" group is shown, no need to include the related line in the "Image" group.

---

![image](https://github.com/SerenityOS/serenity/assets/26030965/e464a646-a6d9-4f92-81bd-96b6ce587900)
