### PR TITLE
LibGfx/ICC: Implement LutBToATagData::evaluate() when there is no CLUT; also add --debug-roundtrip to `icc`

### DIFF
--- a/Userland/Libraries/LibGfx/ICC/TagTypes.h
+++ b/Userland/Libraries/LibGfx/ICC/TagTypes.h
@@ -519,6 +519,9 @@ public:
     Optional<CLUTData> const& clut() const { return m_clut; }
     Optional<Vector<LutCurveType>> const& a_curves() const { return m_a_curves; }
 
+    // Returns the result of the LUT pipeline for u8 outputs.
+    ErrorOr<void> evaluate(ColorSpace connection_space, FloatVector3 const&, Bytes) const;
+
 private:
     u8 m_number_of_input_channels;
     u8 m_number_of_output_channels;
@@ -1298,6 +1301,15 @@ inline ErrorOr<FloatVector3> LutAToBTagData::evaluate(ColorSpace connection_spac
         output_color[2] = output_color[2] * 255.0f - 128.0f;
     }
     return output_color;
+}
+
+inline ErrorOr<void> LutBToATagData::evaluate(ColorSpace connection_space, FloatVector3 const&, Bytes out_bytes) const
+{
+    VERIFY(connection_space == ColorSpace::PCSXYZ || connection_space == ColorSpace::PCSLAB);
+    VERIFY(number_of_input_channels() == 3);
+    VERIFY(number_of_output_channels() == out_bytes.size());
+
+    return Error::from_string_literal("LutBToATagData::evaluate: Not yet implemented");
 }
 
 }

--- a/Userland/Libraries/LibGfx/ICC/TagTypes.h
+++ b/Userland/Libraries/LibGfx/ICC/TagTypes.h
@@ -1276,7 +1276,7 @@ inline ErrorOr<FloatVector3> LutAToBTagData::evaluate(ColorSpace connection_spac
         FloatVector3 new_color = {
             (float)e[0] * color[0] + (float)e[1] * color[1] + (float)e[2] * color[2] + (float)e[9],
             (float)e[3] * color[0] + (float)e[4] * color[1] + (float)e[5] * color[2] + (float)e[10],
-            (float)e[6] * color[0] + (float)e[7] * color[1] + (float)e[8] * color[2] + (float)e[11]
+            (float)e[6] * color[0] + (float)e[7] * color[1] + (float)e[8] * color[2] + (float)e[11],
         };
         color = new_color.clamped(0.f, 1.f);
     }


### PR DESCRIPTION
This is enough to make these work:

    for f in VideoHD VideoNTSC VideoPAL; do
        Build/lagom/bin/icc --debug-roundtrip \
            ~/Downloads/Adobe\ ICC\ Profiles\ \(end-user\)/RGB/$f.icc
    done

It's also possible to convert images to those color spaces:

    Build/lagom/bin/image -o image-pal.png \
        --convert-to-color-profile path/to/RGB/VideoPAL.icc \
        image-srgb.png

(If there's no png file with an embedded sRGB profile at hand, do first:

    Build/lagom/bin/icc --reencode-to serenity-sRGB.icc -n sRGB
    Build/lagom/bin/image -o image-srgb.png \
        --assign-color-profile serenity-sRGB.icc image-no-color-space.png

)

In color-managed viewers, images-srgb.png and image-pal.png should
look identical.

But if you either explicitly assign the sRGB profile to the pal
image, or strip the embedded color space, they'll look different
(since image viewers then assume the image in the VideoPAL space
is in sRGB):

    Build/lagom/bin/image -o image-pal-strip.png --strip-color-profile \
        image-pal.png

    Build/lagom/bin/image -o image-not-actually-srgb.png \
        --assign-color-profile serenity-sRGB.icc image-pal.png

---

icc: Add a --debug-roundtrip flag

With this, we convert a bunch of random colors to a
profile's profile connection space and back, and count
how many u8 colors make it through unchanged.

With this, you can do something like:

    for f in ~/Downloads/Adobe\ ICC\ Profiles\ \(end-user\)/*/*.icc; do
        echo $f
        Build/lagom/bin/icc --debug-roundtrip $f
    done

to test conversion through a bunch of profiles. These profiles are
available at:
https://www.adobe.com/support/downloads/iccprofiles/iccprofiles_win.html

...which ultimately leads to:
https://download.adobe.com/pub/adobe/iccprofiles/win/AdobeICCProfilesCS4Win_end-user.zip

(Or use `Build/lagom/bin/icc --debug-roundtrip -n sRGB` to test the
built-in sRGB profile.)