### PR TITLE
LibWeb/CSS: Fix crashing when calc() is used for border-radius

### DIFF
--- a/Tests/LibWeb/Ref/calc-border-radius.html
+++ b/Tests/LibWeb/Ref/calc-border-radius.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <link rel="match" href="reference/calc-border-radius-ref.html" />
+    <style>
+        .box {
+            width: 200px;
+            height: 200px;
+            background-color: lightblue;
+            border-radius: calc(2 * 10px);
+            border: 2px solid black;
+        }
+    </style>
+</head>
+<body>
+
+<div class="box"></div>
+
+</body>
+</html>

--- a/Tests/LibWeb/Ref/reference/calc-border-radius-ref.html
+++ b/Tests/LibWeb/Ref/reference/calc-border-radius-ref.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        .box {
+            width: 200px;
+            height: 200px;
+            background-color: lightblue;
+            border-radius: 20px;
+            border: 2px solid black;
+        }
+    </style>
+</head>
+<body>
+
+<div class="box"></div>
+
+</body>
+</html>

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/BorderRadiusStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/BorderRadiusStyleValue.cpp
@@ -24,9 +24,9 @@ ValueComparingNonnullRefPtr<StyleValue const> BorderRadiusStyleValue::absolutize
         return *this;
     auto absolutized_horizontal_radius = m_properties.horizontal_radius;
     auto absolutized_vertical_radius = m_properties.vertical_radius;
-    if (!m_properties.horizontal_radius.is_percentage())
+    if (m_properties.horizontal_radius.is_length())
         absolutized_horizontal_radius = m_properties.horizontal_radius.length().absolutized(viewport_rect, font_metrics, root_font_metrics);
-    if (!m_properties.vertical_radius.is_percentage())
+    if (m_properties.vertical_radius.is_length())
         absolutized_vertical_radius = m_properties.vertical_radius.length().absolutized(viewport_rect, font_metrics, root_font_metrics);
     return BorderRadiusStyleValue::create(absolutized_horizontal_radius, absolutized_vertical_radius);
 }


### PR DESCRIPTION
`BorderRadiusStyleValue::absolutized` should not try to extract length from LengthPercentage that represents calculated.