### PR TITLE
Tests: Don't include LibWebView test if LibWeb is disabled

### DIFF
--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -655,11 +655,11 @@ if (BUILD_LAGOM)
             LibTimeZone
             LibUnicode
             LibVideo
-            LibWebView
             LibXML
         )
         if (ENABLE_LAGOM_LIBWEB)
             list(APPEND TEST_DIRECTORIES LibWeb)
+            list(APPEND TEST_DIRECTORIES LibWebView)
         endif()
 
         foreach (dir IN LISTS TEST_DIRECTORIES)


### PR DESCRIPTION
This unbreaks ENABLE_LAGOM_LIBWEB=OFF again.

@trflynn89 GitHub doesn’t let me reopen the old pull request unfortunately...