### PR TITLE
LibWebView: Compare cookie expiration dates with Unix time during purge

### DIFF
--- a/Userland/Libraries/LibWebView/CookieJar.cpp
+++ b/Userland/Libraries/LibWebView/CookieJar.cpp
@@ -643,7 +643,7 @@ void CookieJar::purge_expired_cookies()
 
     m_storage.visit(
         [&](PersistedStorage& storage) {
-            storage.database.execute_statement(storage.statements.expire_cookie, {}, {}, {}, now);
+            storage.database.execute_statement(storage.statements.expire_cookie, {}, {}, {}, now.seconds_since_epoch());
         },
         [&](TransientStorage& storage) {
             Vector<CookieStorageKey> keys_to_evict;


### PR DESCRIPTION
When purging cookies, we purge all cookies that have an expiry_time that is less than the current time. In the query where we do this comparison, we were sending a UnixDateTime object as a query parameter to be compared with the expiry_time which is stored in the form of an integer representing a Unix timestamp. This resulted in the query results to be incorrect, and cookies to be purged before they expired.

Now, we convert the current time to Unix time before sending it as a parameter to the comparison query.

fixes #22694