### PR TITLE
Taskbar: Use name of Ladybird as default QuickLaunch

### DIFF
--- a/Base/home/anon/.config/Taskbar.ini
+++ b/Base/home/anon/.config/Taskbar.ini
@@ -2,7 +2,7 @@
 TimeFormat=%T
 
 [QuickLaunch_Entries]
-Browser=0:Browser.af
+Ladybird=0:Browser.af
 FileManager=1:FileManager.af
 Terminal=2:Terminal.af
 TextEditor=3:TextEditor.af


### PR DESCRIPTION
As the name of the Browser app is now titled Ladybird this was resulting in a double up if installed fresh then rebooted (or likely after an upgrade). This change corrects this by using the Ladybird title