### PR TITLE
LibWeb: Reset message port receive state before dispatching events

### DIFF
--- a/AK/Span.h
+++ b/AK/Span.h
@@ -326,7 +326,7 @@ template<typename T>
 requires(IsTrivial<T>)
 ReadonlyBytes to_readonly_bytes(Span<T> span)
 {
-    return ReadonlyBytes { static_cast<void*>(span.data()), span.size() * sizeof(T) };
+    return ReadonlyBytes { static_cast<void const*>(span.data()), span.size() * sizeof(T) };
 }
 
 template<typename T>

--- a/Userland/Libraries/LibWeb/HTML/MessagePort.cpp
+++ b/Userland/Libraries/LibWeb/HTML/MessagePort.cpp
@@ -297,8 +297,11 @@ void MessagePort::read_from_socket()
 
         auto serialize_with_transfer_result = MUST(decoder.decode<SerializedTransferRecord>());
 
-        post_message_task_steps(serialize_with_transfer_result);
+        // Make sure to advance our state machine before dispatching the MessageEvent,
+        // as dispatching events can run arbitrary JS (and cause us to receive another message!)
         m_socket_state = SocketState::Header;
+
+        post_message_task_steps(serialize_with_transfer_result);
         break;
     }
     case SocketState::Error:


### PR DESCRIPTION
Dispatching events can cause arbitrary JS to run, which could cause the
event loop to be re-entered, or even post another message to the same
message port.

Fixes #22381 