### PR TITLE
LibWeb: Resolve grid item vertical margin/padding against CB width

### DIFF
--- a/Tests/LibWeb/Layout/expected/grid/grid-item-vertical-padding-and-margin-percentages.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-item-vertical-padding-and-margin-percentages.txt
@@ -1,0 +1,13 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x466 [BFC] children: not-inline
+    Box <body> at (8,8) content-size 500x450 [GFC] children: not-inline
+      BlockContainer <div.a> at (8,183) content-size 500x0 [BFC] children: not-inline
+      BlockContainer <div.b> at (8,183) content-size 500x0 [BFC] children: not-inline
+      BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x466]
+    PaintableBox (Box<BODY>) [8,8 500x450]
+      PaintableWithLines (BlockContainer<DIV>.a) [8,58 500x125]
+      PaintableWithLines (BlockContainer<DIV>.b) [8,183 500x175]

--- a/Tests/LibWeb/Layout/input/grid/grid-item-vertical-padding-and-margin-percentages.html
+++ b/Tests/LibWeb/Layout/input/grid/grid-item-vertical-padding-and-margin-percentages.html
@@ -1,0 +1,19 @@
+<!doctype html><style>
+    * {
+        outline: 1px solid black;
+    }
+    body {
+        display: grid;
+        width: 500px;
+    }
+    div.a {
+        padding-top: 25%;
+        margin-top: 10%;
+        background: pink;
+    }
+    div.b {
+        padding-bottom: 35%;
+        margin-bottom: 20%;
+        background: orange;
+    }
+</style><body><div class="a"></div><div class="b"></div>

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -1823,9 +1823,8 @@ void GridFormattingContext::resolve_items_box_metrics(GridDimension const dimens
         auto& box_state = m_state.get_mutable(item.box);
         auto& computed_values = item.box->computed_values();
 
+        CSSPixels containing_block_width = containing_block_size_for_item(item, GridDimension::Column);
         if (dimension == GridDimension::Column) {
-            CSSPixels containing_block_width = containing_block_size_for_item(item, GridDimension::Column);
-
             box_state.padding_right = computed_values.padding().right().to_px(grid_container(), containing_block_width);
             box_state.padding_left = computed_values.padding().left().to_px(grid_container(), containing_block_width);
 
@@ -1835,13 +1834,11 @@ void GridFormattingContext::resolve_items_box_metrics(GridDimension const dimens
             box_state.border_right = computed_values.border_right().width;
             box_state.border_left = computed_values.border_left().width;
         } else {
-            CSSPixels containing_block_height = containing_block_size_for_item(item, GridDimension::Row);
+            box_state.padding_top = computed_values.padding().top().to_px(grid_container(), containing_block_width);
+            box_state.padding_bottom = computed_values.padding().bottom().to_px(grid_container(), containing_block_width);
 
-            box_state.padding_top = computed_values.padding().top().to_px(grid_container(), containing_block_height);
-            box_state.padding_bottom = computed_values.padding().bottom().to_px(grid_container(), containing_block_height);
-
-            box_state.margin_top = computed_values.margin().top().to_px(grid_container(), containing_block_height);
-            box_state.margin_bottom = computed_values.margin().bottom().to_px(grid_container(), containing_block_height);
+            box_state.margin_top = computed_values.margin().top().to_px(grid_container(), containing_block_width);
+            box_state.margin_bottom = computed_values.margin().bottom().to_px(grid_container(), containing_block_width);
 
             box_state.border_top = computed_values.border_top().width;
             box_state.border_bottom = computed_values.border_bottom().width;


### PR DESCRIPTION
Percentage vertical margin and padding values are relative to the containing block *width*, not *height*. This has to be one of the most commonly recurring mistakes we make :^)

Visual progress on https://splice.com/

Before:
![image](https://github.com/SerenityOS/serenity/assets/5954907/8bbb1410-f8ad-43d1-9801-9a0391189d9a)

After:
![Screenshot at 2024-01-06 18-42-53](https://github.com/SerenityOS/serenity/assets/5954907/49f5fc82-8bb1-4c9a-877f-d1ad400d449a)
