### PR TITLE
LibGUI+SystemMonitor: Make the icon column in the Processes tab non-selectable

### DIFF
--- a/Userland/Applications/SystemMonitor/main.cpp
+++ b/Userland/Applications/SystemMonitor/main.cpp
@@ -301,6 +301,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto& process_table_view = *process_table_container.find_child_of_type_named<GUI::TreeView>("process_table");
     process_table_view.set_model(TRY(GUI::SortingProxyModel::create(process_model)));
+    process_table_view.column_header().set_section_selectable(ProcessModel::Icon, false);
 
     for (auto column = 0; column < ProcessModel::Column::__Count; ++column) {
         process_table_view.set_column_visible(column,

--- a/Userland/Libraries/LibGUI/HeaderView.cpp
+++ b/Userland/Libraries/LibGUI/HeaderView.cpp
@@ -342,6 +342,16 @@ void HeaderView::set_section_visible(int section, bool visible)
     update();
 }
 
+void HeaderView::set_section_selectable(int section, bool selectable)
+{
+    auto& data = section_data(section);
+    if (data.selectable == selectable)
+        return;
+    data.selectable = selectable;
+    if (m_context_menu)
+        m_context_menu = nullptr;
+}
+
 Menu& HeaderView::ensure_context_menu()
 {
     // FIXME: This menu needs to be rebuilt if the model is swapped out,
@@ -358,6 +368,8 @@ Menu& HeaderView::ensure_context_menu()
         int section_count = this->section_count();
         for (int section = 0; section < section_count; ++section) {
             auto& column_data = this->section_data(section);
+            if (!column_data.selectable)
+                continue;
             auto name = model()->column_name(section).release_value_but_fixme_should_propagate_errors().to_byte_string();
             column_data.visibility_action = Action::create_checkable(name, [this, section](auto& action) {
                 set_section_visible(section, action.is_checked());

--- a/Userland/Libraries/LibGUI/HeaderView.h
+++ b/Userland/Libraries/LibGUI/HeaderView.h
@@ -36,6 +36,8 @@ public:
     bool is_section_visible(int section) const;
     void set_section_visible(int section, bool);
 
+    void set_section_selectable(int section, bool);
+
     int section_count() const;
     Gfx::IntRect section_rect(int section) const;
 
@@ -92,6 +94,7 @@ private:
         bool has_initialized_size { false };
         bool has_initialized_default_size { false };
         bool visibility { true };
+        bool selectable { true };
         RefPtr<Action> visibility_action;
         Gfx::TextAlignment alignment { Gfx::TextAlignment::CenterLeft };
     };


### PR DESCRIPTION
Previously, any TableView column could be made visible through a context menu shown by right clicking on the table header. This change allows columns to be marked as non-selectable, so their visibility
cannot be toggled in this way. 

This marks the icon column in the SystemMonitor Processes tab as non-selectable. This means the icon column can no longer be selected, but is still visible in the process properties window.

Video showing the issue:

https://github.com/SerenityOS/serenity/assets/2817754/8dfc08f3-56a1-4aaa-b7bd-e1caf8690164
