### PR TITLE
LibWeb/CSS: Improve parsing of length percentage values for transforms

### DIFF
--- a/Tests/LibWeb/Ref/reference/transform-calc-length-percentage-ref.html
+++ b/Tests/LibWeb/Ref/reference/transform-calc-length-percentage-ref.html
@@ -1,0 +1,15 @@
+<!doctype html><style>
+    * { outline: 1px solid black; }
+    html { background: white; }
+    body {
+        background: pink;
+        padding: 32px;
+        width: 200px;
+    }
+    div {
+        background: orange;
+        transform: translate(-26px, -25px);
+        width: 50px;
+        height: 50px;
+    }
+</style><body><div>

--- a/Tests/LibWeb/Ref/transform-calc-length-percentage.html
+++ b/Tests/LibWeb/Ref/transform-calc-length-percentage.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<link rel="match" href="reference/transform-calc-length-percentage-ref.html" /><style>
+    * { outline: 1px solid black; }
+    html { background: white; }
+    body {
+        background: pink;
+        padding: 32px;
+        width: 200px;
+    }
+    div {
+        background: orange;
+        transform: translate(calc(-50% - 1px), -50%);
+        width: 50px;
+        height: 50px;
+    }
+</style><body><div>

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -5095,7 +5095,7 @@ RefPtr<StyleValue> Parser::parse_transform_value(TokenStream<ComponentValue>& to
                 break;
             }
             case TransformFunctionParameterType::LengthPercentage: {
-                if (maybe_calc_value && maybe_calc_value->resolves_to_length()) {
+                if (maybe_calc_value && maybe_calc_value->resolves_to_length_percentage()) {
                     values.append(maybe_calc_value.release_nonnull());
                 } else {
                     auto dimension_value = parse_dimension_value(value);

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -426,7 +426,7 @@ Vector<CSS::Transformation> StyleProperties::transformations_for_style_value(Sty
         for (auto& transformation_value : transformation_style_value.values()) {
             if (transformation_value->is_calculated()) {
                 auto& calculated = transformation_value->as_calculated();
-                if (calculated.resolves_to_length()) {
+                if (calculated.resolves_to_length_percentage()) {
                     values.append(CSS::LengthPercentage { calculated });
                 } else if (calculated.resolves_to_percentage()) {
                     values.append({ calculated.resolve_percentage().value() });


### PR DESCRIPTION
There were a few missing/incorrect checks for length percentage values when parsing transforms, which caused us to fail at parsing such values.

Fixes #22666.