### PR TITLE
LibWeb: Let parent formatting context determine size of flex containers

### DIFF
--- a/Tests/LibWeb/Layout/expected/flex-item-with-cyclic-percentage-height.txt
+++ b/Tests/LibWeb/Layout/expected/flex-item-with-cyclic-percentage-height.txt
@@ -2,7 +2,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (1,1) content-size 798x39.46875 [BFC] children: not-inline
     BlockContainer <body> at (10,10) content-size 780x21.46875 children: not-inline
       Box <div.flexrow> at (11,11) content-size 778x19.46875 flex-container(row) [FFC] children: not-inline
-        Box <div.project> at (12,12) content-size 44.03125x17.46875 flex-container(column) flex-item [FFC] children: not-inline
+        Box <div.project> at (12,12) content-size 44.03125x19.46875 flex-container(column) flex-item [FFC] children: not-inline
           BlockContainer <(anonymous)> at (12,12) content-size 44.03125x17.46875 flex-item [BFC] children: inline
             line 0 width: 44.03125, height: 17.46875, bottom: 17.46875, baseline: 13.53125
               frag 0 from TextNode start: 0, length: 6, rect: [12,12 44.03125x17.46875]
@@ -11,8 +11,8 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x41.46875]
-    PaintableWithLines (BlockContainer<BODY>) [9,9 782x23.46875]
-      PaintableBox (Box<DIV>.flexrow) [10,10 780x21.46875]
-        PaintableBox (Box<DIV>.project) [11,11 46.03125x19.46875]
+    PaintableWithLines (BlockContainer<BODY>) [9,9 782x23.46875] overflow: [10,10 780x22.46875]
+      PaintableBox (Box<DIV>.flexrow) [10,10 780x21.46875] overflow: [11,11 778x21.46875]
+        PaintableBox (Box<DIV>.project) [11,11 46.03125x21.46875]
           PaintableWithLines (BlockContainer(anonymous)) [12,12 44.03125x17.46875]
             TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/flex/flex-item-with-intrinsic-aspect-ratio-and-max-height.txt
+++ b/Tests/LibWeb/Layout/expected/flex/flex-item-with-intrinsic-aspect-ratio-and-max-height.txt
@@ -1,11 +1,11 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (1,1) content-size 798x69.96875 [BFC] children: not-inline
-    Box <body> at (10,10) content-size 780x51.96875 flex-container(row) [FFC] children: not-inline
-      ImageBox <img> at (11,11) content-size 66.65625x49.984375 flex-item children: not-inline
+  BlockContainer <html> at (1,1) content-size 798x69.984375 [BFC] children: not-inline
+    Box <body> at (10,10) content-size 780x51.984375 flex-container(row) [FFC] children: not-inline
+      ImageBox <img> at (11,11) content-size 64x49.984375 flex-item children: not-inline
       BlockContainer <(anonymous)> (not painted) [BFC] children: inline
         TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x71.96875]
-    PaintableBox (Box<BODY>) [9,9 782x53.96875] overflow: [10,10 780x51.984375]
-      ImagePaintable (ImageBox<IMG>) [10,10 68.65625x51.984375]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x71.984375]
+    PaintableBox (Box<BODY>) [9,9 782x53.984375]
+      ImagePaintable (ImageBox<IMG>) [10,10 66x51.984375]

--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -680,7 +680,8 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
 
     place_block_level_element_in_normal_flow_horizontally(box, available_space);
 
-    if (box.is_replaced_box())
+    // NOTE: Flex containers with `auto` height are treated as `max-content`, so we can compute their height early.
+    if (box.is_replaced_box() || box.display().is_flex_inside())
         compute_height(box, available_space);
 
     if (independent_formatting_context) {
@@ -1245,17 +1246,6 @@ CSSPixels BlockFormattingContext::greatest_child_width(Box const& box) const
         });
     }
     return max_width;
-}
-
-void BlockFormattingContext::determine_width_of_child(Box const&, AvailableSpace const&)
-{
-    // NOTE: We don't do anything here, since we'll have already determined the width of the child
-    //       before recursing into nested layout within the child.
-}
-
-void BlockFormattingContext::determine_height_of_child(Box const& box, AvailableSpace const& available_space)
-{
-    compute_height(box, available_space);
 }
 
 }

--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.h
@@ -50,10 +50,6 @@ public:
 
     void layout_block_level_box(Box const&, BlockContainer const&, LayoutMode, CSSPixels& bottom_of_lowest_margin_box, AvailableSpace const&);
 
