### PR TITLE
LibELF: Ignore RISC-V attribute section program header

### DIFF
--- a/Userland/Libraries/LibELF/ELFABI.h
+++ b/Userland/Libraries/LibELF/ELFABI.h
@@ -482,18 +482,20 @@ typedef struct {
 } Elf64_Phdr;
 
 /* Segment types - p_type */
-#define PT_NULL 0            /* unused */
-#define PT_LOAD 1            /* loadable segment */
-#define PT_DYNAMIC 2         /* dynamic linking section */
-#define PT_INTERP 3          /* the RTLD */
-#define PT_NOTE 4            /* auxiliary information */
-#define PT_SHLIB 5           /* reserved - purpose undefined */
-#define PT_PHDR 6            /* program header */
-#define PT_TLS 7             /* thread local storage */
-#define PT_LOOS 0x60000000   /* reserved range for OS */
-#define PT_HIOS 0x6fffffff   /*  specific segment types */
-#define PT_LOPROC 0x70000000 /* reserved range for processor */
-#define PT_HIPROC 0x7fffffff /*  specific segment types */
+#define PT_NULL 0          /* unused */
+#define PT_LOAD 1          /* loadable segment */
+#define PT_DYNAMIC 2       /* dynamic linking section */
+#define PT_INTERP 3        /* the RTLD */
+#define PT_NOTE 4          /* auxiliary information */
+#define PT_SHLIB 5         /* reserved - purpose undefined */
+#define PT_PHDR 6          /* program header */
+#define PT_TLS 7           /* thread local storage */
+#define PT_LOOS 0x60000000 /* reserved range for OS */
+#define PT_HIOS 0x6fffffff /* specific segment types */
+
+#define PT_LOPROC 0x70000000           /* start of reserved range for processor specific segment types */
+#define PT_RISCV_ATTRIBUTES 0x70000003 /* RISC-V ELF attribute section */
+#define PT_HIPROC 0x7fffffff           /* end of reserved range for processor specific segment types */
 
 #define PT_GNU_EH_FRAME 0x6474e550 /* Exception handling info */
 #define PT_GNU_RELRO 0x6474e552    /* Read-only after relocation */

--- a/Userland/Libraries/LibELF/Validation.cpp
+++ b/Userland/Libraries/LibELF/Validation.cpp
@@ -231,6 +231,12 @@ ErrorOr<bool> validate_program_headers(Elf_Ehdr const& elf_header, size_t file_s
     for (size_t header_index = 0; header_index < num_program_headers; ++header_index) {
         auto& program_header = program_header_begin[header_index];
 
+        if (elf_header.e_machine == EM_RISCV && program_header.p_type == PT_RISCV_ATTRIBUTES) {
+            // TODO: Handle RISC-V attribute section.
+            //       We have to continue here, as `p_memsz` is 0 when using the GNU toolchain
+            continue;
+        }
+
         if (program_header.p_filesz > program_header.p_memsz) {
             if (verbose)
                 dbgln("Program header ({}) has p_filesz ({}) larger than p_memsz ({})", header_index, program_header.p_filesz, program_header.p_memsz);


### PR DESCRIPTION
We have to skip our usual validations, as the checks might not hold for this program header type (and the checks wouldn't really make sense for PT_RISCV_ATTRIBUTES either).

PT_RISCV_ATTRIBUTES is defined here:
https://github.com/riscv-non-isa/riscv-elf-psabi-doc/blob/v1.0/riscv-elf.adoc#program-header-table