### PR TITLE
LibGUI: Make AboutDialog Copyright 2018-2024

### DIFF
--- a/Userland/Libraries/LibGUI/AboutDialog.gml
+++ b/Userland/Libraries/LibGUI/AboutDialog.gml
@@ -61,7 +61,7 @@
                 name: "copyright"
                 text_alignment: "CenterLeft"
                 fixed_height: 14
-                text: "Copyright © the SerenityOS developers, 2018-2023"
+                text: "Copyright © the SerenityOS developers, 2018-2024"
             }
 
             @GUI::Layout::Spacer {}


### PR DESCRIPTION
Make all About dialogs show copyright up to the current year.

Happy New Year everyone!

<img width="446" alt="Screenshot 2024-01-06 at 16 34 40" src="https://github.com/SerenityOS/serenity/assets/7754483/4736eddb-4a46-48d1-969b-99a50cf805c6">