### PR TITLE
LibWeb+WebContent: Spawn Worker processes from the chrome

### DIFF
--- a/Ladybird/AppKit/UI/LadybirdWebViewBridge.cpp
+++ b/Ladybird/AppKit/UI/LadybirdWebViewBridge.cpp
@@ -51,6 +51,11 @@ WebViewBridge::WebViewBridge(Vector<Web::DevicePixelRect> screen_rects, float de
         if (on_scroll)
             on_scroll(to_widget_position(position));
     };
+
+    on_request_worker_agent = []() {
+        auto worker_client = MUST(launch_web_worker_process(MUST(get_paths_for_helper_process("WebWorker"sv))));
+        return worker_client->dup_sockets();
+    };
 }
 
 WebViewBridge::~WebViewBridge() = default;

--- a/Ladybird/HelperProcess.cpp
+++ b/Ladybird/HelperProcess.cpp
@@ -152,6 +152,11 @@ ErrorOr<NonnullRefPtr<ImageDecoderClient::Client>> launch_image_decoder_process(
     return launch_generic_server_process<ImageDecoderClient::Client>(candidate_image_decoder_paths, ""sv, "ImageDecoder"sv);
 }
 
+ErrorOr<NonnullRefPtr<Web::HTML::WebWorkerClient>> launch_web_worker_process(ReadonlySpan<String> candidate_web_worker_paths)
+{
+    return launch_generic_server_process<Web::HTML::WebWorkerClient>(candidate_web_worker_paths, ""sv, "WebWorker"sv);
+}
+
 ErrorOr<NonnullRefPtr<Protocol::RequestClient>> launch_request_server_process(ReadonlySpan<String> candidate_request_server_paths, StringView serenity_resource_root)
 {
     return launch_generic_server_process<Protocol::RequestClient>(candidate_request_server_paths, serenity_resource_root, "RequestServer"sv);

--- a/Ladybird/HelperProcess.h
+++ b/Ladybird/HelperProcess.h
@@ -13,6 +13,7 @@
 #include <LibImageDecoderClient/Client.h>
 #include <LibProtocol/RequestClient.h>
 #include <LibProtocol/WebSocketClient.h>
+#include <LibWeb/Worker/WebWorkerClient.h>
 #include <LibWebView/ViewImplementation.h>
 #include <LibWebView/WebContentClient.h>
 
@@ -22,5 +23,6 @@ ErrorOr<NonnullRefPtr<WebView::WebContentClient>> launch_web_content_process(
     Ladybird::WebContentOptions const&);
 
 ErrorOr<NonnullRefPtr<ImageDecoderClient::Client>> launch_image_decoder_process(ReadonlySpan<String> candidate_image_decoder_paths);
+ErrorOr<NonnullRefPtr<Web::HTML::WebWorkerClient>> launch_web_worker_process(ReadonlySpan<String> candidate_web_worker_paths);
 ErrorOr<NonnullRefPtr<Protocol::RequestClient>> launch_request_server_process(ReadonlySpan<String> candidate_request_server_paths, StringView serenity_resource_root);
 ErrorOr<NonnullRefPtr<Protocol::WebSocketClient>> launch_web_socket_process(ReadonlySpan<String> candidate_web_socket_paths, StringView serenity_resource_root);

--- a/Ladybird/Qt/WebContentView.cpp
+++ b/Ladybird/Qt/WebContentView.cpp
@@ -33,6 +33,7 @@
 #include <LibMain/Main.h>
 #include <LibWeb/Crypto/Crypto.h>
 #include <LibWeb/Loader/ContentFilter.h>
+#include <LibWeb/Worker/WebWorkerClient.h>
 #include <LibWebView/WebContentClient.h>
 #include <QApplication>
 #include <QCursor>
@@ -112,6 +113,11 @@ WebContentView::WebContentView(WebContentOptions const& web_content_options, Str
 
     on_leave_tooltip_area = []() {
         QToolTip::hideText();
+    };
+
+    on_request_worker_agent = []() {
+        auto worker_client = MUST(launch_web_worker_process(MUST(get_paths_for_helper_process("WebWorker"sv))));
+        return worker_client->dup_sockets();
     };
 }
 

--- a/Ladybird/WebWorker/main.cpp
+++ b/Ladybird/WebWorker/main.cpp
@@ -33,9 +33,11 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     AK::set_rich_debug_enabled(true);
 
     int fd_passing_socket { -1 };
+    StringView serenity_resource_root;
 
     Core::ArgsParser args_parser;
     args_parser.add_option(fd_passing_socket, "File descriptor of the fd passing socket", "fd-passing-socket", 'c', "fd-passing-socket");
+    args_parser.add_option(serenity_resource_root, "Absolute path to directory for serenity resources", "serenity-resource-root", 'r', "serenity-resource-root");
     args_parser.parse(arguments);
 
     platform_init();

--- a/Meta/gn/secondary/Userland/Libraries/LibWebView/BUILD.gn
+++ b/Meta/gn/secondary/Userland/Libraries/LibWebView/BUILD.gn
@@ -123,6 +123,7 @@ shared_library("LibWebView") {
     "InspectorClient.cpp",
     "RequestServerAdapter.cpp",
     "SearchEngine.cpp",
+    "SocketPair.cpp",
     "SourceHighlighter.cpp",
     "URL.cpp",
     "UserAgent.cpp",

--- a/Userland/Applications/Browser/main.cpp
+++ b/Userland/Applications/Browser/main.cpp
@@ -119,6 +119,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::unveil("/tmp/session/%sid/portal/filesystemaccess", "rw"));
     TRY(Core::System::unveil("/tmp/session/%sid/portal/image", "rw"));
     TRY(Core::System::unveil("/tmp/session/%sid/portal/webcontent", "rw"));
+    TRY(Core::System::unveil("/tmp/session/%sid/portal/webworker", "rw"));
     TRY(Core::System::unveil("/tmp/session/%sid/portal/request", "rw"));
     TRY(Core::System::unveil("/tmp/session/%sid/portal/sql", "rw"));
     TRY(Core::System::unveil("/home", "rwc"));

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -457,6 +457,7 @@ class Window;
 class WindowEnvironmentSettingsObject;
 class WindowProxy;
 class Worker;
+class WorkerAgent;
 class WorkerDebugConsoleClient;
 class WorkerEnvironmentSettingsObject;
 class WorkerGlobalScope;

--- a/Userland/Libraries/LibWeb/HTML/WorkerAgent.cpp
+++ b/Userland/Libraries/LibWeb/HTML/WorkerAgent.cpp
@@ -4,92 +4,10 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/LexicalPath.h>
-#include <LibCore/Socket.h>
-#include <LibCore/System.h>
+#include <LibWeb/Bindings/HostDefined.h>
 #include <LibWeb/HTML/WorkerAgent.h>
+#include <LibWeb/Page/Page.h>
 #include <LibWeb/Worker/WebWorkerClient.h>
-
-// FIXME: Deduplicate this code with ladybird!!
-
-#ifndef AK_OS_SERENITY
-namespace {
-
-ErrorOr<String> application_directory()
-{
-    auto current_executable_path = TRY(Core::System::current_executable_path());
-    auto dirname = LexicalPath::dirname(current_executable_path);
-    return String::from_byte_string(dirname);
-}
-
-ErrorOr<Vector<String>> get_paths_for_helper_process(StringView process_name)
-{
-    auto application_path = TRY(application_directory());
-    Vector<String> paths;
-
-    TRY(paths.try_append(TRY(String::formatted("{}/{}", application_path, process_name))));
-    TRY(paths.try_append(TRY(String::formatted("./{}", process_name))));
-    // NOTE: Add platform-specific paths here
-    return paths;
-}
-
-ErrorOr<NonnullRefPtr<Web::HTML::WebWorkerClient>> launch_web_worker_process(ReadonlySpan<String> candidate_web_content_paths)
-{
-    int socket_fds[2] {};
-    TRY(Core::System::socketpair(AF_LOCAL, SOCK_STREAM, 0, socket_fds));
-
-    int ui_fd = socket_fds[0];
-    int wc_fd = socket_fds[1];
-
-    int fd_passing_socket_fds[2] {};
-    TRY(Core::System::socketpair(AF_LOCAL, SOCK_STREAM, 0, fd_passing_socket_fds));
-
-    int ui_fd_passing_fd = fd_passing_socket_fds[0];
-    int wc_fd_passing_fd = fd_passing_socket_fds[1];
-
-    if (auto child_pid = TRY(Core::System::fork()); child_pid == 0) {
-        TRY(Core::System::close(ui_fd_passing_fd));
-        TRY(Core::System::close(ui_fd));
-
-        auto takeover_string = TRY(String::formatted("WebWorker:{}", wc_fd));
-        TRY(Core::System::setenv("SOCKET_TAKEOVER"sv, takeover_string, true));
-
-        auto webcontent_fd_passing_socket_string = TRY(String::number(wc_fd_passing_fd));
-
-        ErrorOr<void> result;
-        for (auto const& path : candidate_web_content_paths) {
-            if (Core::System::access(path, X_OK).is_error())
-                continue;
-
-            auto arguments = Vector {
-                path.bytes_as_string_view(),
-                "--fd-passing-socket"sv,
-                webcontent_fd_passing_socket_string
-            };
-
-            result = Core::System::exec(arguments[0], arguments.span(), Core::System::SearchInPath::Yes);
-            if (!result.is_error())
-                break;
-        }
-
-        if (result.is_error())
-            warnln("Could not launch any of {}: {}", candidate_web_content_paths, result.error());
-        VERIFY_NOT_REACHED();
-    }
-
-    TRY(Core::System::close(wc_fd_passing_fd));
-    TRY(Core::System::close(wc_fd));
-
-    auto socket = TRY(Core::LocalSocket::adopt_fd(ui_fd));
-    TRY(socket->set_blocking(true));
-
-    auto new_client = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) Web::HTML::WebWorkerClient(move(socket))));
-    new_client->set_fd_passing_socket(TRY(Core::LocalSocket::adopt_fd(ui_fd_passing_fd)));
-
-    return new_client;
-}
-}
-#endif
 
 namespace Web::HTML {
 
@@ -109,15 +27,19 @@ void WorkerAgent::initialize(JS::Realm& realm)
     m_message_port = MessagePort::create(realm);
     m_message_port->entangle_with(*m_outside_port);
 
-#ifndef AK_OS_SERENITY
-    auto paths = MUST(get_paths_for_helper_process("WebWorker"sv));
-    m_worker_ipc = MUST(launch_web_worker_process(paths));
-#else
-    m_worker_ipc = MUST(Web::HTML::WebWorkerClient::try_create());
-#endif
-
     TransferDataHolder data_holder;
     MUST(m_message_port->transfer_steps(data_holder));
+
+    // NOTE: This blocking IPC call may launch another process.
+    //    If spinning the event loop for this can cause other javascript to execute, we're in trouble.
+    auto worker_ipc_sockets = Bindings::host_defined_page(realm).client().request_worker_agent();
+    auto worker_socket = MUST(Core::LocalSocket::adopt_fd(worker_ipc_sockets.socket.take_fd()));
+    MUST(worker_socket->set_blocking(true));
+
+    auto fd_passing_socket = MUST(Core::LocalSocket::adopt_fd(worker_ipc_sockets.fd_passing_socket.take_fd()));
+
+    m_worker_ipc = make_ref_counted<WebWorkerClient>(move(worker_socket));
+    m_worker_ipc->set_fd_passing_socket(move(fd_passing_socket));
 
     m_worker_ipc->async_start_dedicated_worker(m_url, m_worker_options.type, m_worker_options.credentials, m_worker_options.name, move(data_holder));
 }

