### PR TITLE
LibGfx/TIFF: Resolve more oss-fuzz issues

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/TIFFLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/TIFFLoader.cpp
@@ -47,6 +47,9 @@ public:
         if (m_metadata.strip_offsets()->size() != m_metadata.strip_byte_counts()->size())
             return Error::from_string_literal("TIFFImageDecoderPlugin: StripsOffset and StripByteCount have different sizes");
 
+        if (any_of(*m_metadata.bits_per_sample(), [](auto bit_depth) { return bit_depth == 0 || bit_depth > 32; }))
+            return Error::from_string_literal("TIFFImageDecoderPlugin: Invalid value in BitsPerSample");
+
         return {};
     }
 


### PR DESCRIPTION
Fixes oss-fuzz issues [65392](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=65392) and [65401](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=65401)

The first one has a sample with a declared bit depth of more than 65 000 and the second one has two samples with null bit depth.