### PR TITLE
Kernel/riscv64: Return correct range in `kernel_virtual_range` on RISC-V

### DIFF
--- a/Kernel/Memory/MemoryManager.cpp
+++ b/Kernel/Memory/MemoryManager.cpp
@@ -69,12 +69,14 @@ bool MemoryManager::is_initialized()
 
 static UNMAP_AFTER_INIT VirtualRange kernel_virtual_range()
 {
-#if ARCH(AARCH64)
-    // NOTE: This is not the same as x86_64, because the aarch64 kernel currently doesn't use the pre-kernel.
-    return VirtualRange { VirtualAddress(kernel_mapping_base), KERNEL_PD_END - kernel_mapping_base };
-#else
+#if ARCH(X86_64)
     size_t kernel_range_start = kernel_mapping_base + 2 * MiB; // The first 2 MiB are used for mapping the pre-kernel
     return VirtualRange { VirtualAddress(kernel_range_start), KERNEL_PD_END - kernel_range_start };
+#elif ARCH(AARCH64) || ARCH(RISCV64)
+    // NOTE: This is not the same as x86_64, because the aarch64 and riscv64 kernels currently don't use the pre-kernel.
+    return VirtualRange { VirtualAddress(kernel_mapping_base), KERNEL_PD_END - kernel_mapping_base };
+#else
+#    error Unknown architecture
 #endif
 }
 


### PR DESCRIPTION
riscv64 doesn't use a prekernel, so use the same code as aarch64 for determining the kernel virtual address range.