### PR TITLE
HackStudio: Stop incorrectly overriding gutter cursors

### DIFF
--- a/Userland/DevTools/HackStudio/Editor.cpp
+++ b/Userland/DevTools/HackStudio/Editor.cpp
@@ -260,11 +260,7 @@ void Editor::mousemove_event(GUI::MouseEvent& event)
     bool hide_tooltip = (m_tooltip_role == TooltipRole::Documentation);
     bool is_over_clickable = false;
 
-    auto ruler_line_rect = ruler_content_rect(text_position.line());
-    auto hovering_lines_ruler = (event.position().x() < ruler_line_rect.width());
-    if (hovering_lines_ruler && !is_in_drag_select())
-        set_override_cursor(Gfx::StandardCursor::Arrow);
-    else if (m_hovering_editor)
+    if (m_hovering_editor && event.position().x() > fixed_elements_width())
         set_override_cursor(m_hovering_clickable && event.ctrl() ? Gfx::StandardCursor::Hand : Gfx::StandardCursor::IBeam);
 
     for (auto& span : document().spans()) {
@@ -471,8 +467,6 @@ void Editor::set_document(GUI::TextDocument& doc)
 
     VERIFY(is<CodeDocument>(doc));
     GUI::TextEditor::set_document(doc);
-
-    set_override_cursor(Gfx::StandardCursor::IBeam);
 
     auto& code_document = static_cast<CodeDocument&>(doc);
 

--- a/Userland/DevTools/HackStudio/Editor.cpp
+++ b/Userland/DevTools/HackStudio/Editor.cpp
@@ -593,11 +593,6 @@ void Editor::on_identifier_click(const GUI::TextDocumentSpan& span)
     m_language_client->search_declaration(code_document().file_path(), span.range.start().line(), span.range.start().column());
 }
 
-void Editor::set_cursor(const GUI::TextPosition& a_position)
-{
-    TextEditor::set_cursor(a_position);
-}
-
 void Editor::set_syntax_highlighter_for(CodeDocument const& document)
 {
     if (!document.language().has_value()) {

--- a/Userland/DevTools/HackStudio/Editor.h
+++ b/Userland/DevTools/HackStudio/Editor.h
@@ -59,7 +59,6 @@ public:
         VERIFY(m_language_client);
         return *m_language_client;
     }
-    virtual void set_cursor(const GUI::TextPosition& a_position) override;
     void set_semantic_syntax_highlighting(bool value);
 
 private:


### PR DESCRIPTION
Only adjust the cursor to respond to clickable text, if the mouse is over text.