### PR TITLE
Solitaire: Hide solve button when game ends

### DIFF
--- a/Userland/Games/Solitaire/main.cpp
+++ b/Userland/Games/Solitaire/main.cpp
@@ -100,6 +100,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         game.start_solving();
         solve_button.set_enabled(false);
     };
+    solve_button.set_enabled(false);
 
     auto& statusbar = *widget->find_descendant_of_type_named<GUI::Statusbar>("statusbar");
     statusbar.set_text(0, "Score: 0"_string);
@@ -126,8 +127,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     }));
 
     game.on_game_start = [&]() {
-        solve_button.set_enabled(false);
-        action_bar.set_visible(false);
         seconds_elapsed = 0;
         timer->start();
         statusbar.set_text(2, "Time: 00:00"_string);
@@ -141,6 +140,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             timer->stop();
 
         solve_button.set_enabled(false);
+        action_bar.set_visible(false);
 
         if (reason == Solitaire::GameOverReason::Victory) {
             if (seconds_elapsed >= 30) {


### PR DESCRIPTION
`on_game_start` is not called until the player makes a move, so waiting until then means that the solve button would still be visible when starting a new game after completing one. By hiding the button in `on_game_end`, this happens when the game-over animation starts playing instead.