### PR TITLE
Ladybird+LibWebView: Cleanup missing callbacks in InspectorClient

### DIFF
--- a/Userland/Libraries/LibWebView/InspectorClient.cpp
+++ b/Userland/Libraries/LibWebView/InspectorClient.cpp
@@ -173,10 +173,14 @@ InspectorClient::InspectorClient(ViewImplementation& content_web_view, ViewImple
 
 InspectorClient::~InspectorClient()
 {
-    m_content_web_view.on_received_dom_tree = nullptr;
+    m_content_web_view.on_finshed_editing_dom_node = nullptr;
     m_content_web_view.on_received_accessibility_tree = nullptr;
     m_content_web_view.on_received_console_message = nullptr;
     m_content_web_view.on_received_console_messages = nullptr;
+    m_content_web_view.on_received_dom_node_html = nullptr;
+    m_content_web_view.on_received_dom_node_properties = nullptr;
+    m_content_web_view.on_received_dom_tree = nullptr;
+    m_content_web_view.on_received_hovered_node_id = nullptr;
 }
 
 void InspectorClient::inspect()


### PR DESCRIPTION
This was causing reproducible crashes, when closing the inspector window of ladybird running on macos.

````bash
* thread #1, queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=1, address=0xc98)
    frame #0: 0x00000001013f9c4c liblagom-webview.0.dylib`::run_javascript() [inlined] operator! at RefPtr.h:226:38 [opt]
   223          unref_if_not_null(ptr);
   224      }
   225
-> 226      bool operator!() const { return !m_ptr; }
   227
   228      [[nodiscard]] T* leak_ref()
   229      {
Target 0: (Ladybird) stopped.
warning: liblagom-webview.0.dylib was compiled with optimization - stepping may behave oddly; variables may not be available.
(lldb) bt
* thread #1, queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=1, address=0xc98)
  * frame #0: 0x00000001013f9c4c liblagom-webview.0.dylib`::run_javascript() [inlined] operator! at RefPtr.h:226:38 [opt]
    frame #1: 0x00000001013f9c4c liblagom-webview.0.dylib`::run_javascript() [inlined] client at ViewImplementation.cpp:41:5 [opt]
    frame #2: 0x00000001013f9c4c liblagom-webview.0.dylib`::run_javascript() at ViewImplementation.cpp:206:5 [opt]
    frame #3: 0x00000001013ee8dc liblagom-webview.0.dylib`::call() [inlined] operator()<AK::Optional<WebView::ViewImplementation::DOMNodeProperties> > at InspectorClient.cpp:75:30 [opt]
    frame #4: 0x00000001013ee72c liblagom-webview.0.dylib`::call() at Function.h:182:20 [opt]
    frame #5: 0x0000000101404dc4 liblagom-webview.0.dylib`::operator()() at Function.h:115:25 [opt]
    frame #6: 0x0000000101404bac liblagom-webview.0.dylib`::did_inspect_dom_node() at WebContentClient.cpp:207:5 [opt]
    frame #7: 0x0000000101408b50 liblagom-webview.0.dylib`::handle() at WebContentClientEndpoint.h:5711:13 [opt]
    frame #8: 0x000000010132d164 liblagom-ipc.0.dylib`::handle_messages() at Connection.cpp:130:48 [opt]
    frame #9: 0x000000010140b3d0 liblagom-webview.0.dylib`::call() [inlined] operator() at Connection.h:95:13 [opt]
    frame #10: 0x000000010140b398 liblagom-webview.0.dylib`::call() at Function.h:182:20 [opt]
    frame #11: 0x0000000101654e2c liblagom-core.0.dylib`::operator()() at Function.h:115:25 [opt]
    frame #12: 0x0000000101654e2c liblagom-core.0.dylib`::operator()() at Function.h:115:25 [opt]
    frame #13: 0x000000010165430c liblagom-core.0.dylib`::dispatch_event() at EventReceiver.cpp:163:17 [opt]
    frame #14: 0x0000000100d80d1c Ladybird`socket_notifier at EventLoopImplementation.mm:110:14 [opt]
    frame #15: 0x000000018820ed00 CoreFoundation`__CFSocketPerformV0 + 928
    frame #16: 0x00000001881e3a4c CoreFoundation`__CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 28
    frame #17: 0x00000001881e39e0 CoreFoundation`__CFRunLoopDoSource0 + 176
    frame #18: 0x00000001881e3750 CoreFoundation`__CFRunLoopDoSources0 + 244
    frame #19: 0x00000001881e2340 CoreFoundation`__CFRunLoopRun + 828
    frame #20: 0x00000001881e19ac CoreFoundation`CFRunLoopRunSpecific + 608
    frame #21: 0x0000000192790448 HIToolbox`RunCurrentEventLoopInMode + 292
    frame #22: 0x00000001927900d8 HIToolbox`ReceiveNextEventCommon + 220
    frame #23: 0x000000019278ffdc HIToolbox`_BlockUntilNextEventMatchingListInModeWithFilter + 76
    frame #24: 0x000000018b9be8a4 AppKit`_DPSNextEvent + 660
    frame #25: 0x000000018c198980 AppKit`-[NSApplication(NSEventRouting) _nextEventMatchingEventMask:untilDate:inMode:dequeue:] + 716
    frame #26: 0x000000018b9b1d50 AppKit`-[NSApplication run] + 476
    frame #27: 0x0000000100d80fac Ladybird`exec at EventLoopImplementation.mm:169:5 [opt]
    frame #28: 0x000000010164d3b0 liblagom-core.0.dylib`::exec() at EventLoop.cpp:86:20 [opt]
    frame #29: 0x0000000100d7bb4c Ladybird`serenity_main at main.mm:85:23 [opt]
    frame #30: 0x0000000100d9fa08 Ladybird`main at Main.cpp:39:19 [opt]
    frame #31: 0x0000000187d850e0 dyld`start + 2360
````