### PR TITLE
LibPDF+LibGfx (in particular, JPEG): Use regular color codepath for jpeg data too

### DIFF
--- a/Userland/Applications/ImageViewer/ViewWidget.cpp
+++ b/Userland/Applications/ImageViewer/ViewWidget.cpp
@@ -224,7 +224,7 @@ ErrorOr<void> ViewWidget::try_open_file(String const& path, Core::File& file)
     Vector<Animation::Frame> frames;
     // Note: Doing this check only requires reading the header of images
     // (so if the image is not vector graphics it can be still be decoded OOP).
-    if (auto decoder = Gfx::ImageDecoder::try_create_for_raw_bytes(file_data); decoder && decoder->is_vector()) {
+    if (auto decoder = Gfx::ImageDecoder::try_create_for_raw_bytes(file_data); decoder && decoder->natural_frame_format() == Gfx::NaturalFrameFormat::Vector) {
         // Use in-process decoding for vector graphics.
         is_animated = decoder->is_animated();
         loop_count = decoder->loop_count();

--- a/Userland/Libraries/LibGfx/CMYKBitmap.cpp
+++ b/Userland/Libraries/LibGfx/CMYKBitmap.cpp
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2024, Nico Weber <thakis@chromium.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibGfx/CMYKBitmap.h>
+
+namespace Gfx {
+
+ErrorOr<NonnullRefPtr<CMYKBitmap>> CMYKBitmap::create_with_size(IntSize const& size)
+{
+    VERIFY(size.width() >= 0 && size.height() >= 0);
+    auto data = TRY(ByteBuffer::create_uninitialized(size.width() * size.height() * sizeof(CMYK)));
+    return adopt_ref(*new CMYKBitmap(size, move(data)));
+}
+
+}

--- a/Userland/Libraries/LibGfx/CMYKBitmap.h
+++ b/Userland/Libraries/LibGfx/CMYKBitmap.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2024, Nico Weber <thakis@chromium.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/ByteBuffer.h>
+#include <AK/NonnullRefPtr.h>
+#include <AK/RefCounted.h>
+#include <LibGfx/Size.h>
+
+namespace Gfx {
+
+struct CMYK {
+    u8 c;
+    u8 m;
+    u8 y;
+    u8 k;
+};
+
+class CMYKBitmap : public RefCounted<CMYKBitmap> {
+public:
+    static ErrorOr<NonnullRefPtr<CMYKBitmap>> create_with_size(IntSize const& size);
+
+    IntSize const& size() const { return m_size; }
+
+    [[nodiscard]] CMYK* scanline(int y);
+    [[nodiscard]] CMYK const* scanline(int y) const;
+
+    [[nodiscard]] CMYK* begin();
+    [[nodiscard]] CMYK* end();
+
+private:
+    CMYKBitmap(IntSize const& size, ByteBuffer data)
+        : m_size(size)
+        , m_data(move(data))
+    {
+    }
+
+    IntSize m_size;
+    ByteBuffer m_data;
+};
+
+inline CMYK* CMYKBitmap::scanline(int y)
+{
+    VERIFY(y >= 0 && y < m_size.height());
+    return reinterpret_cast<CMYK*>(m_data.data() + y * m_size.width() * sizeof(CMYK));
+}
+
+inline CMYK const* CMYKBitmap::scanline(int y) const
+{
+    VERIFY(y >= 0 && y < m_size.height());
+    return reinterpret_cast<CMYK const*>(m_data.data() + y * m_size.width() * sizeof(CMYK));
+}
+
+inline CMYK* CMYKBitmap::begin()
+{
+    return reinterpret_cast<CMYK*>(m_data.data());
+}
+
+inline CMYK* CMYKBitmap::end()
+{
+    return reinterpret_cast<CMYK*>(m_data.data() + m_data.size());
+}
+
+}

--- a/Userland/Libraries/LibGfx/CMakeLists.txt
+++ b/Userland/Libraries/LibGfx/CMakeLists.txt
@@ -3,6 +3,7 @@ set(SOURCES
     AntiAliasingPainter.cpp
     Bitmap.cpp
     BitmapMixer.cpp
+    CMYKBitmap.cpp
     ClassicStylePainter.cpp
     ClassicWindowTheme.cpp
     Color.cpp

--- a/Userland/Libraries/LibGfx/Forward.h
+++ b/Userland/Libraries/LibGfx/Forward.h
@@ -9,6 +9,7 @@
 namespace Gfx {
 
 class Bitmap;
+class CMYKBitmap;
 class ImmutableBitmap;
 class CharacterBitmap;
 class Color;

--- a/Userland/Libraries/LibGfx/ImageFormats/ImageDecoder.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/ImageDecoder.h
@@ -11,6 +11,7 @@
 #include <AK/RefCounted.h>
 #include <AK/RefPtr.h>
 #include <LibGfx/Bitmap.h>
+#include <LibGfx/CMYKBitmap.h>
 #include <LibGfx/Size.h>
 #include <LibGfx/VectorGraphic.h>
 
@@ -30,6 +31,7 @@ struct VectorImageFrameDescriptor {
 
 enum class NaturalFrameFormat {
     RGB,
+    CMYK,
     Vector,
 };
 
@@ -59,6 +61,7 @@ public:
     virtual ErrorOr<Optional<ReadonlyBytes>> icc_data() { return OptionalNone {}; }
 
     virtual NaturalFrameFormat natural_frame_format() const { return NaturalFrameFormat::RGB; }
+    virtual ErrorOr<NonnullRefPtr<CMYKBitmap>> cmyk_frame() { VERIFY_NOT_REACHED(); }
     virtual ErrorOr<VectorImageFrameDescriptor> vector_frame(size_t) { VERIFY_NOT_REACHED(); }
 
 protected:
@@ -81,6 +84,9 @@ public:
     ErrorOr<Optional<ReadonlyBytes>> icc_data() const { return m_plugin->icc_data(); }
 
     NaturalFrameFormat natural_frame_format() { return m_plugin->natural_frame_format(); }
+
+    // Call only if natural_frame_format() == NaturalFrameFormat::CMYK.
+    ErrorOr<NonnullRefPtr<CMYKBitmap>> cmyk_frame(size_t) { return m_plugin->cmyk_frame(); }
 
     // Call only if natural_frame_format() == NaturalFrameFormat::Vector.
     ErrorOr<VectorImageFrameDescriptor> vector_frame(size_t index) { return m_plugin->vector_frame(index); }

--- a/Userland/Libraries/LibGfx/ImageFormats/ImageDecoder.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/ImageDecoder.h
@@ -31,6 +31,7 @@ struct VectorImageFrameDescriptor {
 
 enum class NaturalFrameFormat {
     RGB,
+    Grayscale,
     CMYK,
     Vector,
 };

--- a/Userland/Libraries/LibGfx/ImageFormats/ImageDecoder.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/ImageDecoder.h
@@ -28,6 +28,11 @@ struct VectorImageFrameDescriptor {
     int duration { 0 };
 };
 
+enum class NaturalFrameFormat {
+    RGB,
+    Vector,
+};
+
 class ImageDecoderPlugin {
 public:
     virtual ~ImageDecoderPlugin() = default;
@@ -53,7 +58,7 @@ public:
     virtual ErrorOr<ImageFrameDescriptor> frame(size_t index, Optional<IntSize> ideal_size = {}) = 0;
     virtual ErrorOr<Optional<ReadonlyBytes>> icc_data() { return OptionalNone {}; }
 
-    virtual bool is_vector() { return false; }
+    virtual NaturalFrameFormat natural_frame_format() const { return NaturalFrameFormat::RGB; }
     virtual ErrorOr<VectorImageFrameDescriptor> vector_frame(size_t) { VERIFY_NOT_REACHED(); }
 
 protected:
@@ -75,7 +80,9 @@ public:
     ErrorOr<ImageFrameDescriptor> frame(size_t index, Optional<IntSize> ideal_size = {}) const { return m_plugin->frame(index, ideal_size); }
     ErrorOr<Optional<ReadonlyBytes>> icc_data() const { return m_plugin->icc_data(); }
 
-    bool is_vector() { return m_plugin->is_vector(); }
+    NaturalFrameFormat natural_frame_format() { return m_plugin->natural_frame_format(); }
+
+    // Call only if natural_frame_format() == NaturalFrameFormat::Vector.
     ErrorOr<VectorImageFrameDescriptor> vector_frame(size_t index) { return m_plugin->vector_frame(index); }
 
 private:

--- a/Userland/Libraries/LibGfx/ImageFormats/JPEGLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEGLoader.cpp
@@ -2010,7 +2010,11 @@ NaturalFrameFormat JPEGImageDecoderPlugin::natural_frame_format() const
     if (m_context->state == JPEGLoadingContext::State::Error)
         return NaturalFrameFormat::RGB;
     VERIFY(m_context->state >= JPEGLoadingContext::State::HeaderDecoded);
-    return m_context->components.size() == 4 ? NaturalFrameFormat::CMYK : NaturalFrameFormat::RGB;
+    if (m_context->components.size() == 1)
+        return NaturalFrameFormat::Grayscale;
+    if (m_context->components.size() == 4)
+        return NaturalFrameFormat::CMYK;
+    return NaturalFrameFormat::RGB;
 }
 
 ErrorOr<NonnullRefPtr<CMYKBitmap>> JPEGImageDecoderPlugin::cmyk_frame()

--- a/Userland/Libraries/LibGfx/ImageFormats/JPEGLoader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/JPEGLoader.h
@@ -39,6 +39,9 @@ public:
     virtual ErrorOr<ImageFrameDescriptor> frame(size_t index, Optional<IntSize> ideal_size = {}) override;
     virtual ErrorOr<Optional<ReadonlyBytes>> icc_data() override;
 
+    virtual NaturalFrameFormat natural_frame_format() const override;
+    virtual ErrorOr<NonnullRefPtr<CMYKBitmap>> cmyk_frame() override;
+
 private:
     JPEGImageDecoderPlugin(NonnullOwnPtr<JPEGLoadingContext>);
 

--- a/Userland/Libraries/LibGfx/ImageFormats/TinyVGLoader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/TinyVGLoader.h
@@ -83,7 +83,7 @@ public:
     virtual IntSize size() override;
     virtual ErrorOr<ImageFrameDescriptor> frame(size_t index, Optional<IntSize> ideal_size = {}) override;
 
-    virtual bool is_vector() override { return true; }
+    virtual NaturalFrameFormat natural_frame_format() const override { return NaturalFrameFormat::Vector; }
     virtual ErrorOr<VectorImageFrameDescriptor> vector_frame(size_t index) override;
 
     virtual ~TinyVGImageDecoderPlugin() override = default;

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -1124,11 +1124,6 @@ PDFErrorOr<Renderer::LoadedImage> Renderer::load_image(NonnullRefPtr<StreamObjec
         component_value_decoders.empend(0.0f, 255.0f, dmin, dmax);
     }
 
-    if (TRY(is_filter(CommonNames::DCTDecode))) {
-        // TODO: stream objects could store Variant<bytes/Bitmap> to avoid serialisation/deserialisation here
-        return LoadedImage { TRY(Gfx::Bitmap::create_from_serialized_bytes(image->bytes())), is_image_mask };
-    }
-
     auto bitmap = MUST(Gfx::Bitmap::create(Gfx::BitmapFormat::BGRA8888, { width, height }));
     int x = 0;
     int y = 0;


### PR DESCRIPTION
This handing the original jpeg channels to the color spaces, so this finally adds a way to get "raw" CMYK data from a jpeg, and also a way to know if jpeg data originally was grayscale.

The regula color codepath is fairly slow, so this makes pages with jpegs render subjectively quite a bit slower. Objectively, processing my 1000 file pdf test set goes from 45s to 1m57s. (But the majority of the time is spent on 0000849.pdf, a file with many many jpegs. If I filter that one file out in test_pdf.py, it's 45s -> 1m7s. Still 50% slower, but not 160% slower). In return, they're correct. And it provides additional incentive for making that codepath faster :^)

We now handle /Decode arrays on jpegs, and we now color-manage jpeg data in PDFs (including CMYK and grayscale jpegs).

Fixes all remaining color-related issues I'm aware of. (There are a bunch of missing non-color image-related issues still: We don't clip images, we ignore smask state on the graphics state, probably more.)