### PR TITLE
LibJS: Never give back virtual memory once it belongs to a cell type

### DIFF
--- a/Userland/Applications/Assistant/main.cpp
+++ b/Userland/Applications/Assistant/main.cpp
@@ -146,7 +146,7 @@ private:
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath cpath unix proc exec thread"));
+    TRY(Core::System::pledge("stdio recvfd sendfd rpath cpath unix proc exec thread map_fixed"));
 
     Core::LockFile lockfile("/tmp/lock/assistant.lock");
 

--- a/Userland/Applications/Spreadsheet/main.cpp
+++ b/Userland/Applications/Spreadsheet/main.cpp
@@ -23,7 +23,7 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath fattr unix cpath wpath thread"));
+    TRY(Core::System::pledge("stdio recvfd sendfd rpath fattr unix cpath wpath thread map_fixed"));
 
     auto app = TRY(GUI::Application::create(arguments));
 

--- a/Userland/Libraries/LibJS/Heap/BlockAllocator.h
+++ b/Userland/Libraries/LibJS/Heap/BlockAllocator.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021-2023, Andreas Kling <kling@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -20,9 +20,7 @@ public:
     void deallocate_block(void*);
 
 private:
-    static constexpr size_t max_cached_blocks = 512;
-
-    Vector<void*, max_cached_blocks> m_blocks;
+    Vector<void*> m_blocks;
 };
 
 }

--- a/Userland/Libraries/LibJS/Heap/CellAllocator.cpp
+++ b/Userland/Libraries/LibJS/Heap/CellAllocator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2020-2023, Andreas Kling <kling@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -37,11 +37,10 @@ Cell* CellAllocator::allocate_cell(Heap& heap)
 
 void CellAllocator::block_did_become_empty(Badge<Heap>, HeapBlock& block)
 {
-    auto& heap = block.heap();
     block.m_list_node.remove();
     // NOTE: HeapBlocks are managed by the BlockAllocator, so we don't want to `delete` the block here.
     block.~HeapBlock();
-    heap.block_allocator().deallocate_block(&block);
+    m_block_allocator.deallocate_block(&block);
 }
 
 void CellAllocator::block_did_become_usable(Badge<Heap>, HeapBlock& block)

