### PR TITLE
LibWeb: Improve media document styling to center image

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/DocumentLoading.cpp
+++ b/Userland/Libraries/LibWeb/DOM/DocumentLoading.cpp
@@ -335,6 +335,24 @@ static WebIDL::ExceptionOr<JS::NonnullGCPtr<DOM::Document>> load_media_document(
         return {};
     };
 
+    auto style_element = TRY(DOM::create_element(document, HTML::TagNames::style, Namespace::HTML));
+    style_element->set_text_content(R"~~~(
+        :root {
+            background-color: #222;
+        }
+        img, video, audio {
+            position: absolute;
+            inset: 0;
+            max-width: 100vw;
+            max-height: 100vh;
+            margin: auto;
+        }
+        img {
+            background-color: #fff;
+        }
+    )~~~"_string);
+    TRY(document->head()->append_child(style_element));
+
     auto url_string = document->url_string();
     if (type.is_image()) {
         auto img_element = TRY(DOM::create_element(document, HTML::TagNames::img, Namespace::HTML));


### PR DESCRIPTION
When navigating to a plain image url a simple HTML page is generated around it in `DocumentLoading.cpp`, I have added some CSS styling to make that page some what more pleasant to look at. It now features a dark background with a centered media element, clamped to the viewport width and height like Firefox and Chrome.

# Before
![Screenshot 2024-01-06 at 17 35 06](https://github.com/SerenityOS/serenity/assets/19894029/87bcfcbd-cf05-4e73-ad80-1a2508662604)

# After
![Screenshot 2024-01-06 at 17 34 39](https://github.com/SerenityOS/serenity/assets/19894029/014f1103-08d3-4b10-b572-a4ad149d3358)

There is also still an issue that the page title is not updated but I think that has something to do with navigatables.