### PR TITLE
LibWeb: Skip empty paint borders commands in RecordingPainter

### DIFF
--- a/Userland/Libraries/LibWeb/Painting/RecordingPainter.cpp
+++ b/Userland/Libraries/LibWeb/Painting/RecordingPainter.cpp
@@ -411,6 +411,8 @@ void RecordingPainter::draw_triangle_wave(Gfx::IntPoint a_p1, Gfx::IntPoint a_p2
 
 void RecordingPainter::paint_borders(DevicePixelRect const& border_rect, CornerRadii const& corner_radii, BordersDataDevicePixels const& borders_data)
 {
+    if (borders_data.top.width == 0 && borders_data.right.width == 0 && borders_data.bottom.width == 0 && borders_data.left.width == 0)
+        return;
     push_command(PaintBorders { border_rect, corner_radii, borders_data });
 }
 


### PR DESCRIPTION
With this change, we create substantially fewer border painting commands, which means fewer reallocations of the vector that stores commands.

This makes the rendering of
https://html.spec.whatwg.org/multipage/browsing-the-web.html visibly faster, where we allocated ~10 of such commands now vs ~8000 before.