### PR TITLE
HackStudio: Stop crash from leaking Editor widgets when closing tabs

### DIFF
--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -801,6 +801,7 @@ void HackStudioWidget::add_new_editor(GUI::TabWidget& parent)
 
     wrapper.on_tab_close_request = [this, &parent](auto& tab) {
         parent.deferred_invoke([this, &parent, &tab] {
+            tab.editor().document().unregister_client(tab.editor());
             set_current_editor_wrapper(tab);
             parent.remove_tab(tab);
             m_all_editor_wrappers.remove_first_matching([&tab](auto& entry) { return entry == &tab; });


### PR DESCRIPTION
When re-opening an existing file, we would reuse the document and register a new Editor with it, but never unregister that Editor.

Previously, this would cause a crash if you opened a binary file, closed its tab, then opened that binary file again. HackStudio would crash while calling `HackStudio::EditorWrapper::update_title()` on an invalid EditorWrapper. But now it doesn't!

Something still gets leaked each time, but we now don't crash at least.