### PR TITLE
LibWeb: Paint 1x1 backgrounds as color fill instead of tiling bitmap

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/StyleValues/AbstractImageStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/AbstractImageStyleValue.h
@@ -37,6 +37,8 @@ public:
 
     virtual bool is_paintable() const = 0;
     virtual void paint(PaintContext& context, DevicePixelRect const& dest_rect, ImageRendering) const = 0;
+
+    virtual Optional<Gfx::Color> color_if_single_pixel_bitmap() const { return {}; }
 };
 
 // And now, some gradient related things. Maybe these should live somewhere else.

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.cpp
@@ -146,4 +146,13 @@ JS::GCPtr<HTML::DecodedImageData> ImageStyleValue::image_data() const
     return m_image_request->image_data();
 }
 
+Optional<Gfx::Color> ImageStyleValue::color_if_single_pixel_bitmap() const
+{
+    if (auto const* b = bitmap(m_current_frame_index)) {
+        if (b->width() == 1 && b->height() == 1)
+            return b->bitmap().get_pixel(0, 0);
+    }
+    return {};
+}
+
 }

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.h
@@ -47,6 +47,8 @@ public:
     virtual bool is_paintable() const override;
     void paint(PaintContext& context, DevicePixelRect const& dest_rect, CSS::ImageRendering image_rendering) const override;
 
+    virtual Optional<Gfx::Color> color_if_single_pixel_bitmap() const override;
+
     Function<void()> on_animate;
 
     JS::GCPtr<HTML::DecodedImageData> image_data() const;


### PR DESCRIPTION
This yields a huge speedup on pages that use this weird but not-entirely-uncommon technique.


https://github.com/SerenityOS/serenity/assets/5954907/a72bbbb2-3878-4a54-a940-4491088bc63a

