### PR TITLE
LibGfx/ICC: Speedups, round 1

### DIFF
--- a/Userland/Libraries/LibGfx/ICC/Profile.h
+++ b/Userland/Libraries/LibGfx/ICC/Profile.h
@@ -241,12 +241,12 @@ private:
     ErrorOr<void> check_required_tags();
     ErrorOr<void> check_tag_types();
 
+    ProfileHeader m_header;
+    OrderedHashMap<TagSignature, NonnullRefPtr<TagData>> m_tag_table;
+
     // FIXME: The color conversion stuff should be in some other class.
     ErrorOr<FloatVector3> to_pcs_a_to_b(TagData const& tag_data, ReadonlyBytes) const;
     ErrorOr<void> from_pcs_b_to_a(TagData const& tag_data, FloatVector3 const&, Bytes) const;
-
-    ProfileHeader m_header;
-    OrderedHashMap<TagSignature, NonnullRefPtr<TagData>> m_tag_table;
 };
 
 }

--- a/Userland/Libraries/LibGfx/ICC/Profile.h
+++ b/Userland/Libraries/LibGfx/ICC/Profile.h
@@ -249,6 +249,13 @@ private:
     ErrorOr<FloatVector3> to_pcs_a_to_b(TagData const& tag_data, ReadonlyBytes) const;
     ErrorOr<void> from_pcs_b_to_a(TagData const& tag_data, FloatVector3 const&, Bytes) const;
 
+    // Cached values.
+    bool m_cached_has_any_a_to_b_tag { false };
+    bool m_cached_has_a_to_b0_tag { false };
+    bool m_cached_has_any_b_to_a_tag { false };
+    bool m_cached_has_b_to_a0_tag { false };
+    bool m_cached_has_all_rgb_matrix_tags { false };
+
     // Only valid for RGB matrix-based profiles.
     ErrorOr<FloatMatrix3x3> xyz_to_rgb_matrix() const;
     FloatMatrix3x3 rgb_to_xyz_matrix() const;

--- a/Userland/Libraries/LibGfx/ICC/Profile.h
+++ b/Userland/Libraries/LibGfx/ICC/Profile.h
@@ -18,6 +18,7 @@
 #include <LibGfx/CIELAB.h>
 #include <LibGfx/ICC/DistinctFourCC.h>
 #include <LibGfx/ICC/TagTypes.h>
+#include <LibGfx/Matrix3x3.h>
 #include <LibGfx/Vector3.h>
 
 namespace Gfx::ICC {
@@ -247,6 +248,10 @@ private:
     // FIXME: The color conversion stuff should be in some other class.
     ErrorOr<FloatVector3> to_pcs_a_to_b(TagData const& tag_data, ReadonlyBytes) const;
     ErrorOr<void> from_pcs_b_to_a(TagData const& tag_data, FloatVector3 const&, Bytes) const;
+
+    // Only valid for RGB matrix-based profiles.
+    ErrorOr<FloatMatrix3x3> xyz_to_rgb_matrix() const;
+    FloatMatrix3x3 rgb_to_xyz_matrix() const;
 };
 
 }

--- a/Userland/Libraries/LibGfx/ICC/Profile.h
+++ b/Userland/Libraries/LibGfx/ICC/Profile.h
@@ -252,6 +252,8 @@ private:
     // Only valid for RGB matrix-based profiles.
     ErrorOr<FloatMatrix3x3> xyz_to_rgb_matrix() const;
     FloatMatrix3x3 rgb_to_xyz_matrix() const;
+
+    mutable Optional<FloatMatrix3x3> m_cached_xyz_to_rgb_matrix;
 };
 
 }


### PR DESCRIPTION
Fairly harmless code reorganizations. The third commit only helps matrix profiles. The fourth probably helps clut-based profiles too, but I haven't measured that.

A follow-up will help matrix profiles some more and be a bit more invasive.

In total, this PR takes time needed for

    time Build/lagom/bin/pdf --page 3 --render out.png \
        ~/Downloads/0000/0000849.pdf

from ~1.8s to ~1.3s on my machine.