### PR TITLE
LibPDF: Tolerate whitespace after `xref` and `startxref`

### DIFF
--- a/Userland/Libraries/LibPDF/DocumentParser.cpp
+++ b/Userland/Libraries/LibPDF/DocumentParser.cpp
@@ -481,6 +481,7 @@ PDFErrorOr<NonnullRefPtr<XRefTable>> DocumentParser::parse_xref_table()
     }
 
     m_reader.move_by(4);
+    m_reader.consume_non_eol_whitespace();
     if (!m_reader.consume_eol())
         return error("Expected newline after \"xref\"");
 
@@ -741,6 +742,8 @@ bool DocumentParser::navigate_to_after_startxref()
         auto offset = m_reader.offset() + 1;
 
         m_reader.consume_eol();
+        m_reader.consume_whitespace();
+
         if (!m_reader.matches("startxref"))
             continue;
 

--- a/Userland/Libraries/LibPDF/Reader.cpp
+++ b/Userland/Libraries/LibPDF/Reader.cpp
@@ -16,8 +16,13 @@ bool Reader::is_eol(char c)
 
 bool Reader::is_whitespace(char c)
 {
+    return is_eol(c) || is_non_eol_whitespace(c);
+}
+
+bool Reader::is_non_eol_whitespace(char c)
+{
     // 3.1.1 Character Set
-    return is_eol(c) || c == 0 || c == 0x9 || c == 0xc || c == ' ';
+    return c == 0 || c == 0x9 || c == 0xc || c == ' ';
 }
 
 bool Reader::matches_eol() const
@@ -28,6 +33,11 @@ bool Reader::matches_eol() const
 bool Reader::matches_whitespace() const
 {
     return !done() && is_whitespace(peek());
+}
+
+bool Reader::matches_non_eol_whitespace() const
+{
+    return !done() && is_non_eol_whitespace(peek());
 }
 
 bool Reader::matches_number() const
@@ -68,6 +78,16 @@ bool Reader::consume_whitespace()
 {
     bool consumed = false;
     while (matches_whitespace()) {
+        consumed = true;
+        consume();
+    }
+    return consumed;
+}
+
+bool Reader::consume_non_eol_whitespace()
+{
+    bool consumed = false;
+    while (matches_non_eol_whitespace()) {
         consumed = true;
         consume();
     }

--- a/Userland/Libraries/LibPDF/Reader.h
+++ b/Userland/Libraries/LibPDF/Reader.h
@@ -133,15 +133,18 @@ public:
 
     static bool is_eol(char);
     static bool is_whitespace(char);
+    static bool is_non_eol_whitespace(char);
 
     bool matches_eol() const;
     bool matches_whitespace() const;
+    bool matches_non_eol_whitespace() const;
     bool matches_number() const;
     bool matches_delimiter() const;
     bool matches_regular_character() const;
 
     bool consume_eol();
     bool consume_whitespace();
+    bool consume_non_eol_whitespace();
     char consume();
     void consume(int amount);
     bool consume(char);


### PR DESCRIPTION
The spec isn't super clear on if this is allowed:

"""Each cross-reference section shall begin with a line containing the
keyword xref. Following this line..."""

"""The two preceding lines shall contain, one per line and in order, the
keyword startxref and..."""

It kind of sounds like anything goes on both lines as long as they
contain `xref` and `startxref`.

In practice, both seem to always occur at the start of their line,
but in 0000780.pdf (and nowhere else), there's one space after each
keyword before the following linebreak, and this makes that file load.