### PR TITLE
LibGfx/GIF: Only parse global color table if header flag is set

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/GIFLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/GIFLoader.cpp
@@ -250,11 +250,9 @@ static ErrorOr<void> load_header_and_logical_screen(GIFLoadingContext& context)
 
     if (global_color_table_flag) {
         u8 bits_per_pixel = (packed_fields & 7) + 1;
-        int color_map_entry_count = 1;
-        for (int i = 0; i < bits_per_pixel; ++i)
-            color_map_entry_count *= 2;
+        size_t color_map_entry_count = 1 << bits_per_pixel;
 
-        for (int i = 0; i < color_map_entry_count; ++i) {
+        for (size_t i = 0; i < color_map_entry_count; ++i) {
             u8 r = TRY(context.stream.read_value<u8>());
             u8 g = TRY(context.stream.read_value<u8>());
             u8 b = TRY(context.stream.read_value<u8>());


### PR DESCRIPTION
This fixes an issue where GIF images without a global color table would have the first segment incorrectly interpreted as color table data.

Makes many more screenshots appear on https://virtuallyfun.com/ :^)

Before:
![Screenshot at 2024-01-04 21-49-53](https://github.com/SerenityOS/serenity/assets/5954907/898cd52b-2735-4d06-acdd-b755ed9e3cf3)

After:
![Screenshot at 2024-01-04 21-49-59](https://github.com/SerenityOS/serenity/assets/5954907/72eb3946-3cfa-4a6a-869f-e4b6a70d4bef)
