### PR TITLE
HackStudio: Correctly handle invalid addresses during backtrace creation

### DIFF
--- a/Userland/DevTools/HackStudio/Debugger/BacktraceModel.cpp
+++ b/Userland/DevTools/HackStudio/Debugger/BacktraceModel.cpp
@@ -33,34 +33,34 @@ GUI::ModelIndex BacktraceModel::index(int row, int column, const GUI::ModelIndex
 
 Vector<BacktraceModel::FrameInfo> BacktraceModel::create_backtrace(Debug::ProcessInspector const& inspector, PtraceRegisters const& regs)
 {
-    FlatPtr current_ebp = regs.bp();
-    FlatPtr current_instruction = regs.ip();
+    FlatPtr current_frame_pointer = regs.bp();
+    FlatPtr current_program_counter = regs.ip();
     Vector<BacktraceModel::FrameInfo> frames;
     size_t frame_index = 0;
     do {
-        auto lib = inspector.library_at(current_instruction);
+        auto lib = inspector.library_at(current_program_counter);
         if (!lib)
             continue;
 
         // After the first frame, current_instruction holds the return address from the function call.
         // We need to go back to the 'call' instruction to get accurate source position information.
         if (frame_index > 0)
-            --current_instruction;
-        ByteString name = lib->debug_info->elf().symbolicate(current_instruction - lib->base_address);
+            --current_program_counter;
+        ByteString name = lib->debug_info->elf().symbolicate(current_program_counter - lib->base_address);
         if (name.is_empty()) {
-            dbgln("BacktraceModel: couldn't find containing function for address: {:p} (library={})", current_instruction, lib->name);
+            dbgln("BacktraceModel: couldn't find containing function for address: {:p} (library={})", current_program_counter, lib->name);
             name = "<missing>";
         }
 
-        auto source_position = lib->debug_info->get_source_position(current_instruction - lib->base_address);
+        auto source_position = lib->debug_info->get_source_position(current_program_counter - lib->base_address);
 
-        frames.append({ name, current_instruction, current_ebp, source_position });
-        auto frame_info = Debug::StackFrameUtils::get_info(inspector, current_ebp);
+        frames.append({ name, current_program_counter, current_frame_pointer, source_position });
+        auto frame_info = Debug::StackFrameUtils::get_info(inspector, current_frame_pointer);
         VERIFY(frame_info.has_value());
-        current_instruction = frame_info.value().return_address;
-        current_ebp = frame_info.value().next_ebp;
+        current_program_counter = frame_info.value().return_address;
+        current_frame_pointer = frame_info.value().next_ebp;
         ++frame_index;
-    } while (current_ebp && current_instruction);
+    } while (current_frame_pointer && current_program_counter);
     return frames;
 }
 


### PR DESCRIPTION
This fixes a bug where we previously would hang if we couldn't find a library containing the current program counter.

I came across this bug while trying to fix backtrace generation on RISC-V.