### PR TITLE
Kernel/riscv64: Add support for hart-local RISC-V Timer

### DIFF
--- a/Kernel/Arch/riscv64/CSR.h
+++ b/Kernel/Arch/riscv64/CSR.h
@@ -215,4 +215,31 @@ struct [[gnu::packed]] alignas(u64) SSTATUS {
 };
 static_assert(AssertSize<SSTATUS, 8>());
 
+// 4.1.8 Supervisor Cause Register (scause)
+constexpr u64 SCAUSE_INTERRUPT_MASK = 1LU << 63;
+
+enum class SCAUSE : u64 {
+    // Interrupts
+    SupervisorSoftwareInterrupt = SCAUSE_INTERRUPT_MASK | 1,
+    SupervisorTimerInterrupt = SCAUSE_INTERRUPT_MASK | 5,
+    SupervisorExternalInterrupt = SCAUSE_INTERRUPT_MASK | 9,
+
+    // Exceptions
+    InstructionAddressMisaligned = 0,
+    InstructionAccessFault = 1,
+    IllegalInstrction = 2,
+    Breakpoint = 3,
+    LoadAddressMisaligned = 4,
+    LoadAccessFault = 5,
+    StoreOrAMOAddressMisaligned = 6,
+    StoreOrAMOAccessFault = 7,
+    EnvironmentCallFromUMode = 8,
+    EnvironmentCallFromSMode = 9,
+
+    InstructionPageFault = 12,
+    LoadPageFault = 13,
+
+    StoreOrAMOPageFault = 15,
+};
+
 }

--- a/Kernel/Arch/riscv64/CurrentTime.cpp
+++ b/Kernel/Arch/riscv64/CurrentTime.cpp
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2023, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/Arch/CurrentTime.h>
+
+namespace Kernel {
+
+fptr optional_current_time()
+{
+    return nullptr;
+}
+
+}

--- a/Kernel/Arch/riscv64/Timer.cpp
+++ b/Kernel/Arch/riscv64/Timer.cpp
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2023, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Format.h>
+#include <AK/NeverDestroyed.h>
+#include <Kernel/Arch/riscv64/SBI.h>
+#include <Kernel/Arch/riscv64/Timer.h>
+
+namespace Kernel::RISCV64 {
+
+Timer::Timer()
+    : HardwareTimer(to_underlying(CSR::SCAUSE::SupervisorTimerInterrupt) & ~CSR::SCAUSE_INTERRUPT_MASK)
+{
+    // FIXME: Actually query the frequency of the timer from the device tree.
+    // Based on the "/cpus/timebase-frequency" device tree node for the QEMU virt machine
+    m_frequency = 10'000'000; // in Hz
+
+    set_interrupt_interval_usec(m_frequency / OPTIMAL_TICKS_PER_SECOND_RATE);
+    enable_interrupt_mode();
+}
+
+Timer::~Timer() = default;
+
+NonnullLockRefPtr<Timer> Timer::initialize()
+{
+    return adopt_lock_ref(*new Timer);
+}
+
+u64 Timer::microseconds_since_boot()
+{
+    return RISCV64::CSR::read(RISCV64::CSR::Address::TIME);
+}
+
+bool Timer::handle_irq(RegisterState const& regs)
+{
+    auto result = HardwareTimer::handle_irq(regs);
+
+    set_compare(microseconds_since_boot() + m_interrupt_interval);
+
+    return result;
+}
+
+u64 Timer::update_time(u64& seconds_since_boot, u32& ticks_this_second, bool query_only)
+{
+    // Should only be called by the time keeper interrupt handler!
+    u64 current_value = microseconds_since_boot();
+    u64 delta_ticks = m_main_counter_drift;
+    if (current_value >= m_main_counter_last_read) {
+        delta_ticks += current_value - m_main_counter_last_read;
+    } else {
+        // the counter wrapped around
+        delta_ticks += (NumericLimits<u64>::max() - m_main_counter_last_read + 1) + current_value;
+    }
+
+    u64 ticks_since_last_second = (u64)ticks_this_second + delta_ticks;
+    auto ticks_per_second = frequency();
+    seconds_since_boot += ticks_since_last_second / ticks_per_second;
+    ticks_this_second = ticks_since_last_second % ticks_per_second;
+
+    if (!query_only) {
+        m_main_counter_drift = 0;
+        m_main_counter_last_read = current_value;
+    }
+
+    // Return the time passed (in ns) since last time update_time was called
+    return (delta_ticks * 1000000000ull) / ticks_per_second;
+}
+
+void Timer::enable_interrupt_mode()
+{
+    set_compare(microseconds_since_boot() + m_interrupt_interval);
+    enable_irq();
+}
+
+void Timer::set_interrupt_interval_usec(u32 interrupt_interval)
+{
+    m_interrupt_interval = interrupt_interval;
+}
+
+void Timer::set_compare(u64 compare)
+{
+    if (SBI::Timer::set_timer(compare).is_error())
+        MUST(SBI::Legacy::set_timer(compare));
+}
+
+}

