### PR TITLE
LibGfx/ICC+LibPDF: Speedups, round 2

### DIFF
--- a/Userland/Libraries/LibGfx/ICC/Profile.cpp
+++ b/Userland/Libraries/LibGfx/ICC/Profile.cpp
@@ -1571,8 +1571,84 @@ ErrorOr<CIELAB> Profile::to_lab(ReadonlyBytes color) const
     return CIELAB { lab[0], lab[1], lab[2] };
 }
 
+bool Profile::is_matrix_matrix_conversion(Profile const& source_profile) const
+{
+    auto has_normal_device_class = [](DeviceClass device) {
+        return device == DeviceClass::InputDevice
+            || device == DeviceClass::DisplayDevice
+            || device == DeviceClass::OutputDevice
+            || device == DeviceClass::ColorSpace;
+    };
+
+    return has_normal_device_class(device_class())
+        && has_normal_device_class(source_profile.device_class())
+        && connection_space() == ColorSpace::PCSXYZ
+        && source_profile.connection_space() == ColorSpace::PCSXYZ
+        && data_color_space() == ColorSpace::RGB
+        && source_profile.data_color_space() == ColorSpace::RGB
+        && !m_cached_has_any_a_to_b_tag
+        && !source_profile.m_cached_has_any_a_to_b_tag
+        && m_cached_has_all_rgb_matrix_tags
+        && source_profile.m_cached_has_all_rgb_matrix_tags;
+}
+
+ErrorOr<void> Profile::convert_image_matrix_matrix(Gfx::Bitmap& bitmap, Profile const& source_profile) const
+{
+    auto const& sourceRedTRC = *source_profile.m_tag_table.get(redTRCTag).value();
+    auto const& sourceGreenTRC = *source_profile.m_tag_table.get(greenTRCTag).value();
+    auto const& sourceBlueTRC = *source_profile.m_tag_table.get(blueTRCTag).value();
+
+    auto evaluate_curve = [](TagData const& trc, float f) {
+        VERIFY(trc.type() == CurveTagData::Type || trc.type() == ParametricCurveTagData::Type);
+        if (trc.type() == CurveTagData::Type)
+            return static_cast<CurveTagData const&>(trc).evaluate(f);
+        return static_cast<ParametricCurveTagData const&>(trc).evaluate(f);
+    };
+
+    FloatMatrix3x3 matrix = source_profile.rgb_to_xyz_matrix() * TRY(xyz_to_rgb_matrix());
+
+    auto const& destinationRedTRC = *m_tag_table.get(redTRCTag).value();
+    auto const& destinationGreenTRC = *m_tag_table.get(greenTRCTag).value();
+    auto const& destinationBlueTRC = *m_tag_table.get(blueTRCTag).value();
+
+    auto evaluate_curve_inverse = [](TagData const& trc, float f) {
+        VERIFY(trc.type() == CurveTagData::Type || trc.type() == ParametricCurveTagData::Type);
+        if (trc.type() == CurveTagData::Type)
+            return static_cast<CurveTagData const&>(trc).evaluate_inverse(f);
+        return static_cast<ParametricCurveTagData const&>(trc).evaluate_inverse(f);
+    };
+
+    for (auto& pixel : bitmap) {
+        FloatVector3 rgb { (float)Color::from_argb(pixel).red(), (float)Color::from_argb(pixel).green(), (float)Color::from_argb(pixel).blue() };
+        rgb = rgb / 255.0f;
+
+        FloatVector3 linear_rgb = {
+            evaluate_curve(sourceRedTRC, rgb[0]),
+            evaluate_curve(sourceGreenTRC, rgb[1]),
+            evaluate_curve(sourceBlueTRC, rgb[2]),
+        };
+        linear_rgb = matrix * linear_rgb;
+
+        linear_rgb.clamp(0.f, 1.f);
+        float device_r = evaluate_curve_inverse(destinationRedTRC, linear_rgb[0]);
+        float device_g = evaluate_curve_inverse(destinationGreenTRC, linear_rgb[1]);
+        float device_b = evaluate_curve_inverse(destinationBlueTRC, linear_rgb[2]);
+
+        u8 out_r = round(255 * device_r);
+        u8 out_g = round(255 * device_g);
+        u8 out_b = round(255 * device_b);
+
+        pixel = Color(out_r, out_g, out_b, Color::from_argb(pixel).alpha()).value();
+    }
+
+    return {};
+}
+
 ErrorOr<void> Profile::convert_image(Gfx::Bitmap& bitmap, Profile const& source_profile) const
 {
+    if (is_matrix_matrix_conversion(source_profile))
+        return convert_image_matrix_matrix(bitmap, source_profile);
+
     for (auto& pixel : bitmap) {
         u8 rgb[] = { Color::from_argb(pixel).red(), Color::from_argb(pixel).green(), Color::from_argb(pixel).blue() };
         auto pcs = TRY(source_profile.to_pcs(rgb));

--- a/Userland/Libraries/LibGfx/ICC/Profile.h
+++ b/Userland/Libraries/LibGfx/ICC/Profile.h
@@ -149,6 +149,29 @@ struct ProfileHeader {
     Optional<Crypto::Hash::MD5::DigestType> id;
 };
 
+// FIXME: This doesn't belong here.
+class MatrixMatrixConversion {
+public:
+    MatrixMatrixConversion(LutCurveType source_red_TRC,
+        LutCurveType source_green_TRC,
+        LutCurveType source_blue_TRC,
+        FloatMatrix3x3 matrix,
+        LutCurveType destination_red_TRC,
+        LutCurveType destination_green_TRC,
+        LutCurveType destination_blue_TRC);
+
+    Color map(FloatVector3) const;
+
+private:
+    LutCurveType m_source_red_TRC;
+    LutCurveType m_source_green_TRC;
+    LutCurveType m_source_blue_TRC;
+    FloatMatrix3x3 m_matrix;
+    LutCurveType m_destination_red_TRC;
+    LutCurveType m_destination_green_TRC;
+    LutCurveType m_destination_blue_TRC;
+};
+
 class Profile : public RefCounted<Profile> {
 public:
     static ErrorOr<NonnullRefPtr<Profile>> try_load_from_externally_owned_memory(ReadonlyBytes);
@@ -225,6 +248,8 @@ public:
     XYZ const& green_matrix_column() const;
     XYZ const& blue_matrix_column() const;
 
+    Optional<MatrixMatrixConversion> matrix_matrix_conversion(Profile const& source_profile) const;
+
 private:
     Profile(ProfileHeader const& header, OrderedHashMap<TagSignature, NonnullRefPtr<TagData>> tag_table)
         : m_header(header)
@@ -248,8 +273,7 @@ private:
     // FIXME: The color conversion stuff should be in some other class.
     ErrorOr<FloatVector3> to_pcs_a_to_b(TagData const& tag_data, ReadonlyBytes) const;
     ErrorOr<void> from_pcs_b_to_a(TagData const& tag_data, FloatVector3 const&, Bytes) const;
-    bool is_matrix_matrix_conversion(Profile const& source_profile) const;
-    ErrorOr<void> convert_image_matrix_matrix(Gfx::Bitmap& bitmap, Profile const& source_profile) const;
+    ErrorOr<void> convert_image_matrix_matrix(Gfx::Bitmap&, MatrixMatrixConversion const&) const;
 
     // Cached values.
     bool m_cached_has_any_a_to_b_tag { false };

--- a/Userland/Libraries/LibGfx/ICC/Profile.h
+++ b/Userland/Libraries/LibGfx/ICC/Profile.h
@@ -248,6 +248,8 @@ private:
     // FIXME: The color conversion stuff should be in some other class.
     ErrorOr<FloatVector3> to_pcs_a_to_b(TagData const& tag_data, ReadonlyBytes) const;
     ErrorOr<void> from_pcs_b_to_a(TagData const& tag_data, FloatVector3 const&, Bytes) const;
+    bool is_matrix_matrix_conversion(Profile const& source_profile) const;
+    ErrorOr<void> convert_image_matrix_matrix(Gfx::Bitmap& bitmap, Profile const& source_profile) const;
 
     // Cached values.
     bool m_cached_has_any_a_to_b_tag { false };

--- a/Userland/Libraries/LibPDF/ColorSpace.cpp
+++ b/Userland/Libraries/LibPDF/ColorSpace.cpp
@@ -499,9 +499,6 @@ ICCBasedColorSpace::ICCBasedColorSpace(NonnullRefPtr<Gfx::ICC::Profile> profile)
 
 PDFErrorOr<ColorOrStyle> ICCBasedColorSpace::style(ReadonlySpan<Value> arguments) const
 {
-    if (!s_srgb_profile)
-        s_srgb_profile = TRY(Gfx::ICC::sRGB());
-
     Vector<u8> bytes;
     for (size_t i = 0; i < arguments.size(); ++i) {
         auto const& arg = arguments[i];
@@ -522,7 +519,7 @@ PDFErrorOr<ColorOrStyle> ICCBasedColorSpace::style(ReadonlySpan<Value> arguments
 
     auto pcs = TRY(m_profile->to_pcs(bytes));
     Array<u8, 3> output;
-    TRY(s_srgb_profile->from_pcs(m_profile, pcs, output.span()));
+    TRY(sRGB()->from_pcs(m_profile, pcs, output.span()));
 
     return Color(output[0], output[1], output[2]);
 }
@@ -551,6 +548,13 @@ Vector<float> ICCBasedColorSpace::default_decode() const
         }
         return decoding_ranges;
     }
+}
+
+NonnullRefPtr<Gfx::ICC::Profile> ICCBasedColorSpace::sRGB()
+{
+    if (!s_srgb_profile)
+        s_srgb_profile = MUST(Gfx::ICC::sRGB());
+    return *s_srgb_profile;
 }
 
 PDFErrorOr<NonnullRefPtr<LabColorSpace>> LabColorSpace::create(Document* document, Vector<Value>&& parameters)

--- a/Userland/Libraries/LibPDF/ColorSpace.h
+++ b/Userland/Libraries/LibPDF/ColorSpace.h
@@ -188,6 +188,8 @@ public:
     Vector<float> default_decode() const override;
     ColorSpaceFamily const& family() const override { return ColorSpaceFamily::ICCBased; }
 
+    static NonnullRefPtr<Gfx::ICC::Profile> sRGB();
+
 private:
     ICCBasedColorSpace(NonnullRefPtr<Gfx::ICC::Profile>);
 

--- a/Userland/Libraries/LibPDF/ColorSpace.h
+++ b/Userland/Libraries/LibPDF/ColorSpace.h
@@ -195,6 +195,7 @@ private:
 
     static RefPtr<Gfx::ICC::Profile> s_srgb_profile;
     NonnullRefPtr<Gfx::ICC::Profile> m_profile;
+    Optional<Gfx::ICC::MatrixMatrixConversion> m_map;
 };
 
 class LabColorSpace final : public ColorSpace {


### PR DESCRIPTION
Adds a dedicated matrix->matrix path. RGB profiles are usually matrix profiles, so this speeds up converting from most RGB colorspaces to sRGB (which is currently what LibPDF always converts to, but even if we make it support showing wide gamut colors on a wide gamut monitor, it'll still use a different RGB output profile) – that is, this is the common case.

Here are a few numbers from my local measurements. I timed four different workloads, at 5 different commits.

Workloads:

1. `time Build/lagom/bin/pdf --page 3 --render out.png ~/Downloads/0000/0000849.pdf`, ran a few times, eyeballed the min
2. `time Build/lagom/bin/pdf --debugging-stats ~/Downloads/0000/0000849.pdf`
3. `time Meta/test_pdf.py ~/Downloads/0000`
4. `time Meta/test_pdf.py ~/Downloads/0000` but with 0000849.pdf filtered out by adding `files = [f for f in files if '0000849' not in f]` to test_pdf.py locally

3 and 4 time rendering all pages in my 1000-file 0000.zip PDF/A test set (https://pdfa.org/new-large-scale-pdf-corpus-now-publicly-available/) on all cores in parallel. This time is dominated by rendering `0000849.pdf` (a file with many high-res JPEGs on 133 pages), and since the parallelism is limited to the pdf level, that file ends up serializing `test_pdf.py` – hence the run with that excluded, and the measurements on just that file.

The commits I measured at:
* "before icc": `64ec38e7fe1cb3a27ab35775459ea882e9548b4d^` (before the final commit in #22650)
* "before opts": `64ec38e7fe1cb3a27ab35775459ea882e9548b4d` (after the final commit in #22650)
* "master": 340936ad09b37d11583c92aa895ee22771208791 (what I currently have checked out; includes #22683)
* "icc-fasterer": my local branch for this PR
* "icc-fastererer": another local branch that has some more micro-optimizations

Data:

```
before icc    : 0000849.pdf p3: 0.65s, 0000849.pdf all: 10.9s, test_pdf.py all 43.4s, test_pdf.py all without 0000849.pdf: 42.9s
before opts   : 0000849.pdf p3: 1.84s, 0000849.pdf all: 1m17s, test_pdf.py all 1m57s, test_pdf.py all without 0000849.pdf: 1m07s
master        : 0000849.pdf p3: 1.33s, 0000849.pdf all: 51.4s, test_pdf.py all 1m25s, test_pdf.py all without 0000849.pdf: 56.9s
icc-fasterer  : 0000849.pdf p3: 1.13s, 0000849.pdf all: 41.2s, test_pdf.py all 1m13s, test_pdf.py all without 0000849.pdf: 53.9s
icc-fastererer: 0000849.pdf p3: 0.99s, 0000849.pdf all: 29.1s, test_pdf.py all   54s, test_pdf.py all without 0000849.pdf: 43.9s
```

This PR reduces time for p3 of 0000849.pdf from ~1.3s to ~1.1s (~15% speedup), is a ~19% speedup on 0000849.pdf for all pages, etc.