### PR TITLE
Calculator: Allow system shortcuts

### DIFF
--- a/Userland/Applications/Calculator/CalculatorWidget.cpp
+++ b/Userland/Applications/Calculator/CalculatorWidget.cpp
@@ -184,6 +184,8 @@ void CalculatorWidget::keydown_event(GUI::KeyEvent& event)
         m_divide_button->click();
     else if (event.code_point() == '%')
         m_percent_button->click();
+    else
+        event.ignore();
 
     update_display();
 }


### PR DESCRIPTION
Before the key events for shortcuts such as ALT-F4 did not work as the widget was swallowing up the shortcut. This changes ignores the event if nothing else matched