### PR TITLE
LibWeb: Fix auto-fill track counting to correctly handle gaps in GFC

### DIFF
--- a/Tests/LibWeb/Layout/expected/grid/columns-auto-fill-with-gap-2.txt
+++ b/Tests/LibWeb/Layout/expected/grid/columns-auto-fill-with-gap-2.txt
@@ -1,0 +1,23 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x33.46875 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x17.46875 children: not-inline
+      Box <div.grid> at (8,8) content-size 784x17.46875 [GFC] children: not-inline
+        BlockContainer <div> at (8,8) content-size 367x17.46875 [BFC] children: inline
+          line 0 width: 9.34375, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [8,8 9.34375x17.46875]
+              "a"
+          TextNode <#text>
+        BlockContainer <div> at (425,8) content-size 367x17.46875 [BFC] children: inline
+          line 0 width: 9.46875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 1, rect: [425,8 9.46875x17.46875]
+              "b"
+          TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x33.46875]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x17.46875]
+      PaintableBox (Box<DIV>.grid) [8,8 784x17.46875]
+        PaintableWithLines (BlockContainer<DIV>) [8,8 367x17.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [425,8 367x17.46875]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/input/grid/columns-auto-fill-with-gap-2.html
+++ b/Tests/LibWeb/Layout/input/grid/columns-auto-fill-with-gap-2.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html><style type="text/css">
+* {
+    outline: 1px solid black;
+}
+.grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(calc((100% - 50px) / 2), 1fr));
+    grid-gap: 50px;
+}
+</style><div class="grid"><div>a</div><div>b</div></div>

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.h
@@ -245,7 +245,6 @@ private:
     Optional<int> get_line_index_by_line_name(GridDimension dimension, String const&);
     CSSPixels resolve_definite_track_size(CSS::GridSize const&, AvailableSpace const&);
     int count_of_repeated_auto_fill_or_fit_tracks(Vector<CSS::ExplicitGridTrack> const& track_list);
-    int get_count_of_tracks(Vector<CSS::ExplicitGridTrack> const&);
 
     void build_grid_areas();
 
@@ -255,7 +254,7 @@ private:
     void place_item_with_column_position(Box const& child_box, int& auto_placement_cursor_x, int& auto_placement_cursor_y);
     void place_item_with_no_declared_position(Box const& child_box, int& auto_placement_cursor_x, int& auto_placement_cursor_y);
 
-    void initialize_grid_tracks_from_definition(Vector<CSS::ExplicitGridTrack> const& tracks_definition, Vector<GridTrack>& tracks);
+    void initialize_grid_tracks_from_definition(GridDimension);
     void initialize_grid_tracks_for_columns_and_rows();
     void initialize_gap_tracks(AvailableSpace const&);
 


### PR DESCRIPTION
Fixes the mistake that gaps are counted as if they exist after each track, when actually gaps are present only between tracks.

Visual progression on https://kde.org/products/