--- a/Userland/Libraries/LibWeb/HTML/WorkerAgent.h
+++ b/Userland/Libraries/LibWeb/HTML/WorkerAgent.h
@@ -6,12 +6,8 @@
 
 #pragma once
 
-#include <LibCore/Socket.h>
 #include <LibWeb/Forward.h>
-#include <LibWeb/HTML/MessageEvent.h>
 #include <LibWeb/HTML/MessagePort.h>
-#include <LibWeb/HTML/Scripting/WorkerEnvironmentSettingsObject.h>
-#include <LibWeb/HTML/Window.h>
 #include <LibWeb/Worker/WebWorkerClient.h>
 
 namespace Web::HTML {
@@ -22,13 +18,11 @@ struct WorkerOptions {
     String name { String {} };
 };
 
-struct WorkerAgent : JS::Cell {
+class WorkerAgent : public JS::Cell {
     JS_CELL(Agent, JS::Cell);
     JS_DECLARE_ALLOCATOR(WorkerAgent);
 
     WorkerAgent(AK::URL url, WorkerOptions const& options, JS::GCPtr<MessagePort> outside_port);
-
-    RefPtr<Web::HTML::WebWorkerClient> m_worker_ipc;
 
 private:
     virtual void initialize(JS::Realm&) override;
@@ -39,6 +33,8 @@ private:
 
     JS::GCPtr<MessagePort> m_message_port;
     JS::GCPtr<MessagePort> m_outside_port;
+
+    RefPtr<Web::HTML::WebWorkerClient> m_worker_ipc;
 };
 
 }

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -34,6 +34,7 @@
 #include <LibWeb/HTML/SelectItem.h>
 #include <LibWeb/Loader/FileRequest.h>
 #include <LibWeb/PixelUnits.h>
+#include <LibWebView/SocketPair.h>
 
 namespace Web {
 
@@ -283,6 +284,8 @@ public:
     virtual void page_did_change_theme_color(Gfx::Color) { }
 
     virtual void page_did_insert_clipboard_entry([[maybe_unused]] String data, [[maybe_unused]] String presentation_style, [[maybe_unused]] String mime_type) { }
+
+    virtual WebView::SocketPair request_worker_agent() { return { -1, -1 }; }
 
     virtual void inspector_did_load() { }
     virtual void inspector_did_select_dom_node([[maybe_unused]] i32 node_id, [[maybe_unused]] Optional<CSS::Selector::PseudoElement::Type> const& pseudo_element) { }

--- a/Userland/Libraries/LibWeb/Worker/WebWorkerClient.cpp
+++ b/Userland/Libraries/LibWeb/Worker/WebWorkerClient.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibCore/System.h>
 #include <LibWeb/Worker/WebWorkerClient.h>
 
 namespace Web::HTML {
@@ -16,6 +17,14 @@ void WebWorkerClient::die()
 WebWorkerClient::WebWorkerClient(NonnullOwnPtr<Core::LocalSocket> socket)
     : IPC::ConnectionToServer<WebWorkerClientEndpoint, WebWorkerServerEndpoint>(*this, move(socket))
 {
+}
+
+WebView::SocketPair WebWorkerClient::dup_sockets()
+{
+    WebView::SocketPair pair;
+    pair.socket = MUST(Core::System::dup(socket().fd().value()));
+    pair.fd_passing_socket = MUST(Core::System::dup(fd_passing_socket().fd().value()));
+    return pair;
 }
 
 }

--- a/Userland/Libraries/LibWeb/Worker/WebWorkerClient.h
+++ b/Userland/Libraries/LibWeb/Worker/WebWorkerClient.h
@@ -10,6 +10,7 @@
 #include <LibIPC/ConnectionToServer.h>
 #include <LibWeb/Worker/WebWorkerClientEndpoint.h>
 #include <LibWeb/Worker/WebWorkerServerEndpoint.h>
+#include <LibWebView/SocketPair.h>
 
 namespace Web::HTML {
 
@@ -20,6 +21,8 @@ class WebWorkerClient final
 
 public:
     explicit WebWorkerClient(NonnullOwnPtr<Core::LocalSocket>);
+
+    WebView::SocketPair dup_sockets();
 
 private:
     virtual void die() override;

--- a/Userland/Libraries/LibWebView/CMakeLists.txt
+++ b/Userland/Libraries/LibWebView/CMakeLists.txt
@@ -8,6 +8,7 @@ set(SOURCES
     InspectorClient.cpp
     RequestServerAdapter.cpp
     SearchEngine.cpp
+    SocketPair.cpp
     SourceHighlighter.cpp
     URL.cpp
     UserAgent.cpp

--- a/Userland/Libraries/LibWebView/Forward.h
+++ b/Userland/Libraries/LibWebView/Forward.h
@@ -21,6 +21,7 @@ class WebContentClient;
 struct Attribute;
 struct CookieStorageKey;
 struct SearchEngine;
+struct SocketPair;
 
 }
 

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
@@ -17,6 +17,7 @@
 #include <LibGfx/Palette.h>
 #include <LibGfx/SystemTheme.h>
 #include <LibWeb/Crypto/Crypto.h>
+#include <LibWeb/Worker/WebWorkerClient.h>
 
 REGISTER_WIDGET(WebView, OutOfProcessWebView)
 
@@ -70,6 +71,11 @@ OutOfProcessWebView::OutOfProcessWebView()
 
     on_finish_handling_input_event = [this](auto event_was_accepted) {
         did_finish_handling_input_event(event_was_accepted);
+    };
+
+    on_request_worker_agent = []() {
+        auto worker_client = MUST(Web::HTML::WebWorkerClient::try_create());
+        return worker_client->dup_sockets();
     };
 }
 

--- a/Userland/Libraries/LibWebView/SocketPair.cpp
+++ b/Userland/Libraries/LibWebView/SocketPair.cpp
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2024, Andrew Kaster <akaster@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibIPC/Decoder.h>
+#include <LibIPC/Encoder.h>
+#include <LibWebView/SocketPair.h>
+
+template<>
+ErrorOr<void> IPC::encode(Encoder& encoder, WebView::SocketPair const& pair)
+{
+    TRY(encoder.encode(pair.socket));
+    TRY(encoder.encode(pair.fd_passing_socket));
+    return {};
+}
+
+template<>
+ErrorOr<WebView::SocketPair> IPC::decode(Decoder& decoder)
+{
+    auto socket = TRY(decoder.decode<IPC::File>());
+    auto fd_passing_socket = TRY(decoder.decode<IPC::File>());
+
+    return WebView::SocketPair { move(socket), move(fd_passing_socket) };
+}

--- a/Userland/Libraries/LibWebView/SocketPair.h
+++ b/Userland/Libraries/LibWebView/SocketPair.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2024, Andrew Kaster <akaster@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibIPC/File.h>
+
+namespace WebView {
+
+struct SocketPair {
+    IPC::File socket;
+    IPC::File fd_passing_socket;
+};
+
+}
+
+namespace IPC {
+
+template<>
+ErrorOr<void> encode(Encoder&, WebView::SocketPair const&);
+
+template<>
+ErrorOr<WebView::SocketPair> decode(Decoder&);
+
+}

--- a/Userland/Libraries/LibWebView/ViewImplementation.h
+++ b/Userland/Libraries/LibWebView/ViewImplementation.h
@@ -177,6 +177,7 @@ public:
     Function<void(i32, String const&, Vector<Attribute> const&)> on_inspector_replaced_dom_node_attribute;
     Function<void(i32, Gfx::IntPoint, String const&, Optional<String> const&, Optional<Attribute> const&)> on_inspector_requested_dom_tree_context_menu;
     Function<void(String const&)> on_inspector_executed_console_script;
+    Function<SocketPair()> on_request_worker_agent;
 
     virtual Web::DevicePixelRect viewport_rect() const = 0;
     virtual Gfx::IntPoint to_content_position(Gfx::IntPoint widget_position) const = 0;

--- a/Userland/Libraries/LibWebView/WebContentClient.cpp
+++ b/Userland/Libraries/LibWebView/WebContentClient.cpp
@@ -478,4 +478,12 @@ void WebContentClient::inspector_did_execute_console_script(String const& script
         m_view.on_inspector_executed_console_script(script);
 }
 
+Messages::WebContentClient::RequestWorkerAgentResponse WebContentClient::request_worker_agent()
+{
+    if (m_view.on_request_worker_agent)
+        return m_view.on_request_worker_agent();
+
+    return Messages::WebContentClient::RequestWorkerAgentResponse { WebView::SocketPair { -1, -1 } };
+}
+
 }

--- a/Userland/Libraries/LibWebView/WebContentClient.h
+++ b/Userland/Libraries/LibWebView/WebContentClient.h
@@ -98,6 +98,7 @@ private:
     virtual void inspector_did_replace_dom_node_attribute(i32 node_id, String const& name, Vector<Attribute> const& replacement_attributes) override;
     virtual void inspector_did_request_dom_tree_context_menu(i32 node_id, Gfx::IntPoint position, String const& type, Optional<String> const& tag, Optional<Attribute> const& attribute) override;
     virtual void inspector_did_execute_console_script(String const& script) override;
+    virtual Messages::WebContentClient::RequestWorkerAgentResponse request_worker_agent() override;
 
     ViewImplementation& m_view;
 };

