### PR TITLE
LibIPC+LibWeb: Avoid redundant copy of every tranferred IPC message

### DIFF
--- a/Meta/gn/secondary/Userland/Libraries/LibIPC/BUILD.gn
+++ b/Meta/gn/secondary/Userland/Libraries/LibIPC/BUILD.gn
@@ -13,6 +13,7 @@ shared_library("LibIPC") {
     "Encoder.h",
     "File.h",
     "Forward.h",
+    "Message.cpp",
     "Message.h",
     "MultiServer.h",
     "SingleServer.h",

--- a/Userland/Libraries/LibIPC/CMakeLists.txt
+++ b/Userland/Libraries/LibIPC/CMakeLists.txt
@@ -2,6 +2,7 @@ set(SOURCES
     Connection.cpp
     Decoder.cpp
     Encoder.cpp
+    Message.cpp
 )
 
 serenity_lib(LibIPC ipc)

--- a/Userland/Libraries/LibIPC/Connection.cpp
+++ b/Userland/Libraries/LibIPC/Connection.cpp
@@ -8,7 +8,6 @@
 #include <LibCore/System.h>
 #include <LibIPC/Connection.h>
 #include <LibIPC/Stub.h>
-#include <sched.h>
 #include <sys/select.h>
 
 namespace IPC {
@@ -60,50 +59,9 @@ ErrorOr<void> ConnectionBase::post_message(MessageBuffer buffer)
     if (!m_socket->is_open())
         return Error::from_string_literal("Trying to post_message during IPC shutdown");
 
-    // Prepend the message size.
-    uint32_t message_size = buffer.data.size();
-    TRY(buffer.data.try_prepend(reinterpret_cast<u8 const*>(&message_size), sizeof(message_size)));
-
-    for (auto& fd : buffer.fds) {
-        if (auto result = fd_passing_socket().send_fd(fd->value()); result.is_error()) {
-            shutdown_with_error(result.error());
-            return result;
-        }
-    }
-
-    ReadonlyBytes bytes_to_write { buffer.data.span() };
-    int writes_done = 0;
-    size_t initial_size = bytes_to_write.size();
-    while (!bytes_to_write.is_empty()) {
-        auto maybe_nwritten = m_socket->write_some(bytes_to_write);
-        writes_done++;
-        if (maybe_nwritten.is_error()) {
-            auto error = maybe_nwritten.release_error();
-            if (error.is_errno()) {
-                // FIXME: This is a hacky way to at least not crash on large messages
-                // The limit of 100 writes is arbitrary, and there to prevent indefinite spinning on the EventLoop
-                if (error.code() == EAGAIN && writes_done < 100) {
-                    sched_yield();
-                    continue;
-                }
-                shutdown_with_error(error);
-                switch (error.code()) {
-                case EPIPE:
-                    return Error::from_string_literal("IPC::Connection::post_message: Disconnected from peer");
-                case EAGAIN:
-                    return Error::from_string_literal("IPC::Connection::post_message: Peer buffer overflowed");
-                default:
-                    return Error::from_syscall("IPC::Connection::post_message write"sv, -error.code());
-                }
-            } else {
-                return error;
-            }
-        }
-
-        bytes_to_write = bytes_to_write.slice(maybe_nwritten.value());
-    }
-    if (writes_done > 1) {
-        dbgln("LibIPC::Connection FIXME Warning, needed {} writes needed to send message of size {}B, this is pretty bad, as it spins on the EventLoop", writes_done, initial_size);
+    if (auto result = buffer.transfer_message(fd_passing_socket(), *m_socket); result.is_error()) {
+        shutdown_with_error(result.error());
+        return result.release_error();
     }
 
     m_responsiveness_timer->start();

--- a/Userland/Libraries/LibIPC/Encoder.h
+++ b/Userland/Libraries/LibIPC/Encoder.h
@@ -40,11 +40,6 @@ public:
         return m_buffer.data.try_ensure_capacity(m_buffer.data.size() + capacity);
     }
 
-    void append(u8 value)
-    {
-        m_buffer.data.unchecked_append(value);
-    }
-
     ErrorOr<void> append(u8 const* values, size_t count)
     {
         TRY(extend_capacity(count));
@@ -67,31 +62,7 @@ private:
 template<Arithmetic T>
 ErrorOr<void> encode(Encoder& encoder, T const& value)
 {
-    TRY(encoder.extend_capacity(sizeof(T)));
-
-    if constexpr (sizeof(T) == 1) {
-        encoder.append(static_cast<u8>(value));
-    } else if constexpr (sizeof(T) == 2) {
-        encoder.append(static_cast<u8>(value));
-        encoder.append(static_cast<u8>(value >> 8));
-    } else if constexpr (sizeof(T) == 4) {
-        encoder.append(static_cast<u8>(value));
-        encoder.append(static_cast<u8>(value >> 8));
-        encoder.append(static_cast<u8>(value >> 16));
-        encoder.append(static_cast<u8>(value >> 24));
-    } else if constexpr (sizeof(T) == 8) {
-        encoder.append(static_cast<u8>(value));
-        encoder.append(static_cast<u8>(value >> 8));
-        encoder.append(static_cast<u8>(value >> 16));
-        encoder.append(static_cast<u8>(value >> 24));
-        encoder.append(static_cast<u8>(value >> 32));
-        encoder.append(static_cast<u8>(value >> 40));
-        encoder.append(static_cast<u8>(value >> 48));
-        encoder.append(static_cast<u8>(value >> 56));
-    } else {
-        static_assert(DependentFalse<T>);
-    }
-
+    TRY(encoder.append(reinterpret_cast<u8 const*>(&value), sizeof(value)));
     return {};
 }
 

--- a/Userland/Libraries/LibIPC/Encoder.h
+++ b/Userland/Libraries/LibIPC/Encoder.h
@@ -37,20 +37,20 @@ public:
 
     ErrorOr<void> extend_capacity(size_t capacity)
     {
-        return m_buffer.data.try_ensure_capacity(m_buffer.data.size() + capacity);
+        TRY(m_buffer.extend_data_capacity(capacity));
+        return {};
     }
 
     ErrorOr<void> append(u8 const* values, size_t count)
     {
-        TRY(extend_capacity(count));
-        m_buffer.data.unchecked_append(values, count);
+        TRY(m_buffer.append_data(values, count));
         return {};
     }
 
     ErrorOr<void> append_file_descriptor(int fd)
     {
-        auto auto_fd = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) AutoCloseFileDescriptor(fd)));
-        return m_buffer.fds.try_append(move(auto_fd));
+        TRY(m_buffer.append_file_descriptor(fd));
+        return {};
     }
 
     ErrorOr<void> encode_size(size_t size);