-    virtual bool can_determine_size_of_child() const override { return true; }
-    virtual void determine_width_of_child(Box const&, AvailableSpace const&) override;
-    virtual void determine_height_of_child(Box const&, AvailableSpace const&) override;
-
     void resolve_vertical_box_model_metrics(Box const&);
 
     enum class DidIntroduceClearance {

--- a/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021-2024, Andreas Kling <kling@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -23,10 +23,6 @@ public:
     virtual CSSPixels automatic_content_height() const override;
 
     Box const& flex_container() const { return context_box(); }
-
-    virtual bool can_determine_size_of_child() const override;
-    virtual void determine_width_of_child(Box const&, AvailableSpace const&) override;
-    virtual void determine_height_of_child(Box const&, AvailableSpace const&) override;
 
     virtual CSSPixelPoint calculate_static_position(Box const&) const override;
 
@@ -162,8 +158,6 @@ private:
 
     void determine_flex_base_size_and_hypothetical_main_size(FlexItem&);
 
-    void determine_main_size_of_flex_container();
-
     void collect_flex_items_into_flex_lines();
 
     void resolve_flexible_lengths();
@@ -229,7 +223,6 @@ private:
         AvailableSpace space;
     };
     Optional<AxisAgnosticAvailableSpace> m_available_space_for_items;
-    Optional<AxisAgnosticAvailableSpace> m_available_space_for_flex_container;
 };
 
 }

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.h
@@ -89,10 +89,6 @@ public:
     [[nodiscard]] CSSPixels calculate_stretch_fit_width(Box const&, AvailableSize const&) const;
     [[nodiscard]] CSSPixels calculate_stretch_fit_height(Box const&, AvailableSize const&) const;
 
-    virtual bool can_determine_size_of_child() const { return false; }
-    virtual void determine_width_of_child(Box const&, AvailableSpace const&) { }
-    virtual void determine_height_of_child(Box const&, AvailableSpace const&) { }
-
     virtual CSSPixelPoint calculate_static_position(Box const&) const;
     bool can_skip_is_anonymous_text_run(Box&);
 

--- a/Userland/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -172,6 +172,10 @@ void InlineFormattingContext::dimension_box_on_line(Box const& box, LayoutMode l
 
     box_state.set_content_width(width);
 
+    // NOTE: Flex containers with `auto` height are treated as `max-content`, so we can compute their height early.
+    if (box_state.has_definite_height() || box.display().is_flex_inside())
+        parent().compute_height(box, AvailableSpace(AvailableSize::make_definite(width), AvailableSize::make_definite(m_containing_block_state.content_height())));
+
     auto independent_formatting_context = layout_inside(box, layout_mode, box_state.available_inner_space_or_constraints_from(*m_available_space));
 
     auto const& height_value = box.computed_values().height();
@@ -387,21 +391,6 @@ bool InlineFormattingContext::can_fit_new_line_at_y(CSSPixels y) const
     if (bottom_left_edge > top_right_edge)
         return false;
     return true;
-}
-
-bool InlineFormattingContext::can_determine_size_of_child() const
-{
-    return parent().can_determine_size_of_child();
-}
-
-void InlineFormattingContext::determine_width_of_child(Box const& box, AvailableSpace const& available_space)
-{
-    return parent().determine_width_of_child(box, available_space);
-}
-
-void InlineFormattingContext::determine_height_of_child(Box const& box, AvailableSpace const& available_space)
-{
-    return parent().determine_height_of_child(box, available_space);
 }
 
 CSSPixels InlineFormattingContext::vertical_float_clearance() const

--- a/Userland/Libraries/LibWeb/Layout/InlineFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/InlineFormattingContext.h
@@ -34,10 +34,6 @@ public:
     bool any_floats_intrude_at_y(CSSPixels y) const;
     bool can_fit_new_line_at_y(CSSPixels y) const;
 
-    virtual bool can_determine_size_of_child() const override;
-    virtual void determine_width_of_child(Box const&, AvailableSpace const&) override;
-    virtual void determine_height_of_child(Box const&, AvailableSpace const&) override;
-
     CSSPixels vertical_float_clearance() const;
     void set_vertical_float_clearance(CSSPixels);
 


### PR DESCRIPTION
Until now, we had implemented flex container sizing by awkwardly doing exactly what the spec said (basically having FFC size the container) despite that not really making sense in the big picture. (Parent formatting contexts should be responsible for sizing and placing their children)

This patch moves us away from the Flexbox spec text a little bit, by removing the logic for sizing the flex container in FFC, and instead making sure that all formatting contexts can set both width and height of flex container children.

This required changes in BFC and IFC, but it's actually quite simple! Width was already not a problem, and it turns out height isn't either, since the automatic height of a flex container is max-content. With this in mind, we can simply determine the height of flex containers before transferring control to FFC, and everything flows nicely.

With this change, we can remove all the virtuals and FFC logic for negotiating container size with the parent formatting context. We also don't need the "available space for flex container" stuff anymore either, so that's gone as well.

There are some minor diffs in layout test results from this, but the new results actually match other browsers more closely, so that's fine.

This should make flex layout, and indeed layout in general, easier to understand, since this was the main weird special case outside of BFC/IFC where a formatting context delegates work to its parent instead of the other way around. :^)