### PR TITLE
Kernel/riscv64: Add SBI-based shutdown and reboot support

### DIFF
--- a/Kernel/Arch/riscv64/PowerState.cpp
+++ b/Kernel/Arch/riscv64/PowerState.cpp
@@ -5,17 +5,24 @@
  */
 
 #include <Kernel/Arch/PowerState.h>
+#include <Kernel/Arch/riscv64/SBI.h>
 
 namespace Kernel {
 
 void arch_specific_reboot()
 {
-    TODO_RISCV64();
+    auto ret = SBI::SystemReset::system_reset(SBI::SystemReset::ResetType::ColdReboot, SBI::SystemReset::ResetReason::NoReason);
+    dbgln("SBI: Failed to reboot: {}", ret);
+    dbgln("SBI: Attempting to shut down using the legacy extension...");
+    SBI::Legacy::shutdown();
 }
 
 void arch_specific_poweroff()
 {
-    TODO_RISCV64();
+    auto ret = SBI::SystemReset::system_reset(SBI::SystemReset::ResetType::Shutdown, SBI::SystemReset::ResetReason::NoReason);
+    dbgln("SBI: Failed to shut down: {}", ret);
+    dbgln("SBI: Attempting to shut down using the legacy extension...");
+    SBI::Legacy::shutdown();
 }
 
 }

--- a/Kernel/Arch/riscv64/SBI.cpp
+++ b/Kernel/Arch/riscv64/SBI.cpp
@@ -86,6 +86,17 @@ SBIErrorOr<long> get_mimpid()
 
 namespace Legacy {
 
+static long sbi_legacy_ecall0(LegacyEID extension_id)
+{
+    register unsigned long a0 asm("a0");
+    register unsigned long a7 asm("a7") = to_underlying(extension_id);
+    asm volatile("ecall"
+                 : "=r"(a0)
+                 : "r"(a7)
+                 : "memory");
+    return static_cast<long>(a0);
+}
+
 static long sbi_legacy_ecall1(LegacyEID extension_id, unsigned long arg0)
 {
     register unsigned long a0 asm("a0") = arg0;
@@ -113,6 +124,13 @@ LegacySBIErrorOr<void> console_putchar(int ch)
         return {};
 
     return err;
+}
+
+void shutdown()
+{
+    sbi_legacy_ecall0(LegacyEID::SystemShutdown);
+
+    VERIFY_NOT_REACHED();
 }
 
 }

--- a/Kernel/Arch/riscv64/SBI.h
+++ b/Kernel/Arch/riscv64/SBI.h
@@ -46,6 +46,8 @@ enum class EID : i32 {
     Base = 0x10,
     // Debug Console Extension ("DBCN")
     DebugConsole = 0x4442434E,
+    // System Reset Extension ("SRST")
+    SystemReset = 0x53525354,
     // Timer Extension ("TIME")
     Timer = 0x54494D45,
 };
@@ -152,6 +154,32 @@ enum class FID : i32 {
 // Programs the clock for next event after stime_value time. stime_value is in absolute time. This
 // function must clear the pending timer interrupt bit as well.
 SBIErrorOr<void> set_timer(u64 stime_value);
+
+}
+
+// Chapter 10. System Reset Extension (EID #0x53525354 "SRST")
+// Since SBI v0.2
+namespace SystemReset {
+
+enum class FID : i32 {
+    SystemReset = 0,
+};
+
+enum class ResetType : u32 {
+    Shutdown = 0x0,
+    ColdReboot = 0x1,
+    WarmReboot = 0x2,
+};
+
+enum class ResetReason : u32 {
+    NoReason = 0x0,
+    SystemFailure = 0x1,
+};
+
+// System reset (FID #0)
+// Reset the system based on provided reset_type and reset_reason. This is a synchronous call and
+// does not return if it succeeds.
+SBIError system_reset(ResetType reset_type, ResetReason reset_reason);
 
 }
 

--- a/Kernel/Arch/riscv64/SBI.h
+++ b/Kernel/Arch/riscv64/SBI.h
@@ -204,6 +204,50 @@ void initialize();
 }
 
 template<>
+struct AK::Formatter<Kernel::SBI::SBIError> : Formatter<StringView> {
+    ErrorOr<void> format(FormatBuilder& builder, Kernel::SBI::SBIError error)
+    {
+        auto string = "Unknown error"sv;
+
+        using enum Kernel::SBI::SBIError;
+        switch (error) {
+        case Success:
+            string = "Completed successfully"sv;
+            break;
+        case Failed:
+            string = "Failed"sv;
+            break;
+        case NotSupported:
+            string = "Not supported"sv;
+            break;
+        case InvalidParam:
+            string = "Invalid parameter(s)"sv;
+            break;
+        case Denied:
+            string = "Denied or not allowed"sv;
+            break;
+        case InvalidAddress:
+            string = "Invalid address(s)"sv;
+            break;
+        case AlreadyAvailable:
+            string = "Already available"sv;
+            break;
+        case AlreadyStarted:
+            string = "Already started"sv;
+            break;
+        case AlreadyStopped:
+            string = "Already stopped"sv;
+            break;
+        case NoSHMEM:
+            string = "Shared memory not available"sv;
+            break;
+        }
+
+        return builder.put_string(string);
+    }
+};
+
+template<>
 struct AK::Formatter<Kernel::SBI::Base::SpecificationVersion> : Formatter<FormatString> {
     ErrorOr<void> format(FormatBuilder& builder, Kernel::SBI::Base::SpecificationVersion const& version)
     {

--- a/Kernel/Arch/riscv64/SBI.h
+++ b/Kernel/Arch/riscv64/SBI.h
@@ -133,6 +133,11 @@ LegacySBIErrorOr<void> set_timer(u64 stime_value);
 // Write data present in ch to debug console.
 LegacySBIErrorOr<void> console_putchar(int ch);
 
+// System Shutdown (EID #0x08)
+// Puts all the harts to shutdown state from supervisor point of view.
+// This SBI call doesn’t return irrespective whether it succeeds or fails.
+[[noreturn]] void shutdown();
+
 }
 
 // Chapter 6. Timer Extension (EID #0x54494D45 "TIME")

--- a/Kernel/Library/Panic.cpp
+++ b/Kernel/Library/Panic.cpp
@@ -10,6 +10,8 @@
 #    include <Kernel/Arch/x86_64/Shutdown.h>
 #elif ARCH(AARCH64)
 #    include <Kernel/Arch/aarch64/RPi/Watchdog.h>
+#elif ARCH(RISCV64)
+#    include <Kernel/Arch/riscv64/SBI.h>
 #endif
 #include <Kernel/Boot/CommandLine.h>
 #include <Kernel/KSyms.h>
@@ -25,6 +27,11 @@ namespace Kernel {
     virtualbox_shutdown();
 #elif ARCH(AARCH64)
     RPi::Watchdog::the().system_shutdown();
+#elif ARCH(RISCV64)
+    auto ret = SBI::SystemReset::system_reset(SBI::SystemReset::ResetType::Shutdown, SBI::SystemReset::ResetReason::SystemFailure);
+    dbgln("SBI: Failed to shut down: {}", ret);
+    dbgln("SBI: Attempting to shut down using the legacy extension...");
+    SBI::Legacy::shutdown();
 #endif
     // Note: If we failed to invoke platform shutdown, we need to halt afterwards
     // to ensure no further execution on any CPU still happens.


### PR DESCRIPTION
This PR adds support for rebooting and shutting down using the SBI.

I am not sure if there is a better (or preferred) way of formatting enums, but this method seems to be used in other places. Or should I just print the error code, not a message?