### PR TITLE
LibGfx/ICC: Improve XYZ coordinates of gray colors

### DIFF
--- a/Userland/Libraries/LibGfx/ICC/Profile.cpp
+++ b/Userland/Libraries/LibGfx/ICC/Profile.cpp
@@ -1287,7 +1287,8 @@ ErrorOr<FloatVector3> Profile::to_pcs(ReadonlyBytes color) const
             // ICC v4, F.2 grayTRCTag
             // "connection = grayTRC[device]"
             float gray = evaluate_curve(grayTRCTag, color[0] / 255.f);
-            return FloatVector3 { gray, gray, gray };
+            FloatVector3 white { pcs_illuminant().X, pcs_illuminant().Y, pcs_illuminant().Z };
+            return white * gray;
         }
 
         // FIXME: Per ICC v4, A.1 General, this should also handle HLS, HSV, YCbCr.


### PR DESCRIPTION
In XYZ space, gray doesn't have three equal values. Instead, it is a line through the whitepoint.

(Multiplying by the whitepoint has the same effect as multiplying the sRGB matrix with a (g, g, g) vector, since the numbers on the matrix's rows add up to the whitepoint.)

Fixes the very slight red tint on all the figures in chapter 4 of the PDF 1.7 spec.