### PR TITLE
LibELF: Correctly determine symbol amount for DT_GNU_HASH table

### DIFF
--- a/Userland/Utilities/readelf.cpp
+++ b/Userland/Utilities/readelf.cpp
@@ -565,7 +565,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             });
 
             if (object->symbol_count()) {
-                // FIXME: Add support for init/fini/start/main sections
                 outln("   Num: Value{}      Size{}       Type     Bind     Name", addr_padding, addr_padding);
                 object->for_each_symbol([](const ELF::DynamicObject::Symbol& sym) {
                     out("  {:>4}: ", sym.index());


### PR DESCRIPTION
This fixes the incorrect determination of the dynamic symbol amount when `DT_GNU_HASH` table is used. In this case the header no longer contains the amount of elements as with `DT_HASH` and therefore the amount has to be determined differently.

Before, running e.g. `readelf --dyn-syms /usr/bin/env` reported that there are 57 entries however only 44 were shown:
```
Symbol table '.dynsym' contains 57 entries.
   Num: Value              Size               Type     Bind     Name
     0: 0x0000000000000000 0x0000000000000000 NOTYPE   LOCAL    
     1: 0x0000000000000000 0x0000000000000000 OBJECT   GLOBAL   _ZTVN10__cxxabiv120__si_class_type_infoE
     2: 0x0000000000000000 0x0000000000000000 OBJECT   GLOBAL   stderr
     3: 0x0000000000000000 0x0000000000000000 FUNC     GLOBAL   _ZN4Core6System6pledgeEN2AK10StringViewES2_
     4: 0x0000000000000000 0x0000000000000000 OBJECT   GLOBAL   _ZTVN10__cxxabiv117__class_type_infoE
     5: 0x0000000000000000 0x0000000000000000 FUNC     GLOBAL   _ZN2AK10StringViewC1ERKNS_10ByteStringE
     6: 0x0000000000000000 0x0000000000000000 FUNC     GLOBAL   _ZN4Core6System4execEN2AK10StringViewENS1_4SpanIKS2_EENS0_12SearchInPathENS1_8OptionalIS5_EE
     7: 0x0000000000000000 0x0000000000000000 FUNC     GLOBAL   _ZdlPvm
     8: 0x0000000000000000 0x0000000000000000 FUNC     GLOBAL   _ZNK2AK10ByteString8containsEcNS_15CaseSensitivityE
     9: 0x0000000000000000 0x0000000000000000 FUNC     GLOBAL   _ZN2AK4voutEP4FILENS_10StringViewERNS_22TypeErasedFormatParamsEb
    10: 0x0000000000000000 0x0000000000000000 FUNC     GLOBAL   putenv
    11: 0x0000000000000000 0x0000000000000000 FUNC     GLOBAL   _ZN2AK17StandardFormatter5parseERNS_22TypeErasedFormatParamsERNS_12FormatParserE
    12: 0x0000000000000000 0x0000000000000000 FUNC     GLOBAL   malloc
    13: 0x0000000000000000 0x0000000000000000 FUNC     WEAK     _ITM_deregisterTMCloneTable
    14: 0x0000000000000000 0x0000000000000000 FUNC     GLOBAL   _ZN2AK10StringImpl6createEPKcmNS_11ShouldChompE
    15: 0x0000000000000000 0x0000000000000000 FUNC     GLOBAL   ak_verification_failed
    16: 0x0000000000000000 0x0000000000000000 FUNC     GLOBAL   unsetenv
    17: 0x0000000000000000 0x0000000000000000 FUNC     GLOBAL   _ZN4Core10ArgsParser5parseEN2AK4SpanINS1_10StringViewEEENS0_15FailureBehaviorE
    18: 0x0000000000000000 0x0000000000000000 FUNC     GLOBAL   _ZN2AK10StringImpl20the_empty_stringimplEv
    19: 0x0000000000000000 0x0000000000000000 OBJECT   GLOBAL   environ
    20: 0x0000000000000000 0x0000000000000000 FUNC     GLOBAL   tzset
    21: 0x0000000000000000 0x0000000000000000 OBJECT   GLOBAL   __stack_chk_guard
    22: 0x0000000000000000 0x0000000000000000 FUNC     GLOBAL   _ZN2AK9FormatterImvE6formatERNS_13FormatBuilderEm
    23: 0x0000000000000000 0x0000000000000000 FUNC     GLOBAL   _ZN2AK4vdbgENS_10StringViewERNS_22TypeErasedFormatParamsEb
    24: 0x0000000000000000 0x0000000000000000 FUNC     GLOBAL   exit
    25: 0x0000000000000000 0x0000000000000000 FUNC     WEAK     _ITM_registerTMCloneTable
    26: 0x0000000000000000 0x0000000000000000 FUNC     GLOBAL   _ZN4Core10ArgsParserC1Ev
    27: 0x0000000000000000 0x0000000000000000 FUNC     GLOBAL   _ZN4Core10ArgsParser10add_optionERbPKcS3_cNS0_14OptionHideModeE
    28: 0x0000000000000000 0x0000000000000000 FUNC     GLOBAL   _ZN2AK9FormatterINS_12FormatStringEvE7vformatERNS_13FormatBuilderENS_10StringViewERNS_22TypeErasedFormatParamsE
    29: 0x0000000000000000 0x0000000000000000 OBJECT   GLOBAL   stdout
    30: 0x0000000000000000 0x0000000000000000 FUNC     GLOBAL   _ZN2AK10StringImplD1Ev
    31: 0x0000000000000000 0x0000000000000000 FUNC     GLOBAL   __errno_location
    32: 0x0000000000000000 0x0000000000000000 FUNC     GLOBAL   clearenv
    33: 0x0000000000000000 0x0000000000000000 FUNC     GLOBAL   _ZNK2AK10StringView10split_viewEcNS_13SplitBehaviorE
    34: 0x0000000000000000 0x0000000000000000 FUNC     GLOBAL   __begin_atexit_locking
    35: 0x0000000000000000 0x0000000000000000 FUNC     GLOBAL   malloc_good_size
    36: 0x0000000000000000 0x0000000000000000 FUNC     GLOBAL   free
    37: 0x0000000000000000 0x0000000000000000 FUNC     GLOBAL   _ZN4Core10ArgsParser10add_optionERN2AK10StringViewEPKcS5_cS5_NS0_14OptionHideModeE
    38: 0x0000000000000000 0x0000000000000000 FUNC     GLOBAL   _ZN2AK9FormatterINS_10StringViewEvE6formatERNS_13FormatBuilderES1_
    39: 0x0000000000000000 0x0000000000000000 FUNC     GLOBAL   _ZN2AK9FormatterIivE6formatERNS_13FormatBuilderEi
    40: 0x0000000000000000 0x0000000000000000 FUNC     GLOBAL   _ZN4Core10ArgsParser10add_optionEONS0_6OptionE
    41: 0x0000000000000000 0x0000000000000000 FUNC     GLOBAL   _ZN4Core10ArgsParser23add_positional_argumentERN2AK6VectorINS1_10ByteStringELm0EEEPKcS7_NS0_8RequiredE
    42: 0x0000000000000000 0x0000000000000000 FUNC     GLOBAL   strerror
    43: 0x0000000000000000 0x0000000000000000 FUNC     GLOBAL   strlen
    44: 0x0000000000000000 0x0000000000000000 FUNC     GLOBAL   __stack_chk_fail
```

After it correctly shows all 57 entries:

```
    Symbol table '.dynsym' contains 57 entries.
   Num: Value              Size               Type     Bind     Name
     0: 0x0000000000000000 0x0000000000000000 NOTYPE   LOCAL    
     1: 0x0000000000000000 0x0000000000000000 OBJECT   GLOBAL   _ZTVN10__cxxabiv120__si_class_type_infoE
     2: 0x0000000000000000 0x0000000000000000 OBJECT   GLOBAL   stderr
     3: 0x0000000000000000 0x0000000000000000 FUNC     GLOBAL   _ZN4Core6System6pledgeEN2AK10StringViewES2_
     4: 0x0000000000000000 0x0000000000000000 OBJECT   GLOBAL   _ZTVN10__cxxabiv117__class_type_infoE
     5: 0x0000000000000000 0x0000000000000000 FUNC     GLOBAL   _ZN2AK10StringViewC1ERKNS_10ByteStringE
     6: 0x0000000000000000 0x0000000000000000 FUNC     GLOBAL   _ZN4Core6System4execEN2AK10StringViewENS1_4SpanIKS2_EENS0_12SearchInPathENS1_8OptionalIS5_EE
     7: 0x0000000000000000 0x0000000000000000 FUNC     GLOBAL   _ZdlPvm
     8: 0x0000000000000000 0x0000000000000000 FUNC     GLOBAL   _ZNK2AK10ByteString8containsEcNS_15CaseSensitivityE
     9: 0x0000000000000000 0x0000000000000000 FUNC     GLOBAL   _ZN2AK4voutEP4FILENS_10StringViewERNS_22TypeErasedFormatParamsEb
    10: 0x0000000000000000 0x0000000000000000 FUNC     GLOBAL   putenv
    11: 0x0000000000000000 0x0000000000000000 FUNC     GLOBAL   _ZN2AK17StandardFormatter5parseERNS_22TypeErasedFormatParamsERNS_12FormatParserE
    12: 0x0000000000000000 0x0000000000000000 FUNC     GLOBAL   malloc
    13: 0x0000000000000000 0x0000000000000000 FUNC     WEAK     _ITM_deregisterTMCloneTable
    14: 0x0000000000000000 0x0000000000000000 FUNC     GLOBAL   _ZN2AK10StringImpl6createEPKcmNS_11ShouldChompE
    15: 0x0000000000000000 0x0000000000000000 FUNC     GLOBAL   ak_verification_failed
    16: 0x0000000000000000 0x0000000000000000 FUNC     GLOBAL   unsetenv
    17: 0x0000000000000000 0x0000000000000000 FUNC     GLOBAL   _ZN4Core10ArgsParser5parseEN2AK4SpanINS1_10StringViewEEENS0_15FailureBehaviorE
    18: 0x0000000000000000 0x0000000000000000 FUNC     GLOBAL   _ZN2AK10StringImpl20the_empty_stringimplEv
    19: 0x0000000000000000 0x0000000000000000 OBJECT   GLOBAL   environ
    20: 0x0000000000000000 0x0000000000000000 FUNC     GLOBAL   tzset
    21: 0x0000000000000000 0x0000000000000000 OBJECT   GLOBAL   __stack_chk_guard
    22: 0x0000000000000000 0x0000000000000000 FUNC     GLOBAL   _ZN2AK9FormatterImvE6formatERNS_13FormatBuilderEm
    23: 0x0000000000000000 0x0000000000000000 FUNC     GLOBAL   _ZN2AK4vdbgENS_10StringViewERNS_22TypeErasedFormatParamsEb
    24: 0x0000000000000000 0x0000000000000000 FUNC     GLOBAL   exit
    25: 0x0000000000000000 0x0000000000000000 FUNC     WEAK     _ITM_registerTMCloneTable
    26: 0x0000000000000000 0x0000000000000000 FUNC     GLOBAL   _ZN4Core10ArgsParserC1Ev
    27: 0x0000000000000000 0x0000000000000000 FUNC     GLOBAL   _ZN4Core10ArgsParser10add_optionERbPKcS3_cNS0_14OptionHideModeE
    28: 0x0000000000000000 0x0000000000000000 FUNC     GLOBAL   _ZN2AK9FormatterINS_12FormatStringEvE7vformatERNS_13FormatBuilderENS_10StringViewERNS_22TypeErasedFormatParamsE
    29: 0x0000000000000000 0x0000000000000000 OBJECT   GLOBAL   stdout
    30: 0x0000000000000000 0x0000000000000000 FUNC     GLOBAL   _ZN2AK10StringImplD1Ev
    31: 0x0000000000000000 0x0000000000000000 FUNC     GLOBAL   __errno_location
    32: 0x0000000000000000 0x0000000000000000 FUNC     GLOBAL   clearenv
    33: 0x0000000000000000 0x0000000000000000 FUNC     GLOBAL   _ZNK2AK10StringView10split_viewEcNS_13SplitBehaviorE
    34: 0x0000000000000000 0x0000000000000000 FUNC     GLOBAL   __begin_atexit_locking
    35: 0x0000000000000000 0x0000000000000000 FUNC     GLOBAL   malloc_good_size
    36: 0x0000000000000000 0x0000000000000000 FUNC     GLOBAL   free
    37: 0x0000000000000000 0x0000000000000000 FUNC     GLOBAL   _ZN4Core10ArgsParser10add_optionERN2AK10StringViewEPKcS5_cS5_NS0_14OptionHideModeE
    38: 0x0000000000000000 0x0000000000000000 FUNC     GLOBAL   _ZN2AK9FormatterINS_10StringViewEvE6formatERNS_13FormatBuilderES1_
    39: 0x0000000000000000 0x0000000000000000 FUNC     GLOBAL   _ZN2AK9FormatterIivE6formatERNS_13FormatBuilderEi
    40: 0x0000000000000000 0x0000000000000000 FUNC     GLOBAL   _ZN4Core10ArgsParser10add_optionEONS0_6OptionE
    41: 0x0000000000000000 0x0000000000000000 FUNC     GLOBAL   _ZN4Core10ArgsParser23add_positional_argumentERN2AK6VectorINS1_10ByteStringELm0EEEPKcS7_NS0_8RequiredE
    42: 0x0000000000000000 0x0000000000000000 FUNC     GLOBAL   strerror
    43: 0x0000000000000000 0x0000000000000000 FUNC     GLOBAL   strlen
    44: 0x0000000000000000 0x0000000000000000 FUNC     GLOBAL   __stack_chk_fail
    45: 0x0000000000003280 0x000000000000017c FUNC     WEAK     _ZN2AK14__format_valueIPcEENS_7ErrorOrIvNS_5ErrorEEERNS_22TypeErasedFormatParamsERNS_13FormatBuilderERNS_12FormatParserEPKv
    46: 0x0000000000000000 0x0000000000000000 FUNC     WEAK     __cxa_finalize
    47: 0x0000000000000000 0x0000000000000000 FUNC     WEAK     __register_frame_info
    48: 0x0000000000003400 0x0000000000000099 FUNC     WEAK     _ZN2AK14__format_valueINS_10ByteStringEEENS_7ErrorOrIvNS_5ErrorEEERNS_22TypeErasedFormatParamsERNS_13FormatBuilderERNS_12FormatParserEPKv
    49: 0x0000000000000000 0x0000000000000000 FUNC     WEAK     __deregister_frame_info
    50: 0x0000000000002000 0x0000000000000000 FUNC     GLOBAL   _init
    51: 0x0000000000003a60 0x0000000000000089 FUNC     WEAK     _ZN2AK14__format_valueIiEENS_7ErrorOrIvNS_5ErrorEEERNS_22TypeErasedFormatParamsERNS_13FormatBuilderERNS_12FormatParserEPKv
    52: 0x0000000000005c48 0x0000000000000010 OBJECT   WEAK     _ZTIN2AK8FunctionIFNS_7ErrorOrIbNS_5ErrorEEENS_10StringViewEEE19CallableWrapperBaseE
    53: 0x0000000000004560 0x0000000000000051 OBJECT   WEAK     _ZTSN2AK8FunctionIFNS_7ErrorOrIbNS_5ErrorEEENS_10StringViewEEE19CallableWrapperBaseE
    54: 0x0000000000003af0 0x000000000000008c FUNC     WEAK     _ZN2AK14__format_valueINS_10StringViewEEENS_7ErrorOrIvNS_5ErrorEEERNS_22TypeErasedFormatParamsERNS_13FormatBuilderERNS_12FormatParserEPKv
    55: 0x0000000000003c60 0x0000000000000000 FUNC     GLOBAL   _fini
    56: 0x0000000000003810 0x0000000000000248 FUNC     WEAK     _ZN2AK14__format_valueINS_5ErrorEEENS_7ErrorOrIvS1_EERNS_22TypeErasedFormatParamsERNS_13FormatBuilderERNS_12FormatParserEPKv
```
    
    