### PR TITLE
LibLine: Cursor jump non-space word and cut-and-paste functionality

### DIFF
--- a/Userland/Libraries/LibLine/Editor.cpp
+++ b/Userland/Libraries/LibLine/Editor.cpp
@@ -166,6 +166,8 @@ void Editor::set_default_keybinds()
     register_key_input_callback(Key { '.', Key::Alt }, EDITOR_INTERNAL_FUNCTION(insert_last_words));
     register_key_input_callback(Key { 'b', Key::Alt }, EDITOR_INTERNAL_FUNCTION(cursor_left_word));
     register_key_input_callback(Key { 'f', Key::Alt }, EDITOR_INTERNAL_FUNCTION(cursor_right_word));
+    register_key_input_callback(Key { ctrl('B'), Key::Alt }, EDITOR_INTERNAL_FUNCTION(cursor_left_nonspace_word));
+    register_key_input_callback(Key { ctrl('F'), Key::Alt }, EDITOR_INTERNAL_FUNCTION(cursor_right_nonspace_word));
     // ^[^H: alt-backspace: backward delete word
     register_key_input_callback(Key { '\b', Key::Alt }, EDITOR_INTERNAL_FUNCTION(erase_alnum_word_backwards));
     register_key_input_callback(Key { 'd', Key::Alt }, EDITOR_INTERNAL_FUNCTION(erase_alnum_word_forwards));

--- a/Userland/Libraries/LibLine/Editor.cpp
+++ b/Userland/Libraries/LibLine/Editor.cpp
@@ -164,6 +164,7 @@ void Editor::set_default_keybinds()
 
     // ^[.: alt-.: insert last arg of previous command (similar to `!$`)
     register_key_input_callback(Key { '.', Key::Alt }, EDITOR_INTERNAL_FUNCTION(insert_last_words));
+    register_key_input_callback(ctrl('Y'), EDITOR_INTERNAL_FUNCTION(insert_last_erased));
     register_key_input_callback(Key { 'b', Key::Alt }, EDITOR_INTERNAL_FUNCTION(cursor_left_word));
     register_key_input_callback(Key { 'f', Key::Alt }, EDITOR_INTERNAL_FUNCTION(cursor_right_word));
     register_key_input_callback(Key { ctrl('B'), Key::Alt }, EDITOR_INTERNAL_FUNCTION(cursor_left_nonspace_word));

