### PR TITLE
LibWeb: Take padding into account when resolving border radii

### DIFF
--- a/Tests/LibWeb/Ref/border-radius-with-padding.html
+++ b/Tests/LibWeb/Ref/border-radius-with-padding.html
@@ -1,0 +1,10 @@
+<!doctype html><head>
+<link rel="match" href="reference/border-radius-with-padding-ref.html" />
+<style type="text/css">
+    div {
+        border: 1px solid black;
+        border-radius: 32px;
+        padding: 25px;
+        width: 0px;
+    }
+</style></head><body><div>

--- a/Tests/LibWeb/Ref/reference/border-radius-with-padding-ref.html
+++ b/Tests/LibWeb/Ref/reference/border-radius-with-padding-ref.html
@@ -1,0 +1,8 @@
+<!doctype html><style type="text/css">
+    div {
+        border: 1px solid black;
+        border-radius: 32px;
+        width: 50px;
+        height: 50px;
+    }
+</style><div>

--- a/Userland/Libraries/LibWeb/Layout/LayoutState.cpp
+++ b/Userland/Libraries/LibWeb/Layout/LayoutState.cpp
@@ -285,8 +285,7 @@ void LayoutState::resolve_border_radii()
         if (paintable && is<Painting::PaintableBox>(*paintable)) {
             auto& paintable_box = static_cast<Painting::PaintableBox&>(*paintable);
 
-            CSSPixelRect const content_rect { 0, 0, used_values.content_width(), used_values.content_height() };
-            auto border_rect = content_rect.inflated(used_values.border_top, used_values.border_right, used_values.border_bottom, used_values.border_left);
+            CSSPixelRect const border_rect { 0, 0, used_values.border_box_width(), used_values.border_box_height() };
 
             auto const& border_top_left_radius = node.computed_values().border_top_left_radius();
             auto const& border_top_right_radius = node.computed_values().border_top_right_radius();


### PR DESCRIPTION
Before this change, we were resolving border radii values based on content box + border widths only, ignoring padding.

Visual progression on https://splice.com ("Try free" button, top right)

Before:
![Screenshot at 2024-01-07 16-23-36](https://github.com/SerenityOS/serenity/assets/5954907/f6b1180a-350a-469f-a863-300a8e38c152)

After:
![Screenshot at 2024-01-07 16-25-40](https://github.com/SerenityOS/serenity/assets/5954907/edf9fbfa-230b-4566-b359-f95a4c828810)
