### PR TITLE
Meta/gn: Build WebContent Qt bits only if enable_qt is set

### DIFF
--- a/Meta/gn/secondary/Ladybird/BUILD.gn
+++ b/Meta/gn/secondary/Ladybird/BUILD.gn
@@ -1,11 +1,7 @@
 import("//Ladybird/compile_qt_resource_file.gni")
+import("//Ladybird/enable_qt.gni")
 import("//Ladybird/link_qt.gni")
 import("//Ladybird/moc_qt_objects.gni")
-
-declare_args() {
-  # Build the Ladybird application using the Qt chrome.
-  enable_qt = current_os != "mac"
-}
 
 group("Ladybird") {
   if (current_os == "mac") {

--- a/Meta/gn/secondary/Ladybird/WebContent/BUILD.gn
+++ b/Meta/gn/secondary/Ladybird/WebContent/BUILD.gn
@@ -1,3 +1,4 @@
+import("//Ladybird/enable_qt.gni")
 import("//Ladybird/link_qt.gni")
 import("//Ladybird/moc_qt_objects.gni")
 import("//Meta/gn/build/libs/pulse/enable.gni")
@@ -20,16 +21,12 @@ link_qt("WebContent_qt") {
 }
 
 executable("WebContent") {
-  configs += [
-    "//Ladybird:ladybird_config",
-    ":WebContent_qt",
-  ]
+  configs += [ "//Ladybird:ladybird_config" ]
   include_dirs = [
     "//Userland/Services",
     "//Ladybird",
   ]
   deps = [
-    ":generate_moc",
     "//AK",
     "//Meta/gn/build/libs/pulse",
     "//Userland/Libraries/LibCore",
@@ -52,15 +49,6 @@ executable("WebContent") {
     "//Ladybird/FontPlugin.cpp",
     "//Ladybird/HelperProcess.cpp",
     "//Ladybird/ImageCodecPlugin.cpp",
-    "//Ladybird/Qt/AudioCodecPluginQt.cpp",
-    "//Ladybird/Qt/AudioThread.cpp",
-    "//Ladybird/Qt/EventLoopImplementationQt.cpp",
-    "//Ladybird/Qt/EventLoopImplementationQtEventTarget.cpp",
-    "//Ladybird/Qt/RequestManagerQt.cpp",
-    "//Ladybird/Qt/StringUtils.cpp",
-    "//Ladybird/Qt/WebSocketClientManagerQt.cpp",
-    "//Ladybird/Qt/WebSocketImplQt.cpp",
-    "//Ladybird/Qt/WebSocketQt.cpp",
     "//Ladybird/Utilities.cpp",
     "//Userland/Services/WebContent/ConnectionFromClient.cpp",
     "//Userland/Services/WebContent/ConsoleGlobalEnvironmentExtensions.cpp",
@@ -70,7 +58,24 @@ executable("WebContent") {
     "//Userland/Services/WebContent/WebDriverConnection.cpp",
     "main.cpp",
   ]
-  sources += get_target_outputs(":generate_moc")
+
+  if (enable_qt) {
+    configs += [ ":WebContent_qt" ]
+    sources += [
+      "//Ladybird/Qt/AudioCodecPluginQt.cpp",
+      "//Ladybird/Qt/AudioThread.cpp",
+      "//Ladybird/Qt/EventLoopImplementationQt.cpp",
+      "//Ladybird/Qt/EventLoopImplementationQtEventTarget.cpp",
+      "//Ladybird/Qt/RequestManagerQt.cpp",
+      "//Ladybird/Qt/StringUtils.cpp",
+      "//Ladybird/Qt/WebSocketClientManagerQt.cpp",
+      "//Ladybird/Qt/WebSocketImplQt.cpp",
+      "//Ladybird/Qt/WebSocketQt.cpp",
+    ]
+
+    sources += get_target_outputs(":generate_moc")
+    deps += [ ":generate_moc" ]
+  }
 
   if (current_os == "linux" || current_os == "mac") {
     cflags_cc = [ "-DHAS_ACCELERATED_GRAPHICS" ]

--- a/Meta/gn/secondary/Ladybird/enable_qt.gni
+++ b/Meta/gn/secondary/Ladybird/enable_qt.gni
@@ -1,0 +1,4 @@
+declare_args() {
+  # Build the Ladybird application using the Qt chrome.
+  enable_qt = current_os != "mac"
+}

--- a/Meta/gn/secondary/Userland/Libraries/LibCompress/BUILD.gn
+++ b/Meta/gn/secondary/Userland/Libraries/LibCompress/BUILD.gn
@@ -8,6 +8,7 @@ shared_library("LibCompress") {
     "Gzip.cpp",
     "Lzma.cpp",
     "Lzma2.cpp",
+    "PackBitsDecoder.cpp",
     "Xz.cpp",
     "Zlib.cpp",
   ]

--- a/Meta/gn/secondary/Userland/Libraries/LibGfx/BUILD.gn
+++ b/Meta/gn/secondary/Userland/Libraries/LibGfx/BUILD.gn
@@ -51,6 +51,7 @@ shared_library("LibGfx") {
     "Font/OpenType/Tables.cpp",
     "Font/ScaledFont.cpp",
     "Font/Typeface.cpp",
+    "Font/VectorFont.cpp",
     "Font/WOFF/Font.cpp",
     "Font/WOFF2/Font.cpp",
     "FontCascadeList.cpp",


### PR DESCRIPTION
With this, it's possible to build Ladybird without having Qt installed.
(Previously, the build required `moc` to exist.)

In fact, it's possible to build Ladybird without anything off `brew`
as long as you have `ninja` and `gn` (both of which don't have any
dependencies themselves and are easy to build).