### PR TITLE
LibPDF: Tolerate trailing whitespace after %%EOF marker

### DIFF
--- a/Userland/Libraries/LibPDF/DocumentParser.cpp
+++ b/Userland/Libraries/LibPDF/DocumentParser.cpp
@@ -725,6 +725,7 @@ bool DocumentParser::navigate_to_before_eof_marker()
 
     while (!m_reader.done()) {
         m_reader.consume_eol();
+        m_reader.consume_whitespace();
         if (m_reader.matches("%%EOF")) {
             m_reader.move_by(5);
             return true;

--- a/Userland/Libraries/LibPDF/DocumentParser.cpp
+++ b/Userland/Libraries/LibPDF/DocumentParser.cpp
@@ -46,6 +46,10 @@ PDFErrorOr<Version> DocumentParser::initialize()
         // If the length given in the linearization dictionary is not equal to the length
         // of the document, then this file has most likely been incrementally updated, and
         // should no longer be treated as linearized.
+        // FIXME: This check requires knowing the full size of the file, while linearization
+        //        is all about being able to render some of it without having to download all of it.
+        //        PDF 2.0 Annex G.7 "Accessing an updated file" talks about this some,
+        //        but mostly just throws its hand in the air.
         is_linearized = m_linearization_dictionary.value().length_of_file == m_reader.bytes().size();
     }
 


### PR DESCRIPTION
At first I tried implmenting the quirk from PDF 1.7 Appendix H,
3.4.4, "File Trailer": """Acrobat viewers require only that the %%EOF
marker appear somewhere within the last 1024 bytes of the file.""
This would've been like https://github.com/SerenityOS/serenity/pull/22548 but at end-of-file instead of at
start-of-file.

This helped a bunch of files, but also broke a bunch of files that
made more than 1024 bytes of stuff at the end, and it wouldn't have
helped 0000059.pdf, which has over 40k of \0 bytes after the %%EOF.
So just tolerate whitespace after the %%EOF line, and keep ignoring
and arbitrary amount of other stuff after that like before.

This helps:
* https://github.com/SerenityOS/serenity/commit/00005991f12356ba358801a87296c97b2d7b6148.pdf
  One trailing \0 byte after %%EOF. Due to that byte, the
  is_linearized() check fails and we go down the non-linearized
  codepath. But with this fix, that code path succeeds.
* https://github.com/SerenityOS/serenity/commit/0000937a22d09fc06222e0e72a86356fcf90015b.pdf
  Same.
* 0000055.pdf
  Has one space followed by a \n after %%EOF
* 0000059.pdf
  Has over 40kB of trailing \0 bytes

The following files keep working with it:
* 0000242.pdf
  5586 bytes of trailing HTML
* https://github.com/SerenityOS/serenity/commit/000033629fdb6e3178532cd584895339b78f1667.pdf
  5586 bytes of trailing HTML fragment
* 0000136.pdf
  2054 bytes of trailing space characters
  This one kind of only worked by accident before since it found
  the %%EOF block before the final %%EOF block. Maybe this is
  even an intentional XRefStm compat hack? Anyways, now it
  find the final block instead.
* 0000327.pdf
  11044 bytes of trailing HTML