### PR TITLE
Kernel+Userland: Propagate proper filetypes in SysFS, ProcFS and DevPtsFS, add the listdir utility

### DIFF
--- a/Base/usr/share/man/man1/listdir.md
+++ b/Base/usr/share/man/man1/listdir.md
@@ -1,0 +1,43 @@
+## Name
+
+lsdir - list directory entries
+
+## Synopsis
+
+```**sh
+# lsdir [options...] [path...]
+```
+
+## Description
+
+This utility will list all directory entries of a given path (or list of paths)
+and print their inode number and file type (in either POSIX DT_* format or human readable).
+
+The utility uses `LibCore` `DirIterator` object and restrict its functionality
+to the `get_dir_entries` syscall only, to get the raw values of each directory
+entry.
+
+## Options
+
+* `-P`, `--posix-names`: Show POSIX names for file types
+* `-t`, `--total-entries-count`: Print count of listed entries when traversing a directory
+
+## Arguments
+
+* `path`: Directory to list
+
+## Examples
+
+```sh
+# List directory entries of working directory
+$ lsdir
+# List directory entries of /proc directory 
+$ lsdir /proc
+# List directory entries of /proc directory with POSIX names for file types
+$ lsdir -P /proc
+# List directory entries of /proc directory and print in the end the count of traversed entries
+$ lsdir -t /proc
+```
+
+## See also
+* [`ls`(1)](help://man/1/ls)

--- a/Kernel/FileSystem/DevPtsFS/FileSystem.cpp
+++ b/Kernel/FileSystem/DevPtsFS/FileSystem.cpp
@@ -44,6 +44,11 @@ Inode& DevPtsFS::root_inode()
     return *m_root_inode;
 }
 
