### PR TITLE
LibWeb/CSS: Revert to PercentageOr::resolve() to be templated

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/PercentageOr.h
+++ b/Userland/Libraries/LibWeb/CSS/PercentageOr.h
@@ -100,7 +100,8 @@ public:
         return resolved(layout_node, reference_value).to_px(layout_node);
     }
 
-    Angle resolved(Layout::Node const& layout_node, Angle reference_value) const
+    T resolved(Layout::Node const& layout_node, T reference_value) const
+    requires(!IsSame<T, Length>)
     {
         return m_value.visit(
             [&](T const& t) {


### PR DESCRIPTION
In 4bc38300ad9e7ca7665bd6afa0ab9c0557807286 this function was modified to accept only Angle instead of being templated, with the purpose of preventing Length from being passed.

This change reverts the function to being templated but adds a constraint specifically forbidding Length. This adjustment will allow for the future use of Frequency, Number, Time, etc., if we would want.

cc @AtkinsSJ 