### PR TITLE
LibGfx/OpenType: Read the correct number of pairs from kern table

### DIFF
--- a/Userland/Libraries/LibGfx/Font/OpenType/Tables.cpp
+++ b/Userland/Libraries/LibGfx/Font/OpenType/Tables.cpp
@@ -266,7 +266,7 @@ ErrorOr<Kern> Kern::from_slice(ReadonlyBytes slice)
         auto subtable_format = (subtable_header.coverage & 0xFF00) >> 8;
         if (subtable_format == 0) {
             auto const& format0_header = *TRY(stream.read_in_place<Format0 const>());
-            auto pairs = TRY(stream.read_in_place<Format0Pair const>(5));
+            auto pairs = TRY(stream.read_in_place<Format0Pair const>(format0_header.n_pairs));
 
             subtables.append(Subtable {
                 .header = subtable_header,


### PR DESCRIPTION
We were trying to read exactly 5 pairs for some reason, instead of the number specified by the format 0 header.

Fixing this makes "OpenSans Condensed" load on my machine.