### PR TITLE
LibWeb: Fail to parse cookie date when date does not exist

### DIFF
--- a/Base/res/html/misc/cookie.html
+++ b/Base/res/html/misc/cookie.html
@@ -22,6 +22,8 @@
     <label for=invalid5>The cookie is too large</label>
     <br /><input id=invalid6 type=button onclick="setCookie(this.value)" value="cookie11=value11; domain=uk.gov" />
     <label for=invalid6>The cookie's domain is on the Public Suffix List</label>
+    <br /><input id=invalid7 type=button onclick="setCookie(this.value)" value="cookie12=value12; expires=Sat, 31 Feb 2060 08:10:36 GMT" />
+    <label for=invalid4>The cookie has a date that does not exist</label>
     <br />
 
     <h3>Unretrievable cookies (the browser should accept these but not display them):</h3>

--- a/Userland/Libraries/LibWeb/Cookie/ParsedCookie.cpp
+++ b/Userland/Libraries/LibWeb/Cookie/ParsedCookie.cpp
@@ -345,7 +345,9 @@ Optional<UnixDateTime> parse_date_time(StringView date_string)
     // 6. Let the parsed-cookie-date be the date whose day-of-month, month, year, hour, minute, and second (in UTC) are the
     //    day-of-month-value, the month-value, the year-value, the hour-value, the minute-value, and the second-value, respectively.
     //    If no such date exists, abort these steps and fail to parse the cookie-date.
-    // FIXME: Fail on dates that do not exist.
+    if (day_of_month > static_cast<unsigned int>(days_in_month(year, month)))
+        return {};
+
     // FIXME: This currently uses UNIX time, which is not equivalent to UTC due to leap seconds.
     auto parsed_cookie_date = UnixDateTime::from_unix_time_parts(year, month, day_of_month, hour, minute, second, 0);
 


### PR DESCRIPTION
Previously, the cookie date validation did not validate days in the context of the month and year, resulting in dates that do not exist to be successfully parsed (e.g. February 31st). We now validate that the day does not exceed the number of days for the given month and year, taking leap years into account.