### PR TITLE
LibGfx: Speed up filling solid color paths a little (and some misc changes)

### DIFF
--- a/Userland/Libraries/LibGfx/EdgeFlagPathRasterizer.cpp
+++ b/Userland/Libraries/LibGfx/EdgeFlagPathRasterizer.cpp
@@ -15,19 +15,8 @@
 #    pragma GCC optimize("O3")
 #endif
 
-// This a pretty naive implementation of edge-flag scanline AA.
-// The paper lists many possible optimizations, maybe implement one? (FIXME!)
+// This an implementation of edge-flag scanline AA, as described in:
 // https://mlab.taik.fi/~kkallio/antialiasing/EdgeFlagAA.pdf
-// This currently implements:
-//      - The scanline buffer optimization (only allocate one scanline)
-// Possible other optimizations according to the paper:
-//      - Using fixed point numbers
-//      - Edge tracking
-//      - Mask tracking
-//      - Loop unrolling (compilers might handle this better now, the paper is from 2007)
-// Optimizations I think we could add:
-//      - Using fast_u32_fills() for runs of solid colors
-//      - Clipping the plotted edges earlier
 
 namespace Gfx {
 

--- a/Userland/Libraries/LibGfx/EdgeFlagPathRasterizer.cpp
+++ b/Userland/Libraries/LibGfx/EdgeFlagPathRasterizer.cpp
@@ -322,11 +322,9 @@ void EdgeFlagPathRasterizer<SamplesPerPixel>::accumulate_non_zero_scanline(EdgeE
                     auto winding = m_windings[x].counts[y_sub];
                     auto previous_winding_count = sum_winding.counts[y_sub];
                     sum_winding.counts[y_sub] += winding;
-                    // Toggle fill on change to/from zero
-                    if ((previous_winding_count == 0 && sum_winding.counts[y_sub] != 0)
-                        || (sum_winding.counts[y_sub] == 0 && previous_winding_count != 0)) {
+                    // Toggle fill on change to/from zero.
+                    if (bool(previous_winding_count) ^ bool(sum_winding.counts[y_sub]))
                         sample ^= subpixel_bit;
-                    }
                 }
             }
         }

--- a/Userland/Libraries/LibGfx/EdgeFlagPathRasterizer.cpp
+++ b/Userland/Libraries/LibGfx/EdgeFlagPathRasterizer.cpp
@@ -70,16 +70,19 @@ static Vector<Detail::Edge> prepare_edges(ReadonlySpan<FloatLine> lines, unsigne
         if (max_y < top_clip)
             continue;
 
-        float start_x = p0.x();
-        float end_x = p1.x();
-
+        auto start_x = p0.x();
+        auto end_x = p1.x();
         auto dx = end_x - start_x;
         auto dy = max_y - min_y;
+
+        if (dy == 0)
+            continue;
+
         auto dxdy = dx / dy;
 
         // Trim off the non-visible portions of the edge.
         if (min_y < top_clip) {
-            start_x += (top_clip - min_y) * dxdy;
+            start_x += dxdy * (top_clip - min_y);
             min_y = top_clip;
         }
         if (max_y > bottom_clip) {

--- a/Userland/Libraries/LibGfx/EdgeFlagPathRasterizer.cpp
+++ b/Userland/Libraries/LibGfx/EdgeFlagPathRasterizer.cpp
@@ -262,7 +262,7 @@ Detail::Edge* EdgeFlagPathRasterizer<SamplesPerPixel>::plot_edges_for_scanline(i
             else
                 active_edges = current_edge;
         } else {
-            // This egde sticks around for a few more scanlines.
+            // This edge sticks around for a few more scanlines.
             plot_edge(*current_edge, 0, SamplesPerPixel, edge_extent);
             prev_edge = current_edge;
             current_edge = current_edge->next_edge;

--- a/Userland/Libraries/LibGfx/EdgeFlagPathRasterizer.h
+++ b/Userland/Libraries/LibGfx/EdgeFlagPathRasterizer.h
@@ -167,10 +167,17 @@ private:
 
     void fill_internal(Painter&, Path const&, auto color_or_function, Painter::WindingRule, FloatPoint offset);
     Detail::Edge* plot_edges_for_scanline(int scanline, auto plot_edge, EdgeExtent&, Detail::Edge* active_edges = nullptr);
-    void accumulate_even_odd_scanline(Painter&, int scanline, EdgeExtent, auto& color_or_function);
-    void accumulate_non_zero_scanline(Painter&, int scanline, EdgeExtent, auto& color_or_function);
+
+    template<Painter::WindingRule>
+    void write_scanline(Painter&, int scanline, EdgeExtent, auto& color_or_function);
     Color scanline_color(int scanline, int offset, u8 alpha, auto& color_or_function);
     void write_pixel(Painter&, int scanline, int offset, SampleType sample, auto& color_or_function);
+    void fast_fill_solid_color_span(Painter&, int scanline, int start, int end, Color color);
+
+    template<Painter::WindingRule, typename Callback>
+    void accumulate_scanline(EdgeExtent, Callback);
+    void accumulate_even_odd_scanline(EdgeExtent, auto sample_callback);
+    void accumulate_non_zero_scanline(EdgeExtent, auto sample_callback);
 
     struct WindingCounts {
         // NOTE: This only allows up to 256 winding levels. Increase this if required (i.e. to an i16).


### PR DESCRIPTION
![ezgif com-optimize](https://github.com/SerenityOS/serenity/assets/11597044/766664e7-bd97-42cb-9ab8-4a6c5d0b60bc)

The main change here is making use of `fast_u32_fill()` within the rasterizer for solid colors, which brought the above fullscreen (in SerenityOS) demo from 15 fps to around 25 (note the fps dropped to 22 while recording). 

Note: That there's quite a bit outside just the rasterizer that's a little slow here. Each rotation copies the path and invalidates the line segments, so that all gets regenerated. There's also uses of strokes that generate a new path per-frame. There's probably some low hanging fruit still.