### PR TITLE
LibGfx/JPEG: Reject ycck or cmyk jpegs with k subsampled for now

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/JPEGLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEGLoader.cpp
@@ -1287,7 +1287,7 @@ static ErrorOr<void> read_start_of_frame(JPEGStream& stream, JPEGLoadingContext&
             bool channel_matches_y_factor = component.hsample_factor == y_component.hsample_factor && component.vsample_factor == y_component.vsample_factor;
             bool k_channel_matches_y = context.color_transform == ColorTransform::YCCK && i == 3 && channel_matches_y_factor;
 
-            if ((component.hsample_factor != 1 || component.vsample_factor != 1) && !k_channel_matches_y) {
+            if (((component.hsample_factor != 1 || component.vsample_factor != 1) && !k_channel_matches_y) || (i == 3 && !channel_matches_y_factor)) {
                 dbgln_if(JPEG_DEBUG, "Unsupported chroma subsampling factors: horizontal: {}, vertical: {}",
                     component.hsample_factor,
                     component.vsample_factor);


### PR DESCRIPTION
The decoder assumes that k's sampling factor matches y's at the moment. Better to error out than to silently render something broken.

For ycck, covered by ycck-2111.jpg in the tests.