--- a/Userland/Libraries/LibIPC/Forward.h
+++ b/Userland/Libraries/LibIPC/Forward.h
@@ -13,7 +13,7 @@ namespace IPC {
 class Decoder;
 class Encoder;
 class Message;
-struct MessageBuffer;
+class MessageBuffer;
 class File;
 class Stub;
 

--- a/Userland/Libraries/LibIPC/Forward.h
+++ b/Userland/Libraries/LibIPC/Forward.h
@@ -13,6 +13,7 @@ namespace IPC {
 class Decoder;
 class Encoder;
 class Message;
+struct MessageBuffer;
 class File;
 class Stub;
 

--- a/Userland/Libraries/LibIPC/Message.cpp
+++ b/Userland/Libraries/LibIPC/Message.cpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2024, Tim Flynn <trflynn89@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibCore/Socket.h>
+#include <LibIPC/Message.h>
+#include <sched.h>
+
+namespace IPC {
+
+using MessageSizeType = u32;
+
+ErrorOr<void> MessageBuffer::transfer_message(Core::LocalSocket& fd_passing_socket, Core::LocalSocket& data_socket)
+{
+    MessageSizeType message_size = data.size();
+    TRY(data.try_prepend(reinterpret_cast<u8 const*>(&message_size), sizeof(message_size)));
+
+    for (auto const& fd : fds)
+        TRY(fd_passing_socket.send_fd(fd->value()));
+
+    ReadonlyBytes bytes_to_write { data.span() };
+    size_t writes_done = 0;
+
+    while (!bytes_to_write.is_empty()) {
+        auto maybe_nwritten = data_socket.write_some(bytes_to_write);
+        ++writes_done;
+
+        if (maybe_nwritten.is_error()) {
+            if (auto error = maybe_nwritten.release_error(); error.is_errno()) {
+                // FIXME: This is a hacky way to at least not crash on large messages
+                // The limit of 100 writes is arbitrary, and there to prevent indefinite spinning on the EventLoop
+                if (error.code() == EAGAIN && writes_done < 100) {
+                    sched_yield();
+                    continue;
+                }
+
+                switch (error.code()) {
+                case EPIPE:
+                    return Error::from_string_literal("IPC::transfer_message: Disconnected from peer");
+                case EAGAIN:
+                    return Error::from_string_literal("IPC::transfer_message: Peer buffer overflowed");
+                default:
+                    return Error::from_syscall("IPC::transfer_message write"sv, -error.code());
+                }
+            } else {
+                return error;
+            }
+        }
+
+        bytes_to_write = bytes_to_write.slice(maybe_nwritten.value());
+    }
+
+    if (writes_done > 1) {
+        dbgln("LibIPC::transfer_message FIXME Warning, needed {} writes needed to send message of size {}B, this is pretty bad, as it spins on the EventLoop", writes_done, data.size());
+    }
+
+    return {};
+}
+
+}

--- a/Userland/Libraries/LibIPC/Message.h
+++ b/Userland/Libraries/LibIPC/Message.h
@@ -10,6 +10,8 @@
 #include <AK/Error.h>
 #include <AK/RefCounted.h>
 #include <AK/RefPtr.h>
+#include <AK/Vector.h>
+#include <LibCore/Forward.h>
 #include <unistd.h>
 
 namespace IPC {
@@ -34,6 +36,8 @@ private:
 };
 
 struct MessageBuffer {
+    ErrorOr<void> transfer_message(Core::LocalSocket& fd_passing_socket, Core::LocalSocket& data_socket);
+
     Vector<u8, 1024> data;
     Vector<NonnullRefPtr<AutoCloseFileDescriptor>, 1> fds;
 };

--- a/Userland/Libraries/LibIPC/Message.h
+++ b/Userland/Libraries/LibIPC/Message.h
@@ -35,11 +35,20 @@ private:
     int m_fd;
 };
 
-struct MessageBuffer {
+class MessageBuffer {
+public:
+    MessageBuffer();
+
+    ErrorOr<void> extend_data_capacity(size_t capacity);
+    ErrorOr<void> append_data(u8 const* values, size_t count);
+
+    ErrorOr<void> append_file_descriptor(int fd);
+
     ErrorOr<void> transfer_message(Core::LocalSocket& fd_passing_socket, Core::LocalSocket& data_socket);
 
-    Vector<u8, 1024> data;
-    Vector<NonnullRefPtr<AutoCloseFileDescriptor>, 1> fds;
+private:
+    Vector<u8, 1024> m_data;
+    Vector<NonnullRefPtr<AutoCloseFileDescriptor>, 1> m_fds;
 };
 
 enum class ErrorCode : u32 {

--- a/Userland/Libraries/LibIPC/Stub.h
+++ b/Userland/Libraries/LibIPC/Stub.h
@@ -9,15 +9,13 @@
 
 #include <AK/ByteString.h>
 #include <AK/OwnPtr.h>
+#include <LibIPC/Forward.h>
 
 namespace AK {
 class BufferStream;
 }
 
 namespace IPC {
-
-class Message;
-struct MessageBuffer;
 
 class Stub {
 public:


### PR DESCRIPTION
For every IPC message sent, we currently prepend the message size to the IPC message buffer. This incurs the cost of copying the entire message to its newly allocated position. Instead, reserve the bytes for the size at the front of the buffer upon creation. Prevent dangerous access to the buffer with specific public methods.

Further, the actual transfer of the message is moved to a helper method. This removes copy-pasted duplication in LibWeb's MessagePort, and also ensures callers can't forget to set the buffer size before transfer.

Fixes #22358