### PR TITLE
Everywhere: Add deprecated_ prefix to `JsonValue::to_byte_string`

### DIFF
--- a/AK/JsonValue.h
+++ b/AK/JsonValue.h
@@ -85,7 +85,7 @@ public:
         return alternative;
     }
 
-    ByteString to_byte_string() const
+    ByteString deprecated_to_byte_string() const
     {
         if (is_string())
             return as_string();
@@ -290,7 +290,7 @@ template<>
 struct Formatter<JsonValue> : Formatter<StringView> {
     ErrorOr<void> format(FormatBuilder& builder, JsonValue const& value)
     {
-        return Formatter<StringView>::format(builder, value.to_byte_string());
+        return Formatter<StringView>::format(builder, value.serialized<StringBuilder>());
     }
 };
 

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSEnums.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSEnums.cpp
@@ -77,7 +77,7 @@ enum class ValueID;
         enum_generator.appendln("enum class @name:titlecase@ : @enum_type@ {");
 
         for (auto& member : members.values()) {
-            auto member_name = member.to_byte_string();
+            auto member_name = member.as_string();
             // Don't include aliases in the enum.
             if (member_name.contains('='))
                 continue;
@@ -126,7 +126,7 @@ Optional<@name:titlecase@> value_id_to_@name:snakecase@(ValueID value_id)
 
         for (auto& member : members.values()) {
             auto member_generator = enum_generator.fork();
-            auto member_name = member.to_byte_string();
+            auto member_name = member.as_string();
             if (member_name.contains('=')) {
                 auto parts = member_name.split_view('=');
                 member_generator.set("valueid:titlecase", title_casify(parts[0]));
@@ -154,7 +154,7 @@ ValueID to_value_id(@name:titlecase@ @name:snakecase@_value)
 
         for (auto& member : members.values()) {
             auto member_generator = enum_generator.fork();
-            auto member_name = member.to_byte_string();
+            auto member_name = member.as_string();
             if (member_name.contains('='))
                 continue;
             member_generator.set("member:titlecase", title_casify(member_name));
@@ -178,7 +178,7 @@ StringView to_string(@name:titlecase@ value)
 
         for (auto& member : members.values()) {
             auto member_generator = enum_generator.fork();
-            auto member_name = member.to_byte_string();
+            auto member_name = member.as_string();
             if (member_name.contains('='))
                 continue;
             member_generator.set("member:css", member_name);

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPropertyID.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPropertyID.cpp
@@ -73,7 +73,7 @@ void replace_logical_aliases(JsonObject& properties)
         if (logical_alias_for.has_value()) {
             auto const& aliased_properties = logical_alias_for.value();
             for (auto const& aliased_property : aliased_properties.values()) {
-                logical_aliases.set(name, aliased_property.to_byte_string());
+                logical_aliases.set(name, aliased_property.as_string());
             }
         }
     });
@@ -768,7 +768,7 @@ size_t property_maximum_value_count(PropertyID property_id)
             VERIFY(max_values.has_value() && max_values->is_number() && !max_values->is_double());
             auto property_generator = generator.fork();
             property_generator.set("name:titlecase", title_casify(name));
-            property_generator.set("max_values", max_values->to_byte_string());
+            property_generator.set("max_values", max_values->template serialized<StringBuilder>());
             property_generator.append(R"~~~(
     case PropertyID::@name:titlecase@:
         return @max_values@;
@@ -834,7 +834,7 @@ Vector<PropertyID> longhands_for_shorthand(PropertyID property_id)
                     first = false;
                 else
                     builder.append(", "sv);
-                builder.appendff("PropertyID::{}", title_casify(longhand.to_byte_string()));
+                builder.appendff("PropertyID::{}", title_casify(longhand.as_string()));
                 return IterationDecision::Continue;
             });
             property_generator.set("longhands", builder.to_byte_string());

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSTransformFunctions.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSTransformFunctions.cpp
@@ -189,7 +189,7 @@ TransformFunctionMetadata transform_function_metadata(TransformFunction transfor
             member_generator.append(first ? " "sv : ", "sv);
             first = false;
 
-            member_generator.append(MUST(String::formatted("{{ TransformFunctionParameterType::{}, {}}}", parameter_type, value.as_object().get("required"sv)->to_byte_string())));
+            member_generator.append(MUST(String::formatted("{{ TransformFunctionParameterType::{}, {}}}", parameter_type, value.as_object().get("required"sv)->as_bool())));
         });
 
         member_generator.append(R"~~~( }

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSValueID.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSValueID.cpp
@@ -57,7 +57,7 @@ enum class ValueID {
 
     identifier_data.for_each([&](auto& name) {
         auto member_generator = generator.fork();
-        member_generator.set("name:titlecase", title_casify(name.to_byte_string()));
+        member_generator.set("name:titlecase", title_casify(name.as_string()));
 
         member_generator.append(R"~~~(
     @name:titlecase@,
@@ -105,8 +105,8 @@ HashMap<StringView, ValueID, AK::CaseInsensitiveASCIIStringViewTraits> g_stringv
 
     identifier_data.for_each([&](auto& name) {
         auto member_generator = generator.fork();
-        member_generator.set("name", name.to_byte_string());
-        member_generator.set("name:titlecase", title_casify(name.to_byte_string()));
+        member_generator.set("name", name.as_string());
+        member_generator.set("name:titlecase", title_casify(name.as_string()));
         member_generator.append(R"~~~(
     {"@name@"sv, ValueID::@name:titlecase@},
 )~~~");
@@ -126,8 +126,8 @@ StringView string_from_value_id(ValueID value_id) {
 
     identifier_data.for_each([&](auto& name) {
         auto member_generator = generator.fork();
-        member_generator.set("name", name.to_byte_string());
-        member_generator.set("name:titlecase", title_casify(name.to_byte_string()));
+        member_generator.set("name", name.as_string());
+        member_generator.set("name:titlecase", title_casify(name.as_string()));
         member_generator.append(R"~~~(
     case ValueID::@name:titlecase@:
         return "@name@"sv;

--- a/Tests/AK/TestJSON.cpp
+++ b/Tests/AK/TestJSON.cpp
@@ -115,7 +115,7 @@ TEST_CASE(json_duplicate_keys)
 TEST_CASE(json_u64_roundtrip)
 {
     auto big_value = 0xffffffffffffffffull;
-    auto json = JsonValue(big_value).to_byte_string();
+    auto json = JsonValue(big_value).serialized<StringBuilder>();
     auto value = JsonValue::from_string(json);
     EXPECT_EQ_FORCE(value.is_error(), false);
     EXPECT_EQ(value.value().as_u64(), big_value);

--- a/Userland/Applications/Presenter/Presentation.cpp
+++ b/Userland/Applications/Presenter/Presentation.cpp
@@ -133,7 +133,8 @@ HashMap<ByteString, ByteString> Presentation::parse_metadata(JsonObject const& m
     HashMap<ByteString, ByteString> metadata;
 
     metadata_object.for_each_member([&](auto const& key, auto const& value) {
-        metadata.set(key, value.to_byte_string());
+        // FIXME: Do not serialize values here just to convert them back to proper types later.
+        metadata.set(key, value.deprecated_to_byte_string());
     });
 
     return metadata;

--- a/Userland/Applications/Presenter/SlideObject.cpp
+++ b/Userland/Applications/Presenter/SlideObject.cpp
@@ -58,7 +58,7 @@ void SlideObject::set_property(StringView name, JsonValue value)
 void GraphicsObject::set_property(StringView name, JsonValue value)
 {
     if (name == "color"sv) {
-        if (auto color = Gfx::Color::from_string(value.to_byte_string()); color.has_value()) {
+        if (auto color = Gfx::Color::from_string(value.as_string()); color.has_value()) {
             m_color = color.release_value();
         }
     }
@@ -68,15 +68,15 @@ void GraphicsObject::set_property(StringView name, JsonValue value)
 void Text::set_property(StringView name, JsonValue value)
 {
     if (name == "text"sv) {
-        m_text = value.to_byte_string();
+        m_text = value.as_string();
     } else if (name == "font"sv) {
-        m_font_family = value.to_byte_string();
+        m_font_family = value.as_string();
     } else if (name == "font-weight"sv) {
-        m_font_weight = Gfx::name_to_weight(value.to_byte_string());
+        m_font_weight = Gfx::name_to_weight(value.as_string());
     } else if (name == "font-size"sv) {
         m_font_size_in_pt = value.to_float();
     } else if (name == "text-alignment"sv) {
-        m_text_align = value.to_byte_string();
+        m_text_align = value.as_string();
     }
     GraphicsObject::set_property(name, move(value));
 }
@@ -84,11 +84,11 @@ void Text::set_property(StringView name, JsonValue value)
 void Image::set_property(StringView name, JsonValue value)
 {
     if (name == "path"sv) {
-        m_src = value.to_byte_string();
+        m_src = value.as_string();
     } else if (name == "scaling-mode"sv) {
-        if (value.to_byte_string() == "nearest-neighbor"sv)
+        if (value.as_string() == "nearest-neighbor"sv)
             m_image_rendering = "crisp-edges"sv;
-        else if (value.to_byte_string() == "smooth-pixels"sv)
+        else if (value.as_string() == "smooth-pixels"sv)
             m_image_rendering = "pixelated"sv;
     }
     SlideObject::set_property(name, move(value));

--- a/Userland/Applications/Spreadsheet/HelpWindow.cpp
+++ b/Userland/Applications/Spreadsheet/HelpWindow.cpp
@@ -166,7 +166,7 @@ ByteString HelpWindow::render(StringView key)
         markdown_builder.append("No required arguments.\n"sv);
 
     for (size_t i = 0; i < argc; ++i)
-        markdown_builder.appendff("- `{}`\n", argnames.at(i).to_byte_string());
+        markdown_builder.appendff("- `{}`\n", argnames.at(i).as_string());
 
     if (argc > 0)
         markdown_builder.append("\n"sv);
@@ -175,7 +175,7 @@ ByteString HelpWindow::render(StringView key)
         auto opt_count = argnames.size() - argc;
         markdown_builder.appendff("{} optional argument(s):\n", opt_count);
         for (size_t i = argc; i < (size_t)argnames.size(); ++i)
-            markdown_builder.appendff("- `{}`\n", argnames.at(i).to_byte_string());
+            markdown_builder.appendff("- `{}`\n", argnames.at(i).as_string());
         markdown_builder.append("\n"sv);
     }
 
@@ -188,8 +188,8 @@ ByteString HelpWindow::render(StringView key)
         VERIFY(examples.has_value());
         markdown_builder.append("# EXAMPLES\n"sv);
         examples->for_each_member([&](auto& text, auto& description_value) {
-            dbgln("```js\n{}\n```\n\n- {}\n", text, description_value.to_byte_string());
-            markdown_builder.appendff("```js\n{}\n```\n\n- {}\n", text, description_value.to_byte_string());
+            dbgln("```js\n{}\n```\n\n- {}\n", text, description_value.as_string());
+            markdown_builder.appendff("```js\n{}\n```\n\n- {}\n", text, description_value.as_string());
         });
     }
 

--- a/Userland/Applications/Spreadsheet/Spreadsheet.cpp
+++ b/Userland/Applications/Spreadsheet/Spreadsheet.cpp
@@ -731,7 +731,7 @@ ByteString Sheet::generate_inline_documentation_for(StringView function, size_t 
             builder.append('<');
         else if (i >= argc)
             builder.append('[');
-        builder.append(argnames[i].to_byte_string());
+        builder.append(argnames[i].as_string());
         if (i == argument_index)
             builder.append('>');
         else if (i >= argc)

--- a/Userland/DevTools/Profiler/Profile.cpp
+++ b/Userland/DevTools/Profiler/Profile.cpp
@@ -292,7 +292,7 @@ ErrorOr<NonnullOwnPtr<Profile>> Profile::load_from_perfcore_file(StringView path
     HashMap<FlatPtr, ByteString> profile_strings;
     for (FlatPtr string_id = 0; string_id < strings.size(); ++string_id) {
         auto const& value = strings.at(string_id);
-        profile_strings.set(string_id, value.to_byte_string());
+        profile_strings.set(string_id, value.as_string());
     }
 
     auto events_value = object.get_array("events"sv);

--- a/Userland/Libraries/LibGUI/DynamicWidgetContainer.cpp
+++ b/Userland/Libraries/LibGUI/DynamicWidgetContainer.cpp
@@ -144,7 +144,7 @@ void DynamicWidgetContainer::restore_view_state()
 
             order_or_error.value().as_array().for_each([&](auto& section_label) {
                 for (auto& container : containers) {
-                    if (container.section_label() == section_label.to_byte_string())
+                    if (container.section_label() == section_label.as_string())
                         new_child_order.append(container);
                 }
             });

--- a/Userland/Libraries/LibGUI/JsonArrayModel.cpp
+++ b/Userland/Libraries/LibGUI/JsonArrayModel.cpp
@@ -138,7 +138,7 @@ Variant JsonArrayModel::data(ModelIndex const& index, ModelRole role) const
             return "";
         if (data->is_number())
             return data.value();
-        return data->to_byte_string();
+        return data->as_string();
     }
 
     if (role == ModelRole::Sort) {

--- a/Userland/Libraries/LibJS/Runtime/JSONObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/JSONObject.cpp
@@ -439,7 +439,7 @@ Value JSONObject::parse_json_value(VM& vm, JsonValue const& value)
     if (value.is_number())
         return Value(value.to_double(0));
     if (value.is_string())
-        return PrimitiveString::create(vm, value.to_byte_string());
+        return PrimitiveString::create(vm, value.as_string());
     if (value.is_bool())
         return Value(static_cast<bool>(value.as_bool()));
     VERIFY_NOT_REACHED();

--- a/Userland/Libraries/LibWeb/WebDriver/Client.cpp
+++ b/Userland/Libraries/LibWeb/WebDriver/Client.cpp
@@ -269,8 +269,7 @@ ErrorOr<void, Client::WrappedError> Client::handle_request(JsonValue body)
 {
     if constexpr (WEBDRIVER_DEBUG) {
         dbgln("Got HTTP request: {} {}", m_request->method_name(), m_request->resource());
-        if (!body.is_null())
-            dbgln("Body: {}", body.to_byte_string());
+        dbgln("Body: {}", body);
     }
 
     auto [handler, parameters] = TRY(match_route(*m_request));

--- a/Userland/Services/WebDriver/Client.cpp
+++ b/Userland/Services/WebDriver/Client.cpp
@@ -323,7 +323,7 @@ Web::WebDriver::Response Client::switch_to_window(Web::WebDriver::Parameters par
     if (!handle.has_value())
         return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidArgument, "No property called 'handle' present");
 
-    return session->switch_to_window(handle->to_byte_string());
+    return session->switch_to_window(handle->as_string());
 }
 
 // 11.4 Get Window Handles, https://w3c.github.io/webdriver/#dfn-get-window-handles

--- a/Userland/Shell/Shell.cpp
+++ b/Userland/Shell/Shell.cpp
@@ -2067,7 +2067,7 @@ ErrorOr<Vector<Line::CompletionSuggestion>> Shell::complete_via_program_itself(s
                     dbgln("LibLine: Unhandled completion kind: {}", kind);
                 }
             } else {
-                suggestions.append(parsed.to_byte_string());
+                suggestions.append(parsed.deprecated_to_byte_string());
             }
 
             return IterationDecision::Continue;

--- a/Userland/Utilities/json.cpp
+++ b/Userland/Utilities/json.cpp
@@ -108,11 +108,7 @@ void print(JsonValue const& value, int spaces_per_indent, int indent, bool use_c
         else if (value.is_null())
             out("\033[34;1m");
     }
-    if (value.is_string())
-        out("\"");
-    out("{}", value.to_byte_string());
-    if (value.is_string())
-        out("\"");
+    out("{}", value);
     if (use_color)
         out("\033[0m");
 }

--- a/Userland/Utilities/lsirq.cpp
+++ b/Userland/Utilities/lsirq.cpp
@@ -42,7 +42,7 @@ ErrorOr<int> serenity_main(Main::Arguments)
         out("{:>4}: ", interrupt);
 
         for (size_t i = 0; i < cpu_count; ++i)
-            out("{:>10}", call_counts[i].to_byte_string());
+            out("{:>10}", call_counts[i].as_integer<u64>());
 
         outln("  {:10}  {:30}", controller, purpose);
     });

--- a/Userland/Utilities/pmap.cpp
+++ b/Userland/Utilities/pmap.cpp
@@ -49,7 +49,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     for (auto& value : sorted_regions) {
         auto& map = value.as_object();
         auto address = map.get_addr("address"sv).value_or(0);
-        auto size = map.get("size"sv).value_or({}).to_byte_string();
+        auto size = map.get_u64("size"sv).value();
 
         auto access = ByteString::formatted("{}{}{}{}{}",
             (map.get_bool("readable"sv).value_or(false) ? "r" : "-"),
@@ -61,13 +61,13 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         out("{:p}  ", address);
         out("{:>10} ", size);
         if (extended) {
-            auto resident = map.get("amount_resident"sv).value_or({}).to_byte_string();
-            auto dirty = map.get("amount_dirty"sv).value_or({}).to_byte_string();
-            auto vmobject = map.get_byte_string("vmobject"sv).value_or({});
+            auto resident = map.get_u64("amount_resident"sv).value();
+            auto dirty = map.get_u64("amount_dirty"sv).value();
+            auto vmobject = map.get_byte_string("vmobject"sv).value();
             if (vmobject.ends_with("VMObject"sv))
                 vmobject = vmobject.substring(0, vmobject.length() - 8);
-            auto purgeable = map.get("purgeable"sv).value_or({}).to_byte_string();
-            auto cow_pages = map.get("cow_pages"sv).value_or({}).to_byte_string();
+            auto purgeable = map.get_u64("purgeable"sv).value();
+            auto cow_pages = map.get_u64("cow_pages"sv).value();
             out("{:>10} ", resident);
             out("{:>10} ", dirty);
             out("{:6} ", access);


### PR DESCRIPTION
`JsonValue::to_byte_string` has peculiar type-erasure semantics which is not usually intended. Unfortunately, it also has a very stereotypical name which does not warn about unexpected behavior. So let's prefix it with `deprecated_` to make new code use `as_string` if it just wants to get string value or `serialized<StringBuilder>` if it needs to do proper serialization.

Revival of #21813, this is part of a bigger AK::JsonValue refactor with the end result pushed [here](https://github.com/DanShaders/serenity/tree/json-rewrite).