--- a/Userland/Libraries/LibJS/Heap/CellAllocator.cpp
+++ b/Userland/Libraries/LibJS/Heap/CellAllocator.cpp
@@ -12,8 +12,9 @@
 
 namespace JS {
 
-CellAllocator::CellAllocator(size_t cell_size)
-    : m_cell_size(cell_size)
+CellAllocator::CellAllocator(size_t cell_size, char const* class_name)
+    : m_class_name(class_name)
+    , m_cell_size(cell_size)
 {
 }
 
@@ -23,7 +24,7 @@ Cell* CellAllocator::allocate_cell(Heap& heap)
         heap.register_cell_allocator({}, *this);
 
     if (m_usable_blocks.is_empty()) {
-        auto block = HeapBlock::create_with_cell_size(heap, *this, m_cell_size);
+        auto block = HeapBlock::create_with_cell_size(heap, *this, m_cell_size, m_class_name);
         m_usable_blocks.append(*block.leak_ptr());
     }
 

--- a/Userland/Libraries/LibJS/Heap/CellAllocator.h
+++ b/Userland/Libraries/LibJS/Heap/CellAllocator.h
@@ -17,13 +17,13 @@
     static JS::TypeIsolatingCellAllocator<ClassName> cell_allocator;
 
 #define JS_DEFINE_ALLOCATOR(ClassName) \
-    JS::TypeIsolatingCellAllocator<ClassName> ClassName::cell_allocator;
+    JS::TypeIsolatingCellAllocator<ClassName> ClassName::cell_allocator { #ClassName };
 
 namespace JS {
 
 class CellAllocator {
 public:
-    explicit CellAllocator(size_t cell_size);
+    CellAllocator(size_t cell_size, char const* class_name = nullptr);
     ~CellAllocator() = default;
 
     size_t cell_size() const { return m_cell_size; }
@@ -53,6 +53,7 @@ public:
     BlockAllocator& block_allocator() { return m_block_allocator; }
 
 private:
+    char const* const m_class_name { nullptr };
     size_t const m_cell_size;
 
     BlockAllocator m_block_allocator;
@@ -67,7 +68,12 @@ class TypeIsolatingCellAllocator {
 public:
     using CellType = T;
 
-    NeverDestroyed<CellAllocator> allocator { sizeof(T) };
+    TypeIsolatingCellAllocator(char const* class_name)
+        : allocator(sizeof(T), class_name)
+    {
+    }
+
+    NeverDestroyed<CellAllocator> allocator;
 };
 
 }

--- a/Userland/Libraries/LibJS/Heap/CellAllocator.h
+++ b/Userland/Libraries/LibJS/Heap/CellAllocator.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2020-2023, Andreas Kling <kling@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -10,6 +10,7 @@
 #include <AK/NeverDestroyed.h>
 #include <AK/NonnullOwnPtr.h>
 #include <LibJS/Forward.h>
+#include <LibJS/Heap/BlockAllocator.h>
 #include <LibJS/Heap/HeapBlock.h>
 
 #define JS_DECLARE_ALLOCATOR(ClassName) \
@@ -49,8 +50,12 @@ public:
     IntrusiveListNode<CellAllocator> m_list_node;
     using List = IntrusiveList<&CellAllocator::m_list_node>;
 
+    BlockAllocator& block_allocator() { return m_block_allocator; }
+
 private:
     size_t const m_cell_size;
+
+    BlockAllocator m_block_allocator;
 
     using BlockList = IntrusiveList<&HeapBlock::m_list_node>;
     BlockList m_full_blocks;

--- a/Userland/Libraries/LibJS/Heap/Heap.h
+++ b/Userland/Libraries/LibJS/Heap/Heap.h
@@ -15,7 +15,6 @@
 #include <AK/Vector.h>
 #include <LibCore/Forward.h>
 #include <LibJS/Forward.h>
-#include <LibJS/Heap/BlockAllocator.h>
 #include <LibJS/Heap/Cell.h>
 #include <LibJS/Heap/CellAllocator.h>
 #include <LibJS/Heap/Handle.h>
@@ -82,8 +81,6 @@ public:
     void did_destroy_execution_context(Badge<ExecutionContext>, ExecutionContext&);
 
     void register_cell_allocator(Badge<CellAllocator>, CellAllocator&);
-
-    BlockAllocator& block_allocator() { return m_block_allocator; }
 
     void uproot_cell(Cell* cell);
 
@@ -153,8 +150,6 @@ private:
     WeakContainer::List m_weak_containers;
 
     Vector<GCPtr<Cell>> m_uprooted_cells;
-
-    BlockAllocator m_block_allocator;
 
     size_t m_gc_deferrals { 0 };
     bool m_should_gc_when_deferral_ends { false };

--- a/Userland/Libraries/LibJS/Heap/HeapBlock.cpp
+++ b/Userland/Libraries/LibJS/Heap/HeapBlock.cpp
@@ -18,11 +18,14 @@
 
 namespace JS {
 
-NonnullOwnPtr<HeapBlock> HeapBlock::create_with_cell_size(Heap& heap, CellAllocator& cell_allocator, size_t cell_size)
+NonnullOwnPtr<HeapBlock> HeapBlock::create_with_cell_size(Heap& heap, CellAllocator& cell_allocator, size_t cell_size, [[maybe_unused]] char const* class_name)
 {
 #ifdef AK_OS_SERENITY
     char name[64];
-    snprintf(name, sizeof(name), "LibJS: HeapBlock(%zu)", cell_size);
+    if (class_name)
+        snprintf(name, sizeof(name), "LibJS: HeapBlock(%zu): %s", cell_size, class_name);
+    else
+        snprintf(name, sizeof(name), "LibJS: HeapBlock(%zu)", cell_size);
 #else
     char const* name = nullptr;
 #endif

--- a/Userland/Libraries/LibJS/Heap/HeapBlock.cpp
+++ b/Userland/Libraries/LibJS/Heap/HeapBlock.cpp
@@ -26,7 +26,7 @@ NonnullOwnPtr<HeapBlock> HeapBlock::create_with_cell_size(Heap& heap, CellAlloca
 #else
     char const* name = nullptr;
 #endif
-    auto* block = static_cast<HeapBlock*>(heap.block_allocator().allocate_block(name));
+    auto* block = static_cast<HeapBlock*>(cell_allocator.block_allocator().allocate_block(name));
     new (block) HeapBlock(heap, cell_allocator, cell_size);
     return NonnullOwnPtr<HeapBlock>(NonnullOwnPtr<HeapBlock>::Adopt, *block);
 }

--- a/Userland/Libraries/LibJS/Heap/HeapBlock.h
+++ b/Userland/Libraries/LibJS/Heap/HeapBlock.h
@@ -26,7 +26,7 @@ class HeapBlock : public HeapBlockBase {
 
 public:
     using HeapBlockBase::block_size;
-    static NonnullOwnPtr<HeapBlock> create_with_cell_size(Heap&, CellAllocator&, size_t);
+    static NonnullOwnPtr<HeapBlock> create_with_cell_size(Heap&, CellAllocator&, size_t cell_size, char const* class_name);
 
     size_t cell_size() const { return m_cell_size; }
     size_t cell_count() const { return (block_size - sizeof(HeapBlock)) / m_cell_size; }

--- a/Userland/Services/WebContent/main.cpp
+++ b/Userland/Services/WebContent/main.cpp
@@ -27,7 +27,7 @@
 ErrorOr<int> serenity_main(Main::Arguments)
 {
     Core::EventLoop event_loop;
-    TRY(Core::System::pledge("stdio recvfd sendfd accept unix rpath thread proc"));
+    TRY(Core::System::pledge("stdio recvfd sendfd accept unix rpath thread proc map_fixed"));
 
     // This must be first; we can't check if /tmp/webdriver exists once we've unveiled other paths.
     auto webdriver_socket_path = ByteString::formatted("{}/webdriver", TRY(Core::StandardPaths::runtime_directory()));

--- a/Userland/Utilities/js.cpp
+++ b/Userland/Utilities/js.cpp
@@ -531,7 +531,7 @@ private:
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio rpath wpath cpath tty sigaction"));
+    TRY(Core::System::pledge("stdio rpath wpath cpath tty sigaction map_fixed"));
 
     bool gc_on_every_allocation = false;
     bool disable_syntax_highlight = false;


### PR DESCRIPTION
Instead of returning `HeapBlock` memory to the kernel (or a non-type specific shared cache), we now keep a `BlockAllocator` per `CellAllocator` and implement "deallocation" by basically informing the kernel that we don't need the physical memory right now.

This is done with `MADV_FREE` or `MADV_DONTNEED` if available, but for other platforms (including SerenityOS) we `munmap` and then re-`mmap` the memory to achieve the same effect. It's definitely clunky, so I've added a `FIXME` about implementing the `madvise` options on SerenityOS too.

The important outcome of this change is that GC types that use a type-specific allocator become immune to type confusion attacks, since their virtual addresses will only ever be re-used for the same exact type again and again.

Fixes #22274