### PR TITLE
HackStudio: Make Editor ask Debugger if a breakpoint was added/removed

### DIFF
--- a/Userland/DevTools/HackStudio/Debugger/Debugger.h
+++ b/Userland/DevTools/HackStudio/Debugger/Debugger.h
@@ -34,7 +34,7 @@ public:
 
     static bool is_initialized();
 
-    void on_breakpoint_change(ByteString const& file, size_t line, BreakpointChange change_type);
+    [[nodiscard]] bool change_breakpoint(ByteString const& file, size_t line, BreakpointChange change_type);
     bool set_execution_position(ByteString const& file, size_t line);
 
     void set_executable_path(ByteString const& path) { m_executable_path = path; }

--- a/Userland/DevTools/HackStudio/Editor.cpp
+++ b/Userland/DevTools/HackStudio/Editor.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2018-2021, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2018-2022, the SerenityOS developers.
+ * Copyright (c) 2023-2024, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -784,9 +785,10 @@ void Editor::set_semantic_syntax_highlighting(bool value)
 ErrorOr<void> Editor::add_breakpoint(size_t line_number)
 {
     if (!breakpoint_lines().contains_slow(line_number)) {
-        add_gutter_indicator(m_breakpoint_indicator_id, line_number);
-        TRY(breakpoint_lines().try_append(line_number));
-        Debugger::the().on_breakpoint_change(wrapper().filename_title(), line_number, BreakpointChange::Added);
+        if (Debugger::the().change_breakpoint(wrapper().filename_title(), line_number, BreakpointChange::Added)) {
+            add_gutter_indicator(m_breakpoint_indicator_id, line_number);
+            TRY(breakpoint_lines().try_append(line_number));
+        }
     }
 
     return {};
@@ -794,9 +796,10 @@ ErrorOr<void> Editor::add_breakpoint(size_t line_number)
 
 void Editor::remove_breakpoint(size_t line_number)
 {
-    remove_gutter_indicator(m_breakpoint_indicator_id, line_number);
-    breakpoint_lines().remove_first_matching([&](size_t line) { return line == line_number; });
-    Debugger::the().on_breakpoint_change(wrapper().filename_title(), line_number, BreakpointChange::Removed);
+    if (Debugger::the().change_breakpoint(wrapper().filename_title(), line_number, BreakpointChange::Removed)) {
+        remove_gutter_indicator(m_breakpoint_indicator_id, line_number);
+        breakpoint_lines().remove_first_matching([&](size_t line) { return line == line_number; });
+    }
 }
 
 ErrorOr<void> Editor::update_git_diff_indicators()


### PR DESCRIPTION
Rather than adding/removing a breakpoint indicator, and then telling the debugger about it and hoping it works, let the debugger tell us if it succeeded and then use that to update the indicator.

This prevents the user from adding breakpoints to invalid locations while the debugger is running. It also avoids a couple of scary VERIFY()s. We still allow creating breakpoints in invalid locations while the debugger is *not* running.