### PR TITLE
CI: Update comment-on-pr version

### DIFF
--- a/.github/workflows/lintcommits.yml
+++ b/.github/workflows/lintcommits.yml
@@ -87,7 +87,7 @@ jobs:
 
       - name: Comment on PR
         if: ${{ failure() && !github.event.pull_request.draft }}
-        uses: IdanHo/comment-on-pr@5f51df338210754f519f721f8320d8f72525a4d0
+        uses: IdanHo/comment-on-pr@dba728af7671011d7fd2c52acfc80f7217ae58b8
         env:
           GITHUB_TOKEN: ${{ secrets.BUGGIEBOT_TOKEN }}
         with:


### PR DESCRIPTION
The newer version installs a specific version of octokit, since the latest version no longer supports the ruby installation in github actions vms. This should resolve the CI issues.

Relevant comment-on-pr commit: https://github.com/IdanHo/comment-on-pr/commit/dba728af7671011d7fd2c52acfc80f7217ae58b8
NOTE: Made this change on my phone, please review extra carefully