### PR TITLE
LibPDF: An Encoding's /Differences entry is optional

### DIFF
--- a/Userland/Libraries/LibPDF/Encoding.cpp
+++ b/Userland/Libraries/LibPDF/Encoding.cpp
@@ -50,22 +50,24 @@ PDFErrorOr<NonnullRefPtr<Encoding>> Encoding::from_object(Document* document, No
     encoding->m_descriptors = TRY(base_encoding->m_descriptors.clone());
     encoding->m_name_mapping = TRY(base_encoding->m_name_mapping.clone());
 
-    auto differences_array = TRY(dict->get_array(document, CommonNames::Differences));
+    if (dict->contains(CommonNames::Differences)) {
+        auto differences_array = TRY(dict->get_array(document, CommonNames::Differences));
 
-    u16 current_code_point = 0;
-    bool first = true;
+        u16 current_code_point = 0;
+        bool first = true;
 
-    for (auto& item : *differences_array) {
-        if (item.has_u32()) {
-            current_code_point = item.to_int();
-            first = false;
-        } else {
-            VERIFY(item.has<NonnullRefPtr<Object>>());
-            VERIFY(!first);
-            auto& object = item.get<NonnullRefPtr<Object>>();
-            auto name = object->cast<NameObject>()->name();
-            encoding->set(current_code_point, name);
-            current_code_point++;
+        for (auto& item : *differences_array) {
+            if (item.has_u32()) {
+                current_code_point = item.to_int();
+                first = false;
+            } else {
+                VERIFY(item.has<NonnullRefPtr<Object>>());
+                VERIFY(!first);
+                auto& object = item.get<NonnullRefPtr<Object>>();
+                auto name = object->cast<NameObject>()->name();
+                encoding->set(current_code_point, name);
+                current_code_point++;
+            }
         }
     }
 

--- a/Userland/Libraries/LibPDF/Encoding.cpp
+++ b/Userland/Libraries/LibPDF/Encoding.cpp
@@ -42,6 +42,11 @@ PDFErrorOr<NonnullRefPtr<Encoding>> Encoding::from_object(Document* document, No
         auto base_encoding_obj = MUST(dict->get_object(document, CommonNames::BaseEncoding));
         base_encoding = TRY(Encoding::from_object(document, base_encoding_obj));
     } else {
+        // FIXME:
+        // "If this entry is absent, the Differences entry describes differences from an implicit base encoding.
+        // For a font program that is embedded in the PDF file, the implicit base encoding is the font program’s built-in encoding,
+        // as described above and further elaborated in the sections on specific font types below.
+        // Otherwise, for a nonsymbolic font, it is StandardEncoding, and for a symbolic font, it is the font’s built-in encoding."
         base_encoding = Encoding::standard_encoding();
     }
 


### PR DESCRIPTION
Per "TABLE 5.11 Entries in an encoding dictionary", /Differences is
optional.

(Per "Encodings for TrueType Fonts" in 5.5.5 Character Encoding,
nonsymbolic truetype fonts are even recommended to have "no Differences
array." But in practice, most seem to have it.)

Fixes crashes on:
* 0000001.pdf
* 0000574.pdf
* 0000337.pdf

All three don't render super great, but at least they no longer crash.

---

Just adds an if and indents the body, no other change.

Form 8 crashes with 5 distinct stacks to 5 crashes with 4 distinct stacks on the 1000 pdf 0000.zip PDFA test set.