### PR TITLE
AK+LibJS: Implement the GetSubstitution AO according to the spec

### DIFF
--- a/AK/Utf16View.cpp
+++ b/AK/Utf16View.cpp
@@ -213,6 +213,25 @@ Utf16View Utf16View::unicode_substring_view(size_t code_point_offset, size_t cod
     VERIFY_NOT_REACHED();
 }
 
+bool Utf16View::starts_with(Utf16View const& needle) const
+{
+    if (needle.is_empty())
+        return true;
+    if (is_empty())
+        return false;
+    if (needle.length_in_code_units() > length_in_code_units())
+        return false;
+    if (begin_ptr() == needle.begin_ptr())
+        return true;
+
+    for (auto this_it = begin(), needle_it = needle.begin(); needle_it != needle.end(); ++needle_it, ++this_it) {
+        if (*this_it != *needle_it)
+            return false;
+    }
+
+    return true;
+}
+
 bool Utf16View::validate(size_t& valid_code_units) const
 {
     valid_code_units = 0;

--- a/AK/Utf16View.h
+++ b/AK/Utf16View.h
@@ -71,6 +71,14 @@ public:
     {
     }
 
+    template<size_t Size>
+    Utf16View(char16_t const (&code_units)[Size])
+        : m_code_units(
+            reinterpret_cast<u16 const*>(&code_units[0]),
+            code_units[Size - 1] == u'\0' ? Size - 1 : Size)
+    {
+    }
+
     bool operator==(Utf16View const& other) const { return m_code_units == other.m_code_units; }
 
     enum class AllowInvalidCodeUnits {

--- a/AK/Utf16View.h
+++ b/AK/Utf16View.h
@@ -111,6 +111,8 @@ public:
     Utf16View unicode_substring_view(size_t code_point_offset, size_t code_point_length) const;
     Utf16View unicode_substring_view(size_t code_point_offset) const { return unicode_substring_view(code_point_offset, length_in_code_points() - code_point_offset); }
 
+    bool starts_with(Utf16View const&) const;
+
     bool validate(size_t& valid_code_units) const;
     bool validate() const
     {

--- a/Tests/AK/TestUtf16.cpp
+++ b/Tests/AK/TestUtf16.cpp
@@ -89,6 +89,36 @@ TEST_CASE(decode_utf16)
     EXPECT_EQ(i, expected.size());
 }
 
+TEST_CASE(utf16_literal)
+{
+    {
+        Utf16View view { u"" };
+        EXPECT(view.validate());
+        EXPECT_EQ(view.length_in_code_units(), 0u);
+    }
+    {
+        Utf16View view { u"a" };
+        EXPECT(view.validate());
+        EXPECT_EQ(view.length_in_code_units(), 1u);
+        EXPECT_EQ(view.code_unit_at(0), 0x61u);
+    }
+    {
+        Utf16View view { u"abc" };
+        EXPECT(view.validate());
+        EXPECT_EQ(view.length_in_code_units(), 3u);
+        EXPECT_EQ(view.code_unit_at(0), 0x61u);
+        EXPECT_EQ(view.code_unit_at(1), 0x62u);
+        EXPECT_EQ(view.code_unit_at(2), 0x63u);
+    }
+    {
+        Utf16View view { u"🙃" };
+        EXPECT(view.validate());
+        EXPECT_EQ(view.length_in_code_units(), 2u);
+        EXPECT_EQ(view.code_unit_at(0), 0xd83du);
+        EXPECT_EQ(view.code_unit_at(1), 0xde43u);
+    }
+}
+
 TEST_CASE(iterate_utf16)
 {
     auto string = MUST(AK::utf8_to_utf16("Привет 😀"sv));

--- a/Tests/AK/TestUtf16.cpp
+++ b/Tests/AK/TestUtf16.cpp
@@ -310,3 +310,29 @@ TEST_CASE(substring_view)
         EXPECT_EQ(MUST(view.to_utf8(Utf16View::AllowInvalidCodeUnits::No)), "\ufffd"sv);
     }
 }
+
+TEST_CASE(starts_with)
+{
+    EXPECT(Utf16View {}.starts_with(u""));
+    EXPECT(!Utf16View {}.starts_with(u" "));
+
+    EXPECT(Utf16View { u"a" }.starts_with(u""));
+    EXPECT(Utf16View { u"a" }.starts_with(u"a"));
+    EXPECT(!Utf16View { u"a" }.starts_with(u"b"));
+    EXPECT(!Utf16View { u"a" }.starts_with(u"ab"));
+
+    EXPECT(Utf16View { u"abc" }.starts_with(u""));
+    EXPECT(Utf16View { u"abc" }.starts_with(u"a"));
+    EXPECT(Utf16View { u"abc" }.starts_with(u"ab"));
+    EXPECT(Utf16View { u"abc" }.starts_with(u"abc"));
+    EXPECT(!Utf16View { u"abc" }.starts_with(u"b"));
+    EXPECT(!Utf16View { u"abc" }.starts_with(u"bc"));
+
+    auto emoji = Utf16View { u"😀🙃" };
+
+    EXPECT(emoji.starts_with(u""));
+    EXPECT(emoji.starts_with(u"😀"));
+    EXPECT(emoji.starts_with(u"😀🙃"));
+    EXPECT(!emoji.starts_with(u"a"));
+    EXPECT(!emoji.starts_with(u"🙃"));
+}

--- a/Userland/Libraries/LibJS/Runtime/StringPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/StringPrototype.cpp
@@ -64,7 +64,7 @@ static Optional<size_t> split_match(Utf16View const& haystack, size_t start, Utf
 }
 
 // 6.1.4.1 StringIndexOf ( string, searchValue, fromIndex ), https://tc39.es/ecma262/#sec-stringindexof
-static Optional<size_t> string_index_of(Utf16View const& string, Utf16View const& search_value, size_t from_index)
+Optional<size_t> string_index_of(Utf16View const& string, Utf16View const& search_value, size_t from_index)
 {
     // 1. Let len be the length of string.
     size_t string_length = string.length_in_code_units();

--- a/Userland/Libraries/LibJS/Runtime/StringPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/StringPrototype.h
@@ -17,6 +17,7 @@ struct CodePoint {
     size_t code_unit_count { 0 };
 };
 
+Optional<size_t> string_index_of(Utf16View const& string, Utf16View const& search_value, size_t from_index);
 CodePoint code_point_at(Utf16View const& string, size_t position);
 static constexpr Utf8View whitespace_characters = Utf8View("\x09\x0A\x0B\x0C\x0D\x20\xC2\xA0\xE1\x9A\x80\xE2\x80\x80\xE2\x80\x81\xE2\x80\x82\xE2\x80\x83\xE2\x80\x84\xE2\x80\x85\xE2\x80\x86\xE2\x80\x87\xE2\x80\x88\xE2\x80\x89\xE2\x80\x8A\xE2\x80\xAF\xE2\x81\x9F\xE3\x80\x80\xE2\x80\xA8\xE2\x80\xA9\xEF\xBB\xBF"sv);
 ThrowCompletionOr<String> trim_string(VM&, Value string, TrimMode where);

--- a/Userland/Libraries/LibJS/Runtime/Value.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Value.cpp
@@ -59,7 +59,7 @@ static inline bool same_type_for_equality(Value const& lhs, Value const& rhs)
     return false;
 }
 
-static const Crypto::SignedBigInteger BIGINT_ZERO { 0 };
+static Crypto::SignedBigInteger const BIGINT_ZERO { 0 };
 
 ALWAYS_INLINE bool both_number(Value const& lhs, Value const& rhs)
 {
@@ -655,14 +655,14 @@ static Optional<NumberParseResult> parse_number_text(StringView text)
 double string_to_number(StringView string)
 {
     // 1. Let text be StringToCodePoints(str).
-    ByteString text = Utf8View(string).trim(whitespace_characters, AK::TrimMode::Both).as_string();
+    auto text = Utf8View(string).trim(whitespace_characters, AK::TrimMode::Both).as_string();
 
     // 2. Let literal be ParseText(text, StringNumericLiteral).
     if (text.is_empty())
         return 0;
-    if (text == "Infinity" || text == "+Infinity")
+    if (text == "Infinity"sv || text == "+Infinity"sv)
         return INFINITY;
-    if (text == "-Infinity")
+    if (text == "-Infinity"sv)
         return -INFINITY;
 
     auto result = parse_number_text(text);


### PR DESCRIPTION
There was recently a normative change to this AO in ECMA-262. See:
https://github.com/tc39/ecma262/commit/5eaee2f

It turns out we already implemented this to align with web-reality
before it was codified in the spec. This was a bit difficult to reason
without spec text and with a somewhat ad-hoc implementation. So this
patch aligns our implementation with the spec. There should not be any
behavior change.

No test262 diff.