### PR TITLE
LibWeb: Stop timers when finalizing a Window or WorkerGlobalScope

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/Window.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Window.cpp
@@ -130,6 +130,12 @@ void Window::visit_edges(JS::Cell::Visitor& visitor)
     visitor.visit(m_byte_length_queuing_strategy_size_function);
 }
 
+void Window::finalize()
+{
+    Base::finalize();
+    WindowOrWorkerGlobalScopeMixin::finalize();
+}
+
 Window::~Window() = default;
 
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#normalizing-the-feature-name

--- a/Userland/Libraries/LibWeb/HTML/Window.h
+++ b/Userland/Libraries/LibWeb/HTML/Window.h
@@ -210,6 +210,7 @@ private:
     explicit Window(JS::Realm&);
 
     virtual void visit_edges(Cell::Visitor&) override;
+    virtual void finalize() override;
 
     // ^HTML::GlobalEventHandlers
     virtual DOM::EventTarget& global_event_handlers_to_event_target(FlyString const&) override { return *this; }

--- a/Userland/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.cpp
+++ b/Userland/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.cpp
@@ -64,6 +64,11 @@ void WindowOrWorkerGlobalScopeMixin::visit_edges(JS::Cell::Visitor& visitor)
         entry.value.visit_edges(visitor);
 }
 
+void WindowOrWorkerGlobalScopeMixin::finalize()
+{
+    clear_map_of_active_timers();
+}
+
 // https://html.spec.whatwg.org/multipage/webappapis.html#dom-origin
 WebIDL::ExceptionOr<String> WindowOrWorkerGlobalScopeMixin::origin() const
 {

--- a/Userland/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.h
+++ b/Userland/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.h
@@ -64,6 +64,7 @@ public:
 protected:
     void initialize(JS::Realm&);
     void visit_edges(JS::Cell::Visitor&);
+    void finalize();
 
 private:
     enum class Repeat {

--- a/Userland/Libraries/LibWeb/HTML/WorkerGlobalScope.cpp
+++ b/Userland/Libraries/LibWeb/HTML/WorkerGlobalScope.cpp
@@ -55,6 +55,12 @@ void WorkerGlobalScope::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_page);
 }
 
+void WorkerGlobalScope::finalize()
+{
+    Base::finalize();
+    WindowOrWorkerGlobalScopeMixin::finalize();
+}
+
 void WorkerGlobalScope::set_internal_port(JS::NonnullGCPtr<MessagePort> port)
 {
     m_internal_port = port;

--- a/Userland/Libraries/LibWeb/HTML/WorkerGlobalScope.h
+++ b/Userland/Libraries/LibWeb/HTML/WorkerGlobalScope.h
@@ -95,6 +95,7 @@ protected:
 
 private:
     virtual void visit_edges(Cell::Visitor&) override;
+    virtual void finalize() override;
 
     JS::GCPtr<WorkerLocation> m_location;
     JS::GCPtr<WorkerNavigator> m_navigator;


### PR DESCRIPTION
This avoids an assertion that timers are not active when destroyed.