### PR TITLE
LibWeb: Cache the viewport rect across all of style computation

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -2356,13 +2356,6 @@ void StyleComputer::invalidate_rule_cache()
     m_user_agent_rule_cache = nullptr;
 }
 
-CSSPixelRect StyleComputer::viewport_rect() const
-{
-    if (auto const navigable = document().navigable())
-        return navigable->viewport_rect();
-    return {};
-}
-
 void StyleComputer::did_load_font(FlyString const&)
 {
     document().invalidate_style();

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.h
@@ -109,6 +109,8 @@ public:
         Variant<Linear, CubicBezier, Steps> timing_function;
     };
 
+    void set_viewport_rect(Badge<DOM::Document>, CSSPixelRect const& viewport_rect) { m_viewport_rect = viewport_rect; }
+
 private:
     enum class ComputeStyleMode {
         Normal,
@@ -136,7 +138,8 @@ private:
     template<typename Callback>
     void for_each_stylesheet(CascadeOrigin, Callback) const;
 
-    CSSPixelRect viewport_rect() const;
+    [[nodiscard]] CSSPixelRect viewport_rect() const { return m_viewport_rect; }
+
     [[nodiscard]] Length::FontMetrics calculate_root_element_font_metrics(StyleProperties const&) const;
     CSSPixels parent_or_root_element_line_height(DOM::Element const*, Optional<CSS::Selector::PseudoElement::Type>) const;
 
@@ -241,6 +244,8 @@ private:
     mutable HashMap<AnimationKey, NonnullOwnPtr<Animation>> m_active_animations;
     mutable HashMap<AnimationKey, OwnPtr<AnimationStateSnapshot>> m_finished_animations; // If fill-mode is forward/both, this is non-null and contains the final state.
     mutable RefPtr<Platform::Timer> m_animation_driver_timer;
+
+    CSSPixelRect m_viewport_rect;
 };
 
 }

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -1129,6 +1129,9 @@ void Document::update_style()
     if (m_created_for_appropriate_template_contents)
         return;
 
+    // Fetch the viewport rect once, instead of repeatedly, during style computation.
+    style_computer().set_viewport_rect({}, viewport_rect());
+
     evaluate_media_rules();
 
     auto invalidation = update_style_recursively(*this);


### PR DESCRIPTION
Fetching the viewport rect is currently somewhat expensive, since it requires finding the navigable the document is active in.

We can avoid the cost of repeated calls by simply allowing StyleComputer to cache the viewport rect at the start of style computation.