### PR TITLE
LibProtocol: Don't assume request creation will succeed across IPC

### DIFF
--- a/Userland/Libraries/LibProtocol/RequestClient.cpp
+++ b/Userland/Libraries/LibProtocol/RequestClient.cpp
@@ -29,7 +29,10 @@ RefPtr<Request> RequestClient::start_request(ByteString const& method, URL const
     if (body_result.is_error())
         return nullptr;
 
-    auto response = IPCProxy::start_request(method, url, headers_or_error.release_value(), body_result.release_value(), proxy_data);
+    auto maybe_response = IPCProxy::try_start_request(method, url, headers_or_error.release_value(), body_result.release_value(), proxy_data);
+    if (maybe_response.is_error())
+        return nullptr;
+    auto response = maybe_response.release_value();
     auto request_id = response.request_id();
     if (request_id < 0 || !response.response_fd().has_value())
         return nullptr;


### PR DESCRIPTION
Allow it to fail, and return null if it does.
Fixes frequent crashes in unfavourable network conditions.

Offshoot fix for https://github.com/SerenityOS/serenity/issues/22607#issuecomment-1885222390.