+u8 DevPtsFS::internal_file_type_to_directory_entry_type(DirectoryEntryView const& entry) const
+{
+    return ram_backed_file_type_to_directory_entry_type(entry);
+}
+
 ErrorOr<NonnullRefPtr<Inode>> DevPtsFS::get_inode(InodeIdentifier inode_id) const
 {
     if (inode_id.index() == 1)

--- a/Kernel/FileSystem/DevPtsFS/FileSystem.h
+++ b/Kernel/FileSystem/DevPtsFS/FileSystem.h
@@ -28,6 +28,8 @@ public:
     virtual Inode& root_inode() override;
 
 private:
+    virtual u8 internal_file_type_to_directory_entry_type(DirectoryEntryView const& entry) const override;
+
     DevPtsFS();
     ErrorOr<NonnullRefPtr<Inode>> get_inode(InodeIdentifier) const;
 

--- a/Kernel/FileSystem/ProcFS/Definitions.h
+++ b/Kernel/FileSystem/ProcFS/Definitions.h
@@ -8,45 +8,46 @@
 
 #include <AK/StringView.h>
 #include <AK/Types.h>
+#include <Kernel/FileSystem/RAMBackedFileType.h>
 
 namespace Kernel {
 
 struct segmented_global_inode_index {
     StringView name;
-    u8 file_type;
+    RAMBackedFileType file_type;
     u32 primary;
     u16 subdirectory;
     u32 property;
 };
 
 constexpr segmented_global_inode_index global_inode_ids[] = {
-    { "."sv, DT_DIR, 0, 0, 1 }, // NOTE: This is here for the root directory
-    { "self"sv, DT_DIR, 0, 0, 2 }
+    { "."sv, RAMBackedFileType::Directory, 0, 0, 1 }, // NOTE: This is here for the root directory
+    { "self"sv, RAMBackedFileType::Directory, 0, 0, 2 }
 };
 
 struct segmented_process_directory_entry {
     StringView name;
-    u8 file_type;
+    RAMBackedFileType file_type;
     u16 subdirectory;
     u32 property;
 };
 
-constexpr segmented_process_directory_entry main_process_directory_root_entry = { "."sv, DT_DIR, 0, 0 };
-constexpr segmented_process_directory_entry process_fd_subdirectory_root_entry = { "."sv, DT_DIR, 1, 0 };
-constexpr segmented_process_directory_entry process_stacks_subdirectory_root_entry = { "."sv, DT_DIR, 2, 0 };
-constexpr segmented_process_directory_entry process_children_subdirectory_root_entry = { "."sv, DT_DIR, 3, 0 };
+constexpr segmented_process_directory_entry main_process_directory_root_entry = { "."sv, RAMBackedFileType::Directory, 0, 0 };
+constexpr segmented_process_directory_entry process_fd_subdirectory_root_entry = { "."sv, RAMBackedFileType::Directory, 1, 0 };
+constexpr segmented_process_directory_entry process_stacks_subdirectory_root_entry = { "."sv, RAMBackedFileType::Directory, 2, 0 };
+constexpr segmented_process_directory_entry process_children_subdirectory_root_entry = { "."sv, RAMBackedFileType::Directory, 3, 0 };
 
-constexpr segmented_process_directory_entry process_fd_directory_entry = { "fd"sv, DT_DIR, 1, 0 };
-constexpr segmented_process_directory_entry process_stacks_directory_entry = { "stacks"sv, DT_DIR, 2, 0 };
-constexpr segmented_process_directory_entry process_children_directory_entry = { "children"sv, DT_DIR, 3, 0 };
-constexpr segmented_process_directory_entry process_unveil_list_entry = { "unveil"sv, DT_REG, 0, 1 };
-constexpr segmented_process_directory_entry process_pledge_list_entry = { "pledge"sv, DT_REG, 0, 2 };
-constexpr segmented_process_directory_entry process_fds_list_entry = { "fds"sv, DT_REG, 0, 3 };
-constexpr segmented_process_directory_entry process_exe_symlink_entry = { "exe"sv, DT_LNK, 0, 4 };
-constexpr segmented_process_directory_entry process_cwd_symlink_entry = { "cwd"sv, DT_LNK, 0, 5 };
-constexpr segmented_process_directory_entry process_perf_events_entry = { "perf_events"sv, DT_REG, 0, 6 };
-constexpr segmented_process_directory_entry process_vm_entry = { "vm"sv, DT_REG, 0, 7 };
-constexpr segmented_process_directory_entry process_cmdline_entry = { "cmdline"sv, DT_REG, 0, 8 };
+constexpr segmented_process_directory_entry process_fd_directory_entry = { "fd"sv, RAMBackedFileType::Directory, 1, 0 };
+constexpr segmented_process_directory_entry process_stacks_directory_entry = { "stacks"sv, RAMBackedFileType::Directory, 2, 0 };
+constexpr segmented_process_directory_entry process_children_directory_entry = { "children"sv, RAMBackedFileType::Directory, 3, 0 };
+constexpr segmented_process_directory_entry process_unveil_list_entry = { "unveil"sv, RAMBackedFileType::Regular, 0, 1 };
+constexpr segmented_process_directory_entry process_pledge_list_entry = { "pledge"sv, RAMBackedFileType::Regular, 0, 2 };
+constexpr segmented_process_directory_entry process_fds_list_entry = { "fds"sv, RAMBackedFileType::Regular, 0, 3 };
+constexpr segmented_process_directory_entry process_exe_symlink_entry = { "exe"sv, RAMBackedFileType::Link, 0, 4 };
+constexpr segmented_process_directory_entry process_cwd_symlink_entry = { "cwd"sv, RAMBackedFileType::Link, 0, 5 };
+constexpr segmented_process_directory_entry process_perf_events_entry = { "perf_events"sv, RAMBackedFileType::Regular, 0, 6 };
+constexpr segmented_process_directory_entry process_vm_entry = { "vm"sv, RAMBackedFileType::Regular, 0, 7 };
+constexpr segmented_process_directory_entry process_cmdline_entry = { "cmdline"sv, RAMBackedFileType::Regular, 0, 8 };
 constexpr segmented_process_directory_entry main_process_directory_entries[] = {
     process_fd_directory_entry,
     process_stacks_directory_entry,

--- a/Kernel/FileSystem/ProcFS/FileSystem.cpp
+++ b/Kernel/FileSystem/ProcFS/FileSystem.cpp
@@ -8,6 +8,7 @@
 
 #include <Kernel/FileSystem/ProcFS/FileSystem.h>
 #include <Kernel/FileSystem/ProcFS/Inode.h>
+#include <Kernel/FileSystem/RAMBackedFileType.h>
 
 namespace Kernel {
 
@@ -30,6 +31,11 @@ ErrorOr<void> ProcFS::initialize()
 {
     m_root_inode = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) ProcFSInode(const_cast<ProcFS&>(*this), 1)));
     return {};
+}
+
+u8 ProcFS::internal_file_type_to_directory_entry_type(DirectoryEntryView const& entry) const
+{
+    return ram_backed_file_type_to_directory_entry_type(entry);
 }
 
 Inode& ProcFS::root_inode()

--- a/Kernel/FileSystem/ProcFS/FileSystem.h
+++ b/Kernel/FileSystem/ProcFS/FileSystem.h
@@ -28,6 +28,8 @@ public:
     virtual Inode& root_inode() override;
 
 private:
+    virtual u8 internal_file_type_to_directory_entry_type(DirectoryEntryView const& entry) const override;
+
     ProcFS();
 
     ErrorOr<NonnullRefPtr<Inode>> get_inode(InodeIdentifier) const;

--- a/Kernel/FileSystem/RAMBackedFileType.h
+++ b/Kernel/FileSystem/RAMBackedFileType.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2024, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Types.h>
+#include <Kernel/API/POSIX/sys/stat.h>
+#include <Kernel/FileSystem/FileSystem.h>
+
+namespace Kernel {
+
+enum class RAMBackedFileType : u8 {
+    Directory,
+    Character,
+    Block,
+    Regular,
+    FIFO,
+    Link,
+    Socket,
+    Unknown,
+};
+
+inline RAMBackedFileType ram_backed_file_type_from_mode(mode_t mode)
+{
+    switch (mode & S_IFMT) {
+    case S_IFDIR:
+        return RAMBackedFileType::Directory;
+    case S_IFCHR:
+        return RAMBackedFileType::Character;
+    case S_IFBLK:
+        return RAMBackedFileType::Block;
+    case S_IFREG:
+        return RAMBackedFileType::Regular;
+    case S_IFIFO:
+        return RAMBackedFileType::FIFO;
+    case S_IFLNK:
+        return RAMBackedFileType::Link;
+    case S_IFSOCK:
+        return RAMBackedFileType::Socket;
+    default:
+        return RAMBackedFileType::Unknown;
+    }
+}
+
+inline u8 ram_backed_file_type_to_directory_entry_type(FileSystem::DirectoryEntryView const& entry)
+{
+    switch (static_cast<RAMBackedFileType>(entry.file_type)) {
+    case RAMBackedFileType::Directory:
+        return DT_DIR;
+    case RAMBackedFileType::Character:
+        return DT_CHR;
+    case RAMBackedFileType::Block:
+        return DT_BLK;
+    case RAMBackedFileType::Regular:
+        return DT_REG;
+    case RAMBackedFileType::FIFO:
+        return DT_FIFO;
+    case RAMBackedFileType::Link:
+        return DT_LNK;
+    case RAMBackedFileType::Socket:
+        return DT_SOCK;
+    case RAMBackedFileType::Unknown:
+    default:
+        return DT_UNKNOWN;
+    }
+}
+
+}

--- a/Kernel/FileSystem/RAMFS/FileSystem.cpp
+++ b/Kernel/FileSystem/RAMFS/FileSystem.cpp
@@ -1,10 +1,11 @@
 /*
  * Copyright (c) 2019-2020, Sergey Bugaev <bugaevc@serenityos.org>
- * Copyright (c) 2022-2023, Liav A. <liavalb@hotmail.co.il>
+ * Copyright (c) 2022-2024, Liav A. <liavalb@hotmail.co.il>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <Kernel/FileSystem/RAMBackedFileType.h>
 #include <Kernel/FileSystem/RAMFS/FileSystem.h>
 #include <Kernel/FileSystem/RAMFS/Inode.h>
 
@@ -39,25 +40,7 @@ unsigned RAMFS::next_inode_index()
 
 u8 RAMFS::internal_file_type_to_directory_entry_type(DirectoryEntryView const& entry) const
 {
-    switch (static_cast<FileType>(entry.file_type)) {
-    case FileType::Directory:
-        return DT_DIR;
-    case FileType::Character:
-        return DT_CHR;
-    case FileType::Block:
-        return DT_BLK;
-    case FileType::Regular:
-        return DT_REG;
-    case FileType::FIFO:
-        return DT_FIFO;
-    case FileType::Link:
-        return DT_LNK;
-    case FileType::Socket:
-        return DT_SOCK;
-    case FileType::Unknown:
-    default:
-        return DT_UNKNOWN;
-    }
+    return ram_backed_file_type_to_directory_entry_type(entry);
 }
 
 }

--- a/Kernel/FileSystem/RAMFS/FileSystem.h
+++ b/Kernel/FileSystem/RAMFS/FileSystem.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2019-2020, Sergey Bugaev <bugaevc@serenityos.org>
- * Copyright (c) 2022-2023, Liav A. <liavalb@hotmail.co.il>
+ * Copyright (c) 2022-2024, Liav A. <liavalb@hotmail.co.il>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -28,17 +28,6 @@ public:
     virtual Inode& root_inode() override;
 
     virtual u8 internal_file_type_to_directory_entry_type(DirectoryEntryView const& entry) const override;
-
-    enum class FileType : u8 {
-        Directory,
-        Character,
-        Block,
-        Regular,
-        FIFO,
-        Link,
-        Socket,
-        Unknown,
-    };
 
 private:
     RAMFS();

--- a/Kernel/FileSystem/RAMFS/Inode.cpp
+++ b/Kernel/FileSystem/RAMFS/Inode.cpp
@@ -1,10 +1,11 @@
 /*
  * Copyright (c) 2019-2020, Sergey Bugaev <bugaevc@serenityos.org>
- * Copyright (c) 2022-2023, Liav A. <liavalb@hotmail.co.il>
+ * Copyright (c) 2022-2024, Liav A. <liavalb@hotmail.co.il>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <Kernel/FileSystem/RAMBackedFileType.h>
 #include <Kernel/FileSystem/RAMFS/FileSystem.h>
 #include <Kernel/FileSystem/RAMFS/Inode.h>
 #include <Kernel/Tasks/Process.h>
@@ -50,28 +51,6 @@ InodeMetadata RAMFSInode::metadata() const
     return m_metadata;
 }
 
-static RAMFS::FileType file_type_from_mode(mode_t mode)
-{
-    switch (mode & S_IFMT) {
-    case S_IFDIR:
-        return RAMFS::FileType::Directory;
-    case S_IFCHR:
-        return RAMFS::FileType::Character;
-    case S_IFBLK:
-        return RAMFS::FileType::Block;
-    case S_IFREG:
-        return RAMFS::FileType::Regular;
-    case S_IFIFO:
-        return RAMFS::FileType::FIFO;
-    case S_IFLNK:
-        return RAMFS::FileType::Link;
-    case S_IFSOCK:
-        return RAMFS::FileType::Socket;
-    default:
-        return RAMFS::FileType::Unknown;
-    }
-}
-
 ErrorOr<void> RAMFSInode::traverse_as_directory(Function<ErrorOr<void>(FileSystem::DirectoryEntryView const&)> callback) const
 {
     MutexLocker locker(m_inode_lock, Mutex::Mode::Shared);
@@ -79,15 +58,15 @@ ErrorOr<void> RAMFSInode::traverse_as_directory(Function<ErrorOr<void>(FileSyste
     if (!is_directory())
         return ENOTDIR;
 
-    TRY(callback({ "."sv, identifier(), to_underlying(RAMFS::FileType::Directory) }));
+    TRY(callback({ "."sv, identifier(), to_underlying(RAMBackedFileType::Directory) }));
     if (m_root_directory_inode) {
-        TRY(callback({ ".."sv, identifier(), to_underlying(RAMFS::FileType::Directory) }));
+        TRY(callback({ ".."sv, identifier(), to_underlying(RAMBackedFileType::Directory) }));
     } else if (auto parent = m_parent.strong_ref()) {
-        TRY(callback({ ".."sv, parent->identifier(), to_underlying(RAMFS::FileType::Directory) }));
+        TRY(callback({ ".."sv, parent->identifier(), to_underlying(RAMBackedFileType::Directory) }));
     }
 
     for (auto& child : m_children) {
-        TRY(callback({ child.name->view(), child.inode->identifier(), to_underlying(file_type_from_mode(child.inode->metadata().mode)) }));
+        TRY(callback({ child.name->view(), child.inode->identifier(), to_underlying(ram_backed_file_type_from_mode(child.inode->metadata().mode)) }));
     }
     return {};
 }

--- a/Kernel/FileSystem/SysFS/Component.cpp
+++ b/Kernel/FileSystem/SysFS/Component.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Liav A. <liavalb@hotmail.co.il>
+ * Copyright (c) 2021-2024, Liav A. <liavalb@hotmail.co.il>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -107,18 +107,18 @@ SysFSSymbolicLink::SysFSSymbolicLink(SysFSDirectory const& parent_directory, Sys
 
 ErrorOr<void> SysFSDirectory::traverse_as_directory(FileSystemID fsid, Function<ErrorOr<void>(FileSystem::DirectoryEntryView const&)> callback) const
 {
-    TRY(callback({ "."sv, { fsid, component_index() }, 0 }));
+    TRY(callback({ "."sv, { fsid, component_index() }, to_underlying(RAMBackedFileType::Directory) }));
     if (is_root_directory()) {
-        TRY(callback({ ".."sv, { fsid, component_index() }, 0 }));
+        TRY(callback({ ".."sv, { fsid, component_index() }, to_underlying(RAMBackedFileType::Directory) }));
     } else {
         VERIFY(m_parent_directory);
-        TRY(callback({ ".."sv, { fsid, m_parent_directory->component_index() }, 0 }));
+        TRY(callback({ ".."sv, { fsid, m_parent_directory->component_index() }, to_underlying(RAMBackedFileType::Directory) }));
     }
 
     return m_child_components.with([&](auto& list) -> ErrorOr<void> {
         for (auto& child_component : list) {
             InodeIdentifier identifier = { fsid, child_component.component_index() };
-            TRY(callback({ child_component.name(), identifier, 0 }));
+            TRY(callback({ child_component.name(), identifier, to_underlying(child_component.type()) }));
         }
         return {};
     });

--- a/Kernel/FileSystem/SysFS/FileSystem.cpp
+++ b/Kernel/FileSystem/SysFS/FileSystem.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/StringView.h>
+#include <Kernel/FileSystem/RAMBackedFileType.h>
 #include <Kernel/FileSystem/SysFS/FileSystem.h>
 #include <Kernel/FileSystem/SysFS/Inode.h>
 #include <Kernel/FileSystem/SysFS/Registry.h>
@@ -23,6 +24,11 @@ ErrorOr<void> SysFS::initialize()
 {
     m_root_inode = TRY(SysFSComponentRegistry::the().root_directory().to_inode(*this));
     return {};
+}
+
+u8 SysFS::internal_file_type_to_directory_entry_type(DirectoryEntryView const& entry) const
+{
+    return ram_backed_file_type_to_directory_entry_type(entry);
 }
 
 Inode& SysFS::root_inode()

--- a/Kernel/FileSystem/SysFS/FileSystem.h
+++ b/Kernel/FileSystem/SysFS/FileSystem.h
@@ -28,6 +28,8 @@ public:
     virtual Inode& root_inode() override;
 
 private:
+    virtual u8 internal_file_type_to_directory_entry_type(DirectoryEntryView const& entry) const override;
+
     SysFS();
 
     RefPtr<SysFSInode> m_root_inode;

--- a/Tests/Kernel/CMakeLists.txt
+++ b/Tests/Kernel/CMakeLists.txt
@@ -41,6 +41,7 @@ set(LIBTEST_BASED_SOURCES
     TestEmptyPrivateInodeVMObject.cpp
     TestEmptySharedInodeVMObject.cpp
     TestExt2FS.cpp
+    TestFileSystemDirentTypes.cpp
     TestInvalidUIDSet.cpp
     TestSharedInodeVMObject.cpp
     TestPosixFallocate.cpp

--- a/Tests/Kernel/TestFileSystemDirentTypes.cpp
+++ b/Tests/Kernel/TestFileSystemDirentTypes.cpp
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2024, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/API/POSIX/dirent.h>
+#include <LibTest/TestCase.h>
+#include <dirent.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+TEST_CASE(test_sysfs_root_directory)
+{
+    auto dirfd = open("/sys/", O_RDONLY | O_DIRECTORY);
+    auto cleanup_guard = ScopeGuard([&] {
+        close(dirfd);
+    });
+
+    DIR* dir = fdopendir(dirfd);
+    EXPECT(dir != nullptr);
+
+    auto cleanup_dir_guard = ScopeGuard([&] {
+        closedir(dir);
+    });
+
+    auto* _dirent = readdir(dir);
+    EXPECT(_dirent != nullptr);
+    // NOTE: We should see '.'
+    EXPECT_EQ(_dirent->d_type, DT_DIR);
+
+    _dirent = readdir(dir);
+    EXPECT(_dirent != nullptr);
+    // NOTE: We should see '..'
+    EXPECT_EQ(_dirent->d_type, DT_DIR);
+
+    while (true) {
+        _dirent = readdir(dir);
+        if (_dirent == nullptr)
+            break;
+        // NOTE: We should only see a directory entry in the /sys directory
+        EXPECT_EQ(_dirent->d_type, DT_DIR);
+    }
+}
+
+TEST_CASE(test_devpts_root_directory)
+{
+    auto dirfd = open("/dev/pts/", O_RDONLY | O_DIRECTORY);
+    auto cleanup_guard = ScopeGuard([&] {
+        close(dirfd);
+    });
+
+    DIR* dir = fdopendir(dirfd);
+    EXPECT(dir != nullptr);
+
+    auto cleanup_dir_guard = ScopeGuard([&] {
+        closedir(dir);
+    });
+
+    auto* _dirent = readdir(dir);
+    EXPECT(_dirent != nullptr);
+    // NOTE: We should see '.'
+    EXPECT_EQ(_dirent->d_type, DT_DIR);
+
+    _dirent = readdir(dir);
+    EXPECT(_dirent != nullptr);
+    // NOTE: We should see '..'
+    EXPECT_EQ(_dirent->d_type, DT_DIR);
+}
+
+TEST_CASE(test_procfs_root_directory)
+{
+    auto dirfd = open("/proc/", O_RDONLY | O_DIRECTORY);
+    auto cleanup_guard = ScopeGuard([&] {
+        close(dirfd);
+    });
+
+    DIR* dir = fdopendir(dirfd);
+    EXPECT(dir != nullptr);
+
+    auto cleanup_dir_guard = ScopeGuard([&] {
+        closedir(dir);
+    });
+
+    auto* _dirent = readdir(dir);
+    EXPECT(_dirent != nullptr);
+    // NOTE: We should see '.' now
+    EXPECT_EQ(_dirent->d_type, DT_DIR);
+
+    _dirent = readdir(dir);
+    EXPECT(_dirent != nullptr);
+    // NOTE: We should see '..' now
+    EXPECT_EQ(_dirent->d_type, DT_DIR);
+
+    _dirent = readdir(dir);
+    EXPECT(_dirent != nullptr);
+    // NOTE: We should see 'self' now
+    EXPECT_EQ(_dirent->d_type, DT_LNK);
+}

--- a/Userland/Libraries/LibCore/DirIterator.cpp
+++ b/Userland/Libraries/LibCore/DirIterator.cpp
@@ -82,7 +82,9 @@ bool DirIterator::advance_next()
         if constexpr (dirent_has_d_type) {
             // dirent structures from readdir aren't guaranteed to contain valid file types,
             // as it is possible that the underlying filesystem doesn't keep track of those.
-            if (m_next->type == DirectoryEntry::Type::Unknown) {
+            // However, if we were requested to not do stat on the entries of this directory,
+            // the calling code will be given the raw unknown type.
+            if ((m_flags & Flags::NoStat) == 0 && m_next->type == DirectoryEntry::Type::Unknown) {
                 struct stat statbuf;
                 if (fstatat(dirfd(m_dir), de->d_name, &statbuf, AT_SYMLINK_NOFOLLOW) < 0) {
                     m_error = Error::from_errno(errno);

--- a/Userland/Libraries/LibCore/DirIterator.h
+++ b/Userland/Libraries/LibCore/DirIterator.h
@@ -20,6 +20,7 @@ public:
         NoFlags = 0x0,
         SkipDots = 0x1,
         SkipParentAndBaseDir = 0x2,
+        NoStat = 0x4,
     };
 
     explicit DirIterator(ByteString path, Flags = Flags::NoFlags);

--- a/Userland/Libraries/LibCore/DirectoryEntry.cpp
+++ b/Userland/Libraries/LibCore/DirectoryEntry.cpp
@@ -9,6 +9,56 @@
 
 namespace Core {
 
+StringView DirectoryEntry::posix_name_from_directory_entry_type(Type type)
+{
+    switch (type) {
+    case Type::BlockDevice:
+        return "DT_BLK"sv;
+    case Type::CharacterDevice:
+        return "DT_CHR"sv;
+    case Type::Directory:
+        return "DT_DIR"sv;
+    case Type::File:
+        return "DT_REG"sv;
+    case Type::NamedPipe:
+        return "DT_FIFO"sv;
+    case Type::Socket:
+        return "DT_SOCK"sv;
+    case Type::SymbolicLink:
+        return "DT_LNK"sv;
+    case Type::Unknown:
+        return "DT_UNKNOWN"sv;
+    case Type::Whiteout:
+        return "DT_WHT"sv;
+    }
+    VERIFY_NOT_REACHED();
+}
+
+StringView DirectoryEntry::representative_name_from_directory_entry_type(Type type)
+{
+    switch (type) {
+    case Type::BlockDevice:
+        return "BlockDevice"sv;
+    case Type::CharacterDevice:
+        return "CharacterDevice"sv;
+    case Type::Directory:
+        return "Directory"sv;
+    case Type::File:
+        return "File"sv;
+    case Type::NamedPipe:
+        return "NamedPipe"sv;
+    case Type::Socket:
+        return "Socket"sv;
+    case Type::SymbolicLink:
+        return "SymbolicLink"sv;
+    case Type::Unknown:
+        return "Unknown"sv;
+    case Type::Whiteout:
+        return "Whiteout"sv;
+    }
+    VERIFY_NOT_REACHED();
+}
+
 DirectoryEntry::Type DirectoryEntry::directory_entry_type_from_stat(mode_t st_mode)
 {
     switch (st_mode & S_IFMT) {

--- a/Userland/Libraries/LibCore/DirectoryEntry.h
+++ b/Userland/Libraries/LibCore/DirectoryEntry.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/ByteString.h>
+#include <AK/StringView.h>
 #include <dirent.h>
 
 namespace Core {
@@ -28,6 +29,8 @@ struct DirectoryEntry {
     ByteString name;
     ino_t inode_number;
 
+    static StringView posix_name_from_directory_entry_type(Type);
+    static StringView representative_name_from_directory_entry_type(Type);
     static Type directory_entry_type_from_stat(mode_t st_mode);
     static DirectoryEntry from_dirent(dirent const&);
     static DirectoryEntry from_stat(DIR*, dirent const&);

--- a/Userland/Utilities/listdir.cpp
+++ b/Userland/Utilities/listdir.cpp
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2024, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Function.h>
+#include <AK/StringView.h>
+#include <LibCore/ArgsParser.h>
+#include <LibCore/DirIterator.h>
+#include <LibCore/DirectoryEntry.h>
+#include <LibCore/System.h>
+#include <LibMain/Main.h>
+
+static bool flag_show_unix_posix_file_type = false;
+static bool flag_show_total_count = false;
+
+ErrorOr<int> serenity_main(Main::Arguments arguments)
+{
+    TRY(Core::System::pledge("stdio rpath"));
+
+    Vector<StringView> paths;
+
+    Core::ArgsParser args_parser;
+    args_parser.set_general_help("List Dirent entries in a directory.");
+    args_parser.add_option(flag_show_unix_posix_file_type, "Show POSIX names for file types", "posix-names", 'P');
+    args_parser.add_option(flag_show_total_count, "Show total count for each directory being iterated", "total-entries-count", 't');
+    args_parser.add_positional_argument(paths, "Directory to list", "path", Core::ArgsParser::Required::No);
+    args_parser.parse(arguments);
+
+    if (paths.is_empty())
+        paths.append("."sv);
+
+    for (auto& path : paths) {
+        Core::DirIterator di(path, Core::DirIterator::NoStat);
+        if (di.has_error()) {
+            auto error = di.error();
+            warnln("Failed to open {} - {}", path, error);
+            return error;
+        }
+
+        outln("Traversing {}", path);
+        size_t count = 0;
+
+        Function<StringView(Core::DirectoryEntry::Type)> name_from_directory_entry_type;
+        if (flag_show_unix_posix_file_type)
+            name_from_directory_entry_type = Core::DirectoryEntry::posix_name_from_directory_entry_type;
+        else
+            name_from_directory_entry_type = Core::DirectoryEntry::representative_name_from_directory_entry_type;
+
+        while (di.has_next()) {
+            auto dir_entry = di.next();
+            if (dir_entry.has_value()) {
+                outln("    {} (Type: {}, Inode number: {})",
+                    dir_entry.value().name,
+                    name_from_directory_entry_type(dir_entry.value().type),
+                    dir_entry.value().inode_number);
+                count++;
+            }
+        }
+        if (flag_show_total_count)
+            outln("Directory {} has {} which has being listed during the program runtime", path, count);
+    }
+
+    return 0;
+}


### PR DESCRIPTION
Should actually fix the problem being represented in #22533 (even though we just allow zeroed type now).

Still need to add a man page for the new `listdir` utility, but I will want to ensure I did write it correctly as well :)