### PR TITLE
Ladybird: Show an informational dialog after taking a screenshot

### DIFF
--- a/Ladybird/AppKit/UI/LadybirdWebView.mm
+++ b/Ladybird/AppKit/UI/LadybirdWebView.mm
@@ -791,16 +791,43 @@ static void copy_data_to_clipboard(StringView data, NSPasteboardType pasteboard_
 
 - (void)takeVisibleScreenshot:(id)sender
 {
-    m_web_view_bridge->take_screenshot(WebView::ViewImplementation::ScreenshotType::Visible)->when_rejected([](auto const& error) {
-        (void)error; // FIXME: Display the error.
-    });
+    [self takeScreenshot:WebView::ViewImplementation::ScreenshotType::Visible];
 }
 
 - (void)takeFullScreenshot:(id)sender
 {
-    m_web_view_bridge->take_screenshot(WebView::ViewImplementation::ScreenshotType::Full)->when_rejected([](auto const& error) {
-        (void)error; // FIXME: Display the error.
-    });
+    [self takeScreenshot:WebView::ViewImplementation::ScreenshotType::Full];
+}
+
+- (void)takeScreenshot:(WebView::ViewImplementation::ScreenshotType)type
+{
+    m_web_view_bridge->take_screenshot(type)
+        ->when_resolved([self](auto const& path) {
+            auto message = MUST(String::formatted("Screenshot saved to: {}", path));
+
+            auto* dialog = [[NSAlert alloc] init];
+            [dialog setMessageText:Ladybird::string_to_ns_string(message)];
+            [[dialog addButtonWithTitle:@"OK"] setTag:NSModalResponseOK];
+            [[dialog addButtonWithTitle:@"Open folder"] setTag:NSModalResponseContinue];
+
+            __block auto* ns_path = Ladybird::string_to_ns_string(path.string());
+
+            [dialog beginSheetModalForWindow:[self window]
+                           completionHandler:^(NSModalResponse response) {
+                               if (response == NSModalResponseContinue) {
+                                   [[NSWorkspace sharedWorkspace] selectFile:ns_path inFileViewerRootedAtPath:@""];
+                               }
+                           }];
+        })
+        .when_rejected([self](auto const& error) {
+            auto error_message = MUST(String::formatted("{}", error));
+
+            auto* dialog = [[NSAlert alloc] init];
+            [dialog setMessageText:Ladybird::string_to_ns_string(error_message)];
+
+            [dialog beginSheetModalForWindow:[self window]
+                           completionHandler:nil];
+        });
 }
 
 - (void)openLink:(id)sender

--- a/Ladybird/Qt/Tab.cpp
+++ b/Ladybird/Qt/Tab.cpp
@@ -21,6 +21,7 @@
 #include <QColorDialog>
 #include <QCoreApplication>
 #include <QCursor>
+#include <QDesktopServices>
 #include <QFileDialog>
 #include <QFont>
 #include <QFontMetrics>
@@ -32,6 +33,7 @@
 #include <QMimeData>
 #include <QPainter>
 #include <QPoint>
+#include <QPushButton>
 #include <QResizeEvent>
 
 namespace Ladybird {
@@ -307,22 +309,41 @@ Tab::Tab(BrowserWindow* window, WebContentOptions const& web_content_options, St
         m_window->new_tab(qstring_from_ak_string(url), Web::HTML::ActivateTab::Yes);
     });
 
+    auto take_screenshot = [this](auto type) {
+        auto& view = this->view();
+
+        view.take_screenshot(type)
+            ->when_resolved([this](auto const& path) {
+                auto message = MUST(String::formatted("Screenshot saved to: {}", path));
+
+                QMessageBox dialog(this);
+                dialog.setWindowTitle("Ladybird");
+                dialog.setIcon(QMessageBox::Information);
+                dialog.setText(qstring_from_ak_string(message));
+                dialog.addButton(QMessageBox::Ok);
+                dialog.addButton(QMessageBox::Open)->setText("Open folder");
+
+                if (dialog.exec() == QMessageBox::Open) {
+                    auto path_url = QUrl::fromLocalFile(qstring_from_ak_string(path.dirname()));
+                    QDesktopServices::openUrl(path_url);
+                }
+            })
+            .when_rejected([this](auto const& error) {
+                auto error_message = MUST(String::formatted("{}", error));
+                QMessageBox::warning(this, "Ladybird", qstring_from_ak_string(error_message));
+            });
+    };
+
     auto* take_visible_screenshot_action = new QAction("Take &Visible Screenshot", this);
     take_visible_screenshot_action->setIcon(load_icon_from_uri("resource://icons/16x16/filetype-image.png"sv));
-    QObject::connect(take_visible_screenshot_action, &QAction::triggered, this, [this]() {
-        view().take_screenshot(WebView::ViewImplementation::ScreenshotType::Visible)->when_rejected([this](auto const& error) {
-            auto error_message = MUST(String::formatted("{}", error));
-            QMessageBox::warning(this, "Ladybird", qstring_from_ak_string(error_message));
-        });
+    QObject::connect(take_visible_screenshot_action, &QAction::triggered, this, [take_screenshot]() {
+        take_screenshot(WebView::ViewImplementation::ScreenshotType::Visible);
     });
 
     auto* take_full_screenshot_action = new QAction("Take &Full Screenshot", this);
     take_full_screenshot_action->setIcon(load_icon_from_uri("resource://icons/16x16/filetype-image.png"sv));
-    QObject::connect(take_full_screenshot_action, &QAction::triggered, this, [this]() {
-        view().take_screenshot(WebView::ViewImplementation::ScreenshotType::Full)->when_rejected([this](auto const& error) {
-            auto error_message = MUST(String::formatted("{}", error));
-            QMessageBox::warning(this, "Ladybird", qstring_from_ak_string(error_message));
-        });
+    QObject::connect(take_full_screenshot_action, &QAction::triggered, this, [take_screenshot]() {
+        take_screenshot(WebView::ViewImplementation::ScreenshotType::Full);
     });
 
     m_page_context_menu = new QMenu("Context menu", this);

--- a/Userland/Libraries/LibGUI/Dialog.h
+++ b/Userland/Libraries/LibGUI/Dialog.h
@@ -21,6 +21,7 @@ public:
         Aborted = 2,
         Yes = 3,
         No = 4,
+        Reveal = 5,
     };
 
     enum class ScreenPosition {

--- a/Userland/Libraries/LibGUI/MessageBox.cpp
+++ b/Userland/Libraries/LibGUI/MessageBox.cpp
@@ -130,7 +130,7 @@ ErrorOr<RefPtr<Gfx::Bitmap>> MessageBox::icon() const
 
 bool MessageBox::should_include_ok_button() const
 {
-    return m_input_type == InputType::OK || m_input_type == InputType::OKCancel;
+    return m_input_type == InputType::OK || m_input_type == InputType::OKCancel || m_input_type == InputType::OKReveal;
 }
 
 bool MessageBox::should_include_cancel_button() const
@@ -146,6 +146,11 @@ bool MessageBox::should_include_yes_button() const
 bool MessageBox::should_include_no_button() const
 {
     return should_include_yes_button();
+}
+
+bool MessageBox::should_include_reveal_button() const
+{
+    return m_input_type == InputType::OKReveal;
 }
 
 ErrorOr<void> MessageBox::build()
@@ -188,6 +193,8 @@ ErrorOr<void> MessageBox::build()
         m_no_button = add_button("No"_string, ExecResult::No);
     if (should_include_cancel_button())
         m_cancel_button = add_button("Cancel"_string, ExecResult::Cancel);
+    if (should_include_reveal_button())
+        m_reveal_button = add_button("Open folder"_string, ExecResult::Reveal);
     button_container.add_spacer();
 
     return {};

--- a/Userland/Libraries/LibGUI/MessageBox.h
+++ b/Userland/Libraries/LibGUI/MessageBox.h
@@ -32,6 +32,7 @@ public:
     enum class InputType {
         OK,
         OKCancel,
+        OKReveal,
         YesNo,
         YesNoCancel,
     };
@@ -58,6 +59,7 @@ private:
     bool should_include_cancel_button() const;
     bool should_include_yes_button() const;
     bool should_include_no_button() const;
+    bool should_include_reveal_button() const;
 
     ErrorOr<void> build();
     ErrorOr<RefPtr<Gfx::Bitmap>> icon() const;
@@ -69,6 +71,7 @@ private:
     RefPtr<GUI::Button> m_yes_button;
     RefPtr<GUI::Button> m_no_button;
     RefPtr<GUI::Button> m_cancel_button;
+    RefPtr<GUI::Button> m_reveal_button;
     RefPtr<Label> m_text_label;
 };
 


### PR DESCRIPTION
People often ask "where did my screenshot go :(", so this displays where the screenshot is saved and presents an option
to open its containing folder.

In the future, it'd be nicer to have a downloads manager, and then we can pipe screenshots through that.

https://github.com/SerenityOS/serenity/assets/5600524/6c02c6e8-cc38-4e44-b1fb-580b9d256e97

https://github.com/SerenityOS/serenity/assets/5600524/650c9483-5518-4437-9559-d4d67d4816a1

https://github.com/SerenityOS/serenity/assets/5600524/266cabbb-4a5d-4227-849e-e7de883f7f5c




