### PR TITLE
Calculator: Make calculator display non-interactive

### DIFF
--- a/Userland/Applications/Calculator/CalculatorWindow.gml
+++ b/Userland/Applications/Calculator/CalculatorWindow.gml
@@ -19,6 +19,8 @@
             @GUI::TextBox {
                 name: "entry_textbox"
                 font_type: "FixedWidth"
+                mode: "DisplayOnly"
+                focus_policy: "NoFocus"
             }
 
             @GUI::Widget {

--- a/Userland/Applications/Calculator/CalculatorWindow.gml
+++ b/Userland/Applications/Calculator/CalculatorWindow.gml
@@ -308,6 +308,7 @@
                     fixed_width: 35
                     fixed_height: 28
                     foreground_role: "SyntaxPreprocessorValue"
+                    focus_policy: "NoFocus"
                 }
             }
         }


### PR DESCRIPTION
Previously, it was possible for the user to input text into the calculator display. With this change, the calculator display is made read-only.

I've also included a change to make the equals button non-focusable. This isn't necessary, as pressing Enter will activate the button whether it is in focus or not. This makes the equals button behave the same as all other buttons.

As it is, this change breaks copy and paste functionality. This is fixed by #22572, which should be merged first.