### PR TITLE
LibHTTP: Disable notifications on the underlying socket when shut down

### DIFF
--- a/Userland/Libraries/LibHTTP/Job.cpp
+++ b/Userland/Libraries/LibHTTP/Job.cpp
@@ -111,6 +111,8 @@ void Job::shutdown(ShutdownMode mode)
 {
     if (!m_socket)
         return;
+
+    m_socket->set_notifications_enabled(false);
     if (mode == ShutdownMode::CloseSocket) {
         m_socket->close();
         m_socket->on_ready_to_read = nullptr;


### PR DESCRIPTION
Fixes #22427.