### PR TITLE
Browser: Allow system shortcuts to function

### DIFF
--- a/Userland/Applications/Browser/BrowserWindow.cpp
+++ b/Userland/Applications/Browser/BrowserWindow.cpp
@@ -720,6 +720,10 @@ void BrowserWindow::event(Core::Event& event)
     case GUI::Event::Resize:
         broadcast_window_size(static_cast<GUI::ResizeEvent&>(event).size());
         break;
+    case GUI::Event::KeyDown:
+        // FIXME: add support for hotkeys *within* ladybird
+        event.ignore();
+        break;
     default:
         break;
     }


### PR DESCRIPTION
Before shortcuts like ALT-F4, etc did not work. This makes the window ignore keydown events. In the future this may be altered to allow for custom shortcuts from within ladybird?