### PR TITLE
LibWeb: Skip window-scrollTo test that keeps timing out on macOS

### DIFF
--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -1,2 +1,3 @@
 [Skipped]
 Text/input/Worker/Worker-echo.html
+Text/input/window-scrollTo.html


### PR DESCRIPTION
Ref #22493 