### PR TITLE
LibGfx: Take into account unicode ranges to find font for space glyph

### DIFF
--- a/Tests/LibWeb/Ref/reference/space-glyph-width-ref.html
+++ b/Tests/LibWeb/Ref/reference/space-glyph-width-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        .text {
+            font-size: 100px;
+        }
+    </style>
+</head>
+<body>
+    <div class="text">A B</div>
+</body>
+</html>

--- a/Tests/LibWeb/Ref/space-glyph-width.html
+++ b/Tests/LibWeb/Ref/space-glyph-width.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <link rel="match" href="reference/space-glyph-width-ref.html" />
+    <style>
+        @font-face {
+            font-family: 'HashFont';
+            src: url('assets/HashSans.woff');
+            unicode-range: U+0;
+        }
+
+        .text {
+            font-family: 'HashFont', 'SerenitySans';
+            font-size: 100px;
+        }
+    </style>
+</head>
+<body>
+    <div class="text">A B</div>
+</body>
+</html>

--- a/Userland/Libraries/LibGfx/TextLayout.h
+++ b/Userland/Libraries/LibGfx/TextLayout.h
@@ -105,7 +105,8 @@ Variant<DrawGlyph, DrawEmoji> prepare_draw_glyph_or_emoji(FloatPoint point, Utf8
 template<typename Callback>
 void for_each_glyph_position(FloatPoint baseline_start, Utf8View string, FontCascadeList const& font_list, Callback callback, IncludeLeftBearing include_left_bearing = IncludeLeftBearing::No, Optional<float&> width = {})
 {
-    float space_width = font_list.first().glyph_width(' ') + font_list.first().glyph_spacing();
+    auto const& space_glyph_font = font_list.font_for_code_point(' ');
+    float space_width = space_glyph_font.glyph_width(' ') + space_glyph_font.glyph_spacing();
 
     u32 last_code_point = 0;
 


### PR DESCRIPTION
Instead of assuming that the first font in the cascade font list will have a glyph for space, we need to find it in the list taking into account unicode ranges.