### PR TITLE
LibWeb: Fix crash in DOMImplementation for null namespaces and actually create XML documents

### DIFF
--- a/Tests/LibWeb/Text/expected/DOM/DOMImplementation-create-xml-document.txt
+++ b/Tests/LibWeb/Text/expected/DOM/DOMImplementation-create-xml-document.txt
@@ -1,0 +1,1 @@
+XMLDocument

--- a/Tests/LibWeb/Text/expected/DOM/DOMParser-xml-document.txt
+++ b/Tests/LibWeb/Text/expected/DOM/DOMParser-xml-document.txt
@@ -1,0 +1,1 @@
+XMLDocument

--- a/Tests/LibWeb/Text/input/DOM/DOMImplementation-create-xml-document.html
+++ b/Tests/LibWeb/Text/input/DOM/DOMImplementation-create-xml-document.html
@@ -1,0 +1,7 @@
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const xmlDoc = document.implementation.createDocument(null, "books");
+        println(xmlDoc.constructor.name);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/DOM/DOMParser-xml-document.html
+++ b/Tests/LibWeb/Text/input/DOM/DOMParser-xml-document.html
@@ -1,0 +1,8 @@
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const parser = new DOMParser();
+        const xmlDoc = parser.parseFromString('<svg></svg>', "text/xml");
+        println(xmlDoc.constructor.name);
+    });
+</script>

--- a/Userland/Libraries/LibWeb/DOM/DOMImplementation.cpp
+++ b/Userland/Libraries/LibWeb/DOM/DOMImplementation.cpp
@@ -58,7 +58,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Document>> DOMImplementation::create_docume
 
     // 3. If qualifiedName is not the empty string, then set element to the result of running the internal createElementNS steps, given document, namespace, qualifiedName, and an empty dictionary.
     if (!qualified_name.is_empty())
-        element = TRY(xml_document->create_element_ns(namespace_.value(), qualified_name, ElementCreationOptions {}));
+        element = TRY(xml_document->create_element_ns(namespace_, qualified_name, ElementCreationOptions {}));
 
     // 4. If doctype is non-null, append doctype to document.
     if (doctype)

--- a/Userland/Libraries/LibWeb/DOM/DOMImplementation.cpp
+++ b/Userland/Libraries/LibWeb/DOM/DOMImplementation.cpp
@@ -8,10 +8,10 @@
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Bindings/MainThreadVM.h>
 #include <LibWeb/DOM/DOMImplementation.h>
-#include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/DocumentType.h>
 #include <LibWeb/DOM/ElementFactory.h>
 #include <LibWeb/DOM/Text.h>
+#include <LibWeb/DOM/XMLDocument.h>
 #include <LibWeb/HTML/Origin.h>
 #include <LibWeb/Namespace.h>
 
@@ -48,8 +48,8 @@ void DOMImplementation::visit_edges(Cell::Visitor& visitor)
 // https://dom.spec.whatwg.org/#dom-domimplementation-createdocument
 WebIDL::ExceptionOr<JS::NonnullGCPtr<Document>> DOMImplementation::create_document(Optional<String> const& namespace_, String const& qualified_name, JS::GCPtr<DocumentType> doctype) const
 {
-    // FIXME: 1. Let document be a new XMLDocument
-    auto xml_document = Document::create(realm());
+    // 1. Let document be a new XMLDocument
+    auto xml_document = XMLDocument::create(realm());
 
     xml_document->set_ready_for_post_load_tasks(true);
 

--- a/Userland/Libraries/LibWeb/DOM/XMLDocument.h
+++ b/Userland/Libraries/LibWeb/DOM/XMLDocument.h
@@ -15,7 +15,7 @@ class XMLDocument final : public Document {
     JS_DECLARE_ALLOCATOR(XMLDocument);
 
 public:
-    static JS::NonnullGCPtr<XMLDocument> create(JS::Realm&, AK::URL const&);
+    static JS::NonnullGCPtr<XMLDocument> create(JS::Realm&, AK::URL const& url = "about:blank"sv);
     virtual ~XMLDocument() override = default;
 
 private:

--- a/Userland/Libraries/LibWeb/HTML/DOMParser.cpp
+++ b/Userland/Libraries/LibWeb/HTML/DOMParser.cpp
@@ -6,6 +6,7 @@
 
 #include <LibWeb/Bindings/DOMParserPrototype.h>
 #include <LibWeb/Bindings/MainThreadVM.h>
+#include <LibWeb/DOM/XMLDocument.h>
 #include <LibWeb/HTML/DOMParser.h>
 #include <LibWeb/HTML/HTMLDocument.h>
 #include <LibWeb/HTML/Parser/HTMLParser.h>
@@ -59,7 +60,7 @@ JS::NonnullGCPtr<DOM::Document> DOMParser::parse_from_string(StringView string, 
         parser->run("about:blank"sv);
     } else {
         // -> Otherwise
-        document = DOM::Document::create(realm(), verify_cast<HTML::Window>(relevant_global_object(*this)).associated_document().url());
+        document = DOM::XMLDocument::create(realm(), verify_cast<HTML::Window>(relevant_global_object(*this)).associated_document().url());
         document->set_content_type(Bindings::idl_enum_to_string(type));
 
         // 1. Create an XML parser parse, associated with document, and with XML scripting support disabled.


### PR DESCRIPTION
I was playing around again trying to figure out why attributes are not having namespaces applied, and stumbled across these small fixes (and a crash).