### PR TITLE
LibWeb: Add support for implicit grid lines formed by grid areas in GFC 

### DIFF
--- a/Tests/LibWeb/Layout/expected/grid/implicit-lines.txt
+++ b/Tests/LibWeb/Layout/expected/grid/implicit-lines.txt
@@ -1,0 +1,30 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x236 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x220 children: not-inline
+      Box <div.grid-container> at (8,8) content-size 784x220 [GFC] children: not-inline
+        BlockContainer <div.item2> at (405,8) content-size 387x100 [BFC] children: inline
+          line 0 width: 49.1875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 6, rect: [405,8 49.1875x17.46875]
+              "Item 2"
+          TextNode <#text>
+        BlockContainer <div.item1> at (8,8) content-size 387x210 [BFC] children: inline
+          line 0 width: 46.71875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 6, rect: [8,8 46.71875x17.46875]
+              "Item 1"
+          TextNode <#text>
+        BlockContainer <div.item3> at (405,118) content-size 387x100 [BFC] children: inline
+          line 0 width: 49.1875, height: 17.46875, bottom: 17.46875, baseline: 13.53125
+            frag 0 from TextNode start: 0, length: 6, rect: [405,118 49.1875x17.46875]
+              "Item 2"
+          TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x236]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x220]
+      PaintableBox (Box<DIV>.grid-container) [8,8 784x220]
+        PaintableWithLines (BlockContainer<DIV>.item2) [405,8 387x100]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.item1) [8,8 387x210]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.item3) [405,118 387x100]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/input/grid/implicit-lines.html
+++ b/Tests/LibWeb/Layout/input/grid/implicit-lines.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html><html lang="en"><style>
+.grid-container {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    grid-template-rows: 100px 100px;
+    gap: 10px;
+    height: 220px;
+    grid-template-areas: 
+    "one two"
+    "one three";
+}
+
+.item1 {
+    background-color: lightblue;
+    grid-row-start: one-start;
+    grid-row-end: one-end;
+    grid-column-start: one-start;
+    grid-column-end: one-end;
+}
+
+.item2 {
+    background-color: lightcoral;
+    grid-area: two;
+}
+
+.item3 {
+    background-color: lightgreen;
+    grid-row-start: three-start;
+    grid-row-end: three-end;
+    grid-column-start: three-start;
+    grid-column-end: three-end;
+}
+</style>
+<div class="grid-container"><div class="item2">Item 2</div><div class="item1">Item 1</div><div class="item3">Item 2</div></div>

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -1412,8 +1412,8 @@ void GridFormattingContext::place_grid_items()
 {
     auto grid_template_columns = grid_container().computed_values().grid_template_columns();
     auto grid_template_rows = grid_container().computed_values().grid_template_rows();
-    auto column_count = m_column_lines.size();
-    auto row_count = m_row_lines.size();
+    auto column_tracks_count = m_column_lines.size() - 1;
+    auto row_tracks_count = m_row_lines.size() - 1;
 
     // https://drafts.csswg.org/css-grid/#overview-placement
     // 2.2. Placing Items
@@ -1437,7 +1437,7 @@ void GridFormattingContext::place_grid_items()
         return IterationDecision::Continue;
     });
 
-    m_occupation_grid = OccupationGrid(column_count, row_count);
+    m_occupation_grid = OccupationGrid(column_tracks_count, row_tracks_count);
 
     build_grid_areas();
 
@@ -1930,8 +1930,8 @@ void GridFormattingContext::run(Box const&, LayoutMode, AvailableSpace const& av
     auto const& grid_computed_values = grid_container().computed_values();
 
     // NOTE: We store explicit grid sizes to later use in determining the position of items with negative index.
-    m_explicit_columns_line_count = m_column_lines.size() + 1;
-    m_explicit_rows_line_count = m_row_lines.size() + 1;
+    m_explicit_columns_line_count = m_column_lines.size();
+    m_explicit_rows_line_count = m_row_lines.size();
 
     place_grid_items();
 
@@ -2294,8 +2294,7 @@ void GridFormattingContext::init_grid_lines(GridDimension dimension)
     };
 
     expand_lines_definition(lines_definition);
-    if (line_names.size() > 0)
-        lines.append({ .names = line_names });
+    lines.append({ .names = line_names });
 }
 
 void OccupationGrid::set_occupied(int column_start, int column_end, int row_start, int row_end)


### PR DESCRIPTION
According to spec each grid area implicitly defines 4 additional named
lines that could be used to specify items position.