--- a/Userland/Libraries/LibLine/Editor.h
+++ b/Userland/Libraries/LibLine/Editor.h
@@ -105,8 +105,10 @@ struct Configuration {
     M(clear_screen)                            \
     M(cursor_left_character)                   \
     M(cursor_left_word)                        \
+    M(cursor_left_nonspace_word)               \
     M(cursor_right_character)                  \
     M(cursor_right_word)                       \
+    M(cursor_right_nonspace_word)              \
     M(enter_search)                            \
     M(erase_character_backwards)               \
     M(erase_character_forwards)                \

--- a/Userland/Libraries/LibLine/Editor.h
+++ b/Userland/Libraries/LibLine/Editor.h
@@ -124,6 +124,7 @@ struct Configuration {
     M(transpose_characters)                    \
     M(transpose_words)                         \
     M(insert_last_words)                       \
+    M(insert_last_erased)                      \
     M(erase_alnum_word_backwards)              \
     M(erase_alnum_word_forwards)               \
     M(capitalize_word)                         \
@@ -505,6 +506,7 @@ private:
     RefPtr<Core::Notifier> m_notifier;
 
     Vector<u32> m_paste_buffer;
+    Vector<u32> m_last_erased;
 
     bool m_initialized { false };
     bool m_refresh_needed { false };

--- a/Userland/Libraries/LibLine/InternalFunctions.cpp
+++ b/Userland/Libraries/LibLine/InternalFunctions.cpp
@@ -78,16 +78,17 @@ void Editor::search_backwards()
 
 void Editor::cursor_left_word()
 {
-    if (m_cursor > 0) {
-        auto skipped_at_least_one_character = false;
-        for (;;) {
-            if (m_cursor == 0)
+    auto has_seen_alnum = false;
+    while (m_cursor) {
+        // after seeing at least one alnum, stop just before a non-alnum
+        if (not is_ascii_alphanumeric(m_buffer[m_cursor - 1])) {
+            if (has_seen_alnum)
                 break;
-            if (skipped_at_least_one_character && !is_ascii_alphanumeric(m_buffer[m_cursor - 1])) // stop *after* a non-alnum, but only if it changes the position
-                break;
-            skipped_at_least_one_character = true;
-            --m_cursor;
+        } else {
+            has_seen_alnum = true;
         }
+
+        --m_cursor;
     }
     m_inline_search_cursor = m_cursor;
 }

--- a/Userland/Libraries/LibLine/InternalFunctions.cpp
+++ b/Userland/Libraries/LibLine/InternalFunctions.cpp
@@ -105,17 +105,17 @@ void Editor::cursor_left_character()
 
 void Editor::cursor_right_word()
 {
-    if (m_cursor < m_buffer.size()) {
-        // Temporarily put a space at the end of our buffer,
-        // doing this greatly simplifies the logic below.
-        m_buffer.append(' ');
-        for (;;) {
-            if (m_cursor >= m_buffer.size())
+    auto has_seen_alnum = false;
+    while (m_cursor < m_buffer.size()) {
+        // after seeing at least one alnum, stop at the first non-alnum
+        if (not is_ascii_alphanumeric(m_buffer[m_cursor])) {
+            if (has_seen_alnum)
                 break;
-            if (!is_ascii_alphanumeric(m_buffer[++m_cursor]))
-                break;
+        } else {
+            has_seen_alnum = true;
         }
-        m_buffer.take_last();
+
+        ++m_cursor;
     }
     m_inline_search_cursor = m_cursor;
     m_search_offset = 0;

--- a/Userland/Libraries/LibLine/InternalFunctions.cpp
+++ b/Userland/Libraries/LibLine/InternalFunctions.cpp
@@ -93,6 +93,23 @@ void Editor::cursor_left_word()
     m_inline_search_cursor = m_cursor;
 }
 
+void Editor::cursor_left_nonspace_word()
+{
+    auto has_seen_nonspace = false;
+    while (m_cursor) {
+        // after seeing at least one non-space, stop just before a space
+        if (is_ascii_space(m_buffer[m_cursor - 1])) {
+            if (has_seen_nonspace)
+                break;
+        } else {
+            has_seen_nonspace = true;
+        }
+
+        --m_cursor;
+    }
+    m_inline_search_cursor = m_cursor;
+}
+
 void Editor::cursor_left_character()
 {
     if (m_cursor > 0) {
@@ -113,6 +130,24 @@ void Editor::cursor_right_word()
                 break;
         } else {
             has_seen_alnum = true;
+        }
+
+        ++m_cursor;
+    }
+    m_inline_search_cursor = m_cursor;
+    m_search_offset = 0;
+}
+
+void Editor::cursor_right_nonspace_word()
+{
+    auto has_seen_nonspace = false;
+    while (m_cursor < m_buffer.size()) {
+        // after seeing at least one non-space, stop at the first space
+        if (is_ascii_space(m_buffer[m_cursor])) {
+            if (has_seen_nonspace)
+                break;
+        } else {
+            has_seen_nonspace = true;
         }
 
         ++m_cursor;


### PR DESCRIPTION
#### LibLine: Skip initial non-alphanumeric chars in `cursor_left_word()`

#### LibLine: Skip initial non-alphanumeric chars in `cursor_right_word()`

Before these used to skip only one non-alnum instead of all the consecutive
ones. Now it matches behaviour with bash/readline.

#### LibLine: Implement internal functions to jump cursor over non-space word
```
    Two new internal functions `cursor_left_nonspace_word()` (`Ctrl+Alt+B`)
    and `cursor_right_nonspace_word()` (`Ctrl+Alt+F`) that jump the cursor
    left or right until a non-space character.

    Same implementation as the alphanumeric word jump functions
    `cursor_left_word()` (`Alt+B`) and `cursor_right_word()` (`Alt+F`).
```

#### LibLine: Implement basic cut-and-paste functionality
```
    Every cut operation (erase last word backward/forward, erase line till
    start/end) stores the erased characters in `m_last_erased` byte string.

    The last erased characters will get inserted into the buffer when
    `Ctrl+Y` (`insert_last_erased()` internal function) is pressed.
```

gnu readline can do much more than this: whole stack of erased characters
instead of just the last one; and consecutive erase operation merge into one
stack entry in the erase history.