--- a/Kernel/Arch/riscv64/Timer.h
+++ b/Kernel/Arch/riscv64/Timer.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2023, Sönke Holz <sholz8530@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Types.h>
+#include <Kernel/Interrupts/IRQHandler.h>
+#include <Kernel/Library/NonnullLockRefPtr.h>
+#include <Kernel/Time/HardwareTimer.h>
+
+namespace Kernel::RISCV64 {
+
+struct TimerRegisters;
+
+class Timer final : public HardwareTimer<IRQHandler> {
+public:
+    virtual ~Timer();
+
+    static NonnullLockRefPtr<Timer> initialize();
+
+    virtual HardwareTimerType timer_type() const override { return HardwareTimerType::RISCVTimer; }
+    virtual StringView model() const override { return "RISC-V Timer"sv; }
+    virtual size_t ticks_per_second() const override { return m_frequency; }
+
+    virtual bool is_periodic() const override { TODO_RISCV64(); }
+    virtual bool is_periodic_capable() const override { TODO_RISCV64(); }
+    virtual void set_periodic() override { TODO_RISCV64(); }
+    virtual void set_non_periodic() override { TODO_RISCV64(); }
+    virtual void disable() override { TODO_RISCV64(); }
+
+    virtual void reset_to_default_ticks_per_second() override { TODO_RISCV64(); }
+    virtual bool try_to_set_frequency(size_t) override { TODO_RISCV64(); }
+    virtual bool is_capable_of_frequency(size_t) const override { TODO_RISCV64(); }
+    virtual size_t calculate_nearest_possible_frequency(size_t) const override { TODO_RISCV64(); }
+
+    // FIXME: Share code with HPET::update_time
+    u64 update_time(u64& seconds_since_boot, u32& ticks_this_second, bool query_only);
+
+    u64 microseconds_since_boot();
+
+    void set_interrupt_interval_usec(u32);
+    void enable_interrupt_mode();
+
+private:
+    Timer();
+
+    void set_compare(u64 compare);
+
+    //^ IRQHandler
+    virtual bool handle_irq(RegisterState const&) override;
+
+    u32 m_interrupt_interval { 0 };
+
+    u64 m_main_counter_last_read { 0 };
+    u64 m_main_counter_drift { 0 };
+};
+
+}

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -530,6 +530,7 @@ elseif("${SERENITY_ARCH}" STREQUAL "riscv64")
         Arch/riscv64/SafeMem.cpp
         Arch/riscv64/SBI.cpp
         Arch/riscv64/SmapDisabler.cpp
+        Arch/riscv64/Timer.cpp
     )
 
     add_compile_options(-fno-stack-protector -fno-sanitize=all)

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -517,6 +517,7 @@ elseif("${SERENITY_ARCH}" STREQUAL "riscv64")
         Arch/riscv64/Firmware/ACPI/StaticParsing.cpp
 
         Arch/riscv64/boot.S
+        Arch/riscv64/CurrentTime.cpp
         Arch/riscv64/DebugOutput.cpp
         Arch/riscv64/Delay.cpp
         Arch/riscv64/InterruptManagement.cpp

--- a/Kernel/Time/HardwareTimer.h
+++ b/Kernel/Time/HardwareTimer.h
@@ -14,12 +14,17 @@
 namespace Kernel {
 
 enum class HardwareTimerType {
+#if ARCH(X86_64)
     i8253 = 0x1,                   /* PIT */
     RTC = 0x2,                     /* Real Time Clock */
     HighPrecisionEventTimer = 0x3, /* also known as IA-PC HPET */
     LocalAPICTimer = 0x4,          /* Local APIC */
-#if ARCH(AARCH64)
-    RPiTimer = 0x5
+#elif ARCH(AARCH64)
+    RPiTimer = 0x5,
+#elif ARCH(RISCV64)
+    RISCVTimer = 0x6,
+#else
+#    error Unknown architecture
 #endif
 };
 


### PR DESCRIPTION
This PR adds support for the hart-local timer as defined by the privileged ISA.
This timer uses the SBI to set up the timer interrupts.

The code falls back to the legacy SBI extension, as we don't have any generic SBI extension probing code.