--- a/Userland/Services/WebContent/PageClient.cpp
+++ b/Userland/Services/WebContent/PageClient.cpp
@@ -21,6 +21,7 @@
 #include <LibWeb/Painting/ViewportPaintable.h>
 #include <LibWeb/Platform/Timer.h>
 #include <LibWebView/Attribute.h>
+#include <LibWebView/SocketPair.h>
 #include <WebContent/ConnectionFromClient.h>
 #include <WebContent/PageClient.h>
 #include <WebContent/PageHost.h>
@@ -559,6 +560,17 @@ void PageClient::page_did_change_theme_color(Gfx::Color color)
 void PageClient::page_did_insert_clipboard_entry(String data, String presentation_style, String mime_type)
 {
     client().async_did_insert_clipboard_entry(move(data), move(presentation_style), move(mime_type));
+}
+
+WebView::SocketPair PageClient::request_worker_agent()
+{
+    auto response = client().send_sync_but_allow_failure<Messages::WebContentClient::RequestWorkerAgent>();
+    if (!response) {
+        dbgln("WebContent client disconnected during RequestWorkerAgent. Exiting peacefully.");
+        exit(0);
+    }
+
+    return response->take_sockets();
 }
 
 void PageClient::inspector_did_load()

--- a/Userland/Services/WebContent/PageClient.h
+++ b/Userland/Services/WebContent/PageClient.h
@@ -128,6 +128,7 @@ private:
     virtual void page_did_finish_text_test() override;
     virtual void page_did_change_theme_color(Gfx::Color color) override;
     virtual void page_did_insert_clipboard_entry(String data, String presentation_style, String mime_type) override;
