### PR TITLE
LibWebView: Properly decode Base64-encoded strings as UTF-8

### DIFF
--- a/Base/res/ladybird/inspector.js
+++ b/Base/res/ladybird/inspector.js
@@ -13,6 +13,10 @@ let consoleGroupNextID = 0;
 let consoleHistory = [];
 let consoleHistoryIndex = 0;
 
+const decodeBase64 = encoded => {
+    return new TextDecoder().decode(Uint8Array.from(atob(encoded), c => c.charCodeAt(0)));
+};
+
 const beginSplitViewDrag = () => {
     let inspectorTop = document.getElementById("inspector-top");
     let inspectorBottom = document.getElementById("inspector-bottom");
@@ -100,7 +104,7 @@ inspector.reset = () => {
 
 inspector.loadDOMTree = tree => {
     let domTree = document.getElementById("dom-tree");
-    domTree.innerHTML = atob(tree);
+    domTree.innerHTML = decodeBase64(tree);
 
     let domNodes = domTree.querySelectorAll(".hoverable");
 
@@ -123,7 +127,7 @@ inspector.loadDOMTree = tree => {
 
 inspector.loadAccessibilityTree = tree => {
     let accessibilityTree = document.getElementById("accessibility-tree");
-    accessibilityTree.innerHTML = atob(tree);
+    accessibilityTree.innerHTML = decodeBase64(tree);
 };
 
 inspector.inspectDOMNodeID = nodeID => {
@@ -450,7 +454,7 @@ inspector.appendConsoleOutput = output => {
     let parent = consoleParentGroup();
 
     let element = document.createElement("p");
-    element.innerHTML = atob(output);
+    element.innerHTML = decodeBase64(output);
 
     parent.appendChild(element);
     scrollConsoleToBottom();
@@ -477,7 +481,7 @@ inspector.beginConsoleGroup = (label, startExpanded) => {
     details.open = startExpanded;
 
     let summary = document.createElement("summary");
-    summary.innerHTML = atob(label);
+    summary.innerHTML = decodeBase64(label);
 
     details.appendChild(summary);
     parent.appendChild(details);


### PR DESCRIPTION
In the UI process, we encode generated HTML as Base64 to avoid having to deal with things like arbitrarily nested quotes. The HTML is encoded as UTF-8, and the raw bytes of that encoding are transcoded to Base64.

In the Inspector process, we are decoding the Base64 string using `atob`, which has awkward non-Unicode limitations. The resulting string is only a byte string. We must further decode the bytes as UTF-8, which we do using `TextDecoder`.

Fixes #22536 

Before:
![Screenshot_20240102_123322](https://github.com/SerenityOS/serenity/assets/5600524/9ce33e68-72c1-4165-99aa-68359d380639)


After:
![Screenshot_20240102_123201](https://github.com/SerenityOS/serenity/assets/5600524/b35c2866-4672-4318-bd93-7735f6545945)

