### PR TITLE
LibHTTP: Tolerate random whitespace in chunked encoding size field

### DIFF
--- a/Userland/Libraries/LibHTTP/Job.cpp
+++ b/Userland/Libraries/LibHTTP/Job.cpp
@@ -413,7 +413,7 @@ void Job::on_socket_connected()
                         m_should_read_chunk_ending_line = false;
                         continue;
                     }
-                    auto size_lines = size_data.view().lines();
+                    auto size_lines = size_data.view().trim_whitespace().lines();
                     dbgln_if(JOB_DEBUG, "Job: Received a chunk with size '{}'", size_data);
                     if (size_lines.size() == 0) {
                         if (!m_socket->is_eof())


### PR DESCRIPTION
Some servers decide to add newlines (and not \r\n) into that field, this commit makes us tolerate that and not crash in cases like in #22463.

Fixes #22463.