### PR TITLE
LibGfx/JPEG: Make ycck jpegs with just cc subsampled decode correctly

### DIFF
--- a/Tests/LibGfx/TestImageDecoder.cpp
+++ b/Tests/LibGfx/TestImageDecoder.cpp
@@ -232,7 +232,7 @@ TEST_CASE(test_jpeg_ycck)
     Array test_inputs = {
         TEST_INPUT("jpg/ycck-1111.jpg"sv),
         // TEST_INPUT("jpg/ycck-2111.jpg"sv), // FIXME: Enable once this decodes correctly
-        // TEST_INPUT("jpg/ycck-2112.jpg"sv), // FIXME: Enable once this decodes correctly
+        TEST_INPUT("jpg/ycck-2112.jpg"sv),
     };
 
     for (auto test_input : test_inputs) {

--- a/Userland/Libraries/LibGfx/ImageFormats/JPEGLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEGLoader.cpp
@@ -1282,7 +1282,12 @@ static ErrorOr<void> read_start_of_frame(JPEGStream& stream, JPEGLoadingContext&
                 return Error::from_string_literal("Unsupported luma subsampling factors");
             }
         } else {
-            if (component.hsample_factor != 1 || component.vsample_factor != 1) {
+            // YCCK with just CC subsampled and K matching Y is fine.
+            auto const& y_component = context.components[0];
+            bool channel_matches_y_factor = component.hsample_factor == y_component.hsample_factor && component.vsample_factor == y_component.vsample_factor;
+            bool k_channel_matches_y = context.color_transform == ColorTransform::YCCK && i == 3 && channel_matches_y_factor;
+
+            if ((component.hsample_factor != 1 || component.vsample_factor != 1) && !k_channel_matches_y) {
                 dbgln_if(JPEG_DEBUG, "Unsupported chroma subsampling factors: horizontal: {}, vertical: {}",
                     component.hsample_factor,
                     component.vsample_factor);


### PR DESCRIPTION
We currently assume that the K (black) channel uses the same sampling
as the Y channel already, so this already works as long as we don't
error out on it.