### PR TITLE
Kernel+LibCore: Fixes to file type attribute handling

### DIFF
--- a/Kernel/FileSystem/Ext2FS/FileSystem.cpp
+++ b/Kernel/FileSystem/Ext2FS/FileSystem.cpp
@@ -214,6 +214,13 @@ u8 Ext2FS::internal_file_type_to_directory_entry_type(DirectoryEntryView const& 
     }
 }
 
+Ext2FS::FeaturesOptional Ext2FS::get_features_optional() const
+{
+    if (m_super_block.s_rev_level > 0)
+        return static_cast<Ext2FS::FeaturesOptional>(m_super_block.s_feature_compat);
+    return Ext2FS::FeaturesOptional::None;
+}
+
 Ext2FS::FeaturesReadOnly Ext2FS::get_features_readonly() const
 {
     if (m_super_block.s_rev_level > 0)

--- a/Kernel/FileSystem/Ext2FS/FileSystem.h
+++ b/Kernel/FileSystem/Ext2FS/FileSystem.h
@@ -22,6 +22,13 @@ class Ext2FS final : public BlockBasedFileSystem {
     friend class Ext2FSInode;
 
 public:
+    // s_feature_compat
+    enum class FeaturesOptional : u32 {
+        None = 0,
+        ExtendedAttributes = EXT2_FEATURE_COMPAT_EXT_ATTR,
+    };
+    AK_ENUM_BITWISE_FRIEND_OPERATORS(FeaturesOptional);
+
     // s_feature_ro_compat
     enum class FeaturesReadOnly : u32 {
         None = 0,
@@ -43,6 +50,7 @@ public:
 
     virtual u8 internal_file_type_to_directory_entry_type(DirectoryEntryView const& entry) const override;
 
+    FeaturesOptional get_features_optional() const;
     FeaturesReadOnly get_features_readonly() const;
 
     virtual StringView class_name() const override { return "Ext2FS"sv; }

--- a/Userland/Libraries/LibCore/DirectoryEntry.cpp
+++ b/Userland/Libraries/LibCore/DirectoryEntry.cpp
@@ -9,7 +9,7 @@
 
 namespace Core {
 
-static DirectoryEntry::Type directory_entry_type_from_stat(mode_t st_mode)
+DirectoryEntry::Type DirectoryEntry::directory_entry_type_from_stat(mode_t st_mode)
 {
     switch (st_mode & S_IFMT) {
     case S_IFIFO:

--- a/Userland/Libraries/LibCore/DirectoryEntry.h
+++ b/Userland/Libraries/LibCore/DirectoryEntry.h
@@ -28,6 +28,7 @@ struct DirectoryEntry {
     ByteString name;
     ino_t inode_number;
 
+    static Type directory_entry_type_from_stat(mode_t st_mode);
     static DirectoryEntry from_dirent(dirent const&);
     static DirectoryEntry from_stat(DIR*, dirent const&);
 };


### PR DESCRIPTION
Currently, we treat extended Ext2 attributes as if they are always available, which may not be the case for all Ext2 filesystems, such as those generated by `genext2fs`. With this PR, we avoid exposing extended attributes when the filesystem doesn't explicitly claim to support them.

`DirIterator::advance_next()` was also missing checks for valid file type attributes, so that has also been addressed.

Fixes #22533, though we should still store/expose file type attributes when possible for other filesystems.

cc @alimpfard