### PR TITLE
LibPDF: Scan for PDF file start in first 1024 bytes

### DIFF
--- a/Userland/Libraries/LibPDF/Document.cpp
+++ b/Userland/Libraries/LibPDF/Document.cpp
@@ -97,6 +97,12 @@ ByteString Document::text_string_to_utf8(ByteString const& text_string)
 
 PDFErrorOr<NonnullRefPtr<Document>> Document::create(ReadonlyBytes bytes)
 {
+    size_t offset_to_start = TRY(DocumentParser::scan_for_header_start(bytes));
+    if (offset_to_start != 0) {
+        dbgln("warning: PDF header not at start of file, skipping {} bytes", offset_to_start);
+        bytes = bytes.slice(offset_to_start);
+    }
+
     auto parser = adopt_ref(*new DocumentParser({}, bytes));
     auto document = adopt_ref(*new Document(parser));
 

--- a/Userland/Libraries/LibPDF/DocumentParser.h
+++ b/Userland/Libraries/LibPDF/DocumentParser.h
@@ -18,6 +18,8 @@ struct Version {
 class DocumentParser final : public RefCounted<DocumentParser>
     , public Parser {
 public:
+    static PDFErrorOr<size_t> scan_for_header_start(ReadonlyBytes);
+
     DocumentParser(Document*, ReadonlyBytes);
 
     enum class LinearizationResult {


### PR DESCRIPTION
Other readers do this too, and files depend on this.

Fixes opening these four files from the PDFA 0000.zip dataset:

* 0000015.pdf Starts with `C:\web\webeuncet\_cat\_docs\_publics\` before header
* 0000408.pdf Starts with UTF-8 BOM
* 0000524.pdf Starts with 867 bytes of HTML containing a PHP backtrace
* 0000680.pdf Starts with `C:\web\webeuncet\_cat\_docs\_publics\` too

---

I've had this sitting in a local branch for 2.5 months now since it's kinda gross, but being able to open these files makes up for it. Right? Riiight???