### PR TITLE
Meta: Let test_pdf.py be less dramatic about issue counts

### DIFF
--- a/Meta/test_pdf.py
+++ b/Meta/test_pdf.py
@@ -92,7 +92,7 @@ def main():
                     issue.filenames.append(r.filename)
                     issue.filename_to_issues[r.filename] = j['issues'][diag]
                     issue.num_pages += len(j['issues'][diag])
-                    issue.count += sum(a * b for (a, b) in j['issues'][diag])
+                    issue.count += sum(count for (page, count) in j['issues'][diag])
             continue
         if r.returncode == 1:
             failed_files.append(r.filename)


### PR DESCRIPTION
For every issue string, json['issues'][issue_string] contains a list of (page, count_of_issue_on_this_page) tuples.

To get the total number the issue appears in the current document, we need to add up all the count_of_issue_on_this_page, not multiply the page number with count_of_issue_on_this_page and add those (－‸ლ)