### PR TITLE
Shell: Print paths in plain mode when stdout is not a tty

### DIFF
--- a/Userland/Shell/Shell.cpp
+++ b/Userland/Shell/Shell.cpp
@@ -72,7 +72,7 @@ void Shell::setup_signals()
 
 void Shell::print_path(StringView path)
 {
-    if (s_disable_hyperlinks || !m_is_interactive) {
+    if (s_disable_hyperlinks || !m_is_interactive || !isatty(STDOUT_FILENO)) {
         out("{}", path);
         return;
     }


### PR DESCRIPTION
This makes e.g. `pwd | ...` behave as expected, where pwd doesn't add a hyperlink around the path.