### PR TITLE
SystemMonitor: Condense process statistics displayed in processes tab

### DIFF
--- a/Userland/Applications/SystemMonitor/ProcessModel.cpp
+++ b/Userland/Applications/SystemMonitor/ProcessModel.cpp
@@ -255,7 +255,7 @@ GUI::Variant ProcessModel::data(GUI::ModelIndex const& index, GUI::ModelRole rol
         VERIFY_NOT_REACHED();
     }
 
-    if (role == GUI::ModelRole::Display) {
+    if (role == GUI::ModelRole::Display || role == DISPLAY_VERBOSE) {
         switch (index.column()) {
         case Column::Icon:
             return icon_for(thread);
@@ -306,17 +306,29 @@ GUI::Variant ProcessModel::data(GUI::ModelIndex const& index, GUI::ModelRole rol
         case Column::CowFaults:
             return thread.current_state.cow_faults;
         case Column::IPv4SocketReadBytes:
-            return human_readable_size_long(thread.current_state.ipv4_socket_read_bytes, UseThousandsSeparator::Yes);
+            if (role == DISPLAY_VERBOSE)
+                return human_readable_size_long(thread.current_state.ipv4_socket_read_bytes, UseThousandsSeparator::Yes);
+            return human_readable_size(thread.current_state.ipv4_socket_read_bytes, AK::HumanReadableBasedOn::Base2, UseThousandsSeparator::Yes);
         case Column::IPv4SocketWriteBytes:
-            return human_readable_size_long(thread.current_state.ipv4_socket_write_bytes, UseThousandsSeparator::Yes);
+            if (role == DISPLAY_VERBOSE)
+                return human_readable_size_long(thread.current_state.ipv4_socket_write_bytes, UseThousandsSeparator::Yes);
+            return human_readable_size(thread.current_state.ipv4_socket_write_bytes, AK::HumanReadableBasedOn::Base2, UseThousandsSeparator::Yes);
         case Column::UnixSocketReadBytes:
-            return human_readable_size_long(thread.current_state.unix_socket_read_bytes, UseThousandsSeparator::Yes);
+            if (role == DISPLAY_VERBOSE)
+                return human_readable_size_long(thread.current_state.unix_socket_read_bytes, UseThousandsSeparator::Yes);
+            return human_readable_size(thread.current_state.unix_socket_read_bytes, AK::HumanReadableBasedOn::Base2, UseThousandsSeparator::Yes);
         case Column::UnixSocketWriteBytes:
-            return human_readable_size_long(thread.current_state.unix_socket_write_bytes, UseThousandsSeparator::Yes);
+            if (role == DISPLAY_VERBOSE)
+                return human_readable_size_long(thread.current_state.unix_socket_write_bytes, UseThousandsSeparator::Yes);
+            return human_readable_size(thread.current_state.unix_socket_write_bytes, AK::HumanReadableBasedOn::Base2, UseThousandsSeparator::Yes);
         case Column::FileReadBytes:
-            return human_readable_size_long(thread.current_state.file_read_bytes, UseThousandsSeparator::Yes);
+            if (role == DISPLAY_VERBOSE)
+                return human_readable_size_long(thread.current_state.file_read_bytes, UseThousandsSeparator::Yes);
+            return human_readable_size(thread.current_state.file_read_bytes, AK::HumanReadableBasedOn::Base2, UseThousandsSeparator::Yes);
         case Column::FileWriteBytes:
-            return human_readable_size_long(thread.current_state.file_write_bytes, UseThousandsSeparator::Yes);
+            if (role == DISPLAY_VERBOSE)
+                return human_readable_size_long(thread.current_state.file_write_bytes, UseThousandsSeparator::Yes);
+            return human_readable_size(thread.current_state.file_write_bytes, AK::HumanReadableBasedOn::Base2, UseThousandsSeparator::Yes);
         case Column::Pledge:
             return thread.current_state.pledge;
         case Column::Veil:

--- a/Userland/Applications/SystemMonitor/ProcessModel.h
+++ b/Userland/Applications/SystemMonitor/ProcessModel.h
@@ -55,6 +55,8 @@ public:
         __Count
     };
 
+    static constexpr GUI::ModelRole DISPLAY_VERBOSE = static_cast<GUI::ModelRole>(0x101);
+
     static ErrorOr<String> read_command_line(pid_t pid);
 
     static ProcessModel& the();

--- a/Userland/Applications/SystemMonitor/ProcessStateWidget.cpp
+++ b/Userland/Applications/SystemMonitor/ProcessStateWidget.cpp
@@ -50,7 +50,7 @@ public:
                 }
                 return m_target.column_name(index.row()).release_value_but_fixme_should_propagate_errors();
             }
-            return m_target_index.sibling_at_column(index.row()).data();
+            return m_target_index.sibling_at_column(index.row()).data(ProcessModel::DISPLAY_VERBOSE);
         }
 
         if (role == GUI::ModelRole::Font) {


### PR DESCRIPTION
Previously, some non-default process statistics were displayed in a long human readable format in the processes tab, which could negatively affect readability. A shorter format is now used in the processes tab, while the process properties window retains the longer format.

This fixes a regression introduced in #19346. I didn't realize that additional columns could be selected :facepalm:.

Before:
![systemmonitor_process_stats_before](https://github.com/SerenityOS/serenity/assets/2817754/9b13021c-cbfb-4adc-9e49-877d33ee60e4)


After:
![systemmonitor_process_stats_after](https://github.com/SerenityOS/serenity/assets/2817754/6e5a6560-1829-4405-95a9-15dc567ef727)
