### PR TITLE
LibWeb: Use UTF-16 code unit offsets in Range::to_string

### DIFF
--- a/Tests/LibWeb/Text/expected/DOM/Range-to-string.txt
+++ b/Tests/LibWeb/Text/expected/DOM/Range-to-string.txt
@@ -1,0 +1,2 @@
+Hello💨😮 World   
+llo💨😮 Wo

--- a/Tests/LibWeb/Text/input/DOM/Range-to-string.html
+++ b/Tests/LibWeb/Text/input/DOM/Range-to-string.html
@@ -1,0 +1,14 @@
+<body><p id="p1"><b>Hello💨</b>😮 World</p>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const p1 = document.getElementById("p1");
+        const hello = p1.firstChild.firstChild;
+        const world = p1.lastChild;
+        const range = document.createRange();
+        range.setStart(hello, 2);
+        range.setEnd(world, 5);
+        println('');
+        println(range.toString());
+    });
+</script>

--- a/Userland/Libraries/LibWeb/DOM/AbstractRange.cpp
+++ b/Userland/Libraries/LibWeb/DOM/AbstractRange.cpp
@@ -10,7 +10,7 @@
 
 namespace Web::DOM {
 
-AbstractRange::AbstractRange(Node& start_container, u32 start_offset, Node& end_container, u32 end_offset)
+AbstractRange::AbstractRange(Node& start_container, WebIDL::UnsignedLong start_offset, Node& end_container, WebIDL::UnsignedLong end_offset)
     : Bindings::PlatformObject(start_container.realm())
     , m_start_container(start_container)
     , m_start_offset(start_offset)

--- a/Userland/Libraries/LibWeb/DOM/AbstractRange.h
+++ b/Userland/Libraries/LibWeb/DOM/AbstractRange.h
@@ -9,9 +9,11 @@
 
 #include <LibWeb/Bindings/PlatformObject.h>
 #include <LibWeb/Forward.h>
+#include <LibWeb/WebIDL/Types.h>
 
 namespace Web::DOM {
 
+// https://dom.spec.whatwg.org/#abstractrange
 class AbstractRange : public Bindings::PlatformObject {
     WEB_PLATFORM_OBJECT(AbstractRange, Bindings::PlatformObject);
 
@@ -20,11 +22,11 @@ public:
 
     Node* start_container() { return m_start_container.ptr(); }
     Node const* start_container() const { return m_start_container.ptr(); }
-    unsigned start_offset() const { return m_start_offset; }
+    WebIDL::UnsignedLong start_offset() const { return m_start_offset; }
 
     Node* end_container() { return m_end_container.ptr(); }
     Node const* end_container() const { return m_end_container.ptr(); }
-    unsigned end_offset() const { return m_end_offset; }
+    WebIDL::UnsignedLong end_offset() const { return m_end_offset; }
 
     // https://dom.spec.whatwg.org/#range-collapsed
     bool collapsed() const
@@ -34,16 +36,16 @@ public:
     }
 
 protected:
-    AbstractRange(Node& start_container, u32 start_offset, Node& end_container, u32 end_offset);
+    AbstractRange(Node& start_container, WebIDL::UnsignedLong start_offset, Node& end_container, WebIDL::UnsignedLong end_offset);
 
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
 
     JS::NonnullGCPtr<Node> m_start_container;
-    u32 m_start_offset;
+    WebIDL::UnsignedLong m_start_offset;
 
     JS::NonnullGCPtr<Node> m_end_container;
-    u32 m_end_offset;
+    WebIDL::UnsignedLong m_end_offset;
 };
 
 }

--- a/Userland/Libraries/LibWeb/DOM/Range.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Range.cpp
@@ -44,7 +44,7 @@ JS::NonnullGCPtr<Range> Range::create(Document& document)
     return realm.heap().allocate<Range>(realm, document);
 }
 
