### PR TITLE
Ladybird/Qt: Ensure the Inspector widget is deleted before the WebView

### DIFF
--- a/Ladybird/Qt/Tab.cpp
+++ b/Ladybird/Qt/Tab.cpp
@@ -579,6 +579,10 @@ Tab::Tab(BrowserWindow* window, WebContentOptions const& web_content_options, St
 Tab::~Tab()
 {
     close_sub_widgets();
+
+    // Delete the InspectorWidget explicitly to ensure it is deleted before the WebContentView. Otherwise, Qt
+    // can destroy these objects in any order, which may cause use-after-free in InspectorWidget's destructor.
+    delete m_inspector_widget;
 }
 
 void Tab::select_dropdown_add_item(QMenu* menu, Web::HTML::SelectItem const& item)


### PR DESCRIPTION
According to Qt documentation, destruction of a QObject's children may happen in any order. In our case, the Tab's WebContentView is deleted before its InspectorWidget. The InspectorWidget performs cleanup on that WebContentView in its destructor; this causes use-after-free since it has already been destroyed.

From reading Qt threads, if a particular destruction order is required, it is okay to enforce that order with manual `delete`s. This patch does so with the InspectorWidget to ensure it is deleted before the WebContentView. Qt's object ownership is okay with this - it will remove the InspectorWidget from the Tab's children, preventing any double deletion.

Fixes #22279