### PR TITLE
LibWeb/CSS: Resolve percentages in NumericCalculationNode

### DIFF
--- a/Tests/LibWeb/Layout/expected/css-values/calc-min-with-percentage.txt
+++ b/Tests/LibWeb/Layout/expected/css-values/calc-min-with-percentage.txt
@@ -1,0 +1,9 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x116 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 500x100 children: not-inline
+      BlockContainer <div> at (8,8) content-size 100x100 children: not-inline
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x116]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 500x100]
+      PaintableWithLines (BlockContainer<DIV>) [8,8 100x100]

--- a/Tests/LibWeb/Layout/input/css-values/calc-min-with-percentage.html
+++ b/Tests/LibWeb/Layout/input/css-values/calc-min-with-percentage.html
@@ -1,0 +1,13 @@
+<!doctype html><style>
+* {
+    outline: 1px solid black;
+}
+body {
+    width: 500px;
+}
+div {
+    width: min(100px, 50%);
+    height: 100px;
+    background: orange;
+}
+</style><body><div>

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.cpp
@@ -217,8 +217,18 @@ bool NumericCalculationNode::contains_percentage() const
     return m_value.has<Percentage>();
 }
 
-CalculatedStyleValue::CalculationResult NumericCalculationNode::resolve(Optional<Length::ResolutionContext const&>, CalculatedStyleValue::PercentageBasis const&) const
+CalculatedStyleValue::CalculationResult NumericCalculationNode::resolve(Optional<Length::ResolutionContext const&>, CalculatedStyleValue::PercentageBasis const& percentage_basis) const
 {
+    if (m_value.has<Percentage>()) {
+        return percentage_basis.visit(
+            [&](Empty const&) -> CalculatedStyleValue::CalculationResult {
+                VERIFY_NOT_REACHED();
+            },
+            [&](auto const& value) {
+                return CalculatedStyleValue::CalculationResult(value.percentage_of(m_value.get<Percentage>()));
+            });
+    }
+
     return m_value;
 }
 


### PR DESCRIPTION
Percentages should be resolved against the provided percentage basis instead of just returning the underlying value.

Fixes https://github.com/SerenityOS/serenity/issues/22654