### PR TITLE
LibWeb: Support auto-fill for rows in GFC

### DIFF
--- a/Tests/LibWeb/Layout/expected/grid/auto-fill-rows.txt
+++ b/Tests/LibWeb/Layout/expected/grid/auto-fill-rows.txt
@@ -1,0 +1,30 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x250.9375 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x234.9375 children: not-inline
+      Box <div.grid-container> at (8,8) content-size 784x234.9375 [GFC] children: not-inline
+        BlockContainer <div> at (8,8) content-size 784x200 [BFC] children: inline
+          line 0 width: 46.71875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 6, rect: [8,8 46.71875x17.46875]
+              "Item 1"
+          TextNode <#text>
+        BlockContainer <div> at (8,208) content-size 784x17.46875 [BFC] children: inline
+          line 0 width: 49.1875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 6, rect: [8,208 49.1875x17.46875]
+              "Item 2"
+          TextNode <#text>
+        BlockContainer <div> at (8,225.46875) content-size 784x17.46875 [BFC] children: inline
+          line 0 width: 49.46875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 6, rect: [8,225.46875 49.46875x17.46875]
+              "Item 3"
+          TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x250.9375]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x234.9375]
+      PaintableBox (Box<DIV>.grid-container) [8,8 784x234.9375]
+        PaintableWithLines (BlockContainer<DIV>) [8,8 784x200]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [8,208 784x17.46875]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [8,225.46875 784x17.46875]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/input/grid/auto-fill-rows.html
+++ b/Tests/LibWeb/Layout/input/grid/auto-fill-rows.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html><html><style>
+* {
+    outline: 1px solid black;
+}
+.grid-container {
+    display: grid;
+    grid-template-rows: repeat(auto-fill, 200px);
+}
+</style><div class="grid-container"><div>Item 1</div><div>Item 2</div><div>Item 3</div></html>

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.h
@@ -244,7 +244,7 @@ private:
 
     Optional<int> get_line_index_by_line_name(GridDimension dimension, String const&);
     CSSPixels resolve_definite_track_size(CSS::GridSize const&, AvailableSpace const&);
-    int count_of_repeated_auto_fill_or_fit_tracks(Vector<CSS::ExplicitGridTrack> const& track_list);
+    int count_of_repeated_auto_fill_or_fit_tracks(GridDimension);
 
     void build_grid_areas();
 


### PR DESCRIPTION
This change fixes the function that calculates the number of auto-fill tracks, ensuring it uses height when applied to rows, instead of assuming that it always operates on columns.