-JS::NonnullGCPtr<Range> Range::create(Node& start_container, u32 start_offset, Node& end_container, u32 end_offset)
+JS::NonnullGCPtr<Range> Range::create(Node& start_container, WebIDL::UnsignedLong start_offset, Node& end_container, WebIDL::UnsignedLong end_offset)
 {
     auto& realm = start_container.realm();
     return realm.heap().allocate<Range>(realm, start_container, start_offset, end_container, end_offset);
@@ -61,7 +61,7 @@ Range::Range(Document& document)
 {
 }
 
-Range::Range(Node& start_container, u32 start_offset, Node& end_container, u32 end_offset)
+Range::Range(Node& start_container, WebIDL::UnsignedLong start_offset, Node& end_container, WebIDL::UnsignedLong end_offset)
     : AbstractRange(start_container, start_offset, end_container, end_offset)
 {
     live_ranges().set(this);
@@ -207,13 +207,13 @@ WebIDL::ExceptionOr<void> Range::set_start_or_end(Node& node, u32 offset, StartO
 }
 
 // https://dom.spec.whatwg.org/#concept-range-bp-set
-WebIDL::ExceptionOr<void> Range::set_start(Node& node, u32 offset)
+WebIDL::ExceptionOr<void> Range::set_start(Node& node, WebIDL::UnsignedLong offset)
 {
     // The setStart(node, offset) method steps are to set the start of this to boundary point (node, offset).
     return set_start_or_end(node, offset, StartOrEnd::Start);
 }
 
-WebIDL::ExceptionOr<void> Range::set_end(Node& node, u32 offset)
+WebIDL::ExceptionOr<void> Range::set_end(Node& node, WebIDL::UnsignedLong offset)
 {
     // The setEnd(node, offset) method steps are to set the end of this to boundary point (node, offset).
     return set_start_or_end(node, offset, StartOrEnd::End);
@@ -276,7 +276,7 @@ WebIDL::ExceptionOr<void> Range::set_end_after(Node& node)
 }
 
 // https://dom.spec.whatwg.org/#dom-range-compareboundarypoints
-WebIDL::ExceptionOr<i16> Range::compare_boundary_points(u16 how, Range const& source_range) const
+WebIDL::ExceptionOr<WebIDL::Short> Range::compare_boundary_points(WebIDL::UnsignedShort how, Range const& source_range) const
 {
     // 1. If how is not one of
     //      - START_TO_START,
@@ -499,7 +499,7 @@ bool Range::intersects_node(Node const& node) const
 }
 
 // https://dom.spec.whatwg.org/#dom-range-ispointinrange
-WebIDL::ExceptionOr<bool> Range::is_point_in_range(Node const& node, u32 offset) const
+WebIDL::ExceptionOr<bool> Range::is_point_in_range(Node const& node, WebIDL::UnsignedLong offset) const
 {
     // 1. If node’s root is different from this’s root, return false.
     if (&node.root() != &root())
@@ -524,7 +524,7 @@ WebIDL::ExceptionOr<bool> Range::is_point_in_range(Node const& node, u32 offset)
 }
 
 // https://dom.spec.whatwg.org/#dom-range-comparepoint
-WebIDL::ExceptionOr<i16> Range::compare_point(Node const& node, u32 offset) const
+WebIDL::ExceptionOr<WebIDL::Short> Range::compare_point(Node const& node, WebIDL::UnsignedLong offset) const
 {
     // 1. If node’s root is different from this’s root, then throw a "WrongDocumentError" DOMException.
     if (&node.root() != &root())

--- a/Userland/Libraries/LibWeb/DOM/Range.h
+++ b/Userland/Libraries/LibWeb/DOM/Range.h
@@ -10,6 +10,7 @@
 
 #include <LibWeb/DOM/AbstractRange.h>
 #include <LibWeb/Selection/Selection.h>
+#include <LibWeb/WebIDL/Types.h>
 
 namespace Web::DOM {
 
@@ -29,15 +30,15 @@ class Range final : public AbstractRange {
 public:
     [[nodiscard]] static JS::NonnullGCPtr<Range> create(Document&);
     [[nodiscard]] static JS::NonnullGCPtr<Range> create(HTML::Window&);
-    [[nodiscard]] static JS::NonnullGCPtr<Range> create(Node& start_container, u32 start_offset, Node& end_container, u32 end_offset);
+    [[nodiscard]] static JS::NonnullGCPtr<Range> create(Node& start_container, WebIDL::UnsignedLong start_offset, Node& end_container, WebIDL::UnsignedLong end_offset);
     static WebIDL::ExceptionOr<JS::NonnullGCPtr<Range>> construct_impl(JS::Realm&);
 
     virtual ~Range() override;
 
     // FIXME: There are a ton of methods missing here.
 
-    WebIDL::ExceptionOr<void> set_start(Node& node, u32 offset);
-    WebIDL::ExceptionOr<void> set_end(Node& node, u32 offset);
+    WebIDL::ExceptionOr<void> set_start(Node& node, WebIDL::UnsignedLong offset);
+    WebIDL::ExceptionOr<void> set_end(Node& node, WebIDL::UnsignedLong offset);
     WebIDL::ExceptionOr<void> set_start_before(Node& node);
     WebIDL::ExceptionOr<void> set_start_after(Node& node);
     WebIDL::ExceptionOr<void> set_end_before(Node& node);
@@ -47,14 +48,14 @@ public:
     WebIDL::ExceptionOr<void> select_node_contents(Node&);
 
     // https://dom.spec.whatwg.org/#dom-range-start_to_start
-    enum HowToCompareBoundaryPoints : u16 {
+    enum HowToCompareBoundaryPoints : WebIDL::UnsignedShort {
         START_TO_START = 0,
         START_TO_END = 1,
         END_TO_END = 2,
         END_TO_START = 3,
     };
 
-    WebIDL::ExceptionOr<i16> compare_boundary_points(u16 how, Range const& source_range) const;
+    WebIDL::ExceptionOr<WebIDL::Short> compare_boundary_points(WebIDL::UnsignedShort how, Range const& source_range) const;
 
     JS::NonnullGCPtr<Range> inverted() const;
     JS::NonnullGCPtr<Range> normalized() const;
@@ -70,8 +71,8 @@ public:
     }
 
     bool intersects_node(Node const&) const;
-    WebIDL::ExceptionOr<bool> is_point_in_range(Node const&, u32 offset) const;
-    WebIDL::ExceptionOr<i16> compare_point(Node const&, u32 offset) const;
+    WebIDL::ExceptionOr<bool> is_point_in_range(Node const&, WebIDL::UnsignedLong offset) const;
+    WebIDL::ExceptionOr<WebIDL::Short> compare_point(Node const&, WebIDL::UnsignedLong offset) const;
 
     WebIDL::ExceptionOr<void> delete_contents();
     WebIDL::ExceptionOr<JS::NonnullGCPtr<DocumentFragment>> extract_contents();
@@ -94,7 +95,7 @@ public:
 
 private:
     explicit Range(Document&);
-    Range(Node& start_container, u32 start_offset, Node& end_container, u32 end_offset);
+    Range(Node& start_container, WebIDL::UnsignedLong start_offset, Node& end_container, WebIDL::UnsignedLong end_offset);
 
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;


### PR DESCRIPTION
Similar to another problem we had in CharacterData, we were assuming
that the offsets were raw utf8 byte offsets into the data, instead of
utf16 code units. Fix this by using the substring helpers in
CharacterData to get the text data from the Range.

There are more instances of this issue around the place that we will
need to track down and add tests for, but this fixes one of them :^)

For the test included in this commit, we were previously returning:

llo💨😮

Instead of the expected:

llo💨😮 Wo