### PR TITLE
AK: Improve performance of StringUtils::find_last

### DIFF
--- a/AK/ByteString.h
+++ b/AK/ByteString.h
@@ -189,7 +189,7 @@ public:
         return bit_cast<u8>((*m_impl)[i]);
     }
 
-    using ConstIterator = SimpleIterator<const ByteString, char const>;
+    using ConstIterator = SimpleIterator<ByteString const, char const>;
 
     [[nodiscard]] constexpr ConstIterator begin() const { return ConstIterator::begin(*this); }
     [[nodiscard]] constexpr ConstIterator end() const { return ConstIterator::end(*this); }

--- a/AK/StringUtils.cpp
+++ b/AK/StringUtils.cpp
@@ -174,7 +174,7 @@ Optional<T> convert_to_uint_from_hex(StringView str, TrimWhitespace trim_whitesp
 
     T value = 0;
     auto const count = string.length();
-    const T upper_bound = NumericLimits<T>::max();
+    T const upper_bound = NumericLimits<T>::max();
 
     for (size_t i = 0; i < count; i++) {
         char digit = string[i];
@@ -213,7 +213,7 @@ Optional<T> convert_to_uint_from_octal(StringView str, TrimWhitespace trim_white
 
     T value = 0;
     auto const count = string.length();
-    const T upper_bound = NumericLimits<T>::max();
+    T const upper_bound = NumericLimits<T>::max();
 
     for (size_t i = 0; i < count; i++) {
         char digit = string[i];

--- a/AK/StringUtils.cpp
+++ b/AK/StringUtils.cpp
@@ -412,10 +412,15 @@ Optional<size_t> find_last(StringView haystack, char needle)
 
 Optional<size_t> find_last(StringView haystack, StringView needle)
 {
-    for (size_t i = haystack.length(); i > 0; --i) {
-        auto value = StringUtils::find(haystack, needle, i - 1);
-        if (value.has_value())
-            return value;
+    if (needle.length() > haystack.length())
+        return {};
+
+    for (size_t i = haystack.length() - needle.length();; --i) {
+        if (haystack.substring_view(i, needle.length()) == needle)
+            return i;
+
+        if (i == 0)
+            break;
     }
 
     return {};

--- a/AK/StringView.h
+++ b/AK/StringView.h
@@ -83,7 +83,7 @@ public:
         return m_characters[index];
     }
 
-    using ConstIterator = SimpleIterator<const StringView, char const>;
+    using ConstIterator = SimpleIterator<StringView const, char const>;
 
     [[nodiscard]] constexpr ConstIterator begin() const { return ConstIterator::begin(*this); }
     [[nodiscard]] constexpr ConstIterator end() const { return ConstIterator::end(*this); }

--- a/Tests/AK/TestStringUtils.cpp
+++ b/Tests/AK/TestStringUtils.cpp
@@ -407,6 +407,25 @@ TEST_CASE(find)
     EXPECT_EQ(AK::StringUtils::find(test_string, "78"sv).has_value(), false);
 }
 
+TEST_CASE(find_last)
+{
+    auto test_string = "abcdabc"sv;
+
+    EXPECT_EQ(AK::StringUtils::find_last(test_string, ""sv), 7u);
+    EXPECT_EQ(AK::StringUtils::find_last(test_string, "a"sv), 4u);
+    EXPECT_EQ(AK::StringUtils::find_last(test_string, "b"sv), 5u);
+    EXPECT_EQ(AK::StringUtils::find_last(test_string, "c"sv), 6u);
+    EXPECT_EQ(AK::StringUtils::find_last(test_string, "ab"sv), 4u);
+    EXPECT_EQ(AK::StringUtils::find_last(test_string, "bc"sv), 5u);
+    EXPECT_EQ(AK::StringUtils::find_last(test_string, "abc"sv), 4u);
+    EXPECT_EQ(AK::StringUtils::find_last(test_string, "abcd"sv), 0u);
+    EXPECT_EQ(AK::StringUtils::find_last(test_string, test_string), 0u);
+
+    EXPECT(!AK::StringUtils::find_last(test_string, "1"sv).has_value());
+    EXPECT(!AK::StringUtils::find_last(test_string, "e"sv).has_value());
+    EXPECT(!AK::StringUtils::find_last(test_string, "abd"sv).has_value());
+}
+
 TEST_CASE(replace_all_overlapping)
 {
     // Replace only should take into account non-overlapping instances of the


### PR DESCRIPTION
The current algorithm is currently O(N^2) because we forward-search an
ever-increasing substring of the haystack. This implementation reduces
the search time of a 500,000-length string (where the desired needle is
at index 0) from 72 seconds to 2-3 milliseconds.