### PR TITLE
LibWeb: Remove spammy dbgln and refactor unsigned to u32 in WebContentServer.ipc

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
@@ -215,7 +215,6 @@ void HTMLScriptElement::prepare_script()
     // 12. Otherwise, return. (No script is executed, and el's type is left as null.)
     else {
         VERIFY(m_script_type == ScriptType::Null);
-        dbgln("HTMLScriptElement: Refusing to run script because the type '{}' is not recognized.", script_block_type);
         return;
     }
 

--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -145,7 +145,7 @@ Painting::PaintableBox const* EventHandler::paint_root() const
     return m_browsing_context->active_document()->paintable_box();
 }
 
-bool EventHandler::handle_mousewheel(CSSPixelPoint position, CSSPixelPoint screen_position, unsigned button, unsigned buttons, unsigned int modifiers, int wheel_delta_x, int wheel_delta_y)
+bool EventHandler::handle_mousewheel(CSSPixelPoint position, CSSPixelPoint screen_position, u32 button, u32 buttons, u32 modifiers, int wheel_delta_x, int wheel_delta_y)
 {
     if (!m_browsing_context->active_document())
         return false;
@@ -207,7 +207,7 @@ bool EventHandler::handle_mousewheel(CSSPixelPoint position, CSSPixelPoint scree
     return handled_event;
 }
 
-bool EventHandler::handle_mouseup(CSSPixelPoint position, CSSPixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers)
+bool EventHandler::handle_mouseup(CSSPixelPoint position, CSSPixelPoint screen_position, u32 button, u32 buttons, u32 modifiers)
 {
     if (!m_browsing_context->active_document())
         return false;
@@ -321,7 +321,7 @@ after_node_use:
     return handled_event;
 }
 
-bool EventHandler::handle_mousedown(CSSPixelPoint position, CSSPixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers)
+bool EventHandler::handle_mousedown(CSSPixelPoint position, CSSPixelPoint screen_position, u32 button, u32 buttons, u32 modifiers)
 {
     if (!m_browsing_context->active_document())
         return false;
@@ -419,7 +419,7 @@ bool EventHandler::handle_mousedown(CSSPixelPoint position, CSSPixelPoint screen
     return true;
 }
 
-bool EventHandler::handle_mousemove(CSSPixelPoint position, CSSPixelPoint screen_position, unsigned buttons, unsigned modifiers)
+bool EventHandler::handle_mousemove(CSSPixelPoint position, CSSPixelPoint screen_position, u32 buttons, u32 modifiers)
 {
     if (!m_browsing_context->active_document())
         return false;
@@ -545,7 +545,7 @@ bool EventHandler::handle_mousemove(CSSPixelPoint position, CSSPixelPoint screen
     return true;
 }
 
-bool EventHandler::handle_doubleclick(CSSPixelPoint position, CSSPixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers)
+bool EventHandler::handle_doubleclick(CSSPixelPoint position, CSSPixelPoint screen_position, u32 button, u32 buttons, u32 modifiers)
 {
     if (!m_browsing_context->active_document())
         return false;
@@ -695,7 +695,7 @@ constexpr bool should_ignore_keydown_event(u32 code_point)
     return code_point == 0 || code_point == 27;
 }
 
-bool EventHandler::fire_keyboard_event(FlyString const& event_name, HTML::BrowsingContext& browsing_context, KeyCode key, unsigned int modifiers, u32 code_point)
+bool EventHandler::fire_keyboard_event(FlyString const& event_name, HTML::BrowsingContext& browsing_context, KeyCode key, u32 modifiers, u32 code_point)
 {
     JS::GCPtr<DOM::Document> document = browsing_context.active_document();
     if (!document)
@@ -723,7 +723,7 @@ bool EventHandler::fire_keyboard_event(FlyString const& event_name, HTML::Browsi
     return document->root().dispatch_event(event);
 }
 
-bool EventHandler::handle_keydown(KeyCode key, unsigned modifiers, u32 code_point)
+bool EventHandler::handle_keydown(KeyCode key, u32 modifiers, u32 code_point)
 {
     if (!m_browsing_context->active_document())
         return false;
@@ -831,7 +831,7 @@ bool EventHandler::handle_keydown(KeyCode key, unsigned modifiers, u32 code_poin
     return fire_keyboard_event(UIEvents::EventNames::keypress, m_browsing_context, key, modifiers, code_point);
 }
 
-bool EventHandler::handle_keyup(KeyCode key, unsigned modifiers, u32 code_point)
+bool EventHandler::handle_keyup(KeyCode key, u32 modifiers, u32 code_point)
 {
     return fire_keyboard_event(UIEvents::EventNames::keyup, m_browsing_context, key, modifiers, code_point);
 }

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -213,7 +213,7 @@ void ConnectionFromClient::process_next_input_event()
         m_input_event_queue_timer->start();
 }
 
-void ConnectionFromClient::mouse_down(Web::DevicePixelPoint position, Web::DevicePixelPoint screen_position, unsigned int button, unsigned int buttons, unsigned int modifiers)
+void ConnectionFromClient::mouse_down(Web::DevicePixelPoint position, Web::DevicePixelPoint screen_position, u32 button, u32 buttons, u32 modifiers)
 {
     enqueue_input_event(
         QueuedMouseEvent {
@@ -226,7 +226,7 @@ void ConnectionFromClient::mouse_down(Web::DevicePixelPoint position, Web::Devic
         });
 }
 
-void ConnectionFromClient::mouse_move(Web::DevicePixelPoint position, Web::DevicePixelPoint screen_position, [[maybe_unused]] unsigned int button, unsigned int buttons, unsigned int modifiers)
+void ConnectionFromClient::mouse_move(Web::DevicePixelPoint position, Web::DevicePixelPoint screen_position, [[maybe_unused]] u32 button, u32 buttons, u32 modifiers)
 {
     auto event = QueuedMouseEvent {
         .type = QueuedMouseEvent::Type::MouseMove,
@@ -249,7 +249,7 @@ void ConnectionFromClient::mouse_move(Web::DevicePixelPoint position, Web::Devic
     enqueue_input_event(move(event));
 }
 
-void ConnectionFromClient::mouse_up(Web::DevicePixelPoint position, Web::DevicePixelPoint screen_position, unsigned int button, unsigned int buttons, unsigned int modifiers)
+void ConnectionFromClient::mouse_up(Web::DevicePixelPoint position, Web::DevicePixelPoint screen_position, u32 button, u32 buttons, u32 modifiers)
 {
     enqueue_input_event(
         QueuedMouseEvent {
@@ -262,7 +262,7 @@ void ConnectionFromClient::mouse_up(Web::DevicePixelPoint position, Web::DeviceP
         });
 }
 
-void ConnectionFromClient::mouse_wheel(Web::DevicePixelPoint position, Web::DevicePixelPoint screen_position, unsigned int button, unsigned int buttons, unsigned int modifiers, Web::DevicePixels wheel_delta_x, Web::DevicePixels wheel_delta_y)
+void ConnectionFromClient::mouse_wheel(Web::DevicePixelPoint position, Web::DevicePixelPoint screen_position, u32 button, u32 buttons, u32 modifiers, Web::DevicePixels wheel_delta_x, Web::DevicePixels wheel_delta_y)
 {
     auto event = QueuedMouseEvent {
         .type = QueuedMouseEvent::Type::MouseWheel,
@@ -290,7 +290,7 @@ void ConnectionFromClient::mouse_wheel(Web::DevicePixelPoint position, Web::Devi
     enqueue_input_event(move(event));
 }
 
-void ConnectionFromClient::doubleclick(Web::DevicePixelPoint position, Web::DevicePixelPoint screen_position, unsigned int button, unsigned int buttons, unsigned int modifiers)
+void ConnectionFromClient::doubleclick(Web::DevicePixelPoint position, Web::DevicePixelPoint screen_position, u32 button, u32 buttons, u32 modifiers)
 {
     enqueue_input_event(
         QueuedMouseEvent {
@@ -303,7 +303,7 @@ void ConnectionFromClient::doubleclick(Web::DevicePixelPoint position, Web::Devi
         });
 }
 
-void ConnectionFromClient::key_down(i32 key, unsigned int modifiers, u32 code_point)
+void ConnectionFromClient::key_down(i32 key, u32 modifiers, u32 code_point)
 {
     enqueue_input_event(
         QueuedKeyboardEvent {
@@ -314,7 +314,7 @@ void ConnectionFromClient::key_down(i32 key, unsigned int modifiers, u32 code_po
         });
 }
 
-void ConnectionFromClient::key_up(i32 key, unsigned int modifiers, u32 code_point)
+void ConnectionFromClient::key_up(i32 key, u32 modifiers, u32 code_point)
 {
     enqueue_input_event(
         QueuedKeyboardEvent {

--- a/Userland/Services/WebContent/ConnectionFromClient.h
+++ b/Userland/Services/WebContent/ConnectionFromClient.h
@@ -61,13 +61,13 @@ private:
     virtual void load_url(URL const&) override;
     virtual void load_html(ByteString const&) override;
     virtual void set_viewport_rect(Web::DevicePixelRect const&) override;
-    virtual void mouse_down(Web::DevicePixelPoint, Web::DevicePixelPoint, unsigned, unsigned, unsigned) override;
-    virtual void mouse_move(Web::DevicePixelPoint, Web::DevicePixelPoint, unsigned, unsigned, unsigned) override;
-    virtual void mouse_up(Web::DevicePixelPoint, Web::DevicePixelPoint, unsigned, unsigned, unsigned) override;
-    virtual void mouse_wheel(Web::DevicePixelPoint, Web::DevicePixelPoint, unsigned, unsigned, unsigned, Web::DevicePixels, Web::DevicePixels) override;
-    virtual void doubleclick(Web::DevicePixelPoint, Web::DevicePixelPoint, unsigned, unsigned, unsigned) override;
-    virtual void key_down(i32, unsigned, u32) override;
-    virtual void key_up(i32, unsigned, u32) override;
+    virtual void mouse_down(Web::DevicePixelPoint, Web::DevicePixelPoint, u32, u32, u32) override;
+    virtual void mouse_move(Web::DevicePixelPoint, Web::DevicePixelPoint, u32, u32, u32) override;
+    virtual void mouse_up(Web::DevicePixelPoint, Web::DevicePixelPoint, u32, u32, u32) override;
+    virtual void mouse_wheel(Web::DevicePixelPoint, Web::DevicePixelPoint, u32, u32, u32, Web::DevicePixels, Web::DevicePixels) override;
+    virtual void doubleclick(Web::DevicePixelPoint, Web::DevicePixelPoint, u32, u32, u32) override;
+    virtual void key_down(i32, u32, u32) override;
+    virtual void key_up(i32, u32, u32) override;
     virtual void add_backing_store(i32 front_bitmap_id, Gfx::ShareableBitmap const& front_bitmap, i32 back_bitmap_id, Gfx::ShareableBitmap const& back_bitmap) override;
     virtual void ready_to_paint() override;
     virtual void debug_request(ByteString const&, ByteString const&) override;
@@ -164,9 +164,9 @@ private:
         Type type {};
         Web::DevicePixelPoint position {};
         Web::DevicePixelPoint screen_position {};
-        unsigned button {};
-        unsigned buttons {};
-        unsigned modifiers {};
+        u32 button {};
+        u32 buttons {};
+        u32 modifiers {};
         Web::DevicePixels wheel_delta_x {};
         Web::DevicePixels wheel_delta_y {};
         size_t coalesced_event_count { 0 };
@@ -179,7 +179,7 @@ private:
         };
         Type type {};
         i32 key {};
-        unsigned int modifiers {};
+        u32 modifiers {};
         u32 code_point {};
     };
 

--- a/Userland/Services/WebContent/WebContentServer.ipc
+++ b/Userland/Services/WebContent/WebContentServer.ipc
@@ -28,14 +28,14 @@ endpoint WebContentServer
 
     set_viewport_rect(Web::DevicePixelRect rect) =|
 
-    mouse_down(Web::DevicePixelPoint position, Web::DevicePixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers) =|
-    mouse_move(Web::DevicePixelPoint position, Web::DevicePixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers) =|
-    mouse_up(Web::DevicePixelPoint position, Web::DevicePixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers) =|
-    mouse_wheel(Web::DevicePixelPoint position, Web::DevicePixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers, Web::DevicePixels wheel_delta_x, Web::DevicePixels wheel_delta_y) =|
-    doubleclick(Web::DevicePixelPoint position, Web::DevicePixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers) =|
+    mouse_down(Web::DevicePixelPoint position, Web::DevicePixelPoint screen_position, u32 button, u32 buttons, u32 modifiers) =|
+    mouse_move(Web::DevicePixelPoint position, Web::DevicePixelPoint screen_position, u32 button, u32 buttons, u32 modifiers) =|
+    mouse_up(Web::DevicePixelPoint position, Web::DevicePixelPoint screen_position, u32 button, u32 buttons, u32 modifiers) =|
+    mouse_wheel(Web::DevicePixelPoint position, Web::DevicePixelPoint screen_position, u32 button, u32 buttons, u32 modifiers, Web::DevicePixels wheel_delta_x, Web::DevicePixels wheel_delta_y) =|
+    doubleclick(Web::DevicePixelPoint position, Web::DevicePixelPoint screen_position, u32 button, u32 buttons, u32 modifiers) =|
 
-    key_down(i32 key, unsigned modifiers, u32 code_point) =|
-    key_up(i32 key, unsigned modifiers, u32 code_point) =|
+    key_down(i32 key, u32 modifiers, u32 code_point) =|
+    key_up(i32 key, u32 modifiers, u32 code_point) =|
 
     debug_request(ByteString request, ByteString argument) =|
     get_source() =|


### PR DESCRIPTION
*Two small commits:*

## LibWeb: Remove refusing to run script debug line

Many sites load application/json and application/ld+json content with script elements, so this debug line shows up on a lot of sites and is not informative.

## LibWeb: Refactor unsigned to u32 in WebContentServer.ipc

The type u32 is already used almost everywhere in WebContentServer.ipc except for the mouse and key events so let's fix that.