### PR TITLE
LibWeb/CSS: Remove nullpointer dereference in Parser

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -6611,7 +6611,8 @@ LengthOrCalculated Parser::Parser::parse_as_sizes_attribute()
         //    If it does not parse correctly, or it does parse correctly but the <media-condition> evaluates to false, continue.
         TokenStream<ComponentValue> token_stream { unparsed_size };
         auto media_condition = parse_media_condition(token_stream, MediaCondition::AllowOr::Yes);
-        if (media_condition && media_condition->evaluate(*m_context.window()) == MatchResult::True) {
+        auto context_window = m_context.window();
+        if (context_window && media_condition && media_condition->evaluate(*context_window) == MatchResult::True) {
             return size.value();
         } else {
             continue;

--- a/Userland/Libraries/LibWeb/CSS/Parser/ParsingContext.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/ParsingContext.cpp
@@ -56,7 +56,7 @@ AK::URL ParsingContext::complete_url(StringView relative_url) const
 
 HTML::Window const* ParsingContext::window() const
 {
-    return m_document ? &m_document->window() : nullptr;
+    return m_document && m_document->default_view() ? &m_document->window() : nullptr;
 }
 
 }


### PR DESCRIPTION
Hi, I played around with Ladybird today and found an issue on one of my websites. I do not exactly know what is happening, but it looks like the page does something that causes the WebContent process to break.
On platinenmacher.tech it seams that there is a document without a window. During size attribute parsing the window pointer is dereferenced which causes a crash. This checks for the window to be actually there before dereferencing.

I am new to C++ and coming from C so if what I did is bollocks feel free to tell me the correct way to do this.