### PR TITLE
LibPDF: Mark text rendering matrix dirty after changing it in text_begin

### DIFF
--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -416,6 +416,7 @@ RENDERER_HANDLER(text_begin)
 {
     m_text_matrix = Gfx::AffineTransform();
     m_text_line_matrix = Gfx::AffineTransform();
+    m_text_rendering_matrix_is_dirty = true;
     return {};
 }
 


### PR DESCRIPTION
A certain PDF was drawing some text used `9 0 0 9 474.54 700.6801 Tm` to set the text matrix to a matrix that scaled by 9 in one text object.

Then, after ending that text object, it had the following new text object which contained nothing that invalidated the text matrix:

```
BT
/F1 7 Tf
/DeviceRGB CS
0 0 0 SC
10 TL
86.37849 21.908 Td
(Authorized licensed use limited to: ...) Tj
ET
```

`BT` did reset it as required, but since we didn't mark the matrix as dirty, we never recomputed it and drew the additional text scaled up 9x.

---

(`/F1` was built-in helvetica:

```
5 0 obj
<<
  /Type /Font
  /Encoding /WinAnsiEncoding
  /Subtype /Type1
  /BaseFont /Helvetica
>>
endobj

```
)