### PR TITLE
LibGfx/TIFF: Add Exif (tag) support

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/TIFFLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/TIFFLoader.cpp
@@ -423,32 +423,6 @@ private:
         return {};
     }
 
-    ErrorOr<Type> read_type()
-    {
-        switch (TRY(read_value<u16>())) {
-        case to_underlying(Type::Byte):
-            return Type::Byte;
-        case to_underlying(Type::ASCII):
-            return Type::ASCII;
-        case to_underlying(Type::UnsignedShort):
-            return Type::UnsignedShort;
-        case to_underlying(Type::UnsignedLong):
-            return Type::UnsignedLong;
-        case to_underlying(Type::UnsignedRational):
-            return Type::UnsignedRational;
-        case to_underlying(Type::Undefined):
-            return Type::Undefined;
-        case to_underlying(Type::SignedLong):
-            return Type::SignedLong;
-        case to_underlying(Type::SignedRational):
-            return Type::SignedRational;
-        case to_underlying(Type::UTF8):
-            return Type::UTF8;
-        default:
-            return Error::from_string_literal("TIFFImageDecoderPlugin: Unknown type");
-        }
-    }
-
     static constexpr u8 size_of_type(Type type)
     {
         switch (type) {
@@ -541,7 +515,8 @@ private:
     ErrorOr<void> read_tag()
     {
         auto const tag = TRY(read_value<u16>());
-        auto const type = TRY(read_type());
+        auto const raw_type = TRY(read_value<u16>());
+        auto const type = TRY(tiff_type_from_u16(raw_type));
         auto const count = TRY(read_value<u32>());
 
         Checked<u32> checked_size = size_of_type(type);

--- a/Userland/Libraries/LibGfx/ImageFormats/TIFFLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/TIFFLoader.cpp
@@ -423,36 +423,6 @@ private:
         return {};
     }
 
-    static constexpr u8 size_of_type(Type type)
-    {
-        switch (type) {
-        case Type::Byte:
-            return 1;
-        case Type::ASCII:
-            return 1;
-        case Type::UnsignedShort:
-            return 2;
-        case Type::UnsignedLong:
-            return 4;
-        case Type::UnsignedRational:
-            return 8;
-        case Type::Undefined:
-            return 1;
-        case Type::SignedLong:
-            return 4;
-        case Type::SignedRational:
-            return 8;
-        case Type::Float:
-            return 4;
-        case Type::Double:
-            return 8;
-        case Type::UTF8:
-            return 1;
-        default:
-            VERIFY_NOT_REACHED();
-        }
-    }
-
     ErrorOr<Vector<Value, 1>> read_tiff_value(Type type, u32 count, u32 offset)
     {
         auto const old_offset = TRY(m_stream->tell());

--- a/Userland/Libraries/LibGfx/ImageFormats/TIFFLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/TIFFLoader.cpp
@@ -468,6 +468,7 @@ private:
         }
         case Type::UnsignedShort:
             return read_every_values.template operator()<u16>();
+        case Type::IFD:
         case Type::UnsignedLong:
             return read_every_values.template operator()<u32>();
         case Type::UnsignedRational:

--- a/Userland/Libraries/LibGfx/ImageFormats/TIFFLoader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/TIFFLoader.h
@@ -17,6 +17,10 @@ namespace Gfx {
 // First TIFF Technical notes from 1995
 // https://www.awaresystems.be/imaging/tiff/specification/TIFFPM6.pdf
 
+// This is also compatible with Exif as it is, basically, another set of TIFF tags:
+// The spec is named "Exchangeable image file format for digital still cameras: Exif Version 3.0"
+// And it can be found at https://www.cipa.jp/e/std/std-sec.html
+
 namespace TIFF {
 class TIFFLoadingContext;
 }

--- a/Userland/Libraries/LibGfx/ImageFormats/TIFFLoader.h
+++ b/Userland/Libraries/LibGfx/ImageFormats/TIFFLoader.h
@@ -11,7 +11,11 @@
 
 namespace Gfx {
 
+// This is a link to the main TIFF specification from 1992
 // https://www.itu.int/itudoc/itu-t/com16/tiff-fx/docs/tiff6.pdf
+
+// First TIFF Technical notes from 1995
+// https://www.awaresystems.be/imaging/tiff/specification/TIFFPM6.pdf
 
 namespace TIFF {
 class TIFFLoadingContext;

--- a/Userland/Libraries/LibGfx/TIFFGenerator.py
+++ b/Userland/Libraries/LibGfx/TIFFGenerator.py
@@ -136,6 +136,7 @@ known_tags: List[Tag] = [
     Tag('317', [TIFFType.UnsignedShort], [1], Predictor.NoPrediction, "Predictor", Predictor),
     Tag('320', [TIFFType.UnsignedShort], [], None, "ColorMap"),
     Tag('338', [TIFFType.UnsignedShort], [], None, "ExtraSamples", ExtraSample),
+    Tag('34665', [TIFFType.UnsignedLong, TIFFType.IFD], [1], None, "ExifIFD"),
     Tag('34675', [TIFFType.Undefined], [], None, "ICCProfile"),
 ]
 

--- a/Userland/Libraries/LibGfx/TIFFGenerator.py
+++ b/Userland/Libraries/LibGfx/TIFFGenerator.py
@@ -40,6 +40,7 @@ class TIFFType(EnumWithExportName):
     SignedRational = 10, 8
     Float = 11, 4
     Double = 12, 8
+    IFD = 13, 4
     UTF8 = 129, 1
 
 
@@ -218,7 +219,7 @@ def tiff_type_to_cpp(t: TIFFType, with_promotion: bool = True) -> str:
         return 'ByteBuffer'
     if t == TIFFType.UnsignedShort:
         return 'u16'
-    if t == TIFFType.UnsignedLong:
+    if t == TIFFType.UnsignedLong or t == TIFFType.IFD:
         return 'u32'
     if t == TIFFType.UnsignedRational:
         return 'TIFF::Rational<u32>'


### PR DESCRIPTION
While generating these two functions is not extremely profitable, having a single place that covers all information about the `Type` enum is really great!


This PR actually only add support for the `ExifIFD` tag, so not really a huge thing :sweat_smile:
I have some code to read the IFD, but it's too hackish to be upstreamed yet. But I promise it works:
![image](https://github.com/SerenityOS/serenity/assets/26030965/a2530df0-fd69-48bf-938b-233321bca3c3)