+    virtual WebView::SocketPair request_worker_agent() override;
     virtual void inspector_did_load() override;
     virtual void inspector_did_select_dom_node(i32 node_id, Optional<Web::CSS::Selector::PseudoElement::Type> const& pseudo_element) override;
     virtual void inspector_did_set_dom_node_text(i32 node_id, String const& text) override;

--- a/Userland/Services/WebContent/WebContentClient.ipc
+++ b/Userland/Services/WebContent/WebContentClient.ipc
@@ -9,6 +9,7 @@
 #include <LibWeb/HTML/SelectItem.h>
 #include <LibWeb/Page/Page.h>
 #include <LibWebView/Attribute.h>
+#include <LibWebView/SocketPair.h>
 
 endpoint WebContentClient
 {
@@ -77,6 +78,8 @@ endpoint WebContentClient
     did_get_js_console_messages(i32 start_index, Vector<ByteString> message_types, Vector<ByteString> messages) =|
 
     did_finish_text_test() =|
+
+    request_worker_agent() => (WebView::SocketPair sockets) // FIXME: Add required attributes to select a SharedWorker Agent
 
     inspector_did_load() =|
     inspector_did_select_dom_node(i32 node_id, Optional<Web::CSS::Selector::PseudoElement::Type> pseudo_element) =|

--- a/Userland/Services/WebContent/main.cpp
+++ b/Userland/Services/WebContent/main.cpp
@@ -41,7 +41,6 @@ ErrorOr<int> serenity_main(Main::Arguments)
     TRY(Core::System::unveil("/tmp/session/%sid/portal/request", "rw"));
     TRY(Core::System::unveil("/tmp/session/%sid/portal/image", "rw"));
     TRY(Core::System::unveil("/tmp/session/%sid/portal/websocket", "rw"));
-    TRY(Core::System::unveil("/tmp/session/%sid/portal/webworker", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
     Web::Platform::EventLoopPlugin::install(*new Web::Platform::EventLoopPluginSerenity);

--- a/Userland/Utilities/headless-browser.cpp
+++ b/Userland/Utilities/headless-browser.cpp
@@ -44,6 +44,7 @@
 #include <LibWeb/Cookie/Cookie.h>
 #include <LibWeb/Cookie/ParsedCookie.h>
 #include <LibWeb/HTML/ActivateTab.h>
+#include <LibWeb/Worker/WebWorkerClient.h>
 #include <LibWebView/CookieJar.h>
 #include <LibWebView/Database.h>
 #include <LibWebView/URL.h>
@@ -168,6 +169,15 @@ private:
 
         on_set_cookie = [this](auto const& url, auto const& cookie, auto source) {
             m_cookie_jar.set_cookie(url, cookie, source);
+        };
+
+        on_request_worker_agent = []() {
+#if defined(AK_OS_SERENITY)
+            auto worker_client = MUST(Web::HTML::WebWorkerClient::try_create());
+#else
+            auto worker_client = MUST(launch_web_worker_process(MUST(get_paths_for_helper_process("WebWorker"sv))));
+#endif
+            return worker_client->dup_sockets();
         };
     }
 


### PR DESCRIPTION
Instead of spawning these processes from the WebContent process, we now create them in the Browser chrome.

Part 1/N of "all processes are owned by the chrome".